### PR TITLE
feat: approximate identities on a compact group

### DIFF
--- a/TauCeti/Order/Filter/SmallSets.lean
+++ b/TauCeti/Order/Filter/SmallSets.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Order.Filter.SmallSets
+
+/-!
+# Indexing a net by the members of a filter
+
+A family indexed by the members of a filter `l` — a net of the shape `k : {s : Set α // s ∈ l} → β`
+— is naturally taken along `Filter.comap Subtype.val l.smallSets`, for which `∀ᶠ s in _, p s` says
+that `p` holds for every small enough member of `l`. This file records that this index filter is
+never the bottom filter, so that convergence along it has content.
+-/
+
+public section
+
+open Filter
+
+namespace TauCeti
+
+/-- **A filter indexes a nontrivial net by its own members.** A net indexed by the members of a
+filter `l` converges along this filter, the members read through `Filter.smallSets`, so that
+`∀ᶠ s in _, p s` says that `p` holds for every small enough member of `l`; it is not the bottom
+filter, every member of `l` being an index below itself. -/
+theorem comap_val_smallSets_neBot {α : Type*} (l : Filter α) :
+    NeBot (comap (Subtype.val : {s : Set α // s ∈ l} → Set α) l.smallSets) := by
+  refine comap_neBot_iff.2 fun t ht => ?_
+  obtain ⟨V, hV, hVt⟩ := eventually_smallSets.1 ht
+  exact ⟨⟨V, hV⟩, hVt V subset_rfl⟩
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
+++ b/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
@@ -308,14 +308,15 @@ theorem tendsto_convolutionCLM_toLp {ι : Type*} {l : Filter ι} {U : ι → Set
   exact ((hki.mono hi).norm_convolutionCLM_toLp_sub_le f (half_pos hε).le hfV).trans_lt
     (half_lt_self hε)
 
-omit [IsTopologicalGroup G] [CompactSpace G] [MeasurableSpace G] [BorelSpace G] in
-variable (G) in
-/-- **The neighbourhood-directed index filter is nontrivial.** A net indexed by the neighbourhoods
-of `1` converges along this filter, the neighbourhoods read through `Filter.smallSets`, so that
-`∀ᶠ U in _, p U` says that `p` holds for every neighbourhood of `1` small enough; it is not the
-bottom filter, every neighbourhood of `1` being an index below itself. -/
-theorem comap_val_smallSets_nhds_one_neBot :
-    NeBot (comap (Subtype.val : {U : Set G // U ∈ 𝓝 (1 : G)} → Set G) (𝓝 (1 : G)).smallSets) := by
+/-- **A filter indexes a nontrivial net by its own members.** A net indexed by the members of a
+filter `l` converges along this filter, the members read through `Filter.smallSets`, so that
+`∀ᶠ s in _, p s` says that `p` holds for every small enough member of `l`; it is not the bottom
+filter, every member of `l` being an index below itself.
+
+For `l = 𝓝 1` this is the index filter of
+`TauCeti.exists_isMollifier_tendsto_convolutionCLM_toLp`. -/
+theorem comap_val_smallSets_neBot {α : Type*} (l : Filter α) :
+    NeBot (comap (Subtype.val : {s : Set α // s ∈ l} → Set α) l.smallSets) := by
   refine comap_neBot_iff.2 fun t ht => ?_
   obtain ⟨V, hV, hVt⟩ := eventually_smallSets.1 ht
   exact ⟨⟨V, hV⟩, hVt V subset_rfl⟩
@@ -326,7 +327,7 @@ function.** There is a kernel `k U` for each neighbourhood `U` of the identity, 
 supported in `U`, such that for *every* continuous `f` the convolutions `k U * f` converge
 uniformly to `f` as `U` shrinks to the identity.
 
-The index filter is the one of `TauCeti.comap_val_smallSets_nhds_one_neBot`, which is nontrivial,
+The index filter is the one of `TauCeti.comap_val_smallSets_neBot` at `𝓝 1`, which is nontrivial,
 so the convergence has content. Unlike
 `TauCeti.exists_isMollifier_norm_convolutionCLM_toLp_sub_le`, where the kernel may depend on the
 function being approximated, the family here is chosen once and for all. -/

--- a/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
+++ b/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
@@ -19,8 +19,9 @@ changes it by as little as one likes in the uniform norm.
 A mollifying kernel is bundled as `TauCeti.IsMollifier U k`: the kernel is nonnegative, invariant
 under inversion, has unit mass for normalized Haar measure, and vanishes off `U`. Inversion
 invariance of a nonnegative kernel is the symmetry `k g⁻¹ = conj (k g)`, so `convolutionOperator k`
-is self-adjoint (`TauCeti.IsMollifier.isSelfAdjoint_convolutionOperator`); this is the hypothesis
-under which the spectral theorem applies to it.
+is self-adjoint (`TauCeti.IsMollifier.isSelfAdjoint_convolutionOperator`); this is one of the two
+hypotheses of the spectral theorem for compact self-adjoint operators, the other, compactness,
+being no concern of this file.
 
 ## Main definitions
 
@@ -41,6 +42,9 @@ under which the spectral theorem applies to it.
   kernel supported in `U` with `‖k * f - f‖ ≤ ε`.
 * `TauCeti.tendsto_convolutionCLM_toLp`: the same statement as convergence of a net of kernels
   whose supports shrink to `1`.
+* `TauCeti.exists_isMollifier_tendsto_convolutionCLM_toLp`: **the approximate identity as a single
+  family.** One mollifying kernel for each neighbourhood of `1`, whose convolutions converge
+  uniformly to `f` as the neighbourhood shrinks, simultaneously for every continuous `f`.
 
 ## Implementation notes
 
@@ -80,24 +84,24 @@ namespace TauCeti
 
 section CompactGroup
 
-variable {𝕜 G : Type*} [RCLike 𝕜] [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
-  [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
+variable {𝕜 E G : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [Group G] [TopologicalSpace G]
+  [IsTopologicalGroup G] [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
 
 /-! ### Uniform continuity on a compact group -/
 
 /-- The left translates `z ↦ (x ↦ f (z⁻¹ * x))` of a continuous function on a compact group,
-as a continuous map into `C(G, 𝕜)` with the uniform norm. -/
-private noncomputable def leftTranslateCM (f : C(G, 𝕜)) : C(G, C(G, 𝕜)) :=
+as a continuous map into `C(G, E)` with the uniform norm. -/
+private noncomputable def leftTranslateCM (f : C(G, E)) : C(G, C(G, E)) :=
   ContinuousMap.curry
     (f.comp ⟨fun p : G × G => p.1⁻¹ * p.2, continuous_fst.inv.mul continuous_snd⟩)
 
 omit [CompactSpace G] [MeasurableSpace G] [BorelSpace G] in
-private theorem leftTranslateCM_apply (f : C(G, 𝕜)) (z x : G) :
+private theorem leftTranslateCM_apply (f : C(G, E)) (z x : G) :
     leftTranslateCM f z x = f (z⁻¹ * x) :=
   (rfl)
 
 omit [CompactSpace G] [MeasurableSpace G] [BorelSpace G] in
-private theorem leftTranslateCM_one (f : C(G, 𝕜)) : leftTranslateCM f 1 = f := by
+private theorem leftTranslateCM_one (f : C(G, E)) : leftTranslateCM f 1 = f := by
   ext x
   rw [leftTranslateCM_apply, inv_one, one_mul]
 
@@ -107,11 +111,11 @@ a neighbourhood `V` of the identity such that translating the argument by any `z
 value of `f` by at most `ε`, *uniformly* in the argument.
 
 The uniform structure of `G` is not mentioned: the statement is continuity at `z = 1` of the map
-sending `z` to the left translate of `f` by `z`, which is continuous into `C(G, 𝕜)` for the
+sending `z` to the left translate of `f` by `z`, which is continuous into `C(G, E)` for the
 uniform norm because `G` is compact. -/
-theorem exists_mem_nhds_one_norm_sub_le (f : C(G, 𝕜)) {ε : ℝ} (hε : 0 < ε) :
+theorem exists_mem_nhds_one_norm_sub_le (f : C(G, E)) {ε : ℝ} (hε : 0 < ε) :
     ∃ V ∈ 𝓝 (1 : G), ∀ z ∈ V, ∀ x : G, ‖f (z⁻¹ * x) - f x‖ ≤ ε := by
-  have htendsto : Tendsto (leftTranslateCM (𝕜 := 𝕜) (G := G) f) (𝓝 1) (𝓝 f) := by
+  have htendsto : Tendsto (leftTranslateCM (E := E) (G := G) f) (𝓝 1) (𝓝 f) := by
     simpa only [leftTranslateCM_one] using (leftTranslateCM f).continuous.tendsto 1
   refine ⟨leftTranslateCM f ⁻¹' Metric.closedBall f ε,
     htendsto (Metric.closedBall_mem_nhds f hε), fun z hz x => ?_⟩
@@ -159,8 +163,9 @@ theorem inv_apply_eq_conj (h : IsMollifier U k) (g : G) : k g⁻¹ = (starRingEn
   rw [h.inv_apply]
   exact (RCLike.conj_eq_iff_im.2 (RCLike.nonneg_iff.1 (h.nonneg g)).2).symm
 
-/-- **The convolution operator of a mollifying kernel is self-adjoint**, so the spectral theorem
-for compact self-adjoint operators applies to it. -/
+/-- **The convolution operator of a mollifying kernel is self-adjoint.** This is one of the two
+hypotheses of the spectral theorem for compact self-adjoint operators; compactness of
+`convolutionOperator k` is a separate matter, not established here. -/
 theorem isSelfAdjoint_convolutionOperator (h : IsMollifier U k) :
     IsSelfAdjoint (convolutionOperator k) :=
   _root_.TauCeti.isSelfAdjoint_convolutionOperator k h.inv_apply_eq_conj
@@ -218,7 +223,7 @@ theorem exists_isMollifier [T2Space G] {U : Set G} (hU : U ∈ 𝓝 (1 : G)) :
     RCLike.continuous_ofReal.comp (continuous_const.mul ψ.continuous)⟩, ?_, ?_, ?_, ?_⟩
   · exact fun g => RCLike.ofReal_nonneg.2 (mul_nonneg (inv_nonneg.2 hmass.le) (hψ_nonneg g))
   · exact fun g => by simp only [ContinuousMap.coe_mk, hψ_inv]
-  · change ∫ g, ((c⁻¹ * ψ g : ℝ) : 𝕜) ∂(haarProb G) = 1
+  · simp only [ContinuousMap.coe_mk]
     rw [integral_ofReal, integral_const_mul, ← hcdef, inv_mul_cancel₀ hmass.ne',
       RCLike.ofReal_one]
   · exact fun g hg => by
@@ -292,17 +297,11 @@ theorem IsMollifier.norm_convolutionCLM_toLp_sub_le {U : Set G} {k : C(G, 𝕜)}
     · rw [norm_mul]
       exact mul_le_mul_of_nonneg_left (hf z hz x) (norm_nonneg _)
     · simp [h.eq_zero_of_notMem z hz]
-  have hint : Integrable (fun z : G => k z * (f (z⁻¹ * x) - f x)) (haarProb G) :=
-    integrable_continuousMap G
-      (⟨fun z => k z * (f (z⁻¹ * x) - f x),
-        k.continuous.mul
-          ((f.continuous.comp (continuous_id.inv.mul continuous_const)).sub continuous_const)⟩ :
-        C(G, 𝕜))
   rw [hval]
   calc ‖∫ z, k z * (f (z⁻¹ * x) - f x) ∂(haarProb G)‖
-      ≤ ∫ z, ‖k z * (f (z⁻¹ * x) - f x)‖ ∂(haarProb G) := norm_integral_le_integral_norm _
-    _ ≤ ∫ z, ‖k z‖ * ε ∂(haarProb G) :=
-        integral_mono hint.norm ((integrable_continuousMap G k).norm.mul_const ε) hbound
+      ≤ ∫ z, ‖k z‖ * ε ∂(haarProb G) :=
+        norm_integral_le_of_norm_le ((integrable_continuousMap G k).norm.mul_const ε)
+          (Eventually.of_forall hbound)
     _ = ε := by rw [integral_mul_const, h.integral_norm_eq_one, one_mul]
 
 variable (𝕜) in
@@ -327,8 +326,10 @@ variable (𝕜) in
 function is annihilated by every mollifying convolution operator, because convolving against a
 kernel supported near the identity moves a function by less than its own norm.
 
-This is why the Peter-Weyl argument can start: it guarantees a *nonzero* self-adjoint compact
-convolution operator to feed to the spectral theorem. -/
+This is why the Peter-Weyl argument can start: together with the self-adjointness above, and with
+compactness of `convolutionOperator k` established elsewhere, it supplies a *nonzero* operator to
+feed to the spectral theorem. Nonvanishing and self-adjointness are what is proved here;
+compactness is not. -/
 theorem exists_isMollifier_convolutionOperator_toLp_ne_zero [T2Space G] {f : C(G, 𝕜)} (hf : f ≠ 0)
     {U : Set G} (hU : U ∈ 𝓝 (1 : G)) :
     ∃ k : C(G, 𝕜), IsMollifier U k ∧
@@ -343,19 +344,50 @@ theorem exists_isMollifier_convolutionOperator_toLp_ne_zero [T2Space G] {f : C(G
   rw [hconv, zero_sub, norm_neg]
   exact half_lt_self hfpos
 
-/-- **The approximate identity as a net.** If the kernels `k i` are mollifying kernels whose
-supporting neighbourhoods `U i` eventually shrink inside every neighbourhood of the identity, then
-`k i * f` converges uniformly to `f` for every continuous `f`. -/
+/-- **The approximate identity as a net.** If the kernels `k i` are eventually mollifying kernels
+whose supporting neighbourhoods `U i` eventually shrink inside every neighbourhood of the identity,
+then `k i * f` converges uniformly to `f` for every continuous `f`. -/
 theorem tendsto_convolutionCLM_toLp {ι : Type*} {l : Filter ι} {U : ι → Set G} {k : ι → C(G, 𝕜)}
-    (hk : ∀ i, IsMollifier (U i) (k i)) (hU : ∀ V ∈ 𝓝 (1 : G), ∀ᶠ i in l, U i ⊆ V)
+    (hk : ∀ᶠ i in l, IsMollifier (U i) (k i)) (hU : ∀ V ∈ 𝓝 (1 : G), ∀ᶠ i in l, U i ⊆ V)
     (f : C(G, 𝕜)) :
     Tendsto (fun i => convolutionCLM (k i) (ContinuousMap.toLp 2 (haarProb G) 𝕜 f)) l (𝓝 f) := by
   refine Metric.tendsto_nhds.2 fun ε hε => ?_
   obtain ⟨V, hV, hfV⟩ := exists_mem_nhds_one_norm_sub_le f (half_pos hε)
-  filter_upwards [hU V hV] with i hi
+  filter_upwards [hk, hU V hV] with i hki hi
   rw [dist_eq_norm]
-  exact (((hk i).mono hi).norm_convolutionCLM_toLp_sub_le f (half_pos hε).le hfV).trans_lt
+  exact ((hki.mono hi).norm_convolutionCLM_toLp_sub_le f (half_pos hε).le hfV).trans_lt
     (half_lt_self hε)
+
+omit [IsTopologicalGroup G] [CompactSpace G] [MeasurableSpace G] [BorelSpace G] in
+variable (G) in
+/-- **The neighbourhood-directed index filter is nontrivial.** A net indexed by the neighbourhoods
+of `1` converges along this filter, the neighbourhoods read through `Filter.smallSets`, so that
+`∀ᶠ U in _, p U` says that `p` holds for every neighbourhood of `1` small enough; it is not the
+bottom filter, every neighbourhood of `1` being an index below itself. -/
+theorem neBot_comap_val_smallSets_nhds_one :
+    NeBot (comap (Subtype.val : {U : Set G // U ∈ 𝓝 (1 : G)} → Set G) (𝓝 (1 : G)).smallSets) := by
+  refine comap_neBot_iff.2 fun t ht => ?_
+  obtain ⟨V, hV, hVt⟩ := eventually_smallSets.1 ht
+  exact ⟨⟨V, hV⟩, hVt V subset_rfl⟩
+
+variable (𝕜 G) in
+/-- **The approximate identity itself: a single family of mollifying kernels that works for every
+function.** There is a kernel `k U` for each neighbourhood `U` of the identity, mollifying and
+supported in `U`, such that for *every* continuous `f` the convolutions `k U * f` converge
+uniformly to `f` as `U` shrinks to the identity.
+
+The index filter is the one of `TauCeti.neBot_comap_val_smallSets_nhds_one`, which is nontrivial,
+so the convergence has content. Unlike
+`TauCeti.exists_isMollifier_norm_convolutionCLM_toLp_sub_le`, where the kernel may depend on the
+function being approximated, the family here is chosen once and for all. -/
+theorem exists_isMollifier_tendsto_convolutionCLM_toLp [T2Space G] :
+    ∃ k : {U : Set G // U ∈ 𝓝 (1 : G)} → C(G, 𝕜), (∀ U, IsMollifier U.1 (k U)) ∧
+      ∀ f : C(G, 𝕜),
+        Tendsto (fun U => convolutionCLM (k U) (ContinuousMap.toLp 2 (haarProb G) 𝕜 f))
+          (comap Subtype.val (𝓝 (1 : G)).smallSets) (𝓝 f) := by
+  choose k hk using fun U : {U : Set G // U ∈ 𝓝 (1 : G)} => exists_isMollifier 𝕜 U.2
+  refine ⟨k, hk, fun f => tendsto_convolutionCLM_toLp (Eventually.of_forall hk) ?_ f⟩
+  exact fun V hV => (eventually_smallSets_subset.2 hV).comap Subtype.val
 
 end CompactGroup
 

--- a/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
+++ b/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
@@ -33,8 +33,6 @@ being no concern of this file.
 * `TauCeti.exists_mem_nhds_one_norm_sub_le`: uniform continuity of a continuous function on a
   compact group, in the form `‖f (z⁻¹ * x) - f x‖ ≤ ε` for `z` near `1`, uniformly in `x`.
 * `TauCeti.exists_isMollifier`: mollifying kernels exist supported in any neighbourhood of `1`.
-* `TauCeti.convolutionCLM_toLp_apply`: the translated form `(k * f) x = ∫ z, k z * f (z⁻¹ * x)` of
-  convolution against a continuous function.
 * `TauCeti.IsMollifier.norm_convolutionCLM_toLp_sub_le`: the uniform estimate
   `‖k * f - f‖ ≤ ε` for a kernel supported where `f` varies by at most `ε`.
 * `TauCeti.exists_isMollifier_norm_convolutionCLM_toLp_sub_le`: **the approximate identity.** For
@@ -230,55 +228,7 @@ theorem exists_isMollifier [T2Space G] {U : Set G} (hU : U ∈ 𝓝 (1 : G)) :
       simp only [ContinuousMap.coe_mk, hψ_zero g fun hc => hg (hWU hc), mul_zero,
         RCLike.ofReal_zero]
 
-/-! ### Convolution against a continuous function -/
-
-/-- **Convolution written by translating the function rather than the kernel**:
-`(k * f) x = ∫ z, k z * f (z⁻¹ * x)`.
-
-This is the form in which an approximate identity is read: the mass of `k` sits near `1`, so the
-integral averages the values of `f` near `x`. It follows from
-`TauCeti.convolutionCLM_apply_apply` by the substitution `y = z⁻¹ * x`, which preserves normalized
-Haar measure because it is inversion followed by right translation. -/
-theorem convolutionCLM_toLp_apply (k f : C(G, 𝕜)) (x : G) :
-    convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) x
-      = ∫ z, k z * f (z⁻¹ * x) ∂(haarProb G) := by
-  set F : G → 𝕜 := fun y => k (x * y⁻¹) * f y with hFdef
-  have hcoe : convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) x
-      = ∫ y, F y ∂(haarProb G) := by
-    rw [convolutionCLM_apply_apply]
-    refine integral_congr_ae ?_
-    filter_upwards [ContinuousMap.coeFn_toLp (E := 𝕜) (p := 2) (haarProb G) (𝕜 := 𝕜) f] with y hy
-    rw [hy]
-  rw [hcoe]
-  calc ∫ y, F y ∂(haarProb G)
-      = ∫ z, F (z * x) ∂(haarProb G) := (integral_mul_right_eq_self F x).symm
-    _ = ∫ z, F (z⁻¹ * x) ∂(haarProb G) :=
-        (integral_inv_eq_self (fun w => F (w * x)) (haarProb G)).symm
-    _ = ∫ z, k z * f (z⁻¹ * x) ∂(haarProb G) := by
-        refine integral_congr_ae (Eventually.of_forall fun z => ?_)
-        have hz : x * (z⁻¹ * x)⁻¹ = z := by group
-        rw [hFdef]
-        simp only [hz]
-
-/-- The error of an approximation of `f` by `k * f`, when the kernel `k` has unit mass: the average
-against `k` of the increments of `f`. -/
-theorem convolutionCLM_toLp_sub_apply (k f : C(G, 𝕜))
-    (hk : ∫ g, k g ∂(haarProb G) = 1) (x : G) :
-    convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) x - f x
-      = ∫ z, k z * (f (z⁻¹ * x) - f x) ∂(haarProb G) := by
-  have h₁ : Integrable (fun z : G => k z * f (z⁻¹ * x)) (haarProb G) :=
-    integrable_continuousMap G
-      (⟨fun z => k z * f (z⁻¹ * x),
-        k.continuous.mul (f.continuous.comp (continuous_id.inv.mul continuous_const))⟩ :
-        C(G, 𝕜))
-  have h₂ : Integrable (fun z : G => k z * f x) (haarProb G) :=
-    (integrable_continuousMap G k).mul_const _
-  rw [convolutionCLM_toLp_apply]
-  have hsplit : ∫ z, k z * (f (z⁻¹ * x) - f x) ∂(haarProb G)
-      = (∫ z, k z * f (z⁻¹ * x) ∂(haarProb G)) - ∫ z, k z * f x ∂(haarProb G) := by
-    simp_rw [mul_sub]
-    exact integral_sub h₁ h₂
-  rw [hsplit, integral_mul_const, hk, one_mul]
+/-! ### Approximate-identity estimates -/
 
 /-- **The approximate-identity estimate.** If a mollifying kernel is supported where `f` varies by
 at most `ε`, then convolving `f` against it changes `f` by at most `ε` in the uniform norm. -/
@@ -364,7 +314,7 @@ variable (G) in
 of `1` converges along this filter, the neighbourhoods read through `Filter.smallSets`, so that
 `∀ᶠ U in _, p U` says that `p` holds for every neighbourhood of `1` small enough; it is not the
 bottom filter, every neighbourhood of `1` being an index below itself. -/
-theorem neBot_comap_val_smallSets_nhds_one :
+theorem comap_val_smallSets_nhds_one_neBot :
     NeBot (comap (Subtype.val : {U : Set G // U ∈ 𝓝 (1 : G)} → Set G) (𝓝 (1 : G)).smallSets) := by
   refine comap_neBot_iff.2 fun t ht => ?_
   obtain ⟨V, hV, hVt⟩ := eventually_smallSets.1 ht
@@ -376,7 +326,7 @@ function.** There is a kernel `k U` for each neighbourhood `U` of the identity, 
 supported in `U`, such that for *every* continuous `f` the convolutions `k U * f` converge
 uniformly to `f` as `U` shrinks to the identity.
 
-The index filter is the one of `TauCeti.neBot_comap_val_smallSets_nhds_one`, which is nontrivial,
+The index filter is the one of `TauCeti.comap_val_smallSets_nhds_one_neBot`, which is nontrivial,
 so the convergence has content. Unlike
 `TauCeti.exists_isMollifier_norm_convolutionCLM_toLp_sub_le`, where the kernel may depend on the
 function being approximated, the family here is chosen once and for all. -/

--- a/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
+++ b/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Order.Filter.SmallSets
 public import TauCeti.RepresentationTheory.Compact.Convolution
 public import Mathlib.Topology.UrysohnsLemma
 
@@ -307,19 +308,6 @@ theorem tendsto_convolutionCLM_toLp {ι : Type*} {l : Filter ι} {U : ι → Set
   rw [dist_eq_norm]
   exact ((hki.mono hi).norm_convolutionCLM_toLp_sub_le f (half_pos hε).le hfV).trans_lt
     (half_lt_self hε)
-
-/-- **A filter indexes a nontrivial net by its own members.** A net indexed by the members of a
-filter `l` converges along this filter, the members read through `Filter.smallSets`, so that
-`∀ᶠ s in _, p s` says that `p` holds for every small enough member of `l`; it is not the bottom
-filter, every member of `l` being an index below itself.
-
-For `l = 𝓝 1` this is the index filter of
-`TauCeti.exists_isMollifier_tendsto_convolutionCLM_toLp`. -/
-theorem comap_val_smallSets_neBot {α : Type*} (l : Filter α) :
-    NeBot (comap (Subtype.val : {s : Set α // s ∈ l} → Set α) l.smallSets) := by
-  refine comap_neBot_iff.2 fun t ht => ?_
-  obtain ⟨V, hV, hVt⟩ := eventually_smallSets.1 ht
-  exact ⟨⟨V, hV⟩, hVt V subset_rfl⟩
 
 variable (𝕜 G) in
 /-- **The approximate identity itself: a single family of mollifying kernels that works for every

--- a/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
+++ b/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
@@ -1,0 +1,362 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Compact.Convolution
+public import Mathlib.Topology.UrysohnsLemma
+
+/-!
+# Approximate identities on a compact group
+
+Convolution against a continuous kernel smooths an `L²` class into a continuous function
+(`TauCeti.convolutionCLM`). This file supplies the kernels that make that smoothing harmless: for
+every neighbourhood `U` of the identity there is a **mollifying kernel** supported in `U`, and
+convolving a continuous function against a kernel supported in a small enough neighbourhood
+changes it by as little as one likes in the uniform norm.
+
+A mollifying kernel is bundled as `TauCeti.IsMollifier U k`: the kernel is nonnegative, invariant
+under inversion, has unit mass for normalized Haar measure, and vanishes off `U`. Inversion
+invariance of a nonnegative kernel is the symmetry `k g⁻¹ = conj (k g)`, so `convolutionOperator k`
+is self-adjoint (`TauCeti.IsMollifier.isSelfAdjoint_convolutionOperator`); this is the hypothesis
+under which the spectral theorem applies to it.
+
+## Main definitions
+
+* `TauCeti.IsMollifier`: `k` is a nonnegative, inversion-invariant, unit-mass continuous kernel
+  vanishing outside `U`.
+
+## Main statements
+
+* `TauCeti.exists_mem_nhds_one_norm_sub_le`: uniform continuity of a continuous function on a
+  compact group, in the form `‖f (z⁻¹ * x) - f x‖ ≤ ε` for `z` near `1`, uniformly in `x`.
+* `TauCeti.exists_isMollifier`: mollifying kernels exist supported in any neighbourhood of `1`.
+* `TauCeti.convolutionCLM_toLp_apply`: the translated form `(k * f) x = ∫ z, k z * f (z⁻¹ * x)` of
+  convolution against a continuous function.
+* `TauCeti.IsMollifier.norm_convolutionCLM_toLp_sub_le`: the uniform estimate
+  `‖k * f - f‖ ≤ ε` for a kernel supported where `f` varies by at most `ε`.
+* `TauCeti.exists_isMollifier_norm_convolutionCLM_toLp_sub_le`: **the approximate identity.** For
+  every continuous `f`, every `ε > 0` and every neighbourhood `U` of `1` there is a mollifying
+  kernel supported in `U` with `‖k * f - f‖ ≤ ε`.
+* `TauCeti.tendsto_convolutionCLM_toLp`: the same statement as convergence of a net of kernels
+  whose supports shrink to `1`.
+
+## Implementation notes
+
+Uniform continuity is obtained from the same currying trick that builds the kernel sections in
+`TauCeti/RepresentationTheory/Compact/Convolution.lean`: the left translates `z ↦ (x ↦ f (z⁻¹ * x))`
+assemble into a *continuous* map `G → C(G, 𝕜)` for the uniform norm, and continuity at `z = 1` is
+exactly the uniform estimate. No uniform structure on `G` is mentioned.
+
+The kernels themselves come from Urysohn's lemma, which needs `G` to be Hausdorff (a compact
+Hausdorff group is regular and locally compact); this is the standing convention of the roadmap and
+the only place in the compact-group development where `T2Space G` is used so far. A bump at the
+identity supported in a *symmetric* neighbourhood is made inversion invariant by adding its
+composition with inversion, and then normalized by its mass, which is positive because Haar measure
+is positive on nonempty open sets.
+
+Kernels take values in `𝕜` rather than in `ℝ` because that is what `convolutionCLM` consumes;
+nonnegativity is stated with the scoped `ComplexOrder` instance on an `RCLike` field, for which
+`0 ≤ z` means `z` is real and nonnegative.
+
+## References
+
+This is `approx_identity_exists` from Layer 5 of the
+[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap), the last input to the
+uniform density of the matrix coefficients in `C(G)` that the roadmap's non-circular route to the
+Peter-Weyl theorem requires.
+
+* G. B. Folland, *A Course in Abstract Harmonic Analysis*, 2nd ed., CRC (2016), Chapter 5.
+* D. Bump, *Lie Groups*, 2nd ed., Springer GTM 225 (2013), Chapter 2.
+-/
+
+public section
+
+open Filter MeasureTheory Set
+open scoped ComplexOrder Topology
+
+namespace TauCeti
+
+section CompactGroup
+
+variable {𝕜 G : Type*} [RCLike 𝕜] [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
+
+/-! ### Uniform continuity on a compact group -/
+
+/-- The left translates `z ↦ (x ↦ f (z⁻¹ * x))` of a continuous function on a compact group,
+as a continuous map into `C(G, 𝕜)` with the uniform norm. -/
+private noncomputable def leftTranslateCM (f : C(G, 𝕜)) : C(G, C(G, 𝕜)) :=
+  ContinuousMap.curry
+    (f.comp ⟨fun p : G × G => p.1⁻¹ * p.2, continuous_fst.inv.mul continuous_snd⟩)
+
+omit [CompactSpace G] [MeasurableSpace G] [BorelSpace G] in
+private theorem leftTranslateCM_apply (f : C(G, 𝕜)) (z x : G) :
+    leftTranslateCM f z x = f (z⁻¹ * x) :=
+  (rfl)
+
+omit [CompactSpace G] [MeasurableSpace G] [BorelSpace G] in
+private theorem leftTranslateCM_one (f : C(G, 𝕜)) : leftTranslateCM f 1 = f := by
+  ext x
+  rw [leftTranslateCM_apply, inv_one, one_mul]
+
+omit [MeasurableSpace G] [BorelSpace G] in
+/-- **Uniform continuity of a continuous function on a compact group.** For every `ε > 0` there is
+a neighbourhood `V` of the identity such that translating the argument by any `z ∈ V` moves the
+value of `f` by at most `ε`, *uniformly* in the argument.
+
+The uniform structure of `G` is not mentioned: the statement is continuity at `z = 1` of the map
+sending `z` to the left translate of `f` by `z`, which is continuous into `C(G, 𝕜)` for the
+uniform norm because `G` is compact. -/
+theorem exists_mem_nhds_one_norm_sub_le (f : C(G, 𝕜)) {ε : ℝ} (hε : 0 < ε) :
+    ∃ V ∈ 𝓝 (1 : G), ∀ z ∈ V, ∀ x : G, ‖f (z⁻¹ * x) - f x‖ ≤ ε := by
+  have htendsto : Tendsto (leftTranslateCM (𝕜 := 𝕜) (G := G) f) (𝓝 1) (𝓝 f) := by
+    simpa only [leftTranslateCM_one] using (leftTranslateCM f).continuous.tendsto 1
+  refine ⟨leftTranslateCM f ⁻¹' Metric.closedBall f ε,
+    htendsto (Metric.closedBall_mem_nhds f hε), fun z hz x => ?_⟩
+  have hz' : ‖leftTranslateCM f z - f‖ ≤ ε := by
+    simpa only [mem_preimage, Metric.mem_closedBall, dist_eq_norm] using hz
+  calc ‖f (z⁻¹ * x) - f x‖
+      = ‖(leftTranslateCM f z - f) x‖ := by rw [ContinuousMap.sub_apply, leftTranslateCM_apply]
+    _ ≤ ‖leftTranslateCM f z - f‖ := (leftTranslateCM f z - f).norm_coe_le_norm x
+    _ ≤ ε := hz'
+
+/-! ### Mollifying kernels -/
+
+/-- A **mollifying kernel supported in `U`**: a continuous kernel on a compact group which is
+nonnegative, invariant under inversion, of unit mass for normalized Haar measure, and zero outside
+`U`.
+
+Nonnegativity is taken in the scoped `ComplexOrder` order of the `RCLike` field `𝕜`, so it says in
+particular that `k` is real-valued. Together with inversion invariance it gives the symmetry
+`k g⁻¹ = conj (k g)` that makes `convolutionOperator k` self-adjoint. -/
+structure IsMollifier (U : Set G) (k : C(G, 𝕜)) : Prop where
+  /-- A mollifying kernel is nonnegative, hence real-valued. -/
+  nonneg : ∀ g, 0 ≤ k g
+  /-- A mollifying kernel is invariant under inversion. -/
+  inv_apply : ∀ g, k g⁻¹ = k g
+  /-- A mollifying kernel has unit mass for normalized Haar measure. -/
+  integral_eq_one : ∫ g, k g ∂(haarProb G) = 1
+  /-- A mollifying kernel supported in `U` vanishes outside `U`. -/
+  eq_zero_of_notMem : ∀ g ∉ U, k g = 0
+
+namespace IsMollifier
+
+variable {U U' : Set G} {k : C(G, 𝕜)}
+
+/-- Enlarging the neighbourhood a kernel is supported in. -/
+theorem mono (h : IsMollifier U k) (hUU' : U ⊆ U') : IsMollifier U' k :=
+  { h with eq_zero_of_notMem := fun g hg => h.eq_zero_of_notMem g fun hg' => hg (hUU' hg') }
+
+/-- A mollifying kernel is its own norm: it takes nonnegative real values. -/
+theorem apply_eq_norm (h : IsMollifier U k) (g : G) : k g = (‖k g‖ : 𝕜) :=
+  (RCLike.norm_of_nonneg' (h.nonneg g)).symm
+
+/-- A mollifying kernel is symmetric in the sense required for self-adjointness of the associated
+convolution operator: inversion invariance and real-valuedness combine to `k g⁻¹ = conj (k g)`. -/
+theorem inv_apply_eq_conj (h : IsMollifier U k) (g : G) : k g⁻¹ = (starRingEnd 𝕜) (k g) := by
+  rw [h.inv_apply]
+  exact (RCLike.conj_eq_iff_im.2 (RCLike.nonneg_iff.1 (h.nonneg g)).2).symm
+
+/-- **The convolution operator of a mollifying kernel is self-adjoint**, so the spectral theorem
+for compact self-adjoint operators applies to it. -/
+theorem isSelfAdjoint_convolutionOperator (h : IsMollifier U k) :
+    IsSelfAdjoint (convolutionOperator k) :=
+  _root_.TauCeti.isSelfAdjoint_convolutionOperator k h.inv_apply_eq_conj
+
+/-- A mollifying kernel has unit `L¹` norm. -/
+theorem integral_norm_eq_one (h : IsMollifier U k) : ∫ g, ‖k g‖ ∂(haarProb G) = 1 := by
+  have hcast : ((∫ g, ‖k g‖ ∂(haarProb G) : ℝ) : 𝕜) = 1 := by
+    rw [← integral_ofReal, ← h.integral_eq_one]
+    exact integral_congr_ae (Eventually.of_forall fun g => (h.apply_eq_norm g).symm)
+  exact_mod_cast hcast
+
+end IsMollifier
+
+variable (𝕜) in
+/-- **Mollifying kernels exist, supported in any prescribed neighbourhood of the identity.**
+
+The kernel is built from a Urysohn bump at the identity supported in a symmetric open
+neighbourhood, made inversion invariant by adding its composition with inversion, and normalized by
+its mass, which is positive because Haar measure is positive on nonempty open sets. -/
+theorem exists_isMollifier [T2Space G] {U : Set G} (hU : U ∈ 𝓝 (1 : G)) :
+    ∃ k : C(G, 𝕜), IsMollifier U k := by
+  obtain ⟨V, hVU, hVopen, hV1⟩ := mem_nhds_iff.1 hU
+  -- A symmetric open neighbourhood of `1` inside `U`.
+  set W : Set G := V ∩ V⁻¹
+  have hWopen : IsOpen W := hVopen.inter hVopen.inv
+  have hW1 : (1 : G) ∈ W := ⟨hV1, by simpa using hV1⟩
+  have hWU : W ⊆ U := inter_subset_left.trans hVU
+  have hWsymm : ∀ g : G, g ∈ W → g⁻¹ ∈ W := by
+    rintro g ⟨h1, h2⟩
+    exact ⟨by simpa using h2, by simpa using h1⟩
+  obtain ⟨φ, hφ1, hφ0, -, hφIcc⟩ :=
+    exists_continuous_one_zero_of_isCompact (X := G) isCompact_singleton hWopen.isClosed_compl
+      (disjoint_compl_right_iff_subset.2 (singleton_subset_iff.2 hW1))
+  -- Symmetrize the bump.
+  set ψ : C(G, ℝ) := φ + φ.comp ⟨Inv.inv, continuous_inv⟩
+  have hψ_apply : ∀ g : G, ψ g = φ g + φ g⁻¹ := fun _ => rfl
+  have hψ_nonneg : ∀ g : G, 0 ≤ ψ g := fun g => by
+    rw [hψ_apply]
+    exact add_nonneg (hφIcc g).1 (hφIcc g⁻¹).1
+  have hψ_inv : ∀ g : G, ψ g⁻¹ = ψ g := fun g => by
+    rw [hψ_apply, hψ_apply, inv_inv, add_comm]
+  have hψ_zero : ∀ g ∉ W, ψ g = 0 := fun g hg => by
+    have hg' : g⁻¹ ∉ W := fun hc => hg (by simpa using hWsymm _ hc)
+    simp only [hψ_apply, hφ0 hg, hφ0 hg', Pi.zero_apply, add_zero]
+  have hψ_one : ψ 1 = 2 := by
+    rw [hψ_apply, inv_one, hφ1 rfl]
+    norm_num
+  -- Its mass is positive, so it can be normalized.
+  have hψ_int : Integrable ψ (haarProb G) := integrable_continuousMap G ψ
+  have hmass : 0 < ∫ g, ψ g ∂(haarProb G) := by
+    refine (integral_pos_iff_support_of_nonneg hψ_nonneg hψ_int).2 ?_
+    exact ψ.continuous.isOpen_support.measure_pos _ ⟨1, by simp [Function.mem_support, hψ_one]⟩
+  set c : ℝ := ∫ g, ψ g ∂(haarProb G) with hcdef
+  refine ⟨⟨fun g => ((c⁻¹ * ψ g : ℝ) : 𝕜),
+    RCLike.continuous_ofReal.comp (continuous_const.mul ψ.continuous)⟩, ?_, ?_, ?_, ?_⟩
+  · exact fun g => RCLike.ofReal_nonneg.2 (mul_nonneg (inv_nonneg.2 hmass.le) (hψ_nonneg g))
+  · exact fun g => by simp only [ContinuousMap.coe_mk, hψ_inv]
+  · change ∫ g, ((c⁻¹ * ψ g : ℝ) : 𝕜) ∂(haarProb G) = 1
+    rw [integral_ofReal, integral_const_mul, ← hcdef, inv_mul_cancel₀ hmass.ne',
+      RCLike.ofReal_one]
+  · exact fun g hg => by
+      simp only [ContinuousMap.coe_mk, hψ_zero g fun hc => hg (hWU hc), mul_zero,
+        RCLike.ofReal_zero]
+
+/-! ### Convolution against a continuous function -/
+
+/-- **Convolution written by translating the function rather than the kernel**:
+`(k * f) x = ∫ z, k z * f (z⁻¹ * x)`.
+
+This is the form in which an approximate identity is read: the mass of `k` sits near `1`, so the
+integral averages the values of `f` near `x`. It follows from
+`TauCeti.convolutionCLM_apply_apply` by the substitution `y = z⁻¹ * x`, which preserves normalized
+Haar measure because it is inversion followed by right translation. -/
+theorem convolutionCLM_toLp_apply (k f : C(G, 𝕜)) (x : G) :
+    convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) x
+      = ∫ z, k z * f (z⁻¹ * x) ∂(haarProb G) := by
+  set F : G → 𝕜 := fun y => k (x * y⁻¹) * f y with hFdef
+  have hcoe : convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) x
+      = ∫ y, F y ∂(haarProb G) := by
+    rw [convolutionCLM_apply_apply]
+    refine integral_congr_ae ?_
+    filter_upwards [ContinuousMap.coeFn_toLp (E := 𝕜) (p := 2) (haarProb G) (𝕜 := 𝕜) f] with y hy
+    rw [hy]
+  rw [hcoe]
+  calc ∫ y, F y ∂(haarProb G)
+      = ∫ z, F (z * x) ∂(haarProb G) := (integral_mul_right_eq_self F x).symm
+    _ = ∫ z, F (z⁻¹ * x) ∂(haarProb G) :=
+        (integral_inv_eq_self (fun w => F (w * x)) (haarProb G)).symm
+    _ = ∫ z, k z * f (z⁻¹ * x) ∂(haarProb G) := by
+        refine integral_congr_ae (Eventually.of_forall fun z => ?_)
+        have hz : x * (z⁻¹ * x)⁻¹ = z := by group
+        rw [hFdef]
+        simp only [hz]
+
+/-- The error of an approximation of `f` by `k * f`, when the kernel `k` has unit mass: the average
+against `k` of the increments of `f`. -/
+theorem convolutionCLM_toLp_sub_apply (k f : C(G, 𝕜))
+    (hk : ∫ g, k g ∂(haarProb G) = 1) (x : G) :
+    convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) x - f x
+      = ∫ z, k z * (f (z⁻¹ * x) - f x) ∂(haarProb G) := by
+  have h₁ : Integrable (fun z : G => k z * f (z⁻¹ * x)) (haarProb G) :=
+    integrable_continuousMap G
+      (⟨fun z => k z * f (z⁻¹ * x),
+        k.continuous.mul (f.continuous.comp (continuous_id.inv.mul continuous_const))⟩ :
+        C(G, 𝕜))
+  have h₂ : Integrable (fun z : G => k z * f x) (haarProb G) :=
+    (integrable_continuousMap G k).mul_const _
+  rw [convolutionCLM_toLp_apply]
+  have hsplit : ∫ z, k z * (f (z⁻¹ * x) - f x) ∂(haarProb G)
+      = (∫ z, k z * f (z⁻¹ * x) ∂(haarProb G)) - ∫ z, k z * f x ∂(haarProb G) := by
+    simp_rw [mul_sub]
+    exact integral_sub h₁ h₂
+  rw [hsplit, integral_mul_const, hk, one_mul]
+
+/-- **The approximate-identity estimate.** If a mollifying kernel is supported where `f` varies by
+at most `ε`, then convolving `f` against it changes `f` by at most `ε` in the uniform norm. -/
+theorem IsMollifier.norm_convolutionCLM_toLp_sub_le {U : Set G} {k : C(G, 𝕜)}
+    (h : IsMollifier U k) (f : C(G, 𝕜)) {ε : ℝ} (hε : 0 ≤ ε)
+    (hf : ∀ z ∈ U, ∀ x : G, ‖f (z⁻¹ * x) - f x‖ ≤ ε) :
+    ‖convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) - f‖ ≤ ε := by
+  refine (ContinuousMap.norm_le _ hε).2 fun x => ?_
+  have hval : (convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) - f) x
+      = ∫ z, k z * (f (z⁻¹ * x) - f x) ∂(haarProb G) := by
+    rw [ContinuousMap.sub_apply]
+    exact convolutionCLM_toLp_sub_apply k f h.integral_eq_one x
+  have hbound : ∀ z : G, ‖k z * (f (z⁻¹ * x) - f x)‖ ≤ ‖k z‖ * ε := by
+    intro z
+    by_cases hz : z ∈ U
+    · rw [norm_mul]
+      exact mul_le_mul_of_nonneg_left (hf z hz x) (norm_nonneg _)
+    · simp [h.eq_zero_of_notMem z hz]
+  have hint : Integrable (fun z : G => k z * (f (z⁻¹ * x) - f x)) (haarProb G) :=
+    integrable_continuousMap G
+      (⟨fun z => k z * (f (z⁻¹ * x) - f x),
+        k.continuous.mul
+          ((f.continuous.comp (continuous_id.inv.mul continuous_const)).sub continuous_const)⟩ :
+        C(G, 𝕜))
+  rw [hval]
+  calc ‖∫ z, k z * (f (z⁻¹ * x) - f x) ∂(haarProb G)‖
+      ≤ ∫ z, ‖k z * (f (z⁻¹ * x) - f x)‖ ∂(haarProb G) := norm_integral_le_integral_norm _
+    _ ≤ ∫ z, ‖k z‖ * ε ∂(haarProb G) :=
+        integral_mono hint.norm ((integrable_continuousMap G k).norm.mul_const ε) hbound
+    _ = ε := by rw [integral_mul_const, h.integral_norm_eq_one, one_mul]
+
+variable (𝕜) in
+/-- **Approximate identities exist on a compact group.** For every continuous `f`, every `ε > 0`
+and every neighbourhood `U` of the identity there is a mollifying kernel supported in `U` whose
+convolution with `f` is uniformly within `ε` of `f`.
+
+This is the input to the uniform density of the matrix coefficients in `C(G)`: a continuous
+function is approximated by convolutions, and convolutions are decomposed spectrally into finitely
+many matrix coefficients. -/
+theorem exists_isMollifier_norm_convolutionCLM_toLp_sub_le [T2Space G] (f : C(G, 𝕜)) {ε : ℝ}
+    (hε : 0 < ε) {U : Set G} (hU : U ∈ 𝓝 (1 : G)) :
+    ∃ k : C(G, 𝕜), IsMollifier U k ∧
+      ‖convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) - f‖ ≤ ε := by
+  obtain ⟨V, hV, hfV⟩ := exists_mem_nhds_one_norm_sub_le f hε
+  obtain ⟨k, hk⟩ := exists_isMollifier 𝕜 (Filter.inter_mem hU hV)
+  exact ⟨k, hk.mono inter_subset_left,
+    hk.norm_convolutionCLM_toLp_sub_le f hε.le fun z hz => hfV z hz.2⟩
+
+variable (𝕜) in
+/-- **The mollifying convolution operators are jointly nondegenerate.** No nonzero continuous
+function is annihilated by every mollifying convolution operator, because convolving against a
+kernel supported near the identity moves a function by less than its own norm.
+
+This is why the Peter-Weyl argument can start: it guarantees a *nonzero* self-adjoint compact
+convolution operator to feed to the spectral theorem. -/
+theorem exists_isMollifier_convolutionOperator_toLp_ne_zero [T2Space G] {f : C(G, 𝕜)} (hf : f ≠ 0)
+    {U : Set G} (hU : U ∈ 𝓝 (1 : G)) :
+    ∃ k : C(G, 𝕜), IsMollifier U k ∧
+      convolutionOperator k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) ≠ 0 := by
+  have hfpos : 0 < ‖f‖ := norm_pos_iff.2 hf
+  obtain ⟨k, hk, hle⟩ :=
+    exists_isMollifier_norm_convolutionCLM_toLp_sub_le 𝕜 f (half_pos hfpos) hU
+  refine ⟨k, hk, fun hzero => absurd hle (not_le.2 ?_)⟩
+  rw [convolutionOperator_apply] at hzero
+  have hconv : convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) = 0 :=
+    ContinuousMap.toLp_injective (haarProb G) (by rw [hzero, map_zero])
+  rw [hconv, zero_sub, norm_neg]
+  exact half_lt_self hfpos
+
+/-- **The approximate identity as a net.** If the kernels `k i` are mollifying kernels whose
+supporting neighbourhoods `U i` eventually shrink inside every neighbourhood of the identity, then
+`k i * f` converges uniformly to `f` for every continuous `f`. -/
+theorem tendsto_convolutionCLM_toLp {ι : Type*} {l : Filter ι} {U : ι → Set G} {k : ι → C(G, 𝕜)}
+    (hk : ∀ i, IsMollifier (U i) (k i)) (hU : ∀ V ∈ 𝓝 (1 : G), ∀ᶠ i in l, U i ⊆ V)
+    (f : C(G, 𝕜)) :
+    Tendsto (fun i => convolutionCLM (k i) (ContinuousMap.toLp 2 (haarProb G) 𝕜 f)) l (𝓝 f) := by
+  refine Metric.tendsto_nhds.2 fun ε hε => ?_
+  obtain ⟨V, hV, hfV⟩ := exists_mem_nhds_one_norm_sub_le f (half_pos hε)
+  filter_upwards [hU V hV] with i hi
+  rw [dist_eq_norm]
+  exact (((hk i).mono hi).norm_convolutionCLM_toLp_sub_le f (half_pos hε).le hfV).trans_lt
+    (half_lt_self hε)
+
+end CompactGroup
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Compact/Convolution.lean
+++ b/TauCeti/RepresentationTheory/Compact/Convolution.lean
@@ -39,6 +39,8 @@ manufactures finite-dimensional representations of `G` without presupposing that
 
 * `TauCeti.convolutionCLM_apply_apply`: the pointwise formula
   `(k * f) x = ∫ y, k (x * y⁻¹) * f y`.
+* `TauCeti.convolutionCLM_toLp_apply`: the translated formula
+  `(k * f) x = ∫ z, k z * f (z⁻¹ * x)` when `f` is continuous.
 * `TauCeti.norm_convolutionCLM_apply_le`: `‖k * f‖_∞ ≤ ‖k‖_∞ * ‖f‖₂`, so convolution against a
   continuous kernel is bounded from `L²(G)` into the uniform norm of `C(G)`.
 * `TauCeti.isSelfAdjoint_convolutionOperator`: a symmetric kernel gives a self-adjoint operator.
@@ -182,6 +184,52 @@ theorem convolutionCLM_apply_apply (k : C(G, 𝕜)) (f : Lp 𝕜 2 (haarProb G))
   rw [convolutionCLM_apply_apply', convSection_apply, inner_toLp_left]
   refine integral_congr_ae (Filter.Eventually.of_forall fun y => ?_)
   simp only [convSectionCM_apply, RCLike.conj_conj]
+
+/-- **Convolution written by translating the function rather than the kernel**:
+`(k * f) x = ∫ z, k z * f (z⁻¹ * x)`.
+
+This form follows from `TauCeti.convolutionCLM_apply_apply` by the substitution `y = z⁻¹ * x`,
+which preserves normalized Haar measure because it is inversion followed by right translation. -/
+theorem convolutionCLM_toLp_apply (k f : C(G, 𝕜)) (x : G) :
+    convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) x
+      = ∫ z, k z * f (z⁻¹ * x) ∂(haarProb G) := by
+  set F : G → 𝕜 := fun y => k (x * y⁻¹) * f y with hFdef
+  have hcoe : convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) x
+      = ∫ y, F y ∂(haarProb G) := by
+    rw [convolutionCLM_apply_apply]
+    refine integral_congr_ae ?_
+    filter_upwards [ContinuousMap.coeFn_toLp (E := 𝕜) (p := 2) (haarProb G) (𝕜 := 𝕜) f] with y hy
+    rw [hy]
+  rw [hcoe]
+  calc ∫ y, F y ∂(haarProb G)
+      = ∫ z, F (z * x) ∂(haarProb G) := (integral_mul_right_eq_self F x).symm
+    _ = ∫ z, F (z⁻¹ * x) ∂(haarProb G) :=
+        (integral_inv_eq_self (fun w => F (w * x)) (haarProb G)).symm
+    _ = ∫ z, k z * f (z⁻¹ * x) ∂(haarProb G) := by
+        refine integral_congr_ae (Filter.Eventually.of_forall fun z => ?_)
+        have hz : x * (z⁻¹ * x)⁻¹ = z := by group
+        rw [hFdef]
+        simp only [hz]
+
+/-- The error of an approximation of `f` by `k * f`, when the kernel `k` has unit mass: the average
+against `k` of the increments of `f`. -/
+theorem convolutionCLM_toLp_sub_apply (k f : C(G, 𝕜))
+    (hk : ∫ g, k g ∂(haarProb G) = 1) (x : G) :
+    convolutionCLM k (ContinuousMap.toLp 2 (haarProb G) 𝕜 f) x - f x
+      = ∫ z, k z * (f (z⁻¹ * x) - f x) ∂(haarProb G) := by
+  have h₁ : Integrable (fun z : G => k z * f (z⁻¹ * x)) (haarProb G) :=
+    integrable_continuousMap G
+      (⟨fun z => k z * f (z⁻¹ * x),
+        k.continuous.mul (f.continuous.comp (continuous_id.inv.mul continuous_const))⟩ :
+        C(G, 𝕜))
+  have h₂ : Integrable (fun z : G => k z * f x) (haarProb G) :=
+    (integrable_continuousMap G k).mul_const _
+  rw [convolutionCLM_toLp_apply]
+  have hsplit : ∫ z, k z * (f (z⁻¹ * x) - f x) ∂(haarProb G)
+      = (∫ z, k z * f (z⁻¹ * x) ∂(haarProb G)) - ∫ z, k z * f x ∂(haarProb G) := by
+    simp_rw [mul_sub]
+    exact integral_sub h₁ h₂
+  rw [hsplit, integral_mul_const, hk, one_mul]
 
 private theorem integrable_convolution_integrand (k : C(G, 𝕜))
     (f : Lp 𝕜 2 (haarProb G)) (x : G) :


### PR DESCRIPTION
This PR builds approximate identities on a compact group: for every neighbourhood `U` of the identity there is a **mollifying kernel** supported in `U` — continuous, nonnegative, invariant under inversion, of unit mass for normalized Haar measure — and convolving a continuous function against a kernel supported in a small enough neighbourhood changes it by as little as one likes in the uniform norm.

The milestone is Layer 5 of `RepresentationTheory/CompactGroups/README.md`, the analytic core of the Peter-Weyl theorem, whose non-circular route the roadmap spells out as `convolutionOperator` → `convolutionOperator_isCompact` → `convolutionOperator_isSelfAdjoint` → `nonzero_eigenspace_finite_dim_continuous_rep` → `approx_identity_exists` → `representativeStarSubalgebra_dense`. `approx_identity_exists` is the named target here, and it is the one step of that chain that depends on nothing else in it: `convolutionCLM` and its self-adjointness landed in TauCeti#2318, compactness and the eigenspaces are in flight in TauCeti#2448, and this PR supplies the remaining independent input. What remains on the milestone after this PR is assembling the eigenspaces into `ContRepresentation`s and then the uniform density of the representative ring in `C(G)`, which combines the two halves.

The deliverable is bundled as a predicate `IsMollifier U k`, with the four properties as fields, together with:

- `exists_isMollifier`, the existence of such a kernel in any neighbourhood of `1`;
- `IsMollifier.isSelfAdjoint_convolutionOperator`, since inversion invariance of a nonnegative kernel *is* the symmetry `k g⁻¹ = conj (k g)` that TauCeti#2318 asks for, so these are exactly the kernels the spectral theorem may be applied to;
- `IsMollifier.norm_convolutionCLM_toLp_sub_le`, the uniform estimate for any kernel supported where `f` varies little;
- `exists_isMollifier_norm_convolutionCLM_toLp_sub_le`, the approximate identity itself, and `tendsto_convolutionCLM_toLp`, the same statement for a net of kernels whose supports shrink to `1`;
- `exists_isMollifier_convolutionOperator_toLp_ne_zero`, the corollary that no nonzero continuous function is annihilated by every mollifying convolution operator, which is what will produce a *nonzero* compact self-adjoint operator to feed to the spectral theorem.

Two supporting statements are of independent use. `exists_mem_nhds_one_norm_sub_le` is uniform continuity of a continuous function on a compact group, in the translation-increment form the estimate needs; it is proved by the currying trick already used for the kernel sections in `Convolution.lean` — the left translates `z ↦ (x ↦ f (z⁻¹ * x))` assemble into a continuous map into `C(G, 𝕜)` for the uniform norm, and continuity at `z = 1` is the uniform estimate — so no uniform structure has to be put on `G`, which matters because Mathlib deliberately keeps `IsTopologicalGroup.toUniformSpace` a `def`. `convolutionCLM_toLp_apply` rewrites convolution by translating the function rather than the kernel, `(k * f) x = ∫ z, k z * f (z⁻¹ * x)`; the substitution `y = z⁻¹ * x` preserves normalized Haar measure because it is inversion followed by right translation, both already available from `Haar.lean`.

The kernels come from Mathlib's `exists_continuous_one_zero_of_isCompact`, applied to a *symmetric* open neighbourhood `V ∩ V⁻¹`, so that adding the bump to its composition with inversion makes it inversion invariant without enlarging its support; normalization uses `integral_pos_iff_support_of_nonneg` and the fact that Haar measure is positive on nonempty open sets. This is the first place in the compact-group development to need `T2Space G`, which Urysohn's lemma requires and which is the roadmap's standing convention for `G`; it is assumed only on the declarations that construct a kernel, not on the estimates. Nonnegativity of a kernel is stated with the scoped `ComplexOrder` order on the `RCLike` field, where `0 ≤ z` says exactly that `z` is real and nonnegative. No Mathlib source is vendored, and nothing is derived from the supplementary source snapshot.

The new module is `TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean`, 362 lines. It is a new file rather than an addition to `Convolution.lean` because it is about the kernels rather than about the operator, and because it is the first file here to need Urysohn's lemma and `T2Space G`.

Validation: `lake exe cache get` reports `No files to download`, `lake build` reports `Build completed successfully (7105 jobs).`, and `lake exe axioms` reports `axioms: audited 30290 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"approx-identity-exists"}-->

🤖 Prepared with Claude Code
