### PR TITLE
refactor(CliffordAlgebra): remove the subsumed reflection-lift corollary

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -224,18 +224,6 @@ theorem reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare
   exact (coe_lipschitzToOrthogonal_apply Q _ m).symm.trans
     (congrArg (fun y : QuadraticMap.orthogonalGroup Q => (y : V ≃ₗ[K] V) m) hlipschitz)
 
-/-- If both individual normalization scalars are squares, the product of the reflections in `v`
-and `w` lifts through the Spin action. -/
-theorem reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare_of_isSquare
-    (v w : V) [Invertible (Q v)] [Invertible (Q w)]
-    (hv : IsSquare (-⅟(Q v))) (hw : IsSquare (-⅟(Q w))) :
-    (⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ :
-        QuadraticMap.orthogonalGroup Q) *
-      ⟨QuadraticMap.reflection Q w, QuadraticMap.reflection_mem_orthogonalGroup Q w⟩ ∈
-        (spinToOrthogonal Q).range := by
-  exact reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare Q v w
-    (by simpa only [neg_mul_neg] using hv.mul hw)
-
 end Square
 
 section IsAlgClosed


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR deletes `reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare_of_isSquare`, which is strictly weaker than the theorem immediately above it. It assumes `IsSquare (-⅟(Q v))` and `IsSquare (-⅟(Q w))` separately, whereas `reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare` assumes only `IsSquare (⅟(Q v) * ⅟(Q w))`; the former pair implies the latter by `neg_mul_neg`, and the deleted theorem's entire body is that implication.

Recognising that a pair of reflections needs only the *product* of the inverse norms to be a square is the good idea in this file, and the deleted corollary is the weaker statement that idea replaced. Nothing references it: `git grep` finds only the declaration site, and it does not appear in the added lines of any open PR (#2343, #2397, #2411, #2413, #2419, #2470, #2492). It was also absent from the module docstring's "Main results" index, so no index change is needed.

The full build with `--iofail`, axiom audit, module-system check and environment lint pass; `lint-env` reports no new violations.

🤖 Prepared with Claude Code