### PR TITLE
docs(Sl2): name the instance that makes the quotient rank identity apply

### DIFF
--- a/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
+++ b/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
@@ -256,8 +256,11 @@ private theorem exists_invariant_notMem_of_ne_bot_of_ne_of_le {d : ℕ}
       (fun hc ↦ hWN ((LieSubmodule.toSubmodule_inj _ _).1 hc))
   have hWlt : finrank K W < finrank K N := Submodule.finrank_lt_finrank_of_lt hWsub
   have hquot : finrank K (M ⧸ W) ≤ d := by
-    -- Ascribing the type states Mathlib's rank identity at the Lie quotient, so the arithmetic
-    -- below never has to see through the `LieSubmodule → Submodule` coercion.
+    -- There is no cross-type conversion here to justify. Mathlib *defines* the Lie-submodule
+    -- quotient to be the submodule quotient, `HasQuotient M (LieSubmodule R L M)` being
+    -- `⟨fun N => M ⧸ N.toSubmodule⟩` in `Mathlib/Algebra/Lie/Quotient.lean`, and `↥W` carries the
+    -- submodule's own carrier. So the submodule rank identity *is* the identity for `M ⧸ W`;
+    -- ascribing the type is what states it in that form.
     have hadd : finrank K (M ⧸ W) + finrank K W = finrank K M :=
       Submodule.finrank_quotient_add_finrank (W : Submodule K M)
     omega


### PR DESCRIPTION
A one-comment correction in `exists_invariant_notMem_of_ne_bot_of_ne_of_le`.

The comment above `hadd` said the type ascription is there so the arithmetic "never has to see
through the `LieSubmodule → Submodule` coercion". There is no such conversion to see through:
`Mathlib/Algebra/Lie/Quotient.lean` *defines*

```lean
instance : HasQuotient M (LieSubmodule R L M) :=
  ⟨fun N => M ⧸ N.toSubmodule⟩
```

so `M ⧸ W` is the submodule quotient rather than a second construction identified with it, and
`SetLike (LieSubmodule R L M) M` takes `coe s := s.carrier`, the submodule's own carrier. The
submodule rank identity therefore *is* the identity for `M ⧸ W`, and the ascription only states it
in that form. The comment now says that, and cites the instance.

Context: this text was written while decomposing #2327, where `proof-quality` twice objected that
the step "relies on undocumented definitional equality". I wrote this correction during that review
but pushed it after the PR had already merged, so it never reached `main` — hence the separate
change. No proof or statement is touched; the diff is the comment alone.

Roadmap: RepresentationTheory
