### PR TITLE
refactor(EllipticCurve): factor the monic-quadratic integrality bookkeeping

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.Polynomial.IsIntegral
+import Mathlib.Tactic.ComputeDegree
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Denominator
 
 /-!
@@ -62,6 +63,28 @@ namespace WeierstrassCurve
 
 variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R)
 
+-- An element satisfying a monic quadratic relation with integral coefficients is integral: this
+-- is `IsIntegral.of_aeval_monic_of_isIntegral_coeff` for `X ^ 2 + C b * X + C c`, with the degree
+-- computation and the per-coefficient obligations discharged. Kept here rather than exported,
+-- since `isIntegral_y_of_equation_of_isIntegral_x` is its only consumer.
+private theorem isIntegral_of_sq_add_mul_add_eq_zero {A : Type*} [CommRing A] [Algebra R A]
+    {b c y : A} (hb : IsIntegral R b) (hc : IsIntegral R c) (h : y ^ 2 + b * y + c = 0) :
+    IsIntegral R y := by
+  nontriviality A
+  have hdeg : (X ^ 2 + (C b * X + C c) : A[X]).natDegree = 2 := by compute_degree!
+  refine IsIntegral.of_aeval_monic_of_isIntegral_coeff (p := X ^ 2 + (C b * X + C c))
+    (monic_X_pow_add (by compute_degree!)) (by omega) ?_ ?_
+  · have : Polynomial.eval y (X ^ 2 + (C b * X + C c) : A[X]) = 0 := by
+      simpa only [eval_add, eval_pow, eval_X, eval_mul, eval_C, add_assoc] using h
+    rw [this]
+    exact isIntegral_zero
+  · intro i
+    match i with
+    | 0 => simpa using hc
+    | 1 => simpa using hb
+    | 2 => simpa using (isIntegral_one : IsIntegral R (1 : A))
+    | (n + 3) => simpa using (isIntegral_zero : IsIntegral R (0 : A))
+
 /-- **An integral `x`-coordinate forces an integral `y`-coordinate**, over any `R`-algebra.
 
 On the curve, `y` is a root of the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)`,
@@ -69,32 +92,17 @@ whose coefficients are polynomial in `x` and so are integral whenever `x` is. No
 fraction-field or factorisation hypothesis is needed, and `x` need not come from `R` itself. -/
 theorem isIntegral_y_of_equation_of_isIntegral_x {A : Type*} [CommRing A] [Algebra R A] {x y : A}
     (h : (W.baseChange A).toAffine.Equation x y) (hx : IsIntegral R x) : IsIntegral R y := by
-  nontriviality A
   rw [_root_.WeierstrassCurve.Affine.equation_iff] at h
   simp only [_root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_a₁,
     _root_.WeierstrassCurve.map_a₂, _root_.WeierstrassCurve.map_a₃,
     _root_.WeierstrassCurve.map_a₄, _root_.WeierstrassCurve.map_a₆] at h
-  set b : A := algebraMap R A W.a₁ * x + algebraMap R A W.a₃ with hb
-  set c : A := -(x ^ 3 + algebraMap R A W.a₂ * x ^ 2 + algebraMap R A W.a₄ * x
-    + algebraMap R A W.a₆) with hc
-  have hbI : IsIntegral R b := (isIntegral_algebraMap.mul hx).add isIntegral_algebraMap
-  have hcI : IsIntegral R c :=
-    (((hx.pow 3).add (isIntegral_algebraMap.mul (hx.pow 2))).add
-      (isIntegral_algebraMap.mul hx)).add isIntegral_algebraMap |>.neg
-  have hdeg : (X ^ 2 + (C b * X + C c) : A[X]).natDegree = 2 := by compute_degree!
-  refine IsIntegral.of_aeval_monic_of_isIntegral_coeff
-    (p := X ^ 2 + (C b * X + C c)) (monic_X_pow_add (by compute_degree!)) (by omega) ?_ ?_
-  · have heval : Polynomial.eval y (X ^ 2 + (C b * X + C c) : A[X]) = 0 := by
-      simp only [eval_add, eval_pow, eval_X, eval_mul, eval_C, hb, hc]
-      linear_combination h
-    rw [heval]
-    exact isIntegral_zero
-  · intro i
-    match i with
-    | 0 => simpa using hcI
-    | 1 => simpa using hbI
-    | 2 => simpa using (isIntegral_one : IsIntegral R (1 : A))
-    | (n + 3) => simpa using (isIntegral_zero : IsIntegral R (0 : A))
+  refine isIntegral_of_sq_add_mul_add_eq_zero
+    (b := algebraMap R A W.a₁ * x + algebraMap R A W.a₃)
+    (c := -(x ^ 3 + algebraMap R A W.a₂ * x ^ 2 + algebraMap R A W.a₄ * x + algebraMap R A W.a₆))
+    ((isIntegral_algebraMap.mul hx).add isIntegral_algebraMap)
+    ((((hx.pow 3).add (isIntegral_algebraMap.mul (hx.pow 2))).add
+      (isIntegral_algebraMap.mul hx)).add isIntegral_algebraMap).neg ?_
+  linear_combination h
 
 section FractionField
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"integral-quadratic"}-->

Roadmap: EllipticCurves

A single-file refactor of merged code. `isIntegral_y_of_equation_of_isIntegral_x`
(`TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean`) goes from **43 lines to 11**; the
public API is unchanged and no new declaration is exported.

## What changed

The theorem applied Mathlib's `IsIntegral.of_aeval_monic_of_isIntegral_coeff` inline, which meant
naming the polynomial `X ^ 2 + (C b * X + C c)`, computing its degree, and discharging integrality
of every coefficient by index (`match i with | 0 | 1 | 2 | n + 3`). None of that is
elliptic-curve content, and it was the bulk of the proof.

It now goes through a private helper stating the underlying fact once —

```lean
private theorem isIntegral_of_sq_add_mul_add_eq_zero {A : Type*} [CommRing A] [Algebra R A]
    {b c y : A} (hb : IsIntegral R b) (hc : IsIntegral R c) (h : y ^ 2 + b * y + c = 0) :
    IsIntegral R y
```

— leaving the curve theorem to say only what is about curves: rewrite the Weierstrass equation,
identify `b` and `c`, and close with `linear_combination`.

## Why it is private

Mathlib has the general monic-polynomial statement but not the quadratic one — checked by a
compiled probe rather than by grep: with `hb`, `hc` and `h : y ^ 2 + b * y + c = 0` in context,
`exact? ` fails to produce `IsIntegral R y`. An earlier revision of this PR therefore exported the
quadratic criterion from a new `TauCeti/RingTheory/IntegralClosure/Quadratic.lean`. The local
`reuse` review objected that a public special case of Mathlib's generic theorem with a single
consumer is a parallel API, and asked for it to be a private helper beside that consumer instead.
That is what is here; the helper carries a comment recording the reason.

## Scope

No roadmap claim is made and none is needed: `CLAUDE.md` states that improving existing code is
"always in scope and needs no roadmap entry: refactoring, simplifying proofs, fixing or modestly
generalising an existing lemma, relocating a misplaced declaration, adopting a cleaner idiom".
This is a proof simplification of a merged theorem, with no change to any statement. The
`Roadmap:` line above is attribution: the file it touches belongs to the Nagell–Lutz integrality
strand of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
locally. No `sorry`, no raised heartbeat limits.

## Local review

Run before opening. `reuse` returned `request_changes` on the exported-lemma revision described
above and approves this one; `api-design`, `naming`, `placement` and `scope` approve.
