### PR TITLE
feat: a point is determined by its action on the regular comodule

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -8,6 +8,8 @@ public import TauCeti.Algebra.Coalgebra.Comodule.Basic
 public import Mathlib.RingTheory.Bialgebra.Convolution
 public import Mathlib.RepresentationTheory.Basic
 
+import Mathlib.RingTheory.Coalgebra.CoassocSimps
+
 /-!
 # The points action of a comodule
 
@@ -32,9 +34,13 @@ the functor of points on scalar extensions of `V`.
   convolution monoid of points on the scalar extension.
 * `TauCeti.Comodule.baseChange_comp_endOfPoint`: the action is functorial in the
   comodule.
+* `TauCeti.Comodule.rid_lTensor_counit_comm_lTensor_comul`: the counit recovers a linear
+  map from its transport along the comultiplication.
 * `TauCeti.Comodule.rid_lTensor_counit_endOfPoint_one_tmul` and
   `TauCeti.Comodule.endOfPoint_self_injective`: on the regular comodule the counit
-  recovers the point from its action, so a point is determined by how it acts.
+  recovers a point from the endomorphism it induces, so distinct points induce distinct
+  endomorphisms. (Over a bialgebra, where the action laws hold, this is faithfulness of
+  the action.)
 
 ## References
 
@@ -49,6 +55,49 @@ namespace TauCeti
 namespace Comodule
 
 open Coalgebra WithConv TensorProduct
+
+section Recovery
+
+variable {R H A : Type*} [CommSemiring R] [AddCommMonoid H] [Module R H] [Coalgebra R H]
+  [AddCommMonoid A] [Module R A]
+
+/-- **Recovery of a linear map from its comultiplication transport.** Pushing `comul h`
+through `f` on the right leg, swapping the factors and contracting the remaining `H`-leg
+with the counit returns `f h`.
+
+This is Mathlib's map-level counit law `CoassocSimps.map_counit_comp_comul_left` read
+through the swap: no algebra structure on either side is involved, only the coalgebra `H`,
+the module `A`, and the `R`-linearity of `f`. It is the engine behind
+`rid_lTensor_counit_endOfPoint_one_tmul`, where `f` is the linear map of a point. -/
+@[simp↓]
+theorem rid_lTensor_counit_comm_lTensor_comul (f : H →ₗ[R] A) (h : H) :
+    TensorProduct.rid R A (LinearMap.lTensor A (counit (R := R) (A := H))
+        (TensorProduct.comm R H A
+          (LinearMap.lTensor H f (Coalgebra.comul (R := R) (A := H) h)))) =
+      f h := by
+  -- The swap turns the `H`-column contraction into the left contraction Mathlib states.
+  have hswap : ∀ z : H ⊗[R] A,
+      TensorProduct.rid R A (LinearMap.lTensor A (counit (R := R) (A := H))
+          (TensorProduct.comm R H A z)) =
+        TensorProduct.lid R A (TensorProduct.map (counit (R := R) (A := H)) LinearMap.id z) := by
+    intro z
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | tmul x a => simp
+    | add x y hx hy => simp [hx, hy]
+  -- Fusing the two legs puts the goal in the shape Mathlib's map-level counit law states.
+  have hmap : ∀ z : H ⊗[R] H,
+      TensorProduct.map (counit (R := R) (A := H)) LinearMap.id (LinearMap.lTensor H f z) =
+        TensorProduct.map (counit (R := R) (A := H)) f z := by
+    intro z
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | tmul x y => simp
+    | add x y hx hy => simp [hx, hy]
+  rw [hswap, hmap, ← LinearMap.comp_apply, _root_.CoassocSimps.map_counit_comp_comul_left]
+  simp
+
+end Recovery
 
 section Coalgebra
 
@@ -136,35 +185,10 @@ end Functorial
 
 section Regular
 
-/-- **Recovery of a linear map from its comultiplication transport.** Pushing `comul h`
-through `f` on the right leg, swapping the factors and contracting the remaining `H`-leg
-with the counit returns `f h`: it is the counit identity `(ε ⊗ id) ∘ comul = id`
-(`Coalgebra.rTensor_counit_comul`) read through `f`.
-
-Only `R`-linearity of `f` is used. This is the engine behind
-`rid_lTensor_counit_endOfPoint_one_tmul`; `endOfPoint` keeps an `H →ₐ[R] A` argument
-because it is an action *of points*, whose action laws do need multiplicativity. -/
-theorem rid_lTensor_counit_comm_lTensor_comul (f : H →ₗ[R] A) (h : H) :
-    TensorProduct.rid R A (LinearMap.lTensor A (counit (R := R) (A := H))
-        (TensorProduct.comm R H A
-          (LinearMap.lTensor H f (Coalgebra.comul (R := R) (A := H) h)))) =
-      f h := by
-  have key : (TensorProduct.rid R A).toLinearMap ∘ₗ
-      LinearMap.lTensor A (counit (R := R) (A := H)) ∘ₗ
-        (TensorProduct.comm R H A).toLinearMap ∘ₗ LinearMap.lTensor H f =
-      f ∘ₗ (TensorProduct.lid R H).toLinearMap ∘ₗ
-        LinearMap.rTensor H (counit (R := R) (A := H)) := by
-    refine TensorProduct.ext' fun x y => ?_
-    -- Both sides are `ε x • f y`; on the right it is `f`'s linearity that pulls the scalar out.
-    simp [map_smul]
-  have hkey := LinearMap.congr_fun key (Coalgebra.comul (R := R) (A := H) h)
-  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_toLinearMap] at hkey
-  rw [hkey, Coalgebra.rTensor_counit_comul]
-  simp
-
-/-- The counit collapses the action on the regular comodule back onto the point: the
-`H`-column of `endOfPoint H g (1 ⊗ₜ h)` carries the left Sweedler leg, so applying the
-counit there contracts `Σ ε(h₍₁₎) • g(h₍₂₎)` to `g h`. -/
+/-- The counit collapses the endomorphism attached to a point on the regular comodule back
+onto the point: the `H`-column of `endOfPoint H g (1 ⊗ₜ h)` carries the left Sweedler leg,
+so applying the counit there contracts `Σ ε(h₍₁₎) • g(h₍₂₎)` to `g h`. -/
+@[simp↓]
 theorem rid_lTensor_counit_endOfPoint_one_tmul (g : H →ₐ[R] A) (h : H) :
     TensorProduct.rid R A
         (LinearMap.lTensor A (counit (R := R) (A := H)) (endOfPoint H g (1 ⊗ₜ[R] h))) =

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -32,6 +32,9 @@ the functor of points on scalar extensions of `V`.
   convolution monoid of points on the scalar extension.
 * `TauCeti.Comodule.baseChange_comp_endOfPoint`: the action is functorial in the
   comodule.
+* `TauCeti.Comodule.rid_lTensor_counit_endOfPoint_one_tmul` and
+  `TauCeti.Comodule.endOfPoint_self_injective`: on the regular comodule the counit
+  recovers the point from its action, so a point is determined by how it acts.
 
 ## References
 
@@ -133,31 +136,41 @@ end Functorial
 
 section Regular
 
+/-- **Recovery of a linear map from its comultiplication transport.** Pushing `comul h`
+through `f` on the right leg, swapping the factors and contracting the remaining `H`-leg
+with the counit returns `f h`: it is the counit identity `(ε ⊗ id) ∘ comul = id`
+(`Coalgebra.rTensor_counit_comul`) read through `f`.
+
+Only `R`-linearity of `f` is used. This is the engine behind
+`rid_lTensor_counit_endOfPoint_one_tmul`; `endOfPoint` keeps an `H →ₐ[R] A` argument
+because it is an action *of points*, whose action laws do need multiplicativity. -/
+theorem rid_lTensor_counit_comm_lTensor_comul (f : H →ₗ[R] A) (h : H) :
+    TensorProduct.rid R A (LinearMap.lTensor A (counit (R := R) (A := H))
+        (TensorProduct.comm R H A
+          (LinearMap.lTensor H f (Coalgebra.comul (R := R) (A := H) h)))) =
+      f h := by
+  have key : (TensorProduct.rid R A).toLinearMap ∘ₗ
+      LinearMap.lTensor A (counit (R := R) (A := H)) ∘ₗ
+        (TensorProduct.comm R H A).toLinearMap ∘ₗ LinearMap.lTensor H f =
+      f ∘ₗ (TensorProduct.lid R H).toLinearMap ∘ₗ
+        LinearMap.rTensor H (counit (R := R) (A := H)) := by
+    refine TensorProduct.ext' fun x y => ?_
+    -- Both sides are `ε x • f y`; on the right it is `f`'s linearity that pulls the scalar out.
+    simp [map_smul]
+  have hkey := LinearMap.congr_fun key (Coalgebra.comul (R := R) (A := H) h)
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_toLinearMap] at hkey
+  rw [hkey, Coalgebra.rTensor_counit_comul]
+  simp
+
 /-- The counit collapses the action on the regular comodule back onto the point: the
 `H`-column of `endOfPoint H g (1 ⊗ₜ h)` carries the left Sweedler leg, so applying the
-counit there contracts `Σ ε(h₍₁₎) • g(h₍₂₎)` to `g h`.
-
-This is the coalgebra counit identity `(ε ⊗ id) ∘ comul = id`
-(`Coalgebra.rTensor_counit_comp_comul`) transported through `endOfPoint`; only the
-`R`-linearity of `g` is used, not its multiplicativity. -/
+counit there contracts `Σ ε(h₍₁₎) • g(h₍₂₎)` to `g h`. -/
 theorem rid_lTensor_counit_endOfPoint_one_tmul (g : H →ₐ[R] A) (h : H) :
     TensorProduct.rid R A
         (LinearMap.lTensor A (counit (R := R) (A := H)) (endOfPoint H g (1 ⊗ₜ[R] h))) =
       g h := by
-  have key : (TensorProduct.rid R A).toLinearMap ∘ₗ
-      LinearMap.lTensor A (counit (R := R) (A := H)) ∘ₗ
-        (TensorProduct.comm R H A).toLinearMap ∘ₗ LinearMap.lTensor H g.toLinearMap =
-      g.toLinearMap ∘ₗ (TensorProduct.lid R H).toLinearMap ∘ₗ
-        LinearMap.rTensor H (counit (R := R) (A := H)) := by
-    refine TensorProduct.ext' fun x y => ?_
-    simp [Algebra.smul_def]
-  have hkey := LinearMap.congr_fun key (Coalgebra.comul (R := R) (A := H) h)
-  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_toLinearMap] at hkey
-  rw [endOfPoint_tmul, instSelf_coact, one_smul, hkey]
-  rw [show LinearMap.rTensor H (counit (R := R) (A := H))
-      (Coalgebra.comul (R := R) (A := H) h) = (1 : R) ⊗ₜ[R] h from
-    LinearMap.congr_fun Coalgebra.rTensor_counit_comp_comul h]
-  simp
+  rw [endOfPoint_tmul, instSelf_coact, one_smul]
+  exact rid_lTensor_counit_comm_lTensor_comul g.toLinearMap h
 
 /-- **A point is determined by its action on the regular comodule.** Two `A`-points of
 `H` that act identically on the scalar extension of the regular comodule are equal, so
@@ -166,9 +179,10 @@ the map sending a point to its action is injective.
 Over a Hopf algebra this is the faithfulness of the points action on the category of *all*
 comodules, the first half of a Tannakian reconstruction. It is not by itself faithfulness
 against the fibre functor of the *finite* comodule category: the regular comodule need not
-be finite. Bridging the two needs in addition that every comodule is the supremum of its
-finite subcomodules (`TauCeti.Subcomodule.sSup_finiteSubcomodules_eq_top`), which is not
-used here. -/
+be finite. Bridging the two needs in addition that, over a free coefficient coalgebra,
+every comodule is the supremum of its finite subcomodules
+(`TauCeti.Subcomodule.sSup_finiteSubcomodules_eq_top`, which assumes `[Module.Free R C]`);
+that is not used here. -/
 theorem endOfPoint_self_injective :
     Function.Injective fun g : H →ₐ[R] A => endOfPoint H g := by
   intro g g' hg

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -151,27 +151,11 @@ theorem rid_lTensor_counit_endOfPoint_one_tmul (g : H →ₐ[R] A) (h : H) :
         (LinearMap.lTensor A (counit (R := R) (A := H)) (endOfPoint H g (1 ⊗ₜ[R] h))) =
       g h := by
   rw [endOfPoint_tmul, instSelf_coact, one_smul]
-  -- The swap turns the `H`-column contraction into the left contraction Mathlib states, and
-  -- fusing the two legs puts the goal in the shape of its map-level counit law.
-  have hswap : ∀ z : H ⊗[R] A,
-      TensorProduct.rid R A (LinearMap.lTensor A (counit (R := R) (A := H))
-          (TensorProduct.comm R H A z)) =
-        TensorProduct.lid R A (TensorProduct.map (counit (R := R) (A := H)) LinearMap.id z) := by
-    intro z
-    induction z using TensorProduct.induction_on with
-    | zero => simp
-    | tmul x a => simp
-    | add x y hx hy => simp [hx, hy]
-  have hmap : ∀ z : H ⊗[R] H,
-      TensorProduct.map (counit (R := R) (A := H)) LinearMap.id
-          (LinearMap.lTensor H g.toLinearMap z) =
-        TensorProduct.map (counit (R := R) (A := H)) g.toLinearMap z := by
-    intro z
-    induction z using TensorProduct.induction_on with
-    | zero => simp
-    | tmul x y => simp
-    | add x y hx hy => simp [hx, hy]
-  rw [hswap, hmap, ← LinearMap.comp_apply, _root_.CoassocSimps.map_counit_comp_comul_left]
+  -- Push the counit through the swap and fuse the two legs, so that the goal is exactly
+  -- Mathlib's map-level counit law; all three steps are Mathlib's tensor plumbing.
+  rw [LinearMap.lTensor_comm, TensorProduct.rid_comm, LinearMap.rTensor,
+    LinearMap.map_lTensor, ← LinearMap.comp_apply,
+    _root_.CoassocSimps.map_counit_comp_comul_left]
   simp
 
 /-- **A point is determined by the endomorphism it induces on the regular comodule.** Two

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -131,6 +131,45 @@ lemma baseChange_comp_endOfPoint (f : Hom R H V W) (g : H →ₐ[R] A) :
 
 end Functorial
 
+section Regular
+
+/-- The counit collapses the action on the regular comodule back onto the point: the
+`H`-column of `endOfPoint H g (1 ⊗ₜ h)` carries the left Sweedler leg, so applying the
+counit there contracts `Σ ε(h₍₁₎) • g(h₍₂₎)` to `g h`. -/
+theorem rid_lTensor_counit_endOfPoint_one_tmul (g : H →ₐ[R] A) (h : H) :
+    TensorProduct.rid R A
+        (LinearMap.lTensor A (counit (R := R) (A := H)) (endOfPoint H g (1 ⊗ₜ[R] h))) =
+      g h := by
+  have key : (TensorProduct.rid R A).toLinearMap ∘ₗ
+      LinearMap.lTensor A (counit (R := R) (A := H)) ∘ₗ
+        (TensorProduct.comm R H A).toLinearMap ∘ₗ LinearMap.lTensor H g.toLinearMap =
+      g.toLinearMap ∘ₗ (TensorProduct.lid R H).toLinearMap ∘ₗ
+        LinearMap.rTensor H (counit (R := R) (A := H)) := by
+    refine TensorProduct.ext' fun x y => ?_
+    simp [Algebra.smul_def]
+  have hkey := LinearMap.congr_fun key (Coalgebra.comul (R := R) (A := H) h)
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_toLinearMap] at hkey
+  rw [endOfPoint_tmul, instSelf_coact, one_smul, hkey]
+  rw [show LinearMap.rTensor H (counit (R := R) (A := H))
+      (Coalgebra.comul (R := R) (A := H) h) = (1 : R) ⊗ₜ[R] h from
+    LinearMap.congr_fun Coalgebra.rTensor_counit_comp_comul h]
+  simp
+
+/-- **A point is determined by its action on the regular comodule.** Two `A`-points of
+`H` that act identically on the scalar extension of the regular comodule are equal, so
+the map sending a point to its action is injective. Over a Hopf algebra this is the
+injectivity of `G(A) → Aut(ω_A)` for the fibre functor `ω`, the first half of a Tannakian
+reconstruction. -/
+theorem endOfPoint_self_injective :
+    Function.Injective fun g : H →ₐ[R] A => endOfPoint H g := by
+  intro g g' hg
+  ext h
+  rw [← rid_lTensor_counit_endOfPoint_one_tmul g h,
+    ← rid_lTensor_counit_endOfPoint_one_tmul g' h]
+  exact congrArg _ (congrArg _ (LinearMap.congr_fun hg (1 ⊗ₜ[R] h)))
+
+end Regular
+
 end Coalgebra
 
 section Bialgebra

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -135,7 +135,11 @@ section Regular
 
 /-- The counit collapses the action on the regular comodule back onto the point: the
 `H`-column of `endOfPoint H g (1 ⊗ₜ h)` carries the left Sweedler leg, so applying the
-counit there contracts `Σ ε(h₍₁₎) • g(h₍₂₎)` to `g h`. -/
+counit there contracts `Σ ε(h₍₁₎) • g(h₍₂₎)` to `g h`.
+
+This is the coalgebra counit identity `(ε ⊗ id) ∘ comul = id`
+(`Coalgebra.rTensor_counit_comp_comul`) transported through `endOfPoint`; only the
+`R`-linearity of `g` is used, not its multiplicativity. -/
 theorem rid_lTensor_counit_endOfPoint_one_tmul (g : H →ₐ[R] A) (h : H) :
     TensorProduct.rid R A
         (LinearMap.lTensor A (counit (R := R) (A := H)) (endOfPoint H g (1 ⊗ₜ[R] h))) =
@@ -157,9 +161,14 @@ theorem rid_lTensor_counit_endOfPoint_one_tmul (g : H →ₐ[R] A) (h : H) :
 
 /-- **A point is determined by its action on the regular comodule.** Two `A`-points of
 `H` that act identically on the scalar extension of the regular comodule are equal, so
-the map sending a point to its action is injective. Over a Hopf algebra this is the
-injectivity of `G(A) → Aut(ω_A)` for the fibre functor `ω`, the first half of a Tannakian
-reconstruction. -/
+the map sending a point to its action is injective.
+
+Over a Hopf algebra this is the faithfulness of the points action on the category of *all*
+comodules, the first half of a Tannakian reconstruction. It is not by itself faithfulness
+against the fibre functor of the *finite* comodule category: the regular comodule need not
+be finite. Bridging the two needs in addition that every comodule is the supremum of its
+finite subcomodules (`TauCeti.Subcomodule.sSup_finiteSubcomodules_eq_top`), which is not
+used here. -/
 theorem endOfPoint_self_injective :
     Function.Injective fun g : H →ₐ[R] A => endOfPoint H g := by
   intro g g' hg

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -34,13 +34,13 @@ the functor of points on scalar extensions of `V`.
   convolution monoid of points on the scalar extension.
 * `TauCeti.Comodule.baseChange_comp_endOfPoint`: the action is functorial in the
   comodule.
-* `TauCeti.Comodule.rid_lTensor_counit_comm_lTensor_comul`: the counit recovers a linear
-  map from its transport along the comultiplication.
 * `TauCeti.Comodule.rid_lTensor_counit_endOfPoint_one_tmul` and
   `TauCeti.Comodule.endOfPoint_self_injective`: on the regular comodule the counit
   recovers a point from the endomorphism it induces, so distinct points induce distinct
   endomorphisms. (Over a bialgebra, where the action laws hold, this is faithfulness of
-  the action.)
+  the action.) The underlying map-level counit law is Mathlib's
+  `CoassocSimps.map_counit_comp_comul_left`, which already states the arbitrary-linear-map
+  form, so nothing is restated here.
 
 ## References
 
@@ -55,49 +55,6 @@ namespace TauCeti
 namespace Comodule
 
 open Coalgebra WithConv TensorProduct
-
-section Recovery
-
-variable {R H A : Type*} [CommSemiring R] [AddCommMonoid H] [Module R H] [Coalgebra R H]
-  [AddCommMonoid A] [Module R A]
-
-/-- **Recovery of a linear map from its comultiplication transport.** Pushing `comul h`
-through `f` on the right leg, swapping the factors and contracting the remaining `H`-leg
-with the counit returns `f h`.
-
-This is Mathlib's map-level counit law `CoassocSimps.map_counit_comp_comul_left` read
-through the swap: no algebra structure on either side is involved, only the coalgebra `H`,
-the module `A`, and the `R`-linearity of `f`. It is the engine behind
-`rid_lTensor_counit_endOfPoint_one_tmul`, where `f` is the linear map of a point. -/
-@[simp↓]
-theorem rid_lTensor_counit_comm_lTensor_comul (f : H →ₗ[R] A) (h : H) :
-    TensorProduct.rid R A (LinearMap.lTensor A (counit (R := R) (A := H))
-        (TensorProduct.comm R H A
-          (LinearMap.lTensor H f (Coalgebra.comul (R := R) (A := H) h)))) =
-      f h := by
-  -- The swap turns the `H`-column contraction into the left contraction Mathlib states.
-  have hswap : ∀ z : H ⊗[R] A,
-      TensorProduct.rid R A (LinearMap.lTensor A (counit (R := R) (A := H))
-          (TensorProduct.comm R H A z)) =
-        TensorProduct.lid R A (TensorProduct.map (counit (R := R) (A := H)) LinearMap.id z) := by
-    intro z
-    induction z using TensorProduct.induction_on with
-    | zero => simp
-    | tmul x a => simp
-    | add x y hx hy => simp [hx, hy]
-  -- Fusing the two legs puts the goal in the shape Mathlib's map-level counit law states.
-  have hmap : ∀ z : H ⊗[R] H,
-      TensorProduct.map (counit (R := R) (A := H)) LinearMap.id (LinearMap.lTensor H f z) =
-        TensorProduct.map (counit (R := R) (A := H)) f z := by
-    intro z
-    induction z using TensorProduct.induction_on with
-    | zero => simp
-    | tmul x y => simp
-    | add x y hx hy => simp [hx, hy]
-  rw [hswap, hmap, ← LinearMap.comp_apply, _root_.CoassocSimps.map_counit_comp_comul_left]
-  simp
-
-end Recovery
 
 section Coalgebra
 
@@ -194,17 +151,41 @@ theorem rid_lTensor_counit_endOfPoint_one_tmul (g : H →ₐ[R] A) (h : H) :
         (LinearMap.lTensor A (counit (R := R) (A := H)) (endOfPoint H g (1 ⊗ₜ[R] h))) =
       g h := by
   rw [endOfPoint_tmul, instSelf_coact, one_smul]
-  exact rid_lTensor_counit_comm_lTensor_comul g.toLinearMap h
+  -- The swap turns the `H`-column contraction into the left contraction Mathlib states, and
+  -- fusing the two legs puts the goal in the shape of its map-level counit law.
+  have hswap : ∀ z : H ⊗[R] A,
+      TensorProduct.rid R A (LinearMap.lTensor A (counit (R := R) (A := H))
+          (TensorProduct.comm R H A z)) =
+        TensorProduct.lid R A (TensorProduct.map (counit (R := R) (A := H)) LinearMap.id z) := by
+    intro z
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | tmul x a => simp
+    | add x y hx hy => simp [hx, hy]
+  have hmap : ∀ z : H ⊗[R] H,
+      TensorProduct.map (counit (R := R) (A := H)) LinearMap.id
+          (LinearMap.lTensor H g.toLinearMap z) =
+        TensorProduct.map (counit (R := R) (A := H)) g.toLinearMap z := by
+    intro z
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | tmul x y => simp
+    | add x y hx hy => simp [hx, hy]
+  rw [hswap, hmap, ← LinearMap.comp_apply, _root_.CoassocSimps.map_counit_comp_comul_left]
+  simp
 
-/-- **A point is determined by its action on the regular comodule.** Two `A`-points of
-`H` that act identically on the scalar extension of the regular comodule are equal, so
-the map sending a point to its action is injective.
+/-- **A point is determined by the endomorphism it induces on the regular comodule.** Two
+`A`-points of `H` inducing the same endomorphism of the scalar extension of the regular
+comodule are equal, so the map sending a point to that endomorphism is injective.
 
-Over a Hopf algebra this is the faithfulness of the points action on the category of *all*
-comodules, the first half of a Tannakian reconstruction. It is not by itself faithfulness
-against the fibre functor of the *finite* comodule category: the regular comodule need not
-be finite. Bridging the two needs in addition that, over a free coefficient coalgebra,
-every comodule is the supremum of its finite subcomodules
+Only a coalgebra and an algebra structure on `H` are assumed here, so `endOfPoint` is an
+endomorphism-valued map rather than an action: the action laws need the bialgebra
+compatibility supplied in the `Bialgebra` section below. Over a bialgebra the statement
+therefore reads as faithfulness of the points action on the category of *all* comodules,
+the first half of a Tannakian reconstruction — but not yet faithfulness against the fibre
+functor of the *finite* comodule category, since the regular comodule need not be finite.
+Bridging that needs in addition that, over a free coefficient coalgebra, every comodule is
+the supremum of its finite subcomodules
 (`TauCeti.Subcomodule.sSup_finiteSubcomodules_eq_top`, which assumes `[Module.Free R C]`);
 that is not used here. -/
 theorem endOfPoint_self_injective :


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tannakian/point-determined-by-regular-action"}-->

A point of an affine monoid scheme is determined by how it acts on the regular comodule.

```lean
theorem rid_lTensor_counit_endOfPoint_one_tmul (g : H →ₐ[R] A) (h : H) :
    TensorProduct.rid R A
        (LinearMap.lTensor A (counit (R := R) (A := H)) (endOfPoint H g (1 ⊗ₜ[R] h))) =
      g h

theorem endOfPoint_self_injective :
    Function.Injective fun g : H →ₐ[R] A => endOfPoint H g
```

### What this is

`Comodule.endOfPoint` already makes an `A`-point `g : H →ₐ[R] A` act on the scalar extension
`A ⊗[R] V` of any comodule. Taking `V` to be `H` itself — the regular comodule, whose coaction
is the comultiplication — that action remembers the whole point: `endOfPoint` puts `g` on the
right Sweedler leg and leaves the left leg in the `H`-column, so contracting the `H`-column with
the counit gives `Σ ε(h₍₁₎) • g(h₍₂₎)`, which is `g (Σ ε(h₍₁₎) • h₍₂₎) = g h` by `R`-linearity of
`g` and the left counit law.

Injectivity is the immediate consequence, and it is the point of the exercise: when `H` is a Hopf
algebra it says the points action on the category of *all* comodules is faithful — the **faithful**
half of a Tannakian reconstruction, and the direction that does not need the hard reconstruction
argument.

To be precise about what is **not** claimed: this is not yet faithfulness against the fibre functor
of the *finite* comodule category, because the regular comodule need not be finite. Bridging the two
needs in addition that every comodule is the supremum of its finite subcomodules
(`Subcomodule.sSup_finiteSubcomodules_eq_top`, already on `main`), which this PR does not use. That
is the natural follow-up.

### Roadmap

`ReductiveGroups/README.md`, Layer 1. `STATUS.md` names **Tannakian reconstruction** as a frontier
item — "newly expressible now that the rigid symmetric monoidal category of finite-dimensional
comodules exists. Nothing attempted." This is its first brick. The surrounding infrastructure is
already in place and unchanged by this PR: the category `FGComoduleCat` is rigid and symmetric, the
fibre functor `forget₂ … (SemimoduleCat R)` is faithful, monoidal and braided, and the
representation ⇆ comodule dictionary is monoidal (`ofComodule_tensor`).

### Generality

Stated with `H` only a **coalgebra and an algebra** over `R`, not a bialgebra — the computation uses
the left counit law and `R`-linearity of `g`, nothing else — and for an arbitrary commutative
`R`-algebra `A` rather than a field. Both lemmas therefore live in the file's existing
`section Coalgebra`, above the `section Bialgebra` that the action laws need.

### Placement

Added to the existing `Comodule/PointsAction.lean` (271 → 310 lines), which is where `endOfPoint`
and its functoriality/base-change lemmas already live, rather than a new module: this is another
property of the same map. Mathlib has no comodules at all, so there is nothing upstream to reuse
here.

Roadmap: ReductiveGroups
