### PR TITLE
feat: extend Pin corrections over fixed subspaces

### DIFF
--- a/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -15,7 +15,7 @@ form. It is the structural step used when a Cartan--Dieudonne argument enlarges 
 
 ## Main result
 
-* `TauCeti.BilinForm.restrict_sup_span_singleton_nondegenerate`: adjoining a vector with nonzero
+* `TauCeti.BilinForm.restrict_nondegenerate_sup_span_singleton`: adjoining a vector with nonzero
   self-pairing from the orthogonal complement preserves nondegeneracy.
 * `TauCeti.BilinForm.finrank_sup_span_singleton_of_mem_orthogonal`: adjoining a vector with
   nonzero self-pairing from the orthogonal complement increases finrank by one.
@@ -33,7 +33,7 @@ variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V]
 
 /-- Adjoining a vector with nonzero self-pairing from the orthogonal complement of a nondegenerate
 subspace preserves nondegeneracy. -/
-theorem restrict_sup_span_singleton_nondegenerate
+theorem restrict_nondegenerate_sup_span_singleton
     (B : BilinForm K V) (hB : B.IsRefl) (W : Submodule K V)
     (hW : (B.restrict W).Nondegenerate) (x : V) (hxx : B x x ≠ 0)
     (hx : x ∈ B.orthogonal W) :

--- a/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
+public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 
 /-!
 # Extending nondegenerate subspaces by an orthogonal vector
@@ -16,6 +17,8 @@ form. It is the structural step used when a Cartan--Dieudonne argument enlarges 
 
 * `TauCeti.BilinForm.restrict_sup_span_singleton_nondegenerate`: adjoining a vector with nonzero
   self-pairing from the orthogonal complement preserves nondegeneracy.
+* `TauCeti.BilinForm.finrank_sup_span_singleton_of_mem_orthogonal`: adjoining a vector with
+  nonzero self-pairing from the orthogonal complement increases finrank by one.
 -/
 
 public section
@@ -47,9 +50,7 @@ theorem restrict_sup_span_singleton_nondegenerate
     -- Expose the ambient bilinear form under its restriction to `S`.
     change B y w' = 0 at hyw
     rw [← hsum] at hyw
-    simpa only [map_add, LinearMap.add_apply, LinearMap.coe_restrictScalars,
-      LinearMap.coe_mk, AddHom.coe_mk, LinearMap.map_smul_of_tower, LinearMap.smul_apply,
-      hBxw', smul_eq_mul, mul_zero, add_zero] using hyw
+    simpa [hBxw'] using hyw
   have hw0 : w = 0 := congrArg Subtype.val (hW.1 ⟨w, hw⟩ hwzero)
   have hxS : x ∈ S := Submodule.mem_sup_right (Submodule.mem_span_singleton_self x)
   have hyx := hy ⟨x, hxS⟩
@@ -61,6 +62,17 @@ theorem restrict_sup_span_singleton_nondegenerate
     exact (mul_eq_zero.mp hyx).resolve_right hxx
   apply Subtype.ext
   simp [← hsum, hw0, ha]
+
+/-- Adjoining a vector with nonzero self-pairing from the orthogonal complement increases
+finrank by one. -/
+theorem finrank_sup_span_singleton_of_mem_orthogonal
+    [Module.Finite K V] (B : BilinForm K V) (W : Submodule K V) (x : V)
+    (hxx : B x x ≠ 0) (hx : x ∈ B.orthogonal W) :
+    Module.finrank K ↑(W ⊔ Submodule.span K {x} : Submodule K V) =
+      Module.finrank K W + 1 := by
+  apply Submodule.finrank_sup_span_singleton
+  intro hxW
+  exact hxx (hx x hxW)
 
 end BilinForm
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
+
+/-!
+# Extending nondegenerate subspaces by an orthogonal vector
+
+This file records the one-vector extension of a nondegenerate subspace for a reflexive bilinear
+form. It is the structural step used when a Cartan--Dieudonne argument enlarges a fixed subspace.
+
+## Main result
+
+* `TauCeti.BilinForm.restrict_sup_span_singleton_nondegenerate`: adjoining a vector with nonzero
+  self-pairing from the orthogonal complement preserves nondegeneracy.
+-/
+
+public section
+
+namespace TauCeti
+
+open LinearMap (BilinForm)
+
+namespace BilinForm
+
+variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V]
+
+/-- Adjoining a vector with nonzero self-pairing from the orthogonal complement of a nondegenerate
+subspace preserves nondegeneracy. -/
+theorem restrict_sup_span_singleton_nondegenerate
+    (B : BilinForm K V) (hB : B.IsRefl) (W : Submodule K V)
+    (hW : (B.restrict W).Nondegenerate) (x : V) (hxx : B x x ≠ 0)
+    (hx : x ∈ B.orthogonal W) :
+    (B.restrict (W ⊔ Submodule.span K {x})).Nondegenerate := by
+  let S : Submodule K V := W ⊔ Submodule.span K {x}
+  apply (hB.domRestrict S).nondegenerate_iff_separatingLeft.2
+  intro y hy
+  obtain ⟨w, hw, z, hz, hsum⟩ := Submodule.mem_sup.mp y.2
+  obtain ⟨a, rfl⟩ := Submodule.mem_span_singleton.mp hz
+  have hwzero : ∀ w' : W, B w w' = 0 := by
+    intro w'
+    have hBxw' : B x w' = 0 := hB.eq_zero (hx w' w'.2)
+    have hyw := hy ⟨w', Submodule.mem_sup_left w'.2⟩
+    -- Expose the ambient bilinear form under its restriction to `S`.
+    change B y w' = 0 at hyw
+    rw [← hsum] at hyw
+    simpa only [map_add, LinearMap.add_apply, LinearMap.coe_restrictScalars,
+      LinearMap.coe_mk, AddHom.coe_mk, LinearMap.map_smul_of_tower, LinearMap.smul_apply,
+      hBxw', smul_eq_mul, mul_zero, add_zero] using hyw
+  have hw0 : w = 0 := congrArg Subtype.val (hW.1 ⟨w, hw⟩ hwzero)
+  have hxS : x ∈ S := Submodule.mem_sup_right (Submodule.mem_span_singleton_self x)
+  have hyx := hy ⟨x, hxS⟩
+  -- Expose the ambient bilinear form under its restriction to `S`.
+  change B y x = 0 at hyx
+  rw [← hsum, hw0, zero_add] at hyx
+  have ha : a = 0 := by
+    rw [map_smul, LinearMap.smul_apply, smul_eq_mul] at hyx
+    exact (mul_eq_zero.mp hyx).resolve_right hxx
+  apply Subtype.ext
+  simp [← hsum, hw0, ha]
+
+end BilinForm
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.FieldTheory.IsSepClosed
+public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
 public import TauCeti.LinearAlgebra.CliffordAlgebra.ReflectionLift
 
 /-!
@@ -23,7 +24,8 @@ This is the one-vector reduction used by the finite-dimensional Cartan--Dieudonn
 * `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_apply_eq_self`: an element in the
   range of the Pin action corrects an orthogonal automorphism to fix a chosen vector of invertible
   norm.
-* `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup`: the correction preserves
+* `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton`:
+  the correction preserves
   an arbitrary previously fixed subspace when the new vector is orthogonal to it.
 
 ## References
@@ -99,8 +101,9 @@ private theorem associated_apply_of_mem_orthogonalGroup
     (g : QuadraticMap.orthogonalGroup Q) (x y : V) :
     QuadraticMap.associated Q ((g : V ≃ₗ[K] V) x) ((g : V ≃ₗ[K] V) y) =
       QuadraticMap.associated Q x y := by
-  simp only [QuadraticMap.associated_apply, ← map_add,
-    QuadraticMap.map_app_of_mem_orthogonalGroup g.2]
+  simpa only [QuadraticMap.associated_apply, QuadraticMap.polar] using
+    congrArg (⅟(2 : Module.End K K) • ·)
+      (QuadraticMap.polar_apply_of_mem_orthogonalGroup g.2 x y)
 
 omit [IsSepClosed K] in
 private theorem reflection_fixes_of_mem_orthogonal
@@ -130,7 +133,7 @@ private theorem linearEquiv_eqOn_sup_span_singleton
 
 /-- Given an orthogonal automorphism that fixes `W` and an anisotropic vector `x` orthogonal to
 `W`, a Pin-range correction makes the product fix `W ⊔ K ∙ x` pointwise. -/
-theorem exists_mem_range_pinToOrthogonal_mul_eqOn_sup
+theorem exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton
     (g : QuadraticMap.orthogonalGroup Q) (W : Submodule K V)
     (hfix : ∀ w ∈ W, ((g : V ≃ₗ[K] V) w) = w)
     (x : V) [Invertible (Q x)]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.FieldTheory.IsSepClosed
-public import TauCeti.LinearAlgebra.BilinearForm.Orthogonal
 public import TauCeti.LinearAlgebra.CliffordAlgebra.ReflectionLift
 
 /-!
@@ -25,7 +24,7 @@ This is the one-vector reduction used by the finite-dimensional Cartan--Dieudonn
   range of the Pin action corrects an orthogonal automorphism to fix a chosen vector of invertible
   norm.
 * `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup`: the correction preserves
-  a previously fixed nondegenerate subspace when the new vector is orthogonal to it.
+  an arbitrary previously fixed subspace when the new vector is orthogonal to it.
 
 ## References
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.FieldTheory.IsSepClosed
+public import TauCeti.LinearAlgebra.BilinearForm.Orthogonal
 public import TauCeti.LinearAlgebra.CliffordAlgebra.ReflectionLift
 
 /-!
@@ -23,6 +24,8 @@ This is the one-vector reduction used by the finite-dimensional Cartan--Dieudonn
 * `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_apply_eq_self`: an element in the
   range of the Pin action corrects an orthogonal automorphism to fix a chosen vector of invertible
   norm.
+* `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup`: the correction preserves
+  a previously fixed nondegenerate subspace when the new vector is orthogonal to it.
 
 ## References
 
@@ -44,6 +47,13 @@ namespace CliffordAlgebra
 variable {K : Type u} {V : Type v} [Field K] [IsSepClosed K]
   [AddCommGroup V] [Module K V] (Q : QuadraticForm K V) [Invertible (2 : K)]
 
+private theorem reflection_mem_range_pinToOrthogonal_of_isSepClosed
+    (w : V) [Invertible (Q w)] :
+    (⟨QuadraticMap.reflection Q w, QuadraticMap.reflection_mem_orthogonalGroup Q w⟩ :
+      QuadraticMap.orthogonalGroup Q) ∈ (pinToOrthogonal Q).range :=
+  reflection_mem_range_pinToOrthogonal_of_isSquare Q w
+    (IsSepClosed.exists_eq_mul_self _)
+
 /-- Given an orthogonal automorphism `g` and a vector `v` of invertible norm, an element in the
 range of the Pin action can be multiplied into `g` so that the product fixes `v`. The correcting
 orthogonal element is the image under `pinToOrthogonal` of a lift of either one reflection or two
@@ -53,11 +63,6 @@ theorem exists_mem_range_pinToOrthogonal_mul_apply_eq_self
     [Invertible (Q v)] :
     ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ (pinToOrthogonal Q).range ∧
       (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) v = v) := by
-  have reflection_mem_range (w : V) [Invertible (Q w)] :
-      (⟨QuadraticMap.reflection Q w, QuadraticMap.reflection_mem_orthogonalGroup Q w⟩ :
-        QuadraticMap.orthogonalGroup Q) ∈ (pinToOrthogonal Q).range :=
-    reflection_mem_range_pinToOrthogonal_of_isSquare Q w
-      (IsSepClosed.exists_eq_mul_self _)
   have hmap : Q ((g : V ≃ₗ[K] V) v) = Q v :=
     QuadraticMap.map_app_of_mem_orthogonalGroup g.2 v
   rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q _ v hmap
@@ -66,7 +71,7 @@ theorem exists_mem_range_pinToOrthogonal_mul_apply_eq_self
     let r : QuadraticMap.orthogonalGroup Q :=
       ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - v),
         QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
-    refine ⟨r, reflection_mem_range _, ?_⟩
+    refine ⟨r, reflection_mem_range_pinToOrthogonal_of_isSepClosed Q _, ?_⟩
     -- Expose the underlying automorphisms of the subgroup product before applying the reflection
     -- computation.
     change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - v)
@@ -80,13 +85,124 @@ theorem exists_mem_range_pinToOrthogonal_mul_apply_eq_self
       ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - -v),
         QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
     refine ⟨r₁ * r₂,
-      (pinToOrthogonal Q).range.mul_mem (reflection_mem_range v) (reflection_mem_range _), ?_⟩
+      (pinToOrthogonal Q).range.mul_mem
+        (reflection_mem_range_pinToOrthogonal_of_isSepClosed Q v)
+        (reflection_mem_range_pinToOrthogonal_of_isSepClosed Q _), ?_⟩
     -- Expose the two underlying reflections before applying their public computation equations.
     change QuadraticMap.reflection Q v
       (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - -v)
         ((g : V ≃ₗ[K] V) v)) = v
     rw [QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ (-v)
       (hmap.trans (Q.map_neg v).symm), map_neg, QuadraticMap.reflection_apply_self, neg_neg]
+
+omit [IsSepClosed K] in
+private theorem associated_apply_of_mem_orthogonalGroup
+    (g : QuadraticMap.orthogonalGroup Q) (x y : V) :
+    QuadraticMap.associated Q ((g : V ≃ₗ[K] V) x) ((g : V ≃ₗ[K] V) y) =
+      QuadraticMap.associated Q x y := by
+  simp only [QuadraticMap.associated_apply, ← map_add,
+    QuadraticMap.map_app_of_mem_orthogonalGroup g.2]
+
+omit [IsSepClosed K] in
+private theorem reflection_fixes_of_mem_orthogonal
+    (W : Submodule K V) (u : V) [Invertible (Q u)]
+    (hu : u ∈ LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W)
+    {w : V} (hw : w ∈ W) :
+    QuadraticMap.reflection Q u w = w := by
+  apply QuadraticMap.reflection_apply_of_isOrtho
+  apply QuadraticMap.associated_isOrtho.mp
+  simpa only [QuadraticMap.associated_isSymm] using hu w hw
+
+omit [IsSepClosed K] [Invertible (2 : K)] in
+private theorem linearEquiv_eqOn_sup_span_singleton
+    (f : V ≃ₗ[K] V) (W : Submodule K V) (x : V)
+    (hW : ∀ w ∈ W, f w = w) (hx : f x = x) :
+    ∀ y ∈ W ⊔ Submodule.span K {x}, f y = y := by
+  apply LinearMap.eqOn_sup (f := f) (g := LinearEquiv.refl K V)
+  · intro w hw
+    simpa only [LinearEquiv.refl_apply] using hW w hw
+  · apply LinearMap.eqOn_span'
+    intro y hy
+    simp only [Set.mem_singleton_iff] at hy
+    subst y
+    -- Remove the identity-equivalence coercion introduced by `eqOn_span'`.
+    change f x = x
+    exact hx
+
+/-- Given an orthogonal automorphism that fixes `W` and an anisotropic vector `x` orthogonal to
+`W`, a Pin-range correction makes the product fix `W ⊔ K ∙ x` pointwise. -/
+theorem exists_mem_range_pinToOrthogonal_mul_eqOn_sup
+    (g : QuadraticMap.orthogonalGroup Q) (W : Submodule K V)
+    (hfix : ∀ w ∈ W, ((g : V ≃ₗ[K] V) w) = w)
+    (x : V) [Invertible (Q x)]
+    (hx : x ∈ LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) :
+    ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ (pinToOrthogonal Q).range ∧
+      ∀ y ∈ W ⊔ Submodule.span K {x},
+        (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) y) = y := by
+  let B : LinearMap.BilinForm K V := QuadraticMap.associated Q
+  have hmap : Q ((g : V ≃ₗ[K] V) x) = Q x :=
+    QuadraticMap.map_app_of_mem_orthogonalGroup g.2 x
+  have hgx : (g : V ≃ₗ[K] V) x ∈ B.orthogonal W := by
+    intro w hw
+    calc
+      B w ((g : V ≃ₗ[K] V) x) =
+          B ((g : V ≃ₗ[K] V) w) ((g : V ≃ₗ[K] V) x) := by
+            rw [hfix w hw]
+      _ = B w x := associated_apply_of_mem_orthogonalGroup Q g w x
+      _ = 0 := hx w hw
+  have hsub : (g : V ≃ₗ[K] V) x - x ∈ B.orthogonal W := by
+    intro w hw
+    have hwx : B w x = 0 := hx w hw
+    simp only [map_sub, hgx w hw, hwx, sub_self]
+  have hadd : (g : V ≃ₗ[K] V) x + x ∈ B.orthogonal W := by
+    intro w hw
+    have hwx : B w x = 0 := hx w hw
+    simp only [map_add, hgx w hw, hwx, add_zero]
+  rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q _ x hmap
+      (isUnit_of_invertible (Q x)).ne_zero with hsubUnit | haddUnit
+  · let : Invertible (Q ((g : V ≃ₗ[K] V) x - x)) := hsubUnit.invertible
+    let r : QuadraticMap.orthogonalGroup Q :=
+      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - x),
+        QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+    refine ⟨r, reflection_mem_range_pinToOrthogonal_of_isSepClosed Q _, ?_⟩
+    apply linearEquiv_eqOn_sup_span_singleton _ W x
+    · intro w hw
+      -- Expose the reflection underlying the subgroup product before applying its pointwise API.
+      change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - x)
+        ((g : V ≃ₗ[K] V) w) = w
+      rw [hfix w hw]
+      exact reflection_fixes_of_mem_orthogonal Q W _ hsub hw
+    · -- Expose the reflection underlying the subgroup product at the new generator.
+      change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - x)
+        ((g : V ≃ₗ[K] V) x) = x
+      exact QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ x hmap
+  · have : Invertible (Q ((g : V ≃ₗ[K] V) x - -x)) := by
+      simpa only [sub_neg_eq_add] using haddUnit.invertible
+    have hadd' : (g : V ≃ₗ[K] V) x - -x ∈ B.orthogonal W := by
+      simpa only [sub_neg_eq_add] using hadd
+    let r₁ : QuadraticMap.orthogonalGroup Q :=
+      ⟨QuadraticMap.reflection Q x, QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+    let r₂ : QuadraticMap.orthogonalGroup Q :=
+      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x),
+        QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+    refine ⟨r₁ * r₂,
+      (pinToOrthogonal Q).range.mul_mem
+        (reflection_mem_range_pinToOrthogonal_of_isSepClosed Q x)
+        (reflection_mem_range_pinToOrthogonal_of_isSepClosed Q _), ?_⟩
+    apply linearEquiv_eqOn_sup_span_singleton _ W x
+    · intro w hw
+      -- Expose the two reflections underlying the subgroup product.
+      change QuadraticMap.reflection Q x
+        (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x)
+          ((g : V ≃ₗ[K] V) w)) = w
+      rw [hfix w hw, reflection_fixes_of_mem_orthogonal Q W _ hadd' hw,
+        reflection_fixes_of_mem_orthogonal Q W _ hx hw]
+    · -- Expose the two reflections underlying the subgroup product at the new generator.
+      change QuadraticMap.reflection Q x
+        (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x)
+          ((g : V ≃ₗ[K] V) x)) = x
+      rw [QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ (-x)
+        (hmap.trans (Q.map_neg x).symm), map_neg, QuadraticMap.reflection_apply_self, neg_neg]
 
 end CliffordAlgebra
 end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -5,8 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.Determinant
-public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
-public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 public import Mathlib.LinearAlgebra.Reflection

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.Determinant
+public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
+public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 public import Mathlib.LinearAlgebra.Reflection
@@ -402,6 +404,25 @@ theorem isUnit_sub_or_add_of_map_eq (x y : V) (hxy : Q x = Q y) (hy : Q y ≠ 0)
 end Field
 
 end CartanDieudonneStep
+
+section FixedSubspaceStep
+
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+variable (Q : QuadraticForm K V) [Invertible (2 : K)]
+
+/-- Adjoining an anisotropic vector orthogonal to a subspace increases its finrank by one. -/
+theorem finrank_sup_span_singleton_of_mem_orthogonal
+    [Module.Finite K V] (W : Submodule K V) (x : V) [Invertible (Q x)]
+    (hx : x ∈ LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) :
+    Module.finrank K ↑(W ⊔ Submodule.span K {x} : Submodule K V) =
+      Module.finrank K W + 1 := by
+  apply Submodule.finrank_sup_span_singleton
+  intro hxW
+  have hzero := hx x hxW
+  rw [QuadraticMap.associated_eq_self_apply] at hzero
+  exact (isUnit_of_invertible (Q x)).ne_zero hzero
+
+end FixedSubspaceStep
 
 end QuadraticMap
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -405,25 +405,6 @@ end Field
 
 end CartanDieudonneStep
 
-section FixedSubspaceStep
-
-variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
-variable (Q : QuadraticForm K V) [Invertible (2 : K)]
-
-/-- Adjoining an anisotropic vector orthogonal to a subspace increases its finrank by one. -/
-theorem finrank_sup_span_singleton_of_mem_orthogonal
-    [Module.Finite K V] (W : Submodule K V) (x : V) [Invertible (Q x)]
-    (hx : x ∈ LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) :
-    Module.finrank K ↑(W ⊔ Submodule.span K {x} : Submodule K V) =
-      Module.finrank K W + 1 := by
-  apply Submodule.finrank_sup_span_singleton
-  intro hxW
-  have hzero := hx x hxW
-  rw [QuadraticMap.associated_eq_self_apply] at hzero
-  exact (isUnit_of_invertible (Q x)).ne_zero hzero
-
-end FixedSubspaceStep
-
 end QuadraticMap
 
 end TauCeti


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Extends the one-vector Cartan–Dieudonné correction across a fixed nondegenerate subspace.

- Shows that adjoining an orthogonal anisotropic vector preserves nondegeneracy and raises finrank by one.
- Produces a Pin-range correction that fixes the enlarged subspace pointwise.

## Roadmap target

Advances Layer 2 `spinToSpecialOrthogonal_surjective`:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L119-L125

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#spinToSpecialOrthogonal_surjective"}-->

## Dependency

This builds on the one-step Cartan–Dieudonné reduction merged in [#2410](https://github.com/TauCetiProject/TauCeti/pull/2410).

## Verification

Full builds, audits, environment lint, whitespace, an external consumer probe, proof golf, and independent exact-diff review pass at `940da3e1352b133acfd5f13c2d009e2073bafca1`.

## Scale and generality

Changes three files by +211/−7 lines. The nondegeneracy theorem is generic for reflexive bilinear forms over a field; the finrank result specializes to quadratic forms; the Pin correction needs a separably closed field and invertible `2`. No basis or coordinate choice is used.

## Scope

- **Consumes:** the one-vector Cartan-Dieudonne correction and existing Pin reflection lifts.
- **Provides:** nondegeneracy and Pin correction after adjoining one orthogonal anisotropic vector to a fixed subspace.
- **Fits:** supplies the induction step intended for Cartan-Dieudonne generation and global Pin surjectivity.
- **Boundary:** finite-dimensional iteration and the global group theorem belong to downstream slices.