### PR TITLE
feat(Huber): rings with a zero sequence of units

### DIFF
--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -87,7 +87,7 @@ theorem IsTateRing.hasZeroSequenceOfUnits {A : Type*} [CommRing A] [TopologicalS
 
 namespace HasZeroSequenceOfUnits
 
-variable [ContinuousMul A] (h : HasZeroSequenceOfUnits A)
+variable [SeparatelyContinuousMul A] (h : HasZeroSequenceOfUnits A)
 include h
 
 /-- A choice of zero sequence of units, fixed once.
@@ -98,14 +98,14 @@ not serve. Everything downstream therefore goes through this sequence rather tha
 unquantified unit. -/
 noncomputable def seq : ℕ → Aˣ := h.choose
 
-omit [ContinuousMul A] in
-/-- The chosen sequence converges to zero. This is the characteristic property of
-`TauCeti.Huber.HasZeroSequenceOfUnits.seq`; its body is not exposed. -/
+omit [SeparatelyContinuousMul A] in
+/-- The chosen sequence converges to zero: the characteristic property of
+`TauCeti.Huber.HasZeroSequenceOfUnits.seq`, which is all any consumer needs of it. -/
 theorem tendsto_seq : Tendsto (fun n ↦ ((seq h n : A))) atTop (nhds 0) := h.choose_spec
 
 /-- Every element is absorbed into every neighbourhood of zero by some term of the sequence.
 
-Only continuity of multiplication by a constant is used: `uₙ · x → 0 · x = 0`. -/
+Separate continuity of multiplication suffices, and is what the section assumes. -/
 theorem exists_seq_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
     ∃ n : ℕ, ((seq h n : A)) * x ∈ U := by
   have hmul : Tendsto (fun n ↦ ((seq h n : A)) * x) atTop (nhds ((0 : A) * x)) :=

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -15,8 +15,10 @@ the two facts about it that the theorem uses — that a Tate ring satisfies it, 
 that satisfies it every element is absorbed into every neighbourhood of zero, so the dilates of
 a neighbourhood cover the ring.
 
-The covering is the point. Henkel's proof applies a Baire argument to the sets `uₙ⁻¹ • U`, and
-what makes that argument start is exactly that they exhaust the ring.
+The covering is the point, and it must be **countable**. Henkel's proof applies a Baire argument
+to the sets `uₙ⁻¹ • U` indexed by `n : ℕ`; a cover indexed by all of `Aˣ` would exhaust the ring
+just as well but could not start that argument. So a sequence is chosen once, as
+`HasZeroSequenceOfUnits.seq`, and the absorption step and the covering both range over it.
 
 ## Main definitions
 
@@ -26,10 +28,12 @@ what makes that argument start is exactly that they exhaust the ring.
 
 * `TauCeti.Huber.IsTateRing.hasZeroSequenceOfUnits`: a Tate ring has one, namely the powers of a
   pseudouniformiser.
-* `TauCeti.Huber.HasZeroSequenceOfUnits.exists_unit_mul_mem`: some term of the sequence carries a
+* `TauCeti.Huber.HasZeroSequenceOfUnits.seq`: a choice of such a sequence, fixed once so that
+  everything below ranges over the same countable family.
+* `TauCeti.Huber.HasZeroSequenceOfUnits.exists_seq_mul_mem`: some term of the sequence carries a
   given element into a given neighbourhood of zero.
-* `TauCeti.Huber.HasZeroSequenceOfUnits.iUnion_smul_eq_univ`: the dilates of a neighbourhood of
-  zero cover the ring.
+* `TauCeti.Huber.HasZeroSequenceOfUnits.iUnion_seq_smul_eq_univ`: the dilates `uₙ⁻¹ • U` cover
+  the ring, indexed by `ℕ`.
 
 ## References
 
@@ -82,24 +86,37 @@ namespace HasZeroSequenceOfUnits
 variable [IsTopologicalRing A] (h : HasZeroSequenceOfUnits A)
 include h
 
-/-- Every element is absorbed into every neighbourhood of zero by some unit of the sequence.
+/-- A choice of zero sequence of units, fixed once.
+
+The absorption step and the covering below must range over the *same* countable family: Baire
+needs a countable cover, and a cover indexed by all of `Aˣ` — which may be uncountable — would
+not serve. Everything downstream therefore goes through this sequence rather than through an
+unquantified unit. -/
+noncomputable def seq : ℕ → Aˣ := h.choose
+
+omit [IsTopologicalRing A] in
+/-- The chosen sequence converges to zero. This is the characteristic property of
+`TauCeti.Huber.HasZeroSequenceOfUnits.seq`; its body is not exposed. -/
+theorem tendsto_seq : Tendsto (fun n ↦ ((seq h n : A))) atTop (nhds 0) := h.choose_spec
+
+/-- Every element is absorbed into every neighbourhood of zero by some term of the sequence.
 
 Only continuity of multiplication by a constant is used: `uₙ · x → 0 · x = 0`. -/
-theorem exists_unit_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
-    ∃ u : Aˣ, (u : A) * x ∈ U := by
-  obtain ⟨u, hu⟩ := h
-  have hmul : Tendsto (fun n ↦ ((u n : A)) * x) atTop (nhds ((0 : A) * x)) := hu.mul_const x
+theorem exists_seq_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
+    ∃ n : ℕ, ((seq h n : A)) * x ∈ U := by
+  have hmul : Tendsto (fun n ↦ ((seq h n : A)) * x) atTop (nhds ((0 : A) * x)) :=
+    (tendsto_seq h).mul_const x
   rw [zero_mul] at hmul
-  obtain ⟨n, hn⟩ := (hmul.eventually_mem hU).exists
-  exact ⟨u n, hn⟩
+  exact (hmul.eventually_mem hU).exists
 
-/-- **The covering Henkel's Baire argument runs on**: the dilates `u⁻¹ • U` of a neighbourhood of
-zero, as `u` ranges over the units, exhaust the ring. -/
-theorem iUnion_smul_eq_univ {U : Set A} (hU : U ∈ nhds (0 : A)) :
-    ⋃ u : Aˣ, (u⁻¹ : Aˣ) • U = Set.univ := by
+/-- **The countable covering Henkel's Baire argument runs on**: the dilates `uₙ⁻¹ • U` of a
+neighbourhood of zero, over the chosen sequence, exhaust the ring. The index is `ℕ`, which is
+what makes the cover usable in a Baire argument. -/
+theorem iUnion_seq_smul_eq_univ {U : Set A} (hU : U ∈ nhds (0 : A)) :
+    ⋃ n : ℕ, ((seq h n)⁻¹ : Aˣ) • U = Set.univ := by
   refine Set.eq_univ_of_forall fun x ↦ Set.mem_iUnion.mpr ?_
-  obtain ⟨u, hu⟩ := h.exists_unit_mul_mem x hU
-  exact ⟨u, ⟨(u : A) * x, hu, by simp [smul_eq_mul, ← mul_assoc]⟩⟩
+  obtain ⟨n, hn⟩ := exists_seq_mul_mem h x hU
+  exact ⟨n, ⟨(seq h n : A) * x, hn, by simp [smul_eq_mul, ← mul_assoc]⟩⟩
 
 end HasZeroSequenceOfUnits
 

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -65,6 +65,7 @@ def HasZeroSequenceOfUnits : Prop :=
   ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (nhds 0)
 
 /-- Unfolding lemma for `TauCeti.Huber.HasZeroSequenceOfUnits`. -/
+@[simp]
 theorem hasZeroSequenceOfUnits_iff :
     HasZeroSequenceOfUnits A ↔ ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (nhds 0) :=
   (Iff.rfl)

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -33,6 +33,12 @@ pseudouniformiser, say — keeps it rather than trading it for an opaque choice.
   a given element into a given neighbourhood of zero.
 * `TauCeti.Huber.iUnion_inv_smul_eq_univ_of_tendsto`: its dilates `uₙ⁻¹ • U` cover the ring,
   indexed by `ℕ`.
+* `TauCeti.Huber.IsPseudoUniformizer.hasZeroSequenceOfUnits` and
+  `TauCeti.Huber.IsTateRing.hasZeroSequenceOfUnits`: the powers of a pseudouniformiser are such
+  a sequence, so a Tate ring satisfies the hypothesis.
+* `TauCeti.Huber.HasZeroSequenceOfUnits.exists_unit_mul_mem` and
+  `TauCeti.Huber.HasZeroSequenceOfUnits.exists_iUnion_inv_smul_eq_univ`: the two facts above
+  read off the hypothesis rather than a given sequence.
 
 ## References
 
@@ -119,18 +125,27 @@ namespace HasZeroSequenceOfUnits
 variable [SeparatelyContinuousMul A] (h : HasZeroSequenceOfUnits A)
 include h
 
-/-- Some zero sequence of units absorbs a given element into a given neighbourhood of zero. -/
-theorem exists_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
-    ∃ (u : ℕ → Aˣ) (n : ℕ), ((u n : A)) * x ∈ U := by
+/-- Some unit carries a given element into a given neighbourhood of zero.
+
+Deliberately not phrased with a sequence: quantifying over an unconstrained `u : ℕ → Aˣ` would
+say no more than this, since a constant sequence witnesses it. The sequence matters only for the
+covering below, where it is carried with its convergence hypothesis. -/
+theorem exists_unit_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
+    ∃ v : Aˣ, (v : A) * x ∈ U := by
   obtain ⟨u, hu⟩ := h
   obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto hu x hU
-  exact ⟨u, n, hn⟩
+  exact ⟨u n, hn⟩
 
-/-- Some zero sequence of units has its dilates of a neighbourhood of zero covering the ring. -/
+/-- Some *zero* sequence of units has its dilates of a neighbourhood of zero covering the ring.
+
+The convergence hypothesis is carried inside the existential: without it the sequence binder
+would be vacuous, and a caller destructing the result would get a sequence with no relation to
+the topology. -/
 theorem exists_iUnion_inv_smul_eq_univ {U : Set A} (hU : U ∈ nhds (0 : A)) :
-    ∃ u : ℕ → Aˣ, ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
+    ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (nhds 0) ∧
+      ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
   obtain ⟨u, hu⟩ := h
-  exact ⟨u, iUnion_inv_smul_eq_univ_of_tendsto hu hU⟩
+  exact ⟨u, hu, iUnion_inv_smul_eq_univ_of_tendsto hu hU⟩
 
 end HasZeroSequenceOfUnits
 

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -32,14 +32,16 @@ just as well but could not start that argument. So a sequence is chosen once, as
   everything below ranges over the same countable family.
 * `TauCeti.Huber.HasZeroSequenceOfUnits.exists_seq_mul_mem`: some term of the sequence carries a
   given element into a given neighbourhood of zero.
-* `TauCeti.Huber.HasZeroSequenceOfUnits.iUnion_seq_smul_eq_univ`: the dilates `uₙ⁻¹ • U` cover
+* `TauCeti.Huber.HasZeroSequenceOfUnits.iUnion_seq_inv_smul_eq_univ`: the dilates `uₙ⁻¹ • U` cover
   the ring, indexed by `ℕ`.
 
 ## References
 
+* A. Henkel, *An Open Mapping Theorem for rings which have a zero sequence of units*,
+  [arXiv:1407.5647](https://arxiv.org/abs/1407.5647). The hypothesis formalised here, the
+  terminology, and both results below are its setup.
 * [Wedhorn, *Adic Spaces*][wedhorn_adic], Theorem 6.16 and Propositions 6.17–6.18, which are
-  proved from Henkel's open mapping theorem; this file states the hypothesis that theorem places
-  on the base ring.
+  proved from Henkel's theorem; downstream context for this file rather than its source.
 -/
 
 public section
@@ -48,7 +50,7 @@ open Filter Topology Pointwise
 
 namespace TauCeti.Huber
 
-variable (A : Type*) [CommRing A] [TopologicalSpace A]
+variable (A : Type*) [MonoidWithZero A] [TopologicalSpace A]
 
 /-- Henkel's hypothesis on the base ring: there is a sequence of units converging to zero.
 
@@ -64,10 +66,8 @@ theorem hasZeroSequenceOfUnits_iff :
 
 variable {A}
 
-/-- **A Tate ring has a zero sequence of units**: the powers of a pseudouniformiser.
-
-This is where the Tate condition enters Henkel's theorem — a Huber ring that is not Tate need
-not admit such a sequence, `ℤ_[p]` being the example. -/
+/-- **The powers of a pseudouniformiser are a zero sequence of units.** No Huber or Tate
+hypothesis is needed: a topologically nilpotent unit is exactly what the definition asks for. -/
 theorem IsPseudoUniformizer.hasZeroSequenceOfUnits {a : A} (ha : IsPseudoUniformizer a) :
     HasZeroSequenceOfUnits A :=
   ⟨fun n ↦ ha.isUnit.unit ^ n, by
@@ -75,15 +75,19 @@ theorem IsPseudoUniformizer.hasZeroSequenceOfUnits {a : A} (ha : IsPseudoUniform
     have hnil : Tendsto (fun n ↦ a ^ n) atTop (nhds 0) := ha.isTopologicallyNilpotent
     simpa only [Units.val_pow_eq_pow_val, IsUnit.unit_spec] using hnil⟩
 
-/-- A Tate ring satisfies Henkel's hypothesis on the base ring. -/
-theorem IsTateRing.hasZeroSequenceOfUnits [IsTopologicalRing A] [IsTateRing A] :
-    HasZeroSequenceOfUnits A :=
+/-- **A Tate ring satisfies Henkel's hypothesis on the base ring**, via the powers of a
+pseudouniformiser.
+
+This is where the Tate condition enters Henkel's theorem: a Huber ring that is not Tate need not
+admit such a sequence, `ℤ_[p]` being the example. -/
+theorem IsTateRing.hasZeroSequenceOfUnits {A : Type*} [CommRing A] [TopologicalSpace A]
+    [IsTopologicalRing A] [IsTateRing A] : HasZeroSequenceOfUnits A :=
   let ⟨_, ha⟩ := IsTateRing.exists_isPseudoUniformizer (A := A)
   ha.hasZeroSequenceOfUnits
 
 namespace HasZeroSequenceOfUnits
 
-variable [IsTopologicalRing A] (h : HasZeroSequenceOfUnits A)
+variable [ContinuousMul A] (h : HasZeroSequenceOfUnits A)
 include h
 
 /-- A choice of zero sequence of units, fixed once.
@@ -94,7 +98,7 @@ not serve. Everything downstream therefore goes through this sequence rather tha
 unquantified unit. -/
 noncomputable def seq : ℕ → Aˣ := h.choose
 
-omit [IsTopologicalRing A] in
+omit [ContinuousMul A] in
 /-- The chosen sequence converges to zero. This is the characteristic property of
 `TauCeti.Huber.HasZeroSequenceOfUnits.seq`; its body is not exposed. -/
 theorem tendsto_seq : Tendsto (fun n ↦ ((seq h n : A))) atTop (nhds 0) := h.choose_spec
@@ -112,11 +116,11 @@ theorem exists_seq_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
 /-- **The countable covering Henkel's Baire argument runs on**: the dilates `uₙ⁻¹ • U` of a
 neighbourhood of zero, over the chosen sequence, exhaust the ring. The index is `ℕ`, which is
 what makes the cover usable in a Baire argument. -/
-theorem iUnion_seq_smul_eq_univ {U : Set A} (hU : U ∈ nhds (0 : A)) :
+theorem iUnion_seq_inv_smul_eq_univ {U : Set A} (hU : U ∈ nhds (0 : A)) :
     ⋃ n : ℕ, ((seq h n)⁻¹ : Aˣ) • U = Set.univ := by
   refine Set.eq_univ_of_forall fun x ↦ Set.mem_iUnion.mpr ?_
   obtain ⟨n, hn⟩ := exists_seq_mul_mem h x hU
-  exact ⟨n, ⟨(seq h n : A) * x, hn, by simp [smul_eq_mul, ← mul_assoc]⟩⟩
+  exact ⟨n, Set.mem_inv_smul_set_iff.mpr (by rwa [Units.smul_def, smul_eq_mul])⟩
 
 end HasZeroSequenceOfUnits
 

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -27,18 +27,19 @@ pseudouniformiser, say — keeps it rather than trading it for an opaque choice.
 
 ## Main results
 
-* `TauCeti.Huber.IsTateRing.hasZeroSequenceOfUnits`: a Tate ring has one, namely the powers of a
-  pseudouniformiser.
-* `TauCeti.Huber.exists_mul_mem_of_tendsto`: along any zero sequence of units, some term carries
-  a given element into a given neighbourhood of zero.
-* `TauCeti.Huber.iUnion_inv_smul_eq_univ_of_tendsto`: its dilates `uₙ⁻¹ • U` cover the ring,
+* `TauCeti.Huber.exists_mul_mem_of_tendsto_zero`: along any zero sequence of units, some term
+  carries a given element into a given neighbourhood of zero.
+* `TauCeti.Huber.iUnion_inv_smul_eq_univ_of_tendsto_zero`: its dilates `uₙ⁻¹ • U` cover the ring,
   indexed by `ℕ`.
-* `TauCeti.Huber.IsPseudoUniformizer.hasZeroSequenceOfUnits` and
-  `TauCeti.Huber.IsTateRing.hasZeroSequenceOfUnits`: the powers of a pseudouniformiser are such
-  a sequence, so a Tate ring satisfies the hypothesis.
-* `TauCeti.Huber.HasZeroSequenceOfUnits.exists_unit_mul_mem` and
-  `TauCeti.Huber.HasZeroSequenceOfUnits.exists_iUnion_inv_smul_eq_univ`: the two facts above
-  read off the hypothesis rather than a given sequence.
+* `TauCeti.Huber.IsPseudoUniformizer.tendsto_pow_unit`,
+  `TauCeti.Huber.IsPseudoUniformizer.hasZeroSequenceOfUnits` and
+  `TauCeti.Huber.IsTateRing.hasZeroSequenceOfUnits`: the powers of a pseudouniformiser converge
+  to zero as units, so a pseudouniformiser — hence a Tate ring, by instance search — satisfies
+  the hypothesis.
+* `TauCeti.Huber.HasZeroSequenceOfUnits.exists_iUnion_inv_smul_eq_univ`: the covering, read off
+  the class rather than a given sequence, with the convergence carried inside the existential.
+* `TauCeti.Huber.HasZeroSequenceOfUnits.exists_unit_mul_mem`: the weaker unit-only form of
+  absorption — it produces some `v : Aˣ`, with no sequence and no term index.
 
 ## References
 
@@ -61,32 +62,42 @@ variable (A : Type*) [MonoidWithZero A] [TopologicalSpace A]
 
 A discrete ring has none unless it is trivial, and that is the intended exclusion: the theorem
 needs to shrink a neighbourhood by an invertible factor. -/
-def HasZeroSequenceOfUnits : Prop :=
-  ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (nhds 0)
+class HasZeroSequenceOfUnits : Prop where
+  /-- Some sequence of units converges to zero. -/
+  exists_tendsto : ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0)
 
-/-- Unfolding lemma for `TauCeti.Huber.HasZeroSequenceOfUnits`. -/
+/-- Destructor for `TauCeti.Huber.HasZeroSequenceOfUnits`: it is a class so that a Tate ring
+supplies it by instance search, and this is how a proof reaches the sequence. -/
 @[simp]
 theorem hasZeroSequenceOfUnits_iff :
-    HasZeroSequenceOfUnits A ↔ ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (nhds 0) :=
-  (Iff.rfl)
+    HasZeroSequenceOfUnits A ↔ ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0) :=
+  ⟨fun h ↦ h.exists_tendsto, fun h ↦ ⟨h⟩⟩
 
 variable {A}
 
-/-- **The powers of a pseudouniformiser are a zero sequence of units.** No Huber or Tate
-hypothesis is needed: a topologically nilpotent unit is exactly what the definition asks for. -/
+/-- **The powers of a pseudouniformiser converge to zero, as units.** This is the concrete zero
+sequence, kept nameable so a caller holding `ϖ` can feed *it* to the results below instead of
+destructing an existential. -/
+theorem IsPseudoUniformizer.tendsto_pow_unit {a : A} (ha : IsPseudoUniformizer a) :
+    Tendsto (fun n ↦ ((ha.isUnit.unit ^ n : Aˣ) : A)) atTop (𝓝 0) := by
+  -- `IsTopologicallyNilpotent` is a `def`, so ascribe its `Tendsto` form for `simp` to see.
+  have hnil : Tendsto (fun n ↦ a ^ n) atTop (𝓝 0) := ha.isTopologicallyNilpotent
+  simpa only [Units.val_pow_eq_pow_val, IsUnit.unit_spec] using hnil
+
+/-- **A pseudouniformiser makes the ring admit a zero sequence of units.** No Huber or Tate
+hypothesis is needed: a topologically nilpotent unit is exactly what the class asks for. The
+witness is `TauCeti.Huber.IsPseudoUniformizer.tendsto_pow_unit`, which a caller wanting the
+powers themselves should use instead. -/
 theorem IsPseudoUniformizer.hasZeroSequenceOfUnits {a : A} (ha : IsPseudoUniformizer a) :
     HasZeroSequenceOfUnits A :=
-  ⟨fun n ↦ ha.isUnit.unit ^ n, by
-    -- `IsTopologicallyNilpotent` is a `def`, so ascribe its `Tendsto` form for `simp` to see.
-    have hnil : Tendsto (fun n ↦ a ^ n) atTop (nhds 0) := ha.isTopologicallyNilpotent
-    simpa only [Units.val_pow_eq_pow_val, IsUnit.unit_spec] using hnil⟩
+  ⟨_, ha.tendsto_pow_unit⟩
 
 /-- **A Tate ring satisfies Henkel's hypothesis on the base ring**, via the powers of a
 pseudouniformiser.
 
 This is where the Tate condition enters Henkel's theorem: a Huber ring that is not Tate need not
 admit such a sequence, `ℤ_[p]` being the example. -/
-theorem IsTateRing.hasZeroSequenceOfUnits {A : Type*} [CommRing A] [TopologicalSpace A]
+instance IsTateRing.hasZeroSequenceOfUnits {A : Type*} [CommRing A] [TopologicalSpace A]
     [IsTopologicalRing A] [IsTateRing A] : HasZeroSequenceOfUnits A :=
   let ⟨_, ha⟩ := IsTateRing.exists_isPseudoUniformizer (A := A)
   ha.hasZeroSequenceOfUnits
@@ -94,7 +105,7 @@ theorem IsTateRing.hasZeroSequenceOfUnits {A : Type*} [CommRing A] [TopologicalS
 section Absorption
 
 variable [SeparatelyContinuousMul A] {u : ℕ → Aˣ}
-  (hu : Tendsto (fun n ↦ ((u n : A))) atTop (nhds 0))
+  (hu : Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0))
 include hu
 
 /-- **Absorption.** Along a zero sequence of units, every element is carried into every
@@ -103,9 +114,9 @@ neighbourhood of zero by some term of the sequence.
 Stated for an arbitrary such sequence rather than a chosen one, so a caller holding a concrete
 sequence — the powers of a pseudouniformiser, say — gets the conclusion for *that* sequence.
 Separate continuity of multiplication is all the proof uses: `uₙ · x → 0 · x = 0`. -/
-theorem exists_mul_mem_of_tendsto (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
+theorem exists_mul_mem_of_tendsto_zero (x : A) {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
     ∃ n : ℕ, ((u n : A)) * x ∈ U := by
-  have hmul : Tendsto (fun n ↦ ((u n : A)) * x) atTop (nhds ((0 : A) * x)) := hu.mul_const x
+  have hmul : Tendsto (fun n ↦ ((u n : A)) * x) atTop (𝓝 ((0 : A) * x)) := hu.mul_const x
   rw [zero_mul] at hmul
   exact (hmul.eventually_mem hU).exists
 
@@ -113,28 +124,27 @@ theorem exists_mul_mem_of_tendsto (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) 
 neighbourhood of zero exhaust the ring. The index is `ℕ`, which is what makes the cover usable
 in a Baire argument — a cover by all of `Aˣ` would exhaust the ring too but could not start
 that argument. -/
-theorem iUnion_inv_smul_eq_univ_of_tendsto {U : Set A} (hU : U ∈ nhds (0 : A)) :
+theorem iUnion_inv_smul_eq_univ_of_tendsto_zero {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
     ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
   refine Set.eq_univ_of_forall fun x ↦ Set.mem_iUnion.mpr ?_
-  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto hu x hU
+  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto_zero hu x hU
   exact ⟨n, Set.mem_inv_smul_set_iff.mpr (by rwa [Units.smul_def, smul_eq_mul])⟩
 
 end Absorption
 
 namespace HasZeroSequenceOfUnits
 
-variable [SeparatelyContinuousMul A] (h : HasZeroSequenceOfUnits A)
-include h
+variable [SeparatelyContinuousMul A] [HasZeroSequenceOfUnits A]
 
 /-- Some unit carries a given element into a given neighbourhood of zero.
 
 Deliberately not phrased with a sequence: quantifying over an unconstrained `u : ℕ → Aˣ` would
 say no more than this, since a constant sequence witnesses it. The sequence matters only for the
 covering below, where it is carried with its convergence hypothesis. -/
-theorem exists_unit_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
+theorem exists_unit_mul_mem (x : A) {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
     ∃ v : Aˣ, (v : A) * x ∈ U := by
-  obtain ⟨u, hu⟩ := h
-  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto hu x hU
+  obtain ⟨u, hu⟩ := ‹HasZeroSequenceOfUnits A›.exists_tendsto
+  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto_zero hu x hU
   exact ⟨u n, hn⟩
 
 /-- Some *zero* sequence of units has its dilates of a neighbourhood of zero covering the ring.
@@ -142,11 +152,11 @@ theorem exists_unit_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
 The convergence hypothesis is carried inside the existential: without it the sequence binder
 would be vacuous, and a caller destructing the result would get a sequence with no relation to
 the topology. -/
-theorem exists_iUnion_inv_smul_eq_univ {U : Set A} (hU : U ∈ nhds (0 : A)) :
-    ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (nhds 0) ∧
+theorem exists_iUnion_inv_smul_eq_univ {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
+    ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0) ∧
       ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
-  obtain ⟨u, hu⟩ := h
-  exact ⟨u, hu, iUnion_inv_smul_eq_univ_of_tendsto hu hU⟩
+  obtain ⟨u, hu⟩ := ‹HasZeroSequenceOfUnits A›.exists_tendsto
+  exact ⟨u, hu, iUnion_inv_smul_eq_univ_of_tendsto_zero hu hU⟩
 
 end HasZeroSequenceOfUnits
 

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -36,10 +36,10 @@ pseudouniformiser, say — keeps it rather than trading it for an opaque choice.
   `TauCeti.Huber.IsTateRing.hasZeroSequenceOfUnits`: the powers of a pseudouniformiser converge
   to zero as units, so a pseudouniformiser — hence a Tate ring, by instance search — satisfies
   the hypothesis.
-* `TauCeti.Huber.HasZeroSequenceOfUnits.exists_iUnion_inv_smul_eq_univ`: the covering, read off
-  the class rather than a given sequence, with the convergence carried inside the existential.
 * `TauCeti.Huber.HasZeroSequenceOfUnits.exists_unit_mul_mem`: the weaker unit-only form of
-  absorption — it produces some `v : Aˣ`, with no sequence and no term index.
+  absorption — it produces some `v : Aˣ`, with no sequence and no term index. The covering is
+  *not* restated at class level: destructing `exists_tendsto` and applying
+  `iUnion_inv_smul_eq_univ_of_tendsto_zero` is the same two steps.
 
 ## References
 
@@ -104,7 +104,7 @@ instance IsTateRing.hasZeroSequenceOfUnits {A : Type*} [CommRing A] [Topological
 
 section Absorption
 
-variable [SeparatelyContinuousMul A] {u : ℕ → Aˣ}
+variable [ContinuousConstSMul Aᵐᵒᵖ A] {u : ℕ → Aˣ}
   (hu : Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0))
 include hu
 
@@ -113,10 +113,13 @@ neighbourhood of zero by some term of the sequence.
 
 Stated for an arbitrary such sequence rather than a chosen one, so a caller holding a concrete
 sequence — the powers of a pseudouniformiser, say — gets the conclusion for *that* sequence.
-Separate continuity of multiplication is all the proof uses: `uₙ · x → 0 · x = 0`. -/
+Only continuity of right multiplication by the fixed `x` is used — `uₙ · x → 0 · x = 0` — which
+is why the hypothesis is the opposite-action `ContinuousConstSMul Aᵐᵒᵖ A` rather than
+`SeparatelyContinuousMul A`; the latter implies it, so a topological ring still qualifies. -/
 theorem exists_mul_mem_of_tendsto_zero (x : A) {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
     ∃ n : ℕ, ((u n : A)) * x ∈ U := by
-  have hmul : Tendsto (fun n ↦ ((u n : A)) * x) atTop (𝓝 ((0 : A) * x)) := hu.mul_const x
+  have hmul : Tendsto (fun n ↦ ((u n : A)) * x) atTop (𝓝 ((0 : A) * x)) := by
+    simpa only [op_smul_eq_mul] using hu.const_smul (MulOpposite.op x)
   rw [zero_mul] at hmul
   exact (hmul.eventually_mem hU).exists
 
@@ -134,29 +137,19 @@ end Absorption
 
 namespace HasZeroSequenceOfUnits
 
-variable [SeparatelyContinuousMul A] [HasZeroSequenceOfUnits A]
+variable [ContinuousConstSMul Aᵐᵒᵖ A] [HasZeroSequenceOfUnits A]
 
 /-- Some unit carries a given element into a given neighbourhood of zero.
 
 Deliberately not phrased with a sequence: quantifying over an unconstrained `u : ℕ → Aˣ` would
-say no more than this, since a constant sequence witnesses it. The sequence matters only for the
-covering below, where it is carried with its convergence hypothesis. -/
+say no more than this, since a constant sequence witnesses it. The sequence matters only for
+`iUnion_inv_smul_eq_univ_of_tendsto_zero`, which is stated for a given sequence carrying its own
+convergence hypothesis rather than restated at class level. -/
 theorem exists_unit_mul_mem (x : A) {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
     ∃ v : Aˣ, (v : A) * x ∈ U := by
   obtain ⟨u, hu⟩ := ‹HasZeroSequenceOfUnits A›.exists_tendsto
   obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto_zero hu x hU
   exact ⟨u n, hn⟩
-
-/-- Some *zero* sequence of units has its dilates of a neighbourhood of zero covering the ring.
-
-The convergence hypothesis is carried inside the existential: without it the sequence binder
-would be vacuous, and a caller destructing the result would get a sequence with no relation to
-the topology. -/
-theorem exists_iUnion_inv_smul_eq_univ {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
-    ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0) ∧
-      ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
-  obtain ⟨u, hu⟩ := ‹HasZeroSequenceOfUnits A›.exists_tendsto
-  exact ⟨u, hu, iUnion_inv_smul_eq_univ_of_tendsto_zero hu hU⟩
 
 end HasZeroSequenceOfUnits
 

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -17,8 +17,9 @@ a neighbourhood cover the ring.
 
 The covering is the point, and it must be **countable**. Henkel's proof applies a Baire argument
 to the sets `uₙ⁻¹ • U` indexed by `n : ℕ`; a cover indexed by all of `Aˣ` would exhaust the ring
-just as well but could not start that argument. So a sequence is chosen once, as
-`HasZeroSequenceOfUnits.seq`, and the absorption step and the covering both range over it.
+just as well but could not start that argument. Both results are therefore stated for an
+arbitrary zero sequence, so that a caller holding a concrete one — the powers of a
+pseudouniformiser, say — keeps it rather than trading it for an opaque choice.
 
 ## Main definitions
 
@@ -28,16 +29,14 @@ just as well but could not start that argument. So a sequence is chosen once, as
 
 * `TauCeti.Huber.IsTateRing.hasZeroSequenceOfUnits`: a Tate ring has one, namely the powers of a
   pseudouniformiser.
-* `TauCeti.Huber.HasZeroSequenceOfUnits.seq`: a choice of such a sequence, fixed once so that
-  everything below ranges over the same countable family.
-* `TauCeti.Huber.HasZeroSequenceOfUnits.exists_seq_mul_mem`: some term of the sequence carries a
-  given element into a given neighbourhood of zero.
-* `TauCeti.Huber.HasZeroSequenceOfUnits.iUnion_seq_inv_smul_eq_univ`: the dilates `uₙ⁻¹ • U` cover
-  the ring, indexed by `ℕ`.
+* `TauCeti.Huber.exists_mul_mem_of_tendsto`: along any zero sequence of units, some term carries
+  a given element into a given neighbourhood of zero.
+* `TauCeti.Huber.iUnion_inv_smul_eq_univ_of_tendsto`: its dilates `uₙ⁻¹ • U` cover the ring,
+  indexed by `ℕ`.
 
 ## References
 
-* A. Henkel, *An Open Mapping Theorem for rings which have a zero sequence of units*,
+* L. Henkel, *An Open Mapping Theorem for rings which have a zero sequence of units*,
   [arXiv:1407.5647](https://arxiv.org/abs/1407.5647). The hypothesis formalised here, the
   terminology, and both results below are its setup.
 * [Wedhorn, *Adic Spaces*][wedhorn_adic], Theorem 6.16 and Propositions 6.17–6.18, which are
@@ -85,42 +84,53 @@ theorem IsTateRing.hasZeroSequenceOfUnits {A : Type*} [CommRing A] [TopologicalS
   let ⟨_, ha⟩ := IsTateRing.exists_isPseudoUniformizer (A := A)
   ha.hasZeroSequenceOfUnits
 
+section Absorption
+
+variable [SeparatelyContinuousMul A] {u : ℕ → Aˣ}
+  (hu : Tendsto (fun n ↦ ((u n : A))) atTop (nhds 0))
+include hu
+
+/-- **Absorption.** Along a zero sequence of units, every element is carried into every
+neighbourhood of zero by some term of the sequence.
+
+Stated for an arbitrary such sequence rather than a chosen one, so a caller holding a concrete
+sequence — the powers of a pseudouniformiser, say — gets the conclusion for *that* sequence.
+Separate continuity of multiplication is all the proof uses: `uₙ · x → 0 · x = 0`. -/
+theorem exists_mul_mem_of_tendsto (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
+    ∃ n : ℕ, ((u n : A)) * x ∈ U := by
+  have hmul : Tendsto (fun n ↦ ((u n : A)) * x) atTop (nhds ((0 : A) * x)) := hu.mul_const x
+  rw [zero_mul] at hmul
+  exact (hmul.eventually_mem hU).exists
+
+/-- **The countable covering Henkel's Baire argument runs on**: the dilates `uₙ⁻¹ • U` of a
+neighbourhood of zero exhaust the ring. The index is `ℕ`, which is what makes the cover usable
+in a Baire argument — a cover by all of `Aˣ` would exhaust the ring too but could not start
+that argument. -/
+theorem iUnion_inv_smul_eq_univ_of_tendsto {U : Set A} (hU : U ∈ nhds (0 : A)) :
+    ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
+  refine Set.eq_univ_of_forall fun x ↦ Set.mem_iUnion.mpr ?_
+  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto hu x hU
+  exact ⟨n, Set.mem_inv_smul_set_iff.mpr (by rwa [Units.smul_def, smul_eq_mul])⟩
+
+end Absorption
+
 namespace HasZeroSequenceOfUnits
 
 variable [SeparatelyContinuousMul A] (h : HasZeroSequenceOfUnits A)
 include h
 
-/-- A choice of zero sequence of units, fixed once.
+/-- Some zero sequence of units absorbs a given element into a given neighbourhood of zero. -/
+theorem exists_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
+    ∃ (u : ℕ → Aˣ) (n : ℕ), ((u n : A)) * x ∈ U := by
+  obtain ⟨u, hu⟩ := h
+  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto hu x hU
+  exact ⟨u, n, hn⟩
 
-The absorption step and the covering below must range over the *same* countable family: Baire
-needs a countable cover, and a cover indexed by all of `Aˣ` — which may be uncountable — would
-not serve. Everything downstream therefore goes through this sequence rather than through an
-unquantified unit. -/
-noncomputable def seq : ℕ → Aˣ := h.choose
-
-omit [SeparatelyContinuousMul A] in
-/-- The chosen sequence converges to zero: the characteristic property of
-`TauCeti.Huber.HasZeroSequenceOfUnits.seq`, which is all any consumer needs of it. -/
-theorem tendsto_seq : Tendsto (fun n ↦ ((seq h n : A))) atTop (nhds 0) := h.choose_spec
-
-/-- Every element is absorbed into every neighbourhood of zero by some term of the sequence.
-
-Separate continuity of multiplication suffices, and is what the section assumes. -/
-theorem exists_seq_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
-    ∃ n : ℕ, ((seq h n : A)) * x ∈ U := by
-  have hmul : Tendsto (fun n ↦ ((seq h n : A)) * x) atTop (nhds ((0 : A) * x)) :=
-    (tendsto_seq h).mul_const x
-  rw [zero_mul] at hmul
-  exact (hmul.eventually_mem hU).exists
-
-/-- **The countable covering Henkel's Baire argument runs on**: the dilates `uₙ⁻¹ • U` of a
-neighbourhood of zero, over the chosen sequence, exhaust the ring. The index is `ℕ`, which is
-what makes the cover usable in a Baire argument. -/
-theorem iUnion_seq_inv_smul_eq_univ {U : Set A} (hU : U ∈ nhds (0 : A)) :
-    ⋃ n : ℕ, ((seq h n)⁻¹ : Aˣ) • U = Set.univ := by
-  refine Set.eq_univ_of_forall fun x ↦ Set.mem_iUnion.mpr ?_
-  obtain ⟨n, hn⟩ := exists_seq_mul_mem h x hU
-  exact ⟨n, Set.mem_inv_smul_set_iff.mpr (by rwa [Units.smul_def, smul_eq_mul])⟩
+/-- Some zero sequence of units has its dilates of a neighbourhood of zero covering the ring. -/
+theorem exists_iUnion_inv_smul_eq_univ {U : Set A} (hU : U ∈ nhds (0 : A)) :
+    ∃ u : ℕ → Aˣ, ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
+  obtain ⟨u, hu⟩ := h
+  exact ⟨u, iUnion_inv_smul_eq_univ_of_tendsto hu hU⟩
 
 end HasZeroSequenceOfUnits
 

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -5,79 +5,47 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.RingTheory.Huber.Basic
+public import TauCeti.Topology.Algebra.ZeroSequenceOfUnits
 
 /-!
-# Rings with a zero sequence of units
+# A Tate ring has a zero sequence of units
 
 Henkel's open mapping theorem is stated for a topological ring carrying a *zero sequence of
-units*: a sequence of units converging to zero. This file isolates that hypothesis and records
-the two facts about it that the theorem uses — that a Tate ring satisfies it, and that in a ring
-that satisfies it every element is absorbed into every neighbourhood of zero, so the dilates of
-a neighbourhood cover the ring.
+units*. That hypothesis and the absorption property it exists for are generic, and live in
+`TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean`; this file supplies the bridge from Huber
+theory, namely that the powers of a pseudouniformiser are such a sequence.
 
-The covering is the point, and it must be **countable**. Henkel's proof applies a Baire argument
-to the sets `uₙ⁻¹ • U` indexed by `n : ℕ`; a cover indexed by all of `Aˣ` would exhaust the ring
-just as well but could not start that argument. Both results are therefore stated for an
-arbitrary zero sequence, so that a caller holding a concrete one — the powers of a
-pseudouniformiser, say — keeps it rather than trading it for an opaque choice.
-
-## Main definitions
-
-* `TauCeti.Huber.HasZeroSequenceOfUnits`: the ring admits a sequence of units tending to zero.
+This is where the Tate condition enters Henkel's theorem: a Huber ring that is not Tate need not
+admit such a sequence, `ℤ_[p]` being the example.
 
 ## Main results
 
-* `TauCeti.Huber.exists_mul_mem_of_tendsto_zero`: along any zero sequence of units, some term
-  carries a given element into a given neighbourhood of zero.
-* `TauCeti.Huber.iUnion_inv_smul_eq_univ_of_tendsto_zero`: its dilates `uₙ⁻¹ • U` cover the ring,
-  indexed by `ℕ`.
-* `TauCeti.Huber.IsPseudoUniformizer.tendsto_pow_unit`,
-  `TauCeti.Huber.IsPseudoUniformizer.hasZeroSequenceOfUnits` and
-  `TauCeti.Huber.IsTateRing.hasZeroSequenceOfUnits`: the powers of a pseudouniformiser converge
-  to zero as units, so a pseudouniformiser — hence a Tate ring, by instance search — satisfies
-  the hypothesis.
-* `TauCeti.Huber.HasZeroSequenceOfUnits.exists_unit_mul_mem`: the weaker unit-only form of
-  absorption — it produces some `v : Aˣ`, with no sequence and no term index. The covering is
-  *not* restated at class level: destructing `exists_tendsto` and applying
-  `iUnion_inv_smul_eq_univ_of_tendsto_zero` is the same two steps.
+* `TauCeti.Huber.IsPseudoUniformizer.tendsto_pow_unit`: the powers of a pseudouniformiser
+  converge to zero, as units. This is the concrete sequence, kept nameable so a caller holding
+  `ϖ` can feed *it* to the generic results instead of destructing an existential.
+* `TauCeti.Huber.IsPseudoUniformizer.hasZeroSequenceOfUnits` and
+  `TauCeti.Huber.IsTateRing.hasZeroSequenceOfUnits`: a pseudouniformiser — hence a Tate ring, by
+  instance search — satisfies the hypothesis.
 
 ## References
 
 * L. Henkel, *An Open Mapping Theorem for rings which have a zero sequence of units*,
-  [arXiv:1407.5647](https://arxiv.org/abs/1407.5647). The hypothesis formalised here, the
-  terminology, and both results below are its setup.
+  [arXiv:1407.5647](https://arxiv.org/abs/1407.5647), whose hypothesis this discharges.
 * [Wedhorn, *Adic Spaces*][wedhorn_adic], Theorem 6.16 and Propositions 6.17–6.18, which are
   proved from Henkel's theorem; downstream context for this file rather than its source.
 -/
 
 public section
 
-open Filter Topology Pointwise
+open Filter Topology
 
 namespace TauCeti.Huber
 
-variable (A : Type*) [MonoidWithZero A] [TopologicalSpace A]
-
-/-- Henkel's hypothesis on the base ring: there is a sequence of units converging to zero.
-
-A discrete ring has none unless it is trivial, and that is the intended exclusion: the theorem
-needs to shrink a neighbourhood by an invertible factor. -/
-class HasZeroSequenceOfUnits : Prop where
-  /-- Some sequence of units converges to zero. -/
-  exists_tendsto : ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0)
-
-/-- Destructor for `TauCeti.Huber.HasZeroSequenceOfUnits`: it is a class so that a Tate ring
-supplies it by instance search, and this is how a proof reaches the sequence. -/
-@[simp]
-theorem hasZeroSequenceOfUnits_iff :
-    HasZeroSequenceOfUnits A ↔ ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0) :=
-  ⟨fun h ↦ h.exists_tendsto, fun h ↦ ⟨h⟩⟩
-
-variable {A}
+variable {A : Type*} [MonoidWithZero A] [TopologicalSpace A]
 
 /-- **The powers of a pseudouniformiser converge to zero, as units.** This is the concrete zero
-sequence, kept nameable so a caller holding `ϖ` can feed *it* to the results below instead of
-destructing an existential. -/
+sequence, kept nameable so a caller holding `ϖ` can feed *it* to the absorption and covering
+results instead of destructing an existential. -/
 theorem IsPseudoUniformizer.tendsto_pow_unit {a : A} (ha : IsPseudoUniformizer a) :
     Tendsto (fun n ↦ ((ha.isUnit.unit ^ n : Aˣ) : A)) atTop (𝓝 0) := by
   -- `IsTopologicallyNilpotent` is a `def`, so ascribe its `Tendsto` form for `simp` to see.
@@ -102,55 +70,6 @@ instance IsTateRing.hasZeroSequenceOfUnits {A : Type*} [CommRing A] [Topological
   let ⟨_, ha⟩ := IsTateRing.exists_isPseudoUniformizer (A := A)
   ha.hasZeroSequenceOfUnits
 
-section Absorption
-
-variable [ContinuousConstSMul Aᵐᵒᵖ A] {u : ℕ → Aˣ}
-  (hu : Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0))
-include hu
-
-/-- **Absorption.** Along a zero sequence of units, every element is carried into every
-neighbourhood of zero by some term of the sequence.
-
-Stated for an arbitrary such sequence rather than a chosen one, so a caller holding a concrete
-sequence — the powers of a pseudouniformiser, say — gets the conclusion for *that* sequence.
-Only continuity of right multiplication by the fixed `x` is used — `uₙ · x → 0 · x = 0` — which
-is why the hypothesis is the opposite-action `ContinuousConstSMul Aᵐᵒᵖ A` rather than
-`SeparatelyContinuousMul A`; the latter implies it, so a topological ring still qualifies. -/
-theorem exists_mul_mem_of_tendsto_zero (x : A) {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
-    ∃ n : ℕ, ((u n : A)) * x ∈ U := by
-  have hmul : Tendsto (fun n ↦ ((u n : A)) * x) atTop (𝓝 ((0 : A) * x)) := by
-    simpa only [op_smul_eq_mul] using hu.const_smul (MulOpposite.op x)
-  rw [zero_mul] at hmul
-  exact (hmul.eventually_mem hU).exists
-
-/-- **The countable covering Henkel's Baire argument runs on**: the dilates `uₙ⁻¹ • U` of a
-neighbourhood of zero exhaust the ring. The index is `ℕ`, which is what makes the cover usable
-in a Baire argument — a cover by all of `Aˣ` would exhaust the ring too but could not start
-that argument. -/
-theorem iUnion_inv_smul_eq_univ_of_tendsto_zero {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
-    ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
-  refine Set.eq_univ_of_forall fun x ↦ Set.mem_iUnion.mpr ?_
-  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto_zero hu x hU
-  exact ⟨n, Set.mem_inv_smul_set_iff.mpr (by rwa [Units.smul_def, smul_eq_mul])⟩
-
-end Absorption
-
-namespace HasZeroSequenceOfUnits
-
-variable [ContinuousConstSMul Aᵐᵒᵖ A] [HasZeroSequenceOfUnits A]
-
-/-- Some unit carries a given element into a given neighbourhood of zero.
-
-Deliberately not phrased with a sequence: quantifying over an unconstrained `u : ℕ → Aˣ` would
-say no more than this, since a constant sequence witnesses it. The sequence matters only for
-`iUnion_inv_smul_eq_univ_of_tendsto_zero`, which is stated for a given sequence carrying its own
-convergence hypothesis rather than restated at class level. -/
-theorem exists_unit_mul_mem (x : A) {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
-    ∃ v : Aˣ, (v : A) * x ∈ U := by
-  obtain ⟨u, hu⟩ := ‹HasZeroSequenceOfUnits A›.exists_tendsto
-  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto_zero hu x hU
-  exact ⟨u n, hn⟩
-
-end HasZeroSequenceOfUnits
-
 end TauCeti.Huber
+
+end

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -53,9 +53,11 @@ theorem IsPseudoUniformizer.tendsto_pow_unit {a : A} (ha : IsPseudoUniformizer a
   simpa only [Units.val_pow_eq_pow_val, IsUnit.unit_spec] using hnil
 
 /-- **A pseudouniformiser makes the ring admit a zero sequence of units.** No Huber or Tate
-hypothesis is needed: a topologically nilpotent unit is exactly what the class asks for. The
-witness is `TauCeti.Huber.IsPseudoUniformizer.tendsto_pow_unit`, which a caller wanting the
-powers themselves should use instead. -/
+hypothesis is needed: a topologically nilpotent unit *supplies* the class, through its powers.
+It is sufficient, not equivalent — the class asks only for some sequence of units tending to
+zero, and such a sequence need not consist of the powers of a single unit. The witness here is
+`TauCeti.Huber.IsPseudoUniformizer.tendsto_pow_unit`, which a caller wanting the powers
+themselves should use instead. -/
 theorem IsPseudoUniformizer.hasZeroSequenceOfUnits {a : A} (ha : IsPseudoUniformizer a) :
     HasZeroSequenceOfUnits A :=
   ⟨_, ha.tendsto_pow_unit⟩

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RingTheory.Huber.Basic
+
+/-!
+# Rings with a zero sequence of units
+
+Henkel's open mapping theorem is stated for a topological ring carrying a *zero sequence of
+units*: a sequence of units converging to zero. This file isolates that hypothesis and records
+the two facts about it that the theorem uses — that a Tate ring satisfies it, and that in a ring
+that satisfies it every element is absorbed into every neighbourhood of zero, so the dilates of
+a neighbourhood cover the ring.
+
+The covering is the point. Henkel's proof applies a Baire argument to the sets `uₙ⁻¹ • U`, and
+what makes that argument start is exactly that they exhaust the ring.
+
+## Main definitions
+
+* `TauCeti.Huber.HasZeroSequenceOfUnits`: the ring admits a sequence of units tending to zero.
+
+## Main results
+
+* `TauCeti.Huber.IsTateRing.hasZeroSequenceOfUnits`: a Tate ring has one, namely the powers of a
+  pseudouniformiser.
+* `TauCeti.Huber.HasZeroSequenceOfUnits.exists_unit_mul_mem`: some term of the sequence carries a
+  given element into a given neighbourhood of zero.
+* `TauCeti.Huber.HasZeroSequenceOfUnits.iUnion_smul_eq_univ`: the dilates of a neighbourhood of
+  zero cover the ring.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Theorem 6.16 and Propositions 6.17–6.18, which are
+  proved from Henkel's open mapping theorem; this file states the hypothesis that theorem places
+  on the base ring.
+-/
+
+public section
+
+open Filter Topology Pointwise
+
+namespace TauCeti.Huber
+
+variable (A : Type*) [CommRing A] [TopologicalSpace A]
+
+/-- Henkel's hypothesis on the base ring: there is a sequence of units converging to zero.
+
+A discrete ring has none unless it is trivial, and that is the intended exclusion: the theorem
+needs to shrink a neighbourhood by an invertible factor. -/
+def HasZeroSequenceOfUnits : Prop :=
+  ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (nhds 0)
+
+/-- Unfolding lemma for `TauCeti.Huber.HasZeroSequenceOfUnits`. -/
+theorem hasZeroSequenceOfUnits_iff :
+    HasZeroSequenceOfUnits A ↔ ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (nhds 0) :=
+  (Iff.rfl)
+
+variable {A}
+
+/-- **A Tate ring has a zero sequence of units**: the powers of a pseudouniformiser.
+
+This is where the Tate condition enters Henkel's theorem — a Huber ring that is not Tate need
+not admit such a sequence, `ℤ_[p]` being the example. -/
+theorem IsPseudoUniformizer.hasZeroSequenceOfUnits {a : A} (ha : IsPseudoUniformizer a) :
+    HasZeroSequenceOfUnits A :=
+  ⟨fun n ↦ ha.isUnit.unit ^ n, by
+    -- `IsTopologicallyNilpotent` is a `def`, so ascribe its `Tendsto` form for `simp` to see.
+    have hnil : Tendsto (fun n ↦ a ^ n) atTop (nhds 0) := ha.isTopologicallyNilpotent
+    simpa only [Units.val_pow_eq_pow_val, IsUnit.unit_spec] using hnil⟩
+
+/-- A Tate ring satisfies Henkel's hypothesis on the base ring. -/
+theorem IsTateRing.hasZeroSequenceOfUnits [IsTopologicalRing A] [IsTateRing A] :
+    HasZeroSequenceOfUnits A :=
+  let ⟨_, ha⟩ := IsTateRing.exists_isPseudoUniformizer (A := A)
+  ha.hasZeroSequenceOfUnits
+
+namespace HasZeroSequenceOfUnits
+
+variable [IsTopologicalRing A] (h : HasZeroSequenceOfUnits A)
+include h
+
+/-- Every element is absorbed into every neighbourhood of zero by some unit of the sequence.
+
+Only continuity of multiplication by a constant is used: `uₙ · x → 0 · x = 0`. -/
+theorem exists_unit_mul_mem (x : A) {U : Set A} (hU : U ∈ nhds (0 : A)) :
+    ∃ u : Aˣ, (u : A) * x ∈ U := by
+  obtain ⟨u, hu⟩ := h
+  have hmul : Tendsto (fun n ↦ ((u n : A)) * x) atTop (nhds ((0 : A) * x)) := hu.mul_const x
+  rw [zero_mul] at hmul
+  obtain ⟨n, hn⟩ := (hmul.eventually_mem hU).exists
+  exact ⟨u n, hn⟩
+
+/-- **The covering Henkel's Baire argument runs on**: the dilates `u⁻¹ • U` of a neighbourhood of
+zero, as `u` ranges over the units, exhaust the ring. -/
+theorem iUnion_smul_eq_univ {U : Set A} (hU : U ∈ nhds (0 : A)) :
+    ⋃ u : Aˣ, (u⁻¹ : Aˣ) • U = Set.univ := by
+  refine Set.eq_univ_of_forall fun x ↦ Set.mem_iUnion.mpr ?_
+  obtain ⟨u, hu⟩ := h.exists_unit_mul_mem x hU
+  exact ⟨u, ⟨(u : A) * x, hu, by simp [smul_eq_mul, ← mul_assoc]⟩⟩
+
+end HasZeroSequenceOfUnits
+
+end TauCeti.Huber

--- a/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
+++ b/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
@@ -12,7 +12,7 @@ public import Mathlib.Topology.Algebra.ConstMulAction
 Henkel's open mapping theorem is stated for a topological ring carrying a *zero sequence of
 units*: a sequence of units converging to zero. This file isolates that hypothesis and proves the
 absorption property it exists for — every element is carried into every neighbourhood of zero by
-some term of the sequence, so the dilates of a neighbourhood cover the module.
+some term of the sequence, so the dilates of a neighbourhood cover the space acted on.
 
 The class carries no continuity, and this file assumes no continuity *instance* either, so each
 result below takes an explicit `hc : ContinuousAt (fun a : A ↦ a • x) 0` — continuity of the
@@ -21,8 +21,10 @@ are false for a `MonoidWithZero` with an arbitrary topology. `ContinuousSMul A M
 joint continuity, strictly more than these proofs use.
 
 Nothing here is Huber-specific, or even ring-specific. The hypothesis is about `A`, but the
-absorption and covering results act on an `A`-module `M`, which is the form Henkel's theorem
-needs: his Baire argument covers the *domain* of the map, not the base ring. Taking `M = A`
+absorption and covering results act on a space `M` carrying a zero and a zero-preserving
+`A`-action — `[Zero M] [TopologicalSpace M] [MulActionWithZero A M]`, no additive structure on `M`
+required, so `M` is *not* assumed to be a module. That is the form Henkel's theorem needs, since
+his Baire argument covers the *domain* of the map rather than the base ring; taking `M = A`
 recovers the ring statements. The bridge to Huber theory — that the powers of a pseudouniformiser
 are such a sequence, so a Tate ring qualifies — is in
 `TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean`.
@@ -43,9 +45,10 @@ All three carry the continuity hypothesis described above; the covering needs it
 the two pointwise results only at their own.
 
 * `TauCeti.exists_smul_mem_of_tendsto_zero`: along any zero sequence of units, some term carries a
-  given element of an `A`-module into a given neighbourhood of zero.
-* `TauCeti.iUnion_inv_smul_eq_univ_of_tendsto_zero`: its dilates `uₙ⁻¹ • U` cover the module,
-  indexed by `ℕ`.
+  given element of a space carrying a zero-preserving `A`-action into a given neighbourhood of
+  zero.
+* `TauCeti.iUnion_inv_smul_eq_univ_of_tendsto_zero`: its dilates `uₙ⁻¹ • U` cover `M`, indexed
+  by `ℕ`.
 * `TauCeti.HasZeroSequenceOfUnits.exists_unit_smul_mem`: the weaker unit-only form of absorption —
   it produces some `v : Aˣ`, with no sequence and no term index.
 
@@ -88,8 +91,9 @@ variable {M : Type*} [Zero M] [TopologicalSpace M] [MulActionWithZero A M]
   {u : ℕ → Aˣ} (hu : Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0))
 include hu
 
-/-- **Absorption.** Along a zero sequence of units in `A`, every element of an `A`-module `M` is
-carried into every neighbourhood of zero by some term of the sequence.
+/-- **Absorption.** Along a zero sequence of units in `A`, every element of a space `M` carrying a
+zero-preserving `A`-action is carried into every neighbourhood of zero by some term of the
+sequence.
 
 Stated for an arbitrary such sequence rather than a chosen one, so a caller holding a concrete
 sequence — the powers of a pseudouniformiser, say — gets the conclusion for *that* sequence.
@@ -108,9 +112,9 @@ theorem exists_smul_mem_of_tendsto_zero (x : M) (hc : ContinuousAt (fun a : A �
   exact (hsmul.eventually_mem hU).exists
 
 /-- **The countable covering Henkel's Baire argument runs on**: the dilates `uₙ⁻¹ • U` of a
-neighbourhood of zero exhaust the module. The index is `ℕ`, which is what makes the cover usable
-in a Baire argument — a cover by all of `Aˣ` would exhaust `M` too but could not start that
-argument. Henkel needs this for the *domain* of the map, hence the module form. -/
+neighbourhood of zero exhaust `M`. The index is `ℕ`, which is what makes the cover usable in a
+Baire argument — a cover by all of `Aˣ` would exhaust `M` too but could not start that argument.
+Henkel needs this for the *domain* of the map, which is why `M` is not just the base ring. -/
 theorem iUnion_inv_smul_eq_univ_of_tendsto_zero
     (hc : ∀ x : M, ContinuousAt (fun a : A ↦ a • x) 0) {U : Set M} (hU : U ∈ 𝓝 (0 : M)) :
     ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by

--- a/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
+++ b/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Algebra.OpenSubgroup
+public import Mathlib.Topology.Algebra.ConstMulAction
+
+/-!
+# Rings with a zero sequence of units
+
+Henkel's open mapping theorem is stated for a topological ring carrying a *zero sequence of
+units*: a sequence of units converging to zero. This file isolates that hypothesis and proves the
+absorption property it exists for — in such a ring every element is carried into every
+neighbourhood of zero by some term of the sequence, so the dilates of a neighbourhood cover the
+ring.
+
+Nothing here is Huber-specific, or even ring-specific: the statements live over a
+`MonoidWithZero` with continuous right multiplication by a constant. The bridge to Huber theory —
+that the powers of a pseudouniformiser are such a sequence, so a Tate ring qualifies — is in
+`TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean`.
+
+The covering is the point, and it must be **countable**. Henkel's proof applies a Baire argument
+to the sets `uₙ⁻¹ • U` indexed by `n : ℕ`; a cover indexed by all of `Aˣ` would exhaust the ring
+just as well but could not start that argument. Both results are therefore stated for an
+arbitrary zero sequence, so that a caller holding a concrete one — the powers of a
+pseudouniformiser, say — keeps it rather than trading it for an opaque choice.
+
+## Main definitions
+
+* `TauCeti.HasZeroSequenceOfUnits`: the ring admits a sequence of units tending to zero.
+
+## Main results
+
+* `TauCeti.exists_mul_mem_of_tendsto_zero`: along any zero sequence of units, some term carries a
+  given element into a given neighbourhood of zero.
+* `TauCeti.iUnion_inv_smul_eq_univ_of_tendsto_zero`: its dilates `uₙ⁻¹ • U` cover the ring,
+  indexed by `ℕ`.
+* `TauCeti.HasZeroSequenceOfUnits.exists_unit_mul_mem`: the weaker unit-only form of absorption —
+  it produces some `v : Aˣ`, with no sequence and no term index.
+
+## References
+
+* L. Henkel, *An Open Mapping Theorem for rings which have a zero sequence of units*,
+  [arXiv:1407.5647](https://arxiv.org/abs/1407.5647). The hypothesis formalised here, the
+  terminology, and both results below are its setup.
+-/
+
+public section
+
+open Filter Topology Pointwise
+
+namespace TauCeti
+
+variable (A : Type*) [MonoidWithZero A] [TopologicalSpace A]
+
+/-- Henkel's hypothesis on the base ring: there is a sequence of units converging to zero.
+
+A discrete ring has none unless it is trivial, and that is the intended exclusion: the theorem
+needs to shrink a neighbourhood by an invertible factor. -/
+class HasZeroSequenceOfUnits : Prop where
+  /-- Some sequence of units converges to zero. -/
+  exists_tendsto : ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0)
+
+/-- Destructor for `TauCeti.HasZeroSequenceOfUnits`: it is a class so that a Tate ring supplies it
+by instance search, and this is how a proof reaches the sequence. -/
+@[simp]
+theorem hasZeroSequenceOfUnits_iff :
+    HasZeroSequenceOfUnits A ↔ ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0) :=
+  ⟨fun h ↦ h.exists_tendsto, fun h ↦ ⟨h⟩⟩
+
+variable {A}
+
+section Absorption
+
+variable [ContinuousConstSMul Aᵐᵒᵖ A] {u : ℕ → Aˣ}
+  (hu : Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0))
+include hu
+
+/-- **Absorption.** Along a zero sequence of units, every element is carried into every
+neighbourhood of zero by some term of the sequence.
+
+Stated for an arbitrary such sequence rather than a chosen one, so a caller holding a concrete
+sequence — the powers of a pseudouniformiser, say — gets the conclusion for *that* sequence.
+Only continuity of right multiplication by the fixed `x` is used — `uₙ · x → 0 · x = 0` — which
+is why the hypothesis is the opposite-action `ContinuousConstSMul Aᵐᵒᵖ A` rather than
+`SeparatelyContinuousMul A`; the latter implies it, so a topological ring still qualifies. -/
+theorem exists_mul_mem_of_tendsto_zero (x : A) {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
+    ∃ n : ℕ, ((u n : A)) * x ∈ U := by
+  have hmul : Tendsto (fun n ↦ ((u n : A)) * x) atTop (𝓝 ((0 : A) * x)) := by
+    simpa only [op_smul_eq_mul] using hu.const_smul (MulOpposite.op x)
+  rw [zero_mul] at hmul
+  exact (hmul.eventually_mem hU).exists
+
+/-- **The countable covering Henkel's Baire argument runs on**: the dilates `uₙ⁻¹ • U` of a
+neighbourhood of zero exhaust the ring. The index is `ℕ`, which is what makes the cover usable
+in a Baire argument — a cover by all of `Aˣ` would exhaust the ring too but could not start
+that argument. -/
+theorem iUnion_inv_smul_eq_univ_of_tendsto_zero {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
+    ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
+  refine Set.eq_univ_of_forall fun x ↦ Set.mem_iUnion.mpr ?_
+  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto_zero hu x hU
+  exact ⟨n, Set.mem_inv_smul_set_iff.mpr (by rwa [Units.smul_def, smul_eq_mul])⟩
+
+end Absorption
+
+namespace HasZeroSequenceOfUnits
+
+variable [ContinuousConstSMul Aᵐᵒᵖ A] [HasZeroSequenceOfUnits A]
+
+/-- Some unit carries a given element into a given neighbourhood of zero.
+
+Deliberately not phrased with a sequence: quantifying over an unconstrained `u : ℕ → Aˣ` would
+say no more than this, since a constant sequence witnesses it. The sequence matters only for
+`iUnion_inv_smul_eq_univ_of_tendsto_zero`, which is stated for a given sequence carrying its own
+convergence hypothesis rather than restated at class level. -/
+theorem exists_unit_mul_mem (x : A) {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
+    ∃ v : Aˣ, (v : A) * x ∈ U := by
+  obtain ⟨u, hu⟩ := ‹HasZeroSequenceOfUnits A›.exists_tendsto
+  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto_zero hu x hU
+  exact ⟨u n, hn⟩
+
+end HasZeroSequenceOfUnits
+
+end TauCeti
+
+end

--- a/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
+++ b/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
@@ -15,9 +15,11 @@ absorption property it exists for — in such a ring every element is carried in
 neighbourhood of zero by some term of the sequence, so the dilates of a neighbourhood cover the
 ring.
 
-Nothing here is Huber-specific, or even ring-specific: the statements live over a
-`MonoidWithZero` with continuous right multiplication by a constant. The bridge to Huber theory —
-that the powers of a pseudouniformiser are such a sequence, so a Tate ring qualifies — is in
+Nothing here is Huber-specific, or even ring-specific. The hypothesis is about `A`, but the
+absorption and covering results act on an `A`-module `M`, which is the form Henkel's theorem
+needs: his Baire argument covers the *domain* of the map, not the base ring. Taking `M = A`
+recovers the ring statements. The bridge to Huber theory — that the powers of a pseudouniformiser
+are such a sequence, so a Tate ring qualifies — is in
 `TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean`.
 
 The covering is the point, and it must be **countable**. Henkel's proof applies a Baire argument
@@ -32,11 +34,11 @@ pseudouniformiser, say — keeps it rather than trading it for an opaque choice.
 
 ## Main results
 
-* `TauCeti.exists_mul_mem_of_tendsto_zero`: along any zero sequence of units, some term carries a
-  given element into a given neighbourhood of zero.
-* `TauCeti.iUnion_inv_smul_eq_univ_of_tendsto_zero`: its dilates `uₙ⁻¹ • U` cover the ring,
+* `TauCeti.exists_smul_mem_of_tendsto_zero`: along any zero sequence of units, some term carries a
+  given element of an `A`-module into a given neighbourhood of zero.
+* `TauCeti.iUnion_inv_smul_eq_univ_of_tendsto_zero`: its dilates `uₙ⁻¹ • U` cover the module,
   indexed by `ℕ`.
-* `TauCeti.HasZeroSequenceOfUnits.exists_unit_mul_mem`: the weaker unit-only form of absorption —
+* `TauCeti.HasZeroSequenceOfUnits.exists_unit_smul_mem`: the weaker unit-only form of absorption —
   it produces some `v : Aˣ`, with no sequence and no term index.
 
 ## References
@@ -74,51 +76,56 @@ variable {A}
 
 section Absorption
 
-variable [ContinuousConstSMul Aᵐᵒᵖ A] {u : ℕ → Aˣ}
-  (hu : Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0))
-include hu
+variable {M : Type*} [Zero M] [TopologicalSpace M] [MulActionWithZero A M]
+  (hc : ∀ x : M, Continuous fun a : A ↦ a • x)
+  {u : ℕ → Aˣ} (hu : Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0))
+include hc hu
 
-/-- **Absorption.** Along a zero sequence of units, every element is carried into every
-neighbourhood of zero by some term of the sequence.
+/-- **Absorption.** Along a zero sequence of units in `A`, every element of an `A`-module `M` is
+carried into every neighbourhood of zero by some term of the sequence.
 
 Stated for an arbitrary such sequence rather than a chosen one, so a caller holding a concrete
 sequence — the powers of a pseudouniformiser, say — gets the conclusion for *that* sequence.
-Only continuity of right multiplication by the fixed `x` is used — `uₙ · x → 0 · x = 0` — which
-is why the hypothesis is the opposite-action `ContinuousConstSMul Aᵐᵒᵖ A` rather than
-`SeparatelyContinuousMul A`; the latter implies it, so a topological ring still qualifies. -/
-theorem exists_mul_mem_of_tendsto_zero (x : A) {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
-    ∃ n : ℕ, ((u n : A)) * x ∈ U := by
-  have hmul : Tendsto (fun n ↦ ((u n : A)) * x) atTop (𝓝 ((0 : A) * x)) := by
-    simpa only [op_smul_eq_mul] using hu.const_smul (MulOpposite.op x)
-  rw [zero_mul] at hmul
-  exact (hmul.eventually_mem hU).exists
+
+The only topological input is `hc`, continuity of the scalar action with the vector held fixed:
+the proof is `uₙ • x → 0 • x = 0`. It is an unbundled hypothesis because Mathlib has no class for
+"continuous in the scalar, vector fixed" — `ContinuousSMul A M` is joint continuity, which is
+strictly more than this argument uses. At `M = A` it is separate continuity of multiplication,
+`fun x ↦ by simpa only [smul_eq_mul] using continuous_mul_const x`. -/
+theorem exists_smul_mem_of_tendsto_zero (x : M) {U : Set M} (hU : U ∈ 𝓝 (0 : M)) :
+    ∃ n : ℕ, ((u n : A)) • x ∈ U := by
+  have hsmul : Tendsto (fun n ↦ ((u n : A)) • x) atTop (𝓝 ((0 : A) • x)) :=
+    ((hc x).tendsto 0).comp hu
+  rw [zero_smul] at hsmul
+  exact (hsmul.eventually_mem hU).exists
 
 /-- **The countable covering Henkel's Baire argument runs on**: the dilates `uₙ⁻¹ • U` of a
-neighbourhood of zero exhaust the ring. The index is `ℕ`, which is what makes the cover usable
-in a Baire argument — a cover by all of `Aˣ` would exhaust the ring too but could not start
-that argument. -/
-theorem iUnion_inv_smul_eq_univ_of_tendsto_zero {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
+neighbourhood of zero exhaust the module. The index is `ℕ`, which is what makes the cover usable
+in a Baire argument — a cover by all of `Aˣ` would exhaust `M` too but could not start that
+argument. Henkel needs this for the *domain* of the map, hence the module form. -/
+theorem iUnion_inv_smul_eq_univ_of_tendsto_zero {U : Set M} (hU : U ∈ 𝓝 (0 : M)) :
     ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
   refine Set.eq_univ_of_forall fun x ↦ Set.mem_iUnion.mpr ?_
-  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto_zero hu x hU
-  exact ⟨n, Set.mem_inv_smul_set_iff.mpr (by rwa [Units.smul_def, smul_eq_mul])⟩
+  obtain ⟨n, hn⟩ := exists_smul_mem_of_tendsto_zero hc hu x hU
+  exact ⟨n, Set.mem_inv_smul_set_iff.mpr (by rwa [Units.smul_def])⟩
 
 end Absorption
 
 namespace HasZeroSequenceOfUnits
 
-variable [ContinuousConstSMul Aᵐᵒᵖ A] [HasZeroSequenceOfUnits A]
+variable {M : Type*} [Zero M] [TopologicalSpace M] [MulActionWithZero A M]
+  [HasZeroSequenceOfUnits A]
 
-/-- Some unit carries a given element into a given neighbourhood of zero.
+/-- Some unit of `A` carries a given element of `M` into a given neighbourhood of zero.
 
 Deliberately not phrased with a sequence: quantifying over an unconstrained `u : ℕ → Aˣ` would
 say no more than this, since a constant sequence witnesses it. The sequence matters only for
 `iUnion_inv_smul_eq_univ_of_tendsto_zero`, which is stated for a given sequence carrying its own
 convergence hypothesis rather than restated at class level. -/
-theorem exists_unit_mul_mem (x : A) {U : Set A} (hU : U ∈ 𝓝 (0 : A)) :
-    ∃ v : Aˣ, (v : A) * x ∈ U := by
+theorem exists_unit_smul_mem (hc : ∀ x : M, Continuous fun a : A ↦ a • x) (x : M) {U : Set M}
+    (hU : U ∈ 𝓝 (0 : M)) : ∃ v : Aˣ, (v : A) • x ∈ U := by
   obtain ⟨u, hu⟩ := ‹HasZeroSequenceOfUnits A›.exists_tendsto
-  obtain ⟨n, hn⟩ := exists_mul_mem_of_tendsto_zero hu x hU
+  obtain ⟨n, hn⟩ := exists_smul_mem_of_tendsto_zero hc hu x hU
   exact ⟨u n, hn⟩
 
 end HasZeroSequenceOfUnits

--- a/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
+++ b/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
@@ -11,9 +11,14 @@ public import Mathlib.Topology.Algebra.ConstMulAction
 
 Henkel's open mapping theorem is stated for a topological ring carrying a *zero sequence of
 units*: a sequence of units converging to zero. This file isolates that hypothesis and proves the
-absorption property it exists for — in such a ring every element is carried into every
-neighbourhood of zero by some term of the sequence, so the dilates of a neighbourhood cover the
-ring.
+absorption property it exists for — every element is carried into every neighbourhood of zero by
+some term of the sequence, so the dilates of a neighbourhood cover the module.
+
+The class carries no continuity, and this file assumes no continuity *instance* either, so each
+result below takes an explicit `hc : ContinuousAt (fun a : A ↦ a • x) 0` — continuity of the
+scalar action in the scalar alone, at zero, for the vector in question. Without it the statements
+are false for a `MonoidWithZero` with an arbitrary topology. `ContinuousSMul A M` would do but is
+joint continuity, strictly more than these proofs use.
 
 Nothing here is Huber-specific, or even ring-specific. The hypothesis is about `A`, but the
 absorption and covering results act on an `A`-module `M`, which is the form Henkel's theorem
@@ -33,6 +38,9 @@ pseudouniformiser, say — keeps it rather than trading it for an opaque choice.
 * `TauCeti.HasZeroSequenceOfUnits`: the ring admits a sequence of units tending to zero.
 
 ## Main results
+
+All three carry the continuity hypothesis described above; the covering needs it at every vector,
+the two pointwise results only at their own.
 
 * `TauCeti.exists_smul_mem_of_tendsto_zero`: along any zero sequence of units, some term carries a
   given element of an `A`-module into a given neighbourhood of zero.
@@ -77,9 +85,8 @@ variable {A}
 section Absorption
 
 variable {M : Type*} [Zero M] [TopologicalSpace M] [MulActionWithZero A M]
-  (hc : ∀ x : M, Continuous fun a : A ↦ a • x)
   {u : ℕ → Aˣ} (hu : Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0))
-include hc hu
+include hu
 
 /-- **Absorption.** Along a zero sequence of units in `A`, every element of an `A`-module `M` is
 carried into every neighbourhood of zero by some term of the sequence.
@@ -87,15 +94,16 @@ carried into every neighbourhood of zero by some term of the sequence.
 Stated for an arbitrary such sequence rather than a chosen one, so a caller holding a concrete
 sequence — the powers of a pseudouniformiser, say — gets the conclusion for *that* sequence.
 
-The only topological input is `hc`, continuity of the scalar action with the vector held fixed:
-the proof is `uₙ • x → 0 • x = 0`. It is an unbundled hypothesis because Mathlib has no class for
-"continuous in the scalar, vector fixed" — `ContinuousSMul A M` is joint continuity, which is
-strictly more than this argument uses. At `M = A` it is separate continuity of multiplication,
-`fun x ↦ by simpa only [smul_eq_mul] using continuous_mul_const x`. -/
-theorem exists_smul_mem_of_tendsto_zero (x : M) {U : Set M} (hU : U ∈ 𝓝 (0 : M)) :
+The only topological input is `hc`, and it is needed only at the one `x` the conclusion is about
+and only at `0 : A`: the proof is `uₙ • x → 0 • x = 0`. It is an unbundled hypothesis because
+Mathlib has no class for "continuous in the scalar, vector fixed" — `ContinuousSMul A M` is joint
+continuity, which is strictly more than this argument uses. At `M = A` it is discharged by
+`(continuous_mul_const x).continuousAt` modulo `smul_eq_mul`. -/
+theorem exists_smul_mem_of_tendsto_zero (x : M) (hc : ContinuousAt (fun a : A ↦ a • x) 0)
+    {U : Set M} (hU : U ∈ 𝓝 (0 : M)) :
     ∃ n : ℕ, ((u n : A)) • x ∈ U := by
   have hsmul : Tendsto (fun n ↦ ((u n : A)) • x) atTop (𝓝 ((0 : A) • x)) :=
-    ((hc x).tendsto 0).comp hu
+    Filter.Tendsto.comp hc hu
   rw [zero_smul] at hsmul
   exact (hsmul.eventually_mem hU).exists
 
@@ -103,10 +111,11 @@ theorem exists_smul_mem_of_tendsto_zero (x : M) {U : Set M} (hU : U ∈ 𝓝 (0 
 neighbourhood of zero exhaust the module. The index is `ℕ`, which is what makes the cover usable
 in a Baire argument — a cover by all of `Aˣ` would exhaust `M` too but could not start that
 argument. Henkel needs this for the *domain* of the map, hence the module form. -/
-theorem iUnion_inv_smul_eq_univ_of_tendsto_zero {U : Set M} (hU : U ∈ 𝓝 (0 : M)) :
+theorem iUnion_inv_smul_eq_univ_of_tendsto_zero
+    (hc : ∀ x : M, ContinuousAt (fun a : A ↦ a • x) 0) {U : Set M} (hU : U ∈ 𝓝 (0 : M)) :
     ⋃ n : ℕ, ((u n)⁻¹ : Aˣ) • U = Set.univ := by
   refine Set.eq_univ_of_forall fun x ↦ Set.mem_iUnion.mpr ?_
-  obtain ⟨n, hn⟩ := exists_smul_mem_of_tendsto_zero hc hu x hU
+  obtain ⟨n, hn⟩ := exists_smul_mem_of_tendsto_zero hu x (hc x) hU
   exact ⟨n, Set.mem_inv_smul_set_iff.mpr (by rwa [Units.smul_def])⟩
 
 end Absorption
@@ -122,10 +131,10 @@ Deliberately not phrased with a sequence: quantifying over an unconstrained `u :
 say no more than this, since a constant sequence witnesses it. The sequence matters only for
 `iUnion_inv_smul_eq_univ_of_tendsto_zero`, which is stated for a given sequence carrying its own
 convergence hypothesis rather than restated at class level. -/
-theorem exists_unit_smul_mem (hc : ∀ x : M, Continuous fun a : A ↦ a • x) (x : M) {U : Set M}
+theorem exists_unit_smul_mem (x : M) (hc : ContinuousAt (fun a : A ↦ a • x) 0) {U : Set M}
     (hU : U ∈ 𝓝 (0 : M)) : ∃ v : Aˣ, (v : A) • x ∈ U := by
   obtain ⟨u, hu⟩ := ‹HasZeroSequenceOfUnits A›.exists_tendsto
-  obtain ⟨n, hn⟩ := exists_smul_mem_of_tendsto_zero hc hu x hU
+  obtain ⟨n, hn⟩ := exists_smul_mem_of_tendsto_zero hu x hc hU
   exact ⟨u n, hn⟩
 
 end HasZeroSequenceOfUnits

--- a/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
+++ b/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Topology.Algebra.OpenSubgroup
 public import Mathlib.Topology.Algebra.ConstMulAction
 
 /-!
@@ -63,8 +62,9 @@ class HasZeroSequenceOfUnits : Prop where
   /-- Some sequence of units converges to zero. -/
   exists_tendsto : ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0)
 
-/-- Destructor for `TauCeti.HasZeroSequenceOfUnits`: it is a class so that a Tate ring supplies it
-by instance search, and this is how a proof reaches the sequence. -/
+/-- The class unfolds to the existential it wraps. This is its `@[simp]` normal form; a proof
+already holding the instance normally reaches the sequence through the field directly, as
+`‹HasZeroSequenceOfUnits A›.exists_tendsto`. -/
 @[simp]
 theorem hasZeroSequenceOfUnits_iff :
     HasZeroSequenceOfUnits A ↔ ∃ u : ℕ → Aˣ, Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0) :=

--- a/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
+++ b/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
@@ -30,8 +30,8 @@ are such a sequence, so a Tate ring qualifies — is in
 `TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean`.
 
 The covering is the point, and it must be **countable**. Henkel's proof applies a Baire argument
-to the sets `uₙ⁻¹ • U` indexed by `n : ℕ`; a cover indexed by all of `Aˣ` would exhaust the ring
-just as well but could not start that argument. Both results are therefore stated for an
+to the sets `uₙ⁻¹ • U` indexed by `n : ℕ`; a cover indexed by all of `Aˣ` would exhaust `M` just
+as well but could not start that argument. Both results are therefore stated for an
 arbitrary zero sequence, so that a caller holding a concrete one — the powers of a
 pseudouniformiser, say — keeps it rather than trading it for an opaque choice.
 
@@ -56,7 +56,7 @@ the two pointwise results only at their own.
 
 * L. Henkel, *An Open Mapping Theorem for rings which have a zero sequence of units*,
   [arXiv:1407.5647](https://arxiv.org/abs/1407.5647). The hypothesis formalised here, the
-  terminology, and both results below are its setup.
+  terminology, and the results below are its setup.
 -/
 
 public section


### PR DESCRIPTION
Henkel's open mapping theorem is stated for a topological ring carrying a *zero sequence of
units*: a sequence of units converging to zero. This PR isolates that hypothesis, proves the
absorption property it exists for, and discharges it for Tate rings — the input Layer 0.6 needs.

**Two new files.**

`TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean` holds the generic material, under
`namespace TauCeti`, importing only `Mathlib.Topology.Algebra.ConstMulAction`:

* `TauCeti.HasZeroSequenceOfUnits` — the hypothesis, as a `class` so a Tate ring supplies it by
  instance search, with `hasZeroSequenceOfUnits_iff` as its `@[simp]` destructor;
* `TauCeti.exists_smul_mem_of_tendsto_zero` — **absorption**: along any zero sequence of units in
  `A`, some term carries a given element of `M` into a given neighbourhood of zero;
* `TauCeti.iUnion_inv_smul_eq_univ_of_tendsto_zero` — **the covering** Henkel's Baire argument
  runs on: the dilates `uₙ⁻¹ • U` exhaust `M`, indexed by `ℕ`;
* `TauCeti.HasZeroSequenceOfUnits.exists_unit_smul_mem` — the weaker unit-only form: it produces
  some `v : Aˣ`, with no sequence and no term index.

`TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean` holds only the bridge from Huber theory:

* `IsPseudoUniformizer.tendsto_pow_unit` — the powers of a pseudouniformiser converge to zero as
  units. This is the concrete sequence, kept nameable so a caller holding `ϖ` can feed *it* to the
  generic results rather than destructing an existential;
* `IsPseudoUniformizer.hasZeroSequenceOfUnits` and `IsTateRing.hasZeroSequenceOfUnits` (an
  `instance`) — a pseudouniformiser, hence a Tate ring, satisfies the hypothesis.

**Why the covering must be countable, and why it is not over the base ring.** Henkel applies a Baire
argument to `uₙ⁻¹ • U` indexed by `n : ℕ`; a cover indexed by all of `Aˣ` would exhaust the ring
just as well but could not start that argument. That is why both results take an arbitrary zero
sequence rather than choosing one — a caller with a concrete sequence keeps it. And the cover is
of the *domain* of the map, not of the base ring, so `x` and `U` live in a space `M` carrying a
zero and a zero-preserving `A`-action — `[Zero M] [TopologicalSpace M] [MulActionWithZero A M]`.
No additive structure on `M` is required, so `M` is deliberately **not** assumed to be a module;
taking `M = A` recovers the ring statements.

**The continuity hypothesis is unbundled, and as weak as the proofs allow.** They use only
`uₙ • x → 0 • x = 0`, i.e. continuity of the scalar action *in the scalar alone, at zero*, so the
two pointwise results carry `hc : ContinuousAt (fun a : A ↦ a • x) 0` for the single `x` their
conclusion is about. Only `iUnion_inv_smul_eq_univ_of_tendsto_zero` quantifies over all vectors,
and it too asks only for `∀ x : M, ContinuousAt (fun a : A ↦ a • x) 0`.

Mathlib has no class for this: `ContinuousSMul A M` is *joint* continuity, strictly more than the
argument uses and, at `M = A`, not implied by separate continuity of multiplication. At `M = A`
the hypothesis is discharged by `(continuous_mul_const x).continuousAt` modulo `smul_eq_mul`.

**This is Layer 0.6 groundwork, not the open mapping theorem.** Only the hypothesis and the two
facts about it are here; Henkel's theorem itself is a separate PR.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0.6-zero-sequence-of-units"}-->

🤖 Prepared with Claude Code
