### PR TITLE
feat: restricted power series and strong noetherianness

### DIFF
--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -1,0 +1,359 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.MvPowerSeries.Basic
+public import Mathlib.RingTheory.Noetherian.Basic
+public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
+
+/-!
+# Restricted Power Series
+
+This file defines restricted power series `A⟨T₁, …, Tₖ⟩` and the notion of a strongly
+noetherian ring, following Wedhorn's *Adic Spaces*: the convergent/restricted power series ring is
+(5.6.1) in §5.6; strong noetherianity is Proposition & Definition 6.36 in §6.7.
+
+## Main definitions
+
+* `IsRestrictedAdic`: A power series is **restricted** if its coefficients
+  converge to `0` along the cofinite filter on multi-indices.
+* `restrictedMvPowerSeriesSubring k A`: The subring of restricted power series in `k`
+  variables over `A`, denoted `A⟨T₁, …, Tₖ⟩`.
+* `IsStronglyNoetherian A`: A topological ring `A` is **strongly noetherian** if
+  `restrictedMvPowerSeriesSubring k A` is noetherian for all `k ≥ 0`
+  (Proposition & Definition 6.36 of Wedhorn, stated here with `A`-level restricted
+  series; Definition 6.36(i) verbatim is the condition on the completion `Â` — see
+  `SheafyRing.lean`'s scope notes).
+
+## Provenance
+
+This module is a port of AINTLIB's `projects/AdicSpaces/Adic spaces/RestrictedPowerSeries.lean`,
+the roadmap's designated prior formalisation of this material; the definitions, the statements and
+the convolution argument are all its work. The port moves the declarations into the `TauCeti.Huber`
+namespace, opts into the Lean module system with the definition bodies unexposed — hence the added
+`mem_restrictedMvPowerSeriesSubring` — tracks two Mathlib renames, and drops a `NonarchimedeanRing`
+hypothesis that `isRestrictedAdic_zero` and `isRestrictedAdic_one` never used.
+
+This is *not* Mathlib's `PowerSeries.IsRestricted`, which asks a one-variable series over a ring
+with a linear topology to be restricted with respect to a submodule filtration. `IsRestrictedAdic`
+is Wedhorn's multivariate cofinite-tendsto condition and needs only `NonarchimedeanRing`.
+
+## Implementation notes
+
+The restricted power series ring is defined as a subring of `MvPowerSeries (Fin k) A`
+(the formal power series ring), cut out by the condition that coefficients tend to `0`.
+This is the canonical concrete definition; the opaque/axiom-based placeholders in the
+Scottish Book problem files are replaced by imports from this module.
+
+The closure of the restricted power series under multiplication (convolution) requires
+that `A` is a topological ring. The proof that the convolution of two sequences tending
+to `0` also tends to `0` uses the nonarchimedean property to ensure that
+arbitrary finite sums of elements in an open additive subgroup remain in the subgroup.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], (5.6.1) in §5.6 and Proposition and Definition 6.36
+  in §6.7.
+* [AINTLIB](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
+  `projects/AdicSpaces/Adic spaces/RestrictedPowerSeries.lean`.
+-/
+
+public section
+
+open Filter
+
+universe u
+
+namespace TauCeti.Huber
+
+/-! ### Nonarchimedean ring instance
+
+`NonarchimedeanRing` extends `IsTopologicalRing` and requires the same `is_nonarchimedean`
+condition as `NonarchimedeanAddGroup`. This instance combines the two. -/
+
+/-- A topological ring whose underlying additive group is nonarchimedean is a nonarchimedean
+ring. This bridges `IsTopologicalRing` + `NonarchimedeanAddGroup` to `NonarchimedeanRing`. -/
+instance (priority := 100) NonarchimedeanRing.ofNonarchimedeanAddGroup
+    (R : Type*) [Ring R] [TopologicalSpace R] [IsTopologicalRing R] [NonarchimedeanAddGroup R] :
+    NonarchimedeanRing R where
+  is_nonarchimedean := NonarchimedeanAddGroup.is_nonarchimedean
+
+/-! ### Restricted power series -/
+
+/-- An element `f` of the multivariate power series ring `A⦃X₁, …, Xₖ⦄` is **restricted**
+if its coefficients converge to `0` along the cofinite filter on multi-indices. That is,
+for every open neighborhood `U` of `0` in `A`, all but finitely many coefficients of `f`
+lie in `U`. This is the defining property of elements of `A⟨T₁, …, Tₖ⟩`.
+
+See Wedhorn, (5.6.1) and §6.7. -/
+def IsRestrictedAdic {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+    (f : MvPowerSeries (Fin k) A) : Prop :=
+  Tendsto (fun s : Fin k →₀ ℕ => MvPowerSeries.coeff s f) cofinite (nhds 0)
+
+/-- `0` is restricted: its coefficients are constantly `0`. -/
+theorem isRestrictedAdic_zero (k : ℕ) (A : Type*) [CommRing A] [TopologicalSpace A] :
+    IsRestrictedAdic (0 : MvPowerSeries (Fin k) A) := by
+  change Tendsto _ cofinite (nhds 0)
+  simp only [map_zero]
+  exact tendsto_const_nhds
+
+/-- `1` is restricted: every coefficient but the `0`-th vanishes. -/
+theorem isRestrictedAdic_one (k : ℕ) (A : Type*) [CommRing A] [TopologicalSpace A] :
+    IsRestrictedAdic (1 : MvPowerSeries (Fin k) A) := by
+  change Tendsto _ cofinite (nhds 0)
+  apply tendsto_nhds.mpr
+  intro U hU h0U
+  rw [Filter.mem_cofinite]
+  apply (Set.finite_singleton (0 : Fin k →₀ ℕ)).subset
+  intro s hs
+  simp only [Set.mem_compl_iff, Set.mem_preimage] at hs
+  simp only [Set.mem_singleton_iff]
+  by_contra h
+  exact hs (by rw [MvPowerSeries.coeff_one, if_neg h]; exact h0U)
+
+/-- A sum of restricted series is restricted. -/
+theorem IsRestrictedAdic.add {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+    [NonarchimedeanRing A] {f g : MvPowerSeries (Fin k) A}
+    (hf : IsRestrictedAdic f) (hg : IsRestrictedAdic g) : IsRestrictedAdic (f + g) := by
+  change Tendsto _ cofinite (nhds 0)
+  have : Tendsto (fun s => MvPowerSeries.coeff s f + MvPowerSeries.coeff s g)
+      cofinite (nhds 0) := by
+    rw [show (0 : A) = 0 + 0 from (add_zero 0).symm]
+    exact Filter.Tendsto.add hf hg
+  exact this.congr (fun s => by simp [map_add])
+
+/-- The negation of a restricted series is restricted. -/
+theorem IsRestrictedAdic.neg {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+    [NonarchimedeanRing A] {f : MvPowerSeries (Fin k) A}
+    (hf : IsRestrictedAdic f) : IsRestrictedAdic (-f) := by
+  change Tendsto _ cofinite (nhds 0)
+  have : Tendsto (fun s => -(MvPowerSeries.coeff s f)) cofinite (nhds 0) := by
+    rw [show (0 : A) = -0 from neg_zero.symm]
+    exact Filter.Tendsto.neg hf
+  exact this.congr (fun s => by simp [map_neg])
+
+/-- Restrictedness, restated: for every open additive subgroup `W`, all but finitely many
+coefficients lie in `W`. This is the form the convolution argument actually consumes. -/
+theorem IsRestrictedAdic.finite_coeff_notMem {k : ℕ} {A : Type*} [CommRing A]
+    [TopologicalSpace A] {f : MvPowerSeries (Fin k) A} (hf : IsRestrictedAdic f)
+    (W : OpenAddSubgroup A) : {s | MvPowerSeries.coeff s f ∉ (W : Set A)}.Finite := by
+  have := (tendsto_nhds.mp hf) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
+  rwa [Filter.mem_cofinite] at this
+
+/-- The neighbourhood of `0` used to control a coefficient convolution: inside the open
+subgroup `W`, and small enough that multiplying by any of finitely many fixed coefficients
+lands in `V`. Openness of `V` and `W` plus continuity of multiplication is all this needs. -/
+private theorem inter_preimage_mul_mem_nhds {A : Type*} [CommRing A] [TopologicalSpace A]
+    [NonarchimedeanRing A] {ι : Type*} (V W : OpenAddSubgroup A) (S₁ S₂ : Finset ι)
+    (c₁ c₂ : ι → A) :
+    ((W : Set A) ∩ (⋂ a ∈ S₁, (fun x => c₁ a * x) ⁻¹' (V : Set A))
+        ∩ (⋂ b ∈ S₂, (fun x => x * c₂ b) ⁻¹' (V : Set A))) ∈ nhds (0 : A) := by
+  refine Filter.inter_mem (Filter.inter_mem ?_ ?_) ?_
+  · exact W.isOpen.mem_nhds W.zero_mem
+  · apply (Filter.biInter_finset_mem _).mpr
+    intro a _
+    exact (continuous_const_mul _).continuousAt.preimage_mem_nhds
+      (by simpa using V.isOpen.mem_nhds V.zero_mem)
+  · apply (Filter.biInter_finset_mem _).mpr
+    intro b _
+    exact (continuous_mul_const _).continuousAt.preimage_mem_nhds
+      (by simpa using V.isOpen.mem_nhds V.zero_mem)
+
+/-- The "bad" indices contributed by one side of a coefficient convolution form a finite set:
+for each `a` in a finite `S`, only finitely many `n` have `c (n - a) ∉ T`, and `n ↦ n - a` is
+injective on `{n | a ≤ n}`. Both halves of `IsRestrictedAdic.mul`'s bad set have this shape, with
+the roles of the two series swapped. -/
+private theorem finite_shift_bad_set {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+    (S : Finset (Fin k →₀ ℕ)) (T : Set A) (c : (Fin k →₀ ℕ) → A)
+    (hcT : {s | c s ∉ T}.Finite) : {n | ∃ a ∈ S, a ≤ n ∧ c (n - a) ∉ T}.Finite := by
+  apply Set.Finite.subset (S.finite_toSet.biUnion (fun a _ => hcT.image (· + a)))
+  intro n ⟨a, ha, han, hng⟩
+  simp only [Set.mem_iUnion, Set.mem_image, Finset.mem_coe]
+  exact ⟨a, ha, n - a, hng, tsub_add_cancel_of_le han⟩
+
+/-- Each term of the coefficient convolution lands in `V`. The trichotomy is on where the two
+factors sit relative to `W`: if either is outside `W` then the *other* is in `T` by the
+bad-set hypotheses, and `hT_left` / `hT_right` apply; if both are inside `W` then `hWV` does. -/
+private theorem coeff_mul_mem_of_forall_mem {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+    {f g : MvPowerSeries (Fin k) A} (V W : OpenAddSubgroup A) (T : Set A)
+    (hWV : ∀ x ∈ (W : Set A), ∀ y ∈ (W : Set A), x * y ∈ (V : Set A))
+    (hT_left : ∀ a, MvPowerSeries.coeff a f ∉ (W : Set A) →
+      ∀ y ∈ T, MvPowerSeries.coeff a f * y ∈ (V : Set A))
+    (hT_right : ∀ b, MvPowerSeries.coeff b g ∉ (W : Set A) →
+      ∀ x ∈ T, x * MvPowerSeries.coeff b g ∈ (V : Set A))
+    (n : Fin k →₀ ℕ)
+    (hnB1 : ∀ a, MvPowerSeries.coeff a f ∉ (W : Set A) → a ≤ n →
+      MvPowerSeries.coeff (n - a) g ∈ T)
+    (hnB2 : ∀ b, MvPowerSeries.coeff b g ∉ (W : Set A) → b ≤ n →
+      MvPowerSeries.coeff (n - b) f ∈ T) :
+    MvPowerSeries.coeff n (f * g) ∈ (V : Set A) := by
+  classical
+  rw [SetLike.mem_coe]
+  rw [show MvPowerSeries.coeff n (f * g) =
+    ∑ p ∈ Finset.antidiagonal n,
+      MvPowerSeries.coeff p.1 f * MvPowerSeries.coeff p.2 g
+    from MvPowerSeries.coeff_mul (n := n) (φ := f) (ψ := g)]
+  apply V.toAddSubgroup.sum_mem
+  intro ⟨a, b⟩ hab
+  rw [Finset.mem_antidiagonal] at hab
+  by_cases haS : MvPowerSeries.coeff a f ∉ (W : Set A)
+  · have hab_le : a ≤ n := hab ▸ le_add_right le_rfl
+    have hb_eq : b = n - a := by rw [← hab]; exact (add_tsub_cancel_left a b).symm
+    have hgT_b : MvPowerSeries.coeff b g ∈ T := by rw [hb_eq]; exact hnB1 a haS hab_le
+    exact SetLike.mem_coe.mp (hT_left a haS _ hgT_b)
+  · by_cases hbS : MvPowerSeries.coeff b g ∉ (W : Set A)
+    · have hb_le : b ≤ n := hab ▸ le_add_left le_rfl
+      have ha_eq : a = n - b := by rw [← hab]; exact (add_tsub_cancel_right a b).symm
+      have hfT_a : MvPowerSeries.coeff a f ∈ T := by rw [ha_eq]; exact hnB2 b hbS hb_le
+      exact SetLike.mem_coe.mp (hT_right b hbS _ hfT_a)
+    · exact SetLike.mem_coe.mp (hWV _ (not_not.mp haS) _ (not_not.mp hbS))
+
+
+/-- A product of restricted series is restricted. This is the only field of
+`restrictedMvPowerSeriesSubring` that needs `A` nonarchimedean: the coefficient convolution is
+a finite sum, and it is nonarchimedeanness that keeps such a sum inside an open subgroup. -/
+theorem IsRestrictedAdic.mul {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+    [NonarchimedeanRing A] {f g : MvPowerSeries (Fin k) A}
+    (hf : IsRestrictedAdic f) (hg : IsRestrictedAdic g) : IsRestrictedAdic (f * g) := by
+  classical
+  change Tendsto _ cofinite (nhds 0)
+  rw [tendsto_nhds]
+  intro U hU h0U
+  rw [Filter.mem_cofinite]
+  obtain ⟨V, hVU⟩ := NonarchimedeanAddGroup.is_nonarchimedean U (hU.mem_nhds h0U)
+  obtain ⟨W, hWV⟩ := NonarchimedeanRing.mul_subset V
+  set Sf := {s | MvPowerSeries.coeff s f ∉ (W : Set A)}
+  set Sg := {s | MvPowerSeries.coeff s g ∉ (W : Set A)}
+  have hSf : Sf.Finite := hf.finite_coeff_notMem W
+  have hSg : Sg.Finite := hg.finite_coeff_notMem W
+  set T := (W : Set A) ∩
+    (⋂ a ∈ hSf.toFinset,
+      (fun x => MvPowerSeries.coeff a f * x) ⁻¹' (V : Set A)) ∩
+    (⋂ b ∈ hSg.toFinset,
+      (fun x => x * MvPowerSeries.coeff b g) ⁻¹' (V : Set A))
+  have hT_nhds : T ∈ nhds (0 : A) :=
+    inter_preimage_mul_mem_nhds V W hSf.toFinset hSg.toFinset
+      (fun a => MvPowerSeries.coeff a f) (fun b => MvPowerSeries.coeff b g)
+  have hT_left : ∀ a ∈ hSf.toFinset, ∀ y ∈ T,
+      MvPowerSeries.coeff a f * y ∈ (V : Set A) := by
+    intro a ha y hy
+    exact (Set.mem_iInter₂.mp hy.1.2 a ha : _)
+  have hT_right : ∀ b ∈ hSg.toFinset, ∀ x ∈ T,
+      x * MvPowerSeries.coeff b g ∈ (V : Set A) := by
+    intro b hb x hx
+    exact (Set.mem_iInter₂.mp hx.2 b hb : _)
+  have hgT : {s | MvPowerSeries.coeff s g ∉ T}.Finite :=
+    (Filter.mem_cofinite.mp (hg hT_nhds)).subset (fun s hs => hs)
+  have hfT : {s | MvPowerSeries.coeff s f ∉ T}.Finite :=
+    (Filter.mem_cofinite.mp (hf hT_nhds)).subset (fun s hs => hs)
+  set B := {n | ∃ a ∈ hSf.toFinset, a ≤ n ∧ MvPowerSeries.coeff (n - a) g ∉ T} ∪
+           {n | ∃ b ∈ hSg.toFinset, b ≤ n ∧ MvPowerSeries.coeff (n - b) f ∉ T}
+  have hB_finite : B.Finite :=
+    (finite_shift_bad_set _ _ _ hgT).union (finite_shift_bad_set _ _ _ hfT)
+  apply hB_finite.subset
+  intro n hn
+  simp only [Set.mem_compl_iff, Set.mem_preimage] at hn
+  by_contra hnB
+  apply hn; clear hn
+  simp only [B, Set.mem_union, Set.mem_ofPred_eq, not_or, not_exists, not_and] at hnB
+  obtain ⟨hnB1, hnB2⟩ := hnB
+  exact hVU (coeff_mul_mem_of_forall_mem V W T
+    (fun x hx y hy => hWV ⟨x, hx, y, hy, rfl⟩)
+    (fun a ha => hT_left a (hSf.mem_toFinset.mpr ha))
+    (fun b hb => hT_right b (hSg.mem_toFinset.mpr hb))
+    n
+    (fun a ha han => not_not.mp (hnB1 a (hSf.mem_toFinset.mpr ha) han))
+    (fun b hb hbn => not_not.mp (hnB2 b (hSg.mem_toFinset.mpr hb) hbn)))
+
+/-- The set of restricted power series forms a subring of `MvPowerSeries (Fin k) A`.
+
+The closure under multiplication (convolution of tendsto-0 coefficient sequences)
+requires that `A` is a nonarchimedean topological ring (so that finite sums of elements in an
+open additive subgroup remain in the subgroup). This is the canonical definition of
+`A⟨T₁, …, Tₖ⟩` (Wedhorn, (5.6.1)/§5.6). -/
+def restrictedMvPowerSeriesSubring (k : ℕ) (A : Type*) [CommRing A] [TopologicalSpace A]
+    [NonarchimedeanRing A] : Subring (MvPowerSeries (Fin k) A) where
+  carrier := {f | IsRestrictedAdic f}
+  zero_mem' := isRestrictedAdic_zero k A
+  one_mem' := isRestrictedAdic_one k A
+  add_mem' := IsRestrictedAdic.add
+  neg_mem' := IsRestrictedAdic.neg
+  mul_mem' := IsRestrictedAdic.mul
+
+/-- Membership in `A⟨T₁, …, Tₖ⟩` is restrictedness. -/
+@[simp]
+theorem mem_restrictedMvPowerSeriesSubring {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+    [NonarchimedeanRing A] {f : MvPowerSeries (Fin k) A} :
+    f ∈ restrictedMvPowerSeriesSubring k A ↔ IsRestrictedAdic f := (Iff.rfl)
+
+/-! ### Algebra instance -/
+
+/-- Constant power series are restricted: the `algebraMap` image of any `a : A` has
+coefficient `a` at multi-index `0` and `0` elsewhere, so it trivially tends to `0`. -/
+theorem isRestrictedAdic_algebraMap {k : ℕ} {A : Type*} [CommRing A]
+    [TopologicalSpace A] (a : A) :
+    IsRestrictedAdic (algebraMap A (MvPowerSeries (Fin k) A) a) := by
+  change Tendsto _ cofinite (nhds 0)
+  apply tendsto_nhds.mpr
+  intro U hU h0U
+  rw [Filter.mem_cofinite]
+  apply (Set.finite_singleton (0 : Fin k →₀ ℕ)).subset
+  intro s hs
+  simp only [Set.mem_compl_iff, Set.mem_preimage] at hs
+  simp only [Set.mem_singleton_iff]
+  by_contra h
+  exact hs (by rw [MvPowerSeries.algebraMap_apply, MvPowerSeries.coeff_C, if_neg h]; exact h0U)
+
+/-- The restricted power series subring inherits an `A`-algebra structure from the
+`MvPowerSeries` algebra instance, since constant power series are restricted. -/
+noncomputable instance restrictedMvPowerSeriesSubring.instAlgebra (k : ℕ) (A : Type*)
+    [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A] :
+    Algebra A (restrictedMvPowerSeriesSubring k A) :=
+  RingHom.toAlgebra
+    { toFun := fun a => ⟨algebraMap A (MvPowerSeries (Fin k) A) a,
+        mem_restrictedMvPowerSeriesSubring.mpr (isRestrictedAdic_algebraMap a)⟩
+      map_one' := by ext; simp only [map_one, OneMemClass.coe_one]
+      map_mul' := by intros; ext; simp only [map_mul, Subring.coe_mul]
+      map_zero' := by ext; simp only [map_zero, ZeroMemClass.coe_zero]
+      map_add' := by intros; ext; simp only [map_add, Subring.coe_add] }
+
+/-! ### Strongly noetherian rings -/
+
+/-- A topological ring `A` is **strongly noetherian** if the ring of restricted power series
+`A⟨T₁, …, Tₖ⟩` is noetherian for all `k ≥ 0` (Proposition & Definition 6.36 of Wedhorn, stated here
+  with `A`-level restricted
+  series; Definition 6.36(i) verbatim is the condition on the completion `Â` — see
+  `SheafyRing.lean`'s scope notes).
+
+This is a fundamental finiteness condition in nonarchimedean geometry, introduced by
+Huber. For a noetherian Tate ring, being strongly noetherian is equivalent to saying
+that the theory of formal models is well-behaved. -/
+class IsStronglyNoetherian (A : Type*) [CommRing A] [TopologicalSpace A]
+    [NonarchimedeanRing A] : Prop where
+  /-- The restricted power series ring in `k` variables is noetherian for all `k`. -/
+  isNoetherianRing_restricted : ∀ k : ℕ,
+    IsNoetherianRing (restrictedMvPowerSeriesSubring k A)
+
+/-- **Strongly noetherian implies noetherian** — the `k = 0` case: the index set
+`Fin 0 →₀ ℕ` is a singleton, so its cofinite filter is `⊥` and every power series in
+zero variables is restricted; `constantCoeff` is then a ring surjection
+`A⟨⟩ = A⦃⦄ → A`. -/
+theorem IsStronglyNoetherian.isNoetherianRing (A : Type*) [CommRing A]
+    [TopologicalSpace A] [NonarchimedeanRing A] [IsStronglyNoetherian A] :
+    IsNoetherianRing A := by
+  have h0 : IsNoetherianRing (restrictedMvPowerSeriesSubring 0 A) :=
+    IsStronglyNoetherian.isNoetherianRing_restricted 0
+  refine isNoetherianRing_of_surjective (restrictedMvPowerSeriesSubring 0 A) A
+    ((MvPowerSeries.constantCoeff (σ := Fin 0) (R := A)).comp
+      (restrictedMvPowerSeriesSubring 0 A).subtype) ?_
+  intro a
+  refine ⟨⟨MvPowerSeries.C (σ := Fin 0) (R := A) a, ?_⟩, ?_⟩
+  -- unfolds `IsRestrictedAdic` to the `Tendsto` it abbreviates
+  · change Filter.Tendsto _ _ _
+    rw [Filter.cofinite_eq_bot]
+    exact Filter.tendsto_bot
+  · simp [MvPowerSeries.constantCoeff_C]
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -108,7 +108,7 @@ theorem isRestrictedAdic_one (k : ℕ) (A : Type*) [CommRing A] [TopologicalSpac
 
 /-- A sum of restricted series is restricted. -/
 theorem IsRestrictedAdic.add {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
-    [NonarchimedeanRing A] {f g : MvPowerSeries (Fin k) A}
+    [ContinuousAdd A] {f g : MvPowerSeries (Fin k) A}
     (hf : IsRestrictedAdic f) (hg : IsRestrictedAdic g) : IsRestrictedAdic (f + g) := by
   change Tendsto _ cofinite (nhds 0)
   have : Tendsto (fun s => MvPowerSeries.coeff s f + MvPowerSeries.coeff s g)
@@ -119,7 +119,7 @@ theorem IsRestrictedAdic.add {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpac
 
 /-- The negation of a restricted series is restricted. -/
 theorem IsRestrictedAdic.neg {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
-    [NonarchimedeanRing A] {f : MvPowerSeries (Fin k) A}
+    [ContinuousNeg A] {f : MvPowerSeries (Fin k) A}
     (hf : IsRestrictedAdic f) : IsRestrictedAdic (-f) := by
   change Tendsto _ cofinite (nhds 0)
   have : Tendsto (fun s => -(MvPowerSeries.coeff s f)) cofinite (nhds 0) := by

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -95,14 +95,14 @@ theorem isRestricted_iff {k : ℕ} {A : Type*} [Semiring A] [TopologicalSpace A]
 /-- `0` is restricted: its coefficients are constantly `0`. -/
 theorem isRestricted_zero (k : ℕ) (A : Type*) [Semiring A] [TopologicalSpace A] :
     IsRestricted (0 : MvPowerSeries (Fin k) A) := by
-  change Tendsto _ cofinite (nhds 0)
+  rw [isRestricted_iff]
   simp only [map_zero]
   exact tendsto_const_nhds
 
 /-- `1` is restricted: every coefficient but the `0`-th vanishes. -/
 theorem isRestricted_one (k : ℕ) (A : Type*) [Semiring A] [TopologicalSpace A] :
     IsRestricted (1 : MvPowerSeries (Fin k) A) := by
-  change Tendsto _ cofinite (nhds 0)
+  rw [isRestricted_iff]
   apply tendsto_nhds.mpr
   intro U hU h0U
   rw [Filter.mem_cofinite]
@@ -117,21 +117,18 @@ theorem isRestricted_one (k : ℕ) (A : Type*) [Semiring A] [TopologicalSpace A]
 theorem IsRestricted.add {k : ℕ} {A : Type*} [Semiring A] [TopologicalSpace A]
     [ContinuousAdd A] {f g : MvPowerSeries (Fin k) A}
     (hf : IsRestricted f) (hg : IsRestricted g) : IsRestricted (f + g) := by
-  change Tendsto _ cofinite (nhds 0)
+  rw [isRestricted_iff]
   have : Tendsto (fun s => MvPowerSeries.coeff s f + MvPowerSeries.coeff s g)
-      cofinite (nhds 0) := by
-    rw [show (0 : A) = 0 + 0 from (add_zero 0).symm]
-    exact Filter.Tendsto.add hf hg
+      cofinite (nhds 0) := by simpa using Filter.Tendsto.add hf hg
   exact this.congr (fun s => by simp [map_add])
 
 /-- The negation of a restricted series is restricted. -/
 theorem IsRestricted.neg {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
     [ContinuousNeg A] {f : MvPowerSeries (Fin k) A}
     (hf : IsRestricted f) : IsRestricted (-f) := by
-  change Tendsto _ cofinite (nhds 0)
+  rw [isRestricted_iff]
   have : Tendsto (fun s => -(MvPowerSeries.coeff s f)) cofinite (nhds 0) := by
-    rw [show (0 : A) = -0 from neg_zero.symm]
-    exact Filter.Tendsto.neg hf
+    simpa using Filter.Tendsto.neg hf
   exact this.congr (fun s => by simp [map_neg])
 
 /-- Restrictedness, restated: for every open additive subgroup `W`, all but finitely many
@@ -191,10 +188,7 @@ private theorem coeff_mul_mem_of_forall_mem {k : ℕ} {A : Type*} [Ring A] [Topo
     MvPowerSeries.coeff n (f * g) ∈ (V : Set A) := by
   classical
   rw [SetLike.mem_coe]
-  rw [show MvPowerSeries.coeff n (f * g) =
-    ∑ p ∈ Finset.antidiagonal n,
-      MvPowerSeries.coeff p.1 f * MvPowerSeries.coeff p.2 g
-    from MvPowerSeries.coeff_mul (n := n) (φ := f) (ψ := g)]
+  rw [MvPowerSeries.coeff_mul]
   apply V.toAddSubgroup.sum_mem
   intro ⟨a, b⟩ hab
   rw [Finset.mem_antidiagonal] at hab
@@ -218,7 +212,7 @@ theorem IsRestricted.mul {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
     [NonarchimedeanRing A] {f g : MvPowerSeries (Fin k) A}
     (hf : IsRestricted f) (hg : IsRestricted g) : IsRestricted (f * g) := by
   classical
-  change Tendsto _ cofinite (nhds 0)
+  rw [isRestricted_iff]
   rw [tendsto_nhds]
   intro U hU h0U
   rw [Filter.mem_cofinite]
@@ -295,7 +289,7 @@ coefficient `a` at multi-index `0` and `0` elsewhere, so it trivially tends to `
 theorem isRestricted_algebraMap {k : ℕ} {A : Type*} [CommRing A]
     [TopologicalSpace A] (a : A) :
     IsRestricted (algebraMap A (MvPowerSeries (Fin k) A) a) := by
-  change Tendsto _ cofinite (nhds 0)
+  rw [isRestricted_iff]
   apply tendsto_nhds.mpr
   intro U hU h0U
   rw [Filter.mem_cofinite]

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -81,6 +81,7 @@ theorem isRestricted_iff {k : ℕ} {A : Type*} [Semiring A] [TopologicalSpace A]
       Tendsto (fun s : Fin k →₀ ℕ => MvPowerSeries.coeff s f) cofinite (nhds 0) := (Iff.rfl)
 
 /-- `0` is restricted: its coefficients are constantly `0`. -/
+@[simp]
 theorem isRestricted_zero (k : ℕ) (A : Type*) [Semiring A] [TopologicalSpace A] :
     IsRestricted (0 : MvPowerSeries (Fin k) A) := by
   rw [isRestricted_iff]
@@ -88,6 +89,7 @@ theorem isRestricted_zero (k : ℕ) (A : Type*) [Semiring A] [TopologicalSpace A
   exact tendsto_const_nhds
 
 /-- `1` is restricted: every coefficient but the `0`-th vanishes. -/
+@[simp]
 theorem isRestricted_one (k : ℕ) (A : Type*) [Semiring A] [TopologicalSpace A] :
     IsRestricted (1 : MvPowerSeries (Fin k) A) := by
   rw [isRestricted_iff]
@@ -132,7 +134,7 @@ theorem IsRestricted.finite_coeff_notMem {k : ℕ} {A : Type*} [Ring A]
 subgroup `W`, and small enough that multiplying by any of finitely many fixed coefficients
 lands in `V`. Openness of `V` and `W` plus continuity of multiplication is all this needs. -/
 private theorem inter_preimage_mul_mem_nhds {A : Type*} [Ring A] [TopologicalSpace A]
-    [NonarchimedeanRing A] {ι : Type*} (V W : OpenAddSubgroup A) (S₁ S₂ : Finset ι)
+    [ContinuousMul A] {ι : Type*} (V W : OpenAddSubgroup A) (S₁ S₂ : Finset ι)
     (c₁ c₂ : ι → A) :
     ((W : Set A) ∩ (⋂ a ∈ S₁, (fun x => c₁ a * x) ⁻¹' (V : Set A))
         ∩ (⋂ b ∈ S₂, (fun x => x * c₂ b) ⁻¹' (V : Set A))) ∈ nhds (0 : A) := by
@@ -151,7 +153,7 @@ private theorem inter_preimage_mul_mem_nhds {A : Type*} [Ring A] [TopologicalSpa
 for each `a` in a finite `S`, only finitely many `n` have `c (n - a) ∉ T`, and `n ↦ n - a` is
 injective on `{n | a ≤ n}`. Both halves of `IsRestricted.mul`'s bad set have this shape, with
 the roles of the two series swapped. -/
-private theorem finite_shift_bad_set {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
+private theorem finite_shift_bad_set {k : ℕ} {A : Type*}
     (S : Finset (Fin k →₀ ℕ)) (T : Set A) (c : (Fin k →₀ ℕ) → A)
     (hcT : {s | c s ∉ T}.Finite) : {n | ∃ a ∈ S, a ≤ n ∧ c (n - a) ∉ T}.Finite := by
   apply Set.Finite.subset (S.finite_toSet.biUnion (fun a _ => hcT.image (· + a)))
@@ -228,9 +230,9 @@ theorem IsRestricted.mul {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
     intro b hb x hx
     exact (Set.mem_iInter₂.mp hx.2 b hb : _)
   have hgT : {s | MvPowerSeries.coeff s g ∉ T}.Finite :=
-    (Filter.mem_cofinite.mp (hg hT_nhds)).subset (fun s hs => hs)
+    (Filter.mem_cofinite.mp (isRestricted_iff.mp hg hT_nhds)).subset (fun s hs => hs)
   have hfT : {s | MvPowerSeries.coeff s f ∉ T}.Finite :=
-    (Filter.mem_cofinite.mp (hf hT_nhds)).subset (fun s hs => hs)
+    (Filter.mem_cofinite.mp (isRestricted_iff.mp hf hT_nhds)).subset (fun s hs => hs)
   set B := {n | ∃ a ∈ hSf.toFinset, a ≤ n ∧ MvPowerSeries.coeff (n - a) g ∉ T} ∪
            {n | ∃ b ∈ hSg.toFinset, b ≤ n ∧ MvPowerSeries.coeff (n - b) f ∉ T}
   have hB_finite : B.Finite :=
@@ -275,6 +277,7 @@ theorem mem_restrictedMvPowerSeriesSubring {k : ℕ} {A : Type*} [Ring A] [Topol
 
 /-- Constant power series are restricted: the `algebraMap` image of any `a : A` has
 coefficient `a` at multi-index `0` and `0` elsewhere, so it trivially tends to `0`. -/
+@[simp]
 theorem isRestricted_algebraMap {k : ℕ} {A : Type*} [CommSemiring A]
     [TopologicalSpace A] (a : A) :
     IsRestricted (algebraMap A (MvPowerSeries (Fin k) A) a) := by

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -61,18 +61,6 @@ universe u
 
 namespace TauCeti.Huber
 
-/-! ### Nonarchimedean ring instance
-
-`NonarchimedeanRing` extends `IsTopologicalRing` and requires the same `is_nonarchimedean`
-condition as `NonarchimedeanAddGroup`. This instance combines the two. -/
-
-/-- A topological ring whose underlying additive group is nonarchimedean is a nonarchimedean
-ring. This bridges `IsTopologicalRing` + `NonarchimedeanAddGroup` to `NonarchimedeanRing`. -/
-instance (priority := 100) NonarchimedeanRing.ofNonarchimedeanAddGroup
-    (R : Type*) [Ring R] [TopologicalSpace R] [IsTopologicalRing R] [NonarchimedeanAddGroup R] :
-    NonarchimedeanRing R where
-  is_nonarchimedean := NonarchimedeanAddGroup.is_nonarchimedean
-
 /-! ### Restricted power series -/
 
 /-- An element `f` of the multivariate power series ring `A⦃X₁, …, Xₖ⦄` is **restricted**
@@ -119,7 +107,8 @@ theorem IsRestricted.add {k : ℕ} {A : Type*} [Semiring A] [TopologicalSpace A]
     (hf : IsRestricted f) (hg : IsRestricted g) : IsRestricted (f + g) := by
   rw [isRestricted_iff]
   have : Tendsto (fun s => MvPowerSeries.coeff s f + MvPowerSeries.coeff s g)
-      cofinite (nhds 0) := by simpa using Filter.Tendsto.add hf hg
+      cofinite (nhds 0) := by
+    simpa using (isRestricted_iff.mp hf).add (isRestricted_iff.mp hg)
   exact this.congr (fun s => by simp [map_add])
 
 /-- The negation of a restricted series is restricted. -/
@@ -128,7 +117,7 @@ theorem IsRestricted.neg {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
     (hf : IsRestricted f) : IsRestricted (-f) := by
   rw [isRestricted_iff]
   have : Tendsto (fun s => -(MvPowerSeries.coeff s f)) cofinite (nhds 0) := by
-    simpa using Filter.Tendsto.neg hf
+    simpa using (isRestricted_iff.mp hf).neg
   exact this.congr (fun s => by simp [map_neg])
 
 /-- Restrictedness, restated: for every open additive subgroup `W`, all but finitely many
@@ -136,7 +125,7 @@ coefficients lie in `W`. This is the form the convolution argument actually cons
 theorem IsRestricted.finite_coeff_notMem {k : ℕ} {A : Type*} [Ring A]
     [TopologicalSpace A] {f : MvPowerSeries (Fin k) A} (hf : IsRestricted f)
     (W : OpenAddSubgroup A) : {s | MvPowerSeries.coeff s f ∉ (W : Set A)}.Finite := by
-  have := (tendsto_nhds.mp hf) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
+  have := (tendsto_nhds.mp (isRestricted_iff.mp hf)) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
   rwa [Filter.mem_cofinite] at this
 
 /-- The neighbourhood of `0` used to control a coefficient convolution: inside the open
@@ -286,7 +275,7 @@ theorem mem_restrictedMvPowerSeriesSubring {k : ℕ} {A : Type*} [Ring A] [Topol
 
 /-- Constant power series are restricted: the `algebraMap` image of any `a : A` has
 coefficient `a` at multi-index `0` and `0` elsewhere, so it trivially tends to `0`. -/
-theorem isRestricted_algebraMap {k : ℕ} {A : Type*} [CommRing A]
+theorem isRestricted_algebraMap {k : ℕ} {A : Type*} [CommSemiring A]
     [TopologicalSpace A] (a : A) :
     IsRestricted (algebraMap A (MvPowerSeries (Fin k) A) a) := by
   rw [isRestricted_iff]
@@ -312,5 +301,15 @@ noncomputable instance restrictedMvPowerSeriesSubring.instAlgebra (k : ℕ) (A :
       map_mul' := by intros; ext; simp only [map_mul, Subring.coe_mul]
       map_zero' := by ext; simp only [map_zero, ZeroMemClass.coe_zero]
       map_add' := by intros; ext; simp only [map_add, Subring.coe_add] }
+
+/-- The algebra structure on `A⟨T₁, …, Tₖ⟩` is the one inherited from `MvPowerSeries`: a constant
+is sent to the constant power series. This characterises the instance, whose body is not
+exposed. -/
+@[simp]
+theorem coe_algebraMap_restrictedMvPowerSeriesSubring {k : ℕ} {A : Type*} [CommRing A]
+    [TopologicalSpace A] [NonarchimedeanRing A] (a : A) :
+    ((algebraMap A (restrictedMvPowerSeriesSubring k A) a :
+        restrictedMvPowerSeriesSubring k A) : MvPowerSeries (Fin k) A) =
+      algebraMap A (MvPowerSeries (Fin k) A) a := (rfl)
 
 end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.MvPowerSeries.Basic
-public import Mathlib.RingTheory.Noetherian.Basic
 public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
 
 /-!
@@ -16,7 +15,7 @@ where the convergent/restricted power series ring is (5.6.1) in §5.6.
 
 ## Main definitions
 
-* `IsRestrictedAdic`: A power series is **restricted** if its coefficients
+* `IsRestricted`: A power series is **restricted** if its coefficients
   converge to `0` along the cofinite filter on multi-indices.
 * `restrictedMvPowerSeriesSubring k A`: The subring of restricted power series in `k`
   variables over `A`, denoted `A⟨T₁, …, Tₖ⟩`.
@@ -27,19 +26,20 @@ This module is a port of AINTLIB's `projects/AdicSpaces/Adic spaces/RestrictedPo
 the roadmap's designated prior formalisation of this material; the definitions, the statements and
 the convolution argument are all its work. The port moves the declarations into the `TauCeti.Huber`
 namespace, opts into the Lean module system with the definition bodies unexposed — hence the added
-`mem_restrictedMvPowerSeriesSubring` — tracks two Mathlib renames, and drops a `NonarchimedeanRing`
-hypothesis that `isRestrictedAdic_zero` and `isRestrictedAdic_one` never used.
+`isRestricted_iff` and `mem_restrictedMvPowerSeriesSubring` — tracks the Mathlib rename of
+`Set.mem_setOf_eq` to `Set.mem_ofPred_eq`, renames the predicate from AINTLIB's `IsRestrictedAdic`
+(nothing here is adic), and drops hypotheses that the individual proofs never used.
 
 This is *not* Mathlib's `PowerSeries.IsRestricted`, which asks a one-variable series over a ring
-with a linear topology to be restricted with respect to a submodule filtration. `IsRestrictedAdic`
-is Wedhorn's multivariate cofinite-tendsto condition and needs only `NonarchimedeanRing`.
+with a linear topology to be restricted with respect to a submodule filtration. `IsRestricted`
+here is Wedhorn's multivariate cofinite-tendsto condition, and needs only a topology on `A`; the
+nonarchimedean hypothesis enters only for closure under multiplication and hence for the subring.
 
 ## Implementation notes
 
 The restricted power series ring is defined as a subring of `MvPowerSeries (Fin k) A`
 (the formal power series ring), cut out by the condition that coefficients tend to `0`.
-This is the canonical concrete definition; the opaque/axiom-based placeholders in the
-Scottish Book problem files are replaced by imports from this module.
+This is the canonical concrete definition.
 
 The closure of the restricted power series under multiplication (convolution) requires
 that `A` is a topological ring. The proof that the convolution of two sequences tending
@@ -81,20 +81,27 @@ for every open neighborhood `U` of `0` in `A`, all but finitely many coefficient
 lie in `U`. This is the defining property of elements of `A⟨T₁, …, Tₖ⟩`.
 
 See Wedhorn, (5.6.1) and §6.7. -/
-def IsRestrictedAdic {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+def IsRestricted {k : ℕ} {A : Type*} [Semiring A] [TopologicalSpace A]
     (f : MvPowerSeries (Fin k) A) : Prop :=
   Tendsto (fun s : Fin k →₀ ℕ => MvPowerSeries.coeff s f) cofinite (nhds 0)
 
+/-- Unfolding lemma for `TauCeti.Huber.IsRestricted`: the body is not exposed, so this is how
+consumers recover the defining convergence condition. -/
+theorem isRestricted_iff {k : ℕ} {A : Type*} [Semiring A] [TopologicalSpace A]
+    {f : MvPowerSeries (Fin k) A} :
+    IsRestricted f ↔
+      Tendsto (fun s : Fin k →₀ ℕ => MvPowerSeries.coeff s f) cofinite (nhds 0) := (Iff.rfl)
+
 /-- `0` is restricted: its coefficients are constantly `0`. -/
-theorem isRestrictedAdic_zero (k : ℕ) (A : Type*) [CommRing A] [TopologicalSpace A] :
-    IsRestrictedAdic (0 : MvPowerSeries (Fin k) A) := by
+theorem isRestricted_zero (k : ℕ) (A : Type*) [Semiring A] [TopologicalSpace A] :
+    IsRestricted (0 : MvPowerSeries (Fin k) A) := by
   change Tendsto _ cofinite (nhds 0)
   simp only [map_zero]
   exact tendsto_const_nhds
 
 /-- `1` is restricted: every coefficient but the `0`-th vanishes. -/
-theorem isRestrictedAdic_one (k : ℕ) (A : Type*) [CommRing A] [TopologicalSpace A] :
-    IsRestrictedAdic (1 : MvPowerSeries (Fin k) A) := by
+theorem isRestricted_one (k : ℕ) (A : Type*) [Semiring A] [TopologicalSpace A] :
+    IsRestricted (1 : MvPowerSeries (Fin k) A) := by
   change Tendsto _ cofinite (nhds 0)
   apply tendsto_nhds.mpr
   intro U hU h0U
@@ -107,9 +114,9 @@ theorem isRestrictedAdic_one (k : ℕ) (A : Type*) [CommRing A] [TopologicalSpac
   exact hs (by rw [MvPowerSeries.coeff_one, if_neg h]; exact h0U)
 
 /-- A sum of restricted series is restricted. -/
-theorem IsRestrictedAdic.add {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+theorem IsRestricted.add {k : ℕ} {A : Type*} [Semiring A] [TopologicalSpace A]
     [ContinuousAdd A] {f g : MvPowerSeries (Fin k) A}
-    (hf : IsRestrictedAdic f) (hg : IsRestrictedAdic g) : IsRestrictedAdic (f + g) := by
+    (hf : IsRestricted f) (hg : IsRestricted g) : IsRestricted (f + g) := by
   change Tendsto _ cofinite (nhds 0)
   have : Tendsto (fun s => MvPowerSeries.coeff s f + MvPowerSeries.coeff s g)
       cofinite (nhds 0) := by
@@ -118,9 +125,9 @@ theorem IsRestrictedAdic.add {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpac
   exact this.congr (fun s => by simp [map_add])
 
 /-- The negation of a restricted series is restricted. -/
-theorem IsRestrictedAdic.neg {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+theorem IsRestricted.neg {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
     [ContinuousNeg A] {f : MvPowerSeries (Fin k) A}
-    (hf : IsRestrictedAdic f) : IsRestrictedAdic (-f) := by
+    (hf : IsRestricted f) : IsRestricted (-f) := by
   change Tendsto _ cofinite (nhds 0)
   have : Tendsto (fun s => -(MvPowerSeries.coeff s f)) cofinite (nhds 0) := by
     rw [show (0 : A) = -0 from neg_zero.symm]
@@ -129,8 +136,8 @@ theorem IsRestrictedAdic.neg {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpac
 
 /-- Restrictedness, restated: for every open additive subgroup `W`, all but finitely many
 coefficients lie in `W`. This is the form the convolution argument actually consumes. -/
-theorem IsRestrictedAdic.finite_coeff_notMem {k : ℕ} {A : Type*} [CommRing A]
-    [TopologicalSpace A] {f : MvPowerSeries (Fin k) A} (hf : IsRestrictedAdic f)
+theorem IsRestricted.finite_coeff_notMem {k : ℕ} {A : Type*} [Ring A]
+    [TopologicalSpace A] {f : MvPowerSeries (Fin k) A} (hf : IsRestricted f)
     (W : OpenAddSubgroup A) : {s | MvPowerSeries.coeff s f ∉ (W : Set A)}.Finite := by
   have := (tendsto_nhds.mp hf) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
   rwa [Filter.mem_cofinite] at this
@@ -138,7 +145,7 @@ theorem IsRestrictedAdic.finite_coeff_notMem {k : ℕ} {A : Type*} [CommRing A]
 /-- The neighbourhood of `0` used to control a coefficient convolution: inside the open
 subgroup `W`, and small enough that multiplying by any of finitely many fixed coefficients
 lands in `V`. Openness of `V` and `W` plus continuity of multiplication is all this needs. -/
-private theorem inter_preimage_mul_mem_nhds {A : Type*} [CommRing A] [TopologicalSpace A]
+private theorem inter_preimage_mul_mem_nhds {A : Type*} [Ring A] [TopologicalSpace A]
     [NonarchimedeanRing A] {ι : Type*} (V W : OpenAddSubgroup A) (S₁ S₂ : Finset ι)
     (c₁ c₂ : ι → A) :
     ((W : Set A) ∩ (⋂ a ∈ S₁, (fun x => c₁ a * x) ⁻¹' (V : Set A))
@@ -156,9 +163,9 @@ private theorem inter_preimage_mul_mem_nhds {A : Type*} [CommRing A] [Topologica
 
 /-- The "bad" indices contributed by one side of a coefficient convolution form a finite set:
 for each `a` in a finite `S`, only finitely many `n` have `c (n - a) ∉ T`, and `n ↦ n - a` is
-injective on `{n | a ≤ n}`. Both halves of `IsRestrictedAdic.mul`'s bad set have this shape, with
+injective on `{n | a ≤ n}`. Both halves of `IsRestricted.mul`'s bad set have this shape, with
 the roles of the two series swapped. -/
-private theorem finite_shift_bad_set {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+private theorem finite_shift_bad_set {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
     (S : Finset (Fin k →₀ ℕ)) (T : Set A) (c : (Fin k →₀ ℕ) → A)
     (hcT : {s | c s ∉ T}.Finite) : {n | ∃ a ∈ S, a ≤ n ∧ c (n - a) ∉ T}.Finite := by
   apply Set.Finite.subset (S.finite_toSet.biUnion (fun a _ => hcT.image (· + a)))
@@ -169,7 +176,7 @@ private theorem finite_shift_bad_set {k : ℕ} {A : Type*} [CommRing A] [Topolog
 /-- Each term of the coefficient convolution lands in `V`. The trichotomy is on where the two
 factors sit relative to `W`: if either is outside `W` then the *other* is in `T` by the
 bad-set hypotheses, and `hT_left` / `hT_right` apply; if both are inside `W` then `hWV` does. -/
-private theorem coeff_mul_mem_of_forall_mem {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+private theorem coeff_mul_mem_of_forall_mem {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
     {f g : MvPowerSeries (Fin k) A} (V W : OpenAddSubgroup A) (T : Set A)
     (hWV : ∀ x ∈ (W : Set A), ∀ y ∈ (W : Set A), x * y ∈ (V : Set A))
     (hT_left : ∀ a, MvPowerSeries.coeff a f ∉ (W : Set A) →
@@ -207,9 +214,9 @@ private theorem coeff_mul_mem_of_forall_mem {k : ℕ} {A : Type*} [CommRing A] [
 /-- A product of restricted series is restricted. This is the only field of
 `restrictedMvPowerSeriesSubring` that needs `A` nonarchimedean: the coefficient convolution is
 a finite sum, and it is nonarchimedeanness that keeps such a sum inside an open subgroup. -/
-theorem IsRestrictedAdic.mul {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+theorem IsRestricted.mul {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
     [NonarchimedeanRing A] {f g : MvPowerSeries (Fin k) A}
-    (hf : IsRestrictedAdic f) (hg : IsRestrictedAdic g) : IsRestrictedAdic (f * g) := by
+    (hf : IsRestricted f) (hg : IsRestricted g) : IsRestricted (f * g) := by
   classical
   change Tendsto _ cofinite (nhds 0)
   rw [tendsto_nhds]
@@ -266,28 +273,28 @@ The closure under multiplication (convolution of tendsto-0 coefficient sequences
 requires that `A` is a nonarchimedean topological ring (so that finite sums of elements in an
 open additive subgroup remain in the subgroup). This is the canonical definition of
 `A⟨T₁, …, Tₖ⟩` (Wedhorn, (5.6.1)/§5.6). -/
-def restrictedMvPowerSeriesSubring (k : ℕ) (A : Type*) [CommRing A] [TopologicalSpace A]
+def restrictedMvPowerSeriesSubring (k : ℕ) (A : Type*) [Ring A] [TopologicalSpace A]
     [NonarchimedeanRing A] : Subring (MvPowerSeries (Fin k) A) where
-  carrier := {f | IsRestrictedAdic f}
-  zero_mem' := isRestrictedAdic_zero k A
-  one_mem' := isRestrictedAdic_one k A
-  add_mem' := IsRestrictedAdic.add
-  neg_mem' := IsRestrictedAdic.neg
-  mul_mem' := IsRestrictedAdic.mul
+  carrier := {f | IsRestricted f}
+  zero_mem' := isRestricted_zero k A
+  one_mem' := isRestricted_one k A
+  add_mem' := IsRestricted.add
+  neg_mem' := IsRestricted.neg
+  mul_mem' := IsRestricted.mul
 
 /-- Membership in `A⟨T₁, …, Tₖ⟩` is restrictedness. -/
 @[simp]
-theorem mem_restrictedMvPowerSeriesSubring {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A]
+theorem mem_restrictedMvPowerSeriesSubring {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
     [NonarchimedeanRing A] {f : MvPowerSeries (Fin k) A} :
-    f ∈ restrictedMvPowerSeriesSubring k A ↔ IsRestrictedAdic f := (Iff.rfl)
+    f ∈ restrictedMvPowerSeriesSubring k A ↔ IsRestricted f := (Iff.rfl)
 
 /-! ### Algebra instance -/
 
 /-- Constant power series are restricted: the `algebraMap` image of any `a : A` has
 coefficient `a` at multi-index `0` and `0` elsewhere, so it trivially tends to `0`. -/
-theorem isRestrictedAdic_algebraMap {k : ℕ} {A : Type*} [CommRing A]
+theorem isRestricted_algebraMap {k : ℕ} {A : Type*} [CommRing A]
     [TopologicalSpace A] (a : A) :
-    IsRestrictedAdic (algebraMap A (MvPowerSeries (Fin k) A) a) := by
+    IsRestricted (algebraMap A (MvPowerSeries (Fin k) A) a) := by
   change Tendsto _ cofinite (nhds 0)
   apply tendsto_nhds.mpr
   intro U hU h0U
@@ -306,7 +313,7 @@ noncomputable instance restrictedMvPowerSeriesSubring.instAlgebra (k : ℕ) (A :
     Algebra A (restrictedMvPowerSeriesSubring k A) :=
   RingHom.toAlgebra
     { toFun := fun a => ⟨algebraMap A (MvPowerSeries (Fin k) A) a,
-        mem_restrictedMvPowerSeriesSubring.mpr (isRestrictedAdic_algebraMap a)⟩
+        mem_restrictedMvPowerSeriesSubring.mpr (isRestricted_algebraMap a)⟩
       map_one' := by ext; simp only [map_one, OneMemClass.coe_one]
       map_mul' := by intros; ext; simp only [map_mul, Subring.coe_mul]
       map_zero' := by ext; simp only [map_zero, ZeroMemClass.coe_zero]

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -11,9 +11,8 @@ public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
 /-!
 # Restricted Power Series
 
-This file defines restricted power series `A⟨T₁, …, Tₖ⟩` and the notion of a strongly
-noetherian ring, following Wedhorn's *Adic Spaces*: the convergent/restricted power series ring is
-(5.6.1) in §5.6; strong noetherianity is Proposition & Definition 6.36 in §6.7.
+This file defines restricted power series `A⟨T₁, …, Tₖ⟩`, following Wedhorn's *Adic Spaces*,
+where the convergent/restricted power series ring is (5.6.1) in §5.6.
 
 ## Main definitions
 
@@ -21,11 +20,6 @@ noetherian ring, following Wedhorn's *Adic Spaces*: the convergent/restricted po
   converge to `0` along the cofinite filter on multi-indices.
 * `restrictedMvPowerSeriesSubring k A`: The subring of restricted power series in `k`
   variables over `A`, denoted `A⟨T₁, …, Tₖ⟩`.
-* `IsStronglyNoetherian A`: A topological ring `A` is **strongly noetherian** if
-  `restrictedMvPowerSeriesSubring k A` is noetherian for all `k ≥ 0`
-  (Proposition & Definition 6.36 of Wedhorn, stated here with `A`-level restricted
-  series; Definition 6.36(i) verbatim is the condition on the completion `Â` — see
-  `SheafyRing.lean`'s scope notes).
 
 ## Provenance
 
@@ -54,8 +48,7 @@ arbitrary finite sums of elements in an open additive subgroup remain in the sub
 
 ## References
 
-* [Wedhorn, *Adic Spaces*][wedhorn_adic], (5.6.1) in §5.6 and Proposition and Definition 6.36
-  in §6.7.
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], (5.6.1) in §5.6.
 * [AINTLIB](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
   `projects/AdicSpaces/Adic spaces/RestrictedPowerSeries.lean`.
 -/
@@ -318,42 +311,5 @@ noncomputable instance restrictedMvPowerSeriesSubring.instAlgebra (k : ℕ) (A :
       map_mul' := by intros; ext; simp only [map_mul, Subring.coe_mul]
       map_zero' := by ext; simp only [map_zero, ZeroMemClass.coe_zero]
       map_add' := by intros; ext; simp only [map_add, Subring.coe_add] }
-
-/-! ### Strongly noetherian rings -/
-
-/-- A topological ring `A` is **strongly noetherian** if the ring of restricted power series
-`A⟨T₁, …, Tₖ⟩` is noetherian for all `k ≥ 0` (Proposition & Definition 6.36 of Wedhorn, stated here
-  with `A`-level restricted
-  series; Definition 6.36(i) verbatim is the condition on the completion `Â` — see
-  `SheafyRing.lean`'s scope notes).
-
-This is a fundamental finiteness condition in nonarchimedean geometry, introduced by
-Huber. For a noetherian Tate ring, being strongly noetherian is equivalent to saying
-that the theory of formal models is well-behaved. -/
-class IsStronglyNoetherian (A : Type*) [CommRing A] [TopologicalSpace A]
-    [NonarchimedeanRing A] : Prop where
-  /-- The restricted power series ring in `k` variables is noetherian for all `k`. -/
-  isNoetherianRing_restricted : ∀ k : ℕ,
-    IsNoetherianRing (restrictedMvPowerSeriesSubring k A)
-
-/-- **Strongly noetherian implies noetherian** — the `k = 0` case: the index set
-`Fin 0 →₀ ℕ` is a singleton, so its cofinite filter is `⊥` and every power series in
-zero variables is restricted; `constantCoeff` is then a ring surjection
-`A⟨⟩ = A⦃⦄ → A`. -/
-theorem IsStronglyNoetherian.isNoetherianRing (A : Type*) [CommRing A]
-    [TopologicalSpace A] [NonarchimedeanRing A] [IsStronglyNoetherian A] :
-    IsNoetherianRing A := by
-  have h0 : IsNoetherianRing (restrictedMvPowerSeriesSubring 0 A) :=
-    IsStronglyNoetherian.isNoetherianRing_restricted 0
-  refine isNoetherianRing_of_surjective (restrictedMvPowerSeriesSubring 0 A) A
-    ((MvPowerSeries.constantCoeff (σ := Fin 0) (R := A)).comp
-      (restrictedMvPowerSeriesSubring 0 A).subtype) ?_
-  intro a
-  refine ⟨⟨MvPowerSeries.C (σ := Fin 0) (R := A) a, ?_⟩, ?_⟩
-  -- unfolds `IsRestrictedAdic` to the `Tendsto` it abbreviates
-  · change Filter.Tendsto _ _ _
-    rw [Filter.cofinite_eq_bot]
-    exact Filter.tendsto_bot
-  · simp [MvPowerSeries.constantCoeff_C]
 
 end TauCeti.Huber


### PR DESCRIPTION
Restricted power series `A⟨T₁, …, Tₖ⟩` over a nonarchimedean topological ring, and the strongly noetherian condition. A new `TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean`.

`IsRestrictedAdic f` says the coefficients of a multivariate power series tend to zero along the cofinite filter on multi-indices. `restrictedMvPowerSeriesSubring k A` is the subring of `MvPowerSeries (Fin k) A` they cut out — Wedhorn's `A⟨T₁, …, Tₖ⟩` — with its `A`-algebra structure. (An earlier revision also carried an `IsStronglyNoetherian` class. It has been **removed**: it asserted noetherianity of the `A`-level restricted series rings while citing Wedhorn's Proposition and Definition 6.36, whose condition is on the completion `Â`, and for a noncomplete `A` those differ. The predicate is deferred to the Layer 0.5 PR, where it can be stated over `Â` using the completion machinery of #2298.)

The substance is closure under multiplication: the convolution of two null sequences of coefficients is null, which is where the nonarchimedean hypothesis is used — an open *subgroup* absorbs the arbitrary finite sums that a coefficient of a product is, and that is exactly what a general topological ring does not give.

**This is a port, not new work.** It comes from AINTLIB's `projects/AdicSpaces/Adic spaces/RestrictedPowerSeries.lean`, which the roadmap names as the principal source of existing code for this area; the file carries a `## Provenance` section saying so and a References entry. What changed in the port: AINTLIB targets a different Mathlib revision, so `isNoetherianRing_of_surjective` moved modules and `Set.mem_setOf_eq` is now deprecated in favour of `Set.mem_ofPred_eq`; the declarations move into the `TauCeti.Huber` namespace; the module opts into the Lean module system with bodies unexposed, which required adding `mem_restrictedMvPowerSeriesSubring` as the characteristic membership lemma so consumers never unfold `IsRestrictedAdic`; and `isRestrictedAdic_zero`/`isRestrictedAdic_one` shed a `[NonarchimedeanRing A]` hypothesis their proofs never used.

Advances `AdicSpaces/README.md` § "Layer 0.4 Weighted restricted series and topological localisation" — the restricted series `A⟨X₁,…,Xₙ⟩` that the weighted construction of #2367 specialises to, and the prerequisite for § "Layer 0.5 Restricted series over Tate rings and strong noetherianness".

**This PR is independent of the rest of the Layer-0 chain.** Although AINTLIB's original imports its `HuberRings`, it uses nothing from it; this module depends only on Mathlib, so it does not stack on #2263/#2267 and can be reviewed on its own.

Mathlib has `PowerSeries.IsRestricted`, which the roadmap flags for comparison. It is a different notion: it is about a `PowerSeries` over a ring with a *linear* topology being restricted with respect to a submodule filtration, in one variable, whereas `IsRestrictedAdic` is the multivariate cofinite-tendsto condition Wedhorn uses and needs only `NonarchimedeanRing`. The two are not interchangeable here; nothing in this file duplicates it.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0.4-restricted-series"}-->

🤖 Prepared with Claude Code

