### PR TITLE
refactor(L2): name the box exhaustion and the box step of the vanishing argument

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/L2/Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Product.lean
@@ -272,6 +272,44 @@ theorem setIntegral_prod_eq_zero_of_forall_inner [SFinite μ] [SFinite ν] {h : 
     _ = inner 𝕜 (L2prodMul F G) h := (L2.inner_def _ _).symm
     _ = 0 := hz F G
 
+/-- **The boxes built from two spanning sequences exhaust the product space.** -/
+private theorem iUnion_prod_spanningSets [SigmaFinite μ] [SigmaFinite ν] :
+    ⋃ n, (spanningSets μ n ×ˢ spanningSets ν n) = (Set.univ : Set (α × β)) := by
+  refine Set.eq_univ_of_forall fun p => ?_
+  have h1 : p.1 ∈ ⋃ n, spanningSets μ n := by rw [iUnion_spanningSets]; trivial
+  have h2 : p.2 ∈ ⋃ n, spanningSets ν n := by rw [iUnion_spanningSets]; trivial
+  obtain ⟨i, hi⟩ := Set.mem_iUnion.1 h1
+  obtain ⟨j, hj⟩ := Set.mem_iUnion.1 h2
+  exact Set.mem_iUnion.2 ⟨max i j, monotone_spanningSets μ (le_max_left i j) hi,
+    monotone_spanningSets ν (le_max_right i j) hj⟩
+
+/-- **Orthogonality kills the part of a measurable set inside a single box.** -/
+private theorem setIntegral_inter_prod_spanningSets_eq_zero [SigmaFinite μ] [SigmaFinite ν]
+    {h : Lp 𝕜 2 (μ.prod ν)}
+    (hz : ∀ (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν), inner 𝕜 (L2prodMul F G) h = 0)
+    {u : Set (α × β)} (hu : MeasurableSet u) (n : ℕ) :
+    ∫ p in u ∩ (spanningSets μ n ×ˢ spanningSets ν n), h p ∂(μ.prod ν) = 0 := by
+  -- Inside a box the product measure is finite, so the rectangles on which the integral is known
+  -- to vanish generate the whole product σ-algebra.
+  have hboxfin : (μ.prod ν) (spanningSets μ n ×ˢ spanningSets ν n) < ⊤ := by
+    rw [Measure.prod_prod]
+    exact ENNReal.mul_lt_top (measure_spanningSets_lt_top μ n) (measure_spanningSets_lt_top ν n)
+  have hrect : ∀ s, MeasurableSet s → ∀ t, MeasurableSet t →
+      ∫ p in s ×ˢ t, h p ∂((μ.prod ν).restrict
+        (spanningSets μ n ×ˢ spanningSets ν n)) = 0 := by
+    intro s hs t ht
+    rw [Measure.restrict_restrict (hs.prod ht), Set.prod_inter_prod]
+    exact setIntegral_prod_eq_zero_of_forall_inner hz
+      (hs.inter (measurableSet_spanningSets μ n))
+      (lt_of_le_of_lt (measure_mono Set.inter_subset_right)
+        (measure_spanningSets_lt_top μ n)).ne
+      (ht.inter (measurableSet_spanningSets ν n))
+      (lt_of_le_of_lt (measure_mono Set.inter_subset_right)
+        (measure_spanningSets_lt_top ν n)).ne
+  have hdyn := setIntegral_eq_zero_of_forall_prod
+    (integrableOn_Lp_of_measure_ne_top h one_le_two hboxfin.ne) hrect u hu
+  rwa [Measure.restrict_restrict hu] at hdyn
+
 /-- **Orthogonality kills every finite-measure set integral.** Exhaust the product space by finite
 boxes `spanningSets μ n ×ˢ spanningSets ν n`, run the Dynkin step inside each box, and pass to the
 monotone limit. -/
@@ -279,47 +317,17 @@ theorem setIntegral_eq_zero_of_forall_inner [SigmaFinite μ] [SigmaFinite ν] {h
     (hz : ∀ (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν), inner 𝕜 (L2prodMul F G) h = 0)
     (u : Set (α × β)) (hu : MeasurableSet u) (hfin : (μ.prod ν) u < ⊤) :
     ∫ p in u, h p ∂(μ.prod ν) = 0 := by
-  have hAm : ∀ n, MeasurableSet (spanningSets μ n) := measurableSet_spanningSets μ
-  have hBm : ∀ n, MeasurableSet (spanningSets ν n) := measurableSet_spanningSets ν
-  have hboxfin : ∀ n, (μ.prod ν) (spanningSets μ n ×ˢ spanningSets ν n) < ⊤ := by
-    intro n
-    rw [Measure.prod_prod]
-    exact ENNReal.mul_lt_top (measure_spanningSets_lt_top μ n) (measure_spanningSets_lt_top ν n)
-  have hbox : ∀ n, ∫ p in u ∩ (spanningSets μ n ×ˢ spanningSets ν n), h p ∂(μ.prod ν) = 0 := by
-    intro n
-    have hrect : ∀ s, MeasurableSet s → ∀ t, MeasurableSet t →
-        ∫ p in s ×ˢ t, h p ∂((μ.prod ν).restrict
-          (spanningSets μ n ×ˢ spanningSets ν n)) = 0 := by
-      intro s hs t ht
-      rw [Measure.restrict_restrict (hs.prod ht), Set.prod_inter_prod]
-      exact setIntegral_prod_eq_zero_of_forall_inner hz (hs.inter (hAm n))
-        (lt_of_le_of_lt (measure_mono Set.inter_subset_right)
-          (measure_spanningSets_lt_top μ n)).ne
-        (ht.inter (hBm n))
-        (lt_of_le_of_lt (measure_mono Set.inter_subset_right)
-          (measure_spanningSets_lt_top ν n)).ne
-    have hdyn := setIntegral_eq_zero_of_forall_prod
-      (integrableOn_Lp_of_measure_ne_top h one_le_two (hboxfin n).ne) hrect u hu
-    rwa [Measure.restrict_restrict hu] at hdyn
   have hmono : Monotone fun n => u ∩ (spanningSets μ n ×ˢ spanningSets ν n) := fun m n hmn =>
     Set.inter_subset_inter_right _
       (Set.prod_mono (monotone_spanningSets μ hmn) (monotone_spanningSets ν hmn))
   have hcover : ⋃ n, u ∩ (spanningSets μ n ×ˢ spanningSets ν n) = u := by
-    rw [← Set.inter_iUnion]
-    have huniv : ⋃ n, (spanningSets μ n ×ˢ spanningSets ν n) = Set.univ := by
-      refine Set.eq_univ_of_forall fun p => ?_
-      have h1 : p.1 ∈ ⋃ n, spanningSets μ n := by rw [iUnion_spanningSets]; trivial
-      have h2 : p.2 ∈ ⋃ n, spanningSets ν n := by rw [iUnion_spanningSets]; trivial
-      obtain ⟨i, hi⟩ := Set.mem_iUnion.1 h1
-      obtain ⟨j, hj⟩ := Set.mem_iUnion.1 h2
-      exact Set.mem_iUnion.2 ⟨max i j, monotone_spanningSets μ (le_max_left i j) hi,
-        monotone_spanningSets ν (le_max_right i j) hj⟩
-    rw [huniv, Set.inter_univ]
+    rw [← Set.inter_iUnion, iUnion_prod_spanningSets, Set.inter_univ]
   have htend := tendsto_setIntegral_of_monotone
-    (fun n => hu.inter ((hAm n).prod (hBm n))) hmono
+    (fun n => hu.inter ((measurableSet_spanningSets μ n).prod (measurableSet_spanningSets ν n)))
+    hmono
     (by rw [hcover]; exact integrableOn_Lp_of_measure_ne_top h one_le_two hfin.ne)
   rw [hcover] at htend
-  simp only [hbox] at htend
+  simp only [setIntegral_inter_prod_spanningSets_eq_zero hz hu] at htend
   exact tendsto_nhds_unique htend tendsto_const_nhds
 
 /-- **Completeness of the tensor family.** The elementary tensors built from two Hilbert bases have

--- a/TauCeti/Analysis/Semigroups/UniformlyContinuous.lean
+++ b/TauCeti/Analysis/Semigroups/UniformlyContinuous.lean
@@ -117,6 +117,39 @@ private theorem continuous_of_continuousAt_zero (S : StronglyContinuousSemigroup
       _ < C * (ε / C) := by gcongr
       _ = ε := by field_simp
 
+omit [CompleteSpace X] in
+/-- **A norm-continuous semigroup stays within any prescribed distance of the identity on a short
+enough initial interval.** -/
+private theorem exists_pos_forall_norm_realOperator_sub_one_le
+    (S : StronglyContinuousSemigroup X)
+    (hreal : Continuous fun t : ℝ ↦ S.realOperator t) {c : ℝ} (hc : 0 < c) :
+    ∃ t : ℝ, 0 < t ∧ ∀ s ∈ Set.uIoc (0 : ℝ) t, ‖S.realOperator s - 1‖ ≤ c := by
+  obtain ⟨δ, hδ, hsmall⟩ := Metric.continuousAt_iff.mp hreal.continuousAt c hc
+  refine ⟨δ / 2, half_pos hδ, fun s hs ↦ ?_⟩
+  rw [Set.uIoc_of_le (half_pos hδ).le] at hs
+  have hsδ : dist s 0 < δ := by
+    rw [Real.dist_eq, sub_zero, abs_of_nonneg hs.1.le]
+    exact hs.2.trans_lt (half_lt_self hδ)
+  simpa only [S.realOperator_zero, ContinuousLinearMap.one_def, dist_eq_norm] using
+    (hsmall hsδ).le
+
+/-- **The normalized local orbit average inherits any uniform bound on the orbit's distance to
+the identity.** -/
+private theorem norm_normalizedIntegral_sub_one_le (S : StronglyContinuousSemigroup X)
+    {t c : ℝ} (ht : 0 < t) (hint : IntervalIntegrable S.realOperator volume 0 t)
+    (hnorm : ∀ s ∈ Set.uIoc (0 : ℝ) t, ‖S.realOperator s - 1‖ ≤ c) :
+    ‖t⁻¹ • (∫ s in (0 : ℝ)..t, S.realOperator s) - 1‖ ≤ c := by
+  rw [S.normalizedIntegral_sub_one_eq ht hint, norm_smul, Real.norm_eq_abs, abs_inv,
+    abs_of_pos ht]
+  calc
+    t⁻¹ * ‖∫ s in (0 : ℝ)..t, (S.realOperator s - 1)‖
+        ≤ t⁻¹ * (c * |t - 0|) := by
+          gcongr
+          exact intervalIntegral.norm_integral_le_of_norm_le_const hnorm
+    _ = c := by
+          simp only [sub_zero, abs_of_pos ht]
+          field_simp
+
 /-- If a strongly continuous semigroup is continuous in operator norm at zero, then every vector
 lies in the domain of its generator. -/
 theorem domain_eq_top_of_continuousAt_zero (S : StronglyContinuousSemigroup X)
@@ -124,51 +157,26 @@ theorem domain_eq_top_of_continuousAt_zero (S : StronglyContinuousSemigroup X)
   have hS' := S.continuous_of_continuousAt_zero hS
   have hreal : Continuous fun t : ℝ ↦ S.realOperator t :=
     (hS'.comp continuous_real_toNNReal).congr fun t ↦ (S.realOperator_def t).symm
-  obtain ⟨δ, hδ, hsmall⟩ := Metric.continuousAt_iff.mp hreal.continuousAt (1 / 2) (by norm_num)
-  let t : ℝ := δ / 2
-  have ht : 0 < t := half_pos hδ
-  have hnorm : ∀ s ∈ Set.uIoc (0 : ℝ) t, ‖S.realOperator s - 1‖ ≤ 1 / 2 := by
-    intro s hs
-    rw [Set.uIoc_of_le ht.le] at hs
-    have hsδ : dist s 0 < δ := by
-      rw [Real.dist_eq, sub_zero, abs_of_nonneg hs.1.le]
-      exact hs.2.trans_lt (half_lt_self hδ)
-    simpa only [S.realOperator_zero, ContinuousLinearMap.one_def, dist_eq_norm] using
-      (hsmall hsδ).le
-  let B : X →L[ℝ] X := t⁻¹ • ∫ s in (0 : ℝ)..t, S.realOperator s
-  have hB : ‖B - 1‖ < 1 := by
-    have hB_sub : B - 1 = t⁻¹ • ∫ s in (0 : ℝ)..t, (S.realOperator s - 1) :=
-      S.normalizedIntegral_sub_one_eq ht (hreal.intervalIntegrable 0 t)
-    rw [hB_sub]
-    rw [norm_smul, Real.norm_eq_abs, abs_inv, abs_of_pos ht]
-    calc
-      t⁻¹ * ‖∫ s in (0 : ℝ)..t, (S.realOperator s - 1)‖
-          ≤ t⁻¹ * ((1 / 2) * |t - 0|) := by
-            gcongr
-            exact intervalIntegral.norm_integral_le_of_norm_le_const hnorm
-      _ = 1 / 2 := by simp only [sub_zero, abs_of_pos ht]; field_simp
-      _ < 1 := by norm_num
-  have hBunit : IsUnit B := by
-    have hnorm_one_sub : ‖1 - B‖ < 1 := by
-      have hone_sub : 1 - B = -(B - 1) := by module
-      rw [hone_sub, norm_neg]
+  obtain ⟨t, ht, hnorm⟩ :=
+    S.exists_pos_forall_norm_realOperator_sub_one_le hreal (c := 1 / 2) (by norm_num)
+  have hint : IntervalIntegrable S.realOperator volume 0 t := hreal.intervalIntegrable 0 t
+  have hB : ‖t⁻¹ • (∫ s in (0 : ℝ)..t, S.realOperator s) - 1‖ < 1 :=
+    (S.norm_normalizedIntegral_sub_one_le ht hint hnorm).trans_lt (by norm_num)
+  have hBunit : IsUnit (t⁻¹ • ∫ s in (0 : ℝ)..t, S.realOperator s) := by
+    have hone_sub : ‖1 - t⁻¹ • (∫ s in (0 : ℝ)..t, S.realOperator s)‖ < 1 := by
+      rw [show (1 : X →L[ℝ] X) - t⁻¹ • (∫ s in (0 : ℝ)..t, S.realOperator s) =
+        -(t⁻¹ • (∫ s in (0 : ℝ)..t, S.realOperator s) - 1) by module, norm_neg]
       exact hB
-    have h := isUnit_one_sub_of_norm_lt_one hnorm_one_sub
-    simpa only [sub_sub_cancel] using h
-  have hBsurj : Function.Surjective B :=
-    (ContinuousLinearMap.isUnit_iff_bijective.mp hBunit).2
+    simpa only [sub_sub_cancel] using isUnit_one_sub_of_norm_lt_one hone_sub
   apply top_unique
   intro y _
-  obtain ⟨x, hx⟩ := hBsurj y
+  obtain ⟨x, hx⟩ := (ContinuousLinearMap.isUnit_iff_bijective.mp hBunit).2 y
   rw [← hx]
-  have hint : IntervalIntegrable S.realOperator volume 0 t :=
-    (hreal.intervalIntegrable 0 t)
   have horbit : (∫ s in (0 : ℝ)..t, S.realOperator s) x =
       ∫ s in Set.Ioc 0 t, S.realOperator s x := by
     rw [ContinuousLinearMap.intervalIntegral_apply hint, intervalIntegral.integral_of_le ht.le]
-  have hB_apply : B x = t⁻¹ • (∫ s in (0 : ℝ)..t, S.realOperator s) x := by
-    rfl
-  rw [hB_apply, horbit]
+  change t⁻¹ • (∫ s in (0 : ℝ)..t, S.realOperator s) x ∈ S.domain
+  rw [horbit]
   exact S.domain.smul_mem t⁻¹ (S.integral_orbit_mem_domain x ht)
 
 /-- If a strongly continuous semigroup is continuous in operator norm, then every vector lies in


### PR DESCRIPTION
`setIntegral_eq_zero_of_forall_inner` carried three separate arguments in one 43-line body: the
Dynkin step inside a single spanning box, the fact that the boxes exhaust `α × β`, and the
monotone limit. Only the last is specific to the theorem.

| helper | says |
|---|---|
| `iUnion_prod_spanningSets` | `⋃ n, spanningSets μ n ×ˢ spanningSets ν n = univ` |
| `setIntegral_inter_prod_spanningSets_eq_zero` | the integral of `h` over `u ∩ (n-th box)` vanishes |

Neither is available in Mathlib: `iUnion_spanningSets` covers a single σ-finite measure, and
nothing states the product version (the `max i j` step is what makes the two sequences line up).

Hypotheses were re-derived at the point of extraction rather than inherited. In particular the box
lemma does **not** take the parent's finiteness hypothesis `hfin : (μ.prod ν) u < ⊤` — inside a box
the finiteness it needs is the box's own — and `iUnion_prod_spanningSets` mentions neither `𝕜` nor
`h`.

Proof body: 43 → 13 lines; the two new bodies are 8 and 19. The parent is now just: the sets
increase, they cover `u`, so the integrals converge to the integral over `u`, and every one of them
is zero.

Roadmap: OrthogonalL2Bases
