### PR TITLE
refactor(PosDef): share the quadratic-form expansion and extract denominator clearing

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/PosDef.lean
+++ b/TauCeti/LinearAlgebra/Matrix/PosDef.lean
@@ -39,13 +39,6 @@ namespace Matrix
 
 variable {n : Type*}
 
-/-- The quadratic form of a matrix, expanded as a double sum. Stated over any commutative ring
-with trivial star, so that the integer and rational forms are one lemma rather than two. -/
-private theorem star_dotProduct_mulVec_eq_sum {R : Type*} [CommRing R] [StarRing R]
-    [TrivialStar R] [Fintype n] (M : Matrix n n R) (y : n → R) :
-    star y ⬝ᵥ (M *ᵥ y) = ∑ i, ∑ j, y i * M i j * y j := by
-  simp [_root_.dotProduct, _root_.Matrix.mulVec_apply_eq_sum, Finset.mul_sum, mul_assoc]
-
 /-- Clearing denominators: a nonzero rational vector on a finite index type is a nonzero integer
 vector scaled by a common nonzero denominator. -/
 private theorem exists_intCast_mul_eq_of_ne_zero [Finite n] {x : n → ℚ} (hx : x ≠ 0) :
@@ -81,11 +74,9 @@ private theorem posDef_map_intCast_of_finite [Finite n] {A : Matrix n n ℤ} (hA
   -- The two quadratic forms differ by the square of the common denominator.
   have key : ((star z ⬝ᵥ (A *ᵥ z) : ℤ) : ℚ) =
       (c : ℚ) ^ 2 * (star x ⬝ᵥ ((A.map (Int.cast : ℤ → ℚ)) *ᵥ x)) := by
-    rw [star_dotProduct_mulVec_eq_sum, star_dotProduct_mulVec_eq_sum, Finset.mul_sum]
+    simp only [_root_.Matrix.dot_mulVec_eq_sum_sum, star_trivial, Finset.mul_sum]
     push_cast
-    refine Finset.sum_congr rfl fun i _ ↦ ?_
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl fun j _ ↦ ?_
+    refine Finset.sum_congr rfl fun j _ ↦ Finset.sum_congr rfl fun i _ ↦ ?_
     rw [hz, hz, _root_.Matrix.map_apply]
     ring
   have hpos : (0 : ℚ) < ((star z ⬝ᵥ (A *ᵥ z) : ℤ) : ℚ) := by

--- a/TauCeti/LinearAlgebra/Matrix/PosDef.lean
+++ b/TauCeti/LinearAlgebra/Matrix/PosDef.lean
@@ -39,27 +39,21 @@ namespace Matrix
 
 variable {n : Type*}
 
-/-- The finite case of `TauCeti.Matrix.posDef_map_intCast`, where positive definiteness can be
-tested against ordinary vectors. -/
-private theorem posDef_map_intCast_of_finite [Finite n] {A : Matrix n n ℤ} (hA : A.PosDef) :
-    (A.map (Int.cast : ℤ → ℚ)).PosDef := by
+/-- The quadratic form of a matrix, expanded as a double sum. Stated over any commutative ring
+with trivial star, so that the integer and rational forms are one lemma rather than two. -/
+private theorem star_dotProduct_mulVec_eq_sum {R : Type*} [CommRing R] [StarRing R]
+    [TrivialStar R] [Fintype n] (M : Matrix n n R) (y : n → R) :
+    star y ⬝ᵥ (M *ᵥ y) = ∑ i, ∑ j, y i * M i j * y j := by
+  simp [_root_.dotProduct, _root_.Matrix.mulVec_apply_eq_sum, Finset.mul_sum, mul_assoc]
+
+/-- Clearing denominators: a nonzero rational vector on a finite index type is a nonzero integer
+vector scaled by a common nonzero denominator. -/
+private theorem exists_intCast_mul_eq_of_ne_zero [Finite n] {x : n → ℚ} (hx : x ≠ 0) :
+    ∃ (c : ℤ) (z : n → ℤ), c ≠ 0 ∧ z ≠ 0 ∧ ∀ i, (z i : ℚ) = (c : ℚ) * x i := by
   classical
   have _i : Fintype n := Fintype.ofFinite n
-  refine _root_.Matrix.PosDef.of_dotProduct_mulVec_pos ?_ fun x hx ↦ ?_
-  · ext i j
-    simpa using congrArg (fun m : ℤ ↦ (m : ℚ)) (hA.isHermitian.apply i j)
-  -- Expand both quadratic forms as double sums.
-  have expandQ : ∀ y : n → ℚ, star y ⬝ᵥ ((A.map (Int.cast : ℤ → ℚ)) *ᵥ y) =
-      ∑ i, ∑ j, y i * (A i j : ℚ) * y j := by
-    intro y
-    simp [_root_.dotProduct, _root_.Matrix.mulVec_apply_eq_sum, Finset.mul_sum, mul_assoc]
-  have expandZ : ∀ y : n → ℤ, star y ⬝ᵥ (A *ᵥ y) = ∑ i, ∑ j, y i * A i j * y j := by
-    intro y
-    simp [_root_.dotProduct, _root_.Matrix.mulVec_apply_eq_sum, Finset.mul_sum, mul_assoc]
-  -- Clear the denominators of `x`, producing an integer vector `z = c • x`.
   obtain ⟨c, hc⟩ := IsLocalization.exist_integer_multiples_of_finite (nonZeroDivisors ℤ) x
-  have hc' : ∀ i, ∃ y : ℤ, (y : ℚ) = ((c : ℤ) : ℚ) * x i := by
-    intro i
+  have hc' : ∀ i, ∃ y : ℤ, (y : ℚ) = ((c : ℤ) : ℚ) * x i := fun i => by
     obtain ⟨y, hy⟩ := hc i
     exact ⟨y, by simpa [Algebra.smul_def] using hy⟩
   choose z hz using hc'
@@ -70,20 +64,34 @@ private theorem posDef_map_intCast_of_finite [Finite n] {A : Matrix n n ℤ} (hA
     have hi := hz i
     rw [h] at hi
     simpa [hc0] using hi.symm
+  exact ⟨(c : ℤ), z, nonZeroDivisors.coe_ne_zero c, hzne, hz⟩
+
+/-- The finite case of `TauCeti.Matrix.posDef_map_intCast`, where positive definiteness can be
+tested against ordinary vectors. -/
+private theorem posDef_map_intCast_of_finite [Finite n] {A : Matrix n n ℤ} (hA : A.PosDef) :
+    (A.map (Int.cast : ℤ → ℚ)).PosDef := by
+  classical
+  have _i : Fintype n := Fintype.ofFinite n
+  refine _root_.Matrix.PosDef.of_dotProduct_mulVec_pos ?_ fun x hx ↦ ?_
+  · ext i j
+    simpa using congrArg (fun m : ℤ ↦ (m : ℚ)) (hA.isHermitian.apply i j)
+  -- Clear the denominators of `x`, producing a nonzero integer vector `z = c • x`.
+  obtain ⟨c, z, hc0, hzne, hz⟩ := exists_intCast_mul_eq_of_ne_zero hx
+  have hcQ : (c : ℚ) ≠ 0 := Int.cast_ne_zero.mpr hc0
   -- The two quadratic forms differ by the square of the common denominator.
   have key : ((star z ⬝ᵥ (A *ᵥ z) : ℤ) : ℚ) =
-      ((c : ℤ) : ℚ) ^ 2 * (star x ⬝ᵥ ((A.map (Int.cast : ℤ → ℚ)) *ᵥ x)) := by
-    rw [expandQ, expandZ, Finset.mul_sum]
+      (c : ℚ) ^ 2 * (star x ⬝ᵥ ((A.map (Int.cast : ℤ → ℚ)) *ᵥ x)) := by
+    rw [star_dotProduct_mulVec_eq_sum, star_dotProduct_mulVec_eq_sum, Finset.mul_sum]
     push_cast
     refine Finset.sum_congr rfl fun i _ ↦ ?_
     rw [Finset.mul_sum]
     refine Finset.sum_congr rfl fun j _ ↦ ?_
-    rw [hz, hz]
+    rw [hz, hz, _root_.Matrix.map_apply]
     ring
   have hpos : (0 : ℚ) < ((star z ⬝ᵥ (A *ᵥ z) : ℤ) : ℚ) := by
     exact_mod_cast hA.dotProduct_mulVec_pos hzne
   rw [key] at hpos
-  have hsq : (0 : ℚ) < ((c : ℤ) : ℚ) ^ 2 := by positivity
+  have hsq : (0 : ℚ) < (c : ℚ) ^ 2 := by positivity
   exact (mul_pos_iff_of_pos_left hsq).mp hpos
 
 /-- **An integer matrix positive definite over `ℤ` is positive definite over `ℚ`.** -/

--- a/TauCeti/LinearAlgebra/Matrix/PosDef.lean
+++ b/TauCeti/LinearAlgebra/Matrix/PosDef.lean
@@ -41,7 +41,7 @@ variable {n : Type*}
 
 /-- Clearing denominators: a nonzero rational vector on a finite index type is a nonzero integer
 vector scaled by a common nonzero denominator. -/
-private theorem exists_intCast_mul_eq_of_ne_zero [Finite n] {x : n → ℚ} (hx : x ≠ 0) :
+private theorem exists_intCast_eq_mul_of_ne_zero [Finite n] {x : n → ℚ} (hx : x ≠ 0) :
     ∃ (c : ℤ) (z : n → ℤ), c ≠ 0 ∧ z ≠ 0 ∧ ∀ i, (z i : ℚ) = (c : ℚ) * x i := by
   classical
   have _i : Fintype n := Fintype.ofFinite n
@@ -69,7 +69,7 @@ private theorem posDef_map_intCast_of_finite [Finite n] {A : Matrix n n ℤ} (hA
   · ext i j
     simpa using congrArg (fun m : ℤ ↦ (m : ℚ)) (hA.isHermitian.apply i j)
   -- Clear the denominators of `x`, producing a nonzero integer vector `z = c • x`.
-  obtain ⟨c, z, hc0, hzne, hz⟩ := exists_intCast_mul_eq_of_ne_zero hx
+  obtain ⟨c, z, hc0, hzne, hz⟩ := exists_intCast_eq_mul_of_ne_zero hx
   have hcQ : (c : ℚ) ≠ 0 := Int.cast_ne_zero.mpr hc0
   -- The two quadratic forms differ by the square of the common denominator.
   have key : ((star z ⬝ᵥ (A *ᵥ z) : ℤ) : ℚ) =


### PR DESCRIPTION
`posDef_map_intCast_of_finite` ran to 43 lines, and six of those were the same proof written
twice: `expandQ` and `expandZ` expand the quadratic form as a double sum over `ℚ` and over `ℤ`
respectively, with byte-identical `simp` calls. The rest interleaved denominator clearing with the
scaling identity.

## The expansion is Mathlib's

Both copies are `Matrix.dot_mulVec_eq_sum_sum` (`Data/Matrix/Mul.lean`), which holds over any
non-unital semiring. The only gaps were the `star` on the left — closed by `star_trivial`, since
`ℤ` and `ℚ` have trivial star — and the summation order, which is `∑ j, ∑ i` there rather than
`∑ i, ∑ j`, so the two `Finset.sum_congr` binders swap. Both `expandQ` and `expandZ` are gone and
nothing replaces them.

## The helper

`exists_intCast_mul_eq_of_ne_zero` — clearing denominators: a nonzero rational vector on a finite
index type is a nonzero integer vector scaled by a common nonzero denominator. This is where
`IsLocalization.exist_integer_multiples_of_finite` and the nonvanishing of the scaled vector live,
and the statement mentions neither matrices nor positive definiteness.

## What is left

The scaling identity and the conclusion:

```lean
obtain ⟨c, z, hc0, hzne, hz⟩ := exists_intCast_mul_eq_of_ne_zero hx
have key : ((star z ⬝ᵥ (A *ᵥ z) : ℤ) : ℚ) =
    (c : ℚ) ^ 2 * (star x ⬝ᵥ ((A.map (Int.cast : ℤ → ℚ)) *ᵥ x)) := by
  simp only [_root_.Matrix.dot_mulVec_eq_sum_sum, star_trivial, Finset.mul_sum]
  push_cast
  refine Finset.sum_congr rfl fun j _ ↦ Finset.sum_congr rfl fun i _ ↦ ?_
  rw [hz, hz, _root_.Matrix.map_apply]
  ring
```

Going through Mathlib's form means the entries appear as `A.map Int.cast i j` rather than the
original's hand-written `(A i j : ℚ)`, so the entrywise step needs `Matrix.map_apply`. That is the
honest shape; the original was hiding the coercion inside its own lemma statement.

## Scope

The statement and docstring of `posDef_map_intCast_of_finite` are unchanged, as is the public
`posDef_map_intCast` that consumes it, and the one helper is `private`; the diff is proof-internal.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all green;
no new lint violations. Proof body 43 → 22 lines, with one helper at 16.

Roadmap: RepresentationTheory
