### PR TITLE
refactor(Harnack): name the centered bounds at an intermediate radius

### DIFF
--- a/TauCeti/Analysis/PDE/Harnack/Planar.lean
+++ b/TauCeti/Analysis/PDE/Harnack/Planar.lean
@@ -245,6 +245,18 @@ theorem eq_zero_on_ball_of_harmonicOnNhd_of_nonneg_on_sphere_of_eq_zero
   · simpa [hfc_zero] using hz_bounds.2
   · simpa using hnonneg_ball z hz
 
+/-- **The centered Harnack bounds at an intermediate radius.** If `f` is harmonic and nonnegative
+throughout the open disk of radius `R` about `c`, then for every `ρ` with `‖w - c‖ < ρ < R` the
+two-sided comparison with `f c` holds with `ρ` in place of `R`. -/
+private theorem harnack_inequality_center_of_norm_sub_lt_of_lt
+    (hf : HarmonicOnNhd f (ball c R)) (hnonneg : ∀ z ∈ ball c R, 0 ≤ f z) {ρ : ℝ}
+    (hρd : ‖w - c‖ < ρ) (hρR : ρ < R) :
+    (ρ - ‖w - c‖) / (ρ + ‖w - c‖) * f c ≤ f w ∧
+      f w ≤ (ρ + ‖w - c‖) / (ρ - ‖w - c‖) * f c :=
+  harnack_inequality_center_of_nonneg_on_sphere (hf.mono (closedBall_subset_ball hρR))
+    (fun z hz ↦ hnonneg z (sphere_subset_ball hρR hz))
+    (by simpa [mem_ball, dist_eq_norm] using hρd)
+
 /-- **The centered Harnack inequality on an open planar disk.**
 
 If `f` is harmonic and nonnegative throughout the open disk of radius `R` about `c`, then
@@ -278,21 +290,11 @@ theorem harnack_inequality_center (hf : HarmonicOnNhd f (ball c R))
   · apply le_of_tendsto hlowerTendsto
     filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hdR),
       self_mem_nhdsWithin] with ρ (hρd : ‖w - c‖ < ρ) (hρR : ρ < R)
-    have hwρ : w ∈ ball c ρ := by
-      simpa [mem_ball, dist_eq_norm] using hρd
-    exact
-      (harnack_inequality_center_of_nonneg_on_sphere
-        (hf.mono (closedBall_subset_ball hρR))
-        (fun z hz ↦ hnonneg z (sphere_subset_ball hρR hz)) hwρ).1
+    exact (harnack_inequality_center_of_norm_sub_lt_of_lt hf hnonneg hρd hρR).1
   · apply ge_of_tendsto hupperTendsto
     filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hdR),
       self_mem_nhdsWithin] with ρ (hρd : ‖w - c‖ < ρ) (hρR : ρ < R)
-    have hwρ : w ∈ ball c ρ := by
-      simpa [mem_ball, dist_eq_norm] using hρd
-    exact
-      (harnack_inequality_center_of_nonneg_on_sphere
-        (hf.mono (closedBall_subset_ball hρR))
-        (fun z hz ↦ hnonneg z (sphere_subset_ball hρR hz)) hwρ).2
+    exact (harnack_inequality_center_of_norm_sub_lt_of_lt hf hnonneg hρd hρR).2
 
 /-- **Harnack's inequality on a smaller closed disk.**
 


### PR DESCRIPTION
`harnack_inequality_center` derives the Harnack bounds on an open disk by taking a limit over radii `ρ ↑ R`, applying the closed-disk result `harnack_inequality_center_of_nonneg_on_sphere` at each `ρ`. Its two halves — lower bound and upper bound — differ only in taking `.1` versus `.2`, so the transfer to radius `ρ` was written out twice, verbatim.

`harnack_inequality_center_of_norm_sub_lt_of_lt` states that transfer once: with `f` harmonic and nonnegative on the *open* disk of radius `R`, the two-sided comparison holds at every intermediate radius `ρ` with `‖w - c‖ < ρ < R`.

The point of the lemma is the change of hypotheses. The closed-disk result wants `HarmonicOnNhd f (closedBall c ρ)`, nonnegativity on `sphere c ρ`, and `w ∈ ball c ρ`; what the limit argument has in hand is open-disk data at radius `R` plus two inequalities on `ρ`. The three adaptations (`closedBall_subset_ball`, `sphere_subset_ball`, and `mem_ball_iff_norm`) now happen in one place rather than in each branch.

Its hypotheses are re-derived rather than inherited. It takes `hρd : ‖w - c‖ < ρ` and `hρR : ρ < R` and nothing else about the geometry — the parent's `hR : 0 < R`, `hdR : ‖w - c‖ < R` and the membership `hw : w ∈ ball c R` are all in scope at the extraction point and none of them are needed, since `hρd` and `hρR` already imply what the proof uses. The `have hwρ : w ∈ ball c ρ` step that both branches carried is subsumed.

The parent drops from 41 lines to 31, and each branch of the `constructor` is now three lines: the `filter_upwards`, then a single application.

I left the two `Tendsto` computations alone. They look symmetric, but `hlowerTendsto` and `hupperTendsto` have the numerator and denominator exchanged and are discharged by genuinely different non-vanishing facts — `add_pos_of_pos_of_nonneg hR (norm_nonneg _)` against `(sub_pos.mpr hdR).ne'`. A shared engine over them would be a generic statement about `ρ ↦ (ρ + p) / (ρ + q) * k`, which is `Filter.Tendsto.div`/`Filter.Tendsto.mul` composition rather than a fact about Harnack bounds.

Gates run locally: `lake build` (7150 jobs), `lake exe axioms` (31134 declarations), `lake exe module-system` (1596 modules), `scripts/lint-env.sh` — all green.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
