### PR TITLE
feat(HeckeRing): moving the base point of a decomposition quotient

### DIFF
--- a/TauCeti/GroupTheory/DoubleCoset/Basic.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Basic.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.GroupTheory.DoubleCoset
 
+import Mathlib.Tactic.Group
+
 /-!
 # Double cosets: the left-coset decomposition
 
@@ -15,6 +17,11 @@ ranges over representatives of the quotient of `H` by the stabiliser `H ∩ aKa�
 decomposition indexes the left cosets
 inside a double coset and underlies the finiteness of Hecke coset decompositions in
 `TauCeti.NumberTheory.HeckeRing.Basic`.
+
+This file also records how the stabiliser `(gKg⁻¹).subgroupOf H` responds to moving the base
+point `g`: right multiplication by anything normalising `K` leaves it alone, and left
+multiplication by anything normalising `H` conjugates it. `TauCeti.NumberTheory.HeckeRing.
+StabConjugation` turns those into equivalences of decomposition quotients.
 
 Vendored from the in-review mathlib4 PR
 [#41253](https://github.com/leanprover-community/mathlib4/pull/41253) (Chris Birkbeck), per the
@@ -47,5 +54,42 @@ lemma doubleCoset_eq_iUnion_leftCosets (H K : Subgroup G) (a : G) :
   refine Set.subset_iUnion_of_subset (QuotientGroup.mk h) (le_of_eq ?_)
   rw [hn, leftCoset_eq_iff]
   simpa [mul_assoc] using hK
+
+/-- Conjugation only sees `g` modulo the normalizer on the right: `(gh)Γ(gh)⁻¹ = gΓg⁻¹`
+whenever `h` normalizes `Γ`. Membership in `Γ` itself is the special case
+`Subgroup.le_normalizer`. -/
+lemma conjAct_smul_mul_right_of_mem_normalizer (Γ : Subgroup G) (g : G) {h : G}
+    (hh : h ∈ Subgroup.normalizer Γ) :
+    ConjAct.toConjAct (g * h) • Γ = ConjAct.toConjAct g • Γ := by
+  rw [map_mul, ← smul_smul, Subgroup.conjAct_pointwise_smul_eq_self hh]
+
+/-- The stabilizer cut out inside `Γ₁` is unchanged by right multiplication of the base point
+by anything normalizing `Γ₂`. -/
+lemma subgroupOf_conjAct_smul_mul_right_of_mem_normalizer (Γ₁ Γ₂ : Subgroup G) (g : G) {h : G}
+    (hh : h ∈ Subgroup.normalizer Γ₂) :
+    (ConjAct.toConjAct (g * h) • Γ₂).subgroupOf Γ₁ =
+      (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁ := by
+  rw [conjAct_smul_mul_right_of_mem_normalizer Γ₂ g hh]
+
+/-- Left multiplication of the base point by anything normalizing `Γ₁` conjugates the
+stabilizer by it: `x` stabilizes `hg` exactly when `h⁻¹xh` stabilizes `g`. Membership in `Γ₁`
+itself is the special case `Subgroup.le_normalizer`.
+
+The conjugating automorphism of `↥Γ₁` is `Subgroup.normalizerMonoidHom`, which is defined for
+exactly this: `MulAut.conj h` would need `h` to be an element of `Γ₁`. -/
+lemma subgroupOf_conjAct_smul_mul_left_of_mem_normalizer (Γ₁ Γ₂ : Subgroup G) (g : G)
+    (h : Subgroup.normalizer (Γ₁ : Set G)) :
+    (ConjAct.toConjAct ((h : G) * g) • Γ₂).subgroupOf Γ₁ =
+      ((ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁).map
+        (Γ₁.normalizerMonoidHom h).toMonoidHom := by
+  ext x
+  rw [Subgroup.mem_map_equiv]
+  simp only [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
+    ConjAct.smul_def, map_inv, ConjAct.ofConjAct_toConjAct, inv_inv,
+    Subgroup.normalizerMonoidHom_apply_symm_apply_coe]
+  -- Both sides are membership of the *same* element of `Γ₂`, written with different
+  -- bracketing: `(hg)⁻¹x(hg)` versus `g⁻¹(h⁻¹xh)g`. `group` proves that identity; the `iff`
+  -- is then congruence along it, so no rewriting has to find a redex.
+  exact iff_of_eq (congrArg (· ∈ Γ₂) (by group))
 
 end DoubleCoset

--- a/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
+++ b/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
@@ -6,36 +6,34 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.NumberTheory.HeckeRing.Basic
-
-import Mathlib.Tactic.Group
+public import TauCeti.GroupTheory.DoubleCoset.Basic
 
 /-!
 # Moving the base point of a decomposition quotient
 
 `DoubleCoset.DecompQuotient Γ₁ Γ₂ g` is `Γ₁ ⧸ (gΓ₂g⁻¹).subgroupOf Γ₁`, so it depends on `g`
-only through the conjugate `gΓ₂g⁻¹`. This file records how that conjugate — and hence the
-quotient — responds to multiplying `g` on either side by a group element:
+only through the conjugate `gΓ₂g⁻¹`. The conjugation facts themselves are general subgroup
+theory and live in `TauCeti.GroupTheory.DoubleCoset.Basic`
+(`conjAct_smul_mul_right_of_mem_normalizer` and the two `subgroupOf_…` lemmas); this file turns
+them into equivalences of the quotients:
 
-* multiplying on the **right** by anything normalizing `Γ₂` changes nothing at all, since
-  `(gh)Γ₂(gh)⁻¹ = gΓ₂g⁻¹` (`conjAct_smul_mul_right_of_mem_normalizer`,
-  `subgroupOf_conjAct_smul_mul_right_of_mem_normalizer`);
-* multiplying on the **left** by `h ∈ Γ₁` conjugates the stabilizer by `h`
-  (`subgroupOf_conjAct_smul_mul_left_of_mem_normalizer`).
+* moving the base point on the **left** by anything normalizing `Γ₁` conjugates the stabilizer,
+  hence gives `Γ₁/Stab(hg) ≃ Γ₁/Stab(g)`;
+* moving it on the **right** by anything normalizing `Γ₂` changes the stabilizer not at all, so
+  the two-sided move reduces to the left one.
 
 Ported from the AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) project,
 `LeanModularForms/HeckeRIngs/AbstractHeckeRing/StabConjugation.lean`
 (Chris Birkbeck). The source states these for a bundled `HeckePair` and for `g` in the
-ambient submonoid `Δ`; neither is used by the arguments, which are facts about conjugation
-of subgroups, so they are stated here for arbitrary subgroups and an arbitrary `g : G`.
+ambient submonoid `Δ`; neither is used by the arguments, so they are stated here for arbitrary
+subgroups, an arbitrary `g : G`, and multipliers taken from the normalizers.
 
 ## Main results
 
-* `DoubleCoset.conjAct_smul_mul_right_of_mem_normalizer`: `(gh)Γ(gh)⁻¹ = gΓg⁻¹` whenever `h`
-  normalizes `Γ`.
-* `DoubleCoset.subgroupOf_conjAct_smul_mul_left_of_mem_normalizer`: left multiplication by `h ∈ Γ₁`
-  conjugates the stabilizer by `h`.
 * `DoubleCoset.decompQuotientEquivMulLeft`, `DoubleCoset.decompQuotientEquivMulLeftRight`:
-  the induced equivalences of decomposition quotients.
+  the equivalences of decomposition quotients induced by moving the base point.
+* `DoubleCoset.decompQuotientEquivMulLeft_mk`,
+  `DoubleCoset.decompQuotientEquivMulLeftRight_mk`: what each does to a representative.
 -/
 
 public section
@@ -45,43 +43,6 @@ open scoped Pointwise
 namespace DoubleCoset
 
 variable {G : Type*} [Group G]
-
-/-- Conjugation only sees `g` modulo the normalizer on the right: `(gh)Γ(gh)⁻¹ = gΓg⁻¹`
-whenever `h` normalizes `Γ`. Membership in `Γ` itself is the special case
-`Subgroup.le_normalizer`. -/
-lemma conjAct_smul_mul_right_of_mem_normalizer (Γ : Subgroup G) (g : G) {h : G}
-    (hh : h ∈ Subgroup.normalizer Γ) :
-    ConjAct.toConjAct (g * h) • Γ = ConjAct.toConjAct g • Γ := by
-  rw [map_mul, ← smul_smul, Subgroup.conjAct_pointwise_smul_eq_self hh]
-
-/-- The stabilizer cut out inside `Γ₁` is unchanged by right multiplication of the base point
-by anything normalizing `Γ₂`. -/
-lemma subgroupOf_conjAct_smul_mul_right_of_mem_normalizer (Γ₁ Γ₂ : Subgroup G) (g : G) {h : G}
-    (hh : h ∈ Subgroup.normalizer Γ₂) :
-    (ConjAct.toConjAct (g * h) • Γ₂).subgroupOf Γ₁ =
-      (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁ := by
-  rw [conjAct_smul_mul_right_of_mem_normalizer Γ₂ g hh]
-
-/-- Left multiplication of the base point by anything normalizing `Γ₁` conjugates the
-stabilizer by it: `x` stabilizes `hg` exactly when `h⁻¹xh` stabilizes `g`. Membership in `Γ₁`
-itself is the special case `Subgroup.le_normalizer`.
-
-The conjugating automorphism of `↥Γ₁` is `Subgroup.normalizerMonoidHom`, which is defined for
-exactly this: `MulAut.conj h` would need `h` to be an element of `Γ₁`. -/
-lemma subgroupOf_conjAct_smul_mul_left_of_mem_normalizer (Γ₁ Γ₂ : Subgroup G) (g : G)
-    (h : Subgroup.normalizer (Γ₁ : Set G)) :
-    (ConjAct.toConjAct ((h : G) * g) • Γ₂).subgroupOf Γ₁ =
-      ((ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁).map
-        (Γ₁.normalizerMonoidHom h).toMonoidHom := by
-  ext x
-  rw [Subgroup.mem_map_equiv]
-  simp only [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
-    ConjAct.smul_def, map_inv, ConjAct.ofConjAct_toConjAct, inv_inv,
-    Subgroup.normalizerMonoidHom_apply_symm_apply_coe]
-  -- Both sides are membership of the *same* element of `Γ₂`, written with different
-  -- bracketing: `(hg)⁻¹x(hg)` versus `g⁻¹(h⁻¹xh)g`. `group` proves that identity; the `iff`
-  -- is then congruence along it, so no rewriting has to find a redex.
-  exact iff_of_eq (congrArg (· ∈ Γ₂) (by group))
 
 /-- Moving the base point on the left by anything normalizing `Γ₁` is an equivalence of
 decomposition quotients, `Γ₁/Stab(hg) ≃ Γ₁/Stab(g)`, induced by `σ ↦ h⁻¹σh`.

--- a/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
+++ b/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.Basic
+
+import Mathlib.Tactic.Group
+
+/-!
+# Moving the base point of a decomposition quotient
+
+`DoubleCoset.DecompQuotient Γ₁ Γ₂ g` is `Γ₁ ⧸ (gΓ₂g⁻¹).subgroupOf Γ₁`, so it depends on `g`
+only through the conjugate `gΓ₂g⁻¹`. This file records how that conjugate — and hence the
+quotient — responds to multiplying `g` on either side by a group element:
+
+* multiplying on the **right** by `h ∈ Γ₂` changes nothing at all, since `(gh)Γ₂(gh)⁻¹ = gΓ₂g⁻¹`
+  (`conjAct_smul_mul_right_of_mem`, `subgroupOf_conjAct_smul_mul_right_of_mem`);
+* multiplying on the **left** by `h ∈ Γ₁` conjugates the stabilizer by `h`
+  (`subgroupOf_conjAct_smul_mul_left_of_mem`).
+
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/AbstractHeckeRing/StabConjugation.lean`](https://github.com/CBirkbeck/AINTLIB),
+Chris Birkbeck). The source states these for a bundled `HeckePair` and for `g` in the
+ambient submonoid `Δ`; neither is used by the arguments, which are facts about conjugation
+of subgroups, so they are stated here for arbitrary subgroups and an arbitrary `g : G`.
+
+## Main results
+
+* `DoubleCoset.conjAct_smul_mul_right_of_mem`: `(gh)Γ(gh)⁻¹ = gΓg⁻¹` for `h ∈ Γ`.
+* `DoubleCoset.subgroupOf_conjAct_smul_mul_left_of_mem`: left multiplication by `h ∈ Γ₁`
+  conjugates the stabilizer by `h`.
+-/
+
+public section
+
+open scoped Pointwise
+
+namespace DoubleCoset
+
+variable {G : Type*} [Group G]
+
+/-- Conjugation only sees `g` modulo `Γ` on the right: `(gh)Γ(gh)⁻¹ = gΓg⁻¹` for `h ∈ Γ`,
+because `h` normalizes `Γ`. -/
+lemma conjAct_smul_mul_right_of_mem (Γ : Subgroup G) (g : G) {h : G} (hh : h ∈ Γ) :
+    ConjAct.toConjAct (g * h) • Γ = ConjAct.toConjAct g • Γ := by
+  rw [map_mul, ← smul_smul,
+    Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hh)]
+
+/-- The stabilizer cut out inside `Γ₁` is unchanged by right multiplication of the base point
+by an element of `Γ₂`. -/
+lemma subgroupOf_conjAct_smul_mul_right_of_mem (Γ₁ Γ₂ : Subgroup G) (g : G) {h : G}
+    (hh : h ∈ Γ₂) :
+    (ConjAct.toConjAct (g * h) • Γ₂).subgroupOf Γ₁ =
+      (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁ := by
+  rw [conjAct_smul_mul_right_of_mem Γ₂ g hh]
+
+/-- Left multiplication of the base point by `h ∈ Γ₁` conjugates the stabilizer by `h`:
+`x` stabilizes `hg` exactly when `h⁻¹xh` stabilizes `g`. -/
+lemma subgroupOf_conjAct_smul_mul_left_of_mem (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) :
+    (ConjAct.toConjAct ((h : G) * g) • Γ₂).subgroupOf Γ₁ =
+      ((ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁).map (MulAut.conj h).toMonoidHom := by
+  ext x
+  simp only [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
+    ConjAct.smul_def, map_inv, ConjAct.ofConjAct_toConjAct, inv_inv, Subgroup.mem_map,
+    MulEquiv.coe_toMonoidHom, MulAut.conj_apply]
+  constructor
+  · intro hx
+    refine ⟨⟨(h : G)⁻¹ * (x : G) * (h : G),
+      Γ₁.mul_mem (Γ₁.mul_mem (Γ₁.inv_mem h.2) x.2) h.2⟩, ?_, ?_⟩
+    · change (g : G)⁻¹ * ((h : G)⁻¹ * (x : G) * (h : G)) * g ∈ Γ₂
+      rw [show (g : G)⁻¹ * ((h : G)⁻¹ * (x : G) * (h : G)) * g =
+        ((h : G) * g)⁻¹ * (x : G) * ((h : G) * g) by group]
+      exact hx
+    · apply Subtype.ext
+      simp only [Subgroup.coe_mul, Subgroup.coe_inv]
+      group
+  · rintro ⟨y, hy, rfl⟩
+    change ((h : G) * g)⁻¹ * ((h : G) * (y : G) * (h : G)⁻¹) * ((h : G) * g) ∈ Γ₂
+    rw [show ((h : G) * g)⁻¹ * ((h : G) * (y : G) * (h : G)⁻¹) * ((h : G) * g) =
+      g⁻¹ * (y : G) * g by group]
+    exact hy
+
+end DoubleCoset

--- a/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
+++ b/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
@@ -94,31 +94,11 @@ quotients, `Γ₁/Stab(hg) ≃ Γ₁/Stab(g)`, induced by `σ ↦ h⁻¹σh`.
 Well-definedness is `subgroupOf_conjAct_smul_mul_left_of_mem`: the two stabilizers differ by
 conjugation by `h`, so that conjugation carries one coset relation to the other. -/
 noncomputable def decompQuotientEquivMulLeft (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) :
-    DecompQuotient Γ₁ Γ₂ ((h : G) * g) ≃ DecompQuotient Γ₁ Γ₂ g := by
-  set K := (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁ with hK
-  refine (Subgroup.quotientEquivOfEq
-    (subgroupOf_conjAct_smul_mul_left_of_mem Γ₁ Γ₂ g h)).trans ?_
-  have hwd : ∀ a b : Γ₁, QuotientGroup.leftRel (K.map (MulAut.conj h).toMonoidHom) a b →
-      QuotientGroup.leftRel K ((MulAut.conj h).symm a) ((MulAut.conj h).symm b) := by
-    intro a b hab
-    rw [QuotientGroup.leftRel_apply] at hab ⊢
-    simp only [← map_inv, ← map_mul]
-    obtain ⟨k, hk, hkeq⟩ := Subgroup.mem_map.mp hab
-    rw [show a⁻¹ * b = MulAut.conj h k from hkeq.symm, MulEquiv.symm_apply_apply]
-    exact hk
-  refine Equiv.ofBijective (Quotient.map' (MulAut.conj h).symm hwd) ⟨?_, ?_⟩
-  · refine Quotient.ind₂ fun a b hab ↦ ?_
-    simp only [Quotient.map'_mk''] at hab
-    rw [Quotient.eq''] at hab ⊢
-    rw [QuotientGroup.leftRel_apply] at hab ⊢
-    simp only [← map_inv, ← map_mul] at hab
-    exact Subgroup.mem_map.mpr ⟨(MulAut.conj h).symm (a⁻¹ * b), hab, by
-      rw [MulEquiv.coe_toMonoidHom, MulEquiv.apply_symm_apply]⟩
-  · refine Quotient.ind fun b ↦ ⟨Quotient.mk'' (MulAut.conj h b), ?_⟩
-    simp only [Quotient.map'_mk'']
-    rw [Quotient.eq'', QuotientGroup.leftRel_apply, MulEquiv.symm_apply_apply,
-      inv_mul_cancel]
-    exact K.one_mem
+    DecompQuotient Γ₁ Γ₂ ((h : G) * g) ≃ DecompQuotient Γ₁ Γ₂ g :=
+  (Subgroup.quotientEquivOfEq (subgroupOf_conjAct_smul_mul_left_of_mem Γ₁ Γ₂ g h)).trans <|
+    Quotient.congr (MulAut.conj h).symm.toEquiv fun a b ↦ by
+      simp only [QuotientGroup.leftRel_apply, Subgroup.mem_map_equiv,
+        MulEquiv.toEquiv_eq_coe, EquivLike.coe_coe, ← map_inv, ← map_mul]
 
 /-- Moving the base point on both sides — by `h ∈ Γ₁` on the left and by anything normalizing
 `Γ₂` on the right — is again an equivalence of decomposition quotients. Right multiplication

--- a/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
+++ b/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
@@ -83,4 +83,47 @@ lemma subgroupOf_conjAct_smul_mul_left_of_mem (Γ₁ Γ₂ : Subgroup G) (g : G)
       g⁻¹ * (y : G) * g by group]
     exact hy
 
+/-- Moving the base point by `h ∈ Γ₁` on the left is an equivalence of decomposition
+quotients, `Γ₁/Stab(hg) ≃ Γ₁/Stab(g)`, induced by `σ ↦ h⁻¹σh`.
+
+Well-definedness is `subgroupOf_conjAct_smul_mul_left_of_mem`: the two stabilizers differ by
+conjugation by `h`, so that conjugation carries one coset relation to the other. -/
+noncomputable def decompQuotientEquivMulLeft (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) :
+    DecompQuotient Γ₁ Γ₂ ((h : G) * g) ≃ DecompQuotient Γ₁ Γ₂ g := by
+  set K := (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁ with hK
+  refine (Subgroup.quotientEquivOfEq
+    (subgroupOf_conjAct_smul_mul_left_of_mem Γ₁ Γ₂ g h)).trans ?_
+  have hwd : ∀ a b : Γ₁, QuotientGroup.leftRel (K.map (MulAut.conj h).toMonoidHom) a b →
+      QuotientGroup.leftRel K ((MulAut.conj h).symm a) ((MulAut.conj h).symm b) := by
+    intro a b hab
+    rw [QuotientGroup.leftRel_apply] at hab ⊢
+    simp only [← map_inv, ← map_mul]
+    obtain ⟨k, hk, hkeq⟩ := Subgroup.mem_map.mp hab
+    rw [show a⁻¹ * b = MulAut.conj h k from hkeq.symm, MulEquiv.symm_apply_apply]
+    exact hk
+  refine Equiv.ofBijective (Quotient.map' (MulAut.conj h).symm hwd) ⟨?_, ?_⟩
+  · refine Quotient.ind₂ fun a b hab ↦ ?_
+    simp only [Quotient.map'_mk''] at hab
+    rw [Quotient.eq''] at hab ⊢
+    rw [QuotientGroup.leftRel_apply] at hab ⊢
+    simp only [← map_inv, ← map_mul] at hab
+    exact Subgroup.mem_map.mpr ⟨(MulAut.conj h).symm (a⁻¹ * b), hab, by
+      rw [MulEquiv.coe_toMonoidHom, MulEquiv.apply_symm_apply]⟩
+  · refine Quotient.ind fun b ↦ ⟨Quotient.mk'' (MulAut.conj h b), ?_⟩
+    simp only [Quotient.map'_mk'']
+    rw [Quotient.eq'', QuotientGroup.leftRel_apply, MulEquiv.symm_apply_apply,
+      inv_mul_cancel]
+    exact K.one_mem
+
+/-- Moving the base point on both sides — by `h ∈ Γ₁` on the left and `k ∈ Γ₂` on the right —
+is again an equivalence of decomposition quotients. Right multiplication contributes nothing
+(`subgroupOf_conjAct_smul_mul_right_of_mem`), so this is `decompQuotientEquivMulLeft` after
+re-associating. -/
+noncomputable def decompQuotientEquivMulLeftRight (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁)
+    {k : G} (hk : k ∈ Γ₂) :
+    DecompQuotient Γ₁ Γ₂ ((h : G) * g * k) ≃ DecompQuotient Γ₁ Γ₂ g :=
+  (Subgroup.quotientEquivOfEq (by rw [mul_assoc])).trans
+    ((decompQuotientEquivMulLeft Γ₁ Γ₂ (g * k) h).trans
+      (Subgroup.quotientEquivOfEq (subgroupOf_conjAct_smul_mul_right_of_mem Γ₁ Γ₂ g hk)))
+
 end DoubleCoset

--- a/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
+++ b/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
@@ -21,9 +21,9 @@ quotient — responds to multiplying `g` on either side by a group element:
 * multiplying on the **left** by `h ∈ Γ₁` conjugates the stabilizer by `h`
   (`subgroupOf_conjAct_smul_mul_left_of_mem`).
 
-Ported from the AINTLIB `LeanModularForms` project
-([`LeanModularForms/HeckeRIngs/AbstractHeckeRing/StabConjugation.lean`](https://github.com/CBirkbeck/AINTLIB),
-Chris Birkbeck). The source states these for a bundled `HeckePair` and for `g` in the
+Ported from the AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) project,
+`LeanModularForms/HeckeRIngs/AbstractHeckeRing/StabConjugation.lean`
+(Chris Birkbeck). The source states these for a bundled `HeckePair` and for `g` in the
 ambient submonoid `Δ`; neither is used by the arguments, which are facts about conjugation
 of subgroups, so they are stated here for arbitrary subgroups and an arbitrary `g : G`.
 

--- a/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
+++ b/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
@@ -62,46 +62,36 @@ lemma subgroupOf_conjAct_smul_mul_right_of_mem_normalizer (Γ₁ Γ₂ : Subgrou
       (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁ := by
   rw [conjAct_smul_mul_right_of_mem_normalizer Γ₂ g hh]
 
-/-- Left multiplication of the base point by `h ∈ Γ₁` conjugates the stabilizer by `h`:
-`x` stabilizes `hg` exactly when `h⁻¹xh` stabilizes `g`. -/
-lemma subgroupOf_conjAct_smul_mul_left_of_mem (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) :
+/-- Left multiplication of the base point by anything normalizing `Γ₁` conjugates the
+stabilizer by it: `x` stabilizes `hg` exactly when `h⁻¹xh` stabilizes `g`. Membership in `Γ₁`
+itself is the special case `Subgroup.le_normalizer`.
+
+The conjugating automorphism of `↥Γ₁` is `Subgroup.normalizerMonoidHom`, which is defined for
+exactly this: `MulAut.conj h` would need `h` to be an element of `Γ₁`. -/
+lemma subgroupOf_conjAct_smul_mul_left_of_mem_normalizer (Γ₁ Γ₂ : Subgroup G) (g : G)
+    (h : Subgroup.normalizer (Γ₁ : Set G)) :
     (ConjAct.toConjAct ((h : G) * g) • Γ₂).subgroupOf Γ₁ =
-      ((ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁).map (MulAut.conj h).toMonoidHom := by
+      ((ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁).map
+        (Γ₁.normalizerMonoidHom h).toMonoidHom := by
   ext x
+  rw [Subgroup.mem_map_equiv]
   simp only [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
-    ConjAct.smul_def, map_inv, ConjAct.ofConjAct_toConjAct, inv_inv, Subgroup.mem_map,
-    MulEquiv.coe_toMonoidHom, MulAut.conj_apply]
-  -- Both directions produce a membership stated about a `↥Γ₁` element whose value is a
-  -- product; `change` names the underlying `G`-element so `group` can normalise it. The
-  -- `Subgroup.mem_subgroupOf` simp step above leaves the coercion implicit, which is what
-  -- makes the explicit form necessary rather than merely convenient.
-  constructor
-  · intro hx
-    refine ⟨⟨(h : G)⁻¹ * (x : G) * (h : G),
-      Γ₁.mul_mem (Γ₁.mul_mem (Γ₁.inv_mem h.2) x.2) h.2⟩, ?_, ?_⟩
-    · change (g : G)⁻¹ * ((h : G)⁻¹ * (x : G) * (h : G)) * g ∈ Γ₂
-      rw [show (g : G)⁻¹ * ((h : G)⁻¹ * (x : G) * (h : G)) * g =
-        ((h : G) * g)⁻¹ * (x : G) * ((h : G) * g) by group]
-      exact hx
-    · -- the witness conjugates back to `x`; check it on underlying elements
-      apply Subtype.ext
-      simp only [Subgroup.coe_mul, Subgroup.coe_inv]
-      group
-  · rintro ⟨y, hy, rfl⟩
-    change ((h : G) * g)⁻¹ * ((h : G) * (y : G) * (h : G)⁻¹) * ((h : G) * g) ∈ Γ₂
-    rw [show ((h : G) * g)⁻¹ * ((h : G) * (y : G) * (h : G)⁻¹) * ((h : G) * g) =
-      g⁻¹ * (y : G) * g by group]
-    exact hy
+    ConjAct.smul_def, map_inv, ConjAct.ofConjAct_toConjAct, inv_inv,
+    Subgroup.normalizerMonoidHom_apply_symm_apply_coe]
+  rw [show ((h : G) * g)⁻¹ * (x : G) * ((h : G) * g) =
+    g⁻¹ * ((h : G)⁻¹ * (x : G) * (h : G)) * g by group]
 
-/-- Moving the base point by `h ∈ Γ₁` on the left is an equivalence of decomposition
-quotients, `Γ₁/Stab(hg) ≃ Γ₁/Stab(g)`, induced by `σ ↦ h⁻¹σh`.
+/-- Moving the base point on the left by anything normalizing `Γ₁` is an equivalence of
+decomposition quotients, `Γ₁/Stab(hg) ≃ Γ₁/Stab(g)`, induced by `σ ↦ h⁻¹σh`.
 
-Well-definedness is `subgroupOf_conjAct_smul_mul_left_of_mem`: the two stabilizers differ by
-conjugation by `h`, so that conjugation carries one coset relation to the other. -/
-noncomputable def decompQuotientEquivMulLeft (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) :
+Well-definedness is `subgroupOf_conjAct_smul_mul_left_of_mem_normalizer`: the two stabilizers
+differ by that conjugation, so it carries one coset relation to the other. -/
+noncomputable def decompQuotientEquivMulLeft (Γ₁ Γ₂ : Subgroup G) (g : G)
+    (h : Subgroup.normalizer (Γ₁ : Set G)) :
     DecompQuotient Γ₁ Γ₂ ((h : G) * g) ≃ DecompQuotient Γ₁ Γ₂ g :=
-  (Subgroup.quotientEquivOfEq (subgroupOf_conjAct_smul_mul_left_of_mem Γ₁ Γ₂ g h)).trans <|
-    Quotient.congr (MulAut.conj h).symm.toEquiv fun a b ↦ by
+  (Subgroup.quotientEquivOfEq
+      (subgroupOf_conjAct_smul_mul_left_of_mem_normalizer Γ₁ Γ₂ g h)).trans <|
+    Quotient.congr (Γ₁.normalizerMonoidHom h).symm.toEquiv fun a b ↦ by
       simp only [QuotientGroup.leftRel_apply, Subgroup.mem_map_equiv,
         MulEquiv.toEquiv_eq_coe, EquivLike.coe_coe, ← map_inv, ← map_mul]
 
@@ -112,19 +102,20 @@ made so: `QuotientGroup.mk`'s implicit subgroup argument comes from the type ind
 `DecompQuotient Γ₁ Γ₂ (↑h * g)`, and simp rewrites `ConjAct.toConjAct (↑h * g)` inside it to
 `ConjAct.toConjAct ↑h * ConjAct.toConjAct g` via `ConjAct.toConjAct_mul`. `scripts/lint-env.sh`
 reports exactly that as a `simpNF` violation. Rewrite with this lemma by name. -/
-lemma decompQuotientEquivMulLeft_mk (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) (x : Γ₁) :
+lemma decompQuotientEquivMulLeft_mk (Γ₁ Γ₂ : Subgroup G) (g : G)
+    (h : Subgroup.normalizer (Γ₁ : Set G)) (x : Γ₁) :
     decompQuotientEquivMulLeft Γ₁ Γ₂ g h (QuotientGroup.mk x) =
-      QuotientGroup.mk ((MulAut.conj h).symm x) :=
+      QuotientGroup.mk ((Γ₁.normalizerMonoidHom h).symm x) :=
   -- `(rfl)` rather than `rfl`: the equivalences are not `@[expose]`, so the parentheses opt
   -- out of exporting the definitional equality that this lemma exists to replace.
   (rfl)
 
-/-- Moving the base point on both sides — by `h ∈ Γ₁` on the left and by anything normalizing
-`Γ₂` on the right — is again an equivalence of decomposition quotients. Right multiplication
-contributes nothing (`subgroupOf_conjAct_smul_mul_right_of_mem_normalizer`), so this is
-`decompQuotientEquivMulLeft` after re-associating. -/
-noncomputable def decompQuotientEquivMulLeftRight (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁)
-    {k : G} (hk : k ∈ Subgroup.normalizer Γ₂) :
+/-- Moving the base point on both sides — on the left by anything normalizing `Γ₁`, on the
+right by anything normalizing `Γ₂` — is again an equivalence of decomposition quotients. Right
+multiplication contributes nothing (`subgroupOf_conjAct_smul_mul_right_of_mem_normalizer`), so
+this is `decompQuotientEquivMulLeft` after re-associating. -/
+noncomputable def decompQuotientEquivMulLeftRight (Γ₁ Γ₂ : Subgroup G) (g : G)
+    (h : Subgroup.normalizer (Γ₁ : Set G)) {k : G} (hk : k ∈ Subgroup.normalizer Γ₂) :
     DecompQuotient Γ₁ Γ₂ ((h : G) * g * k) ≃ DecompQuotient Γ₁ Γ₂ g :=
   (Subgroup.quotientEquivOfEq (by rw [mul_assoc])).trans
     ((decompQuotientEquivMulLeft Γ₁ Γ₂ (g * k) h).trans
@@ -133,12 +124,10 @@ noncomputable def decompQuotientEquivMulLeftRight (Γ₁ Γ₂ : Subgroup G) (g 
 
 /-- What `decompQuotientEquivMulLeftRight` does to a representative. Not `@[simp]`, for the
 same reason as `decompQuotientEquivMulLeft_mk`. -/
-lemma decompQuotientEquivMulLeftRight_mk (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) {k : G}
-    (hk : k ∈ Subgroup.normalizer Γ₂) (x : Γ₁) :
+lemma decompQuotientEquivMulLeftRight_mk (Γ₁ Γ₂ : Subgroup G) (g : G)
+    (h : Subgroup.normalizer (Γ₁ : Set G)) {k : G} (hk : k ∈ Subgroup.normalizer Γ₂) (x : Γ₁) :
     decompQuotientEquivMulLeftRight Γ₁ Γ₂ g h hk (QuotientGroup.mk x) =
-      QuotientGroup.mk ((MulAut.conj h).symm x) :=
-  -- `(rfl)` rather than `rfl`: the equivalences are not `@[expose]`, so the parentheses opt
-  -- out of exporting the definitional equality that this lemma exists to replace.
+      QuotientGroup.mk ((Γ₁.normalizerMonoidHom h).symm x) :=
   (rfl)
 
 end DoubleCoset

--- a/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
+++ b/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
@@ -20,7 +20,7 @@ quotient — responds to multiplying `g` on either side by a group element:
   `(gh)Γ₂(gh)⁻¹ = gΓ₂g⁻¹` (`conjAct_smul_mul_right_of_mem_normalizer`,
   `subgroupOf_conjAct_smul_mul_right_of_mem_normalizer`);
 * multiplying on the **left** by `h ∈ Γ₁` conjugates the stabilizer by `h`
-  (`subgroupOf_conjAct_smul_mul_left_of_mem`).
+  (`subgroupOf_conjAct_smul_mul_left_of_mem_normalizer`).
 
 Ported from the AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) project,
 `LeanModularForms/HeckeRIngs/AbstractHeckeRing/StabConjugation.lean`
@@ -32,7 +32,7 @@ of subgroups, so they are stated here for arbitrary subgroups and an arbitrary `
 
 * `DoubleCoset.conjAct_smul_mul_right_of_mem_normalizer`: `(gh)Γ(gh)⁻¹ = gΓg⁻¹` whenever `h`
   normalizes `Γ`.
-* `DoubleCoset.subgroupOf_conjAct_smul_mul_left_of_mem`: left multiplication by `h ∈ Γ₁`
+* `DoubleCoset.subgroupOf_conjAct_smul_mul_left_of_mem_normalizer`: left multiplication by `h ∈ Γ₁`
   conjugates the stabilizer by `h`.
 * `DoubleCoset.decompQuotientEquivMulLeft`, `DoubleCoset.decompQuotientEquivMulLeftRight`:
   the induced equivalences of decomposition quotients.
@@ -78,8 +78,10 @@ lemma subgroupOf_conjAct_smul_mul_left_of_mem_normalizer (Γ₁ Γ₂ : Subgroup
   simp only [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
     ConjAct.smul_def, map_inv, ConjAct.ofConjAct_toConjAct, inv_inv,
     Subgroup.normalizerMonoidHom_apply_symm_apply_coe]
-  rw [show ((h : G) * g)⁻¹ * (x : G) * ((h : G) * g) =
-    g⁻¹ * ((h : G)⁻¹ * (x : G) * (h : G)) * g by group]
+  -- Both sides are membership of the *same* element of `Γ₂`, written with different
+  -- bracketing: `(hg)⁻¹x(hg)` versus `g⁻¹(h⁻¹xh)g`. `group` proves that identity; the `iff`
+  -- is then congruence along it, so no rewriting has to find a redex.
+  exact iff_of_eq (congrArg (· ∈ Γ₂) (by group))
 
 /-- Moving the base point on the left by anything normalizing `Γ₁` is an equivalence of
 decomposition quotients, `Γ₁/Stab(hg) ≃ Γ₁/Stab(g)`, induced by `σ ↦ h⁻¹σh`.

--- a/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
+++ b/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
@@ -16,8 +16,9 @@ import Mathlib.Tactic.Group
 only through the conjugate `gΓ₂g⁻¹`. This file records how that conjugate — and hence the
 quotient — responds to multiplying `g` on either side by a group element:
 
-* multiplying on the **right** by `h ∈ Γ₂` changes nothing at all, since `(gh)Γ₂(gh)⁻¹ = gΓ₂g⁻¹`
-  (`conjAct_smul_mul_right_of_mem`, `subgroupOf_conjAct_smul_mul_right_of_mem`);
+* multiplying on the **right** by anything normalizing `Γ₂` changes nothing at all, since
+  `(gh)Γ₂(gh)⁻¹ = gΓ₂g⁻¹` (`conjAct_smul_mul_right_of_mem_normalizer`,
+  `subgroupOf_conjAct_smul_mul_right_of_mem_normalizer`);
 * multiplying on the **left** by `h ∈ Γ₁` conjugates the stabilizer by `h`
   (`subgroupOf_conjAct_smul_mul_left_of_mem`).
 
@@ -29,9 +30,12 @@ of subgroups, so they are stated here for arbitrary subgroups and an arbitrary `
 
 ## Main results
 
-* `DoubleCoset.conjAct_smul_mul_right_of_mem`: `(gh)Γ(gh)⁻¹ = gΓg⁻¹` for `h ∈ Γ`.
+* `DoubleCoset.conjAct_smul_mul_right_of_mem_normalizer`: `(gh)Γ(gh)⁻¹ = gΓg⁻¹` whenever `h`
+  normalizes `Γ`.
 * `DoubleCoset.subgroupOf_conjAct_smul_mul_left_of_mem`: left multiplication by `h ∈ Γ₁`
   conjugates the stabilizer by `h`.
+* `DoubleCoset.decompQuotientEquivMulLeft`, `DoubleCoset.decompQuotientEquivMulLeftRight`:
+  the induced equivalences of decomposition quotients.
 -/
 
 public section
@@ -42,20 +46,21 @@ namespace DoubleCoset
 
 variable {G : Type*} [Group G]
 
-/-- Conjugation only sees `g` modulo `Γ` on the right: `(gh)Γ(gh)⁻¹ = gΓg⁻¹` for `h ∈ Γ`,
-because `h` normalizes `Γ`. -/
-lemma conjAct_smul_mul_right_of_mem (Γ : Subgroup G) (g : G) {h : G} (hh : h ∈ Γ) :
+/-- Conjugation only sees `g` modulo the normalizer on the right: `(gh)Γ(gh)⁻¹ = gΓg⁻¹`
+whenever `h` normalizes `Γ`. Membership in `Γ` itself is the special case
+`Subgroup.le_normalizer`. -/
+lemma conjAct_smul_mul_right_of_mem_normalizer (Γ : Subgroup G) (g : G) {h : G}
+    (hh : h ∈ Subgroup.normalizer Γ) :
     ConjAct.toConjAct (g * h) • Γ = ConjAct.toConjAct g • Γ := by
-  rw [map_mul, ← smul_smul,
-    Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hh)]
+  rw [map_mul, ← smul_smul, Subgroup.conjAct_pointwise_smul_eq_self hh]
 
 /-- The stabilizer cut out inside `Γ₁` is unchanged by right multiplication of the base point
-by an element of `Γ₂`. -/
-lemma subgroupOf_conjAct_smul_mul_right_of_mem (Γ₁ Γ₂ : Subgroup G) (g : G) {h : G}
-    (hh : h ∈ Γ₂) :
+by anything normalizing `Γ₂`. -/
+lemma subgroupOf_conjAct_smul_mul_right_of_mem_normalizer (Γ₁ Γ₂ : Subgroup G) (g : G) {h : G}
+    (hh : h ∈ Subgroup.normalizer Γ₂) :
     (ConjAct.toConjAct (g * h) • Γ₂).subgroupOf Γ₁ =
       (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁ := by
-  rw [conjAct_smul_mul_right_of_mem Γ₂ g hh]
+  rw [conjAct_smul_mul_right_of_mem_normalizer Γ₂ g hh]
 
 /-- Left multiplication of the base point by `h ∈ Γ₁` conjugates the stabilizer by `h`:
 `x` stabilizes `hg` exactly when `h⁻¹xh` stabilizes `g`. -/
@@ -115,15 +120,16 @@ noncomputable def decompQuotientEquivMulLeft (Γ₁ Γ₂ : Subgroup G) (g : G) 
       inv_mul_cancel]
     exact K.one_mem
 
-/-- Moving the base point on both sides — by `h ∈ Γ₁` on the left and `k ∈ Γ₂` on the right —
-is again an equivalence of decomposition quotients. Right multiplication contributes nothing
-(`subgroupOf_conjAct_smul_mul_right_of_mem`), so this is `decompQuotientEquivMulLeft` after
-re-associating. -/
+/-- Moving the base point on both sides — by `h ∈ Γ₁` on the left and by anything normalizing
+`Γ₂` on the right — is again an equivalence of decomposition quotients. Right multiplication
+contributes nothing (`subgroupOf_conjAct_smul_mul_right_of_mem_normalizer`), so this is
+`decompQuotientEquivMulLeft` after re-associating. -/
 noncomputable def decompQuotientEquivMulLeftRight (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁)
-    {k : G} (hk : k ∈ Γ₂) :
+    {k : G} (hk : k ∈ Subgroup.normalizer Γ₂) :
     DecompQuotient Γ₁ Γ₂ ((h : G) * g * k) ≃ DecompQuotient Γ₁ Γ₂ g :=
   (Subgroup.quotientEquivOfEq (by rw [mul_assoc])).trans
     ((decompQuotientEquivMulLeft Γ₁ Γ₂ (g * k) h).trans
-      (Subgroup.quotientEquivOfEq (subgroupOf_conjAct_smul_mul_right_of_mem Γ₁ Γ₂ g hk)))
+      (Subgroup.quotientEquivOfEq
+        (subgroupOf_conjAct_smul_mul_right_of_mem_normalizer Γ₁ Γ₂ g hk)))
 
 end DoubleCoset

--- a/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
+++ b/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
@@ -105,7 +105,13 @@ noncomputable def decompQuotientEquivMulLeft (Γ₁ Γ₂ : Subgroup G) (g : G) 
       simp only [QuotientGroup.leftRel_apply, Subgroup.mem_map_equiv,
         MulEquiv.toEquiv_eq_coe, EquivLike.coe_coe, ← map_inv, ← map_mul]
 
-@[simp]
+/-- What `decompQuotientEquivMulLeft` does to a representative: it conjugates by `h⁻¹`.
+
+Deliberately *not* `@[simp]`. The left-hand side is not in simp normal form and cannot be
+made so: `QuotientGroup.mk`'s implicit subgroup argument comes from the type index
+`DecompQuotient Γ₁ Γ₂ (↑h * g)`, and simp rewrites `ConjAct.toConjAct (↑h * g)` inside it to
+`ConjAct.toConjAct ↑h * ConjAct.toConjAct g` via `ConjAct.toConjAct_mul`. `scripts/lint-env.sh`
+reports exactly that as a `simpNF` violation. Rewrite with this lemma by name. -/
 lemma decompQuotientEquivMulLeft_mk (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) (x : Γ₁) :
     decompQuotientEquivMulLeft Γ₁ Γ₂ g h (QuotientGroup.mk x) =
       QuotientGroup.mk ((MulAut.conj h).symm x) :=
@@ -125,7 +131,8 @@ noncomputable def decompQuotientEquivMulLeftRight (Γ₁ Γ₂ : Subgroup G) (g 
       (Subgroup.quotientEquivOfEq
         (subgroupOf_conjAct_smul_mul_right_of_mem_normalizer Γ₁ Γ₂ g hk)))
 
-@[simp]
+/-- What `decompQuotientEquivMulLeftRight` does to a representative. Not `@[simp]`, for the
+same reason as `decompQuotientEquivMulLeft_mk`. -/
 lemma decompQuotientEquivMulLeftRight_mk (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) {k : G}
     (hk : k ∈ Subgroup.normalizer Γ₂) (x : Γ₁) :
     decompQuotientEquivMulLeftRight Γ₁ Γ₂ g h hk (QuotientGroup.mk x) =

--- a/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
+++ b/TauCeti/NumberTheory/HeckeRing/StabConjugation.lean
@@ -71,6 +71,10 @@ lemma subgroupOf_conjAct_smul_mul_left_of_mem (Γ₁ Γ₂ : Subgroup G) (g : G)
   simp only [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
     ConjAct.smul_def, map_inv, ConjAct.ofConjAct_toConjAct, inv_inv, Subgroup.mem_map,
     MulEquiv.coe_toMonoidHom, MulAut.conj_apply]
+  -- Both directions produce a membership stated about a `↥Γ₁` element whose value is a
+  -- product; `change` names the underlying `G`-element so `group` can normalise it. The
+  -- `Subgroup.mem_subgroupOf` simp step above leaves the coercion implicit, which is what
+  -- makes the explicit form necessary rather than merely convenient.
   constructor
   · intro hx
     refine ⟨⟨(h : G)⁻¹ * (x : G) * (h : G),
@@ -79,7 +83,8 @@ lemma subgroupOf_conjAct_smul_mul_left_of_mem (Γ₁ Γ₂ : Subgroup G) (g : G)
       rw [show (g : G)⁻¹ * ((h : G)⁻¹ * (x : G) * (h : G)) * g =
         ((h : G) * g)⁻¹ * (x : G) * ((h : G) * g) by group]
       exact hx
-    · apply Subtype.ext
+    · -- the witness conjugates back to `x`; check it on underlying elements
+      apply Subtype.ext
       simp only [Subgroup.coe_mul, Subgroup.coe_inv]
       group
   · rintro ⟨y, hy, rfl⟩
@@ -100,6 +105,14 @@ noncomputable def decompQuotientEquivMulLeft (Γ₁ Γ₂ : Subgroup G) (g : G) 
       simp only [QuotientGroup.leftRel_apply, Subgroup.mem_map_equiv,
         MulEquiv.toEquiv_eq_coe, EquivLike.coe_coe, ← map_inv, ← map_mul]
 
+@[simp]
+lemma decompQuotientEquivMulLeft_mk (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) (x : Γ₁) :
+    decompQuotientEquivMulLeft Γ₁ Γ₂ g h (QuotientGroup.mk x) =
+      QuotientGroup.mk ((MulAut.conj h).symm x) :=
+  -- `(rfl)` rather than `rfl`: the equivalences are not `@[expose]`, so the parentheses opt
+  -- out of exporting the definitional equality that this lemma exists to replace.
+  (rfl)
+
 /-- Moving the base point on both sides — by `h ∈ Γ₁` on the left and by anything normalizing
 `Γ₂` on the right — is again an equivalence of decomposition quotients. Right multiplication
 contributes nothing (`subgroupOf_conjAct_smul_mul_right_of_mem_normalizer`), so this is
@@ -111,5 +124,14 @@ noncomputable def decompQuotientEquivMulLeftRight (Γ₁ Γ₂ : Subgroup G) (g 
     ((decompQuotientEquivMulLeft Γ₁ Γ₂ (g * k) h).trans
       (Subgroup.quotientEquivOfEq
         (subgroupOf_conjAct_smul_mul_right_of_mem_normalizer Γ₁ Γ₂ g hk)))
+
+@[simp]
+lemma decompQuotientEquivMulLeftRight_mk (Γ₁ Γ₂ : Subgroup G) (g : G) (h : Γ₁) {k : G}
+    (hk : k ∈ Subgroup.normalizer Γ₂) (x : Γ₁) :
+    decompQuotientEquivMulLeftRight Γ₁ Γ₂ g h hk (QuotientGroup.mk x) =
+      QuotientGroup.mk ((MulAut.conj h).symm x) :=
+  -- `(rfl)` rather than `rfl`: the equivalences are not `@[expose]`, so the parentheses opt
+  -- out of exporting the definitional equality that this lemma exists to replace.
+  (rfl)
 
 end DoubleCoset


### PR DESCRIPTION
`DoubleCoset.DecompQuotient Γ₁ Γ₂ g` is `Γ₁ ⧸ (gΓ₂g⁻¹).subgroupOf Γ₁`, so it depends on `g`
only through the conjugate `gΓ₂g⁻¹`. This adds the facts describing how that conjugate — and
hence the quotient itself — responds to moving the base point `g`.

## Main results

* `conjAct_smul_mul_right_of_mem` — `(gh)Γ(gh)⁻¹ = gΓg⁻¹` for `h ∈ Γ`.
* `subgroupOf_conjAct_smul_mul_right_of_mem` — hence the stabilizer cut out inside `Γ₁` is
  unchanged by right multiplication of the base point.
* `subgroupOf_conjAct_smul_mul_left_of_mem` — left multiplication by `h ∈ Γ₁` conjugates the
  stabilizer by `h`.
* `decompQuotientEquivMulLeft` — `Γ₁/Stab(hg) ≃ Γ₁/Stab(g)` for `h ∈ Γ₁`, induced by
  `σ ↦ h⁻¹σh`.
* `decompQuotientEquivMulLeftRight` — the same for `h·g·k` with `h ∈ Γ₁` and `k ∈ Γ₂`.

## Provenance

Ported from the AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) project,
`LeanModularForms/HeckeRIngs/AbstractHeckeRing/StabConjugation.lean` (Chris Birkbeck,
Apache-2.0), where these support the `CongruenceHecke` degree-combinatorics computations.

Three deliberate departures from the source, all in the direction of less assumption and
less duplication:

* **No `HeckePair`, no `Δ`.** The source bundles a `HeckePair P` and takes `g` in the
  ambient submonoid `Δ`, with side conditions `hm : h * g ∈ P.Δ`. None of that is used —
  these are facts about conjugating subgroups — so everything here is stated for arbitrary
  `Γ₁ Γ₂ : Subgroup G` and arbitrary `g : G`, with `Γ₁ ≠ Γ₂` allowed. The membership side
  conditions disappear entirely.
* **The right-multiplication proof is one `rw`** through Mathlib's
  `Subgroup.conjAct_pointwise_smul_eq_self`, in place of the source's twelve-line
  `ext`/`group` argument. `HeckeRing/Basic.lean` already reaches for that lemma the same way.
* **No `conj_inv_eq_symm` helper.** The source carries a private lemma
  `MulAut.conj h⁻¹ = (MulAut.conj h).symm` to thread `MulAut.conj h⁻¹` through the quotient
  arguments. Using `(MulAut.conj h).symm` directly removes the need for it —
  `MulEquiv.symm_apply_apply` and `apply_symm_apply` then apply directly.

## Roadmap node

`TauCetiRoadmap/ModularForms/README.md`, **Layer 2(a) — "The Hecke ring, stated at `GL_n` —
consume Mathlib's definitions, build the convolution product here, migrate AINTLIB's `GLn/`
development."** That node specifies "Congruence level stays at `n = 2` (Shimura §3.3; AINTLIB
`GLn/CongruenceHecke/*`)", and these base-point equivalences are precisely what the
`CongruenceHecke` degree-combinatorics computations rest on: they are what lets a degree count
be transported along a change of double-coset representative.

This is independent of the `GL2` multiplication-table stack (#2279 / #2286 / #2478): it
imports only `TauCeti.NumberTheory.HeckeRing.Basic`, which is in `main`.

Roadmap: ModularForms
