### PR TITLE
refactor(Winding): name the pointwise winding integrand of a chord expansion

### DIFF
--- a/TauCeti/Analysis/Contour/Winding/CrossingValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue/Basic.lean
@@ -44,6 +44,21 @@ namespace TauCeti.Contour
 
 open Complex Filter Topology
 
+/-- **The winding integrand of a normalized chord expansion.** For `τ ≠ 0`, `q ≠ 0` and
+`q - L = τ r`, the real winding integrand at position `τ q` and velocity `L + τ d` is
+`(r.re * L.im - r.im * L.re + (q.re * d.im - q.im * d.re)) / ‖q‖²`. -/
+private theorem realWindingIntegrand_mul_add_eq_div {τ : ℝ} {q r d L : ℂ} (hτ : τ ≠ 0)
+    (hq : q ≠ 0) (hqr : q - L = (τ : ℂ) * r) :
+    realWindingIntegrand ((τ : ℂ) * q) (L + (τ : ℂ) * d)
+      = (r.re * L.im - r.im * L.re + (q.re * d.im - q.im * d.re)) / Complex.normSq q := by
+  obtain rfl : L = q - (τ : ℂ) * r := by linear_combination -hqr
+  rw [realWindingIntegrand_eq_div]
+  simp only [Complex.mul_re, Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im, zero_mul,
+    add_zero, sub_zero, Complex.add_re, Complex.add_im, Complex.sub_re, Complex.sub_im,
+    Complex.normSq_mul, Complex.normSq_ofReal]
+  field_simp [hτ, Complex.normSq_eq_zero.not.mpr hq]
+  ring
+
 /-- Algebraic form of the crossing limit. If `q → L`, `(q - L) / τ → A/2`, and
 `d → A`, then the real winding integrand of position `τq` and velocity `L + τd` tends to
 `(L.re * A.im - L.im * A.re) / (2‖L‖²)`.
@@ -78,24 +93,8 @@ private theorem tendsto_realWindingIntegrand_mul_add {α : Type*} {l : Filter α
   convert hdiv.congr' ?_ using 1
   · ring_nf
   filter_upwards [hqr, hτ, hq_ne] with i hqi hτi hqi_ne
-  rw [realWindingIntegrand_eq_div]
-  simp only [Complex.mul_re, Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im, zero_mul,
-    add_zero, Complex.add_re, Complex.add_im, Complex.normSq_mul, Complex.normSq_ofReal]
-  have hτsq : τ i ^ 2 ≠ 0 := pow_ne_zero _ hτi
-  have hLre : L.re = (q i).re - τ i * (r i).re := by
-    have := congrArg Complex.re hqi
-    simp only [Complex.sub_re, Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im, zero_mul,
-      sub_zero] at this
-    linarith
-  have hLim : L.im = (q i).im - τ i * (r i).im := by
-    have := congrArg Complex.im hqi
-    simp only [Complex.sub_im, Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im, zero_mul,
-      add_zero] at this
-    linarith
-  rw [hLre, hLim]
   simp only [Pi.div_apply]
-  field_simp [hτi, Complex.normSq_eq_zero.not.mpr hqi_ne]
-  ring
+  exact (realWindingIntegrand_mul_add_eq_div hτi hqi_ne hqi).symm
 
 /-- **Hungerbühler–Wasem Proposition 2.3, crossing value.** At a crossing `γ t₀ = s`,
 a normalized second-order chord expansion with coefficients `L` and `A`, together with the

--- a/TauCeti/Analysis/Contour/Winding/CrossingValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue/Basic.lean
@@ -44,13 +44,17 @@ namespace TauCeti.Contour
 
 open Complex Filter Topology
 
-/-- **The winding integrand of a normalized chord expansion.** For `τ ≠ 0`, `q ≠ 0` and
-`q - L = τ r`, the real winding integrand at position `τ q` and velocity `L + τ d` is
-`(r.re * L.im - r.im * L.re + (q.re * d.im - q.im * d.re)) / ‖q‖²`. -/
-private theorem realWindingIntegrand_mul_add_eq_div {τ : ℝ} {q r d L : ℂ} (hτ : τ ≠ 0)
-    (hq : q ≠ 0) (hqr : q - L = (τ : ℂ) * r) :
+/-- **The winding integrand of a normalized chord expansion.** For `τ ≠ 0` and `q - L = τ r`, the
+real winding integrand at position `τ q` and velocity `L + τ d` is
+`(r.re * L.im - r.im * L.re + (q.re * d.im - q.im * d.re)) / ‖q‖²`.
+
+At `q = 0` both sides are `0`, by the junk value of division. -/
+private theorem realWindingIntegrand_mul_add_eq_div_of_sub_eq_mul {τ : ℝ} {q r d L : ℂ}
+    (hτ : τ ≠ 0) (hqr : q - L = (τ : ℂ) * r) :
     realWindingIntegrand ((τ : ℂ) * q) (L + (τ : ℂ) * d)
       = (r.re * L.im - r.im * L.re + (q.re * d.im - q.im * d.re)) / Complex.normSq q := by
+  rcases eq_or_ne q 0 with rfl | hq
+  · simp
   obtain rfl : L = q - (τ : ℂ) * r := by linear_combination -hqr
   rw [realWindingIntegrand_eq_div]
   simp only [Complex.mul_re, Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im, zero_mul,
@@ -88,13 +92,11 @@ private theorem tendsto_realWindingIntegrand_mul_add {α : Type*} {l : Filter α
       ((hq_re.mul hd_im).sub (hq_im.mul hd_re))) using 1
     all_goals simp <;> ring_nf
   have hdiv := hnum.div hnorm ((Complex.normSq_eq_zero.not.mpr hL))
-  have hq_ne : ∀ᶠ i in l, q i ≠ 0 :=
-    hq.eventually (isOpen_compl_singleton.mem_nhds hL)
   convert hdiv.congr' ?_ using 1
   · ring_nf
-  filter_upwards [hqr, hτ, hq_ne] with i hqi hτi hqi_ne
+  filter_upwards [hqr, hτ] with i hqi hτi
   simp only [Pi.div_apply]
-  exact (realWindingIntegrand_mul_add_eq_div hτi hqi_ne hqi).symm
+  exact (realWindingIntegrand_mul_add_eq_div_of_sub_eq_mul hτi hqi).symm
 
 /-- **Hungerbühler–Wasem Proposition 2.3, crossing value.** At a crossing `γ t₀ = s`,
 a normalized second-order chord expansion with coefficients `L` and `A`, together with the


### PR DESCRIPTION
`tendsto_realWindingIntegrand_mul_add` proved a limit, but half its body was a pointwise algebraic identity carried out under `filter_upwards` — fourteen lines of coordinate manipulation with no filter or limit anywhere in it.

`realWindingIntegrand_mul_add_eq_div_of_sub_eq_mul` states that identity on its own: for `τ ≠ 0` and a chord expansion `q - L = τ r`, the real winding integrand at position `τ q` and velocity `L + τ d` is

```
(r.re * L.im - r.im * L.re + (q.re * d.im - q.im * d.re)) / ‖q‖²
```

Its hypotheses are re-derived, not inherited. It takes plain complex numbers instead of the parent's `α`-indexed families, and the parent's filter, its limits `L`, `A`, and the second-order data play no part.

Only `τ ≠ 0` survives as a hypothesis. The obvious `q ≠ 0` is *not* needed: at `q = 0` the denominator `‖q‖²` vanishes and Lean's total division sends both sides to `0`, so the identity holds there for free. Dropping it also deletes the parent's `hq_ne : ∀ᶠ i in l, q i ≠ 0`, which existed only to feed this step. `τ ≠ 0` is genuinely load-bearing — at `τ = 0` the left side collapses to `realWindingIntegrand 0 L = 0` while the right side does not.

Once separated, the identity got much shorter than the version inlined in the parent. Substituting the chord expansion up front (`obtain rfl : L = q - τ * r`) removes the two `congrArg`/`linarith` blocks that were reading `L.re` and `L.im` back out of it, and `field_simp`/`ring` close the rest. It also exposed that the parent's `have hτsq : τ ^ 2 ≠ 0` was dead; `field_simp` was never given it. That is dropped.

The parent drops from 40 lines to 22.

Not reusing `realWindingIntegrand_mul_mul` is deliberate: that lemma scales position *and* velocity by the same factor, whereas here the velocity is `L + τ d` and only the position carries `τ`.

Gates run locally: `lake build` (7147 jobs), `lake exe axioms` (31039 declarations), `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
