### PR TITLE
feat: identify the closed Banach exponential derivative

### DIFF
--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp/Derivative.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp/Derivative.lean
@@ -11,8 +11,8 @@ import TauCeti.Analysis.Normed.Algebra.Basic
 /-!
 # The closed form of the Banach-algebra exponential derivative
 
-This file identifies the Fréchet derivative of the noncommutative exponential with left
-multiplication by `exp x`, followed by the regularized commutator quotient.
+This file identifies the Fréchet derivative of the noncommutative exponential with the regularized
+commutator quotient, followed by left multiplication by `exp x`.
 
 ## Main results
 
@@ -40,21 +40,20 @@ attribute [local instance] TauCeti.normedAlgebraRatOfReal
 
 /-- The exponential derivative in direction `y` is left multiplication by `exp x` applied to
 the regularized commutator factor. -/
-theorem expFDeriv_apply_eq_exp_mul_banachDexpFactor (x y : R) :
-    expFDeriv ℝ x y = exp x * banachDexpFactor x y := by
+theorem expFDeriv_apply_eq_exp_mul_banachDexpFactor {𝕂 : Type*}
+    [NontriviallyNormedField 𝕂] [NormedAlgebra ℝ 𝕂] [NormedAlgebra 𝕂 R]
+    [IsScalarTower ℝ 𝕂 R] (x y : R) :
+    expFDeriv 𝕂 x y = exp x * banachDexpFactor x y := by
   rw [TauCeti.expFDeriv_apply_eq_integral,
     banachDexpFactor_apply_eq_integral]
   have hint : IntervalIntegrable
       (fun t : ℝ ↦ exp (-(t • x)) * y * exp (t • x)) volume 0 1 := by
     exact Continuous.intervalIntegrable (μ := volume) (by fun_prop) 0 1
-  change (∫ t in (0 : ℝ)..1, exp ((1 - t) • x) * y * exp (t • x)) =
-    (ContinuousLinearMap.mul ℝ R (exp x))
-      (∫ t in (0 : ℝ)..1, exp (-(t • x)) * y * exp (t • x))
+  rw [← ContinuousLinearMap.mul_apply' ℝ]
   rw [← (ContinuousLinearMap.mul ℝ R (exp x)).intervalIntegral_comp_comm hint]
   apply intervalIntegral.integral_congr
   intro t _ht
-  change exp ((1 - t) • x) * y * exp (t • x) =
-    exp x * (exp (-(t • x)) * y * exp (t • x))
+  simp only [ContinuousLinearMap.mul_apply']
   have hcomm : Commute x (-(t • x)) := (Commute.refl x).smul_right t |>.neg_right
   rw [← mul_assoc, ← mul_assoc, ← exp_add_of_commute hcomm]
   congr 3

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexpDerivative.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexpDerivative.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.SpecialFunctions.Exponential
+public import TauCeti.Geometry.Lie.Adjoint.BanachDexpIntegral
+
+/-!
+# The closed form of the Banach-algebra exponential derivative
+
+This file identifies the Fréchet derivative of the noncommutative exponential with left
+multiplication by `exp x`, followed by the regularized commutator quotient.
+
+## Main results
+
+* `TauCeti.Lie.expFDeriv_apply_eq_exp_mul_banachDexpFactor`: the pointwise formula.
+* `TauCeti.Lie.expFDeriv_eq_exp_mul_banachDexpFactor`: the bundled operator formula.
+* `TauCeti.Lie.fderiv_exp_eq_exp_mul_banachDexpFactor`: the corresponding `fderiv` formula.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The conjugation formulas".
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Lie
+
+open NormedSpace MeasureTheory
+
+variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R] [CompleteSpace R]
+
+/-- A real normed algebra regarded as a rational normed algebra within this module. -/
+noncomputable local instance normedAlgebraRatOfRealBanachDexpDerivative : NormedAlgebra ℚ R :=
+  .restrictScalars ℚ ℝ R
+
+/-- The exponential derivative in direction `y` is left multiplication by `exp x` applied to
+the regularized commutator factor. -/
+theorem expFDeriv_apply_eq_exp_mul_banachDexpFactor (x y : R) :
+    expFDeriv ℝ x y = exp x * banachDexpFactor x y := by
+  rw [TauCeti.expFDeriv_apply_eq_integral,
+    banachDexpFactor_apply_eq_integral_conj]
+  have hint : IntervalIntegrable
+      (fun t : ℝ ↦ exp ((-t) • x) * y * exp (t • x)) volume 0 1 := by
+    exact Continuous.intervalIntegrable (μ := volume) (by fun_prop) 0 1
+  change (∫ t in (0 : ℝ)..1, exp ((1 - t) • x) * y * exp (t • x)) =
+    (ContinuousLinearMap.mul ℝ R (exp x))
+      (∫ t in (0 : ℝ)..1, exp ((-t) • x) * y * exp (t • x))
+  rw [← (ContinuousLinearMap.mul ℝ R (exp x)).intervalIntegral_comp_comm hint]
+  apply intervalIntegral.integral_congr
+  intro t _ht
+  change exp ((1 - t) • x) * y * exp (t • x) =
+    exp x * (exp ((-t) • x) * y * exp (t • x))
+  have hcomm : Commute x ((-t) • x) := (Commute.refl x).smul_right (-t)
+  rw [← mul_assoc, ← mul_assoc, ← exp_add_of_commute hcomm]
+  congr 3
+  module
+
+/-- The Fréchet derivative is left multiplication by `exp x` composed with the regularized
+commutator factor. -/
+theorem expFDeriv_eq_exp_mul_banachDexpFactor (x : R) :
+    expFDeriv ℝ x =
+      (ContinuousLinearMap.mul ℝ R (exp x)).comp (banachDexpFactor x) := by
+  ext y
+  exact expFDeriv_apply_eq_exp_mul_banachDexpFactor x y
+
+/-- The Fréchet derivative of the Banach-algebra exponential is left multiplication by `exp x`
+composed with `(1 - exp (-ad x)) / ad x`. -/
+theorem fderiv_exp_eq_exp_mul_banachDexpFactor (x : R) :
+    fderiv ℝ exp x =
+      (ContinuousLinearMap.mul ℝ R (exp x)).comp (banachDexpFactor x) := by
+  rw [TauCeti.fderiv_exp, expFDeriv_eq_exp_mul_banachDexpFactor]
+
+end TauCeti.Lie
+

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexpDerivative.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexpDerivative.lean
@@ -5,7 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.SpecialFunctions.Exponential
-public import TauCeti.Geometry.Lie.Adjoint.BanachDexpIntegral
+public import TauCeti.Geometry.Lie.Adjoint.BanachDexp.Integral
+import TauCeti.Analysis.Normed.Algebra.Basic
 
 /-!
 # The closed form of the Banach-algebra exponential derivative
@@ -35,9 +36,7 @@ open NormedSpace MeasureTheory
 
 variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R] [CompleteSpace R]
 
-/-- A real normed algebra regarded as a rational normed algebra within this module. -/
-noncomputable local instance normedAlgebraRatOfRealBanachDexpDerivative : NormedAlgebra ℚ R :=
-  .restrictScalars ℚ ℝ R
+attribute [local instance] TauCeti.normedAlgebraRatOfReal
 
 /-- The exponential derivative in direction `y` is left multiplication by `exp x` applied to
 the regularized commutator factor. -/
@@ -46,17 +45,17 @@ theorem expFDeriv_apply_eq_exp_mul_banachDexpFactor (x y : R) :
   rw [TauCeti.expFDeriv_apply_eq_integral,
     banachDexpFactor_apply_eq_integral_conj]
   have hint : IntervalIntegrable
-      (fun t : ℝ ↦ exp ((-t) • x) * y * exp (t • x)) volume 0 1 := by
+      (fun t : ℝ ↦ exp (-(t • x)) * y * exp (t • x)) volume 0 1 := by
     exact Continuous.intervalIntegrable (μ := volume) (by fun_prop) 0 1
   change (∫ t in (0 : ℝ)..1, exp ((1 - t) • x) * y * exp (t • x)) =
     (ContinuousLinearMap.mul ℝ R (exp x))
-      (∫ t in (0 : ℝ)..1, exp ((-t) • x) * y * exp (t • x))
+      (∫ t in (0 : ℝ)..1, exp (-(t • x)) * y * exp (t • x))
   rw [← (ContinuousLinearMap.mul ℝ R (exp x)).intervalIntegral_comp_comm hint]
   apply intervalIntegral.integral_congr
   intro t _ht
   change exp ((1 - t) • x) * y * exp (t • x) =
-    exp x * (exp ((-t) • x) * y * exp (t • x))
-  have hcomm : Commute x ((-t) • x) := (Commute.refl x).smul_right (-t)
+    exp x * (exp (-(t • x)) * y * exp (t • x))
+  have hcomm : Commute x (-(t • x)) := (Commute.refl x).smul_right t |>.neg_right
   rw [← mul_assoc, ← mul_assoc, ← exp_add_of_commute hcomm]
   congr 3
   module
@@ -77,4 +76,3 @@ theorem fderiv_exp_eq_exp_mul_banachDexpFactor (x : R) :
   rw [TauCeti.fderiv_exp, expFDeriv_eq_exp_mul_banachDexpFactor]
 
 end TauCeti.Lie
-

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexpDerivative.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexpDerivative.lean
@@ -43,7 +43,7 @@ the regularized commutator factor. -/
 theorem expFDeriv_apply_eq_exp_mul_banachDexpFactor (x y : R) :
     expFDeriv ℝ x y = exp x * banachDexpFactor x y := by
   rw [TauCeti.expFDeriv_apply_eq_integral,
-    banachDexpFactor_apply_eq_integral_conj]
+    banachDexpFactor_apply_eq_integral]
   have hint : IntervalIntegrable
       (fun t : ℝ ↦ exp (-(t • x)) * y * exp (t • x)) volume 0 1 := by
     exact Continuous.intervalIntegrable (μ := volume) (by fun_prop) 0 1


### PR DESCRIPTION
## Goal

Complete the Banach-algebra shadow of Deliverable A, Layer 1 by expressing the derivative of the noncommutative exponential as left multiplication by exp x followed by the everywhere-defined regularized commutator quotient.

## Correctness argument

The merged integral formula from #2597 gives the exponential derivative as the integral of exp ((1 - t) • x) * y * exp (t • x). The existing Banach dexp factor is the integral of exp (-(t • x)) * y * exp (t • x). Left multiplication by exp x transforms the second integrand into the first because x commutes with -(t • x), so the exponential addition law applies pointwise.

Extensionality upgrades that pointwise identity to equality of continuous linear maps. Composing it with the existing theorem identifying fderiv of exp with expFDeriv yields the requested closed derivative formula without any invertibility hypothesis on ad x.

This advances [RepresentationTheory/LieGroups, Deliverable A, Layer 1](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md) and intention TauCetiProject/TauCetiRoadmap#162.

## Validation

- lake build --iofail: 7,241 jobs
- lake exe axioms: 33,304 declarations; only propext, Classical.choice, and Quot.sound
- lake exe module-system: all 1,665 modules
- scripts/lint-env.sh: no new violations; 2,556/2,556 declarations documented
- Full governing AGENTS.md and CLAUDE.md audit completed against the complete changed file

Roadmap: RepresentationTheory