### PR TITLE
refactor(Hyperbolic): name the real comparison function behind the length lower bound

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
@@ -504,17 +504,49 @@ theorem hyperbolicLength_comp_eq_of_leftInvOn {f g : ℂ → ℂ}
 
 /-! ## The distance is a lower bound for the length -/
 
-/-- The lower bound for a path issued from the origin, where the hyperbolic distance to the
-endpoint is `Real.artanh` of its Euclidean norm. Comparing with the real function
-`t ↦ (v * γ t).re` for a suitable unit vector `v` — rather than with `t ↦ ‖γ t‖`, which need not
-be differentiable — turns the estimate into the displacement bound
-`TauCeti.norm_sub_le_densityLength` applied to `Real.artanh ∘ ψ` against the Poincaré density. -/
+/-- **A path issued from the origin admits a real comparison function.** For a path `γ` with
+`γ a = 0` there are real functions `ψ` and `ψ'` with `ψ a = 0` and `ψ b = ‖γ b‖`, dominated
+pointwise by `‖γ‖` and `‖γ'‖`, with `ψ` continuous wherever `γ` is and `ψ'` its derivative
+wherever `γ'` is that of `γ`. -/
+private theorem exists_re_comparison_of_eq_zero {s u : Set ℝ} (hγ : ContinuousOn γ s)
+    (hderiv : ∀ x ∈ u, HasDerivAt γ (γ' x) x) (h0 : γ a = 0) :
+    ∃ ψ ψ' : ℝ → ℝ, ψ a = 0 ∧ ψ b = ‖γ b‖ ∧ (∀ x, |ψ x| ≤ ‖γ x‖) ∧
+      (∀ x, |ψ' x| ≤ ‖γ' x‖) ∧ ContinuousOn ψ s ∧
+      ∀ x ∈ u, HasDerivAt ψ (ψ' x) x := by
+  -- Rotate by a unit `v` with `v * γ b = ‖γ b‖`, then take real parts; `γ` itself need not be
+  -- differentiable in norm, but its real part is.
+  obtain ⟨v, hvnorm, hvb⟩ := Complex.exists_norm_eq_mul_self (γ b)
+  refine ⟨fun t => (v * γ t).re, fun t => (v * γ' t).re, by simp [h0],
+    by simp only [← hvb, Complex.ofReal_re],
+    fun t => (Complex.abs_re_le_norm _).trans_eq (by rw [norm_mul, hvnorm, one_mul]),
+    fun t => (Complex.abs_re_le_norm _).trans_eq (by rw [norm_mul, hvnorm, one_mul]),
+    Complex.reCLM.continuous.comp_continuousOn (continuousOn_const.mul hγ), fun t ht => ?_⟩
+  simpa [Function.comp_def] using
+    Complex.reCLM.hasFDerivAt.comp_hasDerivAt t ((hderiv t ht).const_mul v)
+
+/-- **A comparison function has hyperbolic speed at most that of the path.** At a point `t` where
+`γ` lies inside the unit disc, if `|ψ t| ≤ ‖γ t‖` and the derivative of `ψ` at `t` is bounded in
+absolute value by `‖γ' t‖`, then `Real.artanh ∘ ψ` moves at `t` at most at the
+Poincaré-density-weighted speed of `γ`. -/
+private theorem norm_deriv_artanh_le_of_abs_le {ψ : ℝ → ℝ} {d t : ℝ} (hψ : |ψ t| ≤ ‖γ t‖)
+    (hd : |d| ≤ ‖γ' t‖) (hψd : HasDerivAt ψ d t) (hγd : HasDerivAt γ (γ' t) t) (ht : ‖γ t‖ < 1) :
+    ‖deriv (fun s => Real.artanh (ψ s)) t‖ ≤ (1 - ‖γ t‖ ^ 2)⁻¹ * ‖deriv γ t‖ := by
+  have hmem : ψ t ∈ Ioo (-1 : ℝ) 1 := abs_lt.mp (hψ.trans_lt ht)
+  have hPpos : (0 : ℝ) < 1 - ψ t ^ 2 := by nlinarith [hmem.1, hmem.2]
+  have hPQ : 1 - ‖γ t‖ ^ 2 ≤ 1 - ψ t ^ 2 := by
+    nlinarith [hψ, abs_nonneg (ψ t), sq_abs (ψ t), norm_nonneg (γ t)]
+  rw [hγd.deriv, ← div_eq_inv_mul, (hψd.artanh hmem).deriv, Real.norm_eq_abs, abs_mul, abs_inv,
+    abs_of_pos hPpos, inv_mul_eq_div]
+  gcongr
+  nlinarith [norm_nonneg (γ t), ht]
+
+/-- The lower bound for a path issued from the origin: its hyperbolic length is at least
+`Real.artanh` of the Euclidean norm of its endpoint, which is the hyperbolic distance from the
+origin to that endpoint. -/
 private theorem artanh_norm_le_hyperbolicLength (hab : a ≤ b) (hγ : ContinuousOn γ (Icc a b))
     (hderiv : ∀ t ∈ Ioo a b, HasDerivAt γ (γ' t) t) (hγ' : ContinuousOn γ' (Icc a b))
     (hmem : ∀ t ∈ Icc a b, ‖γ t‖ < 1) (h0 : γ a = 0) :
     Real.artanh ‖γ b‖ ≤ hyperbolicLength γ a b := by
-  have hpos : ∀ t ∈ Icc a b, (0 : ℝ) < 1 - ‖γ t‖ ^ 2 := fun t ht => by
-    nlinarith [norm_nonneg (γ t), hmem t ht]
   have hγu : ContinuousOn γ (uIcc a b) := by rwa [uIcc_of_le hab]
   have hγ'u : ContinuousOn γ' (uIcc a b) := by rwa [uIcc_of_le hab]
   have hmemu : ∀ t ∈ uIcc a b, ‖γ t‖ < 1 := by rwa [uIcc_of_le hab]
@@ -524,22 +556,11 @@ private theorem artanh_norm_le_hyperbolicLength (hab : a ≤ b) (hγ : Continuou
       MeasureTheory.volume a b := by
     simpa only [div_eq_inv_mul] using
       intervalIntegrable_norm_deriv_div_one_sub_norm_sq hγu hγ'u hderivu hmemu
-  obtain ⟨v, hvnorm, hvb⟩ := Complex.exists_norm_eq_mul_self (γ b)
-  set ψ : ℝ → ℝ := fun t => (v * γ t).re with hψdef
-  have hψa : ψ a = 0 := by simp [hψdef, h0]
-  have hψb : ψ b = ‖γ b‖ := by simp only [hψdef, ← hvb, Complex.ofReal_re]
-  have hψbound : ∀ t : ℝ, |ψ t| ≤ ‖γ t‖ := fun t =>
-    (Complex.abs_re_le_norm _).trans_eq (by rw [norm_mul, hvnorm, one_mul])
+  -- compare with a real function `ψ` rather than with `t ↦ ‖γ t‖`, which need not be differentiable
+  obtain ⟨ψ, ψ', hψa, hψb, hψbound, hψ'bound, hψcont, hψderiv⟩ :=
+    exists_re_comparison_of_eq_zero (b := b) hγ hderiv h0
   have hψmem : ∀ t ∈ Icc a b, ψ t ∈ Ioo (-1 : ℝ) 1 := fun t ht =>
     abs_lt.mp ((hψbound t).trans_lt (hmem t ht))
-  have hψderiv : ∀ t ∈ Ioo a b, HasDerivAt ψ ((v * γ' t).re) t := fun t ht => by
-    simpa [hψdef, Function.comp_def] using
-      Complex.reCLM.hasFDerivAt.comp_hasDerivAt t ((hderiv t ht).const_mul v)
-  have hψcont : ContinuousOn ψ (Icc a b) :=
-    Complex.reCLM.continuous.comp_continuousOn (continuousOn_const.mul hγ)
-  have hPpos : ∀ t ∈ Icc a b, (0 : ℝ) < 1 - ψ t ^ 2 := fun t ht => by
-    have := hψmem t ht
-    nlinarith [this.1, this.2]
   -- `Real.artanh ∘ ψ` runs from `0` to `Real.artanh ‖γ b‖` with speed at most the
   -- density-weighted speed of `γ`, so the displacement bound applies to it.
   have hcont : ContinuousOn (fun t => Real.artanh (ψ t)) (uIcc a b) := by
@@ -552,17 +573,8 @@ private theorem artanh_norm_le_hyperbolicLength (hab : a ≤ b) (hγ : Continuou
   have hbound : ∀ t ∈ uIoo a b,
       ‖deriv (fun s => Real.artanh (ψ s)) t‖ ≤ (1 - ‖γ t‖ ^ 2)⁻¹ * ‖deriv γ t‖ := by
     rw [uIoo_of_le hab]
-    intro t ht
-    have htI : t ∈ Icc a b := Ioo_subset_Icc_self ht
-    have hnum : |(v * γ' t).re| ≤ ‖γ' t‖ :=
-      (Complex.abs_re_le_norm _).trans_eq (by rw [norm_mul, hvnorm, one_mul])
-    have hPQ : 1 - ‖γ t‖ ^ 2 ≤ 1 - ψ t ^ 2 := by
-      nlinarith [hψbound t, abs_nonneg (ψ t), sq_abs (ψ t), norm_nonneg (γ t)]
-    rw [(hderiv t ht).deriv, ← div_eq_inv_mul,
-      ((hψderiv t ht).artanh (hψmem t htI)).deriv, Real.norm_eq_abs, abs_mul, abs_inv,
-      abs_of_pos (hPpos t htI), inv_mul_eq_div]
-    gcongr
-    exact hpos t htI
+    exact fun t ht => norm_deriv_artanh_le_of_abs_le (hψbound t) (hψ'bound t) (hψderiv t ht)
+      (hderiv t ht) (hmem t (Ioo_subset_Icc_self ht))
   rw [hyperbolicLength]
   have key := norm_sub_le_densityLength (ρ := fun z : ℂ => (1 - ‖z‖ ^ 2)⁻¹) (γ := γ)
     hcont hdiff (.of_forall hbound) hint2

--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
@@ -508,7 +508,7 @@ theorem hyperbolicLength_comp_eq_of_leftInvOn {f g : ℂ → ℂ}
 `γ a = 0` there are real functions `ψ` and `ψ'` with `ψ a = 0` and `ψ b = ‖γ b‖`, dominated
 pointwise by `‖γ‖` and `‖γ'‖`, with `ψ` continuous wherever `γ` is and `ψ'` its derivative
 wherever `γ'` is that of `γ`. -/
-private theorem exists_re_comparison_of_eq_zero {s u : Set ℝ} (hγ : ContinuousOn γ s)
+private theorem exists_real_comparison_of_eq_zero {s u : Set ℝ} (hγ : ContinuousOn γ s)
     (hderiv : ∀ x ∈ u, HasDerivAt γ (γ' x) x) (h0 : γ a = 0) :
     ∃ ψ ψ' : ℝ → ℝ, ψ a = 0 ∧ ψ b = ‖γ b‖ ∧ (∀ x, |ψ x| ≤ ‖γ x‖) ∧
       (∀ x, |ψ' x| ≤ ‖γ' x‖) ∧ ContinuousOn ψ s ∧
@@ -558,7 +558,7 @@ private theorem artanh_norm_le_hyperbolicLength (hab : a ≤ b) (hγ : Continuou
       intervalIntegrable_norm_deriv_div_one_sub_norm_sq hγu hγ'u hderivu hmemu
   -- compare with a real function `ψ` rather than with `t ↦ ‖γ t‖`, which need not be differentiable
   obtain ⟨ψ, ψ', hψa, hψb, hψbound, hψ'bound, hψcont, hψderiv⟩ :=
-    exists_re_comparison_of_eq_zero (b := b) hγ hderiv h0
+    exists_real_comparison_of_eq_zero (b := b) hγ hderiv h0
   have hψmem : ∀ t ∈ Icc a b, ψ t ∈ Ioo (-1 : ℝ) 1 := fun t ht =>
     abs_lt.mp ((hψbound t).trans_lt (hmem t ht))
   -- `Real.artanh ∘ ψ` runs from `0` to `Real.artanh ‖γ b‖` with speed at most the


### PR DESCRIPTION
Splits `artanh_norm_le_hyperbolicLength` (56-line body) into two named steps, leaving the parent at 34.

- `exists_re_comparison_of_eq_zero` — for a path with `γ a = 0`, produces the real comparison function `ψ` running from `0` to `‖γ b‖`, dominated pointwise by `‖γ‖` and `‖γ'‖`. Stated over arbitrary continuity and differentiability sets `s` and `u` rather than `Icc a b` and `Ioo a b`, since nothing in it uses the interval structure.
- `norm_deriv_artanh_le_of_abs_le` — the pointwise step: at a point where `γ` lies in the unit disc, `Real.artanh ∘ ψ` moves at most at the Poincaré-density-weighted speed of `γ`. Its hypotheses are pointwise at `t`; no interval is needed.

Extracting the second helper made `hpos` and `hPpos` dead in the parent, so they are removed.

The parent docstring previously described how the proof goes — the rotation by a unit `v`, the appeal to `norm_sub_le_densityLength`. It now states what the theorem asserts, and the mechanism moves into the proof as a comment. The module docstring already sketches the argument at module level and is unchanged.

Gates run locally: `lake build` (7104 jobs), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
