### PR TITLE
refactor(Semigroups): name the continuity estimate behind norm continuity

### DIFF
--- a/TauCeti/Analysis/Semigroups/UniformlyContinuous.lean
+++ b/TauCeti/Analysis/Semigroups/UniformlyContinuous.lean
@@ -59,6 +59,20 @@ private theorem normalizedIntegral_sub_one_eq (S : StronglyContinuousSemigroup X
     intervalIntegral.integral_const, smul_sub, smul_smul, sub_zero,
     inv_mul_cancel₀ ht.ne', one_smul]
 
+omit [CompleteSpace X] in
+/-- **A semigroup moves by less than `ε` over an interval on which it stays near the identity.**
+For `a ≤ b`, if the operator norm at `a` is at most `C > 0` and the semigroup is within `ε / C` of
+the identity after the elapsed time `b - a`, then `S b` and `S a` are within `ε`. -/
+private theorem dist_lt_of_le_of_norm_sub_one_lt (S : StronglyContinuousSemigroup X) {a b : NNReal}
+    (hab : a ≤ b) {C ε : ℝ} (hC : 0 < C) (hSa : ‖S a‖ ≤ C)
+    (hgap : ‖S (b - a) - 1‖ < ε / C) : dist (S b) (S a) < ε := by
+  rw [dist_eq_norm, S.sub_eq_comp_sub_one_of_le hab]
+  calc
+    ‖(S a).comp (S (b - a) - 1)‖
+        ≤ ‖S a‖ * ‖S (b - a) - 1‖ := ContinuousLinearMap.opNorm_comp_le _ _
+    _ < C * (ε / C) := mul_lt_mul' hSa hgap (norm_nonneg _) hC
+    _ = ε := by field_simp
+
 private theorem continuous_of_continuousAt_zero (S : StronglyContinuousSemigroup X)
     (hS : ContinuousAt (fun t : NNReal ↦ S t) 0) : Continuous fun t : NNReal ↦ S t := by
   obtain ⟨ω, M, hb⟩ := S.existsGrowthBound
@@ -72,39 +86,23 @@ private theorem continuous_of_continuousAt_zero (S : StronglyContinuousSemigroup
     positivity
   obtain ⟨δ, hδ, hsmall⟩ := Metric.continuousAt_iff.mp hS (ε / C) (div_pos hε hC)
   refine ⟨δ, hδ, fun t ht ↦ ?_⟩
+  -- continuity at zero bounds the gap to the identity over the elapsed time, in either order
+  have hgap : ∀ a b : NNReal, a ≤ b → dist b a < δ → ‖S (b - a) - 1‖ < ε / C := fun a b hab hd => by
+    simpa only [S.map_zero, ContinuousLinearMap.one_def, dist_eq_norm] using
+      hsmall (by simpa [NNReal.dist_eq, NNReal.coe_sub hab] using hd)
   rcases le_total t₀ t with ht₀t | htt₀
-  · have hdiff := S.sub_eq_comp_sub_one_of_le ht₀t
-    have hsmall' : ‖S (t - t₀) - 1‖ < ε / C := by
-      simpa only [S.map_zero, ContinuousLinearMap.one_def, dist_eq_norm] using
-        hsmall (by simpa [NNReal.dist_eq, NNReal.coe_sub ht₀t] using ht)
-    rw [dist_eq_norm, hdiff]
-    calc
-      ‖(S t₀).comp (S (t - t₀) - 1)‖
-          ≤ ‖S t₀‖ * ‖S (t - t₀) - 1‖ := ContinuousLinearMap.opNorm_comp_le _ _
-      _ < C * (ε / C) := by
-        gcongr
-        dsimp [C]
-        linarith [le_max_left ‖S t₀‖ (M * Real.exp (max ω 0 * t₀))]
-      _ = ε := by field_simp
-  · have hdiff : S t - S t₀ = (S t).comp (1 - S (t₀ - t)) := by
-      rw [← neg_sub (S t₀) (S t), S.sub_eq_comp_sub_one_of_le htt₀, ← ContinuousLinearMap.comp_neg,
-        neg_sub]
-    have hsmall' : ‖1 - S (t₀ - t)‖ < ε / C := by
-      rw [← norm_neg, neg_sub]
-      simpa only [S.map_zero, ContinuousLinearMap.one_def, dist_eq_norm] using
-        hsmall (by simpa [NNReal.dist_eq, NNReal.coe_sub htt₀, abs_sub_comm] using ht)
-    have hSt : ‖S t‖ < C := by
-      dsimp [C]
+  · exact S.dist_lt_of_le_of_norm_sub_one_lt ht₀t hC
+      (by dsimp [C]; linarith [le_max_left ‖S t₀‖ (M * Real.exp (max ω 0 * t₀))])
+      (hgap t₀ t ht₀t ht)
+  · have hSt : ‖S t‖ ≤ C := by
       have hbt : ‖S t‖ ≤ M * Real.exp (max ω 0 * t₀) := by
         rw [← S.realOperator_coe]
         exact hb.norm_le_mul_exp_max_zero_mul_of_le t.2 (by exact_mod_cast htt₀)
-      linarith [hbt, le_max_right ‖S t₀‖ (M * Real.exp (max ω 0 * t₀))]
-    rw [dist_eq_norm, hdiff]
-    calc
-      ‖(S t).comp (1 - S (t₀ - t))‖
-          ≤ ‖S t‖ * ‖1 - S (t₀ - t)‖ := ContinuousLinearMap.opNorm_comp_le _ _
-      _ < C * (ε / C) := by gcongr
-      _ = ε := by field_simp
+      dsimp [C]
+      linarith [le_max_right ‖S t₀‖ (M * Real.exp (max ω 0 * t₀))]
+    rw [dist_comm]
+    exact S.dist_lt_of_le_of_norm_sub_one_lt htt₀ hC hSt
+      (hgap t t₀ htt₀ (by rwa [dist_comm]))
 
 omit [CompleteSpace X] in
 /-- **A norm-continuous semigroup stays within any prescribed distance of the identity on a short

--- a/TauCeti/Analysis/Semigroups/UniformlyContinuous.lean
+++ b/TauCeti/Analysis/Semigroups/UniformlyContinuous.lean
@@ -60,12 +60,15 @@ private theorem normalizedIntegral_sub_one_eq (S : StronglyContinuousSemigroup X
     inv_mul_cancel₀ ht.ne', one_smul]
 
 omit [CompleteSpace X] in
-/-- **A semigroup moves by less than `ε` over an interval on which it stays near the identity.**
-For `a ≤ b`, if the operator norm at `a` is at most `C > 0` and the semigroup is within `ε / C` of
-the identity after the elapsed time `b - a`, then `S b` and `S a` are within `ε`. -/
+/-- **A step of a semigroup is short when the semigroup is near the identity at the step's
+length.** For `a ≤ b`, if the operator norm at `a` is at most `C` and `S (b - a)` is within `ε / C`
+of the identity, then `S b` and `S a` are within `ε`. -/
 private theorem dist_lt_of_le_of_norm_sub_one_lt (S : StronglyContinuousSemigroup X) {a b : NNReal}
-    (hab : a ≤ b) {C ε : ℝ} (hC : 0 < C) (hSa : ‖S a‖ ≤ C)
+    (hab : a ≤ b) {C ε : ℝ} (hSa : ‖S a‖ ≤ C)
     (hgap : ‖S (b - a) - 1‖ < ε / C) : dist (S b) (S a) < ε := by
+  -- `C` is positive: it dominates a norm, and it cannot vanish or `ε / C` would too
+  have hpos : 0 < ε / C := (norm_nonneg _).trans_lt hgap
+  have hC : 0 < C := ((norm_nonneg (S a)).trans hSa).lt_of_ne' (by rintro rfl; simp at hpos)
   rw [dist_eq_norm, S.sub_eq_comp_sub_one_of_le hab]
   calc
     ‖(S a).comp (S (b - a) - 1)‖
@@ -91,7 +94,7 @@ private theorem continuous_of_continuousAt_zero (S : StronglyContinuousSemigroup
     simpa only [S.map_zero, ContinuousLinearMap.one_def, dist_eq_norm] using
       hsmall (by simpa [NNReal.dist_eq, NNReal.coe_sub hab] using hd)
   rcases le_total t₀ t with ht₀t | htt₀
-  · exact S.dist_lt_of_le_of_norm_sub_one_lt ht₀t hC
+  · exact S.dist_lt_of_le_of_norm_sub_one_lt ht₀t
       (by dsimp [C]; linarith [le_max_left ‖S t₀‖ (M * Real.exp (max ω 0 * t₀))])
       (hgap t₀ t ht₀t ht)
   · have hSt : ‖S t‖ ≤ C := by
@@ -101,7 +104,7 @@ private theorem continuous_of_continuousAt_zero (S : StronglyContinuousSemigroup
       dsimp [C]
       linarith [le_max_right ‖S t₀‖ (M * Real.exp (max ω 0 * t₀))]
     rw [dist_comm]
-    exact S.dist_lt_of_le_of_norm_sub_one_lt htt₀ hC hSt
+    exact S.dist_lt_of_le_of_norm_sub_one_lt htt₀ hSt
       (hgap t t₀ htt₀ (by rwa [dist_comm]))
 
 omit [CompleteSpace X] in


### PR DESCRIPTION
`continuous_of_continuousAt_zero` upgrades continuity at zero to continuity everywhere. After fixing `t₀` and `ε`, it splits on `le_total t₀ t` and runs the same estimate twice — once with the increment `S t - S t₀ = (S t₀).comp (S (t - t₀) - 1)`, once with its negative — so the two branches differ only by which of `t₀` and `t` is the earlier time.

`dist_lt_of_le_of_norm_sub_one_lt` states that estimate once: for `a ≤ b`, if `‖S a‖ ≤ C` and `S (b - a)` is within `ε / C` of the identity, then `dist (S b) (S a) < ε`. The two branches become one application each, the second under `dist_comm`.

`0 < C` is not assumed. It follows: `C` dominates `‖S a‖`, so it is nonnegative, and it cannot be zero because `ε / 0` is `0`, which no norm is below. So the caller supplies only the two bounds it actually has.

The second half of the duplication was the conversion of the `δ`-hypothesis: both branches turned `dist t t₀ < δ` into `dist (S (later - earlier)) (S 0) < ε / C` through `NNReal.coe_sub`, once in each order. That is now a single `hgap` taking the two times and the inequality between them.

Its hypotheses are re-derived rather than inherited. The parent has `ω`, `M`, the growth bound `hb`, the base point `t₀`, `δ` and the continuity-at-zero hypothesis in scope; none appear. `C` and `ε` are arbitrary reals rather than the parent's `max ‖S t₀‖ (M * exp (max ω 0 * t₀)) + 1`, and `[CompleteSpace X]` is `omit`ted — the estimate is submultiplicativity of the operator norm applied to `sub_eq_comp_sub_one_of_le`, and completeness plays no part.

Both degenerate ends are consistent. At `a = b` the elapsed time is `0`, the gap hypothesis reads `0 < ε / C` and the conclusion `0 < ε`; and for `ε ≤ 0` the gap hypothesis is unsatisfiable, so the statement is vacuous rather than false.

The bound on the earlier operator is taken as `‖S a‖ ≤ C` rather than the strict `<` both branches happened to prove: the product step only needs `‖S a‖ * ‖S (b - a) - 1‖ ≤ C * ‖S (b - a) - 1‖ < C * (ε / C)`, where the strictness comes from the gap.

The parent drops from 45 lines to 29.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: OneParameterSemigroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
