### PR TITLE
feat: attach algebraic closures to valid Lie indices

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Closure.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Closure.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Index
+public import Mathlib.Algebra.Field.ZMod
+public import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+
+/-!
+# Algebraic closures for finite groups of Lie type
+
+This file attaches to every valid Lie-type index the algebraically closed field over which its
+ambient pinned algebraic group will be evaluated. The field is Mathlib's algebraic closure of the
+prime field in the characteristic recorded by the index. Consequently its field, algebraic-closure,
+and characteristic structures are the canonical Mathlib instances rather than parallel data.
+
+## Main definition
+
+* `TauCeti.ValidLieTypeIndex.Closure`: the algebraic closure of the index's prime field.
+
+## Roadmap
+
+This is the algebraic-closure part of item I0 in
+`TauCetiRoadmap/CFSGStatement/README.md`. Milestone L0 uses this carrier when it base-changes the
+pinned Chevalley--Demazure group scheme to the characteristic of a valid Lie-type index and takes
+its algebraic-closure-valued points.
+-/
+
+public section
+
+namespace TauCeti.ValidLieTypeIndex
+
+/-- The algebraic closure of the prime field in the characteristic attached to a valid Lie-type
+index. -/
+abbrev Closure (d : ValidLieTypeIndex) : Type :=
+  AlgebraicClosure (ZMod d.characteristic)
+
+/-! The instances used by the later ambient-group construction are inherited from Mathlib. -/
+
+noncomputable section
+
+example (d : ValidLieTypeIndex) : Field d.Closure := inferInstance
+
+example (d : ValidLieTypeIndex) : IsAlgClosed d.Closure := inferInstance
+
+example (d : ValidLieTypeIndex) : CharP d.Closure d.characteristic := inferInstance
+
+end
+
+end TauCeti.ValidLieTypeIndex


### PR DESCRIPTION
This PR defines `TauCeti.ValidLieTypeIndex.Closure` as Mathlib's algebraic closure of `ZMod d.characteristic`, completing the algebraic-closure target of `CFSGStatement/README.md`, milestone **I0: indices and Mathlib glue**. Keep the field, algebraic-closedness, and characteristic structures canonical by inheriting Mathlib's `Field`, `IsAlgClosed`, and `CharP` instances, and check all three interfaces in the module.

This is the most effective current critical-path step because the CFSG index data has landed, while the other independent I0 work is already in flight in #2580; L0 names this exact carrier for base-changing pinned Chevalley--Demazure group schemes and taking algebraic-closure-valued points. After this PR, I0 still needs the index-dependent diagram and length-permutation selectors and the Suzuki--Ree exponent interface built on #2580; L0 then remains blocked on the root-systems Layer 6 and reductive-groups Layer 9 constructions stated by the roadmap.

Add `TauCeti/GroupTheory/SpecificGroups/CFSG/Closure.lean` (52 lines). Reuse Mathlib's `AlgebraicClosure`, the canonical field structure on prime `ZMod`, and the inherited algebraic-closure and characteristic instances; no Mathlib infrastructure is vendored.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"valid-lie-type-index-closure"}-->

🤖 Prepared with Codex
