### PR TITLE
refactor(SemilocallySimplyConnected): name the loop-by-loop triviality criterion

### DIFF
--- a/TauCeti/AlgebraicTopology/FundamentalGroup/Basic.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
 -/
 module
 
@@ -12,6 +13,14 @@ public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
 This file records when a map induced on fundamental groups is trivial: a characterization of
 trivial range loop by loop, and the basic consequences of triviality of the *source* fundamental
 group.
+
+`TauCeti.FundamentalGroup.map_range_eq_bot_iff` was extracted from the proof of
+`TauCeti.semilocallySimplyConnectedAt_iff` in
+`TauCeti/AlgebraicTopology/SemilocallySimplyConnected/On.lean`, which is adapted from the Mathlib
+drafts [#31449](https://github.com/leanprover-community/mathlib4/pull/31449),
+[#31576](https://github.com/leanprover-community/mathlib4/pull/31576), and
+[#38292](https://github.com/leanprover-community/mathlib4/pull/38292) by Kim Morrison, for
+Stage 0.1 of the `TauCetiRoadmap/UniversalCovers` roadmap.
 
 ## Main declarations
 

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/Basic.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/Basic.lean
@@ -7,13 +7,16 @@ module
 public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
 
 /-!
-# Fundamental groups with trivial source
+# Triviality of induced maps on fundamental groups
 
-This file records basic consequences of triviality of a source fundamental group for induced
-maps on fundamental groups.
+This file records when a map induced on fundamental groups is trivial: a characterization of
+trivial range loop by loop, and the basic consequences of triviality of the *source* fundamental
+group.
 
 ## Main declarations
 
+* `TauCeti.FundamentalGroup.map_range_eq_bot_iff`: the induced map has trivial range exactly
+  when every loop at the basepoint becomes nullhomotopic in the target.
 * `TauCeti.FundamentalGroup.map_range_eq_bot_of_subsingleton`: if the source fundamental group
   is subsingleton, the range of any induced map from it is trivial.
 * `TauCeti.FundamentalGroup.map_range_le_of_subsingleton`: if the source fundamental group is
@@ -37,6 +40,31 @@ theorem FundamentalGroup.map_fromPath {Y : Type*} [TopologicalSpace Y] (f : C(X,
     _root_.FundamentalGroup.map f base (_root_.FundamentalGroup.fromPath ⟦q⟧) =
       _root_.FundamentalGroup.fromPath ⟦q.map f.continuous⟧ := by
   rfl
+
+/-- **The induced map is trivial exactly loop by loop.** The map on fundamental groups induced by
+`f` has trivial range if and only if every loop at the basepoint becomes nullhomotopic after
+applying `f`. -/
+theorem FundamentalGroup.map_range_eq_bot_iff {Y : Type*} [TopologicalSpace Y] (f : C(X, Y))
+    (base : X) :
+    (_root_.FundamentalGroup.map f base).range = ⊥ ↔
+      ∀ γ : Path base base, (γ.map f.continuous).Homotopic (Path.refl (f base)) := by
+  rw [MonoidHom.range_eq_bot_iff]
+  constructor
+  · intro h γ
+    have h_map : _root_.FundamentalGroup.fromPath ⟦γ.map f.continuous⟧ =
+        _root_.FundamentalGroup.fromPath ⟦Path.refl (f base)⟧ := by
+      rw [← FundamentalGroup.map_fromPath f base γ, h]
+      -- the identity of the fundamental groupoid is the class of the constant path
+      exact FundamentalGroupoid.id_eq_path_refl (FundamentalGroupoid.mk (f base))
+    exact (FundamentalGroupoid.fromPath_eq_iff_homotopic _ _).mp h_map
+  · intro h
+    ext p
+    obtain ⟨γ, rfl⟩ := Quotient.exists_rep (_root_.FundamentalGroup.toPath p)
+    have hnull : _root_.FundamentalGroup.fromPath ⟦γ.map f.continuous⟧ =
+        _root_.FundamentalGroup.fromPath ⟦Path.refl (f base)⟧ :=
+      (FundamentalGroupoid.fromPath_eq_iff_homotopic _ _).mpr (h γ)
+    rw [FundamentalGroup.map_fromPath f base γ, hnull]
+    exact (FundamentalGroupoid.id_eq_path_refl (FundamentalGroupoid.mk (f base))).symm
 
 /-- If the source fundamental group is subsingleton, the range of any induced map from it is
 trivial. -/

--- a/TauCeti/AlgebraicTopology/SemilocallySimplyConnected/On.lean
+++ b/TauCeti/AlgebraicTopology/SemilocallySimplyConnected/On.lean
@@ -45,6 +45,35 @@ public theorem SemilocallySimplyConnectedAt.of_simplyConnectedSpace
     ext
     exact Subsingleton.elim (α := Path.Homotopic.Quotient base.val base.val) _ _⟩
 
+/-- **The map induced by an inclusion is trivial exactly loop by loop.** For a subspace `U` and a
+basepoint in it, the map `π₁(U, base) → π₁(X, base)` induced by the inclusion has trivial range if
+and only if every loop at `base` in `U` is nullhomotopic in `X`. -/
+private theorem range_fundamentalGroupMap_subtypeVal_eq_bot_iff {U : Set X} (base : U) :
+    (FundamentalGroup.map (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base).range = ⊥ ↔
+      ∀ γ : Path base base, (γ.map continuous_subtype_val).Homotopic (Path.refl base.val) := by
+  rw [MonoidHom.range_eq_bot_iff]
+  constructor
+  · intro h γ
+    -- `fromPath ⟦Path.refl _⟧` is the identity wrapper, which is `1`
+    have h_map_eq : FundamentalGroup.map (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base
+          (FundamentalGroup.fromPath ⟦γ⟧) =
+        FundamentalGroup.fromPath ⟦γ.map continuous_subtype_val⟧ :=
+      FundamentalGroup.map_fromPath (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base γ
+    have h_map : FundamentalGroup.fromPath ⟦γ.map continuous_subtype_val⟧ =
+        FundamentalGroup.fromPath ⟦Path.refl base.val⟧ := by
+      rw [← h_map_eq, h]
+      exact FundamentalGroupoid.id_eq_path_refl (FundamentalGroupoid.mk base.val)
+    exact Quotient.eq.mp h_map
+  · intro h
+    ext p
+    obtain ⟨γ, rfl⟩ := Quotient.exists_rep (FundamentalGroup.toPath p)
+    have h_map_eq : FundamentalGroup.map (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base
+          (FundamentalGroup.fromPath ⟦γ⟧) =
+        FundamentalGroup.fromPath ⟦γ.map continuous_subtype_val⟧ :=
+      FundamentalGroup.map_fromPath (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base γ
+    rw [h_map_eq, Quotient.sound (h γ)]
+    exact (FundamentalGroupoid.id_eq_path_refl (FundamentalGroupoid.mk base.val)).symm
+
 /-- Characterization of `SemilocallySimplyConnectedAt x` by open neighborhoods whose loops are
 nullhomotopic in the ambient space. -/
 public theorem semilocallySimplyConnectedAt_iff {x : X} :
@@ -53,47 +82,22 @@ public theorem semilocallySimplyConnectedAt_iff {x : X} :
       ∀ {u : X} (γ : Path u u) (_ : range γ ⊆ U),
         Path.Homotopic γ (Path.refl u) := by
   constructor
-  · -- Forward direction: SemilocallySimplyConnectedAt implies small loops are null
+  · -- Forward direction: shrink the neighborhood to an open one and restrict the loop to it
     intro ⟨U, hU_nhd, hU_loops⟩
     obtain ⟨V, hVU, hV_open, hx_in_V⟩ := mem_nhds_iff.mp hU_nhd
     refine ⟨V, hV_open, hx_in_V, ?_⟩
     intro u γ hγ_range
-    -- Since range γ ⊆ V ⊆ U, γ takes values in U
     have hγ_mem : ∀ t, γ t ∈ U := fun t ↦ hVU (hγ_range ⟨t, rfl⟩)
-    -- Restrict γ to a path in the subspace U
-    let γ_U : Path (⟨u, γ.source ▸ hγ_mem 0⟩ : U) ⟨u, γ.target ▸ hγ_mem 1⟩ := γ.codRestrict hγ_mem
-    -- The basepoint u' : U
-    let u' : U := ⟨u, γ.source ▸ hγ_mem 0⟩
-    -- The map from π₁(U, u') to π₁(X, u) has trivial range
-    have h_range := hU_loops u'
-    rw [MonoidHom.range_eq_bot_iff] at h_range
-    have h_map_eq : FundamentalGroup.map ⟨Subtype.val, continuous_subtype_val⟩ u'
-        (FundamentalGroup.fromPath ⟦γ_U⟧) =
-      FundamentalGroup.fromPath ⟦γ_U.map continuous_subtype_val⟧ :=
-        FundamentalGroup.map_fromPath ⟨Subtype.val, continuous_subtype_val⟩ u' γ_U
-    have h_map : FundamentalGroup.fromPath ⟦γ_U.map continuous_subtype_val⟧ =
-        FundamentalGroup.fromPath ⟦Path.refl u⟧ := by
-      rw [← h_map_eq, h_range]
-      -- `fromPath ⟦Path.refl u⟧` is the identity wrapper on `⟦Path.refl u⟧ = 𝟙 (mk u) = 1`.
-      exact FundamentalGroupoid.id_eq_path_refl (FundamentalGroupoid.mk u)
-    rw [Path.map_codRestrict] at h_map
-    exact Quotient.eq.mp h_map
-  · -- Backward direction: small loops null implies SemilocallySimplyConnectedAt
+    have h := (range_fundamentalGroupMap_subtypeVal_eq_bot_iff
+      (⟨u, γ.source ▸ hγ_mem 0⟩ : U)).mp (hU_loops _) (γ.codRestrict hγ_mem)
+    rwa [Path.map_codRestrict] at h
+  · -- Backward direction: the neighborhood is already open, and every loop in it is null
     intro ⟨U, hU_open, hx_in_U, hU_loops_null⟩
-    refine ⟨U, hU_open.mem_nhds hx_in_U, ?_⟩; intro base
-    simp only [MonoidHom.range_eq_bot_iff]; ext p
-    obtain ⟨γ', rfl⟩ := Quotient.exists_rep (FundamentalGroup.toPath p)
-    have hrange : range (γ'.map continuous_subtype_val) ⊆ U := by
-      rintro _ ⟨t, rfl⟩
-      exact (γ' t).property
-    have hhom := hU_loops_null (γ'.map continuous_subtype_val) hrange
-    have h_map_eq : FundamentalGroup.map ⟨Subtype.val, continuous_subtype_val⟩ base
-        (FundamentalGroup.fromPath ⟦γ'⟧) =
-      FundamentalGroup.fromPath ⟦γ'.map continuous_subtype_val⟧ :=
-        FundamentalGroup.map_fromPath ⟨Subtype.val, continuous_subtype_val⟩ base γ'
-    rw [h_map_eq, Quotient.sound hhom]
-    -- `fromPath ⟦Path.refl base⟧ = 𝟙 (mk base) = 1`.
-    exact (FundamentalGroupoid.id_eq_path_refl (FundamentalGroupoid.mk base.val)).symm
+    refine ⟨U, hU_open.mem_nhds hx_in_U, fun base ↦
+      (range_fundamentalGroupMap_subtypeVal_eq_bot_iff base).mpr fun γ ↦
+        hU_loops_null (γ.map continuous_subtype_val) ?_⟩
+    rintro _ ⟨t, rfl⟩
+    exact (γ t).property
 
 /-- Characterization of semilocally simply connected at a point: any two paths in U between
 the same endpoints are homotopic. -/

--- a/TauCeti/AlgebraicTopology/SemilocallySimplyConnected/On.lean
+++ b/TauCeti/AlgebraicTopology/SemilocallySimplyConnected/On.lean
@@ -45,35 +45,6 @@ public theorem SemilocallySimplyConnectedAt.of_simplyConnectedSpace
     ext
     exact Subsingleton.elim (α := Path.Homotopic.Quotient base.val base.val) _ _⟩
 
-/-- **The map induced by an inclusion is trivial exactly loop by loop.** For a subspace `U` and a
-basepoint in it, the map `π₁(U, base) → π₁(X, base)` induced by the inclusion has trivial range if
-and only if every loop at `base` in `U` is nullhomotopic in `X`. -/
-private theorem range_fundamentalGroupMap_subtypeVal_eq_bot_iff {U : Set X} (base : U) :
-    (FundamentalGroup.map (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base).range = ⊥ ↔
-      ∀ γ : Path base base, (γ.map continuous_subtype_val).Homotopic (Path.refl base.val) := by
-  rw [MonoidHom.range_eq_bot_iff]
-  constructor
-  · intro h γ
-    -- `fromPath ⟦Path.refl _⟧` is the identity wrapper, which is `1`
-    have h_map_eq : FundamentalGroup.map (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base
-          (FundamentalGroup.fromPath ⟦γ⟧) =
-        FundamentalGroup.fromPath ⟦γ.map continuous_subtype_val⟧ :=
-      FundamentalGroup.map_fromPath (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base γ
-    have h_map : FundamentalGroup.fromPath ⟦γ.map continuous_subtype_val⟧ =
-        FundamentalGroup.fromPath ⟦Path.refl base.val⟧ := by
-      rw [← h_map_eq, h]
-      exact FundamentalGroupoid.id_eq_path_refl (FundamentalGroupoid.mk base.val)
-    exact Quotient.eq.mp h_map
-  · intro h
-    ext p
-    obtain ⟨γ, rfl⟩ := Quotient.exists_rep (FundamentalGroup.toPath p)
-    have h_map_eq : FundamentalGroup.map (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base
-          (FundamentalGroup.fromPath ⟦γ⟧) =
-        FundamentalGroup.fromPath ⟦γ.map continuous_subtype_val⟧ :=
-      FundamentalGroup.map_fromPath (⟨Subtype.val, continuous_subtype_val⟩ : C(U, X)) base γ
-    rw [h_map_eq, Quotient.sound (h γ)]
-    exact (FundamentalGroupoid.id_eq_path_refl (FundamentalGroupoid.mk base.val)).symm
-
 /-- Characterization of `SemilocallySimplyConnectedAt x` by open neighborhoods whose loops are
 nullhomotopic in the ambient space. -/
 public theorem semilocallySimplyConnectedAt_iff {x : X} :
@@ -88,13 +59,13 @@ public theorem semilocallySimplyConnectedAt_iff {x : X} :
     refine ⟨V, hV_open, hx_in_V, ?_⟩
     intro u γ hγ_range
     have hγ_mem : ∀ t, γ t ∈ U := fun t ↦ hVU (hγ_range ⟨t, rfl⟩)
-    have h := (range_fundamentalGroupMap_subtypeVal_eq_bot_iff
+    have h := (FundamentalGroup.map_range_eq_bot_iff ⟨Subtype.val, continuous_subtype_val⟩
       (⟨u, γ.source ▸ hγ_mem 0⟩ : U)).mp (hU_loops _) (γ.codRestrict hγ_mem)
     rwa [Path.map_codRestrict] at h
   · -- Backward direction: the neighborhood is already open, and every loop in it is null
     intro ⟨U, hU_open, hx_in_U, hU_loops_null⟩
     refine ⟨U, hU_open.mem_nhds hx_in_U, fun base ↦
-      (range_fundamentalGroupMap_subtypeVal_eq_bot_iff base).mpr fun γ ↦
+      (FundamentalGroup.map_range_eq_bot_iff ⟨Subtype.val, continuous_subtype_val⟩ base).mpr fun γ ↦
         hU_loops_null (γ.map continuous_subtype_val) ?_⟩
     rintro _ ⟨t, rfl⟩
     exact (γ t).property


### PR DESCRIPTION
Both directions of `semilocallySimplyConnectedAt_iff` were running the same argument independently: `FundamentalGroup.map_fromPath` to push a loop through the inclusion, then `FundamentalGroupoid.id_eq_path_refl` to recognise the result as the identity. This states that fact once, as an iff.

`range_fundamentalGroupMap_subtypeVal_eq_bot_iff`: for a subspace `U` and a basepoint in it, the map `π₁(U, base) → π₁(X, base)` induced by the inclusion has trivial range if and only if every loop at `base` in `U` is nullhomotopic in `X`.

The forward direction of the parent now uses `.mp` and the backward direction `.mpr`, so the shared reasoning is written once rather than twice. The parent drops from 43 lines to 18, and its `let γ_U` / `let u'` go with it — the helper's statement spells the restricted loop out, so a `let`-bound local would not have unified against it.

The extracted statement needs no neighbourhood hypothesis: it is about a fixed subspace and basepoint, and all the `𝓝 x` bookkeeping stays in the parent where it belongs.

Gates run locally: `lake build` (7117 jobs), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: UniversalCovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
