### PR TITLE
feat(EllipticCurve): the quadratic twist by a quadratic extension

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.VariableChange
+public import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
+public import TauCeti.RingTheory.Norm.Quadratic
 
 /-!
 # The quadratic twist of a Weierstrass curve: definition and invariants
@@ -33,11 +35,22 @@ change of variables, again over any commutative ring in which the relevant param
 * `WeierstrassCurve.exists_smul_eq_quadraticTwistOf_quadraticTwistOf`,
   `WeierstrassCurve.exists_smul_quadraticTwistOf_eq`: the double twist is isomorphic to the
   original curve, and changing the generator moves the twist by a change of variables.
+* `WeierstrassCurve.isElliptic_quadraticTwistOf_trace_norm`,
+  `WeierstrassCurve.exists_smul_quadraticTwistOf_trace_norm_eq`: the twist by the trace and norm
+  of a generator `θ` of a quadratic extension `L/K` is elliptic, and changing the generator moves
+  it by a change of variables — which is what makes the twist by the extension well posed.
 
 These are the `quadraticTwistOf` seeds of `TauCetiRoadmap/EllipticCurves/README.md` §Layer 5
 (twists), pinned in that roadmap's `Suggested.lean`; the extension twist `quadraticTwist E L`
 by a separable quadratic extension, the point isomorphism, and the split-multiplicative-
 reduction theorem are later milestones of the same layer and build on this file.
+
+The twist by a generator is deliberately **not** given its own constructor here. Such a
+definition would accept any field extension, and outside the finite-dimensional case Mathlib's
+`Algebra.trace` and `Algebra.norm` are `0` and `1`, so every `θ` would yield the same unrelated
+`(0, 1)` twist. The results below instead name `Algebra.trace K L θ` and `Algebra.norm K L θ`
+directly and carry `[Algebra.IsQuadraticExtension K L]`, where the construction has its intended
+meaning.
 
 Adapted from the FLT project's quadratic-twist development (`ImperialCollegeLondon/FLT`,
 `FLT/KnownIn1980s/EllipticCurves/QuadraticTwists/QuadraticTwists.lean` at the roadmap's pin
@@ -255,6 +268,39 @@ theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : t ^ 2 - 4 * n ≠ 0) :
   (E.isElliptic_quadraticTwistOf_iff t n).mpr ⟨isUnit_iff_ne_zero.mpr hD, ‹E.IsElliptic›⟩
 
 end Field
+
+section QuadraticTwistBy
+
+open Algebra.IsQuadraticExtension
+
+variable {K : Type*} [Field K] {L : Type*} [Field L] [Algebra K L] (E : WeierstrassCurve K)
+
+variable [Algebra.IsQuadraticExtension K L]
+
+/-- The quadratic twist by a generator `θ` of a quadratic extension `L/K` depends on the choice
+of `θ` only up to isomorphism over `K`: all generators give isomorphic twists. This is what
+makes the twist by the extension itself well posed. Separability is not needed — only the trace
+and norm of `b + aθ`, which any quadratic extension supplies. -/
+theorem exists_smul_quadraticTwistOf_trace_norm_eq {θ θ' : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) (hθ' : θ' ∉ Set.range (algebraMap K L)) :
+    ∃ C : VariableChange K,
+      C • E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)
+        = E.quadraticTwistOf (Algebra.trace K L θ') (Algebra.norm K θ') := by
+  obtain ⟨a, b, ha, rfl⟩ := exists_eq_algebraMap_add_algebraMap_mul K L hθ hθ'
+  simp only [trace_algebraMap_add_algebraMap_mul K L a b θ,
+    norm_algebraMap_add_algebraMap_mul K L a b θ]
+  exact E.exists_smul_quadraticTwistOf_eq _ _ b (isUnit_iff_ne_zero.mpr ha)
+
+variable [Algebra.IsSeparable K L]
+
+/-- The twist of an elliptic curve by a generator of a separable quadratic extension is
+elliptic: the discriminant `t² - 4n` of the generator's minimal polynomial is nonzero. -/
+theorem isElliptic_quadraticTwistOf_trace_norm [E.IsElliptic] {θ : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) :
+    (E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)).IsElliptic :=
+  E.isElliptic_quadraticTwistOf _ _ (discrim_ne_zero K L hθ)
+
+end QuadraticTwistBy
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -37,8 +37,9 @@ change of variables, again over any commutative ring in which the relevant param
   original curve, and changing the generator moves the twist by a change of variables.
 * `WeierstrassCurve.isElliptic_quadraticTwistOf_trace_norm`,
   `WeierstrassCurve.exists_smul_quadraticTwistOf_trace_norm_eq`: the twist by the trace and norm
-  of a generator `θ` of a quadratic extension `L/K` is elliptic, and changing the generator moves
-  it by a change of variables — which is what makes the twist by the extension well posed.
+  of a generator `θ` of a *separable* quadratic extension `L/K` is elliptic when `E` is, and
+  changing the generator moves it by a change of variables — which is what makes the twist by the
+  extension well posed.
 
 These are the `quadraticTwistOf` seeds of `TauCetiRoadmap/EllipticCurves/README.md` §Layer 5
 (twists), pinned in that roadmap's `Suggested.lean`; the extension twist `quadraticTwist E L`
@@ -48,7 +49,7 @@ reduction theorem are later milestones of the same layer and build on this file.
 The twist by a generator is deliberately **not** given its own constructor here. Such a
 definition would accept any field extension, and outside the finite-dimensional case Mathlib's
 `Algebra.trace` and `Algebra.norm` are `0` and `1`, so every `θ` would yield the same unrelated
-`(0, 1)` twist. The results below instead name `Algebra.trace K L θ` and `Algebra.norm K L θ`
+`(0, 1)` twist. The results below instead name `Algebra.trace K L θ` and `Algebra.norm K θ`
 directly and carry `[Algebra.IsQuadraticExtension K L]`, where the construction has its intended
 meaning.
 

--- a/TauCeti/FieldTheory/Galois/Basic.lean
+++ b/TauCeti/FieldTheory/Galois/Basic.lean
@@ -21,14 +21,16 @@ automorphisms and `IsGalois.mem_range_algebraMap_iff_fixed` characterises the ba
 
 These are the descent inputs for the quadratic-twist layer of
 `TauCetiRoadmap/EllipticCurves/README.md` (§Layer 5), consumed by
-`TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean`.
+`TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean` and by
+`TauCeti/RingTheory/Norm/Quadratic.lean`, which expresses the trace and norm of a
+separable quadratic extension through its nontrivial automorphism.
 
 Adapted from the FLT project (`ImperialCollegeLondon/FLT`,
 `FLT/Mathlib/FieldTheory/Galois/Basic.lean` at the roadmap's pin `bc2fe8ff7396`, FLT PR #1088,
 Apache 2.0). That file's own header reads `Authors: Kevin Buzzard, Claude`; following this
 repository's convention for adapted material, the upstream authorship is credited here rather
-than in the copyright header. Only the three results the descent file consumes are ported; the
-rest of the source file is deferred to the Tau Ceti PRs that consume it.
+than in the copyright header. Only the results consumed downstream are ported; the rest of
+the source file is deferred to the Tau Ceti PRs that consume it.
 -/
 
 public section
@@ -59,6 +61,16 @@ theorem mem_range_algebraMap_of_apply_eq {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {
   rcases algEquiv_eq_one_or_eq K L hσ φ with rfl | rfl
   · exact AlgEquiv.one_apply x
   · exact hx
+
+/-- A separable quadratic extension has a nontrivial automorphism. -/
+theorem exists_algEquiv_ne_one : ∃ σ : L ≃ₐ[K] L, σ ≠ 1 :=
+  ((Nat.card_eq_two_iff' 1).mp (card_algEquiv_eq_two K L)).exists
+
+/-- The automorphism group of a separable quadratic extension consists of the identity and one
+nontrivial element. -/
+theorem univ_algEquiv [DecidableEq (L ≃ₐ[K] L)] {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) :
+    (Finset.univ : Finset (L ≃ₐ[K] L)) = {1, σ} :=
+  (Finset.eq_univ_of_forall fun φ ↦ by simpa using algEquiv_eq_one_or_eq K L hσ φ).symm
 
 end Algebra.IsQuadraticExtension
 

--- a/TauCeti/FieldTheory/Galois/Basic.lean
+++ b/TauCeti/FieldTheory/Galois/Basic.lean
@@ -68,7 +68,7 @@ theorem exists_algEquiv_ne_one : ∃ σ : L ≃ₐ[K] L, σ ≠ 1 :=
 
 /-- The automorphism group of a separable quadratic extension consists of the identity and one
 nontrivial element. -/
-theorem univ_algEquiv [DecidableEq (L ≃ₐ[K] L)] {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) :
+theorem univ_eq_pair [DecidableEq (L ≃ₐ[K] L)] {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) :
     (Finset.univ : Finset (L ≃ₐ[K] L)) = {1, σ} :=
   (Finset.eq_univ_of_forall fun φ ↦ by simpa using algEquiv_eq_one_or_eq K L hσ φ).symm
 

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
+public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
+public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+
+/-!
+# Generators of a quadratic extension
+
+Mathlib's `Algebra.IsQuadraticExtension K L` records that `L/K` has degree two but says nothing
+about the elements realising that degree. This file supplies the two facts a consumer needs in
+order to *choose* and *change* a generator:
+
+`Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul`: any two generators of a
+quadratic extension differ by `θ' = b + aθ` with `a ≠ 0`, so a statement proved for one generator
+transfers to every other. This is what makes a construction defined by "pick any `θ ∈ L ∖ K`"
+well posed up to the ambiguity that `b + aθ` describes.
+`linearIndependent_one_of_notMem_range_algebraMap` is the linear-algebra step behind it, and
+needs only a nontrivial ring over `K`, not a field.
+
+These are consumed by the extension quadratic twist in
+`TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean`, which advances
+`TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists).
+
+Adapted from the FLT project (`ImperialCollegeLondon/FLT`,
+`FLT/Mathlib/LinearAlgebra/Dimension/IsQuadraticExtension.lean` at the roadmap's pin
+`bc2fe8ff7396`, FLT PR #1088, Apache 2.0). That file's own header reads
+`Authors: Kevin Buzzard, Claude`; following this repository's convention for adapted material,
+the upstream authorship is credited here rather than in the copyright header. Only the two
+results the twist consumes are ported; the rest of the source file — which restates
+`Algebra.IsQuadraticExtension` itself, already in Mathlib — is not needed.
+-/
+
+public section
+
+variable (K L : Type*) [Field K]
+
+/-- `1` and any element lying outside the base field are linearly independent over the base
+field. The ambient algebra need not be a field — only a nontrivial ring, since the argument
+is just that `θ` is not a `K`-multiple of `1`. -/
+theorem linearIndependent_one_of_notMem_range_algebraMap [Ring L] [Nontrivial L] [Algebra K L]
+    {θ : L} (hθ : θ ∉ Set.range (algebraMap K L)) : LinearIndependent K ![(1 : L), θ] :=
+  (LinearIndependent.pair_iff' one_ne_zero).mpr fun a ha ↦
+    hθ ⟨a, by rwa [Algebra.algebraMap_eq_smul_one]⟩
+
+variable [Field L] [Algebra K L] [Algebra.IsQuadraticExtension K L]
+
+namespace Algebra.IsQuadraticExtension
+
+/-- Any element of a quadratic extension `L/K` is a `K`-linear combination of `1` and a given
+generator `θ`, and the `θ`-coefficient is nonzero if the element also lies outside `K`. So any
+two generators differ by `θ' = b + aθ` with `a ≠ 0`. -/
+theorem exists_eq_algebraMap_add_algebraMap_mul {θ θ' : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) (hθ' : θ' ∉ Set.range (algebraMap K L)) :
+    ∃ a b : K, a ≠ 0 ∧ θ' = algebraMap K L b + algebraMap K L a * θ := by
+  have hli := linearIndependent_one_of_notMem_range_algebraMap K L hθ
+  have hmem : θ' ∈ Submodule.span K (Set.range ![(1 : L), θ]) := by
+    rw [hli.span_eq_top_of_card_eq_finrank
+      (by rw [Fintype.card_fin]; exact (finrank_eq_two K L).symm)]
+    trivial
+  rw [Matrix.range_cons_cons_empty, Submodule.mem_span_pair] at hmem
+  obtain ⟨c, d, hcd⟩ := hmem
+  refine ⟨d, c, fun hd ↦ hθ' ⟨c, ?_⟩, ?_⟩
+  · rw [← hcd, hd, zero_smul, add_zero, Algebra.algebraMap_eq_smul_one]
+  · rw [← hcd, Algebra.smul_def, Algebra.smul_def, mul_one]
+
+end Algebra.IsQuadraticExtension
+
+end

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
 public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 
 /-!

--- a/TauCeti/RingTheory/Norm/Quadratic.lean
+++ b/TauCeti/RingTheory/Norm/Quadratic.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Norm.Transitivity
+public import Mathlib.RingTheory.Trace.Basic
+public import TauCeti.FieldTheory.Galois.Basic
+
+/-!
+# Trace and norm in a separable quadratic extension
+
+For a separable quadratic extension `L/K` the trace and norm are the two elementary symmetric
+functions of the pair `{x, σx}`, where `σ` is the nontrivial automorphism: `tr x = x + σx` and
+`N x = x · σx` (`algebraMap_trace_eq_add`, `algebraMap_norm_eq_mul`). Everything else here is a
+consequence, except the two evaluations of `b + aθ`, which need no separability at all:
+
+* `trace_algebraMap_add_algebraMap_mul` and `norm_algebraMap_add_algebraMap_mul` evaluate the
+  trace and norm of `b + aθ` over any quadratic extension, separable or not — the first by
+  `K`-linearity of the trace, the second from the `2 × 2` identity
+  `det (b • 1 + a • M) = b² + ab · tr M + a² · det M`. This is how a statement about one
+  generator transfers to another;
+* `discrim_ne_zero`: for `θ` outside `K`, the discriminant `t² - 4n` of its minimal polynomial
+  `X² - tX + n` is nonzero, since it equals `(θ - σθ)²` and `σ` moves `θ`.
+
+In characteristic two `discrim_ne_zero` says `t ≠ 0`, reflecting that a separable quadratic
+extension is then Artin–Schreier rather than Kummer.
+
+These are consumed by the extension quadratic twist in
+`TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean`, which advances
+`TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists): `discrim_ne_zero` is exactly what
+makes the twist by a generator elliptic.
+
+Adapted from the FLT project (`ImperialCollegeLondon/FLT`,
+`FLT/Mathlib/RingTheory/Norm/Quadratic.lean` at the roadmap's pin `bc2fe8ff7396`, FLT PR #1088,
+Apache 2.0). That file's own header reads `Authors: Kevin Buzzard, Claude`; following this
+repository's convention for adapted material, the upstream authorship is credited here rather
+than in the copyright header. Ported with the source's `@[expose]` dropped, and with the two
+square-root lemmas left to the PR that consumes them.
+-/
+
+public section
+
+variable (K L : Type*) [Field K] [Field L] [Algebra K L]
+variable [Algebra.IsQuadraticExtension K L]
+
+namespace Algebra.IsQuadraticExtension
+
+/-- The trace of `b + aθ` in a quadratic extension is `a·tr(θ) + 2b`. Separability is not
+needed: this is `K`-linearity of the trace together with `tr(b) = [L : K]·b = 2b`. -/
+theorem trace_algebraMap_add_algebraMap_mul (a b : K) (θ : L) :
+    Algebra.trace K L (algebraMap K L b + algebraMap K L a * θ)
+      = a * Algebra.trace K L θ + 2 * b := by
+  rw [map_add, Algebra.trace_algebraMap, ← Algebra.smul_def, map_smul,
+    Algebra.IsQuadraticExtension.finrank_eq_two]
+  simp only [nsmul_eq_mul, Nat.cast_ofNat]
+  ring
+
+/-- The norm of `b + aθ` in a quadratic extension is `b² + ab·tr(θ) + a²·N(θ)`. Separability is
+not needed: in any `K`-basis of `L`, multiplication by `b + aθ` has matrix `b • 1 + a • M` where
+`M` is the matrix of multiplication by `θ`, and for a `2 × 2` matrix
+`det (b • 1 + a • M) = b² + ab · tr M + a² · det M`. -/
+theorem norm_algebraMap_add_algebraMap_mul (a b : K) (θ : L) :
+    Algebra.norm K (algebraMap K L b + algebraMap K L a * θ)
+      = b ^ 2 + a * b * Algebra.trace K L θ + a ^ 2 * Algebra.norm K θ := by
+  classical
+  let bs : Module.Basis (Fin 2) K L :=
+    Module.finBasisOfFinrankEq K L (finrank_eq_two K L)
+  have key : Algebra.leftMulMatrix bs (algebraMap K L b + algebraMap K L a * θ)
+      = b • (1 : Matrix (Fin 2) (Fin 2) K) + a • Algebra.leftMulMatrix bs θ := by
+    rw [map_add, map_mul, AlgHom.commutes, AlgHom.commutes, Algebra.algebraMap_eq_smul_one,
+      Algebra.smul_def]
+    simp [Algebra.smul_def]
+  rw [Algebra.norm_eq_matrix_det bs, Algebra.trace_eq_matrix_trace bs,
+    Algebra.norm_eq_matrix_det bs, key]
+  simp [Matrix.det_fin_two, Matrix.trace_fin_two]
+  ring
+
+variable [Algebra.IsSeparable K L]
+
+/-- In a separable quadratic extension, the trace of `x` is `x + σx`, where `σ` is the
+nontrivial automorphism. -/
+theorem algebraMap_trace_eq_add {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) (x : L) :
+    algebraMap K L (Algebra.trace K L x) = x + σ x := by
+  classical
+  rw [trace_eq_sum_automorphisms, univ_algEquiv K L hσ, Finset.sum_pair (Ne.symm hσ)]
+  simp
+
+/-- In a separable quadratic extension, the norm of `x` is `x * σx`, where `σ` is the
+nontrivial automorphism. -/
+theorem algebraMap_norm_eq_mul {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) (x : L) :
+    algebraMap K L (Algebra.norm K x) = x * σ x := by
+  classical
+  rw [Algebra.norm_eq_prod_automorphisms, univ_algEquiv K L hσ, Finset.prod_pair (Ne.symm hσ)]
+  simp
+
+/-- If `θ` generates a separable quadratic extension of `K` — that is, lies outside `K` — and
+`t`, `n` denote its trace and norm, so that `θ² = tθ - n`, then the discriminant `t² - 4n` of
+the minimal polynomial of `θ` is nonzero: over the nontrivial automorphism `σ` it equals
+`(θ - σθ)²`, and `σθ ≠ θ`. -/
+theorem discrim_ne_zero {θ : L} (hθ : θ ∉ Set.range (algebraMap K L)) :
+    Algebra.trace K L θ ^ 2 - 4 * Algebra.norm K θ ≠ 0 := by
+  obtain ⟨σ, hσ⟩ := exists_algEquiv_ne_one K L
+  intro h0
+  have h1 : (θ - σ θ) ^ 2 = 0 := by
+    have h2 := congrArg (algebraMap K L) h0
+    simp only [map_sub, map_pow, map_mul, map_zero, map_ofNat,
+      algebraMap_trace_eq_add K L hσ, algebraMap_norm_eq_mul K L hσ] at h2
+    linear_combination h2
+  exact hθ (mem_range_algebraMap_of_apply_eq K L hσ
+    (sub_eq_zero.mp ((pow_eq_zero_iff two_ne_zero).mp h1)).symm)
+
+end Algebra.IsQuadraticExtension
+
+end

--- a/TauCeti/RingTheory/Norm/Quadratic.lean
+++ b/TauCeti/RingTheory/Norm/Quadratic.lean
@@ -49,6 +49,7 @@ namespace Algebra.IsQuadraticExtension
 
 /-- The trace of `b + aθ` in a quadratic extension is `a·tr(θ) + 2b`. Separability is not
 needed: this is `K`-linearity of the trace together with `tr(b) = [L : K]·b = 2b`. -/
+@[simp]
 theorem trace_algebraMap_add_algebraMap_mul (a b : K) (θ : L) :
     Algebra.trace K L (algebraMap K L b + algebraMap K L a * θ)
       = a * Algebra.trace K L θ + 2 * b := by
@@ -61,6 +62,7 @@ theorem trace_algebraMap_add_algebraMap_mul (a b : K) (θ : L) :
 not needed: in any `K`-basis of `L`, multiplication by `b + aθ` has matrix `b • 1 + a • M` where
 `M` is the matrix of multiplication by `θ`, and for a `2 × 2` matrix
 `det (b • 1 + a • M) = b² + ab · tr M + a² · det M`. -/
+@[simp]
 theorem norm_algebraMap_add_algebraMap_mul (a b : K) (θ : L) :
     Algebra.norm K (algebraMap K L b + algebraMap K L a * θ)
       = b ^ 2 + a * b * Algebra.trace K L θ + a ^ 2 * Algebra.norm K θ := by
@@ -84,7 +86,7 @@ nontrivial automorphism. -/
 theorem algebraMap_trace_eq_add {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) (x : L) :
     algebraMap K L (Algebra.trace K L x) = x + σ x := by
   classical
-  rw [trace_eq_sum_automorphisms, univ_algEquiv K L hσ, Finset.sum_pair (Ne.symm hσ)]
+  rw [trace_eq_sum_automorphisms, univ_eq_pair K L hσ, Finset.sum_pair (Ne.symm hσ)]
   simp
 
 /-- In a separable quadratic extension, the norm of `x` is `x * σx`, where `σ` is the
@@ -92,7 +94,7 @@ nontrivial automorphism. -/
 theorem algebraMap_norm_eq_mul {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) (x : L) :
     algebraMap K L (Algebra.norm K x) = x * σ x := by
   classical
-  rw [Algebra.norm_eq_prod_automorphisms, univ_algEquiv K L hσ, Finset.prod_pair (Ne.symm hσ)]
+  rw [Algebra.norm_eq_prod_automorphisms, univ_eq_pair K L hσ, Finset.prod_pair (Ne.symm hσ)]
   simp
 
 /-- If `θ` generates a separable quadratic extension of `K` — that is, lies outside `K` — and

--- a/TauCeti/RingTheory/Norm/Quadratic.lean
+++ b/TauCeti/RingTheory/Norm/Quadratic.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.RingTheory.Norm.Transitivity
 public import Mathlib.RingTheory.Trace.Basic
 public import TauCeti.FieldTheory.Galois.Basic
+public import TauCeti.LinearAlgebra.Matrix.CharpolyFinTwo
 
 /-!
 # Trace and norm in a separable quadratic extension
@@ -59,9 +60,10 @@ theorem trace_algebraMap_add_algebraMap_mul (a b : K) (θ : L) :
   ring
 
 /-- The norm of `b + aθ` in a quadratic extension is `b² + ab·tr(θ) + a²·N(θ)`. Separability is
-not needed: in any `K`-basis of `L`, multiplication by `b + aθ` has matrix `b • 1 + a • M` where
-`M` is the matrix of multiplication by `θ`, and for a `2 × 2` matrix
-`det (b • 1 + a • M) = b² + ab · tr M + a² · det M`. -/
+not needed: in any `K`-basis of `L`, multiplication by `b + aθ` has matrix `a • M - (-b) • 1`
+where `M` is the matrix of multiplication by `θ`, and
+`TauCeti.Matrix.det_smul_sub_smul_one_fin_two` evaluates that pencil determinant as
+`det M · a² + tr M · ab + b²`. -/
 @[simp]
 theorem norm_algebraMap_add_algebraMap_mul (a b : K) (θ : L) :
     Algebra.norm K (algebraMap K L b + algebraMap K L a * θ)
@@ -70,13 +72,12 @@ theorem norm_algebraMap_add_algebraMap_mul (a b : K) (θ : L) :
   let bs : Module.Basis (Fin 2) K L :=
     Module.finBasisOfFinrankEq K L (finrank_eq_two K L)
   have key : Algebra.leftMulMatrix bs (algebraMap K L b + algebraMap K L a * θ)
-      = b • (1 : Matrix (Fin 2) (Fin 2) K) + a • Algebra.leftMulMatrix bs θ := by
-    rw [map_add, map_mul, AlgHom.commutes, AlgHom.commutes, Algebra.algebraMap_eq_smul_one,
-      Algebra.smul_def]
+      = a • Algebra.leftMulMatrix bs θ - (-b) • (1 : Matrix (Fin 2) (Fin 2) K) := by
+    rw [neg_smul, sub_neg_eq_add, add_comm, map_add, map_mul, AlgHom.commutes, AlgHom.commutes,
+      Algebra.algebraMap_eq_smul_one, Algebra.smul_def]
     simp [Algebra.smul_def]
   rw [Algebra.norm_eq_matrix_det bs, Algebra.trace_eq_matrix_trace bs,
-    Algebra.norm_eq_matrix_det bs, key]
-  simp [Matrix.det_fin_two, Matrix.trace_fin_two]
+    Algebra.norm_eq_matrix_det bs, key, TauCeti.Matrix.det_smul_sub_smul_one_fin_two]
   ring
 
 variable [Algebra.IsSeparable K L]


### PR DESCRIPTION
Let `L/K` be a quadratic extension and `θ ∈ L` a generator. This PR adds the quadratic twist of a Weierstrass curve `E/K` by `θ` — the extension-twist layer sitting directly on the `quadraticTwistOf` slice that landed in #2254.

Two results in `TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean`:

* `isElliptic_quadraticTwistOf_trace_norm` — the twist by `Algebra.trace K L θ` and `Algebra.norm K θ` is elliptic when `θ` generates a separable quadratic extension, because the discriminant `t² − 4n` of `θ`'s minimal polynomial is then nonzero;
* `exists_smul_quadraticTwistOf_trace_norm_eq` — changing the generator moves that twist only by a `VariableChange K`. This is what makes the notion well posed, and it is the hypothesis the roadmap's `quadraticTwist E L` will rest on.

**There is deliberately no `quadraticTwistBy` constructor.** An earlier revision of this PR had one, taking any `θ` in any extension `L/K`. That is unsound as public API: Mathlib's `Algebra.trace` and `Algebra.norm` are `LinearMap.trace` and `LinearMap.det` of multiplication, hence `0` and `1` on a non-finite-dimensional module, so outside the finite case *every* `θ` would produce the same unrelated `(0, 1)` twist. The two theorems above instead name `Algebra.trace K L θ` and `Algebra.norm K θ` directly and carry `[Algebra.IsQuadraticExtension K L]`, where the construction has its intended meaning. The module docstring records this.

Two consumer-justified support files, each holding only what the twist consumes. `TauCeti/RingTheory/Norm/Quadratic.lean`: in a separable quadratic extension the trace and norm are the elementary symmetric functions `x + σx` and `x·σx` of the pair `{x, σx}`; their values on `b + aθ`; and `discrim_ne_zero`, that a generator's discriminant is nonzero — in characteristic two this reads `t ≠ 0`, reflecting that such an extension is Artin–Schreier rather than Kummer. `TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean`: any two generators differ by `θ' = b + aθ` with `a ≠ 0`. Two lemmas are also added to `TauCeti/FieldTheory/Galois/Basic.lean` (`exists_algEquiv_ne_one`, `univ_algEquiv`), completing the deferred-with-consumers remainder of the file that #2268 opened.

**Generator independence does not need separability.** `norm_algebraMap_add_algebraMap_mul` would naturally go through the nontrivial automorphism, which forces `[Algebra.IsSeparable K L]`; it is proved here from the matrix of multiplication instead, since in any `K`-basis of `L` multiplication by `b + aθ` has matrix `b • 1 + a • M` with `M` the matrix of multiplication by `θ`, and for a `2 × 2` matrix `det (b • 1 + a • M) = b² + ab · tr M + a² · det M`. Trace and norm come from the same matrix, so no basis has to contain `θ` and no case split on `θ ∈ K` arises. `exists_smul_quadraticTwistOf_trace_norm_eq` consequently holds over any quadratic extension. `isElliptic_quadraticTwistOf_trace_norm` keeps separability, correctly: it goes through `discrim_ne_zero`, and in characteristic two an inseparable quadratic extension has `t = 0`, so the discriminant really does vanish.

Checked against pinned Mathlib before porting: none of the eleven new names occurs anywhere in Mathlib (untruncated grep, zero hits each), and — since a grep cannot prove absence when Mathlib supplies facts generically — the five support statements were each written as a standalone `example` and `exact?` failed on all five. Also checked AINTLIB, which has no `quadraticTwist*` declaration in any of its local clones, and Michael Stoll's repository, whose scope is the Layer 6 Mordell–Weil lane and carries no twist material.

Adapted from the FLT project (`ImperialCollegeLondon/FLT`, `FLT/KnownIn1980s/EllipticCurves/QuadraticTwists/QuadraticTwists.lean`, `FLT/Mathlib/RingTheory/Norm/Quadratic.lean`, `FLT/Mathlib/LinearAlgebra/Dimension/IsQuadraticExtension.lean` and `FLT/Mathlib/FieldTheory/Galois/Basic.lean`, all at the roadmap's pin `bc2fe8ff7396` = merged FLT PR #1088, Apache 2.0). Those files' own headers read `Authors: Kevin Buzzard, Claude`; following this repository's convention for adapted material, upstream authorship is credited in each module docstring rather than in the copyright header. Note that FLT has since deleted these files upstream, so the source was read at the pin rather than from a current checkout. Changes in porting: `@[expose]` dropped; imports narrowed to the modules actually used; `exists_smul_quadraticTwistOf_eq` is applied through `isUnit_iff_ne_zero.mpr`, since #2254 generalised its hypothesis from `a ≠ 0` to `IsUnit a`; the norm lemma is freed from separability as described above; and the source's public twist constructor is not ported, for the reason given above.

The branch was rebuilt on current `main` after #2440 merged, which consolidated `QuadraticTwist/Basic.lean` into `QuadraticTwist.lean` and dropped the `_of_isUnit` suffixes. This PR therefore now carries only the extension twist: four files, eleven new declarations, no deletions beyond the docstring lines it rewrites.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"quadratictwistof"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
