### PR TITLE
feat(EllipticCurve): a squarefree bound on the x-denominator forces integrality

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
@@ -191,8 +191,8 @@ theorem den_eq_one_of_dvd_squarefree {W : _root_.WeierstrassCurve ℤ} {x y : �
     refine isUnit_den_of_dvd_squarefree W h (m := (m : ℤ)) (Int.squarefree_natCast.mpr hsf) ?_
     rw [← Int.natAbs_dvd, Rat.isFractionRingDen x]
     exact Int.natCast_dvd_natCast.mpr hdvd
-  have hd := Rat.isFractionRingDen x
-  rcases Int.isUnit_iff.mp hunit with h1 | h1 <;> rw [h1] at hd <;> simpa using hd.symm
+  rw [← Rat.isFractionRingDen x]
+  exact Int.isUnit_iff_natAbs_eq.mp hunit
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
@@ -6,7 +6,7 @@ module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Basic
 public import Mathlib.RingTheory.Localization.NumDen
-public import Mathlib.RingTheory.Localization.Rat
+import Mathlib.RingTheory.Localization.Rat
 
 /-!
 # Denominators of points on a Weierstrass curve over a unique factorization domain
@@ -36,9 +36,10 @@ of `y`.
   `x`-coordinate of a point divides it at least twice.
 * `TauCeti.WeierstrassCurve.not_prime_den`: the denominator of the `x`-coordinate of a point is
   not a prime element.
-* `TauCeti.WeierstrassCurve.den_eq_one_of_dvd_prime`: over `ℤ`, if the denominator of a rational
-  `x`-coordinate divides a prime then it is `1` — the integrality conclusion the rational root
-  theorem feeds into.
+* `TauCeti.WeierstrassCurve.isUnit_den_of_dvd_squarefree`: a squarefree bound on that denominator
+  forces it to be a unit.
+* `TauCeti.WeierstrassCurve.den_eq_one_of_dvd_squarefree`: the same over `ℤ`, where it says the
+  rational `x`-coordinate is an integer — the conclusion the rational root theorem feeds into.
 
 This is the denominator input to the Nagell–Lutz integrality milestone of
 `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz".
@@ -51,6 +52,12 @@ that roadmap at `dev/modular-curves @ 9fec8eba7652`: the descent follows
 `LutzNagell/LutzNagellTheorem/PIDDenominators.lean`
 (`den_no_simple_prime_factor_of_on_curve`, `den_not_prime_of_on_curve`) and its positive restatement
 `den_powerful_of_on_curve` in `LutzNagell/LutzNagellTheorem/PIDMain.lean`.
+
+The `ℚ`/`ℤ` conclusion follows `LutzNagell/LutzNagellTheorem/GeneralDenominators.lean`,
+declaration `den_ne_prime_of_on_general_curve`. That source states the prime-denominator
+exclusion — extra hypothesis `x.den = p` for a prime `p`, conclusion `False` — and names the
+divisibility consequence in its docstring without stating it; `den_eq_one_of_dvd_squarefree` is
+that consequence, with a squarefree bound in place of a prime one.
 -/
 
 public section
@@ -145,6 +152,21 @@ theorem sq_dvd_den_of_prime_of_dvd (h : (W.baseChange K).toAffine.Equation x y) 
     linear_combination key
   exact not_isRelPrime_of_cleared_equation hq hu' hα hcl (num_den_reduced R y)
 
+/-- **A squarefree bound on the denominator forces it to be a unit.**
+
+A prime dividing the denominator divides it twice (`sq_dvd_den_of_prime_of_dvd`), so it would
+divide any bound twice as well; a squarefree bound admits no such prime, leaving the denominator
+without prime factors. -/
+theorem isUnit_den_of_dvd_squarefree (h : (W.baseChange K).toAffine.Equation x y) {m : R}
+    (hsf : Squarefree m) (hdvd : (den R x : R) ∣ m) : IsUnit (den R x : R) := by
+  by_contra hnu
+  obtain ⟨q, hq_irr, hq_dvd⟩ := WfDvdMonoid.exists_irreducible_factor hnu
+    (mem_nonZeroDivisors_iff_ne_zero.mp (den R x).2)
+  have hq : Prime q := UniqueFactorizationMonoid.irreducible_iff_prime.mp hq_irr
+  have hqq : q * q ∣ (den R x : R) := by
+    rw [← pow_two]; exact sq_dvd_den_of_prime_of_dvd W h hq hq_dvd
+  exact hq.not_isUnit (hsf q (hqq.trans hdvd))
+
 /-- **The denominator of the `x`-coordinate of a point is not prime.**
 
 The Nagell–Lutz form of `TauCeti.WeierstrassCurve.sq_dvd_den_of_prime_of_dvd`: a prime element is
@@ -155,21 +177,22 @@ theorem not_prime_den (h : (W.baseChange K).toAffine.Equation x y) :
   hp.not_isUnit <| hp.irreducible.squarefree _ <| by
     simpa [sq] using sq_dvd_den_of_prime_of_dvd W h hp dvd_rfl
 
--- The `Rat.den` form of `not_prime_den`: over `ℤ` the ring-theoretic denominator and the numeral
--- agree up to sign (`Rat.isFractionRingDen`). Only `den_eq_one_of_dvd_prime` consumes it.
-private theorem not_prime_rat_den {W : _root_.WeierstrassCurve ℤ} {x y : ℚ}
-    (h : (W.baseChange ℚ).toAffine.Equation x y) : ¬x.den.Prime := fun hp ↦
-  not_prime_den W h <| Int.prime_iff_natAbs_prime.mpr <| by rw [Rat.isFractionRingDen x]; exact hp
+/-- **A rational point whose `x`-denominator divides a squarefree number has an integral
+`x`-coordinate.**
 
-/-- **A rational point whose `x`-denominator divides a prime has an integral `x`-coordinate.**
-
-This is what the Nagell–Lutz integrality argument consumes: the rational root theorem bounds
-`x.den` by a prime `p`, and since a denominator is never prime
-(`TauCeti.WeierstrassCurve.not_prime_den`) the divisor `p` is excluded, leaving `x.den = 1`. -/
-theorem den_eq_one_of_dvd_prime {W : _root_.WeierstrassCurve ℤ} {x y : ℚ}
-    (h : (W.baseChange ℚ).toAffine.Equation x y) {p : ℕ} (hp : p.Prime) (hdvd : x.den ∣ p) :
-    x.den = 1 :=
-  (hp.eq_one_or_self_of_dvd _ hdvd).resolve_right fun hx ↦ not_prime_rat_den h (hx ▸ hp)
+The `ℚ`/`ℤ` form of `isUnit_den_of_dvd_squarefree`, which is what the Nagell–Lutz integrality
+argument consumes: the rational root theorem bounds `x.den`, and a squarefree bound leaves the
+denominator a unit, hence `1`. Over `ℤ` the ring-theoretic denominator and the numeral agree up
+to sign (`Rat.isFractionRingDen`). -/
+theorem den_eq_one_of_dvd_squarefree {W : _root_.WeierstrassCurve ℤ} {x y : ℚ}
+    (h : (W.baseChange ℚ).toAffine.Equation x y) {m : ℕ} (hsf : Squarefree m)
+    (hdvd : x.den ∣ m) : x.den = 1 := by
+  have hunit : IsUnit (den ℤ x : ℤ) := by
+    refine isUnit_den_of_dvd_squarefree W h (m := (m : ℤ)) (Int.squarefree_natCast.mpr hsf) ?_
+    rw [← Int.natAbs_dvd, Rat.isFractionRingDen x]
+    exact Int.natCast_dvd_natCast.mpr hdvd
+  have hd := Rat.isFractionRingDen x
+  rcases Int.isUnit_iff.mp hunit with h1 | h1 <;> rw [h1] at hd <;> simpa using hd.symm
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Basic
 public import Mathlib.RingTheory.Localization.NumDen
+public import Mathlib.RingTheory.Localization.Rat
 
 /-!
 # Denominators of points on a Weierstrass curve over a unique factorization domain
@@ -35,6 +36,9 @@ of `y`.
   `x`-coordinate of a point divides it at least twice.
 * `TauCeti.WeierstrassCurve.not_prime_den`: the denominator of the `x`-coordinate of a point is
   not a prime element.
+* `TauCeti.WeierstrassCurve.den_eq_one_of_dvd_prime`: over `ℤ`, if the denominator of a rational
+  `x`-coordinate divides a prime then it is `1` — the integrality conclusion the rational root
+  theorem feeds into.
 
 This is the denominator input to the Nagell–Lutz integrality milestone of
 `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz".
@@ -150,6 +154,22 @@ theorem not_prime_den (h : (W.baseChange K).toAffine.Equation x y) :
     ¬Prime (den R x : R) := fun hp ↦
   hp.not_isUnit <| hp.irreducible.squarefree _ <| by
     simpa [sq] using sq_dvd_den_of_prime_of_dvd W h hp dvd_rfl
+
+-- The `Rat.den` form of `not_prime_den`: over `ℤ` the ring-theoretic denominator and the numeral
+-- agree up to sign (`Rat.isFractionRingDen`). Only `den_eq_one_of_dvd_prime` consumes it.
+private theorem not_prime_rat_den {W : _root_.WeierstrassCurve ℤ} {x y : ℚ}
+    (h : (W.baseChange ℚ).toAffine.Equation x y) : ¬x.den.Prime := fun hp ↦
+  not_prime_den W h <| Int.prime_iff_natAbs_prime.mpr <| by rw [Rat.isFractionRingDen x]; exact hp
+
+/-- **A rational point whose `x`-denominator divides a prime has an integral `x`-coordinate.**
+
+This is what the Nagell–Lutz integrality argument consumes: the rational root theorem bounds
+`x.den` by a prime `p`, and since a denominator is never prime
+(`TauCeti.WeierstrassCurve.not_prime_den`) the divisor `p` is excluded, leaving `x.den = 1`. -/
+theorem den_eq_one_of_dvd_prime {W : _root_.WeierstrassCurve ℤ} {x y : ℚ}
+    (h : (W.baseChange ℚ).toAffine.Equation x y) {p : ℕ} (hp : p.Prime) (hdvd : x.den ∣ p) :
+    x.den = 1 :=
+  (hp.eq_one_or_self_of_dvd _ hdvd).resolve_right fun hx ↦ not_prime_rat_den h (hx ▸ hp)
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -112,15 +112,9 @@ The rational root theorem gives `den x ∣ f.leadingCoeff`; powerfulness of the 
 which squarefreeness forbids. -/
 theorem isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff
     (h : (W.baseChange K).toAffine.Equation x y) {f : R[X]} (hroot : aeval x f = 0)
-    (hsf : Squarefree f.leadingCoeff) : IsLocalization.IsInteger R x := by
-  refine isInteger_of_isUnit_den ?_
-  by_contra hnu
-  obtain ⟨q, hq_irr, hq_dvd⟩ := WfDvdMonoid.exists_irreducible_factor hnu
-    (mem_nonZeroDivisors_iff_ne_zero.mp (den R x).2)
-  have hq : Prime q := UniqueFactorizationMonoid.irreducible_iff_prime.mp hq_irr
-  have hden : q * q ∣ (den R x : R) := by
-    rw [← pow_two]; exact sq_dvd_den_of_prime_of_dvd W h hq hq_dvd
-  exact hq.not_isUnit (hsf q (hden.trans (den_dvd_of_is_root hroot)))
+    (hsf : Squarefree f.leadingCoeff) : IsLocalization.IsInteger R x :=
+  isInteger_of_isUnit_den <|
+    isUnit_den_of_dvd_squarefree W h hsf (den_dvd_of_is_root hroot)
 
 end UniqueFactorization
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"rat-denominator"}-->

Roadmap: EllipticCurves

Extends the merged `TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean` (#2246) with the
integrality conclusion its results exist to produce.

```lean
theorem isUnit_den_of_dvd_squarefree (h : (W.baseChange K).toAffine.Equation x y) {m : R}
    (hsf : Squarefree m) (hdvd : (den R x : R) ∣ m) : IsUnit (den R x : R)

theorem den_eq_one_of_dvd_squarefree {W : WeierstrassCurve ℤ} {x y : ℚ}
    (h : (W.baseChange ℚ).toAffine.Equation x y) {m : ℕ} (hsf : Squarefree m)
    (hdvd : x.den ∣ m) : x.den = 1
```

A squarefree bound on the denominator of an `x`-coordinate forces it to be a unit; over `ℤ` that
says the rational `x`-coordinate is an integer. This is the step the Nagell–Lutz integrality
argument takes, once the rational root theorem has bounded the denominator.

## Construction

A prime dividing the denominator divides it twice (the merged `sq_dvd_den_of_prime_of_dvd`), so it
would divide any bound twice; a squarefree bound admits no such prime, leaving the denominator
without prime factors. The `ℚ`/`ℤ` form then follows because the ring-theoretic
`IsFractionRing.den ℤ x` and the numeral `Rat.den` agree up to `natAbs`
(`Rat.isFractionRingDen`), and a unit of `ℤ` has `natAbs = 1`.

**This also shortens merged code.** `isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff`
was carrying the same argument inline — pick an irreducible factor of a non-unit denominator,
square it, contradict squarefreeness — and now reads
`isInteger_of_isUnit_den <| isUnit_den_of_dvd_squarefree W h hsf (den_dvd_of_is_root hroot)`,
nine proof lines to three. So the general lemma has two consumers, one of them pre-existing.

## Provenance

Ported from the AINTLIB `NagellLutz` project (Apache-2.0), file
`LutzNagell/LutzNagellTheorem/GeneralDenominators.lean`, declaration
`den_ne_prime_of_on_general_curve`. Three deviations:

* The source states the curve equation raw — `y² + a₁xy + a₃y = x³ + a₂x² + a₄x + a₆` over `ℚ` —
  where this uses `(W.baseChange ℚ).toAffine.Equation`, matching the convention of the file it is
  joining.
* The source exports only the bridge, in the weaker shape *"extra hypothesis `x.den = p` for a
  prime `p`, conclusion `False`"*. Its own docstring then says: *"This suffices for the Lutz–Nagell
  integrality argument: when the rational root theorem gives `x.den | p` for a prime `p`, we
  conclude `x.den ≠ p` and hence `x.den = 1`."* That consequence is named in prose and never
  stated; here it is the exported theorem — with a **squarefree** bound rather than a prime one,
  which is all the argument uses, and with no `x.den = p` hypothesis.
* The source's import of the thin `GeneralCurve` wrapper is dropped — it is vestigial (the proof
  never uses it), and TauCeti works with `W.baseChange` directly rather than porting such wrappers.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 6**, item *"The torsion subgroup and
Nagell–Lutz"* — the same target the file it extends already cites, and this is the `ℚ`/`ℤ` form
that target's integrality argument consumes. It advances the target rather than merely supplying a
prerequisite: `x.den = 1` is the integrality statement itself, at the point where the rational root
theorem has done its work.

No torsion hypothesis is used and none is claimed: this is the denominator half of the argument,
and nothing here proves anything about `n • P`.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
locally. No `sorry`, no raised heartbeat limits; both proofs are one term each.

## Review history

The local pre-PR pass caught one thing — an earlier shape exported the `Rat.den` transport itself,
a thin lemma with no consumer — and the fix was to export the integrality conclusion instead.

The server's round 1 then returned five findings the local pass had missed, and they were right.
`generality` had the important one: the prime hypothesis was too strong and the statement wanted
to be generic unitness of the denominator, which is what produced `isUnit_den_of_dvd_squarefree`
and, with it, the simplification of the merged theorem described above.
