### PR TITLE
refactor(QuadraticForm): bundle the reflection as an orthogonal-group element

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -54,8 +54,7 @@ theorem exists_mem_range_pinToOrthogonal_mul_apply_eq_self
     ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ (pinToOrthogonal Q).range ∧
       (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) v = v) := by
   have reflection_mem_range (w : V) [Invertible (Q w)] :
-      (⟨QuadraticMap.reflection Q w, QuadraticMap.reflection_mem_orthogonalGroup Q w⟩ :
-        QuadraticMap.orthogonalGroup Q) ∈ (pinToOrthogonal Q).range :=
+      QuadraticMap.reflectionOrthogonal Q w ∈ (pinToOrthogonal Q).range :=
     reflection_mem_range_pinToOrthogonal_of_isSquare Q w
       (IsSepClosed.exists_eq_mul_self _)
   have hmap : Q ((g : V ≃ₗ[K] V) v) = Q v :=
@@ -63,28 +62,16 @@ theorem exists_mem_range_pinToOrthogonal_mul_apply_eq_self
   rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q _ v hmap
       (isUnit_of_invertible (Q v)).ne_zero with hsub | hadd
   · let : Invertible (Q ((g : V ≃ₗ[K] V) v - v)) := hsub.invertible
-    let r : QuadraticMap.orthogonalGroup Q :=
-      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - v),
-        QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
-    refine ⟨r, reflection_mem_range _, ?_⟩
-    -- Expose the underlying automorphisms of the subgroup product before applying the reflection
-    -- computation.
-    change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - v)
-      ((g : V ≃ₗ[K] V) v) = v
+    refine ⟨QuadraticMap.reflectionOrthogonal Q ((g : V ≃ₗ[K] V) v - v),
+      reflection_mem_range _, ?_⟩
+    simp only [Subgroup.coe_mul, QuadraticMap.coe_reflectionOrthogonal, LinearEquiv.mul_apply]
     exact QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ v hmap
   · have : Invertible (Q ((g : V ≃ₗ[K] V) v - -v)) := by
       simpa only [sub_neg_eq_add] using hadd.invertible
-    let r₁ : QuadraticMap.orthogonalGroup Q :=
-      ⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
-    let r₂ : QuadraticMap.orthogonalGroup Q :=
-      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - -v),
-        QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
-    refine ⟨r₁ * r₂,
+    refine ⟨QuadraticMap.reflectionOrthogonal Q v *
+        QuadraticMap.reflectionOrthogonal Q ((g : V ≃ₗ[K] V) v - -v),
       (pinToOrthogonal Q).range.mul_mem (reflection_mem_range v) (reflection_mem_range _), ?_⟩
-    -- Expose the two underlying reflections before applying their public computation equations.
-    change QuadraticMap.reflection Q v
-      (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) v - -v)
-        ((g : V ≃ₗ[K] V) v)) = v
+    simp only [Subgroup.coe_mul, QuadraticMap.coe_reflectionOrthogonal, LinearEquiv.mul_apply]
     rw [QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ (-v)
       (hmap.trans (Q.map_neg v).symm), map_neg, QuadraticMap.reflection_apply_self, neg_neg]
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -148,8 +148,9 @@ variable [Invertible (2 : K)]
 private theorem pinToOrthogonal_pinReflectionLift (v : V) [Invertible (Q v)]
     (hv : IsSquare (-⅟(Q v))) :
     pinToOrthogonal Q (pinReflectionLift Q v hv) =
-      ⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ := by
+      QuadraticMap.reflectionOrthogonal Q v := by
   apply Subtype.ext
+  rw [QuadraticMap.coe_reflectionOrthogonal]
   apply LinearEquiv.ext
   intro m
   rw [pinReflectionLift, pinToOrthogonal_ι_apply (reflectionScale_norm Q v hv),
@@ -163,15 +164,15 @@ private theorem pinToOrthogonal_pinReflectionLift (v : V) [Invertible (Q v)]
 action. -/
 theorem reflection_mem_range_pinToOrthogonal_of_isSquare (v : V) [Invertible (Q v)]
     (hv : IsSquare (-⅟(Q v))) :
-    (⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ :
-      QuadraticMap.orthogonalGroup Q) ∈ (pinToOrthogonal Q).range := by
+    QuadraticMap.reflectionOrthogonal Q v ∈ (pinToOrthogonal Q).range := by
   rw [MonoidHom.mem_range]
   exact ⟨pinReflectionLift Q v hv, pinToOrthogonal_pinReflectionLift Q v hv⟩
 
 private theorem lipschitzToOrthogonal_unitι_eq (v : V) [Invertible (Q v)] :
     lipschitzToOrthogonal Q ⟨unitι Q v, unitι_mem_lipschitzGroup v⟩ =
-      ⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ := by
+      QuadraticMap.reflectionOrthogonal Q v := by
   apply Subtype.ext
+  rw [QuadraticMap.coe_reflectionOrthogonal]
   apply LinearEquiv.ext
   intro m
   rw [coe_lipschitzToOrthogonal_apply, lipschitzVectorAction_unitι]
@@ -181,9 +182,7 @@ reflections in `v` and `w` lifts through the Spin action. -/
 theorem reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare
     (v w : V) [Invertible (Q v)] [Invertible (Q w)]
     (h : IsSquare (⅟(Q v) * ⅟(Q w))) :
-    (⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ :
-        QuadraticMap.orthogonalGroup Q) *
-      ⟨QuadraticMap.reflection Q w, QuadraticMap.reflection_mem_orthogonalGroup Q w⟩ ∈
+    QuadraticMap.reflectionOrthogonal Q v * QuadraticMap.reflectionOrthogonal Q w ∈
         (spinToOrthogonal Q).range := by
   have : Invertible (reflectionPairScale Q v w h) :=
     (reflectionPairScale_isUnit Q v w h).invertible
@@ -201,9 +200,7 @@ theorem reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare
   have hlipschitz : lipschitzToOrthogonal Q
       ⟨unitι Q (reflectionPairScale Q v w h • v) * unitι Q w,
         mul_mem (unitι_mem_lipschitzGroup _) (unitι_mem_lipschitzGroup _)⟩ =
-      (⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ :
-        QuadraticMap.orthogonalGroup Q) *
-      ⟨QuadraticMap.reflection Q w, QuadraticMap.reflection_mem_orthogonalGroup Q w⟩ := by
+      QuadraticMap.reflectionOrthogonal Q v * QuadraticMap.reflectionOrthogonal Q w := by
     have hmul :
         (⟨unitι Q (reflectionPairScale Q v w h • v) * unitι Q w,
           mul_mem (unitι_mem_lipschitzGroup _) (unitι_mem_lipschitzGroup _)⟩ : lipschitzGroup Q) =
@@ -215,6 +212,7 @@ theorem reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare
     rw [hmul,
       map_mul, lipschitzToOrthogonal_unitι_eq, lipschitzToOrthogonal_unitι_eq]
     apply Subtype.ext
+    simp only [Subgroup.coe_mul, QuadraticMap.coe_reflectionOrthogonal]
     exact congrArg (fun x : V ≃ₗ[K] V => x * QuadraticMap.reflection Q w)
       (reflection_smul_eq Q (reflectionPairScale Q v w h) v)
   apply Subtype.ext
@@ -234,8 +232,7 @@ variable {K : Type u} {V : Type v} [Field K] [IsAlgClosed K] [AddCommGroup V] [M
 /-- Over an algebraically closed field, every reflection in a vector of invertible norm lifts to
 the Pin group. -/
 theorem reflection_mem_range_pinToOrthogonal (v : V) [Invertible (Q v)] :
-    (⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ :
-      QuadraticMap.orthogonalGroup Q) ∈ (pinToOrthogonal Q).range := by
+    QuadraticMap.reflectionOrthogonal Q v ∈ (pinToOrthogonal Q).range := by
   exact reflection_mem_range_pinToOrthogonal_of_isSquare Q v
     (IsAlgClosed.exists_eq_mul_self (-⅟(Q v)))
 
@@ -243,9 +240,7 @@ theorem reflection_mem_range_pinToOrthogonal (v : V) [Invertible (Q v)] :
 norm lifts to the Spin group. -/
 theorem reflection_mul_reflection_mem_range_spinToOrthogonal
     (v w : V) [Invertible (Q v)] [Invertible (Q w)] :
-    (⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ :
-        QuadraticMap.orthogonalGroup Q) *
-      ⟨QuadraticMap.reflection Q w, QuadraticMap.reflection_mem_orthogonalGroup Q w⟩ ∈
+    QuadraticMap.reflectionOrthogonal Q v * QuadraticMap.reflectionOrthogonal Q w ∈
         (spinToOrthogonal Q).range := by
   exact reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare Q v w
     (IsAlgClosed.exists_eq_mul_self (⅟(Q v) * ⅟(Q w)))

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -370,6 +370,7 @@ theorem coe_reflectionOrthogonal :
 
 /-- The bundled reflection is an involution, so it has order dividing two in the orthogonal
 group. -/
+@[simp]
 theorem reflectionOrthogonal_mul_self :
     reflectionOrthogonal Q v * reflectionOrthogonal Q v = 1 :=
   Subtype.ext <| by

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -42,7 +42,8 @@ transvection rather than a reflection in `v ^ ⊥`.
   with `Q v` invertible, built from Mathlib's `Module.reflection`.
 * `TauCeti.QuadraticMap.reflectionOrthogonal Q v`: the same reflection bundled as an element of
   `orthogonalGroup Q`, so that statements about products of reflections and about the ranges of the
-  Pin and Spin actions can name it.
+  Pin and Spin actions can name it. `TauCeti.QuadraticMap.reflectionOrthogonal_mul_self` and
+  `TauCeti.QuadraticMap.reflectionOrthogonal_inv` are its group-level involution facts.
 
 ## Main results
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -40,6 +40,9 @@ transvection rather than a reflection in `v ^ ⊥`.
 * `TauCeti.QuadraticMap.specialOrthogonalGroup Q`: its determinant-one subgroup.
 * `TauCeti.QuadraticMap.reflection Q v`: the reflection in the hyperplane orthogonal to a vector `v`
   with `Q v` invertible, built from Mathlib's `Module.reflection`.
+* `TauCeti.QuadraticMap.reflectionOrthogonal Q v`: the same reflection bundled as an element of
+  `orthogonalGroup Q`, so that statements about products of reflections and about the ranges of the
+  Pin and Spin actions can name it.
 
 ## Main results
 
@@ -349,6 +352,20 @@ theorem reflection_mem_orthogonalGroup : reflection Q v ∈ orthogonalGroup Q :=
       polar_neg_right, polar_smul_right, QuadraticMap.polar_comm ⇑Q y v, smul_eq_mul, smul_eq_mul]
     ring
   rw [hexp, hcv, add_sub_cancel_right]
+
+/-- The reflection in a vector of invertible norm, as an element of the orthogonal group.
+
+`reflection_mem_orthogonalGroup` gives the membership; this bundles it, so that statements about
+reflections inside `orthogonalGroup Q` — products of reflections, membership in the range of the
+Pin and Spin actions, generation results — can name the group element instead of repeating the
+anonymous constructor. -/
+noncomputable def reflectionOrthogonal : orthogonalGroup Q :=
+  ⟨reflection Q v, reflection_mem_orthogonalGroup Q v⟩
+
+@[simp]
+theorem coe_reflectionOrthogonal :
+    (reflectionOrthogonal Q v : M ≃ₗ[R] M) = reflection Q v := by
+  simp only [reflectionOrthogonal]
 
 end Reflection
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -367,6 +367,19 @@ theorem coe_reflectionOrthogonal :
     (reflectionOrthogonal Q v : M ≃ₗ[R] M) = reflection Q v := by
   simp only [reflectionOrthogonal]
 
+/-- The bundled reflection is an involution, so it has order dividing two in the orthogonal
+group. -/
+theorem reflectionOrthogonal_mul_self :
+    reflectionOrthogonal Q v * reflectionOrthogonal Q v = 1 :=
+  Subtype.ext <| by
+    simp only [Subgroup.coe_mul, coe_reflectionOrthogonal, Subgroup.coe_one, reflection_mul_self]
+
+/-- The bundled reflection is its own inverse in the orthogonal group. -/
+@[simp]
+theorem reflectionOrthogonal_inv :
+    (reflectionOrthogonal Q v)⁻¹ = reflectionOrthogonal Q v :=
+  inv_eq_of_mul_eq_one_left (reflectionOrthogonal_mul_self Q v)
+
 end Reflection
 
 section CartanDieudonneStep


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR adds `QuadraticMap.reflectionOrthogonal Q v`, the reflection in `v` bundled as an element of `orthogonalGroup Q`, together with its `coe_reflectionOrthogonal` simp lemma, and uses it in place of the anonymous constructor. The expression `⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩` currently appears sixteen times, twelve in `ReflectionLift.lean` and four in `CartanDieudonne.lean`, and almost always inside a *statement*, where it is the single biggest obstacle to reading what these theorems say. Compare

```
(⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ :
    QuadraticMap.orthogonalGroup Q) *
  ⟨QuadraticMap.reflection Q w, QuadraticMap.reflection_mem_orthogonalGroup Q w⟩ ∈
    (spinToOrthogonal Q).range
```

with

```
QuadraticMap.reflectionOrthogonal Q v * QuadraticMap.reflectionOrthogonal Q w ∈
  (spinToOrthogonal Q).range
```

Two proof changes fall out. `CartanDieudonne.lean` had two `change` blocks whose job was to unfold the subgroup coercion by definitional equality; those no longer typecheck, because `reflectionOrthogonal` is not `@[expose]`d and the module system will not unfold it in an exported proof. They are replaced by `simp only [Subgroup.coe_mul, QuadraticMap.coe_reflectionOrthogonal, LinearEquiv.mul_apply]`, which states the same step through named lemmas. Two `let` bindings that existed only to abbreviate the anonymous constructor are inlined, since the bundled name is already short.

On coordination: #2470 and #2492 add eighteen more copies of this expression to the same two files, so I raised this on both before opening. In the event the collision does not materialise — this branch test-merges clean against `pull/2470/head`, `pull/2492/head` and my own #2503, all of which touch these files — so no rebase should be needed on any of them.

The full build with `--iofail`, axiom audit, module-system check and environment lint pass; `lint-env` reports no new violations.

🤖 Prepared with Claude Code