### PR TITLE
feat: make multiplicative Jordan decomposition coordinate-invariant

### DIFF
--- a/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
@@ -48,15 +48,18 @@ open Module
 universe u v w
 
 variable {K : Type u} {V : Type v} {W : Type w}
-variable [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
 
 section Predicates
 
+variable [CommRing K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
+
 /-- Semisimplicity of a linear automorphism is invariant under transport by a linear
 equivalence. -/
+@[simp]
 theorem isSemisimple_congrLinearEquiv_iff
     (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
-    IsSemisimple (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) ↔ IsSemisimple g := by
+    IsSemisimple (LinearMap.GeneralLinearGroup.ofLinearEquiv
+      (e.symm.trans (g.toLinearEquiv.trans e))) ↔ IsSemisimple g := by
   rw [isSemisimple_def, isSemisimple_def]
   symm
   apply LinearEquiv.isSemisimple_iff (e := e)
@@ -64,10 +67,13 @@ theorem isSemisimple_congrLinearEquiv_iff
   simp
 
 /-- Unipotence of a linear automorphism is invariant under transport by a linear equivalence. -/
+@[simp]
 theorem isUnipotent_congrLinearEquiv_iff
     (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
-    IsUnipotent (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) ↔ IsUnipotent g := by
+    IsUnipotent (LinearMap.GeneralLinearGroup.ofLinearEquiv
+      (e.symm.trans (g.toLinearEquiv.trans e))) ↔ IsUnipotent g := by
   rw [isUnipotent_def, isUnipotent_def]
+  rw [← LinearMap.GeneralLinearGroup.congrLinearEquiv_apply e g]
   have hmap :
       LinearEquiv.conjRingEquiv e ((g : End K V) - 1) =
         ((LinearMap.GeneralLinearGroup.congrLinearEquiv e g :
@@ -81,6 +87,7 @@ end Predicates
 
 section PerfectField
 
+variable [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
 variable [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W]
 
 /-- The multiplicative Jordan--Chevalley decomposition commutes with transport by a linear
@@ -101,19 +108,25 @@ theorem jordanDecomposition_congrLinearEquiv
 
 /-- The semisimple factor of the multiplicative Jordan decomposition commutes with transport by
 a linear equivalence. -/
+@[simp]
 theorem semisimplePart_congrLinearEquiv
     (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
-    semisimplePart (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) =
+    semisimplePart (LinearMap.GeneralLinearGroup.ofLinearEquiv
+      (e.symm.trans (g.toLinearEquiv.trans e))) =
       LinearMap.GeneralLinearGroup.congrLinearEquiv e (semisimplePart g) := by
+  rw [← LinearMap.GeneralLinearGroup.congrLinearEquiv_apply e g]
   rw [semisimplePart_def (LinearMap.GeneralLinearGroup.congrLinearEquiv e g)]
   exact congrArg Prod.fst (jordanDecomposition_congrLinearEquiv e g)
 
 /-- The unipotent factor of the multiplicative Jordan decomposition commutes with transport by a
 linear equivalence. -/
+@[simp]
 theorem unipotentPart_congrLinearEquiv
     (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
-    unipotentPart (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) =
+    unipotentPart (LinearMap.GeneralLinearGroup.ofLinearEquiv
+      (e.symm.trans (g.toLinearEquiv.trans e))) =
       LinearMap.GeneralLinearGroup.congrLinearEquiv e (unipotentPart g) := by
+  rw [← LinearMap.GeneralLinearGroup.congrLinearEquiv_apply e g]
   rw [unipotentPart_def (LinearMap.GeneralLinearGroup.congrLinearEquiv e g)]
   exact congrArg Prod.snd (jordanDecomposition_congrLinearEquiv e g)
 

--- a/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
@@ -88,15 +88,17 @@ end Predicates
 section PerfectField
 
 variable [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
-variable [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W]
+variable [PerfectField K] [FiniteDimensional K V]
 
 /-- The multiplicative Jordan--Chevalley decomposition commutes with transport by a linear
 equivalence. -/
 theorem jordanDecomposition_congrLinearEquiv
     (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
+    letI := FiniteDimensional.of_surjective e.toLinearMap e.surjective
     jordanDecomposition (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) =
       (LinearMap.GeneralLinearGroup.congrLinearEquiv e (semisimplePart g),
         LinearMap.GeneralLinearGroup.congrLinearEquiv e (unipotentPart g)) := by
+  let _ := FiniteDimensional.of_surjective e.toLinearMap e.surjective
   symm
   apply (eq_jordanDecomposition_iff
     (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) _ _).2
@@ -111,9 +113,11 @@ a linear equivalence. -/
 @[simp]
 theorem semisimplePart_congrLinearEquiv
     (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
+    letI := FiniteDimensional.of_surjective e.toLinearMap e.surjective
     semisimplePart (LinearMap.GeneralLinearGroup.ofLinearEquiv
       (e.symm.trans (g.toLinearEquiv.trans e))) =
       LinearMap.GeneralLinearGroup.congrLinearEquiv e (semisimplePart g) := by
+  let _ := FiniteDimensional.of_surjective e.toLinearMap e.surjective
   rw [← LinearMap.GeneralLinearGroup.congrLinearEquiv_apply e g]
   rw [semisimplePart_def (LinearMap.GeneralLinearGroup.congrLinearEquiv e g)]
   exact congrArg Prod.fst (jordanDecomposition_congrLinearEquiv e g)
@@ -123,9 +127,11 @@ linear equivalence. -/
 @[simp]
 theorem unipotentPart_congrLinearEquiv
     (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
+    letI := FiniteDimensional.of_surjective e.toLinearMap e.surjective
     unipotentPart (LinearMap.GeneralLinearGroup.ofLinearEquiv
       (e.symm.trans (g.toLinearEquiv.trans e))) =
       LinearMap.GeneralLinearGroup.congrLinearEquiv e (unipotentPart g) := by
+  let _ := FiniteDimensional.of_surjective e.toLinearMap e.surjective
   rw [← LinearMap.GeneralLinearGroup.congrLinearEquiv_apply e g]
   rw [unipotentPart_def (LinearMap.GeneralLinearGroup.congrLinearEquiv e g)]
   exact congrArg Prod.snd (jordanDecomposition_congrLinearEquiv e g)

--- a/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.JordanChevalley.Multiplicative
+
+/-!
+# Functoriality of the multiplicative Jordan decomposition
+
+The multiplicative Jordan--Chevalley decomposition of a linear automorphism does not depend on
+the coordinates used to describe it.  A linear equivalence `e : V ≃ₗ[K] W` transports an
+automorphism by conjugation.  This file proves that semisimplicity and unipotence are invariant
+under this transport and that both canonical Jordan factors commute with it.
+
+This is the first functoriality step for the Jordan decomposition requested in Layer 4 of the
+ReductiveGroups roadmap.  In particular, it makes the general-linear decomposition invariant
+under a change of basis, as required before it can be transported through a faithful
+representation of an affine algebraic group.
+
+## Main declarations
+
+* `TauCeti.GeneralLinearGroup.isSemisimple_congrLinearEquiv_iff`: semisimplicity is invariant
+  under linear conjugation.
+* `TauCeti.GeneralLinearGroup.isUnipotent_congrLinearEquiv_iff`: unipotence is invariant under
+  linear conjugation.
+* `TauCeti.GeneralLinearGroup.jordanDecomposition_congrLinearEquiv`: the canonical pair is
+  equivariant under linear conjugation.
+* `TauCeti.GeneralLinearGroup.semisimplePart_congrLinearEquiv` and
+  `TauCeti.GeneralLinearGroup.unipotentPart_congrLinearEquiv`: the two factor formulas.
+
+## References
+
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+-/
+
+public section
+
+namespace TauCeti
+
+open LinearMap
+
+namespace GeneralLinearGroup
+
+open Module
+
+universe u v w
+
+variable {K : Type u} {V : Type v} {W : Type w}
+variable [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
+
+section Predicates
+
+/-- Semisimplicity of a linear automorphism is invariant under transport by a linear
+equivalence. -/
+theorem isSemisimple_congrLinearEquiv_iff
+    (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
+    IsSemisimple (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) ↔ IsSemisimple g := by
+  rw [isSemisimple_def, isSemisimple_def]
+  symm
+  apply LinearEquiv.isSemisimple_iff (e := e)
+  ext x
+  simp
+
+/-- Unipotence of a linear automorphism is invariant under transport by a linear equivalence. -/
+theorem isUnipotent_congrLinearEquiv_iff
+    (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
+    IsUnipotent (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) ↔ IsUnipotent g := by
+  rw [isUnipotent_def, isUnipotent_def]
+  have hmap :
+      LinearEquiv.conjRingEquiv e ((g : End K V) - 1) =
+        ((LinearMap.GeneralLinearGroup.congrLinearEquiv e g :
+          GeneralLinearGroup K W) : End K W) - 1 := by
+    ext x
+    simp
+  rw [← hmap]
+  exact IsNilpotent.map_iff (LinearEquiv.conjRingEquiv e).injective
+
+end Predicates
+
+section PerfectField
+
+variable [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W]
+
+/-- The multiplicative Jordan--Chevalley decomposition commutes with transport by a linear
+equivalence. -/
+theorem jordanDecomposition_congrLinearEquiv
+    (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
+    jordanDecomposition (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) =
+      (LinearMap.GeneralLinearGroup.congrLinearEquiv e (semisimplePart g),
+        LinearMap.GeneralLinearGroup.congrLinearEquiv e (unipotentPart g)) := by
+  symm
+  apply (eq_jordanDecomposition_iff
+    (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) _ _).2
+  refine ⟨(isSemisimple_congrLinearEquiv_iff e _).2 (isSemisimple_semisimplePart g),
+    (isUnipotent_congrLinearEquiv_iff e _).2 (isUnipotent_unipotentPart g), ?_, ?_⟩
+  · exact (commute_semisimplePart_unipotentPart g).map
+      (LinearMap.GeneralLinearGroup.congrLinearEquiv e).toMonoidHom
+  · rw [← map_mul, semisimplePart_mul_unipotentPart]
+
+/-- The semisimple factor of the multiplicative Jordan decomposition commutes with transport by
+a linear equivalence. -/
+theorem semisimplePart_congrLinearEquiv
+    (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
+    semisimplePart (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) =
+      LinearMap.GeneralLinearGroup.congrLinearEquiv e (semisimplePart g) := by
+  rw [semisimplePart_def (LinearMap.GeneralLinearGroup.congrLinearEquiv e g)]
+  exact congrArg Prod.fst (jordanDecomposition_congrLinearEquiv e g)
+
+/-- The unipotent factor of the multiplicative Jordan decomposition commutes with transport by a
+linear equivalence. -/
+theorem unipotentPart_congrLinearEquiv
+    (e : V ≃ₗ[K] W) (g : GeneralLinearGroup K V) :
+    unipotentPart (LinearMap.GeneralLinearGroup.congrLinearEquiv e g) =
+      LinearMap.GeneralLinearGroup.congrLinearEquiv e (unipotentPart g) := by
+  rw [unipotentPart_def (LinearMap.GeneralLinearGroup.congrLinearEquiv e g)]
+  exact congrArg Prod.snd (jordanDecomposition_congrLinearEquiv e g)
+
+end PerfectField
+
+end GeneralLinearGroup
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
@@ -60,9 +60,21 @@ variable {K : Type u} {V : Type v} [CommRing K] [AddCommGroup V] [Module K V]
 def IsSemisimple (g : GeneralLinearGroup K V) : Prop :=
   Module.End.IsSemisimple (g : End K V)
 
+/-- Semisimplicity of a linear automorphism means semisimplicity of its underlying
+endomorphism. -/
+theorem isSemisimple_def (g : GeneralLinearGroup K V) :
+    IsSemisimple g ↔ Module.End.IsSemisimple (g : End K V) :=
+  Iff.rfl
+
 /-- A linear automorphism is unipotent if its difference from the identity is nilpotent. -/
 def IsUnipotent (g : GeneralLinearGroup K V) : Prop :=
   _root_.IsNilpotent ((g : End K V) - 1)
+
+/-- Unipotence of a linear automorphism means that its underlying endomorphism minus the
+identity is nilpotent. -/
+theorem isUnipotent_def (g : GeneralLinearGroup K V) :
+    IsUnipotent g ↔ _root_.IsNilpotent ((g : End K V) - 1) :=
+  Iff.rfl
 
 /-- The identity automorphism is semisimple. -/
 @[simp]
@@ -211,9 +223,19 @@ theorem eq_jordanDecomposition_iff (g s u : GeneralLinearGroup K V) :
 noncomputable def semisimplePart (g : GeneralLinearGroup K V) : GeneralLinearGroup K V :=
   (jordanDecomposition g).1
 
+/-- The semisimple part is the first factor of the canonical Jordan decomposition. -/
+theorem semisimplePart_def (g : GeneralLinearGroup K V) :
+    semisimplePart g = (jordanDecomposition g).1 :=
+  (rfl)
+
 /-- The unipotent factor of the multiplicative Jordan–Chevalley decomposition. -/
 noncomputable def unipotentPart (g : GeneralLinearGroup K V) : GeneralLinearGroup K V :=
   (jordanDecomposition g).2
+
+/-- The unipotent part is the second factor of the canonical Jordan decomposition. -/
+theorem unipotentPart_def (g : GeneralLinearGroup K V) :
+    unipotentPart g = (jordanDecomposition g).2 :=
+  (rfl)
 
 /-- The semisimple factor is semisimple. -/
 theorem isSemisimple_semisimplePart (g : GeneralLinearGroup K V) :


### PR DESCRIPTION
This PR makes the multiplicative Jordan–Chevalley decomposition coordinate-invariant: transport a linear automorphism across any linear equivalence, preserve semisimplicity and unipotence, and transport the canonical semisimple and unipotent factors exactly.

It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4, milestone **“Jordan decomposition of elements into semisimple and unipotent parts … functorial under representations”**. This PR supplies the change-of-coordinates case required to use the merged general-linear decomposition independently of a chosen basis; after this PR, the milestone still needs transport from `GL(V)` to arbitrary affine algebraic groups through a faithful representation, independence from the chosen faithful representation, and functoriality under general representation morphisms.

This is the most effective unclaimed current step because the general-linear existence and uniqueness theorem landed in #2564 and the faithful closed embedding landed in #2582, while open ReductiveGroups PRs already own the next Tannakian, tangent-dimension, and smoothness-synchronization work. Coordinate invariance is the immediate missing bridge between the canonical `GL(V)` factors and any representation-based construction.

Add `TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean` (124 lines). The main theorem `GeneralLinearGroup.jordanDecomposition_congrLinearEquiv` follows from the existing uniqueness characterization after proving that linear conjugation preserves the two factor predicates; the projection theorems give the corresponding formulas for `semisimplePart` and `unipotentPart`. Add four documented characterization lemmas to `Multiplicative.lean` so its opaque predicates and factor projections can be used through public API rather than definitional unfolding. The total change is 146 insertions across two files.

The proofs reuse Mathlib's `LinearEquiv.isSemisimple_iff`, `IsNilpotent.map_iff`, `LinearEquiv.conjRingEquiv`, and `LinearMap.GeneralLinearGroup.congrLinearEquiv`, together with Tau Ceti's merged uniqueness theorem `isSemisimple_isUnipotent_unique`; no Mathlib infrastructure is vendored. The mathematical organization follows T. A. Springer, *Linear Algebraic Groups*, §2.4, as cited in the new module documentation.

Exact-name and concept searches over pinned Mathlib and Tau Ceti found no existing Jordan-factor conjugation or `congrLinearEquiv` equivariance theorem.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"jordan-decomposition-conjugation-equivariance"}-->

🤖 Prepared with Codex
