### PR TITLE
refactor(CliffordAlgebra): name the filtration memberships that simp statements inline

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -51,8 +51,8 @@ private theorem mul_mem_filtrationPrevious_left (Q : QuadraticForm R M) (i j : �
       simp
   | succ i =>
       rw [filtrationPrevious_succ] at hx
-      rw [Nat.succ_add, filtrationPrevious_succ, ← filtration_mul]
-      exact Submodule.mul_mem_mul hx hy
+      rw [Nat.succ_add, filtrationPrevious_succ]
+      exact mul_mem_filtration Q hx hy
 
 private theorem mul_mem_filtrationPrevious_right (Q : QuadraticForm R M) (i j : ℕ)
     {x y : CliffordAlgebra Q} (hx : x ∈ filtration Q i) (hy : y ∈ filtrationPrevious Q j) :
@@ -65,8 +65,8 @@ private theorem mul_mem_filtrationPrevious_right (Q : QuadraticForm R M) (i j : 
       simp
   | succ j =>
       rw [filtrationPrevious_succ] at hy
-      rw [Nat.add_succ, filtrationPrevious_succ, ← filtration_mul]
-      exact Submodule.mul_mem_mul hx hy
+      rw [Nat.add_succ, filtrationPrevious_succ]
+      exact mul_mem_filtration Q hx hy
 
 private noncomputable def filtrationMul (Q : QuadraticForm R M) (i j : ℕ) :
     filtration Q i →ₗ[R] filtration Q j →ₗ[R] filtration Q (i + j) :=
@@ -82,9 +82,8 @@ private theorem filtrationGradedPreMul_apply (Q : QuadraticForm R M) (i j : ℕ)
     (x : filtration Q i) (y : filtration Q j) :
     filtrationGradedPreMul Q i j x y =
       Submodule.Quotient.mk
-        (⟨(x : CliffordAlgebra Q) * y, by
-          rw [← filtration_mul Q i j]
-          exact Submodule.mul_mem_mul x.property y.property⟩ : filtration Q (i + j)) :=
+        (⟨(x : CliffordAlgebra Q) * y, mul_mem_filtration Q x.property y.property⟩ :
+          filtration Q (i + j)) :=
   rfl
 
 private theorem filtrationGradedPreMul_mem_ker_left (Q : QuadraticForm R M) (i j : ℕ) :
@@ -129,9 +128,8 @@ theorem filtrationGradedMul_apply_mk (Q : QuadraticForm R M) (i j : ℕ) (x : fi
     (y : filtration Q j) :
     filtrationGradedMul Q i j (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) =
       Submodule.Quotient.mk
-        (⟨(x : CliffordAlgebra Q) * y, by
-          rw [← filtration_mul Q i j]
-          exact Submodule.mul_mem_mul x.property y.property⟩ : filtration Q (i + j)) :=
+        (⟨(x : CliffordAlgebra Q) * y, mul_mem_filtration Q x.property y.property⟩ :
+          filtration Q (i + j)) :=
   by
   rw [filtrationGradedMul, LinearMap.liftQ₂_mk]
   exact filtrationGradedPreMul_apply Q i j x y

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
@@ -21,8 +21,6 @@ The generic change-of-form transport belongs in `TauCeti.LinearAlgebra.CliffordA
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.exteriorPower_mem_zero_form_filtration`: a degree `k + 1` exterior
-  element lies in the degree `k + 1` step of the zero-form filtration.
 * `TauCeti.CliffordAlgebra.exteriorPower_succ_disjoint_zero_form_filtration`: degree `k + 1` is
   disjoint from the lower zero-form filtration.
 * `TauCeti.CliffordAlgebra.zeroFormFiltrationQuotientEquivExteriorPower`: the successive
@@ -46,17 +44,6 @@ namespace TauCeti
 namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
-
-/-- A degree `k + 1` exterior element lies in the degree `k + 1` step of the zero-form filtration.
-
-`⋀[R]^(k + 1) M` is the `k + 1`-st power of the range of `ExteriorAlgebra.ι`, and
-`ExteriorAlgebra R M` is `CliffordAlgebra (0 : QuadraticForm R M)`, so this is
-`ι_range_pow_le_filtration` at the zero form. It is stated separately so that the quotient
-equivalence's characteristic lemmas below can name this membership instead of rebuilding it
-inside their own statements. -/
-theorem exteriorPower_mem_zero_form_filtration (k : ℕ) (x : ⋀[R]^(k + 1) M) :
-    (x : CliffordAlgebra (0 : QuadraticForm R M)) ∈ filtration (0 : QuadraticForm R M) (k + 1) :=
-  ι_range_pow_le_filtration (0 : QuadraticForm R M) (k + 1) x.property
 
 /-- The degree `k + 1` exterior power is disjoint from the lower zero-form filtration. -/
 theorem exteriorPower_succ_disjoint_zero_form_filtration (k : ℕ) :
@@ -118,7 +105,8 @@ quotient class. -/
 theorem zeroFormFiltrationQuotientEquivExteriorPower_symm_apply (k : ℕ)
     (x : ⋀[R]^(k + 1) M) :
     (zeroFormFiltrationQuotientEquivExteriorPower k).symm x =
-      Submodule.Quotient.mk ⟨x, exteriorPower_mem_zero_form_filtration k x⟩ := by
+      Submodule.Quotient.mk
+        ⟨x, ι_range_pow_le_filtration (0 : QuadraticForm R M) (k + 1) x.property⟩ := by
   rw [zeroFormFiltrationQuotientEquivExteriorPower, LinearEquiv.trans_symm,
     LinearEquiv.trans_apply, quotientEquivOfEqSup_symm_apply]
   apply (Submodule.quotEquivOfEq _ _
@@ -131,7 +119,8 @@ that element. -/
 theorem zeroFormFiltrationQuotientEquivExteriorPower_apply (k : ℕ)
     (x : ⋀[R]^(k + 1) M) :
     zeroFormFiltrationQuotientEquivExteriorPower k
-      (Submodule.Quotient.mk ⟨x, exteriorPower_mem_zero_form_filtration k x⟩) = x := by
+      (Submodule.Quotient.mk
+        ⟨x, ι_range_pow_le_filtration (0 : QuadraticForm R M) (k + 1) x.property⟩) = x := by
   rw [← zeroFormFiltrationQuotientEquivExteriorPower_symm_apply k x,
     LinearEquiv.apply_symm_apply]
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
@@ -21,6 +21,8 @@ The generic change-of-form transport belongs in `TauCeti.LinearAlgebra.CliffordA
 
 ## Main results
 
+* `TauCeti.CliffordAlgebra.exteriorPower_mem_zero_form_filtration`: a degree `k + 1` exterior
+  element lies in the degree `k + 1` step of the zero-form filtration.
 * `TauCeti.CliffordAlgebra.exteriorPower_succ_disjoint_zero_form_filtration`: degree `k + 1` is
   disjoint from the lower zero-form filtration.
 * `TauCeti.CliffordAlgebra.zeroFormFiltrationQuotientEquivExteriorPower`: the successive
@@ -44,6 +46,17 @@ namespace TauCeti
 namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+/-- A degree `k + 1` exterior element lies in the degree `k + 1` step of the zero-form filtration.
+
+`⋀[R]^(k + 1) M` is the `k + 1`-st power of the range of `ExteriorAlgebra.ι`, and
+`ExteriorAlgebra R M` is `CliffordAlgebra (0 : QuadraticForm R M)`, so this is
+`ι_range_pow_le_filtration` at the zero form. It is stated separately so that the quotient
+equivalence's characteristic lemmas below can name this membership instead of rebuilding it
+inside their own statements. -/
+theorem exteriorPower_mem_zero_form_filtration (k : ℕ) (x : ⋀[R]^(k + 1) M) :
+    (x : CliffordAlgebra (0 : QuadraticForm R M)) ∈ filtration (0 : QuadraticForm R M) (k + 1) :=
+  ι_range_pow_le_filtration (0 : QuadraticForm R M) (k + 1) x.property
 
 /-- The degree `k + 1` exterior power is disjoint from the lower zero-form filtration. -/
 theorem exteriorPower_succ_disjoint_zero_form_filtration (k : ℕ) :
@@ -105,9 +118,7 @@ quotient class. -/
 theorem zeroFormFiltrationQuotientEquivExteriorPower_symm_apply (k : ℕ)
     (x : ⋀[R]^(k + 1) M) :
     (zeroFormFiltrationQuotientEquivExteriorPower k).symm x =
-      Submodule.Quotient.mk ⟨x, by
-        rw [zero_form_filtration_succ_eq_exteriorPower_sup]
-        exact Submodule.mem_sup_left x.property⟩ := by
+      Submodule.Quotient.mk ⟨x, exteriorPower_mem_zero_form_filtration k x⟩ := by
   rw [zeroFormFiltrationQuotientEquivExteriorPower, LinearEquiv.trans_symm,
     LinearEquiv.trans_apply, quotientEquivOfEqSup_symm_apply]
   apply (Submodule.quotEquivOfEq _ _
@@ -120,9 +131,7 @@ that element. -/
 theorem zeroFormFiltrationQuotientEquivExteriorPower_apply (k : ℕ)
     (x : ⋀[R]^(k + 1) M) :
     zeroFormFiltrationQuotientEquivExteriorPower k
-      (Submodule.Quotient.mk ⟨x, by
-        rw [zero_form_filtration_succ_eq_exteriorPower_sup]
-        exact Submodule.mem_sup_left x.property⟩) = x := by
+      (Submodule.Quotient.mk ⟨x, exteriorPower_mem_zero_form_filtration k x⟩) = x := by
   rw [← zeroFormFiltrationQuotientEquivExteriorPower_symm_apply k x,
     LinearEquiv.apply_symm_apply]
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -235,10 +235,7 @@ theorem filtration_mul (i j : ℕ) :
     omega
 
 /-- The elementwise form of `filtration_mul`: a product of an element of the `i`-th step and an
-element of the `j`-th step lies in the `i + j`-th step.
-
-This is the membership that the associated-graded product lemmas need in order to name their
-representatives, rather than rebuilding it from `filtration_mul` in each statement. -/
+element of the `j`-th step lies in the `i + j`-th step. -/
 theorem mul_mem_filtration {i j : ℕ} {x y : CliffordAlgebra Q} (hx : x ∈ filtration Q i)
     (hy : y ∈ filtration Q j) : x * y ∈ filtration Q (i + j) := by
   rw [← filtration_mul Q i j]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -49,7 +49,8 @@ supremum over the `i` of a fixed parity.
 * `TauCeti.CliffordAlgebra.filtration_mul`: the filtration is multiplicative, and in fact exactly
   so: `filtration Q i * filtration Q j = filtration Q (i + j)`. This is the statement that makes
   the associated graded object an algebra, and it is the prerequisite the roadmap asks for before
-  anything downstream; `TauCeti.CliffordAlgebra.filtration_pow` is its iterate.
+  anything downstream; `TauCeti.CliffordAlgebra.filtration_pow` is its iterate and
+  `TauCeti.CliffordAlgebra.mul_mem_filtration` its elementwise form.
 * `TauCeti.CliffordAlgebra.filtration_succ_eq_sup`: the recursion for the successor step.
 * `TauCeti.CliffordAlgebra.filtration_eq_iSup_pow`: the comparison with the submodule powers of
   `LinearMap.range (ι Q)`.
@@ -232,6 +233,16 @@ theorem filtration_mul (i j : ℕ) :
       (prod_map_ι_mem_filtration Q ?_)
     rw [List.length_drop]
     omega
+
+/-- The elementwise form of `filtration_mul`: a product of an element of the `i`-th step and an
+element of the `j`-th step lies in the `i + j`-th step.
+
+This is the membership that the associated-graded product lemmas need in order to name their
+representatives, rather than rebuilding it from `filtration_mul` in each statement. -/
+theorem mul_mem_filtration {i j : ℕ} {x y : CliffordAlgebra Q} (hx : x ∈ filtration Q i)
+    (hy : y ∈ filtration Q j) : x * y ∈ filtration Q (i + j) := by
+  rw [← filtration_mul Q i j]
+  exact Submodule.mul_mem_mul hx hy
 
 /-- Iterating `filtration_mul`: the `n`-th submodule power of the `i`-th step is the `i * n`-th
 step. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -29,8 +29,7 @@ It does not construct the total associated-graded algebra or prove multiplicatio
 
 * `TauCeti.CliffordAlgebra.equivExterior_mem_zero_form_filtration` and
   `TauCeti.CliffordAlgebra.equivExterior_symm_mem_filtration`: `equivExterior` and its inverse
-  carry the degree `k + 1` filtration step to the zero-form one and back. These are the
-  memberships the characteristic lemmas of `filtrationGradedEquiv` name.
+  carry each Clifford filtration step to the corresponding zero-form step and back.
 
 ## References
 
@@ -93,25 +92,19 @@ private noncomputable def equivExteriorFiltrationQuotient (Q : QuadraticForm R M
   Submodule.Quotient.equiv _ _ (equivExteriorFiltration Q (k + 1))
     (equivExteriorFiltration_map_previous Q k)
 
-/-- `equivExterior` carries the degree `k + 1` filtration step into the zero-form one.
-
-Named so that `filtrationGradedEquiv_apply_mk` can state its representative as a term. -/
+/-- `equivExterior` carries each Clifford filtration step into the corresponding zero-form step. -/
 theorem equivExterior_mem_zero_form_filtration (Q : QuadraticForm R M) [Invertible (2 : R)]
-    (k : ℕ) (x : filtration Q (k + 1)) :
-    equivExterior Q x ∈ filtration (0 : QuadraticForm R M) (k + 1) := by
-  simpa only [coe_equivExteriorFiltration_apply] using
-    (equivExteriorFiltration Q (k + 1) x).property
+    (k : ℕ) (x : filtration Q k) :
+    equivExterior Q x ∈ filtration (0 : QuadraticForm R M) k := by
+  simpa only [coe_equivExteriorFiltration_apply] using (equivExteriorFiltration Q k x).property
 
-/-- The inverse of `equivExterior` carries a degree `k + 1` exterior element back into the degree
-`k + 1` filtration step.
-
-Named so that `filtrationGradedEquiv_symm_apply` can state its representative as a term. -/
+/-- The inverse of `equivExterior` carries each zero-form filtration step back into the
+corresponding Clifford step. -/
 theorem equivExterior_symm_mem_filtration (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
-    (x : ⋀[R]^(k + 1) M) : (equivExterior Q).symm x ∈ filtration Q (k + 1) := by
+    (x : filtration (0 : QuadraticForm R M) k) :
+    (equivExterior Q).symm x ∈ filtration Q k := by
   simpa only [coe_equivExteriorFiltration_symm_apply] using
-    ((equivExteriorFiltration Q (k + 1)).symm
-      (⟨x, exteriorPower_mem_zero_form_filtration k x⟩ :
-        filtration (0 : QuadraticForm R M) (k + 1))).property
+    ((equivExteriorFiltration Q k).symm x).property
 
 /-- The successive degree quotient of a Clifford algebra is the corresponding exterior power. -/
 noncomputable def filtrationGradedEquiv (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
@@ -125,7 +118,7 @@ theorem filtrationGradedEquiv_apply_mk (Q : QuadraticForm R M) [Invertible (2 : 
     filtrationGradedEquiv Q k (Submodule.Quotient.mk x) =
       zeroFormFiltrationQuotientEquivExteriorPower k
         (Submodule.Quotient.mk
-          (⟨equivExterior Q x, equivExterior_mem_zero_form_filtration Q k x⟩ :
+          (⟨equivExterior Q x, equivExterior_mem_zero_form_filtration Q (k + 1) x⟩ :
             filtration (0 : QuadraticForm R M) (k + 1))) := by
   rw [filtrationGradedEquiv, LinearEquiv.trans_apply, equivExteriorFiltrationQuotient,
     Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
@@ -140,7 +133,8 @@ theorem filtrationGradedEquiv_symm_apply (Q : QuadraticForm R M) [Invertible (2 
     (x : ⋀[R]^(k + 1) M) :
     (filtrationGradedEquiv Q k).symm x =
       Submodule.Quotient.mk
-        (⟨(equivExterior Q).symm x, equivExterior_symm_mem_filtration Q k x⟩ :
+        (⟨(equivExterior Q).symm x, equivExterior_symm_mem_filtration Q (k + 1)
+            ⟨x, ι_range_pow_le_filtration (0 : QuadraticForm R M) (k + 1) x.property⟩⟩ :
           filtration Q (k + 1)) := by
   rw [filtrationGradedEquiv, LinearEquiv.trans_symm, LinearEquiv.trans_apply,
     zeroFormFiltrationQuotientEquivExteriorPower_symm_apply,

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -25,6 +25,13 @@ It does not construct the total associated-graded algebra or prove multiplicatio
 * `TauCeti.CliffordAlgebra.filtrationGradedEquiv`: the corresponding degree-quotient equivalence
   with the exterior power.
 
+## Main results
+
+* `TauCeti.CliffordAlgebra.equivExterior_mem_zero_form_filtration` and
+  `TauCeti.CliffordAlgebra.equivExterior_symm_mem_filtration`: `equivExterior` and its inverse
+  carry the degree `k + 1` filtration step to the zero-form one and back. These are the
+  memberships the characteristic lemmas of `filtrationGradedEquiv` name.
+
 ## References
 
 * [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
@@ -86,6 +93,26 @@ private noncomputable def equivExteriorFiltrationQuotient (Q : QuadraticForm R M
   Submodule.Quotient.equiv _ _ (equivExteriorFiltration Q (k + 1))
     (equivExteriorFiltration_map_previous Q k)
 
+/-- `equivExterior` carries the degree `k + 1` filtration step into the zero-form one.
+
+Named so that `filtrationGradedEquiv_apply_mk` can state its representative as a term. -/
+theorem equivExterior_mem_zero_form_filtration (Q : QuadraticForm R M) [Invertible (2 : R)]
+    (k : ℕ) (x : filtration Q (k + 1)) :
+    equivExterior Q x ∈ filtration (0 : QuadraticForm R M) (k + 1) := by
+  simpa only [coe_equivExteriorFiltration_apply] using
+    (equivExteriorFiltration Q (k + 1) x).property
+
+/-- The inverse of `equivExterior` carries a degree `k + 1` exterior element back into the degree
+`k + 1` filtration step.
+
+Named so that `filtrationGradedEquiv_symm_apply` can state its representative as a term. -/
+theorem equivExterior_symm_mem_filtration (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
+    (x : ⋀[R]^(k + 1) M) : (equivExterior Q).symm x ∈ filtration Q (k + 1) := by
+  simpa only [coe_equivExteriorFiltration_symm_apply] using
+    ((equivExteriorFiltration Q (k + 1)).symm
+      (⟨x, exteriorPower_mem_zero_form_filtration k x⟩ :
+        filtration (0 : QuadraticForm R M) (k + 1))).property
+
 /-- The successive degree quotient of a Clifford algebra is the corresponding exterior power. -/
 noncomputable def filtrationGradedEquiv (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
     FiltrationGradedPiece Q (k + 1) ≃ₗ[R] ⋀[R]^(k + 1) M :=
@@ -98,9 +125,7 @@ theorem filtrationGradedEquiv_apply_mk (Q : QuadraticForm R M) [Invertible (2 : 
     filtrationGradedEquiv Q k (Submodule.Quotient.mk x) =
       zeroFormFiltrationQuotientEquivExteriorPower k
         (Submodule.Quotient.mk
-          (⟨equivExterior Q x, by
-            simpa only [coe_equivExteriorFiltration_apply] using
-              (equivExteriorFiltration Q (k + 1) x).property⟩ :
+          (⟨equivExterior Q x, equivExterior_mem_zero_form_filtration Q k x⟩ :
             filtration (0 : QuadraticForm R M) (k + 1))) := by
   rw [filtrationGradedEquiv, LinearEquiv.trans_apply, equivExteriorFiltrationQuotient,
     Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
@@ -115,11 +140,7 @@ theorem filtrationGradedEquiv_symm_apply (Q : QuadraticForm R M) [Invertible (2 
     (x : ⋀[R]^(k + 1) M) :
     (filtrationGradedEquiv Q k).symm x =
       Submodule.Quotient.mk
-        (⟨(equivExterior Q).symm x, by
-          simpa only [coe_equivExteriorFiltration_symm_apply] using
-            ((equivExteriorFiltration Q (k + 1)).symm
-              (⟨x, ι_range_pow_le_filtration (0 : QuadraticForm R M) (k + 1) x.property⟩ :
-                filtration (0 : QuadraticForm R M) (k + 1))).property⟩ :
+        (⟨(equivExterior Q).symm x, equivExterior_symm_mem_filtration Q k x⟩ :
           filtration Q (k + 1)) := by
   rw [filtrationGradedEquiv, LinearEquiv.trans_symm, LinearEquiv.trans_apply,
     zeroFormFiltrationQuotientEquivExteriorPower_symm_apply,

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -94,17 +94,18 @@ private noncomputable def equivExteriorFiltrationQuotient (Q : QuadraticForm R M
 
 /-- `equivExterior` carries each Clifford filtration step into the corresponding zero-form step. -/
 theorem equivExterior_mem_zero_form_filtration (Q : QuadraticForm R M) [Invertible (2 : R)]
-    (k : ℕ) (x : filtration Q k) :
+    {k : ℕ} {x : CliffordAlgebra Q} (hx : x ∈ filtration Q k) :
     equivExterior Q x ∈ filtration (0 : QuadraticForm R M) k := by
-  simpa only [coe_equivExteriorFiltration_apply] using (equivExteriorFiltration Q k x).property
+  simpa only [coe_equivExteriorFiltration_apply] using
+    (equivExteriorFiltration Q k ⟨x, hx⟩).property
 
 /-- The inverse of `equivExterior` carries each zero-form filtration step back into the
 corresponding Clifford step. -/
-theorem equivExterior_symm_mem_filtration (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
-    (x : filtration (0 : QuadraticForm R M) k) :
+theorem equivExterior_symm_mem_filtration (Q : QuadraticForm R M) [Invertible (2 : R)] {k : ℕ}
+    {x : ExteriorAlgebra R M} (hx : x ∈ filtration (0 : QuadraticForm R M) k) :
     (equivExterior Q).symm x ∈ filtration Q k := by
   simpa only [coe_equivExteriorFiltration_symm_apply] using
-    ((equivExteriorFiltration Q k).symm x).property
+    ((equivExteriorFiltration Q k).symm ⟨x, hx⟩).property
 
 /-- The successive degree quotient of a Clifford algebra is the corresponding exterior power. -/
 noncomputable def filtrationGradedEquiv (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
@@ -118,7 +119,7 @@ theorem filtrationGradedEquiv_apply_mk (Q : QuadraticForm R M) [Invertible (2 : 
     filtrationGradedEquiv Q k (Submodule.Quotient.mk x) =
       zeroFormFiltrationQuotientEquivExteriorPower k
         (Submodule.Quotient.mk
-          (⟨equivExterior Q x, equivExterior_mem_zero_form_filtration Q (k + 1) x⟩ :
+          (⟨equivExterior Q x, equivExterior_mem_zero_form_filtration Q x.property⟩ :
             filtration (0 : QuadraticForm R M) (k + 1))) := by
   rw [filtrationGradedEquiv, LinearEquiv.trans_apply, equivExteriorFiltrationQuotient,
     Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
@@ -133,8 +134,8 @@ theorem filtrationGradedEquiv_symm_apply (Q : QuadraticForm R M) [Invertible (2 
     (x : ⋀[R]^(k + 1) M) :
     (filtrationGradedEquiv Q k).symm x =
       Submodule.Quotient.mk
-        (⟨(equivExterior Q).symm x, equivExterior_symm_mem_filtration Q (k + 1)
-            ⟨x, ι_range_pow_le_filtration (0 : QuadraticForm R M) (k + 1) x.property⟩⟩ :
+        (⟨(equivExterior Q).symm x, equivExterior_symm_mem_filtration Q
+            (ι_range_pow_le_filtration (0 : QuadraticForm R M) (k + 1) x.property)⟩ :
           filtration Q (k + 1)) := by
   rw [filtrationGradedEquiv, LinearEquiv.trans_symm, LinearEquiv.trans_apply,
     zeroFormFiltrationQuotientEquivExteriorPower_symm_apply,


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR gives names to the four filtration memberships that were being rebuilt inside the statements of public `@[simp]` lemmas, so that those statements become terms. Each of `filtrationGradedPreMul_apply`, `filtrationGradedMul_apply_mk`, `zeroFormFiltrationQuotientEquivExteriorPower_symm_apply`, `zeroFormFiltrationQuotientEquivExteriorPower_apply`, `filtrationGradedEquiv_apply_mk` and `filtrationGradedEquiv_symm_apply` previously spelled its representative as `Submodule.Quotient.mk ⟨_, by …⟩` with a tactic block inside the statement.

The two `zeroFormFiltrationQuotientEquivExteriorPower` lemmas are the sharp case: their statements called the `private` lemma `zero_form_filtration_succ_eq_exteriorPower_sup`, so a consumer outside the file could not restate them, rewrite with them by hand, or reproduce the membership. That is now `exteriorPower_mem_zero_form_filtration`, which needs no new mathematics: `⋀[R]^n M` is the `n`-th power of `LinearMap.range (ExteriorAlgebra.ι R)` and `ExteriorAlgebra R M` is `CliffordAlgebra (0 : QuadraticForm R M)`, so `ι_range_pow_le_filtration` at the zero form already is the witness. `Graded.lean` was in fact already using it in exactly that form at one site while `ExteriorFiltration.lean` rebuilt it from the private lemma at two others.

`mul_mem_filtration` is the elementwise form of `filtration_mul`. Besides the two statements, it also replaces the same `rw [← filtration_mul]; exact Submodule.mul_mem_mul` incantation in the bodies of `mul_mem_filtrationPrevious_left` and `mul_mem_filtrationPrevious_right`, so it had four call sites waiting for it.

No lemma changes its meaning, its name, or its generality; the `private` lemma stays private. All four new declarations are indexed in their module docstrings. The full build with `--iofail`, axiom audit, module-system check and environment lint pass; `lint-env` reports no new violations, which is the relevant check here since restating a `@[simp]` lemma risks a fresh `simpNF` complaint and these files carry no grandfathered entries.

🤖 Prepared with Claude Code