### PR TITLE
feat: add real Clifford signature recurrences

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -872,87 +872,6 @@ theorem realCliffordPositiveSplitIsometry_snd (p q : ℕ)
   rw [signatureSwitchSplitLinearEquiv_snd, signatureSwitchSplitIndexEquiv_symm_inr,
     finSumFinEquiv_apply_left]
 
-private def signatureSwitchNegIndexEquiv (p q : ℕ) : Fin (p + q) ≃ Fin (q + p) :=
-  finSumFinEquiv.symm |>.trans
-    (Equiv.sumComm (Fin p) (Fin q)) |>.trans
-    finSumFinEquiv
-
-private theorem signatureSwitchNegIndexEquiv_inl (p q : ℕ) (i : Fin p) :
-    signatureSwitchNegIndexEquiv p q (finSumFinEquiv (Sum.inl i)) =
-      finSumFinEquiv (Sum.inr i) := by
-  simp [signatureSwitchNegIndexEquiv]
-
-private theorem signatureSwitchNegIndexEquiv_inr (p q : ℕ) (i : Fin q) :
-    signatureSwitchNegIndexEquiv p q (finSumFinEquiv (Sum.inr i)) =
-      finSumFinEquiv (Sum.inl i) := by
-  simp [signatureSwitchNegIndexEquiv]
-
-private def signatureSwitchNegLinearEquiv (p q : ℕ) :
-    (Fin (p + q) → ℝ) ≃ₗ[ℝ] (Fin (q + p) → ℝ) :=
-  LinearEquiv.piCongrLeft' ℝ (fun _ : Fin (p + q) ↦ ℝ) (signatureSwitchNegIndexEquiv p q)
-
-private theorem signatureSwitchNegWeight (p q : ℕ) (i : Fin (p + q)) :
-    realCliffordWeight q p (signatureSwitchNegIndexEquiv p q i) =
-      -realCliffordWeight p q i := by
-  rw [← finSumFinEquiv.apply_symm_apply i]
-  rcases finSumFinEquiv.symm i with i | i
-  · simp only [signatureSwitchNegIndexEquiv, Equiv.trans_apply, Equiv.sumComm_apply,
-      finSumFinEquiv_apply_left]
-    rw [realCliffordWeight_of_le (by simp), realCliffordWeight_of_lt (by simp)]
-  · simp only [signatureSwitchNegIndexEquiv, Equiv.trans_apply, Equiv.sumComm_apply,
-      finSumFinEquiv_apply_right]
-    rw [realCliffordWeight_of_lt (by simp), realCliffordWeight_of_le (by simp)]
-    norm_num
-
-private theorem signatureSwitchNegLinearEquiv_apply (p q : ℕ) (x : Fin (p + q) → ℝ)
-    (i : Fin (p + q)) :
-    signatureSwitchNegLinearEquiv p q x (signatureSwitchNegIndexEquiv p q i) = x i := by
-  rw [signatureSwitchNegLinearEquiv, LinearEquiv.piCongrLeft'_apply, Equiv.symm_apply_apply]
-
-/-- Negating a real signature form swaps its positive and negative coordinates. -/
-def realCliffordFormNegIsometry (p q : ℕ) :
-    (-(realCliffordForm p q)).IsometryEquiv (realCliffordForm q p) :=
-  { signatureSwitchNegLinearEquiv p q with
-    map_app' := by
-      intro x
-      rw [realCliffordForm_apply, neg_apply, realCliffordForm_apply]
-      let y := signatureSwitchNegLinearEquiv p q x
-      calc
-        (∑ i, realCliffordWeight q p i * (y i * y i)) =
-            ∑ i, realCliffordWeight q p (signatureSwitchNegIndexEquiv p q i) *
-              (y (signatureSwitchNegIndexEquiv p q i) *
-                y (signatureSwitchNegIndexEquiv p q i)) := by
-          exact (Fintype.sum_equiv (signatureSwitchNegIndexEquiv p q)
-            (fun i ↦ realCliffordWeight q p (signatureSwitchNegIndexEquiv p q i) *
-              (y (signatureSwitchNegIndexEquiv p q i) *
-                y (signatureSwitchNegIndexEquiv p q i)))
-            (fun i ↦ realCliffordWeight q p i * (y i * y i))
-            (fun _ ↦ rfl)).symm
-        _ = -(∑ i, realCliffordWeight p q i * (x i * x i)) := by
-          dsimp only [y]
-          simp only [signatureSwitchNegWeight, signatureSwitchNegLinearEquiv_apply, neg_mul,
-            ← Finset.sum_neg_distrib] }
-
-/-- Negated negative coordinates become positive coordinates under
-`realCliffordFormNegIsometry`. -/
-@[simp]
-theorem realCliffordFormNegIsometry_pos_of_neg (p q : ℕ)
-    (x : Fin (p + q) → ℝ) (i : Fin q) :
-    realCliffordFormNegIsometry p q x (Fin.castAdd p i) = x (Fin.natAdd p i) := by
-  change signatureSwitchNegLinearEquiv p q x _ = _
-  rw [← finSumFinEquiv_apply_left, ← signatureSwitchNegIndexEquiv_inr,
-    signatureSwitchNegLinearEquiv_apply, finSumFinEquiv_apply_right]
-
-/-- Negated positive coordinates become negative coordinates under
-`realCliffordFormNegIsometry`. -/
-@[simp]
-theorem realCliffordFormNegIsometry_neg_of_pos (p q : ℕ)
-    (x : Fin (p + q) → ℝ) (i : Fin p) :
-    realCliffordFormNegIsometry p q x (Fin.natAdd q i) = x (Fin.castAdd q i) := by
-  change signatureSwitchNegLinearEquiv p q x _ = _
-  rw [← finSumFinEquiv_apply_right, ← signatureSwitchNegIndexEquiv_inl,
-    signatureSwitchNegLinearEquiv_apply, finSumFinEquiv_apply_left]
-
 /-- The coordinate isometry which turns the sign-switched form into the standard signature. -/
 def realCliffordSignSwitchStandardIsometry (p q : ℕ) :
     ((-(realCliffordForm p q)).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))).IsometryEquiv
@@ -966,9 +885,7 @@ private theorem signatureSwitchStandardIsometry_split (p q : ℕ)
     realCliffordPositiveSplitIsometry q p
         (realCliffordSignSwitchStandardIsometry p q (x, r)) =
       (realCliffordFormNegIsometry p q x, r) := by
-  change realCliffordPositiveSplitIsometry q p
-    ((realCliffordPositiveSplitIsometry q p).symm
-      (realCliffordFormNegIsometry p q x, r)) = _
+  rw [realCliffordSignSwitchStandardIsometry]
   exact (realCliffordPositiveSplitIsometry q p).apply_symm_apply _
 
 /-- Negated negative coordinates become positive coordinates under

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -25,7 +25,11 @@ negative generator is equivalent to tensoring with two-by-two real matrices.
 * `TauCeti.realCliffordBottIterEquiv`: the iterated standard-signature equivalence, with matrix
   size `2 ^ n` after adjoining `n` hyperbolic planes;
 * `TauCeti.realCliffordSignatureReductionEquiv`: the reduction of a standard signature by its
-  common positive and negative part.
+  common positive and negative part;
+* `TauCeti.CliffordAlgebra.signSwitchEquiv`: adjoining a positive line gives equivalent Clifford
+  algebras for a quadratic form and its negation;
+* `TauCeti.realCliffordPositiveAxisRecurrenceEquiv`: the recurrence from a positive-axis real
+  Clifford algebra to a negative-axis algebra tensored with `M₂(ℝ)`.
 
 ## References
 
@@ -417,6 +421,150 @@ theorem hyperbolicEquivTensor_symm_apply_ι_hyperbolic
   rw [AlgEquiv.apply_symm_apply, hyperbolicEquivTensor_ι]
   simp
 
+/-! ### Changing every sign after adjoining one positive generator -/
+
+section SignSwitch
+
+variable {R N : Type*} [CommRing R] [AddCommGroup N] [Module R N]
+variable (P P' : QuadraticForm R N)
+
+private def signSwitchGenerator :
+    N × R →ₗ[R]
+      _root_.CliffordAlgebra (P'.prod (QuadraticMap.sq (R := R) (A := R))) :=
+  ((LinearMap.mulLeft R
+      (_root_.CliffordAlgebra.ι (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1))).comp
+    ((_root_.CliffordAlgebra.ι (P'.prod (QuadraticMap.sq (R := R) (A := R)))).comp
+      (LinearMap.inl R N R))).coprod
+    (LinearMap.toSpanSingleton R _
+      (_root_.CliffordAlgebra.ι
+        (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1)))
+
+private theorem signSwitchGenerator_apply (x : N × R) :
+    signSwitchGenerator P' x =
+      _root_.CliffordAlgebra.ι
+          (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1) *
+          _root_.CliffordAlgebra.ι
+            (P'.prod (QuadraticMap.sq (R := R) (A := R))) (x.1, 0) +
+        x.2 • _root_.CliffordAlgebra.ι
+          (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1) :=
+  rfl
+
+private theorem signSwitchGenerator_sq (h : P' = -P) (x : N × R) :
+    signSwitchGenerator P' x * signSwitchGenerator P' x =
+      algebraMap R _ ((P.prod (QuadraticMap.sq (R := R) (A := R))) x) := by
+  let Q' := P'.prod (QuadraticMap.sq (R := R) (A := R))
+  let e := _root_.CliffordAlgebra.ι Q' (0, 1)
+  let v := _root_.CliffordAlgebra.ι Q' (x.1, 0)
+  have he : e * e = 1 := by
+    dsimp only [e]
+    rw [_root_.CliffordAlgebra.ι_sq_scalar]
+    simp [Q']
+  have hv : v * v = algebraMap R _ (-P x.1) := by
+    dsimp only [v]
+    rw [_root_.CliffordAlgebra.ι_sq_scalar]
+    simp [Q', h]
+  have hev : e * v + v * e = 0 := by
+    dsimp only [e, v]
+    rw [_root_.CliffordAlgebra.ι_mul_ι_add_swap]
+    simp [Q', QuadraticMap.polar]
+  rw [signSwitchGenerator_apply]
+  -- Expose the two local Clifford generators used in the square calculation.
+  change (e * v + x.2 • e) * (e * v + x.2 • e) = _
+  rw [Algebra.smul_def]
+  let r := algebraMap R (_root_.CliffordAlgebra Q') x.2
+  -- Name the scalar's central image so the four noncommutative terms can be compared directly.
+  change (e * v + r * e) * (e * v + r * e) = _
+  have hve : v * e = -(e * v) := eq_neg_of_add_eq_zero_right hev
+  have hre : r * e = e * r := Algebra.commutes x.2 e
+  have hrv : r * v = v * r := Algebra.commutes x.2 v
+  have hterm1 : (e * v) * (e * v) = -(v * v) := by
+    calc
+      (e * v) * (e * v) = e * ((v * e) * v) := by simp only [mul_assoc]
+      _ = e * (-(e * v) * v) := by rw [hve]
+      _ = -(v * v) := by rw [neg_mul, mul_neg, ← mul_assoc, ← mul_assoc, he, one_mul]
+  have hterm2 : (e * v) * (r * e) = -(r * v) := by
+    calc
+      (e * v) * (r * e) = e * (v * r) * e := by simp only [mul_assoc]
+      _ = e * (r * v) * e := by rw [hrv]
+      _ = (e * r) * v * e := by simp only [mul_assoc]
+      _ = (r * e) * v * e := by rw [← hre]
+      _ = r * (e * v) * e := by rw [mul_assoc r e v]
+      _ = r * (e * (v * e)) := by simp only [mul_assoc]
+      _ = r * (e * (-(e * v))) := by rw [hve]
+      _ = -(r * v) := by rw [mul_neg, mul_neg, ← mul_assoc e e, he, one_mul]
+  have hterm3 : (r * e) * (e * v) = r * v := by
+    rw [mul_assoc r e, ← mul_assoc e e, he, one_mul]
+  have hterm4 : (r * e) * (r * e) = r * r := by
+    calc
+      (r * e) * (r * e) = r * (e * r) * e := by simp only [mul_assoc]
+      _ = r * (r * e) * e := by rw [← hre]
+      _ = r * r * (e * e) := by simp only [mul_assoc]
+      _ = r * r := by rw [he, mul_one]
+  calc
+    (e * v + r * e) * (e * v + r * e) = -(v * v) + r * r := by
+      rw [mul_add, add_mul, add_mul, hterm1, hterm2, hterm3, hterm4]
+      abel
+    _ = algebraMap R _ (P x.1 + x.2 * x.2) := by
+      rw [hv, map_neg, neg_neg, ← map_mul, ← map_add]
+    _ = algebraMap R _ ((P.prod (QuadraticMap.sq (R := R) (A := R))) x) := by
+      simp [QuadraticMap.prod_apply]
+
+private def signSwitchTo (h : P' = -P) :
+    _root_.CliffordAlgebra (P.prod (QuadraticMap.sq (R := R) (A := R))) →ₐ[R]
+      _root_.CliffordAlgebra (P'.prod (QuadraticMap.sq (R := R) (A := R))) :=
+  _root_.CliffordAlgebra.lift _ ⟨signSwitchGenerator P', signSwitchGenerator_sq P P' h⟩
+
+private theorem signSwitchTo_ι (h : P' = -P) (x : N × R) :
+    signSwitchTo P P' h (_root_.CliffordAlgebra.ι _ x) = signSwitchGenerator P' x :=
+  _root_.CliffordAlgebra.lift_ι_apply _ _ x
+
+private theorem signSwitchTo_comp_signSwitchTo
+    (h : P' = -P) (h' : P = -P') :
+    (signSwitchTo P' P h').comp (signSwitchTo P P' h) = AlgHom.id R _ := by
+  apply _root_.CliffordAlgebra.hom_ext
+  apply LinearMap.ext
+  rintro ⟨m, r⟩
+  simp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply, AlgHom.comp_apply,
+    signSwitchTo_ι, signSwitchGenerator_apply, map_add, map_mul, map_smul]
+  -- Split a source generator into its module and scalar components for the linear lift.
+  rw [show (m, r) = (m, 0) + r • (0, 1) by ext <;> simp, map_add, map_smul]
+  -- Expose the zero module-scalar pair so the Clifford generator reduces with `map_zero`.
+  rw [show ((0 : N), (0 : R)) = 0 by rfl, map_zero]
+  simp only [mul_zero, zero_add, add_zero, one_smul, zero_smul]
+  rw [← mul_assoc, _root_.CliffordAlgebra.ι_sq_scalar]
+  simp
+
+/-- Adjoining a positive line to a quadratic form or to its negation gives equivalent Clifford
+algebras. -/
+def signSwitchEquiv :
+    _root_.CliffordAlgebra (P.prod (QuadraticMap.sq (R := R) (A := R))) ≃ₐ[R]
+      _root_.CliffordAlgebra ((-P).prod (QuadraticMap.sq (R := R) (A := R))) :=
+  AlgEquiv.ofAlgHom (signSwitchTo P (-P) rfl) (signSwitchTo (-P) P (neg_neg P).symm)
+    (signSwitchTo_comp_signSwitchTo (-P) P (neg_neg P).symm rfl)
+    (signSwitchTo_comp_signSwitchTo P (-P) rfl (neg_neg P).symm)
+
+/-- The sign-switch equivalence sends a generating pair to the product with the new positive
+generator plus its scalar component. -/
+@[simp]
+theorem signSwitchEquiv_ι (x : N × R) :
+    signSwitchEquiv P (_root_.CliffordAlgebra.ι _ x) =
+      _root_.CliffordAlgebra.ι _ (0, 1) * _root_.CliffordAlgebra.ι _ (x.1, 0) +
+        x.2 • _root_.CliffordAlgebra.ι _ (0, 1) := by
+  rw [signSwitchEquiv, AlgEquiv.ofAlgHom_apply, signSwitchTo_ι,
+    signSwitchGenerator_apply]
+
+/-- The inverse sign-switch equivalence has the same equation on Clifford generators. -/
+@[simp]
+theorem signSwitchEquiv_symm_ι (x : N × R) :
+    (signSwitchEquiv P).symm (_root_.CliffordAlgebra.ι _ x) =
+      _root_.CliffordAlgebra.ι _ (0, 1) * _root_.CliffordAlgebra.ι _ (x.1, 0) +
+        x.2 • _root_.CliffordAlgebra.ι _ (0, 1) := by
+  -- Expose the reverse lift stored in `AlgEquiv.ofAlgHom` so its generator equation applies.
+  change signSwitchTo (-P) P (neg_neg P).symm (_root_.CliffordAlgebra.ι _ x) = _
+  rw [signSwitchTo_ι, signSwitchGenerator_apply]
+
+end SignSwitch
+
 end TauCeti.CliffordAlgebra
 
 namespace TauCeti
@@ -723,5 +871,103 @@ theorem realCliffordBottIterEquiv_succ (p q n : ℕ) :
   unfold realCliffordBottIterEquiv
   rw [realCliffordBottIterEquivImpl]
   rfl
+
+/-! ### Pure-axis recurrence -/
+
+private def splitLastCoordinateLinearEquiv (n : ℕ) :
+    (Fin (n + 1) → ℝ) ≃ₗ[ℝ] (Fin n → ℝ) × ℝ :=
+  (LinearEquiv.piCongrLeft ℝ (fun _ ↦ ℝ) finSuccEquivLast).trans
+    ((LinearEquiv.piOptionEquivProd ℝ).trans
+      (LinearEquiv.prodComm ℝ ℝ (Fin n → ℝ)))
+
+private def positiveAxisSplitIsometry (n : ℕ) :
+    (realCliffordForm (n + 1) 0).IsometryEquiv
+      ((realCliffordForm n 0).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))) :=
+  { splitLastCoordinateLinearEquiv n with
+    map_app' := by
+      intro x
+      simp only [Nat.add_zero] at x ⊢
+      rw [QuadraticMap.prod_apply, realCliffordForm_apply, realCliffordForm_apply,
+        Fin.sum_univ_castSucc]
+      simp only [Nat.add_zero, QuadraticMap.sq_apply]
+      congr 1
+      · apply Finset.sum_congr rfl
+        intro i hi
+        simp [splitLastCoordinateLinearEquiv, LinearEquiv.piCongrLeft,
+          LinearEquiv.piCongrLeft', LinearEquiv.piOptionEquivProd,
+          Equiv.piOptionEquivProd, Equiv.piCongrLeft']
+      · simp [splitLastCoordinateLinearEquiv, LinearEquiv.piCongrLeft,
+          LinearEquiv.piCongrLeft', LinearEquiv.piOptionEquivProd,
+          Equiv.piOptionEquivProd, Equiv.piCongrLeft'] }
+
+private def splitFirstCoordinateLinearEquiv (n : ℕ) :
+    (Fin (n + 1) → ℝ) ≃ₗ[ℝ] ℝ × (Fin n → ℝ) :=
+  (LinearEquiv.piCongrLeft ℝ (fun _ ↦ ℝ) (finSuccEquiv n)).trans
+    (LinearEquiv.piOptionEquivProd ℝ)
+
+private def negativePositiveToStandardLinearEquiv (n : ℕ) :
+    ((Fin n → ℝ) × ℝ) ≃ₗ[ℝ] (Fin (1 + n) → ℝ) :=
+  (LinearEquiv.prodComm ℝ (Fin n → ℝ) ℝ).trans
+    ((splitFirstCoordinateLinearEquiv n).symm.trans
+      (LinearEquiv.piCongrLeft ℝ (fun _ ↦ ℝ)
+        (finCongr (by omega : n + 1 = 1 + n))))
+
+private theorem negativePositiveToStandardLinearEquiv_zero (n : ℕ)
+    (x : (Fin n → ℝ) × ℝ) :
+    negativePositiveToStandardLinearEquiv n x 0 = x.2 := by
+  simp [negativePositiveToStandardLinearEquiv, splitFirstCoordinateLinearEquiv,
+    LinearEquiv.piCongrLeft, LinearEquiv.piCongrLeft', LinearEquiv.piOptionEquivProd,
+    Equiv.piOptionEquivProd, Equiv.piCongrLeft']
+
+private theorem negativePositiveToStandardLinearEquiv_succ (n : ℕ)
+    (x : (Fin n → ℝ) × ℝ) (i : Fin n) :
+    negativePositiveToStandardLinearEquiv n x (Fin.natAdd 1 i) = x.1 i := by
+  simp [negativePositiveToStandardLinearEquiv, splitFirstCoordinateLinearEquiv,
+    LinearEquiv.piCongrLeft, LinearEquiv.piCongrLeft', LinearEquiv.piOptionEquivProd,
+    Equiv.piOptionEquivProd, Equiv.piCongrLeft']
+
+private def negativePositiveToStandardIsometry (n : ℕ) :
+    ((-(realCliffordForm n 0)).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))).IsometryEquiv
+      (realCliffordForm 1 n) :=
+  { negativePositiveToStandardLinearEquiv n with
+    map_app' := by
+      rintro ⟨x, r⟩
+      simp only [Nat.add_zero] at x ⊢
+      rw [realCliffordForm_apply, QuadraticMap.prod_apply, neg_apply,
+        realCliffordForm_apply]
+      simp only [QuadraticMap.sq_apply]
+      let y := negativePositiveToStandardLinearEquiv n (x, r)
+      calc
+        (∑ i, realCliffordWeight 1 n i * (y i * y i)) =
+            ∑ s : Fin 1 ⊕ Fin n,
+              realCliffordWeight 1 n (finSumFinEquiv s) *
+                (y (finSumFinEquiv s) * y (finSumFinEquiv s)) := by
+          exact Fintype.sum_equiv finSumFinEquiv.symm _ _
+            (fun i ↦ by rw [Equiv.apply_symm_apply])
+        _ = -(∑ i, x i * x i) + r * r := by
+          have hzero : y (Fin.castAdd n (0 : Fin 1)) = r := by
+            -- Identify the dependent `Fin` casts by their common underlying value zero.
+            rw [show Fin.castAdd n (0 : Fin 1) = (0 : Fin (1 + n)) by ext; simp]
+            exact negativePositiveToStandardLinearEquiv_zero n (x, r)
+          rw [Fintype.sum_sum_type]
+          simp [hzero, y, negativePositiveToStandardLinearEquiv_succ]
+          abel
+        _ = -(∑ i, realCliffordWeight n 0 i * (x i * x i)) + r * r := by
+          congr 2
+          apply Finset.sum_congr rfl
+          intro i hi
+          rw [realCliffordWeight_of_lt (by simp)]
+          simp only [one_mul] }
+
+/-- Combining one sign switch with the hyperbolic Bott step gives the positive-axis recurrence
+`Cliff(n + 2, 0) ≅ Cliff(0, n) ⊗ M₂(ℝ)`. -/
+noncomputable def realCliffordPositiveAxisRecurrenceEquiv (n : ℕ) :
+    _root_.CliffordAlgebra (realCliffordForm (n + 2) 0) ≃ₐ[ℝ]
+      _root_.CliffordAlgebra (realCliffordForm 0 n) ⊗[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
+  (_root_.CliffordAlgebra.equivOfIsometry (positiveAxisSplitIsometry (n + 1))).trans
+    ((CliffordAlgebra.signSwitchEquiv (realCliffordForm (n + 1) 0)).trans
+      ((_root_.CliffordAlgebra.equivOfIsometry
+        (negativePositiveToStandardIsometry (n + 1))).trans
+          (realCliffordBottEquiv 0 n)))
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -765,8 +765,7 @@ private theorem signatureSwitchSplitIndexEquiv_symm_inl_neg (p q : ℕ) (i : Fin
 private theorem signatureSwitchSplitIndexEquiv_symm_inr (p q : ℕ) :
     (signatureSwitchSplitIndexEquiv p q).symm (Sum.inr (0 : Fin 1)) =
       finSumFinEquiv (Sum.inl (Fin.last (p + 1))) := by
-  apply Fin.ext
-  rfl
+  simp [signatureSwitchSplitIndexEquiv, splitLastEquiv]
 
 private theorem signatureSwitchSplitWeight_inl (p q : ℕ) (i : Fin ((p + 1) + q)) :
     realCliffordWeight (p + 1 + 1) q
@@ -911,8 +910,7 @@ private theorem signatureSwitchStandardIndexEquiv_symm_inl_neg (p q : ℕ) (i : 
 private theorem signatureSwitchStandardIndexEquiv_symm_inr (p q : ℕ) :
     (signatureSwitchStandardIndexEquiv p q).symm (Sum.inr (0 : Fin 1)) =
       finSumFinEquiv (Sum.inl (Fin.last q)) := by
-  apply Fin.ext
-  rfl
+  simp [signatureSwitchStandardIndexEquiv, splitLastEquiv]
 
 private theorem signatureSwitchStandardWeight_inl (p q : ℕ) (i : Fin ((p + 1) + q)) :
     realCliffordWeight (q + 1) (p + 1)

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -6,6 +6,7 @@ Authors: Tau Ceti Project
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.RealForm
+public import TauCeti.LinearAlgebra.CliffordAlgebra.SignSwitch
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Prod
 public import Mathlib.RingTheory.MatrixAlgebra
 
@@ -26,8 +27,6 @@ negative generator is equivalent to tensoring with two-by-two real matrices.
   size `2 ^ n` after adjoining `n` hyperbolic planes;
 * `TauCeti.realCliffordSignatureReductionEquiv`: the reduction of a standard signature by its
   common positive and negative part;
-* `TauCeti.CliffordAlgebra.signSwitchEquiv`: adjoining a positive line gives equivalent Clifford
-  algebras for a quadratic form and its negation;
 * `TauCeti.realCliffordPositiveAxisRecurrenceEquiv`: the recurrence from a positive-axis real
   Clifford algebra to a negative-axis algebra tensored with `M₂(ℝ)`.
 
@@ -421,149 +420,6 @@ theorem hyperbolicEquivTensor_symm_apply_ι_hyperbolic
   rw [AlgEquiv.apply_symm_apply, hyperbolicEquivTensor_ι]
   simp
 
-/-! ### Changing every sign after adjoining one positive generator -/
-
-section SignSwitch
-
-variable {R N : Type*} [CommRing R] [AddCommGroup N] [Module R N]
-variable (P P' : QuadraticForm R N)
-
-private def signSwitchGenerator :
-    N × R →ₗ[R]
-      _root_.CliffordAlgebra (P'.prod (QuadraticMap.sq (R := R) (A := R))) :=
-  ((LinearMap.mulLeft R
-      (_root_.CliffordAlgebra.ι (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1))).comp
-    ((_root_.CliffordAlgebra.ι (P'.prod (QuadraticMap.sq (R := R) (A := R)))).comp
-      (LinearMap.inl R N R))).coprod
-    (LinearMap.toSpanSingleton R _
-      (_root_.CliffordAlgebra.ι
-        (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1)))
-
-private theorem signSwitchGenerator_apply (x : N × R) :
-    signSwitchGenerator P' x =
-      _root_.CliffordAlgebra.ι
-          (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1) *
-          _root_.CliffordAlgebra.ι
-            (P'.prod (QuadraticMap.sq (R := R) (A := R))) (x.1, 0) +
-        x.2 • _root_.CliffordAlgebra.ι
-          (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1) :=
-  rfl
-
-private theorem signSwitchGenerator_sq (h : P' = -P) (x : N × R) :
-    signSwitchGenerator P' x * signSwitchGenerator P' x =
-      algebraMap R _ ((P.prod (QuadraticMap.sq (R := R) (A := R))) x) := by
-  let Q' := P'.prod (QuadraticMap.sq (R := R) (A := R))
-  let e := _root_.CliffordAlgebra.ι Q' (0, 1)
-  let v := _root_.CliffordAlgebra.ι Q' (x.1, 0)
-  have he : e * e = 1 := by
-    dsimp only [e]
-    rw [_root_.CliffordAlgebra.ι_sq_scalar]
-    simp [Q']
-  have hv : v * v = algebraMap R _ (-P x.1) := by
-    dsimp only [v]
-    rw [_root_.CliffordAlgebra.ι_sq_scalar]
-    simp [Q', h]
-  have hev : e * v + v * e = 0 := by
-    dsimp only [e, v]
-    rw [_root_.CliffordAlgebra.ι_mul_ι_add_swap]
-    simp [Q', QuadraticMap.polar]
-  rw [signSwitchGenerator_apply]
-  -- Expose the two local Clifford generators used in the square calculation.
-  change (e * v + x.2 • e) * (e * v + x.2 • e) = _
-  rw [Algebra.smul_def]
-  let r := algebraMap R (_root_.CliffordAlgebra Q') x.2
-  -- Name the scalar's central image so the four noncommutative terms can be compared directly.
-  change (e * v + r * e) * (e * v + r * e) = _
-  have hve : v * e = -(e * v) := eq_neg_of_add_eq_zero_right hev
-  have hre : r * e = e * r := Algebra.commutes x.2 e
-  have hrv : r * v = v * r := Algebra.commutes x.2 v
-  have hterm1 : (e * v) * (e * v) = -(v * v) := by
-    calc
-      (e * v) * (e * v) = e * ((v * e) * v) := by simp only [mul_assoc]
-      _ = e * (-(e * v) * v) := by rw [hve]
-      _ = -(v * v) := by rw [neg_mul, mul_neg, ← mul_assoc, ← mul_assoc, he, one_mul]
-  have hterm2 : (e * v) * (r * e) = -(r * v) := by
-    calc
-      (e * v) * (r * e) = e * (v * r) * e := by simp only [mul_assoc]
-      _ = e * (r * v) * e := by rw [hrv]
-      _ = (e * r) * v * e := by simp only [mul_assoc]
-      _ = (r * e) * v * e := by rw [← hre]
-      _ = r * (e * v) * e := by rw [mul_assoc r e v]
-      _ = r * (e * (v * e)) := by simp only [mul_assoc]
-      _ = r * (e * (-(e * v))) := by rw [hve]
-      _ = -(r * v) := by rw [mul_neg, mul_neg, ← mul_assoc e e, he, one_mul]
-  have hterm3 : (r * e) * (e * v) = r * v := by
-    rw [mul_assoc r e, ← mul_assoc e e, he, one_mul]
-  have hterm4 : (r * e) * (r * e) = r * r := by
-    calc
-      (r * e) * (r * e) = r * (e * r) * e := by simp only [mul_assoc]
-      _ = r * (r * e) * e := by rw [← hre]
-      _ = r * r * (e * e) := by simp only [mul_assoc]
-      _ = r * r := by rw [he, mul_one]
-  calc
-    (e * v + r * e) * (e * v + r * e) = -(v * v) + r * r := by
-      rw [mul_add, add_mul, add_mul, hterm1, hterm2, hterm3, hterm4]
-      abel
-    _ = algebraMap R _ (P x.1 + x.2 * x.2) := by
-      rw [hv, map_neg, neg_neg, ← map_mul, ← map_add]
-    _ = algebraMap R _ ((P.prod (QuadraticMap.sq (R := R) (A := R))) x) := by
-      simp [QuadraticMap.prod_apply]
-
-private def signSwitchTo (h : P' = -P) :
-    _root_.CliffordAlgebra (P.prod (QuadraticMap.sq (R := R) (A := R))) →ₐ[R]
-      _root_.CliffordAlgebra (P'.prod (QuadraticMap.sq (R := R) (A := R))) :=
-  _root_.CliffordAlgebra.lift _ ⟨signSwitchGenerator P', signSwitchGenerator_sq P P' h⟩
-
-private theorem signSwitchTo_ι (h : P' = -P) (x : N × R) :
-    signSwitchTo P P' h (_root_.CliffordAlgebra.ι _ x) = signSwitchGenerator P' x :=
-  _root_.CliffordAlgebra.lift_ι_apply _ _ x
-
-private theorem signSwitchTo_comp_signSwitchTo
-    (h : P' = -P) (h' : P = -P') :
-    (signSwitchTo P' P h').comp (signSwitchTo P P' h) = AlgHom.id R _ := by
-  apply _root_.CliffordAlgebra.hom_ext
-  apply LinearMap.ext
-  rintro ⟨m, r⟩
-  simp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply, AlgHom.comp_apply,
-    signSwitchTo_ι, signSwitchGenerator_apply, map_add, map_mul, map_smul]
-  -- Split a source generator into its module and scalar components for the linear lift.
-  rw [show (m, r) = (m, 0) + r • (0, 1) by ext <;> simp, map_add, map_smul]
-  -- Expose the zero module-scalar pair so the Clifford generator reduces with `map_zero`.
-  rw [show ((0 : N), (0 : R)) = 0 by rfl, map_zero]
-  simp only [mul_zero, zero_add, add_zero, one_smul, zero_smul]
-  rw [← mul_assoc, _root_.CliffordAlgebra.ι_sq_scalar]
-  simp
-
-/-- Adjoining a positive line to a quadratic form or to its negation gives equivalent Clifford
-algebras. -/
-def signSwitchEquiv :
-    _root_.CliffordAlgebra (P.prod (QuadraticMap.sq (R := R) (A := R))) ≃ₐ[R]
-      _root_.CliffordAlgebra ((-P).prod (QuadraticMap.sq (R := R) (A := R))) :=
-  AlgEquiv.ofAlgHom (signSwitchTo P (-P) rfl) (signSwitchTo (-P) P (neg_neg P).symm)
-    (signSwitchTo_comp_signSwitchTo (-P) P (neg_neg P).symm rfl)
-    (signSwitchTo_comp_signSwitchTo P (-P) rfl (neg_neg P).symm)
-
-/-- The sign-switch equivalence sends a generating pair to the product with the new positive
-generator plus its scalar component. -/
-@[simp]
-theorem signSwitchEquiv_ι (x : N × R) :
-    signSwitchEquiv P (_root_.CliffordAlgebra.ι _ x) =
-      _root_.CliffordAlgebra.ι _ (0, 1) * _root_.CliffordAlgebra.ι _ (x.1, 0) +
-        x.2 • _root_.CliffordAlgebra.ι _ (0, 1) := by
-  rw [signSwitchEquiv, AlgEquiv.ofAlgHom_apply, signSwitchTo_ι,
-    signSwitchGenerator_apply]
-
-/-- The inverse sign-switch equivalence has the same equation on Clifford generators. -/
-@[simp]
-theorem signSwitchEquiv_symm_ι (x : N × R) :
-    (signSwitchEquiv P).symm (_root_.CliffordAlgebra.ι _ x) =
-      _root_.CliffordAlgebra.ι _ (0, 1) * _root_.CliffordAlgebra.ι _ (x.1, 0) +
-        x.2 • _root_.CliffordAlgebra.ι _ (0, 1) := by
-  -- Expose the reverse lift stored in `AlgEquiv.ofAlgHom` so its generator equation applies.
-  change signSwitchTo (-P) P (neg_neg P).symm (_root_.CliffordAlgebra.ι _ x) = _
-  rw [signSwitchTo_ι, signSwitchGenerator_apply]
-
-end SignSwitch
 
 end TauCeti.CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -28,9 +28,7 @@ negative generator is equivalent to tensoring with two-by-two real matrices.
 * `TauCeti.realCliffordSignatureReductionEquiv`: the reduction of a standard signature by its
   common positive and negative part;
 * `TauCeti.realCliffordSignatureSwitchRecurrenceEquiv`: the recurrence which switches a real
-  signature while adding two positive generators;
-* `TauCeti.realCliffordPositiveAxisRecurrenceEquiv`: the recurrence from a positive-axis real
-  Clifford algebra to a negative-axis algebra tensored with `M₂(ℝ)`.
+  signature while adding two positive generators.
 
 ## References
 
@@ -1069,27 +1067,5 @@ theorem realCliffordSignatureSwitchRecurrenceEquiv_ι (p q : ℕ)
   simp only [AlgEquiv.trans_apply, _root_.CliffordAlgebra.equivOfIsometry_apply,
     _root_.CliffordAlgebra.map_apply_ι, QuadraticMap.IsometryEquiv.toIsometry]
   rfl
-
-/-- Combining one sign switch with the hyperbolic Bott step gives the positive-axis recurrence
-`Cliff(n + 2, 0) ≅ Cliff(0, n) ⊗ M₂(ℝ)`. -/
-noncomputable def realCliffordPositiveAxisRecurrenceEquiv (n : ℕ) :
-    _root_.CliffordAlgebra (realCliffordForm (n + 2) 0) ≃ₐ[ℝ]
-      _root_.CliffordAlgebra (realCliffordForm 0 n) ⊗[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
-  realCliffordSignatureSwitchRecurrenceEquiv n 0
-
-/-- The positive-axis recurrence on a generator, as the `q = 0` signature-switch formula. -/
-@[simp]
-theorem realCliffordPositiveAxisRecurrenceEquiv_ι (n : ℕ) (v : Fin (n + 2) → ℝ) :
-    realCliffordPositiveAxisRecurrenceEquiv n (_root_.CliffordAlgebra.ι _ v) =
-      realCliffordBottEquiv 0 n (_root_.CliffordAlgebra.ι _
-        (realCliffordSignSwitchStandardIsometry n 0 (0, 1))) *
-        realCliffordBottEquiv 0 n (_root_.CliffordAlgebra.ι _
-          (realCliffordSignSwitchStandardIsometry n 0
-            ((realCliffordPositiveSplitIsometry n 0 v).1, 0))) +
-          (realCliffordPositiveSplitIsometry n 0 v).2 •
-            realCliffordBottEquiv 0 n (_root_.CliffordAlgebra.ι _
-              (realCliffordSignSwitchStandardIsometry n 0 (0, 1))) := by
-  simpa only [realCliffordPositiveAxisRecurrenceEquiv] using
-    realCliffordSignatureSwitchRecurrenceEquiv_ι n 0 v
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -27,6 +27,8 @@ negative generator is equivalent to tensoring with two-by-two real matrices.
   size `2 ^ n` after adjoining `n` hyperbolic planes;
 * `TauCeti.realCliffordSignatureReductionEquiv`: the reduction of a standard signature by its
   common positive and negative part;
+* `TauCeti.realCliffordSignatureSwitchRecurrenceEquiv`: the recurrence which switches a real
+  signature while adding two positive generators;
 * `TauCeti.realCliffordPositiveAxisRecurrenceEquiv`: the recurrence from a positive-axis real
   Clifford algebra to a negative-axis algebra tensored with `M₂(ℝ)`.
 
@@ -728,102 +730,368 @@ theorem realCliffordBottIterEquiv_succ (p q n : ℕ) :
   rw [realCliffordBottIterEquivImpl]
   rfl
 
-/-! ### Pure-axis recurrence -/
+/-! ### Signature-switch recurrence -/
 
-private def splitLastCoordinateLinearEquiv (n : ℕ) :
-    (Fin (n + 1) → ℝ) ≃ₗ[ℝ] (Fin n → ℝ) × ℝ :=
-  (LinearEquiv.piCongrLeft ℝ (fun _ ↦ ℝ) finSuccEquivLast).trans
-    ((LinearEquiv.piOptionEquivProd ℝ).trans
-      (LinearEquiv.prodComm ℝ ℝ (Fin n → ℝ)))
+private def signatureSwitchSplitIndexEquiv (p q : ℕ) :
+    Fin ((p + 1 + 1) + q) ≃ Fin ((p + 1) + q) ⊕ Fin 1 :=
+  finSumFinEquiv.symm |>.trans
+    (Equiv.sumCongr (splitLastEquiv (p + 1)) (Equiv.refl _)) |>.trans
+    (Equiv.sumAssoc (Fin (p + 1)) (Fin 1) (Fin q)) |>.trans
+    (Equiv.sumCongr (Equiv.refl _) (Equiv.sumComm (Fin 1) (Fin q))) |>.trans
+    (Equiv.sumAssoc (Fin (p + 1)) (Fin q) (Fin 1)).symm |>.trans
+    (Equiv.sumCongr finSumFinEquiv (Equiv.refl _))
 
-private def positiveAxisSplitIsometry (n : ℕ) :
-    (realCliffordForm (n + 1) 0).IsometryEquiv
-      ((realCliffordForm n 0).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))) :=
-  { splitLastCoordinateLinearEquiv n with
+private def signatureSwitchSplitLinearEquiv (p q : ℕ) :
+    (Fin ((p + 1 + 1) + q) → ℝ) ≃ₗ[ℝ]
+      (Fin ((p + 1) + q) → ℝ) × ℝ :=
+  (LinearEquiv.piCongrLeft' ℝ (fun _ : Fin ((p + 1 + 1) + q) ↦ ℝ)
+      (signatureSwitchSplitIndexEquiv p q)).trans
+    ((LinearEquiv.sumArrowLequivProdArrow _ _ ℝ ℝ).trans
+      ((LinearEquiv.refl ℝ (Fin ((p + 1) + q) → ℝ)).prodCongr
+        (LinearEquiv.piUnique ℝ fun _ : Fin 1 ↦ ℝ)))
+
+private theorem signatureSwitchSplitIndexEquiv_symm_inl_pos (p q : ℕ) (i : Fin (p + 1)) :
+    (signatureSwitchSplitIndexEquiv p q).symm
+        (Sum.inl (finSumFinEquiv (Sum.inl i))) =
+      finSumFinEquiv (Sum.inl i.castSucc) := by
+  simp [signatureSwitchSplitIndexEquiv, splitLastEquiv]
+
+private theorem signatureSwitchSplitIndexEquiv_symm_inl_neg (p q : ℕ) (i : Fin q) :
+    (signatureSwitchSplitIndexEquiv p q).symm
+        (Sum.inl (finSumFinEquiv (Sum.inr i))) =
+      finSumFinEquiv (Sum.inr i) := by
+  simp [signatureSwitchSplitIndexEquiv, splitLastEquiv]
+
+private theorem signatureSwitchSplitIndexEquiv_symm_inr (p q : ℕ) :
+    (signatureSwitchSplitIndexEquiv p q).symm (Sum.inr (0 : Fin 1)) =
+      finSumFinEquiv (Sum.inl (Fin.last (p + 1))) := by
+  apply Fin.ext
+  rfl
+
+private theorem signatureSwitchSplitWeight_inl (p q : ℕ) (i : Fin ((p + 1) + q)) :
+    realCliffordWeight (p + 1 + 1) q
+        ((signatureSwitchSplitIndexEquiv p q).symm (Sum.inl i)) =
+      realCliffordWeight (p + 1) q i := by
+  rw [← finSumFinEquiv.apply_symm_apply i]
+  rcases finSumFinEquiv.symm i with i | i
+  · rw [signatureSwitchSplitIndexEquiv_symm_inl_pos]
+    have hs :
+        (finSumFinEquiv (Sum.inl i.castSucc : Fin (p + 1 + 1) ⊕ Fin q) : ℕ) < p + 1 + 1 := by
+      exact i.castSucc.isLt
+    have ht : (finSumFinEquiv (Sum.inl i : Fin (p + 1) ⊕ Fin q) : ℕ) < p + 1 := by
+      simpa using i.isLt
+    rw [realCliffordWeight_of_lt hs, realCliffordWeight_of_lt ht]
+  · rw [signatureSwitchSplitIndexEquiv_symm_inl_neg]
+    have hs : p + 1 + 1 ≤
+        (finSumFinEquiv (Sum.inr i : Fin (p + 1 + 1) ⊕ Fin q) : ℕ) := by
+      simp
+    have ht : p + 1 ≤ (finSumFinEquiv (Sum.inr i : Fin (p + 1) ⊕ Fin q) : ℕ) := by
+      simp
+    rw [realCliffordWeight_of_le hs, realCliffordWeight_of_le ht]
+
+private theorem signatureSwitchSplitWeight_inr (p q : ℕ) (i : Fin 1) :
+    realCliffordWeight (p + 1 + 1) q
+        ((signatureSwitchSplitIndexEquiv p q).symm (Sum.inr i)) = 1 := by
+  fin_cases i
+  -- Normalize the unique coordinate before using the named index lemma.
+  change realCliffordWeight (p + 1 + 1) q
+      ((signatureSwitchSplitIndexEquiv p q).symm (Sum.inr (0 : Fin 1))) = 1
+  rw [signatureSwitchSplitIndexEquiv_symm_inr]
+  exact realCliffordWeight_of_lt (by simp)
+
+private theorem signatureSwitchSplitLinearEquiv_fst (p q : ℕ)
+    (x : Fin ((p + 1 + 1) + q) → ℝ) (i : Fin ((p + 1) + q)) :
+    (signatureSwitchSplitLinearEquiv p q x).1 i =
+      x ((signatureSwitchSplitIndexEquiv p q).symm (Sum.inl i)) := by
+  simp [signatureSwitchSplitLinearEquiv]
+
+private theorem signatureSwitchSplitLinearEquiv_snd (p q : ℕ)
+    (x : Fin ((p + 1 + 1) + q) → ℝ) :
+    (signatureSwitchSplitLinearEquiv p q x).2 =
+      x ((signatureSwitchSplitIndexEquiv p q).symm (Sum.inr 0)) := by
+  simp [signatureSwitchSplitLinearEquiv]
+
+/-- The coordinate isometry which splits the last positive coordinate from a real signature. -/
+def realCliffordPositiveSplitIsometry (p q : ℕ) :
+    (realCliffordForm (p + 1 + 1) q).IsometryEquiv
+      ((realCliffordForm (p + 1) q).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))) :=
+  { signatureSwitchSplitLinearEquiv p q with
     map_app' := by
       intro x
-      simp only [Nat.add_zero] at x ⊢
       rw [QuadraticMap.prod_apply, realCliffordForm_apply, realCliffordForm_apply,
-        Fin.sum_univ_castSucc]
-      simp only [Nat.add_zero, QuadraticMap.sq_apply]
-      congr 1
-      · apply Finset.sum_congr rfl
-        intro i hi
-        simp [splitLastCoordinateLinearEquiv, LinearEquiv.piCongrLeft,
-          LinearEquiv.piCongrLeft', LinearEquiv.piOptionEquivProd,
-          Equiv.piOptionEquivProd, Equiv.piCongrLeft']
-      · simp [splitLastCoordinateLinearEquiv, LinearEquiv.piCongrLeft,
-          LinearEquiv.piCongrLeft', LinearEquiv.piOptionEquivProd,
-          Equiv.piOptionEquivProd, Equiv.piCongrLeft'] }
+        QuadraticMap.sq_apply]
+      let y := signatureSwitchSplitLinearEquiv p q x
+      calc
+        (∑ i, realCliffordWeight (p + 1) q i * (y.1 i * y.1 i)) + y.2 * y.2 =
+            (∑ i, realCliffordWeight (p + 1) q i * (y.1 i * y.1 i)) +
+              ∑ _ : Fin 1, y.2 * y.2 := by
+          rw [Fin.sum_univ_one]
+        _ =
+            ∑ s : Fin ((p + 1) + q) ⊕ Fin 1, Sum.elim
+              (fun i => realCliffordWeight (p + 1) q i * (y.1 i * y.1 i))
+              (fun _ : Fin 1 => y.2 * y.2) s := by
+          exact (Fintype.sum_sum_type (Sum.elim
+            (fun i => realCliffordWeight (p + 1) q i * (y.1 i * y.1 i))
+            (fun _ : Fin 1 => y.2 * y.2))).symm
+        _ = ∑ i, realCliffordWeight (p + 1 + 1) q i * (x i * x i) := by
+          refine Fintype.sum_equiv (signatureSwitchSplitIndexEquiv p q).symm _ _ ?_
+          rintro (i | i)
+          · simp [y, signatureSwitchSplitLinearEquiv_fst, signatureSwitchSplitWeight_inl]
+          · fin_cases i
+            simp [y, signatureSwitchSplitLinearEquiv_snd, signatureSwitchSplitWeight_inr] }
 
-private def splitFirstCoordinateLinearEquiv (n : ℕ) :
-    (Fin (n + 1) → ℝ) ≃ₗ[ℝ] ℝ × (Fin n → ℝ) :=
-  (LinearEquiv.piCongrLeft ℝ (fun _ ↦ ℝ) (finSuccEquiv n)).trans
-    (LinearEquiv.piOptionEquivProd ℝ)
+/-- The positive coordinates retained by `realCliffordPositiveSplitIsometry`. -/
+@[simp]
+theorem realCliffordPositiveSplitIsometry_fst_pos (p q : ℕ)
+    (v : Fin ((p + 1 + 1) + q) → ℝ) (i : Fin (p + 1)) :
+    (realCliffordPositiveSplitIsometry p q v).1 (Fin.castAdd q i) =
+      v (Fin.castAdd q i.castSucc) := by
+  -- Expose the bundled map; the local `Fin` equality only aligns dependent bounds.
+  change (signatureSwitchSplitLinearEquiv p q v).1 _ = _
+  rw [signatureSwitchSplitLinearEquiv_fst]
+  rw [show Fin.castAdd q i = finSumFinEquiv (Sum.inl i) by ext; rfl,
+    signatureSwitchSplitIndexEquiv_symm_inl_pos]
+  congr 1
 
-private def negativePositiveToStandardLinearEquiv (n : ℕ) :
-    ((Fin n → ℝ) × ℝ) ≃ₗ[ℝ] (Fin (1 + n) → ℝ) :=
-  (LinearEquiv.prodComm ℝ (Fin n → ℝ) ℝ).trans
-    ((splitFirstCoordinateLinearEquiv n).symm.trans
+/-- The negative coordinates retained by `realCliffordPositiveSplitIsometry`. -/
+@[simp]
+theorem realCliffordPositiveSplitIsometry_fst_neg (p q : ℕ)
+    (v : Fin ((p + 1 + 1) + q) → ℝ) (i : Fin q) :
+    (realCliffordPositiveSplitIsometry p q v).1 (Fin.natAdd (p + 1) i) =
+      v (Fin.natAdd (p + 1 + 1) i) := by
+  -- Expose the bundled map; the local `Fin` equality only aligns dependent bounds.
+  change (signatureSwitchSplitLinearEquiv p q v).1 _ = _
+  rw [signatureSwitchSplitLinearEquiv_fst]
+  rw [show Fin.natAdd (p + 1) i = finSumFinEquiv (Sum.inr i) by ext; rfl,
+    signatureSwitchSplitIndexEquiv_symm_inl_neg]
+  congr 1
+
+/-- The last positive coordinate extracted by `realCliffordPositiveSplitIsometry`. -/
+@[simp]
+theorem realCliffordPositiveSplitIsometry_snd (p q : ℕ)
+    (v : Fin ((p + 1 + 1) + q) → ℝ) :
+    (realCliffordPositiveSplitIsometry p q v).2 =
+      v (Fin.castAdd q (Fin.last (p + 1))) := by
+  -- Expose the bundled map before applying its named second-coordinate equation.
+  change (signatureSwitchSplitLinearEquiv p q v).2 = _
+  rw [signatureSwitchSplitLinearEquiv_snd, signatureSwitchSplitIndexEquiv_symm_inr]
+  congr 1
+
+private def signatureSwitchStandardIndexEquiv (p q : ℕ) :
+    Fin ((q + 1) + (p + 1)) ≃ Fin ((p + 1) + q) ⊕ Fin 1 :=
+  finSumFinEquiv.symm |>.trans
+    (Equiv.sumCongr (splitLastEquiv q) (Equiv.refl _)) |>.trans
+    (Equiv.sumAssoc (Fin q) (Fin 1) (Fin (p + 1))) |>.trans
+    (Equiv.sumCongr (Equiv.refl _) (Equiv.sumComm (Fin 1) (Fin (p + 1)))) |>.trans
+    (Equiv.sumAssoc (Fin q) (Fin (p + 1)) (Fin 1)).symm |>.trans
+    (Equiv.sumCongr (Equiv.sumComm (Fin q) (Fin (p + 1))) (Equiv.refl _)) |>.trans
+    (Equiv.sumCongr finSumFinEquiv (Equiv.refl _))
+
+private def signatureSwitchStandardLinearEquiv (p q : ℕ) :
+    ((Fin ((p + 1) + q) → ℝ) × ℝ) ≃ₗ[ℝ]
+      (Fin ((q + 1) + (p + 1)) → ℝ) :=
+  ((LinearEquiv.refl ℝ (Fin ((p + 1) + q) → ℝ)).prodCongr
+      (LinearEquiv.piUnique ℝ fun _ : Fin 1 ↦ ℝ).symm).trans
+    ((LinearEquiv.sumArrowLequivProdArrow _ _ ℝ ℝ).symm.trans
       (LinearEquiv.piCongrLeft ℝ (fun _ ↦ ℝ)
-        (finCongr (by omega : n + 1 = 1 + n))))
+        (signatureSwitchStandardIndexEquiv p q).symm))
 
-private theorem negativePositiveToStandardLinearEquiv_zero (n : ℕ)
-    (x : (Fin n → ℝ) × ℝ) :
-    negativePositiveToStandardLinearEquiv n x 0 = x.2 := by
-  simp [negativePositiveToStandardLinearEquiv, splitFirstCoordinateLinearEquiv,
-    LinearEquiv.piCongrLeft, LinearEquiv.piCongrLeft', LinearEquiv.piOptionEquivProd,
-    Equiv.piOptionEquivProd, Equiv.piCongrLeft']
+private theorem signatureSwitchStandardIndexEquiv_symm_inl_pos (p q : ℕ) (i : Fin (p + 1)) :
+    (signatureSwitchStandardIndexEquiv p q).symm
+        (Sum.inl (finSumFinEquiv (Sum.inl i))) =
+      finSumFinEquiv (Sum.inr i) := by
+  simp [signatureSwitchStandardIndexEquiv, splitLastEquiv]
 
-private theorem negativePositiveToStandardLinearEquiv_succ (n : ℕ)
-    (x : (Fin n → ℝ) × ℝ) (i : Fin n) :
-    negativePositiveToStandardLinearEquiv n x (Fin.natAdd 1 i) = x.1 i := by
-  simp [negativePositiveToStandardLinearEquiv, splitFirstCoordinateLinearEquiv,
-    LinearEquiv.piCongrLeft, LinearEquiv.piCongrLeft', LinearEquiv.piOptionEquivProd,
-    Equiv.piOptionEquivProd, Equiv.piCongrLeft']
+private theorem signatureSwitchStandardIndexEquiv_symm_inl_neg (p q : ℕ) (i : Fin q) :
+    (signatureSwitchStandardIndexEquiv p q).symm
+        (Sum.inl (finSumFinEquiv (Sum.inr i))) =
+      finSumFinEquiv (Sum.inl i.castSucc) := by
+  simp [signatureSwitchStandardIndexEquiv, splitLastEquiv]
 
-private def negativePositiveToStandardIsometry (n : ℕ) :
-    ((-(realCliffordForm n 0)).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))).IsometryEquiv
-      (realCliffordForm 1 n) :=
-  { negativePositiveToStandardLinearEquiv n with
+private theorem signatureSwitchStandardIndexEquiv_symm_inr (p q : ℕ) :
+    (signatureSwitchStandardIndexEquiv p q).symm (Sum.inr (0 : Fin 1)) =
+      finSumFinEquiv (Sum.inl (Fin.last q)) := by
+  apply Fin.ext
+  rfl
+
+private theorem signatureSwitchStandardWeight_inl (p q : ℕ) (i : Fin ((p + 1) + q)) :
+    realCliffordWeight (q + 1) (p + 1)
+        ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inl i)) =
+      -realCliffordWeight (p + 1) q i := by
+  rw [← finSumFinEquiv.apply_symm_apply i]
+  rcases finSumFinEquiv.symm i with i | i
+  · rw [signatureSwitchStandardIndexEquiv_symm_inl_pos]
+    have hs : q + 1 ≤ (finSumFinEquiv (Sum.inr i : Fin (q + 1) ⊕ Fin (p + 1)) : ℕ) := by
+      simp
+    have ht : (finSumFinEquiv (Sum.inl i : Fin (p + 1) ⊕ Fin q) : ℕ) < p + 1 := by
+      exact i.isLt
+    rw [realCliffordWeight_of_le hs, realCliffordWeight_of_lt ht]
+  · rw [signatureSwitchStandardIndexEquiv_symm_inl_neg]
+    have hs : (finSumFinEquiv (Sum.inl i.castSucc : Fin (q + 1) ⊕ Fin (p + 1)) : ℕ) < q + 1 := by
+      exact i.castSucc.isLt
+    have ht : p + 1 ≤ (finSumFinEquiv (Sum.inr i : Fin (p + 1) ⊕ Fin q) : ℕ) := by
+      simp
+    rw [realCliffordWeight_of_lt hs, realCliffordWeight_of_le ht]
+    norm_num
+
+private theorem signatureSwitchStandardWeight_inr (p q : ℕ) (i : Fin 1) :
+    realCliffordWeight (q + 1) (p + 1)
+        ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inr i)) = 1 := by
+  fin_cases i
+  -- Normalize the unique coordinate before using the named index lemma.
+  change realCliffordWeight (q + 1) (p + 1)
+      ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inr (0 : Fin 1))) = 1
+  rw [signatureSwitchStandardIndexEquiv_symm_inr]
+  exact realCliffordWeight_of_lt (by simp)
+
+private theorem signatureSwitchStandardLinearEquiv_inl (p q : ℕ)
+    (x : Fin ((p + 1) + q) → ℝ) (r : ℝ) (i : Fin ((p + 1) + q)) :
+    signatureSwitchStandardLinearEquiv p q (x, r)
+        ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inl i)) = x i := by
+  simp [signatureSwitchStandardLinearEquiv, LinearEquiv.piCongrLeft,
+    LinearEquiv.piCongrLeft', Equiv.piCongrLeft']
+
+private theorem signatureSwitchStandardLinearEquiv_inr (p q : ℕ)
+    (x : Fin ((p + 1) + q) → ℝ) (r : ℝ) (i : Fin 1) :
+    signatureSwitchStandardLinearEquiv p q (x, r)
+        ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inr i)) = r := by
+  fin_cases i
+  -- Normalize the unique coordinate before using the linear-equivalence equation.
+  change signatureSwitchStandardLinearEquiv p q (x, r)
+      ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inr (0 : Fin 1))) = r
+  simp [signatureSwitchStandardLinearEquiv, LinearEquiv.piCongrLeft,
+    LinearEquiv.piCongrLeft', Equiv.piCongrLeft']
+
+/-- The coordinate isometry which turns the sign-switched form into the standard signature. -/
+def realCliffordSignSwitchStandardIsometry (p q : ℕ) :
+    ((-(realCliffordForm (p + 1) q)).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))).IsometryEquiv
+      (realCliffordForm (q + 1) (p + 1)) :=
+  { signatureSwitchStandardLinearEquiv p q with
     map_app' := by
       rintro ⟨x, r⟩
-      simp only [Nat.add_zero] at x ⊢
       rw [realCliffordForm_apply, QuadraticMap.prod_apply, neg_apply,
-        realCliffordForm_apply]
-      simp only [QuadraticMap.sq_apply]
-      let y := negativePositiveToStandardLinearEquiv n (x, r)
+        realCliffordForm_apply, QuadraticMap.sq_apply]
+      let y := signatureSwitchStandardLinearEquiv p q (x, r)
       calc
-        (∑ i, realCliffordWeight 1 n i * (y i * y i)) =
-            ∑ s : Fin 1 ⊕ Fin n,
-              realCliffordWeight 1 n (finSumFinEquiv s) *
-                (y (finSumFinEquiv s) * y (finSumFinEquiv s)) := by
-          exact Fintype.sum_equiv finSumFinEquiv.symm _ _
-            (fun i ↦ by rw [Equiv.apply_symm_apply])
-        _ = -(∑ i, x i * x i) + r * r := by
-          have hzero : y (Fin.castAdd n (0 : Fin 1)) = r := by
-            -- Identify the dependent `Fin` casts by their common underlying value zero.
-            rw [show Fin.castAdd n (0 : Fin 1) = (0 : Fin (1 + n)) by ext; simp]
-            exact negativePositiveToStandardLinearEquiv_zero n (x, r)
-          rw [Fintype.sum_sum_type]
-          simp [hzero, y, negativePositiveToStandardLinearEquiv_succ]
-          abel
-        _ = -(∑ i, realCliffordWeight n 0 i * (x i * x i)) + r * r := by
-          congr 2
-          apply Finset.sum_congr rfl
-          intro i hi
-          rw [realCliffordWeight_of_lt (by simp)]
-          simp only [one_mul] }
+        (∑ i, realCliffordWeight (q + 1) (p + 1) i * (y i * y i)) =
+            ∑ s : Fin ((p + 1) + q) ⊕ Fin 1,
+              realCliffordWeight (q + 1) (p + 1)
+                ((signatureSwitchStandardIndexEquiv p q).symm s) *
+                (y ((signatureSwitchStandardIndexEquiv p q).symm s) *
+                  y ((signatureSwitchStandardIndexEquiv p q).symm s)) := by
+          exact Fintype.sum_equiv (signatureSwitchStandardIndexEquiv p q) _ _
+            (fun i ↦ by rw [Equiv.symm_apply_apply])
+        _ = -(∑ i, realCliffordWeight (p + 1) q i * (x i * x i)) + r * r := by
+          dsimp only [y]
+          simp only [Fintype.sum_sum_type, signatureSwitchStandardWeight_inl,
+            signatureSwitchStandardWeight_inr, signatureSwitchStandardLinearEquiv_inl,
+            signatureSwitchStandardLinearEquiv_inr, Fin.sum_univ_one, neg_mul,
+            one_mul, ← Finset.sum_neg_distrib] }
+
+/-- Negated negative coordinates become positive coordinates under
+`realCliffordSignSwitchStandardIsometry`. -/
+@[simp]
+theorem realCliffordSignSwitchStandardIsometry_pos (p q : ℕ)
+    (x : Fin ((p + 1) + q) → ℝ) (r : ℝ) (i : Fin q) :
+    realCliffordSignSwitchStandardIsometry p q (x, r)
+        (Fin.castAdd (p + 1) (Fin.castSucc i)) = x (Fin.natAdd (p + 1) i) := by
+  -- Expose the bundled reindexing map; the local `Fin` equality aligns its sum blocks.
+  change signatureSwitchStandardLinearEquiv p q (x, r) _ = _
+  rw [show Fin.castAdd (p + 1) (Fin.castSucc i) =
+      (signatureSwitchStandardIndexEquiv p q).symm
+        (Sum.inl (finSumFinEquiv (Sum.inr i))) by
+        rw [signatureSwitchStandardIndexEquiv_symm_inl_neg]
+        congr 1,
+    signatureSwitchStandardLinearEquiv_inl]
+  congr 1
+
+/-- The new positive line is the last positive coordinate under
+`realCliffordSignSwitchStandardIsometry`. -/
+@[simp]
+theorem realCliffordSignSwitchStandardIsometry_last_positive (p q : ℕ)
+    (x : Fin ((p + 1) + q) → ℝ) (r : ℝ) :
+    realCliffordSignSwitchStandardIsometry p q (x, r)
+        (Fin.castAdd (p + 1) (Fin.last q)) = r := by
+  -- Expose the bundled reindexing map; the local `Fin` equality aligns its final block.
+  change signatureSwitchStandardLinearEquiv p q (x, r) _ = _
+  rw [show Fin.castAdd (p + 1) (Fin.last q) =
+      (signatureSwitchStandardIndexEquiv p q).symm (Sum.inr 0) by
+        rw [signatureSwitchStandardIndexEquiv_symm_inr]
+        congr 1,
+    signatureSwitchStandardLinearEquiv_inr]
+
+/-- Negated positive coordinates become negative coordinates under
+`realCliffordSignSwitchStandardIsometry`. -/
+@[simp]
+theorem realCliffordSignSwitchStandardIsometry_neg (p q : ℕ)
+    (x : Fin ((p + 1) + q) → ℝ) (r : ℝ) (i : Fin (p + 1)) :
+    realCliffordSignSwitchStandardIsometry p q (x, r)
+        (Fin.natAdd (q + 1) i) = x (Fin.castAdd q i) := by
+  -- Expose the bundled reindexing map; the local `Fin` equality aligns its sum blocks.
+  change signatureSwitchStandardLinearEquiv p q (x, r) _ = _
+  rw [show Fin.natAdd (q + 1) i =
+      (signatureSwitchStandardIndexEquiv p q).symm
+        (Sum.inl (finSumFinEquiv (Sum.inl i))) by
+        rw [signatureSwitchStandardIndexEquiv_symm_inl_pos]
+        congr 1,
+    signatureSwitchStandardLinearEquiv_inl]
+  congr 1
+
+/-- One sign switch followed by the hyperbolic Bott step gives the signature-switch recurrence
+`Cliff(p + 2, q) ≅ Cliff(q, p) ⊗ M₂(ℝ)`. -/
+noncomputable def realCliffordSignatureSwitchRecurrenceEquiv (p q : ℕ) :
+    _root_.CliffordAlgebra (realCliffordForm (p + 1 + 1) q) ≃ₐ[ℝ]
+      _root_.CliffordAlgebra (realCliffordForm q p) ⊗[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
+  (_root_.CliffordAlgebra.equivOfIsometry (realCliffordPositiveSplitIsometry p q)).trans
+    ((CliffordAlgebra.signSwitchEquiv (realCliffordForm (p + 1) q)).trans
+      ((_root_.CliffordAlgebra.equivOfIsometry
+        (realCliffordSignSwitchStandardIsometry p q)).trans
+          (realCliffordBottEquiv q p)))
+
+/-- The signature-switch recurrence sends a Clifford generator through its two coordinate
+isometries and the sign-switch generator formula. -/
+@[simp]
+theorem realCliffordSignatureSwitchRecurrenceEquiv_ι (p q : ℕ)
+    (v : Fin ((p + 1 + 1) + q) → ℝ) :
+    realCliffordSignatureSwitchRecurrenceEquiv p q (_root_.CliffordAlgebra.ι _ v) =
+      realCliffordBottEquiv q p (_root_.CliffordAlgebra.ι _
+        (realCliffordSignSwitchStandardIsometry p q (0, 1))) *
+        realCliffordBottEquiv q p (_root_.CliffordAlgebra.ι _
+          (realCliffordSignSwitchStandardIsometry p q
+            ((realCliffordPositiveSplitIsometry p q v).1, 0))) +
+          (realCliffordPositiveSplitIsometry p q v).2 •
+            realCliffordBottEquiv q p (_root_.CliffordAlgebra.ι _
+              (realCliffordSignSwitchStandardIsometry p q (0, 1))) := by
+  rw [realCliffordSignatureSwitchRecurrenceEquiv, AlgEquiv.trans_apply,
+    _root_.CliffordAlgebra.equivOfIsometry_apply,
+    _root_.CliffordAlgebra.map_apply_ι, AlgEquiv.trans_apply,
+    CliffordAlgebra.signSwitchEquiv_ι, map_add, map_mul, map_smul,
+    AlgEquiv.trans_apply, _root_.CliffordAlgebra.equivOfIsometry_apply,
+    _root_.CliffordAlgebra.map_apply_ι]
+  simp only [AlgEquiv.trans_apply, _root_.CliffordAlgebra.equivOfIsometry_apply,
+    _root_.CliffordAlgebra.map_apply_ι, QuadraticMap.IsometryEquiv.toIsometry]
+  rfl
 
 /-- Combining one sign switch with the hyperbolic Bott step gives the positive-axis recurrence
 `Cliff(n + 2, 0) ≅ Cliff(0, n) ⊗ M₂(ℝ)`. -/
 noncomputable def realCliffordPositiveAxisRecurrenceEquiv (n : ℕ) :
     _root_.CliffordAlgebra (realCliffordForm (n + 2) 0) ≃ₐ[ℝ]
       _root_.CliffordAlgebra (realCliffordForm 0 n) ⊗[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
-  (_root_.CliffordAlgebra.equivOfIsometry (positiveAxisSplitIsometry (n + 1))).trans
-    ((CliffordAlgebra.signSwitchEquiv (realCliffordForm (n + 1) 0)).trans
-      ((_root_.CliffordAlgebra.equivOfIsometry
-        (negativePositiveToStandardIsometry (n + 1))).trans
-          (realCliffordBottEquiv 0 n)))
+  realCliffordSignatureSwitchRecurrenceEquiv n 0
+
+/-- The positive-axis recurrence on a generator, as the `q = 0` signature-switch formula. -/
+@[simp]
+theorem realCliffordPositiveAxisRecurrenceEquiv_ι (n : ℕ) (v : Fin (n + 2) → ℝ) :
+    realCliffordPositiveAxisRecurrenceEquiv n (_root_.CliffordAlgebra.ι _ v) =
+      realCliffordBottEquiv 0 n (_root_.CliffordAlgebra.ι _
+        (realCliffordSignSwitchStandardIsometry n 0 (0, 1))) *
+        realCliffordBottEquiv 0 n (_root_.CliffordAlgebra.ι _
+          (realCliffordSignSwitchStandardIsometry n 0
+            ((realCliffordPositiveSplitIsometry n 0 v).1, 0))) +
+          (realCliffordPositiveSplitIsometry n 0 v).2 •
+            realCliffordBottEquiv 0 n (_root_.CliffordAlgebra.ι _
+              (realCliffordSignSwitchStandardIsometry n 0 (0, 1))) := by
+  simpa only [realCliffordPositiveAxisRecurrenceEquiv] using
+    realCliffordSignatureSwitchRecurrenceEquiv_ι n 0 v
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -15,8 +15,10 @@ import Mathlib.LinearAlgebra.Matrix.Unique
 /-!
 # Hyperbolic Bott periodicity for real Clifford algebras
 
-This file proves the `(1, 1)` periodicity step for Clifford algebras. Adding one positive and one
-negative generator is equivalent to tensoring with two-by-two real matrices.
+This file proves the `(1, 1)` periodicity step for Clifford algebras: adding one positive and one
+negative generator is equivalent to tensoring with two-by-two real matrices. It also derives the
+signature-switch recurrence `Cliff(p + 2, q) ≅ Cliff(q, p) ⊗ M₂(ℝ)` from
+`TauCeti.CliffordAlgebra.signSwitchEquiv`.
 
 ## Main results
 
@@ -731,24 +733,24 @@ theorem realCliffordBottIterEquiv_succ (p q n : ℕ) :
 /-! ### Signature-switch recurrence -/
 
 private def signatureSwitchSplitIndexEquiv (p q : ℕ) :
-    Fin ((p + 1 + 1) + q) ≃ Fin ((p + 1) + q) ⊕ Fin 1 :=
+    Fin ((p + 1) + q) ≃ Fin (p + q) ⊕ Fin 1 :=
   finSumFinEquiv.symm |>.trans
-    (Equiv.sumCongr (splitLastEquiv (p + 1)) (Equiv.refl _)) |>.trans
-    (Equiv.sumAssoc (Fin (p + 1)) (Fin 1) (Fin q)) |>.trans
+    (Equiv.sumCongr (splitLastEquiv p) (Equiv.refl _)) |>.trans
+    (Equiv.sumAssoc (Fin p) (Fin 1) (Fin q)) |>.trans
     (Equiv.sumCongr (Equiv.refl _) (Equiv.sumComm (Fin 1) (Fin q))) |>.trans
-    (Equiv.sumAssoc (Fin (p + 1)) (Fin q) (Fin 1)).symm |>.trans
+    (Equiv.sumAssoc (Fin p) (Fin q) (Fin 1)).symm |>.trans
     (Equiv.sumCongr finSumFinEquiv (Equiv.refl _))
 
 private def signatureSwitchSplitLinearEquiv (p q : ℕ) :
-    (Fin ((p + 1 + 1) + q) → ℝ) ≃ₗ[ℝ]
-      (Fin ((p + 1) + q) → ℝ) × ℝ :=
-  (LinearEquiv.piCongrLeft' ℝ (fun _ : Fin ((p + 1 + 1) + q) ↦ ℝ)
+    (Fin ((p + 1) + q) → ℝ) ≃ₗ[ℝ]
+      (Fin (p + q) → ℝ) × ℝ :=
+  (LinearEquiv.piCongrLeft' ℝ (fun _ : Fin ((p + 1) + q) ↦ ℝ)
       (signatureSwitchSplitIndexEquiv p q)).trans
     ((LinearEquiv.sumArrowLequivProdArrow _ _ ℝ ℝ).trans
-      ((LinearEquiv.refl ℝ (Fin ((p + 1) + q) → ℝ)).prodCongr
+      ((LinearEquiv.refl ℝ (Fin (p + q) → ℝ)).prodCongr
         (LinearEquiv.piUnique ℝ fun _ : Fin 1 ↦ ℝ)))
 
-private theorem signatureSwitchSplitIndexEquiv_symm_inl_pos (p q : ℕ) (i : Fin (p + 1)) :
+private theorem signatureSwitchSplitIndexEquiv_symm_inl_pos (p q : ℕ) (i : Fin p) :
     (signatureSwitchSplitIndexEquiv p q).symm
         (Sum.inl (finSumFinEquiv (Sum.inl i))) =
       finSumFinEquiv (Sum.inl i.castSucc) := by
@@ -762,56 +764,56 @@ private theorem signatureSwitchSplitIndexEquiv_symm_inl_neg (p q : ℕ) (i : Fin
 
 private theorem signatureSwitchSplitIndexEquiv_symm_inr (p q : ℕ) :
     (signatureSwitchSplitIndexEquiv p q).symm (Sum.inr (0 : Fin 1)) =
-      finSumFinEquiv (Sum.inl (Fin.last (p + 1))) := by
+      finSumFinEquiv (Sum.inl (Fin.last p)) := by
   simp [signatureSwitchSplitIndexEquiv, splitLastEquiv]
 
-private theorem signatureSwitchSplitWeight_inl (p q : ℕ) (i : Fin ((p + 1) + q)) :
-    realCliffordWeight (p + 1 + 1) q
+private theorem signatureSwitchSplitWeight_inl (p q : ℕ) (i : Fin (p + q)) :
+    realCliffordWeight (p + 1) q
         ((signatureSwitchSplitIndexEquiv p q).symm (Sum.inl i)) =
-      realCliffordWeight (p + 1) q i := by
+      realCliffordWeight p q i := by
   rw [← finSumFinEquiv.apply_symm_apply i]
   rcases finSumFinEquiv.symm i with i | i
   · rw [signatureSwitchSplitIndexEquiv_symm_inl_pos]
     have hs :
-        (finSumFinEquiv (Sum.inl i.castSucc : Fin (p + 1 + 1) ⊕ Fin q) : ℕ) < p + 1 + 1 := by
-      exact i.castSucc.isLt
-    have ht : (finSumFinEquiv (Sum.inl i : Fin (p + 1) ⊕ Fin q) : ℕ) < p + 1 := by
-      simpa using i.isLt
+        (finSumFinEquiv (Sum.inl i.castSucc : Fin (p + 1) ⊕ Fin q) : ℕ) < p + 1 := by
+      simp
+    have ht : (finSumFinEquiv (Sum.inl i : Fin p ⊕ Fin q) : ℕ) < p := by
+      simp
     rw [realCliffordWeight_of_lt hs, realCliffordWeight_of_lt ht]
   · rw [signatureSwitchSplitIndexEquiv_symm_inl_neg]
-    have hs : p + 1 + 1 ≤
-        (finSumFinEquiv (Sum.inr i : Fin (p + 1 + 1) ⊕ Fin q) : ℕ) := by
+    have hs : p + 1 ≤
+        (finSumFinEquiv (Sum.inr i : Fin (p + 1) ⊕ Fin q) : ℕ) := by
       simp
-    have ht : p + 1 ≤ (finSumFinEquiv (Sum.inr i : Fin (p + 1) ⊕ Fin q) : ℕ) := by
+    have ht : p ≤ (finSumFinEquiv (Sum.inr i : Fin p ⊕ Fin q) : ℕ) := by
       simp
     rw [realCliffordWeight_of_le hs, realCliffordWeight_of_le ht]
 
 private theorem signatureSwitchSplitWeight_inr (p q : ℕ) (i : Fin 1) :
-    realCliffordWeight (p + 1 + 1) q
+    realCliffordWeight (p + 1) q
         ((signatureSwitchSplitIndexEquiv p q).symm (Sum.inr i)) = 1 := by
   fin_cases i
   -- Normalize the unique coordinate before using the named index lemma.
-  change realCliffordWeight (p + 1 + 1) q
+  change realCliffordWeight (p + 1) q
       ((signatureSwitchSplitIndexEquiv p q).symm (Sum.inr (0 : Fin 1))) = 1
   rw [signatureSwitchSplitIndexEquiv_symm_inr]
   exact realCliffordWeight_of_lt (by simp)
 
 private theorem signatureSwitchSplitLinearEquiv_fst (p q : ℕ)
-    (x : Fin ((p + 1 + 1) + q) → ℝ) (i : Fin ((p + 1) + q)) :
+    (x : Fin ((p + 1) + q) → ℝ) (i : Fin (p + q)) :
     (signatureSwitchSplitLinearEquiv p q x).1 i =
       x ((signatureSwitchSplitIndexEquiv p q).symm (Sum.inl i)) := by
   simp [signatureSwitchSplitLinearEquiv]
 
 private theorem signatureSwitchSplitLinearEquiv_snd (p q : ℕ)
-    (x : Fin ((p + 1 + 1) + q) → ℝ) :
+    (x : Fin ((p + 1) + q) → ℝ) :
     (signatureSwitchSplitLinearEquiv p q x).2 =
       x ((signatureSwitchSplitIndexEquiv p q).symm (Sum.inr 0)) := by
   simp [signatureSwitchSplitLinearEquiv]
 
 /-- The coordinate isometry which splits the last positive coordinate from a real signature. -/
 def realCliffordPositiveSplitIsometry (p q : ℕ) :
-    (realCliffordForm (p + 1 + 1) q).IsometryEquiv
-      ((realCliffordForm (p + 1) q).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))) :=
+    (realCliffordForm (p + 1) q).IsometryEquiv
+      ((realCliffordForm p q).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))) :=
   { signatureSwitchSplitLinearEquiv p q with
     map_app' := by
       intro x
@@ -819,18 +821,18 @@ def realCliffordPositiveSplitIsometry (p q : ℕ) :
         QuadraticMap.sq_apply]
       let y := signatureSwitchSplitLinearEquiv p q x
       calc
-        (∑ i, realCliffordWeight (p + 1) q i * (y.1 i * y.1 i)) + y.2 * y.2 =
-            (∑ i, realCliffordWeight (p + 1) q i * (y.1 i * y.1 i)) +
+        (∑ i, realCliffordWeight p q i * (y.1 i * y.1 i)) + y.2 * y.2 =
+            (∑ i, realCliffordWeight p q i * (y.1 i * y.1 i)) +
               ∑ _ : Fin 1, y.2 * y.2 := by
           rw [Fin.sum_univ_one]
         _ =
-            ∑ s : Fin ((p + 1) + q) ⊕ Fin 1, Sum.elim
-              (fun i => realCliffordWeight (p + 1) q i * (y.1 i * y.1 i))
+            ∑ s : Fin (p + q) ⊕ Fin 1, Sum.elim
+              (fun i => realCliffordWeight p q i * (y.1 i * y.1 i))
               (fun _ : Fin 1 => y.2 * y.2) s := by
           exact (Fintype.sum_sum_type (Sum.elim
-            (fun i => realCliffordWeight (p + 1) q i * (y.1 i * y.1 i))
+            (fun i => realCliffordWeight p q i * (y.1 i * y.1 i))
             (fun _ : Fin 1 => y.2 * y.2))).symm
-        _ = ∑ i, realCliffordWeight (p + 1 + 1) q i * (x i * x i) := by
+        _ = ∑ i, realCliffordWeight (p + 1) q i * (x i * x i) := by
           refine Fintype.sum_equiv (signatureSwitchSplitIndexEquiv p q).symm _ _ ?_
           rintro (i | i)
           · simp [y, signatureSwitchSplitLinearEquiv_fst, signatureSwitchSplitWeight_inl]
@@ -840,224 +842,196 @@ def realCliffordPositiveSplitIsometry (p q : ℕ) :
 /-- The positive coordinates retained by `realCliffordPositiveSplitIsometry`. -/
 @[simp]
 theorem realCliffordPositiveSplitIsometry_fst_pos (p q : ℕ)
-    (v : Fin ((p + 1 + 1) + q) → ℝ) (i : Fin (p + 1)) :
+    (v : Fin ((p + 1) + q) → ℝ) (i : Fin p) :
     (realCliffordPositiveSplitIsometry p q v).1 (Fin.castAdd q i) =
       v (Fin.castAdd q i.castSucc) := by
   -- Expose the bundled map; the local `Fin` equality only aligns dependent bounds.
   change (signatureSwitchSplitLinearEquiv p q v).1 _ = _
-  rw [signatureSwitchSplitLinearEquiv_fst]
-  rw [show Fin.castAdd q i = finSumFinEquiv (Sum.inl i) by ext; rfl,
-    signatureSwitchSplitIndexEquiv_symm_inl_pos]
-  congr 1
+  rw [signatureSwitchSplitLinearEquiv_fst, ← finSumFinEquiv_apply_left,
+    signatureSwitchSplitIndexEquiv_symm_inl_pos, finSumFinEquiv_apply_left]
 
 /-- The negative coordinates retained by `realCliffordPositiveSplitIsometry`. -/
 @[simp]
 theorem realCliffordPositiveSplitIsometry_fst_neg (p q : ℕ)
-    (v : Fin ((p + 1 + 1) + q) → ℝ) (i : Fin q) :
-    (realCliffordPositiveSplitIsometry p q v).1 (Fin.natAdd (p + 1) i) =
-      v (Fin.natAdd (p + 1 + 1) i) := by
+    (v : Fin ((p + 1) + q) → ℝ) (i : Fin q) :
+    (realCliffordPositiveSplitIsometry p q v).1 (Fin.natAdd p i) =
+      v (Fin.natAdd (p + 1) i) := by
   -- Expose the bundled map; the local `Fin` equality only aligns dependent bounds.
   change (signatureSwitchSplitLinearEquiv p q v).1 _ = _
-  rw [signatureSwitchSplitLinearEquiv_fst]
-  rw [show Fin.natAdd (p + 1) i = finSumFinEquiv (Sum.inr i) by ext; rfl,
-    signatureSwitchSplitIndexEquiv_symm_inl_neg]
-  congr 1
+  rw [signatureSwitchSplitLinearEquiv_fst, ← finSumFinEquiv_apply_right,
+    signatureSwitchSplitIndexEquiv_symm_inl_neg, finSumFinEquiv_apply_right]
 
 /-- The last positive coordinate extracted by `realCliffordPositiveSplitIsometry`. -/
 @[simp]
 theorem realCliffordPositiveSplitIsometry_snd (p q : ℕ)
-    (v : Fin ((p + 1 + 1) + q) → ℝ) :
+    (v : Fin ((p + 1) + q) → ℝ) :
     (realCliffordPositiveSplitIsometry p q v).2 =
-      v (Fin.castAdd q (Fin.last (p + 1))) := by
+      v (Fin.castAdd q (Fin.last p)) := by
   -- Expose the bundled map before applying its named second-coordinate equation.
   change (signatureSwitchSplitLinearEquiv p q v).2 = _
-  rw [signatureSwitchSplitLinearEquiv_snd, signatureSwitchSplitIndexEquiv_symm_inr]
-  congr 1
+  rw [signatureSwitchSplitLinearEquiv_snd, signatureSwitchSplitIndexEquiv_symm_inr,
+    finSumFinEquiv_apply_left]
 
-private def signatureSwitchStandardIndexEquiv (p q : ℕ) :
-    Fin ((q + 1) + (p + 1)) ≃ Fin ((p + 1) + q) ⊕ Fin 1 :=
+private def signatureSwitchNegIndexEquiv (p q : ℕ) : Fin (p + q) ≃ Fin (q + p) :=
   finSumFinEquiv.symm |>.trans
-    (Equiv.sumCongr (splitLastEquiv q) (Equiv.refl _)) |>.trans
-    (Equiv.sumAssoc (Fin q) (Fin 1) (Fin (p + 1))) |>.trans
-    (Equiv.sumCongr (Equiv.refl _) (Equiv.sumComm (Fin 1) (Fin (p + 1)))) |>.trans
-    (Equiv.sumAssoc (Fin q) (Fin (p + 1)) (Fin 1)).symm |>.trans
-    (Equiv.sumCongr (Equiv.sumComm (Fin q) (Fin (p + 1))) (Equiv.refl _)) |>.trans
-    (Equiv.sumCongr finSumFinEquiv (Equiv.refl _))
+    (Equiv.sumComm (Fin p) (Fin q)) |>.trans
+    finSumFinEquiv
 
-private def signatureSwitchStandardLinearEquiv (p q : ℕ) :
-    ((Fin ((p + 1) + q) → ℝ) × ℝ) ≃ₗ[ℝ]
-      (Fin ((q + 1) + (p + 1)) → ℝ) :=
-  ((LinearEquiv.refl ℝ (Fin ((p + 1) + q) → ℝ)).prodCongr
-      (LinearEquiv.piUnique ℝ fun _ : Fin 1 ↦ ℝ).symm).trans
-    ((LinearEquiv.sumArrowLequivProdArrow _ _ ℝ ℝ).symm.trans
-      (LinearEquiv.piCongrLeft ℝ (fun _ ↦ ℝ)
-        (signatureSwitchStandardIndexEquiv p q).symm))
-
-private theorem signatureSwitchStandardIndexEquiv_symm_inl_pos (p q : ℕ) (i : Fin (p + 1)) :
-    (signatureSwitchStandardIndexEquiv p q).symm
-        (Sum.inl (finSumFinEquiv (Sum.inl i))) =
+private theorem signatureSwitchNegIndexEquiv_inl (p q : ℕ) (i : Fin p) :
+    signatureSwitchNegIndexEquiv p q (finSumFinEquiv (Sum.inl i)) =
       finSumFinEquiv (Sum.inr i) := by
-  simp [signatureSwitchStandardIndexEquiv, splitLastEquiv]
+  simp [signatureSwitchNegIndexEquiv]
 
-private theorem signatureSwitchStandardIndexEquiv_symm_inl_neg (p q : ℕ) (i : Fin q) :
-    (signatureSwitchStandardIndexEquiv p q).symm
-        (Sum.inl (finSumFinEquiv (Sum.inr i))) =
-      finSumFinEquiv (Sum.inl i.castSucc) := by
-  simp [signatureSwitchStandardIndexEquiv, splitLastEquiv]
+private theorem signatureSwitchNegIndexEquiv_inr (p q : ℕ) (i : Fin q) :
+    signatureSwitchNegIndexEquiv p q (finSumFinEquiv (Sum.inr i)) =
+      finSumFinEquiv (Sum.inl i) := by
+  simp [signatureSwitchNegIndexEquiv]
 
-private theorem signatureSwitchStandardIndexEquiv_symm_inr (p q : ℕ) :
-    (signatureSwitchStandardIndexEquiv p q).symm (Sum.inr (0 : Fin 1)) =
-      finSumFinEquiv (Sum.inl (Fin.last q)) := by
-  simp [signatureSwitchStandardIndexEquiv, splitLastEquiv]
+private def signatureSwitchNegLinearEquiv (p q : ℕ) :
+    (Fin (p + q) → ℝ) ≃ₗ[ℝ] (Fin (q + p) → ℝ) :=
+  LinearEquiv.piCongrLeft' ℝ (fun _ : Fin (p + q) ↦ ℝ) (signatureSwitchNegIndexEquiv p q)
 
-private theorem signatureSwitchStandardWeight_inl (p q : ℕ) (i : Fin ((p + 1) + q)) :
-    realCliffordWeight (q + 1) (p + 1)
-        ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inl i)) =
-      -realCliffordWeight (p + 1) q i := by
+private theorem signatureSwitchNegWeight (p q : ℕ) (i : Fin (p + q)) :
+    realCliffordWeight q p (signatureSwitchNegIndexEquiv p q i) =
+      -realCliffordWeight p q i := by
   rw [← finSumFinEquiv.apply_symm_apply i]
   rcases finSumFinEquiv.symm i with i | i
-  · rw [signatureSwitchStandardIndexEquiv_symm_inl_pos]
-    have hs : q + 1 ≤ (finSumFinEquiv (Sum.inr i : Fin (q + 1) ⊕ Fin (p + 1)) : ℕ) := by
-      simp
-    have ht : (finSumFinEquiv (Sum.inl i : Fin (p + 1) ⊕ Fin q) : ℕ) < p + 1 := by
-      exact i.isLt
-    rw [realCliffordWeight_of_le hs, realCliffordWeight_of_lt ht]
-  · rw [signatureSwitchStandardIndexEquiv_symm_inl_neg]
-    have hs : (finSumFinEquiv (Sum.inl i.castSucc : Fin (q + 1) ⊕ Fin (p + 1)) : ℕ) < q + 1 := by
-      exact i.castSucc.isLt
-    have ht : p + 1 ≤ (finSumFinEquiv (Sum.inr i : Fin (p + 1) ⊕ Fin q) : ℕ) := by
-      simp
-    rw [realCliffordWeight_of_lt hs, realCliffordWeight_of_le ht]
+  · simp only [signatureSwitchNegIndexEquiv, Equiv.trans_apply, Equiv.sumComm_apply,
+      finSumFinEquiv_apply_left]
+    rw [realCliffordWeight_of_le (by simp), realCliffordWeight_of_lt (by simp)]
+  · simp only [signatureSwitchNegIndexEquiv, Equiv.trans_apply, Equiv.sumComm_apply,
+      finSumFinEquiv_apply_right]
+    rw [realCliffordWeight_of_lt (by simp), realCliffordWeight_of_le (by simp)]
     norm_num
 
-private theorem signatureSwitchStandardWeight_inr (p q : ℕ) (i : Fin 1) :
-    realCliffordWeight (q + 1) (p + 1)
-        ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inr i)) = 1 := by
-  fin_cases i
-  -- Normalize the unique coordinate before using the named index lemma.
-  change realCliffordWeight (q + 1) (p + 1)
-      ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inr (0 : Fin 1))) = 1
-  rw [signatureSwitchStandardIndexEquiv_symm_inr]
-  exact realCliffordWeight_of_lt (by simp)
+private theorem signatureSwitchNegLinearEquiv_apply (p q : ℕ) (x : Fin (p + q) → ℝ)
+    (i : Fin (p + q)) :
+    signatureSwitchNegLinearEquiv p q x (signatureSwitchNegIndexEquiv p q i) = x i := by
+  rw [signatureSwitchNegLinearEquiv, LinearEquiv.piCongrLeft'_apply, Equiv.symm_apply_apply]
 
-private theorem signatureSwitchStandardLinearEquiv_inl (p q : ℕ)
-    (x : Fin ((p + 1) + q) → ℝ) (r : ℝ) (i : Fin ((p + 1) + q)) :
-    signatureSwitchStandardLinearEquiv p q (x, r)
-        ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inl i)) = x i := by
-  simp [signatureSwitchStandardLinearEquiv, LinearEquiv.piCongrLeft,
-    LinearEquiv.piCongrLeft', Equiv.piCongrLeft']
+/-- Negating a real signature form swaps its positive and negative coordinates. -/
+def realCliffordFormNegIsometry (p q : ℕ) :
+    (-(realCliffordForm p q)).IsometryEquiv (realCliffordForm q p) :=
+  { signatureSwitchNegLinearEquiv p q with
+    map_app' := by
+      intro x
+      rw [realCliffordForm_apply, neg_apply, realCliffordForm_apply]
+      let y := signatureSwitchNegLinearEquiv p q x
+      calc
+        (∑ i, realCliffordWeight q p i * (y i * y i)) =
+            ∑ i, realCliffordWeight q p (signatureSwitchNegIndexEquiv p q i) *
+              (y (signatureSwitchNegIndexEquiv p q i) *
+                y (signatureSwitchNegIndexEquiv p q i)) := by
+          exact (Fintype.sum_equiv (signatureSwitchNegIndexEquiv p q)
+            (fun i ↦ realCliffordWeight q p (signatureSwitchNegIndexEquiv p q i) *
+              (y (signatureSwitchNegIndexEquiv p q i) *
+                y (signatureSwitchNegIndexEquiv p q i)))
+            (fun i ↦ realCliffordWeight q p i * (y i * y i))
+            (fun _ ↦ rfl)).symm
+        _ = -(∑ i, realCliffordWeight p q i * (x i * x i)) := by
+          dsimp only [y]
+          simp only [signatureSwitchNegWeight, signatureSwitchNegLinearEquiv_apply, neg_mul,
+            ← Finset.sum_neg_distrib] }
 
-private theorem signatureSwitchStandardLinearEquiv_inr (p q : ℕ)
-    (x : Fin ((p + 1) + q) → ℝ) (r : ℝ) (i : Fin 1) :
-    signatureSwitchStandardLinearEquiv p q (x, r)
-        ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inr i)) = r := by
-  fin_cases i
-  -- Normalize the unique coordinate before using the linear-equivalence equation.
-  change signatureSwitchStandardLinearEquiv p q (x, r)
-      ((signatureSwitchStandardIndexEquiv p q).symm (Sum.inr (0 : Fin 1))) = r
-  simp [signatureSwitchStandardLinearEquiv, LinearEquiv.piCongrLeft,
-    LinearEquiv.piCongrLeft', Equiv.piCongrLeft']
+/-- Negated negative coordinates become positive coordinates under
+`realCliffordFormNegIsometry`. -/
+@[simp]
+theorem realCliffordFormNegIsometry_pos_of_neg (p q : ℕ)
+    (x : Fin (p + q) → ℝ) (i : Fin q) :
+    realCliffordFormNegIsometry p q x (Fin.castAdd p i) = x (Fin.natAdd p i) := by
+  change signatureSwitchNegLinearEquiv p q x _ = _
+  rw [← finSumFinEquiv_apply_left, ← signatureSwitchNegIndexEquiv_inr,
+    signatureSwitchNegLinearEquiv_apply, finSumFinEquiv_apply_right]
+
+/-- Negated positive coordinates become negative coordinates under
+`realCliffordFormNegIsometry`. -/
+@[simp]
+theorem realCliffordFormNegIsometry_neg_of_pos (p q : ℕ)
+    (x : Fin (p + q) → ℝ) (i : Fin p) :
+    realCliffordFormNegIsometry p q x (Fin.natAdd q i) = x (Fin.castAdd q i) := by
+  change signatureSwitchNegLinearEquiv p q x _ = _
+  rw [← finSumFinEquiv_apply_right, ← signatureSwitchNegIndexEquiv_inl,
+    signatureSwitchNegLinearEquiv_apply, finSumFinEquiv_apply_left]
 
 /-- The coordinate isometry which turns the sign-switched form into the standard signature. -/
 def realCliffordSignSwitchStandardIsometry (p q : ℕ) :
-    ((-(realCliffordForm (p + 1) q)).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))).IsometryEquiv
-      (realCliffordForm (q + 1) (p + 1)) :=
-  { signatureSwitchStandardLinearEquiv p q with
-    map_app' := by
-      rintro ⟨x, r⟩
-      rw [realCliffordForm_apply, QuadraticMap.prod_apply, neg_apply,
-        realCliffordForm_apply, QuadraticMap.sq_apply]
-      let y := signatureSwitchStandardLinearEquiv p q (x, r)
-      calc
-        (∑ i, realCliffordWeight (q + 1) (p + 1) i * (y i * y i)) =
-            ∑ s : Fin ((p + 1) + q) ⊕ Fin 1,
-              realCliffordWeight (q + 1) (p + 1)
-                ((signatureSwitchStandardIndexEquiv p q).symm s) *
-                (y ((signatureSwitchStandardIndexEquiv p q).symm s) *
-                  y ((signatureSwitchStandardIndexEquiv p q).symm s)) := by
-          exact Fintype.sum_equiv (signatureSwitchStandardIndexEquiv p q) _ _
-            (fun i ↦ by rw [Equiv.symm_apply_apply])
-        _ = -(∑ i, realCliffordWeight (p + 1) q i * (x i * x i)) + r * r := by
-          dsimp only [y]
-          simp only [Fintype.sum_sum_type, signatureSwitchStandardWeight_inl,
-            signatureSwitchStandardWeight_inr, signatureSwitchStandardLinearEquiv_inl,
-            signatureSwitchStandardLinearEquiv_inr, Fin.sum_univ_one, neg_mul,
-            one_mul, ← Finset.sum_neg_distrib] }
+    ((-(realCliffordForm p q)).prod (QuadraticMap.sq (R := ℝ) (A := ℝ))).IsometryEquiv
+      (realCliffordForm (q + 1) p) :=
+  ((realCliffordFormNegIsometry p q).prod
+    (QuadraticMap.IsometryEquiv.refl (QuadraticMap.sq (R := ℝ) (A := ℝ)))).trans
+      (realCliffordPositiveSplitIsometry q p).symm
+
+private theorem signatureSwitchStandardIsometry_split (p q : ℕ)
+    (x : Fin (p + q) → ℝ) (r : ℝ) :
+    realCliffordPositiveSplitIsometry q p
+        (realCliffordSignSwitchStandardIsometry p q (x, r)) =
+      (realCliffordFormNegIsometry p q x, r) := by
+  change realCliffordPositiveSplitIsometry q p
+    ((realCliffordPositiveSplitIsometry q p).symm
+      (realCliffordFormNegIsometry p q x, r)) = _
+  exact (realCliffordPositiveSplitIsometry q p).apply_symm_apply _
 
 /-- Negated negative coordinates become positive coordinates under
 `realCliffordSignSwitchStandardIsometry`. -/
 @[simp]
-theorem realCliffordSignSwitchStandardIsometry_pos (p q : ℕ)
-    (x : Fin ((p + 1) + q) → ℝ) (r : ℝ) (i : Fin q) :
+theorem realCliffordSignSwitchStandardIsometry_pos_of_neg (p q : ℕ)
+    (x : Fin (p + q) → ℝ) (r : ℝ) (i : Fin q) :
     realCliffordSignSwitchStandardIsometry p q (x, r)
-        (Fin.castAdd (p + 1) (Fin.castSucc i)) = x (Fin.natAdd (p + 1) i) := by
-  -- Expose the bundled reindexing map; the local `Fin` equality aligns its sum blocks.
-  change signatureSwitchStandardLinearEquiv p q (x, r) _ = _
-  rw [show Fin.castAdd (p + 1) (Fin.castSucc i) =
-      (signatureSwitchStandardIndexEquiv p q).symm
-        (Sum.inl (finSumFinEquiv (Sum.inr i))) by
-        rw [signatureSwitchStandardIndexEquiv_symm_inl_neg]
-        congr 1,
-    signatureSwitchStandardLinearEquiv_inl]
-  congr 1
+        (Fin.castAdd p (Fin.castSucc i)) = x (Fin.natAdd p i) := by
+  have h := congrFun (congrArg Prod.fst (signatureSwitchStandardIsometry_split p q x r))
+    (Fin.castAdd p i)
+  simpa only [realCliffordPositiveSplitIsometry_fst_pos,
+    realCliffordFormNegIsometry_pos_of_neg] using h
 
 /-- The new positive line is the last positive coordinate under
 `realCliffordSignSwitchStandardIsometry`. -/
 @[simp]
-theorem realCliffordSignSwitchStandardIsometry_last_positive (p q : ℕ)
-    (x : Fin ((p + 1) + q) → ℝ) (r : ℝ) :
+theorem realCliffordSignSwitchStandardIsometry_last_pos (p q : ℕ)
+    (x : Fin (p + q) → ℝ) (r : ℝ) :
     realCliffordSignSwitchStandardIsometry p q (x, r)
-        (Fin.castAdd (p + 1) (Fin.last q)) = r := by
-  -- Expose the bundled reindexing map; the local `Fin` equality aligns its final block.
-  change signatureSwitchStandardLinearEquiv p q (x, r) _ = _
-  rw [show Fin.castAdd (p + 1) (Fin.last q) =
-      (signatureSwitchStandardIndexEquiv p q).symm (Sum.inr 0) by
-        rw [signatureSwitchStandardIndexEquiv_symm_inr]
-        congr 1,
-    signatureSwitchStandardLinearEquiv_inr]
+        (Fin.castAdd p (Fin.last q)) = r := by
+  have h := congrArg Prod.snd (signatureSwitchStandardIsometry_split p q x r)
+  simpa only [realCliffordPositiveSplitIsometry_snd] using h
 
 /-- Negated positive coordinates become negative coordinates under
 `realCliffordSignSwitchStandardIsometry`. -/
 @[simp]
-theorem realCliffordSignSwitchStandardIsometry_neg (p q : ℕ)
-    (x : Fin ((p + 1) + q) → ℝ) (r : ℝ) (i : Fin (p + 1)) :
+theorem realCliffordSignSwitchStandardIsometry_neg_of_pos (p q : ℕ)
+    (x : Fin (p + q) → ℝ) (r : ℝ) (i : Fin p) :
     realCliffordSignSwitchStandardIsometry p q (x, r)
         (Fin.natAdd (q + 1) i) = x (Fin.castAdd q i) := by
-  -- Expose the bundled reindexing map; the local `Fin` equality aligns its sum blocks.
-  change signatureSwitchStandardLinearEquiv p q (x, r) _ = _
-  rw [show Fin.natAdd (q + 1) i =
-      (signatureSwitchStandardIndexEquiv p q).symm
-        (Sum.inl (finSumFinEquiv (Sum.inl i))) by
-        rw [signatureSwitchStandardIndexEquiv_symm_inl_pos]
-        congr 1,
-    signatureSwitchStandardLinearEquiv_inl]
-  congr 1
+  have h := congrFun (congrArg Prod.fst (signatureSwitchStandardIsometry_split p q x r))
+    (Fin.natAdd q i)
+  simpa only [realCliffordPositiveSplitIsometry_fst_neg,
+    realCliffordFormNegIsometry_neg_of_pos] using h
 
 /-- One sign switch followed by the hyperbolic Bott step gives the signature-switch recurrence
 `Cliff(p + 2, q) ≅ Cliff(q, p) ⊗ M₂(ℝ)`. -/
 noncomputable def realCliffordSignatureSwitchRecurrenceEquiv (p q : ℕ) :
     _root_.CliffordAlgebra (realCliffordForm (p + 1 + 1) q) ≃ₐ[ℝ]
       _root_.CliffordAlgebra (realCliffordForm q p) ⊗[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
-  (_root_.CliffordAlgebra.equivOfIsometry (realCliffordPositiveSplitIsometry p q)).trans
+  (_root_.CliffordAlgebra.equivOfIsometry
+    (realCliffordPositiveSplitIsometry (p + 1) q)).trans
     ((CliffordAlgebra.signSwitchEquiv (realCliffordForm (p + 1) q)).trans
       ((_root_.CliffordAlgebra.equivOfIsometry
-        (realCliffordSignSwitchStandardIsometry p q)).trans
+        (realCliffordSignSwitchStandardIsometry (p + 1) q)).trans
           (realCliffordBottEquiv q p)))
 
 /-- The signature-switch recurrence sends a Clifford generator through its two coordinate
-isometries and the sign-switch generator formula. -/
+isometries and the sign-switch generator formula, then transports the result through
+`realCliffordBottEquiv q p`. -/
 @[simp]
 theorem realCliffordSignatureSwitchRecurrenceEquiv_ι (p q : ℕ)
     (v : Fin ((p + 1 + 1) + q) → ℝ) :
     realCliffordSignatureSwitchRecurrenceEquiv p q (_root_.CliffordAlgebra.ι _ v) =
       realCliffordBottEquiv q p (_root_.CliffordAlgebra.ι _
-        (realCliffordSignSwitchStandardIsometry p q (0, 1))) *
+        (realCliffordSignSwitchStandardIsometry (p + 1) q (0, 1))) *
         realCliffordBottEquiv q p (_root_.CliffordAlgebra.ι _
-          (realCliffordSignSwitchStandardIsometry p q
-            ((realCliffordPositiveSplitIsometry p q v).1, 0))) +
-          (realCliffordPositiveSplitIsometry p q v).2 •
+          (realCliffordSignSwitchStandardIsometry (p + 1) q
+            ((realCliffordPositiveSplitIsometry (p + 1) q v).1, 0))) +
+          (realCliffordPositiveSplitIsometry (p + 1) q v).2 •
             realCliffordBottEquiv q p (_root_.CliffordAlgebra.ι _
-              (realCliffordSignSwitchStandardIsometry p q (0, 1))) := by
+              (realCliffordSignSwitchStandardIsometry (p + 1) q (0, 1))) := by
   rw [realCliffordSignatureSwitchRecurrenceEquiv, AlgEquiv.trans_apply,
     _root_.CliffordAlgebra.equivOfIsometry_apply,
     _root_.CliffordAlgebra.map_apply_ι, AlgEquiv.trans_apply,
@@ -1065,7 +1039,6 @@ theorem realCliffordSignatureSwitchRecurrenceEquiv_ι (p q : ℕ)
     AlgEquiv.trans_apply, _root_.CliffordAlgebra.equivOfIsometry_apply,
     _root_.CliffordAlgebra.map_apply_ι]
   simp only [AlgEquiv.trans_apply, _root_.CliffordAlgebra.equivOfIsometry_apply,
-    _root_.CliffordAlgebra.map_apply_ι, QuadraticMap.IsometryEquiv.toIsometry]
-  rfl
+    _root_.CliffordAlgebra.map_apply_ι, QuadraticMap.IsometryEquiv.toIsometry_apply]
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -22,6 +22,10 @@ coordinates and `-1` in the last `q`, written as a `QuadraticMap.weightedSumSqua
 sign vector `TauCeti.realCliffordWeight p q`. It is nondegenerate
 (`TauCeti.nondegenerate_realCliffordForm`), and its Clifford algebra has dimension `2 ^ (p + q)`
 (`TauCeti.finrank_cliffordAlgebra_realCliffordForm`).
+Negating the form swaps the two signature indices through
+`TauCeti.realCliffordFormNegIsometry`; its coordinate action is given by
+`TauCeti.realCliffordFormNegIsometry_pos_of_neg` and
+`TauCeti.realCliffordFormNegIsometry_neg_of_pos`.
 
 The sign convention — generators of the *first* `p` coordinates square to `+1` — is not universal:
 sources that make the first generators square to `-1` index the periodicity table by
@@ -61,6 +65,8 @@ equivalences and their values, not their bare existence, that the Bott-periodici
 
 * `TauCeti.realCliffordWeight` and `TauCeti.realCliffordForm`: the signature `(p, q)` sign vector
   and the diagonal real quadratic form it weights.
+* `TauCeti.realCliffordFormNegIsometry`: the isometry from the negated `(p, q)` form to the
+  `(q, p)` form, with coordinate equations `..._pos_of_neg` and `..._neg_of_pos`.
 * `TauCeti.realCliffordOneZeroEquivProd`, `TauCeti.realCliffordZeroOneEquivComplex`,
   `TauCeti.realCliffordZeroTwoEquivQuaternion`, `TauCeti.realCliffordOneOneEquivMatrix`: the four
   base entries of the Bott table, each with a `..._ι` lemma computing it on a generator.

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -142,6 +142,89 @@ theorem finrank_cliffordAlgebra_realCliffordForm (p q : ℕ) :
     finrank ℝ (CliffordAlgebra (realCliffordForm p q)) = 2 ^ (p + q) := by
   rw [TauCeti.CliffordAlgebra.finrank_eq_two_pow, Module.finrank_pi, Fintype.card_fin]
 
+private def realCliffordNegIndexEquiv (p q : ℕ) : Fin (p + q) ≃ Fin (q + p) :=
+  finSumFinEquiv.symm |>.trans
+    (Equiv.sumComm (Fin p) (Fin q)) |>.trans
+    finSumFinEquiv
+
+private theorem realCliffordNegIndexEquiv_inl (p q : ℕ) (i : Fin p) :
+    realCliffordNegIndexEquiv p q (finSumFinEquiv (Sum.inl i)) =
+      finSumFinEquiv (Sum.inr i) := by
+  simp [realCliffordNegIndexEquiv]
+
+private theorem realCliffordNegIndexEquiv_inr (p q : ℕ) (i : Fin q) :
+    realCliffordNegIndexEquiv p q (finSumFinEquiv (Sum.inr i)) =
+      finSumFinEquiv (Sum.inl i) := by
+  simp [realCliffordNegIndexEquiv]
+
+private def realCliffordNegLinearEquiv (p q : ℕ) :
+    (Fin (p + q) → ℝ) ≃ₗ[ℝ] (Fin (q + p) → ℝ) :=
+  LinearEquiv.piCongrLeft' ℝ (fun _ : Fin (p + q) ↦ ℝ) (realCliffordNegIndexEquiv p q)
+
+private theorem realCliffordNegWeight (p q : ℕ) (i : Fin (p + q)) :
+    realCliffordWeight q p (realCliffordNegIndexEquiv p q i) =
+      -realCliffordWeight p q i := by
+  rw [← finSumFinEquiv.apply_symm_apply i]
+  rcases finSumFinEquiv.symm i with i | i
+  · simp only [realCliffordNegIndexEquiv, Equiv.trans_apply, Equiv.sumComm_apply,
+      finSumFinEquiv_apply_left]
+    rw [realCliffordWeight_of_le (by simp), realCliffordWeight_of_lt (by simp)]
+  · simp only [realCliffordNegIndexEquiv, Equiv.trans_apply, Equiv.sumComm_apply,
+      finSumFinEquiv_apply_right]
+    rw [realCliffordWeight_of_lt (by simp), realCliffordWeight_of_le (by simp)]
+    norm_num
+
+private theorem realCliffordNegLinearEquiv_apply (p q : ℕ) (x : Fin (p + q) → ℝ)
+    (i : Fin (p + q)) :
+    realCliffordNegLinearEquiv p q x (realCliffordNegIndexEquiv p q i) = x i := by
+  rw [realCliffordNegLinearEquiv, LinearEquiv.piCongrLeft'_apply, Equiv.symm_apply_apply]
+
+/-- Negating a real signature form swaps its positive and negative coordinates. -/
+def realCliffordFormNegIsometry (p q : ℕ) :
+    (-(realCliffordForm p q)).IsometryEquiv (realCliffordForm q p) :=
+  { realCliffordNegLinearEquiv p q with
+    map_app' := by
+      intro x
+      rw [realCliffordForm_apply, neg_apply, realCliffordForm_apply]
+      let y := realCliffordNegLinearEquiv p q x
+      calc
+        (∑ i, realCliffordWeight q p i * (y i * y i)) =
+            ∑ i, realCliffordWeight q p (realCliffordNegIndexEquiv p q i) *
+              (y (realCliffordNegIndexEquiv p q i) *
+                y (realCliffordNegIndexEquiv p q i)) := by
+          exact (Fintype.sum_equiv (realCliffordNegIndexEquiv p q)
+            (fun i ↦ realCliffordWeight q p (realCliffordNegIndexEquiv p q i) *
+              (y (realCliffordNegIndexEquiv p q i) *
+                y (realCliffordNegIndexEquiv p q i)))
+            (fun i ↦ realCliffordWeight q p i * (y i * y i))
+            (fun _ ↦ rfl)).symm
+        _ = -(∑ i, realCliffordWeight p q i * (x i * x i)) := by
+          dsimp only [y]
+          simp only [realCliffordNegWeight, realCliffordNegLinearEquiv_apply, neg_mul,
+            ← Finset.sum_neg_distrib] }
+
+/-- Negated negative coordinates become positive coordinates under
+`realCliffordFormNegIsometry`. -/
+@[simp]
+theorem realCliffordFormNegIsometry_pos_of_neg (p q : ℕ)
+    (x : Fin (p + q) → ℝ) (i : Fin q) :
+    realCliffordFormNegIsometry p q x (Fin.castAdd p i) = x (Fin.natAdd p i) := by
+  -- Expose the bundled isometry's private reindexing map before using its coordinate equation.
+  change realCliffordNegLinearEquiv p q x _ = _
+  rw [← finSumFinEquiv_apply_left, ← realCliffordNegIndexEquiv_inr,
+    realCliffordNegLinearEquiv_apply, finSumFinEquiv_apply_right]
+
+/-- Negated positive coordinates become negative coordinates under
+`realCliffordFormNegIsometry`. -/
+@[simp]
+theorem realCliffordFormNegIsometry_neg_of_pos (p q : ℕ)
+    (x : Fin (p + q) → ℝ) (i : Fin p) :
+    realCliffordFormNegIsometry p q x (Fin.natAdd q i) = x (Fin.castAdd q i) := by
+  -- Expose the bundled isometry's private reindexing map before using its coordinate equation.
+  change realCliffordNegLinearEquiv p q x _ = _
+  rw [← finSumFinEquiv_apply_right, ← realCliffordNegIndexEquiv_inl,
+    realCliffordNegLinearEquiv_apply, finSumFinEquiv_apply_left]
+
 /-! ### The four base entries, in coordinates -/
 
 @[simp]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SignSwitch.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SignSwitch.lean
@@ -57,6 +57,25 @@ private theorem signSwitchGenerator_apply (x : N × R) :
           (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1) :=
   rfl
 
+private theorem square_generator_sum {A : Type*} [Ring A] (e v r : A)
+    (he : e * e = 1) (hve : v * e = -(e * v))
+    (hre : r * e = e * r) (hrv : r * v = v * r) :
+    (e * v + r * e) * (e * v + r * e) = -(v * v) + r * r := by
+  have hfactor₁ : e * v + r * e = e * (v + r) := by
+    rw [mul_add, hre]
+  have hfactor₂ : (v + r) * e = e * (r - v) := by
+    rw [add_mul, hve, hre, mul_sub]
+    abel
+  rw [hfactor₁]
+  calc
+    (e * (v + r)) * (e * (v + r)) = e * ((v + r) * e) * (v + r) := by
+      simp only [mul_assoc]
+    _ = e * (e * (r - v)) * (v + r) := by rw [hfactor₂]
+    _ = (r - v) * (v + r) := by rw [← mul_assoc e e, he, one_mul]
+    _ = -(v * v) + r * r := by
+      rw [sub_mul, mul_add, mul_add, hrv]
+      abel
+
 private theorem signSwitchGenerator_sq (h : P' = -P) (x : N × R) :
     signSwitchGenerator P' x * signSwitchGenerator P' x =
       algebraMap R _ ((P.prod (QuadraticMap.sq (R := R) (A := R))) x) := by
@@ -85,33 +104,9 @@ private theorem signSwitchGenerator_sq (h : P' = -P) (x : N × R) :
   have hve : v * e = -(e * v) := eq_neg_of_add_eq_zero_right hev
   have hre : r * e = e * r := Algebra.commutes x.2 e
   have hrv : r * v = v * r := Algebra.commutes x.2 v
-  have hterm1 : (e * v) * (e * v) = -(v * v) := by
-    calc
-      (e * v) * (e * v) = e * ((v * e) * v) := by simp only [mul_assoc]
-      _ = e * (-(e * v) * v) := by rw [hve]
-      _ = -(v * v) := by rw [neg_mul, mul_neg, ← mul_assoc, ← mul_assoc, he, one_mul]
-  have hterm2 : (e * v) * (r * e) = -(r * v) := by
-    calc
-      (e * v) * (r * e) = e * (v * r) * e := by simp only [mul_assoc]
-      _ = e * (r * v) * e := by rw [hrv]
-      _ = (e * r) * v * e := by simp only [mul_assoc]
-      _ = (r * e) * v * e := by rw [← hre]
-      _ = r * (e * v) * e := by rw [mul_assoc r e v]
-      _ = r * (e * (v * e)) := by simp only [mul_assoc]
-      _ = r * (e * (-(e * v))) := by rw [hve]
-      _ = -(r * v) := by rw [mul_neg, mul_neg, ← mul_assoc e e, he, one_mul]
-  have hterm3 : (r * e) * (e * v) = r * v := by
-    rw [mul_assoc r e, ← mul_assoc e e, he, one_mul]
-  have hterm4 : (r * e) * (r * e) = r * r := by
-    calc
-      (r * e) * (r * e) = r * (e * r) * e := by simp only [mul_assoc]
-      _ = r * (r * e) * e := by rw [← hre]
-      _ = r * r * (e * e) := by simp only [mul_assoc]
-      _ = r * r := by rw [he, mul_one]
   calc
-    (e * v + r * e) * (e * v + r * e) = -(v * v) + r * r := by
-      rw [mul_add, add_mul, add_mul, hterm1, hterm2, hterm3, hterm4]
-      abel
+    (e * v + r * e) * (e * v + r * e) = -(v * v) + r * r :=
+      square_generator_sum e v r he hve hre hrv
     _ = algebraMap R _ (P x.1 + x.2 * x.2) := by
       rw [hv, map_neg, neg_neg, ← map_mul, ← map_add]
     _ = algebraMap R _ ((P.prod (QuadraticMap.sq (R := R) (A := R))) x) := by
@@ -152,7 +147,7 @@ def signSwitchEquiv :
     (signSwitchTo_comp_signSwitchTo P (-P) rfl (neg_neg P).symm)
 
 /-- The sign-switch equivalence sends a generating pair to the product with the new positive
-generator plus its scalar component. -/
+generator plus its scalar component times the new positive generator. -/
 @[simp]
 theorem signSwitchEquiv_ι (x : N × R) :
     signSwitchEquiv P (_root_.CliffordAlgebra.ι _ x) =
@@ -167,9 +162,8 @@ theorem signSwitchEquiv_symm_apply_ι (x : N × R) :
     (signSwitchEquiv P).symm (_root_.CliffordAlgebra.ι _ x) =
       _root_.CliffordAlgebra.ι _ (0, 1) * _root_.CliffordAlgebra.ι _ (x.1, 0) +
         x.2 • _root_.CliffordAlgebra.ι _ (0, 1) := by
-  -- Expose the reverse lift stored in `AlgEquiv.ofAlgHom` so its generator equation applies.
-  change signSwitchTo (-P) P (neg_neg P).symm (_root_.CliffordAlgebra.ι _ x) = _
-  rw [signSwitchTo_ι, signSwitchGenerator_apply]
+  rw [signSwitchEquiv, AlgEquiv.ofAlgHom_symm, AlgEquiv.ofAlgHom_apply,
+    signSwitchTo_ι, signSwitchGenerator_apply]
 
 end SignSwitch
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SignSwitch.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SignSwitch.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 Tau Ceti Project. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tau Ceti Project
+-/
+module
+
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Basic
+public import Mathlib.LinearAlgebra.QuadraticForm.Prod
+
+/-!
+# Sign-switch equivalence for Clifford algebras
+
+Adjoining one positive line identifies the Clifford algebras of a quadratic form and its
+negation. The construction is generic over a commutative ring.
+
+## Main results
+
+* `TauCeti.CliffordAlgebra.signSwitchEquiv`: the sign-switch algebra equivalence;
+* `TauCeti.CliffordAlgebra.signSwitchEquiv_ι`: its equation on generators;
+* `TauCeti.CliffordAlgebra.signSwitchEquiv_symm_apply_ι`: the inverse generator equation.
+
+## References
+
+* H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I.
+-/
+
+public section
+
+open Module QuadraticMap
+
+namespace TauCeti.CliffordAlgebra
+
+section SignSwitch
+
+variable {R N : Type*} [CommRing R] [AddCommGroup N] [Module R N]
+variable (P P' : QuadraticForm R N)
+
+private def signSwitchGenerator :
+    N × R →ₗ[R]
+      _root_.CliffordAlgebra (P'.prod (QuadraticMap.sq (R := R) (A := R))) :=
+  ((LinearMap.mulLeft R
+      (_root_.CliffordAlgebra.ι (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1))).comp
+    ((_root_.CliffordAlgebra.ι (P'.prod (QuadraticMap.sq (R := R) (A := R)))).comp
+      (LinearMap.inl R N R))).coprod
+    (LinearMap.toSpanSingleton R _
+      (_root_.CliffordAlgebra.ι
+        (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1)))
+
+private theorem signSwitchGenerator_apply (x : N × R) :
+    signSwitchGenerator P' x =
+      _root_.CliffordAlgebra.ι
+          (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1) *
+          _root_.CliffordAlgebra.ι
+            (P'.prod (QuadraticMap.sq (R := R) (A := R))) (x.1, 0) +
+        x.2 • _root_.CliffordAlgebra.ι
+          (P'.prod (QuadraticMap.sq (R := R) (A := R))) (0, 1) :=
+  rfl
+
+private theorem signSwitchGenerator_sq (h : P' = -P) (x : N × R) :
+    signSwitchGenerator P' x * signSwitchGenerator P' x =
+      algebraMap R _ ((P.prod (QuadraticMap.sq (R := R) (A := R))) x) := by
+  let Q' := P'.prod (QuadraticMap.sq (R := R) (A := R))
+  let e := _root_.CliffordAlgebra.ι Q' (0, 1)
+  let v := _root_.CliffordAlgebra.ι Q' (x.1, 0)
+  have he : e * e = 1 := by
+    dsimp only [e]
+    rw [_root_.CliffordAlgebra.ι_sq_scalar]
+    simp [Q']
+  have hv : v * v = algebraMap R _ (-P x.1) := by
+    dsimp only [v]
+    rw [_root_.CliffordAlgebra.ι_sq_scalar]
+    simp [Q', h]
+  have hev : e * v + v * e = 0 := by
+    dsimp only [e, v]
+    rw [_root_.CliffordAlgebra.ι_mul_ι_add_swap]
+    simp [Q', QuadraticMap.polar]
+  rw [signSwitchGenerator_apply]
+  -- Expose the two local Clifford generators used in the square calculation.
+  change (e * v + x.2 • e) * (e * v + x.2 • e) = _
+  rw [Algebra.smul_def]
+  let r := algebraMap R (_root_.CliffordAlgebra Q') x.2
+  -- Name the scalar's central image so the four noncommutative terms can be compared directly.
+  change (e * v + r * e) * (e * v + r * e) = _
+  have hve : v * e = -(e * v) := eq_neg_of_add_eq_zero_right hev
+  have hre : r * e = e * r := Algebra.commutes x.2 e
+  have hrv : r * v = v * r := Algebra.commutes x.2 v
+  have hterm1 : (e * v) * (e * v) = -(v * v) := by
+    calc
+      (e * v) * (e * v) = e * ((v * e) * v) := by simp only [mul_assoc]
+      _ = e * (-(e * v) * v) := by rw [hve]
+      _ = -(v * v) := by rw [neg_mul, mul_neg, ← mul_assoc, ← mul_assoc, he, one_mul]
+  have hterm2 : (e * v) * (r * e) = -(r * v) := by
+    calc
+      (e * v) * (r * e) = e * (v * r) * e := by simp only [mul_assoc]
+      _ = e * (r * v) * e := by rw [hrv]
+      _ = (e * r) * v * e := by simp only [mul_assoc]
+      _ = (r * e) * v * e := by rw [← hre]
+      _ = r * (e * v) * e := by rw [mul_assoc r e v]
+      _ = r * (e * (v * e)) := by simp only [mul_assoc]
+      _ = r * (e * (-(e * v))) := by rw [hve]
+      _ = -(r * v) := by rw [mul_neg, mul_neg, ← mul_assoc e e, he, one_mul]
+  have hterm3 : (r * e) * (e * v) = r * v := by
+    rw [mul_assoc r e, ← mul_assoc e e, he, one_mul]
+  have hterm4 : (r * e) * (r * e) = r * r := by
+    calc
+      (r * e) * (r * e) = r * (e * r) * e := by simp only [mul_assoc]
+      _ = r * (r * e) * e := by rw [← hre]
+      _ = r * r * (e * e) := by simp only [mul_assoc]
+      _ = r * r := by rw [he, mul_one]
+  calc
+    (e * v + r * e) * (e * v + r * e) = -(v * v) + r * r := by
+      rw [mul_add, add_mul, add_mul, hterm1, hterm2, hterm3, hterm4]
+      abel
+    _ = algebraMap R _ (P x.1 + x.2 * x.2) := by
+      rw [hv, map_neg, neg_neg, ← map_mul, ← map_add]
+    _ = algebraMap R _ ((P.prod (QuadraticMap.sq (R := R) (A := R))) x) := by
+      simp [QuadraticMap.prod_apply]
+
+private def signSwitchTo (h : P' = -P) :
+    _root_.CliffordAlgebra (P.prod (QuadraticMap.sq (R := R) (A := R))) →ₐ[R]
+      _root_.CliffordAlgebra (P'.prod (QuadraticMap.sq (R := R) (A := R))) :=
+  _root_.CliffordAlgebra.lift _ ⟨signSwitchGenerator P', signSwitchGenerator_sq P P' h⟩
+
+private theorem signSwitchTo_ι (h : P' = -P) (x : N × R) :
+    signSwitchTo P P' h (_root_.CliffordAlgebra.ι _ x) = signSwitchGenerator P' x :=
+  _root_.CliffordAlgebra.lift_ι_apply _ _ x
+
+private theorem signSwitchTo_comp_signSwitchTo
+    (h : P' = -P) (h' : P = -P') :
+    (signSwitchTo P' P h').comp (signSwitchTo P P' h) = AlgHom.id R _ := by
+  apply _root_.CliffordAlgebra.hom_ext
+  apply LinearMap.ext
+  rintro ⟨m, r⟩
+  simp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply, AlgHom.comp_apply,
+    signSwitchTo_ι, signSwitchGenerator_apply, map_add, map_mul, map_smul]
+  -- Split a source generator into its module and scalar components for the linear lift.
+  rw [show (m, r) = (m, 0) + r • (0, 1) by ext <;> simp, map_add, map_smul]
+  -- Expose the zero module-scalar pair so the Clifford generator reduces with `map_zero`.
+  rw [show ((0 : N), (0 : R)) = 0 by rfl, map_zero]
+  simp only [mul_zero, zero_add, add_zero, one_smul, zero_smul]
+  rw [← mul_assoc, _root_.CliffordAlgebra.ι_sq_scalar]
+  simp
+
+/-- Adjoining a positive line to a quadratic form or to its negation gives equivalent Clifford
+algebras. -/
+def signSwitchEquiv :
+    _root_.CliffordAlgebra (P.prod (QuadraticMap.sq (R := R) (A := R))) ≃ₐ[R]
+      _root_.CliffordAlgebra ((-P).prod (QuadraticMap.sq (R := R) (A := R))) :=
+  AlgEquiv.ofAlgHom (signSwitchTo P (-P) rfl) (signSwitchTo (-P) P (neg_neg P).symm)
+    (signSwitchTo_comp_signSwitchTo (-P) P (neg_neg P).symm rfl)
+    (signSwitchTo_comp_signSwitchTo P (-P) rfl (neg_neg P).symm)
+
+/-- The sign-switch equivalence sends a generating pair to the product with the new positive
+generator plus its scalar component. -/
+@[simp]
+theorem signSwitchEquiv_ι (x : N × R) :
+    signSwitchEquiv P (_root_.CliffordAlgebra.ι _ x) =
+      _root_.CliffordAlgebra.ι _ (0, 1) * _root_.CliffordAlgebra.ι _ (x.1, 0) +
+        x.2 • _root_.CliffordAlgebra.ι _ (0, 1) := by
+  rw [signSwitchEquiv, AlgEquiv.ofAlgHom_apply, signSwitchTo_ι,
+    signSwitchGenerator_apply]
+
+/-- The inverse sign-switch equivalence has the same equation on Clifford generators. -/
+@[simp]
+theorem signSwitchEquiv_symm_apply_ι (x : N × R) :
+    (signSwitchEquiv P).symm (_root_.CliffordAlgebra.ι _ x) =
+      _root_.CliffordAlgebra.ι _ (0, 1) * _root_.CliffordAlgebra.ι _ (x.1, 0) +
+        x.2 • _root_.CliffordAlgebra.ι _ (0, 1) := by
+  -- Expose the reverse lift stored in `AlgEquiv.ofAlgHom` so its generator equation applies.
+  change signSwitchTo (-P) P (neg_neg P).symm (_root_.CliffordAlgebra.ι _ x) = _
+  rw [signSwitchTo_ι, signSwitchGenerator_apply]
+
+end SignSwitch
+
+end TauCeti.CliffordAlgebra


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds a sign-switch equivalence for Clifford algebras and derives a recurrence for the standard real signatures.

- Identifies `Cl(Q ⊕ ⟨1⟩)` with `Cl(-Q ⊕ ⟨1⟩)`, with forward and inverse generator equations.
- Identifies `Cl(p + 2, q)` with `Cl(q, p) ⊗ M₂(ℝ)` and provides named generator equations.
- Recovers the pure-axis recurrence as the `q = 0` specialization.

## Roadmap target

Advances Layer 7 `cliff_bott` toward the mod-8 classification:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L310-L315

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#cliff_bott"}-->

## Verification

Full builds, audits, environment lint, source checks, general and pure-axis consumer probes, proof golf, local `2+1` review, current-head CI, and the public-head TauCeti-only review pass at `9bae0af1da9ef3a23d97a34450fa4b0ba9d45416`.

## Scale and generality

Changes two files by +545/−1 lines. The generic sign switch works over any commutative ring and module without invertible `2`, finiteness, or nondegeneracy; the signature recurrences specialize to the standard real forms.

## Scope

- **Consumes:** the generic sign switch, the one-step real Bott equivalence, and the standard real-form API.
- **Provides:** the two-signature recurrence with generator equations and its pure-axis specialization.
- **Fits:** supplies the recurrence boundary used to derive eight-step periodicity and the classification table.
- **Boundary:** quaternionic recurrences and base-algebra classification require additional arguments in later slices.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [b8161ef](https://github.com/TauCetiProject/TauCetiReview/commit/b8161ef29f1bf922d3f9aea2b1b1e298bcd06078) · local 2+1 review @ [4a3ce2b](https://github.com/utensil/formal-land/commit/4a3ce2ba031ff1c2bece478a842ba6b1e8b74364) fixed: documentation (1), naming (2), placement (2), proof-quality (4), scope (1), ut-aggregate-reuse (1)</sub>