### PR TITLE
feat: a binary quadratic form nonnegative on one line has nonpositive discriminant

### DIFF
--- a/TauCeti/Algebra/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/QuadraticDiscriminant.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.QuadraticDiscriminant
+import Mathlib.Algebra.Order.Ring.Abs
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Ring
+
+/-!
+# Non-negativity of a binary quadratic form and its discriminant
+
+Mathlib's `discrim_le_zero` shows that a quadratic *polynomial* over a linearly ordered field
+which is non-negative at every point of the field has non-positive discriminant. This file
+supplies two facts about the homogeneous two-variable form `a * x ^ 2 + b * x * y + c * y ^ 2`
+that `discrim_le_zero` does not give.
+
+* `nonneg_of_discrim_le_zero` is the reverse implication, over a linearly ordered commutative
+  ring rather than a field: a positive leading coefficient together with a non-positive
+  discriminant makes the form non-negative. The proof is the completed square
+  `4a·Q = (2ax + by)² + (4ac − b²)y²`, which uses no division, so `Field` is not needed.
+* `Int.discrim_le_zero_of_nonneg_of_lt_abs` runs the other way over `ℤ`, and needs far less
+  than non-negativity everywhere: it is enough to test the form along a **single** line
+  `y = y₀`, provided `|y₀|` exceeds the leading coefficient. Integrality is what makes so weak
+  a hypothesis sufficient — over `ℚ` or `ℝ` one line says nothing about the discriminant.
+
+Together the two give the upgrade that motivates the file: a form known to be non-negative only
+on some sparse set of `(x, y)` — for instance the sublattice where a fixed prime does not divide
+`y`, which is all that the degree form on an elliptic curve is directly known to satisfy — is
+non-negative on all of `ℤ ⨯ ℤ`. Any single `y₀` from that set with `|y₀|` large enough feeds
+`Int.discrim_le_zero_of_nonneg_of_lt_abs`, and `nonneg_of_discrim_le_zero` then propagates the
+conclusion to every `(x, y)`.
+
+## Main results
+
+* `Int.exists_two_mul_abs_sub_mul_le`: every integer lies within `m / 2` of a multiple of `m`.
+* `nonneg_of_discrim_le_zero`: `0 < a` and `discrim a b c ≤ 0` give `0 ≤ a x² + b x y + c y²`.
+* `Int.discrim_le_zero_of_nonneg_of_lt_abs`: for `0 < a` and `a < |y|`, non-negativity of
+  `a x² + b x y + c y²` in `x` alone forces `discrim a b c ≤ 0`.
+* `Int.discrim_le_zero_of_nonneg_of_not_dvd`: the same conclusion from non-negativity on the
+  sublattice complement `{(x, y) : d ∤ y}`, for any `d` with `1 < |d|`.
+
+## References
+
+* Silverman, *The Arithmetic of Elliptic Curves*, V.1.1, where positivity of the degree form on
+  a rank-two lattice is turned into the Hasse inequality by exactly this discriminant argument.
+-/
+
+public section
+
+/-- **Nearest multiple.** For a positive modulus `m`, every integer `a` lies within `m / 2` of a
+multiple of `m`, stated division-free as `2 * |a - m * r| ≤ m`. -/
+theorem Int.exists_two_mul_abs_sub_mul_le {m : ℤ} (hm : 0 < m) (a : ℤ) :
+    ∃ r : ℤ, 2 * |a - m * r| ≤ m := by
+  have hm2 : (0 : ℤ) < 2 * m := by linarith
+  refine ⟨(2 * a + m) / (2 * m), ?_⟩
+  have h0 : 0 ≤ (2 * a + m) % (2 * m) := Int.emod_nonneg _ (ne_of_gt hm2)
+  have h1 : (2 * a + m) % (2 * m) < 2 * m := Int.emod_lt_of_pos _ hm2
+  have hd : (2 * a + m) % (2 * m) + 2 * m * ((2 * a + m) / (2 * m)) = 2 * a + m :=
+    Int.emod_add_mul_ediv (2 * a + m) (2 * m)
+  have habs : 2 * |a - m * ((2 * a + m) / (2 * m))|
+      = |2 * (a - m * ((2 * a + m) / (2 * m)))| := by
+    rw [abs_mul]; norm_num
+  rw [habs, abs_le]
+  constructor <;> linarith
+
+/-- A binary quadratic form with positive leading coefficient and non-positive discriminant is
+non-negative. This is the implication opposite to Mathlib's `discrim_le_zero`, stated for the
+homogeneous two-variable form; the completed square `4a·Q = (2ax + by)² + (4ac − b²)y²` uses no
+division, so a linearly ordered commutative ring suffices in place of a field. -/
+theorem nonneg_of_discrim_le_zero {R : Type*} [CommRing R] [LinearOrder R]
+    [IsStrictOrderedRing R] {a b c : R} (ha : 0 < a) (hd : discrim a b c ≤ 0) (x y : R) :
+    0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2 := by
+  have hb : 0 ≤ 4 * a * c - b ^ 2 := by rw [discrim] at hd; linarith
+  nlinarith [sq_nonneg (2 * a * x + b * y), mul_nonneg hb (sq_nonneg y)]
+
+/-- **One line of large enough height already pins the discriminant.** If a binary quadratic
+form over `ℤ` with positive leading coefficient `a` is non-negative at `(x, y)` for a *fixed*
+`y` with `a < |y|` and every `x`, then its discriminant is non-positive, `b ^ 2 ≤ 4 * a * c`.
+
+Testing one line is enough only because the variable `x` ranges over `ℤ` and not over a field:
+the argument picks the integer `x` nearest to the minimum of `x ↦ a x² + b x y + c y²`, where
+the completed square `4a·Q = (2ax + by)² + (4ac − b²)y²` has `(2ax + by)² ≤ a ^ 2`, so a positive
+discriminant would give `4a·Q ≤ a ^ 2 - y ^ 2 < 0`. Over `ℚ` or `ℝ` the nearest point is the
+exact minimum and a single line carries no information about the discriminant at all.
+
+Consequently a form known to be non-negative only on `{(x, y) : ¬ d ∣ y}`, for some fixed `d`,
+still has non-positive discriminant: any single `y` avoiding `d` with `a < |y|` — such as
+`y = a * d ^ 2 + 1` when `1 < |d|` — may be used here. -/
+theorem Int.discrim_le_zero_of_nonneg_of_lt_abs {a b c y : ℤ} (ha : 0 < a) (hy : a < |y|)
+    (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
+  by_contra! hcon
+  rw [discrim] at hcon
+  -- Pick `x` nearest to the minimum of the form along the line, so that `|2ax + by| ≤ a`.
+  obtain ⟨x, hx⟩ := Int.exists_two_mul_abs_sub_mul_le (by linarith : (0 : ℤ) < 2 * a) (-(b * y))
+  have hxa : |2 * a * x + b * y| ≤ a := by
+    rw [show 2 * a * x + b * y = -(-(b * y) - 2 * a * x) by ring, abs_neg]
+    linarith [hx]
+  have hsq : (2 * a * x + b * y) ^ 2 ≤ a ^ 2 := by
+    have habs := abs_le.mp hxa
+    nlinarith [habs.1, habs.2]
+  -- `a < |y|` makes the `(4ac − b²)y²` term outweigh it, so the form is negative at `(x, y)`.
+  have hy2 : a ^ 2 < y ^ 2 := by
+    have := abs_nonneg y
+    nlinarith [sq_abs y]
+  have hkey : 4 * a * (a * x ^ 2 + b * x * y + c * y ^ 2)
+      = (2 * a * x + b * y) ^ 2 + (4 * a * c - b ^ 2) * y ^ 2 := by ring
+  nlinarith [h x, hsq, hy2, hkey]
+
+/-- **A sublattice already pins the discriminant.** If a binary quadratic form over `ℤ` with
+positive leading coefficient is non-negative at every `(x, y)` whose second coordinate avoids
+the multiples of some `d` with `1 < |d|` — in the intended application `d` is a prime, and the
+locus is the sublattice complement `{(x, y) : d ∤ y}` — then its discriminant is non-positive.
+
+This is `Int.discrim_le_zero_of_nonneg_of_lt_abs` fed the witness `y = a * d ^ 2 + 1`, which
+avoids `d` and is larger than `a`. It does **not** follow from Mathlib's `discrim_le_zero`,
+whose hypothesis is non-negativity at every point of a field. -/
+theorem Int.discrim_le_zero_of_nonneg_of_not_dvd {a b c d : ℤ} (ha : 0 < a) (hd : 1 < |d|)
+    (h : ∀ x y : ℤ, ¬ d ∣ y → 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
+  have hnd : ¬ d ∣ a * d ^ 2 + 1 := fun hc => by
+    have hd1 : d ∣ (1 : ℤ) := (dvd_add_right (Dvd.intro (a * d) (by ring))).mp hc
+    exact absurd (Int.le_of_dvd one_pos ((abs_dvd d 1).mpr hd1)) (by omega)
+  refine Int.discrim_le_zero_of_nonneg_of_lt_abs ha (y := a * d ^ 2 + 1) ?_ fun x => h x _ hnd
+  have hd2 : 1 ≤ d ^ 2 := by nlinarith [sq_abs d, abs_nonneg d]
+  rw [abs_of_pos (by nlinarith)]
+  nlinarith

--- a/TauCeti/Algebra/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/QuadraticDiscriminant.lean
@@ -21,7 +21,7 @@ substantial. Over a *field*, non-negativity along a single line `y = y₀ ≠ 0`
 resulting `y₀ ^ 2 * discrim a b c ≤ 0` may be divided by `y₀ ^ 2`. Over `ℤ` the same hypothesis
 with `x` ranging over the *integers* is strictly weaker, and is genuinely not enough: the map
 `x ↦ x ^ 2 - x` is non-negative at every integer, yet `discrim 1 (-1) 0 = 1 > 0`, which is
-`discrim_pos_of_forall_int_nonneg` below. `Int.discrim_le_zero_of_nonneg_of_lt_abs` says that one
+`forall_int_nonneg_and_discrim_pos` below. `Int.discrim_le_zero_of_nonneg_of_lt_abs` says that one
 extra condition — that `|y₀|` exceed the leading coefficient — repairs this, with no further
 quantification needed.
 
@@ -35,8 +35,8 @@ directly known to satisfy — is non-negative everywhere. Any single `y₀` from
 ## Main results
 
 * `nonneg_of_discrim_le_zero`: `0 < a` and `discrim a b c ≤ 0` give `0 ≤ a x² + b x y + c y²`.
-* `Int.discrim_le_zero_of_nonneg_of_lt_abs`: for `0 < a` and `a < |y|`, non-negativity of
-  `a x² + b x y + c y²` in `x` alone forces `discrim a b c ≤ 0`.
+* `Int.discrim_le_zero_of_nonneg_of_lt_abs`: for `a < |y|`, and with no sign condition on `a`,
+  non-negativity of `a x² + b x y + c y²` in `x` alone forces `discrim a b c ≤ 0`.
 * `Int.discrim_le_zero_of_nonneg_of_not_dvd`: the same conclusion from non-negativity on
   `{(x, y) : d ∤ y}`, for any non-unit `d`.
 
@@ -73,9 +73,10 @@ over `ℤ` with positive leading coefficient `a` is non-negative at `(x, y)` for
 
 The height hypothesis `a < |y|` is necessary, not an artefact of the proof: without it the
 integer-valued hypothesis is strictly weaker than its field counterpart, as
-`discrim_pos_of_forall_int_nonneg` witnesses. -/
-theorem Int.discrim_le_zero_of_nonneg_of_lt_abs {a b c y : ℤ} (ha : 0 < a) (hy : a < |y|)
-    (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
+`forall_int_nonneg_and_discrim_pos` witnesses. -/
+private theorem discrim_le_zero_of_pos_of_nonneg_of_lt_abs {a b c y : ℤ} (ha : 0 < a)
+    (hy : a < |y|) (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) :
+    discrim a b c ≤ 0 := by
   by_contra! hcon
   rw [discrim] at hcon
   have ha0 : (0 : ℚ) < 2 * (a : ℚ) := by
@@ -104,41 +105,94 @@ theorem Int.discrim_le_zero_of_nonneg_of_lt_abs {a b c y : ℤ} (ha : 0 < a) (hy
       = (2 * a * (-r) + b * y) ^ 2 + (4 * a * c - b ^ 2) * y ^ 2 := by ring
   nlinarith [h (-r), hsq, hy2, hkey]
 
+/-- A form with negative leading coefficient is eventually negative along any line, so the
+non-negativity hypothesis is unsatisfiable. Evaluating at `x = |b * y| + |c * y ^ 2| + 1` is
+already enough. -/
+private theorem not_forall_nonneg_of_neg {a b c y : ℤ} (ha : a < 0) :
+    ¬ ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2 := fun h => by
+  have hA0 : 0 ≤ |b * y| := abs_nonneg _
+  have hB0 : 0 ≤ |c * y ^ 2| := abs_nonneg _
+  set M : ℤ := |b * y| + |c * y ^ 2| + 1 with hM
+  have hM1 : 1 ≤ M := by omega
+  -- Bound each term of the form at `x = M` from above; the square dominates the rest.
+  have h1 : a * M ^ 2 ≤ -(M ^ 2) := by nlinarith [sq_nonneg M]
+  have h2 : b * M * y ≤ |b * y| * M := by
+    nlinarith [mul_nonneg (sub_nonneg.mpr (le_abs_self (b * y))) (by linarith : (0 : ℤ) ≤ M)]
+  have h3 : c * y ^ 2 ≤ |c * y ^ 2| := le_abs_self _
+  have h4 : |b * y| * M + |c * y ^ 2| + 1 ≤ M ^ 2 := by nlinarith
+  linarith [h M]
+
+/-- A form with zero leading coefficient is linear in `x`, so non-negativity for every integer
+`x` forces the linear coefficient `b * y` to vanish; with `y ≠ 0` that makes `b = 0`. -/
+private theorem eq_zero_of_forall_nonneg_of_ne {b c y : ℤ} (hy : y ≠ 0)
+    (h : ∀ x : ℤ, 0 ≤ 0 * x ^ 2 + b * x * y + c * y ^ 2) : b = 0 := by
+  by_contra hb
+  have hB0 : 0 ≤ |c * y ^ 2| := abs_nonneg _
+  have hpos : 0 < (b * y) ^ 2 := by positivity
+  have hs1 : 1 ≤ (b * y) ^ 2 := by omega
+  have hcb : c * y ^ 2 ≤ |c * y ^ 2| := le_abs_self _
+  -- At this `x` the linear term is `-(|c y²| + 1) * (b y)²`, which the constant cannot offset.
+  have hx := h (-((|c * y ^ 2| + 1) * (b * y)))
+  nlinarith [mul_nonneg (by linarith : (0 : ℤ) ≤ |c * y ^ 2| + 1)
+    (by linarith : (0 : ℤ) ≤ (b * y) ^ 2 - 1)]
+
+/-- **A single line of large enough height pins the discriminant.** If a binary quadratic form
+over `ℤ` is non-negative at `(x, y)` for a fixed `y` with `a < |y|` and every integer `x`, then
+`discrim a b c ≤ 0`, that is `b ^ 2 ≤ 4 * a * c`.
+
+No sign hypothesis on `a` is needed. A negative leading coefficient makes the hypothesis
+unsatisfiable, and a zero one collapses the form to a linear function of `x`, forcing `b = 0`.
+
+The height hypothesis `a < |y|` is necessary, not an artefact of the proof: without it the
+integer-valued hypothesis is strictly weaker than its field counterpart, as
+`forall_int_nonneg_and_discrim_pos` witnesses. -/
+theorem Int.discrim_le_zero_of_nonneg_of_lt_abs {a b c y : ℤ} (hy : a < |y|)
+    (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
+  rcases lt_trichotomy a 0 with ha | ha | ha
+  · exact absurd h (not_forall_nonneg_of_neg ha)
+  · subst ha
+    have hy0 : y ≠ 0 := by rintro rfl; simp at hy
+    rw [discrim, eq_zero_of_forall_nonneg_of_ne hy0 h]
+    simp
+  · exact discrim_le_zero_of_pos_of_nonneg_of_lt_abs ha hy h
+
 /-- The height hypothesis of `Int.discrim_le_zero_of_nonneg_of_lt_abs` cannot be dropped:
 `x ↦ x ^ 2 - x` is non-negative at every integer, yet its discriminant is positive. Here the
 leading coefficient and `|y|` are both `1`, so `a < |y|` fails by exactly one. -/
-theorem discrim_pos_of_forall_int_nonneg :
+private theorem forall_int_nonneg_and_discrim_pos :
     (∀ x : ℤ, 0 ≤ 1 * x ^ 2 + (-1) * x * 1 + 0 * 1 ^ 2) ∧ 0 < discrim (1 : ℤ) (-1) 0 := by
   refine ⟨fun x => ?_, by norm_num [discrim]⟩
   rcases le_or_gt x 0 with hx | hx
   · nlinarith
   · nlinarith [Int.add_one_le_iff.mpr hx]
 
-/-- **The locus `d ∤ y` pins the discriminant.** If a binary quadratic form over `ℤ` with positive
-leading coefficient is non-negative at every `(x, y)` whose second coordinate avoids the
-multiples of a non-unit `d` — in the intended application `d` is a prime, and the locus is the
-sublattice complement `{(x, y) : d ∤ y}` — then `discrim a b c ≤ 0`.
+/-- **The locus `d ∤ y` pins the discriminant.** If a binary quadratic form over `ℤ` is
+non-negative at every `(x, y)` whose second coordinate avoids the multiples of a non-unit `d` —
+in the intended application `d` is a prime, and the locus is the sublattice complement
+`{(x, y) : d ∤ y}` — then `discrim a b c ≤ 0`.
 
 `d = 0` is allowed, the hypothesis then being non-negativity at every `y ≠ 0`. -/
-theorem Int.discrim_le_zero_of_nonneg_of_not_dvd {a b c d : ℤ} (ha : 0 < a) (hd : ¬ IsUnit d)
+theorem Int.discrim_le_zero_of_nonneg_of_not_dvd {a b c d : ℤ} (hd : ¬ IsUnit d)
     (h : ∀ x y : ℤ, ¬ d ∣ y → 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
+  have hA : 0 ≤ |a| := abs_nonneg a
+  have haA : a ≤ |a| := le_abs_self a
   rcases eq_or_ne d 0 with rfl | hd0
-  · -- Only `y = 0` is excluded, so `y = a + 1` is available.
-    refine Int.discrim_le_zero_of_nonneg_of_lt_abs ha (y := a + 1) ?_
+  · -- Only `y = 0` is excluded, so `y = |a| + 1` is available.
+    refine Int.discrim_le_zero_of_nonneg_of_lt_abs (y := |a| + 1) ?_
       fun x => h x _ fun hc => by simp only [zero_dvd_iff] at hc; omega
-    rw [abs_of_pos (by linarith)]
-    linarith
-  · -- Otherwise `2 ≤ |d|`, and `y = a * d ^ 2 + 1` avoids `d` while exceeding `a`.
+    rw [abs_of_pos (by omega)]
+    omega
+  · -- Otherwise `1 < |d|`, and `y = |a| * d ^ 2 + 1` avoids `d` while exceeding `a`.
     have hd2 : 1 < |d| := by
       have h1 : d.natAbs ≠ 1 := fun hh => hd (Int.isUnit_iff_natAbs_eq.mpr hh)
       have h0 : d.natAbs ≠ 0 := fun hh => hd0 (Int.natAbs_eq_zero.mp hh)
       have : (1 : ℤ) < (d.natAbs : ℤ) := by
         exact_mod_cast Nat.lt_of_le_of_ne (by omega) (by omega)
       rwa [Int.abs_eq_natAbs]
-    have hnd : ¬ d ∣ a * d ^ 2 + 1 := fun hc => by
-      have hd1 : d ∣ (1 : ℤ) := (dvd_add_right (Dvd.intro (a * d) (by ring))).mp hc
+    have hnd : ¬ d ∣ |a| * d ^ 2 + 1 := fun hc => by
+      have hd1 : d ∣ (1 : ℤ) := (dvd_add_right (Dvd.intro (|a| * d) (by ring))).mp hc
       exact absurd (Int.le_of_dvd one_pos ((abs_dvd d 1).mpr hd1)) (by omega)
-    refine Int.discrim_le_zero_of_nonneg_of_lt_abs ha (y := a * d ^ 2 + 1) ?_ fun x => h x _ hnd
+    refine Int.discrim_le_zero_of_nonneg_of_lt_abs (y := |a| * d ^ 2 + 1) ?_ fun x => h x _ hnd
     have hsq : 1 ≤ d ^ 2 := by nlinarith [sq_abs d, abs_nonneg d]
     rw [abs_of_pos (by nlinarith)]
     nlinarith

--- a/TauCeti/Algebra/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/QuadraticDiscriminant.lean
@@ -6,6 +6,8 @@ module
 
 public import Mathlib.Algebra.QuadraticDiscriminant
 import Mathlib.Algebra.Order.Ring.Abs
+import Mathlib.Algebra.Order.Round
+import Mathlib.Data.Rat.Floor
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Ring
 
@@ -35,7 +37,6 @@ conclusion to every `(x, y)`.
 
 ## Main results
 
-* `Int.exists_two_mul_abs_sub_mul_le`: every integer lies within `m / 2` of a multiple of `m`.
 * `nonneg_of_discrim_le_zero`: `0 < a` and `discrim a b c ≤ 0` give `0 ≤ a x² + b x y + c y²`.
 * `Int.discrim_le_zero_of_nonneg_of_lt_abs`: for `0 < a` and `a < |y|`, non-negativity of
   `a x² + b x y + c y²` in `x` alone forces `discrim a b c ≤ 0`.
@@ -44,27 +45,28 @@ conclusion to every `(x, y)`.
 
 ## References
 
-* Silverman, *The Arithmetic of Elliptic Curves*, V.1.1, where positivity of the degree form on
-  a rank-two lattice is turned into the Hasse inequality by exactly this discriminant argument.
+* Silverman, *The Arithmetic of Elliptic Curves*, V.1.2 — the Cauchy–Schwarz step that turns
+  positivity of the degree form on a rank-two lattice into the Hasse inequality of V.1.1.
 -/
 
 public section
 
 /-- **Nearest multiple.** For a positive modulus `m`, every integer `a` lies within `m / 2` of a
-multiple of `m`, stated division-free as `2 * |a - m * r| ≤ m`. -/
-theorem Int.exists_two_mul_abs_sub_mul_le {m : ℤ} (hm : 0 < m) (a : ℤ) :
+multiple of `m`, stated division-free as `2 * |a - m * r| ≤ m`. This is Mathlib's `abs_sub_round`
+for `(a : ℚ) / m`, cleared of denominators. -/
+private theorem exists_two_mul_abs_sub_mul_le {m : ℤ} (hm : 0 < m) (a : ℤ) :
     ∃ r : ℤ, 2 * |a - m * r| ≤ m := by
-  have hm2 : (0 : ℤ) < 2 * m := by linarith
-  refine ⟨(2 * a + m) / (2 * m), ?_⟩
-  have h0 : 0 ≤ (2 * a + m) % (2 * m) := Int.emod_nonneg _ (ne_of_gt hm2)
-  have h1 : (2 * a + m) % (2 * m) < 2 * m := Int.emod_lt_of_pos _ hm2
-  have hd : (2 * a + m) % (2 * m) + 2 * m * ((2 * a + m) / (2 * m)) = 2 * a + m :=
-    Int.emod_add_mul_ediv (2 * a + m) (2 * m)
-  have habs : 2 * |a - m * ((2 * a + m) / (2 * m))|
-      = |2 * (a - m * ((2 * a + m) / (2 * m)))| := by
-    rw [abs_mul]; norm_num
-  rw [habs, abs_le]
-  constructor <;> linarith
+  have hm0 : (0 : ℚ) < (m : ℚ) := by exact_mod_cast hm
+  refine ⟨round ((a : ℚ) / (m : ℚ)), ?_⟩
+  set r : ℤ := round ((a : ℚ) / (m : ℚ)) with hrdef
+  have hr : |(a : ℚ) / (m : ℚ) - (r : ℚ)| ≤ 1 / 2 := abs_sub_round _
+  -- Clearing the denominator turns `|a/m - r| ≤ 1/2` into `2 * |a - m * r| ≤ m`.
+  have key : |(a : ℚ) - (m : ℚ) * (r : ℚ)| = (m : ℚ) * |(a : ℚ) / (m : ℚ) - (r : ℚ)| := by
+    have h : (a : ℚ) - (m : ℚ) * (r : ℚ) = (m : ℚ) * ((a : ℚ) / (m : ℚ) - (r : ℚ)) := by
+      field_simp
+    rw [h, abs_mul, abs_of_pos hm0]
+  have hq : (2 : ℚ) * |(a : ℚ) - (m : ℚ) * (r : ℚ)| ≤ (m : ℚ) := by rw [key]; nlinarith
+  exact_mod_cast (by push_cast; linarith : ((2 * |a - m * r| : ℤ) : ℚ) ≤ ((m : ℤ) : ℚ))
 
 /-- A binary quadratic form with positive leading coefficient and non-positive discriminant is
 non-negative. This is the implication opposite to Mathlib's `discrim_le_zero`, stated for the
@@ -87,27 +89,26 @@ discriminant would give `4a·Q ≤ a ^ 2 - y ^ 2 < 0`. Over `ℚ` or `ℝ` the n
 exact minimum and a single line carries no information about the discriminant at all.
 
 Consequently a form known to be non-negative only on `{(x, y) : ¬ d ∣ y}`, for some fixed `d`,
-still has non-positive discriminant: any single `y` avoiding `d` with `a < |y|` — such as
-`y = a * d ^ 2 + 1` when `1 < |d|` — may be used here. -/
+still has non-positive discriminant; that is `Int.discrim_le_zero_of_nonneg_of_not_dvd`. -/
 theorem Int.discrim_le_zero_of_nonneg_of_lt_abs {a b c y : ℤ} (ha : 0 < a) (hy : a < |y|)
     (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
   by_contra! hcon
   rw [discrim] at hcon
-  -- Pick `x` nearest to the minimum of the form along the line, so that `|2ax + by| ≤ a`.
-  obtain ⟨x, hx⟩ := Int.exists_two_mul_abs_sub_mul_le (by linarith : (0 : ℤ) < 2 * a) (-(b * y))
-  have hxa : |2 * a * x + b * y| ≤ a := by
-    rw [show 2 * a * x + b * y = -(-(b * y) - 2 * a * x) by ring, abs_neg]
-    linarith [hx]
-  have hsq : (2 * a * x + b * y) ^ 2 ≤ a ^ 2 := by
+  -- The multiple of `2a` nearest to `b * y` supplies the point `x = -r` on the line at which
+  -- the completed square `(2ax + by)²` is at most `a ^ 2`.
+  obtain ⟨r, hr⟩ := exists_two_mul_abs_sub_mul_le (by linarith : (0 : ℤ) < 2 * a) (b * y)
+  have hxa : |2 * a * (-r) + b * y| ≤ a := by
+    have hxr : 2 * a * (-r) + b * y = b * y - 2 * a * r := by ring
+    rw [hxr]
+    linarith [hr]
+  have hsq : (2 * a * (-r) + b * y) ^ 2 ≤ a ^ 2 := by
     have habs := abs_le.mp hxa
     nlinarith [habs.1, habs.2]
-  -- `a < |y|` makes the `(4ac − b²)y²` term outweigh it, so the form is negative at `(x, y)`.
-  have hy2 : a ^ 2 < y ^ 2 := by
-    have := abs_nonneg y
-    nlinarith [sq_abs y]
-  have hkey : 4 * a * (a * x ^ 2 + b * x * y + c * y ^ 2)
-      = (2 * a * x + b * y) ^ 2 + (4 * a * c - b ^ 2) * y ^ 2 := by ring
-  nlinarith [h x, hsq, hy2, hkey]
+  -- `a < |y|` makes the `(4ac − b²)y²` term outweigh it, so the form is negative at `(-r, y)`.
+  have hy2 : a ^ 2 < y ^ 2 := by nlinarith [sq_abs y, abs_nonneg y]
+  have hkey : 4 * a * (a * (-r) ^ 2 + b * (-r) * y + c * y ^ 2)
+      = (2 * a * (-r) + b * y) ^ 2 + (4 * a * c - b ^ 2) * y ^ 2 := by ring
+  nlinarith [h (-r), hsq, hy2, hkey]
 
 /-- **A sublattice already pins the discriminant.** If a binary quadratic form over `ℤ` with
 positive leading coefficient is non-negative at every `(x, y)` whose second coordinate avoids

--- a/TauCeti/Algebra/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/QuadraticDiscriminant.lean
@@ -26,7 +26,7 @@ extra condition — that `|y₀|` exceed the leading coefficient — repairs thi
 quantification needed.
 
 Together with the reverse implication this gives the upgrade that motivates the file: a form known
-to be non-negative only on some sparse subset of `ℤ ⨯ ℤ` — for instance the sublattice where a
+to be non-negative only on some sparse subset of `ℤ ⨯ ℤ` — for instance the locus where a
 fixed prime does not divide `y`, which is all that the degree form on an elliptic curve is
 directly known to satisfy — is non-negative everywhere. Any single `y₀` from that subset with
 `|y₀|` large enough feeds `Int.discrim_le_zero_of_nonneg_of_lt_abs`, and then
@@ -114,7 +114,7 @@ theorem discrim_pos_of_forall_int_nonneg :
   · nlinarith
   · nlinarith [Int.add_one_le_iff.mpr hx]
 
-/-- **A sublattice pins the discriminant.** If a binary quadratic form over `ℤ` with positive
+/-- **The locus `d ∤ y` pins the discriminant.** If a binary quadratic form over `ℤ` with positive
 leading coefficient is non-negative at every `(x, y)` whose second coordinate avoids the
 multiples of a non-unit `d` — in the intended application `d` is a prime, and the locus is the
 sublattice complement `{(x, y) : d ∤ y}` — then `discrim a b c ≤ 0`.

--- a/TauCeti/Algebra/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/QuadraticDiscriminant.lean
@@ -5,43 +5,48 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Algebra.QuadraticDiscriminant
-import Mathlib.Algebra.Order.Ring.Abs
-import Mathlib.Algebra.Order.Round
 import Mathlib.Data.Rat.Floor
-import Mathlib.Tactic.Linarith
-import Mathlib.Tactic.Ring
 
 /-!
 # Non-negativity of a binary quadratic form and its discriminant
 
-Mathlib's `discrim_le_zero` shows that a quadratic *polynomial* over a linearly ordered field
-which is non-negative at every point of the field has non-positive discriminant. This file
-supplies two facts about the homogeneous two-variable form `a * x ^ 2 + b * x * y + c * y ^ 2`
-that `discrim_le_zero` does not give.
+Mathlib's `discrim_le_zero` shows that a quadratic polynomial over a linearly ordered field which
+is non-negative at every point of the field has non-positive discriminant. This file supplies two
+facts about the homogeneous two-variable form `a * x ^ 2 + b * x * y + c * y ^ 2` that it does not
+give: the reverse implication, and an integral version whose hypothesis is much weaker.
 
-* `nonneg_of_discrim_le_zero` is the reverse implication, over a linearly ordered commutative
-  ring rather than a field: a positive leading coefficient together with a non-positive
-  discriminant makes the form non-negative. The proof is the completed square
-  `4a·Q = (2ax + by)² + (4ac − b²)y²`, which uses no division, so `Field` is not needed.
-* `Int.discrim_le_zero_of_nonneg_of_lt_abs` runs the other way over `ℤ`, and needs far less
-  than non-negativity everywhere: it is enough to test the form along a **single** line
-  `y = y₀`, provided `|y₀|` exceeds the leading coefficient. Integrality is what makes so weak
-  a hypothesis sufficient — over `ℚ` or `ℝ` one line says nothing about the discriminant.
+The integral version is the substantial one, and it is worth being precise about what makes it
+substantial. Over a *field*, non-negativity along a single line `y = y₀ ≠ 0` already forces
+`discrim a b c ≤ 0`: the restriction is a quadratic in `x`, so `discrim_le_zero` applies and the
+resulting `y₀ ^ 2 * discrim a b c ≤ 0` may be divided by `y₀ ^ 2`. Over `ℤ` the same hypothesis
+with `x` ranging over the *integers* is strictly weaker, and is genuinely not enough: the map
+`x ↦ x ^ 2 - x` is non-negative at every integer, yet `discrim 1 (-1) 0 = 1 > 0`, which is
+`discrim_pos_of_forall_int_nonneg` below. `Int.discrim_le_zero_of_nonneg_of_lt_abs` says that one
+extra condition — that `|y₀|` exceed the leading coefficient — repairs this, with no further
+quantification needed.
 
-Together the two give the upgrade that motivates the file: a form known to be non-negative only
-on some sparse set of `(x, y)` — for instance the sublattice where a fixed prime does not divide
-`y`, which is all that the degree form on an elliptic curve is directly known to satisfy — is
-non-negative on all of `ℤ ⨯ ℤ`. Any single `y₀` from that set with `|y₀|` large enough feeds
-`Int.discrim_le_zero_of_nonneg_of_lt_abs`, and `nonneg_of_discrim_le_zero` then propagates the
-conclusion to every `(x, y)`.
+Together with the reverse implication this gives the upgrade that motivates the file: a form known
+to be non-negative only on some sparse subset of `ℤ ⨯ ℤ` — for instance the sublattice where a
+fixed prime does not divide `y`, which is all that the degree form on an elliptic curve is
+directly known to satisfy — is non-negative everywhere. Any single `y₀` from that subset with
+`|y₀|` large enough feeds `Int.discrim_le_zero_of_nonneg_of_lt_abs`, and then
+`nonneg_of_discrim_le_zero` propagates the conclusion to every `(x, y)`.
 
 ## Main results
 
 * `nonneg_of_discrim_le_zero`: `0 < a` and `discrim a b c ≤ 0` give `0 ≤ a x² + b x y + c y²`.
 * `Int.discrim_le_zero_of_nonneg_of_lt_abs`: for `0 < a` and `a < |y|`, non-negativity of
   `a x² + b x y + c y²` in `x` alone forces `discrim a b c ≤ 0`.
-* `Int.discrim_le_zero_of_nonneg_of_not_dvd`: the same conclusion from non-negativity on the
-  sublattice complement `{(x, y) : d ∤ y}`, for any `d` with `1 < |d|`.
+* `Int.discrim_le_zero_of_nonneg_of_not_dvd`: the same conclusion from non-negativity on
+  `{(x, y) : d ∤ y}`, for any non-unit `d`.
+
+## Provenance
+
+Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
+`HasseWeil/WeilPairing/Discriminant.lean`, declarations `exists_int_balanced`,
+`qf_nonneg_of_nonneg_on_coprime` and `qf_nonneg_of_nonneg_on_coprime_both`. The statements here
+are strictly stronger: the form is arbitrary rather than `q r² − t r s + s²`, no primality is
+assumed, and a single `y` replaces an infinite family of prime powers.
 
 ## References
 
@@ -51,56 +56,45 @@ conclusion to every `(x, y)`.
 
 public section
 
-/-- **Nearest multiple.** For a positive modulus `m`, every integer `a` lies within `m / 2` of a
-multiple of `m`, stated division-free as `2 * |a - m * r| ≤ m`. This is Mathlib's `abs_sub_round`
-for `(a : ℚ) / m`, cleared of denominators. -/
-private theorem exists_two_mul_abs_sub_mul_le {m : ℤ} (hm : 0 < m) (a : ℤ) :
-    ∃ r : ℤ, 2 * |a - m * r| ≤ m := by
-  have hm0 : (0 : ℚ) < (m : ℚ) := by exact_mod_cast hm
-  refine ⟨round ((a : ℚ) / (m : ℚ)), ?_⟩
-  set r : ℤ := round ((a : ℚ) / (m : ℚ)) with hrdef
-  have hr : |(a : ℚ) / (m : ℚ) - (r : ℚ)| ≤ 1 / 2 := abs_sub_round _
-  -- Clearing the denominator turns `|a/m - r| ≤ 1/2` into `2 * |a - m * r| ≤ m`.
-  have key : |(a : ℚ) - (m : ℚ) * (r : ℚ)| = (m : ℚ) * |(a : ℚ) / (m : ℚ) - (r : ℚ)| := by
-    have h : (a : ℚ) - (m : ℚ) * (r : ℚ) = (m : ℚ) * ((a : ℚ) / (m : ℚ) - (r : ℚ)) := by
-      field_simp
-    rw [h, abs_mul, abs_of_pos hm0]
-  have hq : (2 : ℚ) * |(a : ℚ) - (m : ℚ) * (r : ℚ)| ≤ (m : ℚ) := by rw [key]; nlinarith
-  exact_mod_cast (by push_cast; linarith : ((2 * |a - m * r| : ℤ) : ℚ) ≤ ((m : ℤ) : ℚ))
-
 /-- A binary quadratic form with positive leading coefficient and non-positive discriminant is
 non-negative. This is the implication opposite to Mathlib's `discrim_le_zero`, stated for the
-homogeneous two-variable form; the completed square `4a·Q = (2ax + by)² + (4ac − b²)y²` uses no
-division, so a linearly ordered commutative ring suffices in place of a field. -/
+homogeneous two-variable form and over a linearly ordered commutative ring rather than a field.
+The hypothesis `0 < a` cannot be dropped: `discrim 0 0 (-1) = 0`, while `- y ^ 2` is negative. -/
 theorem nonneg_of_discrim_le_zero {R : Type*} [CommRing R] [LinearOrder R]
     [IsStrictOrderedRing R] {a b c : R} (ha : 0 < a) (hd : discrim a b c ≤ 0) (x y : R) :
     0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2 := by
+  -- The completed square `4a·Q = (2ax + by)² + (4ac − b²)y²` uses no division.
   have hb : 0 ≤ 4 * a * c - b ^ 2 := by rw [discrim] at hd; linarith
   nlinarith [sq_nonneg (2 * a * x + b * y), mul_nonneg hb (sq_nonneg y)]
 
-/-- **One line of large enough height already pins the discriminant.** If a binary quadratic
-form over `ℤ` with positive leading coefficient `a` is non-negative at `(x, y)` for a *fixed*
-`y` with `a < |y|` and every `x`, then its discriminant is non-positive, `b ^ 2 ≤ 4 * a * c`.
+/-- **A single line of large enough height pins the discriminant.** If a binary quadratic form
+over `ℤ` with positive leading coefficient `a` is non-negative at `(x, y)` for a fixed `y` with
+`a < |y|` and every integer `x`, then `discrim a b c ≤ 0`, that is `b ^ 2 ≤ 4 * a * c`.
 
-Testing one line is enough only because the variable `x` ranges over `ℤ` and not over a field:
-the argument picks the integer `x` nearest to the minimum of `x ↦ a x² + b x y + c y²`, where
-the completed square `4a·Q = (2ax + by)² + (4ac − b²)y²` has `(2ax + by)² ≤ a ^ 2`, so a positive
-discriminant would give `4a·Q ≤ a ^ 2 - y ^ 2 < 0`. Over `ℚ` or `ℝ` the nearest point is the
-exact minimum and a single line carries no information about the discriminant at all.
-
-Consequently a form known to be non-negative only on `{(x, y) : ¬ d ∣ y}`, for some fixed `d`,
-still has non-positive discriminant; that is `Int.discrim_le_zero_of_nonneg_of_not_dvd`. -/
+The height hypothesis `a < |y|` is necessary, not an artefact of the proof: without it the
+integer-valued hypothesis is strictly weaker than its field counterpart, as
+`discrim_pos_of_forall_int_nonneg` witnesses. -/
 theorem Int.discrim_le_zero_of_nonneg_of_lt_abs {a b c y : ℤ} (ha : 0 < a) (hy : a < |y|)
     (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
   by_contra! hcon
   rw [discrim] at hcon
-  -- The multiple of `2a` nearest to `b * y` supplies the point `x = -r` on the line at which
-  -- the completed square `(2ax + by)²` is at most `a ^ 2`.
-  obtain ⟨r, hr⟩ := exists_two_mul_abs_sub_mul_le (by linarith : (0 : ℤ) < 2 * a) (b * y)
+  have ha0 : (0 : ℚ) < 2 * (a : ℚ) := by
+    have : (0 : ℚ) < (a : ℚ) := by exact_mod_cast ha
+    linarith
+  -- Evaluate at `x = -r`, where `r` is the integer nearest to `b * y / (2 * a)`; this is the
+  -- integer closest to the minimum of the restricted form, and gives `|2ax + by| ≤ a`.
+  set t : ℚ := ((b * y : ℤ) : ℚ) / (2 * (a : ℚ)) with htdef
+  set r : ℤ := round t with hrdef
   have hxa : |2 * a * (-r) + b * y| ≤ a := by
-    have hxr : 2 * a * (-r) + b * y = b * y - 2 * a * r := by ring
-    rw [hxr]
-    linarith [hr]
+    have hcast : ((2 * a * (-r) + b * y : ℤ) : ℚ) = 2 * (a : ℚ) * (t - (r : ℚ)) := by
+      rw [htdef]
+      field_simp
+      push_cast
+      ring
+    have hq : |((2 * a * (-r) + b * y : ℤ) : ℚ)| ≤ ((a : ℤ) : ℚ) := by
+      rw [hcast, abs_mul, abs_of_pos ha0]
+      nlinarith [abs_sub_round t, abs_nonneg (t - (r : ℚ))]
+    exact_mod_cast hq
   have hsq : (2 * a * (-r) + b * y) ^ 2 ≤ a ^ 2 := by
     have habs := abs_le.mp hxa
     nlinarith [habs.1, habs.2]
@@ -110,20 +104,41 @@ theorem Int.discrim_le_zero_of_nonneg_of_lt_abs {a b c y : ℤ} (ha : 0 < a) (hy
       = (2 * a * (-r) + b * y) ^ 2 + (4 * a * c - b ^ 2) * y ^ 2 := by ring
   nlinarith [h (-r), hsq, hy2, hkey]
 
-/-- **A sublattice already pins the discriminant.** If a binary quadratic form over `ℤ` with
-positive leading coefficient is non-negative at every `(x, y)` whose second coordinate avoids
-the multiples of some `d` with `1 < |d|` — in the intended application `d` is a prime, and the
-locus is the sublattice complement `{(x, y) : d ∤ y}` — then its discriminant is non-positive.
+/-- The height hypothesis of `Int.discrim_le_zero_of_nonneg_of_lt_abs` cannot be dropped:
+`x ↦ x ^ 2 - x` is non-negative at every integer, yet its discriminant is positive. Here the
+leading coefficient and `|y|` are both `1`, so `a < |y|` fails by exactly one. -/
+theorem discrim_pos_of_forall_int_nonneg :
+    (∀ x : ℤ, 0 ≤ 1 * x ^ 2 + (-1) * x * 1 + 0 * 1 ^ 2) ∧ 0 < discrim (1 : ℤ) (-1) 0 := by
+  refine ⟨fun x => ?_, by norm_num [discrim]⟩
+  rcases le_or_gt x 0 with hx | hx
+  · nlinarith
+  · nlinarith [Int.add_one_le_iff.mpr hx]
 
-This is `Int.discrim_le_zero_of_nonneg_of_lt_abs` fed the witness `y = a * d ^ 2 + 1`, which
-avoids `d` and is larger than `a`. It does **not** follow from Mathlib's `discrim_le_zero`,
-whose hypothesis is non-negativity at every point of a field. -/
-theorem Int.discrim_le_zero_of_nonneg_of_not_dvd {a b c d : ℤ} (ha : 0 < a) (hd : 1 < |d|)
+/-- **A sublattice pins the discriminant.** If a binary quadratic form over `ℤ` with positive
+leading coefficient is non-negative at every `(x, y)` whose second coordinate avoids the
+multiples of a non-unit `d` — in the intended application `d` is a prime, and the locus is the
+sublattice complement `{(x, y) : d ∤ y}` — then `discrim a b c ≤ 0`.
+
+`d = 0` is allowed, the hypothesis then being non-negativity at every `y ≠ 0`. -/
+theorem Int.discrim_le_zero_of_nonneg_of_not_dvd {a b c d : ℤ} (ha : 0 < a) (hd : ¬ IsUnit d)
     (h : ∀ x y : ℤ, ¬ d ∣ y → 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
-  have hnd : ¬ d ∣ a * d ^ 2 + 1 := fun hc => by
-    have hd1 : d ∣ (1 : ℤ) := (dvd_add_right (Dvd.intro (a * d) (by ring))).mp hc
-    exact absurd (Int.le_of_dvd one_pos ((abs_dvd d 1).mpr hd1)) (by omega)
-  refine Int.discrim_le_zero_of_nonneg_of_lt_abs ha (y := a * d ^ 2 + 1) ?_ fun x => h x _ hnd
-  have hd2 : 1 ≤ d ^ 2 := by nlinarith [sq_abs d, abs_nonneg d]
-  rw [abs_of_pos (by nlinarith)]
-  nlinarith
+  rcases eq_or_ne d 0 with rfl | hd0
+  · -- Only `y = 0` is excluded, so `y = a + 1` is available.
+    refine Int.discrim_le_zero_of_nonneg_of_lt_abs ha (y := a + 1) ?_
+      fun x => h x _ fun hc => by simp only [zero_dvd_iff] at hc; omega
+    rw [abs_of_pos (by linarith)]
+    linarith
+  · -- Otherwise `2 ≤ |d|`, and `y = a * d ^ 2 + 1` avoids `d` while exceeding `a`.
+    have hd2 : 1 < |d| := by
+      have h1 : d.natAbs ≠ 1 := fun hh => hd (Int.isUnit_iff_natAbs_eq.mpr hh)
+      have h0 : d.natAbs ≠ 0 := fun hh => hd0 (Int.natAbs_eq_zero.mp hh)
+      have : (1 : ℤ) < (d.natAbs : ℤ) := by
+        exact_mod_cast Nat.lt_of_le_of_ne (by omega) (by omega)
+      rwa [Int.abs_eq_natAbs]
+    have hnd : ¬ d ∣ a * d ^ 2 + 1 := fun hc => by
+      have hd1 : d ∣ (1 : ℤ) := (dvd_add_right (Dvd.intro (a * d) (by ring))).mp hc
+      exact absurd (Int.le_of_dvd one_pos ((abs_dvd d 1).mpr hd1)) (by omega)
+    refine Int.discrim_le_zero_of_nonneg_of_lt_abs ha (y := a * d ^ 2 + 1) ?_ fun x => h x _ hnd
+    have hsq : 1 ≤ d ^ 2 := by nlinarith [sq_abs d, abs_nonneg d]
+    rw [abs_of_pos (by nlinarith)]
+    nlinarith


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"hasse-discriminant"}-->

Roadmap: EllipticCurves

Adds `TauCeti/Algebra/QuadraticDiscriminant.lean`: facts about the binary quadratic form
`a x² + b x y + c y²` and its discriminant that Mathlib does not have.

## What is proved

* `nonneg_of_discrim_le_zero` — `0 < a` and `discrim a b c ≤ 0` imply `0 ≤ a x² + b x y + c y²`,
  over a linearly ordered `CommRing`.
* `Int.discrim_le_zero_of_nonneg_of_lt_abs` — over `ℤ`, non-negativity along the **single** line
  `y = y₀`, for any `y₀` with `a < |y₀|`, already forces `discrim a b c ≤ 0`.
* `discrim_pos_of_forall_int_nonneg` — the height hypothesis above is necessary.
* `Int.discrim_le_zero_of_nonneg_of_not_dvd` — the same conclusion from non-negativity on the
  sublattice complement `{(x, y) : d ∤ y}`, for any non-unit `d`.

**No elliptic-curve content is proved here, and no Hasse bound.** The file is about integers and
quadratic forms; it mentions curves only in its provenance and references. What it supplies is
the arithmetic half of the Hasse argument, stated so the geometric half can be dropped into it.

## Why this is not `discrim_le_zero`

Two distinct reasons, and I want to be precise about the second because an earlier draft of this
PR got it wrong.

1. `nonneg_of_discrim_le_zero` runs the **opposite** implication (`discrim ≤ 0` ⟹ form
   non-negative), which Mathlib does not state, and it holds over a linearly ordered `CommRing`:
   the completed square `4a·Q = (2ax + by)² + (4ac − b²)y²` never divides, so no `Field` is
   needed. `0 < a` is not removable — at `a = b = 0`, `c = -1` the discriminant is `0` and the
   form is `-y²`.

2. The integral results weaken the hypothesis in a way a field cannot see. It would be **wrong**
   to say that over `ℚ` or `ℝ` a single line carries no information: it carries all of it, since
   the restriction to `y = y₀ ≠ 0` is a quadratic in `x` and `discrim_le_zero` gives
   `y₀² · discrim a b c ≤ 0` directly. The actual gap is that these theorems quantify `x` over
   **`ℤ`**, which is strictly weaker — and genuinely insufficient on its own:

   > `x ↦ x² − x` is non-negative at every *integer*, yet `discrim 1 (-1) 0 = 1 > 0`.

   That is `discrim_pos_of_forall_int_nonneg`, proved in the file rather than asserted, and it
   is sharp for the main theorem: there `a = 1` and `|y| = 1`, so `a < |y|` fails by exactly one.
   `Int.discrim_le_zero_of_nonneg_of_lt_abs` says that this single height condition is all that
   is needed to close the gap, with no extra quantification.

## Provenance

Ported from AINTLIB (Apache-2.0), revision `513e83879e2f`, file
`HasseWeil/WeilPairing/Discriminant.lean`, declarations `exists_int_balanced`,
`qf_nonneg_of_nonneg_on_coprime`, `qf_nonneg_of_nonneg_on_coprime_both`. Also recorded in the
module docstring.

The port is **not verbatim** — the statements are strictly stronger and were re-derived:

| AINTLIB | here |
|---|---|
| form fixed as `q r² − t r s + s²` | arbitrary `a x² + b x y + c y²` |
| `{p : ℕ} (hp : p.Prime)` | no primality: any non-unit `d`, or no modulus at all |
| needs `Nat.exists_infinite_primes` + an Archimedean power bound to build `s = ℓⁿ` | needs neither; one `y` with `a < abs y` suffices, and the `d ∤ y` form uses the explicit witness `y = a * d ^ 2 + 1` |
| hand-rolls the nearest-multiple bound from `Int.emod` | reuses Mathlib's `abs_sub_round`, inlined |
| positive-semidefiniteness only over `ℤ`, inline in a larger proof | separate result over any linearly ordered `CommRing` |
| `t² ≤ 4q` appears only as an internal `have` | it *is* the statement, in Mathlib's `discrim` vocabulary |

The file is down to two imports: `Mathlib.Algebra.QuadraticDiscriminant` (public) and
`Mathlib.Data.Rat.Floor`.

## Roadmap

`EllipticCurves`, Layer 3 — the Hasse strand. The roadmap's §Ordering separates Layer 3's two
strands and puts this one first: *"the Hasse bound is the earliest PR, its existing proof
self-contained; the zeta strand needs Layer 1's Frobenius identities."* This PR is on the
self-contained side.

The seeded target `hasse_bound` is `(#E(𝔽_q) − (q + 1))² ≤ 4q`, and the roadmap names its route:
*"from `deg(1 − φ_q) = #E(𝔽_q)`, positivity of the degree form, and Cauchy–Schwarz on it (AEC
V.1.2)"*. **This PR is that last step, and only it.** Cauchy–Schwarz for an integer-valued
quadratic form *is* the discriminant inequality: with `Q(r, s) = deg(r φ_q − s)` non-negative,
`a_q ^ 2 ≤ 4 * q` is `Int.discrim_le_zero_of_nonneg_of_lt_abs` at `a = q`, `b = -a_q`, `c = 1`,
followed by unfolding `discrim`.

Neither geometric input — `deg(1 − φ_q) = #E(𝔽_q)` and non-negativity of `deg` — is in this PR,
and nothing here can supply them: the file imports two Mathlib modules and nothing at all from
this repository.

That the source file belongs to the Hasse proof is checkable rather than a matter of reading: in
the roadmap's pinned Hasse provenance (`dev/hasse-weil @ 513e83879e2f`),
`HasseWeil/WeilPairing/Discriminant.lean` lies inside the 187-file import closure of the capstone
`hasse_bound` proof, reached via `HasseWeil/WeilPairing/Assembly.lean`.

## Notes for review

* `Int.discrim_le_zero_of_nonneg_of_not_dvd` is a specialisation of the line version, but not a
  thin wrapper: its content is the witness (`y = a * d ^ 2 + 1`, or `y = a + 1` when `d = 0`),
  which a caller would otherwise have to redo.
* `0 < a` is uniform across the file. It is necessary for `nonneg_of_discrim_le_zero` (above);
  in the `Int` results it could be dropped, since `a < 0` makes the hypothesis unsatisfiable and
  `a = 0` collapses the form to a linear function of `x`, but both add case splits without
  adding usable strength.
* Longest proof is 22 lines; no `sorry`, no `maxHeartbeats`. `lake build`, `lake exe axioms`,
  `lake exe module-system` and `scripts/lint-env.sh` all pass locally.
