### PR TITLE
feat(Algebra): a locus avoiding d in both coordinates pins the discriminant

### DIFF
--- a/TauCeti/Algebra/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/QuadraticDiscriminant.lean
@@ -26,26 +26,28 @@ extra condition — that `|y₀|` exceed the leading coefficient — repairs thi
 quantification needed.
 
 Together with the reverse implication this gives the upgrade that motivates the file: a form known
-to be non-negative only on some sparse subset of `ℤ ⨯ ℤ` — for instance the locus where a
-fixed prime does not divide `y`, which is all that the degree form on an elliptic curve is
-directly known to satisfy — is non-negative everywhere. Any single `y₀` from that subset with
-`|y₀|` large enough feeds `Int.discrim_le_zero_of_nonneg_of_lt_abs`, and then
-`nonneg_of_discrim_le_zero` propagates the conclusion to every `(x, y)`.
+to be non-negative only on some sparse subset of `ℤ ⨯ ℤ` — the locus where a fixed prime divides
+neither coordinate, which is all that the degree form on an elliptic curve is directly known to
+satisfy — is non-negative everywhere. `Int.discrim_le_zero_of_nonneg_of_not_dvd_of_not_dvd` pins
+the discriminant from that locus alone, and `nonneg_of_discrim_le_zero` then propagates the
+conclusion to every `(x, y)`.
 
 ## Main results
 
 * `nonneg_of_discrim_le_zero`: `0 < a` and `discrim a b c ≤ 0` give `0 ≤ a x² + b x y + c y²`.
 * `Int.discrim_le_zero_of_nonneg_of_lt_abs`: for `a < |y|`, and with no sign condition on `a`,
   non-negativity of `a x² + b x y + c y²` in `x` alone forces `discrim a b c ≤ 0`.
-* `Int.discrim_le_zero_of_nonneg_of_not_dvd`: the same conclusion from non-negativity on
-  `{(x, y) : d ∤ y}`, for any non-unit `d`.
-* `Int.discrim_le_zero_of_nonneg_of_not_dvd_of_not_dvd`: from non-negativity on the smaller
-  `{(x, y) : d ∤ x ∧ d ∤ y}`.
+* `Int.discrim_le_zero_of_nonneg_of_not_dvd_of_not_dvd`: the same conclusion from non-negativity
+  on `{(x, y) : d ∤ x ∧ d ∤ y}`, for any non-unit `d`.
 
-The two `not_dvd` results are proved from a common lemma in which each coordinate runs over an
-arithmetic progression rather than all of `ℤ`. Only one `x` is ever used — the member of the
-progression nearest the minimum of the restricted form — so thinning the line to gap `m` costs
-exactly a factor `m` in the height hypothesis, which the choice of `y` absorbs.
+Both are proved from a common lemma in which `x` runs over an arithmetic progression rather than
+all of `ℤ`. Only one `x` is ever used — the member of the progression nearest the minimum of the
+restricted form — so thinning the line to gap `m` costs exactly a factor `m` in the height
+hypothesis, which the choice of `y` absorbs; `m = 1` is the full line.
+
+The weaker hypothesis constraining only `y` is not stated separately: it is strictly stronger
+than the one above, so a caller holding it applies the same theorem through
+`fun x y _ hy => h x y hy`.
 
 ## Provenance
 
@@ -56,9 +58,9 @@ are strictly stronger: the form is arbitrary rather than `q r² − t r s + s²`
 assumed, and a single `y` replaces an infinite family of prime powers.
 
 The source proves its two locus results independently, the `d ∤ y` one by an infinite family of
-prime powers together with a balanced-remainder lemma. Neither is reproduced: the `d ∤ y` result
-is the case `m = 1` of the progression lemma, and the balanced remainder it needed is Mathlib's
-`round`.
+prime powers together with a balanced-remainder lemma. Neither is reproduced. The `d ∤ y`
+statement is not carried at all: it follows from the `d ∤ x ∧ d ∤ y` one in a line, its hypothesis
+being the stronger of the two. The balanced remainder it needed is Mathlib's `round`.
 
 ## References
 
@@ -123,22 +125,8 @@ private theorem discrim_le_zero_of_pos_of_nonneg_on_progression {a b c m x₀ y 
       = (2 * a * x + b * y) ^ 2 + (4 * a * c - b ^ 2) * y ^ 2 := by ring
   nlinarith [h k, hsq, hy2, hkey]
 
-/-- **A single line of large enough height pins the discriminant.** If a binary quadratic form
-over `ℤ` with positive leading coefficient `a` is non-negative at `(x, y)` for a fixed `y` with
-`a < |y|` and every integer `x`, then `discrim a b c ≤ 0`, that is `b ^ 2 ≤ 4 * a * c`.
-
-The height hypothesis `a < |y|` is necessary, not an artefact of the proof: without it the
-integer-valued hypothesis is strictly weaker than its field counterpart, as
-`forall_int_nonneg_and_discrim_pos` witnesses. -/
-private theorem discrim_le_zero_of_pos_of_nonneg_of_lt_abs {a b c y : ℤ} (ha : 0 < a)
-    (hy : a < |y|) (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) :
-    discrim a b c ≤ 0 :=
-  discrim_le_zero_of_pos_of_nonneg_on_progression (x₀ := 0) ha one_pos (by simpa using hy)
-    fun k => by simpa using h k
-
-/-- A form with negative leading coefficient is eventually negative along any line, so the
-non-negativity hypothesis is unsatisfiable. Evaluating at `x = |b * y| + |c * y ^ 2| + 1` is
-already enough. -/
+/-- A form with negative leading coefficient is eventually negative along any progression, so the
+non-negativity hypothesis is unsatisfiable. -/
 private theorem not_forall_nonneg_on_progression_of_neg {a b c m x₀ y : ℤ} (ha : a < 0)
     (hm : 0 < m) :
     ¬ ∀ k : ℤ, 0 ≤ a * (x₀ + m * k) ^ 2 + b * (x₀ + m * k) * y + c * y ^ 2 := fun h => by
@@ -162,12 +150,6 @@ private theorem not_forall_nonneg_on_progression_of_neg {a b c m x₀ y : ℤ} (
   have h4 : |b * y| * x + |c * y ^ 2| + 1 ≤ x ^ 2 := by nlinarith
   linarith [h k]
 
-/-- A form with negative leading coefficient is eventually negative along any line, so the
-non-negativity hypothesis is unsatisfiable. -/
-private theorem not_forall_nonneg_of_neg {a b c y : ℤ} (ha : a < 0) :
-    ¬ ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2 := fun h =>
-  not_forall_nonneg_on_progression_of_neg (x₀ := 0) ha one_pos fun k => by simpa using h k
-
 /-- A form with zero leading coefficient is linear along a progression, so non-negativity there
 forces the slope `b * y * m` to vanish; with `y ≠ 0` and `0 < m` that makes `b = 0`. -/
 private theorem eq_zero_of_forall_nonneg_on_progression_of_ne {b c m x₀ y : ℤ} (hy : y ≠ 0)
@@ -187,12 +169,6 @@ private theorem eq_zero_of_forall_nonneg_on_progression_of_ne {b c m x₀ y : �
   nlinarith [mul_nonneg (by linarith : (0 : ℤ) ≤ |C| + 1)
     (by linarith : (0 : ℤ) ≤ (b * y * m) ^ 2 - 1)]
 
-/-- A form with zero leading coefficient is linear in `x`, so non-negativity for every integer
-`x` forces the linear coefficient `b * y` to vanish; with `y ≠ 0` that makes `b = 0`. -/
-private theorem eq_zero_of_forall_nonneg_of_ne {b c y : ℤ} (hy : y ≠ 0)
-    (h : ∀ x : ℤ, 0 ≤ 0 * x ^ 2 + b * x * y + c * y ^ 2) : b = 0 :=
-  eq_zero_of_forall_nonneg_on_progression_of_ne (x₀ := 0) hy one_pos fun k => by simpa using h k
-
 /-- **A single line of large enough height pins the discriminant.** If a binary quadratic form
 over `ℤ` is non-negative at `(x, y)` for a fixed `y` with `a < |y|` and every integer `x`, then
 `discrim a b c ≤ 0`, that is `b ^ 2 ≤ 4 * a * c`.
@@ -205,13 +181,16 @@ integer-valued hypothesis is strictly weaker than its field counterpart, as
 `forall_int_nonneg_and_discrim_pos` witnesses. -/
 theorem Int.discrim_le_zero_of_nonneg_of_lt_abs {a b c y : ℤ} (hy : a < |y|)
     (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
+  -- The whole line is the progression of gap `1` through `0`.
+  have hprog : ∀ k : ℤ, 0 ≤ a * (0 + 1 * k) ^ 2 + b * (0 + 1 * k) * y + c * y ^ 2 :=
+    fun k => by simpa using h k
   rcases lt_trichotomy a 0 with ha | ha | ha
-  · exact absurd h (not_forall_nonneg_of_neg ha)
+  · exact absurd hprog (not_forall_nonneg_on_progression_of_neg ha one_pos)
   · subst ha
     have hy0 : y ≠ 0 := by rintro rfl; simp at hy
-    rw [discrim, eq_zero_of_forall_nonneg_of_ne hy0 h]
+    rw [discrim, eq_zero_of_forall_nonneg_on_progression_of_ne hy0 one_pos hprog]
     simp
-  · exact discrim_le_zero_of_pos_of_nonneg_of_lt_abs ha hy h
+  · exact discrim_le_zero_of_pos_of_nonneg_on_progression ha one_pos (by simpa using hy) hprog
 
 /-- The height hypothesis of `Int.discrim_le_zero_of_nonneg_of_lt_abs` cannot be dropped:
 `x ↦ x ^ 2 - x` is non-negative at every integer, yet its discriminant is positive. Here the
@@ -222,37 +201,6 @@ private theorem forall_int_nonneg_and_discrim_pos :
   rcases le_or_gt x 0 with hx | hx
   · nlinarith
   · nlinarith [Int.add_one_le_iff.mpr hx]
-
-/-- **The locus `d ∤ y` pins the discriminant.** If a binary quadratic form over `ℤ` is
-non-negative at every `(x, y)` whose second coordinate avoids the multiples of a non-unit `d` —
-in the intended application `d` is a prime, and the locus is the sublattice complement
-`{(x, y) : d ∤ y}` — then `discrim a b c ≤ 0`.
-
-`d = 0` is allowed, the hypothesis then being non-negativity at every `y ≠ 0`. -/
-theorem Int.discrim_le_zero_of_nonneg_of_not_dvd {a b c d : ℤ} (hd : ¬ IsUnit d)
-    (h : ∀ x y : ℤ, ¬ d ∣ y → 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
-  have hA : 0 ≤ |a| := abs_nonneg a
-  have haA : a ≤ |a| := le_abs_self a
-  rcases eq_or_ne d 0 with rfl | hd0
-  · -- Only `y = 0` is excluded, so `y = |a| + 1` is available.
-    refine Int.discrim_le_zero_of_nonneg_of_lt_abs (y := |a| + 1) ?_
-      fun x => h x _ fun hc => by simp only [zero_dvd_iff] at hc; omega
-    rw [abs_of_pos (by omega)]
-    omega
-  · -- Otherwise `1 < |d|`, and `y = |a| * d ^ 2 + 1` avoids `d` while exceeding `a`.
-    have hd2 : 1 < |d| := by
-      have h1 : d.natAbs ≠ 1 := fun hh => hd (Int.isUnit_iff_natAbs_eq.mpr hh)
-      have h0 : d.natAbs ≠ 0 := fun hh => hd0 (Int.natAbs_eq_zero.mp hh)
-      have : (1 : ℤ) < (d.natAbs : ℤ) := by
-        exact_mod_cast Nat.lt_of_le_of_ne (by omega) (by omega)
-      rwa [Int.abs_eq_natAbs]
-    have hnd : ¬ d ∣ |a| * d ^ 2 + 1 := fun hc => by
-      have hd1 : d ∣ (1 : ℤ) := (dvd_add_right (Dvd.intro (|a| * d) (by ring))).mp hc
-      exact absurd (Int.le_of_dvd one_pos ((abs_dvd d 1).mpr hd1)) (by omega)
-    refine Int.discrim_le_zero_of_nonneg_of_lt_abs (y := |a| * d ^ 2 + 1) ?_ fun x => h x _ hnd
-    have hsq : 1 ≤ d ^ 2 := by nlinarith [sq_abs d, abs_nonneg d]
-    rw [abs_of_pos (by nlinarith)]
-    nlinarith
 
 /-- Every member of the progression `1 + max |d| 2 * ℤ` avoids the multiples of a non-unit `d`.
 

--- a/TauCeti/Algebra/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/QuadraticDiscriminant.lean
@@ -86,13 +86,15 @@ quadratic form over `ℤ` with positive leading coefficient `a` is non-negative 
 fixed `y` and every `x` in the progression `x₀ + m * ℤ`, and `a * m < |y|`, then
 `discrim a b c ≤ 0`.
 
-Only one `x` is used: the member of the progression nearest the minimum of the restricted form,
-which satisfies `|2 a x + b y| ≤ a * m`. Thinning the line to a progression of gap `m` therefore
-costs exactly a factor `m` in the height hypothesis, and `m = 1` is the full line. -/
+The height hypothesis carries a factor `m` that the single-line version does not; `m = 1` is the
+full line. -/
 private theorem discrim_le_zero_of_pos_of_nonneg_on_progression {a b c m x₀ y : ℤ} (ha : 0 < a)
     (hm : 0 < m) (hy : a * m < |y|)
     (h : ∀ k : ℤ, 0 ≤ a * (x₀ + m * k) ^ 2 + b * (x₀ + m * k) * y + c * y ^ 2) :
     discrim a b c ≤ 0 := by
+  -- Only one `x` is used: the member of the progression nearest the minimum of the restricted
+  -- form, which satisfies `|2 a x + b y| ≤ a * m`. That is why thinning the line to gap `m` costs
+  -- exactly a factor `m` in the height.
   by_contra! hcon
   rw [discrim] at hcon
   have ham : (0 : ℚ) < 2 * (a : ℚ) * (m : ℚ) := by
@@ -169,14 +171,14 @@ private theorem eq_zero_of_forall_nonneg_on_progression_of_ne {b c m x₀ y : �
   nlinarith [mul_nonneg (by linarith : (0 : ℤ) ≤ |C| + 1)
     (by linarith : (0 : ℤ) ≤ (b * y * m) ^ 2 - 1)]
 
-/-- **A progression of large enough height pins the discriminant, whatever the sign of `a`.**
-This is the sign dispatch shared by the two public theorems: a negative leading coefficient makes
-the hypothesis unsatisfiable, a zero one collapses the form to a linear function forcing `b = 0`,
-and a positive one is the case that does the work. -/
+/-- **A progression of large enough height pins the discriminant, whatever the sign of `a`.** No
+sign hypothesis on `a` is needed; this is the form both public theorems specialise. -/
 private theorem discrim_le_zero_of_nonneg_on_progression {a b c m x₀ y : ℤ} (hm : 0 < m)
     (hy : a * m < |y|)
     (h : ∀ k : ℤ, 0 ≤ a * (x₀ + m * k) ^ 2 + b * (x₀ + m * k) * y + c * y ^ 2) :
     discrim a b c ≤ 0 := by
+  -- A negative leading coefficient makes the hypothesis unsatisfiable; a zero one collapses the
+  -- form to a linear function, forcing `b = 0`; a positive one is the case that does the work.
   rcases lt_trichotomy a 0 with ha | ha | ha
   · exact absurd h (not_forall_nonneg_on_progression_of_neg ha hm)
   · subst ha
@@ -243,13 +245,13 @@ applies this theorem through `fun x y _ hy => h x y hy`. The implication does no
 way, and it is this form that an elliptic curve supplies, the pencil `r π − s` being known to be
 an isogeny only away from both coordinates.
 
-Both coordinates are taken in the progression `1 + max |d| 2 * ℤ`, every member of which avoids
-the multiples of `d`; the widened gap costs a factor `max |d| 2` in the height, which the choice
-of `y` absorbs. `d = 0` is allowed, the hypothesis then being non-negativity at every
-`(x, y)` with `x ≠ 0` and `y ≠ 0`. -/
+`d = 0` is allowed, the hypothesis then being non-negativity at every `(x, y)` with `x ≠ 0` and
+`y ≠ 0`. -/
 theorem Int.discrim_le_zero_of_nonneg_of_not_dvd_of_not_dvd {a b c d : ℤ} (hd : ¬ IsUnit d)
     (h : ∀ x y : ℤ, ¬ d ∣ x → ¬ d ∣ y → 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) :
     discrim a b c ≤ 0 := by
+  -- Both coordinates run over `1 + max |d| 2 * ℤ`, every member of which avoids the multiples of
+  -- `d`; the widened gap costs a factor `max |d| 2` in the height, which the choice of `y` absorbs.
   set m : ℤ := max |d| 2 with hmdef
   have hm2 : 2 ≤ m := le_max_right _ _
   have hm0 : 0 < m := by omega

--- a/TauCeti/Algebra/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/QuadraticDiscriminant.lean
@@ -169,6 +169,22 @@ private theorem eq_zero_of_forall_nonneg_on_progression_of_ne {b c m x₀ y : �
   nlinarith [mul_nonneg (by linarith : (0 : ℤ) ≤ |C| + 1)
     (by linarith : (0 : ℤ) ≤ (b * y * m) ^ 2 - 1)]
 
+/-- **A progression of large enough height pins the discriminant, whatever the sign of `a`.**
+This is the sign dispatch shared by the two public theorems: a negative leading coefficient makes
+the hypothesis unsatisfiable, a zero one collapses the form to a linear function forcing `b = 0`,
+and a positive one is the case that does the work. -/
+private theorem discrim_le_zero_of_nonneg_on_progression {a b c m x₀ y : ℤ} (hm : 0 < m)
+    (hy : a * m < |y|)
+    (h : ∀ k : ℤ, 0 ≤ a * (x₀ + m * k) ^ 2 + b * (x₀ + m * k) * y + c * y ^ 2) :
+    discrim a b c ≤ 0 := by
+  rcases lt_trichotomy a 0 with ha | ha | ha
+  · exact absurd h (not_forall_nonneg_on_progression_of_neg ha hm)
+  · subst ha
+    have hy0 : y ≠ 0 := by rintro rfl; simp at hy
+    rw [discrim, eq_zero_of_forall_nonneg_on_progression_of_ne hy0 hm h]
+    simp
+  · exact discrim_le_zero_of_pos_of_nonneg_on_progression ha hm hy h
+
 /-- **A single line of large enough height pins the discriminant.** If a binary quadratic form
 over `ℤ` is non-negative at `(x, y)` for a fixed `y` with `a < |y|` and every integer `x`, then
 `discrim a b c ≤ 0`, that is `b ^ 2 ≤ 4 * a * c`.
@@ -180,17 +196,10 @@ The height hypothesis `a < |y|` is necessary, not an artefact of the proof: with
 integer-valued hypothesis is strictly weaker than its field counterpart, as
 `forall_int_nonneg_and_discrim_pos` witnesses. -/
 theorem Int.discrim_le_zero_of_nonneg_of_lt_abs {a b c y : ℤ} (hy : a < |y|)
-    (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 := by
+    (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) : discrim a b c ≤ 0 :=
   -- The whole line is the progression of gap `1` through `0`.
-  have hprog : ∀ k : ℤ, 0 ≤ a * (0 + 1 * k) ^ 2 + b * (0 + 1 * k) * y + c * y ^ 2 :=
+  discrim_le_zero_of_nonneg_on_progression (x₀ := 0) one_pos (by simpa using hy)
     fun k => by simpa using h k
-  rcases lt_trichotomy a 0 with ha | ha | ha
-  · exact absurd hprog (not_forall_nonneg_on_progression_of_neg ha one_pos)
-  · subst ha
-    have hy0 : y ≠ 0 := by rintro rfl; simp at hy
-    rw [discrim, eq_zero_of_forall_nonneg_on_progression_of_ne hy0 one_pos hprog]
-    simp
-  · exact discrim_le_zero_of_pos_of_nonneg_on_progression ha one_pos (by simpa using hy) hprog
 
 /-- The height hypothesis of `Int.discrim_le_zero_of_nonneg_of_lt_abs` cannot be dropped:
 `x ↦ x ^ 2 - x` is non-negative at every integer, yet its discriminant is positive. Here the
@@ -228,10 +237,11 @@ private theorem not_dvd_one_add_max_mul {d : ℤ} (hd : ¬ IsUnit d) (k : ℤ) :
 quadratic form over `ℤ` is non-negative at every `(x, y)` with `d ∤ x` and `d ∤ y`, for a non-unit
 `d`, then `discrim a b c ≤ 0`.
 
-This strengthens `Int.discrim_le_zero_of_nonneg_of_not_dvd`, whose hypothesis constrains only `y`
-and so is available on a strictly larger set of points; the conclusion here is drawn from less.
-The two are not interderivable in the other direction, and it is this form that an elliptic curve
-supplies when the pencil `r π − s` is known to be an isogeny only away from both coordinates.
+The one-coordinate variant, constraining only `y`, is not stated separately: its hypothesis holds
+on a strictly larger set of points, so it is the stronger of the two and a caller holding it
+applies this theorem through `fun x y _ hy => h x y hy`. The implication does not run the other
+way, and it is this form that an elliptic curve supplies, the pencil `r π − s` being known to be
+an isogeny only away from both coordinates.
 
 Both coordinates are taken in the progression `1 + max |d| 2 * ℤ`, every member of which avoids
 the multiples of `d`; the widened gap costs a factor `max |d| 2` in the height, which the choice
@@ -257,11 +267,4 @@ theorem Int.discrim_le_zero_of_nonneg_of_not_dvd_of_not_dvd {a b c d : ℤ} (hd 
     have h2 : |a| * m ≤ m * (|a| * m) := by nlinarith
     linarith
   have hyd : ¬ d ∣ y := hdm _
-  have hprog : ∀ k : ℤ, 0 ≤ a * (1 + m * k) ^ 2 + b * (1 + m * k) * y + c * y ^ 2 :=
-    fun k => h _ y (hdm k) hyd
-  rcases lt_trichotomy a 0 with ha | ha | ha
-  · exact absurd hprog (not_forall_nonneg_on_progression_of_neg ha hm0)
-  · subst ha
-    rw [discrim, eq_zero_of_forall_nonneg_on_progression_of_ne hy0.ne' hm0 hprog]
-    simp
-  · exact discrim_le_zero_of_pos_of_nonneg_on_progression ha hm0 hheight hprog
+  exact discrim_le_zero_of_nonneg_on_progression hm0 hheight fun k => h _ y (hdm k) hyd

--- a/TauCeti/Algebra/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/QuadraticDiscriminant.lean
@@ -39,6 +39,13 @@ directly known to satisfy — is non-negative everywhere. Any single `y₀` from
   non-negativity of `a x² + b x y + c y²` in `x` alone forces `discrim a b c ≤ 0`.
 * `Int.discrim_le_zero_of_nonneg_of_not_dvd`: the same conclusion from non-negativity on
   `{(x, y) : d ∤ y}`, for any non-unit `d`.
+* `Int.discrim_le_zero_of_nonneg_of_not_dvd_of_not_dvd`: from non-negativity on the smaller
+  `{(x, y) : d ∤ x ∧ d ∤ y}`.
+
+The two `not_dvd` results are proved from a common lemma in which each coordinate runs over an
+arithmetic progression rather than all of `ℤ`. Only one `x` is ever used — the member of the
+progression nearest the minimum of the restricted form — so thinning the line to gap `m` costs
+exactly a factor `m` in the height hypothesis, which the choice of `y` absorbs.
 
 ## Provenance
 
@@ -47,6 +54,11 @@ Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f
 `qf_nonneg_of_nonneg_on_coprime` and `qf_nonneg_of_nonneg_on_coprime_both`. The statements here
 are strictly stronger: the form is arbitrary rather than `q r² − t r s + s²`, no primality is
 assumed, and a single `y` replaces an infinite family of prime powers.
+
+The source proves its two locus results independently, the `d ∤ y` one by an infinite family of
+prime powers together with a balanced-remainder lemma. Neither is reproduced: the `d ∤ y` result
+is the case `m = 1` of the progression lemma, and the balanced remainder it needed is Mathlib's
+`round`.
 
 ## References
 
@@ -67,6 +79,50 @@ theorem nonneg_of_discrim_le_zero {R : Type*} [CommRing R] [LinearOrder R]
   have hb : 0 ≤ 4 * a * c - b ^ 2 := by rw [discrim] at hd; linarith
   nlinarith [sq_nonneg (2 * a * x + b * y), mul_nonneg hb (sq_nonneg y)]
 
+/-- **An arithmetic progression of large enough height pins the discriminant.** If a binary
+quadratic form over `ℤ` with positive leading coefficient `a` is non-negative at `(x, y)` for a
+fixed `y` and every `x` in the progression `x₀ + m * ℤ`, and `a * m < |y|`, then
+`discrim a b c ≤ 0`.
+
+Only one `x` is used: the member of the progression nearest the minimum of the restricted form,
+which satisfies `|2 a x + b y| ≤ a * m`. Thinning the line to a progression of gap `m` therefore
+costs exactly a factor `m` in the height hypothesis, and `m = 1` is the full line. -/
+private theorem discrim_le_zero_of_pos_of_nonneg_on_progression {a b c m x₀ y : ℤ} (ha : 0 < a)
+    (hm : 0 < m) (hy : a * m < |y|)
+    (h : ∀ k : ℤ, 0 ≤ a * (x₀ + m * k) ^ 2 + b * (x₀ + m * k) * y + c * y ^ 2) :
+    discrim a b c ≤ 0 := by
+  by_contra! hcon
+  rw [discrim] at hcon
+  have ham : (0 : ℚ) < 2 * (a : ℚ) * (m : ℚ) := by
+    have h1 : (0 : ℚ) < (a : ℚ) := by exact_mod_cast ha
+    have h2 : (0 : ℚ) < (m : ℚ) := by exact_mod_cast hm
+    positivity
+  -- `k` is the integer nearest the value putting `x₀ + m * k` at the minimum of the restricted
+  -- form, so the progression member `x₀ + m * k` has `|2 a x + b y| ≤ a * m`.
+  set t : ℚ := (-((b * y : ℤ) : ℚ) - 2 * (a : ℚ) * (x₀ : ℚ)) / (2 * (a : ℚ) * (m : ℚ)) with htdef
+  set k : ℤ := round t with hkdef
+  set x : ℤ := x₀ + m * k with hxdef
+  have hxa : |2 * a * x + b * y| ≤ a * m := by
+    have hcast : ((2 * a * x + b * y : ℤ) : ℚ) = 2 * (a : ℚ) * (m : ℚ) * ((k : ℚ) - t) := by
+      rw [hxdef, htdef]
+      field_simp
+      push_cast
+      ring
+    have hq : |((2 * a * x + b * y : ℤ) : ℚ)| ≤ ((a * m : ℤ) : ℚ) := by
+      rw [hcast, abs_mul, abs_of_pos ham]
+      push_cast
+      nlinarith [abs_sub_round t, abs_nonneg ((k : ℚ) - t), abs_sub_comm (k : ℚ) t]
+    exact_mod_cast hq
+  have hsq : (2 * a * x + b * y) ^ 2 ≤ (a * m) ^ 2 := by
+    have habs := abs_le.mp hxa
+    nlinarith [habs.1, habs.2]
+  -- `a * m < |y|` makes the `(4ac − b²)y²` term outweigh it, so the form is negative at `(x, y)`.
+  have ham0 : 0 < a * m := by positivity
+  have hy2 : (a * m) ^ 2 < y ^ 2 := by nlinarith [sq_abs y, abs_nonneg y]
+  have hkey : 4 * a * (a * x ^ 2 + b * x * y + c * y ^ 2)
+      = (2 * a * x + b * y) ^ 2 + (4 * a * c - b ^ 2) * y ^ 2 := by ring
+  nlinarith [h k, hsq, hy2, hkey]
+
 /-- **A single line of large enough height pins the discriminant.** If a binary quadratic form
 over `ℤ` with positive leading coefficient `a` is non-negative at `(x, y)` for a fixed `y` with
 `a < |y|` and every integer `x`, then `discrim a b c ≤ 0`, that is `b ^ 2 ≤ 4 * a * c`.
@@ -76,65 +132,66 @@ integer-valued hypothesis is strictly weaker than its field counterpart, as
 `forall_int_nonneg_and_discrim_pos` witnesses. -/
 private theorem discrim_le_zero_of_pos_of_nonneg_of_lt_abs {a b c y : ℤ} (ha : 0 < a)
     (hy : a < |y|) (h : ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) :
-    discrim a b c ≤ 0 := by
-  by_contra! hcon
-  rw [discrim] at hcon
-  have ha0 : (0 : ℚ) < 2 * (a : ℚ) := by
-    have : (0 : ℚ) < (a : ℚ) := by exact_mod_cast ha
-    linarith
-  -- Evaluate at `x = -r`, where `r` is the integer nearest to `b * y / (2 * a)`; this is the
-  -- integer closest to the minimum of the restricted form, and gives `|2ax + by| ≤ a`.
-  set t : ℚ := ((b * y : ℤ) : ℚ) / (2 * (a : ℚ)) with htdef
-  set r : ℤ := round t with hrdef
-  have hxa : |2 * a * (-r) + b * y| ≤ a := by
-    have hcast : ((2 * a * (-r) + b * y : ℤ) : ℚ) = 2 * (a : ℚ) * (t - (r : ℚ)) := by
-      rw [htdef]
-      field_simp
-      push_cast
-      ring
-    have hq : |((2 * a * (-r) + b * y : ℤ) : ℚ)| ≤ ((a : ℤ) : ℚ) := by
-      rw [hcast, abs_mul, abs_of_pos ha0]
-      nlinarith [abs_sub_round t, abs_nonneg (t - (r : ℚ))]
-    exact_mod_cast hq
-  have hsq : (2 * a * (-r) + b * y) ^ 2 ≤ a ^ 2 := by
-    have habs := abs_le.mp hxa
-    nlinarith [habs.1, habs.2]
-  -- `a < |y|` makes the `(4ac − b²)y²` term outweigh it, so the form is negative at `(-r, y)`.
-  have hy2 : a ^ 2 < y ^ 2 := by nlinarith [sq_abs y, abs_nonneg y]
-  have hkey : 4 * a * (a * (-r) ^ 2 + b * (-r) * y + c * y ^ 2)
-      = (2 * a * (-r) + b * y) ^ 2 + (4 * a * c - b ^ 2) * y ^ 2 := by ring
-  nlinarith [h (-r), hsq, hy2, hkey]
+    discrim a b c ≤ 0 :=
+  discrim_le_zero_of_pos_of_nonneg_on_progression (x₀ := 0) ha one_pos (by simpa using hy)
+    fun k => by simpa using h k
 
 /-- A form with negative leading coefficient is eventually negative along any line, so the
 non-negativity hypothesis is unsatisfiable. Evaluating at `x = |b * y| + |c * y ^ 2| + 1` is
 already enough. -/
-private theorem not_forall_nonneg_of_neg {a b c y : ℤ} (ha : a < 0) :
-    ¬ ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2 := fun h => by
+private theorem not_forall_nonneg_on_progression_of_neg {a b c m x₀ y : ℤ} (ha : a < 0)
+    (hm : 0 < m) :
+    ¬ ∀ k : ℤ, 0 ≤ a * (x₀ + m * k) ^ 2 + b * (x₀ + m * k) * y + c * y ^ 2 := fun h => by
   have hA0 : 0 ≤ |b * y| := abs_nonneg _
   have hB0 : 0 ≤ |c * y ^ 2| := abs_nonneg _
   set M : ℤ := |b * y| + |c * y ^ 2| + 1 with hM
   have hM1 : 1 ≤ M := by omega
-  -- Bound each term of the form at `x = M` from above; the square dominates the rest.
-  have h1 : a * M ^ 2 ≤ -(M ^ 2) := by nlinarith [sq_nonneg M]
-  have h2 : b * M * y ≤ |b * y| * M := by
-    nlinarith [mul_nonneg (sub_nonneg.mpr (le_abs_self (b * y))) (by linarith : (0 : ℤ) ≤ M)]
+  -- The progression reaches past `M`, and there the square already dominates the rest.
+  set k : ℤ := M + |x₀| with hk
+  have hk0 : 0 ≤ k := by have := abs_nonneg x₀; omega
+  set x : ℤ := x₀ + m * k with hx
+  have hxM : M ≤ x := by
+    have h1 : k ≤ m * k := le_mul_of_one_le_left hk0 hm
+    have h2 : -|x₀| ≤ x₀ := neg_abs_le x₀
+    rw [hx, hk] at *
+    linarith
+  have h1 : a * x ^ 2 ≤ -(x ^ 2) := by nlinarith [sq_nonneg x]
+  have h2 : b * x * y ≤ |b * y| * x := by
+    nlinarith [mul_nonneg (sub_nonneg.mpr (le_abs_self (b * y))) (by linarith : (0 : ℤ) ≤ x)]
   have h3 : c * y ^ 2 ≤ |c * y ^ 2| := le_abs_self _
-  have h4 : |b * y| * M + |c * y ^ 2| + 1 ≤ M ^ 2 := by nlinarith
-  linarith [h M]
+  have h4 : |b * y| * x + |c * y ^ 2| + 1 ≤ x ^ 2 := by nlinarith
+  linarith [h k]
+
+/-- A form with negative leading coefficient is eventually negative along any line, so the
+non-negativity hypothesis is unsatisfiable. -/
+private theorem not_forall_nonneg_of_neg {a b c y : ℤ} (ha : a < 0) :
+    ¬ ∀ x : ℤ, 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2 := fun h =>
+  not_forall_nonneg_on_progression_of_neg (x₀ := 0) ha one_pos fun k => by simpa using h k
+
+/-- A form with zero leading coefficient is linear along a progression, so non-negativity there
+forces the slope `b * y * m` to vanish; with `y ≠ 0` and `0 < m` that makes `b = 0`. -/
+private theorem eq_zero_of_forall_nonneg_on_progression_of_ne {b c m x₀ y : ℤ} (hy : y ≠ 0)
+    (hm : 0 < m)
+    (h : ∀ k : ℤ, 0 ≤ 0 * (x₀ + m * k) ^ 2 + b * (x₀ + m * k) * y + c * y ^ 2) : b = 0 := by
+  by_contra hb
+  set C : ℤ := b * y * x₀ + c * y ^ 2 with hC
+  have hid : ∀ k : ℤ, 0 * (x₀ + m * k) ^ 2 + b * (x₀ + m * k) * y + c * y ^ 2
+      = b * y * m * k + C := fun k => by rw [hC]; ring
+  have hC0 : 0 ≤ |C| := abs_nonneg _
+  have hCle : C ≤ |C| := le_abs_self _
+  have hpos : 0 < (b * y * m) ^ 2 := by positivity
+  have hs1 : 1 ≤ (b * y * m) ^ 2 := by omega
+  -- At this `k` the linear term is `-(|C| + 1) * (b y m)²`, which the constant cannot offset.
+  have hx := h (-((|C| + 1) * (b * y * m)))
+  rw [hid] at hx
+  nlinarith [mul_nonneg (by linarith : (0 : ℤ) ≤ |C| + 1)
+    (by linarith : (0 : ℤ) ≤ (b * y * m) ^ 2 - 1)]
 
 /-- A form with zero leading coefficient is linear in `x`, so non-negativity for every integer
 `x` forces the linear coefficient `b * y` to vanish; with `y ≠ 0` that makes `b = 0`. -/
 private theorem eq_zero_of_forall_nonneg_of_ne {b c y : ℤ} (hy : y ≠ 0)
-    (h : ∀ x : ℤ, 0 ≤ 0 * x ^ 2 + b * x * y + c * y ^ 2) : b = 0 := by
-  by_contra hb
-  have hB0 : 0 ≤ |c * y ^ 2| := abs_nonneg _
-  have hpos : 0 < (b * y) ^ 2 := by positivity
-  have hs1 : 1 ≤ (b * y) ^ 2 := by omega
-  have hcb : c * y ^ 2 ≤ |c * y ^ 2| := le_abs_self _
-  -- At this `x` the linear term is `-(|c y²| + 1) * (b y)²`, which the constant cannot offset.
-  have hx := h (-((|c * y ^ 2| + 1) * (b * y)))
-  nlinarith [mul_nonneg (by linarith : (0 : ℤ) ≤ |c * y ^ 2| + 1)
-    (by linarith : (0 : ℤ) ≤ (b * y) ^ 2 - 1)]
+    (h : ∀ x : ℤ, 0 ≤ 0 * x ^ 2 + b * x * y + c * y ^ 2) : b = 0 :=
+  eq_zero_of_forall_nonneg_on_progression_of_ne (x₀ := 0) hy one_pos fun k => by simpa using h k
 
 /-- **A single line of large enough height pins the discriminant.** If a binary quadratic form
 over `ℤ` is non-negative at `(x, y)` for a fixed `y` with `a < |y|` and every integer `x`, then
@@ -196,3 +253,67 @@ theorem Int.discrim_le_zero_of_nonneg_of_not_dvd {a b c d : ℤ} (hd : ¬ IsUnit
     have hsq : 1 ≤ d ^ 2 := by nlinarith [sq_abs d, abs_nonneg d]
     rw [abs_of_pos (by nlinarith)]
     nlinarith
+
+/-- Every member of the progression `1 + max |d| 2 * ℤ` avoids the multiples of a non-unit `d`.
+
+The modulus is `|d|` in the intended case, `2` being needed only for `d = 0`: there the multiples
+of `d` are `{0}` alone, and what has to be said is that `1 + 2 * k` is odd, hence nonzero. -/
+private theorem not_dvd_one_add_max_mul {d : ℤ} (hd : ¬ IsUnit d) (k : ℤ) :
+    ¬ d ∣ 1 + max |d| 2 * k := by
+  intro hdvd
+  rcases eq_or_ne d 0 with rfl | hd0
+  · rw [zero_dvd_iff] at hdvd
+    rw [abs_zero, max_eq_right (by norm_num)] at hdvd
+    omega
+  · have hd2 : 1 < |d| := by
+      have h1 : d.natAbs ≠ 1 := fun hh => hd (Int.isUnit_iff_natAbs_eq.mpr hh)
+      have h0 : d.natAbs ≠ 0 := fun hh => hd0 (Int.natAbs_eq_zero.mp hh)
+      have : (1 : ℤ) < (d.natAbs : ℤ) := by
+        exact_mod_cast Nat.lt_of_le_of_ne (by omega) (by omega)
+      rwa [Int.abs_eq_natAbs]
+    rw [max_eq_left (by omega), add_comm] at hdvd
+    have hd1 : d ∣ (1 : ℤ) :=
+      (dvd_add_right (((dvd_abs d d).mpr dvd_rfl).mul_right k)).mp hdvd
+    exact absurd (Int.le_of_dvd one_pos ((abs_dvd d 1).mpr hd1)) (by omega)
+
+/-- **The locus where `d` divides neither coordinate pins the discriminant.** If a binary
+quadratic form over `ℤ` is non-negative at every `(x, y)` with `d ∤ x` and `d ∤ y`, for a non-unit
+`d`, then `discrim a b c ≤ 0`.
+
+This strengthens `Int.discrim_le_zero_of_nonneg_of_not_dvd`, whose hypothesis constrains only `y`
+and so is available on a strictly larger set of points; the conclusion here is drawn from less.
+The two are not interderivable in the other direction, and it is this form that an elliptic curve
+supplies when the pencil `r π − s` is known to be an isogeny only away from both coordinates.
+
+Both coordinates are taken in the progression `1 + max |d| 2 * ℤ`, every member of which avoids
+the multiples of `d`; the widened gap costs a factor `max |d| 2` in the height, which the choice
+of `y` absorbs. `d = 0` is allowed, the hypothesis then being non-negativity at every
+`(x, y)` with `x ≠ 0` and `y ≠ 0`. -/
+theorem Int.discrim_le_zero_of_nonneg_of_not_dvd_of_not_dvd {a b c d : ℤ} (hd : ¬ IsUnit d)
+    (h : ∀ x y : ℤ, ¬ d ∣ x → ¬ d ∣ y → 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) :
+    discrim a b c ≤ 0 := by
+  set m : ℤ := max |d| 2 with hmdef
+  have hm2 : 2 ≤ m := le_max_right _ _
+  have hm0 : 0 < m := by omega
+  have hdm : ∀ k : ℤ, ¬ d ∣ 1 + m * k := fun k => by rw [hmdef]; exact not_dvd_one_add_max_mul hd k
+  -- One second coordinate serves every case: it avoids `d` and clears the widened height bound.
+  have hA : 0 ≤ |a| := abs_nonneg a
+  have haA : a ≤ |a| := le_abs_self a
+  have hAm : 0 ≤ |a| * m := mul_nonneg hA hm0.le
+  set y : ℤ := 1 + m * (|a| * m) with hy
+  have hmm : 0 ≤ m * (|a| * m) := mul_nonneg hm0.le hAm
+  have hy0 : 0 < y := by rw [hy]; linarith
+  have hheight : a * m < |y| := by
+    rw [abs_of_pos hy0, hy]
+    have h1 : a * m ≤ |a| * m := mul_le_mul_of_nonneg_right haA hm0.le
+    have h2 : |a| * m ≤ m * (|a| * m) := by nlinarith
+    linarith
+  have hyd : ¬ d ∣ y := hdm _
+  have hprog : ∀ k : ℤ, 0 ≤ a * (1 + m * k) ^ 2 + b * (1 + m * k) * y + c * y ^ 2 :=
+    fun k => h _ y (hdm k) hyd
+  rcases lt_trichotomy a 0 with ha | ha | ha
+  · exact absurd hprog (not_forall_nonneg_on_progression_of_neg ha hm0)
+  · subst ha
+    rw [discrim, eq_zero_of_forall_nonneg_on_progression_of_ne hy0.ne' hm0 hprog]
+    simp
+  · exact discrim_le_zero_of_pos_of_nonneg_on_progression ha hm0 hheight hprog


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"discriminant-coprime-both"}-->

Roadmap: EllipticCurves

**No elliptic curve appears in any statement here.** This is integer arithmetic about a binary
quadratic form; the elliptic-curve reading is motivation only.

In `TauCeti/Algebra/QuadraticDiscriminant.lean`: one public theorem added, and the public theorem
it supersedes removed.

```lean
theorem Int.discrim_le_zero_of_nonneg_of_not_dvd_of_not_dvd {a b c d : ℤ} (hd : ¬ IsUnit d)
    (h : ∀ x y : ℤ, ¬ d ∣ x → ¬ d ∣ y → 0 ≤ a * x ^ 2 + b * x * y + c * y ^ 2) :
    discrim a b c ≤ 0
```

## Why this supersedes the theorem already in the file

`Int.discrim_le_zero_of_nonneg_of_not_dvd`, merged in #2323, draws the same conclusion from
non-negativity on `{(x, y) : d ∤ y}`. That hypothesis constrains only the second coordinate, so it
is available at strictly more points, and **it cannot be supplied from the one here** — the
implication runs the other way. The theorem added here is therefore strictly stronger, and it is
the form an elliptic curve actually supplies: the degree of the pencil `r π − s` is a degree, hence
non-negative, only where `r π − s` is genuinely an isogeny, which is away from **both**
coordinates.

The converse direction is a one-liner, so the older theorem is **deleted** rather than kept beside
it: a caller holding the `d ∤ y` hypothesis applies the new theorem through
`fun x y _ hy => h x y hy`. It has no consumers in the repository — it is new API from #2323
awaiting the Hasse consumer — so nothing else changes.

## What the proof adds

Both results now come from a single lemma in which each coordinate runs over an arithmetic
progression `x₀ + m * ℤ` rather than all of `ℤ`.

That reformulation is available because the positive-leading-coefficient argument never used the
whole line: it evaluates at exactly one `x`, the member nearest the minimum of the restricted form,
where `|2 a x + b y| ≤ a * m`. Thinning the line to gap `m` therefore costs exactly a factor `m` in
the height hypothesis — `a * m < |y|` in place of `a < |y|` — and the choice of `y` absorbs it. The
negative and zero leading-coefficient cases generalise the same way.

Consequences for the existing code:

* `Int.discrim_le_zero_of_nonneg_of_lt_abs` is the case `m = 1`, `x₀ = 0`, and is now proved
  directly from the three progression lemmas. The three private helpers it used — one per sign of
  the leading coefficient — are deleted rather than rewritten as one-line specialisations of their
  progression counterparts, so no argument is stated twice.
* Both coordinates of the new theorem are taken in `1 + max |d| 2 * ℤ`, whose members avoid the
  multiples of `d` — a private lemma. The modulus is `|d|` in the intended case; `2` is needed
  only for `d = 0`, where the multiples of `d` are `{0}` alone and the point is that `1 + 2 * k`
  is odd.

## Mathlib check

Mathlib's `discrim_le_zero` is over a `LinearOrderedField` and quantifies over every element of
the field, so it applies neither to a hypothesis quantified over `ℤ` nor to one restricted to a
sublattice complement; that gap is what the merged file exists to fill, and this PR widens it.
Compile-checked, not grep-checked: `exact?` fails on the statement above, on the balanced-
remainder fact, on the progression-restricted discriminant statement, and on the non-divisibility
helper `¬ d ∣ 1 + max |d| 2 * k`. `Mathlib/Algebra/Order/Round.lean` supplies `round` and
`abs_sub_round` for a `LinearOrderedField`, which is what the progression lemma uses over `ℚ`;
there is no `ℤ`-level nearest-multiple statement, and none is added here.

Mathlib's `Algebra/QuadraticDiscriminant.lean` carries only the forward directions —
`discrim_le_zero`, `discrim_lt_zero` and their nonpos/neg variants, all over a
`LinearOrderedField` — and no statement going from `discrim a b c ≤ 0` to non-negativity. That is
what `nonneg_of_discrim_le_zero` in this file supplies, and it is unaffected by this PR.

## Provenance

Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
`HasseWeil/WeilPairing/Discriminant.lean`, theorem `qf_nonneg_of_nonneg_on_coprime_both`.

The statement here is strictly stronger than the source's: the form is arbitrary rather than
`q r² − t r s + s²`, the modulus is any non-unit rather than a prime, and no sign hypothesis is
placed on the leading coefficient. The source's proof is an explicit negative witness at
`(m t + 1, 2 m q + 1)`; it is not reproduced, the progression lemma covering both loci at once.
The source's other theorem there, `qf_nonneg_of_nonneg_on_coprime`, is not ported and should not
be: it is the `d ∤ y` locus, which #2323 already covers, and it follows from this one in a line.
Its supporting `exists_int_balanced` is Mathlib's `round`.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 3 — elliptic curves over finite fields, the
Hasse bound (AEC V.1)**. The layer's seeded target is

```lean
theorem hasse_bound … : ((Nat.card W.toAffine.Point : ℤ) - ((Nat.card K : ℤ) + 1)) ^ 2 ≤ 4 * (Nat.card K : ℤ)
```

and `discrim q (-t) 1 ≤ 0` is exactly `t ^ 2 ≤ 4 * q`, so this is that target's final inequality,
reached from the degree form's non-negativity. Producing that non-negativity is the Weil pairing's
work and is not attempted here; this supplies a prerequisite the target needs.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
locally. No `sorry`, no raised heartbeat limits. Longest proof in the file is 35 lines, the new
theorem 28.
