### PR TITLE
fix(QuadraticForm): drop the simp attribute from map_app_of_mem_orthogonalGroup

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -122,8 +122,12 @@ variable {Q : QuadraticMap R M N}
 theorem mem_orthogonalGroup_iff {f : M ≃ₗ[R] M} :
     f ∈ orthogonalGroup Q ↔ ∀ m, Q (f m) = Q m := Iff.rfl
 
-/-- The defining property of an orthogonal automorphism, in the form in which it rewrites. -/
-@[simp]
+/-- The defining property of an orthogonal automorphism, in the form in which it rewrites.
+
+This is deliberately not a `simp` lemma: its left-hand side `Q (f m)` matches every application
+of every quadratic map to every linear equivalence, and discharging the side goal
+`f ∈ orthogonalGroup Q` unfolds through `mem_orthogonalGroup_iff` to `∀ m, Q (f m) = Q m`, which
+this lemma applies to again. Name it explicitly in the `simp` calls that want it. -/
 theorem map_app_of_mem_orthogonalGroup {f : M ≃ₗ[R] M} (hf : f ∈ orthogonalGroup Q) (m : M) :
     Q (f m) = Q m := hf m
 


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR removes the `@[simp]` attribute from `QuadraticMap.map_app_of_mem_orthogonalGroup`, which cannot serve as a rewrite rule. Its left-hand side `Q (f m)` matches every application of every quadratic map to every linear equivalence, and the side goal `f ∈ orthogonalGroup Q` that simp must then discharge unfolds through the `@[simp]` `mem_orthogonalGroup_iff` (an `Iff.rfl`) into `∀ m, Q (f m) = Q m`, a goal of the same shape the lemma itself concludes. The statement, name and generality are unchanged, and a docstring now records why the attribute is absent and that callers should name the lemma explicitly.

Nothing downstream needed adjusting: `SpinAction`, `PinAction`, `ReflectionLift` and `CartanDieudonne` build unchanged, so no proof was relying on the rule firing implicitly. The full build, axiom audit, module-system check and environment lint pass at `66d7bb88`; `lint-env` reports no new violations.

This file is not otherwise part of the change; `map_app_of_mem_orthogonalGroup` dates from #1499. Two neighbouring lemmas, `isOrtho_iff_of_mem_orthogonalGroup` and `polar_apply_of_mem_orthogonalGroup`, carry `@[simp]` with the same hypothesis-discharging shape but far more specific left-hand sides, so they are left alone here rather than widening this PR.

🤖 Prepared with Claude Code