### PR TITLE
feat: the diagram of a finite-type Cartan matrix is a forest

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
@@ -51,12 +51,15 @@ denominators. The symmetrization itself is not redone here: Mathlib packages it 
 * `TauCeti.IsFiniteType.apply_mul_apply_mem_of_ne`: the rank-two bound. For `i ≠ j` the Cartan
   product `A i j * A j i` lies in `{0, 1, 2, 3}`, so every edge of the diagram is single, double or
   triple.
+* `TauCeti.IsFiniteType.exists_apply_succ_eq_zero`: **a finite-type diagram carries no cycle**. A
+  cyclic list of at least three distinct indices has a missing edge. This is the second estimate:
+  the test vector is supported on the indices of the putative cycle, its coordinate at each of them
+  being the reciprocal of the symmetrizer, and each edge of the cycle then cancels the diagonal
+  contribution of one of its ends.
 * `TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero`: **a finite-type diagram carries no
-  triangle**. Two distinct neighbours of an index are never adjacent to one another. This is the
-  second estimate: the test vector is supported on the three indices of the putative triangle, its
-  coordinate at each of them being the weight of the opposite edge, and the rank-two bound then
-  makes the symmetrized form nonpositive there. `TauCeti.IsFiniteType.pairwise_apply_eq_zero` is the
-  same statement for a whole neighbourhood, in the shape the star bound consumes.
+  triangle**, the three-index case of the previous item: two distinct neighbours of an index are
+  never adjacent to one another. `TauCeti.IsFiniteType.pairwise_apply_eq_zero` is the same statement
+  for a whole neighbourhood, in the shape the star bound consumes.
 
 The star bound selects its neighbours through a pairwise non-adjacency hypothesis; with the triangle
 excluded that hypothesis comes for free, and the consequences below are the unconditional graph
@@ -187,16 +190,6 @@ private theorem symmetrization_apply_comm {d : B → ℚ}
     (hpd : (Matrix.of fun i j ↦ d i * (A i j : ℚ)).PosDef) (p q : B) :
     d q * (A q p : ℚ) = d p * (A p q : ℚ) := by
   simpa using hpd.isHermitian.apply p q
-
-omit [Fintype B] in
-/-- **The square of an edge weight of the symmetrization is a scaled Cartan product.** The weight
-`dₚAₚq` squares to `dₚdq · AₚqAqₚ`, the two symmetrizer values times the Cartan product of the
-edge. This is what lets the triangle estimate be run over `ℚ`: the square roots of the geometric
-argument never appear. -/
-private theorem sq_symmetrization_apply {d : B → ℚ} {p q : B}
-    (hsymm : d q * (A q p : ℚ) = d p * (A p q : ℚ)) :
-    (d p * (A p q : ℚ)) ^ 2 = d p * d q * ((A p q : ℚ) * (A q p : ℚ)) := by
-  linear_combination (-(d p * (A p q : ℚ))) * hsymm
 
 /-- **A principal submatrix of a finite-type matrix is of finite type.** This is the form in which
 a forbidden subdiagram excludes every diagram containing it. -/
@@ -355,122 +348,155 @@ theorem apply_mul_apply_mem_of_ne (h : IsFiniteType A) {i j : B} (hij : i ≠ j)
   simp only [Set.mem_insert_iff, Set.mem_singleton_iff]
   omega
 
-/-- **Three Cartan products in the rank-two range satisfy `(α + β + γ) ^ 2 ≤ 9αβγ`.** This is the
-arithmetic behind the exclusion of triangles. The three edges of a triangle carry Cartan products
-between `1` and `3`, and the inequality then says that the test vector built from those three
-products does not see a positive value of the symmetrized form. Equality holds exactly at
-`α = β = γ = 1`, the simply laced triangle, which is the affine diagram `Ã₂`. -/
-private theorem add_sq_le_nine_mul {α β γ : ℤ} (hα : 1 ≤ α) (hα' : α ≤ 3) (hβ : 1 ≤ β)
-    (hβ' : β ≤ 3) (hγ : 1 ≤ γ) (hγ' : γ ≤ 3) :
-    (α + β + γ) ^ 2 ≤ 9 * (α * β * γ) := by
-  interval_cases α <;> interval_cases β <;> interval_cases γ <;> norm_num
+/-- **A cyclic diagram is not of finite type.** On an index type of size at least three, no
+finite-type matrix joins every index to its cyclic successor: some `Tₖ,ₖ₊₁` vanishes.
 
-/-- **The endgame of the triangle exclusion.** If `m` is positive with `m² = P²αβγ` and the three
-Cartan products satisfy the bound of `TauCeti.IsFiniteType.add_sq_le_nine_mul`, then `3m` is not
-below `P(α + β + γ)`: squaring the strict inequality would make `9P²αβγ` smaller than itself.
+This is the positive-definiteness estimate behind the acyclicity of a finite-type diagram, and the
+test vector is the reciprocal `xᵢ = 1/dᵢ` of the symmetrizer. At it the symmetrized form
+`∑ᵢⱼ xᵢ dᵢTᵢⱼ xⱼ` collects `2/dᵢ` from each diagonal entry and `Tᵢⱼ/dⱼ` from each off-diagonal one,
+and the latter is nonpositive throughout. The two entries of the pair `{k, k+1}` contribute equally,
+each `Tₖ₊₁,ₖ/dₖ ≤ -1/dₖ`, since the symmetrization identity `dₖTₖ,ₖ₊₁ = dₖ₊₁Tₖ₊₁,ₖ` is exactly what
+makes `Tᵢⱼ/dⱼ` symmetric in `i` and `j`. So the value is at most `∑ₖ 2/dₖ - 2∑ₖ 1/dₖ = 0`, which
+positive definiteness forbids. Edges off the cycle only lower the value further, so the cycle need
+not be chordless, and the scaling by the symmetrizer is what keeps the test vector rational: the
+geometric argument takes unit vectors along the coroots and needs their square roots.
 
-At the call site `P` is the product of the three symmetrizer values, `α`, `β`, `γ` are the Cartan
-products along the three edges of the triangle, and `m` is the product of the three edge weights of
-the symmetrization, up to sign; the value of the symmetrized form at the test vector is
-`2P(α + β + γ) - 6m`, so positive definiteness is exactly the inequality refuted here. -/
-private theorem not_three_mul_lt {P m α β γ : ℚ} (hP : 0 < P) (hm : 0 < m)
-    (hm2 : m ^ 2 = P ^ 2 * (α * β * γ)) (hb : (α + β + γ) ^ 2 ≤ 9 * (α * β * γ)) :
-    ¬ 3 * m < P * (α + β + γ) := fun hlt ↦ by
-  nlinarith [mul_le_mul_of_nonneg_left hb (mul_pos hP hP).le, sq_nonneg (P * (α + β + γ) - 3 * m)]
-
-/-- **The three-index core of the no-triangle theorem.** A finite-type matrix on three indices has
-a missing edge: if the first index is joined to the other two, those two are not joined to each
-other.
-
-The proof is the second, and last, positive-definiteness estimate of this file, and it is a
-different one from the star bound: the test vector is supported on *all three* indices, and at each
-of them its coordinate is the weight, in the symmetrization, of the *opposite* edge. Writing
-`a`, `b`, `c` for the three edge weights - each negative, since the off-diagonal entries are - the
-symmetrized form evaluates at that vector to `2(d₀c² + d₁b² + d₂a²) + 6abc`, and the identity
-`a² = d₀d₁·(A₀₁A₁₀)` turns this into `2P(α + β + γ) - 6m` in the notation of
-`TauCeti.IsFiniteType.not_three_mul_lt`. -/
-private theorem apply_eq_zero_fin_three {T : Matrix (Fin 3) (Fin 3) ℤ} (h : IsFiniteType T)
-    (h01 : T 0 1 ≠ 0) (h02 : T 0 2 ≠ 0) :
-    T 1 2 = 0 := by
-  by_contra h12
+The affine diagrams `Ãₙ` are what this excludes, and at three indices every triangle:
+`TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero` is the case `m = 3`. -/
+private theorem exists_apply_succ_eq_zero_fin {m : ℕ} [NeZero m] (hm : 3 ≤ m)
+    {T : Matrix (Fin m) (Fin m) ℤ} (h : IsFiniteType T) :
+    ∃ k, T k (k + 1) = 0 := by
+  by_contra hcon
+  push Not at hcon
   obtain ⟨d, hd, hpd⟩ := h.exists_symmetrizer
   have hsymm := symmetrization_apply_comm hpd
-  -- Each of the three edges is present, so each edge weight of the symmetrization is negative.
-  have hT01 : T 0 1 < 0 := lt_of_le_of_ne (h.apply_le_zero_of_ne (by decide)) h01
-  have hT02 : T 0 2 < 0 := lt_of_le_of_ne (h.apply_le_zero_of_ne (by decide)) h02
-  have hT12 : T 1 2 < 0 := lt_of_le_of_ne (h.apply_le_zero_of_ne (by decide)) h12
-  have ha : d 0 * ((T 0 1 : ℤ) : ℚ) < 0 := mul_neg_of_pos_of_neg (hd 0) (by exact_mod_cast hT01)
-  have hb : d 0 * ((T 0 2 : ℤ) : ℚ) < 0 := mul_neg_of_pos_of_neg (hd 0) (by exact_mod_cast hT02)
-  have hc : d 1 * ((T 1 2 : ℤ) : ℚ) < 0 := mul_neg_of_pos_of_neg (hd 1) (by exact_mod_cast hT12)
-  -- The test vector: at each index, the weight of the opposite edge.
-  have hq := hpd.dotProduct_mulVec_pos
-    (x := ![-(d 1 * ((T 1 2 : ℤ) : ℚ)), -(d 0 * ((T 0 2 : ℤ) : ℚ)), -(d 0 * ((T 0 1 : ℤ) : ℚ))])
-    (fun hcon ↦ by
-      have h0 := congrFun hcon 0
-      simp only [Matrix.cons_val_zero, Pi.zero_apply, neg_eq_zero] at h0
-      linarith)
+  -- An index, its successor and its predecessor are pairwise distinct, the cycle being long enough.
+  have hval1 : ((1 : Fin m) : ℕ) = 1 := by
+    rw [Fin.val_one', Nat.mod_eq_of_lt (by omega)]
+  have hone : (1 : Fin m) ≠ 0 := fun hc ↦ by
+    have hval := congrArg Fin.val hc
+    rw [hval1, Fin.val_zero] at hval
+    omega
+  have htwo : (1 : Fin m) + 1 ≠ 0 := fun hc ↦ by
+    have hval2 : (((1 : Fin m) + 1 : Fin m) : ℕ) = 2 := by
+      rw [Fin.val_add, hval1, Nat.mod_eq_of_lt (by omega)]
+    have hval := congrArg Fin.val hc
+    rw [hval2, Fin.val_zero] at hval
+    omega
+  have hsucc : ∀ i : Fin m, i + 1 ≠ i := fun i hc ↦
+    hone (add_left_cancel (show i + 1 = i + 0 by simpa using hc))
+  have hpred : ∀ i : Fin m, i - 1 ≠ i := by
+    intro i hc
+    have h1 : i - 1 + 1 = i + 1 := by rw [hc]
+    rw [sub_add_cancel] at h1
+    exact hsucc i h1.symm
+  have hsp : ∀ i : Fin m, i + 1 ≠ i - 1 := by
+    intro i hc
+    refine htwo (add_left_cancel (a := i) ?_)
+    rw [← add_assoc, hc, sub_add_cancel, add_zero]
+  -- `f i j` is the contribution of the pair `(i, j)` to the form at the test vector; it is
+  -- symmetric, and nonpositive off the diagonal.
+  obtain ⟨f, hf⟩ : ∃ f : Fin m → Fin m → ℚ, ∀ i j, f i j = (T i j : ℚ) / d j := ⟨_, fun _ _ ↦ rfl⟩
+  have hfsymm : ∀ i j, f i j = f j i := by
+    intro i j
+    rw [hf, hf, div_eq_div_iff (hd j).ne' (hd i).ne']
+    linear_combination -hsymm i j
+  have hdiag : ∀ i, f i i = 2 / d i := by
+    intro i
+    rw [hf, h.apply_self]
+    norm_num
+  have hnonpos : ∀ i j : Fin m, j ≠ i → f i j ≤ 0 := by
+    intro i j hji
+    have h1 : ((T i j : ℤ) : ℚ) ≤ 0 := by exact_mod_cast h.apply_le_zero_of_ne (Ne.symm hji)
+    rw [hf, div_eq_mul_inv]
+    simpa using mul_le_mul_of_nonneg_right h1 (inv_nonneg.mpr (hd j).le)
+  -- Along an edge of the cycle the contribution is at most `-1/dᵢ`, at either of its two entries.
+  have hedge : ∀ i : Fin m, f i (i + 1) ≤ -(d i)⁻¹ := by
+    intro i
+    have h0 : T (i + 1) i ≠ 0 := fun hc ↦ hcon i (h.apply_eq_zero_symm hc)
+    have hle : T (i + 1) i ≤ -1 := by
+      have := h.apply_le_zero_of_ne (hsucc i)
+      omega
+    have hcast : ((T (i + 1) i : ℤ) : ℚ) ≤ -1 := by exact_mod_cast hle
+    calc f i (i + 1) = (T (i + 1) i : ℚ) * (d i)⁻¹ := by rw [hfsymm, hf, div_eq_mul_inv]
+      _ ≤ (-1 : ℚ) * (d i)⁻¹ := mul_le_mul_of_nonneg_right hcast (inv_nonneg.mpr (hd i).le)
+      _ = -(d i)⁻¹ := by ring
+  -- Positive definiteness at the test vector.
+  have hx : (fun k : Fin m ↦ (d k)⁻¹) ≠ 0 := fun hc ↦ by
+    simpa [(hd (0 : Fin m)).ne'] using congrFun hc 0
+  have hq := hpd.dotProduct_mulVec_pos hx
   rw [star_trivial, Matrix.dot_mulVec_eq_sum_sum] at hq
-  simp only [Fin.sum_univ_three, Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
-    Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons] at hq
-  rw [h.apply_self 0, h.apply_self 1, h.apply_self 2, hsymm 0 1, hsymm 0 2, hsymm 1 2] at hq
-  push_cast at hq
-  -- The square of an edge weight is the Cartan product of that edge, scaled by two symmetrizers.
-  have ea := sq_symmetrization_apply (hsymm 0 1)
-  have eb := sq_symmetrization_apply (hsymm 0 2)
-  have ec := sq_symmetrization_apply (hsymm 1 2)
-  -- Package the three edges as the data the arithmetic endgame consumes.
-  refine not_three_mul_lt (P := d 0 * d 1 * d 2)
-    (m := -(d 0 * ((T 0 1 : ℤ) : ℚ) * (d 0 * ((T 0 2 : ℤ) : ℚ)) * (d 1 * ((T 1 2 : ℤ) : ℚ))))
-    (α := ((T 0 1 : ℤ) : ℚ) * ((T 1 0 : ℤ) : ℚ)) (β := ((T 0 2 : ℤ) : ℚ) * ((T 2 0 : ℤ) : ℚ))
-    (γ := ((T 1 2 : ℤ) : ℚ) * ((T 2 1 : ℤ) : ℚ))
-    (mul_pos (mul_pos (hd 0) (hd 1)) (hd 2))
-    (neg_pos.mpr (mul_neg_of_pos_of_neg (mul_pos_of_neg_of_neg ha hb) hc)) ?_ ?_ ?_
-  · -- `m² = P²αβγ`, by multiplying the three edge identities.
-    have : (-(d 0 * ((T 0 1 : ℤ) : ℚ) * (d 0 * ((T 0 2 : ℤ) : ℚ)) * (d 1 * ((T 1 2 : ℤ) : ℚ)))) ^ 2
-        = (d 0 * ((T 0 1 : ℤ) : ℚ)) ^ 2 * (d 0 * ((T 0 2 : ℤ) : ℚ)) ^ 2 *
-          (d 1 * ((T 1 2 : ℤ) : ℚ)) ^ 2 := by ring
-    rw [this, ea, eb, ec]
-    ring
-  · -- The rank-two bound on each of the three edges feeds the arithmetic inequality.
-    have hα := h.one_le_apply_mul_apply h01
-    have hβ := h.one_le_apply_mul_apply h02
-    have hγ := h.one_le_apply_mul_apply h12
-    have hα' := h.apply_mul_apply_mem_of_ne (i := 0) (j := 1) (by decide)
-    have hβ' := h.apply_mul_apply_mem_of_ne (i := 0) (j := 2) (by decide)
-    have hγ' := h.apply_mul_apply_mem_of_ne (i := 1) (j := 2) (by decide)
-    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hα' hβ' hγ'
-    have := add_sq_le_nine_mul hα (by omega) hβ (by omega) hγ (by omega)
-    exact_mod_cast this
-  · -- Positive definiteness at the test vector, rewritten through the three edge identities: each
-    -- diagonal contribution is twice `P` times the Cartan product of the opposite edge.
-    have ea' : 2 * d 2 * (d 0 * ((T 0 1 : ℤ) : ℚ)) ^ 2
-        = 2 * (d 0 * d 1 * d 2) * (((T 0 1 : ℤ) : ℚ) * ((T 1 0 : ℤ) : ℚ)) := by rw [ea]; ring
-    have eb' : 2 * d 1 * (d 0 * ((T 0 2 : ℤ) : ℚ)) ^ 2
-        = 2 * (d 0 * d 1 * d 2) * (((T 0 2 : ℤ) : ℚ) * ((T 2 0 : ℤ) : ℚ)) := by rw [eb]; ring
-    have ec' : 2 * d 0 * (d 1 * ((T 1 2 : ℤ) : ℚ)) ^ 2
-        = 2 * (d 0 * d 1 * d 2) * (((T 1 2 : ℤ) : ℚ) * ((T 2 1 : ℤ) : ℚ)) := by rw [ec]; ring
-    linarith [hq, ea', eb', ec']
+  simp only [Matrix.of_apply] at hq
+  have hq' : (0 : ℚ) < ∑ i, ∑ j, f i j := by
+    rw [Finset.sum_comm]
+    refine lt_of_lt_of_le hq (le_of_eq (Finset.sum_congr rfl fun j _ ↦
+      Finset.sum_congr rfl fun i _ ↦ ?_))
+    rw [hf, inv_mul_cancel_left₀ (hd i).ne', div_eq_mul_inv]
+  -- Each index contributes at most `1/dᵢ - 1/dᵢ₋₁`, and those differences telescope around the
+  -- cycle to `0`.
+  have hbound : ∀ i : Fin m, ∑ j, f i j ≤ (d i)⁻¹ - (d (i - 1))⁻¹ := by
+    intro i
+    rw [← Finset.sum_sdiff (Finset.subset_univ ({i, i + 1, i - 1} : Finset (Fin m)))]
+    have hrest : ∑ j ∈ Finset.univ \ ({i, i + 1, i - 1} : Finset (Fin m)), f i j ≤ 0 := by
+      refine Finset.sum_nonpos fun j hj ↦ hnonpos i j ?_
+      simp only [Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton, not_or] at hj
+      tauto
+    have hthree : ∑ j ∈ ({i, i + 1, i - 1} : Finset (Fin m)), f i j
+        = f i i + f i (i + 1) + f i (i - 1) := by
+      rw [Finset.sum_insert (by
+          simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+          exact ⟨(hsucc i).symm, (hpred i).symm⟩),
+        Finset.sum_insert (by simpa using hsp i), Finset.sum_singleton, add_assoc]
+    have hlast : f i (i - 1) ≤ -(d (i - 1))⁻¹ := by
+      have hshift := hedge (i - 1)
+      rwa [sub_add_cancel, hfsymm] at hshift
+    have hhalf : (2 : ℚ) / d i = (d i)⁻¹ + (d i)⁻¹ := by
+      rw [div_eq_mul_inv]; ring
+    have hii := hdiag i
+    have hnext := hedge i
+    rw [hthree]
+    linarith
+  have hshift : ∑ i : Fin m, (d (i - 1))⁻¹ = ∑ i : Fin m, (d i)⁻¹ :=
+    Fintype.sum_equiv (Equiv.subRight (1 : Fin m)) _ _ fun _ ↦ rfl
+  have hle := Finset.sum_le_sum fun i (_ : i ∈ (Finset.univ : Finset (Fin m))) ↦ hbound i
+  rw [Finset.sum_sub_distrib, hshift, sub_self] at hle
+  linarith
+
+/-- **A finite-type diagram carries no cycle.** A cyclic list of at least three distinct indices
+has a missing edge: some index of the cycle is not joined to its successor. The cycle is not
+required to be chordless, and no edge of it is required to be simple.
+
+Only the principal submatrix on the indices of the cycle is involved, so this is
+`TauCeti.IsFiniteType.exists_apply_succ_eq_zero_fin` transported along the injection.
+`TauCeti.IsFiniteType.isAcyclic_diagramGraph` is the same statement in the language of graphs. -/
+theorem exists_apply_succ_eq_zero (h : IsFiniteType A) {m : ℕ} [NeZero m] (hm : 3 ≤ m)
+    {v : Fin m → B} (hv : Function.Injective v) :
+    ∃ k, A (v k) (v (k + 1)) = 0 := by
+  obtain ⟨k, hk⟩ := exists_apply_succ_eq_zero_fin hm (h.submatrix hv)
+  exact ⟨k, hk⟩
 
 /-- **A finite-type diagram carries no triangle.** Two distinct neighbours of an index are never
 adjacent to one another, so the neighbourhood of an index is pairwise non-adjacent and the star
 bound applies to it with no side condition.
 
-This is what turns the conditional consequences of the star bound into graph statements: the degree
-bound `TauCeti.IsFiniteType.card_le_three_of_forall_apply_ne_zero`, the fact that at most one edge
-at an index is multiple, and the isolation of a triple edge. -/
+This is the three-index case of `TauCeti.IsFiniteType.exists_apply_succ_eq_zero`, and it is what
+turns the conditional consequences of the star bound into graph statements: the degree bound
+`TauCeti.IsFiniteType.card_le_three_of_forall_apply_ne_zero`, the fact that at most one edge at an
+index is multiple, and the isolation of a triple edge. -/
 theorem apply_eq_zero_of_apply_ne_zero (h : IsFiniteType A) {i j k : B} (hij : i ≠ j) (hik : i ≠ k)
     (hjk : j ≠ k) (hj : A i j ≠ 0) (hk : A i k ≠ 0) :
     A j k = 0 := by
-  -- Restrict to the principal submatrix on the three indices and apply the three-index core.
-  have he : Function.Injective ![i, j, k] := by
+  by_contra hjk0
+  -- Were the three indices pairwise joined they would close up into a cycle of length three.
+  have hki : A k i ≠ 0 := fun hc ↦ hk (h.apply_eq_zero_symm hc)
+  have hv : Function.Injective ![i, j, k] := by
     intro p q hpq
     fin_cases p <;> fin_cases q <;> simp_all
-  have h' := h.submatrix he
-  have e01 : (A.submatrix ![i, j, k] ![i, j, k]) 0 1 = A i j := by simp
-  have e02 : (A.submatrix ![i, j, k] ![i, j, k]) 0 2 = A i k := by simp
-  have e12 : (A.submatrix ![i, j, k] ![i, j, k]) 1 2 = A j k := by simp
-  have := apply_eq_zero_fin_three h' (e01 ▸ hj) (e02 ▸ hk)
-  rwa [e12] at this
+  obtain ⟨t, ht⟩ := h.exists_apply_succ_eq_zero (m := 3) (by norm_num) hv
+  fin_cases t
+  · exact hj (by simpa using ht)
+  · exact hjk0 (by simpa using ht)
+  · exact hki (by simpa using ht)
 
 /-- **The neighbourhood of an index is pairwise non-adjacent.** This is the no-triangle theorem in
 the form the star bound consumes: a set of neighbours of `i`, none of them `i` itself, satisfies the

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
@@ -361,8 +361,10 @@ positive definiteness forbids. Edges off the cycle only lower the value further,
 not be chordless, and the scaling by the symmetrizer is what keeps the test vector rational: the
 geometric argument takes unit vectors along the coroots and needs their square roots.
 
-The affine diagrams `Ãₙ` are what this excludes, and at three indices every triangle:
-`TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero` is the case `m = 3`. -/
+The affine diagrams `Ãₙ` for `n ≥ 2`, the ones whose diagrams are cycles, are what this excludes,
+and at three indices every triangle: `TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero` is the
+case `m = 3`. The remaining affine diagram `Ã₁` is a double edge on two indices rather than a cycle,
+and is excluded instead by the rank-two bound `TauCeti.IsFiniteType.apply_mul_apply_mem_of_ne`. -/
 private theorem exists_apply_succ_eq_zero_fin {m : ℕ} [NeZero m] (hm : 3 ≤ m)
     {T : Matrix (Fin m) (Fin m) ℤ} (h : IsFiniteType T) :
     ∃ k, T k (k + 1) = 0 := by
@@ -384,7 +386,7 @@ private theorem exists_apply_succ_eq_zero_fin {m : ℕ} [NeZero m] (hm : 3 ≤ m
     rw [hval2, Fin.val_zero] at hval
     omega
   have hsucc : ∀ i : Fin m, i + 1 ≠ i := fun i hc ↦
-    hone (add_left_cancel (show i + 1 = i + 0 by simpa using hc))
+    hone (add_left_cancel (hc.trans (add_zero i).symm))
   have hpred : ∀ i : Fin m, i - 1 ≠ i := by
     intro i hc
     have h1 : i - 1 + 1 = i + 1 := by rw [hc]

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Diagram.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Diagram.lean
@@ -22,9 +22,10 @@ connected finite-type diagram is therefore a **tree**, with exactly one fewer ed
 vertices, and the Dynkin diagram of an irreducible root system is one such tree.
 
 Acyclicity is the graph form of `TauCeti.IsFiniteType.exists_apply_succ_eq_zero`, whose statement is
-about a cyclic list of indices; the work here is to turn a `SimpleGraph.Walk` that is a cycle into
-such a list, cyclically indexed by `Fin` of its length. Connectedness in the root-system case is
-irreducibility, which Mathlib packages as `RootPairing.Base.induction_on_cartanMatrix`.
+about a cyclic list of indices; the list is supplied by Mathlib's characterization of acyclicity as
+containing no copy of a cycle graph, `SimpleGraph.isAcyclic_iff_free_cycleGraph`. Connectedness in
+the root-system case is irreducibility, which Mathlib packages as
+`RootPairing.Base.induction_on_cartanMatrix`.
 
 ## Main definitions
 
@@ -34,7 +35,8 @@ irreducibility, which Mathlib packages as `RootPairing.Base.induction_on_cartanM
 ## Main results
 
 * `TauCeti.IsFiniteType.isAcyclic_diagramGraph`: **the diagram of a finite-type matrix is a
-  forest**. The affine diagrams `Ãₙ`, the cycles, are excluded here in one theorem.
+  forest**. The affine diagrams `Ãₙ` for `n ≥ 2`, the ones whose diagrams are cycles, are excluded
+  here in one theorem.
 * `TauCeti.IsFiniteType.degree_le_three`: **the degree bound**, in graph form.
 * `TauCeti.IsFiniteType.isTree_diagramGraph` and
   `TauCeti.IsFiniteType.card_edgeFinset_add_one_eq_card`: a connected finite-type diagram is a tree,
@@ -63,18 +65,20 @@ when both entries of the transposed pair are nonzero.
 For a generalized Cartan matrix, and so for a matrix of finite type, one of the two entries is
 nonzero exactly when the other is (`TauCeti.IsFiniteType.diagramGraph_adj_iff`), and the definition
 is the expected one. Asking for both is what makes the relation symmetric for an arbitrary matrix,
-where it is the diagram of the symmetrized vanishing pattern. -/
-def diagramGraph (A : Matrix B B ℤ) : SimpleGraph B where
-  Adj i j := i ≠ j ∧ A i j ≠ 0 ∧ A j i ≠ 0
-  symm := ⟨fun _ _ h ↦ ⟨h.1.symm, h.2.2, h.2.1⟩⟩
-  loopless := ⟨fun _ h ↦ h.1 rfl⟩
+where it is the diagram of the symmetrized vanishing pattern; the symmetrization that
+`SimpleGraph.fromRel` performs is then a duplication, and `TauCeti.diagramGraph_adj` reads the
+adjacency back off. -/
+def diagramGraph (A : Matrix B B ℤ) : SimpleGraph B :=
+  SimpleGraph.fromRel fun i j ↦ A i j ≠ 0 ∧ A j i ≠ 0
 
 @[simp]
 theorem diagramGraph_adj {i j : B} :
-    (diagramGraph A).Adj i j ↔ i ≠ j ∧ A i j ≠ 0 ∧ A j i ≠ 0 := Iff.rfl
+    (diagramGraph A).Adj i j ↔ i ≠ j ∧ A i j ≠ 0 ∧ A j i ≠ 0 := by
+  rw [diagramGraph, SimpleGraph.fromRel_adj]
+  tauto
 
 instance [DecidableEq B] (A : Matrix B B ℤ) : DecidableRel (diagramGraph A).Adj :=
-  fun i j ↦ inferInstanceAs (Decidable (i ≠ j ∧ A i j ≠ 0 ∧ A j i ≠ 0))
+  fun _ _ ↦ decidable_of_iff _ diagramGraph_adj.symm
 
 namespace IsFiniteType
 
@@ -83,54 +87,36 @@ variable [Fintype B]
 /-- **Adjacency in the diagram of a finite-type matrix is a single nonvanishing condition**, the
 vanishing pattern of such a matrix being symmetric. -/
 theorem diagramGraph_adj_iff (h : IsFiniteType A) {i j : B} :
-    (diagramGraph A).Adj i j ↔ i ≠ j ∧ A i j ≠ 0 :=
-  ⟨fun hadj ↦ ⟨hadj.1, hadj.2.1⟩,
+    (diagramGraph A).Adj i j ↔ i ≠ j ∧ A i j ≠ 0 := by
+  rw [diagramGraph_adj]
+  exact ⟨fun hadj ↦ ⟨hadj.1, hadj.2.1⟩,
     fun hadj ↦ ⟨hadj.1, hadj.2, fun hc ↦ hadj.2 (h.apply_eq_zero_symm hc)⟩⟩
 
 /-- **The diagram of a finite-type matrix is a forest.** No walk of the diagram that returns to its
 start is a cycle.
 
-The vertices of a cycle, read off by `SimpleGraph.Walk.getVert`, are a list of at least three
-distinct indices each joined to its cyclic successor, which is what
-`TauCeti.IsFiniteType.exists_apply_succ_eq_zero` forbids. The wrap-around edge is the one from the
-last vertex back to the first, and it is the step `SimpleGraph.Walk.getVert` takes from
-`c.length - 1` to `c.length`, the endpoint being the start again. -/
+A cycle in a graph is a copy of a cycle graph of length at least three
+(`SimpleGraph.isAcyclic_iff_free_cycleGraph`), so its vertices are a list of at least three distinct
+indices each joined to its cyclic successor, which is what
+`TauCeti.IsFiniteType.exists_apply_succ_eq_zero` forbids. -/
 theorem isAcyclic_diagramGraph (h : IsFiniteType A) : (diagramGraph A).IsAcyclic := by
-  intro u c hc
-  have hlen : 3 ≤ c.length := hc.three_le_length
-  have : NeZero c.length := ⟨by omega⟩
-  have hval1 : ((1 : Fin c.length) : ℕ) = 1 := by
-    rw [Fin.val_one', Nat.mod_eq_of_lt (by omega)]
-  -- The vertices of the cycle, indexed cyclically by `Fin c.length`.
-  set v : Fin c.length → B := fun t ↦ c.getVert t with hvdef
-  have hinj : Function.Injective v := by
-    intro s t hst
-    have hs : (s : ℕ) < c.length := s.isLt
-    have ht : (t : ℕ) < c.length := t.isLt
-    exact Fin.val_injective (hc.getVert_injOn' (by simp only [Set.mem_ofPred_eq]; omega)
-      (by simp only [Set.mem_ofPred_eq]; omega) hst)
-  have hadj : ∀ t : Fin c.length, (diagramGraph A).Adj (v t) (v (t + 1)) := by
-    intro t
-    have hlt : (t : ℕ) < c.length := t.isLt
-    -- The successor in `Fin c.length` is the successor step of the walk, wrapping at the end
-    -- because the walk starts and finishes at `u`.
-    have hstep : c.getVert ((t + 1 : Fin c.length) : ℕ) = c.getVert ((t : ℕ) + 1) := by
-      by_cases hcase : (t : ℕ) + 1 = c.length
-      · have h0 : ((t + 1 : Fin c.length) : ℕ) = 0 := by
-          rw [Fin.val_add, hval1, hcase, Nat.mod_self]
-        rw [h0, hcase, c.getVert_zero, c.getVert_length]
-      · congr 1
-        rw [Fin.val_add, hval1, Nat.mod_eq_of_lt (by omega)]
-    simpa only [hvdef, hstep] using c.adj_getVert_succ hlt
-  obtain ⟨k, hk⟩ := h.exists_apply_succ_eq_zero hlen hinj
-  exact (hadj k).2.1 hk
+  rw [SimpleGraph.isAcyclic_iff_free_cycleGraph]
+  rintro n hn ⟨f⟩
+  have : NeZero n := ⟨by omega⟩
+  -- The vertices of the copy are distinct, and each is joined to its cyclic successor.
+  obtain ⟨k, hk⟩ := h.exists_apply_succ_eq_zero hn f.injective
+  have hadj : (SimpleGraph.cycleGraph n).Adj k (k + 1) := by
+    rw [SimpleGraph.cycleGraph_adj', add_sub_cancel_left, Fin.val_one',
+      Nat.mod_eq_of_lt (by omega)]
+    exact Or.inr rfl
+  exact (diagramGraph_adj.mp (f.toHom.map_adj hadj)).2.1 hk
 
 /-- **The degree bound in graph form**: no index of a finite-type matrix has four neighbours in the
 diagram, so a finite-type diagram branches into at most three arms. -/
 theorem degree_le_three [DecidableEq B] (h : IsFiniteType A) (i : B) :
     (diagramGraph A).degree i ≤ 3 :=
   h.card_le_three_of_forall_apply_ne_zero (SimpleGraph.notMem_neighborFinset_self _ i)
-    fun _ hj ↦ ((SimpleGraph.mem_neighborFinset _ _ _).mp hj).2.1
+    fun _ hj ↦ (diagramGraph_adj.mp ((SimpleGraph.mem_neighborFinset _ _ _).mp hj)).2.1
 
 /-- **A connected finite-type diagram is a tree.** For the Cartan matrix of a base this is the
 irreducible case, the one the classification enumerates. -/
@@ -165,8 +151,8 @@ theorem preconnected_diagramGraph_cartanMatrix [P.IsReduced] [P.IsIrreducible] (
     (SimpleGraph.Reachable.refl i) fun p q hp hne ↦ ?_
   rcases eq_or_ne p q with rfl | hpq
   · exact hp
-  · exact hp.trans (SimpleGraph.Adj.reachable
-      ⟨hpq, fun hc ↦ hne (b.cartanMatrix_apply_eq_zero_iff_symm.mp hc), hne⟩)
+  · exact hp.trans (SimpleGraph.Adj.reachable (diagramGraph_adj.mpr
+      ⟨hpq, fun hc ↦ hne (b.cartanMatrix_apply_eq_zero_iff_symm.mp hc), hne⟩))
 
 variable [Nonempty ι] [P.IsRootSystem] [P.IsReduced] [P.IsIrreducible] (b : P.Base)
 
@@ -187,7 +173,7 @@ theorem isTree_diagramGraph_cartanMatrix : (diagramGraph b.cartanMatrix).IsTree 
 /-- **The Dynkin diagram of an irreducible root system has one edge fewer than it has simple
 roots.** With the degree bound of `TauCeti.IsFiniteType.degree_le_three`, this is the shape
 constraint that the enumeration of the admissible diagrams is run against. -/
-theorem card_edgeFinset_add_one_eq_card_support [DecidableEq ι] :
+theorem card_edgeFinset_add_one_eq_card_support [DecidableEq b.support] :
     (diagramGraph b.cartanMatrix).edgeFinset.card + 1 = b.support.card :=
   (Fintype.card_coe b.support) ▸ (isTree_diagramGraph_cartanMatrix b).card_edgeFinset
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Diagram.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Diagram.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Acyclic
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Basic
+
+public section
+
+/-!
+# The diagram of a finite-type Cartan matrix is a forest
+
+The elimination tools of `TauCeti.LinearAlgebra.RootSystem.FiniteType.Basic` are stated entrywise:
+they say that certain patterns of nonzero entries cannot occur together. The classification of
+finite-type Cartan matrices reads them as statements about a graph, the *diagram* of the matrix,
+whose vertices are the indices and whose edges are the nonzero off-diagonal pairs. This file
+introduces that graph and records the two global shape theorems the classification runs on: the
+diagram of a finite-type matrix is **acyclic**, and every vertex of it has degree at most `3`. A
+connected finite-type diagram is therefore a **tree**, with exactly one fewer edge than it has
+vertices, and the Dynkin diagram of an irreducible root system is one such tree.
+
+Acyclicity is the graph form of `TauCeti.IsFiniteType.exists_apply_succ_eq_zero`, whose statement is
+about a cyclic list of indices; the work here is to turn a `SimpleGraph.Walk` that is a cycle into
+such a list, cyclically indexed by `Fin` of its length. Connectedness in the root-system case is
+irreducibility, which Mathlib packages as `RootPairing.Base.induction_on_cartanMatrix`.
+
+## Main definitions
+
+* `TauCeti.diagramGraph`: the diagram of an integer matrix, a `SimpleGraph` on its index type,
+  joining two distinct indices when the entries of the transposed pair are both nonzero.
+
+## Main results
+
+* `TauCeti.IsFiniteType.isAcyclic_diagramGraph`: **the diagram of a finite-type matrix is a
+  forest**. The affine diagrams `Ãₙ`, the cycles, are excluded here in one theorem.
+* `TauCeti.IsFiniteType.degree_le_three`: **the degree bound**, in graph form.
+* `TauCeti.IsFiniteType.isTree_diagramGraph` and
+  `TauCeti.IsFiniteType.card_edgeFinset_add_one_eq_card`: a connected finite-type diagram is a tree,
+  and so has one fewer edge than it has vertices.
+* `TauCeti.isTree_diagramGraph_cartanMatrix` and
+  `TauCeti.card_edgeFinset_add_one_eq_card_support`: **the Dynkin diagram of an irreducible reduced
+  crystallographic finite root system is a tree**, whose edges number one fewer than its simple
+  roots. Connectedness is `TauCeti.preconnected_diagramGraph_cartanMatrix`.
+
+## References
+
+This file supplies the "no cycles" and "`n - 1` edges" steps of the classification of finite-type
+Cartan matrices, Layer 5 of `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`. See
+J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §11.4, where the shape of
+an admissible diagram is deduced from exactly these two facts, and Bourbaki, *Lie Groups and Lie
+Algebras, Chapters 4-6*, Ch. VI §4.
+-/
+
+namespace TauCeti
+
+variable {B : Type*} {A : Matrix B B ℤ}
+
+/-- The **diagram** of an integer matrix: the graph on the index type joining two distinct indices
+when both entries of the transposed pair are nonzero.
+
+For a generalized Cartan matrix, and so for a matrix of finite type, one of the two entries is
+nonzero exactly when the other is (`TauCeti.IsFiniteType.diagramGraph_adj_iff`), and the definition
+is the expected one. Asking for both is what makes the relation symmetric for an arbitrary matrix,
+where it is the diagram of the symmetrized vanishing pattern. -/
+def diagramGraph (A : Matrix B B ℤ) : SimpleGraph B where
+  Adj i j := i ≠ j ∧ A i j ≠ 0 ∧ A j i ≠ 0
+  symm := ⟨fun _ _ h ↦ ⟨h.1.symm, h.2.2, h.2.1⟩⟩
+  loopless := ⟨fun _ h ↦ h.1 rfl⟩
+
+@[simp]
+theorem diagramGraph_adj {i j : B} :
+    (diagramGraph A).Adj i j ↔ i ≠ j ∧ A i j ≠ 0 ∧ A j i ≠ 0 := Iff.rfl
+
+instance [DecidableEq B] (A : Matrix B B ℤ) : DecidableRel (diagramGraph A).Adj :=
+  fun i j ↦ inferInstanceAs (Decidable (i ≠ j ∧ A i j ≠ 0 ∧ A j i ≠ 0))
+
+namespace IsFiniteType
+
+variable [Fintype B]
+
+/-- **Adjacency in the diagram of a finite-type matrix is a single nonvanishing condition**, the
+vanishing pattern of such a matrix being symmetric. -/
+theorem diagramGraph_adj_iff (h : IsFiniteType A) {i j : B} :
+    (diagramGraph A).Adj i j ↔ i ≠ j ∧ A i j ≠ 0 :=
+  ⟨fun hadj ↦ ⟨hadj.1, hadj.2.1⟩,
+    fun hadj ↦ ⟨hadj.1, hadj.2, fun hc ↦ hadj.2 (h.apply_eq_zero_symm hc)⟩⟩
+
+/-- **The diagram of a finite-type matrix is a forest.** No walk of the diagram that returns to its
+start is a cycle.
+
+The vertices of a cycle, read off by `SimpleGraph.Walk.getVert`, are a list of at least three
+distinct indices each joined to its cyclic successor, which is what
+`TauCeti.IsFiniteType.exists_apply_succ_eq_zero` forbids. The wrap-around edge is the one from the
+last vertex back to the first, and it is the step `SimpleGraph.Walk.getVert` takes from
+`c.length - 1` to `c.length`, the endpoint being the start again. -/
+theorem isAcyclic_diagramGraph (h : IsFiniteType A) : (diagramGraph A).IsAcyclic := by
+  intro u c hc
+  have hlen : 3 ≤ c.length := hc.three_le_length
+  have : NeZero c.length := ⟨by omega⟩
+  have hval1 : ((1 : Fin c.length) : ℕ) = 1 := by
+    rw [Fin.val_one', Nat.mod_eq_of_lt (by omega)]
+  -- The vertices of the cycle, indexed cyclically by `Fin c.length`.
+  set v : Fin c.length → B := fun t ↦ c.getVert t with hvdef
+  have hinj : Function.Injective v := by
+    intro s t hst
+    have hs : (s : ℕ) < c.length := s.isLt
+    have ht : (t : ℕ) < c.length := t.isLt
+    exact Fin.val_injective (hc.getVert_injOn' (by simp only [Set.mem_ofPred_eq]; omega)
+      (by simp only [Set.mem_ofPred_eq]; omega) hst)
+  have hadj : ∀ t : Fin c.length, (diagramGraph A).Adj (v t) (v (t + 1)) := by
+    intro t
+    have hlt : (t : ℕ) < c.length := t.isLt
+    -- The successor in `Fin c.length` is the successor step of the walk, wrapping at the end
+    -- because the walk starts and finishes at `u`.
+    have hstep : c.getVert ((t + 1 : Fin c.length) : ℕ) = c.getVert ((t : ℕ) + 1) := by
+      by_cases hcase : (t : ℕ) + 1 = c.length
+      · have h0 : ((t + 1 : Fin c.length) : ℕ) = 0 := by
+          rw [Fin.val_add, hval1, hcase, Nat.mod_self]
+        rw [h0, hcase, c.getVert_zero, c.getVert_length]
+      · congr 1
+        rw [Fin.val_add, hval1, Nat.mod_eq_of_lt (by omega)]
+    simpa only [hvdef, hstep] using c.adj_getVert_succ hlt
+  obtain ⟨k, hk⟩ := h.exists_apply_succ_eq_zero hlen hinj
+  exact (hadj k).2.1 hk
+
+/-- **The degree bound in graph form**: no index of a finite-type matrix has four neighbours in the
+diagram, so a finite-type diagram branches into at most three arms. -/
+theorem degree_le_three [DecidableEq B] (h : IsFiniteType A) (i : B) :
+    (diagramGraph A).degree i ≤ 3 :=
+  h.card_le_three_of_forall_apply_ne_zero (SimpleGraph.notMem_neighborFinset_self _ i)
+    fun _ hj ↦ ((SimpleGraph.mem_neighborFinset _ _ _).mp hj).2.1
+
+/-- **A connected finite-type diagram is a tree.** For the Cartan matrix of a base this is the
+irreducible case, the one the classification enumerates. -/
+theorem isTree_diagramGraph (h : IsFiniteType A) (hconn : (diagramGraph A).Connected) :
+    (diagramGraph A).IsTree :=
+  ⟨hconn, h.isAcyclic_diagramGraph⟩
+
+/-- **A connected finite-type diagram has one edge fewer than it has vertices.** This is the
+counting form of acyclicity, and the constraint that the enumeration of admissible diagrams is run
+against. -/
+theorem card_edgeFinset_add_one_eq_card [DecidableEq B] (h : IsFiniteType A)
+    (hconn : (diagramGraph A).Connected) :
+    (diagramGraph A).edgeFinset.card + 1 = Fintype.card B :=
+  (h.isTree_diagramGraph hconn).card_edgeFinset
+
+end IsFiniteType
+
+section RootPairing
+
+variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  {P : RootPairing ι R M N} [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic]
+
+/-- **The Dynkin diagram of an irreducible root system is connected.** Irreducibility of a root
+pairing says that the roots do not split into two mutually orthogonal families, and Mathlib records
+it as the induction principle `RootPairing.Base.induction_on_cartanMatrix`: a property of the simple
+roots that propagates along nonzero Cartan entries holds everywhere once it holds somewhere. Being
+reachable from a fixed simple root is such a property. -/
+theorem preconnected_diagramGraph_cartanMatrix [P.IsReduced] [P.IsIrreducible] (b : P.Base) :
+    (diagramGraph b.cartanMatrix).Preconnected := by
+  intro i j
+  refine b.induction_on_cartanMatrix (fun k ↦ (diagramGraph b.cartanMatrix).Reachable i k)
+    (SimpleGraph.Reachable.refl i) fun p q hp hne ↦ ?_
+  rcases eq_or_ne p q with rfl | hpq
+  · exact hp
+  · exact hp.trans (SimpleGraph.Adj.reachable
+      ⟨hpq, fun hc ↦ hne (b.cartanMatrix_apply_eq_zero_iff_symm.mp hc), hne⟩)
+
+variable [Nonempty ι] [P.IsRootSystem] [P.IsReduced] [P.IsIrreducible] (b : P.Base)
+
+omit [P.IsRootSystem] in
+include b in
+/-- **The Dynkin diagram of an irreducible root system is connected**, as a `Connected` graph: a
+root system with at least one root has at least one simple root. -/
+theorem connected_diagramGraph_cartanMatrix : (diagramGraph b.cartanMatrix).Connected := by
+  have : Nonempty b.support := b.support_nonempty.to_subtype
+  exact ⟨preconnected_diagramGraph_cartanMatrix b⟩
+
+/-- **The Dynkin diagram of an irreducible root system is a tree.** Both halves are theorems about
+the Cartan matrix: acyclicity because it is of finite type, connectedness because the root system is
+irreducible. -/
+theorem isTree_diagramGraph_cartanMatrix : (diagramGraph b.cartanMatrix).IsTree :=
+  (isFiniteType_cartanMatrix b).isTree_diagramGraph (connected_diagramGraph_cartanMatrix b)
+
+/-- **The Dynkin diagram of an irreducible root system has one edge fewer than it has simple
+roots.** With the degree bound of `TauCeti.IsFiniteType.degree_le_three`, this is the shape
+constraint that the enumeration of the admissible diagrams is run against. -/
+theorem card_edgeFinset_add_one_eq_card_support [DecidableEq ι] :
+    (diagramGraph b.cartanMatrix).edgeFinset.card + 1 = b.support.card :=
+  (Fintype.card_coe b.support) ▸ (isTree_diagramGraph_cartanMatrix b).card_edgeFinset
+
+end RootPairing
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the diagram of a finite-type Cartan matrix has no cycles, and reads the entrywise elimination tools of `TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean` as statements about a graph. `TauCeti.IsFiniteType.exists_apply_succ_eq_zero` says that a cyclic list of at least three distinct indices of a finite-type matrix has a missing edge; `TauCeti.diagramGraph` packages the nonzero off-diagonal pairs of an integer matrix as a `SimpleGraph`, `TauCeti.IsFiniteType.isAcyclic_diagramGraph` is the acyclicity of that graph, and `TauCeti.IsFiniteType.degree_le_three` restates the existing degree bound on it. A connected finite-type diagram is therefore a tree with one edge fewer than it has vertices (`TauCeti.IsFiniteType.card_edgeFinset_add_one_eq_card`). Since irreducibility of a root pairing is exactly connectedness of its diagram, via Mathlib's `RootPairing.Base.induction_on_cartanMatrix`, the Dynkin diagram of an irreducible reduced crystallographic finite root system is a tree whose edges number one fewer than its simple roots (`TauCeti.isTree_diagramGraph_cartanMatrix`, `TauCeti.card_edgeFinset_add_one_eq_card_support`).

The estimate itself is short and stays over `ℚ`. Writing `d` for the symmetrizer, the test vector is its reciprocal `xᵢ = 1/dᵢ`, at which the symmetrized form collects `2/dᵢ` from each diagonal entry and the nonpositive `Tᵢⱼ/dⱼ` from each off-diagonal one. The symmetrization identity `dᵢTᵢⱼ = dⱼTⱼᵢ` is exactly what makes `Tᵢⱼ/dⱼ` symmetric in `i` and `j`, so the two entries of an edge `{k, k+1}` of the cycle contribute equally, each at most `-1/dₖ`; with as many edges as indices the two sums cancel and the form is nonpositive at a nonzero vector. Edges off the cycle only lower the value further, so the cycle need not be chordless and its edges need not be simple. Scaling by the symmetrizer is what keeps the vector rational: the geometric argument takes unit vectors along the coroots and needs their square roots.

This subsumes the no-triangle theorem, which was the case of three indices and had its own proof through an inequality on the three Cartan products. `TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero` keeps its statement and its consumers, and is now four lines derived from the general estimate; the three private lemmas that supported the old proof (`add_sq_le_nine_mul`, `not_three_mul_lt`, `apply_eq_zero_fin_three`) and the private `sq_symmetrization_apply` they alone used are deleted.

Milestone: "the classification of finite-type Cartan matrices" in Layer 5 of `RepresentationTheory/RootSystems/README.md`, whose target `existsUnique_dynkinType` needs the shape of an admissible diagram pinned down before the induction on the number of nodes can run. The elimination tools now in hand are the rank-two bound, the star bound, the degree bound, the isolation of a triple edge, the simple lacing of a branch vertex, nonsingularity, and acyclicity; what remains on that target is the arithmetic that turns a tree of degree at most three into the A-D-E-B-C-F-G list, namely the contraction of a simple chain and the leg-length inequality at a branch vertex, after which the rank-one and rank-two base cases already proved close the induction.

Files: `TauCeti/LinearAlgebra/RootSystem/FiniteType/Diagram.lean` (new, 196 lines) and `TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean` (the cycle estimate replacing the triangle machinery, net +26 lines).

No material was taken from the supplementary source snapshot; nothing was vendored from Mathlib.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"isfinitetype-isacyclic-diagramgraph"}-->

🤖 Prepared with Claude Code
