### PR TITLE
feat: embed finite-type affine groups in general linear groups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Coordinate
+public import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.FiniteType
+
+/-!
+# Embedding a finite-type affine group in a general linear group
+
+Let `H` be a commutative Hopf algebra of finite type over a field `k`. The fundamental theorem
+of coalgebras places a finite set of algebra generators of `H` in a finite-dimensional
+subcomodule `M` of the regular comodule. The matrix coefficients of `M` then generate `H` as a
+`k`-algebra. After choosing a finite basis of `M`, every matrix coefficient is a linear
+combination of the entries of its coefficient matrix. Hence the associated coordinate morphism
+
+```text
+O(GLₙ) ⟶ H
+```
+
+is surjective. Contravariantly, its spectrum is a closed immersion of the affine group scheme
+represented by `H` into `GLₙ`.
+
+## Main declaration
+
+* `TauCeti.Comodule.exists_surjective_coordinateBialgHom`: a finite-type commutative Hopf
+  algebra over a field admits a finite-dimensional regular subcomodule whose coordinate
+  morphism from `O(GLₙ)` is surjective.
+
+## References
+
+This is the coordinate-algebra form of the affine-group embedding theorem; see J. S. Milne,
+*Algebraic Groups* (2017), Proposition 4.7 and Theorem 4.9. It advances Layer 1, "Embedding
+theorem (hard)", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open Module
+
+namespace TauCeti.Comodule
+
+universe u v w
+
+noncomputable section
+
+variable {k : Type u} {H : Type v} {M : Type w}
+variable [Field k] [CommRing H] [HopfAlgebra k H]
+variable [AddCommMonoid M] [Module k M] [Comodule k H M]
+variable {n : ℕ}
+
+private theorem matrixCoefficient_mem_range_coordinateBialgHom
+    (b : Basis (Fin n) k M) (φ : M →ₗ[k] k) (m : M) :
+    matrixCoefficient (R := k) (C := H) φ m ∈
+      (coordinateBialgHom (H := H) b).toAlgHom.range := by
+  have hcoeff (j : Fin n) :
+      matrixCoefficient (R := k) (C := H) φ (b j) =
+        ∑ i, φ (b i) • coefficientMatrix (C := H) b i j := by
+    rw [matrixCoefficient_def, coact_basis_eq_sum_coefficientMatrix, map_sum]
+    simp
+  rw [← b.sum_repr m]
+  have hsum := map_sum (matrixCoefficientLinear (R := k) (C := H) φ)
+    (fun j => (b.repr m) j • b j) Finset.univ
+  simp only [matrixCoefficientLinear_apply] at hsum
+  rw [hsum]
+  refine (coordinateBialgHom (H := H) b).toAlgHom.range.sum_mem
+    (t := Finset.univ) ?_
+  intro j _
+  rw [matrixCoefficient_smul, hcoeff]
+  refine (coordinateBialgHom (H := H) b).toAlgHom.range.smul_mem ?_ ((b.repr m) j)
+  refine (coordinateBialgHom (H := H) b).toAlgHom.range.sum_mem
+    (t := Finset.univ) ?_
+  intro i _
+  refine (coordinateBialgHom (H := H) b).toAlgHom.range.smul_mem ?_ (φ (b i))
+  exact ⟨_, coordinateBialgHom_X b i j⟩
+
+/-- **A finite-type commutative Hopf algebra over a field is a quotient of the coordinate
+ring of some general linear group.** More precisely, it has a finite-dimensional subcomodule
+of its regular comodule and a basis for which the associated coordinate bialgebra morphism
+`O(GLₙ) → H` is surjective.
+
+Contravariantly, the affine group scheme represented by `H` embeds as a closed subgroup of
+`GLₙ`. -/
+theorem exists_surjective_coordinateBialgHom [Algebra.FiniteType k H] :
+    ∃ (M : Subcomodule k H H) (n : ℕ) (b : Basis (Fin n) k M),
+      Function.Surjective (coordinateBialgHom (H := H) b) := by
+  let _ : Ring H := Algebra.semiringToRing k
+  obtain ⟨M, hMfinite, hMcoeff⟩ :=
+    exists_finite_subcomodule_matrixCoefficientSubalgebra_eq_top (k := k) (C := H)
+  let : AddCommGroup M := Module.addCommMonoidToAddCommGroup k
+  let : Module.Free k M := Module.Free.of_divisionRing k M
+  let : Module.Finite k M := hMfinite
+  let b := Module.finBasis k M
+  refine ⟨M, Module.finrank k M, b, ?_⟩
+  have hsurjective :
+      Function.Surjective (coordinateBialgHom (H := H) b).toAlgHom := by
+    rw [← AlgHom.range_eq_top]
+    apply top_unique
+    rw [← hMcoeff]
+    exact matrixCoefficientSubalgebra_le (R := k) (C := H) (M := M) fun φ m =>
+      matrixCoefficient_mem_range_coordinateBialgHom b φ m
+  exact hsurjective
+
+end
+
+end TauCeti.Comodule

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
@@ -25,7 +25,9 @@ represented by `H` into `GLₙ`.
 
 ## Main declaration
 
-* `TauCeti.Comodule.exists_surjective_coordinateBialgHom`: a finite-type commutative Hopf
+* `TauCeti.Comodule.matrixCoefficientSubalgebra_le_coordinateBialgHom_range`: the matrix
+  coefficient subalgebra is contained in the range of the coordinate morphism.
+* `TauCeti.Comodule.exists_coordinateBialgHom_surjective`: a finite-type commutative Hopf
   algebra over a field admits a finite-dimensional regular subcomodule whose coordinate
   morphism from `O(GLₙ)` is surjective.
 
@@ -47,9 +49,12 @@ universe u v w
 noncomputable section
 
 variable {k : Type u} {H : Type v} {M : Type w}
-variable [Field k] [CommRing H] [HopfAlgebra k H]
-variable [AddCommMonoid M] [Module k M] [Comodule k H M]
 variable {n : ℕ}
+
+section Range
+
+variable [CommRing k] [CommRing H] [HopfAlgebra k H]
+variable [AddCommMonoid M] [Module k M] [Comodule k H M]
 
 private theorem matrixCoefficient_mem_range_coordinateBialgHom
     (b : Basis (Fin n) k M) (φ : M →ₗ[k] k) (m : M) :
@@ -76,6 +81,19 @@ private theorem matrixCoefficient_mem_range_coordinateBialgHom
   refine (coordinateBialgHom (H := H) b).toAlgHom.range.smul_mem ?_ (φ (b i))
   exact ⟨_, coordinateBialgHom_X b i j⟩
 
+/-- The matrix coefficient subalgebra of a finite free comodule is contained in the range of
+its coordinate bialgebra morphism. -/
+theorem matrixCoefficientSubalgebra_le_coordinateBialgHom_range
+    (b : Basis (Fin n) k M) :
+    matrixCoefficientSubalgebra (R := k) (C := H) (M := M) ≤
+      (coordinateBialgHom (H := H) b).toAlgHom.range :=
+  matrixCoefficientSubalgebra_le (R := k) (C := H) (M := M) fun φ m =>
+    matrixCoefficient_mem_range_coordinateBialgHom b φ m
+
+end Range
+
+variable [Field k] [CommRing H] [HopfAlgebra k H]
+
 /-- **A finite-type commutative Hopf algebra over a field is a quotient of the coordinate
 ring of some general linear group.** More precisely, it has a finite-dimensional subcomodule
 of its regular comodule and a basis for which the associated coordinate bialgebra morphism
@@ -83,7 +101,7 @@ of its regular comodule and a basis for which the associated coordinate bialgebr
 
 Contravariantly, the affine group scheme represented by `H` embeds as a closed subgroup of
 `GLₙ`. -/
-theorem exists_surjective_coordinateBialgHom [Algebra.FiniteType k H] :
+theorem exists_coordinateBialgHom_surjective [Algebra.FiniteType k H] :
     ∃ (M : Subcomodule k H H) (n : ℕ) (b : Basis (Fin n) k M),
       Function.Surjective (coordinateBialgHom (H := H) b) := by
   let _ : Ring H := Algebra.semiringToRing k
@@ -99,8 +117,7 @@ theorem exists_surjective_coordinateBialgHom [Algebra.FiniteType k H] :
     rw [← AlgHom.range_eq_top]
     apply top_unique
     rw [← hMcoeff]
-    exact matrixCoefficientSubalgebra_le (R := k) (C := H) (M := M) fun φ m =>
-      matrixCoefficient_mem_range_coordinateBialgHom b φ m
+    exact matrixCoefficientSubalgebra_le_coordinateBialgHom_range b
   exact hsurjective
 
 end


### PR DESCRIPTION
This PR proves the coordinate-algebra form of the affine-group embedding theorem: construct, for every finite-type commutative Hopf algebra `H` over a field, a finite-dimensional subcomodule of the regular comodule with a `Fin n` basis whose coordinate morphism `O(GLₙ) → H` is surjective.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, milestone “Embedding theorem (hard): every affine group scheme of finite type has a faithful f.d. representation, i.e. a closed immersion `G ↪ GLₙ`”. The merged fundamental-theorem development already supplies a finite regular subcomodule whose matrix coefficients algebra-generate `H`; this PR performs the missing basis-and-coordinate-map step, expanding every matrix coefficient in the chosen coefficient matrix and placing those entries in the range of `Comodule.coordinateBialgHom`. Since the coefficient algebra is all of `H`, that range is all of `H`.

After this PR, the milestone remains to package this surjective coordinate map as a closed immersion through the faithful-representation criterion; that complementary packaging is already in flight in #2383.

The new file `TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean` has 108 lines, one public existence theorem, and one private basis-expansion lemma. It reuses `Comodule.exists_finite_subcomodule_matrixCoefficientSubalgebra_eq_top`, `Comodule.coordinateBialgHom_X`, and `AlgHom.range_eq_top`; no Mathlib infrastructure is vendored. The argument follows J. S. Milne, *Algebraic Groups* (2017), Proposition 4.7 and Theorem 4.9, credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-type-hopf-embeds-general-linear"}-->

🤖 Prepared with Codex
