### PR TITLE
feat: add multiplicative Jordan decomposition

### DIFF
--- a/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
@@ -52,7 +52,9 @@ open Module
 
 universe u v
 
-variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+section Definitions
+
+variable {K : Type u} {V : Type v} [CommRing K] [AddCommGroup V] [Module K V]
 
 /-- A linear automorphism is semisimple if its underlying linear endomorphism is semisimple. -/
 def IsSemisimple (g : GeneralLinearGroup K V) : Prop :=
@@ -64,7 +66,8 @@ def IsUnipotent (g : GeneralLinearGroup K V) : Prop :=
 
 /-- The identity automorphism is semisimple. -/
 @[simp]
-theorem isSemisimple_one : IsSemisimple (1 : GeneralLinearGroup K V) := by
+theorem isSemisimple_one [IsSemisimpleModule K V] :
+    IsSemisimple (1 : GeneralLinearGroup K V) := by
   unfold IsSemisimple
   exact Module.End.isSemisimple_id
 
@@ -74,9 +77,12 @@ theorem isUnipotent_one : IsUnipotent (1 : GeneralLinearGroup K V) := by
   unfold IsUnipotent
   simp
 
+end Definitions
+
 section PerfectField
 
-variable [PerfectField K] [FiniteDimensional K V]
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+  [PerfectField K] [FiniteDimensional K V]
 
 private theorem exists_jordanDecomposition (g : GeneralLinearGroup K V) :
     ∃ p : GeneralLinearGroup K V × GeneralLinearGroup K V,
@@ -154,8 +160,7 @@ theorem isSemisimple_isUnipotent_unique
     (hs₂ : IsSemisimple s₂) (hu₂ : IsUnipotent u₂) (hc₂ : Commute s₂ u₂)
     (h : s₁ * u₁ = s₂ * u₂) :
     s₁ = s₂ ∧ u₁ = u₂ := by
-  change Module.End.IsSemisimple (s₁ : End K V) at hs₁
-  change Module.End.IsSemisimple (s₂ : End K V) at hs₂
+  unfold IsSemisimple at hs₁ hs₂
   have hadd : additiveNilpotentPart s₁ u₁ + (s₁ : End K V) =
       additiveNilpotentPart s₂ u₂ + (s₂ : End K V) := by
     rw [additiveNilpotentPart_add, additiveNilpotentPart_add, h]

--- a/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
@@ -1,0 +1,282 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.JordanChevalley
+
+/-!
+# Multiplicative Jordan–Chevalley decomposition
+
+Over a perfect field, every linear automorphism of a finite-dimensional vector space factors
+uniquely as the product of a semisimple automorphism and a unipotent automorphism that commute.
+This is the multiplicative Jordan–Chevalley decomposition.
+
+The construction converts Mathlib's additive decomposition `f = n + s` into
+`f = s * (1 + s⁻¹n)`.  The semisimple summand `s` is invertible because it differs from the
+invertible map `f` by a commuting nilpotent map.  Uniqueness is reduced in the opposite direction
+to `Module.End.isNilpotent_isSemisimple_unique`.
+
+This is the general-linear-group case of the Jordan decomposition requested in Layer 4 of the
+ReductiveGroups roadmap.  It is the linear-algebra input for transporting Jordan decompositions
+through faithful representations of affine algebraic groups.
+
+## Main declarations
+
+* `TauCeti.GeneralLinearGroup.IsSemisimple`: a linear automorphism is semisimple when its
+  underlying endomorphism is semisimple.
+* `TauCeti.GeneralLinearGroup.IsUnipotent`: a linear automorphism is unipotent when its
+  difference from the identity is nilpotent.
+* `TauCeti.GeneralLinearGroup.jordanDecomposition`: the canonical commuting semisimple and
+  unipotent factors.
+* `TauCeti.GeneralLinearGroup.eq_jordanDecomposition_iff`: the existence and uniqueness
+  characterization of those factors.
+
+## References
+
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+* `Mathlib.LinearAlgebra.JordanChevalley`, whose additive existence and uniqueness theorems are
+  used here.
+-/
+
+public section
+
+namespace TauCeti
+
+open LinearMap
+
+namespace GeneralLinearGroup
+
+open Module
+
+universe u v
+
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+
+/-- A linear automorphism is semisimple if its underlying linear endomorphism is semisimple. -/
+def IsSemisimple (g : GeneralLinearGroup K V) : Prop :=
+  Module.End.IsSemisimple (g : End K V)
+
+/-- A linear automorphism is unipotent if its difference from the identity is nilpotent. -/
+def IsUnipotent (g : GeneralLinearGroup K V) : Prop :=
+  _root_.IsNilpotent ((g : End K V) - 1)
+
+/-- The semisimplicity predicate is read on the underlying endomorphism. -/
+lemma isSemisimple_iff (g : GeneralLinearGroup K V) :
+    IsSemisimple g ↔ Module.End.IsSemisimple (g : End K V) :=
+  Iff.rfl
+
+/-- The unipotence predicate is nilpotence of the difference from the identity. -/
+lemma isUnipotent_iff (g : GeneralLinearGroup K V) :
+    IsUnipotent g ↔ _root_.IsNilpotent ((g : End K V) - 1) :=
+  Iff.rfl
+
+/-- The identity automorphism is semisimple. -/
+@[simp]
+theorem isSemisimple_one : IsSemisimple (1 : GeneralLinearGroup K V) := by
+  rw [isSemisimple_iff]
+  exact Module.End.isSemisimple_id
+
+/-- The identity automorphism is unipotent. -/
+@[simp]
+theorem isUnipotent_one : IsUnipotent (1 : GeneralLinearGroup K V) := by
+  rw [isUnipotent_iff]
+  simp
+
+section PerfectField
+
+variable [PerfectField K] [FiniteDimensional K V]
+
+private theorem exists_jordanDecomposition (g : GeneralLinearGroup K V) :
+    ∃ p : GeneralLinearGroup K V × GeneralLinearGroup K V,
+      IsSemisimple p.1 ∧ IsUnipotent p.2 ∧ Commute p.1 p.2 ∧ g = p.1 * p.2 := by
+  let f : End K V := g
+  obtain ⟨n, hn_mem, s, hs_mem, hn, hs, hf⟩ := f.exists_isNilpotent_isSemisimple
+  have hfn : Commute f n := Algebra.commute_of_mem_adjoin_self hn_mem
+  have hfs : Commute f s := Algebra.commute_of_mem_adjoin_self hs_mem
+  have hns : Commute n s :=
+    Algebra.commute_of_mem_adjoin_singleton_of_commute hs_mem hfn.symm
+  have hs_unit : _root_.IsUnit s := by
+    have hs_eq : s = f + -n := by rw [hf]; abel
+    rw [hs_eq]
+    exact hn.neg.isUnit_add_left_of_commute g.isUnit hfn.symm.neg_left
+  let s' : GeneralLinearGroup K V := hs_unit.unit
+  let u' : GeneralLinearGroup K V := s'⁻¹ * g
+  have hs'_val : (s' : End K V) = s := hs_unit.unit_spec
+  have hs'n : Commute ((s'⁻¹ : GeneralLinearGroup K V) : End K V) n := by
+    apply Commute.units_inv_left
+    simpa only [hs'_val] using hns.symm
+  have hu'_sub : (u' : End K V) - 1 =
+      ((s'⁻¹ : GeneralLinearGroup K V) : End K V) * n := by
+    dsimp only [u']
+    rw [Units.val_mul]
+    -- Expose the named endomorphism `f` beneath the coercions from the two units.
+    change ((s'⁻¹ : GeneralLinearGroup K V) : End K V) * f - 1 = _
+    rw [hf, mul_add, ← hs'_val]
+    simp
+  have hs'g : Commute s' g := by
+    apply Commute.units_of_val
+    simpa only [hs'_val] using hfs.symm
+  refine ⟨⟨s', u'⟩, ?_, ?_, ?_, ?_⟩
+  · rw [isSemisimple_iff, hs'_val]
+    exact hs
+  · rw [isUnipotent_iff, hu'_sub]
+    exact hs'n.isNilpotent_mul_left hn
+  · exact (Commute.refl s').inv_right.mul_right hs'g
+  · dsimp only [u']
+    simp
+
+private def additiveNilpotentPart
+    (s u : GeneralLinearGroup K V) : End K V :=
+  (s : End K V) * ((u : End K V) - 1)
+
+omit [PerfectField K] [FiniteDimensional K V] in
+private theorem additiveNilpotentPart_isNilpotent
+    {s u : GeneralLinearGroup K V} (hu : IsUnipotent u) (hsu : Commute s u) :
+    _root_.IsNilpotent (additiveNilpotentPart s u) := by
+  rw [isUnipotent_iff] at hu
+  apply (hsu.units_val.sub_right (Commute.one_right _)).isNilpotent_mul_left
+  exact hu
+
+omit [PerfectField K] [FiniteDimensional K V] in
+private theorem additiveNilpotentPart_add
+    (s u : GeneralLinearGroup K V) :
+    additiveNilpotentPart s u + (s : End K V) = (s * u : GeneralLinearGroup K V) := by
+  dsimp only [additiveNilpotentPart]
+  rw [Units.val_mul]
+  rw [mul_sub, mul_one, sub_add_cancel]
+
+omit [PerfectField K] [FiniteDimensional K V] in
+private theorem additiveNilpotentPart_commute
+    {s u : GeneralLinearGroup K V} (hsu : Commute s u) :
+    Commute (additiveNilpotentPart s u) (s : End K V) := by
+  apply (Commute.refl (s : End K V)).mul_left
+  exact (hsu.units_val.sub_right (Commute.one_right _)).symm
+
+/-- Two commuting semisimple–unipotent factorizations of the same linear automorphism have the
+same factors. -/
+theorem isSemisimple_isUnipotent_unique
+    {s₁ u₁ s₂ u₂ : GeneralLinearGroup K V}
+    (hs₁ : IsSemisimple s₁) (hu₁ : IsUnipotent u₁) (hc₁ : Commute s₁ u₁)
+    (hs₂ : IsSemisimple s₂) (hu₂ : IsUnipotent u₂) (hc₂ : Commute s₂ u₂)
+    (h : s₁ * u₁ = s₂ * u₂) :
+    s₁ = s₂ ∧ u₁ = u₂ := by
+  have hadd : additiveNilpotentPart s₁ u₁ + (s₁ : End K V) =
+      additiveNilpotentPart s₂ u₂ + (s₂ : End K V) := by
+    rw [additiveNilpotentPart_add, additiveNilpotentPart_add, h]
+  have hs : (s₁ : End K V) = (s₂ : End K V) :=
+    (Module.End.isNilpotent_isSemisimple_unique
+      (additiveNilpotentPart_isNilpotent hu₁ hc₁) ((isSemisimple_iff s₁).mp hs₁)
+      (additiveNilpotentPart_isNilpotent hu₂ hc₂) ((isSemisimple_iff s₂).mp hs₂)
+      (additiveNilpotentPart_commute hc₁) (additiveNilpotentPart_commute hc₂) hadd).2
+  have hs' : s₁ = s₂ := Units.ext hs
+  subst s₂
+  exact ⟨rfl, mul_left_cancel h⟩
+
+/-- The canonical multiplicative Jordan–Chevalley decomposition of a linear automorphism.  The
+first factor is semisimple, the second is unipotent, and the two factors commute. -/
+noncomputable def jordanDecomposition (g : GeneralLinearGroup K V) :
+    GeneralLinearGroup K V × GeneralLinearGroup K V :=
+  Classical.choose (exists_jordanDecomposition g)
+
+/-- The canonical Jordan decomposition has the defining semisimple, unipotent, commutation, and
+product properties. -/
+theorem jordanDecomposition_spec (g : GeneralLinearGroup K V) :
+    IsSemisimple (jordanDecomposition g).1 ∧
+      IsUnipotent (jordanDecomposition g).2 ∧
+      Commute (jordanDecomposition g).1 (jordanDecomposition g).2 ∧
+      g = (jordanDecomposition g).1 * (jordanDecomposition g).2 :=
+  Classical.choose_spec (exists_jordanDecomposition g)
+
+/-- A pair is the canonical Jordan decomposition exactly when it is a commuting
+semisimple–unipotent factorization. -/
+theorem eq_jordanDecomposition_iff (g s u : GeneralLinearGroup K V) :
+    (s, u) = jordanDecomposition g ↔
+      IsSemisimple s ∧ IsUnipotent u ∧ Commute s u ∧ g = s * u := by
+  constructor
+  · intro h
+    have hs : s = (jordanDecomposition g).1 := congrArg Prod.fst h
+    have hu : u = (jordanDecomposition g).2 := congrArg Prod.snd h
+    subst s
+    subst u
+    exact jordanDecomposition_spec g
+  · intro h
+    have h_unique := isSemisimple_isUnipotent_unique h.1 h.2.1 h.2.2.1
+      (jordanDecomposition_spec g).1 (jordanDecomposition_spec g).2.1
+      (jordanDecomposition_spec g).2.2.1
+      (h.2.2.2.symm.trans (jordanDecomposition_spec g).2.2.2)
+    exact Prod.ext h_unique.1 h_unique.2
+
+/-- The semisimple factor of the multiplicative Jordan–Chevalley decomposition. -/
+noncomputable def semisimplePart (g : GeneralLinearGroup K V) : GeneralLinearGroup K V :=
+  (jordanDecomposition g).1
+
+/-- The unipotent factor of the multiplicative Jordan–Chevalley decomposition. -/
+noncomputable def unipotentPart (g : GeneralLinearGroup K V) : GeneralLinearGroup K V :=
+  (jordanDecomposition g).2
+
+/-- The semisimple factor is semisimple. -/
+theorem isSemisimple_semisimplePart (g : GeneralLinearGroup K V) :
+    IsSemisimple (semisimplePart g) :=
+  (jordanDecomposition_spec g).1
+
+/-- The unipotent factor is unipotent. -/
+theorem isUnipotent_unipotentPart (g : GeneralLinearGroup K V) :
+    IsUnipotent (unipotentPart g) :=
+  (jordanDecomposition_spec g).2.1
+
+/-- The semisimple and unipotent factors commute. -/
+theorem commute_semisimplePart_unipotentPart (g : GeneralLinearGroup K V) :
+    Commute (semisimplePart g) (unipotentPart g) :=
+  (jordanDecomposition_spec g).2.2.1
+
+/-- Multiplying the semisimple and unipotent factors recovers the original automorphism. -/
+@[simp]
+theorem semisimplePart_mul_unipotentPart (g : GeneralLinearGroup K V) :
+    semisimplePart g * unipotentPart g = g :=
+  (jordanDecomposition_spec g).2.2.2.symm
+
+/-- A semisimple automorphism is its own semisimple part. -/
+@[simp]
+theorem semisimplePart_eq_self {g : GeneralLinearGroup K V} (hg : IsSemisimple g) :
+    semisimplePart g = g :=
+  (isSemisimple_isUnipotent_unique
+    (isSemisimple_semisimplePart g) (isUnipotent_unipotentPart g)
+    (commute_semisimplePart_unipotentPart g) hg isUnipotent_one (Commute.one_right g)
+    (by simp)).1
+
+/-- A semisimple automorphism has trivial unipotent part. -/
+@[simp]
+theorem unipotentPart_eq_one_of_isSemisimple
+    {g : GeneralLinearGroup K V} (hg : IsSemisimple g) :
+    unipotentPart g = 1 :=
+  (isSemisimple_isUnipotent_unique
+    (isSemisimple_semisimplePart g) (isUnipotent_unipotentPart g)
+    (commute_semisimplePart_unipotentPart g) hg isUnipotent_one (Commute.one_right g)
+    (by simp)).2
+
+/-- A unipotent automorphism has trivial semisimple part. -/
+@[simp]
+theorem semisimplePart_eq_one_of_isUnipotent
+    {g : GeneralLinearGroup K V} (hg : IsUnipotent g) :
+    semisimplePart g = 1 :=
+  (isSemisimple_isUnipotent_unique
+    (isSemisimple_semisimplePart g) (isUnipotent_unipotentPart g)
+    (commute_semisimplePart_unipotentPart g) isSemisimple_one hg (Commute.one_left g)
+    (by simp)).1
+
+/-- A unipotent automorphism is its own unipotent part. -/
+@[simp]
+theorem unipotentPart_eq_self {g : GeneralLinearGroup K V} (hg : IsUnipotent g) :
+    unipotentPart g = g :=
+  (isSemisimple_isUnipotent_unique
+    (isSemisimple_semisimplePart g) (isUnipotent_unipotentPart g)
+    (commute_semisimplePart_unipotentPart g) isSemisimple_one hg (Commute.one_left g)
+    (by simp)).2
+
+end PerfectField
+
+end GeneralLinearGroup
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
@@ -62,26 +62,16 @@ def IsSemisimple (g : GeneralLinearGroup K V) : Prop :=
 def IsUnipotent (g : GeneralLinearGroup K V) : Prop :=
   _root_.IsNilpotent ((g : End K V) - 1)
 
-/-- The semisimplicity predicate is read on the underlying endomorphism. -/
-lemma isSemisimple_iff (g : GeneralLinearGroup K V) :
-    IsSemisimple g ↔ Module.End.IsSemisimple (g : End K V) :=
-  Iff.rfl
-
-/-- The unipotence predicate is nilpotence of the difference from the identity. -/
-lemma isUnipotent_iff (g : GeneralLinearGroup K V) :
-    IsUnipotent g ↔ _root_.IsNilpotent ((g : End K V) - 1) :=
-  Iff.rfl
-
 /-- The identity automorphism is semisimple. -/
 @[simp]
 theorem isSemisimple_one : IsSemisimple (1 : GeneralLinearGroup K V) := by
-  rw [isSemisimple_iff]
+  unfold IsSemisimple
   exact Module.End.isSemisimple_id
 
 /-- The identity automorphism is unipotent. -/
 @[simp]
 theorem isUnipotent_one : IsUnipotent (1 : GeneralLinearGroup K V) := by
-  rw [isUnipotent_iff]
+  unfold IsUnipotent
   simp
 
 section PerfectField
@@ -119,9 +109,11 @@ private theorem exists_jordanDecomposition (g : GeneralLinearGroup K V) :
     apply Commute.units_of_val
     simpa only [hs'_val] using hfs.symm
   refine ⟨⟨s', u'⟩, ?_, ?_, ?_, ?_⟩
-  · rw [isSemisimple_iff, hs'_val]
+  · unfold IsSemisimple
+    rw [hs'_val]
     exact hs
-  · rw [isUnipotent_iff, hu'_sub]
+  · unfold IsUnipotent
+    rw [hu'_sub]
     exact hs'n.isNilpotent_mul_left hn
   · exact (Commute.refl s').inv_right.mul_right hs'g
   · dsimp only [u']
@@ -135,7 +127,7 @@ omit [PerfectField K] [FiniteDimensional K V] in
 private theorem additiveNilpotentPart_isNilpotent
     {s u : GeneralLinearGroup K V} (hu : IsUnipotent u) (hsu : Commute s u) :
     _root_.IsNilpotent (additiveNilpotentPart s u) := by
-  rw [isUnipotent_iff] at hu
+  unfold IsUnipotent at hu
   apply (hsu.units_val.sub_right (Commute.one_right _)).isNilpotent_mul_left
   exact hu
 
@@ -162,13 +154,15 @@ theorem isSemisimple_isUnipotent_unique
     (hs₂ : IsSemisimple s₂) (hu₂ : IsUnipotent u₂) (hc₂ : Commute s₂ u₂)
     (h : s₁ * u₁ = s₂ * u₂) :
     s₁ = s₂ ∧ u₁ = u₂ := by
+  change Module.End.IsSemisimple (s₁ : End K V) at hs₁
+  change Module.End.IsSemisimple (s₂ : End K V) at hs₂
   have hadd : additiveNilpotentPart s₁ u₁ + (s₁ : End K V) =
       additiveNilpotentPart s₂ u₂ + (s₂ : End K V) := by
     rw [additiveNilpotentPart_add, additiveNilpotentPart_add, h]
   have hs : (s₁ : End K V) = (s₂ : End K V) :=
     (Module.End.isNilpotent_isSemisimple_unique
-      (additiveNilpotentPart_isNilpotent hu₁ hc₁) ((isSemisimple_iff s₁).mp hs₁)
-      (additiveNilpotentPart_isNilpotent hu₂ hc₂) ((isSemisimple_iff s₂).mp hs₂)
+      (additiveNilpotentPart_isNilpotent hu₁ hc₁) hs₁
+      (additiveNilpotentPart_isNilpotent hu₂ hc₂) hs₂
       (additiveNilpotentPart_commute hc₁) (additiveNilpotentPart_commute hc₂) hadd).2
   have hs' : s₁ = s₂ := Units.ext hs
   subst s₂


### PR DESCRIPTION
This PR equips the general linear group with its multiplicative Jordan–Chevalley decomposition: over a perfect field, define the canonical commuting semisimple and unipotent factors of every finite-dimensional linear automorphism, prove that their product is the original automorphism, and prove that every other such factorization has the same factors.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4, milestone “Jordan decomposition of elements into semisimple and unipotent parts” by completing the general-linear-group theorem that the merged faithful embedding infrastructure can consume. It is the most effective current step because Mathlib already supplies the additive Jordan–Chevalley theorem and Tau Ceti now has the finite-type embedding theorem, while the active ReductiveGroups PRs cover finite-type synchronization, Tannakian packaging, descent, and separate tangent/adjoint refinements. After this PR, the milestone still needs independence from the chosen faithful representation, transport to arbitrary affine algebraic groups after geometric base change, and functoriality under representations.

The proof follows T. A. Springer, *Linear Algebraic Groups*, §2.4, and reuses Mathlib’s `Module.End.exists_isNilpotent_isSemisimple` and `Module.End.isNilpotent_isSemisimple_unique`. It converts `f = n + s` into `f = s · (1 + s⁻¹n)`, proves the semisimple summand is invertible because it differs from `f` by a commuting nilpotent, and converts competing multiplicative decompositions back to additive ones for uniqueness. No Mathlib implementation is vendored.

Add `TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean` (282 lines) with the semisimple and unipotent predicates, the canonical decomposition and its uniqueness characterization, and simplification laws for already semisimple or unipotent automorphisms.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"multiplicative-jordan-decomposition"}-->

🤖 Prepared with Codex
