### PR TITLE
feat: add auditable group presentation metadata

### DIFF
--- a/TauCeti/GroupTheory/Presentation/GroupPresentation.lean
+++ b/TauCeti/GroupTheory/Presentation/GroupPresentation.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.Data.Set.Finite.Basic
+public import Mathlib.GroupTheory.PresentedGroup
+public import TauCeti.GroupTheory.Presentation.Relator
+
+/-!
+# Auditable finite group presentations
+
+This file packages a finite group presentation together with the metadata needed to audit a
+transcription from a published source. Generator names determine the arity of the relators, so a
+presentation cannot separately record an incompatible generator count. The expected generator and
+relator counts remain as checkable transcription metadata.
+
+The stored relators are human-readable `TauCeti.Relator` expressions. They are compiled to
+Mathlib's signed words and then interpreted by `FreeGroup.mk`; the resulting finite relation set
+defines `TauCeti.GroupPresentation.Group` using Mathlib's `PresentedGroup`.
+
+## Main definitions
+
+* `TauCeti.GroupPresentation`: cited presentation data and its transcription metadata.
+* `TauCeti.GroupPresentation.relators`: the compiled signed words.
+* `TauCeti.GroupPresentation.relatorSet`: the relations as free-group elements.
+* `TauCeti.GroupPresentation.Group`: the group defined by the presentation.
+* `TauCeti.GroupPresentation.matchesMetadata`: the executable generator and relator count check.
+
+## References
+
+This file implements the finite-presentation metadata format in milestone S0 of
+`TauCetiRoadmap/CFSGStatement/README.md`. Its record fields and dependent-arity design are adapted
+from the target signatures in the human-owned roadmap's `CFSGStatement/Suggested.lean`.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- A finite group presentation together with auditable source and transcription metadata.
+
+The source must be a full presentation of the abstract group, not a semi-presentation for
+recognizing generators in a group already constructed elsewhere. `generatorNames` alone determines
+the relator arity; `expectedGeneratorCount` is retained only as metadata checked by
+`matchesMetadata`.
+
+There is deliberately no checksum field: without a pinned normalization and algorithm, a checksum
+would not be a reproducible check on the transcribed expressions. -/
+structure GroupPresentation where
+  /-- Generator names, in the order used by the relator indices. -/
+  generatorNames : List String
+  /-- Bibliographic citation or database name for the full presentation. -/
+  source : String
+  /-- Page, theorem number, or stable database identifier locating the presentation. -/
+  sourceLocator : String
+  /-- The source's generator and commutator conventions. -/
+  generatorConvention : String
+  /-- Notes explaining any normalization or conversion made during transcription. -/
+  transcriptionNotes : String
+  /-- The number of generators stated by the source. -/
+  expectedGeneratorCount : ℕ
+  /-- The number of relators stated by the source. -/
+  expectedRelatorCount : ℕ
+  /-- Relators transcribed in the generator order recorded by `generatorNames`. -/
+  transcribed : List (Relator (Fin generatorNames.length))
+
+namespace GroupPresentation
+
+/-- The number of generators in a presentation, determined by its generator-name list. -/
+abbrev generatorCount (P : GroupPresentation) : ℕ := P.generatorNames.length
+
+/-- The relator expressions compiled to left-to-right signed words. -/
+def relators (P : GroupPresentation) : List (PresentationWord (Fin P.generatorCount)) :=
+  P.transcribed.map Relator.toWord
+
+/-- Compilation preserves the number of relators. -/
+@[simp]
+theorem length_relators (P : GroupPresentation) : P.relators.length = P.transcribed.length := by
+  simp [relators]
+
+/-- The compiled relations, interpreted as elements of the free group. -/
+def relatorSet (P : GroupPresentation) : Set (FreeGroup (Fin P.generatorCount)) :=
+  {r | r ∈ P.relators.map FreeGroup.mk}
+
+/-- Membership in the relation set is membership in the list of interpreted compiled words. -/
+@[simp]
+theorem mem_relatorSet_iff (P : GroupPresentation) (r : FreeGroup (Fin P.generatorCount)) :
+    r ∈ P.relatorSet ↔ r ∈ P.relators.map FreeGroup.mk :=
+  Iff.rfl
+
+/-- The relation set of a `GroupPresentation` is finite. -/
+theorem relatorSet_finite (P : GroupPresentation) : P.relatorSet.Finite := by
+  simpa only [relatorSet] using (P.relators.map FreeGroup.mk).finite_toSet
+
+/-- The group defined by the generators and compiled relations of a presentation. -/
+abbrev Group (P : GroupPresentation) : Type :=
+  PresentedGroup P.relatorSet
+
+/-- The recorded generator and relator counts agree with the transcribed data.
+
+This checks transcription metadata only; it makes no claim that the source presents a named group
+or that the transcription agrees with the source. -/
+def matchesMetadata (P : GroupPresentation) : Prop :=
+  P.generatorCount = P.expectedGeneratorCount ∧
+    P.transcribed.length = P.expectedRelatorCount
+
+/-- The metadata check is exactly the pair of generator- and relator-count equalities. -/
+@[simp]
+theorem matchesMetadata_iff (P : GroupPresentation) : P.matchesMetadata ↔
+    P.generatorCount = P.expectedGeneratorCount ∧
+      P.transcribed.length = P.expectedRelatorCount :=
+  Iff.rfl
+
+end GroupPresentation
+
+end TauCeti

--- a/TauCeti/GroupTheory/Presentation/GroupPresentation.lean
+++ b/TauCeti/GroupTheory/Presentation/GroupPresentation.lean
@@ -5,7 +5,6 @@ Authors: Codex
 -/
 module
 
-public import Mathlib.Data.Set.Finite.Basic
 public import Mathlib.GroupTheory.PresentedGroup
 public import TauCeti.GroupTheory.Presentation.Relator
 
@@ -13,13 +12,15 @@ public import TauCeti.GroupTheory.Presentation.Relator
 # Auditable finite group presentations
 
 This file packages a finite group presentation together with the metadata needed to audit a
-transcription from a published source. Generator names determine the arity of the relators, so a
-presentation cannot separately record an incompatible generator count. The expected generator and
-relator counts remain as checkable transcription metadata.
+transcription from a published source. The generator-name list alone fixes the relator index type
+to `Fin generatorNames.length`, so the relator arity cannot disagree with the generator names. The
+generator and relator counts stated by the source are separate metadata, checked against the
+transcribed data by `TauCeti.GroupPresentation.matchesMetadata`.
 
 The stored relators are human-readable `TauCeti.Relator` expressions. They are compiled to
-Mathlib's signed words and then interpreted by `FreeGroup.mk`; the resulting finite relation set
-defines `TauCeti.GroupPresentation.Group` using Mathlib's `PresentedGroup`.
+Mathlib's signed words and then interpreted by `FreeGroup.mk`; the resulting finite list of
+relations, regarded as a set, defines `TauCeti.GroupPresentation.Group` using Mathlib's
+`PresentedGroup`.
 
 ## Main definitions
 
@@ -27,7 +28,7 @@ defines `TauCeti.GroupPresentation.Group` using Mathlib's `PresentedGroup`.
 * `TauCeti.GroupPresentation.relators`: the compiled signed words.
 * `TauCeti.GroupPresentation.relatorSet`: the relations as free-group elements.
 * `TauCeti.GroupPresentation.Group`: the group defined by the presentation.
-* `TauCeti.GroupPresentation.matchesMetadata`: the executable generator and relator count check.
+* `TauCeti.GroupPresentation.matchesMetadata`: the decidable generator and relator count check.
 
 ## References
 
@@ -81,19 +82,24 @@ def relators (P : GroupPresentation) : List (PresentationWord (Fin P.generatorCo
 theorem length_relators (P : GroupPresentation) : P.relators.length = P.transcribed.length := by
   simp [relators]
 
+/-- The compiled words are exactly the compilations of the transcribed expressions. -/
+@[simp]
+theorem mem_relators_iff (P : GroupPresentation) (w : PresentationWord (Fin P.generatorCount)) :
+    w ∈ P.relators ↔ ∃ t ∈ P.transcribed, t.toWord = w := by
+  simp [relators]
+
 /-- The compiled relations, interpreted as elements of the free group. -/
 def relatorSet (P : GroupPresentation) : Set (FreeGroup (Fin P.generatorCount)) :=
   {r | r ∈ P.relators.map FreeGroup.mk}
 
-/-- Membership in the relation set is membership in the list of interpreted compiled words. -/
+/-- The relations are exactly the free-group elements denoted by the transcribed expressions.
+
+This is stated against `Relator.toFreeGroup` rather than against the compiled words, so a consumer
+discharging the relations of `PresentedGroup` never has to unfold the compiler. -/
 @[simp]
 theorem mem_relatorSet_iff (P : GroupPresentation) (r : FreeGroup (Fin P.generatorCount)) :
-    r ∈ P.relatorSet ↔ r ∈ P.relators.map FreeGroup.mk :=
-  Iff.rfl
-
-/-- The relation set of a `GroupPresentation` is finite. -/
-theorem relatorSet_finite (P : GroupPresentation) : P.relatorSet.Finite := by
-  simpa only [relatorSet] using (P.relators.map FreeGroup.mk).finite_toSet
+    r ∈ P.relatorSet ↔ ∃ t ∈ P.transcribed, t.toFreeGroup = r := by
+  simp [relatorSet]
 
 /-- The group defined by the generators and compiled relations of a presentation. -/
 abbrev Group (P : GroupPresentation) : Type :=
@@ -107,13 +113,30 @@ def matchesMetadata (P : GroupPresentation) : Prop :=
   P.generatorCount = P.expectedGeneratorCount ∧
     P.transcribed.length = P.expectedRelatorCount
 
-/-- A matching relator count ensures that the compiled relator list has the recorded length.
+/-- The metadata check unfolds to its two count equalities. -/
+@[simp]
+theorem matchesMetadata_iff (P : GroupPresentation) :
+    P.matchesMetadata ↔
+      P.generatorCount = P.expectedGeneratorCount ∧
+        P.transcribed.length = P.expectedRelatorCount :=
+  Iff.rfl
 
-A presentation satisfying `matchesMetadata` supplies this hypothesis as its second conjunct. -/
-theorem length_relators_eq_expected (P : GroupPresentation)
-    (h : P.transcribed.length = P.expectedRelatorCount) :
-    P.relators.length = P.expectedRelatorCount :=
-  P.length_relators.trans h
+instance (P : GroupPresentation) : Decidable P.matchesMetadata :=
+  decidable_of_iff _ (matchesMetadata_iff P).symm
+
+/-- A transcribed row discharges its count check by `decide`. The record below is an illustration
+of the format, not a transcription of a published source. -/
+example : GroupPresentation.matchesMetadata
+    { generatorNames := ["a", "b"]
+      source := "illustrative record"
+      sourceLocator := "none"
+      generatorConvention := "Mathlib's commutator bracket"
+      transcriptionNotes := "no normalization was needed"
+      expectedGeneratorCount := 2
+      expectedRelatorCount := 3
+      transcribed :=
+        [.pow (.gen 0) 2, .pow (.gen 1) 3, .pow (.mul (.gen 0) (.gen 1)) 2] } := by
+  decide
 
 end GroupPresentation
 

--- a/TauCeti/GroupTheory/Presentation/GroupPresentation.lean
+++ b/TauCeti/GroupTheory/Presentation/GroupPresentation.lean
@@ -107,10 +107,13 @@ def matchesMetadata (P : GroupPresentation) : Prop :=
   P.generatorCount = P.expectedGeneratorCount ∧
     P.transcribed.length = P.expectedRelatorCount
 
-/-- Matching metadata ensures that the compiled relator list has the recorded length. -/
-theorem length_relators_eq_expected (P : GroupPresentation) (h : P.matchesMetadata) :
+/-- A matching relator count ensures that the compiled relator list has the recorded length.
+
+A presentation satisfying `matchesMetadata` supplies this hypothesis as its second conjunct. -/
+theorem length_relators_eq_expected (P : GroupPresentation)
+    (h : P.transcribed.length = P.expectedRelatorCount) :
     P.relators.length = P.expectedRelatorCount :=
-  P.length_relators.trans h.2
+  P.length_relators.trans h
 
 end GroupPresentation
 

--- a/TauCeti/GroupTheory/Presentation/GroupPresentation.lean
+++ b/TauCeti/GroupTheory/Presentation/GroupPresentation.lean
@@ -107,12 +107,10 @@ def matchesMetadata (P : GroupPresentation) : Prop :=
   P.generatorCount = P.expectedGeneratorCount ∧
     P.transcribed.length = P.expectedRelatorCount
 
-/-- The metadata check is exactly the pair of generator- and relator-count equalities. -/
-@[simp]
-theorem matchesMetadata_iff (P : GroupPresentation) : P.matchesMetadata ↔
-    P.generatorCount = P.expectedGeneratorCount ∧
-      P.transcribed.length = P.expectedRelatorCount :=
-  Iff.rfl
+/-- Matching metadata ensures that the compiled relator list has the recorded length. -/
+theorem length_relators_eq_expected (P : GroupPresentation) (h : P.matchesMetadata) :
+    P.relators.length = P.expectedRelatorCount :=
+  P.length_relators.trans h.2
 
 end GroupPresentation
 


### PR DESCRIPTION
This PR packages the finite-presentation metadata format required by `TauCetiRoadmap/CFSGStatement/README.md`, milestone **S0: presentation format and sources**. Define `GroupPresentation` with bibliographic and transcription metadata, make the generator-name list determine the relator arity, compile the landed `Relator` expressions into a finite relation set, expose the resulting `PresentedGroup`, and provide the decidable generator- and relator-count check.

This is the next effective step after the S0 relator compiler landed in #2578: each future sporadic row can now store source data and type-safe relators without duplicating the presentation arity. After this PR, S0 still needs the complete 26-row manifest of admissible full-presentation sources, including locators and review status; S1 then needs the independently audited relator transcription for every row.

The dependent record shape is adapted from the target signatures in the human-owned roadmap's `CFSGStatement/Suggested.lean`. Reuse Mathlib's `FreeGroup.mk` and `PresentedGroup`; no Mathlib implementation is vendored. Add `TauCeti/GroupTheory/Presentation/GroupPresentation.lean` (143 lines).

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"group-presentation-metadata"}-->

🤖 Prepared with Codex

