### PR TITLE
feat: the incoming sum at a sink is onto on an indecomposable

### DIFF
--- a/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
+++ b/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.CategoryTheory.Idempotents.Basic
 public import Mathlib.CategoryTheory.Limits.Shapes.BinaryBiproducts
 public import Mathlib.CategoryTheory.Linear.Basic
+public import Mathlib.CategoryTheory.Preadditive.Biproducts
 public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 
 /-!
@@ -20,9 +22,13 @@ this file supplies — an object all of whose idempotent endomorphisms are trivi
 indecomposable — together with the form in which it is used in practice: over a field, an object
 whose endomorphism space is one-dimensional (a *brick*) is indecomposable.
 
-Only one direction is proved. The converse needs a decomposition `X ≅ im e ⊞ ker e` attached to an
-idempotent `e`, that is, idempotent completeness of the ambient category, which is a genuinely
-extra hypothesis and is not needed by any consumer here.
+The converse holds as soon as idempotents split, that is, over an idempotent-complete category
+(`CategoryTheory.IsIdempotentComplete`, which every abelian category is): splitting `e` and `𝟙 - e`
+produces two retracts of `X` whose idempotents add up to the identity, and any such pair realizes
+`X` as their biproduct. So over such a category an object is indecomposable exactly when it is
+nonzero and carries no idempotent endomorphism other than `0` and the identity, which is the form
+in which indecomposability is *used*: it turns a decomposition of a vertex space into a
+decomposition of the whole object.
 
 ## Main results
 
@@ -30,6 +36,11 @@ extra hypothesis and is not needed by any consumer here.
   endomorphisms are `0` and the identity is indecomposable.
 * `TauCeti.indecomposable_of_finrank_end_eq_one`: in a `k`-linear category over a field,
   **a brick is indecomposable**.
+* `TauCeti.isoBiprodOfRetracts`: two retracts of `X` whose idempotents sum to the identity exhibit
+  `X` as their biproduct.
+* `TauCeti.idempotent_eq_zero_or_id_of_indecomposable`: the converse of the first criterion, over
+  an idempotent-complete category, packaged with it as
+  `TauCeti.indecomposable_iff_idempotent_eq_zero_or_id`.
 
 ## Implementation notes
 
@@ -49,6 +60,12 @@ applied to the identity, which spans the endomorphism space because it is nonzer
 The brick criterion is stated for a field. The argument itself only inverts one scalar, so it
 would run over a division ring, but `CategoryTheory.Linear` takes a commutative base and
 `Module.finrank` is the invariant used by the consumers, so no generality is lost in practice.
+
+`isoBiprodOfRetracts` asks only for the two retractions and the identity `r₁ ≫ i₁ + r₂ ≫ i₂ = 𝟙 X`;
+the orthogonality relations `i₁ ≫ r₂ = 0` and `i₂ ≫ r₁ = 0` that make the comparison map an
+isomorphism are consequences, extracted by cancelling the split monomorphisms `i₁` and `i₂`. Stating
+it this way keeps it usable from any source of complementary idempotents, not only from
+`CategoryTheory.IsIdempotentComplete.idempotents_split`.
 -/
 
 public section
@@ -79,6 +96,58 @@ theorem indecomposable_of_idempotent_eq_zero_or_id [HasBinaryBiproducts C] {X : 
     -- Framing instead with `biprod.inr`, `biprod.snd` kills the idempotent and leaves `𝟙 Z`.
     have := congrArg (fun f : X ⟶ X ↦ biprod.inr ≫ i.inv ≫ f ≫ i.hom ≫ biprod.snd) h1
     simpa using this.symm
+
+/-- **Two retracts whose idempotents sum to the identity split an object as a biproduct.** The
+comparison map is `biprod.lift r₁ r₂`, with inverse `biprod.desc i₁ i₂`; one composite is the
+hypothesis `r₁ ≫ i₁ + r₂ ≫ i₂ = 𝟙 X`, and the other is the identity because the two retracts are
+orthogonal, `i₁ ≫ r₂ = 0` and `i₂ ≫ r₁ = 0`. -/
+noncomputable def isoBiprodOfRetracts [HasBinaryBiproducts C] {X Y Z : C} (i₁ : Y ⟶ X) (r₁ : X ⟶ Y)
+    (i₂ : Z ⟶ X) (r₂ : X ⟶ Z) (h₁ : i₁ ≫ r₁ = 𝟙 Y) (h₂ : i₂ ≫ r₂ = 𝟙 Z)
+    (h : r₁ ≫ i₁ + r₂ ≫ i₂ = 𝟙 X) : X ≅ Y ⊞ Z := by
+  -- `i₁` and `i₂` are split monomorphisms, so orthogonality can be checked after composing with
+  -- them, where the hypothesis `h` and the two retraction identities settle it.
+  haveI : IsSplitMono i₁ := ⟨⟨r₁, h₁⟩⟩
+  haveI : IsSplitMono i₂ := ⟨⟨r₂, h₂⟩⟩
+  have horth₁ : i₁ ≫ r₂ = 0 := by
+    have key : i₁ ≫ (r₁ ≫ i₁ + r₂ ≫ i₂) = i₁ := by rw [h, Category.comp_id]
+    rw [Preadditive.comp_add, ← Category.assoc, h₁, Category.id_comp] at key
+    rw [← cancel_mono i₂, Category.assoc]
+    simpa using key
+  have horth₂ : i₂ ≫ r₁ = 0 := by
+    have key : i₂ ≫ (r₁ ≫ i₁ + r₂ ≫ i₂) = i₂ := by rw [h, Category.comp_id]
+    rw [Preadditive.comp_add, ← Category.assoc (f := i₂) (g := r₂), h₂, Category.id_comp] at key
+    rw [← cancel_mono i₁, Category.assoc]
+    simpa using key
+  exact
+    { hom := biprod.lift r₁ r₂
+      inv := biprod.desc i₁ i₂
+      hom_inv_id := by rw [biprod.lift_desc, h]
+      inv_hom_id := by
+        refine biprod.hom_ext' _ _ (biprod.hom_ext _ _ ?_ ?_) (biprod.hom_ext _ _ ?_ ?_) <;>
+          simp [h₁, h₂, horth₁, horth₂] }
+
+/-- **An indecomposable object has no nontrivial idempotent endomorphism**, as soon as idempotents
+split. Splitting `e` and `𝟙 X - e` writes `X` as a biproduct of the two retracts, and
+indecomposability makes one of them zero: the first vanishing forces `e = 0`, the second `e = 𝟙 X`.
+This is the converse of `TauCeti.indecomposable_of_idempotent_eq_zero_or_id`. -/
+theorem idempotent_eq_zero_or_id_of_indecomposable [HasBinaryBiproducts C] [IsIdempotentComplete C]
+    {X : C} (hX : Indecomposable X) {e : X ⟶ X} (he : e ≫ e = e) : e = 0 ∨ e = 𝟙 X := by
+  obtain ⟨Y, i₁, r₁, h₁, hr₁⟩ := IsIdempotentComplete.idempotents_split X e he
+  obtain ⟨Z, i₂, r₂, h₂, hr₂⟩ := IsIdempotentComplete.idempotents_split X (𝟙 X - e) (by
+    simp [Preadditive.sub_comp, Preadditive.comp_sub, he])
+  have hsum : r₁ ≫ i₁ + r₂ ≫ i₂ = 𝟙 X := by rw [hr₁, hr₂]; abel
+  rcases hX.2 Y Z (isoBiprodOfRetracts i₁ r₁ i₂ r₂ h₁ h₂ hsum) with hY | hZ
+  · exact Or.inl (by rw [← hr₁, hY.eq_of_tgt r₁ 0, Limits.zero_comp])
+  · refine Or.inr (sub_eq_zero.mp ?_).symm
+    rw [← hr₂, hZ.eq_of_tgt r₂ 0, Limits.zero_comp]
+
+/-- **Indecomposability is the triviality of the idempotent endomorphisms**, over a category in
+which idempotents split. -/
+theorem indecomposable_iff_idempotent_eq_zero_or_id [HasBinaryBiproducts C]
+    [IsIdempotentComplete C] {X : C} :
+    Indecomposable X ↔ ¬ IsZero X ∧ ∀ e : X ⟶ X, e ≫ e = e → e = 0 ∨ e = 𝟙 X :=
+  ⟨fun hX ↦ ⟨hX.1, fun _ he ↦ idempotent_eq_zero_or_id_of_indecomposable hX he⟩,
+    fun hX ↦ indecomposable_of_idempotent_eq_zero_or_id hX.1 hX.2⟩
 
 variable {k : Type*} [Field k] [Linear k C]
 

--- a/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
+++ b/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
@@ -97,10 +97,9 @@ theorem indecomposable_of_idempotent_eq_zero_or_id [HasBinaryBiproducts C] {X : 
     have := congrArg (fun f : X ⟶ X ↦ biprod.inr ≫ i.inv ≫ f ≫ i.hom ≫ biprod.snd) h1
     simpa using this.symm
 
-/-- **Two retracts whose idempotents sum to the identity split an object as a biproduct.** The
-comparison map is `biprod.lift r₁ r₂`, with inverse `biprod.desc i₁ i₂`; one composite is the
-hypothesis `r₁ ≫ i₁ + r₂ ≫ i₂ = 𝟙 X`, and the other is the identity because the two retracts are
-orthogonal, `i₁ ≫ r₂ = 0` and `i₂ ≫ r₁ = 0`. -/
+/-- **Two retracts whose idempotents sum to the identity split an object as a biproduct.** Its
+comparison map and inverse are read off by `TauCeti.isoBiprodOfRetracts_hom` and
+`TauCeti.isoBiprodOfRetracts_inv`. -/
 noncomputable def isoBiprodOfRetracts [HasBinaryBiproducts C] {X Y Z : C} (i₁ : Y ⟶ X) (r₁ : X ⟶ Y)
     (i₂ : Z ⟶ X) (r₂ : X ⟶ Z) (h₁ : i₁ ≫ r₁ = 𝟙 Y) (h₂ : i₂ ≫ r₂ = 𝟙 Z)
     (h : r₁ ≫ i₁ + r₂ ≫ i₂ = 𝟙 X) : X ≅ Y ⊞ Z := by
@@ -126,10 +125,26 @@ noncomputable def isoBiprodOfRetracts [HasBinaryBiproducts C] {X Y Z : C} (i₁ 
         refine biprod.hom_ext' _ _ (biprod.hom_ext _ _ ?_ ?_) (biprod.hom_ext _ _ ?_ ?_) <;>
           simp [h₁, h₂, horth₁, horth₂] }
 
+/-- The comparison map of `TauCeti.isoBiprodOfRetracts` is the pair of the two retractions. -/
+@[simp]
+theorem isoBiprodOfRetracts_hom [HasBinaryBiproducts C] {X Y Z : C} {i₁ : Y ⟶ X} {r₁ : X ⟶ Y}
+    {i₂ : Z ⟶ X} {r₂ : X ⟶ Z} {h₁ : i₁ ≫ r₁ = 𝟙 Y} {h₂ : i₂ ≫ r₂ = 𝟙 Z}
+    {h : r₁ ≫ i₁ + r₂ ≫ i₂ = 𝟙 X} :
+    (isoBiprodOfRetracts i₁ r₁ i₂ r₂ h₁ h₂ h).hom = biprod.lift r₁ r₂ :=
+  -- The parentheses are load-bearing: `isoBiprodOfRetracts` does not expose its body, and the
+  -- bare-`rfl` elaborator refuses to unfold a sealed definition, even in the defining module.
+  (rfl)
+
+/-- The inverse of `TauCeti.isoBiprodOfRetracts` is the pair of the two sections. -/
+@[simp]
+theorem isoBiprodOfRetracts_inv [HasBinaryBiproducts C] {X Y Z : C} {i₁ : Y ⟶ X} {r₁ : X ⟶ Y}
+    {i₂ : Z ⟶ X} {r₂ : X ⟶ Z} {h₁ : i₁ ≫ r₁ = 𝟙 Y} {h₂ : i₂ ≫ r₂ = 𝟙 Z}
+    {h : r₁ ≫ i₁ + r₂ ≫ i₂ = 𝟙 X} :
+    (isoBiprodOfRetracts i₁ r₁ i₂ r₂ h₁ h₂ h).inv = biprod.desc i₁ i₂ :=
+  (rfl)
+
 /-- **An indecomposable object has no nontrivial idempotent endomorphism**, as soon as idempotents
-split. Splitting `e` and `𝟙 X - e` writes `X` as a biproduct of the two retracts, and
-indecomposability makes one of them zero: the first vanishing forces `e = 0`, the second `e = 𝟙 X`.
-This is the converse of `TauCeti.indecomposable_of_idempotent_eq_zero_or_id`. -/
+split. This is the converse of `TauCeti.indecomposable_of_idempotent_eq_zero_or_id`. -/
 theorem idempotent_eq_zero_or_id_of_indecomposable [HasBinaryBiproducts C] [IsIdempotentComplete C]
     {X : C} (hX : Indecomposable X) {e : X ⟶ X} (he : e ≫ e = e) : e = 0 ∨ e = 𝟙 X := by
   obtain ⟨Y, i₁, r₁, h₁, hr₁⟩ := IsIdempotentComplete.idempotents_split X e he

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Basic.lean
@@ -37,6 +37,8 @@ and sources in finite acyclic quivers are proved in
 ## Main results
 
 * `TauCeti.Quiver.IsSink.isSource_reflect`: reflecting at a sink turns it into a source.
+* `TauCeti.Quiver.IsSink.path_self_eq_nil`: a closed path at a sink is the trivial one, with
+  `TauCeti.Quiver.IsSource.path_self_eq_nil` its dual.
 * `TauCeti.Quiver.hom_reflect_reflect`: reflecting twice at the same vertex restores the original
   arrows, so reflection at a vertex is an involution.
 
@@ -107,6 +109,22 @@ theorem IsSink.eq_of_path {i b : V} (h : IsSink i) (p : Path i b) : i = b := by
 
 /-- A path into a source is trivial, so it starts where it ends. -/
 theorem IsSource.eq_of_path {i a : V} (h : IsSource i) (p : Path a i) : a = i := by
+  cases p with
+  | nil => rfl
+  | cons _ e => exact (h.isEmpty_hom _).elim e
+
+/-- A closed path at a sink is the trivial one: its last arrow would have to be a loop at the
+sink. This is the form `TauCeti.Quiver.IsSink.eq_of_path` takes once its conclusion has been
+substituted, and it is what says that a sink acts on a representation only through the identity. -/
+theorem IsSink.path_self_eq_nil {i : V} (h : IsSink i) (p : Path i i) : p = Path.nil := by
+  cases p with
+  | nil => rfl
+  | cons q e =>
+    obtain rfl := h.eq_of_path q
+    exact h.isEmpty_hom_self.elim e
+
+/-- A closed path at a source is the trivial one. -/
+theorem IsSource.path_self_eq_nil {i : V} (h : IsSource i) (p : Path i i) : p = Path.nil := by
   cases p with
   | nil => rfl
   | cons _ e => exact (h.isEmpty_hom _).elim e

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Indecomposable.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Indecomposable.lean
@@ -152,11 +152,7 @@ private theorem sinkEndApp_naturality (hi : IsSink i)
 variable (M) in
 /-- **The endomorphism of `M` given by an endomorphism at a sink.** For a sink `i` of `Q` and a
 linear endomorphism `π` of `Mᵢ` fixing the image of every arrow into `i`, this is the endomorphism
-of `M` acting by `π` at `i` and by the identity at every other vertex.
-
-Naturality is exactly the two hypotheses: a path into `i` from another vertex ends with an arrow
-into `i`, so `π` fixes its image, and no path of positive length leaves a sink, so nothing is left
-to check in the other direction. -/
+of `M` acting by `π` at `i` and by the identity at every other vertex. -/
 noncomputable def sinkEnd (hi : IsSink i) (π : M.obj i →ₗ[k] M.obj i)
     (hπ : ∀ (b : Q) (e : b ⟶ i) (z : M.obj b), π ((M.map e.toPath).hom z) =
       (M.map e.toPath).hom z) : M ⟶ M where
@@ -207,6 +203,7 @@ theorem sinkEnd_comp_self (hidem : IsIdempotentElem π) :
   NatTrans.ext (funext fun a ↦ sinkEndApp_comp_self hidem a)
 
 /-- `TauCeti.sinkEnd` is the identity exactly when the endomorphism it is built from is. -/
+@[simp]
 theorem sinkEnd_eq_id_iff : sinkEnd M hi π hπ = 𝟙 M ↔ π = LinearMap.id := by
   refine ⟨fun h ↦ ?_, fun h ↦ NatTrans.ext (funext fun a ↦ sinkEndApp_eq_id h a)⟩
   have happ : (sinkEnd M hi π hπ).app i = 𝟙 (M.obj i) := by rw [h]; rfl
@@ -216,6 +213,7 @@ theorem sinkEnd_eq_id_iff : sinkEnd M hi π hπ = 𝟙 M ↔ π = LinearMap.id :
 /-- `TauCeti.sinkEnd` vanishes exactly when the endomorphism it is built from vanishes and the
 representation is concentrated at the sink: away from the sink it acts by the identity, which is
 zero only on a vanishing vertex space. -/
+@[simp]
 theorem sinkEnd_eq_zero_iff :
     sinkEnd M hi π hπ = 0 ↔ π = 0 ∧ ∀ a : Q, a ≠ i → Subsingleton (M.obj a) := by
   refine ⟨fun h ↦ ⟨?_, fun a ha ↦ ?_⟩,
@@ -240,11 +238,7 @@ private theorem isZero_of_forall_subsingleton (hall : ∀ a : Q, Subsingleton (M
 /-- **An idempotent at a sink of an indecomposable representation is trivial.** Let `i` be a sink
 of `Q` and `M` an indecomposable representation. An idempotent endomorphism of `Mᵢ` fixing the
 image of every arrow into `i` is either the identity, or zero — and in the second case `M` vanishes
-away from `i`.
-
-Indecomposability enters through `TauCeti.idempotent_eq_zero_or_id_of_indecomposable`: the category
-of representations is abelian, so idempotents split, and an idempotent endomorphism of an
-indecomposable object is trivial. -/
+away from `i`. -/
 theorem sinkIdempotent_eq_id_or_eq_zero_of_indecomposable (hi : IsSink i)
     (hM : Indecomposable M) (π : M.obj i →ₗ[k] M.obj i)
     (hπ : ∀ (b : Q) (e : b ⟶ i) (z : M.obj b), π ((M.map e.toPath).hom z) =
@@ -256,10 +250,8 @@ theorem sinkIdempotent_eq_id_or_eq_zero_of_indecomposable (hi : IsSink i)
   · exact Or.inr ((sinkEnd_eq_zero_iff (hi := hi) (hπ := hπ)).mp h)
   · exact Or.inl ((sinkEnd_eq_id_iff (hi := hi) (hπ := hπ)).mp h)
 
-/-- **An indecomposable representation concentrated at a sink is a line there.** Every subspace of
-the vertex space at a sink is a direct summand of it and, the representation vanishing elsewhere,
-splits off as a subrepresentation; so an indecomposable representation concentrated at a sink is
-spanned there by a single nonzero vector. -/
+/-- **An indecomposable representation concentrated at a sink is a line there**: its vertex space
+at the sink is spanned by a single nonzero vector. -/
 theorem exists_ne_zero_span_eq_top_of_forall_subsingleton (hi : IsSink i)
     (hM : Indecomposable M) (h : ∀ a : Q, a ≠ i → Subsingleton (M.obj a)) :
     ∃ y : M.obj i, y ≠ 0 ∧ Submodule.span k {y} = ⊤ := by
@@ -378,10 +370,7 @@ private theorem isIso_simpleRepHom_app (hi : IsSink i) {y : M.obj ((Paths.of Q).
       @ModuleCat.isZero_of_subsingleton k _ (M.obj a) (hsub a ha)
     exact ⟨0, hzs.eq_of_src _ _, hzm.eq_of_src _ _⟩
 
-/-- **An indecomposable representation concentrated at a sink is the vertex simple there.** It is a
-line at the sink by `TauCeti.exists_ne_zero_span_eq_top_of_forall_subsingleton`, and the morphism
-`TauCeti.simpleRepHom` attached to a spanning vector of that line is an isomorphism: at the sink it
-carries the generator to a spanning vector, and away from it both vertex spaces vanish. -/
+/-- **An indecomposable representation concentrated at a sink is the vertex simple there.** -/
 theorem nonempty_iso_simpleRep_of_forall_subsingleton (hi : IsSink i) (hM : Indecomposable M)
     (h : ∀ a : Q, a ≠ i → Subsingleton (M.obj a)) : Nonempty (M ≅ simpleRep k Q i) := by
   obtain ⟨y, hy, hspan⟩ := exists_ne_zero_span_eq_top_of_forall_subsingleton hi hM h

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Indecomposable.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Indecomposable.lean
@@ -1,0 +1,416 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.CategoryTheory.Abelian.FunctorCategory
+public import Mathlib.LinearAlgebra.Projection
+public import TauCeti.CategoryTheory.Preadditive.Indecomposable
+public import TauCeti.RepresentationTheory.Quiver.Reflection.Representation
+public import TauCeti.RepresentationTheory.Quiver.Representation.Simple
+
+/-!
+# Reflecting an indecomposable representation at a sink
+
+The Bernstein-Gelfand-Ponomarev reflection at a sink `i` replaces the vertex space `Mᵢ` by the
+kernel of the sum `TauCeti.incomingSum` of the arrows into `i`, and it acts on dimension vectors by
+the simple reflection `sᵢ` exactly when that sum is onto (`TauCeti.dimVector_reflectRep`). This file
+discharges that hypothesis: the sum of the arrows into a sink is onto for every indecomposable
+representation except the vertex simple `Sᵢ`, which is the representation the reflection
+annihilates.
+
+One construction does the work. No arrow leaves a sink, so a linear endomorphism `π` of `Mᵢ` that
+fixes the image of every arrow into `i` extends by the identity at the other vertices to an
+endomorphism `TauCeti.sinkEnd` of the whole representation, idempotent as soon as `π` is. The
+category of representations is abelian, hence idempotent complete, so an indecomposable object
+carries no idempotent endomorphism besides `0` and the identity
+(`TauCeti.idempotent_eq_zero_or_id_of_indecomposable`), and therefore `π` itself is `0` or the
+identity. Applied to the projection onto the range of the incoming sum along a complement, this
+says the range is all of `Mᵢ` unless `M` vanishes away from `i`; applied to the projection onto a
+line, it says a representation concentrated at a sink is a line there, hence is `Sᵢ`.
+
+## Main definitions
+
+* `TauCeti.sinkEnd`: the endomorphism of `M` acting by a given endomorphism of `Mᵢ` at a sink `i`
+  and by the identity elsewhere, with `TauCeti.sinkEnd_eq_id_iff` and
+  `TauCeti.sinkEnd_eq_zero_iff` recognizing when it is trivial.
+
+## Main results
+
+* `TauCeti.sinkIdempotent_eq_id_or_eq_zero_of_indecomposable`: an idempotent of `Mᵢ` fixing the
+  image of the arrows into a sink `i` of an indecomposable `M` is the identity, or is zero and `M`
+  vanishes away from `i`.
+* `TauCeti.exists_ne_zero_span_eq_top_of_forall_subsingleton` and
+  `TauCeti.nonempty_iso_simpleRep_of_forall_subsingleton`: an indecomposable representation
+  concentrated at a sink is a line there, hence isomorphic to the vertex simple.
+* `TauCeti.surjective_incomingSum_of_indecomposable`: **the sum of the arrows into a sink is onto
+  for every indecomposable representation not isomorphic to the vertex simple there.**
+* `TauCeti.dimVector_reflectRep_of_indecomposable`: consequently the reflection at a sink acts on
+  the dimension vector of such a representation by the simple reflection at that vertex.
+
+## Implementation notes
+
+`TauCeti.sinkEnd` takes its hypothesis on `π` in the form "`π` fixes the image of each arrow into
+`i`" rather than "`π` fixes the range of `TauCeti.incomingSum`". The two agree on a finite quiver,
+by `TauCeti.map_toPath_mem_range_incomingSum`, but the arrow form needs no finiteness, and neither
+then do the construction, its recognition lemmas, or the statement that an indecomposable
+representation concentrated at a sink is a line there. Finiteness enters only where
+`TauCeti.incomingSum` does.
+
+The results comparing `M` with `TauCeti.simpleRep k Q i` are stated in the last section, where the
+quiver, its arrows and the field all live in one universe. This is forced, not chosen: the vertex
+spaces of a reflected representation are cut out of a product indexed by the arrows, so
+`TauCeti.reflectRep` needs them in `max v w x`, while `Sᵢ` puts the field itself at `i` and so
+needs them in the universe of the field. A statement mentioning both therefore has to identify the
+two, and the general statements above -- which name no vertex simple -- are proved in the wider
+setting and specialize to it.
+
+As in the neighbouring files, a vertex `i : Q` is used as an object of the free category
+`CategoryTheory.Paths Q`, which is `Q` only by unfolding a semireducible definition. Rewriting
+cannot see through that identification, so every step that branches on equality of vertices is
+factored through a lemma quantified over `Q`, and the components of `TauCeti.sinkEnd` are supplied
+by the private `sinkEndApp`; `TauCeti.sinkEnd_app_self` and `TauCeti.sinkEnd_app_of_ne` are the
+interface.
+
+## References
+
+This is the Layer 4 identity `dim (C⁺ᵢ M) = sᵢ · dim M` of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md` with its hypothesis
+discharged, and the input to the second milestone of that roadmap's Layer 5, that reflection
+preserves indecomposability away from `Sᵢ`. See Bernstein--Gelfand--Ponomarev, *Coxeter functors
+and Gabriel's theorem*, and Derksen--Weyman, *An Introduction to Quiver Representations*, Ch. 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+open _root_.TauCeti.Quiver
+
+universe u v w x
+
+section General
+
+variable {k : Type u} {Q : Type v} [Field k] [Quiver.{w} Q]
+variable {M : QuiverRep.{u, v, w, max v w x} k Q} {i : Q}
+
+/-! ### The endomorphism attached to an idempotent at a sink -/
+
+section SinkEnd
+
+variable {π : M.obj i →ₗ[k] M.obj i}
+
+variable (M π) in
+open scoped Classical in
+/-- The vertex components of `TauCeti.sinkEnd`: the given endomorphism at `i`, the identity
+elsewhere. -/
+private noncomputable def sinkEndApp (a : Q) : M.obj a ⟶ M.obj a :=
+  if h : a = i then eqToHom (by rw [h]) ≫ ModuleCat.ofHom π ≫ eqToHom (by rw [h])
+  else 𝟙 (M.obj a)
+
+@[simp]
+private theorem sinkEndApp_self : sinkEndApp M π i = ModuleCat.ofHom π := by
+  classical
+  simp only [sinkEndApp, dif_pos rfl, eqToHom_refl, Category.id_comp, Category.comp_id]
+
+@[simp]
+private theorem sinkEndApp_of_ne {a : Q} (ha : a ≠ i) : sinkEndApp M π a = 𝟙 (M.obj a) := by
+  classical
+  simp only [sinkEndApp, dif_neg ha]
+
+/-- A vector fixed on the image of every arrow into `i` is fixed on the image of every path into
+`i` from another vertex: such a path ends with an arrow into `i`. -/
+private theorem map_path_fixed
+    (hπ : ∀ (b : Q) (e : b ⟶ i) (z : M.obj b), π ((M.map e.toPath).hom z) =
+      (M.map e.toPath).hom z)
+    {a : Q} (ha : a ≠ i) (p : Quiver.Path a i) (y : M.obj a) :
+    π ((M.map p).hom y) = (M.map p).hom y := by
+  cases p with
+  | nil => exact absurd rfl ha
+  | cons q e =>
+    have hcomp : M.map (q.cons e) = M.map q ≫ M.map e.toPath := M.map_comp q e.toPath
+    rw [hcomp]
+    exact hπ _ e _
+
+private theorem sinkEndApp_naturality (hi : IsSink i)
+    (hπ : ∀ (b : Q) (e : b ⟶ i) (z : M.obj b), π ((M.map e.toPath).hom z) =
+      (M.map e.toPath).hom z)
+    {a b : Q} (p : Quiver.Path a b) :
+    M.map p ≫ sinkEndApp M π b = sinkEndApp M π a ≫ M.map p := by
+  rcases eq_or_ne a i with rfl | ha
+  · -- a path out of a sink is trivial, and both sides are its component at the sink
+    obtain rfl := hi.eq_of_path p
+    rw [hi.path_self_eq_nil p, QuiverRep.map_nil, Category.id_comp, Category.comp_id]
+  · rw [sinkEndApp_of_ne ha, Category.id_comp]
+    rcases eq_or_ne b i with rfl | hb
+    · rw [sinkEndApp_self]
+      exact ModuleCat.hom_ext (LinearMap.ext fun y ↦ map_path_fixed hπ ha p y)
+    · rw [sinkEndApp_of_ne hb, Category.comp_id]
+
+variable (M) in
+/-- **The endomorphism of `M` given by an endomorphism at a sink.** For a sink `i` of `Q` and a
+linear endomorphism `π` of `Mᵢ` fixing the image of every arrow into `i`, this is the endomorphism
+of `M` acting by `π` at `i` and by the identity at every other vertex.
+
+Naturality is exactly the two hypotheses: a path into `i` from another vertex ends with an arrow
+into `i`, so `π` fixes its image, and no path of positive length leaves a sink, so nothing is left
+to check in the other direction. -/
+noncomputable def sinkEnd (hi : IsSink i) (π : M.obj i →ₗ[k] M.obj i)
+    (hπ : ∀ (b : Q) (e : b ⟶ i) (z : M.obj b), π ((M.map e.toPath).hom z) =
+      (M.map e.toPath).hom z) : M ⟶ M where
+  app a := sinkEndApp M π a
+  naturality _ _ p := sinkEndApp_naturality hi hπ p
+
+variable {hi : IsSink i}
+  {hπ : ∀ (b : Q) (e : b ⟶ i) (z : M.obj b), π ((M.map e.toPath).hom z) = (M.map e.toPath).hom z}
+
+private theorem sinkEnd_app (a : Q) : (sinkEnd M hi π hπ).app a = sinkEndApp M π a := rfl
+
+/-- At the sink, `TauCeti.sinkEnd` acts by the given endomorphism. -/
+@[simp]
+theorem sinkEnd_app_self : (sinkEnd M hi π hπ).app i = ModuleCat.ofHom π :=
+  (sinkEnd_app i).trans sinkEndApp_self
+
+/-- Away from the sink, `TauCeti.sinkEnd` acts by the identity. -/
+@[simp]
+theorem sinkEnd_app_of_ne {a : Q} (ha : a ≠ i) : (sinkEnd M hi π hπ).app a = 𝟙 (M.obj a) :=
+  (sinkEnd_app a).trans (sinkEndApp_of_ne ha)
+
+private theorem sinkEndApp_comp_self (hidem : IsIdempotentElem π) (a : Q) :
+    sinkEndApp M π a ≫ sinkEndApp M π a = sinkEndApp M π a := by
+  rcases eq_or_ne a i with rfl | ha
+  · rw [sinkEndApp_self, ← ModuleCat.ofHom_comp]
+    exact congrArg ModuleCat.ofHom hidem
+  · rw [sinkEndApp_of_ne ha, Category.comp_id]
+
+private theorem sinkEndApp_eq_id (h : π = LinearMap.id) (a : Q) :
+    sinkEndApp M π a = 𝟙 (M.obj a) := by
+  rcases eq_or_ne a i with rfl | ha
+  · rw [sinkEndApp_self, h]
+    rfl
+  · rw [sinkEndApp_of_ne ha]
+
+private theorem sinkEndApp_eq_zero (hzero : π = 0)
+    (hsub : ∀ a : Q, a ≠ i → Subsingleton (M.obj a)) (a : Q) : sinkEndApp M π a = 0 := by
+  rcases eq_or_ne a i with rfl | ha
+  · rw [sinkEndApp_self, hzero]
+    rfl
+  · have := hsub a ha
+    rw [sinkEndApp_of_ne ha]
+    exact (Limits.IsZero.iff_id_eq_zero _).mp (ModuleCat.isZero_of_subsingleton _)
+
+/-- `TauCeti.sinkEnd` is idempotent as soon as the endomorphism it is built from is. -/
+theorem sinkEnd_comp_self (hidem : IsIdempotentElem π) :
+    sinkEnd M hi π hπ ≫ sinkEnd M hi π hπ = sinkEnd M hi π hπ :=
+  NatTrans.ext (funext fun a ↦ sinkEndApp_comp_self hidem a)
+
+/-- `TauCeti.sinkEnd` is the identity exactly when the endomorphism it is built from is. -/
+theorem sinkEnd_eq_id_iff : sinkEnd M hi π hπ = 𝟙 M ↔ π = LinearMap.id := by
+  refine ⟨fun h ↦ ?_, fun h ↦ NatTrans.ext (funext fun a ↦ sinkEndApp_eq_id h a)⟩
+  have happ : (sinkEnd M hi π hπ).app i = 𝟙 (M.obj i) := by rw [h]; rfl
+  rw [sinkEnd_app_self] at happ
+  exact congrArg ModuleCat.Hom.hom happ
+
+/-- `TauCeti.sinkEnd` vanishes exactly when the endomorphism it is built from vanishes and the
+representation is concentrated at the sink: away from the sink it acts by the identity, which is
+zero only on a vanishing vertex space. -/
+theorem sinkEnd_eq_zero_iff :
+    sinkEnd M hi π hπ = 0 ↔ π = 0 ∧ ∀ a : Q, a ≠ i → Subsingleton (M.obj a) := by
+  refine ⟨fun h ↦ ⟨?_, fun a ha ↦ ?_⟩,
+    fun ⟨hzero, hsub⟩ ↦ NatTrans.ext (funext fun a ↦ sinkEndApp_eq_zero hzero hsub a)⟩
+  · have happ : (sinkEnd M hi π hπ).app i = 0 := by rw [h]; rfl
+    rw [sinkEnd_app_self] at happ
+    exact congrArg ModuleCat.Hom.hom happ
+  · have happ : (sinkEnd M hi π hπ).app a = 0 := by rw [h]; rfl
+    rw [sinkEnd_app_of_ne ha] at happ
+    exact ModuleCat.subsingleton_of_isZero ((Limits.IsZero.iff_id_eq_zero _).mpr happ)
+
+end SinkEnd
+
+/-! ### Idempotents at a sink of an indecomposable representation -/
+
+section Idempotents
+
+private theorem isZero_of_forall_subsingleton (hall : ∀ a : Q, Subsingleton (M.obj a)) :
+    Limits.IsZero M :=
+  Functor.isZero _ fun a ↦ @ModuleCat.isZero_of_subsingleton k _ (M.obj a) (hall a)
+
+/-- **An idempotent at a sink of an indecomposable representation is trivial.** Let `i` be a sink
+of `Q` and `M` an indecomposable representation. An idempotent endomorphism of `Mᵢ` fixing the
+image of every arrow into `i` is either the identity, or zero — and in the second case `M` vanishes
+away from `i`.
+
+Indecomposability enters through `TauCeti.idempotent_eq_zero_or_id_of_indecomposable`: the category
+of representations is abelian, so idempotents split, and an idempotent endomorphism of an
+indecomposable object is trivial. -/
+theorem sinkIdempotent_eq_id_or_eq_zero_of_indecomposable (hi : IsSink i)
+    (hM : Indecomposable M) (π : M.obj i →ₗ[k] M.obj i)
+    (hπ : ∀ (b : Q) (e : b ⟶ i) (z : M.obj b), π ((M.map e.toPath).hom z) =
+      (M.map e.toPath).hom z)
+    (hidem : IsIdempotentElem π) :
+    π = LinearMap.id ∨ π = 0 ∧ ∀ a : Q, a ≠ i → Subsingleton (M.obj a) := by
+  rcases idempotent_eq_zero_or_id_of_indecomposable hM
+      (sinkEnd_comp_self (hi := hi) (hπ := hπ) hidem) with h | h
+  · exact Or.inr ((sinkEnd_eq_zero_iff (hi := hi) (hπ := hπ)).mp h)
+  · exact Or.inl ((sinkEnd_eq_id_iff (hi := hi) (hπ := hπ)).mp h)
+
+/-- **An indecomposable representation concentrated at a sink is a line there.** Every subspace of
+the vertex space at a sink is a direct summand of it and, the representation vanishing elsewhere,
+splits off as a subrepresentation; so an indecomposable representation concentrated at a sink is
+spanned there by a single nonzero vector. -/
+theorem exists_ne_zero_span_eq_top_of_forall_subsingleton (hi : IsSink i)
+    (hM : Indecomposable M) (h : ∀ a : Q, a ≠ i → Subsingleton (M.obj a)) :
+    ∃ y : M.obj i, y ≠ 0 ∧ Submodule.span k {y} = ⊤ := by
+  -- the vertex space at `i` is nonzero, since otherwise `M` would be a zero object
+  have hnt : Nontrivial (M.obj i) := by
+    rw [← not_subsingleton_iff_nontrivial]
+    intro hs
+    refine hM.1 (isZero_of_forall_subsingleton fun a ↦ ?_)
+    rcases eq_or_ne a i with rfl | ha
+    · exact hs
+    · exact h a ha
+  obtain ⟨y, hy⟩ := exists_ne (0 : M.obj i)
+  refine ⟨y, hy, ?_⟩
+  -- an arrow into a sink starts elsewhere, so it acts by zero here and the projection onto the
+  -- line through `y` extends to an endomorphism of `M`
+  obtain ⟨U, hU⟩ := (Submodule.span k {y}).exists_isCompl
+  have hidem : IsIdempotentElem ((Submodule.span k {y}).projection U hU) :=
+    Submodule.isIdempotentElem_projection hU
+  have hproj : LinearMap.IsProj (Submodule.span k {y})
+      ((Submodule.span k {y}).projection U hU) := by
+    have hrange := LinearMap.IsIdempotentElem.isProj_range _ hidem
+    rwa [Submodule.range_projection hU] at hrange
+  have hπ : ∀ (b : Q) (e : b ⟶ i) (z : M.obj b),
+      (Submodule.span k {y}).projection U hU ((M.map e.toPath).hom z) =
+        (M.map e.toPath).hom z := by
+    intro b e z
+    have : Subsingleton (M.obj b) := h b (hi.ne_of_hom e)
+    rw [Subsingleton.elim z 0, map_zero, map_zero]
+  rcases sinkIdempotent_eq_id_or_eq_zero_of_indecomposable hi hM _ hπ hidem with hid | ⟨hz, -⟩
+  · exact hproj.submodule_eq_top_iff.mpr hid
+  · -- the projection onto the line through `y` does not vanish
+    exact absurd (Submodule.span_singleton_eq_bot.mp (hproj.submodule_eq_bot_iff.mpr hz)) hy
+
+end Idempotents
+
+/-! ### The surjectivity of the incoming sum -/
+
+section IncomingSum
+
+variable [Fintype Q] [∀ a b : Q, Fintype (a ⟶ b)]
+
+/-- **The sum of the arrows into a sink of an indecomposable representation is onto, unless the
+representation is concentrated at that sink.** This is the surjectivity hypothesis of
+`TauCeti.dimVector_reflectRep`, discharged: the range of the incoming sum is a direct summand of
+`Mᵢ`, so a proper range would split `M`, and the only splitting an indecomposable representation
+admits leaves nothing outside the sink. -/
+theorem surjective_incomingSum_or_forall_subsingleton (hi : IsSink i) (hM : Indecomposable M) :
+    Function.Surjective (incomingSum M i) ∨ ∀ a : Q, a ≠ i → Subsingleton (M.obj a) := by
+  -- project onto the range of the incoming sum along a complement
+  obtain ⟨U, hU⟩ := (LinearMap.range (incomingSum M i)).exists_isCompl
+  have hidem : IsIdempotentElem ((LinearMap.range (incomingSum M i)).projection U hU) :=
+    Submodule.isIdempotentElem_projection hU
+  have hproj : LinearMap.IsProj (LinearMap.range (incomingSum M i))
+      ((LinearMap.range (incomingSum M i)).projection U hU) := by
+    have hrange := LinearMap.IsIdempotentElem.isProj_range _ hidem
+    rwa [Submodule.range_projection hU] at hrange
+  have hπ : ∀ (b : Q) (e : b ⟶ i) (z : M.obj b),
+      (LinearMap.range (incomingSum M i)).projection U hU ((M.map e.toPath).hom z) =
+        (M.map e.toPath).hom z := fun b e z ↦
+    (Submodule.projection_eq_self_iff hU _).mpr (map_toPath_mem_range_incomingSum M e z)
+  rcases sinkIdempotent_eq_id_or_eq_zero_of_indecomposable hi hM _ hπ hidem with hid | ⟨-, hsub⟩
+  · -- the projection onto the range is the identity, so the range is everything
+    exact Or.inl (LinearMap.range_eq_top.mp (hproj.submodule_eq_top_iff.mpr hid))
+  · exact Or.inr hsub
+
+end IncomingSum
+
+end General
+
+/-! ### The vertex simple as the exceptional case -/
+
+section VertexSimple
+
+variable {k : Type u} {Q : Type u} [Field k] [Quiver.{u} Q]
+variable {M : QuiverRep.{u, u, u, u} k Q} {i : Q}
+
+/-- No path of positive length leaves a sink, so every vector of the vertex space there satisfies
+the hypothesis of `TauCeti.simpleRepHom`. -/
+private theorem map_eq_zero_of_isSink (hi : IsSink i) (y : M.obj ((Paths.of Q).obj i)) {a : Q}
+    (p : Quiver.Path i a) (hp : p.length ≠ 0) : M.map p y = 0 := by
+  obtain rfl := hi.eq_of_path p
+  rw [hi.path_self_eq_nil p] at hp
+  exact absurd Quiver.Path.length_nil hp
+
+private theorem isIso_simpleRepHom_app_self (hi : IsSink i)
+    {y : M.obj ((Paths.of Q).obj i)} (hy : y ≠ 0) (hspan : Submodule.span k {y} = ⊤) :
+    IsIso ((simpleRepHom y (map_eq_zero_of_isSink hi y)).app ((Paths.of Q).obj i)) := by
+  rw [ConcreteCategory.isIso_iff_bijective]
+  -- the component carries `c` times the generator to `c • y`
+  have key : ∀ c : k, (simpleRepHom y (map_eq_zero_of_isSink hi y)).app ((Paths.of Q).obj i)
+      (c • simpleRepGenerator k i) = c • y := fun c ↦ by
+    rw [map_smul, simpleRepHom_app_generator]
+  constructor
+  · intro z₁ z₂ hz
+    obtain ⟨c₁, rfl⟩ := exists_eq_smul_simpleRepGenerator (k := k) z₁
+    obtain ⟨c₂, rfl⟩ := exists_eq_smul_simpleRepGenerator (k := k) z₂
+    rw [key, key] at hz
+    have hzero : (c₁ - c₂) • y = 0 := by rw [sub_smul, hz, sub_self]
+    rcases smul_eq_zero.mp hzero with h | h
+    · rw [sub_eq_zero.mp h]
+    · exact absurd h hy
+  · intro z
+    have hz : z ∈ Submodule.span k {y} := by rw [hspan]; trivial
+    obtain ⟨c, hc⟩ := Submodule.mem_span_singleton.mp hz
+    exact ⟨c • simpleRepGenerator k i, (key c).trans hc⟩
+
+private theorem isIso_simpleRepHom_app (hi : IsSink i) {y : M.obj ((Paths.of Q).obj i)}
+    (hy : y ≠ 0) (hspan : Submodule.span k {y} = ⊤)
+    (hsub : ∀ a : Q, a ≠ i → Subsingleton (M.obj a)) (a : Q) :
+    IsIso ((simpleRepHom y (map_eq_zero_of_isSink hi y)).app a) := by
+  rcases eq_or_ne a i with rfl | ha
+  · exact isIso_simpleRepHom_app_self hi hy hspan
+  · -- away from the sink both vertex spaces vanish, so every map between them is invertible
+    have hzs : Limits.IsZero ((simpleRep k Q i).obj a) := isZero_simpleRep_obj ha
+    have hzm : Limits.IsZero (M.obj a) :=
+      @ModuleCat.isZero_of_subsingleton k _ (M.obj a) (hsub a ha)
+    exact ⟨0, hzs.eq_of_src _ _, hzm.eq_of_src _ _⟩
+
+/-- **An indecomposable representation concentrated at a sink is the vertex simple there.** It is a
+line at the sink by `TauCeti.exists_ne_zero_span_eq_top_of_forall_subsingleton`, and the morphism
+`TauCeti.simpleRepHom` attached to a spanning vector of that line is an isomorphism: at the sink it
+carries the generator to a spanning vector, and away from it both vertex spaces vanish. -/
+theorem nonempty_iso_simpleRep_of_forall_subsingleton (hi : IsSink i) (hM : Indecomposable M)
+    (h : ∀ a : Q, a ≠ i → Subsingleton (M.obj a)) : Nonempty (M ≅ simpleRep k Q i) := by
+  obtain ⟨y, hy, hspan⟩ := exists_ne_zero_span_eq_top_of_forall_subsingleton hi hM h
+  have hiso : ∀ a : Paths Q, IsIso ((simpleRepHom y (map_eq_zero_of_isSink hi y)).app a) := fun a ↦
+    isIso_simpleRepHom_app hi hy hspan h a
+  have := NatIso.isIso_of_isIso_app (simpleRepHom y (map_eq_zero_of_isSink hi y))
+  exact ⟨(asIso (simpleRepHom y (map_eq_zero_of_isSink hi y))).symm⟩
+
+variable [Fintype Q] [∀ a b : Q, Fintype (a ⟶ b)]
+
+/-- **The sum of the arrows into a sink is onto for every indecomposable representation other than
+the vertex simple there.** The vertex simple `Sᵢ` is genuinely excluded, by
+`TauCeti.incomingSum_not_surjective`. -/
+theorem surjective_incomingSum_of_indecomposable (hi : IsSink i) (hM : Indecomposable M)
+    (hne : ¬ Nonempty (M ≅ simpleRep k Q i)) : Function.Surjective (incomingSum M i) :=
+  (surjective_incomingSum_or_forall_subsingleton hi hM).resolve_right fun h ↦
+    hne (nonempty_iso_simpleRep_of_forall_subsingleton hi hM h)
+
+/-- **The reflection at a sink acts on the dimension vector of an indecomposable representation by
+the simple reflection there**, unless that representation is the vertex simple at the sink, which
+the reflection annihilates instead. This is the Layer 4 identity `dim (C⁺ᵢ M) = sᵢ · dim M` with
+its hypothesis discharged. -/
+theorem dimVector_reflectRep_of_indecomposable [DecidableEq Q] (hi : IsSink i)
+    (hM : Indecomposable M) (hne : ¬ Nonempty (M ≅ simpleRep k Q i))
+    (hfin : ∀ e : Σ b : Q, (b ⟶ i), FiniteDimensional k (M.obj e.1)) :
+    (fun j : Q ↦ (dimVector (reflectRep M hi) j : ℤ))
+      = vertexPreReflection Q i (fun j ↦ (dimVector M j : ℤ)) :=
+  dimVector_reflectRep M hi hfin (surjective_incomingSum_of_indecomposable hi hM hne)
+
+end VertexSimple
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Indecomposable.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Indecomposable.lean
@@ -15,7 +15,7 @@ public import TauCeti.RepresentationTheory.Quiver.Representation.Simple
 
 The Bernstein-Gelfand-Ponomarev reflection at a sink `i` replaces the vertex space `Mᵢ` by the
 kernel of the sum `TauCeti.incomingSum` of the arrows into `i`, and it acts on dimension vectors by
-the simple reflection `sᵢ` exactly when that sum is onto (`TauCeti.dimVector_reflectRep`). This file
+the simple reflection `sᵢ` whenever that sum is onto (`TauCeti.dimVector_reflectRep`). This file
 discharges that hypothesis: the sum of the arrows into a sink is onto for every indecomposable
 representation except the vertex simple `Sᵢ`, which is the representation the reflection
 annihilates.
@@ -44,7 +44,7 @@ line, it says a representation concentrated at a sink is a line there, hence is 
 * `TauCeti.exists_ne_zero_span_eq_top_of_forall_subsingleton` and
   `TauCeti.nonempty_iso_simpleRep_of_forall_subsingleton`: an indecomposable representation
   concentrated at a sink is a line there, hence isomorphic to the vertex simple.
-* `TauCeti.surjective_incomingSum_of_indecomposable`: **the sum of the arrows into a sink is onto
+* `TauCeti.incomingSum_surjective_of_indecomposable`: **the sum of the arrows into a sink is onto
   for every indecomposable representation not isomorphic to the vertex simple there.**
 * `TauCeti.dimVector_reflectRep_of_indecomposable`: consequently the reflection at a sink acts on
   the dimension vector of such a representation by the simple reflection at that vertex.
@@ -298,7 +298,7 @@ representation is concentrated at that sink.** This is the surjectivity hypothes
 `TauCeti.dimVector_reflectRep`, discharged: the range of the incoming sum is a direct summand of
 `Mᵢ`, so a proper range would split `M`, and the only splitting an indecomposable representation
 admits leaves nothing outside the sink. -/
-theorem surjective_incomingSum_or_forall_subsingleton (hi : IsSink i) (hM : Indecomposable M) :
+theorem incomingSum_surjective_or_forall_subsingleton (hi : IsSink i) (hM : Indecomposable M) :
     Function.Surjective (incomingSum M i) ∨ ∀ a : Q, a ≠ i → Subsingleton (M.obj a) := by
   -- project onto the range of the incoming sum along a complement
   obtain ⟨U, hU⟩ := (LinearMap.range (incomingSum M i)).exists_isCompl
@@ -336,47 +336,12 @@ private theorem map_eq_zero_of_isSink (hi : IsSink i) (y : M.obj ((Paths.of Q).o
   rw [hi.path_self_eq_nil p] at hp
   exact absurd Quiver.Path.length_nil hp
 
-private theorem isIso_simpleRepHom_app_self (hi : IsSink i)
-    {y : M.obj ((Paths.of Q).obj i)} (hy : y ≠ 0) (hspan : Submodule.span k {y} = ⊤) :
-    IsIso ((simpleRepHom y (map_eq_zero_of_isSink hi y)).app ((Paths.of Q).obj i)) := by
-  rw [ConcreteCategory.isIso_iff_bijective]
-  -- the component carries `c` times the generator to `c • y`
-  have key : ∀ c : k, (simpleRepHom y (map_eq_zero_of_isSink hi y)).app ((Paths.of Q).obj i)
-      (c • simpleRepGenerator k i) = c • y := fun c ↦ by
-    rw [map_smul, simpleRepHom_app_generator]
-  constructor
-  · intro z₁ z₂ hz
-    obtain ⟨c₁, rfl⟩ := exists_eq_smul_simpleRepGenerator (k := k) z₁
-    obtain ⟨c₂, rfl⟩ := exists_eq_smul_simpleRepGenerator (k := k) z₂
-    rw [key, key] at hz
-    have hzero : (c₁ - c₂) • y = 0 := by rw [sub_smul, hz, sub_self]
-    rcases smul_eq_zero.mp hzero with h | h
-    · rw [sub_eq_zero.mp h]
-    · exact absurd h hy
-  · intro z
-    have hz : z ∈ Submodule.span k {y} := by rw [hspan]; trivial
-    obtain ⟨c, hc⟩ := Submodule.mem_span_singleton.mp hz
-    exact ⟨c • simpleRepGenerator k i, (key c).trans hc⟩
-
-private theorem isIso_simpleRepHom_app (hi : IsSink i) {y : M.obj ((Paths.of Q).obj i)}
-    (hy : y ≠ 0) (hspan : Submodule.span k {y} = ⊤)
-    (hsub : ∀ a : Q, a ≠ i → Subsingleton (M.obj a)) (a : Q) :
-    IsIso ((simpleRepHom y (map_eq_zero_of_isSink hi y)).app a) := by
-  rcases eq_or_ne a i with rfl | ha
-  · exact isIso_simpleRepHom_app_self hi hy hspan
-  · -- away from the sink both vertex spaces vanish, so every map between them is invertible
-    have hzs : Limits.IsZero ((simpleRep k Q i).obj a) := isZero_simpleRep_obj ha
-    have hzm : Limits.IsZero (M.obj a) :=
-      @ModuleCat.isZero_of_subsingleton k _ (M.obj a) (hsub a ha)
-    exact ⟨0, hzs.eq_of_src _ _, hzm.eq_of_src _ _⟩
-
 /-- **An indecomposable representation concentrated at a sink is the vertex simple there.** -/
 theorem nonempty_iso_simpleRep_of_forall_subsingleton (hi : IsSink i) (hM : Indecomposable M)
     (h : ∀ a : Q, a ≠ i → Subsingleton (M.obj a)) : Nonempty (M ≅ simpleRep k Q i) := by
   obtain ⟨y, hy, hspan⟩ := exists_ne_zero_span_eq_top_of_forall_subsingleton hi hM h
-  have hiso : ∀ a : Paths Q, IsIso ((simpleRepHom y (map_eq_zero_of_isSink hi y)).app a) := fun a ↦
-    isIso_simpleRepHom_app hi hy hspan h a
-  have := NatIso.isIso_of_isIso_app (simpleRepHom y (map_eq_zero_of_isSink hi y))
+  have := isIso_simpleRepHom y (map_eq_zero_of_isSink hi y) hy hspan fun a ha ↦
+    @ModuleCat.isZero_of_subsingleton k _ (M.obj a) (h a ha)
   exact ⟨(asIso (simpleRepHom y (map_eq_zero_of_isSink hi y))).symm⟩
 
 variable [Fintype Q] [∀ a b : Q, Fintype (a ⟶ b)]
@@ -384,9 +349,9 @@ variable [Fintype Q] [∀ a b : Q, Fintype (a ⟶ b)]
 /-- **The sum of the arrows into a sink is onto for every indecomposable representation other than
 the vertex simple there.** The vertex simple `Sᵢ` is genuinely excluded, by
 `TauCeti.incomingSum_not_surjective`. -/
-theorem surjective_incomingSum_of_indecomposable (hi : IsSink i) (hM : Indecomposable M)
+theorem incomingSum_surjective_of_indecomposable (hi : IsSink i) (hM : Indecomposable M)
     (hne : ¬ Nonempty (M ≅ simpleRep k Q i)) : Function.Surjective (incomingSum M i) :=
-  (surjective_incomingSum_or_forall_subsingleton hi hM).resolve_right fun h ↦
+  (incomingSum_surjective_or_forall_subsingleton hi hM).resolve_right fun h ↦
     hne (nonempty_iso_simpleRep_of_forall_subsingleton hi hM h)
 
 /-- **The reflection at a sink acts on the dimension vector of an indecomposable representation by
@@ -398,7 +363,7 @@ theorem dimVector_reflectRep_of_indecomposable [DecidableEq Q] (hi : IsSink i)
     (hfin : ∀ e : Σ b : Q, (b ⟶ i), FiniteDimensional k (M.obj e.1)) :
     (fun j : Q ↦ (dimVector (reflectRep M hi) j : ℤ))
       = vertexPreReflection Q i (fun j ↦ (dimVector M j : ℤ)) :=
-  dimVector_reflectRep M hi hfin (surjective_incomingSum_of_indecomposable hi hM hne)
+  dimVector_reflectRep M hi hfin (incomingSum_surjective_of_indecomposable hi hM hne)
 
 end VertexSimple
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Representation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Representation.lean
@@ -140,8 +140,7 @@ theorem incomingSum_apply (M : QuiverRep.{u, v, w, max v w x} k Q) (i : Q)
     incomingSum M i f = ∑ e : Σ b : Q, (b ⟶ i), (M.map e.2.toPath).hom (f e) := by
   simp [incomingSum]
 
-/-- **The image of an arrow into `i` lies in the range of `TauCeti.incomingSum`.** The family
-supported at that arrow, with the given value, is a preimage. -/
+/-- **The image of an arrow into `i` lies in the range of `TauCeti.incomingSum`.** -/
 theorem map_toPath_mem_range_incomingSum (M : QuiverRep.{u, v, w, max v w x} k Q) {b i : Q}
     (e : b ⟶ i) (y : M.obj b) :
     (M.map e.toPath).hom y ∈ LinearMap.range (incomingSum M i) := by

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Representation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Representation.lean
@@ -37,7 +37,8 @@ representation concentrated at `i` whose space at `i` is nontrivial, of which th
 ## Main definitions
 
 * `TauCeti.incomingSum`: the map `⨁_{a : b ⟶ i} M_b → Mᵢ` summing the arrows into a vertex,
-  defined at every vertex of every representation.
+  defined at every vertex of every representation, whose range contains the image of every arrow
+  into that vertex (`TauCeti.map_toPath_mem_range_incomingSum`).
 * `TauCeti.reflectRep`: the reflection `C⁺ᵢ M` of a representation at a sink `i`, a
   representation of `TauCeti.Quiver.Reflect Q i`.
 * `TauCeti.reflectionFunctor`: the BGP reflection functor at a sink.
@@ -138,6 +139,18 @@ theorem incomingSum_apply (M : QuiverRep.{u, v, w, max v w x} k Q) (i : Q)
     (f : (e : Σ b : Q, (b ⟶ i)) → M.obj e.1) :
     incomingSum M i f = ∑ e : Σ b : Q, (b ⟶ i), (M.map e.2.toPath).hom (f e) := by
   simp [incomingSum]
+
+/-- **The image of an arrow into `i` lies in the range of `TauCeti.incomingSum`.** The family
+supported at that arrow, with the given value, is a preimage. -/
+theorem map_toPath_mem_range_incomingSum (M : QuiverRep.{u, v, w, max v w x} k Q) {b i : Q}
+    (e : b ⟶ i) (y : M.obj b) :
+    (M.map e.toPath).hom y ∈ LinearMap.range (incomingSum M i) := by
+  classical
+  refine ⟨Pi.single ⟨b, e⟩ y, ?_⟩
+  rw [incomingSum_apply, Finset.sum_eq_single_of_mem ⟨b, e⟩ (Finset.mem_univ _)]
+  · simp
+  · intro c _ hc
+    simp [Pi.single_eq_of_ne hc]
 
 /-- The source of `TauCeti.incomingSum` has dimension `∑_b #(b ⟶ i) · dim M_b`. Only the vertex
 spaces at the sources of arrows into `i` need be finite-dimensional; they are the only ones the

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Simple.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Simple.lean
@@ -41,6 +41,8 @@ line through `x` at `i` and zero elsewhere, which is `Sᵢ`.
 ## Main results
 
 * `TauCeti.simpleRep_simple`: `Sᵢ` is a simple object of `TauCeti.QuiverRep k Q`.
+* `TauCeti.isIso_simpleRepHom`: a representation spanned at `i` by a single nonzero vector and
+  vanishing at every other vertex is `Sᵢ`.
 * `TauCeti.exists_iso_simpleRep_of_simple`: over an acyclic quiver every simple representation is
   isomorphic to some `Sᵢ`.
 * `TauCeti.exists_eq_smul_simpleRepGenerator`: `(Sᵢ)ᵢ` is the line spanned by the generator.
@@ -308,6 +310,43 @@ theorem simpleRepHom_app_generator {i : Q} {M : QuiverRep k Q} (x : M.obj ((Path
   rw [simpleRepSelfEquiv_apply_generator]
   exact LinearMap.toSpanSingleton_apply_one k _ x
 
+/-- **A representation carried by a single vector at `i` is `Sᵢ`**: the morphism `Sᵢ ⟶ M` attached
+to a nonzero vector `x` spanning `Mᵢ` is an isomorphism, as soon as `M` vanishes at every other
+vertex. -/
+theorem isIso_simpleRepHom {i : Q} {M : QuiverRep k Q} (x : M.obj ((Paths.of Q).obj i))
+    (hx : ∀ {a : Q} (p : Quiver.Path i a), p.length ≠ 0 → M.map p x = 0) (hx0 : x ≠ 0)
+    (hspan : Submodule.span k ({x} : Set (M.obj ((Paths.of Q).obj i))) = ⊤)
+    (hM : ∀ a : Q, a ≠ i → IsZero (M.obj a)) : IsIso (simpleRepHom x hx) := by
+  -- at `i` the morphism attached to `x` is `(Sᵢ)ᵢ ≃ k` followed by `c ↦ c • x`
+  have hcoe : ∀ y, (simpleRepHom x hx).app ((Paths.of Q).obj i) y
+      = LinearMap.toSpanSingleton k (M.obj ((Paths.of Q).obj i)) x (simpleRepSelfEquiv k i y) := by
+    intro y
+    obtain ⟨c, rfl⟩ := exists_eq_smul_simpleRepGenerator k y
+    simp [LinearMap.toSpanSingleton_apply]
+  have hisoi : IsIso ((simpleRepHom x hx).app ((Paths.of Q).obj i)) := by
+    rw [ConcreteCategory.isIso_iff_bijective]
+    constructor
+    · intro y z hyz
+      refine (simpleRepSelfEquiv k i).injective
+        (LinearMap.ker_eq_bot.1 (LinearMap.ker_toSpanSingleton k hx0) ?_)
+      rw [← hcoe, ← hcoe]
+      exact hyz
+    · intro y
+      obtain ⟨c, hc⟩ :=
+        LinearMap.range_eq_top.1 ((LinearMap.range_toSpanSingleton x).trans hspan) y
+      exact ⟨(simpleRepSelfEquiv k i).symm c, by rw [hcoe, LinearEquiv.apply_symm_apply]; exact hc⟩
+  rw [NatTrans.isIso_iff_isIso_app]
+  intro a
+  change Q at a
+  change IsIso ((simpleRepHom x hx).app ((Paths.of Q).obj a))
+  rcases eq_or_ne a i with rfl | ha
+  · exact hisoi
+  · -- away from `i` both vertex spaces vanish, so every map between them is invertible
+    have hs : IsZero ((simpleRep k Q i).obj ((Paths.of Q).obj a)) := isZero_simpleRep_obj ha
+    have ht : IsZero (M.obj ((Paths.of Q).obj a)) := hM a ha
+    rw [hs.eq_of_src ((simpleRepHom x hx).app ((Paths.of Q).obj a)) (hs.iso ht).hom]
+    infer_instance
+
 /-- **The vertex simples exhaust the simples.** Over an acyclic quiver every simple representation
 is isomorphic to a vertex simple `Sᵢ`.
 
@@ -382,35 +421,7 @@ theorem exists_iso_simpleRep_of_simple (hQ : Quiver.IsAcyclic Q) (M : QuiverRep 
     · have : Subsingleton (M.obj a) := ModuleCat.subsingleton_of_isZero (hM a ha)
       exact Subsingleton.elim _ _
   refine ⟨i, ⟨?_⟩⟩
-  -- at `i` the morphism attached to `x` is `(Sᵢ)ᵢ ≃ k` followed by `c ↦ c • x`
-  have hcoe : ∀ y, (simpleRepHom x hxp).app ((Paths.of Q).obj i) y
-      = LinearMap.toSpanSingleton k (M.obj ((Paths.of Q).obj i)) x (simpleRepSelfEquiv k i y) := by
-    intro y
-    obtain ⟨c, rfl⟩ := exists_eq_smul_simpleRepGenerator k y
-    simp [LinearMap.toSpanSingleton_apply]
-  have hisoi : IsIso ((simpleRepHom x hxp).app ((Paths.of Q).obj i)) := by
-    rw [ConcreteCategory.isIso_iff_bijective]
-    constructor
-    · intro y z hyz
-      refine (simpleRepSelfEquiv k i).injective
-        (LinearMap.ker_eq_bot.1 (LinearMap.ker_toSpanSingleton k hx) ?_)
-      rw [← hcoe, ← hcoe]
-      exact hyz
-    · intro y
-      obtain ⟨c, hc⟩ :=
-        LinearMap.range_eq_top.1 ((LinearMap.range_toSpanSingleton x).trans hspan) y
-      exact ⟨(simpleRepSelfEquiv k i).symm c, by rw [hcoe, LinearEquiv.apply_symm_apply]; exact hc⟩
-  have hiso : IsIso (simpleRepHom x hxp) := by
-    rw [NatTrans.isIso_iff_isIso_app]
-    intro a
-    change Q at a
-    change IsIso ((simpleRepHom x hxp).app ((Paths.of Q).obj a))
-    rcases eq_or_ne a i with rfl | ha
-    · exact hisoi
-    · have hs : IsZero ((simpleRep k Q i).obj ((Paths.of Q).obj a)) := isZero_simpleRep_obj ha
-      have ht : IsZero (M.obj ((Paths.of Q).obj a)) := hM a ha
-      rw [hs.eq_of_src ((simpleRepHom x hxp).app ((Paths.of Q).obj a)) (hs.iso ht).hom]
-      infer_instance
+  have := isIso_simpleRepHom x hxp hx hspan hM
   exact (asIso (simpleRepHom x hxp)).symm
 
 /-- Vertex simples at distinct vertices are not isomorphic: their dimension vectors differ. -/


### PR DESCRIPTION
This PR proves that the sum of the arrows into a sink is onto on an indecomposable representation of a quiver, unless that representation is the vertex simple there, and reads off the dimension-vector identity for the Bernstein-Gelfand-Ponomarev reflection that the fact was missing.

The target is the reflection-functor entry of Layer 4 of `RepresentationTheory/QuiverRepresentations/README.md`: "on dimension vectors it acts by the simple reflection `sᵢ` of the Tits form: `dim (C⁺ᵢ M) = sᵢ · dim M` whenever `M` has no `Sᵢ` summand". `dimVector_reflectRep` already proved that identity, but only under the hypothesis that `incomingSum M i` is surjective, and nothing discharged it; `dimVector_reflectRep_of_indecomposable` now states it for an indecomposable `M` with `M ≇ Sᵢ`. This is also the numerical half of the second milestone of that roadmap's Layer 5 (Gabriel's theorem): "for an indecomposable `M ≇ Sᵢ`, the functor `reflectionFunctor⁺ i` sends `M` to an indecomposable of the reflected quiver, killing exactly the summand `Sᵢ`; on dimension vectors it realizes `sᵢ`".

One construction carries the argument. No arrow leaves a sink, so a linear endomorphism `π` of `Mᵢ` fixing the image of every arrow into `i` extends by the identity at the other vertices to an endomorphism `sinkEnd` of the whole representation, idempotent as soon as `π` is; `sinkEnd_eq_id_iff` and `sinkEnd_eq_zero_iff` recognize when it is trivial. Representations of a quiver form an abelian category, hence idempotents split, so an indecomposable object carries no idempotent endomorphism besides `0` and the identity — that converse of `indecomposable_of_idempotent_eq_zero_or_id` is added to `TauCeti/CategoryTheory/Preadditive/Indecomposable.lean` as `idempotent_eq_zero_or_id_of_indecomposable`, together with `isoBiprodOfRetracts`, which turns two retracts whose idempotents sum to the identity into a biproduct decomposition. Applying it to the projection onto the range of the incoming sum along a complement gives `surjective_incomingSum_or_forall_subsingleton`; applying it to the projection onto a line gives `exists_ne_zero_span_eq_top_of_forall_subsingleton`, so an indecomposable representation concentrated at a sink is a line there and `nonempty_iso_simpleRep_of_forall_subsingleton` identifies it with `Sᵢ`. The exclusion of `Sᵢ` is not an artefact: `incomingSum_not_surjective` already records that the incoming sum fails to be onto exactly there.

`sinkEnd` and everything up to the line criterion need no finiteness hypothesis, because the condition on `π` is stated arrow by arrow rather than through `incomingSum`; the two agree on a finite quiver by `map_toPath_mem_range_incomingSum`, which is added beside `incomingSum` itself. `Quiver.IsSink.path_self_eq_nil` and its dual join `IsSink.eq_of_path` in `Reflection/Basic.lean`. The statements comparing `M` with `simpleRep k Q i` live in their own section, where the quiver, its arrows and the field share one universe: `reflectRep` needs the vertex spaces in `max v w x`, since the reflected space is cut out of a product indexed by the arrows, while `Sᵢ` puts the field itself at `i`, so a statement naming both has to identify the two universes; the results that name no vertex simple are proved in the wider setting.

What remains for that Layer 5 milestone is the categorical half: the reflection functor at a source and the isomorphism `C⁻ᵢ C⁺ᵢ M ≅ M` for an `M` with no `Sᵢ` summand, which upgrade this dimension identity to the statement that reflection preserves indecomposability.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"incomingsum-surjective-of-indecomposable"}-->

🤖 Prepared with Claude Code
