### PR TITLE
feat(Huber): the formal Laurent series field is a Tate ring

### DIFF
--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -80,21 +80,22 @@ theorem isOpen_powerSeries_as_subring :
     IsOpen ((powerSeries_as_subring K : Subring K⸨X⸩) : Set K⸨X⸩) :=
   (coe_powerSeries_as_subring K) ▸ Valued.isOpen_integer K⸨X⸩
 
-/-- The variable `X`, viewed inside the ring of definition. -/
-noncomputable def XD : powerSeries_as_subring K := powerSeriesEquivSubring K PowerSeries.X
+/-- The variable `X`, viewed inside the ring of definition `K⟦X⟧ ⊆ K⸨X⸩`. -/
+noncomputable def subringX : powerSeries_as_subring K := powerSeriesEquivSubring K PowerSeries.X
 
 @[simp]
-theorem coe_XD : (XD K : K⸨X⸩) = ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) := (rfl)
+theorem coe_subringX : (subringX K : K⸨X⸩) = ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) := (rfl)
 
 /-- The ideal of definition `(X)` of `K⟦X⟧ ⊆ K⸨X⸩`. -/
-noncomputable def idealOfDefinition : Ideal (powerSeries_as_subring K) := Ideal.span {XD K}
+noncomputable def idealOfDefinition : Ideal (powerSeries_as_subring K) := Ideal.span {subringX K}
 
 /-- Unfolding lemma for `TauCeti.Huber.LaurentSeries.idealOfDefinition`. -/
-theorem idealOfDefinition_def : idealOfDefinition K = Ideal.span {XD K} := (rfl)
+theorem idealOfDefinition_def : idealOfDefinition K = Ideal.span {subringX K} := (rfl)
 
-/-- `X` is nonzero in `K⸨X⸩`, so all its powers are invertible. -/
+/-- `X` is nonzero in `K⸨X⸩`, so, `K⸨X⸩` being a field, all its powers are invertible. -/
 theorem coe_X_ne_zero : ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ≠ 0 := by
-  simp
+  simp only [HahnSeries.ofPowerSeries_X, ne_eq, HahnSeries.single_eq_zero_iff, one_ne_zero,
+    not_false_eq_true]
 
 variable {K}
 
@@ -109,9 +110,9 @@ theorem mem_idealOfDefinition_pow_iff (n : ℕ) (f : powerSeries_as_subring K) :
       have hmem := g.2
       rwa [← SetLike.mem_coe, coe_powerSeries_as_subring, SetLike.mem_coe,
         Valuation.mem_integer_iff] at hmem
-    have hcoe : ((g * XD K ^ n : powerSeries_as_subring K) : K⸨X⸩)
+    have hcoe : ((g * subringX K ^ n : powerSeries_as_subring K) : K⸨X⸩)
         = (g : K⸨X⸩) * ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n := by
-      push_cast [coe_XD]
+      push_cast [coe_subringX]
       rfl
     rw [hcoe, map_mul, valuation_X_pow]
     calc Valued.v (g : K⸨X⸩) * exp (-(n : ℤ)) ≤ 1 * exp (-(n : ℤ)) := by gcongr
@@ -123,9 +124,9 @@ theorem mem_idealOfDefinition_pow_iff (n : ℕ) (f : powerSeries_as_subring K) :
       exact hf
     obtain ⟨F, hF⟩ := (val_le_one_iff_eq_coe K _).mp hu
     refine ⟨powerSeriesEquivSubring K F, Subtype.ext ?_⟩
-    have hcoe : ((powerSeriesEquivSubring K F * XD K ^ n : powerSeries_as_subring K) : K⸨X⸩)
+    have hcoe : ((powerSeriesEquivSubring K F * subringX K ^ n : powerSeries_as_subring K) : K⸨X⸩)
         = (F : K⸨X⸩) * ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n := by
-      push_cast [coe_XD]
+      push_cast [coe_subringX]
       rfl
     rw [hcoe, hF, inv_mul_cancel_right₀ (pow_ne_zero n (coe_X_ne_zero K))]
 
@@ -173,9 +174,15 @@ noncomputable def pairOfDefinition : PairOfDefinition K⸨X⸩ where
   ringOfDefinition := powerSeries_as_subring K
   isOpen_ringOfDefinition := isOpen_powerSeries_as_subring K
   idealOfDefinition := idealOfDefinition K
-  fg_idealOfDefinition := ⟨{XD K}, by simp [idealOfDefinition_def]⟩
+  fg_idealOfDefinition := ⟨{subringX K}, by simp [idealOfDefinition_def]⟩
   isAdic_idealOfDefinition := isAdic_idealOfDefinition K
 
+/-- The ring of definition of `TauCeti.Huber.LaurentSeries.pairOfDefinition` is the power series.
+
+There is deliberately no companion lemma for the ideal: `PairOfDefinition.idealOfDefinition` is
+dependent on `ringOfDefinition`, so with the body hidden by the module system an equation between
+the two ideals does not typecheck. The bridge
+`TauCeti.Huber.LaurentSeries.mem_idealOfDefinition_pow_iff` is what consumers use instead. -/
 @[simp]
 theorem pairOfDefinition_ringOfDefinition :
     (pairOfDefinition K).ringOfDefinition = powerSeries_as_subring K := (rfl)

--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.LaurentSeries
+public import Mathlib.Topology.Algebra.Valued.WithZeroMulInt
 public import TauCeti.RingTheory.Huber.Basic
 
 /-!
@@ -14,10 +15,7 @@ For a field `K` the formal Laurent series `K⸨X⸩`, with the `X`-adic topology
 `LaurentSeries.valued` instance, are a Tate ring: the power series are an open subring, the
 ideal `(X)` is a finitely generated ideal of definition, and `X` itself is a pseudouniformiser.
 
-This is the equal-characteristic half of the roadmap's Layer-0 examples separating Huber from
-Tate. The mixed-characteristic half — `ℤ_[p]` Huber but not Tate, and `ℚ_[p]` Tate — is separate
-unmerged work (TauCetiProject/TauCeti#2508 and #2538) and is deliberately not referenced by name
-here, since nothing in this repository provides it yet.
+`K⸨X⸩` is the equal-characteristic Tate example of the roadmap's Layer-0 Examples row.
 
 ## Main definitions
 
@@ -44,9 +42,7 @@ form and the `ℤᵐ⁰` bounds the rest of the file uses.
 
 ## Provenance
 
-New work; the roadmap names no source for this row. The file's shape deliberately mirrors the
-`ℤ_[p]` example being prepared in TauCetiProject/TauCeti#2508, so that the Layer-0 examples end
-up presenting the same interface; that module is not in this repository yet.
+New work; the roadmap names no source for this row.
 
 ## References
 
@@ -212,17 +208,14 @@ theorem mem_pairOfDefinition_idealImage (n : ℕ) (f : K⸨X⸩) :
 
 /-- **`X` is a pseudouniformiser of `K⸨X⸩`**: it is a unit, since `K⸨X⸩` is a field, and
 `v (Xⁿ) = exp (-n)` tends to zero. -/
-theorem isPseudoUniformizer_X : IsPseudoUniformizer ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) := by
-  refine isPseudoUniformizer_iff.mpr ⟨isUnit_iff_ne_zero.mpr (coe_X_ne_zero K), ?_⟩
-  refine Filter.tendsto_def.mpr fun s hs ↦ ?_
-  obtain ⟨c, hc, hcs⟩ := exists_ball_subset K hs
-  filter_upwards [eventually_ge_atTop (1 - log c).toNat] with n hn
-  refine hcs ?_
-  rw [Set.mem_ofPred_eq, valuation_X_pow, ← lt_log_iff_exp_lt hc]
-  omega
+theorem isPseudoUniformizer_X : IsPseudoUniformizer ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) :=
+  isPseudoUniformizer_iff.mpr ⟨isUnit_iff_ne_zero.mpr (coe_X_ne_zero K),
+    Valued.tendsto_zero_pow_of_le_exp_neg_one (by simpa using (valuation_X_pow (K := K) 1).le)⟩
 
+/-- **`K⸨X⸩` is a Huber ring**, with `(K⟦X⟧, (X))` as a pair of definition. -/
 instance isHuberRing : IsHuberRing K⸨X⸩ := ⟨⟨pairOfDefinition K⟩⟩
 
+/-- **`K⸨X⸩` is a Tate ring**: `X` is a pseudouniformiser. -/
 instance isTateRing : IsTateRing K⸨X⸩ where
   exists_isPseudoUniformizer := ⟨_, isPseudoUniformizer_X K⟩
 

--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -14,8 +14,10 @@ For a field `K` the formal Laurent series `K⸨X⸩`, with the `X`-adic topology
 `LaurentSeries.valued` instance, are a Tate ring: the power series are an open subring, the
 ideal `(X)` is a finitely generated ideal of definition, and `X` itself is a pseudouniformiser.
 
-Together with `TauCeti.Huber.PadicInt.not_isTateRing` and `TauCeti.Huber.Padic.isTateRing` this
-is the equal-characteristic half of the roadmap's Layer-0 examples separating Huber from Tate.
+This is the equal-characteristic half of the roadmap's Layer-0 examples separating Huber from
+Tate. The mixed-characteristic half — `ℤ_[p]` Huber but not Tate, and `ℚ_[p]` Tate — is separate
+unmerged work (TauCetiProject/TauCeti#2508 and #2538) and is deliberately not referenced by name
+here, since nothing in this repository provides it yet.
 
 ## Main definitions
 
@@ -42,9 +44,9 @@ form and the `ℤᵐ⁰` bounds the rest of the file uses.
 
 ## Provenance
 
-New work; the roadmap names no source for this row. The file's shape follows
-`TauCeti/RingTheory/Huber/Padic.lean`, the `ℤ_[p]` example, so that the two Layer-0 examples
-present the same interface.
+New work; the roadmap names no source for this row. The file's shape deliberately mirrors the
+`ℤ_[p]` example being prepared in TauCetiProject/TauCeti#2508, so that the Layer-0 examples end
+up presenting the same interface; that module is not in this repository yet.
 
 ## References
 
@@ -101,6 +103,7 @@ variable {K}
 
 /-- **The bridge to the valuation**: a power series lies in `(X)ⁿ` exactly when its valuation is
 at most `exp (-n)`. -/
+@[simp]
 theorem mem_idealOfDefinition_pow_iff (n : ℕ) (f : powerSeries_as_subring K) :
     f ∈ idealOfDefinition K ^ n ↔ Valued.v (f : K⸨X⸩) ≤ exp (-(n : ℤ)) := by
   rw [idealOfDefinition_def, Ideal.span_singleton_pow, Ideal.mem_span_singleton']
@@ -187,6 +190,23 @@ the two ideals does not typecheck. The bridge
 theorem pairOfDefinition_ringOfDefinition :
     (pairOfDefinition K).ringOfDefinition = powerSeries_as_subring K := (rfl)
 
+/-- **The pair of definition is `(K⟦X⟧, (X))`**, said without touching the dependent field:
+`PairOfDefinition.idealImage n` is the image of `(X)ⁿ` in `K⸨X⸩`, so it can be compared with a
+valuation bound directly. -/
+@[simp]
+theorem mem_pairOfDefinition_idealImage (n : ℕ) (f : K⸨X⸩) :
+    f ∈ (pairOfDefinition K).idealImage n ↔ Valued.v f ≤ exp (-(n : ℤ)) := by
+  rw [PairOfDefinition.mem_idealImage]
+  refine ⟨?_, fun hf ↦ ?_⟩
+  · rintro ⟨y, hy, rfl⟩
+    exact (mem_idealOfDefinition_pow_iff n y).mp hy
+  · have hle : Valued.v f ≤ 1 :=
+      hf.trans (by simpa using exp_le_exp.mpr (by omega : (-(n : ℤ)) ≤ 0))
+    have hmem : f ∈ powerSeries_as_subring K := by
+      rw [← SetLike.mem_coe, coe_powerSeries_as_subring]
+      exact hle
+    exact ⟨⟨f, hmem⟩, (mem_idealOfDefinition_pow_iff n _).mpr hf, rfl⟩
+
 /-- **`X` is a pseudouniformiser of `K⸨X⸩`**: it is a unit, since `K⸨X⸩` is a field, and
 `v (Xⁿ) = exp (-n)` tends to zero. -/
 theorem isPseudoUniformizer_X : IsPseudoUniformizer ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) := by
@@ -194,8 +214,8 @@ theorem isPseudoUniformizer_X : IsPseudoUniformizer ((PowerSeries.X : K⟦X⟧) 
   refine Filter.tendsto_def.mpr fun s hs ↦ ?_
   obtain ⟨c, hc, hcs⟩ := exists_ball_subset K hs
   filter_upwards [eventually_ge_atTop (1 - log c).toNat] with n hn
-  refine hcs (show Valued.v (((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n) < c from ?_)
-  rw [valuation_X_pow, ← lt_log_iff_exp_lt hc]
+  refine hcs ?_
+  rw [Set.mem_ofPred_eq, valuation_X_pow, ← lt_log_iff_exp_lt hc]
   omega
 
 instance isHuberRing : IsHuberRing K⸨X⸩ := ⟨⟨pairOfDefinition K⟩⟩

--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -78,6 +78,21 @@ theorem isOpen_powerSeries_as_subring :
     IsOpen ((powerSeries_as_subring K : Subring K⸨X⸩) : Set K⸨X⸩) :=
   (coe_powerSeries_as_subring K) ▸ Valued.isOpen_integer K⸨X⸩
 
+/-- The power series are the valuation integers of `K⸨X⸩`, packaged as
+`Valuation.Integers`. This is what lets the divisibility/valuation dictionary
+(`Valuation.Integers.dvd_iff_le`) apply to `(X)ⁿ` directly, with no transport and no
+coefficient bookkeeping. -/
+theorem integers_powerSeries_as_subring :
+    Valuation.Integers (Valued.v : Valuation K⸨X⸩ ℤᵐ⁰) (powerSeries_as_subring K) where
+  hom_inj := Subtype.val_injective
+  map_le_one x := by
+    have hmem := x.2
+    rwa [← SetLike.mem_coe, coe_powerSeries_as_subring, SetLike.mem_coe,
+      Valuation.mem_integer_iff] at hmem
+  exists_of_le_one {r} hr := by
+    obtain ⟨F, hF⟩ := (val_le_one_iff_eq_coe K r).mp hr
+    exact ⟨powerSeriesEquivSubring K F, hF⟩
+
 /-- The variable `X`, viewed inside the ring of definition `K⟦X⟧ ⊆ K⸨X⸩`. -/
 noncomputable def subringX : powerSeries_as_subring K := powerSeriesEquivSubring K PowerSeries.X
 
@@ -102,32 +117,13 @@ at most `exp (-n)`. -/
 @[simp]
 theorem mem_idealOfDefinition_pow_iff (n : ℕ) (f : powerSeries_as_subring K) :
     f ∈ idealOfDefinition K ^ n ↔ Valued.v (f : K⸨X⸩) ≤ exp (-(n : ℤ)) := by
-  rw [idealOfDefinition_def, Ideal.span_singleton_pow, Ideal.mem_span_singleton']
-  constructor
-  · rintro ⟨g, rfl⟩
-    have hg : Valued.v (g : K⸨X⸩) ≤ 1 := by
-      have hmem := g.2
-      rwa [← SetLike.mem_coe, coe_powerSeries_as_subring, SetLike.mem_coe,
-        Valuation.mem_integer_iff] at hmem
-    have hcoe : ((g * subringX K ^ n : powerSeries_as_subring K) : K⸨X⸩)
-        = (g : K⸨X⸩) * ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n := by
-      push_cast [coe_subringX]
-      rfl
-    rw [hcoe, map_mul, valuation_X_pow]
-    calc Valued.v (g : K⸨X⸩) * exp (-(n : ℤ)) ≤ 1 * exp (-(n : ℤ)) := by gcongr
-      _ = exp (-(n : ℤ)) := one_mul _
-  · intro hf
-    have hu : Valued.v ((f : K⸨X⸩) * (((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n)⁻¹) ≤ 1 := by
-      rw [map_mul, map_inv₀, valuation_X_pow, ← le_div_iff₀ (by simp), div_eq_mul_inv, one_mul,
-        inv_inv]
-      exact hf
-    obtain ⟨F, hF⟩ := (val_le_one_iff_eq_coe K _).mp hu
-    refine ⟨powerSeriesEquivSubring K F, Subtype.ext ?_⟩
-    have hcoe : ((powerSeriesEquivSubring K F * subringX K ^ n : powerSeries_as_subring K) : K⸨X⸩)
-        = (F : K⸨X⸩) * ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n := by
-      push_cast [coe_subringX]
-      rfl
-    rw [hcoe, hF, inv_mul_cancel_right₀ (pow_ne_zero n (coe_X_ne_zero K))]
+  rw [idealOfDefinition_def, Ideal.span_singleton_pow, Ideal.mem_span_singleton,
+    (integers_powerSeries_as_subring K).dvd_iff_le]
+  -- `algebraMap ↥(powerSeries_as_subring K) K⸨X⸩` is `Subtype.val`, so both sides are already
+  -- the coercions; only the weight has to be evaluated.
+  change Valued.v (f : K⸨X⸩) ≤ Valued.v ((subringX K : K⸨X⸩) ^ n) ↔
+    Valued.v (f : K⸨X⸩) ≤ exp (-(n : ℤ))
+  rw [coe_subringX, valuation_X_pow]
 
 variable (K)
 

--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -27,7 +27,7 @@ ideal `(X)` is a finitely generated ideal of definition, and `X` itself is a pse
 * `TauCeti.Huber.LaurentSeries.mem_idealOfDefinition_pow_iff`: membership of `(X)ⁿ` is the
   valuation bound `v f ≤ exp (-n)`. `isAdic_idealOfDefinition` and
   `mem_pairOfDefinition_idealImage` are read off it; the openness of the ring of definition and
-  the nilpotence of `X` come from Mathlib's valuation API instead.
+  the topological nilpotence of `X` come from Mathlib's valuation API instead.
 * `TauCeti.Huber.LaurentSeries.isPseudoUniformizer_X`: `X` is a pseudouniformiser.
 * `TauCeti.Huber.LaurentSeries.isHuberRing` and `TauCeti.Huber.LaurentSeries.isTateRing`.
 
@@ -105,8 +105,7 @@ noncomputable def idealOfDefinition : Ideal (powerSeries_as_subring K) := Ideal.
 /-- Unfolding lemma for `TauCeti.Huber.LaurentSeries.idealOfDefinition`. -/
 theorem idealOfDefinition_def : idealOfDefinition K = Ideal.span {subringX K} := (rfl)
 
-/-- `X` is nonzero in `K⸨X⸩`. Only nontriviality of the coefficients is involved; that its
-powers are then invertible is separate, and uses that `K⸨X⸩` is a field. -/
+/-- `X` is nonzero in `K⸨X⸩`. -/
 theorem coe_X_ne_zero : ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ≠ 0 := by
   simp only [HahnSeries.ofPowerSeries_X, ne_eq, HahnSeries.single_eq_zero_iff, one_ne_zero,
     not_false_eq_true]
@@ -176,17 +175,18 @@ noncomputable def pairOfDefinition : PairOfDefinition K⸨X⸩ where
 /-- The ring of definition of `TauCeti.Huber.LaurentSeries.pairOfDefinition` is the power series.
 
 The ideal is characterised by `TauCeti.Huber.LaurentSeries.mem_pairOfDefinition_idealOfDefinition`
-in membership form; an *equation* between the two ideals does not typecheck, since
-`idealOfDefinition`'s type depends on `ringOfDefinition`. -/
+in membership form. An equation is avoided rather than impossible: `idealOfDefinition`'s type
+depends on `ringOfDefinition`, so an equation would be between two `Ideal` types that the
+elaborator identifies only through that projection. -/
 @[simp]
 theorem pairOfDefinition_ringOfDefinition :
     (pairOfDefinition K).ringOfDefinition = powerSeries_as_subring K := (rfl)
 
 /-- **The ideal of definition of `pairOfDefinition` is `(X)`**, in membership form.
 
-An *equation* between `idealOfDefinition` and `idealOfDefinition K` does not typecheck, since
-the former's type depends on the pair's `ringOfDefinition`; a membership statement is unaffected,
-because `f` is already taken in that dependent type. -/
+The membership form is used because `idealOfDefinition`'s type depends on the pair's
+`ringOfDefinition`; `f` is already taken in that dependent type, so nothing has to be
+transported. -/
 @[simp]
 theorem mem_pairOfDefinition_idealOfDefinition {n : ℕ}
     {f : (pairOfDefinition K).ringOfDefinition} :

--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.LaurentSeries
+public import TauCeti.RingTheory.Huber.Basic
+
+/-!
+# The formal Laurent series field is a Tate ring
+
+For a field `K` the formal Laurent series `K⸨X⸩`, with the `X`-adic topology of Mathlib's
+`LaurentSeries.valued` instance, are a Tate ring: the power series are an open subring, the
+ideal `(X)` is a finitely generated ideal of definition, and `X` itself is a pseudouniformiser.
+
+Together with `TauCeti.Huber.PadicInt.not_isTateRing` and `TauCeti.Huber.Padic.isTateRing` this
+is the equal-characteristic half of the roadmap's Layer-0 examples separating Huber from Tate.
+
+## Main definitions
+
+* `TauCeti.Huber.LaurentSeries.idealOfDefinition`: the ideal `(X)` of `K⟦X⟧ ⊆ K⸨X⸩`.
+* `TauCeti.Huber.LaurentSeries.pairOfDefinition`: the pair of definition `(K⟦X⟧, (X))`.
+
+## Main results
+
+* `TauCeti.Huber.LaurentSeries.mem_idealOfDefinition_pow_iff`: membership of `(X)ⁿ` is the
+  valuation bound `v f ≤ exp (-n)`. Every topological statement here is read off this.
+* `TauCeti.Huber.LaurentSeries.isPseudoUniformizer_X`: `X` is a pseudouniformiser.
+* `TauCeti.Huber.LaurentSeries.isHuberRing` and `TauCeti.Huber.LaurentSeries.isTateRing`.
+
+## Implementation notes
+
+The ring of definition is not built by hand: `LaurentSeries.val_le_one_iff_eq_coe` says that a
+Laurent series has valuation at most one exactly when it is a power series, so Mathlib's
+`LaurentSeries.powerSeries_as_subring` *is* the valuation subring and is open by
+`Valued.isOpen_integer`.
+
+The neighbourhood API of a `Valued` ring is phrased in the value group `ValueGroup₀ v` rather
+than in `Γ₀`, so the two `private` lemmas below convert once, in each direction, between that
+form and the `ℤᵐ⁰` bounds the rest of the file uses.
+
+## Provenance
+
+New work; the roadmap names no source for this row. The file's shape follows
+`TauCeti/RingTheory/Huber/Padic.lean`, the `ℤ_[p]` example, so that the two Layer-0 examples
+present the same interface.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], §6, where Huber and Tate rings are introduced
+  (Proposition and Definition 6.1) and `F⸨t⸩` is the standard equal-characteristic example of a
+  Tate ring.
+-/
+
+public section
+
+open Filter Topology WithZero PowerSeries
+open scoped LaurentSeries
+
+namespace TauCeti.Huber
+
+namespace LaurentSeries
+
+open _root_.LaurentSeries (powerSeries_as_subring powerSeriesEquivSubring val_le_one_iff_eq_coe
+  valuation_X_pow)
+
+variable (K : Type*) [Field K]
+
+/-- The power series inside `K⸨X⸩` are exactly the elements of valuation at most one. -/
+theorem coe_powerSeries_as_subring :
+    ((powerSeries_as_subring K : Subring K⸨X⸩) : Set K⸨X⸩) = (Valued.v (R := K⸨X⸩)).integer := by
+  ext f
+  simp only [Valuation.mem_integer_iff, SetLike.mem_coe]
+  rw [val_le_one_iff_eq_coe]
+  exact ⟨by rintro ⟨g, -, rfl⟩; exact ⟨g, rfl⟩, by rintro ⟨g, rfl⟩; exact ⟨g, trivial, rfl⟩⟩
+
+/-- The ring of definition is open, being the valuation subring. -/
+theorem isOpen_powerSeries_as_subring :
+    IsOpen ((powerSeries_as_subring K : Subring K⸨X⸩) : Set K⸨X⸩) :=
+  (coe_powerSeries_as_subring K) ▸ Valued.isOpen_integer K⸨X⸩
+
+/-- The variable `X`, viewed inside the ring of definition. -/
+noncomputable def XD : powerSeries_as_subring K := powerSeriesEquivSubring K PowerSeries.X
+
+@[simp]
+theorem coe_XD : (XD K : K⸨X⸩) = ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) := (rfl)
+
+/-- The ideal of definition `(X)` of `K⟦X⟧ ⊆ K⸨X⸩`. -/
+noncomputable def idealOfDefinition : Ideal (powerSeries_as_subring K) := Ideal.span {XD K}
+
+/-- Unfolding lemma for `TauCeti.Huber.LaurentSeries.idealOfDefinition`. -/
+theorem idealOfDefinition_def : idealOfDefinition K = Ideal.span {XD K} := (rfl)
+
+/-- `X` is nonzero in `K⸨X⸩`, so all its powers are invertible. -/
+theorem coe_X_ne_zero : ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ≠ 0 := by
+  simp
+
+variable {K}
+
+/-- **The bridge to the valuation**: a power series lies in `(X)ⁿ` exactly when its valuation is
+at most `exp (-n)`. -/
+theorem mem_idealOfDefinition_pow_iff (n : ℕ) (f : powerSeries_as_subring K) :
+    f ∈ idealOfDefinition K ^ n ↔ Valued.v (f : K⸨X⸩) ≤ exp (-(n : ℤ)) := by
+  rw [idealOfDefinition_def, Ideal.span_singleton_pow, Ideal.mem_span_singleton']
+  constructor
+  · rintro ⟨g, rfl⟩
+    have hg : Valued.v (g : K⸨X⸩) ≤ 1 := by
+      have hmem := g.2
+      rwa [← SetLike.mem_coe, coe_powerSeries_as_subring, SetLike.mem_coe,
+        Valuation.mem_integer_iff] at hmem
+    have hcoe : ((g * XD K ^ n : powerSeries_as_subring K) : K⸨X⸩)
+        = (g : K⸨X⸩) * ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n := by
+      push_cast [coe_XD]
+      rfl
+    rw [hcoe, map_mul, valuation_X_pow]
+    calc Valued.v (g : K⸨X⸩) * exp (-(n : ℤ)) ≤ 1 * exp (-(n : ℤ)) := by gcongr
+      _ = exp (-(n : ℤ)) := one_mul _
+  · intro hf
+    have hu : Valued.v ((f : K⸨X⸩) * (((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n)⁻¹) ≤ 1 := by
+      rw [map_mul, map_inv₀, valuation_X_pow, ← le_div_iff₀ (by simp), div_eq_mul_inv, one_mul,
+        inv_inv]
+      exact hf
+    obtain ⟨F, hF⟩ := (val_le_one_iff_eq_coe K _).mp hu
+    refine ⟨powerSeriesEquivSubring K F, Subtype.ext ?_⟩
+    have hcoe : ((powerSeriesEquivSubring K F * XD K ^ n : powerSeries_as_subring K) : K⸨X⸩)
+        = (F : K⸨X⸩) * ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n := by
+      push_cast [coe_XD]
+      rfl
+    rw [hcoe, hF, inv_mul_cancel_right₀ (pow_ne_zero n (coe_X_ne_zero K))]
+
+variable (K)
+
+/-- The valuation ball cut out by `v (Xⁿ)` is a neighbourhood of zero. The bound is phrased with
+`v (Xⁿ)` rather than `exp (-n)` so that it is visibly in the value group. -/
+private theorem ball_mem_nhds (n : ℕ) :
+    {x : K⸨X⸩ | Valued.v x < Valued.v (((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n)} ∈ 𝓝 (0 : K⸨X⸩) := by
+  refine Valued.mem_nhds_zero.mpr
+    ⟨Units.mk0 (Valued.v.restrict (((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n)) (by simp), ?_⟩
+  exact fun _ hx ↦ Valued.v.restrict_lt_iff.mp hx
+
+/-- Conversely every neighbourhood of zero contains a valuation ball with a bound in `ℤᵐ⁰`. -/
+private theorem exists_ball_subset {s : Set K⸨X⸩} (hs : s ∈ 𝓝 (0 : K⸨X⸩)) :
+    ∃ c : ℤᵐ⁰, c ≠ 0 ∧ {x : K⸨X⸩ | Valued.v x < c} ⊆ s := by
+  obtain ⟨γ, hγ⟩ := Valued.mem_nhds_zero.mp hs
+  exact ⟨MonoidWithZeroHom.ValueGroup₀.embedding γ.1, by simp,
+    fun x hx ↦ hγ (Valued.v.restrict_lt_iff_lt_embedding.mpr hx)⟩
+
+/-- The subspace topology on `K⟦X⟧ ⊆ K⸨X⸩` is the `X`-adic topology. -/
+theorem isAdic_idealOfDefinition : IsAdic (idealOfDefinition K) := by
+  rw [isAdic_iff]
+  refine ⟨fun n ↦ ?_, fun s hs ↦ ?_⟩
+  · have hmem : (((idealOfDefinition K ^ n).toAddSubgroup :
+        AddSubgroup (powerSeries_as_subring K)) : Set (powerSeries_as_subring K))
+        ∈ 𝓝 (0 : powerSeries_as_subring K) := by
+      rw [IsInducing.subtypeVal.nhds_eq_comap, ZeroMemClass.coe_zero, Filter.mem_comap]
+      refine ⟨_, ball_mem_nhds K n, fun f hf ↦ (mem_idealOfDefinition_pow_iff n f).mpr ?_⟩
+      have hf' : Valued.v (f : K⸨X⸩)
+          < Valued.v (((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n) := hf
+      rw [valuation_X_pow] at hf'
+      exact hf'.le
+    exact AddSubgroup.isOpen_of_mem_nhds _ hmem
+  · rw [IsInducing.subtypeVal.nhds_eq_comap, ZeroMemClass.coe_zero, Filter.mem_comap] at hs
+    obtain ⟨t, ht, hts⟩ := hs
+    obtain ⟨c, hc, hct⟩ := exists_ball_subset K ht
+    refine ⟨(1 - log c).toNat, fun f hf ↦ hts (hct ?_)⟩
+    refine lt_of_le_of_lt ((mem_idealOfDefinition_pow_iff _ f).mp hf) ?_
+    rw [← lt_log_iff_exp_lt hc]
+    omega
+
+/-- **The pair of definition** `(K⟦X⟧, (X))` of `K⸨X⸩`. -/
+noncomputable def pairOfDefinition : PairOfDefinition K⸨X⸩ where
+  ringOfDefinition := powerSeries_as_subring K
+  isOpen_ringOfDefinition := isOpen_powerSeries_as_subring K
+  idealOfDefinition := idealOfDefinition K
+  fg_idealOfDefinition := ⟨{XD K}, by simp [idealOfDefinition_def]⟩
+  isAdic_idealOfDefinition := isAdic_idealOfDefinition K
+
+@[simp]
+theorem pairOfDefinition_ringOfDefinition :
+    (pairOfDefinition K).ringOfDefinition = powerSeries_as_subring K := (rfl)
+
+/-- **`X` is a pseudouniformiser of `K⸨X⸩`**: it is a unit, since `K⸨X⸩` is a field, and
+`v (Xⁿ) = exp (-n)` tends to zero. -/
+theorem isPseudoUniformizer_X : IsPseudoUniformizer ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) := by
+  refine isPseudoUniformizer_iff.mpr ⟨isUnit_iff_ne_zero.mpr (coe_X_ne_zero K), ?_⟩
+  refine Filter.tendsto_def.mpr fun s hs ↦ ?_
+  obtain ⟨c, hc, hcs⟩ := exists_ball_subset K hs
+  filter_upwards [eventually_ge_atTop (1 - log c).toNat] with n hn
+  refine hcs (show Valued.v (((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ^ n) < c from ?_)
+  rw [valuation_X_pow, ← lt_log_iff_exp_lt hc]
+  omega
+
+instance isHuberRing : IsHuberRing K⸨X⸩ := ⟨⟨pairOfDefinition K⟩⟩
+
+instance isTateRing : IsTateRing K⸨X⸩ where
+  exists_isPseudoUniformizer := ⟨_, isPseudoUniformizer_X K⟩
+
+end LaurentSeries
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -25,7 +25,9 @@ ideal `(X)` is a finitely generated ideal of definition, and `X` itself is a pse
 ## Main results
 
 * `TauCeti.Huber.LaurentSeries.mem_idealOfDefinition_pow_iff`: membership of `(X)ⁿ` is the
-  valuation bound `v f ≤ exp (-n)`. Every topological statement here is read off this.
+  valuation bound `v f ≤ exp (-n)`. `isAdic_idealOfDefinition` and
+  `mem_pairOfDefinition_idealImage` are read off it; the openness of the ring of definition and
+  the nilpotence of `X` come from Mathlib's valuation API instead.
 * `TauCeti.Huber.LaurentSeries.isPseudoUniformizer_X`: `X` is a pseudouniformiser.
 * `TauCeti.Huber.LaurentSeries.isHuberRing` and `TauCeti.Huber.LaurentSeries.isTateRing`.
 
@@ -78,20 +80,18 @@ theorem isOpen_powerSeries_as_subring :
     IsOpen ((powerSeries_as_subring K : Subring K⸨X⸩) : Set K⸨X⸩) :=
   (coe_powerSeries_as_subring K) ▸ Valued.isOpen_integer K⸨X⸩
 
-/-- The power series are the valuation integers of `K⸨X⸩`, packaged as
-`Valuation.Integers`. This is what lets the divisibility/valuation dictionary
-(`Valuation.Integers.dvd_iff_le`) apply to `(X)ⁿ` directly, with no transport and no
-coefficient bookkeeping. -/
+/-- The power series *are* the valuation subring of `K⸨X⸩`, as subrings. -/
+theorem powerSeries_as_subring_eq_integer :
+    (powerSeries_as_subring K : Subring K⸨X⸩) = (Valued.v (R := K⸨X⸩)).integer :=
+  SetLike.ext' (coe_powerSeries_as_subring K)
+
+/-- The power series are the valuation integers of `K⸨X⸩`, packaged as `Valuation.Integers`.
+This is Mathlib's `Valuation.integer.integers` transported along
+`TauCeti.Huber.LaurentSeries.powerSeries_as_subring_eq_integer`, and is what lets the
+divisibility/valuation dictionary `Valuation.Integers.dvd_iff_le` apply to `(X)ⁿ` directly. -/
 theorem integers_powerSeries_as_subring :
-    Valuation.Integers (Valued.v : Valuation K⸨X⸩ ℤᵐ⁰) (powerSeries_as_subring K) where
-  hom_inj := Subtype.val_injective
-  map_le_one x := by
-    have hmem := x.2
-    rwa [← SetLike.mem_coe, coe_powerSeries_as_subring, SetLike.mem_coe,
-      Valuation.mem_integer_iff] at hmem
-  exists_of_le_one {r} hr := by
-    obtain ⟨F, hF⟩ := (val_le_one_iff_eq_coe K r).mp hr
-    exact ⟨powerSeriesEquivSubring K F, hF⟩
+    Valuation.Integers (Valued.v : Valuation K⸨X⸩ ℤᵐ⁰) (powerSeries_as_subring K) :=
+  powerSeries_as_subring_eq_integer K ▸ Valuation.integer.integers _
 
 /-- The variable `X`, viewed inside the ring of definition `K⟦X⟧ ⊆ K⸨X⸩`. -/
 noncomputable def subringX : powerSeries_as_subring K := powerSeriesEquivSubring K PowerSeries.X
@@ -105,7 +105,8 @@ noncomputable def idealOfDefinition : Ideal (powerSeries_as_subring K) := Ideal.
 /-- Unfolding lemma for `TauCeti.Huber.LaurentSeries.idealOfDefinition`. -/
 theorem idealOfDefinition_def : idealOfDefinition K = Ideal.span {subringX K} := (rfl)
 
-/-- `X` is nonzero in `K⸨X⸩`, so, `K⸨X⸩` being a field, all its powers are invertible. -/
+/-- `X` is nonzero in `K⸨X⸩`. Only nontriviality of the coefficients is involved; that its
+powers are then invertible is separate, and uses that `K⸨X⸩` is a field. -/
 theorem coe_X_ne_zero : ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ≠ 0 := by
   simp only [HahnSeries.ofPowerSeries_X, ne_eq, HahnSeries.single_eq_zero_iff, one_ne_zero,
     not_false_eq_true]
@@ -174,13 +175,23 @@ noncomputable def pairOfDefinition : PairOfDefinition K⸨X⸩ where
 
 /-- The ring of definition of `TauCeti.Huber.LaurentSeries.pairOfDefinition` is the power series.
 
-There is deliberately no companion lemma for the ideal: `PairOfDefinition.idealOfDefinition` is
-dependent on `ringOfDefinition`, so with the body hidden by the module system an equation between
-the two ideals does not typecheck. The bridge
-`TauCeti.Huber.LaurentSeries.mem_idealOfDefinition_pow_iff` is what consumers use instead. -/
+The ideal is characterised by `TauCeti.Huber.LaurentSeries.mem_pairOfDefinition_idealOfDefinition`
+in membership form; an *equation* between the two ideals does not typecheck, since
+`idealOfDefinition`'s type depends on `ringOfDefinition`. -/
 @[simp]
 theorem pairOfDefinition_ringOfDefinition :
     (pairOfDefinition K).ringOfDefinition = powerSeries_as_subring K := (rfl)
+
+/-- **The ideal of definition of `pairOfDefinition` is `(X)`**, in membership form.
+
+An *equation* between `idealOfDefinition` and `idealOfDefinition K` does not typecheck, since
+the former's type depends on the pair's `ringOfDefinition`; a membership statement is unaffected,
+because `f` is already taken in that dependent type. -/
+@[simp]
+theorem mem_pairOfDefinition_idealOfDefinition {n : ℕ}
+    {f : (pairOfDefinition K).ringOfDefinition} :
+    f ∈ (pairOfDefinition K).idealOfDefinition ^ n ↔ Valued.v (f : K⸨X⸩) ≤ exp (-(n : ℤ)) :=
+  mem_idealOfDefinition_pow_iff n f
 
 /-- **The pair of definition is `(K⟦X⟧, (X))`**, said without touching the dependent field:
 `PairOfDefinition.idealImage n` is the image of `(X)ⁿ` in `K⸨X⸩`, so it can be compared with a

--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -192,8 +192,11 @@ theorem pairOfDefinition_ringOfDefinition :
 
 /-- **The pair of definition is `(K⟦X⟧, (X))`**, said without touching the dependent field:
 `PairOfDefinition.idealImage n` is the image of `(X)ⁿ` in `K⸨X⸩`, so it can be compared with a
-valuation bound directly. -/
-@[simp]
+valuation bound directly.
+
+Deliberately not `@[simp]`: `PairOfDefinition.mem_idealImage` is itself a simp lemma, so simp
+rewrites this left-hand side further, to an existential over the subring, and the `simpNF`
+linter rejects the attribute. Rewrite with this lemma explicitly. -/
 theorem mem_pairOfDefinition_idealImage (n : ℕ) (f : K⸨X⸩) :
     f ∈ (pairOfDefinition K).idealImage n ↔ Valued.v f ≤ exp (-(n : ℤ)) := by
   rw [PairOfDefinition.mem_idealImage]

--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -169,8 +169,9 @@ noncomputable def pairOfDefinition : PairOfDefinition K⸨X⸩ where
 
 /-- The ring of definition of `TauCeti.Huber.LaurentSeries.pairOfDefinition` is the power series.
 
-The ideal is characterised by `TauCeti.Huber.LaurentSeries.mem_pairOfDefinition_idealOfDefinition`
-in membership form. An equation is avoided rather than impossible: `idealOfDefinition`'s type
+The ideal is characterised in membership form by
+`TauCeti.Huber.LaurentSeries.mem_pairOfDefinition_idealOfDefinition_pow_iff`. An equation is
+avoided rather than impossible: `idealOfDefinition`'s type
 depends on `ringOfDefinition`, so an equation would be between two `Ideal` types that the
 elaborator identifies only through that projection. -/
 @[simp]
@@ -183,7 +184,7 @@ The membership form is used because `idealOfDefinition`'s type depends on the pa
 `ringOfDefinition`; `f` is already taken in that dependent type, so nothing has to be
 transported. -/
 @[simp]
-theorem mem_pairOfDefinition_idealOfDefinition {n : ℕ}
+theorem mem_pairOfDefinition_idealOfDefinition_pow_iff {n : ℕ}
     {f : (pairOfDefinition K).ringOfDefinition} :
     f ∈ (pairOfDefinition K).idealOfDefinition ^ n ↔ Valued.v (f : K⸨X⸩) ≤ exp (-(n : ℤ)) :=
   mem_idealOfDefinition_pow_iff n f

--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -105,11 +105,6 @@ noncomputable def idealOfDefinition : Ideal (powerSeries_as_subring K) := Ideal.
 /-- Unfolding lemma for `TauCeti.Huber.LaurentSeries.idealOfDefinition`. -/
 theorem idealOfDefinition_def : idealOfDefinition K = Ideal.span {subringX K} := (rfl)
 
-/-- `X` is nonzero in `K⸨X⸩`. -/
-theorem coe_X_ne_zero : ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) ≠ 0 := by
-  simp only [HahnSeries.ofPowerSeries_X, ne_eq, HahnSeries.single_eq_zero_iff, one_ne_zero,
-    not_false_eq_true]
-
 variable {K}
 
 /-- **The bridge to the valuation**: a power series lies in `(X)ⁿ` exactly when its valuation is
@@ -216,7 +211,8 @@ theorem mem_pairOfDefinition_idealImage (n : ℕ) (f : K⸨X⸩) :
 /-- **`X` is a pseudouniformiser of `K⸨X⸩`**: it is a unit, since `K⸨X⸩` is a field, and
 `v (Xⁿ) = exp (-n)` tends to zero. -/
 theorem isPseudoUniformizer_X : IsPseudoUniformizer ((PowerSeries.X : K⟦X⟧) : K⸨X⸩) :=
-  isPseudoUniformizer_iff.mpr ⟨isUnit_iff_ne_zero.mpr (coe_X_ne_zero K),
+  isPseudoUniformizer_iff.mpr ⟨isUnit_iff_ne_zero.mpr
+      (by simp),
     Valued.tendsto_zero_pow_of_le_exp_neg_one (by simpa using (valuation_X_pow (K := K) 1).le)⟩
 
 /-- **`K⸨X⸩` is a Huber ring**, with `(K⟦X⟧, (X))` as a pair of definition. -/


### PR DESCRIPTION
`K⸨X⸩` is a Tate ring. A new `TauCeti/RingTheory/Huber/LaurentSeries.lean`, independent of the
other open Layer-0 PRs.

This is the equal-characteristic counterpart of #2538 (`ℚ_[p]`), and completes the roadmap's
Layer-0 Examples row apart from the strongly noetherian `ℚ_p⟨T₁,…,Tₙ⟩`.

**The ring of definition is not built by hand.** Mathlib's `LaurentSeries.val_le_one_iff_eq_coe`
says a Laurent series has valuation at most one exactly when it is a power series, so
`LaurentSeries.powerSeries_as_subring` *is* the valuation subring; `coe_powerSeries_as_subring`
records that identification and openness is then `Valued.isOpen_integer`. No transport across a
`RingEquiv` is needed.

**Everything else runs on one bridge.** `mem_idealOfDefinition_pow_iff` identifies membership of
`(X)ⁿ` with the valuation bound `v f ≤ exp (-n)`:

* one way, `f = g · Xⁿ` with `v g ≤ 1` gives `v f = v g · exp(-n) ≤ exp(-n)`;
* the other, `v (f · (Xⁿ)⁻¹) ≤ 1` puts `f · (Xⁿ)⁻¹` back in the power series, using that `K⸨X⸩`
  is a field so `Xⁿ` is invertible.

Both halves of `IsAdic` — that each `(X)ⁿ` is open, and that each neighbourhood of zero contains
one — are then read off that bridge together with the two `private` conversion lemmas below it.

**One wrinkle worth flagging.** Mathlib's `Valued` neighbourhood API (`Valued.mem_nhds_zero`,
`Valued.hasBasis_nhds_zero`) is phrased in `ValueGroup₀ v` rather than in `Γ₀`, so a bound in
`ℤᵐ⁰` cannot be handed to it directly. `ball_mem_nhds` and `exists_ball_subset` do that
conversion once in each direction — outward via `Units.mk0 (v.restrict (Xⁿ))`, inward via
`Valuation.restrict_lt_iff_lt_embedding` — and the rest of the file works in `ℤᵐ⁰` with
`WithZero.exp`/`log`. They are `private` because they are bookkeeping, not results.

Scope: only `K⸨X⸩`. Strong noetherianness (roadmap §0.5) is a separate row and is not here.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0-examples-laurent-series"}-->

🤖 Prepared with Claude Code
