### PR TITLE
feat: the real Clifford forms Cliff(p, q) and the base entries of the Bott table

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -48,8 +48,9 @@ given an abbreviation, so that every lemma about a general `CliffordAlgebra` app
 unfolding.
 
 The scaffolding of the four constructions — the two transporting isometries and the two hand-built
-algebra maps together with their surjectivity — is `private`: the public interface is the four
-`AlgEquiv`s and the lemmas computing them on a generator, which is all a downstream file needs.
+algebra maps together with their surjectivity and the resulting bijectivity — is `private`: the
+public interface is the four `AlgEquiv`s and the lemmas computing them on a generator, which is all
+a downstream file needs.
 
 All four identifications are bundled `AlgEquiv`s rather than the `Nonempty` existence statements
 the roadmap asks for, and each comes with a lemma computing it on a generator: it is the
@@ -107,11 +108,13 @@ theorem realCliffordWeight_of_le {p q : ℕ} {i : Fin (p + q)} (hi : p ≤ (i : 
     realCliffordWeight p q i = -1 :=
   if_neg (not_lt.2 hi)
 
+@[simp]
 theorem realCliffordWeight_mul_self (p q : ℕ) (i : Fin (p + q)) :
     realCliffordWeight p q i * realCliffordWeight p q i = 1 := by
   unfold realCliffordWeight
   split <;> norm_num
 
+@[simp]
 theorem realCliffordWeight_ne_zero (p q : ℕ) (i : Fin (p + q)) :
     realCliffordWeight p q i ≠ 0 := by
   intro h
@@ -122,6 +125,7 @@ theorem realCliffordForm_apply (p q : ℕ) (v : Fin (p + q) → ℝ) :
     realCliffordForm p q v = ∑ i, realCliffordWeight p q i * (v i * v i) := by
   simp [realCliffordForm]
 
+@[simp]
 theorem polar_realCliffordForm (p q : ℕ) (v w : Fin (p + q) → ℝ) :
     polar (realCliffordForm p q) v w = 2 * ∑ i, realCliffordWeight p q i * (v i * w i) := by
   simp only [polar, realCliffordForm_apply, Pi.add_apply, Finset.mul_sum,
@@ -140,6 +144,7 @@ theorem nondegenerate_realCliffordForm (p q : ℕ) : (realCliffordForm p q).Nond
 /-- The real Clifford algebra of signature `(p, q)` has dimension `2 ^ (p + q)`, as every Clifford
 algebra of a space of that dimension does. This is the count that forces the surjections built
 below to be isomorphisms. -/
+@[simp]
 theorem finrank_cliffordAlgebra_realCliffordForm (p q : ℕ) :
     finrank ℝ (CliffordAlgebra (realCliffordForm p q)) = 2 ^ (p + q) := by
   rw [TauCeti.CliffordAlgebra.finrank_eq_two_pow, Module.finrank_pi, Fintype.card_fin]
@@ -197,22 +202,29 @@ private theorem realCliffordOneZeroToProd_surjective :
       + ((a - b) / 2) • CliffordAlgebra.ι (realCliffordForm 1 0) (Pi.single 0 1), ?_⟩
   ext <;> simp [realCliffordOneZeroToProd_ι] <;> ring
 
+/-- `realCliffordOneZeroToProd` is bijective: it is surjective, and both sides have dimension `2`,
+so surjectivity forces injectivity. -/
+private theorem realCliffordOneZeroToProd_bijective :
+    Function.Bijective realCliffordOneZeroToProd := by
+  have hrank : finrank ℝ (CliffordAlgebra (realCliffordForm 1 0)) = finrank ℝ (ℝ × ℝ) := by
+    rw [finrank_cliffordAlgebra_realCliffordForm, Module.finrank_prod, Module.finrank_self]
+    norm_num
+  exact ⟨(LinearMap.injective_iff_surjective_of_finrank_eq_finrank
+    (f := realCliffordOneZeroToProd.toLinearMap) hrank).2
+    realCliffordOneZeroToProd_surjective, realCliffordOneZeroToProd_surjective⟩
+
 /-- **`Cliff(1,0) ≅ ℝ × ℝ`**, the first base entry of the real periodicity table: a single
 generator squaring to `+1` splits the algebra. -/
 noncomputable def realCliffordOneZeroEquivProd :
     CliffordAlgebra (realCliffordForm 1 0) ≃ₐ[ℝ] ℝ × ℝ :=
-  AlgEquiv.ofBijective realCliffordOneZeroToProd <| by
-    have hrank : finrank ℝ (CliffordAlgebra (realCliffordForm 1 0)) = finrank ℝ (ℝ × ℝ) := by
-      rw [finrank_cliffordAlgebra_realCliffordForm, Module.finrank_prod, Module.finrank_self]
-      norm_num
-    exact ⟨(LinearMap.injective_iff_surjective_of_finrank_eq_finrank
-      (f := realCliffordOneZeroToProd.toLinearMap) hrank).2
-      realCliffordOneZeroToProd_surjective, realCliffordOneZeroToProd_surjective⟩
+  AlgEquiv.ofBijective realCliffordOneZeroToProd realCliffordOneZeroToProd_bijective
 
+/-- `realCliffordOneZeroEquivProd` sends the generator of the coordinate `v` to the pair
+`(v 0, -v 0)`: the two characters of `ℝ[e]/(e² - 1)` read off the two components. -/
 @[simp]
 theorem realCliffordOneZeroEquivProd_ι (v : Fin (1 + 0) → ℝ) :
-    realCliffordOneZeroEquivProd (CliffordAlgebra.ι _ v) = (v 0, -v 0) :=
-  realCliffordOneZeroToProd_ι v
+    realCliffordOneZeroEquivProd (CliffordAlgebra.ι _ v) = (v 0, -v 0) := by
+  rw [realCliffordOneZeroEquivProd, AlgEquiv.ofBijective_apply, realCliffordOneZeroToProd_ι]
 
 /-! ### `Cliff(0,1) ≅ ℂ` -/
 
@@ -236,6 +248,8 @@ private theorem realCliffordZeroOneEquivComplex_eq (x : CliffordAlgebra (realCli
       CliffordAlgebraComplex.equiv
         (CliffordAlgebra.equivOfIsometry realCliffordZeroOneIsometry x) := rfl
 
+/-- `realCliffordZeroOneEquivComplex` sends the generator of the coordinate `v` to the purely
+imaginary complex number `v 0 • Complex.I`. -/
 @[simp]
 theorem realCliffordZeroOneEquivComplex_ι (v : Fin (0 + 1) → ℝ) :
     realCliffordZeroOneEquivComplex (CliffordAlgebra.ι _ v) = v 0 • Complex.I := by
@@ -271,6 +285,8 @@ private theorem realCliffordZeroTwoEquivQuaternion_eq
       CliffordAlgebraQuaternion.equiv
         (CliffordAlgebra.equivOfIsometry realCliffordZeroTwoIsometry x) := rfl
 
+/-- `realCliffordZeroTwoEquivQuaternion` sends the generator of the coordinate `v` to the imaginary
+quaternion `v 0 * i + v 1 * j`. -/
 @[simp]
 theorem realCliffordZeroTwoEquivQuaternion_ι (v : Fin (0 + 2) → ℝ) :
     realCliffordZeroTwoEquivQuaternion (CliffordAlgebra.ι _ v) = ⟨0, v 0, v 1, 0⟩ := by
@@ -318,22 +334,30 @@ private theorem realCliffordOneOneToMatrix_surjective :
   fin_cases i <;> fin_cases j <;>
     simp [realCliffordOneOneToMatrix_ι, Algebra.algebraMap_eq_smul_one] <;> ring
 
+/-- `realCliffordOneOneToMatrix` is bijective: it is surjective, and both sides have dimension `4`,
+so surjectivity forces injectivity. -/
+private theorem realCliffordOneOneToMatrix_bijective :
+    Function.Bijective realCliffordOneOneToMatrix := by
+  have hrank : finrank ℝ (CliffordAlgebra (realCliffordForm 1 1)) =
+      finrank ℝ (Matrix (Fin 2) (Fin 2) ℝ) := by
+    rw [finrank_cliffordAlgebra_realCliffordForm, Module.finrank_matrix]
+    simp
+  exact ⟨(LinearMap.injective_iff_surjective_of_finrank_eq_finrank
+    (f := realCliffordOneOneToMatrix.toLinearMap) hrank).2
+    realCliffordOneOneToMatrix_surjective, realCliffordOneOneToMatrix_surjective⟩
+
 /-- **`Cliff(1,1) ≅ M₂(ℝ)`**, the fourth base entry of the real periodicity table and the seed of
 the periodicity step `Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)`. -/
 noncomputable def realCliffordOneOneEquivMatrix :
     CliffordAlgebra (realCliffordForm 1 1) ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
-  AlgEquiv.ofBijective realCliffordOneOneToMatrix <| by
-    have hrank : finrank ℝ (CliffordAlgebra (realCliffordForm 1 1)) =
-        finrank ℝ (Matrix (Fin 2) (Fin 2) ℝ) := by
-      rw [finrank_cliffordAlgebra_realCliffordForm, Module.finrank_matrix]
-      simp
-    exact ⟨(LinearMap.injective_iff_surjective_of_finrank_eq_finrank
-      (f := realCliffordOneOneToMatrix.toLinearMap) hrank).2
-      realCliffordOneOneToMatrix_surjective, realCliffordOneOneToMatrix_surjective⟩
+  AlgEquiv.ofBijective realCliffordOneOneToMatrix realCliffordOneOneToMatrix_bijective
 
+/-- `realCliffordOneOneEquivMatrix` sends the generator of the coordinate `v` to
+`!![v 0, v 1; -v 1, -v 0]`, the combination `v 0 • !![1, 0; 0, -1] + v 1 • !![0, 1; -1, 0]` of the
+images of the `+1` and `-1` generators. -/
 @[simp]
 theorem realCliffordOneOneEquivMatrix_ι (v : Fin (1 + 1) → ℝ) :
-    realCliffordOneOneEquivMatrix (CliffordAlgebra.ι _ v) = !![v 0, v 1; -v 1, -v 0] :=
-  realCliffordOneOneToMatrix_ι v
+    realCliffordOneOneEquivMatrix (CliffordAlgebra.ι _ v) = !![v 0, v 1; -v 1, -v 0] := by
+  rw [realCliffordOneOneEquivMatrix, AlgEquiv.ofBijective_apply, realCliffordOneOneToMatrix_ι]
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -1,0 +1,321 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Equivs
+public import Mathlib.LinearAlgebra.QuadraticForm.Radical
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
+
+/-!
+# The real Clifford algebras `Cliff(p, q)` and the base entries of the Bott table
+
+Over `ℂ` a nondegenerate quadratic form is determined by its rank, so there is one Clifford algebra
+in each dimension. Over `ℝ` this fails: a nondegenerate real form is classified by its signature
+`(p, q)`, and the resulting algebras `Cliff(p, q)` run through matrix algebras over `ℝ`, `ℂ` and
+`ℍ` in a pattern periodic modulo `8`. This file introduces the family of forms that the pattern is
+indexed by, and pins the four small entries that fix the indexing convention.
+
+`TauCeti.realCliffordForm p q` is the diagonal form on `Fin (p + q) → ℝ` with `+1` in the first `p`
+coordinates and `-1` in the last `q`, written as a `QuadraticMap.weightedSumSquares` against the
+sign vector `TauCeti.realCliffordWeight p q`. It is nondegenerate
+(`TauCeti.nondegenerate_realCliffordForm`), and its Clifford algebra has dimension `2 ^ (p + q)`
+(`TauCeti.finrank_cliffordAlgebra_realCliffordForm`).
+
+The sign convention — generators of the *first* `p` coordinates square to `+1` — is not universal:
+sources that make the first generators square to `-1` index the periodicity table by
+`(p - q) mod 8` where this one uses `(q - p) mod 8`. The convention is therefore fixed here by
+four explicit small identifications, which are the content of the rest of the file:
+
+* `Cliff(1,0) ≅ ℝ × ℝ` — `TauCeti.realCliffordOneZeroEquivProd`;
+* `Cliff(0,1) ≅ ℂ` — `TauCeti.realCliffordZeroOneEquivComplex`;
+* `Cliff(0,2) ≅ ℍ` — `TauCeti.realCliffordZeroTwoEquivQuaternion`;
+* `Cliff(1,1) ≅ M₂(ℝ)` — `TauCeti.realCliffordOneOneEquivMatrix`.
+
+The middle two are Mathlib's `CliffordAlgebraComplex.equiv` and `CliffordAlgebraQuaternion.equiv`
+transported along an isometry, since the forms Mathlib uses there are exactly the `(0,1)` and
+`(0,2)` signature forms in disguise. The outer two are built here from the universal property: a
+single generator squaring to `+1` splits the algebra into two copies of `ℝ`, and a hyperbolic pair
+generates the whole of `M₂(ℝ)`. In both cases the constructed algebra map is proved *surjective* by
+exhibiting explicit preimages, and injectivity is then forced by the dimension count
+`2 ^ (p + q)`, which is the general mechanism the complex structure theorem uses as well.
+
+## Implementation notes
+
+`Cliff(p, q)` is spelled `CliffordAlgebra (realCliffordForm p q)` throughout rather than being
+given an abbreviation, so that every lemma about a general `CliffordAlgebra` applies to it without
+unfolding.
+
+All four identifications are bundled `AlgEquiv`s rather than the `Nonempty` existence statements
+the roadmap asks for, and each comes with a lemma computing it on a generator: it is the
+equivalences and their values, not their bare existence, that the Bott-periodicity step
+`Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)` will consume.
+
+## Main definitions
+
+* `TauCeti.realCliffordWeight` and `TauCeti.realCliffordForm`: the signature `(p, q)` sign vector
+  and the diagonal real quadratic form it weights.
+* `TauCeti.realCliffordOneZeroEquivProd`, `TauCeti.realCliffordZeroOneEquivComplex`,
+  `TauCeti.realCliffordZeroTwoEquivQuaternion`, `TauCeti.realCliffordOneOneEquivMatrix`: the four
+  base entries of the Bott table, each with a `..._ι` lemma computing it on a generator.
+* `TauCeti.realCliffordZeroOneIsometry` and `TauCeti.realCliffordZeroTwoIsometry`: the isometries
+  matching the signature `(0,1)` and `(0,2)` forms with the forms Mathlib's complex and quaternion
+  identifications are stated for.
+
+## Main results
+
+* `TauCeti.nondegenerate_realCliffordForm`: the signature forms are nondegenerate.
+* `TauCeti.finrank_cliffordAlgebra_realCliffordForm`:
+  `finrank ℝ (CliffordAlgebra (realCliffordForm p q)) = 2 ^ (p + q)`.
+* `TauCeti.realCliffordOneZeroToProd_surjective` and
+  `TauCeti.realCliffordOneOneToMatrix_surjective`: the two hand-built algebra maps are onto, which
+  with the dimension count makes them isomorphisms.
+
+## References
+
+* [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
+  Layer 7, "The real forms `Cliff(p, q)`".
+* H. B. Lawson, M.-L. Michelsohn, *Spin Geometry*, Princeton (1989), Chapter I, §4.
+-/
+
+public section
+
+open Module QuadraticMap
+
+open scoped Quaternion
+
+namespace TauCeti
+
+/-! ### The real quadratic form of a signature -/
+
+/-- The sign vector of signature `(p, q)`: `+1` on the first `p` coordinates of `Fin (p + q)` and
+`-1` on the last `q`. -/
+def realCliffordWeight (p q : ℕ) (i : Fin (p + q)) : ℝ := if (i : ℕ) < p then 1 else -1
+
+/-- The real quadratic form of signature `(p, q)`: the diagonal form
+`x ↦ ∑ᵢ₌₀^{p-1} xᵢ² - ∑ᵢ₌ₚ^{p+q-1} xᵢ²` on `Fin (p + q) → ℝ`. Its Clifford algebra is the real
+Clifford algebra `Cliff(p, q)`. -/
+def realCliffordForm (p q : ℕ) : QuadraticForm ℝ (Fin (p + q) → ℝ) :=
+  weightedSumSquares ℝ (realCliffordWeight p q)
+
+@[simp]
+theorem realCliffordWeight_of_lt {p q : ℕ} {i : Fin (p + q)} (hi : (i : ℕ) < p) :
+    realCliffordWeight p q i = 1 :=
+  if_pos hi
+
+@[simp]
+theorem realCliffordWeight_of_le {p q : ℕ} {i : Fin (p + q)} (hi : p ≤ (i : ℕ)) :
+    realCliffordWeight p q i = -1 :=
+  if_neg (not_lt.2 hi)
+
+theorem realCliffordWeight_mul_self (p q : ℕ) (i : Fin (p + q)) :
+    realCliffordWeight p q i * realCliffordWeight p q i = 1 := by
+  unfold realCliffordWeight
+  split <;> norm_num
+
+theorem realCliffordWeight_ne_zero (p q : ℕ) (i : Fin (p + q)) :
+    realCliffordWeight p q i ≠ 0 := by
+  intro h
+  simpa [h] using realCliffordWeight_mul_self p q i
+
+theorem realCliffordForm_apply (p q : ℕ) (v : Fin (p + q) → ℝ) :
+    realCliffordForm p q v = ∑ i, realCliffordWeight p q i * (v i * v i) := by
+  simp [realCliffordForm]
+
+theorem polar_realCliffordForm (p q : ℕ) (v w : Fin (p + q) → ℝ) :
+    polar (realCliffordForm p q) v w = 2 * ∑ i, realCliffordWeight p q i * (v i * w i) := by
+  simp only [polar, realCliffordForm_apply, Pi.add_apply, Finset.mul_sum,
+    ← Finset.sum_sub_distrib]
+  exact Finset.sum_congr rfl fun i _ => by ring
+
+/-- The signature forms are nondegenerate: the polar form pairs the `i`-th coordinate vector with
+the `i`-th coordinate, up to the nonzero sign `realCliffordWeight p q i`. -/
+theorem nondegenerate_realCliffordForm (p q : ℕ) : (realCliffordForm p q).Nondegenerate := by
+  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, QuadraticMap.radical_eq_ker_polarBilin,
+    LinearMap.ker_eq_bot']
+  intro v hv
+  funext j
+  have h := LinearMap.congr_fun hv (Pi.single j 1)
+  rw [QuadraticMap.polarBilin_apply_apply, polar_realCliffordForm] at h
+  simp only [Pi.single_apply, mul_ite, mul_one, mul_zero, Finset.sum_ite_eq',
+    Finset.mem_univ, if_true, LinearMap.zero_apply] at h
+  have h' : realCliffordWeight p q j * v j = 0 := by linarith
+  rcases mul_eq_zero.1 h' with h'' | h''
+  · exact absurd h'' (realCliffordWeight_ne_zero p q j)
+  · simpa using h''
+
+/-- The real Clifford algebra of signature `(p, q)` has dimension `2 ^ (p + q)`, as every Clifford
+algebra of a space of that dimension does. This is the count that forces the surjections built
+below to be isomorphisms. -/
+theorem finrank_cliffordAlgebra_realCliffordForm (p q : ℕ) :
+    finrank ℝ (CliffordAlgebra (realCliffordForm p q)) = 2 ^ (p + q) := by
+  rw [TauCeti.CliffordAlgebra.finrank_eq_two_pow, Module.finrank_pi, Fintype.card_fin]
+
+/-! ### The four base entries, in coordinates -/
+
+theorem realCliffordForm_one_zero_apply (v : Fin (1 + 0) → ℝ) :
+    realCliffordForm 1 0 v = v 0 * v 0 := by
+  rw [realCliffordForm_apply]
+  simp [realCliffordWeight]
+
+theorem realCliffordForm_zero_one_apply (v : Fin (0 + 1) → ℝ) :
+    realCliffordForm 0 1 v = -(v 0 * v 0) := by
+  rw [realCliffordForm_apply]
+  simp [realCliffordWeight]
+
+theorem realCliffordForm_zero_two_apply (v : Fin (0 + 2) → ℝ) :
+    realCliffordForm 0 2 v = -(v 0 * v 0) + -(v 1 * v 1) := by
+  rw [realCliffordForm_apply, Fin.sum_univ_two]
+  simp [realCliffordWeight]
+
+theorem realCliffordForm_one_one_apply (v : Fin (1 + 1) → ℝ) :
+    realCliffordForm 1 1 v = v 0 * v 0 - v 1 * v 1 := by
+  rw [realCliffordForm_apply, Fin.sum_univ_two]
+  simp [realCliffordWeight]
+  ring
+
+/-! ### `Cliff(1,0) ≅ ℝ × ℝ` -/
+
+/-- The algebra map `Cliff(1,0) → ℝ × ℝ` sending the generator `e` to `(1, -1)`. This is legitimate
+because `(1, -1)` squares to `1 = Q e`, and it is the pair of the two characters `e ↦ 1` and
+`e ↦ -1` of `ℝ[e]/(e² - 1)`. -/
+def realCliffordOneZeroToProd :
+    CliffordAlgebra (realCliffordForm 1 0) →ₐ[ℝ] ℝ × ℝ :=
+  CliffordAlgebra.lift _
+    ⟨(LinearMap.proj 0).prod (-LinearMap.proj 0), fun v => by
+      ext <;> simp [realCliffordForm_one_zero_apply]⟩
+
+@[simp]
+theorem realCliffordOneZeroToProd_ι (v : Fin (1 + 0) → ℝ) :
+    realCliffordOneZeroToProd (CliffordAlgebra.ι _ v) = (v 0, -v 0) :=
+  CliffordAlgebra.lift_ι_apply _ _ v
+
+theorem realCliffordOneZeroToProd_surjective :
+    Function.Surjective realCliffordOneZeroToProd := by
+  rintro ⟨a, b⟩
+  refine ⟨algebraMap ℝ _ ((a + b) / 2)
+      + ((a - b) / 2) • CliffordAlgebra.ι (realCliffordForm 1 0) (Pi.single 0 1), ?_⟩
+  ext <;> simp <;> ring
+
+/-- **`Cliff(1,0) ≅ ℝ × ℝ`**, the first base entry of the real periodicity table: a single
+generator squaring to `+1` splits the algebra. -/
+noncomputable def realCliffordOneZeroEquivProd :
+    CliffordAlgebra (realCliffordForm 1 0) ≃ₐ[ℝ] ℝ × ℝ :=
+  AlgEquiv.ofBijective realCliffordOneZeroToProd <| by
+    have hrank : finrank ℝ (CliffordAlgebra (realCliffordForm 1 0)) = finrank ℝ (ℝ × ℝ) := by
+      rw [finrank_cliffordAlgebra_realCliffordForm, Module.finrank_prod, Module.finrank_self]
+      norm_num
+    exact ⟨(LinearMap.injective_iff_surjective_of_finrank_eq_finrank
+      (f := realCliffordOneZeroToProd.toLinearMap) hrank).2
+      realCliffordOneZeroToProd_surjective, realCliffordOneZeroToProd_surjective⟩
+
+@[simp]
+theorem realCliffordOneZeroEquivProd_ι (v : Fin (1 + 0) → ℝ) :
+    realCliffordOneZeroEquivProd (CliffordAlgebra.ι _ v) = (v 0, -v 0) :=
+  realCliffordOneZeroToProd_ι v
+
+/-! ### `Cliff(0,1) ≅ ℂ` -/
+
+/-- The signature `(0,1)` form is Mathlib's `CliffordAlgebraComplex.Q`, `r ↦ -r²`, read on the
+one-dimensional space `Fin (0 + 1) → ℝ`. -/
+def realCliffordZeroOneIsometry :
+    (realCliffordForm 0 1).IsometryEquiv CliffordAlgebraComplex.Q :=
+  ⟨(LinearEquiv.funUnique (Fin 1) ℝ ℝ : (Fin (0 + 1) → ℝ) ≃ₗ[ℝ] ℝ), fun v => by
+    simp [realCliffordForm_zero_one_apply]⟩
+
+/-- **`Cliff(0,1) ≅ ℂ`**, the second base entry of the real periodicity table: a single generator
+squaring to `-1` is a square root of `-1`. -/
+noncomputable def realCliffordZeroOneEquivComplex :
+    CliffordAlgebra (realCliffordForm 0 1) ≃ₐ[ℝ] ℂ :=
+  (CliffordAlgebra.equivOfIsometry realCliffordZeroOneIsometry).trans
+    CliffordAlgebraComplex.equiv
+
+@[simp]
+theorem realCliffordZeroOneEquivComplex_ι (v : Fin (0 + 1) → ℝ) :
+    realCliffordZeroOneEquivComplex (CliffordAlgebra.ι _ v) = v 0 • Complex.I := by
+  change CliffordAlgebraComplex.equiv
+      (CliffordAlgebra.equivOfIsometry realCliffordZeroOneIsometry (CliffordAlgebra.ι _ v)) = _
+  rw [CliffordAlgebra.equivOfIsometry_apply, CliffordAlgebra.map_apply_ι]
+  simp [realCliffordZeroOneIsometry]
+  rfl
+
+/-! ### `Cliff(0,2) ≅ ℍ` -/
+
+/-- The signature `(0,2)` form is Mathlib's `CliffordAlgebraQuaternion.Q (-1) (-1)` read on
+`Fin (0 + 2) → ℝ` instead of on `ℝ × ℝ`. -/
+def realCliffordZeroTwoIsometry :
+    (realCliffordForm 0 2).IsometryEquiv (CliffordAlgebraQuaternion.Q (-1 : ℝ) (-1)) :=
+  ⟨(LinearEquiv.finTwoArrow ℝ ℝ : (Fin (0 + 2) → ℝ) ≃ₗ[ℝ] ℝ × ℝ), fun v => by
+    simp [realCliffordForm_zero_two_apply]⟩
+
+/-- **`Cliff(0,2) ≅ ℍ`**, the third base entry of the real periodicity table: two anticommuting
+generators squaring to `-1` are the quaternion units `i` and `j`. -/
+noncomputable def realCliffordZeroTwoEquivQuaternion :
+    CliffordAlgebra (realCliffordForm 0 2) ≃ₐ[ℝ] ℍ[ℝ] :=
+  (CliffordAlgebra.equivOfIsometry realCliffordZeroTwoIsometry).trans
+    CliffordAlgebraQuaternion.equiv
+
+@[simp]
+theorem realCliffordZeroTwoEquivQuaternion_ι (v : Fin (0 + 2) → ℝ) :
+    realCliffordZeroTwoEquivQuaternion (CliffordAlgebra.ι _ v) = ⟨0, v 0, v 1, 0⟩ := by
+  change CliffordAlgebraQuaternion.equiv
+      (CliffordAlgebra.equivOfIsometry realCliffordZeroTwoIsometry (CliffordAlgebra.ι _ v)) = _
+  rw [CliffordAlgebra.equivOfIsometry_apply, CliffordAlgebra.map_apply_ι]
+  simp only [IsometryEquiv.toIsometry_apply, CliffordAlgebraQuaternion.equiv_apply,
+    CliffordAlgebraQuaternion.toQuaternion_ι, QuaternionAlgebra.mk.injEq, and_true, true_and]
+  exact ⟨rfl, rfl⟩
+
+/-! ### `Cliff(1,1) ≅ M₂(ℝ)` -/
+
+/-- The algebra map `Cliff(1,1) → M₂(ℝ)` sending the `+1` generator to the diagonal involution
+`!![1, 0; 0, -1]` and the `-1` generator to the rotation `!![0, 1; -1, 0]`. The two matrices
+anticommute, so the map is well defined by the universal property. -/
+def realCliffordOneOneToMatrix :
+    CliffordAlgebra (realCliffordForm 1 1) →ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
+  CliffordAlgebra.lift _
+    ⟨(LinearMap.proj 0).smulRight !![1, 0; 0, -1] +
+        (LinearMap.proj 1).smulRight !![0, 1; -1, 0], fun v => by
+      ext i j
+      fin_cases i <;> fin_cases j <;>
+        simp [realCliffordForm_one_one_apply, Matrix.mul_apply, Fin.sum_univ_two,
+          Algebra.algebraMap_eq_smul_one] <;> ring⟩
+
+@[simp]
+theorem realCliffordOneOneToMatrix_ι (v : Fin (1 + 1) → ℝ) :
+    realCliffordOneOneToMatrix (CliffordAlgebra.ι _ v) = !![v 0, v 1; -v 1, -v 0] := by
+  rw [realCliffordOneOneToMatrix, CliffordAlgebra.lift_ι_apply]
+  simp [Matrix.smul_of]
+
+theorem realCliffordOneOneToMatrix_surjective :
+    Function.Surjective realCliffordOneOneToMatrix := by
+  intro m
+  refine ⟨algebraMap ℝ _ ((m 0 0 + m 1 1) / 2)
+      + ((m 0 0 - m 1 1) / 2) • CliffordAlgebra.ι (realCliffordForm 1 1) (Pi.single 0 1)
+      + ((m 0 1 - m 1 0) / 2) • CliffordAlgebra.ι (realCliffordForm 1 1) (Pi.single 1 1)
+      + ((m 0 1 + m 1 0) / 2) •
+        (CliffordAlgebra.ι (realCliffordForm 1 1) (Pi.single 0 1) *
+          CliffordAlgebra.ι (realCliffordForm 1 1) (Pi.single 1 1)), ?_⟩
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Algebra.algebraMap_eq_smul_one] <;> ring
+
+/-- **`Cliff(1,1) ≅ M₂(ℝ)`**, the fourth base entry of the real periodicity table and the seed of
+the periodicity step `Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)`. -/
+noncomputable def realCliffordOneOneEquivMatrix :
+    CliffordAlgebra (realCliffordForm 1 1) ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
+  AlgEquiv.ofBijective realCliffordOneOneToMatrix <| by
+    have hrank : finrank ℝ (CliffordAlgebra (realCliffordForm 1 1)) =
+        finrank ℝ (Matrix (Fin 2) (Fin 2) ℝ) := by
+      rw [finrank_cliffordAlgebra_realCliffordForm, Module.finrank_matrix]
+      simp
+    exact ⟨(LinearMap.injective_iff_surjective_of_finrank_eq_finrank
+      (f := realCliffordOneOneToMatrix.toLinearMap) hrank).2
+      realCliffordOneOneToMatrix_surjective, realCliffordOneOneToMatrix_surjective⟩
+
+@[simp]
+theorem realCliffordOneOneEquivMatrix_ι (v : Fin (1 + 1) → ℝ) :
+    realCliffordOneOneEquivMatrix (CliffordAlgebra.ι _ v) = !![v 0, v 1; -v 1, -v 0] :=
+  realCliffordOneOneToMatrix_ι v
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -47,6 +47,10 @@ exhibiting explicit preimages, and injectivity is then forced by the dimension c
 given an abbreviation, so that every lemma about a general `CliffordAlgebra` applies to it without
 unfolding.
 
+The scaffolding of the four constructions — the two transporting isometries and the two hand-built
+algebra maps together with their surjectivity — is `private`: the public interface is the four
+`AlgEquiv`s and the lemmas computing them on a generator, which is all a downstream file needs.
+
 All four identifications are bundled `AlgEquiv`s rather than the `Nonempty` existence statements
 the roadmap asks for, and each comes with a lemma computing it on a generator: it is the
 equivalences and their values, not their bare existence, that the Bott-periodicity step
@@ -59,18 +63,12 @@ equivalences and their values, not their bare existence, that the Bott-periodici
 * `TauCeti.realCliffordOneZeroEquivProd`, `TauCeti.realCliffordZeroOneEquivComplex`,
   `TauCeti.realCliffordZeroTwoEquivQuaternion`, `TauCeti.realCliffordOneOneEquivMatrix`: the four
   base entries of the Bott table, each with a `..._ι` lemma computing it on a generator.
-* `TauCeti.realCliffordZeroOneIsometry` and `TauCeti.realCliffordZeroTwoIsometry`: the isometries
-  matching the signature `(0,1)` and `(0,2)` forms with the forms Mathlib's complex and quaternion
-  identifications are stated for.
 
 ## Main results
 
 * `TauCeti.nondegenerate_realCliffordForm`: the signature forms are nondegenerate.
 * `TauCeti.finrank_cliffordAlgebra_realCliffordForm`:
   `finrank ℝ (CliffordAlgebra (realCliffordForm p q)) = 2 ^ (p + q)`.
-* `TauCeti.realCliffordOneZeroToProd_surjective` and
-  `TauCeti.realCliffordOneOneToMatrix_surjective`: the two hand-built algebra maps are onto, which
-  with the dimension count makes them isomorphisms.
 
 ## References
 
@@ -119,6 +117,7 @@ theorem realCliffordWeight_ne_zero (p q : ℕ) (i : Fin (p + q)) :
   intro h
   simpa [h] using realCliffordWeight_mul_self p q i
 
+@[simp]
 theorem realCliffordForm_apply (p q : ℕ) (v : Fin (p + q) → ℝ) :
     realCliffordForm p q v = ∑ i, realCliffordWeight p q i * (v i * v i) := by
   simp [realCliffordForm]
@@ -129,21 +128,14 @@ theorem polar_realCliffordForm (p q : ℕ) (v w : Fin (p + q) → ℝ) :
     ← Finset.sum_sub_distrib]
   exact Finset.sum_congr rfl fun i _ => by ring
 
-/-- The signature forms are nondegenerate: the polar form pairs the `i`-th coordinate vector with
-the `i`-th coordinate, up to the nonzero sign `realCliffordWeight p q i`. -/
+/-- The signature forms are nondegenerate: the radical of a weighted sum of squares is spanned by
+the coordinates with weight zero, and every signature weight is `±1`. -/
 theorem nondegenerate_realCliffordForm (p q : ℕ) : (realCliffordForm p q).Nondegenerate := by
-  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, QuadraticMap.radical_eq_ker_polarBilin,
-    LinearMap.ker_eq_bot']
+  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, realCliffordForm,
+    QuadraticForm.radical_weightedSumSquares, Submodule.eq_bot_iff]
   intro v hv
   funext j
-  have h := LinearMap.congr_fun hv (Pi.single j 1)
-  rw [QuadraticMap.polarBilin_apply_apply, polar_realCliffordForm] at h
-  simp only [Pi.single_apply, mul_ite, mul_one, mul_zero, Finset.sum_ite_eq',
-    Finset.mem_univ, if_true, LinearMap.zero_apply] at h
-  have h' : realCliffordWeight p q j * v j = 0 := by linarith
-  rcases mul_eq_zero.1 h' with h'' | h''
-  · exact absurd h'' (realCliffordWeight_ne_zero p q j)
-  · simpa using h''
+  exact Pi.mem_spanSubset_iff.1 hv j (realCliffordWeight_ne_zero p q j)
 
 /-- The real Clifford algebra of signature `(p, q)` has dimension `2 ^ (p + q)`, as every Clifford
 algebra of a space of that dimension does. This is the count that forces the surjections built
@@ -154,21 +146,25 @@ theorem finrank_cliffordAlgebra_realCliffordForm (p q : ℕ) :
 
 /-! ### The four base entries, in coordinates -/
 
+@[simp]
 theorem realCliffordForm_one_zero_apply (v : Fin (1 + 0) → ℝ) :
     realCliffordForm 1 0 v = v 0 * v 0 := by
   rw [realCliffordForm_apply]
   simp [realCliffordWeight]
 
+@[simp]
 theorem realCliffordForm_zero_one_apply (v : Fin (0 + 1) → ℝ) :
     realCliffordForm 0 1 v = -(v 0 * v 0) := by
   rw [realCliffordForm_apply]
   simp [realCliffordWeight]
 
+@[simp]
 theorem realCliffordForm_zero_two_apply (v : Fin (0 + 2) → ℝ) :
     realCliffordForm 0 2 v = -(v 0 * v 0) + -(v 1 * v 1) := by
   rw [realCliffordForm_apply, Fin.sum_univ_two]
   simp [realCliffordWeight]
 
+@[simp]
 theorem realCliffordForm_one_one_apply (v : Fin (1 + 1) → ℝ) :
     realCliffordForm 1 1 v = v 0 * v 0 - v 1 * v 1 := by
   rw [realCliffordForm_apply, Fin.sum_univ_two]
@@ -180,23 +176,26 @@ theorem realCliffordForm_one_one_apply (v : Fin (1 + 1) → ℝ) :
 /-- The algebra map `Cliff(1,0) → ℝ × ℝ` sending the generator `e` to `(1, -1)`. This is legitimate
 because `(1, -1)` squares to `1 = Q e`, and it is the pair of the two characters `e ↦ 1` and
 `e ↦ -1` of `ℝ[e]/(e² - 1)`. -/
-def realCliffordOneZeroToProd :
+private def realCliffordOneZeroToProd :
     CliffordAlgebra (realCliffordForm 1 0) →ₐ[ℝ] ℝ × ℝ :=
   CliffordAlgebra.lift _
     ⟨(LinearMap.proj 0).prod (-LinearMap.proj 0), fun v => by
       ext <;> simp [realCliffordForm_one_zero_apply]⟩
 
-@[simp]
-theorem realCliffordOneZeroToProd_ι (v : Fin (1 + 0) → ℝ) :
+/-- The value of `realCliffordOneZeroToProd` on a generator. -/
+private theorem realCliffordOneZeroToProd_ι (v : Fin (1 + 0) → ℝ) :
     realCliffordOneZeroToProd (CliffordAlgebra.ι _ v) = (v 0, -v 0) :=
   CliffordAlgebra.lift_ι_apply _ _ v
 
-theorem realCliffordOneZeroToProd_surjective :
+/-- `realCliffordOneZeroToProd` is surjective: the two characters of `ℝ[e]/(e² - 1)` separate
+`(1, 0)` and `(0, 1)`, so every pair is hit by an explicit combination of `1` and the generator.
+With the dimension count `finrank_cliffordAlgebra_realCliffordForm` this makes it bijective. -/
+private theorem realCliffordOneZeroToProd_surjective :
     Function.Surjective realCliffordOneZeroToProd := by
   rintro ⟨a, b⟩
   refine ⟨algebraMap ℝ _ ((a + b) / 2)
       + ((a - b) / 2) • CliffordAlgebra.ι (realCliffordForm 1 0) (Pi.single 0 1), ?_⟩
-  ext <;> simp <;> ring
+  ext <;> simp [realCliffordOneZeroToProd_ι] <;> ring
 
 /-- **`Cliff(1,0) ≅ ℝ × ℝ`**, the first base entry of the real periodicity table: a single
 generator squaring to `+1` splits the algebra. -/
@@ -219,7 +218,7 @@ theorem realCliffordOneZeroEquivProd_ι (v : Fin (1 + 0) → ℝ) :
 
 /-- The signature `(0,1)` form is Mathlib's `CliffordAlgebraComplex.Q`, `r ↦ -r²`, read on the
 one-dimensional space `Fin (0 + 1) → ℝ`. -/
-def realCliffordZeroOneIsometry :
+private def realCliffordZeroOneIsometry :
     (realCliffordForm 0 1).IsometryEquiv CliffordAlgebraComplex.Q :=
   ⟨(LinearEquiv.funUnique (Fin 1) ℝ ℝ : (Fin (0 + 1) → ℝ) ≃ₗ[ℝ] ℝ), fun v => by
     simp [realCliffordForm_zero_one_apply]⟩
@@ -231,20 +230,26 @@ noncomputable def realCliffordZeroOneEquivComplex :
   (CliffordAlgebra.equivOfIsometry realCliffordZeroOneIsometry).trans
     CliffordAlgebraComplex.equiv
 
+/-- `realCliffordZeroOneEquivComplex` unfolded into the two equivalences it composes. -/
+private theorem realCliffordZeroOneEquivComplex_eq (x : CliffordAlgebra (realCliffordForm 0 1)) :
+    realCliffordZeroOneEquivComplex x =
+      CliffordAlgebraComplex.equiv
+        (CliffordAlgebra.equivOfIsometry realCliffordZeroOneIsometry x) := rfl
+
 @[simp]
 theorem realCliffordZeroOneEquivComplex_ι (v : Fin (0 + 1) → ℝ) :
     realCliffordZeroOneEquivComplex (CliffordAlgebra.ι _ v) = v 0 • Complex.I := by
-  change CliffordAlgebraComplex.equiv
-      (CliffordAlgebra.equivOfIsometry realCliffordZeroOneIsometry (CliffordAlgebra.ι _ v)) = _
-  rw [CliffordAlgebra.equivOfIsometry_apply, CliffordAlgebra.map_apply_ι]
-  simp [realCliffordZeroOneIsometry]
+  rw [realCliffordZeroOneEquivComplex_eq, CliffordAlgebra.equivOfIsometry_apply,
+    CliffordAlgebra.map_apply_ι]
+  simp only [IsometryEquiv.toIsometry_apply, realCliffordZeroOneIsometry,
+    CliffordAlgebraComplex.equiv_apply, CliffordAlgebraComplex.toComplex_ι, Complex.real_smul]
   rfl
 
 /-! ### `Cliff(0,2) ≅ ℍ` -/
 
 /-- The signature `(0,2)` form is Mathlib's `CliffordAlgebraQuaternion.Q (-1) (-1)` read on
 `Fin (0 + 2) → ℝ` instead of on `ℝ × ℝ`. -/
-def realCliffordZeroTwoIsometry :
+private def realCliffordZeroTwoIsometry :
     (realCliffordForm 0 2).IsometryEquiv (CliffordAlgebraQuaternion.Q (-1 : ℝ) (-1)) :=
   ⟨(LinearEquiv.finTwoArrow ℝ ℝ : (Fin (0 + 2) → ℝ) ≃ₗ[ℝ] ℝ × ℝ), fun v => by
     simp [realCliffordForm_zero_two_apply]⟩
@@ -256,22 +261,31 @@ noncomputable def realCliffordZeroTwoEquivQuaternion :
   (CliffordAlgebra.equivOfIsometry realCliffordZeroTwoIsometry).trans
     CliffordAlgebraQuaternion.equiv
 
+/-- `realCliffordZeroTwoEquivQuaternion` unfolded into the two equivalences it composes. Stating
+this separately is what lets the generator lemma below be proved by rewriting: the codomain of
+`CliffordAlgebraQuaternion.equiv` is `ℍ[ℝ,-1,-1]` rather than the `ℍ[ℝ]` of the statement, so
+`rw [AlgEquiv.trans_apply]` cannot see the composite. -/
+private theorem realCliffordZeroTwoEquivQuaternion_eq
+    (x : CliffordAlgebra (realCliffordForm 0 2)) :
+    realCliffordZeroTwoEquivQuaternion x =
+      CliffordAlgebraQuaternion.equiv
+        (CliffordAlgebra.equivOfIsometry realCliffordZeroTwoIsometry x) := rfl
+
 @[simp]
 theorem realCliffordZeroTwoEquivQuaternion_ι (v : Fin (0 + 2) → ℝ) :
     realCliffordZeroTwoEquivQuaternion (CliffordAlgebra.ι _ v) = ⟨0, v 0, v 1, 0⟩ := by
-  change CliffordAlgebraQuaternion.equiv
-      (CliffordAlgebra.equivOfIsometry realCliffordZeroTwoIsometry (CliffordAlgebra.ι _ v)) = _
-  rw [CliffordAlgebra.equivOfIsometry_apply, CliffordAlgebra.map_apply_ι]
+  rw [realCliffordZeroTwoEquivQuaternion_eq, CliffordAlgebra.equivOfIsometry_apply,
+    CliffordAlgebra.map_apply_ι]
   simp only [IsometryEquiv.toIsometry_apply, CliffordAlgebraQuaternion.equiv_apply,
-    CliffordAlgebraQuaternion.toQuaternion_ι, QuaternionAlgebra.mk.injEq, and_true, true_and]
-  exact ⟨rfl, rfl⟩
+    CliffordAlgebraQuaternion.toQuaternion_ι]
+  rfl
 
 /-! ### `Cliff(1,1) ≅ M₂(ℝ)` -/
 
 /-- The algebra map `Cliff(1,1) → M₂(ℝ)` sending the `+1` generator to the diagonal involution
 `!![1, 0; 0, -1]` and the `-1` generator to the rotation `!![0, 1; -1, 0]`. The two matrices
 anticommute, so the map is well defined by the universal property. -/
-def realCliffordOneOneToMatrix :
+private def realCliffordOneOneToMatrix :
     CliffordAlgebra (realCliffordForm 1 1) →ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
   CliffordAlgebra.lift _
     ⟨(LinearMap.proj 0).smulRight !![1, 0; 0, -1] +
@@ -281,13 +295,17 @@ def realCliffordOneOneToMatrix :
         simp [realCliffordForm_one_one_apply, Matrix.mul_apply, Fin.sum_univ_two,
           Algebra.algebraMap_eq_smul_one] <;> ring⟩
 
-@[simp]
-theorem realCliffordOneOneToMatrix_ι (v : Fin (1 + 1) → ℝ) :
+/-- The value of `realCliffordOneOneToMatrix` on a generator. -/
+private theorem realCliffordOneOneToMatrix_ι (v : Fin (1 + 1) → ℝ) :
     realCliffordOneOneToMatrix (CliffordAlgebra.ι _ v) = !![v 0, v 1; -v 1, -v 0] := by
   rw [realCliffordOneOneToMatrix, CliffordAlgebra.lift_ι_apply]
   simp [Matrix.smul_of]
 
-theorem realCliffordOneOneToMatrix_surjective :
+/-- `realCliffordOneOneToMatrix` is surjective: the images of `1`, the two generators and their
+product are the four matrix units up to an invertible change of basis, so every matrix has an
+explicit preimage. With the dimension count `finrank_cliffordAlgebra_realCliffordForm` this makes
+it bijective. -/
+private theorem realCliffordOneOneToMatrix_surjective :
     Function.Surjective realCliffordOneOneToMatrix := by
   intro m
   refine ⟨algebraMap ℝ _ ((m 0 0 + m 1 1) / 2)
@@ -298,7 +316,7 @@ theorem realCliffordOneOneToMatrix_surjective :
           CliffordAlgebra.ι (realCliffordForm 1 1) (Pi.single 1 1)), ?_⟩
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [Algebra.algebraMap_eq_smul_one] <;> ring
+    simp [realCliffordOneOneToMatrix_ι, Algebra.algebraMap_eq_smul_one] <;> ring
 
 /-- **`Cliff(1,1) ≅ M₂(ℝ)`**, the fourth base entry of the real periodicity table and the seed of
 the periodicity step `Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)`. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -125,13 +125,6 @@ theorem realCliffordForm_apply (p q : ℕ) (v : Fin (p + q) → ℝ) :
     realCliffordForm p q v = ∑ i, realCliffordWeight p q i * (v i * v i) := by
   simp [realCliffordForm]
 
-@[simp]
-theorem polar_realCliffordForm (p q : ℕ) (v w : Fin (p + q) → ℝ) :
-    polar (realCliffordForm p q) v w = 2 * ∑ i, realCliffordWeight p q i * (v i * w i) := by
-  simp only [polar, realCliffordForm_apply, Pi.add_apply, Finset.mul_sum,
-    ← Finset.sum_sub_distrib]
-  exact Finset.sum_congr rfl fun i _ => by ring
-
 /-- The signature forms are nondegenerate: the radical of a weighted sum of squares is spanned by
 the coordinates with weight zero, and every signature weight is `±1`. -/
 theorem nondegenerate_realCliffordForm (p q : ℕ) : (realCliffordForm p q).Nondegenerate := by
@@ -235,6 +228,12 @@ private def realCliffordZeroOneIsometry :
   ⟨(LinearEquiv.funUnique (Fin 1) ℝ ℝ : (Fin (0 + 1) → ℝ) ≃ₗ[ℝ] ℝ), fun v => by
     simp [realCliffordForm_zero_one_apply]⟩
 
+/-- `realCliffordZeroOneIsometry` reads off the single coordinate. -/
+private theorem realCliffordZeroOneIsometry_apply (v : Fin (0 + 1) → ℝ) :
+    realCliffordZeroOneIsometry v = v 0 := by
+  simp [realCliffordZeroOneIsometry, ← IsometryEquiv.coe_toLinearEquiv,
+    LinearEquiv.funUnique_apply]
+
 /-- **`Cliff(0,1) ≅ ℂ`**, the second base entry of the real periodicity table: a single generator
 squaring to `-1` is a square root of `-1`. -/
 noncomputable def realCliffordZeroOneEquivComplex :
@@ -255,9 +254,8 @@ theorem realCliffordZeroOneEquivComplex_ι (v : Fin (0 + 1) → ℝ) :
     realCliffordZeroOneEquivComplex (CliffordAlgebra.ι _ v) = v 0 • Complex.I := by
   rw [realCliffordZeroOneEquivComplex_eq, CliffordAlgebra.equivOfIsometry_apply,
     CliffordAlgebra.map_apply_ι]
-  simp only [IsometryEquiv.toIsometry_apply, realCliffordZeroOneIsometry,
+  simp only [IsometryEquiv.toIsometry_apply, realCliffordZeroOneIsometry_apply,
     CliffordAlgebraComplex.equiv_apply, CliffordAlgebraComplex.toComplex_ι, Complex.real_smul]
-  rfl
 
 /-! ### `Cliff(0,2) ≅ ℍ` -/
 
@@ -267,6 +265,12 @@ private def realCliffordZeroTwoIsometry :
     (realCliffordForm 0 2).IsometryEquiv (CliffordAlgebraQuaternion.Q (-1 : ℝ) (-1)) :=
   ⟨(LinearEquiv.finTwoArrow ℝ ℝ : (Fin (0 + 2) → ℝ) ≃ₗ[ℝ] ℝ × ℝ), fun v => by
     simp [realCliffordForm_zero_two_apply]⟩
+
+/-- `realCliffordZeroTwoIsometry` reads off the two coordinates. -/
+private theorem realCliffordZeroTwoIsometry_apply (v : Fin (0 + 2) → ℝ) :
+    realCliffordZeroTwoIsometry v = (v 0, v 1) := by
+  simp [realCliffordZeroTwoIsometry, ← IsometryEquiv.coe_toLinearEquiv,
+    LinearEquiv.finTwoArrow_apply]
 
 /-- **`Cliff(0,2) ≅ ℍ`**, the third base entry of the real periodicity table: two anticommuting
 generators squaring to `-1` are the quaternion units `i` and `j`. -/
@@ -293,8 +297,11 @@ theorem realCliffordZeroTwoEquivQuaternion_ι (v : Fin (0 + 2) → ℝ) :
   rw [realCliffordZeroTwoEquivQuaternion_eq, CliffordAlgebra.equivOfIsometry_apply,
     CliffordAlgebra.map_apply_ι]
   simp only [IsometryEquiv.toIsometry_apply, CliffordAlgebraQuaternion.equiv_apply,
-    CliffordAlgebraQuaternion.toQuaternion_ι]
-  rfl
+    CliffordAlgebraQuaternion.toQuaternion_ι, realCliffordZeroTwoIsometry_apply]
+  -- Both sides are now the same quadruple; they differ only in the instance path of the two zero
+  -- components, `CliffordAlgebraQuaternion.toQuaternion` producing them in `ℍ[ℝ,-1,-1]` and the
+  -- statement reading them in `ℍ[ℝ]`, so the components match on the nose.
+  ext <;> rfl
 
 /-! ### `Cliff(1,1) ≅ M₂(ℝ)` -/
 


### PR DESCRIPTION
This PR builds the family of real quadratic forms that the real Clifford algebras `Cliff(p, q)` are indexed by, and pins the sign convention of the Bott periodicity table by identifying its four small entries. `TauCeti.realCliffordForm p q : QuadraticForm ℝ (Fin (p + q) → ℝ)` is the diagonal form with `+1` in the first `p` coordinates and `-1` in the last `q`, built as a `QuadraticMap.weightedSumSquares` against the sign vector `TauCeti.realCliffordWeight p q`. It is proved nondegenerate (`nondegenerate_realCliffordForm`, from Mathlib's `QuadraticForm.radical_weightedSumSquares`), and its Clifford algebra is computed to have dimension `2 ^ (p + q)` (`finrank_cliffordAlgebra_realCliffordForm`, from the existing `TauCeti.CliffordAlgebra.finrank_eq_two_pow`). On top of that the four base entries are constructed as bundled `AlgEquiv`s, each with a lemma computing it on a generator: `realCliffordOneZeroEquivProd : Cliff(1,0) ≃ₐ[ℝ] ℝ × ℝ`, `realCliffordZeroOneEquivComplex : Cliff(0,1) ≃ₐ[ℝ] ℂ`, `realCliffordZeroTwoEquivQuaternion : Cliff(0,2) ≃ₐ[ℝ] ℍ[ℝ]`, and `realCliffordOneOneEquivMatrix : Cliff(1,1) ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ`.

The target is `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`, Layer 7 ("Real Clifford algebras, Bott periodicity, and `Spin(p, q)`"), first bullet: "**The real forms `Cliff(p, q)`.** `realCliffordForm p q : QuadraticForm ℝ (Fin (p+q) → ℝ)`, the diagonal form with `p` entries `+1` and `q` entries `-1` … The sign convention is fixed by four base entries stated as **definitional acceptance tests** … `Cliff(1,0) ≅ ℝ × ℝ`, `Cliff(0,1) ≅ ℂ`, `Cliff(0,2) ≅ ℍ`, `Cliff(1,1) ≅ M₂(ℝ)`." The corresponding `Suggested.lean` entries are `realCliffordForm`, `cliff_zero_two_equiv_quaternion` and `cliff_one_one_equiv_matrix`; the signature of `realCliffordForm` matches it exactly, and the two `Nonempty (… ≃ₐ[ℝ] …)` statements are strengthened here to the equivalences themselves, since Bott periodicity (`cliff_bott`) needs the maps and not only their existence. Nothing in this PR touches `spinPQ` or the periodicity step; those remain open. Layer 7 is independent of the complex Layers 1–6, so this does not overlap the Clifford filtration, bivector or Pin/Spin work already merged, nor any open PR.

The two middle identifications are transported along an isometry from Mathlib's own small Clifford algebras, which are exactly these signature forms in disguise: `CliffordAlgebraComplex.equiv` (for `Q r = -(r * r)`, the `(0,1)` form on a one-dimensional space) and `CliffordAlgebraQuaternion.equiv` (for `Q (a, b) = -a² - b²`, the `(0,2)` form on `ℝ × ℝ`), both from `Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean`; no Mathlib code is vendored, only consumed. The two outer identifications are built here from the universal property `CliffordAlgebra.lift`, since Mathlib has no `Cliff` of a form with a `+1` generator: a single generator squaring to `+1` maps to `(1, -1) ∈ ℝ × ℝ`, and the hyperbolic pair of `Cliff(1,1)` maps to the anticommuting matrices `!![1, 0; 0, -1]` and `!![0, 1; -1, 0]`. In both cases the algebra map is shown surjective by exhibiting explicit preimages, and injectivity is then forced by the `2 ^ (p + q)` dimension count — the same mechanism the complex structure theorem of Layer 1 will use.

`lake build` is green and `lake exe axioms` reports all declarations within the `propext`, `Classical.choice`, `Quot.sound` allowlist. One file is added, `TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean` (321 lines); nothing existing is changed.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"realcliffordform"}-->

🤖 Prepared with Claude Code

