### PR TITLE
feat(Huber): the p-adic numbers are a Tate ring

### DIFF
--- a/TauCeti/RingTheory/Huber/Padic/Field.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Field.lean
@@ -15,9 +15,10 @@ pseudouniformiser. Together with `TauCeti.Huber.PadicInt.not_isTateRing` this is
 Layer-0 example separating the two notions: the same ideal of definition makes `ℤ_[p]` Huber but
 not Tate, and `ℚ_[p]` Tate, the difference being that `p` becomes a unit in `ℚ_[p]`.
 
-No transport is needed here, unlike for `ℤ_[p]`: Mathlib defines `ℤ_[p]` as the subring
-`{x : ℚ_[p] | ‖x‖ ≤ 1}`, so `Ideal ℤ_[p]` is already the type
-`TauCeti.Huber.PairOfDefinition` asks for.
+No `Ideal.comap` is needed here. Mathlib's `ℤ_[p]` is the subtype `{x : ℚ_[p] // ‖x‖ ≤ 1}` and
+`PadicInt.subring p` is a separate declaration cutting out the same set, so `ℤ_[p]` and
+`↥(PadicInt.subring p)` are definitionally equal. That is why `idealOfDefinition :=
+maximalIdeal ℤ_[p]` typechecks against the expected `Ideal ↥(PadicInt.subring p)` below.
 
 ## Main definitions
 
@@ -25,6 +26,10 @@ No transport is needed here, unlike for `ℤ_[p]`: Mathlib defines `ℤ_[p]` as 
 
 ## Main results
 
+* `TauCeti.Huber.Padic.pairOfDefinition_ringOfDefinition` and
+  `TauCeti.Huber.Padic.mem_pairOfDefinition_idealOfDefinition`: the two projections of the pair.
+  The ring of definition is pinned down by an equation, the ideal of definition by the
+  membership form `‖x‖ < 1` — see the note on that lemma for why.
 * `TauCeti.Huber.Padic.isPseudoUniformizer_p`: `p` is a pseudouniformiser of `ℚ_[p]`.
 * `TauCeti.Huber.Padic.isHuberRing` and `TauCeti.Huber.Padic.isTateRing`: `ℚ_[p]` is a Huber
   ring, and a Tate ring.
@@ -71,9 +76,9 @@ noncomputable def pairOfDefinition : PairOfDefinition ℚ_[p] where
 
 /-- The ring of definition of `pairOfDefinition` is `ℤ_[p]`.
 
-The ideal of definition is characterised by
-`TauCeti.Huber.Padic.mem_pairOfDefinition_idealOfDefinition`; an equation is avoided because
-`idealOfDefinition`'s type depends on `ringOfDefinition`. -/
+The companion projection, the ideal of definition, is characterised by
+`TauCeti.Huber.Padic.mem_pairOfDefinition_idealOfDefinition` in membership form rather than by an
+equation; that lemma's docstring gives the reason. -/
 @[simp]
 theorem pairOfDefinition_ringOfDefinition :
     (pairOfDefinition (p := p)).ringOfDefinition = _root_.PadicInt.subring p := (rfl)
@@ -81,10 +86,12 @@ theorem pairOfDefinition_ringOfDefinition :
 /-- **The ideal of definition of `pairOfDefinition` is `(p)`**, in membership form: an element
 belongs exactly when its norm is less than one.
 
-The membership form is used because `idealOfDefinition`'s type depends on `ringOfDefinition`, so
-an equation with `maximalIdeal ℤ_[p]` would be between two different `Ideal` types. It also
-leaves the ideal decidable downstream, which a statement transported along an equivalence would
-not. -/
+The membership form is used because `pairOfDefinition`'s body is not exposed, so the projection
+`pairOfDefinition.ringOfDefinition` does not reduce. The equation
+`pairOfDefinition.idealOfDefinition = maximalIdeal ℤ_[p]` is therefore rejected — the elaborator
+reports `Ideal ℤ_[p]` against `Ideal ↥pairOfDefinition.ringOfDefinition`, noting that
+`pairOfDefinition` "was not unfolded because their definition is not exposed". Membership avoids
+the issue: `x` already inhabits the dependent type, so nothing has to be transported. -/
 @[simp]
 theorem mem_pairOfDefinition_idealOfDefinition
     {x : (pairOfDefinition (p := p)).ringOfDefinition} :

--- a/TauCeti/RingTheory/Huber/Padic/Field.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Field.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.SpecificLimits.Normed
+public import TauCeti.RingTheory.Huber.Padic.Basic
+
+/-!
+# The p-adic numbers are a Tate ring
+
+`ℚ_[p]` is a Tate ring, with `(ℤ_[p], (p))` as a pair of definition and `p` as a
+pseudouniformiser. Together with `TauCeti.Huber.PadicInt.not_isTateRing` this is the roadmap's
+Layer-0 example separating the two notions: the same ideal of definition makes `ℤ_[p]` Huber but
+not Tate, and `ℚ_[p]` Tate, the difference being that `p` becomes a unit in `ℚ_[p]`.
+
+No transport is needed here, unlike for `ℤ_[p]`: Mathlib defines `ℤ_[p]` as the subring
+`{x : ℚ_[p] | ‖x‖ ≤ 1}`, so `Ideal ℤ_[p]` is already the type
+`TauCeti.Huber.PairOfDefinition` asks for.
+
+## Main definitions
+
+* `TauCeti.Huber.PairOfDefinition.padic`: the pair of definition `(ℤ_[p], (p))` of `ℚ_[p]`.
+
+## Main results
+
+* `TauCeti.Huber.Padic.isPseudoUniformizer_p`: `p` is a pseudouniformiser of `ℚ_[p]`.
+* `TauCeti.Huber.Padic.isHuberRing` and `TauCeti.Huber.Padic.isTateRing`: `ℚ_[p]` is a Huber
+  ring, and a Tate ring.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], §6, where Huber and Tate rings are introduced
+  (Proposition and Definition 6.1) and `ℚ_[p]` is the standard example of a Tate ring.
+-/
+
+public section
+
+open Topology IsLocalRing
+
+namespace TauCeti.Huber
+
+namespace Padic
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- The unit ball `ℤ_[p]` is open in `ℚ_[p]`. This is Mathlib's
+`PadicInt.isOpenEmbedding_coe` read through `Subtype.range_coe`. -/
+private theorem isOpen_padicIntSubring :
+    IsOpen ((_root_.PadicInt.subring p : Subring ℚ_[p]) : Set ℚ_[p]) := by
+  have h := (_root_.PadicInt.isOpenEmbedding_coe (p := p)).isOpen_range
+  rwa [Subtype.range_coe_subtype] at h
+
+/-- `p` is a pseudouniformiser of `ℚ_[p]`: it is a unit, and its powers have norm `p⁻ⁿ → 0`. -/
+theorem isPseudoUniformizer_p : IsPseudoUniformizer (p : ℚ_[p]) := by
+  have hlt : (p : ℝ)⁻¹ < 1 := inv_lt_one_of_one_lt₀ <| mod_cast (Fact.out : p.Prime).one_lt
+  -- `IsTopologicallyNilpotent` is by definition this convergence, so `exact` accepts it
+  have hnil : Filter.Tendsto (fun n : ℕ ↦ (p : ℚ_[p]) ^ n) Filter.atTop (𝓝 0) :=
+    tendsto_pow_atTop_nhds_zero_of_norm_lt_one (by rw [_root_.Padic.norm_p]; exact hlt)
+  exact isPseudoUniformizer_iff.mpr
+    ⟨Ne.isUnit (by exact_mod_cast (Fact.out : p.Prime).ne_zero), hnil⟩
+
+/-- The pair of definition `(ℤ_[p], (p))` exhibiting `ℚ_[p]` as a Huber ring. -/
+noncomputable def _root_.TauCeti.Huber.PairOfDefinition.padic :
+    PairOfDefinition ℚ_[p] where
+  ringOfDefinition := _root_.PadicInt.subring p
+  isOpen_ringOfDefinition := isOpen_padicIntSubring
+  idealOfDefinition := maximalIdeal ℤ_[p]
+  fg_idealOfDefinition := by
+    rw [_root_.PadicInt.maximalIdeal_eq_span_p]; exact Submodule.fg_span_singleton _
+  isAdic_idealOfDefinition := PadicInt.isAdic_maximalIdeal
+
+/-- The ring of definition of `PairOfDefinition.padic` is `ℤ_[p]`.
+
+There is no companion equation for `idealOfDefinition`: its type is `Ideal ↥ringOfDefinition`, so
+an equation with `maximalIdeal ℤ_[p]` only typechecks once `ringOfDefinition` has been rewritten,
+which the opaque body does not permit. Rewrite with this lemma first. -/
+@[simp]
+theorem _root_.TauCeti.Huber.PairOfDefinition.padic_ringOfDefinition :
+    (PairOfDefinition.padic (p := p)).ringOfDefinition = _root_.PadicInt.subring p := (rfl)
+
+/-- **The ideal of definition of `PairOfDefinition.padic` is `(p)`**, in membership form.
+
+`idealOfDefinition` has type `Ideal ↥ringOfDefinition`, so an equation with `maximalIdeal ℤ_[p]`
+does not typecheck while the body is opaque. Saying which elements belong avoids the dependent
+type altogether, and unlike a statement transported along an equivalence it determines the ideal
+for a downstream user: `‖x‖ < 1` is checkable. -/
+@[simp]
+theorem _root_.TauCeti.Huber.PairOfDefinition.mem_padic_idealOfDefinition
+    {x : (PairOfDefinition.padic (p := p)).ringOfDefinition} :
+    x ∈ (PairOfDefinition.padic (p := p)).idealOfDefinition ↔ ‖(x : ℚ_[p])‖ < 1 := by
+  simp only [PairOfDefinition.padic]
+  exact _root_.PadicInt.mem_nonunits
+
+/-- **`ℚ_[p]` is a Huber ring**, with `(ℤ_[p], (p))` as a pair of definition. -/
+instance isHuberRing : IsHuberRing ℚ_[p] :=
+  ⟨⟨PairOfDefinition.padic⟩⟩
+
+/-- **`ℚ_[p]` is a Tate ring**, with `p` as a pseudouniformiser. -/
+instance isTateRing : IsTateRing ℚ_[p] :=
+  ⟨⟨(p : ℚ_[p]), isPseudoUniformizer_p⟩⟩
+
+end Padic
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Padic/Field.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Field.lean
@@ -21,7 +21,7 @@ No transport is needed here, unlike for `ℤ_[p]`: Mathlib defines `ℤ_[p]` as 
 
 ## Main definitions
 
-* `TauCeti.Huber.PairOfDefinition.padic`: the pair of definition `(ℤ_[p], (p))` of `ℚ_[p]`.
+* `TauCeti.Huber.pairOfDefinition`: the pair of definition `(ℤ_[p], (p))` of `ℚ_[p]`.
 
 ## Main results
 
@@ -54,16 +54,14 @@ private theorem isOpen_padicIntSubring :
 
 /-- `p` is a pseudouniformiser of `ℚ_[p]`: it is a unit, and its powers have norm `p⁻ⁿ → 0`. -/
 theorem isPseudoUniformizer_p : IsPseudoUniformizer (p : ℚ_[p]) := by
-  have hlt : (p : ℝ)⁻¹ < 1 := inv_lt_one_of_one_lt₀ <| mod_cast (Fact.out : p.Prime).one_lt
-  -- `IsTopologicallyNilpotent` is by definition this convergence, so `exact` accepts it
+  -- `IsTopologicalNilpotent` is by definition this convergence, so `exact` accepts it
   have hnil : Filter.Tendsto (fun n : ℕ ↦ (p : ℚ_[p]) ^ n) Filter.atTop (𝓝 0) :=
-    tendsto_pow_atTop_nhds_zero_of_norm_lt_one (by rw [_root_.Padic.norm_p]; exact hlt)
+    tendsto_pow_atTop_nhds_zero_of_norm_lt_one _root_.Padic.norm_p_lt_one
   exact isPseudoUniformizer_iff.mpr
     ⟨Ne.isUnit (by exact_mod_cast (Fact.out : p.Prime).ne_zero), hnil⟩
 
 /-- The pair of definition `(ℤ_[p], (p))` exhibiting `ℚ_[p]` as a Huber ring. -/
-noncomputable def _root_.TauCeti.Huber.PairOfDefinition.padic :
-    PairOfDefinition ℚ_[p] where
+noncomputable def pairOfDefinition : PairOfDefinition ℚ_[p] where
   ringOfDefinition := _root_.PadicInt.subring p
   isOpen_ringOfDefinition := isOpen_padicIntSubring
   idealOfDefinition := maximalIdeal ℤ_[p]
@@ -71,31 +69,32 @@ noncomputable def _root_.TauCeti.Huber.PairOfDefinition.padic :
     rw [_root_.PadicInt.maximalIdeal_eq_span_p]; exact Submodule.fg_span_singleton _
   isAdic_idealOfDefinition := PadicInt.isAdic_maximalIdeal
 
-/-- The ring of definition of `PairOfDefinition.padic` is `ℤ_[p]`.
+/-- The ring of definition of `pairOfDefinition` is `ℤ_[p]`.
 
-There is no companion equation for `idealOfDefinition`: its type is `Ideal ↥ringOfDefinition`, so
-an equation with `maximalIdeal ℤ_[p]` only typechecks once `ringOfDefinition` has been rewritten,
-which the opaque body does not permit. Rewrite with this lemma first. -/
+The ideal of definition is characterised by
+`TauCeti.Huber.Padic.mem_pairOfDefinition_idealOfDefinition`; an equation is avoided because
+`idealOfDefinition`'s type depends on `ringOfDefinition`. -/
 @[simp]
-theorem _root_.TauCeti.Huber.PairOfDefinition.padic_ringOfDefinition :
-    (PairOfDefinition.padic (p := p)).ringOfDefinition = _root_.PadicInt.subring p := (rfl)
+theorem pairOfDefinition_ringOfDefinition :
+    (pairOfDefinition (p := p)).ringOfDefinition = _root_.PadicInt.subring p := (rfl)
 
-/-- **The ideal of definition of `PairOfDefinition.padic` is `(p)`**, in membership form.
+/-- **The ideal of definition of `pairOfDefinition` is `(p)`**, in membership form: an element
+belongs exactly when its norm is less than one.
 
-`idealOfDefinition` has type `Ideal ↥ringOfDefinition`, so an equation with `maximalIdeal ℤ_[p]`
-does not typecheck while the body is opaque. Saying which elements belong avoids the dependent
-type altogether, and unlike a statement transported along an equivalence it determines the ideal
-for a downstream user: `‖x‖ < 1` is checkable. -/
+The membership form is used because `idealOfDefinition`'s type depends on `ringOfDefinition`, so
+an equation with `maximalIdeal ℤ_[p]` would be between two different `Ideal` types. It also
+leaves the ideal decidable downstream, which a statement transported along an equivalence would
+not. -/
 @[simp]
-theorem _root_.TauCeti.Huber.PairOfDefinition.mem_padic_idealOfDefinition
-    {x : (PairOfDefinition.padic (p := p)).ringOfDefinition} :
-    x ∈ (PairOfDefinition.padic (p := p)).idealOfDefinition ↔ ‖(x : ℚ_[p])‖ < 1 := by
-  simp only [PairOfDefinition.padic]
+theorem mem_pairOfDefinition_idealOfDefinition
+    {x : (pairOfDefinition (p := p)).ringOfDefinition} :
+    x ∈ (pairOfDefinition (p := p)).idealOfDefinition ↔ ‖(x : ℚ_[p])‖ < 1 := by
+  simp only [pairOfDefinition]
   exact _root_.PadicInt.mem_nonunits
 
 /-- **`ℚ_[p]` is a Huber ring**, with `(ℤ_[p], (p))` as a pair of definition. -/
 instance isHuberRing : IsHuberRing ℚ_[p] :=
-  ⟨⟨PairOfDefinition.padic⟩⟩
+  ⟨⟨pairOfDefinition⟩⟩
 
 /-- **`ℚ_[p]` is a Tate ring**, with `p` as a pseudouniformiser. -/
 instance isTateRing : IsTateRing ℚ_[p] :=

--- a/TauCeti/RingTheory/Huber/Padic/Field.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Field.lean
@@ -21,7 +21,7 @@ No transport is needed here, unlike for `ℤ_[p]`: Mathlib defines `ℤ_[p]` as 
 
 ## Main definitions
 
-* `TauCeti.Huber.pairOfDefinition`: the pair of definition `(ℤ_[p], (p))` of `ℚ_[p]`.
+* `TauCeti.Huber.Padic.pairOfDefinition`: the pair of definition `(ℤ_[p], (p))` of `ℚ_[p]`.
 
 ## Main results
 


### PR DESCRIPTION
`ℚ_[p]` is a Tate ring. A new `TauCeti/RingTheory/Huber/Padic/Field.lean`.

Together with `PadicInt.not_isTateRing` from #2508 (now merged) this is the roadmap's Layer-0
example separating Huber from Tate. The same ideal `(p)` serves both: it makes `ℤ_[p]` Huber but
*not* Tate, because a pseudouniformiser has to be a topologically nilpotent **unit** and every
unit of `ℤ_[p]` has norm one. Passing to `ℚ_[p]` makes `p` a unit and nothing else changes, so
the pair `(ℤ_[p], (p))` now witnesses a Tate ring.

What gets proved.

* `isPseudoUniformizer_p` — `p` is a unit in `ℚ_[p]` (`Ne.isUnit`, from primality giving
  `p ≠ 0`), and `pⁿ → 0`, which is
  `tendsto_pow_atTop_nhds_zero_of_norm_lt_one` applied to Mathlib's `Padic.norm_p_lt_one`. No
  norm computation is done by hand.
* `pairOfDefinition` — `ℤ_[p]` is open in `ℚ_[p]`, which is `PadicInt.isOpenEmbedding_coe`
  read through `Subtype.range_coe_subtype`; the adic part is `PadicInt.isAdic_maximalIdeal`
  from #2508, and finite generation is `PadicInt.maximalIdeal_eq_span_p`.
* `pairOfDefinition_ringOfDefinition` and `mem_pairOfDefinition_idealOfDefinition` — both
  projections of the pair are pinned down, the first by an equation and the second in the
  membership form `‖x‖ < 1`.
* `isHuberRing` and `isTateRing` — immediate from the above.

**No `Ideal.comap` is needed here**, unlike for `ℤ_[p]`. Mathlib's `ℤ_[p]` is the subtype
`{x : ℚ_[p] // ‖x‖ ≤ 1}` and `PadicInt.subring p` is a separate declaration cutting out the same
set, so `ℤ_[p]` and `↥(PadicInt.subring p)` are definitionally equal and the field assignment
`idealOfDefinition := maximalIdeal ℤ_[p]` typechecks directly. #2508 had to move an ideal across
a `RingEquiv`; this PR does not.

The ideal of definition is nevertheless stated in **membership** form rather than as an equation,
and the reason is the module system rather than the dependency itself. `pairOfDefinition`'s body
is not exposed, so `pairOfDefinition.ringOfDefinition` does not reduce, and the equation is
rejected:

```
error: Type mismatch
  maximalIdeal ℤ_[p]
has type
  Ideal ℤ_[p]
but is expected to have type
  Ideal ↥pairOfDefinition.ringOfDefinition

Note: The following definitions were not unfolded because their definition is not exposed:
  pairOfDefinition
```

Membership sidesteps it because `x` already inhabits the dependent type. Both docstrings in the
file now say exactly this.

Scope: only `ℚ_[p]`. `F⸨t⸩` and the strongly noetherian `ℚ_p⟨T₁,…,Tₙ⟩` are separate roadmap rows
and are not in this PR.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0-examples-padic-field"}-->

🤖 Prepared with Claude Code
