### PR TITLE
feat(LinearAlgebra): a quadratic form forced by per-prime matrix congruences

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FrobeniusQuadraticForm.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FrobeniusQuadraticForm.lean
@@ -30,10 +30,10 @@ which the trace is read off.
 
 ## Main results
 
-* `eq_frobenius_quadratic_form_of_det_trace`: from per-prime data with `det` and `trace`.
-* `eq_frobenius_quadratic_form_of_det_det_one_sub`: the same from `det` data alone.
-* `frobenius_quadratic_form_nonneg_of_det_trace`: the non-negativity corollary, when `D` is a
-  degree and hence non-negative.
+* `eq_quadratic_form_of_det_trace`: from per-prime data with `det` and `trace`.
+* `eq_quadratic_form_of_det_det_one_sub`: the same from `det` data alone.
+* `quadratic_form_nonneg_of_det_trace`, `quadratic_form_nonneg_of_det_det_one_sub`: the
+  non-negativity corollaries, when `D` is a degree and hence non-negative.
 
 ## Provenance
 
@@ -61,7 +61,7 @@ variable {p ℓ : ℕ} {q t D r s : ℤ}
 /-- **The per-prime congruence.** If `M` has determinant `q`, trace `t`, and the pencil
 `r • M - s • 1` has determinant `D`, then `D` agrees with `q * r ^ 2 - t * (r * s) + s ^ 2`
 modulo `ℓ`. -/
-theorem intCast_eq_of_det_trace {M : Matrix (Fin 2) (Fin 2) (ZMod ℓ)}
+theorem intCast_eq_quadratic_form_of_det_trace {M : Matrix (Fin 2) (Fin 2) (ZMod ℓ)}
     (hdet : M.det = (q : ZMod ℓ)) (htrace : M.trace = (t : ZMod ℓ))
     (hpencil : ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
     (D : ZMod ℓ) = ((q * r ^ 2 - t * (r * s) + s ^ 2 : ℤ) : ZMod ℓ) := by
@@ -71,11 +71,11 @@ theorem intCast_eq_of_det_trace {M : Matrix (Fin 2) (Fin 2) (ZMod ℓ)}
 
 /-- **The per-prime congruence, from determinants alone.** A Weil pairing supplies determinants
 rather than traces, so the trace hypothesis is replaced by `(1 - M).det = q + 1 - t`. -/
-theorem intCast_eq_of_det_det_one_sub {M : Matrix (Fin 2) (Fin 2) (ZMod ℓ)}
+theorem intCast_eq_quadratic_form_of_det_det_one_sub {M : Matrix (Fin 2) (Fin 2) (ZMod ℓ)}
     (hdet : M.det = (q : ZMod ℓ)) (hdetOneSub : (1 - M).det = ((q + 1 - t : ℤ) : ZMod ℓ))
     (hpencil : ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
     (D : ZMod ℓ) = ((q * r ^ 2 - t * (r * s) + s ^ 2 : ℤ) : ZMod ℓ) := by
-  refine intCast_eq_of_det_trace hdet ?_ hpencil
+  refine intCast_eq_quadratic_form_of_det_trace hdet ?_ hpencil
   -- `1 - M` is the pencil at `r = s = -1`, so the trace is read off the two determinants.
   have h : (1 - M).det = M.det * (-1) ^ 2 - M.trace * (-1 * -1) + (-1 : ZMod ℓ) ^ 2 := by
     simpa [neg_add_eq_sub] using det_smul_sub_smul_one_fin_two M (-1) (-1)
@@ -86,32 +86,41 @@ theorem intCast_eq_of_det_det_one_sub {M : Matrix (Fin 2) (Fin 2) (ZMod ℓ)}
 /-- **The quadratic form is forced.** If for every prime `ℓ ≠ p` the integer `D` is realised
 modulo `ℓ` as the pencil determinant of a `2 × 2` matrix with determinant `q` and trace `t`, then
 `D = q * r ^ 2 - t * (r * s) + s ^ 2` as integers. -/
-theorem eq_frobenius_quadratic_form_of_det_trace
+theorem eq_quadratic_form_of_det_trace
     (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
       M.det = (q : ZMod ℓ) ∧ M.trace = (t : ZMod ℓ) ∧
         ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
     D = q * r ^ 2 - t * (r * s) + s ^ 2 :=
   Int.eq_of_intCast_eq_all_primes_ne (p := p) fun ℓ hℓ hℓne ↦
     let ⟨_, hdet, htrace, hpencil⟩ := h ℓ hℓ hℓne
-    intCast_eq_of_det_trace hdet htrace hpencil
+    intCast_eq_quadratic_form_of_det_trace hdet htrace hpencil
 
 /-- **The quadratic form is forced, from determinants alone.** -/
-theorem eq_frobenius_quadratic_form_of_det_det_one_sub
+theorem eq_quadratic_form_of_det_det_one_sub
     (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
       M.det = (q : ZMod ℓ) ∧ (1 - M).det = ((q + 1 - t : ℤ) : ZMod ℓ) ∧
         ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
     D = q * r ^ 2 - t * (r * s) + s ^ 2 :=
   Int.eq_of_intCast_eq_all_primes_ne (p := p) fun ℓ hℓ hℓne ↦
     let ⟨_, hdet, hdetOneSub, hpencil⟩ := h ℓ hℓ hℓne
-    intCast_eq_of_det_det_one_sub hdet hdetOneSub hpencil
+    intCast_eq_quadratic_form_of_det_det_one_sub hdet hdetOneSub hpencil
+
+/-- **Non-negativity, from determinants alone.** The det-only companion of
+`quadratic_form_nonneg_of_det_trace`, which is the branch a pairing supplies. -/
+theorem quadratic_form_nonneg_of_det_det_one_sub (hD : 0 ≤ D)
+    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
+      M.det = (q : ZMod ℓ) ∧ (1 - M).det = ((q + 1 - t : ℤ) : ZMod ℓ) ∧
+        ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
+    0 ≤ q * r ^ 2 - t * (r * s) + s ^ 2 :=
+  eq_quadratic_form_of_det_det_one_sub h ▸ hD
 
 /-- **Non-negativity.** When the realised integer is non-negative — as a degree is — the quadratic
 form is non-negative. -/
-theorem frobenius_quadratic_form_nonneg_of_det_trace (hD : 0 ≤ D)
+theorem quadratic_form_nonneg_of_det_trace (hD : 0 ≤ D)
     (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
       M.det = (q : ZMod ℓ) ∧ M.trace = (t : ZMod ℓ) ∧
         ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
     0 ≤ q * r ^ 2 - t * (r * s) + s ^ 2 :=
-  eq_frobenius_quadratic_form_of_det_trace h ▸ hD
+  eq_quadratic_form_of_det_trace h ▸ hD
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FrobeniusQuadraticForm.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FrobeniusQuadraticForm.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Data.Matrix.Basic
+public import TauCeti.Data.Int.CongrAllPrimes
+public import TauCeti.LinearAlgebra.Matrix.CharpolyFinTwo
+import Mathlib.Tactic.LinearCombination
+
+/-!
+# The Frobenius quadratic form from per-prime matrix data
+
+Let `q` and `t` be integers, thought of as the size of the base field and the trace of Frobenius.
+This file shows that an integer `D` is *forced* to equal the binary quadratic form
+`q * r ^ 2 - t * (r * s) + s ^ 2` as soon as, for every prime `ℓ` other than one exceptional `p`,
+`D` is realised modulo `ℓ` as the determinant of the pencil `r • M - s • 1` of some `2 × 2` matrix
+`M` over `ZMod ℓ` with determinant `q` and trace `t`.
+
+Nothing about elliptic curves appears here, and none is proved: the matrix data is a
+**hypothesis** throughout. The intended instance — where `D` is the degree of `r π - s` for the
+`q`-power Frobenius `π`, and `M` is its matrix on the `ℓ`-torsion — is what makes the conclusion
+the Hasse quadratic form, but supplying that instance is the work of the Weil pairing and is not
+done here.
+
+Two forms of the hypothesis are provided, because a Weil pairing supplies determinants rather
+than traces: one taking `M.trace = t` directly, and one taking `(1 - M).det = q + 1 - t`, from
+which the trace is read off.
+
+## Main results
+
+* `frobeniusQuadraticForm_eq_of_det_trace`: from per-prime data with `det` and `trace`.
+* `frobeniusQuadraticForm_eq_of_det_det_one_sub`: the same from `det` data alone.
+* `frobeniusQuadraticForm_nonneg_of_det_trace`: the non-negativity corollary, when `D` is a
+  degree and hence non-negative.
+
+## Provenance
+
+Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
+`HasseWeil/WeilPairing/Reduction.lean`, declarations `deg_eq_of_frobMatrix_data`,
+`qf_nonneg_of_frobMatrix_data`, `frob_det_congruence` and `deg_eq_of_frob_det_data`.
+
+Two deviations. The source's `det_smul_sub_smul_one_fin_two_of` takes `M.det = q` and
+`M.trace = t` as hypotheses; TauCeti already has the unconditional
+`Matrix.det_smul_sub_smul_one_fin_two` (merged as #2328), so that lemma is used and the
+hypotheses are substituted at the call site. And the source's `det_one_sub_fin_two` is not
+reproduced: `(1 - M).det = 1 - M.trace + M.det` is a three-line computation, kept private here.
+The names say what is concluded rather than naming the elliptic-curve instance, since no curve
+occurs in any statement.
+-/
+
+public section
+
+open Matrix TauCeti.Matrix
+
+namespace TauCeti
+
+variable {p ℓ : ℕ} {q t D r s : ℤ}
+
+-- The `2 × 2` case of `det (1 - M)`, read as the trace when the determinants are known.
+private theorem det_one_sub_fin_two {R : Type*} [CommRing R] (M : Matrix (Fin 2) (Fin 2) R) :
+    (1 - M).det = 1 - M.trace + M.det := by
+  rw [det_fin_two, trace_fin_two, det_fin_two M]
+  simp
+  ring
+
+/-- **The per-prime congruence.** If `M` has determinant `q`, trace `t`, and the pencil
+`r • M - s • 1` has determinant `D`, then `D` agrees with `q * r ^ 2 - t * (r * s) + s ^ 2`
+modulo `ℓ`. -/
+theorem intCast_eq_of_det_trace {M : Matrix (Fin 2) (Fin 2) (ZMod ℓ)}
+    (hdet : M.det = (q : ZMod ℓ)) (htrace : M.trace = (t : ZMod ℓ))
+    (hpencil : ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
+    (D : ZMod ℓ) = ((q * r ^ 2 - t * (r * s) + s ^ 2 : ℤ) : ZMod ℓ) := by
+  rw [← hpencil, det_smul_sub_smul_one_fin_two, hdet, htrace]
+  push_cast
+  ring
+
+/-- **The per-prime congruence, from determinants alone.** A Weil pairing supplies determinants
+rather than traces, so the trace hypothesis is replaced by `(1 - M).det = q + 1 - t`. -/
+theorem intCast_eq_of_det_det_one_sub {M : Matrix (Fin 2) (Fin 2) (ZMod ℓ)}
+    (hdet : M.det = (q : ZMod ℓ)) (hdetOneSub : (1 - M).det = ((q + 1 - t : ℤ) : ZMod ℓ))
+    (hpencil : ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
+    (D : ZMod ℓ) = ((q * r ^ 2 - t * (r * s) + s ^ 2 : ℤ) : ZMod ℓ) := by
+  refine intCast_eq_of_det_trace hdet ?_ hpencil
+  have h := det_one_sub_fin_two M
+  rw [hdetOneSub, hdet] at h
+  push_cast at h
+  linear_combination h
+
+/-- **The quadratic form is forced.** If for every prime `ℓ ≠ p` the integer `D` is realised
+modulo `ℓ` as the pencil determinant of a `2 × 2` matrix with determinant `q` and trace `t`, then
+`D = q * r ^ 2 - t * (r * s) + s ^ 2` as integers. -/
+theorem frobeniusQuadraticForm_eq_of_det_trace
+    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
+      M.det = (q : ZMod ℓ) ∧ M.trace = (t : ZMod ℓ) ∧
+        ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
+    D = q * r ^ 2 - t * (r * s) + s ^ 2 :=
+  Int.eq_of_intCast_eq_all_primes_ne (p := p) fun ℓ hℓ hℓne ↦
+    let ⟨_, hdet, htrace, hpencil⟩ := h ℓ hℓ hℓne
+    intCast_eq_of_det_trace hdet htrace hpencil
+
+/-- **The quadratic form is forced, from determinants alone.** -/
+theorem frobeniusQuadraticForm_eq_of_det_det_one_sub
+    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
+      M.det = (q : ZMod ℓ) ∧ (1 - M).det = ((q + 1 - t : ℤ) : ZMod ℓ) ∧
+        ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
+    D = q * r ^ 2 - t * (r * s) + s ^ 2 :=
+  Int.eq_of_intCast_eq_all_primes_ne (p := p) fun ℓ hℓ hℓne ↦
+    let ⟨_, hdet, hdetOneSub, hpencil⟩ := h ℓ hℓ hℓne
+    intCast_eq_of_det_det_one_sub hdet hdetOneSub hpencil
+
+/-- **Non-negativity.** When the realised integer is non-negative — as a degree is — the quadratic
+form is non-negative. -/
+theorem frobeniusQuadraticForm_nonneg_of_det_trace (hD : 0 ≤ D)
+    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
+      M.det = (q : ZMod ℓ) ∧ M.trace = (t : ZMod ℓ) ∧
+        ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
+    0 ≤ q * r ^ 2 - t * (r * s) + s ^ 2 :=
+  frobeniusQuadraticForm_eq_of_det_trace h ▸ hD
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FrobeniusQuadraticForm.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FrobeniusQuadraticForm.lean
@@ -30,9 +30,9 @@ which the trace is read off.
 
 ## Main results
 
-* `frobeniusQuadraticForm_eq_of_det_trace`: from per-prime data with `det` and `trace`.
-* `frobeniusQuadraticForm_eq_of_det_det_one_sub`: the same from `det` data alone.
-* `frobeniusQuadraticForm_nonneg_of_det_trace`: the non-negativity corollary, when `D` is a
+* `eq_frobenius_quadratic_form_of_det_trace`: from per-prime data with `det` and `trace`.
+* `eq_frobenius_quadratic_form_of_det_det_one_sub`: the same from `det` data alone.
+* `frobenius_quadratic_form_nonneg_of_det_trace`: the non-negativity corollary, when `D` is a
   degree and hence non-negative.
 
 ## Provenance
@@ -58,13 +58,6 @@ namespace TauCeti
 
 variable {p ℓ : ℕ} {q t D r s : ℤ}
 
--- The `2 × 2` case of `det (1 - M)`, read as the trace when the determinants are known.
-private theorem det_one_sub_fin_two {R : Type*} [CommRing R] (M : Matrix (Fin 2) (Fin 2) R) :
-    (1 - M).det = 1 - M.trace + M.det := by
-  rw [det_fin_two, trace_fin_two, det_fin_two M]
-  simp
-  ring
-
 /-- **The per-prime congruence.** If `M` has determinant `q`, trace `t`, and the pencil
 `r • M - s • 1` has determinant `D`, then `D` agrees with `q * r ^ 2 - t * (r * s) + s ^ 2`
 modulo `ℓ`. -/
@@ -83,7 +76,9 @@ theorem intCast_eq_of_det_det_one_sub {M : Matrix (Fin 2) (Fin 2) (ZMod ℓ)}
     (hpencil : ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
     (D : ZMod ℓ) = ((q * r ^ 2 - t * (r * s) + s ^ 2 : ℤ) : ZMod ℓ) := by
   refine intCast_eq_of_det_trace hdet ?_ hpencil
-  have h := det_one_sub_fin_two M
+  -- `1 - M` is the pencil at `r = s = -1`, so the trace is read off the two determinants.
+  have h : (1 - M).det = M.det * (-1) ^ 2 - M.trace * (-1 * -1) + (-1 : ZMod ℓ) ^ 2 := by
+    simpa [neg_add_eq_sub] using det_smul_sub_smul_one_fin_two M (-1) (-1)
   rw [hdetOneSub, hdet] at h
   push_cast at h
   linear_combination h
@@ -91,7 +86,7 @@ theorem intCast_eq_of_det_det_one_sub {M : Matrix (Fin 2) (Fin 2) (ZMod ℓ)}
 /-- **The quadratic form is forced.** If for every prime `ℓ ≠ p` the integer `D` is realised
 modulo `ℓ` as the pencil determinant of a `2 × 2` matrix with determinant `q` and trace `t`, then
 `D = q * r ^ 2 - t * (r * s) + s ^ 2` as integers. -/
-theorem frobeniusQuadraticForm_eq_of_det_trace
+theorem eq_frobenius_quadratic_form_of_det_trace
     (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
       M.det = (q : ZMod ℓ) ∧ M.trace = (t : ZMod ℓ) ∧
         ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
@@ -101,7 +96,7 @@ theorem frobeniusQuadraticForm_eq_of_det_trace
     intCast_eq_of_det_trace hdet htrace hpencil
 
 /-- **The quadratic form is forced, from determinants alone.** -/
-theorem frobeniusQuadraticForm_eq_of_det_det_one_sub
+theorem eq_frobenius_quadratic_form_of_det_det_one_sub
     (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
       M.det = (q : ZMod ℓ) ∧ (1 - M).det = ((q + 1 - t : ℤ) : ZMod ℓ) ∧
         ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
@@ -112,11 +107,11 @@ theorem frobeniusQuadraticForm_eq_of_det_det_one_sub
 
 /-- **Non-negativity.** When the realised integer is non-negative — as a degree is — the quadratic
 form is non-negative. -/
-theorem frobeniusQuadraticForm_nonneg_of_det_trace (hD : 0 ≤ D)
+theorem frobenius_quadratic_form_nonneg_of_det_trace (hD : 0 ≤ D)
     (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
       M.det = (q : ZMod ℓ) ∧ M.trace = (t : ZMod ℓ) ∧
         ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
     0 ≤ q * r ^ 2 - t * (r * s) + s ^ 2 :=
-  frobeniusQuadraticForm_eq_of_det_trace h ▸ hD
+  eq_frobenius_quadratic_form_of_det_trace h ▸ hD
 
 end TauCeti

--- a/TauCeti/Data/Int/CongrAllPrimes.lean
+++ b/TauCeti/Data/Int/CongrAllPrimes.lean
@@ -17,7 +17,7 @@ and exceeds its absolute value.
 
 The exception is what makes these usable: an argument that produces congruences one prime at a
 time is typically forced to omit a characteristic, and may omit it without weakening the
-conclusion. `TauCeti.eq_quadratic_form_of_det_trace` is such an argument.
+conclusion. `TauCeti.Matrix.eq_quadratic_form_of_det_trace` is such an argument.
 
 ## Main results
 

--- a/TauCeti/Data/Int/CongrAllPrimes.lean
+++ b/TauCeti/Data/Int/CongrAllPrimes.lean
@@ -17,7 +17,7 @@ and exceeds its absolute value.
 
 The exception is what makes these usable: an argument that produces congruences one prime at a
 time is typically forced to omit a characteristic, and may omit it without weakening the
-conclusion. `TauCeti.eq_frobenius_quadratic_form_of_det_trace` is such an argument.
+conclusion. `TauCeti.eq_quadratic_form_of_det_trace` is such an argument.
 
 ## Main results
 

--- a/TauCeti/Data/Int/CongrAllPrimes.lean
+++ b/TauCeti/Data/Int/CongrAllPrimes.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Data.ZMod.Basic
+public import Mathlib.Data.Nat.Prime.Infinite
+
+/-!
+# Integers pinned by their residues at all but one prime
+
+An integer divisible by every prime except possibly one is zero, and consequently two integers
+congruent modulo every prime except possibly one are equal. A nonzero integer has finitely many
+prime divisors while the excluded primes are infinite in number, so some prime both divides it
+and exceeds its absolute value.
+
+The exception is what makes these usable: an argument that produces congruences one prime at a
+time is typically forced to omit a characteristic, and may omit it without weakening the
+conclusion.
+
+## Main results
+
+* `Int.eq_zero_of_dvd_all_primes_ne`: an integer divisible by every prime `≠ p` is zero.
+* `Int.eq_of_intCast_eq_all_primes_ne`: two integers agreeing in `ZMod ℓ` for every prime `ℓ ≠ p`
+  are equal.
+
+## Provenance
+
+Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
+`HasseWeil/WeilPairing/IntegerSeparation.lean`, declarations `int_eq_zero_of_dvd_all_primes_ne`
+and `int_eq_of_congr_all_primes_ne`. Both statements are unchanged; the names follow Mathlib's
+convention of naming after the conclusion, and the proofs are shortened — the first by
+`Nat.exists_infinite_primes` at a single bound rather than a `max` of two, the second by
+`sub_eq_zero` in place of `omega`.
+-/
+
+public section
+
+namespace Int
+
+/-- **An integer divisible by every prime except possibly one is zero.**
+
+A nonzero integer is divisible only by primes at most its absolute value, but the primes `≠ p`
+are unbounded, so one of them both divides it and exceeds it. -/
+theorem eq_zero_of_dvd_all_primes_ne {D : ℤ} {p : ℕ}
+    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → (ℓ : ℤ) ∣ D) : D = 0 := by
+  by_contra hD
+  obtain ⟨ℓ, hℓ_ge, hℓ_prime⟩ := Nat.exists_infinite_primes (max (D.natAbs + 1) (p + 1))
+  have hle : ℓ ≤ D.natAbs :=
+    Nat.le_of_dvd (natAbs_pos.mpr hD) <| by
+      simpa using natAbs_dvd_natAbs.mpr (h ℓ hℓ_prime (by omega))
+  omega
+
+/-- **Two integers agreeing modulo every prime except possibly one are equal.** -/
+theorem eq_of_intCast_eq_all_primes_ne {A B : ℤ} {p : ℕ}
+    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → (A : ZMod ℓ) = (B : ZMod ℓ)) : A = B :=
+  sub_eq_zero.mp <| eq_zero_of_dvd_all_primes_ne (p := p) fun ℓ hℓ hℓne ↦ by
+    have : NeZero ℓ := ⟨hℓ.ne_zero⟩
+    exact ZMod.intCast_zmod_eq_zero_iff_dvd _ ℓ |>.mp <| by
+      rw [Int.cast_sub, h ℓ hℓ hℓne, sub_self]
+
+end Int

--- a/TauCeti/Data/Int/CongrAllPrimes.lean
+++ b/TauCeti/Data/Int/CongrAllPrimes.lean
@@ -17,7 +17,7 @@ and exceeds its absolute value.
 
 The exception is what makes these usable: an argument that produces congruences one prime at a
 time is typically forced to omit a characteristic, and may omit it without weakening the
-conclusion. `TauCeti.frobeniusQuadraticForm_eq_of_det_trace` is such an argument.
+conclusion. `TauCeti.eq_frobenius_quadratic_form_of_det_trace` is such an argument.
 
 ## Main results
 

--- a/TauCeti/Data/Int/CongrAllPrimes.lean
+++ b/TauCeti/Data/Int/CongrAllPrimes.lean
@@ -17,7 +17,7 @@ and exceeds its absolute value.
 
 The exception is what makes these usable: an argument that produces congruences one prime at a
 time is typically forced to omit a characteristic, and may omit it without weakening the
-conclusion.
+conclusion. `TauCeti.frobeniusQuadraticForm_eq_of_det_trace` is such an argument.
 
 ## Main results
 

--- a/TauCeti/LinearAlgebra/Matrix/QuadraticFormCongruence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/QuadraticFormCongruence.lean
@@ -10,7 +10,7 @@ public import TauCeti.LinearAlgebra.Matrix.CharpolyFinTwo
 import Mathlib.Tactic.LinearCombination
 
 /-!
-# The Frobenius quadratic form from per-prime matrix data
+# A quadratic form forced by per-prime matrix congruences
 
 Let `q` and `t` be integers, thought of as the size of the base field and the trace of Frobenius.
 This file shows that an integer `D` is *forced* to equal the binary quadratic form
@@ -32,8 +32,9 @@ which the trace is read off.
 
 * `eq_quadratic_form_of_det_trace`: from per-prime data with `det` and `trace`.
 * `eq_quadratic_form_of_det_det_one_sub`: the same from `det` data alone.
-* `quadratic_form_nonneg_of_det_trace`, `quadratic_form_nonneg_of_det_det_one_sub`: the
-  non-negativity corollaries, when `D` is a degree and hence non-negative.
+When the realised integer is non-negative — as a degree is — non-negativity of the form follows
+by rewriting, `eq_quadratic_form_of_det_trace h ▸ hD`; that is left to consumers rather than
+exported as a corollary.
 
 ## Provenance
 
@@ -54,7 +55,7 @@ public section
 
 open Matrix TauCeti.Matrix
 
-namespace TauCeti
+namespace TauCeti.Matrix
 
 variable {p ℓ : ℕ} {q t D r s : ℤ}
 
@@ -105,22 +106,4 @@ theorem eq_quadratic_form_of_det_det_one_sub
     let ⟨_, hdet, hdetOneSub, hpencil⟩ := h ℓ hℓ hℓne
     intCast_eq_quadratic_form_of_det_det_one_sub hdet hdetOneSub hpencil
 
-/-- **Non-negativity, from determinants alone.** The det-only companion of
-`quadratic_form_nonneg_of_det_trace`, which is the branch a pairing supplies. -/
-theorem quadratic_form_nonneg_of_det_det_one_sub (hD : 0 ≤ D)
-    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
-      M.det = (q : ZMod ℓ) ∧ (1 - M).det = ((q + 1 - t : ℤ) : ZMod ℓ) ∧
-        ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
-    0 ≤ q * r ^ 2 - t * (r * s) + s ^ 2 :=
-  eq_quadratic_form_of_det_det_one_sub h ▸ hD
-
-/-- **Non-negativity.** When the realised integer is non-negative — as a degree is — the quadratic
-form is non-negative. -/
-theorem quadratic_form_nonneg_of_det_trace (hD : 0 ≤ D)
-    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
-      M.det = (q : ZMod ℓ) ∧ M.trace = (t : ZMod ℓ) ∧
-        ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
-    0 ≤ q * r ^ 2 - t * (r * s) + s ^ 2 :=
-  eq_quadratic_form_of_det_trace h ▸ hD
-
-end TauCeti
+end TauCeti.Matrix

--- a/TauCeti/LinearAlgebra/Matrix/QuadraticFormCongruence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/QuadraticFormCongruence.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Data.Matrix.Basic
 public import TauCeti.Data.Int.CongrAllPrimes
 public import TauCeti.LinearAlgebra.Matrix.CharpolyFinTwo
 import Mathlib.Tactic.LinearCombination


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"frobenius-quadratic-form"}-->

Roadmap: EllipticCurves

**No elliptic curve appears in any statement here, and no Hasse bound is proved.** The
finite-level matrix data that would make this about curves is a *hypothesis* throughout;
supplying it is the work of the Weil pairing and is not done in this PR.

Two files, the second consuming the first.

```lean
-- TauCeti/Data/Int/CongrAllPrimes.lean
theorem Int.eq_zero_of_dvd_all_primes_ne {D : ℤ} {p : ℕ}
    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → (ℓ : ℤ) ∣ D) : D = 0
theorem Int.eq_of_intCast_eq_all_primes_ne {A B : ℤ} {p : ℕ}
    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → (A : ZMod ℓ) = (B : ZMod ℓ)) : A = B

-- TauCeti/LinearAlgebra/Matrix/QuadraticFormCongruence.lean
theorem eq_quadratic_form_of_det_trace
    (h : ∀ ℓ : ℕ, ℓ.Prime → ℓ ≠ p → ∃ M : Matrix (Fin 2) (Fin 2) (ZMod ℓ),
      M.det = (q : ZMod ℓ) ∧ M.trace = (t : ZMod ℓ) ∧
        ((r : ZMod ℓ) • M - (s : ZMod ℓ) • 1).det = (D : ZMod ℓ)) :
    D = q * r ^ 2 - t * (r * s) + s ^ 2
```

plus the `det`-only variant (`(1 - M).det = q + 1 - t` in place of the trace, which is the shape a
pairing actually supplies) and the two per-prime congruences they factor through. Non-negativity,
when `D` is a degree, is `eq_quadratic_form_of_det_trace h ▸ hD` and is left to consumers.

## What this is

An integer with only finitely many prime divisors cannot be divisible by every prime bar one, so
congruence modulo all but one prime pins an integer exactly. Feeding the `2 × 2` pencil identity
`(r • M - s • 1).det = M.det · r² − M.trace · rs + s²` into that gives: if `D` is realised, modulo
every prime `ℓ ≠ p`, as the pencil determinant of a matrix with determinant `q` and trace `t`, then
`D = q r² − t rs + s²` over `ℤ`.

The instance this exists for is `D = deg(rπ − s)` with `M` the matrix of the `q`-power Frobenius on
the `ℓ`-torsion, where the conclusion is the Hasse quadratic form and non-negativity of `deg` gives
`0 ≤ q r² − t rs + s²`. **That instance is not constructed here** — it needs the finite-level Weil
pairing.

## Mathlib and TauCeti check

Neither integer-separation statement is in the pin; compile-checked rather than grep-checked —
`exact?` fails on `(∀ ℓ prime, ℓ ≠ p → (ℓ:ℤ) ∣ D) → D = 0`. TauCeti has a *single-modulus* bounded
lemma, `ZMod.eq_of_intCast_eq_of_two_mul_natAbs_lt`, which is a different statement: one modulus
with explicit size bounds, versus infinitely many with none.

The `2 × 2` work is **not** re-done: `TauCeti.Matrix.det_smul_sub_smul_one_fin_two`, merged by this
campaign as #2328, is used directly. The source's variant takes `det` and `trace` as hypotheses;
the merged one is unconditional, so the hypotheses are substituted at the call site instead. The
source's `det_one_sub_fin_two` is likewise not reproduced — `(1 - M).det` is that same lemma at
`r = s = -1`.

## Provenance

Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, files
`HasseWeil/WeilPairing/IntegerSeparation.lean` (`int_eq_zero_of_dvd_all_primes_ne`,
`int_eq_of_congr_all_primes_ne`) and `HasseWeil/WeilPairing/Reduction.lean`
(`deg_eq_of_frobMatrix_data`, `qf_nonneg_of_frobMatrix_data`, `frob_det_congruence`,
`deg_eq_of_frob_det_data`).

Statements are unchanged. Names are conclusion-shaped and drop the elliptic-curve vocabulary,
since no curve occurs: `deg_eq_of_frobMatrix_data` becomes `eq_quadratic_form_of_det_trace`. The
files are placed by what they are about rather than by what motivates them — the arithmetic in
`namespace Int` under `TauCeti/Data/Int/`, the matrix congruences under
`TauCeti/LinearAlgebra/Matrix/` — leaving the elliptic-curve application for a later file.

The source's two non-negativity corollaries are not ported: each is a one-line `▸` transport of
the equality theorem above it, so consumers rewrite directly.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 3 — elliptic curves over finite fields, the
Hasse bound (AEC V.1)**, whose entry states the bound "is landable now: the existing proof
(provenance) carries a self-contained finite-level pairing, so this headline can be the first PR
while Layers 0–2 are still built out". This is the arithmetic half of that proof: the step from
per-prime determinant data to the integer quadratic form. It supplies a prerequisite the target
needs rather than advancing the target itself.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
locally. No `sorry`, no raised heartbeat limits.

## Local review

Run before opening; all five rubrics consulted approve. Two earlier rounds shaped it: the first
said the integer-separation file alone was scaffolding with no consumer and should wait for that
consumer — which is why both files ship together — and the second caught that
`(1 - M).det` was a special case of the already-merged pencil lemma, and that the equality
theorems should be named for the orientation of their conclusions.
