### PR TITLE
feat(HeckeRing/GLn): upper-triangular representatives of a diagonal double coset

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/Triangular.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Triangular.lean
@@ -25,6 +25,8 @@ which have no business importing Lie-algebra theory use it.
 
 * `Matrix.mul_apply_diag_of_isUpperTriangular` — the diagonal of a product of upper-triangular
   matrices is the pointwise product of the diagonals.
+* `Matrix.inv_apply_diag_mul_of_isUpperTriangular` — on the diagonal, the inverse inverts
+  entrywise: `M⁻¹ i i * M i i = 1`.
 * `Matrix.inv_apply_diag_of_isUpperTriangular` — where an upper-triangular matrix carries a `1`
   on the diagonal, so does its inverse.
 * `TauCeti.vecMul_injective_of_submatrix_isUpperTriangular` — a rectangular matrix has injective
@@ -52,13 +54,20 @@ theorem mul_apply_diag_of_isUpperTriangular (hA : A.IsUpperTriangular)
 
 variable {S : Type*} [CommRing S] {M : Matrix n n S}
 
+/-- On the diagonal, the inverse of an invertible upper-triangular matrix inverts entrywise:
+`M⁻¹ i i * M i i = 1`. Read `M⁻¹ * M = 1` at `(i, i)`, where the product's diagonal is the
+pointwise product because `M⁻¹` is upper triangular too. -/
+theorem inv_apply_diag_mul_of_isUpperTriangular [Invertible M] (hM : M.IsUpperTriangular)
+    (i : n) : M⁻¹ i i * M i i = 1 := by
+  have hinv : M⁻¹.IsUpperTriangular := blockTriangular_inv_of_blockTriangular hM
+  have h := congrFun (congrFun (nonsing_inv_mul M (isUnit_det_of_invertible M)) i) i
+  rwa [mul_apply_diag_of_isUpperTriangular hinv hM i, one_apply_eq] at h
+
 /-- Where an invertible upper-triangular matrix has a `1` on the diagonal, so does its inverse.
 The hypothesis is needed only at the entry asked about. -/
 theorem inv_apply_diag_of_isUpperTriangular [Invertible M] (hM : M.IsUpperTriangular) {i : n}
     (hdiag : M i i = 1) : M⁻¹ i i = 1 := by
-  have hinv : M⁻¹.IsUpperTriangular := blockTriangular_inv_of_blockTriangular hM
-  have h := congrFun (congrFun (nonsing_inv_mul M (isUnit_det_of_invertible M)) i) i
-  rwa [mul_apply_diag_of_isUpperTriangular hinv hM i, hdiag, mul_one, one_apply_eq] at h
+  simpa [hdiag] using inv_apply_diag_mul_of_isUpperTriangular hM i
 
 end Matrix
 

--- a/TauCeti/LinearAlgebra/Matrix/Triangular.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Triangular.lean
@@ -11,9 +11,10 @@ public import Mathlib.LinearAlgebra.Matrix.Block
 # Triangular matrices
 
 Mathlib's `Matrix.BlockTriangular` API computes determinants and inverses of triangular
-matrices, but not their individual diagonal entries. This file supplies the one fact that
+matrices, but not their individual diagonal entries. This file supplies the facts that
 consumers keep needing: on the diagonal, a product of upper-triangular matrices multiplies
-entrywise, because `∑ k, A i k * B k i` has a single surviving term.
+entrywise, because `∑ k, A i k * B k i` has a single surviving term — and consequences of
+that, such as the diagonal of an inverse.
 
 The result previously lived in `TauCeti.Algebra.Lie.GeneralLinear.Borel`, phrased through
 membership in the Borel subalgebra. It is a statement about matrices with no Lie theory in it,
@@ -24,6 +25,8 @@ which have no business importing Lie-algebra theory use it.
 
 * `Matrix.mul_apply_diag_of_isUpperTriangular` — the diagonal of a product of upper-triangular
   matrices is the pointwise product of the diagonals.
+* `Matrix.inv_apply_diag_of_isUpperTriangular` — inverting a unipotent upper-triangular matrix
+  leaves the diagonal at `1`; read off the previous result.
 * `TauCeti.vecMul_injective_of_submatrix_isUpperTriangular` — a rectangular matrix has injective
   row multiplication when a square column selection is upper triangular with nonzero diagonal.
 -/
@@ -46,6 +49,17 @@ theorem mul_apply_diag_of_isUpperTriangular (hA : A.IsUpperTriangular)
     · rw [hA h, zero_mul]
     · rw [hB h, mul_zero]
   · exact fun h ↦ absurd (Finset.mem_univ i) h
+
+variable {S : Type*} [CommRing S] {M : Matrix n n S}
+
+/-- The inverse of an invertible upper-triangular matrix with `1` on the diagonal again has `1`
+on the diagonal: read `M⁻¹ * M = 1` on the diagonal through
+`Matrix.mul_apply_diag_of_isUpperTriangular`, using that `M⁻¹` is upper triangular too. -/
+theorem inv_apply_diag_of_isUpperTriangular [Invertible M] (hM : M.IsUpperTriangular)
+    (hdiag : ∀ i, M i i = 1) (i : n) : M⁻¹ i i = 1 := by
+  have hinv : M⁻¹.IsUpperTriangular := blockTriangular_inv_of_blockTriangular hM
+  have h := congrFun (congrFun (nonsing_inv_mul M (isUnit_det_of_invertible M)) i) i
+  rwa [mul_apply_diag_of_isUpperTriangular hinv hM i, hdiag i, mul_one, one_apply_eq] at h
 
 end Matrix
 

--- a/TauCeti/LinearAlgebra/Matrix/Triangular.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Triangular.lean
@@ -25,8 +25,8 @@ which have no business importing Lie-algebra theory use it.
 
 * `Matrix.mul_apply_diag_of_isUpperTriangular` — the diagonal of a product of upper-triangular
   matrices is the pointwise product of the diagonals.
-* `Matrix.inv_apply_diag_of_isUpperTriangular` — inverting a unipotent upper-triangular matrix
-  leaves the diagonal at `1`; read off the previous result.
+* `Matrix.inv_apply_diag_of_isUpperTriangular` — where an upper-triangular matrix carries a `1`
+  on the diagonal, so does its inverse.
 * `TauCeti.vecMul_injective_of_submatrix_isUpperTriangular` — a rectangular matrix has injective
   row multiplication when a square column selection is upper triangular with nonzero diagonal.
 -/
@@ -52,14 +52,13 @@ theorem mul_apply_diag_of_isUpperTriangular (hA : A.IsUpperTriangular)
 
 variable {S : Type*} [CommRing S] {M : Matrix n n S}
 
-/-- The inverse of an invertible upper-triangular matrix with `1` on the diagonal again has `1`
-on the diagonal: read `M⁻¹ * M = 1` on the diagonal through
-`Matrix.mul_apply_diag_of_isUpperTriangular`, using that `M⁻¹` is upper triangular too. -/
-theorem inv_apply_diag_of_isUpperTriangular [Invertible M] (hM : M.IsUpperTriangular)
-    (hdiag : ∀ i, M i i = 1) (i : n) : M⁻¹ i i = 1 := by
+/-- Where an invertible upper-triangular matrix has a `1` on the diagonal, so does its inverse.
+The hypothesis is needed only at the entry asked about. -/
+theorem inv_apply_diag_of_isUpperTriangular [Invertible M] (hM : M.IsUpperTriangular) {i : n}
+    (hdiag : M i i = 1) : M⁻¹ i i = 1 := by
   have hinv : M⁻¹.IsUpperTriangular := blockTriangular_inv_of_blockTriangular hM
   have h := congrFun (congrFun (nonsing_inv_mul M (isUnit_det_of_invertible M)) i) i
-  rwa [mul_apply_diag_of_isUpperTriangular hinv hM i, hdiag i, mul_one, one_apply_eq] at h
+  rwa [mul_apply_diag_of_isUpperTriangular hinv hM i, hdiag, mul_one, one_apply_eq] at h
 
 end Matrix
 

--- a/TauCeti/LinearAlgebra/Matrix/Triangular.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Triangular.lean
@@ -55,8 +55,7 @@ theorem mul_apply_diag_of_isUpperTriangular (hA : A.IsUpperTriangular)
 variable {S : Type*} [CommRing S] {M : Matrix n n S}
 
 /-- On the diagonal, the inverse of an invertible upper-triangular matrix inverts entrywise:
-`M⁻¹ i i * M i i = 1`. Read `M⁻¹ * M = 1` at `(i, i)`, where the product's diagonal is the
-pointwise product because `M⁻¹` is upper triangular too. -/
+`M⁻¹ i i * M i i = 1`. -/
 theorem inv_apply_diag_mul_of_isUpperTriangular [Invertible M] (hM : M.IsUpperTriangular)
     (i : n) : M⁻¹ i i * M i i = 1 := by
   have hinv : M⁻¹.IsUpperTriangular := blockTriangular_inv_of_blockTriangular hM

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -39,8 +39,8 @@ does not, since `upperTriGL` is visibly a composition of injective maps.
   matrices, hence distinct representatives.
 * `eq_of_upperTriGL_eq`, `eq_of_mul_inv_mem_SLnZ` — the representatives lie in *distinct* left
   `SL_n(ℤ)`-cosets: two of them are left-equivalent only when their entry assignments already
-  agree. So for a chain `a_i ∣ a_j` of positive naturals the double coset meets at least
-  `∏_{i < j} (a_j / a_i)` distinct left cosets.
+  agree. So for a positive `IsDvdChain` the double coset meets at least `∏_{i < j} (a_j / a_i)`
+  distinct left cosets.
 
 The two steps behind that conclusion are also stated separately, since each is reusable:
 `dvd_comparison_of_upperTriGL_eq` turns left equivalence into `(a_j / a_i) ∣ C_{ij}` for the
@@ -113,7 +113,7 @@ lemma isUpperTriangular_unitriMat {a : Fin n → ℕ} (B : UpperTriEntries n a) 
 def unitriSL {a : Fin n → ℕ} (B : UpperTriEntries n a) : SpecialLinearGroup (Fin n) ℤ :=
   ⟨unitriMat B, det_unitriMat B⟩
 
-@[simp] lemma unitriSL_coe {a : Fin n → ℕ} (B : UpperTriEntries n a) :
+@[simp] lemma coe_unitriSL {a : Fin n → ℕ} (B : UpperTriEntries n a) :
     (unitriSL B : Matrix (Fin n) (Fin n) ℤ) = unitriMat B := (rfl)
 
 /-- The upper-triangular representative `diag(a) · U(B)` attached to a bounded entry
@@ -126,10 +126,7 @@ work from `diag(a) · U(B)` without unfolding `upperTriGL`. -/
 lemma upperTriGL_def {a : Fin n → ℕ} (B : UpperTriEntries n a) :
     upperTriGL B = natDiagGL n a * (mapGL ℚ (unitriSL B)) := (rfl)
 
-/-- Each upper-triangular representative lies in the double coset of `diag(a)`.
-
-Immediate from the definition: `U(B) ∈ SL_n(ℤ)`, so `diag(a) · U(B)` is already of the form
-`h₁ · diag(a) · h₂` with `h₁ = 1`. -/
+/-- Each upper-triangular representative lies in the double coset of `diag(a)`. -/
 lemma upperTriGL_mem_doubleCoset {a : Fin n → ℕ} (B : UpperTriEntries n a) :
     upperTriGL B ∈ doubleCoset (natDiagGL n a) (SLnZ n) (SLnZ n) :=
   mem_doubleCoset.mpr ⟨1, one_mem _, mapGL ℚ (unitriSL B), coe_mem_SLnZ n _,
@@ -166,16 +163,13 @@ lemma unitriMat_injective {a : Fin n → ℕ} : Function.Injective (unitriMat (a
   rw [unitriMat_apply_lt B₁ hij, unitriMat_apply_lt B₂ hij] at hE
   exact Fin.ext (by exact_mod_cast hE)
 
-/-- Distinct entry assignments give distinct representatives.
-
-`upperTriGL` is a composition of injective maps — left multiplication by the fixed unit
-`diag(a)`, then `mapGL ℚ`, then `unitriMat` — so no positivity hypothesis is needed: even at a
-tuple where `natDiagGL` takes its junk value `1`, left multiplication is still injective. -/
+/-- Distinct entry assignments give distinct representatives. No positivity hypothesis on `a`
+is needed: this holds even at a tuple where `natDiagGL` takes its junk value `1`. -/
 lemma upperTriGL_injective {a : Fin n → ℕ} : Function.Injective (upperTriGL (a := a)) := by
   intro B₁ B₂ h
   rw [upperTriGL, upperTriGL] at h
   have hSL := mapGL_injective (mul_left_cancel h)
-  exact unitriMat_injective (by rw [← unitriSL_coe, ← unitriSL_coe, hSL])
+  exact unitriMat_injective (by rw [← coe_unitriSL, ← coe_unitriSL, hSL])
 
 /-! ## Distinctness of the left cosets
 
@@ -184,13 +178,8 @@ Two representatives lie in the same left `SL_n(ℤ)`-coset exactly when the conj
 `(a_j / a_i) ∣ C_{ij}` for the comparison matrix `C = U(B₁) · U(B₂)⁻¹`. The entry bound
 `B_{ij} < a_j / a_i` then forces `C = 1`. -/
 
-/-- The comparison matrix `C` between two representatives is the identity above the diagonal.
-
-Strong induction on `j - i`. Reading `C · U(B₂) = U(B₁)` at `(i, j)`, every term of the sum
-except `k = i` and `k = j` drops: below `i` because `C` is upper triangular, strictly between
-because the inductive hypothesis has already killed those entries, and above `j` because
-`U(B₂)` is upper triangular. What is left is `(B₂)_{ij} + C_{ij} = (B₁)_{ij}`, so `C_{ij}` is a
-difference of two entries each below `a_j / a_i`; being divisible by `a_j / a_i` it vanishes. -/
+/-- A unipotent upper-triangular `C` with `C · U(B₂) = U(B₁)`, divisible above the diagonal by
+the entry bounds, vanishes above the diagonal. -/
 private lemma comparison_apply_eq_zero {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
     {C : Matrix (Fin n) (Fin n) ℤ} (hmul : C * unitriMat B₂ = unitriMat B₁)
     (hup : Matrix.IsUpperTriangular C) (hdiag : ∀ i, C i i = 1)
@@ -228,12 +217,12 @@ private lemma comparison_apply_eq_zero {a : Fin n → ℕ} {B₁ B₂ : UpperTri
     rw [hCij, abs_lt]
     omega
 
-/-- Two upper-triangular representatives lie in the same left `SL_n(ℤ)`-coset only if their
-entry assignments agree.
+/-- The divisibility criterion for equality of entry assignments: if the comparison matrix
+`C = U(B₁) · U(B₂)⁻¹` satisfies `(a_j / a_i) ∣ C_{ij}` above the diagonal, then `B₁ = B₂`.
 
-The connecting element is `S = M₁ M₂⁻¹`; conjugating, `diag(a)⁻¹ S diag(a) = U(B₁) U(B₂)⁻¹`,
-whose `(i,j)` entry is `S_{ij} · a_j / a_i`. Integrality of `S` is therefore exactly the
-divisibility hypothesis fed to `comparison_apply_eq_zero`. -/
+This is arithmetic about a hypothesised divisibility; nothing here mentions cosets. What makes
+that divisibility hold for two representatives in the same left `SL_n(ℤ)`-coset is
+`dvd_comparison_of_upperTriGL_eq`, and `eq_of_upperTriGL_eq` is the two combined. -/
 lemma eq_of_dvd_comparison {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
     (hdvd : ∀ ⦃i j : Fin n⦄, i < j →
       ((a j / a i : ℕ) : ℤ) ∣ (unitriMat B₁ * (unitriMat B₂)⁻¹) i j) :
@@ -249,7 +238,7 @@ lemma eq_of_dvd_comparison {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
     rw [hC, Matrix.mul_apply_diag_of_isUpperTriangular (isUpperTriangular_unitriMat B₁) hup₂ i,
       unitriMat_apply_diag,
       Matrix.inv_apply_diag_of_isUpperTriangular (isUpperTriangular_unitriMat B₂)
-        (unitriMat_apply_diag B₂) i, one_mul]
+        (unitriMat_apply_diag B₂ i), one_mul]
   have hmul : C * unitriMat B₂ = unitriMat B₁ := by
     rw [hC, Matrix.mul_assoc, Matrix.nonsing_inv_mul _ (Matrix.isUnit_det_of_invertible _),
       Matrix.mul_one]
@@ -262,27 +251,27 @@ lemma eq_of_dvd_comparison {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
     · rw [hup h, Matrix.one_apply_ne h.ne']
   exact unitriMat_injective (by rw [← hmul, hC1, Matrix.one_mul])
 
-/-- The inverse of `U(B)` in `SL_n(ℤ)` is its matrix inverse: `det U(B) = 1`, so the scalar in
-`Matrix.inv_def` is `1` and both sides are the adjugate. -/
-lemma unitriSL_inv_coe {a : Fin n → ℕ} (B : UpperTriEntries n a) :
+/-- The inverse of `U(B)` in `SL_n(ℤ)` is its matrix inverse.
+
+Deliberately not `@[simp]`: `simp` already rewrites the left-hand side past this, to
+`(unitriMat B).adjugate`, through `SpecialLinearGroup.coe_inv` and `coe_unitriSL`, so the
+marking is rejected by `simpNF` as not being in normal form. The lemma is kept as the named
+bridge to the `Matrix.inv` spelling, for `rw` and for `simp only` sets that want it. -/
+lemma coe_inv_unitriSL {a : Fin n → ℕ} (B : UpperTriEntries n a) :
     (((unitriSL B)⁻¹ : SpecialLinearGroup (Fin n) ℤ) : Matrix (Fin n) (Fin n) ℤ)
       = (unitriMat B)⁻¹ := by
-  rw [SpecialLinearGroup.coe_inv, Matrix.inv_def, unitriSL_coe, det_unitriMat, Ring.inverse_one,
+  rw [SpecialLinearGroup.coe_inv, Matrix.inv_def, coe_unitriSL, det_unitriMat, Ring.inverse_one,
     one_smul]
 
-/-- Lying in the same left `SL_n(ℤ)`-coset supplies the divisibility hypothesis of
-`eq_of_dvd_comparison`; this is what makes distinctness a theorem rather than a criterion.
-
-Cancelling `U(B₂)` on the right of `diag(a) · U(B₁) = S · diag(a) · U(B₂)` gives
-`diag(a) · C = S · diag(a)` for the comparison matrix `C = U(B₁) · U(B₂)⁻¹`, whose `(i, j)` entry
-reads `a_i · C_{ij} = S_{ij} · a_j`. For `i < j` the chain condition writes `a_j` as
-`a_i · (a_j / a_i)` exactly, so cancelling `a_i > 0` leaves `C_{ij} = S_{ij} · (a_j / a_i)`.
-Integrality of `S` is
-therefore the only input: it is where the divisibility comes from. -/
+/-- Two representatives in the same left `SL_n(ℤ)`-coset have comparison matrix divisible above
+the diagonal: `(a_j / a_i) ∣ C_{ij}` for `C = U(B₁) · U(B₂)⁻¹`. This is the divisibility that
+`eq_of_dvd_comparison` takes as a hypothesis, so the two together make distinctness a theorem
+about the coset relation rather than a criterion. Only `a i ∣ a j` is needed, at the pair asked
+about. -/
 lemma dvd_comparison_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
-    (hchain : ∀ ⦃i j : Fin n⦄, i < j → a i ∣ a j) {B₁ B₂ : UpperTriEntries n a}
+    {B₁ B₂ : UpperTriEntries n a}
     {S : SpecialLinearGroup (Fin n) ℤ} (hS : upperTriGL B₁ = mapGL ℚ S * upperTriGL B₂)
-    {i j : Fin n} (hij : i < j) :
+    {i j : Fin n} (hdvd : a i ∣ a j) :
     ((a j / a i : ℕ) : ℤ) ∣ (unitriMat B₁ * (unitriMat B₂)⁻¹) i j := by
   -- Cancel `U(B₂)` on the right, in the group `GL_n(ℚ)`.
   have hGL : natDiagGL n a * mapGL ℚ (unitriSL B₁ * (unitriSL B₂)⁻¹)
@@ -300,32 +289,30 @@ lemma dvd_comparison_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
   rw [natDiagGL_coe n a ha, mapGL_coe_matrix, mapGL_coe_matrix, Matrix.diagonal_mul,
     Matrix.mul_diagonal] at hentry
   simp only [SpecialLinearGroup.map_apply_coe, RingHom.mapMatrix_apply, algebraMap_int_eq,
-    eq_intCast, Matrix.map_apply, SpecialLinearGroup.coe_mul, unitriSL_coe,
-    unitriSL_inv_coe] at hentry
+    eq_intCast, Matrix.map_apply, SpecialLinearGroup.coe_mul, coe_unitriSL,
+    coe_inv_unitriSL] at hentry
   have hZ : (a i : ℤ) * (unitriMat B₁ * (unitriMat B₂)⁻¹) i j
       = (S : Matrix (Fin n) (Fin n) ℤ) i j * (a j : ℤ) := by exact_mod_cast hentry
   -- `a j = a i * (a j / a i)` exactly, so `a i` cancels.
-  rw [← Nat.mul_div_cancel' (hchain hij), Nat.cast_mul, ← mul_assoc,
+  rw [← Nat.mul_div_cancel' hdvd, Nat.cast_mul, ← mul_assoc,
     mul_comm ((S : Matrix _ _ ℤ) i j), mul_assoc] at hZ
   exact Dvd.intro_left _ (mul_left_cancel₀ (by exact_mod_cast (ha i).ne') hZ).symm
 
-/-- The upper-triangular representatives lie in pairwise **distinct** left `SL_n(ℤ)`-cosets: if
-two of them differ by a left factor in `SL_n(ℤ)`, their entry assignments already agree.
-
-Combining `dvd_comparison_of_upperTriGL_eq`, which turns the coset relation into the divisibility
-`(a_j / a_i) ∣ C_{ij}`, with `eq_of_dvd_comparison`, which turns that divisibility into `C = 1`.
-So the double coset `SL_n(ℤ) · diag(a) · SL_n(ℤ)` contains at least `∏_{i < j} (a_j / a_i)`
-distinct left cosets. -/
-theorem eq_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
-    (hchain : ∀ ⦃i j : Fin n⦄, i < j → a i ∣ a j) {B₁ B₂ : UpperTriEntries n a}
+/-- The upper-triangular representatives of a positive divisibility chain lie in pairwise
+**distinct** left `SL_n(ℤ)`-cosets: if two of them differ by a left factor in `SL_n(ℤ)`, their
+entry assignments already agree. So the double coset `SL_n(ℤ) · diag(a) · SL_n(ℤ)` meets at
+least `∏_{i < j} (a_j / a_i)` distinct left cosets. -/
+theorem eq_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (hchain : IsDvdChain a)
+    {B₁ B₂ : UpperTriEntries n a}
     {S : SpecialLinearGroup (Fin n) ℤ} (hS : upperTriGL B₁ = mapGL ℚ S * upperTriGL B₂) :
     B₁ = B₂ :=
-  eq_of_dvd_comparison fun _ _ hij ↦ dvd_comparison_of_upperTriGL_eq ha hchain hS hij
+  eq_of_dvd_comparison fun _ _ hij ↦
+    dvd_comparison_of_upperTriGL_eq ha hS (isDvdChain_iff.mp hchain hij.le)
 
 /-- The same statement phrased with the subgroup `SLnZ n` of `GL_n(ℚ)`: distinct entry
 assignments give representatives in distinct left cosets of `SL_n(ℤ)`. -/
-theorem eq_of_mul_inv_mem_SLnZ {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
-    (hchain : ∀ ⦃i j : Fin n⦄, i < j → a i ∣ a j) {B₁ B₂ : UpperTriEntries n a}
+theorem eq_of_mul_inv_mem_SLnZ {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (hchain : IsDvdChain a)
+    {B₁ B₂ : UpperTriEntries n a}
     (h : upperTriGL B₁ * (upperTriGL B₂)⁻¹ ∈ SLnZ n) : B₁ = B₂ := by
   obtain ⟨S, hSeq⟩ := (mem_SLnZ_iff n).mp h
   exact eq_of_upperTriGL_eq ha hchain (by rw [hSeq]; group)

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.Block
+public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
+
+/-!
+# Upper-triangular representatives for a diagonal double coset
+
+For a tuple `a` of positive naturals, this file exhibits a family of elements of the double
+coset `SL_n(ℤ) · diag(a) · SL_n(ℤ)`, indexed by the bounded entry assignments
+`B_{ij} ∈ {0, …, a_j / a_i - 1}` for `i < j`, and shows the family is injective.
+
+The representative attached to `B` is *defined* as `diag(a) · U(B)`, where `U(B)` is the
+unipotent upper-triangular integral matrix with off-diagonal entries `B`. Two things follow
+from that shape, and are the reason for choosing it over an entrywise definition: `U(B)` is
+upper triangular with ones on the diagonal, so `det U(B) = 1` and `U(B) ∈ SL_n(ℤ)`; and hence
+the representative lies in the double coset with no further argument.
+`upperTriGL_apply_lt` and `upperTriGL_apply_diag` recover the entrywise description
+`M_{ij} = a_i · B_{ij}`, which is what the injectivity argument uses.
+
+## Main definitions
+
+* `UpperTriRep` — the bounded entry assignments `B_{ij} ∈ Fin (a j / a i)` for `i < j`.
+* `unitriMat`, `unitriSL` — the unipotent upper-triangular matrix `U(B)`, and its packaging as
+  an element of `SL_n(ℤ)`.
+* `upperTriGL` — the representative `diag(a) · U(B)` in `GL_n(ℚ)`.
+
+## Main results
+
+* `upperTriGL_mem_doubleCoset` — every representative lies in `SL_n(ℤ) · diag(a) · SL_n(ℤ)`.
+* `unitriMat_injective`, `upperTriGL_injective` — distinct entry assignments give distinct
+  matrices, hence distinct representatives.
+
+## References
+
+The general-`n` statement is Shimura, *Introduction to the Arithmetic Theory of Automorphic
+Functions* (1971), Exercise 3.26(A), p. 65: for every `α ∈ Δ` one can choose representatives
+`α_j` of `ΓαΓ = ⋃_j Γα_j` with `L_ν α_j ⊆ L_ν` for the standard flag `L_ν = ∑_{i ≤ ν} ℤ e_i`,
+i.e. upper-triangular ones. Shimura leaves it as an exercise and works the `n = 2` case
+explicitly in Prop. 3.33 (p. 70) and Prop. 3.36 (p. 72).
+
+The definitions follow the AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB)
+file `LeanModularForms/HeckeRIngs/GLn/CosetDecomposition.lean` (Chris Birkbeck), whose module
+docstring cites "Shimura, Proposition 3.22" — that number is in fact Lemma 3.22, an Euler
+product identity, and is unrelated. The results here are new: the AINTLIB file states the
+definitions and the determinant, and advertises the coset results in its docstring without
+proving them.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup DoubleCoset
+
+namespace HeckeRing.GLn
+
+variable (n : ℕ)
+
+/-- Bounded entry assignments for upper-triangular representatives: an integer
+`B_{ij} ∈ {0, …, a_j / a_i - 1}` for each pair `i < j`.
+
+Stated for an arbitrary tuple `a`, with no chain or positivity hypothesis: those are needed by
+the results, not to name the index type, and `Fin (a j / a i)` is already empty exactly when
+`a j < a i`. -/
+abbrev UpperTriRep (a : Fin n → ℕ) : Type :=
+  (p : {ij : Fin n × Fin n // ij.1 < ij.2}) → Fin (a p.val.2 / a p.val.1)
+
+variable {n}
+
+/-- The unipotent upper-triangular integral matrix `U(B)`: ones on the diagonal, `B_{ij}`
+above it, zeros below. -/
+def unitriMat {a : Fin n → ℕ} (B : UpperTriRep n a) : Matrix (Fin n) (Fin n) ℤ :=
+  fun i j ↦ if h : i < j then (B ⟨(i, j), h⟩ : ℕ) else if i = j then 1 else 0
+
+@[simp] lemma unitriMat_apply_lt {a : Fin n → ℕ} (B : UpperTriRep n a) {i j : Fin n}
+    (h : i < j) : unitriMat B i j = (B ⟨(i, j), h⟩ : ℕ) := by
+  simp [unitriMat, h]
+
+@[simp] lemma unitriMat_apply_diag {a : Fin n → ℕ} (B : UpperTriRep n a) (i : Fin n) :
+    unitriMat B i i = 1 := by
+  simp [unitriMat]
+
+lemma unitriMat_apply_of_lt {a : Fin n → ℕ} (B : UpperTriRep n a) {i j : Fin n} (h : j < i) :
+    unitriMat B i j = 0 := by
+  simp [unitriMat, h.asymm, h.ne']
+
+lemma isUpperTriangular_unitriMat {a : Fin n → ℕ} (B : UpperTriRep n a) :
+    Matrix.IsUpperTriangular (unitriMat B) :=
+  fun _ _ h ↦ unitriMat_apply_of_lt B h
+
+/-- `U(B)` is upper triangular with ones on the diagonal, so its determinant is `1`. -/
+@[simp] lemma det_unitriMat {a : Fin n → ℕ} (B : UpperTriRep n a) : (unitriMat B).det = 1 := by
+  rw [Matrix.det_of_isUpperTriangular (isUpperTriangular_unitriMat B)]
+  simp
+
+/-- `U(B)` packaged as an element of `SL_n(ℤ)`. -/
+def unitriSL {a : Fin n → ℕ} (B : UpperTriRep n a) : SpecialLinearGroup (Fin n) ℤ :=
+  ⟨unitriMat B, det_unitriMat B⟩
+
+@[simp] lemma unitriSL_coe {a : Fin n → ℕ} (B : UpperTriRep n a) :
+    (unitriSL B : Matrix (Fin n) (Fin n) ℤ) = unitriMat B := (rfl)
+
+/-- The upper-triangular representative `diag(a) · U(B)` attached to a bounded entry
+assignment. -/
+noncomputable def upperTriGL {a : Fin n → ℕ} (B : UpperTriRep n a) : GL (Fin n) ℚ :=
+  natDiagGL n a * (mapGL ℚ (unitriSL B))
+
+/-- Each upper-triangular representative lies in the double coset of `diag(a)`.
+
+Immediate from the definition: `U(B) ∈ SL_n(ℤ)`, so `diag(a) · U(B)` is already of the form
+`h₁ · diag(a) · h₂` with `h₁ = 1`. -/
+lemma upperTriGL_mem_doubleCoset {a : Fin n → ℕ} (B : UpperTriRep n a) :
+    upperTriGL B ∈ doubleCoset (natDiagGL n a) (SLnZ n) (SLnZ n) :=
+  mem_doubleCoset.mpr ⟨1, one_mem _, mapGL ℚ (unitriSL B), coe_mem_SLnZ n _,
+    by rw [upperTriGL, one_mul]⟩
+
+/-- The entrywise description of the representative above the diagonal: `M_{ij} = a_i · B_{ij}`.
+-/
+lemma upperTriGL_apply_lt {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (B : UpperTriRep n a)
+    {i j : Fin n} (h : i < j) :
+    (upperTriGL B : Matrix (Fin n) (Fin n) ℚ) i j = (a i : ℚ) * (B ⟨(i, j), h⟩ : ℕ) := by
+  rw [upperTriGL]
+  simp [natDiagGL_coe n a ha, Matrix.diagonal_mul, unitriMat_apply_lt B h]
+
+/-- The entrywise description on the diagonal: `M_{ii} = a_i`. -/
+lemma upperTriGL_apply_diag {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (B : UpperTriRep n a)
+    (i : Fin n) : (upperTriGL B : Matrix (Fin n) (Fin n) ℚ) i i = (a i : ℚ) := by
+  rw [upperTriGL]
+  simp [natDiagGL_coe n a ha, Matrix.diagonal_mul]
+
+/-- Distinct entry assignments give distinct unipotent matrices. -/
+lemma unitriMat_injective {a : Fin n → ℕ} : Function.Injective (unitriMat (a := a)) := by
+  intro B₁ B₂ h
+  funext p
+  obtain ⟨⟨i, j⟩, hij⟩ := p
+  have hE := congrFun (congrFun h i) j
+  rw [unitriMat_apply_lt B₁ hij, unitriMat_apply_lt B₂ hij] at hE
+  exact Fin.ext (by exact_mod_cast hE)
+
+/-- Distinct entry assignments give distinct representatives: the entries `a_i · B_{ij}`
+determine `B`, because every `a_i` is nonzero. -/
+lemma upperTriGL_injective {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) :
+    Function.Injective (upperTriGL (a := a)) := by
+  intro B₁ B₂ h
+  refine unitriMat_injective (funext fun i ↦ funext fun j ↦ ?_)
+  rcases lt_trichotomy i j with hij | rfl | hij
+  · have hE : (upperTriGL B₁ : Matrix (Fin n) (Fin n) ℚ) i j =
+        (upperTriGL B₂ : Matrix (Fin n) (Fin n) ℚ) i j := by rw [h]
+    rw [upperTriGL_apply_lt ha B₁ hij, upperTriGL_apply_lt ha B₂ hij] at hE
+    have hai : (a i : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (ha i).ne'
+    rw [unitriMat_apply_lt B₁ hij, unitriMat_apply_lt B₂ hij]
+    exact_mod_cast mul_left_cancel₀ hai hE
+  · simp
+  · rw [unitriMat_apply_of_lt B₁ hij, unitriMat_apply_of_lt B₂ hij]
+
+end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -5,7 +5,6 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.LinearAlgebra.Matrix.Block
 public import TauCeti.LinearAlgebra.Matrix.Triangular
 public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
 
@@ -38,10 +37,16 @@ does not, since `upperTriGL` is visibly a composition of injective maps.
 * `upperTriGL_mem_doubleCoset` — every representative lies in `SL_n(ℤ) · diag(a) · SL_n(ℤ)`.
 * `unitriMat_injective`, `upperTriGL_injective` — distinct entry assignments give distinct
   matrices, hence distinct representatives.
-* `upperTriGL_eq_of_dvd` — the representatives lie in *distinct* left `SL_n(ℤ)`-cosets: two of
-  them are left-equivalent only when their entry assignments agree. Left equivalence says the
-  comparison matrix `C = U(B₁) · U(B₂)⁻¹` satisfies `(a_j / a_i) ∣ C_{ij}`, and the entry bound
-  then forces `C = 1` by induction on `j - i`.
+* `eq_of_upperTriGL_eq`, `eq_of_mul_inv_mem_SLnZ` — the representatives lie in *distinct* left
+  `SL_n(ℤ)`-cosets: two of them are left-equivalent only when their entry assignments already
+  agree. So for a chain `a_i ∣ a_j` of positive naturals the double coset meets at least
+  `∏_{i < j} (a_j / a_i)` distinct left cosets.
+
+The two steps behind that conclusion are also stated separately, since each is reusable:
+`dvd_comparison_of_upperTriGL_eq` turns left equivalence into `(a_j / a_i) ∣ C_{ij}` for the
+comparison matrix `C = U(B₁) · U(B₂)⁻¹`, by conjugating the connecting element back through
+`diag(a)`; and `eq_of_dvd_comparison` turns that divisibility into `C = 1`, because the entry
+bound `B_{ij} < a_j / a_i` leaves no room for a nonzero multiple, by induction on `j - i`.
 
 ## References
 
@@ -116,6 +121,11 @@ assignment. -/
 noncomputable def upperTriGL {a : Fin n → ℕ} (B : UpperTriEntries n a) : GL (Fin n) ℚ :=
   natDiagGL n a * (mapGL ℚ (unitriSL B))
 
+/-- The defining factorisation of the representative, as a characteristic lemma: consumers can
+work from `diag(a) · U(B)` without unfolding `upperTriGL`. -/
+lemma upperTriGL_def {a : Fin n → ℕ} (B : UpperTriEntries n a) :
+    upperTriGL B = natDiagGL n a * (mapGL ℚ (unitriSL B)) := (rfl)
+
 /-- Each upper-triangular representative lies in the double coset of `diag(a)`.
 
 Immediate from the definition: `U(B) ∈ SL_n(ℤ)`, so `diag(a) · U(B)` is already of the form
@@ -174,22 +184,6 @@ Two representatives lie in the same left `SL_n(ℤ)`-coset exactly when the conj
 `(a_j / a_i) ∣ C_{ij}` for the comparison matrix `C = U(B₁) · U(B₂)⁻¹`. The entry bound
 `B_{ij} < a_j / a_i` then forces `C = 1`. -/
 
-section Triangular
-
-variable {R : Type*} [CommRing R] {M : Matrix (Fin n) (Fin n) R}
-
-/-- The inverse of an upper-triangular matrix with `1` on the diagonal again has `1` on the
-diagonal: `M⁻¹ * M = 1` read on the diagonal, through
-`Matrix.mul_apply_diag_of_isUpperTriangular`. -/
-lemma inv_apply_diag_of_isUpperTriangular [Invertible M] (hM : Matrix.IsUpperTriangular M)
-    (hdiag : ∀ i, M i i = 1) (i : Fin n) : M⁻¹ i i = 1 := by
-  have hinv : Matrix.IsUpperTriangular M⁻¹ := Matrix.blockTriangular_inv_of_blockTriangular hM
-  have h := congrFun (congrFun (Matrix.nonsing_inv_mul M (Matrix.isUnit_det_of_invertible M)) i) i
-  rwa [Matrix.mul_apply_diag_of_isUpperTriangular hinv hM i, hdiag i, mul_one,
-    Matrix.one_apply_eq] at h
-
-end Triangular
-
 /-- The comparison matrix `C` between two representatives is the identity above the diagonal.
 
 Strong induction on `j - i`. Reading `C · U(B₂) = U(B₁)` at `(i, j)`, every term of the sum
@@ -240,7 +234,7 @@ entry assignments agree.
 The connecting element is `S = M₁ M₂⁻¹`; conjugating, `diag(a)⁻¹ S diag(a) = U(B₁) U(B₂)⁻¹`,
 whose `(i,j)` entry is `S_{ij} · a_j / a_i`. Integrality of `S` is therefore exactly the
 divisibility hypothesis fed to `comparison_apply_eq_zero`. -/
-lemma upperTriGL_eq_of_dvd {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
+lemma eq_of_dvd_comparison {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
     (hdvd : ∀ ⦃i j : Fin n⦄, i < j →
       ((a j / a i : ℕ) : ℤ) ∣ (unitriMat B₁ * (unitriMat B₂)⁻¹) i j) :
     B₁ = B₂ := by
@@ -254,7 +248,7 @@ lemma upperTriGL_eq_of_dvd {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
   have hdiag : ∀ i, C i i = 1 := fun i ↦ by
     rw [hC, Matrix.mul_apply_diag_of_isUpperTriangular (isUpperTriangular_unitriMat B₁) hup₂ i,
       unitriMat_apply_diag,
-      inv_apply_diag_of_isUpperTriangular (isUpperTriangular_unitriMat B₂)
+      Matrix.inv_apply_diag_of_isUpperTriangular (isUpperTriangular_unitriMat B₂)
         (unitriMat_apply_diag B₂) i, one_mul]
   have hmul : C * unitriMat B₂ = unitriMat B₁ := by
     rw [hC, Matrix.mul_assoc, Matrix.nonsing_inv_mul _ (Matrix.isUnit_det_of_invertible _),
@@ -267,5 +261,73 @@ lemma upperTriGL_eq_of_dvd {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
     · rw [hdiag, Matrix.one_apply_eq]
     · rw [hup h, Matrix.one_apply_ne h.ne']
   exact unitriMat_injective (by rw [← hmul, hC1, Matrix.one_mul])
+
+/-- The inverse of `U(B)` in `SL_n(ℤ)` is its matrix inverse: `det U(B) = 1`, so the scalar in
+`Matrix.inv_def` is `1` and both sides are the adjugate. -/
+lemma unitriSL_inv_coe {a : Fin n → ℕ} (B : UpperTriEntries n a) :
+    (((unitriSL B)⁻¹ : SpecialLinearGroup (Fin n) ℤ) : Matrix (Fin n) (Fin n) ℤ)
+      = (unitriMat B)⁻¹ := by
+  rw [SpecialLinearGroup.coe_inv, Matrix.inv_def, unitriSL_coe, det_unitriMat, Ring.inverse_one,
+    one_smul]
+
+/-- Lying in the same left `SL_n(ℤ)`-coset supplies the divisibility hypothesis of
+`eq_of_dvd_comparison`; this is what makes distinctness a theorem rather than a criterion.
+
+Cancelling `U(B₂)` on the right of `diag(a) · U(B₁) = S · diag(a) · U(B₂)` gives
+`diag(a) · C = S · diag(a)` for the comparison matrix `C = U(B₁) · U(B₂)⁻¹`, whose `(i, j)` entry
+reads `a_i · C_{ij} = S_{ij} · a_j`. For `i < j` the chain condition writes `a_j` as
+`a_i · (a_j / a_i)` exactly, so cancelling `a_i > 0` leaves `C_{ij} = S_{ij} · (a_j / a_i)`.
+Integrality of `S` is
+therefore the only input: it is where the divisibility comes from. -/
+lemma dvd_comparison_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
+    (hchain : ∀ ⦃i j : Fin n⦄, i < j → a i ∣ a j) {B₁ B₂ : UpperTriEntries n a}
+    {S : SpecialLinearGroup (Fin n) ℤ} (hS : upperTriGL B₁ = mapGL ℚ S * upperTriGL B₂)
+    {i j : Fin n} (hij : i < j) :
+    ((a j / a i : ℕ) : ℤ) ∣ (unitriMat B₁ * (unitriMat B₂)⁻¹) i j := by
+  -- Cancel `U(B₂)` on the right, in the group `GL_n(ℚ)`.
+  have hGL : natDiagGL n a * mapGL ℚ (unitriSL B₁ * (unitriSL B₂)⁻¹)
+      = mapGL ℚ S * natDiagGL n a := by
+    rw [upperTriGL, upperTriGL] at hS
+    rw [map_mul, map_inv, ← mul_assoc, hS]
+    group
+  -- Read the `(i, j)` entry of both sides, then descend from `ℚ` to `ℤ`.
+  have hmat : (natDiagGL n a : Matrix (Fin n) (Fin n) ℚ) *
+        (mapGL ℚ (unitriSL B₁ * (unitriSL B₂)⁻¹) : Matrix (Fin n) (Fin n) ℚ)
+      = (mapGL ℚ S : Matrix (Fin n) (Fin n) ℚ) *
+        (natDiagGL n a : Matrix (Fin n) (Fin n) ℚ) := by
+    rw [← Units.val_mul, ← Units.val_mul, hGL]
+  have hentry := congrFun (congrFun hmat i) j
+  rw [natDiagGL_coe n a ha, mapGL_coe_matrix, mapGL_coe_matrix, Matrix.diagonal_mul,
+    Matrix.mul_diagonal] at hentry
+  simp only [SpecialLinearGroup.map_apply_coe, RingHom.mapMatrix_apply, algebraMap_int_eq,
+    eq_intCast, Matrix.map_apply, SpecialLinearGroup.coe_mul, unitriSL_coe,
+    unitriSL_inv_coe] at hentry
+  have hZ : (a i : ℤ) * (unitriMat B₁ * (unitriMat B₂)⁻¹) i j
+      = (S : Matrix (Fin n) (Fin n) ℤ) i j * (a j : ℤ) := by exact_mod_cast hentry
+  -- `a j = a i * (a j / a i)` exactly, so `a i` cancels.
+  rw [← Nat.mul_div_cancel' (hchain hij), Nat.cast_mul, ← mul_assoc,
+    mul_comm ((S : Matrix _ _ ℤ) i j), mul_assoc] at hZ
+  exact Dvd.intro_left _ (mul_left_cancel₀ (by exact_mod_cast (ha i).ne') hZ).symm
+
+/-- The upper-triangular representatives lie in pairwise **distinct** left `SL_n(ℤ)`-cosets: if
+two of them differ by a left factor in `SL_n(ℤ)`, their entry assignments already agree.
+
+Combining `dvd_comparison_of_upperTriGL_eq`, which turns the coset relation into the divisibility
+`(a_j / a_i) ∣ C_{ij}`, with `eq_of_dvd_comparison`, which turns that divisibility into `C = 1`.
+So the double coset `SL_n(ℤ) · diag(a) · SL_n(ℤ)` contains at least `∏_{i < j} (a_j / a_i)`
+distinct left cosets. -/
+theorem eq_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
+    (hchain : ∀ ⦃i j : Fin n⦄, i < j → a i ∣ a j) {B₁ B₂ : UpperTriEntries n a}
+    {S : SpecialLinearGroup (Fin n) ℤ} (hS : upperTriGL B₁ = mapGL ℚ S * upperTriGL B₂) :
+    B₁ = B₂ :=
+  eq_of_dvd_comparison fun _ _ hij ↦ dvd_comparison_of_upperTriGL_eq ha hchain hS hij
+
+/-- The same statement phrased with the subgroup `SLnZ n` of `GL_n(ℚ)`: distinct entry
+assignments give representatives in distinct left cosets of `SL_n(ℤ)`. -/
+theorem eq_of_mul_inv_mem_SLnZ {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
+    (hchain : ∀ ⦃i j : Fin n⦄, i < j → a i ∣ a j) {B₁ B₂ : UpperTriEntries n a}
+    (h : upperTriGL B₁ * (upperTriGL B₂)⁻¹ ∈ SLnZ n) : B₁ = B₂ := by
+  obtain ⟨S, hSeq⟩ := (mem_SLnZ_iff n).mp h
+  exact eq_of_upperTriGL_eq ha hchain (by rw [hSeq]; group)
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -21,12 +21,13 @@ unipotent upper-triangular integral matrix with off-diagonal entries `B`. Two th
 from that shape, and are the reason for choosing it over an entrywise definition: `U(B)` is
 upper triangular with ones on the diagonal, so `det U(B) = 1` and `U(B) ∈ SL_n(ℤ)`; and hence
 the representative lies in the double coset with no further argument.
-`upperTriGL_apply_lt` and `upperTriGL_apply_diag` recover the entrywise description
-`M_{ij} = a_i · B_{ij}`, which is what the injectivity argument uses.
+`upperTriGL_apply_lt`, `upperTriGL_apply_diag` and `upperTriGL_apply_eq_zero_of_lt` recover the
+entrywise description `M_{ij} = a_i · B_{ij}` for consumers that need it; injectivity itself
+does not, since `upperTriGL` is visibly a composition of injective maps.
 
 ## Main definitions
 
-* `UpperTriRep` — the bounded entry assignments `B_{ij} ∈ Fin (a j / a i)` for `i < j`.
+* `UpperTriEntries` — the bounded entry assignments `B_{ij} ∈ Fin (a j / a i)` for `i < j`.
 * `unitriMat`, `unitriSL` — the unipotent upper-triangular matrix `U(B)`, and its packaging as
   an element of `SL_n(ℤ)`.
 * `upperTriGL` — the representative `diag(a) · U(B)` in `GL_n(ℚ)`.
@@ -69,73 +70,81 @@ variable (n : ℕ)
 `B_{ij} ∈ {0, …, a_j / a_i - 1}` for each pair `i < j`.
 
 Stated for an arbitrary tuple `a`, with no chain or positivity hypothesis: those are needed by
-the results, not to name the index type, and `Fin (a j / a i)` is already empty exactly when
-`a j < a i`. -/
-abbrev UpperTriRep (a : Fin n → ℕ) : Type :=
+the results, not to name the index type. The component `Fin (a j / a i)` is empty exactly when
+`a j / a i = 0`, which for positive `a i` means `a j < a i`. -/
+abbrev UpperTriEntries (a : Fin n → ℕ) : Type :=
   (p : {ij : Fin n × Fin n // ij.1 < ij.2}) → Fin (a p.val.2 / a p.val.1)
 
 variable {n}
 
 /-- The unipotent upper-triangular integral matrix `U(B)`: ones on the diagonal, `B_{ij}`
 above it, zeros below. -/
-def unitriMat {a : Fin n → ℕ} (B : UpperTriRep n a) : Matrix (Fin n) (Fin n) ℤ :=
+def unitriMat {a : Fin n → ℕ} (B : UpperTriEntries n a) : Matrix (Fin n) (Fin n) ℤ :=
   fun i j ↦ if h : i < j then (B ⟨(i, j), h⟩ : ℕ) else if i = j then 1 else 0
 
-@[simp] lemma unitriMat_apply_lt {a : Fin n → ℕ} (B : UpperTriRep n a) {i j : Fin n}
+@[simp] lemma unitriMat_apply_lt {a : Fin n → ℕ} (B : UpperTriEntries n a) {i j : Fin n}
     (h : i < j) : unitriMat B i j = (B ⟨(i, j), h⟩ : ℕ) := by
   simp [unitriMat, h]
 
-@[simp] lemma unitriMat_apply_diag {a : Fin n → ℕ} (B : UpperTriRep n a) (i : Fin n) :
+@[simp] lemma unitriMat_apply_diag {a : Fin n → ℕ} (B : UpperTriEntries n a) (i : Fin n) :
     unitriMat B i i = 1 := by
   simp [unitriMat]
 
-lemma unitriMat_apply_of_lt {a : Fin n → ℕ} (B : UpperTriRep n a) {i j : Fin n} (h : j < i) :
-    unitriMat B i j = 0 := by
+@[simp] lemma unitriMat_apply_eq_zero_of_lt {a : Fin n → ℕ} (B : UpperTriEntries n a)
+    {i j : Fin n} (h : j < i) : unitriMat B i j = 0 := by
   simp [unitriMat, h.asymm, h.ne']
 
-lemma isUpperTriangular_unitriMat {a : Fin n → ℕ} (B : UpperTriRep n a) :
+lemma isUpperTriangular_unitriMat {a : Fin n → ℕ} (B : UpperTriEntries n a) :
     Matrix.IsUpperTriangular (unitriMat B) :=
-  fun _ _ h ↦ unitriMat_apply_of_lt B h
+  fun _ _ h ↦ unitriMat_apply_eq_zero_of_lt B h
 
 /-- `U(B)` is upper triangular with ones on the diagonal, so its determinant is `1`. -/
-@[simp] lemma det_unitriMat {a : Fin n → ℕ} (B : UpperTriRep n a) : (unitriMat B).det = 1 := by
+@[simp] lemma det_unitriMat {a : Fin n → ℕ} (B : UpperTriEntries n a) : (unitriMat B).det = 1 := by
   rw [Matrix.det_of_isUpperTriangular (isUpperTriangular_unitriMat B)]
   simp
 
 /-- `U(B)` packaged as an element of `SL_n(ℤ)`. -/
-def unitriSL {a : Fin n → ℕ} (B : UpperTriRep n a) : SpecialLinearGroup (Fin n) ℤ :=
+def unitriSL {a : Fin n → ℕ} (B : UpperTriEntries n a) : SpecialLinearGroup (Fin n) ℤ :=
   ⟨unitriMat B, det_unitriMat B⟩
 
-@[simp] lemma unitriSL_coe {a : Fin n → ℕ} (B : UpperTriRep n a) :
+@[simp] lemma unitriSL_coe {a : Fin n → ℕ} (B : UpperTriEntries n a) :
     (unitriSL B : Matrix (Fin n) (Fin n) ℤ) = unitriMat B := (rfl)
 
 /-- The upper-triangular representative `diag(a) · U(B)` attached to a bounded entry
 assignment. -/
-noncomputable def upperTriGL {a : Fin n → ℕ} (B : UpperTriRep n a) : GL (Fin n) ℚ :=
+noncomputable def upperTriGL {a : Fin n → ℕ} (B : UpperTriEntries n a) : GL (Fin n) ℚ :=
   natDiagGL n a * (mapGL ℚ (unitriSL B))
 
 /-- Each upper-triangular representative lies in the double coset of `diag(a)`.
 
 Immediate from the definition: `U(B) ∈ SL_n(ℤ)`, so `diag(a) · U(B)` is already of the form
 `h₁ · diag(a) · h₂` with `h₁ = 1`. -/
-lemma upperTriGL_mem_doubleCoset {a : Fin n → ℕ} (B : UpperTriRep n a) :
+lemma upperTriGL_mem_doubleCoset {a : Fin n → ℕ} (B : UpperTriEntries n a) :
     upperTriGL B ∈ doubleCoset (natDiagGL n a) (SLnZ n) (SLnZ n) :=
   mem_doubleCoset.mpr ⟨1, one_mem _, mapGL ℚ (unitriSL B), coe_mem_SLnZ n _,
     by rw [upperTriGL, one_mul]⟩
 
 /-- The entrywise description of the representative above the diagonal: `M_{ij} = a_i · B_{ij}`.
 -/
-lemma upperTriGL_apply_lt {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (B : UpperTriRep n a)
+@[simp] lemma upperTriGL_apply_lt {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (B : UpperTriEntries n a)
     {i j : Fin n} (h : i < j) :
     (upperTriGL B : Matrix (Fin n) (Fin n) ℚ) i j = (a i : ℚ) * (B ⟨(i, j), h⟩ : ℕ) := by
   rw [upperTriGL]
   simp [natDiagGL_coe n a ha, Matrix.diagonal_mul, unitriMat_apply_lt B h]
 
 /-- The entrywise description on the diagonal: `M_{ii} = a_i`. -/
-lemma upperTriGL_apply_diag {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (B : UpperTriRep n a)
-    (i : Fin n) : (upperTriGL B : Matrix (Fin n) (Fin n) ℚ) i i = (a i : ℚ) := by
+@[simp] lemma upperTriGL_apply_diag {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
+    (B : UpperTriEntries n a) (i : Fin n) :
+    (upperTriGL B : Matrix (Fin n) (Fin n) ℚ) i i = (a i : ℚ) := by
   rw [upperTriGL]
   simp [natDiagGL_coe n a ha, Matrix.diagonal_mul]
+
+/-- The representative is upper triangular: entries below the diagonal vanish. -/
+@[simp] lemma upperTriGL_apply_eq_zero_of_lt {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
+    (B : UpperTriEntries n a) {i j : Fin n} (h : j < i) :
+    (upperTriGL B : Matrix (Fin n) (Fin n) ℚ) i j = 0 := by
+  rw [upperTriGL]
+  simp [natDiagGL_coe n a ha, Matrix.diagonal_mul, unitriMat_apply_eq_zero_of_lt B h]
 
 /-- Distinct entry assignments give distinct unipotent matrices. -/
 lemma unitriMat_injective {a : Fin n → ℕ} : Function.Injective (unitriMat (a := a)) := by
@@ -146,21 +155,16 @@ lemma unitriMat_injective {a : Fin n → ℕ} : Function.Injective (unitriMat (a
   rw [unitriMat_apply_lt B₁ hij, unitriMat_apply_lt B₂ hij] at hE
   exact Fin.ext (by exact_mod_cast hE)
 
-/-- Distinct entry assignments give distinct representatives: the entries `a_i · B_{ij}`
-determine `B`, because every `a_i` is nonzero. -/
-lemma upperTriGL_injective {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) :
-    Function.Injective (upperTriGL (a := a)) := by
+/-- Distinct entry assignments give distinct representatives.
+
+`upperTriGL` is a composition of injective maps — left multiplication by the fixed unit
+`diag(a)`, then `mapGL ℚ`, then `unitriMat` — so no positivity hypothesis is needed: even at a
+tuple where `natDiagGL` takes its junk value `1`, left multiplication is still injective. -/
+lemma upperTriGL_injective {a : Fin n → ℕ} : Function.Injective (upperTriGL (a := a)) := by
   intro B₁ B₂ h
-  refine unitriMat_injective (funext fun i ↦ funext fun j ↦ ?_)
-  rcases lt_trichotomy i j with hij | rfl | hij
-  · have hE : (upperTriGL B₁ : Matrix (Fin n) (Fin n) ℚ) i j =
-        (upperTriGL B₂ : Matrix (Fin n) (Fin n) ℚ) i j := by rw [h]
-    rw [upperTriGL_apply_lt ha B₁ hij, upperTriGL_apply_lt ha B₂ hij] at hE
-    have hai : (a i : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (ha i).ne'
-    rw [unitriMat_apply_lt B₁ hij, unitriMat_apply_lt B₂ hij]
-    exact_mod_cast mul_left_cancel₀ hai hE
-  · simp
-  · rw [unitriMat_apply_of_lt B₁ hij, unitriMat_apply_of_lt B₂ hij]
+  rw [upperTriGL, upperTriGL] at h
+  have hSL := mapGL_injective (mul_left_cancel h)
+  exact unitriMat_injective (by rw [← unitriSL_coe, ← unitriSL_coe, hSL])
 
 /-! ## Distinctness of the left cosets
 
@@ -201,7 +205,7 @@ except `k = i` and `k = j` drops: below `i` because `C` is upper triangular, str
 because the inductive hypothesis has already killed those entries, and above `j` because
 `U(B₂)` is upper triangular. What is left is `(B₂)_{ij} + C_{ij} = (B₁)_{ij}`, so `C_{ij}` is a
 difference of two entries each below `a_j / a_i`; being divisible by `a_j / a_i` it vanishes. -/
-private lemma comparison_apply_eq_zero {a : Fin n → ℕ} {B₁ B₂ : UpperTriRep n a}
+private lemma comparison_apply_eq_zero {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
     {C : Matrix (Fin n) (Fin n) ℤ} (hmul : C * unitriMat B₂ = unitriMat B₁)
     (hup : Matrix.IsUpperTriangular C) (hdiag : ∀ i, C i i = 1)
     (hdvd : ∀ ⦃i j : Fin n⦄, i < j → ((a j / a i : ℕ) : ℤ) ∣ C i j) :
@@ -224,7 +228,7 @@ private lemma comparison_apply_eq_zero {a : Fin n → ℕ} {B₁ B₂ : UpperTri
       · rcases lt_trichotomy k j with hkj | rfl | hjk
         · rw [ih ((k : ℕ) - (i : ℕ)) (by omega) i k rfl hik, zero_mul]
         · exact absurd rfl hk.2
-        · rw [unitriMat_apply_of_lt B₂ hjk, mul_zero]
+        · rw [unitriMat_apply_eq_zero_of_lt B₂ hjk, mul_zero]
     have hkey := congrFun (congrFun hmul i) j
     rw [Matrix.mul_apply, ← Finset.sum_subset (Finset.subset_univ ({i, j} : Finset (Fin n)))
       hvanish, Finset.sum_pair hne, hdiag i, one_mul, unitriMat_apply_diag, mul_one,
@@ -244,7 +248,7 @@ entry assignments agree.
 The connecting element is `S = M₁ M₂⁻¹`; conjugating, `diag(a)⁻¹ S diag(a) = U(B₁) U(B₂)⁻¹`,
 whose `(i,j)` entry is `S_{ij} · a_j / a_i`. Integrality of `S` is therefore exactly the
 divisibility hypothesis fed to `comparison_apply_eq_zero`. -/
-lemma upperTriGL_eq_of_dvd {a : Fin n → ℕ} {B₁ B₂ : UpperTriRep n a}
+lemma upperTriGL_eq_of_dvd {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
     (hdvd : ∀ ⦃i j : Fin n⦄, i < j →
       ((a j / a i : ℕ) : ℤ) ∣ (unitriMat B₁ * (unitriMat B₂)⁻¹) i j) :
     B₁ = B₂ := by

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.LinearAlgebra.Matrix.Block
+public import TauCeti.LinearAlgebra.Matrix.Triangular
 public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
 
 /-!
@@ -175,25 +176,16 @@ Two representatives lie in the same left `SL_n(ℤ)`-coset exactly when the conj
 
 section Triangular
 
-variable {R : Type*} [CommRing R] {M N : Matrix (Fin n) (Fin n) R}
-
-/-- On the diagonal, a product of upper-triangular matrices multiplies entrywise: only the
-`k = i` term of `∑ k, M i k * N k i` survives. -/
-lemma mul_apply_diag_of_isUpperTriangular (hM : Matrix.IsUpperTriangular M)
-    (hN : Matrix.IsUpperTriangular N) (i : Fin n) : (M * N) i i = M i i * N i i := by
-  rw [Matrix.mul_apply]
-  refine Finset.sum_eq_single i (fun k _ hk ↦ ?_) fun h ↦ absurd (Finset.mem_univ i) h
-  rcases lt_or_gt_of_ne hk with h | h
-  · rw [hM h, zero_mul]
-  · rw [hN h, mul_zero]
+variable {R : Type*} [CommRing R] {M : Matrix (Fin n) (Fin n) R}
 
 /-- The inverse of an upper-triangular matrix with `1` on the diagonal again has `1` on the
-diagonal. -/
+diagonal: `M⁻¹ * M = 1` read on the diagonal, through
+`Matrix.mul_apply_diag_of_isUpperTriangular`. -/
 lemma inv_apply_diag_of_isUpperTriangular [Invertible M] (hM : Matrix.IsUpperTriangular M)
     (hdiag : ∀ i, M i i = 1) (i : Fin n) : M⁻¹ i i = 1 := by
   have hinv : Matrix.IsUpperTriangular M⁻¹ := Matrix.blockTriangular_inv_of_blockTriangular hM
   have h := congrFun (congrFun (Matrix.nonsing_inv_mul M (Matrix.isUnit_det_of_invertible M)) i) i
-  rwa [mul_apply_diag_of_isUpperTriangular hinv hM i, hdiag i, mul_one,
+  rwa [Matrix.mul_apply_diag_of_isUpperTriangular hinv hM i, hdiag i, mul_one,
     Matrix.one_apply_eq] at h
 
 end Triangular
@@ -260,7 +252,7 @@ lemma upperTriGL_eq_of_dvd {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
   have hup : Matrix.IsUpperTriangular C :=
     Matrix.BlockTriangular.mul (isUpperTriangular_unitriMat B₁) hup₂
   have hdiag : ∀ i, C i i = 1 := fun i ↦ by
-    rw [hC, mul_apply_diag_of_isUpperTriangular (isUpperTriangular_unitriMat B₁) hup₂ i,
+    rw [hC, Matrix.mul_apply_diag_of_isUpperTriangular (isUpperTriangular_unitriMat B₁) hup₂ i,
       unitriMat_apply_diag,
       inv_apply_diag_of_isUpperTriangular (isUpperTriangular_unitriMat B₂)
         (unitriMat_apply_diag B₂) i, one_mul]

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -17,10 +17,13 @@ coset `SL_n(ℤ) · diag(a) · SL_n(ℤ)`, indexed by the bounded entry assignme
 coset, and its injectivity need no hypothesis on `a` at all.
 
 *Distinctness of the cosets* does: when `a` is positive and a divisibility chain (`IsDvdChain`),
-the family lies in pairwise distinct left `SL_n(ℤ)`-cosets, so the double coset meets at least
-`∏_{i < j} (a_j / a_i)` of them. The chain condition is what makes `a_j / a_i` an exact
-quotient, which is what turns integrality of the connecting element into the divisibility the
-argument runs on.
+distinct entry assignments give representatives in distinct left `SL_n(ℤ)`-cosets. The chain
+condition is what makes `a_j / a_i` an exact quotient, which is what turns integrality of the
+connecting element into the divisibility the argument runs on.
+
+Counting the index type then bounds the number of left cosets in the double coset below by
+`∏_{i < j} (a_j / a_i)`. That count is a consequence of the distinctness proved here, not
+itself a declaration in this file.
 
 The representative attached to `B` is *defined* as `diag(a) · U(B)`, where `U(B)` is the
 unipotent upper-triangular integral matrix with off-diagonal entries `B`. Two things follow
@@ -45,8 +48,7 @@ does not, since `upperTriGL` is visibly a composition of injective maps.
   matrices, hence distinct representatives.
 * `eq_of_upperTriGL_eq`, `eq_of_upperTriGL_mul_inv_mem_SLnZ` — the representatives lie in
   *distinct* left `SL_n(ℤ)`-cosets: two of them are left-equivalent only when their entry
-  assignments already agree. So for a positive `IsDvdChain` the double coset meets at least
-  `∏_{i < j} (a_j / a_i)` distinct left cosets.
+  assignments already agree, for a positive `IsDvdChain`.
 
 The two steps behind that conclusion are also stated separately, since each is reusable:
 `dvd_comparison_of_upperTriGL_eq` turns left equivalence into `(a_j / a_i) ∣ C_{ij}` for the
@@ -65,9 +67,8 @@ and Prop. 3.36 (p. 72).
 
 That exercise is motivation, not the statement proved here. It asserts only that
 flag-preserving representatives *exist*; it does not supply this bounded family
-`B_{ij} ∈ Fin (a_j / a_i)`, nor the distinctness of the left cosets they occupy, nor the
-resulting `∏_{i < j} (a_j / a_i)` lower bound. Those are proved below and are not read off
-from the exercise.
+`B_{ij} ∈ Fin (a_j / a_i)`, nor the distinctness of the left cosets they occupy. Those are
+proved below and are not read off from the exercise.
 
 The definitions follow the AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB)
 file `LeanModularForms/HeckeRIngs/GLn/CosetDecomposition.lean` (Chris Birkbeck), whose module
@@ -313,8 +314,7 @@ lemma dvd_comparison_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
 
 /-- The upper-triangular representatives of a positive divisibility chain lie in pairwise
 **distinct** left `SL_n(ℤ)`-cosets: if two of them differ by a left factor in `SL_n(ℤ)`, their
-entry assignments already agree. So the double coset `SL_n(ℤ) · diag(a) · SL_n(ℤ)` meets at
-least `∏_{i < j} (a_j / a_i)` distinct left cosets. -/
+entry assignments already agree. Equivalently, `B ↦ SL_n(ℤ) · upperTriGL B` is injective. -/
 theorem eq_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (hchain : IsDvdChain a)
     {B₁ B₂ : UpperTriEntries n a}
     {S : SpecialLinearGroup (Fin n) ℤ} (hS : upperTriGL B₁ = mapGL ℚ S * upperTriGL B₂) :

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -11,10 +11,16 @@ public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
 /-!
 # Upper-triangular representatives for a diagonal double coset
 
-For a tuple `a` of positive naturals, this file exhibits a family of elements of the double
+For an arbitrary tuple `a` of naturals, this file exhibits a family of elements of the double
 coset `SL_n(ℤ) · diag(a) · SL_n(ℤ)`, indexed by the bounded entry assignments
-`B_{ij} ∈ {0, …, a_j / a_i - 1}` for `i < j`, and shows that they lie in pairwise distinct
-left `SL_n(ℤ)`-cosets — so the double coset contains at least `∏_{i < j} (a_j / a_i)` of them.
+`B_{ij} ∈ {0, …, a_j / a_i - 1}` for `i < j`. The construction, its membership in the double
+coset, and its injectivity need no hypothesis on `a` at all.
+
+*Distinctness of the cosets* does: when `a` is positive and a divisibility chain (`IsDvdChain`),
+the family lies in pairwise distinct left `SL_n(ℤ)`-cosets, so the double coset meets at least
+`∏_{i < j} (a_j / a_i)` of them. The chain condition is what makes `a_j / a_i` an exact
+quotient, which is what turns integrality of the connecting element into the divisibility the
+argument runs on.
 
 The representative attached to `B` is *defined* as `diag(a) · U(B)`, where `U(B)` is the
 unipotent upper-triangular integral matrix with off-diagonal entries `B`. Two things follow

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -13,7 +13,8 @@ public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
 
 For a tuple `a` of positive naturals, this file exhibits a family of elements of the double
 coset `SL_n(ℤ) · diag(a) · SL_n(ℤ)`, indexed by the bounded entry assignments
-`B_{ij} ∈ {0, …, a_j / a_i - 1}` for `i < j`, and shows the family is injective.
+`B_{ij} ∈ {0, …, a_j / a_i - 1}` for `i < j`, and shows that they lie in pairwise distinct
+left `SL_n(ℤ)`-cosets — so the double coset contains at least `∏_{i < j} (a_j / a_i)` of them.
 
 The representative attached to `B` is *defined* as `diag(a) · U(B)`, where `U(B)` is the
 unipotent upper-triangular integral matrix with off-diagonal entries `B`. Two things follow
@@ -35,6 +36,10 @@ the representative lies in the double coset with no further argument.
 * `upperTriGL_mem_doubleCoset` — every representative lies in `SL_n(ℤ) · diag(a) · SL_n(ℤ)`.
 * `unitriMat_injective`, `upperTriGL_injective` — distinct entry assignments give distinct
   matrices, hence distinct representatives.
+* `upperTriGL_eq_of_dvd` — the representatives lie in *distinct* left `SL_n(ℤ)`-cosets: two of
+  them are left-equivalent only when their entry assignments agree. Left equivalence says the
+  comparison matrix `C = U(B₁) · U(B₂)⁻¹` satisfies `(a_j / a_i) ∣ C_{ij}`, and the entry bound
+  then forces `C = 1` by induction on `j - i`.
 
 ## References
 
@@ -156,5 +161,115 @@ lemma upperTriGL_injective {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) :
     exact_mod_cast mul_left_cancel₀ hai hE
   · simp
   · rw [unitriMat_apply_of_lt B₁ hij, unitriMat_apply_of_lt B₂ hij]
+
+/-! ## Distinctness of the left cosets
+
+Two representatives lie in the same left `SL_n(ℤ)`-coset exactly when the conjugate
+`diag(a)⁻¹ · S · diag(a)` of the connecting element `S` is integral, which says
+`(a_j / a_i) ∣ C_{ij}` for the comparison matrix `C = U(B₁) · U(B₂)⁻¹`. The entry bound
+`B_{ij} < a_j / a_i` then forces `C = 1`. -/
+
+section Triangular
+
+variable {R : Type*} [CommRing R] {M N : Matrix (Fin n) (Fin n) R}
+
+/-- On the diagonal, a product of upper-triangular matrices multiplies entrywise: only the
+`k = i` term of `∑ k, M i k * N k i` survives. -/
+lemma mul_apply_diag_of_isUpperTriangular (hM : Matrix.IsUpperTriangular M)
+    (hN : Matrix.IsUpperTriangular N) (i : Fin n) : (M * N) i i = M i i * N i i := by
+  rw [Matrix.mul_apply]
+  refine Finset.sum_eq_single i (fun k _ hk ↦ ?_) fun h ↦ absurd (Finset.mem_univ i) h
+  rcases lt_or_gt_of_ne hk with h | h
+  · rw [hM h, zero_mul]
+  · rw [hN h, mul_zero]
+
+/-- The inverse of an upper-triangular matrix with `1` on the diagonal again has `1` on the
+diagonal. -/
+lemma inv_apply_diag_of_isUpperTriangular [Invertible M] (hM : Matrix.IsUpperTriangular M)
+    (hdiag : ∀ i, M i i = 1) (i : Fin n) : M⁻¹ i i = 1 := by
+  have hinv : Matrix.IsUpperTriangular M⁻¹ := Matrix.blockTriangular_inv_of_blockTriangular hM
+  have h := congrFun (congrFun (Matrix.nonsing_inv_mul M (Matrix.isUnit_det_of_invertible M)) i) i
+  rwa [mul_apply_diag_of_isUpperTriangular hinv hM i, hdiag i, mul_one,
+    Matrix.one_apply_eq] at h
+
+end Triangular
+
+/-- The comparison matrix `C` between two representatives is the identity above the diagonal.
+
+Strong induction on `j - i`. Reading `C · U(B₂) = U(B₁)` at `(i, j)`, every term of the sum
+except `k = i` and `k = j` drops: below `i` because `C` is upper triangular, strictly between
+because the inductive hypothesis has already killed those entries, and above `j` because
+`U(B₂)` is upper triangular. What is left is `(B₂)_{ij} + C_{ij} = (B₁)_{ij}`, so `C_{ij}` is a
+difference of two entries each below `a_j / a_i`; being divisible by `a_j / a_i` it vanishes. -/
+private lemma comparison_apply_eq_zero {a : Fin n → ℕ} {B₁ B₂ : UpperTriRep n a}
+    {C : Matrix (Fin n) (Fin n) ℤ} (hmul : C * unitriMat B₂ = unitriMat B₁)
+    (hup : Matrix.IsUpperTriangular C) (hdiag : ∀ i, C i i = 1)
+    (hdvd : ∀ ⦃i j : Fin n⦄, i < j → ((a j / a i : ℕ) : ℤ) ∣ C i j) :
+    ∀ ⦃i j : Fin n⦄, i < j → C i j = 0 := by
+  suffices H : ∀ d : ℕ, ∀ i j : Fin n, (j : ℕ) - (i : ℕ) = d → i < j → C i j = 0 from
+    fun i j hij ↦ H _ i j rfl hij
+  intro d
+  induction d using Nat.strong_induction_on with
+  | _ d ih =>
+    intro i j hd hij
+    have hne : i ≠ j := hij.ne
+    -- Only `k = i` and `k = j` contribute to `(C * U(B₂)) i j`.
+    have hvanish : ∀ k ∈ Finset.univ, k ∉ ({i, j} : Finset (Fin n)) →
+        C i k * unitriMat B₂ k j = 0 := by
+      intro k _ hk
+      simp only [Finset.mem_insert, Finset.mem_singleton, not_or] at hk
+      rcases lt_trichotomy k i with hki | rfl | hik
+      · rw [hup hki, zero_mul]
+      · exact absurd rfl hk.1
+      · rcases lt_trichotomy k j with hkj | rfl | hjk
+        · rw [ih ((k : ℕ) - (i : ℕ)) (by omega) i k rfl hik, zero_mul]
+        · exact absurd rfl hk.2
+        · rw [unitriMat_apply_of_lt B₂ hjk, mul_zero]
+    have hkey := congrFun (congrFun hmul i) j
+    rw [Matrix.mul_apply, ← Finset.sum_subset (Finset.subset_univ ({i, j} : Finset (Fin n)))
+      hvanish, Finset.sum_pair hne, hdiag i, one_mul, unitriMat_apply_diag, mul_one,
+      unitriMat_apply_lt B₂ hij, unitriMat_apply_lt B₁ hij] at hkey
+    -- `C i j` is a difference of two entries, each strictly below `a j / a i`.
+    have hb₁ : (B₁ ⟨(i, j), hij⟩ : ℕ) < a j / a i := (B₁ ⟨(i, j), hij⟩).isLt
+    have hb₂ : (B₂ ⟨(i, j), hij⟩ : ℕ) < a j / a i := (B₂ ⟨(i, j), hij⟩).isLt
+    refine Int.eq_zero_of_abs_lt_dvd (hdvd hij) ?_
+    have hCij : C i j = ((B₁ ⟨(i, j), hij⟩ : ℕ) : ℤ) - ((B₂ ⟨(i, j), hij⟩ : ℕ) : ℤ) := by
+      linarith
+    rw [hCij, abs_lt]
+    omega
+
+/-- Two upper-triangular representatives lie in the same left `SL_n(ℤ)`-coset only if their
+entry assignments agree.
+
+The connecting element is `S = M₁ M₂⁻¹`; conjugating, `diag(a)⁻¹ S diag(a) = U(B₁) U(B₂)⁻¹`,
+whose `(i,j)` entry is `S_{ij} · a_j / a_i`. Integrality of `S` is therefore exactly the
+divisibility hypothesis fed to `comparison_apply_eq_zero`. -/
+lemma upperTriGL_eq_of_dvd {a : Fin n → ℕ} {B₁ B₂ : UpperTriRep n a}
+    (hdvd : ∀ ⦃i j : Fin n⦄, i < j →
+      ((a j / a i : ℕ) : ℤ) ∣ (unitriMat B₁ * (unitriMat B₂)⁻¹) i j) :
+    B₁ = B₂ := by
+  have : Invertible (unitriMat B₂) :=
+    Matrix.invertibleOfIsUnitDet _ (by rw [det_unitriMat]; exact isUnit_one)
+  have hup₂ : Matrix.IsUpperTriangular (unitriMat B₂)⁻¹ :=
+    Matrix.blockTriangular_inv_of_blockTriangular (isUpperTriangular_unitriMat B₂)
+  set C : Matrix (Fin n) (Fin n) ℤ := unitriMat B₁ * (unitriMat B₂)⁻¹ with hC
+  have hup : Matrix.IsUpperTriangular C :=
+    Matrix.BlockTriangular.mul (isUpperTriangular_unitriMat B₁) hup₂
+  have hdiag : ∀ i, C i i = 1 := fun i ↦ by
+    rw [hC, mul_apply_diag_of_isUpperTriangular (isUpperTriangular_unitriMat B₁) hup₂ i,
+      unitriMat_apply_diag,
+      inv_apply_diag_of_isUpperTriangular (isUpperTriangular_unitriMat B₂)
+        (unitriMat_apply_diag B₂) i, one_mul]
+  have hmul : C * unitriMat B₂ = unitriMat B₁ := by
+    rw [hC, Matrix.mul_assoc, Matrix.nonsing_inv_mul _ (Matrix.isUnit_det_of_invertible _),
+      Matrix.mul_one]
+  have hzero := comparison_apply_eq_zero hmul hup hdiag hdvd
+  have hC1 : C = 1 := by
+    ext i j
+    rcases lt_trichotomy i j with h | rfl | h
+    · rw [hzero h, Matrix.one_apply_ne h.ne]
+    · rw [hdiag, Matrix.one_apply_eq]
+    · rw [hup h, Matrix.one_apply_ne h.ne']
+  exact unitriMat_injective (by rw [← hmul, hC1, Matrix.one_mul])
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -46,15 +46,16 @@ does not, since `upperTriGL` is visibly a composition of injective maps.
 * `upperTriGL_mem_doubleCoset` — every representative lies in `SL_n(ℤ) · diag(a) · SL_n(ℤ)`.
 * `unitriMat_injective`, `upperTriGL_injective` — distinct entry assignments give distinct
   matrices, hence distinct representatives.
-* `eq_of_upperTriGL_eq`, `eq_of_upperTriGL_mul_inv_mem_SLnZ` — the representatives lie in
-  *distinct* left `SL_n(ℤ)`-cosets: two of them are left-equivalent only when their entry
-  assignments already agree, for a positive `IsDvdChain`.
+* `eq_of_upperTriGL_eq_mapGL_mul_upperTriGL` and `eq_of_upperTriGL_mul_inv_mem_SLnZ` — the
+  representatives lie in *distinct* left `SL_n(ℤ)`-cosets: two of them are left-equivalent
+  only when their entry assignments already agree, for a positive `IsDvdChain`.
 
 The two steps behind that conclusion are also stated separately, since each is reusable:
-`dvd_comparison_of_upperTriGL_eq` turns left equivalence into `(a_j / a_i) ∣ C_{ij}` for the
-comparison matrix `C = U(B₁) · U(B₂)⁻¹`, by conjugating the connecting element back through
-`diag(a)`; and `eq_of_dvd_comparison` turns that divisibility into `C = 1`, because the entry
-bound `B_{ij} < a_j / a_i` leaves no room for a nonzero multiple, by induction on `j - i`.
+`dvd_comparison_of_upperTriGL_eq_mapGL_mul_upperTriGL` turns left equivalence into
+`(a_j / a_i) ∣ C_{ij}` for the comparison matrix `C = U(B₁) · U(B₂)⁻¹`, by conjugating the
+connecting element back through `diag(a)`; and `eq_of_dvd_comparison` turns that divisibility
+into `C = 1`, because the entry bound `B_{ij} < a_j / a_i` leaves no room for a nonzero
+multiple, by induction on `j - i`.
 
 ## References
 
@@ -236,7 +237,8 @@ private lemma comparison_apply_eq_zero {a : Fin n → ℕ} {B₁ B₂ : UpperTri
 
 This is arithmetic about a hypothesised divisibility; nothing here mentions cosets. What makes
 that divisibility hold for two representatives in the same left `SL_n(ℤ)`-coset is
-`dvd_comparison_of_upperTriGL_eq`, and `eq_of_upperTriGL_eq` is the two combined. -/
+`dvd_comparison_of_upperTriGL_eq_mapGL_mul_upperTriGL`, and
+`eq_of_upperTriGL_eq_mapGL_mul_upperTriGL` is the two combined. -/
 lemma eq_of_dvd_comparison {a : Fin n → ℕ} {B₁ B₂ : UpperTriEntries n a}
     (hdvd : ∀ ⦃i j : Fin n⦄, i < j →
       ((a j / a i : ℕ) : ℤ) ∣ (unitriMat B₁ * (unitriMat B₂)⁻¹) i j) :
@@ -271,7 +273,7 @@ Deliberately not `@[simp]`: `simp` already rewrites the left-hand side past this
 `(unitriMat B).adjugate`, through `SpecialLinearGroup.coe_inv` and `coe_unitriSL`, so the
 marking is rejected by `simpNF` as not being in normal form. The lemma is kept as the named
 bridge to the `Matrix.inv` spelling, for `rw` and for `simp only` sets that want it. -/
-lemma coe_inv_unitriSL {a : Fin n → ℕ} (B : UpperTriEntries n a) :
+private lemma coe_inv_unitriSL {a : Fin n → ℕ} (B : UpperTriEntries n a) :
     (((unitriSL B)⁻¹ : SpecialLinearGroup (Fin n) ℤ) : Matrix (Fin n) (Fin n) ℤ)
       = (unitriMat B)⁻¹ := by
   rw [SpecialLinearGroup.coe_inv, Matrix.inv_def, coe_unitriSL, det_unitriMat, Ring.inverse_one,
@@ -282,10 +284,9 @@ the diagonal: `(a_j / a_i) ∣ C_{ij}` for `C = U(B₁) · U(B₂)⁻¹`. This i
 `eq_of_dvd_comparison` takes as a hypothesis, so the two together make distinctness a theorem
 about the coset relation rather than a criterion. Only `a i ∣ a j` is needed, at the pair asked
 about. -/
-lemma dvd_comparison_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
-    {B₁ B₂ : UpperTriEntries n a}
-    {S : SpecialLinearGroup (Fin n) ℤ} (hS : upperTriGL B₁ = mapGL ℚ S * upperTriGL B₂)
-    {i j : Fin n} (hdvd : a i ∣ a j) :
+lemma dvd_comparison_of_upperTriGL_eq_mapGL_mul_upperTriGL {a : Fin n → ℕ}
+    (ha : ∀ i, 0 < a i) {B₁ B₂ : UpperTriEntries n a} {S : SpecialLinearGroup (Fin n) ℤ}
+    (hS : upperTriGL B₁ = mapGL ℚ S * upperTriGL B₂) {i j : Fin n} (hdvd : a i ∣ a j) :
     ((a j / a i : ℕ) : ℤ) ∣ (unitriMat B₁ * (unitriMat B₂)⁻¹) i j := by
   -- Cancel `U(B₂)` on the right, in the group `GL_n(ℚ)`.
   have hGL : natDiagGL n a * mapGL ℚ (unitriSL B₁ * (unitriSL B₂)⁻¹)
@@ -315,12 +316,13 @@ lemma dvd_comparison_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
 /-- The upper-triangular representatives of a positive divisibility chain lie in pairwise
 **distinct** left `SL_n(ℤ)`-cosets: if two of them differ by a left factor in `SL_n(ℤ)`, their
 entry assignments already agree. Equivalently, `B ↦ SL_n(ℤ) · upperTriGL B` is injective. -/
-theorem eq_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (hchain : IsDvdChain a)
+theorem eq_of_upperTriGL_eq_mapGL_mul_upperTriGL {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
+    (hchain : IsDvdChain a)
     {B₁ B₂ : UpperTriEntries n a}
     {S : SpecialLinearGroup (Fin n) ℤ} (hS : upperTriGL B₁ = mapGL ℚ S * upperTriGL B₂) :
     B₁ = B₂ :=
   eq_of_dvd_comparison fun _ _ hij ↦
-    dvd_comparison_of_upperTriGL_eq ha hS (isDvdChain_iff.mp hchain hij.le)
+    dvd_comparison_of_upperTriGL_eq_mapGL_mul_upperTriGL ha hS (isDvdChain_iff.mp hchain hij.le)
 
 /-- The same statement phrased with the subgroup `SLnZ n` of `GL_n(ℚ)`: distinct entry
 assignments give representatives in distinct left cosets of `SL_n(ℤ)`. -/
@@ -328,6 +330,6 @@ theorem eq_of_upperTriGL_mul_inv_mem_SLnZ {a : Fin n → ℕ} (ha : ∀ i, 0 < a
     (hchain : IsDvdChain a) {B₁ B₂ : UpperTriEntries n a}
     (h : upperTriGL B₁ * (upperTriGL B₂)⁻¹ ∈ SLnZ n) : B₁ = B₂ := by
   obtain ⟨S, hSeq⟩ := (mem_SLnZ_iff n).mp h
-  exact eq_of_upperTriGL_eq ha hchain (by rw [hSeq]; group)
+  exact eq_of_upperTriGL_eq_mapGL_mul_upperTriGL ha hchain (by rw [hSeq]; group)
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chris Birkbeck
+Authors: Chris Birkbeck, Claude
 -/
 module
 
@@ -56,11 +56,18 @@ bound `B_{ij} < a_j / a_i` leaves no room for a nonzero multiple, by induction o
 
 ## References
 
-The general-`n` statement is Shimura, *Introduction to the Arithmetic Theory of Automorphic
-Functions* (1971), Exercise 3.26(A), p. 65: for every `α ∈ Δ` one can choose representatives
-`α_j` of `ΓαΓ = ⋃_j Γα_j` with `L_ν α_j ⊆ L_ν` for the standard flag `L_ν = ∑_{i ≤ ν} ℤ e_i`,
-i.e. upper-triangular ones. Shimura leaves it as an exercise and works the `n = 2` case
-explicitly in Prop. 3.33 (p. 70) and Prop. 3.36 (p. 72).
+The background for working with upper-triangular representatives at all is Shimura,
+*Introduction to the Arithmetic Theory of Automorphic Functions* (1971), Exercise 3.26(A),
+p. 65: for every `α ∈ Δ` one can choose representatives `α_j` of `ΓαΓ = ⋃_j Γα_j` with
+`L_ν α_j ⊆ L_ν` for the standard flag `L_ν = ∑_{i ≤ ν} ℤ e_i`, i.e. upper-triangular ones.
+Shimura leaves it as an exercise and works the `n = 2` case explicitly in Prop. 3.33 (p. 70)
+and Prop. 3.36 (p. 72).
+
+That exercise is motivation, not the statement proved here. It asserts only that
+flag-preserving representatives *exist*; it does not supply this bounded family
+`B_{ij} ∈ Fin (a_j / a_i)`, nor the distinctness of the left cosets they occupy, nor the
+resulting `∏_{i < j} (a_j / a_i)` lower bound. Those are proved below and are not read off
+from the exercise.
 
 The definitions follow the AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB)
 file `LeanModularForms/HeckeRIngs/GLn/CosetDecomposition.lean` (Chris Birkbeck), whose module

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -43,10 +43,10 @@ does not, since `upperTriGL` is visibly a composition of injective maps.
 * `upperTriGL_mem_doubleCoset` — every representative lies in `SL_n(ℤ) · diag(a) · SL_n(ℤ)`.
 * `unitriMat_injective`, `upperTriGL_injective` — distinct entry assignments give distinct
   matrices, hence distinct representatives.
-* `eq_of_upperTriGL_eq`, `eq_of_mul_inv_mem_SLnZ` — the representatives lie in *distinct* left
-  `SL_n(ℤ)`-cosets: two of them are left-equivalent only when their entry assignments already
-  agree. So for a positive `IsDvdChain` the double coset meets at least `∏_{i < j} (a_j / a_i)`
-  distinct left cosets.
+* `eq_of_upperTriGL_eq`, `eq_of_upperTriGL_mul_inv_mem_SLnZ` — the representatives lie in
+  *distinct* left `SL_n(ℤ)`-cosets: two of them are left-equivalent only when their entry
+  assignments already agree. So for a positive `IsDvdChain` the double coset meets at least
+  `∏_{i < j} (a_j / a_i)` distinct left cosets.
 
 The two steps behind that conclusion are also stated separately, since each is reusable:
 `dvd_comparison_of_upperTriGL_eq` turns left equivalence into `(a_j / a_i) ∣ C_{ij}` for the
@@ -324,8 +324,8 @@ theorem eq_of_upperTriGL_eq {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (hchain : 
 
 /-- The same statement phrased with the subgroup `SLnZ n` of `GL_n(ℚ)`: distinct entry
 assignments give representatives in distinct left cosets of `SL_n(ℤ)`. -/
-theorem eq_of_mul_inv_mem_SLnZ {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (hchain : IsDvdChain a)
-    {B₁ B₂ : UpperTriEntries n a}
+theorem eq_of_upperTriGL_mul_inv_mem_SLnZ {a : Fin n → ℕ} (ha : ∀ i, 0 < a i)
+    (hchain : IsDvdChain a) {B₁ B₂ : UpperTriEntries n a}
     (h : upperTriGL B₁ * (upperTriGL B₂)⁻¹ ∈ SLnZ n) : B₁ = B₂ := by
   obtain ⟨S, hSeq⟩ := (mem_SLnZ_iff n).mp h
   exact eq_of_upperTriGL_eq ha hchain (by rw [hSeq]; group)


### PR DESCRIPTION
For a tuple `a` of positive naturals, the bounded entry assignments
`B_ij ∈ {0, …, a_j/a_i − 1}` (`i < j`) index a family of elements of the double coset
`SL_n(ℤ) · diag(a) · SL_n(ℤ)`. This adds that family, its membership in the double coset, its
injectivity, and — the substantive part — that its members lie in **pairwise distinct left
`SL_n(ℤ)`-cosets**, so for a chain `a_i ∣ a_j` the double coset meets at least `∏_{i<j} (a_j/a_i)`
distinct left cosets.

## Design

The representative is **defined** as `diag(a) · U(B)`, where `U(B)` is the unipotent
upper-triangular integral matrix with off-diagonal entries `B` — not entrywise. That shape does
the work:

* `U(B)` is upper triangular with ones on the diagonal, so `det U(B) = 1` and `U(B) ∈ SL_n(ℤ)`;
* hence `diag(a) · U(B)` lies in the double coset with `h₁ = 1`, with no further argument;
* and `upperTriGL` is visibly a composition of injective maps, so injectivity needs no
  positivity hypothesis — even where `natDiagGL` takes its junk value `1`, left multiplication
  is injective.

An entrywise definition would have forced a Smith-normal-form argument for what is here a
one-line consequence of the definition. The entrywise description `M_ij = a_i · B_ij` is
supplied as `@[simp]` characterisation lemmas above, on, and below the diagonal, and
`upperTriGL_def` names the factorisation itself, for consumers that want either.

## Distinctness

Two steps, each stated separately because each is reusable.

**`dvd_comparison_of_upperTriGL_eq`** turns the coset relation into arithmetic. Cancelling
`U(B₂)` on the right of `diag(a) · U(B₁) = S · diag(a) · U(B₂)` — a group computation in
`GL_n(ℚ)` — leaves `diag(a) · C = S · diag(a)` for the comparison matrix `C = U(B₁) · U(B₂)⁻¹`,
whose `(i,j)` entry reads `a_i · C_ij = S_ij · a_j`. Under the chain condition `a_i ∣ a_j` that
writes `a_j` as `a_i · (a_j/a_i)` exactly, so cancelling `a_i > 0` gives
`C_ij = S_ij · (a_j/a_i)`. **Integrality of the connecting element is the entire source of the
divisibility** — nothing else is assumed.

**`eq_of_dvd_comparison`** turns that divisibility into `C = 1`. Reading `C · U(B₂) = U(B₁)` at
`(i,j)`, every term of the sum drops except `k = i` and `k = j` — below `i` because `C` is upper
triangular, strictly between by the inductive hypothesis, above `j` because `U(B₂)` is — leaving
`C_ij = (B₁)_ij − (B₂)_ij`. That difference is smaller in absolute value than its own divisor
`a_j/a_i`, so it vanishes; induction on `j − i` gives `C = 1`.

Composing them, **`eq_of_upperTriGL_eq`** is distinctness as a theorem about the coset relation
itself, and **`eq_of_mul_inv_mem_SLnZ`** phrases the same statement through the subgroup
`SLnZ n`.

## A relocated lemma

`inv_apply_diag_of_isUpperTriangular` — inverting a unipotent upper-triangular matrix leaves the
diagonal at `1` — goes into `TauCeti/LinearAlgebra/Matrix/Triangular.lean`, beside the product
lemma it is read off from (`mul_apply_diag_of_isUpperTriangular`, added by #2605). It is a
statement about matrices with nothing `GL_n`-specific in it, and it is stated there for any
`[Fintype n] [LinearOrder n]` rather than for `Fin n`. That is the second file in this diff.

## Provenance and a corrected citation

The definitions follow Chris Birkbeck's AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB),
`LeanModularForms/HeckeRIngs/GLn/CosetDecomposition.lean`, which supplies `UpperTriRep`,
`upperTriMat`, `upperTriGL` and the determinant, and advertises `upperTriMat_injective`,
`upperTriGL_mem_doubleCoset` and `upperTriMat_distinct_cosets` in its module docstring — none
of which are proved there; those three names occur only inside the docstring. The theorems here
are therefore new rather than ported.

Two corrections to that source, both checked against the book:

* Its docstring cites **"Shimura, Proposition 3.22"**. Shimura's 3.22 is a *Lemma*, on p. 61,
  giving `T_i^(n) X^i · (Σ_m T(p^m) X^m) = …` in the Euler-product computation — unrelated to
  coset representatives. The general-`n` statement is **Exercise 3.26(A)**, p. 65 ("Prove (by
  induction on `n`) that for every `α ∈ Δ`, we can find representatives `{α_j}` so that
  `ΓαΓ = ∪_j Γα_j` and `L_ν α_j ⊂ L_ν`"); the worked `n = 2` cases are Prop. 3.33 (p. 70) and
  Prop. 3.36 (p. 72). The file cites those.
* Its determinant proof calls `Matrix.det_of_upperTriangular`, which mathlib deprecated on
  2026-07-30 in favour of `det_of_isUpperTriangular`. This uses the current name.

`DivChain` is likewise spelled with TauCeti's `IsDvdChain` conventions, and the index type is
renamed `UpperTriEntries` — it holds bounded entry assignments, not representatives.

## Roadmap

`TauCetiRoadmap/ModularForms/README.md`, **Layer 2(a)** — "The Hecke ring, stated at `GL_n` …
migrate AINTLIB's `GLn/` development". Upper-triangular representatives are the machinery
behind the *triangular expansion* that 2(a) records as one of the two steps still open at
general `n` for Shimura's Theorem 3.20 ("uniqueness of the leading double coset in the
triangular expansion, leading coefficient `1`").

Independent of the `GL2` stack: it imports only `GLn/DiagonalCosets` and
`LinearAlgebra/Matrix/Triangular` (added by #2605, now merged), both in `main`.

Roadmap: ModularForms
