### PR TITLE
refactor(Crosscut): extract the increment bound behind the arc modulus

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
 public import TauCeti.Analysis.Complex.Conformal.LengthArea
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
+import TauCeti.MeasureTheory.Integral.DominatedIncrement
 import TauCeti.Topology.Circle.Metric
 
 /-!
@@ -35,10 +36,17 @@ The engine is the chord bound of `Conformal/LengthArea.lean` in its primitive, s
 `TauCeti.ofReal_dist_le_mul_lintegral_Ioc`: the images of the endpoints of an arc of angles are at
 distance at most `|ρ|` times the angular integral of `‖deriv f‖` over *that* arc. Applied to a
 sub-arc, it says that the oscillation of `f` along a piece of the circle is controlled by the length
-carried by that piece alone. Since the total length is finite, Mathlib's absolute continuity of the
-integral (`MeasureTheory.exists_pos_setLIntegral_lt_of_measure_lt`) makes the length carried by a
-short sub-arc uniformly small: that is `TauCeti.exists_pos_forall_dist_le_of_lintegral_ne_top`, a
-modulus of continuity for `f` along the arc, in the angular parameter.
+carried by that piece alone — in the vocabulary of
+`TauCeti/MeasureTheory/Integral/DominatedIncrement.lean`, that the increments of
+`f ∘ circleMap ζ ρ` are *dominated* by the angular length density
+`θ ↦ |ρ| * ‖deriv f (circleMap ζ ρ θ)‖ₑ`. Neither of the two conclusions drawn from that
+domination sees the circle: a map on an order-connected subset of `ℝ` whose increments are
+dominated by a density of finite total integral has bounded image and is uniformly continuous, the
+latter by absolute continuity of the integral. Both are proved there, at that generality, and the
+two statements below are their instances at the arc —
+`TauCeti.exists_pos_forall_dist_le_of_lintegral_ne_top`, a modulus of continuity for `f` along the
+arc in the angular parameter, and
+`TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`.
 
 Turning the angular modulus into a statement about the plane needs the chord formula
 `TauCeti.dist_circleMap_eq_two_mul_sin_abs`: on an arc of angular width below a full turn the chord
@@ -148,16 +156,41 @@ private lemma ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo (hUo : IsOpen U)
   ofReal_dist_le_mul_lintegral_Ioc hUo hf ζ hle fun _ hθ =>
     hmemU _ ⟨h₁.1.trans_le hθ.1, hθ.2.trans_lt h₂.2⟩
 
+/-- The chord bound in the form the increment estimates of
+`TauCeti/MeasureTheory/Integral/DominatedIncrement.lean` consume: along an arc of angles on which
+`f` is holomorphic, the increments of `f ∘ circleMap ζ ρ` are dominated by the *angular length
+density* `θ ↦ |ρ| * ‖deriv f (circleMap ζ ρ θ)‖ₑ`, whose integral over a sub-arc is the length of
+the image of that sub-arc. Moving the constant `|ρ|` inside the integral is all that separates the
+two forms. -/
+private lemma edist_le_setLIntegral_enorm_deriv_circleMap (hUo : IsOpen U)
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} {a b : ℝ}
+    (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U) :
+    ∀ θ₁ ∈ Ioo a b, ∀ θ₂ ∈ Ioo a b, θ₁ ≤ θ₂ →
+      edist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂)) ≤
+        ∫⁻ θ in Ioc θ₁ θ₂, ENNReal.ofReal |ρ| * ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
+  intro θ₁ h₁ θ₂ h₂ hle
+  rw [edist_dist, lintegral_const_mul' _ _ ENNReal.ofReal_ne_top]
+  exact ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo hUo hf ζ hmemU h₁ h₂ hle
+
+/-- An arc of finite image length carries a finite integral of the angular length density: the two
+differ by the finite factor `|ρ|`. -/
+private lemma setLIntegral_enorm_deriv_circleMap_ne_top {ρ : ℝ} {a b : ℝ}
+    (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
+    (∫⁻ θ in Ioo a b, ENNReal.ofReal |ρ| * ‖deriv f (circleMap ζ ρ θ)‖ₑ) ≠ ⊤ := by
+  rw [lintegral_const_mul' _ _ ENNReal.ofReal_ne_top]
+  exact ENNReal.mul_ne_top ENNReal.ofReal_ne_top hfin
+
 /-- **A modulus of continuity along an arc of finite image length.** If `f` is holomorphic on an
 open set containing the piece of the circle of radius `ρ` about `ζ` cut out by the angles `Ioo a b`,
 and the angular integral of `‖deriv f‖` over that arc is finite, then for every tolerance `ε > 0`
 there is an angular gap `η > 0` within which the images of two angles of the arc stay `ε` apart.
 
 The gap is uniform over the arc, and in particular does not shrink as an end of the arc is
-approached: that is the whole content, and it comes from the absolute continuity of the integral,
-`MeasureTheory.exists_pos_setLIntegral_lt_of_measure_lt`. A short sub-arc carries little length,
-and by the chord bound `TauCeti.ofReal_dist_le_mul_lintegral_Ioc` the length a sub-arc carries
-bounds the distance between the images of its two ends.
+approached: that is the whole content. A short sub-arc carries little length, and by the chord
+bound `TauCeti.ofReal_dist_le_mul_lintegral_Ioc` the length a sub-arc carries bounds the distance
+between the images of its two ends; that is the domination hypothesis of
+`TauCeti.uniformContinuousOn_of_edist_le_setLIntegral`, which draws the modulus from the absolute
+continuity of the integral and knows nothing of circles.
 
 Uniform continuity in the angle is *not* uniform continuity of `f` on the arc as a subset of the
 plane, but on an arc of angular width below a full turn the two agree, which is what
@@ -171,50 +204,17 @@ theorem exists_pos_forall_dist_le_of_lintegral_ne_top (hUo : IsOpen U)
     (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) {ε : ℝ} (hε : 0 < ε) :
     ∃ η > 0, ∀ θ₁ ∈ Ioo a b, ∀ θ₂ ∈ Ioo a b, |θ₁ - θ₂| ≤ η →
       dist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂)) ≤ ε := by
-  -- a circle of radius `0` is the single point `ζ`, where every distance in sight vanishes
-  rcases eq_or_ne ρ 0 with rfl | hρ
-  · exact ⟨1, one_pos, fun _ _ _ _ _ => by simp [hε.le]⟩
-  have hρpos : 0 < |ρ| := abs_pos.mpr hρ
-  have hρ0 : ENNReal.ofReal |ρ| ≠ 0 := (ENNReal.ofReal_pos.mpr hρpos).ne'
-  have hcne : ENNReal.ofReal (ε / |ρ|) ≠ 0 := (ENNReal.ofReal_pos.mpr (div_pos hε hρpos)).ne'
-  obtain ⟨δ, hδ, hδlt⟩ :=
-    exists_pos_setLIntegral_lt_of_measure_lt (μ := volume.restrict (Ioo a b)) hfin hcne
-  obtain ⟨d, hd0, hdδ⟩ := exists_between hδ
-  have hdtop : d ≠ ⊤ := (hdδ.trans_le le_top).ne
-  -- the estimate for a pair of angles in increasing order
-  have key : ∀ θ₁ ∈ Ioo a b, ∀ θ₂ ∈ Ioo a b, θ₁ ≤ θ₂ → θ₂ - θ₁ ≤ d.toReal →
-      dist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂)) ≤ ε := by
-    intro θ₁ h₁ θ₂ h₂ hle hgap
-    have hsub : Ioc θ₁ θ₂ ⊆ Ioo a b := fun θ hθ => ⟨h₁.1.trans hθ.1, hθ.2.trans_lt h₂.2⟩
-    have hmeas : (volume.restrict (Ioo a b)) (Ioc θ₁ θ₂) < δ := by
-      refine lt_of_le_of_lt ((Measure.restrict_apply_le _ _).trans ?_) hdδ
-      rw [Real.volume_Ioc, ← ENNReal.ofReal_toReal hdtop]
-      exact ENNReal.ofReal_le_ofReal hgap
-    have hres : (volume.restrict (Ioo a b)).restrict (Ioc θ₁ θ₂) = volume.restrict (Ioc θ₁ θ₂) := by
-      rw [Measure.restrict_restrict measurableSet_Ioc, inter_eq_self_of_subset_left hsub]
-    have hlt : ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ < ENNReal.ofReal (ε / |ρ|) := by
-      have hbound := hδlt (Ioc θ₁ θ₂) hmeas
-      rwa [hres] at hbound
-    have hmul : ENNReal.ofReal |ρ| * ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ
-        < ENNReal.ofReal ε := by
-      refine (ENNReal.mul_lt_mul_right hρ0 ENNReal.ofReal_ne_top hlt).trans_eq ?_
-      rw [← ENNReal.ofReal_mul (abs_nonneg ρ)]
-      congr 1
-      field_simp
-    exact ((ENNReal.ofReal_lt_ofReal_iff hε).mp
-      ((ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo hUo hf ζ hmemU h₁ h₂ hle).trans_lt
-        hmul)).le
-  refine ⟨d.toReal, ENNReal.toReal_pos hd0.ne' hdtop, fun θ₁ h₁ θ₂ h₂ habs => ?_⟩
-  rcases le_total θ₁ θ₂ with hle | hle
-  · rw [abs_sub_comm, abs_of_nonneg (sub_nonneg.mpr hle)] at habs
-    exact key θ₁ h₁ θ₂ h₂ hle habs
-  · rw [abs_of_nonneg (sub_nonneg.mpr hle)] at habs
-    rw [dist_comm]
-    exact key θ₂ h₂ θ₁ h₁ hle habs
+  have huc : UniformContinuousOn (fun θ => f (circleMap ζ ρ θ)) (Ioo a b) :=
+    uniformContinuousOn_of_edist_le_setLIntegral ordConnected_Ioo
+      (edist_le_setLIntegral_enorm_deriv_circleMap hUo hf ζ hmemU)
+      (setLIntegral_enorm_deriv_circleMap_ne_top hfin)
+  obtain ⟨η, hη, hmod⟩ := Metric.uniformContinuousOn_iff_le.1 huc ε hε
+  exact ⟨η, hη, fun θ₁ h₁ θ₂ h₂ habs => hmod θ₁ h₁ θ₂ h₂ (by rwa [Real.dist_eq])⟩
 
 /-- **An arc of finite image length has bounded image.** The chord bound applied to the whole arc
-rather than to a sub-arc: any two of its points have images at distance at most
-`|ρ| * ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ`, a finite number.
+rather than to a sub-arc: by `TauCeti.isBounded_image_of_edist_le_setLIntegral` any two of its
+points have images at distance at most `|ρ| * ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ`, a
+finite number.
 
 This is what makes a subsingleton cluster set along the arc an honest limit, the compactness input
 of `TauCeti.exists_tendsto_of_clusterSetOn_subsingleton`. -/
@@ -223,24 +223,10 @@ theorem isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top (hUo : IsOpen U)
     (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
     (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
     IsBounded (f '' (circleMap ζ ρ '' Ioo a b)) := by
-  set L : ℝ≥0∞ := ENNReal.ofReal |ρ| * ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ with hL
-  have hLtop : L ≠ ⊤ := by
-    rw [hL]
-    exact ENNReal.mul_ne_top ENNReal.ofReal_ne_top hfin
-  have key : ∀ θ₁ ∈ Ioo a b, ∀ θ₂ ∈ Ioo a b, θ₁ ≤ θ₂ →
-      dist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂)) ≤ L.toReal := by
-    intro θ₁ h₁ θ₂ h₂ hle
-    refine (ENNReal.ofReal_le_iff_le_toReal hLtop).mp ?_
-    refine (ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo hUo hf ζ hmemU h₁ h₂ hle).trans ?_
-    rw [hL]
-    gcongr
-    exact fun θ hθ => ⟨h₁.1.trans hθ.1, hθ.2.trans_lt h₂.2⟩
-  rw [image_image, Metric.isBounded_image_iff]
-  refine ⟨L.toReal, fun θ₁ h₁ θ₂ h₂ => ?_⟩
-  rcases le_total θ₁ θ₂ with hle | hle
-  · exact key θ₁ h₁ θ₂ h₂ hle
-  · rw [dist_comm]
-    exact key θ₂ h₂ θ₁ h₁ hle
+  rw [image_image]
+  exact isBounded_image_of_edist_le_setLIntegral ordConnected_Ioo
+    (edist_le_setLIntegral_enorm_deriv_circleMap hUo hf ζ hmemU)
+    (setLIntegral_enorm_deriv_circleMap_ne_top hfin)
 
 /-! ## The cluster sets of an arc of finite image length -/
 

--- a/TauCeti/MeasureTheory/Integral/DominatedIncrement.lean
+++ b/TauCeti/MeasureTheory/Integral/DominatedIncrement.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+public import Mathlib.Topology.MetricSpace.Bounded
+
+/-!
+# Maps of the line whose increments are dominated by a density
+
+A map `g` defined on a set `s ⊆ ℝ` is said here to have its **increments dominated** by a density
+`φ : ℝ → ℝ≥0∞` when
+
+> `edist (g x) (g y) ≤ ∫⁻ t in Ioc x y, φ t` for all `x ≤ y` in `s`.
+
+This is the conclusion the fundamental theorem of calculus delivers for a `C¹` map, with
+`φ = ‖deriv g‖ₑ`; it is also the conclusion the chord bound of the length–area method delivers for
+a holomorphic map restricted to a circular arc, with `φ` the angular length density
+(`TauCeti.ofReal_dist_le_mul_lintegral_Ioc` in `Analysis/Complex/Conformal/LengthArea.lean`). What
+this file records is that, on an order-connected `s` and for a density of **finite total
+integral**, the domination alone forces two things:
+
+* `g` has **bounded range** — indeed `Metric.ediam (g '' s) ≤ ∫⁻ t in s, φ t`, with no finiteness
+  hypothesis at all (`TauCeti.ediam_image_le_of_edist_le_setLIntegral`); and
+* `g` is **uniformly continuous** on `s`
+  (`TauCeti.uniformContinuousOn_of_edist_le_setLIntegral`).
+
+The second is the one with content, and it is the one that does not follow from bounded variation:
+domination by a *finite* integral is an absolute-continuity statement, and the modulus of continuity
+it yields comes from `MeasureTheory.exists_pos_setLIntegral_lt_of_measure_lt` — a short subinterval
+carries little of the total integral, uniformly in where it sits. Nothing here needs `s` to be an
+interval, only order-connected, so a half-line and the whole line are covered along with `Ioo a b`;
+and nothing needs `φ` to be measurable, the integrals being lower integrals throughout.
+
+## Why uniform continuity is the right conclusion
+
+Uniform continuity is what a boundary-limit argument spends: on a complete target it turns the
+Cauchy criterion at an endpoint of `s` into an honest limit there, so a map dominated by a density
+of finite integral over `Ioo a b` extends continuously to `Icc a b`. The two statements below are
+therefore stated in the packaged `UniformContinuousOn` / `Metric.ediam` vocabulary rather than in
+`ε`–`δ` form; `Metric.uniformContinuousOn_iff_le` unpacks the first for a consumer that wants an
+explicit modulus, and `Metric.isBounded_iff_ediam_ne_top` the second.
+
+The target is an arbitrary pseudo-metric space: the domination hypothesis is a statement about
+`edist`, and neither conclusion sees any linear structure. The domain is `ℝ` with Lebesgue measure,
+which is where `Ioc x y` and its measure `ENNReal.ofReal (y - x)` — the two things the modulus
+argument uses — live.
+
+## Main results
+
+* `TauCeti.ediam_image_le_of_edist_le_setLIntegral` — the image of an order-connected `s` under a
+  map whose increments are dominated by `φ` has diameter at most `∫⁻ t in s, φ t`.
+* `TauCeti.isBounded_image_of_edist_le_setLIntegral` — hence that image is bounded as soon as the
+  total integral is finite.
+* `TauCeti.uniformContinuousOn_of_edist_le_setLIntegral` — and the map is uniformly continuous on
+  `s`, by absolute continuity of the integral.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Set
+open scoped ENNReal
+
+variable {X : Type*} [PseudoMetricSpace X] {g : ℝ → X} {φ : ℝ → ℝ≥0∞} {s : Set ℝ}
+
+/-- **The increments of `g` are dominated over all of `s`, not merely over subintervals.** On an
+order-connected `s` the interval `Ioc x y` spanned by two of its points is again inside `s`, so the
+domination hypothesis, stated for increasing pairs, extends to all pairs and to the total integral.
+
+This is the whole of the order-connectedness hypothesis: it is what lets a bound over a subinterval
+be compared with the total integral. -/
+private lemma edist_le_setLIntegral (hs : s.OrdConnected)
+    (hdom : ∀ x ∈ s, ∀ y ∈ s, x ≤ y → edist (g x) (g y) ≤ ∫⁻ t in Ioc x y, φ t)
+    {x : ℝ} (hx : x ∈ s) {y : ℝ} (hy : y ∈ s) :
+    edist (g x) (g y) ≤ ∫⁻ t in s, φ t := by
+  have key : ∀ u ∈ s, ∀ v ∈ s, u ≤ v → edist (g u) (g v) ≤ ∫⁻ t in s, φ t := fun u hu v hv huv =>
+    (hdom u hu v hv huv).trans
+      (lintegral_mono_set (Ioc_subset_Icc_self.trans (hs.out hu hv)))
+  rcases le_total x y with hxy | hxy
+  · exact key x hx y hy hxy
+  · rw [edist_comm]
+    exact key y hy x hx hxy
+
+/-- **A map whose increments are dominated by `φ` has image of diameter at most the total integral
+of `φ`.** For an order-connected `s ⊆ ℝ` and a map `g` with
+`edist (g x) (g y) ≤ ∫⁻ t in Ioc x y, φ t` for every increasing pair in `s`, the image `g '' s` has
+`Metric.ediam` at most `∫⁻ t in s, φ t`.
+
+No finiteness is assumed: the statement is in `ℝ≥0∞` and is vacuously true when the total integral
+is infinite. Read for `φ = ‖deriv g‖ₑ` it is the statement that a curve is no wider than it is
+long. -/
+theorem ediam_image_le_of_edist_le_setLIntegral (hs : s.OrdConnected)
+    (hdom : ∀ x ∈ s, ∀ y ∈ s, x ≤ y → edist (g x) (g y) ≤ ∫⁻ t in Ioc x y, φ t) :
+    Metric.ediam (g '' s) ≤ ∫⁻ t in s, φ t := by
+  refine Metric.ediam_le ?_
+  rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩
+  exact edist_le_setLIntegral hs hdom hx hy
+
+/-- **A map whose increments are dominated by a density of finite integral has bounded image.**
+The finiteness form of `TauCeti.ediam_image_le_of_edist_le_setLIntegral`, and the form a
+compactness argument consumes: an unbounded set carries the junk value `0` for `Metric.diam`, so
+boundedness is what makes a real-valued diameter bound meaningful. -/
+theorem isBounded_image_of_edist_le_setLIntegral (hs : s.OrdConnected)
+    (hdom : ∀ x ∈ s, ∀ y ∈ s, x ≤ y → edist (g x) (g y) ≤ ∫⁻ t in Ioc x y, φ t)
+    (hfin : (∫⁻ t in s, φ t) ≠ ⊤) :
+    Bornology.IsBounded (g '' s) :=
+  Metric.isBounded_iff_ediam_ne_top.2
+    (ne_top_of_le_ne_top hfin (ediam_image_le_of_edist_le_setLIntegral hs hdom))
+
+/-- **A map whose increments are dominated by a density of finite integral is uniformly
+continuous.** For an order-connected `s ⊆ ℝ` and a map `g` with
+`edist (g x) (g y) ≤ ∫⁻ t in Ioc x y, φ t` for every increasing pair in `s`, finiteness of
+`∫⁻ t in s, φ t` makes `g` uniformly continuous on `s`.
+
+The modulus is uniform over `s` — in particular it does not degrade as an endpoint of `s` is
+approached, which is the whole content — and it comes from the absolute continuity of the integral,
+`MeasureTheory.exists_pos_setLIntegral_lt_of_measure_lt`: a subinterval short enough carries less
+than `ENNReal.ofReal ε` of the total, wherever in `s` it sits, and by hypothesis the amount a
+subinterval carries bounds the increment across it.
+
+Absolute continuity is the exact input. Domination by a density that is merely *integrable over
+compacts* would give continuity but no uniform modulus, and a bound on the total variation alone
+would give neither: a monotone jump function has bounded variation and is not uniformly
+continuous. -/
+theorem uniformContinuousOn_of_edist_le_setLIntegral (hs : s.OrdConnected)
+    (hdom : ∀ x ∈ s, ∀ y ∈ s, x ≤ y → edist (g x) (g y) ≤ ∫⁻ t in Ioc x y, φ t)
+    (hfin : (∫⁻ t in s, φ t) ≠ ⊤) :
+    UniformContinuousOn g s := by
+  rw [Metric.uniformContinuousOn_iff_le]
+  intro ε hε
+  obtain ⟨δ, hδ, hδlt⟩ := exists_pos_setLIntegral_lt_of_measure_lt
+    (μ := volume.restrict s) (f := φ) hfin (ENNReal.ofReal_pos.mpr hε).ne'
+  -- a finite gauge below `δ`, so that a real-valued length may be compared with it
+  obtain ⟨d, hd0, hdδ⟩ := exists_between hδ
+  have hdtop : d ≠ ⊤ := (hdδ.trans_le le_top).ne
+  -- the estimate for a pair in increasing order
+  have key : ∀ x ∈ s, ∀ y ∈ s, x ≤ y → y - x ≤ d.toReal → dist (g x) (g y) ≤ ε := by
+    intro x hx y hy hxy hgap
+    have hsub : Ioc x y ⊆ s := Ioc_subset_Icc_self.trans (hs.out hx hy)
+    have hmeas : (volume.restrict s) (Ioc x y) < δ := by
+      refine lt_of_le_of_lt ((Measure.restrict_apply_le _ _).trans ?_) hdδ
+      rw [Real.volume_Ioc, ← ENNReal.ofReal_toReal hdtop]
+      exact ENNReal.ofReal_le_ofReal hgap
+    have hres : (volume.restrict s).restrict (Ioc x y) = volume.restrict (Ioc x y) := by
+      rw [Measure.restrict_restrict measurableSet_Ioc, inter_eq_self_of_subset_left hsub]
+    have hlt : ∫⁻ t in Ioc x y, φ t < ENNReal.ofReal ε := by
+      have hbound := hδlt (Ioc x y) hmeas
+      rwa [hres] at hbound
+    have hedist := (hdom x hx y hy hxy).trans_lt hlt
+    rw [edist_dist] at hedist
+    exact ((ENNReal.ofReal_lt_ofReal_iff hε).mp hedist).le
+  refine ⟨d.toReal, ENNReal.toReal_pos hd0.ne' hdtop, fun x hx y hy hxy => ?_⟩
+  rw [Real.dist_eq] at hxy
+  rcases le_total x y with hle | hle
+  · refine key x hx y hy hle ?_
+    rw [abs_of_nonpos (by linarith)] at hxy
+    linarith
+  · rw [dist_comm]
+    refine key y hy x hx hle ?_
+    rw [abs_of_nonneg (by linarith)] at hxy
+    linarith
+
+end TauCeti


### PR DESCRIPTION
This PR extracts the one-dimensional core of `Conformal/Crosscut/EndpointLimit.lean` into a new file `TauCeti/MeasureTheory/Integral/DominatedIncrement.lean`, at the generality at which it holds, and reproves the two circle statements from it. Say that a map `g` of a set `s ⊆ ℝ` into a pseudo-metric space has its **increments dominated** by a density `φ : ℝ → ℝ≥0∞` when `edist (g x) (g y) ≤ ∫⁻ t in Ioc x y, φ t` for every `x ≤ y` in `s`. On an order-connected `s` that alone gives `Metric.ediam (g '' s) ≤ ∫⁻ t in s, φ t` (`TauCeti.ediam_image_le_of_edist_le_setLIntegral`), with no finiteness hypothesis at all; and when the total integral is finite it gives a bounded image (`TauCeti.isBounded_image_of_edist_le_setLIntegral`) together with `UniformContinuousOn g s` (`TauCeti.uniformContinuousOn_of_edist_le_setLIntegral`), the latter by the absolute continuity of the integral, `MeasureTheory.exists_pos_setLIntegral_lt_of_measure_lt`. Neither conclusion sees a circle, a complex derivative, or any linear structure on the target.

`TauCeti.exists_pos_forall_dist_le_of_lintegral_ne_top` and `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top` keep their names, signatures and docstrings and become the instances of those statements at `s = Ioo a b` and `φ θ = |ρ| * ‖deriv f (circleMap ζ ρ θ)‖ₑ`, the domination hypothesis being the chord bound `TauCeti.ofReal_dist_le_mul_lintegral_Ioc` of `Conformal/LengthArea.lean` with the constant moved inside the integral. Two private lemmas in `EndpointLimit.lean` perform that move. Nothing else in the file changes, and no declaration is renamed, deleted or weakened. The special case `ρ = 0` that the old modulus argument carried disappears along with the division by `|ρ|` that forced it: with the factor inside the density there is nothing to divide by.

The motivating roadmap is `TauCetiRoadmap/ConformalMapping/README.md`, layer **L5** (Carathéodory boundary correspondence, Jordan-domain case): `EndpointLimit.lean` is the file that degenerates the ends of an image crosscut of finite length to points, and the modulus extracted here is what its Cauchy criterion runs on. This is a refactor of already-merged code rather than new mathematics, so it claims no new roadmap target; per `.claude/CLAUDE.md` improving existing code is in scope without one, and the attribution line below names the roadmap chiefly motivating it.

The extracted statements are checked against the pinned Mathlib and are not there. Mathlib has the absolute-continuity input `MeasureTheory.exists_pos_setLIntegral_lt_of_measure_lt` and, separately, `BoundedVariationOn.exists_tendsto_left` / `exists_tendsto_right`; but bounded variation gives one-sided limits without a uniform modulus — a monotone jump function is the counterexample — and there is no lemma relating `eVariationOn` to `∫⁻ ‖deriv‖`, so neither route supplies what is proved here. No Mathlib source is vendored.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"uniformcontinuouson-of-edist-le-setlintegral"}-->

🤖 Prepared with Claude Code
