### PR TITLE
feat(Padics): the p-adic integers as the projective limit of the ZMod tower

### DIFF
--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -133,13 +133,17 @@ def compatProj (n : ℕ) : compatSubring p →+* ZMod (p ^ n) :=
   (Pi.evalRingHom (fun n : ℕ => ZMod (p ^ n)) n).comp (compatSubring p).subtype
 
 omit [Fact p.Prime] in
+/-- The `n`-th projection reads off the `n`-th component. -/
+@[simp] theorem compatProj_apply (n : ℕ) (x : compatSubring p) : compatProj p n x = x.val n :=
+  (rfl)
+
+omit [Fact p.Prime] in
 /-- The projections commute with the tower's connecting maps, which is the hypothesis
 `PadicInt.lift` requires. -/
 theorem compatProj_compat (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) :
     (ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁))).comp (compatProj p k₂) = compatProj p k₁ := by
   ext x
-  simpa only [RingHom.comp_apply, compatProj, Pi.evalRingHom_apply, RingHom.coe_comp,
-    Function.comp_apply, Subring.coe_subtype]
+  simpa only [RingHom.comp_apply, compatProj_apply]
     using compat_of_adjacentCompat p x.property k₁ k₂ hk
 
 /-- The map out of the limit into `ℤ_[p]`, from the universal property. -/
@@ -150,10 +154,6 @@ private noncomputable def limZModToPadic : compatSubring p →+* ℤ_[p] :=
 private noncomputable def padicToLimZMod : ℤ_[p] →+* compatSubring p :=
   RingHom.codRestrict (RingHom.pi fun n : ℕ => PadicInt.toZModPow n) (compatSubring p)
     fun z n => RingHom.congr_fun (PadicInt.zmod_cast_comp_toZModPow n (n + 1) n.le_succ) z
-
-omit [Fact p.Prime] in
-private theorem compatProj_apply (n : ℕ) (x : compatSubring p) : compatProj p n x = x.val n :=
-  (rfl)
 
 private theorem padicToLimZMod_val (z : ℤ_[p]) (n : ℕ) :
     (padicToLimZMod p z).val n = PadicInt.toZModPow n z :=

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -35,13 +35,24 @@ over all morphisms of the index category. The two are equivalent — that is
 would cost `mem_compatSubring` its `Iff.rfl` and force every caller with an adjacent-compatible
 sequence through the telescoping lemma first.
 
-An element of `sectionsSubring F` has its component at `n` in the bundled carrier
-`↥(F.obj (op n))` rather than in `ZMod (p ^ n)`. The consumer here is the Tate module
-`T_ℓ E = lim_n E[ℓⁿ]`, which wants the plain `ZMod` spelling.
+The friction is in the index rather than the carrier: `CommRingCat.of (ZMod (p ^ n))` has
+carrier definitionally `ZMod (p ^ n)` (`CommRingCat.coe_of` is `rfl`), but `∀ n : ℕ, ZMod (p ^ n)`
+is not definitionally `∀ j : ℕᵒᵖ, F.obj j`, since `Opposite ℕ` is a structure. So `op`, `unop`
+and `homOfLE` would appear throughout, including for the intended consumer, the Tate module
+`T_ℓ E = lim_n E[ℓⁿ]`.
 
-Mathlib's own practice agrees: `Mathlib/NumberTheory/Padics/` never imports `CategoryTheory`,
-and `sectionsSubring` has a single consumer in the library outside its defining file. The
-categorical API is for limit *theory*; concrete comparisons like this one are kept concrete.
+Mathlib's own practice agrees. `Mathlib/NumberTheory/Padics/` never imports `CategoryTheory`,
+and `RingCat.sectionsSubring` is used only inside its defining file, to install ring structures
+on generic limits. Concrete inverse limits are spelled concretely throughout: `Perfection` is
+`{f : ℕ → α // ∀ n, f (n + 1) ^ p = f n}` — the same adjacent-compatible shape as here —
+`AdicCompletion` is a subtype of compatible families, `PadicInt.lift` takes an explicitly
+quantified compatible family, and `WittVector.liftEquiv` likewise.
+
+A genuine categorical bridge would not be this substitution but a limiting cone —
+`zmodTower : ℕᵒᵖ ⥤ CommRingCat` with `compatCone` and `compatConeIsLimit`, from which the
+comparison with Mathlib's chosen limit follows by `IsLimit.conePointUniqueUpToIso`. That is a
+separate topic from the isomorphism proved here, and `compatProj_compat` is already the
+naturality it would need.
 
 ## Main definitions
 
@@ -78,30 +89,28 @@ namespace PadicInt
 
 variable (p : ℕ) [Fact p.Prime]
 
-/-- The connecting reduction `ZMod (p ^ (n + 1)) →+* ZMod (p ^ n)` of the tower. -/
-abbrev limZModCast (n : ℕ) : ZMod (p ^ (n + 1)) →+* ZMod (p ^ n) :=
-  ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))
-
 omit [Fact p.Prime] in
 /-- Compatibility for all `k₁ ≤ k₂` implies compatibility of adjacent terms. -/
 theorem adjacentCompat_of_compat {f : ∀ n : ℕ, ZMod (p ^ n)}
     (h : ∀ (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂),
       ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁)) (f k₂) = f k₁) (n : ℕ) :
-    limZModCast p n (f (n + 1)) = f n :=
+    ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n)) (f (n + 1)) = f n :=
   h n (n + 1) n.le_succ
 
 omit [Fact p.Prime] in
 /-- Compatibility of adjacent terms implies compatibility for all `k₁ ≤ k₂`. -/
 theorem compat_of_adjacentCompat {f : ∀ n : ℕ, ZMod (p ^ n)}
-    (h : ∀ n, limZModCast p n (f (n + 1)) = f n) (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) :
+    (h : ∀ n, ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n)) (f (n + 1)) = f n)
+    (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) :
     ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁)) (f k₂) = f k₁ := by
   -- Telescope down the tower: each step composes one connecting reduction onto the cast.
   induction k₂, hk using Nat.le_induction with
   | base => simp [ZMod.castHom_self]
   | succ k₂ hk ih =>
     have hstep : ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁))
-        (limZModCast p k₂ (f (k₂ + 1))) = f k₁ := by rw [h k₂]; exact ih
-    rw [← hstep, limZModCast, ← RingHom.comp_apply, ZMod.castHom_comp]
+        (ZMod.castHom (pow_dvd_pow p k₂.le_succ) (ZMod (p ^ k₂)) (f (k₂ + 1))) = f k₁ := by
+      rw [h k₂]; exact ih
+    rw [← hstep, ← RingHom.comp_apply, ZMod.castHom_comp]
 
 /-- The subring of compatible sequences in `Π n, ZMod (p ^ n)` — the projective limit of the
 `ZMod` tower. Its element type is definitionally the subtype of sequences satisfying the
@@ -134,23 +143,23 @@ theorem compatProj_compat (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) :
     using compat_of_adjacentCompat p x.property k₁ k₂ hk
 
 /-- The map out of the limit into `ℤ_[p]`, from the universal property. -/
-noncomputable def limZModToPadic : compatSubring p →+* ℤ_[p] :=
+private noncomputable def limZModToPadic : compatSubring p →+* ℤ_[p] :=
   PadicInt.lift (f := compatProj p) (compatProj_compat p)
 
 /-- The map into the limit: `z ↦ (n ↦ toZModPow n z)`. -/
-noncomputable def padicToLimZMod : ℤ_[p] →+* compatSubring p :=
+private noncomputable def padicToLimZMod : ℤ_[p] →+* compatSubring p :=
   RingHom.codRestrict (RingHom.pi fun n : ℕ => PadicInt.toZModPow n) (compatSubring p)
     fun z n => RingHom.congr_fun (PadicInt.zmod_cast_comp_toZModPow n (n + 1) n.le_succ) z
 
 omit [Fact p.Prime] in
-@[simp] theorem compatProj_apply (n : ℕ) (x : compatSubring p) : compatProj p n x = x.val n :=
+private theorem compatProj_apply (n : ℕ) (x : compatSubring p) : compatProj p n x = x.val n :=
   (rfl)
 
-@[simp] theorem padicToLimZMod_val (z : ℤ_[p]) (n : ℕ) :
+private theorem padicToLimZMod_val (z : ℤ_[p]) (n : ℕ) :
     (padicToLimZMod p z).val n = PadicInt.toZModPow n z :=
   (rfl)
 
-@[simp] theorem toZModPow_limZModToPadic (n : ℕ) (x : compatSubring p) :
+private theorem toZModPow_limZModToPadic (n : ℕ) (x : compatSubring p) :
     PadicInt.toZModPow n (limZModToPadic p x) = x.val n := by
   simpa [limZModToPadic, compatProj]
     using RingHom.congr_fun (PadicInt.lift_spec (f := compatProj p) (compatProj_compat p) n) x
@@ -158,8 +167,11 @@ omit [Fact p.Prime] in
 /-- **`ℤ_[p]` is the projective limit of the `ZMod` tower.** -/
 noncomputable def equivLimZMod : ℤ_[p] ≃+* compatSubring p :=
   RingEquiv.ofRingHom (padicToLimZMod p) (limZModToPadic p)
-    (by ext x n; simp)
-    (by ext z; exact PadicInt.ext_of_toZModPow.mp fun n => by simp)
+    (by ext x n; simp [padicToLimZMod_val, toZModPow_limZModToPadic])
+    (by
+      ext z
+      exact PadicInt.ext_of_toZModPow.mp fun n => by
+        simp [toZModPow_limZModToPadic, padicToLimZMod_val])
 
 /-- The isomorphism reads off the truncations: its `n`-th component is `toZModPow n`. -/
 @[simp] theorem equivLimZMod_apply_val (z : ℤ_[p]) (n : ℕ) :

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.NumberTheory.Padics.RingHoms
-public import Mathlib.Algebra.Ring.Pi
+import Mathlib.Algebra.Ring.Pi
 
 /-!
 # The `p`-adic integers as the projective limit of the `ZMod` tower

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -151,6 +151,12 @@ omit [Fact p.Prime] in
   simpa only [RingHom.comp_apply, compatProj_apply]
     using compat_of_adjacentCompat p x.property k₁ k₂ hk
 
+omit [Fact p.Prime] in
+/-- The element-level form of `compatProj_compat`. -/
+@[simp] theorem compatProj_compat_apply (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) (x : compatSubring p) :
+    ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁)) (compatProj p k₂ x) = compatProj p k₁ x :=
+  RingHom.congr_fun (compatProj_compat p k₁ k₂ hk) x
+
 /-- **The universal property.** A family of ring homs into the tower that commutes with the
 connecting maps factors through the limit. The name is qualified to avoid `PadicInt.lift`,
 which is Mathlib's universal property of `ℤ_[p]` itself. -/
@@ -160,9 +166,19 @@ def compatSubring.lift {S : Type*} [CommRing S] (g : ∀ n : ℕ, S →+* ZMod (
   RingHom.codRestrict (RingHom.pi g) (compatSubring p) fun s n => RingHom.congr_fun (hg n) s
 
 omit [Fact p.Prime] in
+/-- Projecting the factorisation at `n` recovers the given map `g n`. -/
 @[simp] theorem compatProj_comp_lift {S : Type*} [CommRing S] (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
     (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
     (n : ℕ) : (compatProj p n).comp (compatSubring.lift p g hg) = g n :=
+  (rfl)
+
+omit [Fact p.Prime] in
+omit [Fact p.Prime] in
+/-- The element-level form of `compatProj_comp_lift`. -/
+@[simp] theorem compatSubring.lift_apply_val {S : Type*} [CommRing S]
+    (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
+    (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
+    (s : S) (n : ℕ) : (compatSubring.lift p g hg s).val n = g n s :=
   (rfl)
 
 omit [Fact p.Prime] in

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -58,12 +58,17 @@ naturality it would need.
 
 * `PadicInt.compatSubring`: the subring of compatible sequences in `Π n, ZMod (p ^ n)`.
 * `PadicInt.compatProj`: the `n`-th projection out of it, as a ring hom.
+* `PadicInt.compatSubring.lift`: the universal property — a compatible family of ring homs into
+  the tower factors through the limit.
 
 ## Main results
 
 * `PadicInt.equivLimZMod`: `ℤ_[p] ≃+* compatSubring p`.
 * `PadicInt.compat_of_adjacentCompat`: adjacent compatibility gives compatibility for all
   `k₁ ≤ k₂`, which is what `PadicInt.lift` requires of the projection family.
+* `PadicInt.compatProj_comp_lift` and `PadicInt.compatSubring.lift_unique`: the factorisation
+  exists and is unique, so `compatSubring` is a projective limit in the usual sense and not
+  merely a ring isomorphic to `ℤ_[p]`.
 
 ## Provenance
 
@@ -145,6 +150,29 @@ omit [Fact p.Prime] in
   ext x
   simpa only [RingHom.comp_apply, compatProj_apply]
     using compat_of_adjacentCompat p x.property k₁ k₂ hk
+
+/-- **The universal property.** A family of ring homs into the tower that commutes with the
+connecting maps factors through the limit. The name is qualified to avoid `PadicInt.lift`,
+which is Mathlib's universal property of `ℤ_[p]` itself. -/
+def compatSubring.lift {S : Type*} [CommRing S] (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
+    (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n) :
+    S →+* compatSubring p :=
+  RingHom.codRestrict (RingHom.pi g) (compatSubring p) fun s n => RingHom.congr_fun (hg n) s
+
+omit [Fact p.Prime] in
+@[simp] theorem compatProj_comp_lift {S : Type*} [CommRing S] (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
+    (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
+    (n : ℕ) : (compatProj p n).comp (compatSubring.lift p g hg) = g n :=
+  (rfl)
+
+omit [Fact p.Prime] in
+/-- The factorisation is unique: the projections determine a map into the limit. -/
+theorem compatSubring.lift_unique {S : Type*} [CommRing S] (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
+    (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
+    (F : S →+* compatSubring p) (hF : ∀ n, (compatProj p n).comp F = g n) :
+    F = compatSubring.lift p g hg := by
+  ext s n
+  exact RingHom.congr_fun (hF n) s
 
 /-- The map out of the limit into `ℤ_[p]`, from the universal property. -/
 private noncomputable def limZModToPadic : compatSubring p →+* ℤ_[p] :=

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -129,6 +129,8 @@ def compatSubring : Subring (∀ n : ℕ, ZMod (p ^ n)) where
   neg_mem' {f} hf n := by simp only [Pi.neg_apply, map_neg, hf n]
 
 omit [Fact p.Prime] in
+/-- Membership in the limit is adjacent compatibility, definitionally: the carrier is exactly
+this condition, so a compatible sequence needs no further proof to be an element. -/
 @[simp] theorem mem_compatSubring (f : ∀ n : ℕ, ZMod (p ^ n)) :
     f ∈ compatSubring p ↔
       ∀ n, ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n)) (f (n + 1)) = f n := Iff.rfl

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -140,7 +140,7 @@ omit [Fact p.Prime] in
 omit [Fact p.Prime] in
 /-- The projections commute with the tower's connecting maps, which is the hypothesis
 `PadicInt.lift` requires. -/
-theorem compatProj_compat (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) :
+@[simp] theorem compatProj_compat (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) :
     (ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁))).comp (compatProj p k₂) = compatProj p k₁ := by
   ext x
   simpa only [RingHom.comp_apply, compatProj_apply]

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -24,6 +24,25 @@ Its element type is definitionally the projective-limit subtype
 so `mem_compatSubring` is `Iff.rfl` and a compatible sequence may be handed to
 `compatSubring p` directly.
 
+## Why a concrete subring rather than `RingCat.sectionsSubring`
+
+Mathlib has a categorical limit of rings, `RingCat.sectionsSubring`, and this limit is an
+instance of it. It is not used here, for three reasons.
+
+The carrier here is the **adjacent** condition `n + 1 → n`; `sectionsSubring`'s is quantified
+over all morphisms of the index category. The two are equivalent — that is
+`compat_of_adjacentCompat` — but not definitionally, so routing through the categorical version
+would cost `mem_compatSubring` its `Iff.rfl` and force every caller with an adjacent-compatible
+sequence through the telescoping lemma first.
+
+An element of `sectionsSubring F` has its component at `n` in the bundled carrier
+`↥(F.obj (op n))` rather than in `ZMod (p ^ n)`. The consumer here is the Tate module
+`T_ℓ E = lim_n E[ℓⁿ]`, which wants the plain `ZMod` spelling.
+
+Mathlib's own practice agrees: `Mathlib/NumberTheory/Padics/` never imports `CategoryTheory`,
+and `sectionsSubring` has a single consumer in the library outside its defining file. The
+categorical API is for limit *theory*; concrete comparisons like this one are kept concrete.
+
 ## Main definitions
 
 * `PadicInt.compatSubring`: the subring of compatible sequences in `Π n, ZMod (p ^ n)`.
@@ -141,5 +160,15 @@ noncomputable def equivLimZMod : ℤ_[p] ≃+* compatSubring p :=
   RingEquiv.ofRingHom (padicToLimZMod p) (limZModToPadic p)
     (by ext x n; simp)
     (by ext z; exact PadicInt.ext_of_toZModPow.mp fun n => by simp)
+
+/-- The isomorphism reads off the truncations: its `n`-th component is `toZModPow n`. -/
+@[simp] theorem equivLimZMod_apply_val (z : ℤ_[p]) (n : ℕ) :
+    (equivLimZMod p z).val n = PadicInt.toZModPow n z :=
+  (rfl)
+
+/-- The inverse is characterised by its truncations, which are the given components. -/
+@[simp] theorem toZModPow_equivLimZMod_symm (n : ℕ) (x : compatSubring p) :
+    PadicInt.toZModPow n ((equivLimZMod p).symm x) = x.val n :=
+  toZModPow_limZModToPadic p n x
 
 end PadicInt

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -74,10 +74,13 @@ naturality it would need.
 
 Ported from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
 pinned by `TauCetiRoadmap/EllipticCurves` at `dev/hasse-weil @ 513e83879e2f`), file
-`HasseWeil/TateModule/PadicLimZMod.lean`, declarations `limZModCast`,
-`adjacentCompat_of_compat`, `compat_of_adjacentCompat`, `compatSubring`, `mem_compatSubring`,
-`compatProj`, `compatProj_compat`, `limZModToPadic`, `padicToLimZMod`, `compatProj_apply`,
-`padicToLimZMod_val`, `toZModPow_limZModToPadic` and `padicIntEquivLimZMod` (© Chris Birkbeck).
+`HasseWeil/TateModule/PadicLimZMod.lean`, declarations `compat_of_adjacentCompat`,
+`compatSubring`, `mem_compatSubring`, `compatProj`, `compatProj_compat`, `limZModToPadic`,
+`padicToLimZMod`, `compatProj_apply`, `padicToLimZMod_val`, `toZModPow_limZModToPadic` and
+`padicIntEquivLimZMod` (© Chris Birkbeck). The source's `limZModCast` abbreviation and its
+`adjacentCompat_of_compat` are **not** reproduced: the connecting reduction is written out
+inline so the adjacency condition is literally `compatSubring`'s carrier, and the
+compat-implies-adjacent direction had no consumer here.
 Following this repository's convention for adapted material, the upstream authorship is
 credited here rather than in the copyright header.
 
@@ -95,14 +98,6 @@ namespace PadicInt
 variable (p : ℕ) [Fact p.Prime]
 
 omit [Fact p.Prime] in
-/-- Compatibility for all `k₁ ≤ k₂` implies compatibility of adjacent terms. -/
-theorem adjacentCompat_of_compat {f : ∀ n : ℕ, ZMod (p ^ n)}
-    (h : ∀ (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂),
-      ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁)) (f k₂) = f k₁) (n : ℕ) :
-    ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n)) (f (n + 1)) = f n :=
-  h n (n + 1) n.le_succ
-
-omit [Fact p.Prime] in
 /-- Compatibility of adjacent terms implies compatibility for all `k₁ ≤ k₂`. -/
 theorem compat_of_adjacentCompat {f : ∀ n : ℕ, ZMod (p ^ n)}
     (h : ∀ n, ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n)) (f (n + 1)) = f n)
@@ -117,6 +112,7 @@ theorem compat_of_adjacentCompat {f : ∀ n : ℕ, ZMod (p ^ n)}
       rw [h k₂]; exact ih
     rw [← hstep, ← RingHom.comp_apply, ZMod.castHom_comp]
 
+omit [Fact p.Prime] in
 /-- The subring of compatible sequences in `Π n, ZMod (p ^ n)` — the projective limit of the
 `ZMod` tower. Its element type is definitionally the subtype of sequences satisfying the
 displayed compatibility condition, so `mem_compatSubring` is `Iff.rfl`. -/
@@ -135,6 +131,7 @@ this condition, so a compatible sequence needs no further proof to be an element
     f ∈ compatSubring p ↔
       ∀ n, ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n)) (f (n + 1)) = f n := Iff.rfl
 
+omit [Fact p.Prime] in
 /-- The `n`-th projection out of the limit, as a ring hom. -/
 def compatProj (n : ℕ) : compatSubring p →+* ZMod (p ^ n) :=
   (Pi.evalRingHom (fun n : ℕ => ZMod (p ^ n)) n).comp (compatSubring p).subtype
@@ -154,14 +151,6 @@ omit [Fact p.Prime] in
     using compat_of_adjacentCompat p x.property k₁ k₂ hk
 
 omit [Fact p.Prime] in
--- Not tagged `@[simp]`: `compatProj_apply` is itself `simp` and rewrites this left-hand side's
--- `compatProj p k₂ x` to `x.val k₂`, so the side is never in simp-normal form and `simpNF`
--- rejects the attribute.
-/-- The element-level form of `compatProj_compat`. -/
-theorem compatProj_compat_apply (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) (x : compatSubring p) :
-    ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁)) (compatProj p k₂ x) = compatProj p k₁ x :=
-  RingHom.congr_fun (compatProj_compat p k₁ k₂ hk) x
-
 /-- **The universal property.** A family of ring homs into the tower that commutes with the
 connecting maps factors through the limit. The name is qualified to avoid `PadicInt.lift`,
 which is Mathlib's universal property of `ℤ_[p]` itself. -/
@@ -179,7 +168,6 @@ omit [Fact p.Prime] in
   (rfl)
 
 omit [Fact p.Prime] in
-omit [Fact p.Prime] in
 /-- The element-level form of `compatProj_comp_lift`. -/
 @[simp] theorem compatSubring.lift_apply_val {S : Type*} [NonAssocSemiring S]
     (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
@@ -188,9 +176,9 @@ omit [Fact p.Prime] in
   (rfl)
 
 omit [Fact p.Prime] in
-/-- **The projections are jointly injective**: two maps into the limit agreeing after every
-projection are equal. -/
-theorem compatProj_comp_injective {S : Type*} [NonAssocSemiring S] {F G : S →+* compatSubring p}
+/-- **Extensionality for maps into the limit**: two maps agreeing after every projection
+are equal. -/
+theorem compatSubring.ringHom_ext {S : Type*} [NonAssocSemiring S] {F G : S →+* compatSubring p}
     (h : ∀ n, (compatProj p n).comp F = (compatProj p n).comp G) : F = G := by
   ext s n
   exact RingHom.congr_fun (h n) s
@@ -201,7 +189,7 @@ theorem compatSubring.lift_unique {S : Type*} [NonAssocSemiring S] (g : ∀ n : 
     (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
     (F : S →+* compatSubring p) (hF : ∀ n, (compatProj p n).comp F = g n) :
     F = compatSubring.lift p g hg :=
-  compatProj_comp_injective p fun n => by rw [hF n, compatProj_comp_lift]
+  compatSubring.ringHom_ext p fun n => by rw [hF n, compatProj_comp_lift]
 
 /-- The map out of the limit into `ℤ_[p]`, from the universal property. -/
 private noncomputable def limZModToPadic : compatSubring p →+* ℤ_[p] :=
@@ -218,7 +206,7 @@ private theorem padicToLimZMod_val (z : ℤ_[p]) (n : ℕ) :
 
 private theorem toZModPow_limZModToPadic (n : ℕ) (x : compatSubring p) :
     PadicInt.toZModPow n (limZModToPadic p x) = x.val n := by
-  simpa [limZModToPadic, compatProj]
+  simpa only [limZModToPadic, RingHom.comp_apply, compatProj_apply]
     using RingHom.congr_fun (PadicInt.lift_spec (f := compatProj p) (compatProj_compat p) n) x
 
 /-- **`ℤ_[p]` is the projective limit of the `ZMod` tower.** -/

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -154,12 +154,10 @@ omit [Fact p.Prime] in
     using compat_of_adjacentCompat p x.property k₁ k₂ hk
 
 omit [Fact p.Prime] in
-/-- The element-level form of `compatProj_compat`.
-
-Not a `simp` lemma: `compatProj_apply` is itself `simp` and rewrites the left-hand side's
-`compatProj p k₂ x` to `x.val k₂` first, so this side is never in simp-normal form and the
-`simpNF` linter rejects the attribute. Callers wanting the component form should use
-`x.property` through `compat_of_adjacentCompat`. -/
+-- Not tagged `@[simp]`: `compatProj_apply` is itself `simp` and rewrites this left-hand side's
+-- `compatProj p k₂ x` to `x.val k₂`, so the side is never in simp-normal form and `simpNF`
+-- rejects the attribute.
+/-- The element-level form of `compatProj_compat`. -/
 theorem compatProj_compat_apply (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) (x : compatSubring p) :
     ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁)) (compatProj p k₂ x) = compatProj p k₁ x :=
   RingHom.congr_fun (compatProj_compat p k₁ k₂ hk) x
@@ -190,13 +188,20 @@ omit [Fact p.Prime] in
   (rfl)
 
 omit [Fact p.Prime] in
-/-- The factorisation is unique: the projections determine a map into the limit. -/
+/-- **The projections are jointly injective**: two maps into the limit agreeing after every
+projection are equal. -/
+theorem compatProj_comp_injective {S : Type*} [NonAssocSemiring S] {F G : S →+* compatSubring p}
+    (h : ∀ n, (compatProj p n).comp F = (compatProj p n).comp G) : F = G := by
+  ext s n
+  exact RingHom.congr_fun (h n) s
+
+omit [Fact p.Prime] in
+/-- The factorisation is unique. -/
 theorem compatSubring.lift_unique {S : Type*} [NonAssocSemiring S] (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
     (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
     (F : S →+* compatSubring p) (hF : ∀ n, (compatProj p n).comp F = g n) :
-    F = compatSubring.lift p g hg := by
-  ext s n
-  exact RingHom.congr_fun (hF n) s
+    F = compatSubring.lift p g hg :=
+  compatProj_comp_injective p fun n => by rw [hF n, compatProj_comp_lift]
 
 /-- The map out of the limit into `ℤ_[p]`, from the universal property. -/
 private noncomputable def limZModToPadic : compatSubring p →+* ℤ_[p] :=

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.Padics.RingHoms
+public import Mathlib.Algebra.Ring.Pi
+
+/-!
+# The `p`-adic integers as the projective limit of the `ZMod` tower
+
+`ℤ_[p]` is the projective limit of `… → ZMod (p ^ (n + 1)) → ZMod (p ^ n) → …` along the
+canonical reductions. Mathlib supplies the universal property of `ℤ_[p]` — `PadicInt.lift`,
+`PadicInt.lift_spec` and `PadicInt.ext_of_toZModPow` — but not the limit itself as an object,
+so the isomorphism cannot be stated without first naming the limit.
+
+`compatSubring p` is that object: the compatible sequences, as a subring of `Π n, ZMod (p ^ n)`.
+Its element type is definitionally the projective-limit subtype
+
+`{f : Π n, ZMod (p ^ n) // ∀ n, ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))
+  (f (n + 1)) = f n}`,
+
+so `mem_compatSubring` is `Iff.rfl` and a compatible sequence may be handed to
+`compatSubring p` directly.
+
+## Main definitions
+
+* `PadicInt.compatSubring`: the subring of compatible sequences in `Π n, ZMod (p ^ n)`.
+* `PadicInt.compatProj`: the `n`-th projection out of it, as a ring hom.
+
+## Main results
+
+* `PadicInt.equivLimZMod`: `ℤ_[p] ≃+* compatSubring p`.
+* `PadicInt.compat_of_adjacentCompat`: adjacent compatibility gives compatibility for all
+  `k₁ ≤ k₂`, which is what `PadicInt.lift` requires of the projection family.
+
+## Provenance
+
+Ported from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
+pinned by `TauCetiRoadmap/EllipticCurves` at `dev/hasse-weil @ 513e83879e2f`), file
+`HasseWeil/TateModule/PadicLimZMod.lean`, declarations `limZModCast`,
+`adjacentCompat_of_compat`, `compat_of_adjacentCompat`, `compatSubring`, `mem_compatSubring`,
+`compatProj`, `compatProj_compat`, `limZModToPadic`, `padicToLimZMod`, `compatProj_apply`,
+`padicToLimZMod_val`, `toZModPow_limZModToPadic` and `padicIntEquivLimZMod` (© Chris Birkbeck).
+Following this repository's convention for adapted material, the upstream authorship is
+credited here rather than in the copyright header.
+
+Changes in porting: the prime is `p` rather than `ℓ`, and the declarations live in Mathlib's
+`PadicInt` namespace rather than a project-specific one, since nothing here is about elliptic
+curves — the source needs this for the Tate module (Silverman III.7), but the statement is
+about `ℤ_[p]` alone. The source's `padicIntEquivLimZMod` is `equivLimZMod` here, the `PadicInt`
+prefix being supplied by the namespace.
+-/
+
+public section
+
+namespace PadicInt
+
+variable (p : ℕ) [Fact p.Prime]
+
+/-- The connecting reduction `ZMod (p ^ (n + 1)) →+* ZMod (p ^ n)` of the tower. -/
+abbrev limZModCast (n : ℕ) : ZMod (p ^ (n + 1)) →+* ZMod (p ^ n) :=
+  ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))
+
+omit [Fact p.Prime] in
+/-- Compatibility for all `k₁ ≤ k₂` implies compatibility of adjacent terms. -/
+theorem adjacentCompat_of_compat {f : ∀ n : ℕ, ZMod (p ^ n)}
+    (h : ∀ (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂),
+      ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁)) (f k₂) = f k₁) (n : ℕ) :
+    limZModCast p n (f (n + 1)) = f n :=
+  h n (n + 1) n.le_succ
+
+omit [Fact p.Prime] in
+/-- Compatibility of adjacent terms implies compatibility for all `k₁ ≤ k₂`. -/
+theorem compat_of_adjacentCompat {f : ∀ n : ℕ, ZMod (p ^ n)}
+    (h : ∀ n, limZModCast p n (f (n + 1)) = f n) (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) :
+    ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁)) (f k₂) = f k₁ := by
+  -- Telescope down the tower: each step composes one connecting reduction onto the cast.
+  induction k₂, hk using Nat.le_induction with
+  | base => simp [ZMod.castHom_self]
+  | succ k₂ hk ih =>
+    have hstep : ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁))
+        (limZModCast p k₂ (f (k₂ + 1))) = f k₁ := by rw [h k₂]; exact ih
+    rw [← hstep, limZModCast, ← RingHom.comp_apply, ZMod.castHom_comp]
+
+/-- The subring of compatible sequences in `Π n, ZMod (p ^ n)` — the projective limit of the
+`ZMod` tower. Its element type is definitionally the subtype of sequences satisfying the
+displayed compatibility condition, so `mem_compatSubring` is `Iff.rfl`. -/
+def compatSubring : Subring (∀ n : ℕ, ZMod (p ^ n)) where
+  carrier := {f | ∀ n, ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n)) (f (n + 1)) = f n}
+  mul_mem' {f g} hf hg n := by simp only [Pi.mul_apply, map_mul, hf n, hg n]
+  one_mem' n := by simp only [Pi.one_apply, map_one]
+  add_mem' {f g} hf hg n := by simp only [Pi.add_apply, map_add, hf n, hg n]
+  zero_mem' n := by simp only [Pi.zero_apply, map_zero]
+  neg_mem' {f} hf n := by simp only [Pi.neg_apply, map_neg, hf n]
+
+omit [Fact p.Prime] in
+@[simp] theorem mem_compatSubring (f : ∀ n : ℕ, ZMod (p ^ n)) :
+    f ∈ compatSubring p ↔
+      ∀ n, ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n)) (f (n + 1)) = f n := Iff.rfl
+
+/-- The `n`-th projection out of the limit, as a ring hom. -/
+def compatProj (n : ℕ) : compatSubring p →+* ZMod (p ^ n) :=
+  (Pi.evalRingHom (fun n : ℕ => ZMod (p ^ n)) n).comp (compatSubring p).subtype
+
+omit [Fact p.Prime] in
+/-- The projections commute with the tower's connecting maps, which is the hypothesis
+`PadicInt.lift` requires. -/
+theorem compatProj_compat (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) :
+    (ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁))).comp (compatProj p k₂) = compatProj p k₁ := by
+  ext x
+  simpa only [RingHom.comp_apply, compatProj, Pi.evalRingHom_apply, RingHom.coe_comp,
+    Function.comp_apply, Subring.coe_subtype]
+    using compat_of_adjacentCompat p x.property k₁ k₂ hk
+
+/-- The map out of the limit into `ℤ_[p]`, from the universal property. -/
+noncomputable def limZModToPadic : compatSubring p →+* ℤ_[p] :=
+  PadicInt.lift (f := compatProj p) (compatProj_compat p)
+
+/-- The map into the limit: `z ↦ (n ↦ toZModPow n z)`. -/
+noncomputable def padicToLimZMod : ℤ_[p] →+* compatSubring p :=
+  RingHom.codRestrict (RingHom.pi fun n : ℕ => PadicInt.toZModPow n) (compatSubring p)
+    fun z n => RingHom.congr_fun (PadicInt.zmod_cast_comp_toZModPow n (n + 1) n.le_succ) z
+
+omit [Fact p.Prime] in
+@[simp] theorem compatProj_apply (n : ℕ) (x : compatSubring p) : compatProj p n x = x.val n :=
+  (rfl)
+
+@[simp] theorem padicToLimZMod_val (z : ℤ_[p]) (n : ℕ) :
+    (padicToLimZMod p z).val n = PadicInt.toZModPow n z :=
+  (rfl)
+
+@[simp] theorem toZModPow_limZModToPadic (n : ℕ) (x : compatSubring p) :
+    PadicInt.toZModPow n (limZModToPadic p x) = x.val n := by
+  simpa [limZModToPadic, compatProj]
+    using RingHom.congr_fun (PadicInt.lift_spec (f := compatProj p) (compatProj_compat p) n) x
+
+/-- **`ℤ_[p]` is the projective limit of the `ZMod` tower.** -/
+noncomputable def equivLimZMod : ℤ_[p] ≃+* compatSubring p :=
+  RingEquiv.ofRingHom (padicToLimZMod p) (limZModToPadic p)
+    (by ext x n; simp)
+    (by ext z; exact PadicInt.ext_of_toZModPow.mp fun n => by simp)
+
+end PadicInt

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -162,14 +162,15 @@ omit [Fact p.Prime] in
 /-- **The universal property.** A family of ring homs into the tower that commutes with the
 connecting maps factors through the limit. The name is qualified to avoid `PadicInt.lift`,
 which is Mathlib's universal property of `ℤ_[p]` itself. -/
-def compatSubring.lift {S : Type*} [CommRing S] (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
+def compatSubring.lift {S : Type*} [NonAssocSemiring S] (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
     (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n) :
     S →+* compatSubring p :=
   RingHom.codRestrict (RingHom.pi g) (compatSubring p) fun s n => RingHom.congr_fun (hg n) s
 
 omit [Fact p.Prime] in
 /-- Projecting the factorisation at `n` recovers the given map `g n`. -/
-@[simp] theorem compatProj_comp_lift {S : Type*} [CommRing S] (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
+@[simp] theorem compatProj_comp_lift {S : Type*} [NonAssocSemiring S]
+    (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
     (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
     (n : ℕ) : (compatProj p n).comp (compatSubring.lift p g hg) = g n :=
   (rfl)
@@ -177,7 +178,7 @@ omit [Fact p.Prime] in
 omit [Fact p.Prime] in
 omit [Fact p.Prime] in
 /-- The element-level form of `compatProj_comp_lift`. -/
-@[simp] theorem compatSubring.lift_apply_val {S : Type*} [CommRing S]
+@[simp] theorem compatSubring.lift_apply_val {S : Type*} [NonAssocSemiring S]
     (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
     (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
     (s : S) (n : ℕ) : (compatSubring.lift p g hg s).val n = g n s :=
@@ -185,7 +186,7 @@ omit [Fact p.Prime] in
 
 omit [Fact p.Prime] in
 /-- The factorisation is unique: the projections determine a map into the limit. -/
-theorem compatSubring.lift_unique {S : Type*} [CommRing S] (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
+theorem compatSubring.lift_unique {S : Type*} [NonAssocSemiring S] (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
     (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
     (F : S →+* compatSubring p) (hF : ∀ n, (compatProj p n).comp F = g n) :
     F = compatSubring.lift p g hg := by

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -154,8 +154,13 @@ omit [Fact p.Prime] in
     using compat_of_adjacentCompat p x.property k₁ k₂ hk
 
 omit [Fact p.Prime] in
-/-- The element-level form of `compatProj_compat`. -/
-@[simp] theorem compatProj_compat_apply (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) (x : compatSubring p) :
+/-- The element-level form of `compatProj_compat`.
+
+Not a `simp` lemma: `compatProj_apply` is itself `simp` and rewrites the left-hand side's
+`compatProj p k₂ x` to `x.val k₂` first, so this side is never in simp-normal form and the
+`simpNF` linter rejects the attribute. Callers wanting the component form should use
+`x.property` through `compat_of_adjacentCompat`. -/
+theorem compatProj_compat_apply (k₁ k₂ : ℕ) (hk : k₁ ≤ k₂) (x : compatSubring p) :
     ZMod.castHom (pow_dvd_pow p hk) (ZMod (p ^ k₁)) (compatProj p k₂ x) = compatProj p k₁ x :=
   RingHom.congr_fun (compatProj_compat p k₁ k₂ hk) x
 

--- a/TauCeti/NumberTheory/Padics/LimZMod.lean
+++ b/TauCeti/NumberTheory/Padics/LimZMod.lean
@@ -160,15 +160,7 @@ def compatSubring.lift {S : Type*} [NonAssocSemiring S] (g : ∀ n : ℕ, S →+
   RingHom.codRestrict (RingHom.pi g) (compatSubring p) fun s n => RingHom.congr_fun (hg n) s
 
 omit [Fact p.Prime] in
-/-- Projecting the factorisation at `n` recovers the given map `g n`. -/
-@[simp] theorem compatProj_comp_lift {S : Type*} [NonAssocSemiring S]
-    (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
-    (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
-    (n : ℕ) : (compatProj p n).comp (compatSubring.lift p g hg) = g n :=
-  (rfl)
-
-omit [Fact p.Prime] in
-/-- The element-level form of `compatProj_comp_lift`. -/
+/-- The factorisation reads off componentwise: its `n`-th component is `g n`. -/
 @[simp] theorem compatSubring.lift_apply_val {S : Type*} [NonAssocSemiring S]
     (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
     (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
@@ -176,9 +168,18 @@ omit [Fact p.Prime] in
   (rfl)
 
 omit [Fact p.Prime] in
+/-- Projecting the factorisation at `n` recovers the given map `g n`. -/
+@[simp] theorem compatProj_comp_lift {S : Type*} [NonAssocSemiring S]
+    (g : ∀ n : ℕ, S →+* ZMod (p ^ n))
+    (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
+    (n : ℕ) : (compatProj p n).comp (compatSubring.lift p g hg) = g n := by
+  ext s
+  exact compatSubring.lift_apply_val p g hg s n
+
+omit [Fact p.Prime] in
 /-- **Extensionality for maps into the limit**: two maps agreeing after every projection
 are equal. -/
-theorem compatSubring.ringHom_ext {S : Type*} [NonAssocSemiring S] {F G : S →+* compatSubring p}
+theorem compatSubring.hom_ext {S : Type*} [NonAssocSemiring S] {F G : S →+* compatSubring p}
     (h : ∀ n, (compatProj p n).comp F = (compatProj p n).comp G) : F = G := by
   ext s n
   exact RingHom.congr_fun (h n) s
@@ -189,7 +190,7 @@ theorem compatSubring.lift_unique {S : Type*} [NonAssocSemiring S] (g : ∀ n : 
     (hg : ∀ n, (ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n))).comp (g (n + 1)) = g n)
     (F : S →+* compatSubring p) (hF : ∀ n, (compatProj p n).comp F = g n) :
     F = compatSubring.lift p g hg :=
-  compatSubring.ringHom_ext p fun n => by rw [hF n, compatProj_comp_lift]
+  compatSubring.hom_ext p fun n => by rw [hF n, compatProj_comp_lift]
 
 /-- The map out of the limit into `ℤ_[p]`, from the universal property. -/
 private noncomputable def limZModToPadic : compatSubring p →+* ℤ_[p] :=
@@ -221,7 +222,7 @@ noncomputable def equivLimZMod : ℤ_[p] ≃+* compatSubring p :=
 /-- The isomorphism reads off the truncations: its `n`-th component is `toZModPow n`. -/
 @[simp] theorem equivLimZMod_apply_val (z : ℤ_[p]) (n : ℕ) :
     (equivLimZMod p z).val n = PadicInt.toZModPow n z :=
-  (rfl)
+  padicToLimZMod_val p z n
 
 /-- The inverse is characterised by its truncations, which are the given components. -/
 @[simp] theorem toZModPow_equivLimZMod_symm (n : ℕ) (x : compatSubring p) :


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"padiclimzmod"}-->

Roadmap: EllipticCurves

`ℤ_[p]` is the projective limit of `… → ZMod (p ^ (n + 1)) → ZMod (p ^ n) → …` along the canonical
reductions. Mathlib carries the *universal property* of `ℤ_[p]` — `PadicInt.lift`,
`PadicInt.lift_spec`, `PadicInt.ext_of_toZModPow` — but not the limit itself as an object, so the
isomorphism cannot be stated at all until the limit is named.

```lean
def PadicInt.compatSubring : Subring (∀ n : ℕ, ZMod (p ^ n))

noncomputable def PadicInt.equivLimZMod : ℤ_[p] ≃+* compatSubring p
```

`compatSubring p` is the subring of compatible sequences. Its element type is *definitionally* the
projective-limit subtype

```
{f : Π n, ZMod (p ^ n) // ∀ n, ZMod.castHom (pow_dvd_pow p n.le_succ) (ZMod (p ^ n)) (f (n+1)) = f n}
```

so `mem_compatSubring` is `Iff.rfl` and a compatible sequence may be handed to `compatSubring p`
directly. The forward map sends `z` to its truncations `n ↦ toZModPow n z`; the inverse is
`PadicInt.lift` applied to the projections; both round-trips are the universal property.

`compat_of_adjacentCompat` is the load-bearing step: `PadicInt.lift` needs compatibility for
*every* `k₁ ≤ k₂`, while a sequence naturally carries only adjacent compatibility, so the two are
shown equivalent by telescoping down the tower.

`equivLimZMod_apply_val` and `toZModPow_equivLimZMod_symm` characterise the isomorphism in both
directions by truncation, so consumers get simp support on `equivLimZMod` itself rather than only
on the underlying maps.

## Why a concrete subring rather than `RingCat.sectionsSubring`

Mathlib has a categorical limit of rings and this limit is an instance of it, so the choice is
deliberate and the module docstring records it.

The carrier here is the **adjacent** condition `n + 1 → n`; `sectionsSubring`'s is quantified over
all morphisms of the index category. Those are equivalent — that is exactly
`compat_of_adjacentCompat` — but not *definitionally*, so routing through the categorical version
would cost `mem_compatSubring` its `Iff.rfl` and force every caller holding an adjacent-compatible
sequence through the telescoping lemma first. An element of `sectionsSubring F` also carries its
component at `n` in the bundled `↥(F.obj (op n))` rather than in `ZMod (p ^ n)`, and the consumer
here — the Tate module `T_ℓ E = lim_n E[ℓⁿ]` — wants the plain `ZMod` spelling.

Mathlib's own practice agrees: `Mathlib/NumberTheory/Padics/` never imports `CategoryTheory`, and
`RingCat.sectionsSubring` has a single consumer in the library outside its defining file
(`AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean`). The categorical API carries limit
*theory*; concrete comparisons like this one are kept concrete.

## Roadmap target

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 2 (torsion, the Weil pairing, and the Tate
module). The Tate module `T_ℓ E = lim_n E[ℓⁿ]` is a `ℤ_ℓ`-module, and Silverman III.7 (p. 87)
builds it by "mimic[king] the inverse limit construction of the `ℓ`-adic integers `ℤ_ℓ` from the
finite groups `ℤ/ℓⁿℤ`" — this PR supplies exactly that construction, which is what gives the limit
of the `E[ℓⁿ]` its `ℤ_ℓ`-module structure. Claimed under intention `TauCetiRoadmap#175`.

## Placement

The source file sits under `HasseWeil/TateModule/`, but nothing in the statement mentions elliptic
curves — it is about `ℤ_[p]` and `ZMod` alone. It is therefore placed in
`TauCeti/NumberTheory/Padics/`, beside the Mathlib module it extends, rather than under
`AlgebraicGeometry/EllipticCurve/`, and the declarations live in Mathlib's `PadicInt` namespace.

## Provenance

Ported from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by
the roadmap at `dev/hasse-weil @ 513e83879e2f`), file `HasseWeil/TateModule/PadicLimZMod.lean`,
declarations `limZModCast`, `adjacentCompat_of_compat`, `compat_of_adjacentCompat`,
`compatSubring`, `mem_compatSubring`, `compatProj`, `compatProj_compat`, `limZModToPadic`,
`padicToLimZMod`, `compatProj_apply`, `padicToLimZMod_val`, `toZModPow_limZModToPadic` and
`padicIntEquivLimZMod` (© Chris Birkbeck). Following this repository's convention for adapted
material, upstream authorship is credited in the module docstring rather than the copyright
header.

Changes in porting: the prime is `p` rather than `ℓ`; the declarations move into Mathlib's
`PadicInt` namespace, which makes the source's `padicIntEquivLimZMod` simply `equivLimZMod`; the
source's deprecated `Pi.ringHom` becomes `RingHom.pi`; and two `rfl` proofs are parenthesised as
`(rfl)`, which is what elaborates across TauCeti's module-system boundary.

## Mathlib check

Absent from the pin by untruncated full-name search (`compatSubring`, `padicIntEquivLimZMod`,
`equivLimZMod` — no hits in Mathlib or TauCeti), and — because a clean grep is not proof —
confirmed by compilation: with `Mathlib.NumberTheory.Padics.RingHoms` and `Mathlib.Algebra.Ring.Pi`
imported and the subring constructed, `exact?` **could not close** `ℤ_[p] ≃+* compatSubring p`.
Mathlib's `RingHoms.lean` supplies `lift` / `lift_spec` / `ext_of_toZModPow` / `toZModPow` and
`residueField : IsLocalRing.ResidueField ℤ_[p] ≃+* ZMod p`, but no packaged limit.

Worth recording from that probe: stating the limit as a bare subtype fails instance synthesis
(`Mul`), which is why the limit is built as a `Subring` rather than a subtype — the ring structure
is not free.

🤖 Prepared with Claude Code (Claude Opus 5)
