### PR TITLE
feat: prove tangent dimension invariance under base change

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.LinearAlgebra.Dual.Lemmas
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Tangent
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Cotangent
+import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
 
 /-!
 # The conormal sequence of a closed affine subgroup
@@ -235,23 +236,8 @@ theorem finrank_quotientLie_add_finrank_conormal (I : HopfIdeal k H)
         Module.finrank k (conormalSubspace I) =
       Module.finrank k
         (Derivation k H (Bialgebra.CounitAlgebra k H k)) := by
-  have hquotient :
-      Module.finrank k
-          (Derivation k (H ⧸ I.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) =
-        Module.finrank k (Bialgebra.CotangentSpace k (H ⧸ I.toIdeal)) :=
-    (Derivation.cotangentLinearEquiv
-      (R := k) (A := H ⧸ I.toIdeal) (B := k)).finrank_eq.symm.trans
-        Subspace.dual_finrank_eq
-  have hambient :
-      Module.finrank k
-          (Derivation k H (Bialgebra.CounitAlgebra k H k)) =
-        Module.finrank k (Bialgebra.CotangentSpace k H) :=
-    (Derivation.cotangentLinearEquiv
-      (R := k) (A := H) (B := k)).finrank_eq.symm.trans
-        Subspace.dual_finrank_eq
-  rw [hquotient, hambient]
-  exact finrank_quotientCotangent_add_finrank_conormal I
+  simpa only [Derivation.finrank_eq_finrank_cotangentSpace] using
+    finrank_quotientCotangent_add_finrank_conormal I
 
 end Field
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Adjoint
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Cotangent
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Equivariance
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Map
@@ -17,7 +18,8 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Naturality
 Aggregator for the tangent-level theory: the counit-valued derivations
 (`Tangent.Basic`), their description by the cotangent space
 (`Tangent.Cotangent`), finiteness at an identity of finite type
-(`Tangent.FiniteType`), functoriality in the bialgebra
+(`Tangent.FiniteType`), tangent dimensions and their invariance under coefficient-field extension
+(`Tangent.Dimension`), functoriality in the bialgebra
 (`Tangent.DerivationMap`, `Tangent.Map`) and coefficient algebra
 (`Tangent.Naturality`), and the adjoint action of the points
 (`Tangent.Adjoint`), including equivariance of the differential

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Dimension.Constructions
+public import Mathlib.RingTheory.TensorProduct.Finite
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
+
+/-!
+# Dimensions of tangent Lie algebras
+
+For an affine group over a field, the tangent Lie algebra is the linear dual of the
+augmentation cotangent space. This file records the resulting equality of dimensions and shows
+that the tangent Lie algebra of a finite-type affine group is finite-dimensional.
+
+When the cotangent space is finite projective, tangent vectors with values in an extension field
+`K` are the scalar extension of base-field tangent vectors. Consequently their dimension over
+`K` is the dimension of the original tangent space over `k`:
+
+```text
+dim_K Lie(G)(K) = dim_k Lie(G)(k).
+```
+
+This is the base-change dimension tool needed before geometric dimension and smoothness arguments
+in Layer 2 of the ReductiveGroups roadmap.
+
+## Main declarations
+
+* `TauCeti.Derivation.finrank_eq_finrank_cotangentSpace`: tangent and cotangent dimensions agree.
+* `TauCeti.Bialgebra.instFiniteDimensionalDerivationCounitAlgebra`: finite-type affine groups
+  have finite-dimensional tangent Lie algebras.
+* `TauCeti.Derivation.finrank_tangent_baseChange`: tangent dimension is invariant under extension
+  of the coefficient field.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§10 and 12.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w
+
+open scoped TensorProduct
+
+namespace Derivation
+
+variable {k : Type u} [Field k]
+variable {H : Type v} [CommRing H] [Bialgebra k H]
+
+/-- The tangent Lie algebra at the identity and the augmentation cotangent space have the same
+dimension over the base field. -/
+theorem finrank_eq_finrank_cotangentSpace :
+    Module.finrank k
+        (Derivation k H (Bialgebra.CounitAlgebra k H k)) =
+      Module.finrank k (Bialgebra.CotangentSpace k H) :=
+  (cotangentLinearEquiv (R := k) (A := H) (B := k)).finrank_eq.symm.trans
+    Subspace.dual_finrank_eq
+
+end Derivation
+
+namespace Bialgebra
+
+variable {k : Type u} [Field k]
+variable {H : Type v} [CommRing H] [Bialgebra k H]
+
+/-- The tangent Lie algebra of a finite-type affine monoid over a field is finite-dimensional. -/
+noncomputable instance instFiniteDimensionalDerivationCounitAlgebra
+    [Algebra.FiniteType k H] :
+    FiniteDimensional k
+      (Derivation k H (CounitAlgebra k H k)) :=
+  Module.Finite.equiv
+    (Derivation.cotangentLinearEquiv (R := k) (A := H) (B := k))
+
+end Bialgebra
+
+namespace Derivation
+
+variable {k : Type u} [Field k]
+variable {H : Type v} [CommRing H] [Bialgebra k H]
+variable {K : Type w} [Field K] [Algebra k K]
+
+/-- Tangent vectors with values in an extension field are finite-dimensional when the
+augmentation cotangent space is finite projective. -/
+noncomputable instance instFiniteDimensionalCounitAlgebraBaseChange
+    [Module.Finite k (Bialgebra.CotangentSpace k H)]
+    [Module.Projective k (Bialgebra.CotangentSpace k H)] :
+    FiniteDimensional K
+      (Derivation k H (Bialgebra.CounitAlgebra k H K)) :=
+  Module.Finite.equiv
+    (tangentScalarExtensionEquiv (R := k) (A := H) (B := K))
+
+/-- **Tangent dimension is invariant under extension of the coefficient field.**
+
+Here `Derivation k H (CounitAlgebra k H K)` is the `K`-valued tangent space of the affine
+monoid represented by `H`. The finite-projective hypotheses give its canonical scalar-extension
+description. -/
+theorem finrank_tangent_baseChange
+    [Module.Finite k (Bialgebra.CotangentSpace k H)]
+    [Module.Projective k (Bialgebra.CotangentSpace k H)] :
+    Module.finrank K
+        (Derivation k H (Bialgebra.CounitAlgebra k H K)) =
+      Module.finrank k
+        (Derivation k H (Bialgebra.CounitAlgebra k H k)) := by
+  calc
+    Module.finrank K
+          (Derivation k H (Bialgebra.CounitAlgebra k H K)) =
+        Module.finrank K
+          (K ⊗[k] Module.Dual k (Bialgebra.CotangentSpace k H)) :=
+      (tangentScalarExtensionEquiv (R := k) (A := H) (B := K)).finrank_eq.symm
+    _ = Module.finrank k (Module.Dual k (Bialgebra.CotangentSpace k H)) :=
+      Module.finrank_baseChange
+    _ = Module.finrank k
+          (Derivation k H (Bialgebra.CounitAlgebra k H k)) :=
+      (cotangentLinearEquiv (R := k) (A := H) (B := k)).finrank_eq
+
+end Derivation
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
@@ -6,8 +6,8 @@ module
 
 public import Mathlib.LinearAlgebra.Dimension.Constructions
 import Mathlib.RingTheory.SimpleModule.InjectiveProjective
-public import Mathlib.RingTheory.TensorProduct.Finite
-public import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
+import Mathlib.RingTheory.TensorProduct.Finite
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Cotangent
 
 /-!
 # Dimensions of tangent Lie algebras
@@ -54,10 +54,10 @@ namespace Derivation
 variable {k : Type u} [Field k]
 variable {H : Type v} [CommRing H] [Bialgebra k H]
 
-/-- When the augmentation cotangent space is finite-dimensional, it and the tangent Lie algebra
-at the identity have the same dimension over the base field. -/
-theorem finrank_eq_finrank_cotangentSpace
-    [Module.Finite k (Bialgebra.CotangentSpace k H)] :
+/-- The augmentation cotangent space and tangent Lie algebra at the identity have the same
+dimension over the base field. -/
+@[simp]
+theorem finrank_eq_finrank_cotangentSpace :
     Module.finrank k
         (Derivation k H (Bialgebra.CounitAlgebra k H k)) =
       Module.finrank k (Bialgebra.CotangentSpace k H) :=
@@ -82,6 +82,7 @@ noncomputable instance instFiniteDimensionalDerivationCounitAlgebra
 Here `Derivation k H (CounitAlgebra k H K)` is the `K`-valued tangent space of the affine
 monoid represented by `H`. Finite-dimensionality gives its canonical scalar-extension
 description, since modules over a field are projective. -/
+@[simp]
 theorem finrank_tangent_baseChange
     [Module.Finite k (Bialgebra.CotangentSpace k H)] :
     Module.finrank K

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
@@ -13,8 +13,10 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Cotangent
 # Dimensions of tangent Lie algebras
 
 For an affine monoid over a field, the tangent Lie algebra is the linear dual of the
-augmentation cotangent space. This file records the resulting equality of dimensions and shows
-that the tangent Lie algebra of a finite-type affine monoid is finite-dimensional.
+augmentation cotangent space. This file records the resulting equality of their `Module.finrank`
+values and shows that the tangent Lie algebra of a finite-type affine monoid is finite-dimensional.
+Without a finiteness hypothesis, this equality uses Mathlib's convention that the `finrank` of an
+infinite-dimensional space is zero.
 
 When the cotangent space is finite-dimensional, tangent vectors with values in an extension field
 `K` are the scalar extension of base-field tangent vectors; projectivity is automatic over a
@@ -30,7 +32,8 @@ in Layer 2 of the ReductiveGroups roadmap.
 
 ## Main declarations
 
-* `TauCeti.Derivation.finrank_eq_finrank_cotangentSpace`: tangent and cotangent dimensions agree.
+* `TauCeti.Derivation.finrank_eq_finrank_cotangentSpace`: tangent and cotangent `finrank` values
+  agree.
 * `TauCeti.Derivation.instFiniteDimensionalDerivationCounitAlgebra`: tangent spaces with
   coefficient-field values are finite-dimensional when the augmentation cotangent space is.
 * `TauCeti.Derivation.finrank_tangent_baseChange`: tangent dimension is invariant under extension
@@ -55,7 +58,8 @@ variable {k : Type u} [Field k]
 variable {H : Type v} [CommRing H] [Bialgebra k H]
 
 /-- The augmentation cotangent space and tangent Lie algebra at the identity have the same
-dimension over the base field. -/
+`Module.finrank` over the base field. Without a finiteness hypothesis, this is an equality in
+Mathlib's finite-rank convention, where infinite-dimensional spaces have `finrank` zero. -/
 @[simp]
 theorem finrank_eq_finrank_cotangentSpace :
     Module.finrank k

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
@@ -5,19 +5,21 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.Dimension.Constructions
+import Mathlib.RingTheory.SimpleModule.InjectiveProjective
 public import Mathlib.RingTheory.TensorProduct.Finite
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
 
 /-!
 # Dimensions of tangent Lie algebras
 
-For an affine group over a field, the tangent Lie algebra is the linear dual of the
+For an affine monoid over a field, the tangent Lie algebra is the linear dual of the
 augmentation cotangent space. This file records the resulting equality of dimensions and shows
-that the tangent Lie algebra of a finite-type affine group is finite-dimensional.
+that the tangent Lie algebra of a finite-type affine monoid is finite-dimensional.
 
-When the cotangent space is finite projective, tangent vectors with values in an extension field
-`K` are the scalar extension of base-field tangent vectors. Consequently their dimension over
-`K` is the dimension of the original tangent space over `k`:
+When the cotangent space is finite-dimensional, tangent vectors with values in an extension field
+`K` are the scalar extension of base-field tangent vectors; projectivity is automatic over a
+field. Consequently their dimension over `K` is the dimension of the original tangent space over
+`k`:
 
 ```text
 dim_K Lie(G)(K) = dim_k Lie(G)(k).
@@ -29,8 +31,8 @@ in Layer 2 of the ReductiveGroups roadmap.
 ## Main declarations
 
 * `TauCeti.Derivation.finrank_eq_finrank_cotangentSpace`: tangent and cotangent dimensions agree.
-* `TauCeti.Bialgebra.instFiniteDimensionalDerivationCounitAlgebra`: finite-type affine groups
-  have finite-dimensional tangent Lie algebras.
+* `TauCeti.Derivation.instFiniteDimensionalDerivationCounitAlgebra`: tangent spaces with
+  coefficient-field values are finite-dimensional when the augmentation cotangent space is.
 * `TauCeti.Derivation.finrank_tangent_baseChange`: tangent dimension is invariant under extension
   of the coefficient field.
 
@@ -62,51 +64,32 @@ theorem finrank_eq_finrank_cotangentSpace
   (cotangentLinearEquiv (R := k) (A := H) (B := k)).finrank_eq.symm.trans
     Subspace.dual_finrank_eq
 
-end Derivation
-
-namespace Bialgebra
-
-variable {k : Type u} [Field k]
-variable {H : Type v} [CommRing H] [Bialgebra k H]
-
-/-- The tangent Lie algebra of a finite-type affine monoid over a field is finite-dimensional. -/
-noncomputable instance instFiniteDimensionalDerivationCounitAlgebra
-    [Algebra.FiniteType k H] :
-    FiniteDimensional k
-      (Derivation k H (CounitAlgebra k H k)) :=
-  Module.Finite.equiv
-    (Derivation.cotangentLinearEquiv (R := k) (A := H) (B := k))
-
-end Bialgebra
-
-namespace Derivation
-
-variable {k : Type u} [Field k]
-variable {H : Type v} [CommRing H] [Bialgebra k H]
 variable {K : Type w} [Field K] [Algebra k K]
 
 /-- Tangent vectors with values in an extension field are finite-dimensional when the
-augmentation cotangent space is finite projective. -/
-noncomputable instance instFiniteDimensionalCounitAlgebraBaseChange
-    [Module.Finite k (Bialgebra.CotangentSpace k H)]
-    [Module.Projective k (Bialgebra.CotangentSpace k H)] :
+augmentation cotangent space is finite-dimensional. -/
+noncomputable instance instFiniteDimensionalDerivationCounitAlgebra
+    [Module.Finite k (Bialgebra.CotangentSpace k H)] :
     FiniteDimensional K
-      (Derivation k H (Bialgebra.CounitAlgebra k H K)) :=
-  Module.Finite.equiv
+      (Derivation k H (Bialgebra.CounitAlgebra k H K)) := by
+  let _ : Module.Projective k (Bialgebra.CotangentSpace k H) :=
+    Module.projective_of_isSemisimpleRing _ _
+  exact Module.Finite.equiv
     (tangentScalarExtensionEquiv (R := k) (A := H) (B := K))
 
 /-- **Tangent dimension is invariant under extension of the coefficient field.**
 
 Here `Derivation k H (CounitAlgebra k H K)` is the `K`-valued tangent space of the affine
-monoid represented by `H`. The finite-projective hypotheses give its canonical scalar-extension
-description. -/
+monoid represented by `H`. Finite-dimensionality gives its canonical scalar-extension
+description, since modules over a field are projective. -/
 theorem finrank_tangent_baseChange
-    [Module.Finite k (Bialgebra.CotangentSpace k H)]
-    [Module.Projective k (Bialgebra.CotangentSpace k H)] :
+    [Module.Finite k (Bialgebra.CotangentSpace k H)] :
     Module.finrank K
         (Derivation k H (Bialgebra.CounitAlgebra k H K)) =
       Module.finrank k
         (Derivation k H (Bialgebra.CounitAlgebra k H k)) := by
+  let _ : Module.Projective k (Bialgebra.CotangentSpace k H) :=
+    Module.projective_of_isSemisimpleRing _ _
   calc
     Module.finrank K
           (Derivation k H (Bialgebra.CounitAlgebra k H K)) =

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
@@ -52,9 +52,10 @@ namespace Derivation
 variable {k : Type u} [Field k]
 variable {H : Type v} [CommRing H] [Bialgebra k H]
 
-/-- The tangent Lie algebra at the identity and the augmentation cotangent space have the same
-dimension over the base field. -/
-theorem finrank_eq_finrank_cotangentSpace :
+/-- When the augmentation cotangent space is finite-dimensional, it and the tangent Lie algebra
+at the identity have the same dimension over the base field. -/
+theorem finrank_eq_finrank_cotangentSpace
+    [Module.Finite k (Bialgebra.CotangentSpace k H)] :
     Module.finrank k
         (Derivation k H (Bialgebra.CounitAlgebra k H k)) =
       Module.finrank k (Bialgebra.CotangentSpace k H) :=


### PR DESCRIPTION
This PR establishes that the tangent Lie algebra of a finite-type affine monoid over a field is finite-dimensional and that tangent dimension is invariant under extension of the coefficient field. Package the equality between tangent and augmentation-cotangent dimensions, derive finite-dimensionality from the existing finite-type cotangent theorem, and identify `dim_K Lie(G)(K)` with `dim_k Lie(G)(k)` through the existing scalar-extension equivalence.

This advances `ReductiveGroups/README.md`, Layer 2, milestone **“Smoothness and dimension tools via `Lie(G)`”**. The exact dependency edge is that the merged augmentation-cotangent finiteness and tangent scalar-extension equivalence identify every coefficient-valued tangent space with scalar extension of one finite dual, while geometric dimension and smoothness arguments require that this identification preserve the numerical dimension after field extension. After this PR, the milestone still requires dimension formulas for differentials and kernels once the in-flight coefficient-linear Lie synchronization lands, followed by the smoothness criterion itself.

This is the most effective distinct current step because the adjoint representation, closed-subgroup tangent identification, kernel Lie equivalence, and standard `GL_n` tangent computation are already merged, while current open ReductiveGroups PRs own smooth-category synchronization and the remaining standard tangent examples. The result works for every commutative bialgebra with finite-projective augmentation cotangent space; finite type is used only for the separate finite-dimensionality instance over a field.

The implementation reuses `Derivation.cotangentLinearEquiv`, `Derivation.tangentScalarExtensionEquiv`, Mathlib's `Module.finrank_baseChange`, and the existing finite-type cotangent instance. No Mathlib infrastructure is vendored. The mathematical description follows J. S. Milne, *Algebraic Groups* (2017), §§10 and 12, as cited in the module documentation.

Add `TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean` (123 lines, four public declarations).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tangent-dimension-base-change"}-->

🤖 Prepared with Codex
