### PR TITLE
refactor(CliffordAlgebra): remove the unused bivector range specialisations

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -96,6 +96,9 @@ noncomputable def cliffordBivectorAlternating : M [⋀^Fin 2]→ₗ[R] CliffordA
       intro v i j h hij
       fin_cases i <;> fin_cases j <;> simp_all [cliffordBivector_def] }
 
+-- Proving the exported `cliffordBivectorAlternating_apply` by `rfl` directly would require
+-- `cliffordBivectorAlternating` to be `@[expose]`d, which it deliberately is not. The `rfl` is
+-- therefore done here, inside the module, and re-exported below.
 private theorem cliffordBivectorAlternating_apply_internal (a b : M) :
     cliffordBivectorAlternating Q ![a, b] = cliffordBivector Q a b := rfl
 
@@ -208,18 +211,6 @@ theorem cliffordBivectorExterior_range_le_of_cliffordBivector_mem
   change cliffordBivectorExterior Q (exteriorPower.ιMulti R 2 ![v 0, v 1]) ∈ P
   rw [cliffordBivectorExterior_apply_ιMulti]
   exact hP _ _
-
-/-- The exterior-square Clifford bivector map takes values in the even component. -/
-theorem cliffordBivectorExterior_range_le_evenOdd_zero :
-    LinearMap.range (cliffordBivectorExterior Q) ≤ evenOdd Q 0 :=
-  cliffordBivectorExterior_range_le_of_cliffordBivector_mem Q _
-    (cliffordBivector_mem_evenOdd_zero Q)
-
-/-- The exterior-square Clifford bivector map takes values in filtration degree at most two. -/
-theorem cliffordBivectorExterior_range_le_filtration_two :
-    LinearMap.range (cliffordBivectorExterior Q) ≤ filtration Q 2 :=
-  cliffordBivectorExterior_range_le_of_cliffordBivector_mem Q _
-    (cliffordBivector_mem_filtration_two Q)
 
 /-- The action-normalization identity for the half-normalized Clifford bivector. -/
 theorem cliffordBivector_lie_ι (a b x : M) :


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR deletes `cliffordBivectorExterior_range_le_evenOdd_zero` and `cliffordBivectorExterior_range_le_filtration_two`. Each is a two-line application of `cliffordBivectorExterior_range_le_of_cliffordBivector_mem`, the general statement added later that takes the target submodule as a parameter; that general form is the one with a consumer (`QuadraticLieSubalgebra.lean`), while these two specialisations have none, and neither is listed in the module docstring's "Main results".

I checked the open PRs as well as `main` before deleting: neither name appears in the added lines of #2343, #2397, #2411, #2413, #2419, #2470 or #2492.

Two things I deliberately did **not** remove while I was in this file:

- `cliffordBivector_swap` and `cliffordBivectorAlternating`/`_apply` are used by the in-flight #2411 and #2419, so they stay.
- `cliffordBivector_self` is unused today, but it is the alternating property of `cliffordBivectorAlternating` specialised to the bivector and it is `@[simp]`, so it is canonical API rather than a leftover specialisation. Keeping it.

The PR also adds a comment explaining `cliffordBivectorAlternating_apply_internal`. I had assumed it was a verbatim duplicate of the public lemma below it and tried to delete it; the build then fails with `Not a definitional equality`, because an exported theorem may only be proved by `rfl` if every definition it unfolds is `@[expose]`d, and `cliffordBivectorAlternating` deliberately is not. The private lemma is doing real work under the module system, so the comment records that for the next reader.

The full build with `--iofail`, axiom audit, module-system check and environment lint pass; `lint-env` reports no new violations.

🤖 Prepared with Claude Code