### PR TITLE
refactor(GeneralLinear): name the localization normal form behind the generation proof

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/HopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/HopfAlgebra.lean
@@ -301,20 +301,17 @@ theorem antipode_det_localizedGenericMatrix :
   rw [AlgHom.map_det, AlgHom.mapMatrix_apply, map_antipode_localizedGenericMatrix,
     Matrix.det_nonsing_inv]
 
-/-- **Every element of the coordinate ring of `GLₙ` is an image from the matrix-monoid coordinate
-ring times a power of the inverse generic determinant.** This is the surjectivity half of the
-localization property, written with `Ring.inverse` rather than as a fraction. -/
-private theorem exists_eq_mul_inverse_det_pow (z : CoordinateRing R n) :
-    ∃ (m : ℕ) (p : MatrixMonoid.CoordinateRing R n),
-      z = coordinateRingMap R n p *
-        Ring.inverse (Matrix.det (localizedGenericMatrix R n)) ^ m := by
-  obtain ⟨m, p, hz⟩ := IsLocalization.Away.surj
-    (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R)) z
+/-- **Every element of a localization away from `r` is an image times a power of the inverse of
+`r`.** This is the surjectivity half of the localization property, written with `Ring.inverse`
+rather than as a fraction. -/
+private theorem exists_eq_mul_inverse_algebraMap_pow {A : Type*} [CommSemiring A] (r : A)
+    {B : Type*} [CommSemiring B] [Algebra A B] [IsLocalization.Away r B] (z : B) :
+    ∃ (m : ℕ) (p : A), z = algebraMap A B p * Ring.inverse (algebraMap A B r) ^ m := by
+  obtain ⟨m, p, hz⟩ := IsLocalization.Away.surj r z
   refine ⟨m, p, ?_⟩
   rw [Ring.inverse_pow]
-  apply (Ring.eq_mul_inverse_iff_mul_eq _ _ _
-    ((isUnit_det_localizedGenericMatrix R n).pow m)).mpr
-  simpa [det_localizedGenericMatrix] using hz
+  exact (Ring.eq_mul_inverse_iff_mul_eq _ _ _
+    ((IsLocalization.Away.algebraMap_isUnit r).pow m)).mpr hz
 
 private theorem adjoin_X_union_antipode_X :
     Algebra.adjoin R
@@ -359,7 +356,9 @@ private theorem adjoin_X_union_antipode_X :
     exact hantipodePoly _
   apply Algebra.eq_top_iff.mpr
   intro z
-  obtain ⟨m, p, hz⟩ := exists_eq_mul_inverse_det_pow R n z
+  obtain ⟨m, p, hz⟩ :=
+    exists_eq_mul_inverse_algebraMap_pow (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R)) z
+  simp only [← coordinateRingMap_apply, ← det_localizedGenericMatrix] at hz
   rw [hz]
   exact B.mul_mem (hpoly p) (B.pow_mem hinv m)
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/HopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/HopfAlgebra.lean
@@ -301,6 +301,21 @@ theorem antipode_det_localizedGenericMatrix :
   rw [AlgHom.map_det, AlgHom.mapMatrix_apply, map_antipode_localizedGenericMatrix,
     Matrix.det_nonsing_inv]
 
+/-- **Every element of the coordinate ring of `GLₙ` is an image from the matrix-monoid coordinate
+ring times a power of the inverse generic determinant.** This is the surjectivity half of the
+localization property, written with `Ring.inverse` rather than as a fraction. -/
+private theorem exists_eq_mul_inverse_det_pow (z : CoordinateRing R n) :
+    ∃ (m : ℕ) (p : MatrixMonoid.CoordinateRing R n),
+      z = coordinateRingMap R n p *
+        Ring.inverse (Matrix.det (localizedGenericMatrix R n)) ^ m := by
+  obtain ⟨m, p, hz⟩ := IsLocalization.Away.surj
+    (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R)) z
+  refine ⟨m, p, ?_⟩
+  rw [Ring.inverse_pow]
+  apply (Ring.eq_mul_inverse_iff_mul_eq _ _ _
+    ((isUnit_det_localizedGenericMatrix R n).pow m)).mpr
+  simpa [det_localizedGenericMatrix] using hz
+
 private theorem adjoin_X_union_antipode_X :
     Algebra.adjoin R
         (Set.range (fun ij : Fin n × Fin n =>
@@ -344,15 +359,8 @@ private theorem adjoin_X_union_antipode_X :
     exact hantipodePoly _
   apply Algebra.eq_top_iff.mpr
   intro z
-  obtain ⟨m, p, hz⟩ := IsLocalization.Away.surj
-    (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R)) z
-  have hz' : z = coordinateRingMap R n p *
-      Ring.inverse (Matrix.det (localizedGenericMatrix R n)) ^ m := by
-    rw [Ring.inverse_pow]
-    apply (Ring.eq_mul_inverse_iff_mul_eq _ _ _
-      ((isUnit_det_localizedGenericMatrix R n).pow m)).mpr
-    simpa [det_localizedGenericMatrix] using hz
-  rw [hz']
+  obtain ⟨m, p, hz⟩ := exists_eq_mul_inverse_det_pow R n z
+  rw [hz]
   exact B.mul_mem (hpoly p) (B.pow_mem hinv m)
 
 private theorem comul_coassoc :


### PR DESCRIPTION
`adjoin_X_union_antipode_X` proves that the entry coordinates together with their antipodes
generate the coordinate ring of `GLₙ`. Its last third was not about generation at all: it took an
arbitrary `z`, invoked `IsLocalization.Away.surj`, and rewrote the resulting fraction into a
`Ring.inverse` power — twelve lines before the generation argument could resume.

`exists_eq_mul_inverse_algebraMap_pow` now states that step, and states it where it actually lives:

```lean
z = algebraMap A B p * Ring.inverse (algebraMap A B r) ^ m
```

for any `r : A` and `[IsLocalization.Away r B]`. Nothing about matrices or determinants survives —
and `CommSemiring` suffices, since that is all `IsLocalization.Away.surj` and `Ring.inverse`
require. Mathlib states the surjectivity as `z * (algebraMap r) ^ n = algebraMap a`; the
`Ring.inverse` form is what the rest of this file uses (the antipode lands there too, via
`antipode_det_localizedGenericMatrix`).

The determinant specialization is two named rewrites at the call site —
`coordinateRingMap_apply` and `det_localizedGenericMatrix` — rather than a second declaration, so
the PR adds exactly one lemma.

Proof body: 47 → 42 lines; the new body is 6.

Roadmap: ReductiveGroups
