### PR TITLE
refactor(Conditional): name the cross-term identity behind the polarisation

### DIFF
--- a/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
+++ b/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
+import Mathlib.MeasureTheory.Function.ConditionalExpectation.PullOut
 -- Non-public: `eLpNorm_condExp_le_eLpNorm` (the Lᵖ contraction of conditional expectation) is
 -- used only inside the proof of the L¹-continuity lemma below, not in any public signature.
 import Mathlib.MeasureTheory.Function.ConditionalExpectation.Real
@@ -136,6 +137,22 @@ lemma condExp_ae_eq_of_forall_condExp_ae_eq_of_tendsto_eLpNorm
   filter_upwards [h_norm_zero] with ω hω
   simp only [Pi.zero_apply] at hω
   exact sub_eq_zero.mp hω
+
+/-- **The cross term against a coarser conditional expectation.** If `f` is `m`-measurable and is
+the conditional expectation of `g` on `m`, then `∫ g * f = ∫ f * f`. -/
+theorem integral_mul_eq_integral_sq_of_condExp_ae_eq {Ω : Type*} {mΩ : MeasurableSpace Ω}
+    {m : MeasurableSpace Ω} (hm : m ≤ mΩ) {μ : @Measure Ω mΩ} [SigmaFinite (μ.trim hm)]
+    {f g : Ω → ℝ}
+    (hf : AEStronglyMeasurable[m] f μ) (hgf_int : Integrable (fun ω => g ω * f ω) μ)
+    (hg_int : Integrable g μ) (h_tower : μ[g | m] =ᵐ[μ] f) :
+    ∫ ω, g ω * f ω ∂μ = ∫ ω, f ω * f ω ∂μ := by
+  -- pull the `m`-measurable factor out of the conditional expectation, then apply the tower law
+  have h_pullout := condExp_mul_of_aestronglyMeasurable_right (m := m) hf hgf_int hg_int
+  calc ∫ ω, g ω * f ω ∂μ
+      = ∫ ω, μ[fun ω => g ω * f ω | m] ω ∂μ := (integral_condExp hm).symm
+    _ = ∫ ω, μ[g | m] ω * f ω ∂μ := integral_congr_ae h_pullout
+    _ = ∫ ω, f ω * f ω ∂μ := by
+        refine integral_congr_ae ?_; filter_upwards [h_tower] with ω hω; rw [hω]
 
 end MeasureTheory
 

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -449,6 +449,22 @@ private lemma ae_norm_condExp_indicator_le_one {Ω : Type*} {m0 : MeasurableSpac
   ae_bdd_norm_condExp_of_ae_bdd_norm (m := m') <| Filter.Eventually.of_forall fun ω => by
     simpa only [norm_one] using norm_indicator_le_norm_self (fun _ => (1 : ℝ)) ω
 
+/-- **The cross term against a coarser conditional expectation.** If `f` is `m`-measurable and is
+the conditional expectation of `g` on `m`, then `∫ g * f = ∫ f * f`. -/
+private lemma integral_mul_eq_integral_sq_of_condExp_ae_eq {Ω : Type*} {mΩ : MeasurableSpace Ω}
+    {m : MeasurableSpace Ω} (hm : m ≤ mΩ) {μ : @Measure Ω mΩ} [SigmaFinite (μ.trim hm)]
+    {f g : Ω → ℝ}
+    (hf : StronglyMeasurable[m] f) (hgf_int : Integrable (fun ω => g ω * f ω) μ)
+    (hg_int : Integrable g μ) (h_tower : μ[g | m] =ᵐ[μ] f) :
+    ∫ ω, g ω * f ω ∂μ = ∫ ω, f ω * f ω ∂μ := by
+  -- pull the `m`-measurable factor out of the conditional expectation, then apply the tower law
+  have h_pullout := condExp_mul_of_stronglyMeasurable_right (m := m) hf hgf_int hg_int
+  calc ∫ ω, g ω * f ω ∂μ
+      = ∫ ω, μ[fun ω => g ω * f ω | m] ω ∂μ := (integral_condExp hm).symm
+    _ = ∫ ω, μ[g | m] ω * f ω ∂μ := integral_congr_ae h_pullout
+    _ = ∫ ω, f ω * f ω ∂μ := by
+        refine integral_congr_ae ?_; filter_upwards [h_tower] with ω hω; rw [hω]
+
 /-- **Kallenberg Lemma 1.3 (contraction-independence).** If `(X, W) =ᵈ (X, W')` and
 `σ(W) ≤ σ(W')` (so `W` is a contraction of `W'`), then conditioning the indicator of `X` on the
 finer `σ(W')` equals conditioning on the coarser `σ(W)`, almost everywhere. -/
@@ -486,15 +502,9 @@ theorem condExp_indicator_eq_of_law_eq_of_comap_le [IsFiniteMeasure μ] (X : Ω 
     hμ₂_int.bdd_mul hμ₂_int.aestronglyMeasurable hμ₂_bound
   have hμ₂μ₁_int : Integrable (fun ω => μ₂ ω * μ₁ ω) μ :=
     hμ₁_int.bdd_mul hμ₂_int.aestronglyMeasurable hμ₂_bound
-  -- Cross term `∫ μ₂ μ₁ = ∫ μ₁ μ₁` via pull-out and the tower property.
-  have h_cross : ∫ ω, μ₂ ω * μ₁ ω ∂μ = ∫ ω, μ₁ ω * μ₁ ω ∂μ := by
-    have hμ₁_meas : StronglyMeasurable[mW] μ₁ := stronglyMeasurable_condExp
-    have h_pullout := condExp_mul_of_stronglyMeasurable_right (m := mW) hμ₁_meas hμ₂μ₁_int hμ₂_int
-    calc ∫ ω, μ₂ ω * μ₁ ω ∂μ
-        = ∫ ω, μ[fun ω => μ₂ ω * μ₁ ω | mW] ω ∂μ := (integral_condExp hmW_le).symm
-      _ = ∫ ω, μ[μ₂ | mW] ω * μ₁ ω ∂μ := integral_congr_ae h_pullout
-      _ = ∫ ω, μ₁ ω * μ₁ ω ∂μ := by
-          refine integral_congr_ae ?_; filter_upwards [h_tower] with ω hω; rw [hω]
+  have hμ₁_meas : StronglyMeasurable[mW] μ₁ := stronglyMeasurable_condExp
+  have h_cross : ∫ ω, μ₂ ω * μ₁ ω ∂μ = ∫ ω, μ₁ ω * μ₁ ω ∂μ :=
+    integral_mul_eq_integral_sq_of_condExp_ae_eq hmW_le hμ₁_meas hμ₂μ₁_int hμ₂_int h_tower
   have h_sq_eq : ∫ ω, μ₁ ω * μ₁ ω ∂μ = ∫ ω, μ₂ ω * μ₂ ω ∂μ := h_sq_eq_raw
   -- `μ₁ =ᵐ μ₂` from the polarisation `∫ (μ₂ - μ₁)² = ∫ μ₂² - 2 ∫ μ₂ μ₁ + ∫ μ₁² = 0`.
   exact (ae_eq_of_integral_mul_eq_of_integral_sq_eq hμ₁sq_int hμ₂sq_int hμ₂μ₁_int

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Probability.Independence.Conditional
 import Mathlib.MeasureTheory.Function.ConditionalExpectation.PullOut
+import TauCeti.MeasureTheory.Function.ConditionalExpectation
 import Mathlib.MeasureTheory.Function.ConditionalExpectation.Real
 import Mathlib.MeasureTheory.Function.AEEqOfIntegral
 import Mathlib.MeasureTheory.Function.FactorsThrough
@@ -449,22 +450,6 @@ private lemma ae_norm_condExp_indicator_le_one {Ω : Type*} {m0 : MeasurableSpac
   ae_bdd_norm_condExp_of_ae_bdd_norm (m := m') <| Filter.Eventually.of_forall fun ω => by
     simpa only [norm_one] using norm_indicator_le_norm_self (fun _ => (1 : ℝ)) ω
 
-/-- **The cross term against a coarser conditional expectation.** If `f` is `m`-measurable and is
-the conditional expectation of `g` on `m`, then `∫ g * f = ∫ f * f`. -/
-private lemma integral_mul_eq_integral_sq_of_condExp_ae_eq {Ω : Type*} {mΩ : MeasurableSpace Ω}
-    {m : MeasurableSpace Ω} (hm : m ≤ mΩ) {μ : @Measure Ω mΩ} [SigmaFinite (μ.trim hm)]
-    {f g : Ω → ℝ}
-    (hf : StronglyMeasurable[m] f) (hgf_int : Integrable (fun ω => g ω * f ω) μ)
-    (hg_int : Integrable g μ) (h_tower : μ[g | m] =ᵐ[μ] f) :
-    ∫ ω, g ω * f ω ∂μ = ∫ ω, f ω * f ω ∂μ := by
-  -- pull the `m`-measurable factor out of the conditional expectation, then apply the tower law
-  have h_pullout := condExp_mul_of_stronglyMeasurable_right (m := m) hf hgf_int hg_int
-  calc ∫ ω, g ω * f ω ∂μ
-      = ∫ ω, μ[fun ω => g ω * f ω | m] ω ∂μ := (integral_condExp hm).symm
-    _ = ∫ ω, μ[g | m] ω * f ω ∂μ := integral_congr_ae h_pullout
-    _ = ∫ ω, f ω * f ω ∂μ := by
-        refine integral_congr_ae ?_; filter_upwards [h_tower] with ω hω; rw [hω]
-
 /-- **Kallenberg Lemma 1.3 (contraction-independence).** If `(X, W) =ᵈ (X, W')` and
 `σ(W) ≤ σ(W')` (so `W` is a contraction of `W'`), then conditioning the indicator of `X` on the
 finer `σ(W')` equals conditioning on the coarser `σ(W)`, almost everywhere. -/
@@ -502,9 +487,9 @@ theorem condExp_indicator_eq_of_law_eq_of_comap_le [IsFiniteMeasure μ] (X : Ω 
     hμ₂_int.bdd_mul hμ₂_int.aestronglyMeasurable hμ₂_bound
   have hμ₂μ₁_int : Integrable (fun ω => μ₂ ω * μ₁ ω) μ :=
     hμ₁_int.bdd_mul hμ₂_int.aestronglyMeasurable hμ₂_bound
-  have hμ₁_meas : StronglyMeasurable[mW] μ₁ := stronglyMeasurable_condExp
   have h_cross : ∫ ω, μ₂ ω * μ₁ ω ∂μ = ∫ ω, μ₁ ω * μ₁ ω ∂μ :=
-    integral_mul_eq_integral_sq_of_condExp_ae_eq hmW_le hμ₁_meas hμ₂μ₁_int hμ₂_int h_tower
+    MeasureTheory.integral_mul_eq_integral_sq_of_condExp_ae_eq hmW_le
+      (stronglyMeasurable_condExp (m := mW)).aestronglyMeasurable hμ₂μ₁_int hμ₂_int h_tower
   have h_sq_eq : ∫ ω, μ₁ ω * μ₁ ω ∂μ = ∫ ω, μ₂ ω * μ₂ ω ∂μ := h_sq_eq_raw
   -- `μ₁ =ᵐ μ₂` from the polarisation `∫ (μ₂ - μ₁)² = ∫ μ₂² - 2 ∫ μ₂ μ₁ + ∫ μ₁² = 0`.
   exact (ae_eq_of_integral_mul_eq_of_integral_sq_eq hμ₁sq_int hμ₂sq_int hμ₂μ₁_int


### PR DESCRIPTION
`condExp_indicator_eq_of_law_eq_of_comap_le` finishes by polarisation: `∫ (μ₂ - μ₁)² = ∫ μ₂² - 2∫ μ₂μ₁ + ∫ μ₁² = 0`. Supplying the cross term `∫ μ₂μ₁ = ∫ μ₁μ₁` took eleven lines in the middle of the proof, and none of it is about indicators, laws, or contractions.

`integral_mul_eq_integral_sq_of_condExp_ae_eq` states it on its own: if `f` is a.e. `m`-measurable and is the conditional expectation of `g` on `m`, then `∫ g * f = ∫ f * f`. It lives in `TauCeti/MeasureTheory/Function/ConditionalExpectation.lean`, the generic conditional-expectation module, since nothing in it is about conditional independence, indicators, laws or contractions.

Its hypotheses are re-derived rather than inherited. The parent has `X`, `W`, `W'`, the pair-law equality, the comap ordering, the indicator `φ` and the measurability of `X` all in scope; none of them appear. The helper needs the sub-σ-algebra ordering, the σ-finiteness of the trim that `integral_condExp` requires, `f` being a.e. `m`-measurable, integrability of `g` and of `g * f`, and the tower relation `μ[g | m] =ᵐ f`. That is exactly what the two-step argument consumes.

Mathlib has the pull-out lemma (`condExp_mul_of_stronglyMeasurable_right`) and `integral_condExp`, but not this composite, which is the shape the polarisation argument actually needs.

The parent drops from 40 lines to 34, and the cross term becomes a single application.

One note on the signature. The lemma takes its own `{Ω} {mΩ : MeasurableSpace Ω}` and writes `{μ : @Measure Ω mΩ}` explicitly, matching `ae_eq_of_integral_mul_eq_of_integral_sq_eq` earlier in the file. Writing `{μ : Measure Ω}` instead lets the elaborator find a `MeasurableSpace Ω` instance other than `mΩ`, and then `μ.trim hm` fails to typecheck — the file's section variable supplies a competing instance.

## Review rounds

- `placement`: the lemma is generic conditional-expectation material, so it moved out of the independence file into `TauCeti/MeasureTheory/Function/ConditionalExpectation.lean` as public API. `Mathlib.…ConditionalExpectation.PullOut` is imported there non-publicly, since only the proof mentions it.
- `generality`: `StronglyMeasurable[m] f` was one notch too strong — Mathlib's `condExp_mul_of_aestronglyMeasurable_right` needs only `AEStronglyMeasurable[m] f μ`, which is what the statement now takes. The call site passes `(stronglyMeasurable_condExp (m := mW)).aestronglyMeasurable`.

## `placement` and `api-design` disagree here, and I have measured both states

| state | `placement` | `api-design` |
|---|---|---|
| private lemma in `Probability/Independence/Conditional.lean` | ⛔ "hides reusable measure-theory material in a downstream topic file" | ✅ approved |
| public in `MeasureTheory/Function/ConditionalExpectation.lean` (this PR) | ✅ approved | ⛔ "promotes a one-use proof helper to public API" |

There is no third state. A non-public declaration in `ConditionalExpectation.lean` is invisible to `Conditional.lean`, so "put it in the generic module but keep it non-public" does not typecheck as a plan; `api-design`'s suggested alternative — keep it private to the independence file — is exactly the first row, which `placement` blocked.

I have shipped the second row, for the same reason as in #2581, which is deadlocked on the identical axis: `placement` owns the location question, and the lemma's statement mentions only a sub-σ-algebra, a measure, two real functions and a conditional expectation. Nothing in it is about conditional independence, indicators, laws or contractions, which is precisely `placement`'s point.

If the resolution is that this should not be public, then it belongs inline in the polarisation proof and `placement`'s finding needs withdrawing in the same round — otherwise the next push simply swaps which rubric blocks.

Gates run locally: `lake build` (7209 jobs), `lake exe axioms` (32636 declarations), `lake exe module-system` (1644 modules), `scripts/lint-env.sh` — all green.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
