### PR TITLE
refactor(HopfIdeal): route the normality criterion through the quotient-points API

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
@@ -109,6 +109,39 @@ theorem quotientPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
     simpa using hn y ((HopfIdeal.mem_toIdeal (I := I)).mp hy)
   exact RingHom.mem_ker.mp (hker (hI.conjugation_mem hx))
 
+/-- **The quotient-map point lies in the quotient points subgroup.** The point of
+`H ⊗ H/I` given by the right inclusion after `Ideal.Quotient.mkₐ` kills `I`, so it belongs to
+`quotientPointsSubgroup`. -/
+private theorem toConv_includeRight_comp_mkₐ_mem_quotientPointsSubgroup
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
+    (toConv (Algebra.TensorProduct.includeRight.comp (Ideal.Quotient.mkₐ R I.toIdeal)) :
+        HopfAlgebra.points (R := R) (H := H)
+          (CommAlgCat.of R (TensorProduct R H (H ⧸ I.toIdeal)))) ∈
+      quotientPointsSubgroup H I (CommAlgCat.of R (TensorProduct R H (H ⧸ I.toIdeal))) := by
+  rw [mem_quotientPointsSubgroup_iff]
+  intro y hy
+  simp only [AlgHom.comp_apply, Algebra.TensorProduct.includeRight_apply]
+  have hyzero : (Ideal.Quotient.mkₐ R I.toIdeal) y = 0 :=
+    Ideal.Quotient.eq_zero_iff_mem.mpr ((HopfIdeal.mem_toIdeal (I := I)).mpr hy)
+  rw [hyzero, TensorProduct.tmul_zero]
+
+/-- **The product of the two canonical points of `H ⊗ H/I` is the quotient map on the right
+factor.** Pairing the left inclusion with the right inclusion after `Ideal.Quotient.mkₐ` gives
+`id ⊗ mk`. -/
+private theorem productMap_includeLeft_includeRight_comp_mkₐ
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
+    Algebra.TensorProduct.productMap
+        (Algebra.TensorProduct.includeLeft :
+          H →ₐ[R] TensorProduct R H (H ⧸ I.toIdeal))
+        (Algebra.TensorProduct.includeRight.comp (Ideal.Quotient.mkₐ R I.toIdeal)) =
+      Algebra.TensorProduct.map (AlgHom.id R H) (Ideal.Quotient.mkₐ R I.toIdeal) := by
+  apply Algebra.TensorProduct.ext'
+  intro y z
+  rw [Algebra.TensorProduct.productMap_apply_tmul, Algebra.TensorProduct.map_tmul]
+  simp only [AlgHom.comp_apply, AlgHom.id_apply, Algebra.TensorProduct.includeRight_apply]
+  rw [Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.tmul_mul_tmul,
+    mul_one, one_mul]
+
 /-- A Hopf ideal is normal if and only if it cuts out a normal subgroup over every
 commutative value algebra. -/
 theorem isNormal_iff_quotientPointsSubgroup_normal
@@ -126,14 +159,8 @@ theorem isNormal_iff_quotientPointsSubgroup_normal
       toConv Algebra.TensorProduct.includeLeft
     let n : HopfAlgebra.points (R := R) (H := H) A :=
       toConv (Algebra.TensorProduct.includeRight.comp (Ideal.Quotient.mkₐ R I.toIdeal))
-    have hn : n ∈ quotientPointsSubgroup H I A := by
-      rw [mem_quotientPointsSubgroup_iff]
-      intro y hy
-      simp only [n, AlgHom.comp_apply,
-        Algebra.TensorProduct.includeRight_apply]
-      have hyzero : (Ideal.Quotient.mkₐ R I.toIdeal) y = 0 :=
-        Ideal.Quotient.eq_zero_iff_mem.mpr ((HopfIdeal.mem_toIdeal (I := I)).mpr hy)
-      rw [hyzero, TensorProduct.tmul_zero]
+    have hn : n ∈ quotientPointsSubgroup H I A :=
+      toConv_includeRight_comp_mkₐ_mem_quotientPointsSubgroup H I
     have hconj := (hnormal A).conj_mem n hn g
     rw [mem_quotientPointsSubgroup_iff] at hconj
     have hzero := hconj x hx
@@ -146,14 +173,8 @@ theorem isNormal_iff_quotientPointsSubgroup_normal
             hzero
     have hproduct :
         Algebra.TensorProduct.productMap g.ofConv n.ofConv =
-          Algebra.TensorProduct.map (AlgHom.id R H) (Ideal.Quotient.mkₐ R I.toIdeal) := by
-      apply Algebra.TensorProduct.ext'
-      intro y z
-      rw [Algebra.TensorProduct.productMap_apply_tmul, Algebra.TensorProduct.map_tmul]
-      simp only [g, n, Q, AlgHom.comp_apply, AlgHom.id_apply,
-        Algebra.TensorProduct.includeRight_apply]
-      rw [Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.tmul_mul_tmul,
-        mul_one, one_mul]
+          Algebra.TensorProduct.map (AlgHom.id R H) (Ideal.Quotient.mkₐ R I.toIdeal) :=
+      productMap_includeLeft_includeRight_comp_mkₐ H I
     rw [hproduct] at heval
     have hmem := RingHom.mem_ker.mpr heval
     rw [HopfIdeal.ker_tensorProduct_map_id_quotient I.toIdeal] at hmem

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
@@ -109,26 +109,6 @@ theorem quotientPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
     simpa using hn y ((HopfIdeal.mem_toIdeal (I := I)).mp hy)
   exact RingHom.mem_ker.mp (hker (hI.conjugation_mem hx))
 
-section
-
-variable {S A B C : Type*} [CommSemiring S] [CommSemiring A] [Algebra S A] [Semiring B]
-  [Algebra S B] [CommSemiring C] [Algebra S C]
-
-/-- The product of the left inclusion with the right inclusion after `f` is the functorial
-map `AlgHom.id ⊗ f`. -/
-private theorem productMap_includeLeft_includeRight_comp (f : B →ₐ[S] C) :
-    Algebra.TensorProduct.productMap
-        (Algebra.TensorProduct.includeLeft : A →ₐ[S] TensorProduct S A C)
-        (Algebra.TensorProduct.includeRight.comp f) =
-      Algebra.TensorProduct.map (AlgHom.id S A) f := by
-  refine Algebra.TensorProduct.ext ?_ ?_
-  · rw [Algebra.TensorProduct.productMap_left, Algebra.TensorProduct.map_comp_includeLeft,
-      AlgHom.comp_id]
-  · exact (Algebra.TensorProduct.productMap_right _ _).trans
-      (Algebra.TensorProduct.map_comp_includeRight _ _).symm
-
-end
-
 /-- A Hopf ideal is normal if and only if it cuts out a normal subgroup over every
 commutative value algebra. -/
 theorem isNormal_iff_quotientPointsSubgroup_normal
@@ -166,7 +146,11 @@ theorem isNormal_iff_quotientPointsSubgroup_normal
         Algebra.TensorProduct.productMap g.ofConv n.ofConv =
           Algebra.TensorProduct.map (AlgHom.id R H) (Ideal.Quotient.mkₐ R I.toIdeal) := by
       rw [hgof, hnof]
-      exact productMap_includeLeft_includeRight_comp (A := H) (Ideal.Quotient.mkₐ R I.toIdeal)
+      refine Algebra.TensorProduct.ext ?_ ?_
+      · rw [Algebra.TensorProduct.productMap_left,
+          Algebra.TensorProduct.map_comp_includeLeft, AlgHom.comp_id]
+      · exact (Algebra.TensorProduct.productMap_right _ _).trans
+          (Algebra.TensorProduct.map_comp_includeRight _ _).symm
     rw [hproduct] at heval
     have hmem := RingHom.mem_ker.mpr heval
     rw [HopfIdeal.ker_tensorProduct_map_id_quotient I.toIdeal] at hmem

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
@@ -109,38 +109,20 @@ theorem quotientPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
     simpa using hn y ((HopfIdeal.mem_toIdeal (I := I)).mp hy)
   exact RingHom.mem_ker.mp (hker (hI.conjugation_mem hx))
 
-/-- **The quotient-map point lies in the quotient points subgroup.** The point of
-`H ⊗ H/I` given by the right inclusion after `Ideal.Quotient.mkₐ` kills `I`, so it belongs to
-`quotientPointsSubgroup`. -/
-private theorem toConv_includeRight_comp_mkₐ_mem_quotientPointsSubgroup
-    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
-    (toConv (Algebra.TensorProduct.includeRight.comp (Ideal.Quotient.mkₐ R I.toIdeal)) :
-        HopfAlgebra.points (R := R) (H := H)
-          (CommAlgCat.of R (TensorProduct R H (H ⧸ I.toIdeal)))) ∈
-      quotientPointsSubgroup H I (CommAlgCat.of R (TensorProduct R H (H ⧸ I.toIdeal))) := by
-  rw [mem_quotientPointsSubgroup_iff]
-  intro y hy
-  simp only [AlgHom.comp_apply, Algebra.TensorProduct.includeRight_apply]
-  have hyzero : (Ideal.Quotient.mkₐ R I.toIdeal) y = 0 :=
-    Ideal.Quotient.eq_zero_iff_mem.mpr ((HopfIdeal.mem_toIdeal (I := I)).mpr hy)
-  rw [hyzero, TensorProduct.tmul_zero]
-
-/-- **The product of the two canonical points of `H ⊗ H/I` is the quotient map on the right
-factor.** Pairing the left inclusion with the right inclusion after `Ideal.Quotient.mkₐ` gives
-`id ⊗ mk`. -/
-private theorem productMap_includeLeft_includeRight_comp_mkₐ
-    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
+/-- The product of the left inclusion with the right inclusion after `f` is the functorial
+map `AlgHom.id ⊗ f`. -/
+private theorem productMap_includeLeft_includeRight_comp
+    {A B C : Type*} [CommSemiring A] [Algebra R A] [Semiring B] [Algebra R B]
+    [CommSemiring C] [Algebra R C] (f : B →ₐ[R] C) :
     Algebra.TensorProduct.productMap
-        (Algebra.TensorProduct.includeLeft :
-          H →ₐ[R] TensorProduct R H (H ⧸ I.toIdeal))
-        (Algebra.TensorProduct.includeRight.comp (Ideal.Quotient.mkₐ R I.toIdeal)) =
-      Algebra.TensorProduct.map (AlgHom.id R H) (Ideal.Quotient.mkₐ R I.toIdeal) := by
-  apply Algebra.TensorProduct.ext'
-  intro y z
-  rw [Algebra.TensorProduct.productMap_apply_tmul, Algebra.TensorProduct.map_tmul]
-  simp only [AlgHom.comp_apply, AlgHom.id_apply, Algebra.TensorProduct.includeRight_apply]
-  rw [Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.tmul_mul_tmul,
-    mul_one, one_mul]
+        (Algebra.TensorProduct.includeLeft : A →ₐ[R] TensorProduct R A C)
+        (Algebra.TensorProduct.includeRight.comp f) =
+      Algebra.TensorProduct.map (AlgHom.id R A) f := by
+  refine Algebra.TensorProduct.ext ?_ ?_
+  · rw [Algebra.TensorProduct.productMap_left, Algebra.TensorProduct.map_comp_includeLeft,
+      AlgHom.comp_id]
+  · exact (Algebra.TensorProduct.productMap_right _ _).trans
+      (Algebra.TensorProduct.map_comp_includeRight _ _).symm
 
 /-- A Hopf ideal is normal if and only if it cuts out a normal subgroup over every
 commutative value algebra. -/
@@ -158,23 +140,29 @@ theorem isNormal_iff_quotientPointsSubgroup_normal
     let g : HopfAlgebra.points (R := R) (H := H) A :=
       toConv Algebra.TensorProduct.includeLeft
     let n : HopfAlgebra.points (R := R) (H := H) A :=
-      toConv (Algebra.TensorProduct.includeRight.comp (Ideal.Quotient.mkₐ R I.toIdeal))
+      quotientPointsHom H I A (toConv Algebra.TensorProduct.includeRight)
     have hn : n ∈ quotientPointsSubgroup H I A :=
-      toConv_includeRight_comp_mkₐ_mem_quotientPointsSubgroup H I
+      quotientPointsHom_mem_quotientPointsSubgroup H I A _
+    have hgof : g.ofConv = (Algebra.TensorProduct.includeLeft : H →ₐ[R] TensorProduct R H Q) :=
+      ofConv_toConv _
+    have hnof : n.ofConv =
+        (Algebra.TensorProduct.includeRight : Q →ₐ[R] TensorProduct R H Q).comp
+          (Ideal.Quotient.mkₐ R I.toIdeal) :=
+      AlgHom.ext fun h => quotientPointsHom_apply_apply H I A _ h
     have hconj := (hnormal A).conj_mem n hn g
     rw [mem_quotientPointsSubgroup_iff] at hconj
     have hzero := hconj x hx
     have heval :
         (Algebra.TensorProduct.productMap g.ofConv n.ofConv)
-            (HopfAlgebra.conjugationAlgHom (R := R) (H := H) x) = 0 := by
-      exact
-        (AlgHom.congr_fun
-          (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := H) g n) x).trans
-            hzero
+            (HopfAlgebra.conjugationAlgHom (R := R) (H := H) x) = 0 :=
+      (AlgHom.congr_fun
+        (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := H) g n) x).trans hzero
     have hproduct :
         Algebra.TensorProduct.productMap g.ofConv n.ofConv =
-          Algebra.TensorProduct.map (AlgHom.id R H) (Ideal.Quotient.mkₐ R I.toIdeal) :=
-      productMap_includeLeft_includeRight_comp_mkₐ H I
+          Algebra.TensorProduct.map (AlgHom.id R H) (Ideal.Quotient.mkₐ R I.toIdeal) := by
+      rw [hgof, hnof]
+      exact productMap_includeLeft_includeRight_comp (R := R) (A := H)
+        (Ideal.Quotient.mkₐ R I.toIdeal)
     rw [hproduct] at heval
     have hmem := RingHom.mem_ker.mpr heval
     rw [HopfIdeal.ker_tensorProduct_map_id_quotient I.toIdeal] at hmem

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
@@ -109,20 +109,25 @@ theorem quotientPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
     simpa using hn y ((HopfIdeal.mem_toIdeal (I := I)).mp hy)
   exact RingHom.mem_ker.mp (hker (hI.conjugation_mem hx))
 
+section
+
+variable {S A B C : Type*} [CommSemiring S] [CommSemiring A] [Algebra S A] [Semiring B]
+  [Algebra S B] [CommSemiring C] [Algebra S C]
+
 /-- The product of the left inclusion with the right inclusion after `f` is the functorial
 map `AlgHom.id ⊗ f`. -/
-private theorem productMap_includeLeft_includeRight_comp
-    {A B C : Type*} [CommSemiring A] [Algebra R A] [Semiring B] [Algebra R B]
-    [CommSemiring C] [Algebra R C] (f : B →ₐ[R] C) :
+private theorem productMap_includeLeft_includeRight_comp (f : B →ₐ[S] C) :
     Algebra.TensorProduct.productMap
-        (Algebra.TensorProduct.includeLeft : A →ₐ[R] TensorProduct R A C)
+        (Algebra.TensorProduct.includeLeft : A →ₐ[S] TensorProduct S A C)
         (Algebra.TensorProduct.includeRight.comp f) =
-      Algebra.TensorProduct.map (AlgHom.id R A) f := by
+      Algebra.TensorProduct.map (AlgHom.id S A) f := by
   refine Algebra.TensorProduct.ext ?_ ?_
   · rw [Algebra.TensorProduct.productMap_left, Algebra.TensorProduct.map_comp_includeLeft,
       AlgHom.comp_id]
   · exact (Algebra.TensorProduct.productMap_right _ _).trans
       (Algebra.TensorProduct.map_comp_includeRight _ _).symm
+
+end
 
 /-- A Hopf ideal is normal if and only if it cuts out a normal subgroup over every
 commutative value algebra. -/
@@ -161,8 +166,7 @@ theorem isNormal_iff_quotientPointsSubgroup_normal
         Algebra.TensorProduct.productMap g.ofConv n.ofConv =
           Algebra.TensorProduct.map (AlgHom.id R H) (Ideal.Quotient.mkₐ R I.toIdeal) := by
       rw [hgof, hnof]
-      exact productMap_includeLeft_includeRight_comp (R := R) (A := H)
-        (Ideal.Quotient.mkₐ R I.toIdeal)
+      exact productMap_includeLeft_includeRight_comp (A := H) (Ideal.Quotient.mkₐ R I.toIdeal)
     rw [hproduct] at heval
     have hmem := RingHom.mem_ker.mpr heval
     rw [HopfIdeal.ker_tensorProduct_map_id_quotient I.toIdeal] at hmem


### PR DESCRIPTION
The backward direction of `isNormal_iff_quotientPointsSubgroup_normal` open-coded two things the
points API already supplies.

**The membership.** The right-hand point was built as `toConv (includeRight.comp mkₐ)` and then
shown to kill `I` by hand. It is now built as
`quotientPointsHom H I A (toConv includeRight)` — a quotient point by construction — so its
membership in `quotientPointsSubgroup` is literally
`quotientPointsHom_mem_quotientPointsSubgroup`, with no vanishing-on-`I` computation at all.

**The conversions.** Both points' `ofConv` are now named once (`hgof`, `hnof`, the latter from
`quotientPointsHom_apply_apply`), so the final `productMap` step rewrites through stated equations
instead of relying on the `let`s unfolding and on the `toConv`/`ofConv` round trip being
definitional.

Proof body: 44 → 42 lines. The bulk of the win is not length: it is that the membership step is
now a citation rather than a proof, and that nothing in the argument depends on hidden defeq.

Roadmap: ReductiveGroups
