### PR TITLE
feat(CliffordAlgebra): identify the leading-term map with the graded equivalence

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -70,6 +70,10 @@ supremum over the `i` of a fixed parity.
   `TauCeti.CliffordAlgebra.changeForm_mem_filtration_iff`: contraction and change of
   quadratic form respect the filtration, contraction lowers every positive step by one, and the
   change-form equivalence transports every step exactly.
+* `TauCeti.CliffordAlgebra.changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration` and its
+  `Fin`-indexed form
+  `TauCeti.CliffordAlgebra.changeForm_prod_ofFn_ι_sub_prod_ofFn_ι_mem_filtration`: change of form
+  has identity symbol, that is, it moves a word of generators only by lower-degree terms.
 * `TauCeti.CliffordAlgebra.fg_filtration`: each step is a finitely generated module when `M` is.
 
 ## References
@@ -596,6 +600,44 @@ private theorem changeForm_prod_map_ι_mem_filtration (h : B.toQuadraticMap = Q'
       simpa [Nat.add_comm] using hmul
     · exact filtration_mono Q' (Nat.le_succ _)
         (contractLeft_mem_filtration Q' (B m) (changeForm_prod_map_ι_mem_filtration h l))
+
+/-- **Change of form has identity symbol.** Transporting a word of at most `k + 1` generators
+along `changeForm` changes it only by terms of filtration degree at most `k`: the difference
+between the word in the `ι Q` and the same word in the `ι Q'` drops one step.
+
+`changeForm_mem_filtration` says `changeForm` is a filtered map; this says its associated graded
+map is the identity, which is what makes the two routes to the degree quotients agree. The bound
+is phrased as `l.length ≤ k + 1` rather than through `l.length - 1` so that the empty list is not
+a special case of truncated subtraction. -/
+theorem changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration (h : B.toQuadraticMap = Q' - Q) :
+    ∀ (l : List M) (k : ℕ), l.length ≤ k + 1 →
+      changeForm h (l.map (ι Q)).prod - (l.map (ι Q')).prod ∈ filtration Q' k
+  | [], _, _ => by simp
+  | m :: l, 0, hk => by
+      have hl : l = [] := List.length_eq_zero_iff.mp (by simpa using hk)
+      subst hl
+      simp
+  | m :: l, k + 1, hk => by
+      have hl : l.length ≤ k + 1 := by simpa using hk
+      rw [List.map_cons, List.prod_cons, List.map_cons, List.prod_cons, changeForm_ι_mul,
+        sub_right_comm, ← mul_sub]
+      refine Submodule.sub_mem _ ?_ ?_
+      · have hmul :=
+          Submodule.mul_mem_mul (ι_mem_filtration_one Q' m)
+            (changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration h l k hl)
+        rw [filtration_mul Q' 1 k] at hmul
+        simpa [Nat.add_comm] using hmul
+      · exact contractLeft_mem_filtration Q' (B m)
+          (filtration_mono Q' hl (changeForm_prod_map_ι_mem_filtration Q h l))
+
+/-- The `Fin`-indexed form of `changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration`, which is how
+the leading-term map presents its representatives. -/
+theorem changeForm_prod_ofFn_ι_sub_prod_ofFn_ι_mem_filtration (h : B.toQuadraticMap = Q' - Q)
+    (k : ℕ) (v : Fin (k + 1) → M) :
+    changeForm h (List.ofFn ((ι Q) ∘ v)).prod - (List.ofFn ((ι Q') ∘ v)).prod ∈
+      filtration Q' k := by
+  simpa only [List.map_ofFn] using
+    changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration Q h (List.ofFn v) k (by simp)
 
 /-- Changing quadratic form by a bilinear form preserves each filtration step. -/
 theorem changeForm_mem_filtration (h : B.toQuadraticMap = Q' - Q) {k : ℕ}

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -71,10 +71,9 @@ supremum over the `i` of a fixed parity.
   `TauCeti.CliffordAlgebra.changeForm_mem_filtration_iff`: contraction and change of
   quadratic form respect the filtration, contraction lowers every positive step by one, and the
   change-form equivalence transports every step exactly.
-* `TauCeti.CliffordAlgebra.changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration` and its
-  `Fin`-indexed form
-  `TauCeti.CliffordAlgebra.changeForm_prod_ofFn_ι_sub_prod_ofFn_ι_mem_filtration`: change of form
-  has identity symbol, that is, it moves a word of generators only by lower-degree terms.
+* `TauCeti.CliffordAlgebra.changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration`: change of form
+  has identity symbol, that is, it moves a word of generators only by terms two filtration degrees
+  lower.
 * `TauCeti.CliffordAlgebra.fg_filtration`: each step is a finitely generated module when `M` is.
 
 ## References

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -56,7 +56,9 @@ supremum over the `i` of a fixed parity.
   `LinearMap.range (ι Q)`.
 * `TauCeti.CliffordAlgebra.filtrationLeadingTerm` and
   `TauCeti.CliffordAlgebra.filtrationLeadingTerm_surjective`: the exterior-power leading-term map
-  onto each successive filtration quotient, the surjectivity half of the associated-graded bridge.
+  onto each successive filtration quotient. It is surjective over any `CommRing`; when `2` is
+  invertible `TauCeti.CliffordAlgebra.filtrationGradedEquiv_comp_filtrationLeadingTerm` identifies
+  it with the inverse of the graded equivalence.
 * `TauCeti.CliffordAlgebra.iSup_filtration_eq_top` and
   `TauCeti.CliffordAlgebra.exists_mem_filtration`: the filtration is exhaustive.
 * `TauCeti.CliffordAlgebra.involute_mem_filtration`,
@@ -432,7 +434,7 @@ private noncomputable def filtrationLeadingTermAlternating (k : ℕ) :
 filtration quotient. A repeated generator becomes a lower-filtration term under the Clifford
 relation, so the product descends to an alternating map.
 
-This is the surjectivity half of the Layer 0 `filtrationGradedEquiv` target in the
+This is the `CommRing`-level half of the Layer 0 `filtrationGradedEquiv` target in the
 [spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L62-L68). -/
 noncomputable def filtrationLeadingTerm (k : ℕ) : ExteriorAlgebra.exteriorPower R (k + 1) M →ₗ[R]
     FiltrationGradedPiece Q (k + 1) :=
@@ -587,57 +589,42 @@ theorem contractLeft_mem_filtration (d : Module.Dual R M) {k : ℕ} {x : Cliffor
     (hx : x ∈ filtration Q k) : contractLeft d x ∈ filtration Q k :=
   contractLeft_mem_filtration_succ Q d (filtration_mono Q (Nat.le_succ k) hx)
 
-private theorem changeForm_prod_map_ι_mem_filtration (h : B.toQuadraticMap = Q' - Q) :
-    ∀ l : List M, changeForm h (l.map (ι Q)).prod ∈ filtration Q' l.length
-  | [] => by simpa using one_mem_filtration Q' 0
-  | m :: l => by
-    rw [List.map_cons, List.prod_cons, changeForm_ι_mul]
-    refine Submodule.sub_mem _ ?_ ?_
-    · have hmul :=
-        Submodule.mul_mem_mul (ι_mem_filtration_one Q' m)
-          (changeForm_prod_map_ι_mem_filtration h l)
-      rw [filtration_mul Q' 1 l.length] at hmul
-      simpa [Nat.add_comm] using hmul
-    · exact filtration_mono Q' (Nat.le_succ _)
-        (contractLeft_mem_filtration Q' (B m) (changeForm_prod_map_ι_mem_filtration h l))
+/-- **Change of form has identity symbol, and its correction is even.** Transporting a word of at
+most `k + 2` generators along `changeForm` changes it only by terms of filtration degree at most
+`k`: the difference between the word in the `ι Q` and the same word in the `ι Q'` drops *two*
+steps. It corrects by left contractions, and each contraction removes a pair of generators, so a
+one-step bound would not be sharp. Mathlib's `changeForm_ι_mul_ι` is the first instance: a
+two-generator word is corrected by the scalar `B m₁ m₂`, which lies in `filtration Q' 0`.
 
-/-- **Change of form has identity symbol.** Transporting a word of at most `k + 1` generators
-along `changeForm` changes it only by terms of filtration degree at most `k`: the difference
-between the word in the `ι Q` and the same word in the `ι Q'` drops one step.
-
-`changeForm_mem_filtration` says `changeForm` is a filtered map; this says its associated graded
-map is the identity, which is what makes the two routes to the degree quotients agree. The bound
-is phrased as `l.length ≤ k + 1` rather than through `l.length - 1` so that the empty list is not
-a special case of truncated subtraction. -/
+Where `changeForm_mem_filtration` says `changeForm` is a filtered map, this says its associated
+graded map is the identity. -/
 theorem changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration (h : B.toQuadraticMap = Q' - Q) :
-    ∀ (l : List M) (k : ℕ), l.length ≤ k + 1 →
+    ∀ (l : List M) {k : ℕ}, l.length ≤ k + 2 →
       changeForm h (l.map (ι Q)).prod - (l.map (ι Q')).prod ∈ filtration Q' k
   | [], _, _ => by simp
-  | m :: l, 0, hk => by
+  | [m], _, _ => by simp
+  | m :: n :: l, 0, hk => by
       have hl : l = [] := List.length_eq_zero_iff.mp (by simpa using hk)
       subst hl
-      simp
-  | m :: l, k + 1, hk => by
-      have hl : l.length ≤ k + 1 := by simpa using hk
-      rw [List.map_cons, List.prod_cons, List.map_cons, List.prod_cons, changeForm_ι_mul,
-        sub_right_comm, ← mul_sub]
+      simp [changeForm_ι_mul_ι]
+  | m :: n :: l, k + 1, hk => by
+      have hl : (n :: l).length ≤ k + 2 := by simpa using hk
+      have hIH := changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration h (n :: l) hl
+      -- The tail's transport is its own word plus a lower-degree correction, so it stays in range.
+      have htail : changeForm h ((n :: l).map (ι Q)).prod ∈ filtration Q' (k + 2) := by
+        simpa using Submodule.add_mem _ (filtration_mono Q' (by omega) hIH)
+          (prod_map_ι_mem_filtration Q' hl)
+      simp only [List.map_cons, List.prod_cons] at hIH htail ⊢
+      rw [changeForm_ι_mul, sub_right_comm, ← mul_sub]
       refine Submodule.sub_mem _ ?_ ?_
-      · have hmul :=
-          Submodule.mul_mem_mul (ι_mem_filtration_one Q' m)
-            (changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration h l k hl)
-        rw [filtration_mul Q' 1 k] at hmul
-        simpa [Nat.add_comm] using hmul
-      · exact contractLeft_mem_filtration Q' (B m)
-          (filtration_mono Q' hl (changeForm_prod_map_ι_mem_filtration Q h l))
+      · simpa [Nat.add_comm] using mul_mem_filtration Q' (ι_mem_filtration_one Q' m) hIH
+      · exact contractLeft_mem_filtration_succ Q' (B m) htail
 
-/-- The `Fin`-indexed form of `changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration`, which is how
-the leading-term map presents its representatives. -/
-theorem changeForm_prod_ofFn_ι_sub_prod_ofFn_ι_mem_filtration (h : B.toQuadraticMap = Q' - Q)
-    (k : ℕ) (v : Fin (k + 1) → M) :
-    changeForm h (List.ofFn ((ι Q) ∘ v)).prod - (List.ofFn ((ι Q') ∘ v)).prod ∈
-      filtration Q' k := by
-  simpa only [List.map_ofFn] using
-    changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration Q h (List.ofFn v) k (by simp)
+private theorem changeForm_prod_map_ι_mem_filtration (h : B.toQuadraticMap = Q' - Q)
+    (l : List M) : changeForm h (l.map (ι Q)).prod ∈ filtration Q' l.length := by
+  have hdiff := changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration Q h l
+    (k := l.length) (by omega)
+  simpa using Submodule.add_mem _ hdiff (prod_map_ι_mem_filtration Q' (le_refl l.length))
 
 /-- Changing quadratic form by a bilinear form preserves each filtration step. -/
 theorem changeForm_mem_filtration (h : B.toQuadraticMap = Q' - Q) {k : ℕ}

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -16,7 +16,10 @@ form.
 
 This is the degree-quotient part of the Layer 0 `filtrationGradedEquiv` target in the
 [spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L62-L68).
-It does not construct the total associated-graded algebra or prove multiplication compatibility.
+It also identifies that equivalence with the leading-term map built in
+`TauCeti.LinearAlgebra.CliffordAlgebra.Filtration`, which reaches the same target by a different
+route, completing the bridge that file describes itself as having proved only half of. It does not
+construct the total associated-graded algebra or prove multiplication compatibility.
 
 ## Main definitions
 
@@ -30,6 +33,9 @@ It does not construct the total associated-graded algebra or prove multiplicatio
 * `TauCeti.CliffordAlgebra.equivExterior_mem_zero_form_filtration` and
   `TauCeti.CliffordAlgebra.equivExterior_symm_mem_filtration`: `equivExterior` and its inverse
   carry each Clifford filtration step to the corresponding zero-form step and back.
+* `TauCeti.CliffordAlgebra.filtrationGradedEquiv_comp_filtrationLeadingTerm`: the graded
+  equivalence inverts `Filtration.lean`'s leading-term map, so the two independent routes to the
+  degree quotient are the same map.
 
 ## References
 
@@ -143,6 +149,45 @@ theorem filtrationGradedEquiv_symm_apply (Q : QuadraticForm R M) [Invertible (2 
     Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
   apply congrArg Submodule.Quotient.mk
   exact Subtype.ext (coe_equivExteriorFiltration_symm_apply Q (k + 1) _)
+
+/-- The change-of-form transport moves a word of `k + 1` generators to the corresponding exterior
+word, modulo the previous filtration step. -/
+private theorem equivExterior_prod_ofFn_sub_ιMulti_mem (Q : QuadraticForm R M)
+    [Invertible (2 : R)] (k : ℕ) (v : Fin (k + 1) → M) :
+    equivExterior Q (List.ofFn ((ι Q) ∘ v)).prod -
+        (exteriorPower.ιMulti R (k + 1) v : ExteriorAlgebra R M) ∈
+      filtration (0 : QuadraticForm R M) k := by
+  simpa only [equivExterior, changeFormEquiv_apply, exteriorPower.ιMulti_apply_coe,
+    ExteriorAlgebra.ιMulti_apply, Function.comp_def] using
+    changeForm_prod_ofFn_ι_sub_prod_ofFn_ι_mem_filtration Q
+      (Q' := (0 : QuadraticForm R M)) changeForm.associated_neg_proof k v
+
+/-- **The leading-term map and the graded equivalence are mutually inverse.** -/
+theorem filtrationGradedEquiv_comp_filtrationLeadingTerm (Q : QuadraticForm R M)
+    [Invertible (2 : R)] (k : ℕ) :
+    (filtrationGradedEquiv Q k).toLinearMap ∘ₗ filtrationLeadingTerm Q k = LinearMap.id := by
+  apply exteriorPower.linearMap_ext
+  apply AlternatingMap.ext
+  intro v
+  simp only [LinearMap.compAlternatingMap_apply, LinearMap.comp_apply, LinearEquiv.coe_coe,
+    LinearMap.id_coe, id_eq, filtrationLeadingTerm_apply_ιMulti, filtrationGradedEquiv_apply_mk]
+  rw [← zeroFormFiltrationQuotientEquivExteriorPower_apply k (exteriorPower.ιMulti R (k + 1) v)]
+  congr 1
+  rw [Submodule.Quotient.eq, mem_filtrationPreviousRestricted_iff, filtrationPrevious_succ]
+  simpa using equivExterior_prod_ofFn_sub_ιMulti_mem Q k v
+
+/-- The leading-term map is the inverse of the graded equivalence. -/
+theorem filtrationLeadingTerm_eq_coe_symm (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
+    filtrationLeadingTerm Q k = (filtrationGradedEquiv Q k).symm.toLinearMap := by
+  refine LinearMap.ext fun x => (filtrationGradedEquiv Q k).injective ?_
+  simp only [LinearEquiv.coe_coe, LinearEquiv.apply_symm_apply]
+  exact LinearMap.congr_fun (filtrationGradedEquiv_comp_filtrationLeadingTerm Q k) x
+
+/-- Consequently the leading-term map is bijective when `2` is invertible. -/
+theorem filtrationLeadingTerm_bijective (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
+    Function.Bijective (filtrationLeadingTerm Q k) := by
+  rw [filtrationLeadingTerm_eq_coe_symm]
+  exact (filtrationGradedEquiv Q k).symm.bijective
 
 end CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -35,12 +35,21 @@ construct the total associated-graded algebra or prove multiplication compatibil
   carry each Clifford filtration step to the corresponding zero-form step and back.
 * `TauCeti.CliffordAlgebra.filtrationGradedEquiv_comp_filtrationLeadingTerm`: the graded
   equivalence inverts `Filtration.lean`'s leading-term map, so the two independent routes to the
-  degree quotient are the same map.
+  degree quotient are the same map, with
+  `TauCeti.CliffordAlgebra.filtrationLeadingTerm_eq_filtrationGradedEquiv_symm` the map-level form.
 
 ## References
 
 * [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
   Layer 0, "The degree filtration".
+* The identification of the associated graded of the Clifford filtration with the exterior algebra
+  is the Clifford-algebra analogue of the Poincaré-Birkhoff-Witt theorem; see C. Chevalley, *The
+  Algebraic Theory of Spinors* (1954), Chapter II, and H. B. Lawson and M.-L. Michelsohn, *Spin
+  Geometry* (1989), Proposition I.1.2.
+* The transport used here is Bourbaki's `λ_B`, Mathlib's `CliffordAlgebra.changeForm`: it is
+  triangular with identity leading term rather than an antisymmetrisation, which is why the two
+  routes agree on the nose with no scalar. See N. Bourbaki, *Algèbre* IX §9, and
+  [grinberg_clifford_2016] as cited by Mathlib's `Contraction.lean`.
 -/
 
 public section
@@ -150,7 +159,9 @@ theorem filtrationGradedEquiv_symm_apply (Q : QuadraticForm R M) [Invertible (2 
   apply congrArg Submodule.Quotient.mk
   exact Subtype.ext (coe_equivExteriorFiltration_symm_apply Q (k + 1) _)
 
-/-- **The leading-term map and the graded equivalence are mutually inverse.** -/
+/-- **The graded equivalence undoes the leading-term map.** Together with
+`filtrationLeadingTerm_surjective`, which holds over any `CommRing`, this identifies the two
+independent routes `Filtration.lean` and this file take to the degree-`k + 1` quotient. -/
 theorem filtrationGradedEquiv_comp_filtrationLeadingTerm (Q : QuadraticForm R M)
     [Invertible (2 : R)] (k : ℕ) :
     (filtrationGradedEquiv Q k).toLinearMap ∘ₗ filtrationLeadingTerm Q k = LinearMap.id := by
@@ -164,22 +175,26 @@ theorem filtrationGradedEquiv_comp_filtrationLeadingTerm (Q : QuadraticForm R M)
   rw [Submodule.Quotient.eq, mem_filtrationPreviousRestricted_iff, filtrationPrevious_succ]
   -- What remains is `changeForm`'s symbol computation at `Q' = 0`, read through `equivExterior`.
   simpa only [equivExterior, changeFormEquiv_apply, exteriorPower.ιMulti_apply_coe,
-    ExteriorAlgebra.ιMulti_apply, Function.comp_def, AddSubgroupClass.coe_sub] using
-    changeForm_prod_ofFn_ι_sub_prod_ofFn_ι_mem_filtration Q
-      (Q' := (0 : QuadraticForm R M)) changeForm.associated_neg_proof k v
+    ExteriorAlgebra.ιMulti_apply, Function.comp_def, AddSubgroupClass.coe_sub,
+    List.map_ofFn] using
+    changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration Q
+      (Q' := (0 : QuadraticForm R M)) changeForm.associated_neg_proof (List.ofFn v)
+      (by simp)
 
-/-- The leading-term map is the inverse of the graded equivalence. -/
-theorem filtrationLeadingTerm_eq_coe_symm (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
+/-- The pointwise form, which is the one `simp` can use. -/
+@[simp]
+theorem filtrationGradedEquiv_filtrationLeadingTerm (Q : QuadraticForm R M) [Invertible (2 : R)]
+    (k : ℕ) (x : ⋀[R]^(k + 1) M) :
+    filtrationGradedEquiv Q k (filtrationLeadingTerm Q k x) = x :=
+  LinearMap.congr_fun (filtrationGradedEquiv_comp_filtrationLeadingTerm Q k) x
+
+/-- The leading-term map is `filtrationGradedEquiv`'s inverse. -/
+theorem filtrationLeadingTerm_eq_filtrationGradedEquiv_symm (Q : QuadraticForm R M)
+    [Invertible (2 : R)] (k : ℕ) :
     filtrationLeadingTerm Q k = (filtrationGradedEquiv Q k).symm.toLinearMap := by
   rw [← LinearMap.comp_id (filtrationGradedEquiv Q k).symm.toLinearMap]
   exact (LinearEquiv.eq_toLinearMap_symm_comp _ _).2
     (filtrationGradedEquiv_comp_filtrationLeadingTerm Q k)
-
-/-- Consequently the leading-term map is bijective when `2` is invertible. -/
-theorem filtrationLeadingTerm_bijective (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
-    Function.Bijective (filtrationLeadingTerm Q k) := by
-  rw [filtrationLeadingTerm_eq_coe_symm]
-  exact (filtrationGradedEquiv Q k).symm.bijective
 
 end CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -150,18 +150,6 @@ theorem filtrationGradedEquiv_symm_apply (Q : QuadraticForm R M) [Invertible (2 
   apply congrArg Submodule.Quotient.mk
   exact Subtype.ext (coe_equivExteriorFiltration_symm_apply Q (k + 1) _)
 
-/-- The change-of-form transport moves a word of `k + 1` generators to the corresponding exterior
-word, modulo the previous filtration step. -/
-private theorem equivExterior_prod_ofFn_sub_ιMulti_mem (Q : QuadraticForm R M)
-    [Invertible (2 : R)] (k : ℕ) (v : Fin (k + 1) → M) :
-    equivExterior Q (List.ofFn ((ι Q) ∘ v)).prod -
-        (exteriorPower.ιMulti R (k + 1) v : ExteriorAlgebra R M) ∈
-      filtration (0 : QuadraticForm R M) k := by
-  simpa only [equivExterior, changeFormEquiv_apply, exteriorPower.ιMulti_apply_coe,
-    ExteriorAlgebra.ιMulti_apply, Function.comp_def] using
-    changeForm_prod_ofFn_ι_sub_prod_ofFn_ι_mem_filtration Q
-      (Q' := (0 : QuadraticForm R M)) changeForm.associated_neg_proof k v
-
 /-- **The leading-term map and the graded equivalence are mutually inverse.** -/
 theorem filtrationGradedEquiv_comp_filtrationLeadingTerm (Q : QuadraticForm R M)
     [Invertible (2 : R)] (k : ℕ) :
@@ -174,14 +162,18 @@ theorem filtrationGradedEquiv_comp_filtrationLeadingTerm (Q : QuadraticForm R M)
   rw [← zeroFormFiltrationQuotientEquivExteriorPower_apply k (exteriorPower.ιMulti R (k + 1) v)]
   congr 1
   rw [Submodule.Quotient.eq, mem_filtrationPreviousRestricted_iff, filtrationPrevious_succ]
-  simpa using equivExterior_prod_ofFn_sub_ιMulti_mem Q k v
+  -- What remains is `changeForm`'s symbol computation at `Q' = 0`, read through `equivExterior`.
+  simpa only [equivExterior, changeFormEquiv_apply, exteriorPower.ιMulti_apply_coe,
+    ExteriorAlgebra.ιMulti_apply, Function.comp_def, AddSubgroupClass.coe_sub] using
+    changeForm_prod_ofFn_ι_sub_prod_ofFn_ι_mem_filtration Q
+      (Q' := (0 : QuadraticForm R M)) changeForm.associated_neg_proof k v
 
 /-- The leading-term map is the inverse of the graded equivalence. -/
 theorem filtrationLeadingTerm_eq_coe_symm (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
     filtrationLeadingTerm Q k = (filtrationGradedEquiv Q k).symm.toLinearMap := by
-  refine LinearMap.ext fun x => (filtrationGradedEquiv Q k).injective ?_
-  simp only [LinearEquiv.coe_coe, LinearEquiv.apply_symm_apply]
-  exact LinearMap.congr_fun (filtrationGradedEquiv_comp_filtrationLeadingTerm Q k) x
+  rw [← LinearMap.comp_id (filtrationGradedEquiv Q k).symm.toLinearMap]
+  exact (LinearEquiv.eq_toLinearMap_symm_comp _ _).2
+    (filtrationGradedEquiv_comp_filtrationLeadingTerm Q k)
 
 /-- Consequently the leading-term map is bijective when `2` is invertible. -/
 theorem filtrationLeadingTerm_bijective (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR identifies the two independent routes `main` takes to the Layer 0 degree-quotient target, and supplies the symbol computation that makes the identification possible.

`Filtration.lean` builds `filtrationLeadingTerm` with `filtrationLeadingTerm_surjective` over any `CommRing`; `Graded.lean` separately builds `filtrationGradedEquiv` by transport along `equivExterior`, needing `Invertible (2 : R)`. Nothing connected them and neither had a consumer. After this PR, `filtrationGradedEquiv_comp_filtrationLeadingTerm` says the graded equivalence undoes the leading-term map, with a pointwise `@[simp]` form and the map-level `filtrationLeadingTerm_eq_filtrationGradedEquiv_symm`. The roughly 200 lines supporting `filtrationLeadingTerm` become the `CommRing`-level half of a map now known to be the graded equivalence's inverse whenever `2` is invertible.

The input is `changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration`: transporting a word of at most `k + 2` generators along `changeForm` changes it only by terms of filtration degree at most `k`. Where `changeForm_mem_filtration` says `changeForm` is a filtered map, this says its associated graded map is the identity. The bound is two steps rather than one because `changeForm` corrects by left contractions and each removes a pair of generators; Mathlib's `changeForm_ι_mul_ι` is the degree-two witness, correcting a two-generator word by the scalar `B m₁ m₂`. The old `changeForm_prod_map_ι_mem_filtration` is now derived from it rather than being a second structural recursion over the same shape.

There is no sign, scalar or factorial discrepancy between the two routes: the transport is Bourbaki's `λ_B`, triangular with identity leading term rather than an antisymmetrisation. The degree-two case was already in the repo as `equivExterior_ι_mul_ι_sub_swap`.

Full build with `--iofail`, axiom audit, module-system check and environment lint pass; `lint-env` reports no new violations.

🤖 Prepared with Claude Code