### PR TITLE
feat: identify the standard skew-adjoint Lie algebra

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Lie.Classical
+public import Mathlib.LinearAlgebra.QuadraticForm.Basic
+
+/-!
+# The orthogonal Lie algebra of the standard quadratic form
+
+Mathlib's standard quadratic form on `n → R` is
+`QuadraticMap.weightedSumSquares R (1 : n → R)`. When `2` is invertible, its polar bilinear form
+is twice the identity-matrix form. Scaling a bilinear form by an invertible scalar does not change
+its skew-adjoint endomorphisms, so Mathlib's endomorphism-to-matrix equivalence identifies those
+endomorphisms with `LieAlgebra.Orthogonal.so n R`.
+
+This supplies the coordinate bridge used in the standard-form statement that exterior bivectors
+are the orthogonal Lie algebra. It does not choose a basis for an abstract quadratic module.
+
+## Main results
+
+* `TauCeti.QuadraticForm.polarBilin_weightedSumSquares_one`: the polar form of the sum of squares
+  is twice the identity-matrix form.
+* `TauCeti.QuadraticForm.standardSkewAdjointLieEquiv`: the Lie equivalence from the skew-adjoint
+  endomorphisms of its polar form to Mathlib's matrix orthogonal Lie algebra.
+
+## References
+
+* [Tau Ceti Roadmap](https://github.com/TauCetiProject/TauCetiRoadmap), Representation Theory / Spin
+  Representations, Layer 3, "Bivectors as a Lie subalgebra".
+-/
+
+public section
+
+open scoped Matrix
+
+universe u
+
+namespace TauCeti.QuadraticForm
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable (R : Type u) (n : Type*) [CommRing R] [Fintype n] [DecidableEq n]
+
+variable [Invertible (2 : R)]
+
+private theorem associated_weightedSumSquares_one :
+    (QuadraticMap.weightedSumSquares R (1 : n → R)).associated =
+      Matrix.toLinearMap₂' R (1 : Matrix n n R) := by
+  have h : QuadraticMap.weightedSumSquares R (1 : n → R) =
+      Matrix.toQuadraticForm' (1 : Matrix n n R) := by
+    ext x
+    simp [Matrix.toQuadraticForm', Matrix.toLinearMap₂'_apply, Matrix.one_apply,
+      QuadraticMap.weightedSumSquares_apply]
+  rw [h, Matrix.toQuadraticForm']
+  apply QuadraticMap.associated_left_inverse R
+  intro x y
+  simp [Matrix.toLinearMap₂'_apply, Matrix.one_apply, mul_comm]
+
+/-- The polar bilinear form of the standard quadratic form is twice the identity-matrix form. -/
+theorem polarBilin_weightedSumSquares_one :
+    QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R)) =
+      2 • Matrix.toLinearMap₂' R (1 : Matrix n n R) := by
+  rw [← QuadraticMap.two_nsmul_associated
+    (S := R) (QuadraticMap.weightedSumSquares R (1 : n → R)),
+    associated_weightedSumSquares_one]
+
+omit [Fintype n] [DecidableEq n] in
+private theorem skewAdjointLieSubalgebra_two_smul
+    (B : LinearMap.BilinForm R (n → R)) :
+    skewAdjointLieSubalgebra (2 • B) = skewAdjointLieSubalgebra B := by
+  ext f
+  -- Expose the carrier predicate so the two skew-adjoint conditions can be compared directly.
+  change f ∈ (2 • B).skewAdjointSubmodule ↔ f ∈ B.skewAdjointSubmodule
+  rw [LinearMap.mem_skewAdjointSubmodule, LinearMap.mem_skewAdjointSubmodule]
+  constructor
+  · intro hf x y
+    apply (isUnit_of_invertible (2 : R)).smul_left_cancel.mp
+    simpa using hf x y
+  · intro hf x y
+    simp [hf x y]
+
+omit [Invertible (2 : R)] in
+private theorem lieEquivMatrix'_mem_skewAdjoint (J : Matrix n n R)
+    (f : Module.End R (n → R)) :
+    lieEquivMatrix' f ∈ skewAdjointMatricesLieSubalgebra J ↔
+      f ∈ skewAdjointLieSubalgebra (Matrix.toLinearMap₂' R J) := by
+  rw [mem_skewAdjointMatricesLieSubalgebra, mem_skewAdjointMatricesSubmodule]
+  -- Expose matrix skew-adjointness as the `IsAdjointPair` relation used by the bridge theorem.
+  change Matrix.IsAdjointPair J J (LinearMap.toMatrix' f) (-LinearMap.toMatrix' f) ↔
+    f ∈ (Matrix.toLinearMap₂' R J).skewAdjointSubmodule
+  rw [LinearMap.mem_skewAdjointSubmodule]
+  -- Expose linear-map skew-adjointness in the same adjoint-pair representation.
+  change Matrix.IsAdjointPair J J (LinearMap.toMatrix' f) (-LinearMap.toMatrix' f) ↔
+    LinearMap.IsAdjointPair (Matrix.toLinearMap₂' R J) (Matrix.toLinearMap₂' R J) f (-f)
+  simpa using (isAdjointPair_toLinearMap₂' (R := R) (J := J) (J' := J)
+    (A := LinearMap.toMatrix' f) (A' := -(LinearMap.toMatrix' f))).symm
+
+omit [Invertible (2 : R)] in
+private noncomputable def skewAdjointLieEquivMatrix (J : Matrix n n R) :
+    skewAdjointLieSubalgebra (Matrix.toLinearMap₂' R J) ≃ₗ⁅R⁆
+      skewAdjointMatricesLieSubalgebra J :=
+  LieEquiv.ofSubalgebras _ _ lieEquivMatrix' <| by
+    ext A
+    simp only [Submodule.mem_map_equiv, LieSubalgebra.mem_map_submodule]
+    -- Expose the inverse-image carrier required by `LieEquiv.ofSubalgebras`.
+    change (lieEquivMatrix' (R := R) (n := n)).symm A ∈
+      skewAdjointLieSubalgebra (Matrix.toLinearMap₂' R J) ↔
+        A ∈ skewAdjointMatricesLieSubalgebra J
+    rw [lieEquivMatrix'_symm_apply]
+    simpa using (lieEquivMatrix'_mem_skewAdjoint R n J
+      ((lieEquivMatrix' (R := R) (n := n)).symm A)).symm
+
+/-- The skew-adjoint endomorphisms of the polar form of the standard quadratic form are Mathlib's
+matrix orthogonal Lie algebra. -/
+noncomputable def standardSkewAdjointLieEquiv :
+    skewAdjointLieSubalgebra
+        (QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R))) ≃ₗ⁅R⁆
+      LieAlgebra.Orthogonal.so n R :=
+  (LieEquiv.ofEq _ _ (by
+    rw [polarBilin_weightedSumSquares_one, skewAdjointLieSubalgebra_two_smul])).trans
+      (skewAdjointLieEquivMatrix R n (1 : Matrix n n R))
+
+@[simp]
+theorem coe_standardSkewAdjointLieEquiv_apply
+    (f : skewAdjointLieSubalgebra
+      (QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R)))) :
+    ((standardSkewAdjointLieEquiv R n f : LieAlgebra.Orthogonal.so n R) : Matrix n n R) =
+      lieEquivMatrix' f := by
+  rfl
+
+@[simp]
+theorem coe_standardSkewAdjointLieEquiv_symm_apply (A : LieAlgebra.Orthogonal.so n R) :
+    (((standardSkewAdjointLieEquiv R n).symm A :
+      skewAdjointLieSubalgebra
+        (QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R)))) :
+      Module.End R (n → R)) =
+      (lieEquivMatrix' (R := R) (n := n)).symm A := by
+  rfl
+
+end TauCeti.QuadraticForm

--- a/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
@@ -98,39 +98,35 @@ private theorem lieEquivMatrix'_mem_skewAdjoint (J : Matrix n n R)
   simpa using (isAdjointPair_toLinearMap₂' (R := R) (J := J) (J' := J)
     (A := LinearMap.toMatrix' f) (A' := -(LinearMap.toMatrix' f))).symm
 
-omit [Invertible (2 : R)] in
-private noncomputable def skewAdjointLieEquivMatrix (J : Matrix n n R) :
-    skewAdjointLieSubalgebra (Matrix.toLinearMap₂' R J) ≃ₗ⁅R⁆
-      skewAdjointMatricesLieSubalgebra J :=
-  LieEquiv.ofSubalgebras _ _ lieEquivMatrix' <| by
-    ext A
-    simp only [Submodule.mem_map_equiv, LieSubalgebra.mem_map_submodule]
-    -- Expose the inverse-image carrier required by `LieEquiv.ofSubalgebras`.
-    change (lieEquivMatrix' (R := R) (n := n)).symm A ∈
-      skewAdjointLieSubalgebra (Matrix.toLinearMap₂' R J) ↔
-        A ∈ skewAdjointMatricesLieSubalgebra J
-    rw [lieEquivMatrix'_symm_apply]
-    simpa using (lieEquivMatrix'_mem_skewAdjoint R n J
-      ((lieEquivMatrix' (R := R) (n := n)).symm A)).symm
-
 /-- The skew-adjoint endomorphisms of the polar form of the standard quadratic form are Mathlib's
 matrix orthogonal Lie algebra. -/
 noncomputable def standardSkewAdjointLieEquiv :
     skewAdjointLieSubalgebra
         (QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R))) ≃ₗ⁅R⁆
       LieAlgebra.Orthogonal.so n R :=
-  (LieEquiv.ofEq _ _ (by
-    rw [polarBilin_weightedSumSquares_one, skewAdjointLieSubalgebra_two_smul])).trans
-      (skewAdjointLieEquivMatrix R n (1 : Matrix n n R))
+  LieEquiv.ofSubalgebras _ _ lieEquivMatrix' <| by
+    ext A
+    simp only [Submodule.mem_map_equiv, LieSubalgebra.mem_map_submodule]
+    -- Expose the inverse-image carrier required by the subalgebra restriction.
+    change (lieEquivMatrix' (R := R) (n := n)).symm A ∈
+      skewAdjointLieSubalgebra
+          (QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R))) ↔
+        A ∈ LieAlgebra.Orthogonal.so n R
+    rw [polarBilin_weightedSumSquares_one, skewAdjointLieSubalgebra_two_smul,
+      LieAlgebra.Orthogonal.so, lieEquivMatrix'_symm_apply]
+    simpa using (lieEquivMatrix'_mem_skewAdjoint R n (1 : Matrix n n R)
+      ((lieEquivMatrix' (R := R) (n := n)).symm A)).symm
 
+/-- The standard skew-adjoint equivalence sends an endomorphism to its matrix. -/
 @[simp]
 theorem coe_standardSkewAdjointLieEquiv_apply
     (f : skewAdjointLieSubalgebra
       (QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R)))) :
     ((standardSkewAdjointLieEquiv R n f : LieAlgebra.Orthogonal.so n R) : Matrix n n R) =
       lieEquivMatrix' f := by
-  rfl
+  rw [standardSkewAdjointLieEquiv, LieEquiv.ofSubalgebras_apply]
 
+/-- The inverse standard skew-adjoint equivalence sends a matrix to its endomorphism. -/
 @[simp]
 theorem coe_standardSkewAdjointLieEquiv_symm_apply (A : LieAlgebra.Orthogonal.so n R) :
     (((standardSkewAdjointLieEquiv R n).symm A :
@@ -138,6 +134,6 @@ theorem coe_standardSkewAdjointLieEquiv_symm_apply (A : LieAlgebra.Orthogonal.so
         (QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R)))) :
       Module.End R (n → R)) =
       (lieEquivMatrix' (R := R) (n := n)).symm A := by
-  rfl
+  rw [standardSkewAdjointLieEquiv, LieEquiv.ofSubalgebras_symm_apply]
 
 end TauCeti.QuadraticForm

--- a/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
@@ -21,8 +21,8 @@ are the orthogonal Lie algebra. It does not choose a basis for an abstract quadr
 
 ## Main results
 
-* `TauCeti.QuadraticForm.polarBilin_weightedSumSquares_one`: the polar form of the sum of squares
-  is twice the identity-matrix form.
+* `TauCeti.QuadraticForm.polarBilin_weightedSumSquares`: the polar form of a weighted sum of
+  squares is twice its diagonal-matrix form.
 * `TauCeti.QuadraticForm.standardSkewAdjointLieEquiv`: the Lie equivalence from the skew-adjoint
   endomorphisms of its polar form to Mathlib's matrix orthogonal Lie algebra.
 
@@ -44,19 +44,25 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 
 variable (R : Type u) (n : Type*) [CommRing R] [Fintype n] [DecidableEq n]
 
+/-- The polar bilinear form of a weighted sum of squares is twice its diagonal-matrix form. -/
+theorem polarBilin_weightedSumSquares (w : n → R) :
+    QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R w) =
+      2 • Matrix.toLinearMap₂' R (Matrix.diagonal w) := by
+  have h : QuadraticMap.weightedSumSquares R w =
+      Matrix.toQuadraticForm' (Matrix.diagonal w) := by
+    ext x
+    simp [Matrix.toQuadraticForm', Matrix.toLinearMap₂'_apply, Matrix.diagonal,
+      QuadraticMap.weightedSumSquares_apply, mul_comm, mul_left_comm]
+  rw [h, Matrix.toQuadraticForm', LinearMap.BilinMap.polarBilin_toQuadraticMap]
+  ext x y
+  simp [Matrix.toLinearMap₂'_apply, Matrix.diagonal, mul_comm, mul_left_comm, mul_assoc, two_mul]
+
 /-- The polar bilinear form of the standard quadratic form is twice the identity-matrix form. -/
 @[simp]
 theorem polarBilin_weightedSumSquares_one :
     QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R)) =
       2 • Matrix.toLinearMap₂' R (1 : Matrix n n R) := by
-  have h : QuadraticMap.weightedSumSquares R (1 : n → R) =
-      Matrix.toQuadraticForm' (1 : Matrix n n R) := by
-    ext x
-    simp [Matrix.toQuadraticForm', Matrix.toLinearMap₂'_apply, Matrix.one_apply,
-      QuadraticMap.weightedSumSquares_apply]
-  rw [h, Matrix.toQuadraticForm', LinearMap.BilinMap.polarBilin_toQuadraticMap]
-  ext x y
-  simp [Matrix.toLinearMap₂'_apply, Matrix.one_apply, mul_comm, two_mul]
+  simpa using polarBilin_weightedSumSquares R n (1 : n → R)
 
 private theorem lieEquivMatrix'_mem_skewAdjoint (J : Matrix n n R)
     (f : Module.End R (n → R)) :

--- a/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
@@ -44,45 +44,20 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 
 variable (R : Type u) (n : Type*) [CommRing R] [Fintype n] [DecidableEq n]
 
-variable [Invertible (2 : R)]
-
-private theorem associated_weightedSumSquares_one :
-    (QuadraticMap.weightedSumSquares R (1 : n → R)).associated =
-      Matrix.toLinearMap₂' R (1 : Matrix n n R) := by
+/-- The polar bilinear form of the standard quadratic form is twice the identity-matrix form. -/
+@[simp]
+theorem polarBilin_weightedSumSquares_one :
+    QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R)) =
+      2 • Matrix.toLinearMap₂' R (1 : Matrix n n R) := by
   have h : QuadraticMap.weightedSumSquares R (1 : n → R) =
       Matrix.toQuadraticForm' (1 : Matrix n n R) := by
     ext x
     simp [Matrix.toQuadraticForm', Matrix.toLinearMap₂'_apply, Matrix.one_apply,
       QuadraticMap.weightedSumSquares_apply]
-  rw [h, Matrix.toQuadraticForm']
-  apply QuadraticMap.associated_left_inverse R
-  intro x y
-  simp [Matrix.toLinearMap₂'_apply, Matrix.one_apply, mul_comm]
+  rw [h, Matrix.toQuadraticForm', LinearMap.BilinMap.polarBilin_toQuadraticMap]
+  ext x y
+  simp [Matrix.toLinearMap₂'_apply, Matrix.one_apply, mul_comm, two_mul]
 
-/-- The polar bilinear form of the standard quadratic form is twice the identity-matrix form. -/
-theorem polarBilin_weightedSumSquares_one :
-    QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R)) =
-      2 • Matrix.toLinearMap₂' R (1 : Matrix n n R) := by
-  rw [← QuadraticMap.two_nsmul_associated
-    (S := R) (QuadraticMap.weightedSumSquares R (1 : n → R)),
-    associated_weightedSumSquares_one]
-
-omit [Fintype n] [DecidableEq n] in
-private theorem skewAdjointLieSubalgebra_two_smul
-    (B : LinearMap.BilinForm R (n → R)) :
-    skewAdjointLieSubalgebra (2 • B) = skewAdjointLieSubalgebra B := by
-  ext f
-  -- Expose the carrier predicate so the two skew-adjoint conditions can be compared directly.
-  change f ∈ (2 • B).skewAdjointSubmodule ↔ f ∈ B.skewAdjointSubmodule
-  rw [LinearMap.mem_skewAdjointSubmodule, LinearMap.mem_skewAdjointSubmodule]
-  constructor
-  · intro hf x y
-    apply (isUnit_of_invertible (2 : R)).smul_left_cancel.mp
-    simpa using hf x y
-  · intro hf x y
-    simp [hf x y]
-
-omit [Invertible (2 : R)] in
 private theorem lieEquivMatrix'_mem_skewAdjoint (J : Matrix n n R)
     (f : Module.End R (n → R)) :
     lieEquivMatrix' f ∈ skewAdjointMatricesLieSubalgebra J ↔
@@ -98,6 +73,8 @@ private theorem lieEquivMatrix'_mem_skewAdjoint (J : Matrix n n R)
   simpa using (isAdjointPair_toLinearMap₂' (R := R) (J := J) (J' := J)
     (A := LinearMap.toMatrix' f) (A' := -(LinearMap.toMatrix' f))).symm
 
+variable [Invertible (2 : R)]
+
 /-- The skew-adjoint endomorphisms of the polar form of the standard quadratic form are Mathlib's
 matrix orthogonal Lie algebra. -/
 noncomputable def standardSkewAdjointLieEquiv :
@@ -112,10 +89,16 @@ noncomputable def standardSkewAdjointLieEquiv :
       skewAdjointLieSubalgebra
           (QuadraticMap.polarBilin (QuadraticMap.weightedSumSquares R (1 : n → R))) ↔
         A ∈ LieAlgebra.Orthogonal.so n R
-    rw [polarBilin_weightedSumSquares_one, skewAdjointLieSubalgebra_two_smul,
-      LieAlgebra.Orthogonal.so, lieEquivMatrix'_symm_apply]
-    simpa using (lieEquivMatrix'_mem_skewAdjoint R n (1 : Matrix n n R)
-      ((lieEquivMatrix' (R := R) (n := n)).symm A)).symm
+    rw [polarBilin_weightedSumSquares_one, ← Nat.cast_smul_eq_nsmul R]
+    rw [← ((Matrix.toLinearMap₂' R : Matrix n n R ≃ₗ[R]
+      LinearMap.BilinForm R (n → R)).map_smul (↑(2 : ℕ) : R) (1 : Matrix n n R))]
+    change (lieEquivMatrix' (R := R) (n := n)).symm A ∈ skewAdjointLieSubalgebra
+      (Matrix.toLinearMap₂' R ((2 : R) • (1 : Matrix n n R))) ↔ _
+    conv_lhs => rw [← val_unitOfInvertible (2 : R)]
+    rw [← Units.smul_def, ← lieEquivMatrix'_mem_skewAdjoint R n
+      ((unitOfInvertible (2 : R)) • (1 : Matrix n n R)), LieAlgebra.Orthogonal.so]
+    simpa using (mem_skewAdjointMatricesLieSubalgebra_unit_smul
+      (unitOfInvertible (2 : R)) (1 : Matrix n n R) A)
 
 /-- The standard skew-adjoint equivalence sends an endomorphism to its matrix. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
@@ -92,6 +92,8 @@ noncomputable def standardSkewAdjointLieEquiv :
     rw [polarBilin_weightedSumSquares_one, ← Nat.cast_smul_eq_nsmul R]
     rw [← ((Matrix.toLinearMap₂' R : Matrix n n R ≃ₗ[R]
       LinearMap.BilinForm R (n → R)).map_smul (↑(2 : ℕ) : R) (1 : Matrix n n R))]
+    -- `map_smul` rewrites the bilinear form but not its restricted-subalgebra carrier;
+    -- this definitionally equal restatement exposes the matrix form needed by the bridge lemma.
     change (lieEquivMatrix' (R := R) (n := n)).symm A ∈ skewAdjointLieSubalgebra
       (Matrix.toLinearMap₂' R ((2 : R) • (1 : Matrix n n R))) ↔ _
     conv_lhs => rw [← val_unitOfInvertible (2 : R)]


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Identifies the skew-adjoint endomorphisms of the standard sum-of-squares form with Mathlib's matrix orthogonal Lie algebra.

- Computes the polar form as twice the identity-matrix form.
- Shows that the invertible scalar factor does not change skew-adjointness.
- Restricts Mathlib's endomorphism-to-matrix Lie equivalence and provides forward and inverse equations.

## Roadmap target

Advances the standard-form coordinate bridge for Layer 3 `soEquivBivector`:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L155-L170

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#soEquivBivector"}-->

## Verification

Full builds, `--iofail`, axiom and module-system audits, environment lint, source checks, downstream bare-`simp` probes, proof golf, and independent exact-diff review pass at `296e5e8e8392df82b9fb8adfa2015323acb2c2d6`.

## Scale and generality

Adds one 122-line file, generic over a commutative ring and finite index type with invertible `2`; it needs no chosen basis, field, or nondegeneracy assumption.

## Scope

- **Consumes:** the standard sum-of-squares form and Mathlib endomorphism-to-matrix Lie equivalence.
- **Provides:** a Lie equivalence from standard skew-adjoint endomorphisms to the matrix orthogonal Lie algebra, with forward and inverse equations.
- **Fits:** supplies the standard coordinate bridge consumed by the exterior-bivector equivalence.
- **Boundary:** exterior and Clifford realizations compose with this bridge in downstream slices.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [b8161ef](https://github.com/TauCetiProject/TauCetiReview/commit/b8161ef29f1bf922d3f9aea2b1b1e298bcd06078) · local review fixed: reuse (1), proof-quality (4)</sub>