### PR TITLE
refactor(RestrictedPowerSeries): build the convolution neighbourhood from Mathlib

### DIFF
--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -130,16 +130,17 @@ theorem IsRestricted.finite_coeff_notMem {k : ℕ} {A : Type*} [Ring A]
   have := (tendsto_nhds.mp (isRestricted_iff.mp hf)) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
   rwa [Filter.mem_cofinite] at this
 
-/-- The neighbourhood of `0` used to control a coefficient convolution: inside the open
-subgroup `W`, and small enough that multiplying by any of finitely many fixed coefficients
-lands in `V`. Openness of `V` and `W` plus continuity of multiplication is all this needs. -/
-private theorem inter_preimage_mul_mem_nhds {A : Type*} [Ring A] [TopologicalSpace A]
-    [ContinuousMul A] {ι : Type*} (V W : OpenAddSubgroup A) (S₁ S₂ : Finset ι)
-    (c₁ c₂ : ι → A) :
-    ((W : Set A) ∩ (⋂ a ∈ S₁, (fun x => c₁ a * x) ⁻¹' (V : Set A))
-        ∩ (⋂ b ∈ S₂, (fun x => x * c₂ b) ⁻¹' (V : Set A))) ∈ nhds (0 : A) := by
-  refine Filter.inter_mem (Filter.inter_mem ?_ ?_) ?_
-  · exact W.isOpen.mem_nhds W.zero_mem
+/-- **A neighbourhood of `0` small enough that multiplying it by any of finitely many prescribed
+elements, on either side, lands in the open subgroup `V`.** Openness of `V` plus continuity of
+multiplication is all this needs. -/
+private theorem exists_mem_nhds_zero_forall_mul_mem {A : Type*} [Ring A] [TopologicalSpace A]
+    [ContinuousMul A] {ι : Type*} (V : OpenAddSubgroup A) (S₁ S₂ : Finset ι) (c₁ c₂ : ι → A) :
+    ∃ T ∈ nhds (0 : A), (∀ a ∈ S₁, ∀ y ∈ T, c₁ a * y ∈ (V : Set A)) ∧
+      ∀ b ∈ S₂, ∀ x ∈ T, x * c₂ b ∈ (V : Set A) := by
+  refine ⟨(⋂ a ∈ S₁, (fun x => c₁ a * x) ⁻¹' (V : Set A))
+      ∩ (⋂ b ∈ S₂, (fun x => x * c₂ b) ⁻¹' (V : Set A)), Filter.inter_mem ?_ ?_,
+    fun a ha y hy => Set.mem_iInter₂.mp hy.1 a ha,
+    fun b hb x hx => Set.mem_iInter₂.mp hx.2 b hb⟩
   · apply (Filter.biInter_finset_mem _).mpr
     intro a _
     exact (continuous_const_mul _).continuousAt.preimage_mem_nhds
@@ -213,22 +214,9 @@ theorem IsRestricted.mul {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
   set Sg := {s | MvPowerSeries.coeff s g ∉ (W : Set A)}
   have hSf : Sf.Finite := hf.finite_coeff_notMem W
   have hSg : Sg.Finite := hg.finite_coeff_notMem W
-  set T := (W : Set A) ∩
-    (⋂ a ∈ hSf.toFinset,
-      (fun x => MvPowerSeries.coeff a f * x) ⁻¹' (V : Set A)) ∩
-    (⋂ b ∈ hSg.toFinset,
-      (fun x => x * MvPowerSeries.coeff b g) ⁻¹' (V : Set A))
-  have hT_nhds : T ∈ nhds (0 : A) :=
-    inter_preimage_mul_mem_nhds V W hSf.toFinset hSg.toFinset
+  obtain ⟨T, hT_nhds, hT_left, hT_right⟩ :=
+    exists_mem_nhds_zero_forall_mul_mem V hSf.toFinset hSg.toFinset
       (fun a => MvPowerSeries.coeff a f) (fun b => MvPowerSeries.coeff b g)
-  have hT_left : ∀ a ∈ hSf.toFinset, ∀ y ∈ T,
-      MvPowerSeries.coeff a f * y ∈ (V : Set A) := by
-    intro a ha y hy
-    exact (Set.mem_iInter₂.mp hy.1.2 a ha : _)
-  have hT_right : ∀ b ∈ hSg.toFinset, ∀ x ∈ T,
-      x * MvPowerSeries.coeff b g ∈ (V : Set A) := by
-    intro b hb x hx
-    exact (Set.mem_iInter₂.mp hx.2 b hb : _)
   have hgT : {s | MvPowerSeries.coeff s g ∉ T}.Finite :=
     (Filter.mem_cofinite.mp (isRestricted_iff.mp hg hT_nhds)).subset (fun s hs => hs)
   have hfT : {s | MvPowerSeries.coeff s f ∉ T}.Finite :=

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -198,11 +198,11 @@ theorem IsRestricted.mul {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
   -- left directly and on the right through the opposite ring.
   obtain ⟨T₁, hT₁mem, hT₁⟩ := exists_mem_nhds_zero_mul_subset
     (hSf.image fun a => MvPowerSeries.coeff a f).isCompact (V.isOpen.mem_nhds V.zero_mem)
+  have hVop : MulOpposite.unop ⁻¹' (V : Set A) ∈ nhds (0 : Aᵐᵒᵖ) :=
+    MulOpposite.continuous_unop.continuousAt.preimage_mem_nhds
+      (by simpa using V.isOpen.mem_nhds V.zero_mem)
   obtain ⟨T₂, hT₂mem, hT₂⟩ := exists_mem_nhds_zero_mul_subset
-    (hSg.image fun b => MulOpposite.op (MvPowerSeries.coeff b g)).isCompact
-    (show MulOpposite.unop ⁻¹' (V : Set A) ∈ nhds (0 : Aᵐᵒᵖ) from
-      MulOpposite.continuous_unop.continuousAt.preimage_mem_nhds
-        (by simpa using V.isOpen.mem_nhds V.zero_mem))
+    (hSg.image fun b => MulOpposite.op (MvPowerSeries.coeff b g)).isCompact hVop
   set T : Set A := T₁ ∩ MulOpposite.op ⁻¹' T₂ with hTdef
   have hT_nhds : T ∈ nhds (0 : A) :=
     Filter.inter_mem hT₁mem

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -131,10 +131,11 @@ theorem IsRestricted.finite_coeff_notMem {k : ℕ} {A : Type*} [Ring A]
   rwa [Filter.mem_cofinite] at this
 
 /-- **A neighbourhood of `0` small enough that multiplying it by any of finitely many prescribed
-elements, on either side, lands in the open subgroup `V`.** Openness of `V` plus continuity of
-multiplication is all this needs. -/
-private theorem exists_mem_nhds_zero_forall_mul_mem {A : Type*} [Ring A] [TopologicalSpace A]
-    [ContinuousMul A] {ι : Type*} (V : OpenAddSubgroup A) (S₁ S₂ : Finset ι) (c₁ c₂ : ι → A) :
+elements, on either side, lands in the open subgroup `V`.** Openness of `V` plus *separate*
+continuity of multiplication is all this needs. -/
+private theorem exists_mem_nhds_zero_forall_mul_mem {A : Type*} [NonUnitalNonAssocRing A]
+    [TopologicalSpace A] [SeparatelyContinuousMul A] {ι : Type*} (V : OpenAddSubgroup A)
+    (S₁ S₂ : Finset ι) (c₁ c₂ : ι → A) :
     ∃ T ∈ nhds (0 : A), (∀ a ∈ S₁, ∀ y ∈ T, c₁ a * y ∈ (V : Set A)) ∧
       ∀ b ∈ S₂, ∀ x ∈ T, x * c₂ b ∈ (V : Set A) := by
   refine ⟨(⋂ a ∈ S₁, (fun x => c₁ a * x) ⁻¹' (V : Set A))

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -131,25 +131,22 @@ theorem IsRestricted.finite_coeff_notMem {k : ℕ} {A : Type*} [Ring A]
   rwa [Filter.mem_cofinite] at this
 
 /-- **A neighbourhood of `0` small enough that multiplying it by any of finitely many prescribed
-elements, on either side, lands in the open subgroup `V`.** Openness of `V` plus *separate*
-continuity of multiplication is all this needs. -/
-private theorem exists_mem_nhds_zero_forall_mul_mem {A : Type*} [NonUnitalNonAssocRing A]
-    [TopologicalSpace A] [SeparatelyContinuousMul A] {ι : Type*} (V : OpenAddSubgroup A)
+elements, on either side, lands in a prescribed neighbourhood `U` of `0`.** *Separate* continuity
+of multiplication is all this needs. -/
+private theorem exists_mem_nhds_zero_forall_mul_mem {A : Type*} [TopologicalSpace A]
+    [MulZeroClass A] [SeparatelyContinuousMul A] {ι : Type*} {U : Set A} (hU : U ∈ nhds (0 : A))
     (S₁ S₂ : Finset ι) (c₁ c₂ : ι → A) :
-    ∃ T ∈ nhds (0 : A), (∀ a ∈ S₁, ∀ y ∈ T, c₁ a * y ∈ (V : Set A)) ∧
-      ∀ b ∈ S₂, ∀ x ∈ T, x * c₂ b ∈ (V : Set A) := by
-  refine ⟨(⋂ a ∈ S₁, (fun x => c₁ a * x) ⁻¹' (V : Set A))
-      ∩ (⋂ b ∈ S₂, (fun x => x * c₂ b) ⁻¹' (V : Set A)), Filter.inter_mem ?_ ?_,
-    fun a ha y hy => Set.mem_iInter₂.mp hy.1 a ha,
+    ∃ T ∈ nhds (0 : A), (∀ a ∈ S₁, ∀ y ∈ T, c₁ a * y ∈ U) ∧
+      ∀ b ∈ S₂, ∀ x ∈ T, x * c₂ b ∈ U := by
+  refine ⟨(⋂ a ∈ S₁, (fun x => c₁ a * x) ⁻¹' U) ∩ (⋂ b ∈ S₂, (fun x => x * c₂ b) ⁻¹' U),
+    Filter.inter_mem ?_ ?_, fun a ha y hy => Set.mem_iInter₂.mp hy.1 a ha,
     fun b hb x hx => Set.mem_iInter₂.mp hx.2 b hb⟩
   · apply (Filter.biInter_finset_mem _).mpr
     intro a _
-    exact (continuous_const_mul _).continuousAt.preimage_mem_nhds
-      (by simpa using V.isOpen.mem_nhds V.zero_mem)
+    exact (continuous_const_mul _).continuousAt.preimage_mem_nhds (by simpa using hU)
   · apply (Filter.biInter_finset_mem _).mpr
     intro b _
-    exact (continuous_mul_const _).continuousAt.preimage_mem_nhds
-      (by simpa using V.isOpen.mem_nhds V.zero_mem)
+    exact (continuous_mul_const _).continuousAt.preimage_mem_nhds (by simpa using hU)
 
 /-- The "bad" indices contributed by one side of a coefficient convolution form a finite set:
 for each `a` in a finite `S`, only finitely many `n` have `c (n - a) ∉ T`, and `n ↦ n - a` is
@@ -216,7 +213,7 @@ theorem IsRestricted.mul {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
   have hSf : Sf.Finite := hf.finite_coeff_notMem W
   have hSg : Sg.Finite := hg.finite_coeff_notMem W
   obtain ⟨T, hT_nhds, hT_left, hT_right⟩ :=
-    exists_mem_nhds_zero_forall_mul_mem V hSf.toFinset hSg.toFinset
+    exists_mem_nhds_zero_forall_mul_mem (V.isOpen.mem_nhds V.zero_mem) hSf.toFinset hSg.toFinset
       (fun a => MvPowerSeries.coeff a f) (fun b => MvPowerSeries.coeff b g)
   have hgT : {s | MvPowerSeries.coeff s g ∉ T}.Finite :=
     (Filter.mem_cofinite.mp (isRestricted_iff.mp hg hT_nhds)).subset (fun s hs => hs)

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -208,10 +208,14 @@ theorem IsRestricted.mul {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
     Filter.inter_mem hT₁mem
       (MulOpposite.continuous_op.continuousAt.preimage_mem_nhds (by simpa using hT₂mem))
   have hT_left : ∀ a ∈ hSf.toFinset, ∀ y ∈ T, MvPowerSeries.coeff a f * y ∈ (V : Set A) :=
-    fun a ha y hy => hT₁ ⟨_, ⟨a, hSf.mem_toFinset.mp ha, rfl⟩, y, hy.1, rfl⟩
-  have hT_right : ∀ b ∈ hSg.toFinset, ∀ x ∈ T, x * MvPowerSeries.coeff b g ∈ (V : Set A) :=
-    fun b hb x hx =>
-      hT₂ ⟨_, ⟨b, hSg.mem_toFinset.mp hb, rfl⟩, MulOpposite.op x, hx.2, rfl⟩
+    fun a ha y hy =>
+      hT₁ (Set.mul_mem_mul (Set.mem_image_of_mem _ (hSf.mem_toFinset.mp ha)) hy.1)
+  have hT_right : ∀ b ∈ hSg.toFinset, ∀ x ∈ T, x * MvPowerSeries.coeff b g ∈ (V : Set A) := by
+    intro b hb x hx
+    -- `hT₂` lives in `Aᵐᵒᵖ`, where the product is reversed; unopping it gives the `A`-statement.
+    have hmem := hT₂ (Set.mul_mem_mul (Set.mem_image_of_mem _ (hSg.mem_toFinset.mp hb))
+      (Set.mem_preimage.mp hx.2))
+    simpa only [Set.mem_preimage, MulOpposite.unop_mul, MulOpposite.unop_op] using hmem
   have hgT : {s | MvPowerSeries.coeff s g ∉ T}.Finite :=
     (Filter.mem_cofinite.mp (isRestricted_iff.mp hg hT_nhds)).subset (fun s hs => hs)
   have hfT : {s | MvPowerSeries.coeff s f ∉ T}.Finite :=

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -130,24 +130,6 @@ theorem IsRestricted.finite_coeff_notMem {k : ℕ} {A : Type*} [Ring A]
   have := (tendsto_nhds.mp (isRestricted_iff.mp hf)) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
   rwa [Filter.mem_cofinite] at this
 
-/-- **A neighbourhood of `0` small enough that multiplying it by any of finitely many prescribed
-elements, on either side, lands in a prescribed neighbourhood `U` of `0`.** *Separate* continuity
-of multiplication is all this needs. -/
-private theorem exists_mem_nhds_zero_forall_mul_mem {A : Type*} [TopologicalSpace A]
-    [MulZeroClass A] [SeparatelyContinuousMul A] {ι : Type*} {U : Set A} (hU : U ∈ nhds (0 : A))
-    (S₁ S₂ : Finset ι) (c₁ c₂ : ι → A) :
-    ∃ T ∈ nhds (0 : A), (∀ a ∈ S₁, ∀ y ∈ T, c₁ a * y ∈ U) ∧
-      ∀ b ∈ S₂, ∀ x ∈ T, x * c₂ b ∈ U := by
-  refine ⟨(⋂ a ∈ S₁, (fun x => c₁ a * x) ⁻¹' U) ∩ (⋂ b ∈ S₂, (fun x => x * c₂ b) ⁻¹' U),
-    Filter.inter_mem ?_ ?_, fun a ha y hy => Set.mem_iInter₂.mp hy.1 a ha,
-    fun b hb x hx => Set.mem_iInter₂.mp hx.2 b hb⟩
-  · apply (Filter.biInter_finset_mem _).mpr
-    intro a _
-    exact (continuous_const_mul _).continuousAt.preimage_mem_nhds (by simpa using hU)
-  · apply (Filter.biInter_finset_mem _).mpr
-    intro b _
-    exact (continuous_mul_const _).continuousAt.preimage_mem_nhds (by simpa using hU)
-
 /-- The "bad" indices contributed by one side of a coefficient convolution form a finite set:
 for each `a` in a finite `S`, only finitely many `n` have `c (n - a) ∉ T`, and `n ↦ n - a` is
 injective on `{n | a ≤ n}`. Both halves of `IsRestricted.mul`'s bad set have this shape, with
@@ -212,9 +194,24 @@ theorem IsRestricted.mul {k : ℕ} {A : Type*} [Ring A] [TopologicalSpace A]
   set Sg := {s | MvPowerSeries.coeff s g ∉ (W : Set A)}
   have hSf : Sf.Finite := hf.finite_coeff_notMem W
   have hSg : Sg.Finite := hg.finite_coeff_notMem W
-  obtain ⟨T, hT_nhds, hT_left, hT_right⟩ :=
-    exists_mem_nhds_zero_forall_mul_mem (V.isOpen.mem_nhds V.zero_mem) hSf.toFinset hSg.toFinset
-      (fun a => MvPowerSeries.coeff a f) (fun b => MvPowerSeries.coeff b g)
+  -- A neighbourhood of `0` that the finitely many large coefficients multiply into `V`, on the
+  -- left directly and on the right through the opposite ring.
+  obtain ⟨T₁, hT₁mem, hT₁⟩ := exists_mem_nhds_zero_mul_subset
+    (hSf.image fun a => MvPowerSeries.coeff a f).isCompact (V.isOpen.mem_nhds V.zero_mem)
+  obtain ⟨T₂, hT₂mem, hT₂⟩ := exists_mem_nhds_zero_mul_subset
+    (hSg.image fun b => MulOpposite.op (MvPowerSeries.coeff b g)).isCompact
+    (show MulOpposite.unop ⁻¹' (V : Set A) ∈ nhds (0 : Aᵐᵒᵖ) from
+      MulOpposite.continuous_unop.continuousAt.preimage_mem_nhds
+        (by simpa using V.isOpen.mem_nhds V.zero_mem))
+  set T : Set A := T₁ ∩ MulOpposite.op ⁻¹' T₂ with hTdef
+  have hT_nhds : T ∈ nhds (0 : A) :=
+    Filter.inter_mem hT₁mem
+      (MulOpposite.continuous_op.continuousAt.preimage_mem_nhds (by simpa using hT₂mem))
+  have hT_left : ∀ a ∈ hSf.toFinset, ∀ y ∈ T, MvPowerSeries.coeff a f * y ∈ (V : Set A) :=
+    fun a ha y hy => hT₁ ⟨_, ⟨a, hSf.mem_toFinset.mp ha, rfl⟩, y, hy.1, rfl⟩
+  have hT_right : ∀ b ∈ hSg.toFinset, ∀ x ∈ T, x * MvPowerSeries.coeff b g ∈ (V : Set A) :=
+    fun b hb x hx =>
+      hT₂ ⟨_, ⟨b, hSg.mem_toFinset.mp hb, rfl⟩, MulOpposite.op x, hx.2, rfl⟩
   have hgT : {s | MvPowerSeries.coeff s g ∉ T}.Finite :=
     (Filter.mem_cofinite.mp (isRestricted_iff.mp hg hT_nhds)).subset (fun s hs => hs)
   have hfT : {s | MvPowerSeries.coeff s f ∉ T}.Finite :=


### PR DESCRIPTION
`IsRestricted.mul` built the neighbourhood that controls the coefficient convolution by hand:
`inter_preimage_mul_mem_nhds` produced an explicit triple intersection

```lean
(W : Set A) ∩ (⋂ a ∈ Sf, (coeff a f * ·) ⁻¹' V) ∩ (⋂ b ∈ Sg, (· * coeff b g) ⁻¹' V)
```

and the caller then recovered its two multiplication properties by projecting into the components.

Mathlib already does this. `exists_mem_nhds_zero_mul_subset` gives, for a compact set of
multipliers `K` and a neighbourhood `U` of `0`, some `T ∈ 𝓝 0` with `K * T ⊆ U`. The finitely many
large coefficients form a finite — hence compact — set, so it applies directly on the left; running
it in `Aᵐᵒᵖ` gives the right-hand side, and the intersection of the two neighbourhoods is the `T`
the convolution argument wants.

Net effect: `inter_preimage_mul_mem_nhds` is gone, the file is 17 lines shorter and carries one
fewer private declaration, and `IsRestricted.mul` grows by two lines. No statement changes.

This is the fix the `reuse` rubric asked for. I contested it first — the helper's separate-continuity
generality had been approved by `generality` in the same round — and the re-review upheld the
finding, so it is applied as stated. It is also the better outcome than I expected: routing through
Mathlib removes the hand-rolled declaration entirely rather than just relocating it.

Roadmap: AdicSpaces
