### PR TITLE
feat: assemble covering-space monodromy

### DIFF
--- a/TauCeti/Topology/Covering/Category.lean
+++ b/TauCeti/Topology/Covering/Category.lean
@@ -149,6 +149,13 @@ theorem totalSpace_map {p q : CoveringSpace X} (f : p ⟶ q) :
 theorem w {p q : CoveringSpace X} (f : p ⟶ q) : f.hom.left ≫ q.proj = p.proj :=
   CategoryTheory.Over.w _
 
+/-- The commuting triangle of a morphism of covering spaces, as an equality of the underlying
+functions. -/
+theorem proj_hom_comp_hom_left_hom {p q : CoveringSpace X} (f : p ⟶ q) :
+    q.proj.hom ∘ f.hom.left.hom = p.proj.hom := by
+  funext e
+  exact DFunLike.congr_fun (congrArg TopCat.Hom.hom (w f)) e
+
 /-- Construct a morphism of covering spaces from a continuous map over the base. -/
 def homMk {p q : CoveringSpace X} (f : (p : TopCat) ⟶ (q : TopCat))
     (w : f ≫ q.proj = p.proj := by cat_disch) : p ⟶ q :=

--- a/TauCeti/Topology/Covering/Monodromy.lean
+++ b/TauCeti/Topology/Covering/Monodromy.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Topology.Covering.Category
+public import TauCeti.Topology.Homotopy.Monodromy.Functoriality
+
+/-!
+# The monodromy functor on covering spaces
+
+For a fixed topological space `X`, a covering space over `X` determines its monodromy functor from
+the fundamental groupoid of `X` to types. A map of covering spaces restricts on every fibre and
+therefore induces a natural transformation of monodromy functors. This file assembles those object-
+and morphism-level constructions into a functor on `TauCeti.CoveringSpace X`.
+
+The resulting functor is faithful: a map over `X` is determined by all of its restrictions to the
+fibres. Fullness and the characterization of its essential image are the remaining topological
+content of the classification of covering spaces by fundamental-groupoid actions.
+
+## Main declarations
+
+* `TauCeti.CoveringSpace.monodromyFunctor`: the functor from covering spaces over `X` to functors
+  from the fundamental groupoid of `X` to types.
+* `TauCeti.CoveringSpace.monodromyFunctor_map_app`: the natural transformation induced by a map of
+  covering spaces, evaluated at a base point.
+* `TauCeti.CoveringSpace.faithfulMonodromyFunctor`: monodromy is faithful on maps of covers.
+
+## References
+
+This is the functor-construction step in Stage 2, item 8 of
+`TauCetiRoadmap/UniversalCovers/README.md`. It reuses Mathlib's object-level
+`IsCoveringMap.monodromyFunctor` and Tau Ceti's functoriality of monodromy under maps of covering
+spaces.
+-/
+
+public section
+
+open CategoryTheory
+
+universe u
+
+namespace TauCeti.CoveringSpace
+
+variable {X : TopCat.{u}}
+
+/-- The commuting triangle of a map of covering spaces, as the function equality used by the
+monodromy API. -/
+theorem comp_hom_left_eq {p q : CoveringSpace X} (f : p ⟶ q) :
+    q.proj.hom ∘ f.hom.left.hom = p.proj.hom := by
+  funext e
+  exact DFunLike.congr_fun (congrArg TopCat.Hom.hom (w f)) e
+
+/-- Monodromy as a functor from covering spaces over `X` to functors from the fundamental
+groupoid of `X` to types.
+
+The definition is exposed because its object values are themselves types: later classification
+constructions need them to reduce to the corresponding fibres. The map computation is provided by
+`monodromyFunctor_map_app`. -/
+@[expose] noncomputable def monodromyFunctor (X : TopCat.{u}) :
+    CoveringSpace X ⥤ (FundamentalGroupoid X ⥤ Type u) where
+  obj p := p.isCoveringMap_proj.monodromyFunctor
+  map {p q} f := IsCoveringMap.monodromyNatTrans p.isCoveringMap_proj q.isCoveringMap_proj
+    f.hom.left.hom (comp_hom_left_eq f)
+  map_id p := by
+    simp
+  map_comp {p q r} f g := by
+    simpa using IsCoveringMap.monodromyNatTrans_comp p.isCoveringMap_proj
+      q.isCoveringMap_proj r.isCoveringMap_proj f.hom.left.hom g.hom.left.hom
+      (comp_hom_left_eq f) (comp_hom_left_eq g)
+
+@[simp]
+theorem monodromyFunctor_obj (p : CoveringSpace X) :
+    (monodromyFunctor X).obj p = p.isCoveringMap_proj.monodromyFunctor :=
+  rfl
+
+/-- At a base point, the natural transformation assigned by monodromy is the restriction of the
+underlying map of total spaces to the corresponding fibre. -/
+@[simp]
+theorem monodromyFunctor_map_app {p q : CoveringSpace X} (f : p ⟶ q) (x : X) :
+    ((monodromyFunctor X).map f).app (FundamentalGroupoid.mk x) =
+      ↾(IsCoveringMap.fiberMap f.hom.left.hom (comp_hom_left_eq f) x) := by
+  exact IsCoveringMap.monodromyNatTrans_app p.isCoveringMap_proj q.isCoveringMap_proj
+    f.hom.left.hom (comp_hom_left_eq f) x
+
+/-- The monodromy functor is faithful: a map of covering spaces is determined by its restrictions
+to all fibres. -/
+instance faithfulMonodromyFunctor (X : TopCat.{u}) : (monodromyFunctor X).Faithful where
+  map_injective {p q} f g h := by
+    apply ObjectProperty.hom_ext
+    ext e
+    have happ := NatTrans.congr_app h (FundamentalGroupoid.mk (p.proj e))
+    rw [monodromyFunctor_map_app, monodromyFunctor_map_app] at happ
+    let e' : p.proj ⁻¹' {p.proj e} := ⟨e, rfl⟩
+    have happ := ConcreteCategory.congr_hom happ e'
+    calc
+      f.hom.left e =
+          (IsCoveringMap.fiberMap f.hom.left.hom (comp_hom_left_eq f) (p.proj e) e' :
+            (q : TopCat)) :=
+        (IsCoveringMap.fiberMap_apply_coe f.hom.left.hom (comp_hom_left_eq f)
+          (p.proj e) e').symm
+      _ = IsCoveringMap.fiberMap g.hom.left.hom (comp_hom_left_eq g) (p.proj e) e' := by
+        exact Subtype.ext_iff.mp happ
+      _ = g.hom.left e :=
+        IsCoveringMap.fiberMap_apply_coe g.hom.left.hom (comp_hom_left_eq g) (p.proj e) e'
+
+end TauCeti.CoveringSpace

--- a/TauCeti/Topology/Covering/Monodromy.lean
+++ b/TauCeti/Topology/Covering/Monodromy.lean
@@ -48,10 +48,10 @@ variable {X : TopCat.{u}}
 /-- Monodromy as a functor from covering spaces over `X` to functors from the fundamental
 groupoid of `X` to types.
 
-The definition is exposed because its object values are themselves types: without exposure the
-characteristic lemmas `monodromyFunctor_obj` and `monodromyFunctor_map_app` are unprovable and
-unstatable respectively, since both need `(monodromyFunctor X).obj p` to reduce to the fibre
-functor of `p`. Consumers should use those two lemmas rather than the record fields. -/
+A covering space is sent to its own monodromy functor, and a map of covering spaces to the natural
+transformation restricting that map to every fibre. The definition is exposed, so downstream files
+may unfold its object and morphism values; the intended interface for doing so is
+`monodromyFunctor_obj` and `monodromyFunctor_map_app` rather than the record fields. -/
 @[expose] noncomputable def monodromyFunctor (X : TopCat.{u}) :
     CoveringSpace X ⥤ (FundamentalGroupoid X ⥤ Type u) where
   obj p := p.isCoveringMap_proj.monodromyFunctor

--- a/TauCeti/Topology/Covering/Monodromy.lean
+++ b/TauCeti/Topology/Covering/Monodromy.lean
@@ -25,7 +25,7 @@ content of the classification of covering spaces by fundamental-groupoid actions
   from the fundamental groupoid of `X` to types.
 * `TauCeti.CoveringSpace.monodromyFunctor_map_app`: the natural transformation induced by a map of
   covering spaces, evaluated at a base point.
-* `TauCeti.CoveringSpace.faithfulMonodromyFunctor`: monodromy is faithful on maps of covers.
+* `TauCeti.CoveringSpace.monodromyFunctor_faithful`: monodromy is faithful on maps of covers.
 
 ## References
 
@@ -45,30 +45,24 @@ namespace TauCeti.CoveringSpace
 
 variable {X : TopCat.{u}}
 
-/-- The commuting triangle of a map of covering spaces, as the function equality used by the
-monodromy API. -/
-theorem comp_hom_left_eq {p q : CoveringSpace X} (f : p ⟶ q) :
-    q.proj.hom ∘ f.hom.left.hom = p.proj.hom := by
-  funext e
-  exact DFunLike.congr_fun (congrArg TopCat.Hom.hom (w f)) e
-
 /-- Monodromy as a functor from covering spaces over `X` to functors from the fundamental
 groupoid of `X` to types.
 
-The definition is exposed because its object values are themselves types: later classification
-constructions need them to reduce to the corresponding fibres. The map computation is provided by
-`monodromyFunctor_map_app`. -/
+The definition is exposed because its object values are themselves types: without exposure the
+characteristic lemmas `monodromyFunctor_obj` and `monodromyFunctor_map_app` are unprovable and
+unstatable respectively, since both need `(monodromyFunctor X).obj p` to reduce to the fibre
+functor of `p`. Consumers should use those two lemmas rather than the record fields. -/
 @[expose] noncomputable def monodromyFunctor (X : TopCat.{u}) :
     CoveringSpace X ⥤ (FundamentalGroupoid X ⥤ Type u) where
   obj p := p.isCoveringMap_proj.monodromyFunctor
   map {p q} f := IsCoveringMap.monodromyNatTrans p.isCoveringMap_proj q.isCoveringMap_proj
-    f.hom.left.hom (comp_hom_left_eq f)
+    f.hom.left.hom (proj_hom_comp_hom_left_hom f)
   map_id p := by
     simp
   map_comp {p q r} f g := by
     simpa using IsCoveringMap.monodromyNatTrans_comp p.isCoveringMap_proj
       q.isCoveringMap_proj r.isCoveringMap_proj f.hom.left.hom g.hom.left.hom
-      (comp_hom_left_eq f) (comp_hom_left_eq g)
+      (proj_hom_comp_hom_left_hom f) (proj_hom_comp_hom_left_hom g)
 
 @[simp]
 theorem monodromyFunctor_obj (p : CoveringSpace X) :
@@ -80,13 +74,13 @@ underlying map of total spaces to the corresponding fibre. -/
 @[simp]
 theorem monodromyFunctor_map_app {p q : CoveringSpace X} (f : p ⟶ q) (x : X) :
     ((monodromyFunctor X).map f).app (FundamentalGroupoid.mk x) =
-      ↾(IsCoveringMap.fiberMap f.hom.left.hom (comp_hom_left_eq f) x) := by
+      ↾(IsCoveringMap.fiberMap f.hom.left.hom (proj_hom_comp_hom_left_hom f) x) := by
   exact IsCoveringMap.monodromyNatTrans_app p.isCoveringMap_proj q.isCoveringMap_proj
-    f.hom.left.hom (comp_hom_left_eq f) x
+    f.hom.left.hom (proj_hom_comp_hom_left_hom f) x
 
 /-- The monodromy functor is faithful: a map of covering spaces is determined by its restrictions
 to all fibres. -/
-instance faithfulMonodromyFunctor (X : TopCat.{u}) : (monodromyFunctor X).Faithful where
+instance monodromyFunctor_faithful (X : TopCat.{u}) : (monodromyFunctor X).Faithful where
   map_injective {p q} f g h := by
     apply ObjectProperty.hom_ext
     ext e
@@ -96,13 +90,14 @@ instance faithfulMonodromyFunctor (X : TopCat.{u}) : (monodromyFunctor X).Faithf
     have happ := ConcreteCategory.congr_hom happ e'
     calc
       f.hom.left e =
-          (IsCoveringMap.fiberMap f.hom.left.hom (comp_hom_left_eq f) (p.proj e) e' :
+          (IsCoveringMap.fiberMap f.hom.left.hom (proj_hom_comp_hom_left_hom f) (p.proj e) e' :
             (q : TopCat)) :=
-        (IsCoveringMap.fiberMap_apply_coe f.hom.left.hom (comp_hom_left_eq f)
+        (IsCoveringMap.fiberMap_apply_coe f.hom.left.hom (proj_hom_comp_hom_left_hom f)
           (p.proj e) e').symm
-      _ = IsCoveringMap.fiberMap g.hom.left.hom (comp_hom_left_eq g) (p.proj e) e' := by
+      _ = IsCoveringMap.fiberMap g.hom.left.hom (proj_hom_comp_hom_left_hom g) (p.proj e) e' := by
         exact Subtype.ext_iff.mp happ
       _ = g.hom.left e :=
-        IsCoveringMap.fiberMap_apply_coe g.hom.left.hom (comp_hom_left_eq g) (p.proj e) e'
+        IsCoveringMap.fiberMap_apply_coe g.hom.left.hom (proj_hom_comp_hom_left_hom g)
+          (p.proj e) e'
 
 end TauCeti.CoveringSpace


### PR DESCRIPTION
This PR assembles the covering-space monodromy functor required by `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, alternative lens: send every cover over `X` to Mathlib's functor from `FundamentalGroupoid X` to its fibres, and send every map over `X` to the natural transformation obtained by restricting it fibrewise. Prove that this functor is faithful, since the family of all fibre restrictions determines the underlying map of total spaces.

The preferred `CFSGStatement` roadmap has no viable current-main step: its remaining I0 selectors are already in flight, L0--L2 are explicitly blocked on RootSystems Layer 6 and ReductiveGroups Layer 9, and S0's remaining target is the indivisible complete 26-row source manifest. UniversalCovers has instead just received the two exact prerequisites in #2528 and #2531, making this the next unclaimed critical-path assembly step.

This advances the milestone “classify covers by functors from the fundamental groupoid and connected covers by transitive fundamental-group actions.” After this PR, the milestone still needs fullness, reconstruction of a covering space from a suitably locally constant functor, the essential-image/equivalence theorem, and its connected/transitive restriction.

Reuse Mathlib's `IsCoveringMap.monodromyFunctor` and Tau Ceti's `IsCoveringMap.monodromyNatTrans`, identity, composition, and fibre-map APIs; no Mathlib implementation is vendored. Add `TauCeti/Topology/Covering/Monodromy.lean` (108 lines).

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"covering-space-monodromy-functor"}-->

🤖 Prepared with Codex
