### PR TITLE
feat: add Gaussian Hermite expansions

### DIFF
--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Parseval.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Parseval.lean
@@ -19,10 +19,16 @@ abstract `HilbertBasis.repr` coordinate as the Gaussian integral against `Hₙ /
 ## Main statements
 
 * `TauCeti.gaussianHermiteHilbertBasis_repr_apply` identifies each coordinate with its integral.
-* `TauCeti.tsum_norm_sq_gaussianHermite_coeff` is Parseval's identity for those coefficients.
-* `TauCeti.summable_norm_sq_gaussianHermite_coeff` gives square-summability of the coefficients.
+* `TauCeti.tsum_norm_sq_integral_hermite_mul_gaussianReal` is Parseval's identity for those
+  coefficients.
+* `TauCeti.summable_norm_sq_integral_hermite_mul_gaussianReal` gives square-summability of the
+  coefficients.
 * `TauCeti.hasSum_gaussianHermite_expansion` reconstructs every `L²` vector from its Gaussian
   Hermite series.
+
+The coefficient itself has no name of its own: it is spelled out as the integral against
+`Hₙ / √(n!)`, so the two Parseval-side lemmas are named after that integral, as
+`TauCeti.memLp_hermite_gaussianReal` names the same normalized integrand.
 
 All statements hold for an arbitrary `RCLike` scalar field, simultaneously covering real and
 complex-valued `L²` functions.
@@ -52,7 +58,7 @@ theorem gaussianHermiteHilbertBasis_repr_apply
 
 /-- **Parseval's identity for the Gaussian Hermite basis.** The squared norms of the Gaussian
 Hermite coefficients of `f` sum to `‖f‖²`. -/
-theorem tsum_norm_sq_gaussianHermite_coeff (f : Lp 𝕜 2 (gaussianReal 0 1)) :
+theorem tsum_norm_sq_integral_hermite_mul_gaussianReal (f : Lp 𝕜 2 (gaussianReal 0 1)) :
     ∑' n : ℕ, ‖∫ x : ℝ, (algebraMap ℝ 𝕜)
       (aeval x (hermite n) / Real.sqrt (n.factorial : ℝ)) * f x ∂(gaussianReal 0 1)‖ ^ 2 =
         ‖f‖ ^ 2 := by
@@ -60,7 +66,7 @@ theorem tsum_norm_sq_gaussianHermite_coeff (f : Lp 𝕜 2 (gaussianReal 0 1)) :
     (gaussianHermiteHilbertBasis 𝕜).tsum_norm_sq_inner f
 
 /-- The squared norms of the Gaussian Hermite coefficients of an `L²` function are summable. -/
-theorem summable_norm_sq_gaussianHermite_coeff (f : Lp 𝕜 2 (gaussianReal 0 1)) :
+theorem summable_norm_sq_integral_hermite_mul_gaussianReal (f : Lp 𝕜 2 (gaussianReal 0 1)) :
     Summable fun n : ℕ => ‖∫ x : ℝ, (algebraMap ℝ 𝕜)
       (aeval x (hermite n) / Real.sqrt (n.factorial : ℝ)) * f x ∂(gaussianReal 0 1)‖ ^ 2 := by
   simpa only [← HilbertBasis.repr_apply_apply, gaussianHermiteHilbertBasis_repr_apply] using

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Parseval.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Parseval.lean
@@ -23,7 +23,6 @@ abstract `HilbertBasis.repr` coordinate as the Gaussian integral against `Hₙ /
 * `TauCeti.summable_norm_sq_gaussianHermite_coeff` gives square-summability of the coefficients.
 * `TauCeti.hasSum_gaussianHermite_expansion` reconstructs every `L²` vector from its Gaussian
   Hermite series.
-* `TauCeti.gaussianHermiteHilbertBasis_repr_self` identifies the coordinates of a basis vector.
 
 All statements hold for an arbitrary `RCLike` scalar field, simultaneously covering real and
 complex-valued `L²` functions.
@@ -76,14 +75,5 @@ theorem hasSum_gaussianHermite_expansion (f : Lp 𝕜 2 (gaussianReal 0 1)) :
           gaussianHermiteHilbertBasis 𝕜 n) f := by
   simpa only [gaussianHermiteHilbertBasis_repr_apply] using
     (gaussianHermiteHilbertBasis 𝕜).hasSum_repr f
-
-/-- The coordinates of the `n`-th normalized Hermite polynomial are a single `1` in position
-`n`. -/
-@[simp]
-theorem gaussianHermiteHilbertBasis_repr_self (n : ℕ) :
-    (gaussianHermiteHilbertBasis 𝕜).repr (gaussianHermiteHilbertBasis 𝕜 n) =
-      lp.single 2 n (1 : 𝕜) := by
-  classical
-  exact (gaussianHermiteHilbertBasis 𝕜).repr_self n
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Parseval.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Parseval.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Analysis.InnerProductSpace.Parseval
+public import TauCeti.Probability.Distributions.Gaussian.Hermite.Basis
+
+/-!
+# Parseval and expansions for the Gaussian Hermite basis
+
+`TauCeti.gaussianHermiteHilbertBasis` exhibits the normalized probabilists' Hermite polynomials
+`Hₙ / √(n!)` as a Hilbert basis of `L²(N(0, 1); 𝕜)`. This file supplies the coefficient,
+Parseval, and reconstruction API for that basis. In particular, its coordinate theorem writes the
+abstract `HilbertBasis.repr` coordinate as the Gaussian integral against `Hₙ / √(n!)`.
+
+## Main statements
+
+* `TauCeti.gaussianHermiteHilbertBasis_repr_apply` identifies each coordinate with its integral.
+* `TauCeti.tsum_norm_sq_gaussianHermite_coeff` is Parseval's identity for those coefficients.
+* `TauCeti.summable_norm_sq_gaussianHermite_coeff` gives square-summability of the coefficients.
+* `TauCeti.hasSum_gaussianHermite_expansion` reconstructs every `L²` vector from its Gaussian
+  Hermite series.
+* `TauCeti.gaussianHermiteHilbertBasis_repr_self` identifies the coordinates of a basis vector.
+
+All statements hold for an arbitrary `RCLike` scalar field, simultaneously covering real and
+complex-valued `L²` functions.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Polynomial ProbabilityTheory
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+
+/-- The `n`-th Gaussian Hermite coordinate is the integral of `f` against the normalized
+probabilists' Hermite polynomial `Hₙ / √(n!)`. -/
+@[simp]
+theorem gaussianHermiteHilbertBasis_repr_apply
+    (f : Lp 𝕜 2 (gaussianReal 0 1)) (n : ℕ) :
+    (gaussianHermiteHilbertBasis 𝕜).repr f n =
+      ∫ x : ℝ, (algebraMap ℝ 𝕜)
+        (aeval x (hermite n) / Real.sqrt (n.factorial : ℝ)) * f x ∂(gaussianReal 0 1) := by
+  rw [(gaussianHermiteHilbertBasis 𝕜).repr_apply_apply, MeasureTheory.L2.inner_def]
+  refine integral_congr_ae ?_
+  filter_upwards [coeFn_gaussianHermiteHilbertBasis 𝕜 n] with x hx
+  rw [hx]
+  simp [RCLike.inner_apply, RCLike.conj_ofReal, mul_comm]
+
+/-- **Parseval's identity for the Gaussian Hermite basis.** The squared norms of the Gaussian
+Hermite coefficients of `f` sum to `‖f‖²`. -/
+theorem tsum_norm_sq_gaussianHermite_coeff (f : Lp 𝕜 2 (gaussianReal 0 1)) :
+    ∑' n : ℕ, ‖∫ x : ℝ, (algebraMap ℝ 𝕜)
+      (aeval x (hermite n) / Real.sqrt (n.factorial : ℝ)) * f x ∂(gaussianReal 0 1)‖ ^ 2 =
+        ‖f‖ ^ 2 := by
+  simpa only [← HilbertBasis.repr_apply_apply, gaussianHermiteHilbertBasis_repr_apply] using
+    (gaussianHermiteHilbertBasis 𝕜).tsum_norm_sq_inner f
+
+/-- The squared norms of the Gaussian Hermite coefficients of an `L²` function are summable. -/
+theorem summable_norm_sq_gaussianHermite_coeff (f : Lp 𝕜 2 (gaussianReal 0 1)) :
+    Summable fun n : ℕ => ‖∫ x : ℝ, (algebraMap ℝ 𝕜)
+      (aeval x (hermite n) / Real.sqrt (n.factorial : ℝ)) * f x ∂(gaussianReal 0 1)‖ ^ 2 := by
+  simpa only [← HilbertBasis.repr_apply_apply, gaussianHermiteHilbertBasis_repr_apply] using
+    (gaussianHermiteHilbertBasis 𝕜).summable_norm_sq_inner f
+
+/-- **The Gaussian Hermite expansion.** Every `f ∈ L²(N(0, 1); 𝕜)` is the sum of its
+normalized Hermite-polynomial series. -/
+theorem hasSum_gaussianHermite_expansion (f : Lp 𝕜 2 (gaussianReal 0 1)) :
+    HasSum (fun n : ℕ =>
+      (∫ x : ℝ, (algebraMap ℝ 𝕜)
+        (aeval x (hermite n) / Real.sqrt (n.factorial : ℝ)) * f x ∂(gaussianReal 0 1)) •
+          gaussianHermiteHilbertBasis 𝕜 n) f := by
+  simpa only [gaussianHermiteHilbertBasis_repr_apply] using
+    (gaussianHermiteHilbertBasis 𝕜).hasSum_repr f
+
+/-- The coordinates of the `n`-th normalized Hermite polynomial are a single `1` in position
+`n`. -/
+@[simp]
+theorem gaussianHermiteHilbertBasis_repr_self (n : ℕ) :
+    (gaussianHermiteHilbertBasis 𝕜).repr (gaussianHermiteHilbertBasis 𝕜 n) =
+      lp.single 2 n (1 : 𝕜) := by
+  classical
+  exact (gaussianHermiteHilbertBasis 𝕜).repr_self n
+
+end TauCeti


### PR DESCRIPTION
This PR supplies the concrete coefficient, Parseval, square-summability, and reconstruction API for the normalized probabilists' Hermite basis of `L²(N(0,1); 𝕜)`, and identifies each abstract `HilbertBasis.repr` coordinate with the Gaussian integral against `Hₙ/√(n!)`.

This advances `TauCetiRoadmap/OrthogonalL2Bases/README.md`, milestone A3′ (the Gaussian Hermite basis on the measure side): that milestone calls `gaussianHermiteHilbertBasis` the basis used by standard `L²(N(0,1))` expansions, and the roadmap status identifies its missing coefficient, summability, and expansion packaging as the next frontier. The proofs reuse `HilbertBasis.hasSum_repr`, `HilbertBasis.repr_apply_apply`, and the generic norm-square Parseval API from `TauCeti.Analysis.InnerProductSpace.Parseval`; no Mathlib infrastructure is vendored.

After this PR, the analogous concrete expansion API for `chebyshevTHilbertBasis` remains on this roadmap frontier.

Roadmap: OrthogonalL2Bases

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"gaussian-hermite-expansion"}-->

🤖 Prepared with Codex
