### PR TITLE
refactor(Subcomodule): name the two comodule axioms of the induced coaction

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
@@ -135,55 +135,71 @@ private theorem lTensor_counit_natural (t : N ⊗[R] C) :
   rw [← LinearMap.comp_apply, LinearMap.rTensor_comp_lTensor, ← LinearMap.comp_apply,
     LinearMap.lTensor_comp_rTensor]
 
+/-- **Coassociativity of the induced coaction.** This is the first comodule axiom for
+`Subcomodule.inducedCoact`, and the coassociativity field of `Subcomodule.instComodule`. -/
+private theorem inducedCoact_coassoc :
+    TensorProduct.assoc R N C C ∘ₗ N.inducedCoact.rTensor C ∘ₗ N.inducedCoact =
+      Coalgebra.comul.lTensor N ∘ₗ N.inducedCoact := by
+  -- Both sides are determined by their images under the subtype inclusion, so the identity is
+  -- transported from the coassociativity of `M`.
+  ext n
+  apply (subtype_rTensor_tensor_injective N).comp
+    (TensorProduct.assoc R N C C).symm.injective
+  simp only [LinearMap.comp_apply, LinearMap.rTensor_def]
+  calc
+    ((SMulMemClass.subtype N).rTensor C).rTensor C
+        ((TensorProduct.assoc R N C C).symm
+          (TensorProduct.assoc R N C C
+            (TensorProduct.map N.inducedCoact (LinearMap.id : C →ₗ[R] C)
+              (N.inducedCoact n)))) =
+        TensorProduct.map ((SMulMemClass.subtype N).rTensor C) (LinearMap.id : C →ₗ[R] C)
+          (TensorProduct.map N.inducedCoact (LinearMap.id : C →ₗ[R] C)
+            (N.inducedCoact n)) := by
+          rw [LinearEquiv.symm_apply_apply, LinearMap.rTensor_def]
+    _ =
+        (Comodule.coact (R := R) (C := C) (M := M)).rTensor C
+          (Comodule.coact (R := R) (C := C) (M := M) n) := by
+          rw [map_rTensor_inducedCoact]
+          simp only [← LinearMap.rTensor_def, subtype_rTensor_inducedCoact]
+    _ =
+        (TensorProduct.assoc R M C C).symm
+          (Coalgebra.comul.lTensor M
+            (Comodule.coact (R := R) (C := C) (M := M) n)) := by
+          apply (TensorProduct.assoc R M C C).injective
+          simp [Comodule.coassoc_apply (R := R) (C := C) (M := M)]
+    _ =
+        ((SMulMemClass.subtype N).rTensor C).rTensor C
+          ((TensorProduct.assoc R N C C).symm
+            (Coalgebra.comul.lTensor N (N.inducedCoact n))) := by
+          rw [← assoc_symm_lTensor_comul_natural]
+          rw [subtype_rTensor_inducedCoact]
+
+/-- **The counit law for the induced coaction.** This is the second comodule axiom for
+`Subcomodule.inducedCoact`, and the counit field of `Subcomodule.instComodule`. -/
+private theorem lTensor_counit_comp_inducedCoact :
+    Coalgebra.counit.lTensor N ∘ₗ N.inducedCoact = (TensorProduct.mk R N R).flip 1 := by
+  -- The inclusion is injective on `N ⊗[R] R`, so it suffices to check the identity in `M ⊗[R] R`.
+  ext n
+  apply subtype_rTensor_R_injective N
+  simp only [LinearMap.comp_apply]
+  calc
+    (SMulMemClass.subtype N).rTensor R
+        (Coalgebra.counit.lTensor N (N.inducedCoact n)) =
+        Coalgebra.counit.lTensor M
+          ((SMulMemClass.subtype N).rTensor C (N.inducedCoact n)) := by
+          exact lTensor_counit_natural N (N.inducedCoact n)
+    _ = (n : M) ⊗ₜ[R] 1 := by
+          simp
+    _ = (SMulMemClass.subtype N).rTensor R (n ⊗ₜ[R] 1) := by
+          rw [LinearMap.rTensor_tmul, SMulMemClass.subtype_apply]
+
 /-- The subtype of a subcomodule carries the inherited right-comodule structure. -/
 noncomputable instance instComodule : Comodule R C N where
   coact := N.inducedCoact
-  coassoc := by
-    ext n
-    apply (subtype_rTensor_tensor_injective N).comp
-      (TensorProduct.assoc R N C C).symm.injective
-    simp only [LinearMap.comp_apply, LinearMap.rTensor_def]
-    calc
-      ((SMulMemClass.subtype N).rTensor C).rTensor C
-          ((TensorProduct.assoc R N C C).symm
-            (TensorProduct.assoc R N C C
-              (TensorProduct.map N.inducedCoact (LinearMap.id : C →ₗ[R] C)
-                (N.inducedCoact n)))) =
-          TensorProduct.map ((SMulMemClass.subtype N).rTensor C) (LinearMap.id : C →ₗ[R] C)
-            (TensorProduct.map N.inducedCoact (LinearMap.id : C →ₗ[R] C)
-              (N.inducedCoact n)) := by
-            rw [LinearEquiv.symm_apply_apply, LinearMap.rTensor_def]
-      _ =
-          (Comodule.coact (R := R) (C := C) (M := M)).rTensor C
-            (Comodule.coact (R := R) (C := C) (M := M) n) := by
-            rw [map_rTensor_inducedCoact]
-            simp only [← LinearMap.rTensor_def, subtype_rTensor_inducedCoact]
-      _ =
-          (TensorProduct.assoc R M C C).symm
-            (Coalgebra.comul.lTensor M
-              (Comodule.coact (R := R) (C := C) (M := M) n)) := by
-            apply (TensorProduct.assoc R M C C).injective
-            simp [Comodule.coassoc_apply (R := R) (C := C) (M := M)]
-      _ =
-          ((SMulMemClass.subtype N).rTensor C).rTensor C
-            ((TensorProduct.assoc R N C C).symm
-              (Coalgebra.comul.lTensor N (N.inducedCoact n))) := by
-            rw [← assoc_symm_lTensor_comul_natural]
-            rw [subtype_rTensor_inducedCoact]
-  lTensor_counit_comp_coact := by
-    ext n
-    apply subtype_rTensor_R_injective N
-    simp only [LinearMap.comp_apply]
-    calc
-      (SMulMemClass.subtype N).rTensor R
-          (Coalgebra.counit.lTensor N (N.inducedCoact n)) =
-          Coalgebra.counit.lTensor M
-            ((SMulMemClass.subtype N).rTensor C (N.inducedCoact n)) := by
-            exact lTensor_counit_natural N (N.inducedCoact n)
-      _ = (n : M) ⊗ₜ[R] 1 := by
-            simp
-      _ = (SMulMemClass.subtype N).rTensor R (n ⊗ₜ[R] 1) := by
-            rw [LinearMap.rTensor_tmul, SMulMemClass.subtype_apply]
+  -- The two axioms are `by exact` rather than bare terms: this instance is public, so its body may
+  -- not name a private declaration, while a tactic proof of a `Prop` field may.
+  coassoc := by exact inducedCoact_coassoc N
+  lTensor_counit_comp_coact := by exact lTensor_counit_comp_inducedCoact N
 
 /-- The inherited coaction on a subcomodule is `Subcomodule.inducedCoact`. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
@@ -176,7 +176,7 @@ private theorem inducedCoact_coassoc :
 
 /-- **The counit law for the induced coaction.** This is the second comodule axiom for
 `Subcomodule.inducedCoact`, and the counit field of `Subcomodule.instComodule`. -/
-private theorem lTensor_counit_comp_inducedCoact :
+private theorem inducedCoact_counit :
     Coalgebra.counit.lTensor N ∘ₗ N.inducedCoact = (TensorProduct.mk R N R).flip 1 := by
   -- The inclusion is injective on `N ⊗[R] R`, so it suffices to check the identity in `M ⊗[R] R`.
   ext n
@@ -199,7 +199,7 @@ noncomputable instance instComodule : Comodule R C N where
   -- The two axioms are `by exact` rather than bare terms: this instance is public, so its body may
   -- not name a private declaration, while a tactic proof of a `Prop` field may.
   coassoc := by exact inducedCoact_coassoc N
-  lTensor_counit_comp_coact := by exact lTensor_counit_comp_inducedCoact N
+  lTensor_counit_comp_coact := by exact inducedCoact_counit N
 
 /-- The inherited coaction on a subcomodule is `Subcomodule.inducedCoact`. -/
 @[simp]


### PR DESCRIPTION
`instComodule` proved both comodule axioms inline, giving a 46-line structure body. This names them,
matching what the file already does with its naturality facts (`assoc_symm_tmul_natural`,
`lTensor_counit_natural`, `map_rTensor_inducedCoact`, …), all of which are private lemmas kept above
the instance.

| helper | says |
|---|---|
| `inducedCoact_coassoc` | `assoc ∘ₗ inducedCoact.rTensor C ∘ₗ inducedCoact = comul.lTensor N ∘ₗ inducedCoact` — coassociativity of the induced coaction |
| `lTensor_counit_comp_inducedCoact` | `counit.lTensor N ∘ₗ inducedCoact = (mk R N R).flip 1` — its counit law |

The instance is now its three fields. Structure body: 46 → 2 lines; the two new bodies are 34 and 15.
No statement changes, and both helpers are `private`.

## Why the fields are `by exact`

The direct form `coassoc := inducedCoact_coassoc N` does not compile:

```
Unknown identifier `inducedCoact_coassoc`
Note: A private declaration `inducedCoact_coassoc` (from the current module) exists but would
need to be public to access here.
```

The instance is public, so its body may not name a private declaration; a tactic proof of a `Prop`
field may, which is why the existing inline proofs could already call the private naturality lemmas.
`by exact` is therefore load-bearing rather than noise, and there is a comment in the source saying
so. The alternative — making the two axioms public — would add API that nothing outside this
instance wants.

Roadmap: ReductiveGroups
