### PR TITLE
feat(Huber): the p-adic integers are Huber but not Tate

### DIFF
--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -35,8 +35,7 @@ Huber ring is nonarchimedean, which is exactly the hypothesis under which
   `TauCeti.Huber.PairOfDefinition.coe_idealImage`: membership in the image of `Iⁿ`.
 * `TauCeti.Huber.PairOfDefinition.hasBasis_nhds_zero`: the images of `Iⁿ` are a neighbourhood
   basis of zero.
-* `TauCeti.Huber.fg_comap_of_equiv` and `TauCeti.Huber.IsAdic.comap`: finite generation and an
-  adic topology transport along a ring equivalence that is an
+* `TauCeti.Huber.IsAdic.comap`: an adic topology transports along a ring equivalence that is an
   inducing map. This is what lets a ring of definition carry an ideal of definition that natively
   lives in a merely equivalent ring, which is what `TauCeti.Huber.PairOfDefinition` needs.
 * `TauCeti.Huber.IsHuberRing.toNonarchimedeanRing`: a Huber ring is nonarchimedean.
@@ -134,12 +133,6 @@ section Transport
 
 variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
   [CommRing B] [TopologicalSpace B] [IsTopologicalRing B]
-
-omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
-/-- Finite generation transports along a ring equivalence. -/
-theorem fg_comap_of_equiv (e : B ≃+* A) {I : Ideal A} (h : I.FG) : (I.comap e).FG := by
-  rw [← Ideal.map_symm]
-  exact Ideal.FG.map h e.symm.toRingHom
 
 omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
 /-- The powers of a comapped ideal are the comapped powers, along a ring equivalence. -/

--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.RingTheory.Finiteness.Ideal
 public import Mathlib.Topology.Algebra.Nonarchimedean.AdicTopology
+public import TauCeti.Topology.Algebra.Nonarchimedean.AdicTopology
 public import TauCeti.RingTheory.Huber.PowerBounded
 
 /-!
@@ -35,9 +36,6 @@ Huber ring is nonarchimedean, which is exactly the hypothesis under which
   `TauCeti.Huber.PairOfDefinition.coe_idealImage`: membership in the image of `Iⁿ`.
 * `TauCeti.Huber.PairOfDefinition.hasBasis_nhds_zero`: the images of `Iⁿ` are a neighbourhood
   basis of zero.
-* `TauCeti.Huber.IsAdic.comap`: an adic topology transports along a ring equivalence that is an
-  inducing map. This is what lets a ring of definition carry an ideal of definition that natively
-  lives in a merely equivalent ring, which is what `TauCeti.Huber.PairOfDefinition` needs.
 * `TauCeti.Huber.IsHuberRing.toNonarchimedeanRing`: a Huber ring is nonarchimedean.
 * `TauCeti.Huber.PairOfDefinition.isBounded_ringOfDefinition`: a ring of definition is bounded,
   hence `A₀ ≤ A°` (`TauCeti.Huber.PairOfDefinition.le_powerBoundedSubring`). This is the
@@ -128,42 +126,6 @@ class IsTateRing (A : Type*) [CommRing A] [TopologicalSpace A] [IsTopologicalRin
     extends IsHuberRing A where
   /-- A Tate ring contains a topologically nilpotent unit. -/
   exists_isPseudoUniformizer : ∃ a : A, IsPseudoUniformizer a
-
-section Transport
-
-variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
-  [CommRing B] [TopologicalSpace B] [IsTopologicalRing B]
-
-omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
-/-- The powers of a comapped ideal are the comapped powers, along a ring equivalence. -/
-private theorem comap_pow_of_equiv (e : B ≃+* A) (I : Ideal A) (n : ℕ) :
-    (I ^ n).comap e = I.comap e ^ n := by
-  rw [← Ideal.map_symm, ← Ideal.map_symm, Ideal.map_pow]
-
-/-- An adic topology transports along a ring equivalence that is also an inducing map.
-
-This is what lets a ring of definition carry an ideal of definition: `PairOfDefinition` asks for
-an `Ideal A₀` whose adic topology is the subspace topology, while the ideal at hand usually lives
-in a ring that is only equivalent to `A₀`. -/
-theorem IsAdic.comap (e : B ≃+* A) (he : IsInducing e) {I : Ideal A} (h : IsAdic I) :
-    IsAdic (I.comap e) := by
-  rw [isAdic_iff] at h ⊢
-  obtain ⟨hopen, hnhds⟩ := h
-  have hset : ∀ n : ℕ,
-      ((I.comap e ^ n : Ideal B) : Set B) = e ⁻¹' ((I ^ n : Ideal A) : Set A) := by
-    intro n
-    ext b
-    rw [← comap_pow_of_equiv e I n, SetLike.mem_coe, Ideal.mem_comap, Set.mem_preimage,
-      SetLike.mem_coe]
-  refine ⟨fun n ↦ ?_, fun s hs ↦ ?_⟩
-  · rw [hset n, he.isOpen_iff]
-    exact ⟨_, hopen n, rfl⟩
-  · rw [he.nhds_eq_comap (0 : B), map_zero, Filter.mem_comap] at hs
-    obtain ⟨t, ht, hts⟩ := hs
-    obtain ⟨n, hn⟩ := hnhds t ht
-    exact ⟨n, by rw [hset n]; exact fun b hb ↦ hts (hn hb)⟩
-
-end Transport
 
 namespace PairOfDefinition
 

--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -35,6 +35,10 @@ Huber ring is nonarchimedean, which is exactly the hypothesis under which
   `TauCeti.Huber.PairOfDefinition.coe_idealImage`: membership in the image of `Iⁿ`.
 * `TauCeti.Huber.PairOfDefinition.hasBasis_nhds_zero`: the images of `Iⁿ` are a neighbourhood
   basis of zero.
+* `TauCeti.Huber.fg_comap_of_equiv` and `TauCeti.Huber.IsAdic.comap`: finite generation and an
+  adic topology transport along a ring equivalence that is an
+  inducing map. This is what lets a ring of definition carry an ideal of definition that natively
+  lives in a merely equivalent ring, which is what `TauCeti.Huber.PairOfDefinition` needs.
 * `TauCeti.Huber.IsHuberRing.toNonarchimedeanRing`: a Huber ring is nonarchimedean.
 * `TauCeti.Huber.PairOfDefinition.isBounded_ringOfDefinition`: a ring of definition is bounded,
   hence `A₀ ≤ A°` (`TauCeti.Huber.PairOfDefinition.le_powerBoundedSubring`). This is the
@@ -125,6 +129,48 @@ class IsTateRing (A : Type*) [CommRing A] [TopologicalSpace A] [IsTopologicalRin
     extends IsHuberRing A where
   /-- A Tate ring contains a topologically nilpotent unit. -/
   exists_isPseudoUniformizer : ∃ a : A, IsPseudoUniformizer a
+
+section Transport
+
+variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
+  [CommRing B] [TopologicalSpace B] [IsTopologicalRing B]
+
+omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
+/-- Finite generation transports along a ring equivalence. -/
+theorem fg_comap_of_equiv (e : B ≃+* A) {I : Ideal A} (h : I.FG) : (I.comap e).FG := by
+  rw [← Ideal.map_symm]
+  exact Ideal.FG.map h e.symm.toRingHom
+
+omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
+/-- The powers of a comapped ideal are the comapped powers, along a ring equivalence. -/
+private theorem comap_pow_of_equiv (e : B ≃+* A) (I : Ideal A) (n : ℕ) :
+    (I ^ n).comap e = I.comap e ^ n := by
+  rw [← Ideal.map_symm, ← Ideal.map_symm, Ideal.map_pow]
+
+/-- An adic topology transports along a ring equivalence that is also an inducing map.
+
+This is what lets a ring of definition carry an ideal of definition: `PairOfDefinition` asks for
+an `Ideal A₀` whose adic topology is the subspace topology, while the ideal at hand usually lives
+in a ring that is only equivalent to `A₀`. -/
+theorem IsAdic.comap (e : B ≃+* A) (he : IsInducing e) {I : Ideal A} (h : IsAdic I) :
+    IsAdic (I.comap e) := by
+  rw [isAdic_iff] at h ⊢
+  obtain ⟨hopen, hnhds⟩ := h
+  have hset : ∀ n : ℕ,
+      ((I.comap e ^ n : Ideal B) : Set B) = e ⁻¹' ((I ^ n : Ideal A) : Set A) := by
+    intro n
+    ext b
+    rw [← comap_pow_of_equiv e I n, SetLike.mem_coe, Ideal.mem_comap, Set.mem_preimage,
+      SetLike.mem_coe]
+  refine ⟨fun n ↦ ?_, fun s hs ↦ ?_⟩
+  · rw [hset n, he.isOpen_iff]
+    exact ⟨_, hopen n, rfl⟩
+  · rw [he.nhds_eq_comap (0 : B), map_zero, Filter.mem_comap] at hs
+    obtain ⟨t, ht, hts⟩ := hs
+    obtain ⟨n, hn⟩ := hnhds t ht
+    exact ⟨n, by rw [hset n]; exact fun b hb ↦ hts (hn hb)⟩
+
+end Transport
 
 namespace PairOfDefinition
 

--- a/TauCeti/RingTheory/Huber/Padic.lean
+++ b/TauCeti/RingTheory/Huber/Padic.lean
@@ -42,7 +42,9 @@ Tate, and `ℚ_p⟨T₁,…,Tₙ⟩` is complete and strongly noetherian — are
 
 ## References
 
-* [Wedhorn, *Adic Spaces*][wedhorn_adic], Example 6.3.
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], §6, where Huber and Tate rings are introduced
+  (Proposition and Definition 6.1) and `ℤ_[p]` is the standard example of a Huber ring that
+  is not Tate.
 -/
 
 public section

--- a/TauCeti/RingTheory/Huber/Padic.lean
+++ b/TauCeti/RingTheory/Huber/Padic.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.NumberTheory.Padics.PadicIntegers
+public import Mathlib.NumberTheory.Padics.ProperSpace
+public import Mathlib.Topology.Algebra.Ring.Compact
 public import TauCeti.RingTheory.Huber.Basic
 
 /-!
@@ -26,9 +28,8 @@ nilpotent.
   adicity transport along a ring equivalence that is also an inducing map. This is what lets a
   ring of definition carry an ideal that natively lives in a merely equivalent ring, which is
   what `TauCeti.Huber.PairOfDefinition` needs here.
-* `TauCeti.Huber.PadicInt.coe_maximalIdeal_pow` and
-  `TauCeti.Huber.PadicInt.isOpen_maximalIdeal_pow`: `(p)ⁿ` is the closed ball of radius `p⁻ⁿ`,
-  and is open.
+* `TauCeti.Huber.PadicInt.coe_maximalIdeal_pow`: `(p)ⁿ` is the closed ball of radius `p⁻ⁿ`.
+  Openness is Mathlib's `IsLocalRing.isOpen_maximalIdeal_pow`.
 * `TauCeti.Huber.PadicInt.isAdic_maximalIdeal`: the norm topology of `ℤ_[p]` is the `(p)`-adic
   topology. Mathlib has `IsAdicComplete (maximalIdeal ℤ_[p]) ℤ_[p]` but not this comparison of
   topologies, which is what a pair of definition requires.
@@ -109,23 +110,11 @@ theorem coe_maximalIdeal_pow (n : ℕ) :
   rw [_root_.PadicInt.maximalIdeal_eq_span_p, Ideal.span_singleton_pow,
     ← _root_.PadicInt.norm_le_pow_iff_mem_span_pow]
 
-/-- Every power of the maximal ideal of `ℤ_[p]` is open. -/
-theorem isOpen_maximalIdeal_pow (n : ℕ) :
-    IsOpen ((maximalIdeal ℤ_[p] ^ n : Ideal ℤ_[p]) : Set ℤ_[p]) := by
-  -- the ultrametric inequality carries the ball of radius `p⁻ⁿ` about any point back into the set
-  have hp0 : (0 : ℝ) < p := mod_cast (Fact.out : p.Prime).pos
-  rw [coe_maximalIdeal_pow, Metric.isOpen_iff]
-  intro x hx
-  refine ⟨(p : ℝ) ^ (-n : ℤ), zpow_pos hp0 _, fun y hy ↦ ?_⟩
-  rw [Set.mem_ofPred_eq, show y = y - x + x by ring]
-  refine (_root_.PadicInt.nonarchimedean _ _).trans (max_le (le_of_lt ?_) hx)
-  simpa [dist_eq_norm] using hy
-
 /-- **The norm topology of `ℤ_[p]` is the `(p)`-adic topology.** -/
 theorem isAdic_maximalIdeal : IsAdic (maximalIdeal ℤ_[p]) := by
   have hp1 : (p : ℝ)⁻¹ < 1 := inv_lt_one_of_one_lt₀ <| mod_cast (Fact.out : p.Prime).one_lt
   rw [isAdic_iff]
-  refine ⟨isOpen_maximalIdeal_pow, fun s hs ↦ ?_⟩
+  refine ⟨IsLocalRing.isOpen_maximalIdeal_pow ℤ_[p], fun s hs ↦ ?_⟩
   obtain ⟨ε, hε, hball⟩ := Metric.mem_nhds_iff.mp hs
   obtain ⟨n, hn⟩ := exists_pow_lt_of_lt_one hε hp1
   refine ⟨n, fun x hx ↦ hball ?_⟩

--- a/TauCeti/RingTheory/Huber/Padic.lean
+++ b/TauCeti/RingTheory/Huber/Padic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.NumberTheory.Padics.PadicIntegers
 public import Mathlib.NumberTheory.Padics.ProperSpace
 public import Mathlib.Topology.Algebra.Ring.Compact
 public import TauCeti.RingTheory.Huber.Basic
@@ -24,10 +23,6 @@ nilpotent.
 
 ## Main results
 
-* `TauCeti.Huber.fg_comap_of_equiv` and `TauCeti.Huber.IsAdic.comap`: finite generation and
-  adicity transport along a ring equivalence that is also an inducing map. This is what lets a
-  ring of definition carry an ideal that natively lives in a merely equivalent ring, which is
-  what `TauCeti.Huber.PairOfDefinition` needs here.
 * `TauCeti.Huber.PadicInt.coe_maximalIdeal_pow`: `(p)ⁿ` is the closed ball of radius `p⁻ⁿ`.
   Openness is Mathlib's `IsLocalRing.isOpen_maximalIdeal_pow`.
 * `TauCeti.Huber.PadicInt.isAdic_maximalIdeal`: the norm topology of `ℤ_[p]` is the `(p)`-adic
@@ -35,6 +30,12 @@ nilpotent.
   topologies, which is what a pair of definition requires.
 * `TauCeti.Huber.PadicInt.isHuberRing` and `TauCeti.Huber.PadicInt.not_isTateRing`: the two
   halves of the example.
+
+## Implementation notes
+
+The ring of definition is all of `ℤ_[p]`, so the ideal of definition has to be carried across
+`Subring.topEquiv`; `TauCeti.Huber.IsAdic.comap` in `TauCeti/RingTheory/Huber/Basic.lean` is the
+general transport that does it.
 
 ## Scope
 
@@ -53,48 +54,6 @@ public section
 open Topology IsLocalRing
 
 namespace TauCeti.Huber
-
-section Transport
-
-variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
-  [CommRing B] [TopologicalSpace B] [IsTopologicalRing B]
-
-omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
-/-- Finite generation transports along a ring equivalence. -/
-private theorem fg_comap_of_equiv (e : B ≃+* A) {I : Ideal A} (h : I.FG) : (I.comap e).FG := by
-  rw [← Ideal.map_symm]
-  exact Ideal.FG.map h e.symm.toRingHom
-
-omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
-/-- The powers of a comapped ideal are the comapped powers, along a ring equivalence. -/
-private theorem comap_pow_of_equiv (e : B ≃+* A) (I : Ideal A) (n : ℕ) :
-    (I ^ n).comap e = I.comap e ^ n := by
-  rw [← Ideal.map_symm, ← Ideal.map_symm, Ideal.map_pow]
-
-/-- An adic topology transports along a ring equivalence that is also an inducing map.
-
-This is what lets a ring of definition carry an ideal of definition: `PairOfDefinition` asks for
-an `Ideal A₀` whose adic topology is the subspace topology, while the ideal at hand usually lives
-in a ring that is only equivalent to `A₀`. -/
-theorem IsAdic.comap (e : B ≃+* A) (he : IsInducing e) {I : Ideal A} (h : IsAdic I) :
-    IsAdic (I.comap e) := by
-  rw [isAdic_iff] at h ⊢
-  obtain ⟨hopen, hnhds⟩ := h
-  have hset : ∀ n : ℕ,
-      ((I.comap e ^ n : Ideal B) : Set B) = e ⁻¹' ((I ^ n : Ideal A) : Set A) := by
-    intro n
-    ext b
-    rw [← comap_pow_of_equiv e I n]
-    exact Iff.rfl
-  refine ⟨fun n ↦ ?_, fun s hs ↦ ?_⟩
-  · rw [hset n, he.isOpen_iff]
-    exact ⟨_, hopen n, rfl⟩
-  · rw [he.nhds_eq_comap (0 : B), map_zero, Filter.mem_comap] at hs
-    obtain ⟨t, ht, hts⟩ := hs
-    obtain ⟨n, hn⟩ := hnhds t ht
-    exact ⟨n, by rw [hset n]; exact fun b hb ↦ hts (hn hb)⟩
-
-end Transport
 
 namespace PadicInt
 
@@ -148,8 +107,9 @@ Stated as a membership characterisation rather than an equation because the type
 @[simp]
 theorem mem_pairOfDefinition_idealOfDefinition
     {x : (pairOfDefinition (p := p)).ringOfDefinition} :
-    x ∈ (pairOfDefinition (p := p)).idealOfDefinition ↔ (x : ℤ_[p]) ∈ maximalIdeal ℤ_[p] :=
-  (Iff.rfl)
+    x ∈ (pairOfDefinition (p := p)).idealOfDefinition ↔ (x : ℤ_[p]) ∈ maximalIdeal ℤ_[p] := by
+  simp only [pairOfDefinition]
+  exact Ideal.mem_comap
 
 /-- **`ℤ_[p]` is a Huber ring**, with `(ℤ_[p], (p))` as a pair of definition. -/
 instance isHuberRing : IsHuberRing ℤ_[p] :=

--- a/TauCeti/RingTheory/Huber/Padic.lean
+++ b/TauCeti/RingTheory/Huber/Padic.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.Padics.PadicIntegers
+public import TauCeti.RingTheory.Huber.Basic
+
+/-!
+# The p-adic integers and numbers as Huber rings
+
+`ℤ_[p]` is a Huber ring which is not Tate, and `ℚ_[p]` is a Tate ring. These are the roadmap's
+Layer-0 examples after the discrete case, and the first to separate `IsHuberRing` from
+`IsTateRing`: `ℤ_[p]` has no topologically nilpotent unit, because its units are exactly the
+elements of norm one.
+
+## Main results
+
+* `TauCeti.Huber.IsAdic.comap`: an adic topology transports along a ring equivalence that is
+  also an inducing map, which is what puts a ring of definition's ideal where
+  `TauCeti.Huber.PairOfDefinition` wants it.
+* `TauCeti.Huber.PadicInt.isAdic_maximalIdeal`: the norm topology of `ℤ_[p]` is the `(p)`-adic
+  topology.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Example 6.3.
+-/
+
+public section
+
+open Topology IsLocalRing
+
+namespace TauCeti.Huber
+
+section Transport
+
+variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
+  [CommRing B] [TopologicalSpace B] [IsTopologicalRing B]
+
+omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
+/-- Finite generation transports along a ring equivalence.
+
+Stated in the abstract so the `Ideal.map_symm` rewrite is elaborated once here rather than against
+a concrete subring instance, where unification is expensive. -/
+theorem fg_comap_of_equiv (e : B ≃+* A) {I : Ideal A} (h : I.FG) : (I.comap e).FG := by
+  classical
+  obtain ⟨s, hs⟩ := h
+  refine ⟨s.image e.symm, ?_⟩
+  rw [← Ideal.map_symm, ← hs, Finset.coe_image, Ideal.map_span]
+
+omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
+/-- The powers of a comapped ideal are the comapped powers, along a ring equivalence. -/
+private theorem comap_pow_of_equiv (e : B ≃+* A) (I : Ideal A) (n : ℕ) :
+    (I ^ n).comap e = I.comap e ^ n := by
+  rw [← Ideal.map_symm, ← Ideal.map_symm, Ideal.map_pow]
+
+/-- An adic topology transports along a ring equivalence that is also an inducing map.
+
+This is what lets a ring of definition carry an ideal of definition: `PairOfDefinition` asks for
+an `Ideal A₀` whose adic topology is the subspace topology, while the ideal at hand usually lives
+in a ring that is only equivalent to `A₀`. -/
+theorem IsAdic.comap (e : B ≃+* A) (he : IsInducing e) {I : Ideal A} (h : IsAdic I) :
+    IsAdic (I.comap e) := by
+  rw [isAdic_iff] at h ⊢
+  obtain ⟨hopen, hnhds⟩ := h
+  have hset : ∀ n : ℕ,
+      ((I.comap e ^ n : Ideal B) : Set B) = e ⁻¹' ((I ^ n : Ideal A) : Set A) := by
+    intro n
+    ext b
+    rw [← comap_pow_of_equiv e I n]
+    exact Iff.rfl
+  refine ⟨fun n ↦ ?_, fun s hs ↦ ?_⟩
+  · rw [hset n, he.isOpen_iff]
+    exact ⟨_, hopen n, rfl⟩
+  · rw [he.nhds_eq_comap (0 : B), map_zero, Filter.mem_comap] at hs
+    obtain ⟨t, ht, hts⟩ := hs
+    obtain ⟨n, hn⟩ := hnhds t ht
+    exact ⟨n, by rw [hset n]; exact fun b hb ↦ hts (hn hb)⟩
+
+end Transport
+
+namespace PadicInt
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- The `n`-th power of the maximal ideal of `ℤ_[p]` is the closed ball of radius `p⁻ⁿ`: this is
+what ties the norm topology to the `(p)`-adic one. -/
+theorem coe_maximalIdeal_pow (n : ℕ) :
+    ((maximalIdeal ℤ_[p] ^ n : Ideal ℤ_[p]) : Set ℤ_[p])
+      = {x : ℤ_[p] | ‖x‖ ≤ (p : ℝ) ^ (-n : ℤ)} := by
+  ext x
+  simp only [Set.mem_ofPred_eq, SetLike.mem_coe]
+  rw [_root_.PadicInt.maximalIdeal_eq_span_p, Ideal.span_singleton_pow,
+    ← _root_.PadicInt.norm_le_pow_iff_mem_span_pow]
+
+/-- Every power of the maximal ideal of `ℤ_[p]` is open: the ultrametric inequality carries the
+whole ball of radius `p⁻ⁿ` around any of its points back into it. -/
+theorem isOpen_maximalIdeal_pow (n : ℕ) :
+    IsOpen ((maximalIdeal ℤ_[p] ^ n : Ideal ℤ_[p]) : Set ℤ_[p]) := by
+  have hp0 : (0 : ℝ) < p := mod_cast (Fact.out : p.Prime).pos
+  rw [coe_maximalIdeal_pow, Metric.isOpen_iff]
+  intro x hx
+  refine ⟨(p : ℝ) ^ (-n : ℤ), zpow_pos hp0 _, fun y hy ↦ ?_⟩
+  rw [Set.mem_ofPred_eq, show y = y - x + x by ring]
+  refine (_root_.PadicInt.nonarchimedean _ _).trans (max_le (le_of_lt ?_) hx)
+  simpa [dist_eq_norm] using hy
+
+/-- **The norm topology of `ℤ_[p]` is the `(p)`-adic topology.** -/
+theorem isAdic_maximalIdeal : IsAdic (maximalIdeal ℤ_[p]) := by
+  have hp1 : (p : ℝ)⁻¹ < 1 := inv_lt_one_of_one_lt₀ <| mod_cast (Fact.out : p.Prime).one_lt
+  rw [isAdic_iff]
+  refine ⟨isOpen_maximalIdeal_pow, fun s hs ↦ ?_⟩
+  obtain ⟨ε, hε, hball⟩ := Metric.mem_nhds_iff.mp hs
+  obtain ⟨n, hn⟩ := exists_pow_lt_of_lt_one hε hp1
+  refine ⟨n, fun x hx ↦ hball ?_⟩
+  rw [coe_maximalIdeal_pow, Set.mem_ofPred_eq] at hx
+  refine Metric.mem_ball.mpr (lt_of_le_of_lt ?_ hn)
+  simpa [zpow_neg, zpow_natCast, ← inv_pow, dist_eq_norm] using hx
+
+/-- The pair of definition `(ℤ_[p], (p))` exhibiting `ℤ_[p]` as a Huber ring. The ring of
+definition is everything, and the ideal of definition is the maximal ideal carried across
+`Subring.topEquiv`. -/
+noncomputable def pairOfDefinition : PairOfDefinition ℤ_[p] where
+  ringOfDefinition := ⊤
+  isOpen_ringOfDefinition := by simp
+  idealOfDefinition :=
+    (maximalIdeal ℤ_[p]).comap (Subring.topEquiv : (⊤ : Subring ℤ_[p]) ≃+* ℤ_[p])
+  fg_idealOfDefinition :=
+    fg_comap_of_equiv _ (by
+      rw [_root_.PadicInt.maximalIdeal_eq_span_p]; exact Submodule.fg_span_singleton _)
+  isAdic_idealOfDefinition :=
+    IsAdic.comap _ Topology.IsInducing.subtypeVal isAdic_maximalIdeal
+
+/-- **`ℤ_[p]` is a Huber ring**, with `(ℤ_[p], (p))` as a pair of definition. -/
+instance isHuberRing : IsHuberRing ℤ_[p] :=
+  ⟨⟨pairOfDefinition⟩⟩
+
+/-- **`ℤ_[p]` is not a Tate ring.** Its units are exactly the elements of norm one, whose powers
+all have norm one, so no unit is topologically nilpotent and there is no pseudouniformiser. -/
+theorem not_isTateRing : ¬ IsTateRing ℤ_[p] := by
+  intro h
+  obtain ⟨a, ha⟩ := h.exists_isPseudoUniformizer
+  have hone : ∀ n : ℕ, ‖a ^ n‖ = 1 := fun n ↦ by
+    rw [norm_pow, _root_.PadicInt.isUnit_iff.mp ha.isUnit, one_pow]
+  have hnorm : Filter.Tendsto (fun n : ℕ ↦ ‖a ^ n‖) Filter.atTop (nhds ‖(0 : ℤ_[p])‖) :=
+    (continuous_norm.tendsto _).comp ha.isTopologicallyNilpotent
+  rw [norm_zero, Filter.tendsto_congr hone] at hnorm
+  exact one_ne_zero (tendsto_nhds_unique tendsto_const_nhds hnorm)
+
+end PadicInt
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Padic.lean
+++ b/TauCeti/RingTheory/Huber/Padic.lean
@@ -8,20 +8,37 @@ public import Mathlib.NumberTheory.Padics.PadicIntegers
 public import TauCeti.RingTheory.Huber.Basic
 
 /-!
-# The p-adic integers and numbers as Huber rings
+# The p-adic integers are a Huber ring, and not a Tate ring
 
-`ℤ_[p]` is a Huber ring which is not Tate, and `ℚ_[p]` is a Tate ring. These are the roadmap's
-Layer-0 examples after the discrete case, and the first to separate `IsHuberRing` from
-`IsTateRing`: `ℤ_[p]` has no topologically nilpotent unit, because its units are exactly the
-elements of norm one.
+`ℤ_[p]` with its norm topology is a Huber ring, with `(ℤ_[p], (p))` as a pair of definition, and
+it is not a Tate ring. It is the roadmap's Layer-0 example after the discrete case, and the first
+to separate `TauCeti.Huber.IsHuberRing` from `TauCeti.Huber.IsTateRing`: the units of `ℤ_[p]` are
+exactly the elements of norm one, whose powers again have norm one, so no unit is topologically
+nilpotent.
+
+## Main definitions
+
+* `TauCeti.Huber.PadicInt.pairOfDefinition`: the pair of definition `(ℤ_[p], (p))`.
 
 ## Main results
 
-* `TauCeti.Huber.IsAdic.comap`: an adic topology transports along a ring equivalence that is
-  also an inducing map, which is what puts a ring of definition's ideal where
-  `TauCeti.Huber.PairOfDefinition` wants it.
+* `TauCeti.Huber.fg_comap_of_equiv` and `TauCeti.Huber.IsAdic.comap`: finite generation and
+  adicity transport along a ring equivalence that is also an inducing map. This is what lets a
+  ring of definition carry an ideal that natively lives in a merely equivalent ring, which is
+  what `TauCeti.Huber.PairOfDefinition` needs here.
+* `TauCeti.Huber.PadicInt.coe_maximalIdeal_pow` and
+  `TauCeti.Huber.PadicInt.isOpen_maximalIdeal_pow`: `(p)ⁿ` is the closed ball of radius `p⁻ⁿ`,
+  and is open.
 * `TauCeti.Huber.PadicInt.isAdic_maximalIdeal`: the norm topology of `ℤ_[p]` is the `(p)`-adic
-  topology.
+  topology. Mathlib has `IsAdicComplete (maximalIdeal ℤ_[p]) ℤ_[p]` but not this comparison of
+  topologies, which is what a pair of definition requires.
+* `TauCeti.Huber.PadicInt.isHuberRing` and `TauCeti.Huber.PadicInt.not_isTateRing`: the two
+  halves of the example.
+
+## Scope
+
+Only `ℤ_[p]` is treated here. The roadmap's remaining Layer-0 examples — `ℚ_[p]` and `F⸨t⸩` are
+Tate, and `ℚ_p⟨T₁,…,Tₙ⟩` is complete and strongly noetherian — are not proved in this file.
 
 ## References
 
@@ -40,15 +57,10 @@ variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
   [CommRing B] [TopologicalSpace B] [IsTopologicalRing B]
 
 omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
-/-- Finite generation transports along a ring equivalence.
-
-Stated in the abstract so the `Ideal.map_symm` rewrite is elaborated once here rather than against
-a concrete subring instance, where unification is expensive. -/
-theorem fg_comap_of_equiv (e : B ≃+* A) {I : Ideal A} (h : I.FG) : (I.comap e).FG := by
-  classical
-  obtain ⟨s, hs⟩ := h
-  refine ⟨s.image e.symm, ?_⟩
-  rw [← Ideal.map_symm, ← hs, Finset.coe_image, Ideal.map_span]
+/-- Finite generation transports along a ring equivalence. -/
+private theorem fg_comap_of_equiv (e : B ≃+* A) {I : Ideal A} (h : I.FG) : (I.comap e).FG := by
+  rw [← Ideal.map_symm]
+  exact Ideal.FG.map h e.symm.toRingHom
 
 omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
 /-- The powers of a comapped ideal are the comapped powers, along a ring equivalence. -/
@@ -95,10 +107,10 @@ theorem coe_maximalIdeal_pow (n : ℕ) :
   rw [_root_.PadicInt.maximalIdeal_eq_span_p, Ideal.span_singleton_pow,
     ← _root_.PadicInt.norm_le_pow_iff_mem_span_pow]
 
-/-- Every power of the maximal ideal of `ℤ_[p]` is open: the ultrametric inequality carries the
-whole ball of radius `p⁻ⁿ` around any of its points back into it. -/
+/-- Every power of the maximal ideal of `ℤ_[p]` is open. -/
 theorem isOpen_maximalIdeal_pow (n : ℕ) :
     IsOpen ((maximalIdeal ℤ_[p] ^ n : Ideal ℤ_[p]) : Set ℤ_[p]) := by
+  -- the ultrametric inequality carries the ball of radius `p⁻ⁿ` about any point back into the set
   have hp0 : (0 : ℝ) < p := mod_cast (Fact.out : p.Prime).pos
   rw [coe_maximalIdeal_pow, Metric.isOpen_iff]
   intro x hx
@@ -133,12 +145,27 @@ noncomputable def pairOfDefinition : PairOfDefinition ℤ_[p] where
   isAdic_idealOfDefinition :=
     IsAdic.comap _ Topology.IsInducing.subtypeVal isAdic_maximalIdeal
 
+/-- The ring of definition of `pairOfDefinition` is all of `ℤ_[p]`. -/
+@[simp]
+theorem pairOfDefinition_ringOfDefinition :
+    (pairOfDefinition (p := p)).ringOfDefinition = ⊤ := (rfl)
+
+/-- Membership in the ideal of definition of `pairOfDefinition` is membership in `(p)`.
+
+Stated as a membership characterisation rather than an equation because the type of
+`idealOfDefinition` depends on `ringOfDefinition`. -/
+@[simp]
+theorem mem_pairOfDefinition_idealOfDefinition
+    {x : (pairOfDefinition (p := p)).ringOfDefinition} :
+    x ∈ (pairOfDefinition (p := p)).idealOfDefinition ↔ (x : ℤ_[p]) ∈ maximalIdeal ℤ_[p] :=
+  (Iff.rfl)
+
 /-- **`ℤ_[p]` is a Huber ring**, with `(ℤ_[p], (p))` as a pair of definition. -/
 instance isHuberRing : IsHuberRing ℤ_[p] :=
   ⟨⟨pairOfDefinition⟩⟩
 
-/-- **`ℤ_[p]` is not a Tate ring.** Its units are exactly the elements of norm one, whose powers
-all have norm one, so no unit is topologically nilpotent and there is no pseudouniformiser. -/
+/-- **`ℤ_[p]` is not a Tate ring**: it admits no pseudouniformiser. Together with
+`TauCeti.Huber.PadicInt.isHuberRing` this separates `IsHuberRing` from `IsTateRing`. -/
 theorem not_isTateRing : ¬ IsTateRing ℤ_[p] := by
   intro h
   obtain ⟨a, ha⟩ := h.exists_isPseudoUniformizer

--- a/TauCeti/RingTheory/Huber/Padic/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Basic.lean
@@ -19,7 +19,8 @@ nilpotent.
 
 ## Main definitions
 
-* `TauCeti.Huber.PadicInt.pairOfDefinition`: the pair of definition `(ℤ_[p], (p))`.
+* `TauCeti.Huber.PairOfDefinition.padicInt`: the pair of definition `(ℤ_[p], (p))`, named to
+  match the sibling Layer-0 example `TauCeti.Huber.PairOfDefinition.discrete`.
 
 ## Main results
 
@@ -86,7 +87,8 @@ theorem isAdic_maximalIdeal : IsAdic (maximalIdeal ℤ_[p]) := by
 /-- The pair of definition `(ℤ_[p], (p))` exhibiting `ℤ_[p]` as a Huber ring. The ring of
 definition is everything, and the ideal of definition is the maximal ideal carried across
 `Subring.topEquiv`. -/
-noncomputable def pairOfDefinition : PairOfDefinition ℤ_[p] where
+noncomputable def _root_.TauCeti.Huber.PairOfDefinition.padicInt :
+    PairOfDefinition ℤ_[p] where
   ringOfDefinition := ⊤
   isOpen_ringOfDefinition := by simp
   idealOfDefinition :=
@@ -99,25 +101,26 @@ noncomputable def pairOfDefinition : PairOfDefinition ℤ_[p] where
   isAdic_idealOfDefinition :=
     IsAdic.comap _ Topology.IsInducing.subtypeVal isAdic_maximalIdeal
 
-/-- The ring of definition of `pairOfDefinition` is all of `ℤ_[p]`. -/
+/-- The ring of definition of `PairOfDefinition.padicInt` is all of `ℤ_[p]`. -/
 @[simp]
-theorem pairOfDefinition_ringOfDefinition :
-    (pairOfDefinition (p := p)).ringOfDefinition = ⊤ := (rfl)
+theorem _root_.TauCeti.Huber.PairOfDefinition.padicInt_ringOfDefinition :
+    (PairOfDefinition.padicInt (p := p)).ringOfDefinition = ⊤ := (rfl)
 
-/-- Membership in the ideal of definition of `pairOfDefinition` is membership in `(p)`.
+/-- Membership in the ideal of definition of `PairOfDefinition.padicInt` is membership in `(p)`.
 
 Stated as a membership characterisation rather than an equation because the type of
 `idealOfDefinition` depends on `ringOfDefinition`. -/
 @[simp]
-theorem mem_pairOfDefinition_idealOfDefinition
-    {x : (pairOfDefinition (p := p)).ringOfDefinition} :
-    x ∈ (pairOfDefinition (p := p)).idealOfDefinition ↔ (x : ℤ_[p]) ∈ maximalIdeal ℤ_[p] := by
-  simp only [pairOfDefinition]
+theorem _root_.TauCeti.Huber.PairOfDefinition.mem_padicInt_idealOfDefinition
+    {x : (PairOfDefinition.padicInt (p := p)).ringOfDefinition} :
+    x ∈ (PairOfDefinition.padicInt (p := p)).idealOfDefinition ↔
+      (x : ℤ_[p]) ∈ maximalIdeal ℤ_[p] := by
+  simp only [PairOfDefinition.padicInt]
   exact Ideal.mem_comap
 
 /-- **`ℤ_[p]` is a Huber ring**, with `(ℤ_[p], (p))` as a pair of definition. -/
 instance isHuberRing : IsHuberRing ℤ_[p] :=
-  ⟨⟨pairOfDefinition⟩⟩
+  ⟨⟨PairOfDefinition.padicInt⟩⟩
 
 /-- **`ℤ_[p]` is not a Tate ring**: it admits no pseudouniformiser. Together with
 `TauCeti.Huber.PadicInt.isHuberRing` this separates `IsHuberRing` from `IsTateRing`. -/

--- a/TauCeti/RingTheory/Huber/Padic/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Basic.lean
@@ -89,9 +89,11 @@ noncomputable def pairOfDefinition : PairOfDefinition ℤ_[p] where
   isOpen_ringOfDefinition := by simp
   idealOfDefinition :=
     (maximalIdeal ℤ_[p]).comap (Subring.topEquiv : (⊤ : Subring ℤ_[p]) ≃+* ℤ_[p])
-  fg_idealOfDefinition :=
-    fg_comap_of_equiv _ (by
-      rw [_root_.PadicInt.maximalIdeal_eq_span_p]; exact Submodule.fg_span_singleton _)
+  fg_idealOfDefinition := by
+    rw [← Ideal.map_symm]
+    exact Ideal.FG.map
+      (by rw [_root_.PadicInt.maximalIdeal_eq_span_p]; exact Submodule.fg_span_singleton _)
+      (Subring.topEquiv : (⊤ : Subring ℤ_[p]) ≃+* ℤ_[p]).symm.toRingHom
   isAdic_idealOfDefinition :=
     IsAdic.comap _ Topology.IsInducing.subtypeVal isAdic_maximalIdeal
 

--- a/TauCeti/RingTheory/Huber/Padic/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Basic.lean
@@ -23,7 +23,8 @@ nilpotent.
 
 ## Main results
 
-* `TauCeti.Huber.PadicInt.coe_maximalIdeal_pow`: `(p)ⁿ` is the closed ball of radius `p⁻ⁿ`.
+* `TauCeti.Huber.PadicInt.coe_maximalIdeal_pow_eq_setOf_norm_le`:
+  `(p)ⁿ` is the closed ball of radius `p⁻ⁿ`.
   Openness is Mathlib's `IsLocalRing.isOpen_maximalIdeal_pow`.
 * `TauCeti.Huber.PadicInt.isAdic_maximalIdeal`: the norm topology of `ℤ_[p]` is the `(p)`-adic
   topology. Mathlib has `IsAdicComplete (maximalIdeal ℤ_[p]) ℤ_[p]` but not this comparison of
@@ -62,7 +63,7 @@ variable {p : ℕ} [Fact p.Prime]
 
 /-- The `n`-th power of the maximal ideal of `ℤ_[p]` is the closed ball of radius `p⁻ⁿ`: this is
 what ties the norm topology to the `(p)`-adic one. -/
-theorem coe_maximalIdeal_pow (n : ℕ) :
+theorem coe_maximalIdeal_pow_eq_setOf_norm_le (n : ℕ) :
     ((maximalIdeal ℤ_[p] ^ n : Ideal ℤ_[p]) : Set ℤ_[p])
       = {x : ℤ_[p] | ‖x‖ ≤ (p : ℝ) ^ (-n : ℤ)} := by
   ext x
@@ -78,7 +79,7 @@ theorem isAdic_maximalIdeal : IsAdic (maximalIdeal ℤ_[p]) := by
   obtain ⟨ε, hε, hball⟩ := Metric.mem_nhds_iff.mp hs
   obtain ⟨n, hn⟩ := exists_pow_lt_of_lt_one hε hp1
   refine ⟨n, fun x hx ↦ hball ?_⟩
-  rw [coe_maximalIdeal_pow, Set.mem_ofPred_eq] at hx
+  rw [coe_maximalIdeal_pow_eq_setOf_norm_le, Set.mem_ofPred_eq] at hx
   refine Metric.mem_ball.mpr (lt_of_le_of_lt ?_ hn)
   simpa [zpow_neg, zpow_natCast, ← inv_pow, dist_eq_norm] using hx
 

--- a/TauCeti/RingTheory/Huber/Padic/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Basic.lean
@@ -34,7 +34,8 @@ nilpotent.
 ## Implementation notes
 
 The ring of definition is all of `ℤ_[p]`, so the ideal of definition has to be carried across
-`Subring.topEquiv`; `TauCeti.Huber.IsAdic.comap` in `TauCeti/RingTheory/Huber/Basic.lean` is the
+`Subring.topEquiv`; `IsAdic.comap` in `TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean`
+is the
 general transport that does it.
 
 ## Scope

--- a/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -20,6 +20,7 @@ equivalent to `A₀`.
 
 ## Main results
 
+* `Ideal.comap_pow_of_equiv`: the powers of a comapped ideal are the comapped powers.
 * `IsAdic.comap`: an adic topology transports along an inducing ring equivalence.
 
 ## References
@@ -37,7 +38,7 @@ variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
 
 omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
 /-- The powers of a comapped ideal are the comapped powers, along a ring equivalence. -/
-private theorem comap_pow_of_equiv (e : B ≃+* A) (I : Ideal A) (n : ℕ) :
+theorem comap_pow_of_equiv (e : B ≃+* A) (I : Ideal A) (n : ℕ) :
     (I ^ n).comap e = I.comap e ^ n := by
   rw [← Ideal.map_symm, ← Ideal.map_symm, Ideal.map_pow]
 

--- a/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Algebra.Nonarchimedean.AdicTopology
+public import Mathlib.RingTheory.Ideal.Maps
+
+/-!
+# Transporting an adic topology along a ring equivalence
+
+An `IsAdic` hypothesis moves across a ring equivalence that is also an inducing map. Nothing
+here mentions a Huber ring or a pair of definition — it is a statement about Mathlib's `IsAdic`
+and `Ideal.comap` — so it is stated in the root namespace, mirroring the home of `IsAdic` itself.
+
+The use downstream is that `TauCeti.Huber.PairOfDefinition` asks for an `Ideal A₀` whose adic
+topology is the subspace topology, while the ideal at hand usually lives in a ring that is only
+equivalent to `A₀`.
+
+## Main results
+
+* `IsAdic.comap`: an adic topology transports along an inducing ring equivalence.
+
+## References
+
+* Mathlib's `Mathlib/Topology/Algebra/Nonarchimedean/AdicTopology.lean`, which defines `IsAdic`
+  and supplies the `isAdic_iff` characterisation both halves of the proof run on.
+-/
+
+public section
+
+open Topology
+
+variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
+  [CommRing B] [TopologicalSpace B] [IsTopologicalRing B]
+
+omit [TopologicalSpace A] [IsTopologicalRing A] [TopologicalSpace B] [IsTopologicalRing B] in
+/-- The powers of a comapped ideal are the comapped powers, along a ring equivalence. -/
+private theorem comap_pow_of_equiv (e : B ≃+* A) (I : Ideal A) (n : ℕ) :
+    (I ^ n).comap e = I.comap e ^ n := by
+  rw [← Ideal.map_symm, ← Ideal.map_symm, Ideal.map_pow]
+
+/-- An adic topology transports along a ring equivalence that is also an inducing map.
+
+This is what lets a ring of definition carry an ideal of definition: `PairOfDefinition` asks for
+an `Ideal A₀` whose adic topology is the subspace topology, while the ideal at hand usually lives
+in a ring that is only equivalent to `A₀`. -/
+theorem IsAdic.comap (e : B ≃+* A) (he : IsInducing e) {I : Ideal A} (h : IsAdic I) :
+    IsAdic (I.comap e) := by
+  rw [isAdic_iff] at h ⊢
+  obtain ⟨hopen, hnhds⟩ := h
+  have hset : ∀ n : ℕ,
+      ((I.comap e ^ n : Ideal B) : Set B) = e ⁻¹' ((I ^ n : Ideal A) : Set A) := by
+    intro n
+    ext b
+    rw [← comap_pow_of_equiv e I n, SetLike.mem_coe, Ideal.mem_comap, Set.mem_preimage,
+      SetLike.mem_coe]
+  refine ⟨fun n ↦ ?_, fun s hs ↦ ?_⟩
+  · rw [hset n, he.isOpen_iff]
+    exact ⟨_, hopen n, rfl⟩
+  · rw [he.nhds_eq_comap (0 : B), map_zero, Filter.mem_comap] at hs
+    obtain ⟨t, ht, hts⟩ := hs
+    obtain ⟨n, hn⟩ := hnhds t ht
+    exact ⟨n, by rw [hset n]; exact fun b hb ↦ hts (hn hb)⟩


### PR DESCRIPTION
`ℤ_[p]` is a Huber ring and is not a Tate ring. A new
`TauCeti/RingTheory/Huber/Padic.lean` (181 lines).

This is the roadmap's Layer-0 **Examples** item after the discrete case, and the first result in
this lane that *separates* `IsHuberRing` from `IsTateRing` — until now `IsTateRing` had no
witnessed non-example.

**The substance is `isAdic_maximalIdeal`.** `PairOfDefinition` demands that the subspace topology
on the ring of definition *equal* the `I`-adic topology. Mathlib has
`IsAdicComplete (maximalIdeal ℤ_[p]) ℤ_[p]` but no such comparison of topologies, so it is proved
here from `PadicInt.norm_le_pow_iff_mem_span_pow`: `(p)ⁿ` is exactly the closed ball of radius
`p⁻ⁿ` (`coe_maximalIdeal_pow`), those balls are open by the ultrametric inequality
(`isOpen_maximalIdeal_pow`), and they are cofinal in the neighbourhoods of zero because
`p⁻ⁿ → 0`.

Two small transport lemmas make the pair typecheck: `PairOfDefinition` wants an
`Ideal ↥ringOfDefinition`, while the maximal ideal lives in `ℤ_[p]` itself, so `IsAdic.comap`
carries adicity along a ring equivalence that is also an inducing map, and a private
`fg_comap_of_equiv` does the same for finite generation. `IsAdic.comap` is stated generally
because Layer 0.3 and the `ℚ_[p]` example will want it too.

`not_isTateRing` is the non-vacuous half: a pseudouniformiser is a topologically nilpotent unit,
`PadicInt.isUnit_iff` makes every unit have norm one, so `‖aⁿ‖` is constantly one while `aⁿ → 0`
forces `‖aⁿ‖ → 0`, giving `1 = 0`.

Scope: only `ℤ_[p]`. The roadmap's remaining Layer-0 examples (`ℚ_[p]` and `F⸨t⸩` Tate,
`ℚ_p⟨T₁,…,Tₙ⟩` strongly noetherian) are not in this PR, and the module docstring says so.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0-examples-padic-int"}-->
