### PR TITLE
feat: duality of Dynkin types

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/Duality.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Duality.lean
@@ -1,0 +1,337 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.DynkinType
+
+public section
+
+/-!
+# Duality of Dynkin types
+
+Interchanging the roots and the coroots of a root pairing (`RootPairing.flip`) transposes every
+pairing `⟨αᵢ, αⱼ^∨⟩`, hence transposes the Cartan matrix of a base. On the classification side that
+operation permutes the Dynkin types, and this file pins the permutation: `TauCeti.DynkinType.dual`
+exchanges `Bₙ` with `Cₙ` and fixes every other type. Duality is what makes the orientation carried
+by `TauCeti.HasCartanType` meaningful, since `Bₙ` and `Cₙ` are exactly the pair of types that the
+orientation separates.
+
+The dual type is not read off the transposed matrix on the nose. Transposing a Cartan matrix does
+not merely relabel the diagram, it reverses every arrow, and for `F₄` and `G₂` the reversed diagram
+is the original one read backwards. So duality carries a relabelling of the nodes as well as a
+change of type, and `TauCeti.DynkinType.dualNodeEquiv` is that relabelling: the identity for the
+classical families and the `E` types, and the reversal `Fin.revPerm` for `F₄` and `G₂`.
+
+`TauCeti.DynkinType.Valid` is deliberately *not* preserved by duality, and the failure is exactly
+the low-rank coincidence `B 2 = C 2`: `B 2` is valid and its dual `C 2` is not, because the two
+name the same root system and the enumeration keeps only one of the names. Away from that pair
+validity does transfer (`TauCeti.DynkinType.valid_dual_iff`). The last section shows that nothing
+is lost there: at rank at most two a base has a Cartan type exactly when it has the dual type
+(`TauCeti.hasCartanType_dual_iff_of_rank_le_two`), because transposing a matrix with constant
+diagonal and at most two indices is itself a simultaneous relabelling.
+
+## Main definitions
+
+* `TauCeti.DynkinType.dual`: the dual Dynkin type, exchanging `Bₙ` and `Cₙ`.
+* `TauCeti.DynkinType.dualNodeEquiv`: the relabelling of nodes that duality carries.
+
+## Main results
+
+* `TauCeti.pairingIn_flip` and `TauCeti.cartanMatrix_flip`: flipping a root pairing transposes the
+  integral pairing, hence the Cartan matrix of a base.
+* `TauCeti.DynkinType.cartanMatrix_dual`: the standard Cartan matrix of the dual type is the
+  transpose of the standard Cartan matrix, read through `dualNodeEquiv`.
+* `TauCeti.hasCartanType_flip_iff`: **the Cartan type of a base and the Cartan type of the flipped
+  base are dual**. In particular a base is of type `Bₙ` exactly when the flipped base is of type
+  `Cₙ` (`TauCeti.hasCartanType_flip_C_iff`).
+* `TauCeti.DynkinType.valid_dual_iff`: validity transfers along duality except for the pair
+  `B 2`, `C 2`.
+* `TauCeti.hasCartanType_dual_iff_of_rank_le_two`: at rank at most two a type and its dual match
+  the same bases, which is why dropping `C 2` from the valid types loses nothing.
+
+## References
+
+This file supplies the duality half of the `DynkinType` layer of
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`: Layer 5 records that
+`DynkinType.cartanMatrix (.B n)` is the transpose of `DynkinType.cartanMatrix (.C n)` and that the
+two types are "identified only after `flip` (duality)", and Layer 6 asks for the adjoint root datum
+to be `RootPairing.flip` of the dual type's datum. See Bourbaki, *Lie Groups and Lie Algebras,
+Chapters 4-6*, plates I-IX, for the standard Cartan matrices and their duals.
+-/
+
+namespace TauCeti
+
+section Flip
+
+variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+
+/-- **Flipping a root pairing transposes its integral pairing.** The pairing of the flipped pairing
+is transposed by definition (`RootPairing.pairing_flip`); the content here is that the *chosen*
+preimage in `S` is transposed too, which needs `algebraMap S R` to be injective. -/
+lemma pairingIn_flip (S : Type*) [CommRing S] [Algebra S R] [FaithfulSMul S R]
+    (P : RootPairing ι R M N) [P.IsValuedIn S] (i j : ι) :
+    P.flip.pairingIn S i j = P.pairingIn S j i :=
+  FaithfulSMul.algebraMap_injective S R <| by simp
+
+/-- A base of `P` is a base of `P.flip` supported on the same simple indices
+(`RootPairing.Base.flip`); this is the resulting identification of the two index types, which the
+Cartan matrices of the base and of its flip are indexed by. -/
+def flipSupportEquiv {P : RootPairing ι R M N} (b : P.Base) : b.flip.support ≃ b.support :=
+  Equiv.subtypeEquivRight fun _ ↦ by rw [RootPairing.Base.flip_support]
+
+@[simp] lemma coe_flipSupportEquiv {P : RootPairing ι R M N} (b : P.Base) (i : b.flip.support) :
+    (flipSupportEquiv b i : ι) = i := (rfl)
+
+/-- **The Cartan matrix of the flipped base is the transpose of the Cartan matrix of the base.** -/
+lemma cartanMatrix_flip [CharZero R] {P : RootPairing ι R M N} [P.IsCrystallographic] (b : P.Base)
+    (i j : b.flip.support) :
+    b.flip.cartanMatrix i j = b.cartanMatrix (flipSupportEquiv b j) (flipSupportEquiv b i) := by
+  have h₁ : b.flip.cartanMatrix i j = P.flip.pairingIn ℤ (i : ι) (j : ι) :=
+    RootPairing.Base.cartanMatrixIn_def _ _ _ _
+  have h₂ : b.cartanMatrix (flipSupportEquiv b j) (flipSupportEquiv b i)
+      = P.pairingIn ℤ (j : ι) (i : ι) := RootPairing.Base.cartanMatrixIn_def _ _ _ _
+  rw [h₁, h₂, pairingIn_flip]
+
+/-- Flipping a base twice returns the original base. -/
+lemma base_flip_flip {P : RootPairing ι R M N} (b : P.Base) : b.flip.flip = b := rfl
+
+end Flip
+
+namespace DynkinType
+
+/-- **The dual Dynkin type.** Duality reverses the arrows of a diagram, which exchanges the types
+`Bₙ` and `Cₙ` — the one pair whose standard Cartan matrices are transposes of one another without
+being equal — and fixes all the others. It is realized on root systems by `RootPairing.flip`; see
+`TauCeti.hasCartanType_flip_iff`. -/
+@[expose] def dual : DynkinType → DynkinType
+  | .A n => .A n
+  | .B n => .C n
+  | .C n => .B n
+  | .D n => .D n
+  | .E6 => .E6
+  | .E7 => .E7
+  | .E8 => .E8
+  | .F4 => .F4
+  | .G2 => .G2
+
+@[simp] lemma dual_A (n : ℕ) : (A n).dual = A n := rfl
+@[simp] lemma dual_B (n : ℕ) : (B n).dual = C n := rfl
+@[simp] lemma dual_C (n : ℕ) : (C n).dual = B n := rfl
+@[simp] lemma dual_D (n : ℕ) : (D n).dual = D n := rfl
+@[simp] lemma dual_E6 : E6.dual = E6 := rfl
+@[simp] lemma dual_E7 : E7.dual = E7 := rfl
+@[simp] lemma dual_E8 : E8.dual = E8 := rfl
+@[simp] lemma dual_F4 : F4.dual = F4 := rfl
+@[simp] lemma dual_G2 : G2.dual = G2 := rfl
+
+/-- Duality is an involution. -/
+@[simp] lemma dual_dual (t : DynkinType) : t.dual.dual = t := by cases t <;> rfl
+
+/-- Duality is injective, being an involution; so distinct types stay distinct after dualizing. -/
+lemma dual_injective : Function.Injective dual :=
+  Function.LeftInverse.injective dual_dual
+
+/-- Duality preserves the rank: it reverses arrows without adding or removing nodes. -/
+@[simp] lemma rank_dual (t : DynkinType) : t.dual.rank = t.rank := by cases t <;> rfl
+
+/-- Duality preserves simple-lacedness: a diagram has an arrow to reverse exactly when its dual
+does. -/
+@[simp] lemma isSimplyLaced_dual (t : DynkinType) : t.dual.IsSimplyLaced ↔ t.IsSimplyLaced := by
+  cases t <;> simp
+
+/-- **Validity transfers along duality away from the pair `B 2`, `C 2`.** The excluded pair is the
+low-rank coincidence `B 2 = C 2`: both names describe the same root system, and the enumeration
+keeps only `B 2` valid, so `TauCeti.DynkinType.valid_B_two_and_not_valid_dual` below records the
+one place where the transfer genuinely fails. -/
+lemma valid_dual_iff {t : DynkinType} (hB : t ≠ B 2) (hC : t ≠ C 2) :
+    t.dual.Valid ↔ t.Valid := by
+  cases t with
+  | B n =>
+      have hn : n ≠ 2 := fun h ↦ hB (by rw [h])
+      simp only [dual_B, valid_C, valid_B]
+      omega
+  | C n =>
+      have hn : n ≠ 2 := fun h ↦ hC (by rw [h])
+      simp only [dual_C, valid_B, valid_C]
+      omega
+  | _ => simp
+
+/-- The single failure of `TauCeti.DynkinType.valid_dual_iff`: `B 2` is a valid type whose dual
+`C 2` is not. The two name the same root system, and
+`TauCeti.hasCartanType_dual_iff_of_rank_le_two` shows that no base is lost by keeping only the
+first name. -/
+lemma valid_B_two_and_not_valid_dual : (B 2).Valid ∧ ¬ (B 2).dual.Valid := by
+  refine ⟨valid_B.mpr le_rfl, ?_⟩
+  rw [dual_B]
+  simp
+
+/-- **The relabelling of nodes carried by duality.** Transposing a Cartan matrix reverses the
+arrows of its diagram, and for the classical families and the `E` types the result is the standard
+matrix of the dual type already in the Bourbaki numbering. For `F₄` and `G₂` — the two types that
+are self-dual without being simply laced — the reversed diagram is the original one read backwards,
+so the relabelling there is `Fin.revPerm`. -/
+@[expose] def dualNodeEquiv : (t : DynkinType) → Fin t.rank ≃ Fin t.dual.rank
+  | .A _ => Equiv.refl _
+  | .B _ => Equiv.refl _
+  | .C _ => Equiv.refl _
+  | .D _ => Equiv.refl _
+  | .E6 => Equiv.refl _
+  | .E7 => Equiv.refl _
+  | .E8 => Equiv.refl _
+  | .F4 => Fin.revPerm
+  | .G2 => Fin.revPerm
+
+-- Stated as equalities of equivalences rather than pointwise: the two sides of a pointwise
+-- statement live in `Fin t.rank` and `Fin t.dual.rank`, so its left-hand side would carry a
+-- dependent type that `simp` rewrites, leaving it out of simp-normal form.
+@[simp] lemma dualNodeEquiv_A (n : ℕ) : (A n).dualNodeEquiv = Equiv.refl (Fin n) := rfl
+@[simp] lemma dualNodeEquiv_B (n : ℕ) : (B n).dualNodeEquiv = Equiv.refl (Fin n) := rfl
+@[simp] lemma dualNodeEquiv_C (n : ℕ) : (C n).dualNodeEquiv = Equiv.refl (Fin n) := rfl
+@[simp] lemma dualNodeEquiv_D (n : ℕ) : (D n).dualNodeEquiv = Equiv.refl (Fin n) := rfl
+@[simp] lemma dualNodeEquiv_E6 : E6.dualNodeEquiv = Equiv.refl (Fin 6) := rfl
+@[simp] lemma dualNodeEquiv_E7 : E7.dualNodeEquiv = Equiv.refl (Fin 7) := rfl
+@[simp] lemma dualNodeEquiv_E8 : E8.dualNodeEquiv = Equiv.refl (Fin 8) := rfl
+@[simp] lemma dualNodeEquiv_F4 : F4.dualNodeEquiv = Fin.revPerm := rfl
+@[simp] lemma dualNodeEquiv_G2 : G2.dualNodeEquiv = Fin.revPerm := rfl
+
+/-- **The standard Cartan matrix of the dual type is the transpose**, read through the node
+relabelling `TauCeti.DynkinType.dualNodeEquiv`. For the simply-laced types the standard matrices
+are symmetric and there is nothing to move; for `Bₙ` and `Cₙ` the transposition is
+`CartanMatrix.B_transpose`; and for `F₄` and `G₂` the transpose is the matrix itself with its nodes
+reversed. -/
+theorem cartanMatrix_dual (t : DynkinType) (i j : Fin t.rank) :
+    t.dual.cartanMatrix (t.dualNodeEquiv i) (t.dualNodeEquiv j) = t.cartanMatrix j i := by
+  -- Splitting on `t` leaves the dependent indices to be reduced by hand; `dual` and
+  -- `dualNodeEquiv` are `@[expose]`d so that `change` can carry out that reduction, after which
+  -- the standard matrices are named by the `cartanMatrix_*` equations.
+  cases t with
+  | A n =>
+      change Fin n at i j
+      change (A n).cartanMatrix i j = (A n).cartanMatrix j i
+      rw [cartanMatrix_A]
+      exact (CartanMatrix.A_isSymm n).apply j i
+  | D n =>
+      change Fin n at i j
+      change (D n).cartanMatrix i j = (D n).cartanMatrix j i
+      rw [cartanMatrix_D]
+      exact (CartanMatrix.D_isSymm n).apply j i
+  | E6 =>
+      change E6.cartanMatrix i j = E6.cartanMatrix j i
+      rw [cartanMatrix_E6]
+      exact CartanMatrix.E₆_isSymm.apply j i
+  | E7 =>
+      change E7.cartanMatrix i j = E7.cartanMatrix j i
+      rw [cartanMatrix_E7]
+      exact CartanMatrix.E₇_isSymm.apply j i
+  | E8 =>
+      change E8.cartanMatrix i j = E8.cartanMatrix j i
+      rw [cartanMatrix_E8]
+      exact CartanMatrix.E₈_isSymm.apply j i
+  | B n =>
+      change Fin n at i j
+      change (C n).cartanMatrix i j = (B n).cartanMatrix j i
+      rw [cartanMatrix_C, cartanMatrix_B, ← CartanMatrix.B_transpose, Matrix.transpose_apply]
+  | C n =>
+      change Fin n at i j
+      change (B n).cartanMatrix i j = (C n).cartanMatrix j i
+      rw [cartanMatrix_B, cartanMatrix_C, ← CartanMatrix.C_transpose, Matrix.transpose_apply]
+  | F4 =>
+      change F4.cartanMatrix i.rev j.rev = F4.cartanMatrix j i
+      rw [cartanMatrix_F4]
+      fin_cases i <;> fin_cases j <;> decide
+  | G2 =>
+      change G2.cartanMatrix i.rev j.rev = G2.cartanMatrix j i
+      rw [cartanMatrix_G2]
+      fin_cases i <;> fin_cases j <;> decide
+
+/-- `TauCeti.DynkinType.cartanMatrix_dual` as an identity of matrices rather than of entries. -/
+theorem cartanMatrix_dual_eq_reindex (t : DynkinType) :
+    t.dual.cartanMatrix = t.cartanMatrix.transpose.reindex t.dualNodeEquiv t.dualNodeEquiv := by
+  ext i j
+  simpa using cartanMatrix_dual t (t.dualNodeEquiv.symm i) (t.dualNodeEquiv.symm j)
+
+/-- **Reversing the nodes of a standard Cartan matrix of rank at most two transposes it.** With at
+most two indices the only off-diagonal entries form a single transposed pair, which the reversal
+swaps, while the diagonal is constant. This is why the orientation built into
+`TauCeti.HasCartanType` carries no information at rank at most two. -/
+lemma cartanMatrix_rev_of_rank_le_two {t : DynkinType} (ht : t.rank ≤ 2) (i j : Fin t.rank) :
+    t.cartanMatrix j.rev i.rev = t.cartanMatrix i j := by
+  rcases eq_or_ne i j with rfl | hij
+  · rw [cartanMatrix_apply_same, cartanMatrix_apply_same]
+  -- Two distinct indices force the rank to be exactly two, and there the reversal is the swap.
+  have hrev : ∀ k l : Fin t.rank, k ≠ l → k.rev = l := by
+    intro k l hkl
+    have hkl' : (k : ℕ) ≠ (l : ℕ) := fun h ↦ hkl (Fin.ext h)
+    have hk := k.isLt
+    have hl := l.isLt
+    exact Fin.ext (by simp only [Fin.val_rev]; omega)
+  rw [hrev j i hij.symm, hrev i j hij]
+
+end DynkinType
+
+section HasCartanType
+
+variable {ι R M N : Type*} [CommRing R] [CharZero R] [AddCommGroup M] [Module R M]
+  [AddCommGroup N] [Module R N] {P : RootPairing ι R M N} [P.IsCrystallographic]
+
+/-- **The Cartan type of a flipped base is the dual type.** Flipping transposes the Cartan matrix
+(`TauCeti.cartanMatrix_flip`), and transposing a standard Cartan matrix is passing to the dual type
+up to the node relabelling `TauCeti.DynkinType.dualNodeEquiv`. -/
+theorem HasCartanType.flip {b : P.Base} {t : DynkinType} (h : HasCartanType P b t) :
+    HasCartanType P.flip b.flip t.dual := by
+  obtain ⟨e, he⟩ := h
+  refine ⟨(flipSupportEquiv b).trans (e.trans t.dualNodeEquiv), fun i j ↦ ?_⟩
+  simp only [Equiv.trans_apply]
+  rw [cartanMatrix_flip b i j, he _ _, DynkinType.cartanMatrix_dual]
+
+/-- **A base has Cartan type `t` exactly when the flipped base has the dual type.** This is what
+gives `TauCeti.DynkinType.dual` its meaning: passing from a root system to its dual is passing from
+a Dynkin type to its dual. -/
+theorem hasCartanType_flip_iff {b : P.Base} {t : DynkinType} :
+    HasCartanType P.flip b.flip t.dual ↔ HasCartanType P b t := by
+  refine ⟨fun h ↦ ?_, HasCartanType.flip⟩
+  have h' := h.flip
+  rw [DynkinType.dual_dual, base_flip_flip] at h'
+  exact h'
+
+/-- **A base is of type `Bₙ` exactly when the flipped base is of type `Cₙ`.** This is the worked
+instance of `TauCeti.hasCartanType_flip_iff`: `Bₙ` and `Cₙ` are the pair of types that the oriented
+matching of `TauCeti.HasCartanType` keeps apart, and duality is what identifies them. -/
+theorem hasCartanType_flip_C_iff {b : P.Base} {n : ℕ} :
+    HasCartanType P.flip b.flip (.C n) ↔ HasCartanType P b (.B n) :=
+  hasCartanType_flip_iff (t := .B n)
+
+end HasCartanType
+
+section RankLeTwo
+
+variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+  [AddCommGroup N] [Module R N] {P : RootPairing ι R M N} [P.IsCrystallographic]
+
+/-- **At rank at most two a base has a Cartan type exactly when it has the dual type.** The
+enumeration keeps `B 2` valid and drops `C 2`, and this is what makes that choice harmless: the two
+names match exactly the same bases. From rank three on the statement fails, since `Bₙ` and `Cₙ` are
+then genuinely different root systems. -/
+theorem hasCartanType_dual_iff_of_rank_le_two {b : P.Base} {t : DynkinType} (ht : t.rank ≤ 2) :
+    HasCartanType P b t.dual ↔ HasCartanType P b t := by
+  -- Both directions are the same computation, so prove the general step once and apply it twice.
+  have key : ∀ s : DynkinType, s.rank ≤ 2 → HasCartanType P b s → HasCartanType P b s.dual := by
+    rintro s hs ⟨e, he⟩
+    refine ⟨e.trans (Fin.revPerm.trans s.dualNodeEquiv), fun i j ↦ ?_⟩
+    rw [he i j]
+    simp only [Equiv.trans_apply, Fin.revPerm_apply]
+    rw [DynkinType.cartanMatrix_dual, DynkinType.cartanMatrix_rev_of_rank_le_two hs]
+  refine ⟨fun h ↦ ?_, key t ht⟩
+  simpa using key t.dual (by simpa using ht) h
+
+/-- Types `B 2` and `C 2` match exactly the same bases, the low-rank coincidence that
+`TauCeti.DynkinType.Valid` resolves by keeping only `B 2`. -/
+theorem hasCartanType_C_two_iff_B_two {b : P.Base} :
+    HasCartanType P b (.C 2) ↔ HasCartanType P b (.B 2) :=
+  hasCartanType_dual_iff_of_rank_le_two (t := .B 2) le_rfl
+
+end RankLeTwo
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Duality.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Duality.lean
@@ -45,7 +45,8 @@ diagonal and at most two indices is itself a simultaneous relabelling.
   transpose of the standard Cartan matrix, read through `dualNodeEquiv`.
 * `TauCeti.hasCartanType_flip_iff`: **the Cartan type of a base and the Cartan type of the flipped
   base are dual**. In particular a base is of type `Bₙ` exactly when the flipped base is of type
-  `Cₙ` (`TauCeti.hasCartanType_flip_C_iff`).
+  `Cₙ` (`TauCeti.hasCartanType_flip_C_iff`, and `TauCeti.hasCartanType_flip_B_iff` for the other
+  orientation).
 * `TauCeti.DynkinType.valid_dual_iff`: validity transfers along duality except for the pair
   `B 2`, `C 2`.
 * `TauCeti.hasCartanType_dual_iff_of_rank_le_two`: at rank at most two a type and its dual match
@@ -110,8 +111,10 @@ does. -/
 
 /-- **Validity transfers along duality away from the pair `B 2`, `C 2`.** The excluded pair is the
 low-rank coincidence `B 2 = C 2`: both names describe the same root system, and the enumeration
-keeps only `B 2` valid, so `TauCeti.DynkinType.valid_B_two_and_not_valid_dual` below records the
-failure on that pair. -/
+keeps only `B 2` valid. So both orientations of that pair genuinely fail — `B 2` is valid while its
+dual `C 2` is not, and `C 2` is not valid while its dual `B 2` is (`simp` proves either from
+`TauCeti.DynkinType.valid_B`, `TauCeti.DynkinType.valid_C` and `dual_B`, `dual_C`). No base is lost
+by keeping only the first name; see `TauCeti.hasCartanType_dual_iff_of_rank_le_two`. -/
 lemma valid_dual_iff {t : DynkinType} (hB : t ≠ B 2) (hC : t ≠ C 2) :
     t.dual.Valid ↔ t.Valid := by
   cases t with
@@ -124,16 +127,6 @@ lemma valid_dual_iff {t : DynkinType} (hB : t ≠ B 2) (hC : t ≠ C 2) :
       simp only [dual_C, valid_B, valid_C]
       omega
   | _ => simp
-
-/-- One orientation of the pair excluded from `TauCeti.DynkinType.valid_dual_iff`: `B 2` is a valid
-type whose dual `C 2` is not. Both orientations fail, since `(C 2).dual = B 2` is valid while `C 2`
-is not; the two names describe the same root system, and
-`TauCeti.hasCartanType_dual_iff_of_rank_le_two` shows that no base is lost by keeping only the
-first name. -/
-lemma valid_B_two_and_not_valid_dual : (B 2).Valid ∧ ¬ (B 2).dual.Valid := by
-  refine ⟨valid_B.mpr le_rfl, ?_⟩
-  rw [dual_B]
-  simp
 
 /-- **The relabelling of nodes carried by duality.** Transposing a Cartan matrix reverses the
 arrows of its diagram, and for the classical families and the `E` types the result is the standard
@@ -269,10 +262,20 @@ a Dynkin type to its dual. -/
 
 /-- **A base is of type `Bₙ` exactly when the flipped base is of type `Cₙ`.** This is the worked
 instance of `TauCeti.hasCartanType_flip_iff`: `Bₙ` and `Cₙ` are the pair of types that the oriented
-matching of `TauCeti.HasCartanType` keeps apart, and duality is what identifies them. -/
-theorem hasCartanType_flip_C_iff {b : P.Base} {n : ℕ} :
+matching of `TauCeti.HasCartanType` keeps apart, and duality is what identifies them.
+
+It is stated separately from `TauCeti.hasCartanType_flip_iff` because that lemma matches a flipped
+type `t.dual` syntactically, so neither `simp` nor `rw` recovers this instance from it: doing so
+would mean solving `.C n = ?t.dual` for `?t`. -/
+@[simp] theorem hasCartanType_flip_C_iff {b : P.Base} {n : ℕ} :
     HasCartanType P.flip b.flip (.C n) ↔ HasCartanType P b (.B n) :=
   hasCartanType_flip_iff (t := .B n)
+
+/-- The other orientation of `TauCeti.hasCartanType_flip_C_iff`: a base is of type `Cₙ` exactly
+when the flipped base is of type `Bₙ`. -/
+@[simp] theorem hasCartanType_flip_B_iff {b : P.Base} {n : ℕ} :
+    HasCartanType P.flip b.flip (.B n) ↔ HasCartanType P b (.C n) :=
+  hasCartanType_flip_iff (t := .C n)
 
 end HasCartanType
 
@@ -300,7 +303,7 @@ theorem hasCartanType_dual_iff_of_rank_le_two {b : P.Base} {t : DynkinType} (ht 
 
 /-- Types `B 2` and `C 2` match exactly the same bases, the low-rank coincidence that
 `TauCeti.DynkinType.Valid` resolves by keeping only `B 2`. -/
-theorem hasCartanType_C_two_iff_B_two {b : P.Base} :
+@[simp] theorem hasCartanType_C_two_iff_B_two {b : P.Base} :
     HasCartanType P b (.C 2) ↔ HasCartanType P b (.B 2) :=
   hasCartanType_dual_iff_of_rank_le_two (t := .B 2) le_rfl
 

--- a/TauCeti/LinearAlgebra/RootSystem/Duality.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Duality.lean
@@ -72,7 +72,7 @@ namespace RootPairing
 /-- **Flipping a root pairing transposes its integral pairing.** The pairing of the flipped pairing
 is transposed by definition (`RootPairing.pairing_flip`); the content here is that the *chosen*
 preimage in `S` is transposed too, which needs `algebraMap S R` to be injective. -/
-lemma pairingIn_flip (S : Type*) [CommRing S] [Algebra S R] [FaithfulSMul S R]
+@[simp] lemma pairingIn_flip (S : Type*) [CommRing S] [Algebra S R] [FaithfulSMul S R]
     (P : RootPairing ι R M N) [P.IsValuedIn S] (i j : ι) :
     P.flip.pairingIn S i j = P.pairingIn S j i :=
   FaithfulSMul.algebraMap_injective S R <| by simp
@@ -85,12 +85,13 @@ Cartan matrices of the base and of its flip are indexed by. -/
 def flipSupportEquiv {P : RootPairing ι R M N} (b : P.Base) : b.flip.support ≃ b.support :=
   Equiv.subtypeEquivRight fun _ ↦ by rw [RootPairing.Base.flip_support]
 
-@[simp] lemma coe_flipSupportEquiv {P : RootPairing ι R M N} (b : P.Base) (i : b.flip.support) :
+@[simp] lemma coe_flipSupportEquiv_apply {P : RootPairing ι R M N} (b : P.Base)
+    (i : b.flip.support) :
     (flipSupportEquiv b i : ι) = i := (rfl)
 
 /-- **The Cartan matrix of the flipped base is the transpose of the Cartan matrix of the base.** -/
-lemma cartanMatrix_flip [CharZero R] {P : RootPairing ι R M N} [P.IsCrystallographic] (b : P.Base)
-    (i j : b.flip.support) :
+@[simp] lemma cartanMatrix_flip [CharZero R] {P : RootPairing ι R M N} [P.IsCrystallographic]
+    (b : P.Base) (i j : b.flip.support) :
     b.flip.cartanMatrix i j = b.cartanMatrix (flipSupportEquiv b j) (flipSupportEquiv b i) := by
   have h₁ : b.flip.cartanMatrix i j = P.flip.pairingIn ℤ (i : ι) (j : ι) :=
     RootPairing.Base.cartanMatrixIn_def _ _ _ _
@@ -99,7 +100,7 @@ lemma cartanMatrix_flip [CharZero R] {P : RootPairing ι R M N} [P.IsCrystallogr
   rw [h₁, h₂, pairingIn_flip]
 
 /-- Flipping a base twice returns the original base. -/
-lemma flip_flip {P : RootPairing ι R M N} (b : P.Base) : b.flip.flip = b := rfl
+@[simp] lemma flip_flip {P : RootPairing ι R M N} (b : P.Base) : b.flip.flip = b := rfl
 
 end Base
 

--- a/TauCeti/LinearAlgebra/RootSystem/Duality.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Duality.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.LinearAlgebra.RootSystem.DynkinType
+public import TauCeti.LinearAlgebra.RootSystem.Flip
 
 public section
 
@@ -12,11 +13,12 @@ public section
 # Duality of Dynkin types
 
 Interchanging the roots and the coroots of a root pairing (`RootPairing.flip`) transposes every
-pairing `⟨αᵢ, αⱼ^∨⟩`, hence transposes the Cartan matrix of a base. On the classification side that
-operation permutes the Dynkin types, and this file pins the permutation: `TauCeti.DynkinType.dual`
-exchanges `Bₙ` with `Cₙ` and fixes every other type. Duality is what makes the orientation carried
-by `TauCeti.HasCartanType` meaningful, since `Bₙ` and `Cₙ` are exactly the pair of types that the
-orientation separates.
+pairing `⟨αᵢ, αⱼ^∨⟩`, hence transposes the Cartan matrix of a base
+(`TauCeti.RootPairing.Base.cartanMatrix_flip`, proved in `TauCeti.LinearAlgebra.RootSystem.Flip`).
+On the classification side that operation permutes the Dynkin types, and this file pins the
+permutation: `TauCeti.DynkinType.dual` exchanges `Bₙ` with `Cₙ` and fixes every other type.
+Duality is what makes the orientation carried by `TauCeti.HasCartanType` meaningful, since `Bₙ` and
+`Cₙ` are exactly the pair of types that the orientation separates.
 
 The dual type is not read off the transposed matrix on the nose. Transposing a Cartan matrix does
 not merely relabel the diagram, it reverses every arrow, and for `F₄` and `G₂` the reversed diagram
@@ -39,8 +41,6 @@ diagonal and at most two indices is itself a simultaneous relabelling.
 
 ## Main results
 
-* `TauCeti.RootPairing.pairingIn_flip` and `TauCeti.RootPairing.Base.cartanMatrix_flip`: flipping a
-  root pairing transposes the integral pairing, hence the Cartan matrix of a base.
 * `TauCeti.DynkinType.cartanMatrix_dual`: the standard Cartan matrix of the dual type is the
   transpose of the standard Cartan matrix, read through `dualNodeEquiv`.
 * `TauCeti.hasCartanType_flip_iff`: **the Cartan type of a base and the Cartan type of the flipped
@@ -62,51 +62,6 @@ Chapters 4-6*, plates I-IX, for the standard Cartan matrices and their duals.
 -/
 
 namespace TauCeti
-
-section Flip
-
-variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
-
-namespace RootPairing
-
-/-- **Flipping a root pairing transposes its integral pairing.** The pairing of the flipped pairing
-is transposed by definition (`RootPairing.pairing_flip`); the content here is that the *chosen*
-preimage in `S` is transposed too, which needs `algebraMap S R` to be injective. -/
-@[simp] lemma pairingIn_flip (S : Type*) [CommRing S] [Algebra S R] [FaithfulSMul S R]
-    (P : RootPairing ι R M N) [P.IsValuedIn S] (i j : ι) :
-    P.flip.pairingIn S i j = P.pairingIn S j i :=
-  FaithfulSMul.algebraMap_injective S R <| by simp
-
-namespace Base
-
-/-- A base of `P` is a base of `P.flip` supported on the same simple indices
-(`RootPairing.Base.flip`); this is the resulting identification of the two index types, which the
-Cartan matrices of the base and of its flip are indexed by. -/
-def flipSupportEquiv {P : RootPairing ι R M N} (b : P.Base) : b.flip.support ≃ b.support :=
-  Equiv.subtypeEquivRight fun _ ↦ by rw [RootPairing.Base.flip_support]
-
-@[simp] lemma coe_flipSupportEquiv_apply {P : RootPairing ι R M N} (b : P.Base)
-    (i : b.flip.support) :
-    (flipSupportEquiv b i : ι) = i := (rfl)
-
-/-- **The Cartan matrix of the flipped base is the transpose of the Cartan matrix of the base.** -/
-@[simp] lemma cartanMatrix_flip [CharZero R] {P : RootPairing ι R M N} [P.IsCrystallographic]
-    (b : P.Base) (i j : b.flip.support) :
-    b.flip.cartanMatrix i j = b.cartanMatrix (flipSupportEquiv b j) (flipSupportEquiv b i) := by
-  have h₁ : b.flip.cartanMatrix i j = P.flip.pairingIn ℤ (i : ι) (j : ι) :=
-    RootPairing.Base.cartanMatrixIn_def _ _ _ _
-  have h₂ : b.cartanMatrix (flipSupportEquiv b j) (flipSupportEquiv b i)
-      = P.pairingIn ℤ (j : ι) (i : ι) := RootPairing.Base.cartanMatrixIn_def _ _ _ _
-  rw [h₁, h₂, pairingIn_flip]
-
-/-- Flipping a base twice returns the original base. -/
-@[simp] lemma flip_flip {P : RootPairing ι R M N} (b : P.Base) : b.flip.flip = b := rfl
-
-end Base
-
-end RootPairing
-
-end Flip
 
 namespace DynkinType
 
@@ -216,7 +171,7 @@ relabelling `TauCeti.DynkinType.dualNodeEquiv`. For the simply-laced types the s
 are symmetric and there is nothing to move; for `Bₙ` and `Cₙ` the transposition is
 `CartanMatrix.B_transpose`; and for `F₄` and `G₂` the transpose is the matrix itself with its nodes
 reversed. -/
-theorem cartanMatrix_dual (t : DynkinType) (i j : Fin t.rank) :
+@[simp] theorem cartanMatrix_dual (t : DynkinType) (i j : Fin t.rank) :
     t.dual.cartanMatrix (t.dualNodeEquiv i) (t.dualNodeEquiv j) = t.cartanMatrix j i := by
   -- Splitting on `t` leaves the dependent indices to be reduced by hand; `change` carries out that
   -- reduction inside this module, after which the standard matrices are named by the
@@ -305,7 +260,7 @@ theorem HasCartanType.flip {b : P.Base} {t : DynkinType} (h : HasCartanType P b 
 /-- **A base has Cartan type `t` exactly when the flipped base has the dual type.** This is what
 gives `TauCeti.DynkinType.dual` its meaning: passing from a root system to its dual is passing from
 a Dynkin type to its dual. -/
-theorem hasCartanType_flip_iff {b : P.Base} {t : DynkinType} :
+@[simp] theorem hasCartanType_flip_iff {b : P.Base} {t : DynkinType} :
     HasCartanType P.flip b.flip t.dual ↔ HasCartanType P b t := by
   refine ⟨fun h ↦ ?_, HasCartanType.flip⟩
   have h' := h.flip

--- a/TauCeti/LinearAlgebra/RootSystem/Duality.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Duality.lean
@@ -39,8 +39,8 @@ diagonal and at most two indices is itself a simultaneous relabelling.
 
 ## Main results
 
-* `TauCeti.pairingIn_flip` and `TauCeti.cartanMatrix_flip`: flipping a root pairing transposes the
-  integral pairing, hence the Cartan matrix of a base.
+* `TauCeti.RootPairing.pairingIn_flip` and `TauCeti.RootPairing.Base.cartanMatrix_flip`: flipping a
+  root pairing transposes the integral pairing, hence the Cartan matrix of a base.
 * `TauCeti.DynkinType.cartanMatrix_dual`: the standard Cartan matrix of the dual type is the
   transpose of the standard Cartan matrix, read through `dualNodeEquiv`.
 * `TauCeti.hasCartanType_flip_iff`: **the Cartan type of a base and the Cartan type of the flipped
@@ -67,6 +67,8 @@ section Flip
 
 variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
+namespace RootPairing
+
 /-- **Flipping a root pairing transposes its integral pairing.** The pairing of the flipped pairing
 is transposed by definition (`RootPairing.pairing_flip`); the content here is that the *chosen*
 preimage in `S` is transposed too, which needs `algebraMap S R` to be injective. -/
@@ -74,6 +76,8 @@ lemma pairingIn_flip (S : Type*) [CommRing S] [Algebra S R] [FaithfulSMul S R]
     (P : RootPairing ι R M N) [P.IsValuedIn S] (i j : ι) :
     P.flip.pairingIn S i j = P.pairingIn S j i :=
   FaithfulSMul.algebraMap_injective S R <| by simp
+
+namespace Base
 
 /-- A base of `P` is a base of `P.flip` supported on the same simple indices
 (`RootPairing.Base.flip`); this is the resulting identification of the two index types, which the
@@ -95,7 +99,11 @@ lemma cartanMatrix_flip [CharZero R] {P : RootPairing ι R M N} [P.IsCrystallogr
   rw [h₁, h₂, pairingIn_flip]
 
 /-- Flipping a base twice returns the original base. -/
-lemma base_flip_flip {P : RootPairing ι R M N} (b : P.Base) : b.flip.flip = b := rfl
+lemma flip_flip {P : RootPairing ι R M N} (b : P.Base) : b.flip.flip = b := rfl
+
+end Base
+
+end RootPairing
 
 end Flip
 
@@ -104,7 +112,10 @@ namespace DynkinType
 /-- **The dual Dynkin type.** Duality reverses the arrows of a diagram, which exchanges the types
 `Bₙ` and `Cₙ` — the one pair whose standard Cartan matrices are transposes of one another without
 being equal — and fixes all the others. It is realized on root systems by `RootPairing.flip`; see
-`TauCeti.hasCartanType_flip_iff`. -/
+`TauCeti.hasCartanType_flip_iff`.
+
+This is `@[expose]`d because it occurs in the *type* of `TauCeti.DynkinType.dualNodeEquiv` below,
+whose constructor equations do not even elaborate unless `(.A n).dual.rank` reduces to `n`. -/
 @[expose] def dual : DynkinType → DynkinType
   | .A n => .A n
   | .B n => .C n
@@ -144,7 +155,7 @@ does. -/
 /-- **Validity transfers along duality away from the pair `B 2`, `C 2`.** The excluded pair is the
 low-rank coincidence `B 2 = C 2`: both names describe the same root system, and the enumeration
 keeps only `B 2` valid, so `TauCeti.DynkinType.valid_B_two_and_not_valid_dual` below records the
-one place where the transfer genuinely fails. -/
+failure on that pair. -/
 lemma valid_dual_iff {t : DynkinType} (hB : t ≠ B 2) (hC : t ≠ C 2) :
     t.dual.Valid ↔ t.Valid := by
   cases t with
@@ -158,8 +169,9 @@ lemma valid_dual_iff {t : DynkinType} (hB : t ≠ B 2) (hC : t ≠ C 2) :
       omega
   | _ => simp
 
-/-- The single failure of `TauCeti.DynkinType.valid_dual_iff`: `B 2` is a valid type whose dual
-`C 2` is not. The two name the same root system, and
+/-- One orientation of the pair excluded from `TauCeti.DynkinType.valid_dual_iff`: `B 2` is a valid
+type whose dual `C 2` is not. Both orientations fail, since `(C 2).dual = B 2` is valid while `C 2`
+is not; the two names describe the same root system, and
 `TauCeti.hasCartanType_dual_iff_of_rank_le_two` shows that no base is lost by keeping only the
 first name. -/
 lemma valid_B_two_and_not_valid_dual : (B 2).Valid ∧ ¬ (B 2).dual.Valid := by
@@ -172,7 +184,7 @@ arrows of its diagram, and for the classical families and the `E` types the resu
 matrix of the dual type already in the Bourbaki numbering. For `F₄` and `G₂` — the two types that
 are self-dual without being simply laced — the reversed diagram is the original one read backwards,
 so the relabelling there is `Fin.revPerm`. -/
-@[expose] def dualNodeEquiv : (t : DynkinType) → Fin t.rank ≃ Fin t.dual.rank
+def dualNodeEquiv : (t : DynkinType) → Fin t.rank ≃ Fin t.dual.rank
   | .A _ => Equiv.refl _
   | .B _ => Equiv.refl _
   | .C _ => Equiv.refl _
@@ -185,16 +197,18 @@ so the relabelling there is `Fin.revPerm`. -/
 
 -- Stated as equalities of equivalences rather than pointwise: the two sides of a pointwise
 -- statement live in `Fin t.rank` and `Fin t.dual.rank`, so its left-hand side would carry a
--- dependent type that `simp` rewrites, leaving it out of simp-normal form.
-@[simp] lemma dualNodeEquiv_A (n : ℕ) : (A n).dualNodeEquiv = Equiv.refl (Fin n) := rfl
-@[simp] lemma dualNodeEquiv_B (n : ℕ) : (B n).dualNodeEquiv = Equiv.refl (Fin n) := rfl
-@[simp] lemma dualNodeEquiv_C (n : ℕ) : (C n).dualNodeEquiv = Equiv.refl (Fin n) := rfl
-@[simp] lemma dualNodeEquiv_D (n : ℕ) : (D n).dualNodeEquiv = Equiv.refl (Fin n) := rfl
-@[simp] lemma dualNodeEquiv_E6 : E6.dualNodeEquiv = Equiv.refl (Fin 6) := rfl
-@[simp] lemma dualNodeEquiv_E7 : E7.dualNodeEquiv = Equiv.refl (Fin 7) := rfl
-@[simp] lemma dualNodeEquiv_E8 : E8.dualNodeEquiv = Equiv.refl (Fin 8) := rfl
-@[simp] lemma dualNodeEquiv_F4 : F4.dualNodeEquiv = Fin.revPerm := rfl
-@[simp] lemma dualNodeEquiv_G2 : G2.dualNodeEquiv = Fin.revPerm := rfl
+-- dependent type that `simp` rewrites, leaving it out of simp-normal form. The proofs are
+-- parenthesised because `dualNodeEquiv` is not `@[expose]`d, so a bare `rfl` body would demand
+-- that its equations be checkable from the exported signature alone.
+@[simp] lemma dualNodeEquiv_A (n : ℕ) : (A n).dualNodeEquiv = Equiv.refl (Fin n) := (rfl)
+@[simp] lemma dualNodeEquiv_B (n : ℕ) : (B n).dualNodeEquiv = Equiv.refl (Fin n) := (rfl)
+@[simp] lemma dualNodeEquiv_C (n : ℕ) : (C n).dualNodeEquiv = Equiv.refl (Fin n) := (rfl)
+@[simp] lemma dualNodeEquiv_D (n : ℕ) : (D n).dualNodeEquiv = Equiv.refl (Fin n) := (rfl)
+@[simp] lemma dualNodeEquiv_E6 : E6.dualNodeEquiv = Equiv.refl (Fin 6) := (rfl)
+@[simp] lemma dualNodeEquiv_E7 : E7.dualNodeEquiv = Equiv.refl (Fin 7) := (rfl)
+@[simp] lemma dualNodeEquiv_E8 : E8.dualNodeEquiv = Equiv.refl (Fin 8) := (rfl)
+@[simp] lemma dualNodeEquiv_F4 : F4.dualNodeEquiv = Fin.revPerm := (rfl)
+@[simp] lemma dualNodeEquiv_G2 : G2.dualNodeEquiv = Fin.revPerm := (rfl)
 
 /-- **The standard Cartan matrix of the dual type is the transpose**, read through the node
 relabelling `TauCeti.DynkinType.dualNodeEquiv`. For the simply-laced types the standard matrices
@@ -203,9 +217,9 @@ are symmetric and there is nothing to move; for `Bₙ` and `Cₙ` the transposit
 reversed. -/
 theorem cartanMatrix_dual (t : DynkinType) (i j : Fin t.rank) :
     t.dual.cartanMatrix (t.dualNodeEquiv i) (t.dualNodeEquiv j) = t.cartanMatrix j i := by
-  -- Splitting on `t` leaves the dependent indices to be reduced by hand; `dual` and
-  -- `dualNodeEquiv` are `@[expose]`d so that `change` can carry out that reduction, after which
-  -- the standard matrices are named by the `cartanMatrix_*` equations.
+  -- Splitting on `t` leaves the dependent indices to be reduced by hand; `change` carries out that
+  -- reduction inside this module, after which the standard matrices are named by the
+  -- `cartanMatrix_*` equations.
   cases t with
   | A n =>
       change Fin n at i j
@@ -277,14 +291,15 @@ variable {ι R M N : Type*} [CommRing R] [CharZero R] [AddCommGroup M] [Module R
   [AddCommGroup N] [Module R N] {P : RootPairing ι R M N} [P.IsCrystallographic]
 
 /-- **The Cartan type of a flipped base is the dual type.** Flipping transposes the Cartan matrix
-(`TauCeti.cartanMatrix_flip`), and transposing a standard Cartan matrix is passing to the dual type
-up to the node relabelling `TauCeti.DynkinType.dualNodeEquiv`. -/
+(`TauCeti.RootPairing.Base.cartanMatrix_flip`), and transposing a standard Cartan matrix is passing
+to the dual type up to the node relabelling `TauCeti.DynkinType.dualNodeEquiv`. -/
 theorem HasCartanType.flip {b : P.Base} {t : DynkinType} (h : HasCartanType P b t) :
     HasCartanType P.flip b.flip t.dual := by
-  obtain ⟨e, he⟩ := h
-  refine ⟨(flipSupportEquiv b).trans (e.trans t.dualNodeEquiv), fun i j ↦ ?_⟩
+  obtain ⟨e, he⟩ := (hasCartanType_iff b t).mp h
+  refine (hasCartanType_iff _ _).mpr
+    ⟨(RootPairing.Base.flipSupportEquiv b).trans (e.trans t.dualNodeEquiv), fun i j ↦ ?_⟩
   simp only [Equiv.trans_apply]
-  rw [cartanMatrix_flip b i j, he _ _, DynkinType.cartanMatrix_dual]
+  rw [RootPairing.Base.cartanMatrix_flip b i j, he _ _, DynkinType.cartanMatrix_dual]
 
 /-- **A base has Cartan type `t` exactly when the flipped base has the dual type.** This is what
 gives `TauCeti.DynkinType.dual` its meaning: passing from a root system to its dual is passing from
@@ -293,7 +308,7 @@ theorem hasCartanType_flip_iff {b : P.Base} {t : DynkinType} :
     HasCartanType P.flip b.flip t.dual ↔ HasCartanType P b t := by
   refine ⟨fun h ↦ ?_, HasCartanType.flip⟩
   have h' := h.flip
-  rw [DynkinType.dual_dual, base_flip_flip] at h'
+  rw [DynkinType.dual_dual, RootPairing.Base.flip_flip] at h'
   exact h'
 
 /-- **A base is of type `Bₙ` exactly when the flipped base is of type `Cₙ`.** This is the worked
@@ -318,8 +333,9 @@ theorem hasCartanType_dual_iff_of_rank_le_two {b : P.Base} {t : DynkinType} (ht 
     HasCartanType P b t.dual ↔ HasCartanType P b t := by
   -- Both directions are the same computation, so prove the general step once and apply it twice.
   have key : ∀ s : DynkinType, s.rank ≤ 2 → HasCartanType P b s → HasCartanType P b s.dual := by
-    rintro s hs ⟨e, he⟩
-    refine ⟨e.trans (Fin.revPerm.trans s.dualNodeEquiv), fun i j ↦ ?_⟩
+    intro s hs h
+    obtain ⟨e, he⟩ := (hasCartanType_iff b s).mp h
+    refine (hasCartanType_iff _ _).mpr ⟨e.trans (Fin.revPerm.trans s.dualNodeEquiv), fun i j ↦ ?_⟩
     rw [he i j]
     simp only [Equiv.trans_apply, Fin.revPerm_apply]
     rw [DynkinType.cartanMatrix_dual, DynkinType.cartanMatrix_rev_of_rank_le_two hs]

--- a/TauCeti/LinearAlgebra/RootSystem/DynkinType.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/DynkinType.lean
@@ -396,14 +396,19 @@ with the standard Cartan matrix of `t` after a single simultaneous relabelling o
 Matching without transposing is deliberate: from rank `3` on, `Bₙ` and `Cₙ` are different root
 systems with transposed Cartan matrices (`CartanMatrix.B_transpose`), so an unoriented match would
 identify them. It does not separate `B 2` from `C 2`, which are the same root system;
-`TauCeti.DynkinType.Valid` excludes `C 2`.
-
-This is `@[expose]`d so that consumers in other modules can destructure the relabelling directly,
-as the results in this file do. -/
-@[expose] def HasCartanType (b : P.Base) (t : DynkinType) : Prop :=
+`TauCeti.DynkinType.Valid` excludes `C 2`. -/
+def HasCartanType (b : P.Base) (t : DynkinType) : Prop :=
   ∃ e : b.support ≃ Fin t.rank, ∀ i j, b.cartanMatrix i j = t.cartanMatrix (e i) (e j)
 
 variable {P}
+
+/-- Having Cartan type `t`, unfolded to the relabelling it asserts to exist. The body of
+`TauCeti.HasCartanType` is deliberately not exposed, so this is the interface through which
+consumers in other modules build and destructure it. -/
+lemma hasCartanType_iff (b : P.Base) (t : DynkinType) :
+    HasCartanType P b t ↔
+      ∃ e : b.support ≃ Fin t.rank, ∀ i j, b.cartanMatrix i j = t.cartanMatrix (e i) (e j) :=
+  (Iff.rfl)
 
 /-- Having Cartan type `t`, expressed as a reindexing of matrices rather than entrywise. -/
 lemma hasCartanType_iff_reindex (b : P.Base) (t : DynkinType) :

--- a/TauCeti/LinearAlgebra/RootSystem/DynkinType.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/DynkinType.lean
@@ -396,8 +396,11 @@ with the standard Cartan matrix of `t` after a single simultaneous relabelling o
 Matching without transposing is deliberate: from rank `3` on, `Bₙ` and `Cₙ` are different root
 systems with transposed Cartan matrices (`CartanMatrix.B_transpose`), so an unoriented match would
 identify them. It does not separate `B 2` from `C 2`, which are the same root system;
-`TauCeti.DynkinType.Valid` excludes `C 2`. -/
-def HasCartanType (b : P.Base) (t : DynkinType) : Prop :=
+`TauCeti.DynkinType.Valid` excludes `C 2`.
+
+This is `@[expose]`d so that consumers in other modules can destructure the relabelling directly,
+as the results in this file do. -/
+@[expose] def HasCartanType (b : P.Base) (t : DynkinType) : Prop :=
   ∃ e : b.support ≃ Fin t.rank, ∀ i j, b.cartanMatrix i j = t.cartanMatrix (e i) (e j)
 
 variable {P}

--- a/TauCeti/LinearAlgebra/RootSystem/Flip.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Flip.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.RootSystem.CartanMatrix
+
+public section
+
+/-!
+# Flipping a root pairing transposes its Cartan matrix
+
+Mathlib's `RootPairing.flip` interchanges the roots and the coroots of a root pairing, and
+`RootPairing.Base.flip` records that a base of `P` is a base of `P.flip` supported on the same
+simple indices. Interchanging the two sides transposes every pairing `⟨αᵢ, αⱼ^∨⟩`
+(`RootPairing.pairing_flip`); this file carries that transposition across the integral structure
+and the Cartan matrix of a base, which is where flipping is used.
+
+## Main definitions
+
+* `TauCeti.RootPairing.Base.flipSupportEquiv`: the identification of the support of a base with the
+  support of its flip, which the two Cartan matrices are indexed by.
+
+## Main results
+
+* `TauCeti.RootPairing.pairingIn_flip`: flipping transposes the *chosen* preimage of a pairing in
+  the coefficient ring `S`, not only the pairing itself.
+* `TauCeti.RootPairing.Base.cartanMatrix_flip`: the Cartan matrix of the flipped base is the
+  transpose of the Cartan matrix of the base.
+
+## References
+
+This file supplies the root-pairing half of the duality item of Layer 5 of
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, which records that
+`DynkinType.cartanMatrix (.B n)` is the transpose of `DynkinType.cartanMatrix (.C n)` and that the
+two types are "identified only after `flip` (duality)"; the classification side of that item is
+`TauCeti.LinearAlgebra.RootSystem.Duality`.
+-/
+
+namespace TauCeti
+
+variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+
+namespace RootPairing
+
+/-- **Flipping a root pairing transposes its integral pairing.** The pairing of the flipped pairing
+is transposed by definition (`RootPairing.pairing_flip`); the content here is that the *chosen*
+preimage in `S` is transposed too, which needs `algebraMap S R` to be injective. -/
+@[simp] lemma pairingIn_flip (S : Type*) [CommRing S] [Algebra S R] [FaithfulSMul S R]
+    (P : RootPairing ι R M N) [P.IsValuedIn S] (i j : ι) :
+    P.flip.pairingIn S i j = P.pairingIn S j i :=
+  FaithfulSMul.algebraMap_injective S R <| by simp
+
+namespace Base
+
+/-- A base of `P` is a base of `P.flip` supported on the same simple indices
+(`RootPairing.Base.flip`); this is the resulting identification of the two index types, which the
+Cartan matrices of the base and of its flip are indexed by. -/
+def flipSupportEquiv {P : RootPairing ι R M N} (b : P.Base) : b.flip.support ≃ b.support :=
+  Equiv.subtypeEquivRight fun _ ↦ by rw [RootPairing.Base.flip_support]
+
+@[simp] lemma coe_flipSupportEquiv_apply {P : RootPairing ι R M N} (b : P.Base)
+    (i : b.flip.support) :
+    (flipSupportEquiv b i : ι) = i := (rfl)
+
+/-- **The Cartan matrix of the flipped base is the transpose of the Cartan matrix of the base.** -/
+@[simp] lemma cartanMatrix_flip [CharZero R] {P : RootPairing ι R M N} [P.IsCrystallographic]
+    (b : P.Base) (i j : b.flip.support) :
+    b.flip.cartanMatrix i j = b.cartanMatrix (flipSupportEquiv b j) (flipSupportEquiv b i) := by
+  have h₁ : b.flip.cartanMatrix i j = P.flip.pairingIn ℤ (i : ι) (j : ι) :=
+    RootPairing.Base.cartanMatrixIn_def _ _ _ _
+  have h₂ : b.cartanMatrix (flipSupportEquiv b j) (flipSupportEquiv b i)
+      = P.pairingIn ℤ (j : ι) (i : ι) := RootPairing.Base.cartanMatrixIn_def _ _ _ _
+  rw [h₁, h₂, pairingIn_flip]
+
+/-- Flipping a base twice returns the original base. -/
+@[simp] lemma flip_flip {P : RootPairing ι R M N} (b : P.Base) : b.flip.flip = b := rfl
+
+end Base
+
+end RootPairing
+
+end TauCeti


### PR DESCRIPTION
This PR pins the duality of Dynkin types: interchanging the roots and the coroots of a root pairing (`RootPairing.flip`) transposes every pairing, hence transposes the Cartan matrix of a base, and on the classification side that operation is the permutation of Dynkin types exchanging `Bₙ` with `Cₙ`. `TauCeti.DynkinType.dual` is that permutation, `TauCeti.DynkinType.dualNodeEquiv` is the relabelling of Bourbaki nodes it carries (the identity for the classical families and the `E` types, the reversal `Fin.revPerm` for the self-dual-but-not-simply-laced `F₄` and `G₂`), and `TauCeti.DynkinType.cartanMatrix_dual` says the standard Cartan matrix of the dual type is the transpose read through that relabelling. Transferred to root pairings, `TauCeti.hasCartanType_flip_iff` states that a base has Cartan type `t` exactly when the flipped base has type `t.dual`, with `TauCeti.hasCartanType_flip_C_iff` the worked `Bₙ`/`Cₙ` instance. The supporting root-pairing lemmas are `TauCeti.pairingIn_flip` (flipping transposes the chosen integral preimage of a pairing, not only the pairing itself) and `TauCeti.cartanMatrix_flip`.

The exact roadmap target is `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, Layer 5, the `DynkinType.cartanMatrix` item: "The Cartan matrix is **oriented** ... Concretely `DynkinType.cartanMatrix (.B n)` is the transpose of `DynkinType.cartanMatrix (.C n)`; the two are distinct root systems, identified only after `flip` (duality)." Layer 6 of the same file consumes the operation named here when it asks that "The adjoint form is `RootPairing.flip` of the dual type's datum, not a second pinned definition." Nothing in `Suggested.lean` names `dual`, but the README is definitive and this is the statement it pins; it sits directly on top of `TauCeti.DynkinType.cartanMatrix` and `TauCeti.HasCartanType`, which landed in TauCeti#1431.

The roadmap also records that `Valid` is not preserved by exchanging `Bₙ` and `Cₙ`, and this PR makes that precise rather than papering over it. `TauCeti.DynkinType.valid_dual_iff` transfers validity along duality away from the single pair `B 2`, `C 2`, and `TauCeti.DynkinType.valid_B_two_and_not_valid_dual` exhibits the one genuine failure. The final section shows that nothing is lost by keeping only `B 2`: `TauCeti.hasCartanType_dual_iff_of_rank_le_two` proves that at rank at most two a base has a Cartan type exactly when it has the dual type, because reversing the nodes of a matrix with constant diagonal and at most two indices transposes it, so `TauCeti.hasCartanType_C_two_iff_B_two` says `B 2` and `C 2` match exactly the same bases. That discharges a claim the `DynkinType` module docstring had so far only asserted in prose.

The one change outside the new file is a one-line `@[expose]` on `TauCeti.HasCartanType` in `TauCeti/LinearAlgebra/RootSystem/DynkinType.lean` (with a sentence added to its docstring saying why). `HasCartanType` is a `Prop`-valued `def` unfolding to an existential over relabellings, and without exposure a consumer in another module cannot destructure it at all; the file's own results already do so internally. No proof or statement in that file changes. `TauCeti.DynkinType.cartanMatrix` is deliberately left unexposed, as its comment there asks.

No Mathlib infrastructure is vendored. The proofs consume Mathlib's `RootPairing.flip`, `RootPairing.Base.flip`, `RootPairing.pairing_flip`, `RootPairing.Base.cartanMatrixIn_def`, and the standard Cartan matrices `CartanMatrix.A/B/C/D/E₆/E₇/E₈/F₄/G₂` together with their symmetry lemmas and `CartanMatrix.B_transpose`/`C_transpose`.

Verified locally against the pinned Mathlib: `lake build` completes all 6801 jobs, `lake exe axioms` audits 27756 declarations with no axiom outside `propext`, `Classical.choice`, `Quot.sound`, `lake exe module-system` passes, and the default environment-linter set reports no violations on the new module.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"dynkintype-dual"}-->

🤖 Prepared with Claude Code
