### PR TITLE
refactor(Subcomodule): name the two comodule axioms of the quotient coaction

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Quotient.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Quotient.lean
@@ -138,55 +138,73 @@ private theorem tensor_assoc_quotient_coact (m : M) :
           rw [LinearMap.lTensor_map]
           simp
 
+/-- **Coassociativity of the quotient coaction.** This is the first comodule axiom for
+`Subcomodule.quotientCoact`, and the coassociativity field of
+`Subcomodule.instComoduleQuotient`. -/
+private theorem quotientCoact_coassoc :
+    TensorProduct.assoc R (M ⧸ N.toSubmodule) C C ∘ₗ N.quotientCoact.rTensor C ∘ₗ
+        N.quotientCoact =
+      Coalgebra.comul.lTensor (M ⧸ N.toSubmodule) ∘ₗ N.quotientCoact := by
+  -- Both sides are linear maps out of a quotient, so it is enough to check them on classes.
+  apply Submodule.linearMap_qext
+  ext m
+  rw [LinearMap.comp_apply, LinearMap.comp_apply, LinearMap.comp_apply, LinearMap.comp_apply,
+    Submodule.mkQ_apply, quotientCoact_mk, LinearMap.rTensor_map]
+  rw [N.quotientCoact_comp_mkQ]
+  calc
+    TensorProduct.assoc R (M ⧸ N.toSubmodule) C C
+        (TensorProduct.map
+          ((TensorProduct.map N.toSubmodule.mkQ (LinearMap.id : C →ₗ[R] C)).comp
+            (Comodule.coact (R := R) (C := C) (M := M)))
+          (LinearMap.id : C →ₗ[R] C)
+          (Comodule.coact (R := R) (C := C) (M := M) m)) =
+        Coalgebra.comul.lTensor (M ⧸ N.toSubmodule)
+          (TensorProduct.map N.toSubmodule.mkQ (LinearMap.id : C →ₗ[R] C)
+            (Comodule.coact (R := R) (C := C) (M := M) m)) := by
+          exact N.tensor_assoc_quotient_coact m
+    _ = (LinearMap.lTensor (M ⧸ N.toSubmodule) Coalgebra.comul ∘ₗ N.quotientCoact)
+          (Submodule.Quotient.mk m) := by
+          rw [LinearMap.comp_apply, quotientCoact_mk]
+
+/-- **The counit law for the quotient coaction.** This is the second comodule axiom for
+`Subcomodule.quotientCoact`, and the counit field of `Subcomodule.instComoduleQuotient`. -/
+private theorem quotientCoact_counit :
+    Coalgebra.counit.lTensor (M ⧸ N.toSubmodule) ∘ₗ N.quotientCoact =
+      (TensorProduct.mk R (M ⧸ N.toSubmodule) R).flip 1 := by
+  -- Again it suffices to check on classes, where the ambient counit law applies.
+  apply Submodule.linearMap_qext
+  ext m
+  rw [LinearMap.comp_apply, LinearMap.comp_apply, Submodule.mkQ_apply, quotientCoact_mk]
+  calc
+    Coalgebra.counit.lTensor (M ⧸ N.toSubmodule)
+        (TensorProduct.map N.toSubmodule.mkQ (LinearMap.id : C →ₗ[R] C)
+          (Comodule.coact (R := R) (C := C) (M := M) m)) =
+      TensorProduct.map N.toSubmodule.mkQ
+        (Coalgebra.counit.comp (LinearMap.id : C →ₗ[R] C))
+        (Comodule.coact (R := R) (C := C) (M := M) m) := by
+        exact
+          LinearMap.lTensor_map (R := R) M Coalgebra.counit N.toSubmodule.mkQ
+            (LinearMap.id : C →ₗ[R] C)
+            (Comodule.coact (R := R) (C := C) (M := M) m)
+    _ =
+      TensorProduct.map N.toSubmodule.mkQ (LinearMap.id : R →ₗ[R] R)
+        (Coalgebra.counit.lTensor M
+          (Comodule.coact (R := R) (C := C) (M := M) m)) := by
+        rw [LinearMap.lTensor_def, TensorProduct.map_map]
+        simp
+    _ = ((TensorProduct.mk R (M ⧸ N.toSubmodule) R).flip 1)
+          (Submodule.Quotient.mk m) := by
+        rw [Comodule.lTensor_counit_coact]
+        simp only [LinearMap.flip_apply, TensorProduct.mk_apply, TensorProduct.map_tmul,
+          LinearMap.id_coe, id_eq, Submodule.mkQ_apply]
+
 /-- The quotient of a right comodule by a subcomodule inherits a right-comodule structure. -/
 instance instComoduleQuotient : Comodule R C (M ⧸ N.toSubmodule) where
   coact := N.quotientCoact
-  coassoc := by
-    apply Submodule.linearMap_qext
-    ext m
-    rw [LinearMap.comp_apply, LinearMap.comp_apply, LinearMap.comp_apply, LinearMap.comp_apply,
-      Submodule.mkQ_apply, quotientCoact_mk, LinearMap.rTensor_map]
-    rw [N.quotientCoact_comp_mkQ]
-    calc
-      TensorProduct.assoc R (M ⧸ N.toSubmodule) C C
-          (TensorProduct.map
-            ((TensorProduct.map N.toSubmodule.mkQ (LinearMap.id : C →ₗ[R] C)).comp
-              (Comodule.coact (R := R) (C := C) (M := M)))
-            (LinearMap.id : C →ₗ[R] C)
-            (Comodule.coact (R := R) (C := C) (M := M) m)) =
-          Coalgebra.comul.lTensor (M ⧸ N.toSubmodule)
-            (TensorProduct.map N.toSubmodule.mkQ (LinearMap.id : C →ₗ[R] C)
-              (Comodule.coact (R := R) (C := C) (M := M) m)) := by
-            exact N.tensor_assoc_quotient_coact m
-      _ = (LinearMap.lTensor (M ⧸ N.toSubmodule) Coalgebra.comul ∘ₗ N.quotientCoact)
-            (Submodule.Quotient.mk m) := by
-            rw [LinearMap.comp_apply, quotientCoact_mk]
-  lTensor_counit_comp_coact := by
-    apply Submodule.linearMap_qext
-    ext m
-    rw [LinearMap.comp_apply, LinearMap.comp_apply, Submodule.mkQ_apply, quotientCoact_mk]
-    calc
-      Coalgebra.counit.lTensor (M ⧸ N.toSubmodule)
-          (TensorProduct.map N.toSubmodule.mkQ (LinearMap.id : C →ₗ[R] C)
-            (Comodule.coact (R := R) (C := C) (M := M) m)) =
-        TensorProduct.map N.toSubmodule.mkQ
-          (Coalgebra.counit.comp (LinearMap.id : C →ₗ[R] C))
-          (Comodule.coact (R := R) (C := C) (M := M) m) := by
-          exact
-            LinearMap.lTensor_map (R := R) M Coalgebra.counit N.toSubmodule.mkQ
-              (LinearMap.id : C →ₗ[R] C)
-              (Comodule.coact (R := R) (C := C) (M := M) m)
-      _ =
-        TensorProduct.map N.toSubmodule.mkQ (LinearMap.id : R →ₗ[R] R)
-          (Coalgebra.counit.lTensor M
-            (Comodule.coact (R := R) (C := C) (M := M) m)) := by
-          rw [LinearMap.lTensor_def, TensorProduct.map_map]
-          simp
-      _ = ((TensorProduct.mk R (M ⧸ N.toSubmodule) R).flip 1)
-            (Submodule.Quotient.mk m) := by
-          rw [Comodule.lTensor_counit_coact]
-          simp only [LinearMap.flip_apply, TensorProduct.mk_apply, TensorProduct.map_tmul,
-            LinearMap.id_coe, id_eq, Submodule.mkQ_apply]
+  -- The two axioms are `by exact` rather than bare terms: this instance is public, so its body may
+  -- not name a private declaration, while a tactic proof of a `Prop` field may.
+  coassoc := by exact quotientCoact_coassoc N
+  lTensor_counit_comp_coact := by exact quotientCoact_counit N
 
 /-- The coaction on the quotient comodule is `Subcomodule.quotientCoact`. -/
 @[simp]


### PR DESCRIPTION
`instComoduleQuotient` proved both comodule axioms inline, giving a 46-line structure body. This
names them, as the surrounding area already does for every other coaction it constructs.

| helper | says |
|---|---|
| `quotientCoact_coassoc` | `assoc ∘ₗ quotientCoact.rTensor C ∘ₗ quotientCoact = comul.lTensor (M ⧸ N) ∘ₗ quotientCoact` |
| `quotientCoact_counit` | `counit.lTensor (M ⧸ N) ∘ₗ quotientCoact = (mk R (M ⧸ N) R).flip 1` |

The names follow the `〈coaction〉_coassoc` / `〈coaction〉_counit` convention already used by
`tensorCoact_`, `prodCoact_` and `dualCoact_` in `TauCeti/Algebra/Coalgebra/Comodule/`.

Structure body: 46 → 2 lines; the two new bodies are 21 and 27. No statement changes, and both
helpers are `private`.

## Why the fields are `by exact`

`coassoc := quotientCoact_coassoc N` does not compile: the instance is public, so its body may not
name a private declaration, whereas a tactic proof of a `Prop` field may. That is why the previous
inline proofs could already call the private helpers in this file. There is a comment in the source
saying so. Making the axioms public instead would add API nothing outside the instance wants.

This is the companion of #2359, which does the same for the induced coaction on a subcomodule; the
two files construct the two comodule structures that `Subcomodule` provides.

Roadmap: ReductiveGroups
