### PR TITLE
feat: a 2x2 matrix scales the standard symplectic form by its determinant

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/SymplecticFinTwo.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymplecticFinTwo.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+
+/-!
+# A `2 × 2` matrix scales the standard symplectic form by its determinant
+
+For `J = !![0, 1; -1, 0]` the standard alternating form on a rank-two module, every `2 × 2` matrix
+`φ` satisfies
+
+`φᵀ * J * φ = φ.det • J`,
+
+and consequently a `φ` whose symplectic adjoint composes with it to a scalar has that scalar as its
+determinant.
+
+Mathlib's `Matrix.J` is not the right vehicle for this. It is defined on `l ⊕ l` for arbitrary `l`
+and characterises the symplectic *group* (`Matrix.mem_iff' : A ∈ symplecticGroup l R ↔ Aᵀ * J * A =
+J`), whereas the identity here holds for an **arbitrary** matrix with `det φ` on the right — a
+statement about the top exterior power, hence specific to rank two. It is false for larger `l`.
+
+## Main results
+
+* `TauCeti.Matrix.transpose_mul_symplectic_mul`: `φᵀ * J * φ = φ.det • J`.
+* `TauCeti.Matrix.det_eq_of_symplectic_adjoint`: if `φᵀ * J = J * ψ` and `ψ * φ = d • 1`, then
+  `φ.det = d`.
+
+## Provenance
+
+Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
+`HasseWeil/WeilPairing/PairingDet.lean`, declarations `symJ`, `transpose_mul_symJ_mul` and
+`det_eq_of_symplectic_adjoint`. The source's `symJ` definition is not ported — the matrix is
+written literally, so no new name competes with Mathlib's `Matrix.J`.
+
+In the pinned Hasse development these are the linear-algebra core of Silverman III.8.6
+(`det φ_ℓ = deg φ`): on `E[ℓ] ≅ 𝔽_ℓ²` the Weil pairing is the standard symplectic form, its adjoint
+property reads `φᵀ J = J φ̂`, and the dual relation is `φ̂ φ = (deg φ) • 1`. **No elliptic-curve
+content appears here** — this file is matrices over a commutative ring.
+-/
+
+public section
+
+open Matrix
+
+namespace TauCeti.Matrix
+
+variable {R : Type*} [CommRing R]
+
+/-- A `2 × 2` matrix scales the standard symplectic form `!![0, 1; -1, 0]` by its determinant. -/
+theorem transpose_mul_symplectic_mul (φ : Matrix (Fin 2) (Fin 2) R) :
+    φᵀ * !![0, 1; -1, 0] * φ = φ.det • !![0, 1; -1, 0] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [mul_apply, Fin.sum_univ_two, det_fin_two, transpose_apply] <;> ring
+
+/-- If `ψ` is the symplectic adjoint of `φ`, in the sense `φᵀ * J = J * ψ`, and `ψ * φ` is the
+scalar `d`, then `d` is the determinant of `φ`.
+
+This is the matrix form of the argument that a pairing-adjoint together with a dual relation pins
+the determinant: `φᵀ J φ = J ψ φ = d • J`, and comparing with
+`transpose_mul_symplectic_mul` gives `det φ = d` by reading off one entry. -/
+theorem det_eq_of_symplectic_adjoint {φ ψ : Matrix (Fin 2) (Fin 2) R} {d : R}
+    (hadj : φᵀ * !![0, 1; -1, 0] = !![0, 1; -1, 0] * ψ)
+    (hdual : ψ * φ = d • (1 : Matrix (Fin 2) (Fin 2) R)) : φ.det = d := by
+  have hkey : φ.det • (!![0, 1; -1, 0] : Matrix (Fin 2) (Fin 2) R)
+      = d • !![0, 1; -1, 0] := by
+    rw [← transpose_mul_symplectic_mul φ, hadj, Matrix.mul_assoc, hdual]
+    ext i j
+    fin_cases i <;> fin_cases j <;> simp [mul_apply, Fin.sum_univ_two]
+  have := congrArg (fun M => M 0 1) hkey
+  simpa using this
+
+end TauCeti.Matrix

--- a/TauCeti/LinearAlgebra/Matrix/SymplecticFinTwo.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymplecticFinTwo.lean
@@ -24,9 +24,9 @@ statement about the top exterior power, hence specific to rank two. It is false 
 
 ## Main results
 
-* `TauCeti.Matrix.transpose_mul_symplectic_mul`: `φᵀ * J * φ = φ.det • J`.
-* `TauCeti.Matrix.det_eq_of_symplectic_adjoint`: if `φᵀ * J = J * ψ` and `ψ * φ = d • 1`, then
-  `φ.det = d`.
+* `TauCeti.Matrix.transpose_mul_symplectic_mul_eq_det_smul`: `φᵀ * J * φ = φ.det • J`.
+* `TauCeti.Matrix.det_eq_of_symplectic_adjoint_of_mul_eq_smul_one`: if `φᵀ * J = J * ψ` and
+  `ψ * φ = d • 1`, then `φ.det = d`.
 
 ## Provenance
 
@@ -50,8 +50,14 @@ namespace TauCeti.Matrix
 variable {R : Type*} [CommRing R]
 
 /-- A `2 × 2` matrix scales the standard symplectic form `!![0, 1; -1, 0]` by its determinant. -/
-theorem transpose_mul_symplectic_mul (φ : Matrix (Fin 2) (Fin 2) R) :
+@[simp]
+theorem transpose_mul_symplectic_mul_eq_det_smul (φ : Matrix (Fin 2) (Fin 2) R) :
     φᵀ * !![0, 1; -1, 0] * φ = φ.det • !![0, 1; -1, 0] := by
+  -- This is the rank-two case of the determinant transformation law
+  -- (`TauCeti.Matrix.detRowAlternating_mulVec`): both entries are the determinant form evaluated
+  -- on the `i`-th and `j`-th columns of `φ`. Deriving it from that lemma is not shorter, because
+  -- `detRowAlternating` is an `alternatization` that `simp` does not put into coordinates, so the
+  -- four entries have to be computed either way.
   ext i j
   fin_cases i <;> fin_cases j <;>
     simp [mul_apply, Fin.sum_univ_two, det_fin_two, transpose_apply] <;> ring
@@ -61,13 +67,13 @@ scalar `d`, then `d` is the determinant of `φ`.
 
 This is the matrix form of the argument that a pairing-adjoint together with a dual relation pins
 the determinant: `φᵀ J φ = J ψ φ = d • J`, and comparing with
-`transpose_mul_symplectic_mul` gives `det φ = d` by reading off one entry. -/
-theorem det_eq_of_symplectic_adjoint {φ ψ : Matrix (Fin 2) (Fin 2) R} {d : R}
+`transpose_mul_symplectic_mul_eq_det_smul` gives `det φ = d` by reading off one entry. -/
+theorem det_eq_of_symplectic_adjoint_of_mul_eq_smul_one {φ ψ : Matrix (Fin 2) (Fin 2) R} {d : R}
     (hadj : φᵀ * !![0, 1; -1, 0] = !![0, 1; -1, 0] * ψ)
     (hdual : ψ * φ = d • (1 : Matrix (Fin 2) (Fin 2) R)) : φ.det = d := by
   have hkey : φ.det • (!![0, 1; -1, 0] : Matrix (Fin 2) (Fin 2) R)
       = d • !![0, 1; -1, 0] := by
-    rw [← transpose_mul_symplectic_mul φ, hadj, Matrix.mul_assoc, hdual]
+    rw [← transpose_mul_symplectic_mul_eq_det_smul φ, hadj, Matrix.mul_assoc, hdual]
     ext i j
     fin_cases i <;> fin_cases j <;> simp [mul_apply, Fin.sum_univ_two]
   have := congrArg (fun M => M 0 1) hkey


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"symplectic-det-fin-two"}-->

Roadmap: EllipticCurves

Adds `TauCeti/LinearAlgebra/Matrix/SymplecticFinTwo.lean`:

```lean
theorem TauCeti.Matrix.transpose_mul_symplectic_mul_eq_det_smul (φ : Matrix (Fin 2) (Fin 2) R) :
    φᵀ * !![0, 1; -1, 0] * φ = φ.det • !![0, 1; -1, 0]

theorem TauCeti.Matrix.det_eq_of_symplectic_adjoint_of_mul_eq_smul_one {φ ψ : Matrix (Fin 2) (Fin 2) R} {d : R}
    (hadj : φᵀ * !![0, 1; -1, 0] = !![0, 1; -1, 0] * ψ)
    (hdual : ψ * φ = d • 1) : φ.det = d
```

A `2 × 2` matrix scales the standard symplectic form by its determinant; consequently a matrix
whose symplectic adjoint composes with it to a scalar has that scalar as its determinant.

**Pure matrix algebra over a commutative ring — no elliptic-curve content, and nothing from this
repository is imported.**

## Why Mathlib's `Matrix.J` is not this

Mathlib has `Matrix.J l R` and `Matrix.mem_iff' : A ∈ symplecticGroup l R ↔ Aᵀ * J l R * A = J l R`.
That is a different statement in two ways, and I checked both before writing:

* it characterises the symplectic **group** — the `det = 1` case — whereas the identity here holds
  for an **arbitrary** matrix, with `det φ` appearing on the right;
* `Matrix.J` is defined on `l ⊕ l` for arbitrary `l`, and `Aᵀ J A = (det A) • J` is **false** above
  rank two: it is a statement about the top exterior power. So Mathlib's `J`, which is deliberately
  general in `l`, is the wrong vehicle for it.

I also checked for the underlying coordinate-free fact (an alternating form composed with an
endomorphism is `det` times the form) — `grep` over `LinearAlgebra/Determinant.lean` and
`LinearAlgebra/Alternating/*.lean` finds no such lemma, only `Basis.det` machinery.

## Provenance

Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
`HasseWeil/WeilPairing/PairingDet.lean`, declarations `symJ`, `transpose_mul_symJ_mul` and
`det_eq_of_symplectic_adjoint`.

The source's `symJ` definition is deliberately **not** ported: the matrix is written literally, so
no new name competes with Mathlib's `Matrix.J`. The source file's remaining eight declarations are
its `LinearMap`/`AlternatingMap` restatements and Frobenius-specific packagings; those are left for
a later PR, since they are only useful once the pairing construction exists.

## Roadmap

`EllipticCurves`, Layer 3 — the Hasse strand, whose §Ordering entry reads *"the Hasse bound is the
earliest PR, its existing proof self-contained; the zeta strand needs Layer 1's Frobenius
identities."*

This is a prerequisite rather than a target, which `CLAUDE.md` admits explicitly: a declaration may
be added when it *"advances a specific roadmap target, or supplies a prerequisite that a specific
target needs"*. The need is checkable: in the roadmap's pinned Hasse provenance
(`dev/hasse-weil @ 513e83879e2f`), `HasseWeil/WeilPairing/PairingDet.lean` lies inside the 187-file
import closure of the capstone `hasse_bound` proof. It is the linear-algebra core of Silverman
III.8.6 (`det φ_ℓ = deg φ`): on `E[ℓ] ≅ 𝔽_ℓ²` the Weil pairing is the standard symplectic form, the
pairing's adjoint property reads `φᵀ J = J φ̂`, and the dual relation is `φ̂ φ = (deg φ) • 1`.

Neither statement here waits on absent material — both are usable today by any caller holding a
`2 × 2` matrix. Together with #2328 (`det (r • M - s • 1)` for `2 × 2`) this completes the
matrix-side input to the Hasse argument, whose arithmetic side is #2323.

## Dry run

Run before opening for review. `naming` wanted both names conclusion-shaped (done), `api-design`
wanted `@[simp]` on the scaling identity (done, and checked against the repository linter rather
than taken on trust).

`reuse` asked for the proof to be derived from the in-repo general transformation law
`TauCeti.Matrix.detRowAlternating_mulVec` rather than computed. I attempted exactly that before
answering, and it does not come out shorter: `detRowAlternating` is a
`MultilinearMap.alternatization`, which `simp` will not put into coordinates, so after `fin_cases`
the four entry goals are precisely the ones plain `ring` already closes — threading the general
lemma through adds a `have` without removing any of them. The specialisation relationship is
recorded as a comment on the proof instead, so a reader is pointed at the general law.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
locally. Longest proof is 9 lines; no `sorry`, no `maxHeartbeats`.
