### PR TITLE
refactor: name the Clifford graded-piece denominator

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -88,25 +88,29 @@ private theorem filtrationGradedPreMul_apply (Q : QuadraticForm R M) (i j : ℕ)
   rfl
 
 private theorem filtrationGradedPreMul_mem_ker_left (Q : QuadraticForm R M) (i j : ℕ) :
-    Submodule.comap (filtration Q i).subtype (filtrationPrevious Q i) ≤
+    filtrationPreviousRestricted Q i ≤
       (filtrationGradedPreMul Q i j).ker := by
   rintro ⟨x, hx⟩ hprevious
+  rw [mem_filtrationPreviousRestricted_iff] at hprevious
   rw [LinearMap.mem_ker]
   ext y
   simp only [filtrationGradedPreMul_apply, LinearMap.zero_apply]
   rw [Submodule.Quotient.mk_eq_zero]
+  rw [mem_filtrationPreviousRestricted_iff]
   -- The filtration product lemma is stated for ambient Clifford-algebra elements.
   change (x : CliffordAlgebra Q) * (y : CliffordAlgebra Q) ∈ filtrationPrevious Q (i + j)
   exact mul_mem_filtrationPrevious_left Q i j hprevious y.property
 
 private theorem filtrationGradedPreMul_mem_ker_right (Q : QuadraticForm R M) (i j : ℕ) :
-    Submodule.comap (filtration Q j).subtype (filtrationPrevious Q j) ≤
+    filtrationPreviousRestricted Q j ≤
       (filtrationGradedPreMul Q i j).flip.ker := by
   rintro ⟨y, hy⟩ hprevious
+  rw [mem_filtrationPreviousRestricted_iff] at hprevious
   rw [LinearMap.mem_ker]
   ext x
   simp only [LinearMap.flip_apply, LinearMap.zero_apply]
   rw [filtrationGradedPreMul_apply, Submodule.Quotient.mk_eq_zero]
+  rw [mem_filtrationPreviousRestricted_iff]
   -- The filtration product lemma is stated for ambient Clifford-algebra elements.
   change (x : CliffordAlgebra Q) * (y : CliffordAlgebra Q) ∈ filtrationPrevious Q (i + j)
   exact mul_mem_filtrationPrevious_right Q i j x.property hprevious
@@ -139,9 +143,10 @@ private theorem filtrationGradedPiece_cast_mk' (Q : QuadraticForm R M) {i j : �
   subst j
   rfl
 
-private theorem filtration_subtype_cast (Q : QuadraticForm R M) {i j : ℕ}
+private theorem filtration_coe_cast (Q : QuadraticForm R M) {i j : ℕ}
     (h : i = j) (x : filtration Q i) :
-    (filtration Q j).subtype (cast (congrArg (fun k => ↥(filtration Q k)) h) x) = x := by
+    ((cast (congrArg (fun k => ↥(filtration Q k)) h) x : filtration Q j) :
+      CliffordAlgebra Q) = x := by
   subst j
   rfl
 
@@ -161,8 +166,8 @@ theorem filtrationGradedMul_assoc (Q : QuadraticForm R M) (i j k : ℕ)
               simp only [filtrationGradedMul_apply_mk]
               rw [filtrationGradedPiece_cast_mk' Q (Nat.add_assoc i j k)]
               apply (Submodule.Quotient.eq _).mpr
-              rw [Submodule.mem_comap, map_sub,
-                filtration_subtype_cast Q (Nat.add_assoc i j k)]
+              rw [mem_filtrationPreviousRestricted_iff, Submodule.coe_sub,
+                filtration_coe_cast Q (Nat.add_assoc i j k)]
               -- Compare the two representatives in the ambient Clifford algebra.
               change ((x : CliffordAlgebra Q) * y) * z - x * (y * z) ∈
                 filtrationPrevious Q (i + (j + k))
@@ -221,7 +226,7 @@ theorem filtrationGradedAlgebraMap₀_apply (Q : QuadraticForm R M) (r : R) :
       (⟨algebraMap R (CliffordAlgebra Q) 1, algebraMap_mem_filtration Q 1 0⟩ : filtration Q 0) =
     Submodule.Quotient.mk (⟨1, one_mem_filtration Q 0⟩ : filtration Q 0)
   apply (Submodule.Quotient.eq _).mpr
-  rw [Submodule.mem_comap]
+  rw [mem_filtrationPreviousRestricted_iff]
   -- Quotient equality is ambient membership, the form in which `map_one` applies.
   change algebraMap R (CliffordAlgebra Q) 1 - 1 ∈ filtrationPrevious Q 0
   rw [map_one, sub_self]
@@ -241,8 +246,8 @@ theorem filtrationGradedAlgebraMap₀_apply (Q : QuadraticForm R M) (r : R) :
       rw [filtrationGradedMul_apply_mk]
       rw [filtrationGradedPiece_cast_mk' Q (Nat.zero_add k).symm]
       apply (Submodule.Quotient.eq _).mpr
-      rw [Submodule.mem_comap, map_sub,
-        filtration_subtype_cast Q (Nat.zero_add k).symm]
+      rw [mem_filtrationPreviousRestricted_iff, Submodule.coe_sub,
+        filtration_coe_cast Q (Nat.zero_add k).symm]
       -- Quotient equality is now ambient membership, the form of the filtration product API.
       change (1 : CliffordAlgebra Q) * (x : CliffordAlgebra Q) - x ∈
         filtrationPrevious Q (0 + k)
@@ -263,8 +268,8 @@ theorem filtrationGradedAlgebraMap₀_apply (Q : QuadraticForm R M) (r : R) :
       rw [filtrationGradedMul_apply_mk]
       rw [filtrationGradedPiece_cast_mk' Q (Nat.add_zero k).symm]
       apply (Submodule.Quotient.eq _).mpr
-      rw [Submodule.mem_comap, map_sub,
-        filtration_subtype_cast Q (Nat.add_zero k).symm]
+      rw [mem_filtrationPreviousRestricted_iff, Submodule.coe_sub,
+        filtration_coe_cast Q (Nat.add_zero k).symm]
       -- Quotient equality is now ambient membership, the form of the filtration product API.
       change (x : CliffordAlgebra Q) * 1 - x ∈ filtrationPrevious Q (k + 0)
       rw [mul_one, sub_self]
@@ -372,7 +377,8 @@ noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
       -- The cast needs an ambient membership witness; `filtration_mul` supplies that witness.
       rw [filtrationGradedPiece_cast_mk' Q (Nat.zero_add k)]
       apply (Submodule.Quotient.eq _).mpr
-      rw [Submodule.mem_comap, map_sub, filtration_subtype_cast Q (Nat.zero_add k)]
+      rw [mem_filtrationPreviousRestricted_iff, Submodule.coe_sub,
+        filtration_coe_cast Q (Nat.zero_add k), Submodule.coe_smul]
       change algebraMap R (CliffordAlgebra Q) r * (x : CliffordAlgebra Q) - r • x ∈
         filtrationPrevious Q k
       rw [Algebra.smul_def, sub_self]
@@ -388,7 +394,7 @@ noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
     (Submodule.Quotient.mk _) = Submodule.Quotient.mk _
   rw [filtrationGradedMul_apply_mk]
   apply (Submodule.Quotient.eq _).mpr
-  rw [Submodule.mem_comap]
+  rw [mem_filtrationPreviousRestricted_iff]
   -- Quotient equality is ambient membership, the form in which `map_mul` applies.
   change algebraMap R (CliffordAlgebra Q) r * algebraMap R (CliffordAlgebra Q) s -
       algebraMap R (CliffordAlgebra Q) (r * s) ∈ filtrationPrevious Q 0
@@ -414,8 +420,8 @@ theorem filtrationGradedAlgebraMap₀_commutes (Q : QuadraticForm R M) (r : R) (
       rw [filtrationGradedMul_apply_mk, filtrationGradedMul_apply_mk]
       rw [filtrationGradedPiece_cast_mk' Q ((Nat.zero_add k).trans (Nat.add_zero k).symm)]
       apply (Submodule.Quotient.eq _).mpr
-      rw [Submodule.mem_comap, map_sub,
-        filtration_subtype_cast Q ((Nat.zero_add k).trans (Nat.add_zero k).symm)]
+      rw [mem_filtrationPreviousRestricted_iff, Submodule.coe_sub,
+        filtration_coe_cast Q ((Nat.zero_add k).trans (Nat.add_zero k).symm)]
       -- Quotient equality is ambient filtration membership; this exposes the coercions needed
       -- for the Clifford algebra's scalar-commutation theorem.
       change algebraMap R (CliffordAlgebra Q) r * (x : CliffordAlgebra Q) -

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
@@ -95,8 +95,7 @@ private theorem zero_form_filtrationPreviousRestricted_succ (k : ℕ) :
     filtrationPreviousRestricted (0 : QuadraticForm R M) (k + 1) =
       Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
         (filtration (0 : QuadraticForm R M) k) := by
-  ext x
-  rw [mem_filtrationPreviousRestricted_iff, filtrationPrevious_succ, Submodule.mem_comap]
+  rw [filtrationPreviousRestricted_succ]
   rfl
 
 /-- The successive zero-form Clifford filtration quotient is the degree `k + 1` exterior power. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
@@ -91,17 +91,11 @@ private theorem zero_form_filtration_succ_eq_exteriorPower_sup (k : ℕ) :
       ⋀[R]^(k + 1) M ⊔ filtration (0 : QuadraticForm R M) k := by
   rw [filtration_succ_eq_sup, sup_comm]
 
-private theorem zero_form_filtrationPreviousRestricted_succ (k : ℕ) :
-    filtrationPreviousRestricted (0 : QuadraticForm R M) (k + 1) =
-      Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
-        (filtration (0 : QuadraticForm R M) k) := by
-  rw [filtrationPreviousRestricted_succ]
-  rfl
-
 /-- The successive zero-form Clifford filtration quotient is the degree `k + 1` exterior power. -/
 noncomputable def zeroFormFiltrationQuotientEquivExteriorPower (k : ℕ) :
     FiltrationGradedPiece (0 : QuadraticForm R M) (k + 1) ≃ₗ[R] ⋀[R]^(k + 1) M :=
-  (Submodule.quotEquivOfEq _ _ (zero_form_filtrationPreviousRestricted_succ k)).trans
+  (Submodule.quotEquivOfEq _ _
+    (filtrationPreviousRestricted_succ (0 : QuadraticForm R M) k)).trans
     (quotientEquivOfEqSup _ _ _ (zero_form_filtration_succ_eq_exteriorPower_sup k)
       (exteriorPower_succ_disjoint_zero_form_filtration k))
 
@@ -116,7 +110,8 @@ theorem zeroFormFiltrationQuotientEquivExteriorPower_symm_apply (k : ℕ)
         exact Submodule.mem_sup_left x.property⟩ := by
   rw [zeroFormFiltrationQuotientEquivExteriorPower, LinearEquiv.trans_symm,
     LinearEquiv.trans_apply, quotientEquivOfEqSup_symm_apply]
-  apply (Submodule.quotEquivOfEq _ _ (zero_form_filtrationPreviousRestricted_succ k)).injective
+  apply (Submodule.quotEquivOfEq _ _
+    (filtrationPreviousRestricted_succ (0 : QuadraticForm R M) k)).injective
   rw [LinearEquiv.apply_symm_apply, Submodule.quotEquivOfEq_mk]
 
 /-- The quotient equivalence sends the canonical class of a degree `k + 1` exterior element to

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
@@ -91,17 +91,18 @@ private theorem zero_form_filtration_succ_eq_exteriorPower_sup (k : ℕ) :
       ⋀[R]^(k + 1) M ⊔ filtration (0 : QuadraticForm R M) k := by
   rw [filtration_succ_eq_sup, sup_comm]
 
-private theorem zero_form_filtrationPrevious_succ_comap (k : ℕ) :
-    Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
-        (filtrationPrevious (0 : QuadraticForm R M) (k + 1)) =
+private theorem zero_form_filtrationPreviousRestricted_succ (k : ℕ) :
+    filtrationPreviousRestricted (0 : QuadraticForm R M) (k + 1) =
       Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
         (filtration (0 : QuadraticForm R M) k) := by
-  rw [filtrationPrevious_succ]
+  ext x
+  rw [mem_filtrationPreviousRestricted_iff, filtrationPrevious_succ, Submodule.mem_comap]
+  rfl
 
 /-- The successive zero-form Clifford filtration quotient is the degree `k + 1` exterior power. -/
 noncomputable def zeroFormFiltrationQuotientEquivExteriorPower (k : ℕ) :
     FiltrationGradedPiece (0 : QuadraticForm R M) (k + 1) ≃ₗ[R] ⋀[R]^(k + 1) M :=
-  (Submodule.quotEquivOfEq _ _ (zero_form_filtrationPrevious_succ_comap k)).trans
+  (Submodule.quotEquivOfEq _ _ (zero_form_filtrationPreviousRestricted_succ k)).trans
     (quotientEquivOfEqSup _ _ _ (zero_form_filtration_succ_eq_exteriorPower_sup k)
       (exteriorPower_succ_disjoint_zero_form_filtration k))
 
@@ -116,7 +117,7 @@ theorem zeroFormFiltrationQuotientEquivExteriorPower_symm_apply (k : ℕ)
         exact Submodule.mem_sup_left x.property⟩ := by
   rw [zeroFormFiltrationQuotientEquivExteriorPower, LinearEquiv.trans_symm,
     LinearEquiv.trans_apply, quotientEquivOfEqSup_symm_apply]
-  apply (Submodule.quotEquivOfEq _ _ (zero_form_filtrationPrevious_succ_comap k)).injective
+  apply (Submodule.quotEquivOfEq _ _ (zero_form_filtrationPreviousRestricted_succ k)).injective
   rw [LinearEquiv.apply_symm_apply, Submodule.quotEquivOfEq_mk]
 
 /-- The quotient equivalence sends the canonical class of a degree `k + 1` exterior element to

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -141,8 +141,8 @@ viewed inside the successor step. -/
 @[simp]
 theorem filtrationPreviousRestricted_succ (Q : QuadraticForm R M) (k : ℕ) :
     filtrationPreviousRestricted Q (k + 1) =
-      (filtration Q k).submoduleOf (filtration Q (k + 1)) := by
-  simp [filtrationPreviousRestricted]
+      Submodule.comap (filtration Q (k + 1)).subtype (filtration Q k) := by
+  rfl
 
 /-- The degree-`k` piece of the associated graded Clifford filtration. -/
 abbrev FiltrationGradedPiece (Q : QuadraticForm R M) (k : ℕ) : Type max u v :=

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -114,10 +114,24 @@ theorem filtrationPrevious_succ (Q : QuadraticForm R M) (k : ℕ) :
     filtrationPrevious Q (k + 1) = filtration Q k :=
   (rfl)
 
+/-- The filtration step preceding degree `k`, viewed inside the degree-`k` filtration step. This is
+the relation defining the degree-`k` associated-graded quotient. -/
+def filtrationPreviousRestricted (Q : QuadraticForm R M) (k : ℕ) :
+    Submodule R (filtration Q k) :=
+  (filtrationPrevious Q k).submoduleOf (filtration Q k)
+
+/-- Membership in the restricted preceding filtration is ambient membership in the preceding
+filtration step. -/
+@[simp]
+theorem mem_filtrationPreviousRestricted_iff (Q : QuadraticForm R M) (k : ℕ)
+    (x : filtration Q k) :
+    x ∈ filtrationPreviousRestricted Q k ↔
+      (x : CliffordAlgebra Q) ∈ filtrationPrevious Q k :=
+  Iff.rfl
+
 /-- The degree-`k` piece of the associated graded Clifford filtration. -/
 abbrev FiltrationGradedPiece (Q : QuadraticForm R M) (k : ℕ) : Type max u v :=
-  filtration Q k ⧸
-    Submodule.comap (filtration Q k).subtype (filtrationPrevious Q k)
+  filtration Q k ⧸ filtrationPreviousRestricted Q k
 
 variable (Q : QuadraticForm R M)
 
@@ -373,8 +387,7 @@ private theorem filtrationLeadingTermRaw_mem_previous (k : ℕ) (v : Fin (k + 1)
 
 private noncomputable def filtrationLeadingTermAlternating (k : ℕ) :
     M [⋀^Fin (k + 1)]→ₗ[R] FiltrationGradedPiece Q (k + 1) :=
-  let P : Submodule R (filtration Q (k + 1)) :=
-    (filtrationPrevious Q (k + 1)).comap (filtration Q (k + 1)).subtype
+  let P := filtrationPreviousRestricted Q (k + 1)
   { toMultilinearMap :=
       P.mkQ.compMultilinearMap
         ((filtrationLeadingTermRaw Q k).codRestrict (filtration Q (k + 1))
@@ -416,7 +429,7 @@ An element of `filtration Q (k + 1)` lies in its image under the inclusion exact
 modulo `filtration Q k` is a leading term. -/
 private noncomputable def leadingTermPreimage (k : ℕ) : Submodule R (filtration Q (k + 1)) :=
   (LinearMap.range (filtrationLeadingTerm Q k)).comap
-    ((filtrationPrevious Q (k + 1)).comap (filtration Q (k + 1)).subtype).mkQ
+    (filtrationPreviousRestricted Q (k + 1)).mkQ
 
 /-- **The lower filtration consists of leading terms, trivially.** An element of `filtration Q k`
 has zero class modulo `filtration Q k`, and zero is a leading term. -/
@@ -426,10 +439,9 @@ private theorem filtration_le_map_leadingTermPreimage (k : ℕ) :
   have hz' : z ∈ filtration Q (k + 1) := filtration_mono Q (by omega) hz
   refine Submodule.mem_map.2 ⟨⟨z, hz'⟩, ?_, rfl⟩
   have hzero :
-      ((filtrationPrevious Q (k + 1)).comap (filtration Q (k + 1)).subtype).mkQ
-        ⟨z, hz'⟩ = 0 :=
+      (filtrationPreviousRestricted Q (k + 1)).mkQ ⟨z, hz'⟩ = 0 :=
     (Submodule.Quotient.mk_eq_zero _).mpr (by
-      rw [Submodule.mem_comap, filtrationPrevious_succ]
+      rw [mem_filtrationPreviousRestricted_iff, filtrationPrevious_succ]
       exact hz)
   simp [leadingTermPreimage, hzero]
 
@@ -468,7 +480,7 @@ theorem filtrationLeadingTerm_surjective (k : ℕ) :
   intro z
   obtain ⟨x, rfl⟩ :=
     Submodule.Quotient.mk_surjective
-      ((filtrationPrevious Q (k + 1)).comap (filtration Q (k + 1)).subtype) z
+      (filtrationPreviousRestricted Q (k + 1)) z
   obtain ⟨y, hy, hxy⟩ := Submodule.mem_map.1 (hle x.property)
   obtain rfl : y = x := Subtype.ext hxy
   simpa [leadingTermPreimage] using hy

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -129,6 +129,21 @@ theorem mem_filtrationPreviousRestricted_iff (Q : QuadraticForm R M) (k : ℕ)
       (x : CliffordAlgebra Q) ∈ filtrationPrevious Q k :=
   Iff.rfl
 
+/-- The restricted preceding filtration is trivial in degree zero. -/
+@[simp]
+theorem filtrationPreviousRestricted_zero (Q : QuadraticForm R M) :
+    filtrationPreviousRestricted Q 0 = ⊥ := by
+  ext x
+  simp [filtrationPreviousRestricted, Submodule.submoduleOf]
+
+/-- In successor degree, the restricted preceding filtration is the preceding filtration step
+viewed inside the successor step. -/
+@[simp]
+theorem filtrationPreviousRestricted_succ (Q : QuadraticForm R M) (k : ℕ) :
+    filtrationPreviousRestricted Q (k + 1) =
+      (filtration Q k).submoduleOf (filtration Q (k + 1)) := by
+  simp [filtrationPreviousRestricted]
+
 /-- The degree-`k` piece of the associated graded Clifford filtration. -/
 abbrev FiltrationGradedPiece (Q : QuadraticForm R M) (k : ℕ) : Type max u v :=
   filtration Q k ⧸ filtrationPreviousRestricted Q k

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -66,12 +66,12 @@ theorem coe_equivExteriorFiltration_symm_apply (Q : QuadraticForm R M) [Invertib
 
 private theorem equivExteriorFiltration_map_previous (Q : QuadraticForm R M) [Invertible (2 : R)]
     (k : ℕ) :
-    (Submodule.comap (filtration Q (k + 1)).subtype (filtration Q k)).map
+    (filtrationPreviousRestricted Q (k + 1)).map
         (equivExteriorFiltration Q (k + 1)).toLinearMap =
-      Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
-        (filtration (0 : QuadraticForm R M) k) := by
+      filtrationPreviousRestricted (0 : QuadraticForm R M) (k + 1) := by
   ext x
-  rw [Submodule.mem_map_equiv]
+  rw [Submodule.mem_map_equiv, mem_filtrationPreviousRestricted_iff,
+    mem_filtrationPreviousRestricted_iff, filtrationPrevious_succ, filtrationPrevious_succ]
   -- The two submodules are over filtration subtypes, so expose their ambient carrier predicates.
   change (changeFormEquiv changeForm.associated_neg_proof).symm
       (x : CliffordAlgebra (0 : QuadraticForm R M)) ∈ filtration Q k ↔
@@ -84,8 +84,7 @@ private noncomputable def equivExteriorFiltrationQuotient (Q : QuadraticForm R M
     FiltrationGradedPiece Q (k + 1) ≃ₗ[R]
       FiltrationGradedPiece (0 : QuadraticForm R M) (k + 1) :=
   Submodule.Quotient.equiv _ _ (equivExteriorFiltration Q (k + 1))
-    (by
-      simpa only [filtrationPrevious_succ] using equivExteriorFiltration_map_previous Q k)
+    (equivExteriorFiltration_map_previous Q k)
 
 /-- The successive degree quotient of a Clifford algebra is the corresponding exterior power. -/
 noncomputable def filtrationGradedEquiv (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Names the preceding filtration step restricted to the current Clifford filtration step.

- Defines `filtrationPreviousRestricted` with characteristic membership, degree-zero, and successor equations.
- Expresses `FiltrationGradedPiece` through that named denominator.
- Migrates the existing filtration, exterior, transport, and graded-multiplication consumers.

## Roadmap context

Refines the merged Layer 0 associated-graded implementation:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-0-the-clifford-algebra-its-universal-property-and-the-two-gradings

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/README.md#associated-graded-algebra"}-->

## Verification

Full builds, audits, environment lint, whitespace, downstream bare-`simp` probes, proof golf, and independent exact-head review pass for the original refactor at `78a3514cd02b48ab7dc8a7b9f1bad0c8739dbe64`. The full build, `--iofail`, audits, environment lint, whitespace, proof golf, and independent exact-head review pass for the reuse repair at `b2c7ce001355f917ca6a8be32a214c7356750743`.

## Scale and generality

Changes four existing files by +66/−39 lines. The generic assumptions and quotient semantics are unchanged.

## Scope

- **Consumes:** the merged Clifford filtration and its repeated restricted-denominator expression.
- **Provides:** one named denominator with membership, zero, and successor equations, and migrates its existing consumers.
- **Fits:** stabilizes the shared quotient boundary used by filtration, exterior, transport, and graded multiplication.
- **Boundary:** the refactor changes no quotient semantics or roadmap theorem.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [b8161ef](https://github.com/TauCetiProject/TauCetiReview/commit/b8161ef29f1bf922d3f9aea2b1b1e298bcd06078) · local skill review @ [d3c1151](https://github.com/utensil/formal-land/commit/d3c1151fe4fd4a1ff08035f37517998a1f585ce6) fixed: reuse (1)</sub>