### PR TITLE
feat(DedekindDomain): a separable extension ramifies at only finitely many primes

### DIFF
--- a/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
+++ b/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
@@ -4,9 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.DedekindDomain.Factorization
+public import Mathlib.FieldTheory.SeparableDegree
+public import Mathlib.RingTheory.DedekindDomain.Basic
 public import Mathlib.RingTheory.Unramified.Locus
 import Mathlib.RingTheory.DedekindDomain.Different
+import Mathlib.RingTheory.DedekindDomain.Factorization
 
 /-!
 # A separable extension of Dedekind domains ramifies at only finitely many primes

--- a/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
+++ b/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
@@ -39,7 +39,7 @@ this file supplies. Layer 2's `E[N]` and Layer 3's Hasse kernel count consume th
 ## Provenance
 
 Ported from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by
-that roadmap at `dev/hasse-weil @ 94f6d72eeea3`), `HasseWeil/Curves/RamificationFinite.lean`,
+that roadmap at `dev/hasse-weil @ 513e83879e2f`), `HasseWeil/Curves/RamificationFinite.lean`,
 declarations `finite_setOf_dvd_differentIdeal`, `finite_setOf_ramificationIdx_ne_one` and
 `finite_setOf_under_ramified`.
 

--- a/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
+++ b/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
@@ -22,7 +22,6 @@ is nonzero; a nonzero ideal of a Dedekind domain has only finitely many divisors
 
 ## Main results
 
-* `Algebra.finite_setOf_dvd_differentIdeal`: the different ideal has finitely many divisors.
 * `Algebra.finite_compl_unramifiedLocus`: the ramification locus is finite.
 
 Stated over Dedekind domains directly rather than in an AKLB tower: no ambient fraction fields
@@ -47,8 +46,10 @@ Changes from the source. The source works in an AKLB tower and rebuilds the stan
 along the way, including `differentIdeal_ne_bot`, which Mathlib now proves; those are dropped, and
 with them the tower. The ramification locus is named by Mathlib's `Algebra.unramifiedLocus` and
 the criterion by Mathlib's `Algebra.IsUnramifiedAt`, in place of the source's hand-rolled
-`ramifiedUnderLocus` and its `Ideal.ramificationIdx _ _ ≠ 1` spelling. Sixteen declarations become
-two.
+`ramifiedUnderLocus` and its `Ideal.ramificationIdx _ _ ≠ 1` spelling. The source's
+divisor-finiteness step is a specialisation of Mathlib's
+`UniqueFactorizationMonoid.fintypeSubtypeDvd` with no consumer of its own, so it stays inside the
+one proof rather than becoming public API. Sixteen declarations become one.
 -/
 
 public section
@@ -63,21 +64,16 @@ variable (A B : Type*) [CommRing A] [IsDedekindDomain A] [CommRing B] [Algebra A
   [IsDedekindDomain B] [Module.IsTorsionFree A B] [Module.Finite A B]
   [Algebra.IsSeparable (FractionRing A) (FractionRing B)]
 
-/-- **The different ideal has only finitely many divisors**, being a nonzero ideal of a Dedekind
-domain. -/
-theorem finite_setOf_dvd_differentIdeal : {P : Ideal B | P ∣ differentIdeal A B}.Finite := by
-  have h : Finite {P : Ideal B // P ∣ differentIdeal A B} :=
-    @Finite.of_fintype _ (UniqueFactorizationMonoid.fintypeSubtypeDvd _
-      (differentIdeal_ne_bot (A := A) (B := B)))
-  exact Set.finite_coe_iff.mp h
-
 /-- **A separable extension of Dedekind domains ramifies at only finitely many primes**: the
 complement of `Algebra.unramifiedLocus` is finite. A ramified prime divides the different ideal,
-which is nonzero and so has finitely many divisors. -/
+which is nonzero and so, being an ideal of a Dedekind domain, has finitely many divisors. -/
 theorem finite_compl_unramifiedLocus : (unramifiedLocus A B)ᶜ.Finite := by
+  have hdvd : {P : Ideal B | P ∣ differentIdeal A B}.Finite :=
+    Set.finite_coe_iff.mp (@Finite.of_fintype _ (UniqueFactorizationMonoid.fintypeSubtypeDvd _
+      (differentIdeal_ne_bot (A := A) (B := B))))
   refine Set.Finite.of_finite_image (f := PrimeSpectrum.asIdeal) ?_
     fun _ _ _ _ h => PrimeSpectrum.ext h
-  refine (finite_setOf_dvd_differentIdeal A B).subset ?_
+  refine hdvd.subset ?_
   rintro _ ⟨p, hp, rfl⟩
   have := p.isPrime
   exact dvd_differentIdeal_iff.mpr hp

--- a/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
+++ b/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
@@ -11,7 +11,7 @@ import Mathlib.RingTheory.DedekindDomain.Different
 import Mathlib.RingTheory.DedekindDomain.Factorization
 
 /-!
-# A separable extension of Dedekind domains ramifies at only finitely many primes
+# Finiteness of the ramification locus of an extension of Dedekind domains
 
 Let `B` be a Dedekind domain, module-finite and torsion-free over a Dedekind domain `A`, with the
 extension of fraction fields separable. Mathlib's `Algebra.unramifiedLocus A B` is the set of
@@ -65,9 +65,10 @@ variable (A B : Type*) [CommRing A] [IsDedekindDomain A] [CommRing B] [Algebra A
   [IsDedekindDomain B] [Module.IsTorsionFree A B] [Module.Finite A B]
   [Algebra.IsSeparable (FractionRing A) (FractionRing B)]
 
-/-- **A separable extension of Dedekind domains ramifies at only finitely many primes**: the
-complement of `Algebra.unramifiedLocus` is finite. A ramified prime divides the different ideal,
-which is nonzero and so, being an ideal of a Dedekind domain, has finitely many divisors. -/
+/-- **A module-finite, torsion-free extension of Dedekind domains whose fraction-field extension
+is separable ramifies at only finitely many primes**: the complement of
+`Algebra.unramifiedLocus` is finite. A ramified prime divides the different ideal, which is
+nonzero and so, being an ideal of a Dedekind domain, has finitely many divisors. -/
 theorem finite_compl_unramifiedLocus : (unramifiedLocus A B)ᶜ.Finite := by
   refine Set.Finite.of_finite_image (f := PrimeSpectrum.asIdeal) ?_
     fun _ _ _ _ h => PrimeSpectrum.ext h

--- a/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
+++ b/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.DedekindDomain.Different
+public import Mathlib.RingTheory.DedekindDomain.Factorization
 public import Mathlib.RingTheory.Unramified.Locus
-public import Mathlib.RingTheory.UniqueFactorizationDomain.Finite
+import Mathlib.RingTheory.DedekindDomain.Different
 
 /-!
 # A separable extension of Dedekind domains ramifies at only finitely many primes
@@ -47,9 +47,8 @@ along the way, including `differentIdeal_ne_bot`, which Mathlib now proves; thos
 with them the tower. The ramification locus is named by Mathlib's `Algebra.unramifiedLocus` and
 the criterion by Mathlib's `Algebra.IsUnramifiedAt`, in place of the source's hand-rolled
 `ramifiedUnderLocus` and its `Ideal.ramificationIdx _ _ ≠ 1` spelling. The source's
-divisor-finiteness step is a specialisation of Mathlib's
-`UniqueFactorizationMonoid.fintypeSubtypeDvd` with no consumer of its own, so it stays inside the
-one proof rather than becoming public API. Sixteen declarations become one.
+divisor-finiteness step is Mathlib's `Ideal.finite_factors`, so it neither is rebuilt from the
+`UniqueFactorizationMonoid` plumbing nor becomes public API here. Sixteen declarations become one.
 -/
 
 public section
@@ -68,15 +67,18 @@ variable (A B : Type*) [CommRing A] [IsDedekindDomain A] [CommRing B] [Algebra A
 complement of `Algebra.unramifiedLocus` is finite. A ramified prime divides the different ideal,
 which is nonzero and so, being an ideal of a Dedekind domain, has finitely many divisors. -/
 theorem finite_compl_unramifiedLocus : (unramifiedLocus A B)ᶜ.Finite := by
-  have hdvd : {P : Ideal B | P ∣ differentIdeal A B}.Finite :=
-    Set.finite_coe_iff.mp (@Finite.of_fintype _ (UniqueFactorizationMonoid.fintypeSubtypeDvd _
-      (differentIdeal_ne_bot (A := A) (B := B))))
   refine Set.Finite.of_finite_image (f := PrimeSpectrum.asIdeal) ?_
     fun _ _ _ _ h => PrimeSpectrum.ext h
-  refine hdvd.subset ?_
+  refine ((Ideal.finite_factors (differentIdeal_ne_bot (A := A) (B := B))).image
+    _root_.IsDedekindDomain.HeightOneSpectrum.asIdeal).subset ?_
   rintro _ ⟨p, hp, rfl⟩
   have := p.isPrime
-  exact dvd_differentIdeal_iff.mpr hp
+  have hdvd : p.asIdeal ∣ differentIdeal A B := dvd_differentIdeal_iff.mpr hp
+  -- a ramified prime is nonzero: `⊥` divides only `⊥`, and the different ideal is not `⊥`
+  have hbot : p.asIdeal ≠ ⊥ := fun h =>
+    differentIdeal_ne_bot (A := A) (B := B) (eq_bot_iff.mpr (h ▸ Ideal.le_of_dvd hdvd))
+  exact ⟨_root_.IsDedekindDomain.HeightOneSpectrum.ofPrime
+    (Ideal.prime_of_isPrime hbot p.isPrime), hdvd, rfl⟩
 
 end Algebra
 

--- a/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
+++ b/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.FieldTheory.SeparableDegree
+public import Mathlib.FieldTheory.Separable
 public import Mathlib.RingTheory.DedekindDomain.Basic
 public import Mathlib.RingTheory.Unramified.Locus
 import Mathlib.RingTheory.DedekindDomain.Different
@@ -75,7 +75,7 @@ theorem finite_compl_unramifiedLocus : (unramifiedLocus A B)ᶜ.Finite := by
   refine ((Ideal.finite_factors (differentIdeal_ne_bot (A := A) (B := B))).image
     _root_.IsDedekindDomain.HeightOneSpectrum.asIdeal).subset ?_
   rintro _ ⟨p, hp, rfl⟩
-  have := p.isPrime
+  have : p.asIdeal.IsPrime := p.isPrime
   have hdvd : p.asIdeal ∣ differentIdeal A B := dvd_differentIdeal_iff.mpr hp
   -- a ramified prime is nonzero: `⊥` divides only `⊥`, and the different ideal is not `⊥`
   have hbot : p.asIdeal ≠ ⊥ := fun h =>

--- a/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
+++ b/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.Different
+public import Mathlib.RingTheory.Unramified.Locus
+public import Mathlib.RingTheory.UniqueFactorizationDomain.Finite
+
+/-!
+# A separable extension of Dedekind domains ramifies at only finitely many primes
+
+Let `B` be a Dedekind domain, module-finite and torsion-free over a Dedekind domain `A`, with the
+extension of fraction fields separable. Mathlib's `Algebra.unramifiedLocus A B` is the set of
+primes of `B` at which `B` is unramified over `A`, and Mathlib knows it is open. Here it is shown
+that its complement — the ramification locus — is *finite*.
+
+The tool is the different ideal. Mathlib's `not_dvd_differentIdeal_iff` says a prime is unramified
+exactly when it does not divide `differentIdeal A B`, and `differentIdeal_ne_bot` says that ideal
+is nonzero; a nonzero ideal of a Dedekind domain has only finitely many divisors.
+
+## Main results
+
+* `Algebra.finite_setOf_dvd_differentIdeal`: the different ideal has finitely many divisors.
+* `Algebra.finite_compl_unramifiedLocus`: the ramification locus is finite.
+
+Stated over Dedekind domains directly rather than in an AKLB tower: no ambient fraction fields
+`K` and `L` and no `IsIntegralClosure B A L` are needed, since the separability hypothesis can be
+carried by `FractionRing A` and `FractionRing B` themselves, which is the form
+`not_dvd_differentIdeal_iff` already takes.
+
+This supports Layer 1 of `TauCetiRoadmap/EllipticCurves/README.md`, whose
+**separable-implies-unramified** milestone asks that a separable isogeny have `e_w = 1` at *every*
+place, "by translation-invariance of the ramification locus". That argument needs the ramification
+locus to be finite before translation-invariance can force it to be empty; the finiteness is what
+this file supplies. Layer 2's `E[N]` and Layer 3's Hasse kernel count consume that milestone.
+
+## Provenance
+
+Ported from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by
+that roadmap at `dev/hasse-weil @ 94f6d72eeea3`), `HasseWeil/Curves/RamificationFinite.lean`,
+declarations `finite_setOf_dvd_differentIdeal`, `finite_setOf_ramificationIdx_ne_one` and
+`finite_setOf_under_ramified`.
+
+Changes from the source. The source works in an AKLB tower and rebuilds the standard instances
+along the way, including `differentIdeal_ne_bot`, which Mathlib now proves; those are dropped, and
+with them the tower. The ramification locus is named by Mathlib's `Algebra.unramifiedLocus` and
+the criterion by Mathlib's `Algebra.IsUnramifiedAt`, in place of the source's hand-rolled
+`ramifiedUnderLocus` and its `Ideal.ramificationIdx _ _ ≠ 1` spelling. Sixteen declarations become
+two.
+-/
+
+public section
+
+open scoped nonZeroDivisors
+
+attribute [local instance] FractionRing.liftAlgebra FractionRing.isScalarTower_liftAlgebra
+
+namespace Algebra
+
+variable (A B : Type*) [CommRing A] [IsDedekindDomain A] [CommRing B] [Algebra A B]
+  [IsDedekindDomain B] [Module.IsTorsionFree A B] [Module.Finite A B]
+  [Algebra.IsSeparable (FractionRing A) (FractionRing B)]
+
+/-- **The different ideal has only finitely many divisors**, being a nonzero ideal of a Dedekind
+domain. -/
+theorem finite_setOf_dvd_differentIdeal : {P : Ideal B | P ∣ differentIdeal A B}.Finite := by
+  have h : Finite {P : Ideal B // P ∣ differentIdeal A B} :=
+    @Finite.of_fintype _ (UniqueFactorizationMonoid.fintypeSubtypeDvd _
+      (differentIdeal_ne_bot (A := A) (B := B)))
+  exact Set.finite_coe_iff.mp h
+
+/-- **A separable extension of Dedekind domains ramifies at only finitely many primes**: the
+complement of `Algebra.unramifiedLocus` is finite. A ramified prime divides the different ideal,
+which is nonzero and so has finitely many divisors. -/
+theorem finite_compl_unramifiedLocus : (unramifiedLocus A B)ᶜ.Finite := by
+  refine Set.Finite.of_finite_image (f := PrimeSpectrum.asIdeal) ?_
+    fun _ _ _ _ h => PrimeSpectrum.ext h
+  refine (finite_setOf_dvd_differentIdeal A B).subset ?_
+  rintro _ ⟨p, hp, rfl⟩
+  have := p.isPrime
+  exact dvd_differentIdeal_iff.mpr hp
+
+end Algebra
+
+end


### PR DESCRIPTION
Let `B` be a Dedekind domain, module-finite and torsion-free over a Dedekind domain `A`, with the extension of fraction fields separable. Mathlib's `Algebra.unramifiedLocus A B` is the set of primes of `B` at which `B` is unramified over `A`, and Mathlib proves it is open (`Algebra.isOpen_unramifiedLocus`). This adds that its complement — the ramification locus — is **finite**.

```lean
theorem Algebra.finite_compl_unramifiedLocus : (Algebra.unramifiedLocus A B)ᶜ.Finite
```

The tool is the different ideal. Mathlib's `not_dvd_differentIdeal_iff` says a prime is unramified exactly when it does not divide `differentIdeal A B`, and `differentIdeal_ne_bot` says that ideal is nonzero; a nonzero ideal of a Dedekind domain has finitely many prime divisors (`Ideal.finite_factors`). The ramification locus is then the preimage of a finite set of ideals under the injective `PrimeSpectrum.asIdeal`.

## Roadmap

Layer 1 of `TauCetiRoadmap/EllipticCurves/README.md`, the **separable-implies-unramified** milestone: "a separable isogeny has `e_w = 1` at *every* place (étale, by translation-invariance of the ramification locus), so `#fibre = deg` over a separably closed field". That argument needs the ramification locus to be finite before translation-invariance can force it to be empty; the finiteness is what this file supplies. The roadmap names the consumers explicitly — "`E[N]` (Layer 2) and the Hasse kernel count (Layer 3) consume exactly this" — and names `Foundation/EC/MulByIntUnramified.lean` as "the `e = 1` input, citing AEC III.4.10(c)".

## Mathlib absence, compiled

The statement, and the divisor-finiteness step it rests on, were probed against the pin with `exact?` in the full AKLB context; both failed to close:

```
example : (Algebra.unramifiedLocus A B)ᶜ.Finite := by exact?
example : {P : Ideal B | P ∣ differentIdeal A B}.Finite := by exact?
```

Mathlib has `Algebra.unramifiedLocus`, `Algebra.isOpen_unramifiedLocus` and `unramifiedLocus_eq_compl_support`, but no finiteness statement; a grep across `Mathlib/NumberTheory` and `Mathlib/RingTheory` for a finiteness-of-ramified-primes result returns nothing.

## Provenance

Ported from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by that roadmap at `dev/hasse-weil @ 513e83879e2f`), `HasseWeil/Curves/RamificationFinite.lean`, declarations `finite_setOf_dvd_differentIdeal`, `finite_setOf_ramificationIdx_ne_one` and `finite_setOf_under_ramified`.

Changes from the source. The source works in an AKLB tower `A ⊆ K ⊆ L ⊇ B` with `[IsIntegralClosure B A L]` and rebuilds the standard instances along the way — `faithfulSMul`, `isDomain`, `isDedekindDomain`, `module_finite`, `isFractionRing`, `isTorsionFree`, `isSeparable_fractionRing` — including `differentIdeal_ne_bot`, which Mathlib now proves directly. All of those are dropped, and with them the tower: the separability hypothesis is carried by `FractionRing A` and `FractionRing B`, which is the form `not_dvd_differentIdeal_iff` already takes. The ramification locus is named by Mathlib's `Algebra.unramifiedLocus` and the criterion by `Algebra.IsUnramifiedAt`, in place of the source's hand-rolled `ramifiedUnderLocus` and its `Ideal.ramificationIdx _ _ ≠ 1` spelling — which also sidesteps a `ramificationIdx` signature difference between the source's toolchain and this repository's pin. The source's divisor-finiteness step is Mathlib's `Ideal.finite_factors`, so it is neither rebuilt from the `UniqueFactorizationMonoid` plumbing nor exported here. Only `Mathlib.RingTheory.Unramified.Locus` and the two modules naming the statement's typeclasses are public imports; the factorization and different-ideal modules are proof-only and imported privately. Sixteen declarations become one.

## Gates

`lake build`, `lake exe axioms` (allowlist clean), `lake exe module-system` and `scripts/lint-env.sh` all pass.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"ramificationlocus"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
