### PR TITLE
feat: close short image crosscuts into small Jordan curves

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Topology.JordanCurve.Basic
+public import TauCeti.Analysis.Complex.Conformal.ShortCrosscut
+import TauCeti.Analysis.Complex.Conformal.Crosscut.Arc
+import TauCeti.Analysis.Complex.Conformal.Crosscut.BoundaryEnds
+import TauCeti.Analysis.Complex.Conformal.Crosscut.Jordan
+import TauCeti.Topology.JordanCurve.SmallArc
+
+/-!
+# Small Jordan curves through image crosscuts
+
+Let `f` be a conformal map of a disc onto a bounded domain whose frontier is a Jordan curve. The
+length--area method supplies, at every point `ζ` of the source circle, arbitrarily small circular
+crosscuts with short images. This file closes such an image crosscut along the frontier of the image
+domain and proves that the resulting Jordan curve is arbitrarily small.
+
+There are two cases. If the two boundary ends of the closed image crosscut coincide, the crosscut
+itself is a Jordan curve by
+`TauCeti.isJordanCurve_closure_image_ball_inter_sphere_of_subsingleton`. Otherwise the crosscut is
+an arc between two nearby points of the image frontier. The quantitative Jordan-curve theorem
+`TauCeti.IsJordanCurve.exists_pos_forall_exists_path_injective_diam_le` joins those points by a
+small injective path along the frontier, and
+the distinct-end closing theorem from `Conformal/Crosscut/Arc.lean` closes the two arcs into a
+Jordan curve. In both cases the curve lies in the closure of the image domain and contains the
+closed image crosscut.
+
+## Main result
+
+* `TauCeti.exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le` -- below every
+  prescribed radius, a short image crosscut lies on an arbitrarily small Jordan curve contained in
+  the closure of the image domain.
+* `TauCeti.exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le_of_isBounded` --
+  the bounded-image form used for a Riemann map.
+
+## Roadmap role
+
+This is the last construction before the planar-separation step in layer **L5** of the
+`ConformalMapping` roadmap, the Jordan-domain case of the Caratheodory boundary correspondence.
+The remaining step is to show that the boundary piece of the crosscut neighbourhood lies on the
+small Jordan curve chosen here. The existing crosscut criterion then bounds the cut-off image
+piece and gives the continuous extension of the conformal map.
+
+Layer L5 is absent from Mathlib's in-progress Riemann-mapping development, and the pinned Mathlib
+has no Jordan-curve vocabulary. The proof follows the crosscut argument in Caratheodory's 1913
+paper and the presentations in Pommerenke, Section 2.2--2.3, and Duren, Chapter 3.
+
+## References
+
+* C. Caratheodory, *Ueber die gegenseitige Beziehung der Raender bei der konformen Abbildung*,
+  Math. Ann. **73** (1913).
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Sections 2.2--2.3.
+* P. L. Duren, *Univalent Functions*, Chapter 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open Bornology Complex MeasureTheory Metric Set
+
+variable {f : ℂ → ℂ} {c ζ : ℂ} {r : ℝ}
+
+/-- **A short image crosscut lies on a small Jordan curve.** Let `f` be holomorphic and injective
+on `ball c r`, with finite Dirichlet integral and Jordan-curve frontier. For every `ε > 0`, every
+boundary point `ζ` of the disc, and every radius bound `R > 0`, there is a genuine circular
+crosscut of radius `ρ < R` whose closed image is contained in a Jordan curve `J` satisfying
+
+* `J ⊆ closure (f '' ball c r)`, and
+* `Metric.diam J ≤ ε`.
+
+The closed image crosscut may itself be the Jordan curve: this is the case in which its two ends
+on `frontier (f '' ball c r)` coincide. When the ends are distinct, `J` is the union of the closed
+image crosscut and a small injective path along that frontier.
+
+No assertion is made about which component of the complement of `J` contains the crosscut
+neighbourhood. Identifying that component is the planar-separation input still needed by the
+Caratheodory boundary correspondence. -/
+theorem exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le
+    (hζ : dist ζ c = r) (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) (hdir : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤)
+    (hfrontier : IsJordanCurve (frontier (f '' ball c r))) {ε R : ℝ}
+    (hε : 0 < ε) (hR : 0 < R) :
+    ∃ ρ ∈ Ioo 0 R, ρ < 2 * r ∧ ∃ J : Set ℂ,
+      IsJordanCurve J ∧
+        closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ J ∧
+        J ⊆ closure (f '' ball c r) ∧ diam J ≤ ε := by
+  have hhalf : 0 < ε / 2 := by positivity
+  obtain ⟨δ, hδ, hpath⟩ :=
+    hfrontier.exists_pos_forall_exists_path_injective_diam_le hhalf
+  let κ := min (ε / 2) (δ / 2)
+  have hκ : 0 < κ := lt_min hhalf (by positivity)
+  obtain ⟨ρ, hρ, hlen⟩ :=
+    exists_circleImageLength_lt_of_lintegral_ne_top f measurableSet_ball ζ hdir
+      (ENNReal.ofReal_pos.mpr hκ).ne' (R := min R (2 * r)) (lt_min hR (by linarith))
+  have hρR : ρ < R := hρ.2.trans_le (min_le_left _ _)
+  have hρr : ρ < 2 * r := hρ.2.trans_le (min_le_right _ _)
+  have hlenFin : circleImageLength f (ball c r) ζ ρ ≠ ⊤ :=
+    (hlen.trans ENNReal.ofReal_lt_top).ne
+  have hcross : diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ κ :=
+    diam_image_ball_inter_sphere_le hf hκ.le hlen.le
+  have hcrossBounded : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) :=
+    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hf hlenFin
+  have hcrossSub : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ closure (f '' ball c r) :=
+    closure_mono (image_mono inter_subset_left)
+  by_cases hends :
+      (frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))).Subsingleton
+  · refine ⟨ρ, ⟨hρ.1, hρR⟩, hρr, closure (f '' (ball c r ∩ sphere ζ ρ)), ?_,
+      subset_rfl, hcrossSub, ?_⟩
+    · exact isJordanCurve_closure_image_ball_inter_sphere_of_subsingleton hζ hρ.1 hρr
+        hf hinj hlenFin hends
+    · rw [diam_closure]
+      exact hcross.trans (by dsimp [κ]; linarith [min_le_left (ε / 2) (δ / 2)])
+  · obtain ⟨u, v, huv, hpair, hclose⟩ :=
+      exists_forall_isJordanCurve_closure_image_ball_inter_sphere_union_range_of_not_subsingleton
+        hζ hρ.1 hρr hf hinj hlenFin hends
+    have hu : u ∈ frontier (f '' ball c r) ∩
+        closure (f '' (ball c r ∩ sphere ζ ρ)) := by
+      rw [hpair]
+      exact mem_insert u {v}
+    have hv : v ∈ frontier (f '' ball c r) ∩
+        closure (f '' (ball c r ∩ sphere ζ ρ)) := by
+      rw [hpair]
+      exact mem_insert_of_mem u (mem_singleton v)
+    have hκδ : κ < δ := by
+      dsimp [κ]
+      linarith [min_le_right (ε / 2) (δ / 2)]
+    have huvδ : dist u v < δ := by
+      refine (dist_le_diam_of_mem hcrossBounded.closure hu.2 hv.2).trans_lt ?_
+      rw [diam_closure]
+      exact hcross.trans_lt hκδ
+    obtain ⟨γ, hγinj, hγsub, hγdiam⟩ := hpath hu.1 hv.1 huv huvδ
+    refine ⟨ρ, ⟨hρ.1, hρR⟩, hρr,
+      closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ range γ,
+      hclose γ hγinj hγsub, subset_union_left, ?_, ?_⟩
+    · exact union_subset hcrossSub (hγsub.trans frontier_subset_closure)
+    · have hinter :
+          (closure (f '' (ball c r ∩ sphere ζ ρ)) ∩ range γ).Nonempty :=
+        ⟨u, hu.2, ⟨0, γ.source⟩⟩
+      calc
+        diam (closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ range γ)
+            ≤ diam (closure (f '' (ball c r ∩ sphere ζ ρ))) + diam (range γ) :=
+          diam_union' hinter
+        _ = diam (f '' (ball c r ∩ sphere ζ ρ)) + diam (range γ) := by
+          rw [diam_closure]
+        _ ≤ κ + ε / 2 := add_le_add hcross hγdiam
+        _ ≤ ε := by dsimp [κ]; linarith [min_le_left (ε / 2) (δ / 2)]
+
+/-- **The bounded-image form of the small-Jordan-curve theorem.** A holomorphic injection of a
+disc onto a bounded domain has finite Dirichlet integral by the conformal area formula, so every
+closed image crosscut produced by the length--area method lies on an arbitrarily small Jordan
+curve in the closure of the image domain.
+
+This is the form used for the Riemann map of a bounded Jordan domain. -/
+theorem exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le_of_isBounded
+    (hζ : dist ζ c = r) (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) (hb : IsBounded (f '' ball c r))
+    (hfrontier : IsJordanCurve (frontier (f '' ball c r))) {ε R : ℝ}
+    (hε : 0 < ε) (hR : 0 < R) :
+    ∃ ρ ∈ Ioo 0 R, ρ < 2 * r ∧ ∃ J : Set ℂ,
+      IsJordanCurve J ∧
+        closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ J ∧
+        J ⊆ closure (f '' ball c r) ∧ diam J ≤ ε :=
+  exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le hζ hr hf hinj
+    (lintegral_enorm_deriv_sq_ne_top_of_isBounded isOpen_ball hf
+      measurableSet_ball.nullMeasurableSet subset_rfl hinj hb)
+    hfrontier hε hR
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.Topology.JordanCurve.Basic
 public import TauCeti.Analysis.Complex.Conformal.ShortCrosscut
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Arc
-import TauCeti.Analysis.Complex.Conformal.Crosscut.BoundaryEnds
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Jordan
 import TauCeti.Topology.JordanCurve.SmallArc
 
@@ -152,9 +151,9 @@ theorem exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le
         _ ≤ ε := by dsimp [κ]; linarith [min_le_left (ε / 2) (δ / 2)]
 
 /-- **The bounded-image form of the small-Jordan-curve theorem.** A holomorphic injection of a
-disc onto a bounded domain has finite Dirichlet integral by the conformal area formula, so every
-closed image crosscut produced by the length--area method lies on an arbitrarily small Jordan
-curve in the closure of the image domain.
+disc onto a bounded domain has finite Dirichlet integral by the conformal area formula, so for
+every positive tolerance and radius bound, some closed image crosscut can be chosen on a Jordan
+curve in the closure of the image domain whose diameter is at most the tolerance.
 
 This is the form used for the Riemann map of a bounded Jordan domain. -/
 theorem exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le_of_isBounded

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
@@ -31,10 +31,10 @@ closed image crosscut.
 
 ## Main result
 
-* `TauCeti.exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le` -- below every
+* `TauCeti.exists_isJordanCurve_superset_closure_image_ball_inter_sphere_diam_le` -- below every
   prescribed radius, a short image crosscut lies on an arbitrarily small Jordan curve contained in
   the closure of the image domain.
-* `TauCeti.exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le_of_isBounded` --
+* `TauCeti.exists_isJordanCurve_superset_closure_image_ball_inter_sphere_diam_le_of_isBounded` --
   the bounded-image form used for a Riemann map.
 
 ## Roadmap role
@@ -80,7 +80,7 @@ image crosscut and a small injective path along that frontier.
 No assertion is made about which component of the complement of `J` contains the crosscut
 neighbourhood. Identifying that component is the planar-separation input still needed by the
 Caratheodory boundary correspondence. -/
-theorem exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le
+theorem exists_isJordanCurve_superset_closure_image_ball_inter_sphere_diam_le
     (hζ : dist ζ c = r) (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r))
     (hinj : InjOn f (ball c r)) (hdir : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤)
     (hfrontier : IsJordanCurve (frontier (f '' ball c r))) {ε R : ℝ}
@@ -88,6 +88,7 @@ theorem exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le
     ∃ ρ ∈ Ioo 0 R, ρ < 2 * r ∧ ∃ J : Set ℂ,
       IsJordanCurve J ∧
         closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ J ∧
+        J ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r) ∧
         J ⊆ closure (f '' ball c r) ∧ diam J ≤ ε := by
   have hhalf : 0 < ε / 2 := by positivity
   obtain ⟨δ, hδ, hpath⟩ :=
@@ -110,7 +111,7 @@ theorem exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le
   by_cases hends :
       (frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))).Subsingleton
   · refine ⟨ρ, ⟨hρ.1, hρR⟩, hρr, closure (f '' (ball c r ∩ sphere ζ ρ)), ?_,
-      subset_rfl, hcrossSub, ?_⟩
+      subset_rfl, subset_union_left, hcrossSub, ?_⟩
     · exact isJordanCurve_closure_image_ball_inter_sphere_of_subsingleton hζ hρ.1 hρr
         hf hinj hlenFin hends
     · rw [diam_closure]
@@ -136,7 +137,7 @@ theorem exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le
     obtain ⟨γ, hγinj, hγsub, hγdiam⟩ := hpath hu.1 hv.1 huv huvδ
     refine ⟨ρ, ⟨hρ.1, hρR⟩, hρr,
       closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ range γ,
-      hclose γ hγinj hγsub, subset_union_left, ?_, ?_⟩
+      hclose γ hγinj hγsub, subset_union_left, union_subset_union subset_rfl hγsub, ?_, ?_⟩
     · exact union_subset hcrossSub (hγsub.trans frontier_subset_closure)
     · have hinter :
           (closure (f '' (ball c r ∩ sphere ζ ρ)) ∩ range γ).Nonempty :=
@@ -156,7 +157,7 @@ every positive tolerance and radius bound, some closed image crosscut can be cho
 curve in the closure of the image domain whose diameter is at most the tolerance.
 
 This is the form used for the Riemann map of a bounded Jordan domain. -/
-theorem exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le_of_isBounded
+theorem exists_isJordanCurve_superset_closure_image_ball_inter_sphere_diam_le_of_isBounded
     (hζ : dist ζ c = r) (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r))
     (hinj : InjOn f (ball c r)) (hb : IsBounded (f '' ball c r))
     (hfrontier : IsJordanCurve (frontier (f '' ball c r))) {ε R : ℝ}
@@ -164,8 +165,9 @@ theorem exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le_
     ∃ ρ ∈ Ioo 0 R, ρ < 2 * r ∧ ∃ J : Set ℂ,
       IsJordanCurve J ∧
         closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ J ∧
+        J ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r) ∧
         J ⊆ closure (f '' ball c r) ∧ diam J ≤ ε :=
-  exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le hζ hr hf hinj
+  exists_isJordanCurve_superset_closure_image_ball_inter_sphere_diam_le hζ hr hf hinj
     (lintegral_enorm_deriv_sq_ne_top_of_isBounded isOpen_ball hf
       measurableSet_ball.nullMeasurableSet subset_rfl hinj hb)
     hfrontier hε hR


### PR DESCRIPTION
This PR constructs arbitrarily small Jordan curves through the short image crosscuts produced by the length--area method. Given a holomorphic injection of a disc with finite Dirichlet integral and Jordan-curve image frontier, it finds below every prescribed radius a genuine circular crosscut whose closed image lies on a Jordan curve contained in the image closure and of diameter at most the prescribed tolerance; it also derives the bounded-image form used by a Riemann map.

This advances the exact target `TauCetiRoadmap/ConformalMapping/README.md`, layer **L5 -- Carathéodory boundary correspondence**, whose Jordan-domain milestone asks that the Riemann map extend to a homeomorphism of closures. It is the next critical-path step because the recently merged distinct-end image-crosscut arc and small injective boundary-arc results supply the two halves of this construction, while the crosscut diameter criterion needs their closed curve before planar separation can identify the boundary of the cut-off side. After this PR, the remaining step is to prove the planar-separation statement that the boundary piece of the crosscut neighbourhood lies on the selected small Jordan curve, then feed that enclosure into the existing continuous-extension criterion.

`TauCeti.exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le` handles both endpoint cases without assuming either one: coincident ends make the closed crosscut itself a Jordan curve, while distinct ends are joined by a quantitatively small injective path along the image frontier and the two arcs are glued. `TauCeti.exists_isJordanCurve_containing_closure_image_ball_inter_sphere_diam_le_of_isBounded` obtains the finite Dirichlet integral from the conformal area formula. The conclusion records `ρ < 2 * r`, so consumers can use that the selected circle is a genuine crosscut rather than reconstructing it from the proof.

The new file is `TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean` (174 lines). No Mathlib source is vendored. The proof consumes Mathlib's `Metric.diam_union'`, `Metric.diam_closure`, and `ENNReal.ofReal` API, together with Tau Ceti's Wolff lemma, short-crosscut diameter bound, finite-length endpoint dichotomy, Jordan-arc gluing theorem, quantitative small-arc theorem, and conformal area formula. The mathematical route follows Carathéodory's 1913 paper, Pommerenke Sections 2.2--2.3, and Duren Chapter 3, as cited in the module docstring.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"small-jordan-curve-crosscut"}-->

🤖 Prepared with Codex
