### PR TITLE
feat: finite multi-marginal couplings

### DIFF
--- a/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Basic.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Basic.lean
@@ -9,9 +9,10 @@ public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
 /-!
 # Multi-marginal couplings
 
-This file defines a multi-marginal coupling as a probability measure on a finite dependent
-product with prescribed one-coordinate marginals. It provides coordinate and pair projections,
-coordinatewise maps, reindexing, and the independent product coupling.
+This file defines a multi-marginal coupling as a probability measure on a dependent product
+with prescribed one-coordinate marginals. It provides coordinate and pair projections,
+coordinatewise maps, reindexing, and, over a finite index type, the independent product
+coupling.
 
 These constructions form the finite multi-marginal part of Layer 0 of the optimal-transport
 roadmap. The definitions allow heterogeneous coordinate spaces; repeated-coordinate projections
@@ -30,7 +31,7 @@ universe u v w
 
 namespace Measure
 
-variable {ι : Type u} [Fintype ι] {X : ι → Type v} [∀ i, MeasurableSpace (X i)]
+variable {ι : Type u} {X : ι → Type v} [∀ i, MeasurableSpace (X i)]
 
 /-- A measure on a dependent product is a multi-marginal coupling of `μ` when its
 pushforward by every coordinate evaluation is the corresponding measure `μ i`. -/
@@ -41,7 +42,6 @@ namespace IsMultiCoupling
 
 variable {π : Measure (∀ i, X i)} {μ : ∀ i, Measure (X i)}
 
-omit [Fintype ι] in
 /-- Projecting a multi-marginal coupling along a family of coordinates gives another
 multi-marginal coupling. The coordinate family need not be injective. -/
 protected theorem project {κ : Type w} (hπ : IsMultiCoupling π μ) (e : κ → ι) :
@@ -58,7 +58,6 @@ protected theorem project {κ : Type w} (hπ : IsMultiCoupling π μ) (e : κ �
     _ = π.map (Function.eval (e j)) := by congr 2
     _ = μ (e j) := hπ.marginal_eq (e j)
 
-omit [Fintype ι] in
 /-- Applying measurable maps coordinatewise to a multi-marginal coupling pushes each marginal
 forward by the corresponding map. -/
 protected theorem map {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)]
@@ -78,7 +77,6 @@ protected theorem map {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)]
       (Measure.map_map (hf i) (measurable_pi_apply i)).symm
     _ = (μ i).map (f i) := congrArg (Measure.map (f i)) (hπ.marginal_eq i)
 
-omit [Fintype ι] in
 /-- The pair projection of a multi-marginal coupling has the prescribed first marginal. -/
 theorem fst_map_pair (hπ : IsMultiCoupling π μ) (i j : ι) :
     (π.map fun x ↦ (x i, x j)).fst = μ i := by
@@ -90,7 +88,6 @@ theorem fst_map_pair (hπ : IsMultiCoupling π μ) (i j : ι) :
     _ = π.map (Function.eval i) := by congr 2
     _ = μ i := hπ.marginal_eq i
 
-omit [Fintype ι] in
 /-- The pair projection of a multi-marginal coupling has the prescribed second marginal. -/
 theorem snd_map_pair (hπ : IsMultiCoupling π μ) (i j : ι) :
     (π.map fun x ↦ (x i, x j)).snd = μ j := by
@@ -106,37 +103,40 @@ end IsMultiCoupling
 
 /-- The finite product of probability measures is a multi-marginal coupling of its factors. -/
 @[simp]
-theorem isMultiCoupling_pi (μ : ∀ i, Measure (X i)) [∀ i, IsProbabilityMeasure (μ i)] :
+theorem isMultiCoupling_pi [Fintype ι] (μ : ∀ i, Measure (X i))
+    [∀ i, IsProbabilityMeasure (μ i)] :
     IsMultiCoupling (Measure.pi μ) μ where
   marginal_eq i := (measurePreserving_eval μ i).map_eq
 
 end Measure
 
-/-- Probability measures on a finite dependent product with prescribed coordinate marginals. -/
-abbrev MultiCoupling {ι : Type u} [Fintype ι] {X : ι → Type v}
+/-- Probability measures on a dependent product with prescribed coordinate marginals. -/
+abbrev MultiCoupling {ι : Type u} {X : ι → Type v}
     [∀ i, MeasurableSpace (X i)] (μ : ∀ i, ProbabilityMeasure (X i)) :=
   {π : ProbabilityMeasure (∀ i, X i) //
     Measure.IsMultiCoupling π.toMeasure (fun i ↦ (μ i).toMeasure)}
 
 namespace MultiCoupling
 
-variable {ι : Type u} [Fintype ι] {X : ι → Type v} [∀ i, MeasurableSpace (X i)]
+variable {ι : Type u} {X : ι → Type v} [∀ i, MeasurableSpace (X i)]
   {μ : ∀ i, ProbabilityMeasure (X i)}
 
 /-- The independent product probability measure, regarded as a multi-marginal coupling. -/
-def pi (μ : ∀ i, ProbabilityMeasure (X i)) : MultiCoupling μ :=
+def pi [Fintype ι] (μ : ∀ i, ProbabilityMeasure (X i)) : MultiCoupling μ :=
   ⟨ProbabilityMeasure.pi μ, by
     simpa only [ProbabilityMeasure.toMeasure_pi] using
       Measure.isMultiCoupling_pi (fun i ↦ (μ i).toMeasure)⟩
 
-/-- Every finite family of probability measures has a multi-marginal coupling. -/
-instance instNonempty : Nonempty (MultiCoupling μ) :=
-  ⟨pi μ⟩
+/-- Every family of probability measures indexed by a finite type has a multi-marginal
+coupling. -/
+instance instNonempty [Finite ι] : Nonempty (MultiCoupling μ) := by
+  have := Fintype.ofFinite ι
+  exact ⟨pi μ⟩
 
 /-- The underlying probability measure of the independent multi-coupling is the product
 probability measure. -/
 @[simp]
-theorem coe_pi (μ : ∀ i, ProbabilityMeasure (X i)) :
+theorem coe_pi [Fintype ι] (μ : ∀ i, ProbabilityMeasure (X i)) :
     (pi μ : ProbabilityMeasure (∀ i, X i)) = ProbabilityMeasure.pi μ :=
   (rfl)
 
@@ -144,8 +144,8 @@ theorem coe_pi (μ : ∀ i, ProbabilityMeasure (X i)) :
 def marginal (π : MultiCoupling μ) (i : ι) : ProbabilityMeasure (X i) :=
   π.1.map (measurable_pi_apply i).aemeasurable
 
-/-- The underlying measure of a coordinate marginal is the corresponding pushforward. -/
-@[simp]
+/-- The underlying measure of a coordinate marginal is the corresponding pushforward. This is
+not a `simp` lemma: `simp` rewrites `π.marginal i` to `μ i` via `marginal_eq` instead. -/
 theorem coe_marginal (π : MultiCoupling μ) (i : ι) :
     (π.marginal i).toMeasure = π.1.toMeasure.map (Function.eval i) :=
   (rfl)
@@ -164,7 +164,7 @@ theorem ext {π κ : MultiCoupling μ} (h : π.1.toMeasure = κ.1.toMeasure) : �
 
 /-- Project a coupling to a finite family of coordinates. The coordinate family need not be
 injective. -/
-def project {κ : Type w} [Fintype κ] (π : MultiCoupling μ) (e : κ → ι) :
+def project {κ : Type w} (π : MultiCoupling μ) (e : κ → ι) :
     MultiCoupling (fun j ↦ μ (e j)) :=
   ⟨π.1.map (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j)).aemeasurable, by
     simpa only [ProbabilityMeasure.toMeasure_map] using π.2.project e⟩
@@ -172,19 +172,19 @@ def project {κ : Type w} [Fintype κ] (π : MultiCoupling μ) (e : κ → ι) :
 /-- The underlying probability measure of a coordinate projection is the corresponding
 pushforward. -/
 @[simp]
-theorem coe_project {κ : Type w} [Fintype κ] (π : MultiCoupling μ) (e : κ → ι) :
+theorem coe_project {κ : Type w} (π : MultiCoupling μ) (e : κ → ι) :
     (π.project e : ProbabilityMeasure (∀ j, X (e j))) =
       π.1.map (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j)).aemeasurable :=
   (rfl)
 
 /-- Reindex a multi-marginal coupling along an equivalence of finite index types. -/
-def reindex {κ : Type w} [Fintype κ] (π : MultiCoupling μ) (e : κ ≃ ι) :
+def reindex {κ : Type w} (π : MultiCoupling μ) (e : κ ≃ ι) :
     MultiCoupling (fun j ↦ μ (e j)) :=
   π.project e
 
 /-- Reindexing is the pushforward by precomposition with the index equivalence. -/
 @[simp]
-theorem coe_reindex {κ : Type w} [Fintype κ] (π : MultiCoupling μ) (e : κ ≃ ι) :
+theorem coe_reindex {κ : Type w} (π : MultiCoupling μ) (e : κ ≃ ι) :
     (π.reindex e : ProbabilityMeasure (∀ j, X (e j))) =
       π.1.map (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j)).aemeasurable :=
   (rfl)
@@ -202,7 +202,7 @@ theorem reindex_refl (π : MultiCoupling μ) : π.reindex (Equiv.refl ι) = π :
 
 /-- Reindexing successively agrees with reindexing by the composite equivalence. -/
 @[simp]
-theorem reindex_trans {κ : Type w} {τ : Type*} [Fintype κ] [Fintype τ]
+theorem reindex_trans {κ : Type w} {τ : Type*}
     (π : MultiCoupling μ) (e : κ ≃ ι) (d : τ ≃ κ) :
     (π.reindex e).reindex d = π.reindex (d.trans e) := by
   apply ext
@@ -232,8 +232,7 @@ theorem coe_map {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)] (π : MultiCo
   (rfl)
 
 /-- Mapping every coordinate by the identity leaves the underlying probability measure
-unchanged. -/
-@[simp]
+unchanged. This is not a `simp` lemma: `simp` unfolds the left-hand side through `coe_map`. -/
 theorem coe_map_id (π : MultiCoupling μ) :
     (π.map (fun _ ↦ id) (fun _ ↦ measurable_id)).1 = π.1 := by
   apply ProbabilityMeasure.toMeasure_injective
@@ -244,7 +243,7 @@ theorem coe_map_id (π : MultiCoupling μ) :
 
 /-- Coordinatewise mapping preserves the independent product coupling. -/
 @[simp]
-theorem map_pi {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)]
+theorem map_pi [Fintype ι] {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)]
     (μ : ∀ i, ProbabilityMeasure (X i)) (f : ∀ i, X i → Y i)
     (hf : ∀ i, Measurable (f i)) :
     (pi μ).map f hf = pi (fun i ↦ (μ i).map (hf i).aemeasurable) := by

--- a/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Basic.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Basic.lean
@@ -82,24 +82,14 @@ protected theorem map {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)]
 /-- The pair projection of a multi-marginal coupling has the prescribed first marginal. -/
 theorem fst_map_pair (hπ : IsMultiCoupling π μ) (i j : ι) :
     (π.map fun x ↦ (x i, x j)).fst = μ i := by
-  calc
-    (π.map fun x ↦ (x i, x j)).fst =
-        π.map (Prod.fst ∘ fun x ↦ (x i, x j)) :=
-      Measure.map_map measurable_fst
-        ((measurable_pi_apply i).prodMk (measurable_pi_apply j))
-    _ = π.map (Function.eval i) := by congr 2
-    _ = μ i := hπ.marginal_eq i
+  rw [Measure.fst_map_prodMk (measurable_pi_apply j)]
+  exact hπ.marginal_eq i
 
 /-- The pair projection of a multi-marginal coupling has the prescribed second marginal. -/
 theorem snd_map_pair (hπ : IsMultiCoupling π μ) (i j : ι) :
     (π.map fun x ↦ (x i, x j)).snd = μ j := by
-  calc
-    (π.map fun x ↦ (x i, x j)).snd =
-        π.map (Prod.snd ∘ fun x ↦ (x i, x j)) :=
-      Measure.map_map measurable_snd
-        ((measurable_pi_apply i).prodMk (measurable_pi_apply j))
-    _ = π.map (Function.eval j) := by congr 2
-    _ = μ j := hπ.marginal_eq j
+  rw [Measure.snd_map_prodMk (measurable_pi_apply i)]
+  exact hπ.marginal_eq j
 
 end IsMultiCoupling
 
@@ -181,6 +171,26 @@ theorem coe_project {κ : Type w} (π : MultiCoupling μ) (e : κ → ι) :
       π.1.map (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j)).aemeasurable :=
   (rfl)
 
+/-- Projecting along the identity coordinate family leaves a multi-marginal coupling
+unchanged. -/
+@[simp]
+theorem project_id (π : MultiCoupling μ) : π.project id = π := by
+  apply Subtype.ext
+  apply ProbabilityMeasure.toMeasure_injective
+  simp only [project, ProbabilityMeasure.toMeasure_map]
+  exact Measure.map_id'
+
+/-- Projecting successively agrees with projecting along the composite coordinate family. -/
+@[simp]
+theorem project_comp {κ : Type w} {τ : Type*} (π : MultiCoupling μ) (e : κ → ι) (d : τ → κ) :
+    (π.project e).project d = π.project (e ∘ d) := by
+  apply ext
+  simp only [project, ProbabilityMeasure.toMeasure_map]
+  rw [Measure.map_map
+    (measurable_pi_lambda _ fun k ↦ measurable_pi_apply (d k))
+    (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j))]
+  rfl
+
 /-- Reindex a multi-marginal coupling along an equivalence of index types. -/
 def reindex {κ : Type w} (π : MultiCoupling μ) (e : κ ≃ ι) :
     MultiCoupling (fun j ↦ μ (e j)) :=
@@ -195,26 +205,15 @@ theorem coe_reindex {κ : Type w} (π : MultiCoupling μ) (e : κ ≃ ι) :
 
 /-- Reindexing by the identity equivalence leaves a multi-marginal coupling unchanged. -/
 @[simp]
-theorem reindex_refl (π : MultiCoupling μ) : π.reindex (Equiv.refl ι) = π := by
-  apply Subtype.ext
-  rw [coe_reindex]
-  apply ProbabilityMeasure.toMeasure_injective
-  -- The bundled `ProbabilityMeasure.map` coercion does not simplify after the dependent
-  -- codomain has been normalized by `Equiv.refl_apply`.
-  change π.1.toMeasure.map (fun x i ↦ x i) = π.1.toMeasure
-  exact Measure.map_id'
+theorem reindex_refl (π : MultiCoupling μ) : π.reindex (Equiv.refl ι) = π :=
+  π.project_id
 
 /-- Reindexing successively agrees with reindexing by the composite equivalence. -/
 @[simp]
 theorem reindex_trans {κ : Type w} {τ : Type*}
     (π : MultiCoupling μ) (e : κ ≃ ι) (d : τ ≃ κ) :
-    (π.reindex e).reindex d = π.reindex (d.trans e) := by
-  apply ext
-  simp only [reindex, project, ProbabilityMeasure.toMeasure_map]
-  rw [Measure.map_map
-    (measurable_pi_lambda _ fun k ↦ measurable_pi_apply (d k))
-    (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j))]
-  rfl
+    (π.reindex e).reindex d = π.reindex (d.trans e) :=
+  π.project_comp e d
 
 /-- Applying measurable maps coordinatewise to a multi-marginal coupling. -/
 def map {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)] (π : MultiCoupling μ)
@@ -258,6 +257,13 @@ theorem map_pi [Fintype ι] {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)]
 /-- The joint law of coordinates `i` and `j` of a multi-marginal coupling. -/
 def projectPair (π : MultiCoupling μ) (i j : ι) : ProbabilityMeasure (X i × X j) :=
   π.1.map ((measurable_pi_apply i).prodMk (measurable_pi_apply j)).aemeasurable
+
+/-- The underlying measure of a pair projection is the corresponding pushforward. This is not a
+`simp` lemma: `simp` rewrites the marginals of a pair projection through `fst_projectPair` and
+`snd_projectPair` instead. -/
+theorem coe_projectPair (π : MultiCoupling μ) (i j : ι) :
+    (π.projectPair i j).toMeasure = π.1.toMeasure.map (fun x ↦ (x i, x j)) :=
+  (rfl)
 
 /-- The first marginal of a pair projection is its first selected coordinate. -/
 @[simp]

--- a/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Basic.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Basic.lean
@@ -16,7 +16,9 @@ coupling.
 
 These constructions form the finite multi-marginal part of Layer 0 of the optimal-transport
 roadmap. The definitions allow heterogeneous coordinate spaces; repeated-coordinate projections
-are also allowed, which is useful for forming diagonal marginals.
+are also allowed, which is useful for forming diagonal marginals. Finiteness of the index type
+is assumed only where the independent product measure is involved, since the marginal,
+projection, reindexing and coordinatewise-map API needs nothing beyond measurable pushforwards.
 -/
 
 public section
@@ -110,7 +112,9 @@ theorem isMultiCoupling_pi [Fintype ι] (μ : ∀ i, Measure (X i))
 
 end Measure
 
-/-- Probability measures on a dependent product with prescribed coordinate marginals. -/
+/-- Probability measures on a dependent product with prescribed coordinate marginals. The
+index type carries no finiteness assumption: it is `MultiCoupling.pi` and
+`MultiCoupling.instNonempty`, not the bundle itself, that need `ι` to be finite. -/
 abbrev MultiCoupling {ι : Type u} {X : ι → Type v}
     [∀ i, MeasurableSpace (X i)] (μ : ∀ i, ProbabilityMeasure (X i)) :=
   {π : ProbabilityMeasure (∀ i, X i) //
@@ -162,7 +166,7 @@ theorem ext {π κ : MultiCoupling μ} (h : π.1.toMeasure = κ.1.toMeasure) : �
   apply Subtype.ext
   exact ProbabilityMeasure.toMeasure_injective h
 
-/-- Project a coupling to a finite family of coordinates. The coordinate family need not be
+/-- Project a coupling to a family of coordinates. The coordinate family need not be
 injective. -/
 def project {κ : Type w} (π : MultiCoupling μ) (e : κ → ι) :
     MultiCoupling (fun j ↦ μ (e j)) :=
@@ -177,7 +181,7 @@ theorem coe_project {κ : Type w} (π : MultiCoupling μ) (e : κ → ι) :
       π.1.map (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j)).aemeasurable :=
   (rfl)
 
-/-- Reindex a multi-marginal coupling along an equivalence of finite index types. -/
+/-- Reindex a multi-marginal coupling along an equivalence of index types. -/
 def reindex {κ : Type w} (π : MultiCoupling μ) (e : κ ≃ ι) :
     MultiCoupling (fun j ↦ μ (e j)) :=
   π.project e

--- a/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Basic.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Basic.lean
@@ -1,0 +1,287 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
+
+/-!
+# Multi-marginal couplings
+
+This file defines a multi-marginal coupling as a probability measure on a finite dependent
+product with prescribed one-coordinate marginals. It provides coordinate and pair projections,
+coordinatewise maps, reindexing, and the independent product coupling.
+
+These constructions form the finite multi-marginal part of Layer 0 of the optimal-transport
+roadmap. The definitions allow heterogeneous coordinate spaces; repeated-coordinate projections
+are also allowed, which is useful for forming diagonal marginals.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+universe u v w
+
+namespace Measure
+
+variable {ι : Type u} [Fintype ι] {X : ι → Type v} [∀ i, MeasurableSpace (X i)]
+
+/-- A measure on a dependent product is a multi-marginal coupling of `μ` when its
+pushforward by every coordinate evaluation is the corresponding measure `μ i`. -/
+structure IsMultiCoupling (π : Measure (∀ i, X i)) (μ : ∀ i, Measure (X i)) : Prop where
+  marginal_eq : ∀ i, π.map (Function.eval i) = μ i
+
+namespace IsMultiCoupling
+
+variable {π : Measure (∀ i, X i)} {μ : ∀ i, Measure (X i)}
+
+omit [Fintype ι] in
+/-- Projecting a multi-marginal coupling along a family of coordinates gives another
+multi-marginal coupling. The coordinate family need not be injective. -/
+protected theorem project {κ : Type w} (hπ : IsMultiCoupling π μ) (e : κ → ι) :
+    IsMultiCoupling
+      (π.map fun x j ↦ x (e j))
+      (fun j ↦ μ (e j)) := by
+  constructor
+  intro j
+  calc
+    (π.map fun x k ↦ x (e k)).map (Function.eval j) =
+        π.map (Function.eval j ∘ fun x k ↦ x (e k)) :=
+      Measure.map_map (measurable_pi_apply j)
+        (measurable_pi_lambda _ fun k ↦ measurable_pi_apply (e k))
+    _ = π.map (Function.eval (e j)) := by congr 2
+    _ = μ (e j) := hπ.marginal_eq (e j)
+
+omit [Fintype ι] in
+/-- Applying measurable maps coordinatewise to a multi-marginal coupling pushes each marginal
+forward by the corresponding map. -/
+protected theorem map {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)]
+    (hπ : IsMultiCoupling π μ) (f : ∀ i, X i → Y i) (hf : ∀ i, Measurable (f i)) :
+    IsMultiCoupling
+      (π.map fun x i ↦ f i (x i))
+      (fun i ↦ (μ i).map (f i)) := by
+  constructor
+  intro i
+  calc
+    (π.map fun x j ↦ f j (x j)).map (Function.eval i) =
+        π.map (Function.eval i ∘ fun x j ↦ f j (x j)) :=
+      Measure.map_map (measurable_pi_apply i)
+        (measurable_pi_lambda _ fun j ↦ (hf j).comp (measurable_pi_apply j))
+    _ = π.map (f i ∘ Function.eval i) := by congr 2
+    _ = (π.map (Function.eval i)).map (f i) :=
+      (Measure.map_map (hf i) (measurable_pi_apply i)).symm
+    _ = (μ i).map (f i) := congrArg (Measure.map (f i)) (hπ.marginal_eq i)
+
+omit [Fintype ι] in
+/-- The pair projection of a multi-marginal coupling has the prescribed first marginal. -/
+theorem fst_map_pair (hπ : IsMultiCoupling π μ) (i j : ι) :
+    (π.map fun x ↦ (x i, x j)).fst = μ i := by
+  calc
+    (π.map fun x ↦ (x i, x j)).fst =
+        π.map (Prod.fst ∘ fun x ↦ (x i, x j)) :=
+      Measure.map_map measurable_fst
+        ((measurable_pi_apply i).prodMk (measurable_pi_apply j))
+    _ = π.map (Function.eval i) := by congr 2
+    _ = μ i := hπ.marginal_eq i
+
+omit [Fintype ι] in
+/-- The pair projection of a multi-marginal coupling has the prescribed second marginal. -/
+theorem snd_map_pair (hπ : IsMultiCoupling π μ) (i j : ι) :
+    (π.map fun x ↦ (x i, x j)).snd = μ j := by
+  calc
+    (π.map fun x ↦ (x i, x j)).snd =
+        π.map (Prod.snd ∘ fun x ↦ (x i, x j)) :=
+      Measure.map_map measurable_snd
+        ((measurable_pi_apply i).prodMk (measurable_pi_apply j))
+    _ = π.map (Function.eval j) := by congr 2
+    _ = μ j := hπ.marginal_eq j
+
+end IsMultiCoupling
+
+/-- The finite product of probability measures is a multi-marginal coupling of its factors. -/
+@[simp]
+theorem isMultiCoupling_pi (μ : ∀ i, Measure (X i)) [∀ i, IsProbabilityMeasure (μ i)] :
+    IsMultiCoupling (Measure.pi μ) μ where
+  marginal_eq i := (measurePreserving_eval μ i).map_eq
+
+end Measure
+
+/-- Probability measures on a finite dependent product with prescribed coordinate marginals. -/
+abbrev MultiCoupling {ι : Type u} [Fintype ι] {X : ι → Type v}
+    [∀ i, MeasurableSpace (X i)] (μ : ∀ i, ProbabilityMeasure (X i)) :=
+  {π : ProbabilityMeasure (∀ i, X i) //
+    Measure.IsMultiCoupling π.toMeasure (fun i ↦ (μ i).toMeasure)}
+
+namespace MultiCoupling
+
+variable {ι : Type u} [Fintype ι] {X : ι → Type v} [∀ i, MeasurableSpace (X i)]
+  {μ : ∀ i, ProbabilityMeasure (X i)}
+
+/-- The independent product probability measure, regarded as a multi-marginal coupling. -/
+def pi (μ : ∀ i, ProbabilityMeasure (X i)) : MultiCoupling μ :=
+  ⟨ProbabilityMeasure.pi μ, by
+    simpa only [ProbabilityMeasure.toMeasure_pi] using
+      Measure.isMultiCoupling_pi (fun i ↦ (μ i).toMeasure)⟩
+
+/-- Every finite family of probability measures has a multi-marginal coupling. -/
+instance instNonempty : Nonempty (MultiCoupling μ) :=
+  ⟨pi μ⟩
+
+/-- The underlying probability measure of the independent multi-coupling is the product
+probability measure. -/
+@[simp]
+theorem coe_pi (μ : ∀ i, ProbabilityMeasure (X i)) :
+    (pi μ : ProbabilityMeasure (∀ i, X i)) = ProbabilityMeasure.pi μ :=
+  (rfl)
+
+/-- The `i`th marginal of a bundled multi-marginal coupling. -/
+def marginal (π : MultiCoupling μ) (i : ι) : ProbabilityMeasure (X i) :=
+  π.1.map (measurable_pi_apply i).aemeasurable
+
+/-- The underlying measure of a coordinate marginal is the corresponding pushforward. -/
+@[simp]
+theorem coe_marginal (π : MultiCoupling μ) (i : ι) :
+    (π.marginal i).toMeasure = π.1.toMeasure.map (Function.eval i) :=
+  (rfl)
+
+/-- Every coordinate marginal of a bundled multi-marginal coupling is its prescribed endpoint. -/
+@[simp]
+theorem marginal_eq (π : MultiCoupling μ) (i : ι) : π.marginal i = μ i := by
+  apply ProbabilityMeasure.toMeasure_injective
+  exact π.2.marginal_eq i
+
+/-- Two bundled multi-marginal couplings are equal when their underlying measures are equal. -/
+@[ext]
+theorem ext {π κ : MultiCoupling μ} (h : π.1.toMeasure = κ.1.toMeasure) : π = κ := by
+  apply Subtype.ext
+  exact ProbabilityMeasure.toMeasure_injective h
+
+/-- Project a coupling to a finite family of coordinates. The coordinate family need not be
+injective. -/
+def project {κ : Type w} [Fintype κ] (π : MultiCoupling μ) (e : κ → ι) :
+    MultiCoupling (fun j ↦ μ (e j)) :=
+  ⟨π.1.map (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j)).aemeasurable, by
+    simpa only [ProbabilityMeasure.toMeasure_map] using π.2.project e⟩
+
+/-- The underlying probability measure of a coordinate projection is the corresponding
+pushforward. -/
+@[simp]
+theorem coe_project {κ : Type w} [Fintype κ] (π : MultiCoupling μ) (e : κ → ι) :
+    (π.project e : ProbabilityMeasure (∀ j, X (e j))) =
+      π.1.map (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j)).aemeasurable :=
+  (rfl)
+
+/-- Reindex a multi-marginal coupling along an equivalence of finite index types. -/
+def reindex {κ : Type w} [Fintype κ] (π : MultiCoupling μ) (e : κ ≃ ι) :
+    MultiCoupling (fun j ↦ μ (e j)) :=
+  π.project e
+
+/-- Reindexing is the pushforward by precomposition with the index equivalence. -/
+@[simp]
+theorem coe_reindex {κ : Type w} [Fintype κ] (π : MultiCoupling μ) (e : κ ≃ ι) :
+    (π.reindex e : ProbabilityMeasure (∀ j, X (e j))) =
+      π.1.map (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j)).aemeasurable :=
+  (rfl)
+
+/-- Reindexing by the identity equivalence leaves a multi-marginal coupling unchanged. -/
+@[simp]
+theorem reindex_refl (π : MultiCoupling μ) : π.reindex (Equiv.refl ι) = π := by
+  apply Subtype.ext
+  rw [coe_reindex]
+  apply ProbabilityMeasure.toMeasure_injective
+  -- The bundled `ProbabilityMeasure.map` coercion does not simplify after the dependent
+  -- codomain has been normalized by `Equiv.refl_apply`.
+  change π.1.toMeasure.map (fun x i ↦ x i) = π.1.toMeasure
+  exact Measure.map_id'
+
+/-- Reindexing successively agrees with reindexing by the composite equivalence. -/
+@[simp]
+theorem reindex_trans {κ : Type w} {τ : Type*} [Fintype κ] [Fintype τ]
+    (π : MultiCoupling μ) (e : κ ≃ ι) (d : τ ≃ κ) :
+    (π.reindex e).reindex d = π.reindex (d.trans e) := by
+  apply ext
+  simp only [reindex, project, ProbabilityMeasure.toMeasure_map]
+  rw [Measure.map_map
+    (measurable_pi_lambda _ fun k ↦ measurable_pi_apply (d k))
+    (measurable_pi_lambda _ fun j ↦ measurable_pi_apply (e j))]
+  rfl
+
+/-- Applying measurable maps coordinatewise to a multi-marginal coupling. -/
+def map {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)] (π : MultiCoupling μ)
+    (f : ∀ i, X i → Y i) (hf : ∀ i, Measurable (f i)) :
+    MultiCoupling (fun i ↦ (μ i).map (hf i).aemeasurable) :=
+  ⟨π.1.map (measurable_pi_lambda _ fun i ↦ (hf i).comp (measurable_pi_apply i)).aemeasurable,
+    by
+      simp only [ProbabilityMeasure.toMeasure_map]
+      convert π.2.map f hf using 1
+      all_goals rfl⟩
+
+/-- The underlying probability measure of a coordinatewise map is the corresponding
+pushforward. -/
+@[simp]
+theorem coe_map {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)] (π : MultiCoupling μ)
+    (f : ∀ i, X i → Y i) (hf : ∀ i, Measurable (f i)) :
+    (π.map f hf : ProbabilityMeasure (∀ i, Y i)) =
+      π.1.map (measurable_pi_lambda _ fun i ↦ (hf i).comp (measurable_pi_apply i)).aemeasurable :=
+  (rfl)
+
+/-- Mapping every coordinate by the identity leaves the underlying probability measure
+unchanged. -/
+@[simp]
+theorem coe_map_id (π : MultiCoupling μ) :
+    (π.map (fun _ ↦ id) (fun _ ↦ measurable_id)).1 = π.1 := by
+  apply ProbabilityMeasure.toMeasure_injective
+  simp only [map, ProbabilityMeasure.toMeasure_map]
+  calc
+    π.1.toMeasure.map (fun x i ↦ id (x i)) = π.1.toMeasure.map id := by congr 2
+    _ = π.1.toMeasure := Measure.map_id
+
+/-- Coordinatewise mapping preserves the independent product coupling. -/
+@[simp]
+theorem map_pi {Y : ι → Type w} [∀ i, MeasurableSpace (Y i)]
+    (μ : ∀ i, ProbabilityMeasure (X i)) (f : ∀ i, X i → Y i)
+    (hf : ∀ i, Measurable (f i)) :
+    (pi μ).map f hf = pi (fun i ↦ (μ i).map (hf i).aemeasurable) := by
+  apply ext
+  simp only [map, pi, ProbabilityMeasure.toMeasure_map, ProbabilityMeasure.toMeasure_pi]
+  exact Measure.pi_map_pi (fun i ↦ (hf i).aemeasurable)
+
+/-- The joint law of coordinates `i` and `j` of a multi-marginal coupling. -/
+def projectPair (π : MultiCoupling μ) (i j : ι) : ProbabilityMeasure (X i × X j) :=
+  π.1.map ((measurable_pi_apply i).prodMk (measurable_pi_apply j)).aemeasurable
+
+/-- The first marginal of a pair projection is its first selected coordinate. -/
+@[simp]
+theorem fst_projectPair (π : MultiCoupling μ) (i j : ι) :
+    (π.projectPair i j).toMeasure.fst = (μ i).toMeasure := by
+  simpa only [projectPair, ProbabilityMeasure.toMeasure_map] using π.2.fst_map_pair i j
+
+/-- The second marginal of a pair projection is its second selected coordinate. -/
+@[simp]
+theorem snd_projectPair (π : MultiCoupling μ) (i j : ι) :
+    (π.projectPair i j).toMeasure.snd = (μ j).toMeasure := by
+  simpa only [projectPair, ProbabilityMeasure.toMeasure_map] using π.2.snd_map_pair i j
+
+/-- Selecting the same coordinate twice gives its diagonal law. -/
+@[simp]
+theorem projectPair_self (π : MultiCoupling μ) (i : ι) :
+    π.projectPair i i = (μ i).map (measurable_id.prodMk measurable_id).aemeasurable := by
+  apply ProbabilityMeasure.toMeasure_injective
+  simp only [projectPair, ProbabilityMeasure.toMeasure_map]
+  calc
+    π.1.toMeasure.map (fun x ↦ (x i, x i)) =
+        π.1.toMeasure.map ((fun x ↦ (x, x)) ∘ Function.eval i) := by congr 2
+    _ = (π.1.toMeasure.map (Function.eval i)).map (fun x ↦ (x, x)) :=
+      (Measure.map_map (measurable_id.prodMk measurable_id) (measurable_pi_apply i)).symm
+    _ = (μ i).toMeasure.map (fun x ↦ (x, x)) :=
+      congrArg (Measure.map fun x ↦ (x, x)) (π.2.marginal_eq i)
+
+end MultiCoupling
+
+end TauCeti


### PR DESCRIPTION
This PR defines `Measure.IsMultiCoupling` and the bundled `MultiCoupling` space for a finite dependent family of measurable spaces, then provides the characteristic API for coordinate marginals, arbitrary coordinate projections, equivalence reindexing, coordinatewise measurable maps, pair projections, and the independent product witness. Pair projections record both raw marginal identities, and repeated projection to one coordinate computes the diagonal law.

It advances `TauCetiRoadmap/OptimalTransport/README.md`, Layer 0, item 5: “Define multi-marginal couplings indexed by a finite type, their projections and reindexing, product nonemptiness, marginal replacement, and reduction to the two-marginal API.” This is the definition/projection/product slice of that target and the next unclaimed part of the Layer 0 definition-level foundation.

After this PR, Layer 0 item 5 still needs marginal replacement, the named bridge from pair projections to the binary `Measure.IsCoupling` API after #2093 lands, and the finite transportation-matrix acceptance theorem; Layer 0 as a milestone also retains the disintegration and finite/countable gluing work stated in items 3–4.

The implementation consumes Mathlib’s `ProbabilityMeasure.pi`, `MeasureTheory.measurePreserving_eval`, `Measure.pi_map_pi`, and `Measure.map_map`; no Mathlib or external formalization code is vendored or adapted. Finiteness of the index type is required exactly where the independent product measure is: `Measure.isMultiCoupling_pi`, `MultiCoupling.pi`, `coe_pi`, `map_pi`, and the `Nonempty` instance. The marginal, projection, reindexing and coordinatewise-map API is stated without it, because those proofs use only measurable pushforwards. The bundled `MultiCoupling` therefore carries no `[Fintype ι]` binder — `lint-env`'s `unusedArguments` linter rejects one, since the instance does not occur in the bundle's type — and the finite case the roadmap asks for is the instance-supplied special case.

This work is distinct from the open binary-coupling PR #2093, graph-plan PR #2138, and gluing PR #2384: it introduces no binary coupling, graph plan, disintegration, or gluing declaration, and its pair-marginal equalities are phrased directly through Mathlib’s `Measure.fst` and `Measure.snd` until the binary bridge can consume #2093.

Roadmap: OptimalTransport

<!--tauceti-target:v1 {"focus":"OptimalTransport","id":"multi-marginal-couplings"}-->

🤖 Prepared with Codex

