### PR TITLE
feat: embed affine groups as closed subgroups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -90,7 +90,7 @@ noncomputable def groupScheme : Grp (Over (Spec (CommRingCat.of R))) :=
     (Opposite.op (coordinateHopfAlgebra R n))
 
 /-- The general linear group scheme is the relative spectrum of its coordinate Hopf algebra. -/
-lemma groupScheme_eq_hopfSpec :
+lemma groupScheme_def :
     groupScheme R n =
       (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
         (Opposite.op (coordinateHopfAlgebra R n)) := by
@@ -328,7 +328,7 @@ noncomputable def groupSchemePointMulEquiv :
       ((Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
         (groupScheme R n).X) :=
   CommHopfAlgCat.mapMulEquivOfPresentation
-    (coordinateHopfAlgebra R n) A (groupScheme_eq_hopfSpec R n)
+    (coordinateHopfAlgebra R n) A (groupScheme_def R n)
 
 /-- The underlying map of the spectrum point associated to an algebra point. -/
 @[simp]
@@ -339,7 +339,7 @@ lemma groupSchemePointMulEquiv_apply_left
         eqToHom (groupScheme_X_left R n).symm := by
   simpa only [groupSchemePointMulEquiv] using
     CommHopfAlgCat.mapMulEquivOfPresentation_apply_left
-      (coordinateHopfAlgebra R n) A (groupScheme_eq_hopfSpec R n)
+      (coordinateHopfAlgebra R n) A (groupScheme_def R n)
         (groupScheme_X_left R n) f
 
 /-- The group of scheme-valued points of the general linear group scheme is the ordinary general
@@ -397,7 +397,7 @@ theorem schemePointsMulEquiv_mapValue (φ : A →ₐ[R] B)
           (CommAlgCat.ofHom φ) q := by
     simpa only [q, groupSchemePointMulEquiv] using
       CommHopfAlgCat.mapMulEquivOfPresentation_mapValue
-        (coordinateHopfAlgebra R n) φ (groupScheme_eq_hopfSpec R n) p
+        (coordinateHopfAlgebra R n) φ (groupScheme_def R n) p
   simp only [schemePointsMulEquiv, MulEquiv.trans_apply]
   rw [hpre, HopfAlgebra.mapPoints_apply, ← AlgHom.mapValue_apply]
   exact pointsMulEquiv_mapValue n φ q

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -89,7 +89,8 @@ noncomputable def groupScheme : Grp (Over (Spec (CommRingCat.of R))) :=
   (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
     (Opposite.op (coordinateHopfAlgebra R n))
 
-private lemma groupScheme_eq_hopfSpec :
+/-- The general linear group scheme is the relative spectrum of its coordinate Hopf algebra. -/
+lemma groupScheme_eq_hopfSpec :
     groupScheme R n =
       (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
         (Opposite.op (coordinateHopfAlgebra R n)) := by

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
@@ -151,7 +151,6 @@ comodule with a basis indexed by `Fin n`.
 
 This is relative spectrum applied contravariantly to the comodule's coordinate Hopf-algebra
 morphism `O(GLₙ) ⟶ H`. -/
-@[expose]
 noncomputable def coordinateGroupSchemeHom (b : Basis (Fin n) k M) :
     (hopfSpec (CommRingCat.of k)).obj (Opposite.op (CommHopfAlgCat.of k H)) ⟶
       GeneralLinear.groupScheme k n :=
@@ -165,7 +164,7 @@ theorem coordinateGroupSchemeHom_def (b : Basis (Fin n) k M) :
     coordinateGroupSchemeHom (H := H) b =
       (hopfSpec (CommRingCat.of k)).map
           (CommHopfAlgCat.ofHom (coordinateBialgHom (H := H) b)).op ≫
-        eqToHom (GeneralLinear.groupScheme_def k n).symm := rfl
+        eqToHom (GeneralLinear.groupScheme_def k n).symm := (rfl)
 
 /-- The group-scheme morphism associated to a finite free comodule is a closed immersion if
 and only if its coordinate Hopf-algebra morphism is surjective. -/
@@ -178,7 +177,7 @@ theorem isClosedImmersion_coordinateGroupSchemeHom_iff (b : Basis (Fin n) k M) :
     ((Over.forget (Spec (CommRingCat.of k))).mapIso
       ((Grp.forget (Over (Spec (CommRingCat.of k)))).mapIso
         (eqToIso (GeneralLinear.groupScheme_def k n).symm))).isIso_hom
-  rw [coordinateGroupSchemeHom]
+  rw [coordinateGroupSchemeHom_def]
   simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
   rw [MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion)]
   exact CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff _

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
@@ -233,9 +233,8 @@ theorem exists_isClosedImmersion_generalLinear
       (MorphismProperty.over_iso_iff
         (@LocallyOfFiniteType : MorphismProperty Scheme.{u})
           ((Grp.forget _).mapIso e)).mp
-        (show LocallyOfFiniteType G.obj.X.hom from inferInstance)
-    change LocallyOfFiniteType
-      (Spec.map (CommRingCat.ofHom (algebraMap k A))) at hA
+        (inferInstance : LocallyOfFiniteType G.obj.X.hom)
+    rw [hopfSpec_obj_X_hom] at hA
     apply RingHom.finiteType_algebraMap.mp
     exact (HasRingHomProperty.Spec_iff (P := @LocallyOfFiniteType)).mp hA
   let : Algebra.FiniteType k A := hAfinite

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
@@ -8,6 +8,7 @@ public import TauCeti.Algebra.AlgebraicGroup.Representation.Coordinate
 public import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.FiniteType
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Scheme
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.ClosedImmersion
+import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
 
 /-!
 # Embedding a finite-type affine group in a general linear group
@@ -36,7 +37,10 @@ group-scheme statement uses the same universe for them, as required by Mathlib's
 * `TauCeti.Comodule.exists_coordinateBialgHom_surjective`: a finite-type commutative Hopf
   algebra over a field admits a finite-dimensional regular subcomodule whose coordinate
   morphism from `O(GLₙ)` is surjective.
-* `TauCeti.Comodule.exists_isClosedImmersion_coordinateGroupSchemeHom`: every finite-type
+* `TauCeti.Comodule.exists_isClosedImmersion_coordinateGroupSchemeHom`: the group scheme
+  represented by a finite-type commutative Hopf algebra embeds as a closed subgroup of some
+  `GLₙ`.
+* `TauCeti.AffineGroupSchemeCat.exists_isClosedImmersion_generalLinear`: every finite-type
   affine group scheme over a field embeds as a closed subgroup of some `GLₙ`.
 
 ## References
@@ -147,12 +151,21 @@ comodule with a basis indexed by `Fin n`.
 
 This is relative spectrum applied contravariantly to the comodule's coordinate Hopf-algebra
 morphism `O(GLₙ) ⟶ H`. -/
+@[expose]
 noncomputable def coordinateGroupSchemeHom (b : Basis (Fin n) k M) :
     (hopfSpec (CommRingCat.of k)).obj (Opposite.op (CommHopfAlgCat.of k H)) ⟶
       GeneralLinear.groupScheme k n :=
   (hopfSpec (CommRingCat.of k)).map
       (CommHopfAlgCat.ofHom (coordinateBialgHom (H := H) b)).op ≫
-    eqToHom (GeneralLinear.groupScheme_eq_hopfSpec k n).symm
+    eqToHom (GeneralLinear.groupScheme_def k n).symm
+
+/-- The group-scheme morphism associated to a comodule is the relative spectrum of its
+coordinate Hopf-algebra morphism, followed by the defining identification of `GLₙ`. -/
+theorem coordinateGroupSchemeHom_def (b : Basis (Fin n) k M) :
+    coordinateGroupSchemeHom (H := H) b =
+      (hopfSpec (CommRingCat.of k)).map
+          (CommHopfAlgCat.ofHom (coordinateBialgHom (H := H) b)).op ≫
+        eqToHom (GeneralLinear.groupScheme_def k n).symm := rfl
 
 /-- The group-scheme morphism associated to a finite free comodule is a closed immersion if
 and only if its coordinate Hopf-algebra morphism is surjective. -/
@@ -161,10 +174,10 @@ theorem isClosedImmersion_coordinateGroupSchemeHom_iff (b : Basis (Fin n) k M) :
     IsClosedImmersion (coordinateGroupSchemeHom (H := H) b).hom.hom.left ↔
       Function.Surjective (coordinateBialgHom (H := H) b) := by
   let _ : IsIso
-      (eqToHom (GeneralLinear.groupScheme_eq_hopfSpec k n).symm).hom.hom.left :=
+      (eqToHom (GeneralLinear.groupScheme_def k n).symm).hom.hom.left :=
     ((Over.forget (Spec (CommRingCat.of k))).mapIso
       ((Grp.forget (Over (Spec (CommRingCat.of k)))).mapIso
-        (eqToIso (GeneralLinear.groupScheme_eq_hopfSpec k n).symm))).isIso_hom
+        (eqToIso (GeneralLinear.groupScheme_def k n).symm))).isIso_hom
   rw [coordinateGroupSchemeHom]
   simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
   rw [MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion)]
@@ -179,9 +192,9 @@ open AlgebraicGeometry
 variable {k H : Type u}
 variable [Field k] [CommRing H] [HopfAlgebra k H]
 
-/-- **Every finite-type affine group scheme over a field embeds as a closed subgroup of some
-general linear group.** More precisely, a finite-dimensional subcomodule of the regular
-comodule and a basis determine a closed immersion into `GLₙ`. -/
+/-- The affine group scheme represented by a finite-type commutative Hopf algebra over a field
+embeds as a closed subgroup of some general linear group. More precisely, a finite-dimensional
+subcomodule of the regular comodule and a basis determine a closed immersion into `GLₙ`. -/
 theorem exists_isClosedImmersion_coordinateGroupSchemeHom [Algebra.FiniteType k H] :
     ∃ (M : Subcomodule k H H) (n : ℕ) (b : Basis (Fin n) k M),
       IsClosedImmersion (coordinateGroupSchemeHom (H := H) b).hom.hom.left := by
@@ -191,3 +204,50 @@ theorem exists_isClosedImmersion_coordinateGroupSchemeHom [Algebra.FiniteType k 
 end FiniteType
 
 end TauCeti.Comodule
+
+namespace TauCeti.AffineGroupSchemeCat
+
+open CategoryTheory AlgebraicGeometry
+
+universe u
+
+variable {k : Type u} [Field k]
+
+/-- **Every finite-type affine group scheme over a field embeds as a closed subgroup of some
+general linear group.** -/
+theorem exists_isClosedImmersion_generalLinear
+    (G : AffineGroupSchemeCat (CommRingCat.of k)) [LocallyOfFiniteType G.obj.X.hom] :
+    ∃ (n : ℕ) (f : G.obj ⟶ GeneralLinear.groupScheme k n),
+      IsClosedImmersion f.hom.hom.left := by
+  let E := commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)
+  let A := (E.inverse.obj G).unop
+  let e : G.obj ≅ (hopfSpec (CommRingCat.of k)).obj (Opposite.op A) :=
+    ((affineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso (E.counitIso.app G)).symm ≪≫
+      (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+        (CommRingCat.of k)).app (E.inverse.obj G)
+  have hAfinite : Algebra.FiniteType k A := by
+    let : MorphismProperty.RespectsIso
+        (@LocallyOfFiniteType : MorphismProperty Scheme.{u}) :=
+      MorphismProperty.IsStableUnderBaseChange.respectsIso
+    have hA : LocallyOfFiniteType
+        ((hopfSpec (CommRingCat.of k)).obj (Opposite.op A)).X.hom :=
+      (MorphismProperty.over_iso_iff
+        (@LocallyOfFiniteType : MorphismProperty Scheme.{u})
+          ((Grp.forget _).mapIso e)).mp
+        (show LocallyOfFiniteType G.obj.X.hom from inferInstance)
+    change LocallyOfFiniteType
+      (Spec.map (CommRingCat.ofHom (algebraMap k A))) at hA
+    apply RingHom.finiteType_algebraMap.mp
+    exact (HasRingHomProperty.Spec_iff (P := @LocallyOfFiniteType)).mp hA
+  let : Algebra.FiniteType k A := hAfinite
+  obtain ⟨M, n, b, hb⟩ :=
+    Comodule.exists_isClosedImmersion_coordinateGroupSchemeHom (k := k) (H := A)
+  refine ⟨n, e.hom ≫ Comodule.coordinateGroupSchemeHom (H := A) b, ?_⟩
+  let _ : IsIso e.hom.hom.hom.left :=
+    ((Over.forget (Spec (CommRingCat.of k))).mapIso
+      ((Grp.forget (Over (Spec (CommRingCat.of k)))).mapIso e)).isIso_hom
+  simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
+  rw [MorphismProperty.cancel_left_of_respectsIso (P := @IsClosedImmersion)]
+  exact hb
+
+end TauCeti.AffineGroupSchemeCat

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
@@ -6,6 +6,8 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Representation.Coordinate
 public import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.FiniteType
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Scheme
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.ClosedImmersion
 
 /-!
 # Embedding a finite-type affine group in a general linear group
@@ -23,13 +25,19 @@ O(GLₙ) ⟶ H
 is surjective. Contravariantly, its spectrum is a closed immersion of the affine group scheme
 represented by `H` into `GLₙ`.
 
-## Main declaration
+The coordinate-algebra statement permits independent universes for `k` and `H`. The final
+group-scheme statement uses the same universe for them, as required by Mathlib's current
+`hopfSpec` construction.
+
+## Main declarations
 
 * `TauCeti.Comodule.matrixCoefficientSubalgebra_le_coordinateBialgHom_range`: the matrix
   coefficient subalgebra is contained in the range of the coordinate morphism.
 * `TauCeti.Comodule.exists_coordinateBialgHom_surjective`: a finite-type commutative Hopf
   algebra over a field admits a finite-dimensional regular subcomodule whose coordinate
   morphism from `O(GLₙ)` is surjective.
+* `TauCeti.Comodule.exists_isClosedImmersion_coordinateGroupSchemeHom`: every finite-type
+  affine group scheme over a field embeds as a closed subgroup of some `GLₙ`.
 
 ## References
 
@@ -121,5 +129,65 @@ theorem exists_coordinateBialgHom_surjective [Algebra.FiniteType k H] :
   exact hsurjective
 
 end
+
+end TauCeti.Comodule
+
+namespace TauCeti.Comodule
+
+section GroupScheme
+
+open CategoryTheory AlgebraicGeometry
+
+variable {k H M : Type u} {n : ℕ}
+variable [CommRing k] [CommRing H] [HopfAlgebra k H]
+variable [AddCommMonoid M] [Module k M] [Comodule k H M]
+
+/-- The morphism from the affine group scheme represented by `H` to `GLₙ` associated to a
+comodule with a basis indexed by `Fin n`.
+
+This is relative spectrum applied contravariantly to the comodule's coordinate Hopf-algebra
+morphism `O(GLₙ) ⟶ H`. -/
+noncomputable def coordinateGroupSchemeHom (b : Basis (Fin n) k M) :
+    (hopfSpec (CommRingCat.of k)).obj (Opposite.op (CommHopfAlgCat.of k H)) ⟶
+      GeneralLinear.groupScheme k n :=
+  (hopfSpec (CommRingCat.of k)).map
+      (CommHopfAlgCat.ofHom (coordinateBialgHom (H := H) b)).op ≫
+    eqToHom (GeneralLinear.groupScheme_eq_hopfSpec k n).symm
+
+/-- The group-scheme morphism associated to a finite free comodule is a closed immersion if
+and only if its coordinate Hopf-algebra morphism is surjective. -/
+@[simp]
+theorem isClosedImmersion_coordinateGroupSchemeHom_iff (b : Basis (Fin n) k M) :
+    IsClosedImmersion (coordinateGroupSchemeHom (H := H) b).hom.hom.left ↔
+      Function.Surjective (coordinateBialgHom (H := H) b) := by
+  let _ : IsIso
+      (eqToHom (GeneralLinear.groupScheme_eq_hopfSpec k n).symm).hom.hom.left :=
+    ((Over.forget (Spec (CommRingCat.of k))).mapIso
+      ((Grp.forget (Over (Spec (CommRingCat.of k)))).mapIso
+        (eqToIso (GeneralLinear.groupScheme_eq_hopfSpec k n).symm))).isIso_hom
+  rw [coordinateGroupSchemeHom]
+  simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
+  rw [MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion)]
+  exact CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff _
+
+end GroupScheme
+
+section FiniteType
+
+open AlgebraicGeometry
+
+variable {k H : Type u}
+variable [Field k] [CommRing H] [HopfAlgebra k H]
+
+/-- **Every finite-type affine group scheme over a field embeds as a closed subgroup of some
+general linear group.** More precisely, a finite-dimensional subcomodule of the regular
+comodule and a basis determine a closed immersion into `GLₙ`. -/
+theorem exists_isClosedImmersion_coordinateGroupSchemeHom [Algebra.FiniteType k H] :
+    ∃ (M : Subcomodule k H H) (n : ℕ) (b : Basis (Fin n) k M),
+      IsClosedImmersion (coordinateGroupSchemeHom (H := H) b).hom.hom.left := by
+  obtain ⟨M, n, b, hb⟩ := exists_coordinateBialgHom_surjective (k := k) (H := H)
+  exact ⟨M, n, b, (isClosedImmersion_coordinateGroupSchemeHom_iff b).2 hb⟩
+
+end FiniteType
 
 end TauCeti.Comodule


### PR DESCRIPTION
This PR completes `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, milestone **“Embedding theorem (hard): every affine group scheme of finite type has a faithful f.d. representation, i.e. a closed immersion `G ↪ GLₙ`.”** Construct the group-scheme morphism from the relative spectrum of a commutative Hopf algebra to `GLₙ` associated to a finite free comodule, identify its closed-immersion property exactly with surjectivity of the coordinate Hopf map, and conclude that every finite-type affine group scheme over a field admits such a closed immersion.

This is the most effective current step because merged PR #2457 already proves the hard finite-subcoalgebra and matrix-coefficient result that produces a surjective map `O(GLₙ) → H`, but stops at the coordinate-algebra formulation; this PR transports that theorem through the already-merged `hopfSpec` closed-immersion criterion to obtain the geometric statement the roadmap names. After this PR, the embedding-theorem milestone is complete; Layer 1 still needs the separate faithful-representation matrix-coefficient characterization and the in-flight Tannakian reconstruction work.

Add `Comodule.coordinateGroupSchemeHom`, its exact closed-immersion criterion, and `exists_isClosedImmersion_coordinateGroupSchemeHom`. Promote the existing definitional presentation of `GeneralLinear.groupScheme` to a documented theorem so the representation morphism can target the canonical named `GLₙ` group scheme without unfolding its opaque body. The scheme statements retain the same-universe restriction imposed by Mathlib's current `hopfSpec` API, while the underlying coordinate-algebra theorem remains universe-polymorphic.

The mathematical argument follows J. S. Milne, *Algebraic Groups* (2017), Proposition 4.7 and Theorem 4.9, as cited in the embedding module. Reuse Tau Ceti's `exists_coordinateBialgHom_surjective` and `CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff`; no Mathlib infrastructure is vendored. Modify `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean` and `TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean` with 71 insertions and 2 deletions.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"affine-group-closed-embedding-general-linear"}-->

🤖 Prepared with Codex
