### PR TITLE
feat: construct the type A simply connected root datum

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -25,16 +25,18 @@ Write `e₀, …, e_n` for the standard basis of the classical model `ℤ ^ (n +
 of type `Aₙ` are the `n * (n + 1)` vectors `e_a - e_b` with `a ≠ b` and the simple roots are
 `αᵢ = eᵢ - eᵢ₊₁`. Everything below is the image of that model in the two pinned lattices: a vector
 of the character lattice is recorded by its pairings against the simple coroots, and a vector of the
-cocharacter lattice by its coordinates in the simple coroots. Thus `e_a` contributes
+cocharacter lattice by its coordinates in the simple coroots. Although `e_a` itself does not lie in
+the coroot lattice, choose a coordinate potential for it so that differences represent coroots:
 
 ```text
 typeAWeight n a   = (⟨e_a, αₖ^∨⟩)ₖ           = ([a = k] - [a = k + 1])ₖ,
-typeACoweight n a = (coefficient of αₖ^∨)ₖ   = ([a ≤ k])ₖ,
+typeACoweight n a = (chosen potential at αₖ^∨)ₖ   = ([a ≤ k])ₖ.
 ```
 
-the second because `e_a - e_b = ∑ a ≤ k < b, αₖ^∨` for `a ≤ b`. The root `e_a - e_b` and its coroot
-are the corresponding differences, and the whole construction is a finite calculation with these
-two families; `typeAWeight_dotProduct_typeACoweight` is the one identity it rests on.
+For `a ≤ b`, the difference of the chosen potentials has the simple-coroot coordinates of
+`e_a - e_b = ∑ a ≤ k < b, αₖ^∨`. The root `e_a - e_b` and its coroot are the corresponding
+differences, and the whole construction is a finite calculation with these two families;
+`typeAWeight_dotProduct_typeACoweight` is the one identity it rests on.
 
 The roots are indexed by `Fin (n * (n + 1))`, the ordered pairs `(a, b)` of distinct elements of
 `Fin (n + 1)` being enumerated by the difference `b - a ≠ 0` first and the source `a` second. The
@@ -88,8 +90,9 @@ pairings `⟨e_a, αₖ^∨⟩ = [a = k] - [a = k + 1]` against the simple coroo
 private def typeAWeight (n a : ℕ) : Fin n → ℤ :=
   fun k => (if a = (k : ℕ) then 1 else 0) - (if a = (k : ℕ) + 1 then 1 else 0)
 
-/-- The cocharacter-lattice coordinates of the classical basis vector `e_a` of type `Aₙ`, read off
-`e_a - e_b = ∑ a ≤ k < b, αₖ^∨`: the `k`-th coordinate is `[a ≤ k]`. -/
+/-- A chosen simple-coroot-coordinate potential for the classical basis vector `e_a` of type `Aₙ`.
+Although `e_a` itself does not lie in the coroot lattice, the differences of these potentials give
+the coordinates of `e_a - e_b`; the `k`-th potential is `[a ≤ k]`. -/
 private def typeACoweight (n a : ℕ) : Fin n → ℤ :=
   fun k => if a ≤ (k : ℕ) then 1 else 0
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -1,0 +1,622 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.DynkinType
+public import Mathlib.LinearAlgebra.Matrix.Dual
+public import Mathlib.LinearAlgebra.RootSystem.Base
+
+public section
+
+/-!
+# The simply connected root datum of type `Aₙ`
+
+This file constructs, uniformly in the rank `n`, the pinned integral root datum of type `Aₙ` on the
+character and cocharacter lattices `Fin n → ℤ`. The character lattice is written in the
+fundamental-weight basis and the cocharacter lattice in the simple-coroot basis, so the `i`-th
+simple root is the `i`-th row of the Bourbaki-numbered Cartan matrix `CartanMatrix.A n` and the
+`i`-th simple coroot is the `i`-th standard basis vector.
+
+## The coordinates
+
+Write `e₀, …, e_n` for the standard basis of the classical model `ℤ ^ (n + 1)`, in which the roots
+of type `Aₙ` are the `n * (n + 1)` vectors `e_a - e_b` with `a ≠ b` and the simple roots are
+`αᵢ = eᵢ - eᵢ₊₁`. Everything below is the image of that model in the two pinned lattices: a vector
+of the character lattice is recorded by its pairings against the simple coroots, and a vector of the
+cocharacter lattice by its coordinates in the simple coroots. Thus `e_a` contributes
+
+```text
+typeAWeight n a   = (⟨e_a, αₖ^∨⟩)ₖ           = ([a = k] - [a = k + 1])ₖ,
+typeACoweight n a = (coefficient of αₖ^∨)ₖ   = ([a ≤ k])ₖ,
+```
+
+the second because `e_a - e_b = ∑ a ≤ k < b, αₖ^∨` for `a ≤ b`. The root `e_a - e_b` and its coroot
+are the corresponding differences, and the whole construction is a finite calculation with these
+two families; `typeAWeight_dotProduct_typeACoweight` is the one identity it rests on.
+
+The roots are indexed by `Fin (n * (n + 1))`, the ordered pairs `(a, b)` of distinct elements of
+`Fin (n + 1)` being enumerated by the difference `b - a ≠ 0` first and the source `a` second. The
+first `n` indices are therefore the simple roots `α₀, …, α_{n-1}` in Bourbaki order, as
+`root_typeASimpleIndex` records.
+
+Only the coroots are asked to span their lattice, and only that half is recorded, in
+`span_coroot_typeASimplyConnectedRootDatum`. The roots span the root lattice, which sits inside the
+weight lattice with index `n + 1` (Bourbaki, Plate I), so the datum is a `RootDatum` carrying no
+`RootPairing.IsRootSystem` instance. That asymmetry is what "simply connected" means here.
+
+## Main definitions
+
+* `TauCeti.DynkinType.typeASimplyConnectedRootDatum`: the pinned root datum of type `Aₙ`.
+* `TauCeti.DynkinType.typeASimpleIndex`: the first `n` root indices, the Bourbaki-numbered simple
+  roots.
+* `TauCeti.DynkinType.typeASimplyConnectedBase`: the base they form.
+
+## Main results
+
+* `TauCeti.DynkinType.root_typeASimpleIndex` and
+  `TauCeti.DynkinType.coroot_typeASimpleIndex`: the `i`-th simple root is the `i`-th row of
+  `CartanMatrix.A n` and the `i`-th simple coroot is `Pi.single i 1`, which is what pins the two
+  lattices as the weight and coweight lattices.
+* `TauCeti.DynkinType.hasCartanType_typeASimplyConnectedRootDatum`: the pinned base has Cartan type
+  `A n`.
+* `TauCeti.DynkinType.span_coroot_typeASimplyConnectedRootDatum`: the coroots span the cocharacter
+  lattice, the simply connected condition.
+
+## References
+
+The coordinates and the node numbering follow Bourbaki, *Lie Groups and Lie Algebras, Chapters
+4--6*, Plate I, and Humphreys, *Introduction to Lie Algebras and Representation Theory*, section
+12.1. This is the `Aₙ` branch of the target "a named datum per valid type" in Layer 6 of
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`.
+-/
+
+namespace TauCeti
+
+open Function Set Submodule
+
+namespace DynkinType
+
+variable {n : ℕ}
+
+/-! ## The two coordinate families -/
+
+/-- The character-lattice coordinates of the classical basis vector `e_a` of type `Aₙ`: its
+pairings `⟨e_a, αₖ^∨⟩ = [a = k] - [a = k + 1]` against the simple coroots. -/
+private def typeAWeight (n a : ℕ) : Fin n → ℤ :=
+  fun k => (if a = (k : ℕ) then 1 else 0) - (if a = (k : ℕ) + 1 then 1 else 0)
+
+/-- The cocharacter-lattice coordinates of the classical basis vector `e_a` of type `Aₙ`, read off
+`e_a - e_b = ∑ a ≤ k < b, αₖ^∨`: the `k`-th coordinate is `[a ≤ k]`. -/
+private def typeACoweight (n a : ℕ) : Fin n → ℤ :=
+  fun k => if a ≤ (k : ℕ) then 1 else 0
+
+private lemma sum_ite_val (f : Fin n → ℤ) (b : ℕ) :
+    ∑ k : Fin n, (if b = (k : ℕ) then f k else 0) = if h : b < n then f ⟨b, h⟩ else 0 := by
+  by_cases h : b < n
+  · rw [dif_pos h, Finset.sum_eq_single (⟨b, h⟩ : Fin n)]
+    · simp
+    · intro c _ hc
+      exact if_neg fun hb => hc (Fin.ext hb.symm)
+    · simp
+  · rw [dif_neg h, Finset.sum_eq_zero]
+    intro k _
+    have := k.isLt
+    exact if_neg (by omega)
+
+private lemma sum_ite_val_succ (f : Fin n → ℤ) (b : ℕ) :
+    ∑ k : Fin n, (if b = (k : ℕ) + 1 then f k else 0)
+      = if h : b - 1 < n ∧ 1 ≤ b then f ⟨b - 1, h.1⟩ else 0 := by
+  by_cases h : b - 1 < n ∧ 1 ≤ b
+  · rw [dif_pos h, Finset.sum_eq_single (⟨b - 1, h.1⟩ : Fin n)]
+    · exact if_pos (show b = b - 1 + 1 by omega)
+    · intro c _ hc
+      refine if_neg fun hb => hc (Fin.ext ?_)
+      simp only
+      omega
+    · simp
+  · rw [dif_neg h, Finset.sum_eq_zero]
+    intro k _
+    have := k.isLt
+    exact if_neg (by omega)
+
+/-- The fundamental pairing identity of type `Aₙ`: in the classical model `⟨e_a, e_c^∨⟩` would be
+`[a = c]`, and the two pinned lattices see that up to the single correction `[a = n]`, which
+cancels in the differences that are the roots and coroots. -/
+private lemma typeAWeight_dotProduct_typeACoweight {a c : ℕ} (ha : a ≤ n) (hc : c ≤ n) :
+    typeAWeight n a ⬝ᵥ typeACoweight n c
+      = (if a = c then 1 else 0) - (if a = n then 1 else 0) := by
+  have key : ∀ b : ℕ, ∑ k : Fin n, (if b = (k : ℕ) then (1 : ℤ) else 0) *
+      (if c ≤ (k : ℕ) then 1 else 0) = if h : b < n then (if c ≤ b then (1 : ℤ) else 0) else 0 := by
+    intro b
+    simp only [ite_mul, one_mul, zero_mul]
+    exact sum_ite_val (fun k => if c ≤ (k : ℕ) then (1 : ℤ) else 0) b
+  have key' : ∀ b : ℕ, ∑ k : Fin n, (if b = (k : ℕ) + 1 then (1 : ℤ) else 0) *
+      (if c ≤ (k : ℕ) then 1 else 0)
+        = if h : b - 1 < n ∧ 1 ≤ b then (if c ≤ b - 1 then (1 : ℤ) else 0) else 0 := by
+    intro b
+    simp only [ite_mul, one_mul, zero_mul]
+    exact sum_ite_val_succ (fun k => if c ≤ (k : ℕ) then (1 : ℤ) else 0) b
+  simp only [dotProduct, typeAWeight, typeACoweight, sub_mul, Finset.sum_sub_distrib,
+    key a, key' a]
+  split_ifs <;> omega
+
+/-! ## The roots and coroots indexed by ordered pairs -/
+
+/-- The ordered pairs of distinct elements of `Fin (n + 1)`, indexing the roots `e_a - e_b` of type
+`Aₙ` before they are enumerated by `Fin (n * (n + 1))`. -/
+private abbrev TypeAIndex (n : ℕ) := {p : Fin (n + 1) × Fin (n + 1) // p.1 ≠ p.2}
+
+/-- The root `e_a - e_b` in fundamental-weight coordinates. -/
+private def typeAPairRoot (p : TypeAIndex n) : Fin n → ℤ :=
+  typeAWeight n (p.val.1 : ℕ) - typeAWeight n (p.val.2 : ℕ)
+
+/-- The coroot `(e_a - e_b)^∨ = e_a - e_b` in simple-coroot coordinates. -/
+private def typeAPairCoroot (p : TypeAIndex n) : Fin n → ℤ :=
+  typeACoweight n (p.val.1 : ℕ) - typeACoweight n (p.val.2 : ℕ)
+
+private lemma typeAPairing (p q : TypeAIndex n) :
+    typeAPairRoot p ⬝ᵥ typeAPairCoroot q =
+      (if p.val.1 = q.val.1 then 1 else 0) - (if p.val.1 = q.val.2 then 1 else 0)
+        - ((if p.val.2 = q.val.1 then 1 else 0) - (if p.val.2 = q.val.2 then (1 : ℤ) else 0)) := by
+  have hle : ∀ x : Fin (n + 1), (x : ℕ) ≤ n := fun x => Nat.lt_succ_iff.mp x.isLt
+  simp only [typeAPairRoot, typeAPairCoroot, sub_dotProduct, dotProduct_sub,
+    typeAWeight_dotProduct_typeACoweight (hle _) (hle _), Fin.val_inj]
+  ring
+
+private lemma typeAPairRoot_self (p : TypeAIndex n) : typeAPairRoot p ⬝ᵥ typeAPairCoroot p = 2 := by
+  rw [typeAPairing]
+  have h := p.2
+  split_ifs <;> simp_all
+
+private lemma typeAPairRoot_injective : Injective (typeAPairRoot (n := n)) := by
+  intro p q hpq
+  have h2 : typeAPairRoot q ⬝ᵥ typeAPairCoroot p = 2 := by rw [← hpq]; exact typeAPairRoot_self p
+  rw [typeAPairing] at h2
+  have hp := p.2
+  have hq := q.2
+  refine Subtype.ext (Prod.ext ?_ ?_) <;> (split_ifs at h2 <;> simp_all)
+
+private lemma typeAPairCoroot_injective : Injective (typeAPairCoroot (n := n)) := by
+  intro p q hpq
+  have h2 : typeAPairRoot p ⬝ᵥ typeAPairCoroot q = 2 := by rw [← hpq]; exact typeAPairRoot_self p
+  rw [typeAPairing] at h2
+  have hp := p.2
+  have hq := q.2
+  refine Subtype.ext (Prod.ext ?_ ?_) <;> (split_ifs at h2 <;> simp_all)
+
+/-- Transposing a family along `Equiv.swap a b` subtracts a multiple of `f a - f b`. This is the
+formal identity behind both reflection axioms: reflecting in the root `e_a - e_b` is exactly the
+transposition of `a` and `b`. -/
+private lemma apply_swap_eq {ι M : Type*} [DecidableEq ι] [AddCommGroup M] (f : ι → M)
+    (a b c : ι) :
+    f (Equiv.swap a b c) =
+      f c - ((if c = a then 1 else 0) - (if c = b then (1 : ℤ) else 0)) • (f a - f b) := by
+  rcases eq_or_ne c a with rfl | hca
+  · rcases eq_or_ne c b with rfl | hcb
+    · simp
+    · simp [Equiv.swap_apply_left, hcb]
+  · rcases eq_or_ne c b with rfl | hcb
+    · simp [Equiv.swap_apply_right, hca]
+    · simp [Equiv.swap_apply_of_ne_of_ne hca hcb, hca, hcb]
+
+/-- Reflection in the root indexed by `p`, as the transposition of the two entries of `p` acting on
+ordered pairs. -/
+private def typeAPairReflection (p : TypeAIndex n) : TypeAIndex n ≃ TypeAIndex n :=
+  Equiv.subtypeEquiv ((Equiv.swap p.val.1 p.val.2).prodCongr (Equiv.swap p.val.1 p.val.2))
+    (fun q => by simp)
+
+private lemma typeAWeight_swap (a b c : Fin (n + 1)) :
+    typeAWeight n ((Equiv.swap a b c : Fin (n + 1)) : ℕ) =
+      typeAWeight n (c : ℕ) - ((if c = a then 1 else 0) - (if c = b then (1 : ℤ) else 0)) •
+        (typeAWeight n (a : ℕ) - typeAWeight n (b : ℕ)) :=
+  apply_swap_eq (fun x : Fin (n + 1) => typeAWeight n (x : ℕ)) a b c
+
+private lemma typeACoweight_swap (a b c : Fin (n + 1)) :
+    typeACoweight n ((Equiv.swap a b c : Fin (n + 1)) : ℕ) =
+      typeACoweight n (c : ℕ) - ((if c = a then 1 else 0) - (if c = b then (1 : ℤ) else 0)) •
+        (typeACoweight n (a : ℕ) - typeACoweight n (b : ℕ)) :=
+  apply_swap_eq (fun x : Fin (n + 1) => typeACoweight n (x : ℕ)) a b c
+
+private lemma typeAPairReflection_root (p q : TypeAIndex n) :
+    typeAPairRoot q - (typeAPairRoot q ⬝ᵥ typeAPairCoroot p) • typeAPairRoot p =
+      typeAPairRoot (typeAPairReflection p q) := by
+  have hR : typeAPairRoot (typeAPairReflection p q) =
+      typeAWeight n ((Equiv.swap p.val.1 p.val.2 q.val.1 : Fin (n + 1)) : ℕ) -
+        typeAWeight n ((Equiv.swap p.val.1 p.val.2 q.val.2 : Fin (n + 1)) : ℕ) := rfl
+  rw [typeAPairing, hR, typeAWeight_swap, typeAWeight_swap]
+  simp only [typeAPairRoot]
+  module
+
+private lemma ite_eq_comm (a b : Fin (n + 1)) :
+    (if a = b then (1 : ℤ) else 0) = if b = a then 1 else 0 := by
+  split_ifs <;> simp_all
+
+private lemma typeAPairReflection_coroot (p q : TypeAIndex n) :
+    typeAPairCoroot q - (typeAPairRoot p ⬝ᵥ typeAPairCoroot q) • typeAPairCoroot p =
+      typeAPairCoroot (typeAPairReflection p q) := by
+  have hR : typeAPairCoroot (typeAPairReflection p q) =
+      typeACoweight n ((Equiv.swap p.val.1 p.val.2 q.val.1 : Fin (n + 1)) : ℕ) -
+        typeACoweight n ((Equiv.swap p.val.1 p.val.2 q.val.2 : Fin (n + 1)) : ℕ) := rfl
+  rw [typeAPairing, hR, typeACoweight_swap, typeACoweight_swap, ite_eq_comm p.val.1 q.val.1,
+    ite_eq_comm p.val.1 q.val.2, ite_eq_comm p.val.2 q.val.1, ite_eq_comm p.val.2 q.val.2]
+  simp only [typeAPairCoroot]
+  module
+
+private instance : (dotProductBilin ℤ ℤ :
+    (Fin n → ℤ) →ₗ[ℤ] (Fin n → ℤ) →ₗ[ℤ] ℤ).IsPerfPair := by
+  change (dotProductEquiv ℤ (Fin n)).toLinearMap.IsPerfPair
+  infer_instance
+
+/-! ## The Bourbaki enumeration of the roots -/
+
+private lemma one_le_val_sub (p : TypeAIndex n) : 1 ≤ ((p.val.2 - p.val.1 : Fin (n + 1)) : ℕ) := by
+  have h : (p.val.2 - p.val.1 : Fin (n + 1)) ≠ 0 := fun h => p.2 (sub_eq_zero.mp h).symm
+  have : ((p.val.2 - p.val.1 : Fin (n + 1)) : ℕ) ≠ 0 := by
+    simpa [Fin.val_eq_zero_iff] using h
+  omega
+
+/-- The nonzero difference `b - a` of an ordered pair of distinct elements, shifted down to an
+index of `Fin n`. -/
+private def typeADiff (p : TypeAIndex n) : Fin n :=
+  ⟨((p.val.2 - p.val.1 : Fin (n + 1)) : ℕ) - 1, by
+    have h1 := one_le_val_sub p
+    have h2 : ((p.val.2 - p.val.1 : Fin (n + 1)) : ℕ) < n + 1 := Fin.isLt _
+    omega⟩
+
+private lemma typeADiff_val (p : TypeAIndex n) :
+    (typeADiff p : ℕ) = ((p.val.2 - p.val.1 : Fin (n + 1)) : ℕ) - 1 := rfl
+
+/-- The shift of a `Fin n` index to the nonzero elements of `Fin (n + 1)`, inverse to
+`TauCeti.DynkinType.typeADiff`. -/
+private def typeASucc (i : Fin n) : Fin (n + 1) := ⟨(i : ℕ) + 1, by omega⟩
+
+private lemma typeASucc_val (i : Fin n) : (typeASucc i : ℕ) = (i : ℕ) + 1 := rfl
+
+private lemma typeASucc_ne_zero (i : Fin n) : typeASucc i ≠ 0 := by
+  intro h
+  have h' := congrArg Fin.val h
+  rw [typeASucc_val] at h'
+  simp at h'
+
+/-- The enumeration of the ordered pairs of distinct elements of `Fin (n + 1)` by the difference
+`b - a ≠ 0` first and the source `a` second. Composed with `finProdFinEquiv` it puts the simple
+roots at the first `n` indices. -/
+private def typeAPairEquiv (n : ℕ) : TypeAIndex n ≃ Fin n × Fin (n + 1) where
+  toFun p := (typeADiff p, p.val.1)
+  invFun q := ⟨(q.2, q.2 + typeASucc q.1), by
+    intro h
+    refine typeASucc_ne_zero q.1 ?_
+    have h0 : q.2 + 0 = q.2 + typeASucc q.1 := by simpa using h
+    exact (add_left_cancel h0).symm⟩
+  left_inv p := by
+    have h1 := one_le_val_sub p
+    have hx : typeASucc (typeADiff p) = p.val.2 - p.val.1 :=
+      Fin.ext (by rw [typeASucc_val, typeADiff_val]; omega)
+    refine Subtype.ext (Prod.ext rfl ?_)
+    change p.val.1 + typeASucc (typeADiff p) = p.val.2
+    rw [hx]
+    abel
+  right_inv q := by
+    refine Prod.ext (Fin.ext ?_) rfl
+    change ((q.2 + typeASucc q.1 - q.2 : Fin (n + 1)) : ℕ) - 1 = (q.1 : ℕ)
+    rw [add_sub_cancel_left, typeASucc_val]
+    omega
+
+/-- The pinned enumeration of the roots of type `Aₙ` by `Fin (n * (n + 1))`. -/
+private def typeAIndexEquiv (n : ℕ) : TypeAIndex n ≃ Fin (n * (n + 1)) :=
+  (typeAPairEquiv n).trans finProdFinEquiv
+
+/-- The pinned simply connected root datum of type `Aₙ`.
+
+Both lattices are `Fin n → ℤ`: the character lattice in the fundamental-weight basis and the
+cocharacter lattice in the simple-coroot basis. The `n * (n + 1)` roots are the classical
+`e_a - e_b` with `a ≠ b`, enumerated with the simple roots first; see
+`TauCeti.DynkinType.root_typeASimpleIndex`. -/
+def typeASimplyConnectedRootDatum (n : ℕ) :
+    RootDatum (Fin (n * (n + 1))) (Fin n → ℤ) (Fin n → ℤ) where
+  toLinearMap := dotProductBilin ℤ ℤ
+  root := ⟨fun k => typeAPairRoot ((typeAIndexEquiv n).symm k),
+    typeAPairRoot_injective.comp (typeAIndexEquiv n).symm.injective⟩
+  coroot := ⟨fun k => typeAPairCoroot ((typeAIndexEquiv n).symm k),
+    typeAPairCoroot_injective.comp (typeAIndexEquiv n).symm.injective⟩
+  root_coroot_two k := typeAPairRoot_self _
+  reflectionPerm k := ((typeAIndexEquiv n).symm.trans
+    (typeAPairReflection ((typeAIndexEquiv n).symm k))).trans (typeAIndexEquiv n)
+  reflectionPerm_root k l := by
+    simpa using typeAPairReflection_root ((typeAIndexEquiv n).symm k) ((typeAIndexEquiv n).symm l)
+  reflectionPerm_coroot k l := by
+    simpa using typeAPairReflection_coroot ((typeAIndexEquiv n).symm k) ((typeAIndexEquiv n).symm l)
+
+private lemma root_typeASimplyConnectedRootDatum (k : Fin (n * (n + 1))) :
+    (typeASimplyConnectedRootDatum n).root k = typeAPairRoot ((typeAIndexEquiv n).symm k) :=
+  rfl
+
+private lemma coroot_typeASimplyConnectedRootDatum (k : Fin (n * (n + 1))) :
+    (typeASimplyConnectedRootDatum n).coroot k = typeAPairCoroot ((typeAIndexEquiv n).symm k) :=
+  rfl
+
+private lemma pairing_typeASimplyConnectedRootDatum (k l : Fin (n * (n + 1))) :
+    (typeASimplyConnectedRootDatum n).pairing k l =
+      (typeASimplyConnectedRootDatum n).root k ⬝ᵥ (typeASimplyConnectedRootDatum n).coroot l :=
+  rfl
+
+/-- The `i`-th simple root of type `Aₙ` sits at root index `i`, the Bourbaki node `i + 1`. -/
+def typeASimpleIndex (n : ℕ) (i : Fin n) : Fin (n * (n + 1)) :=
+  ⟨i, lt_of_lt_of_le i.isLt (Nat.le_mul_of_pos_right n n.succ_pos)⟩
+
+@[simp] lemma typeASimpleIndex_val (i : Fin n) : (typeASimpleIndex n i : ℕ) = i := (rfl)
+
+lemma typeASimpleIndex_injective : Injective (typeASimpleIndex n) := by
+  intro i j h
+  have := congrArg Fin.val h
+  simp only [typeASimpleIndex_val] at this
+  exact Fin.ext this
+
+private lemma typeAIndexEquiv_symm_typeASimpleIndex (i : Fin n) :
+    (typeAIndexEquiv n).symm (typeASimpleIndex n i) =
+      ⟨(⟨i, by omega⟩, ⟨(i : ℕ) + 1, by omega⟩), by simp [Fin.ext_iff]⟩ := by
+  have hlt : (i : ℕ) < n + 1 := by omega
+  have hlt' : (i : ℕ) + 1 < n + 1 := by omega
+  refine Subtype.ext (Prod.ext ?_ ?_) <;>
+    · apply Fin.ext
+      simp [typeAIndexEquiv, typeAPairEquiv, finProdFinEquiv, Fin.divNat, Fin.modNat,
+        typeASimpleIndex, typeASucc_val, Nat.div_eq_of_lt hlt,
+        Nat.mod_eq_of_lt hlt, Fin.add_def, Nat.mod_eq_of_lt hlt']
+
+private lemma root_typeASimpleIndex_eq (i : Fin n) :
+    (typeASimplyConnectedRootDatum n).root (typeASimpleIndex n i) =
+      typeAWeight n (i : ℕ) - typeAWeight n ((i : ℕ) + 1) := by
+  rw [root_typeASimplyConnectedRootDatum, typeAIndexEquiv_symm_typeASimpleIndex]
+  rfl
+
+private lemma coroot_typeASimpleIndex_eq (i : Fin n) :
+    (typeASimplyConnectedRootDatum n).coroot (typeASimpleIndex n i) =
+      typeACoweight n (i : ℕ) - typeACoweight n ((i : ℕ) + 1) := by
+  rw [coroot_typeASimplyConnectedRootDatum, typeAIndexEquiv_symm_typeASimpleIndex]
+  rfl
+
+/-- **The simple roots are the rows of the Cartan matrix.** In the fundamental-weight basis the
+`i`-th simple root of the pinned type `Aₙ` datum is the `i`-th row of `CartanMatrix.A n`, which is
+what pins the character lattice as the weight lattice. -/
+theorem root_typeASimpleIndex (i : Fin n) :
+    (typeASimplyConnectedRootDatum n).root (typeASimpleIndex n i) =
+      fun k => CartanMatrix.A n i k := by
+  rw [root_typeASimpleIndex_eq]
+  funext k
+  simp only [typeAWeight, Pi.sub_apply, CartanMatrix.A, Matrix.of_apply, Fin.ext_iff]
+  split_ifs <;> omega
+
+private lemma typeACoweight_sub_succ (i : Fin n) :
+    typeACoweight n (i : ℕ) - typeACoweight n ((i : ℕ) + 1) = Pi.single i 1 := by
+  funext k
+  simp only [typeACoweight, Pi.sub_apply, Pi.single_apply, Fin.ext_iff]
+  split_ifs <;> omega
+
+/-- **The simple coroots are the standard basis.** This is what pins the cocharacter lattice as the
+coweight lattice, so that the datum is the simply connected one. -/
+theorem coroot_typeASimpleIndex (i : Fin n) :
+    (typeASimplyConnectedRootDatum n).coroot (typeASimpleIndex n i) = Pi.single i 1 := by
+  rw [coroot_typeASimpleIndex_eq, typeACoweight_sub_succ]
+
+/-! ## The pinned base -/
+
+/-- The telescoping identity behind `root_mem_or_neg_mem`: a difference `f a - f b` with `a ≤ b` is
+the sum of the consecutive differences between them. -/
+private lemma sub_eq_sum_Ico {M : Type*} [AddCommGroup M] (f : ℕ → M) {a b : ℕ} (hab : a ≤ b) :
+    f a - f b = ∑ i ∈ Finset.Ico a b, (f i - f (i + 1)) := by
+  induction b, hab using Nat.le_induction with
+  | base => simp
+  | succ b hb ih =>
+    rw [Finset.sum_Ico_succ_top hb, ← ih]
+    abel
+
+private lemma sub_mem_closure_of_le {M : Type*} [AddCommGroup M] (f : ℕ → M) {a b : ℕ}
+    (hb : b ≤ n) (hab : a ≤ b) :
+    f a - f b ∈ AddSubmonoid.closure (range fun i : Fin n => f (i : ℕ) - f ((i : ℕ) + 1)) := by
+  rw [sub_eq_sum_Ico f hab]
+  refine AddSubmonoid.sum_mem _ fun i hi => AddSubmonoid.subset_closure ?_
+  have : i < n := lt_of_lt_of_le (Finset.mem_Ico.mp hi).2 hb
+  exact ⟨⟨i, this⟩, rfl⟩
+
+/-- The simple roots of type `Aₙ` are linearly independent. A relation among the rows of
+`CartanMatrix.A n` forces its coefficients to grow linearly, and the missing row past the last node
+then makes the common ratio `(n + 1)`-torsion, hence zero. -/
+private lemma linearIndependent_typeASimpleRoot (n : ℕ) :
+    LinearIndependent ℤ fun i : Fin n => typeAWeight n (i : ℕ) - typeAWeight n ((i : ℕ) + 1) := by
+  rw [Fintype.linearIndependent_iff]
+  intro g hg
+  let S : ℕ → ℤ := fun c => ∑ j : Fin n, (if (j : ℕ) + 1 = c then g j else 0)
+  have hSval : ∀ j : Fin n, S ((j : ℕ) + 1) = g j := by
+    intro j
+    change ∑ j' : Fin n, (if (j' : ℕ) + 1 = (j : ℕ) + 1 then g j' else 0) = g j
+    rw [Finset.sum_eq_single j]
+    · simp
+    · intro c _ hc
+      exact if_neg fun h => hc (Fin.ext (by omega))
+    · simp
+  have hSzero : ∀ c : ℕ, n < c → S c = 0 := by
+    intro c hc
+    refine Finset.sum_eq_zero fun j _ => if_neg ?_
+    have := j.isLt
+    omega
+  have hS0 : S 0 = 0 := Finset.sum_eq_zero fun j _ => if_neg (by omega)
+  have hshift : ∀ c : ℕ, ∑ j : Fin n, (if (j : ℕ) = c then g j else 0) = S (c + 1) :=
+    fun c => Finset.sum_congr rfl fun j _ => by by_cases h : (j : ℕ) = c <;> simp [h]
+  have hrec : ∀ k : Fin n, S ((k : ℕ) + 1) + S ((k : ℕ) + 1) = S (k : ℕ) + S ((k : ℕ) + 2) := by
+    intro k
+    have h := congrFun hg k
+    simp only [Finset.sum_apply, Pi.smul_apply, Pi.sub_apply, typeAWeight, smul_eq_mul,
+      Pi.zero_apply, mul_sub, mul_ite, mul_one, mul_zero] at h
+    rw [Finset.sum_sub_distrib, Finset.sum_sub_distrib, Finset.sum_sub_distrib] at h
+    rw [hshift, hshift] at h
+    have e1 : ∑ j : Fin n, (if (j : ℕ) + 1 = (k : ℕ) then g j else 0) = S (k : ℕ) := rfl
+    have e2 : ∑ j : Fin n, (if (j : ℕ) + 1 = (k : ℕ) + 1 then g j else 0) = S ((k : ℕ) + 1) := rfl
+    rw [e1, e2] at h
+    linarith [h]
+  have key : ∀ j : ℕ, j ≤ n + 1 → S j = j * S 1 := by
+    intro j
+    induction j using Nat.strong_induction_on with
+    | _ j ih =>
+      match j with
+      | 0 => intro _; simpa using hS0
+      | 1 => intro _; simp
+      | (m + 2) =>
+        intro hm
+        have hmn : m < n := by omega
+        have h0 := ih m (by omega) (by omega)
+        have h1 := ih (m + 1) (by omega) (by omega)
+        have h2 : S (m + 1) + S (m + 1) = S m + S (m + 2) := hrec ⟨m, hmn⟩
+        push_cast at h0 h1 ⊢
+        linarith
+  have hS1 : S 1 = 0 := by
+    have h := key (n + 1) le_rfl
+    rw [hSzero (n + 1) (by omega)] at h
+    have hz : ((n : ℤ) + 1) * S 1 = 0 := by push_cast at h ⊢; linarith
+    rcases mul_eq_zero.mp hz with h' | h'
+    · exact absurd h' (by positivity)
+    · exact h'
+  intro i
+  rw [← hSval i, key ((i : ℕ) + 1) (by have := i.isLt; omega), hS1, mul_zero]
+
+private lemma linearIndependent_typeASimpleCoroot (n : ℕ) :
+    LinearIndependent ℤ fun i : Fin n => typeACoweight n (i : ℕ) -
+      typeACoweight n ((i : ℕ) + 1) := by
+  have h : (fun i : Fin n => typeACoweight n (i : ℕ) - typeACoweight n ((i : ℕ) + 1)) =
+      fun i : Fin n => (Pi.basisFun ℤ (Fin n)) i := by
+    funext i
+    rw [typeACoweight_sub_succ]
+    simp
+  rw [h]
+  exact (Pi.basisFun ℤ (Fin n)).linearIndependent
+
+/-- The support of the pinned base of type `Aₙ`: the first `n` root indices. -/
+private def typeASimpleSupport (n : ℕ) : Finset (Fin (n * (n + 1))) :=
+  Finset.univ.map ⟨typeASimpleIndex n, typeASimpleIndex_injective⟩
+
+private lemma mem_typeASimpleSupport {k : Fin (n * (n + 1))} :
+    k ∈ typeASimpleSupport n ↔ (k : ℕ) < n := by
+  constructor
+  · rintro hk
+    obtain ⟨i, -, rfl⟩ := Finset.mem_map.mp hk
+    simp only [Function.Embedding.coeFn_mk, typeASimpleIndex_val]
+    exact i.isLt
+  · intro hk
+    exact Finset.mem_map.mpr ⟨⟨k, hk⟩, Finset.mem_univ _, Fin.ext rfl⟩
+
+private lemma coe_typeASimpleSupport :
+    (typeASimpleSupport n : Set (Fin (n * (n + 1)))) = range (typeASimpleIndex n) := by
+  simp [typeASimpleSupport]
+
+private lemma image_root_typeASimpleSupport :
+    (typeASimplyConnectedRootDatum n).root '' (typeASimpleSupport n : Set (Fin (n * (n + 1)))) =
+      range fun i : Fin n => typeAWeight n (i : ℕ) - typeAWeight n ((i : ℕ) + 1) := by
+  rw [coe_typeASimpleSupport, ← range_comp]
+  exact congrArg range (funext fun i => root_typeASimpleIndex_eq i)
+
+private lemma image_coroot_typeASimpleSupport :
+    (typeASimplyConnectedRootDatum n).coroot '' (typeASimpleSupport n : Set (Fin (n * (n + 1)))) =
+      range fun i : Fin n => typeACoweight n (i : ℕ) - typeACoweight n ((i : ℕ) + 1) := by
+  rw [coe_typeASimpleSupport, ← range_comp]
+  exact congrArg range (funext fun i => coroot_typeASimpleIndex_eq i)
+
+/-- The Bourbaki-numbered base of the pinned simply connected root datum of type `Aₙ`. Its support
+is the set of the first `n` root indices, carrying the simple roots in Bourbaki order. -/
+def typeASimplyConnectedBase (n : ℕ) : (typeASimplyConnectedRootDatum n).Base where
+  support := typeASimpleSupport n
+  linearIndepOn_root := by
+    have h : LinearIndepOn ℤ (typeASimplyConnectedRootDatum n).root
+        (range (typeASimpleIndex n)) := by
+      rw [linearIndepOn_range_iff typeASimpleIndex_injective]
+      have hcomp : (typeASimplyConnectedRootDatum n).root ∘ typeASimpleIndex n =
+          fun i : Fin n => typeAWeight n (i : ℕ) - typeAWeight n ((i : ℕ) + 1) :=
+        funext fun i => root_typeASimpleIndex_eq i
+      rw [hcomp]
+      exact linearIndependent_typeASimpleRoot n
+    rwa [← coe_typeASimpleSupport] at h
+  linearIndepOn_coroot := by
+    have h : LinearIndepOn ℤ (typeASimplyConnectedRootDatum n).coroot
+        (range (typeASimpleIndex n)) := by
+      rw [linearIndepOn_range_iff typeASimpleIndex_injective]
+      have hcomp : (typeASimplyConnectedRootDatum n).coroot ∘ typeASimpleIndex n =
+          fun i : Fin n => typeACoweight n (i : ℕ) - typeACoweight n ((i : ℕ) + 1) :=
+        funext fun i => coroot_typeASimpleIndex_eq i
+      rw [hcomp]
+      exact linearIndependent_typeASimpleCoroot n
+    rwa [← coe_typeASimpleSupport] at h
+  root_mem_or_neg_mem k := by
+    have hroot : (typeASimplyConnectedRootDatum n).root k =
+        typeAWeight n (((typeAIndexEquiv n).symm k).val.1 : ℕ) -
+          typeAWeight n (((typeAIndexEquiv n).symm k).val.2 : ℕ) := rfl
+    rw [image_root_typeASimpleSupport, hroot]
+    rcases le_total ((((typeAIndexEquiv n).symm k).val.1 : Fin (n + 1)) : ℕ)
+        ((((typeAIndexEquiv n).symm k).val.2 : Fin (n + 1)) : ℕ) with h | h
+    · exact Or.inl (sub_mem_closure_of_le (typeAWeight n)
+        (Nat.lt_succ_iff.mp (((typeAIndexEquiv n).symm k).val.2).isLt) h)
+    · refine Or.inr ?_
+      rw [neg_sub]
+      exact sub_mem_closure_of_le (typeAWeight n)
+        (Nat.lt_succ_iff.mp (((typeAIndexEquiv n).symm k).val.1).isLt) h
+  coroot_mem_or_neg_mem k := by
+    have hcoroot : (typeASimplyConnectedRootDatum n).coroot k =
+        typeACoweight n (((typeAIndexEquiv n).symm k).val.1 : ℕ) -
+          typeACoweight n (((typeAIndexEquiv n).symm k).val.2 : ℕ) := rfl
+    rw [image_coroot_typeASimpleSupport, hcoroot]
+    rcases le_total ((((typeAIndexEquiv n).symm k).val.1 : Fin (n + 1)) : ℕ)
+        ((((typeAIndexEquiv n).symm k).val.2 : Fin (n + 1)) : ℕ) with h | h
+    · exact Or.inl (sub_mem_closure_of_le (typeACoweight n)
+        (Nat.lt_succ_iff.mp (((typeAIndexEquiv n).symm k).val.2).isLt) h)
+    · refine Or.inr ?_
+      rw [neg_sub]
+      exact sub_mem_closure_of_le (typeACoweight n)
+        (Nat.lt_succ_iff.mp (((typeAIndexEquiv n).symm k).val.1).isLt) h
+
+/-- The support of the pinned base is the Bourbaki numbering of the simple roots. -/
+private def typeABaseEquiv (n : ℕ) : (typeASimplyConnectedBase n).support ≃ Fin n where
+  toFun x := ⟨(x : Fin (n * (n + 1))), mem_typeASimpleSupport.mp x.2⟩
+  invFun i := ⟨typeASimpleIndex n i, mem_typeASimpleSupport.mpr (by simp)⟩
+  left_inv x := by
+    apply Subtype.ext
+    apply Fin.ext
+    simp
+  right_inv i := by
+    apply Fin.ext
+    simp
+
+private lemma pairing_typeASimpleIndex (i j : Fin n) :
+    (typeASimplyConnectedRootDatum n).pairing (typeASimpleIndex n i) (typeASimpleIndex n j) =
+      CartanMatrix.A n i j := by
+  rw [pairing_typeASimplyConnectedRootDatum, root_typeASimpleIndex, coroot_typeASimpleIndex,
+    dotProduct_single, mul_one]
+
+/-- **The pinned datum of type `Aₙ` has Cartan type `A n`.** Its Bourbaki-numbered base realizes the
+standard Cartan matrix `CartanMatrix.A n`, with the node numbering of `TauCeti.DynkinType`. -/
+theorem hasCartanType_typeASimplyConnectedRootDatum (n : ℕ) :
+    HasCartanType (typeASimplyConnectedRootDatum n) (typeASimplyConnectedBase n) (.A n) := by
+  rw [hasCartanType_iff]
+  refine ⟨typeABaseEquiv n, fun i j => ?_⟩
+  have hi : (i : Fin (n * (n + 1))) = typeASimpleIndex n (typeABaseEquiv n i) :=
+    Fin.ext (by simp [typeABaseEquiv])
+  have hj : (j : Fin (n * (n + 1))) = typeASimpleIndex n (typeABaseEquiv n j) :=
+    Fin.ext (by simp [typeABaseEquiv])
+  rw [← (FaithfulSMul.algebraMap_injective ℤ ℤ).eq_iff,
+    RootPairing.Base.algebraMap_cartanMatrixIn_apply, hi, hj, pairing_typeASimpleIndex,
+    cartanMatrix_A]
+  rfl
+
+/-- **The coroots of the pinned type `Aₙ` datum span the cocharacter lattice.** This is the simply
+connected lattice condition required by the pinned Chevalley--Demazure construction. Its
+counterpart for the roots is deliberately absent: they span the root lattice, which sits inside the
+weight lattice with index `n + 1` (Bourbaki, Plate I). -/
+theorem span_coroot_typeASimplyConnectedRootDatum (n : ℕ) :
+    (typeASimplyConnectedRootDatum n).corootSpan ℤ = ⊤ := by
+  refine top_unique ?_
+  rw [← (Pi.basisFun ℤ (Fin n)).span_eq]
+  refine Submodule.span_mono ?_
+  rintro _ ⟨i, rfl⟩
+  exact ⟨typeASimpleIndex n i, by rw [coroot_typeASimpleIndex]; simp⟩
+
+end DynkinType
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -42,9 +42,10 @@ first `n` indices are therefore the simple roots `α₀, …, α_{n-1}` in Bourb
 `root_typeASimpleIndex` records.
 
 Only the coroots are asked to span their lattice, and only that half is recorded, in
-`span_coroot_typeASimplyConnectedRootDatum`. The roots span the root lattice, which sits inside the
-weight lattice with index `n + 1` (Bourbaki, Plate I), so the datum is a `RootDatum` carrying no
-`RootPairing.IsRootSystem` instance. That asymmetry is what "simply connected" means here.
+`corootSpan_typeASimplyConnectedRootDatum_eq_top`. The roots span the root lattice, which sits
+inside the weight lattice with index `n + 1` (Bourbaki, Plate I), so the datum is a `RootDatum`
+carrying no `RootPairing.IsRootSystem` instance. That asymmetry is what "simply connected" means
+here.
 
 ## Main definitions
 
@@ -58,11 +59,11 @@ weight lattice with index `n + 1` (Bourbaki, Plate I), so the datum is a `RootDa
 * `TauCeti.DynkinType.root_typeASimpleIndex` and
   `TauCeti.DynkinType.coroot_typeASimpleIndex`: the `i`-th simple root is the `i`-th row of
   `CartanMatrix.A n` and the `i`-th simple coroot is `Pi.single i 1`, which is what pins the two
-  lattices as the weight and coweight lattices.
+  lattices as the weight and coroot lattices.
 * `TauCeti.DynkinType.hasCartanType_typeASimplyConnectedRootDatum`: the pinned base has Cartan type
   `A n`.
-* `TauCeti.DynkinType.span_coroot_typeASimplyConnectedRootDatum`: the coroots span the cocharacter
-  lattice, the simply connected condition.
+* `TauCeti.DynkinType.corootSpan_typeASimplyConnectedRootDatum_eq_top`: the coroots span the
+  cocharacter lattice, the simply connected condition.
 
 ## References
 
@@ -92,35 +93,6 @@ private def typeAWeight (n a : ℕ) : Fin n → ℤ :=
 private def typeACoweight (n a : ℕ) : Fin n → ℤ :=
   fun k => if a ≤ (k : ℕ) then 1 else 0
 
-private lemma sum_ite_val (f : Fin n → ℤ) (b : ℕ) :
-    ∑ k : Fin n, (if b = (k : ℕ) then f k else 0) = if h : b < n then f ⟨b, h⟩ else 0 := by
-  by_cases h : b < n
-  · rw [dif_pos h, Finset.sum_eq_single (⟨b, h⟩ : Fin n)]
-    · simp
-    · intro c _ hc
-      exact if_neg fun hb => hc (Fin.ext hb.symm)
-    · simp
-  · rw [dif_neg h, Finset.sum_eq_zero]
-    intro k _
-    have := k.isLt
-    exact if_neg (by omega)
-
-private lemma sum_ite_val_succ (f : Fin n → ℤ) (b : ℕ) :
-    ∑ k : Fin n, (if b = (k : ℕ) + 1 then f k else 0)
-      = if h : b - 1 < n ∧ 1 ≤ b then f ⟨b - 1, h.1⟩ else 0 := by
-  by_cases h : b - 1 < n ∧ 1 ≤ b
-  · rw [dif_pos h, Finset.sum_eq_single (⟨b - 1, h.1⟩ : Fin n)]
-    · exact if_pos (show b = b - 1 + 1 by omega)
-    · intro c _ hc
-      refine if_neg fun hb => hc (Fin.ext ?_)
-      simp only
-      omega
-    · simp
-  · rw [dif_neg h, Finset.sum_eq_zero]
-    intro k _
-    have := k.isLt
-    exact if_neg (by omega)
-
 /-- The fundamental pairing identity of type `Aₙ`: in the classical model `⟨e_a, e_c^∨⟩` would be
 `[a = c]`, and the two pinned lattices see that up to the single correction `[a = n]`, which
 cancels in the differences that are the roots and coroots. -/
@@ -131,13 +103,39 @@ private lemma typeAWeight_dotProduct_typeACoweight {a c : ℕ} (ha : a ≤ n) (h
       (if c ≤ (k : ℕ) then 1 else 0) = if h : b < n then (if c ≤ b then (1 : ℤ) else 0) else 0 := by
     intro b
     simp only [ite_mul, one_mul, zero_mul]
-    exact sum_ite_val (fun k => if c ≤ (k : ℕ) then (1 : ℤ) else 0) b
+    by_cases h : b < n
+    · rw [dif_pos h]
+      convert Fintype.sum_ite_eq (⟨b, h⟩ : Fin n)
+        (fun k => if c ≤ (k : ℕ) then (1 : ℤ) else 0) using 1 with k
+      simp [Fin.ext_iff]
+    · rw [dif_neg h]
+      exact Finset.sum_eq_zero fun k _ => if_neg (by omega)
   have key' : ∀ b : ℕ, ∑ k : Fin n, (if b = (k : ℕ) + 1 then (1 : ℤ) else 0) *
       (if c ≤ (k : ℕ) then 1 else 0)
         = if h : b - 1 < n ∧ 1 ≤ b then (if c ≤ b - 1 then (1 : ℤ) else 0) else 0 := by
     intro b
     simp only [ite_mul, one_mul, zero_mul]
-    exact sum_ite_val_succ (fun k => if c ≤ (k : ℕ) then (1 : ℤ) else 0) b
+    by_cases h : b - 1 < n ∧ 1 ≤ b
+    · rw [dif_pos h]
+      calc
+        _ = ∑ k : Fin n, if (⟨b - 1, h.1⟩ : Fin n) = k then
+            (if c ≤ (k : ℕ) then (1 : ℤ) else 0) else 0 := by
+          apply Finset.sum_congr rfl
+          intro k _
+          congr 1
+          apply propext
+          constructor
+          · intro hb
+            apply Fin.ext
+            simp only
+            omega
+          · intro hk
+            have hkval := congrArg Fin.val hk
+            simp only at hkval
+            omega
+        _ = _ := Fintype.sum_ite_eq _ _
+    · rw [dif_neg h]
+      exact Finset.sum_eq_zero fun k _ => if_neg (by omega)
   simp only [dotProduct, typeAWeight, typeACoweight, sub_mul, Finset.sum_sub_distrib,
     key a, key' a]
   split_ifs <;> omega
@@ -246,6 +244,7 @@ private lemma typeAPairReflection_coroot (p q : TypeAIndex n) :
 
 private instance : (dotProductBilin ℤ ℤ :
     (Fin n → ℤ) →ₗ[ℤ] (Fin n → ℤ) →ₗ[ℤ] ℤ).IsPerfPair := by
+  -- `dotProductEquiv` has `dotProductBilin` as its underlying linear map by definition.
   change (dotProductEquiv ℤ (Fin n)).toLinearMap.IsPerfPair
   infer_instance
 
@@ -295,11 +294,13 @@ private def typeAPairEquiv (n : ℕ) : TypeAIndex n ≃ Fin n × Fin (n + 1) whe
     have hx : typeASucc (typeADiff p) = p.val.2 - p.val.1 :=
       Fin.ext (by rw [typeASucc_val, typeADiff_val]; omega)
     refine Subtype.ext (Prod.ext rfl ?_)
+    -- Unfold the subtype equivalence to compare its second `Fin (n + 1)` coordinate.
     change p.val.1 + typeASucc (typeADiff p) = p.val.2
     rw [hx]
     abel
   right_inv q := by
     refine Prod.ext (Fin.ext ?_) rfl
+    -- Unfold the first coordinate of the product equivalence to compare its natural values.
     change ((q.2 + typeASucc q.1 - q.2 : Fin (n + 1)) : ℕ) - 1 = (q.1 : ℕ)
     rw [add_sub_cancel_left, typeASucc_val]
     omega
@@ -307,6 +308,34 @@ private def typeAPairEquiv (n : ℕ) : TypeAIndex n ≃ Fin n × Fin (n + 1) whe
 /-- The pinned enumeration of the roots of type `Aₙ` by `Fin (n * (n + 1))`. -/
 private def typeAIndexEquiv (n : ℕ) : TypeAIndex n ≃ Fin (n * (n + 1)) :=
   (typeAPairEquiv n).trans finProdFinEquiv
+
+private def typeAReflectionPerm (n : ℕ) (k : Fin (n * (n + 1))) :
+    Fin (n * (n + 1)) ≃ Fin (n * (n + 1)) :=
+  ((typeAIndexEquiv n).symm.trans
+    (typeAPairReflection ((typeAIndexEquiv n).symm k))).trans (typeAIndexEquiv n)
+
+private lemma typeAReflectionPerm_apply (k l : Fin (n * (n + 1))) :
+    (typeAIndexEquiv n).symm (typeAReflectionPerm n k l) =
+      typeAPairReflection ((typeAIndexEquiv n).symm k) ((typeAIndexEquiv n).symm l) := by
+  simp [typeAReflectionPerm]
+
+private lemma typeAReflectionPerm_root (k l : Fin (n * (n + 1))) :
+    typeAPairRoot ((typeAIndexEquiv n).symm l) -
+        (typeAPairRoot ((typeAIndexEquiv n).symm l) ⬝ᵥ
+          typeAPairCoroot ((typeAIndexEquiv n).symm k)) •
+          typeAPairRoot ((typeAIndexEquiv n).symm k) =
+      typeAPairRoot ((typeAIndexEquiv n).symm (typeAReflectionPerm n k l)) := by
+  rw [typeAReflectionPerm_apply]
+  exact typeAPairReflection_root _ _
+
+private lemma typeAReflectionPerm_coroot (k l : Fin (n * (n + 1))) :
+    typeAPairCoroot ((typeAIndexEquiv n).symm l) -
+        (typeAPairRoot ((typeAIndexEquiv n).symm k) ⬝ᵥ
+          typeAPairCoroot ((typeAIndexEquiv n).symm l)) •
+          typeAPairCoroot ((typeAIndexEquiv n).symm k) =
+      typeAPairCoroot ((typeAIndexEquiv n).symm (typeAReflectionPerm n k l)) := by
+  rw [typeAReflectionPerm_apply]
+  exact typeAPairReflection_coroot _ _
 
 /-- The pinned simply connected root datum of type `Aₙ`.
 
@@ -321,13 +350,10 @@ def typeASimplyConnectedRootDatum (n : ℕ) :
     typeAPairRoot_injective.comp (typeAIndexEquiv n).symm.injective⟩
   coroot := ⟨fun k => typeAPairCoroot ((typeAIndexEquiv n).symm k),
     typeAPairCoroot_injective.comp (typeAIndexEquiv n).symm.injective⟩
-  root_coroot_two k := typeAPairRoot_self _
-  reflectionPerm k := ((typeAIndexEquiv n).symm.trans
-    (typeAPairReflection ((typeAIndexEquiv n).symm k))).trans (typeAIndexEquiv n)
-  reflectionPerm_root k l := by
-    simpa using typeAPairReflection_root ((typeAIndexEquiv n).symm k) ((typeAIndexEquiv n).symm l)
-  reflectionPerm_coroot k l := by
-    simpa using typeAPairReflection_coroot ((typeAIndexEquiv n).symm k) ((typeAIndexEquiv n).symm l)
+  root_coroot_two k := typeAPairRoot_self ((typeAIndexEquiv n).symm k)
+  reflectionPerm := typeAReflectionPerm n
+  reflectionPerm_root := typeAReflectionPerm_root
+  reflectionPerm_coroot := typeAReflectionPerm_coroot
 
 private lemma root_typeASimplyConnectedRootDatum (k : Fin (n * (n + 1))) :
     (typeASimplyConnectedRootDatum n).root k = typeAPairRoot ((typeAIndexEquiv n).symm k) :=
@@ -380,7 +406,7 @@ private lemma coroot_typeASimpleIndex_eq (i : Fin n) :
 /-- **The simple roots are the rows of the Cartan matrix.** In the fundamental-weight basis the
 `i`-th simple root of the pinned type `Aₙ` datum is the `i`-th row of `CartanMatrix.A n`, which is
 what pins the character lattice as the weight lattice. -/
-theorem root_typeASimpleIndex (i : Fin n) :
+@[simp] theorem root_typeASimpleIndex (i : Fin n) :
     (typeASimplyConnectedRootDatum n).root (typeASimpleIndex n i) =
       fun k => CartanMatrix.A n i k := by
   rw [root_typeASimpleIndex_eq]
@@ -395,27 +421,23 @@ private lemma typeACoweight_sub_succ (i : Fin n) :
   split_ifs <;> omega
 
 /-- **The simple coroots are the standard basis.** This is what pins the cocharacter lattice as the
-coweight lattice, so that the datum is the simply connected one. -/
-theorem coroot_typeASimpleIndex (i : Fin n) :
+coroot lattice, so that the datum is the simply connected one. -/
+@[simp] theorem coroot_typeASimpleIndex (i : Fin n) :
     (typeASimplyConnectedRootDatum n).coroot (typeASimpleIndex n i) = Pi.single i 1 := by
   rw [coroot_typeASimpleIndex_eq, typeACoweight_sub_succ]
 
 /-! ## The pinned base -/
 
-/-- The telescoping identity behind `root_mem_or_neg_mem`: a difference `f a - f b` with `a ≤ b` is
-the sum of the consecutive differences between them. -/
-private lemma sub_eq_sum_Ico {M : Type*} [AddCommGroup M] (f : ℕ → M) {a b : ℕ} (hab : a ≤ b) :
-    f a - f b = ∑ i ∈ Finset.Ico a b, (f i - f (i + 1)) := by
-  induction b, hab using Nat.le_induction with
-  | base => simp
-  | succ b hb ih =>
-    rw [Finset.sum_Ico_succ_top hb, ← ih]
-    abel
-
 private lemma sub_mem_closure_of_le {M : Type*} [AddCommGroup M] (f : ℕ → M) {a b : ℕ}
     (hb : b ≤ n) (hab : a ≤ b) :
     f a - f b ∈ AddSubmonoid.closure (range fun i : Fin n => f (i : ℕ) - f ((i : ℕ) + 1)) := by
-  rw [sub_eq_sum_Ico f hab]
+  have hshift := Finset.sum_Ico_add' (fun i => f i - f (i + 1)) 0 (b - a) a
+  simp only [zero_add] at hshift
+  have htel : f a - f b = ∑ i ∈ Finset.Ico a b, (f i - f (i + 1)) := by
+    rw [← Nat.sub_add_cancel hab, ← hshift]
+    simpa [Nat.Ico_zero_eq_range, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
+      (Finset.sum_range_sub' (fun i => f (i + a)) (b - a)).symm
+  rw [htel]
   refine AddSubmonoid.sum_mem _ fun i hi => AddSubmonoid.subset_closure ?_
   have : i < n := lt_of_lt_of_le (Finset.mem_Ico.mp hi).2 hb
   exact ⟨⟨i, this⟩, rfl⟩
@@ -430,12 +452,7 @@ private lemma linearIndependent_typeASimpleRoot (n : ℕ) :
   let S : ℕ → ℤ := fun c => ∑ j : Fin n, (if (j : ℕ) + 1 = c then g j else 0)
   have hSval : ∀ j : Fin n, S ((j : ℕ) + 1) = g j := by
     intro j
-    change ∑ j' : Fin n, (if (j' : ℕ) + 1 = (j : ℕ) + 1 then g j' else 0) = g j
-    rw [Finset.sum_eq_single j]
-    · simp
-    · intro c _ hc
-      exact if_neg fun h => hc (Fin.ext (by omega))
-    · simp
+    simpa only [S, Nat.add_right_cancel_iff, Fin.val_inj] using Fintype.sum_ite_eq' j g
   have hSzero : ∀ c : ℕ, n < c → S c = 0 := by
     intro c hc
     refine Finset.sum_eq_zero fun j _ => if_neg ?_
@@ -572,6 +589,11 @@ def typeASimplyConnectedBase (n : ℕ) : (typeASimplyConnectedRootDatum n).Base 
       exact sub_mem_closure_of_le (typeACoweight n)
         (Nat.lt_succ_iff.mp (((typeAIndexEquiv n).symm k).val.1).isLt) h
 
+/-- Membership in the pinned base support is exactly membership among the first `n` root indices. -/
+@[simp] theorem mem_typeASimplyConnectedBase_support {k : Fin (n * (n + 1))} :
+    k ∈ (typeASimplyConnectedBase n).support ↔ (k : ℕ) < n :=
+  mem_typeASimpleSupport
+
 /-- The support of the pinned base is the Bourbaki numbering of the simple roots. -/
 private def typeABaseEquiv (n : ℕ) : (typeASimplyConnectedBase n).support ≃ Fin n where
   toFun x := ⟨(x : Fin (n * (n + 1))), mem_typeASimpleSupport.mp x.2⟩
@@ -609,7 +631,7 @@ theorem hasCartanType_typeASimplyConnectedRootDatum (n : ℕ) :
 connected lattice condition required by the pinned Chevalley--Demazure construction. Its
 counterpart for the roots is deliberately absent: they span the root lattice, which sits inside the
 weight lattice with index `n + 1` (Bourbaki, Plate I). -/
-theorem span_coroot_typeASimplyConnectedRootDatum (n : ℕ) :
+theorem corootSpan_typeASimplyConnectedRootDatum_eq_top (n : ℕ) :
     (typeASimplyConnectedRootDatum n).corootSpan ℤ = ⊤ := by
   refine top_unique ?_
   rw [← (Pi.basisFun ℤ (Fin n)).span_eq]


### PR DESCRIPTION
This PR constructs the pinned simply connected root datum of type `Aₙ`, uniformly in the rank, for `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, milestone **Layer 6: the Bourbaki numbering and integral root data**, target **A named datum per valid type**. Both lattices are `Fin n → ℤ`, the character lattice in the fundamental-weight basis and the cocharacter lattice in the simple-coroot basis; the `n * (n + 1)` roots are the classical `e_a - e_b` with `a ≠ b`, recorded by their pairings against the simple coroots and enumerated by the difference `b - a` first and the source `a` second, so that the Bourbaki-numbered simple roots occupy the first `n` indices. The acceptance data is proved: the `i`-th simple root is the `i`-th row of `CartanMatrix.A n`, the `i`-th simple coroot is `Pi.single i 1`, the first `n` indices form a base, that base has Cartan type `A n`, and the coroots span the cocharacter lattice, which is the simply connected condition. The roots deliberately get no spanning statement — they generate the root lattice, of index `n + 1` in the weight lattice — so the datum is a `RootDatum` and carries no `RootPairing.IsRootSystem` instance.

The whole construction rests on one identity, that the pinned pairing of `e_a` against `e_c^∨` is `[a = c]` up to a correction `[a = n]` that cancels in every difference; the reflection axioms then reduce to the formal fact that reflecting in `e_a - e_b` is the transposition of `a` and `b`. Linear independence of the simple roots is the only step that is not a direct calculation: a relation among the rows of `CartanMatrix.A n` forces the coefficients to grow linearly along the chain, and the absent row past the last node then makes the common ratio `(n + 1)`-torsion, hence zero over `ℤ`.

The designated roadmap is `CFSGStatement` and this is a prerequisite for it. Its CFSG-local lanes are already in flight — the `I0` index layer in #2534 and #2580 and the `S0` relator compiler in #2578 — while milestone **L0: pinned ambient groups** states that `ValidLieTypeIndex.AmbientGroup` consumes `DynkinType.simplyConnectedRootDatum` and `DynkinType.simplyConnectedBase` from Layer 6 of the root-systems roadmap, and not the existence statement `exists_rootPairing_of_dynkinType`, since a carrier may not be extracted by `Classical.choose`. That is the dependency edge: `L0` needs a named carrier for the underlying diagram of every valid Lie index, and `ValidLieTypeIndex.dynkinType` sends the `A_n(q)` and `²A_n(q)` families, the largest block of the classification list, to `DynkinType.A n`. This PR supplies that branch with an explicit carrier. Type `G2` is being supplied in parallel by #2584 and `DynkinType.numRoots` by #2579; the index type used here is literally `Fin (n * (n + 1))`, which is the `numRoots` of `A n`, so the two fit together without change.

After this PR, Layer 6 still needs the analogous explicit data for `Bₙ`, `Cₙ`, `Dₙ` and the remaining exceptional types, and then the assembly of `DynkinType.simplyConnectedRootDatum`, `simplyConnectedBase`, and their type-indexed acceptance lemmas; CFSG `L0` further needs reductive-groups Layer 9 before it can build an ambient group.

No Mathlib infrastructure is vendored. The construction reuses Mathlib's `RootPairing`/`RootDatum`, `RootPairing.Base`, `dotProductBilin` and `dotProductEquiv`, `Equiv.swap` and `Equiv.subtypeEquiv`, `finProdFinEquiv`, `Pi.basisFun`, `CartanMatrix.A`, and `linearIndepOn_range_iff`, together with Tau Ceti's `DynkinType.cartanMatrix` and `HasCartanType`. The coordinates and node numbering follow Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate I, and Humphreys, *Introduction to Lie Algebras and Representation Theory*, section 12.1, as credited in the module documentation. The new module is `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean` (625 lines); it shares the `SimplyConnectedRootDatum/` directory that #2584 introduces for the `G2` branch, and no existing file changes.

Roadmap: RepresentationTheory

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"type-a-simply-connected-root-datum"}-->

🤖 Prepared with Claude Code
