### PR TITLE
feat: compact perturbations of Fredholm operators

### DIFF
--- a/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
+++ b/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
@@ -42,7 +42,9 @@ forces the values at `c = 0` and `c = 1` to agree.
   operator is Fredholm.
 * `TauCeti.ContinuousLinearMap.index_add_of_isCompactOperator`: a compact perturbation leaves the
   index unchanged.
-* `TauCeti.ContinuousLinearMap.index_one_sub_eq_zero`: `1 - K` has index `0` for `K` compact.
+* `TauCeti.ContinuousLinearMap.index_one_sub_eq_zero` and
+  `TauCeti.ContinuousLinearMap.index_one_add_eq_zero`: `1 - K` and `1 + K` have index `0` for `K`
+  compact.
 
 The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix
 A.1; the compact-perturbation statement is Atkinson's theorem together with the Riesz--Schauder
@@ -167,6 +169,13 @@ theorem index_one_sub_eq_zero {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
     ext x
     simp [sub_eq_add_neg]
   rw [hrw, index_add_of_isCompactOperator isFredholm_id hneg, index_id]
+
+/-- A compact perturbation of the identity has index `0`, in additive form. -/
+@[simp]
+theorem index_one_add_eq_zero {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
+    index (1 + K : E →L[𝕜] E) = 0 := by
+  have hrw : (1 + K : E →L[𝕜] E) = ContinuousLinearMap.id 𝕜 E + K := rfl
+  rw [hrw, index_add_of_isCompactOperator isFredholm_id hK, index_id]
 
 end ContinuousLinearMap
 

--- a/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
+++ b/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
@@ -158,6 +158,7 @@ theorem index_add_of_isCompactOperator (hT : ContinuousLinearMap.IsFredholm T)
   simpa using Continuous.index_eq_of_preconnectedSpace hcont hfred 1 0
 
 /-- A compact perturbation of the identity has index `0`. -/
+@[simp]
 theorem index_one_sub_eq_zero {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
     index (1 - K : E →L[𝕜] E) = 0 := by
   have hneg : IsCompactOperator (-K : E →L[𝕜] E) := by

--- a/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
+++ b/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
@@ -70,8 +70,7 @@ theorem isFredholm_one_sub {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
 theorem isFredholm_one_add {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
     ContinuousLinearMap.IsFredholm (1 + K : E →L[𝕜] E) := by
   have hneg : IsCompactOperator (-K : E →L[𝕜] E) := by
-    change IsCompactOperator (-⇑K)
-    exact hK.neg
+    simpa only [FunLike.coe_neg] using hK.neg
   have hrw : (1 + K : E →L[𝕜] E) = 1 - (-K) := by abel
   rw [hrw]
   exact isFredholm_one_sub hneg
@@ -100,7 +99,10 @@ theorem _root_.ContinuousLinearMap.IsFredholm.add_of_isCompactOperator
     exact h
   have hcomp₁ : ContinuousLinearMap.IsFredholm (S.comp (T + C)) := by
     have hcompact : IsCompactOperator (S.comp C) := by
-      change IsCompactOperator (⇑S ∘ ⇑C)
+      have hcomp : (⇑(S.comp C) : E → E) = ⇑S ∘ ⇑C := by
+        ext x
+        rw [Function.comp_apply, ContinuousLinearMap.comp_apply]
+      rw [hcomp]
       exact hC.clm_comp S
     have hrw : S.comp (T + C) = (1 + S.comp C) + (S.comp T - 1) := by
       rw [ContinuousLinearMap.comp_add]
@@ -109,7 +111,10 @@ theorem _root_.ContinuousLinearMap.IsFredholm.add_of_isCompactOperator
     exact (isFredholm_one_add hcompact).add_of_finiteDimensional_range hleft
   have hcomp₂ : ContinuousLinearMap.IsFredholm ((T + C).comp S) := by
     have hcompact : IsCompactOperator (C.comp S) := by
-      change IsCompactOperator (⇑C ∘ ⇑S)
+      have hcomp : (⇑(C.comp S) : F → F) = ⇑C ∘ ⇑S := by
+        ext x
+        rw [Function.comp_apply, ContinuousLinearMap.comp_apply]
+      rw [hcomp]
       exact hC.comp_clm S
     have hrw : (T + C).comp S = (1 + C.comp S) + (T.comp S - 1) := by
       rw [ContinuousLinearMap.add_comp]
@@ -121,9 +126,9 @@ theorem _root_.ContinuousLinearMap.IsFredholm.add_of_isCompactOperator
     have hker : LinearMap.ker ((T + C : E →L[𝕜] F) : E →ₗ[𝕜] F)
         ≤ LinearMap.ker ((S.comp (T + C) : E →L[𝕜] E) : E →ₗ[𝕜] E) := by
       intro x hx
-      have hx0 : (T + C) x = 0 := hx
-      change S ((T + C) x) = 0
-      rw [hx0, map_zero]
+      rw [LinearMap.mem_ker] at hx ⊢
+      simpa only [ContinuousLinearMap.coe_coe, ContinuousLinearMap.comp_apply, map_zero] using
+        congrArg S hx
     have := ((isFredholm_iff_finite_ker_coker _).mp hcomp₁).1
     exact Submodule.finiteDimensional_of_le hker
   · -- The range of `T + C` contains that of `(T + C) ∘ S`.
@@ -156,8 +161,7 @@ theorem index_add_of_isCompactOperator (hT : ContinuousLinearMap.IsFredholm T)
 theorem index_one_sub_eq_zero {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
     index (1 - K : E →L[𝕜] E) = 0 := by
   have hneg : IsCompactOperator (-K : E →L[𝕜] E) := by
-    change IsCompactOperator (-⇑K)
-    exact hK.neg
+    simpa only [FunLike.coe_neg] using hK.neg
   have hrw : (1 - K : E →L[𝕜] E) = ContinuousLinearMap.id 𝕜 E + (-K) := by
     ext x
     simp [sub_eq_add_neg]

--- a/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
+++ b/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Fredholm.ClosedRange
+public import TauCeti.Analysis.Fredholm.ContinuousFamily
+public import TauCeti.Analysis.Fredholm.FiniteRank
+public import TauCeti.Analysis.Normed.Operator.Compact.RieszTheory
+
+/-!
+# Compact perturbations of Fredholm operators
+
+A compact perturbation of a Fredholm operator between Banach spaces is Fredholm, with the same
+index. This is the last of the three classical stability statements for the Fredholm index --
+after finite-rank perturbations (`TauCeti.Analysis.Fredholm.FiniteRank`) and small perturbations
+(`TauCeti.Analysis.Fredholm.SmallPerturbation`) -- and completes the linear half of Lane F0 of the
+analytic Heegaard Floer roadmap.
+
+The starting point is the Riesz--Schauder theory of
+`TauCeti.Analysis.Normed.Operator.Compact.RieszTheory`: for a compact operator `K` the kernel of
+`1 - K` is finite dimensional and its cokernel is finite dimensional, so `1 - K` is Fredholm.
+
+For a general Fredholm `T` and compact `C`, take a continuous quasi-inverse `S` of `T`, so that
+`S ∘ T` and `T ∘ S` differ from the identity by operators of finite rank. Then
+`S ∘ (T + C) = (1 + S ∘ C) + (S ∘ T - 1)` is a finite-rank perturbation of a compact perturbation
+of the identity, hence Fredholm, and likewise for `(T + C) ∘ S`. The kernel of `T + C` sits inside
+the kernel of `S ∘ (T + C)` and the range of `T + C` contains the range of `(T + C) ∘ S`, so both
+defect spaces of `T + C` are finite dimensional.
+
+The index statement is then a connectedness argument rather than a new computation: the family
+`c ↦ T + c • C` is a continuous family of Fredholm operators over the preconnected parameter space
+`𝕜`, so the local constancy of the index proved in `TauCeti.Analysis.Fredholm.ContinuousFamily`
+forces the values at `c = 0` and `c = 1` to agree.
+
+## Main declarations
+
+* `TauCeti.isFredholm_one_sub` and `TauCeti.isFredholm_one_add`: `1 - K` and `1 + K` are Fredholm
+  for `K` compact.
+* `ContinuousLinearMap.IsFredholm.add_of_isCompactOperator`: a compact perturbation of a Fredholm
+  operator is Fredholm.
+* `TauCeti.ContinuousLinearMap.index_add_of_isCompactOperator`: a compact perturbation leaves the
+  index unchanged.
+* `TauCeti.ContinuousLinearMap.index_one_sub_eq_zero`: `1 - K` has index `0` for `K` compact.
+
+The conventions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix
+A.1; the compact-perturbation statement is Atkinson's theorem together with the Riesz--Schauder
+theory, see Conway, *A Course in Functional Analysis*, Chapter XI.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module
+
+variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜] [CompleteSpace 𝕜]
+variable [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+variable [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
+
+/-- **Riesz--Schauder**: a compact perturbation of the identity is a Fredholm operator. -/
+theorem isFredholm_one_sub {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
+    ContinuousLinearMap.IsFredholm (1 - K : E →L[𝕜] E) :=
+  ContinuousLinearMap.IsFredholm.of_finite_ker_coker _
+    (IsCompactOperator.finiteDimensional_ker_one_sub hK)
+    (IsCompactOperator.finiteDimensional_quotient_range_one_sub hK)
+
+/-- **Riesz--Schauder**, in the form in which compact perturbations of the identity arise below. -/
+theorem isFredholm_one_add {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
+    ContinuousLinearMap.IsFredholm (1 + K : E →L[𝕜] E) := by
+  have hneg : IsCompactOperator (-K : E →L[𝕜] E) := by
+    change IsCompactOperator (-⇑K)
+    exact hK.neg
+  have hrw : (1 + K : E →L[𝕜] E) = 1 - (-K) := by abel
+  rw [hrw]
+  exact isFredholm_one_sub hneg
+
+variable {T C : E →L[𝕜] F}
+
+/-- A compact perturbation of a Fredholm operator between Banach spaces is Fredholm.
+
+The proof is Atkinson's argument: a quasi-inverse `S` of `T` turns `T + C` into a compact
+perturbation of the identity on both sides, up to finite rank, and the two defect spaces of
+`T + C` are then squeezed between those of `S ∘ (T + C)` and `(T + C) ∘ S`. -/
+theorem _root_.ContinuousLinearMap.IsFredholm.add_of_isCompactOperator
+    (hT : ContinuousLinearMap.IsFredholm T) (hC : IsCompactOperator C) :
+    ContinuousLinearMap.IsFredholm (T + C) := by
+  obtain ⟨S, hS⟩ := hT.exists_isQuasiInverse
+  -- `S ∘ T` and `T ∘ S` differ from the identity by an operator of finite rank.
+  have hleft : FiniteDimensional 𝕜
+      (LinearMap.range ((S.comp T - 1 : E →L[𝕜] E) : E →ₗ[𝕜] E)) := by
+    have h := LinearMap.FiniteRangeSetoid.equiv_iff_hasFiniteRange.mp hS.1
+    rw [← Submodule.fg_iff_finiteDimensional]
+    exact h
+  have hright : FiniteDimensional 𝕜
+      (LinearMap.range ((T.comp S - 1 : F →L[𝕜] F) : F →ₗ[𝕜] F)) := by
+    have h := LinearMap.FiniteRangeSetoid.equiv_iff_hasFiniteRange.mp hS.2
+    rw [← Submodule.fg_iff_finiteDimensional]
+    exact h
+  have hcomp₁ : ContinuousLinearMap.IsFredholm (S.comp (T + C)) := by
+    have hcompact : IsCompactOperator (S.comp C) := by
+      change IsCompactOperator (⇑S ∘ ⇑C)
+      exact hC.clm_comp S
+    have hrw : S.comp (T + C) = (1 + S.comp C) + (S.comp T - 1) := by
+      rw [ContinuousLinearMap.comp_add]
+      abel
+    rw [hrw]
+    exact (isFredholm_one_add hcompact).add_of_finiteDimensional_range hleft
+  have hcomp₂ : ContinuousLinearMap.IsFredholm ((T + C).comp S) := by
+    have hcompact : IsCompactOperator (C.comp S) := by
+      change IsCompactOperator (⇑C ∘ ⇑S)
+      exact hC.comp_clm S
+    have hrw : (T + C).comp S = (1 + C.comp S) + (T.comp S - 1) := by
+      rw [ContinuousLinearMap.add_comp]
+      abel
+    rw [hrw]
+    exact (isFredholm_one_add hcompact).add_of_finiteDimensional_range hright
+  refine ContinuousLinearMap.IsFredholm.of_finite_ker_coker _ ?_ ?_
+  · -- The kernel of `T + C` sits inside that of `S ∘ (T + C)`.
+    have hker : LinearMap.ker ((T + C : E →L[𝕜] F) : E →ₗ[𝕜] F)
+        ≤ LinearMap.ker ((S.comp (T + C) : E →L[𝕜] E) : E →ₗ[𝕜] E) := by
+      intro x hx
+      have hx0 : (T + C) x = 0 := hx
+      change S ((T + C) x) = 0
+      rw [hx0, map_zero]
+    have := ((isFredholm_iff_finite_ker_coker _).mp hcomp₁).1
+    exact Submodule.finiteDimensional_of_le hker
+  · -- The range of `T + C` contains that of `(T + C) ∘ S`.
+    have hrange : LinearMap.range (((T + C).comp S : F →L[𝕜] F) : F →ₗ[𝕜] F)
+        ≤ LinearMap.range ((T + C : E →L[𝕜] F) : E →ₗ[𝕜] F) := by
+      rintro y ⟨z, rfl⟩
+      exact ⟨S z, rfl⟩
+    have := ((isFredholm_iff_finite_ker_coker _).mp hcomp₂).2
+    exact FiniteDimensional.of_surjective (Submodule.factor hrange)
+      (Submodule.factor_surjective hrange)
+
+namespace ContinuousLinearMap
+
+/-- A compact perturbation leaves the Fredholm index unchanged.
+
+The scalar family `c ↦ T + c • C` is a continuous family of Fredholm operators over the
+preconnected parameter space `𝕜`, so its index is constant; comparing `c = 0` with `c = 1` gives
+the claim. -/
+theorem index_add_of_isCompactOperator (hT : ContinuousLinearMap.IsFredholm T)
+    (hC : IsCompactOperator C) : index (T + C) = index T := by
+  let _i := IsRCLikeNormedField.rclike 𝕜
+  have hpre : PreconnectedSpace 𝕜 :=
+    ⟨(convex_univ : Convex ℝ (Set.univ : Set 𝕜)).isPreconnected⟩
+  have hcont : Continuous fun c : 𝕜 => T + c • C := by fun_prop
+  have hfred : ∀ c : 𝕜, ContinuousLinearMap.IsFredholm (T + c • C) := fun c =>
+    hT.add_of_isCompactOperator (by simpa using hC.smul c)
+  simpa using Continuous.index_eq_of_preconnectedSpace hcont hfred 1 0
+
+/-- A compact perturbation of the identity has index `0`. -/
+theorem index_one_sub_eq_zero {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
+    index (1 - K : E →L[𝕜] E) = 0 := by
+  have hneg : IsCompactOperator (-K : E →L[𝕜] E) := by
+    change IsCompactOperator (-⇑K)
+    exact hK.neg
+  have hrw : (1 - K : E →L[𝕜] E) = ContinuousLinearMap.id 𝕜 E + (-K) := by
+    ext x
+    simp [sub_eq_add_neg]
+  rw [hrw, index_add_of_isCompactOperator isFredholm_id hneg, index_id]
+
+end ContinuousLinearMap
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Normed/Operator/Compact/Basic.lean
+++ b/TauCeti/Analysis/Normed/Operator/Compact/Basic.lean
@@ -26,9 +26,10 @@ namespace TauCeti
 open Filter
 open scoped Topology
 
-variable {𝕜 X : Type*} [NontriviallyNormedField 𝕜]
+variable {𝕜 X Y : Type*} [NontriviallyNormedField 𝕜]
 variable [NormedAddCommGroup X] [NormedSpace 𝕜 X]
-variable {K : X →L[𝕜] X}
+variable [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
+variable {K : X →L[𝕜] Y}
 
 namespace IsCompactOperator
 
@@ -38,7 +39,7 @@ variable {R : ℝ} {u : ℕ → X}
 
 /-- A compact operator sends a bounded sequence to a sequence with a convergent subsequence. -/
 theorem exists_subseq_tendsto (hK : IsCompactOperator K) (hu : ∀ n, ‖u n‖ ≤ R) :
-    ∃ (y : X) (ψ : ℕ → ℕ), StrictMono ψ ∧ Tendsto (fun k => K (u (ψ k))) atTop (𝓝 y) := by
+    ∃ (y : Y) (ψ : ℕ → ℕ), StrictMono ψ ∧ Tendsto (fun k => K (u (ψ k))) atTop (𝓝 y) := by
   obtain ⟨S, hS, hSsub⟩ := hK.image_closedBall_subset_compact R
   obtain ⟨y, -, ψ, hψ, hψy⟩ :=
     hS.tendsto_subseq fun n => hSsub ⟨u n, by simpa using hu n, rfl⟩

--- a/TauCeti/Analysis/Normed/Operator/Compact/Basic.lean
+++ b/TauCeti/Analysis/Normed/Operator/Compact/Basic.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Normed.Operator.Compact.Basic
+
+/-!
+# Compact operators and bounded sequences
+
+This file records sequential consequences of compactness for bounded sequences in normed spaces.
+
+## Main declarations
+
+* `TauCeti.IsCompactOperator.exists_subseq_tendsto`: a compact operator sends a bounded sequence
+  to a sequence with a convergent subsequence.
+* `TauCeti.IsCompactOperator.exists_dist_lt_of_norm_le`: a compact operator cannot keep the
+  images of a bounded sequence pairwise separated.
+-/
+
+public section
+
+namespace TauCeti
+
+open Filter
+open scoped Topology
+
+variable {𝕜 X : Type*} [NontriviallyNormedField 𝕜]
+variable [NormedAddCommGroup X] [NormedSpace 𝕜 X]
+variable {K : X →L[𝕜] X}
+
+namespace IsCompactOperator
+
+section Separation
+
+variable {R : ℝ} {u : ℕ → X}
+
+/-- A compact operator sends a bounded sequence to a sequence with a convergent subsequence. -/
+theorem exists_subseq_tendsto (hK : IsCompactOperator K) (hu : ∀ n, ‖u n‖ ≤ R) :
+    ∃ (y : X) (ψ : ℕ → ℕ), StrictMono ψ ∧ Tendsto (fun k => K (u (ψ k))) atTop (𝓝 y) := by
+  obtain ⟨S, hS, hSsub⟩ := hK.image_closedBall_subset_compact R
+  obtain ⟨y, -, ψ, hψ, hψy⟩ :=
+    hS.tendsto_subseq fun n => hSsub ⟨u n, by simpa using hu n, rfl⟩
+  exact ⟨y, ψ, hψ, hψy⟩
+
+/-- A compact operator cannot keep the images of a bounded sequence pairwise separated: two
+distinct indices always have images within any prescribed positive distance. -/
+theorem exists_dist_lt_of_norm_le (hK : IsCompactOperator K) (hu : ∀ n, ‖u n‖ ≤ R) {ε : ℝ}
+    (hε : 0 < ε) : ∃ m n, m ≠ n ∧ dist (K (u m)) (K (u n)) < ε := by
+  obtain ⟨y, ψ, hψ, hψy⟩ := exists_subseq_tendsto hK hu
+  have hcauchy := hψy.cauchySeq
+  rw [Metric.cauchySeq_iff'] at hcauchy
+  obtain ⟨N, hN⟩ := hcauchy ε hε
+  exact ⟨ψ (N + 1), ψ N, by simp [hψ.injective.eq_iff], hN (N + 1) (Nat.le_succ N)⟩
+
+end Separation
+
+end IsCompactOperator
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean
+++ b/TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean
@@ -65,11 +65,10 @@ variable {K : X →L[𝕜] X}
 /-- The kernel of `1 - K` is the `1`-eigenspace of `K`. -/
 @[simp]
 theorem ker_one_sub (K : X →L[𝕜] X) :
-    LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X) = End.eigenspace (K : X →ₗ[𝕜] X) 1 := by
+    LinearMap.ker (1 - (K : X →ₗ[𝕜] X)) = End.eigenspace (K : X →ₗ[𝕜] X) 1 := by
   ext x
   rw [LinearMap.mem_ker, End.mem_eigenspace_iff]
-  simp only [ContinuousLinearMap.coe_coe, sub_apply, one_apply_eq_self]
-  rw [sub_eq_zero, one_smul]
+  rw [LinearMap.sub_apply, Module.End.one_apply, one_smul, sub_eq_zero]
   exact eq_comm
 
 namespace IsCompactOperator
@@ -142,7 +141,7 @@ theorem exists_pos_mul_norm_le_of_disjoint_ker (hK : IsCompactOperator K) {M : S
       (((1 : X →L[𝕜] X) - K).continuous.tendsto y).comp hvsub
     have h0 : Tendsto (fun k => (1 - K : X →L[𝕜] X) (v (ψ k))) atTop (𝓝 0) :=
       hAtendsto.comp hψ.tendsto_atTop
-    simpa using tendsto_nhds_unique h1 h0
+    exact LinearMap.mem_ker.mpr (tendsto_nhds_unique h1 h0)
   have hy0 : y = 0 := by simpa using hdisj.le_bot ⟨hyker, hyM⟩
   have hyge : ‖c‖⁻¹ ≤ ‖y‖ := ge_of_tendsto' hvsub.norm fun k => hvge (ψ k)
   rw [hy0, norm_zero] at hyge
@@ -220,7 +219,8 @@ variable [CompleteSpace 𝕜]
 /-- The kernel of a compact perturbation of the identity is finite dimensional. -/
 theorem finiteDimensional_ker_one_sub (hK : IsCompactOperator K) :
     FiniteDimensional 𝕜 (LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X)) := by
-  rw [TauCeti.ker_one_sub]
+  rw [ContinuousLinearMap.toLinearMap_sub, ContinuousLinearMap.toLinearMap_one,
+    TauCeti.ker_one_sub]
   exact finiteDimensional_eigenspace hK one_ne_zero
 
 variable [IsRCLikeNormedField 𝕜] [CompleteSpace X]

--- a/TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean
+++ b/TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean
@@ -1,0 +1,382 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.LocallyConvex.HahnBanach
+public import Mathlib.Analysis.Normed.Module.RieszLemma
+public import TauCeti.Analysis.Normed.Operator.Compact.Eigenspace
+
+/-!
+# Riesz theory for compact perturbations of the identity
+
+Let `K` be a compact operator on a Banach space `X` and write `A = 1 - K`. This file proves the
+three finiteness facts that make `A` a Fredholm operator: its kernel is finite dimensional, its
+range is closed, and its cokernel is finite dimensional. Together they are the operator-theoretic
+half of the Riesz--Schauder theory, and they are what upgrades Mathlib's spectral Fredholm
+alternative for compact operators to a statement about Fredholm operators.
+
+All three arguments feed on the same compactness input, isolated here as
+`TauCeti.IsCompactOperator.exists_dist_lt_of_norm_le`: a compact operator cannot keep the images
+of a bounded sequence pairwise separated.
+
+* The kernel is the `1`-eigenspace of `K`, already known to be finite dimensional.
+* For the range, split off a closed complement `M` of `ker A`, which exists because `ker A` is
+  finite dimensional. On `M` the operator `A` is bounded below: otherwise a sequence in a fixed
+  norm shell with `A xₙ → 0` would, along a subsequence on which `K` converges, converge to a
+  nonzero element of `ker A ⊓ M`. A bounded-below map on a complete space has closed range.
+* For the cokernel, run the classical Riesz argument on the decreasing chain of ranges
+  `range A ⊇ range A² ⊇ ⋯`. Each `Aⁿ` is again `1` minus a compact operator, so each of these
+  ranges is closed, and Riesz's lemma would otherwise produce a separated bounded sequence. Once
+  the chain stabilises at `p`, every `x` splits as an element of `ker A ^ (p + 1)` plus an element
+  of `range A ^ (p + 1) ≤ range A`, so `ker A ^ (p + 1)` surjects onto the cokernel.
+
+## Main declarations
+
+* `TauCeti.IsCompactOperator.exists_dist_lt_of_norm_le`: the compactness input, in the form used
+  three times below.
+* `TauCeti.IsCompactOperator.exists_pos_mul_norm_le_of_disjoint_ker`: `1 - K` is bounded below on
+  any closed subspace meeting its kernel trivially.
+* `TauCeti.IsCompactOperator.finiteDimensional_ker_one_sub`: `ker (1 - K)` is finite dimensional.
+* `TauCeti.IsCompactOperator.isClosed_range_one_sub`: `range (1 - K)` is closed.
+* `TauCeti.IsCompactOperator.isCompactOperator_one_sub_pow`: `1 - (1 - K) ^ n` is compact, so
+  every power of `1 - K` is again a compact perturbation of the identity.
+* `TauCeti.IsCompactOperator.finiteDimensional_quotient_range_one_sub`: `X ⧸ range (1 - K)` is
+  finite dimensional.
+
+The argument is the classical Riesz theory of compact operators; see, for example, Conway,
+*A Course in Functional Analysis*, Chapter VI, Section 5, or Rudin, *Functional Analysis*,
+Chapter 4. It supplies the compact-perturbation half of the Fredholm package asked for in Lane F0
+of the analytic Heegaard Floer roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+open Filter Module
+open scoped Topology
+
+variable {𝕜 X : Type*} [NontriviallyNormedField 𝕜]
+variable [NormedAddCommGroup X] [NormedSpace 𝕜 X]
+variable {K : X →L[𝕜] X}
+
+namespace IsCompactOperator
+
+section Separation
+
+variable {R : ℝ} {u : ℕ → X}
+
+/-- A compact operator sends a bounded sequence to a sequence with a convergent subsequence. -/
+theorem exists_subseq_tendsto (hK : IsCompactOperator K) (hu : ∀ n, ‖u n‖ ≤ R) :
+    ∃ (y : X) (ψ : ℕ → ℕ), StrictMono ψ ∧ Tendsto (fun k => K (u (ψ k))) atTop (𝓝 y) := by
+  obtain ⟨S, hS, hSsub⟩ := hK.image_closedBall_subset_compact R
+  obtain ⟨y, -, ψ, hψ, hψy⟩ :=
+    hS.tendsto_subseq fun n => hSsub ⟨u n, by simpa using hu n, rfl⟩
+  exact ⟨y, ψ, hψ, hψy⟩
+
+/-- A compact operator cannot keep the images of a bounded sequence pairwise separated: two
+distinct indices always have images within any prescribed positive distance.
+
+This is the single compactness input to the Riesz theory below. -/
+theorem exists_dist_lt_of_norm_le (hK : IsCompactOperator K) (hu : ∀ n, ‖u n‖ ≤ R) {ε : ℝ}
+    (hε : 0 < ε) : ∃ m n, m ≠ n ∧ dist (K (u m)) (K (u n)) < ε := by
+  obtain ⟨y, ψ, hψ, hψy⟩ := exists_subseq_tendsto hK hu
+  have hcauchy := hψy.cauchySeq
+  rw [Metric.cauchySeq_iff'] at hcauchy
+  obtain ⟨N, hN⟩ := hcauchy ε hε
+  exact ⟨ψ (N + 1), ψ N, by simp [hψ.injective.eq_iff], hN (N + 1) (Nat.le_succ N)⟩
+
+end Separation
+
+/-- The kernel of `1 - K` is the `1`-eigenspace of `K`. -/
+theorem ker_one_sub (K : X →L[𝕜] X) :
+    LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X) = End.eigenspace (K : X →ₗ[𝕜] X) 1 := by
+  ext x
+  rw [LinearMap.mem_ker, End.mem_eigenspace_iff]
+  change x - K x = 0 ↔ K x = (1 : 𝕜) • x
+  rw [sub_eq_zero, one_smul]
+  exact eq_comm
+
+/-- On a closed subspace `M` meeting `ker (1 - K)` only in `0`, the operator `1 - K` is bounded
+below.
+
+Were it not, a sequence of vectors in a fixed norm shell whose images tend to `0` would, along a
+subsequence on which `K` converges, converge to a nonzero vector of `ker (1 - K) ⊓ M`. -/
+theorem exists_pos_mul_norm_le_of_disjoint_ker (hK : IsCompactOperator K) {M : Submodule 𝕜 X}
+    (hM : IsClosed (M : Set X))
+    (hdisj : Disjoint (LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X)) M) :
+    ∃ c : ℝ, 0 < c ∧ ∀ x ∈ M, c * ‖x‖ ≤ ‖(1 - K : X →L[𝕜] X) x‖ := by
+  by_contra hcon
+  push Not at hcon
+  obtain ⟨c, hc⟩ := NormedField.exists_one_lt_norm 𝕜
+  have hcpos : (0 : ℝ) < ‖c‖ := one_pos.trans hc
+  choose u huM hu using fun n : ℕ => hcon (1 / (n + 1) : ℝ) (by positivity)
+  have hune : ∀ n, u n ≠ 0 := by
+    intro n hn
+    have h := hu n
+    rw [hn] at h
+    simp at h
+  choose d hd0 hdlt hdge hdaux using fun n => rescale_to_shell hc one_pos (hune n)
+  clear hdaux
+  set v : ℕ → X := fun n => d n • u n with hv
+  have hvM : ∀ n, v n ∈ M := fun n => M.smul_mem _ (huM n)
+  have hvle : ∀ n, ‖v n‖ ≤ 1 := fun n => (hdlt n).le
+  have hvge : ∀ n, ‖c‖⁻¹ ≤ ‖v n‖ := by
+    intro n
+    simpa [one_div] using hdge n
+  have hAv : ∀ n, ‖(1 - K : X →L[𝕜] X) (v n)‖ ≤ 1 / (n + 1) := by
+    intro n
+    have hdn : (0 : ℝ) ≤ ‖d n‖ := norm_nonneg _
+    have hstep : (1 : ℝ) / (n + 1) * ‖v n‖ ≤ 1 / (n + 1) := by
+      have hpos : (0 : ℝ) < 1 / (n + 1) := by positivity
+      simpa using mul_le_mul_of_nonneg_left (hvle n) hpos.le
+    calc ‖(1 - K : X →L[𝕜] X) (v n)‖
+        = ‖d n‖ * ‖(1 - K : X →L[𝕜] X) (u n)‖ := by simp [hv, norm_smul]
+      _ ≤ ‖d n‖ * (1 / (n + 1) * ‖u n‖) := mul_le_mul_of_nonneg_left (hu n).le hdn
+      _ = 1 / (n + 1) * ‖v n‖ := by rw [hv]; simp only [norm_smul]; ring
+      _ ≤ 1 / (n + 1) := hstep
+  have hAtendsto : Tendsto (fun n => (1 - K : X →L[𝕜] X) (v n)) atTop (𝓝 0) := by
+    rw [NormedAddGroup.tendsto_nhds_zero]
+    intro ε hε
+    obtain ⟨N, hN⟩ := exists_nat_gt (1 / ε)
+    filter_upwards [eventually_ge_atTop N] with n hn
+    have hnpos : (0 : ℝ) < (n : ℝ) + 1 := by positivity
+    have hlt : 1 / ((n : ℝ) + 1) < ε := by
+      have hNn : (N : ℝ) ≤ (n : ℝ) := Nat.cast_le.mpr hn
+      have h1 : 1 / ε < (n : ℝ) + 1 := by linarith
+      rw [div_lt_iff₀ hε, mul_comm] at h1
+      rw [div_lt_iff₀ hnpos]
+      linarith
+    exact lt_of_le_of_lt (hAv n) hlt
+  obtain ⟨y, ψ, hψ, hψy⟩ := exists_subseq_tendsto hK hvle
+  have hvsub : Tendsto (fun k => v (ψ k)) atTop (𝓝 y) := by
+    have hsum : ∀ k, (1 - K : X →L[𝕜] X) (v (ψ k)) + K (v (ψ k)) = v (ψ k) := by
+      intro k
+      change v (ψ k) - K (v (ψ k)) + K (v (ψ k)) = v (ψ k)
+      abel
+    have hlim : Tendsto (fun k => (1 - K : X →L[𝕜] X) (v (ψ k)) + K (v (ψ k))) atTop
+        (𝓝 (0 + y)) := (hAtendsto.comp hψ.tendsto_atTop).add hψy
+    rw [zero_add] at hlim
+    exact Filter.Tendsto.congr hsum hlim
+  have hyM : y ∈ M := hM.mem_of_tendsto hvsub (Eventually.of_forall fun k => hvM (ψ k))
+  have hyker : y ∈ LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X) := by
+    have h1 : Tendsto (fun k => (1 - K : X →L[𝕜] X) (v (ψ k))) atTop
+        (𝓝 ((1 - K : X →L[𝕜] X) y)) :=
+      (((1 : X →L[𝕜] X) - K).continuous.tendsto y).comp hvsub
+    have h0 : Tendsto (fun k => (1 - K : X →L[𝕜] X) (v (ψ k))) atTop (𝓝 0) :=
+      hAtendsto.comp hψ.tendsto_atTop
+    simpa using tendsto_nhds_unique h1 h0
+  have hy0 : y = 0 := by simpa using hdisj.le_bot ⟨hyker, hyM⟩
+  have hyge : ‖c‖⁻¹ ≤ ‖y‖ := ge_of_tendsto' hvsub.norm fun k => hvge (ψ k)
+  rw [hy0, norm_zero] at hyge
+  exact absurd hyge (not_le.mpr (by positivity))
+
+/-- Every power of a compact perturbation of the identity is again a compact perturbation of the
+identity. -/
+theorem isCompactOperator_one_sub_pow (hK : IsCompactOperator K) (n : ℕ) :
+    IsCompactOperator ⇑((1 : X →L[𝕜] X) - (1 - K) ^ n) := by
+  induction n with
+  | zero =>
+    rw [pow_zero, sub_self]
+    simpa using isCompactOperator_zero (M₁ := X) (M₂ := X)
+  | succ n ih =>
+    have key : (1 : X →L[𝕜] X) - (1 - K) ^ (n + 1)
+        = ((1 : X →L[𝕜] X) - (1 - K) ^ n) + (1 - K) ^ n * K := by
+      rw [pow_succ, mul_sub, mul_one]
+      abel
+    rw [key]
+    simpa using ih.add (by simpa using hK.clm_comp ((1 - K : X →L[𝕜] X) ^ n))
+
+section Chain
+
+/-- Riesz's lemma in the form used below: a proper closed subspace `P` of a subspace `Q` contains
+a vector of `Q` of controlled norm at distance at least `1` from `P`. -/
+private theorem exists_riesz {P Q : Submodule 𝕜 X} (hPQ : P ≤ Q) (hP : IsClosed (P : Set X))
+    (hne : P ≠ Q) {c : 𝕜} (hc : 1 < ‖c‖) :
+    ∃ x ∈ Q, ‖x‖ ≤ ‖c‖ + 1 ∧ ∀ y ∈ P, 1 ≤ ‖x - y‖ := by
+  have h₁ : IsClosed ((P.comap Q.subtype : Submodule 𝕜 Q) : Set Q) :=
+    hP.preimage continuous_subtype_val
+  have h₂ : ∃ x : Q, x ∉ P.comap Q.subtype := by
+    obtain ⟨x, hxQ, hxP⟩ := SetLike.exists_of_lt (lt_of_le_of_ne hPQ hne)
+    exact ⟨⟨x, hxQ⟩, by simpa using hxP⟩
+  obtain ⟨x₀, hx₀norm, hx₀⟩ := riesz_lemma_of_norm_lt hc (R := ‖c‖ + 1) (by linarith) h₁ h₂
+  refine ⟨(x₀ : X), x₀.2, hx₀norm, fun y hy => ?_⟩
+  simpa using hx₀ ⟨y, hPQ hy⟩ (by simpa using hy)
+
+/-- A decreasing chain of closed subspaces stable under `1 - K`, in the sense that `1 - K` carries
+the `n`-th one into the `(n + 1)`-st, cannot be strictly decreasing: Riesz's lemma would otherwise
+produce a bounded sequence whose images under `K` stay `1` apart. -/
+private theorem exists_eq_succ_of_chain (hK : IsCompactOperator K) {V : ℕ → Submodule 𝕜 X}
+    (hmono : ∀ n, V (n + 1) ≤ V n) (hclosed : ∀ n, IsClosed ((V n : Set X)))
+    (hstep : ∀ n, ∀ x ∈ V n, x - K x ∈ V (n + 1)) :
+    ∃ p, V (p + 1) = V p := by
+  by_contra hcon
+  push Not at hcon
+  have hanti : ∀ {m n : ℕ}, m ≤ n → V n ≤ V m := by
+    intro m n h
+    induction h with
+    | refl => exact le_rfl
+    | step h ih => exact (hmono _).trans ih
+  obtain ⟨c, hc⟩ := NormedField.exists_one_lt_norm 𝕜
+  choose f hfmem hfnorm hfsep using fun n =>
+    exists_riesz (hmono n) (hclosed (n + 1)) (hcon n) hc
+  have key : ∀ m n : ℕ, m < n → 1 ≤ ‖K (f m) - K (f n)‖ := by
+    intro m n hmn
+    have hy : (f m - K (f m)) + f n - (f n - K (f n)) ∈ V (m + 1) := by
+      refine Submodule.sub_mem _ (Submodule.add_mem _ (hstep m _ (hfmem m)) ?_) ?_
+      · exact hanti hmn (hfmem n)
+      · exact hanti (Nat.succ_le_succ hmn.le) (hstep n _ (hfmem n))
+    have hrw : K (f m) - K (f n) = f m - ((f m - K (f m)) + f n - (f n - K (f n))) := by abel
+    rw [hrw]
+    exact hfsep m _ hy
+  obtain ⟨m, n, hmn, hlt⟩ := exists_dist_lt_of_norm_le hK hfnorm one_pos
+  rw [dist_eq_norm] at hlt
+  rcases lt_or_gt_of_ne hmn with h | h
+  · exact absurd hlt (not_lt.mpr (key m n h))
+  · rw [norm_sub_rev] at hlt
+    exact absurd hlt (not_lt.mpr (key n m h))
+
+end Chain
+
+variable [CompleteSpace 𝕜]
+
+/-- The kernel of a compact perturbation of the identity is finite dimensional. -/
+theorem finiteDimensional_ker_one_sub (hK : IsCompactOperator K) :
+    FiniteDimensional 𝕜 (LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X)) := by
+  rw [ker_one_sub]
+  exact finiteDimensional_eigenspace hK one_ne_zero
+
+variable [IsRCLikeNormedField 𝕜] [CompleteSpace X]
+
+/-- The range of a compact perturbation of the identity is closed. -/
+theorem isClosed_range_one_sub (hK : IsCompactOperator K) :
+    IsClosed (LinearMap.range ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X) : Set X) := by
+  have hfin : FiniteDimensional 𝕜 (LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X)) :=
+    finiteDimensional_ker_one_sub hK
+  obtain ⟨M, hMclosed, hMcompl⟩ :=
+    (Submodule.ClosedComplemented.of_finiteDimensional
+      (LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X))).exists_isClosed_isCompl
+  obtain ⟨c, hcpos, hc⟩ := exists_pos_mul_norm_le_of_disjoint_ker hK hMclosed hMcompl.disjoint
+  -- Every value of `1 - K` is already attained on `M`.
+  have hrange : (LinearMap.range ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X) : Set X)
+      = Set.range ((1 - K : X →L[𝕜] X).comp M.subtypeL) := by
+    ext y
+    constructor
+    · rintro ⟨x, rfl⟩
+      have hx : x ∈ LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X) ⊔ M := by
+        rw [hMcompl.sup_eq_top]; trivial
+      obtain ⟨n, hn, m, hm, hnm⟩ := Submodule.mem_sup.mp hx
+      refine ⟨⟨m, hm⟩, ?_⟩
+      have hn0 : (1 - K : X →L[𝕜] X) n = 0 := hn
+      simp only [ContinuousLinearMap.comp_apply, Submodule.coe_subtypeL,
+        Submodule.subtype_apply, ContinuousLinearMap.coe_coe]
+      rw [← hnm, map_add, hn0, zero_add]
+    · rintro ⟨m, rfl⟩
+      exact ⟨(m : X), rfl⟩
+  have hMcomplete : CompleteSpace M := hMclosed.completeSpace_coe
+  have hcinv : (0 : ℝ) ≤ c⁻¹ := by positivity
+  have hanti : AntilipschitzWith (Real.toNNReal c⁻¹)
+      ((1 - K : X →L[𝕜] X).comp M.subtypeL) := by
+    refine AddMonoidHomClass.antilipschitz_of_bound _ fun m => ?_
+    have hm := hc (m : X) m.2
+    have h2 : ‖(m : X)‖ ≤ c⁻¹ * ‖(1 - K : X →L[𝕜] X) (m : X)‖ := by
+      have h3 := mul_le_mul_of_nonneg_left hm hcinv
+      rwa [← mul_assoc, inv_mul_cancel₀ hcpos.ne', one_mul] at h3
+    simpa [Real.coe_toNNReal _ hcinv] using h2
+  rw [hrange]
+  exact hanti.isClosed_range ((1 - K : X →L[𝕜] X).comp M.subtypeL).uniformContinuous
+
+/-- The cokernel of a compact perturbation of the identity is finite dimensional. -/
+theorem finiteDimensional_quotient_range_one_sub (hK : IsCompactOperator K) :
+    FiniteDimensional 𝕜 (X ⧸ LinearMap.range ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X)) := by
+  set A : X →L[𝕜] X := 1 - K with hA
+  set V : ℕ → Submodule 𝕜 X :=
+    fun n => LinearMap.range ((A ^ n : X →L[𝕜] X) : X →ₗ[𝕜] X) with hV
+  have hVmem : ∀ (n : ℕ) (x : X), x ∈ V n ↔ ∃ z, (A ^ n) z = x := by
+    intro n x
+    simp only [hV, LinearMap.mem_range, ContinuousLinearMap.coe_coe]
+  have hVsucc : ∀ n, ∀ x ∈ V n, A x ∈ V (n + 1) := by
+    intro n x hx
+    obtain ⟨z, rfl⟩ := (hVmem n x).mp hx
+    exact (hVmem (n + 1) _).mpr ⟨z, by rw [pow_succ']; rfl⟩
+  have hVmono : ∀ n, V (n + 1) ≤ V n := by
+    intro n x hx
+    obtain ⟨z, rfl⟩ := (hVmem _ _).mp hx
+    exact (hVmem n _).mpr ⟨A z, by rw [pow_succ]; rfl⟩
+  have hVmap : ∀ n, V (n + 1) = Submodule.map (A : X →ₗ[𝕜] X) (V n) := by
+    intro n
+    refine le_antisymm (fun x hx => ?_) (fun x hx => ?_)
+    · obtain ⟨z, rfl⟩ := (hVmem _ _).mp hx
+      exact ⟨(A ^ n) z, (hVmem n _).mpr ⟨z, rfl⟩, by rw [pow_succ']; rfl⟩
+    · obtain ⟨w, hw, rfl⟩ := hx
+      exact hVsucc n w hw
+  have hVclosed : ∀ n, IsClosed ((V n : Set X)) := by
+    intro n
+    have h := isClosed_range_one_sub (isCompactOperator_one_sub_pow hK n)
+    rw [sub_sub_cancel, ← hA] at h
+    rw [hV]
+    exact h
+  obtain ⟨p, hp⟩ := exists_eq_succ_of_chain hK hVmono hVclosed (by
+    intro n x hx
+    have : x - K x = A x := rfl
+    rw [this]
+    exact hVsucc n x hx)
+  -- The chain of ranges is constant from `p` on.
+  have hstab : ∀ n, p ≤ n → V (n + 1) = V n := by
+    intro n hn
+    induction n with
+    | zero => rw [Nat.le_zero.mp hn] at hp; exact hp
+    | succ n ih =>
+      rcases Nat.lt_or_ge p (n + 1) with h | h
+      · have hih := ih (Nat.lt_succ_iff.mp h)
+        calc V (n + 1 + 1) = Submodule.map (A : X →ₗ[𝕜] X) (V (n + 1)) := hVmap (n + 1)
+          _ = Submodule.map (A : X →ₗ[𝕜] X) (V n) := by rw [hih]
+          _ = V (n + 1) := (hVmap n).symm
+      · rw [Nat.le_antisymm hn h] at hp; exact hp
+  have hconst : ∀ n, V (p + n) = V p := by
+    intro n
+    induction n with
+    | zero => simp
+    | succ n ih => rw [← Nat.add_assoc, hstab (p + n) (Nat.le_add_right p n)]; exact ih
+  have hV2 : V (p + 1 + (p + 1)) = V (p + 1) := by
+    have h1 : p + 1 + (p + 1) = p + (p + 2) := by omega
+    rw [h1, hconst, hp]
+  -- The kernel of `A ^ (p + 1)` surjects onto the cokernel of `A`.
+  have hkerfin : FiniteDimensional 𝕜
+      (LinearMap.ker ((A ^ (p + 1) : X →L[𝕜] X) : X →ₗ[𝕜] X)) := by
+    have h := finiteDimensional_ker_one_sub (isCompactOperator_one_sub_pow hK (p + 1))
+    rw [sub_sub_cancel, ← hA] at h
+    exact h
+  refine FiniteDimensional.of_surjective
+    ((LinearMap.range (A : X →ₗ[𝕜] X)).mkQ.comp
+      (LinearMap.ker ((A ^ (p + 1) : X →L[𝕜] X) : X →ₗ[𝕜] X)).subtype) ?_
+  intro ξ
+  obtain ⟨x, rfl⟩ := Submodule.mkQ_surjective _ ξ
+  have hx : (A ^ (p + 1)) x ∈ V (p + 1 + (p + 1)) := by
+    rw [hV2]
+    exact (hVmem _ _).mpr ⟨x, rfl⟩
+  obtain ⟨z, hz⟩ := (hVmem _ _).mp hx
+  have hcomp : ∀ (m n : ℕ) (w : X), (A ^ (m + n)) w = (A ^ m) ((A ^ n) w) := by
+    intro m n w
+    rw [pow_add]
+    rfl
+  have hzz : (A ^ (p + 1)) ((A ^ (p + 1)) z) = (A ^ (p + 1)) x := by
+    rw [← hcomp]
+    exact hz
+  refine ⟨⟨x - (A ^ (p + 1)) z, ?_⟩, ?_⟩
+  · rw [LinearMap.mem_ker]
+    change (A ^ (p + 1)) (x - (A ^ (p + 1)) z) = 0
+    rw [map_sub, hzz, sub_self]
+  · have hmem : (A ^ (p + 1)) z ∈ LinearMap.range (A : X →ₗ[𝕜] X) :=
+      ⟨(A ^ p) z, by rw [pow_succ']; rfl⟩
+    simp only [LinearMap.comp_apply, Submodule.subtype_apply, Submodule.mkQ_apply]
+    rw [Submodule.Quotient.eq]
+    simpa using neg_mem hmem
+
+end IsCompactOperator
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean
+++ b/TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean
@@ -17,9 +17,10 @@ range is closed, and its cokernel is finite dimensional. Together they are the o
 half of the Riesz--Schauder theory, and they are what upgrades Mathlib's spectral Fredholm
 alternative for compact operators to a statement about Fredholm operators.
 
-All three arguments feed on the same compactness input, isolated here as
-`TauCeti.IsCompactOperator.exists_dist_lt_of_norm_le`: a compact operator cannot keep the images
-of a bounded sequence pairwise separated.
+Compactness enters the three arguments in different forms: the kernel argument uses the existing
+finite-dimensional eigenspace theorem, the range argument extracts a convergent subsequence with
+`TauCeti.IsCompactOperator.exists_subseq_tendsto`, and the cokernel argument uses the separation
+consequence `TauCeti.IsCompactOperator.exists_dist_lt_of_norm_le`.
 
 * The kernel is the `1`-eigenspace of `K`, already known to be finite dimensional.
 * For the range, split off a closed complement `M` of `ker A`, which exists because `ker A` is
@@ -34,8 +35,8 @@ of a bounded sequence pairwise separated.
 
 ## Main declarations
 
-* `TauCeti.IsCompactOperator.exists_dist_lt_of_norm_le`: the compactness input, in the form used
-  three times below.
+* `TauCeti.IsCompactOperator.exists_dist_lt_of_norm_le`: the compactness input to the descending
+  chain argument.
 * `TauCeti.IsCompactOperator.exists_pos_mul_norm_le_of_disjoint_ker`: `1 - K` is bounded below on
   any closed subspace meeting its kernel trivially.
 * `TauCeti.IsCompactOperator.finiteDimensional_ker_one_sub`: `ker (1 - K)` is finite dimensional.
@@ -79,7 +80,7 @@ theorem exists_subseq_tendsto (hK : IsCompactOperator K) (hu : ∀ n, ‖u n‖ 
 /-- A compact operator cannot keep the images of a bounded sequence pairwise separated: two
 distinct indices always have images within any prescribed positive distance.
 
-This is the single compactness input to the Riesz theory below. -/
+This is the compactness input to the descending-chain argument below. -/
 theorem exists_dist_lt_of_norm_le (hK : IsCompactOperator K) (hu : ∀ n, ‖u n‖ ≤ R) {ε : ℝ}
     (hε : 0 < ε) : ∃ m n, m ≠ n ∧ dist (K (u m)) (K (u n)) < ε := by
   obtain ⟨y, ψ, hψ, hψy⟩ := exists_subseq_tendsto hK hu
@@ -90,14 +91,18 @@ theorem exists_dist_lt_of_norm_le (hK : IsCompactOperator K) (hu : ∀ n, ‖u n
 
 end Separation
 
+end IsCompactOperator
+
 /-- The kernel of `1 - K` is the `1`-eigenspace of `K`. -/
 theorem ker_one_sub (K : X →L[𝕜] X) :
     LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X) = End.eigenspace (K : X →ₗ[𝕜] X) 1 := by
   ext x
   rw [LinearMap.mem_ker, End.mem_eigenspace_iff]
-  change x - K x = 0 ↔ K x = (1 : 𝕜) • x
+  simp only [ContinuousLinearMap.coe_coe, sub_apply, one_apply_eq_self]
   rw [sub_eq_zero, one_smul]
   exact eq_comm
+
+namespace IsCompactOperator
 
 /-- On a closed subspace `M` meeting `ker (1 - K)` only in `0`, the operator `1 - K` is bounded
 below.
@@ -154,7 +159,7 @@ theorem exists_pos_mul_norm_le_of_disjoint_ker (hK : IsCompactOperator K) {M : S
   have hvsub : Tendsto (fun k => v (ψ k)) atTop (𝓝 y) := by
     have hsum : ∀ k, (1 - K : X →L[𝕜] X) (v (ψ k)) + K (v (ψ k)) = v (ψ k) := by
       intro k
-      change v (ψ k) - K (v (ψ k)) + K (v (ψ k)) = v (ψ k)
+      rw [sub_apply, one_apply_eq_self]
       abel
     have hlim : Tendsto (fun k => (1 - K : X →L[𝕜] X) (v (ψ k)) + K (v (ψ k))) atTop
         (𝓝 (0 + y)) := (hAtendsto.comp hψ.tendsto_atTop).add hψy
@@ -245,7 +250,7 @@ variable [CompleteSpace 𝕜]
 /-- The kernel of a compact perturbation of the identity is finite dimensional. -/
 theorem finiteDimensional_ker_one_sub (hK : IsCompactOperator K) :
     FiniteDimensional 𝕜 (LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X)) := by
-  rw [ker_one_sub]
+  rw [TauCeti.ker_one_sub]
   exact finiteDimensional_eigenspace hK one_ne_zero
 
 variable [IsRCLikeNormedField 𝕜] [CompleteSpace X]
@@ -367,8 +372,11 @@ theorem finiteDimensional_quotient_range_one_sub (hK : IsCompactOperator K) :
     exact hz
   refine ⟨⟨x - (A ^ (p + 1)) z, ?_⟩, ?_⟩
   · rw [LinearMap.mem_ker]
-    change (A ^ (p + 1)) (x - (A ^ (p + 1)) z) = 0
-    rw [map_sub, hzz, sub_self]
+    have hzz' :
+        ((A ^ (p + 1) : X →L[𝕜] X) : X →ₗ[𝕜] X) ((A ^ (p + 1)) z) =
+          ((A ^ (p + 1) : X →L[𝕜] X) : X →ₗ[𝕜] X) x := by
+      simpa only [ContinuousLinearMap.coe_coe] using hzz
+    rw [map_sub, hzz', sub_self]
   · have hmem : (A ^ (p + 1)) z ∈ LinearMap.range (A : X →ₗ[𝕜] X) :=
       ⟨(A ^ p) z, by rw [pow_succ']; rfl⟩
     simp only [LinearMap.comp_apply, Submodule.subtype_apply, Submodule.mkQ_apply]

--- a/TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean
+++ b/TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Analysis.LocallyConvex.HahnBanach
 public import Mathlib.Analysis.Normed.Module.RieszLemma
+public import TauCeti.Analysis.Normed.Operator.Compact.Basic
 public import TauCeti.Analysis.Normed.Operator.Compact.Eigenspace
 
 /-!
@@ -35,8 +36,6 @@ consequence `TauCeti.IsCompactOperator.exists_dist_lt_of_norm_le`.
 
 ## Main declarations
 
-* `TauCeti.IsCompactOperator.exists_dist_lt_of_norm_le`: the compactness input to the descending
-  chain argument.
 * `TauCeti.IsCompactOperator.exists_pos_mul_norm_le_of_disjoint_ker`: `1 - K` is bounded below on
   any closed subspace meeting its kernel trivially.
 * `TauCeti.IsCompactOperator.finiteDimensional_ker_one_sub`: `ker (1 - K)` is finite dimensional.
@@ -63,37 +62,8 @@ variable {𝕜 X : Type*} [NontriviallyNormedField 𝕜]
 variable [NormedAddCommGroup X] [NormedSpace 𝕜 X]
 variable {K : X →L[𝕜] X}
 
-namespace IsCompactOperator
-
-section Separation
-
-variable {R : ℝ} {u : ℕ → X}
-
-/-- A compact operator sends a bounded sequence to a sequence with a convergent subsequence. -/
-theorem exists_subseq_tendsto (hK : IsCompactOperator K) (hu : ∀ n, ‖u n‖ ≤ R) :
-    ∃ (y : X) (ψ : ℕ → ℕ), StrictMono ψ ∧ Tendsto (fun k => K (u (ψ k))) atTop (𝓝 y) := by
-  obtain ⟨S, hS, hSsub⟩ := hK.image_closedBall_subset_compact R
-  obtain ⟨y, -, ψ, hψ, hψy⟩ :=
-    hS.tendsto_subseq fun n => hSsub ⟨u n, by simpa using hu n, rfl⟩
-  exact ⟨y, ψ, hψ, hψy⟩
-
-/-- A compact operator cannot keep the images of a bounded sequence pairwise separated: two
-distinct indices always have images within any prescribed positive distance.
-
-This is the compactness input to the descending-chain argument below. -/
-theorem exists_dist_lt_of_norm_le (hK : IsCompactOperator K) (hu : ∀ n, ‖u n‖ ≤ R) {ε : ℝ}
-    (hε : 0 < ε) : ∃ m n, m ≠ n ∧ dist (K (u m)) (K (u n)) < ε := by
-  obtain ⟨y, ψ, hψ, hψy⟩ := exists_subseq_tendsto hK hu
-  have hcauchy := hψy.cauchySeq
-  rw [Metric.cauchySeq_iff'] at hcauchy
-  obtain ⟨N, hN⟩ := hcauchy ε hε
-  exact ⟨ψ (N + 1), ψ N, by simp [hψ.injective.eq_iff], hN (N + 1) (Nat.le_succ N)⟩
-
-end Separation
-
-end IsCompactOperator
-
 /-- The kernel of `1 - K` is the `1`-eigenspace of `K`. -/
+@[simp]
 theorem ker_one_sub (K : X →L[𝕜] X) :
     LinearMap.ker ((1 - K : X →L[𝕜] X) : X →ₗ[𝕜] X) = End.eigenspace (K : X →ₗ[𝕜] X) 1 := by
   ext x


### PR DESCRIPTION
This PR proves that a compact perturbation of a Fredholm operator between Banach spaces is again Fredholm and has the same index, together with the Riesz--Schauder theory it rests on. The `HeegaardFloer` roadmap's Lane F0 ("the nonlinear-analysis substrate") asks for "**Fredholm operators** (index, stability under compact and small perturbations, kernel/cokernel splitting)"; small-norm and finite-rank stability already landed (`TauCeti/Analysis/Fredholm/SmallPerturbation.lean`, `FiniteRank.lean`), and compact perturbation was the one classical statement of that package still missing. After this PR, Lane F0's remaining unmet items are the nonlinear half: finite-dimensional Sard, Sard--Smale, the Fredholm property of `d/ds + A(s)` on the strip, and the "moduli space = zero set of a Fredholm section" package.

`TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean` (378 lines) develops the Riesz theory of `A = 1 - K` for `K` compact. The single compactness input is isolated as `IsCompactOperator.exists_dist_lt_of_norm_le`: a compact operator cannot keep the images of a bounded sequence pairwise separated. From it come the three finiteness facts. `finiteDimensional_ker_one_sub` identifies `ker (1 - K)` with the `1`-eigenspace of `K` and reuses `IsCompactOperator.finiteDimensional_eigenspace` from the existing `Compact/Eigenspace.lean`, whose docstring already advertises itself as "Riesz--Schauder input used for compact perturbations of Fredholm operators". `isClosed_range_one_sub` splits off a closed complement `M` of the (finite-dimensional, hence complemented) kernel, shows `1 - K` is bounded below on `M` by a shell-and-subsequence argument, and concludes with `AntilipschitzWith.isClosed_range`. `finiteDimensional_quotient_range_one_sub` runs the classical Riesz argument on the decreasing chain `range A ⊇ range A² ⊇ ⋯`: each `Aⁿ` is again `1` minus a compact operator (`isCompactOperator_one_sub_pow`), so each range is closed, and Riesz's lemma would otherwise produce a separated bounded sequence; once the chain stabilises at `p`, every `x` splits as an element of `ker A ^ (p + 1)` plus an element of `range A ^ (p + 1) ≤ range A`, so `ker A ^ (p + 1)` surjects onto the cokernel.

`TauCeti/Analysis/Fredholm/CompactPerturbation.lean` (169 lines) turns this into the Fredholm statements. `isFredholm_one_sub` feeds the two defect spaces into the repository's `ContinuousLinearMap.IsFredholm.of_finite_ker_coker`, so no closed-range obligation has to be discharged a second time. For general `T` Fredholm and `C` compact, `ContinuousLinearMap.IsFredholm.add_of_isCompactOperator` runs Atkinson's argument on a continuous quasi-inverse `S` of `T` obtained from Mathlib's `IsFredholm.exists_isQuasiInverse`: `S ∘ (T + C) = (1 + S ∘ C) + (S ∘ T - 1)` is a finite-rank perturbation of a compact perturbation of the identity, hence Fredholm by the existing `IsFredholm.add_of_finiteDimensional_range`, and likewise for `(T + C) ∘ S`; the kernel of `T + C` sits inside that of `S ∘ (T + C)` and its range contains that of `(T + C) ∘ S`. The index statement `index_add_of_isCompactOperator` is then a connectedness argument rather than a new computation: `c ↦ T + c • C` is a continuous family of Fredholm operators over the preconnected parameter space `𝕜`, so `Continuous.index_eq_of_preconnectedSpace` from `Fredholm/ContinuousFamily.lean` equates the values at `c = 0` and `c = 1`. Specialising to `T = 1` gives `index_one_sub_eq_zero`.

Nothing is vendored from Mathlib; the developments consume Mathlib's `ContinuousLinearMap.IsFredholm` and quasi-inverse API, `riesz_lemma_of_norm_lt`, `rescale_to_shell`, `Submodule.ClosedComplemented.of_finiteDimensional`, `Submodule.factor`, and the `IsCompactOperator` calculus. Mathlib's own compact-operator file `Analysis/Normed/Operator/Compact/FredholmAlternative.lean` proves the spectral dichotomy (eigenvalue or resolvent point) and contains no Fredholm-operator statement, so there is no duplication.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"fredholm-compact-perturbation"}-->

🤖 Prepared with Claude Code
