### PR TITLE
refactor: factor integral-curve pushforwards

### DIFF
--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -58,27 +58,11 @@ theorem const_mul_mulInvariantVectorField [LieGroup I (minSmoothness ℝ 3) G]
     {v : GroupLieAlgebra I G} {γ : ℝ → G} {s : Set ℝ}
     (hγ : IsMIntegralCurveOn γ (mulInvariantVectorField v) s) (g : G) :
     IsMIntegralCurveOn (fun t ↦ g * γ t) (mulInvariantVectorField v) s := by
-  have hpush := hγ.comp_of_mfderiv_eq (f := fun x : G ↦ g * x)
+  let _ : ContMDiffMul I 1 G :=
+    ContMDiffMul.of_le (m := 1) (n := minSmoothness ℝ 3) (by norm_num)
+  have hpush := hγ.map_of_mfderiv_eq (f := fun x : G ↦ g * x)
     (fun _ _ ↦ (contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
-    (fun t _ ↦ by
-      have hpull := congrFun (mpullback_mulInvariantVectorField g v) (γ t)
-      have hcancel :
-          mfderiv% (fun y : G ↦ g * y) (γ t)
-              (mfderiv% (fun y : G ↦ g⁻¹ * y) (g * γ t)
-                (mulInvariantVectorField v (g * γ t))) =
-            mulInvariantVectorField v (g * γ t) := by
-        rw [← mfderiv_comp_apply_of_eq (I' := I) (f := fun y : G ↦ g⁻¹ * y)
-          (g := fun y : G ↦ g * y) (y := γ t) (g * γ t)
-          ((contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
-          ((contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
-          (by simp)]
-        have D : (fun y : G ↦ g * y) ∘ (fun y : G ↦ g⁻¹ * y) = id := by
-          funext z
-          simp
-        rw [D, mfderiv_id, ContinuousLinearMap.id_apply]
-      rw [← hpull, mpullback, inverse_mfderiv_mul_left]
-      exact hcancel)
-  rw [show (fun t ↦ g * γ t) = (fun x : G ↦ g * x) ∘ γ by rfl]
+    (fun t _ ↦ mfderiv_mul_left_mulInvariantVectorField g (γ t) v)
   exact hpush
 
 end IsMIntegralCurveOn

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -61,7 +61,7 @@ theorem const_mul_mulInvariantVectorField [LieGroup I (minSmoothness ℝ 3) G]
   let _ : ContMDiffMul I 1 G :=
     ContMDiffMul.of_le (m := 1) (n := minSmoothness ℝ 3) (by norm_num)
   have hpush := hγ.map_of_mfderiv_eq (f := fun x : G ↦ g * x)
-    (fun _ _ ↦ (contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
+    (fun _ _ ↦ mdifferentiableAt_mul_left)
     (fun t _ ↦ mfderiv_mul_left_mulInvariantVectorField g (γ t) v)
   exact hpush
 

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -54,12 +54,10 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 namespace IsMIntegralCurveOn
 
 /-- Left translation preserves integral curves of a left-invariant vector field. -/
-theorem const_mul_mulInvariantVectorField [LieGroup I (minSmoothness ℝ 3) G]
+theorem const_mul_mulInvariantVectorField [ContMDiffMul I 1 G]
     {v : GroupLieAlgebra I G} {γ : ℝ → G} {s : Set ℝ}
     (hγ : IsMIntegralCurveOn γ (mulInvariantVectorField v) s) (g : G) :
     IsMIntegralCurveOn (fun t ↦ g * γ t) (mulInvariantVectorField v) s := by
-  let _ : ContMDiffMul I 1 G :=
-    ContMDiffMul.of_le (m := 1) (n := minSmoothness ℝ 3) (by norm_num)
   have hpush := hγ.map_of_mfderiv_eq (f := fun x : G ↦ g * x)
     (fun _ _ ↦ mdifferentiableAt_mul_left)
     (fun t _ ↦ mfderiv_mul_left_mulInvariantVectorField g (γ t) v)
@@ -70,7 +68,7 @@ end IsMIntegralCurveOn
 namespace IsMIntegralCurve
 
 /-- Left translation preserves global integral curves of a left-invariant vector field. -/
-theorem const_mul_mulInvariantVectorField [LieGroup I (minSmoothness ℝ 3) G]
+theorem const_mul_mulInvariantVectorField [ContMDiffMul I 1 G]
     {v : GroupLieAlgebra I G} {γ : ℝ → G}
     (hγ : IsMIntegralCurve γ (mulInvariantVectorField v)) (g : G) :
     IsMIntegralCurve (fun t ↦ g * γ t) (mulInvariantVectorField v) := by
@@ -97,6 +95,8 @@ theorem exists_isMIntegralCurve_mulInvariantVectorField [CompleteSpace E]
   apply exists_isMIntegralCurve_of_isMIntegralCurveOn hV hε
   intro y
   refine ⟨fun t ↦ y * γ t, by simp [hγ0], ?_⟩
+  let _ : ContMDiffMul I 1 G :=
+    ContMDiffMul.of_le (m := 1) (n := minSmoothness ℝ 3) (by norm_num)
   exact hγ.const_mul_mulInvariantVectorField y
 
 /-- Every left-invariant vector field on a real Lie group modeled on a complete space has a unique
@@ -190,7 +190,9 @@ theorem mulInvariantIntegralCurve_eq_const_mul [CompleteSpace E]
   symm
   apply eq_mulInvariantIntegralCurve v x
   · simp
-  · exact (isMIntegralCurve_mulInvariantIntegralCurve v 1).const_mul_mulInvariantVectorField x
+  · let _ : ContMDiffMul I 1 G :=
+      ContMDiffMul.of_le (m := 1) (n := minSmoothness ℝ 3) (by norm_num)
+    exact (isMIntegralCurve_mulInvariantIntegralCurve v 1).const_mul_mulInvariantVectorField x
 
 /-- The canonical invariant curve through the identity satisfies the one-parameter subgroup law. -/
 @[simp]

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -58,45 +58,28 @@ theorem const_mul_mulInvariantVectorField [LieGroup I (minSmoothness ℝ 3) G]
     {v : GroupLieAlgebra I G} {γ : ℝ → G} {s : Set ℝ}
     (hγ : IsMIntegralCurveOn γ (mulInvariantVectorField v) s) (g : G) :
     IsMIntegralCurveOn (fun t ↦ g * γ t) (mulInvariantVectorField v) s := by
-  intro t ht
-  have hg : MDiffAt (fun x : G ↦ g * x) (γ t) :=
-    (contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp)
-  have hder :
-      (mfderiv% (fun x : G ↦ g * x) (γ t)).comp
-          ((1 : ℝ →L[ℝ] ℝ).smulRight (mulInvariantVectorField v (γ t))) =
-        (1 : ℝ →L[ℝ] ℝ).smulRight (mulInvariantVectorField v (g * γ t)) := by
-    have hvec : mfderiv% (fun x : G ↦ g * x) (γ t)
-        (mulInvariantVectorField v (γ t)) = mulInvariantVectorField v (g * γ t) := by
-      have hpull := congrFun (mpullback_mulInvariantVectorField g v) (γ t)
+  have hpush := hγ.comp_of_mfderiv_eq (f := fun x : G ↦ g * x)
+    (fun x ↦ (contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
+    (fun x ↦ by
+      have hpull := congrFun (mpullback_mulInvariantVectorField g v) x
       have hcancel :
-          mfderiv% (fun x : G ↦ g * x) (γ t)
-              (mfderiv% (fun x : G ↦ g⁻¹ * x) (g * γ t)
-                (mulInvariantVectorField v (g * γ t))) =
-            mulInvariantVectorField v (g * γ t) := by
-        rw [← mfderiv_comp_apply_of_eq (I' := I) (f := fun x : G ↦ g⁻¹ * x)
-          (g := fun x : G ↦ g * x) (y := γ t) (g * γ t)
+          mfderiv% (fun y : G ↦ g * y) x
+              (mfderiv% (fun y : G ↦ g⁻¹ * y) (g * x)
+                (mulInvariantVectorField v (g * x))) =
+            mulInvariantVectorField v (g * x) := by
+        rw [← mfderiv_comp_apply_of_eq (I' := I) (f := fun y : G ↦ g⁻¹ * y)
+          (g := fun y : G ↦ g * y) (y := x) (g * x)
           ((contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
           ((contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
           (by simp)]
-        have D : (fun x : G ↦ g * x) ∘ (fun x : G ↦ g⁻¹ * x) = id := by
+        have D : (fun y : G ↦ g * y) ∘ (fun y : G ↦ g⁻¹ * y) = id := by
           funext z
           simp
         rw [D, mfderiv_id, ContinuousLinearMap.id_apply]
       rw [← hpull, mpullback, inverse_mfderiv_mul_left]
-      exact hcancel
-    calc
-      _ = (1 : ℝ →L[ℝ] ℝ).smulRight
-          (mfderiv% (fun x : G ↦ g * x) (γ t) (mulInvariantVectorField v (γ t))) := by
-        apply ContinuousLinearMap.ext
-        intro c
-        rw [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smulRight_apply,
-          ContinuousLinearMap.smulRight_apply, map_smul]
-      _ = _ := by rw [hvec]
-  -- Write the translated curve as a composition so the manifold chain rule applies directly.
-  change HasMFDerivAt[s] ((fun x : G ↦ g * x) ∘ γ) t
-    ((1 : ℝ →L[ℝ] ℝ).smulRight (mulInvariantVectorField v (g * γ t)))
-  rw [← hder]
-  exact hg.hasMFDerivAt.comp_hasMFDerivWithinAt t (hγ t ht)
+      exact hcancel)
+  change IsMIntegralCurveOn ((fun x : G ↦ g * x) ∘ γ) (mulInvariantVectorField v) s
+  exact hpush
 
 end IsMIntegralCurveOn
 

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -59,16 +59,16 @@ theorem const_mul_mulInvariantVectorField [LieGroup I (minSmoothness ℝ 3) G]
     (hγ : IsMIntegralCurveOn γ (mulInvariantVectorField v) s) (g : G) :
     IsMIntegralCurveOn (fun t ↦ g * γ t) (mulInvariantVectorField v) s := by
   have hpush := hγ.comp_of_mfderiv_eq (f := fun x : G ↦ g * x)
-    (fun x ↦ (contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
-    (fun x ↦ by
-      have hpull := congrFun (mpullback_mulInvariantVectorField g v) x
+    (fun _ _ ↦ (contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
+    (fun t _ ↦ by
+      have hpull := congrFun (mpullback_mulInvariantVectorField g v) (γ t)
       have hcancel :
-          mfderiv% (fun y : G ↦ g * y) x
-              (mfderiv% (fun y : G ↦ g⁻¹ * y) (g * x)
-                (mulInvariantVectorField v (g * x))) =
-            mulInvariantVectorField v (g * x) := by
+          mfderiv% (fun y : G ↦ g * y) (γ t)
+              (mfderiv% (fun y : G ↦ g⁻¹ * y) (g * γ t)
+                (mulInvariantVectorField v (g * γ t))) =
+            mulInvariantVectorField v (g * γ t) := by
         rw [← mfderiv_comp_apply_of_eq (I' := I) (f := fun y : G ↦ g⁻¹ * y)
-          (g := fun y : G ↦ g * y) (y := x) (g * x)
+          (g := fun y : G ↦ g * y) (y := γ t) (g * γ t)
           ((contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
           ((contMDiffAt_mul_left (n := minSmoothness ℝ 3)).mdifferentiableAt (by simp))
           (by simp)]
@@ -78,7 +78,7 @@ theorem const_mul_mulInvariantVectorField [LieGroup I (minSmoothness ℝ 3) G]
         rw [D, mfderiv_id, ContinuousLinearMap.id_apply]
       rw [← hpull, mpullback, inverse_mfderiv_mul_left]
       exact hcancel)
-  change IsMIntegralCurveOn ((fun x : G ↦ g * x) ∘ γ) (mulInvariantVectorField v) s
+  rw [show (fun t ↦ g * γ t) = (fun x : G ↦ g * x) ∘ γ by rfl]
   exact hpush
 
 end IsMIntegralCurveOn

--- a/TauCeti/Geometry/Lie/InvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField.lean
@@ -23,6 +23,8 @@ left-invariant-derivation model of a Lie algebra.
   tangent bundles.
 * `tangentMap_mul_prod_apply`: the value of that tangent map is the sum of the two partial
   derivatives of multiplication.
+* `mfderiv_mul_left_mulInvariantVectorField`: left translation intertwines a left-invariant vector
+  field with itself.
 * `contMDiff_mulInvariantVectorField_infty`: a left-invariant vector field on a smooth Lie group is
   smooth.
 * `contMDiff_mulInvariantVectorField_modelSpace`: the invariant vector field is jointly `C^m` in
@@ -85,6 +87,21 @@ theorem mulInvariantVectorField_one (v : GroupLieAlgebra I G) :
   change mfderiv I I (fun x : G ↦ 1 * x) 1 v = v
   rw [show (fun x : G ↦ 1 * x) = id by funext x; simp, mfderiv_id]
   rfl
+
+/-- The derivative of left translation carries a left-invariant vector field to itself. -/
+theorem mfderiv_mul_left_mulInvariantVectorField [ContMDiffMul I 1 G]
+    (g x : G) (v : GroupLieAlgebra I G) :
+    mfderiv I I (fun y : G ↦ g * y) x (mulInvariantVectorField v x) =
+      mulInvariantVectorField v (g * x) := by
+  simp only [mulInvariantVectorField]
+  rw [← mfderiv_comp_apply_of_eq (I' := I) (f := fun y : G ↦ x * y)
+    (g := fun y : G ↦ g * y) (y := x) (1 : G)
+    ((contMDiffAt_mul_left (n := 1)).mdifferentiableAt (by simp))
+    ((contMDiffAt_mul_left (n := 1)).mdifferentiableAt (by simp)) (by simp)]
+  rw [show (fun y : G ↦ g * y) ∘ (fun y : G ↦ x * y) =
+      (fun y : G ↦ (g * x) * y) by
+    funext y
+    simp [mul_assoc]]
 
 /-- In model coordinates, the invariant vector field is jointly `C^m` in its generating tangent
 vector and the group point when multiplication is `C^n` and `m + 1 ≤ n`. -/

--- a/TauCeti/Geometry/Lie/InvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField.lean
@@ -89,6 +89,7 @@ theorem mulInvariantVectorField_one (v : GroupLieAlgebra I G) :
   rfl
 
 /-- The derivative of left translation carries a left-invariant vector field to itself. -/
+@[simp]
 theorem mfderiv_mul_left_mulInvariantVectorField [ContMDiffMul I 1 G]
     (g x : G) (v : GroupLieAlgebra I G) :
     mfderiv I I (fun y : G ↦ g * y) x (mulInvariantVectorField v x) =
@@ -96,8 +97,7 @@ theorem mfderiv_mul_left_mulInvariantVectorField [ContMDiffMul I 1 G]
   simp only [mulInvariantVectorField]
   rw [← mfderiv_comp_apply_of_eq (I' := I) (f := fun y : G ↦ x * y)
     (g := fun y : G ↦ g * y) (y := x) (1 : G)
-    ((contMDiffAt_mul_left (n := 1)).mdifferentiableAt (by simp))
-    ((contMDiffAt_mul_left (n := 1)).mdifferentiableAt (by simp)) (by simp)]
+    (mdifferentiableAt_mul_left (a := g)) (mdifferentiableAt_mul_left (a := x)) (by simp)]
   rw [show (fun y : G ↦ g * y) ∘ (fun y : G ↦ x * y) =
       (fun y : G ↦ (g * x) * y) by
     funext y

--- a/TauCeti/Geometry/Manifold/IntegralCurve.lean
+++ b/TauCeti/Geometry/Manifold/IntegralCurve.lean
@@ -16,6 +16,9 @@ smooth vector fields on boundaryless smooth manifolds are smooth.
 
 ## Main results
 
+* `IsMIntegralCurveOn.comp_of_mfderiv_eq`: a differentiable map that intertwines two vector fields
+  sends integral curves of the first field to integral curves of the second.
+* `IsMIntegralCurve.comp_of_mfderiv_eq`: the corresponding result for global integral curves.
 * `IsMIntegralCurve.contMDiff_succ`: an integral curve of a `C^n` vector field is `C^(n + 1)`.
 * `IsMIntegralCurve.contMDiff`: an integral curve of a smooth vector field is smooth.
 * `IsMIntegralCurveAt.of_extChartAt_symm`: a coordinate solution gives a manifold integral curve.
@@ -25,7 +28,7 @@ smooth vector fields on boundaryless smooth manifolds are smooth.
 * Mathlib's proof of `exists_isMIntegralCurveAt_of_contMDiffAt_boundaryless`, whose extended-chart
   calculation is adapted by `IsMIntegralCurveAt.of_extChartAt_symm` in the reverse direction.
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
-  Deliverable A, Layer 0, "The exponential map".
+  Deliverable A, Layer 0, "The exponential map", and Layer 1, "The group adjoint".
 -/
 
 public section
@@ -35,6 +38,56 @@ open scoped ContDiff Manifold Topology
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+
+namespace IsMIntegralCurveOn
+
+variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace ℝ E']
+  {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners ℝ E' H'}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
+
+/-- A differentiable map that intertwines two vector fields sends integral curves of the first
+field to integral curves of the second. -/
+theorem comp_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
+    {W : (x : M') → TangentSpace I' x} {γ : ℝ → M} {s : Set ℝ}
+    (hf : ∀ x, MDifferentiableAt I I' f x)
+    (hVW : ∀ x, mfderiv I I' f x (V x) = W (f x))
+    (hγ : IsMIntegralCurveOn γ V s) : IsMIntegralCurveOn (f ∘ γ) W s := by
+  intro t ht
+  have hder :
+      (mfderiv I I' f (γ t)).comp ((1 : ℝ →L[ℝ] ℝ).smulRight (V (γ t))) =
+        (1 : ℝ →L[ℝ] ℝ).smulRight (W (f (γ t))) := by
+    apply ContinuousLinearMap.ext
+    intro c
+    simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smulRight_apply, map_smul]
+    rw [hVW]
+  -- Unfold composition at the base point so the dependent target tangent spaces are definitionally
+  -- identical; no rewrite lemma expresses this type-level conversion.
+  change HasMFDerivAt[s] (f ∘ γ) t
+    ((1 : ℝ →L[ℝ] ℝ).smulRight (W (f (γ t))))
+  rw [← hder]
+  exact (hf (γ t)).hasMFDerivAt.comp_hasMFDerivWithinAt t (hγ t ht)
+
+end IsMIntegralCurveOn
+
+namespace IsMIntegralCurve
+
+variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace ℝ E']
+  {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners ℝ E' H'}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
+
+/-- A differentiable map that intertwines two vector fields sends global integral curves of the
+first field to global integral curves of the second. -/
+theorem comp_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
+    {W : (x : M') → TangentSpace I' x} {γ : ℝ → M}
+    (hf : ∀ x, MDifferentiableAt I I' f x)
+    (hVW : ∀ x, mfderiv I I' f x (V x) = W (f x))
+    (hγ : IsMIntegralCurve γ V) : IsMIntegralCurve (f ∘ γ) W := by
+  rw [isMIntegralCurve_iff_isMIntegralCurveOn]
+  exact (hγ.isMIntegralCurveOn Set.univ).comp_of_mfderiv_eq hf hVW
+
+end IsMIntegralCurve
 
 /-- Convert an ordinary derivative into the model-space derivative expected inside a manifold
 derivative. This is the single boundary where the tangent spaces of the self model on `ℝ` and of

--- a/TauCeti/Geometry/Manifold/IntegralCurve.lean
+++ b/TauCeti/Geometry/Manifold/IntegralCurve.lean
@@ -16,9 +16,9 @@ smooth vector fields on boundaryless smooth manifolds are smooth.
 
 ## Main results
 
-* `IsMIntegralCurveOn.comp_of_mfderiv_eq`: a differentiable map that intertwines two vector fields
-  sends integral curves of the first field to integral curves of the second.
-* `IsMIntegralCurve.comp_of_mfderiv_eq`: the corresponding result for global integral curves.
+* `IsMIntegralCurveOn.map_of_mfderiv_eq`: a map differentiable along an integral curve whose
+  derivative intertwines the vector fields there sends it to an integral curve of the second field.
+* `IsMIntegralCurveAt.map_of_mfderiv_eq`: the corresponding result for local integral curves.
 * `IsMIntegralCurve.contMDiff_succ`: an integral curve of a `C^n` vector field is `C^(n + 1)`.
 * `IsMIntegralCurve.contMDiff`: an integral curve of a smooth vector field is smooth.
 * `IsMIntegralCurveAt.of_extChartAt_symm`: a coordinate solution gives a manifold integral curve.
@@ -46,9 +46,9 @@ variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace ℝ E']
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
   {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
 
-/-- A differentiable map that intertwines two vector fields sends integral curves of the first
-field to integral curves of the second. -/
-theorem comp_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
+/-- A map differentiable along an integral curve whose derivative intertwines the vector fields
+there sends it to an integral curve of the second field. -/
+theorem map_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
     {W : (x : M') → TangentSpace I' x} {γ : ℝ → M} {s : Set ℝ}
     (hf : ∀ t ∈ s, MDifferentiableAt I I' f (γ t))
     (hVW : ∀ t ∈ s, mfderiv I I' f (γ t) (V (γ t)) = W (f (γ t)))
@@ -70,25 +70,30 @@ theorem comp_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
 
 end IsMIntegralCurveOn
 
-namespace IsMIntegralCurve
+namespace IsMIntegralCurveAt
 
 variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace ℝ E']
   {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners ℝ E' H'}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
   {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
 
-/-- A differentiable map that intertwines two vector fields sends global integral curves of the
-first field to global integral curves of the second. -/
-theorem comp_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
-    {W : (x : M') → TangentSpace I' x} {γ : ℝ → M}
-    (hf : ∀ t, MDifferentiableAt I I' f (γ t))
-    (hVW : ∀ t, mfderiv I I' f (γ t) (V (γ t)) = W (f (γ t)))
-    (hγ : IsMIntegralCurve γ V) : IsMIntegralCurve (f ∘ γ) W := by
-  rw [isMIntegralCurve_iff_isMIntegralCurveOn]
-  exact (hγ.isMIntegralCurveOn Set.univ).comp_of_mfderiv_eq
-    (fun t _ ↦ hf t) (fun t _ ↦ hVW t)
+/-- A map eventually differentiable along a local integral curve whose derivative eventually
+intertwines the vector fields sends it to a local integral curve of the second field. -/
+theorem map_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
+    {W : (x : M') → TangentSpace I' x} {γ : ℝ → M} {t₀ : ℝ}
+    (hf : ∀ᶠ t in 𝓝 t₀, MDifferentiableAt I I' f (γ t))
+    (hVW : ∀ᶠ t in 𝓝 t₀, mfderiv I I' f (γ t) (V (γ t)) = W (f (γ t)))
+    (hγ : IsMIntegralCurveAt γ V t₀) : IsMIntegralCurveAt (f ∘ γ) W t₀ := by
+  rw [isMIntegralCurveAt_iff] at hγ ⊢
+  obtain ⟨s, hs, hγs⟩ := hγ
+  rw [Filter.eventually_iff_exists_mem] at hf hVW
+  obtain ⟨sf, hsf, hf⟩ := hf
+  obtain ⟨sVW, hsVW, hVW⟩ := hVW
+  refine ⟨s ∩ sf ∩ sVW, Filter.inter_mem (Filter.inter_mem hs hsf) hsVW, ?_⟩
+  exact (hγs.mono fun _ ht ↦ ht.1.1).map_of_mfderiv_eq
+    (fun t ht ↦ hf t ht.1.2) (fun t ht ↦ hVW t ht.2)
 
-end IsMIntegralCurve
+end IsMIntegralCurveAt
 
 /-- Convert an ordinary derivative into the model-space derivative expected inside a manifold
 derivative. This is the single boundary where the tangent spaces of the self model on `ℝ` and of

--- a/TauCeti/Geometry/Manifold/IntegralCurve.lean
+++ b/TauCeti/Geometry/Manifold/IntegralCurve.lean
@@ -50,8 +50,8 @@ variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace ℝ E']
 field to integral curves of the second. -/
 theorem comp_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
     {W : (x : M') → TangentSpace I' x} {γ : ℝ → M} {s : Set ℝ}
-    (hf : ∀ x, MDifferentiableAt I I' f x)
-    (hVW : ∀ x, mfderiv I I' f x (V x) = W (f x))
+    (hf : ∀ t ∈ s, MDifferentiableAt I I' f (γ t))
+    (hVW : ∀ t ∈ s, mfderiv I I' f (γ t) (V (γ t)) = W (f (γ t)))
     (hγ : IsMIntegralCurveOn γ V s) : IsMIntegralCurveOn (f ∘ γ) W s := by
   intro t ht
   have hder :
@@ -60,13 +60,13 @@ theorem comp_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
     apply ContinuousLinearMap.ext
     intro c
     simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smulRight_apply, map_smul]
-    rw [hVW]
+    rw [hVW t ht]
   -- Unfold composition at the base point so the dependent target tangent spaces are definitionally
   -- identical; no rewrite lemma expresses this type-level conversion.
   change HasMFDerivAt[s] (f ∘ γ) t
     ((1 : ℝ →L[ℝ] ℝ).smulRight (W (f (γ t))))
   rw [← hder]
-  exact (hf (γ t)).hasMFDerivAt.comp_hasMFDerivWithinAt t (hγ t ht)
+  exact (hf t ht).hasMFDerivAt.comp_hasMFDerivWithinAt t (hγ t ht)
 
 end IsMIntegralCurveOn
 
@@ -81,11 +81,12 @@ variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace ℝ E']
 first field to global integral curves of the second. -/
 theorem comp_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
     {W : (x : M') → TangentSpace I' x} {γ : ℝ → M}
-    (hf : ∀ x, MDifferentiableAt I I' f x)
-    (hVW : ∀ x, mfderiv I I' f x (V x) = W (f x))
+    (hf : ∀ t, MDifferentiableAt I I' f (γ t))
+    (hVW : ∀ t, mfderiv I I' f (γ t) (V (γ t)) = W (f (γ t)))
     (hγ : IsMIntegralCurve γ V) : IsMIntegralCurve (f ∘ γ) W := by
   rw [isMIntegralCurve_iff_isMIntegralCurveOn]
-  exact (hγ.isMIntegralCurveOn Set.univ).comp_of_mfderiv_eq hf hVW
+  exact (hγ.isMIntegralCurveOn Set.univ).comp_of_mfderiv_eq
+    (fun t _ ↦ hf t) (fun t _ ↦ hVW t)
 
 end IsMIntegralCurve
 

--- a/TauCeti/Geometry/Manifold/IntegralCurve.lean
+++ b/TauCeti/Geometry/Manifold/IntegralCurve.lean
@@ -57,10 +57,9 @@ theorem map_of_mfderiv_eq {f : M → M'} {V : (x : M) → TangentSpace I x}
   have hder :
       (mfderiv I I' f (γ t)).comp ((1 : ℝ →L[ℝ] ℝ).smulRight (V (γ t))) =
         (1 : ℝ →L[ℝ] ℝ).smulRight (W (f (γ t))) := by
-    apply ContinuousLinearMap.ext
-    intro c
-    simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smulRight_apply, map_smul]
-    rw [hVW t ht]
+    rw [ContinuousLinearMap.smulRight_one_eq_toSpanSingleton,
+      ContinuousLinearMap.smulRight_one_eq_toSpanSingleton,
+      ContinuousLinearMap.comp_toSpanSingleton, hVW t ht]
   -- Unfold composition at the base point so the dependent target tangent spaces are definitionally
   -- identical; no rewrite lemma expresses this type-level conversion.
   change HasMFDerivAt[s] (f ∘ γ) t


### PR DESCRIPTION
## Goal

Factor the manifold chain-rule argument for pushing an integral curve through a differentiable map that intertwines vector fields, and reuse it in the existing left-translation theorem.

## Why this is correct

For an integral curve `γ` of `V`, differentiability of `f` gives the manifold chain rule for `f ∘ γ`. The hypothesis

```lean
mfderiv I I' f x (V x) = W (f x)
```

identifies that composite derivative with the defining derivative of an integral curve of `W`. The proof centralizes the one continuous-linear-map calculation needed to pass from the vector identity to the derivative from `ℝ`.

The global corollary is the `Set.univ` specialization. The existing left-translation theorem now supplies only its Lie-specific facts—smoothness of translation and transport of the invariant vector field—then delegates the chain rule to the shared theorem.

## Scope

This is the separate prerequisite extracted from the reuse review of #2461. The new general theorem and the refactor of its existing duplicate are one atomic reuse change; no Lie-group result changes statement.

## Verification

- `lake build TauCeti.Geometry.Lie.IntegralCurve`
- `lake build --iofail` (7,166 jobs)
- axiom allowlist check passed
- module-system check passed
- Mathlib lint suite: 2,452 declarations documented, no new violations
- `git diff --check`; no `sorry`

Advances [RepresentationTheory/LieGroups, Deliverable A, Layer 1](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md) and supports [intention #162](https://github.com/TauCetiProject/TauCetiRoadmap/issues/162).

Roadmap: RepresentationTheory
