### PR TITLE
feat: identify exterior bivectors with quadratic elements

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -38,6 +38,9 @@ Layer 9 CAR worked instance.
   infinitesimal rotation determined by `QuadraticMap.polar`.
 * `TauCeti.CliffordAlgebra.cliffordBivectorExterior_apply_ιMulti`: the exterior-square map on a
   decomposable bivector.
+* `TauCeti.CliffordAlgebra.equivExterior_cliffordBivector` and
+  `TauCeti.CliffordAlgebra.cliffordBivectorExterior_injective`: the exterior model sends
+  bivectors to exterior products, so the exterior-square map is injective.
 * `TauCeti.CliffordAlgebra.cliffordBivector_mem_evenOdd_zero` and
   `TauCeti.CliffordAlgebra.cliffordBivector_mem_filtration_two`: it is even and has filtration
   degree at most two.
@@ -110,6 +113,42 @@ noncomputable def cliffordBivectorExterior : ⋀[R]^2 M →ₗ[R] CliffordAlgebr
 theorem cliffordBivectorExterior_apply_ιMulti (a b : M) :
     cliffordBivectorExterior Q (exteriorPower.ιMulti R 2 ![a, b]) = cliffordBivector Q a b := by
   simp [cliffordBivectorExterior]
+
+private theorem equivExterior_ι_mul_ι_sub_swap (a b : M) :
+    equivExterior Q (ι Q a * ι Q b - ι Q b * ι Q a) =
+      ExteriorAlgebra.ι R a * ExteriorAlgebra.ι R b -
+        ExteriorAlgebra.ι R b * ExteriorAlgebra.ι R a := by
+  simp only [equivExterior, map_sub, changeFormEquiv_apply, changeForm_ι_mul_ι]
+  rw [QuadraticMap.associated_isSymm R (-Q) a b]
+  module
+
+/-- The exterior model sends a half-normalized Clifford bivector to its exterior product. -/
+theorem equivExterior_cliffordBivector (a b : M) :
+    equivExterior Q (cliffordBivector Q a b) = ExteriorAlgebra.ι R a * ExteriorAlgebra.ι R b := by
+  rw [cliffordBivector_def, map_smul, equivExterior_ι_mul_ι_sub_swap]
+  rw [eq_neg_of_add_eq_zero_right (ExteriorAlgebra.ι_add_mul_swap a b),
+    sub_neg_eq_add, ← two_smul R, invOf_smul_smul]
+
+private theorem equivExterior_comp_cliffordBivectorExterior :
+    (equivExterior Q).toLinearMap.comp (cliffordBivectorExterior Q) = (⋀[R]^2 M).subtype := by
+  apply exteriorPower.linearMap_ext
+  apply AlternatingMap.ext
+  intro x
+  have hx : x = ![x 0, x 1] := by
+    funext i
+    fin_cases i <;> rfl
+  rw [LinearMap.compAlternatingMap_apply, LinearMap.comp_apply,
+    LinearMap.compAlternatingMap_apply, LinearEquiv.coe_coe]
+  rw [hx, cliffordBivectorExterior_apply_ιMulti, equivExterior_cliffordBivector]
+  simp
+
+/-- The exterior-square Clifford bivector map is injective. -/
+theorem cliffordBivectorExterior_injective : Function.Injective (cliffordBivectorExterior Q) := by
+  apply Function.Injective.of_comp (f := equivExterior Q)
+  -- `of_comp` exposes function composition, while the named equation uses `LinearMap.comp`.
+  change Function.Injective ((equivExterior Q).toLinearMap.comp (cliffordBivectorExterior Q))
+  simpa only [equivExterior_comp_cliffordBivectorExterior] using
+    Submodule.subtype_injective (⋀[R]^2 M)
 
 /-- Interchanging the two vectors negates their Clifford bivector. -/
 theorem cliffordBivector_swap (a b : M) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -38,7 +38,8 @@ Layer 9 CAR worked instance.
   infinitesimal rotation determined by `QuadraticMap.polar`.
 * `TauCeti.CliffordAlgebra.cliffordBivectorExterior_apply_ιMulti`: the exterior-square map on a
   decomposable bivector.
-* `TauCeti.CliffordAlgebra.equivExterior_cliffordBivector` and
+* `TauCeti.CliffordAlgebra.equivExterior_cliffordBivector`,
+  `TauCeti.CliffordAlgebra.equivExterior_cliffordBivectorExterior`, and
   `TauCeti.CliffordAlgebra.cliffordBivectorExterior_injective`: the exterior model sends
   bivectors to exterior products, so the exterior-square map is injective.
 * `TauCeti.CliffordAlgebra.cliffordBivector_mem_evenOdd_zero` and
@@ -141,6 +142,14 @@ private theorem equivExterior_comp_cliffordBivectorExterior :
     LinearMap.compAlternatingMap_apply, LinearEquiv.coe_coe]
   rw [hx, cliffordBivectorExterior_apply_ιMulti, equivExterior_cliffordBivector]
   simp
+
+/-- The exterior model is a left inverse of the exterior-square Clifford bivector map.
+
+As with `equivExterior_basis`, this is not a simp lemma because simp unfolds `equivExterior`
+before rewriting its applications. -/
+theorem equivExterior_cliffordBivectorExterior (x : ⋀[R]^2 M) :
+    equivExterior Q (cliffordBivectorExterior Q x) = (x : ExteriorAlgebra R M) :=
+  LinearMap.congr_fun (equivExterior_comp_cliffordBivectorExterior Q) x
 
 /-- The exterior-square Clifford bivector map is injective. -/
 theorem cliffordBivectorExterior_injective : Function.Injective (cliffordBivectorExterior Q) := by

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.QuadraticLieSubalgebra
+
+/-!
+# Clifford bivectors and the exterior square
+
+The half-normalized Clifford bivector map embeds the second exterior power faithfully in the
+Clifford algebra. Its image is the canonical Lie subalgebra of quadratic elements, so the exterior
+square is linearly equivalent to that subalgebra.
+
+This is a generic prerequisite for transporting the Clifford commutator to the exterior square in
+the spin representations roadmap. It does not define the transported bracket or identify it with
+an orthogonal Lie algebra.
+
+## Main results
+
+* `TauCeti.CliffordAlgebra.equivExterior_cliffordBivector`: the exterior model sends a Clifford
+  bivector to the corresponding exterior product.
+* `TauCeti.CliffordAlgebra.cliffordBivectorExterior_injective`: the exterior-square Clifford
+  bivector map is injective.
+* `TauCeti.CliffordAlgebra.cliffordBivectorExteriorEquivQuadraticLieSubalgebra`: the exterior
+  square is linearly equivalent to the quadratic Lie subalgebra.
+
+## References
+
+* [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
+  Layer 3, "the Lie algebra `𝔰𝔬(V) ≅ ⋀²V` inside the Clifford algebra".
+-/
+
+public section
+
+open CliffordAlgebra
+
+universe u v
+
+namespace TauCeti
+
+namespace CliffordAlgebra
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+private theorem equivExterior_ι_mul_ι_sub_swap (Q : QuadraticForm R M)
+    [Invertible (2 : R)] (a b : M) :
+    equivExterior Q (ι Q a * ι Q b - ι Q b * ι Q a) =
+      ExteriorAlgebra.ι R a * ExteriorAlgebra.ι R b -
+        ExteriorAlgebra.ι R b * ExteriorAlgebra.ι R a := by
+  simp only [equivExterior, map_sub, changeFormEquiv_apply, changeForm_ι_mul_ι]
+  rw [QuadraticMap.associated_isSymm R (-Q) a b]
+  module
+
+/-- The exterior model sends a half-normalized Clifford bivector to its exterior product. -/
+theorem equivExterior_cliffordBivector (Q : QuadraticForm R M) [Invertible (2 : R)]
+    (a b : M) :
+    equivExterior Q (cliffordBivector Q a b) = ExteriorAlgebra.ι R a * ExteriorAlgebra.ι R b := by
+  rw [cliffordBivector_def, map_smul, equivExterior_ι_mul_ι_sub_swap]
+  rw [eq_neg_of_add_eq_zero_right (ExteriorAlgebra.ι_add_mul_swap a b),
+    sub_neg_eq_add, ← two_smul R, invOf_smul_smul]
+
+private theorem equivExterior_comp_cliffordBivectorExterior (Q : QuadraticForm R M)
+    [Invertible (2 : R)] :
+    (equivExterior Q).toLinearMap.comp (cliffordBivectorExterior Q) = (⋀[R]^2 M).subtype := by
+  apply exteriorPower.linearMap_ext
+  apply AlternatingMap.ext
+  intro x
+  have hx : x = ![x 0, x 1] := by
+    funext i
+    fin_cases i <;> rfl
+  rw [LinearMap.compAlternatingMap_apply, LinearMap.comp_apply,
+    LinearMap.compAlternatingMap_apply, LinearEquiv.coe_coe]
+  rw [hx, cliffordBivectorExterior_apply_ιMulti, equivExterior_cliffordBivector]
+  simp
+
+/-- The exterior-square Clifford bivector map is injective. -/
+theorem cliffordBivectorExterior_injective (Q : QuadraticForm R M) [Invertible (2 : R)] :
+    Function.Injective (cliffordBivectorExterior Q) := by
+  apply Function.Injective.of_comp (f := equivExterior Q)
+  -- `of_comp` exposes function composition, while the named equation uses `LinearMap.comp`.
+  change Function.Injective ((equivExterior Q).toLinearMap.comp (cliffordBivectorExterior Q))
+  simpa only [equivExterior_comp_cliffordBivectorExterior] using
+    Submodule.subtype_injective (⋀[R]^2 M)
+
+/-- The second exterior power is linearly equivalent to the quadratic elements of the Clifford
+algebra through the half-normalized Clifford bivector map. -/
+noncomputable def cliffordBivectorExteriorEquivQuadraticLieSubalgebra
+    (Q : QuadraticForm R M) [Invertible (2 : R)] :
+    ⋀[R]^2 M ≃ₗ[R] ↥(quadraticLieSubalgebra Q) :=
+  (LinearEquiv.ofInjective (cliffordBivectorExterior Q)
+      (cliffordBivectorExterior_injective Q)).trans
+    (LinearEquiv.ofEq _ _ (quadraticLieSubalgebra_toSubmodule_eq_range Q).symm)
+
+/-- The quadratic element underlying the exterior-square equivalence is the Clifford bivector
+map. -/
+@[simp]
+theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply
+    (Q : QuadraticForm R M) [Invertible (2 : R)] (x : ⋀[R]^2 M) :
+    ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q x : quadraticLieSubalgebra Q) :
+      CliffordAlgebra Q) = cliffordBivectorExterior Q x := by
+  rw [cliffordBivectorExteriorEquivQuadraticLieSubalgebra, LinearEquiv.trans_apply,
+    LinearEquiv.coe_ofEq_apply, LinearEquiv.ofInjective_apply]
+
+/-- Applying the Clifford bivector map to the inverse exterior-square equivalence recovers the
+quadratic element. -/
+@[simp]
+theorem cliffordBivectorExteriorEquivQuadraticLieSubalgebra_symm_apply
+    (Q : QuadraticForm R M) [Invertible (2 : R)] (x : quadraticLieSubalgebra Q) :
+    cliffordBivectorExterior Q
+      ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).symm x) = x := by
+  rw [← coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply]
+  exact congr_arg Subtype.val
+    ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).apply_symm_apply x)
+
+end CliffordAlgebra
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
@@ -60,7 +60,6 @@ theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply
 
 /-- Coercing the forward-after-inverse exterior-square equivalence recovers the quadratic
 element. -/
-@[simp]
 theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply_symm_apply
     (Q : QuadraticForm R M) [Invertible (2 : R)] (x : quadraticLieSubalgebra Q) :
     ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
@@ -7,11 +7,10 @@ module
 public import TauCeti.LinearAlgebra.CliffordAlgebra.QuadraticLieSubalgebra
 
 /-!
-# Clifford bivectors and the exterior square
+# The exterior-square model of quadratic Clifford elements
 
-The half-normalized Clifford bivector map embeds the second exterior power faithfully in the
-Clifford algebra. Its image is the canonical Lie subalgebra of quadratic elements, so the exterior
-square is linearly equivalent to that subalgebra.
+The half-normalized Clifford bivector map identifies the second exterior power with the canonical
+Lie subalgebra of quadratic elements in the Clifford algebra.
 
 This is a generic prerequisite for transporting the Clifford commutator to the exterior square in
 the spin representations roadmap. It does not define the transported bracket or identify it with
@@ -19,10 +18,6 @@ an orthogonal Lie algebra.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.equivExterior_cliffordBivector`: the exterior model sends a Clifford
-  bivector to the corresponding exterior product.
-* `TauCeti.CliffordAlgebra.cliffordBivectorExterior_injective`: the exterior-square Clifford
-  bivector map is injective.
 * `TauCeti.CliffordAlgebra.cliffordBivectorExteriorEquivQuadraticLieSubalgebra`: the exterior
   square is linearly equivalent to the quadratic Lie subalgebra.
 
@@ -44,46 +39,6 @@ namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 
-private theorem equivExterior_ι_mul_ι_sub_swap (Q : QuadraticForm R M)
-    [Invertible (2 : R)] (a b : M) :
-    equivExterior Q (ι Q a * ι Q b - ι Q b * ι Q a) =
-      ExteriorAlgebra.ι R a * ExteriorAlgebra.ι R b -
-        ExteriorAlgebra.ι R b * ExteriorAlgebra.ι R a := by
-  simp only [equivExterior, map_sub, changeFormEquiv_apply, changeForm_ι_mul_ι]
-  rw [QuadraticMap.associated_isSymm R (-Q) a b]
-  module
-
-/-- The exterior model sends a half-normalized Clifford bivector to its exterior product. -/
-theorem equivExterior_cliffordBivector (Q : QuadraticForm R M) [Invertible (2 : R)]
-    (a b : M) :
-    equivExterior Q (cliffordBivector Q a b) = ExteriorAlgebra.ι R a * ExteriorAlgebra.ι R b := by
-  rw [cliffordBivector_def, map_smul, equivExterior_ι_mul_ι_sub_swap]
-  rw [eq_neg_of_add_eq_zero_right (ExteriorAlgebra.ι_add_mul_swap a b),
-    sub_neg_eq_add, ← two_smul R, invOf_smul_smul]
-
-private theorem equivExterior_comp_cliffordBivectorExterior (Q : QuadraticForm R M)
-    [Invertible (2 : R)] :
-    (equivExterior Q).toLinearMap.comp (cliffordBivectorExterior Q) = (⋀[R]^2 M).subtype := by
-  apply exteriorPower.linearMap_ext
-  apply AlternatingMap.ext
-  intro x
-  have hx : x = ![x 0, x 1] := by
-    funext i
-    fin_cases i <;> rfl
-  rw [LinearMap.compAlternatingMap_apply, LinearMap.comp_apply,
-    LinearMap.compAlternatingMap_apply, LinearEquiv.coe_coe]
-  rw [hx, cliffordBivectorExterior_apply_ιMulti, equivExterior_cliffordBivector]
-  simp
-
-/-- The exterior-square Clifford bivector map is injective. -/
-theorem cliffordBivectorExterior_injective (Q : QuadraticForm R M) [Invertible (2 : R)] :
-    Function.Injective (cliffordBivectorExterior Q) := by
-  apply Function.Injective.of_comp (f := equivExterior Q)
-  -- `of_comp` exposes function composition, while the named equation uses `LinearMap.comp`.
-  change Function.Injective ((equivExterior Q).toLinearMap.comp (cliffordBivectorExterior Q))
-  simpa only [equivExterior_comp_cliffordBivectorExterior] using
-    Submodule.subtype_injective (⋀[R]^2 M)
-
 /-- The second exterior power is linearly equivalent to the quadratic elements of the Clifford
 algebra through the half-normalized Clifford bivector map. -/
 noncomputable def cliffordBivectorExteriorEquivQuadraticLieSubalgebra
@@ -103,15 +58,15 @@ theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply
   rw [cliffordBivectorExteriorEquivQuadraticLieSubalgebra, LinearEquiv.trans_apply,
     LinearEquiv.coe_ofEq_apply, LinearEquiv.ofInjective_apply]
 
-/-- Applying the Clifford bivector map to the inverse exterior-square equivalence recovers the
-quadratic element. -/
+/-- Coercing the forward-after-inverse exterior-square equivalence recovers the quadratic
+element. -/
 @[simp]
-theorem cliffordBivectorExteriorEquivQuadraticLieSubalgebra_symm_apply
+theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply_symm_apply
     (Q : QuadraticForm R M) [Invertible (2 : R)] (x : quadraticLieSubalgebra Q) :
-    cliffordBivectorExterior Q
-      ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).symm x) = x := by
-  rw [← coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply]
-  exact congr_arg Subtype.val
+    ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q
+      ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).symm x) : quadraticLieSubalgebra Q) :
+      CliffordAlgebra Q) = x :=
+  congr_arg Subtype.val
     ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).apply_symm_apply x)
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
@@ -58,15 +58,15 @@ theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply
   rw [cliffordBivectorExteriorEquivQuadraticLieSubalgebra, LinearEquiv.trans_apply,
     LinearEquiv.coe_ofEq_apply, LinearEquiv.ofInjective_apply]
 
-/-- Coercing the forward-after-inverse exterior-square equivalence recovers the quadratic
-element. -/
-theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply_symm_apply
+/-- The exterior-algebra element underlying the inverse equivalence is the exterior model of the
+quadratic Clifford element. -/
+theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_symm_apply
     (Q : QuadraticForm R M) [Invertible (2 : R)] (x : quadraticLieSubalgebra Q) :
-    ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q
-      ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).symm x) : quadraticLieSubalgebra Q) :
-      CliffordAlgebra Q) = x :=
-  congr_arg Subtype.val
-    ((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).apply_symm_apply x)
+    (((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).symm x : ⋀[R]^2 M) :
+      ExteriorAlgebra R M) = equivExterior Q x := by
+  rw [← equivExterior_cliffordBivectorExterior Q,
+    ← coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply,
+    LinearEquiv.apply_symm_apply]
 
 end CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
@@ -60,6 +60,7 @@ theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply
 
 /-- The exterior-algebra element underlying the inverse equivalence is the exterior model of the
 quadratic Clifford element. -/
+@[simp]
 theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_symm_apply
     (Q : QuadraticForm R M) [Invertible (2 : R)] (x : quadraticLieSubalgebra Q) :
     (((cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).symm x : ⋀[R]^2 M) :


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Identifies the second exterior power with the canonical Lie subalgebra of quadratic Clifford elements.

- Proves the decomposable and arbitrary exterior-model equations and injectivity of `cliffordBivectorExterior`.
- Packages the linear equivalence with named forward and inverse equations.

## Roadmap target

Advances Layer 3's "Bivectors as a Lie subalgebra" target:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#L366-L371

This is the faithful exterior-square model needed to transport the Clifford commutator to `⋀² M`.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/README.md#bivectors-as-a-lie-subalgebra"}-->

## Verification

`lake build --iofail`, the axiom and module-system audits, environment lint, whitespace, downstream rewrite and simplification probes, proof golf, and an independent exact-head review pass at `e83ca65e0f4e0256bc392480eeeb476406286a59`.

## Scale and generality

Changes two files by +122 lines, generic over a commutative ring, module, and quadratic form with invertible `2`. It needs no basis, finiteness, field, or nondegeneracy assumption. Golf keeps the equivalence opaque behind named equations.

## Scope

- **Consumes:** the exterior-model Clifford bivector map and the canonical quadratic Lie subalgebra.
- **Provides:** a linear equivalence from the second exterior power to quadratic Clifford elements, with forward and inverse equations.
- **Fits:** supplies the faithful model consumed by transported exterior-bivector Lie structure.
- **Boundary:** Lie transport and orthogonal comparison build on this equivalence in later slices.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [b8161ef](https://github.com/TauCetiProject/TauCetiReview/commit/b8161ef29f1bf922d3f9aea2b1b1e298bcd06078) · local skill review @ [d3c1151](https://github.com/utensil/formal-land/commit/d3c1151fe4fd4a1ff08035f37517998a1f585ce6) fixed: proof-quality (1)</sub>