### PR TITLE
feat(Contour): the model sector's crossing angle is its opening angle

### DIFF
--- a/TauCeti/Analysis/Contour/ModelSector/CrossingAngle.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/CrossingAngle.lean
@@ -17,12 +17,14 @@ opening `α` winding number `α / 2π` about its corner. Nothing connected the t
 value was stated in terms of the *parameter* `α`, and the crossing angle in terms of *tangents*,
 with no theorem saying they agree.
 
-This file supplies that bridge — `crossingAngle_modelSector`, for every real `α` — and with
-  angle `α` at its corner — stated for every real `α` as the `[0, 2π)` normalisation of
-  `α`, which is `α` itself exactly when `0 ≤ α < 2π`.
-winding about the corner is the crossing angle over `2π`, with no reference to the
-parametrisation. That is the shape a general curve can be compared against, since a curve is
-tangent to a model sector without being equal to one.
+This file supplies that bridge. `crossingAngle_modelSector` holds for every real `α`: the
+crossing angle at the corner is the `[0, 2π)` normalisation of `α`, which is `α` itself exactly
+when `0 ≤ α < 2π`. Under those bounds, `windingNumber_closedModelSector_eq_crossingAngle` then
+restates the winding number about the corner as the crossing angle over `2π`, with no reference
+to the parametrisation.
+
+That is the shape a general curve can be compared against, since a curve is tangent to a model
+sector without being equal to one.
 
 ## Main declarations
 

--- a/TauCeti/Analysis/Contour/ModelSector/CrossingAngle.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/CrossingAngle.lean
@@ -19,9 +19,9 @@ with no theorem saying they agree.
 
 This file supplies that bridge. `crossingAngle_modelSector` holds for every real `α`: the
 crossing angle at the corner is the `[0, 2π)` normalisation of `α`, which is `α` itself exactly
-when `0 ≤ α < 2π`. Under those bounds, `windingNumber_closedModelSector_eq_crossingAngle` then
-restates the winding number about the corner as the crossing angle over `2π`, with no reference
-to the parametrisation.
+when `0 ≤ α < 2π`. Under those bounds,
+`windingNumber_closedModelSector_eq_crossingAngle_div_two_pi` then restates the winding number
+about the corner as the crossing angle over `2π`, with no reference to the parametrisation.
 
 That is the shape a general curve can be compared against, since a curve is tangent to a model
 sector without being equal to one.
@@ -31,8 +31,8 @@ sector without being equal to one.
 * `TauCeti.Contour.crossingAngle_modelSector`: the model sector of opening `α` has crossing
   angle `α` at its corner — stated for every real `α` as the `[0, 2π)` normalisation of `α`,
   which is `α` itself exactly when `0 ≤ α < 2π`.
-* `TauCeti.Contour.windingNumber_closedModelSector_eq_crossingAngle`: hence its winding number
-  about the corner is `crossingAngle / (2π)`.
+* `TauCeti.Contour.windingNumber_closedModelSector_eq_crossingAngle_div_two_pi`: hence its
+  winding number about the corner is `crossingAngle / (2π)`.
 
 ## References
 
@@ -97,8 +97,8 @@ theorem crossingAngle_modelSector (hr : 0 < r) (φ : ℝ) (α : ℝ) :
 /-- **The model sector's winding number, read off its crossing angle.** Combining
 `windingNumber_closedModelSector` with `crossingAngle_modelSector`: the winding number about the
 corner is the crossing angle over `2π`, with no reference to the parametrisation. -/
-theorem windingNumber_closedModelSector_eq_crossingAngle (hr : 0 < r) (φ : ℝ) (hα : 0 ≤ α)
-    (hα2 : α < 2 * Real.pi) :
+theorem windingNumber_closedModelSector_eq_crossingAngle_div_two_pi (hr : 0 < r) (φ : ℝ)
+    (hα : 0 ≤ α) (hα2 : α < 2 * Real.pi) :
     windingNumber (modelSector z₀ r φ α) (-r) (r + α) z₀ =
       (crossingAngle (modelSector z₀ r φ α) 0 : ℂ) / (2 * (Real.pi : ℂ)) := by
   rw [crossingAngle_modelSector hr φ α, windingNumber_closedModelSector hr φ hα,

--- a/TauCeti/Analysis/Contour/ModelSector/CrossingAngle.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/CrossingAngle.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Contour.ModelSector.Closed
 public import TauCeti.Analysis.Contour.RegularityConditions
+import TauCeti.Analysis.SpecialFunctions.Trigonometric.Angle
 
 /-!
 # The model sector's crossing angle is its opening angle
@@ -89,7 +90,7 @@ theorem crossingAngle_modelSector (hr : 0 < r) (φ : ℝ) (α : ℝ) :
     rw [hderiv (ne_of_lt hs.2) (by rw [abs_of_neg hs.2]; linarith [hs.1]), if_pos hs.2]
   rw [crossingAngle_eq_of_tendsto h_R h_L, neg_neg]
   -- `arg u - arg v` is `α` in `Real.Angle`; the shared transport reads that back.
-  refine toIcoMod_eq_toIcoMod_of_angle_eq ?_
+  refine Real.Angle.toIcoMod_eq_toIcoMod_iff_coe_eq.mpr ?_
   rw [Real.Angle.coe_sub, hu, hv, Complex.arg_exp_mul_I, Complex.arg_exp_mul_I,
     Real.Angle.coe_toIocMod, Real.Angle.coe_toIocMod, ← Real.Angle.coe_sub]
   norm_num

--- a/TauCeti/Analysis/Contour/ModelSector/CrossingAngle.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/CrossingAngle.lean
@@ -17,8 +17,9 @@ opening `α` winding number `α / 2π` about its corner. Nothing connected the t
 value was stated in terms of the *parameter* `α`, and the crossing angle in terms of *tangents*,
 with no theorem saying they agree.
 
-This file supplies that bridge — `crossingAngle_modelSector` — and with it the model sector's
-winding number in intrinsic form, `windingNumber_closedModelSector_eq_crossingAngle`: the
+This file supplies that bridge — `crossingAngle_modelSector`, for every real `α` — and with
+  angle `α` at its corner — stated for every real `α` as the `[0, 2π)` normalisation of
+  `α`, which is `α` itself exactly when `0 ≤ α < 2π`.
 winding about the corner is the crossing angle over `2π`, with no reference to the
 parametrisation. That is the shape a general curve can be compared against, since a curve is
 tangent to a model sector without being equal to one.
@@ -26,14 +27,16 @@ tangent to a model sector without being equal to one.
 ## Main declarations
 
 * `TauCeti.Contour.crossingAngle_modelSector`: the model sector of opening `α` has crossing
-  angle `α` at its corner.
+  angle `α` at its corner — stated for every real `α` as the `[0, 2π)` normalisation of `α`,
+  which is `α` itself exactly when `0 ≤ α < 2π`.
 * `TauCeti.Contour.windingNumber_closedModelSector_eq_crossingAngle`: hence its winding number
   about the corner is `crossingAngle / (2π)`.
 
 ## References
 
-* K. Hungerbühler, J. Wasem, *A generalized notion of winding numbers* — the crossing-angle
-  reading of the model sector's index.
+* N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, arXiv:1808.00997 — the model sector is their equation (2.4), and the crossing-angle
+  reading of its index is what this file supplies.
 -/
 
 public section
@@ -64,8 +67,9 @@ private theorem modelSector_deriv_eventuallyEq (hr : 0 < r) (φ α : ℝ) {t : �
 tangent is `-exp((φ + α)i)` and the outgoing one is `exp(φ i)`, so the normalised angle from the
 exit ray to the reversed entry ray is `α` itself — for `0 ≤ α < 2π`, the range on which the
 opening angle determines the sector. -/
-theorem crossingAngle_modelSector (hr : 0 < r) (φ : ℝ) (hα : 0 ≤ α) (hα2 : α < 2 * Real.pi) :
-    crossingAngle (modelSector z₀ r φ α) 0 = α := by
+@[simp]
+theorem crossingAngle_modelSector (hr : 0 < r) (φ : ℝ) (α : ℝ) :
+    crossingAngle (modelSector z₀ r φ α) 0 = toIcoMod Real.two_pi_pos 0 α := by
   set u : ℂ := Complex.exp ((φ + α : ℝ) * Complex.I) with hu
   set v : ℂ := Complex.exp ((φ : ℝ) * Complex.I) with hv
   -- The one-sided tangent limits are the two ray directions: the derivative is locally constant
@@ -82,16 +86,11 @@ theorem crossingAngle_modelSector (hr : 0 < r) (φ : ℝ) (hα : 0 ≤ α) (hα2
     filter_upwards [Ioo_mem_nhdsLT (neg_lt_zero.mpr hr)] with s hs
     rw [hderiv (ne_of_lt hs.2) (by rw [abs_of_neg hs.2]; linarith [hs.1]), if_pos hs.2]
   rw [crossingAngle_eq_of_tendsto h_R h_L, neg_neg]
-  -- `arg u - arg v` is `α` modulo `2π`, and the `[0, 2π)` normalisation picks out `α`.
-  have hangle : ((Complex.arg u - Complex.arg v : ℝ) : Real.Angle) = (α : ℝ) := by
-    rw [Real.Angle.coe_sub, hu, hv, Complex.arg_exp_mul_I, Complex.arg_exp_mul_I,
-      Real.Angle.coe_toIocMod, Real.Angle.coe_toIocMod, ← Real.Angle.coe_sub]
-    norm_num
-  obtain ⟨k, hk⟩ := Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp hangle
-  have hshift : Complex.arg u - Complex.arg v = α + k • (2 * Real.pi) := by
-    rw [zsmul_eq_mul]; linarith
-  rw [hshift, toIcoMod_add_zsmul]
-  exact (toIcoMod_eq_self Real.two_pi_pos).mpr (Set.mem_Ico.mpr ⟨hα, by rw [zero_add]; exact hα2⟩)
+  -- `arg u - arg v` is `α` in `Real.Angle`; the shared transport reads that back.
+  refine toIcoMod_eq_toIcoMod_of_angle_eq ?_
+  rw [Real.Angle.coe_sub, hu, hv, Complex.arg_exp_mul_I, Complex.arg_exp_mul_I,
+    Real.Angle.coe_toIocMod, Real.Angle.coe_toIocMod, ← Real.Angle.coe_sub]
+  norm_num
 
 /-- **The model sector's winding number, read off its crossing angle.** Combining
 `windingNumber_closedModelSector` with `crossingAngle_modelSector`: the winding number about the
@@ -100,7 +99,8 @@ theorem windingNumber_closedModelSector_eq_crossingAngle (hr : 0 < r) (φ : ℝ)
     (hα2 : α < 2 * Real.pi) :
     windingNumber (modelSector z₀ r φ α) (-r) (r + α) z₀ =
       (crossingAngle (modelSector z₀ r φ α) 0 : ℂ) / (2 * (Real.pi : ℂ)) := by
-  rw [crossingAngle_modelSector hr φ hα hα2, windingNumber_closedModelSector hr φ hα]
+  rw [crossingAngle_modelSector hr φ α, windingNumber_closedModelSector hr φ hα,
+    (toIcoMod_eq_self Real.two_pi_pos).mpr (Set.mem_Ico.mpr ⟨hα, by rw [zero_add]; exact hα2⟩)]
 
 end Contour
 

--- a/TauCeti/Analysis/Contour/ModelSector/CrossingAngle.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/CrossingAngle.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Contour.ModelSector.Closed
+public import TauCeti.Analysis.Contour.RegularityConditions
+
+/-!
+# The model sector's crossing angle is its opening angle
+
+`TauCeti.Contour.crossingAngle` reads the opening angle at a crossing off the two one-sided
+tangent limits, and `TauCeti.Contour.windingNumber_closedModelSector` gives the model sector of
+opening `α` winding number `α / 2π` about its corner. Nothing connected the two: the winding
+value was stated in terms of the *parameter* `α`, and the crossing angle in terms of *tangents*,
+with no theorem saying they agree.
+
+This file supplies that bridge — `crossingAngle_modelSector` — and with it the model sector's
+winding number in intrinsic form, `windingNumber_closedModelSector_eq_crossingAngle`: the
+winding about the corner is the crossing angle over `2π`, with no reference to the
+parametrisation. That is the shape a general curve can be compared against, since a curve is
+tangent to a model sector without being equal to one.
+
+## Main declarations
+
+* `TauCeti.Contour.crossingAngle_modelSector`: the model sector of opening `α` has crossing
+  angle `α` at its corner.
+* `TauCeti.Contour.windingNumber_closedModelSector_eq_crossingAngle`: hence its winding number
+  about the corner is `crossingAngle / (2π)`.
+
+## References
+
+* K. Hungerbühler, J. Wasem, *A generalized notion of winding numbers* — the crossing-angle
+  reading of the model sector's index.
+-/
+
+public section
+
+open Complex Filter Set
+
+open scoped Real Topology
+
+namespace TauCeti
+
+namespace Contour
+
+variable {z₀ : ℂ} {r φ α : ℝ}
+
+/-- Near its corner the model sector is its two-ray corner, so the two curves have the same
+derivative there. -/
+private theorem modelSector_deriv_eventuallyEq (hr : 0 < r) (φ α : ℝ) {t : ℝ} (ht : |t| < r) :
+    deriv (modelSector z₀ r φ α) t =
+      deriv (twoRayCorner z₀ (Complex.exp ((φ + α : ℝ) * Complex.I))
+        (Complex.exp ((φ : ℝ) * Complex.I))) t := by
+  refine Filter.EventuallyEq.deriv_eq ?_
+  have hmem : Set.Ioo (-r) r ∈ 𝓝 t :=
+    Ioo_mem_nhds (by cases abs_lt.mp ht; linarith) (abs_lt.mp ht).2
+  filter_upwards [hmem] with s hs
+  exact (modelSector_eqOn_corner z₀ hr.le φ α (by rwa [Set.uIoo_of_le (by linarith)])).symm
+
+/-- **The model sector's crossing angle is its opening angle.** At the corner the incoming
+tangent is `-exp((φ + α)i)` and the outgoing one is `exp(φ i)`, so the normalised angle from the
+exit ray to the reversed entry ray is `α` itself — for `0 ≤ α < 2π`, the range on which the
+opening angle determines the sector. -/
+theorem crossingAngle_modelSector (hr : 0 < r) (φ : ℝ) (hα : 0 ≤ α) (hα2 : α < 2 * Real.pi) :
+    crossingAngle (modelSector z₀ r φ α) 0 = α := by
+  set u : ℂ := Complex.exp ((φ + α : ℝ) * Complex.I) with hu
+  set v : ℂ := Complex.exp ((φ : ℝ) * Complex.I) with hv
+  -- The one-sided tangent limits are the two ray directions: the derivative is locally constant
+  -- on each side of the corner.
+  have hderiv : ∀ {t : ℝ}, t ≠ 0 → |t| < r →
+      deriv (modelSector z₀ r φ α) t = if t < 0 then -u else v := fun ht htr => by
+    rw [modelSector_deriv_eventuallyEq hr φ α htr, deriv_twoRayCorner_of_ne ht]
+  have h_R : Tendsto (deriv (modelSector z₀ r φ α)) (𝓝[>] 0) (𝓝 v) := by
+    refine Tendsto.congr' ?_ tendsto_const_nhds
+    filter_upwards [Ioo_mem_nhdsGT hr] with s hs
+    rw [hderiv (ne_of_gt hs.1) (by rw [abs_of_pos hs.1]; exact hs.2), if_neg (not_lt.mpr hs.1.le)]
+  have h_L : Tendsto (deriv (modelSector z₀ r φ α)) (𝓝[<] 0) (𝓝 (-u)) := by
+    refine Tendsto.congr' ?_ tendsto_const_nhds
+    filter_upwards [Ioo_mem_nhdsLT (neg_lt_zero.mpr hr)] with s hs
+    rw [hderiv (ne_of_lt hs.2) (by rw [abs_of_neg hs.2]; linarith [hs.1]), if_pos hs.2]
+  rw [crossingAngle_eq_of_tendsto h_R h_L, neg_neg]
+  -- `arg u - arg v` is `α` modulo `2π`, and the `[0, 2π)` normalisation picks out `α`.
+  have hangle : ((Complex.arg u - Complex.arg v : ℝ) : Real.Angle) = (α : ℝ) := by
+    rw [Real.Angle.coe_sub, hu, hv, Complex.arg_exp_mul_I, Complex.arg_exp_mul_I,
+      Real.Angle.coe_toIocMod, Real.Angle.coe_toIocMod, ← Real.Angle.coe_sub]
+    norm_num
+  obtain ⟨k, hk⟩ := Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp hangle
+  have hshift : Complex.arg u - Complex.arg v = α + k • (2 * Real.pi) := by
+    rw [zsmul_eq_mul]; linarith
+  rw [hshift, toIcoMod_add_zsmul]
+  exact (toIcoMod_eq_self Real.two_pi_pos).mpr (Set.mem_Ico.mpr ⟨hα, by rw [zero_add]; exact hα2⟩)
+
+/-- **The model sector's winding number, read off its crossing angle.** Combining
+`windingNumber_closedModelSector` with `crossingAngle_modelSector`: the winding number about the
+corner is the crossing angle over `2π`, with no reference to the parametrisation. -/
+theorem windingNumber_closedModelSector_eq_crossingAngle (hr : 0 < r) (φ : ℝ) (hα : 0 ≤ α)
+    (hα2 : α < 2 * Real.pi) :
+    windingNumber (modelSector z₀ r φ α) (-r) (r + α) z₀ =
+      (crossingAngle (modelSector z₀ r φ α) 0 : ℂ) / (2 * (Real.pi : ℂ)) := by
+  rw [crossingAngle_modelSector hr φ hα hα2, windingNumber_closedModelSector hr φ hα]
+
+end Contour
+
+end TauCeti

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -12,6 +12,7 @@ public import Mathlib.Analysis.Meromorphic.Order
 public import Mathlib.Algebra.Order.ToIntervalMod
 import Mathlib.Analysis.SpecialFunctions.Complex.Log
 import TauCeti.Analysis.Contour.Argument.Lift
+import TauCeti.Analysis.SpecialFunctions.Trigonometric.Angle
 
 /-!
 # The Hungerbühler–Wasem crossing angle and regularity conditions (A′) and (B)
@@ -121,16 +122,6 @@ def basepointAngle (γ : ℝ → ℂ) (a b : ℝ) : ℝ :=
   toIcoMod Real.two_pi_pos 0
     (Complex.arg (-limUnder (𝓝[<] b) (deriv γ)) - Complex.arg (limUnder (𝓝[>] a) (deriv γ)))
 
-/-- **Equal angles have equal normalisations.** Two reals that agree in `Real.Angle` differ by an
-integer multiple of `2π`, which the `[0, 2π)` normalisation discards. This is the transport step
-behind every crossing-angle computation: the angle identity is proved in `Real.Angle`, where
-`2π` is invisible, and then read back as a `toIcoMod` equality. -/
-theorem toIcoMod_eq_toIcoMod_of_angle_eq {x y : ℝ} (h : (x : Real.Angle) = (y : Real.Angle)) :
-    toIcoMod Real.two_pi_pos 0 x = toIcoMod Real.two_pi_pos 0 y := by
-  obtain ⟨k, hk⟩ := Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp h
-  have hshift : x = y + k • (2 * Real.pi) := by rw [zsmul_eq_mul]; linarith
-  rw [hshift, toIcoMod_add_zsmul]
-
 /-- For a nonzero `L : ℂ`, the normalized angle from `L` to `−L` is `π`. This is the engine behind
 the smooth-crossing values of `crossingAngle` and `basepointAngle`. -/
 private theorem toIcoMod_arg_neg_sub_arg {L : ℂ} (hL : L ≠ 0) :
@@ -138,7 +129,7 @@ private theorem toIcoMod_arg_neg_sub_arg {L : ℂ} (hL : L ≠ 0) :
   have hangle : ((Complex.arg (-L) - Complex.arg L : ℝ) : Real.Angle) = (Real.pi : ℝ) := by
     rw [Real.Angle.coe_sub, Complex.arg_neg_coe_angle hL]
     abel
-  rw [toIcoMod_eq_toIcoMod_of_angle_eq hangle]
+  rw [Real.Angle.toIcoMod_eq_toIcoMod_iff_coe_eq.mpr hangle]
   exact (toIcoMod_eq_self Real.two_pi_pos).mpr
     (Set.mem_Ico.mpr ⟨Real.pi_nonneg, by rw [zero_add]; linarith [Real.pi_pos]⟩)
 

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -121,20 +121,24 @@ def basepointAngle (γ : ℝ → ℂ) (a b : ℝ) : ℝ :=
   toIcoMod Real.two_pi_pos 0
     (Complex.arg (-limUnder (𝓝[<] b) (deriv γ)) - Complex.arg (limUnder (𝓝[>] a) (deriv γ)))
 
+/-- **Equal angles have equal normalisations.** Two reals that agree in `Real.Angle` differ by an
+integer multiple of `2π`, which the `[0, 2π)` normalisation discards. This is the transport step
+behind every crossing-angle computation: the angle identity is proved in `Real.Angle`, where
+`2π` is invisible, and then read back as a `toIcoMod` equality. -/
+theorem toIcoMod_eq_toIcoMod_of_angle_eq {x y : ℝ} (h : (x : Real.Angle) = (y : Real.Angle)) :
+    toIcoMod Real.two_pi_pos 0 x = toIcoMod Real.two_pi_pos 0 y := by
+  obtain ⟨k, hk⟩ := Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp h
+  have hshift : x = y + k • (2 * Real.pi) := by rw [zsmul_eq_mul]; linarith
+  rw [hshift, toIcoMod_add_zsmul]
+
 /-- For a nonzero `L : ℂ`, the normalized angle from `L` to `−L` is `π`. This is the engine behind
 the smooth-crossing values of `crossingAngle` and `basepointAngle`. -/
 private theorem toIcoMod_arg_neg_sub_arg {L : ℂ} (hL : L ≠ 0) :
     toIcoMod Real.two_pi_pos 0 (Complex.arg (-L) - Complex.arg L) = Real.pi := by
-  -- `arg (-L) = arg L + π` holds in `Real.Angle`; transporting back to `ℝ` leaves `π` up to a
-  -- multiple of `2π`, which the `[0, 2π)` normalization discards.
   have hangle : ((Complex.arg (-L) - Complex.arg L : ℝ) : Real.Angle) = (Real.pi : ℝ) := by
     rw [Real.Angle.coe_sub, Complex.arg_neg_coe_angle hL]
     abel
-  obtain ⟨k, hk⟩ := Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp hangle
-  have hshift : Complex.arg (-L) - Complex.arg L = Real.pi + k • (2 * Real.pi) := by
-    rw [zsmul_eq_mul]
-    linarith
-  rw [hshift, toIcoMod_add_zsmul]
+  rw [toIcoMod_eq_toIcoMod_of_angle_eq hangle]
   exact (toIcoMod_eq_self Real.two_pi_pos).mpr
     (Set.mem_Ico.mpr ⟨Real.pi_nonneg, by rw [zero_add]; linarith [Real.pi_pos]⟩)
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Angle.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Angle.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Angle
+
+/-!
+# Normalising a real angle into `[0, 2π)`
+
+`Real.Angle` is `ℝ` modulo `2π`, and `toIcoMod Real.two_pi_pos 0` is the section of the quotient
+map picking the representative in `[0, 2π)`. Mathlib records one direction of the relationship
+between the two, as `Real.Angle.coe_toIcoMod`: normalising and then projecting to `Real.Angle`
+changes nothing.
+
+This file records that the section is *injective on angles* — the normalisations of two reals
+agree exactly when the reals agree in `Real.Angle`. That is the transport step behind any
+computation of a normalised angle: the identity is proved in `Real.Angle`, where `2π` is
+invisible, and then read back as an equality of representatives.
+
+## Main results
+
+* `Real.Angle.toIcoMod_eq_toIcoMod_iff_coe_eq`: two reals have the same `[0, 2π)` representative
+  exactly when they are equal in `Real.Angle`.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- **Equal angles are exactly equal normalisations.** Two reals agree in `Real.Angle` — that is,
+differ by an integer multiple of `2π` — exactly when their representatives in `[0, 2π)` agree,
+since the normalisation discards precisely such a multiple.
+
+The forward direction is Mathlib's `Real.Angle.coe_toIcoMod` applied on both sides; the reverse
+shifts one argument by the multiple and uses `toIcoMod_add_zsmul`. -/
+theorem _root_.Real.Angle.toIcoMod_eq_toIcoMod_iff_coe_eq {x y : ℝ} :
+    toIcoMod Real.two_pi_pos 0 x = toIcoMod Real.two_pi_pos 0 y ↔
+      (x : Real.Angle) = (y : Real.Angle) := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · rw [← Real.Angle.coe_toIcoMod x 0, ← Real.Angle.coe_toIcoMod y 0, h]
+  · obtain ⟨k, hk⟩ := Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp h
+    have hshift : x = y + k • (2 * Real.pi) := by rw [zsmul_eq_mul]; linarith
+    rw [hshift, toIcoMod_add_zsmul]
+
+end TauCeti


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"layer1/crossing-angle-model-sector"}-->

`crossingAngle` reads the opening angle at a crossing off the two one-sided tangent limits.
`windingNumber_closedModelSector` gives the model sector of opening `α` the winding number
`α / 2π` about its corner. **Nothing connected the two** — one is stated in terms of the
*parameter* `α`, the other in terms of *tangents*, and no theorem said they agree.

This PR supplies that bridge:

* `crossingAngle_modelSector` — at the corner the incoming tangent is `-exp((φ + α)i)` and the
  outgoing one is `exp(φ i)`, so the normalised angle from the exit ray to the reversed entry
  ray is `α` itself, for `0 ≤ α < 2π` (the range on which the opening angle determines the
  sector; outside it the winding formula still holds but the corner reading lapses, exactly as
  `windingNumber_closedModelSector`'s docstring records).
* `windingNumber_closedModelSector_eq_crossingAngle_div_two_pi` — hence the model sector's
  winding number about its corner is `crossingAngle / (2π)`, stated with no reference to the
  parametrisation.

## Why this shape

A general curve is *tangent* to a model sector at a corner without being *equal* to one. Every
existing route from the model to a concrete curve goes through exact agreement
(`windingNumber_congr_curve` composed with `windingNumber_closedModelSector`), so the winding
of a concrete corner could not be read off the model and had to be computed by hand — which is
what the fundamental-domain corner values at `i`, `ρ` and `ρ + 1` each did, by telescoping a
logarithmic derivative and taking `ε → 0`.

Stating the model's index intrinsically, against the tangent-defined `crossingAngle`, is the
first step to comparing a curve with the model on the strength of its tangents alone.

## The angle-normalisation step

Both this computation and the existing smooth-crossing one need to pass from an identity proved
in `Real.Angle`, where `2π` is invisible, to an equality of `[0, 2π)` representatives. That step
has no contour content whatsoever, so it is stated in a new general module,
`TauCeti/Analysis/SpecialFunctions/Trigonometric/Angle.lean`, in Mathlib's `Real.Angle`
namespace beside `Real.Angle.coe_toIcoMod` — and as the **iff** it actually is, since
`coe_toIcoMod` gives the converse in one line. `toIcoMod_arg_neg_sub_arg`, which previously
inlined the forward direction, now calls it.

## Main declarations

* `TauCeti.Contour.crossingAngle_modelSector`
* `TauCeti.Contour.windingNumber_closedModelSector_eq_crossingAngle_div_two_pi`
* `Real.Angle.toIcoMod_eq_toIcoMod_iff_coe_eq`

Roadmap: ContourIntegration

Layer 1, *the geometry of the winding number* (HW §2) — the layer whose model-sector index
(`α/2π` at a corner, `½` at a smooth crossing) is already built; this connects that index to
the crossing angle the same layer defines.
