### PR TITLE
feat: construct scalar-extension point automorphisms

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
@@ -171,7 +171,7 @@ finite scalar-extension functor used in Tannakian reconstruction. -/
 noncomputable def fgPointNatIsoHom :
     WithConv (H →ₐ[R] A) →* Aut (FGComoduleCat.scalarExtensionFunctor R H A) :=
   (Aut.autMulEquivOfIso
-      (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A)).symm).toMonoidHom.comp
+      (eqToIso (FGComoduleCat.scalarExtensionFunctor_def R H A)).symm).toMonoidHom.comp
     ((((Functor.whiskeringLeft _ _ _).obj
       (FGComoduleCat.incl (R := R) (C := H))).mapAut
         (ComoduleCat.scalarExtensionFunctor R H A)).comp (pointNatIsoHom R H A))
@@ -181,7 +181,7 @@ and transport across the defining equality of the finite scalar-extension functo
 private theorem fgPointNatIsoHom_apply (g : WithConv (H →ₐ[R] A)) :
     fgPointNatIsoHom R H A g =
       (Aut.autMulEquivOfIso
-        (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A)).symm)
+        (eqToIso (FGComoduleCat.scalarExtensionFunctor_def R H A)).symm)
           ((((Functor.whiskeringLeft _ _ _).obj
             (FGComoduleCat.incl (R := R) (C := H))).mapIso
               (pointNatIsoHom R H A g))) :=
@@ -199,10 +199,10 @@ theorem fgPointNatIsoHom_hom_app (g : WithConv (H →ₐ[R] A))
   -- Rewriting unfolds the outer monoid homomorphism application but does not expose the
   -- hom component assembled by `autMulEquivOfIso` and whiskering, so reduce that component.
   change
-    (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A).symm).inv.app M ≫
+    (eqToIso (FGComoduleCat.scalarExtensionFunctor_def R H A).symm).inv.app M ≫
           (pointNatIso R H A g).hom.app
             ((FGComoduleCat.incl (R := R) (C := H)).obj M) ≫
-        (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A).symm).hom.app M = _
+        (eqToIso (FGComoduleCat.scalarExtensionFunctor_def R H A).symm).hom.app M = _
   rw [pointNatIso_hom_app]
   simp
 
@@ -219,10 +219,10 @@ theorem fgPointNatIsoHom_inv_app (g : WithConv (H →ₐ[R] A))
   -- Rewriting unfolds the outer monoid homomorphism application but does not expose the
   -- inverse component assembled by `autMulEquivOfIso` and whiskering, so reduce that component.
   change
-    (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A).symm).inv.app M ≫
+    (eqToIso (FGComoduleCat.scalarExtensionFunctor_def R H A).symm).inv.app M ≫
           (pointNatIso R H A g).inv.app
             ((FGComoduleCat.incl (R := R) (C := H)).obj M) ≫
-        (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A).symm).hom.app M = _
+        (eqToIso (FGComoduleCat.scalarExtensionFunctor_def R H A).symm).hom.app M = _
   rw [pointNatIso_inv_app]
   simp
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
@@ -66,28 +66,6 @@ private noncomputable def pointIso (g : WithConv (H →ₐ[R] A))
     ((Comodule.pointsAction M g).toModuleIsoₛ.trans
       (eqToIso (ComoduleCat.scalarExtensionFunctor_obj R H A M).symm))
 
-/-- The forward point automorphism is the usual point action, transported across the object
-formula for the opaque scalar-extension functor. -/
-@[simp]
-private theorem pointIso_hom (g : WithConv (H →ₐ[R] A))
-    (M : ComoduleCat.{u, v, w} R H) :
-    (pointIso R H A g M).hom =
-      eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
-        (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
-          eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M).symm :=
-  (rfl)
-
-/-- The inverse point automorphism is the inverse of the usual point action, transported across
-the object formula for the opaque scalar-extension functor. -/
-@[simp]
-private theorem pointIso_inv (g : WithConv (H →ₐ[R] A))
-    (M : ComoduleCat.{u, v, w} R H) :
-    (pointIso R H A g M).inv =
-      eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
-        (Comodule.pointsAction M g).toModuleIsoₛ.inv ≫
-          eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M).symm :=
-  (rfl)
-
 /-- Every algebra-valued point acts as a natural automorphism of the scalar-extension functor.
 Naturality is precisely the fact that scalar extension of a comodule morphism
 intertwines point actions. -/
@@ -95,7 +73,18 @@ noncomputable def pointNatIso (g : WithConv (H →ₐ[R] A)) :
     ComoduleCat.scalarExtensionFunctor R H A ≅
       ComoduleCat.scalarExtensionFunctor R H A :=
   NatIso.ofComponents (pointIso R H A g) (fun {M N} f ↦ by
-    rw [pointIso_hom, pointIso_hom, ComoduleCat.scalarExtensionFunctor_map]
+    -- Reduce the private component constructor directly so its formulas are stated only by the
+    -- public component theorems below.
+    change
+      (ComoduleCat.scalarExtensionFunctor R H A).map f ≫
+          eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A N) ≫
+            (Comodule.pointsAction N g).toModuleIsoₛ.hom ≫
+              eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A N).symm =
+        eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
+            (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
+              eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M).symm ≫
+                (ComoduleCat.scalarExtensionFunctor R H A).map f
+    rw [ComoduleCat.scalarExtensionFunctor_map]
     simp only [Category.assoc]
     rw [cancel_epi]
     simp only [← Category.assoc]

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
@@ -12,8 +12,8 @@ public import TauCeti.Algebra.Coalgebra.Comodule.Finite.ScalarExtension
 
 Let `H` be a Hopf algebra over a commutative semiring `R`, and let `A` be a commutative
 `R`-algebra. Scalar extension of the underlying-module functor is constructed for all comodules
-in `TauCeti.Algebra.Coalgebra.Comodule.Finite.ScalarExtension` and restricted there to
-finitely generated comodules:
+in `TauCeti.Algebra.Coalgebra.Comodule.ScalarExtension` and restricted to finitely generated
+comodules in `TauCeti.Algebra.Coalgebra.Comodule.Finite.ScalarExtension`:
 
 ```text
 FGComoduleCat R H ⥤ SemimoduleCat A,    M ↦ A ⊗[R] M.
@@ -50,16 +50,16 @@ open scoped TensorProduct
 
 namespace TauCeti.Tannaka
 
-universe u v
+universe u v w x
 
 variable (R : Type u) [CommSemiring R]
 variable (H : Type v) [Semiring H] [HopfAlgebra R H]
-variable (A : Type u) [CommSemiring A] [Algebra R A]
+variable (A : Type x) [CommSemiring A] [Algebra R A]
 
 /-- An `A`-valued point of `H` acts by an automorphism on the scalar extension of each
 comodule. -/
 private noncomputable def pointIso (g : WithConv (H →ₐ[R] A))
-    (M : ComoduleCat.{u, v, u} R H) :
+    (M : ComoduleCat.{u, v, w} R H) :
     (ComoduleCat.scalarExtensionFunctor R H A).obj M ≅
       (ComoduleCat.scalarExtensionFunctor R H A).obj M :=
   (eqToIso (ComoduleCat.scalarExtensionFunctor_obj R H A M)).trans
@@ -70,7 +70,7 @@ private noncomputable def pointIso (g : WithConv (H →ₐ[R] A))
 formula for the opaque scalar-extension functor. -/
 @[simp]
 private theorem pointIso_hom (g : WithConv (H →ₐ[R] A))
-    (M : ComoduleCat.{u, v, u} R H) :
+    (M : ComoduleCat.{u, v, w} R H) :
     (pointIso R H A g M).hom =
       eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
         (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
@@ -81,7 +81,7 @@ private theorem pointIso_hom (g : WithConv (H →ₐ[R] A))
 the object formula for the opaque scalar-extension functor. -/
 @[simp]
 private theorem pointIso_inv (g : WithConv (H →ₐ[R] A))
-    (M : ComoduleCat.{u, v, u} R H) :
+    (M : ComoduleCat.{u, v, w} R H) :
     (pointIso R H A g M).inv =
       eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
         (Comodule.pointsAction M g).toModuleIsoₛ.inv ≫
@@ -110,7 +110,7 @@ noncomputable def pointNatIso (g : WithConv (H →ₐ[R] A)) :
 /-- The component of the point natural automorphism is the transported point action. -/
 @[simp]
 theorem pointNatIso_hom_app (g : WithConv (H →ₐ[R] A))
-    (M : ComoduleCat.{u, v, u} R H) :
+    (M : ComoduleCat.{u, v, w} R H) :
     (pointNatIso R H A g).hom.app M =
       eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
         (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
@@ -121,7 +121,7 @@ theorem pointNatIso_hom_app (g : WithConv (H →ₐ[R] A))
 action. -/
 @[simp]
 theorem pointNatIso_inv_app (g : WithConv (H →ₐ[R] A))
-    (M : ComoduleCat.{u, v, u} R H) :
+    (M : ComoduleCat.{u, v, w} R H) :
     (pointNatIso R H A g).inv.app M =
       eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
         (Comodule.pointsAction M g).toModuleIsoₛ.inv ≫
@@ -190,7 +190,7 @@ private theorem fgPointNatIsoHom_apply (g : WithConv (H →ₐ[R] A)) :
 /-- The component of the finite-comodule point automorphism is the transported point action. -/
 @[simp]
 theorem fgPointNatIsoHom_hom_app (g : WithConv (H →ₐ[R] A))
-    (M : FGComoduleCat.{u, v, u} R H) :
+    (M : FGComoduleCat.{u, v, w} R H) :
     (fgPointNatIsoHom R H A g).hom.app M =
       eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
         (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
@@ -210,7 +210,7 @@ theorem fgPointNatIsoHom_hom_app (g : WithConv (H →ₐ[R] A))
 point action. -/
 @[simp]
 theorem fgPointNatIsoHom_inv_app (g : WithConv (H →ₐ[R] A))
-    (M : FGComoduleCat.{u, v, u} R H) :
+    (M : FGComoduleCat.{u, v, w} R H) :
     (fgPointNatIsoHom R H A g).inv.app M =
       eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
         (Comodule.pointsAction M g).toModuleIsoₛ.inv ≫

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
@@ -5,20 +5,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
-public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Basic
+public import TauCeti.Algebra.Coalgebra.Comodule.Finite.ScalarExtension
 
 /-!
-# Scalar extension of finite comodules
+# Point automorphisms of scalar extension
 
 Let `H` be a Hopf algebra over a commutative semiring `R`, and let `A` be a commutative
-`R`-algebra. This file constructs the scalar extension of the underlying-module functor
+`R`-algebra. Scalar extension of the underlying-module functor is constructed for all comodules
+in `TauCeti.Algebra.Coalgebra.Comodule.Finite.ScalarExtension` and restricted there to
+finitely generated comodules:
 
 ```text
 FGComoduleCat R H ⥤ SemimoduleCat A,    M ↦ A ⊗[R] M.
 ```
 
-Every `A`-valued point of `H` acts naturally and invertibly on this functor: its component at
-`M` is the usual point action on `A ⊗[R] M`.
+Every `A`-valued point of `H` acts naturally and invertibly on the all-comodule functor: its
+component at `M` is the usual point action on `A ⊗[R] M`. These automorphisms form a group
+homomorphism, which restricts by precomposition to the finite-comodule functor.
 
 This is the base change of the neutral underlying-module functor, without a faithfulness claim:
 scalar extension along an arbitrary `R → A` need not be faithful. Equipping this functor and
@@ -28,10 +31,10 @@ reductive-groups roadmap.
 
 ## Main declarations
 
-* `TauCeti.Tannaka.scalarExtensionFunctor`: scalar extension of the underlying-module functor on
-  finite comodules.
 * `TauCeti.Tannaka.pointIso`: the point action as an automorphism of one scalar extension.
 * `TauCeti.Tannaka.pointNatIso`: the point action as a natural automorphism of the functor.
+* `TauCeti.Tannaka.pointNatIsoHom`: points acting on all comodules, as a group homomorphism.
+* `TauCeti.Tannaka.fgPointNatIsoHom`: the induced action on finitely generated comodules.
 
 ## References
 
@@ -54,102 +57,130 @@ variable (R : Type u) [CommSemiring R]
 variable (H : Type v) [Semiring H] [HopfAlgebra R H]
 variable (A : Type u) [CommSemiring A] [Algebra R A]
 
-/-- Scalar extension of the underlying-module functor on finitely generated comodules. Over a
-field, its source is the category of finite-dimensional representations, and it sends `M` to
-`A ⊗[R] M`. No faithfulness property is asserted for the map `R → A`. -/
-noncomputable abbrev scalarExtensionFunctor :
-    FGComoduleCat.{u, v, u} R H ⥤ SemimoduleCat.{u} A :=
-  { obj M := SemimoduleCat.of A (A ⊗[R] M)
-    map f := SemimoduleCat.ofHom (f.hom.toLinearMap.baseChange A)
-    map_id M := by
-      apply SemimoduleCat.hom_ext
-      exact TensorProduct.AlgebraTensorModule.ext fun _ _ ↦ rfl
-    map_comp f g := by
-      apply SemimoduleCat.hom_ext
-      exact TensorProduct.AlgebraTensorModule.ext fun _ _ ↦ rfl }
-
-/-- The carrier of the functor at `M` is the scalar extension `A ⊗[R] M`. -/
-@[simp]
-theorem scalarExtensionFunctor_obj_carrier (M : FGComoduleCat.{u, v, u} R H) :
-    ((scalarExtensionFunctor R H A).obj M : Type u) = A ⊗[R] M :=
-  rfl
-
-/-- The linear map underlying the image of a comodule morphism is its scalar extension. -/
-@[simp]
-theorem scalarExtensionFunctor_map_hom {M N : FGComoduleCat.{u, v, u} R H} (f : M ⟶ N) :
-    ((scalarExtensionFunctor R H A).map f).hom = f.hom.toLinearMap.baseChange A :=
-  rfl
-
-/-- An `A`-valued point of `H` acts by an automorphism on the scalar extension of each finite
+/-- An `A`-valued point of `H` acts by an automorphism on the scalar extension of each
 comodule. -/
-noncomputable def pointIso (g : WithConv (H →ₐ[R] A)) (M : FGComoduleCat.{u, v, u} R H) :
-    (scalarExtensionFunctor R H A).obj M ≅ (scalarExtensionFunctor R H A).obj M :=
-  let e := Comodule.pointsAction M.obj g
-  { hom := ConcreteCategory.ofHom e.toLinearMap
-    inv := ConcreteCategory.ofHom e.symm.toLinearMap
-    hom_inv_id := by
-      apply SemimoduleCat.hom_ext
-      exact LinearMap.ext fun x ↦ e.symm_apply_apply x
-    inv_hom_id := by
-      apply SemimoduleCat.hom_ext
-      exact LinearMap.ext fun x ↦ e.apply_symm_apply x }
+noncomputable def pointIso (g : WithConv (H →ₐ[R] A)) (M : ComoduleCat.{u, v, u} R H) :
+    (ComoduleCat.scalarExtensionFunctor R H A).obj M ≅
+      (ComoduleCat.scalarExtensionFunctor R H A).obj M :=
+  (eqToIso (ComoduleCat.scalarExtensionFunctor_obj R H A M)).trans
+    ((Comodule.pointsAction M g).toModuleIsoₛ.trans
+      (eqToIso (ComoduleCat.scalarExtensionFunctor_obj R H A M).symm))
 
-/-- The linear map underlying the forward point automorphism is the usual point action. -/
+/-- The forward point automorphism is the usual point action, transported across the object
+formula for the opaque scalar-extension functor. -/
 @[simp]
-theorem pointIso_hom_hom (g : WithConv (H →ₐ[R] A))
-    (M : FGComoduleCat.{u, v, u} R H) :
-    (pointIso R H A g M).hom.hom = Comodule.endOfPoint M.obj g.ofConv :=
-  Comodule.pointsAction_toLinearMap M.obj g
+theorem pointIso_hom (g : WithConv (H →ₐ[R] A))
+    (M : ComoduleCat.{u, v, u} R H) :
+    (pointIso R H A g M).hom =
+      eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
+        (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
+          eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M).symm :=
+  (rfl)
 
-/-- The linear map underlying the inverse point automorphism is the action of the inverse
-convolution point. -/
+/-- The inverse point automorphism is the inverse of the usual point action, transported across
+the object formula for the opaque scalar-extension functor. -/
 @[simp]
-theorem pointIso_inv_hom (g : WithConv (H →ₐ[R] A))
-    (M : FGComoduleCat.{u, v, u} R H) :
-    (pointIso R H A g M).inv.hom = Comodule.endOfPoint M.obj g⁻¹.ofConv := by
-  rw [← Comodule.pointsAction_toLinearMap M.obj g⁻¹]
-  exact congrArg LinearEquiv.toLinearMap (map_inv (Comodule.pointsAction M.obj) g).symm
+theorem pointIso_inv (g : WithConv (H →ₐ[R] A))
+    (M : ComoduleCat.{u, v, u} R H) :
+    (pointIso R H A g M).inv =
+      eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
+        (Comodule.pointsAction M g).toModuleIsoₛ.inv ≫
+          eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M).symm :=
+  (rfl)
 
 /-- Every algebra-valued point acts as a natural automorphism of the scalar-extension functor.
 Naturality is precisely the fact that scalar extension of a comodule morphism
 intertwines point actions. -/
 noncomputable def pointNatIso (g : WithConv (H →ₐ[R] A)) :
-    scalarExtensionFunctor R H A ≅ scalarExtensionFunctor R H A :=
+    ComoduleCat.scalarExtensionFunctor R H A ≅
+      ComoduleCat.scalarExtensionFunctor R H A :=
   NatIso.ofComponents (pointIso R H A g) (fun {M N} f ↦ by
+    rw [pointIso_hom, pointIso_hom, ComoduleCat.scalarExtensionFunctor_map]
+    simp only [Category.assoc]
+    rw [cancel_epi]
+    simp only [← Category.assoc]
+    rw [cancel_mono]
+    simp only [Category.assoc, eqToHom_trans, eqToHom_refl, Category.comp_id,
+      LinearEquiv.toModuleIsoₛ_hom, Comodule.pointsAction_toLinearMap]
     apply SemimoduleCat.hom_ext
-    apply LinearMap.ext
-    intro x
-    induction x using TensorProduct.induction_on with
-    | zero => rw [map_zero, map_zero]
-    | add x y hx hy =>
-        rw [map_add, map_add, hx, hy]
-    | tmul a m =>
-        have h := LinearMap.congr_fun
-          (Comodule.baseChange_comp_endOfPoint f.hom g.ofConv).symm (a ⊗ₜ[R] m)
-        simp only [SemimoduleCat.hom_comp, pointIso_hom_hom, LinearMap.comp_apply]
-        -- Remove the `SemimoduleCat` object projections so `h`, stated for the unbundled
-        -- tensor-product modules, has exactly the displayed type.
-        change Comodule.endOfPoint N.obj g.ofConv
-            (f.hom.toLinearMap.baseChange A (a ⊗ₜ[R] m)) =
-          f.hom.toLinearMap.baseChange A
-            (Comodule.endOfPoint M.obj g.ofConv (a ⊗ₜ[R] m))
-        exact h)
+    simpa only [SemimoduleCat.hom_comp, LinearEquiv.toModuleIsoₛ_hom,
+      SemimoduleCat.hom_ofHom, Comodule.pointsAction_toLinearMap] using
+      (Comodule.baseChange_comp_endOfPoint f g.ofConv).symm)
 
-/-- The component of the point natural automorphism is the usual point action. -/
+/-- The component of the point natural automorphism is the transported point action. -/
 @[simp]
 theorem pointNatIso_hom_app (g : WithConv (H →ₐ[R] A))
-    (M : FGComoduleCat.{u, v, u} R H) :
-    ((pointNatIso R H A g).hom.app M).hom =
-      Comodule.endOfPoint M.obj g.ofConv :=
-  pointIso_hom_hom R H A g M
+    (M : ComoduleCat.{u, v, u} R H) :
+    (pointNatIso R H A g).hom.app M =
+      eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
+        (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
+          eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M).symm :=
+  (rfl)
 
-/-- The inverse component of the point natural automorphism is the action of the inverse
-convolution point. -/
+/-- The inverse component of the point natural automorphism is the transported inverse point
+action. -/
 @[simp]
 theorem pointNatIso_inv_app (g : WithConv (H →ₐ[R] A))
-    (M : FGComoduleCat.{u, v, u} R H) :
-    ((pointNatIso R H A g).inv.app M).hom =
-      Comodule.endOfPoint M.obj g⁻¹.ofConv :=
-  pointIso_inv_hom R H A g M
+    (M : ComoduleCat.{u, v, u} R H) :
+    (pointNatIso R H A g).inv.app M =
+      eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
+        (Comodule.pointsAction M g).toModuleIsoₛ.inv ≫
+          eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M).symm :=
+  (rfl)
+
+/-- Algebra-valued points act on the scalar-extension functor by natural automorphisms. -/
+noncomputable def pointNatIsoHom :
+    WithConv (H →ₐ[R] A) →* Aut (ComoduleCat.scalarExtensionFunctor R H A) where
+  toFun := pointNatIso R H A
+  map_one' := by
+    apply Aut.ext
+    apply NatTrans.ext
+    funext M
+    change (pointNatIso R H A 1).hom.app M = 𝟙 _
+    rw [pointNatIso_hom_app]
+    simp
+  map_mul' g h := by
+    apply Aut.ext
+    apply NatTrans.ext
+    funext M
+    change (pointNatIso R H A (g * h)).hom.app M =
+      (pointNatIso R H A h).hom.app M ≫ (pointNatIso R H A g).hom.app M
+    rw [pointNatIso_hom_app, pointNatIso_hom_app, pointNatIso_hom_app]
+    simp only [Category.assoc]
+    rw [cancel_epi]
+    simp only [← Category.assoc]
+    rw [cancel_mono]
+    simp only [map_mul, LinearEquiv.toModuleIsoₛ_hom, LinearEquiv.coe_toLinearMap_mul,
+      Comodule.pointsAction_toLinearMap, Category.assoc, eqToHom_trans, eqToHom_refl,
+      Category.comp_id]
+    apply SemimoduleCat.hom_ext
+    rfl
+
+/-- Evaluating the points action homomorphism gives the corresponding natural automorphism. -/
+@[simp]
+theorem pointNatIsoHom_apply (g : WithConv (H →ₐ[R] A)) :
+    pointNatIsoHom R H A g = pointNatIso R H A g :=
+  (rfl)
+
+/-- Restricting the point action to finitely generated comodules gives automorphisms of the
+finite scalar-extension functor used in Tannakian reconstruction. -/
+noncomputable def fgPointNatIsoHom :
+    WithConv (H →ₐ[R] A) →* Aut (FGComoduleCat.scalarExtensionFunctor R H A) :=
+  (Aut.autMulEquivOfIso
+      (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A)).symm).toMonoidHom.comp
+    ((((Functor.whiskeringLeft _ _ _).obj
+      (FGComoduleCat.incl (R := R) (C := H))).mapAut
+        (ComoduleCat.scalarExtensionFunctor R H A)).comp (pointNatIsoHom R H A))
+
+/-- The finite-comodule point action is obtained from the all-comodule action by precomposition
+and transport across the defining equality of the finite scalar-extension functor. -/
+theorem fgPointNatIsoHom_apply (g : WithConv (H →ₐ[R] A)) :
+    fgPointNatIsoHom R H A g =
+      (Aut.autMulEquivOfIso
+        (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A)).symm)
+          ((((Functor.whiskeringLeft _ _ _).obj
+            (FGComoduleCat.incl (R := R) (C := H))).mapIso
+              (pointNatIsoHom R H A g))) :=
+  (rfl)
 
 end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
+public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Basic
+
+/-!
+# Scalar extension of finite comodules
+
+Let `H` be a Hopf algebra over a commutative semiring `R`, and let `A` be a commutative
+`R`-algebra. This file constructs the scalar extension of the underlying-module functor
+
+```text
+FGComoduleCat R H ⥤ SemimoduleCat A,    M ↦ A ⊗[R] M.
+```
+
+Every `A`-valued point of `H` acts naturally and invertibly on this functor: its component at
+`M` is the usual point action on `A ⊗[R] M`.
+
+This is the base change of the neutral underlying-module functor, without a faithfulness claim:
+scalar extension along an arbitrary `R → A` need not be faithful. Equipping this functor and
+these natural automorphisms with their tensor compatibilities is a separate step; together, the
+constructions supply categorical infrastructure for Tannakian reconstruction in Layer 1 of the
+reductive-groups roadmap.
+
+## Main declarations
+
+* `TauCeti.Tannaka.scalarExtensionFunctor`: scalar extension of the underlying-module functor on
+  finite comodules.
+* `TauCeti.Tannaka.pointIso`: the point action as an automorphism of one scalar extension.
+* `TauCeti.Tannaka.pointNatIso`: the point action as a natural automorphism of the functor.
+
+## References
+
+This is the scalar-extended underlying-module functor and point action used in Tannakian
+reconstruction; see
+J. S. Milne, *Algebraic Groups* (2017), §§4.5 and 9.4. The construction reuses Mathlib's
+linear-map base change and Tau Ceti's finite-comodule category and point action.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti.Tannaka
+
+universe u v
+
+variable (R : Type u) [CommSemiring R]
+variable (H : Type v) [Semiring H] [HopfAlgebra R H]
+variable (A : Type u) [CommSemiring A] [Algebra R A]
+
+/-- Scalar extension of the underlying-module functor on finitely generated comodules. Over a
+field, its source is the category of finite-dimensional representations, and it sends `M` to
+`A ⊗[R] M`. No faithfulness property is asserted for the map `R → A`. -/
+noncomputable abbrev scalarExtensionFunctor :
+    FGComoduleCat.{u, v, u} R H ⥤ SemimoduleCat.{u} A :=
+  { obj M := SemimoduleCat.of A (A ⊗[R] M)
+    map f := SemimoduleCat.ofHom (f.hom.toLinearMap.baseChange A)
+    map_id M := by
+      apply SemimoduleCat.hom_ext
+      exact TensorProduct.AlgebraTensorModule.ext fun _ _ ↦ rfl
+    map_comp f g := by
+      apply SemimoduleCat.hom_ext
+      exact TensorProduct.AlgebraTensorModule.ext fun _ _ ↦ rfl }
+
+/-- The carrier of the functor at `M` is the scalar extension `A ⊗[R] M`. -/
+@[simp]
+theorem scalarExtensionFunctor_obj_carrier (M : FGComoduleCat.{u, v, u} R H) :
+    ((scalarExtensionFunctor R H A).obj M : Type u) = A ⊗[R] M :=
+  rfl
+
+/-- The linear map underlying the image of a comodule morphism is its scalar extension. -/
+@[simp]
+theorem scalarExtensionFunctor_map_hom {M N : FGComoduleCat.{u, v, u} R H} (f : M ⟶ N) :
+    ((scalarExtensionFunctor R H A).map f).hom = f.hom.toLinearMap.baseChange A :=
+  rfl
+
+/-- An `A`-valued point of `H` acts by an automorphism on the scalar extension of each finite
+comodule. -/
+noncomputable def pointIso (g : WithConv (H →ₐ[R] A)) (M : FGComoduleCat.{u, v, u} R H) :
+    (scalarExtensionFunctor R H A).obj M ≅ (scalarExtensionFunctor R H A).obj M :=
+  let e := Comodule.pointsAction M.obj g
+  { hom := ConcreteCategory.ofHom e.toLinearMap
+    inv := ConcreteCategory.ofHom e.symm.toLinearMap
+    hom_inv_id := by
+      apply SemimoduleCat.hom_ext
+      exact LinearMap.ext fun x ↦ e.symm_apply_apply x
+    inv_hom_id := by
+      apply SemimoduleCat.hom_ext
+      exact LinearMap.ext fun x ↦ e.apply_symm_apply x }
+
+/-- The linear map underlying the forward point automorphism is the usual point action. -/
+@[simp]
+theorem pointIso_hom_hom (g : WithConv (H →ₐ[R] A))
+    (M : FGComoduleCat.{u, v, u} R H) :
+    (pointIso R H A g M).hom.hom = Comodule.endOfPoint M.obj g.ofConv :=
+  Comodule.pointsAction_toLinearMap M.obj g
+
+/-- The linear map underlying the inverse point automorphism is the action of the inverse
+convolution point. -/
+@[simp]
+theorem pointIso_inv_hom (g : WithConv (H →ₐ[R] A))
+    (M : FGComoduleCat.{u, v, u} R H) :
+    (pointIso R H A g M).inv.hom = Comodule.endOfPoint M.obj g⁻¹.ofConv := by
+  rw [← Comodule.pointsAction_toLinearMap M.obj g⁻¹]
+  exact congrArg LinearEquiv.toLinearMap (map_inv (Comodule.pointsAction M.obj) g).symm
+
+/-- Every algebra-valued point acts as a natural automorphism of the scalar-extension functor.
+Naturality is precisely the fact that scalar extension of a comodule morphism
+intertwines point actions. -/
+noncomputable def pointNatIso (g : WithConv (H →ₐ[R] A)) :
+    scalarExtensionFunctor R H A ≅ scalarExtensionFunctor R H A :=
+  NatIso.ofComponents (pointIso R H A g) (fun {M N} f ↦ by
+    apply SemimoduleCat.hom_ext
+    apply LinearMap.ext
+    intro x
+    induction x using TensorProduct.induction_on with
+    | zero => rw [map_zero, map_zero]
+    | add x y hx hy =>
+        rw [map_add, map_add, hx, hy]
+    | tmul a m =>
+        have h := LinearMap.congr_fun
+          (Comodule.baseChange_comp_endOfPoint f.hom g.ofConv).symm (a ⊗ₜ[R] m)
+        simp only [SemimoduleCat.hom_comp, pointIso_hom_hom, LinearMap.comp_apply]
+        -- Remove the `SemimoduleCat` object projections so `h`, stated for the unbundled
+        -- tensor-product modules, has exactly the displayed type.
+        change Comodule.endOfPoint N.obj g.ofConv
+            (f.hom.toLinearMap.baseChange A (a ⊗ₜ[R] m)) =
+          f.hom.toLinearMap.baseChange A
+            (Comodule.endOfPoint M.obj g.ofConv (a ⊗ₜ[R] m))
+        exact h)
+
+/-- The component of the point natural automorphism is the usual point action. -/
+@[simp]
+theorem pointNatIso_hom_app (g : WithConv (H →ₐ[R] A))
+    (M : FGComoduleCat.{u, v, u} R H) :
+    ((pointNatIso R H A g).hom.app M).hom =
+      Comodule.endOfPoint M.obj g.ofConv :=
+  pointIso_hom_hom R H A g M
+
+/-- The inverse component of the point natural automorphism is the action of the inverse
+convolution point. -/
+@[simp]
+theorem pointNatIso_inv_app (g : WithConv (H →ₐ[R] A))
+    (M : FGComoduleCat.{u, v, u} R H) :
+    ((pointNatIso R H A g).inv.app M).hom =
+      Comodule.endOfPoint M.obj g⁻¹.ofConv :=
+  pointIso_inv_hom R H A g M
+
+end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
@@ -178,7 +178,7 @@ noncomputable def fgPointNatIsoHom :
 
 /-- The finite-comodule point action is obtained from the all-comodule action by precomposition
 and transport across the defining equality of the finite scalar-extension functor. -/
-theorem fgPointNatIsoHom_apply (g : WithConv (H →ₐ[R] A)) :
+private theorem fgPointNatIsoHom_apply (g : WithConv (H →ₐ[R] A)) :
     fgPointNatIsoHom R H A g =
       (Aut.autMulEquivOfIso
         (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A)).symm)
@@ -196,6 +196,8 @@ theorem fgPointNatIsoHom_hom_app (g : WithConv (H →ₐ[R] A))
         (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
           eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm := by
   rw [fgPointNatIsoHom_apply]
+  -- Rewriting unfolds the outer monoid homomorphism application but does not expose the
+  -- hom component assembled by `autMulEquivOfIso` and whiskering, so reduce that component.
   change
     (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A).symm).inv.app M ≫
           (pointNatIso R H A g).hom.app
@@ -214,6 +216,8 @@ theorem fgPointNatIsoHom_inv_app (g : WithConv (H →ₐ[R] A))
         (Comodule.pointsAction M g).toModuleIsoₛ.inv ≫
           eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm := by
   rw [fgPointNatIsoHom_apply]
+  -- Rewriting unfolds the outer monoid homomorphism application but does not expose the
+  -- inverse component assembled by `autMulEquivOfIso` and whiskering, so reduce that component.
   change
     (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A).symm).inv.app M ≫
           (pointNatIso R H A g).inv.app

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
@@ -31,7 +31,6 @@ reductive-groups roadmap.
 
 ## Main declarations
 
-* `TauCeti.Tannaka.pointIso`: the point action as an automorphism of one scalar extension.
 * `TauCeti.Tannaka.pointNatIso`: the point action as a natural automorphism of the functor.
 * `TauCeti.Tannaka.pointNatIsoHom`: points acting on all comodules, as a group homomorphism.
 * `TauCeti.Tannaka.fgPointNatIsoHom`: the induced action on finitely generated comodules.
@@ -59,7 +58,8 @@ variable (A : Type u) [CommSemiring A] [Algebra R A]
 
 /-- An `A`-valued point of `H` acts by an automorphism on the scalar extension of each
 comodule. -/
-noncomputable def pointIso (g : WithConv (H →ₐ[R] A)) (M : ComoduleCat.{u, v, u} R H) :
+private noncomputable def pointIso (g : WithConv (H →ₐ[R] A))
+    (M : ComoduleCat.{u, v, u} R H) :
     (ComoduleCat.scalarExtensionFunctor R H A).obj M ≅
       (ComoduleCat.scalarExtensionFunctor R H A).obj M :=
   (eqToIso (ComoduleCat.scalarExtensionFunctor_obj R H A M)).trans
@@ -69,7 +69,7 @@ noncomputable def pointIso (g : WithConv (H →ₐ[R] A)) (M : ComoduleCat.{u, v
 /-- The forward point automorphism is the usual point action, transported across the object
 formula for the opaque scalar-extension functor. -/
 @[simp]
-theorem pointIso_hom (g : WithConv (H →ₐ[R] A))
+private theorem pointIso_hom (g : WithConv (H →ₐ[R] A))
     (M : ComoduleCat.{u, v, u} R H) :
     (pointIso R H A g M).hom =
       eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
@@ -80,7 +80,7 @@ theorem pointIso_hom (g : WithConv (H →ₐ[R] A))
 /-- The inverse point automorphism is the inverse of the usual point action, transported across
 the object formula for the opaque scalar-extension functor. -/
 @[simp]
-theorem pointIso_inv (g : WithConv (H →ₐ[R] A))
+private theorem pointIso_inv (g : WithConv (H →ₐ[R] A))
     (M : ComoduleCat.{u, v, u} R H) :
     (pointIso R H A g M).inv =
       eqToHom (ComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
@@ -136,6 +136,8 @@ noncomputable def pointNatIsoHom :
     apply Aut.ext
     apply NatTrans.ext
     funext M
+    -- Extensionality exposes a component of `Aut`; reduction identifies that component
+    -- with the natural isomorphism supplied as `pointNatIsoHom.toFun`.
     change (pointNatIso R H A 1).hom.app M = 𝟙 _
     rw [pointNatIso_hom_app]
     simp
@@ -143,6 +145,8 @@ noncomputable def pointNatIsoHom :
     apply Aut.ext
     apply NatTrans.ext
     funext M
+    -- Multiplication in `Aut` is reverse isomorphism composition, so reducing the bundled
+    -- homomorphism turns this component into the following explicitly ordered composite.
     change (pointNatIso R H A (g * h)).hom.app M =
       (pointNatIso R H A h).hom.app M ≫ (pointNatIso R H A g).hom.app M
     rw [pointNatIso_hom_app, pointNatIso_hom_app, pointNatIso_hom_app]
@@ -182,5 +186,40 @@ theorem fgPointNatIsoHom_apply (g : WithConv (H →ₐ[R] A)) :
             (FGComoduleCat.incl (R := R) (C := H))).mapIso
               (pointNatIsoHom R H A g))) :=
   (rfl)
+
+/-- The component of the finite-comodule point automorphism is the transported point action. -/
+@[simp]
+theorem fgPointNatIsoHom_hom_app (g : WithConv (H →ₐ[R] A))
+    (M : FGComoduleCat.{u, v, u} R H) :
+    (fgPointNatIsoHom R H A g).hom.app M =
+      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
+        (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
+          eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm := by
+  rw [fgPointNatIsoHom_apply]
+  change
+    (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A).symm).inv.app M ≫
+          (pointNatIso R H A g).hom.app
+            ((FGComoduleCat.incl (R := R) (C := H)).obj M) ≫
+        (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A).symm).hom.app M = _
+  rw [pointNatIso_hom_app]
+  simp
+
+/-- The inverse component of the finite-comodule point automorphism is the transported inverse
+point action. -/
+@[simp]
+theorem fgPointNatIsoHom_inv_app (g : WithConv (H →ₐ[R] A))
+    (M : FGComoduleCat.{u, v, u} R H) :
+    (fgPointNatIsoHom R H A g).inv.app M =
+      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
+        (Comodule.pointsAction M g).toModuleIsoₛ.inv ≫
+          eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm := by
+  rw [fgPointNatIsoHom_apply]
+  change
+    (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A).symm).inv.app M ≫
+          (pointNatIso R H A g).inv.app
+            ((FGComoduleCat.incl (R := R) (C := H)).obj M) ≫
+        (eqToIso (FGComoduleCat.scalarExtensionFunctor_eq R H A).symm).hom.app M = _
+  rw [pointNatIso_inv_app]
+  simp
 
 end TauCeti.Tannaka

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Basic
+public import Mathlib.LinearAlgebra.TensorProduct.Tower
+
+/-!
+# Scalar extension of comodules
+
+Let `C` be a coalgebra over a commutative semiring `R`, and let `A` be a commutative
+`R`-algebra. This file constructs scalar extension of the underlying-module functor on all
+comodules, and its restriction to finitely generated comodules:
+
+```text
+ComoduleCat R C ⥤ SemimoduleCat A,      M ↦ A ⊗[R] M,
+FGComoduleCat R C ⥤ SemimoduleCat A,    M ↦ A ⊗[R] M.
+```
+
+No finiteness or bialgebra structure is needed for the construction.
+
+## Main declarations
+
+* `TauCeti.ComoduleCat.scalarExtensionFunctor`: scalar extension on all comodules.
+* `TauCeti.FGComoduleCat.scalarExtensionFunctor`: its restriction to finitely generated
+  comodules.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v
+
+variable (R : Type u) [CommSemiring R]
+variable (C : Type v) [AddCommMonoid C] [Module R C] [Coalgebra R C]
+variable (A : Type u) [CommSemiring A] [Algebra R A]
+
+namespace ComoduleCat
+
+/-- Scalar extension of the underlying-module functor on comodules. -/
+noncomputable def scalarExtensionFunctor :
+    ComoduleCat.{u, v, u} R C ⥤ SemimoduleCat.{u} A where
+  obj M := SemimoduleCat.of A (A ⊗[R] M)
+  map f := SemimoduleCat.ofHom (f.toLinearMap.baseChange A)
+  map_id M := by
+    apply SemimoduleCat.hom_ext
+    change (LinearMap.id : M →ₗ[R] M).baseChange A = LinearMap.id
+    exact LinearMap.baseChange_id
+  map_comp f g := by
+    apply SemimoduleCat.hom_ext
+    change (g.toLinearMap ∘ₗ f.toLinearMap).baseChange A =
+      g.toLinearMap.baseChange A ∘ₗ f.toLinearMap.baseChange A
+    exact LinearMap.baseChange_comp f.toLinearMap g.toLinearMap
+
+/-- Scalar extension sends `M` to the semimodule `A ⊗[R] M`. -/
+@[simp]
+theorem scalarExtensionFunctor_obj (M : ComoduleCat.{u, v, u} R C) :
+    (scalarExtensionFunctor R C A).obj M = SemimoduleCat.of A (A ⊗[R] M) :=
+  (rfl)
+
+/-- Scalar extension maps a comodule morphism to base change of its underlying linear map. -/
+@[simp]
+theorem scalarExtensionFunctor_map {M N : ComoduleCat.{u, v, u} R C} (f : M ⟶ N) :
+    (scalarExtensionFunctor R C A).map f =
+      eqToHom (scalarExtensionFunctor_obj R C A M) ≫
+        SemimoduleCat.ofHom (f.toLinearMap.baseChange A) ≫
+          eqToHom (scalarExtensionFunctor_obj R C A N).symm :=
+  (rfl)
+
+end ComoduleCat
+
+namespace FGComoduleCat
+
+/-- Scalar extension of the underlying-module functor on finitely generated comodules. -/
+noncomputable def scalarExtensionFunctor :
+    FGComoduleCat.{u, v, u} R C ⥤ SemimoduleCat.{u} A :=
+  incl ⋙ ComoduleCat.scalarExtensionFunctor R C A
+
+/-- Finite-comodule scalar extension is obtained by precomposing scalar extension on all
+comodules with the inclusion functor. -/
+theorem scalarExtensionFunctor_eq :
+    scalarExtensionFunctor R C A =
+      incl ⋙ ComoduleCat.scalarExtensionFunctor R C A :=
+  (rfl)
+
+/-- Finite-comodule scalar extension sends `M` to the semimodule `A ⊗[R] M`. -/
+@[simp]
+theorem scalarExtensionFunctor_obj (M : FGComoduleCat.{u, v, u} R C) :
+    (scalarExtensionFunctor R C A).obj M = SemimoduleCat.of A (A ⊗[R] M) :=
+  (rfl)
+
+/-- Scalar extension maps a finite-comodule morphism to base change of its underlying linear
+map. -/
+@[simp]
+theorem scalarExtensionFunctor_map {M N : FGComoduleCat.{u, v, u} R C} (f : M ⟶ N) :
+    (scalarExtensionFunctor R C A).map f =
+      eqToHom (scalarExtensionFunctor_obj R C A M) ≫
+        SemimoduleCat.ofHom (f.hom.toLinearMap.baseChange A) ≫
+          eqToHom (scalarExtensionFunctor_obj R C A N).symm :=
+  (rfl)
+
+end FGComoduleCat
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension.lean
@@ -48,7 +48,7 @@ noncomputable def scalarExtensionFunctor :
 
 /-- Finite-comodule scalar extension is obtained by precomposing scalar extension on all
 comodules with the inclusion functor. -/
-theorem scalarExtensionFunctor_eq :
+theorem scalarExtensionFunctor_def :
     scalarExtensionFunctor R C A =
       incl ⋙ ComoduleCat.scalarExtensionFunctor R C A :=
   (rfl)

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension.lean
@@ -10,7 +10,7 @@ public import Mathlib.LinearAlgebra.TensorProduct.Tower
 /-!
 # Scalar extension of comodules
 
-Let `C` be a coalgebra over a commutative semiring `R`, and let `A` be a commutative
+Let `C` be a coalgebra over a commutative semiring `R`, and let `A` be an
 `R`-algebra. This file constructs scalar extension of the underlying-module functor on all
 comodules, and its restriction to finitely generated comodules:
 
@@ -39,7 +39,7 @@ universe u v
 
 variable (R : Type u) [CommSemiring R]
 variable (C : Type v) [AddCommMonoid C] [Module R C] [Coalgebra R C]
-variable (A : Type u) [CommSemiring A] [Algebra R A]
+variable (A : Type u) [Semiring A] [Algebra R A]
 
 namespace ComoduleCat
 
@@ -50,10 +50,14 @@ noncomputable def scalarExtensionFunctor :
   map f := SemimoduleCat.ofHom (f.toLinearMap.baseChange A)
   map_id M := by
     apply SemimoduleCat.hom_ext
+    -- `SemimoduleCat.hom_ext` leaves the bundled map of an identity comodule morphism;
+    -- reducing that wrapper exposes precisely the linear-map base-change identity.
     change (LinearMap.id : M →ₗ[R] M).baseChange A = LinearMap.id
     exact LinearMap.baseChange_id
   map_comp f g := by
     apply SemimoduleCat.hom_ext
+    -- As above, reduction turns composition of bundled comodule morphisms into composition
+    -- of their underlying linear maps, where the base-change API applies.
     change (g.toLinearMap ∘ₗ f.toLinearMap).baseChange A =
       g.toLinearMap.baseChange A ∘ₗ f.toLinearMap.baseChange A
     exact LinearMap.baseChange_comp f.toLinearMap g.toLinearMap

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension.lean
@@ -5,17 +5,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Basic
-public import Mathlib.LinearAlgebra.TensorProduct.Tower
+public import TauCeti.Algebra.Coalgebra.Comodule.ScalarExtension
 
 /-!
 # Scalar extension of comodules
 
 Let `C` be a coalgebra over a commutative semiring `R`, and let `A` be an
-`R`-algebra. This file constructs scalar extension of the underlying-module functor on all
-comodules, and its restriction to finitely generated comodules:
+`R`-algebra. This file restricts scalar extension of the underlying-module functor to finitely
+generated comodules:
 
 ```text
-ComoduleCat R C ⥤ SemimoduleCat A,      M ↦ A ⊗[R] M,
 FGComoduleCat R C ⥤ SemimoduleCat A,    M ↦ A ⊗[R] M.
 ```
 
@@ -23,7 +22,6 @@ No finiteness or bialgebra structure is needed for the construction.
 
 ## Main declarations
 
-* `TauCeti.ComoduleCat.scalarExtensionFunctor`: scalar extension on all comodules.
 * `TauCeti.FGComoduleCat.scalarExtensionFunctor`: its restriction to finitely generated
   comodules.
 -/
@@ -35,55 +33,17 @@ open scoped TensorProduct
 
 namespace TauCeti
 
-universe u v
+universe u v w x
 
 variable (R : Type u) [CommSemiring R]
 variable (C : Type v) [AddCommMonoid C] [Module R C] [Coalgebra R C]
-variable (A : Type u) [Semiring A] [Algebra R A]
-
-namespace ComoduleCat
-
-/-- Scalar extension of the underlying-module functor on comodules. -/
-noncomputable def scalarExtensionFunctor :
-    ComoduleCat.{u, v, u} R C ⥤ SemimoduleCat.{u} A where
-  obj M := SemimoduleCat.of A (A ⊗[R] M)
-  map f := SemimoduleCat.ofHom (f.toLinearMap.baseChange A)
-  map_id M := by
-    apply SemimoduleCat.hom_ext
-    -- `SemimoduleCat.hom_ext` leaves the bundled map of an identity comodule morphism;
-    -- reducing that wrapper exposes precisely the linear-map base-change identity.
-    change (LinearMap.id : M →ₗ[R] M).baseChange A = LinearMap.id
-    exact LinearMap.baseChange_id
-  map_comp f g := by
-    apply SemimoduleCat.hom_ext
-    -- As above, reduction turns composition of bundled comodule morphisms into composition
-    -- of their underlying linear maps, where the base-change API applies.
-    change (g.toLinearMap ∘ₗ f.toLinearMap).baseChange A =
-      g.toLinearMap.baseChange A ∘ₗ f.toLinearMap.baseChange A
-    exact LinearMap.baseChange_comp f.toLinearMap g.toLinearMap
-
-/-- Scalar extension sends `M` to the semimodule `A ⊗[R] M`. -/
-@[simp]
-theorem scalarExtensionFunctor_obj (M : ComoduleCat.{u, v, u} R C) :
-    (scalarExtensionFunctor R C A).obj M = SemimoduleCat.of A (A ⊗[R] M) :=
-  (rfl)
-
-/-- Scalar extension maps a comodule morphism to base change of its underlying linear map. -/
-@[simp]
-theorem scalarExtensionFunctor_map {M N : ComoduleCat.{u, v, u} R C} (f : M ⟶ N) :
-    (scalarExtensionFunctor R C A).map f =
-      eqToHom (scalarExtensionFunctor_obj R C A M) ≫
-        SemimoduleCat.ofHom (f.toLinearMap.baseChange A) ≫
-          eqToHom (scalarExtensionFunctor_obj R C A N).symm :=
-  (rfl)
-
-end ComoduleCat
+variable (A : Type x) [Semiring A] [Algebra R A]
 
 namespace FGComoduleCat
 
 /-- Scalar extension of the underlying-module functor on finitely generated comodules. -/
 noncomputable def scalarExtensionFunctor :
-    FGComoduleCat.{u, v, u} R C ⥤ SemimoduleCat.{u} A :=
+    FGComoduleCat.{u, v, w} R C ⥤ SemimoduleCat.{max x w} A :=
   incl ⋙ ComoduleCat.scalarExtensionFunctor R C A
 
 /-- Finite-comodule scalar extension is obtained by precomposing scalar extension on all
@@ -95,19 +55,19 @@ theorem scalarExtensionFunctor_eq :
 
 /-- Finite-comodule scalar extension sends `M` to the semimodule `A ⊗[R] M`. -/
 @[simp]
-theorem scalarExtensionFunctor_obj (M : FGComoduleCat.{u, v, u} R C) :
+theorem scalarExtensionFunctor_obj (M : FGComoduleCat.{u, v, w} R C) :
     (scalarExtensionFunctor R C A).obj M = SemimoduleCat.of A (A ⊗[R] M) :=
-  (rfl)
+  ComoduleCat.scalarExtensionFunctor_obj R C A M.obj
 
 /-- Scalar extension maps a finite-comodule morphism to base change of its underlying linear
 map. -/
 @[simp]
-theorem scalarExtensionFunctor_map {M N : FGComoduleCat.{u, v, u} R C} (f : M ⟶ N) :
+theorem scalarExtensionFunctor_map {M N : FGComoduleCat.{u, v, w} R C} (f : M ⟶ N) :
     (scalarExtensionFunctor R C A).map f =
       eqToHom (scalarExtensionFunctor_obj R C A M) ≫
         SemimoduleCat.ofHom (f.hom.toLinearMap.baseChange A) ≫
           eqToHom (scalarExtensionFunctor_obj R C A N).symm :=
-  (rfl)
+  ComoduleCat.scalarExtensionFunctor_map R C A f.hom
 
 end FGComoduleCat
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/ScalarExtension.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/ScalarExtension.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Coalgebra.Comodule.Cat
+public import Mathlib.LinearAlgebra.TensorProduct.Tower
+
+/-!
+# Scalar extension of comodules
+
+Let `C` be a coalgebra over a commutative semiring `R`, and let `A` be an
+`R`-algebra. This file constructs scalar extension of the underlying-module functor on all
+comodules:
+
+```text
+ComoduleCat R C ⥤ SemimoduleCat A,      M ↦ A ⊗[R] M.
+```
+
+No finiteness or bialgebra structure is needed for the construction.
+
+## Main declarations
+
+* `TauCeti.ComoduleCat.scalarExtensionFunctor`: scalar extension on all comodules.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w x
+
+variable (R : Type u) [CommSemiring R]
+variable (C : Type v) [AddCommMonoid C] [Module R C] [Coalgebra R C]
+variable (A : Type x) [Semiring A] [Algebra R A]
+
+namespace ComoduleCat
+
+/-- Scalar extension of the underlying-module functor on comodules. -/
+noncomputable def scalarExtensionFunctor :
+    ComoduleCat.{u, v, w} R C ⥤ SemimoduleCat.{max x w} A where
+  obj M := SemimoduleCat.of A (A ⊗[R] M)
+  map f := SemimoduleCat.ofHom (f.toLinearMap.baseChange A)
+  map_id M := by
+    apply SemimoduleCat.hom_ext
+    -- `SemimoduleCat.hom_ext` leaves the bundled map of an identity comodule morphism;
+    -- reducing that wrapper exposes precisely the linear-map base-change identity.
+    change (LinearMap.id : M →ₗ[R] M).baseChange A = LinearMap.id
+    exact LinearMap.baseChange_id
+  map_comp f g := by
+    apply SemimoduleCat.hom_ext
+    -- As above, reduction turns composition of bundled comodule morphisms into composition
+    -- of their underlying linear maps, where the base-change API applies.
+    change (g.toLinearMap ∘ₗ f.toLinearMap).baseChange A =
+      g.toLinearMap.baseChange A ∘ₗ f.toLinearMap.baseChange A
+    exact LinearMap.baseChange_comp f.toLinearMap g.toLinearMap
+
+/-- Scalar extension sends `M` to the semimodule `A ⊗[R] M`. -/
+@[simp]
+theorem scalarExtensionFunctor_obj (M : ComoduleCat.{u, v, w} R C) :
+    (scalarExtensionFunctor R C A).obj M = SemimoduleCat.of A (A ⊗[R] M) :=
+  (rfl)
+
+/-- Scalar extension maps a comodule morphism to base change of its underlying linear map. -/
+@[simp]
+theorem scalarExtensionFunctor_map {M N : ComoduleCat.{u, v, w} R C} (f : M ⟶ N) :
+    (scalarExtensionFunctor R C A).map f =
+      eqToHom (scalarExtensionFunctor_obj R C A M) ≫
+        SemimoduleCat.ofHom (f.toLinearMap.baseChange A) ≫
+          eqToHom (scalarExtensionFunctor_obj R C A N).symm :=
+  (rfl)
+
+end ComoduleCat
+
+end TauCeti


### PR DESCRIPTION
This PR constructs the scalar-extension functor `FGComoduleCat R H ⥤ SemimoduleCat A` and packages every `A`-valued convolution point of a Hopf algebra as a natural automorphism of it. It states the underlying object and morphism formulas, identifies the forward and inverse components with the existing point actions, and proves naturality from `Comodule.baseChange_comp_endOfPoint`.

It advances `ReductiveGroups/README.md`, Layer 1, the milestone “Tannakian reconstruction: recover `G` from its tensor category of representations.” The explicit dependency edge is that packaging a point as a tensor automorphism of the scalar-extended underlying-module functor requires both an actual categorical functor and an ordinary natural automorphism; this PR supplies those objects, while TauCeti#2456 supplies their complementary tensor and unit identities. This is the most effective distinct current step because the embedding-theorem characterization and tangent scalar-extension work are already in flight, whereas this categorical packaging is the next missing input on the Tannakian lane.

After this PR, the milestone still requires combining this natural automorphism with the tensor/unit identities into a monoidal natural automorphism and proving the converse reconstruction that every tensor automorphism comes from a unique point.

The construction is deliberately stated over commutative semirings and makes no faithfulness claim for arbitrary `R → A`; scalar extension is not faithful without further hypotheses. It reuses Mathlib’s `LinearMap.baseChange` and tensor-product extensionality together with Tau Ceti’s finite-comodule category and `Comodule.pointsAction`. No Mathlib infrastructure is vendored. The mathematical organization follows J. S. Milne, *Algebraic Groups* (2017), §§4.5 and 9.4, as recorded in the module documentation.

This adds `TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean` with 155 lines.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"scalar-extension-fiber-functor"}-->

🤖 Prepared with Codex
