### PR TITLE
feat(ModularForms): the arc's excised logDeriv integral tends to (π/3)·I

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcExcisionMeasure.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcExcisionMeasure.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Contour.Curve.ExcisionMeasure
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
 
 /-!
 # The excision leaves the arc's full length in the limit
@@ -53,6 +54,36 @@ theorem tendsto_intervalIntegral_excisionIndicator_fdBoundary_arc (H : ℝ) (S :
     (Contour.measure_setOf_mem_eq_zero_of_injOn (injOn_fdBoundary_arc H) S)
   norm_num at h
   exact h
+
+/-- **The excised arc integral of the contour's own logarithmic derivative.** On the arc
+`logDeriv (fdBoundary H)` is the constant `(π/6)·I` (`logDeriv_fdBoundary_arc`), so the excised
+integral is that constant times the surviving length. -/
+theorem intervalIntegral_excised_logDeriv_fdBoundary_arc (H : ℝ) (S : Finset ℂ) (ε : ℝ) :
+    (∫ t in (1 : ℝ)..3, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
+        else logDeriv (fdBoundary H) t) =
+      ((Real.pi / 6 : ℝ) * Complex.I) *
+        (↑(∫ t in (1 : ℝ)..3, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then (0 : ℝ) else 1) : ℂ) := by
+  rw [← intervalIntegral.integral_ofReal, ← intervalIntegral.integral_const_mul]
+  refine intervalIntegral.integral_congr_uIoo fun t ht => ?_
+  rw [uIoo_of_le (by norm_num : (1 : ℝ) ≤ 3)] at ht
+  by_cases hb : ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε
+  · simp [hb]
+  · simp [hb, logDeriv_fdBoundary_arc ht]
+
+/-- **The arc's excised logarithmic-derivative integral tends to `(π/3)·I`.** Combining the
+constant value on the arc with the surviving length's limit `2`. -/
+theorem tendsto_intervalIntegral_excised_logDeriv_fdBoundary_arc (H : ℝ) (S : Finset ℂ) :
+    Tendsto (fun ε => ∫ t in (1 : ℝ)..3, if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
+        else logDeriv (fdBoundary H) t)
+      (𝓝[>] 0) (𝓝 ((Real.pi / 3 : ℝ) * Complex.I)) := by
+  simp only [intervalIntegral_excised_logDeriv_fdBoundary_arc H S]
+  have h := (Complex.continuous_ofReal.tendsto _).comp
+    (tendsto_intervalIntegral_excisionIndicator_fdBoundary_arc H S)
+  -- `2` surviving units of length at `(π/6)·I` each.
+  have hval : ((Real.pi / 6 : ℝ) : ℂ) * Complex.I * ((2 : ℝ) : ℂ)
+      = ((Real.pi / 3 : ℝ) : ℂ) * Complex.I := by push_cast; ring
+  exact hval ▸ h.const_mul _
+
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcExcisionMeasure.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcExcisionMeasure.lean
@@ -17,9 +17,11 @@ within `ε` of the elliptic points. On the arc the excised integral turns out to
 multiple of the *length* of the surviving parameter set, so its `ε → 0` limit is governed by
 that length alone.
 
-This file supplies the limit. The arc runs once around a `π/3` sector of the unit circle, so it
+This file supplies both halves. The arc runs once around a `π/3` sector of the unit circle, so it
 meets each excision centre at most once (`injOn_fdBoundary_arc`), and
 `TauCeti.Contour.tendsto_intervalIntegral_excisionIndicator` applies with the whole length `2`.
+The constant is the contour's own logarithmic derivative, which on the arc is `(π/6)·I`
+(`logDeriv_fdBoundary_arc`), so the excised integral tends to `(π/3)·I`.
 
 ## References
 
@@ -33,6 +35,10 @@ meets each excision centre at most once (`injOn_fdBoundary_arc`), and
 
 * `TauCeti.ModularForm.tendsto_intervalIntegral_excisionIndicator_fdBoundary_arc`: the surviving
   length of `[1, 3]` tends to `2` as `ε → 0⁺`.
+* `TauCeti.ModularForm.intervalIntegral_excised_logDeriv_fdBoundary_arc`: at a fixed `ε`, the
+  excised arc integral of `logDeriv (fdBoundary H)` is `(π/6)·I` times the surviving length.
+* `TauCeti.ModularForm.tendsto_intervalIntegral_excised_logDeriv_fdBoundary_arc`: hence it tends
+  to `(π/3)·I`.
 -/
 
 public section


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-formula/arc-excision-limit"}-->

The `ε → 0` limit of the excised arc integral, the last piece of the arc's contribution to the
valence formula.

#2668 showed the excision costs no *length* in the limit: the surviving part of `[1, 3]` tends
to `2`. This PR converts that into the limit the boundary assembly actually consumes, using the
one extra fact that makes the arc easy — **on the arc the contour's own logarithmic derivative is
constant**.

`Deriv.logDeriv_fdBoundary_arc` gives `logDeriv (fdBoundary H) t = (π/6)·I` on `Ioo 1 3`, so the
excised integral is that constant times the surviving length:

```
∫₁³ (excised logDeriv γ) = (π/6)·I · (surviving length)   →   (π/6)·I · 2 = (π/3)·I
```

The identity holds at every `ε` and is proved by `intervalIntegral.integral_congr_uIoo` — the
constant is only available on the *open* interval, and the two endpoints are null — after which
the real integral comes out through `intervalIntegral.integral_ofReal` and the constant through
`intervalIntegral.integral_const_mul`.

## Why this is the piece that was missing

`intervalIntegral_excised_logDeriv_fdBoundary` (#2603) assembles the whole boundary integral at a
**fixed** `ε` as `2πi·ord_∞ − (k/2)·∫₁³ (excised logDeriv γ)`, deliberately saying nothing about
the limit of that last term. This PR supplies it, and the value is a consistency check on the
whole excision chain: `(k/2)·(π/3)i = k·(π/6)i`, exactly the constant the **unexcised** assembly
`intervalIntegral_logDeriv_fdBoundary` produces. The excision buys tolerance of zeros *on* the
contour and, as it must, changes nothing when there are none.

## Main declarations

* `TauCeti.ModularForm.intervalIntegral_excised_logDeriv_fdBoundary_arc` — the identity at fixed
  `ε`: the excised arc integral is `(π/6)·I` times the surviving length.
* `TauCeti.ModularForm.tendsto_intervalIntegral_excised_logDeriv_fdBoundary_arc` — its limit
  `(π/3)·I`.

Roadmap: ModularForms

Layer 1 of the ModularForms roadmap, *the valence formula (general level)*, which consumes the
Contour Integration roadmap; this completes the arc term's `ε → 0` limit, whose measure-theoretic
half was #2668.
