### PR TITLE
refactor(ExtremalFamily): extract the two facts about the Montel limit

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
@@ -160,35 +160,34 @@ private theorem mapsTo_ball_of_forall_norm_le_one (hΩo : IsOpen Ω) (hconn : Is
 local uniform convergence, so `‖deriv g z₀‖` is the limit of the sequence `u` the family was
 chosen to approach. -/
 private theorem norm_deriv_eq_of_tendstoLocallyUniformlyOn (hΩo : IsOpen Ω) (hz₀ : z₀ ∈ Ω)
-    {F : ℕ → ℂ → ℂ} (hFd : ∀ n, DifferentiableOn ℂ (F n) Ω) {g : ℂ → ℂ} {M : ℝ} {u : ℕ → ℝ}
-    (hconv : TendstoLocallyUniformlyOn F g atTop Ω) (hu : Tendsto u atTop (𝓝 M))
-    (hFu : ∀ n, ‖deriv (F n) z₀‖ = u n) :
+    {F : ℕ → ℂ → ℂ} (hFd : ∀ᶠ n in atTop, DifferentiableOn ℂ (F n) Ω) {g : ℂ → ℂ} {M : ℝ}
+    {u : ℕ → ℝ} (hconv : TendstoLocallyUniformlyOn F g atTop Ω) (hu : Tendsto u atTop (𝓝 M))
+    (hFu : ∀ᶠ n in atTop, ‖deriv (F n) z₀‖ = u n) :
     ‖deriv g z₀‖ = M := by
   have hderiv : TendstoLocallyUniformlyOn (fun n => deriv (F n)) (deriv g) atTop Ω := by
-    have h := _root_.TendstoLocallyUniformlyOn.deriv hconv (Eventually.of_forall hFd) hΩo
+    have h := _root_.TendstoLocallyUniformlyOn.deriv hconv hFd hΩo
     simpa [Function.comp_def] using h
-  refine tendsto_nhds_unique (hderiv.tendsto_at hz₀).norm ?_
-  simpa [hFu] using hu
+  exact tendsto_nhds_unique (hderiv.tendsto_at hz₀).norm
+    (hu.congr' (hFu.mono fun n hn => hn.symm))
 
 /-- The family of pointed disc injections is closed under locally uniform limits, provided the
 limit's derivative at the base point does not vanish: that is exactly what excludes the constant
 alternative in Hurwitz's theorem. -/
 private theorem isPointedDiscInjectionOn_of_tendstoLocallyUniformlyOn (hΩo : IsOpen Ω)
     (hconn : IsPreconnected Ω) (hz₀ : z₀ ∈ Ω) {F : ℕ → ℂ → ℂ}
-    (hF : ∀ n, IsPointedDiscInjectionOn (F n) Ω z₀) {g : ℂ → ℂ}
-    (hgd : DifferentiableOn ℂ g Ω) (hconv : TendstoLocallyUniformlyOn F g atTop Ω)
-    (hderiv : deriv g z₀ ≠ 0) :
+    (hF : ∀ᶠ n in atTop, IsPointedDiscInjectionOn (F n) Ω z₀) {g : ℂ → ℂ}
+    (hconv : TendstoLocallyUniformlyOn F g atTop Ω) (hderiv : deriv g z₀ ≠ 0) :
     IsPointedDiscInjectionOn g Ω z₀ := by
-  have hg₀ : g z₀ = 0 := by
-    have h1 : Tendsto (fun n => F n z₀) atTop (𝓝 (g z₀)) := hconv.tendsto_at hz₀
-    rw [funext fun n => (hF n).map_base] at h1
-    exact tendsto_nhds_unique h1 tendsto_const_nhds
+  have hgd : DifferentiableOn ℂ g Ω :=
+    hconv.differentiableOn (hF.mono fun _ hn => hn.differentiableOn) hΩo
+  have hg₀ : g z₀ = 0 :=
+    tendsto_nhds_unique ((hconv.tendsto_at hz₀).congr' (hF.mono fun _ hn => hn.map_base))
+      tendsto_const_nhds
   have hle : ∀ z ∈ Ω, ‖g z‖ ≤ 1 := fun z hz =>
-    le_of_tendsto (hconv.tendsto_at hz).norm
-      (Eventually.of_forall fun n => (hF n).norm_le_one hz)
+    le_of_tendsto (hconv.tendsto_at hz).norm (hF.mono fun _ hn => hn.norm_le_one hz)
   refine ⟨hgd, mapsTo_ball_of_forall_norm_le_one hΩo hconn hgd hle hz₀ hg₀, ?_, hg₀⟩
-  rcases hurwitz_injOn hΩo hconn (Eventually.of_forall fun n => (hF n).differentiableOn) hconv
-    (Eventually.of_forall fun n => (hF n).injOn) with hinj | ⟨v, hv⟩
+  rcases hurwitz_injOn hΩo hconn (hF.mono fun _ hn => hn.differentiableOn) hconv
+    (hF.mono fun _ hn => hn.injOn) with hinj | ⟨v, hv⟩
   · exact hinj
   · exact absurd (deriv_eq_zero_of_forall_eq hΩo hz₀ hv) hderiv
 
@@ -222,16 +221,17 @@ theorem exists_isMaxOn_norm_deriv (hΩo : IsOpen Ω) (hconn : IsPreconnected Ω)
   choose F hF hFu using hu_mem
   have hb : IsLocallyBoundedOn F Ω :=
     isLocallyBoundedOn_of_forall_norm_le fun n z hz => (hF n).norm_le_one hz
-  obtain ⟨φ, g, hφ, hgd, hconv⟩ := montel hΩo (fun n => (hF n).differentiableOn) hb
+  obtain ⟨φ, g, hφ, -, hconv⟩ := montel hΩo (fun n => (hF n).differentiableOn) hb
   -- The derivatives converge locally uniformly, so the supremum is attained at the limit.
   have hMg : ‖deriv g z₀‖ =
       sSup ((fun f : ℂ → ℂ => ‖deriv f z₀‖) '' {f | IsPointedDiscInjectionOn f Ω z₀}) :=
     norm_deriv_eq_of_tendstoLocallyUniformlyOn hΩo hz₀
-      (fun n => (hF (φ n)).differentiableOn) hconv (hu_tendsto.comp hφ.tendsto_atTop)
-      fun n => hFu (φ n)
+      (Eventually.of_forall fun n => (hF (φ n)).differentiableOn) hconv
+      (hu_tendsto.comp hφ.tendsto_atTop) (Eventually.of_forall fun n => hFu (φ n))
   have hg : IsPointedDiscInjectionOn g Ω z₀ :=
-    isPointedDiscInjectionOn_of_tendstoLocallyUniformlyOn hΩo hconn hz₀ (fun n => hF (φ n)) hgd
-      hconv (by rw [← norm_ne_zero_iff, hMg]; exact hM₀.ne')
+    isPointedDiscInjectionOn_of_tendstoLocallyUniformlyOn hΩo hconn hz₀
+      (Eventually.of_forall fun n => hF (φ n)) hconv
+      (by rw [← norm_ne_zero_iff, hMg]; exact hM₀.ne')
   exact ⟨g, hg, fun f hf => hMg ▸ le_csSup hbdd ⟨f, hf, rfl⟩⟩
 
 /-- **The extremal problem has a solution on a simply connected proper subdomain.** This is the

--- a/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
@@ -156,6 +156,42 @@ private theorem mapsTo_ball_of_forall_norm_le_one (hΩo : IsOpen Ω) (hconn : Is
     simp only [Function.comp_def, hg₀, norm_zero] at hconst
     exact one_ne_zero (heq.symm.trans hconst.symm)
 
+/-- A locally uniform limit attains the limit of the derivative norms: differentiation preserves
+local uniform convergence, so `‖deriv g z₀‖` is the limit of the sequence `u` the family was
+chosen to approach. -/
+private theorem norm_deriv_eq_of_tendstoLocallyUniformlyOn (hΩo : IsOpen Ω) (hz₀ : z₀ ∈ Ω)
+    {F : ℕ → ℂ → ℂ} (hFd : ∀ n, DifferentiableOn ℂ (F n) Ω) {g : ℂ → ℂ} {M : ℝ} {u : ℕ → ℝ}
+    (hconv : TendstoLocallyUniformlyOn F g atTop Ω) (hu : Tendsto u atTop (𝓝 M))
+    (hFu : ∀ n, ‖deriv (F n) z₀‖ = u n) :
+    ‖deriv g z₀‖ = M := by
+  have hderiv : TendstoLocallyUniformlyOn (fun n => deriv (F n)) (deriv g) atTop Ω := by
+    have h := _root_.TendstoLocallyUniformlyOn.deriv hconv (Eventually.of_forall hFd) hΩo
+    simpa [Function.comp_def] using h
+  refine tendsto_nhds_unique (hderiv.tendsto_at hz₀).norm ?_
+  simpa [hFu] using hu
+
+/-- The family of pointed disc injections is closed under locally uniform limits, provided the
+limit's derivative at the base point does not vanish: that is exactly what excludes the constant
+alternative in Hurwitz's theorem. -/
+private theorem isPointedDiscInjectionOn_of_tendstoLocallyUniformlyOn (hΩo : IsOpen Ω)
+    (hconn : IsPreconnected Ω) (hz₀ : z₀ ∈ Ω) {F : ℕ → ℂ → ℂ}
+    (hF : ∀ n, IsPointedDiscInjectionOn (F n) Ω z₀) {g : ℂ → ℂ}
+    (hgd : DifferentiableOn ℂ g Ω) (hconv : TendstoLocallyUniformlyOn F g atTop Ω)
+    (hderiv : deriv g z₀ ≠ 0) :
+    IsPointedDiscInjectionOn g Ω z₀ := by
+  have hg₀ : g z₀ = 0 := by
+    have h1 : Tendsto (fun n => F n z₀) atTop (𝓝 (g z₀)) := hconv.tendsto_at hz₀
+    rw [funext fun n => (hF n).map_base] at h1
+    exact tendsto_nhds_unique h1 tendsto_const_nhds
+  have hle : ∀ z ∈ Ω, ‖g z‖ ≤ 1 := fun z hz =>
+    le_of_tendsto (hconv.tendsto_at hz).norm
+      (Eventually.of_forall fun n => (hF n).norm_le_one hz)
+  refine ⟨hgd, mapsTo_ball_of_forall_norm_le_one hΩo hconn hgd hle hz₀ hg₀, ?_, hg₀⟩
+  rcases hurwitz_injOn hΩo hconn (Eventually.of_forall fun n => (hF n).differentiableOn) hconv
+    (Eventually.of_forall fun n => (hF n).injOn) with hinj | ⟨v, hv⟩
+  · exact hinj
+  · exact absurd (deriv_eq_zero_of_forall_eq hΩo hz₀ hv) hderiv
+
 /-- **The extremal problem has a solution.** If the competing family at a base point `z₀` of an
 open preconnected set `Ω` is nonempty, then some member maximizes `‖deriv · z₀‖` over the whole
 family.
@@ -187,35 +223,16 @@ theorem exists_isMaxOn_norm_deriv (hΩo : IsOpen Ω) (hconn : IsPreconnected Ω)
   have hb : IsLocallyBoundedOn F Ω :=
     isLocallyBoundedOn_of_forall_norm_le fun n z hz => (hF n).norm_le_one hz
   obtain ⟨φ, g, hφ, hgd, hconv⟩ := montel hΩo (fun n => (hF n).differentiableOn) hb
-  -- The limit fixes the base point.
-  have hg₀ : g z₀ = 0 := by
-    have h1 : Tendsto (fun n => F (φ n) z₀) atTop (𝓝 (g z₀)) := hconv.tendsto_at hz₀
-    rw [funext fun n => (hF (φ n)).map_base] at h1
-    exact tendsto_nhds_unique h1 tendsto_const_nhds
-  -- The limit is bounded by `1`, hence lands in the open disc.
-  have hle : ∀ z ∈ Ω, ‖g z‖ ≤ 1 := fun z hz =>
-    le_of_tendsto (hconv.tendsto_at hz).norm
-      (Eventually.of_forall fun n => (hF (φ n)).norm_le_one hz)
-  have hgm : MapsTo g Ω (ball (0 : ℂ) 1) :=
-    mapsTo_ball_of_forall_norm_le_one hΩo hconn hgd hle hz₀ hg₀
   -- The derivatives converge locally uniformly, so the supremum is attained at the limit.
-  have hderiv : TendstoLocallyUniformlyOn (fun n => deriv (F (φ n))) (deriv g) atTop Ω := by
-    have h := _root_.TendstoLocallyUniformlyOn.deriv hconv
-      (Eventually.of_forall fun n => (hF (φ n)).differentiableOn) hΩo
-    simpa [Function.comp_def] using h
   have hMg : ‖deriv g z₀‖ =
-      sSup ((fun f : ℂ → ℂ => ‖deriv f z₀‖) '' {f | IsPointedDiscInjectionOn f Ω z₀}) := by
-    refine tendsto_nhds_unique (hderiv.tendsto_at hz₀).norm ?_
-    simpa [Function.comp_def, hFu] using hu_tendsto.comp hφ.tendsto_atTop
-  -- Injectivity survives by Hurwitz; the constant alternative is excluded by positivity.
-  have hgi : InjOn g Ω := by
-    rcases hurwitz_injOn hΩo hconn (Eventually.of_forall fun n => (hF (φ n)).differentiableOn)
-      hconv (Eventually.of_forall fun n => (hF (φ n)).injOn) with hinj | ⟨v, hv⟩
-    · exact hinj
-    · exfalso
-      rw [deriv_eq_zero_of_forall_eq hΩo hz₀ hv, norm_zero] at hMg
-      exact hM₀.ne hMg
-  exact ⟨g, ⟨hgd, hgm, hgi, hg₀⟩, fun f hf => hMg ▸ le_csSup hbdd ⟨f, hf, rfl⟩⟩
+      sSup ((fun f : ℂ → ℂ => ‖deriv f z₀‖) '' {f | IsPointedDiscInjectionOn f Ω z₀}) :=
+    norm_deriv_eq_of_tendstoLocallyUniformlyOn hΩo hz₀
+      (fun n => (hF (φ n)).differentiableOn) hconv (hu_tendsto.comp hφ.tendsto_atTop)
+      fun n => hFu (φ n)
+  have hg : IsPointedDiscInjectionOn g Ω z₀ :=
+    isPointedDiscInjectionOn_of_tendstoLocallyUniformlyOn hΩo hconn hz₀ (fun n => hF (φ n)) hgd
+      hconv (by rw [← norm_ne_zero_iff, hMg]; exact hM₀.ne')
+  exact ⟨g, hg, fun f hf => hMg ▸ le_csSup hbdd ⟨f, hf, rfl⟩⟩
 
 /-- **The extremal problem has a solution on a simply connected proper subdomain.** This is the
 form the Riemann mapping theorem uses: on a nonempty, simply connected, open, proper subset `Ω` of


### PR DESCRIPTION
`exists_isMaxOn_norm_deriv` ran to 45 lines because it did three things inline: build the
maximizing sequence and extract a locally uniform limit by Montel, verify that the limit is again
a pointed disc injection, and verify that it attains the supremum. Only the first is about *this*
extremal problem; the other two are facts about locally uniformly convergent sequences.

## The helpers

* `isPointedDiscInjectionOn_of_tendstoLocallyUniformlyOn` — the family is closed under locally
  uniform limits, provided the limit's derivative at `z₀` does not vanish. The limit fixes `z₀`
  and is bounded by `1`, hence maps into the open disc by the maximum principle; injectivity is
  Hurwitz, and the nonvanishing derivative is exactly what excludes Hurwitz's constant
  alternative. Stating it that way is what lets the caller supply the exclusion from `hM₀`
  rather than carrying the supremum into the lemma.

* `norm_deriv_eq_of_tendstoLocallyUniformlyOn` — differentiation preserves local uniform
  convergence, so if the derivative norms are a sequence `u` tending to `M`, the limit's
  derivative norm is `M`. It knows nothing about suprema or about the family; the caller
  instantiates `u` at the maximizing sequence.

Both are stated for an arbitrary sequence, so the caller passes the Montel subsequence
`fun n => F (φ n)` rather than the helpers knowing about extraction. Their sequence hypotheses
are `∀ᶠ n in atTop`, matching what `hurwitz_injOn` and `TendstoLocallyUniformlyOn.deriv` actually
consume, and the first derives `DifferentiableOn ℂ g Ω` from the sequence via
`TendstoLocallyUniformlyOn.differentiableOn` rather than taking it as a hypothesis — so `montel`'s
holomorphy component is no longer even bound in the caller.

## What is left

The extremal setup: bound the derivative norms, note the supremum is positive because `f₀`
contributes a nonzero value, take a maximizing sequence, apply Montel, then the two helpers.

```lean
have hMg : ‖deriv g z₀‖ = sSup ... :=
  norm_deriv_eq_of_tendstoLocallyUniformlyOn hΩo hz₀
    (fun n => (hF (φ n)).differentiableOn) hconv (hu_tendsto.comp hφ.tendsto_atTop)
    fun n => hFu (φ n)
have hg : IsPointedDiscInjectionOn g Ω z₀ :=
  isPointedDiscInjectionOn_of_tendstoLocallyUniformlyOn hΩo hconn hz₀ (fun n => hF (φ n)) hgd
    hconv (by rw [← norm_ne_zero_iff, hMg]; exact hM₀.ne')
exact ⟨g, hg, fun f hf => hMg ▸ le_csSup hbdd ⟨f, hf, rfl⟩⟩
```

## Scope

The statement and docstring of the public theorem are unchanged, and both helpers are `private`;
the entire diff is proof-internal.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all green;
no new lint violations. Proof body 45 → 26 lines, with helpers at 13 and 8.

Roadmap: ConformalMapping
