### PR TITLE
feat(RingTheory): AdjoinRoot.map is surjective when the base map is

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingEquiv.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingEquiv.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+
+/-!
+# A ring equivalence of the base induces one of the coordinate rings
+
+Mathlib's `WeierstrassCurve.Affine.CoordinateRing.map` sends a ring homomorphism `f : R →+* S` to
+`R[W] →+* S[W.map f]`, and proves it injective when `f` is (`CoordinateRing.map_injective`). When
+`f` is an equivalence the induced map is an equivalence too, which is what this file adds: the
+missing surjectivity, and the resulting `≃+*`.
+
+## Main results
+
+* `WeierstrassCurve.Affine.CoordinateRing.map_surjective`: `CoordinateRing.map` along a ring
+  equivalence is surjective.
+* `WeierstrassCurve.Affine.CoordinateRing.mapEquiv`: the induced ring equivalence
+  `R[W] ≃+* S[W.map e]`.
+
+Stated over arbitrary commutative rings; the curve need not be elliptic, since the argument is
+just that `Polynomial.map` along `e` and along `e.symm` are mutually inverse.
+
+This supports the Hasse strand of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 3. That
+roadmap's Layer-0 narrative makes the Frobenius "the key input to Layer 3", and the arithmetic
+Frobenius of the function field over a finite field is obtained by transporting the `q`-power map
+of the base along exactly this construction: it is a ring *equivalence* of `K̄` and so must be
+carried to an equivalence of coordinate rings before it can be pushed to the fraction field. The
+roadmap's §"What Mathlib already has (consume)" lists `Affine.CoordinateRing` as consumed
+infrastructure that "is load-bearing API here, not an implementation detail"; this is a complement
+to that API, not a reimplementation of it.
+
+## Provenance
+
+The need for this step, and the surjectivity argument (lift `e.symm` through `AdjoinRoot.mk` and
+`Polynomial.map`), are from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`,
+Apache-2.0, pinned by that roadmap at `dev/hasse-weil @ 513e83879e2f`),
+`HasseWeil/WeilPairing/FrobeniusFunctionFieldEquiv.lean`, declaration `coordRingMap_bijective`.
+There the statement is bundled as bijectivity of a map between the coordinate rings of a curve and
+of its image; here it is split into the surjectivity Mathlib is missing and the packaged `≃+*`,
+with injectivity taken from Mathlib's `CoordinateRing.map_injective` rather than reproved.
+-/
+
+public section
+
+open Polynomial
+
+open scoped Polynomial.Bivariate
+
+namespace WeierstrassCurve.Affine.CoordinateRing
+
+variable {R S : Type*} [CommRing R] [CommRing S] (W : WeierstrassCurve.Affine R)
+
+/-- `CoordinateRing.map` along a ring equivalence is surjective: a class upstairs is the image of
+the class of the same polynomial pulled back along `e.symm`. -/
+lemma map_surjective (e : R ≃+* S) :
+    Function.Surjective (map W (e : R →+* S)) := fun y => by
+  obtain ⟨p, rfl⟩ := AdjoinRoot.mk_surjective y
+  refine ⟨mk W (p.map (mapRingHom (e.symm : S →+* R))), ?_⟩
+  rw [map_mk, Polynomial.map_map]
+  simp
+
+/-- **A ring equivalence of the base induces one of the coordinate rings.** Injectivity is
+Mathlib's `CoordinateRing.map_injective`; surjectivity is `map_surjective` above. -/
+noncomputable def mapEquiv (e : R ≃+* S) :
+    W.CoordinateRing ≃+* (W.map (e : R →+* S)).CoordinateRing :=
+  RingEquiv.ofBijective (map W (e : R →+* S))
+    ⟨map_injective e.injective, map_surjective W e⟩
+
+@[simp]
+lemma mapEquiv_apply (e : R ≃+* S) (x : W.CoordinateRing) :
+    mapEquiv W e x = map W (e : R →+* S) x := RingEquiv.ofBijective_apply _ _ _
+
+end WeierstrassCurve.Affine.CoordinateRing
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingEquiv.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingEquiv.lean
@@ -10,21 +10,18 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
 # A ring equivalence of the base induces one of the coordinate rings
 
 Mathlib's `WeierstrassCurve.Affine.CoordinateRing.map` sends a ring homomorphism `f : R →+* S` to
-`R[W] →+* S[W.map f]`, and proves it injective when `f` is (`CoordinateRing.map_injective`). When
-`f` is an equivalence the induced map is an equivalence, and Mathlib already has the construction
-generically: `R[W]` is by definition `AdjoinRoot W.polynomial`, so `AdjoinRoot.mapRingEquiv`
-applies. What is missing is the bridge — that the generic equivalence *is* `CoordinateRing.map` —
-without which the equivalence is cut off from the `map_mk`, `map_smul` and `map_injective` API
-stated about `CoordinateRing.map`.
+`R[W] →+* S[W.map f]`, and proves it injective when `f` is (`CoordinateRing.map_injective`). This
+file adds the two companions Mathlib does not state — surjectivity and bijectivity, at the same
+generality — and packages the bijective case as a ring equivalence.
 
 ## Main results
 
-* `WeierstrassCurve.Affine.CoordinateRing.mapEquiv`: the induced ring equivalence
-  `R[W] ≃+* S[W.map e]`, as `AdjoinRoot.mapRingEquiv` along `map_polynomial`.
-* `WeierstrassCurve.Affine.CoordinateRing.mapEquiv_apply`: it agrees with `CoordinateRing.map`.
 * `WeierstrassCurve.Affine.CoordinateRing.map_surjective` and
-  `WeierstrassCurve.Affine.CoordinateRing.map_bijective`: the companions of Mathlib's
-  `CoordinateRing.map_injective`, stated like it for an arbitrary `f : R →+* S`.
+  `WeierstrassCurve.Affine.CoordinateRing.map_bijective`: stated, like Mathlib's
+  `CoordinateRing.map_injective`, for an arbitrary `f : R →+* S`.
+* `WeierstrassCurve.Affine.CoordinateRing.mapEquiv`: the induced `R[W] ≃+* S[W.map e]`, with
+  `mapEquiv_apply` identifying it with `CoordinateRing.map` so that the `map_mk`, `map_smul` and
+  `map_injective` API applies to it unchanged.
 
 Stated over arbitrary commutative rings; the curve need not be elliptic.
 
@@ -43,10 +40,10 @@ The need for this step, and the surjectivity argument (lift `e.symm` through `Ad
 `Polynomial.map`), are from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`,
 Apache-2.0, pinned by that roadmap at `dev/hasse-weil @ 513e83879e2f`),
 `HasseWeil/WeilPairing/FrobeniusFunctionFieldEquiv.lean`, declaration `coordRingMap_bijective`.
-There the equivalence is rebuilt by hand — injectivity from `map_injective`, surjectivity by
-lifting `e.symm` through `AdjoinRoot.mk` — inside a 267-line file that also constructs the
-function-field Frobenius. Here neither half is reproved: the equivalence is Mathlib's
-`AdjoinRoot.mapRingEquiv`, and the only new content is that it agrees with `CoordinateRing.map`.
+There it is bundled as bijectivity of one map, for a ring equivalence only, inside a 267-line file
+that also constructs the function-field Frobenius. Here it is split out and generalised: the
+surjectivity is stated for any surjective `f : R →+* S`, matching the generality of Mathlib's
+`CoordinateRing.map_injective`, and the equivalence is the packaging of the bijective case.
 -/
 
 public section
@@ -58,26 +55,6 @@ open scoped Polynomial.Bivariate
 namespace WeierstrassCurve.Affine.CoordinateRing
 
 variable {R S : Type*} [CommRing R] [CommRing S] (W : WeierstrassCurve.Affine R)
-
-/-- **A ring equivalence of the base induces one of the coordinate rings.** This is Mathlib's
-generic `AdjoinRoot.mapRingEquiv`, specialised along `map_polynomial`: `R[W]` is by definition
-`AdjoinRoot W.polynomial`, and `(W.map e).polynomial` is `W.polynomial.map (mapRingHom e)`. -/
-noncomputable def mapEquiv (e : R ≃+* S) :
-    W.CoordinateRing ≃+* (W.map (e : R →+* S)).CoordinateRing :=
-  AdjoinRoot.mapRingEquiv (Polynomial.mapEquiv e) W.polynomial (W.map (e : R →+* S)).polynomial
-    (by rw [WeierstrassCurve.Affine.map_polynomial]; rfl)
-
-/-- **The induced equivalence is Mathlib's `CoordinateRing.map`.** Without this the equivalence
-would be cut off from the `map_mk`, `map_smul` and `map_injective` API stated about
-`CoordinateRing.map`. -/
-@[simp]
-lemma mapEquiv_apply (e : R ≃+* S) (x : W.CoordinateRing) :
-    mapEquiv W e x = map W (e : R →+* S) x := by
-  induction x using AdjoinRoot.induction_on with
-  | _ p =>
-    simp only [mapEquiv, AdjoinRoot.mapRingEquiv, RingEquiv.ofRingHom_apply, AdjoinRoot.map, map,
-      AdjoinRoot.lift_mk]
-    rfl
 
 /-- **`CoordinateRing.map` is surjective when the base map is**, the companion of Mathlib's
 `CoordinateRing.map_injective`. A class upstairs is `mk` of a polynomial, and a polynomial over
@@ -92,6 +69,19 @@ lemma map_surjective {f : R →+* S} (hf : Function.Surjective f) :
 lemma map_bijective {f : R →+* S} (hf : Function.Bijective f) :
     Function.Bijective (map W f) :=
   ⟨map_injective hf.1, map_surjective W hf.2⟩
+
+/-- **A ring equivalence of the base induces one of the coordinate rings**, packaging
+`map_bijective`. -/
+noncomputable def mapEquiv (e : R ≃+* S) :
+    W.CoordinateRing ≃+* (W.map (e : R →+* S)).CoordinateRing :=
+  RingEquiv.ofBijective (map W (e : R →+* S)) (map_bijective W e.bijective)
+
+/-- The induced equivalence is `CoordinateRing.map`, so all of `map_mk`, `map_smul` and
+`map_injective` apply to it. -/
+@[simp]
+lemma mapEquiv_apply (e : R ≃+* S) (x : W.CoordinateRing) :
+    mapEquiv W e x = map W (e : R →+* S) x :=
+  RingEquiv.ofBijective_apply _ _ _
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingEquiv.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingEquiv.lean
@@ -22,8 +22,9 @@ stated about `CoordinateRing.map`.
 * `WeierstrassCurve.Affine.CoordinateRing.mapEquiv`: the induced ring equivalence
   `R[W] ≃+* S[W.map e]`, as `AdjoinRoot.mapRingEquiv` along `map_polynomial`.
 * `WeierstrassCurve.Affine.CoordinateRing.mapEquiv_apply`: it agrees with `CoordinateRing.map`.
-* `WeierstrassCurve.Affine.CoordinateRing.map_bijective`: hence `CoordinateRing.map` along an
-  equivalence is bijective.
+* `WeierstrassCurve.Affine.CoordinateRing.map_surjective` and
+  `WeierstrassCurve.Affine.CoordinateRing.map_bijective`: the companions of Mathlib's
+  `CoordinateRing.map_injective`, stated like it for an arbitrary `f : R →+* S`.
 
 Stated over arbitrary commutative rings; the curve need not be elliptic.
 
@@ -78,9 +79,19 @@ lemma mapEquiv_apply (e : R ≃+* S) (x : W.CoordinateRing) :
       AdjoinRoot.lift_mk]
     rfl
 
-/-- `CoordinateRing.map` along a ring equivalence is bijective. -/
-lemma map_bijective (e : R ≃+* S) : Function.Bijective (map W (e : R →+* S)) := by
-  simpa only [funext (mapEquiv_apply W e)] using (mapEquiv W e).bijective
+/-- **`CoordinateRing.map` is surjective when the base map is**, the companion of Mathlib's
+`CoordinateRing.map_injective`. A class upstairs is `mk` of a polynomial, and a polynomial over
+`S` is the image of one over `R`. -/
+lemma map_surjective {f : R →+* S} (hf : Function.Surjective f) :
+    Function.Surjective (map W f) := fun y => by
+  obtain ⟨p, rfl⟩ := AdjoinRoot.mk_surjective y
+  obtain ⟨q, rfl⟩ := Polynomial.map_surjective (mapRingHom f) (Polynomial.map_surjective f hf) p
+  exact ⟨mk W q, map_mk f q⟩
+
+/-- **`CoordinateRing.map` is bijective when the base map is.** -/
+lemma map_bijective {f : R →+* S} (hf : Function.Bijective f) :
+    Function.Bijective (map W f) :=
+  ⟨map_injective hf.1, map_surjective W hf.2⟩
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingEquiv.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingEquiv.lean
@@ -11,18 +11,21 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
 
 Mathlib's `WeierstrassCurve.Affine.CoordinateRing.map` sends a ring homomorphism `f : R →+* S` to
 `R[W] →+* S[W.map f]`, and proves it injective when `f` is (`CoordinateRing.map_injective`). When
-`f` is an equivalence the induced map is an equivalence too, which is what this file adds: the
-missing surjectivity, and the resulting `≃+*`.
+`f` is an equivalence the induced map is an equivalence, and Mathlib already has the construction
+generically: `R[W]` is by definition `AdjoinRoot W.polynomial`, so `AdjoinRoot.mapRingEquiv`
+applies. What is missing is the bridge — that the generic equivalence *is* `CoordinateRing.map` —
+without which the equivalence is cut off from the `map_mk`, `map_smul` and `map_injective` API
+stated about `CoordinateRing.map`.
 
 ## Main results
 
-* `WeierstrassCurve.Affine.CoordinateRing.map_surjective`: `CoordinateRing.map` along a ring
-  equivalence is surjective.
 * `WeierstrassCurve.Affine.CoordinateRing.mapEquiv`: the induced ring equivalence
-  `R[W] ≃+* S[W.map e]`.
+  `R[W] ≃+* S[W.map e]`, as `AdjoinRoot.mapRingEquiv` along `map_polynomial`.
+* `WeierstrassCurve.Affine.CoordinateRing.mapEquiv_apply`: it agrees with `CoordinateRing.map`.
+* `WeierstrassCurve.Affine.CoordinateRing.map_bijective`: hence `CoordinateRing.map` along an
+  equivalence is bijective.
 
-Stated over arbitrary commutative rings; the curve need not be elliptic, since the argument is
-just that `Polynomial.map` along `e` and along `e.symm` are mutually inverse.
+Stated over arbitrary commutative rings; the curve need not be elliptic.
 
 This supports the Hasse strand of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 3. That
 roadmap's Layer-0 narrative makes the Frobenius "the key input to Layer 3", and the arithmetic
@@ -39,9 +42,10 @@ The need for this step, and the surjectivity argument (lift `e.symm` through `Ad
 `Polynomial.map`), are from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`,
 Apache-2.0, pinned by that roadmap at `dev/hasse-weil @ 513e83879e2f`),
 `HasseWeil/WeilPairing/FrobeniusFunctionFieldEquiv.lean`, declaration `coordRingMap_bijective`.
-There the statement is bundled as bijectivity of a map between the coordinate rings of a curve and
-of its image; here it is split into the surjectivity Mathlib is missing and the packaged `≃+*`,
-with injectivity taken from Mathlib's `CoordinateRing.map_injective` rather than reproved.
+There the equivalence is rebuilt by hand — injectivity from `map_injective`, surjectivity by
+lifting `e.symm` through `AdjoinRoot.mk` — inside a 267-line file that also constructs the
+function-field Frobenius. Here neither half is reproved: the equivalence is Mathlib's
+`AdjoinRoot.mapRingEquiv`, and the only new content is that it agrees with `CoordinateRing.map`.
 -/
 
 public section
@@ -54,25 +58,29 @@ namespace WeierstrassCurve.Affine.CoordinateRing
 
 variable {R S : Type*} [CommRing R] [CommRing S] (W : WeierstrassCurve.Affine R)
 
-/-- `CoordinateRing.map` along a ring equivalence is surjective: a class upstairs is the image of
-the class of the same polynomial pulled back along `e.symm`. -/
-lemma map_surjective (e : R ≃+* S) :
-    Function.Surjective (map W (e : R →+* S)) := fun y => by
-  obtain ⟨p, rfl⟩ := AdjoinRoot.mk_surjective y
-  refine ⟨mk W (p.map (mapRingHom (e.symm : S →+* R))), ?_⟩
-  rw [map_mk, Polynomial.map_map]
-  simp
-
-/-- **A ring equivalence of the base induces one of the coordinate rings.** Injectivity is
-Mathlib's `CoordinateRing.map_injective`; surjectivity is `map_surjective` above. -/
+/-- **A ring equivalence of the base induces one of the coordinate rings.** This is Mathlib's
+generic `AdjoinRoot.mapRingEquiv`, specialised along `map_polynomial`: `R[W]` is by definition
+`AdjoinRoot W.polynomial`, and `(W.map e).polynomial` is `W.polynomial.map (mapRingHom e)`. -/
 noncomputable def mapEquiv (e : R ≃+* S) :
     W.CoordinateRing ≃+* (W.map (e : R →+* S)).CoordinateRing :=
-  RingEquiv.ofBijective (map W (e : R →+* S))
-    ⟨map_injective e.injective, map_surjective W e⟩
+  AdjoinRoot.mapRingEquiv (Polynomial.mapEquiv e) W.polynomial (W.map (e : R →+* S)).polynomial
+    (by rw [WeierstrassCurve.Affine.map_polynomial]; rfl)
 
+/-- **The induced equivalence is Mathlib's `CoordinateRing.map`.** Without this the equivalence
+would be cut off from the `map_mk`, `map_smul` and `map_injective` API stated about
+`CoordinateRing.map`. -/
 @[simp]
 lemma mapEquiv_apply (e : R ≃+* S) (x : W.CoordinateRing) :
-    mapEquiv W e x = map W (e : R →+* S) x := RingEquiv.ofBijective_apply _ _ _
+    mapEquiv W e x = map W (e : R →+* S) x := by
+  induction x using AdjoinRoot.induction_on with
+  | _ p =>
+    simp only [mapEquiv, AdjoinRoot.mapRingEquiv, RingEquiv.ofRingHom_apply, AdjoinRoot.map, map,
+      AdjoinRoot.lift_mk]
+    rfl
+
+/-- `CoordinateRing.map` along a ring equivalence is bijective. -/
+lemma map_bijective (e : R ≃+* S) : Function.Bijective (map W (e : R →+* S)) := by
+  simpa only [funext (mapEquiv_apply W e)] using (mapEquiv W e).bijective
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingEquiv.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingEquiv.lean
@@ -57,8 +57,7 @@ namespace WeierstrassCurve.Affine.CoordinateRing
 variable {R S : Type*} [CommRing R] [CommRing S] (W : WeierstrassCurve.Affine R)
 
 /-- **`CoordinateRing.map` is surjective when the base map is**, the companion of Mathlib's
-`CoordinateRing.map_injective`. A class upstairs is `mk` of a polynomial, and a polynomial over
-`S` is the image of one over `R`. -/
+`CoordinateRing.map_injective`. -/
 lemma map_surjective {f : R →+* S} (hf : Function.Surjective f) :
     Function.Surjective (map W f) := fun y => by
   obtain ⟨p, rfl⟩ := AdjoinRoot.mk_surjective y

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean
@@ -38,15 +38,16 @@ reimplementation of it.
 
 ## Provenance
 
-The need for this step, and the surjectivity argument (lift `e.symm` through `AdjoinRoot.mk` and
-`Polynomial.map`), are from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`,
-Apache-2.0, pinned by that roadmap at `dev/hasse-weil @ 513e83879e2f`),
-`HasseWeil/WeilPairing/FrobeniusFunctionFieldEquiv.lean`, declaration `coordRingMap_bijective`.
-There it is bundled as bijectivity of one map, for a ring equivalence only, inside a 267-line file
-that also constructs the function-field Frobenius. Here it is split out and generalised: the
-surjectivity is stated for any surjective `f : R →+* S`, matching the generality of Mathlib's
-`CoordinateRing.map_injective`, and the equivalence it was bundled
-for is left to the use site.
+The need for these statements is from the AINTLIB `HasseWeil` project
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by that roadmap at
+`dev/hasse-weil @ 513e83879e2f`), `HasseWeil/WeilPairing/FrobeniusFunctionFieldEquiv.lean`,
+declaration `coordRingMap_bijective`. There they are bundled as bijectivity of one map, for a ring
+*equivalence* only — surjectivity being obtained by lifting along `e.symm` — inside a 267-line
+file that also constructs the function-field Frobenius. Here there is no inverse to lift along:
+the statement is for an arbitrary surjective `f : R →+* S`, matching the generality of Mathlib's
+`CoordinateRing.map_injective`, and preimages come from `Polynomial.map_surjective`. The argument
+itself lives one level down, in `TauCeti/RingTheory/AdjoinRoot.lean`; the equivalence the source
+bundled it for is left to the use site.
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean
@@ -10,15 +10,19 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
 # Surjectivity of the coordinate-ring map
 
 Mathlib's `WeierstrassCurve.Affine.CoordinateRing.map` sends a ring homomorphism `f : R →+* S` to
-`R[W] →+* S[W.map f]`, and proves it injective when `f` is (`CoordinateRing.map_injective`). This
-file adds the two companions Mathlib does not state, at the same generality: surjectivity and
-bijectivity.
+`R[W] →+* S[W.map f]`, and proves it injective when `f` is (`CoordinateRing.map_injective`). It
+states no surjectivity. Since `R[W]` is `AdjoinRoot W.polynomial`, the natural home for that
+argument is `AdjoinRoot.map`, where Mathlib states neither the action on a class nor surjectivity;
+both are supplied here, and the coordinate-ring statements follow in a line.
 
 ## Main results
 
+* `AdjoinRoot.map_mk`: `AdjoinRoot.map` on the class of a polynomial is the class of its image —
+  the `AdjoinRoot`-level form of Mathlib's `CoordinateRing.map_mk`.
+* `AdjoinRoot.map_surjective`: `AdjoinRoot.map` is surjective when the base map is.
 * `WeierstrassCurve.Affine.CoordinateRing.map_surjective` and
-  `WeierstrassCurve.Affine.CoordinateRing.map_bijective`: stated, like Mathlib's
-  `CoordinateRing.map_injective`, for an arbitrary `f : R →+* S`.
+  `WeierstrassCurve.Affine.CoordinateRing.map_bijective`: the coordinate-ring specialisations,
+  stated like Mathlib's `CoordinateRing.map_injective` for an arbitrary `f : R →+* S`.
 
 For a base *equivalence* `e` these give `RingEquiv.ofBijective (map W e) (map_bijective W
 e.bijective)` in one line at the use site, so no equivalence is defined here; Mathlib's generic
@@ -29,11 +33,10 @@ Stated over arbitrary commutative rings; the curve need not be elliptic.
 This supports the Hasse strand of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 3. That
 roadmap's Layer-0 narrative makes the Frobenius "the key input to Layer 3", and the arithmetic
 Frobenius of the function field over a finite field is obtained by transporting the `q`-power map
-of the base along exactly this construction: it is a ring *equivalence* of `K̄` and so must be
-carried to an equivalence of coordinate rings before it can be pushed to the fraction field. The
-roadmap's §"What Mathlib already has (consume)" lists `Affine.CoordinateRing` as consumed
-infrastructure that "is load-bearing API here, not an implementation detail"; this is a complement
-to that API, not a reimplementation of it.
+of the base to the coordinate ring, which needs exactly this bijectivity. The roadmap's §"What
+Mathlib already has (consume)" lists `Affine.CoordinateRing` as consumed infrastructure that "is
+load-bearing API here, not an implementation detail"; this is a complement to that API, not a
+reimplementation of it.
 
 ## Provenance
 
@@ -54,6 +57,26 @@ open Polynomial
 
 open scoped Polynomial.Bivariate
 
+namespace AdjoinRoot
+
+variable {R S : Type*} [CommRing R] [CommRing S]
+
+/-- `AdjoinRoot.map` on the class of a polynomial is the class of its image. Mathlib states this
+for `WeierstrassCurve.Affine.CoordinateRing.map` but not for the underlying `AdjoinRoot.map`. -/
+lemma map_mk {f : R →+* S} {p : R[X]} {q : S[X]} (h : q ∣ p.map f) (x : R[X]) :
+    map f p q h (mk p x) = mk q (x.map f) := by
+  rw [map, lift_mk, ← Polynomial.eval₂_map]
+  exact aeval_eq (x.map f)
+
+/-- **`AdjoinRoot.map` is surjective when the base map is.** -/
+lemma map_surjective {f : R →+* S} (hf : Function.Surjective f) {p : R[X]} {q : S[X]}
+    (h : q ∣ p.map f) : Function.Surjective (map f p q h) := fun y => by
+  obtain ⟨t, rfl⟩ := mk_surjective y
+  obtain ⟨u, rfl⟩ := Polynomial.map_surjective f hf t
+  exact ⟨mk p u, map_mk h u⟩
+
+end AdjoinRoot
+
 namespace WeierstrassCurve.Affine.CoordinateRing
 
 variable {R S : Type*} [CommRing R] [CommRing S] (W : WeierstrassCurve.Affine R)
@@ -61,10 +84,9 @@ variable {R S : Type*} [CommRing R] [CommRing S] (W : WeierstrassCurve.Affine R)
 /-- **`CoordinateRing.map` is surjective when the base map is**, the companion of Mathlib's
 `CoordinateRing.map_injective`. -/
 lemma map_surjective {f : R →+* S} (hf : Function.Surjective f) :
-    Function.Surjective (map W f) := fun y => by
-  obtain ⟨p, rfl⟩ := AdjoinRoot.mk_surjective y
-  obtain ⟨q, rfl⟩ := Polynomial.map_surjective (mapRingHom f) (Polynomial.map_surjective f hf) p
-  exact ⟨mk W q, map_mk f q⟩
+    Function.Surjective (map W f) :=
+  AdjoinRoot.map_surjective (Polynomial.map_surjective f hf)
+    (dvd_of_eq (WeierstrassCurve.Affine.map_polynomial (W := W) (f := f)))
 
 /-- **`CoordinateRing.map` is bijective when the base map is.** -/
 lemma map_bijective {f : R →+* S} (hf : Function.Bijective f) :

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean
@@ -5,21 +5,19 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+public import TauCeti.RingTheory.AdjoinRoot
 
 /-!
 # Surjectivity of the coordinate-ring map
 
 Mathlib's `WeierstrassCurve.Affine.CoordinateRing.map` sends a ring homomorphism `f : R →+* S` to
 `R[W] →+* S[W.map f]`, and proves it injective when `f` is (`CoordinateRing.map_injective`). It
-states no surjectivity. Since `R[W]` is `AdjoinRoot W.polynomial`, the natural home for that
-argument is `AdjoinRoot.map`, where Mathlib states neither the action on a class nor surjectivity;
-both are supplied here, and the coordinate-ring statements follow in a line.
+states no surjectivity. Since `R[W]` is `AdjoinRoot W.polynomial`, the argument lives at the
+`AdjoinRoot` level in `TauCeti/RingTheory/AdjoinRoot.lean`; the coordinate-ring statements follow
+in a line each.
 
 ## Main results
 
-* `AdjoinRoot.map_mk`: `AdjoinRoot.map` on the class of a polynomial is the class of its image —
-  the `AdjoinRoot`-level form of Mathlib's `CoordinateRing.map_mk`.
-* `AdjoinRoot.map_surjective`: `AdjoinRoot.map` is surjective when the base map is.
 * `WeierstrassCurve.Affine.CoordinateRing.map_surjective` and
   `WeierstrassCurve.Affine.CoordinateRing.map_bijective`: the coordinate-ring specialisations,
   stated like Mathlib's `CoordinateRing.map_injective` for an arbitrary `f : R →+* S`.
@@ -56,26 +54,6 @@ public section
 open Polynomial
 
 open scoped Polynomial.Bivariate
-
-namespace AdjoinRoot
-
-variable {R S : Type*} [CommRing R] [CommRing S]
-
-/-- `AdjoinRoot.map` on the class of a polynomial is the class of its image. Mathlib states this
-for `WeierstrassCurve.Affine.CoordinateRing.map` but not for the underlying `AdjoinRoot.map`. -/
-lemma map_mk {f : R →+* S} {p : R[X]} {q : S[X]} (h : q ∣ p.map f) (x : R[X]) :
-    map f p q h (mk p x) = mk q (x.map f) := by
-  rw [map, lift_mk, ← Polynomial.eval₂_map]
-  exact aeval_eq (x.map f)
-
-/-- **`AdjoinRoot.map` is surjective when the base map is.** -/
-lemma map_surjective {f : R →+* S} (hf : Function.Surjective f) {p : R[X]} {q : S[X]}
-    (h : q ∣ p.map f) : Function.Surjective (map f p q h) := fun y => by
-  obtain ⟨t, rfl⟩ := mk_surjective y
-  obtain ⟨u, rfl⟩ := Polynomial.map_surjective f hf t
-  exact ⟨mk p u, map_mk h u⟩
-
-end AdjoinRoot
 
 namespace WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean
@@ -7,21 +7,22 @@ module
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
 
 /-!
-# A ring equivalence of the base induces one of the coordinate rings
+# Surjectivity of the coordinate-ring map
 
 Mathlib's `WeierstrassCurve.Affine.CoordinateRing.map` sends a ring homomorphism `f : R →+* S` to
 `R[W] →+* S[W.map f]`, and proves it injective when `f` is (`CoordinateRing.map_injective`). This
-file adds the two companions Mathlib does not state — surjectivity and bijectivity, at the same
-generality — and packages the bijective case as a ring equivalence.
+file adds the two companions Mathlib does not state, at the same generality: surjectivity and
+bijectivity.
 
 ## Main results
 
 * `WeierstrassCurve.Affine.CoordinateRing.map_surjective` and
   `WeierstrassCurve.Affine.CoordinateRing.map_bijective`: stated, like Mathlib's
   `CoordinateRing.map_injective`, for an arbitrary `f : R →+* S`.
-* `WeierstrassCurve.Affine.CoordinateRing.mapEquiv`: the induced `R[W] ≃+* S[W.map e]`, with
-  `mapEquiv_apply` identifying it with `CoordinateRing.map` so that the `map_mk`, `map_smul` and
-  `map_injective` API applies to it unchanged.
+
+For a base *equivalence* `e` these give `RingEquiv.ofBijective (map W e) (map_bijective W
+e.bijective)` in one line at the use site, so no equivalence is defined here; Mathlib's generic
+`AdjoinRoot.mapRingEquiv` is the other route to the same object.
 
 Stated over arbitrary commutative rings; the curve need not be elliptic.
 
@@ -43,7 +44,8 @@ Apache-2.0, pinned by that roadmap at `dev/hasse-weil @ 513e83879e2f`),
 There it is bundled as bijectivity of one map, for a ring equivalence only, inside a 267-line file
 that also constructs the function-field Frobenius. Here it is split out and generalised: the
 surjectivity is stated for any surjective `f : R →+* S`, matching the generality of Mathlib's
-`CoordinateRing.map_injective`, and the equivalence is the packaging of the bijective case.
+`CoordinateRing.map_injective`, and the equivalence it was bundled
+for is left to the use site.
 -/
 
 public section
@@ -68,19 +70,6 @@ lemma map_surjective {f : R →+* S} (hf : Function.Surjective f) :
 lemma map_bijective {f : R →+* S} (hf : Function.Bijective f) :
     Function.Bijective (map W f) :=
   ⟨map_injective hf.1, map_surjective W hf.2⟩
-
-/-- **A ring equivalence of the base induces one of the coordinate rings**, packaging
-`map_bijective`. -/
-noncomputable def mapEquiv (e : R ≃+* S) :
-    W.CoordinateRing ≃+* (W.map (e : R →+* S)).CoordinateRing :=
-  RingEquiv.ofBijective (map W (e : R →+* S)) (map_bijective W e.bijective)
-
-/-- The induced equivalence is `CoordinateRing.map`, so all of `map_mk`, `map_smul` and
-`map_injective` apply to it. -/
-@[simp]
-lemma mapEquiv_apply (e : R ≃+* S) (x : W.CoordinateRing) :
-    mapEquiv W e x = map W (e : R →+* S) x :=
-  RingEquiv.ofBijective_apply _ _ _
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/RingTheory/AdjoinRoot.lean
+++ b/TauCeti/RingTheory/AdjoinRoot.lean
@@ -17,7 +17,8 @@ a general polynomial, and says nothing about surjectivity. Both are added here.
 ## Main results
 
 * `AdjoinRoot.map_mk`: the map sends the class of `x` to the class of `x.map f`. Mathlib states
-  this only in the specialised form `WeierstrassCurve.Affine.CoordinateRing.map_mk`.
+  this only in the specialised form `WeierstrassCurve.Affine.CoordinateRing.map_mk`. Marked
+  `@[simp]`, like its neighbours `AdjoinRoot.map_of` and `AdjoinRoot.map_root`.
 * `AdjoinRoot.map_surjective`: the map is surjective when `f` is.
 
 Stated over arbitrary commutative rings.
@@ -47,6 +48,7 @@ variable {R S : Type*} [CommRing R] [CommRing S]
 
 /-- `AdjoinRoot.map` on the class of a polynomial is the class of its image. Mathlib states this
 for `WeierstrassCurve.Affine.CoordinateRing.map` but not for the underlying `AdjoinRoot.map`. -/
+@[simp]
 lemma map_mk {f : R →+* S} {p : R[X]} {q : S[X]} (h : q ∣ p.map f) (x : R[X]) :
     map f p q h (mk p x) = mk q (x.map f) := by
   rw [map, lift_mk, ← Polynomial.eval₂_map]

--- a/TauCeti/RingTheory/AdjoinRoot.lean
+++ b/TauCeti/RingTheory/AdjoinRoot.lean
@@ -25,6 +25,16 @@ Stated over arbitrary commutative rings.
 This is consumed by `TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean`, which
 specialises it to the coordinate ring of a Weierstrass curve for the Hasse strand of
 `TauCetiRoadmap/EllipticCurves/README.md`, Layer 3.
+
+## Provenance
+
+The surjectivity argument — lift a class to a polynomial, then lift that polynomial along `f` — is
+adapted from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by
+that roadmap at `dev/hasse-weil @ 513e83879e2f`),
+`HasseWeil/WeilPairing/FrobeniusFunctionFieldEquiv.lean`, declaration `coordRingMap_bijective`.
+There it is carried out for the coordinate ring of a Weierstrass curve and only for a base ring
+*equivalence*; here it is stated for `AdjoinRoot.map` along any surjective base homomorphism, with
+`map_mk` — which the source does not isolate — extracted as the step that makes it routine.
 -/
 
 public section

--- a/TauCeti/RingTheory/AdjoinRoot.lean
+++ b/TauCeti/RingTheory/AdjoinRoot.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.AdjoinRoot
+
+/-!
+# Complements on `AdjoinRoot.map`
+
+Mathlib's `AdjoinRoot.map` sends a ring homomorphism `f : R →+* S`, together with a divisibility
+`q ∣ p.map f`, to a ring homomorphism `AdjoinRoot p →+* AdjoinRoot q`. It records the action on
+`AdjoinRoot.of` and on `AdjoinRoot.root` (`map_of`, `map_root`) but not the action on the class of
+a general polynomial, and says nothing about surjectivity. Both are added here.
+
+## Main results
+
+* `AdjoinRoot.map_mk`: the map sends the class of `x` to the class of `x.map f`. Mathlib states
+  this only in the specialised form `WeierstrassCurve.Affine.CoordinateRing.map_mk`.
+* `AdjoinRoot.map_surjective`: the map is surjective when `f` is.
+
+Stated over arbitrary commutative rings.
+
+This is consumed by `TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean`, which
+specialises it to the coordinate ring of a Weierstrass curve for the Hasse strand of
+`TauCetiRoadmap/EllipticCurves/README.md`, Layer 3.
+-/
+
+public section
+
+open Polynomial
+
+namespace AdjoinRoot
+
+variable {R S : Type*} [CommRing R] [CommRing S]
+
+/-- `AdjoinRoot.map` on the class of a polynomial is the class of its image. Mathlib states this
+for `WeierstrassCurve.Affine.CoordinateRing.map` but not for the underlying `AdjoinRoot.map`. -/
+lemma map_mk {f : R →+* S} {p : R[X]} {q : S[X]} (h : q ∣ p.map f) (x : R[X]) :
+    map f p q h (mk p x) = mk q (x.map f) := by
+  rw [map, lift_mk, ← Polynomial.eval₂_map]
+  exact aeval_eq (x.map f)
+
+/-- **`AdjoinRoot.map` is surjective when the base map is.** -/
+lemma map_surjective {f : R →+* S} (hf : Function.Surjective f) {p : R[X]} {q : S[X]}
+    (h : q ∣ p.map f) : Function.Surjective (map f p q h) := fun y => by
+  obtain ⟨t, rfl⟩ := mk_surjective y
+  obtain ⟨u, rfl⟩ := Polynomial.map_surjective f hf t
+  exact ⟨mk p u, map_mk h u⟩
+
+end AdjoinRoot
+
+
+end


### PR DESCRIPTION
Mathlib's `WeierstrassCurve.Affine.CoordinateRing.map` sends a ring homomorphism `f : R →+* S` to `R[W] →+* S[W.map f]` and proves it **injective** when `f` is. It states no surjectivity. Since `R[W]` is `AdjoinRoot W.polynomial`, that argument belongs at the `AdjoinRoot` level — where Mathlib states neither the action on a class nor surjectivity. Both are added in a new ring-theory module, `TauCeti/RingTheory/AdjoinRoot.lean`, and the coordinate-ring statements in `Affine/CoordinateRingMap.lean` follow in a line each.

```lean
lemma AdjoinRoot.map_mk {f : R →+* S} {p : R[X]} {q : S[X]} (h : q ∣ p.map f) (x : R[X]) :
    map f p q h (mk p x) = mk q (x.map f)
lemma AdjoinRoot.map_surjective {f : R →+* S} (hf : Function.Surjective f)
    {p : R[X]} {q : S[X]} (h : q ∣ p.map f) : Function.Surjective (map f p q h)

lemma CoordinateRing.map_surjective {f : R →+* S} (hf : Function.Surjective f) :
    Function.Surjective (map W f)
lemma CoordinateRing.map_bijective {f : R →+* S} (hf : Function.Bijective f) :
    Function.Bijective (map W f)
```

`AdjoinRoot.map_mk` is the `AdjoinRoot`-level form of Mathlib's own `CoordinateRing.map_mk`, which Mathlib states only in the specialised case.

No ring equivalence is defined here, deliberately. For a base equivalence `e`, `RingEquiv.ofBijective (map W e) (map_bijective W e.bijective)` is a one-liner at the use site, and Mathlib's generic `AdjoinRoot.mapRingEquiv` is a second route to the same object — so a third named form would duplicate one of them whichever way it were built.

## Roadmap

The Hasse strand of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 3. The roadmap's Layer-0 narrative calls the Frobenius "the key input to Layer 3", and over a finite field the *arithmetic* Frobenius of the function field `K̄(E)` is obtained by transporting the `q`-power map of `K̄` along exactly this construction — that map is a ring equivalence of the base, so it must first be carried to an equivalence of coordinate rings before it can be pushed to the fraction field. TauCeti already has the field-theoretic half of the same Silverman V.1 route, `TauCeti.FiniteField.pow_card_eq_self_iff_mem_range_algebraMap` (#2307).

The roadmap's §"What Mathlib already has (consume)" lists `Affine.CoordinateRing` as consumed infrastructure whose "infrastructure is load-bearing API here, not an implementation detail: … Layer 0 is built directly on these". This is a complement to that API in the sense TauCeti's `RingTheory/DedekindDomain/Ideal.lean` complements Mathlib's height-one-spectrum API — not a reimplementation of anything Mathlib has.

## Mathlib absence

An untruncated grep over `Mathlib/AlgebraicGeometry/EllipticCurve/` for `mapEquiv`, `map_surjective` and `map_bijective` returns nothing; the neighbourhood of `CoordinateRing.map` (`Affine/Point.lean:184–204`) has `map`, `map_mk`, `map_smul` and `map_injective` only. One abstraction level up Mathlib has `AdjoinRoot.mapRingEquiv`, which supplies an equivalence when the base map is one — but not the surjectivity of `CoordinateRing.map` along an arbitrary surjective hom, which is the statement here. (`exact?` on these statements exhausts its heartbeat budget rather than answering, so it is not evidence either way.)

## Provenance

The need for these statements is from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by that roadmap at `dev/hasse-weil @ 513e83879e2f`), `HasseWeil/WeilPairing/FrobeniusFunctionFieldEquiv.lean`, declaration `coordRingMap_bijective`. There they are bundled as bijectivity of one map, for a ring *equivalence* only — surjectivity being obtained by lifting along `e.symm` — inside a 267-line file that also constructs the function-field Frobenius.

Here there is no inverse to lift along: the statement is for an arbitrary surjective `f : R →+* S`, matching the generality of Mathlib's `CoordinateRing.map_injective`, and preimages come from `Polynomial.map_surjective`. `AdjoinRoot.map_mk`, which the source does not isolate, is what makes the general argument routine. Both generic lemmas carry this credit in `TauCeti/RingTheory/AdjoinRoot.lean`.

Two files: `TauCeti/RingTheory/AdjoinRoot.lean` for the generic lemmas, and `TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean` for the two specialisations. The generic half is kept out of the elliptic-curve tree so it is not hidden behind a late import. Note also that open PR #2486 (another worker) adds `Affine/CoordinateRing.lean`; `CoordinateRingMap.lean` is a separate module and shares no declaration with it.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"coordinateringmapequiv"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
