### PR TITLE
refactor(MixedIID): read the piCongrLeft step off Mathlib's apply lemma

### DIFF
--- a/TauCeti/Probability/Exchangeability/MixedIID/Const.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Const.lean
@@ -72,6 +72,18 @@ theorem MixedIIDWith.map_eq_of_const {μ : Measure Ω} [IsProbabilityMeasure μ]
         rw [← blockLaw_def, hblock]
     _ = (p : Measure α) := (measurePreserving_eval (fun _ : Fin 1 => (p : Measure α)) 0).map_eq
 
+/-- **On a constant family, the measurable `piCongrLeft` is plain reindexing.** For an equivalence
+`e : ι ≃ κ`, the measurable equivalence `MeasurableEquiv.piCongrLeft (fun _ : κ => α) e` sends `g`
+to `fun j ↦ g (e.symm j)`. -/
+private theorem coe_piCongrLeft_const {κ : Type*} (e : ι ≃ κ) :
+    ⇑(MeasurableEquiv.piCongrLeft (fun _ : κ => α) e) = fun g (j : κ) => g (e.symm j) := by
+  -- `piCongrLeft` reindexes *and* casts each coordinate along the resulting type equality; on a
+  -- constant family that cast is the identity, but only propositionally, which is why neither
+  -- `rw` nor `convert` aligns the two functions without naming the identification.
+  funext g j
+  rw [MeasurableEquiv.coe_piCongrLeft]
+  simpa using Equiv.piCongrLeft_apply_apply (fun _ : κ => α) e g (e.symm j)
+
 /-- The coordinates of a process with a constant mixing representative are independent. Along an
 injective selection the block law is a product measure, and `Measure.pi` on a finite index set is
 exactly what independence of that finite subfamily means. -/
@@ -104,17 +116,7 @@ theorem MixedIIDWith.iIndepFun_of_const {μ : Measure Ω} [IsProbabilityMeasure 
     _ = (Measure.pi fun _ : Fin s.card => (p : Measure α)).map fun g (j : s) => g (e.symm j) := by
         rw [← blockLaw_def, hblock]
     _ = Measure.pi fun _ : s => (p : Measure α) := by
-      -- `Measure.pi_map_piCongrLeft` transports along `MeasurableEquiv.piCongrLeft`, which
-      -- reindexes by `e.symm` *and* casts each coordinate along the resulting type equality.
-      -- Here the family `fun _ : s => α` is constant, so that cast is the identity and the
-      -- equiv is just reindexing — but only propositionally, so neither `rw` nor `convert`
-      -- aligns the two map functions on its own. Name the identification instead.
-      have hpiCongrLeft : ⇑(MeasurableEquiv.piCongrLeft (fun _ : s => α) e) =
-          fun g (j : s) => g (e.symm j) := by
-        funext g j
-        rw [MeasurableEquiv.coe_piCongrLeft]
-        simpa using Equiv.piCongrLeft_apply_apply (fun _ : s => α) e g (e.symm j)
-      rw [← hpiCongrLeft]
+      rw [← coe_piCongrLeft_const e]
       exact Measure.pi_map_piCongrLeft e fun _ : s => (p : Measure α)
     _ = Measure.pi fun j : s => μ.map (X (j : ι)) :=
         congrArg Measure.pi (funext fun j => (h.map_eq_of_const j).symm)

--- a/TauCeti/Probability/Exchangeability/MixedIID/Const.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Const.lean
@@ -72,18 +72,6 @@ theorem MixedIIDWith.map_eq_of_const {μ : Measure Ω} [IsProbabilityMeasure μ]
         rw [← blockLaw_def, hblock]
     _ = (p : Measure α) := (measurePreserving_eval (fun _ : Fin 1 => (p : Measure α)) 0).map_eq
 
-/-- **On a constant family, the measurable `piCongrLeft` is plain reindexing.** For an equivalence
-`e : ι ≃ κ`, the measurable equivalence `MeasurableEquiv.piCongrLeft (fun _ : κ => α) e` sends `g`
-to `fun j ↦ g (e.symm j)`. -/
-private theorem coe_piCongrLeft_const {κ : Type*} (e : ι ≃ κ) :
-    ⇑(MeasurableEquiv.piCongrLeft (fun _ : κ => α) e) = fun g (j : κ) => g (e.symm j) := by
-  -- `piCongrLeft` reindexes *and* casts each coordinate along the resulting type equality; on a
-  -- constant family that cast is the identity, but only propositionally, which is why neither
-  -- `rw` nor `convert` aligns the two functions without naming the identification.
-  funext g j
-  rw [MeasurableEquiv.coe_piCongrLeft]
-  simpa using Equiv.piCongrLeft_apply_apply (fun _ : κ => α) e g (e.symm j)
-
 /-- The coordinates of a process with a constant mixing representative are independent. Along an
 injective selection the block law is a product measure, and `Measure.pi` on a finite index set is
 exactly what independence of that finite subfamily means. -/
@@ -116,7 +104,13 @@ theorem MixedIIDWith.iIndepFun_of_const {μ : Measure Ω} [IsProbabilityMeasure 
     _ = (Measure.pi fun _ : Fin s.card => (p : Measure α)).map fun g (j : s) => g (e.symm j) := by
         rw [← blockLaw_def, hblock]
     _ = Measure.pi fun _ : s => (p : Measure α) := by
-      rw [← coe_piCongrLeft_const e]
+      -- `piCongrLeft` also casts each coordinate along a type equality; on the constant family
+      -- `fun _ : s => α` that cast is the identity, but only propositionally
+      have hpi : ⇑(MeasurableEquiv.piCongrLeft (fun _ : s => α) e) =
+          fun g (j : s) => g (e.symm j) := by
+        funext g j
+        simpa using MeasurableEquiv.piCongrLeft_apply_apply (β := fun _ : s => α) e g (e.symm j)
+      rw [← hpi]
       exact Measure.pi_map_piCongrLeft e fun _ : s => (p : Measure α)
     _ = Measure.pi fun j : s => μ.map (X (j : ι)) :=
         congrArg Measure.pi (funext fun j => (h.map_eq_of_const j).symm)


### PR DESCRIPTION
`MixedIIDWith.iIndepFun_of_const` ends by identifying `MeasurableEquiv.piCongrLeft` on a constant family with plain reindexing. That step composed two lemmas — `MeasurableEquiv.coe_piCongrLeft` then `Equiv.piCongrLeft_apply_apply` — under a six-line comment about why neither `rw` nor `convert` aligns the two functions.

`MeasurableEquiv.piCongrLeft_apply_apply` does it in one step. Read at `i := e.symm j` it gives `piCongrLeft … e g (e (e.symm j)) = g (e.symm j)`, and `e (e.symm j) = j` closes the gap, so the identification is a `funext` and a `simpa`. `TauCeti/MeasureTheory/Integral/Pi.lean` already discharges the same kind of step this way.

The body drops from 42 lines to 38, and the comment from six lines to two — keeping only the part that is not obvious from the lemma name, that the coordinate cast is the identity here but only propositionally.

**On the earlier revision.** This PR first extracted the identification as a private `coe_piCongrLeft_const`, and its description claimed the statement was absent from Mathlib. That was wrong in the way that matters: the *constant-family extensional* form is absent, but the pointwise fact that yields it in one step is not, which makes the helper a restatement rather than new content. `reuse` and `placement` both objected — reuse because it duplicated Mathlib for a single use, placement because a general `piCongrLeft` fact does not belong in a MixedIID file — and deleting it answers both.

Gates run locally: `lake build` (7139 jobs), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: Exchangeability

🤖 Generated with [Claude Code](https://claude.com/claude-code)
