### PR TITLE
feat: make the adjoint action natural

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent.lean
@@ -6,12 +6,14 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Adjoint
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Map
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Naturality
 
 /-!
 # The tangent space at the identity
 
 Aggregator for the tangent-level theory: the counit-valued derivations
 (`Tangent.Basic`), functoriality in the bialgebra (`Tangent.DerivationMap`,
-`Tangent.Map`), and the adjoint action of the points (`Tangent.Adjoint`).
+`Tangent.Map`) and coefficient algebra (`Tangent.Naturality`), and the adjoint
+action of the points (`Tangent.Adjoint`).
 The Lie-algebra structure lives in the `Tangent.Lie` aggregator.
 -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -207,7 +207,7 @@ section CounitAlgebraMap
 namespace Bialgebra.CounitAlgebra
 
 variable {R A B C : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
-  [CommSemiring B] [Algebra R B] [CommSemiring C] [Algebra R C]
+  [Semiring B] [Algebra R B] [Semiring C] [Algebra R C]
 
 /-- An algebra homomorphism of coefficients, transported to the counit coefficient
 algebras. -/
@@ -216,23 +216,14 @@ noncomputable def mapAlgHom (phi : B →ₐ[R] C) :
   (algEquivSelf R A C).symm.toAlgHom.comp (phi.comp (algEquivSelf R A B).toAlgHom)
 
 omit [CommSemiring A] [Bialgebra R A] in
-/-- The coefficient algebra map is the original map under the canonical
-identifications with its source and target. -/
-lemma algEquivSelf_mapAlgHom (phi : B →ₐ[R] C) (b : CounitAlgebra R A B) :
-    algEquivSelf R A C (mapAlgHom (A := A) phi b) =
-      phi (algEquivSelf R A B b) := by
-  -- The public equivalences are the API for crossing the coefficient synonyms;
-  -- `change` exposes the composite through those equivalences once.
-  change algEquivSelf R A C
-      ((algEquivSelf R A C).symm (phi (algEquivSelf R A B b))) = _
-  rw [AlgEquiv.apply_symm_apply]
-
-omit [CommSemiring A] [Bialgebra R A] in
 /-- Transport of counit coefficient algebras acts pointwise by the original
 coefficient homomorphism. -/
 @[simp]
 lemma mapAlgHom_apply (phi : B →ₐ[R] C) (b : CounitAlgebra R A B) :
     mapAlgHom (A := A) phi b = phi b := by
+  -- This is the first application theorem for `mapAlgHom`, so there is no
+  -- pointwise public lemma to rewrite with yet. Unfolding the composite through
+  -- its two public equivalences exposes exactly their application lemmas.
   change (algEquivSelf R A C).symm (phi (algEquivSelf R A B b)) = phi b
   rw [algEquivSelf_apply, algEquivSelf_symm_apply]
 
@@ -245,19 +236,28 @@ lemma mapAlgHom_id :
       AlgHom.id R (CounitAlgebra R A B) := by
   ext b
   apply (algEquivSelf R A B).injective
-  rw [algEquivSelf_mapAlgHom, AlgHom.id_apply, AlgHom.id_apply]
+  rw [mapAlgHom_apply]
+  -- The two identity homomorphisms have definitionally equal carriers but
+  -- distinct exported synonym types. `algEquivSelf_apply` cannot rewrite the
+  -- temporarily ill-typed coercion, so cross that boundary explicitly once.
+  change (AlgHom.id R B) (algEquivSelf R A B b) = algEquivSelf R A B b
+  rw [AlgHom.id_apply]
 
 omit [CommSemiring A] [Bialgebra R A] in
 /-- Homomorphisms of counit coefficient algebras preserve composition. -/
 @[simp]
-lemma mapAlgHom_comp {D : Type*} [CommSemiring D] [Algebra R D]
+lemma mapAlgHom_comp {D : Type*} [Semiring D] [Algebra R D]
     (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
     mapAlgHom (A := A) (psi.comp phi) =
       (mapAlgHom (A := A) psi).comp (mapAlgHom (A := A) phi) := by
   ext b
   apply (algEquivSelf R A D).injective
-  rw [algEquivSelf_mapAlgHom, AlgHom.comp_apply, AlgHom.comp_apply,
-    algEquivSelf_mapAlgHom, algEquivSelf_mapAlgHom]
+  rw [mapAlgHom_apply]
+  -- As in `mapAlgHom_id`, the synonym boundary prevents further rewriting
+  -- even though all remaining maps are exposed by `mapAlgHom_apply`.
+  change (psi.comp phi) (algEquivSelf R A B b) =
+    psi (phi (algEquivSelf R A B b))
+  rw [AlgHom.comp_apply]
 
 /-- An algebra map between coefficient algebras, regarded as a linear map for the
 `A`-module structures induced by the counit. -/
@@ -266,22 +266,13 @@ noncomputable def map (phi : B →ₐ[R] C) :
   toFun := mapAlgHom (A := A) phi
   map_add' := map_add (mapAlgHom (A := A) phi)
   map_smul' a b := by
-    have hB : algEquivSelf R A B (algebraMap A (CounitAlgebra R A B) a) =
-        algebraMap R B (counit a) := calc
-      _ = algEquivSelf R A B
-          (algebraMap R (CounitAlgebra R A B) (counit a)) :=
-        congrArg (algEquivSelf R A B) (algebraMap_apply R A B a)
-      _ = _ := (algEquivSelf R A B).commutes (counit a)
-    have hC : algEquivSelf R A C (algebraMap A (CounitAlgebra R A C) a) =
-        algebraMap R C (counit a) := calc
-      _ = algEquivSelf R A C
-          (algebraMap R (CounitAlgebra R A C) (counit a)) :=
-        congrArg (algEquivSelf R A C) (algebraMap_apply R A C a)
-      _ = _ := (algEquivSelf R A C).commutes (counit a)
-    rw [Algebra.smul_def, Algebra.smul_def]
-    apply (algEquivSelf R A C).injective
-    rw [algEquivSelf_mapAlgHom, map_mul, map_mul, map_mul, algEquivSelf_mapAlgHom,
-      hB, RingHom.id_apply, hC, phi.commutes]
+    rw [mapAlgHom_apply, mapAlgHom_apply]
+    -- Scalar multiplication on each synonym is multiplication by the counit
+    -- image. No conversion lemma combines this with a map between two distinct
+    -- synonym types, so expose that stable pointwise formula explicitly.
+    change phi (algebraMap R B (counit a) * algEquivSelf R A B b) =
+      algebraMap R C (counit a) * phi (algEquivSelf R A B b)
+    rw [map_mul, phi.commutes]
 
 /-- The linear coefficient map has the same underlying function as the coefficient
 algebra map. -/
@@ -301,18 +292,22 @@ lemma map_id :
   ext b
   apply (algEquivSelf R A B).injective
   rw [map_apply, LinearMap.id_apply, algEquivSelf_apply]
+  -- `map_apply` exposes the public pointwise API, after which only the exported
+  -- coefficient synonym prevents `AlgHom.id_apply` from matching directly.
   change (AlgHom.id R B) (algEquivSelf R A B b) = algEquivSelf R A B b
   rw [AlgHom.id_apply]
 
 /-- Coefficient maps preserve composition. -/
 @[simp]
-lemma map_comp {D : Type*} [CommSemiring D] [Algebra R D]
+lemma map_comp {D : Type*} [Semiring D] [Algebra R D]
     (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
     map (A := A) (psi.comp phi) =
       (map (A := A) psi).comp (map (A := A) phi) := by
   ext b
   apply (algEquivSelf R A D).injective
   rw [map_apply, LinearMap.comp_apply, map_apply, map_apply]
+  -- The application lemmas reduce both sides to coefficient homomorphisms; the
+  -- remaining conversion only identifies their exported synonym carriers.
   change (psi.comp phi) (algEquivSelf R A B b) =
     psi (phi (algEquivSelf R A B b))
   rw [AlgHom.comp_apply]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -37,6 +37,9 @@ kernel says nothing about the Lie bracket, which appears at second order.
 The synonym `CounitAlgebra` is a fresh scope for the point-induced algebra structure,
 as the dictionary requires; it does not install instances on `B` itself, and
 `Bialgebra.CounitAlgebra.algEquivSelf` transports back to `B` as an `R`-algebra.
+An algebra homomorphism between coefficient algebras transports these synonyms via
+`Bialgebra.CounitAlgebra.mapAlgHom`; `Bialgebra.CounitAlgebra.map` records that this
+transport is linear for the actions induced by the counit.
 
 ## The exterior convolution product
 
@@ -198,6 +201,125 @@ lemma algebraMap_apply (a : A) :
 end Bialgebra.CounitAlgebra
 
 end BialgebraPointScalar
+
+section CounitAlgebraMap
+
+namespace Bialgebra.CounitAlgebra
+
+variable {R A B C : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
+  [CommSemiring B] [Algebra R B] [CommSemiring C] [Algebra R C]
+
+/-- An algebra homomorphism of coefficients, transported to the counit coefficient
+algebras. -/
+noncomputable def mapAlgHom (phi : B →ₐ[R] C) :
+    CounitAlgebra R A B →ₐ[R] CounitAlgebra R A C :=
+  (algEquivSelf R A C).symm.toAlgHom.comp (phi.comp (algEquivSelf R A B).toAlgHom)
+
+omit [CommSemiring A] [Bialgebra R A] in
+/-- The coefficient algebra map is the original map under the canonical
+identifications with its source and target. -/
+lemma algEquivSelf_mapAlgHom (phi : B →ₐ[R] C) (b : CounitAlgebra R A B) :
+    algEquivSelf R A C (mapAlgHom (A := A) phi b) =
+      phi (algEquivSelf R A B b) := by
+  -- The public equivalences are the API for crossing the coefficient synonyms;
+  -- `change` exposes the composite through those equivalences once.
+  change algEquivSelf R A C
+      ((algEquivSelf R A C).symm (phi (algEquivSelf R A B b))) = _
+  rw [AlgEquiv.apply_symm_apply]
+
+omit [CommSemiring A] [Bialgebra R A] in
+/-- Transport of counit coefficient algebras acts pointwise by the original
+coefficient homomorphism. -/
+@[simp]
+lemma mapAlgHom_apply (phi : B →ₐ[R] C) (b : CounitAlgebra R A B) :
+    mapAlgHom (A := A) phi b = phi b := by
+  change (algEquivSelf R A C).symm (phi (algEquivSelf R A B b)) = phi b
+  rw [algEquivSelf_apply, algEquivSelf_symm_apply]
+
+omit [CommSemiring A] [Bialgebra R A] in
+/-- The identity coefficient homomorphism induces the identity homomorphism of
+counit coefficient algebras. -/
+@[simp]
+lemma mapAlgHom_id :
+    mapAlgHom (A := A) (AlgHom.id R B) =
+      AlgHom.id R (CounitAlgebra R A B) := by
+  ext b
+  apply (algEquivSelf R A B).injective
+  rw [algEquivSelf_mapAlgHom, AlgHom.id_apply, AlgHom.id_apply]
+
+omit [CommSemiring A] [Bialgebra R A] in
+/-- Homomorphisms of counit coefficient algebras preserve composition. -/
+@[simp]
+lemma mapAlgHom_comp {D : Type*} [CommSemiring D] [Algebra R D]
+    (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
+    mapAlgHom (A := A) (psi.comp phi) =
+      (mapAlgHom (A := A) psi).comp (mapAlgHom (A := A) phi) := by
+  ext b
+  apply (algEquivSelf R A D).injective
+  rw [algEquivSelf_mapAlgHom, AlgHom.comp_apply, AlgHom.comp_apply,
+    algEquivSelf_mapAlgHom, algEquivSelf_mapAlgHom]
+
+/-- An algebra map between coefficient algebras, regarded as a linear map for the
+`A`-module structures induced by the counit. -/
+noncomputable def map (phi : B →ₐ[R] C) :
+    CounitAlgebra R A B →ₗ[A] CounitAlgebra R A C where
+  toFun := mapAlgHom (A := A) phi
+  map_add' := map_add (mapAlgHom (A := A) phi)
+  map_smul' a b := by
+    have hB : algEquivSelf R A B (algebraMap A (CounitAlgebra R A B) a) =
+        algebraMap R B (counit a) := calc
+      _ = algEquivSelf R A B
+          (algebraMap R (CounitAlgebra R A B) (counit a)) :=
+        congrArg (algEquivSelf R A B) (algebraMap_apply R A B a)
+      _ = _ := (algEquivSelf R A B).commutes (counit a)
+    have hC : algEquivSelf R A C (algebraMap A (CounitAlgebra R A C) a) =
+        algebraMap R C (counit a) := calc
+      _ = algEquivSelf R A C
+          (algebraMap R (CounitAlgebra R A C) (counit a)) :=
+        congrArg (algEquivSelf R A C) (algebraMap_apply R A C a)
+      _ = _ := (algEquivSelf R A C).commutes (counit a)
+    rw [Algebra.smul_def, Algebra.smul_def]
+    apply (algEquivSelf R A C).injective
+    rw [algEquivSelf_mapAlgHom, map_mul, map_mul, map_mul, algEquivSelf_mapAlgHom,
+      hB, RingHom.id_apply, hC, phi.commutes]
+
+/-- The linear coefficient map has the same underlying function as the coefficient
+algebra map. -/
+@[simp]
+lemma map_apply (phi : B →ₐ[R] C) (b : CounitAlgebra R A B) :
+    map (A := A) phi b = phi b := by
+  -- `map` is a structure-valued definition with no generated application theorem;
+  -- unfolding its `toFun` field is stable and exposes exactly `mapAlgHom`.
+  change mapAlgHom (A := A) phi b = _
+  rw [mapAlgHom_apply]
+
+/-- The identity algebra homomorphism induces the identity coefficient map. -/
+@[simp]
+lemma map_id :
+    map (A := A) (AlgHom.id R B) =
+      LinearMap.id (R := A) (M := CounitAlgebra R A B) := by
+  ext b
+  apply (algEquivSelf R A B).injective
+  rw [map_apply, LinearMap.id_apply, algEquivSelf_apply]
+  change (AlgHom.id R B) (algEquivSelf R A B b) = algEquivSelf R A B b
+  rw [AlgHom.id_apply]
+
+/-- Coefficient maps preserve composition. -/
+@[simp]
+lemma map_comp {D : Type*} [CommSemiring D] [Algebra R D]
+    (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
+    map (A := A) (psi.comp phi) =
+      (map (A := A) psi).comp (map (A := A) phi) := by
+  ext b
+  apply (algEquivSelf R A D).injective
+  rw [map_apply, LinearMap.comp_apply, map_apply, map_apply]
+  change (psi.comp phi) (algEquivSelf R A B b) =
+    psi (phi (algEquivSelf R A B b))
+  rw [AlgHom.comp_apply]
+
+end Bialgebra.CounitAlgebra
+
+end CounitAlgebraMap
 
 section CommPointScalar
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Adjoint
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Naturality
 
 /-!
 # The Lie algebra of the tangent space
@@ -14,5 +15,5 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
 Directory aggregator: importing this module provides the Lie algebra structure
 on counit-valued derivations (`Lie.Basic`), the differential as a Lie algebra
 morphism (`Lie.Map`), and the compatibility of the adjoint action with the bracket
-(`Lie.Adjoint`).
+(`Lie.Adjoint`) and change of coefficient algebra (`Lie.Naturality`).
 -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Adjoint
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Naturality
+
+/-!
+# The tangent Lie algebra is natural in the coefficient algebra
+
+Postcomposition along a homomorphism of coefficient rings preserves the convolution
+commutator bracket on counit-valued derivations. Thus the functorial linear map
+`TauCeti.Derivation.mapValue` upgrades to a Lie algebra homomorphism. This is the
+Lie-algebra layer of the natural adjoint action constructed in `Tangent.Naturality`.
+
+## Main declarations
+
+* `TauCeti.Derivation.mapValue_lie`: postcomposition preserves the tangent bracket.
+* `TauCeti.Derivation.lieMapValue`: change of coefficients as a Lie algebra
+  homomorphism.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Derivation
+
+open _root_.Coalgebra
+
+variable {R A B C : Type*} [CommRing R] [CommRing A] [HopfAlgebra R A]
+  [CommRing B] [Algebra R B] [CommRing C] [Algebra R C]
+
+/-- Postcomposition of counit-valued derivations preserves their convolution
+commutator bracket. -/
+@[simp]
+theorem mapValue_lie (phi : B →ₐ[R] C)
+    (d e : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    mapValue (A := A) phi ⁅d, e⁆ =
+      ⁅mapValue (A := A) phi d, mapValue (A := A) phi e⁆ := by
+  ext a
+  rw [mapValue_apply]
+  -- Extensionality and `mapValue_apply` leave function coercions on the two
+  -- brackets; restating them as linear-map applications lets `coe_bracket` apply.
+  change ((Bialgebra.CounitAlgebra.mapAlgHom (A := A) phi).toLinearMap.comp
+      (↑⁅d, e⁆ : A →ₗ[R] Bialgebra.CounitAlgebra R A B)) a =
+    (↑⁅mapValue (A := A) phi d, mapValue (A := A) phi e⁆ :
+      A →ₗ[R] Bialgebra.CounitAlgebra R A C) a
+  rw [coe_bracket, coe_bracket]
+  simp only [LinearMap.comp_sub]
+  rw [LinearMap.algHom_comp_convMul_distrib, LinearMap.algHom_comp_convMul_distrib]
+  simp only [coe_mapValue_linearMap]
+
+/-- Change of coefficient algebra on the tangent Lie algebra. -/
+noncomputable def lieMapValue (phi : B →ₐ[R] C) :
+  Derivation R A (Bialgebra.CounitAlgebra R A B) →ₗ⁅R⁆
+      Derivation R A (Bialgebra.CounitAlgebra R A C) where
+  toLinearMap := mapValue (A := A) phi
+  map_lie' := fun {d e} => mapValue_lie (A := A) phi d e
+
+/-- The underlying linear map of change of coefficients on the tangent Lie algebra is
+`mapValue`. -/
+@[simp]
+lemma lieMapValue_toLinearMap (phi : B →ₐ[R] C) :
+    (lieMapValue (R := R) (A := A) (B := B) (C := C) phi).toLinearMap =
+      mapValue (A := A) phi := by
+  ext d a
+  -- `lieMapValue` has no equation lemma; this is its `toLinearMap` field,
+  -- evaluated after extensionality.
+  change mapValue (A := A) phi d a = mapValue (A := A) phi d a
+  rfl
+
+/-- Change of coefficients on the tangent Lie algebra acts pointwise by
+postcomposition. -/
+@[simp]
+lemma lieMapValue_apply (phi : B →ₐ[R] C)
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A) :
+    lieMapValue (R := R) (A := A) (B := B) (C := C) phi d a =
+      Bialgebra.CounitAlgebra.mapAlgHom (A := A) phi (d a) := by
+  rw [← mapValue_apply (A := A) phi d a]
+  have h := DFunLike.congr_fun
+    (lieMapValue_toLinearMap (R := R) (A := A) (B := B) (C := C) phi) d
+  exact DFunLike.congr_fun h a
+
+/-- Change of coefficients by the identity is the identity Lie algebra homomorphism. -/
+@[simp]
+theorem lieMapValue_id :
+    lieMapValue (A := A) (AlgHom.id R B) =
+      LieHom.id (R := R) := by
+  ext d
+  rw [LieHom.id_apply]
+  have h := DFunLike.congr_fun
+    (lieMapValue_toLinearMap (A := A) (AlgHom.id R B)) d
+  have hid := DFunLike.congr_fun (mapValue_id (A := A) (B := B)) d
+  exact (DFunLike.congr_fun h _).trans (DFunLike.congr_fun hid _)
+
+/-- Change of coefficients on tangent Lie algebras preserves composition. -/
+@[simp]
+theorem lieMapValue_comp {D : Type*} [CommRing D] [Algebra R D]
+    (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
+    lieMapValue (A := A) (psi.comp phi) =
+      (lieMapValue (A := A) psi).comp (lieMapValue (A := A) phi) := by
+  ext d
+  rw [LieHom.comp_apply]
+  have hleft := DFunLike.congr_fun
+    (lieMapValue_toLinearMap (A := A) (psi.comp phi)) d
+  have houter := DFunLike.congr_fun
+    (lieMapValue_toLinearMap (A := A) psi) (lieMapValue (A := A) phi d)
+  have hinner := DFunLike.congr_fun
+    (lieMapValue_toLinearMap (A := A) phi) d
+  calc
+    _ = mapValue (A := A) (psi.comp phi) d _ := DFunLike.congr_fun hleft _
+    _ = ((mapValue (A := A) psi).comp (mapValue (A := A) phi)) d _ := by
+      have hcomp := DFunLike.congr_fun (mapValue_comp (A := A) psi phi) d
+      exact DFunLike.congr_fun hcomp _
+    _ = mapValue (A := A) psi (mapValue (A := A) phi d) _ := by
+      rw [LinearMap.comp_apply]
+    _ = mapValue (A := A) psi (lieMapValue (A := A) phi d) _ := by
+      exact DFunLike.congr_fun (congrArg (mapValue (A := A) psi) hinner.symm) _
+    _ = lieMapValue (A := A) psi (lieMapValue (A := A) phi d) _ :=
+      (DFunLike.congr_fun houter _).symm
+
+end Derivation
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Adjoint
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Naturality
 
 /-!
@@ -30,7 +30,7 @@ namespace Derivation
 
 open _root_.Coalgebra
 
-variable {R A B C : Type*} [CommRing R] [CommRing A] [HopfAlgebra R A]
+variable {R A B C : Type*} [CommRing R] [CommRing A] [Bialgebra R A]
   [CommRing B] [Algebra R B] [CommRing C] [Algebra R C]
 
 /-- Postcomposition of counit-valued derivations preserves their convolution
@@ -42,6 +42,7 @@ theorem mapValue_lie (phi : B →ₐ[R] C)
       ⁅mapValue (A := A) phi d, mapValue (A := A) phi e⁆ := by
   ext a
   rw [mapValue_apply]
+  rw [← Bialgebra.CounitAlgebra.mapAlgHom_apply (A := A) phi]
   -- Extensionality and `mapValue_apply` leave function coercions on the two
   -- brackets; restating them as linear-map applications lets `coe_bracket` apply.
   change ((Bialgebra.CounitAlgebra.mapAlgHom (A := A) phi).toLinearMap.comp
@@ -78,7 +79,7 @@ postcomposition. -/
 lemma lieMapValue_apply (phi : B →ₐ[R] C)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A) :
     lieMapValue (R := R) (A := A) (B := B) (C := C) phi d a =
-      Bialgebra.CounitAlgebra.mapAlgHom (A := A) phi (d a) := by
+      phi (d a) := by
   rw [← mapValue_apply (A := A) phi d a]
   have h := DFunLike.congr_fun
     (lieMapValue_toLinearMap (R := R) (A := A) (B := B) (C := C) phi) d
@@ -89,12 +90,12 @@ lemma lieMapValue_apply (phi : B →ₐ[R] C)
 theorem lieMapValue_id :
     lieMapValue (A := A) (AlgHom.id R B) =
       LieHom.id (R := R) := by
-  ext d
-  rw [LieHom.id_apply]
-  have h := DFunLike.congr_fun
-    (lieMapValue_toLinearMap (A := A) (AlgHom.id R B)) d
-  have hid := DFunLike.congr_fun (mapValue_id (A := A) (B := B)) d
-  exact (DFunLike.congr_fun h _).trans (DFunLike.congr_fun hid _)
+  apply LieHom.ext
+  intro d
+  change (lieMapValue (A := A) (AlgHom.id R B)).toLinearMap d =
+    (LieHom.id (R := R)).toLinearMap d
+  rw [lieMapValue_toLinearMap, mapValue_id]
+  rfl
 
 /-- Change of coefficients on tangent Lie algebras preserves composition. -/
 @[simp]
@@ -102,25 +103,12 @@ theorem lieMapValue_comp {D : Type*} [CommRing D] [Algebra R D]
     (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
     lieMapValue (A := A) (psi.comp phi) =
       (lieMapValue (A := A) psi).comp (lieMapValue (A := A) phi) := by
-  ext d
-  rw [LieHom.comp_apply]
-  have hleft := DFunLike.congr_fun
-    (lieMapValue_toLinearMap (A := A) (psi.comp phi)) d
-  have houter := DFunLike.congr_fun
-    (lieMapValue_toLinearMap (A := A) psi) (lieMapValue (A := A) phi d)
-  have hinner := DFunLike.congr_fun
-    (lieMapValue_toLinearMap (A := A) phi) d
-  calc
-    _ = mapValue (A := A) (psi.comp phi) d _ := DFunLike.congr_fun hleft _
-    _ = ((mapValue (A := A) psi).comp (mapValue (A := A) phi)) d _ := by
-      have hcomp := DFunLike.congr_fun (mapValue_comp (A := A) psi phi) d
-      exact DFunLike.congr_fun hcomp _
-    _ = mapValue (A := A) psi (mapValue (A := A) phi d) _ := by
-      rw [LinearMap.comp_apply]
-    _ = mapValue (A := A) psi (lieMapValue (A := A) phi d) _ := by
-      exact DFunLike.congr_fun (congrArg (mapValue (A := A) psi) hinner.symm) _
-    _ = lieMapValue (A := A) psi (lieMapValue (A := A) phi d) _ :=
-      (DFunLike.congr_fun houter _).symm
+  apply LieHom.ext
+  intro d
+  change (lieMapValue (A := A) (psi.comp phi)).toLinearMap d =
+    ((lieMapValue (A := A) psi).comp (lieMapValue (A := A) phi)).toLinearMap d
+  rw [lieMapValue_toLinearMap, LieHom.toLinearMap_comp, lieMapValue_toLinearMap,
+    lieMapValue_toLinearMap, mapValue_comp]
 
 end Derivation
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean
@@ -92,6 +92,9 @@ theorem lieMapValue_id :
       LieHom.id (R := R) := by
   apply LieHom.ext
   intro d
+  -- `LieHom.ext` states the goal through function coercions, while the public
+  -- functoriality theorem is about underlying linear maps. Expose that stable
+  -- projection once so `lieMapValue_toLinearMap` and `mapValue_id` apply.
   change (lieMapValue (A := A) (AlgHom.id R B)).toLinearMap d =
     (LieHom.id (R := R)).toLinearMap d
   rw [lieMapValue_toLinearMap, mapValue_id]
@@ -105,6 +108,8 @@ theorem lieMapValue_comp {D : Type*} [CommRing D] [Algebra R D]
       (lieMapValue (A := A) psi).comp (lieMapValue (A := A) phi) := by
   apply LieHom.ext
   intro d
+  -- As above, this conversion connects `LieHom.ext` to the public underlying-map
+  -- API; it does not unfold the implementation of coefficient transport.
   change (lieMapValue (A := A) (psi.comp phi)).toLinearMap d =
     ((lieMapValue (A := A) psi).comp (lieMapValue (A := A) phi)).toLinearMap d
   rw [lieMapValue_toLinearMap, LieHom.toLinearMap_comp, lieMapValue_toLinearMap,

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean
@@ -48,18 +48,18 @@ open _root_.Coalgebra WithConv
 namespace Derivation
 
 variable {R A B C : Type*} [CommSemiring R] [CommSemiring A]
-  [CommSemiring B] [Algebra R B] [CommSemiring C] [Algebra R C]
 
 section Bialgebra
 
-variable [Bialgebra R A]
+variable [Bialgebra R A] [Semiring B] [Algebra R B] [Semiring C] [Algebra R C]
 
 /-- Postcomposition of a counit-valued derivation along an algebra homomorphism of
 coefficients. This is the functorial map on tangent vectors. -/
 noncomputable def mapValue (phi : B →ₐ[R] C) :
     Derivation R A (Bialgebra.CounitAlgebra R A B) →ₗ[R]
       Derivation R A (Bialgebra.CounitAlgebra R A C) :=
-  (Bialgebra.CounitAlgebra.map (A := A) phi).compDer |>.restrictScalars R
+  (Bialgebra.CounitAlgebra.map
+    (R := R) (A := A) (B := B) (C := C) phi).compDer |>.restrictScalars R
 
 /-- Postcomposition of a counit-valued derivation acts pointwise. -/
 @[simp]
@@ -97,7 +97,7 @@ theorem mapValue_id :
 
 /-- Postcomposition of counit-valued derivations preserves composition. -/
 @[simp]
-theorem mapValue_comp {D : Type*} [CommSemiring D] [Algebra R D]
+theorem mapValue_comp {D : Type*} [Semiring D] [Algebra R D]
     (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
     mapValue (A := A) (psi.comp phi) =
       (mapValue (A := A) psi).comp (mapValue (A := A) phi) := by
@@ -108,7 +108,8 @@ end Bialgebra
 
 section Adjoint
 
-variable [HopfAlgebra R A]
+variable [HopfAlgebra R A] [CommSemiring B] [Algebra R B]
+  [CommSemiring C] [Algebra R C]
 
 /-- **The adjoint action is natural in the coefficient algebra.** Mapping a point and
 a tangent vector along `phi` and then applying the adjoint action gives the same
@@ -138,19 +139,6 @@ theorem mapValue_adDerivation (phi : B →ₐ[R] C)
   simp only [AlgHom.mapValue_apply, coe_mapValue_linearMap, AlgHom.comp_toLinearMap,
     toConv_ofConv]
   rfl
-
-/-- The valuewise adjoint representations intertwine the functorial maps on points
-and tangent vectors. -/
-theorem mapValue_adRepresentation (phi : B →ₐ[R] C)
-    (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
-    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
-    mapValue phi (adRepresentation B g d) =
-      adRepresentation C
-        (AlgHom.mapValue (R := R) (H := A)
-          (Bialgebra.CounitAlgebra.mapAlgHom
-            (R := R) (A := A) (B := B) (C := C) phi) g)
-        (mapValue phi d) := by
-  rw [adRepresentation_apply, adRepresentation_apply, mapValue_adDerivation]
 
 end Adjoint
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean
@@ -1,0 +1,247 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Adjoint
+
+/-!
+# Naturality of the tangent and adjoint actions in the coefficient algebra
+
+For a Hopf algebra `A` over `R`, the tangent space is naturally a functor of the
+coefficient algebra:
+
+`B ↦ Derivation R A (Bialgebra.CounitAlgebra R A B)`.
+
+An `R`-algebra homomorphism `φ : B →ₐ[R] C` postcomposes a counit-valued
+derivation. This file packages that operation as `Derivation.mapValue`, proves its
+functoriality, and shows that it intertwines the adjoint actions at `B` and `C`.
+Together, these statements make the valuewise representations in
+`Tangent.Adjoint` into a natural action on the Lie functor.
+
+## Main declarations
+
+* `TauCeti.Bialgebra.CounitAlgebra.mapAlgHom`: the coefficient algebra map.
+* `TauCeti.Bialgebra.CounitAlgebra.map`: the same map, linear over the Hopf algebra
+  through the counit actions.
+* `TauCeti.Derivation.mapValue`: postcomposition of counit-valued derivations.
+* `TauCeti.Derivation.mapValue_adDerivation`: the adjoint action commutes with
+  change of coefficient algebra.
+
+The Lie-bracket compatibility, which requires additive inverses, is in
+`Tangent.Lie.Naturality`.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §14.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.Coalgebra WithConv
+
+namespace Bialgebra.CounitAlgebra
+
+variable {R A B C : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
+  [CommSemiring B] [Algebra R B] [CommSemiring C] [Algebra R C]
+
+/-- An algebra homomorphism of coefficients, transported to the counit coefficient
+algebras. -/
+noncomputable def mapAlgHom (phi : B →ₐ[R] C) :
+    CounitAlgebra R A B →ₐ[R] CounitAlgebra R A C :=
+  (algEquivSelf R A C).symm.toAlgHom.comp (phi.comp (algEquivSelf R A B).toAlgHom)
+
+omit [CommSemiring A] [Bialgebra R A] in
+/-- The coefficient algebra map is the original map under the canonical
+identifications with its source and target. -/
+lemma algEquivSelf_mapAlgHom (phi : B →ₐ[R] C) (b : CounitAlgebra R A B) :
+    algEquivSelf R A C (mapAlgHom (A := A) phi b) =
+      phi (algEquivSelf R A B b) := by
+  -- The public equivalences are the API for crossing the coefficient synonyms;
+  -- `change` exposes the composite through those equivalences once.
+  change algEquivSelf R A C
+      ((algEquivSelf R A C).symm (phi (algEquivSelf R A B b))) = _
+  rw [AlgEquiv.apply_symm_apply]
+
+omit [CommSemiring A] [Bialgebra R A] in
+/-- The identity coefficient homomorphism induces the identity homomorphism of
+counit coefficient algebras. -/
+@[simp]
+lemma mapAlgHom_id :
+    mapAlgHom (A := A) (AlgHom.id R B) =
+      AlgHom.id R (CounitAlgebra R A B) := by
+  ext b
+  apply (algEquivSelf R A B).injective
+  rw [algEquivSelf_mapAlgHom, AlgHom.id_apply, AlgHom.id_apply]
+
+omit [CommSemiring A] [Bialgebra R A] in
+/-- Homomorphisms of counit coefficient algebras preserve composition. -/
+@[simp]
+lemma mapAlgHom_comp {D : Type*} [CommSemiring D] [Algebra R D]
+    (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
+    mapAlgHom (A := A) (psi.comp phi) =
+      (mapAlgHom (A := A) psi).comp (mapAlgHom (A := A) phi) := by
+  ext b
+  apply (algEquivSelf R A D).injective
+  rw [algEquivSelf_mapAlgHom, AlgHom.comp_apply, AlgHom.comp_apply,
+    algEquivSelf_mapAlgHom, algEquivSelf_mapAlgHom]
+
+/-- An algebra map between coefficient algebras, regarded as a linear map for the
+`A`-module structures induced by the counit. -/
+noncomputable def map (phi : B →ₐ[R] C) :
+    CounitAlgebra R A B →ₗ[A] CounitAlgebra R A C where
+  toFun := mapAlgHom (A := A) phi
+  map_add' := map_add (mapAlgHom (A := A) phi)
+  map_smul' a b := by
+    have hB : algEquivSelf R A B (algebraMap A (CounitAlgebra R A B) a) =
+        algebraMap R B (counit a) := calc
+      _ = algEquivSelf R A B
+          (algebraMap R (CounitAlgebra R A B) (counit a)) :=
+        congrArg (algEquivSelf R A B) (algebraMap_apply R A B a)
+      _ = _ := (algEquivSelf R A B).commutes (counit a)
+    have hC : algEquivSelf R A C (algebraMap A (CounitAlgebra R A C) a) =
+        algebraMap R C (counit a) := calc
+      _ = algEquivSelf R A C
+          (algebraMap R (CounitAlgebra R A C) (counit a)) :=
+        congrArg (algEquivSelf R A C) (algebraMap_apply R A C a)
+      _ = _ := (algEquivSelf R A C).commutes (counit a)
+    rw [Algebra.smul_def, Algebra.smul_def]
+    apply (algEquivSelf R A C).injective
+    rw [algEquivSelf_mapAlgHom, map_mul, map_mul, map_mul, algEquivSelf_mapAlgHom,
+      hB, RingHom.id_apply, hC, phi.commutes]
+
+/-- The linear coefficient map has the same underlying function as the coefficient
+algebra map. -/
+@[simp]
+lemma map_apply (phi : B →ₐ[R] C) (b : CounitAlgebra R A B) :
+    map (A := A) phi b = mapAlgHom (A := A) phi b := by
+  change mapAlgHom (A := A) phi b = _
+  rfl
+
+/-- The identity algebra homomorphism induces the identity coefficient map. -/
+@[simp]
+lemma map_id :
+    map (A := A) (AlgHom.id R B) =
+      LinearMap.id (R := A) (M := CounitAlgebra R A B) := by
+  ext b
+  apply (algEquivSelf R A B).injective
+  rw [map_apply, algEquivSelf_mapAlgHom, LinearMap.id_apply, AlgHom.id_apply]
+
+/-- Coefficient maps preserve composition. -/
+@[simp]
+lemma map_comp {D : Type*} [CommSemiring D] [Algebra R D]
+    (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
+    map (A := A) (psi.comp phi) =
+      (map (A := A) psi).comp (map (A := A) phi) := by
+  ext b
+  apply (algEquivSelf R A D).injective
+  rw [map_apply, algEquivSelf_mapAlgHom, LinearMap.comp_apply, map_apply,
+    algEquivSelf_mapAlgHom, map_apply, algEquivSelf_mapAlgHom, AlgHom.comp_apply]
+
+end Bialgebra.CounitAlgebra
+
+namespace Derivation
+
+variable {R A B C : Type*} [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
+  [CommSemiring B] [Algebra R B] [CommSemiring C] [Algebra R C]
+
+/-- Postcomposition of a counit-valued derivation along an algebra homomorphism of
+coefficients. This is the functorial map on tangent vectors. -/
+noncomputable def mapValue (phi : B →ₐ[R] C) :
+    Derivation R A (Bialgebra.CounitAlgebra R A B) →ₗ[R]
+      Derivation R A (Bialgebra.CounitAlgebra R A C) :=
+  (Bialgebra.CounitAlgebra.map (A := A) phi).compDer |>.restrictScalars R
+
+/-- Postcomposition of a counit-valued derivation acts pointwise. -/
+@[simp]
+lemma mapValue_apply (phi : B →ₐ[R] C)
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A) :
+    mapValue phi d a = Bialgebra.CounitAlgebra.mapAlgHom (A := A) phi (d a) := by
+  change Bialgebra.CounitAlgebra.map (A := A) phi (d a) = _
+  rw [Bialgebra.CounitAlgebra.map_apply]
+
+/-- On underlying linear maps, change of coefficients is postcomposition by the
+coefficient algebra map. -/
+@[simp]
+lemma coe_mapValue_linearMap (phi : B →ₐ[R] C)
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    ↑(mapValue phi d) =
+      (Bialgebra.CounitAlgebra.mapAlgHom (A := A) phi).toLinearMap.comp
+        (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) := by
+  ext a
+  -- Extensionality presents the left side through its underlying linear map;
+  -- `mapValue_apply` is stated through the derivation coercion.
+  change mapValue phi d a = _
+  rw [mapValue_apply, LinearMap.comp_apply, AlgHom.toLinearMap_apply]
+  rfl
+
+/-- Postcomposition by the identity is the identity on counit-valued derivations. -/
+@[simp]
+theorem mapValue_id :
+    mapValue (A := A) (AlgHom.id R B) =
+      LinearMap.id (R := R)
+        (M := Derivation R A (Bialgebra.CounitAlgebra R A B)) := by
+  ext d a
+  apply (Bialgebra.CounitAlgebra.algEquivSelf R A B).injective
+  rw [mapValue_apply, Bialgebra.CounitAlgebra.algEquivSelf_mapAlgHom,
+    LinearMap.id_apply, AlgHom.id_apply]
+
+/-- Postcomposition of counit-valued derivations preserves composition. -/
+@[simp]
+theorem mapValue_comp {D : Type*} [CommSemiring D] [Algebra R D]
+    (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
+    mapValue (A := A) (psi.comp phi) =
+      (mapValue (A := A) psi).comp (mapValue (A := A) phi) := by
+  ext d a
+  apply (Bialgebra.CounitAlgebra.algEquivSelf R A D).injective
+  rw [mapValue_apply, Bialgebra.CounitAlgebra.algEquivSelf_mapAlgHom,
+    LinearMap.comp_apply, mapValue_apply, mapValue_apply,
+    Bialgebra.CounitAlgebra.algEquivSelf_mapAlgHom,
+    Bialgebra.CounitAlgebra.algEquivSelf_mapAlgHom, AlgHom.comp_apply]
+
+/-- **The adjoint action is natural in the coefficient algebra.** Mapping a point and
+a tangent vector along `phi` and then applying the adjoint action gives the same
+result as applying the action first and postcomposing the resulting derivation. -/
+theorem mapValue_adDerivation (phi : B →ₐ[R] C)
+    (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    mapValue phi (adDerivation B g d) =
+      adDerivation C
+        (AlgHom.mapValue (R := R) (H := A)
+          (Bialgebra.CounitAlgebra.mapAlgHom
+            (R := R) (A := A) (B := B) (C := C) phi) g)
+        (mapValue phi d) := by
+  ext a
+  rw [mapValue_apply, adDerivation_apply, adDerivation_apply]
+  -- The algebra-hom coercion and its underlying linear map agree pointwise; the
+  -- convolution distribution lemma is stated for the latter.
+  change (Bialgebra.CounitAlgebra.mapAlgHom (A := A) phi).toLinearMap
+      ((toConv g.ofConv.toLinearMap *
+          toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+          toConv ((g⁻¹).ofConv.toLinearMap)).ofConv a) = _
+  rw [← LinearMap.comp_apply
+    (Bialgebra.CounitAlgebra.mapAlgHom (A := A) phi).toLinearMap]
+  rw [LinearMap.algHom_comp_convMul_distrib, LinearMap.algHom_comp_convMul_distrib]
+  simp only [AlgHom.mapValue_apply, coe_mapValue_linearMap, AlgHom.comp_toLinearMap,
+    toConv_ofConv]
+  rfl
+
+/-- The valuewise adjoint representations intertwine the functorial maps on points
+and tangent vectors. -/
+theorem mapValue_adRepresentation (phi : B →ₐ[R] C)
+    (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    mapValue phi (adRepresentation B g d) =
+      adRepresentation C
+        (AlgHom.mapValue (R := R) (H := A)
+          (Bialgebra.CounitAlgebra.mapAlgHom
+            (R := R) (A := A) (B := B) (C := C) phi) g)
+        (mapValue phi d) := by
+  rw [adRepresentation_apply, adRepresentation_apply, mapValue_adDerivation]
+
+end Derivation
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean
@@ -9,21 +9,23 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Adjoint
 /-!
 # Naturality of the tangent and adjoint actions in the coefficient algebra
 
-For a Hopf algebra `A` over `R`, the tangent space is naturally a functor of the
+For a bialgebra `A` over `R`, the tangent space is naturally a functor of the
 coefficient algebra:
 
 `B ↦ Derivation R A (Bialgebra.CounitAlgebra R A B)`.
 
 An `R`-algebra homomorphism `φ : B →ₐ[R] C` postcomposes a counit-valued
-derivation. This file packages that operation as `Derivation.mapValue`, proves its
-functoriality, and shows that it intertwines the adjoint actions at `B` and `C`.
+derivation. The underlying maps of counit algebras are defined in `Tangent.Basic`;
+this file packages postcomposition as `Derivation.mapValue`, proves its
+functoriality, and, when `A` is a Hopf algebra, shows that it intertwines the adjoint
+actions at `B` and `C`.
 Together, these statements make the valuewise representations in
 `Tangent.Adjoint` into a natural action on the Lie functor.
 
 ## Main declarations
 
 * `TauCeti.Bialgebra.CounitAlgebra.mapAlgHom`: the coefficient algebra map.
-* `TauCeti.Bialgebra.CounitAlgebra.map`: the same map, linear over the Hopf algebra
+* `TauCeti.Bialgebra.CounitAlgebra.map`: the same map, linear over the bialgebra
   through the counit actions.
 * `TauCeti.Derivation.mapValue`: postcomposition of counit-valued derivations.
 * `TauCeti.Derivation.mapValue_adDerivation`: the adjoint action commutes with
@@ -43,110 +45,14 @@ namespace TauCeti
 
 open _root_.Coalgebra WithConv
 
-namespace Bialgebra.CounitAlgebra
-
-variable {R A B C : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
-  [CommSemiring B] [Algebra R B] [CommSemiring C] [Algebra R C]
-
-/-- An algebra homomorphism of coefficients, transported to the counit coefficient
-algebras. -/
-noncomputable def mapAlgHom (phi : B →ₐ[R] C) :
-    CounitAlgebra R A B →ₐ[R] CounitAlgebra R A C :=
-  (algEquivSelf R A C).symm.toAlgHom.comp (phi.comp (algEquivSelf R A B).toAlgHom)
-
-omit [CommSemiring A] [Bialgebra R A] in
-/-- The coefficient algebra map is the original map under the canonical
-identifications with its source and target. -/
-lemma algEquivSelf_mapAlgHom (phi : B →ₐ[R] C) (b : CounitAlgebra R A B) :
-    algEquivSelf R A C (mapAlgHom (A := A) phi b) =
-      phi (algEquivSelf R A B b) := by
-  -- The public equivalences are the API for crossing the coefficient synonyms;
-  -- `change` exposes the composite through those equivalences once.
-  change algEquivSelf R A C
-      ((algEquivSelf R A C).symm (phi (algEquivSelf R A B b))) = _
-  rw [AlgEquiv.apply_symm_apply]
-
-omit [CommSemiring A] [Bialgebra R A] in
-/-- The identity coefficient homomorphism induces the identity homomorphism of
-counit coefficient algebras. -/
-@[simp]
-lemma mapAlgHom_id :
-    mapAlgHom (A := A) (AlgHom.id R B) =
-      AlgHom.id R (CounitAlgebra R A B) := by
-  ext b
-  apply (algEquivSelf R A B).injective
-  rw [algEquivSelf_mapAlgHom, AlgHom.id_apply, AlgHom.id_apply]
-
-omit [CommSemiring A] [Bialgebra R A] in
-/-- Homomorphisms of counit coefficient algebras preserve composition. -/
-@[simp]
-lemma mapAlgHom_comp {D : Type*} [CommSemiring D] [Algebra R D]
-    (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
-    mapAlgHom (A := A) (psi.comp phi) =
-      (mapAlgHom (A := A) psi).comp (mapAlgHom (A := A) phi) := by
-  ext b
-  apply (algEquivSelf R A D).injective
-  rw [algEquivSelf_mapAlgHom, AlgHom.comp_apply, AlgHom.comp_apply,
-    algEquivSelf_mapAlgHom, algEquivSelf_mapAlgHom]
-
-/-- An algebra map between coefficient algebras, regarded as a linear map for the
-`A`-module structures induced by the counit. -/
-noncomputable def map (phi : B →ₐ[R] C) :
-    CounitAlgebra R A B →ₗ[A] CounitAlgebra R A C where
-  toFun := mapAlgHom (A := A) phi
-  map_add' := map_add (mapAlgHom (A := A) phi)
-  map_smul' a b := by
-    have hB : algEquivSelf R A B (algebraMap A (CounitAlgebra R A B) a) =
-        algebraMap R B (counit a) := calc
-      _ = algEquivSelf R A B
-          (algebraMap R (CounitAlgebra R A B) (counit a)) :=
-        congrArg (algEquivSelf R A B) (algebraMap_apply R A B a)
-      _ = _ := (algEquivSelf R A B).commutes (counit a)
-    have hC : algEquivSelf R A C (algebraMap A (CounitAlgebra R A C) a) =
-        algebraMap R C (counit a) := calc
-      _ = algEquivSelf R A C
-          (algebraMap R (CounitAlgebra R A C) (counit a)) :=
-        congrArg (algEquivSelf R A C) (algebraMap_apply R A C a)
-      _ = _ := (algEquivSelf R A C).commutes (counit a)
-    rw [Algebra.smul_def, Algebra.smul_def]
-    apply (algEquivSelf R A C).injective
-    rw [algEquivSelf_mapAlgHom, map_mul, map_mul, map_mul, algEquivSelf_mapAlgHom,
-      hB, RingHom.id_apply, hC, phi.commutes]
-
-/-- The linear coefficient map has the same underlying function as the coefficient
-algebra map. -/
-@[simp]
-lemma map_apply (phi : B →ₐ[R] C) (b : CounitAlgebra R A B) :
-    map (A := A) phi b = mapAlgHom (A := A) phi b := by
-  change mapAlgHom (A := A) phi b = _
-  rfl
-
-/-- The identity algebra homomorphism induces the identity coefficient map. -/
-@[simp]
-lemma map_id :
-    map (A := A) (AlgHom.id R B) =
-      LinearMap.id (R := A) (M := CounitAlgebra R A B) := by
-  ext b
-  apply (algEquivSelf R A B).injective
-  rw [map_apply, algEquivSelf_mapAlgHom, LinearMap.id_apply, AlgHom.id_apply]
-
-/-- Coefficient maps preserve composition. -/
-@[simp]
-lemma map_comp {D : Type*} [CommSemiring D] [Algebra R D]
-    (psi : C →ₐ[R] D) (phi : B →ₐ[R] C) :
-    map (A := A) (psi.comp phi) =
-      (map (A := A) psi).comp (map (A := A) phi) := by
-  ext b
-  apply (algEquivSelf R A D).injective
-  rw [map_apply, algEquivSelf_mapAlgHom, LinearMap.comp_apply, map_apply,
-    algEquivSelf_mapAlgHom, map_apply, algEquivSelf_mapAlgHom, AlgHom.comp_apply]
-
-end Bialgebra.CounitAlgebra
-
 namespace Derivation
 
-variable {R A B C : Type*} [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
+variable {R A B C : Type*} [CommSemiring R] [CommSemiring A]
   [CommSemiring B] [Algebra R B] [CommSemiring C] [Algebra R C]
+
+section Bialgebra
+
+variable [Bialgebra R A]
 
 /-- Postcomposition of a counit-valued derivation along an algebra homomorphism of
 coefficients. This is the functorial map on tangent vectors. -/
@@ -159,9 +65,10 @@ noncomputable def mapValue (phi : B →ₐ[R] C) :
 @[simp]
 lemma mapValue_apply (phi : B →ₐ[R] C)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A) :
-    mapValue phi d a = Bialgebra.CounitAlgebra.mapAlgHom (A := A) phi (d a) := by
-  change Bialgebra.CounitAlgebra.map (A := A) phi (d a) = _
-  rw [Bialgebra.CounitAlgebra.map_apply]
+    mapValue phi d a = phi (d a) := by
+  simp only [mapValue, LinearMap.coe_restrictScalars, Derivation.coe_comp,
+    LinearMap.comp_apply, Derivation.coeFn_coe, Bialgebra.CounitAlgebra.map_apply]
+  rfl
 
 /-- On underlying linear maps, change of coefficients is postcomposition by the
 coefficient algebra map. -/
@@ -175,7 +82,8 @@ lemma coe_mapValue_linearMap (phi : B →ₐ[R] C)
   -- Extensionality presents the left side through its underlying linear map;
   -- `mapValue_apply` is stated through the derivation coercion.
   change mapValue phi d a = _
-  rw [mapValue_apply, LinearMap.comp_apply, AlgHom.toLinearMap_apply]
+  rw [mapValue_apply, LinearMap.comp_apply, AlgHom.toLinearMap_apply,
+    Bialgebra.CounitAlgebra.mapAlgHom_apply]
   rfl
 
 /-- Postcomposition by the identity is the identity on counit-valued derivations. -/
@@ -185,9 +93,7 @@ theorem mapValue_id :
       LinearMap.id (R := R)
         (M := Derivation R A (Bialgebra.CounitAlgebra R A B)) := by
   ext d a
-  apply (Bialgebra.CounitAlgebra.algEquivSelf R A B).injective
-  rw [mapValue_apply, Bialgebra.CounitAlgebra.algEquivSelf_mapAlgHom,
-    LinearMap.id_apply, AlgHom.id_apply]
+  simp [mapValue]
 
 /-- Postcomposition of counit-valued derivations preserves composition. -/
 @[simp]
@@ -196,15 +102,18 @@ theorem mapValue_comp {D : Type*} [CommSemiring D] [Algebra R D]
     mapValue (A := A) (psi.comp phi) =
       (mapValue (A := A) psi).comp (mapValue (A := A) phi) := by
   ext d a
-  apply (Bialgebra.CounitAlgebra.algEquivSelf R A D).injective
-  rw [mapValue_apply, Bialgebra.CounitAlgebra.algEquivSelf_mapAlgHom,
-    LinearMap.comp_apply, mapValue_apply, mapValue_apply,
-    Bialgebra.CounitAlgebra.algEquivSelf_mapAlgHom,
-    Bialgebra.CounitAlgebra.algEquivSelf_mapAlgHom, AlgHom.comp_apply]
+  simp [mapValue]
+
+end Bialgebra
+
+section Adjoint
+
+variable [HopfAlgebra R A]
 
 /-- **The adjoint action is natural in the coefficient algebra.** Mapping a point and
 a tangent vector along `phi` and then applying the adjoint action gives the same
 result as applying the action first and postcomposing the resulting derivation. -/
+@[simp]
 theorem mapValue_adDerivation (phi : B →ₐ[R] C)
     (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
@@ -216,6 +125,7 @@ theorem mapValue_adDerivation (phi : B →ₐ[R] C)
         (mapValue phi d) := by
   ext a
   rw [mapValue_apply, adDerivation_apply, adDerivation_apply]
+  rw [← Bialgebra.CounitAlgebra.mapAlgHom_apply (A := A) phi]
   -- The algebra-hom coercion and its underlying linear map agree pointwise; the
   -- convolution distribution lemma is stated for the latter.
   change (Bialgebra.CounitAlgebra.mapAlgHom (A := A) phi).toLinearMap
@@ -241,6 +151,8 @@ theorem mapValue_adRepresentation (phi : B →ₐ[R] C)
             (R := R) (A := A) (B := B) (C := C) phi) g)
         (mapValue phi d) := by
   rw [adRepresentation_apply, adRepresentation_apply, mapValue_adDerivation]
+
+end Adjoint
 
 end Derivation
 


### PR DESCRIPTION
This PR makes the existing valuewise adjoint actions natural in the coefficient algebra: transport points and counit-valued derivations along an algebra homomorphism, prove that transport commutes with `adDerivation` and `adRepresentation`, and upgrade tangent transport to a functorial Lie algebra homomorphism. It advances the `ReductiveGroups/README.md` Layer 2 milestone **“the adjoint action `Ad : G → GL(Lie G)`”** by supplying the coefficient-algebra naturality required for the current family of pointwise actions to define an action on the Lie functor.

This is the most effective distinct critical-path step now because the remaining Layer 1 faithfulness and embedding pieces are already in flight in #2383 and #2386, while the merged adjoint action explicitly stopped before naturality in the value algebra. After this PR, the Layer 2 milestone still requires the finite-projective comparison between `B`-valued tangent derivations and `B ⊗[R] Lie(G)(R)`, then transport of this natural action to the fixed finite module and its packaging as the group-scheme morphism into `GL(Lie G)`.

Add `Bialgebra.CounitAlgebra.mapAlgHom` and its `A`-linear form, `Derivation.mapValue` with identity and composition laws, the two adjoint-intertwining theorems, bracket preservation, and `Derivation.lieMapValue` with its own identity and composition laws. The construction reuses Mathlib's `LinearMap.compDer`, convolution postcomposition, and `LieHom` APIs together with Tau Ceti's counit-algebra and adjoint-action infrastructure; no Mathlib implementation is vendored. The mathematical interpretation follows J. S. Milne, *Algebraic Groups* (2017), §14, as cited in the module documentation.

Add `TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean` (247 lines) and `TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean` (127 lines), and expose them through the two existing tangent aggregators.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"adjoint-action-naturality"}-->

🤖 Prepared with Codex
