### PR TITLE
feat(Contour): the argument principle for a cycle through the zeros

### DIFF
--- a/TauCeti/Analysis/Contour/Argument/CyclePV.lean
+++ b/TauCeti/Analysis/Contour/Argument/CyclePV.lean
@@ -8,13 +8,11 @@ module
 public import TauCeti.Analysis.Contour.HungerbuhlerWasem
 public import TauCeti.Analysis.Contour.Residue.LogDeriv
 
-import TauCeti.Analysis.Contour.Argument.Principle
-
 /-!
 # The argument principle for a cycle running through the zeros
 
 The argument principle in the form that tolerates zeros and poles **on** the contour. For `f`
-whose zeros and poles in an open `U` all lie in a finite `S ⊆ U`, and a closed piecewise-`C¹`
+whose zeros and poles in an open `U` all lie in a finite `S`, and a closed piecewise-`C¹`
 *immersion* `γ` null-homologous in `U` and based off `S`, the Cauchy principal value of the
 logarithmic integral is
 
@@ -49,6 +47,14 @@ converge.
 * `TauCeti.Contour.hasCauchyPV_logDeriv_nullHomologous` — the principal-value argument principle
   for a cycle through the zeros.
 
+## Provenance
+
+Adapted from the AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) valence-formula
+development, whose `ForMathlib/GeneralizedResidueTheory/Residue.lean` and
+`.../Residue/GeneralizedTheoremBase.lean` apply the generalized residue theorem to `logDeriv f`;
+here stated against Mathlib's `meromorphicOrderAt` and the raw-`γ` design of the
+contour-integration roadmap.
+
 ## References
 
 * N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
@@ -62,8 +68,8 @@ open Set
 namespace TauCeti.Contour
 
 /-- **The argument principle for a cycle running through the zeros.** For `f` analytic and
-non-vanishing on `U` off a finite `S ⊆ U`, meromorphic at each point of `S` of order `ord`, and a
-closed piecewise-`C¹` immersion `γ` in `U`, null-homologous there and based off `S`,
+non-vanishing on `U` off a finite `S`, meromorphic of order `ord` at each point of `S` lying in
+`U`, and a closed piecewise-`C¹` immersion `γ` in `U`, null-homologous there and based off `S`,
 
 `p.v. ∮_γ f'/f = 2πi · Σ_{z ∈ S} n_z(γ) · ord z`.
 
@@ -71,37 +77,56 @@ Unlike `TauCeti.Contour.argumentPrinciple_nullHomologous`, the curve is free to 
 points of `S`: where the order is nonzero `f'/f` then has a pole on the contour, the integral
 exists only as a principal value, and the generalized winding number supplies the weight, which
 need not be an integer — `1/2` in the standard configuration of a positively oriented curve with
-a single smooth branch through the point. Only the basepoint `γ a` is required to avoid `S`, as
-it is what the principal value is anchored at.
+a single smooth branch through the point. Of the curve, only the endpoint `γ a` is required to
+avoid `S`; that restriction is inherited from the Hungerbühler–Wasem theorem, not from the
+principal value, which excises symmetrically about each singularity.
 
-The order function is prescribed at every point of `S`; `S` may list regular non-vanishing points
-of `f`, whose order is `0` and which therefore contribute nothing. -/
+Nothing is asked of `f` at a point of `S` outside `U`: null-homology forces the winding number
+there to vanish, so such a term drops out whatever `ord` says. `S` may equally list regular
+non-vanishing points of `f`, whose order is `0`. -/
 theorem hasCauchyPV_logDeriv_nullHomologous {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} {ord : ℂ → ℤ}
-    (hU : IsOpen U) (hSU : (S : Set ℂ) ⊆ U)
+    (hU : IsOpen U)
     (hoff : ∀ z ∈ U, z ∉ S → AnalyticAt ℂ f z ∧ f z ≠ 0)
-    (hmero : ∀ s ∈ S, MeromorphicAt f s)
-    (hord : ∀ s ∈ S, meromorphicOrderAt f s = (ord s : WithTop ℤ))
+    (hmero : ∀ s ∈ S, s ∈ U → MeromorphicAt f s)
+    (hord : ∀ s ∈ S, s ∈ U → meromorphicOrderAt f s = (ord s : WithTop ℤ))
     {γ : ℝ → ℂ} {a b : ℝ} (hγ_imm : IsPwC1ImmersionOn γ a b)
     (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b) (hγa : γ a ∉ (S : Set ℂ))
     (hnull : IsNullHomologous γ a b U) :
     HasCauchyPV γ a b (logDeriv f)
       (2 * (Real.pi : ℂ) * Complex.I * ∑ z ∈ S, windingNumber γ a b z * (ord z : ℂ)) := by
-  -- Off `S` the function is analytic and non-vanishing, so its logarithmic derivative is
-  -- holomorphic there; at a point of `S` it is meromorphic, being `deriv f / f`.
-  have hdiff : DifferentiableOn ℂ (logDeriv f) (U \ (↑S : Set ℂ)) := fun z hz =>
-    (analyticAt_logDeriv_of_analyticAt (hoff z hz.1 hz.2).1
+  classical
+  -- Only the points of `S` inside `U` can contribute: run the residue theorem on those, and let
+  -- null-homology kill the rest.
+  set T : Finset ℂ := S.filter (· ∈ U) with hT
+  have hTS : T ⊆ S := Finset.filter_subset _ _
+  have hmemT : ∀ {z : ℂ}, z ∈ T ↔ z ∈ S ∧ z ∈ U := by
+    intro z; rw [hT, Finset.mem_filter]
+  have hTU : (T : Set ℂ) ⊆ U := fun z hz => (hmemT.mp hz).2
+  -- On `U` the two exceptional sets agree, so the off-`S` hypothesis serves `T` unchanged.
+  have hUT : U \ (↑T : Set ℂ) = U \ (↑S : Set ℂ) := by
+    ext z
+    exact ⟨fun hz => ⟨hz.1, fun hzS => hz.2 (hmemT.mpr ⟨hzS, hz.1⟩)⟩,
+      fun hz => ⟨hz.1, fun hzT => hz.2 (hTS hzT)⟩⟩
+  have hdiff : DifferentiableOn ℂ (logDeriv f) (U \ (↑T : Set ℂ)) := by
+    rw [hUT]
+    exact fun z hz => (analyticAt_logDeriv_of_analyticAt (hoff z hz.1 hz.2).1
       (hoff z hz.1 hz.2).2).differentiableAt.differentiableWithinAt
-  have hmeroL : ∀ s ∈ S, MeromorphicAt (logDeriv f) s := fun s hs =>
-    (hmero s hs).deriv.div (hmero s hs)
-  -- `Res_s (f'/f) = ord_s f` at every point of `S`.
-  have hsum : ∑ s ∈ S, windingNumber γ a b s * residue (logDeriv f) s
-      = ∑ z ∈ S, windingNumber γ a b z * (ord z : ℂ) :=
-    Finset.sum_congr rfl fun s hs => by
-      rw [residue_logDeriv_eq_meromorphicOrderAt (hmero s hs) (hord s hs)]
+  have hmeroT : ∀ s ∈ T, MeromorphicAt f s := fun s hs =>
+    hmero s (hTS hs) (hmemT.mp hs).2
+  have hmeroL : ∀ s ∈ T, MeromorphicAt (logDeriv f) s := fun s hs =>
+    (hmeroT s hs).deriv.div (hmeroT s hs)
+  -- `Res_s (f'/f) = ord_s f` inside `U`, and outside it the winding number vanishes.
+  have hsum : ∑ s ∈ T, windingNumber γ a b s * residue (logDeriv f) s
+      = ∑ z ∈ S, windingNumber γ a b z * (ord z : ℂ) := by
+    rw [Finset.sum_congr rfl fun s hs => by
+      rw [residue_logDeriv_eq_meromorphicOrderAt (hmeroT s hs)
+        (hord s (hTS hs) (hmemT.mp hs).2)]]
+    refine Finset.sum_subset hTS fun z hzS hzT => ?_
+    rw [isNullHomologous_iff.mp hnull z fun hzU => hzT (hmemT.mpr ⟨hzS, hzU⟩), zero_mul]
   rw [← hsum]
-  exact hungerbuhlerWasem_residueTheorem_of_simple_poles hU S γ a b hγ_imm hSU hclosed hγa hγU
-    hdiff hmeroL hnull fun s hs =>
-      neg_one_le_meromorphicOrderAt_logDeriv (hmero s hs)
+  exact hungerbuhlerWasem_residueTheorem_of_simple_poles hU T γ a b hγ_imm hTU hclosed
+    (fun h => hγa (hTS h)) hγU hdiff hmeroL hnull fun s hs =>
+      neg_one_le_meromorphicOrderAt_logDeriv (hmeroT s hs)
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Argument/CyclePV.lean
+++ b/TauCeti/Analysis/Contour/Argument/CyclePV.lean
@@ -32,13 +32,13 @@ two ordinary winding numbers on either side of the branch, so any `k ± 1/2` occ
 The proof is the Hungerbühler–Wasem residue theorem in its simple-pole regime
 (`TauCeti.Contour.hungerbuhlerWasem_residueTheorem_of_simple_poles`) applied to `logDeriv f`,
 whose residue at each point is the order of `f` there
-(`TauCeti.Contour.residue_logDeriv_eq_meromorphicOrderAt`). What that regime asks for, and what
-this file supplies, is that `logDeriv f` has at worst a simple pole at each point of `S`: HW's
-conditions (A′) and (B) are then automatic, so no regularity hypothesis beyond the immersion
-survives into the statement. The bound is not an extra assumption on `f` but a fact about
-logarithmic derivatives — `f'/f` has a simple pole at a zero or pole of `f` whatever the order
-there — which is why the hypotheses below are those of the classical statement with the
-avoidance dropped.
+(`TauCeti.Contour.residue_logDeriv_eq_meromorphicOrderAt`). What that regime asks for is that
+`logDeriv f` have at worst a simple pole at each point of `S`, which is
+`TauCeti.Contour.neg_one_le_meromorphicOrderAt_logDeriv`: HW's conditions (A′) and (B) are then
+automatic, so no regularity hypothesis beyond the immersion survives into the statement. That
+bound is not an extra assumption on `f` but a fact about logarithmic derivatives — `f'/f` has a
+simple pole at a zero or pole of `f` whatever the order there — which is why the hypotheses below
+are those of the classical statement with the avoidance dropped.
 
 Immersion, rather than mere piecewise-`C¹` regularity, is what the principal value at an on-curve
 singularity needs: the curve must leave the point at a definite speed for the excised integrals to
@@ -46,8 +46,6 @@ converge.
 
 ## Main results
 
-* `TauCeti.Contour.neg_one_le_meromorphicOrderAt_logDeriv` — a logarithmic derivative has at
-  worst a simple pole.
 * `TauCeti.Contour.hasCauchyPV_logDeriv_nullHomologous` — the principal-value argument principle
   for a cycle through the zeros.
 
@@ -62,60 +60,6 @@ public section
 open Set
 
 namespace TauCeti.Contour
-
-/-- **A logarithmic derivative has at worst a simple pole.** If `f` is meromorphic at `z₀`, of
-whatever order, then `meromorphicOrderAt (logDeriv f) z₀ ≥ -1`.
-
-Near `z₀` the logarithmic derivative splits as `n · (· − z₀)⁻¹ + logDeriv g` with `g` analytic and
-non-vanishing (`TauCeti.Contour.logDeriv_eventuallyEq_principalPart`); *that first summand* has
-order at least `-1`, being exactly `-1` when `n ≠ 0` and `⊤` when `n = 0`, where it is the zero
-function; the second summand is analytic; so the order of the sum is at least `-1`.
-Differentiating cannot make the pole worse than simple however deep the zero or pole of `f` is: a
-zero of order `n` contributes `n/(z - z₀)`, whose order is `-1` irrespective of `n`.
-
-For `logDeriv f` itself the order is exactly `-1` when `ord_{z₀} f ≠ 0` — the analytic tail cannot
-cancel a nonzero principal coefficient — merely `≥ 0` when `ord_{z₀} f = 0`, where `f'/f = g'/g`
-is analytic, and `⊤` when `f` vanishes identically near `z₀`, where `f'/f = deriv f / 0` vanishes
-too. Only the last case is not covered by the splitting, and it is handled separately below.
-
-Meromorphy is essential rather than bookkeeping: at an essential singularity the bound fails, the
-logarithmic derivative of `z ↦ exp (-z⁻¹)` being `z ↦ (z ^ 2)⁻¹`, of order `-2` at `0`.
-
-This is the hypothesis that puts the argument principle into the unconditional regime of the
-Hungerbühler–Wasem residue theorem. -/
-theorem neg_one_le_meromorphicOrderAt_logDeriv {f : ℂ → ℂ} {z₀ : ℂ} (hf : MeromorphicAt f z₀) :
-    ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (logDeriv f) z₀ := by
-  rcases eq_or_ne (meromorphicOrderAt f z₀) ⊤ with htop | hne
-  · -- `f` vanishes on a punctured neighbourhood, so `logDeriv f = deriv f / f` vanishes there too.
-    have hlog : meromorphicOrderAt (logDeriv f) z₀ = ⊤ := by
-      rw [meromorphicOrderAt_eq_top_iff] at htop ⊢
-      filter_upwards [htop] with z hz
-      simp [logDeriv, hz]
-    rw [hlog]
-    exact le_top
-  obtain ⟨n, hn⟩ := WithTop.ne_top_iff_exists.mp hne
-  obtain ⟨g, hg_an, hg_ne, hgerm⟩ := logDeriv_eventuallyEq_principalPart hf hn.symm
-  have hlogg_an : AnalyticAt ℂ (logDeriv g) z₀ := analyticAt_logDeriv_of_analyticAt hg_an hg_ne
-  have hinv : MeromorphicAt (fun z => (z - z₀)⁻¹) z₀ := meromorphicAt_sub_inv z₀
-  have hA : MeromorphicAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ :=
-    analyticAt_const.meromorphicAt.mul hinv
-  have hinv_order : meromorphicOrderAt (fun z : ℂ => (z - z₀)⁻¹) z₀ = ((-1 : ℤ) : WithTop ℤ) := by
-    rw [show (fun z : ℂ => (z - z₀)⁻¹) = ((· - z₀) ^ (-1 : ℤ)) from
-      funext fun z => (zpow_neg_one _).symm]
-    exact meromorphicOrderAt_zpow_id_sub_const
-  have hprincipal :
-      ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ := by
-    rw [show (fun z => (n : ℂ) * (z - z₀)⁻¹)
-        = (fun _ => (n : ℂ)) * (fun z : ℂ => (z - z₀)⁻¹) from rfl,
-      meromorphicOrderAt_mul analyticAt_const.meromorphicAt hinv, hinv_order]
-    exact le_add_of_nonneg_left analyticAt_const.meromorphicOrderAt_nonneg
-  rw [meromorphicOrderAt_congr hgerm,
-    show (fun z => (n : ℂ) * (z - z₀)⁻¹ + logDeriv g z)
-        = (fun z => (n : ℂ) * (z - z₀)⁻¹) + logDeriv g from rfl]
-  exact le_trans (le_min hprincipal
-    (le_trans (by exact_mod_cast (by norm_num : (-1 : ℤ) ≤ (0 : ℤ)))
-      hlogg_an.meromorphicOrderAt_nonneg))
-    (meromorphicOrderAt_add hA hlogg_an.meromorphicAt)
 
 /-- **The argument principle for a cycle running through the zeros.** For `f` analytic and
 non-vanishing on `U` off a finite `S ⊆ U`, meromorphic at each point of `S` of order `ord`, and a

--- a/TauCeti/Analysis/Contour/Argument/CyclePV.lean
+++ b/TauCeti/Analysis/Contour/Argument/CyclePV.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Contour.HungerbuhlerWasem
+public import TauCeti.Analysis.Contour.Residue.LogDeriv
+
+import TauCeti.Analysis.Contour.Argument.Principle
+
+/-!
+# The argument principle for a cycle running through the zeros
+
+The argument principle in the form that tolerates zeros and poles **on** the contour. For `f`
+whose zeros and poles in an open `U` all lie in a finite `S ⊆ U`, and a closed piecewise-`C¹`
+*immersion* `γ` null-homologous in `U` and based off `S`, the Cauchy principal value of the
+logarithmic integral is
+
+`p.v. ∮_γ f'/f = 2πi · Σ_{z ∈ S} n_z(γ) · ord_z f`,
+
+with the generalized (non-integer) winding numbers as weights. Where
+`TauCeti.Contour.argumentPrinciple_nullHomologous` requires `γ` to avoid `S` and produces an
+ordinary integral, here `γ` may run through the points of `S` — a zero on the contour is a pole
+of `f'/f` on the contour, so the integral exists only as a principal value, and the point
+contributes its order weighted by a winding number that need not be an integer: a contour that
+passes smoothly through a zero sees it with weight `1/2`, and one with a corner there sees the
+corresponding fraction of a full turn.
+
+The proof is the Hungerbühler–Wasem residue theorem in its simple-pole regime
+(`TauCeti.Contour.hungerbuhlerWasem_residueTheorem_of_simple_poles`) applied to `logDeriv f`,
+whose residue at each point is the order of `f` there
+(`TauCeti.Contour.residue_logDeriv_eq_meromorphicOrderAt`). What that regime asks for, and what
+this file supplies, is that `logDeriv f` has at worst a simple pole at each point of `S`: HW's
+conditions (A′) and (B) are then automatic, so no regularity hypothesis beyond the immersion
+survives into the statement. The bound is not an extra assumption on `f` but a fact about
+logarithmic derivatives — `f'/f` has a simple pole at a zero or pole of `f` whatever the order
+there — which is why the hypotheses below are those of the classical statement with the
+avoidance dropped.
+
+Immersion, rather than mere piecewise-`C¹` regularity, is what the principal value at an on-curve
+singularity needs: the curve must leave the point at a definite speed for the excised integrals to
+converge.
+
+## Main results
+
+* `TauCeti.Contour.neg_one_le_meromorphicOrderAt_logDeriv` — a logarithmic derivative has at
+  worst a simple pole.
+* `TauCeti.Contour.hasCauchyPV_logDeriv_nullHomologous` — the principal-value argument principle
+  for a cycle through the zeros.
+
+## References
+
+* N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, arXiv:1808.00997.
+-/
+
+public section
+
+open Set
+
+namespace TauCeti.Contour
+
+/-- **A logarithmic derivative has at worst a simple pole.** If `f` is meromorphic at `z₀`, of
+whatever order, then `meromorphicOrderAt (logDeriv f) z₀ ≥ -1`.
+
+Near `z₀` the logarithmic derivative splits as `n · (· − z₀)⁻¹ + logDeriv g` with `g` analytic and
+non-vanishing (`TauCeti.Contour.logDeriv_eventuallyEq_principalPart`); that first summand has order
+at least `-1` — exactly `-1` when `n ≠ 0`, and `⊤` when `n = 0` — and the second is analytic, so
+the order of the sum is at least `-1`. Differentiating cannot make the pole worse than simple
+however deep the zero or pole of `f` is: a zero of order `n` contributes `n/(z - z₀)`, whose
+order is `-1` irrespective of `n`. The remaining case, `f` vanishing identically near `z₀`, has
+`logDeriv f` vanishing there too, of order `⊤`.
+
+This is the hypothesis that puts the argument principle into the unconditional regime of the
+Hungerbühler–Wasem residue theorem. -/
+theorem neg_one_le_meromorphicOrderAt_logDeriv {f : ℂ → ℂ} {z₀ : ℂ} (hf : MeromorphicAt f z₀) :
+    ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (logDeriv f) z₀ := by
+  rcases eq_or_ne (meromorphicOrderAt f z₀) ⊤ with htop | hne
+  · -- `f` vanishes on a punctured neighbourhood, so `logDeriv f = deriv f / f` vanishes there too.
+    have hlog : meromorphicOrderAt (logDeriv f) z₀ = ⊤ := by
+      rw [meromorphicOrderAt_eq_top_iff] at htop ⊢
+      filter_upwards [htop] with z hz
+      simp [logDeriv, hz]
+    rw [hlog]
+    exact le_top
+  obtain ⟨n, hn⟩ := WithTop.ne_top_iff_exists.mp hne
+  obtain ⟨g, hg_an, hg_ne, hgerm⟩ := logDeriv_eventuallyEq_principalPart hf hn.symm
+  have hlogg_an : AnalyticAt ℂ (logDeriv g) z₀ := analyticAt_logDeriv_of_analyticAt hg_an hg_ne
+  have hinv : MeromorphicAt (fun z => (z - z₀)⁻¹) z₀ := meromorphicAt_sub_inv z₀
+  have hA : MeromorphicAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ :=
+    analyticAt_const.meromorphicAt.mul hinv
+  have hinv_order : meromorphicOrderAt (fun z : ℂ => (z - z₀)⁻¹) z₀ = ((-1 : ℤ) : WithTop ℤ) := by
+    rw [show (fun z : ℂ => (z - z₀)⁻¹) = ((· - z₀) ^ (-1 : ℤ)) from
+      funext fun z => (zpow_neg_one _).symm]
+    exact meromorphicOrderAt_zpow_id_sub_const
+  have hprincipal :
+      ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ := by
+    rw [show (fun z => (n : ℂ) * (z - z₀)⁻¹)
+        = (fun _ => (n : ℂ)) * (fun z : ℂ => (z - z₀)⁻¹) from rfl,
+      meromorphicOrderAt_mul analyticAt_const.meromorphicAt hinv, hinv_order]
+    exact le_add_of_nonneg_left analyticAt_const.meromorphicOrderAt_nonneg
+  rw [meromorphicOrderAt_congr hgerm,
+    show (fun z => (n : ℂ) * (z - z₀)⁻¹ + logDeriv g z)
+        = (fun z => (n : ℂ) * (z - z₀)⁻¹) + logDeriv g from rfl]
+  exact le_trans (le_min hprincipal
+    (le_trans (by exact_mod_cast (by norm_num : (-1 : ℤ) ≤ (0 : ℤ)))
+      hlogg_an.meromorphicOrderAt_nonneg))
+    (meromorphicOrderAt_add hA hlogg_an.meromorphicAt)
+
+/-- **The argument principle for a cycle running through the zeros.** For `f` analytic and
+non-vanishing on `U` off a finite `S ⊆ U`, meromorphic at each point of `S` of order `ord`, and a
+closed piecewise-`C¹` immersion `γ` in `U`, null-homologous there and based off `S`,
+
+`p.v. ∮_γ f'/f = 2πi · Σ_{z ∈ S} n_z(γ) · ord z`.
+
+Unlike `TauCeti.Contour.argumentPrinciple_nullHomologous`, the curve is free to pass through the
+points of `S`: at such a point `f'/f` has a pole on the contour, the integral exists only as a
+principal value, and the generalized winding number supplies the fractional weight — `1/2` where
+the curve passes smoothly through the point. Only the basepoint `γ a` is required to avoid `S`,
+as it is what the principal value is anchored at.
+
+The order function is prescribed at every point of `S`; `S` may list regular non-vanishing points
+of `f`, whose order is `0` and which therefore contribute nothing. -/
+theorem hasCauchyPV_logDeriv_nullHomologous {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} {ord : ℂ → ℤ}
+    (hU : IsOpen U) (hSU : (S : Set ℂ) ⊆ U)
+    (hoff : ∀ z ∈ U, z ∉ S → AnalyticAt ℂ f z ∧ f z ≠ 0)
+    (hmero : ∀ s ∈ S, MeromorphicAt f s)
+    (hord : ∀ s ∈ S, meromorphicOrderAt f s = (ord s : WithTop ℤ))
+    {γ : ℝ → ℂ} {a b : ℝ} (hγ_imm : IsPwC1ImmersionOn γ a b)
+    (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b) (hγa : γ a ∉ (S : Set ℂ))
+    (hnull : IsNullHomologous γ a b U) :
+    HasCauchyPV γ a b (logDeriv f)
+      (2 * (Real.pi : ℂ) * Complex.I * ∑ z ∈ S, windingNumber γ a b z * (ord z : ℂ)) := by
+  -- Off `S` the function is analytic and non-vanishing, so its logarithmic derivative is
+  -- holomorphic there; at a point of `S` it is meromorphic, being `deriv f / f`.
+  have hdiff : DifferentiableOn ℂ (logDeriv f) (U \ (↑S : Set ℂ)) := fun z hz =>
+    (analyticAt_logDeriv_of_analyticAt (hoff z hz.1 hz.2).1
+      (hoff z hz.1 hz.2).2).differentiableAt.differentiableWithinAt
+  have hmeroL : ∀ s ∈ S, MeromorphicAt (logDeriv f) s := fun s hs =>
+    (hmero s hs).deriv.div (hmero s hs)
+  -- `Res_s (f'/f) = ord_s f` at every point of `S`.
+  have hsum : ∑ s ∈ S, windingNumber γ a b s * residue (logDeriv f) s
+      = ∑ z ∈ S, windingNumber γ a b z * (ord z : ℂ) :=
+    Finset.sum_congr rfl fun s hs => by
+      rw [residue_logDeriv_eq_meromorphicOrderAt (hmero s hs) (hord s hs)]
+  rw [← hsum]
+  exact hungerbuhlerWasem_residueTheorem_of_simple_poles hU S γ a b hγ_imm hSU hclosed hγa hγU
+    hdiff hmeroL hnull fun s hs =>
+      neg_one_le_meromorphicOrderAt_logDeriv (hmero s hs)
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/Argument/CyclePV.lean
+++ b/TauCeti/Analysis/Contour/Argument/CyclePV.lean
@@ -24,9 +24,10 @@ with the generalized (non-integer) winding numbers as weights. Where
 `TauCeti.Contour.argumentPrinciple_nullHomologous` requires `γ` to avoid `S` and produces an
 ordinary integral, here `γ` may run through the points of `S` — a zero on the contour is a pole
 of `f'/f` on the contour, so the integral exists only as a principal value, and the point
-contributes its order weighted by a winding number that need not be an integer: a contour that
-passes smoothly through a zero sees it with weight `1/2`, and one with a corner there sees the
-corresponding fraction of a full turn.
+contributes its order weighted by a winding number that need not be an integer. In the standard
+configuration — a positively oriented curve with a single smooth branch through the point — that
+weight is `1/2`; in general the generalized winding number at such a point is the average of the
+two ordinary winding numbers on either side of the branch, so any `k ± 1/2` occurs.
 
 The proof is the Hungerbühler–Wasem residue theorem in its simple-pole regime
 (`TauCeti.Contour.hungerbuhlerWasem_residueTheorem_of_simple_poles`) applied to `logDeriv f`,
@@ -66,12 +67,19 @@ namespace TauCeti.Contour
 whatever order, then `meromorphicOrderAt (logDeriv f) z₀ ≥ -1`.
 
 Near `z₀` the logarithmic derivative splits as `n · (· − z₀)⁻¹ + logDeriv g` with `g` analytic and
-non-vanishing (`TauCeti.Contour.logDeriv_eventuallyEq_principalPart`); that first summand has order
-at least `-1` — exactly `-1` when `n ≠ 0`, and `⊤` when `n = 0` — and the second is analytic, so
-the order of the sum is at least `-1`. Differentiating cannot make the pole worse than simple
-however deep the zero or pole of `f` is: a zero of order `n` contributes `n/(z - z₀)`, whose
-order is `-1` irrespective of `n`. The remaining case, `f` vanishing identically near `z₀`, has
-`logDeriv f` vanishing there too, of order `⊤`.
+non-vanishing (`TauCeti.Contour.logDeriv_eventuallyEq_principalPart`); *that first summand* has
+order at least `-1`, being exactly `-1` when `n ≠ 0` and `⊤` when `n = 0`, where it is the zero
+function; the second summand is analytic; so the order of the sum is at least `-1`.
+Differentiating cannot make the pole worse than simple however deep the zero or pole of `f` is: a
+zero of order `n` contributes `n/(z - z₀)`, whose order is `-1` irrespective of `n`.
+
+For `logDeriv f` itself the order is exactly `-1` when `ord_{z₀} f ≠ 0` — the analytic tail cannot
+cancel a nonzero principal coefficient — merely `≥ 0` when `ord_{z₀} f = 0`, where `f'/f = g'/g`
+is analytic, and `⊤` when `f` vanishes identically near `z₀`, where `f'/f = deriv f / 0` vanishes
+too. Only the last case is not covered by the splitting, and it is handled separately below.
+
+Meromorphy is essential rather than bookkeeping: at an essential singularity the bound fails, the
+logarithmic derivative of `z ↦ exp (-z⁻¹)` being `z ↦ (z ^ 2)⁻¹`, of order `-2` at `0`.
 
 This is the hypothesis that puts the argument principle into the unconditional regime of the
 Hungerbühler–Wasem residue theorem. -/
@@ -116,10 +124,11 @@ closed piecewise-`C¹` immersion `γ` in `U`, null-homologous there and based of
 `p.v. ∮_γ f'/f = 2πi · Σ_{z ∈ S} n_z(γ) · ord z`.
 
 Unlike `TauCeti.Contour.argumentPrinciple_nullHomologous`, the curve is free to pass through the
-points of `S`: at such a point `f'/f` has a pole on the contour, the integral exists only as a
-principal value, and the generalized winding number supplies the fractional weight — `1/2` where
-the curve passes smoothly through the point. Only the basepoint `γ a` is required to avoid `S`,
-as it is what the principal value is anchored at.
+points of `S`: where the order is nonzero `f'/f` then has a pole on the contour, the integral
+exists only as a principal value, and the generalized winding number supplies the weight, which
+need not be an integer — `1/2` in the standard configuration of a positively oriented curve with
+a single smooth branch through the point. Only the basepoint `γ a` is required to avoid `S`, as
+it is what the principal value is anchored at.
 
 The order function is prescribed at every point of `S`; `S` may list regular non-vanishing points
 of `f`, whose order is `0` and which therefore contribute nothing. -/

--- a/TauCeti/Analysis/Contour/Argument/Principle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Principle.lean
@@ -38,6 +38,8 @@ meaningless — since the results are stated up to the meromorphic normal form o
 * `TauCeti.Contour.argumentPrinciple` — `∮_{C(c,R)} logDeriv f = 2πi · ∑_{z ∈ S} ord z` when all
   nonzero-order points are contained in a finite set `S` inside the open disc, with `ord` agreeing
   with `meromorphicOrderAt f` on `S`.
+* `TauCeti.Contour.neg_one_le_meromorphicOrderAt_logDeriv` — a logarithmic derivative has at
+  worst a simple pole, whatever the order of `f`.
 * `TauCeti.Contour.argumentPrinciple_local` — the special case `S = {c}`:
   `∮_{C(c,R)} logDeriv f = 2πi · n` when the centre `c`, of order `n`, is the only point of the
   closed disc that may have nonzero meromorphic order.
@@ -112,6 +114,62 @@ theorem logDeriv_eventuallyEq_principalPart {F : ℂ → ℂ} {s : ℂ} {n : ℤ
     funext w; rw [smul_eq_mul]
   rw [logDeriv_eq_of_eventuallyEq hz_FH, hmul]
   exact logDeriv_zpow_sub_mul hz_ne hz_gne hz_gan.differentiableAt
+
+/-- **A logarithmic derivative has at worst a simple pole.** If `f` is meromorphic at `z₀`, of
+whatever order, then `meromorphicOrderAt (logDeriv f) z₀ ≥ -1`.
+
+Near `z₀` the logarithmic derivative splits as `n · (· − z₀)⁻¹ + logDeriv g` with `g` analytic and
+non-vanishing (`TauCeti.Contour.logDeriv_eventuallyEq_principalPart`); *that first summand* has
+order at least `-1`, being exactly `-1` when `n ≠ 0` and `⊤` when `n = 0`, where it is the zero
+function; the second summand is analytic; so the order of the sum is at least `-1`.
+Differentiating cannot make the pole worse than simple however deep the zero or pole of `f` is: a
+zero of order `n` contributes `n/(z - z₀)`, whose order is `-1` irrespective of `n`.
+
+For `logDeriv f` itself the order is exactly `-1` when `ord_{z₀} f ≠ 0` — the analytic tail cannot
+cancel a nonzero principal coefficient — merely `≥ 0` when `ord_{z₀} f = 0`, where `f'/f = g'/g`
+is analytic, and `⊤` when `f` vanishes identically near `z₀`, where `f'/f = deriv f / 0` vanishes
+too. Only the last case is not covered by the splitting, and it is handled separately here.
+
+Meromorphy is essential rather than bookkeeping: at an essential singularity the bound fails, the
+logarithmic derivative of `z ↦ exp (-z⁻¹)` being `z ↦ (z ^ 2)⁻¹`, of order `-2` at `0`.
+
+This is what puts the argument principle into the unconditional simple-pole regime of the
+Hungerbühler–Wasem residue theorem, where a contour may run through the zeros
+(`TauCeti.Contour.hasCauchyPV_logDeriv_nullHomologous`). -/
+theorem neg_one_le_meromorphicOrderAt_logDeriv {f : ℂ → ℂ} {z₀ : ℂ} (hf : MeromorphicAt f z₀) :
+    ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (logDeriv f) z₀ := by
+  rcases eq_or_ne (meromorphicOrderAt f z₀) ⊤ with htop | hne
+  · -- `f` vanishes on a punctured neighbourhood, so `logDeriv f = deriv f / f` vanishes there too.
+    have hlog : meromorphicOrderAt (logDeriv f) z₀ = ⊤ := by
+      rw [meromorphicOrderAt_eq_top_iff] at htop ⊢
+      filter_upwards [htop] with z hz
+      simp [logDeriv, hz]
+    rw [hlog]
+    exact le_top
+  obtain ⟨n, hn⟩ := WithTop.ne_top_iff_exists.mp hne
+  obtain ⟨g, hg_an, hg_ne, hgerm⟩ := logDeriv_eventuallyEq_principalPart hf hn.symm
+  have hlogg_an : AnalyticAt ℂ (logDeriv g) z₀ := analyticAt_logDeriv_of_analyticAt hg_an hg_ne
+  have hinv : MeromorphicAt (fun z : ℂ => (z - z₀)⁻¹) z₀ :=
+    ((analyticAt_id.sub analyticAt_const).meromorphicAt).inv
+  have hA : MeromorphicAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ :=
+    analyticAt_const.meromorphicAt.mul hinv
+  have hinv_order : meromorphicOrderAt (fun z : ℂ => (z - z₀)⁻¹) z₀ = ((-1 : ℤ) : WithTop ℤ) := by
+    rw [show (fun z : ℂ => (z - z₀)⁻¹) = ((· - z₀) ^ (-1 : ℤ)) from
+      funext fun z => (zpow_neg_one _).symm]
+    exact meromorphicOrderAt_zpow_id_sub_const
+  have hprincipal :
+      ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ := by
+    rw [show (fun z => (n : ℂ) * (z - z₀)⁻¹)
+        = (fun _ => (n : ℂ)) * (fun z : ℂ => (z - z₀)⁻¹) from rfl,
+      meromorphicOrderAt_mul analyticAt_const.meromorphicAt hinv, hinv_order]
+    exact le_add_of_nonneg_left analyticAt_const.meromorphicOrderAt_nonneg
+  rw [meromorphicOrderAt_congr hgerm,
+    show (fun z => (n : ℂ) * (z - z₀)⁻¹ + logDeriv g z)
+        = (fun z => (n : ℂ) * (z - z₀)⁻¹) + logDeriv g from rfl]
+  exact le_trans (le_min hprincipal
+    (le_trans (by exact_mod_cast (by norm_num : (-1 : ℤ) ≤ (0 : ℤ)))
+      hlogg_an.meromorphicOrderAt_nonneg))
+    (meromorphicOrderAt_add hA hlogg_an.meromorphicAt)
 
 /-- Passing to the meromorphic normal form leaves the log-derivative's circle integral unchanged:
 the two functions agree off a discrete set, which the circle integral does not see. -/

--- a/TauCeti/Analysis/Contour/Argument/Principle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Principle.lean
@@ -118,17 +118,10 @@ theorem logDeriv_eventuallyEq_principalPart {F : ℂ → ℂ} {s : ℂ} {n : ℤ
 /-- **A logarithmic derivative has at worst a simple pole.** If `f` is meromorphic at `z₀`, of
 whatever order, then `meromorphicOrderAt (logDeriv f) z₀ ≥ -1`.
 
-Near `z₀` the logarithmic derivative splits as `n · (· − z₀)⁻¹ + logDeriv g` with `g` analytic and
-non-vanishing (`TauCeti.Contour.logDeriv_eventuallyEq_principalPart`); *that first summand* has
-order at least `-1`, being exactly `-1` when `n ≠ 0` and `⊤` when `n = 0`, where it is the zero
-function; the second summand is analytic; so the order of the sum is at least `-1`.
 Differentiating cannot make the pole worse than simple however deep the zero or pole of `f` is: a
-zero of order `n` contributes `n/(z - z₀)`, whose order is `-1` irrespective of `n`.
-
-For `logDeriv f` itself the order is exactly `-1` when `ord_{z₀} f ≠ 0` — the analytic tail cannot
-cancel a nonzero principal coefficient — merely `≥ 0` when `ord_{z₀} f = 0`, where `f'/f = g'/g`
-is analytic, and `⊤` when `f` vanishes identically near `z₀`, where `f'/f = deriv f / 0` vanishes
-too. Only the last case is not covered by the splitting, and it is handled separately here.
+zero of order `n` contributes `n/(z - z₀)`, whose order is `-1` irrespective of `n`. Sharply, the
+order is `-1` exactly when `ord_{z₀} f ≠ 0`, is `≥ 0` when `ord_{z₀} f = 0`, and is `⊤` when `f`
+vanishes identically near `z₀`.
 
 Meromorphy is essential rather than bookkeeping: at an essential singularity the bound fails, the
 logarithmic derivative of `z ↦ exp (-z⁻¹)` being `z ↦ (z ^ 2)⁻¹`, of order `-2` at `0`.
@@ -153,19 +146,23 @@ theorem neg_one_le_meromorphicOrderAt_logDeriv {f : ℂ → ℂ} {z₀ : ℂ} (h
     ((analyticAt_id.sub analyticAt_const).meromorphicAt).inv
   have hA : MeromorphicAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ :=
     analyticAt_const.meromorphicAt.mul hinv
+  -- The three representation changes below are extensional identities, stated once each rather
+  -- than as inline `show`s: `zpow_neg_one` for the inverse, and `Pi.mul_apply`/`Pi.add_apply` for
+  -- the pointwise product and sum, whose function-level forms the order lemmas are stated in.
+  have hinv_zpow : (fun z : ℂ => (z - z₀)⁻¹) = ((· - z₀) ^ (-1 : ℤ)) :=
+    funext fun z => (zpow_neg_one _).symm
+  have hmul_pi : (fun z : ℂ => (n : ℂ) * (z - z₀)⁻¹)
+      = (fun _ : ℂ => (n : ℂ)) * (fun z : ℂ => (z - z₀)⁻¹) := funext fun z => rfl
+  have hadd_pi : (fun z : ℂ => (n : ℂ) * (z - z₀)⁻¹ + logDeriv g z)
+      = (fun z : ℂ => (n : ℂ) * (z - z₀)⁻¹) + logDeriv g := funext fun z => rfl
   have hinv_order : meromorphicOrderAt (fun z : ℂ => (z - z₀)⁻¹) z₀ = ((-1 : ℤ) : WithTop ℤ) := by
-    rw [show (fun z : ℂ => (z - z₀)⁻¹) = ((· - z₀) ^ (-1 : ℤ)) from
-      funext fun z => (zpow_neg_one _).symm]
+    rw [hinv_zpow]
     exact meromorphicOrderAt_zpow_id_sub_const
   have hprincipal :
       ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (fun z => (n : ℂ) * (z - z₀)⁻¹) z₀ := by
-    rw [show (fun z => (n : ℂ) * (z - z₀)⁻¹)
-        = (fun _ => (n : ℂ)) * (fun z : ℂ => (z - z₀)⁻¹) from rfl,
-      meromorphicOrderAt_mul analyticAt_const.meromorphicAt hinv, hinv_order]
+    rw [hmul_pi, meromorphicOrderAt_mul analyticAt_const.meromorphicAt hinv, hinv_order]
     exact le_add_of_nonneg_left analyticAt_const.meromorphicOrderAt_nonneg
-  rw [meromorphicOrderAt_congr hgerm,
-    show (fun z => (n : ℂ) * (z - z₀)⁻¹ + logDeriv g z)
-        = (fun z => (n : ℂ) * (z - z₀)⁻¹) + logDeriv g from rfl]
+  rw [meromorphicOrderAt_congr hgerm, hadd_pi]
   exact le_trans (le_min hprincipal
     (le_trans (by exact_mod_cast (by norm_num : (-1 : ℤ) ≤ (0 : ℤ)))
       hlogg_an.meromorphicOrderAt_nonneg))


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"argument-principle-pv"}-->

The argument principle in the form the valence formula actually consumes: one where the contour is allowed to **run through** the zeros.

Two declarations: the contour statement in a new `TauCeti/Analysis/Contour/Argument/CyclePV.lean`, and the local order bound it rests on added to the existing `Argument/Principle.lean`, beside the principal-part splitting that proves it.

`TauCeti.Contour.argumentPrinciple_nullHomologous` requires the cycle to avoid the zero/pole set `S` and yields an ordinary integral. The level-one fundamental-domain boundary does not avoid its singular points — it passes through the elliptic points `i` and `ρ`, where `f'/f` has a pole *on* the contour. There the integral exists only as a Cauchy principal value, and the point contributes its order weighted by a generalized, possibly non-integer, winding number.

```lean
theorem hasCauchyPV_logDeriv_nullHomologous {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} {ord : ℂ → ℤ}
    (hU : IsOpen U) (hSU : (S : Set ℂ) ⊆ U)
    (hoff : ∀ z ∈ U, z ∉ S → AnalyticAt ℂ f z ∧ f z ≠ 0)
    (hmero : ∀ s ∈ S, MeromorphicAt f s)
    (hord : ∀ s ∈ S, meromorphicOrderAt f s = (ord s : WithTop ℤ))
    {γ : ℝ → ℂ} {a b : ℝ} (hγ_imm : IsPwC1ImmersionOn γ a b)
    (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b) (hγa : γ a ∉ (S : Set ℂ))
    (hnull : IsNullHomologous γ a b U) :
    HasCauchyPV γ a b (logDeriv f)
      (2 * (Real.pi : ℂ) * Complex.I * ∑ z ∈ S, windingNumber γ a b z * (ord z : ℂ))
```

The hypotheses are those of the classical statement with the avoidance dropped — only the basepoint `γ a`, which the principal value is anchored at, must miss `S` — and with piecewise-`C¹` regularity strengthened to an immersion, which is what a principal value at an on-curve singularity needs.

### How it is proved

It is the Hungerbühler–Wasem residue theorem in its **simple-pole regime** (`hungerbuhlerWasem_residueTheorem_of_simple_poles`, already on `main`) applied to `logDeriv f`, whose residue at each point is the order of `f` there (`residue_logDeriv_eq_meromorphicOrderAt`, also on `main`).

What that regime asks for, and what this PR supplies, is the second declaration — placed in `Argument/Principle.lean`, next to `logDeriv_eventuallyEq_principalPart`, since it is a local structural fact about logarithmic derivatives rather than part of the contour statement:

```lean
theorem neg_one_le_meromorphicOrderAt_logDeriv {f : ℂ → ℂ} {z₀ : ℂ} (hf : MeromorphicAt f z₀) :
    ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt (logDeriv f) z₀
```

A logarithmic derivative has at worst a **simple** pole, however deep the zero or pole of `f`: near `z₀` it splits as `n · (· − z₀)⁻¹ + logDeriv g` with `g` analytic non-vanishing (`logDeriv_eventuallyEq_principalPart`), and a zero of order `n` contributes `n/(z − z₀)`, whose order is `−1` irrespective of `n`. With that bound HW's conditions (A′) and (B) are automatic, which is why no regularity hypothesis beyond the immersion survives into the statement.

The bound is stated for any `MeromorphicAt f z₀`, with no integer-order hypothesis: the remaining case, `f` vanishing identically near `z₀`, has `logDeriv f = deriv f / f` vanishing there too, of order `⊤`.

### Roadmap

This is the milestone the ContourIntegration roadmap describes in Layer 2's argument-principle bullet, in the regime its own text defers to Layer 4:

> **The argument principle** (the valence formula's contour identity) — what the engine *does* add. […] it is the explicit result the valence formula consumes, and the milestone seeded in `Suggested.lean`. The interior orders give the non-elliptic-orbit sum; **the on-contour points `i`, `ρ` are handled by HW Thm 3.3 (Layer 4)**.

This declaration is exactly that combination — the argument principle with the on-contour points handled by HW Thm 3.3 — and it is the prerequisite the ModularForms Layer-1 target `valence_formula` needs, that roadmap routing Layer 1 to the Contour Integration roadmap.

No new mathematics beyond that: both inputs are already on `main`, and the only new content is the simple-pole bound.

### Provenance

Adapted from the AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) valence-formula development, whose `ForMathlib/GeneralizedResidueTheory/` applies the generalized residue theorem to `logDeriv f`; here stated against Mathlib's `meromorphicOrderAt` and the raw-`γ` design of the contour roadmap.

Roadmap: ContourIntegration
