### PR TITLE
refactor(Compact): name the symmetric bump on a symmetric neighbourhood

### DIFF
--- a/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
+++ b/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
@@ -182,8 +182,7 @@ omit [CompactSpace G] [MeasurableSpace G] [BorelSpace G] in
 /-- **A symmetric open neighbourhood of the identity carries a symmetric bump.** If `W` is open,
 contains `1`, and is closed under inversion, then some continuous real function is nonnegative,
 invariant under inversion, vanishes off `W`, and is positive at `1`. -/
-private theorem exists_symmetric_bump [RegularSpace G] [LocallyCompactSpace G] {W : Set G}
-    (hWopen : IsOpen W)
+private theorem exists_symmetric_bump [LocallyCompactSpace G] {W : Set G} (hWopen : IsOpen W)
     (hW1 : (1 : G) ∈ W) (hWsymm : ∀ g ∈ W, g⁻¹ ∈ W) :
     ∃ ψ : C(G, ℝ), (∀ g, 0 ≤ ψ g) ∧ (∀ g, ψ g⁻¹ = ψ g) ∧ (∀ g ∉ W, ψ g = 0) ∧ 0 < ψ 1 := by
   obtain ⟨φ, hφ1, hφ0, -, hφIcc⟩ :=

--- a/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
+++ b/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
@@ -178,6 +178,28 @@ theorem integral_norm_eq_one (h : IsMollifier U k) : ∫ g, ‖k g‖ ∂(haarPr
 
 end IsMollifier
 
+omit [MeasurableSpace G] [BorelSpace G] in
+/-- **A symmetric open neighbourhood of the identity carries a symmetric bump.** If `W` is open,
+contains `1`, and is closed under inversion, then some continuous real function is nonnegative,
+invariant under inversion, vanishes off `W`, and is positive at `1`. -/
+private theorem exists_symmetric_bump [T2Space G] {W : Set G} (hWopen : IsOpen W)
+    (hW1 : (1 : G) ∈ W) (hWsymm : ∀ g ∈ W, g⁻¹ ∈ W) :
+    ∃ ψ : C(G, ℝ), (∀ g, 0 ≤ ψ g) ∧ (∀ g, ψ g⁻¹ = ψ g) ∧ (∀ g ∉ W, ψ g = 0) ∧ 0 < ψ 1 := by
+  obtain ⟨φ, hφ1, hφ0, -, hφIcc⟩ :=
+    exists_continuous_one_zero_of_isCompact (X := G) isCompact_singleton hWopen.isClosed_compl
+      (disjoint_compl_right_iff_subset.2 (singleton_subset_iff.2 hW1))
+  -- symmetrize the Urysohn bump by adding its composition with inversion
+  refine ⟨φ + φ.comp ⟨Inv.inv, continuous_inv⟩, fun g => ?_, fun g => ?_, fun g hg => ?_, ?_⟩
+  · exact add_nonneg (hφIcc g).1 (hφIcc g⁻¹).1
+  · change φ g⁻¹ + φ g⁻¹⁻¹ = φ g + φ g⁻¹
+    rw [inv_inv, add_comm]
+  · have hg' : g⁻¹ ∉ W := fun hc => hg (by simpa using hWsymm _ hc)
+    change φ g + φ g⁻¹ = 0
+    simp only [hφ0 hg, hφ0 hg', Pi.zero_apply, add_zero]
+  · change 0 < φ 1 + φ 1⁻¹
+    rw [inv_one, hφ1 rfl]
+    norm_num
+
 variable (𝕜) in
 /-- **Mollifying kernels exist, supported in any prescribed neighbourhood of the identity.**
 
@@ -195,28 +217,13 @@ theorem exists_isMollifier [T2Space G] {U : Set G} (hU : U ∈ 𝓝 (1 : G)) :
   have hWsymm : ∀ g : G, g ∈ W → g⁻¹ ∈ W := by
     rintro g ⟨h1, h2⟩
     exact ⟨by simpa using h2, by simpa using h1⟩
-  obtain ⟨φ, hφ1, hφ0, -, hφIcc⟩ :=
-    exists_continuous_one_zero_of_isCompact (X := G) isCompact_singleton hWopen.isClosed_compl
-      (disjoint_compl_right_iff_subset.2 (singleton_subset_iff.2 hW1))
-  -- Symmetrize the bump.
-  set ψ : C(G, ℝ) := φ + φ.comp ⟨Inv.inv, continuous_inv⟩
-  have hψ_apply : ∀ g : G, ψ g = φ g + φ g⁻¹ := fun _ => rfl
-  have hψ_nonneg : ∀ g : G, 0 ≤ ψ g := fun g => by
-    rw [hψ_apply]
-    exact add_nonneg (hφIcc g).1 (hφIcc g⁻¹).1
-  have hψ_inv : ∀ g : G, ψ g⁻¹ = ψ g := fun g => by
-    rw [hψ_apply, hψ_apply, inv_inv, add_comm]
-  have hψ_zero : ∀ g ∉ W, ψ g = 0 := fun g hg => by
-    have hg' : g⁻¹ ∉ W := fun hc => hg (by simpa using hWsymm _ hc)
-    simp only [hψ_apply, hφ0 hg, hφ0 hg', Pi.zero_apply, add_zero]
-  have hψ_one : ψ 1 = 2 := by
-    rw [hψ_apply, inv_one, hφ1 rfl]
-    norm_num
+  obtain ⟨ψ, hψ_nonneg, hψ_inv, hψ_zero, hψ_one⟩ := exists_symmetric_bump hWopen hW1 hWsymm
   -- Its mass is positive, so it can be normalized.
   have hψ_int : Integrable ψ (haarProb G) := integrable_continuousMap G ψ
   have hmass : 0 < ∫ g, ψ g ∂(haarProb G) := by
     refine (integral_pos_iff_support_of_nonneg hψ_nonneg hψ_int).2 ?_
-    exact ψ.continuous.isOpen_support.measure_pos _ ⟨1, by simp [Function.mem_support, hψ_one]⟩
+    exact ψ.continuous.isOpen_support.measure_pos _
+      ⟨1, by simp [Function.mem_support, hψ_one.ne']⟩
   set c : ℝ := ∫ g, ψ g ∂(haarProb G) with hcdef
   refine ⟨⟨fun g => ((c⁻¹ * ψ g : ℝ) : 𝕜),
     RCLike.continuous_ofReal.comp (continuous_const.mul ψ.continuous)⟩, ?_, ?_, ?_, ?_⟩

--- a/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
+++ b/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
@@ -178,11 +178,12 @@ theorem integral_norm_eq_one (h : IsMollifier U k) : ∫ g, ‖k g‖ ∂(haarPr
 
 end IsMollifier
 
-omit [MeasurableSpace G] [BorelSpace G] in
+omit [CompactSpace G] [MeasurableSpace G] [BorelSpace G] in
 /-- **A symmetric open neighbourhood of the identity carries a symmetric bump.** If `W` is open,
 contains `1`, and is closed under inversion, then some continuous real function is nonnegative,
 invariant under inversion, vanishes off `W`, and is positive at `1`. -/
-private theorem exists_symmetric_bump [T2Space G] {W : Set G} (hWopen : IsOpen W)
+private theorem exists_symmetric_bump [RegularSpace G] [LocallyCompactSpace G] {W : Set G}
+    (hWopen : IsOpen W)
     (hW1 : (1 : G) ∈ W) (hWsymm : ∀ g ∈ W, g⁻¹ ∈ W) :
     ∃ ψ : C(G, ℝ), (∀ g, 0 ≤ ψ g) ∧ (∀ g, ψ g⁻¹ = ψ g) ∧ (∀ g ∉ W, ψ g = 0) ∧ 0 < ψ 1 := by
   obtain ⟨φ, hφ1, hφ0, -, hφIcc⟩ :=
@@ -190,14 +191,15 @@ private theorem exists_symmetric_bump [T2Space G] {W : Set G} (hWopen : IsOpen W
       (disjoint_compl_right_iff_subset.2 (singleton_subset_iff.2 hW1))
   -- symmetrize the Urysohn bump by adding its composition with inversion
   refine ⟨φ + φ.comp ⟨Inv.inv, continuous_inv⟩, fun g => ?_, fun g => ?_, fun g hg => ?_, ?_⟩
-  · exact add_nonneg (hφIcc g).1 (hφIcc g⁻¹).1
-  · change φ g⁻¹ + φ g⁻¹⁻¹ = φ g + φ g⁻¹
-    rw [inv_inv, add_comm]
+  · simpa only [ContinuousMap.add_apply, ContinuousMap.comp_apply, ContinuousMap.coe_mk] using
+      add_nonneg (hφIcc g).1 (hφIcc g⁻¹).1
+  · simp only [ContinuousMap.add_apply, ContinuousMap.comp_apply, ContinuousMap.coe_mk, inv_inv]
+    exact add_comm _ _
   · have hg' : g⁻¹ ∉ W := fun hc => hg (by simpa using hWsymm _ hc)
-    change φ g + φ g⁻¹ = 0
-    simp only [hφ0 hg, hφ0 hg', Pi.zero_apply, add_zero]
-  · change 0 < φ 1 + φ 1⁻¹
-    rw [inv_one, hφ1 rfl]
+    simp only [ContinuousMap.add_apply, ContinuousMap.comp_apply, ContinuousMap.coe_mk,
+      hφ0 hg, hφ0 hg', Pi.zero_apply, add_zero]
+  · simp only [ContinuousMap.add_apply, ContinuousMap.comp_apply, ContinuousMap.coe_mk, inv_one,
+      hφ1 rfl]
     norm_num
 
 variable (𝕜) in


### PR DESCRIPTION
`exists_isMollifier` builds a mollifying kernel in three moves: shrink the given neighbourhood to a symmetric open one, build a bump there that is symmetric under inversion, and normalise it by its Haar mass. The middle move took eighteen of its forty-three lines and involves no measure at all.

`exists_symmetric_bump` states it: a symmetric open neighbourhood of the identity carries a continuous real function that is nonnegative, invariant under inversion, vanishes off the neighbourhood, and is positive at `1`.

Bundling the four properties into one existence statement is what lets the parent drop the intermediate `ψ` entirely — it now `obtain`s the bump together with everything it needs, and the Urysohn construction and its symmetrisation stay inside the helper.

Its hypotheses are re-derived rather than inherited. The parent has `U`, `V`, the containment `hWU`, the ambient `𝕜`, and the Haar measure all in scope; the helper takes only that `W` is open, contains `1`, and is closed under inversion. `[CompactSpace G]`, `[MeasurableSpace G]` and `[BorelSpace G]` are `omit`ted, and `[T2Space G]` is replaced by `[LocallyCompactSpace G]` — the statement is purely topological. `exists_continuous_one_zero_of_isCompact` asks for regularity too, but a topological group is regular already (`IsTopologicalGroup.regularSpace`), so only local compactness has to be assumed; the caller supplies it by instance resolution from compactness.

The conclusion is weakened where the parent was specific: it asserts `0 < ψ 1` rather than the `ψ 1 = 2` the construction happens to give, since positivity is all the mass argument uses.

The parent drops from 43 lines to 28, leaving the neighbourhood shrinking and the normalisation.

The four coordinate steps go through `ContinuousMap.add_apply`, `ContinuousMap.comp_apply` and `ContinuousMap.coe_mk` rather than definitional unfolding, so nothing rests on how `φ + φ.comp ⟨Inv.inv, _⟩` happens to be represented.

Gates run locally: `lake build` (7267 jobs), `lake exe axioms` (33977 declarations), `lake exe module-system` (1684 modules), `scripts/lint-env.sh` — all green.

Roadmap: RepresentationTheory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

