### PR TITLE
refactor(Contour): one lemma for the excised corner window

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -48,6 +48,8 @@ versus `MeromorphicOn` (on a set).
 * `hasCauchyPVAt_iff` — restates the predicate as its two defining clauses, so consumers can
   characterize `HasCauchyPVAt` without unfolding its hidden body; the value `cauchyPVAt` is read off
   a witness through `HasCauchyPVAt.cauchyPVAt_eq`.
+* `intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le` — where the curve
+  stays within `ε` of the centre, the truncated integrand is integrable and integrates to `0`.
 * `HasCauchyPVAt.intro` — build the predicate from its two clauses; `HasCauchyPVAt.tendsto`,
   `HasCauchyPVAt.eventually_intervalIntegrable` — the clauses as named accessors;
   `HasCauchyPVAt.cauchyPVAt_eq`, `HasCauchyPVAt.unique` — the value and its uniqueness;
@@ -187,29 +189,27 @@ theorem ae_logDeriv_sub_eq_truncated {γ : ℝ → ℂ} {z₀ : ℂ} {a b ε : �
     deriv_sub_const, inv_mul_eq_div]
 
 /-- **Inside the truncation the integrand vanishes.** Where the curve stays within `ε` of the
-centre `z₀`, the `ε`-truncated contour integrand is identically `0`, so it is integrable there
-and integrates to `0`.
+centre `z₀`, the `ε`-truncated integrand is almost everywhere `0`, so it is integrable and
+integrates to `0`.
 
-Nothing is used but the falsity of the truncation condition, so the integrand's nonzero branch
-is an arbitrary `f (γ s) * deriv γ s`, and the hypothesis need only hold on `Set.uIoc a b` —
-the endpoints form a null set. This is the excised corner window: the truncation is exactly
-what removes the corner's contribution, and the whole content is that nothing survives it. -/
+Nothing is used but the falsity of the truncation condition, so the nonzero branch is an
+arbitrary `g : ℝ → ℂ`, and the hypothesis is imposed only on `Set.uIoc a b` — the oriented
+half-open interval that interval integration actually sees — and only almost everywhere on it.
+This is the excised corner window: the truncation is exactly what removes the corner's
+contribution, and the whole content is that nothing survives it. -/
 theorem intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le {γ : ℝ → ℂ}
-    {f : ℂ → ℂ} {z₀ : ℂ} {a b ε : ℝ} (hnear : ∀ s ∈ Set.uIoc a b, ‖γ s - z₀‖ ≤ ε) :
-    IntervalIntegrable
-        (fun s => if ε < ‖γ s - z₀‖ then f (γ s) * deriv γ s else 0)
+    {g : ℝ → ℂ} {z₀ : ℂ} {a b ε : ℝ}
+    (hnear : ∀ᵐ s ∂MeasureTheory.volume, s ∈ Set.uIoc a b → ‖γ s - z₀‖ ≤ ε) :
+    IntervalIntegrable (fun s => if ε < ‖γ s - z₀‖ then g s else 0)
         MeasureTheory.volume a b ∧
-      ∫ s in a..b, (if ε < ‖γ s - z₀‖ then f (γ s) * deriv γ s else 0) = 0 := by
-  have hpt : ∀ s ∈ Set.uIoc a b,
-      (if ε < ‖γ s - z₀‖ then f (γ s) * deriv γ s else 0) = 0 :=
-    fun s hs => if_neg (not_lt.mpr (hnear s hs))
-  have hint : IntervalIntegrable
-      (fun s => if ε < ‖γ s - z₀‖ then f (γ s) * deriv γ s else 0)
-      MeasureTheory.volume a b :=
-    (intervalIntegrable_const (c := (0 : ℂ))).congr_ae
-      ((MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
-        (Filter.Eventually.of_forall fun s hs => (hpt s hs).symm))
-  exact ⟨hint, intervalIntegral.integral_zero_ae (Filter.Eventually.of_forall hpt)⟩
+      ∫ s in a..b, (if ε < ‖γ s - z₀‖ then g s else 0) = 0 := by
+  have hae : ∀ᵐ s ∂MeasureTheory.volume, s ∈ Set.uIoc a b →
+      (if ε < ‖γ s - z₀‖ then g s else 0) = 0 := by
+    filter_upwards [hnear] with s hs hmem using if_neg (not_lt.mpr (hs hmem))
+  refine ⟨(intervalIntegrable_const (c := (0 : ℂ))).congr_ae ?_,
+    intervalIntegral.integral_zero_ae hae⟩
+  filter_upwards [(MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr hae] with s hs
+    using hs.symm
 
 /-- Constructor for `HasCauchyPVAt` from its two clauses — eventual integrability of the excised
 integrand and convergence of the excised integrals — without unfolding the definition. -/

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -209,11 +209,7 @@ theorem intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le {
     (intervalIntegrable_const (c := (0 : ℂ))).congr_ae
       ((MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
         (Filter.Eventually.of_forall fun s hs => (hpt s hs).symm))
-  refine ⟨hint, ?_⟩
-  have h0 : ∫ s in a..b, (if ε < ‖γ s - z₀‖ then f (γ s) * deriv γ s else 0) =
-      ∫ _ in a..b, (0 : ℂ) :=
-    intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall hpt)
-  rw [h0, intervalIntegral.integral_const, smul_zero]
+  exact ⟨hint, intervalIntegral.integral_zero_ae (Filter.Eventually.of_forall hpt)⟩
 
 /-- Constructor for `HasCauchyPVAt` from its two clauses — eventual integrability of the excised
 integrand and convergence of the excised integrals — without unfolding the definition. -/

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -187,27 +187,33 @@ theorem ae_logDeriv_sub_eq_truncated {γ : ℝ → ℂ} {z₀ : ℂ} {a b ε : �
     deriv_sub_const, inv_mul_eq_div]
 
 /-- **Inside the truncation the integrand vanishes.** Where the curve stays within `ε` of the
-centre `z₀`, the `ε`-truncated winding integrand is identically `0`, so it is integrable there
+centre `z₀`, the `ε`-truncated contour integrand is identically `0`, so it is integrable there
 and integrates to `0`.
 
-This is the excised corner window: the truncation is exactly what removes the corner's
-contribution, and the whole content is that nothing survives it. -/
-theorem intervalIntegrable_and_integral_truncated_eq_zero_of_near {γ : ℝ → ℂ} {z₀ : ℂ}
-    {a b ε : ℝ} (hnear : ∀ s ∈ Set.uIcc a b, ‖γ s - z₀‖ ≤ ε) :
+Nothing is used but the falsity of the truncation condition, so the integrand's nonzero branch
+is an arbitrary `f (γ s) * deriv γ s`, and the hypothesis need only hold on `Set.uIoc a b` —
+the endpoints form a null set. This is the excised corner window: the truncation is exactly
+what removes the corner's contribution, and the whole content is that nothing survives it. -/
+theorem intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le {γ : ℝ → ℂ}
+    {f : ℂ → ℂ} {z₀ : ℂ} {a b ε : ℝ} (hnear : ∀ s ∈ Set.uIoc a b, ‖γ s - z₀‖ ≤ ε) :
     IntervalIntegrable
-        (fun s => if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0)
+        (fun s => if ε < ‖γ s - z₀‖ then f (γ s) * deriv γ s else 0)
         MeasureTheory.volume a b ∧
-      ∫ s in a..b, (if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0) = 0 := by
-  have hzero : Set.EqOn (fun s => if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0)
-      (fun _ => (0 : ℂ)) (Set.uIcc a b) := fun s hs => if_neg (not_lt.mpr (hnear s hs))
+      ∫ s in a..b, (if ε < ‖γ s - z₀‖ then f (γ s) * deriv γ s else 0) = 0 := by
+  have hpt : ∀ s ∈ Set.uIoc a b,
+      (if ε < ‖γ s - z₀‖ then f (γ s) * deriv γ s else 0) = 0 :=
+    fun s hs => if_neg (not_lt.mpr (hnear s hs))
   have hint : IntervalIntegrable
-      (fun s => if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0)
+      (fun s => if ε < ‖γ s - z₀‖ then f (γ s) * deriv γ s else 0)
       MeasureTheory.volume a b :=
     (intervalIntegrable_const (c := (0 : ℂ))).congr_ae
       ((MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
-        (Filter.Eventually.of_forall fun s hs => (hzero (Set.uIoc_subset_uIcc hs)).symm))
+        (Filter.Eventually.of_forall fun s hs => (hpt s hs).symm))
   refine ⟨hint, ?_⟩
-  rw [intervalIntegral.integral_congr hzero, intervalIntegral.integral_const, smul_zero]
+  have h0 : ∫ s in a..b, (if ε < ‖γ s - z₀‖ then f (γ s) * deriv γ s else 0) =
+      ∫ _ in a..b, (0 : ℂ) :=
+    intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall hpt)
+  rw [h0, intervalIntegral.integral_const, smul_zero]
 
 /-- Constructor for `HasCauchyPVAt` from its two clauses — eventual integrability of the excised
 integrand and convergence of the excised integrals — without unfolding the definition. -/

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -193,23 +193,19 @@ and integrates to `0`.
 This is the excised corner window: the truncation is exactly what removes the corner's
 contribution, and the whole content is that nothing survives it. -/
 theorem intervalIntegrable_and_integral_truncated_eq_zero_of_near {γ : ℝ → ℂ} {z₀ : ℂ}
-    {a b ε : ℝ} (hab : a ≤ b) (hnear : ∀ s ∈ Set.Icc a b, ‖γ s - z₀‖ ≤ ε) :
+    {a b ε : ℝ} (hnear : ∀ s ∈ Set.uIcc a b, ‖γ s - z₀‖ ≤ ε) :
     IntervalIntegrable
         (fun s => if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0)
         MeasureTheory.volume a b ∧
       ∫ s in a..b, (if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0) = 0 := by
   have hzero : Set.EqOn (fun s => if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0)
-      (fun _ => (0 : ℂ)) (Set.uIcc a b) := fun s hs => by
-    rw [Set.uIcc_of_le hab] at hs
-    exact if_neg (not_lt.mpr (hnear s hs))
+      (fun _ => (0 : ℂ)) (Set.uIcc a b) := fun s hs => if_neg (not_lt.mpr (hnear s hs))
   have hint : IntervalIntegrable
       (fun s => if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0)
       MeasureTheory.volume a b :=
     (intervalIntegrable_const (c := (0 : ℂ))).congr_ae
       ((MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
-        (Filter.Eventually.of_forall fun s hs => by
-          rw [Set.uIoc_of_le hab] at hs
-          exact (hzero (by rw [Set.uIcc_of_le hab]; exact Set.Ioc_subset_Icc_self hs)).symm))
+        (Filter.Eventually.of_forall fun s hs => (hzero (Set.uIoc_subset_uIcc hs)).symm))
   refine ⟨hint, ?_⟩
   rw [intervalIntegral.integral_congr hzero, intervalIntegral.integral_const, smul_zero]
 

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -186,6 +186,33 @@ theorem ae_logDeriv_sub_eq_truncated {γ : ℝ → ℂ} {z₀ : ℂ} {a b ε : �
   rw [if_pos (hfar s ⟨hmem.1, lt_of_le_of_ne hmem.2 fun h ↦ hs_ne (Set.mem_singleton_iff.mpr h)⟩),
     deriv_sub_const, inv_mul_eq_div]
 
+/-- **Inside the truncation the integrand vanishes.** Where the curve stays within `ε` of the
+centre `z₀`, the `ε`-truncated winding integrand is identically `0`, so it is integrable there
+and integrates to `0`.
+
+This is the excised corner window: the truncation is exactly what removes the corner's
+contribution, and the whole content is that nothing survives it. -/
+theorem intervalIntegrable_and_integral_truncated_eq_zero_of_near {γ : ℝ → ℂ} {z₀ : ℂ}
+    {a b ε : ℝ} (hab : a ≤ b) (hnear : ∀ s ∈ Set.Icc a b, ‖γ s - z₀‖ ≤ ε) :
+    IntervalIntegrable
+        (fun s => if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0)
+        MeasureTheory.volume a b ∧
+      ∫ s in a..b, (if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0) = 0 := by
+  have hzero : Set.EqOn (fun s => if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0)
+      (fun _ => (0 : ℂ)) (Set.uIcc a b) := fun s hs => by
+    rw [Set.uIcc_of_le hab] at hs
+    exact if_neg (not_lt.mpr (hnear s hs))
+  have hint : IntervalIntegrable
+      (fun s => if ε < ‖γ s - z₀‖ then (γ s - z₀)⁻¹ * deriv γ s else 0)
+      MeasureTheory.volume a b :=
+    (intervalIntegrable_const (c := (0 : ℂ))).congr_ae
+      ((MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
+        (Filter.Eventually.of_forall fun s hs => by
+          rw [Set.uIoc_of_le hab] at hs
+          exact (hzero (by rw [Set.uIcc_of_le hab]; exact Set.Ioc_subset_Icc_self hs)).symm))
+  refine ⟨hint, ?_⟩
+  rw [intervalIntegral.integral_congr hzero, intervalIntegral.integral_const, smul_zero]
+
 /-- Constructor for `HasCauchyPVAt` from its two clauses — eventual integrability of the excised
 integrand and convergence of the excised integrals — without unfolding the definition. -/
 theorem HasCauchyPVAt.intro {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}

--- a/TauCeti/Analysis/Contour/WindowSplitting.lean
+++ b/TauCeti/Analysis/Contour/WindowSplitting.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
 import TauCeti.Analysis.Contour.Crossing.Monotonicity
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.ExitTime
@@ -52,18 +53,6 @@ noncomputable section
 namespace TauCeti.Contour
 
 open Filter MeasureTheory Set Topology
-
-/-- The truncated integral vanishes on an interval where the curve stays within radius `ε`. -/
-private theorem integral_truncated_eq_zero {γ : ℝ → ℂ} {g : ℂ → ℂ} {s : ℂ} {l u ε : ℝ}
-    (hlu : l ≤ u) (h_le : ∀ t ∈ Ioc l u, ‖γ t - s‖ ≤ ε) :
-    ∫ t in l..u, (if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0) = 0 := by
-  calc ∫ t in l..u, (if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0)
-      = ∫ _ in l..u, (0 : ℂ) := by
-        refine intervalIntegral.integral_congr_ae ?_
-        rw [uIoc_of_le hlu]
-        filter_upwards with t ht
-        rw [if_neg (not_lt.mpr (h_le t ht))]
-    _ = 0 := by simp
 
 /-- The truncated integral is the plain integral on an interval where the curve stays at
 distance `> ε` almost everywhere. -/
@@ -126,7 +115,9 @@ private theorem integral_truncated_eq_zero_between_exits {γ : ℝ → ℂ} {g :
     (hcₗ : cₗ ∈ Ioo (t₀ - ρ) t₀) (hcᵣ : cᵣ ∈ Ioo t₀ (t₀ + ρ))
     (hεₗ : ‖γ cₗ - s‖ = ε) (hεᵣ : ‖γ cᵣ - s‖ = ε) :
     ∫ u in cₗ..cᵣ, (if ‖γ u - s‖ > ε then g (γ u) * deriv γ u else 0) = 0 := by
-  refine integral_truncated_eq_zero (le_of_lt (hcₗ.2.trans hcᵣ.1)) fun t ht => ?_
+  refine (intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le
+    (f := g) fun t ht => ?_).2
+  rw [uIoc_of_le (le_of_lt (hcₗ.2.trans hcᵣ.1))] at ht
   rcases lt_trichotomy t t₀ with h_lt | h_eq | h_ge
   · have h_bd : ‖γ t - s‖ ≤ ‖γ cₗ - s‖ :=
       hanti ⟨hcₗ.1.le, hcₗ.2.le⟩ ⟨le_trans hcₗ.1.le ht.1.le, h_lt.le⟩ ht.1.le

--- a/TauCeti/Analysis/Contour/WindowSplitting.lean
+++ b/TauCeti/Analysis/Contour/WindowSplitting.lean
@@ -116,7 +116,7 @@ private theorem integral_truncated_eq_zero_between_exits {γ : ℝ → ℂ} {g :
     (hεₗ : ‖γ cₗ - s‖ = ε) (hεᵣ : ‖γ cᵣ - s‖ = ε) :
     ∫ u in cₗ..cᵣ, (if ‖γ u - s‖ > ε then g (γ u) * deriv γ u else 0) = 0 := by
   refine (intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le
-    (f := g) fun t ht => ?_).2
+    (g := fun t => g (γ t) * deriv γ t) (Filter.Eventually.of_forall fun t ht => ?_)).2
   rw [uIoc_of_le (le_of_lt (hcₗ.2.trans hcᵣ.1))] at ht
   rcases lt_trichotomy t t₀ with h_lt | h_eq | h_ge
   · have h_bd : ‖γ t - s‖ ≤ ‖γ cₗ - s‖ :=

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Value.lean
@@ -507,8 +507,9 @@ private lemma truncated_integral_spec (hH : 1 < H) (hε : 0 < ε) (hε₁ : ε <
     (z₀ := Complex.I) (a := (2 + δ : ℝ)) (b := 5) (by linarith)
     fun s hs ↦ lt_norm_of_far_right hε₁ hε₂ hδ_pos hδ_lt h2sin ⟨hs.1, hs.2.le⟩
   obtain ⟨himid, hmid0⟩ := Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near
-    (γ := fdBoundary H) (z₀ := Complex.I) (by linarith)
-    fun s hs ↦ norm_le_of_near hδ_lt h2sin hs
+    (γ := fdBoundary H) (z₀ := Complex.I)
+    fun s hs ↦ norm_le_of_near hδ_lt h2sin
+      (by rwa [Set.uIcc_of_le (by linarith : (2 - δ : ℝ) ≤ 2 + δ)] at hs)
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Value.lean
@@ -508,10 +508,10 @@ private lemma truncated_integral_spec (hH : 1 < H) (hε : 0 < ε) (hε₁ : ε <
     fun s hs ↦ lt_norm_of_far_right hε₁ hε₂ hδ_pos hδ_lt h2sin ⟨hs.1, hs.2.le⟩
   obtain ⟨himid, hmid0⟩ :=
     Contour.intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le
-    (γ := fdBoundary H) (z₀ := Complex.I) (f := fun z => (z - Complex.I)⁻¹)
-    fun s hs ↦ norm_le_of_near hδ_lt h2sin
+    (γ := fdBoundary H) (z₀ := Complex.I)
+    (Filter.Eventually.of_forall fun s hs ↦ norm_le_of_near hδ_lt h2sin
       (Set.Ioc_subset_Icc_self
-        (by rwa [Set.uIoc_of_le (by linarith : (2 - δ : ℝ) ≤ 2 + δ)] at hs))
+        (by rwa [Set.uIoc_of_le (by linarith : (2 - δ : ℝ) ≤ 2 + δ)] at hs)))
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Value.lean
@@ -506,33 +506,16 @@ private lemma truncated_integral_spec (hH : 1 < H) (hε : 0 < ε) (hε₁ : ε <
   have hae_right := Contour.ae_logDeriv_sub_eq_truncated (γ := fdBoundary H)
     (z₀ := Complex.I) (a := (2 + δ : ℝ)) (b := 5) (by linarith)
     fun s hs ↦ lt_norm_of_far_right hε₁ hε₂ hδ_pos hδ_lt h2sin ⟨hs.1, hs.2.le⟩
-  have hmid : EqOn (fun s ↦ if ε < ‖fdBoundary H s - Complex.I‖
-      then (fdBoundary H s - Complex.I)⁻¹ * deriv (fdBoundary H) s else 0)
-      (fun _ ↦ (0 : ℂ)) (uIcc (2 - δ : ℝ) (2 + δ)) := by
-    intro s hs
-    rw [uIcc_of_le (by linarith)] at hs
-    exact if_neg (not_lt.mpr (norm_le_of_near hδ_lt h2sin hs))
+  obtain ⟨himid, hmid0⟩ := Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near
+    (γ := fdBoundary H) (z₀ := Complex.I) (by linarith)
+    fun s hs ↦ norm_le_of_near hδ_lt h2sin hs
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
-  have himid : IntervalIntegrable (fun s ↦ if ε < ‖fdBoundary H s - Complex.I‖
-      then (fdBoundary H s - Complex.I)⁻¹ * deriv (fdBoundary H) s else 0)
-      volume (2 - δ) (2 + δ) := by
-    refine (intervalIntegrable_const (c := (0 : ℂ))).congr_ae
-      ((ae_restrict_iff' measurableSet_uIoc).mpr (Eventually.of_forall fun s hs ↦ ?_))
-    rw [uIoc_of_le (by linarith)] at hs
-    have hsub : s ∈ uIcc (2 - δ : ℝ) (2 + δ) := by
-      rw [uIcc_of_le (by linarith : (2 - δ : ℝ) ≤ 2 + δ)]
-      exact Ioc_subset_Icc_self hs
-    exact (hmid hsub).symm
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩
   have hδ6 : δ * (Real.pi / 6) = 2 * Real.arcsin (ε / 2) := by
     simp only [hδ_def, fdBoundaryArcExcisionHalfWidth_def]
     field_simp
     ring
-  have hmid0 : ∫ s in (2 - δ : ℝ)..(2 + δ), (if ε < ‖fdBoundary H s - Complex.I‖
-      then (fdBoundary H s - Complex.I)⁻¹ * deriv (fdBoundary H) s else 0) = 0 := by
-    rw [intervalIntegral.integral_congr hmid]
-    simp
   rw [← intervalIntegral.integral_add_adjacent_intervals (hi02.trans himid) hi25,
     ← intervalIntegral.integral_add_adjacent_intervals hi02 himid,
     hmid0, add_zero,

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Value.lean
@@ -506,10 +506,12 @@ private lemma truncated_integral_spec (hH : 1 < H) (hε : 0 < ε) (hε₁ : ε <
   have hae_right := Contour.ae_logDeriv_sub_eq_truncated (γ := fdBoundary H)
     (z₀ := Complex.I) (a := (2 + δ : ℝ)) (b := 5) (by linarith)
     fun s hs ↦ lt_norm_of_far_right hε₁ hε₂ hδ_pos hδ_lt h2sin ⟨hs.1, hs.2.le⟩
-  obtain ⟨himid, hmid0⟩ := Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near
-    (γ := fdBoundary H) (z₀ := Complex.I)
+  obtain ⟨himid, hmid0⟩ :=
+    Contour.intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le
+    (γ := fdBoundary H) (z₀ := Complex.I) (f := fun z => (z - Complex.I)⁻¹)
     fun s hs ↦ norm_le_of_near hδ_lt h2sin
-      (by rwa [Set.uIcc_of_le (by linarith : (2 - δ : ℝ) ≤ 2 + δ)] at hs)
+      (Set.Ioc_subset_Icc_self
+        (by rwa [Set.uIoc_of_le (by linarith : (2 - δ : ℝ) ≤ 2 + δ)] at hs))
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -381,32 +381,6 @@ private lemma norm_le_of_near_rho_add_one {δL δR : ℝ} (hH : Real.sqrt 3 / 2 
     exact norm_fdBoundary_sub_rho_add_one_arc_le H ⟨h1.le, by linarith [ht.2]⟩
       (by linarith) (by linarith [ht.2])
 
-/-- Over the excised window the truncated integrand vanishes identically, so it is
-integrable there and contributes nothing to the integral. -/
-private lemma excised_window_rho_add_one {δL δR : ℝ} (hH : Real.sqrt 3 / 2 < H)
-    (hδL1 : δL ≤ 1) (hlin : δL * (H - Real.sqrt 3 / 2) = ε)
-    (hδR1 : δR < 1) (h2sin : 2 * Real.sin (δR * (Real.pi / 12)) = ε)
-    (hle : (1 - δL : ℝ) ≤ 1 + δR) :
-    IntervalIntegrable (fun s ↦ if ε < ‖fdBoundary H s - ((UpperHalfPlane.ρ : ℂ) + 1)‖
-        then (fdBoundary H s - ((UpperHalfPlane.ρ : ℂ) + 1))⁻¹ * deriv (fdBoundary H) s
-        else 0) volume (1 - δL) (1 + δR) ∧
-      ∫ s in (1 - δL : ℝ)..(1 + δR),
-          (if ε < ‖fdBoundary H s - ((UpperHalfPlane.ρ : ℂ) + 1)‖
-            then (fdBoundary H s - ((UpperHalfPlane.ρ : ℂ) + 1))⁻¹ * deriv (fdBoundary H) s
-            else 0) = 0 := by
-  have hmid : EqOn (fun s ↦ if ε < ‖fdBoundary H s - ((UpperHalfPlane.ρ : ℂ) + 1)‖
-      then (fdBoundary H s - ((UpperHalfPlane.ρ : ℂ) + 1))⁻¹ * deriv (fdBoundary H) s
-      else 0)
-      (fun _ ↦ (0 : ℂ)) (uIcc (1 - δL : ℝ) (1 + δR)) := fun s hs ↦
-    if_neg (not_lt.mpr (norm_le_of_near_rho_add_one hH hδL1 hlin hδR1 h2sin
-      (by rwa [uIcc_of_le hle] at hs)))
-  refine ⟨(intervalIntegrable_const (c := (0 : ℂ))).congr_ae
-    ((ae_restrict_iff' measurableSet_uIoc).mpr (Eventually.of_forall fun s hs ↦ ?_)), ?_⟩
-  · rw [uIoc_of_le hle] at hs
-    exact (hmid (by rw [uIcc_of_le hle]; exact Ioc_subset_Icc_self hs)).symm
-  · rw [intervalIntegral.integral_congr hmid]
-    simp
-
 /-- **The excision collapse at `ρ + 1`**: for small `ε`, the `ε`-excised index integrand
 of the boundary contour about `ρ + 1` is interval integrable, and its integral is
 exactly `-πi/3 - arcsin(ε/2)·i`. -/
@@ -443,7 +417,8 @@ private lemma truncated_integral_spec_rho_add_one (hH : Real.sqrt 3 / 2 < H) (h�
     (by linarith) fun s hs ↦
       lt_norm_of_far_right_rho_add_one hε₁ hεH hδR_pos hδR_lt h2sin ⟨hs.1, hs.2.le⟩
   obtain ⟨himid, hmid0⟩ :=
-    excised_window_rho_add_one hH hδL_le hlin hδR_lt h2sin (by linarith)
+    Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near (by linarith)
+      fun s hs => norm_le_of_near_rho_add_one hH hδL_le hlin hδR_lt h2sin hs
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -418,10 +418,10 @@ private lemma truncated_integral_spec_rho_add_one (hH : Real.sqrt 3 / 2 < H) (h�
       lt_norm_of_far_right_rho_add_one hε₁ hεH hδR_pos hδR_lt h2sin ⟨hs.1, hs.2.le⟩
   obtain ⟨himid, hmid0⟩ :=
     Contour.intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le
-      (f := fun z => (z - ((UpperHalfPlane.ρ : ℂ) + 1))⁻¹)
-      fun s hs => norm_le_of_near_rho_add_one hH hδL_le hlin hδR_lt h2sin
+      (Filter.Eventually.of_forall fun s hs =>
+        norm_le_of_near_rho_add_one hH hδL_le hlin hδR_lt h2sin
         (Set.Ioc_subset_Icc_self
-          (by rwa [Set.uIoc_of_le (by linarith : (1 - δL : ℝ) ≤ 1 + δR)] at hs))
+          (by rwa [Set.uIoc_of_le (by linarith : (1 - δL : ℝ) ≤ 1 + δR)] at hs)))
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -417,8 +417,9 @@ private lemma truncated_integral_spec_rho_add_one (hH : Real.sqrt 3 / 2 < H) (h�
     (by linarith) fun s hs ↦
       lt_norm_of_far_right_rho_add_one hε₁ hεH hδR_pos hδR_lt h2sin ⟨hs.1, hs.2.le⟩
   obtain ⟨himid, hmid0⟩ :=
-    Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near (by linarith)
-      fun s hs => norm_le_of_near_rho_add_one hH hδL_le hlin hδR_lt h2sin hs
+    Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near
+      fun s hs => norm_le_of_near_rho_add_one hH hδL_le hlin hδR_lt h2sin
+        (by rwa [Set.uIcc_of_le (by linarith : (1 - δL : ℝ) ≤ 1 + δR)] at hs)
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -417,9 +417,11 @@ private lemma truncated_integral_spec_rho_add_one (hH : Real.sqrt 3 / 2 < H) (h�
     (by linarith) fun s hs ↦
       lt_norm_of_far_right_rho_add_one hε₁ hεH hδR_pos hδR_lt h2sin ⟨hs.1, hs.2.le⟩
   obtain ⟨himid, hmid0⟩ :=
-    Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near
+    Contour.intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le
+      (f := fun z => (z - ((UpperHalfPlane.ρ : ℂ) + 1))⁻¹)
       fun s hs => norm_le_of_near_rho_add_one hH hδL_le hlin hδR_lt h2sin
-        (by rwa [Set.uIcc_of_le (by linarith : (1 - δL : ℝ) ≤ 1 + δR)] at hs)
+        (Set.Ioc_subset_Icc_self
+          (by rwa [Set.uIoc_of_le (by linarith : (1 - δL : ℝ) ≤ 1 + δR)] at hs))
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -380,9 +380,11 @@ private lemma truncated_integral_spec_rho (hH : Real.sqrt 3 / 2 < H) (hε : 0 < 
     (z₀ := (UpperHalfPlane.ρ : ℂ)) (a := (3 + δR : ℝ)) (b := 5) (by linarith)
     fun s hs ↦ lt_norm_of_far_right_rho hH hεH hδR_pos hlin ⟨hs.1, hs.2.le⟩
   obtain ⟨himid, hmid0⟩ :=
-    Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near
+    Contour.intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le
+      (f := fun z => (z - (UpperHalfPlane.ρ : ℂ))⁻¹)
       fun s hs => norm_le_of_near_rho hH hδL_pos.le hδL_lt h2sin hδR_le hlin
-        (by rwa [Set.uIcc_of_le (by linarith : (3 - δL : ℝ) ≤ 3 + δR)] at hs)
+        (Set.Ioc_subset_Icc_self
+          (by rwa [Set.uIoc_of_le (by linarith : (3 - δL : ℝ) ≤ 3 + δR)] at hs))
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -380,8 +380,9 @@ private lemma truncated_integral_spec_rho (hH : Real.sqrt 3 / 2 < H) (hε : 0 < 
     (z₀ := (UpperHalfPlane.ρ : ℂ)) (a := (3 + δR : ℝ)) (b := 5) (by linarith)
     fun s hs ↦ lt_norm_of_far_right_rho hH hεH hδR_pos hlin ⟨hs.1, hs.2.le⟩
   obtain ⟨himid, hmid0⟩ :=
-    Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near (by linarith)
-      fun s hs => norm_le_of_near_rho hH hδL_pos.le hδL_lt h2sin hδR_le hlin hs
+    Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near
+      fun s hs => norm_le_of_near_rho hH hδL_pos.le hδL_lt h2sin hδR_le hlin
+        (by rwa [Set.uIcc_of_le (by linarith : (3 - δL : ℝ) ≤ 3 + δR)] at hs)
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -381,10 +381,10 @@ private lemma truncated_integral_spec_rho (hH : Real.sqrt 3 / 2 < H) (hε : 0 < 
     fun s hs ↦ lt_norm_of_far_right_rho hH hεH hδR_pos hlin ⟨hs.1, hs.2.le⟩
   obtain ⟨himid, hmid0⟩ :=
     Contour.intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le
-      (f := fun z => (z - (UpperHalfPlane.ρ : ℂ))⁻¹)
-      fun s hs => norm_le_of_near_rho hH hδL_pos.le hδL_lt h2sin hδR_le hlin
+      (Filter.Eventually.of_forall fun s hs =>
+        norm_le_of_near_rho hH hδL_pos.le hδL_lt h2sin hδR_le hlin
         (Set.Ioc_subset_Icc_self
-          (by rwa [Set.uIoc_of_le (by linarith : (3 - δL : ℝ) ≤ 3 + δR)] at hs))
+          (by rwa [Set.uIoc_of_le (by linarith : (3 - δL : ℝ) ≤ 3 + δR)] at hs)))
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -347,30 +347,6 @@ private lemma norm_le_of_near_rho {δL δR : ℝ} (hH : Real.sqrt 3 / 2 < H) (h�
       abs_of_nonneg (by nlinarith [h3] : (0 : ℝ) ≤ (t - 3) * (H - Real.sqrt 3 / 2)), ← hlin]
     exact mul_le_mul_of_nonneg_right (by linarith [ht.2]) (by linarith)
 
-/-- Over the excised window the truncated integrand vanishes identically, so it is
-integrable there and contributes nothing to the integral. -/
-private lemma excised_window_rho {δL δR : ℝ} (hH : Real.sqrt 3 / 2 < H) (hδL : 0 ≤ δL)
-    (hδL1 : δL < 1) (h2sin : 2 * Real.sin (δL * (Real.pi / 12)) = ε)
-    (hδR1 : δR ≤ 1) (hlin : δR * (H - Real.sqrt 3 / 2) = ε) (hle : (3 - δL : ℝ) ≤ 3 + δR) :
-    IntervalIntegrable (fun s ↦ if ε < ‖fdBoundary H s - (UpperHalfPlane.ρ : ℂ)‖
-        then (fdBoundary H s - (UpperHalfPlane.ρ : ℂ))⁻¹ * deriv (fdBoundary H) s else 0)
-      volume (3 - δL) (3 + δR) ∧
-      ∫ s in (3 - δL : ℝ)..(3 + δR),
-        (if ε < ‖fdBoundary H s - (UpperHalfPlane.ρ : ℂ)‖
-          then (fdBoundary H s - (UpperHalfPlane.ρ : ℂ))⁻¹ * deriv (fdBoundary H) s
-          else 0) = 0 := by
-  have hmid : EqOn (fun s ↦ if ε < ‖fdBoundary H s - (UpperHalfPlane.ρ : ℂ)‖
-      then (fdBoundary H s - (UpperHalfPlane.ρ : ℂ))⁻¹ * deriv (fdBoundary H) s else 0)
-      (fun _ ↦ (0 : ℂ)) (uIcc (3 - δL : ℝ) (3 + δR)) := fun s hs ↦
-    if_neg (not_lt.mpr (norm_le_of_near_rho hH hδL hδL1 h2sin hδR1 hlin
-      (by rwa [uIcc_of_le hle] at hs)))
-  refine ⟨(intervalIntegrable_const (c := (0 : ℂ))).congr_ae
-    ((ae_restrict_iff' measurableSet_uIoc).mpr (Eventually.of_forall fun s hs ↦ ?_)), ?_⟩
-  · rw [uIoc_of_le hle] at hs
-    exact (hmid (by rw [uIcc_of_le hle]; exact Ioc_subset_Icc_self hs)).symm
-  · rw [intervalIntegral.integral_congr hmid]
-    simp
-
 /-- **The excision collapse at `ρ`**: for small `ε`, the `ε`-excised index integrand of
 the boundary contour about `ρ` is interval integrable, and its integral is exactly
 `-πi/3 - arcsin(ε/2)·i` — the telescope value at the matched asymmetric half-widths. -/
@@ -404,7 +380,8 @@ private lemma truncated_integral_spec_rho (hH : Real.sqrt 3 / 2 < H) (hε : 0 < 
     (z₀ := (UpperHalfPlane.ρ : ℂ)) (a := (3 + δR : ℝ)) (b := 5) (by linarith)
     fun s hs ↦ lt_norm_of_far_right_rho hH hεH hδR_pos hlin ⟨hs.1, hs.2.le⟩
   obtain ⟨himid, hmid0⟩ :=
-    excised_window_rho hH hδL_pos.le hδL_lt h2sin hδR_le hlin (by linarith)
+    Contour.intervalIntegrable_and_integral_truncated_eq_zero_of_near (by linarith)
+      fun s hs => norm_le_of_near_rho hH hδL_pos.le hδL_lt h2sin hδR_le hlin hs
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"layer0/truncated-window-dedup"}-->

Four places in the repository each carried their own version of one fact:

> over a window where the contour stays within `ε` of the centre, the `ε`-truncated
> integrand is identically `0`, so it is integrable there and integrates to `0`.

The corner computations at `i`, `ρ` and `ρ + 1` held it as `excised_window_rho`,
`excised_window_rho_add_one` and an inline `hmid` / `himid` — *mirrored* rather than
identical, because the chord side and the linear side swap between the two corners, which is
why they did not read as duplicates at a glance. `WindowSplitting.lean` held a fourth copy as
the private `integral_truncated_eq_zero`.

Nothing in it is about the fundamental domain, or about which corner, or about the winding
kernel: it is a statement about a curve, a centre and a window, and the proof uses only that
the truncation condition is false. So it is stated once, at the contour layer, in the form all
four call sites need:

* generic in the branch the truncation keeps — an arbitrary `g : ℝ → ℂ`, since the proof uses
  nothing but the falsity of the truncation condition;
* hypothesised on `Set.uIoc a b`, the oriented half-open interval that interval integration actually
  sees, and only *almost everywhere* on it — which is what lets `WindowSplitting`'s `Ioc`
  hypothesis reach it unchanged;
* returning **both** conclusions, so a caller needing only the integral takes `.2`.

`integral_truncated_eq_zero` is deleted rather than left forwarding, and its one call site
inside `integral_truncated_eq_zero_between_exits` calls the shared lemma directly. The two
`excised_window_*` wrappers had exactly one call site each, so they go the same way.

Net: **+45 / −85**, with the shared content stated once.

## Main declarations

* `TauCeti.Contour.intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le`

Roadmap: ContourIntegration

Layer 0, the truncated-integrand infrastructure the principal value is built on; no new
mathematics, and no change to any statement outside the deleted wrappers.
