### PR TITLE
feat: the distinct-end case of an image crosscut

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Arc.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Arc.lean
@@ -6,9 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Path
-public import TauCeti.Topology.JordanCurve.Path
+public import TauCeti.Topology.JordanCurve.Basic
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
+import TauCeti.Topology.JordanCurve.Path
 
 /-!
 # The distinct-end case of an image crosscut
@@ -47,9 +48,9 @@ subsingleton says exactly `u ≠ v`.
 The point of producing an arc is that an arc can be closed into a Jordan curve. Any arc `B` of the
 image boundary running between the same two ends meets the closed image crosscut only there —
 `B` lies in `frontier (f '' ball c r)`, so the intersection lies in the boundary piece `{u, v}` —
-and `TauCeti.isJordanCurve_union_range_of_inter_eq_pair` glues the two arcs along those two points.
-That is
-`TauCeti.exists_forall_isJordanCurve_union_closure_image_ball_inter_sphere_of_not_subsingleton`.
+and `TauCeti.isJordanCurve_range_union_range_of_inter_eq_pair` glues the two arcs along those two
+points. That is
+`exists_forall_isJordanCurve_closure_image_ball_inter_sphere_union_range_of_not_subsingleton`.
 
 Which arc of the boundary to take, and which of the two pieces the crosscut cuts the domain into is
 enclosed by the resulting Jordan curve, is a planar separation question and is not settled here; the
@@ -61,7 +62,7 @@ about the region the curve encloses.
 * `TauCeti.exists_injective_path_range_eq_closure_image_ball_inter_sphere_of_not_subsingleton` —
   a finite-length image crosscut meeting the image boundary in more than one point closes to an
   arc, whose two endpoints are exactly the two points of that meeting.
-* `TauCeti.exists_forall_isJordanCurve_union_closure_image_ball_inter_sphere_of_not_subsingleton` —
+* `exists_forall_isJordanCurve_closure_image_ball_inter_sphere_union_range_of_not_subsingleton` —
   that arc together with any arc of the image boundary joining its two ends is a Jordan curve.
 
 ## Roadmap role
@@ -187,13 +188,13 @@ is a Jordan curve.
 The two arcs meet exactly in `{u, v}`: an intersection point lies on the image boundary because it
 lies on `range δ`, and on the closed image crosscut because it lies on the other arc, so it lies in
 the boundary piece; conversely `u` and `v` are endpoints of both. That is precisely the hypothesis
-of `TauCeti.isJordanCurve_union_range_of_inter_eq_pair`.
+of `TauCeti.isJordanCurve_range_union_range_of_inter_eq_pair`.
 
 Nothing is claimed about which of the two arcs the image boundary is cut into by `u` and `v` should
 be used, nor about the region the resulting Jordan curve encloses: both are planar separation
 questions. What the statement supplies is that whichever arc a separation argument selects, the
 closed curve it produces is a Jordan curve. -/
-theorem exists_forall_isJordanCurve_union_closure_image_ball_inter_sphere_of_not_subsingleton
+theorem exists_forall_isJordanCurve_closure_image_ball_inter_sphere_union_range_of_not_subsingleton
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
     (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤)
@@ -208,7 +209,7 @@ theorem exists_forall_isJordanCurve_union_closure_image_ball_inter_sphere_of_not
       hf hinj hfin hends
   refine ⟨u, v, huv, hpair, fun δ hδinj hδsub => ?_⟩
   rw [← hγrange]
-  refine isJordanCurve_union_range_of_inter_eq_pair hγinj hδinj (subset_antisymm ?_ ?_)
+  refine isJordanCurve_range_union_range_of_inter_eq_pair hγinj hδinj (subset_antisymm ?_ ?_)
   · rintro w ⟨hwγ, hwδ⟩
     exact hpair ▸ ⟨hδsub hwδ, hγrange ▸ hwγ⟩
   · intro w hw

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Arc.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Arc.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.Crosscut.Path
+public import TauCeti.Topology.JordanCurve.Path
+import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
+import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
+
+/-!
+# The distinct-end case of an image crosscut
+
+A genuine circular crosscut of a disc is carried by a conformal map to a simple open arc in the
+image domain, and when its image has finite length
+`TauCeti.exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn` packages the closure of
+that arc as a path whose only possible repetition is a common value of its two endpoints.
+`Conformal/Crosscut/Jordan.lean` settles the branch in which that repetition happens — the two ends
+coincide and the closed image crosscut is a Jordan curve. This file settles the other branch.
+
+If the closed image crosscut meets the boundary of the image domain in more than one point, the
+path has no repetition at all: it is injective, so the closed image crosscut is an **arc**, the
+range of an injective path, and its two endpoints are precisely the two points where it meets
+`frontier (f '' ball c r)`
+(`TauCeti.exists_injective_path_range_eq_closure_image_ball_inter_sphere_of_not_subsingleton`).
+The hypothesis is the exact negation of the one `Conformal/Crosscut/Jordan.lean` runs on, so
+between them the two files describe the closed image crosscut in every case.
+
+## Which two points the arc ends at
+
+`Conformal/Crosscut/BoundaryEnds.lean` already knows that the boundary piece
+`frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))` is a pair, but it does not say
+which pair, and that is exactly what is needed here: the hypothesis on the boundary piece has to be
+converted into a statement about the *path*. The identification comes from
+`TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn`, which writes the
+boundary piece as the union of the cluster sets of `f` over `sphere c r ∩ sphere ζ ρ` — the two
+angular ends of the crosscut, by `TauCeti.sphere_inter_sphere_eq_pair_circleMap` — together with
+the two endpoint limits the path theorem hands out, which
+`TauCeti.clusterSetOn_eq_singleton_of_tendsto` turns into those cluster sets. So the boundary piece
+is `{u, v}` for `u` and `v` the endpoints of the path, and the hypothesis that it is not a
+subsingleton says exactly `u ≠ v`.
+
+## Closing the arc up
+
+The point of producing an arc is that an arc can be closed into a Jordan curve. Any arc `B` of the
+image boundary running between the same two ends meets the closed image crosscut only there —
+`B` lies in `frontier (f '' ball c r)`, so the intersection lies in the boundary piece `{u, v}` —
+and `TauCeti.isJordanCurve_union_range_of_inter_eq_pair` glues the two arcs along those two points.
+That is
+`TauCeti.exists_forall_isJordanCurve_union_closure_image_ball_inter_sphere_of_not_subsingleton`.
+
+Which arc of the boundary to take, and which of the two pieces the crosscut cuts the domain into is
+enclosed by the resulting Jordan curve, is a planar separation question and is not settled here; the
+statement below is deliberately universally quantified over the boundary arc, and asserts nothing
+about the region the curve encloses.
+
+## Main results
+
+* `TauCeti.exists_injective_path_range_eq_closure_image_ball_inter_sphere_of_not_subsingleton` —
+  a finite-length image crosscut meeting the image boundary in more than one point closes to an
+  arc, whose two endpoints are exactly the two points of that meeting.
+* `TauCeti.exists_forall_isJordanCurve_union_closure_image_ball_inter_sphere_of_not_subsingleton` —
+  that arc together with any arc of the image boundary joining its two ends is a Jordan curve.
+
+## Roadmap role
+
+This advances layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, the Jordan-domain case of
+the Carathéodory boundary correspondence. `Conformal/Crosscut/Jordan.lean` names the remaining step
+as "treat the Jordan curve produced here when the ends coincide, and join the crosscut to one of the
+two boundary arcs when they are distinct, in order to bound the whole boundary of the cut-off image
+piece". The second half of that — the joining — is what is done here; the boundary arcs themselves
+come from `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le` of
+`TauCeti/Topology/JordanCurve/SmallArc.lean`, and are small because the two ends are close by
+`TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le_of_isBounded`. What
+remains after this file is the separation argument choosing between the two boundary arcs.
+
+## Coordination with upstream Mathlib
+
+Layer L5 is absent from
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
+human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and the
+pinned Mathlib has no boundary correspondence for conformal maps and no Jordan-curve vocabulary. So
+this file is new Lean formalization rather than a temporary shim. Through
+`Conformal/Crosscut/Image.lean` it consumes the L0–L3 shim
+`TauCeti.isOpen_image_of_differentiableOn_of_injOn`, to be refactored onto Mathlib's open mapping
+API once the upstream work lands. No Mathlib source is vendored.
+
+## References
+
+* C. Carathéodory, *Über die gegenseitige Beziehung der Ränder bei der konformen Abbildung*,
+  Math. Ann. **73** (1913).
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, §2.2–2.3.
+* P. L. Duren, *Univalent Functions*, Ch. 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex Filter Metric Set Topology
+open scoped Real
+
+variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
+
+/-! ## The closed image crosscut as an arc -/
+
+/-- **A finite-length image crosscut with two boundary ends closes to an arc.**
+Let `f` be holomorphic and injective on `ball c r`, and let `ball c r ∩ sphere ζ ρ` be a genuine
+circular crosscut at a boundary point `ζ` whose image has finite length. If the boundary piece
+
+`frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))`
+
+has more than one point, then it is a pair `{u, v}` of distinct points and the closure of the image
+crosscut is the range of an injective path from `u` to `v`.
+
+The hypothesis is the exact negation of the one
+`TauCeti.isJordanCurve_closure_image_ball_inter_sphere_of_subsingleton` runs on, and, like it, it
+is deliberately stated on the boundary piece rather than presuming the planar separation argument
+that would decide which of the two branches occurs.
+
+Only two things have to be added to the path theorem
+`TauCeti.exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn`. First, the boundary piece
+is identified with the pair of endpoints of that path, by writing it as the union of the cluster
+sets at the two angular ends of the crosscut and evaluating those cluster sets at the endpoint
+limits the path theorem supplies. Second, that identification turns the hypothesis into `u ≠ v`,
+which excludes the only repetition the path theorem leaves open. -/
+theorem exists_injective_path_range_eq_closure_image_ball_inter_sphere_of_not_subsingleton
+    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
+    (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤)
+    (hends : ¬ (frontier (f '' ball c r) ∩
+      closure (f '' (ball c r ∩ sphere ζ ρ))).Subsingleton) :
+    ∃ u v, u ≠ v ∧
+      frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v} ∧
+      ∃ γ : Path u v, Function.Injective γ ∧
+        range γ = closure (f '' (ball c r ∩ sphere ζ ρ)) := by
+  obtain ⟨u, v, γ, hγrange, htu, htv, -, -, hγsimple, -⟩ :=
+    exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn hζ hρ hρr hf hinj hfin
+  have hr : 0 < r := by linarith
+  have hφ0 := arccos_div_two_mul_pos hr hρr
+  -- Each angular end of the crosscut is adherent to it, so the endpoint limit is its cluster set.
+  have hcluster : ∀ {θ : ℝ} {w : ℂ},
+      (θ = (c - ζ).arg - Real.arccos (ρ / (2 * r)) ∨
+        θ = (c - ζ).arg + Real.arccos (ρ / (2 * r))) →
+      Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] (circleMap ζ ρ θ)) (𝓝 w) →
+      clusterSetOn f (ball c r ∩ sphere ζ ρ) (circleMap ζ ρ θ) = {w} := by
+    intro θ w hθ hw
+    refine clusterSetOn_eq_singleton_of_tendsto ?_ hw
+    rw [closure_ball_inter_sphere hζ hρ hρr,
+      closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr]
+    refine ⟨θ, ?_, rfl⟩
+    rcases hθ with rfl | rfl
+    · exact ⟨le_rfl, by linarith⟩
+    · exact ⟨by linarith, le_rfl⟩
+  -- The boundary piece is the pair of endpoints of the path.
+  have hpair : frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v} := by
+    rw [frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn isOpen_ball hf hinj,
+      frontier_ball c hr.ne', sphere_inter_sphere_eq_pair_circleMap hζ hρ hρr, biUnion_pair,
+      hcluster (Or.inl rfl) htu, hcluster (Or.inr rfl) htv, singleton_union]
+  -- So the hypothesis says the two ends are distinct.
+  have huv : u ≠ v := by
+    rintro rfl
+    exact hends (by rw [hpair, pair_eq_singleton]; exact subsingleton_singleton)
+  -- Distinct ends leave the path no repetition at all.
+  refine ⟨u, v, huv, hpair, γ, fun a b hab => ?_, hγrange⟩
+  rcases hγsimple hab with h | h | h
+  · exact h
+  · rw [h.1, h.2, γ.source, γ.target] at hab
+    exact absurd hab huv
+  · rw [h.1, h.2, γ.source, γ.target] at hab
+    exact absurd hab.symm huv
+
+/-! ## Closing the arc with an arc of the image boundary -/
+
+/-- **A finite-length image crosscut with two boundary ends closes to a Jordan curve against any
+arc of the image boundary joining them.** Under the hypotheses of
+`TauCeti.exists_injective_path_range_eq_closure_image_ball_inter_sphere_of_not_subsingleton`, the
+boundary piece is a pair `{u, v}` of distinct points, and for *every* injective path `δ` from `u`
+to `v` whose range lies on `frontier (f '' ball c r)` the union
+
+`closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ range δ`
+
+is a Jordan curve.
+
+The two arcs meet exactly in `{u, v}`: an intersection point lies on the image boundary because it
+lies on `range δ`, and on the closed image crosscut because it lies on the other arc, so it lies in
+the boundary piece; conversely `u` and `v` are endpoints of both. That is precisely the hypothesis
+of `TauCeti.isJordanCurve_union_range_of_inter_eq_pair`.
+
+Nothing is claimed about which of the two arcs the image boundary is cut into by `u` and `v` should
+be used, nor about the region the resulting Jordan curve encloses: both are planar separation
+questions. What the statement supplies is that whichever arc a separation argument selects, the
+closed curve it produces is a Jordan curve. -/
+theorem exists_forall_isJordanCurve_union_closure_image_ball_inter_sphere_of_not_subsingleton
+    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
+    (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤)
+    (hends : ¬ (frontier (f '' ball c r) ∩
+      closure (f '' (ball c r ∩ sphere ζ ρ))).Subsingleton) :
+    ∃ u v, u ≠ v ∧
+      frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v} ∧
+      ∀ δ : Path u v, Function.Injective δ → range δ ⊆ frontier (f '' ball c r) →
+        IsJordanCurve (closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ range δ) := by
+  obtain ⟨u, v, huv, hpair, γ, hγinj, hγrange⟩ :=
+    exists_injective_path_range_eq_closure_image_ball_inter_sphere_of_not_subsingleton hζ hρ hρr
+      hf hinj hfin hends
+  refine ⟨u, v, huv, hpair, fun δ hδinj hδsub => ?_⟩
+  rw [← hγrange]
+  refine isJordanCurve_union_range_of_inter_eq_pair hγinj hδinj (subset_antisymm ?_ ?_)
+  · rintro w ⟨hwγ, hwδ⟩
+    exact hpair ▸ ⟨hδsub hwδ, hγrange ▸ hwγ⟩
+  · intro w hw
+    simp only [mem_insert_iff, mem_singleton_iff] at hw
+    rcases hw with rfl | rfl
+    · exact ⟨⟨0, γ.source⟩, ⟨0, δ.source⟩⟩
+    · exact ⟨⟨1, γ.target⟩, ⟨1, δ.target⟩⟩
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean
@@ -28,7 +28,9 @@ The subsingleton hypothesis is deliberately literal. The endpoint theorem in
 `Conformal/Crosscut/BoundaryEnds.lean` shows that the boundary intersection is a pair `{u, v}`, but
 does not prove the two points distinct; asserting distinctness here would assume the planar
 separation argument that remains to be formalized. Instead this theorem gives the exact conclusion
-in the coincident-end branch, with no weakened or surrogate separation claim.
+in the coincident-end branch, with no weakened or surrogate separation claim. The complementary
+branch, in which the boundary intersection is *not* a subsingleton and the closed image crosscut is
+an arc, is `Conformal/Crosscut/Arc.lean`.
 
 ## Main result
 
@@ -42,7 +44,8 @@ the Carathéodory boundary correspondence. The existing length-area machinery pr
 short image crosscuts and the existing path theorem supplies their simple parametrisations. The
 remaining step after this file is the planar separation argument: treat the Jordan curve produced
 here when the ends coincide, and join the crosscut to one of the two boundary arcs when they are
-distinct, in order to bound the whole boundary of the cut-off image piece.
+distinct, in order to bound the whole boundary of the cut-off image piece. The joining itself is
+`Conformal/Crosscut/Arc.lean`; what is left is the choice of boundary arc.
 
 ## References
 

--- a/TauCeti/Topology/JordanCurve/Path.lean
+++ b/TauCeti/Topology/JordanCurve/Path.lean
@@ -34,7 +34,7 @@ second simplicity vocabulary alongside Mathlib's path API.
 
 The criterion has one immediate use that is worth naming on its own: two *arcs* — ranges of
 injective paths — that share their two endpoints and meet nowhere else glue to a Jordan curve
-(`TauCeti.isJordanCurve_union_range_of_inter_eq_pair`). The closed path traversed is
+(`TauCeti.isJordanCurve_range_union_range_of_inter_eq_pair`). The closed path traversed is
 `γ.trans δ.symm`, whose range is `range γ ∪ range δ`; the meeting hypothesis is what turns a
 coincidence between a value of `γ` and a value of `δ` into a coincidence of endpoints, and
 injectivity of each of the two paths handles the coincidences internal to one of them. The
@@ -45,8 +45,8 @@ equal endpoints repeats the value at the two distinct parameters `0` and `1`.
 
 * `TauCeti.isJordanCurve_range_of_eq_or_eq_endpoints` — the range of a closed path whose only
   possible repetition is its pair of endpoints is a Jordan curve.
-* `TauCeti.isJordanCurve_union_range_of_inter_eq_pair` — two arcs with the same two endpoints,
-  meeting exactly there, glue to a Jordan curve.
+* `TauCeti.isJordanCurve_range_union_range_of_inter_eq_pair` — two arcs with the same two
+  endpoints, meeting exactly there, glue to a Jordan curve.
 
 ## Roadmap role
 
@@ -55,8 +55,9 @@ This is the topological gluing step used by layer **L5** of
 finite-length image crosscut is already packaged as a path with exactly this simplicity property in
 `TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean`; when its two boundary ends coincide, the
 first result below identifies the closure of that crosscut as a Jordan curve, and when they are
-distinct the second closes that crosscut up with an arc of the boundary of the image domain. Both
-conformal specializations are in `TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean`.
+distinct the second closes that crosscut up with an arc of the boundary of the image domain. The
+coincident-end specialization is in `TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean` and
+the distinct-end one in `TauCeti/Analysis/Complex/Conformal/Crosscut/Arc.lean`.
 -/
 
 public section
@@ -152,13 +153,12 @@ at which the two halves are joined.
 
 Distinctness of `x` and `y` is a consequence rather than a hypothesis: `δ 0 = δ 1` would contradict
 injectivity of `δ`. -/
-theorem isJordanCurve_union_range_of_inter_eq_pair {y : X} {γ δ : Path x y}
+theorem isJordanCurve_range_union_range_of_inter_eq_pair {y : X} {γ δ : Path x y}
     (hγ : Function.Injective γ) (hδ : Function.Injective δ)
     (hmeet : range γ ∩ range δ = {x, y}) :
     IsJordanCurve (range γ ∪ range δ) := by
   have hrange : range (γ.trans δ.symm) = range γ ∪ range δ := by
     rw [Path.trans_range, Path.symm_range]
-  have hsymm : ∀ b : unitInterval, δ.symm b = δ (unitInterval.symm b) := fun _ => rfl
   rw [← hrange]
   refine isJordanCurve_range_of_eq_or_eq_endpoints _ fun s t hst => ?_
   rw [Path.trans_apply, Path.trans_apply] at hst
@@ -167,7 +167,7 @@ theorem isJordanCurve_union_range_of_inter_eq_pair {y : X} {γ δ : Path x y}
     have h : (2 : ℝ) * s = 2 * t := congrArg Subtype.val (hγ hst)
     exact Or.inl (Subtype.ext (show (s : ℝ) = (t : ℝ) by linarith))
   · -- The first parameter on `γ`, the second on `δ` read backwards.
-    rw [hsymm] at hst
+    simp only [Path.symm_apply, Function.comp_apply] at hst
     rcases eq_zero_and_eq_zero_or_eq_one_and_eq_one_of_apply_eq hγ hδ hmeet hst with ⟨ha, hb⟩ | h
     · have h1 : (2 : ℝ) * s = 0 := congrArg Subtype.val ha
       have h2 : 1 - (2 * (t : ℝ) - 1) = 0 := congrArg Subtype.val hb
@@ -177,7 +177,7 @@ theorem isJordanCurve_union_range_of_inter_eq_pair {y : X} {γ δ : Path x y}
       have h2 : 1 - (2 * (t : ℝ) - 1) = 1 := congrArg Subtype.val h.2
       exact Or.inl (Subtype.ext (show (s : ℝ) = (t : ℝ) by linarith))
   · -- The mirror image of the previous case.
-    rw [hsymm] at hst
+    simp only [Path.symm_apply, Function.comp_apply] at hst
     rcases eq_zero_and_eq_zero_or_eq_one_and_eq_one_of_apply_eq hγ hδ hmeet hst.symm with
       ⟨ha, hb⟩ | h
     · have h1 : (2 : ℝ) * t = 0 := congrArg Subtype.val ha
@@ -188,7 +188,7 @@ theorem isJordanCurve_union_range_of_inter_eq_pair {y : X} {γ δ : Path x y}
       have h2 : 1 - (2 * (s : ℝ) - 1) = 1 := congrArg Subtype.val h.2
       exact Or.inl (Subtype.ext (show (s : ℝ) = (t : ℝ) by linarith))
   · -- Both parameters on the second half: injectivity of `δ` read backwards.
-    rw [hsymm, hsymm] at hst
+    simp only [Path.symm_apply, Function.comp_apply] at hst
     have h : 1 - (2 * (s : ℝ) - 1) = 1 - (2 * (t : ℝ) - 1) := congrArg Subtype.val (hδ hst)
     exact Or.inl (Subtype.ext (show (s : ℝ) = (t : ℝ) by linarith))
 

--- a/TauCeti/Topology/JordanCurve/Path.lean
+++ b/TauCeti/Topology/JordanCurve/Path.lean
@@ -30,10 +30,23 @@ The condition is stated directly rather than bundled as a new notion of simple c
 is the only operation needed here, and keeping it as a theorem hypothesis avoids introducing a
 second simplicity vocabulary alongside Mathlib's path API.
 
-## Main result
+## Gluing two arcs
+
+The criterion has one immediate use that is worth naming on its own: two *arcs* — ranges of
+injective paths — that share their two endpoints and meet nowhere else glue to a Jordan curve
+(`TauCeti.isJordanCurve_union_range_of_inter_eq_pair`). The closed path traversed is
+`γ.trans δ.symm`, whose range is `range γ ∪ range δ`; the meeting hypothesis is what turns a
+coincidence between a value of `γ` and a value of `δ` into a coincidence of endpoints, and
+injectivity of each of the two paths handles the coincidences internal to one of them. The
+endpoints are not asked to be distinct: injectivity of `δ` already forces that, since a path with
+equal endpoints repeats the value at the two distinct parameters `0` and `1`.
+
+## Main results
 
 * `TauCeti.isJordanCurve_range_of_eq_or_eq_endpoints` — the range of a closed path whose only
   possible repetition is its pair of endpoints is a Jordan curve.
+* `TauCeti.isJordanCurve_union_range_of_inter_eq_pair` — two arcs with the same two endpoints,
+  meeting exactly there, glue to a Jordan curve.
 
 ## Roadmap role
 
@@ -41,8 +54,9 @@ This is the topological gluing step used by layer **L5** of
 `TauCetiRoadmap/ConformalMapping/README.md`, the Carathéodory boundary correspondence. A
 finite-length image crosscut is already packaged as a path with exactly this simplicity property in
 `TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean`; when its two boundary ends coincide, the
-result below identifies the closure of that crosscut as a Jordan curve. The conformal specialization
-is in `TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean`.
+first result below identifies the closure of that crosscut as a Jordan curve, and when they are
+distinct the second closes that crosscut up with an arc of the boundary of the image domain. Both
+conformal specializations are in `TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean`.
 -/
 
 public section
@@ -105,5 +119,77 @@ theorem isJordanCurve_range_of_eq_or_eq_endpoints (γ : Path x x)
       ⟨(Homeomorph.Set.univ (AddCircle (1 : ℝ))).trans (AddCircle.homeomorphCircle one_ne_zero)⟩
   have himage := huniv.image hgc.continuousOn hgi.injOn
   rwa [image_univ, hgrange] at himage
+
+/-! ### Gluing two arcs along their endpoints -/
+
+omit [T2Space X] in
+/-- **A value shared by two arcs with the same endpoints is attained at a shared parameter.** If
+the ranges of `γ δ : Path x y` meet exactly in `{x, y}`, then `γ a = δ b` forces both parameters to
+be `0` or both to be `1`.
+
+The shared value lies in `range γ ∩ range δ = {x, y}`, and injectivity of each path identifies the
+parameter at which it takes the endpoint value. -/
+private theorem eq_zero_and_eq_zero_or_eq_one_and_eq_one_of_apply_eq {y : X} {γ δ : Path x y}
+    (hγ : Function.Injective γ) (hδ : Function.Injective δ)
+    (hmeet : range γ ∩ range δ = {x, y}) {a b : unitInterval} (hab : γ a = δ b) :
+    (a = 0 ∧ b = 0) ∨ (a = 1 ∧ b = 1) := by
+  have hmem : γ a ∈ ({x, y} : Set X) :=
+    hmeet ▸ ⟨mem_range_self a, hab ▸ mem_range_self b⟩
+  rcases hmem with h | h
+  · exact Or.inl ⟨hγ (h.trans γ.source.symm), hδ (hab.symm.trans (h.trans δ.source.symm))⟩
+  · exact Or.inr ⟨hγ (h.trans γ.target.symm), hδ (hab.symm.trans (h.trans δ.target.symm))⟩
+
+/-- **Two arcs meeting exactly at their common endpoints glue to a Jordan curve.** Let
+`γ δ : Path x y` be injective and let their ranges meet in exactly the two endpoints,
+`range γ ∩ range δ = {x, y}`. Then `range γ ∪ range δ` is a Jordan curve.
+
+The curve traversed is `γ.trans δ.symm`, a closed path at `x` whose range is `range γ ∪ range δ`
+by `Path.trans_range` and `Path.symm_range`. Its only repetitions are the ones
+`TauCeti.isJordanCurve_range_of_eq_or_eq_endpoints` allows: a coincidence between two parameters on
+the same half is excluded by injectivity of that half, and one between the two halves lands in
+`{x, y}`, so it is either the pair `{0, 1}` of endpoint parameters or the single parameter `1 / 2`
+at which the two halves are joined.
+
+Distinctness of `x` and `y` is a consequence rather than a hypothesis: `δ 0 = δ 1` would contradict
+injectivity of `δ`. -/
+theorem isJordanCurve_union_range_of_inter_eq_pair {y : X} {γ δ : Path x y}
+    (hγ : Function.Injective γ) (hδ : Function.Injective δ)
+    (hmeet : range γ ∩ range δ = {x, y}) :
+    IsJordanCurve (range γ ∪ range δ) := by
+  have hrange : range (γ.trans δ.symm) = range γ ∪ range δ := by
+    rw [Path.trans_range, Path.symm_range]
+  have hsymm : ∀ b : unitInterval, δ.symm b = δ (unitInterval.symm b) := fun _ => rfl
+  rw [← hrange]
+  refine isJordanCurve_range_of_eq_or_eq_endpoints _ fun s t hst => ?_
+  rw [Path.trans_apply, Path.trans_apply] at hst
+  split_ifs at hst with hs ht ht
+  · -- Both parameters on the first half: injectivity of `γ`.
+    have h : (2 : ℝ) * s = 2 * t := congrArg Subtype.val (hγ hst)
+    exact Or.inl (Subtype.ext (show (s : ℝ) = (t : ℝ) by linarith))
+  · -- The first parameter on `γ`, the second on `δ` read backwards.
+    rw [hsymm] at hst
+    rcases eq_zero_and_eq_zero_or_eq_one_and_eq_one_of_apply_eq hγ hδ hmeet hst with ⟨ha, hb⟩ | h
+    · have h1 : (2 : ℝ) * s = 0 := congrArg Subtype.val ha
+      have h2 : 1 - (2 * (t : ℝ) - 1) = 0 := congrArg Subtype.val hb
+      exact Or.inr (Or.inl ⟨Subtype.ext (show (s : ℝ) = 0 by linarith),
+        Subtype.ext (show (t : ℝ) = 1 by linarith)⟩)
+    · have h1 : (2 : ℝ) * s = 1 := congrArg Subtype.val h.1
+      have h2 : 1 - (2 * (t : ℝ) - 1) = 1 := congrArg Subtype.val h.2
+      exact Or.inl (Subtype.ext (show (s : ℝ) = (t : ℝ) by linarith))
+  · -- The mirror image of the previous case.
+    rw [hsymm] at hst
+    rcases eq_zero_and_eq_zero_or_eq_one_and_eq_one_of_apply_eq hγ hδ hmeet hst.symm with
+      ⟨ha, hb⟩ | h
+    · have h1 : (2 : ℝ) * t = 0 := congrArg Subtype.val ha
+      have h2 : 1 - (2 * (s : ℝ) - 1) = 0 := congrArg Subtype.val hb
+      exact Or.inr (Or.inr ⟨Subtype.ext (show (s : ℝ) = 1 by linarith),
+        Subtype.ext (show (t : ℝ) = 0 by linarith)⟩)
+    · have h1 : (2 : ℝ) * t = 1 := congrArg Subtype.val h.1
+      have h2 : 1 - (2 * (s : ℝ) - 1) = 1 := congrArg Subtype.val h.2
+      exact Or.inl (Subtype.ext (show (s : ℝ) = (t : ℝ) by linarith))
+  · -- Both parameters on the second half: injectivity of `δ` read backwards.
+    rw [hsymm, hsymm] at hst
+    have h : 1 - (2 * (s : ℝ) - 1) = 1 - (2 * (t : ℝ) - 1) := congrArg Subtype.val (hδ hst)
+    exact Or.inl (Subtype.ext (show (s : ℝ) = (t : ℝ) by linarith))
 
 end TauCeti


### PR DESCRIPTION
This PR settles the branch of the image-crosscut analysis that `TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean` leaves open. A genuine circular crosscut `ball c r ∩ sphere ζ ρ` of a disc is carried by a conformal map to a simple open arc, and when its image has finite length `TauCeti.exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn` packages the closure of that arc as a path whose only possible repetition is a common value of its two endpoints. `Crosscut/Jordan.lean` treats the case in which that repetition happens — the two ends coincide and the closed image crosscut is a Jordan curve. The new file `TauCeti/Analysis/Complex/Conformal/Crosscut/Arc.lean` treats the complementary case, under the exact negation of that file's hypothesis: if the boundary piece `frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))` is not a subsingleton, then it is a pair `{u, v}` of *distinct* points, the path has no repetition at all, and the closed image crosscut is an **arc** with those two points as its endpoints (`TauCeti.exists_injective_path_range_eq_closure_image_ball_inter_sphere_of_not_subsingleton`). The step that makes this work is identifying which pair the boundary piece is: `TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean` already knows it is *a* pair but not which, and here it is written as the union of the cluster sets over the two angular ends of the crosscut (`TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn` and `TauCeti.sphere_inter_sphere_eq_pair_circleMap`) and those cluster sets are evaluated at the endpoint limits the path theorem hands out, by `TauCeti.clusterSetOn_eq_singleton_of_tendsto`. So the boundary piece is exactly the pair of path endpoints, and the hypothesis becomes `u ≠ v`.

The payload is that an arc can be closed up: `TauCeti.exists_forall_isJordanCurve_closure_image_ball_inter_sphere_union_range_of_not_subsingleton` says that for *every* injective path `δ` from `u` to `v` whose range lies on `frontier (f '' ball c r)`, the union `closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ range δ` is a Jordan curve. The two arcs meet exactly in `{u, v}` because an intersection point lies in the boundary piece. This is the joining step that `Crosscut/Jordan.lean` names as remaining: "treat the Jordan curve produced here when the ends coincide, and join the crosscut to one of the two boundary arcs when they are distinct". Nothing here asserts *which* of the two boundary arcs to take, nor what region the resulting curve encloses — both are planar separation questions, deliberately left alone; the statement is universally quantified over the boundary arc precisely so that it makes no surrogate separation claim. The boundary arcs a consumer would feed it come from `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le`, and are small because the two ends are close by `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le_of_isBounded`.

The gluing is pure topology and is proved where the criterion it runs on lives, in `TauCeti/Topology/JordanCurve/Path.lean`: `TauCeti.isJordanCurve_range_union_range_of_inter_eq_pair` says two arcs `γ δ : Path x y` with `range γ ∩ range δ = {x, y}` glue to a Jordan curve, the closed path traversed being `γ.trans δ.symm` and the meeting hypothesis being what turns a coincidence between the two halves into a coincidence of endpoint parameters, which `TauCeti.isJordanCurve_range_of_eq_or_eq_endpoints` then allows. Distinctness of `x` and `y` is a consequence of injectivity rather than a hypothesis. It is stated for an arbitrary Hausdorff space, as the criterion beside it is. `TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean` is otherwise untouched: two lines of its module docstring now point at the complementary file, so the two branches stay discoverable together.

The roadmap target is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, "Carathéodory boundary correspondence … the Jordan-domain case: the RMT map of a Jordan domain extends to a homeomorphism of closures", and specifically the step `ConformalMapping/STATUS.md` records under **Jordan curve input** as what the forward direction leans on. In accordance with the generality bar of that README, which fixes scalar `ℂ` for layers L0–L6, the conformal statements are for maps of `ℂ`, while the gluing lemma is for an arbitrary Hausdorff space; the disc is a general `ball c r`, the boundary point entering only through `dist ζ c = r`. Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and the pinned Mathlib has no boundary correspondence for conformal maps and no Jordan-curve vocabulary, so this is new Lean formalization rather than a temporary shim. No Mathlib infrastructure was vendored; the Mathlib inputs are the `Path` API (`Path.trans_apply`, `Path.trans_range`, `Path.symm_range`) and, through the existing files, the cluster-set and crosscut machinery already in the repository.

`lake build` (6906 jobs), `lake exe axioms` (29346 declarations, all within the allowlist `[propext, Classical.choice, Quot.sound]`), `lake exe module-system` (1529 modules) and `lake exe lint-style` are green.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"closed-image-crosscut-arc-or-jordan-curve"}-->

🤖 Prepared with Claude Code

