### PR TITLE
refactor(Matrix): lift the triangular diagonal-product lemma out of Borel

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Borel.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.RootSpace
+public import TauCeti.LinearAlgebra.Matrix.Triangular
 public import Mathlib.LinearAlgebra.Matrix.Block
 
 /-!
@@ -43,8 +44,6 @@ triangular matrices are a Lie ideal of the Borel subalgebra,
 
 ## Main results
 
-* `TauCeti.mul_apply_diag_of_mem_upperTriangular`: the diagonal of a product of upper triangular
-  matrices is the pointwise product of the diagonals.
 * `TauCeti.lie_mem_strictUpperTriangular`: the bracket of two upper triangular matrices is strictly
   upper triangular.
 * `TauCeti.upperTriangular_toSubmodule_eq_sup` and
@@ -158,18 +157,6 @@ theorem mul_mem_upperTriangular {A B : Matrix n n R} (hA : A ∈ upperTriangular
     ((mem_upperTriangular_iff_blockTriangular.mp hA).mul
       (mem_upperTriangular_iff_blockTriangular.mp hB))
 
-/-- The diagonal of a product of upper triangular matrices is the pointwise product of the
-diagonals. -/
-theorem mul_apply_diag_of_mem_upperTriangular {A B : Matrix n n R} (hA : A ∈ upperTriangular R n)
-    (hB : B ∈ upperTriangular R n) (i : n) : (A * B) i i = A i i * B i i := by
-  -- the only surviving term of `∑ k, A i k * B k i` is the one with `k = i`
-  rw [Matrix.mul_apply, Finset.sum_eq_single i]
-  · intro k _ hk
-    rcases lt_or_gt_of_ne hk with h | h
-    · rw [hA h, zero_mul]
-    · rw [hB h, mul_zero]
-  · exact fun h => absurd (Finset.mem_univ i) h
-
 /-- The bracket of two upper triangular matrices vanishes on and below the diagonal. -/
 theorem lie_apply_eq_zero_of_mem_upperTriangular {A B : Matrix n n R}
     (hA : A ∈ upperTriangular R n) (hB : B ∈ upperTriangular R n) {i j : n} (hij : j ≤ i) :
@@ -180,8 +167,8 @@ theorem lie_apply_eq_zero_of_mem_upperTriangular {A B : Matrix n n R}
     rw [mem_upperTriangular_iff.mp (mul_mem_upperTriangular hA hB) _ _ h,
       mem_upperTriangular_iff.mp (mul_mem_upperTriangular hB hA) _ _ h, sub_zero]
   · -- on the diagonal the two products agree, by commutativity of `R`
-    rw [mul_apply_diag_of_mem_upperTriangular hA hB,
-      mul_apply_diag_of_mem_upperTriangular hB hA, mul_comm, sub_self]
+    rw [Matrix.mul_apply_diag_of_isUpperTriangular hA hB,
+      Matrix.mul_apply_diag_of_isUpperTriangular hB hA, mul_comm, sub_self]
 
 variable (R n)
 
@@ -229,7 +216,7 @@ theorem mul_mem_strictUpperTriangular {A B : Matrix n n R}
   intro i j hij
   rcases hij.lt_or_eq with h | rfl
   · exact mem_upperTriangular_iff.mp (mul_mem_upperTriangular hA' hB') _ _ h
-  · rw [mul_apply_diag_of_mem_upperTriangular hA' hB',
+  · rw [Matrix.mul_apply_diag_of_isUpperTriangular hA' hB',
       apply_diag_eq_zero_of_mem_strictUpperTriangular hA, zero_mul]
 
 /-- **The bracket of two upper triangular matrices is strictly upper triangular.** So the derived

--- a/TauCeti/Algebra/Lie/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Borel.lean
@@ -6,7 +6,6 @@ module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.RootSpace
 public import TauCeti.LinearAlgebra.Matrix.Triangular
-public import Mathlib.LinearAlgebra.Matrix.Block
 
 /-!
 # The standard Borel subalgebra of `gl n R` and its positive nilpotent ideal
@@ -167,8 +166,10 @@ theorem lie_apply_eq_zero_of_mem_upperTriangular {A B : Matrix n n R}
     rw [mem_upperTriangular_iff.mp (mul_mem_upperTriangular hA hB) _ _ h,
       mem_upperTriangular_iff.mp (mul_mem_upperTriangular hB hA) _ _ h, sub_zero]
   · -- on the diagonal the two products agree, by commutativity of `R`
-    rw [Matrix.mul_apply_diag_of_isUpperTriangular hA hB,
-      Matrix.mul_apply_diag_of_isUpperTriangular hB hA, mul_comm, sub_self]
+    have hA' := mem_upperTriangular_iff_blockTriangular.mp hA
+    have hB' := mem_upperTriangular_iff_blockTriangular.mp hB
+    rw [Matrix.mul_apply_diag_of_isUpperTriangular hA' hB',
+      Matrix.mul_apply_diag_of_isUpperTriangular hB' hA', mul_comm, sub_self]
 
 variable (R n)
 
@@ -216,7 +217,9 @@ theorem mul_mem_strictUpperTriangular {A B : Matrix n n R}
   intro i j hij
   rcases hij.lt_or_eq with h | rfl
   · exact mem_upperTriangular_iff.mp (mul_mem_upperTriangular hA' hB') _ _ h
-  · rw [Matrix.mul_apply_diag_of_isUpperTriangular hA' hB',
+  · rw [Matrix.mul_apply_diag_of_isUpperTriangular
+        (mem_upperTriangular_iff_blockTriangular.mp hA')
+        (mem_upperTriangular_iff_blockTriangular.mp hB'),
       apply_diag_eq_zero_of_mem_strictUpperTriangular hA, zero_mul]
 
 /-- **The bracket of two upper triangular matrices is strictly upper triangular.** So the derived

--- a/TauCeti/LinearAlgebra/Matrix/Triangular.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Triangular.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.Block
+
+/-!
+# Diagonal entries of triangular matrices
+
+Mathlib's `Matrix.BlockTriangular` API computes determinants and inverses of triangular
+matrices, but not their individual diagonal entries. This file supplies the one fact that
+consumers keep needing: on the diagonal, a product of upper-triangular matrices multiplies
+entrywise, because `∑ k, A i k * B k i` has a single surviving term.
+
+The result previously lived in `TauCeti.Algebra.Lie.GeneralLinear.Borel`, phrased through
+membership in the Borel subalgebra. It is a statement about matrices with no Lie theory in it,
+so it is stated here for `Matrix.IsUpperTriangular` and consumed there; that also lets modules
+which have no business importing Lie-algebra theory use it.
+
+## Main results
+
+* `Matrix.mul_apply_diag_of_isUpperTriangular` — the diagonal of a product of upper-triangular
+  matrices is the pointwise product of the diagonals.
+-/
+
+public section
+
+namespace Matrix
+
+variable {R : Type*} [NonUnitalNonAssocSemiring R] {n : Type*} [Fintype n] [LinearOrder n]
+  {A B : Matrix n n R}
+
+/-- The diagonal of a product of upper-triangular matrices is the pointwise product of the
+diagonals. -/
+theorem mul_apply_diag_of_isUpperTriangular (hA : A.IsUpperTriangular)
+    (hB : B.IsUpperTriangular) (i : n) : (A * B) i i = A i i * B i i := by
+  -- the only surviving term of `∑ k, A i k * B k i` is the one with `k = i`
+  rw [Matrix.mul_apply, Finset.sum_eq_single i]
+  · intro k _ hk
+    rcases lt_or_gt_of_ne hk with h | h
+    · rw [hA h, zero_mul]
+    · rw [hB h, mul_zero]
+  · exact fun h ↦ absurd (Finset.mem_univ i) h
+
+end Matrix


### PR DESCRIPTION
`mul_apply_diag_of_mem_upperTriangular` — the diagonal of a product of upper-triangular
matrices is the pointwise product of the diagonals — is a statement about matrices with no Lie
theory in it, but it lived in `TauCeti/Algebra/Lie/GeneralLinear/Borel.lean`, phrased through
membership in the Borel subalgebra. Any module wanting that fact about `∑ k, A i k * B k i` had
to import Lie-algebra theory to get it.

It moves to a new `TauCeti/LinearAlgebra/Matrix/Triangular.lean`, restated for Mathlib's
`Matrix.IsUpperTriangular`. `Borel.lean` consumes it there: its three call sites pass the
membership hypotheses unchanged, because membership is `Iff.rfl` to `BlockTriangular id`
(`mem_upperTriangular_iff_blockTriangular`). The Borel copy is deleted rather than aliased, per
the no-compatibility-shim rule, and its "Main results" entry with it.

The relocated statement also drops `[DecidableEq n]`: neither `Matrix.mul_apply` nor
`Finset.sum_eq_single` needs it, and Lean's `unusedDecidableInType` linter flags it.

No mathematical content changes — the proof is moved verbatim, comment included.

## Why now

Surfaced by a `reuse` finding on #2596, which needs this same fact for a Hecke-ring file. The
reviewer's suggested fix was "delete the duplicate and reuse the existing theorem, or, if
importing Borel is inappropriate, move the existing generic result to a shared matrix module and
make both consumers use it". Importing `Algebra.Lie.GeneralLinear.RootSpace` into
`NumberTheory/HeckeRing/GLn/` to obtain a two-line matrix lemma is the wrong dependency, so this
is the second option. #2596 then consumes it and drops its own copy.

Shipped separately from #2596 because it is a prerequisite refactor of existing code, and this
repo takes one topic per PR.

Roadmap: none
