### PR TITLE
feat(EllipticCurve): the node polynomial and its splitting criteria

### DIFF
--- a/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
@@ -54,6 +54,15 @@ the degree is exactly two.
 
 public section
 
+/-- In characteristic two the discriminant degenerates to `b²`, since `4 = 0` kills the `a c`
+term. This is why `splits_quadratic_iff_isSquare` says nothing there: `discrim a b c` is
+automatically a square. -/
+theorem discrim_eq_sq_of_two_eq_zero {k : Type*} [Field k] (h2 : (2 : k) = 0) (a b c : k) :
+    discrim a b c = b ^ 2 := by
+  have h4 : (4 : k) = 0 := by linear_combination (2 : k) * h2
+  rw [discrim]
+  linear_combination -(a * c) * h4
+
 namespace Polynomial
 
 /-- The derivative of the quadratic `a X² + b X + c` is `2 a X + b`. -/
@@ -134,15 +143,6 @@ theorem splits_quadratic_iff_isSquare {k : Type*} [Field k] [NeZero (2 : k)] {a 
   · rintro ⟨s, hs⟩
     obtain ⟨x, hx⟩ := exists_quadratic_eq_zero ha ⟨s, by rw [hs]⟩
     exact ⟨x, by linear_combination hx⟩
-
-/-- In characteristic two the discriminant degenerates to `b²`, since `4 = 0` kills the `a c`
-term. This is why `splits_quadratic_iff_isSquare` says nothing there: `discrim a b c` is
-automatically a square. -/
-theorem discrim_eq_sq_of_two_eq_zero {k : Type*} [Field k] (h2 : (2 : k) = 0) (a b c : k) :
-    discrim a b c = b ^ 2 := by
-  have h4 : (4 : k) = 0 := by linear_combination (2 : k) * h2
-  rw [discrim]
-  linear_combination -(a * c) * h4
 
 /-- Over a field of characteristic `2`, a quadratic `a X² + b X + c` with `a, b ≠ 0` splits
 exactly when its Artin-Schreier invariant `a c / b²` lies in the image of `z ↦ z² + z`, written

--- a/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
@@ -12,25 +12,26 @@ public import Mathlib.FieldTheory.Separable
 
 Mathlib's `Mathlib/Algebra/QuadraticDiscriminant.lean` works with the *equation*
 `a x² + b x + c = 0` and relates its solutions to `discrim a b c = b² - 4 a c`. This file reads
-those facts back as statements about the *polynomial* `C a * X ^ 2 + C b * X + C c`. Every
-statement below is phrased in terms of Mathlib's `discrim` rather than its expansion, so that
-Mathlib's discriminant API applies to them directly.
+those facts back as statements about the *polynomial* `C a * X ^ 2 + C b * X + C c`. Wherever a
+statement mentions the discriminant it uses Mathlib's `discrim` rather than its expansion, so
+that Mathlib's discriminant API applies to it directly; the two criteria phrased by a root or by
+an Artin-Schreier condition mention no discriminant at all.
 
 Over a field, with `a ≠ 0`:
 
-* `Polynomial.separable_quadratic_iff`: separable exactly when `discrim a b c ≠ 0`;
+* `Polynomial.separable_quadratic_iff_discrim_ne_zero`: separable exactly when `discrim a b c ≠ 0`;
 * `Polynomial.splits_quadratic_iff_exists_root`: splits exactly when it has a root — the
   characteristic-free core, and the only one that mentions no discriminant;
-* `Polynomial.splits_quadratic_iff`: away from characteristic two, splits exactly when
+* `Polynomial.splits_quadratic_iff_isSquare`: away from characteristic two, splits exactly when
   `discrim a b c` is a square;
 * `Polynomial.splits_quadratic_iff_of_two_eq_zero`: in characteristic two, where the discriminant
   degenerates to `b²` and the square-class criterion says nothing, splits exactly when the
   Artin-Schreier invariant `a c / b²` lies in the image of `z ↦ z² + z`, written division-free.
-  Here `b ≠ 0` is also required, which by `separable_quadratic_iff` is separability.
+  Here `b ≠ 0` is also required, which by `separable_quadratic_iff_discrim_ne_zero` is separability.
 
 Two auxiliary identities need neither a field nor `a ≠ 0`, and are stated over a commutative
 (semi)ring: `Polynomial.derivative_quadratic`, computing the derivative as `2 a X + b`, and the
-Bézout-type `Polynomial.sq_derivative_quadratic_sub_mul`,
+Bézout-type `Polynomial.sq_derivative_quadratic_sub_mul_eq_C_discrim`,
 `(P')² - 4 a P = C (discrim a b c)`, which is what exhibits a nonzero discriminant as a
 coprimality witness in every characteristic.
 
@@ -65,8 +66,9 @@ theorem derivative_quadratic {R : Type*} [CommSemiring R] (a b c : R) :
 
 /-- The Bézout-type identity `(P')² - 4 a · P = C (discrim a b c)` for the quadratic
 `P = a X² + b X + c`: the discriminant is an explicit `R[X]`-combination of `P` and its
-derivative, which is what makes it a coprimality witness in `separable_quadratic_iff`. -/
-theorem sq_derivative_quadratic_sub_mul {R : Type*} [CommRing R] (a b c : R) :
+derivative, which is what makes it a coprimality witness in
+`separable_quadratic_iff_discrim_ne_zero`. -/
+theorem sq_derivative_quadratic_sub_mul_eq_C_discrim {R : Type*} [CommRing R] (a b c : R) :
     derivative (C a * X ^ 2 + C b * X + C c) ^ 2
       - 4 * C a * (C a * X ^ 2 + C b * X + C c) = C (discrim a b c) := by
   rw [derivative_quadratic, discrim]
@@ -75,13 +77,13 @@ theorem sq_derivative_quadratic_sub_mul {R : Type*} [CommRing R] (a b c : R) :
 
 /-- A quadratic polynomial `a X² + b X + c` (with `a ≠ 0`) over a field is separable exactly when
 `discrim a b c` is nonzero. This holds in every characteristic; contrast
-`splits_quadratic_iff`, which asks for the discriminant to be a square rather than nonzero, and
-only away from characteristic two. -/
-theorem separable_quadratic_iff {k : Type*} [Field k] {a b c : k} (ha : a ≠ 0) :
+`splits_quadratic_iff_isSquare`, which asks for the discriminant to be a square rather than
+nonzero, and only away from characteristic two. -/
+theorem separable_quadratic_iff_discrim_ne_zero {k : Type*} [Field k] {a b c : k} (ha : a ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).Separable ↔ discrim a b c ≠ 0 := by
   set P := C a * X ^ 2 + C b * X + C c with hP
   have hid : derivative P ^ 2 - 4 * C a * P = C (discrim a b c) :=
-    sq_derivative_quadratic_sub_mul a b c
+    sq_derivative_quadratic_sub_mul_eq_C_discrim a b c
   constructor
   · intro hsep hdisc
     rw [hdisc, map_zero] at hid
@@ -117,9 +119,11 @@ theorem splits_quadratic_iff_exists_root {k : Type*} [Field k] {a b c : k} (ha :
     linear_combination hx
 
 /-- Over a field of characteristic `≠ 2`, a quadratic `a X² + b X + c` (with `a ≠ 0`) *splits*
-exactly when `discrim a b c` is a square. Compare `separable_quadratic_iff`, which asks for the
-discriminant to be nonzero rather than square, and holds in every characteristic. -/
-theorem splits_quadratic_iff {k : Type*} [Field k] [NeZero (2 : k)] {a b c : k} (ha : a ≠ 0) :
+exactly when `discrim a b c` is a square. Compare `separable_quadratic_iff_discrim_ne_zero`,
+which asks for the discriminant to be nonzero rather than square, and holds in every
+characteristic. -/
+theorem splits_quadratic_iff_isSquare {k : Type*} [Field k] [NeZero (2 : k)] {a b c : k}
+    (ha : a ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).Splits ↔ IsSquare (discrim a b c) := by
   rw [splits_quadratic_iff_exists_root ha]
   constructor
@@ -132,9 +136,10 @@ theorem splits_quadratic_iff {k : Type*} [Field k] [NeZero (2 : k)] {a b c : k} 
 
 /-- Over a field of characteristic `2`, a quadratic `a X² + b X + c` with `a, b ≠ 0` splits
 exactly when its Artin-Schreier invariant `a c / b²` lies in the image of `z ↦ z² + z`, written
-division-free as `∃ z, b² (z² + z) = a c`. Here the square-class criterion `splits_quadratic_iff`
-says nothing, since `discrim a b c = b²` is automatically a square; the hypothesis `b ≠ 0` is
-exactly separability, by `separable_quadratic_iff`. -/
+division-free as `∃ z, b² (z² + z) = a c`. Here the square-class criterion
+`splits_quadratic_iff_isSquare` says nothing, since `discrim a b c = b²` is automatically a
+square; the hypothesis `b ≠ 0` is
+exactly separability, by `separable_quadratic_iff_discrim_ne_zero`. -/
 theorem splits_quadratic_iff_of_two_eq_zero {k : Type*} [Field k] (h2 : (2 : k) = 0)
     {a b c : k} (ha : a ≠ 0) (hb : b ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).Splits ↔ ∃ z, b ^ 2 * (z ^ 2 + z) = a * c := by

--- a/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
@@ -24,8 +24,9 @@ Over a field, with `a ≠ 0`:
   characteristic-free core, and the only one that mentions no discriminant;
 * `Polynomial.splits_quadratic_iff_isSquare`: away from characteristic two, splits exactly when
   `discrim a b c` is a square;
-* `Polynomial.splits_quadratic_iff_of_two_eq_zero`: in characteristic two, where the discriminant
-  degenerates to `b²` and the square-class criterion says nothing, splits exactly when the
+* `Polynomial.splits_quadratic_iff_exists_artinSchreier_of_two_eq_zero`: in characteristic two,
+  where the discriminant degenerates to `b²` (`discrim_eq_sq_of_two_eq_zero`) and the square-class
+  criterion says nothing, splits exactly when the
   Artin-Schreier invariant `a c / b²` lies in the image of `z ↦ z² + z`, written division-free.
   Here `b ≠ 0` is also required, which by `separable_quadratic_iff_discrim_ne_zero` is separability.
 
@@ -55,9 +56,9 @@ public section
 
 namespace Polynomial
 
-/-- The derivative of the quadratic `a X² + b X + c` is `2 a X + b`. Deliberately not `@[simp]`:
-Mathlib's simp set already rewrites this left-hand side to `C a * ((1 + 1) * X) + C b`, so the
-lemma is not in simp normal form and `simpNF` rejects it. -/
+/-- The derivative of the quadratic `a X² + b X + c` is `2 a X + b`. -/
+-- Deliberately not `@[simp]`: Mathlib's simp set already rewrites this left-hand side to
+-- `C a * ((1 + 1) * X) + C b`, so the lemma is not in simp normal form and `simpNF` rejects it.
 theorem derivative_quadratic {R : Type*} [CommSemiring R] (a b c : R) :
     derivative (C a * X ^ 2 + C b * X + C c) = 2 * C a * X + C b := by
   simp only [derivative_add, derivative_mul, derivative_C, derivative_X_pow, derivative_X,
@@ -134,14 +135,23 @@ theorem splits_quadratic_iff_isSquare {k : Type*} [Field k] [NeZero (2 : k)] {a 
     obtain ⟨x, hx⟩ := exists_quadratic_eq_zero ha ⟨s, by rw [hs]⟩
     exact ⟨x, by linear_combination hx⟩
 
+/-- In characteristic two the discriminant degenerates to `b²`, since `4 = 0` kills the `a c`
+term. This is why `splits_quadratic_iff_isSquare` says nothing there: `discrim a b c` is
+automatically a square. -/
+theorem discrim_eq_sq_of_two_eq_zero {k : Type*} [Field k] (h2 : (2 : k) = 0) (a b c : k) :
+    discrim a b c = b ^ 2 := by
+  have h4 : (4 : k) = 0 := by linear_combination (2 : k) * h2
+  rw [discrim]
+  linear_combination -(a * c) * h4
+
 /-- Over a field of characteristic `2`, a quadratic `a X² + b X + c` with `a, b ≠ 0` splits
 exactly when its Artin-Schreier invariant `a c / b²` lies in the image of `z ↦ z² + z`, written
 division-free as `∃ z, b² (z² + z) = a c`. Here the square-class criterion
 `splits_quadratic_iff_isSquare` says nothing, since `discrim a b c = b²` is automatically a
 square; the hypothesis `b ≠ 0` is
 exactly separability, by `separable_quadratic_iff_discrim_ne_zero`. -/
-theorem splits_quadratic_iff_of_two_eq_zero {k : Type*} [Field k] (h2 : (2 : k) = 0)
-    {a b c : k} (ha : a ≠ 0) (hb : b ≠ 0) :
+theorem splits_quadratic_iff_exists_artinSchreier_of_two_eq_zero {k : Type*} [Field k]
+    (h2 : (2 : k) = 0) {a b c : k} (ha : a ≠ 0) (hb : b ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).Splits ↔ ∃ z, b ^ 2 * (z ^ 2 + z) = a * c := by
   rw [splits_quadratic_iff_exists_root ha]
   constructor

--- a/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
@@ -57,9 +57,9 @@ public section
 /-- In characteristic two the discriminant degenerates to `b²`, since `4 = 0` kills the `a c`
 term. This is why `splits_quadratic_iff_isSquare` says nothing there: `discrim a b c` is
 automatically a square. -/
-theorem discrim_eq_sq_of_two_eq_zero {k : Type*} [Field k] (h2 : (2 : k) = 0) (a b c : k) :
+theorem discrim_eq_sq_of_two_eq_zero {R : Type*} [CommRing R] (h2 : (2 : R) = 0) (a b c : R) :
     discrim a b c = b ^ 2 := by
-  have h4 : (4 : k) = 0 := by linear_combination (2 : k) * h2
+  have h4 : (4 : R) = 0 := by linear_combination (2 : R) * h2
   rw [discrim]
   linear_combination -(a * c) * h4
 
@@ -116,12 +116,9 @@ theorem splits_quadratic_iff_exists_root {k : Type*} [Field k] {a b c : k} (ha :
     (C a * X ^ 2 + C b * X + C c).Splits ↔ ∃ x, a * x ^ 2 + b * x + c = 0 := by
   set p := C a * X ^ 2 + C b * X + C c with hp
   have hdeg : p.natDegree = 2 := natDegree_quadratic ha
-  have hp0 : p ≠ 0 := fun h ↦ by rw [h, natDegree_zero] at hdeg; omega
   constructor
   · intro hs
-    obtain ⟨x, hx⟩ := hs.exists_eval_eq_zero (by
-      simp only [degree_eq_natDegree hp0, hdeg, ne_eq, Nat.cast_ofNat, OfNat.ofNat_ne_zero,
-        not_false_eq_true])
+    obtain ⟨x, hx⟩ := hs.exists_eval_eq_zero (degree_ne_of_natDegree_ne (by rw [hdeg]; norm_num))
     refine ⟨x, ?_⟩
     simp only [hp, eval_add, eval_mul, eval_pow, eval_C, eval_X] at hx
     linear_combination hx

--- a/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.QuadraticDiscriminant
+public import Mathlib.FieldTheory.Separable
+
+/-!
+# Separability and splitting criteria for quadratic polynomials
+
+Mathlib's `Mathlib/Algebra/QuadraticDiscriminant.lean` works with the *equation*
+`a x² + b x + c = 0` and relates its solutions to the discriminant `b² - 4 a c`. This file reads
+those facts back as statements about the *polynomial* `C a * X ^ 2 + C b * X + C c` over a field,
+where `a ≠ 0`:
+
+* `Polynomial.separable_quadratic_iff`: it is separable exactly when the discriminant is nonzero.
+  The engine is the Bézout-type identity `Polynomial.sq_derivative_quadratic_sub_mul`,
+  `(P')² - 4 a P = C (b² - 4 a c)`, which exhibits a nonzero discriminant as a coprimality witness
+  in every characteristic;
+* `Polynomial.splits_quadratic_iff_exists_root`: it splits exactly when it has a root — the
+  characteristic-free core, and the only one of the three that says nothing about the
+  discriminant. Both directions are Mathlib's `Splits.exists_eval_eq_zero` and
+  `Splits.of_natDegree_eq_two`;
+* `Polynomial.splits_quadratic_iff`: away from characteristic two, it splits exactly when the
+  discriminant is a square;
+* `Polynomial.splits_quadratic_iff_of_two_eq_zero`: in characteristic two, where the discriminant
+  degenerates to `b²` and the square-class criterion says nothing, it splits exactly when the
+  Artin-Schreier invariant `a c / b²` lies in the image of `z ↦ z² + z`, written division-free.
+
+The two splitting criteria are consumed by the node-polynomial criteria of
+`TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean`, which advance
+`TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists): whether the node polynomial of a
+multiplicative reduction splits over the residue field is exactly whether that reduction is split.
+
+Adapted from the FLT project (`ImperialCollegeLondon/FLT`,
+`FLT/Mathlib/Algebra/Polynomial/QuadraticDiscriminant.lean` at the roadmap's pin `bc2fe8ff7396`,
+FLT PR #1088, Apache 2.0). That file's own header reads `Authors: Kevin Buzzard, Claude`;
+following this repository's convention for adapted material, the upstream authorship is credited
+here rather than in the copyright header. Ported with the source's `@[expose]` dropped, and
+without its companion `FLT/Mathlib/Algebra/Polynomial/Splits.lean`: that file's
+`Splits.of_natDegree_le_two_of_isRoot` is superseded here by Mathlib's own
+`Polynomial.Splits.of_natDegree_eq_two`, which the one consumer can use directly since it knows
+the degree is exactly two.
+-/
+
+public section
+
+namespace Polynomial
+
+/-- The derivative of the quadratic `a X² + b X + c` is `2 a X + b`. -/
+theorem derivative_quadratic {R : Type*} [CommSemiring R] (a b c : R) :
+    derivative (C a * X ^ 2 + C b * X + C c) = 2 * C a * X + C b := by
+  simp only [derivative_add, derivative_mul, derivative_C, derivative_X_pow, derivative_X,
+    zero_mul, zero_add, mul_one, add_zero, Nat.cast_ofNat, Nat.reduceSub, pow_one, map_ofNat]
+  ring
+
+/-- The Bézout-type identity `(P')² - 4 a · P = C (b² - 4 a c)` for the quadratic
+`P = a X² + b X + c`: the discriminant is an explicit `R[X]`-combination of `P` and its
+derivative, which is what makes it a coprimality witness in `separable_quadratic_iff`. -/
+theorem sq_derivative_quadratic_sub_mul {R : Type*} [CommRing R] (a b c : R) :
+    derivative (C a * X ^ 2 + C b * X + C c) ^ 2
+      - 4 * C a * (C a * X ^ 2 + C b * X + C c) = C (b ^ 2 - 4 * a * c) := by
+  rw [derivative_quadratic]
+  simp only [map_sub, map_mul, map_pow, map_ofNat]
+  ring
+
+/-- A quadratic polynomial `a X² + b X + c` (with `a ≠ 0`) over a field is separable exactly when
+its discriminant `b² - 4 a c` is nonzero. The `←` direction holds in every characteristic: by the
+Bézout identity `sq_derivative_quadratic_sub_mul`, a nonzero — hence invertible — discriminant
+exhibits `P` and `P'` as coprime. The `→` direction argues that if the discriminant vanishes then
+`P ∣ (P')²`, forcing the coprimality witness `P` to be a unit, contradicting `deg P = 2`. -/
+theorem separable_quadratic_iff {k : Type*} [Field k] {a b c : k} (ha : a ≠ 0) :
+    (C a * X ^ 2 + C b * X + C c).Separable ↔ b ^ 2 - 4 * a * c ≠ 0 := by
+  set P := C a * X ^ 2 + C b * X + C c with hP
+  have hid : derivative P ^ 2 - 4 * C a * P = C (b ^ 2 - 4 * a * c) :=
+    sq_derivative_quadratic_sub_mul a b c
+  constructor
+  · intro hsep hdisc
+    rw [hdisc, map_zero] at hid
+    have hdvd : P ∣ derivative P ^ 2 := ⟨4 * C a, by linear_combination hid⟩
+    exact not_isUnit_of_natDegree_pos P (by rw [hP, natDegree_quadratic ha]; norm_num)
+      (((separable_def P).mp hsep).pow_right.isUnit_of_dvd' dvd_rfl hdvd)
+  · intro hdisc
+    rw [separable_def]
+    have hdinv : C (b ^ 2 - 4 * a * c)⁻¹ * C (b ^ 2 - 4 * a * c) = 1 := by
+      rw [← C_mul, inv_mul_cancel₀ hdisc, C_1]
+    exact ⟨-(C (b ^ 2 - 4 * a * c)⁻¹ * 4 * C a), C (b ^ 2 - 4 * a * c)⁻¹ * derivative P,
+      by linear_combination C (b ^ 2 - 4 * a * c)⁻¹ * hid + hdinv⟩
+
+/-- A quadratic `a X² + b X + c` (`a ≠ 0`) over a field splits exactly when it has a root. Both
+directions are Mathlib's: `Splits.exists_eval_eq_zero` extracts a root from a splitting of
+positive degree, and `Splits.of_natDegree_eq_two` builds the splitting back from one. This is the
+characteristic-free core of the two split criteria below, neither of which adds anything beyond
+restating "has a root" in terms of the discriminant. -/
+theorem splits_quadratic_iff_exists_root {k : Type*} [Field k] {a b c : k} (ha : a ≠ 0) :
+    (C a * X ^ 2 + C b * X + C c).Splits ↔ ∃ x, a * x ^ 2 + b * x + c = 0 := by
+  set p := C a * X ^ 2 + C b * X + C c with hp
+  have hdeg : p.natDegree = 2 := natDegree_quadratic ha
+  have hp0 : p ≠ 0 := fun h ↦ by rw [h, natDegree_zero] at hdeg; omega
+  constructor
+  · intro hs
+    obtain ⟨x, hx⟩ := hs.exists_eval_eq_zero (by
+      simp only [degree_eq_natDegree hp0, hdeg, ne_eq, Nat.cast_ofNat, OfNat.ofNat_ne_zero,
+        not_false_eq_true])
+    refine ⟨x, ?_⟩
+    simp only [hp, eval_add, eval_mul, eval_pow, eval_C, eval_X] at hx
+    linear_combination hx
+  · rintro ⟨x, hx⟩
+    refine Splits.of_natDegree_eq_two hdeg (x := x) ?_
+    simp only [hp, eval_add, eval_mul, eval_pow, eval_C, eval_X]
+    linear_combination hx
+
+/-- Over a field of characteristic `≠ 2`, a quadratic `a X² + b X + c` (with `a ≠ 0`) *splits*
+exactly when its discriminant `b² - 4 a c` is a square: it splits iff it has a root
+(`splits_quadratic_iff_exists_root`), and completing the square
+(`discrim_eq_sq_of_quadratic_eq_zero`, `exists_quadratic_eq_zero`) matches roots with square roots
+of the discriminant. Compare `separable_quadratic_iff`, which asks for the discriminant to be
+nonzero rather than square. -/
+theorem splits_quadratic_iff {k : Type*} [Field k] [NeZero (2 : k)] {a b c : k} (ha : a ≠ 0) :
+    (C a * X ^ 2 + C b * X + C c).Splits ↔ IsSquare (discrim a b c) := by
+  rw [splits_quadratic_iff_exists_root ha]
+  constructor
+  · rintro ⟨x, hx⟩
+    exact ⟨2 * a * x + b, by rw [discrim_eq_sq_of_quadratic_eq_zero (a := a) (b := b) (c := c)
+      (x := x) (by linear_combination hx)]; ring⟩
+  · rintro ⟨s, hs⟩
+    obtain ⟨x, hx⟩ := exists_quadratic_eq_zero ha ⟨s, by rw [hs]⟩
+    exact ⟨x, by linear_combination hx⟩
+
+/-- Over a field of characteristic `2`, a quadratic `a X² + b X + c` with `a, b ≠ 0` splits
+exactly when its Artin-Schreier invariant `a c / b²` lies in the image of `z ↦ z² + z`, written
+division-free as `∃ z, b² (z² + z) = a c`; substitute `z = a x / b` in a root `x`. Here the
+square-class criterion `splits_quadratic_iff` says nothing, since `b² - 4 a c = b²` is
+automatically a square; the hypothesis `b ≠ 0` is exactly separability, by
+`separable_quadratic_iff`. -/
+theorem splits_quadratic_iff_of_two_eq_zero {k : Type*} [Field k] (h2 : (2 : k) = 0)
+    {a b c : k} (ha : a ≠ 0) (hb : b ≠ 0) :
+    (C a * X ^ 2 + C b * X + C c).Splits ↔ ∃ z, b ^ 2 * (z ^ 2 + z) = a * c := by
+  rw [splits_quadratic_iff_exists_root ha]
+  constructor
+  · rintro ⟨x, hx⟩
+    refine ⟨a * x / b, ?_⟩
+    field_simp
+    linear_combination hx - c * h2
+  · rintro ⟨z, hz⟩
+    refine ⟨b * z / a, ?_⟩
+    field_simp
+    linear_combination hz + a * c * h2
+
+end Polynomial
+
+end

--- a/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
@@ -21,7 +21,7 @@ Over a field, with `a ≠ 0`:
 
 * `Polynomial.separable_quadratic_iff_discrim_ne_zero`: separable exactly when `discrim a b c ≠ 0`;
 * `Polynomial.splits_quadratic_iff_exists_root`: splits exactly when it has a root — the
-  characteristic-free core, and the only one that mentions no discriminant;
+  characteristic-free core the other two are read off from;
 * `Polynomial.splits_quadratic_iff_isSquare`: away from characteristic two, splits exactly when
   `discrim a b c` is a square;
 * `Polynomial.splits_quadratic_iff_exists_artinSchreier_of_two_eq_zero`: in characteristic two,
@@ -108,8 +108,10 @@ theorem separable_quadratic_iff_discrim_ne_zero {k : Type*} [Field k] {a b c : k
       by linear_combination C (discrim a b c)⁻¹ * hid + hdinv⟩
 
 /-- A quadratic `a X² + b X + c` (`a ≠ 0`) over a field splits exactly when it has a root. This is
-the characteristic-free core of the two split criteria below, neither of which adds anything
-beyond restating "has a root" in terms of the discriminant. -/
+the characteristic-free core of the two split criteria below, which only restate "has a root":
+`splits_quadratic_iff_isSquare` in terms of the discriminant, and
+`splits_quadratic_iff_exists_artinSchreier_of_two_eq_zero` in terms of the Artin-Schreier
+invariant `a c / b²`. -/
 theorem splits_quadratic_iff_exists_root {k : Type*} [Field k] {a b c : k} (ha : a ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).Splits ↔ ∃ x, a * x ^ 2 + b * x + c = 0 := by
   set p := C a * X ^ 2 + C b * X + C c with hp

--- a/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
@@ -11,23 +11,28 @@ public import Mathlib.FieldTheory.Separable
 # Separability and splitting criteria for quadratic polynomials
 
 Mathlib's `Mathlib/Algebra/QuadraticDiscriminant.lean` works with the *equation*
-`a x² + b x + c = 0` and relates its solutions to the discriminant `b² - 4 a c`. This file reads
-those facts back as statements about the *polynomial* `C a * X ^ 2 + C b * X + C c` over a field,
-where `a ≠ 0`:
+`a x² + b x + c = 0` and relates its solutions to `discrim a b c = b² - 4 a c`. This file reads
+those facts back as statements about the *polynomial* `C a * X ^ 2 + C b * X + C c`. Every
+statement below is phrased in terms of Mathlib's `discrim` rather than its expansion, so that
+Mathlib's discriminant API applies to them directly.
 
-* `Polynomial.separable_quadratic_iff`: it is separable exactly when the discriminant is nonzero.
-  The engine is the Bézout-type identity `Polynomial.sq_derivative_quadratic_sub_mul`,
-  `(P')² - 4 a P = C (b² - 4 a c)`, which exhibits a nonzero discriminant as a coprimality witness
-  in every characteristic;
-* `Polynomial.splits_quadratic_iff_exists_root`: it splits exactly when it has a root — the
-  characteristic-free core, and the only one of the three that says nothing about the
-  discriminant. Both directions are Mathlib's `Splits.exists_eval_eq_zero` and
-  `Splits.of_natDegree_eq_two`;
-* `Polynomial.splits_quadratic_iff`: away from characteristic two, it splits exactly when the
-  discriminant is a square;
+Over a field, with `a ≠ 0`:
+
+* `Polynomial.separable_quadratic_iff`: separable exactly when `discrim a b c ≠ 0`;
+* `Polynomial.splits_quadratic_iff_exists_root`: splits exactly when it has a root — the
+  characteristic-free core, and the only one that mentions no discriminant;
+* `Polynomial.splits_quadratic_iff`: away from characteristic two, splits exactly when
+  `discrim a b c` is a square;
 * `Polynomial.splits_quadratic_iff_of_two_eq_zero`: in characteristic two, where the discriminant
-  degenerates to `b²` and the square-class criterion says nothing, it splits exactly when the
+  degenerates to `b²` and the square-class criterion says nothing, splits exactly when the
   Artin-Schreier invariant `a c / b²` lies in the image of `z ↦ z² + z`, written division-free.
+  Here `b ≠ 0` is also required, which by `separable_quadratic_iff` is separability.
+
+Two auxiliary identities need neither a field nor `a ≠ 0`, and are stated over a commutative
+(semi)ring: `Polynomial.derivative_quadratic`, computing the derivative as `2 a X + b`, and the
+Bézout-type `Polynomial.sq_derivative_quadratic_sub_mul`,
+`(P')² - 4 a P = C (discrim a b c)`, which is what exhibits a nonzero discriminant as a
+coprimality witness in every characteristic.
 
 The two splitting criteria are consumed by the node-polynomial criteria of
 `TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean`, which advance
@@ -49,32 +54,33 @@ public section
 
 namespace Polynomial
 
-/-- The derivative of the quadratic `a X² + b X + c` is `2 a X + b`. -/
+/-- The derivative of the quadratic `a X² + b X + c` is `2 a X + b`. Deliberately not `@[simp]`:
+Mathlib's simp set already rewrites this left-hand side to `C a * ((1 + 1) * X) + C b`, so the
+lemma is not in simp normal form and `simpNF` rejects it. -/
 theorem derivative_quadratic {R : Type*} [CommSemiring R] (a b c : R) :
     derivative (C a * X ^ 2 + C b * X + C c) = 2 * C a * X + C b := by
   simp only [derivative_add, derivative_mul, derivative_C, derivative_X_pow, derivative_X,
     zero_mul, zero_add, mul_one, add_zero, Nat.cast_ofNat, Nat.reduceSub, pow_one, map_ofNat]
   ring
 
-/-- The Bézout-type identity `(P')² - 4 a · P = C (b² - 4 a c)` for the quadratic
+/-- The Bézout-type identity `(P')² - 4 a · P = C (discrim a b c)` for the quadratic
 `P = a X² + b X + c`: the discriminant is an explicit `R[X]`-combination of `P` and its
 derivative, which is what makes it a coprimality witness in `separable_quadratic_iff`. -/
 theorem sq_derivative_quadratic_sub_mul {R : Type*} [CommRing R] (a b c : R) :
     derivative (C a * X ^ 2 + C b * X + C c) ^ 2
-      - 4 * C a * (C a * X ^ 2 + C b * X + C c) = C (b ^ 2 - 4 * a * c) := by
-  rw [derivative_quadratic]
+      - 4 * C a * (C a * X ^ 2 + C b * X + C c) = C (discrim a b c) := by
+  rw [derivative_quadratic, discrim]
   simp only [map_sub, map_mul, map_pow, map_ofNat]
   ring
 
 /-- A quadratic polynomial `a X² + b X + c` (with `a ≠ 0`) over a field is separable exactly when
-its discriminant `b² - 4 a c` is nonzero. The `←` direction holds in every characteristic: by the
-Bézout identity `sq_derivative_quadratic_sub_mul`, a nonzero — hence invertible — discriminant
-exhibits `P` and `P'` as coprime. The `→` direction argues that if the discriminant vanishes then
-`P ∣ (P')²`, forcing the coprimality witness `P` to be a unit, contradicting `deg P = 2`. -/
+`discrim a b c` is nonzero. This holds in every characteristic; contrast
+`splits_quadratic_iff`, which asks for the discriminant to be a square rather than nonzero, and
+only away from characteristic two. -/
 theorem separable_quadratic_iff {k : Type*} [Field k] {a b c : k} (ha : a ≠ 0) :
-    (C a * X ^ 2 + C b * X + C c).Separable ↔ b ^ 2 - 4 * a * c ≠ 0 := by
+    (C a * X ^ 2 + C b * X + C c).Separable ↔ discrim a b c ≠ 0 := by
   set P := C a * X ^ 2 + C b * X + C c with hP
-  have hid : derivative P ^ 2 - 4 * C a * P = C (b ^ 2 - 4 * a * c) :=
+  have hid : derivative P ^ 2 - 4 * C a * P = C (discrim a b c) :=
     sq_derivative_quadratic_sub_mul a b c
   constructor
   · intro hsep hdisc
@@ -84,16 +90,14 @@ theorem separable_quadratic_iff {k : Type*} [Field k] {a b c : k} (ha : a ≠ 0)
       (((separable_def P).mp hsep).pow_right.isUnit_of_dvd' dvd_rfl hdvd)
   · intro hdisc
     rw [separable_def]
-    have hdinv : C (b ^ 2 - 4 * a * c)⁻¹ * C (b ^ 2 - 4 * a * c) = 1 := by
+    have hdinv : C (discrim a b c)⁻¹ * C (discrim a b c) = 1 := by
       rw [← C_mul, inv_mul_cancel₀ hdisc, C_1]
-    exact ⟨-(C (b ^ 2 - 4 * a * c)⁻¹ * 4 * C a), C (b ^ 2 - 4 * a * c)⁻¹ * derivative P,
-      by linear_combination C (b ^ 2 - 4 * a * c)⁻¹ * hid + hdinv⟩
+    exact ⟨-(C (discrim a b c)⁻¹ * 4 * C a), C (discrim a b c)⁻¹ * derivative P,
+      by linear_combination C (discrim a b c)⁻¹ * hid + hdinv⟩
 
-/-- A quadratic `a X² + b X + c` (`a ≠ 0`) over a field splits exactly when it has a root. Both
-directions are Mathlib's: `Splits.exists_eval_eq_zero` extracts a root from a splitting of
-positive degree, and `Splits.of_natDegree_eq_two` builds the splitting back from one. This is the
-characteristic-free core of the two split criteria below, neither of which adds anything beyond
-restating "has a root" in terms of the discriminant. -/
+/-- A quadratic `a X² + b X + c` (`a ≠ 0`) over a field splits exactly when it has a root. This is
+the characteristic-free core of the two split criteria below, neither of which adds anything
+beyond restating "has a root" in terms of the discriminant. -/
 theorem splits_quadratic_iff_exists_root {k : Type*} [Field k] {a b c : k} (ha : a ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).Splits ↔ ∃ x, a * x ^ 2 + b * x + c = 0 := by
   set p := C a * X ^ 2 + C b * X + C c with hp
@@ -113,11 +117,8 @@ theorem splits_quadratic_iff_exists_root {k : Type*} [Field k] {a b c : k} (ha :
     linear_combination hx
 
 /-- Over a field of characteristic `≠ 2`, a quadratic `a X² + b X + c` (with `a ≠ 0`) *splits*
-exactly when its discriminant `b² - 4 a c` is a square: it splits iff it has a root
-(`splits_quadratic_iff_exists_root`), and completing the square
-(`discrim_eq_sq_of_quadratic_eq_zero`, `exists_quadratic_eq_zero`) matches roots with square roots
-of the discriminant. Compare `separable_quadratic_iff`, which asks for the discriminant to be
-nonzero rather than square. -/
+exactly when `discrim a b c` is a square. Compare `separable_quadratic_iff`, which asks for the
+discriminant to be nonzero rather than square, and holds in every characteristic. -/
 theorem splits_quadratic_iff {k : Type*} [Field k] [NeZero (2 : k)] {a b c : k} (ha : a ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).Splits ↔ IsSquare (discrim a b c) := by
   rw [splits_quadratic_iff_exists_root ha]
@@ -131,10 +132,9 @@ theorem splits_quadratic_iff {k : Type*} [Field k] [NeZero (2 : k)] {a b c : k} 
 
 /-- Over a field of characteristic `2`, a quadratic `a X² + b X + c` with `a, b ≠ 0` splits
 exactly when its Artin-Schreier invariant `a c / b²` lies in the image of `z ↦ z² + z`, written
-division-free as `∃ z, b² (z² + z) = a c`; substitute `z = a x / b` in a root `x`. Here the
-square-class criterion `splits_quadratic_iff` says nothing, since `b² - 4 a c = b²` is
-automatically a square; the hypothesis `b ≠ 0` is exactly separability, by
-`separable_quadratic_iff`. -/
+division-free as `∃ z, b² (z² + z) = a c`. Here the square-class criterion `splits_quadratic_iff`
+says nothing, since `discrim a b c = b²` is automatically a square; the hypothesis `b ≠ 0` is
+exactly separability, by `separable_quadratic_iff`. -/
 theorem splits_quadratic_iff_of_two_eq_zero {k : Type*} [Field k] (h2 : (2 : k) = 0)
     {a b c : k} (ha : a ≠ 0) (hb : b ≠ 0) :
     (C a * X ^ 2 + C b * X + C c).Splits ↔ ∃ z, b ^ 2 * (z ^ 2 + z) = a * c := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -10,61 +10,61 @@ public import TauCeti.Algebra.Polynomial.QuadraticDiscriminant
 /-!
 # The node polynomial of a Weierstrass curve
 
-When a Weierstrass curve degenerates to a node, the two tangent directions there are the roots of
-a quadratic, and the reduction is called *split* exactly when those roots are rational over the
+When a Weierstrass curve degenerates to a node, the two tangent directions there are the roots of a
+quadratic, and the reduction is called *split* exactly when those roots are rational over the
 residue field. Mathlib writes that quadratic out inline, in the very definition of
 `WeierstrassCurve.HasSplitMultiplicativeReduction`
 (`Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean`, applied to `W.integralModel R`), but
-gives it no name and proves nothing about it. This file names it `WeierstrassCurve.nodePoly` and
-says when it splits, supplying the criterion the TODO just above that class asks for — *"add
+gives it no name and proves nothing about it. This file names it `WeierstrassCurve.nodePolynomial`
+and says when it splits, supplying the criterion the TODO just above that class asks for — *"add
 characterization in terms of the discriminant when the characteristic is not 2"* — together with
 the characteristic-two counterpart the TODO does not ask for. Restating the class itself through
 these criteria needs `integralModel` and belongs to the minimal-model slice, so the TODO is
 answered at the level of the polynomial, not yet of the class.
 
-* `WeierstrassCurve.nodePoly` is `c₄ T² + a₁ c₄ T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)`, defined over any
-  commutative ring;
-* `WeierstrassCurve.nodePoly_discrim` computes its discriminant as `-c₄ c₆`. This is the number
-  the twist lane needs: twisting by `(t, n)` scales `-c₄ c₆` by `(t² - 4n)⁵`, i.e. by the twisting
-  parameter times a square, so twisting by the right square class moves the discriminant into the
-  squares;
-* `WeierstrassCurve.map_nodePoly` is naturality, `(W.map φ).nodePoly = W.nodePoly.map φ`. It is
-  what lets the criteria below — stated for `W.nodePoly.map φ`, i.e. for the *reduction* of the
-  node polynomial — be read as statements about the node polynomial of the reduced curve;
-* `WeierstrassCurve.variableChange_nodePoly` and
-  `WeierstrassCurve.variableChange_nodePoly_map_splits_iff`: a change of variables `(u, r, s, t)`
-  transforms the node polynomial by the affine substitution
-  `T ↦ u T + s` and the unit scalar `u⁻⁶`, so whether it splits is an isomorphism invariant. This
-  is why split multiplicative reduction is a property of the curve and not of the equation;
-* `WeierstrassCurve.nodePoly_map_splits_iff_isSquare` and
-  `WeierstrassCurve.nodePoly_map_splits_iff_exists_artinSchreier_of_two_eq_zero`: the splitting
-  criteria themselves, each needing `c₄` to survive the map. Away from residue characteristic
-  two it splits iff the image of `-c₄ c₆` is a square; in residue characteristic two, where that
-  says nothing, iff an Artin-Schreier condition holds — and there `c₆` must survive as well. Both
-  come from the general quadratic criteria of
+* `WeierstrassCurve.nodePolynomial` is `c₄ T² + a₁ c₄ T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)`, defined over
+  any commutative ring;
+* `WeierstrassCurve.discrim_nodePolynomial` computes its discriminant as `-c₄ c₆`. This is the
+  number the twist lane needs: twisting by `(t, n)` scales `-c₄ c₆` by `(t² - 4n)⁵`, i.e. by the
+  twisting parameter times a square, so twisting by the right square class moves the discriminant
+  into the squares;
+* `WeierstrassCurve.map_nodePolynomial` is naturality, `(W.map φ).nodePolynomial =
+  W.nodePolynomial.map φ`. It is what lets the criteria below — stated for `W.nodePolynomial.map φ`,
+  i.e. for the *reduction* of the node polynomial — be read as statements about the node polynomial
+  of the reduced curve;
+* `WeierstrassCurve.variableChange_nodePolynomial` and
+  `WeierstrassCurve.splits_variableChange_nodePolynomial_map_iff`: a change of variables `(u, r, s,
+  t)` transforms the node polynomial by the affine substitution `T ↦ u T + s` and the unit scalar
+  `u⁻⁶`, so whether it splits is an isomorphism invariant. This is why split multiplicative
+  reduction is a property of the curve and not of the equation;
+* `WeierstrassCurve.splits_nodePolynomial_map_iff_isSquare` and
+  `WeierstrassCurve.splits_nodePolynomial_map_iff_exists_artinSchreier_of_two_eq_zero`: the
+  splitting criteria themselves, each needing `c₄` to survive the map. Away from residue
+  characteristic two it splits iff the image of `-c₄ c₆` is a square; in residue characteristic two,
+  where that says nothing, iff an Artin-Schreier condition holds — and there `c₆` must survive as
+  well. Both come from the general quadratic criteria of
   `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`.
 
-Nothing here assumes a valuation or a reduction: every statement is about a Weierstrass curve
-over a commutative ring and a ring homomorphism to a field, so it applies to any reduction map
-one later chooses. They advance
-`TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists), whose headline
+Nothing here assumes a valuation or a reduction: every statement is about a Weierstrass curve over
+a commutative ring and a ring homomorphism to a field, so it applies to any reduction map one later
+chooses. They advance `TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists), whose headline
 `exists_quadraticTwist_hasSplitMultiplicativeReduction` — a curve with nonsplit multiplicative
-reduction acquires split reduction after a separable quadratic twist — carries no
-residue-characteristic hypothesis, so it needs both criteria: away from residue characteristic
-two one feeds the twist's scaling of `-c₄ c₆` into `nodePoly_map_splits_iff_isSquare`, and in
-residue characteristic two the route is
-`nodePoly_map_splits_iff_exists_artinSchreier_of_two_eq_zero`.
+reduction acquires split reduction after a separable quadratic twist — carries no residue-
+characteristic hypothesis, so it needs both criteria: away from residue characteristic two one
+feeds the twist's scaling of `-c₄ c₆` into `splits_nodePolynomial_map_iff_isSquare`, and in residue
+characteristic two the route is
+`splits_nodePolynomial_map_iff_exists_artinSchreier_of_two_eq_zero`.
 
-Adapted from the FLT project (`ImperialCollegeLondon/FLT`, at the roadmap's pin `bc2fe8ff7396`,
-FLT PR #1088, Apache 2.0): the node-polynomial block of
+Adapted from the FLT project (`ImperialCollegeLondon/FLT`, at the roadmap's pin `bc2fe8ff7396`, FLT
+PR #1088, Apache 2.0): the node-polynomial block of
 `FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean`, together with
 `splitPolynomial_discrim` from `FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean`,
-renamed here to `nodePoly_discrim` because `splitPolynomial` names no declaration. Those files'
-headers read `Authors: Kevin Buzzard, William Coram, Claude` and `Authors: Kevin Buzzard, Claude`;
-following this repository's convention for adapted material, the upstream authorship is credited
-here rather than in the copyright header. Ported with the source's `@[expose]` dropped, and with
-the minimal-model and multiplicative-reduction blocks of the source file left to the PR that
-consumes them.
+renamed here to `discrim_nodePolynomial` because `splitPolynomial` names no declaration. Those
+files' headers read `Authors: Kevin Buzzard, William Coram, Claude` and `Authors: Kevin Buzzard,
+Claude`; following this repository's convention for adapted material, the upstream authorship is
+credited here rather than in the copyright header. Ported with the source's `@[expose]` dropped,
+and with the minimal-model and multiplicative-reduction blocks of the source file left to the PR
+that consumes them.
 -/
 
 public section
@@ -78,23 +78,24 @@ slopes of the two tangent directions at the node of a multiplicative reduction. 
 polynomial Mathlib writes out inline in `WeierstrassCurve.HasSplitMultiplicativeReduction`, which
 asks for the splitting over the residue field of this polynomial formed from the *integral model*
 `W.integralModel R`, as its one extra condition on top of `HasMultiplicativeReduction`. -/
-noncomputable def nodePoly (W : WeierstrassCurve A) : Polynomial A :=
+noncomputable def nodePolynomial (W : WeierstrassCurve A) : Polynomial A :=
   .C W.c₄ * .X ^ 2 + .C (W.a₁ * W.c₄) * .X - .C (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)
 
-/-- The defining formula for the node polynomial. The definition's body is not exposed across
-the module boundary, so this is how downstream modules see it; `nodePoly_map_eq_quadratic` is the
-corresponding statement for its image under a ring homomorphism. -/
-lemma nodePoly_def (W : WeierstrassCurve A) :
-    W.nodePoly = .C W.c₄ * .X ^ 2 + .C (W.a₁ * W.c₄) * .X
+/-- The defining formula for the node polynomial. The definition's body is not exposed across the
+module boundary, so this is how downstream modules see it;
+`nodePolynomial_map_eq_quadratic` is the corresponding statement for its image under a ring
+homomorphism. -/
+lemma nodePolynomial_def (W : WeierstrassCurve A) :
+    W.nodePolynomial = .C W.c₄ * .X ^ 2 + .C (W.a₁ * W.c₄) * .X
       - .C (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄) := by
-  simp only [nodePoly]
+  simp only [nodePolynomial]
 
 /-- The discriminant of the node polynomial is `-c₄ c₆`. Hence — away from residue characteristic
 two, and provided `c₄` survives the reduction — the tangent directions at the node are rational
 over the residue field exactly when the image of `-c₄ c₆` is a square there
-(`nodePoly_map_splits_iff_isSquare`); twisting by `(t, n)` multiplies `-c₄ c₆` by
+(`splits_nodePolynomial_map_iff_isSquare`); twisting by `(t, n)` multiplies `-c₄ c₆` by
 `(t² - 4n)⁵ = (t² - 4n)⁴ · (t² - 4n)`, i.e. by the twisting parameter up to a square. -/
-theorem nodePoly_discrim (W : WeierstrassCurve A) :
+theorem discrim_nodePolynomial (W : WeierstrassCurve A) :
     discrim W.c₄ (W.a₁ * W.c₄) (-(54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄))
       = -(W.c₄ * W.c₆) := by
   simp only [discrim, c₄, c₆, b₂, b₄, b₆]; ring
@@ -102,9 +103,10 @@ theorem nodePoly_discrim (W : WeierstrassCurve A) :
 /-- The node polynomial is natural in the coefficient ring: it commutes with base change of the
 Weierstrass equation along any ring homomorphism. -/
 @[simp]
-lemma map_nodePoly (φ : A →+* B) (W : WeierstrassCurve A) :
-    (W.map φ).nodePoly = W.nodePoly.map φ := by
-  simp only [nodePoly, WeierstrassCurve.map_c₄, WeierstrassCurve.map_a₁, WeierstrassCurve.map_b₂,
+lemma map_nodePolynomial (φ : A →+* B) (W : WeierstrassCurve A) :
+    (W.map φ).nodePolynomial = W.nodePolynomial.map φ := by
+  simp only [nodePolynomial, WeierstrassCurve.map_c₄, WeierstrassCurve.map_a₁,
+    WeierstrassCurve.map_b₂,
     WeierstrassCurve.map_b₄, WeierstrassCurve.map_b₆, WeierstrassCurve.map_a₂, Polynomial.map_add,
     Polynomial.map_sub, Polynomial.map_mul, Polynomial.map_pow, Polynomial.map_C, Polynomial.map_X,
     Polynomial.map_ofNat, map_add, map_sub, map_mul, map_ofNat]
@@ -112,39 +114,38 @@ lemma map_nodePoly (φ : A →+* B) (W : WeierstrassCurve A) :
 /-- The reduced node polynomial, presented as a quadratic with an additive constant term — the
 shape `C a * X ^ 2 + C b * X + C c` that the criteria of
 `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean` consume. -/
-lemma nodePoly_map_eq_quadratic (φ : A →+* B) (W : WeierstrassCurve A) :
-    W.nodePoly.map φ = .C (φ W.c₄) * .X ^ 2 + .C (φ (W.a₁ * W.c₄)) * .X
+lemma nodePolynomial_map_eq_quadratic (φ : A →+* B) (W : WeierstrassCurve A) :
+    W.nodePolynomial.map φ = .C (φ W.c₄) * .X ^ 2 + .C (φ (W.a₁ * W.c₄)) * .X
       + .C (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)) := by
-  simp only [nodePoly, Polynomial.map_sub, Polynomial.map_add, Polynomial.map_mul,
+  simp only [nodePolynomial, Polynomial.map_sub, Polynomial.map_add, Polynomial.map_mul,
     Polynomial.map_pow, Polynomial.map_C, Polynomial.map_X]
   rw [map_neg, sub_eq_add_neg]
 
-/-- The image of `nodePoly_discrim` under a ring homomorphism, in the shape produced by the
-quadratic criteria applied to `nodePoly_map_eq_quadratic`. -/
-lemma map_nodePoly_discrim (φ : A →+* B) (W : WeierstrassCurve A) :
+/-- The image of `discrim_nodePolynomial` under a ring homomorphism, in the shape produced by the
+quadratic criteria applied to `nodePolynomial_map_eq_quadratic`. -/
+lemma discrim_map_nodePolynomial (φ : A →+* B) (W : WeierstrassCurve A) :
     discrim (φ W.c₄) (φ (W.a₁ * W.c₄)) (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄))
       = φ (-(W.c₄ * W.c₆)) := by
-  have h := congrArg φ W.nodePoly_discrim
+  have h := congrArg φ W.discrim_nodePolynomial
   simp only [discrim, map_add, map_sub, map_mul, map_neg, map_pow, map_ofNat] at h ⊢
   linear_combination h
 
 /-- Under a change of variables `C = (u, r, s, t)`, the node polynomial transforms by the affine
 substitution `T ↦ u T + s` and the unit scalar `u⁻⁶` — reflecting that the tangent slopes `λ`
 transform as `λ ↦ (λ - s)/u`. Over a field this makes splitting invariant; see
-`variableChange_nodePoly_map_splits_iff`. -/
-lemma variableChange_nodePoly (W : WeierstrassCurve A) (C : VariableChange A) :
-    (C • W).nodePoly = .C ((↑C.u⁻¹ : A) ^ 6)
-      * W.nodePoly.comp (.C (↑C.u : A) * .X + .C C.s) := by
+`splits_variableChange_nodePolynomial_map_iff`. -/
+lemma variableChange_nodePolynomial (W : WeierstrassCurve A) (C : VariableChange A) :
+    (C • W).nodePolynomial = .C ((↑C.u⁻¹ : A) ^ 6)
+      * W.nodePolynomial.comp (.C (↑C.u : A) * .X + .C C.s) := by
   -- `ring` cannot see that `u⁻¹` inverts `u`, so the two cancellations it needs are supplied as
   -- hypotheses and fed to `linear_combination`: `e2` corrects the `X²` coefficient, where the
   -- scalar `u⁻⁶` meets the `u²` from `(uX + s)²`, and `e1` the `X` coefficient, where it meets a
   -- single `u`.
+  have hu : (↑C.u⁻¹ : A) * (↑C.u : A) = 1 := C.u.inv_mul
   have e2 : (↑C.u⁻¹ : A) ^ 6 * (↑C.u : A) ^ 2 = (↑C.u⁻¹ : A) ^ 4 := by
-    have := congrArg (Units.val (α := A)) (by group : C.u⁻¹ ^ 6 * C.u ^ 2 = C.u⁻¹ ^ 4)
-    simpa only [Units.val_mul, Units.val_pow_eq_pow_val] using this
+    linear_combination ((↑C.u⁻¹ : A) ^ 4 * ((↑C.u⁻¹ : A) * (↑C.u : A) + 1)) * hu
   have e1 : (↑C.u⁻¹ : A) ^ 6 * (↑C.u : A) = (↑C.u⁻¹ : A) ^ 5 := by
-    have := congrArg (Units.val (α := A)) (by group : C.u⁻¹ ^ 6 * C.u = C.u⁻¹ ^ 5)
-    simpa only [Units.val_mul, Units.val_pow_eq_pow_val] using this
+    linear_combination ((↑C.u⁻¹ : A) ^ 5) * hu
   have hc₄ : Polynomial.C W.c₄ = Polynomial.C W.b₂ ^ 2 - 24 * Polynomial.C W.b₄ := by
     rw [c₄]
     simp only [Polynomial.C_sub, Polynomial.C_mul, Polynomial.C_pow, map_ofNat]
@@ -154,7 +155,7 @@ lemma variableChange_nodePoly (W : WeierstrassCurve A) (C : VariableChange A) :
   have e1p : (Polynomial.C (↑C.u⁻¹ : A)) ^ 6 * Polynomial.C (↑C.u : A)
       = (Polynomial.C (↑C.u⁻¹ : A)) ^ 5 := by
     rw [← Polynomial.C_pow, ← Polynomial.C_mul, e1, Polynomial.C_pow]
-  simp only [nodePoly, variableChange_a₁, variableChange_a₂, variableChange_c₄,
+  simp only [nodePolynomial, variableChange_a₁, variableChange_a₂, variableChange_c₄,
     variableChange_b₂, variableChange_b₄, variableChange_b₆, Polynomial.mul_comp,
     Polynomial.add_comp, Polynomial.sub_comp, Polynomial.C_comp, Polynomial.X_comp, pow_two,
     mul_add, add_mul, mul_sub, sub_mul, Polynomial.C_mul, Polynomial.C_add, Polynomial.C_sub,
@@ -167,18 +168,18 @@ lemma variableChange_nodePoly (W : WeierstrassCurve A) (C : VariableChange A) :
 
 /-- **Invariance of the node polynomial's splitting under change of variables.** Since a change of
 variables transforms the node polynomial by an affine substitution and a unit scalar
-(`variableChange_nodePoly`), whether it splits over a field `k` is unchanged. This is what makes
-split multiplicative reduction an isomorphism invariant rather than a property of the
+(`variableChange_nodePolynomial`), whether it splits over a field `k` is unchanged. This is what
+makes split multiplicative reduction an isomorphism invariant rather than a property of the
 equation. -/
-lemma variableChange_nodePoly_map_splits_iff (φ : A →+* k) (W : WeierstrassCurve A)
+lemma splits_variableChange_nodePolynomial_map_iff (φ : A →+* k) (W : WeierstrassCurve A)
     (C : VariableChange A) :
-    ((C • W).nodePoly.map φ).Splits ↔ (W.nodePoly.map φ).Splits := by
+    ((C • W).nodePolynomial.map φ).Splits ↔ (W.nodePolynomial.map φ).Splits := by
   have hu : φ (↑C.u : A) ≠ 0 := (RingHom.isUnit_map φ C.u.isUnit).ne_zero
   have hu6 : φ ((↑C.u⁻¹ : A) ^ 6) ≠ 0 := by
     rw [map_pow]; exact pow_ne_zero 6 (RingHom.isUnit_map φ C.u⁻¹.isUnit).ne_zero
-  rw [variableChange_nodePoly, Polynomial.map_mul, Polynomial.map_C, Polynomial.map_comp,
-    Polynomial.map_add, Polynomial.map_mul, Polynomial.map_C, Polynomial.map_X, Polynomial.map_C,
-    Polynomial.splits_mul_iff_right (Polynomial.C_ne_zero.mpr hu6) (Polynomial.Splits.C _)]
+  simp only [variableChange_nodePolynomial, Polynomial.map_mul, Polynomial.map_C,
+    Polynomial.map_comp, Polynomial.map_add, Polynomial.map_X]
+  rw [Polynomial.splits_mul_iff_right (Polynomial.C_ne_zero.mpr hu6) (Polynomial.Splits.C _)]
   exact (Polynomial.splits_iff_comp_splits_of_natDegree_eq_one
     (Polynomial.natDegree_linear hu)).symm
 
@@ -186,25 +187,27 @@ lemma variableChange_nodePoly_map_splits_iff (φ : A →+* k) (W : WeierstrassCu
 provided `c₄` does not die under `φ` — the condition that makes the reduced polynomial genuinely
 quadratic, and which multiplicative reduction supplies — the node polynomial splits, i.e. the two
 tangent directions at the node are `k`-rational, exactly when `φ (-(c₄ * c₆))`, the image of its
-discriminant (`nodePoly_discrim`), is a square in `k`. This answers Mathlib's TODO in
+discriminant (`discrim_nodePolynomial`), is a square in `k`. This answers Mathlib's TODO in
 `Reduction.lean` at the level of the node polynomial; restating
 `HasSplitMultiplicativeReduction` itself through it needs `integralModel`. It is also the tool
 that, applied to a quadratic twist via the scaling
 `-c₄' c₆' = (t² - 4n)⁵ · (-c₄ c₆)`, turns a nonsplit reduction into a split one after twisting by
 the right square class. -/
-lemma nodePoly_map_splits_iff_isSquare [NeZero (2 : k)] (φ : A →+* k) (W : WeierstrassCurve A)
+lemma splits_nodePolynomial_map_iff_isSquare [NeZero (2 : k)] (φ : A →+* k) (W : WeierstrassCurve A)
     (hc₄ : φ W.c₄ ≠ 0) :
-    (W.nodePoly.map φ).Splits ↔ IsSquare (φ (-(W.c₄ * W.c₆))) := by
-  rw [nodePoly_map_eq_quadratic, Polynomial.splits_quadratic_iff_isSquare hc₄, map_nodePoly_discrim]
+    (W.nodePolynomial.map φ).Splits ↔ IsSquare (φ (-(W.c₄ * W.c₆))) := by
+  rw [nodePolynomial_map_eq_quadratic, Polynomial.splits_quadratic_iff_isSquare hc₄,
+    discrim_map_nodePolynomial]
 
 /-- **Split criterion in residue characteristic two.** Over a field `k` of characteristic `2`,
-where the square-class criterion `nodePoly_map_splits_iff_isSquare` says nothing, the node
+where the square-class criterion `splits_nodePolynomial_map_iff_isSquare` says nothing, the node
 polynomial splits exactly when its Artin-Schreier invariant lies in the image of `z ↦ z² + z`.
 Both `c₄` and `c₆` are required nonzero in `k`; together they force the linear coefficient
 `a₁ c₄` to be nonzero as well, which is what makes the criterion applicable. -/
-lemma nodePoly_map_splits_iff_exists_artinSchreier_of_two_eq_zero (h2 : (2 : k) = 0) (φ : A →+* k)
+lemma splits_nodePolynomial_map_iff_exists_artinSchreier_of_two_eq_zero (h2 : (2 : k) = 0)
+    (φ : A →+* k)
     (W : WeierstrassCurve A) (hc₄ : φ W.c₄ ≠ 0) (hc₆ : φ W.c₆ ≠ 0) :
-    (W.nodePoly.map φ).Splits ↔ ∃ z, φ (W.a₁ * W.c₄) ^ 2 * (z ^ 2 + z)
+    (W.nodePolynomial.map φ).Splits ↔ ∃ z, φ (W.a₁ * W.c₄) ^ 2 * (z ^ 2 + z)
       = φ W.c₄ * (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)) := by
   -- In characteristic two the discriminant is the square of the linear coefficient
   -- (`discrim_eq_sq_of_two_eq_zero`), and it equals `φ (-(c₄ c₆)) ≠ 0`, so that coefficient is
@@ -212,9 +215,9 @@ lemma nodePoly_map_splits_iff_exists_artinSchreier_of_two_eq_zero (h2 : (2 : k) 
   have hb : φ (W.a₁ * W.c₄) ≠ 0 := by
     intro h0
     refine neg_ne_zero.mpr (mul_ne_zero hc₄ hc₆) ?_
-    rw [← map_mul, ← map_neg, ← map_nodePoly_discrim φ W,
+    rw [← map_mul, ← map_neg, ← discrim_map_nodePolynomial φ W,
       discrim_eq_sq_of_two_eq_zero h2, h0, zero_pow two_ne_zero]
-  rw [nodePoly_map_eq_quadratic,
+  rw [nodePolynomial_map_eq_quadratic,
     Polynomial.splits_quadratic_iff_exists_artinSchreier_of_two_eq_zero h2 hc₄ hb]
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -186,9 +186,10 @@ lemma variableChange_nodePoly_map_splits_iff (φ : A →+* k) (W : WeierstrassCu
 provided `c₄` does not die under `φ` — the condition that makes the reduced polynomial genuinely
 quadratic, and which multiplicative reduction supplies — the node polynomial splits, i.e. the two
 tangent directions at the node are `k`-rational, exactly when `φ (-(c₄ * c₆))`, the image of its
-discriminant (`nodePoly_discrim`), is a square in `k`. This is the characterization Mathlib's
-TODO in `Reduction.lean` asks for, and is the tool that, applied to a quadratic twist via the
-scaling
+discriminant (`nodePoly_discrim`), is a square in `k`. This answers Mathlib's TODO in
+`Reduction.lean` at the level of the node polynomial; restating
+`HasSplitMultiplicativeReduction` itself through it needs `integralModel`. It is also the tool
+that, applied to a quadratic twist via the scaling
 `-c₄' c₆' = (t² - 4n)⁵ · (-c₄ c₆)`, turns a nonsplit reduction into a split one after twisting by
 the right square class. -/
 lemma nodePoly_map_splits_iff_isSquare [NeZero (2 : k)] (φ : A →+* k) (W : WeierstrassCurve A)

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -32,16 +32,17 @@ answered at the level of the polynomial, not yet of the class.
   what lets the criteria below — stated for `W.nodePoly.map φ`, i.e. for the *reduction* of the
   node polynomial — be read as statements about the node polynomial of the reduced curve;
 * `WeierstrassCurve.variableChange_nodePoly` and
-  `WeierstrassCurve.variableChange_nodePoly_map_splits_iff`: a change
-  of variables `(u, r, s, t)` transforms the node polynomial by the affine substitution
+  `WeierstrassCurve.variableChange_nodePoly_map_splits_iff`: a change of variables `(u, r, s, t)`
+  transforms the node polynomial by the affine substitution
   `T ↦ u T + s` and the unit scalar `u⁻⁶`, so whether it splits is an isomorphism invariant. This
   is why split multiplicative reduction is a property of the curve and not of the equation;
 * `WeierstrassCurve.nodePoly_map_splits_iff_isSquare` and
-  `WeierstrassCurve.nodePoly_map_splits_iff_of_two_eq_zero`: the splitting criteria themselves,
-  each needing `c₄` to survive the map. Away from residue characteristic two it splits iff the
-  image of `-c₄ c₆` is a square; in residue characteristic two, where that says nothing, iff an
-  Artin-Schreier condition holds — and there `c₆` must survive as well. Both come from the
-  general quadratic criteria of `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`.
+  `WeierstrassCurve.nodePoly_map_splits_iff_exists_artinSchreier_of_two_eq_zero`: the splitting
+  criteria themselves, each needing `c₄` to survive the map. Away from residue characteristic
+  two it splits iff the image of `-c₄ c₆` is a square; in residue characteristic two, where that
+  says nothing, iff an Artin-Schreier condition holds — and there `c₆` must survive as well. Both
+  come from the general quadratic criteria of
+  `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`.
 
 Nothing here assumes a valuation or a reduction: every statement is about a Weierstrass curve
 over a commutative ring and a ring homomorphism to a field, so it applies to any reduction map
@@ -51,7 +52,8 @@ one later chooses. They advance
 reduction acquires split reduction after a separable quadratic twist — carries no
 residue-characteristic hypothesis, so it needs both criteria: away from residue characteristic
 two one feeds the twist's scaling of `-c₄ c₆` into `nodePoly_map_splits_iff_isSquare`, and in
-residue characteristic two the route is `nodePoly_map_splits_iff_of_two_eq_zero`.
+residue characteristic two the route is
+`nodePoly_map_splits_iff_exists_artinSchreier_of_two_eq_zero`.
 
 Adapted from the FLT project (`ImperialCollegeLondon/FLT`, at the roadmap's pin `bc2fe8ff7396`,
 FLT PR #1088, Apache 2.0): the node-polynomial block of
@@ -78,6 +80,14 @@ asks for the splitting over the residue field of this polynomial formed from the
 `W.integralModel R`, as its one extra condition on top of `HasMultiplicativeReduction`. -/
 noncomputable def nodePoly (W : WeierstrassCurve A) : Polynomial A :=
   .C W.c₄ * .X ^ 2 + .C (W.a₁ * W.c₄) * .X - .C (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)
+
+/-- The defining formula for the node polynomial. The definition's body is not exposed across
+the module boundary, so this is how downstream modules see it; `nodePoly_map_eq_quadratic` is the
+corresponding statement for its image under a ring homomorphism. -/
+lemma nodePoly_def (W : WeierstrassCurve A) :
+    W.nodePoly = .C W.c₄ * .X ^ 2 + .C (W.a₁ * W.c₄) * .X
+      - .C (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄) := by
+  simp only [nodePoly]
 
 /-- The discriminant of the node polynomial is `-c₄ c₆`. Hence — away from residue characteristic
 two, and provided `c₄` survives the reduction — the tangent directions at the node are rational
@@ -114,9 +124,9 @@ quadratic criteria applied to `nodePoly_map_eq_quadratic`. -/
 lemma map_nodePoly_discrim (φ : A →+* B) (W : WeierstrassCurve A) :
     discrim (φ W.c₄) (φ (W.a₁ * W.c₄)) (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄))
       = φ (-(W.c₄ * W.c₆)) := by
-  rw [discrim, mul_neg, sub_neg_eq_add, ← map_pow, ← map_ofNat φ 4, ← map_mul, ← map_mul,
-    ← map_add]
-  exact congrArg φ (by simpa only [discrim, mul_neg, sub_neg_eq_add] using W.nodePoly_discrim)
+  have h := congrArg φ W.nodePoly_discrim
+  simp only [discrim, map_add, map_sub, map_mul, map_neg, map_pow, map_ofNat] at h ⊢
+  linear_combination h
 
 /-- Under a change of variables `C = (u, r, s, t)`, the node polynomial transforms by the affine
 substitution `T ↦ u T + s` and the unit scalar `u⁻⁶` — reflecting that the tangent slopes `λ`
@@ -125,31 +135,35 @@ transform as `λ ↦ (λ - s)/u`. Over a field this makes splitting invariant; s
 lemma variableChange_nodePoly (W : WeierstrassCurve A) (C : VariableChange A) :
     (C • W).nodePoly = .C ((↑C.u⁻¹ : A) ^ 6)
       * W.nodePoly.comp (.C (↑C.u : A) * .X + .C C.s) := by
+  -- `ring` cannot see that `u⁻¹` inverts `u`, so the two cancellations it needs are supplied as
+  -- hypotheses and fed to `linear_combination`: `e2` corrects the `X²` coefficient, where the
+  -- scalar `u⁻⁶` meets the `u²` from `(uX + s)²`, and `e1` the `X` coefficient, where it meets a
+  -- single `u`.
   have e2 : (↑C.u⁻¹ : A) ^ 6 * (↑C.u : A) ^ 2 = (↑C.u⁻¹ : A) ^ 4 := by
     have := congrArg (Units.val (α := A)) (by group : C.u⁻¹ ^ 6 * C.u ^ 2 = C.u⁻¹ ^ 4)
     simpa only [Units.val_mul, Units.val_pow_eq_pow_val] using this
   have e1 : (↑C.u⁻¹ : A) ^ 6 * (↑C.u : A) = (↑C.u⁻¹ : A) ^ 5 := by
     have := congrArg (Units.val (α := A)) (by group : C.u⁻¹ ^ 6 * C.u = C.u⁻¹ ^ 5)
     simpa only [Units.val_mul, Units.val_pow_eq_pow_val] using this
-  have e2p : (algebraMap A (Polynomial A) (↑C.u⁻¹ : A)) ^ 6 * (algebraMap A (Polynomial A) ↑C.u) ^ 2
-      = (algebraMap A (Polynomial A) (↑C.u⁻¹ : A)) ^ 4 := by
-    rw [← map_pow, ← map_pow, ← map_mul, e2, map_pow]
-  have e1p : (algebraMap A (Polynomial A) (↑C.u⁻¹ : A)) ^ 6 * algebraMap A (Polynomial A) ↑C.u
-      = (algebraMap A (Polynomial A) (↑C.u⁻¹ : A)) ^ 5 := by
-    rw [← map_pow, ← map_mul, e1, map_pow]
-  simp only [nodePoly, c₄, variableChange_a₁, variableChange_a₂, variableChange_b₂,
-    variableChange_b₄, variableChange_b₆, Polynomial.mul_comp, Polynomial.add_comp,
-    Polynomial.sub_comp, Polynomial.C_comp, Polynomial.X_comp, pow_two, mul_add, add_mul,
-    mul_sub, sub_mul]
-  simp only [Polynomial.C_eq_algebraMap, map_mul, map_pow, map_sub, map_add, map_ofNat]
-  linear_combination
-    (-(algebraMap A (Polynomial A) W.b₂ ^ 2 - 24 * algebraMap A (Polynomial A) W.b₄) *
-        Polynomial.X ^ 2) * e2p +
-    (-(2 * (algebraMap A (Polynomial A) W.b₂ ^ 2 - 24 * algebraMap A (Polynomial A) W.b₄) *
-            algebraMap A (Polynomial A) C.s +
-          algebraMap A (Polynomial A) W.a₁ *
-            (algebraMap A (Polynomial A) W.b₂ ^ 2 - 24 * algebraMap A (Polynomial A) W.b₄)) *
-        Polynomial.X) * e1p
+  have hc₄ : Polynomial.C W.c₄ = Polynomial.C W.b₂ ^ 2 - 24 * Polynomial.C W.b₄ := by
+    rw [c₄]
+    simp only [Polynomial.C_sub, Polynomial.C_mul, Polynomial.C_pow, map_ofNat]
+  have e2p : (Polynomial.C (↑C.u⁻¹ : A)) ^ 6 * (Polynomial.C (↑C.u : A)) ^ 2
+      = (Polynomial.C (↑C.u⁻¹ : A)) ^ 4 := by
+    rw [← Polynomial.C_pow, ← Polynomial.C_pow, ← Polynomial.C_mul, e2, Polynomial.C_pow]
+  have e1p : (Polynomial.C (↑C.u⁻¹ : A)) ^ 6 * Polynomial.C (↑C.u : A)
+      = (Polynomial.C (↑C.u⁻¹ : A)) ^ 5 := by
+    rw [← Polynomial.C_pow, ← Polynomial.C_mul, e1, Polynomial.C_pow]
+  simp only [nodePoly, variableChange_a₁, variableChange_a₂, variableChange_c₄,
+    variableChange_b₂, variableChange_b₄, variableChange_b₆, Polynomial.mul_comp,
+    Polynomial.add_comp, Polynomial.sub_comp, Polynomial.C_comp, Polynomial.X_comp, pow_two,
+    mul_add, add_mul, mul_sub, sub_mul, Polynomial.C_mul, Polynomial.C_add, Polynomial.C_sub,
+    Polynomial.C_pow, map_ofNat, Polynomial.ofNat_comp]
+  -- the `r`-shift contributes `c₄` through `variableChange_a₂`, in expanded form
+  linear_combination (-Polynomial.C W.c₄ * Polynomial.X ^ 2) * e2p
+    + (-(2 * Polynomial.C W.c₄ * Polynomial.C C.s + Polynomial.C W.a₁ * Polynomial.C W.c₄)
+        * Polynomial.X) * e1p
+    + (-3 * Polynomial.C (↑C.u⁻¹ : A) ^ 6 * Polynomial.C C.r) * hc₄
 
 /-- **Invariance of the node polynomial's splitting under change of variables.** Since a change of
 variables transforms the node polynomial by an affine substitution and a unit scalar
@@ -187,20 +201,20 @@ where the square-class criterion `nodePoly_map_splits_iff_isSquare` says nothing
 polynomial splits exactly when its Artin-Schreier invariant lies in the image of `z ↦ z² + z`.
 Both `c₄` and `c₆` are required nonzero in `k`; together they force the linear coefficient
 `a₁ c₄` to be nonzero as well, which is what makes the criterion applicable. -/
-lemma nodePoly_map_splits_iff_of_two_eq_zero (h2 : (2 : k) = 0) (φ : A →+* k)
+lemma nodePoly_map_splits_iff_exists_artinSchreier_of_two_eq_zero (h2 : (2 : k) = 0) (φ : A →+* k)
     (W : WeierstrassCurve A) (hc₄ : φ W.c₄ ≠ 0) (hc₆ : φ W.c₆ ≠ 0) :
     (W.nodePoly.map φ).Splits ↔ ∃ z, φ (W.a₁ * W.c₄) ^ 2 * (z ^ 2 + z)
       = φ W.c₄ * (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)) := by
+  -- In characteristic two the discriminant is the square of the linear coefficient
+  -- (`discrim_eq_sq_of_two_eq_zero`), and it equals `φ (-(c₄ c₆)) ≠ 0`, so that coefficient is
+  -- nonzero — which is what makes the Artin-Schreier criterion applicable.
   have hb : φ (W.a₁ * W.c₄) ≠ 0 := by
-    have h4 : (4 : k) = 0 := by linear_combination (2 : k) * h2
-    have hAk := map_nodePoly_discrim φ W
-    rw [discrim] at hAk
     intro h0
     refine neg_ne_zero.mpr (mul_ne_zero hc₄ hc₆) ?_
-    rw [← map_mul, ← map_neg]
-    linear_combination -hAk + φ (W.a₁ * W.c₄) * h0
-      + φ W.c₄ * φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄) * h4
-  rw [nodePoly_map_eq_quadratic, Polynomial.splits_quadratic_iff_of_two_eq_zero h2 hc₄ hb]
+    rw [← map_mul, ← map_neg, ← map_nodePoly_discrim φ W,
+      Polynomial.discrim_eq_sq_of_two_eq_zero h2, h0, zero_pow two_ne_zero]
+  rw [nodePoly_map_eq_quadratic,
+    Polynomial.splits_quadratic_iff_exists_artinSchreier_of_two_eq_zero h2 hc₄ hb]
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -39,11 +39,10 @@ answered at the level of the polynomial, not yet of the class.
   reduction is a property of the curve and not of the equation;
 * `WeierstrassCurve.splits_nodePolynomial_map_iff_isSquare` and
   `WeierstrassCurve.splits_nodePolynomial_map_iff_exists_artinSchreier_of_two_eq_zero`: the
-  splitting criteria themselves, each needing `c₄` to survive the map. Away from residue
-  characteristic two it splits iff the image of `-c₄ c₆` is a square; in residue characteristic two,
-  where that says nothing, iff an Artin-Schreier condition holds — and there `c₆` must survive as
-  well. Both come from the general quadratic criteria of
-  `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`.
+  splitting criteria themselves, each needing only `c₄` to survive the map. Away from residue
+  characteristic two it splits iff the image of `-c₄ c₆` is a square; in residue characteristic
+  two, where that says nothing, iff an Artin-Schreier condition holds. Both come from the general
+  quadratic criteria of `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`.
 
 Nothing here assumes a valuation or a reduction: every statement is about a Weierstrass curve over
 a commutative ring and a ring homomorphism to a field, so it applies to any reduction map one later
@@ -202,13 +201,21 @@ lemma splits_nodePolynomial_map_iff_isSquare [NeZero (2 : k)] (φ : A →+* k) (
 /-- **Split criterion in residue characteristic two.** Over a field `k` of characteristic `2`,
 where the square-class criterion `splits_nodePolynomial_map_iff_isSquare` says nothing, the node
 polynomial splits exactly when its Artin-Schreier invariant lies in the image of `z ↦ z² + z`.
-Both `c₄` and `c₆` are required nonzero in `k`; together they force the linear coefficient
-`a₁ c₄` to be nonzero as well, which is what makes the criterion applicable. -/
+Only `c₄` need be assumed nonzero: in characteristic two `1728 = 0`, so `c_relation` reads
+`c₄³ = c₆²` and `c₆ ≠ 0` comes for free. Together they force the linear coefficient `a₁ c₄` to be
+nonzero, which is what makes the criterion applicable. -/
 lemma splits_nodePolynomial_map_iff_exists_artinSchreier_of_two_eq_zero (h2 : (2 : k) = 0)
-    (φ : A →+* k)
-    (W : WeierstrassCurve A) (hc₄ : φ W.c₄ ≠ 0) (hc₆ : φ W.c₆ ≠ 0) :
+    (φ : A →+* k) (W : WeierstrassCurve A) (hc₄ : φ W.c₄ ≠ 0) :
     (W.nodePolynomial.map φ).Splits ↔ ∃ z, φ (W.a₁ * W.c₄) ^ 2 * (z ^ 2 + z)
       = φ W.c₄ * (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)) := by
+  -- `1728 = 0` in characteristic two, so `c_relation` gives `φ c₄ ^ 3 = φ c₆ ^ 2`.
+  have hc₆ : φ W.c₆ ≠ 0 := by
+    intro h0
+    refine hc₄ (pow_eq_zero_iff three_ne_zero |>.mp ?_)
+    have h := congrArg φ W.c_relation
+    have h1728 : (1728 : k) = 0 := by linear_combination (864 : k) * h2
+    simp only [map_mul, map_sub, map_pow, map_ofNat] at h
+    linear_combination -h + φ W.Δ * h1728 + φ W.c₆ * h0
   -- In characteristic two the discriminant is the square of the linear coefficient
   -- (`discrim_eq_sq_of_two_eq_zero`), and it equals `φ (-(c₄ c₆)) ≠ 0`, so that coefficient is
   -- nonzero — which is what makes the Artin-Schreier criterion applicable.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -12,10 +12,14 @@ public import TauCeti.Algebra.Polynomial.QuadraticDiscriminant
 
 When a Weierstrass curve degenerates to a node, the two tangent directions there are the roots of
 a quadratic, and the reduction is called *split* exactly when those roots are rational over the
-residue field. This file introduces that quadratic, `WeierstrassCurve.nodePoly`, and answers the
-question of when it splits — the criterion Mathlib's
-`Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean` leaves open where it defines
-`WeierstrassCurve.HasSplitMultiplicativeReduction`.
+residue field. Mathlib writes that quadratic out inline, in the very definition of
+`WeierstrassCurve.HasSplitMultiplicativeReduction`
+(`Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean`, applied to `W.integralModel R`), but
+gives it no name and proves nothing about it. This file names it `WeierstrassCurve.nodePoly` and
+says when it splits, discharging the TODO recorded just above that class — *"add characterization
+in terms of the discriminant when the characteristic is not 2"* — and adding the characteristic-
+two counterpart. The remaining step, rewriting the class itself through these criteria, needs
+`integralModel` and belongs to the minimal-model slice.
 
 * `WeierstrassCurve.nodePoly` is `c₄ T² + a₁ c₄ T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)`, defined over any
   commutative ring;
@@ -32,13 +36,14 @@ question of when it splits — the criterion Mathlib's
   is why split multiplicative reduction is a property of the curve and not of the equation;
 * `WeierstrassCurve.nodePoly_map_splits_iff_isSquare` and
   `WeierstrassCurve.nodePoly_map_splits_iff_of_two_eq_zero`: the splitting criteria themselves,
-  away from residue characteristic two (splits iff `-c₄ c₆` is a square) and in residue
-  characteristic two (splits iff an Artin-Schreier condition holds), obtained from the general
-  quadratic criteria of `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`.
+  each under the hypothesis that `c₄` survives the map. Away from residue characteristic two it
+  splits iff the image of `-c₄ c₆` is a square; in residue characteristic two, where that says
+  nothing, iff an Artin-Schreier condition holds. Both come from the general quadratic criteria
+  of `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`.
 
-Nothing here assumes a valuation or a reduction: the definition and all seven lemmas are about a
-Weierstrass curve over a commutative ring and a ring homomorphism to a field, so they apply to any
-reduction map one later chooses. They advance
+Nothing here assumes a valuation or a reduction: every statement is about a Weierstrass curve
+over a commutative ring and a ring homomorphism to a field, so it applies to any reduction map
+one later chooses. They advance
 `TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists), whose headline
 `exists_quadraticTwist_hasSplitMultiplicativeReduction` — a curve with nonsplit multiplicative
 reduction acquires split reduction after a separable quadratic twist — is proved by feeding the
@@ -63,9 +68,9 @@ namespace WeierstrassCurve
 variable {A : Type*} [CommRing A] {B : Type*} [CommRing B] {k : Type*} [Field k]
 
 /-- The **node polynomial** `c₄ T² + a₁ c₄ T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)`, whose roots are the
-slopes of the two tangent directions at the node of a multiplicative reduction; its splitting over
-the residue field governs whether the reduction is split (Mathlib's
-`WeierstrassCurve.HasSplitMultiplicativeReduction`). -/
+slopes of the two tangent directions at the node of a multiplicative reduction. This is the
+polynomial Mathlib writes out inline in `WeierstrassCurve.HasSplitMultiplicativeReduction`, whose
+splitting over the residue field *is* that class's defining condition. -/
 noncomputable def nodePoly (W : WeierstrassCurve A) : Polynomial A :=
   .C W.c₄ * .X ^ 2 + .C (W.a₁ * W.c₄) * .X - .C (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)
 
@@ -74,20 +79,13 @@ are rational over the residue field exactly when `-c₄ c₆` is a square there
 (`nodePoly_map_splits_iff_isSquare`); twisting by `(t, n)` multiplies `-c₄ c₆` by
 `(t² - 4n)⁵ = (t² - 4n)⁴ · (t² - 4n)`, i.e. by the twisting parameter up to a square. -/
 theorem nodePoly_discrim (W : WeierstrassCurve A) :
-    (W.a₁ * W.c₄) ^ 2 + 4 * W.c₄ * (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)
+    discrim W.c₄ (W.a₁ * W.c₄) (-(54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄))
       = -(W.c₄ * W.c₆) := by
-  simp only [c₄, c₆, b₂, b₄, b₆]; ring
-
-/-- The node polynomial base-changed along a ring homomorphism. -/
-lemma nodePoly_map (φ : A →+* B) (W : WeierstrassCurve A) :
-    W.nodePoly.map φ = .C (φ W.c₄) * .X ^ 2 + .C (φ (W.a₁ * W.c₄)) * .X
-      - .C (φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)) := by
-  simp only [nodePoly, Polynomial.map_sub, Polynomial.map_add, Polynomial.map_mul,
-    Polynomial.map_pow, Polynomial.map_C, Polynomial.map_X]
+  simp only [discrim, c₄, c₆, b₂, b₄, b₆]; ring
 
 /-- The node polynomial is natural in the coefficient ring: it commutes with base change of the
-Weierstrass equation along any ring homomorphism, since every coefficient is a polynomial in the
-`aᵢ` and `Polynomial.map` is a ring homomorphism on each. -/
+Weierstrass equation along any ring homomorphism. -/
+@[simp]
 lemma map_nodePoly (φ : A →+* B) (W : WeierstrassCurve A) :
     (W.map φ).nodePoly = W.nodePoly.map φ := by
   simp only [nodePoly, WeierstrassCurve.map_c₄, WeierstrassCurve.map_a₁, WeierstrassCurve.map_b₂,
@@ -101,19 +99,23 @@ shape `C a * X ^ 2 + C b * X + C c` that the criteria of
 lemma nodePoly_map_eq_quadratic (φ : A →+* B) (W : WeierstrassCurve A) :
     W.nodePoly.map φ = .C (φ W.c₄) * .X ^ 2 + .C (φ (W.a₁ * W.c₄)) * .X
       + .C (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)) := by
-  rw [nodePoly_map, map_neg, sub_eq_add_neg]
+  simp only [nodePoly, Polynomial.map_sub, Polynomial.map_add, Polynomial.map_mul,
+    Polynomial.map_pow, Polynomial.map_C, Polynomial.map_X]
+  rw [map_neg, sub_eq_add_neg]
 
 /-- The image of `nodePoly_discrim` under a ring homomorphism, in the shape produced by the
 quadratic criteria applied to `nodePoly_map_eq_quadratic`. -/
 lemma map_nodePoly_discrim (φ : A →+* B) (W : WeierstrassCurve A) :
-    φ (W.a₁ * W.c₄) ^ 2 - 4 * φ W.c₄ * (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄))
+    discrim (φ W.c₄) (φ (W.a₁ * W.c₄)) (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄))
       = φ (-(W.c₄ * W.c₆)) := by
-  rw [mul_neg, sub_neg_eq_add, ← map_pow, ← map_ofNat φ 4, ← map_mul, ← map_mul, ← map_add]
-  exact congrArg φ W.nodePoly_discrim
+  rw [discrim, mul_neg, sub_neg_eq_add, ← map_pow, ← map_ofNat φ 4, ← map_mul, ← map_mul,
+    ← map_add]
+  exact congrArg φ (by simpa only [discrim, mul_neg, sub_neg_eq_add] using W.nodePoly_discrim)
 
 /-- Under a change of variables `C = (u, r, s, t)`, the node polynomial transforms by the affine
 substitution `T ↦ u T + s` and the unit scalar `u⁻⁶` — reflecting that the tangent slopes `λ`
-transform as `λ ↦ (λ - s)/u`. In particular its splitting field is unchanged. -/
+transform as `λ ↦ (λ - s)/u`. Over a field this makes splitting invariant; see
+`nodePoly_map_splits_smul_iff`. -/
 lemma nodePoly_smul (W : WeierstrassCurve A) (C : VariableChange A) :
     (C • W).nodePoly = .C ((↑C.u⁻¹ : A) ^ 6)
       * W.nodePoly.comp (.C (↑C.u : A) * .X + .C C.s) := by
@@ -158,23 +160,24 @@ lemma nodePoly_map_splits_smul_iff (φ : A →+* k) (W : WeierstrassCurve A) (C 
   exact (Polynomial.splits_iff_comp_splits_of_natDegree_eq_one
     (Polynomial.natDegree_linear hu)).symm
 
-/-- **Split criterion away from residue characteristic two.** Over a field `k` with `2 ≠ 0`, the
-node polynomial splits — i.e. the two tangent directions at the node are `k`-rational — exactly
-when its discriminant `-c₄ c₆` (`nodePoly_discrim`) is a square in `k`. This is the tool that,
-applied to a quadratic twist via the scaling `-c₄' c₆' = (t² - 4n)⁵ · (-c₄ c₆)`, turns a nonsplit
-reduction into a split one after twisting by the right square class. -/
+/-- **Split criterion away from residue characteristic two.** Over a field `k` with `2 ≠ 0`, and
+provided `c₄` does not die under `φ` — the condition that makes the reduced polynomial genuinely
+quadratic, and which multiplicative reduction supplies — the node polynomial splits, i.e. the two
+tangent directions at the node are `k`-rational, exactly when `φ (-(c₄ * c₆))`, the image of its
+discriminant (`nodePoly_discrim`), is a square in `k`. This discharges Mathlib's TODO at
+`Reduction.lean:315`, and is the tool that, applied to a quadratic twist via the scaling
+`-c₄' c₆' = (t² - 4n)⁵ · (-c₄ c₆)`, turns a nonsplit reduction into a split one after twisting by
+the right square class. -/
 lemma nodePoly_map_splits_iff_isSquare [NeZero (2 : k)] (φ : A →+* k) (W : WeierstrassCurve A)
     (hc₄ : φ W.c₄ ≠ 0) :
     (W.nodePoly.map φ).Splits ↔ IsSquare (φ (-(W.c₄ * W.c₆))) := by
-  rw [nodePoly_map_eq_quadratic, Polynomial.splits_quadratic_iff hc₄, discrim,
-    map_nodePoly_discrim]
+  rw [nodePoly_map_eq_quadratic, Polynomial.splits_quadratic_iff hc₄, map_nodePoly_discrim]
 
 /-- **Split criterion in residue characteristic two.** Over a field `k` of characteristic `2`,
 where the square-class criterion `nodePoly_map_splits_iff_isSquare` says nothing, the node
 polynomial splits exactly when its Artin-Schreier invariant lies in the image of `z ↦ z² + z`.
-Here `c₄` and `c₆` are assumed nonzero, and that forces the linear coefficient `a₁ c₄` to be
-nonzero as well — the discriminant is `(a₁ c₄)²` once `4 = 0`, and it equals `-c₄ c₆ ≠ 0` — so
-`Polynomial.splits_quadratic_iff_of_two_eq_zero` applies. -/
+Both `c₄` and `c₆` are required nonzero in `k`; together they force the linear coefficient
+`a₁ c₄` to be nonzero as well, which is what makes the criterion applicable. -/
 lemma nodePoly_map_splits_iff_of_two_eq_zero (h2 : (2 : k) = 0) (φ : A →+* k)
     (W : WeierstrassCurve A) (hc₄ : φ W.c₄ ≠ 0) (hc₆ : φ W.c₆ ≠ 0) :
     (W.nodePoly.map φ).Splits ↔ ∃ z, φ (W.a₁ * W.c₄) ^ 2 * (z ^ 2 + z)
@@ -182,6 +185,7 @@ lemma nodePoly_map_splits_iff_of_two_eq_zero (h2 : (2 : k) = 0) (φ : A →+* k)
   have hb : φ (W.a₁ * W.c₄) ≠ 0 := by
     have h4 : (4 : k) = 0 := by linear_combination (2 : k) * h2
     have hAk := map_nodePoly_discrim φ W
+    rw [discrim] at hAk
     intro h0
     refine neg_ne_zero.mpr (mul_ne_zero hc₄ hc₆) ?_
     rw [← map_mul, ← map_neg]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.VariableChange
+public import TauCeti.Algebra.Polynomial.QuadraticDiscriminant
+
+/-!
+# The node polynomial of a Weierstrass curve
+
+When a Weierstrass curve degenerates to a node, the two tangent directions there are the roots of
+a quadratic, and the reduction is called *split* exactly when those roots are rational over the
+residue field. This file introduces that quadratic, `WeierstrassCurve.nodePoly`, and answers the
+question of when it splits — the criterion Mathlib's
+`Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean` leaves open where it defines
+`WeierstrassCurve.HasSplitMultiplicativeReduction`.
+
+* `WeierstrassCurve.nodePoly` is `c₄ T² + a₁ c₄ T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)`, defined over any
+  commutative ring;
+* `WeierstrassCurve.nodePoly_discrim` computes its discriminant as `-c₄ c₆`. This is the number
+  the twist lane needs: twisting by `(t, n)` scales `-c₄ c₆` by `(t² - 4n)⁵`, i.e. by the twisting
+  parameter times a square, so twisting by the right square class moves the discriminant into the
+  squares;
+* `WeierstrassCurve.map_nodePoly` is naturality, `(W.map φ).nodePoly = W.nodePoly.map φ`. It is
+  what lets the criteria below — stated for `W.nodePoly.map φ`, i.e. for the *reduction* of the
+  node polynomial — be read as statements about the node polynomial of the reduced curve;
+* `WeierstrassCurve.nodePoly_smul` and `WeierstrassCurve.nodePoly_map_splits_smul_iff`: a change
+  of variables `(u, r, s, t)` transforms the node polynomial by the affine substitution
+  `T ↦ u T + s` and the unit scalar `u⁻⁶`, so whether it splits is an isomorphism invariant. This
+  is why split multiplicative reduction is a property of the curve and not of the equation;
+* `WeierstrassCurve.nodePoly_map_splits_iff_isSquare` and
+  `WeierstrassCurve.nodePoly_map_splits_iff_of_two_eq_zero`: the splitting criteria themselves,
+  away from residue characteristic two (splits iff `-c₄ c₆` is a square) and in residue
+  characteristic two (splits iff an Artin-Schreier condition holds), obtained from the general
+  quadratic criteria of `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`.
+
+Nothing here assumes a valuation or a reduction: the definition and all seven lemmas are about a
+Weierstrass curve over a commutative ring and a ring homomorphism to a field, so they apply to any
+reduction map one later chooses. They advance
+`TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists), whose headline
+`exists_quadraticTwist_hasSplitMultiplicativeReduction` — a curve with nonsplit multiplicative
+reduction acquires split reduction after a separable quadratic twist — is proved by feeding the
+twist's scaling of `-c₄ c₆` into `nodePoly_map_splits_iff_isSquare`.
+
+Adapted from the FLT project (`ImperialCollegeLondon/FLT`, at the roadmap's pin `bc2fe8ff7396`,
+FLT PR #1088, Apache 2.0): the node-polynomial block of
+`FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean`, together with
+`splitPolynomial_discrim` from `FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean`,
+renamed here to `nodePoly_discrim` because `splitPolynomial` names no declaration. Those files'
+headers read `Authors: Kevin Buzzard, William Coram, Claude` and `Authors: Kevin Buzzard, Claude`;
+following this repository's convention for adapted material, the upstream authorship is credited
+here rather than in the copyright header. Ported with the source's `@[expose]` dropped, and with
+the minimal-model and multiplicative-reduction blocks of the source file left to the PR that
+consumes them.
+-/
+
+public section
+
+namespace WeierstrassCurve
+
+variable {A : Type*} [CommRing A] {B : Type*} [CommRing B] {k : Type*} [Field k]
+
+/-- The **node polynomial** `c₄ T² + a₁ c₄ T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)`, whose roots are the
+slopes of the two tangent directions at the node of a multiplicative reduction; its splitting over
+the residue field governs whether the reduction is split (Mathlib's
+`WeierstrassCurve.HasSplitMultiplicativeReduction`). -/
+noncomputable def nodePoly (W : WeierstrassCurve A) : Polynomial A :=
+  .C W.c₄ * .X ^ 2 + .C (W.a₁ * W.c₄) * .X - .C (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)
+
+/-- The discriminant of the node polynomial is `-c₄ c₆`. Hence the tangent directions at the node
+are rational over the residue field exactly when `-c₄ c₆` is a square there
+(`nodePoly_map_splits_iff_isSquare`); twisting by `(t, n)` multiplies `-c₄ c₆` by
+`(t² - 4n)⁵ = (t² - 4n)⁴ · (t² - 4n)`, i.e. by the twisting parameter up to a square. -/
+theorem nodePoly_discrim (W : WeierstrassCurve A) :
+    (W.a₁ * W.c₄) ^ 2 + 4 * W.c₄ * (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)
+      = -(W.c₄ * W.c₆) := by
+  simp only [c₄, c₆, b₂, b₄, b₆]; ring
+
+/-- The node polynomial base-changed along a ring homomorphism. -/
+lemma nodePoly_map (φ : A →+* B) (W : WeierstrassCurve A) :
+    W.nodePoly.map φ = .C (φ W.c₄) * .X ^ 2 + .C (φ (W.a₁ * W.c₄)) * .X
+      - .C (φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)) := by
+  simp only [nodePoly, Polynomial.map_sub, Polynomial.map_add, Polynomial.map_mul,
+    Polynomial.map_pow, Polynomial.map_C, Polynomial.map_X]
+
+/-- The node polynomial is natural in the coefficient ring: it commutes with base change of the
+Weierstrass equation along any ring homomorphism, since every coefficient is a polynomial in the
+`aᵢ` and `Polynomial.map` is a ring homomorphism on each. -/
+lemma map_nodePoly (φ : A →+* B) (W : WeierstrassCurve A) :
+    (W.map φ).nodePoly = W.nodePoly.map φ := by
+  simp only [nodePoly, WeierstrassCurve.map_c₄, WeierstrassCurve.map_a₁, WeierstrassCurve.map_b₂,
+    WeierstrassCurve.map_b₄, WeierstrassCurve.map_b₆, WeierstrassCurve.map_a₂, Polynomial.map_add,
+    Polynomial.map_sub, Polynomial.map_mul, Polynomial.map_pow, Polynomial.map_C, Polynomial.map_X,
+    Polynomial.map_ofNat, map_add, map_sub, map_mul, map_ofNat]
+
+/-- The reduced node polynomial, presented as a quadratic with an additive constant term — the
+shape `C a * X ^ 2 + C b * X + C c` that the criteria of
+`TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean` consume. -/
+lemma nodePoly_map_eq_quadratic (φ : A →+* B) (W : WeierstrassCurve A) :
+    W.nodePoly.map φ = .C (φ W.c₄) * .X ^ 2 + .C (φ (W.a₁ * W.c₄)) * .X
+      + .C (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)) := by
+  rw [nodePoly_map, map_neg, sub_eq_add_neg]
+
+/-- The image of `nodePoly_discrim` under a ring homomorphism, in the shape produced by the
+quadratic criteria applied to `nodePoly_map_eq_quadratic`. -/
+lemma map_nodePoly_discrim (φ : A →+* B) (W : WeierstrassCurve A) :
+    φ (W.a₁ * W.c₄) ^ 2 - 4 * φ W.c₄ * (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄))
+      = φ (-(W.c₄ * W.c₆)) := by
+  rw [mul_neg, sub_neg_eq_add, ← map_pow, ← map_ofNat φ 4, ← map_mul, ← map_mul, ← map_add]
+  exact congrArg φ W.nodePoly_discrim
+
+/-- Under a change of variables `C = (u, r, s, t)`, the node polynomial transforms by the affine
+substitution `T ↦ u T + s` and the unit scalar `u⁻⁶` — reflecting that the tangent slopes `λ`
+transform as `λ ↦ (λ - s)/u`. In particular its splitting field is unchanged. -/
+lemma nodePoly_smul (W : WeierstrassCurve A) (C : VariableChange A) :
+    (C • W).nodePoly = .C ((↑C.u⁻¹ : A) ^ 6)
+      * W.nodePoly.comp (.C (↑C.u : A) * .X + .C C.s) := by
+  have e2 : (↑C.u⁻¹ : A) ^ 6 * (↑C.u : A) ^ 2 = (↑C.u⁻¹ : A) ^ 4 := by
+    have := congrArg (Units.val (α := A)) (by group : C.u⁻¹ ^ 6 * C.u ^ 2 = C.u⁻¹ ^ 4)
+    simpa only [Units.val_mul, Units.val_pow_eq_pow_val] using this
+  have e1 : (↑C.u⁻¹ : A) ^ 6 * (↑C.u : A) = (↑C.u⁻¹ : A) ^ 5 := by
+    have := congrArg (Units.val (α := A)) (by group : C.u⁻¹ ^ 6 * C.u = C.u⁻¹ ^ 5)
+    simpa only [Units.val_mul, Units.val_pow_eq_pow_val] using this
+  have e2p : (algebraMap A (Polynomial A) (↑C.u⁻¹ : A)) ^ 6 * (algebraMap A (Polynomial A) ↑C.u) ^ 2
+      = (algebraMap A (Polynomial A) (↑C.u⁻¹ : A)) ^ 4 := by
+    rw [← map_pow, ← map_pow, ← map_mul, e2, map_pow]
+  have e1p : (algebraMap A (Polynomial A) (↑C.u⁻¹ : A)) ^ 6 * algebraMap A (Polynomial A) ↑C.u
+      = (algebraMap A (Polynomial A) (↑C.u⁻¹ : A)) ^ 5 := by
+    rw [← map_pow, ← map_mul, e1, map_pow]
+  simp only [nodePoly, c₄, variableChange_a₁, variableChange_a₂, variableChange_b₂,
+    variableChange_b₄, variableChange_b₆, Polynomial.mul_comp, Polynomial.add_comp,
+    Polynomial.sub_comp, Polynomial.C_comp, Polynomial.X_comp, pow_two, mul_add, add_mul,
+    mul_sub, sub_mul]
+  simp only [Polynomial.C_eq_algebraMap, map_mul, map_pow, map_sub, map_add, map_ofNat]
+  linear_combination
+    (-(algebraMap A (Polynomial A) W.b₂ ^ 2 - 24 * algebraMap A (Polynomial A) W.b₄) *
+        Polynomial.X ^ 2) * e2p +
+    (-(2 * (algebraMap A (Polynomial A) W.b₂ ^ 2 - 24 * algebraMap A (Polynomial A) W.b₄) *
+            algebraMap A (Polynomial A) C.s +
+          algebraMap A (Polynomial A) W.a₁ *
+            (algebraMap A (Polynomial A) W.b₂ ^ 2 - 24 * algebraMap A (Polynomial A) W.b₄)) *
+        Polynomial.X) * e1p
+
+/-- **Invariance of the node polynomial's splitting under change of variables.** Since a change of
+variables transforms the node polynomial by an affine substitution and a unit scalar
+(`nodePoly_smul`), whether it splits over a field `k` is unchanged. This is what makes split
+multiplicative reduction an isomorphism invariant rather than a property of the equation. -/
+lemma nodePoly_map_splits_smul_iff (φ : A →+* k) (W : WeierstrassCurve A) (C : VariableChange A) :
+    ((C • W).nodePoly.map φ).Splits ↔ (W.nodePoly.map φ).Splits := by
+  have hu : φ (↑C.u : A) ≠ 0 := (RingHom.isUnit_map φ C.u.isUnit).ne_zero
+  have hu6 : φ ((↑C.u⁻¹ : A) ^ 6) ≠ 0 := by
+    rw [map_pow]; exact pow_ne_zero 6 (RingHom.isUnit_map φ C.u⁻¹.isUnit).ne_zero
+  rw [nodePoly_smul, Polynomial.map_mul, Polynomial.map_C, Polynomial.map_comp, Polynomial.map_add,
+    Polynomial.map_mul, Polynomial.map_C, Polynomial.map_X, Polynomial.map_C,
+    Polynomial.splits_mul_iff_right (Polynomial.C_ne_zero.mpr hu6) (Polynomial.Splits.C _)]
+  exact (Polynomial.splits_iff_comp_splits_of_natDegree_eq_one
+    (Polynomial.natDegree_linear hu)).symm
+
+/-- **Split criterion away from residue characteristic two.** Over a field `k` with `2 ≠ 0`, the
+node polynomial splits — i.e. the two tangent directions at the node are `k`-rational — exactly
+when its discriminant `-c₄ c₆` (`nodePoly_discrim`) is a square in `k`. This is the tool that,
+applied to a quadratic twist via the scaling `-c₄' c₆' = (t² - 4n)⁵ · (-c₄ c₆)`, turns a nonsplit
+reduction into a split one after twisting by the right square class. -/
+lemma nodePoly_map_splits_iff_isSquare [NeZero (2 : k)] (φ : A →+* k) (W : WeierstrassCurve A)
+    (hc₄ : φ W.c₄ ≠ 0) :
+    (W.nodePoly.map φ).Splits ↔ IsSquare (φ (-(W.c₄ * W.c₆))) := by
+  rw [nodePoly_map_eq_quadratic, Polynomial.splits_quadratic_iff hc₄, discrim,
+    map_nodePoly_discrim]
+
+/-- **Split criterion in residue characteristic two.** Over a field `k` of characteristic `2`,
+where the square-class criterion `nodePoly_map_splits_iff_isSquare` says nothing, the node
+polynomial splits exactly when its Artin-Schreier invariant lies in the image of `z ↦ z² + z`.
+Here `c₄` and `c₆` are assumed nonzero, and that forces the linear coefficient `a₁ c₄` to be
+nonzero as well — the discriminant is `(a₁ c₄)²` once `4 = 0`, and it equals `-c₄ c₆ ≠ 0` — so
+`Polynomial.splits_quadratic_iff_of_two_eq_zero` applies. -/
+lemma nodePoly_map_splits_iff_of_two_eq_zero (h2 : (2 : k) = 0) (φ : A →+* k)
+    (W : WeierstrassCurve A) (hc₄ : φ W.c₄ ≠ 0) (hc₆ : φ W.c₆ ≠ 0) :
+    (W.nodePoly.map φ).Splits ↔ ∃ z, φ (W.a₁ * W.c₄) ^ 2 * (z ^ 2 + z)
+      = φ W.c₄ * (-φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)) := by
+  have hb : φ (W.a₁ * W.c₄) ≠ 0 := by
+    have h4 : (4 : k) = 0 := by linear_combination (2 : k) * h2
+    have hAk := map_nodePoly_discrim φ W
+    intro h0
+    refine neg_ne_zero.mpr (mul_ne_zero hc₄ hc₆) ?_
+    rw [← map_mul, ← map_neg]
+    linear_combination -hAk + φ (W.a₁ * W.c₄) * h0
+      + φ W.c₄ * φ (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄) * h4
+  rw [nodePoly_map_eq_quadratic, Polynomial.splits_quadratic_iff_of_two_eq_zero h2 hc₄ hb]
+
+end WeierstrassCurve
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -212,7 +212,7 @@ lemma nodePoly_map_splits_iff_exists_artinSchreier_of_two_eq_zero (h2 : (2 : k) 
     intro h0
     refine neg_ne_zero.mpr (mul_ne_zero hc₄ hc₆) ?_
     rw [← map_mul, ← map_neg, ← map_nodePoly_discrim φ W,
-      Polynomial.discrim_eq_sq_of_two_eq_zero h2, h0, zero_pow two_ne_zero]
+      discrim_eq_sq_of_two_eq_zero h2, h0, zero_pow two_ne_zero]
   rw [nodePoly_map_eq_quadratic,
     Polynomial.splits_quadratic_iff_exists_artinSchreier_of_two_eq_zero h2 hc₄ hb]
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -16,10 +16,11 @@ residue field. Mathlib writes that quadratic out inline, in the very definition 
 `WeierstrassCurve.HasSplitMultiplicativeReduction`
 (`Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean`, applied to `W.integralModel R`), but
 gives it no name and proves nothing about it. This file names it `WeierstrassCurve.nodePoly` and
-says when it splits, discharging the TODO recorded just above that class — *"add characterization
-in terms of the discriminant when the characteristic is not 2"* — and adding the characteristic-
-two counterpart. The remaining step, rewriting the class itself through these criteria, needs
-`integralModel` and belongs to the minimal-model slice.
+says when it splits, supplying the criterion the TODO just above that class asks for — *"add
+characterization in terms of the discriminant when the characteristic is not 2"* — together with
+the characteristic-two counterpart the TODO does not ask for. Restating the class itself through
+these criteria needs `integralModel` and belongs to the minimal-model slice, so the TODO is
+answered at the level of the polynomial, not yet of the class.
 
 * `WeierstrassCurve.nodePoly` is `c₄ T² + a₁ c₄ T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)`, defined over any
   commutative ring;
@@ -30,24 +31,27 @@ two counterpart. The remaining step, rewriting the class itself through these cr
 * `WeierstrassCurve.map_nodePoly` is naturality, `(W.map φ).nodePoly = W.nodePoly.map φ`. It is
   what lets the criteria below — stated for `W.nodePoly.map φ`, i.e. for the *reduction* of the
   node polynomial — be read as statements about the node polynomial of the reduced curve;
-* `WeierstrassCurve.nodePoly_smul` and `WeierstrassCurve.nodePoly_map_splits_smul_iff`: a change
+* `WeierstrassCurve.variableChange_nodePoly` and
+  `WeierstrassCurve.variableChange_nodePoly_map_splits_iff`: a change
   of variables `(u, r, s, t)` transforms the node polynomial by the affine substitution
   `T ↦ u T + s` and the unit scalar `u⁻⁶`, so whether it splits is an isomorphism invariant. This
   is why split multiplicative reduction is a property of the curve and not of the equation;
 * `WeierstrassCurve.nodePoly_map_splits_iff_isSquare` and
   `WeierstrassCurve.nodePoly_map_splits_iff_of_two_eq_zero`: the splitting criteria themselves,
-  each under the hypothesis that `c₄` survives the map. Away from residue characteristic two it
-  splits iff the image of `-c₄ c₆` is a square; in residue characteristic two, where that says
-  nothing, iff an Artin-Schreier condition holds. Both come from the general quadratic criteria
-  of `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`.
+  each needing `c₄` to survive the map. Away from residue characteristic two it splits iff the
+  image of `-c₄ c₆` is a square; in residue characteristic two, where that says nothing, iff an
+  Artin-Schreier condition holds — and there `c₆` must survive as well. Both come from the
+  general quadratic criteria of `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`.
 
 Nothing here assumes a valuation or a reduction: every statement is about a Weierstrass curve
 over a commutative ring and a ring homomorphism to a field, so it applies to any reduction map
 one later chooses. They advance
 `TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists), whose headline
 `exists_quadraticTwist_hasSplitMultiplicativeReduction` — a curve with nonsplit multiplicative
-reduction acquires split reduction after a separable quadratic twist — is proved by feeding the
-twist's scaling of `-c₄ c₆` into `nodePoly_map_splits_iff_isSquare`.
+reduction acquires split reduction after a separable quadratic twist — carries no
+residue-characteristic hypothesis, so it needs both criteria: away from residue characteristic
+two one feeds the twist's scaling of `-c₄ c₆` into `nodePoly_map_splits_iff_isSquare`, and in
+residue characteristic two the route is `nodePoly_map_splits_iff_of_two_eq_zero`.
 
 Adapted from the FLT project (`ImperialCollegeLondon/FLT`, at the roadmap's pin `bc2fe8ff7396`,
 FLT PR #1088, Apache 2.0): the node-polynomial block of
@@ -69,13 +73,15 @@ variable {A : Type*} [CommRing A] {B : Type*} [CommRing B] {k : Type*} [Field k]
 
 /-- The **node polynomial** `c₄ T² + a₁ c₄ T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)`, whose roots are the
 slopes of the two tangent directions at the node of a multiplicative reduction. This is the
-polynomial Mathlib writes out inline in `WeierstrassCurve.HasSplitMultiplicativeReduction`, whose
-splitting over the residue field *is* that class's defining condition. -/
+polynomial Mathlib writes out inline in `WeierstrassCurve.HasSplitMultiplicativeReduction`, which
+asks for the splitting over the residue field of this polynomial formed from the *integral model*
+`W.integralModel R`, as its one extra condition on top of `HasMultiplicativeReduction`. -/
 noncomputable def nodePoly (W : WeierstrassCurve A) : Polynomial A :=
   .C W.c₄ * .X ^ 2 + .C (W.a₁ * W.c₄) * .X - .C (54 * W.b₆ - 3 * W.b₂ * W.b₄ + W.a₂ * W.c₄)
 
-/-- The discriminant of the node polynomial is `-c₄ c₆`. Hence the tangent directions at the node
-are rational over the residue field exactly when `-c₄ c₆` is a square there
+/-- The discriminant of the node polynomial is `-c₄ c₆`. Hence — away from residue characteristic
+two, and provided `c₄` survives the reduction — the tangent directions at the node are rational
+over the residue field exactly when the image of `-c₄ c₆` is a square there
 (`nodePoly_map_splits_iff_isSquare`); twisting by `(t, n)` multiplies `-c₄ c₆` by
 `(t² - 4n)⁵ = (t² - 4n)⁴ · (t² - 4n)`, i.e. by the twisting parameter up to a square. -/
 theorem nodePoly_discrim (W : WeierstrassCurve A) :
@@ -115,8 +121,8 @@ lemma map_nodePoly_discrim (φ : A →+* B) (W : WeierstrassCurve A) :
 /-- Under a change of variables `C = (u, r, s, t)`, the node polynomial transforms by the affine
 substitution `T ↦ u T + s` and the unit scalar `u⁻⁶` — reflecting that the tangent slopes `λ`
 transform as `λ ↦ (λ - s)/u`. Over a field this makes splitting invariant; see
-`nodePoly_map_splits_smul_iff`. -/
-lemma nodePoly_smul (W : WeierstrassCurve A) (C : VariableChange A) :
+`variableChange_nodePoly_map_splits_iff`. -/
+lemma variableChange_nodePoly (W : WeierstrassCurve A) (C : VariableChange A) :
     (C • W).nodePoly = .C ((↑C.u⁻¹ : A) ^ 6)
       * W.nodePoly.comp (.C (↑C.u : A) * .X + .C C.s) := by
   have e2 : (↑C.u⁻¹ : A) ^ 6 * (↑C.u : A) ^ 2 = (↑C.u⁻¹ : A) ^ 4 := by
@@ -147,15 +153,17 @@ lemma nodePoly_smul (W : WeierstrassCurve A) (C : VariableChange A) :
 
 /-- **Invariance of the node polynomial's splitting under change of variables.** Since a change of
 variables transforms the node polynomial by an affine substitution and a unit scalar
-(`nodePoly_smul`), whether it splits over a field `k` is unchanged. This is what makes split
-multiplicative reduction an isomorphism invariant rather than a property of the equation. -/
-lemma nodePoly_map_splits_smul_iff (φ : A →+* k) (W : WeierstrassCurve A) (C : VariableChange A) :
+(`variableChange_nodePoly`), whether it splits over a field `k` is unchanged. This is what makes
+split multiplicative reduction an isomorphism invariant rather than a property of the
+equation. -/
+lemma variableChange_nodePoly_map_splits_iff (φ : A →+* k) (W : WeierstrassCurve A)
+    (C : VariableChange A) :
     ((C • W).nodePoly.map φ).Splits ↔ (W.nodePoly.map φ).Splits := by
   have hu : φ (↑C.u : A) ≠ 0 := (RingHom.isUnit_map φ C.u.isUnit).ne_zero
   have hu6 : φ ((↑C.u⁻¹ : A) ^ 6) ≠ 0 := by
     rw [map_pow]; exact pow_ne_zero 6 (RingHom.isUnit_map φ C.u⁻¹.isUnit).ne_zero
-  rw [nodePoly_smul, Polynomial.map_mul, Polynomial.map_C, Polynomial.map_comp, Polynomial.map_add,
-    Polynomial.map_mul, Polynomial.map_C, Polynomial.map_X, Polynomial.map_C,
+  rw [variableChange_nodePoly, Polynomial.map_mul, Polynomial.map_C, Polynomial.map_comp,
+    Polynomial.map_add, Polynomial.map_mul, Polynomial.map_C, Polynomial.map_X, Polynomial.map_C,
     Polynomial.splits_mul_iff_right (Polynomial.C_ne_zero.mpr hu6) (Polynomial.Splits.C _)]
   exact (Polynomial.splits_iff_comp_splits_of_natDegree_eq_one
     (Polynomial.natDegree_linear hu)).symm
@@ -164,14 +172,15 @@ lemma nodePoly_map_splits_smul_iff (φ : A →+* k) (W : WeierstrassCurve A) (C 
 provided `c₄` does not die under `φ` — the condition that makes the reduced polynomial genuinely
 quadratic, and which multiplicative reduction supplies — the node polynomial splits, i.e. the two
 tangent directions at the node are `k`-rational, exactly when `φ (-(c₄ * c₆))`, the image of its
-discriminant (`nodePoly_discrim`), is a square in `k`. This discharges Mathlib's TODO at
-`Reduction.lean:315`, and is the tool that, applied to a quadratic twist via the scaling
+discriminant (`nodePoly_discrim`), is a square in `k`. This is the characterization Mathlib's
+TODO in `Reduction.lean` asks for, and is the tool that, applied to a quadratic twist via the
+scaling
 `-c₄' c₆' = (t² - 4n)⁵ · (-c₄ c₆)`, turns a nonsplit reduction into a split one after twisting by
 the right square class. -/
 lemma nodePoly_map_splits_iff_isSquare [NeZero (2 : k)] (φ : A →+* k) (W : WeierstrassCurve A)
     (hc₄ : φ W.c₄ ≠ 0) :
     (W.nodePoly.map φ).Splits ↔ IsSquare (φ (-(W.c₄ * W.c₆))) := by
-  rw [nodePoly_map_eq_quadratic, Polynomial.splits_quadratic_iff hc₄, map_nodePoly_discrim]
+  rw [nodePoly_map_eq_quadratic, Polynomial.splits_quadratic_iff_isSquare hc₄, map_nodePoly_discrim]
 
 /-- **Split criterion in residue characteristic two.** Over a field `k` of characteristic `2`,
 where the square-class criterion `nodePoly_map_splits_iff_isSquare` says nothing, the node


### PR DESCRIPTION
Introduces `WeierstrassCurve.nodePolynomial`, the quadratic whose roots are the two tangent slopes at
the node of a multiplicative reduction, and settles when it splits. Mathlib defines
`WeierstrassCurve.HasSplitMultiplicativeReduction`
(`Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean:322`) but supplies no criterion for it;
this PR supplies the criterion, in both residue characteristics.

Two new files, 17 declarations. No existing file is modified, so nothing is renamed or removed.

## What is here

**`TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean`** (10 declarations)

* `nodePolynomial W = C c₄ * X ^ 2 + C (a₁ c₄) * X - C (54 b₆ - 3 b₂ b₄ + a₂ c₄)`, over any
  `CommRing`, with `nodePolynomial_def` restating the formula for consumers (the body is not exposed
  across the module boundary);
* `discrim_nodePolynomial`: its discriminant is `-c₄ c₆`. This is the number the twist lane needs —
  twisting by `(t, n)` scales `-c₄ c₆` by `(t² - 4n)⁵`, i.e. by the twisting parameter times a
  square;
* `map_nodePolynomial`, `nodePolynomial_map_eq_quadratic`, `discrim_map_nodePolynomial`: base
  change. `map_nodePolynomial` — `(W.map φ).nodePolynomial = W.nodePolynomial.map φ` — is what lets the criteria,
  stated for `W.nodePolynomial.map φ`, be read as statements about the node polynomial of the reduced
  curve; the other three put the reduced polynomial and its discriminant into the shape the
  quadratic criteria consume;
* `variableChange_nodePolynomial`, `splits_variableChange_nodePolynomial_map_iff`: a change of variables `(u, r, s, t)`
  transforms the node polynomial by `T ↦ u T + s` and the unit scalar `u⁻⁶`, so its splitting is
  unchanged. This is why split multiplicative reduction is an invariant of the curve and not of
  the equation;
* `splits_nodePolynomial_map_iff_isSquare` and `splits_nodePolynomial_map_iff_exists_artinSchreier_of_two_eq_zero`: the criteria.
  Away from residue characteristic two the node polynomial splits iff `-c₄ c₆` is a square; in
  residue characteristic two, where the square-class criterion is vacuous, iff an
  Artin–Schreier condition holds.

Nothing in the file assumes a valuation or a reduction: everything is stated for a Weierstrass
curve over a commutative ring and a ring homomorphism to a field, so it applies to whatever
reduction map is chosen later.

**`TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean`** (7 declarations) — the general facts
the criteria specialise. Mathlib's `Mathlib/Algebra/QuadraticDiscriminant.lean` works with the
*equation* `a x² + b x + c = 0`; this file reads those facts back as statements about the
*polynomial* `C a * X ^ 2 + C b * X + C c` over a field with `a ≠ 0`: separable iff the
discriminant is nonzero (`separable_quadratic_iff_discrim_ne_zero`), splits iff it has a root
(`splits_quadratic_iff_exists_root`), splits iff the discriminant is a square away from
characteristic two (`splits_quadratic_iff_isSquare`), and the Artin–Schreier form in characteristic two
(`splits_quadratic_iff_exists_artinSchreier_of_two_eq_zero`), together with the supporting
`derivative_quadratic`, `sq_derivative_quadratic_sub_mul_eq_C_discrim`, and the root-level
`discrim_eq_sq_of_two_eq_zero` — in characteristic two the discriminant is `b²`, which is why the
square-class criterion says nothing there. Each is proved *through* the corresponding Mathlib fact
rather than around it: `discrim_eq_sq_of_quadratic_eq_zero` and `exists_quadratic_eq_zero` for
the discriminant, and `Splits.exists_eval_eq_zero` / `Splits.of_natDegree_eq_two` for the two
directions of the root criterion.

## Roadmap

`Roadmap: EllipticCurves`

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"nodepolynomial"}-->

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists) names as its concrete deliverable
"the headline that a curve with **nonsplit** multiplicative reduction acquires **split** reduction
after a separable quadratic twist", seeded in `TauCetiRoadmap/EllipticCurves/Suggested.lean:495`
as `exists_quadraticTwist_hasSplitMultiplicativeReduction`. That proof is exactly: the twist
scales `-c₄ c₆` by `(t² - 4n)⁵`, so choosing the square class of `t² - 4n` to correct it and
feeding the result into `splits_nodePolynomial_map_iff_isSquare` turns a nonsplit reduction into a
split one. This PR is that criterion; without it the target cannot be stated in terms of anything
computable.

The stages the target presupposes are present: `quadraticTwistOf` with the `c₄ ↦ D²c₄`,
`c₆ ↦ D³c₆` scalings is on `main` (#2381), and the extension twist `quadraticTwist E L` is open
as #2592. One input remains after this PR — the minimal-model and multiplicative-reduction block
(`isMinimal_of_valuation_c₄_eq_one` and the `residue_integralModel_*` lemmas), which is a
separate topic and will be its own PR; this one deliberately stops at the point where a valuation
would first be needed.

## Provenance

Adapted from the FLT project (`ImperialCollegeLondon/FLT`, Apache 2.0) at the roadmap's
§Provenance pin `bc2fe8ff7396` (FLT PR #1088):

| here | FLT source |
|---|---|
| `TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean` | `FLT/Mathlib/Algebra/Polynomial/QuadraticDiscriminant.lean`, whole file |
| `TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean` | `FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean` lines 39–170, plus `splitPolynomial_discrim` from `FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean` |

Those files' headers read `Authors: Kevin Buzzard, Claude` and
`Authors: Kevin Buzzard, William Coram, Claude`; following this repository's convention for
adapted material the upstream authorship is credited in each module docstring rather than in the
copyright header.

Deviations from the source, all recorded in the docstrings:

* FLT's third file in this cluster, `FLT/Mathlib/Algebra/Polynomial/Splits.lean`, is **not**
  ported. Its `Splits.of_natDegree_le_two_of_isRoot` is superseded at our Mathlib pin by
  `Polynomial.Splits.of_natDegree_eq_two`
  (`Mathlib/Algebra/Polynomial/Splits.lean:663`, *"A polynomial of degree `2` with a root
  splits"*), which the one consumer uses directly because it knows the degree is exactly two;
* `splitPolynomial_discrim` is renamed `discrim_nodePolynomial` (and `map_splitPolynomial_discrim` to
  `discrim_map_nodePolynomial`): `splitPolynomial` names no declaration in either project, whereas
  `nodePolynomial` is the polynomial whose discriminant it computes. It also moves out of the
  Weierstrass complements file and next to `nodePolynomial`, its only consumer;
* the file is `NodePolynomial.lean`, not `Reduction.lean`: its contents are entirely the node
  polynomial, and it does not import Mathlib's `Reduction.lean`. That name stays free for the
  minimal-model slice, which does;
* FLT's `aeval_root_nodePoly_map` is not ported — it is consumed only by the
  multiplicative-reduction block, and it would pull in `AdjoinRoot` for nothing;
* the source's `@[expose]` is dropped, and the `A`/`B`/`k` binders are hoisted to `variable`s
  rather than repeated per declaration.

## Absence

Untruncated name greps over `.lake/packages/mathlib` and `TauCeti/` for all 16 declaration names
return zero hits, as does a concept grep for `IsSquare (discrim …)`. A compiled `exact?` probe
(with `set_option autoImplicit false`, so a mistyped constant cannot be silently bound and yield
a false absence) on the headline statements reports "could not close the goal" with no unknown
identifiers. No open PR touches these paths.

One duplicate *was* found this way and removed before opening: a first draft carried FLT's
`Splits.of_natDegree_le_two_of_isRoot` as a third file. The `exact?` probe on that statement
failed — the `≤ 2`-with-`IsRoot` form really is absent — but the form the consumer actually needs,
`= 2` with `eval x = 0`, is in Mathlib. Probing the statement one has written does not test what
the consumer needs.

## Gates

`lake build` clean; all thirteen environment linters clean; `lake exe axioms` reports only
`propext`, `Classical.choice`, `Quot.sound`; every import of each new file confirmed load-bearing
by removing it and rebuilding; no line over 100 characters; no `sorry`, debug command,
`set_option`, `nolint`, or bare `simp`.


