### PR TITLE
docs(CliffordAlgebra): index the associated-graded file

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -21,6 +21,34 @@ It advances the Layer 0 associated-graded-algebra target in the
 
 Its graded-algebra packaging adapts the pattern in Mathlib's
 [`TensorPower` construction](https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/LinearAlgebra/TensorPower/Basic.lean).
+
+## Main definitions
+
+* `TauCeti.CliffordAlgebra.filtrationAssociatedGraded Q`: the direct sum
+  `⨁ k, FiltrationGradedPiece Q k` of the homogeneous pieces.
+* `TauCeti.CliffordAlgebra.filtrationGradedMul`: the product of two homogeneous pieces, induced by
+  Clifford multiplication through `filtration_mul`.
+* `TauCeti.CliffordAlgebra.filtrationGradedOne` and
+  `TauCeti.CliffordAlgebra.filtrationGradedAlgebraMap₀`: the degree-zero unit and the degree-zero
+  image of a scalar.
+
+## Main results
+
+* The graded structure instances assembling those pieces:
+  `TauCeti.CliffordAlgebra.filtrationGradedGOne`, `filtrationGradedGMul`,
+  `filtrationGradedGMonoid`, `filtrationGradedGRing`, `filtrationGradedGSemiring` and
+  `filtrationGradedGAlgebra`, culminating in
+  `TauCeti.CliffordAlgebra.filtrationAssociatedGradedRing`, the ring structure on the direct sum.
+
+## Implementation notes
+
+`filtrationGradedGSemiring` and `filtrationAssociatedGradedRing` are stated explicitly rather than
+left to instance search. `DirectSum.GRing` is declared over `[∀ i, AddCommGroup (A i)]`, so
+`DirectSum.GRing.toGSemiring` supplies the pointwise `AddCommMonoid` through
+`AddCommGroup.toAddCommMonoid`, which does not match the one instance search finds directly for
+`FiltrationGradedPiece`; without these two declarations neither
+`DirectSum.GSemiring (FiltrationGradedPiece Q)` nor `Ring (filtrationAssociatedGraded Q)` is
+synthesizable.
 -/
 
 public section


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR gives `AssociatedGraded.lean` the "Main definitions" and "Main results" sections it was missing. It exports `filtrationAssociatedGraded`, `filtrationGradedMul`, `filtrationGradedOne`, `filtrationGradedAlgebraMap₀` and seven instances, and was the only file in the Clifford group with no index at all, so nothing told a reader which of those are the endpoints and which are scaffolding.

It also adds an "Implementation notes" section recording something I got wrong and had to establish by experiment, so the next reader does not repeat it. `filtrationGradedGSemiring` and `filtrationAssociatedGradedRing` look redundant: `DirectSum.GRing extends GSemiring`, and `DirectSum.ring` applies to any `GRing`, so instance search ought to find both. It does not. `DirectSum.GRing` is declared over `[∀ i, AddCommGroup (A i)]`, so `GRing.toGSemiring` supplies the pointwise `AddCommMonoid` through `AddCommGroup.toAddCommMonoid`, and that term does not match the one instance search finds directly for `FiltrationGradedPiece`. Deleting either declaration leaves `DirectSum.GSemiring (FiltrationGradedPiece Q)` and `Ring (filtrationAssociatedGraded Q)` unsynthesizable, which I confirmed with `#synth` after removing each in turn.

That is worth writing down because the two declarations are written in a shape that reads like code smell — an explicit `@DirectSum.GRing.toGSemiring` with every argument spelled out, and a `letI : ∀ k, AddCommGroup … := fun _ => inferInstance` — when they are in fact working around the diamond.

Documentation only; no declaration changes. Full build with `--iofail`, axiom audit and environment lint pass.

🤖 Prepared with Claude Code