### PR TITLE
feat: dominance triangularity for maps out of a Specht module

### DIFF
--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -41,6 +41,9 @@ here.
 * `TauCeti.asAlgebraHom_columnAntisymmetrizer_single_eq_zero` and
   `TauCeti.dominates_of_asAlgebraHom_columnAntisymmetrizer_ne_zero`: the sign cancellation, and
   James's dominance lemma itself.
+* `TauCeti.YoungTableau.asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates` and
+  `TauCeti.YoungTableau.dominates_of_asAlgebraHom_columnAntisymmetrizer_apply_ne_zero`: the same
+  lemma for an arbitrary vector of `M^μ` rather than a tabloid.
 
 ## References
 
@@ -147,5 +150,43 @@ theorem dominates_of_asAlgebraHom_columnAntisymmetrizer_ne_zero {lam : YoungDiag
   dominates_of_forall_swap_smul_ne t μ q fun _ _ hxy hcol hfix =>
     h (asAlgebraHom_columnAntisymmetrizer_single_eq_zero t μ q (swap_mem_colSubgroup hcol)
       (Equiv.Perm.sign_swap hxy) hfix)
+
+namespace YoungTableau
+
+/-- **The column antisymmetrizer of a non-dominating shape annihilates the whole permutation
+module.**  James's dominance lemma says that `b_t` kills every `μ`-tabloid once the shape of `t`
+fails to dominate `μ`; the tabloids span `M^μ`, so `b_t` kills all of it.
+
+This is to `TauCeti.dominates_of_asAlgebraHom_columnAntisymmetrizer_ne_zero` what
+`TauCeti.YoungTableau.exists_eq_smul_polytabloid` is to
+`TauCeti.YoungTableau.exists_eq_smul_polytabloid_single`: the same statement, extended off the
+tabloid basis by linearity. -/
+theorem asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates {lam : YoungDiagram}
+    (t : YoungTableau lam) (μ : lam.card.Partition) (h : ¬Dominates (shapePartition lam) μ)
+    (x : (permutationModule μ).V) :
+    (permutationModule μ).ρ.asAlgebraHom (columnAntisymmetrizer t) x = 0 := by
+  have hx : x ∈ Submodule.span ℚ (Set.range (permutationModuleBasis μ)) := by
+    rw [Module.Basis.span_eq]
+    exact Submodule.mem_top
+  induction hx using Submodule.span_induction with
+  | mem w hw =>
+    obtain ⟨q, rfl⟩ := hw
+    rw [MonoidAlgebra.basis_apply]
+    by_contra hne
+    exact h (dominates_of_asAlgebraHom_columnAntisymmetrizer_ne_zero t μ q hne)
+  | zero => rw [map_zero]
+  | add u v _ _ hu hv => rw [map_add, hu, hv, add_zero]
+  | smul r u _ hu => rw [map_smul, hu, smul_zero]
+
+/-- **James's dominance lemma for an arbitrary vector.**  If the column antisymmetrizer of a
+`lam`-tableau does not annihilate some vector of `M^μ`, then the shape of `lam` dominates `μ`. -/
+theorem dominates_of_asAlgebraHom_columnAntisymmetrizer_apply_ne_zero {lam : YoungDiagram}
+    (t : YoungTableau lam) (μ : lam.card.Partition) {x : (permutationModule μ).V}
+    (hx : (permutationModule μ).ρ.asAlgebraHom (columnAntisymmetrizer t) x ≠ 0) :
+    Dominates (shapePartition lam) μ := by
+  by_contra h
+  exact hx (asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates t μ h x)
+
+end YoungTableau
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Dominance.lean
@@ -21,8 +21,8 @@ The proof has two steps beyond that lemma.
 
 * **Off the tabloid basis.** James's dominance lemma sees the column antisymmetrizer `b_t` only on
   a single tabloid.  When `lam` fails to dominate `μ` the lemma says `b_t` kills every tabloid, so
-  by linearity it kills all of `M^μ`
-  (`TauCeti.YoungTableau.asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates`).
+  by linearity it kills all of `M^μ`; that extension lives beside the lemma itself, as
+  `TauCeti.YoungTableau.dominates_of_asAlgebraHom_columnAntisymmetrizer_apply_ne_zero`.
 * **Producing a preimage of the polytabloid inside `S^{lam}`.** The polytabloid is `e_t = b_t·{t}`,
   but the tabloid `{t}` is not in the Specht module, so `b_t` cannot be moved across a map defined
   only on `S^{lam}`.  The tabloid form supplies an invariant complement `M^{lam} = S^{lam} ⊕ W`
@@ -41,17 +41,11 @@ here.
 
 ## Main results
 
-* `TauCeti.YoungTableau.asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates` and
-  `TauCeti.YoungTableau.dominates_of_asAlgebraHom_columnAntisymmetrizer_apply_ne_zero`: James's
-  dominance lemma for an arbitrary vector of `M^μ`.
 * `TauCeti.YoungTableau.exists_mem_asAlgebraHom_columnAntisymmetrizer_eq_polytabloid`: the
   polytabloid is `b_t` applied to a vector already inside the Specht module.
 * `TauCeti.dominates_of_intertwiningMap_ne_zero`: a nonzero map `S^{lam} → M^μ` forces dominance.
-* `TauCeti.intertwiningMap_eq_zero_of_not_dominates` and
-  `TauCeti.subsingleton_intertwiningMap_of_not_dominates`: the contrapositive, as the vanishing of
-  the whole `Hom` space.
-* `TauCeti.dominates_of_injective_intertwiningMap`: the Specht module of `lam` embeds in a
-  permutation module `M^μ` only if `lam` dominates `μ`.
+* `TauCeti.intertwiningMap_eq_zero_of_not_dominates`: the contrapositive, as the vanishing of the
+  whole `Hom` space.
 
 ## References
 
@@ -70,42 +64,6 @@ open scoped BigOperators
 variable {lam : YoungDiagram}
 
 namespace YoungTableau
-
-/-! ### The column antisymmetrizer off the tabloid basis -/
-
-/-- **The column antisymmetrizer of a non-dominating shape annihilates the whole permutation
-module.**  James's dominance lemma says that `b_t` kills every `μ`-tabloid once the shape of `t`
-fails to dominate `μ`; the tabloids span `M^μ`, so `b_t` kills all of it.
-
-This is to `TauCeti.dominates_of_asAlgebraHom_columnAntisymmetrizer_ne_zero` what
-`TauCeti.YoungTableau.exists_eq_smul_polytabloid` is to
-`TauCeti.YoungTableau.exists_eq_smul_polytabloid_single`: the same statement, extended off the
-tabloid basis by linearity. -/
-theorem asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates (t : YoungTableau lam)
-    (μ : lam.card.Partition) (h : ¬Dominates (shapePartition lam) μ)
-    (x : (permutationModule μ).V) :
-    (permutationModule μ).ρ.asAlgebraHom (columnAntisymmetrizer t) x = 0 := by
-  have hx : x ∈ Submodule.span ℚ (Set.range (permutationModuleBasis μ)) := by
-    rw [Module.Basis.span_eq]
-    exact Submodule.mem_top
-  induction hx using Submodule.span_induction with
-  | mem w hw =>
-    obtain ⟨q, rfl⟩ := hw
-    rw [MonoidAlgebra.basis_apply]
-    by_contra hne
-    exact h (dominates_of_asAlgebraHom_columnAntisymmetrizer_ne_zero t μ q hne)
-  | zero => rw [map_zero]
-  | add u v _ _ hu hv => rw [map_add, hu, hv, add_zero]
-  | smul r u _ hu => rw [map_smul, hu, smul_zero]
-
-/-- **James's dominance lemma for an arbitrary vector.**  If the column antisymmetrizer of a
-`lam`-tableau does not annihilate some vector of `M^μ`, then the shape of `lam` dominates `μ`. -/
-theorem dominates_of_asAlgebraHom_columnAntisymmetrizer_apply_ne_zero (t : YoungTableau lam)
-    (μ : lam.card.Partition) {x : (permutationModule μ).V}
-    (hx : (permutationModule μ).ρ.asAlgebraHom (columnAntisymmetrizer t) x ≠ 0) :
-    Dominates (shapePartition lam) μ := by
-  by_contra h
-  exact hx (asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates t μ h x)
 
 /-! ### A preimage of the polytabloid inside the Specht module -/
 
@@ -205,11 +163,19 @@ theorem dominates_of_intertwiningMap_ne_zero (μ : lam.card.Partition)
   set E : (spechtSubrepresentation lam).toSubmodule :=
     ∑ q : colSubgroup t, ((Equiv.Perm.sign (q : Equiv.Perm (Fin lam.card)) : ℤ) : ℚ) •
       (spechtSubrepresentation lam).toRepresentation q ⟨e, he⟩ with hE
+  -- the action on the Specht module is the restriction of the ambient action
+  have hact : ∀ (g : Equiv.Perm (Fin lam.card)) (v : (spechtSubrepresentation lam).toSubmodule),
+      ((spechtSubrepresentation lam).toRepresentation g v :
+          (permutationModule (shapePartition lam)).V) =
+        (permutationModule (shapePartition lam)).ρ g v :=
+    fun g v =>
+      LinearMap.coe_restrict_apply ((spechtSubrepresentation lam).apply_mem_toSubmodule g) v
   have hEcoe : (E : (permutationModule (shapePartition lam)).V) = polytabloid t := by
     rw [hE, ← hbe, asAlgebraHom_columnAntisymmetrizer_apply]
     push_cast
-    rfl
-  have hEne : E ≠ 0 := fun h => polytabloid_ne_zero t (by rw [← hEcoe, h]; rfl)
+    exact Finset.sum_congr rfl fun q _ => by rw [hact]
+  have hEne : E ≠ 0 := fun h =>
+    polytabloid_ne_zero t (by rw [← hEcoe, h, ZeroMemClass.coe_zero])
   -- and `f` carries it to `b_t` applied to `f ⟨e, he⟩`
   have hfE : (permutationModule μ).ρ.asAlgebraHom (columnAntisymmetrizer t) (f ⟨e, he⟩) = f E := by
     rw [asAlgebraHom_columnAntisymmetrizer_apply, hE, map_sum]
@@ -229,35 +195,5 @@ theorem intertwiningMap_eq_zero_of_not_dominates (μ : lam.card.Partition)
     f = 0 := by
   by_contra hf
   exact h (dominates_of_intertwiningMap_ne_zero μ hf)
-
-/-- The `Hom` space from the Specht module of `lam` to `M^μ` is trivial unless the shape of `lam`
-dominates `μ`. -/
-theorem subsingleton_intertwiningMap_of_not_dominates (μ : lam.card.Partition)
-    (h : ¬Dominates (shapePartition lam) μ) :
-    Subsingleton (Representation.IntertwiningMap (spechtSubrepresentation lam).toRepresentation
-      (permutationModule μ).ρ) :=
-  ⟨fun f g => by
-    rw [intertwiningMap_eq_zero_of_not_dominates μ h f,
-      intertwiningMap_eq_zero_of_not_dominates μ h g]⟩
-
-/-- **A Specht module embeds in a permutation module only above it in the dominance order.**  If
-the Specht module of `lam` embeds in `M^μ`, then the shape of `lam` dominates `μ`.
-
-This is the form the classification of the Specht modules uses: a Specht module always sits inside
-the permutation module of its own shape, so an isomorphism between two Specht modules produces
-such an embedding.  Injectivity is not really an extra hypothesis, since the Specht module is
-irreducible and so every nonzero map out of it is injective; it is the convenient one to check. -/
-theorem dominates_of_injective_intertwiningMap (μ : lam.card.Partition)
-    {f : Representation.IntertwiningMap (spechtSubrepresentation lam).toRepresentation
-      (permutationModule μ).ρ} (hf : Function.Injective f) :
-    Dominates (shapePartition lam) μ := by
-  obtain ⟨t⟩ := YoungTableau.nonempty lam
-  refine dominates_of_intertwiningMap_ne_zero (f := f) μ fun h => ?_
-  have hzero : (⟨polytabloid t, polytabloid_mem_spechtSubrepresentation t⟩ :
-      (spechtSubrepresentation lam).toSubmodule) = 0 := by
-    refine hf ?_
-    rw [h, map_zero]
-    rfl
-  exact polytabloid_ne_zero t (congrArg Subtype.val hzero)
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Dominance.lean
@@ -1,0 +1,263 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Symmetric.Specht.SubmoduleTheorem
+
+/-!
+# Dominance triangularity for maps out of a Specht module
+
+A nonzero map of representations from the Specht module `S^{lam}` to the Young permutation module
+`M^μ` forces the shape of `lam` to dominate `μ`
+(`TauCeti.dominates_of_intertwiningMap_ne_zero`).  Equivalently, `Hom(S^{lam}, M^μ)` vanishes
+unless `lam` dominates `μ`: the matrix of multiplicities of the Specht modules in the permutation
+modules is triangular for the dominance order.  This is the shape-comparison half of the
+classification of the Specht modules, and it is what turns James's dominance lemma of
+`TauCeti/RepresentationTheory/Symmetric/Dominance.lean` into a statement about maps.
+
+The proof has two steps beyond that lemma.
+
+* **Off the tabloid basis.** James's dominance lemma sees the column antisymmetrizer `b_t` only on
+  a single tabloid.  When `lam` fails to dominate `μ` the lemma says `b_t` kills every tabloid, so
+  by linearity it kills all of `M^μ`
+  (`TauCeti.YoungTableau.asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates`).
+* **Producing a preimage of the polytabloid inside `S^{lam}`.** The polytabloid is `e_t = b_t·{t}`,
+  but the tabloid `{t}` is not in the Specht module, so `b_t` cannot be moved across a map defined
+  only on `S^{lam}`.  The tabloid form supplies an invariant complement `M^{lam} = S^{lam} ⊕ W`
+  (`TauCeti.isCompl_orthogonalSubrepresentation_permutationModule`); splitting `{t}` along it and
+  applying `b_t` to both summands, the `W`-part lands in `S^{lam} ⊓ W = ⊥`, so the `S^{lam}`-part
+  `e` already satisfies `b_t·e = e_t`
+  (`TauCeti.YoungTableau.exists_mem_asAlgebraHom_columnAntisymmetrizer_eq_polytabloid`).
+
+With those, a nonzero `f : S^{lam} → M^μ` is injective, because `S^{lam}` is irreducible, so
+`f e ≠ 0` and `b_t · f e = f (b_t · e) = f e_t ≠ 0`, and the first step applies.
+
+Combining the theorem with itself in both directions is what shows the Specht modules of distinct
+shapes to be non-isomorphic; that combination needs the Specht module of a partition of `n`
+presented inside the permutation module of the *same* index type `Fin n`, and is not carried out
+here.
+
+## Main results
+
+* `TauCeti.YoungTableau.asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates` and
+  `TauCeti.YoungTableau.dominates_of_asAlgebraHom_columnAntisymmetrizer_apply_ne_zero`: James's
+  dominance lemma for an arbitrary vector of `M^μ`.
+* `TauCeti.YoungTableau.exists_mem_asAlgebraHom_columnAntisymmetrizer_eq_polytabloid`: the
+  polytabloid is `b_t` applied to a vector already inside the Specht module.
+* `TauCeti.dominates_of_intertwiningMap_ne_zero`: a nonzero map `S^{lam} → M^μ` forces dominance.
+* `TauCeti.intertwiningMap_eq_zero_of_not_dominates` and
+  `TauCeti.subsingleton_intertwiningMap_of_not_dominates`: the contrapositive, as the vanishing of
+  the whole `Hom` space.
+* `TauCeti.dominates_of_injective_intertwiningMap`: the Specht module of `lam` embeds in a
+  permutation module `M^μ` only if `lam` dominates `μ`.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 4.
+* B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Section 2.4.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 4, "Distinctness and completeness".
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+variable {lam : YoungDiagram}
+
+namespace YoungTableau
+
+/-! ### The column antisymmetrizer off the tabloid basis -/
+
+/-- **The column antisymmetrizer of a non-dominating shape annihilates the whole permutation
+module.**  James's dominance lemma says that `b_t` kills every `μ`-tabloid once the shape of `t`
+fails to dominate `μ`; the tabloids span `M^μ`, so `b_t` kills all of it.
+
+This is to `TauCeti.dominates_of_asAlgebraHom_columnAntisymmetrizer_ne_zero` what
+`TauCeti.YoungTableau.exists_eq_smul_polytabloid` is to
+`TauCeti.YoungTableau.exists_eq_smul_polytabloid_single`: the same statement, extended off the
+tabloid basis by linearity. -/
+theorem asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates (t : YoungTableau lam)
+    (μ : lam.card.Partition) (h : ¬Dominates (shapePartition lam) μ)
+    (x : (permutationModule μ).V) :
+    (permutationModule μ).ρ.asAlgebraHom (columnAntisymmetrizer t) x = 0 := by
+  have hx : x ∈ Submodule.span ℚ (Set.range (permutationModuleBasis μ)) := by
+    rw [Module.Basis.span_eq]
+    exact Submodule.mem_top
+  induction hx using Submodule.span_induction with
+  | mem w hw =>
+    obtain ⟨q, rfl⟩ := hw
+    rw [MonoidAlgebra.basis_apply]
+    by_contra hne
+    exact h (dominates_of_asAlgebraHom_columnAntisymmetrizer_ne_zero t μ q hne)
+  | zero => rw [map_zero]
+  | add u v _ _ hu hv => rw [map_add, hu, hv, add_zero]
+  | smul r u _ hu => rw [map_smul, hu, smul_zero]
+
+/-- **James's dominance lemma for an arbitrary vector.**  If the column antisymmetrizer of a
+`lam`-tableau does not annihilate some vector of `M^μ`, then the shape of `lam` dominates `μ`. -/
+theorem dominates_of_asAlgebraHom_columnAntisymmetrizer_apply_ne_zero (t : YoungTableau lam)
+    (μ : lam.card.Partition) {x : (permutationModule μ).V}
+    (hx : (permutationModule μ).ρ.asAlgebraHom (columnAntisymmetrizer t) x ≠ 0) :
+    Dominates (shapePartition lam) μ := by
+  by_contra h
+  exact hx (asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates t μ h x)
+
+/-! ### A preimage of the polytabloid inside the Specht module -/
+
+/-- **The polytabloid is already in the image of the column antisymmetrizer on `S^{lam}`.**
+Splitting the tabloid `{t}` as `e + w` along the invariant orthogonal decomposition
+`M^{lam} = S^{lam} ⊕ (S^{lam})ᗮ` and applying `b_t`, the two images stay in their summands while
+their sum is the polytabloid `e_t`, which lies in `S^{lam}`; so the second image lies in the
+intersection of the two summands and vanishes.
+
+This is what lets `b_t` be moved across a map that is defined only on the Specht module: the
+tabloid `{t}` itself is not available there, but `e` is. -/
+theorem exists_mem_asAlgebraHom_columnAntisymmetrizer_eq_polytabloid (t : YoungTableau lam) :
+    ∃ e ∈ (spechtSubrepresentation lam).toSubmodule,
+      (permutationModule (shapePartition lam)).ρ.asAlgebraHom (columnAntisymmetrizer t) e =
+        polytabloid t := by
+  have hc : IsCompl (spechtSubrepresentation lam)
+      (orthogonalSubrepresentation (spechtSubrepresentation lam)) :=
+    isCompl_orthogonalSubrepresentation_permutationModule (shapePartition lam) _
+  have hstable : ∀ (σ : Subrepresentation (permutationModule (shapePartition lam)).ρ)
+      (g : Equiv.Perm (Fin lam.card)), ∀ v ∈ σ.toSubmodule,
+      (permutationModule (shapePartition lam)).ρ g v ∈ σ.toSubmodule :=
+    fun σ g _ hv => σ.apply_mem_toSubmodule g hv
+  -- split the tabloid along the invariant decomposition
+  have hsup : MonoidAlgebra.single (tabloid t) (1 : ℚ) ∈
+      (spechtSubrepresentation lam).toSubmodule ⊔
+        (orthogonalSubrepresentation (spechtSubrepresentation lam)).toSubmodule := by
+    have h := congrArg Subrepresentation.toSubmodule hc.sup_eq_top
+    rw [Subrepresentation.toSubmodule_sup, Subrepresentation.toSubmodule_top] at h
+    rw [h]
+    exact Submodule.mem_top
+  obtain ⟨e, he, w, hw, hsum⟩ := Submodule.mem_sup.mp hsup
+  refine ⟨e, he, ?_⟩
+  -- the two images stay in their summands
+  have hmemS : (permutationModule (shapePartition lam)).ρ.asAlgebraHom (columnAntisymmetrizer t) e ∈
+      (spechtSubrepresentation lam).toSubmodule :=
+    Representation.asAlgebraHom_mem_of_forall_mem _ _ (hstable _) e he _
+  have hmemW : (permutationModule (shapePartition lam)).ρ.asAlgebraHom (columnAntisymmetrizer t) w ∈
+      (orthogonalSubrepresentation (spechtSubrepresentation lam)).toSubmodule :=
+    Representation.asAlgebraHom_mem_of_forall_mem _ _ (hstable _) w hw _
+  -- their sum is the polytabloid, so the second image lies in both summands
+  have hadd : (permutationModule (shapePartition lam)).ρ.asAlgebraHom (columnAntisymmetrizer t) e +
+      (permutationModule (shapePartition lam)).ρ.asAlgebraHom (columnAntisymmetrizer t) w =
+      polytabloid t := by
+    rw [← map_add, hsum, polytabloid_def]
+  have hmemW' : (permutationModule (shapePartition lam)).ρ.asAlgebraHom
+      (columnAntisymmetrizer t) w ∈ (spechtSubrepresentation lam).toSubmodule := by
+    have : (permutationModule (shapePartition lam)).ρ.asAlgebraHom (columnAntisymmetrizer t) w =
+        polytabloid t -
+          (permutationModule (shapePartition lam)).ρ.asAlgebraHom (columnAntisymmetrizer t) e := by
+      rw [← hadd]
+      exact (add_sub_cancel_left _ _).symm
+    rw [this]
+    exact Submodule.sub_mem _ (polytabloid_mem_spechtSubrepresentation t) hmemS
+  have hbot := congrArg Subrepresentation.toSubmodule hc.inf_eq_bot
+  rw [Subrepresentation.toSubmodule_inf, Subrepresentation.toSubmodule_bot] at hbot
+  have hzero : (permutationModule (shapePartition lam)).ρ.asAlgebraHom
+      (columnAntisymmetrizer t) w = 0 := by
+    have hmem : (permutationModule (shapePartition lam)).ρ.asAlgebraHom
+        (columnAntisymmetrizer t) w ∈
+        (spechtSubrepresentation lam).toSubmodule ⊓
+          (orthogonalSubrepresentation (spechtSubrepresentation lam)).toSubmodule :=
+      Submodule.mem_inf.mpr ⟨hmemW', hmemW⟩
+    rw [hbot, Submodule.mem_bot] at hmem
+    exact hmem
+  rw [← hadd, hzero, add_zero]
+
+end YoungTableau
+
+/-! ### Dominance from a nonzero map out of the Specht module -/
+
+open YoungTableau
+
+/-- Classical decidability of membership in the column group, used to form its finite sum, as in
+`TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean`. -/
+noncomputable local instance (t : YoungTableau lam) : DecidablePred (· ∈ colSubgroup t) :=
+  Classical.decPred _
+
+/-- **The dominance triangularity of maps out of a Specht module.**  A nonzero map of
+representations from the Specht module of `lam` to the Young permutation module `M^μ` forces the
+shape of `lam` to dominate `μ`.
+
+The Specht module is irreducible, so `f` is injective.  Pick a `lam`-tableau `t` and a vector `e`
+of `S^{lam}` with `b_t · e = e_t`; then `f e_t ≠ 0` and, because `f` intertwines the actions,
+`b_t · f e = f (b_t · e) = f e_t`, so `b_t` does not annihilate `M^μ` and James's dominance lemma
+applies. -/
+theorem dominates_of_intertwiningMap_ne_zero (μ : lam.card.Partition)
+    {f : Representation.IntertwiningMap (spechtSubrepresentation lam).toRepresentation
+      (permutationModule μ).ρ} (hf : f ≠ 0) :
+    Dominates (shapePartition lam) μ := by
+  obtain ⟨t⟩ := YoungTableau.nonempty lam
+  obtain ⟨e, he, hbe⟩ := exists_mem_asAlgebraHom_columnAntisymmetrizer_eq_polytabloid t
+  have : (spechtSubrepresentation lam).toRepresentation.IsIrreducible :=
+    isIrreducible_spechtSubrepresentation lam
+  have hinj : Function.Injective f :=
+    (Representation.IsIrreducible.injective_or_eq_zero f).resolve_right hf
+  -- the signed sum of the column translates of `e` is the polytabloid, hence nonzero
+  set E : (spechtSubrepresentation lam).toSubmodule :=
+    ∑ q : colSubgroup t, ((Equiv.Perm.sign (q : Equiv.Perm (Fin lam.card)) : ℤ) : ℚ) •
+      (spechtSubrepresentation lam).toRepresentation q ⟨e, he⟩ with hE
+  have hEcoe : (E : (permutationModule (shapePartition lam)).V) = polytabloid t := by
+    rw [hE, ← hbe, asAlgebraHom_columnAntisymmetrizer_apply]
+    push_cast
+    rfl
+  have hEne : E ≠ 0 := fun h => polytabloid_ne_zero t (by rw [← hEcoe, h]; rfl)
+  -- and `f` carries it to `b_t` applied to `f ⟨e, he⟩`
+  have hfE : (permutationModule μ).ρ.asAlgebraHom (columnAntisymmetrizer t) (f ⟨e, he⟩) = f E := by
+    rw [asAlgebraHom_columnAntisymmetrizer_apply, hE, map_sum]
+    exact Finset.sum_congr rfl fun q _ => by
+      rw [map_smul, f.isIntertwining]
+  refine dominates_of_asAlgebraHom_columnAntisymmetrizer_apply_ne_zero t μ
+    (x := f ⟨e, he⟩) ?_
+  rw [hfE]
+  exact fun h => hEne (hinj (h.trans (map_zero f).symm))
+
+/-- **The `Hom` space vanishes off the dominance order.**  If the shape of `lam` does not dominate
+`μ`, every map of representations from the Specht module of `lam` to `M^μ` is zero. -/
+theorem intertwiningMap_eq_zero_of_not_dominates (μ : lam.card.Partition)
+    (h : ¬Dominates (shapePartition lam) μ)
+    (f : Representation.IntertwiningMap (spechtSubrepresentation lam).toRepresentation
+      (permutationModule μ).ρ) :
+    f = 0 := by
+  by_contra hf
+  exact h (dominates_of_intertwiningMap_ne_zero μ hf)
+
+/-- The `Hom` space from the Specht module of `lam` to `M^μ` is trivial unless the shape of `lam`
+dominates `μ`. -/
+theorem subsingleton_intertwiningMap_of_not_dominates (μ : lam.card.Partition)
+    (h : ¬Dominates (shapePartition lam) μ) :
+    Subsingleton (Representation.IntertwiningMap (spechtSubrepresentation lam).toRepresentation
+      (permutationModule μ).ρ) :=
+  ⟨fun f g => by
+    rw [intertwiningMap_eq_zero_of_not_dominates μ h f,
+      intertwiningMap_eq_zero_of_not_dominates μ h g]⟩
+
+/-- **A Specht module embeds in a permutation module only above it in the dominance order.**  If
+the Specht module of `lam` embeds in `M^μ`, then the shape of `lam` dominates `μ`.
+
+This is the form the classification of the Specht modules uses: a Specht module always sits inside
+the permutation module of its own shape, so an isomorphism between two Specht modules produces
+such an embedding.  Injectivity is not really an extra hypothesis, since the Specht module is
+irreducible and so every nonzero map out of it is injective; it is the convenient one to check. -/
+theorem dominates_of_injective_intertwiningMap (μ : lam.card.Partition)
+    {f : Representation.IntertwiningMap (spechtSubrepresentation lam).toRepresentation
+      (permutationModule μ).ρ} (hf : Function.Injective f) :
+    Dominates (shapePartition lam) μ := by
+  obtain ⟨t⟩ := YoungTableau.nonempty lam
+  refine dominates_of_intertwiningMap_ne_zero (f := f) μ fun h => ?_
+  have hzero : (⟨polytabloid t, polytabloid_mem_spechtSubrepresentation t⟩ :
+      (spechtSubrepresentation lam).toSubmodule) = 0 := by
+    refine hf ?_
+    rw [h, map_zero]
+    rfl
+  exact polytabloid_ne_zero t (congrArg Subtype.val hzero)
+
+end TauCeti


### PR DESCRIPTION
This PR proves the dominance triangularity of maps out of a Specht module: a nonzero map of representations from `S^{lam}` to the Young permutation module `M^μ` forces the shape of `lam` to dominate `μ`, so `Hom(S^{lam}, M^μ)` vanishes off the dominance order and the multiplicity matrix of the Specht modules in the permutation modules is triangular.

James's dominance lemma landed in TauCeti#2245 in its tabloid form: if the column antisymmetrizer `b_t` does not annihilate a single `μ`-tabloid, then the shape of `t` dominates `μ`. Its file says in as many words that turning it into a statement about maps needs a complement to `S^{lam}` in `M^{lam}`, and leaves that step open; `SubmoduleTheorem.lean` likewise records that the Specht modules being pairwise non-isomorphic is a separate target. This PR supplies exactly that step. Two lemmas do the work: `asAlgebraHom_columnAntisymmetrizer_apply_eq_zero_of_not_dominates`, which lives beside the dominance lemma in `Symmetric/Dominance.lean`, extends it off the tabloid basis by linearity, standing to it as `exists_eq_smul_polytabloid` stands to `exists_eq_smul_polytabloid_single`; and `exists_mem_asAlgebraHom_columnAntisymmetrizer_eq_polytabloid` splits the tabloid `{t}` along the invariant orthogonal decomposition `M^{lam} = S^{lam} ⊕ (S^{lam})ᗮ` supplied by the tabloid form, applies `b_t` to both summands, and observes that the complementary image lands in `S^{lam} ⊓ (S^{lam})ᗮ = ⊥`, so the `S^{lam}`-part `e` already satisfies `b_t · e = e_t`. With `e` available inside the Specht module, `b_t` can be moved across a map defined only there, and irreducibility of `S^{lam}` (TauCeti#2244's neighbourhood, `isIrreducible_spechtSubrepresentation`) makes a nonzero map injective, so `b_t · f e = f e_t ≠ 0`.

The milestone is the Schur-Weyl roadmap's Layer 4, "Distinctness and completeness", whose first half is `spechtModule μ ≅ spechtModule ν ↔ μ = ν` "via the dominance triangularity below". This PR is that triangularity, in both its positive form (`dominates_of_intertwiningMap_ne_zero`) and its vanishing form (`intertwiningMap_eq_zero_of_not_dominates`). What remains for the distinctness statement itself is plumbing rather than mathematics: applying the theorem in both directions needs the Specht module of a partition of `n` presented inside the permutation module over the *same* index type `Fin n`, whereas `spechtSubrepresentation` is indexed by a Young diagram over `Fin lam.card` and `spechtModule` reaches `Equiv.Perm (Fin n)` only through `finCongr (card_diagramOf μ).symm`; transporting one to the other, and then combining the two dominances with `Dominates.antisymm`, is the next step. Layer 4 also still wants absolute irreducibility, completeness, Young's rule, and the identification of the named small irreducibles.

Everything is stated at the diagram level where the existing polytabloid, tabloid-form and submodule-theorem API already lives, with `Representation.IntertwiningMap` as the bundled map type; no new definitions are introduced.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"specht-module-hom-dominance"}-->

🤖 Prepared with Claude Code

