### PR TITLE
feat: the blocks of a Wedderburn presentation enumerate the simple modules

### DIFF
--- a/TauCeti/RingTheory/Semisimple/BlockCount.lean
+++ b/TauCeti/RingTheory/Semisimple/BlockCount.lean
@@ -37,7 +37,10 @@ semisimplicity is what guarantees a presentation exists in the first place.
 
 What is *not* proved here is the finer uniqueness — that the multiset of degrees `nᵢ` and the
 division rings `Dᵢ` are determined too — which needs the identification of the blocks with the
-isomorphism classes of simple `R`-modules rather than a mere count.
+isomorphism classes of simple `R`-modules rather than a mere count.  That identification is
+`TauCeti.blocks_equiv_simpleModules` in
+`TauCeti/RingTheory/Semisimple/WedderburnBlocks.lean`, which recovers the count below as a count of
+simple modules but still says nothing about the degrees or the division rings.
 
 ## Main results
 

--- a/TauCeti/RingTheory/Semisimple/EndAlgebra.lean
+++ b/TauCeti/RingTheory/Semisimple/EndAlgebra.lean
@@ -19,6 +19,7 @@ public import Mathlib.RingTheory.SimpleRing.Defs
 import Mathlib.LinearAlgebra.Dimension.Constructions
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.RingTheory.SimpleRing.Matrix
+import TauCeti.RingTheory.Semisimple.IsotypicEnd
 import TauCeti.RingTheory.Semisimple.SimpleArtinian
 
 /-!
@@ -95,20 +96,11 @@ is the matrix ring `Mat_k(End_R S)` over the division ring of Schur's lemma, wit
 `M ≠ 0`.
 
 No base field is involved: `M` is a power `Sᵏ` of a minimal left ideal `S` of `R` because `R` is
-simple Artinian and `M` is finite over `R`. -/
-theorem moduleEnd [Nontrivial M] : IsSimpleRing (Module.End R M) := by
-  classical
-  obtain ⟨S, hS⟩ := IsAtomic.exists_atom (Submodule R R)
-  rw [← isSimpleModule_iff_isAtom] at hS
-  obtain ⟨k, ⟨e⟩⟩ := (IsIsotypicOfType.of_isSimpleRing R (↥S) M).linearEquiv_fun
-  have hk : k ≠ 0 := by
-    rintro rfl
-    exact not_subsingleton M e.subsingleton
-  have : Nonempty (Fin k) := ⟨⟨0, Nat.pos_of_ne_zero hk⟩⟩
-  -- Schur's lemma makes `End_R S` a division ring, hence a simple ring, hence so is `Mat_k` of it.
-  have : IsSimpleRing (Matrix (Fin k) (Fin k) (Module.End R ↥S)) := inferInstance
-  exact _root_.IsSimpleRing.of_ringEquiv
-    (e.conjRingEquiv.trans (endVecRingEquivMatrixEnd (Fin k) R ↥S)).symm this
+simple Artinian and `M` is finite over `R`.  That is the only use made of simplicity of `R`, so
+this is the specialization of `TauCeti.isSimpleRing_moduleEnd_of_isIsotypic` along
+`IsSimpleRing.isIsotypic`. -/
+theorem moduleEnd [Nontrivial M] : IsSimpleRing (Module.End R M) :=
+  isSimpleRing_moduleEnd_of_isIsotypic (_root_.IsSimpleRing.isIsotypic R M)
 
 end Simplicity
 

--- a/TauCeti/RingTheory/Semisimple/EndAlgebra.lean
+++ b/TauCeti/RingTheory/Semisimple/EndAlgebra.lean
@@ -13,12 +13,11 @@ public import Mathlib.RingTheory.Artinian.Defs
 public import Mathlib.RingTheory.SimpleModule.Basic
 public import Mathlib.RingTheory.SimpleRing.Defs
 -- Non-public: used only inside proofs. The matrix presentation of the endomorphism algebra of a
--- power, the dimension of a matrix algebra, simplicity of a matrix ring over a simple ring, and the
--- isotypic decomposition over a simple Artinian algebra are all internal to the arguments below,
--- and no exported statement mentions a matrix algebra.
+-- power, the dimension of a matrix algebra, the simplicity of the endomorphism ring of an isotypic
+-- module, and the isotypic decomposition over a simple Artinian algebra are all internal to the
+-- arguments below, and no exported statement mentions a matrix algebra.
 import Mathlib.LinearAlgebra.Dimension.Constructions
 import Mathlib.LinearAlgebra.Matrix.ToLin
-import Mathlib.RingTheory.SimpleRing.Matrix
 import TauCeti.RingTheory.Semisimple.IsotypicEnd
 import TauCeti.RingTheory.Semisimple.SimpleArtinian
 

--- a/TauCeti/RingTheory/Semisimple/IsotypicEnd.lean
+++ b/TauCeti/RingTheory/Semisimple/IsotypicEnd.lean
@@ -4,13 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
--- Public: `IsIsotypic` is the hypothesis, `Module.End` the object under study and `IsSimpleRing`
--- the conclusion; `Module.Finite` is the finiteness hypothesis, and the matrix ring appears in the
--- proof through `endVecRingEquivMatrixEnd`.
-public import Mathlib.LinearAlgebra.Matrix.ToLin
+-- Public: the classes occurring in the exported statement. `IsIsotypic` is the hypothesis, along
+-- with the semisimplicity and finiteness of the module, and `IsSimpleRing (Module.End R M)` is the
+-- conclusion.
 public import Mathlib.RingTheory.SimpleModule.Isotypic
-public import Mathlib.RingTheory.SimpleRing.Congr
-public import Mathlib.RingTheory.SimpleRing.Matrix
+public import Mathlib.RingTheory.SimpleRing.Defs
+-- Non-public: used only inside the proof. The matrix presentation of the endomorphism ring of a
+-- power, transport of simplicity along a ring isomorphism, and simplicity of a matrix ring over a
+-- division ring are all internal to the argument below; no exported statement mentions a matrix.
+import Mathlib.LinearAlgebra.Matrix.ToLin
+import Mathlib.RingTheory.SimpleRing.Congr
+import Mathlib.RingTheory.SimpleRing.Matrix
 
 /-!
 # The endomorphism ring of an isotypic module is simple

--- a/TauCeti/RingTheory/Semisimple/IsotypicEnd.lean
+++ b/TauCeti/RingTheory/Semisimple/IsotypicEnd.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- Public: `IsIsotypic` is the hypothesis, `Module.End` the object under study and `IsSimpleRing`
+-- the conclusion; `Module.Finite` is the finiteness hypothesis, and the matrix ring appears in the
+-- proof through `endVecRingEquivMatrixEnd`.
+public import Mathlib.LinearAlgebra.Matrix.ToLin
+public import Mathlib.RingTheory.SimpleModule.Isotypic
+public import Mathlib.RingTheory.SimpleRing.Congr
+public import Mathlib.RingTheory.SimpleRing.Matrix
+
+/-!
+# The endomorphism ring of an isotypic module is simple
+
+A semisimple module `M` all of whose simple submodules are isomorphic to one another
+(`IsIsotypic R M`) and which is finite over `R` is a finite power `Sⁿ` of a single simple module,
+by Mathlib's `IsIsotypic.linearEquiv_fun`.  Its endomorphism ring is therefore the matrix ring
+`Matₙ(End_R S)` over the division ring supplied by Schur's lemma, and a matrix ring of nonzero
+size over a division ring is simple.  So
+
+  `IsSimpleRing (Module.End R M)`
+
+for every nonzero such `M`, with no hypothesis on `R` beyond what makes `M` semisimple.
+
+This is the shape in which Artin--Wedderburn uniqueness uses endomorphism rings: over a semisimple
+ring the isotypic components of the regular module are exactly the modules this applies to, so
+`End_R R` is a product of simple rings indexed by them, one factor per Wedderburn block.  See
+`TauCeti/RingTheory/Semisimple/WedderburnBlocks.lean`.
+
+## Main results
+
+* `TauCeti.isSimpleRing_moduleEnd_of_isIsotypic`: **the endomorphism ring of a nonzero finite
+  isotypic semisimple module is simple.**
+
+## Implementation notes
+
+Nonzero-ness of `M` is what makes the matrix size `n` nonzero, and it cannot be dropped: for
+`M = 0` the ring `Module.End R M` is trivial and a trivial ring is not simple.
+
+## References
+
+This is the module-theoretic engine behind the Layer 2 uniqueness statements of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md).
+See T. Y. Lam, *A First Course in Noncommutative Rings*, GTM 131, §3, or C. W. Curtis and
+I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*, §25.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M]
+
+/-- **The endomorphism ring of a nonzero finite isotypic semisimple module is simple.**
+
+Writing `M` as a power `Sⁿ` of a simple module presents `End_R M` as the matrix ring
+`Matₙ(End_R S)` over the division ring `End_R S` of Schur's lemma, and `n ≠ 0` because `M ≠ 0`.
+
+The ring `R` is arbitrary: only the module is asked to be semisimple, isotypic and finite.  Over a
+simple Artinian ring every module is isotypic, which is the specialization
+`TauCeti.IsSimpleRing.moduleEnd`. -/
+theorem isSimpleRing_moduleEnd_of_isIsotypic [IsSemisimpleModule R M] [Module.Finite R M]
+    [Nontrivial M] (h : IsIsotypic R M) : IsSimpleRing (Module.End R M) := by
+  classical
+  obtain ⟨n, hn, S, hS, ⟨e⟩⟩ := h.linearEquiv_fun
+  have : Nonempty (Fin n) := ⟨⟨0, Nat.pos_of_ne_zero hn.ne⟩⟩
+  -- Schur's lemma makes `End_R S` a division ring, hence a simple ring, hence so is `Matₙ` of it.
+  exact IsSimpleRing.of_ringEquiv
+    (e.conjRingEquiv.trans (endVecRingEquivMatrixEnd (Fin n) R S)).symm inferInstance
+
+end TauCeti

--- a/TauCeti/RingTheory/Semisimple/WedderburnBlocks.lean
+++ b/TauCeti/RingTheory/Semisimple/WedderburnBlocks.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RingTheory.Semisimple.BlockCount
+public import TauCeti.RingTheory.Semisimple.IsotypicEnd
+public import TauCeti.RingTheory.Semisimple.RegularIsotypicComponent
+
+/-!
+# The blocks of a Wedderburn presentation enumerate the simple modules
+
+Artin--Wedderburn presents a semisimple ring `R` as a finite product of matrix algebras over
+division rings,
+
+`R ≃+* ∏ᵢ Matₙᵢ(Dᵢ)`,
+
+and `TauCeti.card_blocks_eq` shows that the number of factors does not depend on the presentation.
+That count is anonymous: it is read off the central idempotents and says nothing about what a block
+*is*.  This file identifies the index: **the blocks of any such presentation correspond to the
+isomorphism classes of simple `R`-modules**, so a presentation with `n` blocks exhibits exactly `n`
+simple modules up to isomorphism, and every simple module is one of them.
+
+The bridge between the two descriptions is the endomorphism ring of the regular module.  Mathlib's
+`IsSemisimpleModule.endRingEquiv` splits `End_R R` along the isotypic components of `R`,
+
+`Rᵐᵒᵖ ≃+* End_R R ≃+* ∏_{c} End_R c`,
+
+and each factor is a *simple* ring, because an isotypic component is a finite power of one simple
+module and so has a matrix endomorphism ring
+(`TauCeti.isSimpleRing_moduleEnd_of_isIsotypic`).  A presentation `R ≃+* ∏ᵢ Aᵢ` by simple rings
+gives a second such product decomposition of `Rᵐᵒᵖ`, so
+`TauCeti.card_eq_of_ringEquiv_pi_of_isSimpleRing` equates the two indices.  Composing with
+`TauCeti.simpleSubmoduleClassesEquiv`, which identifies the isotypic components of `R` with the
+isomorphism classes of simple left ideals, and with `TauCeti.simpleModuleClass`, which realizes an
+abstract simple module by a left ideal, turns the block count into a count of simple modules.
+
+## Main results
+
+* `TauCeti.isSimpleRing_moduleEnd_of_mem_isotypicComponents`: the endomorphism ring of an isotypic
+  component of the regular module is a simple ring.
+* `TauCeti.card_isotypicComponents_eq_of_ringEquiv_pi`: a presentation of `R` as a finite product
+  of simple rings has as many factors as `R` has isotypic components.
+* `TauCeti.card_simpleSubmoduleClasses_eq_of_ringEquiv_pi` and
+  `TauCeti.nonempty_equiv_simpleSubmoduleClasses_of_ringEquiv_pi`: the factors are in bijection with
+  the isomorphism classes of simple `R`-modules.
+* `TauCeti.exists_simpleSubmodule_of_ringEquiv_pi`: **the blocks enumerate the simple modules.**
+  A presentation of `R` by simple rings indexed by `ι` yields a family of simple left ideals indexed
+  by `ι`, pairwise non-isomorphic, with every simple left ideal isomorphic to one of them.
+* `TauCeti.blocks_equiv_simpleModules`: the same statement for a Wedderburn presentation
+  `R ≃+* ∏ᵢ Matₙᵢ(Dᵢ)` indexed by `Fin n`, the form the roadmap pins.
+* `TauCeti.exists_nonempty_linearEquiv_of_forall_submodule`: such a family exhausts not only the
+  simple left ideals but every simple `R`-module, because over a semisimple ring a simple module is
+  realized by a left ideal.
+
+## Implementation notes
+
+The results are stated for a presentation `R ≃+* ∏ᵢ Aᵢ` by arbitrary simple rings rather than by
+matrix algebras: simplicity of the factors is all the argument uses, and Artin--Wedderburn is what
+supplies such a presentation, not part of the statement.  The positivity hypotheses `NeZero (d i)`
+of the matrix form enter only to make `Matₙᵢ(Dᵢ)` simple, exactly as in
+`TauCeti.card_blocks_eq`; a block of size `0` is the trivial ring, and any presentation could be
+padded with such blocks.
+
+The isomorphism classes are handled through `TauCeti.SimpleSubmoduleClasses R R`, the classes of
+simple *left ideals*, which unlike the classes of abstract simple modules form a type.  The
+exhaustion clause of `TauCeti.exists_simpleSubmodule_of_ringEquiv_pi` is likewise stated for left
+ideals, and `TauCeti.exists_nonempty_linearEquiv_of_forall_submodule` upgrades it to arbitrary
+simple modules in any universe; keeping the two apart is what lets the main statement stay
+universe-monomorphic in the modules it quantifies over.
+
+## References
+
+This implements the Layer 2 target `blocks_equiv_simpleModules` ("blocks enumerate the simple
+modules") of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md).
+See T. Y. Lam, *A First Course in Noncommutative Rings*, GTM 131, §3, or C. W. Curtis and
+I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*, §25.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v
+
+variable {R : Type u} [Ring R] [IsSemisimpleRing R]
+
+/-- **The endomorphism ring of an isotypic component of the regular module is simple.** An isotypic
+component is a nonzero finite module all of whose simple submodules are isomorphic, so
+`TauCeti.isSimpleRing_moduleEnd_of_isIsotypic` applies. -/
+theorem isSimpleRing_moduleEnd_of_mem_isotypicComponents {c : Submodule R R}
+    (hc : c ∈ isotypicComponents R R) : IsSimpleRing (Module.End R c) :=
+  have : Nontrivial c := Submodule.nontrivial_iff_ne_bot.mpr (bot_lt_isotypicComponents hc).ne'
+  have : IsSemisimpleModule R c := by obtain ⟨S, _, rfl⟩ := hc; infer_instance
+  isSimpleRing_moduleEnd_of_isIsotypic (IsIsotypic.isotypicComponents hc)
+
+section Presentation
+
+variable {ι : Type*} [Finite ι] {A : ι → Type v} [∀ i, Ring (A i)] [∀ i, IsSimpleRing (A i)]
+
+/-- **A presentation of a semisimple ring as a finite product of simple rings has one factor for
+each isotypic component of the regular module.**
+
+Both counts are counts of factors in a decomposition of `Rᵐᵒᵖ` as a product of simple rings: the
+opposite of the given presentation on one side, and the splitting of `End_R R ≃+* Rᵐᵒᵖ` along the
+isotypic components on the other, whose factors are simple by
+`TauCeti.isSimpleRing_moduleEnd_of_mem_isotypicComponents`. -/
+theorem card_isotypicComponents_eq_of_ringEquiv_pi (e : R ≃+* ∀ i, A i) :
+    Nat.card (isotypicComponents R R) = Nat.card ι := by
+  classical
+  have : ∀ c : isotypicComponents R R, IsSimpleRing (Module.End R (c : Submodule R R)) :=
+    fun c ↦ isSimpleRing_moduleEnd_of_mem_isotypicComponents c.2
+  exact card_eq_of_ringEquiv_pi_of_isSimpleRing
+    ((RingEquiv.moduleEndSelf R).trans (IsSemisimpleModule.endRingEquiv R R))
+    ((RingEquiv.op e).trans (RingEquiv.piMulOpposite A))
+
+/-- **A presentation of a semisimple ring as a finite product of simple rings has one factor for
+each isomorphism class of simple modules.** -/
+theorem card_simpleSubmoduleClasses_eq_of_ringEquiv_pi (e : R ≃+* ∀ i, A i) :
+    Nat.card (SimpleSubmoduleClasses R R) = Nat.card ι :=
+  (Nat.card_congr (simpleSubmoduleClassesEquiv R R)).trans
+    (card_isotypicComponents_eq_of_ringEquiv_pi e)
+
+/-- The factors of such a presentation are in bijection with the isomorphism classes of simple
+modules. The bijection is not canonical -- nothing orders the factors -- so it is produced as a
+`Nonempty`, from the equality of the two counts. -/
+theorem nonempty_equiv_simpleSubmoduleClasses_of_ringEquiv_pi (e : R ≃+* ∀ i, A i) :
+    Nonempty (ι ≃ SimpleSubmoduleClasses R R) := by
+  have : Finite (SimpleSubmoduleClasses R R) :=
+    .of_equiv _ (simpleSubmoduleClassesEquiv R R).symm
+  have := Fintype.ofFinite ι
+  have := Fintype.ofFinite (SimpleSubmoduleClasses R R)
+  refine ⟨Fintype.equivOfCardEq ?_⟩
+  simpa [Nat.card_eq_fintype_card] using (card_simpleSubmoduleClasses_eq_of_ringEquiv_pi e).symm
+
+/-- **The blocks enumerate the simple modules.** A presentation of a semisimple ring `R` as a
+product of simple rings indexed by `ι` produces a family of simple left ideals indexed by `ι` which
+are pairwise non-isomorphic and exhaust the simple left ideals up to isomorphism.
+
+Since every simple `R`-module is isomorphic to a simple left ideal, the family is a complete
+irredundant list of the simple `R`-modules; that consequence is
+`TauCeti.exists_nonempty_linearEquiv_of_forall_submodule`. -/
+theorem exists_simpleSubmodule_of_ringEquiv_pi (e : R ≃+* ∀ i, A i) :
+    ∃ S : ι → Submodule R R,
+      (∀ i, IsSimpleModule R (S i)) ∧
+      (∀ i j, Nonempty (S i ≃ₗ[R] S j) → i = j) ∧
+      ∀ I : Submodule R R, IsSimpleModule R I → ∃ i, Nonempty (I ≃ₗ[R] S i) := by
+  obtain ⟨φ⟩ := nonempty_equiv_simpleSubmoduleClasses_of_ringEquiv_pi e
+  -- Choose a simple left ideal in each isomorphism class.
+  have hrep : ∀ c : SimpleSubmoduleClasses R R, ∃ (N : Submodule R R) (h : IsSimpleModule R N),
+      @SimpleSubmoduleClasses.mk R _ R _ _ N h = c :=
+    SimpleSubmoduleClasses.ind fun N hN ↦ ⟨N, hN, rfl⟩
+  choose N hN hmk using hrep
+  refine ⟨fun i ↦ N (φ i), fun i ↦ hN (φ i), fun i j h ↦ ?_, fun I hI ↦ ?_⟩
+  · have := hN (φ i)
+    have := hN (φ j)
+    have hij : SimpleSubmoduleClasses.mk (N (φ i)) = SimpleSubmoduleClasses.mk (N (φ j)) :=
+      SimpleSubmoduleClasses.mk_eq_mk_iff.mpr h
+    rw [hmk, hmk] at hij
+    exact φ.injective hij
+  · have := hN (φ (φ.symm (SimpleSubmoduleClasses.mk I)))
+    refine ⟨φ.symm (SimpleSubmoduleClasses.mk I), SimpleSubmoduleClasses.mk_eq_mk_iff.mp ?_⟩
+    rw [hmk, Equiv.apply_symm_apply]
+
+/-- **Blocks enumerate the simple modules**, for a Wedderburn presentation
+`R ≃+* ∏ᵢ Matₙᵢ(Dᵢ)`: the `n` blocks yield `n` pairwise non-isomorphic simple left ideals which
+exhaust the simple left ideals up to isomorphism.
+
+The positivity hypotheses `NeZero (d i)` are what make the matrix blocks simple rings; they are the
+same hypotheses that `IsSemisimpleRing.exists_ringEquiv_pi_matrix_divisionRing` produces and that
+`TauCeti.card_blocks_eq` needs.
+
+The name is the one the roadmap pins for this target; the content is the family, so the general
+statement it specializes is `TauCeti.exists_simpleSubmodule_of_ringEquiv_pi`. -/
+theorem blocks_equiv_simpleModules {n : ℕ} {D : Fin n → Type v} [∀ i, DivisionRing (D i)]
+    {d : Fin n → ℕ} [∀ i, NeZero (d i)]
+    (e : R ≃+* ∀ i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :
+    ∃ S : Fin n → Submodule R R,
+      (∀ i, IsSimpleModule R (S i)) ∧
+      (∀ i j, Nonempty (S i ≃ₗ[R] S j) → i = j) ∧
+      ∀ I : Submodule R R, IsSimpleModule R I → ∃ i, Nonempty (I ≃ₗ[R] S i) := by
+  have : ∀ i, Nonempty (Fin (d i)) := fun i ↦ ⟨⟨0, Nat.pos_of_ne_zero (NeZero.ne (d i))⟩⟩
+  exact exists_simpleSubmodule_of_ringEquiv_pi e
+
+/-- **A Wedderburn presentation has one block for each isomorphism class of simple modules.** -/
+theorem card_simpleSubmoduleClasses_eq_of_ringEquiv_pi_matrix {n : ℕ} {D : Fin n → Type v}
+    [∀ i, DivisionRing (D i)] {d : Fin n → ℕ} [∀ i, NeZero (d i)]
+    (e : R ≃+* ∀ i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :
+    Nat.card (SimpleSubmoduleClasses R R) = n := by
+  have : ∀ i, Nonempty (Fin (d i)) := fun i ↦ ⟨⟨0, Nat.pos_of_ne_zero (NeZero.ne (d i))⟩⟩
+  simpa using card_simpleSubmoduleClasses_eq_of_ringEquiv_pi e
+
+end Presentation
+
+/-- **A family of simple left ideals exhausting the simple left ideals exhausts every simple
+module.** Over a semisimple ring every simple module is isomorphic to a left ideal, so no
+information is lost by listing only the left ideals; this is what turns the family produced by
+`TauCeti.exists_simpleSubmodule_of_ringEquiv_pi` into a list of *all* the simple `R`-modules, in
+any universe. -/
+theorem exists_nonempty_linearEquiv_of_forall_submodule {κ : Type*} {S : κ → Submodule R R}
+    (hS : ∀ I : Submodule R R, IsSimpleModule R I → ∃ k, Nonempty (I ≃ₗ[R] S k))
+    (M : Type*) [AddCommGroup M] [Module R M] [IsSimpleModule R M] :
+    ∃ k, Nonempty (M ≃ₗ[R] S k) := by
+  obtain ⟨I, ⟨f⟩⟩ := IsSemisimpleRing.exists_linearEquiv_ideal_of_isSimpleModule R M
+  have : IsSimpleModule R I := .congr f.symm
+  obtain ⟨k, ⟨g⟩⟩ := hS I inferInstance
+  exact ⟨k, ⟨f.trans g⟩⟩
+
+end TauCeti

--- a/TauCeti/RingTheory/Semisimple/WedderburnBlocks.lean
+++ b/TauCeti/RingTheory/Semisimple/WedderburnBlocks.lean
@@ -47,8 +47,6 @@ abstract simple module by a left ideal, turns the block count into a count of si
 
 ## Main results
 
-* `TauCeti.isSimpleRing_moduleEnd_of_mem_isotypicComponents`: the endomorphism ring of an isotypic
-  component of the regular module is a simple ring.
 * `TauCeti.card_isotypicComponents_eq_of_ringEquiv_pi`: a presentation of `R` as a finite product
   of simple rings has as many factors as `R` has isotypic components.
 * `TauCeti.card_simpleSubmoduleClasses_eq_of_ringEquiv_pi` and
@@ -96,15 +94,6 @@ universe u v
 
 variable {R : Type u} [Ring R] [IsSemisimpleRing R]
 
-/-- **The endomorphism ring of an isotypic component of the regular module is simple.** An isotypic
-component is a nonzero finite module all of whose simple submodules are isomorphic, so
-`TauCeti.isSimpleRing_moduleEnd_of_isIsotypic` applies. -/
-theorem isSimpleRing_moduleEnd_of_mem_isotypicComponents {c : Submodule R R}
-    (hc : c ∈ isotypicComponents R R) : IsSimpleRing (Module.End R c) :=
-  have : Nontrivial c := Submodule.nontrivial_iff_ne_bot.mpr (bot_lt_isotypicComponents hc).ne'
-  have : IsSemisimpleModule R c := by obtain ⟨S, _, rfl⟩ := hc; infer_instance
-  isSimpleRing_moduleEnd_of_isIsotypic (IsIsotypic.isotypicComponents hc)
-
 section Presentation
 
 variable {ι : Type*} [Finite ι] {A : ι → Type v} [∀ i, Ring (A i)] [∀ i, IsSimpleRing (A i)]
@@ -115,12 +104,16 @@ each isotypic component of the regular module.**
 Both counts are counts of factors in a decomposition of `Rᵐᵒᵖ` as a product of simple rings: the
 opposite of the given presentation on one side, and the splitting of `End_R R ≃+* Rᵐᵒᵖ` along the
 isotypic components on the other, whose factors are simple by
-`TauCeti.isSimpleRing_moduleEnd_of_mem_isotypicComponents`. -/
+`TauCeti.isSimpleRing_moduleEnd_of_isIsotypic`: an isotypic component is a nonzero finite module
+all of whose simple submodules are isomorphic. -/
 theorem card_isotypicComponents_eq_of_ringEquiv_pi (e : R ≃+* ∀ i, A i) :
     Nat.card (isotypicComponents R R) = Nat.card ι := by
   classical
-  have : ∀ c : isotypicComponents R R, IsSimpleRing (Module.End R (c : Submodule R R)) :=
-    fun c ↦ isSimpleRing_moduleEnd_of_mem_isotypicComponents c.2
+  have : ∀ c : isotypicComponents R R, IsSimpleRing (Module.End R (c : Submodule R R)) := by
+    rintro ⟨c, hc⟩
+    have : Nontrivial c := Submodule.nontrivial_iff_ne_bot.mpr (bot_lt_isotypicComponents hc).ne'
+    have : IsSemisimpleModule R c := by obtain ⟨S, _, rfl⟩ := hc; infer_instance
+    exact isSimpleRing_moduleEnd_of_isIsotypic (IsIsotypic.isotypicComponents hc)
   exact card_eq_of_ringEquiv_pi_of_isSimpleRing
     ((RingEquiv.moduleEndSelf R).trans (IsSemisimpleModule.endRingEquiv R R))
     ((RingEquiv.op e).trans (RingEquiv.piMulOpposite A))

--- a/TauCeti/RingTheory/Semisimple/WedderburnBlocks.lean
+++ b/TauCeti/RingTheory/Semisimple/WedderburnBlocks.lean
@@ -4,9 +4,18 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.RingTheory.Semisimple.BlockCount
-public import TauCeti.RingTheory.Semisimple.IsotypicEnd
+-- Public: the types occurring in the exported statements. The isotypic components of the regular
+-- module and their isomorphism classes come from `RegularIsotypicComponent`, `IsSimpleRing` is a
+-- hypothesis on the factors and a conclusion about endomorphism rings, and the matrix ring is the
+-- shape of a Wedderburn presentation.
+public import Mathlib.Data.Matrix.Mul
+public import Mathlib.RingTheory.SimpleRing.Defs
 public import TauCeti.RingTheory.Semisimple.RegularIsotypicComponent
+-- Non-public: used only inside proofs. The block count of a product of simple rings and the
+-- simplicity of the endomorphism ring of an isotypic module are the two engines of the arguments
+-- below, and neither is mentioned by an exported statement.
+import TauCeti.RingTheory.Semisimple.BlockCount
+import TauCeti.RingTheory.Semisimple.IsotypicEnd
 
 /-!
 # The blocks of a Wedderburn presentation enumerate the simple modules
@@ -183,14 +192,6 @@ theorem blocks_equiv_simpleModules {n : ℕ} {D : Fin n → Type v} [∀ i, Divi
       ∀ I : Submodule R R, IsSimpleModule R I → ∃ i, Nonempty (I ≃ₗ[R] S i) := by
   have : ∀ i, Nonempty (Fin (d i)) := fun i ↦ ⟨⟨0, Nat.pos_of_ne_zero (NeZero.ne (d i))⟩⟩
   exact exists_simpleSubmodule_of_ringEquiv_pi e
-
-/-- **A Wedderburn presentation has one block for each isomorphism class of simple modules.** -/
-theorem card_simpleSubmoduleClasses_eq_of_ringEquiv_pi_matrix {n : ℕ} {D : Fin n → Type v}
-    [∀ i, DivisionRing (D i)] {d : Fin n → ℕ} [∀ i, NeZero (d i)]
-    (e : R ≃+* ∀ i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :
-    Nat.card (SimpleSubmoduleClasses R R) = n := by
-  have : ∀ i, Nonempty (Fin (d i)) := fun i ↦ ⟨⟨0, Nat.pos_of_ne_zero (NeZero.ne (d i))⟩⟩
-  simpa using card_simpleSubmoduleClasses_eq_of_ringEquiv_pi e
 
 end Presentation
 


### PR DESCRIPTION
This PR identifies the index of an Artin-Wedderburn presentation of a semisimple ring with the isomorphism classes of its simple modules. `TauCeti.card_blocks_eq` already shows that two presentations `R ≃+* ∏ᵢ Matₙᵢ(Dᵢ)` have the same number of blocks, but that count is anonymous: it is read off the central idempotents and says nothing about what a block is. `TauCeti.blocks_equiv_simpleModules` now produces, from a presentation with `n` blocks, a family of `n` simple left ideals that are pairwise non-isomorphic and exhaust the simple left ideals up to isomorphism, and `TauCeti.exists_nonempty_linearEquiv_of_forall_submodule` extends the exhaustion to every simple `R`-module in any universe. The count of isomorphism classes is recorded separately as `TauCeti.card_simpleSubmoduleClasses_eq_of_ringEquiv_pi`.

The proof runs through the endomorphism ring of the regular module. Mathlib's `IsSemisimpleModule.endRingEquiv` splits `End_R R ≃+* Rᵐᵒᵖ` along the isotypic components of `R`, and each factor is a simple ring because an isotypic component of finite length is a finite power of a single simple module, so its endomorphism ring is a matrix ring over the division ring of Schur's lemma. That is the new general lemma `TauCeti.isSimpleRing_moduleEnd_of_isIsotypic`, which asks nothing of the ring. A presentation by simple rings gives a second decomposition of `Rᵐᵒᵖ` into simple factors, so `TauCeti.card_eq_of_ringEquiv_pi_of_isSimpleRing` equates the two indices; composing with `TauCeti.simpleSubmoduleClassesEquiv` and `TauCeti.simpleModuleClass` turns the block count into a count of simple modules. The statements are given for a presentation by arbitrary simple rings, since that is all the argument uses, with the pinned matrix form as a corollary.

The same matrix argument was inlined in `TauCeti.IsSimpleRing.moduleEnd`, which asserted the simplicity of `End_R M` over a simple Artinian ring; that theorem now derives from the new general lemma in two lines, since over a simple Artinian ring every module is isotypic.

Milestone: Layer 2 of the semisimple-algebras roadmap, "Artin-Wedderburn, assembled with uniqueness", whose pinned target `blocks_equiv_simpleModules` this closes; Layer 1.5 supplied the simple-module realization it consumes. What remains on that layer is the finer invariance: that the degrees `nᵢ` and the division rings `Dᵢ` of a presentation are the multiplicity and the endomorphism division ring of the corresponding simple module.

Files: `TauCeti/RingTheory/Semisimple/WedderburnBlocks.lean` (new, 211 lines) and `TauCeti/RingTheory/Semisimple/IsotypicEnd.lean` (new, 74 lines), with `EndAlgebra.lean` reusing the latter and a forward pointer added to `BlockCount.lean`.

No material was taken from the supplementary source snapshot; nothing was vendored from Mathlib.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"blocks-equiv-simplemodules"}-->

🤖 Prepared with Claude Code
