### PR TITLE
refactor(NumberField): reuse the general quadratic-extension lemmas

### DIFF
--- a/TauCeti/NumberTheory/NumberField/Internal/QuadraticIntegralBasis.lean
+++ b/TauCeti/NumberTheory/NumberField/Internal/QuadraticIntegralBasis.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.NumberTheory.NumberField.Basic
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 public import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
+public import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
 
 /-!
 # The `{1, x}` rational basis of algebraic integers in a quadratic number field
@@ -32,20 +33,9 @@ theorem exists_basis_eq_one_self_of_notMem_range_of_isIntegral {K : Type*} [Fiel
     (hx : x ∉ (algebraMap ℚ K).range) (hxint : IsIntegral ℤ x) :
     ∃ b : Module.Basis (Fin 2) ℚ K, ⇑b = ![1, x] ∧ ∀ i, IsIntegral ℤ (b i) := by
   classical
-  -- `x ≠ 0`, else `x = algebraMap ℚ K 0` would be rational.
-  have hxne : x ≠ 0 := by
-    rintro rfl
-    exact hx ⟨0, by rw [map_zero]⟩
-  -- `{1, x}` is linearly independent over `ℚ`: `x` is nonzero and not a `ℚ`-multiple of `1`.
-  have hli : LinearIndependent ℚ ![1, x] := by
-    rw [linearIndependent_fin2]
-    refine ⟨by simpa using hxne, ?_⟩
-    intro c hc
-    simp only [Matrix.cons_val_one, Matrix.cons_val_zero] at hc
-    rw [Algebra.smul_def] at hc
-    refine hx ⟨c⁻¹, ?_⟩
-    rw [map_inv₀]
-    exact inv_eq_of_mul_eq_one_right hc
+  -- `{1, x}` is linearly independent over `ℚ` because `x` lies outside the base field.
+  have hli : LinearIndependent ℚ ![1, x] :=
+    linearIndependent_one_of_notMem_range_algebraMap ℚ K (by simpa using hx)
   -- A linearly independent family of `finrank` vectors is a basis.
   have hcard : Fintype.card (Fin 2) = finrank ℚ K := by
     rw [Fintype.card_fin]; exact hfin.symm

--- a/TauCeti/NumberTheory/NumberField/Internal/QuadraticIntegralBasis.lean
+++ b/TauCeti/NumberTheory/NumberField/Internal/QuadraticIntegralBasis.lean
@@ -6,8 +6,7 @@ module
 
 public import Mathlib.NumberTheory.NumberField.Basic
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
-public import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
-public import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
+import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
 
 /-!
 # The `{1, x}` rational basis of algebraic integers in a quadratic number field

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -9,7 +9,6 @@ public import Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed
 public import Mathlib.RingTheory.Discriminant
 public import Mathlib.LinearAlgebra.Matrix.Notation
 public import TauCeti.FieldTheory.Trace
-public import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
 
 /-!
 # Basics for quadratic number fields
@@ -59,12 +58,6 @@ theorem finrank_rat_eq_two (hmin : minpoly ℤ θ = X ^ 2 - C d)
   rw [(PowerBasis.ofAdjoinEqTop' hint hgen).finrank,
     ← (PowerBasis.ofAdjoinEqTop' hint hgen).natDegree_minpoly, PowerBasis.ofAdjoinEqTop'_gen,
     minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C]
-
-/-- A quadratic number field is a quadratic extension of `ℚ`, packaged as the
-`Algebra.IsQuadraticExtension` instance that the general trace and norm API consumes. -/
-theorem isQuadraticExtension_rat (hmin : minpoly ℤ θ = X ^ 2 - C d)
-    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : Algebra.IsQuadraticExtension ℚ K :=
-  ⟨finrank_rat_eq_two hmin hgen⟩
 
 omit [NumberField K] in
 /-- The generator squares to the radicand in `K`: `θ² = d`. -/

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -9,6 +9,7 @@ public import Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed
 public import Mathlib.RingTheory.Discriminant
 public import Mathlib.LinearAlgebra.Matrix.Notation
 public import TauCeti.FieldTheory.Trace
+public import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
 
 /-!
 # Basics for quadratic number fields
@@ -58,6 +59,12 @@ theorem finrank_rat_eq_two (hmin : minpoly ℤ θ = X ^ 2 - C d)
   rw [(PowerBasis.ofAdjoinEqTop' hint hgen).finrank,
     ← (PowerBasis.ofAdjoinEqTop' hint hgen).natDegree_minpoly, PowerBasis.ofAdjoinEqTop'_gen,
     minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C]
+
+/-- A quadratic number field is a quadratic extension of `ℚ`, packaged as the
+`Algebra.IsQuadraticExtension` instance that the general trace and norm API consumes. -/
+theorem isQuadraticExtension_rat (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : Algebra.IsQuadraticExtension ℚ K :=
+  ⟨finrank_rat_eq_two hmin hgen⟩
 
 omit [NumberField K] in
 /-- The generator squares to the radicand in `K`: `θ² = d`. -/

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.NumberTheory.NumberField.Norm
 public import TauCeti.NumberTheory.DedekindDomain.RelNorm
 public import TauCeti.NumberTheory.NumberField.Quadratic.Conjugation.Basic
+public import TauCeti.RingTheory.Norm.Quadratic
 
 /-!
 # Norm-principality for quadratic conjugation
@@ -53,39 +54,14 @@ private theorem quadraticConj_ne_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
   have h2 : (θ : K) + (θ : K) = 0 := by nth_rewrite 2 [hθ]; ring
   exact coe_gen_ne_zero hmin (add_self_eq_zero.mp h2)
 
-/-- The automorphism group of the quadratic field `K/ℚ` has exactly `2` elements. -/
-private theorem card_aut_eq_two (hmin : minpoly ℤ θ = X ^ 2 - C d)
-    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : Fintype.card (K ≃ₐ[ℚ] K) = 2 := by
-  refine le_antisymm ?_ ?_
-  · exact (AlgEquiv.card_le).trans (finrank_rat_eq_two hmin hgen).le
-  · exact Fintype.one_lt_card_iff.mpr
-      ⟨1, quadraticConj hmin hgen, quadraticConj_ne_one hmin hgen⟩
-
-/-- The quadratic field `K` is Galois over `ℚ`: it has `finrank = 2` automorphisms
-(the identity and the conjugation). -/
-private theorem isGalois_rat (hmin : minpoly ℤ θ = X ^ 2 - C d)
-    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : IsGalois ℚ K :=
-  IsGalois.of_card_aut_eq_finrank ℚ K
-    (by rw [Nat.card_eq_fintype_card, card_aut_eq_two hmin hgen, finrank_rat_eq_two hmin hgen])
-
-/-- The product of an element over the Galois group `{1, σ}` of `K/ℚ` is `y · σy`. -/
-private theorem prod_aut_eq (hmin : minpoly ℤ θ = X ^ 2 - C d)
-    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (y : K) :
-    ∏ g : K ≃ₐ[ℚ] K, g y = y * quadraticConj hmin hgen y := by
-  classical
-  have hu : (Finset.univ : Finset (K ≃ₐ[ℚ] K)) = {1, quadraticConj hmin hgen} := by
-    refine (Finset.eq_of_subset_of_card_le (Finset.subset_univ _) ?_).symm
-    rw [Finset.card_univ, card_aut_eq_two hmin hgen,
-      Finset.card_pair (quadraticConj_ne_one hmin hgen)]
-  rw [hu, Finset.prod_pair (quadraticConj_ne_one hmin hgen), AlgEquiv.one_apply]
-
 /-- The relative-norm generator `N(y) = y · σy`: applying `Algebra.norm ℚ` to `y` and coercing to
 `K` gives the product with its conjugate. -/
 private theorem norm_eq_mul_conj (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (y : K) :
     algebraMap ℚ K (Algebra.norm ℚ y) = y * quadraticConj hmin hgen y := by
-  have := isGalois_rat hmin hgen
-  rw [Algebra.norm_eq_prod_automorphisms, prod_aut_eq hmin hgen]
+  have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
+  exact Algebra.IsQuadraticExtension.algebraMap_norm_eq_mul ℚ K
+    (quadraticConj_ne_one hmin hgen).symm y
 
 /-- **Key norm identity.** For `x : 𝓞 K`, the extension of its integral norm equals `x · σx`, the
 product of `x` with its quadratic conjugate. -/

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -60,7 +60,7 @@ private theorem quadraticConj_ne_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
 private theorem norm_eq_mul_conj (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (y : K) :
     algebraMap ℚ K (Algebra.norm ℚ y) = y * quadraticConj hmin hgen y := by
-  have := isQuadraticExtension_rat hmin hgen
+  have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
   exact Algebra.IsQuadraticExtension.algebraMap_norm_eq_mul ℚ K
     (quadraticConj_ne_one hmin hgen) y
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -7,7 +7,7 @@ module
 public import Mathlib.NumberTheory.NumberField.Norm
 public import TauCeti.NumberTheory.DedekindDomain.RelNorm
 public import TauCeti.NumberTheory.NumberField.Quadratic.Conjugation.Basic
-public import TauCeti.RingTheory.Norm.Quadratic
+import TauCeti.RingTheory.Norm.Quadratic
 
 /-!
 # Norm-principality for quadratic conjugation

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -46,11 +46,12 @@ private theorem coe_gen_ne_zero (hmin : minpoly ℤ θ = X ^ 2 - C d) : (θ : K)
 /-- Quadratic conjugation is a nontrivial automorphism: it does not equal the identity, since it
 sends the nonzero generator `θ` to its negative `-θ`. -/
 private theorem quadraticConj_ne_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
-    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : (1 : K ≃ₐ[ℚ] K) ≠ quadraticConj hmin hgen := by
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : quadraticConj hmin hgen ≠ 1 := by
   intro h
   have hθ : (θ : K) = -(θ : K) := by
     have := DFunLike.congr_fun h (θ : K)
-    rwa [AlgEquiv.one_apply, quadraticConj_gen] at this
+    rw [quadraticConj_gen, AlgEquiv.one_apply] at this
+    exact this.symm
   have h2 : (θ : K) + (θ : K) = 0 := by nth_rewrite 2 [hθ]; ring
   exact coe_gen_ne_zero hmin (add_self_eq_zero.mp h2)
 
@@ -59,9 +60,9 @@ private theorem quadraticConj_ne_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
 private theorem norm_eq_mul_conj (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (y : K) :
     algebraMap ℚ K (Algebra.norm ℚ y) = y * quadraticConj hmin hgen y := by
-  have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
+  have := isQuadraticExtension_rat hmin hgen
   exact Algebra.IsQuadraticExtension.algebraMap_norm_eq_mul ℚ K
-    (quadraticConj_ne_one hmin hgen).symm y
+    (quadraticConj_ne_one hmin hgen) y
 
 /-- **Key norm identity.** For `x : 𝓞 K`, the extension of its integral norm equals `x · σx`, the
 product of `x` with its quadratic conjugate. -/

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -8,6 +8,7 @@ public import TauCeti.NumberTheory.NumberField.Quadratic.Basic
 public import TauCeti.NumberTheory.NumberField.Internal.QuadraticIntegralBasis
 public import TauCeti.NumberTheory.NumberField.Discriminant.OfIntegralBasis
 public import Mathlib.NumberTheory.NumberField.Norm
+public import TauCeti.RingTheory.Norm.Quadratic
 
 /-!
 # The ring of integers of a quadratic field
@@ -86,11 +87,12 @@ private theorem exists_intCast_coords (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hz : (z : K) = algebraMap ℚ K a + algebraMap ℚ K c * (θ : K)) :
     (∃ A : ℤ, (A : ℚ) = 2 * a) ∧ (∃ N : ℤ, (N : ℚ) = a ^ 2 - (d : ℚ) * c ^ 2) := by
   have hfr := finrank_rat_eq_two hmin hgen
+  have : Algebra.IsQuadraticExtension ℚ K := ⟨hfr⟩
   -- Trace: `Tr z = 2a` since `Tr θ = 0`.
   have htr : Algebra.trace ℚ K (z : K) = 2 * a := by
-    rw [hz, map_add, Algebra.trace_algebraMap, hfr, ← Algebra.smul_def, map_smul,
+    rw [hz, Algebra.IsQuadraticExtension.trace_algebraMap_add_algebraMap_mul ℚ K c a (θ : K),
       trace_gen_eq_zero hmin]
-    simp
+    ring
   have hAex : ∃ A : ℤ, (A : ℚ) = 2 * a :=
     ⟨Algebra.trace ℤ (𝓞 K) z, by rw [Algebra.coe_trace_int, htr]⟩
   refine ⟨hAex, ?_⟩

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -86,8 +86,7 @@ private theorem exists_intCast_coords (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) {z : 𝓞 K} {a c : ℚ}
     (hz : (z : K) = algebraMap ℚ K a + algebraMap ℚ K c * (θ : K)) :
     (∃ A : ℤ, (A : ℚ) = 2 * a) ∧ (∃ N : ℤ, (N : ℚ) = a ^ 2 - (d : ℚ) * c ^ 2) := by
-  have hfr := finrank_rat_eq_two hmin hgen
-  have := isQuadraticExtension_rat hmin hgen
+  have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
   -- Trace: `Tr z = 2a` since `Tr θ = 0`.
   have htr : Algebra.trace ℚ K (z : K) = 2 * a := by
     rw [hz, Algebra.IsQuadraticExtension.trace_algebraMap_add_algebraMap_mul ℚ K c a (θ : K),

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -8,7 +8,7 @@ public import TauCeti.NumberTheory.NumberField.Quadratic.Basic
 public import TauCeti.NumberTheory.NumberField.Internal.QuadraticIntegralBasis
 public import TauCeti.NumberTheory.NumberField.Discriminant.OfIntegralBasis
 public import Mathlib.NumberTheory.NumberField.Norm
-public import TauCeti.RingTheory.Norm.Quadratic
+import TauCeti.RingTheory.Norm.Quadratic
 
 /-!
 # The ring of integers of a quadratic field

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -87,7 +87,7 @@ private theorem exists_intCast_coords (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hz : (z : K) = algebraMap ℚ K a + algebraMap ℚ K c * (θ : K)) :
     (∃ A : ℤ, (A : ℚ) = 2 * a) ∧ (∃ N : ℤ, (N : ℚ) = a ^ 2 - (d : ℚ) * c ^ 2) := by
   have hfr := finrank_rat_eq_two hmin hgen
-  have : Algebra.IsQuadraticExtension ℚ K := ⟨hfr⟩
+  have := isQuadraticExtension_rat hmin hgen
   -- Trace: `Tr z = 2a` since `Tr θ = 0`.
   have htr : Algebra.trace ℚ K (z : K) = 2 * a := by
     rw [hz, Algebra.IsQuadraticExtension.trace_algebraMap_add_algebraMap_mul ℚ K c a (θ : K),


### PR DESCRIPTION
#2381 landed the general quadratic-extension lemmas (`Algebra.IsQuadraticExtension`, `linearIndependent_one_of_notMem_range_algebraMap`, `Algebra.IsQuadraticExtension.algebraMap_norm_eq_mul`, `Algebra.IsQuadraticExtension.trace_algebraMap_add_algebraMap_mul`). Three already-merged files still carried hand-rolled special cases of exactly those statements. This rewires them and deletes the duplicates: 3 files, +15/−48.

* `Internal/QuadraticIntegralBasis.lean` — the inline `LinearIndependent ℚ ![1, x]` argument (a nonvanishing step plus a `linearIndependent_fin2` case analysis) becomes one call to `linearIndependent_one_of_notMem_range_algebraMap`.
* `Quadratic/Conjugation/Norm.lean` — `norm_eq_mul_conj` went through `Algebra.norm_eq_prod_automorphisms` and a hand-built Galois-group calculation. It now calls `algebraMap_norm_eq_mul` directly, which retires the three private helpers that existed only to support it: `card_aut_eq_two`, `isGalois_rat` and `prod_aut_eq`.
* `Quadratic/RingOfIntegers.lean` — the trace computation in `exists_intCast_coords` becomes one rewrite by `trace_algebraMap_add_algebraMap_mul`.

Nothing is added: the declaration diff over the three files is 30 → 27, with the three removals above and no additions. All three were `private`, and a repo-wide grep confirms zero remaining references to any of them. One `private` statement is restated: `quadraticConj_ne_one` now reads `quadraticConj hmin hgen ≠ 1` instead of the reversed `(1 : K ≃ₐ[ℚ] K) ≠ quadraticConj hmin hgen`, which existed only to feed the now-deleted `card_aut_eq_two`.

## Review history

**Local ten-rubric sweep before opening.** Eight approved, two raised and fixed: `api-design` observed that the three imports the dedup adds are used only inside proof bodies (one opaque theorem, two private theorems), so `public import` needlessly re-exported them — all three are now plain `import`; and `placement` observed that `Mathlib.LinearAlgebra.LinearIndependent.Lemmas` became obsolete once the hand-written `linearIndependent_fin2` proof went, so it is removed.

**Round 1 (head `736ebbb0`)** asked for the `Algebra.IsQuadraticExtension ℚ K` witness to be lifted out of the two proof bodies:

> `TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean:90` — The fact that `K/ℚ` is a quadratic extension is re-derived inline as `⟨finrank_rat_eq_two hmin hgen⟩` in two separate proofs (here and Conjugation/Norm.lean:62), burying a reusable fact in proof bodies; every further consumer of the new `Algebra.IsQuadraticExtension` API from `hmin`/`hgen` will repeat it. _Fix:_ Add `theorem isQuadraticExtension_rat (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩` next to `finrank_rat_eq_two` in Quadratic/Basic.lean:55 and use `haveI := isQuadraticExtension_rat hmin hgen` at both sites.

Head `75d0d207` did that (with `have` rather than `haveI`, since `linter.style.haveILetI` rejects `haveI` for a `Prop`-valued goal), and also reoriented `quadraticConj_ne_one` as the same round asked.

**Round 2 (head `75d0d207`) reversed it.** `reuse`:

> `TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean:65` — `isQuadraticExtension_rat` merely repackages `finrank_rat_eq_two` as a one-field structure and creates a parallel public API. _Fix:_ Delete this theorem and construct the instance locally at both consumers with `have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩`.

That is verbatim the code round 1 asked to be removed. Three further round-2 rubrics charged costs to the same declaration rather than to the inline form — `api-design` and `placement` both on the `public import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension` that only `isQuadraticExtension_rat`'s statement needed, `documentation` on its missing `## Main results` entry and its docstring calling it an `instance` when typeclass search can never find a hypothesis-taking theorem. Four rubrics against one, so this head takes round 2's side: `isQuadraticExtension_rat` is deleted, the import goes with it (nothing else in `Quadratic/Basic.lean` mentions `Algebra.IsQuadraticExtension`), and both consumers introduce the witness inline exactly as `reuse` specifies. Net effect: `Quadratic/Basic.lean` is byte-identical to the merge base again and leaves the diff, so the PR is back to the three files it started with. `proof-quality`'s independent round-2 finding — the now-unused `have hfr := finrank_rat_eq_two hmin hgen` in `exists_intCast_coords` — is fixed in the same commit.

The reversal is recorded here rather than contested in a thread because round 1's thread was pruned when round 2 replaced it, so there is no live comment to reply to. If the round-1 finding re-fires, it and `reuse`'s round-2 finding cannot both be satisfied, and the contest will go in whichever thread is then live.

**Known overlap.** #2539 also edits `Conjugation/Norm.lean`, on disjoint declarations — it de-privatises `ringOfIntegersQuadraticConjₐ` and `map_ringOfIntegersQuadraticConjₐ`, neither of which this PR touches. Whichever merges second may need a textual rebase.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"numbertheorydedups"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
