### PR TITLE
refactor(Winding): name the index-form invariance behind homotopy invariance

### DIFF
--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -109,7 +109,7 @@ theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x y : ℂ} {p q : Path x y} 
   exact hs.congr fun _ _ => by simp [Path.extend, Path.Homotopy.eval]
 
 /-- **A path homotopy avoiding `w` preserves the curve integral of the index form.** -/
-private theorem curveIntegral_indexForm_eq_of_pathHomotopy {x w : ℂ} {p q : Path x x}
+private theorem curveIntegral_indexForm_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y}
     (φ : p.Homotopy q)
     (hφsmooth : ContDiffOn ℝ 2
       (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
@@ -133,7 +133,7 @@ private theorem curveIntegral_indexForm_eq_of_pathHomotopy {x w : ℂ} {p q : Pa
     ext t
     exact φ.source t
   have heval_one :
-      φ.toHomotopy.evalAt 1 = (Path.refl x).cast p.target q.target := by
+      φ.toHomotopy.evalAt 1 = (Path.refl y).cast p.target q.target := by
     ext t
     exact φ.target t
   rw [heval_zero, heval_one] at hboundary

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -168,7 +168,8 @@ theorem windingNumber_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y} (φ : p.
     hcurve']
 
 /-- Null-homology in `Ω` is invariant under a `C²` path homotopy whose image lies in `Ω`. -/
-theorem isNullHomologous_iff_of_pathHomotopy {x : ℂ} {p q : Path x x} {Ω : Set ℂ} (φ : p.Homotopy q)
+theorem isNullHomologous_iff_of_pathHomotopy {x y : ℂ} {p q : Path x y} {Ω : Set ℂ}
+    (φ : p.Homotopy q)
     (hφsmooth : ContDiffOn ℝ 2
       (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
     (hφΩ : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ∈ Ω) :

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -26,6 +26,8 @@ integrals on the compact image of the homotopy.
   number of a piecewise-`C¹` path with Mathlib's curve integral of the Cauchy-kernel `1`-form.
 * `isPiecewiseC1On_eval_of_smoothPathHomotopy` supplies piecewise-`C¹` regularity for every path
   in a smooth homotopy.
+* `curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy` is the Stokes step: a homotopy through
+  `ℂ \ {w}` preserves the curve integral of the Cauchy-kernel `1`-form.
 * `windingNumber_eq_of_pathHomotopy` proves the Layer 0 homotopy invariance result.
 * `isNullHomologous_iff_of_pathHomotopy` transfers null-homology across a homotopy in the ambient
   set.
@@ -108,13 +110,19 @@ theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x y : ℂ} {p q : Path x y} 
         simpa [Prod.le_def] using ⟨⟨s.2.1, ht.1⟩, ⟨s.2.2, ht.2⟩⟩)
   exact hs.congr fun _ _ => by simp [Path.extend, Path.Homotopy.eval]
 
-/-- **A path homotopy avoiding `w` preserves the curve integral of the index form.** -/
-private theorem curveIntegral_indexForm_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y}
+/-- **A path homotopy avoiding `w` preserves the curve integral of the Cauchy kernel.** Paths with
+the same endpoints, joined by a `C²` homotopy through `ℂ \ {w}`, have equal integrals of the
+`1`-form `z ↦ (z - w)⁻¹ dz`. -/
+theorem curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y}
     (φ : p.Homotopy q)
     (hφsmooth : ContDiffOn ℝ 2
       (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
     (haway : ∀ z ∈ Set.range φ, z ≠ w) :
-    (∫ᶜ z in p, indexForm w z) = ∫ᶜ z in q, indexForm w z := by
+    (∫ᶜ z in p, (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ) =
+      ∫ᶜ z in q, (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ := by
+  -- `indexForm w` is the private abbreviation for this integrand; fold it so the closedness and
+  -- derivative lemmas below, which are stated for it, apply.
+  change (∫ᶜ z in p, indexForm w z) = ∫ᶜ z in q, indexForm w z
   have hrange : IsClosed (Set.range φ) :=
     (isCompact_range φ.toHomotopy.continuous).isClosed
   have hclosedForm : ∀ z ∈ Set.range φ,
@@ -150,11 +158,7 @@ theorem windingNumber_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y} (φ : p.
   have haway : ∀ z ∈ Set.range φ, z ≠ w := by
     rintro _ ⟨st, rfl⟩
     exact havoid st
-  have hcurve := curveIntegral_indexForm_eq_of_pathHomotopy φ hφsmooth haway
-  have hcurve' :
-      (∫ᶜ z in p, (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ) =
-        ∫ᶜ z in q, (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ := by
-    simpa only [indexForm] using hcurve
+  have hcurve' := curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy φ hφsmooth haway
   have hp : IsPiecewiseC1On p.extend 0 1 := by
     simpa using isPiecewiseC1On_eval_of_smoothPathHomotopy φ hφsmooth (0 : I)
   have hq : IsPiecewiseC1On q.extend 0 1 := by

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -15,8 +15,8 @@ import Mathlib.MeasureTheory.Integral.CurveIntegral.Poincare
 /-!
 # Homotopy invariance of the winding number
 
-The winding number of a closed path about `w` is invariant under a twice continuously
-differentiable path homotopy through `ℂ \ {w}`. The proof represents the Cauchy kernel as the closed
+The winding number of a path about `w` is invariant under a twice continuously differentiable
+fixed-endpoint homotopy through `ℂ \ {w}`. The proof represents the Cauchy kernel as the closed
 complex-linear `1`-form `z ↦ (z - w)⁻¹ dz`, then applies Mathlib's Poincaré theorem for curve
 integrals on the compact image of the homotopy.
 
@@ -139,10 +139,10 @@ private theorem curveIntegral_indexForm_eq_of_pathHomotopy {x y w : ℂ} {p q : 
   rw [heval_zero, heval_one] at hboundary
   simpa only [curveIntegral_cast, curveIntegral_refl, add_zero] using hboundary
 
-/-- **Homotopy invariance of the winding number off the curve.** Two closed paths joined through
-`ℂ \ {w}` by a path homotopy whose extension to the unit square is `C²` have the same winding number
-about `w`. -/
-theorem windingNumber_eq_of_pathHomotopy {x w : ℂ} {p q : Path x x} (φ : p.Homotopy q)
+/-- **Homotopy invariance of the winding number off the curve.** Two paths with the same endpoints,
+joined through `ℂ \ {w}` by a path homotopy whose extension to the unit square is `C²`, have the
+same winding number about `w`. -/
+theorem windingNumber_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y} (φ : p.Homotopy q)
     (hφsmooth : ContDiffOn ℝ 2
       (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
     (havoid : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ≠ w) :

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -108,25 +108,21 @@ theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x y : ℂ} {p q : Path x y} 
         simpa [Prod.le_def] using ⟨⟨s.2.1, ht.1⟩, ⟨s.2.2, ht.2⟩⟩)
   exact hs.congr fun _ _ => by simp [Path.extend, Path.Homotopy.eval]
 
-/-- **Homotopy invariance of the winding number off the curve.** Two closed paths joined through
-`ℂ \ {w}` by a path homotopy whose extension to the unit square is `C²` have the same winding number
-about `w`. -/
-theorem windingNumber_eq_of_pathHomotopy {x w : ℂ} {p q : Path x x} (φ : p.Homotopy q)
+/-- **A path homotopy avoiding `w` preserves the curve integral of the index form.** -/
+private theorem curveIntegral_indexForm_eq_of_pathHomotopy {x w : ℂ} {p q : Path x x}
+    (φ : p.Homotopy q)
     (hφsmooth : ContDiffOn ℝ 2
       (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
-    (havoid : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ≠ w) :
-    windingNumber p.extend 0 1 w = windingNumber q.extend 0 1 w := by
+    (haway : ∀ z ∈ Set.range φ, z ≠ w) :
+    (∫ᶜ z in p, indexForm w z) = ∫ᶜ z in q, indexForm w z := by
   have hrange : IsClosed (Set.range φ) :=
     (isCompact_range φ.toHomotopy.continuous).isClosed
-  have haway {z : ℂ} (hz : z ∈ Set.range φ) : z ≠ w := by
-    obtain ⟨st, rfl⟩ := hz
-    exact havoid st
   have hclosedForm : ∀ z ∈ Set.range φ,
       HasFDerivWithinAt (indexForm w) (indexFormDeriv w z) (Set.range φ) z :=
-    fun z hz ↦ (hasFDerivAt_indexForm (haway hz)).hasFDerivWithinAt
+    fun z hz ↦ (hasFDerivAt_indexForm (haway z hz)).hasFDerivWithinAt
   have hcontinuousForm : ContinuousOn (indexForm w) (closure (Set.range φ)) := by
     rw [hrange.closure_eq]
-    exact fun z hz ↦ (hasFDerivAt_indexForm (haway hz)).continuousAt.continuousWithinAt
+    exact fun z hz ↦ (hasFDerivAt_indexForm (haway z hz)).continuousAt.continuousWithinAt
   have hboundary :=
     φ.toHomotopy.curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt
       (t := Set.range φ) (ω := indexForm w) (dω := indexFormDeriv w)
@@ -141,8 +137,20 @@ theorem windingNumber_eq_of_pathHomotopy {x w : ℂ} {p q : Path x x} (φ : p.Ho
     ext t
     exact φ.target t
   rw [heval_zero, heval_one] at hboundary
-  have hcurve : (∫ᶜ z in p, indexForm w z) = ∫ᶜ z in q, indexForm w z := by
-    simpa only [curveIntegral_cast, curveIntegral_refl, add_zero] using hboundary
+  simpa only [curveIntegral_cast, curveIntegral_refl, add_zero] using hboundary
+
+/-- **Homotopy invariance of the winding number off the curve.** Two closed paths joined through
+`ℂ \ {w}` by a path homotopy whose extension to the unit square is `C²` have the same winding number
+about `w`. -/
+theorem windingNumber_eq_of_pathHomotopy {x w : ℂ} {p q : Path x x} (φ : p.Homotopy q)
+    (hφsmooth : ContDiffOn ℝ 2
+      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
+    (havoid : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ≠ w) :
+    windingNumber p.extend 0 1 w = windingNumber q.extend 0 1 w := by
+  have haway : ∀ z ∈ Set.range φ, z ≠ w := by
+    rintro _ ⟨st, rfl⟩
+    exact havoid st
+  have hcurve := curveIntegral_indexForm_eq_of_pathHomotopy φ hφsmooth haway
   have hcurve' :
       (∫ᶜ z in p, (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ) =
         ∫ᶜ z in q, (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ := by
@@ -153,10 +161,10 @@ theorem windingNumber_eq_of_pathHomotopy {x w : ℂ} {p q : Path x x} (φ : p.Ho
     simpa using isPiecewiseC1On_eval_of_smoothPathHomotopy φ hφsmooth (1 : I)
   rw [windingNumber_eq_two_pi_I_inv_mul_curveIntegral
       hp
-      (fun t ↦ haway ⟨(0, t), by simp⟩),
+      (fun t ↦ haway _ ⟨(0, t), by simp⟩),
     windingNumber_eq_two_pi_I_inv_mul_curveIntegral
       hq
-      (fun t ↦ haway ⟨(1, t), by simp⟩),
+      (fun t ↦ haway _ ⟨(1, t), by simp⟩),
     hcurve']
 
 /-- Null-homology in `Ω` is invariant under a `C²` path homotopy whose image lies in `Ω`. -/


### PR DESCRIPTION
`windingNumber_eq_of_pathHomotopy` did two different things in one 43-line body. First a Stokes
argument on the unit square: the index form is closed off `w`, so
`curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt` applies, and the two constant edges of
the homotopy contribute nothing. Only then does the winding number appear at all, via
`windingNumber_eq_two_pi_I_inv_mul_curveIntegral` on each end path.

`curveIntegral_indexForm_eq_of_pathHomotopy` is the first part, stated on its own: a path homotopy
avoiding `w` preserves `∫ᶜ z in p, indexForm w z`. It says nothing about winding numbers, and it
takes the avoidance hypothesis in the form its proof uses — `∀ z ∈ Set.range φ, z ≠ w` — rather
than the parent's `∀ st, φ st ≠ w`.

**The split exposed an unnecessary hypothesis.** Once the Stokes step stands alone it is visible
that closure is never used: the two constant edges of the square are `Path.refl x` and
`Path.refl y`, which the loop case merely identifies. So both the helper and the public
`windingNumber_eq_of_pathHomotopy` are now stated for `p q : Path x y` rather than `Path x x`.
Both in-file consumers pass loops and are unaffected; the theorem and module docstrings are
updated to match, since they previously said "closed path".

Proof body: 43 → 20 lines; the new body is 24.

Roadmap: ContourIntegration

---

**On the visibility of the Stokes lemma.**

The server round asked for it to be public. `api-design` at `7a233b2d`: *"is declared `private`, so
consumers cannot use the reusable curve-integral invariance result independently of winding
numbers. Fix: Make the theorem public, stating its integrand explicitly as
`(z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ` so the implementation-only `indexForm` abbreviation can
remain private."* `proof-quality` said the same thing independently. That is what `b5d68439` does,
and both of those rubrics are satisfied by it.

For transparency: my local dry run — same rubric, different judge model — reaches the opposite
conclusion on the public state, asking to keep the helper private until a roadmap consumer needs
it. I have not flipped back, because flipping would simply re-raise the server finding that
prompted the change, and the server round is the gate. If the private form is preferred after all,
the revert is one commit and I will make it, but the two `api-design` verdicts need reconciling
first rather than alternating.
