### PR TITLE
docs(LinearAlgebra): the provenance listed a declaration the file omits

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/QuadraticFormCongruence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/QuadraticFormCongruence.lean
@@ -39,9 +39,12 @@ exported as a corollary.
 
 Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
 `HasseWeil/WeilPairing/Reduction.lean`, declarations `deg_eq_of_frobMatrix_data`,
-`qf_nonneg_of_frobMatrix_data`, `frob_det_congruence` and `deg_eq_of_frob_det_data`.
+`frob_det_congruence` and `deg_eq_of_frob_det_data`.
 
-Two deviations. The source's `det_smul_sub_smul_one_fin_two_of` takes `M.det = q` and
+Three deviations. The source's fourth declaration, `qf_nonneg_of_frobMatrix_data`, is **not**
+reproduced: it is a one-line `▸` transport of the equality theorem above it that repeats the whole
+matrix-data interface to do so, which is why the Main results section above leaves that step to
+consumers. The source's `det_smul_sub_smul_one_fin_two_of` takes `M.det = q` and
 `M.trace = t` as hypotheses; TauCeti already has the unconditional
 `Matrix.det_smul_sub_smul_one_fin_two` (merged as #2328), so that lemma is used and the
 hypotheses are substituted at the call site. And the source's `det_one_sub_fin_two` is not


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"qfc-provenance"}-->

Roadmap: EllipticCurves

Documentation only. No declaration, statement, proof or import changes.

`TauCeti/LinearAlgebra/Matrix/QuadraticFormCongruence.lean`, merged as #2434, contradicts itself
about what was ported. Its Main results section says

> When the realised integer is non-negative — as a degree is — non-negativity of the form follows
> by rewriting, `eq_quadratic_form_of_det_trace h ▸ hD`; that is left to consumers rather than
> exported as a corollary.

while the Provenance section four lines below lists `qf_nonneg_of_frobMatrix_data` — precisely
that non-negativity corollary — among the declarations the file is ported from.

Both halves were describing something true; the list was the wrong place to say it. The provenance
now names the three declarations actually represented here and states the fourth as a deliberate
omission, with the reason:

> Three deviations. The source's fourth declaration, `qf_nonneg_of_frobMatrix_data`, is **not**
> reproduced: it is a one-line `▸` transport of the equality theorem above it that repeats the
> whole matrix-data interface to do so, which is why the Main results section above leaves that
> step to consumers.

## Why separately

#2434 was `ready-to-merge` when I found this, and pushing a docstring commit at a PR whose every
rubric had gone green risks the banked state for a wording fix. It is corrected here instead, in a
change that touches nothing else.

## Provenance

The file itself is ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision
`513e83879e2f`, file `HasseWeil/WeilPairing/Reduction.lean`. This PR does not port anything; it
corrects that record.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 3 — the Hasse bound (AEC V.1)**, whose
arithmetic side this file serves. Under the repository's rules a documentation fix to existing
code needs no fresh roadmap claim; the attribution line names the roadmap the file belongs to.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` pass locally.
