### PR TITLE
refactor(Crosscut): share the half-angle facts of a circular crosscut

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -372,28 +372,6 @@ theorem exists_clusterSetOn_circleMap_image_Ioo_eq_singleton (hUo : IsOpen U)
 
 /-! ## The two ends of a circular crosscut -/
 
-/-- Half the angular width of a genuine circular crosscut is positive. -/
-private lemma arccos_div_two_mul_pos (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
-    0 < Real.arccos (ρ / (2 * r)) :=
-  Real.arccos_pos.mpr ((div_lt_one (by linarith)).mpr hρr)
-
-/-- Half the angular width of a genuine circular crosscut is below `π / 2`: a crosscut spans less
-than half of its circle. -/
-private lemma arccos_div_two_mul_lt_pi_div_two (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
-    Real.arccos (ρ / (2 * r)) < π / 2 :=
-  Real.arccos_lt_pi_div_two.mpr (div_pos hρ (by linarith))
-
-/-- The open arc of angles of a genuine circular crosscut lies in the disc: by
-`TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo` it parametrises the crosscut itself. -/
-private lemma circleMap_mem_ball_of_mem_Ioo (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
-    {θ : ℝ} (hθ : θ ∈ Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
-      ((c - ζ).arg + Real.arccos (ρ / (2 * r)))) :
-    circleMap ζ ρ θ ∈ ball c r := by
-  have hmem : circleMap ζ ρ θ ∈ ball c r ∩ sphere ζ ρ := by
-    rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
-    exact ⟨θ, hθ, rfl⟩
-  exact hmem.1
-
 /-- The angular integral of the length density over the arc of a genuine circular crosscut is
 finite as soon as `TauCeti.circleImageLength f (ball c r) ζ ρ` is: the crosscut lies in `ball c r`,
 so the indicator in the definition of the latter is inert along it, and the crosscut spans less
@@ -446,10 +424,8 @@ theorem subsingleton_clusterSetOn_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     (clusterSetOn f (ball c r ∩ sphere ζ ρ) e).Subsingleton := by
   have hφ0 := arccos_div_two_mul_pos hρ hρr
   have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
-  obtain ⟨θ₀, hθ₀, rfl⟩ : ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
-      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e := by
-    rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
-    exact he
+  obtain ⟨θ₀, hθ₀, rfl⟩ :=
+    exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere hζ hρ hρr he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact subsingleton_clusterSetOn_circleMap_image_Ioo isOpen_ball hf ζ (by linarith)
     (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
@@ -468,10 +444,8 @@ theorem exists_tendsto_nhdsWithin_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     ∃ v, Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] e) (𝓝 v) := by
   have hφ0 := arccos_div_two_mul_pos hρ hρr
   have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
-  obtain ⟨θ₀, hθ₀, rfl⟩ : ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
-      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e := by
-    rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
-    exact he
+  obtain ⟨θ₀, hθ₀, rfl⟩ :=
+    exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere hζ hρ hρr he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact exists_tendsto_nhdsWithin_circleMap_image_Ioo isOpen_ball hf ζ (by linarith)
     (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
@@ -489,10 +463,8 @@ theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r)
     ∃ v, clusterSetOn f (ball c r ∩ sphere ζ ρ) e = {v} := by
   have hφ0 := arccos_div_two_mul_pos hρ hρr
   have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
-  obtain ⟨θ₀, hθ₀, rfl⟩ : ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
-      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e := by
-    rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
-    exact he
+  obtain ⟨θ₀, hθ₀, rfl⟩ :=
+    exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere hζ hρ hρr he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact exists_clusterSetOn_circleMap_image_Ioo_eq_singleton isOpen_ball hf ζ (by linarith)
     (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -372,6 +372,17 @@ theorem exists_clusterSetOn_circleMap_image_Ioo_eq_singleton (hUo : IsOpen U)
 
 /-! ## The two ends of a circular crosscut -/
 
+/-- The open arc of angles of a genuine circular crosscut lies in the disc: by
+`TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo` it parametrises the crosscut itself. -/
+private lemma circleMap_mem_ball_of_mem_Ioo (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
+    {θ : ℝ} (hθ : θ ∈ Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r)))) :
+    circleMap ζ ρ θ ∈ ball c r := by
+  have hmem : circleMap ζ ρ θ ∈ ball c r ∩ sphere ζ ρ := by
+    rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
+    exact ⟨θ, hθ, rfl⟩
+  exact hmem.1
+
 /-- The angular integral of the length density over the arc of a genuine circular crosscut is
 finite as soon as `TauCeti.circleImageLength f (ball c r) ζ ρ` is: the crosscut lies in `ball c r`,
 so the indicator in the definition of the latter is inert along it, and the crosscut spans less
@@ -380,10 +391,10 @@ private lemma lintegral_enorm_deriv_circleMap_ne_top (hζ : dist ζ c = r) (hρ 
     (hρr : ρ < 2 * r) (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
     ∫⁻ θ in Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
       ((c - ζ).arg + Real.arccos (ρ / (2 * r))), ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤ := by
-  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ (show (0 : ℝ) < r by linarith)
   have hmem : ∀ θ ∈ Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
       ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ ∈ ball c r :=
-    fun θ hθ => ((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1
+    fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ
   have hle : ∫⁻ θ in Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
         ((c - ζ).arg + Real.arccos (ρ / (2 * r))), ‖deriv f (circleMap ζ ρ θ)‖ₑ ≤
       ∫⁻ θ in Ioc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
@@ -422,13 +433,13 @@ theorem subsingleton_clusterSetOn_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) {e : ℂ}
     (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
     (clusterSetOn f (ball c r ∩ sphere ζ ρ) e).Subsingleton := by
-  have hφ0 := arccos_div_two_mul_pos hρ hρr
-  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+  have hr : 0 < r := by linarith
+  have hφ0 := arccos_div_two_mul_pos hr hρr
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hr
   obtain ⟨θ₀, hθ₀, rfl⟩ := (closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact subsingleton_clusterSetOn_circleMap_image_Ioo isOpen_ball hf ζ (by linarith)
-    (by linarith [Real.pi_pos]) hθ₀
-    (fun θ hθ => ((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1)
+    (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **A circular crosscut of finite image length has a limit at each point of its closure.** This is
@@ -442,13 +453,13 @@ theorem exists_tendsto_nhdsWithin_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) {e : ℂ}
     (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
     ∃ v, Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] e) (𝓝 v) := by
-  have hφ0 := arccos_div_two_mul_pos hρ hρr
-  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+  have hr : 0 < r := by linarith
+  have hφ0 := arccos_div_two_mul_pos hr hρr
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hr
   obtain ⟨θ₀, hθ₀, rfl⟩ := (closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact exists_tendsto_nhdsWithin_circleMap_image_Ioo isOpen_ball hf ζ (by linarith)
-    (by linarith [Real.pi_pos]) hθ₀
-    (fun θ hθ => ((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1)
+    (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **The end of a circular crosscut of finite image length is a single point.** This is
@@ -461,13 +472,13 @@ theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r)
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) {e : ℂ}
     (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
     ∃ v, clusterSetOn f (ball c r ∩ sphere ζ ρ) e = {v} := by
-  have hφ0 := arccos_div_two_mul_pos hρ hρr
-  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+  have hr : 0 < r := by linarith
+  have hφ0 := arccos_div_two_mul_pos hr hρr
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hr
   obtain ⟨θ₀, hθ₀, rfl⟩ := (closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact exists_clusterSetOn_circleMap_image_Ioo_eq_singleton isOpen_ball hf ζ (by linarith)
-    (by linarith [Real.pi_pos]) hθ₀
-    (fun θ hθ => ((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1)
+    (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **The two ends of a circular crosscut of finite image length are two points.** The union of the

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -383,7 +383,7 @@ private lemma lintegral_enorm_deriv_circleMap_ne_top (hζ : dist ζ c = r) (hρ 
   have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
   have hmem : ∀ θ ∈ Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
       ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ ∈ ball c r :=
-    fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ
+    fun θ hθ => ((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1
   have hle : ∫⁻ θ in Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
         ((c - ζ).arg + Real.arccos (ρ / (2 * r))), ‖deriv f (circleMap ζ ρ θ)‖ₑ ≤
       ∫⁻ θ in Ioc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
@@ -424,11 +424,11 @@ theorem subsingleton_clusterSetOn_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     (clusterSetOn f (ball c r ∩ sphere ζ ρ) e).Subsingleton := by
   have hφ0 := arccos_div_two_mul_pos hρ hρr
   have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
-  obtain ⟨θ₀, hθ₀, rfl⟩ :=
-    exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere hζ hρ hρr he
+  obtain ⟨θ₀, hθ₀, rfl⟩ := (closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact subsingleton_clusterSetOn_circleMap_image_Ioo isOpen_ball hf ζ (by linarith)
-    (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
+    (by linarith [Real.pi_pos]) hθ₀
+    (fun θ hθ => ((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **A circular crosscut of finite image length has a limit at each point of its closure.** This is
@@ -444,11 +444,11 @@ theorem exists_tendsto_nhdsWithin_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     ∃ v, Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] e) (𝓝 v) := by
   have hφ0 := arccos_div_two_mul_pos hρ hρr
   have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
-  obtain ⟨θ₀, hθ₀, rfl⟩ :=
-    exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere hζ hρ hρr he
+  obtain ⟨θ₀, hθ₀, rfl⟩ := (closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact exists_tendsto_nhdsWithin_circleMap_image_Ioo isOpen_ball hf ζ (by linarith)
-    (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
+    (by linarith [Real.pi_pos]) hθ₀
+    (fun θ hθ => ((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **The end of a circular crosscut of finite image length is a single point.** This is
@@ -463,11 +463,11 @@ theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r)
     ∃ v, clusterSetOn f (ball c r ∩ sphere ζ ρ) e = {v} := by
   have hφ0 := arccos_div_two_mul_pos hρ hρr
   have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
-  obtain ⟨θ₀, hθ₀, rfl⟩ :=
-    exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere hζ hρ hρr he
+  obtain ⟨θ₀, hθ₀, rfl⟩ := (closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact exists_clusterSetOn_circleMap_image_Ioo_eq_singleton isOpen_ball hf ζ (by linarith)
-    (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
+    (by linarith [Real.pi_pos]) hθ₀
+    (fun θ hθ => ((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **The two ends of a circular crosscut of finite image length are two points.** The union of the

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -92,7 +92,7 @@ variable {c ζ : ℂ} {r ρ : ℝ}
 /-- **The half-angle of a genuine circular crosscut is positive**, so the crosscut occupies a
 nondegenerate arc of angles. This is `Real.arccos_pos` at `ρ / (2 * r)`, the argument being below
 `1` exactly because `ρ < 2 * r`. -/
-theorem arccos_div_two_mul_pos (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
+theorem arccos_div_two_mul_pos (hr : 0 < r) (hρr : ρ < 2 * r) :
     0 < Real.arccos (ρ / (2 * r)) :=
   Real.arccos_pos.mpr ((div_lt_one (by linarith)).mpr hρr)
 
@@ -103,7 +103,7 @@ This is `Real.arccos_lt_pi_div_two` at `ρ / (2 * r)`, the argument being positi
 The bound is what makes the chord distance along a crosscut unimodal
 (`TauCeti.isPreconnected_ball_inter_sphere_inter_ball`) and what keeps the closed arc of angles
 inside one period, so that `TauCeti.circleMap` is injective on it. -/
-theorem arccos_div_two_mul_lt_pi_div_two (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
+theorem arccos_div_two_mul_lt_pi_div_two (hρ : 0 < ρ) (hr : 0 < r) :
     Real.arccos (ρ / (2 * r)) < π / 2 :=
   Real.arccos_lt_pi_div_two.mpr (div_pos hρ (by linarith))
 
@@ -171,7 +171,7 @@ theorem ball_inter_sphere_eq_circleMap_image_Ioo (hζ : dist ζ c = r) (hρ : 0 
     refine ⟨?_, circleMap_mem_sphere ζ hρ.le θ⟩
     rw [circleMap_mem_ball_iff hζ hρ]
     have ht : θ - (c - ζ).arg ∈ Icc (-π) π := by
-      have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+      have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hr
       constructor <;> linarith [hθ.1, hθ.2, Real.pi_pos]
     have hcos := (Real.lt_cos_iff_mem_Ioo (by linarith) ht).mpr
       ⟨by linarith [hθ.1], by linarith [hθ.2]⟩
@@ -203,7 +203,7 @@ theorem closedBall_inter_sphere_eq_circleMap_image_Icc (hζ : dist ζ c = r) (h�
     refine ⟨?_, circleMap_mem_sphere ζ hρ.le θ⟩
     rw [circleMap_mem_closedBall_iff hζ hρ]
     have ht : θ - (c - ζ).arg ∈ Icc (-π) π := by
-      have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+      have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hr
       constructor <;> linarith [hθ.1, hθ.2, Real.pi_pos]
     have hcos := (Real.le_cos_iff_mem_Icc hx1.le ht).mpr
       ⟨by linarith [hθ.1], by linarith [hθ.2]⟩
@@ -215,8 +215,9 @@ theorem closedBall_inter_sphere_eq_circleMap_image_Icc (hζ : dist ζ c = r) (h�
 theorem circleMap_crosscut_endpoints_ne (hρ : 0 < ρ) (hρr : ρ < 2 * r) (c ζ : ℂ) :
     circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r))) ≠
       circleMap ζ ρ ((c - ζ).arg + Real.arccos (ρ / (2 * r))) := by
-  have hφ0 := arccos_div_two_mul_pos hρ hρr
-  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+  have hr : 0 < r := by linarith
+  have hφ0 := arccos_div_two_mul_pos hr hρr
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hr
   intro h
   have heq := eq_of_circleMap_eq hρ.ne'
     (by rw [abs_lt]; constructor <;> linarith [Real.pi_pos]) h
@@ -272,22 +273,23 @@ theorem isPathConnected_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ)
   have hne : (Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
       ((c - ζ).arg + Real.arccos (ρ / (2 * r)))).Nonempty := by
     rw [nonempty_Ioo]
-    linarith [arccos_div_two_mul_pos hρ hρr]
+    linarith [arccos_div_two_mul_pos (show (0 : ℝ) < r by linarith) hρr]
   exact ((convex_Ioo _ _).isPathConnected hne).image (continuous_circleMap ζ ρ)
 
 /-- A genuine circular crosscut together with its endpoints is path connected. -/
 theorem isPathConnected_closedBall_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ)
     (hρr : ρ < 2 * r) : IsPathConnected (closedBall c r ∩ sphere ζ ρ) := by
   rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr]
-  exact ((convex_Icc _ _).isPathConnected (nonempty_Icc.2
-    (by linarith [arccos_div_two_mul_pos hρ hρr]))).image (continuous_circleMap ζ ρ)
+  exact ((convex_Icc _ _).isPathConnected (nonempty_Icc.2 (by
+    linarith [arccos_div_two_mul_pos (show (0 : ℝ) < r by linarith) hρr]))).image
+    (continuous_circleMap ζ ρ)
 
 /-- Closing a genuine open circular crosscut adds exactly its two endpoints. -/
 theorem closure_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
     closure (ball c r ∩ sphere ζ ρ) = closedBall c r ∩ sphere ζ ρ := by
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr,
     closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr]
-  have hφ0 := arccos_div_two_mul_pos hρ hρr
+  have hφ0 := arccos_div_two_mul_pos (show (0 : ℝ) < r by linarith) hρr
   let a := (c - ζ).arg - Real.arccos (ρ / (2 * r))
   let b := (c - ζ).arg + Real.arccos (ρ / (2 * r))
   have hab : a < b := by dsimp [a, b]; linarith
@@ -331,7 +333,7 @@ whole crosscut. -/
 theorem isPreconnected_ball_inter_sphere_inter_ball (hζ : dist ζ c = r) (hρ : 0 < ρ)
     (hρr : ρ < 2 * r) {e : ℂ} (he : e ∈ closedBall c r ∩ sphere ζ ρ) (δ : ℝ) :
     IsPreconnected (ball c r ∩ sphere ζ ρ ∩ ball e δ) := by
-  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ (show (0 : ℝ) < r by linarith)
   obtain ⟨θ₀, hθ₀, rfl⟩ := (closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr, ← image_inter_preimage]
   refine IsPreconnected.image ?_ _ (continuous_circleMap ζ ρ).continuousOn

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -35,9 +35,18 @@ with its closure; they do not assert the continuous boundary extension itself.
 
 ## Main results
 
+* `TauCeti.arccos_div_two_mul_pos` and `TauCeti.arccos_div_two_mul_lt_pi_div_two` bound the
+  half-angle: it is positive, and below `π / 2`. These two facts are the standing hypotheses of
+  almost every argument along a crosscut — they are what make the angular window nondegenerate and
+  shorter than a period — and every crosscut file routes through them rather than re-deriving them
+  from `Real.arccos_pos` and `Real.arccos_lt_pi_div_two`.
 * `TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo` and
   `TauCeti.closedBall_inter_sphere_eq_circleMap_image_Icc` identify the open and closed crosscut
-  arcs.
+  arcs. `TauCeti.circleMap_mem_ball_of_mem_Ioo` and
+  `TauCeti.exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere` are their one-sided
+  readings: the open window lands in the disc, and every point of the closed crosscut carries an
+  angle in the closed window. Those are the two directions in which the arc description is
+  actually spent downstream.
 * `TauCeti.sphere_inter_sphere_eq_pair_circleMap` identifies their two distinct endpoints.
 * `TauCeti.isPathConnected_ball_inter_sphere` and
   `TauCeti.closure_ball_inter_sphere` give the corresponding topological packaging, and
@@ -81,6 +90,26 @@ open Complex Metric Set Topology
 open scoped Real
 
 variable {c ζ : ℂ} {r ρ : ℝ}
+
+/-! ## The half-angle -/
+
+/-- **The half-angle of a genuine circular crosscut is positive**, so the crosscut occupies a
+nondegenerate arc of angles. This is `Real.arccos_pos` at `ρ / (2 * r)`, the argument being below
+`1` exactly because `ρ < 2 * r`. -/
+theorem arccos_div_two_mul_pos (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
+    0 < Real.arccos (ρ / (2 * r)) :=
+  Real.arccos_pos.mpr ((div_lt_one (by linarith)).mpr hρr)
+
+/-- **A genuine circular crosscut spans less than a half turn**: its half-angle is below `π / 2`.
+This is `Real.arccos_lt_pi_div_two` at `ρ / (2 * r)`, the argument being positive exactly because
+`0 < ρ`.
+
+The bound is what makes the chord distance along a crosscut unimodal
+(`TauCeti.isPreconnected_ball_inter_sphere_inter_ball`) and what keeps the closed arc of angles
+inside one period, so that `TauCeti.circleMap` is injective on it. -/
+theorem arccos_div_two_mul_lt_pi_div_two (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
+    Real.arccos (ρ / (2 * r)) < π / 2 :=
+  Real.arccos_lt_pi_div_two.mpr (div_pos hρ (by linarith))
 
 /-! ## Metric and angular descriptions -/
 
@@ -146,11 +175,20 @@ theorem ball_inter_sphere_eq_circleMap_image_Ioo (hζ : dist ζ c = r) (hρ : 0 
     refine ⟨?_, circleMap_mem_sphere ζ hρ.le θ⟩
     rw [circleMap_mem_ball_iff hζ hρ]
     have ht : θ - (c - ζ).arg ∈ Icc (-π) π := by
-      have hφπ := Real.arccos_lt_pi.mpr (by linarith : -1 < ρ / (2 * r))
-      constructor <;> linarith [hθ.1, hθ.2]
+      have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+      constructor <;> linarith [hθ.1, hθ.2, Real.pi_pos]
     have hcos := (Real.lt_cos_iff_mem_Ioo (by linarith) ht).mpr
       ⟨by linarith [hθ.1], by linarith [hθ.2]⟩
     simpa only [mul_comm] using ((div_lt_iff₀ (by positivity)).mp hcos)
+
+/-- **The open arc of angles of a genuine circular crosscut lands in the disc.** This is the half
+of `TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo` that forgets the cutting circle, and it is
+the form in which the arc is fed to statements about a curve in `ball c r`. -/
+theorem circleMap_mem_ball_of_mem_Ioo (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
+    {θ : ℝ} (hθ : θ ∈ Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r)))) :
+    circleMap ζ ρ θ ∈ ball c r :=
+  ((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1
 
 /-- The closure-side companion of
 `TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo`: a genuine circular crosscut together with its
@@ -178,11 +216,22 @@ theorem closedBall_inter_sphere_eq_circleMap_image_Icc (hζ : dist ζ c = r) (h�
     refine ⟨?_, circleMap_mem_sphere ζ hρ.le θ⟩
     rw [circleMap_mem_closedBall_iff hζ hρ]
     have ht : θ - (c - ζ).arg ∈ Icc (-π) π := by
-      have hφπ := Real.arccos_lt_pi.mpr (by linarith : -1 < ρ / (2 * r))
-      constructor <;> linarith [hθ.1, hθ.2]
+      have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+      constructor <;> linarith [hθ.1, hθ.2, Real.pi_pos]
     have hcos := (Real.le_cos_iff_mem_Icc hx1.le ht).mpr
       ⟨by linarith [hθ.1], by linarith [hθ.2]⟩
     simpa only [mul_comm] using ((div_le_iff₀ (by positivity)).mp hcos)
+
+/-- **Every point of a genuine circular crosscut, endpoints included, carries an angle in the
+closed window.** This is the one-sided reading of
+`TauCeti.closedBall_inter_sphere_eq_circleMap_image_Icc` companion to
+`TauCeti.circleMap_mem_ball_of_mem_Ioo`, and it is the step by which a statement about a point of
+the closed crosscut is turned into one about its angle. -/
+theorem exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere (hζ : dist ζ c = r)
+    (hρ : 0 < ρ) (hρr : ρ < 2 * r) {e : ℂ} (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
+    ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e :=
+  (closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he
 
 /-! ## The endpoints and topological packaging -/
 
@@ -190,15 +239,11 @@ theorem closedBall_inter_sphere_eq_circleMap_image_Icc (hζ : dist ζ c = r) (h�
 theorem circleMap_crosscut_endpoints_ne (hρ : 0 < ρ) (hρr : ρ < 2 * r) (c ζ : ℂ) :
     circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r))) ≠
       circleMap ζ ρ ((c - ζ).arg + Real.arccos (ρ / (2 * r))) := by
-  have hr : 0 < r := by linarith
-  have hφ0 : 0 < Real.arccos (ρ / (2 * r)) :=
-    Real.arccos_pos.mpr ((div_lt_one (by positivity)).mpr hρr)
-  have hφπ : Real.arccos (ρ / (2 * r)) < π :=
-    Real.arccos_lt_pi.mpr (by
-      have hx : 0 < ρ / (2 * r) := div_pos hρ (by positivity)
-      linarith)
+  have hφ0 := arccos_div_two_mul_pos hρ hρr
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
   intro h
-  have heq := eq_of_circleMap_eq hρ.ne' (by rw [abs_lt]; constructor <;> linarith) h
+  have heq := eq_of_circleMap_eq hρ.ne'
+    (by rw [abs_lt]; constructor <;> linarith [Real.pi_pos]) h
   linarith
 
 /-- The two circles bounding a genuine circular crosscut meet at exactly its two angular
@@ -251,28 +296,22 @@ theorem isPathConnected_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ)
   have hne : (Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
       ((c - ζ).arg + Real.arccos (ρ / (2 * r)))).Nonempty := by
     rw [nonempty_Ioo]
-    have hr : 0 < r := by linarith
-    have hφ := Real.arccos_pos.mpr ((div_lt_one (by positivity)).mpr hρr)
-    linarith
+    linarith [arccos_div_two_mul_pos hρ hρr]
   exact ((convex_Ioo _ _).isPathConnected hne).image (continuous_circleMap ζ ρ)
 
 /-- A genuine circular crosscut together with its endpoints is path connected. -/
 theorem isPathConnected_closedBall_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ)
     (hρr : ρ < 2 * r) : IsPathConnected (closedBall c r ∩ sphere ζ ρ) := by
   rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr]
-  exact ((convex_Icc _ _).isPathConnected (nonempty_Icc.2 (by
-    have hr : 0 < r := by linarith
-    have hφ := Real.arccos_pos.mpr ((div_lt_one (by positivity)).mpr hρr)
-    linarith))).image (continuous_circleMap ζ ρ)
+  exact ((convex_Icc _ _).isPathConnected (nonempty_Icc.2
+    (by linarith [arccos_div_two_mul_pos hρ hρr]))).image (continuous_circleMap ζ ρ)
 
 /-- Closing a genuine open circular crosscut adds exactly its two endpoints. -/
 theorem closure_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
     closure (ball c r ∩ sphere ζ ρ) = closedBall c r ∩ sphere ζ ρ := by
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr,
     closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr]
-  have hφ0 : 0 < Real.arccos (ρ / (2 * r)) := by
-    have hr : 0 < r := by linarith
-    exact Real.arccos_pos.mpr ((div_lt_one (by positivity)).mpr hρr)
+  have hφ0 := arccos_div_two_mul_pos hρ hρr
   let a := (c - ζ).arg - Real.arccos (ρ / (2 * r))
   let b := (c - ζ).arg + Real.arccos (ρ / (2 * r))
   have hab : a < b := by dsimp [a, b]; linarith
@@ -316,13 +355,9 @@ whole crosscut. -/
 theorem isPreconnected_ball_inter_sphere_inter_ball (hζ : dist ζ c = r) (hρ : 0 < ρ)
     (hρr : ρ < 2 * r) {e : ℂ} (he : e ∈ closedBall c r ∩ sphere ζ ρ) (δ : ℝ) :
     IsPreconnected (ball c r ∩ sphere ζ ρ ∩ ball e δ) := by
-  have hr : 0 < r := by linarith
-  have hx0 : 0 < ρ / (2 * r) := div_pos hρ (by positivity)
-  have hφπ2 : Real.arccos (ρ / (2 * r)) < π / 2 := Real.arccos_lt_pi_div_two.mpr hx0
-  obtain ⟨θ₀, hθ₀, rfl⟩ : ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
-      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e := by
-    rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
-    exact he
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+  obtain ⟨θ₀, hθ₀, rfl⟩ :=
+    exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere hζ hρ hρr he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr, ← image_inter_preimage]
   refine IsPreconnected.image ?_ _ (continuous_circleMap ζ ρ).continuousOn
   have hpre : circleMap ζ ρ ⁻¹' ball (circleMap ζ ρ θ₀) δ

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -42,11 +42,7 @@ with its closure; they do not assert the continuous boundary extension itself.
   from `Real.arccos_pos` and `Real.arccos_lt_pi_div_two`.
 * `TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo` and
   `TauCeti.closedBall_inter_sphere_eq_circleMap_image_Icc` identify the open and closed crosscut
-  arcs. `TauCeti.circleMap_mem_ball_of_mem_Ioo` and
-  `TauCeti.exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere` are their one-sided
-  readings: the open window lands in the disc, and every point of the closed crosscut carries an
-  angle in the closed window. Those are the two directions in which the arc description is
-  actually spent downstream.
+  arcs.
 * `TauCeti.sphere_inter_sphere_eq_pair_circleMap` identifies their two distinct endpoints.
 * `TauCeti.isPathConnected_ball_inter_sphere` and
   `TauCeti.closure_ball_inter_sphere` give the corresponding topological packaging, and
@@ -181,15 +177,6 @@ theorem ball_inter_sphere_eq_circleMap_image_Ioo (hζ : dist ζ c = r) (hρ : 0 
       ⟨by linarith [hθ.1], by linarith [hθ.2]⟩
     simpa only [mul_comm] using ((div_lt_iff₀ (by positivity)).mp hcos)
 
-/-- **The open arc of angles of a genuine circular crosscut lands in the disc.** This is the half
-of `TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo` that forgets the cutting circle, and it is
-the form in which the arc is fed to statements about a curve in `ball c r`. -/
-theorem circleMap_mem_ball_of_mem_Ioo (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
-    {θ : ℝ} (hθ : θ ∈ Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
-      ((c - ζ).arg + Real.arccos (ρ / (2 * r)))) :
-    circleMap ζ ρ θ ∈ ball c r :=
-  ((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1
-
 /-- The closure-side companion of
 `TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo`: a genuine circular crosscut together with its
 two endpoints is one closed angular arc. -/
@@ -221,17 +208,6 @@ theorem closedBall_inter_sphere_eq_circleMap_image_Icc (hζ : dist ζ c = r) (h�
     have hcos := (Real.le_cos_iff_mem_Icc hx1.le ht).mpr
       ⟨by linarith [hθ.1], by linarith [hθ.2]⟩
     simpa only [mul_comm] using ((div_le_iff₀ (by positivity)).mp hcos)
-
-/-- **Every point of a genuine circular crosscut, endpoints included, carries an angle in the
-closed window.** This is the one-sided reading of
-`TauCeti.closedBall_inter_sphere_eq_circleMap_image_Icc` companion to
-`TauCeti.circleMap_mem_ball_of_mem_Ioo`, and it is the step by which a statement about a point of
-the closed crosscut is turned into one about its angle. -/
-theorem exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere (hζ : dist ζ c = r)
-    (hρ : 0 < ρ) (hρr : ρ < 2 * r) {e : ℂ} (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
-    ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
-      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e :=
-  (closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he
 
 /-! ## The endpoints and topological packaging -/
 
@@ -356,8 +332,7 @@ theorem isPreconnected_ball_inter_sphere_inter_ball (hζ : dist ζ c = r) (hρ :
     (hρr : ρ < 2 * r) {e : ℂ} (he : e ∈ closedBall c r ∩ sphere ζ ρ) (δ : ℝ) :
     IsPreconnected (ball c r ∩ sphere ζ ρ ∩ ball e δ) := by
   have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
-  obtain ⟨θ₀, hθ₀, rfl⟩ :=
-    exists_mem_Icc_circleMap_eq_of_mem_closedBall_inter_sphere hζ hρ hρr he
+  obtain ⟨θ₀, hθ₀, rfl⟩ := (closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr, ← image_inter_preimage]
   refine IsPreconnected.image ?_ _ (continuous_circleMap ζ ρ).continuousOn
   have hpre : circleMap ζ ρ ⁻¹' ball (circleMap ζ ρ θ₀) δ

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
@@ -139,7 +139,7 @@ theorem exists_path_range_eq_closure_image_ball_inter_sphere (hζ : dist ζ c = 
   let a : ℝ := (c - ζ).arg - φ
   let b : ℝ := (c - ζ).arg + φ
   let g : ℝ → ℂ := fun θ => f (circleMap ζ ρ θ)
-  have hφ0 : 0 < φ := Real.arccos_pos.mpr ((div_lt_one (by linarith)).mpr hρr)
+  have hφ0 : 0 < φ := arccos_div_two_mul_pos hρ hρr
   have hab : a < b := by simp only [a, b]; linarith
   have hcrosscut : ball c r ∩ sphere ζ ρ = circleMap ζ ρ '' Ioo a b := by
     simpa only [a, b, φ] using ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr
@@ -179,8 +179,7 @@ private theorem mem_frontier_image_ball_of_tendsto_arc_endpoint
       θ = (c - ζ).arg + Real.arccos (ρ / (2 * r)))
     {w : ℂ} (hw : Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] (circleMap ζ ρ θ)) (𝓝 w)) :
     w ∈ frontier (f '' ball c r) := by
-  have hφ0 : 0 < Real.arccos (ρ / (2 * r)) :=
-    Real.arccos_pos.mpr ((div_lt_one (by linarith)).mpr hρr)
+  have hφ0 := arccos_div_two_mul_pos hρ hρr
   have heclosed : circleMap ζ ρ θ ∈ closedBall c r ∩ sphere ζ ρ := by
     rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr]
     refine ⟨θ, ?_, rfl⟩
@@ -241,21 +240,14 @@ theorem exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn
   let φ : ℝ := Real.arccos (ρ / (2 * r))
   let a : ℝ := (c - ζ).arg - φ
   let b : ℝ := (c - ζ).arg + φ
-  have hφ0 : 0 < φ := by
-    exact Real.arccos_pos.mpr ((div_lt_one (by linarith)).mpr hρr)
+  have hφ0 : 0 < φ := arccos_div_two_mul_pos hρ hρr
   have hab : a < b := by simp only [a, b]; linarith
-  have hφπ2 : φ < π / 2 := by
-    exact Real.arccos_lt_pi_div_two.mpr (div_pos hρ (by linarith))
+  have hφπ2 : φ < π / 2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
   have hab2π : b - a < 2 * π := by simp only [a, b]; linarith [Real.pi_pos]
   have hcrosscut : ball c r ∩ sphere ζ ρ = circleMap ζ ρ '' Ioo a b := by
     simpa only [a, b, φ] using ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr
-  have hmaps : MapsTo (circleMap ζ ρ) (Ioo a b) (ball c r) := by
-    intro θ hθ
-    have : circleMap ζ ρ θ ∈ ball c r ∩ sphere ζ ρ := by
-      rw [hcrosscut]
-      exact ⟨θ, hθ, rfl⟩
-    exact this.1
-  have hr : 0 < r := by linarith
+  have hmaps : MapsTo (circleMap ζ ρ) (Ioo a b) (ball c r) := fun θ hθ =>
+    (hcrosscut.ge ⟨θ, hθ, rfl⟩).1
   have hua : Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] (circleMap ζ ρ a)) (𝓝 u) := by
     simpa only [a, φ] using hu
   have hvb : Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] (circleMap ζ ρ b)) (𝓝 v) := by

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
@@ -139,7 +139,8 @@ theorem exists_path_range_eq_closure_image_ball_inter_sphere (hζ : dist ζ c = 
   let a : ℝ := (c - ζ).arg - φ
   let b : ℝ := (c - ζ).arg + φ
   let g : ℝ → ℂ := fun θ => f (circleMap ζ ρ θ)
-  have hφ0 : 0 < φ := arccos_div_two_mul_pos hρ hρr
+  have hr : 0 < r := by linarith
+  have hφ0 : 0 < φ := arccos_div_two_mul_pos hr hρr
   have hab : a < b := by simp only [a, b]; linarith
   have hcrosscut : ball c r ∩ sphere ζ ρ = circleMap ζ ρ '' Ioo a b := by
     simpa only [a, b, φ] using ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr
@@ -179,7 +180,7 @@ private theorem mem_frontier_image_ball_of_tendsto_arc_endpoint
       θ = (c - ζ).arg + Real.arccos (ρ / (2 * r)))
     {w : ℂ} (hw : Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] (circleMap ζ ρ θ)) (𝓝 w)) :
     w ∈ frontier (f '' ball c r) := by
-  have hφ0 := arccos_div_two_mul_pos hρ hρr
+  have hφ0 := arccos_div_two_mul_pos (show (0 : ℝ) < r by linarith) hρr
   have heclosed : circleMap ζ ρ θ ∈ closedBall c r ∩ sphere ζ ρ := by
     rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr]
     refine ⟨θ, ?_, rfl⟩
@@ -240,9 +241,10 @@ theorem exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn
   let φ : ℝ := Real.arccos (ρ / (2 * r))
   let a : ℝ := (c - ζ).arg - φ
   let b : ℝ := (c - ζ).arg + φ
-  have hφ0 : 0 < φ := arccos_div_two_mul_pos hρ hρr
+  have hr : 0 < r := by linarith
+  have hφ0 : 0 < φ := arccos_div_two_mul_pos hr hρr
   have hab : a < b := by simp only [a, b]; linarith
-  have hφπ2 : φ < π / 2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+  have hφπ2 : φ < π / 2 := arccos_div_two_mul_lt_pi_div_two hρ hr
   have hab2π : b - a < 2 * π := by simp only [a, b]; linarith [Real.pi_pos]
   have hcrosscut : ball c r ∩ sphere ζ ρ = circleMap ζ ρ '' Ioo a b := by
     simpa only [a, b, φ] using ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr


### PR DESCRIPTION
This PR shares the half-angle bookkeeping of a circular crosscut instead of re-deriving it at every use. Fix a disc `ball c r`, a point `ζ` on its boundary circle and a radius `0 < ρ < 2 * r`; the crosscut `ball c r ∩ sphere ζ ρ` is the arc of angles within `φ = arccos (ρ / (2 * r))` of `arg (c - ζ)`, and essentially every argument along it opens by establishing `0 < φ` and `φ < π / 2` — the first making the angular window nondegenerate, the second keeping it inside one period so that `circleMap` is injective on it. Those two facts were named privately in `Crosscut/EndpointLimit.lean` and re-derived inline eight further times, in three different spellings, across `Crosscut/Endpoints.lean` and `Crosscut/Path.lean`. They move to `Crosscut/Endpoints.lean`, the file that introduces the half-angle, become public as `TauCeti.arccos_div_two_mul_pos` and `TauCeti.arccos_div_two_mul_lt_pi_div_two`, and every site is routed through them. Three of those sites previously asked only for the weaker `φ < π`; they now take the sharp bound and close with `Real.pi_pos`.

The repeated readings of the arc description are shortened in place rather than renamed. Turning a point of the closed crosscut into an angle was four copies of the same three-line rewrite through `TauCeti.closedBall_inter_sphere_eq_circleMap_image_Icc`; each is now the one-line projection `(closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr).le he` of that equality. Symmetrically, the fact that the open window lands in the disc — a private lemma of `Crosscut/EndpointLimit.lean` that `Crosscut/Path.lean` re-derived twice under the name `hmaps` — is spelled at each use as `((ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr).ge ⟨θ, hθ, rfl⟩).1`, so the two set equalities stay the single statement of the arc description.

No theorem statement changes, nothing is renamed, and no declaration leaves the public API; the two half-angle bounds are the only additions. The `Crosscut/Endpoints.lean` module docstring is extended to record them. No Mathlib source is vendored: the two bounds are `Real.arccos_pos` and `Real.arccos_lt_pi_div_two` specialised to `ρ / (2 * r)`, consumed rather than restated.

This is improvement to code that already exists, in the crosscut layer that `TauCetiRoadmap/ConformalMapping/README.md` builds for its layer **L5**, the Jordan-domain case of the Carathéodory boundary correspondence ("L5 — Carathéodory boundary correspondence. The concrete L5 milestone is the **Jordan-domain case**: the RMT map of a Jordan domain extends to a homeomorphism of closures."). It adds no new mathematics and does not extend the project's mathematical scope.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"crosscut-half-angle-bounds"}-->

🤖 Prepared with Claude Code
