### PR TITLE
feat: transport the Lie structure to exterior bivectors

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
@@ -4,22 +4,28 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+import Mathlib.Algebra.Lie.TransferInstance
 public import TauCeti.LinearAlgebra.CliffordAlgebra.QuadraticLieSubalgebra
 
 /-!
 # The exterior-square model of quadratic Clifford elements
 
 The half-normalized Clifford bivector map identifies the second exterior power with the canonical
-Lie subalgebra of quadratic elements in the Clifford algebra.
+Lie subalgebra of quadratic elements in the Clifford algebra. Transporting its Lie structure
+equips the exterior square with the corresponding commutator bracket.
 
-This is a generic prerequisite for transporting the Clifford commutator to the exterior square in
-the spin representations roadmap. It does not define the transported bracket or identify it with
-an orthogonal Lie algebra.
+This is a generic prerequisite for identifying bivectors with the orthogonal Lie algebra in the
+spin representations roadmap. It does not construct that orthogonal Lie equivalence.
 
 ## Main results
 
 * `TauCeti.CliffordAlgebra.cliffordBivectorExteriorEquivQuadraticLieSubalgebra`: the exterior
   square is linearly equivalent to the quadratic Lie subalgebra.
+* `TauCeti.CliffordAlgebra.cliffordBivectorLieRing` and
+  `TauCeti.CliffordAlgebra.cliffordBivectorLieAlgebra`: the Lie structures transported to the
+  exterior square.
+* `TauCeti.CliffordAlgebra.cliffordBivectorLieEquiv`: the transported Lie equivalence with the
+  quadratic Lie subalgebra.
 
 ## References
 
@@ -36,6 +42,8 @@ universe u v
 namespace TauCeti
 
 namespace CliffordAlgebra
+
+attribute [local instance 100] LieRing.ofAssociativeRing
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 
@@ -68,6 +76,64 @@ theorem coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_symm_apply
   rw [← equivExterior_cliffordBivectorExterior Q,
     ← coe_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_apply,
     LinearEquiv.apply_symm_apply]
+
+/-- The Lie ring structure on the second exterior power transported from the quadratic elements
+through `cliffordBivectorExteriorEquivQuadraticLieSubalgebra`. It is explicit in `Q` because the
+exterior square alone does not determine the quadratic form. -/
+@[instance_reducible]
+noncomputable def cliffordBivectorLieRing (Q : QuadraticForm R M) [Invertible (2 : R)] :
+    LieRing (⋀[R]^2 M) :=
+  (cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).toAddEquiv.lieRing
+
+/-- The Lie algebra structure on the second exterior power transported from the quadratic
+elements. It is explicit in `Q` for the same reason as `cliffordBivectorLieRing`. -/
+@[instance_reducible]
+noncomputable def cliffordBivectorLieAlgebra (Q : QuadraticForm R M) [Invertible (2 : R)] :
+    letI := cliffordBivectorLieRing Q
+    LieAlgebra R (⋀[R]^2 M) :=
+  (cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).lieAlgebra
+
+/-- The bracket transported to the second exterior power is the pullback of the commutator on
+the quadratic elements. -/
+theorem lie_eq_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_symm
+    (Q : QuadraticForm R M) [Invertible (2 : R)] (x y : ⋀[R]^2 M) :
+    letI := cliffordBivectorLieRing Q
+    ⁅x, y⁆ = (cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).symm
+      ⁅cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q x,
+        cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q y⁆ :=
+  AddEquiv.bracket_def _ x y
+
+/-- The transported Lie equivalence between the second exterior power and the quadratic
+elements. -/
+noncomputable def cliffordBivectorLieEquiv (Q : QuadraticForm R M) [Invertible (2 : R)] :
+    letI := cliffordBivectorLieRing Q
+    letI := cliffordBivectorLieAlgebra Q
+    ⋀[R]^2 M ≃ₗ⁅R⁆ quadraticLieSubalgebra Q :=
+  (cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).lieEquiv R
+
+/-- The transported Lie equivalence has the same forward map as the exterior-square linear
+equivalence. -/
+@[simp]
+theorem cliffordBivectorLieEquiv_apply (Q : QuadraticForm R M) [Invertible (2 : R)]
+    (x : ⋀[R]^2 M) :
+    letI := cliffordBivectorLieRing Q
+    letI := cliffordBivectorLieAlgebra Q
+    cliffordBivectorLieEquiv Q x =
+      cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q x := by
+  rw [cliffordBivectorLieEquiv]
+  exact LinearEquiv.lieEquiv_apply _ x
+
+/-- The inverse transported Lie equivalence has the same map as the inverse exterior-square
+linear equivalence. -/
+@[simp]
+theorem cliffordBivectorLieEquiv_symm_apply (Q : QuadraticForm R M) [Invertible (2 : R)]
+    (x : quadraticLieSubalgebra Q) :
+    letI := cliffordBivectorLieRing Q
+    letI := cliffordBivectorLieAlgebra Q
+    (cliffordBivectorLieEquiv Q).symm x =
+      (cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).symm x := by
+  rw [cliffordBivectorLieEquiv]
+  exact LinearEquiv.lieEquiv_symm_apply _ x
 
 end CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
@@ -93,16 +93,6 @@ noncomputable def cliffordBivectorLieAlgebra (Q : QuadraticForm R M) [Invertible
     LieAlgebra R (⋀[R]^2 M) :=
   (cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).lieAlgebra
 
-/-- The bracket transported to the second exterior power is the pullback of the commutator on
-the quadratic elements. -/
-theorem lie_eq_cliffordBivectorExteriorEquivQuadraticLieSubalgebra_symm
-    (Q : QuadraticForm R M) [Invertible (2 : R)] (x y : ⋀[R]^2 M) :
-    letI := cliffordBivectorLieRing Q
-    ⁅x, y⁆ = (cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q).symm
-      ⁅cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q x,
-        cliffordBivectorExteriorEquivQuadraticLieSubalgebra Q y⁆ :=
-  AddEquiv.bracket_def _ x y
-
 /-- The transported Lie equivalence between the second exterior power and the quadratic
 elements. -/
 noncomputable def cliffordBivectorLieEquiv (Q : QuadraticForm R M) [Invertible (2 : R)] :


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Transports the Clifford commutator on quadratic elements to the second exterior power.

- Defines explicit quadratic-form-dependent Lie ring and Lie algebra structures on `⋀[R]^2 M`.
- Packages the canonical comparison as a Lie equivalence.
- Provides forward and inverse simp equations for the transported Lie equivalence.

## Roadmap target

Advances the Layer 3 `bivectorLieRing` target:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L136-L150

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#bivectorLieRing"}-->

## Verification

`lake build TauCeti`, full `scripts/lint-env.sh`, downstream bare-`simp` and bracket probes, proof golf, identity/history audit, and independent exact-head review pass at `2d42e86208b22b4342855f07a3ab2a8e119c215e`.

## Scale and generality

Changes one file by +60/−4 lines. The construction is generic over a commutative ring, module, and quadratic form with invertible `2`; it needs no basis, finiteness, field, or nondegeneracy assumption.

## Scope

- **Consumes:** the exterior-to-quadratic equivalence and the Clifford commutator on quadratic elements.
- **Provides:** transported Lie ring and Lie algebra structures on the second exterior power, packaged as a Lie equivalence.
- **Fits:** supplies the exterior-bivector Lie boundary consumed by the standard orthogonal comparison.
- **Boundary:** the skew-adjoint and matrix orthogonal identifications belong to downstream slices.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [b8161ef](https://github.com/TauCetiProject/TauCetiReview/commit/b8161ef29f1bf922d3f9aea2b1b1e298bcd06078) · local skill review @ [d3c1151](https://github.com/utensil/formal-land/commit/d3c1151fe4fd4a1ff08035f37517998a1f585ce6) fixed: none</sub>