### PR TITLE
feat(EllipticCurve): low division polynomials are p-th power substitutions in char p

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
@@ -52,19 +52,13 @@ namespace WeierstrassCurve
 
 variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R)
 
-/-- The characteristic relation, read in the polynomial ring: `(p : R[X]) = 0` whenever
-`CharP R p`. Every proof below is the division-polynomial formula modulo this one fact, so it is
-stated once rather than reshaped inline at each use. -/
-private theorem natCast_eq_zero_poly (p : ℕ) [CharP R p] : (p : R[X]) = 0 := by
-  exact_mod_cast CharP.cast_eq_zero R[X] p
-
 /-- In characteristic two, `Φ₂` is a polynomial in `X²`.
 
 `Φ₂ = X⁴ − b₄X² − 2b₆X − b₈`, and the `2b₆X` term vanishes. -/
 theorem Φ_two_mem_range_expand [CharP R 2] : W.Φ 2 ∈ Set.range (⇑(expand R 2)) := by
   refine ⟨X ^ 2 - C W.b₄ * X - C W.b₈, ?_⟩
   simp only [W.Φ_two, map_sub, map_mul, map_pow, expand_C, expand_X, C_ofNat]
-  linear_combination (X * C W.b₆) * natCast_eq_zero_poly (R := R) 2
+  linear_combination (X * C W.b₆) * CharP.cast_eq_zero R[X] 2
 
 /-- In characteristic two, `ΨSq₂` is a polynomial in `X²`.
 
@@ -73,7 +67,7 @@ theorem ΨSq_two_mem_range_expand [CharP R 2] : W.ΨSq 2 ∈ Set.range (⇑(expa
   refine ⟨C W.b₂ * X + C W.b₆, ?_⟩
   simp only [W.ΨSq_two, _root_.WeierstrassCurve.Ψ₂Sq, map_add, map_mul, expand_C, expand_X,
     C_ofNat]
-  linear_combination (-2 * X ^ 3 - X * C W.b₄) * natCast_eq_zero_poly (R := R) 2
+  linear_combination (-2 * X ^ 3 - X * C W.b₄) * CharP.cast_eq_zero R[X] 2
 
 /-- In characteristic three, `Ψ₃` is a polynomial in `X³`.
 
@@ -81,7 +75,7 @@ theorem ΨSq_two_mem_range_expand [CharP R 2] : W.ΨSq 2 ∈ Set.range (⇑(expa
 theorem Ψ₃_mem_range_expand [CharP R 3] : W.Ψ₃ ∈ Set.range (⇑(expand R 3)) := by
   refine ⟨C W.b₂ * X + C W.b₈, ?_⟩
   simp only [_root_.WeierstrassCurve.Ψ₃, map_add, map_mul, expand_C, expand_X]
-  linear_combination -(X ^ 4 + C W.b₄ * X ^ 2 + C W.b₆ * X) * natCast_eq_zero_poly (R := R) 3
+  linear_combination -(X ^ 4 + C W.b₄ * X ^ 2 + C W.b₆ * X) * CharP.cast_eq_zero R[X] 3
 
 /-- In characteristic three, `ΨSq₃` is a polynomial in `X³`, since it is `Ψ₃²` and `expand` is
 multiplicative. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
@@ -52,35 +52,36 @@ namespace WeierstrassCurve
 
 variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R)
 
+/-- The characteristic relation, read in the polynomial ring: `(p : R[X]) = 0` whenever
+`CharP R p`. Every proof below is the division-polynomial formula modulo this one fact, so it is
+stated once rather than reshaped inline at each use. -/
+private theorem natCast_eq_zero_poly (p : ℕ) [CharP R p] : (p : R[X]) = 0 := by
+  exact_mod_cast CharP.cast_eq_zero R[X] p
+
 /-- In characteristic two, `Φ₂` is a polynomial in `X²`.
 
 `Φ₂ = X⁴ − b₄X² − 2b₆X − b₈`, and the `2b₆X` term vanishes. -/
 theorem Φ_two_mem_range_expand [CharP R 2] : W.Φ 2 ∈ Set.range (⇑(expand R 2)) := by
   refine ⟨X ^ 2 - C W.b₄ * X - C W.b₈, ?_⟩
-  rw [W.Φ_two, map_sub, map_sub, map_mul, expand_C, expand_X, map_pow, expand_X, expand_C]
-  have h2 : (2 : R) * W.b₆ = 0 := by rw [show (2 : R) = 0 from CharP.cast_eq_zero R 2, zero_mul]
-  rw [h2, map_zero, zero_mul, sub_zero]
-  ring
+  simp only [W.Φ_two, map_sub, map_mul, map_pow, expand_C, expand_X, C_ofNat]
+  linear_combination (X * C W.b₆) * natCast_eq_zero_poly (R := R) 2
 
 /-- In characteristic two, `ΨSq₂` is a polynomial in `X²`.
 
 `ΨSq₂ = Ψ₂Sq = 4X³ + b₂X² + 2b₄X + b₆`, and the `4X³` and `2b₄X` terms vanish. -/
 theorem ΨSq_two_mem_range_expand [CharP R 2] : W.ΨSq 2 ∈ Set.range (⇑(expand R 2)) := by
   refine ⟨C W.b₂ * X + C W.b₆, ?_⟩
-  rw [W.ΨSq_two, _root_.WeierstrassCurve.Ψ₂Sq, map_add, map_mul, expand_C, expand_X, expand_C]
-  have h2 : (2 : R) = 0 := CharP.cast_eq_zero R 2
-  have h4 : (4 : R) = 0 := by rw [show (4 : R) = 2 * 2 from by ring, h2, mul_zero]
-  rw [h4, show (2 : R) * W.b₄ = 0 by rw [h2, zero_mul], map_zero, zero_mul, zero_mul]
-  ring
+  simp only [W.ΨSq_two, _root_.WeierstrassCurve.Ψ₂Sq, map_add, map_mul, expand_C, expand_X,
+    C_ofNat]
+  linear_combination (-2 * X ^ 3 - X * C W.b₄) * natCast_eq_zero_poly (R := R) 2
 
 /-- In characteristic three, `Ψ₃` is a polynomial in `X³`.
 
 `Ψ₃ = 3X⁴ + b₂X³ + 3b₄X² + 3b₆X + b₈`, and every term with a factor of `3` vanishes. -/
 theorem Ψ₃_mem_range_expand [CharP R 3] : W.Ψ₃ ∈ Set.range (⇑(expand R 3)) := by
   refine ⟨C W.b₂ * X + C W.b₈, ?_⟩
-  rw [_root_.WeierstrassCurve.Ψ₃, map_add, map_mul, expand_C, expand_X, expand_C]
-  have h3 : (3 : R[X]) = 0 := by exact_mod_cast CharP.cast_eq_zero R[X] 3
-  linear_combination -(X ^ 4 + C W.b₄ * X ^ 2 + C W.b₆ * X) * h3
+  simp only [_root_.WeierstrassCurve.Ψ₃, map_add, map_mul, expand_C, expand_X]
+  linear_combination -(X ^ 4 + C W.b₄ * X ^ 2 + C W.b₆ * X) * natCast_eq_zero_poly (R := R) 3
 
 /-- In characteristic three, `ΨSq₃` is a polynomial in `X³`, since it is `Ψ₃²` and `expand` is
 multiplicative. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
@@ -37,10 +37,12 @@ Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f
 The source's `b_relation_of_charP_three` is not ported: Mathlib already has it verbatim as
 `WeierstrassCurve.b_relation_of_char_three` (`Weierstrass.lean:213`).
 
-The source proves `Φ_three_mem_expand_three_charP` by exhibiting an explicit cubic witness,
-which needs `set_option maxHeartbeats 1000000`; this repository forbids raising the limit, so
-`Φ_three_mem_range_expand` is instead proved through `Polynomial.expand_contract` (whence its
-extra `NoZeroDivisors` hypothesis) and elaborates within the default budget.
+The source's proof of `Φ_three_mem_expand_three_charP` raises the elaboration heartbeat limit
+to five times the default, which this repository forbids. The witness cubic and the
+`linear_combination` strategy here are the source's (its multipliers are symbolically verified
+over `ℤ`, as there); substituting the characteristic-three `b`-relation at the `C`-level inside
+the `linear_combination`, rather than rewriting it into the goal, is what lets the same argument
+elaborate within the default budget.
 -/
 
 public section
@@ -84,36 +86,34 @@ theorem ΨSq_three_mem_range_expand [CharP R 3] : W.ΨSq 3 ∈ Set.range (⇑(ex
   obtain ⟨g, hg⟩ := Ψ₃_mem_range_expand W
   exact ⟨g ^ 2, by rw [W.ΨSq_three, ← hg, map_pow]⟩
 
-/-- In characteristic three, `Φ₃` is a polynomial in `X³`.
+/-- In characteristic three, `Φ₃` is a polynomial in `X³`: explicitly, `Φ₃ = expand 3 g` for the
+cubic `g = X³ − b₂b₄X² + (b₂²b₄² − b₂³b₆ + b₂b₄b₆)X + (b₄³b₆ − b₂b₄b₆² + b₆³)`.
 
-Unlike the cases above, this is proved through the derivative criterion: in characteristic `p` a
-polynomial with vanishing derivative lies in the image of `expand R p`
-(`Polynomial.expand_contract`, whence the `NoZeroDivisors` hypothesis), and
-`derivative (Φ 3) = 0` is a `linear_combination` over `3 = 0` and the characteristic-three
-`b`-relation `b₈ = b₂b₆ − b₄²`. The explicit-witness route this replaces does not elaborate
-within the repository heartbeat budget. -/
-theorem Φ_three_mem_range_expand [CharP R 3] [NoZeroDivisors R] :
-    W.Φ 3 ∈ Set.range (⇑(expand R 3)) := by
-  have hderiv : Polynomial.derivative (W.Φ 3) = 0 := by
-    have h3 : (3 : R[X]) = 0 := by exact_mod_cast CharP.cast_eq_zero R[X] 3
-    have hbC : C W.b₈ = C W.b₂ * C W.b₆ - C W.b₄ ^ 2 := by
-      rw [W.b_relation_of_char_three, map_sub, map_mul, map_pow]
-    rw [_root_.WeierstrassCurve.Φ_three]
-    simp only [_root_.WeierstrassCurve.Ψ₃, _root_.WeierstrassCurve.preΨ₄,
-      _root_.WeierstrassCurve.Ψ₂Sq, derivative_mul, derivative_X, derivative_pow, derivative_add,
-      derivative_C, derivative_ofNat, map_ofNat, map_sub, map_mul, map_pow, Nat.cast_ofNat]
-    rw [hbC]
-    -- The remaining identity is `3 * M = 0` for the explicit polynomial `M` below.
-    linear_combination (3 * X ^ 8 - 14 * C W.b₄ * X ^ 6 -
-      (2 * C W.b₂ * C W.b₄ + 48 * C W.b₆) * X ^ 5 -
-      (65 * C W.b₂ * C W.b₆ - 55 * C W.b₄ ^ 2) * X ^ 4 -
-      (16 * C W.b₂ ^ 2 * C W.b₆ - 16 * C W.b₂ * C W.b₄ ^ 2 + 4 * C W.b₄ * C W.b₆) * X ^ 3 -
-      (C W.b₂ ^ 3 * C W.b₆ - C W.b₂ ^ 2 * C W.b₄ ^ 2 + 17 * C W.b₂ * C W.b₄ * C W.b₆ -
-        18 * C W.b₄ ^ 3 - 3 * C W.b₆ ^ 2) * X ^ 2 -
-      (2 * C W.b₂ ^ 2 * C W.b₄ * C W.b₆ - 2 * C W.b₂ * C W.b₄ ^ 3 + 2 * C W.b₂ * C W.b₆ ^ 2 -
-        4 * C W.b₄ ^ 2 * C W.b₆) * X -
-      (C W.b₂ * C W.b₄ ^ 2 * C W.b₆ - C W.b₄ ^ 4 - C W.b₄ * C W.b₆ ^ 2)) * h3
-  exact ⟨contract 3 (W.Φ 3), expand_contract (p := 3) hderiv (by norm_num)⟩
+The difference `expand 3 g − Φ₃` is `3·M + N·(b₂b₆ − b₄² − b₈)` for explicit polynomials `M`, `N`
+(computed symbolically over `ℤ`, entering through `linear_combination`), so it vanishes by
+`CharP.cast_eq_zero` and the characteristic-three `b`-relation
+`WeierstrassCurve.b_relation_of_char_three`. -/
+theorem Φ_three_mem_range_expand [CharP R 3] : W.Φ 3 ∈ Set.range (⇑(expand R 3)) := by
+  have h3 : (3 : R[X]) = 0 := by exact_mod_cast CharP.cast_eq_zero R[X] 3
+  have hbC : C W.b₈ = C W.b₂ * C W.b₆ - C W.b₄ ^ 2 := by
+    rw [W.b_relation_of_char_three, map_sub, map_mul, map_pow]
+  refine ⟨X ^ 3 - C W.b₂ * C W.b₄ * X ^ 2 +
+    (C W.b₂ ^ 2 * C W.b₄ ^ 2 - C W.b₂ ^ 3 * C W.b₆ + C W.b₂ * C W.b₄ * C W.b₆) * X +
+    (C W.b₄ ^ 3 * C W.b₆ - C W.b₂ * C W.b₄ * C W.b₆ ^ 2 + C W.b₆ ^ 3), ?_⟩
+  rw [_root_.WeierstrassCurve.Φ_three]
+  simp only [_root_.WeierstrassCurve.Ψ₃, _root_.WeierstrassCurve.preΨ₄,
+    _root_.WeierstrassCurve.Ψ₂Sq, map_add, map_sub, map_mul, map_pow, map_ofNat, expand_C,
+    expand_X]
+  linear_combination (2 * C W.b₄ * X ^ 7 + 8 * C W.b₆ * X ^ 6 +
+      (13 * C W.b₂ * C W.b₆ - 11 * C W.b₄ ^ 2) * X ^ 5 +
+      (4 * C W.b₂ ^ 2 * C W.b₆ - 4 * C W.b₂ * C W.b₄ ^ 2 + C W.b₄ * C W.b₆) * X ^ 4 +
+      (6 * C W.b₂ * C W.b₄ * C W.b₆ - 6 * C W.b₄ ^ 3 - C W.b₆ ^ 2) * X ^ 3 +
+      (C W.b₂ ^ 2 * C W.b₄ * C W.b₆ - C W.b₂ * C W.b₄ ^ 3 + C W.b₂ * C W.b₆ ^ 2 -
+        2 * C W.b₄ ^ 2 * C W.b₆) * X ^ 2 +
+      (C W.b₂ * C W.b₄ ^ 2 * C W.b₆ - C W.b₄ ^ 4 - C W.b₄ * C W.b₆ ^ 2) * X) * h3 +
+    (34 * X ^ 5 + 12 * C W.b₂ * X ^ 4 + (C W.b₂ ^ 2 + 18 * C W.b₄) * X ^ 3 +
+      (3 * C W.b₂ * C W.b₄ + 4 * C W.b₆) * X ^ 2 + (3 * C W.b₄ ^ 2 - C W.b₈) * X +
+      C W.b₄ * C W.b₆) * hbC
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
@@ -24,8 +24,6 @@ field or to a universal polynomial ring.
 
 * `TauCeti.WeierstrassCurve.Φ_two_mem_range_expand`, `ΨSq_two_mem_range_expand`: characteristic
   two.
-* `TauCeti.WeierstrassCurve.b₈_eq_of_charP_three`: `b₈ = b₂b₆ − b₄²` in characteristic three,
-  the `4 = 1` specialisation of Mathlib's `b_relation`.
 * `TauCeti.WeierstrassCurve.Ψ₃_mem_range_expand`, `ΨSq_three_mem_range_expand`: characteristic
   three.
 
@@ -33,8 +31,11 @@ field or to a universal polynomial ring.
 
 Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
 `HasseWeil/Verschiebung/DivPolyExpand.lean`, declarations `Φ_two_mem_expand_two_charP`,
-`ΨSq_two_mem_expand_two_charP`, `b_relation_of_charP_three`, `Ψ₃_mem_expand_three_charP` and
+`ΨSq_two_mem_expand_two_charP`, `Ψ₃_mem_expand_three_charP` and
 `ΨSq_three_mem_expand_three_charP`.
+
+The source's `b_relation_of_charP_three` is not ported: Mathlib already has it verbatim as
+`WeierstrassCurve.b_relation_of_char_three` (`Weierstrass.lean:213`).
 
 That file's sixth declaration, `Φ_three_mem_expand_three_charP`, is **not** ported: it carries
 `set_option maxHeartbeats 1000000`, which this repository forbids, and making it elaborate within
@@ -71,14 +72,6 @@ theorem ΨSq_two_mem_range_expand [CharP R 2] : W.ΨSq 2 ∈ Set.range (⇑(expa
   have h4 : (4 : R) = 0 := by rw [show (4 : R) = 2 * 2 from by ring, h2, mul_zero]
   rw [h4, show (2 : R) * W.b₄ = 0 by rw [h2, zero_mul], map_zero, zero_mul, zero_mul]
   ring
-
-/-- In characteristic three, `b₈ = b₂b₆ − b₄²`.
-
-Mathlib's `b_relation` reads `4b₈ = b₂b₆ − b₄²`, and `4 = 1` here. -/
-theorem b₈_eq_of_charP_three [CharP R 3] : W.b₈ = W.b₂ * W.b₆ - W.b₄ ^ 2 := by
-  have h4 : (4 : R) = 1 := by
-    rw [show (4 : R) = 3 + 1 from by ring, show (3 : R) = 0 from CharP.cast_eq_zero R 3, zero_add]
-  simpa [h4] using W.b_relation
 
 /-- In characteristic three, `Ψ₃` is a polynomial in `X³`.
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import Mathlib.Algebra.Polynomial.Expand
+
+/-!
+# Division polynomials in characteristic `p` are `p`-th power substitutions
+
+In characteristic `p` the low division polynomials of a Weierstrass curve lie in the image of
+`Polynomial.expand R p`, that is, they are polynomials in `Xᵖ`. This is the base case of the
+factorisation of the `p`-power isogeny through Frobenius (Silverman III.6.2): the terms that
+obstruct it all carry a factor of `p`.
+
+Concretely, in characteristic `2` the `2 * b₆ * X` term of `Φ₂` and the `4X³`, `2b₄X` terms of
+`ΨSq₂` vanish; in characteristic `3` the `3X⁴`, `3b₄X²`, `3b₆X` terms of `Ψ₃` vanish. Everything
+is stated over an arbitrary commutative ring carrying `CharP`, so it specialises unchanged to a
+field or to a universal polynomial ring.
+
+## Main results
+
+* `TauCeti.WeierstrassCurve.Φ_two_mem_range_expand`, `ΨSq_two_mem_range_expand`: characteristic
+  two.
+* `TauCeti.WeierstrassCurve.b₈_eq_of_charP_three`: `b₈ = b₂b₆ − b₄²` in characteristic three,
+  the `4 = 1` specialisation of Mathlib's `b_relation`.
+* `TauCeti.WeierstrassCurve.Ψ₃_mem_range_expand`, `ΨSq_three_mem_range_expand`: characteristic
+  three.
+
+## Provenance
+
+Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
+`HasseWeil/Verschiebung/DivPolyExpand.lean`, declarations `Φ_two_mem_expand_two_charP`,
+`ΨSq_two_mem_expand_two_charP`, `b_relation_of_charP_three`, `Ψ₃_mem_expand_three_charP` and
+`ΨSq_three_mem_expand_three_charP`.
+
+That file's sixth declaration, `Φ_three_mem_expand_three_charP`, is **not** ported: it carries
+`set_option maxHeartbeats 1000000`, which this repository forbids, and making it elaborate within
+budget is a separate piece of work rather than a transcription.
+-/
+
+public section
+
+open Polynomial
+
+namespace TauCeti
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R)
+
+/-- In characteristic two, `Φ₂` is a polynomial in `X²`.
+
+`Φ₂ = X⁴ − b₄X² − 2b₆X − b₈`, and the `2b₆X` term vanishes. -/
+theorem Φ_two_mem_range_expand [CharP R 2] : W.Φ 2 ∈ Set.range (⇑(expand R 2)) := by
+  refine ⟨X ^ 2 - C W.b₄ * X - C W.b₈, ?_⟩
+  rw [W.Φ_two, map_sub, map_sub, map_mul, expand_C, expand_X, map_pow, expand_X, expand_C]
+  have h2 : (2 : R) * W.b₆ = 0 := by rw [show (2 : R) = 0 from CharP.cast_eq_zero R 2, zero_mul]
+  rw [h2, map_zero, zero_mul, sub_zero]
+  ring
+
+/-- In characteristic two, `ΨSq₂` is a polynomial in `X²`.
+
+`ΨSq₂ = Ψ₂Sq = 4X³ + b₂X² + 2b₄X + b₆`, and the `4X³` and `2b₄X` terms vanish. -/
+theorem ΨSq_two_mem_range_expand [CharP R 2] : W.ΨSq 2 ∈ Set.range (⇑(expand R 2)) := by
+  refine ⟨C W.b₂ * X + C W.b₆, ?_⟩
+  rw [W.ΨSq_two, _root_.WeierstrassCurve.Ψ₂Sq, map_add, map_mul, expand_C, expand_X, expand_C]
+  have h2 : (2 : R) = 0 := CharP.cast_eq_zero R 2
+  have h4 : (4 : R) = 0 := by rw [show (4 : R) = 2 * 2 from by ring, h2, mul_zero]
+  rw [h4, show (2 : R) * W.b₄ = 0 by rw [h2, zero_mul], map_zero, zero_mul, zero_mul]
+  ring
+
+/-- In characteristic three, `b₈ = b₂b₆ − b₄²`.
+
+Mathlib's `b_relation` reads `4b₈ = b₂b₆ − b₄²`, and `4 = 1` here. -/
+theorem b₈_eq_of_charP_three [CharP R 3] : W.b₈ = W.b₂ * W.b₆ - W.b₄ ^ 2 := by
+  have h4 : (4 : R) = 1 := by
+    rw [show (4 : R) = 3 + 1 from by ring, show (3 : R) = 0 from CharP.cast_eq_zero R 3, zero_add]
+  simpa [h4] using W.b_relation
+
+/-- In characteristic three, `Ψ₃` is a polynomial in `X³`.
+
+`Ψ₃ = 3X⁴ + b₂X³ + 3b₄X² + 3b₆X + b₈`, and every term with a factor of `3` vanishes. -/
+theorem Ψ₃_mem_range_expand [CharP R 3] : W.Ψ₃ ∈ Set.range (⇑(expand R 3)) := by
+  refine ⟨C W.b₂ * X + C W.b₈, ?_⟩
+  rw [_root_.WeierstrassCurve.Ψ₃, map_add, map_mul, expand_C, expand_X, expand_C]
+  have h3 : (3 : R[X]) = 0 := by exact_mod_cast CharP.cast_eq_zero R[X] 3
+  linear_combination -(X ^ 4 + C W.b₄ * X ^ 2 + C W.b₆ * X) * h3
+
+/-- In characteristic three, `ΨSq₃` is a polynomial in `X³`, since it is `Ψ₃²` and `expand` is
+multiplicative. -/
+theorem ΨSq_three_mem_range_expand [CharP R 3] : W.ΨSq 3 ∈ Set.range (⇑(expand R 3)) := by
+  obtain ⟨g, hg⟩ := Ψ₃_mem_range_expand W
+  exact ⟨g ^ 2, by rw [W.ΨSq_three, ← hg, map_pow]⟩
+
+end WeierstrassCurve
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
@@ -24,22 +24,23 @@ field or to a universal polynomial ring.
 
 * `TauCeti.WeierstrassCurve.Φ_two_mem_range_expand`, `ΨSq_two_mem_range_expand`: characteristic
   two.
-* `TauCeti.WeierstrassCurve.Ψ₃_mem_range_expand`, `ΨSq_three_mem_range_expand`: characteristic
-  three.
+* `TauCeti.WeierstrassCurve.Ψ₃_mem_range_expand`, `ΨSq_three_mem_range_expand`,
+  `Φ_three_mem_range_expand`: characteristic three.
 
 ## Provenance
 
 Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
 `HasseWeil/Verschiebung/DivPolyExpand.lean`, declarations `Φ_two_mem_expand_two_charP`,
-`ΨSq_two_mem_expand_two_charP`, `Ψ₃_mem_expand_three_charP` and
-`ΨSq_three_mem_expand_three_charP`.
+`ΨSq_two_mem_expand_two_charP`, `Ψ₃_mem_expand_three_charP`,
+`ΨSq_three_mem_expand_three_charP` and `Φ_three_mem_expand_three_charP`.
 
 The source's `b_relation_of_charP_three` is not ported: Mathlib already has it verbatim as
 `WeierstrassCurve.b_relation_of_char_three` (`Weierstrass.lean:213`).
 
-That file's sixth declaration, `Φ_three_mem_expand_three_charP`, is **not** ported: it carries
-`set_option maxHeartbeats 1000000`, which this repository forbids, and making it elaborate within
-budget is a separate piece of work rather than a transcription.
+The source proves `Φ_three_mem_expand_three_charP` by exhibiting an explicit cubic witness,
+which needs `set_option maxHeartbeats 1000000`; this repository forbids raising the limit, so
+`Φ_three_mem_range_expand` is instead proved through `Polynomial.expand_contract` (whence its
+extra `NoZeroDivisors` hypothesis) and elaborates within the default budget.
 -/
 
 public section
@@ -82,6 +83,37 @@ multiplicative. -/
 theorem ΨSq_three_mem_range_expand [CharP R 3] : W.ΨSq 3 ∈ Set.range (⇑(expand R 3)) := by
   obtain ⟨g, hg⟩ := Ψ₃_mem_range_expand W
   exact ⟨g ^ 2, by rw [W.ΨSq_three, ← hg, map_pow]⟩
+
+/-- In characteristic three, `Φ₃` is a polynomial in `X³`.
+
+Unlike the cases above, this is proved through the derivative criterion: in characteristic `p` a
+polynomial with vanishing derivative lies in the image of `expand R p`
+(`Polynomial.expand_contract`, whence the `NoZeroDivisors` hypothesis), and
+`derivative (Φ 3) = 0` is a `linear_combination` over `3 = 0` and the characteristic-three
+`b`-relation `b₈ = b₂b₆ − b₄²`. The explicit-witness route this replaces does not elaborate
+within the repository heartbeat budget. -/
+theorem Φ_three_mem_range_expand [CharP R 3] [NoZeroDivisors R] :
+    W.Φ 3 ∈ Set.range (⇑(expand R 3)) := by
+  have hderiv : Polynomial.derivative (W.Φ 3) = 0 := by
+    have h3 : (3 : R[X]) = 0 := by exact_mod_cast CharP.cast_eq_zero R[X] 3
+    have hbC : C W.b₈ = C W.b₂ * C W.b₆ - C W.b₄ ^ 2 := by
+      rw [W.b_relation_of_char_three, map_sub, map_mul, map_pow]
+    rw [_root_.WeierstrassCurve.Φ_three]
+    simp only [_root_.WeierstrassCurve.Ψ₃, _root_.WeierstrassCurve.preΨ₄,
+      _root_.WeierstrassCurve.Ψ₂Sq, derivative_mul, derivative_X, derivative_pow, derivative_add,
+      derivative_C, derivative_ofNat, map_ofNat, map_sub, map_mul, map_pow, Nat.cast_ofNat]
+    rw [hbC]
+    -- The remaining identity is `3 * M = 0` for the explicit polynomial `M` below.
+    linear_combination (3 * X ^ 8 - 14 * C W.b₄ * X ^ 6 -
+      (2 * C W.b₂ * C W.b₄ + 48 * C W.b₆) * X ^ 5 -
+      (65 * C W.b₂ * C W.b₆ - 55 * C W.b₄ ^ 2) * X ^ 4 -
+      (16 * C W.b₂ ^ 2 * C W.b₆ - 16 * C W.b₂ * C W.b₄ ^ 2 + 4 * C W.b₄ * C W.b₆) * X ^ 3 -
+      (C W.b₂ ^ 3 * C W.b₆ - C W.b₂ ^ 2 * C W.b₄ ^ 2 + 17 * C W.b₂ * C W.b₄ * C W.b₆ -
+        18 * C W.b₄ ^ 3 - 3 * C W.b₆ ^ 2) * X ^ 2 -
+      (2 * C W.b₂ ^ 2 * C W.b₄ * C W.b₆ - 2 * C W.b₂ * C W.b₄ ^ 3 + 2 * C W.b₂ * C W.b₆ ^ 2 -
+        4 * C W.b₄ ^ 2 * C W.b₆) * X -
+      (C W.b₂ * C W.b₄ ^ 2 * C W.b₆ - C W.b₄ ^ 4 - C W.b₄ * C W.b₆ ^ 2)) * h3
+  exact ⟨contract 3 (W.Φ 3), expand_contract (p := 3) hderiv (by norm_num)⟩
 
 end WeierstrassCurve
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divpoly-expand"}-->

Roadmap: EllipticCurves

Adds `TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean`: in characteristic
`p`, the low division polynomials of a Weierstrass curve are polynomials in `Xᵖ`.

```lean
theorem Φ_two_mem_range_expand     [CharP R 2] : W.Φ 2   ∈ Set.range (expand R 2)
theorem ΨSq_two_mem_range_expand   [CharP R 2] : W.ΨSq 2 ∈ Set.range (expand R 2)
theorem Ψ₃_mem_range_expand        [CharP R 3] : W.Ψ₃   ∈ Set.range (expand R 3)
theorem ΨSq_three_mem_range_expand [CharP R 3] : W.ΨSq 3 ∈ Set.range (expand R 3)
theorem Φ_three_mem_range_expand   [CharP R 3] : W.Φ 3 ∈ Set.range (expand R 3)
```

This is the base case of the factorisation of the `p`-power isogeny through Frobenius
(Silverman III.6.2): the terms obstructing it all carry a factor of `p`. Everything is over an
arbitrary commutative ring carrying `CharP`, so it specialises unchanged to a field or to a
universal polynomial ring.

## Mathlib check

Nothing in this direction exists: `grep -F expand` over
`Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/` returns nothing, and there is no
Frobenius/Verschiebung factorisation for division polynomials in the pin. The Mathlib names used
are all confirmed present — `Φ_two` (`Basic.lean:371`), `ΨSq_two` (`:258`), `ΨSq_three` (`:262`),
`b_relation` (`Weierstrass.lean:116`).

⚠ One correction from the dry run: I had also included a char-3 `b₈ = b₂b₆ − b₄²` lemma, which
Mathlib already has verbatim as `WeierstrassCurve.b_relation_of_char_three`
(`Weierstrass.lean:213`). I missed it because I grepped `b_relation` and piped through `head -3`,
truncating the output before that line — a full-name, untruncated search finds it immediately.
The port now cites the Mathlib lemma directly (it enters `Φ_three_mem_range_expand`'s proof).

## Provenance

Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
`HasseWeil/Verschiebung/DivPolyExpand.lean`, declarations `Φ_two_mem_expand_two_charP`,
`ΨSq_two_mem_expand_two_charP`, `Ψ₃_mem_expand_three_charP`,
`ΨSq_three_mem_expand_three_charP` and `Φ_three_mem_expand_three_charP`.

**One proof is adapted to fit the default heartbeat budget.** The source proves
`Φ_three_mem_expand_three_charP` with an explicit witness cubic and a sympy-verified
`linear_combination`, but under a five-fold raised heartbeat limit, which this repository
forbids. `Φ_three_mem_range_expand` keeps the source's witness and strategy (multipliers
re-verified symbolically over `ℤ`) and substitutes the characteristic-three `b₈`-relation at the
`C`-level inside the `linear_combination` rather than rewriting it into the goal — that is what
lets the same argument elaborate within the default budget, over an arbitrary `CharP R 3`
commutative ring with no extra hypotheses.

Names are conclusion-shaped rather than the source's: `…_mem_range_expand` says what is proved.

## Roadmap

`EllipticCurves`, Layer 3 — the Hasse strand, whose §Ordering entry reads *"the Hasse bound is the
earliest PR, its existing proof self-contained; the zeta strand needs Layer 1's Frobenius
identities."*

A prerequisite rather than a target, which `CLAUDE.md` admits explicitly: a declaration may be
added when it *"advances a specific roadmap target, or supplies a prerequisite that a specific
target needs"*. The need is checkable, and I checked it rather than assuming: in the roadmap's
pinned Hasse provenance (`dev/hasse-weil @ 513e83879e2f`),
`HasseWeil/Verschiebung/DivPolyExpand.lean` lies inside the **187-file import closure of the
capstone `hasse_bound` proof** (the project as a whole has 283 files, so closure membership is not
automatic).

No curve point, torsion hypothesis or ellipticity assumption appears in any statement, and nothing
here waits on absent material.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
locally. No `sorry`, no `maxHeartbeats`.
