### PR TITLE
refactor(RootSystem): name the linearity of a vanishing-second-difference sequence

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -445,6 +445,26 @@ private lemma sub_mem_closure_of_le {M : Type*} [AddCommGroup M] (f : ℕ → M)
   have : i < n := lt_of_lt_of_le (Finset.mem_Ico.mp hi).2 hb
   exact ⟨⟨i, this⟩, rfl⟩
 
+/-- **A sequence with vanishing second difference is linear.** If `S 0 = 0` and
+`S (k + 1) + S (k + 1) = S k + S (k + 2)` for every `k < n`, then `S j = j * S 1` for every
+`j ≤ n + 1`. -/
+private lemma eq_natCast_mul_of_second_difference_zero {S : ℕ → ℤ} {n : ℕ} (hS0 : S 0 = 0)
+    (hrec : ∀ k < n, S (k + 1) + S (k + 1) = S k + S (k + 2)) :
+    ∀ j ≤ n + 1, S j = j * S 1 := by
+  intro j
+  induction j using Nat.strong_induction_on with
+  | _ j ih =>
+    match j with
+    | 0 => intro _; simpa using hS0
+    | 1 => intro _; simp
+    | (m + 2) =>
+      intro hm
+      have h0 := ih m (by omega) (by omega)
+      have h1 := ih (m + 1) (by omega) (by omega)
+      have h2 := hrec m (by omega)
+      push_cast at h0 h1 ⊢
+      linarith
+
 /-- The simple roots of type `Aₙ` are linearly independent. A relation among the rows of
 `CartanMatrix.A n` forces its coefficients to grow linearly, and the missing row past the last node
 then makes the common ratio `(n + 1)`-torsion, hence zero. -/
@@ -475,21 +495,8 @@ private lemma linearIndependent_typeASimpleRoot (n : ℕ) :
     have e2 : ∑ j : Fin n, (if (j : ℕ) + 1 = (k : ℕ) + 1 then g j else 0) = S ((k : ℕ) + 1) := rfl
     rw [e1, e2] at h
     linarith [h]
-  have key : ∀ j : ℕ, j ≤ n + 1 → S j = j * S 1 := by
-    intro j
-    induction j using Nat.strong_induction_on with
-    | _ j ih =>
-      match j with
-      | 0 => intro _; simpa using hS0
-      | 1 => intro _; simp
-      | (m + 2) =>
-        intro hm
-        have hmn : m < n := by omega
-        have h0 := ih m (by omega) (by omega)
-        have h1 := ih (m + 1) (by omega) (by omega)
-        have h2 : S (m + 1) + S (m + 1) = S m + S (m + 2) := hrec ⟨m, hmn⟩
-        push_cast at h0 h1 ⊢
-        linarith
+  have key : ∀ j : ℕ, j ≤ n + 1 → S j = j * S 1 :=
+    eq_natCast_mul_of_second_difference_zero hS0 fun k hk => hrec ⟨k, hk⟩
   have hS1 : S 1 = 0 := by
     have h := key (n + 1) le_rfl
     rw [hSzero (n + 1) (by omega)] at h

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -445,12 +445,12 @@ private lemma sub_mem_closure_of_le {M : Type*} [AddCommGroup M] (f : ℕ → M)
   have : i < n := lt_of_lt_of_le (Finset.mem_Ico.mp hi).2 hb
   exact ⟨⟨i, this⟩, rfl⟩
 
-/-- **A sequence with vanishing second difference is linear.** If `S 0 = 0` and
-`S (k + 1) + S (k + 1) = S k + S (k + 2)` for every `k < n`, then `S j = j * S 1` for every
-`j ≤ n + 1`. -/
-private lemma eq_natCast_mul_of_second_difference_zero {S : ℕ → ℤ} {n : ℕ} (hS0 : S 0 = 0)
-    (hrec : ∀ k < n, S (k + 1) + S (k + 1) = S k + S (k + 2)) :
-    ∀ j ≤ n + 1, S j = j * S 1 := by
+/-- **A sequence with vanishing second difference is linear.** In an additive cancellative
+commutative monoid, if `S 0 = 0` and `S (k + 1) + S (k + 1) = S k + S (k + 2)` for every `k < n`,
+then `S j = j • S 1` for every `j ≤ n + 1`. -/
+private lemma eq_nsmul_of_second_difference_zero {M : Type*} [AddCancelCommMonoid M] {S : ℕ → M}
+    {n : ℕ} (hS0 : S 0 = 0) (hrec : ∀ k < n, S (k + 1) + S (k + 1) = S k + S (k + 2)) :
+    ∀ j ≤ n + 1, S j = j • S 1 := by
   intro j
   induction j using Nat.strong_induction_on with
   | _ j ih =>
@@ -462,8 +462,13 @@ private lemma eq_natCast_mul_of_second_difference_zero {S : ℕ → ℤ} {n : �
       have h0 := ih m (by omega) (by omega)
       have h1 := ih (m + 1) (by omega) (by omega)
       have h2 := hrec m (by omega)
-      push_cast at h0 h1 ⊢
-      linarith
+      -- the recurrence reads `(m + 1) • S 1 + (m + 1) • S 1 = m • S 1 + S (m + 2)`, and both
+      -- sides carry the summand `m • S 1`
+      rw [h0, h1] at h2
+      refine add_left_cancel (a := m • S 1) ?_
+      rw [← h2, ← add_smul, ← add_smul]
+      congr 1
+      omega
 
 /-- The simple roots of type `Aₙ` are linearly independent. A relation among the rows of
 `CartanMatrix.A n` forces its coefficients to grow linearly, and the missing row past the last node
@@ -495,8 +500,9 @@ private lemma linearIndependent_typeASimpleRoot (n : ℕ) :
     have e2 : ∑ j : Fin n, (if (j : ℕ) + 1 = (k : ℕ) + 1 then g j else 0) = S ((k : ℕ) + 1) := rfl
     rw [e1, e2] at h
     linarith [h]
-  have key : ∀ j : ℕ, j ≤ n + 1 → S j = j * S 1 :=
-    eq_natCast_mul_of_second_difference_zero hS0 fun k hk => hrec ⟨k, hk⟩
+  have key : ∀ j : ℕ, j ≤ n + 1 → S j = j * S 1 := fun j hj => by
+    simpa [nsmul_eq_mul] using
+      eq_nsmul_of_second_difference_zero hS0 (fun k hk => hrec ⟨k, hk⟩) j hj
   have hS1 : S 1 = 0 := by
     have h := key (n + 1) le_rfl
     rw [hSzero (n + 1) (by omega)] at h


### PR DESCRIPTION
`linearIndependent_typeASimpleRoot` proves linear independence by extracting a sequence `S` of coefficients from a relation among the rows of the Cartan matrix, showing `S` grows linearly, and then using the missing row past the last node to make the common ratio `(n + 1)`-torsion. The middle step — that `S` is linear — took seventeen of its fifty lines, and is a fact about sequences with nothing about root systems in it.

`eq_nsmul_of_second_difference_zero` states it: in an additive cancellative commutative monoid, if `S 0 = 0` and

```
S (k + 1) + S (k + 1) = S k + S (k + 2)
```

for every `k < n`, then `S j = j • S 1` for every `j ≤ n + 1`. That hypothesis is the vanishing of the second difference, and the conclusion is that such a sequence is linear.

Nothing in the argument uses the integers: the recurrence rearranges to `m • S 1 + (m + 2) • S 1 = m • S 1 + S (m + 2)`, and the induction step is the cancellation of the common summand. So the lemma is stated over `[AddCancelCommMonoid M]`, and the parent instantiates it at `M := ℤ`, converting `j • S 1` to `j * S 1` with `nsmul_eq_mul`.

Its hypotheses are re-derived rather than inherited. At the extraction point the parent has the coefficient family `g`, the weights `typeAWeight`, the relation `hg`, and the auxiliary facts `hSval`, `hSzero` and `hshift` all in scope; none of them appear. The recurrence is taken as `∀ k < n` rather than the parent's `∀ k : Fin n`, so the lemma needs no `Fin` at all, and the parent supplies `fun k hk => hrec ⟨k, hk⟩`.

Both degenerate ends hold on their own terms: at `j = 0` the conclusion is the hypothesis `S 0 = 0`, and at `n = 0` the recurrence hypothesis is vacuous while the range `j ≤ 1` leaves only the two base cases.

The parent drops from 50 lines to 38, and the linearity step becomes a single application. `hSzero` stays where it is — it is what makes the ratio torsion, which is the part of the argument that is genuinely about the missing row.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: ReductiveGroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
