### PR TITLE
feat: add computable cyclotomic integers

### DIFF
--- a/TauCeti/Algebra/Polynomial/CoeffList.lean
+++ b/TauCeti/Algebra/Polynomial/CoeffList.lean
@@ -275,6 +275,15 @@ section Ring
 
 variable [Ring R]
 
+/-- Negating every coefficient negates the polynomial. -/
+@[simp]
+theorem ofCoeffList_map_neg (l : List R) : ofCoeffList (l.map (-·)) = -ofCoeffList l := by
+  induction l using List.reverseRecOn with
+  | nil => simp
+  | append_singleton l a ih =>
+    rw [List.map_append, List.map_cons, List.map_nil, ofCoeffList_concat, ofCoeffList_concat, ih,
+      map_neg, neg_mul, ← neg_add]
+
 /-- Subtracting a right multiple of one list of coefficients from another, entrywise. -/
 theorem ofCoeffList_zipWith_sub (c : R) {l l' : List R} (h : l.length = l'.length) :
     ofCoeffList (List.zipWith (fun x y => x - y * c) l l')

--- a/TauCeti/Algebra/Polynomial/CoeffList.lean
+++ b/TauCeti/Algebra/Polynomial/CoeffList.lean
@@ -212,23 +212,14 @@ theorem ofCoeffList_coeffList (p : R[X]) : ofCoeffList p.coeffList = p := by
       Option.getD_none]
     exact (coeff_eq_zero_of_natDegree_lt (by omega)).symm
 
-/-- Convolution of two coefficient lists in ascending degree order.  The output has the usual
-`l.length + m.length - 1` slots; if either input is empty, all of those slots are zero.  This
-cannot be `private`, since the exposed body of `TauCeti.Polynomial.mulCoeffList` mentions it. -/
-@[expose] def coeffConvolution (l m : List R) : List R :=
-  List.ofFn fun i : Fin (l.length + m.length - 1) =>
-    ∑ jk ∈ Finset.antidiagonal (i : ℕ), l.getD jk.1 0 * m.getD jk.2 0
-
-/-- Multiplication of descending coefficient lists.  This is `@[expose]`d, since a consumer
-computing with it in another module reduces it in the kernel. -/
+/-- Multiplication of descending coefficient lists, by convolving them in ascending degree order.
+The output has the usual `l.length + m.length - 1` slots; if either input is empty, all of those
+slots are zero.  This is `@[expose]`d, since a consumer computing with it in another module
+reduces it in the kernel. -/
 @[expose] def mulCoeffList (l m : List R) : List R :=
-  (coeffConvolution l.reverse m.reverse).reverse
-
-/-- `TauCeti.Polynomial.coeffConvolution` produces the usual `l.length + m.length - 1`
-coefficients. -/
-theorem length_coeffConvolution (l m : List R) :
-    (coeffConvolution l m).length = l.length + m.length - 1 := by
-  simp [coeffConvolution]
+  (List.ofFn fun i : Fin (l.length + m.length - 1) =>
+    ∑ jk ∈ Finset.antidiagonal (i : ℕ),
+      l.reverse.getD jk.1 0 * m.reverse.getD jk.2 0).reverse
 
 /-- `TauCeti.Polynomial.mulCoeffList` lists the coefficients of a product of polynomials. -/
 theorem ofCoeffList_mulCoeffList (l m : List R) :
@@ -237,10 +228,10 @@ theorem ofCoeffList_mulCoeffList (l m : List R) :
   rw [coeff_ofCoeffList, coeff_mul]
   by_cases hn : n < l.length + m.length - 1
   · rw [mulCoeffList, List.reverse_reverse, List.getD_eq_getElem]
-    · simp only [coeffConvolution, List.getElem_ofFn, coeff_ofCoeffList]
-    · simpa [length_coeffConvolution] using hn
+    · simp
+    · simpa using hn
   · rw [List.getD_eq_getElem?_getD,
-      List.getElem?_eq_none (by simp [mulCoeffList, length_coeffConvolution]; omega),
+      List.getElem?_eq_none (by simp [mulCoeffList]; omega),
       Option.getD_none]
     simp only [coeff_ofCoeffList]
     symm

--- a/TauCeti/Algebra/Polynomial/CoeffList.lean
+++ b/TauCeti/Algebra/Polynomial/CoeffList.lean
@@ -24,6 +24,9 @@ read from the highest degree down, so that it inverts Mathlib's `Polynomial.coef
 defining recursion is Horner's, `ofCoeffList (l ++ [a]) = ofCoeffList l * X + C a`, and every proof
 below runs along it.  It is a `noncomputable` specification map: the *lists* are what compute.
 
+`TauCeti.Polynomial.mulCoeffList` multiplies two such lists by convolving their coefficients, and
+`TauCeti.Polynomial.ofCoeffList_mulCoeffList` identifies the result with the product polynomial.
+
 `TauCeti.Polynomial.divModByMonicList t l` is long division of `ofCoeffList l` by the monic
 polynomial `X ^ t.length + ofCoeffList t`, carried out as the usual synthetic division: a window of
 `t.length` remainder coefficients is carried along the dividend, and at each step the coefficient
@@ -208,6 +211,52 @@ theorem ofCoeffList_coeffList (p : R[X]) : ofCoeffList p.coeffList = p := by
   · rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none (by simp [hsucc]; omega),
       Option.getD_none]
     exact (coeff_eq_zero_of_natDegree_lt (by omega)).symm
+
+/-- Convolution of two coefficient lists in ascending degree order.  The output has the usual
+`l.length + m.length - 1` slots; if either input is empty, all of those slots are zero.  This
+cannot be `private`, since the exposed body of `TauCeti.Polynomial.mulCoeffList` mentions it. -/
+@[expose] def coeffConvolution (l m : List R) : List R :=
+  List.ofFn fun i : Fin (l.length + m.length - 1) =>
+    ∑ jk ∈ Finset.antidiagonal (i : ℕ), l.getD jk.1 0 * m.getD jk.2 0
+
+/-- Multiplication of descending coefficient lists.  This is `@[expose]`d, since a consumer
+computing with it in another module reduces it in the kernel. -/
+@[expose] def mulCoeffList (l m : List R) : List R :=
+  (coeffConvolution l.reverse m.reverse).reverse
+
+/-- `TauCeti.Polynomial.coeffConvolution` produces the usual `l.length + m.length - 1`
+coefficients. -/
+theorem length_coeffConvolution (l m : List R) :
+    (coeffConvolution l m).length = l.length + m.length - 1 := by
+  simp [coeffConvolution]
+
+/-- `TauCeti.Polynomial.mulCoeffList` lists the coefficients of a product of polynomials. -/
+theorem ofCoeffList_mulCoeffList (l m : List R) :
+    ofCoeffList (mulCoeffList l m) = ofCoeffList l * ofCoeffList m := by
+  ext n
+  rw [coeff_ofCoeffList, coeff_mul]
+  by_cases hn : n < l.length + m.length - 1
+  · rw [mulCoeffList, List.reverse_reverse, List.getD_eq_getElem]
+    · simp only [coeffConvolution, List.getElem_ofFn, coeff_ofCoeffList]
+    · simpa [length_coeffConvolution] using hn
+  · rw [List.getD_eq_getElem?_getD,
+      List.getElem?_eq_none (by simp [mulCoeffList, length_coeffConvolution]; omega),
+      Option.getD_none]
+    simp only [coeff_ofCoeffList]
+    symm
+    apply Finset.sum_eq_zero
+    intro jk hjk
+    rw [Finset.mem_antidiagonal] at hjk
+    by_cases hl : jk.1 < l.length
+    · have hm : m.length ≤ jk.2 := by omega
+      have hm0 : m.reverse.getD jk.2 0 = 0 := by
+        rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none (by simpa using hm),
+          Option.getD_none]
+      rw [hm0, mul_zero]
+    · have hl0 : l.reverse.getD jk.1 0 = 0 := by
+        rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none (by simpa using hl),
+          Option.getD_none]
+      rw [hl0, zero_mul]
 
 /-- The divisor `X ^ t.length + ofCoeffList t` of `TauCeti.Polynomial.divModByMonicList` is
 monic. -/

--- a/TauCeti/RingTheory/Cyclotomic/Basic.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Basic.lean
@@ -176,52 +176,6 @@ theorem toAdjoinRoot_mul (x y : Cyclotomic e) :
     toAdjoinRoot_ofCoeffList, toAdjoinRoot, toAdjoinRoot, ← map_mul, ofCoeffList_mulCoeffList]
   simp only [toPolynomial]
 
-@[simp]
-theorem toAdjoinRoot_sub (x y : Cyclotomic e) :
-    toAdjoinRoot (x - y) = toAdjoinRoot x - toAdjoinRoot y := by
-  rw [show x - y = x + -y from rfl, toAdjoinRoot_add, toAdjoinRoot_neg, sub_eq_add_neg]
-
-/-- The comparison map preserves natural scalar multiplication. -/
-theorem toAdjoinRoot_nsmul (n : ℕ) (x : Cyclotomic e) :
-    toAdjoinRoot (n • x) = n • toAdjoinRoot x := by
-  induction n with
-  | zero =>
-    rw [show (0 : ℕ) • x = (0 : Cyclotomic e) from rfl, zero_nsmul]
-    exact toAdjoinRoot_zero
-  | succ n ih =>
-    rw [show (n + 1) • x = n • x + x from rfl, succ_nsmul, toAdjoinRoot_add, ih]
-
-/-- The comparison map preserves integer scalar multiplication. -/
-theorem toAdjoinRoot_zsmul (z : ℤ) (x : Cyclotomic e) :
-    toAdjoinRoot (z • x) = z • toAdjoinRoot x := by
-  cases z with
-  | ofNat n =>
-    rw [show (Int.ofNat n : ℤ) • x = n • x from rfl, Int.ofNat_eq_natCast, natCast_zsmul]
-    exact toAdjoinRoot_nsmul n x
-  | negSucc n =>
-    rw [show Int.negSucc n • x = -((n + 1) • x) from rfl, negSucc_zsmul,
-      toAdjoinRoot_neg, toAdjoinRoot_nsmul]
-
-/-- The comparison map preserves natural powers. -/
-theorem toAdjoinRoot_pow (x : Cyclotomic e) (n : ℕ) :
-    toAdjoinRoot (x ^ n) = toAdjoinRoot x ^ n := by
-  induction n with
-  | zero => exact toAdjoinRoot_one
-  | succ n ih =>
-    rw [show x ^ (n + 1) = x ^ n * x from rfl, toAdjoinRoot_mul, ih, pow_succ]
-
-/-- The comparison map preserves natural-number casts. -/
-theorem toAdjoinRoot_natCast (n : ℕ) :
-    toAdjoinRoot (n : Cyclotomic e) = n := by
-  rw [show (n : Cyclotomic e) = ofCoeffList e [n] from rfl, toAdjoinRoot_ofCoeffList]
-  simp [TauCeti.Polynomial.ofCoeffList_cons]
-
-/-- The comparison map preserves integer casts. -/
-theorem toAdjoinRoot_intCast (z : ℤ) :
-    toAdjoinRoot (z : Cyclotomic e) = z := by
-  rw [show (z : Cyclotomic e) = ofCoeffList e [z] from rfl, toAdjoinRoot_ofCoeffList]
-  simp [TauCeti.Polynomial.ofCoeffList_cons]
-
 instance : CommRing (Cyclotomic e) where
   add := add
   add_assoc a b c := toAdjoinRoot_injective (by simp only [toAdjoinRoot_add, add_assoc])

--- a/TauCeti/RingTheory/Cyclotomic/Basic.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Basic.lean
@@ -351,8 +351,8 @@ theorem equivAdjoinRoot_apply (x : Cyclotomic e) : equivAdjoinRoot x = toAdjoinR
 @[expose] def zeta (e : ℕ) : Cyclotomic e := ofCoeffList e [1, 0]
 
 @[simp]
-theorem equivAdjoinRoot_zeta : equivAdjoinRoot (zeta e) = AdjoinRoot.root (cyclotomic e ℤ) := by
-  rw [equivAdjoinRoot_apply, zeta, toAdjoinRoot_ofCoeffList]
+theorem toAdjoinRoot_zeta : toAdjoinRoot (zeta e) = AdjoinRoot.root (cyclotomic e ℤ) := by
+  rw [zeta, toAdjoinRoot_ofCoeffList]
   rw [show TauCeti.Polynomial.ofCoeffList ([1, 0] : List ℤ) = X by
     simp [TauCeti.Polynomial.ofCoeffList_cons], AdjoinRoot.mk_X]
 

--- a/TauCeti/RingTheory/Cyclotomic/Basic.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Basic.lean
@@ -6,7 +6,6 @@ module
 
 public import Mathlib.RingTheory.AdjoinRoot
 public import Mathlib.RingTheory.Polynomial.Cyclotomic.Roots
-public import Mathlib.RingTheory.RootsOfUnity.Complex
 public import TauCeti.RingTheory.Polynomial.Cyclotomic.Computable
 
 /-!
@@ -14,9 +13,10 @@ public import TauCeti.RingTheory.Polynomial.Cyclotomic.Computable
 
 This file defines `TauCeti.Cyclotomic e`, an exact, computable model of
 `ℤ[X] / (Polynomial.cyclotomic e ℤ)`.  Its elements are the `e.totient` coefficients of the
-canonical representative, in descending order.  Addition, negation, multiplication, and equality
-are genuine computations on finite lists of integers; multiplication convolves coefficient lists
-with `TauCeti.Polynomial.mulCoeffList` and then applies the computable cyclotomic reduction from
+canonical representative, in descending order; `TauCeti.Cyclotomic.coeff` reads off the coordinate
+of a single power of `ζ`.  Addition, negation, multiplication, and equality are genuine
+computations on finite lists of integers; multiplication convolves coefficient lists with
+`TauCeti.Polynomial.mulCoeffList` and then applies the computable cyclotomic reduction from
 `TauCeti.RingTheory.Polynomial.Cyclotomic.Computable`.
 
 The ring is identified with Mathlib's `AdjoinRoot (Polynomial.cyclotomic e ℤ)`.  For nonzero `e`,
@@ -58,6 +58,17 @@ theorem length_coeffs (x : Cyclotomic e) : x.coeffs.length = e.totient := x.2
 @[ext]
 theorem ext {x y : Cyclotomic e} (h : x.coeffs = y.coeffs) : x = y := Subtype.ext h
 
+/-- The coordinate of `ζ ^ j` on the power basis `ζ ^ (φ e - 1), …, ζ, 1`.  Since
+`TauCeti.Cyclotomic.coeffs` is in descending order this reads it backwards, and it is `0` beyond
+the `e.totient` slots the basis has. -/
+@[expose] def coeff (x : Cyclotomic e) (j : ℕ) : ℤ := x.coeffs.reverse.getD j 0
+
+/-- There is no coordinate beyond the `e.totient` elements of the power basis. -/
+theorem coeff_eq_zero_of_totient_le (x : Cyclotomic e) {j : ℕ} (h : e.totient ≤ j) :
+    x.coeff j = 0 := by
+  rw [coeff, List.getD_eq_getElem?_getD, List.getElem?_eq_none (by simpa using h),
+    Option.getD_none]
+
 /-- Reduce a descending coefficient list modulo `Φ_e` and regard the result as an exact
 cyclotomic integer. -/
 @[expose] def ofCoeffList (e : ℕ) (l : List ℤ) : Cyclotomic e :=
@@ -98,9 +109,41 @@ instance : Pow (Cyclotomic e) ℕ := ⟨fun x n => npowRec n x⟩
 instance : NatCast (Cyclotomic e) := ⟨fun n => ofCoeffList e [n]⟩
 instance : IntCast (Cyclotomic e) := ⟨fun z => ofCoeffList e [z]⟩
 
+/-! The notation of the classes above, and the fields of the `CommRing` structure assembled below,
+are the standalone operations defined here.  The next few lemmas name that identification once, so
+that the proofs which need it can rewrite rather than appeal to definitional unfolding.  None of
+them is `simp`: they unfold arithmetic into coefficient lists, which is the opposite direction to
+the normal form everything else is stated in. -/
+
+/-- Zero is the empty coefficient list. -/
+theorem zero_def : (0 : Cyclotomic e) = ofCoeffList e [] := rfl
+
+/-- One is the coefficient list `[1]`. -/
+theorem one_def : (1 : Cyclotomic e) = ofCoeffList e [1] := rfl
+
+/-- Addition adds coefficient lists entrywise. -/
+theorem add_def (x y : Cyclotomic e) :
+    x + y = ofCoeffList e (List.zipWith (fun a b => a + b) x.coeffs y.coeffs) := rfl
+
+/-- Negation negates every coefficient. -/
+theorem neg_def (x : Cyclotomic e) : -x = ofCoeffList e (x.coeffs.map (-·)) := rfl
+
+/-- `TauCeti.Cyclotomic.neg` is the negation of the `Neg` instance. -/
+theorem neg_eq (x : Cyclotomic e) : neg x = -x := rfl
+
+/-- Multiplication convolves coefficient lists and reduces modulo `Φ_e`. -/
+theorem mul_def (x y : Cyclotomic e) :
+    x * y = ofCoeffList e (mulCoeffList x.coeffs y.coeffs) := rfl
+
 /-- The polynomial represented by an exact cyclotomic integer. -/
 noncomputable def toPolynomial (x : Cyclotomic e) : ℤ[X] :=
   TauCeti.Polynomial.ofCoeffList x.coeffs
+
+/-- The coordinates of an exact cyclotomic integer are the coefficients of its canonical
+polynomial representative. -/
+@[simp]
+theorem coeff_toPolynomial (x : Cyclotomic e) (j : ℕ) : x.toPolynomial.coeff j = x.coeff j := by
+  rw [toPolynomial, TauCeti.Polynomial.coeff_ofCoeffList, coeff]
 
 /-- The comparison map from computable cyclotomic integers to Mathlib's quotient by `Φ_e`. -/
 noncomputable def toAdjoinRoot (x : Cyclotomic e) : AdjoinRoot (cyclotomic e ℤ) :=
@@ -133,24 +176,20 @@ theorem toAdjoinRoot_ofCoeffList (l : List ℤ) :
   rw [modByMonic_eq_sub_mul_div, sub_sub_cancel_left]
   exact dvd_neg.mpr (dvd_mul_right _ _)
 
--- These explicit rewrites expose the standalone computational operations before they are bundled
--- into the `CommRing` instance below.
-
 @[simp]
 theorem toAdjoinRoot_zero : toAdjoinRoot (0 : Cyclotomic e) = 0 := by
-  rw [show (0 : Cyclotomic e) = ofCoeffList e [] from rfl, toAdjoinRoot_ofCoeffList]
+  rw [zero_def, toAdjoinRoot_ofCoeffList]
   simp
 
 @[simp]
 theorem toAdjoinRoot_one : toAdjoinRoot (1 : Cyclotomic e) = 1 := by
-  rw [show (1 : Cyclotomic e) = ofCoeffList e [1] from rfl, toAdjoinRoot_ofCoeffList]
+  rw [one_def, toAdjoinRoot_ofCoeffList]
   simp [TauCeti.Polynomial.ofCoeffList_cons]
 
 @[simp]
 theorem toAdjoinRoot_add (x y : Cyclotomic e) :
     toAdjoinRoot (x + y) = toAdjoinRoot x + toAdjoinRoot y := by
-  rw [show x + y = ofCoeffList e (List.zipWith (fun a b => a + b) x.coeffs y.coeffs) from rfl,
-    toAdjoinRoot_ofCoeffList, toAdjoinRoot, toAdjoinRoot]
+  rw [add_def, toAdjoinRoot_ofCoeffList, toAdjoinRoot, toAdjoinRoot]
   rw [← map_add]
   congr 1
   simpa [sub_eq_add_neg, toPolynomial] using
@@ -159,21 +198,13 @@ theorem toAdjoinRoot_add (x y : Cyclotomic e) :
 @[simp]
 theorem toAdjoinRoot_neg (x : Cyclotomic e) :
     toAdjoinRoot (-x) = -toAdjoinRoot x := by
-  rw [show -x = ofCoeffList e (x.coeffs.map (-·)) from rfl, toAdjoinRoot_ofCoeffList,
-    toAdjoinRoot]
-  rw [← map_neg]
-  congr 1
-  ext n
-  rw [coeff_ofCoeffList, coeff_neg, toPolynomial, coeff_ofCoeffList, ← List.map_reverse,
-    show (List.map (fun z : ℤ => -z) x.coeffs.reverse).getD n 0 =
-      -x.coeffs.reverse.getD n 0 by simpa using
-        (List.getD_map (l := x.coeffs.reverse) (d := 0) (n := n) fun z : ℤ => -z)]
+  rw [neg_def, toAdjoinRoot_ofCoeffList, toAdjoinRoot, toPolynomial, ofCoeffList_map_neg, map_neg]
 
 @[simp]
 theorem toAdjoinRoot_mul (x y : Cyclotomic e) :
     toAdjoinRoot (x * y) = toAdjoinRoot x * toAdjoinRoot y := by
-  rw [show x * y = ofCoeffList e (mulCoeffList x.coeffs y.coeffs) from rfl,
-    toAdjoinRoot_ofCoeffList, toAdjoinRoot, toAdjoinRoot, ← map_mul, ofCoeffList_mulCoeffList]
+  rw [mul_def, toAdjoinRoot_ofCoeffList, toAdjoinRoot, toAdjoinRoot, ← map_mul,
+    ofCoeffList_mulCoeffList]
   simp only [toPolynomial]
 
 instance : CommRing (Cyclotomic e) where
@@ -219,18 +250,14 @@ instance : CommRing (Cyclotomic e) where
   zsmul_succ' := by intros; rfl
   zsmul_neg' := by intros; rfl
   neg_add_cancel a := toAdjoinRoot_injective (by
-    rw [toAdjoinRoot_add, show toAdjoinRoot (neg a) = -toAdjoinRoot a from toAdjoinRoot_neg a,
-      toAdjoinRoot_zero, neg_add_cancel])
+    rw [toAdjoinRoot_add, neg_eq, toAdjoinRoot_neg, toAdjoinRoot_zero, neg_add_cancel])
   intCast z := ofCoeffList e [z]
   intCast_ofNat n := rfl
   intCast_negSucc n := toAdjoinRoot_injective (by
-    -- The structure is still being assembled, so spell out its pending cast and negation fields.
+    -- The structure is still being assembled, so spell out its pending cast field.
     change toAdjoinRoot (ofCoeffList e [Int.negSucc n]) =
       toAdjoinRoot (neg (ofCoeffList e [(n + 1 : ℕ)]))
-    rw [toAdjoinRoot_ofCoeffList,
-      show toAdjoinRoot (neg (ofCoeffList e [(n + 1 : ℕ)])) =
-        -toAdjoinRoot (ofCoeffList e [(n + 1 : ℕ)]) from toAdjoinRoot_neg _,
-      toAdjoinRoot_ofCoeffList]
+    rw [toAdjoinRoot_ofCoeffList, neg_eq, toAdjoinRoot_neg, toAdjoinRoot_ofCoeffList]
     simp [TauCeti.Polynomial.ofCoeffList_cons])
   mul_comm a b := toAdjoinRoot_injective (by simp only [toAdjoinRoot_mul, mul_comm])
 
@@ -373,6 +400,12 @@ theorem reduceRingHom_apply (p : ℕ) [Fact p.Prime] [NeZero e]
     reduceRingHom p r hr x = reduce p r x := by
   rw [reduceRingHom, reduce, evalRingHom, RingHom.comp_apply, toAdjoinRootRingHom_apply,
     toAdjoinRoot, AdjoinRoot.lift_mk, evalCoeffs_eq_eval₂]
+
+/-- Reduction at an `e`-th primitive root sends the distinguished generator `ζ` to that root. -/
+@[simp]
+theorem reduce_zeta (p : ℕ) [Fact p.Prime] [NeZero e] (r : ZMod p) (hr : IsPrimitiveRoot r e) :
+    reduce p r (zeta e) = r := by
+  rw [← reduceRingHom_apply p r hr, reduceRingHom, evalRingHom_zeta]
 
 /-! ## The distinguished complex embedding -/
 

--- a/TauCeti/RingTheory/Cyclotomic/Basic.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Basic.lean
@@ -21,6 +21,14 @@ cyclotomic reduction from `TauCeti.RingTheory.Polynomial.Cyclotomic.Computable`.
 The ring is identified with Mathlib's `AdjoinRoot (Polynomial.cyclotomic e ℤ)`.  For nonzero `e`,
 evaluation at `exp (2 * π * I / e)` then gives the distinguished embedding into `ℂ` used to state
 the correctness of exact character-table computations.
+
+The interface followed here is the one blueprinted in the character-theory roadmap
+(`RepresentationTheory/CharacterTheory/README.md` in TauCetiRoadmap, Layer 6: "Exact cyclotomic
+arithmetic", whose `Suggested.lean` pins `Cyclotomic e` with its `CommRing` instance, the
+generator `ζ_e` as the class of `X`, the reduction to `ZMod p`, and the *pinned* embedding into
+`ℂ` as a ring homomorphism together with its injectivity).  The choice of `exp (2 * π * I / e)`
+for that pin, of descending coefficient lists as the representation, and the identification with
+`AdjoinRoot` rather than the roadmap's `CyclotomicRing e ℤ ℚ` are this file's.
 -/
 
 public section
@@ -32,20 +40,24 @@ namespace TauCeti
 /-! ## Computable coefficient arithmetic -/
 
 /-- Convolution of two coefficient lists in ascending degree order.  The output has the usual
-`l.length + m.length - 1` slots; if either input is empty, all of those slots are zero. -/
-private def coeffConvolution (l m : List ℤ) : List ℤ :=
+`l.length + m.length - 1` slots; if either input is empty, all of those slots are zero.  This
+cannot be `private`, since the exposed body of `TauCeti.mulCoeffList` mentions it. -/
+@[expose] def coeffConvolution (l m : List ℤ) : List ℤ :=
   List.ofFn fun i : Fin (l.length + m.length - 1) =>
     ∑ jk ∈ Finset.antidiagonal (i : ℕ), l.getD jk.1 0 * m.getD jk.2 0
 
-/-- Multiplication of descending coefficient lists. -/
-private def mulCoeffList (l m : List ℤ) : List ℤ :=
+/-- Multiplication of descending coefficient lists.  This cannot be `private`, since the exposed
+body of `TauCeti.Cyclotomic.mul` mentions it. -/
+@[expose] def mulCoeffList (l m : List ℤ) : List ℤ :=
   (coeffConvolution l.reverse m.reverse).reverse
 
-private theorem length_coeffConvolution (l m : List ℤ) :
+/-- `TauCeti.coeffConvolution` produces the usual `l.length + m.length - 1` coefficients. -/
+theorem length_coeffConvolution (l m : List ℤ) :
     (coeffConvolution l m).length = l.length + m.length - 1 := by
   simp [coeffConvolution]
 
-private theorem ofCoeffList_mulCoeffList (l m : List ℤ) :
+/-- `TauCeti.mulCoeffList` lists the coefficients of a product of polynomials. -/
+theorem ofCoeffList_mulCoeffList (l m : List ℤ) :
     ofCoeffList (mulCoeffList l m) = ofCoeffList l * ofCoeffList m := by
   ext n
   rw [coeff_ofCoeffList, coeff_mul]
@@ -117,10 +129,7 @@ theorem coeffs_ofCoeffList (e : ℕ) (l : List ℤ) :
 
 /-- Polynomial convolution followed by canonical cyclotomic reduction. -/
 @[expose] def mul (x y : Cyclotomic e) : Cyclotomic e :=
-  ofCoeffList e
-    ((List.ofFn fun i : Fin (x.coeffs.length + y.coeffs.length - 1) =>
-      ∑ jk ∈ Finset.antidiagonal (i : ℕ),
-        x.coeffs.reverse.getD jk.1 0 * y.coeffs.reverse.getD jk.2 0).reverse)
+  ofCoeffList e (mulCoeffList x.coeffs y.coeffs)
 
 instance : Zero (Cyclotomic e) := ⟨zero e⟩
 instance : One (Cyclotomic e) := ⟨one e⟩
@@ -159,7 +168,11 @@ theorem toAdjoinRoot_injective : Function.Injective (toAdjoinRoot : Cyclotomic e
   simp only [toAdjoinRoot, AdjoinRoot.modByMonicHom_mk, modByMonic_toPolynomial] at h'
   exact ext (eq_of_length_eq_of_ofCoeffList_eq (x.length_coeffs.trans y.length_coeffs.symm) h')
 
-private theorem toAdjoinRoot_ofCoeffList (l : List ℤ) :
+/-- The comparison map sends the exact cyclotomic integer built from a coefficient list to the
+class of the polynomial with those coefficients: reduction modulo `Φ_e` is invisible in the
+quotient. -/
+@[simp]
+theorem toAdjoinRoot_ofCoeffList (l : List ℤ) :
     toAdjoinRoot (ofCoeffList e l) = AdjoinRoot.mk _ (TauCeti.Polynomial.ofCoeffList l) := by
   rw [toAdjoinRoot, toPolynomial, coeffs_ofCoeffList, ofCoeffList_modByCyclotomic,
     AdjoinRoot.mk_eq_mk]
@@ -205,12 +218,8 @@ theorem toAdjoinRoot_neg (x : Cyclotomic e) :
 @[simp]
 theorem toAdjoinRoot_mul (x y : Cyclotomic e) :
     toAdjoinRoot (x * y) = toAdjoinRoot x * toAdjoinRoot y := by
-  have hmul : x * y = ofCoeffList e (mulCoeffList x.coeffs y.coeffs) := by
-    simp only [HMul.hMul, Mul.mul, mul, mulCoeffList, coeffConvolution, List.length_reverse]
-    apply ext
-    rfl
-  rw [hmul, toAdjoinRoot_ofCoeffList, toAdjoinRoot, toAdjoinRoot, ← map_mul,
-    ofCoeffList_mulCoeffList]
+  rw [show x * y = ofCoeffList e (mulCoeffList x.coeffs y.coeffs) from rfl,
+    toAdjoinRoot_ofCoeffList, toAdjoinRoot, toAdjoinRoot, ← map_mul, ofCoeffList_mulCoeffList]
   simp only [toPolynomial]
 
 @[simp]
@@ -352,9 +361,9 @@ theorem equivAdjoinRoot_apply (x : Cyclotomic e) : equivAdjoinRoot x = toAdjoinR
 
 @[simp]
 theorem toAdjoinRoot_zeta : toAdjoinRoot (zeta e) = AdjoinRoot.root (cyclotomic e ℤ) := by
-  rw [zeta, toAdjoinRoot_ofCoeffList]
-  rw [show TauCeti.Polynomial.ofCoeffList ([1, 0] : List ℤ) = X by
-    simp [TauCeti.Polynomial.ofCoeffList_cons], AdjoinRoot.mk_X]
+  have hX : TauCeti.Polynomial.ofCoeffList ([1, 0] : List ℤ) = X := by
+    simp [TauCeti.Polynomial.ofCoeffList_cons]
+  rw [zeta, toAdjoinRoot_ofCoeffList, hX, AdjoinRoot.mk_X]
 
 /-! ## Evaluation and residue maps -/
 
@@ -362,6 +371,13 @@ theorem toAdjoinRoot_zeta : toAdjoinRoot (zeta e) = AdjoinRoot.root (cyclotomic 
 @[expose] noncomputable def evalRingHom {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
     (hr : (cyclotomic e ℤ).eval₂ f r = 0) : Cyclotomic e →+* R :=
   (AdjoinRoot.lift f r hr).comp toAdjoinRootRingHom
+
+/-- Evaluation at a root of `Φ_e` is evaluation of the canonical polynomial representative. -/
+theorem evalRingHom_apply {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
+    (hr : (cyclotomic e ℤ).eval₂ f r = 0) (x : Cyclotomic e) :
+    evalRingHom f r hr x = x.toPolynomial.eval₂ f r := by
+  rw [evalRingHom, RingHom.comp_apply, toAdjoinRootRingHom_apply, toAdjoinRoot,
+    AdjoinRoot.lift_mk]
 
 @[simp]
 theorem evalRingHom_ofCoeffList {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
@@ -419,6 +435,9 @@ theorem reduceRingHom_apply (p : ℕ) [Fact p.Prime] [NeZero e]
 /-- The distinguished complex primitive `e`-th root `exp (2πi/e)`. -/
 noncomputable def complexRoot (e : ℕ) : ℂ := Complex.exp (2 * Real.pi * Complex.I / e)
 
+/-- For nonzero `e`, the distinguished root `TauCeti.Cyclotomic.complexRoot e = exp (2πi/e)` is a
+primitive `e`-th root of unity.  This is what pins which complex root `ζ` names, and hence which
+embedding `TauCeti.Cyclotomic.complexEmbedding` is. -/
 theorem isPrimitiveRoot_complexRoot [NeZero e] : IsPrimitiveRoot (complexRoot e) e :=
   Complex.isPrimitiveRoot_exp e (NeZero.ne e)
 
@@ -433,6 +452,11 @@ theorem eval₂_cyclotomic_complexRoot [NeZero e] :
 noncomputable def complexEmbedding [NeZero e] : Cyclotomic e →+* ℂ :=
   evalRingHom (Int.castRingHom ℂ) (complexRoot e) eval₂_cyclotomic_complexRoot
 
+/-- The pinned embedding evaluates the canonical polynomial representative at `exp (2πi/e)`. -/
+theorem complexEmbedding_apply [NeZero e] (x : Cyclotomic e) :
+    complexEmbedding x = Polynomial.aeval (complexRoot e) x.toPolynomial := by
+  rw [complexEmbedding, evalRingHom_apply, aeval_def, algebraMap_int_eq]
+
 @[simp]
 theorem complexEmbedding_zeta [NeZero e] : complexEmbedding (zeta e) = complexRoot e := by
   rw [complexEmbedding, zeta, evalRingHom_ofCoeffList]
@@ -444,8 +468,7 @@ theorem complexEmbedding_injective [NeZero e] :
   intro x y hxy
   have hzero : complexEmbedding (x - y) = 0 := by rw [map_sub, hxy, sub_self]
   have heval : Polynomial.aeval (complexRoot e) (x - y).toPolynomial = 0 := by
-    simpa [complexEmbedding, evalRingHom, RingHom.comp_apply, toAdjoinRootRingHom_apply,
-      toAdjoinRoot, AdjoinRoot.lift_mk, aeval_def] using hzero
+    rw [← complexEmbedding_apply]; exact hzero
   have hdiv : cyclotomic e ℤ ∣ (x - y).toPolynomial := by
     rw [cyclotomic_eq_minpoly isPrimitiveRoot_complexRoot (NeZero.pos e)]
     exact minpoly.isIntegrallyClosed_dvd

--- a/TauCeti/RingTheory/Cyclotomic/Basic.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Basic.lean
@@ -1,0 +1,468 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.AdjoinRoot
+public import Mathlib.RingTheory.Polynomial.Cyclotomic.Roots
+public import Mathlib.RingTheory.RootsOfUnity.Complex
+public import TauCeti.RingTheory.Polynomial.Cyclotomic.Computable
+
+/-!
+# Computable cyclotomic integers
+
+This file defines `TauCeti.Cyclotomic e`, an exact, computable model of
+`ℤ[X] / (Polynomial.cyclotomic e ℤ)`.  Its elements are the `e.totient` coefficients of the
+canonical representative, in descending order.  Addition, negation, multiplication, and equality
+are genuine computations on finite lists of integers; multiplication uses the computable
+cyclotomic reduction from `TauCeti.RingTheory.Polynomial.Cyclotomic.Computable`.
+
+The ring is identified with Mathlib's `AdjoinRoot (Polynomial.cyclotomic e ℤ)`.  For nonzero `e`,
+evaluation at `exp (2 * π * I / e)` then gives the distinguished embedding into `ℂ` used to state
+the correctness of exact character-table computations.
+-/
+
+public section
+
+open Polynomial TauCeti.Polynomial
+
+namespace TauCeti
+
+/-! ## Computable coefficient arithmetic -/
+
+/-- Convolution of two coefficient lists in ascending degree order.  The output has the usual
+`l.length + m.length - 1` slots; if either input is empty, all of those slots are zero. -/
+private def coeffConvolution (l m : List ℤ) : List ℤ :=
+  List.ofFn fun i : Fin (l.length + m.length - 1) =>
+    ∑ jk ∈ Finset.antidiagonal (i : ℕ), l.getD jk.1 0 * m.getD jk.2 0
+
+/-- Multiplication of descending coefficient lists. -/
+private def mulCoeffList (l m : List ℤ) : List ℤ :=
+  (coeffConvolution l.reverse m.reverse).reverse
+
+private theorem length_coeffConvolution (l m : List ℤ) :
+    (coeffConvolution l m).length = l.length + m.length - 1 := by
+  simp [coeffConvolution]
+
+private theorem ofCoeffList_mulCoeffList (l m : List ℤ) :
+    ofCoeffList (mulCoeffList l m) = ofCoeffList l * ofCoeffList m := by
+  ext n
+  rw [coeff_ofCoeffList, coeff_mul]
+  by_cases hn : n < l.length + m.length - 1
+  · rw [mulCoeffList, List.reverse_reverse, List.getD_eq_getElem]
+    · simp only [coeffConvolution, List.getElem_ofFn, coeff_ofCoeffList]
+    · simpa [length_coeffConvolution] using hn
+  · rw [List.getD_eq_getElem?_getD,
+      List.getElem?_eq_none (by simp [mulCoeffList, length_coeffConvolution]; omega),
+      Option.getD_none]
+    simp only [coeff_ofCoeffList]
+    symm
+    apply Finset.sum_eq_zero
+    intro jk hjk
+    rw [Finset.mem_antidiagonal] at hjk
+    by_cases hl : jk.1 < l.length
+    · have hm : m.length ≤ jk.2 := by omega
+      have hm0 : m.reverse.getD jk.2 0 = 0 := by
+        rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none (by simpa using hm),
+          Option.getD_none]
+      rw [hm0, mul_zero]
+    · have hl0 : l.reverse.getD jk.1 0 = 0 := by
+        rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none (by simpa using hl),
+          Option.getD_none]
+      rw [hl0, zero_mul]
+
+/-! ## The exact ring -/
+
+/-- Exact `e`-th cyclotomic integers, represented by the `e.totient` coefficients of the
+canonical polynomial representative in descending order. -/
+@[expose] def Cyclotomic (e : ℕ) := {l : List ℤ // l.length = e.totient}
+  deriving DecidableEq
+
+namespace Cyclotomic
+
+variable {e : ℕ}
+
+/-- The descending list of coefficients representing an exact cyclotomic integer. -/
+@[expose] def coeffs (x : Cyclotomic e) : List ℤ := x.1
+
+@[simp]
+theorem length_coeffs (x : Cyclotomic e) : x.coeffs.length = e.totient := x.2
+
+@[ext]
+theorem ext {x y : Cyclotomic e} (h : x.coeffs = y.coeffs) : x = y := Subtype.ext h
+
+/-- Reduce a descending coefficient list modulo `Φ_e` and regard the result as an exact
+cyclotomic integer. -/
+@[expose] def ofCoeffList (e : ℕ) (l : List ℤ) : Cyclotomic e :=
+  ⟨modByCyclotomic e l, length_modByCyclotomic e l⟩
+
+@[simp]
+theorem coeffs_ofCoeffList (e : ℕ) (l : List ℤ) :
+    (ofCoeffList e l).coeffs = modByCyclotomic e l := rfl
+
+/-- Zero in the coefficient-vector model. -/
+@[expose] def zero (e : ℕ) : Cyclotomic e := ofCoeffList e []
+
+/-- One in the coefficient-vector model. -/
+@[expose] def one (e : ℕ) : Cyclotomic e := ofCoeffList e [1]
+
+/-- Addition followed by canonical cyclotomic reduction. -/
+@[expose] def add (x y : Cyclotomic e) : Cyclotomic e :=
+  ofCoeffList e (List.zipWith (fun a b => a + b) x.coeffs y.coeffs)
+
+/-- Negation followed by canonical cyclotomic reduction. -/
+@[expose] def neg (x : Cyclotomic e) : Cyclotomic e :=
+  ofCoeffList e (x.coeffs.map (-·))
+
+/-- Polynomial convolution followed by canonical cyclotomic reduction. -/
+@[expose] def mul (x y : Cyclotomic e) : Cyclotomic e :=
+  ofCoeffList e
+    ((List.ofFn fun i : Fin (x.coeffs.length + y.coeffs.length - 1) =>
+      ∑ jk ∈ Finset.antidiagonal (i : ℕ),
+        x.coeffs.reverse.getD jk.1 0 * y.coeffs.reverse.getD jk.2 0).reverse)
+
+instance : Zero (Cyclotomic e) := ⟨zero e⟩
+instance : One (Cyclotomic e) := ⟨one e⟩
+instance : Add (Cyclotomic e) := ⟨add⟩
+instance : Neg (Cyclotomic e) := ⟨neg⟩
+instance : Mul (Cyclotomic e) := ⟨mul⟩
+
+instance : Sub (Cyclotomic e) := ⟨fun x y => x + -y⟩
+instance : SMul ℕ (Cyclotomic e) := ⟨nsmulRec⟩
+instance : SMul ℤ (Cyclotomic e) := ⟨zsmulRec⟩
+instance : Pow (Cyclotomic e) ℕ := ⟨fun x n => npowRec n x⟩
+instance : NatCast (Cyclotomic e) := ⟨fun n => ofCoeffList e [n]⟩
+instance : IntCast (Cyclotomic e) := ⟨fun z => ofCoeffList e [z]⟩
+
+/-- The polynomial represented by an exact cyclotomic integer. -/
+noncomputable def toPolynomial (x : Cyclotomic e) : ℤ[X] :=
+  TauCeti.Polynomial.ofCoeffList x.coeffs
+
+/-- The comparison map from computable cyclotomic integers to Mathlib's quotient by `Φ_e`. -/
+noncomputable def toAdjoinRoot (x : Cyclotomic e) : AdjoinRoot (cyclotomic e ℤ) :=
+  AdjoinRoot.mk _ x.toPolynomial
+
+private theorem degree_toPolynomial_lt (x : Cyclotomic e) :
+    x.toPolynomial.degree < (cyclotomic e ℤ).degree := by
+  rw [degree_cyclotomic]
+  simpa [toPolynomial] using degree_ofCoeffList_lt x.coeffs
+
+private theorem modByMonic_toPolynomial (x : Cyclotomic e) :
+    x.toPolynomial %ₘ cyclotomic e ℤ = x.toPolynomial :=
+  (modByMonic_eq_self_iff (cyclotomic.monic e ℤ)).2 x.degree_toPolynomial_lt
+
+/-- The comparison with `AdjoinRoot` is injective. -/
+theorem toAdjoinRoot_injective : Function.Injective (toAdjoinRoot : Cyclotomic e → _) := by
+  intro x y h
+  have h' := congrArg (AdjoinRoot.modByMonicHom (cyclotomic.monic e ℤ)) h
+  simp only [toAdjoinRoot, AdjoinRoot.modByMonicHom_mk, modByMonic_toPolynomial] at h'
+  exact ext (eq_of_length_eq_of_ofCoeffList_eq (x.length_coeffs.trans y.length_coeffs.symm) h')
+
+private theorem toAdjoinRoot_ofCoeffList (l : List ℤ) :
+    toAdjoinRoot (ofCoeffList e l) = AdjoinRoot.mk _ (TauCeti.Polynomial.ofCoeffList l) := by
+  rw [toAdjoinRoot, toPolynomial, coeffs_ofCoeffList, ofCoeffList_modByCyclotomic,
+    AdjoinRoot.mk_eq_mk]
+  rw [modByMonic_eq_sub_mul_div, sub_sub_cancel_left]
+  exact dvd_neg.mpr (dvd_mul_right _ _)
+
+-- These explicit rewrites expose the standalone computational operations before they are bundled
+-- into the `CommRing` instance below.
+
+@[simp]
+theorem toAdjoinRoot_zero : toAdjoinRoot (0 : Cyclotomic e) = 0 := by
+  rw [show (0 : Cyclotomic e) = ofCoeffList e [] from rfl, toAdjoinRoot_ofCoeffList]
+  simp
+
+@[simp]
+theorem toAdjoinRoot_one : toAdjoinRoot (1 : Cyclotomic e) = 1 := by
+  rw [show (1 : Cyclotomic e) = ofCoeffList e [1] from rfl, toAdjoinRoot_ofCoeffList]
+  simp [TauCeti.Polynomial.ofCoeffList_cons]
+
+@[simp]
+theorem toAdjoinRoot_add (x y : Cyclotomic e) :
+    toAdjoinRoot (x + y) = toAdjoinRoot x + toAdjoinRoot y := by
+  rw [show x + y = ofCoeffList e (List.zipWith (fun a b => a + b) x.coeffs y.coeffs) from rfl,
+    toAdjoinRoot_ofCoeffList, toAdjoinRoot, toAdjoinRoot]
+  rw [← map_add]
+  congr 1
+  simpa [sub_eq_add_neg, toPolynomial] using
+    (ofCoeffList_zipWith_sub (-1 : ℤ) (x.length_coeffs.trans y.length_coeffs.symm))
+
+@[simp]
+theorem toAdjoinRoot_neg (x : Cyclotomic e) :
+    toAdjoinRoot (-x) = -toAdjoinRoot x := by
+  rw [show -x = ofCoeffList e (x.coeffs.map (-·)) from rfl, toAdjoinRoot_ofCoeffList,
+    toAdjoinRoot]
+  rw [← map_neg]
+  congr 1
+  ext n
+  rw [coeff_ofCoeffList, coeff_neg, toPolynomial, coeff_ofCoeffList, ← List.map_reverse,
+    show (List.map (fun z : ℤ => -z) x.coeffs.reverse).getD n 0 =
+      -x.coeffs.reverse.getD n 0 by simpa using
+        (List.getD_map (l := x.coeffs.reverse) (d := 0) (n := n) fun z : ℤ => -z)]
+
+@[simp]
+theorem toAdjoinRoot_mul (x y : Cyclotomic e) :
+    toAdjoinRoot (x * y) = toAdjoinRoot x * toAdjoinRoot y := by
+  have hmul : x * y = ofCoeffList e (mulCoeffList x.coeffs y.coeffs) := by
+    simp only [HMul.hMul, Mul.mul, mul, mulCoeffList, coeffConvolution, List.length_reverse]
+    apply ext
+    rfl
+  rw [hmul, toAdjoinRoot_ofCoeffList, toAdjoinRoot, toAdjoinRoot, ← map_mul,
+    ofCoeffList_mulCoeffList]
+  simp only [toPolynomial]
+
+@[simp]
+theorem toAdjoinRoot_sub (x y : Cyclotomic e) :
+    toAdjoinRoot (x - y) = toAdjoinRoot x - toAdjoinRoot y := by
+  rw [show x - y = x + -y from rfl, toAdjoinRoot_add, toAdjoinRoot_neg, sub_eq_add_neg]
+
+/-- The comparison map preserves natural scalar multiplication. -/
+theorem toAdjoinRoot_nsmul (n : ℕ) (x : Cyclotomic e) :
+    toAdjoinRoot (n • x) = n • toAdjoinRoot x := by
+  induction n with
+  | zero =>
+    rw [show (0 : ℕ) • x = (0 : Cyclotomic e) from rfl, zero_nsmul]
+    exact toAdjoinRoot_zero
+  | succ n ih =>
+    rw [show (n + 1) • x = n • x + x from rfl, succ_nsmul, toAdjoinRoot_add, ih]
+
+/-- The comparison map preserves integer scalar multiplication. -/
+theorem toAdjoinRoot_zsmul (z : ℤ) (x : Cyclotomic e) :
+    toAdjoinRoot (z • x) = z • toAdjoinRoot x := by
+  cases z with
+  | ofNat n =>
+    rw [show (Int.ofNat n : ℤ) • x = n • x from rfl, Int.ofNat_eq_natCast, natCast_zsmul]
+    exact toAdjoinRoot_nsmul n x
+  | negSucc n =>
+    rw [show Int.negSucc n • x = -((n + 1) • x) from rfl, negSucc_zsmul,
+      toAdjoinRoot_neg, toAdjoinRoot_nsmul]
+
+/-- The comparison map preserves natural powers. -/
+theorem toAdjoinRoot_pow (x : Cyclotomic e) (n : ℕ) :
+    toAdjoinRoot (x ^ n) = toAdjoinRoot x ^ n := by
+  induction n with
+  | zero => exact toAdjoinRoot_one
+  | succ n ih =>
+    rw [show x ^ (n + 1) = x ^ n * x from rfl, toAdjoinRoot_mul, ih, pow_succ]
+
+/-- The comparison map preserves natural-number casts. -/
+theorem toAdjoinRoot_natCast (n : ℕ) :
+    toAdjoinRoot (n : Cyclotomic e) = n := by
+  rw [show (n : Cyclotomic e) = ofCoeffList e [n] from rfl, toAdjoinRoot_ofCoeffList]
+  simp [TauCeti.Polynomial.ofCoeffList_cons]
+
+/-- The comparison map preserves integer casts. -/
+theorem toAdjoinRoot_intCast (z : ℤ) :
+    toAdjoinRoot (z : Cyclotomic e) = z := by
+  rw [show (z : Cyclotomic e) = ofCoeffList e [z] from rfl, toAdjoinRoot_ofCoeffList]
+  simp [TauCeti.Polynomial.ofCoeffList_cons]
+
+instance : CommRing (Cyclotomic e) where
+  add := add
+  add_assoc a b c := toAdjoinRoot_injective (by simp only [toAdjoinRoot_add, add_assoc])
+  zero := zero e
+  zero_add a := toAdjoinRoot_injective (by
+    simp only [toAdjoinRoot_add, toAdjoinRoot_zero, zero_add])
+  add_zero a := toAdjoinRoot_injective (by
+    simp only [toAdjoinRoot_add, toAdjoinRoot_zero, add_zero])
+  nsmul := @nsmulRec (Cyclotomic e) ⟨zero e⟩ ⟨add⟩
+  add_comm a b := toAdjoinRoot_injective (by simp only [toAdjoinRoot_add, add_comm])
+  mul := mul
+  mul_assoc a b c := toAdjoinRoot_injective (by simp only [toAdjoinRoot_mul, mul_assoc])
+  one := one e
+  one_mul a := toAdjoinRoot_injective (by
+    simp only [toAdjoinRoot_mul, toAdjoinRoot_one, one_mul])
+  mul_one a := toAdjoinRoot_injective (by
+    simp only [toAdjoinRoot_mul, toAdjoinRoot_one, mul_one])
+  npow := @npowRec (Cyclotomic e) ⟨one e⟩ ⟨mul⟩
+  zero_mul a := toAdjoinRoot_injective (by
+    simp only [toAdjoinRoot_mul, toAdjoinRoot_zero, zero_mul])
+  mul_zero a := toAdjoinRoot_injective (by
+    simp only [toAdjoinRoot_mul, toAdjoinRoot_zero, mul_zero])
+  left_distrib a b c := toAdjoinRoot_injective (by
+    simp only [toAdjoinRoot_add, toAdjoinRoot_mul, left_distrib])
+  right_distrib a b c := toAdjoinRoot_injective (by
+    simp only [toAdjoinRoot_add, toAdjoinRoot_mul, right_distrib])
+  natCast n := ofCoeffList e [n]
+  natCast_zero := toAdjoinRoot_injective (by
+    rw [toAdjoinRoot_ofCoeffList, toAdjoinRoot_zero]
+    simp [TauCeti.Polynomial.ofCoeffList_cons])
+  natCast_succ n := toAdjoinRoot_injective (by
+    rw [toAdjoinRoot_ofCoeffList, toAdjoinRoot_add, toAdjoinRoot_ofCoeffList,
+      toAdjoinRoot_one]
+    simp [TauCeti.Polynomial.ofCoeffList_cons])
+  neg := neg
+  sub := fun x y => add x (neg y)
+  zsmul := @zsmulRec (Cyclotomic e) ⟨zero e⟩ ⟨add⟩ ⟨neg⟩
+    (@nsmulRec (Cyclotomic e) ⟨zero e⟩ ⟨add⟩)
+  sub_eq_add_neg := by intros; rfl
+  zsmul_zero' := by intros; rfl
+  zsmul_succ' := by intros; rfl
+  zsmul_neg' := by intros; rfl
+  neg_add_cancel a := toAdjoinRoot_injective (by
+    rw [toAdjoinRoot_add, show toAdjoinRoot (neg a) = -toAdjoinRoot a from toAdjoinRoot_neg a,
+      toAdjoinRoot_zero, neg_add_cancel])
+  intCast z := ofCoeffList e [z]
+  intCast_ofNat n := rfl
+  intCast_negSucc n := toAdjoinRoot_injective (by
+    -- The structure is still being assembled, so spell out its pending cast and negation fields.
+    change toAdjoinRoot (ofCoeffList e [Int.negSucc n]) =
+      toAdjoinRoot (neg (ofCoeffList e [(n + 1 : ℕ)]))
+    rw [toAdjoinRoot_ofCoeffList,
+      show toAdjoinRoot (neg (ofCoeffList e [(n + 1 : ℕ)])) =
+        -toAdjoinRoot (ofCoeffList e [(n + 1 : ℕ)]) from toAdjoinRoot_neg _,
+      toAdjoinRoot_ofCoeffList]
+    simp [TauCeti.Polynomial.ofCoeffList_cons])
+  mul_comm a b := toAdjoinRoot_injective (by simp only [toAdjoinRoot_mul, mul_comm])
+
+/-! ## Comparison with `AdjoinRoot` -/
+
+/-- The ring homomorphism identifying exact cyclotomic integers with the polynomial quotient. -/
+@[expose] noncomputable def toAdjoinRootRingHom : Cyclotomic e →+* AdjoinRoot (cyclotomic e ℤ) where
+  toFun := toAdjoinRoot
+  map_zero' := toAdjoinRoot_zero
+  map_one' := toAdjoinRoot_one
+  map_add' := toAdjoinRoot_add
+  map_mul' := toAdjoinRoot_mul
+
+@[simp]
+theorem toAdjoinRootRingHom_apply (x : Cyclotomic e) :
+    toAdjoinRootRingHom x = toAdjoinRoot x := (rfl)
+
+/-- Every class modulo `Φ_e` has an exact coefficient-vector representative. -/
+theorem toAdjoinRoot_surjective : Function.Surjective (toAdjoinRoot : Cyclotomic e → _) := by
+  intro z
+  obtain ⟨p, rfl⟩ := AdjoinRoot.mk_surjective z
+  refine ⟨ofCoeffList e p.coeffList, ?_⟩
+  rw [toAdjoinRoot_ofCoeffList, TauCeti.Polynomial.ofCoeffList_coeffList]
+
+/-- Exact cyclotomic integers are the quotient `ℤ[X] / (Φ_e)`. -/
+@[expose] noncomputable def equivAdjoinRoot :
+    Cyclotomic e ≃+* AdjoinRoot (cyclotomic e ℤ) :=
+  RingEquiv.ofBijective toAdjoinRootRingHom
+    ⟨toAdjoinRoot_injective, toAdjoinRoot_surjective⟩
+
+@[simp]
+theorem equivAdjoinRoot_apply (x : Cyclotomic e) : equivAdjoinRoot x = toAdjoinRoot x := rfl
+
+/-- The distinguished generator `ζ`, represented by the polynomial `X`. -/
+@[expose] def zeta (e : ℕ) : Cyclotomic e := ofCoeffList e [1, 0]
+
+@[simp]
+theorem equivAdjoinRoot_zeta : equivAdjoinRoot (zeta e) = AdjoinRoot.root (cyclotomic e ℤ) := by
+  rw [equivAdjoinRoot_apply, zeta, toAdjoinRoot_ofCoeffList]
+  rw [show TauCeti.Polynomial.ofCoeffList ([1, 0] : List ℤ) = X by
+    simp [TauCeti.Polynomial.ofCoeffList_cons], AdjoinRoot.mk_X]
+
+/-! ## Evaluation and residue maps -/
+
+/-- Evaluate exact cyclotomic integers at a root of the mapped cyclotomic polynomial. -/
+@[expose] noncomputable def evalRingHom {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
+    (hr : (cyclotomic e ℤ).eval₂ f r = 0) : Cyclotomic e →+* R :=
+  (AdjoinRoot.lift f r hr).comp toAdjoinRootRingHom
+
+@[simp]
+theorem evalRingHom_ofCoeffList {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
+    (hr : (cyclotomic e ℤ).eval₂ f r = 0) (l : List ℤ) :
+    evalRingHom f r hr (ofCoeffList e l) =
+      (TauCeti.Polynomial.ofCoeffList l).eval₂ f r := by
+  rw [evalRingHom, RingHom.comp_apply, toAdjoinRootRingHom_apply, toAdjoinRoot_ofCoeffList,
+    AdjoinRoot.lift_mk]
+
+/-- Evaluate a coefficient vector by Horner's rule.  Unlike `Polynomial.eval₂`, this is a genuine
+computation because it works directly on the finite list. -/
+@[expose] def evalCoeffs {R : Type*} [Semiring R] (f : ℤ →+* R) (r : R)
+    (x : Cyclotomic e) : R :=
+  x.coeffs.foldl (fun y a => y * r + f a) 0
+
+private theorem eval₂_ofCoeffList {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
+    (l : List ℤ) :
+    (TauCeti.Polynomial.ofCoeffList l).eval₂ f r =
+      l.foldl (fun y a => y * r + f a) 0 := by
+  induction l using List.reverseRecOn with
+  | nil => simp
+  | append_singleton l a ih =>
+    rw [TauCeti.Polynomial.ofCoeffList_concat, eval₂_add, eval₂_mul, eval₂_X, eval₂_C,
+      List.foldl_append, ih]
+    rfl
+
+/-- Direct coefficient-list evaluation agrees with polynomial evaluation. -/
+theorem evalCoeffs_eq_eval₂ {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
+    (x : Cyclotomic e) :
+    evalCoeffs f r x = x.toPolynomial.eval₂ f r := by
+  rw [evalCoeffs, toPolynomial, eval₂_ofCoeffList]
+
+/-- Reduction of exact cyclotomic integers in `ZMod p`, evaluated at a chosen residue `r`.
+When `r` is an `e`-th primitive root, `TauCeti.Cyclotomic.reduceRingHom` packages this as a ring
+homomorphism. -/
+@[expose] def reduce (p : ℕ) (r : ZMod p) (x : Cyclotomic e) : ZMod p :=
+  evalCoeffs (Int.castRingHom (ZMod p)) r x
+
+/-- Reduction at an `e`-th primitive root in a prime field is a ring homomorphism. -/
+noncomputable def reduceRingHom (p : ℕ) [Fact p.Prime] [NeZero e]
+    (r : ZMod p) (hr : IsPrimitiveRoot r e) : Cyclotomic e →+* ZMod p :=
+  evalRingHom (Int.castRingHom (ZMod p)) r <| by
+    rw [← eval_map, map_cyclotomic]
+    exact hr.isRoot_cyclotomic (NeZero.pos e)
+
+@[simp]
+theorem reduceRingHom_apply (p : ℕ) [Fact p.Prime] [NeZero e]
+    (r : ZMod p) (hr : IsPrimitiveRoot r e) (x : Cyclotomic e) :
+    reduceRingHom p r hr x = reduce p r x := by
+  rw [reduceRingHom, reduce, evalRingHom, RingHom.comp_apply, toAdjoinRootRingHom_apply,
+    toAdjoinRoot, AdjoinRoot.lift_mk, evalCoeffs_eq_eval₂]
+
+/-! ## The distinguished complex embedding -/
+
+/-- The distinguished complex primitive `e`-th root `exp (2πi/e)`. -/
+noncomputable def complexRoot (e : ℕ) : ℂ := Complex.exp (2 * Real.pi * Complex.I / e)
+
+theorem isPrimitiveRoot_complexRoot [NeZero e] : IsPrimitiveRoot (complexRoot e) e :=
+  Complex.isPrimitiveRoot_exp e (NeZero.ne e)
+
+/-- The distinguished complex root annihilates the integral cyclotomic polynomial. -/
+theorem eval₂_cyclotomic_complexRoot [NeZero e] :
+    (cyclotomic e ℤ).eval₂ (Int.castRingHom ℂ) (complexRoot e) = 0 := by
+  rw [← eval_map, map_cyclotomic]
+  exact (isPrimitiveRoot_complexRoot (e := e)).isRoot_cyclotomic (NeZero.pos e)
+
+/-- The pinned embedding of exact cyclotomic integers into `ℂ`, sending `ζ` to
+`exp (2πi/e)`. -/
+noncomputable def complexEmbedding [NeZero e] : Cyclotomic e →+* ℂ :=
+  evalRingHom (Int.castRingHom ℂ) (complexRoot e) eval₂_cyclotomic_complexRoot
+
+@[simp]
+theorem complexEmbedding_zeta [NeZero e] : complexEmbedding (zeta e) = complexRoot e := by
+  rw [complexEmbedding, zeta, evalRingHom_ofCoeffList]
+  simp [TauCeti.Polynomial.ofCoeffList_cons]
+
+/-- The distinguished complex realization of exact cyclotomic integers is injective. -/
+theorem complexEmbedding_injective [NeZero e] :
+    Function.Injective (complexEmbedding : Cyclotomic e → ℂ) := by
+  intro x y hxy
+  have hzero : complexEmbedding (x - y) = 0 := by rw [map_sub, hxy, sub_self]
+  have heval : Polynomial.aeval (complexRoot e) (x - y).toPolynomial = 0 := by
+    simpa [complexEmbedding, evalRingHom, RingHom.comp_apply, toAdjoinRootRingHom_apply,
+      toAdjoinRoot, AdjoinRoot.lift_mk, aeval_def] using hzero
+  have hdiv : cyclotomic e ℤ ∣ (x - y).toPolynomial := by
+    rw [cyclotomic_eq_minpoly isPrimitiveRoot_complexRoot (NeZero.pos e)]
+    exact minpoly.isIntegrallyClosed_dvd
+      (isPrimitiveRoot_complexRoot.isIntegral (NeZero.pos e)) heval
+  have hp : (x - y).toPolynomial = 0 :=
+    Polynomial.eq_zero_of_dvd_of_degree_lt hdiv (degree_toPolynomial_lt (x - y))
+  apply sub_eq_zero.mp
+  apply toAdjoinRoot_injective
+  rw [toAdjoinRoot, hp, map_zero, toAdjoinRoot_zero]
+
+/-! The exact arithmetic reduces in the kernel.  In `Cyclotomic 5`, `ζ⁵ = 1`; reduction at
+`2 : ZMod 5`, a primitive fourth root, sends `ζ + 1` to `3`. -/
+
+example : (zeta 5 ^ 5).coeffs = (1 : Cyclotomic 5).coeffs := by decide
+
+example : reduce 5 2 (zeta 4 + 1) = 3 := by decide
+
+end Cyclotomic
+
+end TauCeti

--- a/TauCeti/RingTheory/Cyclotomic/Basic.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Basic.lean
@@ -15,8 +15,9 @@ public import TauCeti.RingTheory.Polynomial.Cyclotomic.Computable
 This file defines `TauCeti.Cyclotomic e`, an exact, computable model of
 `ℤ[X] / (Polynomial.cyclotomic e ℤ)`.  Its elements are the `e.totient` coefficients of the
 canonical representative, in descending order.  Addition, negation, multiplication, and equality
-are genuine computations on finite lists of integers; multiplication uses the computable
-cyclotomic reduction from `TauCeti.RingTheory.Polynomial.Cyclotomic.Computable`.
+are genuine computations on finite lists of integers; multiplication convolves coefficient lists
+with `TauCeti.Polynomial.mulCoeffList` and then applies the computable cyclotomic reduction from
+`TauCeti.RingTheory.Polynomial.Cyclotomic.Computable`.
 
 The ring is identified with Mathlib's `AdjoinRoot (Polynomial.cyclotomic e ℤ)`.  For nonzero `e`,
 evaluation at `exp (2 * π * I / e)` then gives the distinguished embedding into `ℂ` used to state
@@ -36,53 +37,6 @@ public section
 open Polynomial TauCeti.Polynomial
 
 namespace TauCeti
-
-/-! ## Computable coefficient arithmetic -/
-
-/-- Convolution of two coefficient lists in ascending degree order.  The output has the usual
-`l.length + m.length - 1` slots; if either input is empty, all of those slots are zero.  This
-cannot be `private`, since the exposed body of `TauCeti.mulCoeffList` mentions it. -/
-@[expose] def coeffConvolution (l m : List ℤ) : List ℤ :=
-  List.ofFn fun i : Fin (l.length + m.length - 1) =>
-    ∑ jk ∈ Finset.antidiagonal (i : ℕ), l.getD jk.1 0 * m.getD jk.2 0
-
-/-- Multiplication of descending coefficient lists.  This cannot be `private`, since the exposed
-body of `TauCeti.Cyclotomic.mul` mentions it. -/
-@[expose] def mulCoeffList (l m : List ℤ) : List ℤ :=
-  (coeffConvolution l.reverse m.reverse).reverse
-
-/-- `TauCeti.coeffConvolution` produces the usual `l.length + m.length - 1` coefficients. -/
-theorem length_coeffConvolution (l m : List ℤ) :
-    (coeffConvolution l m).length = l.length + m.length - 1 := by
-  simp [coeffConvolution]
-
-/-- `TauCeti.mulCoeffList` lists the coefficients of a product of polynomials. -/
-theorem ofCoeffList_mulCoeffList (l m : List ℤ) :
-    ofCoeffList (mulCoeffList l m) = ofCoeffList l * ofCoeffList m := by
-  ext n
-  rw [coeff_ofCoeffList, coeff_mul]
-  by_cases hn : n < l.length + m.length - 1
-  · rw [mulCoeffList, List.reverse_reverse, List.getD_eq_getElem]
-    · simp only [coeffConvolution, List.getElem_ofFn, coeff_ofCoeffList]
-    · simpa [length_coeffConvolution] using hn
-  · rw [List.getD_eq_getElem?_getD,
-      List.getElem?_eq_none (by simp [mulCoeffList, length_coeffConvolution]; omega),
-      Option.getD_none]
-    simp only [coeff_ofCoeffList]
-    symm
-    apply Finset.sum_eq_zero
-    intro jk hjk
-    rw [Finset.mem_antidiagonal] at hjk
-    by_cases hl : jk.1 < l.length
-    · have hm : m.length ≤ jk.2 := by omega
-      have hm0 : m.reverse.getD jk.2 0 = 0 := by
-        rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none (by simpa using hm),
-          Option.getD_none]
-      rw [hm0, mul_zero]
-    · have hl0 : l.reverse.getD jk.1 0 = 0 := by
-        rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none (by simpa using hl),
-          Option.getD_none]
-      rw [hl0, zero_mul]
 
 /-! ## The exact ring -/
 
@@ -329,7 +283,7 @@ instance : CommRing (Cyclotomic e) where
 /-! ## Comparison with `AdjoinRoot` -/
 
 /-- The ring homomorphism identifying exact cyclotomic integers with the polynomial quotient. -/
-@[expose] noncomputable def toAdjoinRootRingHom : Cyclotomic e →+* AdjoinRoot (cyclotomic e ℤ) where
+noncomputable def toAdjoinRootRingHom : Cyclotomic e →+* AdjoinRoot (cyclotomic e ℤ) where
   toFun := toAdjoinRoot
   map_zero' := toAdjoinRoot_zero
   map_one' := toAdjoinRoot_one
@@ -347,14 +301,19 @@ theorem toAdjoinRoot_surjective : Function.Surjective (toAdjoinRoot : Cyclotomic
   refine ⟨ofCoeffList e p.coeffList, ?_⟩
   rw [toAdjoinRoot_ofCoeffList, TauCeti.Polynomial.ofCoeffList_coeffList]
 
+private theorem toAdjoinRootRingHom_bijective :
+    Function.Bijective (toAdjoinRootRingHom (e := e)) :=
+  ⟨fun _ _ h => toAdjoinRoot_injective (by simpa using h),
+    fun z => (toAdjoinRoot_surjective z).imp fun _ h => by simpa using h⟩
+
 /-- Exact cyclotomic integers are the quotient `ℤ[X] / (Φ_e)`. -/
-@[expose] noncomputable def equivAdjoinRoot :
+noncomputable def equivAdjoinRoot :
     Cyclotomic e ≃+* AdjoinRoot (cyclotomic e ℤ) :=
-  RingEquiv.ofBijective toAdjoinRootRingHom
-    ⟨toAdjoinRoot_injective, toAdjoinRoot_surjective⟩
+  RingEquiv.ofBijective toAdjoinRootRingHom toAdjoinRootRingHom_bijective
 
 @[simp]
-theorem equivAdjoinRoot_apply (x : Cyclotomic e) : equivAdjoinRoot x = toAdjoinRoot x := rfl
+theorem equivAdjoinRoot_apply (x : Cyclotomic e) : equivAdjoinRoot x = toAdjoinRoot x := by
+  rw [equivAdjoinRoot, RingEquiv.ofBijective_apply, toAdjoinRootRingHom_apply]
 
 /-- The distinguished generator `ζ`, represented by the polynomial `X`. -/
 @[expose] def zeta (e : ℕ) : Cyclotomic e := ofCoeffList e [1, 0]
@@ -365,10 +324,27 @@ theorem toAdjoinRoot_zeta : toAdjoinRoot (zeta e) = AdjoinRoot.root (cyclotomic 
     simp [TauCeti.Polynomial.ofCoeffList_cons]
   rw [zeta, toAdjoinRoot_ofCoeffList, hX, AdjoinRoot.mk_X]
 
+@[simp]
+theorem equivAdjoinRoot_symm_root :
+    (equivAdjoinRoot (e := e)).symm (AdjoinRoot.root (cyclotomic e ℤ)) = zeta e :=
+  equivAdjoinRoot.symm_apply_eq.2 (by rw [equivAdjoinRoot_apply, toAdjoinRoot_zeta])
+
+/-- A ring homomorphism out of the exact cyclotomic integers is determined by the image of the
+distinguished generator `ζ`: the integers admit a unique ring homomorphism, and `ζ` generates
+everything else. -/
+theorem ringHom_ext {R : Type*} [CommRing R] {g₁ g₂ : Cyclotomic e →+* R}
+    (h : g₁ (zeta e) = g₂ (zeta e)) : g₁ = g₂ := by
+  have key : g₁.comp (equivAdjoinRoot (e := e)).symm.toRingHom
+      = g₂.comp (equivAdjoinRoot (e := e)).symm.toRingHom :=
+    AdjoinRoot.ringHom_ext (RingHom.ext_int _ _) (by simpa using h)
+  refine RingHom.ext fun x => ?_
+  obtain ⟨y, rfl⟩ := equivAdjoinRoot.symm.surjective x
+  exact RingHom.congr_fun key y
+
 /-! ## Evaluation and residue maps -/
 
 /-- Evaluate exact cyclotomic integers at a root of the mapped cyclotomic polynomial. -/
-@[expose] noncomputable def evalRingHom {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
+noncomputable def evalRingHom {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
     (hr : (cyclotomic e ℤ).eval₂ f r = 0) : Cyclotomic e →+* R :=
   (AdjoinRoot.lift f r hr).comp toAdjoinRootRingHom
 
@@ -386,6 +362,20 @@ theorem evalRingHom_ofCoeffList {R : Type*} [CommRing R] (f : ℤ →+* R) (r : 
       (TauCeti.Polynomial.ofCoeffList l).eval₂ f r := by
   rw [evalRingHom, RingHom.comp_apply, toAdjoinRootRingHom_apply, toAdjoinRoot_ofCoeffList,
     AdjoinRoot.lift_mk]
+
+/-- Evaluation at a root `r` of `Φ_e` sends the distinguished generator `ζ` to `r`. -/
+@[simp]
+theorem evalRingHom_zeta {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
+    (hr : (cyclotomic e ℤ).eval₂ f r = 0) : evalRingHom f r hr (zeta e) = r := by
+  rw [evalRingHom, RingHom.comp_apply, toAdjoinRootRingHom_apply, toAdjoinRoot_zeta,
+    AdjoinRoot.lift_root]
+
+/-- `TauCeti.Cyclotomic.evalRingHom f r hr` is the *only* ring homomorphism sending the
+distinguished generator `ζ` to `r`. -/
+theorem eq_evalRingHom {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
+    (hr : (cyclotomic e ℤ).eval₂ f r = 0) (g : Cyclotomic e →+* R) (hg : g (zeta e) = r) :
+    g = evalRingHom f r hr :=
+  ringHom_ext (by rw [hg, evalRingHom_zeta])
 
 /-- Evaluate a coefficient vector by Horner's rule.  Unlike `Polynomial.eval₂`, this is a genuine
 computation because it works directly on the finite list. -/


### PR DESCRIPTION
This PR adds `Cyclotomic e`, an exact computable coefficient-vector model of `ℤ[X] / Φ_e`, and fulfills the “Exact cyclotomic arithmetic” target in `RepresentationTheory/CharacterTheory/README.md`, Layer 6 (“the executable Burnside-Dixon-Schneider algorithm”). It equips the type with genuinely computable addition, negation, multiplication, casts, powers, and decidable equality.

Identify the model with Mathlib's `AdjoinRoot (Polynomial.cyclotomic e ℤ)`, expose evaluation and prime-field reduction maps, and pin the primitive-root embedding into `ℂ` with an injectivity proof. The implementation reuses Mathlib's `AdjoinRoot`, cyclotomic-polynomial, primitive-root, and complex exponential infrastructure; no Mathlib code is vendored.

This is the most direct next step on Layer 6's critical path because both the structured cyclotomic lift and the final `ExactCharTable` output consume this exact ring and its finite-field/complex realization maps. After this PR, Layer 6 still needs executable class data and finite-field linear algebra, the certified Dixon-prime and good-prime structure results, the eigenvector search, the structured cyclotomic lift, and the assembled solver.

The full build and axiom audit pass, with no declarations outside the permitted axiom allowlist.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"cyclotomic"}-->

🤖 Prepared with Codex
