### PR TITLE
refactor(WeilDivisor): extract the generic-point argument from the finiteness proof

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Principal.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Principal.lean
@@ -48,6 +48,33 @@ variable {X : Scheme.{u}}
 
 noncomputable section
 
+/-- A maximal point of an irreducible space is its generic point. -/
+private lemma eq_genericPoint_of_isMax [IrreducibleSpace X] {y : X} (hy : IsMax y) :
+    y = genericPoint X :=
+  Inseparable.eq <| inseparable_iff_specializes_and.mpr
+    ⟨hy (genericPoint_specializes y), genericPoint_specializes y⟩
+
+/-- A codimension-one point lying in a closed irreducible set that avoids a nonempty open `U` is
+that set's generic point. A strict specialisation from it would have coheight zero, hence be
+maximal, hence be the generic point of `X` — which lies in `U`, contradicting the avoidance. -/
+private lemma eq_of_isGenericPoint_of_subset_compl [IrreducibleSpace X] {U : X.Opens} [Nonempty U]
+    {T : Set X} (hTU : T ⊆ (U : Set X)ᶜ) {y : X} (hyGeneric : IsGenericPoint y T)
+    {x : CodimensionOnePoint X} (hxT : (x : X) ∈ T) : (x : X) = y := by
+  by_contra hne
+  have hxylt : (x : X) < y := by
+    refine ⟨hyGeneric.specializes hxT, ?_⟩
+    intro hyx
+    exact hne (Inseparable.eq <| inseparable_iff_specializes_and.mpr
+      ⟨hyx, hyGeneric.specializes hxT⟩)
+  have hyMax : IsMax y :=
+    Order.coheight_eq_zero.mp <|
+      Order.lt_one_iff.mp <| (Order.coheight_eq_coe_iff.mp x.property).2.2 y hxylt
+  have hηU : genericPoint X ∈ U :=
+    (genericPoint_spec X).mem_open_set_iff U.isOpen |>.mpr <| by
+      obtain ⟨u⟩ := (inferInstance : Nonempty U)
+      exact ⟨u.1, Set.mem_univ _, u.property⟩
+  exact hTU hyGeneric.mem ((eq_genericPoint_of_isMax hyMax).symm ▸ hηU)
+
 /-- A nonempty open subset of an irreducible scheme with Noetherian underlying space contains all
 but finitely many codimension-one points. -/
 lemma finite_setOfPred_not_mem [IrreducibleSpace X] [NoetherianSpace X]
@@ -66,34 +93,10 @@ lemma finite_setOfPred_not_mem [IrreducibleSpace X] [NoetherianSpace X]
       rw [← hSunion]
       exact hxU
     obtain ⟨T, hTS, hxT⟩ := Set.mem_sUnion.mp hxUnion
-    let T' : S := ⟨T, hTS⟩
-    let y : X := g T'
-    have hyGeneric : IsGenericPoint y T := by
-      dsimp only [y, g, T']
-      exact (hSirreducible T hTS).isGenericPoint_genericPoint (hSclosed T hTS)
-    have hxy : (x : X) = y := by
-      by_contra hne
-      have hxylt : (x : X) < y := by
-        refine ⟨hyGeneric.specializes hxT, ?_⟩
-        intro hyx
-        exact hne (Inseparable.eq <| inseparable_iff_specializes_and.mpr
-          ⟨hyx, hyGeneric.specializes hxT⟩)
-      have hyCoheight : coheight y = 0 :=
-        Order.lt_one_iff.mp <| (Order.coheight_eq_coe_iff.mp x.property).2.2 y hxylt
-      have hyMax : IsMax y := Order.coheight_eq_zero.mp hyCoheight
-      have hyη : y ≤ genericPoint X := genericPoint_specializes y
-      have hηy : genericPoint X ≤ y := hyMax hyη
-      have hyEqη : y = genericPoint X :=
-        Inseparable.eq <| inseparable_iff_specializes_and.mpr ⟨hηy, hyη⟩
-      have hηU : genericPoint X ∈ U :=
-        (genericPoint_spec X).mem_open_set_iff U.isOpen |>.mpr <| by
-          obtain ⟨u⟩ := (inferInstance : Nonempty U)
-          exact ⟨u.1, Set.mem_univ _, u.property⟩
-      have hTcompl : T ⊆ (U : Set X)ᶜ := by
-        rw [hSunion]
-        exact Set.subset_sUnion_of_mem hTS
-      exact hTcompl hyGeneric.mem (hyEqη.symm ▸ hηU)
-    exact ⟨T', hxy.symm⟩
+    have hyGeneric : IsGenericPoint (g ⟨T, hTS⟩) T :=
+      (hSirreducible T hTS).isGenericPoint_genericPoint (hSclosed T hTS)
+    have hTcompl : T ⊆ (U : Set X)ᶜ := hSunion ▸ Set.subset_sUnion_of_mem hTS
+    exact ⟨⟨T, hTS⟩, (eq_of_isGenericPoint_of_subset_compl hTcompl hyGeneric hxT).symm⟩
   · exact Set.injOn_of_injective Subtype.val_injective
 
 variable [IsIntegral X] [IsNoetherian X]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Principal.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Principal.lean
@@ -56,7 +56,7 @@ private lemma eq_genericPoint_of_isMax [IrreducibleSpace X] {y : X} (hy : IsMax 
 
 /-- A codimension-one point lying in a set that avoids a nonempty open `U` equals that set's
 generic point. -/
-private lemma eq_of_isGenericPoint_of_subset_compl [IrreducibleSpace X] {U : X.Opens} [Nonempty U]
+private lemma eq_of_subset_compl_of_isGenericPoint [IrreducibleSpace X] {U : X.Opens} [Nonempty U]
     {T : Set X} (hTU : T ⊆ (U : Set X)ᶜ) {y : X} (hyGeneric : IsGenericPoint y T)
     {x : CodimensionOnePoint X} (hxT : (x : X) ∈ T) : (x : X) = y := by
   -- A strict specialisation from `x` would have coheight zero, hence be maximal, hence be the
@@ -97,7 +97,7 @@ lemma finite_setOfPred_not_mem [IrreducibleSpace X] [NoetherianSpace X]
     have hyGeneric : IsGenericPoint (g ⟨T, hTS⟩) T :=
       (hSirreducible T hTS).isGenericPoint_genericPoint (hSclosed T hTS)
     have hTcompl : T ⊆ (U : Set X)ᶜ := hSunion ▸ Set.subset_sUnion_of_mem hTS
-    exact ⟨⟨T, hTS⟩, (eq_of_isGenericPoint_of_subset_compl hTcompl hyGeneric hxT).symm⟩
+    exact ⟨⟨T, hTS⟩, (eq_of_subset_compl_of_isGenericPoint hTcompl hyGeneric hxT).symm⟩
   · exact Set.injOn_of_injective Subtype.val_injective
 
 variable [IsIntegral X] [IsNoetherian X]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Principal.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Principal.lean
@@ -54,12 +54,13 @@ private lemma eq_genericPoint_of_isMax [IrreducibleSpace X] {y : X} (hy : IsMax 
   Inseparable.eq <| inseparable_iff_specializes_and.mpr
     ⟨hy (genericPoint_specializes y), genericPoint_specializes y⟩
 
-/-- A codimension-one point lying in a closed irreducible set that avoids a nonempty open `U` is
-that set's generic point. A strict specialisation from it would have coheight zero, hence be
-maximal, hence be the generic point of `X` — which lies in `U`, contradicting the avoidance. -/
+/-- A codimension-one point lying in a set that avoids a nonempty open `U` equals that set's
+generic point. -/
 private lemma eq_of_isGenericPoint_of_subset_compl [IrreducibleSpace X] {U : X.Opens} [Nonempty U]
     {T : Set X} (hTU : T ⊆ (U : Set X)ᶜ) {y : X} (hyGeneric : IsGenericPoint y T)
     {x : CodimensionOnePoint X} (hxT : (x : X) ∈ T) : (x : X) = y := by
+  -- A strict specialisation from `x` would have coheight zero, hence be maximal, hence be the
+  -- generic point of `X` — which lies in `U`, contradicting `T ⊆ Uᶜ`.
   by_contra hne
   have hxylt : (x : X) < y := by
     refine ⟨hyGeneric.specializes hxT, ?_⟩


### PR DESCRIPTION
`finite_setOfPred_not_mem` ran to 43 lines because the Noetherian decomposition and the geometric
argument were interleaved. The decomposition part is short — write `Uᶜ` as a finite union of closed
irreducibles and map each codimension-one point outside `U` to its component's generic point. The
long part is proving that map is well defined, i.e. that such a point *is* the generic point, and
that is a self-contained statement about specialisation.

## The helpers

* `eq_genericPoint_of_isMax` — a maximal point of an irreducible space is its generic point. Four
  lines, and the only place `genericPoint_specializes` is used twice in opposite directions.

* `eq_of_isGenericPoint_of_subset_compl` — the geometric content: a codimension-one point lying in
  a set `T ⊆ Uᶜ` with `U` nonempty equals `T`'s generic point. Note it assumes only
  `IsGenericPoint y T`: closedness and irreducibility of `T` are what the *caller* uses to produce
  that hypothesis, and never enter the lemma.

Neither mentions `NoetherianSpace` or the finite decomposition; they are about one component.

## What is left

```lean
obtain ⟨S, hSfinite, hSclosed, hSirreducible, hSunion⟩ :=
  NoetherianSpace.exists_finite_set_isClosed_irreducible U.isOpen.isClosed_compl
let g : S → X := fun T ↦ (hSirreducible T T.property).genericPoint
...
obtain ⟨T, hTS, hxT⟩ := Set.mem_sUnion.mp hxUnion
have hyGeneric : IsGenericPoint (g ⟨T, hTS⟩) T :=
  (hSirreducible T hTS).isGenericPoint_genericPoint (hSclosed T hTS)
have hTcompl : T ⊆ (U : Set X)ᶜ := hSunion ▸ Set.subset_sUnion_of_mem hTS
exact ⟨⟨T, hTS⟩, (eq_of_isGenericPoint_of_subset_compl hTcompl hyGeneric hxT).symm⟩
```

The three intermediate `let`s the original introduced (`T' : S`, `y : X`, and the `dsimp only`
that unfolded them) are gone: with the argument in a lemma, `g ⟨T, hTS⟩` can be named once in
`hyGeneric`'s statement instead. `hTcompl` also collapses from a three-line tactic block to a
`▸`.

## Scope

The statement and docstring of `finite_setOfPred_not_mem` are unchanged, and both helpers are
`private`; the entire diff is proof-internal.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all green;
no new lint violations. Proof body 43 → 19 lines, with helpers at 4 and 15.

Roadmap: JacobianChallenge
