### PR TITLE
feat: traverse the small arc of a Jordan curve by an injective path

### DIFF
--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -48,7 +48,9 @@ circle.
   `cos (θ - arg (c - ζ))`, the angles it admits form an arc: it holds throughout an interval of
   angles inside a period centred at `arg (c - ζ)` as soon as it holds at both ends.
 * `TauCeti.lipschitzWith_one_circleExp` and `TauCeti.diam_circleExp_image_Icc_le` — the chord is at
-  most the arc, so an arc of angles of length `b - a` has image of diameter at most `b - a`.
+  most the arc, so an arc of angles of length `b - a` has image of diameter at most `b - a`, and
+  `TauCeti.diam_range_circlePath_le` — the same bound for Mathlib's arc `Circle.path x y`, whose
+  angle is `Circle.angleDiff x y`.
 * `TauCeti.min_angleDiff_le_pi_div_two_mul_dist` — the shorter of the two arcs joining two points of
   the circle has length at most `π / 2` times their distance.
 
@@ -335,6 +337,20 @@ theorem diam_circleExp_image_Icc_le {a b : ℝ} (hab : a ≤ b) :
     Metric.diam (Circle.exp '' Icc a b) ≤ b - a := by
   simpa only [NNReal.coe_one, one_mul, Real.diam_Icc hab] using
     lipschitzWith_one_circleExp.diam_image_le (Icc a b) (isBounded_Icc a b)
+
+/-- **A closed arc is no wider than its angle.** Mathlib's arc `Circle.path x y`, which runs
+counterclockwise from `x` to `y`, has range of diameter at most the length `Circle.angleDiff x y`
+of that arc.
+
+This is `TauCeti.diam_circleExp_image_Icc_le` read through `Circle.range_path`, which presents the
+closed arc as the `Circle.exp` image of an interval of angles of length `Circle.angleDiff x y`. It
+is stated for the range rather than for the path so that it applies unchanged to the reversed arc,
+whose range is the same by `Path.symm_range`. -/
+theorem diam_range_circlePath_le (x y : Circle) :
+    Metric.diam (range (Circle.path x y)) ≤ Circle.angleDiff x y := by
+  rw [Circle.range_path]
+  simpa using diam_circleExp_image_Icc_le (a := Complex.arg (x : ℂ))
+    (b := Circle.angleDiff x y + Complex.arg (x : ℂ)) (by simp [Circle.angleDiff_nonneg])
 
 /-- **The shorter arc is controlled by the chord**: of the two arcs joining `x` to `y` on the
 circle, the shorter has length at most `π / 2` times the distance from `x` to `y`.

--- a/TauCeti/Topology/JordanCurve/SmallArc.lean
+++ b/TauCeti/Topology/JordanCurve/SmallArc.lean
@@ -91,32 +91,36 @@ of two points being close, so `X` carries a `PseudoMetricSpace` instance. Nothin
 in particular the curve is not required to lie in `ℂ`, so `∂Ω` may be met at whatever generality a
 consumer has it.
 
-## The small arc traversed
+## Joining the two points by an injective path
 
 A consumer that *joins* the small arc to another one — gluing two arcs along their two common
 endpoints into a closed curve — needs it as a path rather than as a set, and needs that path
 injective, since a path-connected set carries paths with arbitrary repetitions. The last two
-statements below supply that: on the circle the short arc is the range of Mathlib's arc
-`Circle.path`, injective by `Circle.path_injective_of_ne` and reversed by `Path.symm` when the
-counterclockwise direction is the long way round; transporting it along the parametrization, which
-is injective and continuous, gives an injective path along the curve. Its diameter is bounded by the
-same two uniform continuities, which are recorded here once and spent by both transports.
+statements below supply exactly that, and nothing more: an injective path with the two prescribed
+endpoints, running inside the curve, whose range is of small diameter. They relate its range to
+neither of the two arcs of the cut above.
+
+Their witness on the circle is Mathlib's arc `Circle.path`, injective by
+`Circle.path_injective_of_ne` and reversed by `Path.symm` when the counterclockwise direction is the
+long way round; transporting it along the parametrization, which is injective and continuous, gives
+an injective path along the curve. Its diameter is bounded by the same two uniform continuities,
+which are recorded here once and spent by both transports.
 
 ## Main results
 
 * `TauCeti.exists_isPreconnected_union_eq_compl_pair_circle_diam_le` — two distinct points cut the
   circle into two preconnected arcs, the first of which is of diameter at most `π / 2` times their
   distance even after the two points are put back, and
-  `TauCeti.exists_path_injective_diam_range_le_circle` — that closed short arc is the range of an
-  injective path joining the two points.
+  `TauCeti.exists_path_injective_diam_range_le_circle` — two distinct points of the circle are the
+  endpoints of an injective path whose range has diameter at most `π / 2` times their distance.
 * `TauCeti.IsJordanCurve.exists_pos_forall_diam_le` — **the main statement**: for every `ε > 0`
   there is a `δ > 0` such that two distinct points `p`, `q` of a Jordan curve at distance less than
   `δ` cut it into two arcs one of which has diameter at most `ε` together with `p` and `q`.
 * `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le` — the same packaged with the cutting
   itself, producing the two arcs with the small one named first.
-* `TauCeti.IsJordanCurve.exists_pos_forall_exists_path_injective_diam_le` — the small arc traversed:
-  two nearby points of a Jordan curve are the endpoints of an injective path along it whose range is
-  of diameter at most `ε`.
+* `TauCeti.IsJordanCurve.exists_pos_forall_exists_path_injective_diam_le` — two nearby points of a
+  Jordan curve are the endpoints of an injective path along it whose range is of diameter at
+  most `ε`.
 
 ## References
 
@@ -168,19 +172,19 @@ theorem exists_isPreconnected_union_eq_compl_pair_circle_diam_le {z w : Circle} 
     rw [pair_comm z w]
     exact (hdiam w z).trans ((le_min_iff.mpr ⟨hle, le_rfl⟩).trans hmin)
 
-/-- **The short arc as an injective path.** Two distinct points of the circle are the endpoints of
-an injective path along the shorter of the two arcs they cut it into, whose range — the *closed*
-short arc — has diameter at most `π / 2` times their distance.
+/-- **Two points of the circle are joined by a short injective path.** Two distinct points of the
+circle are the endpoints of an injective path whose range has diameter at most `π / 2` times their
+distance.
 
-This is `TauCeti.exists_isPreconnected_union_eq_compl_pair_circle_diam_le` sharpened on the piece it
-bounds: there the short arc appears as a preconnected set with its two endpoints put back, here as
-the range of a path that traverses it injectively. The path is Mathlib's arc `Circle.path z w`,
-injective by `Circle.path_injective_of_ne`, in the direction in which `Circle.angleDiff` is smaller,
-and its reverse otherwise; reversing changes neither the range (`Path.symm_range`) nor injectivity.
+The witness is Mathlib's arc `Circle.path z w`, injective by `Circle.path_injective_of_ne`, taken in
+the direction in which `Circle.angleDiff` is smaller, and its reverse otherwise; reversing changes
+neither the range (`Path.symm_range`) nor injectivity. Only the endpoints, the injectivity and the
+diameter bound are recorded: nothing is stated relating the range to either piece of the cut of
+`TauCeti.exists_isPreconnected_union_eq_compl_pair_circle_diam_le`.
 
 The diameter bound is `TauCeti.diam_range_circlePath_le` — the arc bounds the chords across it —
-fed the comparison `TauCeti.min_angleDiff_le_pi_div_two_mul_dist` of the shorter arc with the
-chord. -/
+fed the comparison `TauCeti.min_angleDiff_le_pi_div_two_mul_dist` of the shorter arc with the chord,
+which is the comparison that bounds the short arc there too. -/
 theorem exists_path_injective_diam_range_le_circle {z w : Circle} (hzw : z ≠ w) :
     ∃ γ : Path z w, Function.Injective γ ∧ Metric.diam (range γ) ≤ π / 2 * dist z w := by
   have hmin := min_angleDiff_le_pi_div_two_mul_dist z w
@@ -188,10 +192,9 @@ theorem exists_path_injective_diam_range_le_circle {z w : Circle} (hzw : z ≠ w
   · exact ⟨Circle.path z w, Circle.path_injective_of_ne hzw,
       (diam_range_circlePath_le z w).trans ((le_min_iff.mpr ⟨le_rfl, hle⟩).trans hmin)⟩
   · refine ⟨(Circle.path w z).symm, ?_, ?_⟩
-    · have hcoe : ((Circle.path w z).symm : unitInterval → Circle) =
-        (Circle.path w z) ∘ unitInterval.symm := rfl
-      rw [hcoe]
-      exact (Circle.path_injective_of_ne hzw.symm).comp unitInterval.symm_bijective.injective
+    · intro a b hab
+      simp only [Path.symm_apply, Function.comp_apply] at hab
+      exact unitInterval.symm_bijective.injective (Circle.path_injective_of_ne hzw.symm hab)
     · rw [Path.symm_range]
       exact (diam_range_circlePath_le w z).trans ((le_min_iff.mpr ⟨hle, le_rfl⟩).trans hmin)
 
@@ -393,30 +396,28 @@ theorem IsJordanCurve.exists_pos_forall_exists_diam_le (h : IsJordanCurve C) (h�
   · exact ⟨B, A, hBc, hAc, hdisj.symm, by rw [union_comm]; exact hunion,
       fun S hS hSc => (hsep hS hSc).symm, hB⟩
 
-/-! ## The small arc as an injective path -/
+/-! ## Joining the two points by an injective path -/
 
 /-- **Two nearby points of a Jordan curve are joined by a small injective path along it.** For every
 `ε > 0` there is a `δ > 0` such that two distinct points `p`, `q` of a Jordan curve `C` at distance
 less than `δ` are the endpoints of an injective path whose range lies on `C` and has diameter at
 most `ε`.
 
-This is `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le` with the small arc *traversed*: the
-set `A ∪ {p, q}` bounded there becomes the range of a path from `p` to `q`, and the path is
-injective, so it is an arc in the strict sense and not merely a path-connected set. That is what a
-consumer joining the arc to another one needs — gluing two arcs along their common endpoints into a
-closed curve is a statement about paths — and it is not available from path-connectedness alone,
-which produces a path but no control of its repetitions.
+Injectivity is what a consumer joining this path to a second one needs — gluing two arcs along their
+common endpoints into a closed curve is a statement about paths — and it is not available from the
+path-connectedness of the arcs of `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le`, which
+yields a path but no control of its repetitions.
 
 The transport is that of
 `TauCeti.IsJordanCurve.exists_pos_forall_exists_isPreconnected_diam_union_pair_le`, run on the
 circle statement `TauCeti.exists_path_injective_diam_range_le_circle` instead of on the cut into two
 arcs: the parametrization `TauCeti.jordanParam e` is injective and continuous, so it carries the
-injective path along the short arc of parameters to an injective path along `C`, and both uniform
-continuities are spent exactly as before.
+injective path of parameters to an injective path along `C`, and both uniform continuities are spent
+exactly as before.
 
-Nothing is claimed about *which* of the two arcs of `C \ {p, q}` the path traverses beyond its being
-the small one, nor that its range is one of them together with the endpoints; the range is a subset
-of `C` containing `p` and `q`, of small diameter, which is what the bound is about. -/
+Nothing is claimed here about the two arcs of `C \ {p, q}`: neither which of them the path
+traverses, nor that its range is one of them together with the endpoints. What the conclusion offers
+is a subset of `C` containing `p` and `q`, of diameter at most `ε`, traversed injectively. -/
 theorem IsJordanCurve.exists_pos_forall_exists_path_injective_diam_le (h : IsJordanCurve C)
     (hε : 0 < ε) :
     ∃ δ > 0, ∀ ⦃p : X⦄, p ∈ C → ∀ ⦃q : X⦄, q ∈ C → p ≠ q → dist p q < δ →
@@ -431,9 +432,7 @@ theorem IsJordanCurve.exists_pos_forall_exists_path_injective_diam_le (h : IsJor
   -- The path downstairs is the parametrization composed with the path of parameters.
   refine ⟨(γ.map (continuous_jordanParam e)).cast (jordanParam_apply_apply e hp).symm
     (jordanParam_apply_apply e hq).symm, ?_, ?_, ?_⟩ <;>
-    rw [show (((γ.map (continuous_jordanParam e)).cast (jordanParam_apply_apply e hp).symm
-      (jordanParam_apply_apply e hq).symm : Path p q) : unitInterval → X) =
-        jordanParam e ∘ γ from rfl]
+    rw [Path.cast_coe, Path.map_coe]
   · exact (jordanParam_injective e).comp hinj
   · rw [range_comp]
     exact (image_subset_range _ _).trans (range_jordanParam e).subset

--- a/TauCeti/Topology/JordanCurve/SmallArc.lean
+++ b/TauCeti/Topology/JordanCurve/SmallArc.lean
@@ -91,16 +91,32 @@ of two points being close, so `X` carries a `PseudoMetricSpace` instance. Nothin
 in particular the curve is not required to lie in `ℂ`, so `∂Ω` may be met at whatever generality a
 consumer has it.
 
+## The small arc traversed
+
+A consumer that *joins* the small arc to another one — gluing two arcs along their two common
+endpoints into a closed curve — needs it as a path rather than as a set, and needs that path
+injective, since a path-connected set carries paths with arbitrary repetitions. The last two
+statements below supply that: on the circle the short arc is the range of Mathlib's arc
+`Circle.path`, injective by `Circle.path_injective_of_ne` and reversed by `Path.symm` when the
+counterclockwise direction is the long way round; transporting it along the parametrization, which
+is injective and continuous, gives an injective path along the curve. Its diameter is bounded by the
+same two uniform continuities, which are recorded here once and spent by both transports.
+
 ## Main results
 
 * `TauCeti.exists_isPreconnected_union_eq_compl_pair_circle_diam_le` — two distinct points cut the
   circle into two preconnected arcs, the first of which is of diameter at most `π / 2` times their
-  distance even after the two points are put back.
+  distance even after the two points are put back, and
+  `TauCeti.exists_path_injective_diam_range_le_circle` — that closed short arc is the range of an
+  injective path joining the two points.
 * `TauCeti.IsJordanCurve.exists_pos_forall_diam_le` — **the main statement**: for every `ε > 0`
   there is a `δ > 0` such that two distinct points `p`, `q` of a Jordan curve at distance less than
   `δ` cut it into two arcs one of which has diameter at most `ε` together with `p` and `q`.
 * `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le` — the same packaged with the cutting
   itself, producing the two arcs with the small one named first.
+* `TauCeti.IsJordanCurve.exists_pos_forall_exists_path_injective_diam_le` — the small arc traversed:
+  two nearby points of a Jordan curve are the endpoints of an injective path along it whose range is
+  of diameter at most `ε`.
 
 ## References
 
@@ -134,18 +150,15 @@ theorem exists_isPreconnected_union_eq_compl_pair_circle_diam_le {z w : Circle} 
   have hpre : ∀ x y : Circle, IsPreconnected (Circle.path x y '' Ioo 0 1) := fun x y =>
     isPreconnected_Ioo.image _ (Circle.path x y).continuous.continuousOn
   -- Putting the endpoints back — they are the values of the path at `0` and `1` — lands inside the
-  -- closed arc `Circle.range_path`, an image of an interval of angles of length `Circle.angleDiff`.
+  -- closed arc `Circle.range_path`, whose diameter is at most its angle.
   have hdiam : ∀ x y : Circle,
       Metric.diam (Circle.path x y '' Ioo 0 1 ∪ {x, y}) ≤ Circle.angleDiff x y := fun x y => by
     have hsub : Circle.path x y '' Ioo 0 1 ∪ {x, y} ⊆ range (Circle.path x y) :=
       union_subset (image_subset_range _ _)
         (insert_subset ⟨0, (Circle.path x y).source⟩
           (singleton_subset_iff.2 ⟨1, (Circle.path x y).target⟩))
-    refine (Metric.diam_mono hsub
-      (isCompact_range (Circle.path x y).continuous).isBounded).trans ?_
-    rw [Circle.range_path]
-    simpa using diam_circleExp_image_Icc_le (a := Complex.arg (x : ℂ))
-      (b := Circle.angleDiff x y + Complex.arg (x : ℂ)) (by simp [Circle.angleDiff_nonneg])
+    exact (Metric.diam_mono hsub
+      (isCompact_range (Circle.path x y).continuous).isBounded).trans (diam_range_circlePath_le x y)
   have hmin := min_angleDiff_le_pi_div_two_mul_dist z w
   -- Name first whichever of the two arcs is the shorter; its length is bounded by the chord.
   rcases le_total (Circle.angleDiff z w) (Circle.angleDiff w z) with hle | hle
@@ -154,6 +167,41 @@ theorem exists_isPreconnected_union_eq_compl_pair_circle_diam_le {z w : Circle} 
   · refine ⟨_, _, hpre w z, hpre z w, by rw [union_comm]; exact hunion, ?_⟩
     rw [pair_comm z w]
     exact (hdiam w z).trans ((le_min_iff.mpr ⟨hle, le_rfl⟩).trans hmin)
+
+/-- **The short arc as an injective path.** Two distinct points of the circle are the endpoints of
+an injective path along the shorter of the two arcs they cut it into, whose range — the *closed*
+short arc — has diameter at most `π / 2` times their distance.
+
+This is `TauCeti.exists_isPreconnected_union_eq_compl_pair_circle_diam_le` sharpened on the piece it
+bounds: there the short arc appears as a preconnected set with its two endpoints put back, here as
+the range of a path that traverses it injectively. The path is Mathlib's arc `Circle.path z w`,
+injective by `Circle.path_injective_of_ne`, in the direction in which `Circle.angleDiff` is smaller,
+and its reverse otherwise; reversing changes neither the range (`Path.symm_range`) nor injectivity.
+
+The diameter bound is `TauCeti.diam_range_circlePath_le` — the arc bounds the chords across it —
+fed the comparison `TauCeti.min_angleDiff_le_pi_div_two_mul_dist` of the shorter arc with the
+chord. -/
+theorem exists_path_injective_diam_range_le_circle {z w : Circle} (hzw : z ≠ w) :
+    ∃ γ : Path z w, Function.Injective γ ∧ Metric.diam (range γ) ≤ π / 2 * dist z w := by
+  have hmin := min_angleDiff_le_pi_div_two_mul_dist z w
+  rcases le_total (Circle.angleDiff z w) (Circle.angleDiff w z) with hle | hle
+  · exact ⟨Circle.path z w, Circle.path_injective_of_ne hzw,
+      (diam_range_circlePath_le z w).trans ((le_min_iff.mpr ⟨le_rfl, hle⟩).trans hmin)⟩
+  · refine ⟨(Circle.path w z).symm, ?_, ?_⟩
+    · have hcoe : ((Circle.path w z).symm : unitInterval → Circle) =
+        (Circle.path w z) ∘ unitInterval.symm := rfl
+      rw [hcoe]
+      exact (Circle.path_injective_of_ne hzw.symm).comp unitInterval.symm_bijective.injective
+    · rw [Path.symm_range]
+      exact (diam_range_circlePath_le w z).trans ((le_min_iff.mpr ⟨hle, le_rfl⟩).trans hmin)
+
+/-- The scaling shared by the two `δ`-`η` forms below: a distance smaller than `2 / π * η` has
+`π / 2` times it smaller than `η`, which is how a bound stated as a multiple of the chord becomes a
+bound below a prescribed tolerance. -/
+private lemma pi_div_two_mul_lt {η d : ℝ} (hη : 0 < η) (hd : d < 2 / π * η) : π / 2 * d < η := by
+  have hπ : 0 < π := Real.pi_pos
+  calc π / 2 * d < π / 2 * (2 / π * η) := mul_lt_mul_of_pos_left hd (by positivity)
+    _ = η := by field_simp
 
 /-- **Two nearby points cut a short arc off the circle**: the `δ`-`η` form of
 `TauCeti.exists_isPreconnected_union_eq_compl_pair_circle_diam_le`, in which the bound on the
@@ -169,14 +217,50 @@ private theorem exists_pos_forall_isPreconnected_union_eq_compl_pair_circle_diam
   refine ⟨2 / π * η, by positivity, fun z w hzw hd => ?_⟩
   obtain ⟨P, Q, hPc, hQc, hunion, hPd⟩ :=
     exists_isPreconnected_union_eq_compl_pair_circle_diam_le hzw
-  refine ⟨P, Q, hPc, hQc, hunion, hPd.trans_lt ?_⟩
-  calc π / 2 * dist z w < π / 2 * (2 / π * η) := by
-        exact mul_lt_mul_of_pos_left hd (by positivity)
-    _ = η := by field_simp
+  exact ⟨P, Q, hPc, hQc, hunion, hPd.trans_lt (pi_div_two_mul_lt hη hd)⟩
+
+/-- **Two nearby points of the circle are joined by a short injective path**: the `δ`-`η` form of
+`TauCeti.exists_path_injective_diam_range_le_circle`, in the shape the transport to a Jordan curve
+consumes. -/
+private theorem exists_pos_forall_exists_path_injective_diam_range_lt_circle {η : ℝ} (hη : 0 < η) :
+    ∃ δ > 0, ∀ ⦃z w : Circle⦄, z ≠ w → dist z w < δ →
+      ∃ γ : Path z w, Function.Injective γ ∧ Metric.diam (range γ) < η := by
+  have hπ : 0 < π := Real.pi_pos
+  refine ⟨2 / π * η, by positivity, fun z w hzw hd => ?_⟩
+  obtain ⟨γ, hinj, hdiam⟩ := exists_path_injective_diam_range_le_circle hzw
+  exact ⟨γ, hinj, hdiam.trans_lt (pi_div_two_mul_lt hη hd)⟩
 
 /-! ## Cutting a Jordan curve -/
 
 variable {X : Type*} [PseudoMetricSpace X] {C : Set X} {ε : ℝ}
+
+/-- **Uniform continuity of the parametrization**, in the form the two transports below spend it:
+for every `ε > 0` there is an `η > 0` such that a set of parameters of diameter less than `η` is
+carried by `TauCeti.jordanParam e` to a set of diameter at most `ε`.
+
+The circle is compact, so the parametrization is uniformly continuous, and
+`Metric.dist_le_diam_of_mem` — the circle being bounded — reads the hypothesis on the diameter as a
+bound on the distance between any two of the parameters. -/
+private theorem exists_pos_forall_diam_image_jordanParam_le (e : C ≃ₜ Circle) (hε : 0 < ε) :
+    ∃ η > 0, ∀ s : Set Circle, Metric.diam s < η → Metric.diam (jordanParam e '' s) ≤ ε := by
+  obtain ⟨η, hη₀, hη⟩ := Metric.uniformContinuous_iff.mp
+    (CompactSpace.uniformContinuous_of_continuous (continuous_jordanParam e)) ε hε
+  refine ⟨η, hη₀, fun s hs => Metric.diam_le_of_forall_dist_le hε.le ?_⟩
+  rintro _ ⟨u, hu, rfl⟩ _ ⟨v, hv, rfl⟩
+  exact (hη ((Metric.dist_le_diam_of_mem
+    ((isCompact_univ (X := Circle)).isBounded.subset (subset_univ _)) hu hv).trans_lt hs)).le
+
+/-- **Uniform continuity of the inverse of the parametrization**, in the form the two transports
+below spend it: for every `δ₀ > 0` there is a `δ > 0` such that two points of the curve at distance
+less than `δ` are named by parameters at distance less than `δ₀`. The curve is compact, being
+homeomorphic to the circle. -/
+private theorem exists_pos_forall_dist_apply_lt (e : C ≃ₜ Circle) {δ₀ : ℝ} (hδ₀ : 0 < δ₀) :
+    ∃ δ > 0, ∀ p (hp : p ∈ C), ∀ q (hq : q ∈ C), dist p q < δ →
+      dist (e ⟨p, hp⟩) (e ⟨q, hq⟩) < δ₀ := by
+  have : CompactSpace C := e.symm.compactSpace
+  obtain ⟨δ, hδpos, hδ⟩ := Metric.uniformContinuous_iff.mp
+    (CompactSpace.uniformContinuous_of_continuous e.continuous) δ₀ hδ₀
+  exact ⟨δ, hδpos, fun p hp q hq hpq => hδ (by simpa [Subtype.dist_eq] using hpq)⟩
 
 /-- The set-theoretic content of locating the two transported arcs, applied symmetrically to the
 two sides of the cut in `TauCeti.IsJordanCurve.exists_pos_forall_diam_le`: if the disjoint sets `A`
@@ -210,40 +294,31 @@ private theorem IsJordanCurve.exists_pos_forall_exists_isPreconnected_diam_union
       ∃ P Q : Set X, IsPreconnected P ∧ IsPreconnected Q ∧ P ∪ Q = C \ {p, q} ∧
         Metric.diam (P ∪ {p, q}) ≤ ε := by
   obtain ⟨e⟩ := isJordanCurve_iff.mp h
-  have : CompactSpace C := isCompact_iff_compactSpace.mp h.isCompact
   set g := jordanParam e
   have hgc : Continuous g := continuous_jordanParam e
   have hginj : Function.Injective g := jordanParam_injective e
   have hgrange : range g = C := range_jordanParam e
   -- Uniform continuity of the parametrization turns short arcs into sets of small diameter.
-  obtain ⟨η, hη₀, hη⟩ := Metric.uniformContinuous_iff.mp
-    (CompactSpace.uniformContinuous_of_continuous hgc) ε hε
+  obtain ⟨η, hη₀, hη⟩ := exists_pos_forall_diam_image_jordanParam_le e hε
   obtain ⟨δ₀, hδ₀, hcut⟩ :=
     exists_pos_forall_isPreconnected_union_eq_compl_pair_circle_diam_lt hη₀
   -- Uniform continuity of its inverse turns nearby points into nearby parameters.
-  obtain ⟨δ, hδpos, hδ⟩ := Metric.uniformContinuous_iff.mp
-    (CompactSpace.uniformContinuous_of_continuous e.continuous) δ₀ hδ₀
+  obtain ⟨δ, hδpos, hδ⟩ := exists_pos_forall_dist_apply_lt e hδ₀
   refine ⟨δ, hδpos, fun p hp q hq hpq hpqδ => ?_⟩
   set z := e ⟨p, hp⟩
   set w := e ⟨q, hq⟩
   have hgz : g z = p := jordanParam_apply_apply e hp
   have hgw : g w = q := jordanParam_apply_apply e hq
   have hzw : z ≠ w := fun hh => hpq (congrArg Subtype.val (e.injective hh))
-  have hzwδ : dist z w < δ₀ := hδ (by simpa [Subtype.dist_eq] using hpqδ)
-  obtain ⟨P, Q, hPc, hQc, hunion, hPd⟩ := hcut hzw hzwδ
+  obtain ⟨P, Q, hPc, hQc, hunion, hPd⟩ := hcut hzw (hδ p hp q hq hpqδ)
   -- The closed short arc downstairs is the image of the closed short arc of parameters.
   have hclosed : g '' (P ∪ {z, w}) = g '' P ∪ {p, q} := by
     rw [image_union, image_insert_eq, image_singleton, hgz, hgw]
   have himg : g '' P ∪ g '' Q = C \ {p, q} := by
     rw [← image_union, hunion, Set.image_compl_eq_range_sdiff_image hginj, hgrange,
       image_insert_eq, image_singleton, hgz, hgw]
-  refine ⟨g '' P, g '' Q, hPc.image _ hgc.continuousOn, hQc.image _ hgc.continuousOn,
-    himg, ?_⟩
-  rw [← hclosed]
-  refine Metric.diam_le_of_forall_dist_le hε.le ?_
-  rintro _ ⟨u, hu, rfl⟩ _ ⟨v, hv, rfl⟩
-  exact (hη ((Metric.dist_le_diam_of_mem
-    ((isCompact_univ (X := Circle)).isBounded.subset (subset_univ _)) hu hv).trans_lt hPd)).le
+  exact ⟨g '' P, g '' Q, hPc.image _ hgc.continuousOn, hQc.image _ hgc.continuousOn,
+    himg, hclosed ▸ hη _ hPd⟩
 
 /-- **Two nearby points cut a small arc off a Jordan curve.** For every `ε > 0` there is a `δ > 0`
 with the following property: if `p` and `q` are two distinct points of a Jordan curve `C` at
@@ -317,5 +392,52 @@ theorem IsJordanCurve.exists_pos_forall_exists_diam_le (h : IsJordanCurve C) (h�
   · exact ⟨A, B, hAc, hBc, hdisj, hunion, hsep, hA⟩
   · exact ⟨B, A, hBc, hAc, hdisj.symm, by rw [union_comm]; exact hunion,
       fun S hS hSc => (hsep hS hSc).symm, hB⟩
+
+/-! ## The small arc as an injective path -/
+
+/-- **Two nearby points of a Jordan curve are joined by a small injective path along it.** For every
+`ε > 0` there is a `δ > 0` such that two distinct points `p`, `q` of a Jordan curve `C` at distance
+less than `δ` are the endpoints of an injective path whose range lies on `C` and has diameter at
+most `ε`.
+
+This is `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le` with the small arc *traversed*: the
+set `A ∪ {p, q}` bounded there becomes the range of a path from `p` to `q`, and the path is
+injective, so it is an arc in the strict sense and not merely a path-connected set. That is what a
+consumer joining the arc to another one needs — gluing two arcs along their common endpoints into a
+closed curve is a statement about paths — and it is not available from path-connectedness alone,
+which produces a path but no control of its repetitions.
+
+The transport is that of
+`TauCeti.IsJordanCurve.exists_pos_forall_exists_isPreconnected_diam_union_pair_le`, run on the
+circle statement `TauCeti.exists_path_injective_diam_range_le_circle` instead of on the cut into two
+arcs: the parametrization `TauCeti.jordanParam e` is injective and continuous, so it carries the
+injective path along the short arc of parameters to an injective path along `C`, and both uniform
+continuities are spent exactly as before.
+
+Nothing is claimed about *which* of the two arcs of `C \ {p, q}` the path traverses beyond its being
+the small one, nor that its range is one of them together with the endpoints; the range is a subset
+of `C` containing `p` and `q`, of small diameter, which is what the bound is about. -/
+theorem IsJordanCurve.exists_pos_forall_exists_path_injective_diam_le (h : IsJordanCurve C)
+    (hε : 0 < ε) :
+    ∃ δ > 0, ∀ ⦃p : X⦄, p ∈ C → ∀ ⦃q : X⦄, q ∈ C → p ≠ q → dist p q < δ →
+      ∃ γ : Path p q, Function.Injective γ ∧ range γ ⊆ C ∧ Metric.diam (range γ) ≤ ε := by
+  obtain ⟨e⟩ := isJordanCurve_iff.mp h
+  obtain ⟨η, hη₀, hη⟩ := exists_pos_forall_diam_image_jordanParam_le e hε
+  obtain ⟨δ₀, hδ₀, hcut⟩ := exists_pos_forall_exists_path_injective_diam_range_lt_circle hη₀
+  obtain ⟨δ, hδpos, hδ⟩ := exists_pos_forall_dist_apply_lt e hδ₀
+  refine ⟨δ, hδpos, fun p hp q hq hpq hpqδ => ?_⟩
+  have hzw : e ⟨p, hp⟩ ≠ e ⟨q, hq⟩ := fun hh => hpq (congrArg Subtype.val (e.injective hh))
+  obtain ⟨γ, hinj, hdiam⟩ := hcut hzw (hδ p hp q hq hpqδ)
+  -- The path downstairs is the parametrization composed with the path of parameters.
+  refine ⟨(γ.map (continuous_jordanParam e)).cast (jordanParam_apply_apply e hp).symm
+    (jordanParam_apply_apply e hq).symm, ?_, ?_, ?_⟩ <;>
+    rw [show (((γ.map (continuous_jordanParam e)).cast (jordanParam_apply_apply e hp).symm
+      (jordanParam_apply_apply e hq).symm : Path p q) : unitInterval → X) =
+        jordanParam e ∘ γ from rfl]
+  · exact (jordanParam_injective e).comp hinj
+  · rw [range_comp]
+    exact (image_subset_range _ _).trans (range_jordanParam e).subset
+  · rw [range_comp]
+    exact hη _ hdiam
 
 end TauCeti


### PR DESCRIPTION
This PR supplies the small arc of a Jordan curve as an *injective path*. `TauCeti/Topology/JordanCurve/SmallArc.lean` already proves that two nearby points `p`, `q` of a Jordan curve `C` cut off an arc of small diameter, but it delivers that arc as a path-connected *set* `A ∪ {p, q}`. A consumer that joins the small arc to a second arc along their two common endpoints — the way a crosscut and a boundary arc are glued into a closed curve — needs it as a path, and needs that path injective, which path-connectedness does not give: it produces a path with no control of its repetitions. The new `TauCeti.IsJordanCurve.exists_pos_forall_exists_path_injective_diam_le` states exactly that form: for every `ε > 0` there is a `δ > 0` such that two distinct points of `C` at distance less than `δ` are the endpoints of an injective path whose range lies on `C` and has diameter at most `ε`.

On the circle the closed short arc is already the range of Mathlib's arc `Circle.path z w`, injective by `Circle.path_injective_of_ne`, reversed by `Path.symm` when the counterclockwise direction is the long way round — reversing changes neither the range (`Path.symm_range`) nor injectivity. That is `TauCeti.exists_path_injective_diam_range_le_circle`, the path sharpening of the existing `TauCeti.exists_isPreconnected_union_eq_compl_pair_circle_diam_le`, with the same bound `π / 2 * dist z w` coming from the same comparison `TauCeti.min_angleDiff_le_pi_div_two_mul_dist` of the shorter arc with the chord. Its diameter input is named and moved to where the chord–arc comparisons live, `TauCeti/Topology/Circle/Metric.lean`: `TauCeti.diam_range_circlePath_le` says the range of `Circle.path x y` has diameter at most the angle `Circle.angleDiff x y`. That lemma also replaces the inline computation that previously did the same work inside the cut of the circle, so the two statements now share it rather than repeating `Circle.range_path` and `TauCeti.diam_circleExp_image_Icc_le`.

The transport to an arbitrary Jordan curve is the one the existing cut already runs — the parametrization `TauCeti.jordanParam e` is continuous and injective, so it carries an injective path of parameters to an injective path along the curve — and it spends the same two uniform continuities. Those are extracted here as the private `exists_pos_forall_diam_image_jordanParam_le` (a set of parameters of small diameter has image of small diameter) and `exists_pos_forall_dist_apply_lt` (nearby points of the curve have nearby parameters), and the existing set-valued transport is rewritten to consume them, so the new theorem adds no second copy of that argument. Nothing is claimed about which of the two arcs of `C \ {p, q}` the path traverses beyond its being the small one, nor that its range is one of them together with the endpoints.

The roadmap target is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, "Carathéodory boundary correspondence … the Jordan-domain case: the RMT map of a Jordan domain extends to a homeomorphism of closures", and specifically the step `ConformalMapping/STATUS.md` records under **Jordan curve input** as what the forward direction leans on. The image side of that step already produces the two ends `u`, `v` of a short image crosscut on the Jordan curve `frontier (f '' ball c r)`, close together (`TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le_of_isBounded`); what is needed of the curve is a small boundary arc joining them that can be glued to the image crosscut, and gluing is a statement about injective paths. The statements are for a Jordan curve in an arbitrary pseudometric space, matching the rest of `TauCeti/Topology/JordanCurve/`, so no complex-analytic hypothesis is introduced; the generality bar of the README, which fixes scalar `ℂ` for the theorems layers L0–L6 *add*, is untouched because nothing here is about a map of `ℂ`. Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and the pinned Mathlib has no Jordan-curve vocabulary, so this is new Lean formalization rather than a temporary shim. No Mathlib infrastructure was vendored: the Mathlib inputs are the arc API of `Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean` (`Circle.path`, `Circle.path_injective_of_ne`, `Circle.range_path`, `Circle.angleDiff`) and the `Path` API (`Path.map`, `Path.cast`, `Path.symm_range`), all consumed rather than restated.

`lake build` (7086 jobs), `lake exe axioms` (29951 declarations, all within the allowlist `[propext, Classical.choice, Quot.sound]`), `lake exe module-system` (1548 modules) and `lake exe lint-style` are green.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"jordan-curve-small-arc-injective-path"}-->

🤖 Prepared with Claude Code
