### PR TITLE
feat: smooth almost complex structures on manifolds

### DIFF
--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -17,20 +17,28 @@ manifolds. A smooth almost complex structure is a smooth section of the endomorp
 the tangent bundle whose square is fiberwise minus the identity. Its value at each point is the
 existing pointwise almost complex structure on that tangent space.
 
-The smoothness is part of the structure itself, while relations to a symplectic form such as
-tameness and compatibility remain separate hypotheses. This is the manifold-level definition
-needed in Lane F2.1 of the analytic Heegaard Floer roadmap before manifold-valued
-`J`-holomorphic maps can be stated.
+The smoothness is part of the structure itself, while relations to a symplectic form are not
+fields of it. Tameness and compatibility are currently available only pointwise, as
+`TauCeti.SymplecticForm.Tames` and `TauCeti.SymplecticForm.Compatible` on a real module, so they
+can only be stated for the tangent-fiber structures produced by `almostComplexStructureAt`. This
+is the manifold-level definition needed in Lane F2.1 of the analytic Heegaard Floer roadmap
+before manifold-valued `J`-holomorphic maps can be stated.
 
 ## Main declarations
 
 * `TauCeti.SmoothAlmostComplexStructure`: a smooth tangent-bundle endomorphism squaring to `-1`.
-* `TauCeti.SmoothAlmostComplexStructure.atPoint`: the pointwise almost complex structure on a
-  tangent space.
-* `TauCeti.SmoothAlmostComplexStructure.contMDiff_apply`: applying the structure to a smooth
-  vector field gives a smooth vector field.
-* `TauCeti.AlmostComplexStructure.toSmoothModelSpace`: a constant pointwise structure gives a
-  smooth almost complex structure on its model vector space.
+* `TauCeti.SmoothAlmostComplexStructure.almostComplexStructureAt`: the pointwise almost complex
+  structure on a tangent space.
+* `TauCeti.SmoothAlmostComplexStructure.contMDiff_apply`: applying the structure to a `C^n` vector
+  field along a `C^n` map gives a `C^n` vector field along that map.
+* `TauCeti.SmoothAlmostComplexStructure.neg`: the negative of a smooth almost complex structure.
+* `TauCeti.SmoothAlmostComplexStructure.const`: a continuous endomorphism of a real normed space
+  squaring to `-1` gives the constant smooth almost complex structure on that model manifold.
+* `TauCeti.AlmostComplexStructure.constSmooth`: a pointwise almost complex structure on a
+  finite-dimensional real normed space gives the constant smooth almost complex structure on that
+  model manifold.
+* `TauCeti.SmoothAlmostComplexStructure.product`: the standard smooth almost complex structure on
+  `V × V`, sending `(v, w)` to `(-w, v)`.
 
 The definition follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 Section 2.2.
@@ -86,7 +94,7 @@ instance : CoeFun (SmoothAlmostComplexStructure I M) fun _ =>
 
 /-- The value of a smooth almost complex structure at a point, as the existing pointwise
 `AlmostComplexStructure` on that tangent space. -/
-def atPoint (J : SmoothAlmostComplexStructure I M) (x : M) :
+def almostComplexStructureAt (J : SmoothAlmostComplexStructure I M) (x : M) :
     AlmostComplexStructure (TangentSpace I x) where
   toLinearMap := (J.toEndomorphism x).toLinearMap
   square_neg := by
@@ -96,30 +104,31 @@ def atPoint (J : SmoothAlmostComplexStructure I M) (x : M) :
     simpa using h
 
 @[simp]
-lemma atPoint_toLinearMap (J : SmoothAlmostComplexStructure I M) (x : M) :
-    (J.atPoint x).toLinearMap = (J.toEndomorphism x).toLinearMap :=
+lemma almostComplexStructureAt_toLinearMap (J : SmoothAlmostComplexStructure I M) (x : M) :
+    (J.almostComplexStructureAt x).toLinearMap = (J.toEndomorphism x).toLinearMap :=
   (rfl)
 
 /-- Evaluating the pointwise almost complex structure agrees with evaluating the smooth one. -/
 -- This is not a `simp` lemma: `simp` already rewrites the left-hand side through
--- `atPoint_toLinearMap`.
-lemma atPoint_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
-    J.atPoint x v = J x v :=
+-- `almostComplexStructureAt_toLinearMap`.
+lemma almostComplexStructureAt_apply (J : SmoothAlmostComplexStructure I M) (x : M)
+    (v : TangentSpace I x) :
+    J.almostComplexStructureAt x v = J x v :=
   (rfl)
 
 /-- Applying a smooth almost complex structure twice gives the negative tangent vector. -/
 @[simp]
 lemma apply_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
     J x (J x v) = -v :=
-  (J.atPoint x).apply_apply v
+  (J.almostComplexStructureAt x).apply_apply v
 
 /-- A smooth almost complex structure is fiberwise injective. -/
 lemma injective (J : SmoothAlmostComplexStructure I M) (x : M) : Function.Injective (J x) :=
-  (J.atPoint x).injective
+  (J.almostComplexStructureAt x).injective
 
 /-- A smooth almost complex structure is fiberwise surjective. -/
 lemma surjective (J : SmoothAlmostComplexStructure I M) (x : M) : Function.Surjective (J x) :=
-  (J.atPoint x).surjective
+  (J.almostComplexStructureAt x).surjective
 
 /-- Two smooth almost complex structures agreeing on every tangent vector are equal. -/
 @[ext]
@@ -128,19 +137,21 @@ lemma ext (h : ∀ (x : M) (v : TangentSpace I x), J x v = K x v) : J = K := by
   ext x v
   exact h x v
 
-/-- The underlying endomorphism field of a smooth almost complex structure is smooth. -/
-lemma contMDiff_toEndomorphism (J : SmoothAlmostComplexStructure I M) :
-    ContMDiff I (I.prod (modelWithCornersSelf ℝ (E →L[ℝ] E))) ∞
-      (fun x ↦ TotalSpace.mk' (E →L[ℝ] E) x (J.toEndomorphism x)) :=
-  J.toEndomorphism.contMDiff
+section ContMDiffApply
 
-/-- Applying a smooth almost complex structure to a smooth vector field gives a smooth vector
-field. -/
-lemma contMDiff_apply (J : SmoothAlmostComplexStructure I M)
-    {V : ∀ x : M, TangentSpace I x}
-    (hV : ContMDiff I I.tangent ∞ (fun x ↦ TotalSpace.mk' E x (V x))) :
-    ContMDiff I I.tangent ∞ (fun x ↦ TotalSpace.mk' E x (J x (V x))) :=
-  J.contMDiff_toEndomorphism.clm_bundle_apply hV
+variable {E' H' N : Type*} [NormedAddCommGroup E'] [NormedSpace ℝ E'] [TopologicalSpace H']
+  {I' : ModelWithCorners ℝ E' H'} [TopologicalSpace N] [ChartedSpace H' N]
+
+/-- Applying a smooth almost complex structure along a `C^n` map `b` to a `C^n` vector field along
+`b` gives a `C^n` vector field along `b`. Taking `b = id` this says that `J` preserves `C^n`
+vector fields on `M`. -/
+lemma contMDiff_apply {n : ℕ∞ω} [ENat.LEInfty n] (J : SmoothAlmostComplexStructure I M)
+    {b : N → M} (hb : ContMDiff I' I n b) {V : ∀ y : N, TangentSpace I (b y)}
+    (hV : ContMDiff I' I.tangent n (fun y ↦ TotalSpace.mk' E (b y) (V y))) :
+    ContMDiff I' I.tangent n (fun y ↦ TotalSpace.mk' E (b y) (J (b y) (V y))) :=
+  ((J.toEndomorphism.contMDiff.of_le ENat.LEInfty.out).comp hb).clm_bundle_apply hV
+
+end ContMDiffApply
 
 /-- Negating a smooth almost complex structure gives another smooth almost complex structure. -/
 def neg (J : SmoothAlmostComplexStructure I M) : SmoothAlmostComplexStructure I M where
@@ -170,9 +181,17 @@ lemma neg_neg (J : SmoothAlmostComplexStructure I M) : -(-J) = J := by
   ext x v
   simp
 
+/-- The pointwise structure of a negated smooth almost complex structure is the negation of the
+pointwise structure. -/
+@[simp]
+lemma neg_almostComplexStructureAt (J : SmoothAlmostComplexStructure I M) (x : M) :
+    (-J).almostComplexStructureAt x = -J.almostComplexStructureAt x := by
+  ext v
+  simp
+
 /-- A continuous endomorphism of a normed space squaring to `-1` defines a constant smooth almost
 complex structure on the corresponding model manifold. -/
-private def constantModelSpace {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+def const {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
     (Jc : V →L[ℝ] V) (hJc : ∀ v, Jc (Jc v) = -v) :
     SmoothAlmostComplexStructure (modelWithCornersSelf ℝ V) V where
   toEndomorphism :=
@@ -185,14 +204,17 @@ private def constantModelSpace {V : Type*} [NormedAddCommGroup V] [NormedSpace �
   square_neg := by
     intro x
     ext v
-    -- For the self model with identity corners, `TangentSpace` reduces definitionally to `V`;
-    -- Mathlib has no separate conversion lemma for this identification.
-    change Jc (Jc v) = -v
+    -- After the composition and the negated identity are unfolded, the goal is `hJc v`: the
+    -- additive group instance on `TangentSpace 𝓘(ℝ, V) x` is the one of `V` itself.
+    simp only [ContinuousLinearMap.coe_comp, Function.comp_apply, _root_.neg_apply,
+      ContinuousLinearMap.coe_id', id_eq]
     exact hJc v
 
-private lemma constantModelSpace_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+/-- The constant smooth almost complex structure of `Jc` evaluates to `Jc`. -/
+@[simp]
+lemma const_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
     (Jc : V →L[ℝ] V) (hJc : ∀ v, Jc (Jc v) = -v) (x v : V) :
-    constantModelSpace Jc hJc x v = Jc v :=
+    const Jc hJc x v = Jc v :=
   (rfl)
 
 end SmoothAlmostComplexStructure
@@ -203,21 +225,21 @@ variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] [FiniteDimension
 
 /-- A pointwise almost complex structure on a finite-dimensional normed vector space defines a
 constant smooth almost complex structure on the corresponding model manifold. -/
-def toSmoothModelSpace (J : AlmostComplexStructure V) :
+def constSmooth (J : AlmostComplexStructure V) :
     SmoothAlmostComplexStructure (modelWithCornersSelf ℝ V) V :=
-  SmoothAlmostComplexStructure.constantModelSpace (LinearMap.toContinuousLinearMap J.toLinearMap)
+  SmoothAlmostComplexStructure.const (LinearMap.toContinuousLinearMap J.toLinearMap)
     J.apply_apply
 
 @[simp]
-lemma toSmoothModelSpace_apply (J : AlmostComplexStructure V) (x v : V) :
-    J.toSmoothModelSpace x v = J v :=
-  SmoothAlmostComplexStructure.constantModelSpace_apply _ _ x v
+lemma constSmooth_apply (J : AlmostComplexStructure V) (x v : V) :
+    J.constSmooth x v = J v :=
+  SmoothAlmostComplexStructure.const_apply _ _ x v
 
 @[simp]
-lemma toSmoothModelSpace_atPoint (J : AlmostComplexStructure V) (x : V) :
-    J.toSmoothModelSpace.atPoint x = J := by
+lemma constSmooth_almostComplexStructureAt (J : AlmostComplexStructure V) (x : V) :
+    J.constSmooth.almostComplexStructureAt x = J := by
   ext v
-  exact toSmoothModelSpace_apply J x v
+  exact constSmooth_apply J x v
 
 end AlmostComplexStructure
 
@@ -226,17 +248,18 @@ namespace SmoothAlmostComplexStructure
 /-- The standard smooth almost complex structure on `V × V`, sending `(v, w)` to `(-w, v)`. -/
 noncomputable def product (V : Type*) [NormedAddCommGroup V] [NormedSpace ℝ V] :
     SmoothAlmostComplexStructure (modelWithCornersSelf ℝ (V × V)) (V × V) :=
-  constantModelSpace ((-ContinuousLinearMap.snd ℝ V V).prod (ContinuousLinearMap.fst ℝ V V))
-    fun _ ↦ rfl
+  const ((-ContinuousLinearMap.snd ℝ V V).prod (ContinuousLinearMap.fst ℝ V V))
+    fun v => by ext <;> simp
 
 @[simp]
 lemma product_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] (x v : V × V) :
     product V x v = (-v.2, v.1) :=
-  constantModelSpace_apply _ _ x v
+  const_apply _ _ x v
 
 @[simp]
-lemma product_atPoint {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] (x : V × V) :
-    (product V).atPoint x = AlmostComplexStructure.product V := by
+lemma product_almostComplexStructureAt {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (x : V × V) :
+    (product V).almostComplexStructureAt x = AlmostComplexStructure.product V := by
   ext v
   exact product_apply x v
 

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -201,6 +201,12 @@ lemma toSmoothModelSpace_apply (J : AlmostComplexStructure V) (x v : V) :
   rw [toSmoothModelSpace]
   rfl
 
+@[simp]
+lemma toSmoothModelSpace_atPoint (J : AlmostComplexStructure V) (x : V) :
+    J.toSmoothModelSpace.atPoint x = J := by
+  ext v
+  exact toSmoothModelSpace_apply J x v
+
 end AlmostComplexStructure
 
 namespace SmoothAlmostComplexStructure
@@ -233,6 +239,12 @@ lemma product_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] (x v 
     product V x v = (-v.2, v.1) := by
   rw [product]
   rfl
+
+@[simp]
+lemma product_atPoint {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] (x : V × V) :
+    (product V).atPoint x = AlmostComplexStructure.product V := by
+  ext v
+  exact product_apply x v
 
 end SmoothAlmostComplexStructure
 

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -98,6 +98,7 @@ lemma atPoint_toLinearMap (J : SmoothAlmostComplexStructure I M) (x : M) :
     (J.atPoint x).toLinearMap = (J.toEndomorphism x).toLinearMap :=
   (rfl)
 
+@[simp]
 lemma atPoint_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
     J.atPoint x v = J x v :=
   (rfl)
@@ -105,10 +106,8 @@ lemma atPoint_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentS
 /-- Applying a smooth almost complex structure twice gives the negative tangent vector. -/
 @[simp]
 lemma apply_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
-    J x (J x v) = -v := by
-  have h := congrArg (fun A : TangentSpace I x →L[ℝ] TangentSpace I x ↦ A v)
-    (J.square_neg x)
-  simpa using h
+    J x (J x v) = -v :=
+  (J.atPoint x).apply_apply v
 
 /-- A smooth almost complex structure is fiberwise injective. -/
 lemma injective (J : SmoothAlmostComplexStructure I M) (x : M) : Function.Injective (J x) :=
@@ -155,6 +154,7 @@ lemma neg_toEndomorphism (J : SmoothAlmostComplexStructure I M) :
     (-J).toEndomorphism = -J.toEndomorphism :=
   (rfl)
 
+@[simp]
 lemma neg_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
     (-J) x v = -J x v :=
   (rfl)
@@ -186,6 +186,8 @@ def toSmoothModelSpace (J : AlmostComplexStructure V) :
       square_neg := by
         intro x
         ext v
+        -- For the self model with identity corners, `TangentSpace` reduces definitionally to `V`;
+        -- Mathlib has no separate conversion lemma for this identification.
         change J.toLinearMap (J.toLinearMap v) = -v
         exact J.apply_apply v }
 
@@ -195,17 +197,40 @@ lemma toSmoothModelSpace_apply (J : AlmostComplexStructure V) (x v : V) :
   rw [toSmoothModelSpace]
   rfl
 
+end AlmostComplexStructure
+
+namespace SmoothAlmostComplexStructure
+
 /-- The standard smooth almost complex structure on `V × V`, sending `(v, w)` to `(-w, v)`. -/
-noncomputable def smoothProduct (V : Type*) [NormedAddCommGroup V] [NormedSpace ℝ V]
-    [FiniteDimensional ℝ V] :
-    SmoothAlmostComplexStructure (modelWithCornersSelf ℝ (V × V)) (V × V) :=
-  (AlmostComplexStructure.product V).toSmoothModelSpace
+noncomputable def product (V : Type*) [NormedAddCommGroup V] [NormedSpace ℝ V] :
+    SmoothAlmostComplexStructure (modelWithCornersSelf ℝ (V × V)) (V × V) := by
+  let Jc : V × V →L[ℝ] V × V :=
+    (-ContinuousLinearMap.snd ℝ V V).prod (ContinuousLinearMap.fst ℝ V V)
+  exact
+    { toEndomorphism :=
+      ⟨fun _ ↦ Jc, by
+      intro x
+      rw [contMDiffAt_hom_bundle]
+      refine ⟨contMDiffAt_id, ?_⟩
+      simpa [inCoordinates_tangent_bundle_core_model_space] using
+        (contMDiffAt_const (x := x) (c := Jc))⟩
+      square_neg := by
+        intro x
+        ext v
+        -- For the self model with identity corners, `TangentSpace` reduces definitionally to
+        -- `V × V`; Mathlib has no separate conversion lemma for this identification.
+        change Jc (Jc v) = -v
+        have hJc : Jc v = (-v.2, v.1) := by rfl
+        rw [hJc]
+        rfl }
 
 @[simp]
-lemma smoothProduct_apply (x v : V × V) : smoothProduct V x v = (-v.2, v.1) := by
-  rw [smoothProduct, toSmoothModelSpace_apply, product_apply]
+lemma product_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] (x v : V × V) :
+    product V x v = (-v.2, v.1) := by
+  rw [product]
+  rfl
 
-end AlmostComplexStructure
+end SmoothAlmostComplexStructure
 
 end TauCeti
 

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -50,6 +50,18 @@ variable [NormedAddCommGroup E] [NormedSpace ℝ E]
 variable [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
 variable [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
 
+private def constantEndomorphismSection {V : Type*} [NormedAddCommGroup V]
+    [NormedSpace ℝ V] (Jc : V →L[ℝ] V) :
+    ContMDiffSection (modelWithCornersSelf ℝ V) (V →L[ℝ] V) ∞
+      (fun x : V ↦ TangentSpace (modelWithCornersSelf ℝ V) x →L[ℝ]
+        TangentSpace (modelWithCornersSelf ℝ V) x) :=
+  ⟨fun _ ↦ Jc, by
+    intro x
+    rw [contMDiffAt_hom_bundle]
+    refine ⟨contMDiffAt_id, ?_⟩
+    simpa [inCoordinates_tangent_bundle_core_model_space] using
+      (contMDiffAt_const (x := x) (c := Jc))⟩
+
 /-- A smooth almost complex structure on a manifold is a smooth tangent-bundle endomorphism
 whose square is fiberwise minus the identity.
 
@@ -180,13 +192,7 @@ def toSmoothModelSpace (J : AlmostComplexStructure V) :
     SmoothAlmostComplexStructure (modelWithCornersSelf ℝ V) V := by
   let Jc : V →L[ℝ] V := LinearMap.toContinuousLinearMap J.toLinearMap
   exact
-    { toEndomorphism :=
-      ⟨fun _ ↦ Jc, by
-      intro x
-      rw [contMDiffAt_hom_bundle]
-      refine ⟨contMDiffAt_id, ?_⟩
-      simpa [inCoordinates_tangent_bundle_core_model_space] using
-        (contMDiffAt_const (x := x) (c := Jc))⟩
+    { toEndomorphism := constantEndomorphismSection Jc
       square_neg := by
         intro x
         ext v
@@ -217,13 +223,7 @@ noncomputable def product (V : Type*) [NormedAddCommGroup V] [NormedSpace ℝ V]
   let Jc : V × V →L[ℝ] V × V :=
     (-ContinuousLinearMap.snd ℝ V V).prod (ContinuousLinearMap.fst ℝ V V)
   exact
-    { toEndomorphism :=
-      ⟨fun _ ↦ Jc, by
-      intro x
-      rw [contMDiffAt_hom_bundle]
-      refine ⟨contMDiffAt_id, ?_⟩
-      simpa [inCoordinates_tangent_bundle_core_model_space] using
-        (contMDiffAt_const (x := x) (c := Jc))⟩
+    { toEndomorphism := constantEndomorphismSection Jc
       square_neg := by
         intro x
         ext v

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -98,8 +98,9 @@ lemma atPoint_toLinearMap (J : SmoothAlmostComplexStructure I M) (x : M) :
     (J.atPoint x).toLinearMap = (J.toEndomorphism x).toLinearMap :=
   (rfl)
 
-/-- Not a `simp` lemma: `simp` already rewrites the left-hand side through
-`atPoint_toLinearMap`. -/
+/-- Evaluating the pointwise almost complex structure agrees with evaluating the smooth one. -/
+-- This is not a `simp` lemma: `simp` already rewrites the left-hand side through
+-- `atPoint_toLinearMap`.
 lemma atPoint_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
     J.atPoint x v = J x v :=
   (rfl)
@@ -155,8 +156,9 @@ lemma neg_toEndomorphism (J : SmoothAlmostComplexStructure I M) :
     (-J).toEndomorphism = -J.toEndomorphism :=
   (rfl)
 
-/-- Not a `simp` lemma: `simp` already rewrites the left-hand side through
-`neg_toEndomorphism`. -/
+/-- Evaluating a negated smooth almost complex structure negates its value. -/
+-- This is not a `simp` lemma: `simp` already rewrites the left-hand side through
+-- `neg_toEndomorphism`.
 lemma neg_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
     (-J) x v = -J x v :=
   (rfl)

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -98,7 +98,6 @@ lemma atPoint_toLinearMap (J : SmoothAlmostComplexStructure I M) (x : M) :
     (J.atPoint x).toLinearMap = (J.toEndomorphism x).toLinearMap :=
   (rfl)
 
-@[simp]
 lemma atPoint_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
     J.atPoint x v = J x v :=
   (rfl)
@@ -156,7 +155,6 @@ lemma neg_toEndomorphism (J : SmoothAlmostComplexStructure I M) :
     (-J).toEndomorphism = -J.toEndomorphism :=
   (rfl)
 
-@[simp]
 lemma neg_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
     (-J) x v = -J x v :=
   (rfl)

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -50,18 +50,6 @@ variable [NormedAddCommGroup E] [NormedSpace ℝ E]
 variable [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
 variable [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
 
-private def constantEndomorphismSection {V : Type*} [NormedAddCommGroup V]
-    [NormedSpace ℝ V] (Jc : V →L[ℝ] V) :
-    ContMDiffSection (modelWithCornersSelf ℝ V) (V →L[ℝ] V) ∞
-      (fun x : V ↦ TangentSpace (modelWithCornersSelf ℝ V) x →L[ℝ]
-        TangentSpace (modelWithCornersSelf ℝ V) x) :=
-  ⟨fun _ ↦ Jc, by
-    intro x
-    rw [contMDiffAt_hom_bundle]
-    refine ⟨contMDiffAt_id, ?_⟩
-    simpa [inCoordinates_tangent_bundle_core_model_space] using
-      (contMDiffAt_const (x := x) (c := Jc))⟩
-
 /-- A smooth almost complex structure on a manifold is a smooth tangent-bundle endomorphism
 whose square is fiberwise minus the identity.
 
@@ -90,6 +78,8 @@ theorem toEndomorphism_injective :
   subst h
   rfl
 
+/-- A smooth almost complex structure is applied as `J x v`, evaluating its endomorphism of the
+tangent space at `x` on the tangent vector `v`. -/
 instance : CoeFun (SmoothAlmostComplexStructure I M) fun _ =>
     (x : M) → TangentSpace I x → TangentSpace I x :=
   ⟨fun J x ↦ J.toEndomorphism x⟩
@@ -180,6 +170,31 @@ lemma neg_neg (J : SmoothAlmostComplexStructure I M) : -(-J) = J := by
   ext x v
   simp
 
+/-- A continuous endomorphism of a normed space squaring to `-1` defines a constant smooth almost
+complex structure on the corresponding model manifold. -/
+private def constantModelSpace {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (Jc : V →L[ℝ] V) (hJc : ∀ v, Jc (Jc v) = -v) :
+    SmoothAlmostComplexStructure (modelWithCornersSelf ℝ V) V where
+  toEndomorphism :=
+    ⟨fun _ ↦ Jc, by
+      intro x
+      rw [contMDiffAt_hom_bundle]
+      refine ⟨contMDiffAt_id, ?_⟩
+      simpa [inCoordinates_tangent_bundle_core_model_space] using
+        (contMDiffAt_const (x := x) (c := Jc))⟩
+  square_neg := by
+    intro x
+    ext v
+    -- For the self model with identity corners, `TangentSpace` reduces definitionally to `V`;
+    -- Mathlib has no separate conversion lemma for this identification.
+    change Jc (Jc v) = -v
+    exact hJc v
+
+private lemma constantModelSpace_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (Jc : V →L[ℝ] V) (hJc : ∀ v, Jc (Jc v) = -v) (x v : V) :
+    constantModelSpace Jc hJc x v = Jc v :=
+  (rfl)
+
 end SmoothAlmostComplexStructure
 
 namespace AlmostComplexStructure
@@ -189,23 +204,14 @@ variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] [FiniteDimension
 /-- A pointwise almost complex structure on a finite-dimensional normed vector space defines a
 constant smooth almost complex structure on the corresponding model manifold. -/
 def toSmoothModelSpace (J : AlmostComplexStructure V) :
-    SmoothAlmostComplexStructure (modelWithCornersSelf ℝ V) V := by
-  let Jc : V →L[ℝ] V := LinearMap.toContinuousLinearMap J.toLinearMap
-  exact
-    { toEndomorphism := constantEndomorphismSection Jc
-      square_neg := by
-        intro x
-        ext v
-        -- For the self model with identity corners, `TangentSpace` reduces definitionally to `V`;
-        -- Mathlib has no separate conversion lemma for this identification.
-        change J.toLinearMap (J.toLinearMap v) = -v
-        exact J.apply_apply v }
+    SmoothAlmostComplexStructure (modelWithCornersSelf ℝ V) V :=
+  SmoothAlmostComplexStructure.constantModelSpace (LinearMap.toContinuousLinearMap J.toLinearMap)
+    J.apply_apply
 
 @[simp]
 lemma toSmoothModelSpace_apply (J : AlmostComplexStructure V) (x v : V) :
-    J.toSmoothModelSpace x v = J v := by
-  rw [toSmoothModelSpace]
-  rfl
+    J.toSmoothModelSpace x v = J v :=
+  SmoothAlmostComplexStructure.constantModelSpace_apply _ _ x v
 
 @[simp]
 lemma toSmoothModelSpace_atPoint (J : AlmostComplexStructure V) (x : V) :
@@ -219,26 +225,14 @@ namespace SmoothAlmostComplexStructure
 
 /-- The standard smooth almost complex structure on `V × V`, sending `(v, w)` to `(-w, v)`. -/
 noncomputable def product (V : Type*) [NormedAddCommGroup V] [NormedSpace ℝ V] :
-    SmoothAlmostComplexStructure (modelWithCornersSelf ℝ (V × V)) (V × V) := by
-  let Jc : V × V →L[ℝ] V × V :=
-    (-ContinuousLinearMap.snd ℝ V V).prod (ContinuousLinearMap.fst ℝ V V)
-  exact
-    { toEndomorphism := constantEndomorphismSection Jc
-      square_neg := by
-        intro x
-        ext v
-        -- For the self model with identity corners, `TangentSpace` reduces definitionally to
-        -- `V × V`; Mathlib has no separate conversion lemma for this identification.
-        change Jc (Jc v) = -v
-        have hJc : Jc v = (-v.2, v.1) := by rfl
-        rw [hJc]
-        rfl }
+    SmoothAlmostComplexStructure (modelWithCornersSelf ℝ (V × V)) (V × V) :=
+  constantModelSpace ((-ContinuousLinearMap.snd ℝ V V).prod (ContinuousLinearMap.fst ℝ V V))
+    fun _ ↦ rfl
 
 @[simp]
 lemma product_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] (x v : V × V) :
-    product V x v = (-v.2, v.1) := by
-  rw [product]
-  rfl
+    product V x v = (-v.2, v.1) :=
+  constantModelSpace_apply _ _ x v
 
 @[simp]
 lemma product_atPoint {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] (x : V × V) :

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -98,7 +98,8 @@ lemma atPoint_toLinearMap (J : SmoothAlmostComplexStructure I M) (x : M) :
     (J.atPoint x).toLinearMap = (J.toEndomorphism x).toLinearMap :=
   (rfl)
 
-@[simp]
+/-- Not a `simp` lemma: `simp` already rewrites the left-hand side through
+`atPoint_toLinearMap`. -/
 lemma atPoint_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
     J.atPoint x v = J x v :=
   (rfl)
@@ -154,7 +155,8 @@ lemma neg_toEndomorphism (J : SmoothAlmostComplexStructure I M) :
     (-J).toEndomorphism = -J.toEndomorphism :=
   (rfl)
 
-@[simp]
+/-- Not a `simp` lemma: `simp` already rewrites the left-hand side through
+`neg_toEndomorphism`. -/
 lemma neg_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
     (-J) x v = -J x v :=
   (rfl)

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.VectorBundle.ContMDiffSection
+public import Mathlib.Geometry.Manifold.VectorBundle.Hom
+public import Mathlib.Geometry.Manifold.VectorBundle.Tangent
+public import TauCeti.Geometry.Symplectic.AlmostComplex
+
+/-!
+# Smooth almost complex structures on manifolds
+
+This file lifts the pointwise linear algebra of `TauCeti.AlmostComplexStructure` to smooth
+manifolds. A smooth almost complex structure is a smooth section of the endomorphism bundle of
+the tangent bundle whose square is fiberwise minus the identity. Its value at each point is the
+existing pointwise almost complex structure on that tangent space.
+
+The smoothness is part of the structure itself, while relations to a symplectic form such as
+tameness and compatibility remain separate hypotheses. This is the manifold-level definition
+needed in Lane F2.1 of the analytic Heegaard Floer roadmap before manifold-valued
+`J`-holomorphic maps can be stated.
+
+## Main declarations
+
+* `TauCeti.SmoothAlmostComplexStructure`: a smooth tangent-bundle endomorphism squaring to `-1`.
+* `TauCeti.SmoothAlmostComplexStructure.atPoint`: the pointwise almost complex structure on a
+  tangent space.
+* `TauCeti.SmoothAlmostComplexStructure.contMDiff_apply`: applying the structure to a smooth
+  vector field gives a smooth vector field.
+* `TauCeti.AlmostComplexStructure.toSmoothModelSpace`: a constant pointwise structure gives a
+  smooth almost complex structure on its model vector space.
+
+The definition follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
+Section 2.2.
+-/
+
+public section
+
+open Bundle
+open scoped ContDiff Manifold
+
+noncomputable section
+
+namespace TauCeti
+
+variable {E H M : Type*}
+variable [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+variable [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+
+/-- A smooth almost complex structure on a manifold is a smooth tangent-bundle endomorphism
+whose square is fiberwise minus the identity.
+
+The endomorphism is bundled as a smooth section of `End(TM)`. Tameness, compatibility with a
+symplectic form, and integrability are deliberately not fields of this structure. -/
+structure SmoothAlmostComplexStructure (I : ModelWithCorners ℝ E H) (M : Type*)
+    [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M] where
+  /-- The underlying smooth section of the tangent endomorphism bundle. -/
+  toEndomorphism :
+    ContMDiffSection I (E →L[ℝ] E) ∞
+      (fun x : M ↦ TangentSpace I x →L[ℝ] TangentSpace I x)
+  /-- The defining identity `J² = -1` on every tangent fiber. -/
+  square_neg : ∀ x, (toEndomorphism x).comp (toEndomorphism x) = -ContinuousLinearMap.id ℝ _
+
+namespace SmoothAlmostComplexStructure
+
+variable {J K : SmoothAlmostComplexStructure I M}
+
+/-- The underlying smooth endomorphism section determines a smooth almost complex structure. -/
+theorem toEndomorphism_injective :
+    Function.Injective
+      (toEndomorphism : SmoothAlmostComplexStructure I M →
+        ContMDiffSection I (E →L[ℝ] E) ∞
+          (fun x : M ↦ TangentSpace I x →L[ℝ] TangentSpace I x)) := by
+  rintro ⟨J, hJ⟩ ⟨K, hK⟩ h
+  subst h
+  rfl
+
+instance : CoeFun (SmoothAlmostComplexStructure I M) fun _ =>
+    (x : M) → TangentSpace I x → TangentSpace I x :=
+  ⟨fun J x ↦ J.toEndomorphism x⟩
+
+/-- The value of a smooth almost complex structure at a point, as the existing pointwise
+`AlmostComplexStructure` on that tangent space. -/
+def atPoint (J : SmoothAlmostComplexStructure I M) (x : M) :
+    AlmostComplexStructure (TangentSpace I x) where
+  toLinearMap := (J.toEndomorphism x).toLinearMap
+  square_neg := by
+    ext v
+    have h := congrArg (fun A : TangentSpace I x →L[ℝ] TangentSpace I x ↦ A v)
+      (J.square_neg x)
+    simpa using h
+
+@[simp]
+lemma atPoint_toLinearMap (J : SmoothAlmostComplexStructure I M) (x : M) :
+    (J.atPoint x).toLinearMap = (J.toEndomorphism x).toLinearMap :=
+  (rfl)
+
+@[simp]
+lemma atPoint_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
+    J.atPoint x v = J x v :=
+  (rfl)
+
+/-- Applying a smooth almost complex structure twice gives the negative tangent vector. -/
+@[simp]
+lemma apply_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
+    J x (J x v) = -v := by
+  have h := congrArg (fun A : TangentSpace I x →L[ℝ] TangentSpace I x ↦ A v)
+    (J.square_neg x)
+  simpa using h
+
+/-- A smooth almost complex structure is fiberwise injective. -/
+lemma injective (J : SmoothAlmostComplexStructure I M) (x : M) : Function.Injective (J x) :=
+  (J.atPoint x).injective
+
+/-- A smooth almost complex structure is fiberwise surjective. -/
+lemma surjective (J : SmoothAlmostComplexStructure I M) (x : M) : Function.Surjective (J x) :=
+  (J.atPoint x).surjective
+
+/-- Two smooth almost complex structures agreeing on every tangent vector are equal. -/
+@[ext]
+lemma ext (h : ∀ (x : M) (v : TangentSpace I x), J x v = K x v) : J = K := by
+  apply toEndomorphism_injective
+  ext x v
+  exact h x v
+
+/-- The underlying endomorphism field of a smooth almost complex structure is smooth. -/
+lemma contMDiff_toEndomorphism (J : SmoothAlmostComplexStructure I M) :
+    ContMDiff I (I.prod (modelWithCornersSelf ℝ (E →L[ℝ] E))) ∞
+      (fun x ↦ TotalSpace.mk' (E →L[ℝ] E) x (J.toEndomorphism x)) :=
+  J.toEndomorphism.contMDiff
+
+/-- Applying a smooth almost complex structure to a smooth vector field gives a smooth vector
+field. -/
+lemma contMDiff_apply (J : SmoothAlmostComplexStructure I M)
+    {V : ∀ x : M, TangentSpace I x}
+    (hV : ContMDiff I I.tangent ∞ (fun x ↦ TotalSpace.mk' E x (V x))) :
+    ContMDiff I I.tangent ∞ (fun x ↦ TotalSpace.mk' E x (J x (V x))) :=
+  J.contMDiff_toEndomorphism.clm_bundle_apply hV
+
+/-- Negating a smooth almost complex structure gives another smooth almost complex structure. -/
+def neg (J : SmoothAlmostComplexStructure I M) : SmoothAlmostComplexStructure I M where
+  toEndomorphism := -J.toEndomorphism
+  square_neg := by
+    intro x
+    ext v
+    simp
+
+instance : Neg (SmoothAlmostComplexStructure I M) :=
+  ⟨neg⟩
+
+@[simp]
+lemma neg_toEndomorphism (J : SmoothAlmostComplexStructure I M) :
+    (-J).toEndomorphism = -J.toEndomorphism :=
+  (rfl)
+
+@[simp]
+lemma neg_apply (J : SmoothAlmostComplexStructure I M) (x : M) (v : TangentSpace I x) :
+    (-J) x v = -J x v :=
+  (rfl)
+
+@[simp]
+lemma neg_neg (J : SmoothAlmostComplexStructure I M) : -(-J) = J := by
+  ext x v
+  simp
+
+end SmoothAlmostComplexStructure
+
+namespace AlmostComplexStructure
+
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] [FiniteDimensional ℝ V]
+
+/-- A pointwise almost complex structure on a finite-dimensional normed vector space defines a
+constant smooth almost complex structure on the corresponding model manifold. -/
+def toSmoothModelSpace (J : AlmostComplexStructure V) :
+    SmoothAlmostComplexStructure (modelWithCornersSelf ℝ V) V := by
+  let Jc : V →L[ℝ] V := LinearMap.toContinuousLinearMap J.toLinearMap
+  exact
+    { toEndomorphism :=
+      ⟨fun _ ↦ Jc, by
+      intro x
+      rw [contMDiffAt_hom_bundle]
+      refine ⟨contMDiffAt_id, ?_⟩
+      simpa [inCoordinates_tangent_bundle_core_model_space] using
+        (contMDiffAt_const (x := x) (c := Jc))⟩
+      square_neg := by
+        intro x
+        ext v
+        change J.toLinearMap (J.toLinearMap v) = -v
+        exact J.apply_apply v }
+
+@[simp]
+lemma toSmoothModelSpace_apply (J : AlmostComplexStructure V) (x v : V) :
+    J.toSmoothModelSpace x v = J v := by
+  rw [toSmoothModelSpace]
+  rfl
+
+/-- The standard smooth almost complex structure on `V × V`, sending `(v, w)` to `(-w, v)`. -/
+noncomputable def smoothProduct (V : Type*) [NormedAddCommGroup V] [NormedSpace ℝ V]
+    [FiniteDimensional ℝ V] :
+    SmoothAlmostComplexStructure (modelWithCornersSelf ℝ (V × V)) (V × V) :=
+  (AlmostComplexStructure.product V).toSmoothModelSpace
+
+@[simp]
+lemma smoothProduct_apply (x v : V × V) : smoothProduct V x v = (-v.2, v.1) := by
+  rw [smoothProduct, toSmoothModelSpace_apply, product_apply]
+
+end AlmostComplexStructure
+
+end TauCeti
+
+end


### PR DESCRIPTION
This PR lifts the pointwise almost-complex linear algebra to smooth manifolds by defining `SmoothAlmostComplexStructure` as a smooth section of `End(TM)` satisfying `J² = -1` fiberwise. It exposes the induced `AlmostComplexStructure` on each tangent space, proves fiberwise bijectivity and extensionality, shows that applying `J` preserves smooth vector fields, supplies negation, and constructs constant structures on finite-dimensional model manifolds, including the standard product structure `(v, w) ↦ (-w, v)`.

This advances the HeegaardFloer roadmap, Lane F2.1, target “Definitions land immediately”: almost complex structures on manifolds are the next layer above the existing pointwise definitions and are required before manifold-valued `J`-holomorphic maps and their energy can be stated. After this PR, F2.1 still needs smooth symplectic forms with closedness, the unbundled tame/compatible relations on tangent fibers, manifold-level `J`-holomorphic maps, and energy.

The construction follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Section 2.2, as cited in the module docstring. No Mathlib infrastructure is vendored: the implementation directly consumes Mathlib's smooth-section and continuous-linear-map bundle APIs (`ContMDiffSection`, the tangent bundle, and `ContMDiff.clm_bundle_apply`) and Tau Ceti's existing pointwise `AlmostComplexStructure`.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"smooth-almost-complex-structure"}-->

🤖 Prepared with Codex
