### PR TITLE
feat: prove augmentation cotangent finiteness

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Adjoint
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Cotangent
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Map
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Naturality
 
@@ -14,9 +15,10 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Naturality
 
 Aggregator for the tangent-level theory: the counit-valued derivations
 (`Tangent.Basic`), their description by the cotangent space
-(`Tangent.Cotangent`), functoriality in the bialgebra
-(`Tangent.DerivationMap`, `Tangent.Map`) and coefficient algebra
-(`Tangent.Naturality`), and the adjoint action of the points
+(`Tangent.Cotangent`), finiteness at an identity of finite type
+(`Tangent.FiniteType`),
+functoriality in the bialgebra (`Tangent.DerivationMap`, `Tangent.Map`) and
+coefficient algebra (`Tangent.Naturality`), and the adjoint action of the points
 (`Tangent.Adjoint`).
 The Lie-algebra structure lives in the `Tangent.Lie` aggregator.
 -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/FiniteType.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.RingTheory.Ideal.Cotangent
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Basic
+
+/-!
+# Finiteness of the tangent space of a finite-type affine monoid
+
+An augmentation `f : A →ₐ[R] R` makes the cotangent space at the corresponding point,
+`ker(f) / ker(f)²`, a finite `R`-module whenever `A` is noetherian. Although the augmentation
+ideal is initially only known to be finitely generated over `A`, its action on the cotangent
+space factors through `f`; the same generators therefore span over `R`.
+
+Applied to the counit of a commutative bialgebra of finite type over a noetherian base, this gives
+the finite cotangent space at the identity. Over a field it is consequently finite-dimensional
+and projective, which is the finiteness input for the scalar-extension description of the tangent
+space and the adjoint representation in the ReductiveGroups roadmap, Layer 2.
+
+## Main declarations
+
+* `AlgHom.smul_cotangent_ker_eq`: the action on the cotangent space of an augmented algebra
+  factors through the augmentation.
+* `AlgHom.finite_cotangent_ker`: the cotangent space of an augmented noetherian algebra is finite
+  over the base.
+* `TauCeti.Bialgebra.instModuleFiniteCotangent`: the specialization to the counit of a finite-type
+  commutative bialgebra.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§12 and 14.
+-/
+
+public section
+
+namespace AlgHom
+
+variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]
+
+/-- On `ker(f) / ker(f)²`, multiplication by `a : A` agrees with scalar multiplication by
+`f a : R`, for an augmentation `f : A →ₐ[R] R`. -/
+theorem smul_cotangent_ker_eq (f : A →ₐ[R] R) (a : A)
+    (x : (RingHom.ker f.toRingHom).Cotangent) :
+    a • x = f a • x := by
+  let I := RingHom.ker f.toRingHom
+  have ha : a - algebraMap R A (f a) ∈ I := by
+    simp [I]
+  have hzero : (a - algebraMap R A (f a)) • x = 0 :=
+    Ideal.Cotangent.smul_eq_zero_of_mem ha x
+  rw [sub_smul, sub_eq_zero, algebraMap_smul] at hzero
+  exact hzero
+
+/-- The cotangent space at an augmented point of a noetherian algebra is finite over the base.
+
+The augmentation hypothesis is encoded by the codomain of `f`: because `f` is an `R`-algebra
+homomorphism, it is a retraction of `algebraMap R A`. -/
+theorem finite_cotangent_ker (f : A →ₐ[R] R) [IsNoetherianRing A] :
+    Module.Finite R (RingHom.ker f.toRingHom).Cotangent := by
+  classical
+  let I := RingHom.ker f.toRingHom
+  let _ : Module.Finite A I := by
+    rw [Module.Finite.iff_fg]
+    exact I.fg_of_isNoetherianRing
+  obtain ⟨s, hs⟩ := Module.Finite.fg_top (R := A) (M := I)
+  refine Module.finite_def.mpr ⟨s.image I.toCotangent, ?_⟩
+  rw [Submodule.eq_top_iff']
+  intro x
+  obtain ⟨y, rfl⟩ := I.toCotangent_surjective x
+  have hy : y ∈ Submodule.span A (s : Set I) := by
+    rw [hs]
+    exact Submodule.mem_top
+  induction hy using Submodule.span_induction with
+  | mem y hy =>
+      exact Submodule.subset_span (Finset.mem_coe.mpr (Finset.mem_image.mpr ⟨y, hy, rfl⟩))
+  | zero =>
+      rw [map_zero]
+      exact Submodule.zero_mem _
+  | add y z _ _ hy hz =>
+      simpa only [map_add] using Submodule.add_mem _ hy hz
+  | smul a y _ hy =>
+      rw [map_smul, f.smul_cotangent_ker_eq]
+      exact Submodule.smul_mem _ (f a) hy
+
+end AlgHom
+
+namespace TauCeti.Bialgebra
+
+open _root_.Bialgebra
+
+variable (R A : Type*) [CommRing R] [CommRing A] [Bialgebra R A]
+
+/-- The cotangent space at the identity of a finite-type commutative bialgebra over a noetherian
+base is finite over that base. -/
+instance instModuleFiniteCotangent [IsNoetherianRing R] [Algebra.FiniteType R A] :
+    Module.Finite R (RingHom.ker (counitAlgHom R A).toRingHom).Cotangent := by
+  let _ : IsNoetherianRing A := Algebra.FiniteType.isNoetherianRing R A
+  exact AlgHom.finite_cotangent_ker (counitAlgHom R A)
+
+end TauCeti.Bialgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/FiniteType.lean
@@ -4,30 +4,20 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+public import Mathlib.RingTheory.Bialgebra.Basic
 public import Mathlib.RingTheory.FiniteType
-public import Mathlib.RingTheory.Ideal.Cotangent
-public import TauCeti.Algebra.AlgebraicGroup.Tangent.Basic
+public import TauCeti.RingTheory.Ideal.Cotangent
 
 /-!
 # Finiteness of the tangent space of a finite-type affine monoid
 
-An augmentation `f : A →ₐ[R] R` makes the cotangent space at the corresponding point,
-`ker(f) / ker(f)²`, a finite `R`-module whenever `A` is noetherian. Although the augmentation
-ideal is initially only known to be finitely generated over `A`, its action on the cotangent
-space factors through `f`; the same generators therefore span over `R`.
-
-Applied to the counit of a commutative bialgebra of finite type over a noetherian base, this gives
-the finite cotangent space at the identity. Over a field it is consequently finite-dimensional
-and projective, which is the finiteness input for the scalar-extension description of the tangent
-space and the adjoint representation in the ReductiveGroups roadmap, Layer 2.
+The counit of a commutative bialgebra of finite type over a noetherian base has finite cotangent
+space at the identity. Over a field it is consequently finite-dimensional and projective, which
+is the finiteness input for the scalar-extension description of the tangent space and the adjoint
+representation in the ReductiveGroups roadmap, Layer 2.
 
 ## Main declarations
 
-* `AlgHom.smul_cotangent_ker_eq`: the action on the cotangent space of an augmented algebra
-  factors through the augmentation.
-* `AlgHom.finite_cotangent_ker`: the cotangent space of an augmented noetherian algebra is finite
-  over the base.
 * `TauCeti.Bialgebra.instModuleFiniteCotangent`: the specialization to the counit of a finite-type
   commutative bialgebra.
 
@@ -37,56 +27,6 @@ space and the adjoint representation in the ReductiveGroups roadmap, Layer 2.
 -/
 
 public section
-
-namespace AlgHom
-
-variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]
-
-/-- On `ker(f) / ker(f)²`, multiplication by `a : A` agrees with scalar multiplication by
-`f a : R`, for an augmentation `f : A →ₐ[R] R`. -/
-theorem smul_cotangent_ker_eq (f : A →ₐ[R] R) (a : A)
-    (x : (RingHom.ker f.toRingHom).Cotangent) :
-    a • x = f a • x := by
-  let I := RingHom.ker f.toRingHom
-  have ha : a - algebraMap R A (f a) ∈ I := by
-    simp [I]
-  have hzero : (a - algebraMap R A (f a)) • x = 0 :=
-    Ideal.Cotangent.smul_eq_zero_of_mem ha x
-  rw [sub_smul, sub_eq_zero, algebraMap_smul] at hzero
-  exact hzero
-
-/-- The cotangent space at an augmented point of a noetherian algebra is finite over the base.
-
-The augmentation hypothesis is encoded by the codomain of `f`: because `f` is an `R`-algebra
-homomorphism, it is a retraction of `algebraMap R A`. -/
-theorem finite_cotangent_ker (f : A →ₐ[R] R) [IsNoetherianRing A] :
-    Module.Finite R (RingHom.ker f.toRingHom).Cotangent := by
-  classical
-  let I := RingHom.ker f.toRingHom
-  let _ : Module.Finite A I := by
-    rw [Module.Finite.iff_fg]
-    exact I.fg_of_isNoetherianRing
-  obtain ⟨s, hs⟩ := Module.Finite.fg_top (R := A) (M := I)
-  refine Module.finite_def.mpr ⟨s.image I.toCotangent, ?_⟩
-  rw [Submodule.eq_top_iff']
-  intro x
-  obtain ⟨y, rfl⟩ := I.toCotangent_surjective x
-  have hy : y ∈ Submodule.span A (s : Set I) := by
-    rw [hs]
-    exact Submodule.mem_top
-  induction hy using Submodule.span_induction with
-  | mem y hy =>
-      exact Submodule.subset_span (Finset.mem_coe.mpr (Finset.mem_image.mpr ⟨y, hy, rfl⟩))
-  | zero =>
-      rw [map_zero]
-      exact Submodule.zero_mem _
-  | add y z _ _ hy hz =>
-      simpa only [map_add] using Submodule.add_mem _ hy hz
-  | smul a y _ hy =>
-      rw [map_smul, f.smul_cotangent_ker_eq]
-      exact Submodule.smul_mem _ (f a) hy
-
-end AlgHom
 
 namespace TauCeti.Bialgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/FiniteType.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.Bialgebra.Basic
 public import Mathlib.RingTheory.FiniteType
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Cotangent
 public import TauCeti.RingTheory.Ideal.Cotangent
 
 /-!
@@ -18,8 +18,8 @@ representation in the ReductiveGroups roadmap, Layer 2.
 
 ## Main declarations
 
-* `TauCeti.Bialgebra.instModuleFiniteCotangent`: the specialization to the counit of a finite-type
-  commutative bialgebra.
+* `TauCeti.Bialgebra.instModuleFiniteCotangentSpace`: the specialization to the counit of a
+  finite-type commutative bialgebra.
 
 ## References
 
@@ -36,8 +36,8 @@ variable (R A : Type*) [CommRing R] [CommRing A] [Bialgebra R A]
 
 /-- The cotangent space at the identity of a finite-type commutative bialgebra over a noetherian
 base is finite over that base. -/
-instance instModuleFiniteCotangent [IsNoetherianRing R] [Algebra.FiniteType R A] :
-    Module.Finite R (RingHom.ker (counitAlgHom R A).toRingHom).Cotangent := by
+instance instModuleFiniteCotangentSpace [IsNoetherianRing R] [Algebra.FiniteType R A] :
+    Module.Finite R (CotangentSpace R A) := by
   let _ : IsNoetherianRing A := Algebra.FiniteType.isNoetherianRing R A
   exact AlgHom.finite_cotangent_ker (counitAlgHom R A)
 

--- a/TauCeti/RingTheory/Ideal/Cotangent.lean
+++ b/TauCeti/RingTheory/Ideal/Cotangent.lean
@@ -9,13 +9,11 @@ public import Mathlib.RingTheory.Extension.Basic
 /-!
 # Cotangent spaces of augmented algebras
 
-For an augmentation `f : A →ₐ[R] R`, the action of `A` on
-`ker(f) / ker(f)²` factors through `f`. Consequently, if the augmentation ideal is finitely
-generated over `A`, then its cotangent space is finite over `R`.
+For an augmentation `f : A →ₐ[R] R`, if the augmentation ideal is finitely generated over
+`A`, then its cotangent space is finite over `R`.
 
 ## Main declarations
 
-* `TauCeti.AlgHom.smul_eq_map_smul`: the ambient scalar action factors through the augmentation.
 * `TauCeti.AlgHom.finite_cotangent_ker_of_fg`: finite generation of the augmentation ideal gives
   finiteness of its cotangent space over the base.
 * `TauCeti.AlgHom.finite_cotangent_ker`: the noetherian specialization.
@@ -34,20 +32,6 @@ namespace AlgHom
 
 variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]
 
-/-- On `ker(f) / ker(f)²`, multiplication by `a : A` agrees with scalar multiplication by
-`f a : R`, for an augmentation `f : A →ₐ[R] R`. -/
-@[simp]
-theorem smul_eq_map_smul (f : A →ₐ[R] R) (a : A)
-    (x : (RingHom.ker f.toRingHom).Cotangent) :
-    a • x = f a • x := by
-  let I := RingHom.ker f.toRingHom
-  have ha : a - algebraMap R A (f a) ∈ I := by
-    simp [I]
-  have hzero : (a - algebraMap R A (f a)) • x = 0 :=
-    Ideal.Cotangent.smul_eq_zero_of_mem ha x
-  rw [sub_smul, sub_eq_zero, algebraMap_smul] at hzero
-  exact hzero
-
 /-- The cotangent space of an augmentation with finitely generated kernel is finite over the
 base. -/
 theorem finite_cotangent_ker_of_fg (f : A →ₐ[R] R)
@@ -61,11 +45,18 @@ theorem finite_cotangent_ker_of_fg (f : A →ₐ[R] R)
         f.comp_algebraMap.symm
       σ := algebraMap R A
       algebraMap_σ := f.commutes }
-  have hP : P.ker.FG := h
+  -- The extension's `A → R` algebra map is the augmentation `f` by construction.
+  have hker : P.ker = RingHom.ker f.toRingHom := by
+    ext x
+    change f x = 0 ↔ f x = 0
+    rfl
+  have hP : P.ker.FG := by
+    rw [hker]
+    exact h
   let _ : Module.Finite R P.Cotangent :=
     Algebra.Extension.Cotangent.finite (P := P) hP
-  exact Module.Finite.equiv
-    (P.cotangentEquivCotangentKer.restrictScalars R)
+  rw [← hker]
+  exact Module.Finite.equiv (P.cotangentEquivCotangentKer.restrictScalars R)
 
 /-- The cotangent space at an augmented point of a noetherian algebra is finite over the base.
 

--- a/TauCeti/RingTheory/Ideal/Cotangent.lean
+++ b/TauCeti/RingTheory/Ideal/Cotangent.lean
@@ -41,16 +41,16 @@ theorem finite_cotangent_ker_of_fg (f : A →ₐ[R] R)
     Algebra.Extension.ofSurjective f (fun r ↦ ⟨algebraMap R A r, f.commutes r⟩)
   have hmap : algebraMap P.Ring R = f.toRingHom := by
     exact RingHom.algebraMap_toAlgebra f.toRingHom
+  have hker : P.ker = RingHom.ker f.toRingHom := congrArg RingHom.ker hmap
   have hP : P.ker.FG := by
-    change (RingHom.ker (algebraMap P.Ring R)).FG
-    rw [hmap]
+    rw [hker]
     exact h
   let _ : Module.Finite R P.Cotangent :=
     Algebra.Extension.Cotangent.finite (P := P) hP
   have hfinite : Module.Finite R P.ker.Cotangent :=
     Module.Finite.equiv (P.cotangentEquivCotangentKer.restrictScalars R)
-  change Module.Finite R (RingHom.ker f.toRingHom).Cotangent
-  exact hmap ▸ hfinite
+  exact Module.Finite.equiv
+    ((Ideal.Cotangent.equivOfEq P.ker (RingHom.ker f.toRingHom) hker).restrictScalars R)
 
 /-- The cotangent space at an augmented point of a noetherian algebra is finite over the base.
 

--- a/TauCeti/RingTheory/Ideal/Cotangent.lean
+++ b/TauCeti/RingTheory/Ideal/Cotangent.lean
@@ -37,26 +37,20 @@ base. -/
 theorem finite_cotangent_ker_of_fg (f : A →ₐ[R] R)
     (h : (RingHom.ker f.toRingHom).FG) :
     Module.Finite R (RingHom.ker f.toRingHom).Cotangent := by
-  let algAR : Algebra A R := f.toAlgebra
   let P : Algebra.Extension R R :=
-    { Ring := A
-      algebra₂ := algAR
-      isScalarTower := @IsScalarTower.of_algebraMap_eq' R A R _ _ _ _ algAR _
-        f.comp_algebraMap.symm
-      σ := algebraMap R A
-      algebraMap_σ := f.commutes }
-  -- The extension's `A → R` algebra map is the augmentation `f` by construction.
-  have hker : P.ker = RingHom.ker f.toRingHom := by
-    ext x
-    change f x = 0 ↔ f x = 0
-    rfl
+    Algebra.Extension.ofSurjective f (fun r ↦ ⟨algebraMap R A r, f.commutes r⟩)
+  have hmap : algebraMap P.Ring R = f.toRingHom := by
+    exact RingHom.algebraMap_toAlgebra f.toRingHom
   have hP : P.ker.FG := by
-    rw [hker]
+    change (RingHom.ker (algebraMap P.Ring R)).FG
+    rw [hmap]
     exact h
   let _ : Module.Finite R P.Cotangent :=
     Algebra.Extension.Cotangent.finite (P := P) hP
-  rw [← hker]
-  exact Module.Finite.equiv (P.cotangentEquivCotangentKer.restrictScalars R)
+  have hfinite : Module.Finite R P.ker.Cotangent :=
+    Module.Finite.equiv (P.cotangentEquivCotangentKer.restrictScalars R)
+  change Module.Finite R (RingHom.ker f.toRingHom).Cotangent
+  exact hmap ▸ hfinite
 
 /-- The cotangent space at an augmented point of a noetherian algebra is finite over the base.
 

--- a/TauCeti/RingTheory/Ideal/Cotangent.lean
+++ b/TauCeti/RingTheory/Ideal/Cotangent.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Extension.Basic
+
+/-!
+# Cotangent spaces of augmented algebras
+
+For an augmentation `f : A →ₐ[R] R`, the action of `A` on
+`ker(f) / ker(f)²` factors through `f`. Consequently, if the augmentation ideal is finitely
+generated over `A`, then its cotangent space is finite over `R`.
+
+## Main declarations
+
+* `TauCeti.AlgHom.smul_eq_map_smul`: the ambient scalar action factors through the augmentation.
+* `TauCeti.AlgHom.finite_cotangent_ker_of_fg`: finite generation of the augmentation ideal gives
+  finiteness of its cotangent space over the base.
+* `TauCeti.AlgHom.finite_cotangent_ker`: the noetherian specialization.
+
+## References
+
+* Mathlib's `Algebra.Extension.Cotangent.finite` provides the generic cotangent-space finiteness
+  result used here.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace AlgHom
+
+variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]
+
+/-- On `ker(f) / ker(f)²`, multiplication by `a : A` agrees with scalar multiplication by
+`f a : R`, for an augmentation `f : A →ₐ[R] R`. -/
+@[simp]
+theorem smul_eq_map_smul (f : A →ₐ[R] R) (a : A)
+    (x : (RingHom.ker f.toRingHom).Cotangent) :
+    a • x = f a • x := by
+  let I := RingHom.ker f.toRingHom
+  have ha : a - algebraMap R A (f a) ∈ I := by
+    simp [I]
+  have hzero : (a - algebraMap R A (f a)) • x = 0 :=
+    Ideal.Cotangent.smul_eq_zero_of_mem ha x
+  rw [sub_smul, sub_eq_zero, algebraMap_smul] at hzero
+  exact hzero
+
+/-- The cotangent space of an augmentation with finitely generated kernel is finite over the
+base. -/
+theorem finite_cotangent_ker_of_fg (f : A →ₐ[R] R)
+    (h : (RingHom.ker f.toRingHom).FG) :
+    Module.Finite R (RingHom.ker f.toRingHom).Cotangent := by
+  let algAR : Algebra A R := f.toAlgebra
+  let P : Algebra.Extension R R :=
+    { Ring := A
+      algebra₂ := algAR
+      isScalarTower := @IsScalarTower.of_algebraMap_eq' R A R _ _ _ _ algAR _
+        f.comp_algebraMap.symm
+      σ := algebraMap R A
+      algebraMap_σ := f.commutes }
+  have hP : P.ker.FG := h
+  let _ : Module.Finite R P.Cotangent :=
+    Algebra.Extension.Cotangent.finite (P := P) hP
+  exact Module.Finite.equiv
+    (P.cotangentEquivCotangentKer.restrictScalars R)
+
+/-- The cotangent space at an augmented point of a noetherian algebra is finite over the base.
+
+The augmentation hypothesis is encoded by the codomain of `f`: because `f` is an `R`-algebra
+homomorphism, it is a retraction of `algebraMap R A`. -/
+theorem finite_cotangent_ker (f : A →ₐ[R] R) [IsNoetherianRing A] :
+    Module.Finite R (RingHom.ker f.toRingHom).Cotangent :=
+  finite_cotangent_ker_of_fg f (RingHom.ker f.toRingHom).fg_of_isNoetherianRing
+
+end AlgHom
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the augmentation cotangent space `ker(f) / ker(f)²` of an augmented noetherian algebra `f : A →ₐ[R] R` is finite over `R`, and specializes the result to the counit of every finite-type commutative bialgebra over a noetherian base.

It advances `ReductiveGroups/README.md`, Layer 2, the milestone “Tangent space at the identity / `Lie(G)` … and the adjoint action `Ad : G → GL(Lie G)`”. The explicit dependency edge is that the open scalar-extension construction `Derivation.tangentScalarExtensionEquiv` in TauCeti#2447 requires `Module.Finite` and `Module.Projective` for the augmentation cotangent space; this PR supplies finiteness from finite type, while projectivity is automatic over the roadmap’s field base.

The proof takes finite `A`-module generators of the augmentation ideal, maps them to the cotangent quotient, and observes that multiplication by `a : A` there equals scalar multiplication by `f a`, since `a - algebraMap R A (f a)` lies in the augmentation ideal and the ideal annihilates its cotangent space. Thus the same finite family spans over `R`. The implementation reuses Mathlib’s `Ideal.Cotangent.smul_eq_zero_of_mem`, noetherian finite-generation API, and `Algebra.FiniteType.isNoetherianRing`; no Mathlib infrastructure is vendored.

After this PR and TauCeti#2447, the Layer 2 milestone still needs transport of the coefficient-natural adjoint action through the scalar-extension equivalence and packaging it as a group-scheme morphism into `GL(Lie G)`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"augmentation-cotangent-finite-dimensional"}-->

🤖 Prepared with Codex
