### PR TITLE
refactor(Fredholm): decompose the adjoint-range characterisation

### DIFF
--- a/TauCeti/Analysis/Fredholm/Adjoint.lean
+++ b/TauCeti/Analysis/Fredholm/Adjoint.lean
@@ -132,20 +132,18 @@ private theorem adjoint_bijective (e : E ≃L[𝕜] F) :
     refine ⟨B x, ?_⟩
     simp only [← ContinuousLinearMap.comp_apply, hAB, ContinuousLinearMap.id_apply]
 
-/-- The adjoint maps into the orthogonal complement of the kernel: `⟪x, T† y⟫ = ⟪T x, y⟫` vanishes
-for `x` in the kernel. -/
+/-- The adjoint maps into the orthogonal complement of the kernel. Mathlib's
+`ContinuousLinearMap.orthogonal_ker` identifies `(ker T)ᗮ` with the *closure* of the adjoint's
+range, and the range is contained in its closure. -/
 private theorem adjoint_mem_orthogonal_ker (T : E →L[𝕜] F) (y : F) :
     (T†) y ∈ (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ := by
-  rw [Submodule.mem_orthogonal]
-  intro x hx
-  have hx0 : T x = 0 := LinearMap.mem_ker.mp hx
-  rw [T.adjoint_inner_right, hx0]
-  simp
+  rw [T.orthogonal_ker]
+  exact Submodule.le_topologicalClosure _ (LinearMap.mem_range_self _ y)
 
 /-- The adjoint of `T`, restricted to the range of `T` and corestricted to `(ker T)ᗮ`, is
 surjective: it *is* the adjoint of the isomorphism `(ker T)ᗮ ≃L range T`, and the adjoint of an
 isomorphism is bijective. -/
-private theorem surjective_codRestrict_domRestrict_adjoint (T : E →L[𝕜] F)
+private theorem codRestrict_domRestrict_adjoint_surjective (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) :
     Function.Surjective
       (((T†).domRestrict (LinearMap.range (T : E →ₗ[𝕜] F))).codRestrict
@@ -155,14 +153,19 @@ private theorem surjective_codRestrict_domRestrict_adjoint (T : E →L[𝕜] F)
   set e : Kᗮ ≃L[𝕜] R := orthogonalKerEquivRange T hT with he
   have he_apply (x : Kᗮ) : (e x : F) = T (x : E) := by
     simpa only [he] using orthogonalKerEquivRange_apply T hT x
+  -- Peeling both restriction wrappers off the corestricted adjoint, once and by name.
+  have hcoe (y : R) :
+      ((((T†).domRestrict R).codRestrict Kᗮ (fun y => adjoint_mem_orthogonal_ker T y)) y : E)
+        = (T†) (y : F) :=
+    (ContinuousLinearMap.coe_codRestrict_apply _ _ _ y).trans
+      (congrFun (ContinuousLinearMap.coe_domRestrict (T†) R) y)
   have hB : ((T†).domRestrict R).codRestrict Kᗮ (fun y => adjoint_mem_orthogonal_ker T y)
       = ((e : Kᗮ →L[𝕜] R)†) := by
     refine ContinuousLinearMap.ext fun y => ext_inner_left 𝕜 fun x => ?_
     calc
       inner 𝕜 x (((T†).domRestrict R).codRestrict Kᗮ (fun y => adjoint_mem_orthogonal_ker T y) y)
           = inner 𝕜 (x : E) ((T†) (y : F)) := by
-        rw [Submodule.coe_inner]
-        rfl
+        rw [Submodule.coe_inner, hcoe]
       _ = inner 𝕜 (T (x : E)) (y : F) := T.adjoint_inner_right x y
       _ = inner 𝕜 ((e x : R) : F) (y : F) := by rw [he_apply]
       _ = inner 𝕜 (e x) y := (Submodule.coe_inner R (e x) y).symm
@@ -180,7 +183,7 @@ theorem range_adjoint_eq_orthogonal_ker_of_isClosed_range (T : E →L[𝕜] F)
   refine le_antisymm ?_ fun x hx => ?_
   · rintro _ ⟨y, rfl⟩
     exact adjoint_mem_orthogonal_ker T y
-  · obtain ⟨y, hy⟩ := surjective_codRestrict_domRestrict_adjoint T hT ⟨x, hx⟩
+  · obtain ⟨y, hy⟩ := codRestrict_domRestrict_adjoint_surjective T hT ⟨x, hx⟩
     exact ⟨(y : F), congr_arg Subtype.val hy⟩
 
 /-- If a continuous linear map between Hilbert spaces has closed range, then so does its

--- a/TauCeti/Analysis/Fredholm/Adjoint.lean
+++ b/TauCeti/Analysis/Fredholm/Adjoint.lean
@@ -132,54 +132,56 @@ private theorem adjoint_bijective (e : E ≃L[𝕜] F) :
     refine ⟨B x, ?_⟩
     simp only [← ContinuousLinearMap.comp_apply, hAB, ContinuousLinearMap.id_apply]
 
+/-- The adjoint maps into the orthogonal complement of the kernel: `⟪x, T† y⟫ = ⟪T x, y⟫` vanishes
+for `x` in the kernel. -/
+private theorem adjoint_mem_orthogonal_ker (T : E →L[𝕜] F) (y : F) :
+    (T†) y ∈ (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ := by
+  rw [Submodule.mem_orthogonal]
+  intro x hx
+  have hx0 : T x = 0 := LinearMap.mem_ker.mp hx
+  rw [T.adjoint_inner_right, hx0]
+  simp
+
+/-- The adjoint of `T`, restricted to the range of `T` and corestricted to `(ker T)ᗮ`, is
+surjective: it *is* the adjoint of the isomorphism `(ker T)ᗮ ≃L range T`, and the adjoint of an
+isomorphism is bijective. -/
+private theorem surjective_codRestrict_domRestrict_adjoint (T : E →L[𝕜] F)
+    (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) :
+    Function.Surjective
+      (((T†).domRestrict (LinearMap.range (T : E →ₗ[𝕜] F))).codRestrict
+        (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ fun y => adjoint_mem_orthogonal_ker T y) := by
+  set K := LinearMap.ker (T : E →ₗ[𝕜] F) with hK
+  set R := LinearMap.range (T : E →ₗ[𝕜] F) with hR
+  set e : Kᗮ ≃L[𝕜] R := orthogonalKerEquivRange T hT with he
+  have he_apply (x : Kᗮ) : (e x : F) = T (x : E) := by
+    simpa only [he] using orthogonalKerEquivRange_apply T hT x
+  have hB : ((T†).domRestrict R).codRestrict Kᗮ (fun y => adjoint_mem_orthogonal_ker T y)
+      = ((e : Kᗮ →L[𝕜] R)†) := by
+    refine ContinuousLinearMap.ext fun y => ext_inner_left 𝕜 fun x => ?_
+    calc
+      inner 𝕜 x (((T†).domRestrict R).codRestrict Kᗮ (fun y => adjoint_mem_orthogonal_ker T y) y)
+          = inner 𝕜 (x : E) ((T†) (y : F)) := by
+        rw [Submodule.coe_inner]
+        rfl
+      _ = inner 𝕜 (T (x : E)) (y : F) := T.adjoint_inner_right x y
+      _ = inner 𝕜 ((e x : R) : F) (y : F) := by rw [he_apply]
+      _ = inner 𝕜 (e x) y := (Submodule.coe_inner R (e x) y).symm
+      _ = inner 𝕜 x (((e : Kᗮ →L[𝕜] R)†) y) :=
+        (ContinuousLinearMap.adjoint_inner_right (e : Kᗮ →L[𝕜] R) x y).symm
+  rw [hB]
+  exact (adjoint_bijective e).2
+
 /-- A continuous linear map with closed range has adjoint range equal to the orthogonal
 complement of its kernel. -/
 theorem range_adjoint_eq_orthogonal_ker_of_isClosed_range (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) :
     LinearMap.range (T† : F →ₗ[𝕜] E) =
       (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ := by
-  let K := LinearMap.ker (T : E →ₗ[𝕜] F)
-  let R := LinearMap.range (T : E →ₗ[𝕜] F)
-  let e : Kᗮ ≃L[𝕜] R := orthogonalKerEquivRange T hT
-  have he_apply (x : Kᗮ) : (e x : F) = T (x : E) := by
-    simpa only [e] using orthogonalKerEquivRange_apply T hT x
-  have hadj_mem (y : F) : (T†) y ∈ Kᗮ := by
-    rw [Submodule.mem_orthogonal]
-    intro x hx
-    have hx0 : T x = 0 := LinearMap.mem_ker.mp (by simpa [K] using hx)
-    rw [T.adjoint_inner_right, hx0]
-    simp
-  let B : R →L[𝕜] Kᗮ :=
-    ((T†).domRestrict R).codRestrict Kᗮ fun y => hadj_mem y
-  have hB : B = ((e : Kᗮ →L[𝕜] R)†) := by
-    apply ContinuousLinearMap.ext
-    intro y
-    refine ext_inner_left 𝕜 fun x => ?_
-    calc
-      inner 𝕜 x (B y) = inner 𝕜 (x : E) ((T†) (y : F)) := by
-        rw [Submodule.coe_inner]
-        -- `B` hides both restriction wrappers, so expose them in order before applying their
-        -- explicit coercion lemmas.
-        rw [show (B y : E) = ((T†).domRestrict R) y by
-          exact ContinuousLinearMap.coe_codRestrict_apply _ _ _ y]
-        rw [show ((T†).domRestrict R) y = (T†) (y : F) by
-          exact congrFun (ContinuousLinearMap.coe_domRestrict (T†) R) y]
-      _ = inner 𝕜 (T (x : E)) (y : F) := T.adjoint_inner_right x y
-      _ = inner 𝕜 ((e x : R) : F) (y : F) := by
-        rw [he_apply]
-      _ = inner 𝕜 (e x) y := (Submodule.coe_inner R (e x) y).symm
-      _ = inner 𝕜 x (((e : Kᗮ →L[𝕜] R)†) y) :=
-        (ContinuousLinearMap.adjoint_inner_right (e : Kᗮ →L[𝕜] R) x y).symm
-  have hB_surjective : Function.Surjective B := by
-    rw [hB]
-    exact (adjoint_bijective e).2
-  apply le_antisymm
+  refine le_antisymm ?_ fun x hx => ?_
   · rintro _ ⟨y, rfl⟩
-    exact hadj_mem y
-  · intro x hx
-    obtain ⟨y, hy⟩ := hB_surjective ⟨x, hx⟩
-    refine ⟨(y : F), ?_⟩
-    exact congr_arg Subtype.val hy
+    exact adjoint_mem_orthogonal_ker T y
+  · obtain ⟨y, hy⟩ := surjective_codRestrict_domRestrict_adjoint T hT ⟨x, hx⟩
+    exact ⟨(y : F), congr_arg Subtype.val hy⟩
 
 /-- If a continuous linear map between Hilbert spaces has closed range, then so does its
 adjoint. -/

--- a/TauCeti/Analysis/Fredholm/Adjoint.lean
+++ b/TauCeti/Analysis/Fredholm/Adjoint.lean
@@ -160,17 +160,10 @@ private theorem codRestrict_domRestrict_adjoint_surjective (T : E →L[𝕜] F)
     (ContinuousLinearMap.coe_codRestrict_apply _ _ _ y).trans
       (congrFun (ContinuousLinearMap.coe_domRestrict (T†) R) y)
   have hB : ((T†).domRestrict R).codRestrict Kᗮ (fun y => adjoint_mem_orthogonal_ker T y)
-      = ((e : Kᗮ →L[𝕜] R)†) := by
-    refine ContinuousLinearMap.ext fun y => ext_inner_left 𝕜 fun x => ?_
-    calc
-      inner 𝕜 x (((T†).domRestrict R).codRestrict Kᗮ (fun y => adjoint_mem_orthogonal_ker T y) y)
-          = inner 𝕜 (x : E) ((T†) (y : F)) := by
-        rw [Submodule.coe_inner, hcoe]
-      _ = inner 𝕜 (T (x : E)) (y : F) := T.adjoint_inner_right x y
-      _ = inner 𝕜 ((e x : R) : F) (y : F) := by rw [he_apply]
-      _ = inner 𝕜 (e x) y := (Submodule.coe_inner R (e x) y).symm
-      _ = inner 𝕜 x (((e : Kᗮ →L[𝕜] R)†) y) :=
-        (ContinuousLinearMap.adjoint_inner_right (e : Kᗮ →L[𝕜] R) x y).symm
+      = ((e : Kᗮ →L[𝕜] R)†) :=
+    (ContinuousLinearMap.eq_adjoint_iff _ _).2 fun y x => by
+      rw [Submodule.coe_inner, hcoe, Submodule.coe_inner, T.adjoint_inner_left,
+        ContinuousLinearEquiv.coe_coe, he_apply]
   rw [hB]
   exact (adjoint_bijective e).2
 


### PR DESCRIPTION
`range_adjoint_eq_orthogonal_ker_of_isClosed_range` ran to 43 lines because it proved both
inclusions of the set equality inline, and the harder one carried a twenty-line inner-product
calculation. The two inclusions have nothing in common — one is a one-line consequence of
`adjoint_inner_right`, the other is the whole content — so they are now separate lemmas.

## The helpers

* `adjoint_mem_orthogonal_ker` — the adjoint maps into `(ker T)ᗮ`. This is Mathlib's
  `ContinuousLinearMap.orthogonal_ker`, which identifies `(ker T)ᗮ` with the *closure* of the
  adjoint's range, plus `Submodule.le_topologicalClosure`. No closed-range hypothesis and no
  equivalence. This is the `≤` inclusion on its own. (Mathlib stops at the closure; the
  closed-range statement this file proves is not there.)

* `codRestrict_domRestrict_adjoint_surjective` — the `≥` inclusion. The adjoint restricted to
  `range T` and corestricted to `(ker T)ᗮ` **is** the adjoint of the isomorphism
  `orthogonalKerEquivRange T hT : (ker T)ᗮ ≃L range T`, verified by comparing inner products, and
  the adjoint of an isomorphism is bijective (`adjoint_bijective`). Stating the conclusion as
  surjectivity rather than as the operator identity is what keeps the caller free of a `▸` on a
  dependently-typed equation.

## What is left

```lean
refine le_antisymm ?_ fun x hx => ?_
· rintro _ ⟨y, rfl⟩
  exact adjoint_mem_orthogonal_ker T y
· obtain ⟨y, hy⟩ := surjective_codRestrict_domRestrict_adjoint T hT ⟨x, hx⟩
  exact ⟨(y : F), congr_arg Subtype.val hy⟩
```

The wrapper-peeling step the original did with a two-step `rw [show (B y : E) = … ]` dance is now
a named `hcoe`, stating the coercion equality once via `coe_codRestrict_apply` and
`coe_domRestrict`. Writing the wrappers out in the helper's statement makes that step
definitional, but a bare `rfl` there would depend on their unfoldings, so it is spelled out.

## Scope

The statement and docstring of the public theorem are unchanged, and both helpers are `private`;
the entire diff is proof-internal.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all green;
no new lint violations. Proof body 43 → 6 lines, with helpers at 3 and 26.

Roadmap: HeegaardFloer
