### PR TITLE
feat: transcribe the Held group presentation

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.GroupTheory.Presentation.GroupPresentation
+
+/-!
+# A transcribed presentation of the Held group
+
+This file carries the `He` row of the sporadic presentation data required by milestone S1 of
+`TauCetiRoadmap/CFSGStatement/README.md`. It records John Bray's ATLAS version 3 presentation on
+the standard generators `a` and `b` as a `TauCeti.GroupPresentation`, together with the source,
+generator convention, transcription notes, and expected counts.
+
+The presentation displayed by the ATLAS is
+
+```text
+⟨a, b | a² = b⁷ = (ab)¹⁷ = [a,b]⁶ = [a,b³]⁵
+       = [a,babab⁻¹abab]
+       = (ab)⁴ab²ab⁻³ababab⁻¹ab³ab⁻²ab² = 1⟩.
+```
+
+The ATLAS commutator convention is `[r,s] = r⁻¹s⁻¹rs`, opposite to Mathlib's
+`commutatorElement`. Accordingly each displayed commutator is stored using
+`Relator.comm (.inv r) (.inv s)`, as prescribed by `Relator`'s API. The structured expressions
+otherwise preserve the displayed products and powers. The proved `Relator.toWord_toFreeGroup`
+theorem is the audit boundary between these expressions and the signed words used by
+`PresentedGroup`.
+
+GAP 4.15.1 with AtlasRep 2.1.9 independently checks the seven transcribed relations on the
+ATLAS 2058-point standard generators; those generators yield a simple group of order
+`4030387200`. This computation is provenance for the transcription, not a Lean theorem. This file
+asserts no order, finiteness, simplicity, or identification result.
+
+## Main definition
+
+* `TauCeti.Sporadic.hePresentation`: John Bray's ATLAS finite presentation of `He`.
+
+## References
+
+* R. A. Wilson, R. A. Parker, J. N. Bray et al., *ATLAS of Finite Group Representations*,
+  version 3, presentation `HeG1-P1`, contributed by John Bray,
+  <https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/HeG1-P1>.
+-/
+
+public section
+
+namespace TauCeti.Sporadic
+
+private abbrev a : Relator (Fin 2) := .gen 0
+
+private abbrev b : Relator (Fin 2) := .gen 1
+
+@[inherit_doc Relator.mul]
+local infixl:70 " ⬝ " => Relator.mul
+
+/-- The word `babab⁻¹abab` in the long commutator of Bray's presentation. -/
+private abbrev commutatorWord : Relator (Fin 2) :=
+  b ⬝ a ⬝ b ⬝ a ⬝ .inv b ⬝ a ⬝ b ⬝ a ⬝ b
+
+/-- The final relator in Bray's presentation, before setting it equal to the identity. -/
+private abbrev finalWord : Relator (Fin 2) :=
+  .pow (a ⬝ b) 4 ⬝ a ⬝ .pow b 2 ⬝ a ⬝ .pow (.inv b) 3 ⬝
+    a ⬝ b ⬝ a ⬝ b ⬝ a ⬝ .inv b ⬝ a ⬝ .pow b 3 ⬝ a ⬝
+    .pow (.inv b) 2 ⬝ a ⬝ .pow b 2
+
+/-- John Bray's ATLAS version 3 finite presentation of the Held group `He` on its standard
+generators `a` and `b`.
+
+The ATLAS lists this as a full presentation of the abstract group, separately from the
+semi-presentation used to recognize standard generators in a group already constructed. No
+structural property of the presented group is asserted here: this definition records only the
+cited generators and relations. -/
+def hePresentation : GroupPresentation where
+  generatorNames := ["a", "b"]
+  source := "R. A. Wilson, R. A. Parker, J. N. Bray et al., ATLAS of Finite Group \
+    Representations, version 3; presentation contributed by John Bray"
+  sourceLocator := "HeG1-P1, https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/HeG1-P1"
+  generatorConvention := "The ATLAS standard generators a and b, in that order, so index 0 is a \
+    and index 1 is b. Products are read left to right, negative exponents denote inverses, and \
+    [r,s] denotes r^-1 s^-1 r s."
+  transcriptionNotes := "The seven displayed words are stored as seven relators equal to the \
+    identity. ATLAS distinguishes HeG1-P1 from its semi-presentation. GAP 4.15.1 with AtlasRep \
+    2.1.9 checks these relators on the independent ATLAS 2058-point generators, which generate a \
+    simple group of order 4030387200."
+  expectedGeneratorCount := 2
+  expectedRelatorCount := 7
+  transcribed :=
+    [ .pow a 2,
+      .pow b 7,
+      .pow (a ⬝ b) 17,
+      .pow (.comm (.inv a) (.inv b)) 6,
+      .pow (.comm (.inv a) (.inv (.pow b 3))) 5,
+      .comm (.inv a) (.inv commutatorWord),
+      finalWord ]
+
+/-- The generator and relator counts recorded for `He` agree with the transcribed data. -/
+@[simp]
+theorem hePresentation_matchesMetadata : hePresentation.matchesMetadata := by decide
+
+end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
@@ -98,7 +98,6 @@ def hePresentation : GroupPresentation where
       finalWord ]
 
 /-- The generator and relator counts recorded for `He` agree with the transcribed data. -/
-@[simp]
 theorem hePresentation_matchesMetadata : hePresentation.matchesMetadata := by decide
 
 end TauCeti.Sporadic


### PR DESCRIPTION
This PR transcribes John Bray's ATLAS version 3 finite presentation of the Held sporadic simple group `He` into `TauCeti.GroupPresentation`, advancing `TauCetiRoadmap/CFSGStatement/README.md`, milestone **S1: the twenty-six sporadic presentations**, exact target “Fill every `SporadicName.presentation` branch with the complete signed relator words from the S0 manifest.” Record the two standard-generator names, stable presentation identifier `HeG1-P1`, source and contributor, source convention, expected two-generator/seven-relator counts, and all seven structured relator expressions. After this PR, S1 still needs the other twenty-five sporadic rows and their independent transcription reviews before A0 can assemble `CFSGIndex.Group`.

This is the most effective distinct current step because I0's remaining diagram and length selectors are already in flight in #2629 and #2630, L0 remains explicitly blocked on RootSystems Layer 6 and ReductiveGroups Layer 9, and the other active S1 PRs cover the Mathieu, Janko, Thompson, and Y-diagram rows rather than `He`. The Held row depends only on the S0 presentation format already on `main` and directly removes one unfilled carrier required by A0.

The source is R. A. Wilson, R. A. Parker, J. N. Bray et al., *ATLAS of Finite Group Representations*, version 3, presentation `HeG1-P1`, contributed by John Bray (https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/HeG1-P1). ATLAS lists it as a full presentation separately from the Held semi-presentation used only to recognize standard generators. Transcribe
`⟨a,b | a² = b⁷ = (ab)¹⁷ = [a,b]⁶ = [a,b³]⁵ = [a,babab⁻¹abab] = (ab)⁴ab²ab⁻³ababab⁻¹ab³ab⁻²ab² = 1⟩`.

The ATLAS bracket means `[r,s] = r⁻¹s⁻¹rs`, opposite to Mathlib's `commutatorElement`, so the three bracketed relations deliberately use `Relator.comm (.inv r) (.inv s)`. GAP 4.15.1 with AtlasRep 2.1.9 checks the exact seven relations on the independent 2058-point ATLAS generators, which generate a simple group of order `4030387200`; this is recorded only as transcription provenance, and the Lean file asserts no order, finiteness, simplicity, or identification result.

Reuse Tau Ceti's landed `Relator`, its proved `Relator.toWord_toFreeGroup` compiler theorem, and `GroupPresentation`; no Mathlib or external formalization is vendored. Add `TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean` (104 lines).

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"held-group-presentation"}-->

🤖 Prepared with Codex
