### PR TITLE
refactor: factor smooth directional derivatives

### DIFF
--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Geometry.Manifold.Algebra.LeftInvariantDerivation
-import Mathlib.Geometry.Manifold.ContMDiffMFDeriv
 public import TauCeti.Geometry.Manifold.DerivationBundle
 public import TauCeti.Geometry.Lie.InvariantVectorField
 import TauCeti.Geometry.Manifold.VectorField.Regularity

--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -6,7 +6,6 @@ module
 
 public import Mathlib.Geometry.Manifold.Algebra.LeftInvariantDerivation
 import Mathlib.Geometry.Manifold.ContMDiffMFDeriv
-import Mathlib.Geometry.Manifold.VectorBundle.Tangent
 public import TauCeti.Geometry.Manifold.DerivationBundle
 public import TauCeti.Geometry.Lie.InvariantVectorField
 import TauCeti.Geometry.Manifold.VectorField.Regularity

--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -9,6 +9,7 @@ import Mathlib.Geometry.Manifold.ContMDiffMFDeriv
 import Mathlib.Geometry.Manifold.VectorBundle.Tangent
 public import TauCeti.Geometry.Manifold.DerivationBundle
 public import TauCeti.Geometry.Lie.InvariantVectorField
+import TauCeti.Geometry.Manifold.VectorField.Regularity
 
 /-!
 # Evaluation of left-invariant derivations
@@ -95,20 +96,9 @@ theorem contMDiff_mvfderiv_mulInvariantVectorField
     [ContMDiffMul I ∞ G] (v : GroupLieAlgebra I G)
     (f : C^∞⟮I, G; 𝕜⟯) :
     ContMDiff I (modelWithCornersSelf 𝕜 𝕜) ∞
-      (fun g ↦ mvfderiv I f g (mulInvariantVectorField v g)) := by
-  let df : TangentBundle I G → TangentBundle (modelWithCornersSelf 𝕜 𝕜) 𝕜 :=
-    tangentMap% (f : G → 𝕜)
-  have hdf : ContMDiff I.tangent (modelWithCornersSelf 𝕜 𝕜).tangent ∞ df :=
-    f.contMDiff.contMDiff_tangentMap (by simp)
-  have hsnd : ContMDiff (modelWithCornersSelf 𝕜 𝕜).tangent
-      (modelWithCornersSelf 𝕜 𝕜) ∞
-      (fun p : TangentBundle (modelWithCornersSelf 𝕜 𝕜) 𝕜 ↦ p.2) :=
-    contMDiff_snd_tangentBundle_modelSpace 𝕜 (modelWithCornersSelf 𝕜 𝕜)
-  -- `mvfderiv` is the second component of the tangent map, hidden by bundle coercions.
-  change ContMDiff I (modelWithCornersSelf 𝕜 𝕜) ∞
-    (fun g ↦ mfderiv I (modelWithCornersSelf 𝕜 𝕜) f g (mulInvariantVectorField v g))
-  have h := hsnd.comp (hdf.comp (contMDiff_mulInvariantVectorField_infty v))
-  exact h.congr fun g ↦ rfl
+      (fun g ↦ mvfderiv I f g (mulInvariantVectorField v g)) :=
+  f.contMDiff.contMDiff_mvfderiv_apply
+    (contMDiff_mulInvariantVectorField_infty v) (by simp)
 
 /-- The derivation of smooth functions that differentiates along the left-invariant vector
 field of a tangent vector `v` at the identity. -/

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.ContMDiffMFDeriv
+import Mathlib.Geometry.Manifold.VectorBundle.Tangent
+
+/-!
+# Regularity of directional derivatives along vector fields
+
+This file records the regularity of applying the manifold differential of a function to a smooth
+tangent-bundle section.
+
+## Main result
+
+* `ContMDiff.contMDiff_mvfderiv_apply`: applying the differential of a `C^n` function to a `C^m`
+  tangent-bundle section is `C^m` when `m + 1 ≤ n`.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The infinitesimal adjoint".
+-/
+
+public section
+
+open Bundle Manifold
+open scoped ContDiff Manifold
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 1 M]
+  {n m : ℕ∞ω}
+
+/-- Applying the differential of a `C^n` function to a `C^m` tangent-bundle section is `C^m`
+when `m + 1 ≤ n`. -/
+theorem ContMDiff.contMDiff_mvfderiv_apply {f : M → F}
+    {V : ∀ x : M, TangentSpace I x}
+    (hf : ContMDiff I 𝓘(𝕜, F) n f)
+    (hV : ContMDiff I I.tangent m (fun x => (V x : TangentBundle I M)))
+    (hmn : m + 1 ≤ n) :
+    ContMDiff I 𝓘(𝕜, F) m (fun x => mvfderiv I f x (V x)) := by
+  let df : TangentBundle I M → TangentBundle 𝓘(𝕜, F) F := tangentMap% f
+  have hdf : ContMDiff I.tangent 𝓘(𝕜, F).tangent m df :=
+    hf.contMDiff_tangentMap hmn
+  have hsnd : ContMDiff 𝓘(𝕜, F).tangent 𝓘(𝕜, F) m
+      (fun p : TangentBundle 𝓘(𝕜, F) F => p.2) :=
+    contMDiff_snd_tangentBundle_modelSpace F 𝓘(𝕜, F)
+  change ContMDiff I 𝓘(𝕜, F) m
+    (fun x => mfderiv I 𝓘(𝕜, F) f x (V x))
+  have h := hsnd.comp (hdf.comp hV)
+  exact h.congr fun x => rfl

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -50,6 +50,7 @@ theorem ContMDiff.contMDiff_mvfderiv_apply {f : M → F}
   have hsnd : ContMDiff 𝓘(𝕜, F).tangent 𝓘(𝕜, F) m
       (fun p : TangentBundle 𝓘(𝕜, F) F => p.2) :=
     contMDiff_snd_tangentBundle_modelSpace F 𝓘(𝕜, F)
+  -- `TangentSpace 𝓘(𝕜, F) (f x)` is definitionally `F`; there is no lemma-based rewrite.
   change ContMDiff I 𝓘(𝕜, F) m
     (fun x => mfderiv I 𝓘(𝕜, F) f x (V x))
   have h := hsnd.comp (hdf.comp hV)


### PR DESCRIPTION
## Goal

Provide the general regularity lemma needed to apply a smooth function's manifold differential along any smooth tangent-bundle section, so invariant-vector-field constructions do not each reproduce the same tangent-map argument.

## Why this is the right abstraction

The derivative of a `C^n` map has a `C^m` tangent map whenever `m + 1 ≤ n`. Composing that tangent map with a `C^m` section gives a `C^m` tangent vector in the normed-space target; projecting its second component is precisely `mvfderiv`. This proves the finite-order statement directly from Mathlib's bundled tangent-map calculus, with the expected loss of one derivative.

The existing left-invariant scalar-directional-derivative theorem is then an immediate specialization using the already-proved smoothness of the left-invariant field. This confirms the generic interface has the intended consumer and removes the proof construction that would otherwise be duplicated by the right-invariant Layer 1 prerequisite.

This is the first ratified prerequisite extracted from [#2559](https://github.com/TauCetiProject/TauCeti/pull/2559)'s reuse review; the multiplication-specific tangent-map refactor remains a separate topic.

## Verification

- `lake build TauCeti.Geometry.Manifold.VectorField.Regularity TauCeti.Geometry.Lie.Tangent.LeftInvariantDerivation`
- `lake build --iofail` (7,162 jobs)
- `lake exe axioms` (31,277 declarations; allowlist only)
- `lake exe module-system` (1,608 modules)
- `bash scripts/lint-env.sh` (no new violations; 2,447/2,447 declarations documented)
- `git diff --check`
- no `sorry`

Roadmap target: [RepresentationTheory/LieGroups, Deliverable A, Layer 1 — the infinitesimal adjoint](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-1-the-adjoint-representations-ad-and-ad)

Intention: [TauCetiRoadmap#162](https://github.com/TauCetiProject/TauCetiRoadmap/issues/162)

Roadmap: RepresentationTheory
