### PR TITLE
docs(Huber): correct the Padic/Field docstrings on why the ideal is stated by membership

### DIFF
--- a/TauCeti/RingTheory/Huber/Padic/Field.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Field.lean
@@ -15,9 +15,10 @@ pseudouniformiser. Together with `TauCeti.Huber.PadicInt.not_isTateRing` this is
 Layer-0 example separating the two notions: the same ideal of definition makes `ℤ_[p]` Huber but
 not Tate, and `ℚ_[p]` Tate, the difference being that `p` becomes a unit in `ℚ_[p]`.
 
-No transport is needed here, unlike for `ℤ_[p]`: Mathlib defines `ℤ_[p]` as the subring
-`{x : ℚ_[p] | ‖x‖ ≤ 1}`, so `Ideal ℤ_[p]` is already the type
-`TauCeti.Huber.PairOfDefinition` asks for.
+No `Ideal.comap` is needed here. Mathlib's `ℤ_[p]` is the subtype `{x : ℚ_[p] // ‖x‖ ≤ 1}` and
+`PadicInt.subring p` is a separate declaration cutting out the same set, so `ℤ_[p]` and
+`↥(PadicInt.subring p)` are definitionally equal. That is why `idealOfDefinition :=
+maximalIdeal ℤ_[p]` typechecks against the expected `Ideal ↥(PadicInt.subring p)` below.
 
 ## Main definitions
 
@@ -25,6 +26,10 @@ No transport is needed here, unlike for `ℤ_[p]`: Mathlib defines `ℤ_[p]` as 
 
 ## Main results
 
+* `TauCeti.Huber.Padic.pairOfDefinition_ringOfDefinition` and
+  `TauCeti.Huber.Padic.mem_pairOfDefinition_idealOfDefinition`: the two projections of the pair.
+  The ring of definition is pinned down by an equation, the ideal of definition by the
+  membership form `‖x‖ < 1` — see the note on that lemma for why.
 * `TauCeti.Huber.Padic.isPseudoUniformizer_p`: `p` is a pseudouniformiser of `ℚ_[p]`.
 * `TauCeti.Huber.Padic.isHuberRing` and `TauCeti.Huber.Padic.isTateRing`: `ℚ_[p]` is a Huber
   ring, and a Tate ring.
@@ -71,9 +76,9 @@ noncomputable def pairOfDefinition : PairOfDefinition ℚ_[p] where
 
 /-- The ring of definition of `pairOfDefinition` is `ℤ_[p]`.
 
-The ideal of definition is characterised by
-`TauCeti.Huber.Padic.mem_pairOfDefinition_idealOfDefinition`; an equation is avoided because
-`idealOfDefinition`'s type depends on `ringOfDefinition`. -/
+The companion projection, the ideal of definition, is characterised by
+`TauCeti.Huber.Padic.mem_pairOfDefinition_idealOfDefinition` in membership form rather than by an
+equation; that lemma's docstring gives the reason. -/
 @[simp]
 theorem pairOfDefinition_ringOfDefinition :
     (pairOfDefinition (p := p)).ringOfDefinition = _root_.PadicInt.subring p := (rfl)
@@ -81,10 +86,12 @@ theorem pairOfDefinition_ringOfDefinition :
 /-- **The ideal of definition of `pairOfDefinition` is `(p)`**, in membership form: an element
 belongs exactly when its norm is less than one.
 
-The membership form is used because `idealOfDefinition`'s type depends on `ringOfDefinition`, so
-an equation with `maximalIdeal ℤ_[p]` would be between two different `Ideal` types. It also
-leaves the ideal decidable downstream, which a statement transported along an equivalence would
-not. -/
+The membership form is used because `pairOfDefinition`'s body is not exposed, so the projection
+`pairOfDefinition.ringOfDefinition` does not reduce. The equation
+`pairOfDefinition.idealOfDefinition = maximalIdeal ℤ_[p]` is therefore rejected — the elaborator
+reports `Ideal ℤ_[p]` against `Ideal ↥pairOfDefinition.ringOfDefinition`, noting that
+`pairOfDefinition` "was not unfolded because their definition is not exposed". Membership avoids
+the issue: `x` already inhabits the dependent type, so nothing has to be transported. -/
 @[simp]
 theorem mem_pairOfDefinition_idealOfDefinition
     {x : (pairOfDefinition (p := p)).ringOfDefinition} :

--- a/TauCeti/RingTheory/Huber/Padic/Field.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Field.lean
@@ -86,12 +86,16 @@ theorem pairOfDefinition_ringOfDefinition :
 /-- **The ideal of definition of `pairOfDefinition` is `(p)`**, in membership form: an element
 belongs exactly when its norm is less than one.
 
-The membership form is used because `pairOfDefinition`'s body is not exposed, so the projection
-`pairOfDefinition.ringOfDefinition` does not reduce. The equation
-`pairOfDefinition.idealOfDefinition = maximalIdeal ℤ_[p]` is therefore rejected — the elaborator
-reports `Ideal ℤ_[p]` against `Ideal ↥pairOfDefinition.ringOfDefinition`, noting that
-`pairOfDefinition` "was not unfolded because their definition is not exposed". Membership avoids
-the issue: `x` already inhabits the dependent type, so nothing has to be transported. -/
+The membership form is used because the equation
+`pairOfDefinition.idealOfDefinition = maximalIdeal ℤ_[p]` does not elaborate. The two sides *are*
+definitionally equal — marking `pairOfDefinition` `@[expose]` makes that very statement typecheck
+and closes it by `rfl` — but at the transparency the elaborator uses it will not unfold a
+definition whose body is unexposed, so checking `Ideal ℤ_[p]` against
+`Ideal ↥pairOfDefinition.ringOfDefinition` fails with the note that `pairOfDefinition` "was not
+unfolded because their definition is not exposed". This is a limit on elaboration, not a
+statement that the projection cannot reduce. Exposing the body is not worth it here, since it
+would force the proof-only `isOpen_padicIntSubring` public too; membership sidesteps the issue
+entirely, as `x` already inhabits the dependent type. -/
 @[simp]
 theorem mem_pairOfDefinition_idealOfDefinition
     {x : (pairOfDefinition (p := p)).ringOfDefinition} :


### PR DESCRIPTION
Docstring-only fix to `TauCeti/RingTheory/Huber/Padic/Field.lean`. No declaration changes.

**Why this is a separate PR.** #2538 merged at `213afc50` — one push before the documentation fix
I had already made on its branch (`599053d3`), so the corrected text never reached `main`. The
finding it answers was raised on #2538 by the `documentation` rubric and is
[still accurate against `main`](https://github.com/TauCetiProject/TauCeti/pull/2538#discussion_r3745303900).

Three things were wrong.

**1. A false claim.** The lemma docstring justified the membership form partly by saying it
"leaves the ideal decidable downstream, which a statement transported along an equivalence would
not". Nothing in this file is transported — the module docstring says so three lines up — and
`‖(x : ℚ_[p])‖ < 1` carries no `Decidable` instance, so the sentence described a benefit that
does not exist. Deleted.

**2. Two docstrings contradicting each other.** The same lemma said an equation "would be between
two different `Ideal` types", while the module docstring said Mathlib defines `ℤ_[p]` as the
subring `{x : ℚ_[p] | ‖x‖ ≤ 1}` so `Ideal ℤ_[p]` "is already the type `PairOfDefinition` asks
for". Both cannot hold of the same file. I settled it against the compiler rather than by picking
one — putting the equation into the file gives:

```
error: Type mismatch
  maximalIdeal ℤ_[p]
has type
  Ideal ℤ_[p]
but is expected to have type
  Ideal ↥pairOfDefinition.ringOfDefinition

Note: The following definitions were not unfolded because their definition is not exposed:
  pairOfDefinition
```

So the obstruction is that the `def` body is not exposed, hence the projection does not reduce —
not a difference of `Ideal` types in the abstract. Both docstrings now say that, and the module
docstring instead records the fact that *is* true and that the file relies on: `ℤ_[p]` is the
subtype `{x : ℚ_[p] // ‖x‖ ≤ 1}`, `PadicInt.subring p` is a separate declaration cutting out the
same set, and they are definitionally equal — which is why `idealOfDefinition := maximalIdeal
ℤ_[p]` typechecks at the definition site against the expected `Ideal ↥(PadicInt.subring p)`.

**3. An incomplete `Main results`.** It omitted both projection lemmas,
`pairOfDefinition_ringOfDefinition` and `mem_pairOfDefinition_idealOfDefinition`, though two
other docstrings in the file designate the latter as *the* characterisation of the ideal of
definition. Added, noting which is an equation and which is a membership.

Build and the four-linter driver (`simpNF`, `unusedArguments`, `docBlame`, `unusedHavesSuffices`)
are clean on `TauCeti.Huber`.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0-examples-padic-field"}-->

🤖 Prepared with Claude Code
