### PR TITLE
feat(RingTheory): the relative norm on ideal class groups

### DIFF
--- a/TauCeti/RingTheory/ClassGroup/RelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/RelNorm.lean
@@ -59,8 +59,10 @@ variable {R S : Type*} [CommRing R] [CommRing S] [IsDedekindDomain R] [IsDedekin
 
 variable (R) in
 /-- The relative ideal norm restricted to nonzero ideals, using that it reflects `⊥`
-(`Ideal.relNorm_eq_bot_iff`). Exposed, so that `Ideal.coe_relNorm0` — a definitional
-equality — is provable downstream of the module boundary. -/
+(`Ideal.relNorm_eq_bot_iff`).
+
+Exposed because `Ideal.coe_relNorm0` is a definitional equality and Mathlib has no coe lemma for
+`MonoidHom.codRestrict` to route it through; without exposure that lemma does not compile. -/
 @[expose]
 noncomputable def Ideal.relNorm0 : (Ideal S)⁰ →* (Ideal R)⁰ :=
   ((Ideal.relNorm R).toMonoidHom.domRestrict (Ideal S)⁰).codRestrict (Ideal R)⁰ fun I =>
@@ -81,7 +83,8 @@ By `ClassGroup.mk0_eq_mk0_iff` the hypothesis says `span {x} * I = span {y} * J`
 `x y : S`; applying `Ideal.relNorm` and using `Ideal.relNorm_singleton` turns this into the same
 relation between the norms, with the nonzero elements `Algebra.intNorm R S x` and
 `Algebra.intNorm R S y`. -/
-theorem mk0_relNorm0_eq_of_mk0_eq {I J : (Ideal S)⁰} (h : ClassGroup.mk0 I = ClassGroup.mk0 J) :
+private theorem mk0_relNorm0_eq_of_mk0_eq {I J : (Ideal S)⁰}
+    (h : ClassGroup.mk0 I = ClassGroup.mk0 J) :
     ClassGroup.mk0 (Ideal.relNorm0 R I) = ClassGroup.mk0 (Ideal.relNorm0 R J) := by
   -- `Algebra.intNorm_ne_zero` needs the fraction fields to form a finite extension; the lifted
   -- algebra is deliberately not an instance, so it is supplied here.
@@ -104,10 +107,7 @@ theorem mk0_relNorm0_eq_of_mk0_eq {I J : (Ideal S)⁰} (h : ClassGroup.mk0 I = C
 
 Every class has an integral representative, since `ClassGroup.mk0` is surjective, and the class of
 the norm does not depend on the representative (`mk0_relNorm0_eq_of_mk0_eq`); see
-`ClassGroup.relNorm_mk0`.
-
-Exposed so that `ClassGroup.relNorm_mk0`, which computes it on a representative, can unfold it. -/
-@[expose]
+`ClassGroup.relNorm_mk0`. -/
 noncomputable def relNorm : ClassGroup S →* ClassGroup R :=
   ((Con.ker (ClassGroup.mk0 (R := S))).lift ((ClassGroup.mk0 (R := R)).comp (Ideal.relNorm0 R))
       fun _ _ h => mk0_relNorm0_eq_of_mk0_eq h).comp

--- a/TauCeti/RingTheory/ClassGroup/RelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/RelNorm.lean
@@ -41,11 +41,10 @@ Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f
 Deviations from the source. It descends by `Function.surjInv` on `ClassGroup.mk0_surjective`, with
 `Function.surjInv_eq` rewrites discharging `map_one'` and `map_mul'`; the congruence route used
 here needs no choice plumbing in the proofs. It assumes `IsDomain` and `IsIntegrallyClosed`
-alongside `IsDedekindDomain` for both rings, which are implied. Its intermediate `mk0CompRelNorm0`
-is inlined, since `relNorm`'s body has to be exposed for `relNorm_mk0` and so cannot name a
-private declaration; the well-definedness lemma is stated directly about `mk0 ∘ relNorm0`
-instead. Finally its `relNorm_mk0'`, a restatement of `relNorm_mk0` with the membership proof
-spelled out inline, is not ported.
+alongside `IsDedekindDomain` for both rings, which are implied. Its intermediate
+`mk0CompRelNorm0` and that lemma's `_apply` are inlined, the well-definedness fact being stated
+directly about `mk0 ∘ relNorm0`. Finally its `relNorm_mk0'`, a restatement of `relNorm_mk0` with
+the membership proof spelled out inline, is not ported.
 -/
 
 public section
@@ -58,9 +57,6 @@ variable {R S : Type*} [CommRing R] [CommRing S] [IsDedekindDomain R] [IsDedekin
 variable (R) in
 /-- The relative ideal norm restricted to nonzero ideals, using that it reflects `⊥`
 (`Ideal.relNorm_eq_bot_iff`). -/
--- Exposed because `Ideal.coe_relNorm0` is a definitional equality and Mathlib has no coe lemma
--- for `MonoidHom.codRestrict` to route it through; without exposure that lemma does not compile.
-@[expose]
 noncomputable def Ideal.relNorm0 : (Ideal S)⁰ →* (Ideal R)⁰ :=
   ((Ideal.relNorm R).toMonoidHom.domRestrict (Ideal S)⁰).codRestrict (Ideal R)⁰ fun I =>
     mem_nonZeroDivisors_iff_ne_zero.mpr <|
@@ -69,7 +65,7 @@ noncomputable def Ideal.relNorm0 : (Ideal S)⁰ →* (Ideal R)⁰ :=
 @[simp]
 theorem Ideal.coe_relNorm0 (I : (Ideal S)⁰) :
     (Ideal.relNorm0 R I : Ideal R) = Ideal.relNorm R (I : Ideal S) :=
-  rfl
+  (rfl)
 
 namespace ClassGroup
 
@@ -110,6 +106,8 @@ noncomputable def relNorm : ClassGroup S →* ClassGroup R :=
       fun _ _ h => mk0_relNorm0_eq_of_mk0_eq h).comp
     (Con.quotientKerEquivOfSurjective _ ClassGroup.mk0_surjective).symm.toMonoidHom
 
+/-- The relative norm of the class represented by a nonzero ideal `I` is the class represented by
+`I`'s relative norm. This is the computation rule for `ClassGroup.relNorm`. -/
 @[simp]
 theorem relNorm_mk0 (I : (Ideal S)⁰) :
     relNorm (R := R) (ClassGroup.mk0 I) = ClassGroup.mk0 (Ideal.relNorm0 R I) := by

--- a/TauCeti/RingTheory/ClassGroup/RelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/RelNorm.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.ClassGroup.Basic
+public import Mathlib.RingTheory.Ideal.Norm.RelNorm
+import Mathlib.GroupTheory.Congruence.Basic
+
+/-!
+# The relative norm on ideal class groups
+
+For a finite extension `S / R` of Dedekind domains, Mathlib's relative ideal norm
+`Ideal.relNorm R : Ideal S →*₀ Ideal R` is multiplicative and sends principal ideals to
+principal ideals (`Ideal.relNorm_singleton`), so it descends to a group homomorphism
+`ClassGroup.relNorm : ClassGroup S →* ClassGroup R` on ideal class groups.
+
+The descent is along `ClassGroup.mk0 : (Ideal S)⁰ →* ClassGroup S`, which is surjective. Since
+`(Ideal S)⁰` is a monoid rather than a group, `MonoidHom.liftOfSurjective` does not apply; the
+descent instead goes through the monoid congruence `Con.ker` and
+`Con.quotientKerEquivOfSurjective`.
+
+## Main definitions
+
+* `Ideal.relNorm0 : (Ideal S)⁰ →* (Ideal R)⁰`: the relative ideal norm on nonzero ideals.
+* `ClassGroup.relNorm : ClassGroup S →* ClassGroup R`.
+
+## Main results
+
+* `ClassGroup.mk0_relNorm0_eq_of_mk0_eq`: the norms of two integral ideals in the same class are
+  themselves in the same class — the well-definedness of the descent.
+* `ClassGroup.relNorm_mk0`: `relNorm (mk0 I) = mk0 (relNorm0 I)`, the defining computation on an
+  integral representative.
+
+## Provenance
+
+Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
+`HasseWeil/Pic0/ClassGroupNorm.lean`, declarations `relNorm0`, `mk0CompRelNorm0`,
+`mk0CompRelNorm0_apply`, `mk0CompRelNorm0_eq_of_mk0_eq`, `ClassGroup.relNorm`,
+`ClassGroup.relNorm_mk0` and `ClassGroup.relNorm_mk0'`.
+
+Deviations from the source. It descends by `Function.surjInv` on `ClassGroup.mk0_surjective`, with
+`Function.surjInv_eq` rewrites discharging `map_one'` and `map_mul'`; the congruence route used
+here needs no choice plumbing in the proofs. It assumes `IsDomain` and `IsIntegrallyClosed`
+alongside `IsDedekindDomain` for both rings, which are implied. Its intermediate `mk0CompRelNorm0`
+is inlined, since `relNorm`'s body has to be exposed for `relNorm_mk0` and so cannot name a
+private declaration; the well-definedness lemma is stated directly about `mk0 ∘ relNorm0`
+instead. Finally its `relNorm_mk0'`, a restatement of `relNorm_mk0` with the membership proof
+spelled out inline, is not ported.
+-/
+
+public section
+
+open scoped nonZeroDivisors
+
+variable {R S : Type*} [CommRing R] [CommRing S] [IsDedekindDomain R] [IsDedekindDomain S]
+  [Algebra R S] [Module.Finite R S] [Module.IsTorsionFree R S]
+
+variable (R) in
+/-- The relative ideal norm restricted to nonzero ideals, using that it reflects `⊥`
+(`Ideal.relNorm_eq_bot_iff`). Exposed, so that `Ideal.coe_relNorm0` — a definitional
+equality — is provable downstream of the module boundary. -/
+@[expose]
+noncomputable def Ideal.relNorm0 : (Ideal S)⁰ →* (Ideal R)⁰ :=
+  ((Ideal.relNorm R).toMonoidHom.domRestrict (Ideal S)⁰).codRestrict (Ideal R)⁰ fun I =>
+    mem_nonZeroDivisors_iff_ne_zero.mpr <|
+      Ideal.relNorm_eq_bot_iff.not.mpr <| mem_nonZeroDivisors_iff_ne_zero.mp I.2
+
+@[simp]
+theorem Ideal.coe_relNorm0 (I : (Ideal S)⁰) :
+    (Ideal.relNorm0 R I : Ideal R) = Ideal.relNorm R (I : Ideal S) :=
+  rfl
+
+namespace ClassGroup
+
+/-- **Well-definedness of the class-group relative norm**: integral ideals with the same class have
+relative norms with the same class.
+
+By `ClassGroup.mk0_eq_mk0_iff` the hypothesis says `span {x} * I = span {y} * J` for nonzero
+`x y : S`; applying `Ideal.relNorm` and using `Ideal.relNorm_singleton` turns this into the same
+relation between the norms, with the nonzero elements `Algebra.intNorm R S x` and
+`Algebra.intNorm R S y`. -/
+theorem mk0_relNorm0_eq_of_mk0_eq {I J : (Ideal S)⁰} (h : ClassGroup.mk0 I = ClassGroup.mk0 J) :
+    ClassGroup.mk0 (Ideal.relNorm0 R I) = ClassGroup.mk0 (Ideal.relNorm0 R J) := by
+  -- `Algebra.intNorm_ne_zero` needs the fraction fields to form a finite extension; the lifted
+  -- algebra is deliberately not an instance, so it is supplied here.
+  let _ : Algebra (FractionRing R) (FractionRing S) := FractionRing.liftAlgebra R (FractionRing S)
+  have : IsScalarTower R (FractionRing R) (FractionRing S) :=
+    FractionRing.isScalarTower_liftAlgebra R (FractionRing S)
+  have : IsLocalization (Algebra.algebraMapSubmonoid S R⁰) (FractionRing S) :=
+    IsIntegralClosure.isLocalization R (FractionRing R) (FractionRing S) S
+  have : IsScalarTower R S (FractionRing S) := IsScalarTower.of_algebraMap_eq fun _ => rfl
+  have : FiniteDimensional (FractionRing R) (FractionRing S) :=
+    Module.Finite.of_isLocalization R S R⁰
+  rw [ClassGroup.mk0_eq_mk0_iff] at h
+  obtain ⟨x, y, hx, hy, hxy⟩ := h
+  refine ClassGroup.mk0_eq_mk0_iff.mpr ⟨Algebra.intNorm R S x, Algebra.intNorm R S y,
+    Algebra.intNorm_ne_zero.mpr hx, Algebra.intNorm_ne_zero.mpr hy, ?_⟩
+  rw [Ideal.coe_relNorm0, Ideal.coe_relNorm0, ← Ideal.relNorm_singleton (R := R) x,
+    ← Ideal.relNorm_singleton (R := R) y, ← map_mul, ← map_mul, hxy]
+
+/-- The **relative norm on class groups**, induced by `Ideal.relNorm`.
+
+Every class has an integral representative, since `ClassGroup.mk0` is surjective, and the class of
+the norm does not depend on the representative (`mk0_relNorm0_eq_of_mk0_eq`); see
+`ClassGroup.relNorm_mk0`.
+
+Exposed so that `ClassGroup.relNorm_mk0`, which computes it on a representative, can unfold it. -/
+@[expose]
+noncomputable def relNorm : ClassGroup S →* ClassGroup R :=
+  ((Con.ker (ClassGroup.mk0 (R := S))).lift ((ClassGroup.mk0 (R := R)).comp (Ideal.relNorm0 R))
+      fun _ _ h => mk0_relNorm0_eq_of_mk0_eq h).comp
+    (Con.quotientKerEquivOfSurjective _ ClassGroup.mk0_surjective).symm.toMonoidHom
+
+@[simp]
+theorem relNorm_mk0 (I : (Ideal S)⁰) :
+    relNorm (R := R) (ClassGroup.mk0 I) = ClassGroup.mk0 (Ideal.relNorm0 R I) := by
+  have h : (Con.quotientKerEquivOfSurjective _ ClassGroup.mk0_surjective).symm
+      (ClassGroup.mk0 (R := S) I) = (I : (Con.ker (ClassGroup.mk0 (R := S))).Quotient) :=
+    (MulEquiv.symm_apply_eq _).mpr rfl
+  rw [relNorm, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, h]
+  rfl
+
+end ClassGroup

--- a/TauCeti/RingTheory/ClassGroup/RelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/RelNorm.lean
@@ -28,8 +28,6 @@ descent instead goes through the monoid congruence `Con.ker` and
 
 ## Main results
 
-* `ClassGroup.mk0_relNorm0_eq_of_mk0_eq`: the norms of two integral ideals in the same class are
-  themselves in the same class — the well-definedness of the descent.
 * `ClassGroup.relNorm_mk0`: `relNorm (mk0 I) = mk0 (relNorm0 I)`, the defining computation on an
   integral representative.
 
@@ -59,10 +57,9 @@ variable {R S : Type*} [CommRing R] [CommRing S] [IsDedekindDomain R] [IsDedekin
 
 variable (R) in
 /-- The relative ideal norm restricted to nonzero ideals, using that it reflects `⊥`
-(`Ideal.relNorm_eq_bot_iff`).
-
-Exposed because `Ideal.coe_relNorm0` is a definitional equality and Mathlib has no coe lemma for
-`MonoidHom.codRestrict` to route it through; without exposure that lemma does not compile. -/
+(`Ideal.relNorm_eq_bot_iff`). -/
+-- Exposed because `Ideal.coe_relNorm0` is a definitional equality and Mathlib has no coe lemma
+-- for `MonoidHom.codRestrict` to route it through; without exposure that lemma does not compile.
 @[expose]
 noncomputable def Ideal.relNorm0 : (Ideal S)⁰ →* (Ideal R)⁰ :=
   ((Ideal.relNorm R).toMonoidHom.domRestrict (Ideal S)⁰).codRestrict (Ideal R)⁰ fun I =>
@@ -106,8 +103,8 @@ private theorem mk0_relNorm0_eq_of_mk0_eq {I J : (Ideal S)⁰}
 /-- The **relative norm on class groups**, induced by `Ideal.relNorm`.
 
 Every class has an integral representative, since `ClassGroup.mk0` is surjective, and the class of
-the norm does not depend on the representative (`mk0_relNorm0_eq_of_mk0_eq`); see
-`ClassGroup.relNorm_mk0`. -/
+the norm does not depend on the representative; `ClassGroup.relNorm_mk0` is the resulting
+computation. -/
 noncomputable def relNorm : ClassGroup S →* ClassGroup R :=
   ((Con.ker (ClassGroup.mk0 (R := S))).lift ((ClassGroup.mk0 (R := R)).comp (Ideal.relNorm0 R))
       fun _ _ h => mk0_relNorm0_eq_of_mk0_eq h).comp


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"classgroup-relnorm"}-->

Roadmap: EllipticCurves

Adds `TauCeti/RingTheory/ClassGroup/RelNorm.lean`: the relative norm on ideal class groups.

```lean
noncomputable def Ideal.relNorm0 : (Ideal S)⁰ →* (Ideal R)⁰
@[simp] theorem Ideal.coe_relNorm0 (I : (Ideal S)⁰) :
    (Ideal.relNorm0 R I : Ideal R) = Ideal.relNorm R (I : Ideal S)

noncomputable def ClassGroup.relNorm : ClassGroup S →* ClassGroup R
@[simp] theorem ClassGroup.relNorm_mk0 (I : (Ideal S)⁰) :
    relNorm (ClassGroup.mk0 I) = ClassGroup.mk0 (Ideal.relNorm0 R I)
```

For a finite extension `S / R` of Dedekind domains, `Ideal.relNorm R` is multiplicative and sends
principal ideals to principal ideals, so it descends to class groups.

## Mathlib check

Mathlib has the ideal-level norm — `Ideal.relNorm` (`RingTheory/Ideal/Norm/RelNorm.lean:270`),
with `relNorm_singleton`, `relNorm_eq_bot_iff` and multiplicativity — but nothing induced on class
groups. `grep -F "ClassGroup.relNorm"` over the pin returns zero hits, and the absence is
compile-checked rather than grep-checked:

```lean
example : ClassGroup S →* ClassGroup R := by exact?   -- `exact?` could not close the goal
```

`FractionalIdeal.absNorm` exists but is the absolute, `ℕ`-valued norm — unrelated. There is no
`FractionalIdeal.relNorm`, which is why the construction goes through integral representatives.

## Construction

The descent is along `ClassGroup.mk0 : (Ideal S)⁰ →* ClassGroup S`, which is surjective. Note
`(Ideal S)⁰` is a **monoid**, not a group, so `MonoidHom.liftOfSurjective`
(`Algebra/Group/Subgroup/Basic.lean`) does not typecheck here — it requires `[Group G₁]`. The
monoid-level route is the congruence API: `Con.ker`, `Con.lift`, and
`Con.quotientKerEquivOfSurjective`. This replaces the source's `Function.surjInv` construction, so
no choice plumbing appears in any proof.

Neither definition is exposed; both bodies stay opaque across the module boundary, and the
well-definedness lemma is private (so it is not listed as public API). `ClassGroup.relNorm_mk0`
rewrites with `relNorm`'s equation lemma. `Ideal.coe_relNorm0` is a definitional equality, and
Mathlib has no coercion lemma for `MonoidHom.codRestrict` to route it through — a full-tree grep
finds `coe_codRestrict`/`codRestrict_apply` for `ContinuousLinearMap`, `ContinuousAlgHom`,
`InitialSeg`, `RelEmbedding` and first-order embeddings, but not for `MonoidHom` — so it is proved
by an explicitly elaborated `(rfl)`, which unlike bare `rfl` compiles without exposing the
definition.

`Ideal.relNorm0` is built with `MonoidHom.domRestrict` and `MonoidHom.codRestrict` rather than by
hand, so the only new content in it is the nonvanishing side condition, discharged by
`Ideal.relNorm_eq_bot_iff`.

## Generality

The typeclass context is `[CommRing R] [CommRing S] [IsDedekindDomain R] [IsDedekindDomain S]
[Algebra R S] [Module.Finite R S] [Module.IsTorsionFree R S]`. The source additionally assumes
`IsDomain` and `IsIntegrallyClosed` for both rings; all four are implied by `IsDedekindDomain` and
are dropped here (checked by compiling the file without them). `Module.IsTorsionFree` is *not*
implied — dropping it fails to synthesize — and `Module.Free` is not needed.

## Provenance

Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
`HasseWeil/Pic0/ClassGroupNorm.lean`, declarations `relNorm0`, `mk0CompRelNorm0`,
`mk0CompRelNorm0_apply`, `mk0CompRelNorm0_eq_of_mk0_eq`, `ClassGroup.relNorm`,
`ClassGroup.relNorm_mk0` and `ClassGroup.relNorm_mk0'`. The source's `relNorm_mk0'` — the same
statement with the membership proof spelled out inline — is not ported; `mk0CompRelNorm0` and its
`_apply` lemma are inlined for the exposure reason above.

That file continues with the residue-degree-one identity `relNorm 𝔭 = comap 𝔭` (Silverman
III.4.10(a)) and its localization machinery. Those are left for a following PR; this one is the
definition and its characteristic lemma.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 3: elliptic curves over finite fields — the
Hasse bound (AEC V.1)** — the `hasse_bound` target, whose entry states that it is landable now
because *"the existing proof (provenance) carries a self-contained finite-level pairing, so this
headline can be the first PR while Layers 0–2 are still built out"*, and which the roadmap
designs against that provenance directly (*"its design model is the HasseWeil provenance, whose
capstone genuinely consumes it"*).

The class-group norm is what makes the pushforward of divisors along a finite map available: in
the roadmap's pinned Hasse provenance
(`dev/hasse-weil @ 513e83879e2f`) `ClassGroup.relNorm` is used 89 times, by
`Curves/NormValuation.lean`, `Curves/PushforwardDivisor.lean` and
`Curves/NormConormIntegralClosure.lean`, and `Pic0/ClassGroupNorm.lean` lies inside the 187-file
import closure of the capstone `hasse_bound` proof (the project has 283 files, so closure
membership is not automatic). A prerequisite rather than a target, which `CLAUDE.md` admits
explicitly: declarations may be added when they supply *"a prerequisite that a specific target
needs"*.

No curve, point or characteristic hypothesis appears in any statement: this is commutative
algebra, and it is placed under `TauCeti/RingTheory/ClassGroup/` mirroring Mathlib's own
`RingTheory/ClassGroup/`.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
locally. No `sorry`, no raised heartbeat limits; longest proof is 17 lines.
