### PR TITLE
refactor(CliffordAlgebra): remove the unused graded instance unfolders

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -280,19 +280,10 @@ noncomputable instance filtrationGradedGOne {Q : QuadraticForm R M} :
     GradedMonoid.GOne (FiltrationGradedPiece Q) where
   one := filtrationGradedOne Q
 
-/-- The `GOne` field is the named degree-zero filtration class. -/
-@[simp] theorem filtrationGradedGOne_def (Q : QuadraticForm R M) :
-    (GradedMonoid.GOne.one : FiltrationGradedPiece Q 0) = filtrationGradedOne Q := rfl
-
 /-- Homogeneous filtration multiplication supplies the `GMul` structure on filtration pieces. -/
 noncomputable instance filtrationGradedGMul {Q : QuadraticForm R M} :
     GradedMonoid.GMul (FiltrationGradedPiece Q) where
   mul {i j} := fun x y => filtrationGradedMul Q i j x y
-
-/-- The `GMul` field is the named homogeneous filtration product. -/
-@[simp] theorem filtrationGradedGMul_def (Q : QuadraticForm R M) {i j : ℕ}
-    (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j) :
-    GradedMonoid.GMul.mul (A := FiltrationGradedPiece Q) x y = filtrationGradedMul Q i j x y := rfl
 
 /-- The homogeneous unit and multiplication form a graded monoid of filtration pieces. -/
 noncomputable instance filtrationGradedGMonoid {Q : QuadraticForm R M} :
@@ -477,11 +468,6 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
     simpa only [cast_cast, cast_eq] using
       congrArg (cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm))
         (filtrationGradedAlgebraMap₀_mul Q r k x)
-
-/-- The `GAlgebra` field is the named degree-zero scalar map. -/
-@[simp] theorem filtrationGradedGAlgebra_toFun_def (Q : QuadraticForm R M) (r : R) :
-    DirectSum.GAlgebra.toFun (A := FiltrationGradedPiece Q)
-      (self := filtrationGradedGAlgebra (Q := Q)) r = filtrationGradedAlgebraMap₀ Q r := rfl
 
 /-- The direct sum of homogeneous filtration pieces inherits its associated-graded
 ring structure. -/


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR deletes `filtrationGradedGOne_def`, `filtrationGradedGMul_def` and `filtrationGradedGAlgebra_toFun_def`. Each is an `@[simp]` `rfl` lemma rewriting a `GradedMonoid`/`DirectSum` instance projection into its named form. `git grep` finds only the declaration site for all three, and because they carry `@[simp]` they participate in every downstream `simp` call while doing so.

This touches ground that was argued in #1971, so I want to be exact about what is and is not being revisited. That round's `reuse` finding asked for the `_def` lemmas to go; the author contested, on the grounds that they follow Mathlib's `TensorPower.gOne_def` / `galgebra_toFun_def` pattern, and the rubric accepted the argument. Checking the pinned Mathlib, that defence is correct for one group of lemmas and not for the other:

- `TensorPower.gOne_def`, `gMul_def` and `galgebra_toFun_def` are **not** `@[simp]` (`Mathlib/LinearAlgebra/TensorPower/Basic.lean:72, 86, 259`). They exist to unfold that file's *local notation* `ₜ1` and `ₜ*` (declared at `:70` and `:84`), and they are used, at `:141`, `:150`, `:153`, `:162` and `:165`.
- `filtrationGradedOne_def` and `filtrationGradedAlgebraMap₀_apply` in this file are likewise not `@[simp]`, and each is used by its `_mk` sibling. They match the Mathlib pattern, so **this PR keeps them** and the #1971 outcome stands.
- The three deleted here differ on both counts: they are `@[simp]`, and they have no use at all. TauCeti has no local notation for them to unfold, which was the reason Mathlib's exist.

So this is not a re-run of the earlier finding; it separates the three declarations the Mathlib parallel does not cover.

If a reviewer still reads the parallel as covering all five, the minimal consistent outcome is to keep these three but drop `@[simp]` from them, which is exactly Mathlib's shape. I will make that change on request rather than contest a second round.

The full build with `--iofail`, axiom audit, module-system check and environment lint pass; `lint-env` reports no new violations. Test-merges clean against my other open branches touching this area, #2506 and #2512.

🤖 Prepared with Claude Code