### PR TITLE
refactor(Order): isCofinalElement_def should not be simp

### DIFF
--- a/TauCeti/Algebra/Order/Group/Cofinal.lean
+++ b/TauCeti/Algebra/Order/Group/Cofinal.lean
@@ -71,8 +71,11 @@ a property of sets with respect to `≤`. -/
 def IsCofinalElement (H : Subgroup Γ) (γ : Γ) : Prop :=
   ∀ h ∈ H, ∃ n : ℕ, γ ^ n < h
 
-/-- The defining property of a cofinal element. -/
-@[simp]
+/-- The defining property of a cofinal element.
+
+Deliberately not `@[simp]`: the right-hand side is the unfolded bounded quantifier, so tagging
+it rewrites uses of the named predicate into raw `∀ … ∃ …` form. This mirrors
+`TauCeti.Valuation.cofinalValueFor_def`, which is not `@[simp]` for the same reason. -/
 theorem isCofinalElement_def {H : Subgroup Γ} {γ : Γ} :
     IsCofinalElement H γ ↔ ∀ h ∈ H, ∃ n : ℕ, γ ^ n < h :=
   Iff.rfl


### PR DESCRIPTION
`TauCeti.IsCofinalElement.isCofinalElement_def` should not be `@[simp]`.

`IsCofinalElement H γ` unfolds to `∀ h ∈ H, ∃ n : ℕ, γ ^ n < h`, and
`isCofinalElement_def` restates exactly that. Tagging it `@[simp]` rewrites uses of the **named**
predicate into the raw bounded quantifier — past the form consumers actually hold, and past the
lemmas stated about `IsCofinalElement` itself.

Its exact sibling already avoids this. `TauCeti.Valuation.cofinalValueFor_def` is deliberately not
`@[simp]`, and its docstring says why:

> Deliberately not `@[simp]`: the right-hand side is the unfolded bounded quantifier, so tagging
> it would rewrite `a ∈ cofinalIdeal v hH` past the named predicate and into raw `∀ … ∃ …` form.

The two are the same shape and now agree, with the reason recorded on both.

**Verification.** Full build clean — 7303 jobs, zero errors — so nothing in the repository was
relying on the rewrite. That is the point worth checking for a simp removal: the breakage, if any,
would have surfaced in files far from this one.

Noticed while building the §7.1 chain (TauCetiProject/TauCeti#2551, #2574, #2573); deferred until
those landed so it would not entangle them.

Roadmap: none
