### PR TITLE
refactor(CliffordAlgebra): weaken the reflection lifts to separably closed fields

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import Mathlib.FieldTheory.IsSepClosed
 public import TauCeti.LinearAlgebra.CliffordAlgebra.PinAction
 
 /-!
@@ -14,7 +14,7 @@ When the inverse negative norm of a vector is a square, the vector can be rescal
 `-1`. It therefore defines an element of the Pin group whose twisted-conjugation action is the
 reflection in the original vector. A pair of reflections needs only that the product of the
 inverse norms be a square: rescaling one vector then gives a unitary even product and hence a
-lift to the Spin group. Over an algebraically closed field, the required square conditions hold
+lift to the Spin group. Over a separably closed field, the required square conditions hold
 automatically.
 
 ## Main results
@@ -23,7 +23,7 @@ automatically.
   through the Pin action when its normalization scalar is a square.
 * `TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare`: a
   product of two reflections lifts through the Spin action when the product of its normalization
-  scalars is a square. The version without the suffix is an algebraically closed-field corollary.
+  scalars is a square. The version without the suffix is a separably closed-field corollary.
 
 ## References
 
@@ -238,20 +238,20 @@ theorem reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare_of_isSq
 
 end Square
 
-section IsAlgClosed
+section IsSepClosed
 
-variable {K : Type u} {V : Type v} [Field K] [IsAlgClosed K] [AddCommGroup V] [Module K V]
+variable {K : Type u} {V : Type v} [Field K] [IsSepClosed K] [AddCommGroup V] [Module K V]
   [Invertible (2 : K)] (Q : QuadraticForm K V)
 
-/-- Over an algebraically closed field, every reflection in a vector of invertible norm lifts to
+/-- Over a separably closed field, every reflection in a vector of invertible norm lifts to
 the Pin group. -/
 theorem reflection_mem_range_pinToOrthogonal (v : V) [Invertible (Q v)] :
     (⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ :
       QuadraticMap.orthogonalGroup Q) ∈ (pinToOrthogonal Q).range := by
   exact reflection_mem_range_pinToOrthogonal_of_isSquare Q v
-    (IsAlgClosed.exists_eq_mul_self (-⅟(Q v)))
+    (IsSepClosed.exists_eq_mul_self (-⅟(Q v)))
 
-/-- Over an algebraically closed field, every product of two reflections in vectors of invertible
+/-- Over a separably closed field, every product of two reflections in vectors of invertible
 norm lifts to the Spin group. -/
 theorem reflection_mul_reflection_mem_range_spinToOrthogonal
     (v w : V) [Invertible (Q v)] [Invertible (Q w)] :
@@ -260,9 +260,9 @@ theorem reflection_mul_reflection_mem_range_spinToOrthogonal
       ⟨QuadraticMap.reflection Q w, QuadraticMap.reflection_mem_orthogonalGroup Q w⟩ ∈
         (spinToOrthogonal Q).range := by
   exact reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare Q v w
-    (IsAlgClosed.exists_eq_mul_self (⅟(Q v) * ⅟(Q w)))
+    (IsSepClosed.exists_eq_mul_self (⅟(Q v) * ⅟(Q w)))
 
-end IsAlgClosed
+end IsSepClosed
 
 end CliffordAlgebra
 end TauCeti


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR states the two reflection-lift corollaries in `ReflectionLift.lean` over a separably closed field instead of an algebraically closed one. `IsSepClosed.exists_eq_mul_self` supplies exactly the square roots they need, and its `[NeZero (2 : k)]` hypothesis is already available from the section's `[Invertible (2 : K)]` via `Invertible.toNeZero`. Since `IsSepClosed.of_isAlgClosed` is an instance, every algebraically closed application still resolves, so this only weakens the hypothesis.

The motivation is a duplicate on `main`. `CartanDieudonne.lean` is stated over `[IsSepClosed K]` and opens its main proof with an inline

```
have reflection_mem_range (w : V) [Invertible (Q w)] : … :=
  reflection_mem_range_pinToOrthogonal_of_isSquare Q w (IsSepClosed.exists_eq_mul_self _)
```

which is precisely `reflection_mem_range_pinToOrthogonal`, re-derived locally only because the public lemma demanded the stronger hypothesis. After this PR the public lemma applies directly. I have deliberately left that deletion out of this PR: #2470 adds 130 lines to `CartanDieudonne.lean` and #2492 rewrites it, so editing it now would conflict with in-flight work. The cleanup follows once those land.

The full build, axiom audit, module-system check and environment lint pass at `76066e40`; `lint-env` reports no new violations. (It also reports one ratchetable baseline entry, `TauCeti.SymplecticForm.stdComplexLineEnergyDensity_def`, which is pre-existing and unrelated: it appears identically on an unmodified checkout.)

🤖 Prepared with Claude Code