### PR TITLE
refactor(CliffordAlgebra): share the eta-expansion and commutation steps

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 import Mathlib.Tactic.NoncommRing
+public import Mathlib.Data.Fin.Tuple.Reflection
 public import Mathlib.LinearAlgebra.ExteriorPower.Basic
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Filtration
 
@@ -138,9 +139,7 @@ private theorem equivExterior_comp_bivectorExterior :
   apply exteriorPower.linearMap_ext
   apply AlternatingMap.ext
   intro x
-  have hx : x = ![x 0, x 1] := by
-    funext i
-    fin_cases i <;> rfl
+  have hx : x = ![x 0, x 1] := (FinVec.etaExpand_eq x).symm
   rw [LinearMap.compAlternatingMap_apply, LinearMap.comp_apply,
     LinearMap.compAlternatingMap_apply, LinearEquiv.coe_coe]
   rw [hx, bivectorExterior_apply_ιMulti, equivExterior_bivector]
@@ -203,9 +202,7 @@ theorem bivectorExterior_range_le_of_bivector_mem
     ← exteriorPower.ιMulti_span R 2 M]
   refine Submodule.span_le.2 ?_
   rintro _ ⟨v, rfl⟩
-  have hv : v = ![v 0, v 1] := by
-    funext i
-    fin_cases i <;> rfl
+  have hv : v = ![v 0, v 1] := (FinVec.etaExpand_eq v).symm
   rw [hv]
   -- Rewriting does not unfold membership in the comap, so expose the map application explicitly.
   change bivectorExterior Q (exteriorPower.ιMulti R 2 ![v 0, v 1]) ∈ P
@@ -221,16 +218,9 @@ theorem bivector_lie_ι (a b x : M) :
   rw [map_sub, map_smul, map_smul]
   have hbx := ι_mul_ι_add_swap (Q := Q) b x
   have hax := ι_mul_ι_add_swap (Q := Q) a x
-  have hA (r : R) : ι Q a * algebraMap R (CliffordAlgebra Q) r = r • ι Q a := by
-    calc
-      ι Q a * algebraMap R (CliffordAlgebra Q) r = algebraMap R (CliffordAlgebra Q) r * ι Q a :=
-        (Algebra.commutes r (ι Q a)).symm
-      _ = r • ι Q a := (Algebra.smul_def r (ι Q a)).symm
-  have hB (r : R) : ι Q b * algebraMap R (CliffordAlgebra Q) r = r • ι Q b := by
-    calc
-      ι Q b * algebraMap R (CliffordAlgebra Q) r = algebraMap R (CliffordAlgebra Q) r * ι Q b :=
-        (Algebra.commutes r (ι Q b)).symm
-      _ = r • ι Q b := (Algebra.smul_def r (ι Q b)).symm
+  -- A generator commutes past a scalar, turning the product into a scalar action.
+  have hcomm (m : M) (r : R) : ι Q m * algebraMap R (CliffordAlgebra Q) r = r • ι Q m := by
+    rw [← Algebra.commutes r (ι Q m), Algebra.smul_def]
   have h :
       (ι Q a * ι Q b - ι Q b * ι Q a) * ι Q x -
           ι Q x * (ι Q a * ι Q b - ι Q b * ι Q a) =
@@ -251,7 +241,7 @@ theorem bivector_lie_ι (a b x : M) :
             rw [hbx, hax]
       _ = (2 : R) • (QuadraticMap.polar Q b x • ι Q a -
           QuadraticMap.polar Q a x • ι Q b) := by
-            rw [hA, hB, ← Algebra.smul_def, ← Algebra.smul_def]
+            rw [hcomm a, hcomm b, ← Algebra.smul_def, ← Algebra.smul_def]
             rw [two_smul R]
             abel
   rw [h]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 import Mathlib.Tactic.NoncommRing
-public import Mathlib.Data.Fin.Tuple.Reflection
+import Mathlib.Data.Fin.Tuple.Reflection
 public import Mathlib.LinearAlgebra.ExteriorPower.Basic
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Filtration
 


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR removes two pieces of duplicated proof text in `Bivector.lean`.

`equivExterior_comp_bivectorExterior` and `bivectorExterior_range_le_of_bivector_mem` each opened with

```lean
have hx : x = ![x 0, x 1] := by
  funext i
  fin_cases i <;> rfl
```

which is Mathlib's `FinVec.etaExpand_eq`; its docstring gives this exact use as its worked example, `example (a : Fin 2 → α) : a = ![a 0, a 1] := (etaExpand_eq _).symm`. Both now use it, at the cost of one import.

The third `funext i; fin_cases i <;> rfl` in the file, at the end of `bivector_swap`, is left alone. It looks like the same block but is not: after `congr 1` its goal is `![b, a] = ![a, b] ∘ ⇑(Equiv.swap 0 1)`, which is a statement about precomposition with a permutation rather than an eta-expansion, and `FinVec.etaExpand_eq` does not apply. I tried it there first and the compiler rejected it.

In `bivector_lie_ι`, `hA` and `hB` were the same four-line `calc` with `a` and `b` exchanged. They are now a single `hcomm` quantified over the generator, and since the calc was just `Algebra.commutes` followed by `Algebra.smul_def`, it is a two-line rewrite.

No statement changes; this is proof text only. Full build with `--iofail`, axiom audit, module-system check and environment lint pass; `lint-env` reports no new violations.

🤖 Prepared with Claude Code