### PR TITLE
refactor(Quadratic): decompose the norm-principality lemma

### DIFF
--- a/TauCeti/NumberTheory/DedekindDomain/RelNorm.lean
+++ b/TauCeti/NumberTheory/DedekindDomain/RelNorm.lean
@@ -32,10 +32,12 @@ variable {A B : Type*} [CommRing A] [IsDedekindDomain A]
   [CommRing B] [IsDedekindDomain B] [Algebra A B] [Module.Finite A B]
   [Module.IsTorsionFree A B]
 
-/-- **A containment of ideals with equal relative norms is an equality.** Only the larger ideal is
-assumed nonzero; the smaller one is then nonzero too, by the equality of norms. -/
-theorem eq_of_le_of_relNorm_eq {I J : Ideal B} (hIJ : I ≤ J) (hJne : J ≠ 0)
+/-- **A containment of ideals with equal relative norms is an equality.** -/
+theorem eq_of_le_of_relNorm_eq {I J : Ideal B} (hIJ : I ≤ J)
     (hnorm : relNorm A I = relNorm A J) : I = J := by
+  rcases eq_or_ne J 0 with rfl | hJne
+  · -- `I ≤ 0` leaves no room for `I`.
+    simpa [zero_eq_bot, le_bot_iff] using hIJ
   -- `J ∣ I`, so `I = J * C`; cancelling the norms gives `relNorm C = 1`, and an ideal whose norm
   -- is the unit ideal is itself the unit ideal, its norm lying below its contraction.
   obtain ⟨C, hC⟩ := dvd_iff_le.mpr hIJ

--- a/TauCeti/NumberTheory/DedekindDomain/RelNorm.lean
+++ b/TauCeti/NumberTheory/DedekindDomain/RelNorm.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Ideal.Norm.RelNorm
+
+/-!
+# Recovering an ideal from its relative norm
+
+For a finite torsion-free extension `A → B` of Dedekind domains, the relative norm
+`Ideal.relNorm A : Ideal B →*₀ Ideal A` is monotone but far from injective. It is, however,
+injective on any chain: two nested ideals with the same relative norm are equal.
+
+This is the step that turns a containment obtained from generators into an equality, which is how
+norm computations identify an ideal. Mathlib's `Mathlib/RingTheory/Ideal/Norm/RelNorm.lean` has the
+ingredients — multiplicativity, `Ideal.relNorm_eq_bot_iff` and `Ideal.relNorm_le_comap` — but not
+this consequence.
+
+## Main results
+
+* `Ideal.eq_of_le_of_relNorm_eq`: a containment of ideals of `B` with equal relative norms over `A`
+  is an equality.
+-/
+
+public section
+
+namespace Ideal
+
+variable {A B : Type*} [CommRing A] [IsDedekindDomain A]
+  [CommRing B] [IsDedekindDomain B] [Algebra A B] [Module.Finite A B]
+  [Module.IsTorsionFree A B]
+
+/-- **A containment of ideals with equal relative norms is an equality.** Only the larger ideal is
+assumed nonzero; the smaller one is then nonzero too, by the equality of norms. -/
+theorem eq_of_le_of_relNorm_eq {I J : Ideal B} (hIJ : I ≤ J) (hJne : J ≠ 0)
+    (hnorm : relNorm A I = relNorm A J) : I = J := by
+  -- `J ∣ I`, so `I = J * C`; cancelling the norms gives `relNorm C = 1`, and an ideal whose norm
+  -- is the unit ideal is itself the unit ideal, its norm lying below its contraction.
+  obtain ⟨C, hC⟩ := dvd_iff_le.mpr hIJ
+  have hJnorm_ne : relNorm A J ≠ 0 := by
+    rw [Ne, zero_eq_bot, relNorm_eq_bot_iff, ← zero_eq_bot]; exact hJne
+  have hC1 : relNorm A C = 1 := by
+    apply mul_left_cancel₀ hJnorm_ne
+    rw [mul_one, ← map_mul (relNorm A), ← hC, hnorm]
+  have hCtop : C = ⊤ := by
+    have hle : (⊤ : Ideal A) ≤ comap (algebraMap A B) C := by
+      rw [← one_eq_top, ← hC1]; exact relNorm_le_comap A C
+    rw [eq_top_iff_one]
+    have := hle (Submodule.mem_top (x := (1 : A)))
+    rwa [mem_comap, map_one] at this
+  rw [hC, hCtop, mul_top]
+
+end Ideal
+
+end

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -116,6 +116,52 @@ private noncomputable def ringOfIntegersQuadraticConjₐ (hmin : minpoly ℤ θ 
   AlgEquiv.ofRingEquiv (f := ringOfIntegersQuadraticConj hmin hgen)
     (fun z => by rw [algebraMap_int_eq]; exact map_intCast _ z)
 
+/-- **A containment of ideals with equal relative norms is an equality.** In the ring of integers
+`B ∣ A` follows from `A ≤ B`, so `A = B * C`; equal norms then force `relNorm C = 1`, and an ideal
+of norm one is the whole ring because its norm is below its contraction.
+
+The nonvanishing hypothesis is on the larger ideal, which is where the cancellation happens; it is
+automatic for the smaller one only if that one is itself nonzero. -/
+private theorem eq_of_le_of_relNorm_eq {A B : Ideal (𝓞 K)} (hAB : A ≤ B) (hBne : B ≠ 0)
+    (hnorm : Ideal.relNorm ℤ A = Ideal.relNorm ℤ B) : A = B := by
+  obtain ⟨C, hC⟩ := Ideal.dvd_iff_le.mpr hAB
+  have hBnorm_ne : Ideal.relNorm ℤ B ≠ 0 := by
+    rw [Ne, Ideal.zero_eq_bot, Ideal.relNorm_eq_bot_iff, ← Ideal.zero_eq_bot]; exact hBne
+  have hC1 : Ideal.relNorm ℤ C = 1 := by
+    apply mul_left_cancel₀ hBnorm_ne
+    rw [mul_one, ← map_mul (Ideal.relNorm ℤ), ← hC, hnorm]
+  have hCtop : C = ⊤ := by
+    have hle : (⊤ : Ideal ℤ) ≤ Ideal.comap (algebraMap ℤ (𝓞 K)) C := by
+      rw [← Ideal.one_eq_top, ← hC1]; exact Ideal.relNorm_le_comap ℤ C
+    rw [Ideal.eq_top_iff_one]
+    have := hle (Submodule.mem_top (x := (1 : ℤ)))
+    rwa [Ideal.mem_comap, map_one] at this
+  rw [hC, hCtop, Ideal.mul_top]
+
+/-- **The norm ideal, extended, sits inside `J · σJ`.** Each generator of the extension is
+`N(x) = x · σx` for some `x ∈ J`, which is visibly a product of an element of `J` and one of
+`σJ`. -/
+private theorem map_relNorm_le_mul_map_ringOfIntegersQuadraticConj
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (J : Ideal (𝓞 K)) :
+    Ideal.map (algebraMap ℤ (𝓞 K)) (Ideal.relNorm ℤ J) ≤
+      J * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) J := by
+  rw [Ideal.map_relNorm, Ideal.span_le]
+  rintro _ ⟨x, hx, rfl⟩
+  rw [Function.comp_apply, algebraMap_intNorm_eq hmin hgen]
+  exact Ideal.mul_mem_mul hx (Ideal.mem_map_of_mem _ hx)
+
+/-- **`J · σJ` has norm `(relNorm J)²`.** Quadratic conjugation preserves the relative norm — it is
+a `ℤ`-algebra automorphism, so `Ideal.relNorm_map_algEquiv` applies to
+`ringOfIntegersQuadraticConjₐ` — so the two factors contribute the same norm. -/
+private theorem relNorm_mul_map_ringOfIntegersQuadraticConj
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (J : Ideal (𝓞 K)) :
+    Ideal.relNorm ℤ (J * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) J) =
+      Ideal.relNorm ℤ J ^ 2 := by
+  have hreln : Ideal.relNorm ℤ (Ideal.map (ringOfIntegersQuadraticConj hmin hgen) J) =
+      Ideal.relNorm ℤ J :=
+    Ideal.relNorm_map_algEquiv (ringOfIntegersQuadraticConjₐ hmin hgen) J
+  rw [map_mul (Ideal.relNorm ℤ), hreln, ← sq]
+
 /-- **Norm-principality (Lemma A).** For quadratic conjugation `σ = ringOfIntegersQuadraticConj`,
 the product `I · σI` is a principal ideal, for every ideal `I` of `𝓞 K`. This is the
 genus-theoretic hypothesis fed to `mulEquiv_ringOfIntegersQuadraticConj_apply_eq_inv`. -/
@@ -124,48 +170,22 @@ theorem isPrincipal_mul_map_ringOfIntegersQuadraticConj
     (I * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I).IsPrincipal := by
   -- For `I ≠ 0`, `I · σI = (Ideal.relNorm ℤ I).map (algebraMap ℤ (𝓞 K))`, the extension of a
   -- principal `ℤ`-ideal; the equality is obtained by matching relative norms and divisibility.
-  rcases eq_or_ne I 0 with rfl | hJne
+  rcases eq_or_ne I 0 with rfl | hIne
   · exact ⟨0, by simp⟩
-  set σ := ringOfIntegersQuadraticConj hmin hgen with hσdef
-  set J : Ideal (𝓞 K) := I with hJ
-  set A : Ideal (𝓞 K) := Ideal.map (algebraMap ℤ (𝓞 K)) (Ideal.relNorm ℤ J) with hA
-  set B : Ideal (𝓞 K) := J * Ideal.map σ J with hB
-  have hmapne : Ideal.map σ J ≠ 0 := by
-    simpa [Ideal.zero_eq_bot, Ideal.map_eq_bot_iff_of_injective σ.injective] using hJne
-  have hBne : B ≠ 0 := by rw [hB]; exact mul_ne_zero hJne hmapne
-  -- (1) `A` is principal (extension of a principal `ℤ`-ideal).
-  have hAprin : A.IsPrincipal := by
-    have : (Ideal.relNorm ℤ J).IsPrincipal := IsPrincipalIdealRing.principal _
-    rw [hA]
-    infer_instance
-  -- (2) `A ≤ B`: each generator `N(x) = x·σx` lies in `J · σJ`.
-  have hAB : A ≤ B := by
-    rw [hA, Ideal.map_relNorm, Ideal.span_le]
-    rintro _ ⟨x, hx, rfl⟩
-    rw [Function.comp_apply, algebraMap_intNorm_eq hmin hgen, hB]
-    exact Ideal.mul_mem_mul hx (Ideal.mem_map_of_mem σ hx)
-  -- (3) `relNorm A = relNorm B = (relNorm J)²`.
-  have hnorm : Ideal.relNorm ℤ A = Ideal.relNorm ℤ B := by
-    -- `relNorm` is invariant under `σ`, from `Ideal.relNorm_map_algEquiv` for its `ℤ`-algebra form.
-    have hreln : Ideal.relNorm ℤ (Ideal.map σ J) = Ideal.relNorm ℤ J :=
-      Ideal.relNorm_map_algEquiv (ringOfIntegersQuadraticConjₐ hmin hgen) J
-    rw [hB, map_mul (Ideal.relNorm ℤ), hreln, ← sq, hA,
-      Ideal.relNorm_algebraMap, finrank_int_eq_two hmin hgen]
-  -- (4) `A = B`, from `B ∣ A` together with the equal norms.
-  have hAeqB : A = B := by
-    obtain ⟨C, hC⟩ := Ideal.dvd_iff_le.mpr hAB
-    have hBnorm_ne : Ideal.relNorm ℤ B ≠ 0 := by
-      rw [Ne, Ideal.zero_eq_bot, Ideal.relNorm_eq_bot_iff, ← Ideal.zero_eq_bot]; exact hBne
-    have hC1 : Ideal.relNorm ℤ C = 1 := by
-      apply mul_left_cancel₀ hBnorm_ne
-      rw [mul_one, ← map_mul (Ideal.relNorm ℤ), ← hC, hnorm]
-    have hCtop : C = ⊤ := by
-      have hle : (⊤ : Ideal ℤ) ≤ Ideal.comap (algebraMap ℤ (𝓞 K)) C := by
-        rw [← Ideal.one_eq_top, ← hC1]; exact Ideal.relNorm_le_comap ℤ C
-      rw [Ideal.eq_top_iff_one]
-      have := hle (Submodule.mem_top (x := (1 : ℤ)))
-      rwa [Ideal.mem_comap, map_one] at this
-    rw [hC, hCtop, Ideal.mul_top]
-  rw [← hAeqB]; exact hAprin
+  have hBne : I * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I ≠ 0 :=
+    mul_ne_zero hIne (by
+      simpa [Ideal.zero_eq_bot, Ideal.map_eq_bot_iff_of_injective
+        (ringOfIntegersQuadraticConj hmin hgen).injective] using hIne)
+  -- Both ideals have relative norm `(relNorm I)²`.
+  have hnorm : Ideal.relNorm ℤ (Ideal.map (algebraMap ℤ (𝓞 K)) (Ideal.relNorm ℤ I)) =
+      Ideal.relNorm ℤ (I * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I) := by
+    rw [Ideal.relNorm_algebraMap, finrank_int_eq_two hmin hgen,
+      relNorm_mul_map_ringOfIntegersQuadraticConj hmin hgen I]
+  -- So the containment is an equality, and the left side is principal, being the extension of the
+  -- principal `ℤ`-ideal `relNorm I`.
+  rw [← eq_of_le_of_relNorm_eq
+    (map_relNorm_le_mul_map_ringOfIntegersQuadraticConj hmin hgen I) hBne hnorm]
+  have : (Ideal.relNorm ℤ I).IsPrincipal := IsPrincipalIdealRing.principal _
+  infer_instance
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.RingTheory.Ideal.Norm.RelNorm
 public import Mathlib.NumberTheory.NumberField.Norm
+public import TauCeti.NumberTheory.DedekindDomain.RelNorm
 public import TauCeti.NumberTheory.NumberField.Quadratic.Conjugation.Basic
 
 /-!
@@ -116,33 +117,14 @@ private noncomputable def ringOfIntegersQuadraticConjₐ (hmin : minpoly ℤ θ 
   AlgEquiv.ofRingEquiv (f := ringOfIntegersQuadraticConj hmin hgen)
     (fun z => by rw [algebraMap_int_eq]; exact map_intCast _ z)
 
-section RelNorm
-
-variable {A B : Type*} [CommRing A] [IsDedekindDomain A]
-  [CommRing B] [IsDedekindDomain B] [Algebra A B] [Module.Finite A B]
-  [Module.IsTorsionFree A B]
-
-/-- **A containment of ideals with equal relative norms is an equality.** Only the larger ideal is
-assumed nonzero; the smaller one is then nonzero too, by the equality of norms. -/
-private theorem eq_of_le_of_relNorm_eq {I J : Ideal B} (hIJ : I ≤ J) (hJne : J ≠ 0)
-    (hnorm : Ideal.relNorm A I = Ideal.relNorm A J) : I = J := by
-  -- `J ∣ I`, so `I = J * C`; cancelling the norms gives `relNorm C = 1`, and an ideal whose norm
-  -- is the unit ideal is itself the unit ideal, its norm lying below its contraction.
-  obtain ⟨C, hC⟩ := Ideal.dvd_iff_le.mpr hIJ
-  have hJnorm_ne : Ideal.relNorm A J ≠ 0 := by
-    rw [Ne, Ideal.zero_eq_bot, Ideal.relNorm_eq_bot_iff, ← Ideal.zero_eq_bot]; exact hJne
-  have hC1 : Ideal.relNorm A C = 1 := by
-    apply mul_left_cancel₀ hJnorm_ne
-    rw [mul_one, ← map_mul (Ideal.relNorm A), ← hC, hnorm]
-  have hCtop : C = ⊤ := by
-    have hle : (⊤ : Ideal A) ≤ Ideal.comap (algebraMap A B) C := by
-      rw [← Ideal.one_eq_top, ← hC1]; exact Ideal.relNorm_le_comap A C
-    rw [Ideal.eq_top_iff_one]
-    have := hle (Submodule.mem_top (x := (1 : A)))
-    rwa [Ideal.mem_comap, map_one] at this
-  rw [hC, hCtop, Ideal.mul_top]
-
-end RelNorm
+/-- Pushing an ideal forward along quadratic conjugation and along its `ℤ`-algebra form
+`ringOfIntegersQuadraticConjₐ` give the same ideal: the two wrappers carry the same underlying
+ring homomorphism. -/
+private theorem map_ringOfIntegersQuadraticConjₐ (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (J : Ideal (𝓞 K)) :
+    Ideal.map (ringOfIntegersQuadraticConjₐ hmin hgen) J =
+      Ideal.map (ringOfIntegersQuadraticConj hmin hgen) J :=
+  rfl
 
 /-- The extension of the norm ideal of `J` is contained in `J · σJ`. -/
 private theorem map_relNorm_le_mul_map_ringOfIntegersQuadraticConj
@@ -169,11 +151,12 @@ theorem isPrincipal_mul_map_ringOfIntegersQuadraticConj
     mul_ne_zero hIne (by
       simpa [Ideal.zero_eq_bot, Ideal.map_eq_bot_iff_of_injective
         (ringOfIntegersQuadraticConj hmin hgen).injective] using hIne)
-  -- Conjugation preserves the relative norm. The ascription is what identifies `Ideal.map` of the
-  -- ring equivalence with `Ideal.map` of its `ℤ`-algebra form, which is what Mathlib's lemma takes.
+  -- Conjugation preserves the relative norm: rewrite to the `ℤ`-algebra form, which is what
+  -- Mathlib's lemma takes.
   have hreln : Ideal.relNorm ℤ (Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I) =
-      Ideal.relNorm ℤ I :=
-    Ideal.relNorm_map_algEquiv (ringOfIntegersQuadraticConjₐ hmin hgen) I
+      Ideal.relNorm ℤ I := by
+    rw [← map_ringOfIntegersQuadraticConjₐ hmin hgen I,
+      Ideal.relNorm_map_algEquiv (ringOfIntegersQuadraticConjₐ hmin hgen) I]
   -- So both ideals have relative norm `(relNorm I)²`.
   have hnorm : Ideal.relNorm ℤ (Ideal.map (algebraMap ℤ (𝓞 K)) (Ideal.relNorm ℤ I)) =
       Ideal.relNorm ℤ (I * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I) := by
@@ -181,7 +164,7 @@ theorem isPrincipal_mul_map_ringOfIntegersQuadraticConj
       map_mul (Ideal.relNorm ℤ), hreln, ← sq]
   -- So the containment is an equality, and the left side is principal, being the extension of the
   -- principal `ℤ`-ideal `relNorm I`.
-  rw [← eq_of_le_of_relNorm_eq
+  rw [← Ideal.eq_of_le_of_relNorm_eq
     (map_relNorm_le_mul_map_ringOfIntegersQuadraticConj hmin hgen I) hBne hnorm]
   have : (Ideal.relNorm ℤ I).IsPrincipal := IsPrincipalIdealRing.principal _
   infer_instance

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -16,9 +16,9 @@ For a quadratic number field `K = ℚ(√d)` with quadratic conjugation
 key fact that `I · σI` is principal for every ideal `I` of `𝓞 K`.  This is the hypothesis
 consumed by `TauCeti.NumberField.mulEquiv_ringOfIntegersQuadraticConj_apply_eq_inv`.
 
-The proof idea, for `I ≠ 0`, runs through the relative ideal norm: `I · σI` has the same relative
-norm as `(Ideal.relNorm ℤ I).map (algebraMap ℤ (𝓞 K))` and contains it, hence equals it, and that
-extension of a principal `ℤ`-ideal is principal.  (The zero ideal is trivially principal.)
+The proof runs through the relative ideal norm: `I · σI` has the same relative norm as
+`(Ideal.relNorm ℤ I).map (algebraMap ℤ (𝓞 K))` and contains it, hence equals it, and that
+extension of a principal `ℤ`-ideal is principal.  The zero ideal needs no separate treatment.
 
 See D. A. Cox, *Primes of the Form x² + ny²*, and F. Lemmermeyer, *Reciprocity Laws*, for the
 classical genus theory this norm-principality underlies.
@@ -142,14 +142,8 @@ genus-theoretic hypothesis fed to `mulEquiv_ringOfIntegersQuadraticConj_apply_eq
 theorem isPrincipal_mul_map_ringOfIntegersQuadraticConj
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (I : Ideal (𝓞 K)) :
     (I * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I).IsPrincipal := by
-  -- For `I ≠ 0`, `I · σI = (Ideal.relNorm ℤ I).map (algebraMap ℤ (𝓞 K))`, the extension of a
-  -- principal `ℤ`-ideal; the equality is obtained by matching relative norms and divisibility.
-  rcases eq_or_ne I 0 with rfl | hIne
-  · exact ⟨0, by simp⟩
-  have hBne : I * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I ≠ 0 :=
-    mul_ne_zero hIne (by
-      simpa [Ideal.zero_eq_bot, Ideal.map_eq_bot_iff_of_injective
-        (ringOfIntegersQuadraticConj hmin hgen).injective] using hIne)
+  -- `I · σI = (Ideal.relNorm ℤ I).map (algebraMap ℤ (𝓞 K))`, the extension of a principal
+  -- `ℤ`-ideal; the equality is obtained by matching relative norms and divisibility.
   -- Conjugation preserves the relative norm: rewrite to the `ℤ`-algebra form, which is what
   -- Mathlib's lemma takes.
   have hreln : Ideal.relNorm ℤ (Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I) =
@@ -164,7 +158,7 @@ theorem isPrincipal_mul_map_ringOfIntegersQuadraticConj
   -- So the containment is an equality, and the left side is principal, being the extension of the
   -- principal `ℤ`-ideal `relNorm I`.
   rw [← Ideal.eq_of_le_of_relNorm_eq
-    (map_relNorm_le_mul_map_ringOfIntegersQuadraticConj hmin hgen I) hBne hnorm]
+    (map_relNorm_le_mul_map_ringOfIntegersQuadraticConj hmin hgen I) hnorm]
   have : (Ideal.relNorm ℤ I).IsPrincipal := IsPrincipalIdealRing.principal _
   infer_instance
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -120,8 +120,8 @@ private noncomputable def ringOfIntegersQuadraticConjₐ (hmin : minpoly ℤ θ 
 `B ∣ A` follows from `A ≤ B`, so `A = B * C`; equal norms then force `relNorm C = 1`, and an ideal
 of norm one is the whole ring because its norm is below its contraction.
 
-The nonvanishing hypothesis is on the larger ideal, which is where the cancellation happens; it is
-automatic for the smaller one only if that one is itself nonzero. -/
+Only `B` is assumed nonzero, because that is the factor cancelled. Nothing is lost: with the norms
+equal, `A ≠ 0` follows from `hBne` through `Ideal.relNorm_eq_bot_iff`. -/
 private theorem eq_of_le_of_relNorm_eq {A B : Ideal (𝓞 K)} (hAB : A ≤ B) (hBne : B ≠ 0)
     (hnorm : Ideal.relNorm ℤ A = Ideal.relNorm ℤ B) : A = B := by
   obtain ⟨C, hC⟩ := Ideal.dvd_iff_le.mpr hAB

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.Ideal.Norm.RelNorm
 public import Mathlib.NumberTheory.NumberField.Norm
 public import TauCeti.NumberTheory.DedekindDomain.RelNorm
 public import TauCeti.NumberTheory.NumberField.Quadratic.Conjugation.Basic

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -142,13 +142,6 @@ private theorem eq_of_le_of_relNorm_eq {I J : Ideal B} (hIJ : I ≤ J) (hJne : J
     rwa [Ideal.mem_comap, map_one] at this
   rw [hC, hCtop, Ideal.mul_top]
 
-/-- The product of an ideal with its image under an `A`-algebra automorphism has relative norm the
-square of the ideal's. -/
-private theorem relNorm_mul_map_algEquiv (σ : B ≃ₐ[A] B) (I : Ideal B) :
-    Ideal.relNorm A (I * Ideal.map σ I) = Ideal.relNorm A I ^ 2 := by
-  -- An automorphism preserves the relative norm, so both factors contribute the same.
-  rw [map_mul (Ideal.relNorm A), Ideal.relNorm_map_algEquiv σ I, ← sq]
-
 end RelNorm
 
 /-- The extension of the norm ideal of `J` is contained in `J · σJ`. -/
@@ -176,15 +169,16 @@ theorem isPrincipal_mul_map_ringOfIntegersQuadraticConj
     mul_ne_zero hIne (by
       simpa [Ideal.zero_eq_bot, Ideal.map_eq_bot_iff_of_injective
         (ringOfIntegersQuadraticConj hmin hgen).injective] using hIne)
-  -- `relNorm_mul_map_algEquiv` applies to the `ℤ`-algebra form of conjugation; the type ascription
-  -- is what identifies its `Ideal.map` with the ring-equivalence one in the goal.
-  have hsq : Ideal.relNorm ℤ (I * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I) =
-      Ideal.relNorm ℤ I ^ 2 :=
-    relNorm_mul_map_algEquiv (ringOfIntegersQuadraticConjₐ hmin hgen) I
-  -- Both ideals then have relative norm `(relNorm I)²`.
+  -- Conjugation preserves the relative norm. The ascription is what identifies `Ideal.map` of the
+  -- ring equivalence with `Ideal.map` of its `ℤ`-algebra form, which is what Mathlib's lemma takes.
+  have hreln : Ideal.relNorm ℤ (Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I) =
+      Ideal.relNorm ℤ I :=
+    Ideal.relNorm_map_algEquiv (ringOfIntegersQuadraticConjₐ hmin hgen) I
+  -- So both ideals have relative norm `(relNorm I)²`.
   have hnorm : Ideal.relNorm ℤ (Ideal.map (algebraMap ℤ (𝓞 K)) (Ideal.relNorm ℤ I)) =
       Ideal.relNorm ℤ (I * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I) := by
-    rw [Ideal.relNorm_algebraMap, finrank_int_eq_two hmin hgen, hsq]
+    rw [Ideal.relNorm_algebraMap, finrank_int_eq_two hmin hgen,
+      map_mul (Ideal.relNorm ℤ), hreln, ← sq]
   -- So the containment is an equality, and the left side is principal, being the extension of the
   -- principal `ℤ`-ideal `relNorm I`.
   rw [← eq_of_le_of_relNorm_eq

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -116,51 +116,51 @@ private noncomputable def ringOfIntegersQuadraticConjₐ (hmin : minpoly ℤ θ 
   AlgEquiv.ofRingEquiv (f := ringOfIntegersQuadraticConj hmin hgen)
     (fun z => by rw [algebraMap_int_eq]; exact map_intCast _ z)
 
-/-- **A containment of ideals with equal relative norms is an equality.** In the ring of integers
-`B ∣ A` follows from `A ≤ B`, so `A = B * C`; equal norms then force `relNorm C = 1`, and an ideal
-of norm one is the whole ring because its norm is below its contraction.
+section RelNorm
 
-Only `B` is assumed nonzero, because that is the factor cancelled. Nothing is lost: with the norms
-equal, `A ≠ 0` follows from `hBne` through `Ideal.relNorm_eq_bot_iff`. -/
-private theorem eq_of_le_of_relNorm_eq {A B : Ideal (𝓞 K)} (hAB : A ≤ B) (hBne : B ≠ 0)
-    (hnorm : Ideal.relNorm ℤ A = Ideal.relNorm ℤ B) : A = B := by
-  obtain ⟨C, hC⟩ := Ideal.dvd_iff_le.mpr hAB
-  have hBnorm_ne : Ideal.relNorm ℤ B ≠ 0 := by
-    rw [Ne, Ideal.zero_eq_bot, Ideal.relNorm_eq_bot_iff, ← Ideal.zero_eq_bot]; exact hBne
-  have hC1 : Ideal.relNorm ℤ C = 1 := by
-    apply mul_left_cancel₀ hBnorm_ne
-    rw [mul_one, ← map_mul (Ideal.relNorm ℤ), ← hC, hnorm]
+variable {A B : Type*} [CommRing A] [IsDedekindDomain A]
+  [CommRing B] [IsDedekindDomain B] [Algebra A B] [Module.Finite A B]
+  [Module.IsTorsionFree A B]
+
+/-- **A containment of ideals with equal relative norms is an equality.** Only the larger ideal is
+assumed nonzero; the smaller one is then nonzero too, by the equality of norms. -/
+private theorem eq_of_le_of_relNorm_eq {I J : Ideal B} (hIJ : I ≤ J) (hJne : J ≠ 0)
+    (hnorm : Ideal.relNorm A I = Ideal.relNorm A J) : I = J := by
+  -- `J ∣ I`, so `I = J * C`; cancelling the norms gives `relNorm C = 1`, and an ideal whose norm
+  -- is the unit ideal is itself the unit ideal, its norm lying below its contraction.
+  obtain ⟨C, hC⟩ := Ideal.dvd_iff_le.mpr hIJ
+  have hJnorm_ne : Ideal.relNorm A J ≠ 0 := by
+    rw [Ne, Ideal.zero_eq_bot, Ideal.relNorm_eq_bot_iff, ← Ideal.zero_eq_bot]; exact hJne
+  have hC1 : Ideal.relNorm A C = 1 := by
+    apply mul_left_cancel₀ hJnorm_ne
+    rw [mul_one, ← map_mul (Ideal.relNorm A), ← hC, hnorm]
   have hCtop : C = ⊤ := by
-    have hle : (⊤ : Ideal ℤ) ≤ Ideal.comap (algebraMap ℤ (𝓞 K)) C := by
-      rw [← Ideal.one_eq_top, ← hC1]; exact Ideal.relNorm_le_comap ℤ C
+    have hle : (⊤ : Ideal A) ≤ Ideal.comap (algebraMap A B) C := by
+      rw [← Ideal.one_eq_top, ← hC1]; exact Ideal.relNorm_le_comap A C
     rw [Ideal.eq_top_iff_one]
-    have := hle (Submodule.mem_top (x := (1 : ℤ)))
+    have := hle (Submodule.mem_top (x := (1 : A)))
     rwa [Ideal.mem_comap, map_one] at this
   rw [hC, hCtop, Ideal.mul_top]
 
-/-- **The norm ideal, extended, sits inside `J · σJ`.** Each generator of the extension is
-`N(x) = x · σx` for some `x ∈ J`, which is visibly a product of an element of `J` and one of
-`σJ`. -/
+/-- The product of an ideal with its image under an `A`-algebra automorphism has relative norm the
+square of the ideal's. -/
+private theorem relNorm_mul_map_algEquiv (σ : B ≃ₐ[A] B) (I : Ideal B) :
+    Ideal.relNorm A (I * Ideal.map σ I) = Ideal.relNorm A I ^ 2 := by
+  -- An automorphism preserves the relative norm, so both factors contribute the same.
+  rw [map_mul (Ideal.relNorm A), Ideal.relNorm_map_algEquiv σ I, ← sq]
+
+end RelNorm
+
+/-- The extension of the norm ideal of `J` is contained in `J · σJ`. -/
 private theorem map_relNorm_le_mul_map_ringOfIntegersQuadraticConj
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (J : Ideal (𝓞 K)) :
     Ideal.map (algebraMap ℤ (𝓞 K)) (Ideal.relNorm ℤ J) ≤
       J * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) J := by
+  -- Each generator of the extension is `N(x) = x · σx` for some `x ∈ J`.
   rw [Ideal.map_relNorm, Ideal.span_le]
   rintro _ ⟨x, hx, rfl⟩
   rw [Function.comp_apply, algebraMap_intNorm_eq hmin hgen]
   exact Ideal.mul_mem_mul hx (Ideal.mem_map_of_mem _ hx)
-
-/-- **`J · σJ` has norm `(relNorm J)²`.** Quadratic conjugation preserves the relative norm — it is
-a `ℤ`-algebra automorphism, so `Ideal.relNorm_map_algEquiv` applies to
-`ringOfIntegersQuadraticConjₐ` — so the two factors contribute the same norm. -/
-private theorem relNorm_mul_map_ringOfIntegersQuadraticConj
-    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (J : Ideal (𝓞 K)) :
-    Ideal.relNorm ℤ (J * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) J) =
-      Ideal.relNorm ℤ J ^ 2 := by
-  have hreln : Ideal.relNorm ℤ (Ideal.map (ringOfIntegersQuadraticConj hmin hgen) J) =
-      Ideal.relNorm ℤ J :=
-    Ideal.relNorm_map_algEquiv (ringOfIntegersQuadraticConjₐ hmin hgen) J
-  rw [map_mul (Ideal.relNorm ℤ), hreln, ← sq]
 
 /-- **Norm-principality (Lemma A).** For quadratic conjugation `σ = ringOfIntegersQuadraticConj`,
 the product `I · σI` is a principal ideal, for every ideal `I` of `𝓞 K`. This is the
@@ -176,11 +176,15 @@ theorem isPrincipal_mul_map_ringOfIntegersQuadraticConj
     mul_ne_zero hIne (by
       simpa [Ideal.zero_eq_bot, Ideal.map_eq_bot_iff_of_injective
         (ringOfIntegersQuadraticConj hmin hgen).injective] using hIne)
-  -- Both ideals have relative norm `(relNorm I)²`.
+  -- `relNorm_mul_map_algEquiv` applies to the `ℤ`-algebra form of conjugation; the type ascription
+  -- is what identifies its `Ideal.map` with the ring-equivalence one in the goal.
+  have hsq : Ideal.relNorm ℤ (I * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I) =
+      Ideal.relNorm ℤ I ^ 2 :=
+    relNorm_mul_map_algEquiv (ringOfIntegersQuadraticConjₐ hmin hgen) I
+  -- Both ideals then have relative norm `(relNorm I)²`.
   have hnorm : Ideal.relNorm ℤ (Ideal.map (algebraMap ℤ (𝓞 K)) (Ideal.relNorm ℤ I)) =
       Ideal.relNorm ℤ (I * Ideal.map (ringOfIntegersQuadraticConj hmin hgen) I) := by
-    rw [Ideal.relNorm_algebraMap, finrank_int_eq_two hmin hgen,
-      relNorm_mul_map_ringOfIntegersQuadraticConj hmin hgen I]
+    rw [Ideal.relNorm_algebraMap, finrank_int_eq_two hmin hgen, hsq]
   -- So the containment is an equality, and the left side is principal, being the extension of the
   -- principal `ℤ`-ideal `relNorm I`.
   rw [← eq_of_le_of_relNorm_eq


### PR DESCRIPTION
`isPrincipal_mul_map_ringOfIntegersQuadraticConj` ran the whole genus-theoretic argument — four
numbered steps — inside one 46-line body. This extracts the steps that carry content, and puts the
one that is not about quadratic fields where it belongs.

## New module

`TauCeti/NumberTheory/DedekindDomain/RelNorm.lean` — `Ideal.eq_of_le_of_relNorm_eq`: for a finite
torsion-free Dedekind extension `A → B`, a containment `I ≤ J` of ideals of `B` with
`relNorm A I = relNorm A J` and `J ≠ 0` is an equality.

The proof is `Ideal.dvd_iff_le`, multiplicativity of `relNorm`, `relNorm_eq_bot_iff` and
`relNorm_le_comap` — no quadratic data anywhere, which is why it now sits at the Dedekind level
rather than in a quadratic-conjugation file. I searched Mathlib's
`RingTheory/Ideal/Norm/RelNorm.lean` first: it has `relNorm_mono`, `relNorm_eq_bot_iff`,
`relNorm_le_comap` and `relNorm_map_algEquiv`, but nothing of this shape.

## Local helpers

| helper | says |
|---|---|
| `map_relNorm_le_mul_map_ringOfIntegersQuadraticConj` | the extended norm ideal sits inside `I · σI`, each generator being `N(x) = x · σx` |
| `map_ringOfIntegersQuadraticConjₐ` | pushing an ideal along conjugation and along its `ℤ`-algebra form give the same ideal |

The second exists because the norm-preservation step was silently relying on those two wrappers
being definitionally equal. Naming the identification makes the step a rewrite rather than a
coincidence.

The norm-square step `relNorm (I · σI) = (relNorm I)²` is taken inline: it is two rewrites,
`map_mul` and Mathlib's `relNorm_map_algEquiv`, and does not earn a declaration.

## Notes from the compiler

`Module.IsTorsionFree` is the class name — Mathlib's `RelNorm.lean` reads it bare under
`open Module`. `IsDedekindDomain` already implies `IsDomain`, so carrying both binders draws an
overlapping-instance error.

The `set` locals `σ`, `J`, `A`, `B` went with the decomposition. They were not merely redundant:
`set` folds occurrences in the goal, so the folded goal no longer matched the spelled-out helper and
`rw` failed on it.

Proof body: 46 → 25 lines. No statement changes; the only new public declaration is the relocated
Dedekind lemma, in its own module.

Roadmap: Multiquadratic
