### PR TITLE
feat: conjugate a finite-dimensional representation of a compact group into a unitary one

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/PositiveDefinite.lean
+++ b/TauCeti/Analysis/InnerProductSpace/PositiveDefinite.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.Spectrum
+public import Mathlib.LinearAlgebra.Basis.SMul
+
+/-!
+# A positive-definite form is the standard one in suitable coordinates
+
+Let `S` be a symmetric operator on a finite-dimensional inner product space `V` whose associated
+Hermitian form `⟪S v, w⟫` is positive definite. This file produces a linear automorphism of `V`
+along which that form pulls back to the inner product `V` already carries:
+
+`TauCeti.exists_continuousLinearEquiv_inner_map_map` gives `e : V ≃L[𝕜] V` with
+`⟪S (e x), e y⟫ = ⟪x, y⟫` for all `x` and `y`.
+
+Equivalently `e` is an isometry from `(V, ⟪·,·⟫)` onto `(V, ⟪S ·, ·⟫)`, so its inverse is the
+operator usually written `S ^ (1 / 2)`; the construction here avoids building an operator square
+root by scaling an orthonormal eigenbasis of `S` instead. The eigenvalues of `S` are positive
+because the form is definite, so dividing the `i`-th eigenvector by `√(λ i)` produces a basis that
+is orthonormal *for the form*, and `e` is the map carrying the eigenbasis to it.
+
+## Main statements
+
+* `TauCeti.exists_continuousLinearEquiv_inner_map_map`: a positive-definite symmetric operator's
+  form becomes the standard inner product after a change of coordinates.
+
+Only the existence of `e` is exported, since it depends on a choice of eigenbasis. The operator is
+taken continuous and the change of coordinates produced is a continuous linear equivalence; on a
+finite-dimensional space that is no restriction either way, and it is the form the consumer both
+supplies and wants.
+
+The intended consumer is Weyl's unitarian trick: applied to the Gram operator of the Haar-averaged
+inner product of a representation of a compact group, this is what turns the invariant form into
+an honest unitary structure, in
+`TauCeti/RepresentationTheory/Compact/UnitaryModel.lean`.
+-/
+
+public section
+
+open RCLike
+open scoped InnerProductSpace
+
+namespace TauCeti
+
+variable {𝕜 V : Type*} [RCLike 𝕜] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+
+/-- **A positive-definite form is standard in suitable coordinates.** If `S` is a symmetric
+operator on a finite-dimensional inner product space whose form `⟪S ·, ·⟫` is positive definite,
+then there is a continuous linear automorphism `e` with `⟪S (e x), e y⟫ = ⟪x, y⟫`.
+
+The automorphism is the inverse of the square root of `S`, built without any operator functional
+calculus: an orthonormal eigenbasis `b` of `S` has positive eigenvalues `λ i`, so the vectors
+`(√(λ i))⁻¹ • b i` are orthonormal for the form `⟪S ·, ·⟫`, and `e` is the automorphism carrying
+`b i` to them. -/
+theorem exists_continuousLinearEquiv_inner_map_map (S : V →L[𝕜] V)
+    (hsymm : (S : V →ₗ[𝕜] V).IsSymmetric) (hpos : ∀ v : V, v ≠ 0 → 0 < re ⟪S v, v⟫_𝕜) :
+    ∃ e : V ≃L[𝕜] V, ∀ x y : V, ⟪S (e x), e y⟫_𝕜 = ⟪x, y⟫_𝕜 := by
+  classical
+  set n := Module.finrank 𝕜 V with hn
+  set b := hsymm.eigenvectorBasis hn.symm
+  set lam := hsymm.eigenvalues hn.symm
+  have hSb : ∀ i, S (b i) = (lam i : 𝕜) • b i := fun i ↦
+    hsymm.apply_eigenvectorBasis hn.symm i
+  have hbb : ∀ i j, ⟪b i, b j⟫_𝕜 = if i = j then 1 else 0 :=
+    orthonormal_iff_ite.mp b.orthonormal
+  -- The eigenvalues are positive: `⟪S (b i), b i⟫ = λ i` and the form is definite.
+  have hlam : ∀ i, 0 < lam i := fun i ↦ by
+    have h := hpos (b i) (b.orthonormal.ne_zero i)
+    rw [hSb i, inner_smul_left, hbb i i] at h
+    simpa using h
+  -- Scaling the `i`-th eigenvector by `(√(λ i))⁻¹` makes the family orthonormal for the form.
+  set w : Fin n → 𝕜 := fun i ↦ ((Real.sqrt (lam i))⁻¹ : ℝ) with hwdef
+  have hw : ∀ i, IsUnit (w i) := fun i ↦ by
+    refine isUnit_iff_ne_zero.mpr ?_
+    simp [hwdef, Real.sqrt_eq_zero', (hlam i).not_ge]
+  set el : V ≃ₗ[𝕜] V := b.toBasis.equiv (b.toBasis.isUnitSMul hw) (Equiv.refl (Fin n)) with heldef
+  set e : V ≃L[𝕜] V := el.toContinuousLinearEquiv with hedef
+  have he' : ∀ i, e (b.toBasis i) = w i • b.toBasis i := fun i ↦ by
+    simp only [hedef, heldef, LinearEquiv.coe_toContinuousLinearEquiv',
+      Module.Basis.equiv_apply, Equiv.refl_apply, Module.Basis.isUnitSMul_apply]
+  have he : ∀ i, e (b i) = w i • b i := by simpa only [b.coe_toBasis] using he'
+  have hkey : ∀ i j, ⟪S (e (b i)), e (b j)⟫_𝕜 = if i = j then 1 else 0 := fun i j ↦ by
+    rw [he i, he j, map_smul, hSb i, smul_smul, inner_smul_left, inner_smul_right, hbb i j]
+    rcases eq_or_ne i j with rfl | hij
+    · have hr : ((Real.sqrt (lam i))⁻¹ * lam i * (Real.sqrt (lam i))⁻¹ : ℝ) = 1 := by
+        have hne : Real.sqrt (lam i) ≠ 0 := (Real.sqrt_pos.mpr (hlam i)).ne'
+        field_simp
+        exact (Real.sq_sqrt (hlam i).le).symm
+      rw [if_pos rfl, mul_one, hwdef, ← RCLike.ofReal_mul, conj_ofReal, ← RCLike.ofReal_mul, hr,
+        RCLike.ofReal_one]
+    · simp [hij]
+  -- Both sides are sesquilinear, so the basis computation determines them.
+  refine ⟨e, fun x y ↦ ?_⟩
+  rw [← b.sum_inner_mul_inner x y]
+  conv_lhs => rw [← b.sum_repr' x, ← b.sum_repr' y]
+  simp only [map_sum, map_smul, sum_inner, inner_sum, inner_smul_left, inner_smul_right, hkey]
+  simp [inner_conj_symm, mul_comm]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Compact/Unitarizable.lean
+++ b/TauCeti/RepresentationTheory/Compact/Unitarizable.lean
@@ -50,7 +50,9 @@ It is the compact-group replacement for the invertibility of `|G|` in Maschke's 
 invariant-complement and complete-reducibility results of
 `TauCeti.RepresentationTheory.Continuous.InvariantComplement` take `IsUnitary` as a hypothesis; this
 file does not discharge that hypothesis, but the invariant form built here is the input a
-unitarization construction needs.
+unitarization construction needs. `TauCeti.RepresentationTheory.Compact.UnitaryModel` carries that
+construction out in finite dimensions, conjugating `π` into a representation that is unitary for
+the inner product `V` was given.
 
 The mathematical development follows Daniel Bump, *Lie Groups*, second edition, Chapter 2.
 -/
@@ -263,7 +265,8 @@ self-adjoint operator `S` with `(π g)† ∘ S ∘ (π g) = S`.
 
 This operator is the input to unitarization: retopologizing `V` by `⟪S ·, ·⟫`, or conjugating `π`
 by `S ^ (1 / 2)`, makes every `π g` unitary. Neither construction is carried out here, so this file
-does not itself produce an `IsUnitary` representation. -/
+does not itself produce an `IsUnitary` representation;
+`TauCeti.ContRepresentation.exists_isUnitary_congr` does, for a finite-dimensional carrier. -/
 theorem isUnitarizable :
     ∃ S : V →L[𝕜] V, IsSelfAdjoint S ∧ (∀ v : V, v ≠ 0 → 0 < re ⟪S v, v⟫_𝕜) ∧
       ∀ g : G, (ContinuousLinearMap.adjoint (π g)).comp (S.comp (π g)) = S :=

--- a/TauCeti/RepresentationTheory/Compact/UnitaryModel.lean
+++ b/TauCeti/RepresentationTheory/Compact/UnitaryModel.lean
@@ -92,18 +92,15 @@ theorem exists_isUnitary_congr (π : ContRepresentation 𝕜 G V) (hπ : Continu
     ∃ e : V ≃L[𝕜] V, IsUnitary (congr e π) := by
   obtain ⟨A, hA⟩ := exists_continuousLinearEquiv_inner_map_map (gramOperator π hπ)
     (isSymmetric_gramOperator π hπ) fun _ hv ↦ re_inner_gramOperator_self_pos π hπ hv
-  -- `isSymmetric_gramOperator` with the continuous-linear-map coercion, so that it rewrites.
-  have hsymm : ∀ v w : V, ⟪gramOperator π hπ v, w⟫_𝕜 = ⟪v, gramOperator π hπ w⟫_𝕜 :=
-    isSymmetric_gramOperator π hπ
-  -- The averaged form is invariant, written with the Gram operator on the left.
-  have hinv : ∀ (g : G) (v w : V), ⟪gramOperator π hπ (π g v), π g w⟫_𝕜
-      = ⟪gramOperator π hπ v, w⟫_𝕜 := fun g v w ↦ by
-    rw [hsymm, inner_gramOperator_map_map, ← hsymm]
+  -- The same standardization with the Gram operator on the second argument, which is the side
+  -- `inner_gramOperator_map_map` states invariance of the averaged form on.
+  have hA' : ∀ x y : V, ⟪A x, gramOperator π hπ (A y)⟫_𝕜 = ⟪x, y⟫_𝕜 := fun x y ↦ by
+    rw [← inner_conj_symm, hA, inner_conj_symm]
   have hunitary : ∀ (g : G) (x y : V), ⟪congr A.symm π g x, congr A.symm π g y⟫_𝕜 = ⟪x, y⟫_𝕜 := by
     intro g x y
     rw [congr_apply, congr_apply, ContinuousLinearEquiv.symm_symm,
-      ← hA (A.symm (π g (A x))) (A.symm (π g (A y))), ContinuousLinearEquiv.apply_symm_apply,
-      ContinuousLinearEquiv.apply_symm_apply, hinv, hA]
+      ← hA' (A.symm (π g (A x))) (A.symm (π g (A y))), ContinuousLinearEquiv.apply_symm_apply,
+      ContinuousLinearEquiv.apply_symm_apply, inner_gramOperator_map_map, hA']
   exact ⟨A.symm, (isUnitary_iff_norm_map _).mpr fun g ↦
     (LinearMap.norm_map_iff_inner_map_map _).mpr (hunitary g)⟩
 

--- a/TauCeti/RepresentationTheory/Compact/UnitaryModel.lean
+++ b/TauCeti/RepresentationTheory/Compact/UnitaryModel.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.InnerProductSpace.PositiveDefinite
+public import TauCeti.RepresentationTheory.Compact.Unitarizable
+public import TauCeti.RepresentationTheory.Continuous.Representative
+
+/-!
+# The unitary model of a finite-dimensional representation of a compact group
+
+Weyl's unitarian trick, in `TauCeti/RepresentationTheory/Compact/Unitarizable.lean`, averages the
+inner product of a continuous representation `π` of a compact group over Haar measure and records
+the averaged form through its Gram operator `S`, a positive-definite self-adjoint operator with
+`(π g)† ∘ S ∘ (π g) = S`. That is an invariant form, not yet a unitary representation: Lean fixes
+one `InnerProductSpace` structure on the carrier, and `π` is in general not unitary for it.
+
+This file closes the gap in finite dimensions. Changing coordinates by the automorphism `A` that
+standardizes the invariant form
+(`TauCeti.exists_continuousLinearEquiv_inner_map_map`, morally `A = S ^ (-1 / 2)`) conjugates `π`
+into a representation that *is* unitary for the given inner product:
+
+`TauCeti.ContRepresentation.exists_isUnitary_congr` produces `e : V ≃L[𝕜] V` with
+`IsUnitary (congr e π)`.
+
+So a downstream statement about unitary representations loses no generality, and the two
+consequences recorded here are the form that fact is consumed in: a matrix coefficient of an
+arbitrary finite-dimensional continuous representation is a matrix coefficient of a unitary one,
+and hence the representative ring `𝓡(G)` is spanned by the matrix coefficients of the **unitary**
+finite-dimensional continuous representations alone.
+
+## Main statements
+
+* `TauCeti.ContRepresentation.exists_isUnitary_congr`: a finite-dimensional continuous
+  representation of a compact group is conjugate to a unitary one.
+* `TauCeti.ContRepresentation.exists_isUnitary_matrixCoeff_eq`: its matrix coefficients are matrix
+  coefficients of a unitary representation.
+* `TauCeti.isRepresentative_iff_exists_isUnitary`: a representative function is a matrix
+  coefficient of a unitary representation on a standard model.
+
+## Implementation notes
+
+The conjugating automorphism is not asked to be canonical:
+`TauCeti.exists_continuousLinearEquiv_inner_map_map` chooses an eigenbasis of the Gram operator,
+and only its existence is exported. Nothing downstream needs more, since the unitary structure it
+produces is unique up to a unitary equivalence anyway.
+
+Finite dimensionality enters only through that standardization, which is proved by the spectral
+theorem; the Gram operator itself is built for an arbitrary Hilbert-space carrier.
+
+This finishes Layer 1 of the
+[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
+whose statement of the unitarian trick asks that "downstream results may assume `IsUnitary` without
+loss of generality". The Layer 5 (Peter-Weyl) completeness argument is the intended consumer: the
+matrix coefficients that have to be expanded in the coefficients of a family of irreducible
+*unitary* representations are, a priori, coefficients of arbitrary ones. The mathematical
+development follows Daniel Bump, *Lie Groups*, second edition, Chapter 2.
+-/
+
+public section
+
+open MeasureTheory RCLike
+open scoped InnerProductSpace
+
+namespace TauCeti
+
+namespace ContRepresentation
+
+section Unitarization
+
+variable {𝕜 G V : Type*} [RCLike 𝕜] [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+
+local instance instCompleteSpaceUnitaryModel : CompleteSpace V :=
+  FiniteDimensional.complete 𝕜 V
+
+/-- **A finite-dimensional continuous representation of a compact group is conjugate to a unitary
+one.** There is a continuous linear automorphism `e` of the carrier for which the transported
+representation `TauCeti.ContRepresentation.congr e π` preserves the inner product.
+
+This is the unitarian trick in its usable form. Haar averaging supplies the invariant
+positive-definite form `⟪S ·, ·⟫`; the automorphism `A` carrying the standard inner product to
+that form (`TauCeti.exists_continuousLinearEquiv_inner_map_map`) conjugates the invariance of the
+form into unitarity of `A⁻¹ ∘ π · ∘ A`. -/
+theorem exists_isUnitary_congr (π : ContRepresentation 𝕜 G V) (hπ : Continuous π) :
+    ∃ e : V ≃L[𝕜] V, IsUnitary (congr e π) := by
+  obtain ⟨A, hA⟩ := exists_continuousLinearEquiv_inner_map_map (gramOperator π hπ)
+    (isSymmetric_gramOperator π hπ) fun _ hv ↦ re_inner_gramOperator_self_pos π hπ hv
+  have hsymm : ∀ v w : V, ⟪gramOperator π hπ v, w⟫_𝕜 = ⟪v, gramOperator π hπ w⟫_𝕜 := fun v w ↦ by
+    rw [inner_gramOperator_left, inner_gramOperator]
+  -- The averaged form is invariant, written with the Gram operator on the left.
+  have hinv : ∀ (g : G) (v w : V), ⟪gramOperator π hπ (π g v), π g w⟫_𝕜
+      = ⟪gramOperator π hπ v, w⟫_𝕜 := fun g v w ↦ by
+    rw [hsymm, inner_gramOperator_map_map, ← hsymm]
+  have hunitary : ∀ (g : G) (x y : V), ⟪congr A.symm π g x, congr A.symm π g y⟫_𝕜 = ⟪x, y⟫_𝕜 := by
+    intro g x y
+    rw [congr_apply, congr_apply, ContinuousLinearEquiv.symm_symm,
+      ← hA (A.symm (π g (A x))) (A.symm (π g (A y))), ContinuousLinearEquiv.apply_symm_apply,
+      ContinuousLinearEquiv.apply_symm_apply, hinv, hA]
+  exact ⟨A.symm, (isUnitary_iff_norm_map _).mpr fun g ↦
+    (LinearMap.norm_map_iff_inner_map_map _).mpr (hunitary g)⟩
+
+/-- **A matrix coefficient of a finite-dimensional continuous representation of a compact group is
+a matrix coefficient of a unitary one**, on the same carrier and at suitably moved vectors.
+
+Matrix coefficients depend only on the equivalence class of a representation
+(`TauCeti.ContRepresentation.matrixCoeff_congr_adjoint`), so the conjugate unitary model produced
+by `TauCeti.ContRepresentation.exists_isUnitary_congr` produces every matrix coefficient of the
+original. -/
+theorem exists_isUnitary_matrixCoeff_eq (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+    (v w : V) :
+    ∃ (ρ : ContRepresentation 𝕜 G V) (hρ : Continuous ρ), IsUnitary ρ ∧
+      ∃ v' w' : V, matrixCoeff π hπ v w = matrixCoeff ρ hρ v' w' :=
+  let ⟨e, he⟩ := exists_isUnitary_congr π hπ
+  ⟨congr e π, continuous_congr e hπ, he, e v,
+    ContinuousLinearMap.adjoint (e.symm : V →L[𝕜] V) w, (matrixCoeff_congr_adjoint e hπ v w).symm⟩
+
+end Unitarization
+
+end ContRepresentation
+
+section Representative
+
+variable {𝕜 G : Type*} [RCLike 𝕜] [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
+
+/-- **The representative functions of a compact group are the matrix coefficients of its unitary
+finite-dimensional continuous representations.** Restricting the representations allowed in the
+definition of `TauCeti.IsRepresentative` to the unitary ones changes nothing.
+
+The forward direction is unitarization; the reverse is the definition. Consequently the
+representative ring `𝓡(G)`, whose uniform density in `C(G, 𝕜)` is the analytic core of the
+Peter-Weyl theorem, is spanned by the matrix coefficients of unitary representations, which are
+the ones Schur orthogonality applies to. -/
+theorem isRepresentative_iff_exists_isUnitary {f : C(G, 𝕜)} :
+    IsRepresentative f ↔ ∃ (n : ℕ) (π : ContRepresentation 𝕜 G (EuclideanSpace 𝕜 (Fin n)))
+      (hπ : Continuous π), ContRepresentation.IsUnitary π ∧
+        ∃ v w : EuclideanSpace 𝕜 (Fin n), f = ContRepresentation.matrixCoeff π hπ v w := by
+  rw [isRepresentative_iff]
+  constructor
+  · rintro ⟨n, π, hπ, v, w, rfl⟩
+    obtain ⟨ρ, hρ, hunitary, v', w', hvw⟩ :=
+      ContRepresentation.exists_isUnitary_matrixCoeff_eq π hπ v w
+    exact ⟨n, ρ, hρ, hunitary, v', w', hvw⟩
+  · rintro ⟨n, π, hπ, -, v, w, rfl⟩
+    exact ⟨n, π, hπ, v, w, rfl⟩
+
+end Representative
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Compact/UnitaryModel.lean
+++ b/TauCeti/RepresentationTheory/Compact/UnitaryModel.lean
@@ -25,10 +25,12 @@ into a representation that *is* unitary for the given inner product:
 `TauCeti.ContRepresentation.exists_isUnitary_congr` produces `e : V ≃L[𝕜] V` with
 `IsUnitary (congr e π)`.
 
-So a downstream statement about unitary representations loses no generality, and the two
-consequences recorded here are the form that fact is consumed in: a matrix coefficient of an
-arbitrary finite-dimensional continuous representation is a matrix coefficient of a unitary one,
-and hence the representative ring `𝓡(G)` is spanned by the matrix coefficients of the **unitary**
+What this buys is a replacement of `π` by an equivalent representation, not by `π` itself, so a
+property may be proved for unitary representations alone exactly when it is invariant under
+conjugation by a continuous linear automorphism. The two consequences recorded here are the form
+that fact is consumed in, and both are of that kind: a matrix coefficient of an arbitrary
+finite-dimensional continuous representation is a matrix coefficient of a unitary one, and hence
+the representative ring `𝓡(G)` is spanned by the matrix coefficients of the **unitary**
 finite-dimensional continuous representations alone.
 
 ## Main statements
@@ -90,8 +92,9 @@ theorem exists_isUnitary_congr (π : ContRepresentation 𝕜 G V) (hπ : Continu
     ∃ e : V ≃L[𝕜] V, IsUnitary (congr e π) := by
   obtain ⟨A, hA⟩ := exists_continuousLinearEquiv_inner_map_map (gramOperator π hπ)
     (isSymmetric_gramOperator π hπ) fun _ hv ↦ re_inner_gramOperator_self_pos π hπ hv
-  have hsymm : ∀ v w : V, ⟪gramOperator π hπ v, w⟫_𝕜 = ⟪v, gramOperator π hπ w⟫_𝕜 := fun v w ↦ by
-    rw [inner_gramOperator_left, inner_gramOperator]
+  -- `isSymmetric_gramOperator` with the continuous-linear-map coercion, so that it rewrites.
+  have hsymm : ∀ v w : V, ⟪gramOperator π hπ v, w⟫_𝕜 = ⟪v, gramOperator π hπ w⟫_𝕜 :=
+    isSymmetric_gramOperator π hπ
   -- The averaged form is invariant, written with the Gram operator on the left.
   have hinv : ∀ (g : G) (v w : V), ⟪gramOperator π hπ (π g v), π g w⟫_𝕜
       = ⟪gramOperator π hπ v, w⟫_𝕜 := fun g v w ↦ by

--- a/TauCeti/RepresentationTheory/Continuous/Transport.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Transport.lean
@@ -123,6 +123,7 @@ This is `TauCeti.ContRepresentation.matrixCoeff_congr` with the isometry hypothe
 linear isometry equivalence `(e⁻¹)† = e`, and the two statements agree. It is what says that being
 a matrix coefficient depends only on the *equivalence class* of a representation, so a
 representation may be replaced by any conjugate of it — for instance by a unitary one. -/
+@[simp]
 theorem matrixCoeff_congr_adjoint (e : V ≃L[𝕜] W) {π : ContRepresentation 𝕜 G V}
     (hπ : Continuous π) (v w : V) :
     matrixCoeff (congr e π) (continuous_congr e hπ) (e v)

--- a/TauCeti/RepresentationTheory/Continuous/Transport.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Transport.lean
@@ -32,6 +32,8 @@ so nothing is lost by pinning a model.
   `TauCeti.ContRepresentation.IsUnitary.congr`: the transport preserves continuity and unitarity.
 * `TauCeti.ContRepresentation.matrixCoeff_congr`: the matrix coefficients of the transport at the
   transported vectors are those of the original representation.
+* `TauCeti.ContRepresentation.matrixCoeff_congr_adjoint`: the same for an equivalence that is not
+  isometric, where the second vector moves along the adjoint of `e⁻¹` instead of along `e`.
 -/
 
 public section
@@ -105,6 +107,31 @@ theorem matrixCoeff_congr (e : V ≃ₗᵢ[𝕜] W) {π : ContRepresentation �
   simp
 
 end CongrIsometry
+
+section CongrAdjoint
+
+variable {𝕜 G V W : Type*} [RCLike 𝕜] [Monoid G] [TopologicalSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [CompleteSpace V]
+  [NormedAddCommGroup W] [InnerProductSpace 𝕜 W] [CompleteSpace W]
+
+/-- **Transport along an arbitrary continuous linear equivalence moves matrix coefficients along
+`e` and along the adjoint of `e⁻¹`.** For an `e` that is not isometric the second vector has to be
+moved by `(e⁻¹)†` rather than by `e`, since it is paired with the transported vector rather than
+transported itself.
+
+This is `TauCeti.ContRepresentation.matrixCoeff_congr` with the isometry hypothesis dropped: for a
+linear isometry equivalence `(e⁻¹)† = e`, and the two statements agree. It is what says that being
+a matrix coefficient depends only on the *equivalence class* of a representation, so a
+representation may be replaced by any conjugate of it — for instance by a unitary one. -/
+theorem matrixCoeff_congr_adjoint (e : V ≃L[𝕜] W) {π : ContRepresentation 𝕜 G V}
+    (hπ : Continuous π) (v w : V) :
+    matrixCoeff (congr e π) (continuous_congr e hπ) (e v)
+        (ContinuousLinearMap.adjoint (e.symm : W →L[𝕜] V) w) = matrixCoeff π hπ v w := by
+  ext g
+  rw [matrixCoeff_apply, matrixCoeff_apply, congr_apply, ContinuousLinearMap.adjoint_inner_right]
+  simp
+
+end CongrAdjoint
 
 end ContRepresentation
 


### PR DESCRIPTION
This PR conjugates a finite-dimensional continuous representation of a compact group into a unitary one, finishing the unitarian trick. `TauCeti.ContRepresentation.gramOperator` already averages the inner product over Haar measure and records the averaged form as a positive-definite self-adjoint operator `S` with `(π g)† ∘ S ∘ (π g) = S`; that is an invariant form, not a unitary representation, because Lean fixes one `InnerProductSpace` structure on the carrier and `π` need not be unitary for it. `TauCeti.ContRepresentation.exists_isUnitary_congr` now produces `e : V ≃L[𝕜] V` with `IsUnitary (congr e π)`, so a statement proved for unitary representations loses no generality.

The change of coordinates is the content. `TauCeti.exists_continuousLinearEquiv_inner_map_map`, in the new `TauCeti/Analysis/InnerProductSpace/PositiveDefinite.lean`, says that a symmetric operator whose form `⟪S ·, ·⟫` is positive definite becomes the standard inner product after an automorphism: an orthonormal eigenbasis of `S` has positive eigenvalues, so scaling the `i`-th eigenvector by `(√(λ i))⁻¹` gives a basis orthonormal *for the form*. This is the inverse square root of `S` without any operator functional calculus, which matters here because the compact-group development is stated over `[RCLike 𝕜]` and Mathlib's continuous functional calculus for `V →L[𝕜] V` is available only over `ℂ`.

Two consequences are recorded in the form the Peter-Weyl argument consumes them. `TauCeti.ContRepresentation.matrixCoeff_congr_adjoint` extends `matrixCoeff_congr` to an equivalence that is not isometric, where the second vector moves along the adjoint of `e⁻¹` rather than along `e`; matrix coefficients therefore depend only on the equivalence class of a representation, and `TauCeti.ContRepresentation.exists_isUnitary_matrixCoeff_eq` rewrites any of them as a matrix coefficient of a unitary representation. `TauCeti.isRepresentative_iff_exists_isUnitary` is the resulting characterization: a representative function is a matrix coefficient of a *unitary* finite-dimensional continuous representation on a standard model, so the representative ring `𝓡(G)` is spanned by the matrix coefficients of the unitary representations alone.

Milestone: Layer 1 of the compact-groups roadmap, "unitarizability (Weyl's unitarian trick)", whose statement asks that "downstream results may assume `IsUnitary` without loss of generality"; the module docstring of `Unitarizable.lean` recorded that the construction was not carried out, and both pointers are updated here. What remains on the lane to the Layer 5 summit is completeness of the matrix-coefficient system: every representative function has to be expanded in the coefficients of a chosen family of irreducible unitary representations, which is now reachable because the representation whose coefficients are being expanded may be taken unitary and then decomposed by `exists_orthogonal_irreducible_decomposition`.

No material was taken from the supplementary source snapshot; nothing was vendored from Mathlib.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"exists-isunitary-congr"}-->

🤖 Prepared with Claude Code
