### PR TITLE
feat: model the boundary of a Euclidean half-space

### DIFF
--- a/TauCeti/Geometry/Manifold/Boundary/Model.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Model.lean
@@ -171,6 +171,7 @@ theorem euclideanHalfSpaceBoundaryProj_param {n : ℕ}
   ext i
   simp
 
+@[simp]
 theorem euclideanHalfSpaceBoundaryParam_proj {n : ℕ}
     {x : EuclideanSpace ℝ (Fin (n + 1))} (hx : x ∈ euclideanHalfSpaceBoundary n) :
     euclideanHalfSpaceBoundaryParam n (euclideanHalfSpaceBoundaryProj n x) = x := by

--- a/TauCeti/Geometry/Manifold/Boundary/Model.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Model.lean
@@ -64,6 +64,21 @@ private def euclideanHalfSpaceBoundaryLinearEquiv (n : ℕ) :
     apply (WithLp.equiv 2 _).injective
     exact funext fun _ ↦ rfl
 
+private theorem euclideanHalfSpaceBoundaryLinearEquiv_apply {n : ℕ}
+    (x : euclideanHalfSpaceBoundary n) (i : Fin n) :
+    euclideanHalfSpaceBoundaryLinearEquiv n x i = x.1 i.succ :=
+  rfl
+
+private theorem euclideanHalfSpaceBoundaryLinearEquiv_symm_apply_zero {n : ℕ}
+    (x : EuclideanSpace ℝ (Fin n)) :
+    ((euclideanHalfSpaceBoundaryLinearEquiv n).symm x).1 0 = 0 :=
+  rfl
+
+private theorem euclideanHalfSpaceBoundaryLinearEquiv_symm_apply_succ {n : ℕ}
+    (x : EuclideanSpace ℝ (Fin n)) (i : Fin n) :
+    ((euclideanHalfSpaceBoundaryLinearEquiv n).symm x).1 i.succ = x i :=
+  rfl
+
 /-- The continuous linear equivalence from the boundary hyperplane to its lower-dimensional
 Euclidean model. -/
 noncomputable def euclideanHalfSpaceBoundaryEquiv (n : ℕ) :
@@ -74,27 +89,27 @@ noncomputable def euclideanHalfSpaceBoundaryEquiv (n : ℕ) :
 theorem euclideanHalfSpaceBoundaryEquiv_apply {n : ℕ}
     (x : euclideanHalfSpaceBoundary n) (i : Fin n) :
     euclideanHalfSpaceBoundaryEquiv n x i = x.1 i.succ :=
-  by rfl
+  by
+    simpa only [euclideanHalfSpaceBoundaryEquiv, LinearEquiv.coe_toContinuousLinearEquiv'] using
+      euclideanHalfSpaceBoundaryLinearEquiv_apply x i
 
 @[simp]
 theorem euclideanHalfSpaceBoundaryEquiv_symm_apply_zero {n : ℕ}
     (x : EuclideanSpace ℝ (Fin n)) :
     ((euclideanHalfSpaceBoundaryEquiv n).symm x).1 0 = 0 :=
-  by rfl
+  by
+    simpa only [euclideanHalfSpaceBoundaryEquiv,
+      LinearEquiv.coe_toContinuousLinearEquiv_symm'] using
+      euclideanHalfSpaceBoundaryLinearEquiv_symm_apply_zero x
 
 @[simp]
 theorem euclideanHalfSpaceBoundaryEquiv_symm_apply_succ {n : ℕ}
     (x : EuclideanSpace ℝ (Fin n)) (i : Fin n) :
     ((euclideanHalfSpaceBoundaryEquiv n).symm x).1 i.succ = x i :=
-  by rfl
-
-theorem euclideanHalfSpaceBoundaryEquiv_contDiff {n : ℕ∞} (m : ℕ) :
-    ContDiff ℝ n (euclideanHalfSpaceBoundaryEquiv m) :=
-  (euclideanHalfSpaceBoundaryEquiv m).contDiff
-
-theorem euclideanHalfSpaceBoundaryEquiv_symm_contDiff {n : ℕ∞} (m : ℕ) :
-    ContDiff ℝ n (euclideanHalfSpaceBoundaryEquiv m).symm :=
-  (euclideanHalfSpaceBoundaryEquiv m).symm.contDiff
+  by
+    simpa only [euclideanHalfSpaceBoundaryEquiv,
+      LinearEquiv.coe_toContinuousLinearEquiv_symm'] using
+      euclideanHalfSpaceBoundaryLinearEquiv_symm_apply_succ x i
 
 /-- Insert a zero as the zeroth coordinate, parametrizing the boundary of a Euclidean
 half-space by a Euclidean space of dimension one less. -/
@@ -119,10 +134,8 @@ theorem euclideanHalfSpaceBoundaryParam_apply_succ {n : ℕ}
     Submodule.subtypeL_apply, ContinuousLinearEquiv.coe_coe] using
       euclideanHalfSpaceBoundaryEquiv_symm_apply_succ x i
 
-/-- Delete the zeroth coordinate of a point in `(n + 1)`-dimensional Euclidean space. -/
-noncomputable def euclideanHalfSpaceBoundaryProj (n : ℕ) :
-    EuclideanSpace ℝ (Fin (n + 1)) →L[ℝ] EuclideanSpace ℝ (Fin n) :=
-  LinearMap.toContinuousLinearMap
+private def euclideanHalfSpaceBoundaryProjLinearMap (n : ℕ) :
+    EuclideanSpace ℝ (Fin (n + 1)) →ₗ[ℝ] EuclideanSpace ℝ (Fin n) :=
     { toFun := fun x ↦ WithLp.toLp 2 (Fin.tail x)
       map_add' := by
         intro x y
@@ -133,11 +146,23 @@ noncomputable def euclideanHalfSpaceBoundaryProj (n : ℕ) :
         apply (WithLp.equiv 2 _).injective
         exact funext fun _ ↦ rfl }
 
+private theorem euclideanHalfSpaceBoundaryProjLinearMap_apply {n : ℕ}
+    (x : EuclideanSpace ℝ (Fin (n + 1))) (i : Fin n) :
+    euclideanHalfSpaceBoundaryProjLinearMap n x i = x i.succ :=
+  rfl
+
+/-- Delete the zeroth coordinate of a point in `(n + 1)`-dimensional Euclidean space. -/
+noncomputable def euclideanHalfSpaceBoundaryProj (n : ℕ) :
+    EuclideanSpace ℝ (Fin (n + 1)) →L[ℝ] EuclideanSpace ℝ (Fin n) :=
+  LinearMap.toContinuousLinearMap (euclideanHalfSpaceBoundaryProjLinearMap n)
+
 @[simp]
 theorem euclideanHalfSpaceBoundaryProj_apply {n : ℕ}
     (x : EuclideanSpace ℝ (Fin (n + 1))) (i : Fin n) :
     euclideanHalfSpaceBoundaryProj n x i = x i.succ :=
-  by rfl
+  by
+    simpa only [euclideanHalfSpaceBoundaryProj, LinearMap.coe_toContinuousLinearMap'] using
+      euclideanHalfSpaceBoundaryProjLinearMap_apply x i
 
 @[simp]
 theorem euclideanHalfSpaceBoundaryProj_param {n : ℕ}
@@ -187,21 +212,5 @@ theorem euclideanHalfSpaceBoundary_eq_frontier (n : ℕ) :
   rw [frontier_range_modelWithCornersEuclideanHalfSpace]
   ext x
   simp [eq_comm]
-
-/-- The boundary parametrization has image exactly the frontier of Mathlib's Euclidean
-half-space model. -/
-theorem range_euclideanHalfSpaceBoundaryParam_eq_frontier (n : ℕ) :
-    range (euclideanHalfSpaceBoundaryParam n) =
-      frontier (range (modelWithCornersEuclideanHalfSpace (n + 1))) := by
-  rw [range_euclideanHalfSpaceBoundaryParam,
-    euclideanHalfSpaceBoundary_eq_frontier]
-
-theorem euclideanHalfSpaceBoundaryParam_contDiff {n : ℕ∞} (m : ℕ) :
-    ContDiff ℝ n (euclideanHalfSpaceBoundaryParam m) :=
-  (euclideanHalfSpaceBoundaryParam m).contDiff
-
-theorem euclideanHalfSpaceBoundaryProj_contDiff {n : ℕ∞} (m : ℕ) :
-    ContDiff ℝ n (euclideanHalfSpaceBoundaryProj m) :=
-  (euclideanHalfSpaceBoundaryProj m).contDiff
 
 end TauCeti

--- a/TauCeti/Geometry/Manifold/Boundary/Model.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Model.lean
@@ -1,0 +1,203 @@
+import Mathlib.Geometry.Manifold.Instances.Real
+
+/-!
+# The boundary model of a Euclidean half-space
+
+This file identifies the frontier of Mathlib's `(n + 1)`-dimensional manifold-with-boundary
+model `𝓡∂ (n + 1)` with the boundaryless model `𝓡 n`.  Concretely, the frontier is the
+coordinate hyperplane where the zeroth coordinate vanishes; deleting that coordinate gives a
+continuous linear equivalence with `EuclideanSpace ℝ (Fin n)`.
+
+The construction is the standard-model prerequisite for putting a manifold structure on the
+boundary of a manifold modeled on a Euclidean half-space, as prescribed by Layer 1 of the
+GeometricTopology roadmap.  The parametrization and projection API below is intended to let
+boundary charts use this identification without unfolding its coordinate construction.
+-/
+
+open Function Set
+
+open scoped Manifold
+
+namespace TauCeti
+
+/-- The coordinate hyperplane which is the boundary of the `(n + 1)`-dimensional Euclidean
+half-space. -/
+def euclideanHalfSpaceBoundary (n : ℕ) :
+    Submodule ℝ (EuclideanSpace ℝ (Fin (n + 1))) where
+  carrier := {x | x 0 = 0}
+  zero_mem' := by simp
+  add_mem' := by
+    intro x y hx hy
+    simp only [Set.mem_ofPred_eq] at hx hy ⊢
+    simp [hx, hy]
+  smul_mem' := by
+    intro c x hx
+    simp only [Set.mem_ofPred_eq] at hx ⊢
+    simp [hx]
+
+@[simp]
+theorem mem_euclideanHalfSpaceBoundary {n : ℕ} {x : EuclideanSpace ℝ (Fin (n + 1))} :
+    x ∈ euclideanHalfSpaceBoundary n ↔ x 0 = 0 :=
+  Iff.rfl
+
+private def euclideanHalfSpaceBoundaryLinearEquiv (n : ℕ) :
+    euclideanHalfSpaceBoundary n ≃ₗ[ℝ] EuclideanSpace ℝ (Fin n) where
+  toFun x := WithLp.toLp 2 (Fin.tail x.1)
+  invFun x := ⟨WithLp.toLp 2 (Fin.cons 0 x), by simp⟩
+  left_inv x := by
+    apply Subtype.ext
+    apply (WithLp.equiv 2 _).injective
+    simp only [WithLp.equiv_apply]
+    exact (congrArg (fun z ↦ Fin.cons z (Fin.tail x.1.ofLp)) x.2.symm).trans
+      (Fin.cons_self_tail x.1.ofLp)
+  right_inv x := by
+    apply (WithLp.equiv 2 _).injective
+    exact @Fin.tail_cons n (fun _ ↦ ℝ) 0 x.ofLp
+  map_add' x y := by
+    apply (WithLp.equiv 2 _).injective
+    exact funext fun _ ↦ rfl
+  map_smul' c x := by
+    apply (WithLp.equiv 2 _).injective
+    exact funext fun _ ↦ rfl
+
+/-- The continuous linear equivalence from the boundary hyperplane to its lower-dimensional
+Euclidean model. -/
+noncomputable def euclideanHalfSpaceBoundaryEquiv (n : ℕ) :
+    euclideanHalfSpaceBoundary n ≃L[ℝ] EuclideanSpace ℝ (Fin n) :=
+  (euclideanHalfSpaceBoundaryLinearEquiv n).toContinuousLinearEquiv
+
+@[simp]
+theorem euclideanHalfSpaceBoundaryEquiv_apply {n : ℕ}
+    (x : euclideanHalfSpaceBoundary n) (i : Fin n) :
+    euclideanHalfSpaceBoundaryEquiv n x i = x.1 i.succ :=
+  by rfl
+
+@[simp]
+theorem euclideanHalfSpaceBoundaryEquiv_symm_apply_zero {n : ℕ}
+    (x : EuclideanSpace ℝ (Fin n)) :
+    ((euclideanHalfSpaceBoundaryEquiv n).symm x).1 0 = 0 :=
+  by rfl
+
+@[simp]
+theorem euclideanHalfSpaceBoundaryEquiv_symm_apply_succ {n : ℕ}
+    (x : EuclideanSpace ℝ (Fin n)) (i : Fin n) :
+    ((euclideanHalfSpaceBoundaryEquiv n).symm x).1 i.succ = x i :=
+  by rfl
+
+theorem euclideanHalfSpaceBoundaryEquiv_contDiff {n : ℕ∞} (m : ℕ) :
+    ContDiff ℝ n (euclideanHalfSpaceBoundaryEquiv m) :=
+  (euclideanHalfSpaceBoundaryEquiv m).contDiff
+
+theorem euclideanHalfSpaceBoundaryEquiv_symm_contDiff {n : ℕ∞} (m : ℕ) :
+    ContDiff ℝ n (euclideanHalfSpaceBoundaryEquiv m).symm :=
+  (euclideanHalfSpaceBoundaryEquiv m).symm.contDiff
+
+/-- Insert a zero as the zeroth coordinate, parametrizing the boundary of a Euclidean
+half-space by a Euclidean space of dimension one less. -/
+noncomputable def euclideanHalfSpaceBoundaryParam (n : ℕ) :
+    EuclideanSpace ℝ (Fin n) →L[ℝ] EuclideanSpace ℝ (Fin (n + 1)) :=
+  (euclideanHalfSpaceBoundary n).subtypeL.comp
+    (euclideanHalfSpaceBoundaryEquiv n).symm.toContinuousLinearMap
+
+@[simp]
+theorem euclideanHalfSpaceBoundaryParam_apply_zero {n : ℕ}
+    (x : EuclideanSpace ℝ (Fin n)) :
+    euclideanHalfSpaceBoundaryParam n x 0 = 0 :=
+  by simpa only [euclideanHalfSpaceBoundaryParam, ContinuousLinearMap.comp_apply,
+    Submodule.subtypeL_apply, ContinuousLinearEquiv.coe_coe] using
+      euclideanHalfSpaceBoundaryEquiv_symm_apply_zero x
+
+@[simp]
+theorem euclideanHalfSpaceBoundaryParam_apply_succ {n : ℕ}
+    (x : EuclideanSpace ℝ (Fin n)) (i : Fin n) :
+    euclideanHalfSpaceBoundaryParam n x i.succ = x i :=
+  by simpa only [euclideanHalfSpaceBoundaryParam, ContinuousLinearMap.comp_apply,
+    Submodule.subtypeL_apply, ContinuousLinearEquiv.coe_coe] using
+      euclideanHalfSpaceBoundaryEquiv_symm_apply_succ x i
+
+/-- Delete the zeroth coordinate of a point in `(n + 1)`-dimensional Euclidean space. -/
+noncomputable def euclideanHalfSpaceBoundaryProj (n : ℕ) :
+    EuclideanSpace ℝ (Fin (n + 1)) →L[ℝ] EuclideanSpace ℝ (Fin n) :=
+  LinearMap.toContinuousLinearMap
+    { toFun := fun x ↦ WithLp.toLp 2 (Fin.tail x)
+      map_add' := by
+        intro x y
+        apply (WithLp.equiv 2 _).injective
+        exact funext fun _ ↦ rfl
+      map_smul' := by
+        intro c x
+        apply (WithLp.equiv 2 _).injective
+        exact funext fun _ ↦ rfl }
+
+@[simp]
+theorem euclideanHalfSpaceBoundaryProj_apply {n : ℕ}
+    (x : EuclideanSpace ℝ (Fin (n + 1))) (i : Fin n) :
+    euclideanHalfSpaceBoundaryProj n x i = x i.succ :=
+  by rfl
+
+@[simp]
+theorem euclideanHalfSpaceBoundaryProj_param {n : ℕ}
+    (x : EuclideanSpace ℝ (Fin n)) :
+    euclideanHalfSpaceBoundaryProj n (euclideanHalfSpaceBoundaryParam n x) = x := by
+  ext i
+  simp
+
+theorem euclideanHalfSpaceBoundaryParam_proj {n : ℕ}
+    {x : EuclideanSpace ℝ (Fin (n + 1))} (hx : x ∈ euclideanHalfSpaceBoundary n) :
+    euclideanHalfSpaceBoundaryParam n (euclideanHalfSpaceBoundaryProj n x) = x := by
+  ext i
+  refine Fin.cases ?_ (fun j ↦ ?_) i
+  · simpa using hx.symm
+  · simp
+
+@[simp]
+theorem euclideanHalfSpaceBoundaryParam_proj_eq_iff {n : ℕ}
+    {x : EuclideanSpace ℝ (Fin (n + 1))} :
+    euclideanHalfSpaceBoundaryParam n (euclideanHalfSpaceBoundaryProj n x) = x ↔
+      x ∈ euclideanHalfSpaceBoundary n := by
+  constructor
+  · intro h
+    rw [← h]
+    simp
+  · exact euclideanHalfSpaceBoundaryParam_proj
+
+theorem euclideanHalfSpaceBoundaryParam_injective (n : ℕ) :
+    Function.Injective (euclideanHalfSpaceBoundaryParam n) :=
+  fun _ _ h ↦ by simpa using congrArg (euclideanHalfSpaceBoundaryProj n) h
+
+@[simp]
+theorem range_euclideanHalfSpaceBoundaryParam (n : ℕ) :
+    range (euclideanHalfSpaceBoundaryParam n) = euclideanHalfSpaceBoundary n := by
+  ext x
+  constructor
+  · rintro ⟨y, rfl⟩
+    simp
+  · intro hx
+    exact ⟨euclideanHalfSpaceBoundaryProj n x,
+      euclideanHalfSpaceBoundaryParam_proj hx⟩
+
+/-- The coordinate hyperplane is the frontier of Mathlib's Euclidean half-space model. -/
+theorem euclideanHalfSpaceBoundary_eq_frontier (n : ℕ) :
+    (euclideanHalfSpaceBoundary n : Set (EuclideanSpace ℝ (Fin (n + 1)))) =
+      frontier (range (modelWithCornersEuclideanHalfSpace (n + 1))) := by
+  rw [frontier_range_modelWithCornersEuclideanHalfSpace]
+  ext x
+  simp [eq_comm]
+
+/-- The boundary parametrization has image exactly the frontier of Mathlib's Euclidean
+half-space model. -/
+theorem range_euclideanHalfSpaceBoundaryParam_eq_frontier (n : ℕ) :
+    range (euclideanHalfSpaceBoundaryParam n) =
+      frontier (range (modelWithCornersEuclideanHalfSpace (n + 1))) := by
+  rw [range_euclideanHalfSpaceBoundaryParam,
+    euclideanHalfSpaceBoundary_eq_frontier]
+
+theorem euclideanHalfSpaceBoundaryParam_contDiff {n : ℕ∞} (m : ℕ) :
+    ContDiff ℝ n (euclideanHalfSpaceBoundaryParam m) :=
+  (euclideanHalfSpaceBoundaryParam m).contDiff
+
+theorem euclideanHalfSpaceBoundaryProj_contDiff {n : ℕ∞} (m : ℕ) :
+    ContDiff ℝ n (euclideanHalfSpaceBoundaryProj m) :=
+  (euclideanHalfSpaceBoundaryProj m).contDiff
+
+end TauCeti

--- a/TauCeti/Geometry/Manifold/Boundary/Model.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Model.lean
@@ -1,4 +1,6 @@
-import Mathlib.Geometry.Manifold.Instances.Real
+module
+
+public import Mathlib.Geometry.Manifold.Instances.Real
 
 /-!
 # The boundary model of a Euclidean half-space
@@ -13,6 +15,8 @@ boundary of a manifold modeled on a Euclidean half-space, as prescribed by Layer
 GeometricTopology roadmap.  The parametrization and projection API below is intended to let
 boundary charts use this identification without unfolding its coordinate construction.
 -/
+
+public section
 
 open Function Set
 


### PR DESCRIPTION
This PR identifies the frontier of Mathlib's `(n + 1)`-dimensional Euclidean half-space model with the boundaryless model `ℝⁿ`, providing the standard coordinate model needed to restrict manifold-with-boundary charts to their boundaries.

It advances `TauCetiRoadmap/GeometricTopology/README.md`, Layer 1, milestone **“Boundary as a manifold”**, specifically the pinned first step that starts with `modelWithCornersEuclideanHalfSpace (n + 1)` and identifies its boundary model with `EuclideanSpace ℝ (Fin n)`. This is the most effective current step on the roadmap's critical path because Layer 1 is the stated spine for gluing, handles, surgery, cobordisms, and later geometric-topology layers, while no boundary-model code has landed or is in flight.

The new module `TauCeti/Geometry/Manifold/Boundary/Model.lean` (203 lines) defines the zeroth-coordinate hyperplane as a submodule, gives its continuous linear equivalence with `EuclideanSpace ℝ (Fin n)`, and exposes insertion and projection maps with both inverse laws, injectivity, their exact range, and smoothness in every order. It proves that this range is exactly `frontier (range (modelWithCornersEuclideanHalfSpace (n + 1)))`, including the edge case `n = 0`.

What remains after this PR is to restrict ambient half-space charts to this model, prove their transition maps smooth, install the boundaryless manifold structure on `I.boundary M`, and prove the inclusion is a smooth embedding.

No Mathlib infrastructure is vendored. The construction reuses Mathlib's `frontier_range_modelWithCornersEuclideanHalfSpace`, `Fin.cons`/`Fin.tail`, finite-dimensional `LinearEquiv.toContinuousLinearEquiv`, and continuous-linear smoothness API; the raw coordinate equivalence stays private.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"euclidean-half-space-boundary-model"}-->

🤖 Prepared with Codex
