### PR TITLE
docs(ModularForms): the ceiling module doc covers its excision API

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Ceiling/Bridge.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Ceiling/Bridge.lean
@@ -21,10 +21,20 @@ function factors through its cusp function — so the ceiling contour integral o
 logarithmic derivative equals the `q`-circle integral of the cusp function's logarithmic
 derivative.
 
+The same bridge serves the excised valence contour unchanged, because the excision never
+fires on the ceiling: the excision centres of the corner computations lie on the unit circle,
+so their heights are at most `1`, while the ceiling runs at height `H`. Once each centre
+clears `ε` below the ceiling the excised ceiling integrand *is* the unexcised one, and the
+ceiling still reads the cusp order.
+
 ## Main declarations
 
 * `TauCeti.ModularForm.intervalIntegral_fdBoundary_segment5_eq_circleIntegral_logDeriv_cuspFunction`
   (the ceiling bridge).
+* `TauCeti.ModularForm.not_exists_norm_fdBoundary_sub_le_of_mem_Icc_four_five` (the excision
+  never fires on the ceiling) and
+  `…_excised_logDeriv_fdBoundary_segment5_eq_two_pi_I_mul_qExpansionOrderAtCusp` in the same
+  namespace (so the excised ceiling integral is still `2πi · ord_∞`).
 
 ## References
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Ceiling/Bridge.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Ceiling/Bridge.lean
@@ -33,8 +33,9 @@ ceiling still reads the cusp order.
   (the ceiling bridge).
 * `TauCeti.ModularForm.not_exists_norm_fdBoundary_sub_le_of_mem_Icc_four_five` (the excision
   never fires on the ceiling) and
-  `…_excised_logDeriv_fdBoundary_segment5_eq_two_pi_I_mul_qExpansionOrderAtCusp` in the same
-  namespace (so the excised ceiling integral is still `2πi · ord_∞`).
+  `intervalIntegral_excised_logDeriv_fdBoundary_segment5_eq_two_pi_I_mul_qExpansionOrderAtCusp`
+  (same namespace; the fully qualified name does not fit the line limit — so the excised
+  ceiling integral is still `2πi · ord_∞`).
 
 ## References
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-formula/ceiling-doc-excision"}-->

A documentation follow-up to #2603.

#2603 added two excision results to `Ceiling/Bridge.lean` —
`not_exists_norm_fdBoundary_sub_le_of_mem_Icc_four_five` and the excised segment-5 evaluation —
but merged with that file's module docstring still describing only the unexcised `q`-circle
bridge. The `documentation` finding that caught this posted seconds after the merge, so the fix
missed the train.

The overview now says why the excision never fires on the ceiling — the excision centres of the
corner computations lie on the unit circle, so their heights are at most `1`, while the ceiling
runs at height `H` — and the main-declarations list names both theorems the file gained.

Documentation only; no declaration changes.

Roadmap: ModularForms

Layer 1, *the valence formula (general level)*.
