### PR TITLE
refactor(Contour): name the closedness of the excised parameter set

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -725,14 +725,6 @@ theorem cauchyPVAt_concat_range {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ : ℂ
       ∑ k ∈ Finset.range n, cauchyPVAt γ (t k) (t (k + 1)) f z₀ :=
   (HasCauchyPVAt.concat_range fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt).cauchyPVAt_eq
 
-/-- **The excised parameter set is closed.** For a curve continuous on `[[a, b]]`, the set of
-parameters at which it stays within `ε` of a point `s` is closed. -/
-theorem isClosed_setOfPred_mem_uIcc_norm_sub_le {γ : ℝ → ℂ} {a b : ℝ}
-    (hγ_cont : ContinuousOn γ (Set.uIcc a b)) (s : ℂ) (ε : ℝ) :
-    IsClosed {t ∈ Set.uIcc a b | ‖γ t - s‖ ≤ ε} :=
-  ((hγ_cont.sub continuousOn_const).norm).preimage_isClosed_of_isClosed
-    (by rw [← Set.Icc_min_max]; exact isClosed_Icc) isClosed_Iic
-
 end TauCeti.Contour
 
 end

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -725,6 +725,14 @@ theorem cauchyPVAt_concat_range {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ : ℂ
       ∑ k ∈ Finset.range n, cauchyPVAt γ (t k) (t (k + 1)) f z₀ :=
   (HasCauchyPVAt.concat_range fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt).cauchyPVAt_eq
 
+/-- **The excised parameter set is closed.** For a curve continuous on `[[a, b]]`, the set of
+parameters at which it stays within `ε` of a point `s` is closed. -/
+theorem isClosed_setOfPred_mem_uIcc_norm_sub_le {γ : ℝ → ℂ} {a b : ℝ}
+    (hγ_cont : ContinuousOn γ (Set.uIcc a b)) (s : ℂ) (ε : ℝ) :
+    IsClosed {t ∈ Set.uIcc a b | ‖γ t - s‖ ≤ ε} :=
+  ((hγ_cont.sub continuousOn_const).norm).preimage_isClosed_of_isClosed
+    (by rw [← Set.Icc_min_max]; exact isClosed_Icc) isClosed_Iic
+
 end TauCeti.Contour
 
 end

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -722,9 +722,8 @@ private theorem isClosed_setOfPred_mem_uIcc_exists_norm_sub_le {γ : ℝ → ℂ
     simp only [Set.mem_ofPred_eq, Set.mem_iUnion, exists_prop]
     tauto
   rw [he]
-  refine isClosed_biUnion_finset fun s _ => ?_
-  exact ((hγ_cont.sub continuousOn_const).norm).preimage_isClosed_of_isClosed
-    (by rw [← Set.Icc_min_max]; exact isClosed_Icc) isClosed_Iic
+  exact isClosed_biUnion_finset fun s _ =>
+    isClosed_setOfPred_mem_uIcc_norm_sub_le hγ_cont s ε
 
 /-- Adjoining the excision points `S'` multiplies the truncated integrand by the indicator of the
 set of parameters at which the curve stays further than `ε` from every point of `S'`. -/

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
+import TauCeti.Analysis.Contour.Curve.Distance
 import Mathlib.MeasureTheory.Integral.DominatedConvergence
 import Mathlib.Analysis.Calculus.Deriv.Inverse
 import Mathlib.Topology.Order.LeftRightNhds

--- a/TauCeti/Analysis/Contour/Curve/Distance.lean
+++ b/TauCeti/Analysis/Contour/Curve/Distance.lean
@@ -89,4 +89,12 @@ theorem exists_mem_off_curve {γ : ℝ → ℂ} {Ω : Set ℂ} {a b : ℝ} (hΩ 
     IsClopen.eq_univ ⟨hcompact.isClosed, hΩ⟩ ⟨γ a, hγΩ a left_mem_uIcc⟩
   exact noncompact_univ ℂ (huniv ▸ hcompact)
 
+/-- **The set where a curve stays near a point is closed.** For a curve continuous on `[[a, b]]`,
+the set of parameters at which it stays within `ε` of a point `s` is closed. -/
+theorem isClosed_setOfPred_mem_uIcc_norm_sub_le {γ : ℝ → ℂ} {a b : ℝ}
+    (hγ_cont : ContinuousOn γ (uIcc a b)) (s : ℂ) (ε : ℝ) :
+    IsClosed {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε} := by
+  have huIcc : IsClosed (uIcc a b) := by rw [← Icc_min_max]; exact isClosed_Icc
+  exact huIcc.isClosed_le ((hγ_cont.sub continuousOn_const).norm) continuousOn_const
+
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Curve/Distance.lean
+++ b/TauCeti/Analysis/Contour/Curve/Distance.lean
@@ -24,7 +24,8 @@ a uniform positive lower bound `ρ` on `‖γ t - w‖` over `[a, b]`.
   whole ball of points around the avoided point.
 * `TauCeti.Contour.exists_mem_off_curve` — an open set containing a curve contains a point off the
   curve: the compact image cannot exhaust a nonempty open subset of the noncompact connected `ℂ`.
-* `TauCeti.Contour.isClosed_setOfPred_mem_uIcc_norm_sub_le` — the parameters at which a curve stays
+* `TauCeti.Contour.isClosed_setOfPred_mem_uIcc_dist_le` and its norm spelling
+  `TauCeti.Contour.isClosed_setOfPred_mem_uIcc_norm_sub_le` — the parameters at which a curve stays
   within `ε` of a point form a closed set. Where the lemmas above give lower bounds on the distance
   to an avoided point, this one describes the near-point parameter set itself, which is what the
   excision arguments of the principal-value theory need.
@@ -93,12 +94,21 @@ theorem exists_mem_off_curve {γ : ℝ → ℂ} {Ω : Set ℂ} {a b : ℝ} (hΩ 
     IsClopen.eq_univ ⟨hcompact.isClosed, hΩ⟩ ⟨γ a, hγΩ a left_mem_uIcc⟩
   exact noncompact_univ ℂ (huniv ▸ hcompact)
 
-/-- **The set where a curve stays near a point is closed.** For a curve continuous on `[[a, b]]`,
-the set of parameters at which it stays within `ε` of a point `s` is closed. -/
+/-- **The set where a curve stays near a point is closed.** For a curve continuous on `[[a, b]]`
+into a pseudo metric space, the set of parameters at which it stays within `ε` of a point `s` is
+closed. -/
+theorem isClosed_setOfPred_mem_uIcc_dist_le {E : Type*} [PseudoMetricSpace E] {γ : ℝ → E}
+    {a b : ℝ} (hγ_cont : ContinuousOn γ (uIcc a b)) (s : E) (ε : ℝ) :
+    IsClosed {t ∈ uIcc a b | dist (γ t) s ≤ ε} := by
+  have huIcc : IsClosed (uIcc a b) := by rw [← Icc_min_max]; exact isClosed_Icc
+  exact huIcc.isClosed_le
+    ((continuous_id.dist continuous_const).comp_continuousOn hγ_cont) continuousOn_const
+
+/-- The norm spelling of `isClosed_setOfPred_mem_uIcc_dist_le`, which is the form the contour
+arguments use. -/
 theorem isClosed_setOfPred_mem_uIcc_norm_sub_le {E : Type*} [SeminormedAddCommGroup E]
     {γ : ℝ → E} {a b : ℝ} (hγ_cont : ContinuousOn γ (uIcc a b)) (s : E) (ε : ℝ) :
     IsClosed {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε} := by
-  have huIcc : IsClosed (uIcc a b) := by rw [← Icc_min_max]; exact isClosed_Icc
-  exact huIcc.isClosed_le ((hγ_cont.sub continuousOn_const).norm) continuousOn_const
+  simpa [dist_eq_norm] using isClosed_setOfPred_mem_uIcc_dist_le hγ_cont s ε
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Curve/Distance.lean
+++ b/TauCeti/Analysis/Contour/Curve/Distance.lean
@@ -24,6 +24,10 @@ a uniform positive lower bound `ρ` on `‖γ t - w‖` over `[a, b]`.
   whole ball of points around the avoided point.
 * `TauCeti.Contour.exists_mem_off_curve` — an open set containing a curve contains a point off the
   curve: the compact image cannot exhaust a nonempty open subset of the noncompact connected `ℂ`.
+* `TauCeti.Contour.isClosed_setOfPred_mem_uIcc_norm_sub_le` — the parameters at which a curve stays
+  within `ε` of a point form a closed set. Where the lemmas above give lower bounds on the distance
+  to an avoided point, this one describes the near-point parameter set itself, which is what the
+  excision arguments of the principal-value theory need.
 
 These small support lemmas are shared by the argument-lift partition
 (`exists_uniform_modulus_avoiding`, feeding the integer-valuedness of the winding number), by the
@@ -91,8 +95,8 @@ theorem exists_mem_off_curve {γ : ℝ → ℂ} {Ω : Set ℂ} {a b : ℝ} (hΩ 
 
 /-- **The set where a curve stays near a point is closed.** For a curve continuous on `[[a, b]]`,
 the set of parameters at which it stays within `ε` of a point `s` is closed. -/
-theorem isClosed_setOfPred_mem_uIcc_norm_sub_le {γ : ℝ → ℂ} {a b : ℝ}
-    (hγ_cont : ContinuousOn γ (uIcc a b)) (s : ℂ) (ε : ℝ) :
+theorem isClosed_setOfPred_mem_uIcc_norm_sub_le {E : Type*} [SeminormedAddCommGroup E]
+    {γ : ℝ → E} {a b : ℝ} (hγ_cont : ContinuousOn γ (uIcc a b)) (s : E) (ε : ℝ) :
     IsClosed {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε} := by
   have huIcc : IsClosed (uIcc a b) := by rw [← Icc_min_max]; exact isClosed_Icc
   exact huIcc.isClosed_le ((hγ_cont.sub continuousOn_const).norm) continuousOn_const

--- a/TauCeti/Analysis/Contour/PerWindow/CPV.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/CPV.lean
@@ -9,6 +9,7 @@ public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import TauCeti.Analysis.Calculus.OneSidedDerivLimit
+import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
 import TauCeti.Analysis.Contour.Chord.QuotientAsymptotics
 import TauCeti.Analysis.Contour.LogDerivFTC
 import TauCeti.Analysis.Contour.Winding.Number.Basic
@@ -69,8 +70,7 @@ theorem intervalIntegrable_inv_sub_truncated {γ : ℝ → ℂ} {s : ℂ} {a b :
     IntervalIntegrable (fun t => if ‖γ t - s‖ > ε then (γ t - s)⁻¹ * deriv γ t else 0)
       MeasureTheory.volume a b := by
   have hK_closed : IsClosed {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε} :=
-    ((hγ_cont.sub continuousOn_const).norm).preimage_isClosed_of_isClosed
-      (by rw [← Icc_min_max]; exact isClosed_Icc) isClosed_Iic
+    isClosed_setOfPred_mem_uIcc_norm_sub_le hγ_cont s ε
   have h_inv_aesm : AEStronglyMeasurable (fun t => (γ t - s)⁻¹ * deriv γ t)
       (MeasureTheory.volume.restrict (Set.uIoc a b)) := by
     have hγ_aem : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)) :=

--- a/TauCeti/Analysis/Contour/PerWindow/CPV.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/CPV.lean
@@ -9,7 +9,7 @@ public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import TauCeti.Analysis.Calculus.OneSidedDerivLimit
-import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
+import TauCeti.Analysis.Contour.Curve.Distance
 import TauCeti.Analysis.Contour.Chord.QuotientAsymptotics
 import TauCeti.Analysis.Contour.LogDerivFTC
 import TauCeti.Analysis.Contour.Winding.Number.Basic

--- a/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
@@ -90,8 +90,7 @@ theorem intervalIntegrable_pow_inv_mul_deriv_truncated {γ : ℝ → ℂ} {s : �
       (fun t => if ‖γ t - s‖ > ε then c / (γ t - s) ^ k * deriv γ t else 0)
       MeasureTheory.volume a b := by
   have hK_closed : IsClosed {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε} :=
-    ((hγ_cont.sub continuousOn_const).norm).preimage_isClosed_of_isClosed
-      (by rw [← Icc_min_max]; exact isClosed_Icc) isClosed_Iic
+    isClosed_setOfPred_mem_uIcc_norm_sub_le hγ_cont s ε
   have h_fn_aesm : AEStronglyMeasurable (fun t => c / (γ t - s) ^ k * deriv γ t)
       (MeasureTheory.volume.restrict (Set.uIoc a b)) := by
     have hγ_aem : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)) :=

--- a/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
@@ -11,6 +11,7 @@ public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import TauCeti.Analysis.Contour.PiecewiseC1On
 public import TauCeti.Analysis.Contour.RegularityConditions
 import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
+import TauCeti.Analysis.Contour.Curve.Distance
 import TauCeti.Analysis.Calculus.OneSidedDerivLimit
 import TauCeti.Analysis.Contour.HigherOrder.Asymptotics
 import TauCeti.Analysis.Contour.SectorCancellation


### PR DESCRIPTION
Three places in the contour development prove that the excised parameter set is closed, and two of them were character-for-character identical:

```lean
have hK_closed : IsClosed {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε} :=
  ((hγ_cont.sub continuousOn_const).norm).preimage_isClosed_of_isClosed
    (by rw [← Icc_min_max]; exact isClosed_Icc) isClosed_Iic
```

at `PerWindow/CPV.lean:71` and `PerWindow/HigherOrder.lean:92`, with the same three-lemma composition appearing again inside `isClosed_setOfPred_mem_uIcc_exists_norm_sub_le` in `Cauchy/PrincipalValue/On.lean`, where it discharges the per-point branch of a finite union.

`isClosed_setOfPred_mem_uIcc_norm_sub_le` states it once: for a curve continuous on `[[a, b]]`, the set of parameters at which it stays within `ε` of a point `s` is closed. The proof is Mathlib's closed-sublevel combinator `IsClosed.isClosed_le` applied to the closed interval — `reuse` noted that the original three-lemma composition was rebuilding exactly that. All three sites now call it, and the finite-set version reduces to one line — `isClosed_biUnion_finset` applied to it pointwise.

**Placement.** It lives in `Contour/Curve/Distance.lean`, the curve-distance support module. I first put it in `Cauchy/PrincipalValue/Basic.lean`, reasoning that the excised parameter set is principal-value subject matter; `placement` pointed out that the statement mentions only `ContinuousOn γ (uIcc a b)` and `‖γ t - s‖ ≤ ε`, so it is curve-distance material and the consumers should not take a principal-value dependency for a topological fact. That is right, and it also removes the odd edge where `PerWindow/CPV.lean` would have imported principal-value machinery it does not otherwise use. `Curve/Distance.lean` has no TauCeti imports, so depending on it cannot create a cycle.

Its hypotheses are the two the statement needs: continuity of the curve on `[[a, b]]`, and the point and radius. Nothing about integrability, derivatives, windows or principal values is threaded through, though all of that is in scope at each of the three call sites. No positivity is assumed on `ε`: at `ε < 0` the set is empty, which is closed, and the statement holds on its own terms.

This came out of the standing dedup audit over the lemmas I have extracted, and it is the first round of that audit to find genuine cross-file duplication rather than shared technique.

## Further review rounds

- `generality`, twice: nothing uses the complex structure, so the codomain was generalised to a seminormed additive group — and then further, since closedness of a near-point set is *metric* rather than seminormed. The general statement is now `isClosed_setOfPred_mem_uIcc_dist_le` over `[PseudoMetricSpace E]` with `dist (γ t) s ≤ ε`; `isClosed_setOfPred_mem_uIcc_norm_sub_le` remains as the norm spelling, since `‖γ t - s‖` is the form all three contour callers have.
- `documentation`: `Curve/Distance.lean` carries an exhaustive `## Main results` list, and a new public theorem has to appear in it. It is listed now, with a sentence placing it against the neighbouring lemmas: those bound the distance to an *avoided* point from below, whereas this one describes the *near-point* parameter set that the excision arguments consume.

Gates run locally: `lake build` (7229 jobs), `lake exe axioms` (33160 declarations), `lake exe module-system` (1660 modules), `scripts/lint-env.sh` — all green.

Roadmap: ContourIntegration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
