### PR TITLE
feat: the Specht modules classify the irreducible rational representations of Sₙ

### DIFF
--- a/TauCeti/RepresentationTheory/AsModule.lean
+++ b/TauCeti/RepresentationTheory/AsModule.lean
@@ -25,6 +25,8 @@ theory counts, while the objects being classified are representations.
 * `TauCeti.Representation.equivOfAsModuleLinearEquiv`: a `k[G]`-linear isomorphism
   `ρ.asModule ≃ₗ σ.asModule` is an equivalence of representations.
 * `TauCeti.Representation.asModuleLinearEquivOfEquiv`: the converse.
+* `TauCeti.Representation.equivEquivAsModuleLinearEquiv`: the two are mutually inverse, so the
+  dictionary is itself a bijection.
 * `TauCeti.Representation.nonempty_equiv_iff`: the two notions of isomorphism agree.
 * `TauCeti.fdRepIsoOfAsModuleLinearEquiv`: over a commutative ring, and for module-finite carriers,
   such an isomorphism of modules is an isomorphism of the objects of `FDRep k G` that the
@@ -51,12 +53,19 @@ noncomputable def equivOfAsModuleLinearEquiv (f : ρ.asModule ≃ₗ[k[G]] σ.as
     ((_root_.Representation.IntertwiningMap.equivLinearMapAsModule ρ σ).symm f.toLinearMap)
     f.bijective
 
+/-- The two sides are definitionally equal, through three unfoldings that Mathlib states no lemma
+for: `Representation.asModule` is a type synonym for `V` and `Representation.asModuleEquiv` is
+`LinearEquiv.refl` on it, `Representation.IntertwiningMap.ofBijective` keeps the underlying map, and
+so does the `invFun` field of `Representation.IntertwiningMap.equivLinearMapAsModule`. The middle
+step is `Representation.IntertwiningMap.coe_ofBijective`, but rewriting with it is not type-correct
+at reducible transparency: the bijectivity argument is a `Function.Bijective` of a map
+`ρ.asModule → σ.asModule`, and only unfolding the synonym makes it one of a map `V → W`. -/
 @[simp]
 theorem equivOfAsModuleLinearEquiv_apply (f : ρ.asModule ≃ₗ[k[G]] σ.asModule) (v : V) :
     equivOfAsModuleLinearEquiv f v = σ.asModuleEquiv (f (ρ.asModuleEquiv.symm v)) :=
   (rfl)
 
-/-- **An equivalence of representations is a `k`[G]`-linear isomorphism of the attached modules.**
+/-- **An equivalence of representations is a `k[G]`-linear isomorphism of the attached modules.**
 The inverse of `TauCeti.Representation.equivOfAsModuleLinearEquiv`; the underlying map is the one
 `Representation.IntertwiningMap.equivLinearMapAsModule` attaches to the intertwining map. -/
 noncomputable def asModuleLinearEquivOfEquiv (φ : ρ.Equiv σ) : ρ.asModule ≃ₗ[k[G]] σ.asModule :=
@@ -64,6 +73,9 @@ noncomputable def asModuleLinearEquivOfEquiv (φ : ρ.Equiv σ) : ρ.asModule �
     (_root_.Representation.IntertwiningMap.equivLinearMapAsModule ρ σ φ.toIntertwiningMap)
     φ.bijective
 
+/-- Definitional in the same way as `TauCeti.Representation.equivOfAsModuleLinearEquiv_apply`, with
+`LinearEquiv.ofBijective` in place of `Representation.IntertwiningMap.ofBijective` and the `toFun`
+field of `Representation.IntertwiningMap.equivLinearMapAsModule` in place of its `invFun`. -/
 @[simp]
 theorem asModuleLinearEquivOfEquiv_apply (φ : ρ.Equiv σ) (x : ρ.asModule) :
     asModuleLinearEquivOfEquiv φ x = σ.asModuleEquiv.symm (φ (ρ.asModuleEquiv x)) :=
@@ -82,11 +94,33 @@ theorem asModuleLinearEquivOfEquiv_equivOfAsModuleLinearEquiv
   ext x
   simp
 
+variable (ρ σ) in
+/-- **The dictionary is a bijection.** The equivalences of representations `ρ → σ` correspond to the
+`k[G]`-linear isomorphisms `ρ.asModule ≃ₗ σ.asModule`, by the two constructions above. Use this to
+transport a family of isomorphisms; for the isomorphism classes alone,
+`TauCeti.Representation.nonempty_equiv_iff` is enough. -/
+noncomputable def equivEquivAsModuleLinearEquiv :
+    ρ.Equiv σ ≃ (ρ.asModule ≃ₗ[k[G]] σ.asModule) where
+  toFun := asModuleLinearEquivOfEquiv
+  invFun := equivOfAsModuleLinearEquiv
+  left_inv := equivOfAsModuleLinearEquiv_asModuleLinearEquivOfEquiv
+  right_inv := asModuleLinearEquivOfEquiv_equivOfAsModuleLinearEquiv
+
+@[simp]
+theorem equivEquivAsModuleLinearEquiv_apply (φ : ρ.Equiv σ) :
+    equivEquivAsModuleLinearEquiv ρ σ φ = asModuleLinearEquivOfEquiv φ :=
+  (rfl)
+
+@[simp]
+theorem equivEquivAsModuleLinearEquiv_symm_apply (f : ρ.asModule ≃ₗ[k[G]] σ.asModule) :
+    (equivEquivAsModuleLinearEquiv ρ σ).symm f = equivOfAsModuleLinearEquiv f :=
+  (rfl)
+
 /-- **The two notions of isomorphism agree.** Two representations are equivalent exactly when the
 `k[G]`-modules they carry are isomorphic. -/
 theorem nonempty_equiv_iff :
     Nonempty (ρ.Equiv σ) ↔ Nonempty (ρ.asModule ≃ₗ[k[G]] σ.asModule) :=
-  ⟨fun ⟨φ⟩ ↦ ⟨asModuleLinearEquivOfEquiv φ⟩, fun ⟨f⟩ ↦ ⟨equivOfAsModuleLinearEquiv f⟩⟩
+  Equiv.nonempty_congr (equivEquivAsModuleLinearEquiv ρ σ)
 
 end Representation
 

--- a/TauCeti/RepresentationTheory/AsModule.lean
+++ b/TauCeti/RepresentationTheory/AsModule.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RepresentationTheory.FDRep
+public import Mathlib.RepresentationTheory.Intertwining
+
+/-!
+# Isomorphism of representations and of the modules they carry
+
+Mathlib's `Representation.IntertwiningMap.equivLinearMapAsModule` identifies the intertwining maps
+`ρ → σ` with the `k[G]`-linear maps `ρ.asModule → σ.asModule`, but not the *isomorphisms* with the
+*isomorphisms*: an equivalence of representations is a bijective intertwining map, while a linear
+equivalence of modules carries its inverse as data. This file supplies the missing dictionary, in
+both directions and in the form that is usually wanted, an equivalence of `Nonempty`s.
+
+The point of the dictionary is that classification statements are naturally proved on one side and
+used on the other. The isomorphism classes of simple `k[G]`-modules are what the semisimple-algebra
+theory counts, while the objects being classified are representations.
+
+## Main results
+
+* `TauCeti.Representation.equivOfAsModuleLinearEquiv`: a `k[G]`-linear isomorphism
+  `ρ.asModule ≃ₗ σ.asModule` is an equivalence of representations.
+* `TauCeti.Representation.asModuleLinearEquivOfEquiv`: the converse.
+* `TauCeti.Representation.nonempty_equiv_iff`: the two notions of isomorphism agree.
+* `TauCeti.fdRepIsoOfAsModuleLinearEquiv`: over a field, and for finite-dimensional carriers, such
+  an isomorphism of modules is an isomorphism of the objects of `FDRep k G` that the representations
+  name.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped MonoidAlgebra
+
+namespace Representation
+
+variable {k G V W : Type*} [CommRing k] [Monoid G]
+variable [AddCommGroup V] [Module k V] [AddCommGroup W] [Module k W]
+variable {ρ : _root_.Representation k G V} {σ : _root_.Representation k G W}
+
+/-- **A `k[G]`-linear isomorphism of the attached modules is an equivalence of representations.**
+The underlying `k`-linear equivalence is the given one read through
+`Representation.asModuleEquiv`; equivariance is the fact that `g` acts on `asModule` through the
+basis element `MonoidAlgebra.of`. -/
+noncomputable def equivOfAsModuleLinearEquiv (f : ρ.asModule ≃ₗ[k[G]] σ.asModule) : ρ.Equiv σ :=
+  _root_.Representation.Equiv.mk
+    ((ρ.asModuleEquiv.symm.trans (f.restrictScalars k)).trans σ.asModuleEquiv) fun g ↦ by
+      ext v
+      simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, LinearEquiv.trans_apply,
+        LinearEquiv.restrictScalars_apply, _root_.Representation.asModuleEquiv_symm_map_rho,
+        MonoidAlgebra.of_apply, f.map_smul, _root_.Representation.asModuleEquiv_map_smul,
+        _root_.Representation.asAlgebraHom_single, one_smul]
+
+@[simp]
+theorem equivOfAsModuleLinearEquiv_apply (f : ρ.asModule ≃ₗ[k[G]] σ.asModule) (v : V) :
+    equivOfAsModuleLinearEquiv f v = σ.asModuleEquiv (f (ρ.asModuleEquiv.symm v)) :=
+  (rfl)
+
+/-- **An equivalence of representations is a `k`[G]`-linear isomorphism of the attached modules.**
+The inverse of `TauCeti.Representation.equivOfAsModuleLinearEquiv`; the underlying map is the one
+`Representation.IntertwiningMap.equivLinearMapAsModule` attaches to the intertwining map. -/
+noncomputable def asModuleLinearEquivOfEquiv (φ : ρ.Equiv σ) : ρ.asModule ≃ₗ[k[G]] σ.asModule :=
+  LinearEquiv.ofBijective
+    (_root_.Representation.IntertwiningMap.equivLinearMapAsModule ρ σ φ.toIntertwiningMap)
+    φ.bijective
+
+/-- **The two notions of isomorphism agree.** Two representations are equivalent exactly when the
+`k[G]`-modules they carry are isomorphic. -/
+theorem nonempty_equiv_iff :
+    Nonempty (ρ.Equiv σ) ↔ Nonempty (ρ.asModule ≃ₗ[k[G]] σ.asModule) :=
+  ⟨fun ⟨φ⟩ ↦ ⟨asModuleLinearEquivOfEquiv φ⟩, fun ⟨f⟩ ↦ ⟨equivOfAsModuleLinearEquiv f⟩⟩
+
+end Representation
+
+universe u v
+
+variable {k V W : Type u} {G : Type v} [Field k] [Monoid G]
+variable [AddCommGroup V] [Module k V] [FiniteDimensional k V]
+variable [AddCommGroup W] [Module k W] [FiniteDimensional k W]
+variable {ρ : Representation k G V} {σ : Representation k G W}
+
+/-- **A `k[G]`-linear isomorphism of the attached modules is an isomorphism in `FDRep k G`.** The
+finite-dimensional representations are a full subcategory of `Rep k G`, where an equivalence of
+representations is already an isomorphism. -/
+noncomputable def fdRepIsoOfAsModuleLinearEquiv (f : ρ.asModule ≃ₗ[k[G]] σ.asModule) :
+    FDRep.of ρ ≅ FDRep.of σ :=
+  (CategoryTheory.forget₂ (FDRep k G) (Rep k G)).preimageIso
+    (Rep.mkIso (Representation.equivOfAsModuleLinearEquiv f))
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/AsModule.lean
+++ b/TauCeti/RepresentationTheory/AsModule.lean
@@ -26,9 +26,9 @@ theory counts, while the objects being classified are representations.
   `ρ.asModule ≃ₗ σ.asModule` is an equivalence of representations.
 * `TauCeti.Representation.asModuleLinearEquivOfEquiv`: the converse.
 * `TauCeti.Representation.nonempty_equiv_iff`: the two notions of isomorphism agree.
-* `TauCeti.fdRepIsoOfAsModuleLinearEquiv`: over a field, and for finite-dimensional carriers, such
-  an isomorphism of modules is an isomorphism of the objects of `FDRep k G` that the representations
-  name.
+* `TauCeti.fdRepIsoOfAsModuleLinearEquiv`: over a commutative ring, and for module-finite carriers,
+  such an isomorphism of modules is an isomorphism of the objects of `FDRep k G` that the
+  representations name.
 -/
 
 public section
@@ -92,13 +92,13 @@ end Representation
 
 universe u v
 
-variable {k V W : Type u} {G : Type v} [Field k] [Monoid G]
-variable [AddCommGroup V] [Module k V] [FiniteDimensional k V]
-variable [AddCommGroup W] [Module k W] [FiniteDimensional k W]
+variable {k V W : Type u} {G : Type v} [CommRing k] [Monoid G]
+variable [AddCommGroup V] [Module k V] [Module.Finite k V]
+variable [AddCommGroup W] [Module k W] [Module.Finite k W]
 variable {ρ : Representation k G V} {σ : Representation k G W}
 
 /-- **A `k[G]`-linear isomorphism of the attached modules is an isomorphism in `FDRep k G`.** The
-finite-dimensional representations are a full subcategory of `Rep k G`, where an equivalence of
+finitely generated representations are a full subcategory of `Rep k G`, where an equivalence of
 representations is already an isomorphism. -/
 noncomputable def fdRepIsoOfAsModuleLinearEquiv (f : ρ.asModule ≃ₗ[k[G]] σ.asModule) :
     FDRep.of ρ ≅ FDRep.of σ :=

--- a/TauCeti/RepresentationTheory/AsModule.lean
+++ b/TauCeti/RepresentationTheory/AsModule.lean
@@ -39,22 +39,17 @@ open scoped MonoidAlgebra
 
 namespace Representation
 
-variable {k G V W : Type*} [CommRing k] [Monoid G]
-variable [AddCommGroup V] [Module k V] [AddCommGroup W] [Module k W]
+variable {k G V W : Type*} [CommSemiring k] [Monoid G]
+variable [AddCommMonoid V] [Module k V] [AddCommMonoid W] [Module k W]
 variable {ρ : _root_.Representation k G V} {σ : _root_.Representation k G W}
 
 /-- **A `k[G]`-linear isomorphism of the attached modules is an equivalence of representations.**
-The underlying `k`-linear equivalence is the given one read through
-`Representation.asModuleEquiv`; equivariance is the fact that `g` acts on `asModule` through the
-basis element `MonoidAlgebra.of`. -/
+This reads `Representation.IntertwiningMap.equivLinearMapAsModule` backwards: the `k[G]`-linear map
+underlying `f` is an intertwining map, and it is bijective. -/
 noncomputable def equivOfAsModuleLinearEquiv (f : ρ.asModule ≃ₗ[k[G]] σ.asModule) : ρ.Equiv σ :=
-  _root_.Representation.Equiv.mk
-    ((ρ.asModuleEquiv.symm.trans (f.restrictScalars k)).trans σ.asModuleEquiv) fun g ↦ by
-      ext v
-      simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, LinearEquiv.trans_apply,
-        LinearEquiv.restrictScalars_apply, _root_.Representation.asModuleEquiv_symm_map_rho,
-        MonoidAlgebra.of_apply, f.map_smul, _root_.Representation.asModuleEquiv_map_smul,
-        _root_.Representation.asAlgebraHom_single, one_smul]
+  _root_.Representation.IntertwiningMap.ofBijective
+    ((_root_.Representation.IntertwiningMap.equivLinearMapAsModule ρ σ).symm f.toLinearMap)
+    f.bijective
 
 @[simp]
 theorem equivOfAsModuleLinearEquiv_apply (f : ρ.asModule ≃ₗ[k[G]] σ.asModule) (v : V) :
@@ -68,6 +63,24 @@ noncomputable def asModuleLinearEquivOfEquiv (φ : ρ.Equiv σ) : ρ.asModule �
   LinearEquiv.ofBijective
     (_root_.Representation.IntertwiningMap.equivLinearMapAsModule ρ σ φ.toIntertwiningMap)
     φ.bijective
+
+@[simp]
+theorem asModuleLinearEquivOfEquiv_apply (φ : ρ.Equiv σ) (x : ρ.asModule) :
+    asModuleLinearEquivOfEquiv φ x = σ.asModuleEquiv.symm (φ (ρ.asModuleEquiv x)) :=
+  (rfl)
+
+@[simp]
+theorem equivOfAsModuleLinearEquiv_asModuleLinearEquivOfEquiv (φ : ρ.Equiv σ) :
+    equivOfAsModuleLinearEquiv (asModuleLinearEquivOfEquiv φ) = φ := by
+  ext v
+  simp
+
+@[simp]
+theorem asModuleLinearEquivOfEquiv_equivOfAsModuleLinearEquiv
+    (f : ρ.asModule ≃ₗ[k[G]] σ.asModule) :
+    asModuleLinearEquivOfEquiv (equivOfAsModuleLinearEquiv f) = f := by
+  ext x
+  simp
 
 /-- **The two notions of isomorphism agree.** Two representations are equivalent exactly when the
 `k[G]`-modules they carry are isomorphic. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/SimpleModuleCount.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/SimpleModuleCount.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.Basis
+public import TauCeti.RingTheory.Semisimple.CenterDimension
+
+/-!
+# A finite group has at most as many irreducibles as conjugacy classes
+
+Over a **splitting** field the irreducible representations of a finite group are exactly as many as
+its conjugacy classes, and that equality is proved in
+`TauCeti/RepresentationTheory/CharacterTable/Completeness.lean` over an algebraically closed field.
+This file records the inequality, which holds over **every** field for which the group algebra is
+semisimple, with no algebraic closure and no character theory:
+
+`Nat.card (SimpleSubmoduleClasses k[G] k[G]) ≤ Nat.card (ConjClasses G)`.
+
+Two facts meet. The class sums are a basis of the center of `k[G]`
+(`TauCeti.finrank_center_monoidAlgebra`), so the center has dimension the number of conjugacy
+classes; and the center of a semisimple algebra has dimension at least the number of isomorphism
+classes of simple modules (`TauCeti.card_isotypicComponents_le_finrank_center`).
+
+The inequality is what turns a *supply* of pairwise non-isomorphic simple modules, as many as there
+are conjugacy classes, into a *classification*: there can be no others. That is how the Specht
+modules are shown to exhaust the simple `ℚ[Sₙ]`-modules in
+`TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean`, over `ℚ`, which is not
+algebraically closed.
+
+## Main results
+
+* `TauCeti.card_simpleSubmoduleClasses_le_card_conjClasses`: over a field with `k[G]` semisimple,
+  the isomorphism classes of simple `k[G]`-modules are at most the conjugacy classes of `G`.
+
+## References
+
+* C. W. Curtis and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*,
+  §25 and §41.
+* [Character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+  Layer 3, the group-algebra center and the count of irreducibles.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped MonoidAlgebra
+
+variable (k G : Type*) [Field k] [Group G] [Finite G] [IsSemisimpleRing k[G]]
+
+/-- **A finite group has at most as many irreducibles as conjugacy classes.** Over any field whose
+group algebra is semisimple, the isomorphism classes of simple `k[G]`-modules are at most as many
+as the conjugacy classes of `G`.
+
+Equality is a splitting-field statement, and fails over `ℝ` already for a cyclic group of order
+three, where the two nontrivial complex characters combine into a single two-dimensional real
+irreducible. -/
+theorem card_simpleSubmoduleClasses_le_card_conjClasses :
+    Nat.card (SimpleSubmoduleClasses k[G] k[G]) ≤ Nat.card (ConjClasses G) := by
+  rw [Nat.card_congr (simpleSubmoduleClassesEquiv k[G] k[G]), ← finrank_center_monoidAlgebra k G]
+  exact card_isotypicComponents_le_finrank_center k k[G]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/SimpleModuleCount.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/SimpleModuleCount.lean
@@ -39,7 +39,8 @@ algebraically closed.
 * C. W. Curtis and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*,
   §25 and §41.
 * [Character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
-  Layer 3, the group-algebra center and the count of irreducibles.
+  Layer 2, "#irreducibles = #conjugacy classes", consuming the Layer 1 item "the class sums are a
+  basis of the center" through `TauCeti.finrank_center_monoidAlgebra`.
 -/
 
 public section
@@ -56,7 +57,12 @@ as the conjugacy classes of `G`.
 
 Equality is a splitting-field statement, and fails over `ℝ` already for a cyclic group of order
 three, where the two nontrivial complex characters combine into a single two-dimensional real
-irreducible. -/
+irreducible.
+
+`TauCeti.ClassFunction.card_le_card_conjClasses` is the character-theoretic form of the same bound,
+for a family of pairwise inequivalent irreducible representations rather than for the isomorphism
+classes; it is proved from the linear independence of characters, so it asks for an algebraically
+closed field, which this statement does not. -/
 theorem card_simpleSubmoduleClasses_le_card_conjClasses :
     Nat.card (SimpleSubmoduleClasses k[G] k[G]) ≤ Nat.card (ConjClasses G) := by
   rw [Nat.card_congr (simpleSubmoduleClassesEquiv k[G] k[G]), ← finrank_center_monoidAlgebra k G]

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RepresentationTheory.Maschke
+public import TauCeti.RepresentationTheory.AsModule
+public import TauCeti.RepresentationTheory.CharacterTable.SimpleModuleCount
+public import TauCeti.RepresentationTheory.Symmetric.Partitions
+public import TauCeti.RepresentationTheory.Symmetric.Specht.Distinctness
+
+/-!
+# The Specht modules classify the irreducible rational representations of `Sₙ`
+
+The Specht modules `S^μ` are irreducible over `ℚ`
+(`TauCeti.isIrreducible_spechtModule`) and pairwise non-isomorphic
+(`TauCeti.spechtModule_iso_iff`). This file proves that there are no others: `μ ↦ S^μ` is a
+**bijection** from the partitions of `n` to the isomorphism classes of simple
+`ℚ[Sₙ]`-modules, so every irreducible rational representation of the symmetric group is a Specht
+module.
+
+Only counting is left to do. The partitions of `n` index the conjugacy classes of `Sₙ`
+(`TauCeti.partitionEquivConjClasses`), and over any field with `k[G]` semisimple the isomorphism
+classes of simple `k[G]`-modules are at most as many as the conjugacy classes
+(`TauCeti.card_simpleSubmoduleClasses_le_card_conjClasses`). An injection from a finite set into a
+set of no greater size is a bijection.
+
+Working over `ℚ` rather than over `ℂ` costs nothing here, because the counting bound is not a
+splitting-field statement: it bounds the simple modules over *any* field by the conjugacy classes,
+and the Specht modules already saturate the bound over `ℚ`. In particular the classification does
+not go through absolute irreducibility, which is the separate statement `End_{ℚ[Sₙ]} S^μ ≅ ℚ`, still
+open, and is what a corresponding classification over `ℂ` would need.
+
+## Main results
+
+* `TauCeti.spechtModuleClass`: the isomorphism class of the simple `ℚ[Sₙ]`-module `S^μ`.
+* `TauCeti.partitionEquivSimpleModuleClasses`: **the classification**, `μ ↦ S^μ` as a bijection from
+  `Nat.Partition n` to the isomorphism classes of simple `ℚ[Sₙ]`-modules.
+* `TauCeti.exists_nonempty_linearEquiv_spechtModule`: every simple `ℚ[Sₙ]`-module is isomorphic to
+  a Specht module.
+* `TauCeti.exists_nonempty_equiv_spechtModule`: every irreducible rational representation of `Sₙ` is
+  equivalent to a Specht module.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 4.
+* B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Section 2.4.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 4, "Distinctness and completeness".
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped MonoidAlgebra
+
+variable {n : ℕ}
+
+/-- The order of a symmetric group is nonzero in `ℚ`, so `ℚ[Sₙ]` is semisimple by Maschke's
+theorem. This is what puts the isotypic theory at the disposal of the classification. -/
+private instance : NeZero ((Nat.card (Equiv.Perm (Fin n)) : ℚ)) :=
+  ⟨Nat.cast_ne_zero.mpr Nat.card_pos.ne'⟩
+
+/-- **The isomorphism class of the Specht module `S^μ`**, as a simple module over the rational
+group algebra of `Sₙ`. -/
+noncomputable abbrev spechtModuleClass (μ : n.Partition) :
+    SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)] :=
+  simpleModuleClass _ (_root_.Representation.asModule (spechtModule μ).ρ)
+
+/-- **Specht modules with distinct shapes carry non-isomorphic modules.** This is
+`TauCeti.spechtModule_iso_iff` read through the dictionary between isomorphism of representations
+and isomorphism of the `ℚ[Sₙ]`-modules they carry. -/
+theorem nonempty_linearEquiv_spechtModule_asModule_iff (μ ν : n.Partition) :
+    Nonempty (_root_.Representation.asModule (spechtModule μ).ρ ≃ₗ[ℚ[Equiv.Perm (Fin n)]]
+      _root_.Representation.asModule (spechtModule ν).ρ) ↔ μ = ν := by
+  refine ⟨fun ⟨f⟩ ↦ (spechtModule_iso_iff μ ν).mp ⟨fdRepIsoOfAsModuleLinearEquiv f⟩, ?_⟩
+  rintro rfl
+  exact ⟨LinearEquiv.refl _ _⟩
+
+/-- Distinct partitions give distinct isomorphism classes: the irredundancy half of the
+classification. -/
+theorem spechtModuleClass_injective : Function.Injective (spechtModuleClass (n := n)) := fun μ ν h ↦
+  (nonempty_linearEquiv_spechtModule_asModule_iff μ ν).mp (simpleModuleClass_eq_iff.mp h)
+
+/-- **The Specht modules exhaust the simple `ℚ[Sₙ]`-modules.** They are as many as the conjugacy
+classes of `Sₙ` and pairwise non-isomorphic, and no field admits more isomorphism classes of simple
+modules over the group algebra than the group has conjugacy classes. -/
+theorem spechtModuleClass_bijective : Function.Bijective (spechtModuleClass (n := n)) := by
+  classical
+  have : Finite (SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)]) :=
+    .of_equiv _ (simpleSubmoduleClassesEquiv _ _).symm
+  let _ := Fintype.ofFinite (SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)])
+  refine (Fintype.bijective_iff_injective_and_card _).mpr ⟨spechtModuleClass_injective, ?_⟩
+  rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card]
+  refine le_antisymm (Nat.card_le_card_of_injective _ spechtModuleClass_injective) ?_
+  exact (card_simpleSubmoduleClasses_le_card_conjClasses ℚ (Equiv.Perm (Fin n))).trans
+    (Nat.card_congr (partitionEquivConjClasses n).symm).le
+
+/-- **The classification of the irreducible rational representations of the symmetric group.**
+Sending a partition of `n` to the isomorphism class of the Specht module `S^μ` is a bijection onto
+the isomorphism classes of simple `ℚ[Sₙ]`-modules. -/
+noncomputable def partitionEquivSimpleModuleClasses (n : ℕ) :
+    n.Partition ≃ SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)] :=
+  Equiv.ofBijective _ spechtModuleClass_bijective
+
+@[simp]
+theorem partitionEquivSimpleModuleClasses_apply (μ : n.Partition) :
+    partitionEquivSimpleModuleClasses n μ = spechtModuleClass μ :=
+  (rfl)
+
+/-- **Every simple `ℚ[Sₙ]`-module is a Specht module.** -/
+theorem exists_nonempty_linearEquiv_spechtModule (M : Type*) [AddCommGroup M]
+    [Module ℚ[Equiv.Perm (Fin n)] M] [IsSimpleModule ℚ[Equiv.Perm (Fin n)] M] :
+    ∃ μ : n.Partition, Nonempty (M ≃ₗ[ℚ[Equiv.Perm (Fin n)]]
+      _root_.Representation.asModule (spechtModule μ).ρ) := by
+  obtain ⟨μ, hμ⟩ := (spechtModuleClass_bijective (n := n)).surjective
+    (simpleModuleClass ℚ[Equiv.Perm (Fin n)] M)
+  exact ⟨μ, simpleModuleClass_eq_iff.mp hμ.symm⟩
+
+/-- **Every irreducible rational representation of `Sₙ` is a Specht module.** -/
+theorem exists_nonempty_equiv_spechtModule {V : Type*} [AddCommGroup V] [Module ℚ V]
+    (ρ : Representation ℚ (Equiv.Perm (Fin n)) V) [ρ.IsIrreducible] :
+    ∃ μ : n.Partition, Nonempty (ρ.Equiv (spechtModule μ).ρ) := by
+  obtain ⟨μ, hμ⟩ := exists_nonempty_linearEquiv_spechtModule (n := n) ρ.asModule
+  exact ⟨μ, Representation.nonempty_equiv_iff.mpr hμ⟩
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
@@ -67,7 +67,7 @@ private instance : NeZero ((Nat.card (Equiv.Perm (Fin n)) : ℚ)) :=
 group algebra of `Sₙ`.
 
 That this is built as `TauCeti.simpleModuleClass` of the module `S^μ` carries is an
-implementation detail; use `TauCeti.spechtModuleClass_eq_simpleModuleClass` to see it. -/
+implementation detail; use `TauCeti.spechtModuleClass_def` to see it. -/
 noncomputable def spechtModuleClass (μ : n.Partition) :
     SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)] :=
   simpleModuleClass _ (_root_.Representation.asModule (spechtModule μ).ρ)
@@ -75,14 +75,19 @@ noncomputable def spechtModuleClass (μ : n.Partition) :
 /-- The defining equation of `TauCeti.spechtModuleClass`: it is the class of the `ℚ[Sₙ]`-module
 carried by the Specht module `S^μ`. -/
 @[simp]
-theorem spechtModuleClass_eq_simpleModuleClass (μ : n.Partition) :
+theorem spechtModuleClass_def (μ : n.Partition) :
     spechtModuleClass μ =
       simpleModuleClass _ (_root_.Representation.asModule (spechtModule μ).ρ) :=
   (rfl)
 
 /-- **Specht modules with distinct shapes carry non-isomorphic modules.** This is
 `TauCeti.spechtModule_iso_iff` read through the dictionary between isomorphism of representations
-and isomorphism of the `ℚ[Sₙ]`-modules they carry. -/
+and isomorphism of the `ℚ[Sₙ]`-modules they carry.
+
+This is deliberately not a `simp` lemma: `(spechtModule μ).ρ` is not a simp normal form, because the
+`simp` lemma `FDRep.of_ρ'` unfolds it to the composite that `spechtModule` is built from, so `simp`
+would never see this left-hand side. The parallel `TauCeti.spechtModule_iso_iff` can carry the tag
+because its left-hand side mentions only the `FDRep` object. -/
 theorem nonempty_linearEquiv_spechtModule_asModule_iff (μ ν : n.Partition) :
     Nonempty (_root_.Representation.asModule (spechtModule μ).ρ ≃ₗ[ℚ[Equiv.Perm (Fin n)]]
       _root_.Representation.asModule (spechtModule ν).ρ) ↔ μ = ν := by
@@ -94,8 +99,7 @@ theorem nonempty_linearEquiv_spechtModule_asModule_iff (μ ν : n.Partition) :
 classification. -/
 theorem spechtModuleClass_injective : Function.Injective (spechtModuleClass (n := n)) := by
   intro μ ν h
-  rw [spechtModuleClass_eq_simpleModuleClass, spechtModuleClass_eq_simpleModuleClass,
-    simpleModuleClass_eq_iff] at h
+  rw [spechtModuleClass_def, spechtModuleClass_def, simpleModuleClass_eq_iff] at h
   exact (nonempty_linearEquiv_spechtModule_asModule_iff μ ν).mp h
 
 /-- **The Specht modules exhaust the simple `ℚ[Sₙ]`-modules.** They are as many as the conjugacy
@@ -131,7 +135,7 @@ theorem exists_nonempty_linearEquiv_spechtModule (M : Type*) [AddCommGroup M]
       _root_.Representation.asModule (spechtModule μ).ρ) := by
   obtain ⟨μ, hμ⟩ := (spechtModuleClass_bijective (n := n)).surjective
     (simpleModuleClass ℚ[Equiv.Perm (Fin n)] M)
-  rw [spechtModuleClass_eq_simpleModuleClass] at hμ
+  rw [spechtModuleClass_def] at hμ
   exact ⟨μ, simpleModuleClass_eq_iff.mp hμ.symm⟩
 
 /-- **Every irreducible rational representation of `Sₙ` is a Specht module.** -/

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
@@ -35,8 +35,8 @@ open, and is what a corresponding classification over `ℂ` would need.
 ## Main results
 
 * `TauCeti.spechtModuleClass`: the isomorphism class of the simple `ℚ[Sₙ]`-module `S^μ`.
-* `TauCeti.partitionEquivSimpleModuleClasses`: **the classification**, `μ ↦ S^μ` as a bijection from
-  `Nat.Partition n` to the isomorphism classes of simple `ℚ[Sₙ]`-modules.
+* `TauCeti.partitionEquivSimpleSubmoduleClasses`: **the classification**, `μ ↦ S^μ` as a bijection
+  from `Nat.Partition n` to the isomorphism classes of simple `ℚ[Sₙ]`-modules.
 * `TauCeti.exists_nonempty_linearEquiv_spechtModule`: every simple `ℚ[Sₙ]`-module is isomorphic to
   a Specht module.
 * `TauCeti.exists_nonempty_equiv_spechtModule`: every irreducible rational representation of `Sₙ` is
@@ -58,11 +58,6 @@ open scoped MonoidAlgebra
 
 variable {n : ℕ}
 
-/-- The order of a symmetric group is nonzero in `ℚ`, so `ℚ[Sₙ]` is semisimple by Maschke's
-theorem. This is what puts the isotypic theory at the disposal of the classification. -/
-private instance : NeZero ((Nat.card (Equiv.Perm (Fin n)) : ℚ)) :=
-  ⟨Nat.cast_ne_zero.mpr Nat.card_pos.ne'⟩
-
 /-- **The isomorphism class of the Specht module `S^μ`**, as a simple module over the rational
 group algebra of `Sₙ`.
 
@@ -73,8 +68,13 @@ noncomputable def spechtModuleClass (μ : n.Partition) :
   simpleModuleClass _ (_root_.Representation.asModule (spechtModule μ).ρ)
 
 /-- The defining equation of `TauCeti.spechtModuleClass`: it is the class of the `ℚ[Sₙ]`-module
-carried by the Specht module `S^μ`. -/
-@[simp]
+carried by the Specht module `S^μ`.
+
+This is deliberately not a `simp` lemma: its right-hand side is not a simp normal form, since
+`spechtModule μ` is an `FDRep.of` and the `simp` lemma `FDRep.of_ρ'` rewrites `(spechtModule μ).ρ`
+into the composite that `spechtModule` is built from. Tagging it would make that composite the
+normal form of `spechtModuleClass μ`, which is exactly what keeping `TauCeti.spechtModuleClass` an
+unexposed `def` is for. Use it with `rw`, as the two proofs below do. -/
 theorem spechtModuleClass_def (μ : n.Partition) :
     spechtModuleClass μ =
       simpleModuleClass _ (_root_.Representation.asModule (spechtModule μ).ρ) :=
@@ -103,15 +103,12 @@ theorem spechtModuleClass_injective : Function.Injective (spechtModuleClass (n :
   exact (nonempty_linearEquiv_spechtModule_asModule_iff μ ν).mp h
 
 /-- **The Specht modules exhaust the simple `ℚ[Sₙ]`-modules.** They are as many as the conjugacy
-classes of `Sₙ` and pairwise non-isomorphic, and no field admits more isomorphism classes of simple
-modules over the group algebra than the group has conjugacy classes. -/
+classes of `Sₙ` and pairwise non-isomorphic, and over any field whose group algebra is semisimple
+there are no more isomorphism classes of simple modules than the group has conjugacy classes. -/
 theorem spechtModuleClass_bijective : Function.Bijective (spechtModuleClass (n := n)) := by
-  classical
   have : Finite (SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)]) :=
     .of_equiv _ (simpleSubmoduleClassesEquiv _ _).symm
-  let _ := Fintype.ofFinite (SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)])
-  refine (Fintype.bijective_iff_injective_and_card _).mpr ⟨spechtModuleClass_injective, ?_⟩
-  rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card]
+  refine (Nat.bijective_iff_injective_and_card _).mpr ⟨spechtModuleClass_injective, ?_⟩
   refine le_antisymm (Nat.card_le_card_of_injective _ spechtModuleClass_injective) ?_
   exact (card_simpleSubmoduleClasses_le_card_conjClasses ℚ (Equiv.Perm (Fin n))).trans
     (Nat.card_congr (partitionEquivConjClasses n).symm).le
@@ -119,13 +116,13 @@ theorem spechtModuleClass_bijective : Function.Bijective (spechtModuleClass (n :
 /-- **The classification of the irreducible rational representations of the symmetric group.**
 Sending a partition of `n` to the isomorphism class of the Specht module `S^μ` is a bijection onto
 the isomorphism classes of simple `ℚ[Sₙ]`-modules. -/
-noncomputable def partitionEquivSimpleModuleClasses (n : ℕ) :
+noncomputable def partitionEquivSimpleSubmoduleClasses (n : ℕ) :
     n.Partition ≃ SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)] :=
   Equiv.ofBijective _ spechtModuleClass_bijective
 
 @[simp]
-theorem partitionEquivSimpleModuleClasses_apply (μ : n.Partition) :
-    partitionEquivSimpleModuleClasses n μ = spechtModuleClass μ :=
+theorem partitionEquivSimpleSubmoduleClasses_apply (μ : n.Partition) :
+    partitionEquivSimpleSubmoduleClasses n μ = spechtModuleClass μ :=
   (rfl)
 
 /-- **Every simple `ℚ[Sₙ]`-module is a Specht module.** -/

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
@@ -64,10 +64,21 @@ private instance : NeZero ((Nat.card (Equiv.Perm (Fin n)) : ℚ)) :=
   ⟨Nat.cast_ne_zero.mpr Nat.card_pos.ne'⟩
 
 /-- **The isomorphism class of the Specht module `S^μ`**, as a simple module over the rational
-group algebra of `Sₙ`. -/
-noncomputable abbrev spechtModuleClass (μ : n.Partition) :
+group algebra of `Sₙ`.
+
+That this is built as `TauCeti.simpleModuleClass` of the module `S^μ` carries is an
+implementation detail; use `TauCeti.spechtModuleClass_eq_simpleModuleClass` to see it. -/
+noncomputable def spechtModuleClass (μ : n.Partition) :
     SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)] :=
   simpleModuleClass _ (_root_.Representation.asModule (spechtModule μ).ρ)
+
+/-- The defining equation of `TauCeti.spechtModuleClass`: it is the class of the `ℚ[Sₙ]`-module
+carried by the Specht module `S^μ`. -/
+@[simp]
+theorem spechtModuleClass_eq_simpleModuleClass (μ : n.Partition) :
+    spechtModuleClass μ =
+      simpleModuleClass _ (_root_.Representation.asModule (spechtModule μ).ρ) :=
+  (rfl)
 
 /-- **Specht modules with distinct shapes carry non-isomorphic modules.** This is
 `TauCeti.spechtModule_iso_iff` read through the dictionary between isomorphism of representations
@@ -81,8 +92,11 @@ theorem nonempty_linearEquiv_spechtModule_asModule_iff (μ ν : n.Partition) :
 
 /-- Distinct partitions give distinct isomorphism classes: the irredundancy half of the
 classification. -/
-theorem spechtModuleClass_injective : Function.Injective (spechtModuleClass (n := n)) := fun μ ν h ↦
-  (nonempty_linearEquiv_spechtModule_asModule_iff μ ν).mp (simpleModuleClass_eq_iff.mp h)
+theorem spechtModuleClass_injective : Function.Injective (spechtModuleClass (n := n)) := by
+  intro μ ν h
+  rw [spechtModuleClass_eq_simpleModuleClass, spechtModuleClass_eq_simpleModuleClass,
+    simpleModuleClass_eq_iff] at h
+  exact (nonempty_linearEquiv_spechtModule_asModule_iff μ ν).mp h
 
 /-- **The Specht modules exhaust the simple `ℚ[Sₙ]`-modules.** They are as many as the conjugacy
 classes of `Sₙ` and pairwise non-isomorphic, and no field admits more isomorphism classes of simple
@@ -117,6 +131,7 @@ theorem exists_nonempty_linearEquiv_spechtModule (M : Type*) [AddCommGroup M]
       _root_.Representation.asModule (spechtModule μ).ρ) := by
   obtain ⟨μ, hμ⟩ := (spechtModuleClass_bijective (n := n)).surjective
     (simpleModuleClass ℚ[Equiv.Perm (Fin n)] M)
+  rw [spechtModuleClass_eq_simpleModuleClass] at hμ
   exact ⟨μ, simpleModuleClass_eq_iff.mp hμ.symm⟩
 
 /-- **Every irreducible rational representation of `Sₙ` is a Specht module.** -/

--- a/TauCeti/RingTheory/Semisimple/CenterDimension.lean
+++ b/TauCeti/RingTheory/Semisimple/CenterDimension.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Algebra.Subalgebra.Centralizer
+public import Mathlib.LinearAlgebra.DFinsupp
+public import Mathlib.LinearAlgebra.Dimension.Finite
+public import TauCeti.RingTheory.Semisimple.RegularIsotypicComponent
+
+/-!
+# The center bounds the number of simple modules of a semisimple algebra
+
+A semisimple ring `R` has finitely many isomorphism classes of simple modules, indexed by the
+isotypic components of the regular module (`TauCeti.simpleSubmoduleClassesEquiv`). When `R` is an
+algebra over a field `k`, this file bounds that number by the dimension of the center:
+
+`Nat.card (isotypicComponents R R) ≤ Module.finrank k (Subalgebra.center k R)`.
+
+The bound is the counting half of Artin-Wedderburn, obtained without choosing a presentation
+`R ≃+* ∏ᵢ Matₙᵢ(Dᵢ)`: for such a product the center is `∏ᵢ Z(Dᵢ)`, of dimension at least the number
+of blocks, and the argument here says exactly that intrinsically. Where
+`TauCeti.card_blocks_eq` compares two presentations, this bound mentions none.
+
+The mechanism is that each isotypic component of the regular module contains a nonzero *central*
+element (`TauCeti.exists_ne_zero_mem_center_of_mem_isotypicComponents`). Writing `1 = ∑_c e_c` along
+the decomposition of `R` into its isotypic components, the summand `e_c` is central because for
+`z : R` the two decompositions `z = ∑_c z * e_c` and `z = ∑_c e_c * z` have their `c`-th terms in
+the same summand: the first because `c` is a left ideal, the second because an isotypic component of
+the regular module is *two-sided* (`TauCeti.isTwoSided_of_mem_isotypicComponents`, Mathlib's
+`isFullyInvariant_iff_isTwoSided` read on `isotypicComponents R R`). It is nonzero because the same
+uniqueness gives `x * e_c = x` for `x ∈ c`. Elements chosen one from each summand of an independent
+family are linearly independent, so the components are at most as many as the dimension of the
+center.
+
+Nothing here needs `R` itself to be finite-dimensional: only the center is assumed finite as a
+`k`-module, which is what a group algebra supplies through its class-sum basis.
+
+## Main results
+
+* `TauCeti.isTwoSided_of_mem_isotypicComponents`: an isotypic component of the regular module is a
+  two-sided ideal.
+* `TauCeti.exists_ne_zero_mem_center_of_mem_isotypicComponents`: it contains a nonzero central
+  element.
+* `TauCeti.card_isotypicComponents_le_finrank_center`: the number of isotypic components of the
+  regular module is at most the dimension of the center.
+
+## References
+
+* T. Y. Lam, *A First Course in Noncommutative Rings*, GTM 131, §3.
+* C. W. Curtis and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*,
+  §25.
+* [Semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md),
+  Layer 2, "Artin-Wedderburn, assembled with uniqueness".
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+variable {R : Type*} [Ring R]
+
+/-- **An isotypic component of the regular module is a two-sided ideal.** Mathlib's
+`Submodule.IsFullyInvariant.of_mem_isotypicComponents` makes it invariant under every endomorphism
+of the regular module, and those endomorphisms are the right multiplications. -/
+theorem isTwoSided_of_mem_isotypicComponents {c : Ideal R} (hc : c ∈ isotypicComponents R R) :
+    c.IsTwoSided :=
+  isFullyInvariant_iff_isTwoSided.mp (Submodule.IsFullyInvariant.of_mem_isotypicComponents hc)
+
+section Field
+
+variable (k R : Type*) [Field k] [Ring R] [Algebra k R] [IsSemisimpleRing R]
+
+/-- The decomposition of `1` along the isotypic components of the regular module: a family of
+nonzero central elements, one in each component. This is the whole content of the section; the two
+public statements below read off the parts of it that they need. -/
+private theorem exists_center_family :
+    ∃ e : isotypicComponents R R → R, (∀ c, e c ∈ c.1) ∧ (∀ c, e c ≠ 0) ∧
+      ∀ c, e c ∈ Subalgebra.center k R := by
+  classical
+  let _ : Fintype (isotypicComponents R R) := Fintype.ofFinite _
+  have hind : iSupIndep fun c : isotypicComponents R R ↦ c.1 :=
+    (sSupIndep_iff _).mp (sSupIndep_isotypicComponents R R)
+  have htop : ⨆ c : isotypicComponents R R, c.1 = ⊤ :=
+    (sSup_eq_iSup' (isotypicComponents R R)).symm.trans (sSup_isotypicComponents R R)
+  -- Any two decompositions along the components agree term by term.
+  have huniq : ∀ a b : isotypicComponents R R → R, (∀ c, a c ∈ c.1) → (∀ c, b c ∈ c.1) →
+      ∑ c, a c = ∑ c, b c → ∀ c, a c = b c := fun a b ha hb hab c ↦
+    (iSupIndep_iff_finsetSum_eq_imp_eq _).mp hind Finset.univ a b
+      (fun i _ ↦ ⟨ha i, hb i⟩) hab c (Finset.mem_univ c)
+  obtain ⟨v, hv⟩ : ∃ v : ∀ c : isotypicComponents R R, c.1, ∑ c, (v c : R) = 1 :=
+    (Submodule.mem_iSup_finset_iff_exists_sum _ 1).mp (by simp [htop])
+  have hleft : ∀ (x : R) (d : isotypicComponents R R), x * (v d : R) ∈ d.1 := fun x d ↦ by
+    simpa only [smul_eq_mul] using d.1.smul_mem x (v d).2
+  refine ⟨fun c ↦ (v c : R), fun c ↦ (v c).2, fun c hc ↦ ?_, fun c ↦ ?_⟩
+  · -- A vanishing summand would kill its own component.
+    refine absurd ((Submodule.eq_bot_iff _).mpr fun x hx ↦ ?_) (bot_lt_isotypicComponents c.2).ne'
+    have hb : ∀ d : isotypicComponents R R, (if d = c then x else 0) ∈ d.1 := fun d ↦ by
+      split
+      · next h => exact h ▸ hx
+      · exact d.1.zero_mem
+    have hsum : ∑ d, x * (v d : R) = ∑ d, if d = c then x else 0 := by
+      rw [← Finset.mul_sum, hv, mul_one, Finset.sum_ite_eq' Finset.univ c fun _ ↦ x,
+        if_pos (Finset.mem_univ c)]
+    simpa [hc] using (huniq _ _ (hleft x) hb hsum c).symm
+  · -- Centrality: multiplying `1 = ∑ e_d` on either side decomposes the same element.
+    rw [Subalgebra.mem_center_iff]
+    intro z
+    have hright : ∀ d : isotypicComponents R R, (v d : R) * z ∈ d.1 := fun d ↦ by
+      have := isTwoSided_of_mem_isotypicComponents d.2
+      exact Ideal.mul_mem_right z _ (v d).2
+    have hsum : ∑ d, z * (v d : R) = ∑ d, (v d : R) * z := by
+      rw [← Finset.mul_sum, ← Finset.sum_mul, hv, mul_one, one_mul]
+    exact huniq _ _ (hleft z) hright hsum c
+
+/-- **Every isotypic component of the regular module contains a nonzero central element.** It is the
+corresponding summand of the decomposition of `1`; only these two properties are recorded, being all
+that the dimension count below consumes. -/
+theorem exists_ne_zero_mem_center_of_mem_isotypicComponents {c : Submodule R R}
+    (hc : c ∈ isotypicComponents R R) :
+    ∃ e : R, e ∈ c ∧ e ≠ 0 ∧ e ∈ Subalgebra.center k R := by
+  obtain ⟨e, hmem, hne, hcen⟩ := exists_center_family k R
+  exact ⟨e ⟨c, hc⟩, hmem ⟨c, hc⟩, hne ⟨c, hc⟩, hcen ⟨c, hc⟩⟩
+
+/-- **The center bounds the number of isomorphism classes of simple modules.** Over a semisimple
+`k`-algebra whose center is finite-dimensional, the isotypic components of the regular module, which
+`TauCeti.simpleSubmoduleClassesEquiv` identifies with the isomorphism classes of simple modules, are
+at most as many as the dimension of the center.
+
+For a group algebra the right-hand side is the number of conjugacy classes, by
+`TauCeti.finrank_center_monoidAlgebra`. -/
+theorem card_isotypicComponents_le_finrank_center [Module.Finite k (Subalgebra.center k R)] :
+    Nat.card (isotypicComponents R R) ≤ Module.finrank k (Subalgebra.center k R) := by
+  classical
+  let _ : Fintype (isotypicComponents R R) := Fintype.ofFinite _
+  obtain ⟨e, hmem, hne, hcen⟩ := exists_center_family k R
+  have hind : iSupIndep fun c : isotypicComponents R R ↦ c.1 :=
+    (sSupIndep_iff _).mp (sSupIndep_isotypicComponents R R)
+  -- The chosen elements are linearly independent over `k`, one from each independent summand.
+  have hli : LinearIndependent k e := by
+    rw [linearIndependent_iff']
+    intro s g hg i hi
+    have hmem' : ∀ c ∈ s, g c • e c ∈ c.1 := fun c _ ↦ by
+      simpa only [Algebra.smul_def, smul_eq_mul] using
+        c.1.smul_mem (algebraMap k R (g c)) (hmem c)
+    have hzero := (iSupIndep_iff_finsetSum_eq_zero_imp_eq_zero _).mp hind s
+      (fun c ↦ g c • e c) hmem' hg i hi
+    by_contra hgi
+    exact hne i (by rw [← one_smul k (e i), ← inv_mul_cancel₀ hgi, mul_smul, hzero, smul_zero])
+  -- Read the independence inside the center and count.
+  have hli' : LinearIndependent k fun c ↦ (⟨e c, hcen c⟩ : Subalgebra.center k R) :=
+    LinearIndependent.of_comp (Subalgebra.center k R).val.toLinearMap hli
+  simpa using hli'.fintype_card_le_finrank
+
+end Field
+
+end TauCeti

--- a/TauCeti/RingTheory/Semisimple/CenterDimension.lean
+++ b/TauCeti/RingTheory/Semisimple/CenterDimension.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Algebra.Subalgebra.Centralizer
+public import Mathlib.Algebra.Algebra.Subalgebra.Basic
 public import Mathlib.LinearAlgebra.DFinsupp
 public import Mathlib.LinearAlgebra.Dimension.Finite
 public import TauCeti.RingTheory.Semisimple.RegularIsotypicComponent
@@ -24,12 +24,12 @@ of blocks, and the argument here says exactly that intrinsically. Where
 `TauCeti.card_blocks_eq` compares two presentations, this bound mentions none.
 
 The mechanism is that each isotypic component of the regular module contains a nonzero *central*
-element (`TauCeti.exists_ne_zero_mem_center_of_mem_isotypicComponents`). Writing `1 = ∑_c e_c` along
-the decomposition of `R` into its isotypic components, the summand `e_c` is central because for
-`z : R` the two decompositions `z = ∑_c z * e_c` and `z = ∑_c e_c * z` have their `c`-th terms in
-the same summand: the first because `c` is a left ideal, the second because an isotypic component of
-the regular module is *two-sided* (`TauCeti.isTwoSided_of_mem_isotypicComponents`, Mathlib's
-`isFullyInvariant_iff_isTwoSided` read on `isotypicComponents R R`). It is nonzero because the same
+element (`TauCeti.exists_mem_ne_zero_mem_center_of_mem_isotypicComponents`). Writing `1 = ∑_c e_c`
+along the decomposition of `R` into its isotypic components, the summand `e_c` is central because
+for `z : R` the two decompositions `z = ∑_c z * e_c` and `z = ∑_c e_c * z` have their `c`-th terms
+in the same summand: the first because `c` is a left ideal, the second because an isotypic component
+of the regular module is a *two-sided* ideal, which is Mathlib's `isFullyInvariant_iff_isTwoSided`
+read through `Submodule.IsFullyInvariant.of_mem_isotypicComponents`. It is nonzero because the same
 uniqueness gives `x * e_c = x` for `x ∈ c`. Elements chosen one from each summand of an independent
 family are linearly independent, so the components are at most as many as the dimension of the
 center.
@@ -39,10 +39,8 @@ Nothing here needs `R` itself to be finite-dimensional: only the center is assum
 
 ## Main results
 
-* `TauCeti.isTwoSided_of_mem_isotypicComponents`: an isotypic component of the regular module is a
-  two-sided ideal.
-* `TauCeti.exists_ne_zero_mem_center_of_mem_isotypicComponents`: it contains a nonzero central
-  element.
+* `TauCeti.exists_mem_ne_zero_mem_center_of_mem_isotypicComponents`: an isotypic component of the
+  regular module contains a nonzero central element.
 * `TauCeti.card_isotypicComponents_le_finrank_center`: the number of isotypic components of the
   regular module is at most the dimension of the center.
 
@@ -52,7 +50,11 @@ Nothing here needs `R` itself to be finite-dimensional: only the center is assum
 * C. W. Curtis and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*,
   §25.
 * [Semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md),
-  Layer 2, "Artin-Wedderburn, assembled with uniqueness".
+  Layer 1, "the isotypic decomposition as counted data", whose counting spine for the regular module
+  this bound serves; the roadmap directs that spine at the
+  [character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md)
+  Layer 2 item "#irreducibles = #conjugacy classes". The bound itself is not separately itemised on
+  either roadmap.
 -/
 
 public section
@@ -61,25 +63,14 @@ namespace TauCeti
 
 open scoped BigOperators
 
-variable {R : Type*} [Ring R]
-
-/-- **An isotypic component of the regular module is a two-sided ideal.** Mathlib's
-`Submodule.IsFullyInvariant.of_mem_isotypicComponents` makes it invariant under every endomorphism
-of the regular module, and those endomorphisms are the right multiplications. -/
-theorem isTwoSided_of_mem_isotypicComponents {c : Ideal R} (hc : c ∈ isotypicComponents R R) :
-    c.IsTwoSided :=
-  isFullyInvariant_iff_isTwoSided.mp (Submodule.IsFullyInvariant.of_mem_isotypicComponents hc)
-
-section Field
-
-variable (k R : Type*) [Field k] [Ring R] [Algebra k R] [IsSemisimpleRing R]
+variable (R : Type*) [Ring R] [IsSemisimpleRing R]
 
 /-- The decomposition of `1` along the isotypic components of the regular module: a family of
-nonzero central elements, one in each component. This is the whole content of the section; the two
+nonzero central elements, one in each component. This is the whole content of the file; the two
 public statements below read off the parts of it that they need. -/
 private theorem exists_center_family :
     ∃ e : isotypicComponents R R → R, (∀ c, e c ∈ c.1) ∧ (∀ c, e c ≠ 0) ∧
-      ∀ c, e c ∈ Subalgebra.center k R := by
+      ∀ c, e c ∈ Set.center R := by
   classical
   let _ : Fintype (isotypicComponents R R) := Fintype.ofFinite _
   have hind : iSupIndep fun c : isotypicComponents R R ↦ c.1 :=
@@ -107,23 +98,31 @@ private theorem exists_center_family :
         if_pos (Finset.mem_univ c)]
     simpa [hc] using (huniq _ _ (hleft x) hb hsum c).symm
   · -- Centrality: multiplying `1 = ∑ e_d` on either side decomposes the same element.
-    rw [Subalgebra.mem_center_iff]
+    rw [Semigroup.mem_center_iff]
     intro z
     have hright : ∀ d : isotypicComponents R R, (v d : R) * z ∈ d.1 := fun d ↦ by
-      have := isTwoSided_of_mem_isotypicComponents d.2
+      -- An isotypic component of the regular module is a two-sided ideal.
+      have : Ideal.IsTwoSided d.1 := isFullyInvariant_iff_isTwoSided.mp
+        (Submodule.IsFullyInvariant.of_mem_isotypicComponents d.2)
       exact Ideal.mul_mem_right z _ (v d).2
     have hsum : ∑ d, z * (v d : R) = ∑ d, (v d : R) * z := by
       rw [← Finset.mul_sum, ← Finset.sum_mul, hv, mul_one, one_mul]
     exact huniq _ _ (hleft z) hright hsum c
 
+variable {R}
+
 /-- **Every isotypic component of the regular module contains a nonzero central element.** It is the
-corresponding summand of the decomposition of `1`; only these two properties are recorded, being all
-that the dimension count below consumes. -/
-theorem exists_ne_zero_mem_center_of_mem_isotypicComponents {c : Submodule R R}
+corresponding summand of the decomposition of `1`; only these three properties are recorded, being
+all that the dimension count below consumes. -/
+theorem exists_mem_ne_zero_mem_center_of_mem_isotypicComponents {c : Submodule R R}
     (hc : c ∈ isotypicComponents R R) :
-    ∃ e : R, e ∈ c ∧ e ≠ 0 ∧ e ∈ Subalgebra.center k R := by
-  obtain ⟨e, hmem, hne, hcen⟩ := exists_center_family k R
+    ∃ e : R, e ∈ c ∧ e ≠ 0 ∧ e ∈ Set.center R := by
+  obtain ⟨e, hmem, hne, hcen⟩ := exists_center_family R
   exact ⟨e ⟨c, hc⟩, hmem ⟨c, hc⟩, hne ⟨c, hc⟩, hcen ⟨c, hc⟩⟩
+
+section Field
+
+variable (k R : Type*) [Field k] [Ring R] [Algebra k R] [IsSemisimpleRing R]
 
 /-- **The center bounds the number of isomorphism classes of simple modules.** Over a semisimple
 `k`-algebra whose center is finite-dimensional, the isotypic components of the regular module, which
@@ -136,7 +135,7 @@ theorem card_isotypicComponents_le_finrank_center [Module.Finite k (Subalgebra.c
     Nat.card (isotypicComponents R R) ≤ Module.finrank k (Subalgebra.center k R) := by
   classical
   let _ : Fintype (isotypicComponents R R) := Fintype.ofFinite _
-  obtain ⟨e, hmem, hne, hcen⟩ := exists_center_family k R
+  obtain ⟨e, hmem, hne, hcen⟩ := exists_center_family R
   have hind : iSupIndep fun c : isotypicComponents R R ↦ c.1 :=
     (sSupIndep_iff _).mp (sSupIndep_isotypicComponents R R)
   -- The chosen elements are linearly independent over `k`, one from each independent summand.
@@ -148,10 +147,12 @@ theorem card_isotypicComponents_le_finrank_center [Module.Finite k (Subalgebra.c
         c.1.smul_mem (algebraMap k R (g c)) (hmem c)
     have hzero := (iSupIndep_iff_finsetSum_eq_zero_imp_eq_zero _).mp hind s
       (fun c ↦ g c • e c) hmem' hg i hi
-    by_contra hgi
-    exact hne i (by rw [← one_smul k (e i), ← inv_mul_cancel₀ hgi, mul_smul, hzero, smul_zero])
+    have : Nontrivial R := nontrivial_of_ne _ _ (hne i)
+    exact (smul_eq_zero.mp hzero).resolve_right (hne i)
   -- Read the independence inside the center and count.
-  have hli' : LinearIndependent k fun c ↦ (⟨e c, hcen c⟩ : Subalgebra.center k R) :=
+  have hli' : LinearIndependent k
+      fun c ↦ (⟨e c, Subalgebra.mem_center_iff.mpr (Semigroup.mem_center_iff.mp (hcen c))⟩ :
+        Subalgebra.center k R) :=
     LinearIndependent.of_comp (Subalgebra.center k R).val.toLinearMap hli
   simpa using hli'.fintype_card_le_finrank
 


### PR DESCRIPTION
This PR proves that the Specht modules exhaust the irreducible rational representations of the symmetric group. `TauCeti.partitionEquivSimpleSubmoduleClasses` makes `μ ↦ S^μ` a bijection from `Nat.Partition n` onto the isomorphism classes of simple `ℚ[Sₙ]`-modules, with `TauCeti.exists_nonempty_linearEquiv_spechtModule` and `TauCeti.exists_nonempty_equiv_spechtModule` as the two readings of surjectivity: every simple `ℚ[Sₙ]`-module, and every irreducible rational representation of `Sₙ`, is a Specht module. Irreducibility (`TauCeti.isIrreducible_spechtModule`) and irredundancy (`TauCeti.spechtModule_iso_iff`) were already in the repository; what was missing was that there are no others.

Only counting was left, and this PR proves the count in the generality it holds rather than over a splitting field. For a semisimple `k`-algebra `R` whose center is finite-dimensional, `TauCeti.card_isotypicComponents_le_finrank_center` bounds the isomorphism classes of simple `R`-modules by `finrank k (Subalgebra.center k R)`. The argument chooses no Wedderburn presentation: the isotypic components of the regular module are two-sided ideals (Mathlib's `isFullyInvariant_iff_isTwoSided` read through `Submodule.IsFullyInvariant.of_mem_isotypicComponents`), so the summands of `1 = ∑_c e_c` along the decomposition of `R` are central (`TauCeti.exists_mem_ne_zero_mem_center_of_mem_isotypicComponents`, a statement about a semisimple ring, with no base field in sight), and they are nonzero because `x * e_c = x` for `x ∈ c`; being one from each summand of an independent family they are linearly independent. Combined with the class-sum basis of the center (`TauCeti.finrank_center_monoidAlgebra`), this gives `TauCeti.card_simpleSubmoduleClasses_le_card_conjClasses`: a finite group has at most as many irreducibles as conjugacy classes, over *any* field for which the group algebra is semisimple. The Specht modules already saturate that bound over `ℚ`, so the injection is a bijection.

The roadmap sketches completeness the other way round, over `ℂ` first by character theory and then descending to `ℚ`; that route needs absolute irreducibility, `End_{ℚ[Sₙ]} S^μ ≅ ℚ`, which the roadmap itself files under Layer 5 and which is not available. The bound used here is not a splitting-field statement, so it settles the `ℚ` classification directly and leaves absolute irreducibility as the separate milestone it is. Passing between the two notions of isomorphism needed a dictionary Mathlib does not state — `Representation.IntertwiningMap.equivLinearMapAsModule` matches intertwining *maps* with `k[G]`-linear maps but not isomorphisms with isomorphisms — so `TauCeti.Representation.equivEquivAsModuleLinearEquiv`, `TauCeti.Representation.nonempty_equiv_iff` and `TauCeti.fdRepIsoOfAsModuleLinearEquiv` supply it.

Milestone: Layer 4 of the Schur-Weyl roadmap, "completeness and irreducibility (the classification)", whose "Distinctness and completeness" item asks that `μ ↦ spechtModule μ` be a bijection from `Nat.Partition n` to the isomorphism classes of irreducibles; this closes the `ℚ` half. The prerequisite count is the Layer 2 item of the character-theory roadmap ("#irreducibles = #conjugacy classes"), which consumes that roadmap's Layer 1 item "the class sums are a basis of the center"; on the semisimple-algebras roadmap it is served by the Layer 1 item "the isotypic decomposition as counted data", the counting spine that roadmap directs at exactly this character-theory use. What remains on Layer 4 is absolute irreducibility and the resulting `ℂ` classification, Young's rule, and the identification of `S^{(n-1,1)}` with the standard representation.

New files: `TauCeti/RingTheory/Semisimple/CenterDimension.lean` (161 lines), `TauCeti/RepresentationTheory/AsModule.lean` (142), `TauCeti/RepresentationTheory/CharacterTable/SimpleModuleCount.lean` (71), `TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean` (145). No existing module was changed, nothing was vendored from Mathlib, and no material was taken from the supplementary source snapshot.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"specht-modules-exhaust-simple-modules"}-->

🤖 Prepared with Claude Code
