### PR TITLE
feat: select Suzuki-Ree length permutations

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
@@ -35,8 +35,8 @@ four branch equations are simp lemmas rather than the selector body being expose
 * `TauCeti.SuzukiReeIndex.lengthPerm_suzuki`, `TauCeti.SuzukiReeIndex.lengthPerm_reeG2`,
   `TauCeti.SuzukiReeIndex.lengthPerm_reeF4`, and `TauCeti.SuzukiReeIndex.lengthPerm_tits` are the
   branch equations naming the selected permutation on each half-Frobenius family.
-* `TauCeti.SuzukiReeIndex.isLongSimpleRoot_lengthPerm_iff_not_isLongSimpleRoot` proves that this
-  permutation exchanges long and short simple roots.
+* `TauCeti.SuzukiReeIndex.isLongSimpleRoot_lengthPerm` proves that this permutation exchanges long
+  and short simple roots.
 * `TauCeti.SuzukiReeIndex.exponent` is `1` on long simple roots and the characteristic on short
   simple roots.
 * `TauCeti.SuzukiReeIndex.exponent_of_isLongSimpleRoot` and
@@ -143,8 +143,7 @@ def lengthPerm (e : SuzukiReeIndex) : Equiv.Perm (Fin e.1.rank) :=
 /-- The length permutation selected by a Suzuki--Ree index exchanges long and short simple roots
 in the Bourbaki numbering of its underlying untwisted Dynkin diagram. -/
 @[simp]
-theorem isLongSimpleRoot_lengthPerm_iff_not_isLongSimpleRoot (e : SuzukiReeIndex)
-    (i : Fin e.1.rank) :
+theorem isLongSimpleRoot_lengthPerm (e : SuzukiReeIndex) (i : Fin e.1.rank) :
     e.1.dynkinType.IsLongSimpleRoot (e.lengthPerm i) ↔
       ¬e.1.dynkinType.IsLongSimpleRoot i := by
   simp only [ValidLieTypeIndex.dynkinType, ValidLieTypeIndex.rank] at i ⊢

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
@@ -107,39 +107,35 @@ def lengthPerm (e : SuzukiReeIndex) : Equiv.Perm (Fin e.1.rank) :=
           LieTypeIndex.dynkinType_tits, DynkinType.rank_F4])).symm.permCongr lengthPermF4
 
 /-- A Suzuki index selects the rank-two node swap, transported along the `B₂` numbering. -/
-@[simp] theorem lengthPerm_suzuki (m : ℕ) (hvalid : (LieTypeIndex.suzuki m).Valid)
-    (hhalf : (LieTypeIndex.suzuki m).UsesHalfFrobenius) :
-    lengthPerm ⟨⟨.suzuki m, hvalid⟩, hhalf⟩ =
-      (finCongr (show ValidLieTypeIndex.rank ⟨.suzuki m, hvalid⟩ = 2 by
+@[simp] theorem lengthPerm_suzuki (m : ℕ) (hvalid : (LieTypeIndex.suzuki m).Valid) :
+    lengthPerm ⟨⟨.suzuki m, hvalid⟩, by simp⟩ =
+      (finCongr (by
         simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
           LieTypeIndex.dynkinType_suzuki, DynkinType.rank_B])).symm.permCongr
         lengthPermRankTwo := by
   simp only [lengthPerm]
 
 /-- A Ree `G₂` index selects the rank-two node swap, transported along the `G₂` numbering. -/
-@[simp] theorem lengthPerm_reeG2 (m : ℕ) (hvalid : (LieTypeIndex.reeG2 m).Valid)
-    (hhalf : (LieTypeIndex.reeG2 m).UsesHalfFrobenius) :
-    lengthPerm ⟨⟨.reeG2 m, hvalid⟩, hhalf⟩ =
-      (finCongr (show ValidLieTypeIndex.rank ⟨.reeG2 m, hvalid⟩ = 2 by
+@[simp] theorem lengthPerm_reeG2 (m : ℕ) (hvalid : (LieTypeIndex.reeG2 m).Valid) :
+    lengthPerm ⟨⟨.reeG2 m, hvalid⟩, by simp⟩ =
+      (finCongr (by
         simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
           LieTypeIndex.dynkinType_reeG2, DynkinType.rank_G2])).symm.permCongr
         lengthPermRankTwo := by
   simp only [lengthPerm]
 
 /-- A Ree `F₄` index selects the `F₄` diagram reversal. -/
-@[simp] theorem lengthPerm_reeF4 (m : ℕ) (hvalid : (LieTypeIndex.reeF4 m).Valid)
-    (hhalf : (LieTypeIndex.reeF4 m).UsesHalfFrobenius) :
-    lengthPerm ⟨⟨.reeF4 m, hvalid⟩, hhalf⟩ =
-      (finCongr (show ValidLieTypeIndex.rank ⟨.reeF4 m, hvalid⟩ = 4 by
+@[simp] theorem lengthPerm_reeF4 (m : ℕ) (hvalid : (LieTypeIndex.reeF4 m).Valid) :
+    lengthPerm ⟨⟨.reeF4 m, hvalid⟩, by simp⟩ =
+      (finCongr (by
         simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
           LieTypeIndex.dynkinType_reeF4, DynkinType.rank_F4])).symm.permCongr lengthPermF4 := by
   simp only [lengthPerm]
 
 /-- The Tits index selects the `F₄` diagram reversal. -/
-@[simp] theorem lengthPerm_tits (hvalid : LieTypeIndex.tits.Valid)
-    (hhalf : LieTypeIndex.tits.UsesHalfFrobenius) :
-    lengthPerm ⟨⟨.tits, hvalid⟩, hhalf⟩ =
-      (finCongr (show ValidLieTypeIndex.rank ⟨.tits, hvalid⟩ = 4 by
+@[simp] theorem lengthPerm_tits :
+    lengthPerm ⟨⟨.tits, by simp⟩, by simp⟩ =
+      (finCongr (by
         simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
           LieTypeIndex.dynkinType_tits, DynkinType.rank_F4])).symm.permCongr lengthPermF4 := by
   simp only [lengthPerm]

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
@@ -69,10 +69,6 @@ private theorem isLongSimpleRoot_reindexPerm {t u : DynkinType} (h : t = u)
   subst u
   simpa [finCongr_refl, Equiv.permCongr_def] using hp i
 
-private theorem isLongSimpleRoot_congr {t : DynkinType} {i j : Fin t.rank}
-    (h : (i : ℕ) = j) : t.IsLongSimpleRoot i ↔ t.IsLongSimpleRoot j := by
-  rw [Fin.ext h]
-
 /-- The length-exchanging permutation used by the exceptional isogeny attached to a Suzuki--Ree
 index: the node swap for `B₂` and `G₂`, and reversal for `F₄`.
 
@@ -161,22 +157,22 @@ theorem isLongSimpleRoot_lengthPerm (e : SuzukiReeIndex) (i : Fin e.1.rank) :
     convert isLongSimpleRoot_reindexPerm (LieTypeIndex.dynkinType_suzuki _)
       lengthPermRankTwo isLongSimpleRoot_lengthPermRankTwo_iff_not_isLongSimpleRoot_B2 i using 1
     all_goals simp only [lengthPerm_suzuki]
-    exact isLongSimpleRoot_congr rfl
+    rfl
   case reeG2 =>
     convert isLongSimpleRoot_reindexPerm (LieTypeIndex.dynkinType_reeG2 _)
       lengthPermRankTwo isLongSimpleRoot_lengthPermRankTwo_iff_not_isLongSimpleRoot_G2 i using 1
     all_goals simp only [lengthPerm_reeG2]
-    exact isLongSimpleRoot_congr rfl
+    rfl
   case reeF4 =>
     convert isLongSimpleRoot_reindexPerm (LieTypeIndex.dynkinType_reeF4 _)
       lengthPermF4 isLongSimpleRoot_lengthPermF4_iff_not_isLongSimpleRoot_F4 i using 1
     all_goals simp only [lengthPerm_reeF4]
-    exact isLongSimpleRoot_congr rfl
+    rfl
   case tits =>
     convert isLongSimpleRoot_reindexPerm LieTypeIndex.dynkinType_tits lengthPermF4
       isLongSimpleRoot_lengthPermF4_iff_not_isLongSimpleRoot_F4 i using 1
     all_goals simp only [lengthPerm_tits]
-    exact isLongSimpleRoot_congr rfl
+    rfl
 
 /-- The exponent attached to a numbered simple root subgroup by the exceptional isogeny: `1` on a
 long simple root and the defining characteristic on a short simple root.

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
@@ -35,8 +35,8 @@ four branch equations are simp lemmas rather than the selector body being expose
 * `TauCeti.SuzukiReeIndex.lengthPerm_suzuki`, `TauCeti.SuzukiReeIndex.lengthPerm_reeG2`,
   `TauCeti.SuzukiReeIndex.lengthPerm_reeF4`, and `TauCeti.SuzukiReeIndex.lengthPerm_tits` are the
   branch equations naming the selected permutation on each half-Frobenius family.
-* `TauCeti.SuzukiReeIndex.isLongSimpleRoot_lengthPerm` proves that this permutation exchanges long
-  and short simple roots.
+* `TauCeti.SuzukiReeIndex.isLongSimpleRoot_lengthPerm_iff_not_isLongSimpleRoot` proves that this
+  permutation exchanges long and short simple roots.
 * `TauCeti.SuzukiReeIndex.exponent` is `1` on long simple roots and the characteristic on short
   simple roots.
 * `TauCeti.SuzukiReeIndex.exponent_of_isLongSimpleRoot` and
@@ -143,7 +143,8 @@ def lengthPerm (e : SuzukiReeIndex) : Equiv.Perm (Fin e.1.rank) :=
 /-- The length permutation selected by a Suzuki--Ree index exchanges long and short simple roots
 in the Bourbaki numbering of its underlying untwisted Dynkin diagram. -/
 @[simp]
-theorem isLongSimpleRoot_lengthPerm (e : SuzukiReeIndex) (i : Fin e.1.rank) :
+theorem isLongSimpleRoot_lengthPerm_iff_not_isLongSimpleRoot (e : SuzukiReeIndex)
+    (i : Fin e.1.rank) :
     e.1.dynkinType.IsLongSimpleRoot (e.lengthPerm i) ↔
       ¬e.1.dynkinType.IsLongSimpleRoot i := by
   simp only [ValidLieTypeIndex.dynkinType, ValidLieTypeIndex.rank] at i ⊢

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
@@ -24,14 +24,17 @@ already fixed by the root-systems development, without introducing a second tabl
 and `F₄`.
 
 The permutation selector has only the four half-Frobenius branches: Suzuki and Ree `G₂` use the
-rank-two node swap, while Ree `F₄` and Tits use diagram reversal. Its body is exposed because
-milestone L2 must reduce every branch to the corresponding pinned permutation when selecting the
-upstream special isogeny.
+rank-two node swap, while Ree `F₄` and Tits use diagram reversal. Milestone L2 must reduce every
+branch to the corresponding pinned permutation when selecting the upstream special isogeny, so the
+four branch equations are simp lemmas rather than the selector body being exposed.
 
 ## Main definitions and results
 
 * `TauCeti.SuzukiReeIndex.lengthPerm` selects the length-exchanging permutation used by the
   exceptional isogeny.
+* `TauCeti.SuzukiReeIndex.lengthPerm_suzuki`, `TauCeti.SuzukiReeIndex.lengthPerm_reeG2`,
+  `TauCeti.SuzukiReeIndex.lengthPerm_reeF4`, and `TauCeti.SuzukiReeIndex.lengthPerm_tits` are the
+  branch equations naming the selected permutation on each half-Frobenius family.
 * `TauCeti.SuzukiReeIndex.isLongSimpleRoot_lengthPerm` proves that this permutation exchanges long
   and short simple roots.
 * `TauCeti.SuzukiReeIndex.exponent` is `1` on long simple roots and the characteristic on short
@@ -71,8 +74,11 @@ private theorem isLongSimpleRoot_congr {t : DynkinType} {i j : Fin t.rank}
   rw [Fin.ext h]
 
 /-- The length-exchanging permutation used by the exceptional isogeny attached to a Suzuki--Ree
-index: the node swap for `B₂` and `G₂`, and reversal for `F₄`. -/
-@[expose] def lengthPerm (e : SuzukiReeIndex) : Equiv.Perm (Fin e.1.rank) :=
+index: the node swap for `B₂` and `G₂`, and reversal for `F₄`.
+
+The four branch equations `lengthPerm_suzuki`, `lengthPerm_reeG2`, `lengthPerm_reeF4`, and
+`lengthPerm_tits` name the selected permutation on each family, so no consumer needs this body. -/
+def lengthPerm (e : SuzukiReeIndex) : Equiv.Perm (Fin e.1.rank) :=
   match e with
   | ⟨⟨.A _ _, _⟩, h⟩ => by simp at h
   | ⟨⟨.twistedA _ _, _⟩, h⟩ => by simp at h
@@ -104,6 +110,44 @@ index: the node swap for `B₂` and `G₂`, and reversal for `F₄`. -/
         simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
           LieTypeIndex.dynkinType_tits, DynkinType.rank_F4])).symm.permCongr lengthPermF4
 
+/-- A Suzuki index selects the rank-two node swap, transported along the `B₂` numbering. -/
+@[simp] theorem lengthPerm_suzuki (m : ℕ) (hvalid : (LieTypeIndex.suzuki m).Valid)
+    (hhalf : (LieTypeIndex.suzuki m).UsesHalfFrobenius) :
+    lengthPerm ⟨⟨.suzuki m, hvalid⟩, hhalf⟩ =
+      (finCongr (show ValidLieTypeIndex.rank ⟨.suzuki m, hvalid⟩ = 2 by
+        simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
+          LieTypeIndex.dynkinType_suzuki, DynkinType.rank_B])).symm.permCongr
+        lengthPermRankTwo := by
+  simp only [lengthPerm]
+
+/-- A Ree `G₂` index selects the rank-two node swap, transported along the `G₂` numbering. -/
+@[simp] theorem lengthPerm_reeG2 (m : ℕ) (hvalid : (LieTypeIndex.reeG2 m).Valid)
+    (hhalf : (LieTypeIndex.reeG2 m).UsesHalfFrobenius) :
+    lengthPerm ⟨⟨.reeG2 m, hvalid⟩, hhalf⟩ =
+      (finCongr (show ValidLieTypeIndex.rank ⟨.reeG2 m, hvalid⟩ = 2 by
+        simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
+          LieTypeIndex.dynkinType_reeG2, DynkinType.rank_G2])).symm.permCongr
+        lengthPermRankTwo := by
+  simp only [lengthPerm]
+
+/-- A Ree `F₄` index selects the `F₄` diagram reversal. -/
+@[simp] theorem lengthPerm_reeF4 (m : ℕ) (hvalid : (LieTypeIndex.reeF4 m).Valid)
+    (hhalf : (LieTypeIndex.reeF4 m).UsesHalfFrobenius) :
+    lengthPerm ⟨⟨.reeF4 m, hvalid⟩, hhalf⟩ =
+      (finCongr (show ValidLieTypeIndex.rank ⟨.reeF4 m, hvalid⟩ = 4 by
+        simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
+          LieTypeIndex.dynkinType_reeF4, DynkinType.rank_F4])).symm.permCongr lengthPermF4 := by
+  simp only [lengthPerm]
+
+/-- The Tits index selects the `F₄` diagram reversal. -/
+@[simp] theorem lengthPerm_tits (hvalid : LieTypeIndex.tits.Valid)
+    (hhalf : LieTypeIndex.tits.UsesHalfFrobenius) :
+    lengthPerm ⟨⟨.tits, hvalid⟩, hhalf⟩ =
+      (finCongr (show ValidLieTypeIndex.rank ⟨.tits, hvalid⟩ = 4 by
+        simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
+          LieTypeIndex.dynkinType_tits, DynkinType.rank_F4])).symm.permCongr lengthPermF4 := by
+  simp only [lengthPerm]
+
 /-- The length permutation selected by a Suzuki--Ree index exchanges long and short simple roots
 in the Bourbaki numbering of its underlying untwisted Dynkin diagram. -/
 @[simp]
@@ -116,22 +160,22 @@ theorem isLongSimpleRoot_lengthPerm (e : SuzukiReeIndex) (i : Fin e.1.rank) :
   case suzuki =>
     convert isLongSimpleRoot_reindexPerm (LieTypeIndex.dynkinType_suzuki _)
       lengthPermRankTwo isLongSimpleRoot_lengthPermRankTwo_iff_not_isLongSimpleRoot_B2 i using 1
-    all_goals simp only [lengthPerm]
+    all_goals simp only [lengthPerm_suzuki]
     exact isLongSimpleRoot_congr rfl
   case reeG2 =>
     convert isLongSimpleRoot_reindexPerm (LieTypeIndex.dynkinType_reeG2 _)
       lengthPermRankTwo isLongSimpleRoot_lengthPermRankTwo_iff_not_isLongSimpleRoot_G2 i using 1
-    all_goals simp only [lengthPerm]
+    all_goals simp only [lengthPerm_reeG2]
     exact isLongSimpleRoot_congr rfl
   case reeF4 =>
     convert isLongSimpleRoot_reindexPerm (LieTypeIndex.dynkinType_reeF4 _)
       lengthPermF4 isLongSimpleRoot_lengthPermF4_iff_not_isLongSimpleRoot_F4 i using 1
-    all_goals simp only [lengthPerm]
+    all_goals simp only [lengthPerm_reeF4]
     exact isLongSimpleRoot_congr rfl
   case tits =>
     convert isLongSimpleRoot_reindexPerm LieTypeIndex.dynkinType_tits lengthPermF4
       isLongSimpleRoot_lengthPermF4_iff_not_isLongSimpleRoot_F4 i using 1
-    all_goals simp only [lengthPerm]
+    all_goals simp only [lengthPerm_tits]
     exact isLongSimpleRoot_congr rfl
 
 /-- The exponent attached to a numbered simple root subgroup by the exceptional isogeny: `1` on a

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
@@ -5,15 +5,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.GroupTheory.SpecificGroups.CFSG.Index
-public import TauCeti.LinearAlgebra.RootSystem.RootLength
+public import TauCeti.LinearAlgebra.RootSystem.DiagramPermutations
 
 /-!
-# Root-subgroup exponents for the Suzuki--Ree isogenies
+# Numbered data for the Suzuki--Ree isogenies
 
 The exceptional isogenies used to construct the Suzuki and Ree groups exchange long and short
 simple roots. Their action on a simple root subgroup also raises its parameter to an exponent:
 the exponent is `1` on a long simple root and the defining characteristic on a short simple root.
-This file records that convention for `TauCeti.SuzukiReeIndex`.
+This file attaches both the length-exchanging permutation and the exponent convention to
+`TauCeti.SuzukiReeIndex`.
 
 The assignment is a genuine choice. Reversing the two exponents would still make the square of the
 exceptional isogeny a prime-field Frobenius, so the square relation alone does not determine which
@@ -22,8 +23,17 @@ isogeny the later construction uses. Defining the exponent through
 already fixed by the root-systems development, without introducing a second table for `B₂`, `G₂`,
 and `F₄`.
 
+The permutation selector has only the four half-Frobenius branches: Suzuki and Ree `G₂` use the
+rank-two node swap, while Ree `F₄` and Tits use diagram reversal. Its body is exposed because
+milestone L2 must reduce every branch to the corresponding pinned permutation when selecting the
+upstream special isogeny.
+
 ## Main definitions and results
 
+* `TauCeti.SuzukiReeIndex.lengthPerm` selects the length-exchanging permutation used by the
+  exceptional isogeny.
+* `TauCeti.SuzukiReeIndex.isLongSimpleRoot_lengthPerm` proves that this permutation exchanges long
+  and short simple roots.
 * `TauCeti.SuzukiReeIndex.exponent` is `1` on long simple roots and the characteristic on short
   simple roots.
 * `TauCeti.SuzukiReeIndex.exponent_of_isLongSimpleRoot` and
@@ -33,9 +43,10 @@ and `F₄`.
   `TauCeti.SuzukiReeIndex.exponent_eq_characteristic_iff` characterize the two values without
   unfolding the definition.
 
-This is the exponent-convention part of milestone I0 in
-`TauCetiRoadmap/CFSGStatement/README.md`. The convention follows Carter, *Simple Groups of Lie
-Type*, and the Bourbaki numbering fixed by the CFSG and root-systems roadmaps.
+This is the Suzuki--Ree numbered-data part of milestone I0 in
+`TauCetiRoadmap/CFSGStatement/README.md`. The exponent convention follows Carter, *Simple Groups of
+Lie Type*. The permutations and numbering follow Bourbaki, *Lie Groups and Lie Algebras, Chapters
+4--6*, plates II, VIII, and IX, as fixed by the CFSG and root-systems roadmaps.
 -/
 
 public section
@@ -43,6 +54,85 @@ public section
 namespace TauCeti
 
 namespace SuzukiReeIndex
+
+-- Transporting the root-length predicate together with its index type avoids dependent rewriting
+-- through `DynkinType.rank`, which is precisely the dependency that `finCongr` packages.
+private theorem isLongSimpleRoot_reindexPerm {t u : DynkinType} (h : t = u)
+    (p : Equiv.Perm (Fin u.rank))
+    (hp : ∀ j, u.IsLongSimpleRoot (p j) ↔ ¬u.IsLongSimpleRoot j) (i : Fin t.rank) :
+    t.IsLongSimpleRoot
+        ((finCongr (congrArg DynkinType.rank h)).symm.permCongr p i) ↔
+      ¬t.IsLongSimpleRoot i := by
+  subst u
+  simpa [finCongr_refl, Equiv.permCongr_def] using hp i
+
+private theorem isLongSimpleRoot_congr {t : DynkinType} {i j : Fin t.rank}
+    (h : (i : ℕ) = j) : t.IsLongSimpleRoot i ↔ t.IsLongSimpleRoot j := by
+  rw [Fin.ext h]
+
+/-- The length-exchanging permutation used by the exceptional isogeny attached to a Suzuki--Ree
+index: the node swap for `B₂` and `G₂`, and reversal for `F₄`. -/
+@[expose] def lengthPerm (e : SuzukiReeIndex) : Equiv.Perm (Fin e.1.rank) :=
+  match e with
+  | ⟨⟨.A _ _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.twistedA _ _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.B _ _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.C _ _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.D _ _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.twistedD _ _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.E6 _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.E7 _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.E8 _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.F4 _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.G2 _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.twistedE6 _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.trialityD4 _, _⟩, h⟩ => by simp at h
+  | ⟨⟨.suzuki m, hvalid⟩, _⟩ =>
+      (finCongr (by
+        simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
+          LieTypeIndex.dynkinType_suzuki, DynkinType.rank_B])).symm.permCongr lengthPermRankTwo
+  | ⟨⟨.reeG2 m, hvalid⟩, _⟩ =>
+      (finCongr (by
+        simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
+          LieTypeIndex.dynkinType_reeG2, DynkinType.rank_G2])).symm.permCongr lengthPermRankTwo
+  | ⟨⟨.reeF4 m, hvalid⟩, _⟩ =>
+      (finCongr (by
+        simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
+          LieTypeIndex.dynkinType_reeF4, DynkinType.rank_F4])).symm.permCongr lengthPermF4
+  | ⟨⟨.tits, hvalid⟩, _⟩ =>
+      (finCongr (by
+        simp only [ValidLieTypeIndex.rank, ValidLieTypeIndex.dynkinType,
+          LieTypeIndex.dynkinType_tits, DynkinType.rank_F4])).symm.permCongr lengthPermF4
+
+/-- The length permutation selected by a Suzuki--Ree index exchanges long and short simple roots
+in the Bourbaki numbering of its underlying untwisted Dynkin diagram. -/
+@[simp]
+theorem isLongSimpleRoot_lengthPerm (e : SuzukiReeIndex) (i : Fin e.1.rank) :
+    e.1.dynkinType.IsLongSimpleRoot (e.lengthPerm i) ↔
+      ¬e.1.dynkinType.IsLongSimpleRoot i := by
+  simp only [ValidLieTypeIndex.dynkinType, ValidLieTypeIndex.rank] at i ⊢
+  obtain ⟨⟨d, hvalid⟩, hhalf⟩ := e
+  cases d <;> try simp at hhalf
+  case suzuki =>
+    convert isLongSimpleRoot_reindexPerm (LieTypeIndex.dynkinType_suzuki _)
+      lengthPermRankTwo isLongSimpleRoot_lengthPermRankTwo_iff_not_isLongSimpleRoot_B2 i using 1
+    all_goals simp only [lengthPerm]
+    exact isLongSimpleRoot_congr rfl
+  case reeG2 =>
+    convert isLongSimpleRoot_reindexPerm (LieTypeIndex.dynkinType_reeG2 _)
+      lengthPermRankTwo isLongSimpleRoot_lengthPermRankTwo_iff_not_isLongSimpleRoot_G2 i using 1
+    all_goals simp only [lengthPerm]
+    exact isLongSimpleRoot_congr rfl
+  case reeF4 =>
+    convert isLongSimpleRoot_reindexPerm (LieTypeIndex.dynkinType_reeF4 _)
+      lengthPermF4 isLongSimpleRoot_lengthPermF4_iff_not_isLongSimpleRoot_F4 i using 1
+    all_goals simp only [lengthPerm]
+    exact isLongSimpleRoot_congr rfl
+  case tits =>
+    convert isLongSimpleRoot_reindexPerm LieTypeIndex.dynkinType_tits lengthPermF4
+      isLongSimpleRoot_lengthPermF4_iff_not_isLongSimpleRoot_F4 i using 1
+    all_goals simp only [lengthPerm]
+    exact isLongSimpleRoot_congr rfl
 
 /-- The exponent attached to a numbered simple root subgroup by the exceptional isogeny: `1` on a
 long simple root and the defining characteristic on a short simple root.


### PR DESCRIPTION
This PR attaches the pinned length-exchanging diagram permutation to every `SuzukiReeIndex`, selecting the rank-two node swap for Suzuki and Ree `G₂` and the `F₄` reversal for Ree `F₄` and Tits, and proves `SuzukiReeIndex.isLongSimpleRoot_lengthPerm`. This implements the exact `SuzukiReeIndex.lengthPerm` and long/short exchange targets in `TauCetiRoadmap/CFSGStatement/README.md`, milestone **I0: indices and Mathlib glue**.

This is the most effective distinct current step because the raw Bourbaki-numbered permutations, their root-length checks, the CFSG indices, algebraic closures, and exponent selector are already on `main`, while newly opened #2629 owns the separate `GraphTwistedIndex.diagramPerm` target. After this PR, I0 only awaits #2629's graph-permutation selector; L0--L4, S0--S1, and A0 then remain on the path to the classification statement.

The restricted subtype makes the selector total without inventing values for ordinary families. Each surviving branch transports the already-landed raw permutation along the theorem identifying its Dynkin rank, and the exchange proof transports the corresponding `B₂`, `G₂`, or `F₄` root-length theorem. The four branch equations `lengthPerm_suzuki`, `lengthPerm_reeG2`, `lengthPerm_reeF4`, and `lengthPerm_tits` are the public interface for milestone L2, which must reduce each branch to the corresponding pinned permutation when selecting the upstream special isogeny; the selector body itself stays unexposed.

The implementation reuses Mathlib's `finCongr` and `Equiv.permCongr`, together with Tau Ceti's `lengthPermRankTwo`, `lengthPermF4`, and their root-length exchange theorems; no Mathlib infrastructure is vendored. The numbering follows Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, plates II, VIII, and IX, as credited in the module documentation.

Update `TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean` to 197 lines (+96/-6), extending its existing Suzuki--Ree numbered-data API.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"suzukireeindex-lengthperm"}-->

🤖 Prepared with Codex

