### PR TITLE
feat(EllipticCurve): the coordinate ring is faithful, and points are determined by coordinates

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+
+/-!
+# Faithfulness of the coordinate ring, and equality of affine points
+
+Two injectivity facts about Mathlib's affine API for a Weierstrass curve, both absent from the
+pinned Mathlib.
+
+The coordinate ring `R[X][Y] ⧸ ⟨polynomial⟩` contains `R[X]` faithfully: quotienting by the
+Weierstrass polynomial kills nothing in `X` alone, because the free `R[X]`-basis `{1, Y}` of the
+coordinate ring has `1` as one of its members. Consequently the base ring `R` embeds too.
+
+Separately, `Affine.Point.some` is injective in its coordinates, so two nonsingular points are
+equal exactly when their coordinates agree.
+
+## Main results
+
+* `WeierstrassCurve.Affine.CoordinateRing.algebraMap_poly_injective`
+* `WeierstrassCurve.Affine.CoordinateRing.algebraMap_injective'`
+* `WeierstrassCurve.Affine.Point.some_eq_some_iff`
+
+## Provenance
+
+Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
+`HasseWeil/Auxiliary/Universal.lean`, declarations `algebraMap_poly_injective`,
+`algebraMap_injective'` and `some_eq_some_iff` (© Junyan Xu). Only these three are taken: the rest
+of that file constructs the universal elliptic curve over `ℤ[A₁,…,A₆]`, which is a large
+mathlib-track development rather than a leaf, and is left alone.
+
+The source guards the first proof with `set_option backward.isDefEq.respectTransparency false`,
+which this repository forbids; it is not needed here.
+-/
+
+public section
+
+open Polynomial
+
+namespace WeierstrassCurve.Affine
+
+variable {R : Type*} [CommRing R] {W' : WeierstrassCurve.Affine R}
+
+namespace CoordinateRing
+
+/-- The coordinate ring contains `R[X]` faithfully.
+
+A polynomial in `X` alone that dies in the quotient must vanish, since `1` is a member of the free
+`R[X]`-basis `{1, Y}` of the coordinate ring. -/
+theorem algebraMap_poly_injective : Function.Injective (algebraMap R[X] W'.CoordinateRing) :=
+  (injective_iff_map_eq_zero _).mpr fun p hp ↦ And.left <|
+    smul_basis_eq_zero (W' := W') (q := 0) <| by
+      rwa [Algebra.smul_def, mul_one, zero_smul, add_zero]
+
+/-- The coordinate ring contains the base ring faithfully, by composing with `Polynomial.C`. -/
+theorem algebraMap_injective' : Function.Injective (algebraMap R W'.CoordinateRing) :=
+  algebraMap_poly_injective.comp C_injective
+
+end CoordinateRing
+
+namespace Point
+
+/-- Two nonsingular affine points are equal exactly when their coordinates agree. -/
+theorem some_eq_some_iff {x₁ x₂ y₁ y₂ : R} (h₁ : W'.Nonsingular x₁ y₁)
+    (h₂ : W'.Nonsingular x₂ y₂) : some x₁ y₁ h₁ = some x₂ y₂ h₂ ↔ x₁ = x₂ ∧ y₁ = y₂ :=
+  ⟨by rintro (_ | _); trivial, by rintro ⟨rfl, rfl⟩; rfl⟩
+
+end Point
+
+end WeierstrassCurve.Affine


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"coordinate-ring-injective"}-->

Roadmap: EllipticCurves

Adds `TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean`: three injectivity facts
about Mathlib's affine API for a Weierstrass curve.

```lean
theorem WeierstrassCurve.Affine.CoordinateRing.algebraMap_poly_injective :
    Function.Injective (algebraMap R[X] W'.CoordinateRing)

theorem WeierstrassCurve.Affine.CoordinateRing.algebraMap_injective' :
    Function.Injective (algebraMap R W'.CoordinateRing)

theorem WeierstrassCurve.Affine.Point.some_eq_some_iff (h₁ : W'.Nonsingular x₁ y₁)
    (h₂ : W'.Nonsingular x₂ y₂) : some x₁ y₁ h₁ = some x₂ y₂ h₂ ↔ x₁ = x₂ ∧ y₁ = y₂
```

The coordinate ring `R[X][Y] ⧸ ⟨polynomial⟩` contains `R[X]` faithfully — quotienting by the
Weierstrass polynomial kills nothing in `X` alone, since `1` belongs to the free `R[X]`-basis
`{1, Y}` — and hence contains `R` too. Separately, `Affine.Point.some` is injective in its
coordinates.

## Mathlib check

All three are absent from the pin, by full-name untruncated searches:
`grep -F "algebraMap_poly_injective"` → 0 hits, `grep -F "some_eq_some_iff"` → 0 hits, and a
pattern search for any `Injective … algebraMap … CoordinateRing` statement → 0 hits. The
ingredients used (`smul_basis_eq_zero`, `C_injective`, `injective_iff_map_eq_zero`) are all
present.

## Provenance

Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
`HasseWeil/Auxiliary/Universal.lean`, declarations `algebraMap_poly_injective`,
`algebraMap_injective'` and `some_eq_some_iff` (© Junyan Xu).

**Only these three are taken.** The remainder of that file constructs the universal elliptic curve
over `ℤ[A₁,…,A₆]` together with its coordinate ring, function field and specialisation maps — a
large mathlib-track development rather than a leaf, and not something to bring in piecemeal, so it
is left alone.

One improvement over the source: it guards the first proof with
`set_option backward.isDefEq.respectTransparency false`, which this repository forbids. The proof
goes through without it here, so no override is needed.

## Roadmap

`EllipticCurves`, Layer 3 — the Hasse strand, whose §Ordering entry reads *"the Hasse bound is the
earliest PR, its existing proof self-contained; the zeta strand needs Layer 1's Frobenius
identities."*

A prerequisite rather than a target, which `CLAUDE.md` admits explicitly: a declaration may be
added when it *"advances a specific roadmap target, or supplies a prerequisite that a specific
target needs"*. Checked rather than assumed — in the roadmap's pinned Hasse provenance
(`dev/hasse-weil @ 513e83879e2f`), `HasseWeil/Auxiliary/Universal.lean` lies inside the **187-file
import closure of the capstone `hasse_bound` proof** (the project has 283 files, so closure
membership is not automatic).

No curve point count, torsion hypothesis or ellipticity assumption appears in any statement, and
nothing here waits on absent material.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
locally. All three proofs are term-mode; no `sorry`, no `set_option`, no `maxHeartbeats`.
