### PR TITLE
feat: the homogeneous characteristic form of a 2x2 matrix

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/CharpolyFinTwo.lean
+++ b/TauCeti/LinearAlgebra/Matrix/CharpolyFinTwo.lean
@@ -32,6 +32,9 @@ middle coefficient `-M.trace` and constant coefficient `1`, so its discriminant 
 ## Main results
 
 * `TauCeti.Matrix.det_smul_sub_smul_one_fin_two`: the identity displayed above.
+* `TauCeti.Matrix.det_smul_sub_smul_one_of_card_eq_two`: the same for a square matrix on any
+  index type of cardinality two, matching the relationship Mathlib's
+  `Matrix.charpoly_of_card_eq_two` bears to `Matrix.charpoly_fin_two`.
 
 ## Provenance
 
@@ -52,8 +55,8 @@ namespace TauCeti.Matrix
 in `(r, s)` whose coefficients are the determinant and the trace of `M`.
 
 This is the homogeneous form of `Matrix.charpoly_fin_two`, from which it can also be derived by
-evaluating at `r • M`; stated directly it needs no `[Nontrivial R]` hypothesis and no
-`Polynomial`. -/
+applying that lemma to the matrix `r • M` and evaluating the resulting polynomial at the scalar
+`s`; stated directly it needs no `[Nontrivial R]` hypothesis and no `Polynomial`. -/
 theorem det_smul_sub_smul_one_fin_two {R : Type*} [CommRing R]
     (M : Matrix (Fin 2) (Fin 2) R) (r s : R) :
     (r • M - s • (1 : Matrix (Fin 2) (Fin 2) R)).det
@@ -64,5 +67,23 @@ theorem det_smul_sub_smul_one_fin_two {R : Type*} [CommRing R]
     fin_cases i <;> fin_cases j <;> simp
   rw [hlit, det_fin_two_of, det_fin_two M, trace_fin_two M]
   ring
+
+/-- The pencil determinant of a square matrix on any index type of cardinality two, as a binary
+quadratic form in `(r, s)` with coefficients the determinant and trace of `M`.
+
+This is `det_smul_sub_smul_one_fin_two` transported along an equivalence `n ≃ Fin 2`, in the same
+relationship that Mathlib's `Matrix.charpoly_of_card_eq_two` bears to `Matrix.charpoly_fin_two`. -/
+theorem det_smul_sub_smul_one_of_card_eq_two {n R : Type*} [Fintype n] [DecidableEq n]
+    [CommRing R] (M : Matrix n n R) (hn : Fintype.card n = 2) (r s : R) :
+    (r • M - s • (1 : Matrix n n R)).det = M.det * r ^ 2 - M.trace * (r * s) + s ^ 2 := by
+  let e : n ≃ Fin 2 := Fintype.equivFinOfCardEq hn
+  have hsub : (r • M - s • (1 : Matrix n n R)).submatrix e.symm e.symm
+      = r • M.submatrix e.symm e.symm - s • (1 : Matrix (Fin 2) (Fin 2) R) := by
+    simp [Matrix.submatrix_sub, Matrix.submatrix_smul]
+  -- `trace` is transported by hand: Mathlib has `det_submatrix_equiv_self` but no trace analogue.
+  have htr : (M.submatrix e.symm e.symm).trace = M.trace :=
+    Equiv.sum_comp e.symm fun j => M j j
+  rw [← det_submatrix_equiv_self e.symm, hsub, det_smul_sub_smul_one_fin_two,
+    det_submatrix_equiv_self e.symm, htr]
 
 end TauCeti.Matrix

--- a/TauCeti/LinearAlgebra/Matrix/CharpolyFinTwo.lean
+++ b/TauCeti/LinearAlgebra/Matrix/CharpolyFinTwo.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+public import Mathlib.LinearAlgebra.Matrix.Trace
+
+public section
+
+/-!
+# The homogeneous characteristic form of a `2 × 2` matrix
+
+Mathlib's `Matrix.charpoly_fin_two` records the characteristic polynomial of a `2 × 2` matrix as
+`X ^ 2 - C M.trace * X + C M.det`. This file records the *homogeneous* two-variable form of the
+same fact, evaluated directly as a determinant rather than through `Polynomial`:
+
+`(r • M - s • 1).det = M.det * r ^ 2 - M.trace * (r * s) + s ^ 2`.
+
+The two are close. Applying `charpoly_fin_two` to `r • M`, evaluating at `s` with
+`Matrix.eval_charpoly`, and simplifying the resulting `Matrix.trace_smul` and `Matrix.det_smul`
+does prove the identity below — in about twice the lines, and only over a `[Nontrivial R]`, which
+`charpoly_fin_two` requires and the statement here does not. What this file adds is therefore the
+*name* and the `Polynomial`-free form: an equation between two ring elements over any `CommRing`,
+which is the shape a caller with matrix data in hand wants to rewrite with.
+
+Read as a binary quadratic form in `(r, s)`, the right-hand side has leading coefficient `M.det`,
+middle coefficient `-M.trace` and constant coefficient `1`, so its discriminant is
+`M.trace ^ 2 - 4 * M.det` — which is Mathlib's `Matrix.discr` by `Matrix.disc_fin_two`.
+
+## Main results
+
+* `TauCeti.Matrix.det_smul_sub_smul_one_fin_two`: the identity displayed above.
+
+## Provenance
+
+Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
+`HasseWeil/WeilPairing/MatrixDet.lean`, declaration `det_smul_sub_smul_one_fin_two`.
+
+The file's two other declarations are deliberately not ported: `det_smul_sub_smul_one_fin_two_of`
+rewrites the identity under hypotheses `M.det = q` and `M.trace = t`, and `det_one_sub_fin_two` is
+the `r = s = -1` instance. Both are one-line consequences better written at their call sites than
+carried as API.
+-/
+
+open Matrix
+
+namespace TauCeti.Matrix
+
+/-- The determinant of the pencil `r • M - s • 1` of a `2 × 2` matrix, as a binary quadratic form
+in `(r, s)` whose coefficients are the determinant and the trace of `M`.
+
+This is the homogeneous form of `Matrix.charpoly_fin_two`, from which it can also be derived by
+evaluating at `r • M`; stated directly it needs no `[Nontrivial R]` hypothesis and no
+`Polynomial`. -/
+theorem det_smul_sub_smul_one_fin_two {R : Type*} [CommRing R]
+    (M : Matrix (Fin 2) (Fin 2) R) (r s : R) :
+    (r • M - s • (1 : Matrix (Fin 2) (Fin 2) R)).det
+      = M.det * r ^ 2 - M.trace * (r * s) + s ^ 2 := by
+  have hlit : r • M - s • (1 : Matrix (Fin 2) (Fin 2) R)
+      = !![r * M 0 0 - s, r * M 0 1; r * M 1 0, r * M 1 1 - s] := by
+    ext i j
+    fin_cases i <;> fin_cases j <;> simp
+  rw [hlit, det_fin_two_of, det_fin_two M, trace_fin_two M]
+  ring
+
+end TauCeti.Matrix

--- a/TauCeti/LinearAlgebra/Matrix/CharpolyFinTwo.lean
+++ b/TauCeti/LinearAlgebra/Matrix/CharpolyFinTwo.lean
@@ -27,7 +27,7 @@ which is the shape a caller with matrix data in hand wants to rewrite with.
 
 Read as a binary quadratic form in `(r, s)`, the right-hand side has leading coefficient `M.det`,
 middle coefficient `-M.trace` and constant coefficient `1`, so its discriminant is
-`M.trace ^ 2 - 4 * M.det` — which is Mathlib's `Matrix.discr` by `Matrix.disc_fin_two`.
+`M.trace ^ 2 - 4 * M.det` — which is Mathlib's `Matrix.discr` by `Matrix.discr_fin_two`.
 
 ## Main results
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"matrix-det-fin-two"}-->

Roadmap: EllipticCurves

Adds `TauCeti/LinearAlgebra/Matrix/CharpolyFinTwo.lean` with one identity:

```lean
theorem TauCeti.Matrix.det_smul_sub_smul_one_fin_two {R : Type*} [CommRing R]
    (M : Matrix (Fin 2) (Fin 2) R) (r s : R) :
    (r • M - s • (1 : Matrix (Fin 2) (Fin 2) R)).det
      = M.det * r ^ 2 - M.trace * (r * s) + s ^ 2
```

the homogeneous two-variable form of the characteristic polynomial of a `2 × 2` matrix, together
with `det_smul_sub_smul_one_of_card_eq_two`, the same statement for a square matrix on any index
type with `Fintype.card n = 2`. That pair mirrors Mathlib's own `Matrix.charpoly_fin_two` /
`Matrix.charpoly_of_card_eq_two`; neither of mine needs `[Nontrivial R]`, which both of Mathlib's
do. **Pure matrix algebra — no elliptic-curve content appears in the file, which imports two
Mathlib modules and nothing from this repository.**

## On reuse — stated up front, because I checked it rather than assuming

Mathlib has `Matrix.charpoly_fin_two` (`M.charpoly = X ^ 2 - C M.trace * X + C M.det`) and
`Matrix.eval_charpoly`. **The identity above is derivable from them**: apply `charpoly_fin_two` to
`r • M`, evaluate at `s`, and simplify with `Matrix.trace_smul` and `Matrix.det_smul`. I wrote that
derivation out and compiled it before opening this PR. It comes to roughly twice the lines of the
direct proof and, unlike the statement here, requires `[Nontrivial R]`, which `charpoly_fin_two`
carries.

So the honest claim for this PR is *not* that the fact is unreachable — it is that Mathlib does not
**name** the homogeneous form, and that a caller holding matrix data wants an equation between two
ring elements to rewrite with, not a `Polynomial` identity to evaluate. A search for the statement
itself found nothing: Loogle on `Matrix.det (_ • _ - _ • 1)` returns empty, and LeanSearch surfaces
only the univariate `charpoly_fin_two` / `charpoly_of_card_eq_two` and the unrelated
`det_one_add_smul`.

If the reviewers would rather this were inlined at its future call sites than named here, that is a
reasonable call and I will take it — but it would then be rewritten identically at each of them.

## What is deliberately not ported

The AINTLIB source file has three declarations; two are left out on purpose:

* `det_smul_sub_smul_one_fin_two_of` — the same identity after `rw [hdet, htr]` under hypotheses
  `M.det = q` and `M.trace = t`. A one-line rewrite at the call site.
* `det_one_sub_fin_two` — `(1 - M).det = 1 - M.trace + M.det`, which is the `r = s = -1` instance
  of the identity above.

Both are one-line consequences, and the `reuse` rubric on #2323 correctly rejected exactly this
kind of one-use wrapper, so they are not carried as API.

## Provenance

Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
`HasseWeil/WeilPairing/MatrixDet.lean`, declaration `det_smul_sub_smul_one_fin_two`. Restated with
the right-hand side ordered as a quadratic form in `(r, s)` — leading coefficient `M.det`, middle
coefficient `-M.trace`, constant `1` — rather than the source's `r ^ 2 * M.det - r * s * M.trace`,
so that it lines up with the `a x² + b x y + c y²` convention consumers use.

## Roadmap

`EllipticCurves`, Layer 3 — the Hasse strand, whose §Ordering entry reads *"the Hasse bound is the
earliest PR, its existing proof self-contained; the zeta strand needs Layer 1's Frobenius
identities."*

This is a prerequisite rather than a target, which `CLAUDE.md` admits explicitly: a declaration may
be added when it *"advances a specific roadmap target, or supplies a prerequisite that a specific
target needs"*. The need is checkable. In the roadmap's pinned Hasse provenance
(`dev/hasse-weil @ 513e83879e2f`), `HasseWeil/WeilPairing/MatrixDet.lean` lies inside the 187-file
import closure of the capstone `hasse_bound` proof, and its role there is the bridge from the
Frobenius matrix `M = ρ_ℓ(π)` — for which `det M ≡ q` and `tr M ≡ t` — to the binary quadratic form
`q r² − t·rs + s²` whose non-negativity yields the Hasse inequality. The arithmetic half of that
step is #2323; this is the linear-algebra half. Neither contains any curve.

Also worth recording, since it may be useful later: read as a quadratic form in `(r, s)`, the
right-hand side has discriminant `M.trace ^ 2 - 4 * M.det`, which is Mathlib's `Matrix.discr` by
`Matrix.disc_fin_two`. The module docstring notes this; no declaration here depends on it.

## Dry run

Run before opening for review: **7 rubrics approved** (`correctness`, `reuse`, `scope`,
`placement`, `naming`, `api-design`, `attribution`), two requested changes, both now addressed —
`generality` asked for the `Fintype.card n = 2` form, and `documentation` caught that I had
written the charpoly derivation as "evaluating at `r • M`" when `Matrix.eval_charpoly` evaluates
at a *scalar* (the derivation applies `charpoly_fin_two` to the matrix `r • M`, then evaluates at
`s`).

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
locally. Longest proof is 9 lines; no `sorry`, no `maxHeartbeats`.
