### PR TITLE
refactor(RiemannMapping): name the transition map between two disc parametrisations

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Uniqueness.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Uniqueness.lean
@@ -36,21 +36,18 @@ namespace TauCeti
 open _root_.Complex Filter Function Metric Set
 open scoped ComplexConjugate Topology
 
-/-- **The transition map between two conformal parametrisations of the disc.** If `f` and `g` are
-injective and differentiable on `U` with image the unit disc, then `g ∘ f⁻¹` is differentiable on
-the disc, maps it into itself, and is inverted there by `f ∘ g⁻¹`. -/
-private theorem differentiableOn_mapsTo_leftInvOn_comp_invFunOn {U : Set ℂ} (hU : IsOpen U)
+/-- **The transition map between two parametrisations of a common target.** If `f` and `g` are
+injective and differentiable on `U`, with `f` surjecting onto `V` and `g` mapping into it, then
+`g ∘ f⁻¹` is differentiable on `V`, maps `V` into itself, and is left-inverted there by
+`f ∘ g⁻¹`. -/
+private theorem differentiableOn_mapsTo_leftInvOn_comp_invFunOn {U V : Set ℂ} (hU : IsOpen U)
     {f g : ℂ → ℂ} (hf : DifferentiableOn ℂ f U) (hg : DifferentiableOn ℂ g U)
-    (hfi : InjOn f U) (hgi : InjOn g U)
-    (hfimage : f '' U = ball (0 : ℂ) 1) (hgimage : g '' U = ball (0 : ℂ) 1) :
-    DifferentiableOn ℂ (g ∘ Function.invFunOn f U) (ball (0 : ℂ) 1) ∧
-      MapsTo (g ∘ Function.invFunOn f U) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) ∧
-      LeftInvOn (f ∘ Function.invFunOn g U) (g ∘ Function.invFunOn f U) (ball (0 : ℂ) 1) := by
-  obtain ⟨hf_surj, -⟩ := image_eq_iff_surjOn_mapsTo.mp hfimage
-  obtain ⟨-, hg_maps⟩ := image_eq_iff_surjOn_mapsTo.mp hgimage
-  have hfinv : DifferentiableOn ℂ (Function.invFunOn f U) (ball (0 : ℂ) 1) := by
-    rw [← hfimage]
-    exact DifferentiableOn.invFunOn hf hU hfi
+    (hfi : InjOn f U) (hgi : InjOn g U) (hf_surj : SurjOn f U V) (hg_maps : MapsTo g U V) :
+    DifferentiableOn ℂ (g ∘ Function.invFunOn f U) V ∧
+      MapsTo (g ∘ Function.invFunOn f U) V V ∧
+      LeftInvOn (f ∘ Function.invFunOn g U) (g ∘ Function.invFunOn f U) V := by
+  have hfinv : DifferentiableOn ℂ (Function.invFunOn f U) V :=
+    (DifferentiableOn.invFunOn hf hU hfi).mono hf_surj
   refine ⟨hg.comp hfinv hf_surj.mapsTo_invFunOn, hg_maps.comp hf_surj.mapsTo_invFunOn,
     fun z hz => ?_⟩
   simp only [Function.comp_apply]
@@ -76,12 +73,13 @@ theorem exists_eqOn_unitDiscStandardAutomorphismFormula_comp {U : Set ℂ} (hU :
           (u : ℂ) *
             ((f z - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * f z)))
         U := by
-  obtain ⟨-, hf_maps⟩ := image_eq_iff_surjOn_mapsTo.mp hfimage
-  -- the two transition maps, each the inverse of the other on the disc
+  obtain ⟨hf_surj, hf_maps⟩ := image_eq_iff_surjOn_mapsTo.mp hfimage
+  obtain ⟨hg_surj, hg_maps⟩ := image_eq_iff_surjOn_mapsTo.mp hgimage
+  -- the two transition maps, each left-inverting the other on the disc
   obtain ⟨hFdiff, hFmaps, hGF⟩ :=
-    differentiableOn_mapsTo_leftInvOn_comp_invFunOn hU hf hg hfi hgi hfimage hgimage
+    differentiableOn_mapsTo_leftInvOn_comp_invFunOn hU hf hg hfi hgi hf_surj hg_maps
   obtain ⟨hGdiff, hGmaps, hFG⟩ :=
-    differentiableOn_mapsTo_leftInvOn_comp_invFunOn hU hg hf hgi hfi hgimage hfimage
+    differentiableOn_mapsTo_leftInvOn_comp_invFunOn hU hg hf hgi hfi hg_surj hf_maps
   obtain ⟨u, a, _, hclass⟩ :=
     exists_forall_unitDisc_eq_unitDiscStandardAutomorphismEquiv
       hFdiff hGdiff hFmaps hGmaps hGF hFG

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Uniqueness.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Uniqueness.lean
@@ -48,11 +48,9 @@ private theorem differentiableOn_mapsTo_leftInvOn_comp_invFunOn {U V : Set ℂ} 
       LeftInvOn (f ∘ Function.invFunOn g U) (g ∘ Function.invFunOn f U) V := by
   have hfinv : DifferentiableOn ℂ (Function.invFunOn f U) V :=
     (DifferentiableOn.invFunOn hf hU hfi).mono hf_surj
-  refine ⟨hg.comp hfinv hf_surj.mapsTo_invFunOn, hg_maps.comp hf_surj.mapsTo_invFunOn,
-    fun z hz => ?_⟩
-  simp only [Function.comp_apply]
-  rw [hgi.leftInvOn_invFunOn (hf_surj.mapsTo_invFunOn hz)]
-  exact hf_surj.rightInvOn_invFunOn hz
+  exact ⟨hg.comp hfinv hf_surj.mapsTo_invFunOn, hg_maps.comp hf_surj.mapsTo_invFunOn,
+    Set.LeftInvOn.comp hf_surj.rightInvOn_invFunOn hgi.leftInvOn_invFunOn
+      hf_surj.mapsTo_invFunOn⟩
 
 /--
 **Uniqueness in the Riemann mapping theorem, up to a disc automorphism.** If `f` and `g` are

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Uniqueness.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Uniqueness.lean
@@ -36,6 +36,27 @@ namespace TauCeti
 open _root_.Complex Filter Function Metric Set
 open scoped ComplexConjugate Topology
 
+/-- **The transition map between two conformal parametrisations of the disc.** If `f` and `g` are
+injective and differentiable on `U` with image the unit disc, then `g ∘ f⁻¹` is differentiable on
+the disc, maps it into itself, and is inverted there by `f ∘ g⁻¹`. -/
+private theorem differentiableOn_mapsTo_leftInvOn_comp_invFunOn {U : Set ℂ} (hU : IsOpen U)
+    {f g : ℂ → ℂ} (hf : DifferentiableOn ℂ f U) (hg : DifferentiableOn ℂ g U)
+    (hfi : InjOn f U) (hgi : InjOn g U)
+    (hfimage : f '' U = ball (0 : ℂ) 1) (hgimage : g '' U = ball (0 : ℂ) 1) :
+    DifferentiableOn ℂ (g ∘ Function.invFunOn f U) (ball (0 : ℂ) 1) ∧
+      MapsTo (g ∘ Function.invFunOn f U) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) ∧
+      LeftInvOn (f ∘ Function.invFunOn g U) (g ∘ Function.invFunOn f U) (ball (0 : ℂ) 1) := by
+  obtain ⟨hf_surj, -⟩ := image_eq_iff_surjOn_mapsTo.mp hfimage
+  obtain ⟨-, hg_maps⟩ := image_eq_iff_surjOn_mapsTo.mp hgimage
+  have hfinv : DifferentiableOn ℂ (Function.invFunOn f U) (ball (0 : ℂ) 1) := by
+    rw [← hfimage]
+    exact DifferentiableOn.invFunOn hf hU hfi
+  refine ⟨hg.comp hfinv hf_surj.mapsTo_invFunOn, hg_maps.comp hf_surj.mapsTo_invFunOn,
+    fun z hz => ?_⟩
+  simp only [Function.comp_apply]
+  rw [hgi.leftInvOn_invFunOn (hf_surj.mapsTo_invFunOn hz)]
+  exact hf_surj.rightInvOn_invFunOn hz
+
 /--
 **Uniqueness in the Riemann mapping theorem, up to a disc automorphism.** If `f` and `g` are
 holomorphic injections from an open set `U` onto the open unit disc, then there are `u` on the
@@ -55,34 +76,12 @@ theorem exists_eqOn_unitDiscStandardAutomorphismFormula_comp {U : Set ℂ} (hU :
           (u : ℂ) *
             ((f z - (a : ℂ)) / (1 - (starRingEnd ℂ) (a : ℂ) * f z)))
         U := by
-  obtain ⟨hf_surj, hf_maps⟩ := image_eq_iff_surjOn_mapsTo.mp hfimage
-  obtain ⟨hg_surj, hg_maps⟩ := image_eq_iff_surjOn_mapsTo.mp hgimage
-  let F : ℂ → ℂ := g ∘ Function.invFunOn f U
-  let G : ℂ → ℂ := f ∘ Function.invFunOn g U
-  have hfinv : DifferentiableOn ℂ (Function.invFunOn f U) (ball (0 : ℂ) 1) := by
-    rw [← hfimage]
-    exact DifferentiableOn.invFunOn hf hU hfi
-  have hginv : DifferentiableOn ℂ (Function.invFunOn g U) (ball (0 : ℂ) 1) := by
-    rw [← hgimage]
-    exact DifferentiableOn.invFunOn hg hU hgi
-  have hFdiff : DifferentiableOn ℂ F (ball (0 : ℂ) 1) :=
-    hg.comp hfinv hf_surj.mapsTo_invFunOn
-  have hGdiff : DifferentiableOn ℂ G (ball (0 : ℂ) 1) :=
-    hf.comp hginv hg_surj.mapsTo_invFunOn
-  have hFmaps : MapsTo F (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
-    hg_maps.comp hf_surj.mapsTo_invFunOn
-  have hGmaps : MapsTo G (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
-    hf_maps.comp hg_surj.mapsTo_invFunOn
-  have hGF : LeftInvOn G F (ball (0 : ℂ) 1) := by
-    intro z hz
-    simp only [F, G, Function.comp_apply]
-    rw [hgi.leftInvOn_invFunOn (hf_surj.mapsTo_invFunOn hz)]
-    exact hf_surj.rightInvOn_invFunOn hz
-  have hFG : RightInvOn G F (ball (0 : ℂ) 1) := by
-    intro z hz
-    simp only [F, G, Function.comp_apply]
-    rw [hfi.leftInvOn_invFunOn (hg_surj.mapsTo_invFunOn hz)]
-    exact hg_surj.rightInvOn_invFunOn hz
+  obtain ⟨-, hf_maps⟩ := image_eq_iff_surjOn_mapsTo.mp hfimage
+  -- the two transition maps, each the inverse of the other on the disc
+  obtain ⟨hFdiff, hFmaps, hGF⟩ :=
+    differentiableOn_mapsTo_leftInvOn_comp_invFunOn hU hf hg hfi hgi hfimage hgimage
+  obtain ⟨hGdiff, hGmaps, hFG⟩ :=
+    differentiableOn_mapsTo_leftInvOn_comp_invFunOn hU hg hf hgi hfi hgimage hfimage
   obtain ⟨u, a, _, hclass⟩ :=
     exists_forall_unitDisc_eq_unitDiscStandardAutomorphismEquiv
       hFdiff hGdiff hFmaps hGmaps hGF hFG
@@ -91,8 +90,7 @@ theorem exists_eqOn_unitDiscStandardAutomorphismFormula_comp {U : Set ℂ} (hU :
     simpa [mem_ball_zero_iff] using hf_maps hz
   have hclass_z := hclass (Complex.UnitDisc.mk (f z) hfz)
   rw [coe_unitDiscStandardAutomorphismEquiv_apply] at hclass_z
-  have hFz : F (f z) = g z := by
-    simp only [F, Function.comp_apply]
+  have hFz : g (Function.invFunOn f U (f z)) = g z := by
     rw [hfi.leftInvOn_invFunOn hz]
   rw [← hFz]
   simpa using hclass_z


### PR DESCRIPTION
`exists_eqOn_unitDiscStandardAutomorphismFormula_comp` built both transition maps `g ∘ f⁻¹` and `f ∘ g⁻¹` and then proved four facts about each — differentiability, self-mapping, and the two inverse relations — in eight `have`s that differed only by swapping `f` and `g`.

`differentiableOn_mapsTo_leftInvOn_comp_invFunOn` states the three facts once: for `f` and `g` injective and differentiable on `U`, with `f` surjecting onto a target `V` and `g` mapping into it, `g ∘ f⁻¹` is differentiable on `V`, maps `V` into itself, and is **left**-inverted there by `f ∘ g⁻¹`. It is stated over an arbitrary `V` rather than the disc, since the proof never uses the image equalities — only `SurjOn f U V` and `MapsTo g U V`.

The parent calls it twice, the second time with the arguments swapped. That swap is also where the right inverse comes from: `RightInvOn G F` unfolds to `LeftInvOn F G`, so the swapped call supplies it directly rather than repeating the argument.

The body drops from 42 lines to 19.

Two notes on the mechanics:

- The parent's `let F : ℂ → ℂ := g ∘ Function.invFunOn f U` is deleted. The helper's statement spells the composite out, and once the facts came from the helper the closing rewrite no longer matched through the abbreviation — the build says so directly (`has type … g (invFunOn f U (f z)) = … but is expected to have type … F (f z) = …`). The final step now names the composite.
- The helper's hypotheses are the seven actually used; `hf_maps` stays in the parent, which needs it separately to place `f z` in the disc.

Each of the three conclusions is one application of a Mathlib lemma — `DifferentiableOn.invFunOn` restricted by `.mono`, `MapsTo.comp`, and `Set.LeftInvOn.comp` — so the helper is six lines. It is not a wrapper for any one of them: it asserts that the transition map is a self-map of the target with a one-sided inverse, which is what the automorphism classification consumes, and it is used twice.

(`Set.LeftInvOn.comp` has to be named explicitly rather than reached by dot notation: the first argument is a `RightInvOn`, so `.comp` resolves to `RightInvOn.comp` and the third argument stops typechecking.)

Gates run locally: `lake build` (7146 jobs), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: ConformalMapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
