### PR TITLE
refactor(Crosscut): name the plane-to-angle step of the cluster-set criterion

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -274,9 +274,9 @@ theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
     mul_pos (by linarith) (lt_min hsinm hsinw), ?_⟩
   rintro x hx y hy
   obtain ⟨θx, hθx, rfl, hdx⟩ :=
-    exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo ζ ρ hab2π hθ₀ hm0 hx
+    exists_mem_Ioo_circleMap_eq_and_abs_sub_lt_of_mem_ball_circleMap_image_Ioo ζ ρ hab2π hθ₀ hm0 hx
   obtain ⟨θy, hθy, rfl, hdy⟩ :=
-    exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo ζ ρ hab2π hθ₀ hm0 hy
+    exists_mem_Ioo_circleMap_eq_and_abs_sub_lt_of_mem_ball_circleMap_image_Ioo ζ ρ hab2π hθ₀ hm0 hy
   refine hmod θx hθx θy hθy ?_
   have htri : |θx - θy| ≤ |θx - θ₀| + |θ₀ - θy| := abs_sub_le _ _ _
   have hsymm : |θ₀ - θy| = |θy - θ₀| := abs_sub_comm _ _

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -247,6 +247,29 @@ private lemma min_sin_div_two_le_sin_div_two {m t w : ℝ} (hm : 0 < m) (hmt : m
     exact Real.sin_le_sin_of_le_of_le_pi_div_two (by linarith [Real.pi_pos]) (by linarith)
       (by linarith)
 
+/-- **On a non-wrapping arc, closeness in the plane is closeness in angle.** A point of the arc
+`circleMap ζ ρ '' Ioo a b` lying within `2 * |ρ| * min (sin (m / 2)) (sin ((b - a) / 2))` of
+`circleMap ζ ρ θ₀` is the image of an angle within `m` of `θ₀`. -/
+private lemma exists_angle_sub_lt_of_mem_ball_circleMap (ζ : ℂ) (ρ : ℝ) {a b θ₀ m : ℝ}
+    (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b) (hm0 : 0 < m) {x : ℂ}
+    (hx : x ∈ circleMap ζ ρ '' Ioo a b ∩
+      ball (circleMap ζ ρ θ₀) (2 * |ρ| * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)))) :
+    ∃ θ ∈ Ioo a b, circleMap ζ ρ θ = x ∧ |θ - θ₀| < m := by
+  obtain ⟨⟨θ, hθ, rfl⟩, hx⟩ := hx
+  refine ⟨θ, hθ, rfl, ?_⟩
+  have hwidth : |θ - θ₀| ≤ b - a := by
+    rw [abs_le]
+    constructor <;> [linarith [hθ.1, hθ₀.2]; linarith [hθ.2, hθ₀.1]]
+  have hπ : |θ - θ₀| ≤ 2 * π := by linarith
+  rw [mem_ball, dist_circleMap_eq_two_mul_sin_abs ζ ρ hπ] at hx
+  rcases lt_or_ge |θ - θ₀| m with hlt | hcon
+  · exact hlt
+  · exfalso
+    -- the chord grows with the angular gap up to the width of the arc
+    have hmono : min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)) ≤ Real.sin (|θ - θ₀| / 2) :=
+      min_sin_div_two_le_sin_div_two hm0 hcon hwidth hab2π
+    nlinarith [abs_nonneg ρ]
+
 /-- **An arc of finite image length has at most one cluster value at each of its points.** For `f`
 holomorphic on an open set containing the open arc `circleMap ζ ρ '' Ioo a b`, of angular width
 below a full turn and of finite image length, and for any angle `θ₀` of the *closed* arc, `f` has at
@@ -279,7 +302,7 @@ theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
   obtain ⟨η, hη, hmod⟩ :=
     exists_pos_forall_dist_le_of_lintegral_ne_top hUo hf ζ hmemU hfin hε
   -- the angular gap actually used: below half the modulus, and below the width of the arc
-  set m : ℝ := min (η / 2) (b - a) with hm
+  set m : ℝ := min (η / 2) (b - a)
   have hm0 : 0 < m := lt_min (by linarith) (by linarith)
   have hmw : m ≤ b - a := min_le_right _ _
   -- the arc not wrapping around the circle puts both half-angles in `(0, π)`
@@ -289,26 +312,11 @@ theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
     Real.sin_pos_of_pos_of_lt_pi (by linarith) (by linarith)
   refine ⟨2 * |ρ| * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)),
     mul_pos (by linarith) (lt_min hsinm hsinw), ?_⟩
-  -- a point of the arc close to `circleMap ζ ρ θ₀` is close to `θ₀` in angle
-  have hangle : ∀ x ∈ circleMap ζ ρ '' Ioo a b ∩
-      ball (circleMap ζ ρ θ₀) (2 * |ρ| * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2))),
-      ∃ θ ∈ Ioo a b, circleMap ζ ρ θ = x ∧ |θ - θ₀| < m := by
-    rintro _ ⟨⟨θ, hθ, rfl⟩, hx⟩
-    refine ⟨θ, hθ, rfl, ?_⟩
-    have hwidth : |θ - θ₀| ≤ b - a := by
-      rw [abs_le]
-      constructor <;> [linarith [hθ.1, hθ₀.2]; linarith [hθ.2, hθ₀.1]]
-    have hπ : |θ - θ₀| ≤ 2 * π := by linarith
-    rw [mem_ball, dist_circleMap_eq_two_mul_sin_abs ζ ρ hπ] at hx
-    rcases lt_or_ge |θ - θ₀| m with hlt | hcon
-    · exact hlt
-    · exfalso
-      have hmono : min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)) ≤ Real.sin (|θ - θ₀| / 2) :=
-        min_sin_div_two_le_sin_div_two hm0 hcon hwidth hab2π
-      nlinarith [hρpos.le]
   rintro x hx y hy
-  obtain ⟨θx, hθx, rfl, hdx⟩ := hangle x hx
-  obtain ⟨θy, hθy, rfl, hdy⟩ := hangle y hy
+  obtain ⟨θx, hθx, rfl, hdx⟩ :=
+    exists_angle_sub_lt_of_mem_ball_circleMap ζ ρ hab2π hθ₀ hm0 hx
+  obtain ⟨θy, hθy, rfl, hdy⟩ :=
+    exists_angle_sub_lt_of_mem_ball_circleMap ζ ρ hab2π hθ₀ hm0 hy
   refine hmod θx hθx θy hθy ?_
   have htri : |θx - θy| ≤ |θx - θ₀| + |θ₀ - θy| := abs_sub_le _ _ _
   have hsymm : |θ₀ - θy| = |θy - θ₀| := abs_sub_comm _ _

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -250,7 +250,7 @@ private lemma min_sin_div_two_le_sin_div_two {m t w : ℝ} (hm : 0 < m) (hmt : m
 /-- **On a non-wrapping arc, closeness in the plane is closeness in angle.** A point of the arc
 `circleMap ζ ρ '' Ioo a b` lying within `2 * |ρ| * min (sin (m / 2)) (sin ((b - a) / 2))` of
 `circleMap ζ ρ θ₀` is the image of an angle within `m` of `θ₀`. -/
-private lemma exists_angle_sub_lt_of_mem_ball_circleMap (ζ : ℂ) (ρ : ℝ) {a b θ₀ m : ℝ}
+private lemma exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo (ζ : ℂ) (ρ : ℝ) {a b θ₀ m : ℝ}
     (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b) (hm0 : 0 < m) {x : ℂ}
     (hx : x ∈ circleMap ζ ρ '' Ioo a b ∩
       ball (circleMap ζ ρ θ₀) (2 * |ρ| * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)))) :
@@ -314,9 +314,9 @@ theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
     mul_pos (by linarith) (lt_min hsinm hsinw), ?_⟩
   rintro x hx y hy
   obtain ⟨θx, hθx, rfl, hdx⟩ :=
-    exists_angle_sub_lt_of_mem_ball_circleMap ζ ρ hab2π hθ₀ hm0 hx
+    exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo ζ ρ hab2π hθ₀ hm0 hx
   obtain ⟨θy, hθy, rfl, hdy⟩ :=
-    exists_angle_sub_lt_of_mem_ball_circleMap ζ ρ hab2π hθ₀ hm0 hy
+    exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo ζ ρ hab2π hθ₀ hm0 hy
   refine hmod θx hθx θy hθy ?_
   have htri : |θx - θy| ≤ |θx - θ₀| + |θ₀ - θy| := abs_sub_le _ _ _
   have hsymm : |θ₀ - θy| = |θy - θ₀| := abs_sub_comm _ _

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -230,46 +230,6 @@ theorem isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top (hUo : IsOpen U)
 
 /-! ## The cluster sets of an arc of finite image length -/
 
-/-- **The sine of a half-angle is smallest at an end of the range of angles.** For
-`0 < m ≤ t ≤ w < 2 * π`, `sin (t / 2)` is at least `min (sin (m / 2)) (sin (w / 2))`, a positive
-number: the half-angle stays in `[0, π]`, where the sine rises to `π / 2` and falls back, so it is
-bounded below by its value at whichever end of `[m / 2, w / 2]` the half-angle has not passed.
-
-If `w ≤ π` the first of the two is the binding one and the second is slack; both are needed exactly
-because an arc of angular width beyond `π` is allowed. -/
-private lemma min_sin_div_two_le_sin_div_two {m t w : ℝ} (hm : 0 < m) (hmt : m ≤ t) (htw : t ≤ w)
-    (hw : w < 2 * π) : min (Real.sin (m / 2)) (Real.sin (w / 2)) ≤ Real.sin (t / 2) := by
-  rcases le_total (t / 2) (π / 2) with h | h
-  · exact (min_le_left _ _).trans
-      (Real.sin_le_sin_of_le_of_le_pi_div_two (by linarith [Real.pi_pos]) h (by linarith))
-  · refine (min_le_right _ _).trans ?_
-    rw [← Real.sin_pi_sub (w / 2), ← Real.sin_pi_sub (t / 2)]
-    exact Real.sin_le_sin_of_le_of_le_pi_div_two (by linarith [Real.pi_pos]) (by linarith)
-      (by linarith)
-
-/-- **On a non-wrapping arc, closeness in the plane is closeness in angle.** A point of the arc
-`circleMap ζ ρ '' Ioo a b` lying within `2 * |ρ| * min (sin (m / 2)) (sin ((b - a) / 2))` of
-`circleMap ζ ρ θ₀` is the image of an angle within `m` of `θ₀`. -/
-private lemma exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo (ζ : ℂ) (ρ : ℝ) {a b θ₀ m : ℝ}
-    (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b) (hm0 : 0 < m) {x : ℂ}
-    (hx : x ∈ circleMap ζ ρ '' Ioo a b ∩
-      ball (circleMap ζ ρ θ₀) (2 * |ρ| * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)))) :
-    ∃ θ ∈ Ioo a b, circleMap ζ ρ θ = x ∧ |θ - θ₀| < m := by
-  obtain ⟨⟨θ, hθ, rfl⟩, hx⟩ := hx
-  refine ⟨θ, hθ, rfl, ?_⟩
-  have hwidth : |θ - θ₀| ≤ b - a := by
-    rw [abs_le]
-    constructor <;> [linarith [hθ.1, hθ₀.2]; linarith [hθ.2, hθ₀.1]]
-  have hπ : |θ - θ₀| ≤ 2 * π := by linarith
-  rw [mem_ball, dist_circleMap_eq_two_mul_sin_abs ζ ρ hπ] at hx
-  rcases lt_or_ge |θ - θ₀| m with hlt | hcon
-  · exact hlt
-  · exfalso
-    -- the chord grows with the angular gap up to the width of the arc
-    have hmono : min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)) ≤ Real.sin (|θ - θ₀| / 2) :=
-      min_sin_div_two_le_sin_div_two hm0 hcon hwidth hab2π
-    nlinarith [abs_nonneg ρ]
-
 /-- **An arc of finite image length has at most one cluster value at each of its points.** For `f`
 holomorphic on an open set containing the open arc `circleMap ζ ρ '' Ioo a b`, of angular width
 below a full turn and of finite image length, and for any angle `θ₀` of the *closed* arc, `f` has at

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -38,8 +38,9 @@ circle.
   with the angular gap, so the distance to a fixed point of the circle is unimodal along it, and
   `TauCeti.ordConnected_inter_setOf_dist_circleMap_lt` — consequently a ball meets an arc of
   angular width at most `π` in a set of angles that is order connected.
-* `TauCeti.exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo` — the inverse comparison on an arc
-  that does not wrap: a point of the arc close enough to a fixed point of it is the image of a
+* `TauCeti.exists_mem_Ioo_circleMap_eq_and_abs_sub_lt_of_mem_ball_circleMap_image_Ioo` — the
+  inverse comparison on an arc that does not wrap: a point of the arc close enough to a fixed
+  point of it is the image of a
   nearby angle, so closeness in the plane is closeness in angle.
 * `TauCeti.dist_circleMap_sq` — the law of cosines: the point of `circleMap ζ ρ` at angle `θ` is at
   distance `ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, squared, from an
@@ -200,7 +201,8 @@ private lemma min_sin_div_two_le_sin_div_two {m t w : ℝ} (hm : 0 < m) (hmt : m
 /-- **On a non-wrapping arc, closeness in the plane is closeness in angle.** A point of the arc
 `circleMap ζ ρ '' Ioo a b` lying within `2 * |ρ| * min (sin (m / 2)) (sin ((b - a) / 2))` of
 `circleMap ζ ρ θ₀` is the image of an angle within `m` of `θ₀`. -/
-theorem exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo (ζ : ℂ) (ρ : ℝ) {a b θ₀ m : ℝ}
+theorem exists_mem_Ioo_circleMap_eq_and_abs_sub_lt_of_mem_ball_circleMap_image_Ioo (ζ : ℂ)
+    (ρ : ℝ) {a b θ₀ m : ℝ}
     (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b) (hm0 : 0 < m) {x : ℂ}
     (hx : x ∈ circleMap ζ ρ '' Ioo a b ∩
       ball (circleMap ζ ρ θ₀) (2 * |ρ| * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)))) :

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -38,6 +38,9 @@ circle.
   with the angular gap, so the distance to a fixed point of the circle is unimodal along it, and
   `TauCeti.ordConnected_inter_setOf_dist_circleMap_lt` — consequently a ball meets an arc of
   angular width at most `π` in a set of angles that is order connected.
+* `TauCeti.exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo` — the inverse comparison on an arc
+  that does not wrap: a point of the arc close enough to a fixed point of it is the image of a
+  nearby angle, so closeness in the plane is closeness in angle.
 * `TauCeti.dist_circleMap_sq` — the law of cosines: the point of `circleMap ζ ρ` at angle `θ` is at
   distance `ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, squared, from an
   arbitrary point `c` of the plane.
@@ -176,6 +179,46 @@ theorem dist_circleMap_le_dist_circleMap_of_abs_sub_le (ζ : ℂ) (ρ : ℝ) {θ
     Real.sin_le_sin_of_le_of_le_pi_div_two
       (by linarith [abs_nonneg (u - θ₀), Real.pi_pos]) (by linarith) (by linarith)
   exact mul_le_mul_of_nonneg_left hsin (by positivity)
+
+/-- **The sine of a half-angle is smallest at an end of the range of angles.** For
+`0 < m ≤ t ≤ w < 2 * π`, `sin (t / 2)` is at least `min (sin (m / 2)) (sin (w / 2))`, a positive
+number: the half-angle stays in `[0, π]`, where the sine rises to `π / 2` and falls back, so it is
+bounded below by its value at whichever end of `[m / 2, w / 2]` the half-angle has not passed.
+
+If `w ≤ π` the first of the two is the binding one and the second is slack; both are needed exactly
+because an arc of angular width beyond `π` is allowed. -/
+private lemma min_sin_div_two_le_sin_div_two {m t w : ℝ} (hm : 0 < m) (hmt : m ≤ t) (htw : t ≤ w)
+    (hw : w < 2 * π) : min (Real.sin (m / 2)) (Real.sin (w / 2)) ≤ Real.sin (t / 2) := by
+  rcases le_total (t / 2) (π / 2) with h | h
+  · exact (min_le_left _ _).trans
+      (Real.sin_le_sin_of_le_of_le_pi_div_two (by linarith [Real.pi_pos]) h (by linarith))
+  · refine (min_le_right _ _).trans ?_
+    rw [← Real.sin_pi_sub (w / 2), ← Real.sin_pi_sub (t / 2)]
+    exact Real.sin_le_sin_of_le_of_le_pi_div_two (by linarith [Real.pi_pos]) (by linarith)
+      (by linarith)
+
+/-- **On a non-wrapping arc, closeness in the plane is closeness in angle.** A point of the arc
+`circleMap ζ ρ '' Ioo a b` lying within `2 * |ρ| * min (sin (m / 2)) (sin ((b - a) / 2))` of
+`circleMap ζ ρ θ₀` is the image of an angle within `m` of `θ₀`. -/
+theorem exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo (ζ : ℂ) (ρ : ℝ) {a b θ₀ m : ℝ}
+    (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b) (hm0 : 0 < m) {x : ℂ}
+    (hx : x ∈ circleMap ζ ρ '' Ioo a b ∩
+      ball (circleMap ζ ρ θ₀) (2 * |ρ| * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)))) :
+    ∃ θ ∈ Ioo a b, circleMap ζ ρ θ = x ∧ |θ - θ₀| < m := by
+  obtain ⟨⟨θ, hθ, rfl⟩, hx⟩ := hx
+  refine ⟨θ, hθ, rfl, ?_⟩
+  have hwidth : |θ - θ₀| ≤ b - a := by
+    rw [abs_le]
+    constructor <;> [linarith [hθ.1, hθ₀.2]; linarith [hθ.2, hθ₀.1]]
+  have hπ : |θ - θ₀| ≤ 2 * π := by linarith
+  rw [mem_ball, dist_circleMap_eq_two_mul_sin_abs ζ ρ hπ] at hx
+  rcases lt_or_ge |θ - θ₀| m with hlt | hcon
+  · exact hlt
+  · exfalso
+    -- the chord grows with the angular gap up to the width of the arc
+    have hmono : min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)) ≤ Real.sin (|θ - θ₀| / 2) :=
+      min_sin_div_two_le_sin_div_two hm0 hcon hwidth hab2π
+    nlinarith [abs_nonneg ρ]
 
 /-- **An order-connected set of angles within half a turn of `θ₀` keeps that form when cut down by
 the distance to the point at `θ₀`.** For a set `s` of angles contained in the half-turn


### PR DESCRIPTION
`subsingleton_clusterSetOn_circleMap_image_Ioo` carried an eighteen-line `have` doing the geometric half of the argument: turning proximity in the plane into proximity in angle. That is a statement in its own right.

`exists_abs_sub_lt_of_mem_ball_circleMap_image_Ioo` — on a non-wrapping arc, a point of `circleMap ζ ρ '' Ioo a b` lying within `2 * |ρ| * min (sin (m / 2)) (sin ((b - a) / 2))` of `circleMap ζ ρ θ₀` is the image of an angle within `m` of `θ₀`. It is placed beside `min_sin_div_two_le_sin_div_two`, the chord comparison it rests on, matching how that lemma was already factored out of this proof.

Its hypotheses are re-derived rather than inherited from the parent's context:

- **`ρ ≠ 0` is not needed.** The inline proof closed with `nlinarith [hρpos.le]`, drawing on the parent's `0 < |ρ|`. At `ρ = 0` the ball has radius `0`, so the membership hypothesis is vacuous and plain `abs_nonneg` does the same work — the statement holds for every radius.
- **The arc-width bound `m ≤ b - a` is not needed either**; only `0 < m`, the endpoint bound `θ₀ ∈ Icc a b` and the non-wrapping hypothesis `b - a < 2 * π` are used.

The parent's `set m := min (η / 2) (b - a)` is deliberately **kept**: the helper is general in `m`, so it unifies with the folded local rather than being blocked by it. What did go is the `with hm` binding, which had no consumer.

The body drops from 46 lines to 31.

### On `hmw`

A grep suggests `have hmw : m ≤ b - a` is now unused, since its only textual occurrence is its own definition. It is not: it is consumed by the `linarith` calls inside `hsinm` and `hsinw`, which draw on the context without naming their hypotheses. Deleting it fails to compile:

```
error: EndpointLimit.lean:309:51: linarith failed to find a contradiction
```

So it stays. Textual search cannot establish that a hypothesis is dead when `linarith`, `nlinarith` or `positivity` are in scope.

### Why the lemma is public and in `Topology/Circle/Metric.lean`

Round 1 blocked on `placement` and `api-design`, which agreed: the plane-to-angle comparison is
circle-metric material and was sitting in a conformal crosscut module. `api-design` was explicit
about the remedy — *"`private` makes it unavailable to other arc consumers and leaves the circle
metric API incomplete. Fix: Move it to `TauCeti/Topology/Circle/Metric.lean` as a public lemma"* —
and `placement` named the same destination, *"near the chord comparison results"*.

That is what this does. It now sits beside `dist_circleMap_le_dist_circleMap_of_abs_sub_le`, the
forward chord comparison of which it is the inverse, and carries a main-results entry. The sine
bound it rests on moved with it and stays private. `EndpointLimit.lean` already imported the
module, so consuming it needs no import change.

Noting for the record that it currently has one caller: that is the state `api-design` asked for,
on the grounds that the exported circle-metric API should be complete rather than that the lemma
has two consumers today.

Gates run locally: `lake build` (7133 jobs), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: ConformalMapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
