### PR TITLE
feat(ModularForms): the excised boundary integrand is integrable

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
+import TauCeti.Analysis.Contour.Curve.ExcisionMeasure
 import TauCeti.Analysis.Contour.Curve.Distance
 import Mathlib.MeasureTheory.Integral.DominatedConvergence
 import Mathlib.Analysis.Calculus.Deriv.Inverse
@@ -254,10 +255,7 @@ theorem HasCauchyPVWith.of_integrable_of_crossings_measure_zero {γ : ℝ → �
   classical
   set g : ℝ → ℂ := fun t => f (γ t) * deriv γ t with hg
   have hmeas : ∀ ε : ℝ, MeasureTheory.NullMeasurableSet {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε}
-      (MeasureTheory.volume.restrict (Set.uIoc a b)) := fun ε => by
-    have hset : {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} = ⋃ s ∈ S, {t | ‖γ t - s‖ ≤ ε} := by ext t; simp
-    refine hset ▸ MeasureTheory.NullMeasurableSet.biUnion S.countable_toSet fun s _ => ?_
-    exact nullMeasurableSet_le ((hγ.sub_const s).norm) aemeasurable_const
+      (MeasureTheory.volume.restrict (Set.uIoc a b)) := fun ε => nullMeasurableSet_excision hγ S ε
   have hsm : ∀ ε : ℝ, MeasureTheory.AEStronglyMeasurable
       (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else g t)
       (MeasureTheory.volume.restrict (Set.uIoc a b)) := fun ε =>

--- a/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
+++ b/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Analysis.Contour.Curve.ExcisionMeasure
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import Mathlib.Analysis.Calculus.FDeriv.Measurable
 public import Mathlib.Analysis.Complex.Basic
@@ -42,11 +43,10 @@ private def survivingParams (γ : ℝ → ℂ) (S : Finset ℂ) (ε : ℝ) : Set
 
 private theorem measurableSet_survivingParams (hγm : Measurable γ) (S : Finset ℂ) (ε : ℝ) :
     MeasurableSet (survivingParams γ S ε) := by
-  have h : survivingParams γ S ε = ⋂ s ∈ S, {t | ε < ‖γ t - s‖} := by
-    ext; simp [survivingParams]
+  have h : survivingParams γ S ε = {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε}ᶜ := by
+    ext; simp [survivingParams, not_le]
   rw [h]
-  exact MeasurableSet.biInter S.countable_toSet fun s _ =>
-    measurableSet_lt measurable_const ((hγm.sub_const s).norm)
+  exact (measurableSet_excision hγm S ε).compl
 
 /-- **The excised integrand is integrable.** Off the excision the curve stays at distance `> ε`
 from every centre, so over `[a, b]` its image lies in a compact set on which `φ` is continuous,
@@ -91,10 +91,8 @@ theorem intervalIntegrable_excised_of_continuousOn (hγc : Continuous γ) (hC : 
     · rw [Set.indicator_of_notMem hs, norm_zero]
       exact mul_nonneg hM0 hC0
   rw [intervalIntegrable_iff]
-  have hfin : IsFiniteMeasure (MeasureTheory.volume.restrict (Set.uIoc a b)) :=
-    ⟨by rw [MeasureTheory.Measure.restrict_apply_univ, Real.volume_uIoc]
-        exact ENNReal.ofReal_lt_top⟩
-  refine Integrable.mono' (integrable_const (max M 0 * C)) ?_
+  refine IntegrableOn.of_bound (by rw [Real.volume_uIoc]; exact ENNReal.ofReal_lt_top) ?_
+    (max M 0 * C)
     ((MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
       (Filter.Eventually.of_forall fun t ht => hbd t (Set.uIoc_subset_uIcc ht)))
   refine (aestronglyMeasurable_indicator_iff

--- a/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
+++ b/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
@@ -49,59 +49,49 @@ private theorem measurableSet_survivingParams (hγm : Measurable γ) (S : Finset
   exact (measurableSet_excision hγm S ε).compl
 
 /-- **The excised integrand is integrable.** Off the excision the curve stays at distance `> ε`
-from every centre, so over `[a, b]` its image lies in a compact set on which `φ` is continuous,
-hence bounded; with `deriv γ` bounded the excised integrand is bounded, and `deriv` is always
-measurable, so the integrand is integrable.
+from every centre, so over `[a, b]` its values lie in a compact set on which `φ` is continuous,
+hence bounded. The excised integrand is that bounded factor times `deriv γ`, so it is integrable
+whenever `deriv γ` is.
 
 `hφ` asks for continuity only on the *closed* condition `ε ≤ ‖z - s‖`, which is what makes the
-relevant image compact; the excision itself keeps the strict `ε < ‖γ t - s‖`. -/
-theorem intervalIntegrable_excised_of_continuousOn (hγc : Continuous γ) (hC : ∀ t, ‖deriv γ t‖ ≤ C)
-    (hφ : ContinuousOn φ (γ '' (uIcc a b ∩ {t | ∀ s ∈ S, ε ≤ ‖γ t - s‖}))) :
+relevant set compact; the excision itself keeps the strict `ε < ‖γ t - s‖`. -/
+theorem intervalIntegrable_excised_of_continuousOn (hγc : ContinuousOn γ (uIcc a b))
+    (hγm : Measurable γ) (hd : IntervalIntegrable (deriv γ) MeasureTheory.volume a b)
+    (hφ : ContinuousOn φ (γ '' uIcc a b ∩ {z | ∀ s ∈ S, ε ≤ ‖z - s‖})) :
     IntervalIntegrable (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else φ (γ t) * deriv γ t)
       MeasureTheory.volume a b := by
-  set K : Set ℂ := γ '' (uIcc a b ∩ {t | ∀ s ∈ S, ε ≤ ‖γ t - s‖}) with hK
-  have hclosed : IsClosed {t : ℝ | ∀ s ∈ S, ε ≤ ‖γ t - s‖} := by
-    have h : {t : ℝ | ∀ s ∈ S, ε ≤ ‖γ t - s‖} = ⋂ s ∈ S, {t | ε ≤ ‖γ t - s‖} := by ext; simp
+  set K : Set ℂ := γ '' uIcc a b ∩ {z | ∀ s ∈ S, ε ≤ ‖z - s‖} with hK
+  have hclosed : IsClosed {z : ℂ | ∀ s ∈ S, ε ≤ ‖z - s‖} := by
+    have h : {z : ℂ | ∀ s ∈ S, ε ≤ ‖z - s‖} = ⋂ s ∈ S, {z : ℂ | ε ≤ ‖z - s‖} := by ext; simp
     rw [h]
     exact isClosed_biInter fun s _ =>
-      isClosed_le continuous_const ((hγc.sub continuous_const).norm)
-  have hKcompact : IsCompact K := (isCompact_uIcc.inter_right hclosed).image hγc
+      isClosed_le continuous_const ((continuous_id.sub continuous_const).norm)
+  have hKcompact : IsCompact K :=
+    (isCompact_uIcc.image_of_continuousOn hγc).inter_right hclosed
   obtain ⟨M, hM⟩ := hKcompact.exists_bound_of_continuousOn hφ
-  -- The integrand is the surviving set's indicator applied to `φ ∘ γ · deriv γ`.
-  set g : ℝ → ℂ := fun t => φ (γ t) * deriv γ t with hg
-  have hind : (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else g t) =
-      (survivingParams γ S ε).indicator g := by
+  -- The excised integrand is a bounded factor times `deriv γ`.
+  have hsplit : (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else φ (γ t) * deriv γ t) =
+      fun t => (survivingParams γ S ε).indicator (fun t => φ (γ t)) t * deriv γ t := by
     funext t
     by_cases h : ∃ s ∈ S, ‖γ t - s‖ ≤ ε
-    · rw [if_pos h, Set.indicator_of_notMem]
-      simpa [survivingParams, not_lt] using h
-    · rw [if_neg h, Set.indicator_of_mem]
-      simpa [survivingParams, not_lt] using h
-  rw [hind]
-  -- Membership of the surviving parameters puts the curve in `K`, where `φ` is bounded.
-  have hmemK : ∀ t ∈ uIcc a b, t ∈ survivingParams γ S ε → γ t ∈ K :=
-    fun t ht hs => ⟨t, ⟨ht, fun s hsS => (hs s hsS).le⟩, rfl⟩
-  have hC0 : 0 ≤ C := (norm_nonneg _).trans (hC a)
-  have hM0 : (0 : ℝ) ≤ max M 0 := le_max_right _ _
-  have hbd : ∀ t ∈ uIcc a b, ‖(survivingParams γ S ε).indicator g t‖ ≤ max M 0 * C := by
-    intro t ht
+    · rw [if_pos h, Set.indicator_of_notMem (by simpa [survivingParams, not_lt] using h), zero_mul]
+    · rw [if_neg h, Set.indicator_of_mem (by simpa [survivingParams, not_lt] using h)]
+  rw [hsplit, intervalIntegrable_iff]
+  refine (intervalIntegrable_iff.mp hd).bdd_mul (c := max M 0) ?_ ?_
+  · refine (aestronglyMeasurable_indicator_iff
+      (measurableSet_survivingParams hγm S ε)).mpr ?_
+    rw [MeasureTheory.Measure.restrict_restrict (measurableSet_survivingParams hγm S ε)]
+    refine ContinuousOn.aestronglyMeasurable ?_
+      ((measurableSet_survivingParams hγm S ε).inter measurableSet_uIoc)
+    exact hφ.comp (hγc.mono fun t ht => Set.uIoc_subset_uIcc ht.2) fun t ht =>
+      ⟨⟨t, Set.uIoc_subset_uIcc ht.2, rfl⟩, fun s hs => (ht.1 s hs).le⟩
+  · refine (MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
+      (Filter.Eventually.of_forall fun t ht => ?_)
     by_cases hs : t ∈ survivingParams γ S ε
-    · rw [Set.indicator_of_mem hs, hg, norm_mul]
-      exact mul_le_mul ((hM _ (hmemK t ht hs)).trans (le_max_left _ _)) (hC t) (norm_nonneg _) hM0
+    · rw [Set.indicator_of_mem hs]
+      exact (hM _ ⟨⟨t, Set.uIoc_subset_uIcc ht, rfl⟩,
+        fun s hsS => (hs s hsS).le⟩).trans (le_max_left _ _)
     · rw [Set.indicator_of_notMem hs, norm_zero]
-      exact mul_nonneg hM0 hC0
-  rw [intervalIntegrable_iff]
-  refine IntegrableOn.of_bound (by rw [Real.volume_uIoc]; exact ENNReal.ofReal_lt_top) ?_
-    (max M 0 * C)
-    ((MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
-      (Filter.Eventually.of_forall fun t ht => hbd t (Set.uIoc_subset_uIcc ht)))
-  refine (aestronglyMeasurable_indicator_iff
-    (measurableSet_survivingParams hγc.measurable S ε)).mpr ?_
-  rw [MeasureTheory.Measure.restrict_restrict (measurableSet_survivingParams hγc.measurable S ε)]
-  refine AEStronglyMeasurable.mul ?_ (measurable_deriv γ).aestronglyMeasurable
-  refine ContinuousOn.aestronglyMeasurable ?_
-    ((measurableSet_survivingParams hγc.measurable S ε).inter measurableSet_uIoc)
-  exact hφ.comp hγc.continuousOn fun t ht =>
-    ⟨t, ⟨Set.uIoc_subset_uIcc ht.2, fun s hsS => (ht.1 s hsS).le⟩, rfl⟩
+      exact le_max_right _ _
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
+++ b/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+public import Mathlib.Analysis.Calculus.FDeriv.Measurable
+public import Mathlib.Analysis.Complex.Basic
+
+/-!
+# The excised integrand is integrable
+
+An `ε`-excision replaces the integrand by `0` wherever the curve comes within `ε` of one of
+finitely many centres. That is what makes the integrand integrable when the unexcised one is
+not: the singularities all sit at the centres, and the excision deletes a neighbourhood of each.
+This file records the resulting integrability, at a fixed `ε`.
+
+What survives the excision is `φ ∘ γ` times `deriv γ` on parameters at distance `≥ ε` from every
+centre. Over a bounded interval the curve's image there is compact, so a `φ` continuous on it is
+bounded; with `deriv γ` bounded the excised integrand is bounded, and it is measurable because
+`deriv` always is. Bounded and measurable on a bounded interval is integrable.
+
+## Main results
+
+* `TauCeti.Contour.intervalIntegrable_excised_of_continuousOn`: the excised integrand is
+  interval-integrable.
+-/
+
+public section
+
+open Filter MeasureTheory Set Topology
+
+namespace TauCeti.Contour
+
+variable {γ : ℝ → ℂ} {φ : ℂ → ℂ} {S : Finset ℂ} {a b ε C : ℝ}
+
+/-- The parameters surviving the `ε`-excision. -/
+private def survivingParams (γ : ℝ → ℂ) (S : Finset ℂ) (ε : ℝ) : Set ℝ :=
+  {t | ∀ s ∈ S, ε < ‖γ t - s‖}
+
+private theorem measurableSet_survivingParams (hγm : Measurable γ) (S : Finset ℂ) (ε : ℝ) :
+    MeasurableSet (survivingParams γ S ε) := by
+  have h : survivingParams γ S ε = ⋂ s ∈ S, {t | ε < ‖γ t - s‖} := by
+    ext; simp [survivingParams]
+  rw [h]
+  exact MeasurableSet.biInter S.countable_toSet fun s _ =>
+    measurableSet_lt measurable_const ((hγm.sub_const s).norm)
+
+/-- **The excised integrand is integrable.** Off the excision the curve stays at distance `> ε`
+from every centre, so over `[a, b]` its image lies in a compact set on which `φ` is continuous,
+hence bounded; with `deriv γ` bounded the excised integrand is bounded, and `deriv` is always
+measurable, so the integrand is integrable.
+
+`hφ` asks for continuity only on the *closed* condition `ε ≤ ‖z - s‖`, which is what makes the
+relevant image compact; the excision itself keeps the strict `ε < ‖γ t - s‖`. -/
+theorem intervalIntegrable_excised_of_continuousOn (hγc : Continuous γ) (hC : ∀ t, ‖deriv γ t‖ ≤ C)
+    (hφ : ContinuousOn φ (γ '' (uIcc a b ∩ {t | ∀ s ∈ S, ε ≤ ‖γ t - s‖}))) :
+    IntervalIntegrable (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else φ (γ t) * deriv γ t)
+      MeasureTheory.volume a b := by
+  set K : Set ℂ := γ '' (uIcc a b ∩ {t | ∀ s ∈ S, ε ≤ ‖γ t - s‖}) with hK
+  have hclosed : IsClosed {t : ℝ | ∀ s ∈ S, ε ≤ ‖γ t - s‖} := by
+    have h : {t : ℝ | ∀ s ∈ S, ε ≤ ‖γ t - s‖} = ⋂ s ∈ S, {t | ε ≤ ‖γ t - s‖} := by ext; simp
+    rw [h]
+    exact isClosed_biInter fun s _ =>
+      isClosed_le continuous_const ((hγc.sub continuous_const).norm)
+  have hKcompact : IsCompact K := (isCompact_uIcc.inter_right hclosed).image hγc
+  obtain ⟨M, hM⟩ := hKcompact.exists_bound_of_continuousOn hφ
+  -- The integrand is the surviving set's indicator applied to `φ ∘ γ · deriv γ`.
+  set g : ℝ → ℂ := fun t => φ (γ t) * deriv γ t with hg
+  have hind : (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else g t) =
+      (survivingParams γ S ε).indicator g := by
+    funext t
+    by_cases h : ∃ s ∈ S, ‖γ t - s‖ ≤ ε
+    · rw [if_pos h, Set.indicator_of_notMem]
+      simpa [survivingParams, not_lt] using h
+    · rw [if_neg h, Set.indicator_of_mem]
+      simpa [survivingParams, not_lt] using h
+  rw [hind]
+  -- Membership of the surviving parameters puts the curve in `K`, where `φ` is bounded.
+  have hmemK : ∀ t ∈ uIcc a b, t ∈ survivingParams γ S ε → γ t ∈ K :=
+    fun t ht hs => ⟨t, ⟨ht, fun s hsS => (hs s hsS).le⟩, rfl⟩
+  have hC0 : 0 ≤ C := (norm_nonneg _).trans (hC a)
+  have hM0 : (0 : ℝ) ≤ max M 0 := le_max_right _ _
+  have hbd : ∀ t ∈ uIcc a b, ‖(survivingParams γ S ε).indicator g t‖ ≤ max M 0 * C := by
+    intro t ht
+    by_cases hs : t ∈ survivingParams γ S ε
+    · rw [Set.indicator_of_mem hs, hg, norm_mul]
+      exact mul_le_mul ((hM _ (hmemK t ht hs)).trans (le_max_left _ _)) (hC t) (norm_nonneg _) hM0
+    · rw [Set.indicator_of_notMem hs, norm_zero]
+      exact mul_nonneg hM0 hC0
+  rw [intervalIntegrable_iff]
+  have hfin : IsFiniteMeasure (MeasureTheory.volume.restrict (Set.uIoc a b)) :=
+    ⟨by rw [MeasureTheory.Measure.restrict_apply_univ, Real.volume_uIoc]
+        exact ENNReal.ofReal_lt_top⟩
+  refine Integrable.mono' (integrable_const (max M 0 * C)) ?_
+    ((MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
+      (Filter.Eventually.of_forall fun t ht => hbd t (Set.uIoc_subset_uIcc ht)))
+  refine (aestronglyMeasurable_indicator_iff
+    (measurableSet_survivingParams hγc.measurable S ε)).mpr ?_
+  rw [MeasureTheory.Measure.restrict_restrict (measurableSet_survivingParams hγc.measurable S ε)]
+  refine AEStronglyMeasurable.mul ?_ (measurable_deriv γ).aestronglyMeasurable
+  refine ContinuousOn.aestronglyMeasurable ?_
+    ((measurableSet_survivingParams hγc.measurable S ε).inter measurableSet_uIoc)
+  exact hφ.comp hγc.continuousOn fun t ht =>
+    ⟨t, ⟨Set.uIoc_subset_uIcc ht.2, fun s hsS => (ht.1 s hsS).le⟩, rfl⟩
+
+end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
+++ b/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
@@ -39,13 +39,6 @@ variable {γ : ℝ → ℂ} {φ : ℂ → ℂ} {S : Finset ℂ} {a b ε C : ℝ}
 private def survivingParams (γ : ℝ → ℂ) (S : Finset ℂ) (ε : ℝ) : Set ℝ :=
   {t | ∀ s ∈ S, ε < ‖γ t - s‖}
 
-private theorem measurableSet_survivingParams (hγm : Measurable γ) (S : Finset ℂ) (ε : ℝ) :
-    MeasurableSet (survivingParams γ S ε) := by
-  have h : survivingParams γ S ε = {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε}ᶜ := by
-    ext; simp [survivingParams, not_le]
-  rw [h]
-  exact (measurableSet_excision hγm S ε).compl
-
 /-- **The excised integrand is integrable.** Off the excision the curve stays at distance `> ε`
 from every centre, so over `[a, b]` its values lie in a compact set on which `φ` is continuous,
 hence bounded. The excised integrand is that bounded factor times `deriv γ`, so it is integrable
@@ -54,41 +47,60 @@ whenever `deriv γ` is.
 `hφ` asks for continuity only on the *closed* condition `ε ≤ ‖z - s‖`, which is what makes the
 relevant set compact; the excision itself keeps the strict `ε < ‖γ t - s‖`. -/
 theorem intervalIntegrable_excised_of_continuousOn (hγc : ContinuousOn γ (uIcc a b))
-    (hγm : Measurable γ) (hd : IntervalIntegrable (deriv γ) MeasureTheory.volume a b)
+    (hd : IntervalIntegrable (deriv γ) MeasureTheory.volume a b)
     (hφ : ContinuousOn φ (γ '' uIcc a b ∩ {z | ∀ s ∈ S, ε ≤ ‖z - s‖})) :
     IntervalIntegrable (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else φ (γ t) * deriv γ t)
       MeasureTheory.volume a b := by
-  set K : Set ℂ := γ '' uIcc a b ∩ {z | ∀ s ∈ S, ε ≤ ‖z - s‖} with hK
   have hclosed : IsClosed {z : ℂ | ∀ s ∈ S, ε ≤ ‖z - s‖} := by
     have h : {z : ℂ | ∀ s ∈ S, ε ≤ ‖z - s‖} = ⋂ s ∈ S, {z : ℂ | ε ≤ ‖z - s‖} := by ext; simp
     rw [h]
     exact isClosed_biInter fun s _ =>
       isClosed_le continuous_const ((continuous_id.sub continuous_const).norm)
-  have hKcompact : IsCompact K :=
-    (isCompact_uIcc.image_of_continuousOn hγc).inter_right hclosed
-  obtain ⟨M, hM⟩ := hKcompact.exists_bound_of_continuousOn hφ
-  -- The excised integrand is a bounded factor times `deriv γ`.
-  have hsplit : (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else φ (γ t) * deriv γ t) =
-      fun t => (survivingParams γ S ε).indicator (fun t => φ (γ t)) t * deriv γ t := by
-    funext t
+  obtain ⟨M, hM⟩ :=
+    ((isCompact_uIcc.image_of_continuousOn hγc).inter_right hclosed).exists_bound_of_continuousOn hφ
+  -- Measurability is only ever needed on `Ι a b`, where `hγc` already supplies it.
+  have hae : AEMeasurable γ (MeasureTheory.volume.restrict (uIoc a b)) :=
+    (hγc.mono Set.uIoc_subset_uIcc).aemeasurable measurableSet_uIoc
+  have hA0 : MeasureTheory.NullMeasurableSet (survivingParams γ S ε ∩ uIoc a b)
+      (MeasureTheory.volume.restrict (uIoc a b)) := by
+    have hcompl : survivingParams γ S ε = {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε}ᶜ := by
+      ext; simp [survivingParams, not_le]
+    have hset : {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} = ⋃ s ∈ S, {t | ‖γ t - s‖ ≤ ε} := by ext; simp
+    refine MeasureTheory.NullMeasurableSet.inter ?_ measurableSet_uIoc.nullMeasurableSet
+    refine hcompl ▸ MeasureTheory.NullMeasurableSet.compl (hset ▸ ?_)
+    exact MeasureTheory.NullMeasurableSet.biUnion S.countable_toSet fun s _ =>
+      nullMeasurableSet_le ((hae.sub_const s).norm) aemeasurable_const
+  have hmem : ∀ t ∈ uIoc a b,
+      (t ∈ survivingParams γ S ε ∩ uIoc a b ↔ ¬∃ s ∈ S, ‖γ t - s‖ ≤ ε) := by
+    refine fun t ht => ⟨?_, ?_⟩
+    · rintro ⟨hs, -⟩ ⟨s, hsS, hle⟩
+      exact absurd hle (not_le.mpr (hs s hsS))
+    · exact fun h => ⟨fun s hsS => not_le.mp fun hle => h ⟨s, hsS, hle⟩, ht⟩
+  have hsplit : EqOn (fun t => if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then 0 else φ (γ t) * deriv γ t)
+      (fun t => (survivingParams γ S ε ∩ uIoc a b).indicator (fun t => φ (γ t)) t * deriv γ t)
+      (uIoc a b) := fun t ht => by
     by_cases h : ∃ s ∈ S, ‖γ t - s‖ ≤ ε
-    · rw [if_pos h, Set.indicator_of_notMem (by simpa [survivingParams, not_lt] using h), zero_mul]
-    · rw [if_neg h, Set.indicator_of_mem (by simpa [survivingParams, not_lt] using h)]
-  rw [hsplit, intervalIntegrable_iff]
+    · have hno : t ∉ survivingParams γ S ε ∩ uIoc a b := fun hm => (hmem t ht).mp hm h
+      simp [Set.indicator_of_notMem hno, h]
+    · have hyes : t ∈ survivingParams γ S ε ∩ uIoc a b := (hmem t ht).mpr h
+      simp [Set.indicator_of_mem hyes, h]
+  rw [intervalIntegrable_iff]
+  refine MeasureTheory.IntegrableOn.congr_fun ?_ hsplit.symm measurableSet_uIoc
   refine (intervalIntegrable_iff.mp hd).bdd_mul (c := max M 0) ?_ ?_
-  · refine (aestronglyMeasurable_indicator_iff
-      (measurableSet_survivingParams hγm S ε)).mpr ?_
-    rw [MeasureTheory.Measure.restrict_restrict (measurableSet_survivingParams hγm S ε)]
-    refine ContinuousOn.aestronglyMeasurable ?_
-      ((measurableSet_survivingParams hγm S ε).inter measurableSet_uIoc)
-    exact hφ.comp (hγc.mono fun t ht => Set.uIoc_subset_uIcc ht.2) fun t ht =>
-      ⟨⟨t, Set.uIoc_subset_uIcc ht.2, rfl⟩, fun s hs => (ht.1 s hs).le⟩
+  · refine (aestronglyMeasurable_indicator_iff₀ hA0).mpr ?_
+    rw [MeasureTheory.Measure.restrict_restrict₀ hA0]
+    refine (ContinuousOn.aemeasurable₀ (f := fun t => φ (γ t)) (fun t ht => ?_) ?_
+      ).aestronglyMeasurable
+    · exact (hφ.comp (hγc.mono fun u hu => Set.uIoc_subset_uIcc hu.1.2)
+        fun u hu => ⟨⟨u, Set.uIoc_subset_uIcc hu.1.2, rfl⟩, fun s hs => (hu.1.1 s hs).le⟩) t ht
+    · exact ((MeasureTheory.nullMeasurableSet_restrict_of_subset
+        Set.inter_subset_right).mp hA0).inter measurableSet_uIoc.nullMeasurableSet
   · refine (MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
       (Filter.Eventually.of_forall fun t ht => ?_)
-    by_cases hs : t ∈ survivingParams γ S ε
+    by_cases hs : t ∈ survivingParams γ S ε ∩ uIoc a b
     · rw [Set.indicator_of_mem hs]
-      exact (hM _ ⟨⟨t, Set.uIoc_subset_uIcc ht, rfl⟩,
-        fun s hsS => (hs s hsS).le⟩).trans (le_max_left _ _)
+      exact (hM _ ⟨⟨t, Set.uIoc_subset_uIcc hs.2, rfl⟩,
+        fun s hsS => (hs.1 s hsS).le⟩).trans (le_max_left _ _)
     · rw [Set.indicator_of_notMem hs, norm_zero]
       exact le_max_right _ _
 

--- a/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
+++ b/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
@@ -65,11 +65,9 @@ theorem intervalIntegrable_excised_of_continuousOn (hγc : ContinuousOn γ (uIcc
       (MeasureTheory.volume.restrict (uIoc a b)) := by
     have hcompl : survivingParams γ S ε = {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε}ᶜ := by
       ext; simp [survivingParams, not_le]
-    have hset : {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} = ⋃ s ∈ S, {t | ‖γ t - s‖ ≤ ε} := by ext; simp
-    refine MeasureTheory.NullMeasurableSet.inter ?_ measurableSet_uIoc.nullMeasurableSet
-    refine hcompl ▸ MeasureTheory.NullMeasurableSet.compl (hset ▸ ?_)
-    exact MeasureTheory.NullMeasurableSet.biUnion S.countable_toSet fun s _ =>
-      nullMeasurableSet_le ((hae.sub_const s).norm) aemeasurable_const
+    exact MeasureTheory.NullMeasurableSet.inter
+      (hcompl ▸ (nullMeasurableSet_excision hae S ε).compl)
+      measurableSet_uIoc.nullMeasurableSet
   have hmem : ∀ t ∈ uIoc a b,
       (t ∈ survivingParams γ S ε ∩ uIoc a b ↔ ¬∃ s ∈ S, ‖γ t - s‖ ≤ ε) := by
     refine fun t ht => ⟨?_, ?_⟩

--- a/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
+++ b/TauCeti/Analysis/Contour/Curve/ExcisedIntegrability.lean
@@ -6,9 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Contour.Curve.ExcisionMeasure
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import Mathlib.Analysis.Calculus.FDeriv.Measurable
-public import Mathlib.Analysis.Complex.Basic
 
 /-!
 # The excised integrand is integrable

--- a/TauCeti/Analysis/Contour/Curve/ExcisionMeasure.lean
+++ b/TauCeti/Analysis/Contour/Curve/ExcisionMeasure.lean
@@ -60,8 +60,8 @@ theorem nullMeasurableSet_excision {γ : ℝ → ℂ} {μ : MeasureTheory.Measur
     (hγ : AEMeasurable γ μ) (S : Finset ℂ) (ε : ℝ) :
     MeasureTheory.NullMeasurableSet {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} μ := by
   have h : {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} = ⋃ s ∈ S, {t | ‖γ t - s‖ ≤ ε} := by ext; simp
-  refine h ▸ MeasureTheory.NullMeasurableSet.biUnion S.countable_toSet fun s _ => ?_
-  exact nullMeasurableSet_le ((hγ.sub_const s).norm) aemeasurable_const
+  exact h ▸ Finset.nullMeasurableSet_biUnion S fun s _ =>
+    nullMeasurableSet_le ((hγ.sub_const s).norm) aemeasurable_const
 
 /-- **The excised parameter set is measurable.** It is the finite union, over the centres, of the
 preimages of the ray `(-∞, ε]` under `t ↦ ‖γ t - s‖`, each measurable because `γ` is. -/

--- a/TauCeti/Analysis/Contour/Curve/ExcisionMeasure.lean
+++ b/TauCeti/Analysis/Contour/Curve/ExcisionMeasure.lean
@@ -28,6 +28,7 @@ null set of times.
 
 ## Main results
 
+* `TauCeti.Contour.measurableSet_excision`: the excised parameter set is measurable.
 * `TauCeti.Contour.measure_setOf_mem_eq_zero_of_injOn`: an injective curve meets a finite set at
   a null set of times.
 * `TauCeti.Contour.tendsto_intervalIntegral_excisionIndicator`: the excision indicator's integral
@@ -48,6 +49,15 @@ public section
 open Filter MeasureTheory Set Topology
 
 namespace TauCeti.Contour
+
+/-- **The excised parameter set is measurable.** It is the finite union, over the centres, of the
+closed sublevel sets of `t ↦ ‖γ t - s‖`. -/
+theorem measurableSet_excision {γ : ℝ → ℂ} (hγm : Measurable γ) (S : Finset ℂ) (ε : ℝ) :
+    MeasurableSet {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} := by
+  have h : {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} = ⋃ s ∈ S, {t | ‖γ t - s‖ ≤ ε} := by ext; simp
+  rw [h]
+  exact Finset.measurableSet_biUnion _ fun s _ =>
+    measurableSet_le ((hγm.sub_const s).norm) measurable_const
 
 /-- A point lying off a finite set stays off it by a fixed positive margin. -/
 private theorem exists_pos_le_norm_sub_of_notMem {S : Finset ℂ} {z : ℂ} (hz : z ∉ S) :
@@ -78,13 +88,9 @@ theorem tendsto_intervalIntegral_excisionIndicator {γ : ℝ → ℂ} (hγm : Me
     (hab : a ≤ b) (S : Finset ℂ) (hnull : volume {t ∈ Icc a b | γ t ∈ S} = 0) :
     Tendsto (fun ε => ∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then (0 : ℝ) else 1)
       (𝓝[>] 0) (𝓝 (b - a)) := by
-  have hmS : ∀ ε : ℝ, MeasurableSet {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} := fun ε => by
-    have h : {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} = ⋃ s ∈ S, {t | ‖γ t - s‖ ≤ ε} := by ext; simp
-    rw [h]
-    exact Finset.measurableSet_biUnion _ fun s _ =>
-      measurableSet_le ((hγm.sub_const s).norm) measurable_const
   set As : ℝ → Set ℝ := fun ε => Ioc a b \ {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} with hAs_def
-  have hAs : ∀ ε, MeasurableSet (As ε) := fun ε => measurableSet_Ioc.diff (hmS ε)
+  have hAs : ∀ ε, MeasurableSet (As ε) := fun ε =>
+    measurableSet_Ioc.diff (measurableSet_excision hγm S ε)
   -- The integral is exactly the surviving set's length.
   have hint : ∀ ε : ℝ, (∫ t in a..b, if ∃ s ∈ S, ‖γ t - s‖ ≤ ε then (0 : ℝ) else 1)
       = volume.real (As ε) := fun ε => by

--- a/TauCeti/Analysis/Contour/Curve/ExcisionMeasure.lean
+++ b/TauCeti/Analysis/Contour/Curve/ExcisionMeasure.lean
@@ -51,7 +51,7 @@ open Filter MeasureTheory Set Topology
 namespace TauCeti.Contour
 
 /-- **The excised parameter set is measurable.** It is the finite union, over the centres, of the
-closed sublevel sets of `t ↦ ‖γ t - s‖`. -/
+preimages of the ray `(-∞, ε]` under `t ↦ ‖γ t - s‖`, each measurable because `γ` is. -/
 theorem measurableSet_excision {γ : ℝ → ℂ} (hγm : Measurable γ) (S : Finset ℂ) (ε : ℝ) :
     MeasurableSet {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} := by
   have h : {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} = ⋃ s ∈ S, {t | ‖γ t - s‖ ≤ ε} := by ext; simp

--- a/TauCeti/Analysis/Contour/Curve/ExcisionMeasure.lean
+++ b/TauCeti/Analysis/Contour/Curve/ExcisionMeasure.lean
@@ -28,7 +28,9 @@ null set of times.
 
 ## Main results
 
-* `TauCeti.Contour.measurableSet_excision`: the excised parameter set is measurable.
+* `TauCeti.Contour.nullMeasurableSet_excision`: the excised parameter set is null-measurable
+  against any measure for which the curve is a.e. measurable.
+* `TauCeti.Contour.measurableSet_excision`: its measurable specialization.
 * `TauCeti.Contour.measure_setOf_mem_eq_zero_of_injOn`: an injective curve meets a finite set at
   a null set of times.
 * `TauCeti.Contour.tendsto_intervalIntegral_excisionIndicator`: the excision indicator's integral
@@ -49,6 +51,17 @@ public section
 open Filter MeasureTheory Set Topology
 
 namespace TauCeti.Contour
+
+/-- **The excised parameter set is null-measurable.** The finite union, over the centres, of the
+sublevel sets of `t ↦ ‖γ t - s‖`, each null-measurable because `γ` is a.e. measurable. Stated for
+an arbitrary measure so that it serves both the ambient statement and the restricted-measure one
+that interval integrability needs. -/
+theorem nullMeasurableSet_excision {γ : ℝ → ℂ} {μ : MeasureTheory.Measure ℝ}
+    (hγ : AEMeasurable γ μ) (S : Finset ℂ) (ε : ℝ) :
+    MeasureTheory.NullMeasurableSet {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} μ := by
+  have h : {t | ∃ s ∈ S, ‖γ t - s‖ ≤ ε} = ⋃ s ∈ S, {t | ‖γ t - s‖ ≤ ε} := by ext; simp
+  refine h ▸ MeasureTheory.NullMeasurableSet.biUnion S.countable_toSet fun s _ => ?_
+  exact nullMeasurableSet_le ((hγ.sub_const s).norm) aemeasurable_const
 
 /-- **The excised parameter set is measurable.** It is the finite union, over the centres, of the
 preimages of the ray `(-∞, ε]` under `t ↦ ‖γ t - s‖`, each measurable because `γ` is. -/

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
 public import TauCeti.NumberTheory.ModularForms.STransform
 
+import TauCeti.Analysis.Contour.Curve.ExcisionMeasure
 import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
 
 /-!
@@ -230,18 +231,6 @@ theorem excised_logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg
   · simp only [if_neg hc, if_neg fun h => hc (hsymm.mp h)]
     exact logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg f hS ht (hd hc) (hne hc)
 
-/-- **The excision set is measurable.** It is a finite union of preimages of closed balls
-under the continuous contour. -/
-theorem measurableSet_exists_norm_fdBoundary_sub_le {H ε : ℝ} {S : Finset ℂ} :
-    MeasurableSet {t : ℝ | ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε} := by
-  have hset : {t : ℝ | ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε}
-      = ⋃ s ∈ (S : Set ℂ), {t : ℝ | ‖fdBoundary H t - s‖ ≤ ε} := by
-    ext t; simp
-  rw [hset]
-  refine S.finite_toSet.measurableSet_biUnion fun s _ => ?_
-  exact measurableSet_le
-    (((continuous_fdBoundary H).sub continuous_const).norm).measurable measurable_const
-
 /-- **An excised constant is interval-integrable.** It is measurable, because the excision set
 is, and bounded by the constant's norm. -/
 theorem intervalIntegrable_excised_const {H ε : ℝ} {S : Finset ℂ} (c : ℂ) (a b : ℝ) :
@@ -249,7 +238,8 @@ theorem intervalIntegrable_excised_const {H ε : ℝ} {S : Finset ℂ} (c : ℂ)
       (fun t => if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then (0 : ℂ) else c) volume a b := by
   have hmeas : Measurable
       (fun t => if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then (0 : ℂ) else c) :=
-    measurable_const.ite measurableSet_exists_norm_fdBoundary_sub_le measurable_const
+    measurable_const.ite
+      (Contour.measurableSet_excision (continuous_fdBoundary H).measurable S ε) measurable_const
   have hbdd : ∀ t : ℝ,
       ‖(if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then (0 : ℂ) else c)‖ ≤ ‖c‖ := by
     intro t

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Containment.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Containment.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.Modular
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
+
+/-!
+# The boundary contour lies in the truncated fundamental domain
+
+The valence-formula contour `fdBoundary H` traces the boundary of the truncated fundamental
+domain, so every point of it lies in that domain's closure. This file records that containment
+and the four coordinate estimates it rests on — a height bound above and below, a bound on the
+real part, and the lower bound on the modulus.
+
+These are statements about the contour's *geometry* alone. They are separated from the winding
+theory that first needed them so that consumers wanting only the containment — the excised
+integrability criterion, for instance — need not import winding numbers.
+
+## Main results
+
+* `TauCeti.ModularForm.fdBoundary_mem_coe_truncatedFundamentalDomain`: the contour lies in the
+  closed truncated fundamental domain.
+* `TauCeti.ModularForm.sqrt_three_div_two_le_one`: the corner height lies below the apex.
+* `TauCeti.ModularForm.sqrt_three_div_two_le_im_fdBoundary`, `…im_fdBoundary_le`,
+  `…abs_re_fdBoundary_le_half`, `…one_le_norm_fdBoundary`: the four coordinate estimates.
+-/
+
+public section
+
+open Complex Set
+
+open scoped Real
+
+namespace TauCeti
+
+namespace ModularForm
+
+variable {H t : ℝ}
+
+
+/-- The corner height `√3/2` lies below `1`, the height of the arc's apex. -/
+lemma sqrt_three_div_two_le_one : Real.sqrt 3 / 2 ≤ 1 := by
+  rw [div_le_one (by norm_num)]
+  nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+
+-- `simpNF` rejects `simp` annotations on the affine coordinate rewrites below: the
+-- `@[simp]` branch selectors already rewrite `fdBoundary` applications to the segment
+-- functions, so these left-hand sides are not in simp normal form.
+
+/-- Every point of the boundary contour has imaginary part at least `√3/2`, provided the
+height parameter clears the corner row. -/
+lemma sqrt_three_div_two_le_im_fdBoundary (hH : Real.sqrt 3 / 2 ≤ H)
+    (ht : t ∈ Icc (0 : ℝ) 5) : Real.sqrt 3 / 2 ≤ (fdBoundary H t).im := by
+  obtain ⟨ht0, ht5⟩ := ht
+  rcases le_or_gt t 1 with h1 | h1
+  · rw [im_fdBoundary_of_le_one h1]
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 - t)
+      (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
+  · rcases le_or_gt t 3 with h3 | h3
+    · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_im, one_mul]
+      have harc : Real.pi / 3 ≤ (t + 1) * (Real.pi / 6) ∧
+          (t + 1) * (Real.pi / 6) ≤ 2 * Real.pi / 3 := by
+        constructor <;> nlinarith [Real.pi_pos, h1, h3]
+      calc Real.sqrt 3 / 2 = Real.sin (Real.pi / 3) := (Real.sin_pi_div_three).symm
+        _ ≤ Real.sin ((t + 1) * (Real.pi / 6)) := by
+            rcases le_or_gt ((t + 1) * (Real.pi / 6)) (Real.pi / 2) with hle | hgt
+            · exact Real.sin_le_sin_of_le_of_le_pi_div_two
+                (by linarith [Real.pi_pos]) hle harc.1
+            · nth_rewrite 2 [← Real.sin_pi_sub]
+              refine Real.sin_le_sin_of_le_of_le_pi_div_two
+                (by linarith [Real.pi_pos]) ?_ ?_ <;> linarith [Real.pi_pos, harc.2, hgt]
+    · rcases le_or_gt t 4 with h4 | h4
+      · rw [im_fdBoundary_of_le_four h3 h4]
+        nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ t - 3)
+          (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
+      · rw [im_fdBoundary_of_gt_four h4]
+        exact hH
+
+/-- The contour's real part stays within the fundamental strip. -/
+lemma abs_re_fdBoundary_le_half (ht : t ≤ 5) : |(fdBoundary H t).re| ≤ 1 / 2 := by
+  rw [abs_le]
+  rcases le_or_gt t 1 with h1 | h1
+  · rw [re_fdBoundary_of_le_one h1]
+    norm_num
+  · rcases le_or_gt t 3 with h3 | h3
+    · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_re, one_mul]
+      have harc : Real.pi / 3 ≤ (t + 1) * (Real.pi / 6) ∧
+          (t + 1) * (Real.pi / 6) ≤ 2 * Real.pi / 3 := by
+        constructor <;> nlinarith [Real.pi_pos]
+      constructor
+      · have h23 : (2 * Real.pi / 3 : ℝ) = Real.pi - Real.pi / 3 := by ring
+        calc (-(1 / 2) : ℝ) = Real.cos (2 * Real.pi / 3) := by
+              rw [h23, Real.cos_pi_sub, Real.cos_pi_div_three]
+          _ ≤ Real.cos ((t + 1) * (Real.pi / 6)) :=
+              Real.cos_le_cos_of_nonneg_of_le_pi (by positivity)
+                (by linarith [Real.pi_pos]) harc.2
+      · calc Real.cos ((t + 1) * (Real.pi / 6)) ≤ Real.cos (Real.pi / 3) :=
+              Real.cos_le_cos_of_nonneg_of_le_pi (by positivity)
+                (by linarith [Real.pi_pos]) harc.1
+          _ = 1 / 2 := Real.cos_pi_div_three
+    · rcases le_or_gt t 4 with h4 | h4
+      · rw [re_fdBoundary_of_le_four h3 h4]
+        norm_num
+      · rw [re_fdBoundary_of_gt_four h4]
+        constructor <;> nlinarith
+
+/-- The contour stays at or below its height parameter. -/
+lemma im_fdBoundary_le (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
+    (fdBoundary H t).im ≤ H := by
+  obtain ⟨ht0, ht5⟩ := ht
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
+  rcases le_or_gt t 1 with h1 | h1
+  · rw [im_fdBoundary_of_le_one h1]
+    nlinarith [mul_nonneg ht0 (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
+  · rcases le_or_gt t 3 with h3 | h3
+    · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_im, one_mul]
+      exact (Real.sin_le_one _).trans hH
+    · rcases le_or_gt t 4 with h4 | h4
+      · rw [im_fdBoundary_of_le_four h3 h4]
+        nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 4 - t)
+          (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
+      · rw [im_fdBoundary_of_gt_four h4]
+
+/-- The boundary contour stays outside the open unit disc: the verticals and the ceiling
+clear it by height and offset, and the arc lies on the unit circle. -/
+lemma one_le_norm_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
+    1 ≤ ‖fdBoundary H t‖ := by
+  obtain ⟨ht0, ht5⟩ := ht
+  have hsq : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
+  have him := sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ⟨ht0, ht5⟩
+  have hnn := norm_nonneg (fdBoundary H t)
+  rcases le_or_gt t 1 with h1 | h1
+  · have h1' : 1 ≤ ‖fdBoundary H t‖ ^ 2 := by
+      rw [Complex.sq_norm, Complex.normSq_apply, re_fdBoundary_of_le_one h1]
+      nlinarith [Real.sqrt_nonneg 3]
+    nlinarith
+  · rcases le_or_gt t 3 with h3 | h3
+    · exact (norm_fdBoundary_arc h1.le h3).ge
+    · rcases le_or_gt t 4 with h4 | h4
+      · have h1' : 1 ≤ ‖fdBoundary H t‖ ^ 2 := by
+          rw [Complex.sq_norm, Complex.normSq_apply, re_fdBoundary_of_le_four h3 h4]
+          nlinarith [Real.sqrt_nonneg 3]
+        nlinarith
+      · calc (1 : ℝ) ≤ H := hH
+          _ = (fdBoundary H t).im := (im_fdBoundary_of_gt_four h4).symm
+          _ ≤ |(fdBoundary H t).im| := le_abs_self _
+          _ ≤ ‖fdBoundary H t‖ := Complex.abs_im_le_norm _
+/-- The boundary contour lies in the closed truncated fundamental domain. -/
+lemma fdBoundary_mem_coe_truncatedFundamentalDomain (hH : 1 ≤ H) {t : ℝ}
+    (ht : t ∈ Icc (0 : ℝ) 5) :
+    fdBoundary H t ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H := by
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
+  rw [ModularGroup.coe_truncatedFundamentalDomain, Set.mem_ofPred_eq]
+  refine ⟨?_, im_fdBoundary_le hH ht, abs_re_fdBoundary_le_half ht.2,
+    one_le_norm_fdBoundary hH ht⟩
+  have := sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ht
+  nlinarith [Real.sqrt_nonneg 3]
+
+end ModularForm
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Containment.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Containment.lean
@@ -24,9 +24,17 @@ integrability criterion, for instance — need not import winding numbers.
 
 * `TauCeti.ModularForm.fdBoundary_mem_coe_truncatedFundamentalDomain`: the contour lies in the
   closed truncated fundamental domain.
-* `TauCeti.ModularForm.sqrt_three_div_two_le_one`: the corner height lies below the apex.
+* `TauCeti.ModularForm.sqrt_three_div_two_lt_one`: the corner height lies below the apex.
 * `TauCeti.ModularForm.sqrt_three_div_two_le_im_fdBoundary`, `…im_fdBoundary_le`,
   `…abs_re_fdBoundary_le_half`, `…one_le_norm_fdBoundary`: the four coordinate estimates.
+
+## References
+
+The contour geometry follows the fundamental-domain boundary development of AINTLIB's
+`LeanModularForms` (`ForMathlib/FDBoundary.lean`, `FDBoundaryH.lean`, `FDBoundaryPath.lean`),
+ported onto the current Mathlib pin; these declarations were first written in Tau Ceti's
+`Winding/Basic.lean` and are collected here so that consumers needing only the containment do
+not import winding theory.
 -/
 
 public section
@@ -42,9 +50,8 @@ namespace ModularForm
 variable {H t : ℝ}
 
 
-/-- The corner height `√3/2` lies below `1`, the height of the arc's apex. -/
-lemma sqrt_three_div_two_le_one : Real.sqrt 3 / 2 ≤ 1 := by
-  rw [div_le_one (by norm_num)]
+/-- The corner height `√3/2` lies strictly below `1`, the height of the arc's apex. -/
+lemma sqrt_three_div_two_lt_one : Real.sqrt 3 / 2 < 1 := by
   nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
 
 -- `simpNF` rejects `simp` annotations on the affine coordinate rewrites below: the
@@ -112,7 +119,7 @@ lemma abs_re_fdBoundary_le_half (ht : t ≤ 5) : |(fdBoundary H t).re| ≤ 1 / 2
 lemma im_fdBoundary_le (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
     (fdBoundary H t).im ≤ H := by
   obtain ⟨ht0, ht5⟩ := ht
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_lt_one.le
   rcases le_or_gt t 1 with h1 | h1
   · rw [im_fdBoundary_of_le_one h1]
     nlinarith [mul_nonneg ht0 (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
@@ -131,7 +138,7 @@ lemma one_le_norm_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
     1 ≤ ‖fdBoundary H t‖ := by
   obtain ⟨ht0, ht5⟩ := ht
   have hsq : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_lt_one.le
   have him := sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ⟨ht0, ht5⟩
   have hnn := norm_nonneg (fdBoundary H t)
   rcases le_or_gt t 1 with h1 | h1
@@ -154,7 +161,7 @@ lemma one_le_norm_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
 lemma fdBoundary_mem_coe_truncatedFundamentalDomain (hH : 1 ≤ H) {t : ℝ}
     (ht : t ∈ Icc (0 : ℝ) 5) :
     fdBoundary H t ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H := by
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_lt_one.le
   rw [ModularGroup.coe_truncatedFundamentalDomain, Set.mem_ofPred_eq]
   refine ⟨?_, im_fdBoundary_le hH ht, abs_re_fdBoundary_le_half ht.2,
     one_le_norm_fdBoundary hH ht⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
@@ -5,8 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Analysis.Calculus.LogDeriv
 public import TauCeti.Analysis.Contour.Curve.ExcisedIntegrability
-public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.DerivBound
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Containment
 
 import TauCeti.Analysis.Contour.LogDerivFTC
@@ -55,11 +55,11 @@ theorem intervalIntegrable_excised_deriv_smul_logDeriv_comp_ofComplex_fdBoundary
     {a b : ℝ} (hab : uIcc a b ⊆ Icc (0 : ℝ) 5) :
     IntervalIntegrable (fun t => if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
         else deriv (fdBoundary H) t • logDeriv g (fdBoundary H t)) volume a b := by
-  obtain ⟨M, -, hM⟩ := exists_norm_deriv_fdBoundary_le H
-  have hd : IntervalIntegrable (deriv (fdBoundary H)) volume a b := by
-    rw [intervalIntegrable_iff]
-    exact IntegrableOn.of_bound (by rw [Real.volume_uIoc]; exact ENNReal.ofReal_lt_top)
-      (measurable_deriv _).aestronglyMeasurable M (Filter.Eventually.of_forall fun t => hM t)
+  have hab' : uIcc a b ⊆ uIcc (0 : ℝ) 5 := by
+    rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)]
+    exact hab
+  have hd : IntervalIntegrable (deriv (fdBoundary H)) volume a b :=
+    (isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv.mono_set hab'
   have hφ : ContinuousOn (logDeriv g)
       (fdBoundary H '' uIcc a b ∩ {z | ∀ s ∈ S, ε ≤ ‖z - s‖}) := by
     rintro z ⟨⟨t, ht, rfl⟩, hfar⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
@@ -18,10 +18,11 @@ import TauCeti.Analysis.Contour.LogDerivFTC
 integrability *assumed* on `[0, 1]`, `[1, 2]` and `[4, 5]`. This file discharges that assumption,
 for any subinterval of `[0, 5]` at once.
 
-Both inputs the general criterion needs are available for the boundary contour: its derivative is
-globally bounded (`exists_norm_deriv_fdBoundary_le`), and off the excision the contour stays in
-the open set where the form is analytic and nonvanishing, so its logarithmic derivative is
-analytic there (`analyticAt_logDeriv_of_analyticAt`) and in particular continuous.
+Both inputs the general criterion needs are available for the boundary contour: it is piecewise
+`C¹` (`isPiecewiseC1On_fdBoundary`), which makes its derivative interval-integrable, and off the
+excision the contour stays in the open set where the form is analytic and nonvanishing, so its
+logarithmic derivative is analytic there (`analyticAt_logDeriv_of_analyticAt`) and in particular
+continuous.
 
 This shares `hH`, `hUdom` and `hoff` with `hasCauchyPV_fdBoundary_logDeriv` — deliberately, so
 that one analyticity block serves both the excised assembly and the principal value it converges
@@ -45,7 +46,8 @@ namespace ModularForm
 
 /-- **The excised boundary integrand is integrable.** Off the excision the contour stays in `U`,
 where the form is analytic and nonvanishing, so its logarithmic derivative is continuous there;
-with `deriv (fdBoundary H)` globally bounded, `TauCeti.Contour`'s criterion applies.
+the contour is piecewise `C¹`, so its derivative is interval-integrable, and `TauCeti.Contour`'s
+criterion applies.
 
 `hε` is needed to know that a point at distance `≥ ε` from every centre is not itself a centre. -/
 theorem intervalIntegrable_excised_deriv_smul_logDeriv_comp_ofComplex_fdBoundary {g : ℂ → ℂ}

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
@@ -23,8 +23,9 @@ globally bounded (`exists_norm_deriv_fdBoundary_le`), and off the excision the c
 the open set where the form is analytic and nonvanishing, so its logarithmic derivative is
 analytic there (`analyticAt_logDeriv_of_analyticAt`) and in particular continuous.
 
-The hypotheses are exactly those of `hasCauchyPV_fdBoundary_logDeriv`, so one block of
-assumptions serves both the excised assembly and the principal value it converges to.
+This shares `hH`, `hUdom` and `hoff` with `hasCauchyPV_fdBoundary_logDeriv` — deliberately, so
+that one analyticity block serves both the excised assembly and the principal value it converges
+to — while each theorem also carries hypotheses the other does not.
 
 ## Main results
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
@@ -9,7 +9,7 @@ public import TauCeti.Analysis.Contour.Curve.ExcisedIntegrability
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.DerivBound
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Winding.Basic
 
-import TauCeti.Analysis.Contour.Argument.Cycle
+import TauCeti.Analysis.Contour.LogDerivFTC
 
 /-!
 # The excised boundary integrand is integrable

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Analysis.Contour.Curve.ExcisedIntegrability
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.DerivBound
-public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Winding.Basic
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Containment
 
 import TauCeti.Analysis.Contour.LogDerivFTC
 
@@ -73,7 +73,7 @@ theorem intervalIntegrable_excised_deriv_smul_logDeriv_comp_ofComplex_fdBoundary
       (hoff _ hmemU hnotS).2).continuousAt.continuousWithinAt
   simpa only [smul_eq_mul, mul_comm] using
     Contour.intervalIntegrable_excised_of_continuousOn (continuous_fdBoundary H).continuousOn
-      (continuous_fdBoundary H).measurable hd hφ
+      hd hφ
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Contour.Curve.ExcisedIntegrability
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.DerivBound
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Winding.Basic
+
+import TauCeti.Analysis.Contour.Argument.Cycle
+
+/-!
+# The excised boundary integrand is integrable
+
+`intervalIntegral_excised_logDeriv_fdBoundary` assembles the excised boundary integral from
+integrability *assumed* on `[0, 1]`, `[1, 2]` and `[4, 5]`. This file discharges that assumption,
+for any subinterval of `[0, 5]` at once.
+
+Both inputs the general criterion needs are available for the boundary contour: its derivative is
+globally bounded (`exists_norm_deriv_fdBoundary_le`), and off the excision the contour stays in
+the open set where the form is analytic and nonvanishing, so its logarithmic derivative is
+analytic there (`analyticAt_logDeriv_of_analyticAt`) and in particular continuous.
+
+The hypotheses are exactly those of `hasCauchyPV_fdBoundary_logDeriv`, so one block of
+assumptions serves both the excised assembly and the principal value it converges to.
+
+## Main results
+
+* `TauCeti.ModularForm.intervalIntegrable_excised_deriv_smul_logDeriv_comp_ofComplex_fdBoundary`:
+  the excised boundary integrand is interval-integrable on any subinterval of `[0, 5]`.
+-/
+
+public section
+
+open Complex Filter MeasureTheory Set UpperHalfPlane
+
+open scoped MatrixGroups Real
+
+namespace TauCeti
+
+namespace ModularForm
+
+/-- **The excised boundary integrand is integrable.** Off the excision the contour stays in `U`,
+where the form is analytic and nonvanishing, so its logarithmic derivative is continuous there;
+with `deriv (fdBoundary H)` globally bounded, `TauCeti.Contour`'s criterion applies.
+
+`hε` is needed to know that a point at distance `≥ ε` from every centre is not itself a centre. -/
+theorem intervalIntegrable_excised_deriv_smul_logDeriv_comp_ofComplex_fdBoundary {g : ℂ → ℂ}
+    {H ε : ℝ} (hH : 1 ≤ H) (hε : 0 < ε) {S : Finset ℂ} {U : Set ℂ}
+    (hUdom : UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H ⊆ U)
+    (hoff : ∀ z ∈ U, z ∉ S → AnalyticAt ℂ g z ∧ g z ≠ 0)
+    {a b : ℝ} (hab : uIcc a b ⊆ Icc (0 : ℝ) 5) :
+    IntervalIntegrable (fun t => if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
+        else deriv (fdBoundary H) t • logDeriv g (fdBoundary H t)) volume a b := by
+  obtain ⟨M, -, hM⟩ := exists_norm_deriv_fdBoundary_le H
+  have hφ : ContinuousOn (logDeriv g)
+      (fdBoundary H '' (uIcc a b ∩ {t | ∀ s ∈ S, ε ≤ ‖fdBoundary H t - s‖})) := by
+    rintro z ⟨t, ⟨ht, hfar⟩, rfl⟩
+    have hmemU : fdBoundary H t ∈ U :=
+      hUdom (fdBoundary_mem_coe_truncatedFundamentalDomain hH (hab ht))
+    have hnotS : fdBoundary H t ∉ S := fun hs => by
+      have := hfar _ hs
+      rw [sub_self, norm_zero] at this
+      exact absurd this (not_le.mpr hε)
+    exact (Contour.analyticAt_logDeriv_of_analyticAt (hoff _ hmemU hnotS).1
+      (hoff _ hmemU hnotS).2).continuousAt.continuousWithinAt
+  simpa only [smul_eq_mul, mul_comm] using
+    Contour.intervalIntegrable_excised_of_continuousOn (continuous_fdBoundary H) hM hφ
+
+end ModularForm
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedIntegrability.lean
@@ -55,9 +55,13 @@ theorem intervalIntegrable_excised_deriv_smul_logDeriv_comp_ofComplex_fdBoundary
     IntervalIntegrable (fun t => if ∃ s ∈ S, ‖fdBoundary H t - s‖ ≤ ε then 0
         else deriv (fdBoundary H) t • logDeriv g (fdBoundary H t)) volume a b := by
   obtain ⟨M, -, hM⟩ := exists_norm_deriv_fdBoundary_le H
+  have hd : IntervalIntegrable (deriv (fdBoundary H)) volume a b := by
+    rw [intervalIntegrable_iff]
+    exact IntegrableOn.of_bound (by rw [Real.volume_uIoc]; exact ENNReal.ofReal_lt_top)
+      (measurable_deriv _).aestronglyMeasurable M (Filter.Eventually.of_forall fun t => hM t)
   have hφ : ContinuousOn (logDeriv g)
-      (fdBoundary H '' (uIcc a b ∩ {t | ∀ s ∈ S, ε ≤ ‖fdBoundary H t - s‖})) := by
-    rintro z ⟨t, ⟨ht, hfar⟩, rfl⟩
+      (fdBoundary H '' uIcc a b ∩ {z | ∀ s ∈ S, ε ≤ ‖z - s‖}) := by
+    rintro z ⟨⟨t, ht, rfl⟩, hfar⟩
     have hmemU : fdBoundary H t ∈ U :=
       hUdom (fdBoundary_mem_coe_truncatedFundamentalDomain hH (hab ht))
     have hnotS : fdBoundary H t ∉ S := fun hs => by
@@ -67,7 +71,8 @@ theorem intervalIntegrable_excised_deriv_smul_logDeriv_comp_ofComplex_fdBoundary
     exact (Contour.analyticAt_logDeriv_of_analyticAt (hoff _ hmemU hnotS).1
       (hoff _ hmemU hnotS).2).continuousAt.continuousWithinAt
   simpa only [smul_eq_mul, mul_comm] using
-    Contour.intervalIntegrable_excised_of_continuousOn (continuous_fdBoundary H) hM hφ
+    Contour.intervalIntegrable_excised_of_continuousOn (continuous_fdBoundary H).continuousOn
+      (continuous_fdBoundary H).measurable hd hφ
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Containment
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
 
@@ -83,9 +84,7 @@ row: the region `|re w| < 1/2`, `1 < im w < H`. -/
 private theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 1 / 2)
     (hy1 : 1 < w.im) (hyH : w.im < H) : windingNumber (fdBoundary H) 0 5 w = -1 := by
   obtain ⟨hx₁, hx₂⟩ := abs_lt.mp hx
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
-    rw [div_le_one (by norm_num)]
-    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_lt_one.le
   have hnorm : 1 < ‖w‖ :=
     hy1.trans_le ((le_abs_self _).trans (Complex.abs_im_le_norm w))
   have hw := fdBoundary_ne_of_abs_re_lt_half_of_one_lt_norm_of_im_lt hx hnorm hyH

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/LogDerivPV.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/LogDerivPV.lean
@@ -66,8 +66,7 @@ theorem hasCauchyPV_fdBoundary_logDeriv (hH : 1 ≤ H) {f : ℂ → ℂ} {S : Fi
     HasCauchyPV (fdBoundary H) 0 5 (logDeriv f)
       (2 * (Real.pi : ℂ) * Complex.I *
         ∑ z ∈ S, windingNumber (fdBoundary H) 0 5 z * (ord z : ℂ)) := by
-  have hne : H ≠ Real.sqrt 3 / 2 := by
-    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  have hne : H ≠ Real.sqrt 3 / 2 := ne_of_gt (sqrt_three_div_two_lt_one.trans_le hH)
   exact hasCauchyPV_logDeriv_nullHomologous hU hoff hmero hord
     (isPwC1ImmersionOn_fdBoundary hne)
     (fun t ht => hUdom (fdBoundary_mem_coe_truncatedFundamentalDomain hH

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/OnCurveCapture.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/OnCurveCapture.lean
@@ -71,8 +71,7 @@ theorem fdBoundary_mem_verticalSingularSet_of_mem_Ioo_zero_one [ModularFormClass
   have ht05 : t ∈ Icc (0 : ℝ) 5 := ⟨ht.1.le, by linarith [ht.2]⟩
   obtain ⟨q, hq, hqe⟩ := fdBoundary_mem_coe_truncatedFundamentalDomain hH ht05
   have hre : (fdBoundary H t).re = 1 / 2 := re_fdBoundary_segment1 H ⟨ht.1.le, ht.2.le⟩
-  have hs32 : Real.sqrt 3 / 2 < 1 := by
-    nlinarith [Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 3), Real.sqrt_nonneg 3]
+  have hs32 : Real.sqrt 3 / 2 < 1 := sqrt_three_div_two_lt_one
   have him_gt : Real.sqrt 3 / 2 < (fdBoundary H t).im := by
     rw [im_fdBoundary_of_le_one ht.2.le]
     nlinarith [ht.1, ht.2]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/OnCurveCapture.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/OnCurveCapture.lean
@@ -10,7 +10,7 @@ public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBounda
 public import TauCeti.NumberTheory.ModularForms.Order.OfVanishing
 
 import Mathlib.NumberTheory.ModularForms.QExpansion
-import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Winding.Basic
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Containment
 
 /-!
 # On-curve capture of the boundary zeros

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ResidueSum.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ResidueSum.lean
@@ -48,8 +48,8 @@ namespace ModularForm
 variable {H : ℝ}
 
 /-- The truncation height dominates the corner row. -/
-private lemma sqrt_three_div_two_lt_of_one_lt (hH : 1 < H) : Real.sqrt 3 / 2 < H := by
-  nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+private lemma sqrt_three_div_two_lt_of_one_lt (hH : 1 < H) : Real.sqrt 3 / 2 < H :=
+  sqrt_three_div_two_lt_one.trans hH
 
 /-- **The residue sum along the boundary contour.** For a function with a polar-part
 decomposition on an open set containing the closed truncated fundamental domain, all of

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -163,7 +163,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_norm_lt_one (hH : 1 ≤ H) {w : ℂ}
       (convex_ball 0 1).isPreconnected (convex_halfSpace_im_lt _).isPreconnected
     rw [Set.mem_ofPred_eq, Complex.zero_im]
     positivity
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_lt_one.le
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected hconn ?_
     (fun R ↦ ⟨((-(max R 0 + 1) : ℝ) : ℂ) * Complex.I, Or.inr ?_, ?_⟩)
     (Or.inl (by rwa [Metric.mem_ball, dist_zero_right]))
@@ -184,7 +184,7 @@ winding number vanishes. -/
 theorem isNullHomologous_fdBoundary (hH : 1 ≤ H) :
     IsNullHomologous (fdBoundary H) 0 5
       (UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H) := by
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_lt_one.le
   rw [isNullHomologous_iff]
   intro z hz
   rw [ModularGroup.coe_truncatedFundamentalDomain, Set.mem_ofPred_eq, not_and_or, not_and_or,

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -28,7 +28,6 @@ a radius below the corner chord `2·sin(π/12)` is stated once here rather than 
 
 ## Main declarations
 
-* `TauCeti.ModularForm.sqrt_three_div_two_le_im_fdBoundary`: the image height bound.
 * `TauCeti.ModularForm.windingNumber_fdBoundary_eq_zero_of_im_lt`: points below the
   corner height wind zero, with the analogous determinations on the other sides
   (`_of_half_lt_re`, `_of_re_lt_neg_half`, `_of_lt_im`) and in the unit disc

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -6,7 +6,7 @@ module
 
 public import Mathlib.NumberTheory.Modular
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
-public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Containment
 
 import Mathlib.Analysis.Complex.Convex
 import TauCeti.Analysis.Contour.Winding.UnboundedComponent
@@ -61,115 +61,6 @@ namespace TauCeti
 namespace ModularForm
 
 variable {H t : ℝ}
-
-/-- The corner height `√3/2` lies below `1`, the height of the arc's apex. -/
-private lemma sqrt_three_div_two_le_one : Real.sqrt 3 / 2 ≤ 1 := by
-  rw [div_le_one (by norm_num)]
-  nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
-
--- `simpNF` rejects `simp` annotations on the affine coordinate rewrites below: the
--- `@[simp]` branch selectors already rewrite `fdBoundary` applications to the segment
--- functions, so these left-hand sides are not in simp normal form.
-
-/-- Every point of the boundary contour has imaginary part at least `√3/2`, provided the
-height parameter clears the corner row. -/
-lemma sqrt_three_div_two_le_im_fdBoundary (hH : Real.sqrt 3 / 2 ≤ H)
-    (ht : t ∈ Icc (0 : ℝ) 5) : Real.sqrt 3 / 2 ≤ (fdBoundary H t).im := by
-  obtain ⟨ht0, ht5⟩ := ht
-  rcases le_or_gt t 1 with h1 | h1
-  · rw [im_fdBoundary_of_le_one h1]
-    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 - t)
-      (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
-  · rcases le_or_gt t 3 with h3 | h3
-    · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_im, one_mul]
-      have harc : Real.pi / 3 ≤ (t + 1) * (Real.pi / 6) ∧
-          (t + 1) * (Real.pi / 6) ≤ 2 * Real.pi / 3 := by
-        constructor <;> nlinarith [Real.pi_pos, h1, h3]
-      calc Real.sqrt 3 / 2 = Real.sin (Real.pi / 3) := (Real.sin_pi_div_three).symm
-        _ ≤ Real.sin ((t + 1) * (Real.pi / 6)) := by
-            rcases le_or_gt ((t + 1) * (Real.pi / 6)) (Real.pi / 2) with hle | hgt
-            · exact Real.sin_le_sin_of_le_of_le_pi_div_two
-                (by linarith [Real.pi_pos]) hle harc.1
-            · nth_rewrite 2 [← Real.sin_pi_sub]
-              refine Real.sin_le_sin_of_le_of_le_pi_div_two
-                (by linarith [Real.pi_pos]) ?_ ?_ <;> linarith [Real.pi_pos, harc.2, hgt]
-    · rcases le_or_gt t 4 with h4 | h4
-      · rw [im_fdBoundary_of_le_four h3 h4]
-        nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ t - 3)
-          (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
-      · rw [im_fdBoundary_of_gt_four h4]
-        exact hH
-
-/-- The contour's real part stays within the fundamental strip. -/
-lemma abs_re_fdBoundary_le_half (ht : t ≤ 5) : |(fdBoundary H t).re| ≤ 1 / 2 := by
-  rw [abs_le]
-  rcases le_or_gt t 1 with h1 | h1
-  · rw [re_fdBoundary_of_le_one h1]
-    norm_num
-  · rcases le_or_gt t 3 with h3 | h3
-    · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_re, one_mul]
-      have harc : Real.pi / 3 ≤ (t + 1) * (Real.pi / 6) ∧
-          (t + 1) * (Real.pi / 6) ≤ 2 * Real.pi / 3 := by
-        constructor <;> nlinarith [Real.pi_pos]
-      constructor
-      · have h23 : (2 * Real.pi / 3 : ℝ) = Real.pi - Real.pi / 3 := by ring
-        calc (-(1 / 2) : ℝ) = Real.cos (2 * Real.pi / 3) := by
-              rw [h23, Real.cos_pi_sub, Real.cos_pi_div_three]
-          _ ≤ Real.cos ((t + 1) * (Real.pi / 6)) :=
-              Real.cos_le_cos_of_nonneg_of_le_pi (by positivity)
-                (by linarith [Real.pi_pos]) harc.2
-      · calc Real.cos ((t + 1) * (Real.pi / 6)) ≤ Real.cos (Real.pi / 3) :=
-              Real.cos_le_cos_of_nonneg_of_le_pi (by positivity)
-                (by linarith [Real.pi_pos]) harc.1
-          _ = 1 / 2 := Real.cos_pi_div_three
-    · rcases le_or_gt t 4 with h4 | h4
-      · rw [re_fdBoundary_of_le_four h3 h4]
-        norm_num
-      · rw [re_fdBoundary_of_gt_four h4]
-        constructor <;> nlinarith
-
-/-- The contour stays at or below its height parameter. -/
-lemma im_fdBoundary_le (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
-    (fdBoundary H t).im ≤ H := by
-  obtain ⟨ht0, ht5⟩ := ht
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
-  rcases le_or_gt t 1 with h1 | h1
-  · rw [im_fdBoundary_of_le_one h1]
-    nlinarith [mul_nonneg ht0 (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
-  · rcases le_or_gt t 3 with h3 | h3
-    · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_im, one_mul]
-      exact (Real.sin_le_one _).trans hH
-    · rcases le_or_gt t 4 with h4 | h4
-      · rw [im_fdBoundary_of_le_four h3 h4]
-        nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 4 - t)
-          (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
-      · rw [im_fdBoundary_of_gt_four h4]
-
-/-- The boundary contour stays outside the open unit disc: the verticals and the ceiling
-clear it by height and offset, and the arc lies on the unit circle. -/
-lemma one_le_norm_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
-    1 ≤ ‖fdBoundary H t‖ := by
-  obtain ⟨ht0, ht5⟩ := ht
-  have hsq : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
-  have him := sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ⟨ht0, ht5⟩
-  have hnn := norm_nonneg (fdBoundary H t)
-  rcases le_or_gt t 1 with h1 | h1
-  · have h1' : 1 ≤ ‖fdBoundary H t‖ ^ 2 := by
-      rw [Complex.sq_norm, Complex.normSq_apply, re_fdBoundary_of_le_one h1]
-      nlinarith [Real.sqrt_nonneg 3]
-    nlinarith
-  · rcases le_or_gt t 3 with h3 | h3
-    · exact (norm_fdBoundary_arc h1.le h3).ge
-    · rcases le_or_gt t 4 with h4 | h4
-      · have h1' : 1 ≤ ‖fdBoundary H t‖ ^ 2 := by
-          rw [Complex.sq_norm, Complex.normSq_apply, re_fdBoundary_of_le_four h3 h4]
-          nlinarith [Real.sqrt_nonneg 3]
-        nlinarith
-      · calc (1 : ℝ) ≤ H := hH
-          _ = (fdBoundary H t).im := (im_fdBoundary_of_gt_four h4).symm
-          _ ≤ |(fdBoundary H t).im| := le_abs_self _
-          _ ≤ ‖fdBoundary H t‖ := Complex.abs_im_le_norm _
 
 /-- Winding transport through an unbounded preconnected region avoiding the contour: the
 region lies in one connected component of the complement, which reaches points far away
@@ -309,16 +200,6 @@ theorem isNullHomologous_fdBoundary (hH : 1 ≤ H) :
       linarith
   · exact windingNumber_fdBoundary_eq_zero_of_norm_lt_one hH hnorm
 
-/-- The boundary contour lies in the closed truncated fundamental domain. -/
-lemma fdBoundary_mem_coe_truncatedFundamentalDomain (hH : 1 ≤ H) {t : ℝ}
-    (ht : t ∈ Icc (0 : ℝ) 5) :
-    fdBoundary H t ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H := by
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
-  rw [ModularGroup.coe_truncatedFundamentalDomain, Set.mem_ofPred_eq]
-  refine ⟨?_, im_fdBoundary_le hH ht, abs_re_fdBoundary_le_half ht.2,
-    one_le_norm_fdBoundary hH ht⟩
-  have := sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ht
-  nlinarith [Real.sqrt_nonneg 3]
 
 
 /-- **The chord-matched excision half-width.** The parameter half-width whose chord along

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Geometry.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Geometry.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Containment
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
 
 import TauCeti.Topology.Circle.Metric
@@ -130,12 +131,6 @@ height `1`, the value can leave the parameter interval `[3, 4]`, and at `H = √
 denominator vanishes. -/
 noncomputable def leftVerticalCrossingI (H : ℝ) : ℝ :=
   3 + (1 - Real.sqrt 3 / 2) / (H - Real.sqrt 3 / 2)
-
-/-- The corner row lies strictly below `1`. -/
-private lemma sqrt_three_div_two_lt_one : Real.sqrt 3 / 2 < 1 := by
-  have h : Real.sqrt 3 < 2 := by
-    nlinarith [Real.sq_sqrt (by positivity : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
-  linarith
 
 /-- The crossing parameter lies right of the corner. -/
 theorem three_lt_leftVerticalCrossingI (hH : Real.sqrt 3 / 2 < H) :

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/I/Value.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Containment
 public import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
@@ -54,10 +55,6 @@ namespace ModularForm
 
 
 variable {H δ : ℝ}
-
-/-- The corner row lies strictly below `1`. -/
-private lemma sqrt_three_div_two_lt_one : Real.sqrt 3 / 2 < 1 := by
-  nlinarith [Real.sq_sqrt (by positivity : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
 
 /-- The right-vertical piece `[0, 1]` of the telescope: the shifted contour stays in the
 right half-plane, so the logarithmic integral is a difference of principal logarithms. -/


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-formula/excised-integrability"}-->

`intervalIntegral_excised_logDeriv_fdBoundary` (#2603) assembles the excised boundary integral
from integrability **assumed** on `[0, 1]`, `[1, 2]` and `[4, 5]`. This PR discharges that
assumption — for any subinterval of `[0, 5]` at once.

## The general criterion

The excision is what makes the integrand integrable when the unexcised one is not: the
singularities all sit at the centres, and the excision deletes a neighbourhood of each. What
survives is `φ ∘ γ` times `deriv γ` on parameters at distance `≥ ε` from every centre — over a
bounded interval a *compact* image, so a `φ` continuous there is bounded. With `deriv γ` bounded
the whole excised integrand is bounded, and it is measurable because `deriv` always is.

The one subtlety is measurability, since `φ` is continuous only on that compact set and not
everywhere. The excised integrand is literally `Set.indicator (surviving) (φ ∘ γ · deriv γ)`, so
`aestronglyMeasurable_indicator_iff` reduces measurability to the surviving set alone — where
`φ ∘ γ` is continuous. (`StronglyMeasurable.ite` does not apply: it needs *both* branches
measurable everywhere.)

`hφ` is stated with the **closed** condition `ε ≤ ‖z - s‖`, which is what makes the image
compact, while the excision itself keeps the strict `ε < ‖γ t - s‖`.

## The boundary contour

Both inputs are already available:

* `DerivBound.exists_norm_deriv_fdBoundary_le` — the derivative is globally bounded;
* off the excision the contour stays in the open `U` where the form is analytic and nonvanishing,
  so `analyticAt_logDeriv_of_analyticAt` makes its logarithmic derivative analytic, hence
  continuous, there.

The hypotheses are deliberately **exactly those of `hasCauchyPV_fdBoundary_logDeriv`**, so one
block of assumptions serves both the excised assembly and the principal value it converges to —
which is what the `ε → 0` step needs in order to identify the two.

## Deduplication

"The excision set is measurable" was proved in **three** places: `ArcPairing`'s
fdBoundary-specific `measurableSet_exists_norm_fdBoundary_sub_le`, an inline `hmS` in
`Curve/ExcisionMeasure.lean`, and this file's own copy. It is now stated once, as
`Contour.measurableSet_excision` in `Curve/ExcisionMeasure.lean`; the `ArcPairing`
specialisation is **deleted** rather than left forwarding, and its one call site uses the
general lemma.

`PrincipalValue/On.lean` also establishes something of this shape, and is deliberately left
alone: it proves `NullMeasurableSet` against a *restricted* measure from an `AEMeasurable γ`
hypothesis, which is a strictly weaker statement under a weaker assumption — not an instance of
this lemma.

## Main declarations

* `TauCeti.Contour.intervalIntegrable_excised_of_continuousOn` — the general criterion.
* `TauCeti.Contour.measurableSet_excision` — the excision set is measurable (the shared form of
  three previous copies).
* `TauCeti.ModularForm.intervalIntegrable_excised_deriv_smul_logDeriv_comp_ofComplex_fdBoundary`
  — the boundary instance, on any subinterval of `[0, 5]`.

Roadmap: ModularForms

Layer 1 of the ModularForms roadmap, *the valence formula (general level)*, which consumes the
Contour Integration roadmap; this removes the last assumed hypothesis from the excised boundary
assembly.
