### PR TITLE
feat(EllipticCurve): the complement of psi_n in psi_2n

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Complement.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Complement.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+
+/-!
+# The complement of `ψₙ` in `ψ₂ₙ`
+
+Mathlib defines the `n`-division polynomial of a Weierstrass curve as a normalised elliptic
+divisibility sequence, `W.ψ n = normEDS W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) n`, and supplies the
+complement of a normalised EDS, `complEDS₂`, together with
+`normEDS_mul_complEDS₂ : normEDS b c d k * complEDS₂ b c d k = normEDS b c d (2 * k)`.
+
+This file names the curve-level instance of that complement, `W.ψc`, so that the factorisation
+`ψₙ · ψcₙ = ψ₂ₙ` can be quoted without unfolding `ψ` back to `normEDS`. It follows Mathlib's own
+pattern in the same area: `W.ψ` is itself a curve-level name for a `normEDS`, with `ψ_zero`,
+`ψ_one`, `ψ_neg` and so on restating the corresponding `normEDS` lemmas.
+
+## Main definitions
+
+* `WeierstrassCurve.ψc`: the complement of `ψₙ` in `ψ₂ₙ`.
+
+## Main results
+
+* `WeierstrassCurve.ψ_mul_ψc`: `ψₙ · ψcₙ = ψ₂ₙ`.
+* `WeierstrassCurve.ψc_neg`: `ψc` is even.
+
+## Provenance
+
+Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), pinned
+by the roadmap at `dev/modular-curves @ 9fec8eba7652`:
+`LutzNagell/DivisionPolynomialOmega.lean`, declarations `ψc` and `ψc_spec` (© Junyan Xu, David
+Kurniadi Angdinata), which are mathlib-track material.
+
+Only these two are ported. That file's remaining content — the `ω` family, `invar`, and the
+identities relating them — rests on an `invarDenom` / `redInvar` layer that the pinned Mathlib does
+not have: Mathlib's elliptic-divisibility development has since been rewritten around elliptic
+*nets*, which supplies the complement API used here (`complEDS₂`, `normEDS_mul_complEDS₂`) but no
+counterpart of the invariant machinery. So `ω` remains a genuine gap rather than a transcription.
+-/
+
+public section
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+
+open Polynomial
+open scoped Polynomial.Bivariate
+
+/-- The complement of `ψₙ` in `ψ₂ₙ`: the division-polynomial instance of Mathlib's `complEDS₂`. -/
+protected noncomputable def ψc (n : ℤ) : R[X][Y] :=
+  complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) n
+
+/-- The `2n`-division polynomial factors as `ψₙ` times its complement. -/
+theorem ψ_mul_ψc (n : ℤ) : W.ψ n * W.ψc n = W.ψ (2 * n) :=
+  normEDS_mul_complEDS₂ ..
+
+@[simp]
+theorem ψc_neg (n : ℤ) : W.ψc (-n) = W.ψc n :=
+  complEDS₂_neg ..
+
+end WeierstrassCurve


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divpoly-complement"}-->

Roadmap: EllipticCurves

Adds `TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Complement.lean`: the complement
of `ψₙ` in `ψ₂ₙ`.

```lean
protected noncomputable def WeierstrassCurve.ψc (n : ℤ) : R[X][Y] :=
  complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) n

theorem WeierstrassCurve.ψ_mul_ψc (n : ℤ) : W.ψ n * W.ψc n = W.ψ (2 * n)
@[simp] theorem WeierstrassCurve.ψc_neg (n : ℤ) : W.ψc (-n) = W.ψc n
```

## Why this is a curve-level name and not a wrapper to inline

Mathlib defines the division polynomial itself as a normalised EDS —
`W.ψ n = normEDS W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) n` (`DivisionPolynomial/Basic.lean:401`) — and then
restates the `normEDS` lemmas at curve level: `ψ_zero`, `ψ_one`, `ψ_two`, `ψ_neg`, … each of which
is a one-line invocation of the corresponding `normEDS_*`. This PR follows that established pattern
in the same area for the complement, so that `ψₙ · ψcₙ = ψ₂ₙ` can be quoted without unfolding `ψ`
back to `normEDS` and re-supplying the three EDS parameters at every call site.

The underlying Mathlib API used is `complEDS₂`, `normEDS_mul_complEDS₂`
(`NumberTheory/EllipticDivisibilitySequence.lean:546`) and `complEDS₂_neg`; there is no `ψc` in the
pinned Mathlib (`grep -F "ψc"` over `Mathlib/` returns nothing).

## Provenance, and what is deliberately left

Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), pinned by
the roadmap at `dev/modular-curves @ 9fec8eba7652`: `LutzNagell/DivisionPolynomialOmega.lean`,
declarations `ψc` and `ψc_spec`. That file is © Junyan Xu and David Kurniadi Angdinata and is
mathlib-track; these two declarations are genuinely absent from the pinned Mathlib, which is the
condition under which the campaign brief permits porting such material.

**Only these two are ported.** The rest of that file — the `ω` family, `invar`, and the identities
relating them — rests on an `invarDenom` / `redInvar` layer that pinned Mathlib does **not** have.
Mathlib's elliptic-divisibility development has since been rewritten around elliptic *nets*: that
rewrite is what supplies the complement API this PR uses, but it carries no counterpart of the
invariant machinery (`grep -i invar` over
`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean` returns nothing). So `ω` is a genuine
rebuild rather than a transcription, and is not attempted here.

## Roadmap

`EllipticCurves`, **Layer 6**, item "The torsion subgroup and Nagell–Lutz", whose route the roadmap
gives as the division polynomials.

This is a prerequisite rather than a target, which `CLAUDE.md` admits explicitly: a declaration may
be added when it *"advances a specific roadmap target, or supplies a prerequisite that a specific
target needs"*. `ψc` is the first link of the `ω` chain that carries the point-level
`[n]`-multiplication formula, which is what the remaining Nagell–Lutz steps consume.

**No torsion statement and no part of `lutz_nagell` is established here**, and nothing in this PR
is conditional on absent material: both statements hold over any commutative ring and are usable
today.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
locally. No `sorry`, no `maxHeartbeats`.
