### PR TITLE
feat: integrate the Banach exponential derivative

### DIFF
--- a/TauCeti/Analysis/Semigroups/BoundedGenerator/Perturbation.lean
+++ b/TauCeti/Analysis/Semigroups/BoundedGenerator/Perturbation.lean
@@ -59,7 +59,7 @@ theorem norm_exp_smul_sub_exp_smul_apply_le_of_commute (A B : X →L[ℝ] X)
   let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
   have hsum : t • A + t • (B - A) = t • B := by module
   have hint := TauCeti.intervalIntegrable_exp_smul_mul_mul_exp_smul
-    (t • A) (t • (B - A))
+    (t • A) (t • A + t • (B - A)) (t • (B - A))
   have hduhamel := TauCeti.exp_add_sub_exp_eq_integral (t • A) (t • (B - A))
   rw [hsum] at hint hduhamel
   have happly := congrArg (fun C : X →L[ℝ] X => C x) hduhamel

--- a/TauCeti/Analysis/Semigroups/BoundedGenerator/Perturbation.lean
+++ b/TauCeti/Analysis/Semigroups/BoundedGenerator/Perturbation.lean
@@ -59,7 +59,7 @@ theorem norm_exp_smul_sub_exp_smul_apply_le_of_commute (A B : X →L[ℝ] X)
   let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
   have hsum : t • A + t • (B - A) = t • B := by module
   have hint := TauCeti.intervalIntegrable_exp_smul_mul_mul_exp_smul
-    (t • A) (t • A + t • (B - A)) (t • (B - A))
+    (t • A + t • (B - A)) (t • (B - A)) (t • A)
   have hduhamel := TauCeti.exp_add_sub_exp_eq_integral (t • A) (t • (B - A))
   rw [hsum] at hint hduhamel
   have happly := congrArg (fun C : X →L[ℝ] X => C x) hduhamel

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -320,14 +320,9 @@ private noncomputable def expDerivativeIntegral (x y : A) (s : ℝ) : A :=
 
 private theorem continuous_expDerivativeIntegral (x y : A) :
     Continuous (expDerivativeIntegral x y) := by
-  let H : ℝ × ℝ → A := fun p ↦
-    exp ((1 - p.2) • (x + p.1 • y)) * y * exp (p.2 • x)
-  have hH : Continuous H := by
-    dsimp only [H]
-    fun_prop
   unfold expDerivativeIntegral
-  exact intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'
-    (f := fun s t ↦ H (s, t)) hH 0 1
+  apply intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'
+  fun_prop
 
 private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
     HasDerivAt (fun s : ℝ ↦ exp (x + s • y)) (expDerivativeIntegral x y 0) 0 := by
@@ -335,7 +330,7 @@ private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
   have hG : Filter.Tendsto (expDerivativeIntegral x y)
       (nhdsWithin (0 : ℝ) ({0} : Set ℝ)ᶜ)
       (nhds (expDerivativeIntegral x y 0)) :=
-    (continuous_expDerivativeIntegral x y).continuousAt.tendsto.mono_left inf_le_left
+    (continuous_expDerivativeIntegral x y).continuousAt.tendsto.mono_left nhdsWithin_le_nhds
   apply hG.congr'
   filter_upwards [self_mem_nhdsWithin] with s hs
   have hs0 : s ≠ 0 := Set.mem_compl_singleton_iff.mp hs

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -363,11 +363,14 @@ private theorem expFDeriv_real_apply_eq_integral (x y : A) :
 
 /-- The Fréchet derivative of the noncommutative exponential, applied to `y`, is its Duhamel
 integral. -/
-theorem expFDeriv_apply_eq_integral {𝕂 : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
-    [ContinuousSMul ℚ 𝕂] [NormedAlgebra ℝ 𝕂] [NormedAlgebra 𝕂 A]
+theorem expFDeriv_apply_eq_integral {𝕂 : Type*} [NontriviallyNormedField 𝕂]
+    [NormedAlgebra ℝ 𝕂] [NormedAlgebra 𝕂 A]
     [IsScalarTower ℝ 𝕂 A] (x y : A) :
     expFDeriv 𝕂 x y =
       ∫ t in (0 : ℝ)..1, exp ((1 - t) • x) * y * exp (t • x) := by
+  let _ : CharZero 𝕂 := Algebra.charZero_of_charZero ℝ 𝕂
+  let _ : IsScalarTower ℚ ℝ 𝕂 := IsScalarTower.of_algebraMap_eq fun q ↦ by simp [map_ratCast]
+  let _ : ContinuousSMul ℚ 𝕂 := IsScalarTower.continuousSMul ℝ
   have hscalar :
       (expFDeriv 𝕂 x).restrictScalars ℝ = expFDeriv ℝ x :=
     ((hasFDerivAt_exp (𝕂 := 𝕂) x).restrictScalars ℝ).unique

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -325,13 +325,9 @@ private theorem continuous_expDerivativeIntegral (x y : A) :
   have hH : Continuous H := by
     dsimp only [H]
     fun_prop
-  have hcontinuous :
-      Continuous (fun s : ℝ ↦ ∫ t in Set.Icc (0 : ℝ) 1, H (s, t)) :=
-    continuous_parametric_integral_of_continuous
-      (f := fun s t ↦ H (s, t)) hH isCompact_Icc
   unfold expDerivativeIntegral
-  simpa only [intervalIntegral.integral_of_le zero_le_one,
-    ← integral_Icc_eq_integral_Ioc, H] using hcontinuous
+  exact intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'
+    (f := fun s t ↦ H (s, t)) hH 0 1
 
 private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
     HasDerivAt (fun s : ℝ ↦ exp (x + s • y)) (expDerivativeIntegral x y 0) 0 := by
@@ -342,7 +338,7 @@ private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
     (continuous_expDerivativeIntegral x y).continuousAt.tendsto.mono_left inf_le_left
   apply hG.congr'
   filter_upwards [self_mem_nhdsWithin] with s hs
-  have hs0 : s ≠ 0 := hs
+  have hs0 : s ≠ 0 := Set.mem_compl_singleton_iff.mp hs
   have hduhamel := exp_add_sub_exp_eq_integral x (s • y)
   have hintegral :
       (∫ t in (0 : ℝ)..1, exp ((1 - t) • (x + s • y)) * (s • y) * exp (t • x)) =
@@ -351,7 +347,7 @@ private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
     apply intervalIntegral.integral_congr
     intro t _ht
     simp only [Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
-  rw [slope, sub_zero, zero_smul, add_zero, vsub_eq_sub, hduhamel, hintegral,
+  rw [slope_def_module, sub_zero, zero_smul, add_zero, hduhamel, hintegral,
     inv_smul_smul₀ hs0]
 
 private theorem expFDeriv_real_apply_eq_integral (x y : A) :

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -329,25 +329,13 @@ private theorem continuousAt_expDerivativeIntegral (x y : A) :
   have hH : Continuous H := by
     dsimp only [H]
     fun_prop
-  have hK : IsCompact (Set.Icc (-1 : ℝ) 1 ×ˢ Set.uIcc (0 : ℝ) 1) :=
-    isCompact_Icc.prod isCompact_uIcc
-  obtain ⟨C, hC⟩ := (hK.image hH).isBounded.exists_norm_le
-  refine intervalIntegral.continuousAt_of_dominated_interval
-    (F := fun s t ↦ H (s, t)) (bound := fun _ ↦ C) ?_ ?_ intervalIntegrable_const ?_
-  · filter_upwards [] with s
-    exact (by fun_prop : Continuous fun t ↦ H (s, t)).aestronglyMeasurable.restrict
-  · filter_upwards [Metric.ball_mem_nhds (0 : ℝ) zero_lt_one] with s hs
-    filter_upwards with t ht
-    rw [Set.uIoc_of_le zero_le_one] at ht
-    have hsIcc : s ∈ Set.Icc (-1 : ℝ) 1 := by
-      rw [Metric.mem_ball, dist_zero_right, Real.norm_eq_abs] at hs
-      exact ⟨(abs_lt.mp hs).1.le, (abs_lt.mp hs).2.le⟩
-    have htUcc : t ∈ Set.uIcc (0 : ℝ) 1 := by
-      rw [Set.uIcc_of_le zero_le_one]
-      exact ⟨ht.1.le, ht.2⟩
-    exact hC _ ⟨(s, t), ⟨hsIcc, htUcc⟩, rfl⟩
-  · filter_upwards with t _ht
-    exact (by fun_prop : Continuous fun s ↦ H (s, t)).continuousAt
+  have hcontinuous :
+      Continuous (fun s : ℝ ↦ ∫ t in Set.Icc (0 : ℝ) 1, H (s, t)) :=
+    continuous_parametric_integral_of_continuous
+      (f := fun s t ↦ H (s, t)) hH isCompact_Icc
+  unfold expDerivativeIntegral
+  simpa only [intervalIntegral.integral_of_le zero_le_one,
+    ← integral_Icc_eq_integral_Ioc, H] using hcontinuous.continuousAt
 
 private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
     HasDerivAt (fun s : ℝ ↦ exp (x + s • y)) (expDerivativeIntegral x y 0) 0 := by
@@ -366,6 +354,7 @@ private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
     rw [expDerivativeIntegral, ← intervalIntegral.integral_smul]
     apply intervalIntegral.integral_congr
     intro t _ht
+    -- Expose the integral's integrand so the scalar can be moved through both multiplications.
     change exp ((1 - t) • (x + s • y)) * (s • y) * exp (t • x) =
       s • (exp ((1 - t) • (x + s • y)) * y * exp (t • x))
     rw [Algebra.mul_smul_comm, Algebra.smul_mul_assoc]

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -7,6 +7,8 @@ module
 public import Mathlib.Analysis.SpecialFunctions.Exponential
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.Analysis.Calculus.Deriv.Shift
+import Mathlib.Analysis.Calculus.Deriv.Slope
+import Mathlib.MeasureTheory.Integral.DominatedConvergence
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import TauCeti.Analysis.Normed.Algebra.Basic
 
@@ -306,5 +308,81 @@ theorem expFDeriv_zero {𝕂 R : Type*} [NontriviallyNormedField 𝕂] [NormedRi
           · simp [zero_pow hi_zero]
         rw [hsum, smul_zero]
         simp
+
+section IntegralFormula
+
+variable {A : Type*} [NormedRing A] [NormedAlgebra ℝ A] [CompleteSpace A]
+
+/-- A real normed algebra regarded as a rational normed algebra within this section. -/
+noncomputable local instance normedAlgebraRatOfRealDerivativeIntegral : NormedAlgebra ℚ A :=
+  .restrictScalars ℚ ℝ A
+
+private noncomputable def expDerivativeIntegral (x y : A) (s : ℝ) : A :=
+  ∫ t in (0 : ℝ)..1, exp ((1 - t) • (x + s • y)) * y * exp (t • x)
+
+private theorem continuousAt_expDerivativeIntegral (x y : A) :
+    ContinuousAt (expDerivativeIntegral x y) 0 := by
+  let H : ℝ × ℝ → A := fun p ↦
+    exp ((1 - p.2) • (x + p.1 • y)) * y * exp (p.2 • x)
+  have hH : Continuous H := by
+    dsimp only [H]
+    fun_prop
+  have hK : IsCompact (Set.Icc (-1 : ℝ) 1 ×ˢ Set.uIcc (0 : ℝ) 1) :=
+    isCompact_Icc.prod isCompact_uIcc
+  obtain ⟨C, hC⟩ := (hK.image hH).isBounded.exists_norm_le
+  refine intervalIntegral.continuousAt_of_dominated_interval
+    (F := fun s t ↦ H (s, t)) (bound := fun _ ↦ C) ?_ ?_ intervalIntegrable_const ?_
+  · filter_upwards [] with s
+    exact (by fun_prop : Continuous fun t ↦ H (s, t)).aestronglyMeasurable.restrict
+  · filter_upwards [Metric.ball_mem_nhds (0 : ℝ) zero_lt_one] with s hs
+    filter_upwards with t ht
+    rw [Set.uIoc_of_le zero_le_one] at ht
+    have hsIcc : s ∈ Set.Icc (-1 : ℝ) 1 := by
+      rw [Metric.mem_ball, dist_zero_right, Real.norm_eq_abs] at hs
+      exact ⟨(abs_lt.mp hs).1.le, (abs_lt.mp hs).2.le⟩
+    have htUcc : t ∈ Set.uIcc (0 : ℝ) 1 := by
+      rw [Set.uIcc_of_le zero_le_one]
+      exact ⟨ht.1.le, ht.2⟩
+    exact hC _ ⟨(s, t), ⟨hsIcc, htUcc⟩, rfl⟩
+  · filter_upwards with t _ht
+    exact (by fun_prop : Continuous fun s ↦ H (s, t)).continuousAt
+
+private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
+    HasDerivAt (fun s : ℝ ↦ exp (x + s • y)) (expDerivativeIntegral x y 0) 0 := by
+  rw [hasDerivAt_iff_tendsto_slope]
+  have hG : Filter.Tendsto (expDerivativeIntegral x y)
+      (nhdsWithin (0 : ℝ) ({0} : Set ℝ)ᶜ)
+      (nhds (expDerivativeIntegral x y 0)) :=
+    (continuousAt_expDerivativeIntegral x y).tendsto.mono_left inf_le_left
+  apply hG.congr'
+  filter_upwards [self_mem_nhdsWithin] with s hs
+  have hs0 : s ≠ 0 := hs
+  have hduhamel := exp_add_sub_exp_eq_integral x (s • y)
+  have hintegral :
+      (∫ t in (0 : ℝ)..1, exp ((1 - t) • (x + s • y)) * (s • y) * exp (t • x)) =
+        s • expDerivativeIntegral x y s := by
+    rw [expDerivativeIntegral, ← intervalIntegral.integral_smul]
+    apply intervalIntegral.integral_congr
+    intro t _ht
+    change exp ((1 - t) • (x + s • y)) * (s • y) * exp (t • x) =
+      s • (exp ((1 - t) • (x + s • y)) * y * exp (t • x))
+    rw [Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
+  rw [slope, sub_zero, zero_smul, add_zero, vsub_eq_sub, hduhamel, hintegral,
+    inv_smul_smul₀ hs0]
+
+/-- The Fréchet derivative of the noncommutative exponential, applied to `y`, is its Duhamel
+integral. -/
+theorem expFDeriv_apply_eq_integral (x y : A) :
+    expFDeriv ℝ x y =
+      ∫ t in (0 : ℝ)..1, exp ((1 - t) • x) * y * exp (t • x) := by
+  have hline : HasDerivAt (fun s : ℝ ↦ x + s • y) y 0 := by
+    simpa using (hasDerivAt_id (0 : ℝ)).smul_const y |>.const_add x
+  have hseries : HasDerivAt (fun s : ℝ ↦ exp (x + s • y)) (expFDeriv ℝ x y) 0 := by
+    simpa only [Function.comp_apply, zero_smul, add_zero] using!
+      (hasFDerivAt_exp (𝕂 := ℝ) x).comp_hasDerivAt_of_eq 0 hline (by simp)
+  simpa only [expDerivativeIntegral, zero_smul, add_zero] using
+    hseries.unique (hasDerivAt_exp_add_smul_integral x y)
+
+end IntegralFormula
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -19,7 +19,8 @@ every increment. It also derives the corresponding integral formula for the Fré
 
 ## Main results
 
-* `intervalIntegrable_exp_smul_mul_mul_exp_smul`: the Duhamel integrand is interval integrable.
+* `intervalIntegrable_exp_smul_mul_mul_exp_smul`: a three-factor exponential integrand is interval
+  integrable.
 * `exp_add_sub_exp_eq_integral`: `exp (x + h) - exp x` is the integral of
   `exp ((1 - t) (x + h)) * h * exp (t x)` over the unit interval.
 * `TauCeti.expFDeriv_apply_eq_integral`: the Fréchet derivative is the corresponding Duhamel
@@ -64,7 +65,7 @@ private theorem hasDerivAt_exp_smul_mul_exp_smul (x h : A) (t : ℝ) :
 /-- The three-factor exponential integrand underlying Duhamel's formulas is interval integrable. -/
 theorem intervalIntegrable_exp_smul_mul_mul_exp_smul (x y z : A) :
     IntervalIntegrable
-      (fun t : ℝ ↦ exp ((1 - t) • y) * z * exp (t • x)) volume 0 1 :=
+      (fun t : ℝ ↦ exp ((1 - t) • x) * y * exp (t • z)) volume 0 1 :=
   Continuous.intervalIntegrable (μ := volume) (by fun_prop) 0 1
 
 /-- Duhamel's exact finite-increment formula for the exponential in a possibly noncommutative real
@@ -78,7 +79,7 @@ theorem exp_add_sub_exp_eq_integral (x h : A) :
     intro t _ht
     exact hasDerivAt_exp_smul_mul_exp_smul x h t
   have hint : IntervalIntegrable F' volume (0 : ℝ) 1 := by
-    exact (intervalIntegrable_exp_smul_mul_mul_exp_smul x (x + h) h).neg
+    exact (intervalIntegrable_exp_smul_mul_mul_exp_smul (x + h) h x).neg
   have hFTC := intervalIntegral.integral_eq_sub_of_hasDerivAt hderiv hint
   dsimp only [F, F'] at hFTC
   simp only [one_smul, sub_self, sub_zero, zero_smul, exp_zero, mul_one, one_mul,

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -7,8 +7,6 @@ module
 public import Mathlib.Analysis.SpecialFunctions.Exponential
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.Analysis.Calculus.Deriv.Shift
-import Mathlib.Analysis.Calculus.Deriv.Slope
-import Mathlib.MeasureTheory.Integral.DominatedConvergence
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import TauCeti.Analysis.Normed.Algebra.Basic
 
@@ -63,10 +61,10 @@ private theorem hasDerivAt_exp_smul_mul_exp_smul (x h : A) (t : ℝ) :
     hasDerivAt_exp_smul_const' x t
   exact (hleft.fun_mul hright).congr_deriv (by noncomm_ring)
 
-/-- The integrand in Duhamel's finite-increment formula is interval integrable. -/
-theorem intervalIntegrable_exp_smul_mul_mul_exp_smul (x h : A) :
+/-- The three-factor exponential integrand underlying Duhamel's formulas is interval integrable. -/
+theorem intervalIntegrable_exp_smul_mul_mul_exp_smul (x y z : A) :
     IntervalIntegrable
-      (fun t : ℝ ↦ exp ((1 - t) • (x + h)) * h * exp (t • x)) volume 0 1 :=
+      (fun t : ℝ ↦ exp ((1 - t) • y) * z * exp (t • x)) volume 0 1 :=
   Continuous.intervalIntegrable (μ := volume) (by fun_prop) 0 1
 
 /-- Duhamel's exact finite-increment formula for the exponential in a possibly noncommutative real
@@ -80,7 +78,7 @@ theorem exp_add_sub_exp_eq_integral (x h : A) :
     intro t _ht
     exact hasDerivAt_exp_smul_mul_exp_smul x h t
   have hint : IntervalIntegrable F' volume (0 : ℝ) 1 := by
-    exact (intervalIntegrable_exp_smul_mul_mul_exp_smul x h).neg
+    exact (intervalIntegrable_exp_smul_mul_mul_exp_smul x (x + h) h).neg
   have hFTC := intervalIntegral.integral_eq_sub_of_hasDerivAt hderiv hint
   dsimp only [F, F'] at hFTC
   simp only [one_smul, sub_self, sub_zero, zero_smul, exp_zero, mul_one, one_mul,
@@ -315,15 +313,13 @@ section IntegralFormula
 
 variable {A : Type*} [NormedRing A] [NormedAlgebra ℝ A] [CompleteSpace A]
 
-/-- A real normed algebra regarded as a rational normed algebra within this section. -/
-noncomputable local instance normedAlgebraRatOfRealDerivativeIntegral : NormedAlgebra ℚ A :=
-  .restrictScalars ℚ ℝ A
+attribute [local instance] TauCeti.normedAlgebraRatOfReal
 
 private noncomputable def expDerivativeIntegral (x y : A) (s : ℝ) : A :=
   ∫ t in (0 : ℝ)..1, exp ((1 - t) • (x + s • y)) * y * exp (t • x)
 
-private theorem continuousAt_expDerivativeIntegral (x y : A) :
-    ContinuousAt (expDerivativeIntegral x y) 0 := by
+private theorem continuous_expDerivativeIntegral (x y : A) :
+    Continuous (expDerivativeIntegral x y) := by
   let H : ℝ × ℝ → A := fun p ↦
     exp ((1 - p.2) • (x + p.1 • y)) * y * exp (p.2 • x)
   have hH : Continuous H := by
@@ -335,7 +331,7 @@ private theorem continuousAt_expDerivativeIntegral (x y : A) :
       (f := fun s t ↦ H (s, t)) hH isCompact_Icc
   unfold expDerivativeIntegral
   simpa only [intervalIntegral.integral_of_le zero_le_one,
-    ← integral_Icc_eq_integral_Ioc, H] using hcontinuous.continuousAt
+    ← integral_Icc_eq_integral_Ioc, H] using hcontinuous
 
 private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
     HasDerivAt (fun s : ℝ ↦ exp (x + s • y)) (expDerivativeIntegral x y 0) 0 := by
@@ -343,7 +339,7 @@ private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
   have hG : Filter.Tendsto (expDerivativeIntegral x y)
       (nhdsWithin (0 : ℝ) ({0} : Set ℝ)ᶜ)
       (nhds (expDerivativeIntegral x y 0)) :=
-    (continuousAt_expDerivativeIntegral x y).tendsto.mono_left inf_le_left
+    (continuous_expDerivativeIntegral x y).continuousAt.tendsto.mono_left inf_le_left
   apply hG.congr'
   filter_upwards [self_mem_nhdsWithin] with s hs
   have hs0 : s ≠ 0 := hs
@@ -354,16 +350,11 @@ private theorem hasDerivAt_exp_add_smul_integral (x y : A) :
     rw [expDerivativeIntegral, ← intervalIntegral.integral_smul]
     apply intervalIntegral.integral_congr
     intro t _ht
-    -- Expose the integral's integrand so the scalar can be moved through both multiplications.
-    change exp ((1 - t) • (x + s • y)) * (s • y) * exp (t • x) =
-      s • (exp ((1 - t) • (x + s • y)) * y * exp (t • x))
-    rw [Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
+    simp only [Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
   rw [slope, sub_zero, zero_smul, add_zero, vsub_eq_sub, hduhamel, hintegral,
     inv_smul_smul₀ hs0]
 
-/-- The Fréchet derivative of the noncommutative exponential, applied to `y`, is its Duhamel
-integral. -/
-theorem expFDeriv_apply_eq_integral (x y : A) :
+private theorem expFDeriv_real_apply_eq_integral (x y : A) :
     expFDeriv ℝ x y =
       ∫ t in (0 : ℝ)..1, exp ((1 - t) • x) * y * exp (t • x) := by
   have hline : HasDerivAt (fun s : ℝ ↦ x + s • y) y 0 := by
@@ -373,6 +364,23 @@ theorem expFDeriv_apply_eq_integral (x y : A) :
       (hasFDerivAt_exp (𝕂 := ℝ) x).comp_hasDerivAt_of_eq 0 hline (by simp)
   simpa only [expDerivativeIntegral, zero_smul, add_zero] using
     hseries.unique (hasDerivAt_exp_add_smul_integral x y)
+
+/-- The Fréchet derivative of the noncommutative exponential, applied to `y`, is its Duhamel
+integral. -/
+theorem expFDeriv_apply_eq_integral {𝕂 : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
+    [ContinuousSMul ℚ 𝕂] [NormedAlgebra ℝ 𝕂] [NormedAlgebra 𝕂 A]
+    [IsScalarTower ℝ 𝕂 A] (x y : A) :
+    expFDeriv 𝕂 x y =
+      ∫ t in (0 : ℝ)..1, exp ((1 - t) • x) * y * exp (t • x) := by
+  have hscalar :
+      (expFDeriv 𝕂 x).restrictScalars ℝ = expFDeriv ℝ x :=
+    ((hasFDerivAt_exp (𝕂 := 𝕂) x).restrictScalars ℝ).unique
+      (hasFDerivAt_exp (𝕂 := ℝ) x)
+  calc
+    expFDeriv 𝕂 x y = expFDeriv ℝ x y := by
+      simpa using congrArg (fun f : A →L[ℝ] A ↦ f y) hscalar
+    _ = ∫ t in (0 : ℝ)..1, exp ((1 - t) • x) * y * exp (t • x) :=
+      expFDeriv_real_apply_eq_integral x y
 
 end IntegralFormula
 

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -13,17 +13,19 @@ public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import TauCeti.Analysis.Normed.Algebra.Basic
 
 /-!
-# Duhamel's formula for the Banach-algebra exponential
+# Duhamel formulas for the Banach-algebra exponential
 
 This file expresses a finite increment of the exponential in a possibly noncommutative real
 Banach algebra as an integral. Unlike a first-order derivative formula, the identity is exact for
-every increment.
+every increment. It also derives the corresponding integral formula for the Fréchet derivative.
 
-## Main result
+## Main results
 
 * `intervalIntegrable_exp_smul_mul_mul_exp_smul`: the Duhamel integrand is interval integrable.
 * `exp_add_sub_exp_eq_integral`: `exp (x + h) - exp x` is the integral of
   `exp ((1 - t) (x + h)) * h * exp (t x)` over the unit interval.
+* `TauCeti.expFDeriv_apply_eq_integral`: the Fréchet derivative is the corresponding Duhamel
+  integral linear in the increment.
 
 ## References
 


### PR DESCRIPTION
## Goal

Supply the Banach-algebra shadow of the Layer 1 exponential-derivative formula by identifying the constructed Fréchet derivative of exp with its Duhamel integral, over every compatible scalar field.

## Why this proves the formula

Duhamel's exact finite-increment identity rewrites every nonzero real difference quotient as an integral. Continuity of the parameterized integrand gives the slope limit at zero, and uniqueness identifies that limit with expFDeriv ℝ x y. For a compatible scalar field 𝕂, uniqueness after restricting the 𝕂-derivative to real scalars identifies expFDeriv 𝕂 x y with the same integral.

The supporting interval-integrability lemma exposes independent left exponent, middle factor, and right exponent inputs for downstream integral manipulations.

## Verification

- bash scripts/sandbox-build.sh
- git diff --check

This advances TauCetiRoadmap/RepresentationTheory/LieGroups/README.md, Deliverable A, Layer 1, “The conjugation formulas,” specifically its Banach-algebra shadow.

Roadmap: RepresentationTheory