### PR TITLE
refactor(ModularForms): name the positive-determinant transformation law

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Basic.lean
@@ -112,22 +112,18 @@ theorem _root_.SlashInvariantForm.slash_action_eqn_of_det_pos {F : Type*} [FunLi
     {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [SlashInvariantFormClass F Γ k] (f : F) {γ}
     (hγ : γ ∈ Γ) (hdet : 0 < γ.val.det) (τ : ℍ) :
     f (γ • τ) = ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) * denom γ (τ : ℂ) ^ k * f τ := by
-  have h := congr_fun (SlashInvariantForm.slash_action_eqn f γ hγ) τ
-  rw [ModularForm.slash_def] at h
-  have hdet' : (0 : ℝ) < ↑(Matrix.GeneralLinearGroup.det γ) := by
-    rwa [Matrix.GeneralLinearGroup.val_det_apply]
-  have hσ : σ γ = ContinuousAlgEquiv.refl ℝ ℂ := by rw [σ, if_pos hdet']
-  rw [hσ] at h
-  have hden : denom γ (τ : ℂ) ≠ 0 := denom_ne_zero γ τ
   have hdet_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ≠ 0 := by
     exact_mod_cast (abs_pos.mpr (γ.det : ℝˣ).ne_zero).ne'
-  have h2 : f (γ • τ) =
-      f τ * (((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1))⁻¹ * (denom γ (τ : ℂ) ^ (-k))⁻¹ := by
-    rw [← h]
-    field_simp
-    rfl
-  have hexp : -(k - 1) = 1 - k := by ring
-  rw [h2, ← zpow_neg, ← zpow_neg, neg_neg, hexp]
+  have h := congr_fun (SlashInvariantForm.slash_action_eqn f γ hγ) τ
+  have hdet' : (0 : ℝ) < ↑(Matrix.GeneralLinearGroup.det γ) := by
+    rwa [Matrix.GeneralLinearGroup.val_det_apply]
+  rw [ModularForm.slash_def, σ, if_pos hdet'] at h
+  simp only [ContinuousAlgEquiv.refl_apply] at h
+  -- clear the two inverse factors of the slash action in turn, then read off the exponents
+  have hden : denom γ (τ : ℂ) ^ (-k) ≠ 0 := zpow_ne_zero _ (denom_ne_zero γ τ)
+  have hpow : ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1) ≠ 0 := zpow_ne_zero _ hdet_ne
+  rw [(eq_mul_inv_iff_mul_eq₀ hpow).mpr ((eq_mul_inv_iff_mul_eq₀ hden).mpr h),
+    ← zpow_neg, ← zpow_neg, neg_neg, neg_sub]
   ring
 
 /-! ### Changing the invariance group

--- a/TauCeti/NumberTheory/ModularForms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Basic.lean
@@ -42,6 +42,9 @@ AINTLIB `LeanModularForms` project
 
 * `SlashInvariantFormClass.SL_slash_eq`: a form invariant under the image of `Γ ≤ SL(2, ℤ)`
   is fixed by the slash action of every element of `Γ`.
+* `SlashInvariantForm.slash_action_eqn_of_det_pos`: the transformation law
+  `f (γ • τ) = |det γ| ^ (1 - k) * denom γ τ ^ k * f τ` for `γ` of positive determinant,
+  generalising Mathlib's `slash_action_eqn''`, which assumes `det γ = 1`.
 * `Subgroup.IsArithmetic.isCusp_of_isCusp`: any two arithmetic groups have the same cusps.
 * `ModularForm.mem_range_ofLeₗ_iff`, `CuspForm.mem_range_ofLeₗ_iff`: for `Γ' ≤ Γ` with every
   cusp of `Γ` a cusp of `Γ'`, a form for `Γ'` extends to `Γ` exactly when it is `Γ`-slash
@@ -99,6 +102,33 @@ theorem _root_.SlashInvariantFormClass.SL_slash_eq {F : Type*} [FunLike F ℍ �
     (γ : SL(2, ℤ)) (hγ : γ ∈ Γ) : ⇑f ∣[k] γ = ⇑f := by
   rw [ModularForm.SL_slash]
   exact SlashInvariantFormClass.slash_action_eq f _ ⟨γ, hγ, rfl⟩
+
+/-- **The transformation law of a slash-invariant form under a positive-determinant element.**
+For `γ ∈ Γ` with `0 < det γ`, `f (γ • τ) = |det γ| ^ (1 - k) * denom γ τ ^ k * f τ`.
+
+Mathlib's `SlashInvariantForm.slash_action_eqn''` is the `det = 1` case, in which the first
+factor is `1` and disappears. -/
+theorem _root_.SlashInvariantForm.slash_action_eqn_of_det_pos {F : Type*} [FunLike F ℍ ℂ]
+    {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [SlashInvariantFormClass F Γ k] (f : F) {γ}
+    (hγ : γ ∈ Γ) (hdet : 0 < γ.val.det) (τ : ℍ) :
+    f (γ • τ) = ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) * denom γ (τ : ℂ) ^ k * f τ := by
+  have h := congr_fun (SlashInvariantForm.slash_action_eqn f γ hγ) τ
+  rw [ModularForm.slash_def] at h
+  have hdet' : (0 : ℝ) < ↑(Matrix.GeneralLinearGroup.det γ) := by
+    rwa [Matrix.GeneralLinearGroup.val_det_apply]
+  have hσ : σ γ = ContinuousAlgEquiv.refl ℝ ℂ := by rw [σ, if_pos hdet']
+  rw [hσ] at h
+  have hden : denom γ (τ : ℂ) ≠ 0 := denom_ne_zero γ τ
+  have hdet_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ≠ 0 := by
+    exact_mod_cast (abs_pos.mpr (γ.det : ℝˣ).ne_zero).ne'
+  have h2 : f (γ • τ) =
+      f τ * (((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1))⁻¹ * (denom γ (τ : ℂ) ^ (-k))⁻¹ := by
+    rw [← h]
+    field_simp
+    rfl
+  have hexp : -(k - 1) = 1 - k := by ring
+  rw [h2, ← zpow_neg, ← zpow_neg, neg_neg, hexp]
+  ring
 
 /-! ### Changing the invariance group
 

--- a/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
@@ -178,6 +178,32 @@ lemma orderOfVanishingAt_pow (hf : MDiff f) (n : ℕ) (z : ℍ) :
 
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 
+/-- **The transformation law of a slash-invariant form under a positive-determinant element.**
+For `γ ∈ Γ` with `0 < det γ`, `f (γ • τ) = |det γ| ^ (1 - k) * denom γ τ ^ k * f τ`.
+
+Mathlib's `SlashInvariantForm.slash_action_eqn''` is the `det = 1` case, in which the first
+factor is `1` and disappears. -/
+private lemma slash_action_eqn_of_det_pos [SlashInvariantFormClass F Γ k] (f : F) {γ}
+    (hγ : γ ∈ Γ) (hdet : 0 < γ.val.det) (τ : ℍ) :
+    f (γ • τ) = ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) * denom γ (τ : ℂ) ^ k * f τ := by
+  have h := congr_fun (SlashInvariantForm.slash_action_eqn f γ hγ) τ
+  rw [ModularForm.slash_def] at h
+  have hdet' : (0 : ℝ) < ↑(Matrix.GeneralLinearGroup.det γ) := by
+    rwa [Matrix.GeneralLinearGroup.val_det_apply]
+  have hσ : σ γ = ContinuousAlgEquiv.refl ℝ ℂ := by rw [σ, if_pos hdet']
+  rw [hσ] at h
+  have hden : denom γ (τ : ℂ) ≠ 0 := denom_ne_zero γ τ
+  have hdet_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ≠ 0 := by
+    exact_mod_cast (abs_pos.mpr (γ.det : ℝˣ).ne_zero).ne'
+  have h2 : f (γ • τ) =
+      f τ * (((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1))⁻¹ * (denom γ (τ : ℂ) ^ (-k))⁻¹ := by
+    rw [← h]
+    field_simp
+    rfl
+  have hexp : -(k - 1) = 1 - k := by ring
+  rw [h2, ← zpow_neg, ← zpow_neg, neg_neg, hexp]
+  ring
+
 /-- The vanishing order of a slash-invariant form is constant along the action of any
 positive-determinant element of the group. -/
 -- Not a `simp` lemma: the subgroup `Γ` occurs only in the hypotheses, so `simpNF` rejects
@@ -187,30 +213,12 @@ lemma orderOfVanishingAt_smul [SlashInvariantFormClass F Γ k] (f : F) {γ}
     orderOfVanishingAt f (γ • z) = orderOfVanishingAt f z := by
   have hdet_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ≠ 0 := by
     exact_mod_cast (abs_pos.mpr (γ.det : ℝˣ).ne_zero).ne'
-  have hpt : ∀ τ : ℍ, f (γ • τ) =
-      ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) * denom γ (τ : ℂ) ^ k * f τ := by
-    intro τ
-    have h := congr_fun (SlashInvariantForm.slash_action_eqn f γ hγ) τ
-    rw [ModularForm.slash_def] at h
-    have hdet' : (0 : ℝ) < ↑(Matrix.GeneralLinearGroup.det γ) := by
-      rwa [Matrix.GeneralLinearGroup.val_det_apply]
-    have hσ : σ γ = ContinuousAlgEquiv.refl ℝ ℂ := by rw [σ, if_pos hdet']
-    rw [hσ] at h
-    have hden : denom γ (τ : ℂ) ≠ 0 := denom_ne_zero γ τ
-    have h2 : f (γ • τ) =
-        f τ * (((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1))⁻¹ * (denom γ (τ : ℂ) ^ (-k))⁻¹ := by
-      rw [← h]
-      field_simp
-      rfl
-    have hexp : -(k - 1) = 1 - k := by ring
-    rw [h2, ← zpow_neg, ← zpow_neg, neg_neg, hexp]
-    ring
   have hcongr : (fun w : ℂ ↦ f (γ • ofComplex w)) =ᶠ[nhds (z : ℂ)]
       (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) *
         ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) * (⇑f ∘ ofComplex) := by
     filter_upwards [isOpen_upperHalfPlaneSet.mem_nhds z.im_pos] with w hw
     rw [Pi.mul_apply, Function.comp_apply, ofComplex_apply_of_im_pos hw]
-    simpa [denom, mul_assoc] using hpt ⟨w, hw⟩
+    simpa [denom, mul_assoc] using slash_action_eqn_of_det_pos f hγ hdet ⟨w, hw⟩
   have h_an : AnalyticAt ℂ (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) *
       ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) (z : ℂ) := by
     refine AnalyticAt.mul analyticAt_const (AnalyticAt.zpow (by fun_prop) ?_)

--- a/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Analysis.Meromorphic.NormalForm
 public import Mathlib.NumberTheory.ModularForms.Basic
+public import TauCeti.NumberTheory.ModularForms.Basic
 public import TauCeti.Analysis.Complex.UpperHalfPlane.Manifold
 
 /-!
@@ -178,32 +179,6 @@ lemma orderOfVanishingAt_pow (hf : MDiff f) (n : ℕ) (z : ℍ) :
 
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 
-/-- **The transformation law of a slash-invariant form under a positive-determinant element.**
-For `γ ∈ Γ` with `0 < det γ`, `f (γ • τ) = |det γ| ^ (1 - k) * denom γ τ ^ k * f τ`.
-
-Mathlib's `SlashInvariantForm.slash_action_eqn''` is the `det = 1` case, in which the first
-factor is `1` and disappears. -/
-private lemma slash_action_eqn_of_det_pos [SlashInvariantFormClass F Γ k] (f : F) {γ}
-    (hγ : γ ∈ Γ) (hdet : 0 < γ.val.det) (τ : ℍ) :
-    f (γ • τ) = ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) * denom γ (τ : ℂ) ^ k * f τ := by
-  have h := congr_fun (SlashInvariantForm.slash_action_eqn f γ hγ) τ
-  rw [ModularForm.slash_def] at h
-  have hdet' : (0 : ℝ) < ↑(Matrix.GeneralLinearGroup.det γ) := by
-    rwa [Matrix.GeneralLinearGroup.val_det_apply]
-  have hσ : σ γ = ContinuousAlgEquiv.refl ℝ ℂ := by rw [σ, if_pos hdet']
-  rw [hσ] at h
-  have hden : denom γ (τ : ℂ) ≠ 0 := denom_ne_zero γ τ
-  have hdet_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ≠ 0 := by
-    exact_mod_cast (abs_pos.mpr (γ.det : ℝˣ).ne_zero).ne'
-  have h2 : f (γ • τ) =
-      f τ * (((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1))⁻¹ * (denom γ (τ : ℂ) ^ (-k))⁻¹ := by
-    rw [← h]
-    field_simp
-    rfl
-  have hexp : -(k - 1) = 1 - k := by ring
-  rw [h2, ← zpow_neg, ← zpow_neg, neg_neg, hexp]
-  ring
-
 /-- The vanishing order of a slash-invariant form is constant along the action of any
 positive-determinant element of the group. -/
 -- Not a `simp` lemma: the subgroup `Γ` occurs only in the hypotheses, so `simpNF` rejects
@@ -218,7 +193,7 @@ lemma orderOfVanishingAt_smul [SlashInvariantFormClass F Γ k] (f : F) {γ}
         ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) * (⇑f ∘ ofComplex) := by
     filter_upwards [isOpen_upperHalfPlaneSet.mem_nhds z.im_pos] with w hw
     rw [Pi.mul_apply, Function.comp_apply, ofComplex_apply_of_im_pos hw]
-    simpa [denom, mul_assoc] using slash_action_eqn_of_det_pos f hγ hdet ⟨w, hw⟩
+    simpa [denom, mul_assoc] using SlashInvariantForm.slash_action_eqn_of_det_pos f hγ hdet ⟨w, hw⟩
   have h_an : AnalyticAt ℂ (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) *
       ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) (z : ℂ) := by
     refine AnalyticAt.mul analyticAt_const (AnalyticAt.zpow (by fun_prop) ?_)

--- a/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Meromorphic.NormalForm
-public import Mathlib.NumberTheory.ModularForms.Basic
 public import TauCeti.NumberTheory.ModularForms.Basic
 public import TauCeti.Analysis.Complex.UpperHalfPlane.Manifold
 


### PR DESCRIPTION
`orderOfVanishingAt_smul` spent eighteen of its forty lines deriving a pointwise transformation law, before any of the vanishing-order argument began.

`SlashInvariantForm.slash_action_eqn_of_det_pos` states that law on its own: for `γ ∈ Γ` with `0 < det γ`,

```
f (γ • τ) = |det γ| ^ (1 - k) * denom γ τ ^ k * f τ
```

This is not in Mathlib. `SlashInvariantForm.slash_action_eqn'` and `slash_action_eqn''` both carry `[Γ.HasDetOne]`, so they give `f (γ • τ) = denom γ τ ^ k * f τ` — the special case in which the first factor is `1` and disappears. Once the determinant is merely positive the factor `|det γ| ^ (1 - k)` is genuinely present, and the derivation has to go back to `slash_action_eqn` and unfold the slash action, which is what the parent was doing inline.

It lives in `TauCeti/NumberTheory/ModularForms/Basic.lean`, the file for generic lemmas extending Mathlib's modular-forms API, beside `SlashInvariantFormClass.SL_slash_eq`. It is public and listed in that module's `## Main results`: the statement is about slash-invariant forms in general and mentions nothing about vanishing orders, so the order file is not its home. (It first landed as a private helper in `Order/OfVanishing.lean`; `placement` correctly pointed out that it does not belong there, and this is the relocated version.)

Its hypotheses are re-derived rather than inherited. It takes `hγ`, `hdet` and the point, and nothing else; in particular the parent's `hdet_ne` is **not** threaded through. That one is worth calling out, because it was a silent dependency: `field_simp` inside the derivation was picking `hdet_ne` up from the parent's local context, and the extracted lemma failed with a bare `Tactic 'rfl' failed` until I noticed. It is re-derived inside the lemma from `γ` being a unit, so no hypothesis was added to paper over it.

The parent keeps its own `hdet_ne`, which it still needs for the non-vanishing of the multiplier, and drops from 40 lines to 22 — leaving the eventual-equality, analyticity and non-vanishing steps that the order computation actually consumes.

Gates run locally: `lake build` (7167 jobs), `lake exe axioms` (31335 declarations), `lake exe module-system` (1613 modules), `scripts/lint-env.sh` — all green.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
