### PR TITLE
feat: the extreme Weyl modules are the symmetric and exterior powers

### DIFF
--- a/TauCeti/LinearAlgebra/ExteriorPower.lean
+++ b/TauCeti/LinearAlgebra/ExteriorPower.lean
@@ -18,10 +18,12 @@ vanishes as soon as `d` exceeds the rank of the module, and computes the trace o
 endomorphism from a basis of eigenvectors.
 
 It then builds the surjection `exteriorPower.fromTensorPower : ⨂[R]^n M →ₗ[R] ⋀[R]^n M` that is
-right inverse, up to the factor `n!`, to Mathlib's antisymmetrization
-`exteriorPower.toTensorPower`. Consequently the antisymmetrization is injective once `n!` is a unit
-in the base ring, and its image is the image of the antisymmetrization operator `∑_σ sgn(σ) σ` on
-the tensor power. That is the statement a Young symmetrizer of a one-column shape consumes.
+left inverse, up to the factor `n!`, to Mathlib's antisymmetrization
+`exteriorPower.toTensorPower`: composing the antisymmetrization with it is `n! • id` on the exterior
+power, while composing the two the other way round is the antisymmetrization operator
+`∑_σ sgn(σ) σ` on the tensor power. Consequently the antisymmetrization is injective once `n!` is a
+unit in the base ring, and its image is the image of that operator. That is the statement a Young
+symmetrizer of a one-column shape consumes.
 
 It then describes the exterior power in the top degree, that is, in the degree equal to the rank of
 the module. There an exterior product of `n` vectors is the determinant of those vectors against a
@@ -50,7 +52,8 @@ one, spanned by the exterior product of a basis, and an endomorphism acts on it 
   multiplication by `n!`, whence `exteriorPower.toTensorPower_injective`.
 * `exteriorPower.range_toTensorPower`: the image of the antisymmetrization is the image of the
   antisymmetrization operator on the tensor power.
-* `exteriorPower.toTensorPower_comp_map`: the antisymmetrization is natural in the module.
+* `exteriorPower.toTensorPower_comp_map` and `exteriorPower.map_comp_fromTensorPower`: the
+  antisymmetrization and the canonical surjection are natural in the module.
 
 ## References
 
@@ -146,8 +149,9 @@ variable (R M) in
 /-- **The canonical surjection of the tensor power onto the exterior power**, sending a pure
 tensor to the corresponding exterior product.
 
-Mathlib's `exteriorPower.toTensorPower` runs the other way, by antisymmetrization; the two
-composites are `n!`. -/
+Mathlib's `exteriorPower.toTensorPower` runs the other way, by antisymmetrization; antisymmetrizing
+and then projecting back is `n!` on the exterior power, while projecting and then antisymmetrizing
+is the antisymmetrization operator `∑_σ sgn(σ) σ` on the tensor power. -/
 noncomputable def fromTensorPower : (⨂[R]^n M) →ₗ[R] ⋀[R]^n M :=
   PiTensorProduct.lift (ιMulti R n).toMultilinearMap
 
@@ -173,8 +177,7 @@ theorem fromTensorPower_comp_toTensorPower :
     rw [← Units.val_mul, Int.units_mul_self, Units.val_one]
   have h : ∀ σ : Equiv.Perm (Fin n),
       ((Equiv.Perm.sign σ : ℤ)) • ιMulti R n (fun i => v (σ i)) = ιMulti R n v := fun σ => by
-    rw [show (fun i => v (σ i)) = v ∘ σ from rfl, (ιMulti R n).map_perm, Units.smul_def,
-      smul_smul, hsq, one_smul]
+    rw [← Function.comp_def v σ, (ιMulti R n).map_perm, Units.smul_def, smul_smul, hsq, one_smul]
   rw [LinearMap.coe_comp, Function.comp_apply, toTensorPower_apply_ιMulti, map_sum]
   simp only [Units.smul_def, map_zsmul, fromTensorPower_tprod, h]
   rw [Finset.sum_const, Finset.card_univ, Fintype.card_perm, Fintype.card_fin,
@@ -185,14 +188,10 @@ over a `ℚ`-algebra. -/
 theorem toTensorPower_injective (h : IsUnit (n.factorial : R)) :
     Function.Injective (toTensorPower R M n) := by
   obtain ⟨u, hu⟩ := h
-  have key : ∀ z : ⋀[R]^n M, fromTensorPower R M n (toTensorPower R M n z) = (u : R) • z :=
-    fun z => by
-      have := congrArg (fun f : (⋀[R]^n M) →ₗ[R] ⋀[R]^n M => f z)
-        (fromTensorPower_comp_toTensorPower (R := R) (M := M) n)
-      simpa [hu, Nat.cast_smul_eq_nsmul] using this
-  intro x y hxy
-  have hx : (u : R) • x = (u : R) • y := by rw [← key, ← key, hxy]
-  simpa [smul_smul] using congrArg (fun z => ((u⁻¹ : Rˣ) : R) • z) hx
+  -- Rescaling the canonical surjection by `u⁻¹` makes it a left inverse of the antisymmetrization.
+  refine LinearMap.injective_of_comp_eq_id _ (((u⁻¹ : Rˣ) : R) • fromTensorPower R M n) ?_
+  rw [LinearMap.smul_comp, fromTensorPower_comp_toTensorPower, ← Nat.cast_smul_eq_nsmul R,
+    smul_smul, ← hu, u.inv_mul, one_smul]
 
 /-- Projecting a tensor to the exterior power and antisymmetrizing it back is the
 antisymmetrization operator `∑_σ sgn(σ) σ` of the tensor power. -/
@@ -214,6 +213,13 @@ theorem toTensorPower_comp_map {N : Type*} [AddCommGroup N] [Module R N] (f : M 
   refine LinearMap.ext_on (ιMulti_span R n M) ?_
   rintro _ ⟨v, rfl⟩
   simp [Units.smul_def, Function.comp_def]
+
+/-- The canonical surjection is natural in the module. -/
+theorem map_comp_fromTensorPower {N : Type*} [AddCommGroup N] [Module R N] (f : M →ₗ[R] N) :
+    (map n f) ∘ₗ (fromTensorPower R M n) =
+      (fromTensorPower R N n) ∘ₗ (PiTensorProduct.map fun _ : Fin n => f) := by
+  refine PiTensorProduct.ext (MultilinearMap.ext fun m => ?_)
+  simp [Function.comp_def]
 
 /-- The image of the antisymmetrization is the image of the antisymmetrization operator
 `∑_σ sgn(σ) σ` on the tensor power. -/

--- a/TauCeti/LinearAlgebra/ExteriorPower.lean
+++ b/TauCeti/LinearAlgebra/ExteriorPower.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Data.Fintype.Perm
 public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.LinearAlgebra.ExteriorPower.Basis
+public import Mathlib.LinearAlgebra.ExteriorPower.Pairing
 public import Mathlib.LinearAlgebra.Trace
 
 /-!
@@ -15,6 +17,12 @@ This file records that the `d`th exterior power of a finite free module over a c
 vanishes as soon as `d` exceeds the rank of the module, and computes the trace of an induced
 endomorphism from a basis of eigenvectors.
 
+It then builds the surjection `exteriorPower.fromTensorPower : ⨂[R]^n M →ₗ[R] ⋀[R]^n M` that is
+right inverse, up to the factor `n!`, to Mathlib's antisymmetrization
+`exteriorPower.toTensorPower`. Consequently the antisymmetrization is injective once `n!` is a unit
+in the base ring, and its image is the image of the antisymmetrization operator `∑_σ sgn(σ) σ` on
+the tensor power. That is the statement a Young symmetrizer of a one-column shape consumes.
+
 It then describes the exterior power in the top degree, that is, in the degree equal to the rank of
 the module. There an exterior product of `n` vectors is the determinant of those vectors against a
 fixed basis, times the exterior product of that basis; so the top exterior power is free of rank
@@ -22,6 +30,8 @@ one, spanned by the exterior product of a basis, and an endomorphism acts on it 
 
 ## Main definitions
 
+* `exteriorPower.fromTensorPower` is the canonical surjection of the tensor power onto the
+  exterior power.
 * `exteriorPower.topEquiv` identifies the top exterior power of a module with the scalars, using a
   basis indexed by `Fin n`.
 
@@ -36,6 +46,11 @@ one, spanned by the exterior product of a basis, and an endomorphism acts on it 
 * `exteriorPower.map_top_eq_det_smul` says an endomorphism acts on the top exterior power as
   multiplication by its determinant, and `exteriorPower.trace_map_top` computes the resulting
   trace.
+* `exteriorPower.fromTensorPower_comp_toTensorPower`: antisymmetrizing and projecting back is
+  multiplication by `n!`, whence `exteriorPower.toTensorPower_injective`.
+* `exteriorPower.range_toTensorPower`: the image of the antisymmetrization is the image of the
+  antisymmetrization operator on the tensor power.
+* `exteriorPower.toTensorPower_comp_map`: the antisymmetrization is natural in the module.
 
 ## References
 
@@ -46,7 +61,7 @@ determinant of a family of vectors against a basis from `Mathlib.LinearAlgebra.D
 
 public section
 
-open scoped BigOperators
+open scoped BigOperators TensorProduct
 
 universe u w
 
@@ -120,6 +135,96 @@ theorem eq_zero_of_finrank_lt (d : ℕ) (h : Module.finrank R M < d) (x : ⋀[R]
   exact Subsingleton.elim x 0
 
 end Vanishing
+
+/-! ### The exterior power as a quotient of the tensor power -/
+
+section FromTensorPower
+
+variable [CommRing R] [AddCommGroup M] [Module R M] (n : ℕ)
+
+variable (R M) in
+/-- **The canonical surjection of the tensor power onto the exterior power**, sending a pure
+tensor to the corresponding exterior product.
+
+Mathlib's `exteriorPower.toTensorPower` runs the other way, by antisymmetrization; the two
+composites are `n!`. -/
+noncomputable def fromTensorPower : (⨂[R]^n M) →ₗ[R] ⋀[R]^n M :=
+  PiTensorProduct.lift (ιMulti R n).toMultilinearMap
+
+@[simp]
+theorem fromTensorPower_tprod (m : Fin n → M) :
+    fromTensorPower R M n (PiTensorProduct.tprod R m) = ιMulti R n m :=
+  PiTensorProduct.lift.tprod m
+
+theorem fromTensorPower_surjective : Function.Surjective (fromTensorPower R M n) := by
+  rw [← LinearMap.range_eq_top, ← top_le_iff, ← ιMulti_span R n M, Submodule.span_le]
+  rintro _ ⟨v, rfl⟩
+  exact ⟨PiTensorProduct.tprod R v, fromTensorPower_tprod n v⟩
+
+/-- Antisymmetrizing an exterior product and projecting it back multiplies by `n!`: each of the
+`n!` signed reorderings returns the same exterior product. -/
+theorem fromTensorPower_comp_toTensorPower :
+    (fromTensorPower R M n) ∘ₗ (toTensorPower R M n) =
+      n.factorial • LinearMap.id (R := R) (M := ⋀[R]^n M) := by
+  refine LinearMap.ext_on (ιMulti_span R n M) ?_
+  rintro _ ⟨v, rfl⟩
+  have hsq : ∀ σ : Equiv.Perm (Fin n),
+      ((Equiv.Perm.sign σ : ℤ)) * ((Equiv.Perm.sign σ : ℤ)) = 1 := fun σ => by
+    rw [← Units.val_mul, Int.units_mul_self, Units.val_one]
+  have h : ∀ σ : Equiv.Perm (Fin n),
+      ((Equiv.Perm.sign σ : ℤ)) • ιMulti R n (fun i => v (σ i)) = ιMulti R n v := fun σ => by
+    rw [show (fun i => v (σ i)) = v ∘ σ from rfl, (ιMulti R n).map_perm, Units.smul_def,
+      smul_smul, hsq, one_smul]
+  rw [LinearMap.coe_comp, Function.comp_apply, toTensorPower_apply_ιMulti, map_sum]
+  simp only [Units.smul_def, map_zsmul, fromTensorPower_tprod, h]
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_perm, Fintype.card_fin,
+    LinearMap.smul_apply, LinearMap.id_apply]
+
+/-- The antisymmetrization is injective as soon as `n!` is a unit in the base ring, for instance
+over a `ℚ`-algebra. -/
+theorem toTensorPower_injective (h : IsUnit (n.factorial : R)) :
+    Function.Injective (toTensorPower R M n) := by
+  obtain ⟨u, hu⟩ := h
+  have key : ∀ z : ⋀[R]^n M, fromTensorPower R M n (toTensorPower R M n z) = (u : R) • z :=
+    fun z => by
+      have := congrArg (fun f : (⋀[R]^n M) →ₗ[R] ⋀[R]^n M => f z)
+        (fromTensorPower_comp_toTensorPower (R := R) (M := M) n)
+      simpa [hu, Nat.cast_smul_eq_nsmul] using this
+  intro x y hxy
+  have hx : (u : R) • x = (u : R) • y := by rw [← key, ← key, hxy]
+  simpa [smul_smul] using congrArg (fun z => ((u⁻¹ : Rˣ) : R) • z) hx
+
+/-- Projecting a tensor to the exterior power and antisymmetrizing it back is the
+antisymmetrization operator `∑_σ sgn(σ) σ` of the tensor power. -/
+theorem toTensorPower_comp_fromTensorPower :
+    (toTensorPower R M n) ∘ₗ (fromTensorPower R M n) =
+      ∑ σ : Equiv.Perm (Fin n), (Equiv.Perm.sign σ : ℤ) •
+        (PiTensorProduct.reindex R (fun _ : Fin n => M) σ).toLinearMap := by
+  refine PiTensorProduct.ext (MultilinearMap.ext fun m => ?_)
+  rw [LinearMap.compMultilinearMap_apply, LinearMap.compMultilinearMap_apply,
+    LinearMap.coe_comp, Function.comp_apply, fromTensorPower_tprod,
+    toTensorPower_apply_ιMulti, LinearMap.sum_apply]
+  refine Fintype.sum_equiv (Equiv.inv (Equiv.Perm (Fin n))) _ _ fun σ => ?_
+  simp [Units.smul_def, Equiv.Perm.inv_def]
+
+/-- The antisymmetrization is natural in the module. -/
+theorem toTensorPower_comp_map {N : Type*} [AddCommGroup N] [Module R N] (f : M →ₗ[R] N) :
+    (toTensorPower R N n) ∘ₗ (map n f) =
+      (PiTensorProduct.map fun _ : Fin n => f) ∘ₗ (toTensorPower R M n) := by
+  refine LinearMap.ext_on (ιMulti_span R n M) ?_
+  rintro _ ⟨v, rfl⟩
+  simp [Units.smul_def, Function.comp_def]
+
+/-- The image of the antisymmetrization is the image of the antisymmetrization operator
+`∑_σ sgn(σ) σ` on the tensor power. -/
+theorem range_toTensorPower :
+    LinearMap.range (toTensorPower R M n) =
+      LinearMap.range (∑ σ : Equiv.Perm (Fin n), (Equiv.Perm.sign σ : ℤ) •
+        (PiTensorProduct.reindex R (fun _ : Fin n => M) σ).toLinearMap) := by
+  rw [← toTensorPower_comp_fromTensorPower, LinearMap.range_comp,
+    LinearMap.range_eq_top.mpr (fromTensorPower_surjective n), Submodule.map_top]
+
+end FromTensorPower
 
 section Top
 

--- a/TauCeti/LinearAlgebra/ExteriorPower.lean
+++ b/TauCeti/LinearAlgebra/ExteriorPower.lean
@@ -7,7 +7,6 @@ module
 public import Mathlib.Data.Fintype.Perm
 public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.LinearAlgebra.ExteriorPower.Basis
-public import Mathlib.LinearAlgebra.ExteriorPower.Pairing
 public import Mathlib.LinearAlgebra.Trace
 
 /-!
@@ -167,6 +166,7 @@ theorem fromTensorPower_surjective : Function.Surjective (fromTensorPower R M n)
 
 /-- Antisymmetrizing an exterior product and projecting it back multiplies by `n!`: each of the
 `n!` signed reorderings returns the same exterior product. -/
+@[simp]
 theorem fromTensorPower_comp_toTensorPower :
     (fromTensorPower R M n) ∘ₗ (toTensorPower R M n) =
       n.factorial • LinearMap.id (R := R) (M := ⋀[R]^n M) := by

--- a/TauCeti/LinearAlgebra/SymmetricPower.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower.lean
@@ -4,20 +4,48 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Data.Fintype.Perm
 public import Mathlib.LinearAlgebra.PiTensorProduct.Finite
 public import Mathlib.LinearAlgebra.TensorPower.Symmetric
 
 /-!
-# Functoriality of symmetric tensor powers
+# Functoriality of symmetric tensor powers, and the symmetrization back into the tensor power
 
 This file equips Mathlib's symmetric tensor power with the linear map induced by a linear map of
 the underlying modules. It proves the expected action on pure tensors, identity law, and composition
 law. It also records that a symmetric power indexed by a finite type is finitely generated when its
 underlying module is.
 
+It then builds the map back, `SymmetricPower.toTensorPower : Sym[R] ι M →ₗ[R] ⨂[R] (_ : ι), M`,
+for a finite index type. The **symmetrization** `∑_σ σ` of the tensor power is constant on the
+fibres of the quotient map `SymmetricPower.mk`, because reindexing a pure tensor only permutes the
+terms of that sum, so it descends to the symmetric power; `toTensorPower` is that descent. It is
+the exact counterpart of Mathlib's `exteriorPower.toTensorPower`, and it takes a pure symmetric
+tensor to the sum of the pure tensors over all orderings of its factors.
+
+Composing back the other way multiplies by the order of the permutation group: `mk ∘ toTensorPower`
+is `(card ι)!`, because each of the `(card ι)!` reorderings becomes the same symmetric tensor
+again. So as soon as `(card ι)!` is a unit -- for instance over a `ℚ`-algebra -- the symmetrization
+is injective, and it identifies the symmetric power with the image of the symmetrization operator
+inside the tensor power. That is the statement a Young symmetrizer of a one-row shape consumes.
+
 ## Main definitions
 
 * `SymmetricPower.map` is the map induced on a symmetric tensor power.
+* `SymmetricPower.toTensorPower` is the symmetrization, from the symmetric power back into the
+  tensor power.
+
+## Main results
+
+* `SymmetricPower.toTensorPower_tprod`: the symmetrization of a pure symmetric tensor is the sum
+  of the pure tensors over all orderings of its factors.
+* `SymmetricPower.mk_comp_toTensorPower`: composing the symmetrization with the quotient map is
+  multiplication by `(card ι)!`.
+* `SymmetricPower.toTensorPower_injective`: the symmetrization is injective once `(card ι)!` is a
+  unit.
+* `SymmetricPower.range_toTensorPower`: its image is the image of the symmetrization operator on
+  the tensor power.
+* `SymmetricPower.toTensorPower_comp_map`: the symmetrization is natural in the module.
 
 ## References
 
@@ -97,6 +125,114 @@ theorem map_comp {N : Type*} {P : Type*}
   simp
 
 end CommSemiring
+
+/-! ### The symmetrization back into the tensor power -/
+
+section Symmetrization
+
+variable [CommSemiring R] [AddCommMonoid M] [Module R M] [Fintype ι] [DecidableEq ι]
+
+variable (R ι M) in
+/-- The symmetrization operator `∑_σ σ` on the tensor power, permuting the tensor factors. -/
+private noncomputable def symmetrizer : (⨂[R] (_ : ι), M) →ₗ[R] ⨂[R] (_ : ι), M :=
+  ∑ σ : Equiv.Perm ι, (PiTensorProduct.reindex R (fun _ : ι => M) σ).toLinearMap
+
+private theorem symmetrizer_tprod (m : ι → M) :
+    symmetrizer R ι M (⨂ₜ[R] i, m i) = ∑ σ : Equiv.Perm ι, ⨂ₜ[R] i, m (σ i) := by
+  rw [symmetrizer, LinearMap.sum_apply]
+  refine Fintype.sum_equiv (Equiv.inv (Equiv.Perm ι)) _ _ fun σ => ?_
+  simp
+
+private theorem symmetrizer_rel :
+    addConGen (Rel R ι M) ≤ AddCon.ker (symmetrizer R ι M).toAddMonoidHom := by
+  apply AddCon.addConGen_le.2
+  intro x y h
+  cases h with
+  | perm e m =>
+      refine (AddCon.ker_rel _).2 ?_
+      simp only [LinearMap.toAddMonoidHom_coe, symmetrizer_tprod]
+      refine Fintype.sum_bijective (e⁻¹ * ·) (Group.mulLeft_bijective _) _ _ fun σ => ?_
+      congr 1
+      funext i
+      simp
+
+variable (R ι M) in
+/-- **The symmetrization**, from the symmetric power back into the tensor power: the descent of
+the symmetrization operator `∑_σ σ` through the quotient map `SymmetricPower.mk`.
+
+This is the counterpart of Mathlib's `exteriorPower.toTensorPower`. -/
+noncomputable def toTensorPower : Sym[R] ι M →ₗ[R] ⨂[R] (_ : ι), M where
+  toFun := (addConGen (Rel R ι M)).lift (symmetrizer R ι M).toAddMonoidHom symmetrizer_rel
+  map_add' := map_add _
+  map_smul' r x := AddCon.induction_on x fun x => (symmetrizer R ι M).map_smul r x
+
+private theorem toTensorPower_mk' (x : ⨂[R] (_ : ι), M) :
+    toTensorPower R ι M (mk R ι M x) = (symmetrizer R ι M).toAddMonoidHom x :=
+  (rfl)
+
+@[simp]
+theorem toTensorPower_mk (x : ⨂[R] (_ : ι), M) :
+    toTensorPower R ι M (mk R ι M x) =
+      ∑ σ : Equiv.Perm ι, PiTensorProduct.reindex R (fun _ : ι => M) σ x := by
+  rw [toTensorPower_mk', LinearMap.toAddMonoidHom_coe, symmetrizer, LinearMap.sum_apply]
+  rfl
+
+/-- The symmetrization of a pure symmetric tensor is the sum of the pure tensors over all
+orderings of its factors. -/
+@[simp]
+theorem toTensorPower_tprod (m : ι → M) :
+    toTensorPower R ι M (⨂ₛ[R] i, m i) = ∑ σ : Equiv.Perm ι, ⨂ₜ[R] i, m (σ i) := by
+  rw [tprod, LinearMap.compMultilinearMap_apply, toTensorPower_mk']
+  exact symmetrizer_tprod m
+
+private theorem toTensorPower_comp_mk :
+    (toTensorPower R ι M) ∘ₗ mk R ι M = symmetrizer R ι M :=
+  LinearMap.ext fun x => (toTensorPower_mk' x)
+
+/-- The image of the symmetrization is the image of the symmetrization operator `∑_σ σ` on the
+tensor power. -/
+theorem range_toTensorPower :
+    LinearMap.range (toTensorPower R ι M) =
+      LinearMap.range (∑ σ : Equiv.Perm ι,
+        ((PiTensorProduct.reindex R (fun _ : ι => M) σ).toLinearMap)) := by
+  rw [show (∑ σ : Equiv.Perm ι, ((PiTensorProduct.reindex R (fun _ : ι => M) σ).toLinearMap)) =
+      (toTensorPower R ι M) ∘ₗ mk R ι M from toTensorPower_comp_mk.symm,
+    LinearMap.range_comp, range_mk, Submodule.map_top]
+
+/-- Symmetrizing and then projecting back to the symmetric power multiplies by `(card ι)!`: the
+`(card ι)!` reorderings of a pure tensor all become the same symmetric tensor. -/
+theorem mk_comp_toTensorPower :
+    (mk R ι M) ∘ₗ (toTensorPower R ι M) =
+      (Fintype.card ι).factorial • LinearMap.id (R := R) (M := Sym[R] ι M) := by
+  refine LinearMap.ext_on (span_tprod_eq_top (R := R) (ι := ι) (M := M)) ?_
+  rintro _ ⟨m, rfl⟩
+  have h : ∀ σ : Equiv.Perm ι, mk R ι M (⨂ₜ[R] i, m (σ i)) = ⨂ₛ[R] i, m i :=
+    fun σ => tprod_equiv σ m
+  rw [LinearMap.coe_comp, Function.comp_apply, toTensorPower_tprod, map_sum,
+    Finset.sum_congr rfl fun σ (_ : σ ∈ Finset.univ) => h σ, Finset.sum_const, Finset.card_univ,
+    Fintype.card_perm, LinearMap.smul_apply, LinearMap.id_apply]
+
+/-- The symmetrization is injective as soon as `(card ι)!` is a unit in the base ring, for
+instance over a `ℚ`-algebra. -/
+theorem toTensorPower_injective (h : IsUnit ((Fintype.card ι).factorial : R)) :
+    Function.Injective (toTensorPower R ι M) := by
+  obtain ⟨u, hu⟩ := h
+  have key : ∀ z : Sym[R] ι M, mk R ι M (toTensorPower R ι M z) = (u : R) • z := fun z => by
+    have := congrArg (fun f : Sym[R] ι M →ₗ[R] Sym[R] ι M => f z) mk_comp_toTensorPower
+    simpa [hu, Nat.cast_smul_eq_nsmul] using this
+  intro x y hxy
+  have hx : (u : R) • x = (u : R) • y := by rw [← key, ← key, hxy]
+  simpa [smul_smul] using congrArg (fun z => ((u⁻¹ : Rˣ) : R) • z) hx
+
+/-- The symmetrization is natural in the module. -/
+theorem toTensorPower_comp_map {N : Type v} [AddCommMonoid N] [Module R N] (f : M →ₗ[R] N) :
+    (toTensorPower R ι N) ∘ₗ (map (ι := ι) f) =
+      (PiTensorProduct.map fun _ : ι => f) ∘ₗ (toTensorPower R ι M) := by
+  refine LinearMap.ext_on (span_tprod_eq_top (R := R) (ι := ι) (M := M)) ?_
+  rintro _ ⟨m, rfl⟩
+  simp
+
+end Symmetrization
 
 section CommRing
 

--- a/TauCeti/LinearAlgebra/SymmetricPower.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower.lean
@@ -202,6 +202,7 @@ theorem range_toTensorPower :
 
 /-- Symmetrizing and then projecting back to the symmetric power multiplies by `(card ι)!`: the
 `(card ι)!` reorderings of a pure tensor all become the same symmetric tensor. -/
+@[simp]
 theorem mk_comp_toTensorPower :
     (mk R ι M) ∘ₗ (toTensorPower R ι M) =
       (Fintype.card ι).factorial • LinearMap.id (R := R) (M := Sym[R] ι M) := by

--- a/TauCeti/LinearAlgebra/SymmetricPower.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower.lean
@@ -186,8 +186,11 @@ theorem toTensorPower_tprod (m : ι → M) :
   exact symmetrizer_tprod m
 
 private theorem toTensorPower_comp_mk :
-    (toTensorPower R ι M) ∘ₗ mk R ι M = symmetrizer R ι M :=
-  LinearMap.ext fun x => (toTensorPower_mk' x)
+    (toTensorPower R ι M) ∘ₗ mk R ι M =
+      ∑ σ : Equiv.Perm ι, (PiTensorProduct.reindex R (fun _ : ι => M) σ).toLinearMap :=
+  LinearMap.ext fun x => by
+    rw [LinearMap.comp_apply, toTensorPower_mk, LinearMap.sum_apply]
+    simp only [LinearEquiv.coe_coe]
 
 /-- The image of the symmetrization is the image of the symmetrization operator `∑_σ σ` on the
 tensor power. -/
@@ -195,9 +198,7 @@ theorem range_toTensorPower :
     LinearMap.range (toTensorPower R ι M) =
       LinearMap.range (∑ σ : Equiv.Perm ι,
         ((PiTensorProduct.reindex R (fun _ : ι => M) σ).toLinearMap)) := by
-  rw [show (∑ σ : Equiv.Perm ι, ((PiTensorProduct.reindex R (fun _ : ι => M) σ).toLinearMap)) =
-      (toTensorPower R ι M) ∘ₗ mk R ι M from toTensorPower_comp_mk.symm,
-    LinearMap.range_comp, range_mk, Submodule.map_top]
+  rw [← toTensorPower_comp_mk, LinearMap.range_comp, range_mk, Submodule.map_top]
 
 /-- Symmetrizing and then projecting back to the symmetric power multiplies by `(card ι)!`: the
 `(card ι)!` reorderings of a pure tensor all become the same symmetric tensor. -/
@@ -217,12 +218,10 @@ instance over a `ℚ`-algebra. -/
 theorem toTensorPower_injective (h : IsUnit ((Fintype.card ι).factorial : R)) :
     Function.Injective (toTensorPower R ι M) := by
   obtain ⟨u, hu⟩ := h
-  have key : ∀ z : Sym[R] ι M, mk R ι M (toTensorPower R ι M z) = (u : R) • z := fun z => by
-    have := congrArg (fun f : Sym[R] ι M →ₗ[R] Sym[R] ι M => f z) mk_comp_toTensorPower
-    simpa [hu, Nat.cast_smul_eq_nsmul] using this
-  intro x y hxy
-  have hx : (u : R) • x = (u : R) • y := by rw [← key, ← key, hxy]
-  simpa [smul_smul] using congrArg (fun z => ((u⁻¹ : Rˣ) : R) • z) hx
+  -- Rescaling the quotient map by `u⁻¹` makes it a left inverse of the symmetrization.
+  refine LinearMap.injective_of_comp_eq_id _ (((u⁻¹ : Rˣ) : R) • mk R ι M) ?_
+  rw [LinearMap.smul_comp, mk_comp_toTensorPower, ← Nat.cast_smul_eq_nsmul R, smul_smul, ← hu,
+    u.inv_mul, one_smul]
 
 /-- The symmetrization is natural in the module. -/
 theorem toTensorPower_comp_map {N : Type v} [AddCommMonoid N] [Module R N] (f : M →ₗ[R] N) :

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
@@ -31,8 +31,8 @@ map the symmetric and the exterior power **into** the tensor power, with image e
 of the symmetrization, respectively antisymmetrization, operator, and are injective because
 composing back is multiplication by `d!`, invertible over a `ℚ`-algebra. On the symmetric-group
 side, the extreme-shape lemmas of `TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean`
-collapse `c_t` to a single factor, which is evaluated here as an element of the group algebra and
-then as an operator on the tensor power. Both maps are equivariant for `GL n k`, because
+collapse `c_t` to a single factor and evaluate it in the group algebra, which is read here as an
+operator on the tensor power. Both maps are equivariant for `GL n k`, because
 `GL n k` acts diagonally and the two operators only permute tensor factors; so the identification
 of subspaces is an isomorphism of representations, by
 `Representation.IntertwiningMap.equivOfRange`.
@@ -52,12 +52,9 @@ are zero, the exterior power because it is above the rank and the Weyl module by
 * `TauCeti.YoungTableau.weylRepEquivExtPowerRep`: **`𝕊^{(1ᵈ)}(kⁿ) ≅ ⋀ᵈ(kⁿ)`**, the Weyl module of
   a shape with at most one column is the exterior power, with
   `TauCeti.weylRepOfShapeEquivExtPowerRep` its shape-indexed form.
-* `TauCeti.YoungTableau.youngSymmetrizerOver_eq_sum_of_rowSubgroup_eq_top` and
-  `TauCeti.YoungTableau.youngSymmetrizerOver_eq_sum_of_colSubgroup_eq_top`: the value of `c_t` at
-  the two extreme shapes, in the group algebra, with
-  `TauCeti.YoungTableau.permTensorActionAlgHom_youngSymmetrizerOver_of_rowSubgroup_eq_top` and
-  `TauCeti.YoungTableau.permTensorActionAlgHom_youngSymmetrizerOver_of_colSubgroup_eq_top` the
-  corresponding operators on the tensor power.
+* `TauCeti.YoungTableau.permTensorActionAlgHom_youngSymmetrizerOver_of_rowSubgroup_eq_top` and
+  `TauCeti.YoungTableau.permTensorActionAlgHom_youngSymmetrizerOver_of_colSubgroup_eq_top`: the
+  operators on the tensor power that `c_t` becomes at the two extreme shapes.
 
 ## Implementation notes
 
@@ -94,43 +91,7 @@ namespace TauCeti
 
 namespace YoungTableau
 
-variable (k : Type u) [CommRing k] [Algebra ℚ k] {μ : YoungDiagram}
-
-/-- **The Young symmetrizer of a shape with at most one row is the full symmetrization**
-`∑_σ σ`: the row group is everything and the column group is trivial. -/
-theorem youngSymmetrizerOver_eq_sum_of_rowSubgroup_eq_top (t : YoungTableau μ)
-    (h : rowSubgroup t = ⊤) :
-    youngSymmetrizerOver k t =
-      ∑ σ : Equiv.Perm (Fin μ.card), MonoidAlgebra.of k (Equiv.Perm (Fin μ.card)) σ := by
-  rw [youngSymmetrizerOver_def,
-    youngSymmetrizer_eq_rowSymmetrizer t (colSubgroup_eq_bot_of_rowSubgroup_eq_top t h),
-    rowSymmetrizer_def, map_sum]
-  refine Finset.sum_bij (fun p _ => (p : Equiv.Perm (Fin μ.card)))
-    (fun _ _ => Finset.mem_univ _) (fun _ _ _ _ hab => Subtype.ext hab)
-    (fun σ _ => ?_) fun p _ => ?_
-  · refine ⟨⟨σ, by rw [h]; exact Subgroup.mem_top σ⟩, ?_, rfl⟩
-    simp
-  · rw [MonoidAlgebra.of_apply, MonoidAlgebra.mapAlgHom_single, map_one, MonoidAlgebra.of_apply]
-
-/-- **The Young symmetrizer of a shape with at most one column is the full antisymmetrization**
-`∑_σ sgn(σ) σ`: the column group is everything and the row group is trivial. -/
-theorem youngSymmetrizerOver_eq_sum_of_colSubgroup_eq_top (t : YoungTableau μ)
-    (h : colSubgroup t = ⊤) :
-    youngSymmetrizerOver k t =
-      ∑ σ : Equiv.Perm (Fin μ.card),
-        (Equiv.Perm.sign σ : ℤ) • MonoidAlgebra.of k (Equiv.Perm (Fin μ.card)) σ := by
-  rw [youngSymmetrizerOver_def,
-    youngSymmetrizer_eq_columnAntisymmetrizer t (rowSubgroup_eq_bot_of_colSubgroup_eq_top t h),
-    columnAntisymmetrizer_def, map_sum]
-  refine Finset.sum_bij (fun q _ => (q : Equiv.Perm (Fin μ.card)))
-    (fun _ _ => Finset.mem_univ _) (fun _ _ _ _ hab => Subtype.ext hab)
-    (fun σ _ => ?_) fun q _ => ?_
-  · refine ⟨⟨σ, by rw [h]; exact Subgroup.mem_top σ⟩, ?_, rfl⟩
-    simp
-  · rw [Int.cast_smul_eq_zsmul ℚ, map_zsmul, MonoidAlgebra.of_apply,
-      MonoidAlgebra.mapAlgHom_single, map_one, MonoidAlgebra.of_apply]
-
-variable (n : ℕ)
+variable (k : Type u) [CommRing k] [Algebra ℚ k] {μ : YoungDiagram} (n : ℕ)
 
 /-- On a shape with at most one row the Young symmetrizer acts on the tensor power by the
 symmetrization operator `∑_σ σ`. -/
@@ -207,12 +168,36 @@ noncomputable def YoungTableau.weylRepEquivSymPowerRep (t : YoungTableau μ) (h 
     (YoungTableau.weylRep k n t).Equiv (symPowerRep k n μ.card) :=
   (symPowerRepEquivWeylRep k n t h).symm
 
+/-- The isomorphism `TauCeti.YoungTableau.weylRepEquivSymPowerRep` is inverse to the
+symmetrization: symmetrizing its value returns the element of the tensor power it was applied
+to. -/
+@[simp]
+theorem YoungTableau.toTensorPower_weylRepEquivSymPowerRep (t : YoungTableau μ)
+    (h : μ.colLen 0 ≤ 1) (x : (YoungTableau.weylModule k n t).toSubmodule) :
+    SymmetricPower.toTensorPower k (Fin μ.card) (Fin n → k)
+        (YoungTableau.weylRepEquivSymPowerRep k n t h x) =
+      (x : ⨂[k]^μ.card (Fin n → k)) := by
+  rw [YoungTableau.weylRepEquivSymPowerRep, ← symPowerRepEquivWeylRep_apply_coe k n t h,
+    Representation.Equiv.apply_symm_apply]
+
 /-- The shape-indexed form of `TauCeti.YoungTableau.weylRepEquivSymPowerRep`. -/
 noncomputable def weylRepOfShapeEquivSymPowerRep (μ : YoungDiagram) (h : μ.colLen 0 ≤ 1) :
     (weylRepOfShape k n μ).Equiv (symPowerRep k n μ.card) :=
   (YoungTableau.weylRepEquivOfShape k n
       (StandardYoungTableau.rowSuperstandard μ).toEquiv).symm.trans
     (YoungTableau.weylRepEquivSymPowerRep k n _ h)
+
+/-- The shape-indexed isomorphism is the tableau-indexed one at the row-superstandard tableau,
+after moving the argument along `TauCeti.YoungTableau.weylRepEquivOfShape`. -/
+@[simp]
+theorem weylRepOfShapeEquivSymPowerRep_apply (μ : YoungDiagram) (h : μ.colLen 0 ≤ 1)
+    (x : (weylModuleOfShape k n μ).toSubmodule) :
+    weylRepOfShapeEquivSymPowerRep k n μ h x =
+      YoungTableau.weylRepEquivSymPowerRep k n
+        (StandardYoungTableau.rowSuperstandard μ).toEquiv h
+        ((YoungTableau.weylRepEquivOfShape k n
+          (StandardYoungTableau.rowSuperstandard μ).toEquiv).symm x) :=
+  Representation.Equiv.trans_apply _ _ x
 
 end OneRow
 
@@ -264,12 +249,36 @@ noncomputable def YoungTableau.weylRepEquivExtPowerRep (t : YoungTableau μ) (h 
     (YoungTableau.weylRep k n t).Equiv (extPowerRep k n μ.card) :=
   (extPowerRepEquivWeylRep k n t h).symm
 
+/-- The isomorphism `TauCeti.YoungTableau.weylRepEquivExtPowerRep` is inverse to the
+antisymmetrization: antisymmetrizing its value returns the element of the tensor power it was
+applied to. -/
+@[simp]
+theorem YoungTableau.toTensorPower_weylRepEquivExtPowerRep (t : YoungTableau μ)
+    (h : μ.rowLen 0 ≤ 1) (x : (YoungTableau.weylModule k n t).toSubmodule) :
+    exteriorPower.toTensorPower k (Fin n → k) μ.card
+        (YoungTableau.weylRepEquivExtPowerRep k n t h x) =
+      (x : ⨂[k]^μ.card (Fin n → k)) := by
+  rw [YoungTableau.weylRepEquivExtPowerRep, ← extPowerRepEquivWeylRep_apply_coe k n t h,
+    Representation.Equiv.apply_symm_apply]
+
 /-- The shape-indexed form of `TauCeti.YoungTableau.weylRepEquivExtPowerRep`. -/
 noncomputable def weylRepOfShapeEquivExtPowerRep (μ : YoungDiagram) (h : μ.rowLen 0 ≤ 1) :
     (weylRepOfShape k n μ).Equiv (extPowerRep k n μ.card) :=
   (YoungTableau.weylRepEquivOfShape k n
       (StandardYoungTableau.rowSuperstandard μ).toEquiv).symm.trans
     (YoungTableau.weylRepEquivExtPowerRep k n _ h)
+
+/-- The shape-indexed isomorphism is the tableau-indexed one at the row-superstandard tableau,
+after moving the argument along `TauCeti.YoungTableau.weylRepEquivOfShape`. -/
+@[simp]
+theorem weylRepOfShapeEquivExtPowerRep_apply (μ : YoungDiagram) (h : μ.rowLen 0 ≤ 1)
+    (x : (weylModuleOfShape k n μ).toSubmodule) :
+    weylRepOfShapeEquivExtPowerRep k n μ h x =
+      YoungTableau.weylRepEquivExtPowerRep k n
+        (StandardYoungTableau.rowSuperstandard μ).toEquiv h
+        ((YoungTableau.weylRepEquivOfShape k n
+          (StandardYoungTableau.rowSuperstandard μ).toEquiv).symm x) :=
+  Representation.Equiv.trans_apply _ _ x
 
 end OneColumn
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
@@ -89,7 +89,9 @@ namespace TauCeti
 
 namespace YoungTableau
 
-variable (k : Type u) [CommRing k] [Algebra ℚ k] {μ : YoungDiagram} (n : ℕ)
+section Semiring
+
+variable (k : Type u) [CommSemiring k] [Algebra ℚ k] {μ : YoungDiagram} (n : ℕ)
 
 /-- On a shape with at most one row the Young symmetrizer acts on the tensor power by the
 symmetrization operator `∑_σ σ`. -/
@@ -102,6 +104,17 @@ theorem permTensorActionAlgHom_youngSymmetrizerOver_of_rowSubgroup_eq_top (t : Y
   exact Finset.sum_congr rfl fun σ _ => by
     rw [permTensorActionAlgHom_of, permTensorAction_apply]
 
+end Semiring
+
+section Ring
+
+-- The signed sum below is a `ℤ`-linear combination, so it asks the base ring for negation; that is
+-- the only difference from the `CommSemiring` hypothesis of the section above, and it is the same
+-- split as between `TauCeti.YoungTableau.youngSymmetrizerOver_eq_sum_of_rowSubgroup_eq_top` and
+-- `TauCeti.YoungTableau.youngSymmetrizerOver_eq_sum_of_colSubgroup_eq_top`, which the two theorems
+-- respectively rewrite with.
+variable (k : Type u) [CommRing k] [Algebra ℚ k] {μ : YoungDiagram} (n : ℕ)
+
 /-- On a shape with at most one column the Young symmetrizer acts on the tensor power by the
 antisymmetrization operator `∑_σ sgn(σ) σ`. -/
 theorem permTensorActionAlgHom_youngSymmetrizerOver_of_colSubgroup_eq_top (t : YoungTableau μ)
@@ -112,6 +125,8 @@ theorem permTensorActionAlgHom_youngSymmetrizerOver_of_colSubgroup_eq_top (t : Y
   rw [youngSymmetrizerOver_eq_sum_of_colSubgroup_eq_top k t h, map_sum]
   exact Finset.sum_congr rfl fun σ _ => by
     rw [map_zsmul, permTensorActionAlgHom_of, permTensorAction_apply]
+
+end Ring
 
 end YoungTableau
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Data.Nat.Factorial.NatCast
 public import TauCeti.LinearAlgebra.ExteriorPower
 public import TauCeti.LinearAlgebra.SymmetricPower
 public import TauCeti.RepresentationTheory.ClassicalGroups.ExteriorPower
@@ -88,13 +89,6 @@ open scoped TensorProduct
 universe u
 
 namespace TauCeti
-
-/-- Over a `ℚ`-algebra every factorial is invertible. -/
-private theorem isUnit_natCast_factorial (k : Type*) [CommRing k] [Algebra ℚ k] (d : ℕ) :
-    IsUnit (d.factorial : k) := by
-  have h : IsUnit (d.factorial : ℚ) :=
-    isUnit_iff_ne_zero.2 (Nat.cast_ne_zero.2 d.factorial_ne_zero)
-  simpa using h.map (algebraMap ℚ k)
 
 /-! ### The Young symmetrizer of an extreme shape -/
 
@@ -189,7 +183,8 @@ symmetrization `SymmetricPower.toTensorPower`. -/
 noncomputable def symPowerRepEquivWeylRep (t : YoungTableau μ) (h : μ.colLen 0 ≤ 1) :
     (symPowerRep k n μ.card).Equiv (YoungTableau.weylRep k n t) :=
   (symPowerToTensorPower k n μ.card).equivOfRange
-    (SymmetricPower.toTensorPower_injective (by simpa using isUnit_natCast_factorial k μ.card))
+    (SymmetricPower.toTensorPower_injective
+      (by simpa using IsUnit.natCast_factorial_of_algebra (A := k) ℚ μ.card))
     (by
       rw [symPowerToTensorPower_toLinearMap, YoungTableau.weylModule_toSubmodule,
         YoungTableau.permTensorActionAlgHom_youngSymmetrizerOver_of_rowSubgroup_eq_top k n t
@@ -247,7 +242,7 @@ antisymmetrization `exteriorPower.toTensorPower`. -/
 noncomputable def extPowerRepEquivWeylRep (t : YoungTableau μ) (h : μ.rowLen 0 ≤ 1) :
     (extPowerRep k n μ.card).Equiv (YoungTableau.weylRep k n t) :=
   (extPowerToTensorPower k n μ.card).equivOfRange
-    (exteriorPower.toTensorPower_injective μ.card (isUnit_natCast_factorial k μ.card))
+    (exteriorPower.toTensorPower_injective μ.card (IsUnit.natCast_factorial_of_algebra ℚ μ.card))
     (by
       rw [extPowerToTensorPower_toLinearMap, YoungTableau.weylModule_toSubmodule,
         YoungTableau.permTensorActionAlgHom_youngSymmetrizerOver_of_colSubgroup_eq_top k n t

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
@@ -5,8 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Data.Nat.Factorial.NatCast
-public import TauCeti.LinearAlgebra.ExteriorPower
-public import TauCeti.LinearAlgebra.SymmetricPower
 public import TauCeti.RepresentationTheory.ClassicalGroups.ExteriorPower
 public import TauCeti.RepresentationTheory.ClassicalGroups.SymmetricPower
 public import TauCeti.RepresentationTheory.ClassicalGroups.WeylModule
@@ -140,8 +138,11 @@ theorem symPowerToTensorPower_toLinearMap (d : ℕ) :
   (rfl)
 
 /-- **The symmetric power is the Weyl module of a shape with at most one row**, by the
-symmetrization `SymmetricPower.toTensorPower`. -/
-noncomputable def symPowerRepEquivWeylRep (t : YoungTableau μ) (h : μ.colLen 0 ≤ 1) :
+symmetrization `SymmetricPower.toTensorPower`.
+
+This runs the direction the construction produces; the public form of the statement is its inverse
+`TauCeti.YoungTableau.weylRepEquivSymPowerRep`. -/
+private noncomputable def symPowerRepEquivWeylRep (t : YoungTableau μ) (h : μ.colLen 0 ≤ 1) :
     (symPowerRep k n μ.card).Equiv (YoungTableau.weylRep k n t) :=
   (symPowerToTensorPower k n μ.card).equivOfRange
     (SymmetricPower.toTensorPower_injective
@@ -154,8 +155,7 @@ noncomputable def symPowerRepEquivWeylRep (t : YoungTableau μ) (h : μ.colLen 0
 
 /-- The isomorphism `TauCeti.symPowerRepEquivWeylRep` is the symmetrization, read inside the
 tensor power. -/
-@[simp]
-theorem symPowerRepEquivWeylRep_apply_coe (t : YoungTableau μ) (h : μ.colLen 0 ≤ 1)
+private theorem symPowerRepEquivWeylRep_apply_coe (t : YoungTableau μ) (h : μ.colLen 0 ≤ 1)
     (x : SymmetricPower k (Fin μ.card) (Fin n → k)) :
     ((symPowerRepEquivWeylRep k n t h x : (YoungTableau.weylModule k n t).toSubmodule) :
         ⨂[k]^μ.card (Fin n → k)) =
@@ -223,8 +223,11 @@ theorem extPowerToTensorPower_toLinearMap (d : ℕ) :
   (rfl)
 
 /-- **The exterior power is the Weyl module of a shape with at most one column**, by the
-antisymmetrization `exteriorPower.toTensorPower`. -/
-noncomputable def extPowerRepEquivWeylRep (t : YoungTableau μ) (h : μ.rowLen 0 ≤ 1) :
+antisymmetrization `exteriorPower.toTensorPower`.
+
+This runs the direction the construction produces; the public form of the statement is its inverse
+`TauCeti.YoungTableau.weylRepEquivExtPowerRep`. -/
+private noncomputable def extPowerRepEquivWeylRep (t : YoungTableau μ) (h : μ.rowLen 0 ≤ 1) :
     (extPowerRep k n μ.card).Equiv (YoungTableau.weylRep k n t) :=
   (extPowerToTensorPower k n μ.card).equivOfRange
     (exteriorPower.toTensorPower_injective μ.card (IsUnit.natCast_factorial_of_algebra ℚ μ.card))
@@ -236,8 +239,7 @@ noncomputable def extPowerRepEquivWeylRep (t : YoungTableau μ) (h : μ.rowLen 0
 
 /-- The isomorphism `TauCeti.extPowerRepEquivWeylRep` is the antisymmetrization, read inside the
 tensor power. -/
-@[simp]
-theorem extPowerRepEquivWeylRep_apply_coe (t : YoungTableau μ) (h : μ.rowLen 0 ≤ 1)
+private theorem extPowerRepEquivWeylRep_apply_coe (t : YoungTableau μ) (h : μ.rowLen 0 ≤ 1)
     (x : ⋀[k]^μ.card (Fin n → k)) :
     ((extPowerRepEquivWeylRep k n t h x : (YoungTableau.weylModule k n t).toSubmodule) :
         ⨂[k]^μ.card (Fin n → k)) = exteriorPower.toTensorPower k (Fin n → k) μ.card x :=

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
@@ -1,0 +1,281 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.ExteriorPower
+public import TauCeti.LinearAlgebra.SymmetricPower
+public import TauCeti.RepresentationTheory.ClassicalGroups.ExteriorPower
+public import TauCeti.RepresentationTheory.ClassicalGroups.SymmetricPower
+public import TauCeti.RepresentationTheory.ClassicalGroups.WeylModule
+public import TauCeti.RepresentationTheory.Intertwining
+
+/-!
+# The Weyl modules of the two extreme shapes: symmetric and exterior powers
+
+The Weyl construction `TauCeti.YoungTableau.weylModule` cuts a subrepresentation of
+`(kⁿ)^{⊗d}` out of a Young symmetrizer `c_t`. This file evaluates it at the two extreme shapes,
+where the symmetrizer degenerates and the answer is a power of the standard representation:
+
+* a shape with **at most one row** has the whole symmetric group as its row group and a trivial
+  column group, so `c_t` is the symmetrization `∑_σ σ` and the Weyl module is `Symᵈ(kⁿ)`;
+* a shape with **at most one column** has the whole symmetric group as its column group and a
+  trivial row group, so `c_t` is the antisymmetrization `∑_σ sgn(σ) σ` and the Weyl module is
+  `⋀ᵈ(kⁿ)`.
+
+Both are proved the same way, and the two halves of the argument are already in place. On the
+linear-algebra side, `SymmetricPower.toTensorPower` and Mathlib's `exteriorPower.toTensorPower`
+map the symmetric and the exterior power **into** the tensor power, with image exactly the image
+of the symmetrization, respectively antisymmetrization, operator, and are injective because
+composing back is multiplication by `d!`, invertible over a `ℚ`-algebra. On the symmetric-group
+side, the extreme-shape lemmas of `TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean`
+collapse `c_t` to a single factor, which is evaluated here as an element of the group algebra and
+then as an operator on the tensor power. Both maps are equivariant for `GL n k`, because
+`GL n k` acts diagonally and the two operators only permute tensor factors; so the identification
+of subspaces is an isomorphism of representations, by
+`Representation.IntertwiningMap.equivOfRange`.
+
+The hypotheses are stated on the shape, as `μ.colLen 0 ≤ 1` and `μ.rowLen 0 ≤ 1`, which is how
+`TauCeti.YoungTableau.rowSubgroup_eq_top_iff` and
+`TauCeti.YoungTableau.colSubgroup_eq_top_iff` read the two degeneracies off the diagram. No
+condition relating `μ.card` to `n` is needed: for a one-column shape with `μ.card > n` both sides
+are zero, the exterior power because it is above the rank and the Weyl module by
+`TauCeti.YoungTableau.weylModule_eq_bot`, and the isomorphism holds vacuously.
+
+## Main results
+
+* `TauCeti.YoungTableau.weylRepEquivSymPowerRep`: **`𝕊^{(d)}(kⁿ) ≅ Symᵈ(kⁿ)`**, the Weyl module of
+  a shape with at most one row is the symmetric power, with
+  `TauCeti.weylRepOfShapeEquivSymPowerRep` its shape-indexed form.
+* `TauCeti.YoungTableau.weylRepEquivExtPowerRep`: **`𝕊^{(1ᵈ)}(kⁿ) ≅ ⋀ᵈ(kⁿ)`**, the Weyl module of
+  a shape with at most one column is the exterior power, with
+  `TauCeti.weylRepOfShapeEquivExtPowerRep` its shape-indexed form.
+* `TauCeti.YoungTableau.youngSymmetrizerOver_eq_sum_of_rowSubgroup_eq_top` and
+  `TauCeti.YoungTableau.youngSymmetrizerOver_eq_sum_of_colSubgroup_eq_top`: the value of `c_t` at
+  the two extreme shapes, in the group algebra, with
+  `TauCeti.YoungTableau.permTensorActionAlgHom_youngSymmetrizerOver_of_rowSubgroup_eq_top` and
+  `TauCeti.YoungTableau.permTensorActionAlgHom_youngSymmetrizerOver_of_colSubgroup_eq_top` the
+  corresponding operators on the tensor power.
+
+## Implementation notes
+
+The symmetric statements are over a base ring in `Type`, not in `Type u`: Mathlib's
+`SymmetricPower R ι M` requires `R` and the index type `ι` to lie in the same universe, and the
+index type here is `Fin μ.card`. The exterior statements carry no such restriction. This matches
+`TauCeti.symPowerRep`, which is already monomorphic for the same reason.
+
+The results are stated for an arbitrary tableau of the shape, not only for the row-superstandard
+one, since the Weyl module of any tableau of a given shape is the image of an operator that the
+extreme-shape hypothesis pins down completely. The shape-indexed forms are then the special case
+of the row-superstandard tableau, which is what `TauCeti.weylModuleOfShape` is defined from.
+
+## References
+
+* [W. Fulton and J. Harris, *Representation Theory: A First Course*][fulton-harris1991],
+  Lecture 6, "Weyl's construction", where `𝕊^{(d)}V = Sym^d V` and `𝕊^{(1^d)}V = ⋀^d V` are the
+  two extreme cases of the construction.
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 2, "Young symmetrizers and the Schur functor", whose two remaining deliverables
+  `S^{(d)} V ≅ Symᵈ V` and `S^{(1ᵈ)} V ≅ ⋀ᵈ V` are proved here.
+-/
+
+public section
+
+open Matrix
+open scoped TensorProduct
+
+universe u
+
+namespace TauCeti
+
+/-- Over a `ℚ`-algebra every factorial is invertible. -/
+private theorem isUnit_natCast_factorial (k : Type*) [CommRing k] [Algebra ℚ k] (d : ℕ) :
+    IsUnit (d.factorial : k) := by
+  have h : IsUnit (d.factorial : ℚ) :=
+    isUnit_iff_ne_zero.2 (Nat.cast_ne_zero.2 d.factorial_ne_zero)
+  simpa using h.map (algebraMap ℚ k)
+
+/-! ### The Young symmetrizer of an extreme shape -/
+
+namespace YoungTableau
+
+variable (k : Type u) [CommRing k] [Algebra ℚ k] {μ : YoungDiagram}
+
+/-- **The Young symmetrizer of a shape with at most one row is the full symmetrization**
+`∑_σ σ`: the row group is everything and the column group is trivial. -/
+theorem youngSymmetrizerOver_eq_sum_of_rowSubgroup_eq_top (t : YoungTableau μ)
+    (h : rowSubgroup t = ⊤) :
+    youngSymmetrizerOver k t =
+      ∑ σ : Equiv.Perm (Fin μ.card), MonoidAlgebra.of k (Equiv.Perm (Fin μ.card)) σ := by
+  rw [youngSymmetrizerOver_def,
+    youngSymmetrizer_eq_rowSymmetrizer t (colSubgroup_eq_bot_of_rowSubgroup_eq_top t h),
+    rowSymmetrizer_def, map_sum]
+  refine Finset.sum_bij (fun p _ => (p : Equiv.Perm (Fin μ.card)))
+    (fun _ _ => Finset.mem_univ _) (fun _ _ _ _ hab => Subtype.ext hab)
+    (fun σ _ => ?_) fun p _ => ?_
+  · refine ⟨⟨σ, by rw [h]; exact Subgroup.mem_top σ⟩, ?_, rfl⟩
+    simp
+  · rw [MonoidAlgebra.of_apply, MonoidAlgebra.mapAlgHom_single, map_one, MonoidAlgebra.of_apply]
+
+/-- **The Young symmetrizer of a shape with at most one column is the full antisymmetrization**
+`∑_σ sgn(σ) σ`: the column group is everything and the row group is trivial. -/
+theorem youngSymmetrizerOver_eq_sum_of_colSubgroup_eq_top (t : YoungTableau μ)
+    (h : colSubgroup t = ⊤) :
+    youngSymmetrizerOver k t =
+      ∑ σ : Equiv.Perm (Fin μ.card),
+        (Equiv.Perm.sign σ : ℤ) • MonoidAlgebra.of k (Equiv.Perm (Fin μ.card)) σ := by
+  rw [youngSymmetrizerOver_def,
+    youngSymmetrizer_eq_columnAntisymmetrizer t (rowSubgroup_eq_bot_of_colSubgroup_eq_top t h),
+    columnAntisymmetrizer_def, map_sum]
+  refine Finset.sum_bij (fun q _ => (q : Equiv.Perm (Fin μ.card)))
+    (fun _ _ => Finset.mem_univ _) (fun _ _ _ _ hab => Subtype.ext hab)
+    (fun σ _ => ?_) fun q _ => ?_
+  · refine ⟨⟨σ, by rw [h]; exact Subgroup.mem_top σ⟩, ?_, rfl⟩
+    simp
+  · rw [Int.cast_smul_eq_zsmul ℚ, map_zsmul, MonoidAlgebra.of_apply,
+      MonoidAlgebra.mapAlgHom_single, map_one, MonoidAlgebra.of_apply]
+
+variable (n : ℕ)
+
+/-- On a shape with at most one row the Young symmetrizer acts on the tensor power by the
+symmetrization operator `∑_σ σ`. -/
+theorem permTensorActionAlgHom_youngSymmetrizerOver_of_rowSubgroup_eq_top (t : YoungTableau μ)
+    (h : rowSubgroup t = ⊤) :
+    permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) =
+      ∑ σ : Equiv.Perm (Fin μ.card),
+        (PiTensorProduct.reindex k (fun _ : Fin μ.card => Fin n → k) σ).toLinearMap := by
+  rw [youngSymmetrizerOver_eq_sum_of_rowSubgroup_eq_top k t h, map_sum]
+  exact Finset.sum_congr rfl fun σ _ => by
+    rw [permTensorActionAlgHom_of, permTensorAction_apply]
+
+/-- On a shape with at most one column the Young symmetrizer acts on the tensor power by the
+antisymmetrization operator `∑_σ sgn(σ) σ`. -/
+theorem permTensorActionAlgHom_youngSymmetrizerOver_of_colSubgroup_eq_top (t : YoungTableau μ)
+    (h : colSubgroup t = ⊤) :
+    permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) =
+      ∑ σ : Equiv.Perm (Fin μ.card), (Equiv.Perm.sign σ : ℤ) •
+        (PiTensorProduct.reindex k (fun _ : Fin μ.card => Fin n → k) σ).toLinearMap := by
+  rw [youngSymmetrizerOver_eq_sum_of_colSubgroup_eq_top k t h, map_sum]
+  exact Finset.sum_congr rfl fun σ _ => by
+    rw [map_zsmul, permTensorActionAlgHom_of, permTensorAction_apply]
+
+end YoungTableau
+
+/-! ### A shape with at most one row: the symmetric power -/
+
+section OneRow
+
+variable (k : Type) [CommRing k] [Algebra ℚ k] (n : ℕ) {μ : YoungDiagram}
+
+/-- The symmetrization, as an intertwining map of the symmetric power of the standard
+representation with its tensor power. -/
+noncomputable def symPowerToTensorPower (d : ℕ) :
+    Representation.IntertwiningMap (symPowerRep k n d) (tensorPowerRep k n d) where
+  toLinearMap := SymmetricPower.toTensorPower k (Fin d) (Fin n → k)
+  isIntertwining' g := by
+    rw [Representation.symmetricPower_apply, Representation.tensorPower_apply]
+    exact SymmetricPower.toTensorPower_comp_map (stdRep k n g)
+
+omit [Algebra ℚ k] in
+@[simp]
+theorem symPowerToTensorPower_toLinearMap (d : ℕ) :
+    (symPowerToTensorPower k n d).toLinearMap =
+      SymmetricPower.toTensorPower k (Fin d) (Fin n → k) :=
+  (rfl)
+
+/-- **The symmetric power is the Weyl module of a shape with at most one row**, by the
+symmetrization `SymmetricPower.toTensorPower`. -/
+noncomputable def symPowerRepEquivWeylRep (t : YoungTableau μ) (h : μ.colLen 0 ≤ 1) :
+    (symPowerRep k n μ.card).Equiv (YoungTableau.weylRep k n t) :=
+  (symPowerToTensorPower k n μ.card).equivOfRange
+    (SymmetricPower.toTensorPower_injective (by simpa using isUnit_natCast_factorial k μ.card))
+    (by
+      rw [symPowerToTensorPower_toLinearMap, YoungTableau.weylModule_toSubmodule,
+        YoungTableau.permTensorActionAlgHom_youngSymmetrizerOver_of_rowSubgroup_eq_top k n t
+          ((YoungTableau.rowSubgroup_eq_top_iff t).2 h)]
+      exact SymmetricPower.range_toTensorPower)
+
+/-- The isomorphism `TauCeti.symPowerRepEquivWeylRep` is the symmetrization, read inside the
+tensor power. -/
+@[simp]
+theorem symPowerRepEquivWeylRep_apply_coe (t : YoungTableau μ) (h : μ.colLen 0 ≤ 1)
+    (x : SymmetricPower k (Fin μ.card) (Fin n → k)) :
+    ((symPowerRepEquivWeylRep k n t h x : (YoungTableau.weylModule k n t).toSubmodule) :
+        ⨂[k]^μ.card (Fin n → k)) =
+      SymmetricPower.toTensorPower k (Fin μ.card) (Fin n → k) x :=
+  Representation.IntertwiningMap.equivOfRange_apply_coe _ _ _ x
+
+/-- **`𝕊^{(d)}(kⁿ) ≅ Symᵈ(kⁿ)`**: the Weyl module of a shape with at most one row is the
+symmetric power of the standard representation. -/
+noncomputable def YoungTableau.weylRepEquivSymPowerRep (t : YoungTableau μ) (h : μ.colLen 0 ≤ 1) :
+    (YoungTableau.weylRep k n t).Equiv (symPowerRep k n μ.card) :=
+  (symPowerRepEquivWeylRep k n t h).symm
+
+/-- The shape-indexed form of `TauCeti.YoungTableau.weylRepEquivSymPowerRep`. -/
+noncomputable def weylRepOfShapeEquivSymPowerRep (μ : YoungDiagram) (h : μ.colLen 0 ≤ 1) :
+    (weylRepOfShape k n μ).Equiv (symPowerRep k n μ.card) :=
+  (YoungTableau.weylRepEquivOfShape k n
+      (StandardYoungTableau.rowSuperstandard μ).toEquiv).symm.trans
+    (YoungTableau.weylRepEquivSymPowerRep k n _ h)
+
+end OneRow
+
+/-! ### A shape with at most one column: the exterior power -/
+
+section OneColumn
+
+variable (k : Type u) [CommRing k] [Algebra ℚ k] (n : ℕ) {μ : YoungDiagram}
+
+/-- The antisymmetrization, as an intertwining map of the exterior power of the standard
+representation with its tensor power. -/
+noncomputable def extPowerToTensorPower (d : ℕ) :
+    Representation.IntertwiningMap (extPowerRep k n d) (tensorPowerRep k n d) where
+  toLinearMap := exteriorPower.toTensorPower k (Fin n → k) d
+  isIntertwining' g := by
+    rw [Representation.exteriorPower_apply, Representation.tensorPower_apply]
+    exact exteriorPower.toTensorPower_comp_map d (stdRep k n g)
+
+omit [Algebra ℚ k] in
+@[simp]
+theorem extPowerToTensorPower_toLinearMap (d : ℕ) :
+    (extPowerToTensorPower k n d).toLinearMap = exteriorPower.toTensorPower k (Fin n → k) d :=
+  (rfl)
+
+/-- **The exterior power is the Weyl module of a shape with at most one column**, by the
+antisymmetrization `exteriorPower.toTensorPower`. -/
+noncomputable def extPowerRepEquivWeylRep (t : YoungTableau μ) (h : μ.rowLen 0 ≤ 1) :
+    (extPowerRep k n μ.card).Equiv (YoungTableau.weylRep k n t) :=
+  (extPowerToTensorPower k n μ.card).equivOfRange
+    (exteriorPower.toTensorPower_injective μ.card (isUnit_natCast_factorial k μ.card))
+    (by
+      rw [extPowerToTensorPower_toLinearMap, YoungTableau.weylModule_toSubmodule,
+        YoungTableau.permTensorActionAlgHom_youngSymmetrizerOver_of_colSubgroup_eq_top k n t
+          ((YoungTableau.colSubgroup_eq_top_iff t).2 h)]
+      exact exteriorPower.range_toTensorPower μ.card)
+
+/-- The isomorphism `TauCeti.extPowerRepEquivWeylRep` is the antisymmetrization, read inside the
+tensor power. -/
+@[simp]
+theorem extPowerRepEquivWeylRep_apply_coe (t : YoungTableau μ) (h : μ.rowLen 0 ≤ 1)
+    (x : ⋀[k]^μ.card (Fin n → k)) :
+    ((extPowerRepEquivWeylRep k n t h x : (YoungTableau.weylModule k n t).toSubmodule) :
+        ⨂[k]^μ.card (Fin n → k)) = exteriorPower.toTensorPower k (Fin n → k) μ.card x :=
+  Representation.IntertwiningMap.equivOfRange_apply_coe _ _ _ x
+
+/-- **`𝕊^{(1ᵈ)}(kⁿ) ≅ ⋀ᵈ(kⁿ)`**: the Weyl module of a shape with at most one column is the
+exterior power of the standard representation. -/
+noncomputable def YoungTableau.weylRepEquivExtPowerRep (t : YoungTableau μ) (h : μ.rowLen 0 ≤ 1) :
+    (YoungTableau.weylRep k n t).Equiv (extPowerRep k n μ.card) :=
+  (extPowerRepEquivWeylRep k n t h).symm
+
+/-- The shape-indexed form of `TauCeti.YoungTableau.weylRepEquivExtPowerRep`. -/
+noncomputable def weylRepOfShapeEquivExtPowerRep (μ : YoungDiagram) (h : μ.rowLen 0 ≤ 1) :
+    (weylRepOfShape k n μ).Equiv (extPowerRep k n μ.card) :=
+  (YoungTableau.weylRepEquivOfShape k n
+      (StandardYoungTableau.rowSuperstandard μ).toEquiv).symm.trans
+    (YoungTableau.weylRepEquivExtPowerRep k n _ h)
+
+end OneColumn
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -91,13 +91,10 @@ setting the roadmap works in.
   Of that bullet, the `GLₙ`-subrepresentation, the fixed choice of tableau, the canonical
   isomorphism between the images for different tableaux, and the vanishing criterion are built
   here.  The bullet's two remaining deliverables, the extreme cases `S^{(d)} V ≅ Symᵈ V` and
-  `S^{(1ᵈ)} V ≅ ⋀ᵈ V`, are deliberately left to a follow-up, because each first needs
-  infrastructure that exists neither in Mathlib nor here: a linear map `Sym[k]^d M →ₗ[k] ⨂[k]^d M`
-  descending the symmetrizer through `SymmetricPower.mk`, injectivity and naturality for
-  `exteriorPower.toTensorPower`, and the value of `c_t` at a one-row and at a one-column shape.
-  The follow-up can state and prove both against `TauCeti.weylModuleOfShape`,
-  `TauCeti.weylModuleOfShape_toSubmodule` and `TauCeti.weylRepOfShape` without unfolding anything
-  built here.
+  `S^{(1ᵈ)} V ≅ ⋀ᵈ V`, are proved in
+  `TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean`, against
+  `TauCeti.YoungTableau.weylModule_toSubmodule` and `TauCeti.weylRepOfShape` and without
+  unfolding anything built here.
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/Intertwining.lean
+++ b/TauCeti/RepresentationTheory/Intertwining.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RepresentationTheory.Intertwining
-public import Mathlib.RepresentationTheory.Subrepresentation
 
 /-!
 # An injective intertwining map is an isomorphism onto its image

--- a/TauCeti/RepresentationTheory/Intertwining.lean
+++ b/TauCeti/RepresentationTheory/Intertwining.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RepresentationTheory.Intertwining
+public import Mathlib.RepresentationTheory.Subrepresentation
+
+/-!
+# An injective intertwining map is an isomorphism onto its image
+
+Mathlib records the image of an intertwining map as a subrepresentation
+(`Representation.IntertwiningMap.range`) and turns a bijective intertwining map into an
+equivalence (`Representation.IntertwiningMap.ofBijective`), but it does not connect the two: an
+*injective* intertwining map is an isomorphism onto its image, and that is the usual way a
+construction "`W` is the subrepresentation cut out by such and such an operator" is turned into an
+identification of `W` with a representation built independently.
+
+This file supplies the corestriction and that identification. The subrepresentation is taken as an
+argument together with a proof that the image fills it, rather than being fixed to be
+`IntertwiningMap.range f`: in practice the target subrepresentation is defined some other way -- as
+the range of a different operator, say -- and matching the two ranges is a separate step that the
+caller has already done.
+
+## Main definitions
+
+* `Representation.IntertwiningMap.codRestrict`: corestrict an intertwining map to a
+  subrepresentation containing its image.
+* `Representation.IntertwiningMap.equivOfRange`: an injective intertwining map is an equivalence
+  onto a subrepresentation that its image fills.
+-/
+
+public section
+
+namespace Representation.IntertwiningMap
+
+variable {A G V W : Type*} [CommSemiring A] [Monoid G]
+  [AddCommMonoid V] [Module A V] [AddCommMonoid W] [Module A W]
+  {ρ : Representation A G V} {σ : Representation A G W}
+
+/-- Corestrict an intertwining map to a subrepresentation of the target containing its image. -/
+def codRestrict (f : IntertwiningMap ρ σ) (P : Subrepresentation σ)
+    (hP : ∀ v, f v ∈ P.toSubmodule) : IntertwiningMap ρ P.toRepresentation where
+  toLinearMap := LinearMap.codRestrict P.toSubmodule f.toLinearMap hP
+  isIntertwining' g :=
+    LinearMap.ext fun v =>
+      Subtype.ext (congrArg (fun l : V →ₗ[A] W => l v) (f.isIntertwining' g))
+
+@[simp]
+theorem codRestrict_apply_coe (f : IntertwiningMap ρ σ) (P : Subrepresentation σ)
+    (hP : ∀ v, f v ∈ P.toSubmodule) (v : V) :
+    ((f.codRestrict P hP v : P.toSubmodule) : W) = f v := by
+  rfl
+
+/-- **An injective intertwining map is an isomorphism onto its image**, here onto any
+subrepresentation `P` that the image fills. -/
+noncomputable def equivOfRange (f : IntertwiningMap ρ σ) (hf : Function.Injective f)
+    {P : Subrepresentation σ} (hP : LinearMap.range f.toLinearMap = P.toSubmodule) :
+    ρ.Equiv P.toRepresentation :=
+  (f.codRestrict P fun v => hP.le (LinearMap.mem_range_self _ v)).ofBijective
+    ⟨fun _ _ h => hf (by exact congrArg Subtype.val h), fun w => by
+      obtain ⟨v, hv⟩ := hP.ge w.2
+      exact ⟨v, Subtype.ext (by exact hv)⟩⟩
+
+@[simp]
+theorem equivOfRange_apply_coe (f : IntertwiningMap ρ σ) (hf : Function.Injective f)
+    {P : Subrepresentation σ} (hP : LinearMap.range f.toLinearMap = P.toSubmodule) (v : V) :
+    ((f.equivOfRange hf hP v : P.toSubmodule) : W) = f v := by
+  rfl
+
+end Representation.IntertwiningMap

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -23,7 +23,9 @@ sign character.  In particular, each factor squares to its subgroup order times 
 These are the elementary inputs to the essential-idempotence theorem for `c_t` and the
 construction of Specht modules.  The two extreme shapes are also evaluated here: a trivial row or
 column group collapses the corresponding factor to `1`, so on a shape with at most one row the
-whole group fixes `c_t`, and on a shape with at most one column it scales `c_t` by the sign.
+whole group fixes `c_t`, and on a shape with at most one column it scales `c_t` by the sign.  The
+same two degeneracies evaluate the transported symmetrizer `youngSymmetrizerOver` outright, as the
+full symmetrization `∑_σ σ` and the full antisymmetrization `∑_σ sgn(σ) σ` of the group algebra.
 Finally, `b_t` acting on an arbitrary representation is unfolded into the signed sum over the
 column group, which is how every downstream computation with the operator `b_t` begins.
 
@@ -386,7 +388,49 @@ theorem mul_youngSymmetrizerOver_right (t : YoungTableau μ) (q : colSubgroup t)
   rw [map_mul, MonoidAlgebra.mapAlgHom_single, map_one, map_smul] at h
   rwa [youngSymmetrizerOver_def]
 
+/-- **The Young symmetrizer of a shape with at most one row is the full symmetrization**
+`∑_σ σ`: the row group is everything and the column group is trivial. -/
+theorem youngSymmetrizerOver_eq_sum_of_rowSubgroup_eq_top (t : YoungTableau μ)
+    (h : rowSubgroup t = ⊤) :
+    youngSymmetrizerOver k t =
+      ∑ σ : Equiv.Perm (Fin μ.card), MonoidAlgebra.of k (Equiv.Perm (Fin μ.card)) σ := by
+  rw [youngSymmetrizerOver_def,
+    youngSymmetrizer_eq_rowSymmetrizer t (colSubgroup_eq_bot_of_rowSubgroup_eq_top t h),
+    rowSymmetrizer_def, map_sum]
+  refine Finset.sum_bij (fun p _ => (p : Equiv.Perm (Fin μ.card)))
+    (fun _ _ => Finset.mem_univ _) (fun _ _ _ _ hab => Subtype.ext hab)
+    (fun σ _ => ?_) fun p _ => ?_
+  · refine ⟨⟨σ, by rw [h]; exact Subgroup.mem_top σ⟩, ?_, rfl⟩
+    simp
+  · rw [MonoidAlgebra.of_apply, MonoidAlgebra.mapAlgHom_single, map_one, MonoidAlgebra.of_apply]
+
 end Transport
+
+section TransportRing
+
+-- The signed sum below is a `ℤ`-linear combination, so it asks the target ring for negation; that
+-- is the only difference from the `CommSemiring` hypothesis of the section above.
+variable (k : Type*) [CommRing k] [Algebra ℚ k]
+
+/-- **The Young symmetrizer of a shape with at most one column is the full antisymmetrization**
+`∑_σ sgn(σ) σ`: the column group is everything and the row group is trivial. -/
+theorem youngSymmetrizerOver_eq_sum_of_colSubgroup_eq_top (t : YoungTableau μ)
+    (h : colSubgroup t = ⊤) :
+    youngSymmetrizerOver k t =
+      ∑ σ : Equiv.Perm (Fin μ.card),
+        (Equiv.Perm.sign σ : ℤ) • MonoidAlgebra.of k (Equiv.Perm (Fin μ.card)) σ := by
+  rw [youngSymmetrizerOver_def,
+    youngSymmetrizer_eq_columnAntisymmetrizer t (rowSubgroup_eq_bot_of_colSubgroup_eq_top t h),
+    columnAntisymmetrizer_def, map_sum]
+  refine Finset.sum_bij (fun q _ => (q : Equiv.Perm (Fin μ.card)))
+    (fun _ _ => Finset.mem_univ _) (fun _ _ _ _ hab => Subtype.ext hab)
+    (fun σ _ => ?_) fun q _ => ?_
+  · refine ⟨⟨σ, by rw [h]; exact Subgroup.mem_top σ⟩, ?_, rfl⟩
+    simp
+  · rw [Int.cast_smul_eq_zsmul ℚ, map_zsmul, MonoidAlgebra.of_apply,
+      MonoidAlgebra.mapAlgHom_single, map_one, MonoidAlgebra.of_apply]
+
+end TransportRing
 
 end
 


### PR DESCRIPTION
This PR proves the two extreme cases of the Weyl construction: over a commutative ring that is a `ℚ`-algebra, the Weyl module of a Young diagram with **at most one row** is the symmetric power `Symᵈ(kⁿ)` of the standard representation of `GL n k`, and the Weyl module of a diagram with **at most one column** is the exterior power `⋀ᵈ(kⁿ)`. These are the two remaining deliverables of the "Young symmetrizers and the Schur functor" bullet in Layer 2 of the classical-groups roadmap, `S^{(d)} V ≅ Symᵈ V` and `S^{(1ᵈ)} V ≅ ⋀ᵈ V`. The module docstring of `TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean` named them as a follow-up blocked on infrastructure that existed neither in Mathlib nor here, and listed exactly what was missing: a map `Sym[k]^d M →ₗ[k] ⨂[k]^d M` descending the symmetrizer through `SymmetricPower.mk`, injectivity and naturality for `exteriorPower.toTensorPower`, and the value of `c_t` at a one-row and at a one-column shape. This PR builds all three and closes the bullet; that docstring now points here instead.

The milestone is Layer 2 of the classical-groups roadmap, whose remaining item is the decomposition `V^{⊗d} ≅ ⊕_{λ ⊢ d} 𝕊^λ V ⊗ Specht λ`; after this PR what stands between the layer and that decomposition is Schur-Weyl duality itself, which the roadmap assigns to `RepresentationTheory/SchurWeyl`.

Three pieces make up the proof, and both extreme cases run through the same shape. On the linear-algebra side, `SymmetricPower.toTensorPower` is new: the symmetrization operator `∑_σ σ` is constant on the fibres of `SymmetricPower.mk`, so it descends to the symmetric power, and composing back with `mk` is multiplication by `(card ι)!`, hence the descent is injective over a `ℚ`-algebra and its image is exactly the image of the symmetrization operator. `exteriorPower.toTensorPower` is Mathlib's, but nothing was known about it, so this PR adds the canonical surjection `exteriorPower.fromTensorPower` of the tensor power onto the exterior power, the identity `fromTensorPower ∘ toTensorPower = n!`, the resulting injectivity, the description of the image as the image of the antisymmetrization operator `∑_σ sgn(σ) σ`, and naturality in the module.

On the symmetric-group side, the extreme-shape lemmas already in `TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean` collapse the Young symmetrizer to a single factor when the row or the column group is everything; `youngSymmetrizerOver_eq_sum_of_rowSubgroup_eq_top` and `youngSymmetrizerOver_eq_sum_of_colSubgroup_eq_top` evaluate what is left as an element of the group algebra, and two further lemmas read it as an operator on `(kⁿ)^{⊗d}`, matching the two range descriptions above on the nose.

Joining the two is `Representation.IntertwiningMap.equivOfRange`, in the new `TauCeti/RepresentationTheory/Intertwining.lean`: an injective intertwining map is an isomorphism onto any subrepresentation its image fills. Mathlib has the image as a subrepresentation and has `ofBijective`, but not the step between them. Both symmetrization maps are `GL n k`-equivariant because the group acts diagonally while the operators only permute tensor factors, so the identification of subspaces is an isomorphism of representations. Each equivalence comes with a `simp` lemma pinning it down pointwise, so the isomorphism is not opaque.

The statements are given for an arbitrary tableau of the shape, with the shape-indexed forms `weylRepOfShapeEquivSymPowerRep` and `weylRepOfShapeEquivExtPowerRep` derived from `weylRepEquivOfShape`. No relation between `μ.card` and `n` is assumed: for a one-column shape taller than `n` both sides vanish and the isomorphism holds vacuously. The symmetric statements are monomorphic in the base ring because Mathlib's `SymmetricPower R ι M` needs `R` and `ι` in the same universe, which is already why `TauCeti.symPowerRep` is; the exterior statements are universe-polymorphic.

Nothing was vendored. The new declarations extend the `SymmetricPower` and `exteriorPower` namespaces with API Mathlib lacks, and consume Mathlib's `exteriorPower.toTensorPower`, `exteriorPower.alternatingMapLinearEquiv`, `AlternatingMap.map_perm`, `SymmetricPower.mk` and `SymmetricPower.tprod_equiv`.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"weyl-module-extreme-cases"}-->

🤖 Prepared with Claude Code
