### PR TITLE
feat: add a one-step Cartan-Dieudonne reduction

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.ReflectionLift
+
+/-!
+# The one-step Cartan--Dieudonne reduction
+
+Let `g` be an orthogonal automorphism and let `v` have invertible norm. At least one of `g v - v`
+and `g v + v` has invertible norm. A reflection in the former carries `g v` to `v`; a reflection
+in the latter followed by the reflection in `v` does the same. Since these reflections lift to the
+Pin group over an algebraically closed field, an element in the range of `pinToOrthogonal` can be
+multiplied into `g` to make it fix `v`.
+
+This is the one-vector reduction used by the finite-dimensional Cartan--Dieudonne induction.
+
+## Main result
+
+* `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_apply_eq_self`: an element in the
+  range of the Pin action corrects an orthogonal automorphism to fix a chosen vector of invertible
+  norm.
+
+## References
+
+This advances Layer 2's "The double cover" target in
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. See H. B. Lawson and
+M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+-/
+
+public section
+
+open CliffordAlgebra QuadraticMap
+
+namespace TauCeti
+
+universe u v
+
+namespace CliffordAlgebra
+
+variable {K : Type u} {V : Type v} [Field K] [IsAlgClosed K]
+  [AddCommGroup V] [Module K V] (Q : QuadraticForm K V) [Invertible (2 : K)]
+
+/-- Given an orthogonal automorphism `g` and a vector `v` of invertible norm, an element in the
+range of the Pin action can be multiplied into `g` so that the product fixes `v`. The correcting
+element is the lift of either one reflection or a product of two reflections. -/
+theorem exists_mem_range_pinToOrthogonal_mul_apply_eq_self
+    (g : QuadraticMap.orthogonalGroup Q) (v : V)
+    [Invertible (Q v)] :
+    ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ (pinToOrthogonal Q).range ∧
+      (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) v = v) := by
+  have hmap : Q ((g : V ≃ₗ[K] V) v) = Q v :=
+    QuadraticMap.map_app_of_mem_orthogonalGroup g.2 v
+  rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q _ v hmap with hsub | hadd
+  · let : Invertible (Q ((g : V ≃ₗ[K] V) v - v)) := hsub.invertible
+    let r : QuadraticMap.orthogonalGroup Q :=
+      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - v),
+        QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+    refine ⟨r, reflection_mem_range_pinToOrthogonal Q _, ?_⟩
+    -- Expose the underlying automorphisms of the subgroup product before applying the reflection
+    -- computation.
+    change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - v)
+      ((g : V ≃ₗ[K] V) v) = v
+    exact QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ v hmap
+  · let : Invertible (Q ((g : V ≃ₗ[K] V) v + v)) := hadd.invertible
+    let r₁ : QuadraticMap.orthogonalGroup Q :=
+      ⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+    let r₂ : QuadraticMap.orthogonalGroup Q :=
+      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v + v),
+        QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+    refine ⟨r₁ * r₂,
+      (pinToOrthogonal Q).range.mul_mem (reflection_mem_range_pinToOrthogonal Q v)
+        (reflection_mem_range_pinToOrthogonal Q _), ?_⟩
+    -- Expose the two underlying reflections before applying their public computation equations.
+    change QuadraticMap.reflection Q v
+      (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v + v)
+        ((g : V ≃ₗ[K] V) v)) = v
+    rw [QuadraticMap.reflection_add_apply_eq_neg_of_map_eq Q _ v hmap, map_neg,
+      QuadraticMap.reflection_apply_self, neg_neg]
+
+end CliffordAlgebra
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.FieldTheory.IsSepClosed
 public import TauCeti.LinearAlgebra.CliffordAlgebra.ReflectionLift
 
 /-!
@@ -12,8 +13,8 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.ReflectionLift
 Let `g` be an orthogonal automorphism and let `v` have invertible norm. At least one of `g v - v`
 and `g v + v` has invertible norm. A reflection in the former carries `g v` to `v`; a reflection
 in the latter followed by the reflection in `v` does the same. Since these reflections lift to the
-Pin group over an algebraically closed field, an element in the range of `pinToOrthogonal` can be
-multiplied into `g` to make it fix `v`.
+Pin group over a separably closed field of characteristic not two, an element in the range of
+`pinToOrthogonal` can be multiplied into `g` to make it fix `v`.
 
 This is the one-vector reduction used by the finite-dimensional Cartan--Dieudonne induction.
 
@@ -40,45 +41,52 @@ universe u v
 
 namespace CliffordAlgebra
 
-variable {K : Type u} {V : Type v} [Field K] [IsAlgClosed K]
+variable {K : Type u} {V : Type v} [Field K] [IsSepClosed K]
   [AddCommGroup V] [Module K V] (Q : QuadraticForm K V) [Invertible (2 : K)]
 
 /-- Given an orthogonal automorphism `g` and a vector `v` of invertible norm, an element in the
 range of the Pin action can be multiplied into `g` so that the product fixes `v`. The correcting
-element is the lift of either one reflection or a product of two reflections. -/
+orthogonal element is the image under `pinToOrthogonal` of a lift of either one reflection or two
+reflections. -/
 theorem exists_mem_range_pinToOrthogonal_mul_apply_eq_self
     (g : QuadraticMap.orthogonalGroup Q) (v : V)
     [Invertible (Q v)] :
     ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ (pinToOrthogonal Q).range ∧
       (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) v = v) := by
+  have reflection_mem_range (w : V) [Invertible (Q w)] :
+      (⟨QuadraticMap.reflection Q w, QuadraticMap.reflection_mem_orthogonalGroup Q w⟩ :
+        QuadraticMap.orthogonalGroup Q) ∈ (pinToOrthogonal Q).range :=
+    reflection_mem_range_pinToOrthogonal_of_isSquare Q w
+      (IsSepClosed.exists_eq_mul_self _)
   have hmap : Q ((g : V ≃ₗ[K] V) v) = Q v :=
     QuadraticMap.map_app_of_mem_orthogonalGroup g.2 v
-  rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q _ v hmap with hsub | hadd
+  rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q _ v hmap
+      (isUnit_of_invertible (Q v)).ne_zero with hsub | hadd
   · let : Invertible (Q ((g : V ≃ₗ[K] V) v - v)) := hsub.invertible
     let r : QuadraticMap.orthogonalGroup Q :=
       ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - v),
         QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
-    refine ⟨r, reflection_mem_range_pinToOrthogonal Q _, ?_⟩
+    refine ⟨r, reflection_mem_range _, ?_⟩
     -- Expose the underlying automorphisms of the subgroup product before applying the reflection
     -- computation.
     change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - v)
       ((g : V ≃ₗ[K] V) v) = v
     exact QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ v hmap
-  · let : Invertible (Q ((g : V ≃ₗ[K] V) v + v)) := hadd.invertible
+  · have : Invertible (Q ((g : V ≃ₗ[K] V) v - -v)) := by
+      simpa only [sub_neg_eq_add] using hadd.invertible
     let r₁ : QuadraticMap.orthogonalGroup Q :=
       ⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
     let r₂ : QuadraticMap.orthogonalGroup Q :=
-      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v + v),
+      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - -v),
         QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
     refine ⟨r₁ * r₂,
-      (pinToOrthogonal Q).range.mul_mem (reflection_mem_range_pinToOrthogonal Q v)
-        (reflection_mem_range_pinToOrthogonal Q _), ?_⟩
+      (pinToOrthogonal Q).range.mul_mem (reflection_mem_range v) (reflection_mem_range _), ?_⟩
     -- Expose the two underlying reflections before applying their public computation equations.
     change QuadraticMap.reflection Q v
-      (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v + v)
+      (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - -v)
         ((g : V ≃ₗ[K] V) v)) = v
-    rw [QuadraticMap.reflection_add_apply_eq_neg_of_map_eq Q _ v hmap, map_neg,
-      QuadraticMap.reflection_apply_self, neg_neg]
+    rw [QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ (-v)
+      (hmap.trans (Q.map_neg v).symm), map_neg, QuadraticMap.reflection_apply_self, neg_neg]
 
 end CliffordAlgebra
 end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -351,6 +351,77 @@ theorem reflection_mem_orthogonalGroup : reflection Q v ∈ orthogonalGroup Q :=
 
 end Reflection
 
+section CartanDieudonneStep
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+variable (Q : QuadraticForm R M)
+
+/-- If `x` and `y` have the same quadratic value, reflecting `x` in `x - y` carries it to `y`
+whenever `x - y` has invertible norm. -/
+theorem reflection_sub_apply_eq_of_map_eq (x y : M) (hxy : Q x = Q y)
+    [Invertible (Q (x - y))] :
+    reflection Q (x - y) x = y := by
+  rw [reflection_apply]
+  have hpolar : polar Q (x - y) x = Q (x - y) := by
+    calc
+      _ = (2 : R) * Q x - polar Q y x := by
+        rw [polar_sub_left, polar_self]
+        ring
+      _ = Q (x - y) := by
+        conv_rhs =>
+          rw [sub_eq_add_neg, QuadraticMap.map_add ⇑Q, QuadraticMap.map_neg, polar_neg_right]
+        rw [hxy, QuadraticMap.polar_comm ⇑Q y x]
+        ring
+  rw [hpolar, invOf_mul_self, one_smul, sub_sub_cancel]
+
+/-- If `x` and `y` have the same quadratic value, reflecting `x` in `x + y` carries it to `-y`
+whenever `x + y` has invertible norm. -/
+theorem reflection_add_apply_eq_neg_of_map_eq (x y : M) (hxy : Q x = Q y)
+    [Invertible (Q (x + y))] :
+    reflection Q (x + y) x = -y := by
+  rw [reflection_apply]
+  have hpolar : polar Q (x + y) x = Q (x + y) := by
+    calc
+      _ = (2 : R) * Q x + polar Q y x := by
+        rw [polar_add_left, polar_self]
+        ring
+      _ = Q (x + y) := by
+        rw [QuadraticMap.map_add ⇑Q, hxy, QuadraticMap.polar_comm ⇑Q y x]
+        ring
+  rw [hpolar, invOf_mul_self, one_smul]
+  abel
+
+section Field
+
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+variable (Q : QuadraticForm K V) [Invertible (2 : K)]
+
+/-- If `x` and `y` have the same invertible quadratic value, at least one of `x - y` and `x + y`
+has invertible norm. -/
+theorem isUnit_sub_or_add_of_map_eq (x y : V) (hxy : Q x = Q y) [Invertible (Q y)] :
+    IsUnit (Q (x - y)) ∨ IsUnit (Q (x + y)) := by
+  rw [isUnit_iff_ne_zero, isUnit_iff_ne_zero]
+  by_cases hsub : Q (x - y) = 0
+  · right
+    intro hadd
+    have hsum : Q (x - y) + Q (x + y) = 4 * Q y := by
+      rw [sub_eq_add_neg, QuadraticMap.map_add ⇑Q, QuadraticMap.map_neg, polar_neg_right,
+        QuadraticMap.map_add ⇑Q, hxy]
+      ring
+    have hzero : (4 : K) * Q y = 0 := by simpa [hsub, hadd] using hsum.symm
+    have h2 : (2 : K) ≠ 0 := (isUnit_of_invertible (2 : K)).ne_zero
+    have h4 : (4 : K) ≠ 0 := by
+      have hfour : (4 : K) = 2 * 2 := by norm_num
+      rw [hfour]
+      exact mul_ne_zero h2 h2
+    exact (isUnit_of_invertible (Q y)).ne_zero
+      ((mul_eq_zero.mp hzero).resolve_left h4)
+  · exact Or.inl hsub
+
+end Field
+
+end CartanDieudonneStep
+
 end QuadraticMap
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -27,11 +27,11 @@ This file supplies that subgroup, together with its determinant-one subgroup and
 the hyperplanes of vectors of invertible norm. The orthogonal group is the target of the
 twisted-conjugation homomorphism out of the Pin group, so it is the object the Pin/Spin double
 covers are stated against, and the reflections are the generators an eventual Cartan-Dieudonné
-theorem factors an orthogonal automorphism into. Nothing here assumes the hypotheses that theorem
-needs (a field of characteristic not two, a nondegenerate form, finite dimension); the declarations
-below hold over an arbitrary commutative ring. The characteristic restriction is not incidental: in
-characteristic two `polar Q v v = 2 • Q v` vanishes, so `reflection Q v` fixes `v` instead of
-negating it and is a transvection rather than a reflection in `v ^ ⊥`.
+theorem factors an orthogonal automorphism into. The structural and reflection declarations below
+hold over an arbitrary commutative ring; only the final equal-norm dichotomy assumes a field in
+which `2` is nonzero. The characteristic restriction is not incidental: in characteristic two
+`polar Q v v = 2 • Q v` vanishes, so `reflection Q v` fixes `v` instead of negating it and is a
+transvection rather than a reflection in `v ^ ⊥`.
 
 ## Main definitions
 
@@ -76,7 +76,8 @@ subtraction in `M` and `N`, since `QuadraticMap.polar` is stated for `[AddCommGr
 [AddCommGroup N]`, but still no more than a `CommSemiring`; the determinant needs `M` to be an
 additive group over a `CommRing`, and the
 reflections need to divide by `Q v` and so are stated for a `QuadraticForm R M`, that is, for
-`N = R`.
+`N = R`. The closing Cartan--Dieudonne dichotomy additionally assumes a field, a nonzero common
+quadratic value, and `2 ≠ 0`.
 
 ## References
 
@@ -374,31 +375,14 @@ theorem reflection_sub_apply_eq_of_map_eq (x y : M) (hxy : Q x = Q y)
         ring
   rw [hpolar, invOf_mul_self, one_smul, sub_sub_cancel]
 
-/-- If `x` and `y` have the same quadratic value, reflecting `x` in `x + y` carries it to `-y`
-whenever `x + y` has invertible norm. -/
-theorem reflection_add_apply_eq_neg_of_map_eq (x y : M) (hxy : Q x = Q y)
-    [Invertible (Q (x + y))] :
-    reflection Q (x + y) x = -y := by
-  rw [reflection_apply]
-  have hpolar : polar Q (x + y) x = Q (x + y) := by
-    calc
-      _ = (2 : R) * Q x + polar Q y x := by
-        rw [polar_add_left, polar_self]
-        ring
-      _ = Q (x + y) := by
-        rw [QuadraticMap.map_add ⇑Q, hxy, QuadraticMap.polar_comm ⇑Q y x]
-        ring
-  rw [hpolar, invOf_mul_self, one_smul]
-  abel
-
 section Field
 
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
-variable (Q : QuadraticForm K V) [Invertible (2 : K)]
+variable (Q : QuadraticForm K V) [NeZero (2 : K)]
 
-/-- If `x` and `y` have the same invertible quadratic value, at least one of `x - y` and `x + y`
-has invertible norm. -/
-theorem isUnit_sub_or_add_of_map_eq (x y : V) (hxy : Q x = Q y) [Invertible (Q y)] :
+/-- If `x` and `y` have the same nonzero quadratic value, at least one of `x - y` and `x + y`
+has nonzero, hence invertible, norm. -/
+theorem isUnit_sub_or_add_of_map_eq (x y : V) (hxy : Q x = Q y) (hy : Q y ≠ 0) :
     IsUnit (Q (x - y)) ∨ IsUnit (Q (x + y)) := by
   rw [isUnit_iff_ne_zero, isUnit_iff_ne_zero]
   by_cases hsub : Q (x - y) = 0
@@ -409,13 +393,10 @@ theorem isUnit_sub_or_add_of_map_eq (x y : V) (hxy : Q x = Q y) [Invertible (Q y
         QuadraticMap.map_add ⇑Q, hxy]
       ring
     have hzero : (4 : K) * Q y = 0 := by simpa [hsub, hadd] using hsum.symm
-    have h2 : (2 : K) ≠ 0 := (isUnit_of_invertible (2 : K)).ne_zero
     have h4 : (4 : K) ≠ 0 := by
-      have hfour : (4 : K) = 2 * 2 := by norm_num
-      rw [hfour]
-      exact mul_ne_zero h2 h2
-    exact (isUnit_of_invertible (Q y)).ne_zero
-      ((mul_eq_zero.mp hzero).resolve_left h4)
+      simpa only [show (4 : K) = 2 * 2 by norm_num] using
+        mul_ne_zero (NeZero.ne (2 : K)) (NeZero.ne (2 : K))
+    exact hy ((mul_eq_zero.mp hzero).resolve_left h4)
   · exact Or.inl hsub
 
 end Field


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the one-vector reduction used by the Cartan-Dieudonne factorization.

- Proves the reflection formula for pairs of vectors with equal quadratic value.
- Shows that one of their sum or difference has invertible norm.
- Uses Pin lifts to correct an orthogonal automorphism so that it fixes a chosen anisotropic vector.

## Roadmap target

Advances Layer 2 `spinToSpecialOrthogonal_surjective`:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L119-L125

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#spinToSpecialOrthogonal_surjective"}-->

## Verification

Full builds, audits, environment lint, source checks, downstream consumer probes, proof golf, and independent exact-diff review pass at `6035fd7e2d910bb497b662f504e862902199f3fc`.

## Scale and generality

Changes two files by +150/-6 lines. The reflection equation is generic over a commutative ring; the dichotomy needs a field with nonzero `2` and nonzero common quadratic value; the Pin consequence additionally needs separable closure.

## Scope

- **Consumes:** reflection lifts through the Pin group and equal-norm reflection formulas.
- **Provides:** a one-vector correction that makes an orthogonal automorphism fix a chosen anisotropic vector.
- **Fits:** supplies the base reduction consumed by fixed-subspace Cartan-Dieudonne induction.
- **Boundary:** preserving a larger fixed subspace and iterating to global surjectivity are downstream steps.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [b8161ef](https://github.com/TauCetiProject/TauCetiReview/commit/b8161ef29f1bf922d3f9aea2b1b1e298bcd06078) · local skill review @ [d3c1151](https://github.com/utensil/formal-land/commit/d3c1151fe4fd4a1ff08035f37517998a1f585ce6) fixed: generality (1)</sub>