### PR TITLE
feat(Topology): orbit spaces of second-countable spaces are second countable

### DIFF
--- a/TauCeti/Topology/Algebra/ConstMulAction.lean
+++ b/TauCeti/Topology/Algebra/ConstMulAction.lean
@@ -13,7 +13,7 @@ public import Mathlib.Topology.Algebra.ConstMulAction
 
 This file records generic transfer instances for actions whose pointwise orbit maps are
 continuous. A submonoid, and hence a subgroup, inherits `ContinuousConstSMul` from an ambient
-scalar action.
+scalar action, and the orbit space of a second-countable space inherits second countability.
 -/
 
 public section
@@ -41,5 +41,21 @@ instance continuousConstSMul {G X : Type*} [Group G] [TopologicalSpace X] [SMul 
   TauCeti.Submonoid.continuousConstSMul S.toSubmonoid
 
 end Subgroup
+
+namespace MulAction
+
+/-- The orbit space of a second-countable space by a continuous action is second countable.
+
+The quotient map `X → Quotient (orbitRel G X)` is open for any action by continuous maps, so a
+countable basis of `X` pushes forward to a countable basis of the quotient. Note that no
+separation or discreteness hypothesis is needed: openness of the quotient map is what carries
+second countability, not properness of the action. -/
+instance secondCountableTopology_orbitRel {G X : Type*} [Group G] [MulAction G X]
+    [TopologicalSpace X] [SecondCountableTopology X] [ContinuousConstSMul G X] :
+    SecondCountableTopology (Quotient (MulAction.orbitRel G X)) :=
+  TopologicalSpace.Quotient.secondCountableTopology
+    MulAction.isOpenQuotientMap_quotientMk.isOpenMap
+
+end MulAction
 
 end TauCeti


### PR DESCRIPTION
The orbit space of a second-countable space by a continuous action is second countable.

```lean
instance secondCountableTopology_orbitRel {G X : Type*} [Group G] [MulAction G X]
    [TopologicalSpace X] [SecondCountableTopology X] [ContinuousConstSMul G X] :
    SecondCountableTopology (Quotient (MulAction.orbitRel G X))
```

The quotient map `X → Quotient (orbitRel G X)` is open for any action by continuous maps
(Mathlib's `MulAction.isOpenQuotientMap_quotientMk`), so a countable basis of `X` pushes forward
(`TopologicalSpace.Quotient.secondCountableTopology`). No separation or discreteness hypothesis
enters: openness of the quotient map is what carries second countability, not properness.

### Roadmap target
`TauCetiRoadmap/ModularForms/README.md:1012`, Layer 10A — "the analytic modular curve". The layer
requires the point-set work on `X(Γ) = Γ\ℍ*` to be "stated as milestones, not assumed", and lists
among them the effective `PSL₂` action, proper discontinuity, Hausdorffness of the quotient, and
**second countability**.

Measured against current Mathlib, three of those four are already discharged and one is not:

| milestone | status |
|---|---|
| effective `PSL₂` action | already in `main` (`UpperHalfPlane/PSLAction.lean`, `FaithfulSMul PSL(2,ℝ) ℍ`) |
| proper discontinuity | Mathlib — `instProperlyDiscontinuousSL2RSubgroup` |
| Hausdorff quotient | free by instance search, via `t2Space_of_properlyDiscontinuousSMul_of_t2Space` |
| **second countability** | **absent — this PR** |

Each of those was checked with a compiled `example … := inferInstance` probe, not a name search;
the first three resolve, the fourth does not.

### Why here, and why general
Stated for `Γ\ℍ` it would be needlessly special: the proof uses only `SecondCountableTopology X`
and `ContinuousConstSMul G X`, and nothing about the upper half-plane, discreteness, or
primality. So it goes in the general file, at Mathlib's own path
`Topology/Algebra/ConstMulAction.lean` — already mirrored in `TauCeti/` and already home to this
file's `ContinuousConstSMul` transfer instances. That keeps the eventual Mathlib migration a pure
deletion.

Original work, not ported: it is two existing Mathlib lemmas composed.

Roadmap: ModularForms
