### PR TITLE
feat: extend Pin corrections over fixed subspaces

### DIFF
--- a/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
+
+/-!
+# Extending nondegenerate subspaces by an orthogonal vector
+
+This file records that adjoining an anisotropic orthogonal vector to a nondegenerate subspace of a
+reflexive bilinear space preserves nondegeneracy. It is the structural step used when a
+Cartan--Dieudonne argument enlarges a fixed subspace.
+
+## Main result
+
+* `TauCeti.BilinForm.restrict_nondegenerate_sup_span_singleton`: adjoining an orthogonal vector
+  with nonzero self-pairing preserves nondegeneracy.
+-/
+
+public section
+
+namespace TauCeti
+
+open LinearMap (BilinForm)
+
+namespace BilinForm
+
+variable {K V : Type*} [CommRing K] [IsDomain K] [AddCommGroup V] [Module K V]
+
+/-- Adjoining a vector with nonzero self-pairing from the orthogonal complement of a nondegenerate
+subspace preserves nondegeneracy. -/
+theorem restrict_nondegenerate_sup_span_singleton
+    (B : BilinForm K V) (hB : B.IsRefl) (W : Submodule K V)
+    (hW : (B.restrict W).Nondegenerate) (x : V) (hxx : B x x ≠ 0)
+    (hx : x ∈ B.orthogonal W) :
+    (B.restrict (W ⊔ Submodule.span K {x})).Nondegenerate := by
+  let S : Submodule K V := W ⊔ Submodule.span K {x}
+  apply (hB.domRestrict S).nondegenerate_iff_separatingLeft.2
+  intro y hy
+  obtain ⟨w, hw, z, hz, hsum⟩ := Submodule.mem_sup.mp y.2
+  obtain ⟨a, rfl⟩ := Submodule.mem_span_singleton.mp hz
+  have hwzero : ∀ w' : W, B w w' = 0 := by
+    intro w'
+    have hBxw' : B x w' = 0 := hB.eq_zero (hx w' w'.2)
+    have hyw := hy ⟨w', Submodule.mem_sup_left w'.2⟩
+    -- Expose the ambient bilinear form under its restriction to `S`.
+    change B y w' = 0 at hyw
+    rw [← hsum] at hyw
+    simpa [hBxw'] using hyw
+  have hw0 : w = 0 := congrArg Subtype.val (hW.1 ⟨w, hw⟩ hwzero)
+  have hxS : x ∈ S := Submodule.mem_sup_right (Submodule.mem_span_singleton_self x)
+  have hyx := hy ⟨x, hxS⟩
+  -- Expose the ambient bilinear form under its restriction to `S`.
+  change B y x = 0 at hyx
+  rw [← hsum, hw0, zero_add] at hyx
+  have ha : a = 0 := by
+    rw [map_smul, LinearMap.smul_apply, smul_eq_mul] at hyx
+    exact (mul_eq_zero.mp hyx).resolve_right hxx
+  apply Subtype.ext
+  simp [← hsum, hw0, ha]
+
+end BilinForm
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -7,16 +7,16 @@ module
 public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
 
 /-!
-# Extending nondegenerate subspaces by an orthogonal vector
+# Extending left-separating subspaces by an orthogonal vector
 
 This file records that adjoining an orthogonal vector whose self-pairing is a right non-zero-divisor
-to a nondegenerate subspace of a reflexive bilinear space preserves nondegeneracy. It is the
-structural step used when a Cartan--Dieudonne argument enlarges a fixed subspace.
+to a left-separating subspace of a reflexive bilinear space produces a nondegenerate restriction.
+It is the structural step used when a Cartan--Dieudonne argument enlarges a fixed subspace.
 
 ## Main result
 
 * `TauCeti.BilinForm.restrict_nondegenerate_sup_span_singleton`: adjoining an orthogonal vector
-  whose self-pairing is a right non-zero-divisor preserves nondegeneracy.
+  to a left-separating subspace produces a nondegenerate restriction.
 -/
 
 public section
@@ -30,10 +30,10 @@ namespace BilinForm
 variable {K V : Type*} [CommSemiring K] [AddCommMonoid V] [Module K V]
 
 /-- Adjoining a vector whose self-pairing is a right non-zero-divisor from the orthogonal complement
-of a nondegenerate subspace preserves nondegeneracy. -/
+of a left-separating subspace preserves nondegeneracy. -/
 theorem restrict_nondegenerate_sup_span_singleton
     (B : BilinForm K V) (hB : B.IsRefl) (W : Submodule K V)
-    (hW : (B.restrict W).Nondegenerate) (x : V) (hxx : B x x ∈ nonZeroDivisorsRight K)
+    (hW : (B.restrict W).SeparatingLeft) (x : V) (hxx : B x x ∈ nonZeroDivisorsRight K)
     (hx : x ∈ B.orthogonal W) :
     (B.restrict (W ⊔ Submodule.span K {x})).Nondegenerate := by
   let S : Submodule K V := W ⊔ Submodule.span K {x}
@@ -49,7 +49,7 @@ theorem restrict_nondegenerate_sup_span_singleton
       change B y w' = 0 at hyw
       rw [← hsum] at hyw
       simpa [hBxw'] using hyw
-    have hw0 : w = 0 := congrArg Subtype.val (hW.1 ⟨w, hw⟩ hwzero)
+    have hw0 : w = 0 := congrArg Subtype.val (hW ⟨w, hw⟩ hwzero)
     have hxS : x ∈ S := Submodule.mem_sup_right (Submodule.mem_span_singleton_self x)
     have hyx := hy ⟨x, hxS⟩
     -- Expose the ambient bilinear form under its restriction to `S`.

--- a/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -27,7 +27,7 @@ open LinearMap (BilinForm)
 
 namespace BilinForm
 
-variable {K V : Type*} [CommRing K] [IsDomain K] [AddCommGroup V] [Module K V]
+variable {K V : Type*} [CommSemiring K] [NoZeroDivisors K] [AddCommMonoid V] [Module K V]
 
 /-- Adjoining a vector with nonzero self-pairing from the orthogonal complement of a nondegenerate
 subspace preserves nondegeneracy. -/
@@ -37,29 +37,31 @@ theorem restrict_nondegenerate_sup_span_singleton
     (hx : x ∈ B.orthogonal W) :
     (B.restrict (W ⊔ Submodule.span K {x})).Nondegenerate := by
   let S : Submodule K V := W ⊔ Submodule.span K {x}
-  apply (hB.domRestrict S).nondegenerate_iff_separatingLeft.2
-  intro y hy
-  obtain ⟨w, hw, z, hz, hsum⟩ := Submodule.mem_sup.mp y.2
-  obtain ⟨a, rfl⟩ := Submodule.mem_span_singleton.mp hz
-  have hwzero : ∀ w' : W, B w w' = 0 := by
-    intro w'
-    have hBxw' : B x w' = 0 := hB.eq_zero (hx w' w'.2)
-    have hyw := hy ⟨w', Submodule.mem_sup_left w'.2⟩
+  have hleft : (B.restrict S).SeparatingLeft := by
+    intro y hy
+    obtain ⟨w, hw, z, hz, hsum⟩ := Submodule.mem_sup.mp y.2
+    obtain ⟨a, rfl⟩ := Submodule.mem_span_singleton.mp hz
+    have hwzero : ∀ w' : W, B w w' = 0 := by
+      intro w'
+      have hBxw' : B x w' = 0 := hB.eq_zero (hx w' w'.2)
+      have hyw := hy ⟨w', Submodule.mem_sup_left w'.2⟩
+      -- Expose the ambient bilinear form under its restriction to `S`.
+      change B y w' = 0 at hyw
+      rw [← hsum] at hyw
+      simpa [hBxw'] using hyw
+    have hw0 : w = 0 := congrArg Subtype.val (hW.1 ⟨w, hw⟩ hwzero)
+    have hxS : x ∈ S := Submodule.mem_sup_right (Submodule.mem_span_singleton_self x)
+    have hyx := hy ⟨x, hxS⟩
     -- Expose the ambient bilinear form under its restriction to `S`.
-    change B y w' = 0 at hyw
-    rw [← hsum] at hyw
-    simpa [hBxw'] using hyw
-  have hw0 : w = 0 := congrArg Subtype.val (hW.1 ⟨w, hw⟩ hwzero)
-  have hxS : x ∈ S := Submodule.mem_sup_right (Submodule.mem_span_singleton_self x)
-  have hyx := hy ⟨x, hxS⟩
-  -- Expose the ambient bilinear form under its restriction to `S`.
-  change B y x = 0 at hyx
-  rw [← hsum, hw0, zero_add] at hyx
-  have ha : a = 0 := by
-    rw [map_smul, LinearMap.smul_apply, smul_eq_mul] at hyx
-    exact (mul_eq_zero.mp hyx).resolve_right hxx
-  apply Subtype.ext
-  simp [← hsum, hw0, ha]
+    change B y x = 0 at hyx
+    rw [← hsum, hw0, zero_add] at hyx
+    have ha : a = 0 := by
+      rw [map_smul, LinearMap.smul_apply, smul_eq_mul] at hyx
+      exact (mul_eq_zero.mp hyx).resolve_right hxx
+    apply Subtype.ext
+    simp [← hsum, hw0, ha]
+  refine ⟨hleft, fun y hy ↦ hleft y fun z ↦ ?_⟩
+  exact (hB.domRestrict S).eq_zero (hy z)
 
 end BilinForm
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -9,14 +9,14 @@ public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
 /-!
 # Extending nondegenerate subspaces by an orthogonal vector
 
-This file records that adjoining an anisotropic orthogonal vector to a nondegenerate subspace of a
-reflexive bilinear space preserves nondegeneracy. It is the structural step used when a
-Cartan--Dieudonne argument enlarges a fixed subspace.
+This file records that adjoining an orthogonal vector whose self-pairing is a right non-zero-divisor
+to a nondegenerate subspace of a reflexive bilinear space preserves nondegeneracy. It is the
+structural step used when a Cartan--Dieudonne argument enlarges a fixed subspace.
 
 ## Main result
 
 * `TauCeti.BilinForm.restrict_nondegenerate_sup_span_singleton`: adjoining an orthogonal vector
-  with nonzero self-pairing preserves nondegeneracy.
+  whose self-pairing is a right non-zero-divisor preserves nondegeneracy.
 -/
 
 public section
@@ -27,13 +27,13 @@ open LinearMap (BilinForm)
 
 namespace BilinForm
 
-variable {K V : Type*} [CommSemiring K] [NoZeroDivisors K] [AddCommMonoid V] [Module K V]
+variable {K V : Type*} [CommSemiring K] [AddCommMonoid V] [Module K V]
 
-/-- Adjoining a vector with nonzero self-pairing from the orthogonal complement of a nondegenerate
-subspace preserves nondegeneracy. -/
+/-- Adjoining a vector whose self-pairing is a right non-zero-divisor from the orthogonal complement
+of a nondegenerate subspace preserves nondegeneracy. -/
 theorem restrict_nondegenerate_sup_span_singleton
     (B : BilinForm K V) (hB : B.IsRefl) (W : Submodule K V)
-    (hW : (B.restrict W).Nondegenerate) (x : V) (hxx : B x x ≠ 0)
+    (hW : (B.restrict W).Nondegenerate) (x : V) (hxx : B x x ∈ nonZeroDivisorsRight K)
     (hx : x ∈ B.orthogonal W) :
     (B.restrict (W ⊔ Submodule.span K {x})).Nondegenerate := by
   let S : Submodule K V := W ⊔ Submodule.span K {x}
@@ -57,7 +57,7 @@ theorem restrict_nondegenerate_sup_span_singleton
     rw [← hsum, hw0, zero_add] at hyx
     have ha : a = 0 := by
       rw [map_smul, LinearMap.smul_apply, smul_eq_mul] at hyx
-      exact (mul_eq_zero.mp hyx).resolve_right hxx
+      exact hxx a (by simpa using hyx)
     apply Subtype.ext
     simp [← hsum, hw0, ha]
   refine ⟨hleft, fun y hy ↦ hleft y fun z ↦ ?_⟩

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -47,7 +47,7 @@ theorem exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton
     (g : QuadraticMap.orthogonalGroup Q) (W : Submodule K V)
     (hfix : ∀ w ∈ W, ((g : V ≃ₗ[K] V) w) = w)
     (x : V) [Invertible (Q x)]
-    (hx : x ∈ LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) :
+    (hx : ∀ w ∈ W, Q.IsOrtho x w) :
     ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ (pinToOrthogonal Q).range ∧
       ∀ y ∈ W ⊔ Submodule.span K {x},
         (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) y) = y :=

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -20,8 +20,6 @@ reflections lift through the Pin group, so the correcting element lies in the ra
 
 * `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton`: a
   Pin-range correction extends a fixed subspace by one orthogonal anisotropic vector.
-* `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_apply_eq_self`: the specialization
-  to the zero subspace corrects one vector.
 
 ## References
 
@@ -55,16 +53,6 @@ theorem exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton
         (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) y) = y :=
   QuadraticMap.exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem Q
     (pinToOrthogonal Q).range (reflection_mem_range_pinToOrthogonal Q) g W hfix x hx
-
-/-- Given an orthogonal automorphism `g` and a vector `v` of invertible norm, an element in the
-range of the Pin action can be multiplied into `g` so that the product fixes `v`. -/
-theorem exists_mem_range_pinToOrthogonal_mul_apply_eq_self
-    (g : QuadraticMap.orthogonalGroup Q) (v : V) [Invertible (Q v)] :
-    ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ (pinToOrthogonal Q).range ∧
-      (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) v = v) := by
-  obtain ⟨r, hr, hfix⟩ :=
-    exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton Q g ⊥ (by simp) v (by simp)
-  exact ⟨r, hr, hfix v (Submodule.mem_sup_right (Submodule.mem_span_singleton_self v))⟩
 
 end CliffordAlgebra
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -8,21 +8,20 @@ public import Mathlib.FieldTheory.IsSepClosed
 public import TauCeti.LinearAlgebra.CliffordAlgebra.ReflectionLift
 
 /-!
-# The one-step Cartan--Dieudonne reduction
+# Pin corrections over fixed subspaces
 
-Let `g` be an orthogonal automorphism and let `v` have invertible norm. At least one of `g v - v`
-and `g v + v` has invertible norm. A reflection in the former carries `g v` to `v`; a reflection
-in the latter followed by the reflection in `v` does the same. Since these reflections lift to the
-Pin group over a separably closed field of characteristic not two, an element in the range of
-`pinToOrthogonal` can be multiplied into `g` to make it fix `v`.
+Let `g` be an orthogonal automorphism fixing a subspace `W`, and let `x` be an anisotropic vector
+orthogonal to `W`. The generic fixed-subspace correction in the quadratic-form layer uses one or
+two reflections to make the product fix `W ⊔ K ∙ x`. Over a separably closed field those
+reflections lift through the Pin group, so the correcting element lies in the range of
+`pinToOrthogonal`.
 
-This is the one-vector reduction used by the finite-dimensional Cartan--Dieudonne induction.
+## Main results
 
-## Main result
-
-* `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_apply_eq_self`: an element in the
-  range of the Pin action corrects an orthogonal automorphism to fix a chosen vector of invertible
-  norm.
+* `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton`: a
+  Pin-range correction extends a fixed subspace by one orthogonal anisotropic vector.
+* `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_apply_eq_self`: the specialization
+  to the zero subspace corrects one vector.
 
 ## References
 
@@ -44,36 +43,28 @@ namespace CliffordAlgebra
 variable {K : Type u} {V : Type v} [Field K] [IsSepClosed K]
   [AddCommGroup V] [Module K V] (Q : QuadraticForm K V) [Invertible (2 : K)]
 
+/-- Given an orthogonal automorphism that fixes `W` and an anisotropic vector `x` orthogonal to
+`W`, a Pin-range correction makes the product fix `W ⊔ K ∙ x` pointwise. -/
+theorem exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton
+    (g : QuadraticMap.orthogonalGroup Q) (W : Submodule K V)
+    (hfix : ∀ w ∈ W, ((g : V ≃ₗ[K] V) w) = w)
+    (x : V) [Invertible (Q x)]
+    (hx : x ∈ LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) :
+    ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ (pinToOrthogonal Q).range ∧
+      ∀ y ∈ W ⊔ Submodule.span K {x},
+        (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) y) = y :=
+  QuadraticMap.exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem Q
+    (pinToOrthogonal Q).range (reflection_mem_range_pinToOrthogonal Q) g W hfix x hx
+
 /-- Given an orthogonal automorphism `g` and a vector `v` of invertible norm, an element in the
-range of the Pin action can be multiplied into `g` so that the product fixes `v`. The correcting
-orthogonal element is the image under `pinToOrthogonal` of a lift of either one reflection or two
-reflections. -/
+range of the Pin action can be multiplied into `g` so that the product fixes `v`. -/
 theorem exists_mem_range_pinToOrthogonal_mul_apply_eq_self
-    (g : QuadraticMap.orthogonalGroup Q) (v : V)
-    [Invertible (Q v)] :
+    (g : QuadraticMap.orthogonalGroup Q) (v : V) [Invertible (Q v)] :
     ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ (pinToOrthogonal Q).range ∧
       (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) v = v) := by
-  have reflection_mem_range (w : V) [Invertible (Q w)] :
-      QuadraticMap.reflectionOrthogonal Q w ∈ (pinToOrthogonal Q).range :=
-    reflection_mem_range_pinToOrthogonal_of_isSquare Q w
-      (IsSepClosed.exists_eq_mul_self _)
-  have hmap : Q ((g : V ≃ₗ[K] V) v) = Q v :=
-    QuadraticMap.map_app_of_mem_orthogonalGroup g.2 v
-  rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q _ v hmap
-      (isUnit_of_invertible (Q v)).ne_zero with hsub | hadd
-  · let : Invertible (Q ((g : V ≃ₗ[K] V) v - v)) := hsub.invertible
-    refine ⟨QuadraticMap.reflectionOrthogonal Q ((g : V ≃ₗ[K] V) v - v),
-      reflection_mem_range _, ?_⟩
-    simp only [Subgroup.coe_mul, QuadraticMap.coe_reflectionOrthogonal, LinearEquiv.mul_apply]
-    exact QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ v hmap
-  · have : Invertible (Q ((g : V ≃ₗ[K] V) v - -v)) := by
-      simpa only [sub_neg_eq_add] using hadd.invertible
-    refine ⟨QuadraticMap.reflectionOrthogonal Q v *
-        QuadraticMap.reflectionOrthogonal Q ((g : V ≃ₗ[K] V) v - -v),
-      (pinToOrthogonal Q).range.mul_mem (reflection_mem_range v) (reflection_mem_range _), ?_⟩
-    simp only [Subgroup.coe_mul, QuadraticMap.coe_reflectionOrthogonal, LinearEquiv.mul_apply]
-    rw [QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ (-v)
-      (hmap.trans (Q.map_neg v).symm), map_neg, QuadraticMap.reflection_apply_self, neg_neg]
+  obtain ⟨r, hr, hfix⟩ :=
+    exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton Q g ⊥ (by simp) v (by simp)
+  exact ⟨r, hr, hfix v (Submodule.mem_sup_right (Submodule.mem_span_singleton_self v))⟩
 
 end CliffordAlgebra
 end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
 public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
@@ -30,7 +29,7 @@ twisted-conjugation homomorphism out of the Pin group, so it is the object the P
 covers are stated against, and the reflections are the generators an eventual Cartan-Dieudonné
 theorem factors an orthogonal automorphism into. The structural and reflection declarations below
 hold over an arbitrary commutative ring. The equal-norm dichotomy and fixed-subspace correction
-assume a field in which `2` is invertible. The characteristic restriction is not incidental: in
+assume a field in which `2` is nonzero. The characteristic restriction is not incidental: in
 characteristic two `polar Q v v = 2 • Q v` vanishes, so `reflection Q v` fixes `v` instead of
 negating it and is a transvection rather than a reflection in `v ^ ⊥`.
 
@@ -84,7 +83,7 @@ subtraction in `M` and `N`, since `QuadraticMap.polar` is stated for `[AddCommGr
 [AddCommGroup N]`, but still no more than a `CommSemiring`; the determinant needs `M` to be an
 additive group over a `CommRing`, and the
 reflections need to divide by `Q v` and so are stated for a `QuadraticForm R M`, that is, for
-`N = R`. The fixed-subspace correction assumes a field and invertible `2`; the closing
+`N = R`. The fixed-subspace correction assumes a field and `2 ≠ 0`; the closing
 Cartan--Dieudonne dichotomy assumes a field, a nonzero common quadratic value, and `2 ≠ 0`.
 
 ## References
@@ -444,9 +443,9 @@ end Field
 section FixedSubspace
 
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
-variable (Q : QuadraticForm K V) [Invertible (2 : K)]
+variable (Q : QuadraticForm K V) [NeZero (2 : K)]
 
-omit [Invertible (2 : K)] in
+omit [NeZero (2 : K)] in
 private theorem linearEquiv_eqOn_sup_span_singleton
     (f : V ≃ₗ[K] V) (W : Submodule K V) (x : V)
     (hW : ∀ w ∈ W, f w = w) (hx : f x = x) :
@@ -473,28 +472,26 @@ theorem exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem
     (g : QuadraticMap.orthogonalGroup Q) (W : Submodule K V)
     (hfix : ∀ w ∈ W, ((g : V ≃ₗ[K] V) w) = w)
     (x : V) [Invertible (Q x)]
-    (hx : x ∈ LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) :
+    (hx : ∀ w ∈ W, Q.IsOrtho x w) :
     ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ H ∧
       ∀ y ∈ W ⊔ Submodule.span K {x},
         (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) y) = y := by
-  let B : LinearMap.BilinForm K V := QuadraticMap.associated Q
   have hmap : Q ((g : V ≃ₗ[K] V) x) = Q x :=
     QuadraticMap.map_app_of_mem_orthogonalGroup g.2 x
-  have hgx : (g : V ≃ₗ[K] V) x ∈ B.orthogonal W := by
+  have hgx : ∀ w ∈ W, Q.IsOrtho ((g : V ≃ₗ[K] V) x) w := by
     intro w hw
-    -- Expose the associated form hidden behind the local abbreviation.
-    change QuadraticMap.associated Q w ((g : V ≃ₗ[K] V) x) = 0
-    rw [← hfix w hw, QuadraticMap.associated_isOrtho,
-      QuadraticMap.isOrtho_iff_of_mem_orthogonalGroup g.2]
-    exact QuadraticMap.associated_isOrtho.mp (hx w hw)
-  have hsub : (g : V ≃ₗ[K] V) x - x ∈ B.orthogonal W := by
+    rw [← hfix w hw]
+    exact (QuadraticMap.isOrtho_iff_of_mem_orthogonalGroup g.2 x w).mpr (hx w hw)
+  have hsub : ∀ w ∈ W, Q.IsOrtho ((g : V ≃ₗ[K] V) x - x) w := by
     intro w hw
-    have hwx : B w x = 0 := hx w hw
-    simp only [map_sub, hgx w hw, hwx, sub_self]
-  have hadd : (g : V ≃ₗ[K] V) x + x ∈ B.orthogonal W := by
+    apply QuadraticMap.isOrtho_polarBilin.mp
+    simp only [QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_sub_left,
+      (hgx w hw).polar_eq_zero, (hx w hw).polar_eq_zero, sub_self]
+  have hadd : ∀ w ∈ W, Q.IsOrtho ((g : V ≃ₗ[K] V) x + x) w := by
     intro w hw
-    have hwx : B w x = 0 := hx w hw
-    simp only [map_add, hgx w hw, hwx, add_zero]
+    apply QuadraticMap.isOrtho_polarBilin.mp
+    simp only [QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_add_left,
+      (hgx w hw).polar_eq_zero, (hx w hw).polar_eq_zero, add_zero]
   rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q _ x hmap
       (isUnit_of_invertible (Q x)).ne_zero with hsubUnit | haddUnit
   · let : Invertible (Q ((g : V ≃ₗ[K] V) x - x)) := hsubUnit.invertible
@@ -508,15 +505,14 @@ theorem exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem
         ((g : V ≃ₗ[K] V) w) = w
       rw [hfix w hw]
       apply QuadraticMap.reflection_apply_of_isOrtho
-      apply QuadraticMap.associated_isOrtho.mp
-      simpa only [QuadraticMap.associated_isSymm] using hsub w hw
+      exact hsub w hw
     · -- Expose the reflection underlying the subgroup product at the new generator.
       change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - x)
         ((g : V ≃ₗ[K] V) x) = x
       exact QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ x hmap
   · have : Invertible (Q ((g : V ≃ₗ[K] V) x - -x)) := by
       simpa only [sub_neg_eq_add] using haddUnit.invertible
-    have hadd' : (g : V ≃ₗ[K] V) x - -x ∈ B.orthogonal W := by
+    have hadd' : ∀ w ∈ W, Q.IsOrtho ((g : V ≃ₗ[K] V) x - -x) w := by
       simpa only [sub_neg_eq_add] using hadd
     let r₁ : QuadraticMap.orthogonalGroup Q :=
       QuadraticMap.reflectionOrthogonal Q x
@@ -530,16 +526,12 @@ theorem exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem
         (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x)
           ((g : V ≃ₗ[K] V) w)) = w
       rw [hfix w hw]
-      have hfixr₂ :
-          QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x) w = w := by
-        apply QuadraticMap.reflection_apply_of_isOrtho
-        apply QuadraticMap.associated_isOrtho.mp
-        simpa only [QuadraticMap.associated_isSymm] using hadd' w hw
-      have hfixr₁ : QuadraticMap.reflection Q x w = w := by
-        apply QuadraticMap.reflection_apply_of_isOrtho
-        apply QuadraticMap.associated_isOrtho.mp
-        simpa only [QuadraticMap.associated_isSymm] using hx w hw
-      rw [hfixr₂, hfixr₁]
+      have hfix₂ : QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x) w = w :=
+        QuadraticMap.reflection_apply_of_isOrtho Q _
+        (hadd' w hw)
+      rw [hfix₂]
+      exact QuadraticMap.reflection_apply_of_isOrtho Q _
+        (hx w hw)
     · -- Expose the two reflections underlying the subgroup product at the new generator.
       change QuadraticMap.reflection Q x
         (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x)

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -29,10 +29,10 @@ the hyperplanes of vectors of invertible norm. The orthogonal group is the targe
 twisted-conjugation homomorphism out of the Pin group, so it is the object the Pin/Spin double
 covers are stated against, and the reflections are the generators an eventual Cartan-Dieudonné
 theorem factors an orthogonal automorphism into. The structural and reflection declarations below
-hold over an arbitrary commutative ring; only the final equal-norm dichotomy assumes a field in
-which `2` is nonzero. The characteristic restriction is not incidental: in characteristic two
-`polar Q v v = 2 • Q v` vanishes, so `reflection Q v` fixes `v` instead of negating it and is a
-transvection rather than a reflection in `v ^ ⊥`.
+hold over an arbitrary commutative ring. The equal-norm dichotomy and fixed-subspace correction
+assume a field in which `2` is invertible. The characteristic restriction is not incidental: in
+characteristic two `polar Q v v = 2 • Q v` vanishes, so `reflection Q v` fixes `v` instead of
+negating it and is a transvection rather than a reflection in `v ^ ⊥`.
 
 ## Main definitions
 
@@ -84,8 +84,8 @@ subtraction in `M` and `N`, since `QuadraticMap.polar` is stated for `[AddCommGr
 [AddCommGroup N]`, but still no more than a `CommSemiring`; the determinant needs `M` to be an
 additive group over a `CommRing`, and the
 reflections need to divide by `Q v` and so are stated for a `QuadraticForm R M`, that is, for
-`N = R`. The closing Cartan--Dieudonne dichotomy additionally assumes a field, a nonzero common
-quadratic value, and `2 ≠ 0`.
+`N = R`. The fixed-subspace correction assumes a field and invertible `2`; the closing
+Cartan--Dieudonne dichotomy assumes a field, a nonzero common quadratic value, and `2 ≠ 0`.
 
 ## References
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
 public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
@@ -67,6 +68,9 @@ transvection rather than a reflection in `v ^ ⊥`.
   of, under hypotheses (a field of characteristic not two, a nondegenerate form, finite dimension)
   that are not assumed here, and the image of the Pin group's generating vectors under twisted
   conjugation.
+* `TauCeti.QuadraticMap.exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem`: a
+  subgroup containing the invertible-norm reflections supplies the one-step fixed-subspace
+  correction used by Cartan--Dieudonne induction.
 * `TauCeti.QuadraticMap.specialOrthogonalGroup_normal`: `SO(Q)` is normal in `O(Q)`, being the
   kernel of the determinant restricted there.
 
@@ -436,6 +440,119 @@ theorem isUnit_sub_or_add_of_map_eq (x y : V) (hxy : Q x = Q y) (hy : Q y ≠ 0)
   · exact Or.inl hsub
 
 end Field
+
+section FixedSubspace
+
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+variable (Q : QuadraticForm K V) [Invertible (2 : K)]
+
+private theorem reflection_fixes_of_mem_orthogonal
+    (W : Submodule K V) (u : V) [Invertible (Q u)]
+    (hu : u ∈ LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W)
+    {w : V} (hw : w ∈ W) :
+    QuadraticMap.reflection Q u w = w := by
+  apply QuadraticMap.reflection_apply_of_isOrtho
+  apply QuadraticMap.associated_isOrtho.mp
+  simpa only [QuadraticMap.associated_isSymm] using hu w hw
+
+omit [Invertible (2 : K)] in
+private theorem linearEquiv_eqOn_sup_span_singleton
+    (f : V ≃ₗ[K] V) (W : Submodule K V) (x : V)
+    (hW : ∀ w ∈ W, f w = w) (hx : f x = x) :
+    ∀ y ∈ W ⊔ Submodule.span K {x}, f y = y := by
+  apply LinearMap.eqOn_sup (f := f) (g := LinearEquiv.refl K V)
+  · intro w hw
+    simpa only [LinearEquiv.refl_apply] using hW w hw
+  · apply LinearMap.eqOn_span'
+    intro y hy
+    simp only [Set.mem_singleton_iff] at hy
+    subst y
+    -- Remove the identity-equivalence coercion introduced by `eqOn_span'`.
+    change f x = x
+    exact hx
+
+/-- Let `H` be a subgroup of the orthogonal group containing every reflection in a vector of
+invertible norm. If `g` fixes a subspace `W` pointwise and `x` is anisotropic and orthogonal to
+`W`, an element of `H` can be multiplied into `g` so that the product fixes
+`W ⊔ K ∙ x` pointwise. -/
+theorem exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem
+    (H : Subgroup (QuadraticMap.orthogonalGroup Q))
+    (hreflection : ∀ (v : V) [Invertible (Q v)],
+      (⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ :
+        QuadraticMap.orthogonalGroup Q) ∈ H)
+    (g : QuadraticMap.orthogonalGroup Q) (W : Submodule K V)
+    (hfix : ∀ w ∈ W, ((g : V ≃ₗ[K] V) w) = w)
+    (x : V) [Invertible (Q x)]
+    (hx : x ∈ LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W) :
+    ∃ r : QuadraticMap.orthogonalGroup Q, r ∈ H ∧
+      ∀ y ∈ W ⊔ Submodule.span K {x},
+        (((r * g : QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) y) = y := by
+  let B : LinearMap.BilinForm K V := QuadraticMap.associated Q
+  have hmap : Q ((g : V ≃ₗ[K] V) x) = Q x :=
+    QuadraticMap.map_app_of_mem_orthogonalGroup g.2 x
+  have hgx : (g : V ≃ₗ[K] V) x ∈ B.orthogonal W := by
+    intro w hw
+    calc
+      B w ((g : V ≃ₗ[K] V) x) =
+          B ((g : V ≃ₗ[K] V) w) ((g : V ≃ₗ[K] V) x) := by
+            rw [hfix w hw]
+      _ = B w x := by
+        simpa only [B, QuadraticMap.associated_apply, QuadraticMap.polar] using
+          congrArg (⅟(2 : Module.End K K) • ·)
+            (QuadraticMap.polar_apply_of_mem_orthogonalGroup g.2 w x)
+      _ = 0 := hx w hw
+  have hsub : (g : V ≃ₗ[K] V) x - x ∈ B.orthogonal W := by
+    intro w hw
+    have hwx : B w x = 0 := hx w hw
+    simp only [map_sub, hgx w hw, hwx, sub_self]
+  have hadd : (g : V ≃ₗ[K] V) x + x ∈ B.orthogonal W := by
+    intro w hw
+    have hwx : B w x = 0 := hx w hw
+    simp only [map_add, hgx w hw, hwx, add_zero]
+  rcases QuadraticMap.isUnit_sub_or_add_of_map_eq Q _ x hmap
+      (isUnit_of_invertible (Q x)).ne_zero with hsubUnit | haddUnit
+  · let : Invertible (Q ((g : V ≃ₗ[K] V) x - x)) := hsubUnit.invertible
+    let r : QuadraticMap.orthogonalGroup Q :=
+      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - x),
+        QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+    refine ⟨r, hreflection _, ?_⟩
+    apply linearEquiv_eqOn_sup_span_singleton _ W x
+    · intro w hw
+      -- Expose the reflection underlying the subgroup product before applying its pointwise API.
+      change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - x)
+        ((g : V ≃ₗ[K] V) w) = w
+      rw [hfix w hw]
+      exact reflection_fixes_of_mem_orthogonal Q W _ hsub hw
+    · -- Expose the reflection underlying the subgroup product at the new generator.
+      change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - x)
+        ((g : V ≃ₗ[K] V) x) = x
+      exact QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ x hmap
+  · have : Invertible (Q ((g : V ≃ₗ[K] V) x - -x)) := by
+      simpa only [sub_neg_eq_add] using haddUnit.invertible
+    have hadd' : (g : V ≃ₗ[K] V) x - -x ∈ B.orthogonal W := by
+      simpa only [sub_neg_eq_add] using hadd
+    let r₁ : QuadraticMap.orthogonalGroup Q :=
+      ⟨QuadraticMap.reflection Q x, QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+    let r₂ : QuadraticMap.orthogonalGroup Q :=
+      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x),
+        QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+    refine ⟨r₁ * r₂, H.mul_mem (hreflection x) (hreflection _), ?_⟩
+    apply linearEquiv_eqOn_sup_span_singleton _ W x
+    · intro w hw
+      -- Expose the two reflections underlying the subgroup product.
+      change QuadraticMap.reflection Q x
+        (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x)
+          ((g : V ≃ₗ[K] V) w)) = w
+      rw [hfix w hw, reflection_fixes_of_mem_orthogonal Q W _ hadd' hw,
+        reflection_fixes_of_mem_orthogonal Q W _ hx hw]
+    · -- Expose the two reflections underlying the subgroup product at the new generator.
+      change QuadraticMap.reflection Q x
+        (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x)
+          ((g : V ≃ₗ[K] V) x)) = x
+      rw [QuadraticMap.reflection_sub_apply_eq_of_map_eq Q _ (-x)
+        (hmap.trans (Q.map_neg x).symm), map_neg, QuadraticMap.reflection_apply_self, neg_neg]
+
+end FixedSubspace
 
 end CartanDieudonneStep
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -446,15 +446,6 @@ section FixedSubspace
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
 variable (Q : QuadraticForm K V) [Invertible (2 : K)]
 
-private theorem reflection_fixes_of_mem_orthogonal
-    (W : Submodule K V) (u : V) [Invertible (Q u)]
-    (hu : u ∈ LinearMap.BilinForm.orthogonal (QuadraticMap.associated Q) W)
-    {w : V} (hw : w ∈ W) :
-    QuadraticMap.reflection Q u w = w := by
-  apply QuadraticMap.reflection_apply_of_isOrtho
-  apply QuadraticMap.associated_isOrtho.mp
-  simpa only [QuadraticMap.associated_isSymm] using hu w hw
-
 omit [Invertible (2 : K)] in
 private theorem linearEquiv_eqOn_sup_span_singleton
     (f : V ≃ₗ[K] V) (W : Submodule K V) (x : V)
@@ -516,7 +507,9 @@ theorem exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem
       change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - x)
         ((g : V ≃ₗ[K] V) w) = w
       rw [hfix w hw]
-      exact reflection_fixes_of_mem_orthogonal Q W _ hsub hw
+      apply QuadraticMap.reflection_apply_of_isOrtho
+      apply QuadraticMap.associated_isOrtho.mp
+      simpa only [QuadraticMap.associated_isSymm] using hsub w hw
     · -- Expose the reflection underlying the subgroup product at the new generator.
       change QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - x)
         ((g : V ≃ₗ[K] V) x) = x
@@ -536,8 +529,17 @@ theorem exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem
       change QuadraticMap.reflection Q x
         (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x)
           ((g : V ≃ₗ[K] V) w)) = w
-      rw [hfix w hw, reflection_fixes_of_mem_orthogonal Q W _ hadd' hw,
-        reflection_fixes_of_mem_orthogonal Q W _ hx hw]
+      rw [hfix w hw]
+      have hfixr₂ :
+          QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x) w = w := by
+        apply QuadraticMap.reflection_apply_of_isOrtho
+        apply QuadraticMap.associated_isOrtho.mp
+        simpa only [QuadraticMap.associated_isSymm] using hadd' w hw
+      have hfixr₁ : QuadraticMap.reflection Q x w = w := by
+        apply QuadraticMap.reflection_apply_of_isOrtho
+        apply QuadraticMap.associated_isOrtho.mp
+        simpa only [QuadraticMap.associated_isSymm] using hx w hw
+      rw [hfixr₂, hfixr₁]
     · -- Expose the two reflections underlying the subgroup product at the new generator.
       change QuadraticMap.reflection Q x
         (QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x)

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -478,8 +478,7 @@ invertible norm. If `g` fixes a subspace `W` pointwise and `x` is anisotropic an
 theorem exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem
     (H : Subgroup (QuadraticMap.orthogonalGroup Q))
     (hreflection : ∀ (v : V) [Invertible (Q v)],
-      (⟨QuadraticMap.reflection Q v, QuadraticMap.reflection_mem_orthogonalGroup Q v⟩ :
-        QuadraticMap.orthogonalGroup Q) ∈ H)
+      QuadraticMap.reflectionOrthogonal Q v ∈ H)
     (g : QuadraticMap.orthogonalGroup Q) (W : Submodule K V)
     (hfix : ∀ w ∈ W, ((g : V ≃ₗ[K] V) w) = w)
     (x : V) [Invertible (Q x)]
@@ -509,8 +508,7 @@ theorem exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem
       (isUnit_of_invertible (Q x)).ne_zero with hsubUnit | haddUnit
   · let : Invertible (Q ((g : V ≃ₗ[K] V) x - x)) := hsubUnit.invertible
     let r : QuadraticMap.orthogonalGroup Q :=
-      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - x),
-        QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+      QuadraticMap.reflectionOrthogonal Q ((g : V ≃ₗ[K] V) x - x)
     refine ⟨r, hreflection _, ?_⟩
     apply linearEquiv_eqOn_sup_span_singleton _ W x
     · intro w hw
@@ -528,10 +526,9 @@ theorem exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem
     have hadd' : (g : V ≃ₗ[K] V) x - -x ∈ B.orthogonal W := by
       simpa only [sub_neg_eq_add] using hadd
     let r₁ : QuadraticMap.orthogonalGroup Q :=
-      ⟨QuadraticMap.reflection Q x, QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+      QuadraticMap.reflectionOrthogonal Q x
     let r₂ : QuadraticMap.orthogonalGroup Q :=
-      ⟨QuadraticMap.reflection Q ((g : V ≃ₗ[K] V) x - -x),
-        QuadraticMap.reflection_mem_orthogonalGroup Q _⟩
+      QuadraticMap.reflectionOrthogonal Q ((g : V ≃ₗ[K] V) x - -x)
     refine ⟨r₁ * r₂, H.mul_mem (hreflection x) (hreflection _), ?_⟩
     apply linearEquiv_eqOn_sup_span_singleton _ W x
     · intro w hw

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -492,15 +492,11 @@ theorem exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem
     QuadraticMap.map_app_of_mem_orthogonalGroup g.2 x
   have hgx : (g : V ≃ₗ[K] V) x ∈ B.orthogonal W := by
     intro w hw
-    calc
-      B w ((g : V ≃ₗ[K] V) x) =
-          B ((g : V ≃ₗ[K] V) w) ((g : V ≃ₗ[K] V) x) := by
-            rw [hfix w hw]
-      _ = B w x := by
-        simpa only [B, QuadraticMap.associated_apply, QuadraticMap.polar] using
-          congrArg (⅟(2 : Module.End K K) • ·)
-            (QuadraticMap.polar_apply_of_mem_orthogonalGroup g.2 w x)
-      _ = 0 := hx w hw
+    -- Expose the associated form hidden behind the local abbreviation.
+    change QuadraticMap.associated Q w ((g : V ≃ₗ[K] V) x) = 0
+    rw [← hfix w hw, QuadraticMap.associated_isOrtho,
+      QuadraticMap.isOrtho_iff_of_mem_orthogonalGroup g.2]
+    exact QuadraticMap.associated_isOrtho.mp (hx w hw)
   have hsub : (g : V ≃ₗ[K] V) x - x ∈ B.orthogonal W := by
     intro w hw
     have hwx : B w x = 0 := hx w hw


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the fixed-subspace step used by Cartan-Dieudonne reflection induction.

- Proves that adjoining one orthogonal vector whose self-pairing is right-regular preserves nondegeneracy.
- Corrects an orthogonal automorphism by reflections while preserving an existing fixed subspace.
- Specializes the correction so that the reflections lift through the Pin group.

## Roadmap target

Advances the reflection-induction prerequisite for Layer 2 `spinToSpecialOrthogonal_surjective`:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L119-L125

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#spinToSpecialOrthogonal_surjective"}-->

## Verification

Full builds, `--iofail`, audits, environment lint, source and whitespace checks, downstream successor probes, proof golf, concurrent TauCeti-only and skill-augmented reviews, and an additional TauCeti-only public-head review pass at `c9bcaada749bd3b3c2c790f6a28570e0d9841af8`.

## Scale and generality

Changes three files by +198/−47 lines. The bilinear theorem works over a commutative semiring and requires only right-regularity of the selected self-pairing; the generic correction needs a field with nonzero `2`; only the Pin specialization assumes separable closure and invertible `2`. It needs no finite-dimensionality or global nondegeneracy.

## Scope

- **Consumes:** the one-vector reflection correction and the existing orthogonal-complement and Pin-action interfaces.
- **Provides:** nondegeneracy after adjoining one orthogonal regular vector, plus generic and Pin-valued corrections preserving the fixed subspace.
- **Fits:** supplies the induction step consumed by Cartan-Dieudonne generation and Pin surjectivity.
- **Boundary:** finite-dimensional iteration and global surjectivity are consumers of this fixed-subspace step.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [b8161ef](https://github.com/TauCetiProject/TauCetiReview/commit/b8161ef29f1bf922d3f9aea2b1b1e298bcd06078) · local 2+1 review @ [e8e06f7](https://github.com/utensil/formal-land/commit/e8e06f7cc4e71e8608db3b1e5540b4577234c382) fixed: documentation (1), generality (2), reuse (1)</sub>