### PR TITLE
feat(AdicSpace): the trivial-valuation section of the support map

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
@@ -360,7 +360,8 @@ theorem suppFun_comap {B : Type*} [CommRing B] (φ : A →+* B) (v : Spv B) :
 /-- The trivial-valuation section of the support map (Wedhorn, Remark 4.6): the point of
 `Spv A` given by the trivial valuation attached to a prime ideal. -/
 noncomputable def trivialSection (p : PrimeSpectrum A) : Spv A :=
-  ofValuation (Valuation.trivialValuation p.asIdeal)
+  ofValuation
+    (Valuation.trivialValuation p.asIdeal : Valuation A (WithZero (Multiplicative ℤ)))
 
 /-- The valuative relation of a trivial-valuation point: `v(f) ≤ v(s)` holds precisely
 when `f` lies in the prime or `s` does not. -/

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
@@ -30,11 +30,14 @@ We define the valuation spectrum `Spv A` following Wedhorn, *Adic Spaces*
 * `TauCeti.ValuationSpectrum.localizationComapSection S B v hS` : Lift `v` to a localization
   `Spv B`.
 * `TauCeti.ValuationSpectrum.suppFun` : The continuous support map `Spv A → Spec A`.
+* `TauCeti.ValuationSpectrum.trivialSection` : The continuous section of `suppFun` given by
+  the trivial valuation attached to a prime ideal; in particular `suppFun` is surjective
+  (`suppFun_surjective`).
 
 ## References
 
 * T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 4.1, Remark 4.3, Remark 4.4,
-  Proposition 4.7(2)
+  Remark 4.6, Proposition 4.7(2)
 
 Ported from the open Mathlib pull request
 [leanprover-community/mathlib4#38009](https://github.com/leanprover-community/mathlib4/pull/38009)
@@ -350,6 +353,86 @@ theorem continuous_suppFun : Continuous (suppFun : Spv A → PrimeSpectrum A) :=
 theorem suppFun_comap {B : Type*} [CommRing B] (φ : A →+* B) (v : Spv B) :
     suppFun (comap φ v) = PrimeSpectrum.comap φ (suppFun v) := by
   ext; simp [mem_supp_iff, comap_vle]
+
+/-! ### The trivial-valuation section of the support map -/
+
+open scoped Classical in
+/-- The trivial valuation attached to a prime ideal `𝔭`: it is `0` on `𝔭` and `1` off it. -/
+noncomputable def trivialValuation (𝔭 : Ideal A) [hp : 𝔭.IsPrime] :
+    Valuation A (WithZero (Multiplicative ℤ)) where
+  toFun a := if a ∈ 𝔭 then 0 else 1
+  map_zero' := if_pos 𝔭.zero_mem
+  map_one' := if_neg (𝔭.ne_top_iff_one.mp hp.ne_top)
+  map_mul' a b := by
+    by_cases ha : a ∈ 𝔭
+    · simp [Ideal.mul_mem_right b 𝔭 ha, ha]
+    · by_cases hb : b ∈ 𝔭
+      · simp [Ideal.mul_mem_left 𝔭 a hb, hb]
+      · have hab : a * b ∉ 𝔭 := fun h ↦ (hp.mem_or_mem h).elim ha hb
+        simp [hab, ha, hb]
+  map_add_le_max' a b := by
+    by_cases hab : a + b ∈ 𝔭
+    · simp [hab]
+    · have : a ∉ 𝔭 ∨ b ∉ 𝔭 := by
+        by_contra h
+        rw [not_or, not_not, not_not] at h
+        exact hab (𝔭.add_mem h.1 h.2)
+      rcases this with ha | hb
+      · simp [hab, ha]
+      · simp [hab, hb]
+
+open scoped Classical in
+/-- The value of the trivial valuation, as an `if`. -/
+lemma trivialValuation_apply {𝔭 : Ideal A} [𝔭.IsPrime] (a : A) :
+    trivialValuation 𝔭 a = if a ∈ 𝔭 then 0 else 1 := (rfl)
+
+@[simp]
+lemma trivialValuation_eq_zero_iff {𝔭 : Ideal A} [𝔭.IsPrime] {a : A} :
+    trivialValuation 𝔭 a = 0 ↔ a ∈ 𝔭 := by
+  rw [trivialValuation_apply]
+  split <;> simp_all
+
+lemma trivialValuation_eq_one_of_notMem {𝔭 : Ideal A} [𝔭.IsPrime] {a : A} (ha : a ∉ 𝔭) :
+    trivialValuation 𝔭 a = 1 := by
+  rw [trivialValuation_apply, if_neg ha]
+
+/-- The trivial-valuation section of the support map (Wedhorn, Remark 4.6): the point of
+`Spv A` given by the trivial valuation attached to a prime ideal. -/
+noncomputable def trivialSection (p : PrimeSpectrum A) : Spv A :=
+  ofValuation (trivialValuation p.asIdeal)
+
+/-- `trivialSection` is a section of the support map. -/
+@[simp]
+lemma suppFun_trivialSection (p : PrimeSpectrum A) : suppFun (trivialSection p) = p := by
+  ext x
+  rw [suppFun_asIdeal, trivialSection, supp_ofValuation, Valuation.mem_supp_iff,
+    trivialValuation_eq_zero_iff]
+
+/-- The preimage of a basic open under `trivialSection` is the corresponding basic open of
+the prime spectrum: `trivialSection ⁻¹' Spv(A)(f/s) = D(s)`. -/
+lemma trivialSection_preimage_basicOpen (f s : A) :
+    trivialSection ⁻¹' basicOpen f s = (PrimeSpectrum.basicOpen s : Set (PrimeSpectrum A)) := by
+  ext p
+  simp only [Set.mem_preimage, mem_basicOpen_iff, trivialSection, vle_ofValuation, map_zero,
+    SetLike.mem_coe, PrimeSpectrum.mem_basicOpen]
+  constructor
+  · rintro ⟨-, hs0⟩ hs
+    exact hs0 (le_of_eq (trivialValuation_eq_zero_iff.mpr hs))
+  · intro hs
+    rw [trivialValuation_eq_one_of_notMem hs]
+    refine ⟨?_, by simp⟩
+    rw [trivialValuation_apply]
+    split <;> simp
+
+/-- `trivialSection` is continuous. -/
+lemma continuous_trivialSection :
+    Continuous (trivialSection : PrimeSpectrum A → Spv A) :=
+  continuous_generateFrom_iff.mpr fun _ ⟨f, s, hU⟩ ↦
+    hU ▸ trivialSection_preimage_basicOpen f s ▸ (PrimeSpectrum.basicOpen s).isOpen
+
+/-- The support map is surjective; the trivial valuations provide a section. -/
+theorem suppFun_surjective : Function.Surjective (suppFun : Spv A → PrimeSpectrum A) :=
+  fun p ↦ ⟨trivialSection p, suppFun_trivialSection p⟩
 
 end PrimeSpectrum
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.RingTheory.Valuation.ValuativeRel.Comap
+public import TauCeti.RingTheory.Valuation.Trivial
 public import Mathlib.RingTheory.Valuation.Quotient
 public import Mathlib.RingTheory.Valuation.ExtendToLocalization
 public import Mathlib.Topology.Order
@@ -356,73 +357,46 @@ theorem suppFun_comap {B : Type*} [CommRing B] (φ : A →+* B) (v : Spv B) :
 
 /-! ### The trivial-valuation section of the support map -/
 
-open scoped Classical in
-/-- The trivial valuation attached to a prime ideal `𝔭`: it is `0` on `𝔭` and `1` off it. -/
-noncomputable def trivialValuation (𝔭 : Ideal A) [hp : 𝔭.IsPrime] :
-    Valuation A (WithZero (Multiplicative ℤ)) where
-  toFun a := if a ∈ 𝔭 then 0 else 1
-  map_zero' := if_pos 𝔭.zero_mem
-  map_one' := if_neg (𝔭.ne_top_iff_one.mp hp.ne_top)
-  map_mul' a b := by
-    by_cases ha : a ∈ 𝔭
-    · simp [Ideal.mul_mem_right b 𝔭 ha, ha]
-    · by_cases hb : b ∈ 𝔭
-      · simp [Ideal.mul_mem_left 𝔭 a hb, hb]
-      · have hab : a * b ∉ 𝔭 := fun h ↦ (hp.mem_or_mem h).elim ha hb
-        simp [hab, ha, hb]
-  map_add_le_max' a b := by
-    by_cases hab : a + b ∈ 𝔭
-    · simp [hab]
-    · have : a ∉ 𝔭 ∨ b ∉ 𝔭 := by
-        by_contra h
-        rw [not_or, not_not, not_not] at h
-        exact hab (𝔭.add_mem h.1 h.2)
-      rcases this with ha | hb
-      · simp [hab, ha]
-      · simp [hab, hb]
-
-open scoped Classical in
-/-- The value of the trivial valuation, as an `if`. -/
-lemma trivialValuation_apply {𝔭 : Ideal A} [𝔭.IsPrime] (a : A) :
-    trivialValuation 𝔭 a = if a ∈ 𝔭 then 0 else 1 := (rfl)
-
-@[simp]
-lemma trivialValuation_eq_zero_iff {𝔭 : Ideal A} [𝔭.IsPrime] {a : A} :
-    trivialValuation 𝔭 a = 0 ↔ a ∈ 𝔭 := by
-  rw [trivialValuation_apply]
-  split <;> simp_all
-
-lemma trivialValuation_eq_one_of_notMem {𝔭 : Ideal A} [𝔭.IsPrime] {a : A} (ha : a ∉ 𝔭) :
-    trivialValuation 𝔭 a = 1 := by
-  rw [trivialValuation_apply, if_neg ha]
-
 /-- The trivial-valuation section of the support map (Wedhorn, Remark 4.6): the point of
 `Spv A` given by the trivial valuation attached to a prime ideal. -/
 noncomputable def trivialSection (p : PrimeSpectrum A) : Spv A :=
-  ofValuation (trivialValuation p.asIdeal)
+  ofValuation (Valuation.trivialValuation p.asIdeal)
+
+/-- The valuative relation of a trivial-valuation point: `v(f) ≤ v(s)` holds precisely
+when `f` lies in the prime or `s` does not. -/
+@[simp]
+lemma trivialSection_vle_iff (p : PrimeSpectrum A) (f s : A) :
+    (trivialSection p).toValuativeRel.vle f s ↔ f ∈ p.asIdeal ∨ s ∉ p.asIdeal := by
+  rw [trivialSection, vle_ofValuation, Valuation.trivialValuation_apply,
+    Valuation.trivialValuation_apply]
+  constructor
+  · intro h
+    by_cases hf : f ∈ p.asIdeal
+    · exact Or.inl hf
+    · refine Or.inr fun hs ↦ ?_
+      rw [if_neg hf, if_pos hs] at h
+      simp at h
+  · rintro (hf | hs)
+    · simp [hf]
+    · rw [if_neg hs]
+      split <;> simp
 
 /-- `trivialSection` is a section of the support map. -/
 @[simp]
 lemma suppFun_trivialSection (p : PrimeSpectrum A) : suppFun (trivialSection p) = p := by
   ext x
   rw [suppFun_asIdeal, trivialSection, supp_ofValuation, Valuation.mem_supp_iff,
-    trivialValuation_eq_zero_iff]
+    Valuation.trivialValuation_eq_zero_iff]
 
 /-- The preimage of a basic open under `trivialSection` is the corresponding basic open of
 the prime spectrum: `trivialSection ⁻¹' Spv(A)(f/s) = D(s)`. -/
 lemma trivialSection_preimage_basicOpen (f s : A) :
     trivialSection ⁻¹' basicOpen f s = (PrimeSpectrum.basicOpen s : Set (PrimeSpectrum A)) := by
   ext p
-  simp only [Set.mem_preimage, mem_basicOpen_iff, trivialSection, vle_ofValuation, map_zero,
-    SetLike.mem_coe, PrimeSpectrum.mem_basicOpen]
-  constructor
-  · rintro ⟨-, hs0⟩ hs
-    exact hs0 (le_of_eq (trivialValuation_eq_zero_iff.mpr hs))
-  · intro hs
-    rw [trivialValuation_eq_one_of_notMem hs]
-    refine ⟨?_, by simp⟩
-    rw [trivialValuation_apply]
-    split <;> simp
+  have h0 : (0 : A) ∈ p.asIdeal := p.asIdeal.zero_mem
+  simp only [Set.mem_preimage, mem_basicOpen_iff, trivialSection_vle_iff, SetLike.mem_coe,
+    PrimeSpectrum.mem_basicOpen, h0, not_true_eq_false, or_false]
+  tauto
 
 /-- `trivialSection` is continuous. -/
 lemma continuous_trivialSection :

--- a/TauCeti/RingTheory/Valuation/Trivial.lean
+++ b/TauCeti/RingTheory/Valuation/Trivial.lean
@@ -6,7 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.RingTheory.Valuation.Basic
-public import Mathlib.RingTheory.Ideal.Quotient.Operations
+public import Mathlib.RingTheory.Ideal.Quotient.Basic
 
 /-!
 # The trivial valuation attached to a prime ideal
@@ -19,7 +19,8 @@ the support map of the valuation spectrum.
 ## Main definitions
 
 * `TauCeti.Valuation.trivialValuation 𝔭` : The trivial valuation attached to a prime
-  ideal `𝔭`, with values in `WithZero (Multiplicative ℤ)`.
+  ideal `𝔭`, with values in any linearly ordered commutative monoid with zero `Γ₀`
+  (the valuation-spectrum section specializes it to `WithZero (Multiplicative ℤ)`).
 
 ## Main results
 
@@ -68,8 +69,8 @@ lemma trivialValuation_eq_one_iff [Nontrivial Γ₀] {𝔭 : Ideal A} [𝔭.IsPr
   split <;> simp_all
 
 /-- Elements outside the prime ideal have value `1` under the trivial valuation. -/
-lemma trivialValuation_eq_one_of_notMem [Nontrivial Γ₀] {𝔭 : Ideal A} [𝔭.IsPrime] {a : A}
-    (ha : a ∉ 𝔭) : trivialValuation (Γ₀ := Γ₀) 𝔭 a = 1 :=
-  trivialValuation_eq_one_iff.mpr ha
+lemma trivialValuation_eq_one_of_notMem {𝔭 : Ideal A} [𝔭.IsPrime] {a : A}
+    (ha : a ∉ 𝔭) : trivialValuation (Γ₀ := Γ₀) 𝔭 a = 1 := by
+  simp [trivialValuation_apply, ha]
 
 end TauCeti.Valuation

--- a/TauCeti/RingTheory/Valuation/Trivial.lean
+++ b/TauCeti/RingTheory/Valuation/Trivial.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.RingTheory.Valuation.Basic
+public import Mathlib.RingTheory.Ideal.Quotient.Operations
+
+/-!
+# The trivial valuation attached to a prime ideal
+
+The trivial valuation of a prime ideal `𝔭` of a commutative ring: it is `0` on `𝔭` and `1`
+off it. It is the pullback of Mathlib's trivial valuation `1` on the quotient domain `A ⧸ 𝔭`
+along the quotient map.
+
+## Main definitions
+
+* `TauCeti.Valuation.trivialValuation 𝔭` : The trivial valuation attached to a prime
+  ideal `𝔭`, with values in `WithZero (Multiplicative ℤ)`.
+
+## Main results
+
+* `TauCeti.Valuation.trivialValuation_eq_zero_iff` : The trivial valuation vanishes exactly
+  on `𝔭`.
+-/
+
+public section
+
+namespace TauCeti.Valuation
+
+variable {A : Type*} [CommRing A]
+
+open scoped Classical in
+/-- The trivial valuation attached to a prime ideal `𝔭`: it is `0` on `𝔭` and `1` off it,
+as the pullback of the trivial valuation on the quotient domain `A ⧸ 𝔭` along the quotient
+map. -/
+noncomputable def trivialValuation (𝔭 : Ideal A) [𝔭.IsPrime] :
+    Valuation A (WithZero (Multiplicative ℤ)) :=
+  (1 : Valuation (A ⧸ 𝔭) (WithZero (Multiplicative ℤ))).comap (Ideal.Quotient.mk 𝔭)
+
+open scoped Classical in
+/-- The value of the trivial valuation, as an `if`. -/
+lemma trivialValuation_apply {𝔭 : Ideal A} [𝔭.IsPrime] (a : A) :
+    trivialValuation 𝔭 a = if a ∈ 𝔭 then 0 else 1 := by
+  rw [trivialValuation, Valuation.comap_apply, Valuation.one_apply_def]
+  simp only [Ideal.Quotient.eq_zero_iff_mem]
+
+open scoped Classical in
+/-- The trivial valuation vanishes exactly on the prime ideal. -/
+@[simp]
+lemma trivialValuation_eq_zero_iff {𝔭 : Ideal A} [𝔭.IsPrime] {a : A} :
+    trivialValuation 𝔭 a = 0 ↔ a ∈ 𝔭 := by
+  rw [trivialValuation, Valuation.comap_apply, Valuation.one_apply_eq_zero_iff,
+    Ideal.Quotient.eq_zero_iff_mem]
+
+open scoped Classical in
+/-- Elements outside the prime ideal have value `1` under the trivial valuation. -/
+lemma trivialValuation_eq_one_of_notMem {𝔭 : Ideal A} [𝔭.IsPrime] {a : A} (ha : a ∉ 𝔭) :
+    trivialValuation 𝔭 a = 1 := by
+  rw [trivialValuation, Valuation.comap_apply,
+    Valuation.one_apply_of_ne_zero (by simpa [Ideal.Quotient.eq_zero_iff_mem] using ha)]
+
+end TauCeti.Valuation

--- a/TauCeti/RingTheory/Valuation/Trivial.lean
+++ b/TauCeti/RingTheory/Valuation/Trivial.lean
@@ -13,7 +13,8 @@ public import Mathlib.RingTheory.Ideal.Quotient.Operations
 
 The trivial valuation of a prime ideal `𝔭` of a commutative ring: it is `0` on `𝔭` and `1`
 off it. It is the pullback of Mathlib's trivial valuation `1` on the quotient domain `A ⧸ 𝔭`
-along the quotient map.
+along the quotient map. This is the construction behind the trivial-valuation section of
+the support map of the valuation spectrum.
 
 ## Main definitions
 
@@ -24,42 +25,51 @@ along the quotient map.
 
 * `TauCeti.Valuation.trivialValuation_eq_zero_iff` : The trivial valuation vanishes exactly
   on `𝔭`.
+
+## References
+
+* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Remark 4.6.
 -/
 
 public section
 
 namespace TauCeti.Valuation
 
-variable {A : Type*} [CommRing A]
+variable {A : Type*} [CommRing A] {Γ₀ : Type*} [LinearOrderedCommMonoidWithZero Γ₀]
 
 open scoped Classical in
-/-- The trivial valuation attached to a prime ideal `𝔭`: it is `0` on `𝔭` and `1` off it,
-as the pullback of the trivial valuation on the quotient domain `A ⧸ 𝔭` along the quotient
-map. -/
-noncomputable def trivialValuation (𝔭 : Ideal A) [𝔭.IsPrime] :
-    Valuation A (WithZero (Multiplicative ℤ)) :=
-  (1 : Valuation (A ⧸ 𝔭) (WithZero (Multiplicative ℤ))).comap (Ideal.Quotient.mk 𝔭)
+/-- The trivial valuation attached to a prime ideal `𝔭` (Wedhorn, Remark 4.6): it is `0` on
+`𝔭` and `1` off it, as the pullback of the trivial valuation on the quotient domain `A ⧸ 𝔭`
+along the quotient map. -/
+noncomputable def trivialValuation (𝔭 : Ideal A) [𝔭.IsPrime] : Valuation A Γ₀ :=
+  (1 : Valuation (A ⧸ 𝔭) Γ₀).comap (Ideal.Quotient.mk 𝔭)
 
 open scoped Classical in
 /-- The value of the trivial valuation, as an `if`. -/
 lemma trivialValuation_apply {𝔭 : Ideal A} [𝔭.IsPrime] (a : A) :
-    trivialValuation 𝔭 a = if a ∈ 𝔭 then 0 else 1 := by
+    trivialValuation (Γ₀ := Γ₀) 𝔭 a = if a ∈ 𝔭 then 0 else 1 := by
   rw [trivialValuation, Valuation.comap_apply, Valuation.one_apply_def]
   simp only [Ideal.Quotient.eq_zero_iff_mem]
 
 open scoped Classical in
 /-- The trivial valuation vanishes exactly on the prime ideal. -/
 @[simp]
-lemma trivialValuation_eq_zero_iff {𝔭 : Ideal A} [𝔭.IsPrime] {a : A} :
-    trivialValuation 𝔭 a = 0 ↔ a ∈ 𝔭 := by
+lemma trivialValuation_eq_zero_iff [Nontrivial Γ₀] {𝔭 : Ideal A} [𝔭.IsPrime] {a : A} :
+    trivialValuation (Γ₀ := Γ₀) 𝔭 a = 0 ↔ a ∈ 𝔭 := by
   rw [trivialValuation, Valuation.comap_apply, Valuation.one_apply_eq_zero_iff,
     Ideal.Quotient.eq_zero_iff_mem]
 
 open scoped Classical in
+/-- The trivial valuation takes the value `1` exactly off the prime ideal. -/
+@[simp]
+lemma trivialValuation_eq_one_iff [Nontrivial Γ₀] {𝔭 : Ideal A} [𝔭.IsPrime] {a : A} :
+    trivialValuation (Γ₀ := Γ₀) 𝔭 a = 1 ↔ a ∉ 𝔭 := by
+  rw [trivialValuation_apply]
+  split <;> simp_all
+
 /-- Elements outside the prime ideal have value `1` under the trivial valuation. -/
-lemma trivialValuation_eq_one_of_notMem {𝔭 : Ideal A} [𝔭.IsPrime] {a : A} (ha : a ∉ 𝔭) :
-    trivialValuation 𝔭 a = 1 := by
-  rw [trivialValuation, Valuation.comap_apply,
-    Valuation.one_apply_of_ne_zero (by simpa [Ideal.Quotient.eq_zero_iff_mem] using ha)]
+lemma trivialValuation_eq_one_of_notMem [Nontrivial Γ₀] {𝔭 : Ideal A} [𝔭.IsPrime] {a : A}
+    (ha : a ∉ 𝔭) : trivialValuation (Γ₀ := Γ₀) 𝔭 a = 1 :=
+  trivialValuation_eq_one_iff.mpr ha
 
 end TauCeti.Valuation

--- a/TauCeti/RingTheory/Valuation/Trivial.lean
+++ b/TauCeti/RingTheory/Valuation/Trivial.lean
@@ -68,9 +68,4 @@ lemma trivialValuation_eq_one_iff [Nontrivial Γ₀] {𝔭 : Ideal A} [𝔭.IsPr
   rw [trivialValuation_apply]
   split <;> simp_all
 
-/-- Elements outside the prime ideal have value `1` under the trivial valuation. -/
-lemma trivialValuation_eq_one_of_notMem {𝔭 : Ideal A} [𝔭.IsPrime] {a : A}
-    (ha : a ∉ 𝔭) : trivialValuation (Γ₀ := Γ₀) 𝔭 a = 1 := by
-  simp [trivialValuation_apply, ha]
-
 end TauCeti.Valuation


### PR DESCRIPTION
The trivial-valuation section of the support map — **Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Remark 4.6**, completing the Layer 1.1 tail: the trivial valuation attached to a prime ideal (`0` on the ideal, `1` off it) defines a continuous section of `suppFun : Spv A → Spec A`, so the support map is surjective.

Two files:

- New `TauCeti/RingTheory/Valuation/Trivial.lean`: `trivialValuation (𝔭 : Ideal A) [𝔭.IsPrime] : Valuation A (WithZero (Multiplicative ℤ))`, defined as the pullback of Mathlib's trivial valuation `1` on the quotient domain `A ⧸ 𝔭` along the quotient map, with the `if`-normal form `trivialValuation_apply`, the simp characterization `trivialValuation_eq_zero_iff`, and the off-ideal value `trivialValuation_eq_one_of_notMem`.
- `TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean` gains the section machinery, with the simp normal form `trivialSection_vle_iff` driving the topology computations.
- `trivialSection : PrimeSpectrum A → Spv A` with `suppFun_trivialSection : suppFun (trivialSection p) = p` (`@[simp]`).
- `trivialSection_preimage_basicOpen : trivialSection ⁻¹' Spv(A)(f/s) = D(s)`, whence `continuous_trivialSection`.
- `suppFun_surjective`.

**Roadmap target**: `TauCetiRoadmap/AdicSpaces/README.md`, Layer 1.1: *"the continuous support map `supp : Spv A → Spec A`, and the section of `supp` given by the trivial valuation attached to a prime ideal (Wedhorn Remark 4.6)"* — the second clause, the first having merged as #2262.

Part of TauCetiProject/TauCetiRoadmap#174.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-1.1-trivial-section"}-->
