### PR TITLE
refactor(Resolvent): extract the Neumann inverse from the perturbation proof

### DIFF
--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
@@ -270,6 +270,36 @@ section CompleteSpace
 
 variable [CompleteSpace X]
 
+/-- The Neumann inverse. When `|mu - lambda| * ‖R(lambda)‖ < 1`, the operator
+`1 - (lambda - mu) • R(lambda)` is invertible, and its inverse `U` is two-sided and commutes with
+`R(lambda)` — the latter because `1 - (lambda - mu) • R(lambda)` is a polynomial in `R(lambda)`.
+
+Nothing here needs `lambda` to be in the resolvent set: the statement is about the bounded operator
+`resolvent A lambda` alone. -/
+private theorem exists_inverse_one_sub_smul_resolvent
+    (hmu : |mu - lambda| * ‖resolvent A lambda‖ < 1) :
+    ∃ U : X →L[ℝ] X,
+      (∀ y : X, U y - (lambda - mu) • resolvent A lambda (U y) = y) ∧
+      (∀ y : X, U (y - (lambda - mu) • resolvent A lambda y) = y) ∧
+      ∀ y : X, resolvent A lambda (U y) = U (resolvent A lambda y) := by
+  have hnorm : ‖(lambda - mu) • resolvent A lambda‖ < 1 := by
+    rw [norm_smul, Real.norm_eq_abs, abs_sub_comm]
+    exact hmu
+  obtain ⟨u, hu⟩ := isUnit_one_sub_of_norm_lt_one hnorm
+  set B : X →L[ℝ] X := (lambda - mu) • resolvent A lambda with hB
+  refine ⟨((u⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X), fun y => ?_, fun y => ?_, fun y => ?_⟩
+  · have h1 : ((u : X →L[ℝ] X) * (u⁻¹ : (X →L[ℝ] X)ˣ)) = 1 := u.mul_inv
+    rw [hu] at h1
+    simpa [hB] using congrArg (fun S : X →L[ℝ] X => S y) h1
+  · have h1 : (((u⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X) * (u : X →L[ℝ] X)) = 1 := u.inv_mul
+    rw [hu] at h1
+    simpa [hB] using congrArg (fun S : X →L[ℝ] X => S y) h1
+  · have hcomm : Commute ((u : X →L[ℝ] X)) (resolvent A lambda) := by
+      rw [hu, Commute, SemiconjBy, hB, sub_mul, mul_sub, smul_mul_assoc, mul_smul_comm,
+        one_mul, mul_one]
+    simpa [mul_apply_eq_comp] using
+      congrArg (fun S : X →L[ℝ] X => S y) hcomm.units_inv_left.symm
+
 /-- **The Neumann perturbation of a resolvent point.** If `lambda` lies in the resolvent set and
 `|mu - lambda| * ‖R(lambda)‖ < 1`, then `mu` lies in it too.
 
@@ -278,50 +308,23 @@ factor is invertible by the geometric series, so `R(lambda) (I - (lambda - mu) R
 inverts `mu • I - A`. -/
 theorem mem_resolventSet_of_norm_mul_lt_one (h : lambda ∈ resolventSet A)
     (hmu : |mu - lambda| * ‖resolvent A lambda‖ < 1) : mu ∈ resolventSet A := by
-  have hnorm : ‖(lambda - mu) • resolvent A lambda‖ < 1 := by
-    rw [norm_smul, Real.norm_eq_abs, abs_sub_comm]
-    exact hmu
-  obtain ⟨u, hu⟩ := isUnit_one_sub_of_norm_lt_one hnorm
-  set B : X →L[ℝ] X := (lambda - mu) • resolvent A lambda with hB
-  set U : X →L[ℝ] X := ((u⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X) with hU
-  -- `U` is a two-sided inverse of `1 - B`
-  have hUright : ∀ y : X, U y - B (U y) = y := by
-    intro y
-    have h1 : ((u : X →L[ℝ] X) * U) = 1 := u.mul_inv
-    rw [hu] at h1
-    simpa using congrArg (fun S : X →L[ℝ] X => S y) h1
-  have hUleft : ∀ y : X, U (y - B y) = y := by
-    intro y
-    have h1 : (U * (u : X →L[ℝ] X)) = 1 := u.inv_mul
-    rw [hu] at h1
-    simpa using congrArg (fun S : X →L[ℝ] X => S y) h1
-  -- `B` is a multiple of `R(lambda)`, so `U` commutes with `R(lambda)`
-  have hcomm : Commute ((u : X →L[ℝ] X)) (resolvent A lambda) := by
-    rw [hu, Commute, SemiconjBy, hB, sub_mul, mul_sub, smul_mul_assoc, mul_smul_comm,
-      one_mul, mul_one]
-  have hcomm' : ∀ y : X, resolvent A lambda (U y) = U (resolvent A lambda y) := fun y => by
-    simpa [mul_apply_eq_comp] using
-      congrArg (fun S : X →L[ℝ] X => S y) hcomm.units_inv_left.symm
-  refine ⟨resolvent A lambda ∘L U, ?_, ?_, ?_⟩
-  · exact fun y => resolvent_mem_domain h (U y)
-  · intro y
-    have h1 := smul_sub_apply_resolvent h (U y)
-    have h2 : mu • resolvent A lambda (U y) -
-          A ⟨resolvent A lambda (U y), resolvent_mem_domain h (U y)⟩
-        = (lambda • resolvent A lambda (U y) -
-            A ⟨resolvent A lambda (U y), resolvent_mem_domain h (U y)⟩) -
-          (lambda - mu) • resolvent A lambda (U y) := by module
+  obtain ⟨U, hUright, hUleft, hcomm⟩ := exists_inverse_one_sub_smul_resolvent hmu
+  refine ⟨resolvent A lambda ∘L U, fun y => resolvent_mem_domain h (U y), fun y => ?_, fun x => ?_⟩
+  · have h2 : mu • resolvent A lambda (U y) -
+        A ⟨resolvent A lambda (U y), resolvent_mem_domain h (U y)⟩
+      = (lambda • resolvent A lambda (U y) -
+          A ⟨resolvent A lambda (U y), resolvent_mem_domain h (U y)⟩) -
+        (lambda - mu) • resolvent A lambda (U y) := by module
     simp only [ContinuousLinearMap.comp_apply]
-    rw [h2, h1]
-    simpa [hB] using hUright y
-  · intro x
-    have hsplit : mu • (x : X) - A x
-        = (lambda • (x : X) - A x) - (lambda - mu) • (x : X) := by module
-    have h1 : resolvent A lambda (mu • (x : X) - A x) = (x : X) - B (x : X) := by
-      rw [hsplit, map_sub, map_smul, resolvent_smul_sub_apply h x, hB]
-      rfl
+    rw [h2, smul_sub_apply_resolvent h (U y)]
+    exact hUright y
+  · have hsplit : mu • (x : X) - A x
+      = (lambda • (x : X) - A x) - (lambda - mu) • (x : X) := by module
+    have h1 : resolvent A lambda (mu • (x : X) - A x)
+        = (x : X) - (lambda - mu) • resolvent A lambda (x : X) := by
+      rw [hsplit, map_sub, map_smul, resolvent_smul_sub_apply h x]
     simp only [ContinuousLinearMap.comp_apply]
-    rw [hcomm' (mu • (x : X) - A x), h1, hUleft]
+    rw [hcomm (mu • (x : X) - A x), h1, hUleft]
 
 /-- **The resolvent set is open.** -/
 theorem isOpen_resolventSet (A : X →ₗ.[ℝ] X) : IsOpen (resolventSet A) := by

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
@@ -294,9 +294,11 @@ private theorem exists_inverse_one_sub_smul_resolvent
   · have h1 : (((u⁻¹ : (X →L[ℝ] X)ˣ) : X →L[ℝ] X) * (u : X →L[ℝ] X)) = 1 := u.inv_mul
     rw [hu] at h1
     simpa [hB] using congrArg (fun S : X →L[ℝ] X => S y) h1
-  · have hcomm : Commute ((u : X →L[ℝ] X)) (resolvent A lambda) := by
-      rw [hu, Commute, SemiconjBy, hB, sub_mul, mul_sub, smul_mul_assoc, mul_smul_comm,
-        one_mul, mul_one]
+  · -- `1 - (lambda - mu) • R(lambda)` is a polynomial in `R(lambda)`, hence commutes with it.
+    have hcomm : Commute ((u : X →L[ℝ] X)) (resolvent A lambda) := by
+      rw [hu, hB]
+      exact (Commute.one_left _).sub_left
+        ((Commute.refl (resolvent A lambda)).smul_left (lambda - mu))
     simpa [mul_apply_eq_comp] using
       congrArg (fun S : X →L[ℝ] X => S y) hcomm.units_inv_left.symm
 


### PR DESCRIPTION
`mem_resolventSet_of_norm_mul_lt_one` ran to 45 lines because it did two separate things: it built
the Neumann inverse of `1 - (lambda - mu) • R(lambda)` and established its properties, and then it
verified the three conditions for `mu ∈ resolventSet A`. Only the second is about the resolvent
set; the first is a fact about a bounded operator.

## The helper

`exists_inverse_one_sub_smul_resolvent` produces the inverse `U` together with the three
properties the caller uses: it is a right inverse, a left inverse, and it commutes with
`R(lambda)`. The commutation is the one non-obvious part — it holds because
`1 - (lambda - mu) • R(lambda)` is a polynomial in `R(lambda)`, which
`Commute.one_left`/`Commute.smul_left`/`Commute.sub_left` say directly, and then
`Commute.units_inv_left` transfers it from the unit to its inverse.

**It does not need `lambda ∈ resolventSet A`.** The caller passes that hypothesis to everything
else, and I threaded it into the helper by reflex; the `unusedVariables` linter caught that the
statement only ever mentions the bounded operator `resolvent A lambda`, never the fact that it
inverts anything. The docstring says so explicitly.

## What is left

The three resolvent conditions, each now a direct consequence:

```lean
obtain ⟨U, hUright, hUleft, hcomm⟩ := exists_inverse_one_sub_smul_resolvent hmu
refine ⟨resolvent A lambda ∘L U, fun y => resolvent_mem_domain h (U y), fun y => ?_, fun x => ?_⟩
· ... rw [h2, smul_sub_apply_resolvent h (U y)]; exact hUright y
· ... rw [hcomm (mu • (x : X) - A x), h1, hUleft]
```

Two `simpa [hB] using`s in the original also became plain `rw`/`exact`, because the helper now
states its conclusions in the unfolded `(lambda - mu) • resolvent A lambda` form rather than in
terms of a local abbreviation.

## Scope

The statement and docstring of the public theorem are unchanged, and the helper is `private`; the
entire diff is proof-internal.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all green;
no new lint violations. Proof body 45 → 18 lines, with the helper at 18.

Roadmap: OneParameterSemigroups
