### PR TITLE
refactor(GlobalBranch): name the homotopy inside a simply connected set

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -106,6 +106,36 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E
 
 /-! ### Path independence and the global branch -/
 
+/-- **Two paths with the same endpoints in a simply connected set are joined by a homotopy that
+never leaves it.** For continuous `p` and `q` running in `V` from `a` to `b`, there is a homotopy
+`K` between paths from `a` to `b` whose every intermediate path lies in `V`, with `K 0 = p` and
+`K 1 = q`. -/
+private lemma exists_pathHomotopy_forall_mem_of_isSimplyConnected {X : Type*} [TopologicalSpace X]
+    {V : Set X} {a b : X} {p q : I → X} (hV : IsSimplyConnected V)
+    (hp : Continuous p) (hpV : ∀ x, p x ∈ V) (hp0 : p 0 = a) (hp1 : p 1 = b)
+    (hq : Continuous q) (hqV : ∀ x, q x ∈ V) (hq0 : q 0 = a) (hq1 : q 1 = b) :
+    ∃ (P Q : Path a b) (K : P.Homotopy Q), (∀ t x, K (t, x) ∈ V) ∧ (∀ t, K (t, 0) = a) ∧
+      (fun x => K (0, x)) = p ∧ (fun x => K (1, x)) = q := by
+  have := hV.simplyConnectedSpace
+  have haV : a ∈ V := hp0 ▸ hpV 0
+  have hbV : b ∈ V := hp1 ▸ hpV 1
+  -- the two paths, read in the subspace `↥V`, where simple connectivity lives
+  let P : Path (⟨a, haV⟩ : V) (⟨b, hbV⟩ : V) :=
+    { toFun := fun x => ⟨p x, hpV x⟩
+      continuous_toFun := hp.subtype_mk _
+      source' := Subtype.ext hp0
+      target' := Subtype.ext hp1 }
+  let Q : Path (⟨a, haV⟩ : V) (⟨b, hbV⟩ : V) :=
+    { toFun := fun x => ⟨q x, hqV x⟩
+      continuous_toFun := hq.subtype_mk _
+      source' := Subtype.ext hq0
+      target' := Subtype.ext hq1 }
+  obtain ⟨h⟩ := SimplyConnectedSpace.paths_homotopic P Q
+  -- the same homotopy, read back in `X`
+  exact ⟨_, _, h.map (⟨Subtype.val, continuous_subtype_val⟩ : C(V, X)),
+    fun t x => (h (t, x)).2, fun t => by simp, funext fun x => by simp [P],
+    funext fun x => by simp [Q]⟩
+
 namespace ContinuesInside
 
 /-- **Path independence of continuation on a simply connected domain.** Two continuations of one
@@ -117,31 +147,12 @@ theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f�
     (hf : IsAnalyticContinuationAlong f γ univ) (hf0 : f 0 =ᶠ[𝓝 z₀] f₀)
     (hg : IsAnalyticContinuationAlong g δ univ) (hg0 : g 0 =ᶠ[𝓝 z₀] f₀) :
     f 1 =ᶠ[𝓝 (γ 1)] g 1 := by
-  -- Lift the two paths to the subspace `↥U`, where simple connectivity makes them homotopic rel
-  -- endpoints; push the homotopy back to `ℂ` — every intermediate path still lies in `U`, so the
-  -- hypothesis continues the germ along it — and apply `TauCeti.monodromy_theorem` to the
-  -- resulting family. The two given continuations are then matched with the extreme members of
-  -- that family by uniqueness along a fixed path.
-  have := hUc.simplyConnectedSpace
-  have hz₀U : z₀ ∈ U := hγ0 ▸ hγU 0
-  -- The two paths, read in the subspace `↥U`, where simple connectivity lives.
-  let p : Path (⟨z₀, hz₀U⟩ : U) (⟨γ 1, hγU 1⟩ : U) :=
-    { toFun := fun x => ⟨γ x, hγU x⟩
-      continuous_toFun := hγ.subtype_mk _
-      source' := Subtype.ext hγ0
-      target' := rfl }
-  let q : Path (⟨z₀, hz₀U⟩ : U) (⟨γ 1, hγU 1⟩ : U) :=
-    { toFun := fun x => ⟨δ x, hδU x⟩
-      continuous_toFun := hδ.subtype_mk _
-      source' := Subtype.ext hδ0
-      target' := Subtype.ext hend }
-  obtain ⟨h⟩ := SimplyConnectedSpace.paths_homotopic p q
-  -- The same homotopy, read back in `ℂ`; it never leaves `U`.
-  set K := h.map (⟨Subtype.val, continuous_subtype_val⟩ : C(U, ℂ)) with hK
-  have hKmem : ∀ t x : I, K (t, x) ∈ U := fun t x => (h (t, x)).2
-  have hKzero : ∀ t : I, K (t, 0) = z₀ := fun t => by simp [hK]
-  have hKp : (fun x => K (0, x)) = γ := funext fun x => by simp [hK, p]
-  have hKq : (fun x => K (1, x)) = δ := funext fun x => by simp [hK, q]
+  -- Simple connectivity joins the two paths by a homotopy that stays in `U`, so the hypothesis
+  -- continues the germ along every intermediate path and `TauCeti.monodromy_theorem` applies to
+  -- the resulting family. The two given continuations are then matched with the extreme members
+  -- of that family by uniqueness along a fixed path.
+  obtain ⟨_, _, K, hKmem, hKzero, hKp, hKq⟩ :=
+    exists_pathHomotopy_forall_mem_of_isSimplyConnected hUc hγ hγU hγ0 rfl hδ hδU hδ0 hend
   -- A continuation along every intermediate path, all starting from the germ of `f₀`.
   have hcont : ∀ t : I, ContinuesAlong f₀ fun x => K (t, x) := fun t =>
     H.continuesAlong (by fun_prop) (hKmem t) (hKzero t)

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.Monodromy
 public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
+public import TauCeti.Topology.Homotopy.Path
 import Mathlib.Topology.MetricSpace.Thickening
 
 /-!
@@ -41,10 +42,10 @@ The branch produced is unique as soon as `U` is preconnected, by the identity pr
 ## The construction
 
 Path independence is monodromy plus simple connectivity: two paths in `U` with the same endpoints
-lift to paths in the subspace `↥U`, where `SimplyConnectedSpace.paths_homotopic` produces a
-homotopy rel endpoints; pushing that homotopy back down to `ℂ` keeps every intermediate path
-inside `U`, so the hypothesis supplies a continuation along each of them and
-`TauCeti.monodromy_theorem` applies. Uniqueness of continuation along a *fixed* path
+are joined by a homotopy whose every intermediate path is again inside `U`
+(`Path.exists_homotopy_forall_mem_of_isSimplyConnected`), so the hypothesis supplies a continuation
+along each of them and `TauCeti.monodromy_theorem` applies. Uniqueness of continuation along a
+*fixed* path
 (`TauCeti.IsAnalyticContinuationAlong.eventuallyEq`, over the preconnected parameter interval)
 then matches the two given continuations with the two extreme members of that family.
 
@@ -106,36 +107,6 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E
 
 /-! ### Path independence and the global branch -/
 
-/-- **Two paths with the same endpoints in a simply connected set are joined by a homotopy that
-never leaves it.** For continuous `p` and `q` running in `V` from `a` to `b`, there is a homotopy
-`K` between paths from `a` to `b` whose every intermediate path lies in `V`, with `K 0 = p` and
-`K 1 = q`. -/
-private lemma exists_pathHomotopy_forall_mem_of_isSimplyConnected {X : Type*} [TopologicalSpace X]
-    {V : Set X} {a b : X} {p q : I → X} (hV : IsSimplyConnected V)
-    (hp : Continuous p) (hpV : ∀ x, p x ∈ V) (hp0 : p 0 = a) (hp1 : p 1 = b)
-    (hq : Continuous q) (hqV : ∀ x, q x ∈ V) (hq0 : q 0 = a) (hq1 : q 1 = b) :
-    ∃ (P Q : Path a b) (K : P.Homotopy Q), (∀ t x, K (t, x) ∈ V) ∧ (∀ t, K (t, 0) = a) ∧
-      (fun x => K (0, x)) = p ∧ (fun x => K (1, x)) = q := by
-  have := hV.simplyConnectedSpace
-  have haV : a ∈ V := hp0 ▸ hpV 0
-  have hbV : b ∈ V := hp1 ▸ hpV 1
-  -- the two paths, read in the subspace `↥V`, where simple connectivity lives
-  let P : Path (⟨a, haV⟩ : V) (⟨b, hbV⟩ : V) :=
-    { toFun := fun x => ⟨p x, hpV x⟩
-      continuous_toFun := hp.subtype_mk _
-      source' := Subtype.ext hp0
-      target' := Subtype.ext hp1 }
-  let Q : Path (⟨a, haV⟩ : V) (⟨b, hbV⟩ : V) :=
-    { toFun := fun x => ⟨q x, hqV x⟩
-      continuous_toFun := hq.subtype_mk _
-      source' := Subtype.ext hq0
-      target' := Subtype.ext hq1 }
-  obtain ⟨h⟩ := SimplyConnectedSpace.paths_homotopic P Q
-  -- the same homotopy, read back in `X`
-  exact ⟨_, _, h.map (⟨Subtype.val, continuous_subtype_val⟩ : C(V, X)),
-    fun t x => (h (t, x)).2, fun t => by simp, funext fun x => by simp [P],
-    funext fun x => by simp [Q]⟩
-
 namespace ContinuesInside
 
 /-- **Path independence of continuation on a simply connected domain.** Two continuations of one
@@ -151,8 +122,14 @@ theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f�
   -- continues the germ along every intermediate path and `TauCeti.monodromy_theorem` applies to
   -- the resulting family. The two given continuations are then matched with the extreme members
   -- of that family by uniqueness along a fixed path.
-  obtain ⟨_, _, K, hKmem, hKzero, hKp, hKq⟩ :=
-    exists_pathHomotopy_forall_mem_of_isSimplyConnected hUc hγ hγU hγ0 rfl hδ hδU hδ0 hend
+  have hz₀U : z₀ ∈ U := hγ0 ▸ hγU 0
+  let P : Path z₀ (γ 1) := { toFun := γ, continuous_toFun := hγ, source' := hγ0, target' := rfl }
+  let Q : Path z₀ (γ 1) := { toFun := δ, continuous_toFun := hδ, source' := hδ0, target' := hend }
+  obtain ⟨K, hKmem⟩ := Path.exists_homotopy_forall_mem_of_isSimplyConnected
+    (a := ⟨z₀, hz₀U⟩) (b := ⟨γ 1, hγU 1⟩) hUc (p := P) (q := Q) hγU hδU
+  have hKzero : ∀ t : I, K (t, 0) = z₀ := fun t => by simp
+  have hKp : (fun x => K (0, x)) = γ := funext fun x => by simp [P]
+  have hKq : (fun x => K (1, x)) = δ := funext fun x => by simp [Q]
   -- A continuation along every intermediate path, all starting from the germ of `f₀`.
   have hcont : ∀ t : I, ContinuesAlong f₀ fun x => K (t, x) := fun t =>
     H.continuesAlong (by fun_prop) (hKmem t) (hKzero t)

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -6,7 +6,6 @@ Authors: Claude
 module
 
 public import TauCeti.Analysis.Complex.Conformal.Monodromy
-public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
 public import TauCeti.Topology.Homotopy.Path
 import Mathlib.Topology.MetricSpace.Thickening
 
@@ -45,9 +44,8 @@ Path independence is monodromy plus simple connectivity: two paths in `U` with t
 are joined by a homotopy whose every intermediate path is again inside `U`
 (`Path.exists_homotopy_forall_mem_of_isSimplyConnected`), so the hypothesis supplies a continuation
 along each of them and `TauCeti.monodromy_theorem` applies. Uniqueness of continuation along a
-*fixed* path
-(`TauCeti.IsAnalyticContinuationAlong.eventuallyEq`, over the preconnected parameter interval)
-then matches the two given continuations with the two extreme members of that family.
+*fixed* path (`TauCeti.IsAnalyticContinuationAlong.eventuallyEq`, over the preconnected parameter
+interval) then matches the two given continuations with the two extreme members of that family.
 
 The global branch is `F w = (value at w of the terminal germ of a continuation to w)`, chosen once
 per point of `U` by path connectedness; path independence says the choice does not matter. The
@@ -84,10 +82,11 @@ Mathlib has the abstract monodromy statement `IsLocalHomeomorph.monodromy_theore
 criterion `IsCoveringMap.existsUnique_continuousMap_lifts` for a simply connected base
 (`Mathlib/Topology/Homotopy/Lifting.lean`), but consuming them for germs of holomorphic functions
 would first require the étale space of those germs as a topological space, which Mathlib does not
-have; see the discussion in `Conformal/Monodromy.lean`. Mathlib's simple-connectivity API
-(`SimplyConnectedSpace.paths_homotopic`, `IsSimplyConnected.isPathConnected`), its path homotopy
-API (`Path.Homotopy.map`), and its metric thickening of a compact set are consumed rather than
-restated.
+have; see the discussion in `Conformal/Monodromy.lean`. Mathlib's simple-connectivity and path
+homotopy APIs are consumed rather than restated: `IsSimplyConnected.isPathConnected` here, and
+`SimplyConnectedSpace.paths_homotopic` with `Path.Homotopy.map` through
+`Path.exists_homotopy_forall_mem_of_isSimplyConnected`. So is its metric thickening of a compact
+set.
 
 ## References
 
@@ -122,11 +121,10 @@ theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f�
   -- continues the germ along every intermediate path and `TauCeti.monodromy_theorem` applies to
   -- the resulting family. The two given continuations are then matched with the extreme members
   -- of that family by uniqueness along a fixed path.
-  have hz₀U : z₀ ∈ U := hγ0 ▸ hγU 0
   let P : Path z₀ (γ 1) := { toFun := γ, continuous_toFun := hγ, source' := hγ0, target' := rfl }
   let Q : Path z₀ (γ 1) := { toFun := δ, continuous_toFun := hδ, source' := hδ0, target' := hend }
-  obtain ⟨K, hKmem⟩ := Path.exists_homotopy_forall_mem_of_isSimplyConnected
-    (a := ⟨z₀, hz₀U⟩) (b := ⟨γ 1, hγU 1⟩) hUc (p := P) (q := Q) hγU hδU
+  obtain ⟨K, hKmem⟩ :=
+    Path.exists_homotopy_forall_mem_of_isSimplyConnected hUc (p := P) (q := Q) hγU hδU
   have hKzero : ∀ t : I, K (t, 0) = z₀ := fun t => by simp
   have hKp : (fun x => K (0, x)) = γ := funext fun x => by simp [P]
   have hKq : (fun x => K (1, x)) = δ := funext fun x => by simp [Q]

--- a/TauCeti/Topology/Homotopy/Path.lean
+++ b/TauCeti/Topology/Homotopy/Path.lean
@@ -107,15 +107,23 @@ theorem continuous_initialSegmentFamily_uncurry {a b : X} (γ : Path a b) :
 `p` and `q` running in `V` between the same two points of `V`, there is a homotopy from `p` to `q`
 every intermediate path of which again lies in `V`.
 
-`SimplyConnectedSpace.paths_homotopic` gives a homotopy in the subspace `↥V`; the point of this
-statement is that reading it back in `X` costs nothing, because a homotopy in the subspace is by
-construction one that stays in `V`. -/
+The homotopy is stated in the ambient space rather than in `↥V`, with membership in `V` as a
+separate conclusion: that is the form consumers want, and it spares them transporting along the
+subtype. -/
 theorem exists_homotopy_forall_mem_of_isSimplyConnected {V : Set X} (hV : IsSimplyConnected V)
-    {a b : V} {p q : Path (a : X) (b : X)} (hp : ∀ t, p t ∈ V) (hq : ∀ t, q t ∈ V) :
+    {a b : X} {p q : Path a b} (hp : ∀ t, p t ∈ V) (hq : ∀ t, q t ∈ V) :
     ∃ K : p.Homotopy q, ∀ t x, K (t, x) ∈ V := by
   have := hV.simplyConnectedSpace
-  obtain ⟨h⟩ := SimplyConnectedSpace.paths_homotopic (p.codRestrict hp) (q.codRestrict hq)
-  exact ⟨h.map (⟨Subtype.val, continuous_subtype_val⟩ : C(V, X)), fun t x => (h (t, x)).2⟩
+  have haV : a ∈ V := p.source ▸ hp 0
+  have hbV : b ∈ V := p.target ▸ hp 1
+  obtain ⟨h⟩ := SimplyConnectedSpace.paths_homotopic
+    (Path.codRestrict (x := ⟨a, haV⟩) (y := ⟨b, hbV⟩) p hp)
+    (Path.codRestrict (x := ⟨a, haV⟩) (y := ⟨b, hbV⟩) q hq)
+  -- map the subspace homotopy back down, and read its endpoints through `map_codRestrict`
+  refine ⟨(h.map (⟨Subtype.val, continuous_subtype_val⟩ : C(V, X))).cast
+    (Path.map_codRestrict (x := ⟨a, haV⟩) (y := ⟨b, hbV⟩) p hp)
+    (Path.map_codRestrict (x := ⟨a, haV⟩) (y := ⟨b, hbV⟩) q hq), fun t x => ?_⟩
+  simp
 
 end Path
 

--- a/TauCeti/Topology/Homotopy/Path.lean
+++ b/TauCeti/Topology/Homotopy/Path.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Topology.Subpath
 public import Mathlib.Topology.Homotopy.Contractible
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
 -- Private: `Path.Homotopic.map_trans_evalAt` is used only in the proof of
 -- `map_nullhomotopic_of_nullhomotopic` below, so this import is not re-exported.
 import Mathlib.AlgebraicTopology.FundamentalGroupoid.InducedMaps
@@ -14,11 +15,16 @@ import Mathlib.AlgebraicTopology.FundamentalGroupoid.InducedMaps
 /-!
 # Path homotopy helpers
 
-Small path and path-homotopy quotient lemmas used by the universal-cover construction. The
+Small path and path-homotopy lemmas, mostly for the universal-cover construction. The
 quotient subpath identities are adapted from Kim Morrison's Mathlib universal-cover drafts,
 especially [#31576](https://github.com/leanprover-community/mathlib4/pull/31576) and
 [#38292](https://github.com/leanprover-community/mathlib4/pull/38292), following the earlier
 Tau Ceti work in [#42](https://github.com/TauCetiProject/TauCeti/pull/42).
+
+`Path.exists_homotopy_forall_mem_of_isSimplyConnected` is not from that source: it records that
+`SimplyConnectedSpace.paths_homotopic`, applied in a subspace `↥V`, yields a homotopy in the
+ambient space whose intermediate paths all stay in `V`. Analytic continuation consumes it in
+`Analysis/Complex/Conformal/GlobalBranch.lean`.
 -/
 
 public section
@@ -96,6 +102,20 @@ theorem continuous_initialSegmentFamily_uncurry {a b : X} (γ : Path a b) :
     initialSegmentFamily γ 1 = γ.cast rfl (by simp) := by
   ext s
   simp [initialSegmentFamily_apply, min_eq_left s.2.2, γ.extend_apply s.2]
+
+/-- **Two paths with the same endpoints in a simply connected set are homotopic inside it.** For
+`p` and `q` running in `V` between the same two points of `V`, there is a homotopy from `p` to `q`
+every intermediate path of which again lies in `V`.
+
+`SimplyConnectedSpace.paths_homotopic` gives a homotopy in the subspace `↥V`; the point of this
+statement is that reading it back in `X` costs nothing, because a homotopy in the subspace is by
+construction one that stays in `V`. -/
+theorem exists_homotopy_forall_mem_of_isSimplyConnected {V : Set X} (hV : IsSimplyConnected V)
+    {a b : V} {p q : Path (a : X) (b : X)} (hp : ∀ t, p t ∈ V) (hq : ∀ t, q t ∈ V) :
+    ∃ K : p.Homotopy q, ∀ t x, K (t, x) ∈ V := by
+  have := hV.simplyConnectedSpace
+  obtain ⟨h⟩ := SimplyConnectedSpace.paths_homotopic (p.codRestrict hp) (q.codRestrict hq)
+  exact ⟨h.map (⟨Subtype.val, continuous_subtype_val⟩ : C(V, X)), fun t x => (h (t, x)).2⟩
 
 end Path
 


### PR DESCRIPTION
`ContinuesInside.eventuallyEq_at_one` is path independence of analytic continuation on a simply connected domain. Half of it was not about continuation at all: it lifted `γ` and `δ` to the subspace `↥U` as two `Path` structures, invoked `SimplyConnectedSpace.paths_homotopic`, pushed the result back down to `ℂ`, and recorded that every intermediate path is still in `U` — twenty-two of its forty-two lines, in which nothing analytic appears.

That is a fact about topological spaces, so it goes where topological facts go. `Path.exists_homotopy_forall_mem_of_isSimplyConnected` is added to `TauCeti/Topology/Homotopy/Path.lean`: two paths between the same two points of a simply connected `V` are joined by a homotopy every intermediate path of which again lies in `V`.

It is short, because that file already owns the two halves of the round trip. `Path.codRestrict` lifts a path with image in `V` to the subtype and `Path.map_codRestrict` maps it back, so the homotopy `SimplyConnectedSpace.paths_homotopic` produces in `↥V`, pushed down by `Path.Homotopy.map` and cast along those two equations, is a homotopy of the original paths; its membership conclusion is the second component of a subtype element. The by-hand `Path` structures over `↥U` in `GlobalBranch.lean` were rebuilding `Path.codRestrict`.

The subtype endpoints are not parameters: `a ∈ V` and `b ∈ V` follow from the membership hypotheses at the two ends of `p`, so the statement takes `{a b : X} {p q : Path a b}` and builds them internally.

The statement is over an arbitrary topological space and takes bundled `Path`s. Nothing in it is complex-analytic — `IsSimplyConnected` is Mathlib's predicate on a subset of any topological space — and the consumer, `TauCeti.monodromy_theorem`, takes a `Path.Homotopy`, so unbundling would only force the caller to rebuild it.

The parent drops from 42 lines to 29 and keeps the bundling of its two raw paths, which is where the endpoint hypotheses `γ 0 = z₀`, `δ 0 = z₀` and `δ 1 = γ 1` are discharged. The `set K` is gone: the homotopy now arrives from the lemma, so no folded abbreviation stands between the parent and its conclusion.

Two module docstrings are corrected for the move: `GlobalBranch.lean`'s construction paragraph described the lifting it no longer performs, and its Mathlib paragraph listed `SimplyConnectedSpace.paths_homotopic` and `Path.Homotopy.map` as consumed directly, which they no longer are; `Topology/Homotopy/Path.lean`'s provenance paragraph attributed its whole contents to Kim Morrison's universal-cover drafts, which is not the source of the new lemma.

`GlobalBranch.lean` also drops its direct `Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected` import, which the new public import of `TauCeti.Topology.Homotopy.Path` now provides.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: ConformalMapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
