### PR TITLE
refactor(ViaL2): carry moving selections to the directing measure

### DIFF
--- a/TauCeti/Probability/DeFinetti/ViaL2/EmpiricalToDirecting.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/EmpiricalToDirecting.lean
@@ -8,14 +8,21 @@ public import TauCeti.Probability.Exchangeability.L2.Cesaro.ToCondExp
 public import TauCeti.Probability.DeFinetti.DirectingMeasure.Basic
 
 /-!
-# Cesàro averages of an indicator converge to the directing measure
+# Block averages of an indicator converge to the directing measure
 
-`Contractable.tendsto_integral_abs_blockAverage_sub_condExp` identifies the `L¹` limit of the
-fixed-start Cesàro windows of an observable with `μ[f ∘ X 0 | tailProcess X]`, and
+`Contractable.tendsto_integral_abs_blockAverage_sub_condExp` identifies the `L¹` limit of the block
+averages of an observable with `μ[f ∘ X 0 | tailProcess X]`, along **any** selection that is
+injective for all sufficiently large lengths — the selection may move with the length.
 `directingMeasure_ae_eq_condExp` identifies `ω ↦ (directingMeasure μ X ω).real B` with the same
 conditional expectation when the observable is the indicator `𝟙_B`. Composing the two gives the
 statement in the form the `L²` route consumes: the empirical averages of `𝟙_B ∘ X` converge in
 `L¹` to the directing measure's evaluation at `B`.
+
+Fixed-start windows (`fixedStart r`) and disjoint windows (`disjointWindow c`) are both instances.
+The disjoint ones are what a finite-block factorization needs, and fixed starts cannot supply them:
+windows from two distinct fixed starts overlap once the common length exceeds the gap between the
+starts. The limit does not depend on the selection, so every one of them converges to the same
+directing-measure evaluation.
 
 The point is that no directing measure is *constructed* here. `directingMeasure` is Mathlib's
 `condDistrib` conditioned on `tailProcess X`, which the martingale route also uses but does not

--- a/TauCeti/Probability/DeFinetti/ViaL2/EmpiricalToDirecting.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/EmpiricalToDirecting.lean
@@ -35,31 +35,25 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- **The Cesàro averages of an indicator converge to the directing measure.** For a contractable
-process on a standard Borel state space and a measurable set `B`, the fixed-start Cesàro windows of
-`𝟙_B ∘ X` converge in `L¹` to `ω ↦ (directingMeasure μ X ω).real B`. -/
+/-- **The block averages of an indicator converge to the directing measure.** For a contractable
+process on a standard Borel state space and a measurable set `B`, the block averages of `𝟙_B ∘ X`
+along any eventually-injective selection converge in `L¹` to `ω ↦ (directingMeasure μ X ω).real B`.
+
+The selection may move with the length, so this covers the disjoint windows a block factorization
+needs as well as fixed-start ones; the limit is the same for every selection. -/
 theorem Contractable.tendsto_integral_abs_blockAverage_indicator_sub_directingMeasure
     [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
     (hX : Contractable μ X) (hX_meas : ∀ i, Measurable (X i)) {B : Set α} (hB : MeasurableSet B)
-    (r : ℕ) :
+    (k : ∀ n : ℕ, Fin (n + 1) → ℕ) (hk : ∀ᶠ n in atTop, Function.Injective (k n)) :
     Tendsto
-      (fun m => ∫ ω, |blockAverage (fun i ω => Set.indicator B (fun _ => (1 : ℝ)) (X i ω))
-          (fun j : Fin (m + 1) => r + j) ω
+      (fun m => ∫ ω, |blockAverage (fun i ω => Set.indicator B (fun _ => (1 : ℝ)) (X i ω)) (k m) ω
         - (directingMeasure μ X ω).real B| ∂μ)
       atTop (𝓝 0) := by
   have hf : Measurable (Set.indicator B (fun _ => (1 : ℝ))) :=
     (measurable_const.indicator hB)
   have hf_bdd : ∃ C, ∀ x, ‖Set.indicator B (fun _ => (1 : ℝ)) x‖ ≤ C :=
     ⟨1, fun x => by simpa only [norm_one] using norm_indicator_le_norm_self (fun _ => (1 : ℝ)) x⟩
-  -- This route reads a fixed start, instantiating the upstream moving-selection theorem at `r`.
-  have hlim : Tendsto (fun m => ∫ ω,
-      |blockAverage (fun i ω => Set.indicator B (fun _ => (1 : ℝ)) (X i ω))
-          (fun j : Fin (m + 1) => r + (j : ℕ)) ω
-        - (μ[fun ω => Set.indicator B (fun _ => (1 : ℝ)) (X 0 ω) | tailProcess X]) ω| ∂μ)
-      atTop (𝓝 0) := by
-    simpa only [funext (fixedStart_apply r _)] using
-      hX.tendsto_integral_abs_blockAverage_sub_condExp hX_meas hf hf_bdd
-        (fixedStart r) (fixedStart_eventually_injective r)
+  have hlim := hX.tendsto_integral_abs_blockAverage_sub_condExp hX_meas hf hf_bdd k hk
   -- Normalise the composition wrapper so the rewrite matches without relying on defeq.
   have hdir : (fun ω => (directingMeasure μ X ω).real B)
       =ᵐ[μ] μ[fun ω => Set.indicator B (fun _ => (1 : ℝ)) (X 0 ω) | tailProcess X] := by


### PR DESCRIPTION
```lean
theorem Contractable.tendsto_integral_abs_blockAverage_indicator_sub_directingMeasure
    [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
    (hX : Contractable μ X) (hX_meas : ∀ i, Measurable (X i)) {B : Set α} (hB : MeasurableSet B)
    (k : ∀ n : ℕ, Fin (n + 1) → ℕ) (hk : ∀ᶠ n in atTop, Function.Injective (k n)) :
    Tendsto
      (fun m => ∫ ω, |blockAverage (fun i ω => Set.indicator B (fun _ => (1 : ℝ)) (X i ω)) (k m) ω
        - (directingMeasure μ X ω).real B| ∂μ)
      atTop (𝓝 0)
```

#2590 generalised the Cesàro chain — comparison, convergence, tail measurability, conditional
expectation — to moving injective selections. This theorem was the last link still restricted to
fixed starts: it took `r : ℕ` and instantiated the moving-selection conditional-expectation result
at that start, discarding the generality one step before the directing measure.

It now takes the selection and its eventual injectivity and passes them straight through. The limit
is the same function for every selection, so nothing else in the proof changes; the diff is one
file.

With this the whole `L²` chain accepts moving selections, and in particular the disjoint windows
`disjointWindow c` (also from #2590) that a finite-block factorization needs — windows from distinct
fixed starts overlap once the common length exceeds the gap between them, so fixed starts cannot
serve there.

Roadmap: Exchangeability

Advances `TauCetiRoadmap/Exchangeability/README.md`, **Layer 3**. This is the remaining API step
before simultaneous disjoint-window convergence, which the area's `STATUS.md` names as the
substantive step for `deFinetti_viaL2`.

Intention: TauCetiProject/TauCetiRoadmap#131 (claimed).

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol