### PR TITLE
refactor(CliffordAlgebra): hoist the graded-equivalence file's repeated binders

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
@@ -63,16 +63,17 @@ namespace TauCeti
 namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+  (Q : QuadraticForm R M) [Invertible (2 : R)]
 
 /-- `equivExterior` restricted to a Clifford filtration step. -/
-noncomputable def equivExteriorFiltration (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
+noncomputable def equivExteriorFiltration (k : ℕ) :
     filtration Q k ≃ₗ[R] filtration (0 : QuadraticForm R M) k :=
   (equivExterior Q).ofSubmodules _ _
     (changeFormEquiv_map_filtration Q changeForm.associated_neg_proof k)
 
 /-- Coercing the restricted exterior equivalence is the ambient `equivExterior` map. -/
 @[simp]
-theorem coe_equivExteriorFiltration_apply (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
+theorem coe_equivExteriorFiltration_apply (k : ℕ)
     (x : filtration Q k) :
     (equivExteriorFiltration Q k x : CliffordAlgebra (0 : QuadraticForm R M)) =
       equivExterior Q x := by
@@ -80,12 +81,12 @@ theorem coe_equivExteriorFiltration_apply (Q : QuadraticForm R M) [Invertible (2
 
 /-- Coercing the inverse restricted exterior equivalence is the ambient inverse map. -/
 @[simp]
-theorem coe_equivExteriorFiltration_symm_apply (Q : QuadraticForm R M) [Invertible (2 : R)]
+theorem coe_equivExteriorFiltration_symm_apply
     (k : ℕ) (x : filtration (0 : QuadraticForm R M) k) :
     ((equivExteriorFiltration Q k).symm x : CliffordAlgebra Q) = (equivExterior Q).symm x := by
   simp only [equivExteriorFiltration, equivExterior, LinearEquiv.ofSubmodules_symm_apply]
 
-private theorem equivExteriorFiltration_map_previous (Q : QuadraticForm R M) [Invertible (2 : R)]
+private theorem equivExteriorFiltration_map_previous
     (k : ℕ) :
     (filtrationPreviousRestricted Q (k + 1)).map
         (equivExteriorFiltration Q (k + 1)).toLinearMap =
@@ -100,15 +101,14 @@ private theorem equivExteriorFiltration_map_previous (Q : QuadraticForm R M) [In
   rw [← changeFormEquiv_map_filtration Q changeForm.associated_neg_proof k,
     Submodule.mem_map_equiv]
 
-private noncomputable def equivExteriorFiltrationQuotient (Q : QuadraticForm R M)
-    [Invertible (2 : R)] (k : ℕ) :
+private noncomputable def equivExteriorFiltrationQuotient (k : ℕ) :
     FiltrationGradedPiece Q (k + 1) ≃ₗ[R]
       FiltrationGradedPiece (0 : QuadraticForm R M) (k + 1) :=
   Submodule.Quotient.equiv _ _ (equivExteriorFiltration Q (k + 1))
     (equivExteriorFiltration_map_previous Q k)
 
 /-- `equivExterior` carries each Clifford filtration step into the corresponding zero-form step. -/
-theorem equivExterior_mem_zero_form_filtration (Q : QuadraticForm R M) [Invertible (2 : R)]
+theorem equivExterior_mem_zero_form_filtration
     {k : ℕ} {x : CliffordAlgebra Q} (hx : x ∈ filtration Q k) :
     equivExterior Q x ∈ filtration (0 : QuadraticForm R M) k := by
   simpa only [coe_equivExteriorFiltration_apply] using
@@ -116,20 +116,20 @@ theorem equivExterior_mem_zero_form_filtration (Q : QuadraticForm R M) [Invertib
 
 /-- The inverse of `equivExterior` carries each zero-form filtration step back into the
 corresponding Clifford step. -/
-theorem equivExterior_symm_mem_filtration (Q : QuadraticForm R M) [Invertible (2 : R)] {k : ℕ}
+theorem equivExterior_symm_mem_filtration {k : ℕ}
     {x : ExteriorAlgebra R M} (hx : x ∈ filtration (0 : QuadraticForm R M) k) :
     (equivExterior Q).symm x ∈ filtration Q k := by
   simpa only [coe_equivExteriorFiltration_symm_apply] using
     ((equivExteriorFiltration Q k).symm ⟨x, hx⟩).property
 
 /-- The successive degree quotient of a Clifford algebra is the corresponding exterior power. -/
-noncomputable def filtrationGradedEquiv (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
+noncomputable def filtrationGradedEquiv (k : ℕ) :
     FiltrationGradedPiece Q (k + 1) ≃ₗ[R] ⋀[R]^(k + 1) M :=
   (equivExteriorFiltrationQuotient Q k).trans (zeroFormFiltrationQuotientEquivExteriorPower k)
 
 /-- On quotient representatives, `filtrationGradedEquiv` first applies `equivExterior`. -/
 @[simp]
-theorem filtrationGradedEquiv_apply_mk (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
+theorem filtrationGradedEquiv_apply_mk (k : ℕ)
     (x : filtration Q (k + 1)) :
     filtrationGradedEquiv Q k (Submodule.Quotient.mk x) =
       zeroFormFiltrationQuotientEquivExteriorPower k
@@ -145,7 +145,7 @@ theorem filtrationGradedEquiv_apply_mk (Q : QuadraticForm R M) [Invertible (2 : 
 /-- The inverse graded equivalence sends an exterior element to the quotient class of its
 preimage under `equivExterior`. -/
 @[simp]
-theorem filtrationGradedEquiv_symm_apply (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
+theorem filtrationGradedEquiv_symm_apply (k : ℕ)
     (x : ⋀[R]^(k + 1) M) :
     (filtrationGradedEquiv Q k).symm x =
       Submodule.Quotient.mk
@@ -162,8 +162,7 @@ theorem filtrationGradedEquiv_symm_apply (Q : QuadraticForm R M) [Invertible (2 
 /-- **The graded equivalence undoes the leading-term map.** Together with
 `filtrationLeadingTerm_surjective`, which holds over any `CommRing`, this identifies the two
 independent routes `Filtration.lean` and this file take to the degree-`k + 1` quotient. -/
-theorem filtrationGradedEquiv_comp_filtrationLeadingTerm (Q : QuadraticForm R M)
-    [Invertible (2 : R)] (k : ℕ) :
+theorem filtrationGradedEquiv_comp_filtrationLeadingTerm (k : ℕ) :
     (filtrationGradedEquiv Q k).toLinearMap ∘ₗ filtrationLeadingTerm Q k = LinearMap.id := by
   apply exteriorPower.linearMap_ext
   apply AlternatingMap.ext
@@ -183,14 +182,13 @@ theorem filtrationGradedEquiv_comp_filtrationLeadingTerm (Q : QuadraticForm R M)
 
 /-- The pointwise form, which is the one `simp` can use. -/
 @[simp]
-theorem filtrationGradedEquiv_filtrationLeadingTerm (Q : QuadraticForm R M) [Invertible (2 : R)]
+theorem filtrationGradedEquiv_filtrationLeadingTerm
     (k : ℕ) (x : ⋀[R]^(k + 1) M) :
     filtrationGradedEquiv Q k (filtrationLeadingTerm Q k x) = x :=
   LinearMap.congr_fun (filtrationGradedEquiv_comp_filtrationLeadingTerm Q k) x
 
 /-- The leading-term map is `filtrationGradedEquiv`'s inverse. -/
-theorem filtrationLeadingTerm_eq_filtrationGradedEquiv_symm (Q : QuadraticForm R M)
-    [Invertible (2 : R)] (k : ℕ) :
+theorem filtrationLeadingTerm_eq_filtrationGradedEquiv_symm (k : ℕ) :
     filtrationLeadingTerm Q k = (filtrationGradedEquiv Q k).symm.toLinearMap := by
   rw [← LinearMap.comp_id (filtrationGradedEquiv Q k).symm.toLinearMap]
   exact (LinearEquiv.eq_toLinearMap_symm_comp _ _).2


### PR DESCRIPTION
Roadmap: RepresentationTheory

This PR moves `(Q : QuadraticForm R M)` and `[Invertible (2 : R)]` into the section `variable` block of `FiltrationGradedEquiv.lean`. All ten declarations took both explicitly, several on a continuation line.

Worth recording why this file and not its neighbour. I looked at doing the same to `AssociatedGraded.lean`, where the audit note that prompted this listed 29 declarations spelling out `(Q : QuadraticForm R M)`, and decided against it: its six instances take `{Q}` *implicitly*, necessarily, since an instance with an explicit argument cannot fire, and the explicit and implicit declarations interleave through the file (explicit up to line 284, implicit 305-345, explicit 382-457, implicit 463 and 500). A single `variable` block cannot serve both, and toggling binder mode four times would leave a reader worse off than the repetition does. This file has no instances at all, so one block covers everything.

No proof changes and no statement changes beyond where the binders come from. Full build with `--iofail`, axiom audit, module-system check and environment lint pass.

🤖 Prepared with Claude Code