### PR TITLE
feat: package group manifolds as boundaryless

### DIFF
--- a/TauCeti/Geometry/Lie/Interior.lean
+++ b/TauCeti/Geometry/Lie/Interior.lean
@@ -22,7 +22,8 @@ This supplies a prerequisite for Deliverable A, Layer 1 of
 
 * `ContMDiffMul.isInteriorPoint`: every point of a group manifold with `C^n` multiplication, for
   `n ≠ 0`, is an interior point.
-* `ContMDiffMul.boundarylessManifold`: opt-in proof that such a group manifold is boundaryless.
+* `ContMDiffMul.boundarylessManifold`: a group manifold with `C^1` multiplication is boundaryless
+  (opt-in, not an instance).
 
 ## References
 

--- a/TauCeti/Geometry/Lie/Interior.lean
+++ b/TauCeti/Geometry/Lie/Interior.lean
@@ -22,6 +22,7 @@ This supplies a prerequisite for Deliverable A, Layer 1 of
 
 * `ContMDiffMul.isInteriorPoint`: every point of a group manifold with `C^n` multiplication, for
   `n ≠ 0`, is an interior point.
+* `ContMDiffMul.boundarylessManifold`: opt-in proof that such a group manifold is boundaryless.
 
 ## References
 
@@ -55,3 +56,10 @@ theorem ContMDiffMul.isInteriorPoint {n : WithTop ℕ∞} [ContMDiffMul I n G] (
   have htranslate :=
     ((Diffeomorph.smul I I n (g * x⁻¹)).isLocalDiffeomorph x).isInteriorPoint_iff hn |>.mp hx
   simpa [x] using htranslate
+
+/-- A group manifold with `C^1` multiplication is boundaryless.
+
+This theorem is deliberately not an instance: consumers can opt in with
+`attribute [local instance] ContMDiffMul.boundarylessManifold`. -/
+theorem ContMDiffMul.boundarylessManifold [ContMDiffMul I 1 G] : BoundarylessManifold I G :=
+  ⟨ContMDiffMul.isInteriorPoint (n := 1) (by norm_num)⟩


### PR DESCRIPTION
## Goal

Expose the boundarylessness of a group manifold with `C¹` multiplication as an opt-in theorem next to the pointwise interior result that proves it.

## Why this is correct

`ContMDiffMul.isInteriorPoint` already proves every point is interior whenever multiplication has nonzero differentiability. Specializing it at order one supplies exactly the field of Mathlib's `BoundarylessManifold` class.

The theorem is deliberately not a global instance. Consumers opt in with `attribute [local instance] ContMDiffMul.boundarylessManifold`, avoiding any global instance-search change while allowing downstream C³ Banach Lie-group results to recover the boundaryless hypothesis locally.

## Scope

This is a prerequisite extracted from the placement review of #2461. It adds one packaging theorem to `Geometry/Lie/Interior.lean`, the home of the underlying pointwise fact, without changing existing behavior.

## Verification

- opt-in instance consumer compiled in a temporary scratch file
- `lake build TauCeti.Geometry.Lie.Interior`
- `lake build --iofail` (7,166 jobs)
- axiom allowlist check passed
- module-system check passed
- Mathlib lint suite: 2,452 declarations documented, no new violations
- `git diff --check`; no `sorry`

Advances [RepresentationTheory/LieGroups, Deliverable A, Layer 1](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md) and supports [intention #162](https://github.com/TauCetiProject/TauCetiRoadmap/issues/162).

Roadmap: RepresentationTheory
