### PR TITLE
feat: the Cartan subalgebra acts semisimply, and weight spaces are honest

### DIFF
--- a/TauCeti/Algebra/Lie/Weights/Diagonalizable.lean
+++ b/TauCeti/Algebra/Lie/Weights/Diagonalizable.lean
@@ -44,7 +44,6 @@ to honest.
 
 * `TauCeti.isSemisimple_toEnd_coroot`: a coroot acts semisimply on a finite-dimensional module.
 * `TauCeti.isSemisimple_toEnd_cartan`: **every element of the Cartan subalgebra acts semisimply.**
-* `TauCeti.iSup_eigenspace_toEnd_cartan_eq_top`: equivalently, it acts diagonalizably.
 * `TauCeti.genWeightSpace_eq_weightSpace`: **the generalized weight spaces are honest weight
   spaces**, with `TauCeti.mem_genWeightSpace_iff_forall_lie_eq_smul` the pointwise form: membership
   is the eigenvector equation `⁅x, m⁆ = χ x • m` for every `x : H`.
@@ -120,15 +119,10 @@ theorem isSemisimple_toEnd_cartan (x : H) : (toEnd K H M x).IsSemisimple := by
     exact hy.of_mem_adjoin_singleton
       (Subalgebra.smul_mem _ (Algebra.self_mem_adjoin_singleton _ _) c)
 
-/-- **The Cartan subalgebra acts diagonalizably.** The eigenspaces of the action of `x : H` on a
-finite-dimensional module span it. -/
-theorem iSup_eigenspace_toEnd_cartan_eq_top (x : H) :
-    ⨆ μ : K, (toEnd K H M x).eigenspace μ = ⊤ :=
-  (isSemisimple_toEnd_cartan (M := M) x).iSup_eigenspace_eq_top
-
 /-! ### Honest weight spaces -/
 
 /-- The generalized eigenspace of `x : H` at a scalar is an honest eigenspace. -/
+@[simp]
 theorem genWeightSpaceOf_eq_eigenspace (μ : K) (x : H) :
     (genWeightSpaceOf M μ x).toSubmodule = (toEnd K H M x).eigenspace μ :=
   (isSemisimple_toEnd_cartan (M := M) x).isFinitelySemisimple.maxGenEigenspace_eq_eigenspace μ
@@ -139,6 +133,7 @@ a Killing-semisimple Lie algebra, `LieModule.genWeightSpace M χ` is the simulta
 
 Mathlib's `LieModule.weightSpace_le_genWeightSpace` is the inclusion that holds always; this is the
 reverse one, and it is exactly the diagonalizability of the Cartan action. -/
+@[simp]
 theorem genWeightSpace_eq_weightSpace (χ : H → K) : genWeightSpace M χ = weightSpace M χ := by
   refine LieSubmodule.toSubmodule_injective ?_
   rw [genWeightSpace, LieSubmodule.iInf_toSubmodule]
@@ -147,7 +142,11 @@ theorem genWeightSpace_eq_weightSpace (χ : H → K) : genWeightSpace M χ = wei
 
 /-- **Membership of a weight space is the eigenvector equation.** An element of a
 finite-dimensional module lies in the `χ`-weight space exactly when every `x : H` acts on it by the
-scalar `χ x`. -/
+scalar `χ x`.
+
+This is deliberately not a `simp` lemma: `TauCeti.genWeightSpace_eq_weightSpace` already rewrites
+the left-hand side to `m ∈ LieModule.weightSpace M χ`, so tagging it would leave it in
+non-simp-normal form. -/
 theorem mem_genWeightSpace_iff_forall_lie_eq_smul {χ : H → K} {m : M} :
     m ∈ genWeightSpace M χ ↔ ∀ x : H, ⁅(x : L), m⁆ = χ x • m := by
   rw [genWeightSpace_eq_weightSpace, mem_weightSpace]

--- a/TauCeti/Algebra/Lie/Weights/Diagonalizable.lean
+++ b/TauCeti/Algebra/Lie/Weights/Diagonalizable.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Algebra.Lie.Weights.RootSystem
+public import TauCeti.Algebra.Lie.Sl2.Spectrum
+public import TauCeti.LinearAlgebra.Eigenspace.Semisimple
+
+public section
+
+/-!
+# The Cartan subalgebra acts diagonalizably, and weight spaces are honest
+
+Let `L` be a finite-dimensional Lie algebra with non-degenerate Killing form over an algebraically
+closed field of characteristic zero, let `H` be a Cartan subalgebra, and let `M` be a
+finite-dimensional `L`-module. This file proves that **every `x : H` acts on `M` by a semisimple
+endomorphism**, so that Mathlib's *generalized* weight spaces `LieModule.genWeightSpace M χ` are
+the *honest* simultaneous eigenspaces `LieModule.weightSpace M χ`, and `M` is their internal direct
+sum.
+
+The route is the rank-one reduction, not the abstract Jordan decomposition. A nonzero root `α`
+carries an `sl₂` triple whose Cartan element is the coroot `α^∨`, and the `sl₂` engine already
+knows that such an element acts diagonalizably
+(`TauCeti.iSup_eigenspace_toEnd_eq_top`); over an algebraically closed field diagonalizable means
+semisimple (`TauCeti.isSemisimple_of_iSup_eigenspace_eq_top`). The coroots span `H`, and `H` is
+abelian, so the operators they give are commuting semisimple endomorphisms, and semisimplicity
+passes to their span (`Module.End.IsSemisimple.add_of_commute`,
+`Module.End.IsSemisimple.of_mem_adjoin_singleton`).
+
+In particular the proof uses only complete reducibility **for `sl₂`**, which is where
+`TauCeti.iSup_eigenspace_toEnd_eq_top` comes from, and not Weyl's complete reducibility for `L`.
+That is what keeps the highest-weight theory free of circularity: the honest weight-space
+decomposition is available before Weyl's theorem, whose usual proof consumes it.
+
+That every finite-dimensional module is triangularizable over `H` needs no work here: it is
+Mathlib's `LieModule.instIsTriangularizableOfIsAlgClosed`, which is what makes the generalized
+weight spaces exhaust `M` in the first place. The content below is the refinement from generalized
+to honest.
+
+## Main results
+
+* `TauCeti.isSemisimple_toEnd_coroot`: a coroot acts semisimply on a finite-dimensional module.
+* `TauCeti.isSemisimple_toEnd_cartan`: **every element of the Cartan subalgebra acts semisimply.**
+* `TauCeti.iSup_eigenspace_toEnd_cartan_eq_top`: equivalently, it acts diagonalizably.
+* `TauCeti.genWeightSpace_eq_weightSpace`: **the generalized weight spaces are honest weight
+  spaces**, with `TauCeti.mem_genWeightSpace_iff_forall_lie_eq_smul` the pointwise form: membership
+  is the eigenvector equation `⁅x, m⁆ = χ x • m` for every `x : H`.
+* `TauCeti.iSup_weightSpace_eq_top` and `TauCeti.isInternal_weightSpace`: the honest weight spaces
+  span `M`, and `M` is their internal direct sum, so `χ ↦ finrank (weightSpace M χ)` counts honest
+  multiplicities.
+
+## References
+
+This is the "honest weight spaces (the diagonalizability theorem)" item of Layer 2 of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`, whose target signature
+`isSemisimple_toEnd_cartan` is `TauCeti.isSemisimple_toEnd_cartan`.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §6.4 and §20.1.
+-/
+
+namespace TauCeti
+
+open LieAlgebra LieModule Module
+
+universe u v w
+
+variable {K : Type u} {L : Type v} [Field K] [CharZero K] [IsAlgClosed K]
+  [LieRing L] [LieAlgebra K L] [IsKilling K L] [FiniteDimensional K L]
+  {H : LieSubalgebra K L} [H.IsCartanSubalgebra]
+  {M : Type w} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+  [FiniteDimensional K M]
+
+/-! ### Semisimplicity of the Cartan action -/
+
+/-- **A coroot acts semisimply.** The coroot `α^∨` of a weight `α` of `L` acts on a
+finite-dimensional module by a semisimple endomorphism.
+
+For a nonzero `α` this is the `sl₂` engine: `α^∨` is the Cartan element of an `sl₂` triple, whose
+eigenspaces span (`TauCeti.iSup_eigenspace_toEnd_eq_top`), and a diagonalizable endomorphism is
+semisimple. The coroot of a zero weight is zero. -/
+theorem isSemisimple_toEnd_coroot (α : Weight K H L) :
+    (toEnd K H M (IsKilling.coroot α)).IsSemisimple := by
+  by_cases hα : α.IsNonZero
+  · obtain ⟨h, e, f, ht, he, hf⟩ := IsKilling.exists_isSl2Triple_of_weight_isNonZero hα
+    refine isSemisimple_of_iSup_eigenspace_eq_top ?_
+    have hsup := iSup_eigenspace_toEnd_eq_top (K := K) (M := M) ht
+    rw [ht.h_eq_coroot hα he hf] at hsup
+    exact hsup
+  · rw [IsKilling.coroot_eq_zero_iff.2 (not_not.1 hα)]
+    simp
+
+/-- **The Cartan subalgebra acts semisimply.** Every element of a Cartan subalgebra of a
+Killing-semisimple Lie algebra acts on a finite-dimensional module by a semisimple endomorphism.
+
+The coroots span the Cartan subalgebra (`RootPairing.IsRootSystem.span_coroot_eq_top` for
+`LieAlgebra.IsKilling.rootSystem H`) and act semisimply by
+`TauCeti.isSemisimple_toEnd_coroot`; the Cartan subalgebra is abelian, so the endomorphisms they
+give commute, and both a sum of commuting semisimple endomorphisms and a scalar multiple of one are
+again semisimple. -/
+theorem isSemisimple_toEnd_cartan (x : H) : (toEnd K H M x).IsSemisimple := by
+  have hcomm : ∀ y z : H, Commute (toEnd K H M y) (toEnd K H M z) := fun y z ↦
+    LieModule.commute_toEnd_of_mem_center_left M
+      (by rw [(LieAlgebra.isLieAbelian_iff_center_eq_top K H).1 inferInstance]; trivial) z
+  have hx : x ∈ Submodule.span K (Set.range (IsKilling.rootSystem H).coroot) := by
+    rw [RootPairing.IsRootSystem.span_coroot_eq_top]
+    trivial
+  induction hx using Submodule.span_induction with
+  | mem y hy =>
+    obtain ⟨α, rfl⟩ := hy
+    exact isSemisimple_toEnd_coroot α.1
+  | zero => simp
+  | add y z _ _ hy hz =>
+    rw [map_add]
+    exact Module.End.IsSemisimple.add_of_commute (hcomm y z) hy hz
+  | smul c y _ hy =>
+    rw [map_smul]
+    exact hy.of_mem_adjoin_singleton
+      (Subalgebra.smul_mem _ (Algebra.self_mem_adjoin_singleton _ _) c)
+
+/-- **The Cartan subalgebra acts diagonalizably.** The eigenspaces of the action of `x : H` on a
+finite-dimensional module span it. -/
+theorem iSup_eigenspace_toEnd_cartan_eq_top (x : H) :
+    ⨆ μ : K, (toEnd K H M x).eigenspace μ = ⊤ :=
+  (isSemisimple_toEnd_cartan (M := M) x).iSup_eigenspace_eq_top
+
+/-! ### Honest weight spaces -/
+
+/-- The generalized eigenspace of `x : H` at a scalar is an honest eigenspace. -/
+theorem genWeightSpaceOf_eq_eigenspace (μ : K) (x : H) :
+    (genWeightSpaceOf M μ x).toSubmodule = (toEnd K H M x).eigenspace μ :=
+  (isSemisimple_toEnd_cartan (M := M) x).isFinitelySemisimple.maxGenEigenspace_eq_eigenspace μ
+
+/-- **The generalized weight spaces are honest weight spaces.** For a finite-dimensional module over
+a Killing-semisimple Lie algebra, `LieModule.genWeightSpace M χ` is the simultaneous eigenspace
+`LieModule.weightSpace M χ`.
+
+Mathlib's `LieModule.weightSpace_le_genWeightSpace` is the inclusion that holds always; this is the
+reverse one, and it is exactly the diagonalizability of the Cartan action. -/
+theorem genWeightSpace_eq_weightSpace (χ : H → K) : genWeightSpace M χ = weightSpace M χ := by
+  refine LieSubmodule.toSubmodule_injective ?_
+  rw [genWeightSpace, LieSubmodule.iInf_toSubmodule]
+  simp only [genWeightSpaceOf_eq_eigenspace]
+  rfl
+
+/-- **Membership of a weight space is the eigenvector equation.** An element of a
+finite-dimensional module lies in the `χ`-weight space exactly when every `x : H` acts on it by the
+scalar `χ x`. -/
+theorem mem_genWeightSpace_iff_forall_lie_eq_smul {χ : H → K} {m : M} :
+    m ∈ genWeightSpace M χ ↔ ∀ x : H, ⁅(x : L), m⁆ = χ x • m := by
+  rw [genWeightSpace_eq_weightSpace, mem_weightSpace]
+  simp
+
+variable (K H M) in
+/-- **The honest weight spaces span.** A finite-dimensional module over a Killing-semisimple Lie
+algebra is spanned by the simultaneous eigenspaces of its Cartan subalgebra. -/
+theorem iSup_weightSpace_eq_top : ⨆ χ : Weight K H M, weightSpace M (χ : H → K) = ⊤ := by
+  simpa only [genWeightSpace_eq_weightSpace] using iSup_genWeightSpace_eq_top' K H M
+
+variable (K H M) in
+open scoped Classical in
+/-- **The honest weight-space decomposition.** A finite-dimensional module over a
+Killing-semisimple Lie algebra is the internal direct sum of the simultaneous eigenspaces of its
+Cartan subalgebra, so `χ ↦ finrank (weightSpace M χ)` counts honest multiplicities. -/
+theorem isInternal_weightSpace :
+    DirectSum.IsInternal fun χ : Weight K H M ↦ (weightSpace M (χ : H → K)).toSubmodule := by
+  refine DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top ?_ ?_
+  · rw [LieSubmodule.iSupIndep_toSubmodule]
+    simpa only [genWeightSpace_eq_weightSpace] using iSupIndep_genWeightSpace' K H M
+  · rw [← LieSubmodule.iSup_toSubmodule, iSup_weightSpace_eq_top K H M]
+    simp
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.LinearAlgebra.Eigenspace.Minpoly
+public import Mathlib.LinearAlgebra.Eigenspace.Semisimple
+
+public section
+
+/-!
+# Diagonalizable endomorphisms are semisimple
+
+Mathlib records that a semisimple endomorphism of a finite-dimensional vector space over an
+algebraically closed field is diagonalizable
+(`Module.End.IsSemisimple.iSup_eigenspace_eq_top`). This file proves the converse, which needs no
+hypothesis on the field: an endomorphism whose eigenspaces span is annihilated by the product of
+`X - μ` over its finitely many eigenvalues, a squarefree polynomial, so
+`Module.End.isSemisimple_of_squarefree_aeval_eq_zero` applies.
+
+The two together characterise semisimplicity over an algebraically closed field, which is
+`TauCeti.isSemisimple_iff_iSup_eigenspace_eq_top`.
+
+## Main results
+
+* `TauCeti.isSemisimple_of_iSup_eigenspace_eq_top`: an endomorphism of a finite-dimensional vector
+  space whose eigenspaces span the space is semisimple.
+* `TauCeti.isSemisimple_iff_iSup_eigenspace_eq_top`: over an algebraically closed field,
+  semisimplicity is diagonalizability.
+-/
+
+namespace TauCeti
+
+open Module Polynomial
+
+variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V] [FiniteDimensional K V]
+  {f : End K V}
+
+/-- **A diagonalizable endomorphism is semisimple.** If the eigenspaces of `f` span a
+finite-dimensional vector space then `f` is semisimple.
+
+There are finitely many eigenvalues, and `f` is annihilated by the product of the `X - μ` over
+them: that product is squarefree, having distinct linear factors, so
+`Module.End.isSemisimple_of_squarefree_aeval_eq_zero` applies. No hypothesis on the field is
+needed; the converse `Module.End.IsSemisimple.iSup_eigenspace_eq_top` is where algebraic closure
+enters. -/
+theorem isSemisimple_of_iSup_eigenspace_eq_top (hf : ⨆ μ : K, f.eigenspace μ = ⊤) :
+    f.IsSemisimple := by
+  classical
+  set s : Finset K := f.finite_hasEigenvalue.toFinset with hs
+  set p : K[X] := ∏ μ ∈ s, (X - C μ) with hp
+  refine End.isSemisimple_of_squarefree_aeval_eq_zero (p := p) ?_ ?_
+  · exact (separable_prod_X_sub_C_iff'.2 (Set.injOn_id _)).squarefree
+  · refine LinearMap.ker_eq_top.1 (top_le_iff.1 ?_)
+    refine hf ▸ iSup_le fun μ v hv ↦ ?_
+    by_cases hμ : f.HasEigenvalue μ
+    · have heval : p.eval μ = 0 := by
+        rw [hp, eval_prod]
+        exact Finset.prod_eq_zero (by simpa [hs] using hμ) (by simp)
+      have : aeval f p v = p.eval μ • v :=
+        End.aeval_apply_of_mem_apply_eq_smul (End.mem_eigenspace_iff.1 hv)
+      simp [LinearMap.mem_ker, this, heval]
+    · rw [End.hasEigenvalue_iff, not_not] at hμ
+      have hv0 : v = 0 := by simpa [hμ] using hv
+      simp [hv0]
+
+/-- **Semisimplicity is diagonalizability**, over an algebraically closed field and in finite
+dimension. -/
+theorem isSemisimple_iff_iSup_eigenspace_eq_top [IsAlgClosed K] :
+    f.IsSemisimple ↔ ⨆ μ : K, f.eigenspace μ = ⊤ :=
+  ⟨End.IsSemisimple.iSup_eigenspace_eq_top, isSemisimple_of_iSup_eigenspace_eq_top⟩
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -48,6 +48,18 @@ theorem isSemisimple_of_iSup_eigenspace_eq_top (hf : ⨆ μ : K, f.eigenspace μ
     simp [hv]
   have hss : ∀ μ : K,
       IsSemisimpleModule K[X] (AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv μ⟩) := fun μ ↦ by
+    -- `AEval.restrict_equiv_mapSubmodule` restricts `Algebra.lsmul K K V f`, not `f`, to the
+    -- `μ`-eigenspace, and it hands `LinearMap.restrict` an invariance proof of type
+    -- `p ∈ (Algebra.lsmul K K V f).invtSubmodule`, where `LinearMap.restrict` asks for
+    -- `∀ x ∈ p, g x ∈ p`. Those two types are definitionally equal only at default transparency,
+    -- so `LinearMap.coe_restrict_apply` cannot be instantiated against the goal below directly.
+    -- Recording the composite coercion here once, with the submodules supplied explicitly, keeps
+    -- the step below lemma-driven.
+    have hrestrict (w : f.eigenspace μ) :
+        (LinearMap.restrict (p := f.eigenspace μ) (q := f.eigenspace μ)
+          (Algebra.lsmul K K V f) (hinv μ) w : V) = f w :=
+      (LinearMap.coe_restrict_apply _ _).trans
+        ((Algebra.lsmul_apply (R := K) (B := K) V f w).trans (Module.End.smul_def f w))
     refine (AEval.restrict_equiv_mapSubmodule f _ (hinv μ)).isSemisimpleModule_iff.mp ?_
     refine End.isSemisimple_of_squarefree_aeval_eq_zero (p := X - C μ)
       (irreducible_X_sub_C μ).squarefree ?_
@@ -57,15 +69,14 @@ theorem isSemisimple_of_iSup_eigenspace_eq_top (hf : ⨆ μ : K, f.eigenspace μ
     simp only [map_sub, aeval_X, aeval_C, LinearMap.sub_apply, LinearMap.zero_apply,
       Module.algebraMap_end_apply, Submodule.coe_sub, Submodule.coe_smul, ZeroMemClass.coe_zero]
     -- the restriction of `f` to the `μ`-eigenspace is multiplication by `μ`
-    change f (v : V) - μ • (v : V) = 0
-    rw [hv, sub_self]
+    rw [hrestrict, hv, sub_self]
   have htop : ⨆ μ : K, AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv μ⟩ = ⊤ := by
     set Q := ⨆ μ : K, AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv μ⟩
     have hle : (⊤ : Submodule K V) ≤ (Q.restrictScalars K).comap (AEval'.of f).toLinearMap := by
       rw [← hf]
       refine iSup_le fun μ v hv ↦ ?_
       -- membership in the comap of `Q` is membership of the image in `Q`
-      change AEval'.of f v ∈ Q
+      rw [Submodule.mem_comap, Submodule.restrictScalars_mem]
       exact Submodule.mem_iSup_of_mem μ (by simpa using hv)
     refine Submodule.eq_top_iff'.2 fun m ↦ ?_
     simpa using hle (Submodule.mem_top (x := (AEval'.of f).symm m))

--- a/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -5,7 +5,6 @@ Authors: Claude
 -/
 module
 
-public import Mathlib.LinearAlgebra.Eigenspace.Minpoly
 public import Mathlib.LinearAlgebra.Eigenspace.Semisimple
 
 public section
@@ -16,60 +15,60 @@ public section
 Mathlib records that a semisimple endomorphism of a finite-dimensional vector space over an
 algebraically closed field is diagonalizable
 (`Module.End.IsSemisimple.iSup_eigenspace_eq_top`). This file proves the converse, which needs no
-hypothesis on the field: an endomorphism whose eigenspaces span is annihilated by the product of
-`X - μ` over its finitely many eigenvalues, a squarefree polynomial, so
-`Module.End.isSemisimple_of_squarefree_aeval_eq_zero` applies.
-
-The two together characterise semisimplicity over an algebraically closed field, which is
-`TauCeti.isSemisimple_iff_iSup_eigenspace_eq_top`.
+hypothesis on the field and no finiteness hypothesis on the space: an endomorphism whose
+eigenspaces span is, as a `K[X]`-module, the sum of those eigenspaces, and on each of them `X` acts
+by a scalar, so each is annihilated by the squarefree polynomial `X - C μ` and is semisimple.
 
 ## Main results
 
-* `TauCeti.isSemisimple_of_iSup_eigenspace_eq_top`: an endomorphism of a finite-dimensional vector
-  space whose eigenspaces span the space is semisimple.
-* `TauCeti.isSemisimple_iff_iSup_eigenspace_eq_top`: over an algebraically closed field,
-  semisimplicity is diagonalizability.
+* `TauCeti.isSemisimple_of_iSup_eigenspace_eq_top`: an endomorphism whose eigenspaces span the
+  space is semisimple.
 -/
 
 namespace TauCeti
 
 open Module Polynomial
 
-variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V] [FiniteDimensional K V]
-  {f : End K V}
+variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V] {f : End K V}
 
-/-- **A diagonalizable endomorphism is semisimple.** If the eigenspaces of `f` span a
-finite-dimensional vector space then `f` is semisimple.
+/-- **A diagonalizable endomorphism is semisimple.** If the eigenspaces of `f` span the space then
+`f` is semisimple.
 
-There are finitely many eigenvalues, and `f` is annihilated by the product of the `X - μ` over
-them: that product is squarefree, having distinct linear factors, so
-`Module.End.isSemisimple_of_squarefree_aeval_eq_zero` applies. No hypothesis on the field is
-needed; the converse `Module.End.IsSemisimple.iSup_eigenspace_eq_top` is where algebraic closure
-enters. -/
+Semisimplicity of `f` is semisimplicity of `V` as a `K[X]`-module, and the eigenspaces are
+`K[X]`-submodules spanning it, so it is enough that each is semisimple. On the `μ`-eigenspace `X`
+acts by the scalar `μ`, so the restriction of `f` is annihilated by the squarefree polynomial
+`X - C μ` and `Module.End.isSemisimple_of_squarefree_aeval_eq_zero` applies. Neither algebraic
+closure nor finite dimension is needed; the converse
+`Module.End.IsSemisimple.iSup_eigenspace_eq_top` is where both enter. -/
 theorem isSemisimple_of_iSup_eigenspace_eq_top (hf : ⨆ μ : K, f.eigenspace μ = ⊤) :
     f.IsSemisimple := by
-  classical
-  set s : Finset K := f.finite_hasEigenvalue.toFinset with hs
-  set p : K[X] := ∏ μ ∈ s, (X - C μ) with hp
-  refine End.isSemisimple_of_squarefree_aeval_eq_zero (p := p) ?_ ?_
-  · exact (separable_prod_X_sub_C_iff'.2 (Set.injOn_id _)).squarefree
-  · refine LinearMap.ker_eq_top.1 (top_le_iff.1 ?_)
-    refine hf ▸ iSup_le fun μ v hv ↦ ?_
-    by_cases hμ : f.HasEigenvalue μ
-    · have heval : p.eval μ = 0 := by
-        rw [hp, eval_prod]
-        exact Finset.prod_eq_zero (by simpa [hs] using hμ) (by simp)
-      have : aeval f p v = p.eval μ • v :=
-        End.aeval_apply_of_mem_apply_eq_smul (End.mem_eigenspace_iff.1 hv)
-      simp [LinearMap.mem_ker, this, heval]
-    · rw [End.hasEigenvalue_iff, not_not] at hμ
-      have hv0 : v = 0 := by simpa [hμ] using hv
-      simp [hv0]
-
-/-- **Semisimplicity is diagonalizability**, over an algebraically closed field and in finite
-dimension. -/
-theorem isSemisimple_iff_iSup_eigenspace_eq_top [IsAlgClosed K] :
-    f.IsSemisimple ↔ ⨆ μ : K, f.eigenspace μ = ⊤ :=
-  ⟨End.IsSemisimple.iSup_eigenspace_eq_top, isSemisimple_of_iSup_eigenspace_eq_top⟩
+  -- `f` acts on its `μ`-eigenspace as multiplication by `μ`, so that eigenspace is invariant
+  have hinv : ∀ μ : K, f.eigenspace μ ∈ (Algebra.lsmul K K V f).invtSubmodule := fun μ v hv ↦ by
+    rw [End.mem_eigenspace_iff] at hv
+    simp [hv]
+  have hss : ∀ μ : K,
+      IsSemisimpleModule K[X] (AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv μ⟩) := fun μ ↦ by
+    refine (AEval.restrict_equiv_mapSubmodule f _ (hinv μ)).isSemisimpleModule_iff.mp ?_
+    refine End.isSemisimple_of_squarefree_aeval_eq_zero (p := X - C μ)
+      (irreducible_X_sub_C μ).squarefree ?_
+    ext v
+    have hv := v.2
+    rw [End.mem_eigenspace_iff] at hv
+    simp only [map_sub, aeval_X, aeval_C, LinearMap.sub_apply, LinearMap.zero_apply,
+      Module.algebraMap_end_apply, Submodule.coe_sub, Submodule.coe_smul, ZeroMemClass.coe_zero]
+    -- the restriction of `f` to the `μ`-eigenspace is multiplication by `μ`
+    change f (v : V) - μ • (v : V) = 0
+    rw [hv, sub_self]
+  have htop : ⨆ μ : K, AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv μ⟩ = ⊤ := by
+    set Q := ⨆ μ : K, AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv μ⟩
+    have hle : (⊤ : Submodule K V) ≤ (Q.restrictScalars K).comap (AEval'.of f).toLinearMap := by
+      rw [← hf]
+      refine iSup_le fun μ v hv ↦ ?_
+      -- membership in the comap of `Q` is membership of the image in `Q`
+      change AEval'.of f v ∈ Q
+      exact Submodule.mem_iSup_of_mem μ (by simpa using hv)
+    refine Submodule.eq_top_iff'.2 fun m ↦ ?_
+    simpa using hle (Submodule.mem_top (x := (AEval'.of f).symm m))
+  exact isSemisimpleModule_of_isSemisimpleModule_submodule' hss htop
 
 end TauCeti


### PR DESCRIPTION
This PR proves that every element of a Cartan subalgebra `H` of a Killing-semisimple Lie algebra `L` acts by a **semisimple** endomorphism on every finite-dimensional `L`-module, and refines Mathlib's *generalized* weight spaces to the *honest* simultaneous eigenspaces they turn out to be. It is the "honest weight spaces (the diagonalizability theorem)" item of Layer 2 of `RepresentationTheory/LieHighestWeight/README.md`, whose pinned target signature `isSemisimple_toEnd_cartan` is `TauCeti.isSemisimple_toEnd_cartan`.

The route is the rank-one reduction the roadmap asks for, not the abstract Jordan decomposition. A nonzero root `α` carries an `sl₂` triple whose Cartan element is the coroot `α^∨`, and the `sl₂` engine already knows such an element acts diagonalizably (`TauCeti.iSup_eigenspace_toEnd_eq_top`, proved from complete reducibility for `sl₂` alone). The coroots span `H` (`RootPairing.IsRootSystem.span_coroot_eq_top` for `LieAlgebra.IsKilling.rootSystem H`) and `H` is abelian, so the operators they give are commuting semisimple endomorphisms and semisimplicity passes to their span. In particular nothing here consumes Weyl's complete reducibility for `L`, which is Layer 5 and whose usual proof consumes the honest decomposition; that is the circularity the roadmap explicitly asks this layer to avoid.

Consequently `LieModule.genWeightSpace M χ = LieModule.weightSpace M χ` (`genWeightSpace_eq_weightSpace`), membership is the eigenvector equation `⁅x, m⁆ = χ x • m` for every `x : H` (`mem_genWeightSpace_iff_forall_lie_eq_smul`), the honest weight spaces span (`iSup_weightSpace_eq_top`), and `M` is their internal direct sum (`isInternal_weightSpace`), so `χ ↦ finrank (weightSpace M χ)` counts honest multiplicities. Triangularizability of a finite-dimensional module over `H` needs no work: it is Mathlib's `LieModule.instIsTriangularizableOfIsAlgClosed`, so the roadmap's companion target `isTriangularizable_of_finiteDimensional` is already upstream and is cited rather than reproved.

The bridge the argument needs is a converse to Mathlib's `Module.End.IsSemisimple.iSup_eigenspace_eq_top`: a diagonalizable endomorphism is semisimple. Mathlib has only the forward direction, so `TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean` adds `isSemisimple_of_iSup_eigenspace_eq_top`, with neither an algebraic-closure nor a finite-dimensionality hypothesis: each eigenspace is a `K[X]`-submodule on which the restriction of the endomorphism is killed by the squarefree `X - C μ`, hence semisimple, and those submodules span.

Two files, 250 lines: `TauCeti/Algebra/Lie/Weights/Diagonalizable.lean` (175) and `TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean` (75). What remains in Layer 2 after this is the last of its four items, Weyl-invariance of the weight multiplicities, proved directly by restricting to the `sl₂` of each root and pairing the `μ`- and `s_α(μ)`-weight spaces along each string; Layers 3 and 4 (Verma modules, `L(λ)`, and the classification of the finite-dimensional irreducibles) then sit on top of the honest decomposition established here.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"issemisimple-toend-cartan"}-->

🤖 Prepared with Claude Code

