### PR TITLE
feat(ModularForms): the vertical cancellation survives excision

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
@@ -21,9 +21,19 @@ periodicity and the derivatives by the reflection, up to the orientation sign. T
 statement is unconditional: the substitution and the interior congruence need no
 integrability.
 
+The cancellation also survives `ε`-excision, which is what the principal-value assembly of
+the valence formula needs: when the form vanishes at a point *on* the contour the integrand
+is not interval-integrable there, so the boundary integral is assembled from an excised
+integrand and the limit taken only after the pieces are combined. The excised cancellation
+holds whenever the excision set is invariant under the reflection `z ↦ -conj z` that
+exchanges the two verticals — reflection invariance, not translation closure, is the usable
+hypothesis, since a finite set closed under `s ↦ s + 1` is empty.
+
 ## Main declarations
 
 * `TauCeti.ModularForm.intervalIntegral_fdBoundary_segment4_eq_neg_segment1`.
+* `TauCeti.ModularForm.intervalIntegral_excised_fdBoundary_segment4_eq_neg_segment1`: the
+  same cancellation for a reflection-invariantly excised integrand.
 
 ## References
 
@@ -99,23 +109,22 @@ closed under the bare translation `s ↦ s + 1` would have to be empty, since a 
 element of largest real part.) For `TauCeti.ModularForm.verticalSingularSet` the invariance is the
 composite of `re_eq_of_mem_verticalSingularSet` with `sub_one_mem_verticalSingularSet` or
 `add_one_mem_verticalSingularSet`, whose translations are conditional on the real part. -/
-theorem intervalIntegral_excised_fdBoundary_segment4_eq_neg_segment1 (H : ℝ) {φ : ℂ → ℂ}
+theorem intervalIntegral_excised_fdBoundary_segment4_eq_neg_segment1 {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace ℂ E] (H : ℝ) {φ : ℂ → E}
     (hφ : Function.Periodic φ 1) {S : Finset ℂ} {ε : ℝ}
     (hrefl : ∀ s ∈ S, -(starRingEnd ℂ) s ∈ S) :
-    (∫ t in (3 : ℝ)..4, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
-        else φ (fdBoundary H t) * deriv (fdBoundary H) t) =
-      -∫ t in (0 : ℝ)..1, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
-        else φ (fdBoundary H t) * deriv (fdBoundary H) t := by
-  have hcomp : (∫ t in (3 : ℝ)..4, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
-      else φ (fdBoundary H t) * deriv (fdBoundary H) t) =
-      ∫ u in (0 : ℝ)..1, if ∃ s ∈ S, ‖fdBoundary H (4 - u) - s‖ ≤ ε then 0
-        else φ (fdBoundary H (4 - u)) * deriv (fdBoundary H) (4 - u) := by
-    have h := intervalIntegral.integral_comp_sub_left
-      (a := (0 : ℝ)) (b := 1) (d := (4 : ℝ))
-      (fun t => if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then (0 : ℂ)
-        else φ (fdBoundary H t) * deriv (fdBoundary H) t)
-    norm_num at h
-    exact h.symm
+    (∫ t in (3 : ℝ)..4, deriv (fdBoundary H) t •
+        (if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0 else φ (fdBoundary H t))) =
+      -∫ t in (0 : ℝ)..1, deriv (fdBoundary H) t •
+        (if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0 else φ (fdBoundary H t)) := by
+  -- The substitution is the boundary-specific combinator, applied to the excised integrand.
+  have h41 : (4 : ℝ) - 1 = 3 := by norm_num
+  have h40 : (4 : ℝ) - 0 = 4 := by norm_num
+  have hcomp := intervalIntegral_comp_fdBoundary_four_sub H
+    (fun z => if ∃ s ∈ S, ‖z - s‖ ≤ ε then (0 : E) else φ z) (a := 0) (b := 1)
+  -- Only the endpoints need normalizing; `norm_num` here would also distribute the
+  -- scalar into the branches of the `if` and stop matching the goal.
+  simp only [h41, h40] at hcomp
   rw [hcomp, ← intervalIntegral.integral_neg]
   refine intervalIntegral.integral_congr_Ioo_of_le (by norm_num) fun u hu => ?_
   have hval : fdBoundary H (4 - u) = fdBoundary H u - 1 :=
@@ -129,10 +138,11 @@ theorem intervalIntegral_excised_fdBoundary_segment4_eq_neg_segment1 (H : ℝ) {
   have hdist : ∀ s : ℂ, ‖fdBoundary H (4 - u) - s‖
       = ‖fdBoundary H u - -(starRingEnd ℂ) s‖ := by
     intro s
+    have hneg : -fdBoundary H u - (starRingEnd ℂ) s
+        = -(fdBoundary H u - -(starRingEnd ℂ) s) := by ring
     rw [hconj, ← Complex.norm_conj (-(starRingEnd ℂ) (fdBoundary H u) - s)]
     simp only [map_sub, map_neg, Complex.conj_conj]
-    rw [show -fdBoundary H u - (starRingEnd ℂ) s
-        = -(fdBoundary H u - -(starRingEnd ℂ) s) by ring, norm_neg]
+    rw [hneg, norm_neg]
   have hiff : (∃ s ∈ S, ‖fdBoundary H (4 - u) - s‖ ≤ ε) ↔
       ∃ s ∈ S, ‖fdBoundary H u - s‖ ≤ ε := by
     refine ⟨fun ⟨s, hs, hle⟩ => ⟨-(starRingEnd ℂ) s, hrefl s hs, by rwa [← hdist s]⟩,
@@ -140,10 +150,9 @@ theorem intervalIntegral_excised_fdBoundary_segment4_eq_neg_segment1 (H : ℝ) {
     rw [hdist, map_neg, Complex.conj_conj, neg_neg]
     exact hle
   by_cases hc : ∃ s ∈ S, ‖fdBoundary H u - s‖ ≤ ε
-  · rw [if_pos (hiff.mpr hc), if_pos hc, neg_zero]
+  · rw [if_pos (hiff.mpr hc), if_pos hc, smul_zero, smul_zero, neg_zero]
   · rw [if_neg fun h => hc (hiff.mp h), if_neg hc, hval,
-      deriv_fdBoundary_four_sub_vertical H hu, hφ.sub_eq]
-    ring
+      deriv_fdBoundary_four_sub_vertical H hu, hφ.sub_eq, neg_smul]
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
@@ -87,6 +87,50 @@ theorem intervalIntegrable_deriv_smul_fdBoundary_segment4 {E : Type*}
     linear_combination hder
   simp only [Pi.neg_apply, hval', hder', hφ (fdBoundary H x), neg_smul, neg_neg]
 
+/-- **The vertical cancellation survives excision.** The reflection `t ↦ 4 - t` carries the
+right vertical onto the left through the translation `z ↦ z - 1`, so an integrand excised
+within `ε` of a set closed under `s ↦ s ± 1` is excised at matching parameters on the two
+verticals, and the cancellation of the untruncated integrals
+(`TauCeti.ModularForm.intervalIntegral_fdBoundary_segment4_eq_neg_segment1`) persists.
+
+Translation-closure of the excision set is exactly what
+`TauCeti.ModularForm.verticalSingularSet` provides. -/
+theorem intervalIntegral_truncated_fdBoundary_segment4_eq_neg_segment1 (H : ℝ) {φ : ℂ → ℂ}
+    (hφ : Function.Periodic φ 1) {S : Finset ℂ} {ε : ℝ}
+    (hadd : ∀ s ∈ S, s + 1 ∈ S) (hsub : ∀ s ∈ S, s - 1 ∈ S) :
+    (∫ t in (3 : ℝ)..4, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
+        else φ (fdBoundary H t) * deriv (fdBoundary H) t) =
+      -∫ t in (0 : ℝ)..1, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
+        else φ (fdBoundary H t) * deriv (fdBoundary H) t := by
+  have hcomp : (∫ t in (3 : ℝ)..4, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
+      else φ (fdBoundary H t) * deriv (fdBoundary H) t) =
+      ∫ u in (0 : ℝ)..1, if ∃ s ∈ S, ‖fdBoundary H (4 - u) - s‖ ≤ ε then 0
+        else φ (fdBoundary H (4 - u)) * deriv (fdBoundary H) (4 - u) := by
+    have h := intervalIntegral.integral_comp_sub_left
+      (a := (0 : ℝ)) (b := 1) (d := (4 : ℝ))
+      (fun t => if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then (0 : ℂ)
+        else φ (fdBoundary H t) * deriv (fdBoundary H) t)
+    norm_num at h
+    exact h.symm
+  rw [hcomp, ← intervalIntegral.integral_neg]
+  refine intervalIntegral.integral_congr_Ioo_of_le (by norm_num) fun u hu => ?_
+  have hval : fdBoundary H (4 - u) = fdBoundary H u - 1 :=
+    fdBoundary_four_sub_vertical H ⟨hu.1.le, hu.2.le⟩
+  -- The excision test transports along the translation, in both directions.
+  have hiff : (∃ s ∈ S, ‖fdBoundary H (4 - u) - s‖ ≤ ε) ↔
+      ∃ s ∈ S, ‖fdBoundary H u - s‖ ≤ ε := by
+    rw [hval]
+    refine ⟨fun ⟨s, hs, hle⟩ => ⟨s + 1, hadd s hs, ?_⟩, fun ⟨s, hs, hle⟩ => ⟨s - 1, hsub s hs, ?_⟩⟩
+    · rwa [show fdBoundary H u - (s + 1) = fdBoundary H u - 1 - s by ring]
+    · rwa [show fdBoundary H u - 1 - (s - 1) = fdBoundary H u - s by ring]
+  -- Split on the excision test before rewriting: the `ite`'s decidability instance mentions
+  -- the condition, so rewriting inside it is not motive-correct.
+  by_cases hc : ∃ s ∈ S, ‖fdBoundary H u - s‖ ≤ ε
+  · rw [if_pos (hiff.mpr hc), if_pos hc, neg_zero]
+  · rw [if_neg fun h => hc (hiff.mp h), if_neg hc, hval,
+      deriv_fdBoundary_four_sub_vertical H hu, hφ.sub_eq]
+    ring
+
 end ModularForm
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
@@ -87,17 +87,21 @@ theorem intervalIntegrable_deriv_smul_fdBoundary_segment4 {E : Type*}
     linear_combination hder
   simp only [Pi.neg_apply, hval', hder', hφ (fdBoundary H x), neg_smul, neg_neg]
 
-/-- **The vertical cancellation survives excision.** The reflection `t ↦ 4 - t` carries the
-right vertical onto the left through the translation `z ↦ z - 1`, so an integrand excised
-within `ε` of a set closed under `s ↦ s ± 1` is excised at matching parameters on the two
-verticals, and the cancellation of the untruncated integrals
+/-- **The vertical cancellation survives excision.** The reflection `t ↦ 4 - t` carries the right
+vertical onto the left by `z ↦ -conj z`, an isometry of `ℂ`, so an integrand excised within `ε`
+of a set invariant under that reflection is excised at matching parameters on the two verticals,
+and the cancellation of the untruncated integrals
 (`TauCeti.ModularForm.intervalIntegral_fdBoundary_segment4_eq_neg_segment1`) persists.
 
-Translation-closure of the excision set is exactly what
-`TauCeti.ModularForm.verticalSingularSet` provides. -/
-theorem intervalIntegral_truncated_fdBoundary_segment4_eq_neg_segment1 (H : ℝ) {φ : ℂ → ℂ}
+Reflection invariance, not translation closure, is the right hypothesis: the two verticals are
+exchanged by `z ↦ -conj z`, and being an isometry it moves an `ε`-ball to an `ε`-ball. (A set
+closed under the bare translation `s ↦ s + 1` would have to be empty, since a finite set has an
+element of largest real part.) For `TauCeti.ModularForm.verticalSingularSet` the invariance is the
+composite of `re_eq_of_mem_verticalSingularSet` with `sub_one_mem_verticalSingularSet` or
+`add_one_mem_verticalSingularSet`, whose translations are conditional on the real part. -/
+theorem intervalIntegral_excised_fdBoundary_segment4_eq_neg_segment1 (H : ℝ) {φ : ℂ → ℂ}
     (hφ : Function.Periodic φ 1) {S : Finset ℂ} {ε : ℝ}
-    (hadd : ∀ s ∈ S, s + 1 ∈ S) (hsub : ∀ s ∈ S, s - 1 ∈ S) :
+    (hrefl : ∀ s ∈ S, -(starRingEnd ℂ) s ∈ S) :
     (∫ t in (3 : ℝ)..4, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
         else φ (fdBoundary H t) * deriv (fdBoundary H) t) =
       -∫ t in (0 : ℝ)..1, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
@@ -116,15 +120,25 @@ theorem intervalIntegral_truncated_fdBoundary_segment4_eq_neg_segment1 (H : ℝ)
   refine intervalIntegral.integral_congr_Ioo_of_le (by norm_num) fun u hu => ?_
   have hval : fdBoundary H (4 - u) = fdBoundary H u - 1 :=
     fdBoundary_four_sub_vertical H ⟨hu.1.le, hu.2.le⟩
-  -- The excision test transports along the translation, in both directions.
+  -- On the right vertical the reflection is `z ↦ -conj z`, since the real part is `1/2`.
+  have hconj : fdBoundary H (4 - u) = -(starRingEnd ℂ) (fdBoundary H u) := by
+    rw [hval]
+    refine Complex.ext ?_ ?_ <;> simp [re_fdBoundary_of_le_one hu.2.le]
+    norm_num
+  -- An isometry moves the excision test to the reflected centre.
+  have hdist : ∀ s : ℂ, ‖fdBoundary H (4 - u) - s‖
+      = ‖fdBoundary H u - -(starRingEnd ℂ) s‖ := by
+    intro s
+    rw [hconj, ← Complex.norm_conj (-(starRingEnd ℂ) (fdBoundary H u) - s)]
+    simp only [map_sub, map_neg, Complex.conj_conj]
+    rw [show -fdBoundary H u - (starRingEnd ℂ) s
+        = -(fdBoundary H u - -(starRingEnd ℂ) s) by ring, norm_neg]
   have hiff : (∃ s ∈ S, ‖fdBoundary H (4 - u) - s‖ ≤ ε) ↔
       ∃ s ∈ S, ‖fdBoundary H u - s‖ ≤ ε := by
-    rw [hval]
-    refine ⟨fun ⟨s, hs, hle⟩ => ⟨s + 1, hadd s hs, ?_⟩, fun ⟨s, hs, hle⟩ => ⟨s - 1, hsub s hs, ?_⟩⟩
-    · rwa [show fdBoundary H u - (s + 1) = fdBoundary H u - 1 - s by ring]
-    · rwa [show fdBoundary H u - 1 - (s - 1) = fdBoundary H u - s by ring]
-  -- Split on the excision test before rewriting: the `ite`'s decidability instance mentions
-  -- the condition, so rewriting inside it is not motive-correct.
+    refine ⟨fun ⟨s, hs, hle⟩ => ⟨-(starRingEnd ℂ) s, hrefl s hs, by rwa [← hdist s]⟩,
+      fun ⟨s, hs, hle⟩ => ⟨-(starRingEnd ℂ) s, hrefl s hs, ?_⟩⟩
+    rw [hdist, map_neg, Complex.conj_conj, neg_neg]
+    exact hle
   by_cases hc : ∃ s ∈ S, ‖fdBoundary H u - s‖ ≤ ε
   · rw [if_pos (hiff.mpr hc), if_pos hc, neg_zero]
   · rw [if_neg fun h => hc (hiff.mp h), if_neg hc, hval,


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-formula/vertical-excision-cancel"}-->

The vertical cancellation of the boundary contour, in the form that survives an `ε`-excision.

```lean
theorem intervalIntegral_excised_fdBoundary_segment4_eq_neg_segment1 (H : ℝ) {φ : ℂ → ℂ}
    (hφ : Function.Periodic φ 1) {S : Finset ℂ} {ε : ℝ}
    (hrefl : ∀ s ∈ S, -(starRingEnd ℂ) s ∈ S) :
    (∫ t in (3 : ℝ)..4, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
        else φ (fdBoundary H t) * deriv (fdBoundary H) t) =
      -∫ t in (0 : ℝ)..1, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
        else φ (fdBoundary H t) * deriv (fdBoundary H) t
```

### Why the excised form is needed

The merged `intervalIntegral_fdBoundary_segment4_eq_neg_segment1` cancels the two verticals as *ordinary* integrals. That is not enough for the valence formula: when the modular form vanishes at a point **on** the contour the logarithmic-derivative integrand behaves like `n/(t − t₀)` there and is not interval-integrable, so the boundary integral has to be assembled as a Cauchy principal value — from the excised integrand, with the limit taken only after the four pieces are combined.

### The hypothesis is reflection invariance, not translation closure

The two verticals are exchanged by

```
z ↦ -conj z
```

which on the right vertical agrees with `z ↦ z - 1` because the real part there is `1/2`. **Reflection is the correct hypothesis and translation closure is not**, for a concrete reason: a `Finset` closed under `s ↦ s + 1` has an element of largest real part whose successor must also lie in it, so only `∅` qualifies. A theorem stated with that hypothesis would be true but vacuous — it would say nothing about any actual excision.

Being an isometry, `z ↦ -conj z` carries an `ε`-ball to an `ε`-ball, so one invariance hypothesis serves every `ε`, and one direction suffices since the reflection is an involution.

For `verticalSingularSet` the invariance is the composite of `re_eq_of_mem_verticalSingularSet` with whichever of `sub_one_mem_verticalSingularSet` / `add_one_mem_verticalSingularSet` applies — those translations are **conditional on the real part being `±1/2`**, which is exactly the reflection in disguise.

### Placement

Added to the existing `VerticalCancel.lean` rather than a new module: the same theorem about the same pairing, differing only in whether the integrand is excised.

Roadmap: ModularForms
