### PR TITLE
feat: package the smooth adjoint representation

### DIFF
--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -33,6 +33,8 @@ This advances Deliverable A, Layer 1 of
 * `TauCeti.Lie.Ad_one`: the identity acts trivially.
 * `TauCeti.Lie.Ad_mul`: the group adjoint respects multiplication.
 * `TauCeti.Lie.Ad_inv`: inversion corresponds to the inverse automorphism.
+* `TauCeti.Lie.leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad`: the canonical
+  derivation–model equivalence intertwines `Ad` and `tangentAd`.
 
 ## References
 
@@ -88,6 +90,20 @@ theorem leftInvariantDerivationLieEquivGroupLieAlgebra_Ad
           (I := I) (G := G)
           (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G)) D) := by
   rw [Ad_apply, LieEquiv.apply_symm_apply]
+
+/-- The canonical isometric identification with the model space intertwines the derivation and
+tangent adjoint actions. -/
+theorem leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad
+    [T2Space G] [BoundarylessManifold I G]
+    (g : G) (D : LeftInvariantDerivation I G) :
+    leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G) (Ad g D) =
+      tangentAd (I := I) g
+        (leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G) D) := by
+  have h := leftInvariantDerivationLieEquivGroupLieAlgebra_Ad (I := I) g D
+  have hE := congrArg (fun X : GroupLieAlgebra I G ↦ show E from X) h
+  simpa only [leftInvariantDerivationLieEquivGroupLieAlgebra_apply,
+    leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply,
+    leftInvariantDerivationEquivGroupLieAlgebra_apply] using hE
 
 /-- The identity element acts trivially on left-invariant derivations. -/
 @[simp]

--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -93,6 +93,7 @@ theorem leftInvariantDerivationLieEquivGroupLieAlgebra_Ad
 
 /-- The canonical isometric identification with the model space intertwines the derivation and
 tangent adjoint actions. -/
+@[simp high]
 theorem leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad
     [T2Space G] [BoundarylessManifold I G]
     (g : G) (D : LeftInvariantDerivation I G) :

--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -100,6 +100,8 @@ theorem leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad
       tangentAd (I := I) g
         (leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G) D) := by
   have h := leftInvariantDerivationLieEquivGroupLieAlgebra_Ad (I := I) g D
+  -- `GroupLieAlgebra I G` is definitionally the model space `E`; expose it to compare the
+  -- Lie-equivalence identity with the isometric model-space identification.
   have hE := congrArg (fun X : GroupLieAlgebra I G ↦ show E from X) h
   simpa only [leftInvariantDerivationLieEquivGroupLieAlgebra_apply,
     leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply,

--- a/TauCeti/Geometry/Lie/Adjoint/Representation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Representation.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Lie.Adjoint.Derivation
+public import TauCeti.Geometry.Lie.Adjoint.Smooth
+public import Mathlib.RepresentationTheory.Basic
+
+/-!
+# Smoothness of the group adjoint representation
+
+The tangent adjoint action is jointly smooth. This file transports that result across the
+canonical isometric identification between left-invariant derivations and the tangent space at the
+identity, proving smoothness for the roadmap-facing group adjoint `Ad`.
+
+This advances Deliverable A, Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
+
+## Main result
+
+* `TauCeti.Lie.adjointRepresentation`: the group adjoint as a bundled representation.
+* `TauCeti.Lie.continuousAdjointRepresentation`: the same representation valued in bounded
+  operators.
+* `TauCeti.Lie.contMDiff_Ad_apply`: the joint action `(g, X) ↦ Ad g X` is smooth.
+* `TauCeti.Lie.contMDiff_continuousAdjointRepresentation`: the bounded-operator-valued
+  representation is smooth.
+* `TauCeti.Lie.contMDiff_adjointRepresentation_apply`: the bundled representation acts smoothly.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The group adjoint".
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Lie
+
+open scoped ContDiff Manifold
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
+
+attribute [local instance] LieGroup.minSmoothnessThree
+
+local instance lieGroupBoundarylessManifoldAdjointRepresentation : BoundarylessManifold I G where
+  isInteriorPoint' g :=
+    ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) g
+
+/-- The adjoint representation of a Lie group on its algebra of left-invariant derivations. -/
+def adjointRepresentation :
+    Representation ℝ G (LeftInvariantDerivation I G) where
+  toFun g := (Ad (I := I) g).toLinearEquiv.toLinearMap
+  map_one' := by
+    ext D
+    simp
+  map_mul' g h := by
+    ext D
+    rw [Ad_mul]
+    rfl
+
+omit [T2Space G] in
+@[simp]
+theorem adjointRepresentation_apply (g : G) (D : LeftInvariantDerivation I G) :
+    adjointRepresentation (I := I) g D = Ad (I := I) g D := by
+  rw [adjointRepresentation]
+  change (Ad (I := I) g).toLinearEquiv.toLinearMap D = Ad (I := I) g D
+  rfl
+
+/-- The adjoint representation valued in bounded operators. Finite-dimensionality makes every
+linear endomorphism of the Lie algebra continuous. -/
+def continuousAdjointRepresentation (g : G) :
+    LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G := by
+  let _ : FiniteDimensional ℝ (LeftInvariantDerivation I G) :=
+    finiteDimensional_leftInvariantDerivation
+      (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
+  exact LinearMap.toContinuousLinearMap (adjointRepresentation (I := I) g)
+
+@[simp]
+theorem continuousAdjointRepresentation_apply (g : G) (D : LeftInvariantDerivation I G) :
+    continuousAdjointRepresentation (I := I) g D = Ad (I := I) g D := by
+  rw [continuousAdjointRepresentation]
+  exact adjointRepresentation_apply g D
+
+/-- The group adjoint action on left-invariant derivations is jointly smooth. -/
+theorem contMDiff_Ad_apply :
+    ContMDiff (I.prod 𝓘(ℝ, LeftInvariantDerivation I G))
+      𝓘(ℝ, LeftInvariantDerivation I G) ∞
+      (fun p : G × LeftInvariantDerivation I G ↦ Ad (I := I) p.1 p.2) := by
+  let e := leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G)
+  have hin : ContMDiff
+      (I.prod 𝓘(ℝ, LeftInvariantDerivation I G)) (I.prod 𝓘(ℝ, E)) ∞
+      (fun p : G × LeftInvariantDerivation I G ↦ (p.1, e p.2)) :=
+    contMDiff_fst.prodMk (e.toContinuousLinearEquiv.contDiff.contMDiff.comp contMDiff_snd)
+  have hout : ContMDiff 𝓘(ℝ, E) 𝓘(ℝ, LeftInvariantDerivation I G) ∞ e.symm :=
+    e.symm.toContinuousLinearEquiv.contDiff.contMDiff
+  apply (hout.comp (contMDiff_tangentAd_apply (I := I) (G := G))).comp hin |>.congr
+  intro p
+  simp only [Function.comp_apply]
+  rw [Ad_apply]
+  have hsymm (v : GroupLieAlgebra I G) :
+      (leftInvariantDerivationLieEquivGroupLieAlgebra
+        (I := I) (G := G)
+        (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))).symm v =
+        tangentToLeftInvariantDerivation v := by
+    let eLie := leftInvariantDerivationLieEquivGroupLieAlgebra
+      (I := I) (G := G)
+      (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
+    let e₀ := leftInvariantDerivationEquivGroupLieAlgebra
+      (I := I) (G := G)
+      (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
+    apply eLie.injective
+    calc
+      eLie (eLie.symm v) = v := eLie.apply_symm_apply v
+      _ = eLie (tangentToLeftInvariantDerivation v) := by
+        rw [leftInvariantDerivationLieEquivGroupLieAlgebra_apply]
+        rw [← leftInvariantDerivationEquivGroupLieAlgebra_symm_apply
+          (I := I) (G := G)
+          (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G)) v]
+        exact (e₀.apply_symm_apply v).symm
+  rw [hsymm]
+  let v : E := show E from
+    tangentAd (I := I) p.1 ((e p.2 : E) : GroupLieAlgebra I G)
+  change tangentToLeftInvariantDerivation _ = e.symm v
+  dsimp only [e]
+  rw [leftInvariantDerivationLinearIsometryEquivModelVectorSpace_symm_apply]
+  congr 1
+  dsimp only [v, e]
+  rw [leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply,
+    leftInvariantDerivationLieEquivGroupLieAlgebra_apply]
+
+/-- The bounded-operator-valued adjoint representation is smooth. -/
+theorem contMDiff_continuousAdjointRepresentation :
+    ContMDiff I
+      𝓘(ℝ, LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G) ∞
+      (continuousAdjointRepresentation (I := I) (G := G)) := by
+  let _ : FiniteDimensional ℝ (LeftInvariantDerivation I G) :=
+    finiteDimensional_leftInvariantDerivation
+      (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
+  let b := Module.Free.chooseBasis ℝ (LeftInvariantDerivation I G)
+  let eLin :
+      (LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G) ≃ₗ[ℝ]
+        (Module.Free.ChooseBasisIndex ℝ (LeftInvariantDerivation I G) →
+          LeftInvariantDerivation I G) :=
+    LinearMap.toContinuousLinearMap.symm.trans (b.constr ℝ).symm
+  let e := eLin.toContinuousLinearEquiv
+  have heval (T : LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G)
+      (i : Module.Free.ChooseBasisIndex ℝ (LeftInvariantDerivation I G)) :
+      e T i = T (b i) := by
+    change ((b.constr ℝ).symm (LinearMap.toContinuousLinearMap.symm T)) i = T (b i)
+    rw [Module.Basis.constr_symm_apply]
+    rfl
+  have he : ContMDiff I 𝓘(ℝ,
+      Module.Free.ChooseBasisIndex ℝ (LeftInvariantDerivation I G) →
+        LeftInvariantDerivation I G) ∞
+      (e ∘ continuousAdjointRepresentation (I := I) (G := G)) := by
+    rw [contMDiff_pi_space]
+    intro i
+    have hpair : ContMDiff I
+        (I.prod 𝓘(ℝ, LeftInvariantDerivation I G)) ∞
+        (fun g : G => (g, b i)) := contMDiff_id.prodMk contMDiff_const
+    have h := (contMDiff_Ad_apply (I := I) (G := G)).comp hpair
+    apply h.congr
+    intro g
+    rw [Function.comp_apply, heval, continuousAdjointRepresentation_apply]
+    rfl
+  have hback := e.symm.contDiff.contMDiff.comp he
+  simpa only [Function.comp_def, ContinuousLinearEquiv.symm_apply_apply] using hback
+
+/-- The action map of the bundled adjoint representation is jointly smooth. -/
+theorem contMDiff_adjointRepresentation_apply :
+    ContMDiff (I.prod 𝓘(ℝ, LeftInvariantDerivation I G))
+      𝓘(ℝ, LeftInvariantDerivation I G) ∞
+      (fun p : G × LeftInvariantDerivation I G ↦
+        adjointRepresentation (I := I) p.1 p.2) := by
+  simpa only [adjointRepresentation_apply] using
+    contMDiff_Ad_apply (I := I) (G := G)
+
+end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Representation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Representation.lean
@@ -85,11 +85,8 @@ private theorem continuousAdjointRepresentation_coe :
       (derivationModelEquiv (I := I) (G := G)).symm.conjContinuousAlgEquiv
         (show E →L[ℝ] E from adjointContinuousLinearMap (I := I) g) :=
   by
-    funext g
-    apply ContinuousLinearMap.ext
-    intro D
-    rw [continuousAdjointRepresentation, TauCeti.ContRepresentation.congr_apply,
-      ContinuousLinearEquiv.conjContinuousAlgEquiv_apply_apply, modelAdjointRepresentation]
+    rw [continuousAdjointRepresentation, TauCeti.ContRepresentation.coe_congr,
+      modelAdjointRepresentation]
     rfl
 
 @[simp]

--- a/TauCeti/Geometry/Lie/Adjoint/Representation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Representation.lean
@@ -89,6 +89,7 @@ private theorem continuousAdjointRepresentation_coe :
       modelAdjointRepresentation]
     rfl
 
+/-- The packaged continuous adjoint representation acts by the derivation adjoint action. -/
 @[simp]
 theorem continuousAdjointRepresentation_apply (g : G) (D : LeftInvariantDerivation I G) :
     continuousAdjointRepresentation (I := I) g D = Ad (I := I) g D := by

--- a/TauCeti/Geometry/Lie/Adjoint/Representation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Representation.lean
@@ -9,24 +9,27 @@ public import TauCeti.Geometry.Lie.Adjoint.Smooth
 public import Mathlib.RepresentationTheory.Continuous.Basic
 
 /-!
-# Smoothness of the group adjoint representation
+# The group adjoint representation
 
-The tangent adjoint action is jointly smooth. This file transports that result across the
-canonical isometric identification between left-invariant derivations and the tangent space at the
-identity, proving smoothness for the roadmap-facing group adjoint `Ad`.
+This file bundles the roadmap-facing group adjoint `Ad` as a continuous representation on
+left-invariant derivations. It transports operator-valued smoothness across the canonical
+isometric identification between left-invariant derivations and the tangent space at the identity,
+then derives joint smoothness of the action by evaluation.
 
 This advances Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
 
-## Main result
+## Main definitions
 
-* `TauCeti.Lie.adjointRepresentation`: the group adjoint as a bundled representation.
-* `TauCeti.Lie.continuousAdjointRepresentation`: the same representation valued in bounded
-  operators.
+* `TauCeti.Lie.continuousAdjointRepresentation`: the group adjoint as a continuous representation.
+
+## Main results
+
+* `TauCeti.Lie.leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad`: the canonical
+  derivation–model equivalence intertwines `Ad` and `tangentAd`.
 * `TauCeti.Lie.contMDiff_Ad_apply`: the joint action `(g, X) ↦ Ad g X` is smooth.
 * `TauCeti.Lie.contMDiff_continuousAdjointRepresentation`: the bounded-operator-valued
   representation is smooth.
-* `TauCeti.Lie.contMDiff_adjointRepresentation_apply`: the bundled representation acts smoothly.
 
 ## References
 
@@ -45,136 +48,107 @@ open scoped ContDiff Manifold
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
 
 attribute [local instance] LieGroup.minSmoothnessThree
 
-/-- Lie groups have no manifold boundary because every point is interior. -/
-local instance lieGroupBoundarylessManifoldAdjointRepresentation : BoundarylessManifold I G where
-  isInteriorPoint' g :=
-    ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) g
+local instance : FiniteDimensional ℝ (LeftInvariantDerivation I G) :=
+  finiteDimensional_leftInvariantDerivation BoundarylessManifold.isInteriorPoint
 
-/-- The normed additive structure transported from the finite-dimensional tangent Lie algebra. -/
-local instance lieGroupNormedAddCommGroupAdjointRepresentation :
-    NormedAddCommGroup (LeftInvariantDerivation I G) := by
-  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-  exact LeftInvariantDerivation.instNormedAddCommGroup
-
-/-- The normed-space structure transported from the finite-dimensional tangent Lie algebra. -/
-local instance lieGroupNormedSpaceAdjointRepresentation :
-    NormedSpace ℝ (LeftInvariantDerivation I G) := by
-  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-  exact LeftInvariantDerivation.instNormedSpace
-
-/-- Left-invariant derivations are finite-dimensional under the Lie-group hypotheses. -/
-local instance lieGroupFiniteDimensionalAdjointRepresentation :
-    FiniteDimensional ℝ (LeftInvariantDerivation I G) := by
-  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-  exact finiteDimensional_leftInvariantDerivation
-    (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
+/-- The canonical isometric identification with the model space intertwines the derivation and
+tangent adjoint actions. -/
+@[simp]
+theorem leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad
+    (g : G) (D : LeftInvariantDerivation I G) :
+    leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G)
+        (Ad (I := I) g D) =
+      tangentAd (I := I) g
+        (leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G) D) := by
+  have h := leftInvariantDerivationLieEquivGroupLieAlgebra_Ad (I := I) g D
+  -- `GroupLieAlgebra I G` is definitionally the model space `E`; map the equality across that
+  -- identification before rewriting the two derivation equivalences.
+  have hE := congrArg (fun X : GroupLieAlgebra I G ↦ show E from X) h
+  simpa only [leftInvariantDerivationLieEquivGroupLieAlgebra_apply,
+    leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply] using hE
 
 /-- The adjoint representation valued in bounded operators. -/
 def continuousAdjointRepresentation :
     ContRepresentation ℝ G (LeftInvariantDerivation I G) where
-  toMonoidHom :=
-    { toFun := fun g ↦ LinearMap.toContinuousLinearMap
-        (Ad (I := I) g).toLinearEquiv.toLinearMap
-      map_one' := by
-        ext D
-        simp
-      map_mul' := by
-        intro g h
-        ext D
-        rw [Ad_mul]
-        rfl }
-
-/-- The adjoint representation of a Lie group on its algebra of left-invariant derivations. -/
-def adjointRepresentation :
-    Representation ℝ G (LeftInvariantDerivation I G) :=
-  (continuousAdjointRepresentation (I := I) (G := G)).toRepresentation
-
-@[simp]
-theorem adjointRepresentation_apply (g : G) (D : LeftInvariantDerivation I G) :
-    adjointRepresentation (I := I) g D = Ad (I := I) g D := by
-  change LinearMap.toContinuousLinearMap
-    (Ad (I := I) g).toLinearEquiv.toLinearMap D = Ad (I := I) g D
-  rfl
+  toMonoidHom := by
+    let e := (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+      (I := I) (G := G)).toContinuousLinearEquiv
+    let transport := (e.arrowCongr e).symm
+    let A : G → E →L[ℝ] E := fun g ↦
+      show E →L[ℝ] E from adjointContinuousLinearMap (I := I) g
+    have hA_one : A 1 = ContinuousLinearMap.id ℝ E := by
+      have h := adjointContinuousLinearMap_one (I := I) (G := G)
+      change A 1 = ContinuousLinearMap.id ℝ E at h
+      exact h
+    have hA_mul (g h : G) : A (g * h) = (A g).comp (A h) := by
+      have hmul := adjointContinuousLinearMap_mul (I := I) g h
+      change A (g * h) = (A g).comp (A h) at hmul
+      exact hmul
+    exact
+      { toFun := fun g ↦ transport (A g)
+        map_one' := by
+          apply ContinuousLinearMap.ext
+          intro D
+          simp only [transport, ContinuousLinearEquiv.arrowCongr_symm]
+          rw [ContinuousLinearEquiv.arrowCongr_apply, hA_one,
+            ContinuousLinearMap.id_apply]
+          simp only [ContinuousLinearEquiv.symm_symm, ContinuousLinearEquiv.symm_apply_apply,
+            one_apply_eq_self]
+        map_mul' := by
+          intro g h
+          apply ContinuousLinearMap.ext
+          intro D
+          simp only [transport, ContinuousLinearEquiv.arrowCongr_symm, mul_apply_eq_comp]
+          rw [hA_mul]
+          rw [ContinuousLinearEquiv.arrowCongr_apply, ContinuousLinearEquiv.arrowCongr_apply,
+            ContinuousLinearEquiv.arrowCongr_apply, ContinuousLinearMap.comp_apply]
+          apply e.injective
+          simp only [ContinuousLinearEquiv.symm_symm,
+            ContinuousLinearEquiv.apply_symm_apply] }
 
 @[simp]
 theorem continuousAdjointRepresentation_apply (g : G) (D : LeftInvariantDerivation I G) :
     continuousAdjointRepresentation (I := I) g D = Ad (I := I) g D := by
-  exact adjointRepresentation_apply g D
-
-/-- The group adjoint action on left-invariant derivations is jointly smooth. -/
-theorem contMDiff_Ad_apply :
-    ContMDiff (I.prod 𝓘(ℝ, LeftInvariantDerivation I G))
-      𝓘(ℝ, LeftInvariantDerivation I G) ∞
-      (fun p : G × LeftInvariantDerivation I G ↦ Ad (I := I) p.1 p.2) := by
-  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-  let e := leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G)
-  have hin : ContMDiff
-      (I.prod 𝓘(ℝ, LeftInvariantDerivation I G)) (I.prod 𝓘(ℝ, E)) ∞
-      (fun p : G × LeftInvariantDerivation I G ↦ (p.1, e p.2)) :=
-    contMDiff_fst.prodMk (e.toContinuousLinearEquiv.contDiff.contMDiff.comp contMDiff_snd)
-  have hout : ContMDiff 𝓘(ℝ, E) 𝓘(ℝ, LeftInvariantDerivation I G) ∞ e.symm :=
-    e.symm.toContinuousLinearEquiv.contDiff.contMDiff
-  apply (hout.comp (contMDiff_tangentAd_apply (I := I) (G := G))).comp hin |>.congr
-  intro p
-  simp only [Function.comp_apply]
-  rw [Ad_apply]
-  rw [leftInvariantDerivationLieEquivGroupLieAlgebra_symm_apply]
-  let v : E := show E from
-    tangentAd (I := I) p.1 ((e p.2 : E) : GroupLieAlgebra I G)
-  change tangentToLeftInvariantDerivation _ = e.symm v
+  let e := (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+    (I := I) (G := G)).toContinuousLinearEquiv
+  apply e.injective
+  -- Unfold the direct operator transport so the two inverse-equivalence applications are visible.
+  change e (e.symm ((show E →L[ℝ] E from adjointContinuousLinearMap (I := I) g) (e D))) =
+    e (Ad (I := I) g D)
+  rw [ContinuousLinearEquiv.apply_symm_apply]
   dsimp only [e]
-  rw [leftInvariantDerivationLinearIsometryEquivModelVectorSpace_symm_apply]
-  congr 1
-  dsimp only [v, e]
-  rw [leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply,
-    leftInvariantDerivationLieEquivGroupLieAlgebra_apply]
+  have h := tangentAd_apply (I := I) g
+    ((leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+      (I := I) (G := G) D : E) : GroupLieAlgebra I G)
+  have hE := congrArg (fun X : GroupLieAlgebra I G ↦ show E from X) h
+  exact hE.symm.trans
+    (leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad (I := I) g D).symm
 
 /-- The bounded-operator-valued adjoint representation is smooth. -/
 theorem contMDiff_continuousAdjointRepresentation :
     ContMDiff I
       𝓘(ℝ, LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G) ∞
       (continuousAdjointRepresentation (I := I) (G := G)) := by
-  let b := Module.Free.chooseBasis ℝ (LeftInvariantDerivation I G)
-  let eLin :
-      (LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G) ≃ₗ[ℝ]
-        (Module.Free.ChooseBasisIndex ℝ (LeftInvariantDerivation I G) →
-          LeftInvariantDerivation I G) :=
-    LinearMap.toContinuousLinearMap.symm.trans (b.constr ℝ).symm
-  let e := eLin.toContinuousLinearEquiv
-  have heval (T : LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G)
-      (i : Module.Free.ChooseBasisIndex ℝ (LeftInvariantDerivation I G)) :
-      e T i = T (b i) := by
-    change ((b.constr ℝ).symm (LinearMap.toContinuousLinearMap.symm T)) i = T (b i)
-    rw [Module.Basis.constr_symm_apply]
-    rfl
-  have he : ContMDiff I 𝓘(ℝ,
-      Module.Free.ChooseBasisIndex ℝ (LeftInvariantDerivation I G) →
-        LeftInvariantDerivation I G) ∞
-      (e ∘ continuousAdjointRepresentation (I := I) (G := G)) := by
-    rw [contMDiff_pi_space]
-    intro i
-    have hpair : ContMDiff I
-        (I.prod 𝓘(ℝ, LeftInvariantDerivation I G)) ∞
-        (fun g : G => (g, b i)) := contMDiff_id.prodMk contMDiff_const
-    have h := (contMDiff_Ad_apply (I := I) (G := G)).comp hpair
-    apply h.congr
-    intro g
-    rw [Function.comp_apply, heval, continuousAdjointRepresentation_apply]
-    rfl
-  have hback := e.symm.contDiff.contMDiff.comp he
-  simpa only [Function.comp_def, ContinuousLinearEquiv.symm_apply_apply] using hback
+  let e := (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+    (I := I) (G := G)).toContinuousLinearEquiv
+  let transport := (e.arrowCongr e).symm
+  exact transport.contDiff.contMDiff.comp
+    (contMDiff_adjointContinuousLinearMap (I := I) (G := G))
 
-/-- The action map of the bundled adjoint representation is jointly smooth. -/
-theorem contMDiff_adjointRepresentation_apply :
+/-- The group adjoint action on left-invariant derivations is jointly smooth. -/
+theorem contMDiff_Ad_apply :
     ContMDiff (I.prod 𝓘(ℝ, LeftInvariantDerivation I G))
       𝓘(ℝ, LeftInvariantDerivation I G) ∞
-      (fun p : G × LeftInvariantDerivation I G ↦
-        adjointRepresentation (I := I) p.1 p.2) := by
-  simpa only [adjointRepresentation_apply] using
-    contMDiff_Ad_apply (I := I) (G := G)
+      (fun p : G × LeftInvariantDerivation I G ↦ Ad (I := I) p.1 p.2) := by
+  rw [show (fun p : G × LeftInvariantDerivation I G ↦ Ad (I := I) p.1 p.2) =
+      fun p ↦ continuousAdjointRepresentation (I := I) p.1 p.2 by
+    funext p
+    exact (continuousAdjointRepresentation_apply (I := I) p.1 p.2).symm]
+  exact ((contMDiff_continuousAdjointRepresentation (I := I) (G := G)).comp
+    contMDiff_fst).clm_apply contMDiff_snd
 
 end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Representation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Representation.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.Geometry.Lie.Adjoint.Derivation
 public import TauCeti.Geometry.Lie.Adjoint.Smooth
-public import Mathlib.RepresentationTheory.Basic
+public import Mathlib.RepresentationTheory.Continuous.Basic
 
 /-!
 # Smoothness of the group adjoint representation
@@ -45,47 +45,64 @@ open scoped ContDiff Manifold
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G]
 
 attribute [local instance] LieGroup.minSmoothnessThree
 
+/-- Lie groups have no manifold boundary because every point is interior. -/
 local instance lieGroupBoundarylessManifoldAdjointRepresentation : BoundarylessManifold I G where
   isInteriorPoint' g :=
     ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) g
 
+/-- The normed additive structure transported from the finite-dimensional tangent Lie algebra. -/
+local instance lieGroupNormedAddCommGroupAdjointRepresentation :
+    NormedAddCommGroup (LeftInvariantDerivation I G) := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  exact LeftInvariantDerivation.instNormedAddCommGroup
+
+/-- The normed-space structure transported from the finite-dimensional tangent Lie algebra. -/
+local instance lieGroupNormedSpaceAdjointRepresentation :
+    NormedSpace ℝ (LeftInvariantDerivation I G) := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  exact LeftInvariantDerivation.instNormedSpace
+
+/-- Left-invariant derivations are finite-dimensional under the Lie-group hypotheses. -/
+local instance lieGroupFiniteDimensionalAdjointRepresentation :
+    FiniteDimensional ℝ (LeftInvariantDerivation I G) := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  exact finiteDimensional_leftInvariantDerivation
+    (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
+
+/-- The adjoint representation valued in bounded operators. -/
+def continuousAdjointRepresentation :
+    ContRepresentation ℝ G (LeftInvariantDerivation I G) where
+  toMonoidHom :=
+    { toFun := fun g ↦ LinearMap.toContinuousLinearMap
+        (Ad (I := I) g).toLinearEquiv.toLinearMap
+      map_one' := by
+        ext D
+        simp
+      map_mul' := by
+        intro g h
+        ext D
+        rw [Ad_mul]
+        rfl }
+
 /-- The adjoint representation of a Lie group on its algebra of left-invariant derivations. -/
 def adjointRepresentation :
-    Representation ℝ G (LeftInvariantDerivation I G) where
-  toFun g := (Ad (I := I) g).toLinearEquiv.toLinearMap
-  map_one' := by
-    ext D
-    simp
-  map_mul' g h := by
-    ext D
-    rw [Ad_mul]
-    rfl
+    Representation ℝ G (LeftInvariantDerivation I G) :=
+  (continuousAdjointRepresentation (I := I) (G := G)).toRepresentation
 
-omit [T2Space G] in
 @[simp]
 theorem adjointRepresentation_apply (g : G) (D : LeftInvariantDerivation I G) :
     adjointRepresentation (I := I) g D = Ad (I := I) g D := by
-  rw [adjointRepresentation]
-  change (Ad (I := I) g).toLinearEquiv.toLinearMap D = Ad (I := I) g D
+  change LinearMap.toContinuousLinearMap
+    (Ad (I := I) g).toLinearEquiv.toLinearMap D = Ad (I := I) g D
   rfl
-
-/-- The adjoint representation valued in bounded operators. Finite-dimensionality makes every
-linear endomorphism of the Lie algebra continuous. -/
-def continuousAdjointRepresentation (g : G) :
-    LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G := by
-  let _ : FiniteDimensional ℝ (LeftInvariantDerivation I G) :=
-    finiteDimensional_leftInvariantDerivation
-      (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
-  exact LinearMap.toContinuousLinearMap (adjointRepresentation (I := I) g)
 
 @[simp]
 theorem continuousAdjointRepresentation_apply (g : G) (D : LeftInvariantDerivation I G) :
     continuousAdjointRepresentation (I := I) g D = Ad (I := I) g D := by
-  rw [continuousAdjointRepresentation]
   exact adjointRepresentation_apply g D
 
 /-- The group adjoint action on left-invariant derivations is jointly smooth. -/
@@ -93,6 +110,7 @@ theorem contMDiff_Ad_apply :
     ContMDiff (I.prod 𝓘(ℝ, LeftInvariantDerivation I G))
       𝓘(ℝ, LeftInvariantDerivation I G) ∞
       (fun p : G × LeftInvariantDerivation I G ↦ Ad (I := I) p.1 p.2) := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   let e := leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G)
   have hin : ContMDiff
       (I.prod 𝓘(ℝ, LeftInvariantDerivation I G)) (I.prod 𝓘(ℝ, E)) ∞
@@ -104,27 +122,7 @@ theorem contMDiff_Ad_apply :
   intro p
   simp only [Function.comp_apply]
   rw [Ad_apply]
-  have hsymm (v : GroupLieAlgebra I G) :
-      (leftInvariantDerivationLieEquivGroupLieAlgebra
-        (I := I) (G := G)
-        (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))).symm v =
-        tangentToLeftInvariantDerivation v := by
-    let eLie := leftInvariantDerivationLieEquivGroupLieAlgebra
-      (I := I) (G := G)
-      (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
-    let e₀ := leftInvariantDerivationEquivGroupLieAlgebra
-      (I := I) (G := G)
-      (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
-    apply eLie.injective
-    calc
-      eLie (eLie.symm v) = v := eLie.apply_symm_apply v
-      _ = eLie (tangentToLeftInvariantDerivation v) := by
-        rw [leftInvariantDerivationLieEquivGroupLieAlgebra_apply]
-        rw [← leftInvariantDerivationEquivGroupLieAlgebra_symm_apply
-          (I := I) (G := G)
-          (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G)) v]
-        exact (e₀.apply_symm_apply v).symm
-  rw [hsymm]
+  rw [leftInvariantDerivationLieEquivGroupLieAlgebra_symm_apply]
   let v : E := show E from
     tangentAd (I := I) p.1 ((e p.2 : E) : GroupLieAlgebra I G)
   change tangentToLeftInvariantDerivation _ = e.symm v
@@ -140,9 +138,6 @@ theorem contMDiff_continuousAdjointRepresentation :
     ContMDiff I
       𝓘(ℝ, LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G) ∞
       (continuousAdjointRepresentation (I := I) (G := G)) := by
-  let _ : FiniteDimensional ℝ (LeftInvariantDerivation I G) :=
-    finiteDimensional_leftInvariantDerivation
-      (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
   let b := Module.Free.chooseBasis ℝ (LeftInvariantDerivation I G)
   let eLin :
       (LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G) ≃ₗ[ℝ]

--- a/TauCeti/Geometry/Lie/Adjoint/Representation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Representation.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.Geometry.Lie.Adjoint.Derivation
 public import TauCeti.Geometry.Lie.Adjoint.Smooth
-public import Mathlib.RepresentationTheory.Continuous.Basic
+public import TauCeti.RepresentationTheory.Continuous.Transport
 
 /-!
 # The group adjoint representation
@@ -25,8 +25,6 @@ This advances Deliverable A, Layer 1 of
 
 ## Main results
 
-* `TauCeti.Lie.leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad`: the canonical
-  derivation–model equivalence intertwines `Ad` and `tangentAd`.
 * `TauCeti.Lie.contMDiff_Ad_apply`: the joint action `(g, X) ↦ Ad g X` is smooth.
 * `TauCeti.Lie.contMDiff_continuousAdjointRepresentation`: the bounded-operator-valued
   representation is smooth.
@@ -55,89 +53,65 @@ attribute [local instance] LieGroup.minSmoothnessThree
 local instance : FiniteDimensional ℝ (LeftInvariantDerivation I G) :=
   finiteDimensional_leftInvariantDerivation BoundarylessManifold.isInteriorPoint
 
-/-- The canonical isometric identification with the model space intertwines the derivation and
-tangent adjoint actions. -/
-@[simp]
-theorem leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad
-    (g : G) (D : LeftInvariantDerivation I G) :
-    (pointDerivationEquivTangentSpace (I := I) 1 BoundarylessManifold.isInteriorPoint
-        (LeftInvariantDerivation.evalAt 1 (Ad (I := I) g D)) : E) =
-      tangentAd (I := I) g
-        (leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G) D) := by
-  have h := leftInvariantDerivationLieEquivGroupLieAlgebra_Ad (I := I) g D
-  simpa only [leftInvariantDerivationLieEquivGroupLieAlgebra_apply,
-    leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply,
-    leftInvariantDerivationEquivGroupLieAlgebra_apply] using h
+private noncomputable def derivationModelEquiv :
+    LeftInvariantDerivation I G ≃L[ℝ] E :=
+  (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+    (I := I) (G := G)).toContinuousLinearEquiv
+
+private noncomputable def modelAdjointRepresentation : ContRepresentation ℝ G E :=
+  .ofMonoidHom
+    { toFun := fun g ↦ show E →L[ℝ] E from adjointContinuousLinearMap (I := I) g
+      map_one' := adjointContinuousLinearMap_one (I := I) (G := G)
+      map_mul' := by
+        intro g h
+        -- `GroupLieAlgebra I G` is definitionally the model space `E`; expose it before using the
+        -- operator-composition form of the adjoint multiplication law.
+        change (adjointContinuousLinearMap (I := I) (g * h) : E →L[ℝ] E) =
+          (adjointContinuousLinearMap (I := I) g).comp
+            (adjointContinuousLinearMap (I := I) h)
+        exact adjointContinuousLinearMap_mul (I := I) g h }
 
 /-- The adjoint representation valued in bounded operators. -/
-def continuousAdjointRepresentation :
-    ContRepresentation ℝ G (LeftInvariantDerivation I G) where
-  toMonoidHom := by
-    let e := (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
-      (I := I) (G := G)).toContinuousLinearEquiv
-    let transport := (e.arrowCongr e).symm
-    let A : G → E →L[ℝ] E := fun g ↦
-      show E →L[ℝ] E from adjointContinuousLinearMap (I := I) g
-    have hA_one : A 1 = ContinuousLinearMap.id ℝ E := by
-      have h := adjointContinuousLinearMap_one (I := I) (G := G)
-      change A 1 = ContinuousLinearMap.id ℝ E at h
-      exact h
-    have hA_mul (g h : G) : A (g * h) = (A g).comp (A h) := by
-      have hmul := adjointContinuousLinearMap_mul (I := I) g h
-      change A (g * h) = (A g).comp (A h) at hmul
-      exact hmul
-    exact
-      { toFun := fun g ↦ transport (A g)
-        map_one' := by
-          apply ContinuousLinearMap.ext
-          intro D
-          simp only [transport, ContinuousLinearEquiv.arrowCongr_symm]
-          rw [ContinuousLinearEquiv.arrowCongr_apply, hA_one,
-            ContinuousLinearMap.id_apply]
-          simp only [ContinuousLinearEquiv.symm_symm, ContinuousLinearEquiv.symm_apply_apply,
-            one_apply_eq_self]
-        map_mul' := by
-          intro g h
-          apply ContinuousLinearMap.ext
-          intro D
-          simp only [transport, ContinuousLinearEquiv.arrowCongr_symm, mul_apply_eq_comp]
-          rw [hA_mul]
-          rw [ContinuousLinearEquiv.arrowCongr_apply, ContinuousLinearEquiv.arrowCongr_apply,
-            ContinuousLinearEquiv.arrowCongr_apply, ContinuousLinearMap.comp_apply]
-          apply e.injective
-          simp only [ContinuousLinearEquiv.symm_symm,
-            ContinuousLinearEquiv.apply_symm_apply] }
+def continuousAdjointRepresentation : ContRepresentation ℝ G (LeftInvariantDerivation I G) :=
+  TauCeti.ContRepresentation.congr (derivationModelEquiv (I := I) (G := G)).symm
+    (modelAdjointRepresentation (I := I) (G := G))
+
+private theorem continuousAdjointRepresentation_coe :
+    ⇑(continuousAdjointRepresentation (I := I) (G := G)) = fun g ↦
+      (derivationModelEquiv (I := I) (G := G)).symm.conjContinuousAlgEquiv
+        (show E →L[ℝ] E from adjointContinuousLinearMap (I := I) g) :=
+  by
+    funext g
+    apply ContinuousLinearMap.ext
+    intro D
+    exact TauCeti.ContRepresentation.congr_apply _ _ _ _
 
 @[simp]
 theorem continuousAdjointRepresentation_apply (g : G) (D : LeftInvariantDerivation I G) :
     continuousAdjointRepresentation (I := I) g D = Ad (I := I) g D := by
-  let e := (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
-    (I := I) (G := G)).toContinuousLinearEquiv
-  apply e.injective
-  -- Unfold the direct operator transport so the two inverse-equivalence applications are visible.
-  change e (e.symm ((show E →L[ℝ] E from adjointContinuousLinearMap (I := I) g) (e D))) =
-    e (Ad (I := I) g D)
+  rw [continuousAdjointRepresentation, TauCeti.ContRepresentation.congr_apply]
+  apply (derivationModelEquiv (I := I) (G := G)).injective
   rw [ContinuousLinearEquiv.apply_symm_apply]
-  dsimp only [e]
-  have h := tangentAd_apply (I := I) g
+  -- `GroupLieAlgebra I G` is definitionally `E`; expose the conjugated model-space operator.
+  change (adjointContinuousLinearMap (I := I) g : E →L[ℝ] E)
+      (derivationModelEquiv (I := I) (G := G) D) =
+    derivationModelEquiv (I := I) (G := G) (Ad (I := I) g D)
+  dsimp only [derivationModelEquiv]
+  have htangent := tangentAd_apply (I := I) g
     ((leftInvariantDerivationLinearIsometryEquivModelVectorSpace
       (I := I) (G := G) D : E) : GroupLieAlgebra I G)
-  have hE := congrArg (fun X : GroupLieAlgebra I G ↦ show E from X) h
-  have hintertwine := congrArg (fun X : GroupLieAlgebra I G ↦ show E from X)
+  have htangentE := congrArg (fun X : GroupLieAlgebra I G ↦ show E from X) htangent
+  exact htangentE.symm.trans
     (leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad (I := I) g D).symm
-  rw [← leftInvariantDerivationEquivGroupLieAlgebra_apply,
-    ← leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply] at hintertwine
-  exact hE.symm.trans hintertwine
 
 /-- The bounded-operator-valued adjoint representation is smooth. -/
 theorem contMDiff_continuousAdjointRepresentation :
     ContMDiff I
       𝓘(ℝ, LeftInvariantDerivation I G →L[ℝ] LeftInvariantDerivation I G) ∞
       (continuousAdjointRepresentation (I := I) (G := G)) := by
-  let e := (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
-    (I := I) (G := G)).toContinuousLinearEquiv
-  let transport := (e.arrowCongr e).symm
-  exact transport.contDiff.contMDiff.comp
+  rw [continuousAdjointRepresentation_coe]
+  exact (derivationModelEquiv (I := I) (G := G)).symm.conjContinuousAlgEquiv
+    |>.toContinuousLinearEquiv.contDiff.contMDiff.comp
     (contMDiff_adjointContinuousLinearMap (I := I) (G := G))
 
 /-- The group adjoint action on left-invariant derivations is jointly smooth. -/

--- a/TauCeti/Geometry/Lie/Adjoint/Representation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Representation.lean
@@ -61,7 +61,11 @@ private noncomputable def derivationModelEquiv :
 private noncomputable def modelAdjointRepresentation : ContRepresentation ℝ G E :=
   .ofMonoidHom
     { toFun := fun g ↦ show E →L[ℝ] E from adjointContinuousLinearMap (I := I) g
-      map_one' := adjointContinuousLinearMap_one (I := I) (G := G)
+      map_one' := by
+        -- `GroupLieAlgebra I G` is definitionally `E`; expose both it and the operator-space unit.
+        change (adjointContinuousLinearMap (I := I) (1 : G) : E →L[ℝ] E) =
+          ContinuousLinearMap.id ℝ E
+        exact adjointContinuousLinearMap_one (I := I) (G := G)
       map_mul' := by
         intro g h
         -- `GroupLieAlgebra I G` is definitionally the model space `E`; expose it before using the
@@ -84,7 +88,9 @@ private theorem continuousAdjointRepresentation_coe :
     funext g
     apply ContinuousLinearMap.ext
     intro D
-    exact TauCeti.ContRepresentation.congr_apply _ _ _ _
+    rw [continuousAdjointRepresentation, TauCeti.ContRepresentation.congr_apply,
+      ContinuousLinearEquiv.conjContinuousAlgEquiv_apply_apply, modelAdjointRepresentation]
+    rfl
 
 @[simp]
 theorem continuousAdjointRepresentation_apply (g : G) (D : LeftInvariantDerivation I G) :
@@ -97,6 +103,8 @@ theorem continuousAdjointRepresentation_apply (g : G) (D : LeftInvariantDerivati
       (derivationModelEquiv (I := I) (G := G) D) =
     derivationModelEquiv (I := I) (G := G) (Ad (I := I) g D)
   dsimp only [derivationModelEquiv]
+  -- The tangent adjoint is stated on `GroupLieAlgebra I G`, definitionally the model space `E`;
+  -- cast its equation back to `E` to compose it with the isometric intertwining identity.
   have htangent := tangentAd_apply (I := I) g
     ((leftInvariantDerivationLinearIsometryEquivModelVectorSpace
       (I := I) (G := G) D : E) : GroupLieAlgebra I G)

--- a/TauCeti/Geometry/Lie/Adjoint/Representation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Representation.lean
@@ -60,16 +60,14 @@ tangent adjoint actions. -/
 @[simp]
 theorem leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad
     (g : G) (D : LeftInvariantDerivation I G) :
-    leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G)
-        (Ad (I := I) g D) =
+    (pointDerivationEquivTangentSpace (I := I) 1 BoundarylessManifold.isInteriorPoint
+        (LeftInvariantDerivation.evalAt 1 (Ad (I := I) g D)) : E) =
       tangentAd (I := I) g
         (leftInvariantDerivationLinearIsometryEquivModelVectorSpace (I := I) (G := G) D) := by
   have h := leftInvariantDerivationLieEquivGroupLieAlgebra_Ad (I := I) g D
-  -- `GroupLieAlgebra I G` is definitionally the model space `E`; map the equality across that
-  -- identification before rewriting the two derivation equivalences.
-  have hE := congrArg (fun X : GroupLieAlgebra I G ↦ show E from X) h
   simpa only [leftInvariantDerivationLieEquivGroupLieAlgebra_apply,
-    leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply] using hE
+    leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply,
+    leftInvariantDerivationEquivGroupLieAlgebra_apply] using h
 
 /-- The adjoint representation valued in bounded operators. -/
 def continuousAdjointRepresentation :
@@ -125,8 +123,11 @@ theorem continuousAdjointRepresentation_apply (g : G) (D : LeftInvariantDerivati
     ((leftInvariantDerivationLinearIsometryEquivModelVectorSpace
       (I := I) (G := G) D : E) : GroupLieAlgebra I G)
   have hE := congrArg (fun X : GroupLieAlgebra I G ↦ show E from X) h
-  exact hE.symm.trans
+  have hintertwine := congrArg (fun X : GroupLieAlgebra I G ↦ show E from X)
     (leftInvariantDerivationLinearIsometryEquivModelVectorSpace_Ad (I := I) g D).symm
+  rw [← leftInvariantDerivationEquivGroupLieAlgebra_apply,
+    ← leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply] at hintertwine
+  exact hE.symm.trans hintertwine
 
 /-- The bounded-operator-valued adjoint representation is smooth. -/
 theorem contMDiff_continuousAdjointRepresentation :

--- a/TauCeti/RepresentationTheory/Continuous/Transport.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Transport.lean
@@ -58,13 +58,13 @@ noncomputable def congr (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) 
 
 omit [TopologicalSpace G] in
 /-- The action operators of a transported representation. -/
-@[simp]
 theorem congr_apply (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) (g : G) (x : W) :
     congr e π g x = e (π g (e.symm x)) :=
   (rfl)
 
 omit [TopologicalSpace G] in
 /-- The operator-valued function underlying a transported representation. -/
+@[simp]
 theorem coe_congr (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) :
     ⇑(congr e π) = fun g ↦ e.conjContinuousAlgEquiv (π g) := by
   funext g

--- a/TauCeti/RepresentationTheory/Continuous/Transport.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Transport.lean
@@ -63,6 +63,15 @@ theorem congr_apply (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) (g :
     congr e π g x = e (π g (e.symm x)) :=
   (rfl)
 
+omit [TopologicalSpace G] in
+/-- The operator-valued function underlying a transported representation. -/
+theorem coe_congr (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) :
+    ⇑(congr e π) = fun g ↦ e.conjContinuousAlgEquiv (π g) := by
+  funext g
+  apply ContinuousLinearMap.ext
+  intro x
+  exact congr_apply e π g x
+
 /-- Transport preserves continuity of the operator-valued action: conjugation by `e` is the
 continuous algebra equivalence `ContinuousLinearEquiv.conjContinuousAlgEquiv`. -/
 theorem continuous_congr (e : V ≃L[𝕜] W) {π : ContRepresentation 𝕜 G V} (hπ : Continuous π) :


### PR DESCRIPTION
## Goal

Package the group adjoint action on left-invariant derivations as a continuous representation and prove both its operator-valued and jointly evaluated actions are smooth.

## Design

The canonical isometric equivalence from left-invariant derivations to the model space intertwines `Ad` with `tangentAd`. `continuousAdjointRepresentation` transports the already-merged tangent adjoint operator through `ContinuousLinearEquiv.arrowCongr`; this gives the canonical normed-space API without chosen bases or shadow instances.

Operator-valued smoothness is the direct composition of that transport with `contMDiff_adjointContinuousLinearMap`. Joint smoothness then follows from `ContMDiff.clm_apply`. Consumers needing a plain `Representation` use Mathlib's `continuousAdjointRepresentation.toRepresentation`; this PR does not duplicate that bundling.

The exported declarations use the canonical `LeftInvariantDerivation` normed structures under explicit `[T2Space G] [BoundarylessManifold I G]` hypotheses.

## Why

[Deliverable A, Layer 1](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-1-the-adjoint-representations-ad-and-ad) requires `Ad` to be a smooth group representation. This supplies that roadmap-facing interface without reproving the tangent-level geometry.

Intention: [TauCetiRoadmap#162](https://github.com/TauCetiProject/TauCetiRoadmap/issues/162)

## Verification

- `lake build TauCeti.Geometry.Lie.Adjoint.Representation`
- `lake build --iofail` (7,147 jobs)
- axiom allowlist check passed
- module-system check passed
- Mathlib lint suite: 2,425 declarations documented, no new violations
- `git diff --check`; no `sorry`

Roadmap: RepresentationTheory
