### PR TITLE
refactor(Laplacian): extract the barrier and the maximiser argument

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
@@ -62,6 +62,8 @@ namespace TauCeti
 
 open InnerProductSpace Laplacian Topology RealInnerProductSpace
 
+open scoped ContDiff
+
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
 
 /-- The exponential barrier `y ↦ exp (α ⟪u, y⟫)` has derivative `exp (α ⟪u, x⟫) • (α • ⟪u, ·⟫)`.
@@ -75,13 +77,13 @@ private theorem hasFDerivAt_exp_inner (α : ℝ) (u x : E) :
   have h2 : HasFDerivAt (fun z : E => α * ⟪u, z⟫) (α • innerSL ℝ u) x := h1.const_mul α
   exact (Real.hasDerivAt_exp (α * ⟪u, x⟫)).comp_hasFDerivAt x h2
 
-/-- The exponential barrier `y ↦ exp (α ⟪u, y⟫)` is twice continuously differentiable, being the
-exponential of a continuous linear form. -/
+/-- The exponential barrier `y ↦ exp (α ⟪u, y⟫)` is smooth, being the exponential of a continuous
+linear form. -/
 theorem contDiff_exp_inner (α : ℝ) (u : E) :
-    ContDiff ℝ 2 fun y : E => Real.exp (α * ⟪u, y⟫) := by
-  have hi : ContDiff ℝ 2 (fun y : E => (⟪u, y⟫ : ℝ)) := by
+    ContDiff ℝ ∞ fun y : E => Real.exp (α * ⟪u, y⟫) := by
+  have hi : ContDiff ℝ ∞ (fun y : E => (⟪u, y⟫ : ℝ)) := by
     simpa only [coe_innerSL_apply] using (innerSL ℝ u).contDiff
-  exact (by simpa only [smul_eq_mul] using hi.const_smul α : ContDiff ℝ 2 _).exp
+  exact (by simpa only [smul_eq_mul] using hi.const_smul α : ContDiff ℝ ∞ _).exp
 
 /-- The directional derivative of the exponential barrier `y ↦ exp (α ⟪u, y⟫)`. -/
 @[simp] theorem fderiv_exp_inner_apply (α : ℝ) (u x v : E) :
@@ -287,7 +289,8 @@ theorem le_of_laplacian_add_fderiv_nonneg_le_frontier {K : Set E} (hK : IsCompac
   set u : E := (‖v₀‖⁻¹ : ℝ) • v₀
   have hunorm : ‖u‖ = 1 := norm_smul_inv_norm hv₀
   set w : E → ℝ := fun y => Real.exp ((β + 1) * ⟪u, y⟫) with hwdef
-  have hwCD : ContDiff ℝ 2 w := hwdef ▸ contDiff_exp_inner (β + 1) u
+  have hwCD : ContDiff ℝ 2 w :=
+    (hwdef ▸ contDiff_exp_inner (β + 1) u : ContDiff ℝ ∞ w).of_le (by norm_cast)
   exact le_of_strict_subsolution_barrier hK hcont hcd hlap hbdry hwCD.continuous.continuousOn
     (fun _ _ => hwCD.contDiffAt)
     fun y hy => laplacian_add_fderiv_exp_inner_pos_of_norm_le hunorm (hb hy) y

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
@@ -75,6 +75,14 @@ private theorem hasFDerivAt_exp_inner (α : ℝ) (u x : E) :
   have h2 : HasFDerivAt (fun z : E => α * ⟪u, z⟫) (α • innerSL ℝ u) x := h1.const_mul α
   exact (Real.hasDerivAt_exp (α * ⟪u, x⟫)).comp_hasFDerivAt x h2
 
+/-- The exponential barrier `y ↦ exp (α ⟪u, y⟫)` is twice continuously differentiable, being the
+exponential of a continuous linear form. -/
+theorem contDiff_exp_inner (α : ℝ) (u : E) :
+    ContDiff ℝ 2 fun y : E => Real.exp (α * ⟪u, y⟫) := by
+  have hi : ContDiff ℝ 2 (fun y : E => (⟪u, y⟫ : ℝ)) := by
+    simpa only [coe_innerSL_apply] using (innerSL ℝ u).contDiff
+  exact (by simpa only [smul_eq_mul] using hi.const_smul α : ContDiff ℝ 2 _).exp
+
 /-- The directional derivative of the exponential barrier `y ↦ exp (α ⟪u, y⟫)`. -/
 @[simp] theorem fderiv_exp_inner_apply (α : ℝ) (u x v : E) :
     fderiv ℝ (fun y : E => Real.exp (α * ⟪u, y⟫)) x v
@@ -279,11 +287,7 @@ theorem le_of_laplacian_add_fderiv_nonneg_le_frontier {K : Set E} (hK : IsCompac
   set u : E := (‖v₀‖⁻¹ : ℝ) • v₀
   have hunorm : ‖u‖ = 1 := norm_smul_inv_norm hv₀
   set w : E → ℝ := fun y => Real.exp ((β + 1) * ⟪u, y⟫) with hwdef
-  have hwCD : ContDiff ℝ 2 w := by
-    rw [hwdef]
-    have hinner : ContDiff ℝ 2 (fun z : E => (⟪u, z⟫ : ℝ)) := by
-      simpa only [coe_innerSL_apply] using (innerSL ℝ u).contDiff
-    exact (by simpa only [smul_eq_mul] using hinner.const_smul (β + 1) : ContDiff ℝ 2 _).exp
+  have hwCD : ContDiff ℝ 2 w := hwdef ▸ contDiff_exp_inner (β + 1) u
   exact le_of_strict_subsolution_barrier hK hcont hcd hlap hbdry hwCD.continuous.continuousOn
     (fun _ _ => hwCD.contDiffAt)
     fun y hy => laplacian_add_fderiv_exp_inner_pos_of_norm_le hunorm (hb hy) y

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
@@ -50,12 +50,14 @@ hypothesis; in the interior, `f z > m ≥ 0` makes `Δ f + ∇_b f` nonnegative 
 sum is strictly positive and `z` cannot be a local maximum.
 
 The barrier is arbitrary: only its regularity and the sign of `Δ w + ∇_b w` at `z` are used, so
-neither the exponential form nor the drift bound `β` appears. -/
+neither the exponential form nor the drift bound `β` appears. Both are needed only when `z` is
+interior, since the frontier branch is the hypothesis `hbdry` outright. -/
 private theorem le_of_isMaxOn_add_smul {K : Set E} {c f w : E → ℝ} {b : E → E} {m ε : ℝ} {z : E}
     (hm : 0 ≤ m) (hε : 0 < ε) (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
     (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
     (hsub : ∀ ⦃x⦄, x ∈ interior K → c x * f x ≤ Δ f x + fderiv ℝ f x (b x))
-    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) (hzK : z ∈ K) (hwcd : ContDiffAt ℝ 2 w z)
+    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) (hzK : z ∈ K)
+    (hwcd : z ∈ interior K → ContDiffAt ℝ 2 w z)
     (hwpos : z ∈ interior K → 0 < Δ w z + fderiv ℝ w z (b z))
     (hzmax : IsMaxOn (fun y => f y + ε • w y) K z) :
     f z ≤ m := by
@@ -66,9 +68,10 @@ private theorem le_of_isMaxOn_add_smul {K : Set E} {c f w : E → ℝ} {b : E �
       (mul_nonneg (hc hzint) hfz0).trans (hsub hzint)
     have hpos : 0 < Δ (fun y => f y + ε • w y) z +
         fderiv ℝ (fun y => f y + ε • w y) z (b z) := by
-      rw [laplacian_add_fderiv_add_const_smul f w (b z) ε z (hcd hzint) hwcd]
+      rw [laplacian_add_fderiv_add_const_smul f w (b z) ε z (hcd hzint) (hwcd hzint)]
       nlinarith [mul_pos hε (hwpos hzint)]
-    exact not_isLocalMax_of_laplacian_add_fderiv_pos ((hcd hzint).add (hwcd.const_smul ε)) hpos
+    exact not_isLocalMax_of_laplacian_add_fderiv_pos
+      ((hcd hzint).add ((hwcd hzint).const_smul ε)) hpos
       (hzmax.isLocalMax (mem_interior_iff_mem_nhds.mp hzint))
   · exact hbdry ⟨subset_closure hzK, hzint⟩
 
@@ -90,7 +93,7 @@ theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompac
   have hu : ‖u‖ = 1 := norm_smul_inv_norm hv
   let w : E → ℝ := fun y => Real.exp ((β + 1) * ⟪u, y⟫)
   have hwpos (y : E) : 0 < w y := Real.exp_pos _
-  have hwcd : ContDiff ℝ 2 w := contDiff_exp_inner _ u
+  have hwcd : ContDiff ℝ 2 w := (contDiff_exp_inner _ u).of_le (by norm_cast)
   obtain ⟨C, hC⟩ := hK.bddAbove_image hwcd.continuous.continuousOn
   have hC0 : 0 ≤ C := (hwpos x).le.trans (hC (Set.mem_image_of_mem w hxK))
   apply le_of_forall_pos_mul_le hC0
@@ -98,7 +101,7 @@ theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompac
   obtain ⟨z, hzK, hzmax⟩ := hK.exists_isMaxOn ⟨x, hxK⟩
     (hcont.add (hwcd.continuous.continuousOn.const_smul ε))
   have hfz : f z ≤ m :=
-    le_of_isMaxOn_add_smul hm hε hcd hc hsub hbdry hzK hwcd.contDiffAt
+    le_of_isMaxOn_add_smul hm hε hcd hc hsub hbdry hzK (fun _ => hwcd.contDiffAt)
       (fun hz => laplacian_add_fderiv_exp_inner_pos_of_norm_le hu (hb hz) z) hzmax
   have hxle : f x + ε * w x ≤ f z + ε * w z := by
     simpa [smul_eq_mul] using hzmax hxK

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
@@ -43,46 +43,33 @@ open InnerProductSpace Laplacian Topology RealInnerProductSpace
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
   [Nontrivial E]
 
-omit [FiniteDimensional ℝ E] [Nontrivial E] in
-/-- The barrier `y ↦ exp (α ⟪u, y⟫)` is twice continuously differentiable, being the exponential of
-a continuous linear functional. -/
-private theorem contDiff_exp_const_mul_inner (α : ℝ) (u : E) :
-    ContDiff ℝ 2 fun y : E => Real.exp (α * ⟪u, y⟫) := by
-  have hi : ContDiff ℝ 2 (fun y : E => (⟪u, y⟫ : ℝ)) := by
-    simpa only [coe_innerSL_apply] using (innerSL ℝ u).contDiff
-  exact (by simpa only [smul_eq_mul] using hi.const_smul α : ContDiff ℝ 2 _).exp
-
 omit [Nontrivial E] in
-/-- At a maximiser `z` of the perturbed function `f + ε • exp ((β + 1) ⟪u, ·⟫)` over `K`, the
-frontier bound already holds: on the frontier by hypothesis, and in the interior because the
-barrier's strict positivity under `-Δ - b·∇` contradicts `f z > m`. -/
-private theorem le_of_isMaxOn_add_smul_exp_inner {K : Set E} {c f : E → ℝ} {b : E → E}
-    {β m ε : ℝ} {u z : E} (hm : 0 ≤ m) (hu : ‖u‖ = 1) (hε : 0 < ε)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+/-- At a maximiser `z` of `f + ε • w` over `K`, where `w` is a `C²` barrier that is strictly
+positive under `Δ + b·∇` at `z`, the frontier bound already holds. On the frontier that is the
+hypothesis; in the interior, `f z > m ≥ 0` makes `Δ f + ∇_b f` nonnegative there, so the perturbed
+sum is strictly positive and `z` cannot be a local maximum.
+
+The barrier is arbitrary: only its regularity and the sign of `Δ w + ∇_b w` at `z` are used, so
+neither the exponential form nor the drift bound `β` appears. -/
+private theorem le_of_isMaxOn_add_smul {K : Set E} {c f w : E → ℝ} {b : E → E} {m ε : ℝ} {z : E}
+    (hm : 0 ≤ m) (hε : 0 < ε) (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
+    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
     (hsub : ∀ ⦃x⦄, x ∈ interior K → c x * f x ≤ Δ f x + fderiv ℝ f x (b x))
-    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) (hzK : z ∈ K)
-    (hzmax : IsMaxOn (fun y => f y + ε • Real.exp ((β + 1) * ⟪u, y⟫)) K z) :
+    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) (hzK : z ∈ K) (hwcd : ContDiffAt ℝ 2 w z)
+    (hwpos : z ∈ interior K → 0 < Δ w z + fderiv ℝ w z (b z))
+    (hzmax : IsMaxOn (fun y => f y + ε • w y) K z) :
     f z ≤ m := by
   by_cases hzint : z ∈ interior K
   · by_contra hn
-    have hwcd : ContDiff ℝ 2 fun y : E => Real.exp ((β + 1) * ⟪u, y⟫) :=
-      contDiff_exp_const_mul_inner _ u
     have hfz0 : 0 ≤ f z := hm.trans (not_le.mp hn).le
-    have hloc : IsLocalMax (fun y => f y + ε • Real.exp ((β + 1) * ⟪u, y⟫)) z :=
-      hzmax.isLocalMax (mem_interior_iff_mem_nhds.mp hzint)
-    have hLgnonpos : Δ (fun y => f y + ε • Real.exp ((β + 1) * ⟪u, y⟫)) z +
-        fderiv ℝ (fun y => f y + ε • Real.exp ((β + 1) * ⟪u, y⟫)) z (b z) ≤ 0 := by
-      rw [hloc.fderiv_eq_zero]
-      simpa using laplacian_nonpos_of_isLocalMax
-        ((hcd hzint).add (hwcd.contDiffAt.const_smul ε)) hloc
-    have hLwpos := laplacian_add_fderiv_exp_inner_pos_of_norm_le hu (hb hzint) z
-    have hLg := laplacian_add_fderiv_add_const_smul f
-      (fun y : E => Real.exp ((β + 1) * ⟪u, y⟫)) (b z) ε z (hcd hzint) hwcd.contDiffAt
-    rw [hLg] at hLgnonpos
     have hLf0 : 0 ≤ Δ f z + fderiv ℝ f z (b z) :=
       (mul_nonneg (hc hzint) hfz0).trans (hsub hzint)
-    nlinarith [mul_pos hε hLwpos]
+    have hpos : 0 < Δ (fun y => f y + ε • w y) z +
+        fderiv ℝ (fun y => f y + ε • w y) z (b z) := by
+      rw [laplacian_add_fderiv_add_const_smul f w (b z) ε z (hcd hzint) hwcd]
+      nlinarith [mul_pos hε (hwpos hzint)]
+    exact not_isLocalMax_of_laplacian_add_fderiv_pos ((hcd hzint).add (hwcd.const_smul ε)) hpos
+      (hzmax.isLocalMax (mem_interior_iff_mem_nhds.mp hzint))
   · exact hbdry ⟨subset_closure hzK, hzint⟩
 
 /-- **Weak maximum principle for `-Δ - b·∇ + c`.**
@@ -103,7 +90,7 @@ theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompac
   have hu : ‖u‖ = 1 := norm_smul_inv_norm hv
   let w : E → ℝ := fun y => Real.exp ((β + 1) * ⟪u, y⟫)
   have hwpos (y : E) : 0 < w y := Real.exp_pos _
-  have hwcd : ContDiff ℝ 2 w := contDiff_exp_const_mul_inner _ u
+  have hwcd : ContDiff ℝ 2 w := contDiff_exp_inner _ u
   obtain ⟨C, hC⟩ := hK.bddAbove_image hwcd.continuous.continuousOn
   have hC0 : 0 ≤ C := (hwpos x).le.trans (hC (Set.mem_image_of_mem w hxK))
   apply le_of_forall_pos_mul_le hC0
@@ -111,7 +98,8 @@ theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompac
   obtain ⟨z, hzK, hzmax⟩ := hK.exists_isMaxOn ⟨x, hxK⟩
     (hcont.add (hwcd.continuous.continuousOn.const_smul ε))
   have hfz : f z ≤ m :=
-    le_of_isMaxOn_add_smul_exp_inner hm hu hε hcd hc hb hsub hbdry hzK hzmax
+    le_of_isMaxOn_add_smul hm hε hcd hc hsub hbdry hzK hwcd.contDiffAt
+      (fun hz => laplacian_add_fderiv_exp_inner_pos_of_norm_le hu (hb hz) z) hzmax
   have hxle : f x + ε * w x ≤ f z + ε * w z := by
     simpa [smul_eq_mul] using hzmax hxK
   have hwzC : ε * w z ≤ ε * C :=

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
@@ -43,6 +43,48 @@ open InnerProductSpace Laplacian Topology RealInnerProductSpace
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
   [Nontrivial E]
 
+omit [FiniteDimensional ℝ E] [Nontrivial E] in
+/-- The barrier `y ↦ exp (α ⟪u, y⟫)` is twice continuously differentiable, being the exponential of
+a continuous linear functional. -/
+private theorem contDiff_exp_const_mul_inner (α : ℝ) (u : E) :
+    ContDiff ℝ 2 fun y : E => Real.exp (α * ⟪u, y⟫) := by
+  have hi : ContDiff ℝ 2 (fun y : E => (⟪u, y⟫ : ℝ)) := by
+    simpa only [coe_innerSL_apply] using (innerSL ℝ u).contDiff
+  exact (by simpa only [smul_eq_mul] using hi.const_smul α : ContDiff ℝ 2 _).exp
+
+omit [Nontrivial E] in
+/-- At a maximiser `z` of the perturbed function `f + ε • exp ((β + 1) ⟪u, ·⟫)` over `K`, the
+frontier bound already holds: on the frontier by hypothesis, and in the interior because the
+barrier's strict positivity under `-Δ - b·∇` contradicts `f z > m`. -/
+private theorem le_of_isMaxOn_add_smul_exp_inner {K : Set E} {c f : E → ℝ} {b : E → E}
+    {β m ε : ℝ} {u z : E} (hm : 0 ≤ m) (hu : ‖u‖ = 1) (hε : 0 < ε)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hsub : ∀ ⦃x⦄, x ∈ interior K → c x * f x ≤ Δ f x + fderiv ℝ f x (b x))
+    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) (hzK : z ∈ K)
+    (hzmax : IsMaxOn (fun y => f y + ε • Real.exp ((β + 1) * ⟪u, y⟫)) K z) :
+    f z ≤ m := by
+  by_cases hzint : z ∈ interior K
+  · by_contra hn
+    have hwcd : ContDiff ℝ 2 fun y : E => Real.exp ((β + 1) * ⟪u, y⟫) :=
+      contDiff_exp_const_mul_inner _ u
+    have hfz0 : 0 ≤ f z := hm.trans (not_le.mp hn).le
+    have hloc : IsLocalMax (fun y => f y + ε • Real.exp ((β + 1) * ⟪u, y⟫)) z :=
+      hzmax.isLocalMax (mem_interior_iff_mem_nhds.mp hzint)
+    have hLgnonpos : Δ (fun y => f y + ε • Real.exp ((β + 1) * ⟪u, y⟫)) z +
+        fderiv ℝ (fun y => f y + ε • Real.exp ((β + 1) * ⟪u, y⟫)) z (b z) ≤ 0 := by
+      rw [hloc.fderiv_eq_zero]
+      simpa using laplacian_nonpos_of_isLocalMax
+        ((hcd hzint).add (hwcd.contDiffAt.const_smul ε)) hloc
+    have hLwpos := laplacian_add_fderiv_exp_inner_pos_of_norm_le hu (hb hzint) z
+    have hLg := laplacian_add_fderiv_add_const_smul f
+      (fun y : E => Real.exp ((β + 1) * ⟪u, y⟫)) (b z) ε z (hcd hzint) hwcd.contDiffAt
+    rw [hLg] at hLgnonpos
+    have hLf0 : 0 ≤ Δ f z + fderiv ℝ f z (b z) :=
+      (mul_nonneg (hc hzint) hfz0).trans (hsub hzint)
+    nlinarith [mul_pos hε hLwpos]
+  · exact hbdry ⟨subset_closure hzK, hzint⟩
+
 /-- **Weak maximum principle for `-Δ - b·∇ + c`.**
 
 If `c` is nonnegative, `b` has norm at most `β` on the interior of a compact set, and
@@ -59,44 +101,19 @@ theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompac
   obtain ⟨v, hv⟩ := exists_ne (0 : E)
   let u : E := ‖v‖⁻¹ • v
   have hu : ‖u‖ = 1 := norm_smul_inv_norm hv
-  let α : ℝ := β + 1
-  let w : E → ℝ := fun y => Real.exp (α * ⟪u, y⟫)
+  let w : E → ℝ := fun y => Real.exp ((β + 1) * ⟪u, y⟫)
   have hwpos (y : E) : 0 < w y := Real.exp_pos _
-  have hwcd : ContDiff ℝ 2 w := by
-    have hi : ContDiff ℝ 2 (fun y : E => (⟪u, y⟫ : ℝ)) := by
-      simpa only [coe_innerSL_apply] using (innerSL ℝ u).contDiff
-    exact (by simpa only [smul_eq_mul] using hi.const_smul α : ContDiff ℝ 2 _).exp
+  have hwcd : ContDiff ℝ 2 w := contDiff_exp_const_mul_inner _ u
   obtain ⟨C, hC⟩ := hK.bddAbove_image hwcd.continuous.continuousOn
   have hC0 : 0 ≤ C := (hwpos x).le.trans (hC (Set.mem_image_of_mem w hxK))
   apply le_of_forall_pos_mul_le hC0
   intro ε hε
-  let g : E → ℝ := fun y => f y + ε • w y
-  have hgcont : ContinuousOn g K := hcont.add (hwcd.continuous.continuousOn.const_smul ε)
-  obtain ⟨z, hzK, hzmax⟩ := hK.exists_isMaxOn ⟨x, hxK⟩ hgcont
-  have hfz : f z ≤ m := by
-    by_cases hzint : z ∈ interior K
-    · by_contra hn
-      have hfz0 : 0 ≤ f z := hm.trans (not_le.mp hn).le
-      have hgcd : ContDiffAt ℝ 2 g z := (hcd hzint).add (hwcd.contDiffAt.const_smul ε)
-      have hloc : IsLocalMax g z := hzmax.isLocalMax (mem_interior_iff_mem_nhds.mp hzint)
-      have hLgnonpos : Δ g z + fderiv ℝ g z (b z) ≤ 0 := by
-        rw [hloc.fderiv_eq_zero]
-        simpa using laplacian_nonpos_of_isLocalMax hgcd hloc
-      have hLwpos : 0 < Δ w z + fderiv ℝ w z (b z) := by
-        simpa only [w, α] using
-          laplacian_add_fderiv_exp_inner_pos_of_norm_le hu (hb hzint) z
-      have hLg : Δ g z + fderiv ℝ g z (b z) =
-          (Δ f z + fderiv ℝ f z (b z)) +
-            ε * (Δ w z + fderiv ℝ w z (b z)) := by
-        simpa only [g] using laplacian_add_fderiv_add_const_smul f w (b z) ε z
-          (hcd hzint) hwcd.contDiffAt
-      have hLf0 : 0 ≤ Δ f z + fderiv ℝ f z (b z) :=
-        (mul_nonneg (hc hzint) hfz0).trans (hsub hzint)
-      rw [hLg] at hLgnonpos
-      nlinarith [mul_pos hε hLwpos]
-    · exact hbdry ⟨subset_closure hzK, hzint⟩
+  obtain ⟨z, hzK, hzmax⟩ := hK.exists_isMaxOn ⟨x, hxK⟩
+    (hcont.add (hwcd.continuous.continuousOn.const_smul ε))
+  have hfz : f z ≤ m :=
+    le_of_isMaxOn_add_smul_exp_inner hm hu hε hcd hc hb hsub hbdry hzK hzmax
   have hxle : f x + ε * w x ≤ f z + ε * w z := by
-    simpa [g, smul_eq_mul] using hzmax hxK
+    simpa [smul_eq_mul] using hzmax hxK
   have hwzC : ε * w z ≤ ε * C :=
     mul_le_mul_of_nonneg_left (hC (Set.mem_image_of_mem w hzK)) hε.le
   nlinarith [mul_nonneg hε.le (hwpos x).le]


### PR DESCRIPTION
`le_of_mul_le_laplacian_add_fderiv_le_frontier` ran to 46 lines because it did the whole barrier
argument in one block: build `w = exp ((β+1)⟪u,·⟫)`, show it is `C²`, bound it on `K`, take a
maximiser `z` of `f + ε w`, run the interior contradiction at `z`, and let `ε → 0`. The middle
step is what the extraction separates; the regularity fact turns out to belong elsewhere entirely.

## The helper

`le_of_isMaxOn_add_smul` — at a maximiser `z` of `f + ε • w` over `K`, already `f z ≤ m`. On the
frontier that is the hypothesis; in the interior, `f z > m ≥ 0` makes `Δ f + ∇_b f` nonnegative at
`z`, so `laplacian_add_fderiv_add_const_smul` makes the perturbed sum strictly positive and
`not_isLocalMax_of_laplacian_add_fderiv_pos` rules out the local maximum.

**The barrier is arbitrary.** The helper takes any `w` with `ContDiffAt ℝ 2 w z` and
`z ∈ interior K → 0 < Δ w z + fderiv ℝ w z (b z)`; neither the exponential form, nor the unit
vector `u`, nor the drift bound `β` appears. The positivity hypothesis is conditional on interior
membership rather than a `∀ x ∈ interior K` family, because that is exactly what the caller can
supply and what the proof consumes — the `by_cases` on `z ∈ interior K` lives inside the helper.

## `contDiff_exp_inner` goes to `DriftMaximumPrinciple`

The barrier's smoothness is not lower-order material: it sits with `hasFDerivAt_exp_inner`,
`fderiv_exp_inner_apply` and `laplacian_exp_inner`, above that file's `FiniteDimensional` section,
so it carries no finite-dimensionality hypothesis. Moving it there also **deletes a verbatim inline
copy** — `le_of_laplacian_add_fderiv_nonneg_le_frontier` was proving the same five lines inline for
its own barrier, and now calls the lemma.

## Why this does not just reuse `le_of_strict_subsolution_barrier`

That lemma (same file) needs `0 ≤ Δ f x + ∇_b f x` throughout `interior K`. Here the subsolution
hypothesis is `c x * f x ≤ Δ f x + ∇_b f x` with `c ≥ 0`, which yields that sign **only at points
where `f ≥ 0`** — which is why the argument has to be run at the maximiser, where `f z > m ≥ 0` is
available from the contradiction hypothesis.

## Scope

The statement and docstring of the public theorem are unchanged, the new helper is `private`, and
the one new public declaration is the barrier regularity lemma that removes a duplicate.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all green;
no new lint violations. Proof body 46 → 22 lines, with the helper at 13.

Roadmap: PDE
