### PR TITLE
feat: identify the boundary piece a subdomain of a conformal map clings to

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/ClusterSet.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ClusterSet.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Analysis.Complex.Conformal.BoundaryCorrespondence
 public import TauCeti.Topology.ClusterSet
 import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
+import TauCeti.Topology.Frontier
 
 /-!
 # The boundary cluster set of a conformal map
@@ -37,6 +38,13 @@ extension from the hypotheses.
 * **Conversely, the boundary cluster sets exhaust the frontier of the image**, for a bounded
   domain: no boundary point of `f '' U` is missed. This is the surjectivity of the boundary
   correspondence, and it is what makes the inclusion of the first item an equality.
+* **Relatively: the boundary piece a subdomain clings to is the union of its own boundary cluster
+  sets.** For any `V ⊆ U` with compact closure,
+  `frontier (f '' U) ∩ frontier (f '' V) = ⋃ e ∈ frontier U ∩ closure V, clusterSetOn f V e`, the
+  cluster sets being taken *along `V`*. The previous item is the case `V = U`. The point of the
+  relative form is that `V` may be shrunk: taking `V` to be the crosscut neighbourhood
+  `U ∩ ball w ρ` of a boundary point identifies the boundary piece that the circle `sphere w ρ`
+  cuts off, and letting `ρ` fall shrinks those pieces exactly to `clusterSetOn f U w`.
 
 A third ingredient is again not about conformality and is proved upstream, in
 `TauCeti/Analysis/Convex/ClusterSet.lean`: on a **convex** domain — the unit disc, in the
@@ -55,6 +63,16 @@ namely injectivity of the extension on `frontier U`, which `TauCeti.injOn_closur
 then propagates to `closure U` for `TauCeti.closureHomeomorph`. Neither the singleton property nor
 boundary injectivity is proved here.
 
+The relative form is what connects that vocabulary to the *geometric* criterion of
+`Conformal/CutDiameter.lean`. There,
+`TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` produces the continuous
+extension from a bound on the diameter of `f '' (U ∩ sphere w ρ)` together with a bounded set
+enclosing `frontier (f '' U) ∩ frontier (f '' (U ∩ ball w ρ))`. The first of those two data is what
+the length–area method of `Conformal/LengthArea.lean` supplies; the second is the input still
+missing at layer L5, and what the relative form does is *name* it — as a union of cluster sets over
+the boundary points of `U` inside the closed disc — and show that these sets are precisely what the
+cluster set at `w` is the limit of. No estimate on them is claimed here.
+
 In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
 every theorem added in layers L0–L6, the results below are stated for maps of `ℂ`, as in
 `Conformal/BoundaryCorrespondence.lean`.
@@ -70,6 +88,15 @@ every theorem added in layers L0–L6, the results below are stated for maps of 
   bounded domain the boundary cluster sets cover, hence exactly exhaust, the frontier of the image.
   The case a Riemann map presents is the unit disc, where `frontier_ball` rewrites `frontier U` to
   the unit circle.
+* `TauCeti.frontier_inter_closure_image_eq_biUnion_clusterSetOn` and
+  `TauCeti.frontier_inter_frontier_image_eq_biUnion_clusterSetOn` — **the relative form**: the
+  boundary piece a subdomain `V ⊆ U` clings to is the union of the cluster sets along `V` over the
+  boundary points of `U` adherent to `V`, whether that piece is read off `closure (f '' V)` or off
+  `frontier (f '' V)`.
+* `TauCeti.frontier_inter_frontier_image_inter_ball_eq_biUnion_clusterSetOn` and
+  `TauCeti.iInter_frontier_inter_frontier_image_inter_ball_eq_clusterSetOn` — **the boundary piece
+  cut off at a point**: its identification for the crosscut neighbourhood `U ∩ ball w ρ`, and the
+  fact that these pieces shrink, as `ρ` falls, exactly to `clusterSetOn f U w`.
 
 ## Coordination with upstream Mathlib
 
@@ -190,19 +217,155 @@ theorem exists_mem_frontier_mem_clusterSetOn (hUo : IsOpen U) (hUb : Bornology.I
   exact exists_mem_frontier_mem_clusterSetOn_of_notMem_image hUb.isCompact_closure hfd.continuousOn
     hv.1 hv.2
 
+/-- **The boundary piece a subdomain clings to is the union of its own boundary cluster sets.** For
+`f` holomorphic and injective on an open `U` and any `V ⊆ U` with compact closure,
+
+> `frontier (f '' U) ∩ closure (f '' V) = ⋃ e ∈ frontier U ∩ closure V, clusterSetOn f V e`.
+
+So the part of the image boundary that the image of `V` reaches is not merely covered by cluster
+sets: it *is* the union of the cluster sets of `f` **along `V`** at the boundary points of `U`
+adherent to `V`. Taking `V = U` recovers
+`TauCeti.biUnion_clusterSetOn_eq_frontier_image`; the content of the relative form is that shrinking
+`V` shrinks both sides in step, which is what makes the boundary piece an object one can estimate.
+
+Both inclusions come from the same source. Closing `f '' V` adds exactly the cluster values along
+`V` over `frontier V` (`TauCeti.closure_image_eq_image_union_biUnion_clusterSetOn`, which is why
+`closure V` is asked to be compact); a value *taken* on `V` lies in the open set `f '' U`, which is
+disjoint from its own frontier, so only cluster values survive on the left; and a cluster value at
+a point `e` of `frontier V` lying in `U` would be `f e` by continuity, which is again a taken
+value, so the surviving `e` are exactly those outside `U`, that is on `frontier U`. Conversely a
+cluster set along `V` at a point of `frontier U` sits inside `clusterSetOn f U e`, hence on
+`frontier (f '' U)` by `TauCeti.clusterSetOn_subset_frontier_image`, and inside `closure (f '' V)`
+by construction.
+
+Neither `V` nor `U` is asked to be connected, and `V` need not be open; the two sides of a circular
+crosscut, `U ∩ ball ζ ρ` and `U \ closedBall ζ ρ`, are the case layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md` consumes. -/
+theorem frontier_inter_closure_image_eq_biUnion_clusterSetOn (hUo : IsOpen U)
+    (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) {V : Set ℂ} (hVU : V ⊆ U)
+    (hVc : IsCompact (closure V)) :
+    frontier (f '' U) ∩ closure (f '' V) = ⋃ e ∈ frontier U ∩ closure V, clusterSetOn f V e := by
+  have hopen : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hUo hfd hfi
+  refine subset_antisymm ?_ (iUnion₂_subset fun e he => subset_inter
+    (fun _ hv => clusterSetOn_subset_frontier_image hUo hfd hfi he.1 (clusterSetOn_mono hVU hv))
+    fun _ hv => clusterSetOn_subset_closure_image hv)
+  rintro u ⟨hufr, hucl⟩
+  have hunot : u ∉ f '' U := fun h =>
+    eq_empty_iff_forall_notMem.mp hopen.inter_frontier_eq u ⟨h, hufr⟩
+  rw [closure_image_eq_image_union_biUnion_clusterSetOn hVc (hfd.continuousOn.mono hVU)] at hucl
+  rcases hucl with hu | hu
+  · exact absurd (image_mono hVU hu) hunot
+  obtain ⟨e, he, hue⟩ := mem_iUnion₂.mp hu
+  have hecl : e ∈ closure V := frontier_subset_closure he
+  refine mem_iUnion₂.mpr ⟨e, ⟨?_, hecl⟩, hue⟩
+  rw [hUo.frontier_eq]
+  refine ⟨closure_mono hVU hecl, fun heU => ?_⟩
+  rw [clusterSetOn_eq_singleton_of_tendsto hecl
+    ((hfd.differentiableAt (hUo.mem_nhds heU)).continuousAt.continuousWithinAt),
+    mem_singleton_iff] at hue
+  exact hunot ⟨e, heU, hue.symm⟩
+
+/-- **The boundary piece a subdomain clings to, read on the frontier of its image.** The form of
+`TauCeti.frontier_inter_closure_image_eq_biUnion_clusterSetOn` that a domain-splitting estimate
+consumes:
+
+> `frontier (f '' U) ∩ frontier (f '' V) = ⋃ e ∈ frontier U ∩ closure V, clusterSetOn f V e`.
+
+The left-hand sides of the two statements agree because `f '' V` lies in the open set `f '' U`, so
+the boundary of `f '' U` reaches `closure (f '' V)` only through `frontier (f '' V)` — that is
+`TauCeti.frontier_inter_closure_eq_frontier_inter_frontier`, a fact of pure topology.
+
+The distinction matters because the two descriptions arise on opposite sides of the argument. The
+cluster-set description is produced by a *limit* argument, which naturally speaks of closures;
+`TauCeti.diam_image_inter_ball_le` of `Conformal/CutDiameter.lean` — which bounds the width of one
+side of a crosscut by the width of the crosscut together with the boundary piece it cuts off — asks
+for the *frontier* form, this being the shape in which the splitting lemma
+`TauCeti.frontier_image_subset_image_union_frontier_image` delivers it. -/
+theorem frontier_inter_frontier_image_eq_biUnion_clusterSetOn (hUo : IsOpen U)
+    (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) {V : Set ℂ} (hVU : V ⊆ U)
+    (hVc : IsCompact (closure V)) :
+    frontier (f '' U) ∩ frontier (f '' V) = ⋃ e ∈ frontier U ∩ closure V, clusterSetOn f V e := by
+  rw [← frontier_inter_closure_eq_frontier_inter_frontier (image_mono hVU),
+    frontier_inter_closure_image_eq_biUnion_clusterSetOn hUo hfd hfi hVU hVc]
+
 /-- **The boundary cluster sets exhaust the frontier of the image.** For a conformal map of a
 bounded open set, the union of the cluster sets over `frontier U` is exactly `frontier (f '' U)`.
 
-One inclusion is `TauCeti.clusterSetOn_subset_frontier_image` — no boundary cluster value is
-attained, and none escapes the closure of the image — and the other is
-`TauCeti.exists_mem_frontier_mem_clusterSetOn`. Neither connectedness nor simple connectedness of
-`U` is used, and nothing is assumed about `frontier U`. -/
+This is the case `V = U` of `TauCeti.frontier_inter_closure_image_eq_biUnion_clusterSetOn`, where
+both intersections collapse: `frontier s ⊆ closure s` on each side. Neither connectedness nor
+simple connectedness of `U` is used, and nothing is assumed about `frontier U`. -/
 theorem biUnion_clusterSetOn_eq_frontier_image (hUo : IsOpen U) (hUb : Bornology.IsBounded U)
     (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) :
-    ⋃ w ∈ frontier U, clusterSetOn f U w = frontier (f '' U) :=
-  subset_antisymm (iUnion₂_subset fun _ hw => clusterSetOn_subset_frontier_image hUo hfd hfi hw)
-    fun _ hv => by
-      obtain ⟨w, hw, hvw⟩ := exists_mem_frontier_mem_clusterSetOn hUo hUb hfd hfi hv
-      exact mem_biUnion hw hvw
+    ⋃ w ∈ frontier U, clusterSetOn f U w = frontier (f '' U) := by
+  have h := frontier_inter_closure_image_eq_biUnion_clusterSetOn hUo hfd hfi (subset_refl U)
+    hUb.isCompact_closure
+  rwa [inter_eq_self_of_subset_left (frontier_subset_closure (s := f '' U)),
+    inter_eq_self_of_subset_left (frontier_subset_closure (s := U)), eq_comm] at h
+
+/-! ## The boundary piece cut off at a point -/
+
+/-- **The boundary piece the crosscut neighbourhood of a point cuts off.** The instance of
+`TauCeti.frontier_inter_frontier_image_eq_biUnion_clusterSetOn` at `V = U ∩ ball w ρ`, whose closure
+is compact because it lies in `closedBall w ρ`:
+
+> `frontier (f '' U) ∩ frontier (f '' (U ∩ ball w ρ))`
+> `= ⋃ e ∈ frontier U ∩ closure (U ∩ ball w ρ), clusterSetOn f (U ∩ ball w ρ) e`.
+
+The left-hand side is exactly the set that
+`TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` of
+`Conformal/CutDiameter.lean` asks to be enclosed in a small bounded set: what that criterion
+needs made small at each boundary point of `U`, alongside the image of the cutting circle. So this
+identifies its second geometric input — the first being the length–area estimate, which makes the
+image of the cutting circle short — as a union of cluster sets *along the crosscut neighbourhood*,
+indexed by the boundary points of `U` that the neighbourhood reaches.
+
+It is not the middle piece `frontier (f '' U) ∩ closure (f '' (U ∩ sphere w ρ))` of
+`Conformal/Crosscut/Image.lean`, which is indexed by the boundary points *on the cutting circle*
+and is small as soon as the image of that circle is. The piece here is indexed by the boundary
+points *inside* the closed disc, and making it small is the step layer **L5** still lacks. -/
+theorem frontier_inter_frontier_image_inter_ball_eq_biUnion_clusterSetOn (hUo : IsOpen U)
+    (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) (w : ℂ) (ρ : ℝ) :
+    frontier (f '' U) ∩ frontier (f '' (U ∩ ball w ρ)) =
+      ⋃ e ∈ frontier U ∩ closure (U ∩ ball w ρ), clusterSetOn f (U ∩ ball w ρ) e :=
+  frontier_inter_frontier_image_eq_biUnion_clusterSetOn hUo hfd hfi inter_subset_left
+    ((isCompact_closedBall w ρ).of_isClosed_subset isClosed_closure
+      (closure_minimal (inter_subset_right.trans ball_subset_closedBall) isClosed_closedBall))
+
+/-- **The boundary pieces cut off at a point shrink exactly to its cluster set.** At a boundary
+point `w` of `U`,
+
+> `⋂ ρ > 0, frontier (f '' U) ∩ frontier (f '' (U ∩ ball w ρ)) = clusterSetOn f U w`.
+
+The pieces decrease as `ρ` does — the crosscut neighbourhoods are nested, so by
+`TauCeti.frontier_inter_closure_eq_frontier_inter_frontier` and monotonicity of `closure` so are the
+pieces — and what they decrease to is precisely the set of values `f` approaches at `w`. So
+Carathéodory's assertion that a boundary cluster set is a singleton is
+equivalent to the boundary pieces cut off at `w` shrinking to a point, which is the form the
+crosscut estimates of layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` aim at: they bound
+the *diameter* of a piece at a well-chosen radius rather than describe the pieces individually.
+
+The inclusion `⊇` is `TauCeti.clusterSetOn_subset_frontier_image` together with
+`TauCeti.clusterSetOn_inter_of_mem_nhds`, which says a cluster set may be computed inside any ball
+about the point, so the cluster set is adherent to the image of every crosscut neighbourhood. The
+inclusion `⊆` is `TauCeti.clusterSetOn_eq_iInter`: every approach region in `𝓝[U] w` contains some
+`U ∩ ball w ρ`, so a point adherent to the image of each of those is adherent to the image of each
+approach region. -/
+theorem iInter_frontier_inter_frontier_image_inter_ball_eq_clusterSetOn (hUo : IsOpen U)
+    (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) (hw : w ∈ frontier U) :
+    ⋂ ρ > (0 : ℝ), frontier (f '' U) ∩ frontier (f '' (U ∩ ball w ρ)) = clusterSetOn f U w := by
+  refine subset_antisymm (fun u hu => ?_) (subset_iInter₂ fun ρ hρ => ?_)
+  · rw [clusterSetOn_eq_iInter]
+    refine mem_iInter₂.mpr fun s hs => ?_
+    obtain ⟨t, hto, hwt, hts⟩ := mem_nhdsWithin.mp hs
+    obtain ⟨ρ, hρ, hρt⟩ := Metric.isOpen_iff.mp hto w hwt
+    refine closure_mono (image_mono ?_) (frontier_subset_closure (mem_iInter₂.mp hu ρ hρ).2)
+    exact fun z hz => hts ⟨hρt hz.2, hz.1⟩
+  · have hwcl : w ∈ closure (U ∩ ball w ρ) := by
+      rw [mem_closure_iff_nhdsWithin_neBot,
+        nhdsWithin_inter_of_mem' (nhdsWithin_le_nhds (ball_mem_nhds w hρ))]
+      exact mem_closure_iff_nhdsWithin_neBot.mp (frontier_subset_closure hw)
+    rw [frontier_inter_frontier_image_inter_ball_eq_biUnion_clusterSetOn hUo hfd hfi w ρ,
+      ← clusterSetOn_inter_of_mem_nhds (f := f) (U := U) (ball_mem_nhds w hρ)]
+    exact subset_biUnion_of_mem ⟨hw, hwcl⟩
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/ClusterSet.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ClusterSet.lean
@@ -42,9 +42,10 @@ extension from the hypotheses.
   sets.** For any `V ⊆ U` with compact closure,
   `frontier (f '' U) ∩ frontier (f '' V) = ⋃ e ∈ frontier U ∩ closure V, clusterSetOn f V e`, the
   cluster sets being taken *along `V`*. The previous item is the case `V = U`. The point of the
-  relative form is that `V` may be shrunk: taking `V` to be the crosscut neighbourhood
-  `U ∩ ball w ρ` of a boundary point identifies the boundary piece that the circle `sphere w ρ`
-  cuts off, and letting `ρ` fall shrinks those pieces exactly to `clusterSetOn f U w`.
+  relative form is that `V` may be shrunk: taking `V` to be the ball neighbourhood
+  `U ∩ ball w ρ` of a boundary point identifies the boundary piece that neighbourhood clings to —
+  the piece the circle `sphere w ρ` cuts off, in the case where `U ∩ sphere w ρ` is a crosscut —
+  and letting `ρ` fall shrinks those pieces exactly to `clusterSetOn f U w`.
 
 A third ingredient is again not about conformality and is proved upstream, in
 `TauCeti/Analysis/Convex/ClusterSet.lean`: on a **convex** domain — the unit disc, in the
@@ -95,8 +96,8 @@ every theorem added in layers L0–L6, the results below are stated for maps of 
   `frontier (f '' V)`.
 * `TauCeti.frontier_inter_frontier_image_inter_ball_eq_biUnion_clusterSetOn` and
   `TauCeti.iInter_frontier_inter_frontier_image_inter_ball_eq_clusterSetOn` — **the boundary piece
-  cut off at a point**: its identification for the crosscut neighbourhood `U ∩ ball w ρ`, and the
-  fact that these pieces shrink, as `ρ` falls, exactly to `clusterSetOn f U w`.
+  at a point**: its identification for the ball neighbourhood `U ∩ ball w ρ`, and the fact that
+  these pieces shrink, as `ρ` falls, exactly to `clusterSetOn f U w`.
 
 ## Coordination with upstream Mathlib
 
@@ -238,9 +239,11 @@ cluster set along `V` at a point of `frontier U` sits inside `clusterSetOn f U e
 `frontier (f '' U)` by `TauCeti.clusterSetOn_subset_frontier_image`, and inside `closure (f '' V)`
 by construction.
 
-Neither `V` nor `U` is asked to be connected, and `V` need not be open; the two sides of a circular
-crosscut, `U ∩ ball ζ ρ` and `U \ closedBall ζ ρ`, are the case layer **L5** of
-`TauCetiRoadmap/ConformalMapping/README.md` consumes. -/
+Neither `V` nor `U` is asked to be connected, and `V` need not be open. What layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md` consumes are the two sides a circle cuts `U` into:
+`V = U ∩ ball ζ ρ`, whose closure is compact for every `U`, lying as it does in `closedBall ζ ρ`,
+and `V = U \ closedBall ζ ρ`, for which the compactness hypothesis is a real restriction — it
+holds when `U` is bounded, but for unbounded `U` that side has unbounded closure. -/
 theorem frontier_inter_closure_image_eq_biUnion_clusterSetOn (hUo : IsOpen U)
     (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) {V : Set ℂ} (hVU : V ⊆ U)
     (hVc : IsCompact (closure V)) :
@@ -302,9 +305,9 @@ theorem biUnion_clusterSetOn_eq_frontier_image (hUo : IsOpen U) (hUb : Bornology
   rwa [inter_eq_self_of_subset_left (frontier_subset_closure (s := f '' U)),
     inter_eq_self_of_subset_left (frontier_subset_closure (s := U)), eq_comm] at h
 
-/-! ## The boundary piece cut off at a point -/
+/-! ## The boundary piece at a point -/
 
-/-- **The boundary piece the crosscut neighbourhood of a point cuts off.** The instance of
+/-- **The boundary piece the ball neighbourhood of a point clings to.** The instance of
 `TauCeti.frontier_inter_frontier_image_eq_biUnion_clusterSetOn` at `V = U ∩ ball w ρ`, whose closure
 is compact because it lies in `closedBall w ρ`:
 
@@ -314,15 +317,17 @@ is compact because it lies in `closedBall w ρ`:
 The left-hand side is exactly the set that
 `TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` of
 `Conformal/CutDiameter.lean` asks to be enclosed in a small bounded set: what that criterion
-needs made small at each boundary point of `U`, alongside the image of the cutting circle. So this
-identifies its second geometric input — the first being the length–area estimate, which makes the
-image of the cutting circle short — as a union of cluster sets *along the crosscut neighbourhood*,
-indexed by the boundary points of `U` that the neighbourhood reaches.
+needs made small at each boundary point of `U`, alongside the image of the circle `sphere w ρ`. So
+this identifies its second geometric input — the first being the length–area estimate, which makes
+the image of that circle short — as a union of cluster sets *along the ball neighbourhood*, indexed
+by the boundary points of `U` that the neighbourhood reaches. Nothing here asks `U ∩ sphere w ρ` to
+be a crosscut; when it is one, `U ∩ ball w ρ` is the side of that crosscut towards `w` and the set
+below is the boundary piece it cuts off.
 
 It is not the middle piece `frontier (f '' U) ∩ closure (f '' (U ∩ sphere w ρ))` of
-`Conformal/Crosscut/Image.lean`, which is indexed by the boundary points *on the cutting circle*
-and is small as soon as the image of that circle is. The piece here is indexed by the boundary
-points *inside* the closed disc, and making it small is the step layer **L5** still lacks. -/
+`Conformal/Crosscut/Image.lean`, which is indexed by the boundary points *on the circle* and is
+small as soon as the image of that circle is. The piece here is indexed by the boundary points
+*inside* the closed disc, and making it small is the step layer **L5** still lacks. -/
 theorem frontier_inter_frontier_image_inter_ball_eq_biUnion_clusterSetOn (hUo : IsOpen U)
     (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) (w : ℂ) (ρ : ℝ) :
     frontier (f '' U) ∩ frontier (f '' (U ∩ ball w ρ)) =
@@ -331,22 +336,22 @@ theorem frontier_inter_frontier_image_inter_ball_eq_biUnion_clusterSetOn (hUo : 
     ((isCompact_closedBall w ρ).of_isClosed_subset isClosed_closure
       (closure_minimal (inter_subset_right.trans ball_subset_closedBall) isClosed_closedBall))
 
-/-- **The boundary pieces cut off at a point shrink exactly to its cluster set.** At a boundary
+/-- **The boundary pieces at a point shrink exactly to its cluster set.** At a boundary
 point `w` of `U`,
 
 > `⋂ ρ > 0, frontier (f '' U) ∩ frontier (f '' (U ∩ ball w ρ)) = clusterSetOn f U w`.
 
-The pieces decrease as `ρ` does — the crosscut neighbourhoods are nested, so by
+The pieces decrease as `ρ` does — the ball neighbourhoods are nested, so by
 `TauCeti.frontier_inter_closure_eq_frontier_inter_frontier` and monotonicity of `closure` so are the
 pieces — and what they decrease to is precisely the set of values `f` approaches at `w`. So
 Carathéodory's assertion that a boundary cluster set is a singleton is
-equivalent to the boundary pieces cut off at `w` shrinking to a point, which is the form the
+equivalent to the boundary pieces at `w` shrinking to a point, which is the form the
 crosscut estimates of layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` aim at: they bound
 the *diameter* of a piece at a well-chosen radius rather than describe the pieces individually.
 
 The inclusion `⊇` is `TauCeti.clusterSetOn_subset_frontier_image` together with
 `TauCeti.clusterSetOn_inter_of_mem_nhds`, which says a cluster set may be computed inside any ball
-about the point, so the cluster set is adherent to the image of every crosscut neighbourhood. The
+about the point, so the cluster set is adherent to the image of every ball neighbourhood. The
 inclusion `⊆` is `TauCeti.clusterSetOn_eq_iInter`: every approach region in `𝓝[U] w` contains some
 `U ∩ ball w ρ`, so a point adherent to the image of each of those is adherent to the image of each
 approach region. -/

--- a/TauCeti/Topology/ClusterSet.lean
+++ b/TauCeti/Topology/ClusterSet.lean
@@ -137,6 +137,16 @@ lemma isClosed_clusterSetOn : IsClosed (clusterSetOn f U w) := isClosed_setOfPre
 lemma clusterSetOn_mono {V : Set X} (h : U ⊆ V) : clusterSetOn f U w ⊆ clusterSetOn f V w :=
   fun _ hv => hv.mono (nhdsWithin_mono w h)
 
+/-- **The cluster set is local**: cutting the approach set down by a neighbourhood of the point
+leaves it unchanged, since `𝓝[U ∩ V] w = 𝓝[U] w` when `V ∈ 𝓝 w`. The converse inclusion to
+`TauCeti.clusterSetOn_mono` therefore holds for such a `V`, and a cluster set may be computed
+inside any ball about `w`. -/
+lemma clusterSetOn_inter_of_mem_nhds {V : Set X} (hV : V ∈ 𝓝 w) :
+    clusterSetOn f (U ∩ V) w = clusterSetOn f U w := by
+  ext v
+  rw [mem_clusterSetOn_iff, mem_clusterSetOn_iff,
+    nhdsWithin_inter_of_mem' (nhdsWithin_le_nhds hV)]
+
 /-- Every cluster value is a limit of image points: the cluster set sits inside
 `closure (f '' U)`. -/
 lemma clusterSetOn_subset_closure_image : clusterSetOn f U w ⊆ closure (f '' U) :=

--- a/TauCeti/Topology/ClusterSet.lean
+++ b/TauCeti/Topology/ClusterSet.lean
@@ -141,6 +141,7 @@ lemma clusterSetOn_mono {V : Set X} (h : U ⊆ V) : clusterSetOn f U w ⊆ clust
 leaves it unchanged, since `𝓝[U ∩ V] w = 𝓝[U] w` when `V ∈ 𝓝 w`. The converse inclusion to
 `TauCeti.clusterSetOn_mono` therefore holds for such a `V`, and a cluster set may be computed
 inside any ball about `w`. -/
+@[simp]
 lemma clusterSetOn_inter_of_mem_nhds {V : Set X} (hV : V ∈ 𝓝 w) :
     clusterSetOn f (U ∩ V) w = clusterSetOn f U w := by
   ext v

--- a/TauCeti/Topology/Frontier.lean
+++ b/TauCeti/Topology/Frontier.lean
@@ -8,9 +8,9 @@ module
 public import Mathlib.Topology.Connected.Basic
 
 /-!
-# Two frontier lemmas: straddling, and splitting a domain in two
+# Three frontier lemmas: straddling, splitting a domain in two, and clinging to it from inside
 
-Two elementary facts about `frontier`, each the topological core of a step that a boundary
+Three elementary facts about `frontier`, each the topological core of a step that a boundary
 argument would otherwise carry out inside a concrete space.
 
 ## A connected set that straddles a set meets its frontier
@@ -51,15 +51,32 @@ sides themselves is purely set-theoretic: `s ⊆ U` and the covering `U ⊆ s �
 map is open and injective on two disjoint open sides supplies both image hypotheses, as the
 conformal one below does through the open mapping theorem and `Disjoint.image`.
 
+## What a set's frontier sees of a subset
+
+A subset `A` of a set `V` cannot reach `frontier V` except through its own frontier:
+
+> `frontier V ∩ closure A = frontier V ∩ frontier A`
+
+(`TauCeti.frontier_inter_closure_eq_frontier_inter_frontier`). The reason is that `closure A` is
+`A ∪ frontier A`, and a point of `A` on `frontier V` is already on `frontier A`: it is adherent to
+`A` and, since `interior A ⊆ interior V`, it is not interior to `A`. So the part of `frontier V`
+that `A` clings to has two interchangeable descriptions — as the reach of `closure A`, and as the
+meeting of two frontiers. The first is the one an argument about limits of points of `A` produces;
+the second is the one a diameter estimate consumes, `frontier` being where the estimates of a
+domain-splitting argument live.
+
 ## Consumers
 
-Both lemmas serve layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, Carathéodory's
+All three lemmas serve layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, Carathéodory's
 boundary correspondence. The first does so through
 `TauCeti/Analysis/Normed/Module/DiamFrontier.lean`: a ray leaving a bounded set crosses its
 frontier, which is what makes the frontier of such a set as wide as the set itself. The second is
 the splitting step of `TauCeti/Analysis/Complex/Conformal/CutDiameter.lean`, where `s` and `t` are
-the two sides of a circular crosscut of a domain and `u` is the crosscut arc. Nothing here is
-specific to those uses; neither lemma mentions a metric, let alone a holomorphic map.
+the two sides of a circular crosscut of a domain and `u` is the crosscut arc. The third is what
+lets `TauCeti/Analysis/Complex/Conformal/ClusterSet.lean` identify the boundary piece that one
+side of such a crosscut cuts off, whose description as a union of cluster sets is naturally a
+statement about a closure. Nothing here is specific to those uses; no lemma mentions a metric, let
+alone a holomorphic map.
 
 ## Main results
 
@@ -68,6 +85,8 @@ specific to those uses; neither lemma mentions a metric, let alone a holomorphic
 * `TauCeti.frontier_image_subset_image_union_frontier_image` — for a set split into two sides with
   disjoint open images plus a remainder, the frontier of the image of the side lying in that set
   lies on the image of the remainder and on the frontier of the image of the whole.
+* `TauCeti.frontier_inter_closure_eq_frontier_inter_frontier` — the frontier of a set meets the
+  closure of a subset exactly where it meets that subset's frontier.
 -/
 
 public section
@@ -145,5 +164,30 @@ theorem frontier_image_subset_image_union_frontier_image (hfs : IsOpen (f '' s))
   · exact Or.inr hpfr
 
 end ImageSplit
+
+section Inside
+
+variable {X : Type*} [TopologicalSpace X] {A V : Set X}
+
+/-- **The frontier of a set meets the closure of a subset exactly where it meets that subset's
+frontier.** For any `A ⊆ V`,
+
+> `frontier V ∩ closure A = frontier V ∩ frontier A`.
+
+Writing `closure A` as `A ∪ frontier A`, the first piece brings nothing new: a point of `A` on
+`frontier V` is adherent to `A` and is kept out of `interior A` by `interior A ⊆ interior V`, so it
+already lies on `frontier A`. Only the inclusion `A ⊆ V` is used — `V` need be neither open nor
+closed, and `A` is arbitrary.
+
+So the part of `frontier V` that `A` clings to may be described either as its meeting with
+`closure A` or as its meeting with `frontier A`. An argument about limits of points of `A` produces
+the first; a diameter estimate obtained by splitting `V` into pieces consumes the second. -/
+theorem frontier_inter_closure_eq_frontier_inter_frontier (hAV : A ⊆ V) :
+    frontier V ∩ closure A = frontier V ∩ frontier A := by
+  rw [closure_eq_self_union_frontier, inter_union_distrib_left]
+  exact union_eq_right.mpr fun _ hx =>
+    ⟨hx.1, subset_closure hx.2, fun hint => hx.1.2 (interior_mono hAV hint)⟩
+
+end Inside
 
 end TauCeti

--- a/TauCeti/Topology/Frontier.lean
+++ b/TauCeti/Topology/Frontier.lean
@@ -185,8 +185,9 @@ the first; a diameter estimate obtained by splitting `V` into pieces consumes th
 theorem frontier_inter_closure_eq_frontier_inter_frontier (hAV : A ⊆ V) :
     frontier V ∩ closure A = frontier V ∩ frontier A := by
   rw [closure_eq_self_union_frontier, inter_union_distrib_left]
-  exact union_eq_right.mpr fun _ hx =>
-    ⟨hx.1, subset_closure hx.2, fun hint => hx.1.2 (interior_mono hAV hint)⟩
+  refine union_eq_right.mpr fun x hx =>
+    ⟨hx.1, (mem_frontier_iff_notMem_interior hx.2).mpr fun hint => ?_⟩
+  exact (mem_frontier_iff_notMem_interior (hAV hx.2)).mp hx.1 (interior_mono hAV hint)
 
 end Inside
 


### PR DESCRIPTION
This PR identifies the boundary piece that a subdomain of a conformal map clings to. For `f` holomorphic and injective on an open `U ⊆ ℂ` and any `V ⊆ U` whose closure is compact, `frontier (f '' U) ∩ frontier (f '' V) = ⋃ e ∈ frontier U ∩ closure V, clusterSetOn f V e`: the part of the image boundary reached by the image of `V` is not merely covered by cluster sets, it *is* the union of the cluster sets of `f` taken **along `V`** at the boundary points of `U` adherent to `V`. The closure form `frontier (f '' U) ∩ closure (f '' V) = …` is proved first and the frontier form follows from it, the two left-hand sides agreeing because `f '' V` sits inside the open set `f '' U`. Taking `V = U` recovers `TauCeti.biUnion_clusterSetOn_eq_frontier_image`, which is reproved here as that case rather than left as a separate argument. Instantiating instead at the crosscut neighbourhood `V = U ∩ ball w ρ` — where compactness of the closure is automatic — names the set that `TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` of `Conformal/CutDiameter.lean` asks to be enclosed in a small bounded set, and a final theorem shows those pieces shrink, as `ρ` falls, exactly to `clusterSetOn f U w`. So Carathéodory's assertion that a boundary cluster set is a singleton is equivalent to the pieces cut off at `w` shrinking to a point; no estimate on their diameter is claimed.

This advances layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, "Carathéodory boundary correspondence — the Jordan-domain case: the RMT map of a Jordan domain extends to a homeomorphism of closures". The criterion in `Conformal/CutDiameter.lean` names two geometric inputs; the first, a short image crosscut, is supplied by the length–area method of `Conformal/LengthArea.lean`, while the second — a small bounded set enclosing `frontier (f '' U) ∩ frontier (f '' (U ∩ ball w ρ))` — has so far had no description at all, the existing `Conformal/Crosscut/Image.lean` reaching only the *middle* piece `frontier (f '' U) ∩ closure (f '' (U ∩ sphere w ρ))` and saying explicitly that its enclosure theorem "does not by itself discharge that criterion, whose enclosing set has to contain the whole boundary piece … and not only the middle piece". This PR supplies the missing description of that whole piece.

Two steps that mention no holomorphic map are placed at their own generality and consumed: `TauCeti.frontier_inter_closure_eq_frontier_inter_frontier` in `TauCeti/Topology/Frontier.lean`, which says that for any `A ⊆ V` the frontier of `V` meets `closure A` exactly where it meets `frontier A`, and `TauCeti.clusterSetOn_inter_of_mem_nhds` in `TauCeti/Topology/ClusterSet.lean`, which says a cluster set may be computed inside any neighbourhood of the point. Everything conformal is stated for maps of `ℂ`, in accordance with the generality bar of `ConformalMapping/README.md`. No Mathlib source was vendored; the Mathlib inputs (`closure_eq_self_union_frontier`, `nhdsWithin_inter_of_mem'`, `IsOpen.frontier_eq`) are consumed as they stand. Layer L5 is absent from mathlib4#33505, the in-progress human-curated Riemann-mapping-theorem effort, so this is new Lean formalization rather than a temporary shim.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"frontier-inter-frontier-image-inter-ball-eq-biunion-clusterseton"}-->

🤖 Prepared with Claude Code
