### PR TITLE
feat(HeckeRing/GLn): injectivity of the presentation, completing Shimura's Theorem 3.20

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
@@ -163,6 +163,11 @@ lemma isDvdChain_iff {n : ℕ} {a : Fin n → ℕ} :
 lemma isDvdChain_const (c : ℕ) : IsDvdChain (fun _ : Fin n ↦ c) :=
   fun _ _ _ ↦ dvd_refl _
 
+/-- Scaling a divisibility chain by a constant keeps it a chain. -/
+lemma isDvdChain_mul_const {a : Fin n → ℕ} (ha : IsDvdChain a) (c : ℕ) :
+    IsDvdChain (a * fun _ : Fin n ↦ c) :=
+  isDvdChain_iff.mpr fun _ _ hij ↦ mul_dvd_mul (isDvdChain_iff.mp ha hij) dvd_rfl
+
 /-- The positive divisibility chains of length `n`: the parameter space of the diagonal
 double cosets. -/
 abbrev CanonicalDiagonal (n : ℕ) : Type :=

--- a/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
@@ -163,10 +163,12 @@ lemma isDvdChain_iff {n : ℕ} {a : Fin n → ℕ} :
 lemma isDvdChain_const (c : ℕ) : IsDvdChain (fun _ : Fin n ↦ c) :=
   fun _ _ _ ↦ dvd_refl _
 
-/-- Scaling a divisibility chain by a constant keeps it a chain. -/
-lemma isDvdChain_mul_const {a : Fin n → ℕ} (ha : IsDvdChain a) (c : ℕ) :
-    IsDvdChain (a * fun _ : Fin n ↦ c) :=
-  isDvdChain_iff.mpr fun _ _ hij ↦ mul_dvd_mul (isDvdChain_iff.mp ha hij) dvd_rfl
+/-- The pointwise product of two divisibility chains is a divisibility chain. Scaling by a
+constant is the case `b = isDvdChain_const`. -/
+lemma isDvdChain_mul {a b : Fin n → ℕ} (ha : IsDvdChain a) (hb : IsDvdChain b) :
+    IsDvdChain (a * b) :=
+  isDvdChain_iff.mpr fun _ _ hij ↦
+    mul_dvd_mul (isDvdChain_iff.mp ha hij) (isDvdChain_iff.mp hb hij)
 
 /-- The positive divisibility chains of length `n`: the parameter space of the diagonal
 double cosets. -/

--- a/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
@@ -164,7 +164,7 @@ lemma isDvdChain_const (c : ℕ) : IsDvdChain (fun _ : Fin n ↦ c) :=
   fun _ _ _ ↦ dvd_refl _
 
 /-- The pointwise product of two divisibility chains is a divisibility chain. Scaling by a
-constant is the case `b = isDvdChain_const`. -/
+constant `c` is the case where `b` is the constant function, with `hb := isDvdChain_const n c`. -/
 lemma isDvdChain_mul {a b : Fin n → ℕ} (ha : IsDvdChain a) (hb : IsDvdChain b) :
     IsDvdChain (a * b) :=
   isDvdChain_iff.mpr fun _ _ hij ↦

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Basic.lean
@@ -181,10 +181,7 @@ lemma evalHom_apply (P : MvPolynomial (Fin n) ℤ)
     (D : HeckeCoset (posDetInt n) (SLnZ n) (SLnZ n)) :
     evalHom n p P D =
       ∑ d ∈ P.support, P.coeff d • (∏ i, heckeGen n p i ^ d i : IntegralHeckeRing n) D := by
-  rw [evalHom_def]
-  change (MvPolynomial.eval₂ (Int.castRingHom (IntegralHeckeRing n))
-    (fun k : Fin n ↦ heckeGen n p k) P) D = _
-  rw [MvPolynomial.eval₂_eq']
+  rw [evalHom_def, MvPolynomial.coe_eval₂Hom, MvPolynomial.eval₂_eq']
   refine (Finset.sum_apply' D).trans (Finset.sum_congr rfl fun d _ ↦ ?_)
   -- beta-reduce the cast left by `eval₂_eq'`, then turn the `ℤ`-multiple into a `ℤ`-scalar so
   -- that the wrapper's own `smul_apply` closes the goal

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Basic.lean
@@ -169,6 +169,28 @@ lemma is kept as the named computation rule for `rw`. -/
 lemma evalHom_C (a : ℤ) : evalHom n p (MvPolynomial.C a) = (a : IntegralHeckeRing n) :=
   MvPolynomial.eval₂Hom_C _ _ _
 
+/-- **Evaluation rule for `evalHom` at a double coset.** The coefficient of `evalHom P` at `D`
+is the sum, over the support of `P`, of `P.coeff d` times the coefficient of the monomial
+`∏ heckeGen i ^ d i` at `D`.
+
+This is the wrapper-level counterpart of `evalHom_def`: it is stated here, where `evalHom` and
+`IntegralHeckeRing` are both transparent, so that consumers can evaluate a polynomial image at
+a coset without depending on either definition reducing at their own use site. -/
+lemma evalHom_apply (P : MvPolynomial (Fin n) ℤ)
+    (D : HeckeCoset (posDetInt n) (SLnZ n) (SLnZ n)) :
+    evalHom n p P D =
+      ∑ d ∈ P.support, P.coeff d • (∏ i, heckeGen n p i ^ d i : IntegralHeckeRing n) D := by
+  rw [evalHom_def]
+  change (MvPolynomial.eval₂ (Int.castRingHom (IntegralHeckeRing n))
+    (fun k : Fin n ↦ heckeGen n p k) P) D = _
+  rw [MvPolynomial.eval₂_eq']
+  refine (Finset.sum_apply' D).trans (Finset.sum_congr rfl fun d _ ↦ ?_)
+  -- beta-reduce the cast left by `eval₂_eq'`, then turn the `ℤ`-multiple into a `ℤ`-scalar so
+  -- that the wrapper's own `smul_apply` closes the goal
+  change (((P.coeff d : ℤ) : IntegralHeckeRing n) * ∏ i, heckeGen n p i ^ d i) D = _
+  rw [← zsmul_one (P.coeff d), smul_mul_assoc, one_mul]
+  exact HeckeCosetModule.smul_apply _ _ _
+
 /-- Each `heckeGen k` lies in the range of `evalHom`. -/
 lemma heckeGen_mem_evalHom_range (k : Fin n) :
     heckeGen n p k ∈ (evalHom n p).range :=

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Basic.lean
@@ -17,8 +17,9 @@ public section
 Towards **Shimura's Theorem 3.20**, that the `p`-local Hecke ring `pLocalSubring` of `GL_n` is a
 polynomial ring `ℤ[X₁, …, Xₙ]` on the `n` diagonal prime cosets. This file sets up the
 generators and proves the surjectivity half for `n = 1` and `n = 2`. The injectivity half —
-algebraic independence of the generators — and the resulting isomorphism are not part of this
-file; they are planned for a companion `PolynomialRing/Injective.lean`.
+algebraic independence of the generators — and the resulting isomorphisms live in the companion
+file `PolynomialRing/Injective.lean`, which consumes `evalHom_def` and `evalHom_apply` from
+here.
 
 ## Main definitions
 

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Basic.lean
@@ -151,6 +151,12 @@ variable [NeZero n] (p : ℕ) (hp : p.Prime)
 noncomputable def evalHom : MvPolynomial (Fin n) ℤ →+* IntegralHeckeRing n :=
   MvPolynomial.eval₂Hom (Int.castRingHom (IntegralHeckeRing n)) (fun k ↦ heckeGen n p k)
 
+/-- Defining equation for the sealed definition `evalHom`: evaluation of a polynomial at the
+generators, with integer coefficients cast into the Hecke ring. -/
+lemma evalHom_def : evalHom n p =
+    MvPolynomial.eval₂Hom (Int.castRingHom (IntegralHeckeRing n)) (fun k ↦ heckeGen n p k) :=
+  (rfl)
+
 /-- `evalHom` sends the `k`-th variable to the `k`-th generator. -/
 @[simp] lemma evalHom_X (k : Fin n) : evalHom n p (MvPolynomial.X k) = heckeGen n p k :=
   MvPolynomial.eval₂Hom_X' _ _ _

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -742,31 +742,35 @@ end HeckeRing.GLn.Inj
 
 namespace HeckeRing.GLn
 
-variable (p : ℕ) (hp : p.Prime)
+variable (p : ℕ)
 
 /-- **Shimura, Theorem 3.20 for `n = 1`**: the `p`-local Hecke ring of `GL₁` is the
-polynomial ring `ℤ[X]` on the single generator `T(p)`. -/
-noncomputable def polynomialRingEquivOne :
+polynomial ring `ℤ[X]` on the single generator `T(p)`.
+
+Stated for `1 < p` rather than `p.Prime`: rank one needs only that `k ↦ p^k` is injective. -/
+noncomputable def polynomialRingEquivOne (hp : 1 < p) :
     MvPolynomial (Fin 1) ℤ ≃+* pLocalSubring 1 p :=
   RingEquiv.ofBijective (evalHomLocal 1 p)
-    ⟨Inj.evalHomLocal_injective 1 p (Inj.evalHom_one_injective p hp.one_lt),
-     evalHomLocal_one_surjective p hp.pos⟩
+    ⟨Inj.evalHomLocal_injective 1 p (Inj.evalHom_one_injective p hp),
+     evalHomLocal_one_surjective p (Nat.zero_lt_of_lt hp)⟩
+
+/-- The rank-one presentation isomorphism is the evaluation map. -/
+@[simp] lemma polynomialRingEquivOne_apply (hp : 1 < p) (f : MvPolynomial (Fin 1) ℤ) :
+    polynomialRingEquivOne p hp f = evalHomLocal 1 p f := (rfl)
 
 /-- **Shimura, Theorem 3.20 for `n = 2`**: the `p`-local Hecke ring of `GL₂` is the
 polynomial ring `ℤ[X₁, X₂]` on the generators `T(1, p)` and `T(p, p)`. This is the case the
-classical theory of modular forms uses. -/
-noncomputable def polynomialRingEquivTwo :
+classical theory of modular forms uses.
+
+Primality is genuine here: the rank-two argument runs through the `GL₂` recurrence. -/
+noncomputable def polynomialRingEquivTwo (hp : p.Prime) :
     MvPolynomial (Fin 2) ℤ ≃+* pLocalSubring 2 p :=
   RingEquiv.ofBijective (evalHomLocal 2 p)
     ⟨Inj.evalHomLocal_injective 2 p (Inj.evalHom_two_injective p hp),
      evalHomLocal_two_surjective p hp⟩
 
-/-- The rank-one presentation isomorphism is the evaluation map. -/
-@[simp] lemma polynomialRingEquivOne_apply (f : MvPolynomial (Fin 1) ℤ) :
-    polynomialRingEquivOne p hp f = evalHomLocal 1 p f := (rfl)
-
 /-- The rank-two presentation isomorphism is the evaluation map. -/
-@[simp] lemma polynomialRingEquivTwo_apply (f : MvPolynomial (Fin 2) ℤ) :
+@[simp] lemma polynomialRingEquivTwo_apply (hp : p.Prime) (f : MvPolynomial (Fin 2) ℤ) :
     polynomialRingEquivTwo p hp f = evalHomLocal 2 p f := (rfl)
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -92,6 +92,8 @@ private lemma diagElem_mul_diagElem (a b : Fin 2 → ℕ) :
 /-- For n=1, `heckeGen(0)^k = diagElem(fun _ => p^k)`. -/
 private lemma heckeGen_pow_one (p : ℕ) (hp : 0 < p) (k : ℕ) :
     heckeGen 1 p (0 : Fin 1) ^ k = diagElem (fun _ : Fin 1 ↦ p ^ k) := by
+  -- `heckeGen` is sealed (`public section`, no `@[expose]`), so neither `rw [heckeGen]` nor
+  -- `unfold` sees through it; `heckeGen_def` supplies the equation and this states its target.
   rw [show heckeGen 1 p (0 : Fin 1) = diagElem (fun _ : Fin 1 ↦ p) from by
     rw [heckeGen_def]; exact congrArg diagElem (heckeGenDiag_one_eq_const p)]
   exact diagElem_const_pow 1 p hp k
@@ -101,11 +103,13 @@ private lemma heckeGen_pow_one (p : ℕ) (hp : 0 < p) (k : ℕ) :
 private lemma intCast_mul_diagElem_eq_single {n : ℕ} [NeZero n] (a : Fin n → ℕ) (c : ℤ) :
     (Int.castRingHom (IntegralHeckeRing n)) c * diagElem a =
       HeckeCosetModule.single ℤ (diagCoset a) c := by
+  -- no cast lemma reads an `Int.castRingHom` image as a `zsmul` of `1` in this direction, so
+  -- the equation is stated here and discharged by `zsmul_eq_mul`.
   rw [show (Int.castRingHom (IntegralHeckeRing n)) c = c • (1 : IntegralHeckeRing n) from by
       rw [zsmul_eq_mul, mul_one]; rfl, smul_mul_assoc, one_mul, diagElem_def]
   exact HeckeCosetModule.smul_single_one ℤ (diagCoset a) c
 
-/-- For `n = 1` and `p` prime, the cosets `diagCoset (fun _ => p^k)` are injective in `k`:
+/-- For `n = 1` and any base `1 < p`, the cosets `diagCoset (fun _ => p^k)` are injective in `k`:
 if they coincide for `b 0` and `s 0`, then `b 0 = s 0`. -/
 private lemma T_diag_one_ppow_inj (p : ℕ) (hp : 1 < p) {b s : Fin 1 →₀ ℕ}
     (hb : (diagCoset (n := 1) (fun _ ↦ p ^ b 0) : HeckeCoset (posDetInt 1) (SLnZ 1) (SLnZ 1)) =
@@ -174,15 +178,15 @@ private lemma divChain_two_of_dvd {a b : ℕ} (hab : a ∣ b) :
   isDvdChain_iff.mpr fun i j hij ↦ by
     fin_cases i <;> fin_cases j <;> simp_all
 
-/-- Determinant of an SL_n(ℤ) element embedded in GL_n(ℚ) is 1. -/
+/-- Determinant of an SL_n(ℤ) element embedded in GL_n(ℚ) is 1.
+
+`SpecialLinearGroup.det_mapGL` is the same fact for `GeneralLinearGroup.det`, which is
+`ℚˣ`-valued; every use here needs the `Matrix.det` of the coerced matrix, so this is the
+`Units.val` bridge rather than a second proof. -/
 private lemma det_SLnZ_eq_one {g : GL (Fin 2) ℚ} (hg : g ∈ SLnZ 2) :
     (↑g : Matrix (Fin 2) (Fin 2) ℚ).det = 1 := by
   obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff 2).mp hg
-  -- the entries are integers cast into ℚ, so the determinant is the cast of `det σ = 1`
-  have h : (mapGL ℚ σ : Matrix (Fin 2) (Fin 2) ℚ) = (Int.castRingHom ℚ).mapMatrix σ.val := by
-    simp [mapGL_coe_matrix]
-  rw [h, ← RingHom.map_det]
-  simp
+  exact congrArg Units.val (SpecialLinearGroup.det_mapGL (S := ℚ) σ)
 
 /-- Elements in the same SL_n double coset have the same determinant. -/
 private lemma det_doubleCoset_eq {g₁ g₂ : posDetInt 2}
@@ -262,11 +266,16 @@ private lemma det_rep_T_gen_zero_pow_mul (q : {p : ℕ // p.Prime}) (a₀ b₀ :
   | succ n ih =>
     rw [pow_succ', mul_assoc] at hD'
     set g' := heckeGen 2 q.1 0 ^ n * f
+    -- `heckeGen` and `diagElem` are both sealed, so neither side reduces here; the `_def`
+    -- lemmas bridge them and this states the single-`Finsupp` spelling to rewrite with.
     rw [show heckeGen 2 q.1 0 = HeckeCosetModule.single ℤ (diagCoset (![1, q.1])) 1 from by
         rw [heckeGen_def, diagElem_def]
         exact congrArg (fun a ↦ HeckeCosetModule.single ℤ (diagCoset a) 1)
           (funext fun i ↦ by fin_cases i <;> simp [heckeGenDiag_apply])] at hD'
     obtain ⟨D₂, hD₂_mem, hD₂_ne⟩ := Finset.exists_ne_zero_of_sum_ne_zero (by
+      -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a convolution at a coset
+      -- holds by defeq but matches no `Finsupp` lemma through the wrapper; the expansion is
+      -- stated and closed by the wrapper's own `mul_def`/`single_mul`/`sum_apply` chain.
       rw [show (HeckeCosetModule.single ℤ (diagCoset (![1, q.1])) 1 * g') D' =
           ∑ D₂ ∈ g'.support, g' D₂ *
             (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
@@ -316,22 +325,6 @@ private lemma T_gen_pow_support_qpower (q : {p : ℕ // p.Prime}) (e : Fin 2 →
   have h_result := det_rep_T_gen_zero_pow_mul q (2 * e 1) (e 0) _ D hf_det hD
   rw [hD_eq, prod_rep_T_diag a ha_pos] at h_result
   exact mod_cast h_result
-
-/-- Every coset in the support of `heckeGen(q,0)^a * heckeGen(q,1)^b` has entries
-that are powers of `q` (immediate from `T_gen_pow_support_qpower`). -/
-private lemma T_gen_pow_entries_qpower (q : {p : ℕ // p.Prime})
-    (e : Fin 2 → ℕ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
-    (hD : (heckeGen 2 q.1 0 ^ (e 0) * heckeGen 2 q.1 1 ^ (e 1)) D ≠ 0)
-    (a : Fin 2 → ℕ) (ha : D = diagCoset a) (ha_pos : ∀ i, 0 < a i)
-    (ha_div : IsDvdChain a) :
-    ∀ p : ℕ, p.Prime → p ≠ q.1 → ∀ i, ¬(p ∣ a i) := by
-  obtain ⟨a', rfl, ha'_pos, ha'_div, ha'_det⟩ := T_gen_pow_support_qpower q e D hD
-  have ha_eq := eq_of_diagCoset_eq ha_pos ha'_pos ha_div ha'_div ha.symm
-  subst ha_eq
-  intro p hp hpq i h_dvd
-  have : p ∣ ∏ j, a j := dvd_trans h_dvd (Finset.dvd_prod_of_mem _ (Finset.mem_univ i))
-  rw [ha'_det] at this
-  exact hpq ((Nat.prime_dvd_prime_iff_eq hp q.2).mp (hp.dvd_of_dvd_pow this))
 
 /-- `T_single(diagCoset a, α) * diagElem(c,c) = T_single(diagCoset(a * c), α)`. -/
 private lemma T_single_diag_mul_T_scalar (c : ℕ) (hc : 0 < c)
@@ -509,8 +502,9 @@ private lemma T_ad_one_p_mul_T_ad_one_ppow_eval_leading (p : ℕ) (hp : p.Prime)
       show (![1, p ^ (0 + 1)] : Fin 2 → ℕ) = (![1, p] : Fin 2 → ℕ) from by
         funext i; fin_cases i <;> simp,
       HeckeCosetModule.single_apply, if_pos rfl]
-  · rw [show heckeTDiag 1 p = heckeT ⟨p, hp.pos⟩ from (heckeT_prime p hp).symm,
-      heckeT_prime_mul_heckeTDiag_one_prime_pow p hp n]
+  · rw [← heckeT_prime p hp, heckeT_prime_mul_heckeTDiag_one_prime_pow p hp n]
+    -- `Finsupp.add_apply` holds through the `IntegralHeckeRing` wrapper by defeq but does not
+    -- match syntactically, so the split is stated and closed by that lemma.
     rw [show (heckeTDiag 1 (p ^ (n + 1)) + (if n = 1 then ((p : ℤ) + 1) else (p : ℤ)) •
               heckeTDiag p (p ^ n)) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) =
           heckeTDiag 1 (p ^ (n + 1)) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) +
@@ -518,9 +512,13 @@ private lemma T_ad_one_p_mul_T_ad_one_ppow_eval_leading (p : ℕ) (hp : p.Prime)
               (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) from Finsupp.add_apply _ _ _,
       heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos _) (one_dvd _),
       heckeTDiag_eq_diagElem hp.pos (pow_pos hp.pos _) (dvd_pow_self p hn)]
+    -- `diagElem` is sealed, so its value at its own coset does not reduce here; `diagElem_def`
+    -- with `single_apply` gives it, and this states the result to rewrite with.
     rw [show (diagElem (![1, p ^ (n + 1)] : Fin 2 → ℕ))
           (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 1 from
         by rw [diagElem_def, HeckeCosetModule.single_apply, if_pos rfl]]
+    -- `Finsupp.smul_apply`, same obstruction as the `add_apply` above: true through the
+    -- wrapper by defeq, not syntactically matchable, so the pushed-in form is stated.
     rw [show ((if n = 1 then ((p : ℤ) + 1) else (p : ℤ)) • diagElem (![p, p ^ n] : Fin 2 → ℕ))
           (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) =
         (if n = 1 then ((p : ℤ) + 1) else (p : ℤ)) •
@@ -546,6 +544,8 @@ private lemma T_ad_one_p_mul_supp_ne_leading_eval_zero (p : ℕ) (hp : p.Prime) 
   obtain ⟨i, hi_le, hi_eq⟩ := (Nat.dvd_prime_pow hp).mp (ha_prod ▸ dvd_mul_right _ _)
   have ha1_eq : a 1 = p ^ (n - i) := by
     have h : p ^ i * a 1 = p ^ i * p ^ (n - i) := by
+      -- `i + (n - i) = n` is a truncated-subtraction side condition that needs `hi_le`; no
+      -- rewrite reaches it, so it is stated inline and discharged by `omega`.
       rw [← pow_add, show i + (n - i) = n from by omega, ← ha_prod, hi_eq]
     exact Nat.eq_of_mul_eq_mul_left (pow_pos hp.pos i) h
   have ha_form : a = (![p ^ i, p ^ (n - i)] : Fin 2 → ℕ) := by
@@ -574,6 +574,8 @@ private lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
   classical
   induction a with
   | zero =>
+    -- `![1, 1]` and `fun _ ↦ 1` are extensionally but not syntactically equal, so the
+    -- conversion is stated and proved pointwise before `diagElem_one` can apply.
     rw [pow_zero, pow_zero, show (![1, 1] : Fin 2 → ℕ) = (fun _ : Fin 2 ↦ 1) from by
         funext i; fin_cases i <;> rfl, ← diagElem_one]
     rw [diagElem_def, HeckeCosetModule.single_apply, if_pos rfl]
@@ -584,8 +586,7 @@ private lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
       diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)
     set D_leading : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2) :=
       diagCoset (![1, p ^ n] : Fin 2 → ℕ)
-    rw [show heckeTDiag 1 p = HeckeCosetModule.single ℤ (diagCoset (![1, p] : Fin 2 → ℕ)) 1 from
-        (heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _)).trans (diagElem_def _),
+    rw [heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _), diagElem_def,
       HeckeCosetModule.mul_def, HeckeCosetModule.single_mul]
     -- Evaluate the convolution at `D_target` in the wrapper's own vocabulary: push the
     -- evaluation in with `sum_apply` first, then let `sum_def` expose the `Finset.sum`.
@@ -673,6 +674,8 @@ private lemma T_ad_one_p_pow_mul_scalar_eval_at_one_ppow (p : ℕ) (hp : p.Prime
     ((heckeTDiag 1 p) ^ a₁ * diagElem (fun _ : Fin 2 ↦ p ^ b))
         (diagCoset (![p ^ b, p ^ (a₂ + b)] : Fin 2 → ℕ)) =
     ((heckeTDiag 1 p) ^ a₁) (diagCoset (![1, p ^ a₂] : Fin 2 → ℕ)) := by
+  -- a `![…]` literal does not unify with a pointwise product syntactically, so the
+  -- factorisation is stated and proved entrywise before the shifted-coset lemma can apply.
   rw [show (![p ^ b, p ^ (a₂ + b)] : Fin 2 → ℕ) =
       (![1, p ^ a₂] : Fin 2 → ℕ) * (fun _ : Fin 2 ↦ p ^ b) from by
         funext i; fin_cases i
@@ -689,6 +692,8 @@ private lemma monomial_eval_kronecker (p : ℕ) (hp : p.Prime)
     (heckeGen 2 p 0 ^ a₁ * heckeGen 2 p 1 ^ b₁)
         (diagCoset (primePowDiag 2 p ![b₂, a₂ + b₂])) =
     if a₁ = a₂ ∧ b₁ = b₂ then 1 else 0 := by
+  -- `primePowDiag_apply` is entrywise, so reaching the `![…]` literal takes a `funext`; the
+  -- literal spelling is stated here for the rewrites that follow to match.
   rw [show (primePowDiag 2 p ![b₂, a₂ + b₂] : Fin 2 → ℕ) = (![p ^ b₂, p ^ (a₂ + b₂)] : Fin 2 → ℕ)
       from by funext i; fin_cases i <;> simp [primePowDiag_apply],
     heckeGen_zero_eq_heckeTDiag p hp.pos,
@@ -745,8 +750,9 @@ private lemma evalHom_apply_eq_sum_monomial (p : ℕ) (R : MvPolynomial (Fin 2) 
   -- `eval₂Hom` by `rw`/`unfold` here; `evalHom_def` names the equation and this `change`
   -- takes the resulting term to its `Finsupp` application form.
   change (((R.coeff d : ℤ) : IntegralHeckeRing 2) * (∏ k ∈ d.support, heckeGen 2 p k ^ d k)) D = _
-  rw [show ((R.coeff d : ℤ) : IntegralHeckeRing 2) = (R.coeff d) • (1 : IntegralHeckeRing 2) from
-    (zsmul_one _).symm, smul_mul_assoc, one_mul]
+  rw [← zsmul_one (R.coeff d), smul_mul_assoc, one_mul]
+  -- `Finsupp.smul_apply` again: it holds through the `IntegralHeckeRing` wrapper by defeq but
+  -- does not match syntactically, so the pushed-in form is stated and closed by it.
   rw [show ((R.coeff d) • (∏ k ∈ d.support, heckeGen 2 p k ^ d k : IntegralHeckeRing 2)) D =
     R.coeff d • (∏ k ∈ d.support, heckeGen 2 p k ^ d k : IntegralHeckeRing 2) D from
     Finsupp.smul_apply _ _ _, smul_eq_mul, prod_T_gen_pow_eq_two]
@@ -777,13 +783,18 @@ theorem evalHom_two_injective (p : ℕ) (hp : p.Prime) :
   rw [Finset.sum_congr rfl h_delta, Finset.sum_ite_eq_of_mem' R.support s _ hs_mem] at h_zero
   exact hs_coeff h_zero
 
-/-- Injectivity of `evalHomLocal` follows from injectivity of `evalHom`. -/
+/-- Injectivity of `evalHomLocal` follows from injectivity of `evalHom`.
+
+This is *not* an instance of `RingHom.injective_codRestrict`, even though `evalHomLocal` is
+defined as a `codRestrict`: that lemma's `f`, `s` and `h` are implicit and can only be solved
+by unfolding `evalHomLocal`, which is `public` with no `@[expose]` and therefore opaque to
+this module. Elaborating it here reports `evalHomLocal ↦ 662` under "definitions were not
+unfolded because their definition is not exposed". `evalHomLocal_coe` is the exported
+characteristic lemma that replaces the unfolding, so the argument runs through it. -/
 lemma evalHomLocal_injective (n : ℕ) [NeZero n] (p : ℕ)
     (h_inj : Function.Injective (evalHom n p)) :
     Function.Injective (evalHomLocal n p) := by
   intro P Q hPQ
-  -- `evalHomLocal` is sealed upstream, so the coercion is read off `evalHomLocal_coe`
-  -- rather than by unfolding.
   refine h_inj ?_
   rw [← evalHomLocal_coe n p P, ← evalHomLocal_coe n p Q, hPQ]
 

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -24,7 +24,7 @@ leading elementary-divisor vector, and distinct monomials have distinct leading 
 
 * `HeckeRing.GLn.Inj.evalHom_injective_one`, `HeckeRing.GLn.Inj.evalHom_injective_two`:
   evaluation at the generators is injective for `n = 1` and `n = 2`.
-* `HeckeRing.GLn.R_p_isPolynomialRing_one`, `HeckeRing.GLn.R_p_isPolynomialRing_two`:
+* `HeckeRing.GLn.polynomialRingEquivOne`, `HeckeRing.GLn.polynomialRingEquivTwo`:
   **Shimura, Theorem 3.20** for `n = 1` and `n = 2` — `pLocalSubring ≅ ℤ[X₁, …, Xₙ]`.
 
 ## Implementation notes
@@ -772,7 +772,7 @@ variable (p : ℕ) (hp : p.Prime)
 
 /-- **Shimura, Theorem 3.20 for `n = 1`**: the `p`-local Hecke ring of `GL₁` is the
 polynomial ring `ℤ[X]` on the single generator `T(p)`. -/
-noncomputable def R_p_isPolynomialRing_one :
+noncomputable def polynomialRingEquivOne :
     MvPolynomial (Fin 1) ℤ ≃+* pLocalSubring 1 p :=
   RingEquiv.ofBijective (evalHomLocal 1 p)
     ⟨Inj.evalHomLocal_injective 1 p hp (Inj.evalHom_injective_one p hp),
@@ -781,7 +781,7 @@ noncomputable def R_p_isPolynomialRing_one :
 /-- **Shimura, Theorem 3.20 for `n = 2`**: the `p`-local Hecke ring of `GL₂` is the
 polynomial ring `ℤ[X₁, X₂]` on the generators `T(1, p)` and `T(p, p)`. This is the case the
 classical theory of modular forms uses. -/
-noncomputable def R_p_isPolynomialRing_two :
+noncomputable def polynomialRingEquivTwo :
     MvPolynomial (Fin 2) ℤ ≃+* pLocalSubring 2 p :=
   RingEquiv.ofBijective (evalHomLocal 2 p)
     ⟨Inj.evalHomLocal_injective 2 p hp (Inj.evalHom_injective_two p hp),

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -111,8 +111,7 @@ private lemma T_diag_one_ppow_inj (p : ℕ) (hp : 1 < p) {b s : Fin 1 →₀ ℕ
     (fun _ ↦ Nat.pow_pos hpos) (hdiv b) (hdiv s) hb
   exact Nat.pow_right_injective hp (congr_fun heq 0)
 
-/-- n=1: evalHom is injective. Different monomials map to distinct basis elements,
-    so the images are ℤ-linearly independent. -/
+/-- For `n = 1` and any base `1 < p`, evaluation at the Hecke generator is injective. -/
 theorem evalHom_one_injective (p : ℕ) (hp : 1 < p) : Function.Injective (evalHom 1 p) := by
   intro P Q hPQ
   rw [← sub_eq_zero]
@@ -221,23 +220,23 @@ private lemma det_rep_eq_mul_of_m_ne_zero (D₁ D₂ D' : HeckeCoset (posDetInt 
 
 /-- Determinant tracking: if `f` is supported on cosets of determinant `q^{a₀}`, then
 `heckeGen(q,0)^{b₀} · f` is supported on cosets of determinant `q^{b₀ + a₀}`. -/
-private lemma det_rep_T_gen_zero_pow_mul (q : {p : ℕ // p.Prime}) (a₀ b₀ : ℕ)
+private lemma det_rep_T_gen_zero_pow_mul (q : ℕ) (hq : 0 < q) (a₀ b₀ : ℕ)
     (f : IntegralHeckeRing 2) (D' : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
     (hf_det : ∀ D'', f D'' ≠ 0 →
-      (↑(↑(HeckeCoset.rep D'') : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det = ↑(q.1 ^ a₀ : ℕ))
-    (hD' : (heckeGen 2 q.1 0 ^ b₀ * f) D' ≠ 0) :
+      (↑(↑(HeckeCoset.rep D'') : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det = ↑(q ^ a₀ : ℕ))
+    (hD' : (heckeGen 2 q 0 ^ b₀ * f) D' ≠ 0) :
     (↑(↑(HeckeCoset.rep D') : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
-      ↑(q.1 ^ (b₀ + a₀) : ℕ) := by
+      ↑(q ^ (b₀ + a₀) : ℕ) := by
   induction b₀ generalizing f D' with
   | zero =>
     rw [pow_zero, one_mul] at hD'
     simpa only [Nat.zero_add] using hf_det D' hD'
   | succ n ih =>
     rw [pow_succ', mul_assoc] at hD'
-    set g' := heckeGen 2 q.1 0 ^ n * f
+    set g' := heckeGen 2 q 0 ^ n * f
     -- `heckeGen` and `diagElem` are both sealed, so neither side reduces here; the `_def`
     -- lemmas bridge them and this states the single-`Finsupp` spelling to rewrite with.
-    rw [show heckeGen 2 q.1 0 = HeckeCosetModule.single ℤ (diagCoset (![1, q.1])) 1 from by
+    rw [show heckeGen 2 q 0 = HeckeCosetModule.single ℤ (diagCoset (![1, q])) 1 from by
         rw [heckeGen_def, diagElem_def]
         exact congrArg (fun a ↦ HeckeCosetModule.single ℤ (diagCoset a) 1)
           (funext fun i ↦ by fin_cases i <;> simp [heckeGenDiag_apply])] at hD'
@@ -245,23 +244,23 @@ private lemma det_rep_T_gen_zero_pow_mul (q : {p : ℕ // p.Prime}) (a₀ b₀ :
       -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a convolution at a coset
       -- holds by defeq but matches no `Finsupp` lemma through the wrapper; the expansion is
       -- stated and closed by the wrapper's own `mul_def`/`single_mul`/`sum_apply` chain.
-      rw [show (HeckeCosetModule.single ℤ (diagCoset (![1, q.1])) 1 * g') D' =
+      rw [show (HeckeCosetModule.single ℤ (diagCoset (![1, q])) 1 * g') D' =
           ∑ D₂ ∈ g'.support, g' D₂ *
             (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-            (HeckeCoset.rep (diagCoset (![1, q.1]))) (HeckeCoset.rep D₂)) D' from by
+            (HeckeCoset.rep (diagCoset (![1, q]))) (HeckeCoset.rep D₂)) D' from by
           rw [HeckeCosetModule.mul_def, HeckeCosetModule.single_mul,
             HeckeCosetModule.sum_apply, HeckeCosetModule.sum_def]
           simp only [HeckeCosetModule.smul_apply, one_mul]] at hD'
       exact hD')
     have hm_ne : (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-        (HeckeCoset.rep (diagCoset (![1, q.1])))
+        (HeckeCoset.rep (diagCoset (![1, q])))
         (HeckeCoset.rep D₂)) D' ≠ 0 := fun h ↦ hD₂_ne (by rw [h, mul_zero])
     rw [det_rep_eq_mul_of_m_ne_zero _ _ _ hm_ne,
       -- `![…]` literals that are only extensionally equal do not unify syntactically, so the
       -- intended spelling is stated here for the following rewrite to match.
-      show (↑(↑(HeckeCoset.rep (diagCoset (![1, q.1]))) : GL (Fin 2) ℚ) :
-          Matrix (Fin 2) (Fin 2) ℚ).det = (q.1 : ℚ) from by
-        rw [prod_rep_T_diag (![1, q.1]) (fun i ↦ by fin_cases i <;> simp [q.2.pos])]
+      show (↑(↑(HeckeCoset.rep (diagCoset (![1, q]))) : GL (Fin 2) ℚ) :
+          Matrix (Fin 2) (Fin 2) ℚ).det = (q : ℚ) from by
+        rw [prod_rep_T_diag (![1, q]) (fun i ↦ by fin_cases i <;> simp [hq])]
         simp [Fin.prod_univ_two],
       ih f D₂ hf_det (Finsupp.mem_support_iff.mp hD₂_mem)]
     push_cast; ring
@@ -272,26 +271,26 @@ representative — is `q^(e₀ + 2·e₁)`.
 
 This is what makes the exponent pair recoverable: the determinant pins `e₀ + 2·e₁`, and the
 elementary-divisor order then separates the individual exponents. -/
-private lemma T_gen_pow_support_qpower (q : {p : ℕ // p.Prime}) (e : Fin 2 → ℕ)
+private lemma T_gen_pow_support_qpower (q : ℕ) (hq : 0 < q) (e : Fin 2 → ℕ)
     (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
-    (hD : (heckeGen 2 q.1 0 ^ (e 0) * heckeGen 2 q.1 1 ^ (e 1)) D ≠ 0) :
+    (hD : (heckeGen 2 q 0 ^ (e 0) * heckeGen 2 q 1 ^ (e 1)) D ≠ 0) :
     ∃ a : Fin 2 → ℕ, D = diagCoset a ∧ (∀ i, 0 < a i) ∧ IsDvdChain a ∧
-      (∏ i, a i) = q.1 ^ (e 0 + 2 * e 1) := by
+      (∏ i, a i) = q ^ (e 0 + 2 * e 1) := by
   obtain ⟨a, ha_pos, ha_div, hD_eq⟩ := exists_diagonal_representative D
   refine ⟨a, hD_eq, ha_pos, ha_div, ?_⟩
-  have hf_det : ∀ D'', (heckeGen 2 q.1 1 ^ (e 1)) D'' ≠ 0 →
+  have hf_det : ∀ D'', (heckeGen 2 q 1 ^ (e 1)) D'' ≠ 0 →
       (↑(↑(HeckeCoset.rep D'') : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
-        ↑(q.1 ^ (2 * e 1) : ℕ) := by
+        ↑(q ^ (2 * e 1) : ℕ) := by
     classical
     intro D'' hD''
-    rw [heckeGen_one_eq_heckeTScalar q.1 q.2.pos,
-      HeckeRing.GL2.heckeTScalar_pow q.1 q.2.pos (e 1)] at hD''
-    have h_eq : diagCoset (fun _ : Fin 2 ↦ q.1 ^ (e 1)) = D'' := by
+    rw [heckeGen_one_eq_heckeTScalar q hq,
+      HeckeRing.GL2.heckeTScalar_pow q hq (e 1)] at hD''
+    have h_eq : diagCoset (fun _ : Fin 2 ↦ q ^ (e 1)) = D'' := by
       by_contra h
       exact hD'' (by rw [diagElem_def, HeckeCosetModule.single_apply, if_neg h])
-    rw [← h_eq, prod_rep_T_diag _ (fun i ↦ by fin_cases i <;> simp [pow_pos q.2.pos])]
+    rw [← h_eq, prod_rep_T_diag _ (fun i ↦ by fin_cases i <;> simp [pow_pos hq])]
     push_cast [Fin.prod_univ_two, ← pow_add]; ring_nf
-  have h_result := det_rep_T_gen_zero_pow_mul q (2 * e 1) (e 0) _ D hf_det hD
+  have h_result := det_rep_T_gen_zero_pow_mul q hq (2 * e 1) (e 0) _ D hf_det hD
   rw [hD_eq, prod_rep_T_diag a ha_pos] at h_result
   exact mod_cast h_result
 
@@ -308,6 +307,39 @@ private lemma T_single_diag_mul_T_scalar (c : ℕ) (hc : 0 < c)
   rw [h_single, smul_mul_assoc, diagElem_mul_const 2 a ha_pos c hc, diagElem_def]
   exact HeckeCosetModule.smul_single_one ℤ (diagCoset (a * fun _ ↦ c)) α
 
+/-- **Reduction to the basis for products with a scalar coset.** Both statements below about
+`f * diagElem (fun _ ↦ c)` evaluated at a fixed coset `D` are additive in `f`, so it is enough
+to check them on the `single` basis. This lemma performs that reduction once: the `zero` and
+`add` cases are pure `Finsupp`-through-the-wrapper bookkeeping and carry no content.
+
+The target is packaged as an `F : IntegralHeckeRing 2 →+ ℤ` because additivity of the target is
+exactly what the induction consumes. -/
+private lemma eval_mul_diagElem_const_of_single (c : ℕ)
+    (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)) (F : IntegralHeckeRing 2 →+ ℤ)
+    (hsingle : ∀ (D' : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)) (α : ℤ),
+      (HeckeCosetModule.single ℤ D' α * diagElem (fun _ : Fin 2 ↦ c)) D =
+        F (HeckeCosetModule.single ℤ D' α))
+    (f : IntegralHeckeRing 2) : (f * diagElem (fun _ : Fin 2 ↦ c)) D = F f := by
+  classical
+  induction f using HeckeCosetModule.induction_linear with
+  | h0 =>
+    -- `IntegralHeckeRing` is a `def` over `Finsupp`, so a ring element applied at a coset is
+    -- `Finsupp` application through the wrapper: true by defeq, but nothing matches
+    -- syntactically, so the shape is stated once here rather than at every use.
+    change ((0 : IntegralHeckeRing 2) * diagElem (fun _ : Fin 2 ↦ c)) D = F 0
+    rw [zero_mul, map_zero]; rfl
+  | hadd g h ihg ihh =>
+    set g' : IntegralHeckeRing 2 := g
+    set h' : IntegralHeckeRing 2 := h
+    change ((g' + h') * diagElem (fun _ : Fin 2 ↦ c)) D = F (g' + h')
+    rw [add_mul, HeckeCosetModule.add_apply, map_add, ihg, ihh]
+  | hsingle D' α => exact hsingle D' α
+
+/-- Evaluation at a fixed coset, as an additive map on the Hecke ring. -/
+private noncomputable def evalAddHom (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)) :
+    IntegralHeckeRing 2 →+ ℤ :=
+  AddMonoidHom.mk' (fun f ↦ f D) (fun g h ↦ HeckeCosetModule.add_apply g h D)
+
 /-- Scalar shift identity: for any `f : IntegralHeckeRing 2`, scalar `c > 0`, and positive
 divisibility-chain `b`, evaluating `f * diagElem(c,c)` at `diagCoset(b * c)` equals
 `f(diagCoset b)`. -/
@@ -316,57 +348,26 @@ private lemma T_mul_T_scalar_eval_shifted (c : ℕ) (hc : 0 < c) (f : IntegralHe
     (hb_pos : ∀ i, 0 < b i) (hb_div : IsDvdChain b) :
     (f * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * (fun _ : Fin 2 ↦ c))) = f (diagCoset b) := by
   classical
-  induction f using HeckeCosetModule.induction_linear with
-  | h0 =>
-    -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
-    -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
-    -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
-    change ((0 : IntegralHeckeRing 2) * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) =
-      (0 : IntegralHeckeRing 2) (diagCoset b)
-    rw [zero_mul]; rfl
-  | hadd g h ihg ihh =>
-    set g' : IntegralHeckeRing 2 := g
-    set h' : IntegralHeckeRing 2 := h
-    -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
-    -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
-    -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
-    change ((g' + h') * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) =
-      (g' + h') (diagCoset b)
-    rw [add_mul,
-      -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
-      -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
-      -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
-      show (g' * diagElem (fun _ : Fin 2 ↦ c) + h' * diagElem (fun _ : Fin 2 ↦ c))
-            (diagCoset (b * fun _ ↦ c)) =
-            (g' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) +
-            (h' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) from
-        Finsupp.add_apply _ _ _,
-      -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
-      -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
-      -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
-      show (g' + h') (diagCoset b) = g' (diagCoset b) + h' (diagCoset b) from
-        Finsupp.add_apply _ _ _,
-      ihg, ihh]
-  | hsingle D α =>
-    obtain ⟨a, ha_pos, ha_div, hD_eq⟩ := exists_diagonal_representative D
-    rw [hD_eq, T_single_diag_mul_T_scalar c hc a ha_pos α]
-    rw [HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
-    by_cases hab : a = b
-    · subst hab; rw [if_pos rfl, if_pos rfl]
-    · have h_ne_1 : diagCoset (a * fun _ : Fin 2 ↦ c) ≠ diagCoset (b * fun _ : Fin 2 ↦ c) := by
-        intro heq
-        have h1_eq : a * (fun _ : Fin 2 ↦ c) = b * (fun _ : Fin 2 ↦ c) :=
-          eq_of_diagCoset_eq (fun i ↦ Nat.mul_pos (ha_pos i) hc)
-            (fun i ↦ Nat.mul_pos (hb_pos i) hc) (isDvdChain_mul 2 ha_div (isDvdChain_const 2 c))
-            (isDvdChain_mul 2 hb_div (isDvdChain_const 2 c)) heq
-        apply hab
-        funext i
-        have := congr_fun h1_eq i
-        simp only [Pi.mul_apply] at this
-        exact Nat.eq_of_mul_eq_mul_right hc this
-      have h_ne_2 : diagCoset a ≠ diagCoset b := fun heq ↦ hab
-        (eq_of_diagCoset_eq ha_pos hb_pos ha_div hb_div heq)
-      rw [if_neg h_ne_1, if_neg h_ne_2]
+  refine eval_mul_diagElem_const_of_single c _ (evalAddHom (diagCoset b)) ?_ f
+  intro D α
+  obtain ⟨a, ha_pos, ha_div, hD_eq⟩ := exists_diagonal_representative D
+  rw [hD_eq, T_single_diag_mul_T_scalar c hc a ha_pos α]
+  change HeckeCosetModule.single ℤ (diagCoset (a * fun _ : Fin 2 ↦ c)) α
+      (diagCoset (b * fun _ : Fin 2 ↦ c)) =
+    HeckeCosetModule.single ℤ (diagCoset a) α (diagCoset b)
+  rw [HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
+  by_cases hab : a = b
+  · subst hab; rw [if_pos rfl, if_pos rfl]
+  · have h_ne_1 : diagCoset (a * fun _ : Fin 2 ↦ c) ≠ diagCoset (b * fun _ : Fin 2 ↦ c) := by
+      intro heq
+      have h1_eq : a * (fun _ : Fin 2 ↦ c) = b * (fun _ : Fin 2 ↦ c) :=
+        eq_of_diagCoset_eq (fun i ↦ Nat.mul_pos (ha_pos i) hc)
+          (fun i ↦ Nat.mul_pos (hb_pos i) hc) (isDvdChain_mul 2 ha_div (isDvdChain_const 2 c))
+          (isDvdChain_mul 2 hb_div (isDvdChain_const 2 c)) heq
+      exact hab (funext fun i ↦ Nat.eq_of_mul_eq_mul_right hc (congr_fun h1_eq i))
+    have h_ne_2 : diagCoset a ≠ diagCoset b := fun heq ↦ hab
+      (eq_of_diagCoset_eq ha_pos hb_pos ha_div hb_div heq)
+    rw [if_neg h_ne_1, if_neg h_ne_2]
 
 /-- If `c ∤ d i` for some `i`, the evaluation of `f * diagElem(c,c)` at `diagCoset d` is zero. -/
 private lemma T_mul_T_scalar_eval_zero_of_not_dvd (c : ℕ) (hc : 0 < c) (f : IntegralHeckeRing 2)
@@ -374,89 +375,69 @@ private lemma T_mul_T_scalar_eval_zero_of_not_dvd (c : ℕ) (hc : 0 < c) (f : In
     (hd_pos : ∀ i, 0 < d i) (hd_div : IsDvdChain d) (i₀ : Fin 2) (hi₀ : ¬ c ∣ d i₀) :
     (f * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) = 0 := by
   classical
-  induction f using HeckeCosetModule.induction_linear with
-  | h0 =>
-    -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
-    -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
-    -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
-    change ((0 : IntegralHeckeRing 2) * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) = 0
-    rw [zero_mul]; rfl
-  | hadd g h ihg ihh =>
-    set g' : IntegralHeckeRing 2 := g
-    set h' : IntegralHeckeRing 2 := h
-    -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
-    -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
-    -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
-    change ((g' + h') * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) = 0
-    rw [add_mul,
-      -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
-      -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
-      -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
-      show (g' * diagElem (fun _ : Fin 2 ↦ c) + h' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) =
-            (g' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) +
-            (h' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) from Finsupp.add_apply _ _ _,
-      ihg, ihh, add_zero]
-  | hsingle D α =>
-    obtain ⟨a, ha_pos, ha_div, hD_eq⟩ := exists_diagonal_representative D
-    rw [hD_eq, T_single_diag_mul_T_scalar c hc a ha_pos α]
-    rw [HeckeCosetModule.single_apply]
-    have h_ne : diagCoset (a * fun _ : Fin 2 ↦ c) ≠ diagCoset d := by
-      intro heq
-      have h_eq : a * (fun _ : Fin 2 ↦ c) = d :=
-        eq_of_diagCoset_eq (fun i ↦ Nat.mul_pos (ha_pos i) hc) hd_pos
-          (isDvdChain_mul 2 ha_div (isDvdChain_const 2 c)) hd_div heq
-      apply hi₀
-      have := congr_fun h_eq i₀
-      simp only [Pi.mul_apply] at this
-      exact ⟨a i₀, by linarith [this.symm]⟩
-    rw [if_neg h_ne]
+  refine eval_mul_diagElem_const_of_single c _ 0 ?_ f
+  intro D α
+  obtain ⟨a, ha_pos, ha_div, hD_eq⟩ := exists_diagonal_representative D
+  rw [hD_eq, T_single_diag_mul_T_scalar c hc a ha_pos α, HeckeCosetModule.single_apply]
+  have h_ne : diagCoset (a * fun _ : Fin 2 ↦ c) ≠ diagCoset d := by
+    intro heq
+    have h_eq : a * (fun _ : Fin 2 ↦ c) = d :=
+      eq_of_diagCoset_eq (fun i ↦ Nat.mul_pos (ha_pos i) hc) hd_pos
+        (isDvdChain_mul 2 ha_div (isDvdChain_const 2 c)) hd_div heq
+    refine hi₀ ⟨a i₀, ?_⟩
+    have h := congr_fun h_eq i₀
+    simp only [Pi.mul_apply] at h
+    linarith [h.symm]
+  rw [if_neg h_ne]
+  rfl
 
 /-- For `i ≥ 1`, evaluation of `f * heckeTScalar(p)^i` at `diagCoset ![1, k]` is zero
 (since `p^i ∤ 1`). -/
-private lemma T_mul_T_pp_pow_eval_at_one_zero (p : ℕ) (hp : p.Prime) (i k : ℕ) (hi : 1 ≤ i)
+private lemma T_mul_T_pp_pow_eval_at_one_zero (p : ℕ) (hp : 1 < p) (i k : ℕ) (hi : 1 ≤ i)
     (hk : 0 < k) (f : IntegralHeckeRing 2) :
     (f * heckeTScalar p ^ i) (diagCoset (![1, k] : Fin 2 → ℕ)) = 0 := by
-  rw [HeckeRing.GL2.heckeTScalar_pow p hp.pos i]
-  apply T_mul_T_scalar_eval_zero_of_not_dvd (p^i) (pow_pos hp.pos i) f
+  rw [HeckeRing.GL2.heckeTScalar_pow p (Nat.zero_lt_of_lt hp) i]
+  apply T_mul_T_scalar_eval_zero_of_not_dvd (p^i) (pow_pos (Nat.zero_lt_of_lt hp) i) f
     (![1, k] : Fin 2 → ℕ) (fun idx ↦ by fin_cases idx <;> simp [hk])
     (divChain_two_of_dvd (one_dvd k)) 0
   simp only [Matrix.cons_val_zero]
   intro hdvd
   have hle : p ^ i ≤ 1 := Nat.le_of_dvd Nat.one_pos hdvd
   have hge : p ≤ p ^ i := Nat.le_self_pow (by omega) p
-  have hp2 : 2 ≤ p := hp.two_le
+  have hp2 : 2 ≤ p := hp
   omega
 
 /-- `diagElem ![p^i, p^j] = heckeTDiag(1, p^{j-i}) * heckeTScalar(p)^i` for `i ≤ j` with `p`
 prime. -/
-private lemma T_elem_ppow_factor (p : ℕ) (hp : p.Prime) (i j : ℕ) (hij : i ≤ j) :
+private lemma T_elem_ppow_factor (p : ℕ) (hp : 0 < p) (i j : ℕ) (hij : i ≤ j) :
     diagElem (![p^i, p^j] : Fin 2 → ℕ) = heckeTDiag 1 (p ^ (j - i)) * heckeTScalar p ^ i := by
-  rw [heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos _) (one_dvd _),
-      HeckeRing.GL2.heckeTScalar_pow p hp.pos i]
+  rw [heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp _) (one_dvd _),
+      HeckeRing.GL2.heckeTScalar_pow p hp i]
   have h_ji_pos : ∀ idx : Fin 2, 0 < (![1, p^(j-i)] : Fin 2 → ℕ) idx := by
     intro idx; fin_cases idx
     · simp
-    · simp [pow_pos hp.pos]
-  rw [diagElem_mul_const 2 (![1, p^(j-i)] : Fin 2 → ℕ) h_ji_pos (p^i) (pow_pos hp.pos _)]
+    · simp [pow_pos hp]
+  rw [diagElem_mul_const 2 (![1, p^(j-i)] : Fin 2 → ℕ) h_ji_pos (p^i) (pow_pos hp _)]
   apply congrArg diagElem
   funext idx; fin_cases idx
   · simp [Pi.mul_apply]
   · simp [Pi.mul_apply, ← pow_add]; congr 1; omega
 
 /-- The element `T(p, pⁿ)` does not contribute at `T(1, p^{n+1})` (for `n ≥ 1`). -/
-private lemma T_elem_p_ppow_eval_at_one_ppow_succ_zero (p : ℕ) (hp : p.Prime) {n : ℕ}
+private lemma T_elem_p_ppow_eval_at_one_ppow_succ_zero (p : ℕ) (hp : 1 < p) {n : ℕ}
     (hn : n ≠ 0) :
     (diagElem (![p, p ^ n] : Fin 2 → ℕ)) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 0 := by
   classical
   rw [diagElem_def, HeckeCosetModule.single_apply]
   refine if_neg (fun heq ↦ ?_)
   have h_eq : (![p, p ^ n] : Fin 2 → ℕ) = (![1, p ^ (n + 1)] : Fin 2 → ℕ) :=
-    eq_of_diagCoset_eq (fun i ↦ by fin_cases i <;> simp [hp.pos, pow_pos hp.pos])
-      (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos])
+    eq_of_diagCoset_eq
+      (fun i ↦ by fin_cases i <;> simp [Nat.zero_lt_of_lt hp, pow_pos (Nat.zero_lt_of_lt hp)])
+      (fun i ↦ by fin_cases i <;> simp [pow_pos (Nat.zero_lt_of_lt hp)])
       (divChain_two_of_dvd (dvd_pow_self p hn)) (divChain_two_of_dvd (one_dvd _)) heq
   have := congr_fun h_eq 0
   simp only [Matrix.cons_val_zero] at this
-  have := hp.one_lt; omega
+  have := hp; omega
 
 /-- `(T(1,p) · T(1, pⁿ))` evaluated at the leading coset `T(1, p^{n+1})` equals `1`. -/
 private lemma T_ad_one_p_mul_T_ad_one_ppow_eval_leading (p : ℕ) (hp : p.Prime) (n : ℕ) :
@@ -493,7 +474,7 @@ private lemma T_ad_one_p_mul_T_ad_one_ppow_eval_leading (p : ℕ) (hp : p.Prime)
         (if n = 1 then ((p : ℤ) + 1) else (p : ℤ)) •
           diagElem (![p, p ^ n] : Fin 2 → ℕ) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) from
         Finsupp.smul_apply _ _ _,
-      T_elem_p_ppow_eval_at_one_ppow_succ_zero p hp hn,
+      T_elem_p_ppow_eval_at_one_ppow_succ_zero p hp.one_lt hn,
       smul_zero, add_zero]
 
 /-- A non-leading support element `D₂` of `(T(1,p))ⁿ` contributes `0` to the product
@@ -506,7 +487,7 @@ private lemma T_ad_one_p_mul_supp_ne_leading_eval_zero (p : ℕ) (hp : p.Prime) 
       (HeckeCoset.rep D₂)) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 0 := by
   have hg_eq : (heckeTDiag 1 p) ^ n = (heckeGen 2 p 0) ^ n * (heckeGen 2 p 1) ^ 0 := by
     simp only [pow_zero, mul_one, heckeGen_zero_eq_heckeTDiag p hp.pos]
-  obtain ⟨a, hDa, ha_pos, ha_div, ha_det⟩ := T_gen_pow_support_qpower ⟨p, hp⟩
+  obtain ⟨a, hDa, ha_pos, ha_div, ha_det⟩ := T_gen_pow_support_qpower p hp.pos
       ![n, 0] D₂ (hg_eq ▸ hD₂_ne_zero)
   simp only [Matrix.cons_val_zero, Matrix.cons_val_one, mul_zero, add_zero] at ha_det
   have ha_prod : a 0 * a 1 = p ^ n := Fin.prod_univ_two a ▸ ha_det
@@ -533,8 +514,8 @@ private lemma T_ad_one_p_mul_supp_ne_leading_eval_zero (p : ℕ) (hp : p.Prime) 
   -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
   -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
   change (diagElem (![1, p] : Fin 2 → ℕ) * diagElem (![p^i, p^(n-i)] : Fin 2 → ℕ)) _ = 0
-  rw [T_elem_ppow_factor p hp i (n - i) hi_le_sub, ← mul_assoc]
-  exact T_mul_T_pp_pow_eval_at_one_zero p hp i (p ^ (n + 1)) hi_ge (pow_pos hp.pos _) _
+  rw [T_elem_ppow_factor p hp.pos i (n - i) hi_le_sub, ← mul_assoc]
+  exact T_mul_T_pp_pow_eval_at_one_zero p hp.one_lt i (p ^ (n + 1)) hi_ge (pow_pos hp.pos _) _
 
 /-- Leading coefficient of `T(1,p)^a`: `(heckeTDiag 1 p)^a` evaluated at the leading coset
 `diagCoset ![1, p^a]` equals 1. -/
@@ -626,7 +607,7 @@ private lemma T_ad_one_p_pow_eval_at_one_ppow_of_ne (p : ℕ) (hp : p.Prime) {a�
   by_contra h_ne_zero
   have hg_eq : (heckeTDiag 1 p) ^ a₁ = (heckeGen 2 p 0) ^ a₁ * (heckeGen 2 p 1) ^ 0 := by
     simp only [pow_zero, mul_one, heckeGen_zero_eq_heckeTDiag p hp.pos]
-  obtain ⟨a, hDa, ha_pos, ha_div, ha_det⟩ := T_gen_pow_support_qpower ⟨p, hp⟩
+  obtain ⟨a, hDa, ha_pos, ha_div, ha_det⟩ := T_gen_pow_support_qpower p hp.pos
       ![a₁, 0] (diagCoset (![1, p ^ a₂] : Fin 2 → ℕ)) (hg_eq ▸ h_ne_zero)
   simp only [Matrix.cons_val_zero, Matrix.cons_val_one, mul_zero, add_zero] at ha_det
   have h_a_eq : a = (![1, p ^ a₂] : Fin 2 → ℕ) :=
@@ -639,7 +620,7 @@ private lemma T_ad_one_p_pow_eval_at_one_ppow_of_ne (p : ℕ) (hp : p.Prime) {a�
 
 /-- `(heckeTDiag 1 p)^a₁` times the scalar `T(p^b, p^b)`, evaluated at the shifted leading coset
 `T(p^b, p^{a₂+b})`, equals `(heckeTDiag 1 p)^a₁` evaluated at `T(1, p^{a₂})`. -/
-private lemma T_ad_one_p_pow_mul_scalar_eval_at_one_ppow (p : ℕ) (hp : p.Prime) (a₁ a₂ b : ℕ) :
+private lemma T_ad_one_p_pow_mul_scalar_eval_at_one_ppow (p : ℕ) (hp : 0 < p) (a₁ a₂ b : ℕ) :
     ((heckeTDiag 1 p) ^ a₁ * diagElem (fun _ : Fin 2 ↦ p ^ b))
         (diagCoset (![p ^ b, p ^ (a₂ + b)] : Fin 2 → ℕ)) =
     ((heckeTDiag 1 p) ^ a₁) (diagCoset (![1, p ^ a₂] : Fin 2 → ℕ)) := by
@@ -650,8 +631,8 @@ private lemma T_ad_one_p_pow_mul_scalar_eval_at_one_ppow (p : ℕ) (hp : p.Prime
         funext i; fin_cases i
         · simp [Pi.mul_apply]
         · simp [Pi.mul_apply, pow_add]]
-  exact T_mul_T_scalar_eval_shifted (p ^ b) (pow_pos hp.pos _) _ _
-    (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos]) (divChain_two_of_dvd (one_dvd _))
+  exact T_mul_T_scalar_eval_shifted (p ^ b) (pow_pos hp _) _ _
+    (fun i ↦ by fin_cases i <;> simp [pow_pos hp]) (divChain_two_of_dvd (one_dvd _))
 
 /-- Kronecker delta lemma: evaluating the monomial `heckeGen(p,0)^a₁ * heckeGen(p,1)^b₁` at the
 diagonal coset `T(p^b₂, p^(a₂+b₂))` gives 1 iff `(a₁, b₁) = (a₂, b₂)`, and 0 otherwise,
@@ -670,12 +651,12 @@ private lemma monomial_eval_kronecker (p : ℕ) (hp : p.Prime)
     HeckeRing.GL2.heckeTScalar_pow p hp.pos b₁]
   by_cases hmatch : a₁ = a₂ ∧ b₁ = b₂
   · obtain ⟨ha, hb⟩ := hmatch
-    rw [if_pos ⟨ha, hb⟩, ha, ← hb, T_ad_one_p_pow_mul_scalar_eval_at_one_ppow p hp,
+    rw [if_pos ⟨ha, hb⟩, ha, ← hb, T_ad_one_p_pow_mul_scalar_eval_at_one_ppow p hp.pos,
       T_ad_one_p_pow_eval_leading p hp a₂]
   · rw [if_neg hmatch]
     by_cases hbeq : b₁ = b₂
     · subst hbeq
-      rw [T_ad_one_p_pow_mul_scalar_eval_at_one_ppow p hp,
+      rw [T_ad_one_p_pow_mul_scalar_eval_at_one_ppow p hp.pos,
         T_ad_one_p_pow_eval_at_one_ppow_of_ne p hp (fun heq ↦ hmatch ⟨heq, rfl⟩)]
     · have h_not_dvd : ¬ p ^ b₁ ∣ (![p ^ b₂, p ^ (a₂ + b₂)] : Fin 2 → ℕ) 0 := by
         simp only [Matrix.cons_val_zero, Nat.pow_dvd_pow_iff_le_right hp.one_lt]

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -22,7 +22,7 @@ leading elementary-divisor vector, and distinct monomials have distinct leading 
 
 ## Main results
 
-* `HeckeRing.GLn.Inj.evalHom_injective_one`, `HeckeRing.GLn.Inj.evalHom_injective_two`:
+* `HeckeRing.GLn.Inj.evalHom_one_injective`, `HeckeRing.GLn.Inj.evalHom_two_injective`:
   evaluation at the generators is injective for `n = 1` and `n = 2`.
 * `HeckeRing.GLn.polynomialRingEquivOne`, `HeckeRing.GLn.polynomialRingEquivTwo`:
   **Shimura, Theorem 3.20** for `n = 1` and `n = 2` — `pLocalSubring ≅ ℤ[X₁, …, Xₙ]`.
@@ -86,11 +86,11 @@ private lemma diagElem_mul_diagElem (a b : Fin 2 → ℕ) :
   exact h.trans (by simp)
 
 /-- For n=1, `heckeGen(0)^k = diagElem(fun _ => p^k)`. -/
-private lemma heckeGen_pow_one (p : ℕ) (hp : p.Prime) (k : ℕ) :
+private lemma heckeGen_pow_one (p : ℕ) (hp : 0 < p) (k : ℕ) :
     heckeGen 1 p (0 : Fin 1) ^ k = diagElem (fun _ : Fin 1 ↦ p ^ k) := by
   rw [show heckeGen 1 p (0 : Fin 1) = diagElem (fun _ : Fin 1 ↦ p) from by
     rw [heckeGen_def]; exact congrArg diagElem (heckeGenDiag_one_eq_const p)]
-  exact diagElem_const_pow 1 p hp.pos k
+  exact diagElem_const_pow 1 p hp k
 
 /-- An integer scalar times the basis element `diagElem a` is the single `Finsupp` at
 `diagCoset a` with that coefficient. -/
@@ -103,19 +103,20 @@ private lemma intCast_mul_diagElem_eq_single {n : ℕ} [NeZero n] (a : Fin n →
 
 /-- For `n = 1` and `p` prime, the cosets `diagCoset (fun _ => p^k)` are injective in `k`:
 if they coincide for `b 0` and `s 0`, then `b 0 = s 0`. -/
-private lemma T_diag_one_ppow_inj (p : ℕ) (hp : p.Prime) {b s : Fin 1 →₀ ℕ}
+private lemma T_diag_one_ppow_inj (p : ℕ) (hp : 1 < p) {b s : Fin 1 →₀ ℕ}
     (hb : (diagCoset (n := 1) (fun _ ↦ p ^ b 0) : HeckeCoset (posDetInt 1) (SLnZ 1) (SLnZ 1)) =
       diagCoset (fun _ ↦ p ^ s 0)) : b 0 = s 0 := by
   -- each diagonal here is constant, so the chain condition is `isDvdChain_const`
   have hdiv : ∀ c : Fin 1 →₀ ℕ, IsDvdChain (fun _ : Fin 1 ↦ p ^ c 0) :=
     fun c ↦ isDvdChain_const 1 (p ^ c 0)
-  have heq := eq_of_diagCoset_eq (fun _ ↦ Nat.pow_pos hp.pos)
-    (fun _ ↦ Nat.pow_pos hp.pos) (hdiv b) (hdiv s) hb
-  exact Nat.pow_right_injective hp.two_le (congr_fun heq 0)
+  have hpos : 0 < p := Nat.lt_of_lt_of_le Nat.zero_lt_one hp.le
+  have heq := eq_of_diagCoset_eq (fun _ ↦ Nat.pow_pos hpos)
+    (fun _ ↦ Nat.pow_pos hpos) (hdiv b) (hdiv s) hb
+  exact Nat.pow_right_injective hp (congr_fun heq 0)
 
 /-- n=1: evalHom is injective. Different monomials map to distinct basis elements,
     so the images are ℤ-linearly independent. -/
-theorem evalHom_injective_one (p : ℕ) (hp : p.Prime) : Function.Injective (evalHom 1 p) := by
+theorem evalHom_one_injective (p : ℕ) (hp : 1 < p) : Function.Injective (evalHom 1 p) := by
   intro P Q hPQ
   rw [← sub_eq_zero]
   set R := P - Q
@@ -136,7 +137,7 @@ theorem evalHom_injective_one (p : ℕ) (hp : p.Prime) : Function.Injective (eva
     (∑ x ∈ R.support, HeckeCosetModule.single ℤ
       (diagCoset (n := 1) (fun _ ↦ p ^ x 0)) (MvPolynomial.coeff x R)) :=
     Finset.sum_congr rfl (fun x _ ↦ by
-      rw [heckeGen_pow_one p hp]
+      rw [heckeGen_pow_one p (Nat.lt_of_lt_of_le Nat.zero_lt_one hp.le)]
       exact intCast_mul_diagElem_eq_single (n := 1) (fun _ ↦ p ^ x 0) (R.coeff x))
   change (∑ x ∈ R.support,
       (Int.castRingHom (IntegralHeckeRing 1)) (MvPolynomial.coeff x R) * heckeGen 1 p 0 ^ x 0)
@@ -702,7 +703,7 @@ private lemma evalHom_apply_eq_sum_monomial (p : ℕ) (R : MvPolynomial (Fin 2) 
     Finsupp.smul_apply _ _ _, smul_eq_mul, prod_T_gen_pow_eq_two]
 
 /-- n=2: evalHom is injective. -/
-theorem evalHom_injective_two (p : ℕ) (hp : p.Prime) :
+theorem evalHom_two_injective (p : ℕ) (hp : p.Prime) :
     Function.Injective (evalHom 2 p) := by
   intro P Q hPQ
   rw [← sub_eq_zero]; set R := P - Q
@@ -748,7 +749,7 @@ polynomial ring `ℤ[X]` on the single generator `T(p)`. -/
 noncomputable def polynomialRingEquivOne :
     MvPolynomial (Fin 1) ℤ ≃+* pLocalSubring 1 p :=
   RingEquiv.ofBijective (evalHomLocal 1 p)
-    ⟨Inj.evalHomLocal_injective 1 p (Inj.evalHom_injective_one p hp),
+    ⟨Inj.evalHomLocal_injective 1 p (Inj.evalHom_one_injective p hp.one_lt),
      evalHomLocal_one_surjective p hp.pos⟩
 
 /-- **Shimura, Theorem 3.20 for `n = 2`**: the `p`-local Hecke ring of `GL₂` is the
@@ -757,7 +758,7 @@ classical theory of modular forms uses. -/
 noncomputable def polynomialRingEquivTwo :
     MvPolynomial (Fin 2) ℤ ≃+* pLocalSubring 2 p :=
   RingEquiv.ofBijective (evalHomLocal 2 p)
-    ⟨Inj.evalHomLocal_injective 2 p (Inj.evalHom_injective_two p hp),
+    ⟨Inj.evalHomLocal_injective 2 p (Inj.evalHom_two_injective p hp),
      evalHomLocal_two_surjective p hp⟩
 
 /-- The rank-one presentation isomorphism is the evaluation map. -/

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -133,6 +133,9 @@ theorem evalHom_one_injective (p : ℕ) (hp : 1 < p) : Function.Injective (evalH
   apply hcoeff
   suffices h : ((evalHom 1 p) R).toFun D = MvPolynomial.coeff s R from h ▸ h0
   rw [evalHom_def]
+  -- `evalHom` is sealed (`public section`, no `@[expose]`), so it does not reduce to
+  -- `eval₂Hom` by `rw`/`unfold` here; `evalHom_def` names the equation and this `change`
+  -- takes the resulting term to its `Finsupp` application form.
   change Finsupp.toFun (MvPolynomial.eval₂Hom (Int.castRingHom (IntegralHeckeRing 1))
     (fun k ↦ heckeGen 1 p k) R) D = _
   simp only [MvPolynomial.coe_eval₂Hom, MvPolynomial.eval₂_eq', Fin.prod_univ_one]
@@ -143,6 +146,9 @@ theorem evalHom_one_injective (p : ℕ) (hp : 1 < p) : Function.Injective (evalH
     Finset.sum_congr rfl (fun x _ ↦ by
       rw [heckeGen_pow_one p (Nat.lt_of_lt_of_le Nat.zero_lt_one hp.le)]
       exact intCast_mul_diagElem_eq_single (n := 1) (fun _ ↦ p ^ x 0) (R.coeff x))
+  -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
+  -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
+  -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
   change (∑ x ∈ R.support,
       (Int.castRingHom (IntegralHeckeRing 1)) (MvPolynomial.coeff x R) * heckeGen 1 p 0 ^ x 0)
         D = MvPolynomial.coeff s R
@@ -273,6 +279,8 @@ private lemma det_rep_T_gen_zero_pow_mul (q : {p : ℕ // p.Prime}) (a₀ b₀ :
         (HeckeCoset.rep (diagCoset (![1, q.1])))
         (HeckeCoset.rep D₂)) D' ≠ 0 := fun h ↦ hD₂_ne (by rw [h, mul_zero])
     rw [det_rep_eq_mul_of_m_ne_zero _ _ _ hm_ne,
+      -- `![…]` literals that are only extensionally equal do not unify syntactically, so the
+      -- intended spelling is stated here for the following rewrite to match.
       show (↑(↑(HeckeCoset.rep (diagCoset (![1, q.1]))) : GL (Fin 2) ℚ) :
           Matrix (Fin 2) (Fin 2) ℚ).det = (q.1 : ℚ) from by
         rw [prod_rep_T_diag (![1, q.1]) (fun i ↦ by fin_cases i <;> simp [q.2.pos])]
@@ -348,20 +356,32 @@ private lemma T_mul_T_scalar_eval_shifted (c : ℕ) (hc : 0 < c) (f : IntegralHe
   classical
   induction f using HeckeCosetModule.induction_linear with
   | h0 =>
+    -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
+    -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
+    -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
     change ((0 : IntegralHeckeRing 2) * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) =
       (0 : IntegralHeckeRing 2) (diagCoset b)
     rw [zero_mul]; rfl
   | hadd g h ihg ihh =>
     set g' : IntegralHeckeRing 2 := g
     set h' : IntegralHeckeRing 2 := h
+    -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
+    -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
+    -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
     change ((g' + h') * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) =
       (g' + h') (diagCoset b)
     rw [add_mul,
+      -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
+      -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
+      -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
       show (g' * diagElem (fun _ : Fin 2 ↦ c) + h' * diagElem (fun _ : Fin 2 ↦ c))
             (diagCoset (b * fun _ ↦ c)) =
             (g' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) +
             (h' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) from
         Finsupp.add_apply _ _ _,
+      -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
+      -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
+      -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
       show (g' + h') (diagCoset b) = g' (diagCoset b) + h' (diagCoset b) from
         Finsupp.add_apply _ _ _,
       ihg, ihh]
@@ -394,13 +414,22 @@ private lemma T_mul_T_scalar_eval_zero_of_not_dvd (c : ℕ) (hc : 0 < c) (f : In
   classical
   induction f using HeckeCosetModule.induction_linear with
   | h0 =>
+    -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
+    -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
+    -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
     change ((0 : IntegralHeckeRing 2) * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) = 0
     rw [zero_mul]; rfl
   | hadd g h ihg ihh =>
     set g' : IntegralHeckeRing 2 := g
     set h' : IntegralHeckeRing 2 := h
+    -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
+    -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
+    -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
     change ((g' + h') * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) = 0
     rw [add_mul,
+      -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
+      -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
+      -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
       show (g' * diagElem (fun _ : Fin 2 ↦ c) + h' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) =
             (g' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) +
             (h' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) from Finsupp.add_apply _ _ _,
@@ -475,6 +504,8 @@ private lemma T_ad_one_p_mul_T_ad_one_ppow_eval_leading (p : ℕ) (hp : p.Prime)
   · subst hn
     rw [pow_zero, heckeTDiag_one_one, mul_one,
       heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _), diagElem_def,
+      -- `![…]` literals that are only extensionally equal do not unify syntactically, so the
+      -- intended spelling is stated here for the following rewrite to match.
       show (![1, p ^ (0 + 1)] : Fin 2 → ℕ) = (![1, p] : Fin 2 → ℕ) from by
         funext i; fin_cases i <;> simp,
       HeckeCosetModule.single_apply, if_pos rfl]
@@ -529,6 +560,9 @@ private lemma T_ad_one_p_mul_supp_ne_leading_eval_zero (p : ℕ) (hp : p.Prime) 
     have h_div := ha_form ▸ isDvdChain_iff.mp ha_div (by decide : (0 : Fin 2) ≤ 1)
     exact (Nat.pow_dvd_pow_iff_le_right hp.one_lt).mp h_div
   rw [hDa, ha_form, ← diagElem_mul_diagElem]
+  -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
+  -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
+  -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
   change (diagElem (![1, p] : Fin 2 → ℕ) * diagElem (![p^i, p^(n-i)] : Fin 2 → ℕ)) _ = 0
   rw [T_elem_ppow_factor p hp i (n - i) hi_le_sub, ← mul_assoc]
   exact T_mul_T_pp_pow_eval_at_one_zero p hp i (p ^ (n + 1)) hi_ge (pow_pos hp.pos _) _
@@ -595,6 +629,8 @@ private lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
       rw [hs, ih, one_mul, ← diagElem_mul_diagElem]
       rw [show diagElem (![1, p] : Fin 2 → ℕ) = heckeTDiag 1 p from
           (heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _)).symm,
+        -- `![…]` literals that are only extensionally equal do not unify syntactically, so the
+        -- intended spelling is stated here for the following rewrite to match.
         show diagElem (![1, p ^ n] : Fin 2 → ℕ) = heckeTDiag 1 (p ^ n) from
           (heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos n) (one_dvd _)).symm]
       exact T_ad_one_p_mul_T_ad_one_ppow_eval_leading p hp n
@@ -689,9 +725,15 @@ private lemma evalHom_apply_eq_sum_monomial (p : ℕ) (R : MvPolynomial (Fin 2) 
     (evalHom 2 p R) D =
     ∑ d ∈ R.support, R.coeff d * (heckeGen 2 p 0 ^ (d 0) * heckeGen 2 p 1 ^ (d 1)) D := by
   rw [evalHom_def]
+  -- `evalHom` is sealed (`public section`, no `@[expose]`), so it does not reduce to
+  -- `eval₂Hom` by `rw`/`unfold` here; `evalHom_def` names the equation and this `change`
+  -- takes the resulting term to its `Finsupp` application form.
   change (MvPolynomial.eval₂ (Int.castRingHom (IntegralHeckeRing 2))
     (fun k : Fin 2 ↦ heckeGen 2 p k) R) D = _
   rw [MvPolynomial.eval₂_eq]
+  -- `evalHom` is sealed (`public section`, no `@[expose]`), so it does not reduce to
+  -- `eval₂Hom` by `rw`/`unfold` here; `evalHom_def` names the equation and this `change`
+  -- takes the resulting term to its `Finsupp` application form.
   change (∑ d ∈ R.support, (Int.castRingHom (IntegralHeckeRing 2)) (MvPolynomial.coeff d R) *
     ∏ i ∈ d.support, heckeGen 2 p i ^ d i) D = _
   rw [show (∑ d ∈ R.support, (Int.castRingHom (IntegralHeckeRing 2)) (MvPolynomial.coeff d R) *
@@ -699,6 +741,9 @@ private lemma evalHom_apply_eq_sum_monomial (p : ℕ) (R : MvPolynomial (Fin 2) 
       ∑ d ∈ R.support, ((Int.castRingHom (IntegralHeckeRing 2)) (MvPolynomial.coeff d R) *
         ∏ i ∈ d.support, heckeGen 2 p i ^ d i) D from Finset.sum_apply' _]
   refine Finset.sum_congr rfl (fun d _ ↦ ?_)
+  -- `evalHom` is sealed (`public section`, no `@[expose]`), so it does not reduce to
+  -- `eval₂Hom` by `rw`/`unfold` here; `evalHom_def` names the equation and this `change`
+  -- takes the resulting term to its `Finsupp` application form.
   change (((R.coeff d : ℤ) : IntegralHeckeRing 2) * (∏ k ∈ d.support, heckeGen 2 p k ^ d k)) D = _
   rw [show ((R.coeff d : ℤ) : IntegralHeckeRing 2) = (R.coeff d) • (1 : IntegralHeckeRing 2) from
     (zsmul_one _).symm, smul_mul_assoc, one_mul]

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -164,7 +164,7 @@ private lemma divChain_two_of_dvd {a b : ℕ} (hab : a ∣ b) :
     fin_cases i <;> fin_cases j <;> simp_all
 
 /-- Determinant of an SL_n(ℤ) element embedded in GL_n(ℚ) is 1. -/
-lemma det_SLnZ_eq_one {g : GL (Fin 2) ℚ} (hg : g ∈ SLnZ 2) :
+private lemma det_SLnZ_eq_one {g : GL (Fin 2) ℚ} (hg : g ∈ SLnZ 2) :
     (↑g : Matrix (Fin 2) (Fin 2) ℚ).det = 1 := by
   obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff 2).mp hg
   -- the entries are integers cast into ℚ, so the determinant is the cast of `det σ = 1`
@@ -174,7 +174,7 @@ lemma det_SLnZ_eq_one {g : GL (Fin 2) ℚ} (hg : g ∈ SLnZ 2) :
   simp
 
 /-- Elements in the same SL_n double coset have the same determinant. -/
-lemma det_doubleCoset_eq {g₁ g₂ : posDetInt 2}
+private lemma det_doubleCoset_eq {g₁ g₂ : posDetInt 2}
     (h : HeckeCoset.mk (SLnZ 2) (SLnZ 2) g₁ = HeckeCoset.mk (SLnZ 2) (SLnZ 2) g₂) :
     (↑(↑g₁ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
       (↑(↑g₂ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det := by
@@ -190,7 +190,7 @@ lemma det_doubleCoset_eq {g₁ g₂ : posDetInt 2}
   exact this
 
 /-- The diagonal product of rep(diagCoset a) equals ∏ a. -/
-lemma prod_rep_T_diag (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i) :
+private lemma prod_rep_T_diag (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i) :
     (↑(↑(HeckeCoset.rep (diagCoset a)) : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
       ∏ i, (a i : ℚ) := by
   -- the representative and the explicit diagonal matrix lie in the same double coset
@@ -200,7 +200,7 @@ lemma prod_rep_T_diag (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i) :
   exact (det_doubleCoset_eq h_eq).trans (natDiagGL_det 2 a ha)
 
 /-- Every coset in the support of a mulMap output has determinant = det(g₁) * det(g₂). -/
-lemma det_mulMap_eq (g₁ g₂ : posDetInt 2)
+private lemma det_mulMap_eq (g₁ g₂ : posDetInt 2)
     (p : DecompQuotient (SLnZ 2) (SLnZ 2) (g₁ : GL (Fin 2) ℚ) ×
       DecompQuotient (SLnZ 2) (SLnZ 2) (g₂ : GL (Fin 2) ℚ)) :
     (↑(↑(HeckeCoset.rep (HeckeCoset.mulMap (SLnZ 2) (SLnZ 2) (SLnZ 2) g₁ g₂ p)) : GL (Fin 2) ℚ) :
@@ -319,32 +319,6 @@ lemma T_gen_pow_entries_qpower (q : {p : ℕ // p.Prime})
   have : p ∣ ∏ j, a j := dvd_trans h_dvd (Finset.dvd_prod_of_mem _ (Finset.mem_univ i))
   rw [ha'_det] at this
   exact hpq ((Nat.prime_dvd_prime_iff_eq hp q.2).mp (hp.dvd_of_dvd_pow this))
-
-/-- If `(f * g)(D) ≠ 0` in the Hecke ring, there exist `D₁ ∈ supp(f)` and `D₂ ∈ supp(g)`
-with `D ∈ mulSupport(rep D₁, rep D₂)`. -/
-lemma support_mul_exists (f g : IntegralHeckeRing 2)
-    (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
-    (hD : (f * g) D ≠ 0) :
-    ∃ D₁ D₂, f D₁ ≠ 0 ∧ g D₂ ≠ 0 ∧
-      D ∈ (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-        (HeckeCoset.rep D₁) (HeckeCoset.rep D₂)).support := by
-  -- `HeckeCosetModule.mul` is sealed, so unfold it through its API rather than by defeq.
-  -- The evaluation lemmas have to be applied by `rw`, outermost sum first: `simp only` cannot
-  -- match `sum_apply` through the wrapper's `FunLike` coercion, so it silently does nothing.
-  have h := hD
-  rw [HeckeCosetModule.mul_def, HeckeCosetModule.mul_eq_sum, HeckeCosetModule.sum_apply,
-    HeckeCosetModule.sum_def] at h
-  obtain ⟨D₁, hD₁_mem, h₁⟩ := Finset.exists_ne_zero_of_sum_ne_zero h
-  rw [HeckeCosetModule.sum_apply, HeckeCosetModule.sum_def] at h₁
-  obtain ⟨D₂, hD₂_mem, h₂⟩ := Finset.exists_ne_zero_of_sum_ne_zero h₁
-  rw [HeckeCosetModule.smul_apply, HeckeCosetModule.smul_apply] at h₂
-  have hfD₁ := Finsupp.mem_support_iff.mp hD₁_mem
-  have hgD₂ := Finsupp.mem_support_iff.mp hD₂_mem
-  have hm_ne : (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-      (HeckeCoset.rep D₁) (HeckeCoset.rep D₂)) D ≠ 0 := by
-    intro h; exact h₂ (by rw [h, mul_zero, mul_zero])
-  refine ⟨D₁, D₂, hfD₁, hgD₂, ?_⟩
-  exact HeckeCosetModule.mem_support_iff.mpr hm_ne
 
 /-- `T_single(diagCoset a, α) * diagElem(c,c) = T_single(diagCoset(a * c), α)`. -/
 lemma T_single_diag_mul_T_scalar (c : ℕ) (hc : 0 < c)

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -281,7 +281,7 @@ representative — is `q^(e₀ + 2·e₁)`.
 
 This is what makes the exponent pair recoverable: the determinant pins `e₀ + 2·e₁`, and the
 elementary-divisor order then separates the individual exponents. -/
-lemma T_gen_pow_support_qpower (q : {p : ℕ // p.Prime}) (e : Fin 2 → ℕ)
+private lemma T_gen_pow_support_qpower (q : {p : ℕ // p.Prime}) (e : Fin 2 → ℕ)
     (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
     (hD : (heckeGen 2 q.1 0 ^ (e 0) * heckeGen 2 q.1 1 ^ (e 1)) D ≠ 0) :
     ∃ a : Fin 2 → ℕ, D = diagCoset a ∧ (∀ i, 0 < a i) ∧ IsDvdChain a ∧
@@ -306,7 +306,7 @@ lemma T_gen_pow_support_qpower (q : {p : ℕ // p.Prime}) (e : Fin 2 → ℕ)
 
 /-- Every coset in the support of `heckeGen(q,0)^a * heckeGen(q,1)^b` has entries
 that are powers of `q` (immediate from `T_gen_pow_support_qpower`). -/
-lemma T_gen_pow_entries_qpower (q : {p : ℕ // p.Prime})
+private lemma T_gen_pow_entries_qpower (q : {p : ℕ // p.Prime})
     (e : Fin 2 → ℕ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
     (hD : (heckeGen 2 q.1 0 ^ (e 0) * heckeGen 2 q.1 1 ^ (e 1)) D ≠ 0)
     (a : Fin 2 → ℕ) (ha : D = diagCoset a) (ha_pos : ∀ i, 0 < a i)
@@ -321,7 +321,7 @@ lemma T_gen_pow_entries_qpower (q : {p : ℕ // p.Prime})
   exact hpq ((Nat.prime_dvd_prime_iff_eq hp q.2).mp (hp.dvd_of_dvd_pow this))
 
 /-- `T_single(diagCoset a, α) * diagElem(c,c) = T_single(diagCoset(a * c), α)`. -/
-lemma T_single_diag_mul_T_scalar (c : ℕ) (hc : 0 < c)
+private lemma T_single_diag_mul_T_scalar (c : ℕ) (hc : 0 < c)
     (a : Fin 2 → ℕ) (ha_pos : ∀ i, 0 < a i) (α : ℤ) :
     HeckeCosetModule.single ℤ (diagCoset a) α * diagElem (fun _ : Fin 2 ↦ c) =
     HeckeCosetModule.single ℤ (diagCoset (a * (fun _ : Fin 2 ↦ c))) α := by
@@ -336,7 +336,8 @@ lemma T_single_diag_mul_T_scalar (c : ℕ) (hc : 0 < c)
 /-- Scalar shift identity: for any `f : IntegralHeckeRing 2`, scalar `c > 0`, and positive
 divisibility-chain `b`, evaluating `f * diagElem(c,c)` at `diagCoset(b * c)` equals
 `f(diagCoset b)`. -/
-lemma T_mul_T_scalar_eval_shifted (c : ℕ) (hc : 0 < c) (f : IntegralHeckeRing 2) (b : Fin 2 → ℕ)
+private lemma T_mul_T_scalar_eval_shifted (c : ℕ) (hc : 0 < c) (f : IntegralHeckeRing 2)
+    (b : Fin 2 → ℕ)
     (hb_pos : ∀ i, 0 < b i) (hb_div : IsDvdChain b) :
     (f * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * (fun _ : Fin 2 ↦ c))) = f (diagCoset b) := by
   classical
@@ -381,7 +382,7 @@ lemma T_mul_T_scalar_eval_shifted (c : ℕ) (hc : 0 < c) (f : IntegralHeckeRing 
       rw [if_neg h_ne_1, if_neg h_ne_2]
 
 /-- If `c ∤ d i` for some `i`, the evaluation of `f * diagElem(c,c)` at `diagCoset d` is zero. -/
-lemma T_mul_T_scalar_eval_zero_of_not_dvd (c : ℕ) (hc : 0 < c) (f : IntegralHeckeRing 2)
+private lemma T_mul_T_scalar_eval_zero_of_not_dvd (c : ℕ) (hc : 0 < c) (f : IntegralHeckeRing 2)
     (d : Fin 2 → ℕ)
     (hd_pos : ∀ i, 0 < d i) (hd_div : IsDvdChain d) (i₀ : Fin 2) (hi₀ : ¬ c ∣ d i₀) :
     (f * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) = 0 := by
@@ -416,7 +417,7 @@ lemma T_mul_T_scalar_eval_zero_of_not_dvd (c : ℕ) (hc : 0 < c) (f : IntegralHe
 
 /-- For `i ≥ 1`, evaluation of `f * heckeTScalar(p)^i` at `diagCoset ![1, k]` is zero
 (since `p^i ∤ 1`). -/
-lemma T_mul_T_pp_pow_eval_at_one_zero (p : ℕ) (hp : p.Prime) (i k : ℕ) (hi : 1 ≤ i)
+private lemma T_mul_T_pp_pow_eval_at_one_zero (p : ℕ) (hp : p.Prime) (i k : ℕ) (hi : 1 ≤ i)
     (hk : 0 < k) (f : IntegralHeckeRing 2) :
     (f * heckeTScalar p ^ i) (diagCoset (![1, k] : Fin 2 → ℕ)) = 0 := by
   rw [HeckeRing.GL2.heckeTScalar_pow p hp.pos i]
@@ -432,7 +433,7 @@ lemma T_mul_T_pp_pow_eval_at_one_zero (p : ℕ) (hp : p.Prime) (i k : ℕ) (hi :
 
 /-- `diagElem ![p^i, p^j] = heckeTDiag(1, p^{j-i}) * heckeTScalar(p)^i` for `i ≤ j` with `p`
 prime. -/
-lemma T_elem_ppow_factor (p : ℕ) (hp : p.Prime) (i j : ℕ) (hij : i ≤ j) :
+private lemma T_elem_ppow_factor (p : ℕ) (hp : p.Prime) (i j : ℕ) (hij : i ≤ j) :
     diagElem (![p^i, p^j] : Fin 2 → ℕ) = heckeTDiag 1 (p ^ (j - i)) * heckeTScalar p ^ i := by
   rw [heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos _) (one_dvd _),
       HeckeRing.GL2.heckeTScalar_pow p hp.pos i]
@@ -529,7 +530,7 @@ private lemma T_ad_one_p_mul_supp_ne_leading_eval_zero (p : ℕ) (hp : p.Prime) 
 
 /-- Leading coefficient of `T(1,p)^a`: `(heckeTDiag 1 p)^a` evaluated at the leading coset
 `diagCoset ![1, p^a]` equals 1. -/
-lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
+private lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
     ((heckeTDiag 1 p) ^ a) (diagCoset (![1, p ^ a] : Fin 2 → ℕ)) = 1 := by
   classical
   induction a with
@@ -642,7 +643,7 @@ private lemma T_ad_one_p_pow_mul_scalar_eval_at_one_ppow (p : ℕ) (hp : p.Prime
 /-- Kronecker delta lemma: evaluating the monomial `heckeGen(p,0)^a₁ * heckeGen(p,1)^b₁` at the
 diagonal coset `T(p^b₂, p^(a₂+b₂))` gives 1 iff `(a₁, b₁) = (a₂, b₂)`, and 0 otherwise,
 under the hypothesis `b₂ ≤ b₁`. -/
-lemma monomial_eval_kronecker (p : ℕ) (hp : p.Prime)
+private lemma monomial_eval_kronecker (p : ℕ) (hp : p.Prime)
     (a₁ b₁ a₂ b₂ : ℕ) (h : b₂ ≤ b₁) :
     (heckeGen 2 p 0 ^ a₁ * heckeGen 2 p 1 ^ b₁)
         (diagCoset (primePowDiag 2 p ![b₂, a₂ + b₂])) =
@@ -758,5 +759,13 @@ noncomputable def polynomialRingEquivTwo :
   RingEquiv.ofBijective (evalHomLocal 2 p)
     ⟨Inj.evalHomLocal_injective 2 p (Inj.evalHom_injective_two p hp),
      evalHomLocal_two_surjective p hp⟩
+
+/-- The rank-one presentation isomorphism is the evaluation map. -/
+@[simp] lemma polynomialRingEquivOne_apply (f : MvPolynomial (Fin 1) ℤ) :
+    polynomialRingEquivOne p hp f = evalHomLocal 1 p f := (rfl)
+
+/-- The rank-two presentation isomorphism is the evaluation map. -/
+@[simp] lemma polynomialRingEquivTwo_apply (f : MvPolynomial (Fin 2) ℤ) :
+    polynomialRingEquivTwo p hp f = evalHomLocal 2 p f := (rfl)
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -1,0 +1,790 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GLn.PolynomialRing.Basic
+
+@[expose] public section
+
+/-!
+# `pLocalSubring` is a polynomial ring for `n = 1, 2`
+
+The injectivity half of **Shimura's Theorem 3.20** and the resulting isomorphism
+`ℤ[X₁, …, Xₙ] ≃+* pLocalSubring`, for `n = 1` and `n = 2`. The generators and the surjectivity half
+are in `PolynomialRing/Basic.lean`.
+
+Injectivity is proved by a determinant/leading-term argument: the determinant of a double
+coset representative is multiplicative, so a monomial in the generators has a predictable
+leading elementary-divisor vector, and distinct monomials have distinct leading terms.
+
+## Main results
+
+* `HeckeRing.GLn.Inj.evalHom_injective_one`, `HeckeRing.GLn.Inj.evalHom_injective_two`:
+  evaluation at the generators is injective for `n = 1` and `n = 2`.
+* `HeckeRing.GLn.R_p_isPolynomialRing_one`, `HeckeRing.GLn.R_p_isPolynomialRing_two`:
+  **Shimura, Theorem 3.20** for `n = 1` and `n = 2` — `pLocalSubring ≅ ℤ[X₁, …, Xₙ]`.
+
+## Implementation notes
+
+The source states Theorem 3.20 at general `n`, dispatching on `n = 1` and `n = 2` and
+leaving the remaining case as a gap. Here the two proved cases are stated directly, so
+nothing rests on an unformalised step.
+
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GLn/PolynomialRing.lean`](https://github.com/CBirkbeck/AINTLIB),
+Chris Birkbeck), the `Inj` section.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.2, Theorem 3.20.
+-/
+
+open Matrix Subgroup.Commensurable Pointwise HeckeRing DoubleCoset Matrix.SpecialLinearGroup
+
+open scoped Pointwise
+
+namespace HeckeRing.GLn.Inj
+
+open HeckeRing.GLn HeckeRing.GL2
+
+/-- The `CommSemiring` structure this module needs on `IntegralHeckeRing n`, rebuilt locally
+from `HeckeCosetModule.instSemiringHeckeRing` and `HeckeCosetModule.mul_comm_of_antiInvolution`.
+
+`PolynomialRing/Basic.lean` carries the same reconstruction, but as a `local instance`, which
+does not cross the module boundary; and `commSemiringIntegralHeckeRing` is a sealed `def`, so
+registering it for typeclass search does not make its body reduce to the ambient
+`NonAssocSemiring`. Writing the structure here makes it transparent exactly where this file
+needs it, leaving the upstream definitions sealed for every other consumer. -/
+noncomputable local instance commSemiringIntegralHeckeRingLocal (n : ℕ) [NeZero n] :
+    CommSemiring (IntegralHeckeRing n) :=
+  { (HeckeCosetModule.instSemiringHeckeRing ℤ : Semiring (IntegralHeckeRing n)) with
+    mul_comm := HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution n)
+      (transposeAntiInvolution_onHeckeCoset_eq_self n) }
+
+/-- The product of two diagonal basis elements, unfolded: it is the structure-constant family
+of their representatives. The `b₁ = b₂ = 1` case of `HeckeCosetModule.single_mul`.
+
+Kept here rather than beside either parent. It needs `diagElem`, from
+`GLn/DiagonalCosets.lean`, *and* `HeckeCosetModule.single_mul`, from the abstract Hecke-ring
+layer; neither of those files can see the other's contents, and this is the first module
+downstream of both. Moving it either way would mean widening a core file's imports for a
+single lemma. -/
+private lemma diagElem_mul_diagElem (a b : Fin 2 → ℕ) :
+    diagElem a * diagElem b =
+      HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+        (diagCoset a).rep (diagCoset b).rep := by
+  rw [diagElem_def, diagElem_def, HeckeCosetModule.mul_def, HeckeCosetModule.single_mul]
+  -- `rw` cannot match a `Finsupp` lemma through the `HeckeCosetModule` wrapper, so the
+  -- summation equation is supplied as a term
+  have h := HeckeCosetModule.sum_single_index (R := ℤ) (D := diagCoset b) (b := (1 : ℤ))
+    (F := fun D₂ b₂ ↦ (1 : ℤ) • b₂ • HeckeCosetModule.structureConstants ℤ (SLnZ 2)
+      (SLnZ 2) (SLnZ 2) (diagCoset a).rep D₂.rep) (by simp)
+  exact h.trans (by simp)
+
+/-- For n=1, `heckeGen(0)^k = diagElem(fun _ => p^k)`. -/
+private lemma heckeGen_pow_one (p : ℕ) (hp : p.Prime) (k : ℕ) :
+    heckeGen 1 p (0 : Fin 1) ^ k = diagElem (fun _ : Fin 1 ↦ p ^ k) := by
+  rw [show heckeGen 1 p (0 : Fin 1) = diagElem (fun _ : Fin 1 ↦ p) from by
+    rw [heckeGen_def]; exact congrArg diagElem (heckeGenDiag_one_eq_const p)]
+  exact diagElem_const_pow 1 p hp.pos k
+
+/-- An integer scalar times the basis element `diagElem a` is the single `Finsupp` at
+`diagCoset a` with that coefficient. -/
+private lemma intCast_mul_diagElem_eq_single {n : ℕ} [NeZero n] (a : Fin n → ℕ) (c : ℤ) :
+    (Int.castRingHom (IntegralHeckeRing n)) c * diagElem a =
+      HeckeCosetModule.single ℤ (diagCoset a) c := by
+  rw [show (Int.castRingHom (IntegralHeckeRing n)) c = c • (1 : IntegralHeckeRing n) from by
+      rw [zsmul_eq_mul, mul_one]; rfl, smul_mul_assoc, one_mul, diagElem_def]
+  exact HeckeCosetModule.smul_single_one ℤ (diagCoset a) c
+
+/-- For `n = 1` and `p` prime, the cosets `diagCoset (fun _ => p^k)` are injective in `k`:
+if they coincide for `b 0` and `s 0`, then `b 0 = s 0`. -/
+private lemma T_diag_one_ppow_inj (p : ℕ) (hp : p.Prime) {b s : Fin 1 →₀ ℕ}
+    (hb : (diagCoset (n := 1) (fun _ ↦ p ^ b 0) : HeckeCoset (posDetInt 1) (SLnZ 1) (SLnZ 1)) =
+      diagCoset (fun _ ↦ p ^ s 0)) : b 0 = s 0 := by
+  -- each diagonal here is constant, so the chain condition is `isDvdChain_const`
+  have hdiv : ∀ c : Fin 1 →₀ ℕ, IsDvdChain (fun _ : Fin 1 ↦ p ^ c 0) :=
+    fun c ↦ isDvdChain_const 1 (p ^ c 0)
+  have heq := eq_of_diagCoset_eq (fun _ ↦ Nat.pow_pos hp.pos)
+    (fun _ ↦ Nat.pow_pos hp.pos) (hdiv b) (hdiv s) hb
+  exact Nat.pow_right_injective hp.two_le (congr_fun heq 0)
+
+/-- n=1: evalHom is injective. Different monomials map to distinct basis elements,
+    so the images are ℤ-linearly independent. -/
+theorem evalHom_injective_one (p : ℕ) (hp : p.Prime) : Function.Injective (evalHom 1 p) := by
+  intro P Q hPQ
+  rw [← sub_eq_zero]
+  set R := P - Q
+  have hR : evalHom 1 p R = 0 := by simp [R, map_sub, hPQ]
+  by_contra hne
+  obtain ⟨s, hs⟩ := MvPolynomial.support_nonempty.mpr hne
+  have hcoeff : R.coeff s ≠ 0 := MvPolynomial.mem_support_iff.mp hs
+  set D := diagCoset (n := 1) (fun _ ↦ p ^ (s 0))
+  have h0 : (evalHom 1 p R).toFun D = 0 := by rw [hR]; rfl
+  apply hcoeff
+  suffices h : ((evalHom 1 p) R).toFun D = MvPolynomial.coeff s R from h ▸ h0
+  rw [evalHom_def]
+  change Finsupp.toFun (MvPolynomial.eval₂Hom (Int.castRingHom (IntegralHeckeRing 1))
+    (fun k ↦ heckeGen 1 p k) R) D = _
+  simp only [MvPolynomial.coe_eval₂Hom, MvPolynomial.eval₂_eq', Fin.prod_univ_one]
+  have h_sum_eq : (∑ x ∈ R.support,
+      (Int.castRingHom (IntegralHeckeRing 1)) (MvPolynomial.coeff x R) * heckeGen 1 p 0 ^ x 0) =
+    (∑ x ∈ R.support, HeckeCosetModule.single ℤ
+      (diagCoset (n := 1) (fun _ ↦ p ^ x 0)) (MvPolynomial.coeff x R)) :=
+    Finset.sum_congr rfl (fun x _ ↦ by
+      rw [heckeGen_pow_one p hp]
+      exact intCast_mul_diagElem_eq_single (n := 1) (fun _ ↦ p ^ x 0) (R.coeff x))
+  change (∑ x ∈ R.support,
+      (Int.castRingHom (IntegralHeckeRing 1)) (MvPolynomial.coeff x R) * heckeGen 1 p 0 ^ x 0)
+        D = MvPolynomial.coeff s R
+  rw [h_sum_eq]
+  -- `HeckeCosetModule` is a `Finsupp` by definition, so evaluation commutes with the sum;
+  -- `rw` cannot match through the definition, but the lemma applies by defeq
+  have happ : (∑ x ∈ R.support, HeckeCosetModule.single ℤ
+        (diagCoset (n := 1) (fun _ ↦ p ^ x 0)) (MvPolynomial.coeff x R)) D =
+      ∑ x ∈ R.support, HeckeCosetModule.single ℤ
+        (diagCoset (n := 1) (fun _ ↦ p ^ x 0)) (MvPolynomial.coeff x R) D :=
+    Finsupp.finsetSum_apply _ _ _
+  rw [happ]
+  classical
+  simp only [HeckeCosetModule.single_apply, D]
+  rw [Finset.sum_eq_single s (fun b _ hbs ↦ if_neg (fun hb ↦ hbs
+    (Finsupp.ext (fun j ↦ by rw [Fin.fin_one_eq_zero j]; exact T_diag_one_ppow_inj p hp hb))))
+    (fun hns ↦ absurd hs hns)]
+  simp
+
+/-- A two-entry diagonal `![a, b]` is a divisibility chain iff `a ∣ b`. -/
+private lemma divChain_two_of_dvd {a b : ℕ} (hab : a ∣ b) :
+    IsDvdChain (![a, b] : Fin 2 → ℕ) :=
+  isDvdChain_iff.mpr fun i j hij ↦ by
+    fin_cases i <;> fin_cases j <;> simp_all
+
+/-- Determinant of an SL_n(ℤ) element embedded in GL_n(ℚ) is 1. -/
+lemma det_SLnZ_eq_one {g : GL (Fin 2) ℚ} (hg : g ∈ SLnZ 2) :
+    (↑g : Matrix (Fin 2) (Fin 2) ℚ).det = 1 := by
+  obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff 2).mp hg
+  -- the entries are integers cast into ℚ, so the determinant is the cast of `det σ = 1`
+  have h : (mapGL ℚ σ : Matrix (Fin 2) (Fin 2) ℚ) = (Int.castRingHom ℚ).mapMatrix σ.val := by
+    simp [mapGL_coe_matrix]
+  rw [h, ← RingHom.map_det]
+  simp
+
+/-- Elements in the same SL_n double coset have the same determinant. -/
+lemma det_doubleCoset_eq {g₁ g₂ : posDetInt 2}
+    (h : HeckeCoset.mk (SLnZ 2) (SLnZ 2) g₁ = HeckeCoset.mk (SLnZ 2) (SLnZ 2) g₂) :
+    (↑(↑g₁ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
+      (↑(↑g₂ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det := by
+  rw [HeckeCoset.eq_iff] at h
+  have hg₁_mem : (g₁ : GL (Fin 2) ℚ) ∈
+      DoubleCoset.doubleCoset (g₂ : GL (Fin 2) ℚ) (SLnZ 2) (SLnZ 2) := by
+    rw [← h]; exact DoubleCoset.mem_doubleCoset_self _ _ _
+  obtain ⟨h₁, hh₁, h₂, hh₂, heq⟩ := DoubleCoset.mem_doubleCoset.mp hg₁_mem
+  have : (↑(↑g₁ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
+      (h₁ * (↑g₂ : GL (Fin 2) ℚ) * h₂).1.det := by rw [heq]
+  simp only [GeneralLinearGroup.coe_mul, Matrix.det_mul, det_SLnZ_eq_one hh₁,
+    det_SLnZ_eq_one hh₂, one_mul, mul_one] at this
+  exact this
+
+/-- The diagonal product of rep(diagCoset a) equals ∏ a. -/
+lemma prod_rep_T_diag (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i) :
+    (↑(↑(HeckeCoset.rep (diagCoset a)) : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
+      ∏ i, (a i : ℚ) := by
+  -- the representative and the explicit diagonal matrix lie in the same double coset
+  have h_eq : HeckeCoset.mk (SLnZ 2) (SLnZ 2) (HeckeCoset.rep (diagCoset a)) =
+      HeckeCoset.mk (SLnZ 2) (SLnZ 2) ⟨natDiagGL 2 a, natDiagGL_mem_posDetInt 2 a⟩ := by
+    rw [HeckeCoset.mk_rep, diagCoset_def]
+  exact (det_doubleCoset_eq h_eq).trans (natDiagGL_det 2 a ha)
+
+/-- Every coset in the support of a mulMap output has determinant = det(g₁) * det(g₂). -/
+lemma det_mulMap_eq (g₁ g₂ : posDetInt 2)
+    (p : DecompQuotient (SLnZ 2) (SLnZ 2) (g₁ : GL (Fin 2) ℚ) ×
+      DecompQuotient (SLnZ 2) (SLnZ 2) (g₂ : GL (Fin 2) ℚ)) :
+    (↑(↑(HeckeCoset.rep (HeckeCoset.mulMap (SLnZ 2) (SLnZ 2) (SLnZ 2) g₁ g₂ p)) : GL (Fin 2) ℚ) :
+        Matrix (Fin 2) (Fin 2) ℚ).det =
+      (↑(↑g₁ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det *
+        (↑(↑g₂ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det := by
+  -- `mulMap` names the double coset of the explicit product `σ g₁ τ g₂`
+  have h_eq := (HeckeCoset.mk_rep
+      (HeckeCoset.mulMap (SLnZ 2) (SLnZ 2) (SLnZ 2) g₁ g₂ p)).trans
+    (HeckeCoset.mulMap_eq_mk (SLnZ 2) (SLnZ 2) (SLnZ 2) g₁ g₂ p)
+  rw [det_doubleCoset_eq h_eq]
+  simp only [GeneralLinearGroup.coe_mul, Matrix.det_mul]
+  have h1 := det_SLnZ_eq_one (p.1.out.2)
+  have h2 := det_SLnZ_eq_one (p.2.out.2)
+  rw [h1, h2]; ring
+
+/-- If `D'` appears in the support of `m(rep D₁, rep D₂)`, then the determinant of its
+representative is the product of the determinants of `rep D₁` and `rep D₂`. -/
+private lemma det_rep_eq_mul_of_m_ne_zero (D₁ D₂ D' : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+    (hm : (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+      (HeckeCoset.rep D₁) (HeckeCoset.rep D₂)) D' ≠ 0) :
+    (↑(↑(HeckeCoset.rep D') : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
+      (↑(↑(HeckeCoset.rep D₁) : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det *
+        (↑(↑(HeckeCoset.rep D₂) : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det := by
+  classical
+  rw [HeckeCosetModule.structureConstants_apply] at hm
+  -- a nonzero structure constant means `D'` is hit by `mulMap`
+  have hD'_mem : D' ∈ Finset.univ.image
+      (HeckeCoset.mulMap (SLnZ 2) (SLnZ 2) (SLnZ 2) (HeckeCoset.rep D₁) (HeckeCoset.rep D₂)) :=
+    (HeckeCoset.mem_image_mulMap_iff _ _ _).mpr (Nat.cast_ne_zero.mp hm)
+  rw [Finset.mem_image] at hD'_mem
+  obtain ⟨p, _, hD'_eq⟩ := hD'_mem
+  rw [← hD'_eq]; exact det_mulMap_eq (HeckeCoset.rep D₁) (HeckeCoset.rep D₂) p
+
+/-- Determinant tracking: if `f` is supported on cosets of determinant `q^{a₀}`, then
+`heckeGen(q,0)^{b₀} · f` is supported on cosets of determinant `q^{b₀ + a₀}`. -/
+private lemma det_rep_T_gen_zero_pow_mul (q : {p : ℕ // p.Prime}) (a₀ b₀ : ℕ)
+    (f : IntegralHeckeRing 2) (D' : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+    (hf_det : ∀ D'', f D'' ≠ 0 →
+      (↑(↑(HeckeCoset.rep D'') : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det = ↑(q.1 ^ a₀ : ℕ))
+    (hD' : (heckeGen 2 q.1 0 ^ b₀ * f) D' ≠ 0) :
+    (↑(↑(HeckeCoset.rep D') : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
+      ↑(q.1 ^ (b₀ + a₀) : ℕ) := by
+  induction b₀ generalizing f D' with
+  | zero =>
+    rw [pow_zero, one_mul] at hD'
+    simpa only [Nat.zero_add] using hf_det D' hD'
+  | succ n ih =>
+    rw [pow_succ', mul_assoc] at hD'
+    set g' := heckeGen 2 q.1 0 ^ n * f
+    rw [show heckeGen 2 q.1 0 = HeckeCosetModule.single ℤ (diagCoset (![1, q.1])) 1 from by
+        rw [heckeGen_def, diagElem_def]
+        exact congrArg (fun a ↦ HeckeCosetModule.single ℤ (diagCoset a) 1)
+          (funext fun i ↦ by fin_cases i <;> simp [heckeGenDiag_apply])] at hD'
+    obtain ⟨D₂, hD₂_mem, hD₂_ne⟩ := Finset.exists_ne_zero_of_sum_ne_zero (by
+      rw [show (HeckeCosetModule.single ℤ (diagCoset (![1, q.1])) 1 * g') D' =
+          ∑ D₂ ∈ g'.support, g' D₂ *
+            (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+            (HeckeCoset.rep (diagCoset (![1, q.1]))) (HeckeCoset.rep D₂)) D' from by
+          rw [HeckeCosetModule.mul_def, HeckeCosetModule.single_mul,
+            HeckeCosetModule.sum_apply, HeckeCosetModule.sum_def]
+          simp only [HeckeCosetModule.smul_apply, one_mul]] at hD'
+      exact hD')
+    have hm_ne : (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+        (HeckeCoset.rep (diagCoset (![1, q.1])))
+        (HeckeCoset.rep D₂)) D' ≠ 0 := fun h ↦ hD₂_ne (by rw [h, mul_zero])
+    rw [det_rep_eq_mul_of_m_ne_zero _ _ _ hm_ne,
+      show (↑(↑(HeckeCoset.rep (diagCoset (![1, q.1]))) : GL (Fin 2) ℚ) :
+          Matrix (Fin 2) (Fin 2) ℚ).det = (q.1 : ℚ) from by
+        rw [prod_rep_T_diag (![1, q.1]) (fun i ↦ by fin_cases i <;> simp [q.2.pos])]
+        simp [Fin.prod_univ_two],
+      ih f D₂ hf_det (Finsupp.mem_support_iff.mp hD₂_mem)]
+    push_cast; ring
+
+lemma T_gen_pow_support_qpower (q : {p : ℕ // p.Prime}) (e : Fin 2 → ℕ)
+    (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+    (hD : (heckeGen 2 q.1 0 ^ (e 0) * heckeGen 2 q.1 1 ^ (e 1)) D ≠ 0) :
+    ∃ a : Fin 2 → ℕ, D = diagCoset a ∧ (∀ i, 0 < a i) ∧ IsDvdChain a ∧
+      (∏ i, a i) = q.1 ^ (e 0 + 2 * e 1) := by
+  obtain ⟨a, ha_pos, ha_div, hD_eq⟩ := exists_diagonal_representative D
+  refine ⟨a, hD_eq, ha_pos, ha_div, ?_⟩
+  have hf_det : ∀ D'', (heckeGen 2 q.1 1 ^ (e 1)) D'' ≠ 0 →
+      (↑(↑(HeckeCoset.rep D'') : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
+        ↑(q.1 ^ (2 * e 1) : ℕ) := by
+    classical
+    intro D'' hD''
+    rw [heckeGen_one_eq_heckeTScalar q.1 q.2.pos,
+      HeckeRing.GL2.heckeTScalar_pow q.1 q.2.pos (e 1)] at hD''
+    have h_eq : diagCoset (fun _ : Fin 2 ↦ q.1 ^ (e 1)) = D'' := by
+      by_contra h
+      exact hD'' (by rw [diagElem_def, HeckeCosetModule.single_apply, if_neg h])
+    rw [← h_eq, prod_rep_T_diag _ (fun i ↦ by fin_cases i <;> simp [pow_pos q.2.pos])]
+    push_cast [Fin.prod_univ_two, ← pow_add]; ring_nf
+  have h_result := det_rep_T_gen_zero_pow_mul q (2 * e 1) (e 0) _ D hf_det hD
+  rw [hD_eq, prod_rep_T_diag a ha_pos] at h_result
+  exact mod_cast h_result
+
+/-- Every coset in the support of `heckeGen(q,0)^a * heckeGen(q,1)^b` has entries
+that are powers of `q` (immediate from `T_gen_pow_support_qpower`). -/
+lemma T_gen_pow_entries_qpower (q : {p : ℕ // p.Prime})
+    (e : Fin 2 → ℕ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+    (hD : (heckeGen 2 q.1 0 ^ (e 0) * heckeGen 2 q.1 1 ^ (e 1)) D ≠ 0)
+    (a : Fin 2 → ℕ) (ha : D = diagCoset a) (ha_pos : ∀ i, 0 < a i)
+    (ha_div : IsDvdChain a) :
+    ∀ p : ℕ, p.Prime → p ≠ q.1 → ∀ i, ¬(p ∣ a i) := by
+  obtain ⟨a', rfl, ha'_pos, ha'_div, ha'_det⟩ := T_gen_pow_support_qpower q e D hD
+  have ha_eq := eq_of_diagCoset_eq ha_pos ha'_pos ha_div ha'_div ha.symm
+  subst ha_eq
+  intro p hp hpq i h_dvd
+  have : p ∣ ∏ j, a j := dvd_trans h_dvd (Finset.dvd_prod_of_mem _ (Finset.mem_univ i))
+  rw [ha'_det] at this
+  exact hpq ((Nat.prime_dvd_prime_iff_eq hp q.2).mp (hp.dvd_of_dvd_pow this))
+
+/-- If `(f * g)(D) ≠ 0` in the Hecke ring, there exist `D₁ ∈ supp(f)` and `D₂ ∈ supp(g)`
+with `D ∈ mulSupport(rep D₁, rep D₂)`. -/
+lemma support_mul_exists (f g : IntegralHeckeRing 2)
+    (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+    (hD : (f * g) D ≠ 0) :
+    ∃ D₁ D₂, f D₁ ≠ 0 ∧ g D₂ ≠ 0 ∧
+      D ∈ (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+        (HeckeCoset.rep D₁) (HeckeCoset.rep D₂)).support := by
+  -- `HeckeCosetModule.mul` is sealed, so unfold it through its API rather than by defeq.
+  -- The evaluation lemmas have to be applied by `rw`, outermost sum first: `simp only` cannot
+  -- match `sum_apply` through the wrapper's `FunLike` coercion, so it silently does nothing.
+  have h := hD
+  rw [HeckeCosetModule.mul_def, HeckeCosetModule.mul_eq_sum, HeckeCosetModule.sum_apply,
+    HeckeCosetModule.sum_def] at h
+  obtain ⟨D₁, hD₁_mem, h₁⟩ := Finset.exists_ne_zero_of_sum_ne_zero h
+  rw [HeckeCosetModule.sum_apply, HeckeCosetModule.sum_def] at h₁
+  obtain ⟨D₂, hD₂_mem, h₂⟩ := Finset.exists_ne_zero_of_sum_ne_zero h₁
+  rw [HeckeCosetModule.smul_apply, HeckeCosetModule.smul_apply] at h₂
+  have hfD₁ := Finsupp.mem_support_iff.mp hD₁_mem
+  have hgD₂ := Finsupp.mem_support_iff.mp hD₂_mem
+  have hm_ne : (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+      (HeckeCoset.rep D₁) (HeckeCoset.rep D₂)) D ≠ 0 := by
+    intro h; exact h₂ (by rw [h, mul_zero, mul_zero])
+  refine ⟨D₁, D₂, hfD₁, hgD₂, ?_⟩
+  exact HeckeCosetModule.mem_support_iff.mpr hm_ne
+
+/-- `T_single(diagCoset a, α) * diagElem(c,c) = T_single(diagCoset(a * c), α)`. -/
+lemma T_single_diag_mul_T_scalar (c : ℕ) (hc : 0 < c)
+    (a : Fin 2 → ℕ) (ha_pos : ∀ i, 0 < a i) (α : ℤ) :
+    HeckeCosetModule.single ℤ (diagCoset a) α * diagElem (fun _ : Fin 2 ↦ c) =
+    HeckeCosetModule.single ℤ (diagCoset (a * (fun _ : Fin 2 ↦ c))) α := by
+  have h_single : HeckeCosetModule.single ℤ (diagCoset a) α =
+      α • diagElem a := by
+    -- `diagElem` is sealed, so `show` cannot see through it; `diagElem_def` is the bridge.
+    rw [diagElem_def]
+    exact (HeckeCosetModule.smul_single_one ℤ (diagCoset a) α).symm
+  rw [h_single, smul_mul_assoc, diagElem_mul_const 2 a ha_pos c hc, diagElem_def]
+  exact HeckeCosetModule.smul_single_one ℤ (diagCoset (a * fun _ ↦ c)) α
+
+/-- Scalar shift identity: for any `f : IntegralHeckeRing 2`, scalar `c > 0`, and positive
+divisibility-chain `b`, evaluating `f * diagElem(c,c)` at `diagCoset(b * c)` equals
+`f(diagCoset b)`. -/
+lemma T_mul_T_scalar_eval_shifted (c : ℕ) (hc : 0 < c) (f : IntegralHeckeRing 2) (b : Fin 2 → ℕ)
+    (hb_pos : ∀ i, 0 < b i) (hb_div : IsDvdChain b) :
+    (f * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * (fun _ : Fin 2 ↦ c))) = f (diagCoset b) := by
+  classical
+  induction f using HeckeCosetModule.induction_linear with
+  | h0 =>
+    change ((0 : IntegralHeckeRing 2) * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) =
+      (0 : IntegralHeckeRing 2) (diagCoset b)
+    rw [zero_mul]; rfl
+  | hadd g h ihg ihh =>
+    set g' : IntegralHeckeRing 2 := g
+    set h' : IntegralHeckeRing 2 := h
+    change ((g' + h') * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) =
+      (g' + h') (diagCoset b)
+    rw [add_mul,
+      show (g' * diagElem (fun _ : Fin 2 ↦ c) + h' * diagElem (fun _ : Fin 2 ↦ c))
+            (diagCoset (b * fun _ ↦ c)) =
+            (g' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) +
+            (h' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset (b * fun _ ↦ c)) from
+        Finsupp.add_apply _ _ _,
+      show (g' + h') (diagCoset b) = g' (diagCoset b) + h' (diagCoset b) from
+        Finsupp.add_apply _ _ _,
+      ihg, ihh]
+  | hsingle D α =>
+    obtain ⟨a, ha_pos, ha_div, hD_eq⟩ := exists_diagonal_representative D
+    rw [hD_eq, T_single_diag_mul_T_scalar c hc a ha_pos α]
+    rw [HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
+    by_cases hab : a = b
+    · subst hab; rw [if_pos rfl, if_pos rfl]
+    · have h_ne_1 : diagCoset (a * fun _ : Fin 2 ↦ c) ≠ diagCoset (b * fun _ : Fin 2 ↦ c) := by
+        intro heq
+        have h1_eq : a * (fun _ : Fin 2 ↦ c) = b * (fun _ : Fin 2 ↦ c) :=
+          eq_of_diagCoset_eq (fun i ↦ Nat.mul_pos (ha_pos i) hc)
+            (fun i ↦ Nat.mul_pos (hb_pos i) hc) (isDvdChain_mul_const 2 ha_div c)
+            (isDvdChain_mul_const 2 hb_div c) heq
+        apply hab
+        funext i
+        have := congr_fun h1_eq i
+        simp only [Pi.mul_apply] at this
+        exact Nat.eq_of_mul_eq_mul_right hc this
+      have h_ne_2 : diagCoset a ≠ diagCoset b := fun heq ↦ hab
+        (eq_of_diagCoset_eq ha_pos hb_pos ha_div hb_div heq)
+      rw [if_neg h_ne_1, if_neg h_ne_2]
+
+/-- If `c ∤ d i` for some `i`, the evaluation of `f * diagElem(c,c)` at `diagCoset d` is zero. -/
+lemma T_mul_T_scalar_eval_zero_of_not_dvd (c : ℕ) (hc : 0 < c) (f : IntegralHeckeRing 2)
+    (d : Fin 2 → ℕ)
+    (hd_pos : ∀ i, 0 < d i) (hd_div : IsDvdChain d) (i₀ : Fin 2) (hi₀ : ¬ c ∣ d i₀) :
+    (f * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) = 0 := by
+  classical
+  induction f using HeckeCosetModule.induction_linear with
+  | h0 =>
+    change ((0 : IntegralHeckeRing 2) * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) = 0
+    rw [zero_mul]; rfl
+  | hadd g h ihg ihh =>
+    set g' : IntegralHeckeRing 2 := g
+    set h' : IntegralHeckeRing 2 := h
+    change ((g' + h') * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) = 0
+    rw [add_mul,
+      show (g' * diagElem (fun _ : Fin 2 ↦ c) + h' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) =
+            (g' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) +
+            (h' * diagElem (fun _ : Fin 2 ↦ c)) (diagCoset d) from Finsupp.add_apply _ _ _,
+      ihg, ihh, add_zero]
+  | hsingle D α =>
+    obtain ⟨a, ha_pos, ha_div, hD_eq⟩ := exists_diagonal_representative D
+    rw [hD_eq, T_single_diag_mul_T_scalar c hc a ha_pos α]
+    rw [HeckeCosetModule.single_apply]
+    have h_ne : diagCoset (a * fun _ : Fin 2 ↦ c) ≠ diagCoset d := by
+      intro heq
+      have h_eq : a * (fun _ : Fin 2 ↦ c) = d :=
+        eq_of_diagCoset_eq (fun i ↦ Nat.mul_pos (ha_pos i) hc) hd_pos
+          (isDvdChain_mul_const 2 ha_div c) hd_div heq
+      apply hi₀
+      have := congr_fun h_eq i₀
+      simp only [Pi.mul_apply] at this
+      exact ⟨a i₀, by linarith [this.symm]⟩
+    rw [if_neg h_ne]
+
+/-- For `i ≥ 1`, evaluation of `f * heckeTScalar(p)^i` at `diagCoset ![1, k]` is zero
+(since `p^i ∤ 1`). -/
+lemma T_mul_T_pp_pow_eval_at_one_zero (p : ℕ) (hp : p.Prime) (i k : ℕ) (hi : 1 ≤ i)
+    (hk : 0 < k) (f : IntegralHeckeRing 2) :
+    (f * heckeTScalar p ^ i) (diagCoset (![1, k] : Fin 2 → ℕ)) = 0 := by
+  rw [HeckeRing.GL2.heckeTScalar_pow p hp.pos i]
+  apply T_mul_T_scalar_eval_zero_of_not_dvd (p^i) (pow_pos hp.pos i) f
+    (![1, k] : Fin 2 → ℕ) (fun idx ↦ by fin_cases idx <;> simp [hk])
+    (divChain_two_of_dvd (one_dvd k)) 0
+  simp only [Matrix.cons_val_zero]
+  intro hdvd
+  have hle : p ^ i ≤ 1 := Nat.le_of_dvd Nat.one_pos hdvd
+  have hge : p ≤ p ^ i := Nat.le_self_pow (by omega) p
+  have hp2 : 2 ≤ p := hp.two_le
+  omega
+
+/-- `diagElem ![p^i, p^j] = heckeTDiag(1, p^{j-i}) * heckeTScalar(p)^i` for `i ≤ j` with `p`
+prime. -/
+lemma T_elem_ppow_factor (p : ℕ) (hp : p.Prime) (i j : ℕ) (hij : i ≤ j) :
+    diagElem (![p^i, p^j] : Fin 2 → ℕ) = heckeTDiag 1 (p ^ (j - i)) * heckeTScalar p ^ i := by
+  rw [heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos _) (one_dvd _),
+      HeckeRing.GL2.heckeTScalar_pow p hp.pos i]
+  have h_ji_pos : ∀ idx : Fin 2, 0 < (![1, p^(j-i)] : Fin 2 → ℕ) idx := by
+    intro idx; fin_cases idx
+    · simp
+    · simp [pow_pos hp.pos]
+  rw [diagElem_mul_const 2 (![1, p^(j-i)] : Fin 2 → ℕ) h_ji_pos (p^i) (pow_pos hp.pos _)]
+  apply congrArg diagElem
+  funext idx; fin_cases idx
+  · simp [Pi.mul_apply]
+  · simp [Pi.mul_apply, ← pow_add]; congr 1; omega
+
+/-- The element `T(p, pⁿ)` does not contribute at `T(1, p^{n+1})` (for `n ≥ 1`). -/
+private lemma T_elem_p_ppow_eval_at_one_ppow_succ_zero (p : ℕ) (hp : p.Prime) {n : ℕ}
+    (hn : n ≠ 0) :
+    (diagElem (![p, p ^ n] : Fin 2 → ℕ)) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 0 := by
+  classical
+  rw [diagElem_def, HeckeCosetModule.single_apply]
+  refine if_neg (fun heq ↦ ?_)
+  have h_eq : (![p, p ^ n] : Fin 2 → ℕ) = (![1, p ^ (n + 1)] : Fin 2 → ℕ) :=
+    eq_of_diagCoset_eq (fun i ↦ by fin_cases i <;> simp [hp.pos, pow_pos hp.pos])
+      (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos])
+      (divChain_two_of_dvd (dvd_pow_self p hn)) (divChain_two_of_dvd (one_dvd _)) heq
+  have := congr_fun h_eq 0
+  simp only [Matrix.cons_val_zero] at this
+  have := hp.one_lt; omega
+
+/-- `(T(1,p) · T(1, pⁿ))` evaluated at the leading coset `T(1, p^{n+1})` equals `1`. -/
+private lemma T_ad_one_p_mul_T_ad_one_ppow_eval_leading (p : ℕ) (hp : p.Prime) (n : ℕ) :
+    (heckeTDiag 1 p * heckeTDiag 1 (p ^ n)) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 1 := by
+  classical
+  rcases eq_or_ne n 0 with hn | hn
+  · subst hn
+    rw [pow_zero, heckeTDiag_one_one, mul_one,
+      heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _), diagElem_def,
+      show (![1, p ^ (0 + 1)] : Fin 2 → ℕ) = (![1, p] : Fin 2 → ℕ) from by
+        funext i; fin_cases i <;> simp,
+      HeckeCosetModule.single_apply, if_pos rfl]
+  · rw [show heckeTDiag 1 p = heckeT ⟨p, hp.pos⟩ from (heckeT_prime p hp).symm,
+      heckeT_prime_mul_heckeTDiag_one_prime_pow p hp n]
+    rw [show (heckeTDiag 1 (p ^ (n + 1)) + (if n = 1 then ((p : ℤ) + 1) else (p : ℤ)) •
+              heckeTDiag p (p ^ n)) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) =
+          heckeTDiag 1 (p ^ (n + 1)) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) +
+            ((if n = 1 then ((p : ℤ) + 1) else (p : ℤ)) • heckeTDiag p (p ^ n))
+              (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) from Finsupp.add_apply _ _ _,
+      heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos _) (one_dvd _),
+      heckeTDiag_eq_diagElem hp.pos (pow_pos hp.pos _) (dvd_pow_self p hn)]
+    rw [show (diagElem (![1, p ^ (n + 1)] : Fin 2 → ℕ))
+          (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 1 from
+        by rw [diagElem_def, HeckeCosetModule.single_apply, if_pos rfl]]
+    rw [show ((if n = 1 then ((p : ℤ) + 1) else (p : ℤ)) • diagElem (![p, p ^ n] : Fin 2 → ℕ))
+          (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) =
+        (if n = 1 then ((p : ℤ) + 1) else (p : ℤ)) •
+          diagElem (![p, p ^ n] : Fin 2 → ℕ) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) from
+        Finsupp.smul_apply _ _ _,
+      T_elem_p_ppow_eval_at_one_ppow_succ_zero p hp hn,
+      smul_zero, add_zero]
+
+/-- A non-leading support element `D₂` of `(T(1,p))ⁿ` contributes `0` to the product
+`T(1,p) · (T(1,p))ⁿ` at the leading coset `T(1, p^{n+1})`. -/
+private lemma T_ad_one_p_mul_supp_ne_leading_eval_zero (p : ℕ) (hp : p.Prime) (n : ℕ)
+    (D₂ : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)) (hD₂_ne_zero : ((heckeTDiag 1 p) ^ n) D₂ ≠ 0)
+    (hD₂_ne : D₂ ≠ diagCoset (![1, p ^ n] : Fin 2 → ℕ)) :
+    (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+      (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ)))
+      (HeckeCoset.rep D₂)) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 0 := by
+  have hg_eq : (heckeTDiag 1 p) ^ n = (heckeGen 2 p 0) ^ n * (heckeGen 2 p 1) ^ 0 := by
+    simp only [pow_zero, mul_one, heckeGen_zero_eq_heckeTDiag p hp.pos]
+  obtain ⟨a, hDa, ha_pos, ha_div, ha_det⟩ := T_gen_pow_support_qpower ⟨p, hp⟩
+      ![n, 0] D₂ (hg_eq ▸ hD₂_ne_zero)
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, mul_zero, add_zero] at ha_det
+  have ha_prod : a 0 * a 1 = p ^ n := Fin.prod_univ_two a ▸ ha_det
+  obtain ⟨i, hi_le, hi_eq⟩ := (Nat.dvd_prime_pow hp).mp (ha_prod ▸ dvd_mul_right _ _)
+  have ha1_eq : a 1 = p ^ (n - i) := by
+    have h : p ^ i * a 1 = p ^ i * p ^ (n - i) := by
+      rw [← pow_add, show i + (n - i) = n from by omega, ← ha_prod, hi_eq]
+    exact Nat.eq_of_mul_eq_mul_left (pow_pos hp.pos i) h
+  have ha_form : a = (![p ^ i, p ^ (n - i)] : Fin 2 → ℕ) := by
+    funext k; fin_cases k
+    · exact hi_eq
+    · exact ha1_eq
+  have hi_ge : 1 ≤ i := by
+    by_contra h_not
+    obtain rfl : i = 0 := by omega
+    exact hD₂_ne (by rw [hDa, ha_form]; simp [pow_zero])
+  have hi_le_sub : i ≤ n - i := by
+    have h_div := ha_form ▸ isDvdChain_iff.mp ha_div (by decide : (0 : Fin 2) ≤ 1)
+    exact (Nat.pow_dvd_pow_iff_le_right hp.one_lt).mp h_div
+  rw [hDa, ha_form, ← diagElem_mul_diagElem]
+  change (diagElem (![1, p] : Fin 2 → ℕ) * diagElem (![p^i, p^(n-i)] : Fin 2 → ℕ)) _ = 0
+  rw [T_elem_ppow_factor p hp i (n - i) hi_le_sub, ← mul_assoc]
+  exact T_mul_T_pp_pow_eval_at_one_zero p hp i (p ^ (n + 1)) hi_ge (pow_pos hp.pos _) _
+
+/-- Leading coefficient of `T(1,p)^a`: `(heckeTDiag 1 p)^a` evaluated at the leading coset
+`diagCoset ![1, p^a]` equals 1. -/
+lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
+    ((heckeTDiag 1 p) ^ a) (diagCoset (![1, p ^ a] : Fin 2 → ℕ)) = 1 := by
+  classical
+  induction a with
+  | zero =>
+    rw [pow_zero, pow_zero, show (![1, 1] : Fin 2 → ℕ) = (fun _ : Fin 2 ↦ 1) from by
+        funext i; fin_cases i <;> rfl, ← diagElem_one]
+    rw [diagElem_def, HeckeCosetModule.single_apply, if_pos rfl]
+  | succ n ih =>
+    rw [pow_succ']
+    set g := (heckeTDiag 1 p) ^ n
+    set D_target : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2) :=
+      diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)
+    set D_leading : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2) :=
+      diagCoset (![1, p ^ n] : Fin 2 → ℕ)
+    rw [show heckeTDiag 1 p = HeckeCosetModule.single ℤ (diagCoset (![1, p] : Fin 2 → ℕ)) 1 from
+        (heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _)).trans (diagElem_def _),
+      HeckeCosetModule.mul_def, HeckeCosetModule.single_mul]
+    -- Evaluate the convolution at `D_target` in the wrapper's own vocabulary: push the
+    -- evaluation in with `sum_apply` first, then let `sum_def` expose the `Finset.sum`.
+    rw [HeckeCosetModule.sum_apply, HeckeCosetModule.sum_def]
+    simp only [HeckeCosetModule.smul_apply, one_mul]
+    have h_leading_in_supp : D_leading ∈ g.support :=
+      HeckeCosetModule.mem_support_iff.mpr (ih ▸ one_ne_zero)
+    rw [← Finset.sum_erase_add _ _ h_leading_in_supp]
+    have h_erased : ∀ D₂ ∈ g.support.erase D_leading,
+        (g D₂ • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+          (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep D₂)) D_target = 0 := by
+      intro D₂ hD₂
+      rw [Finset.mem_erase] at hD₂
+      -- The `•` here and the one in `smul_apply` print alike but sit on different instance
+      -- paths, so `rw`/`simp` cannot match it. Writing the equation out lets it elaborate
+      -- with the goal's instances, and `smul_apply` then checks against it up to defeq.
+      have hs : (g D₂ • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+            (diagCoset (![1, p] : Fin 2 → ℕ)).rep D₂.rep) D_target =
+          g D₂ * (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+            (diagCoset (![1, p] : Fin 2 → ℕ)).rep D₂.rep) D_target :=
+        HeckeCosetModule.smul_apply _ _ _
+      rw [hs]
+      rw [T_ad_one_p_mul_supp_ne_leading_eval_zero p hp n D₂
+        (HeckeCosetModule.mem_support_iff.mp hD₂.2) hD₂.1, mul_zero]
+    have h_sum_zero :
+        ∑ x ∈ g.support.erase D_leading, (g x •
+          HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+          (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep x)) D_target = 0 :=
+      Finset.sum_eq_zero h_erased
+    -- Goal: ∑ + (g D_leading • m ...) D_target = 1
+    -- Strategy: prove the leading term equals 1, then linarith with h_sum_zero
+    have h_leading_eq : (g D_leading •
+        HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+          (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep D_leading))
+          D_target = 1 := by
+      have hs : (g D_leading • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+            (diagCoset (![1, p] : Fin 2 → ℕ)).rep D_leading.rep) D_target =
+          g D_leading * (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+            (diagCoset (![1, p] : Fin 2 → ℕ)).rep D_leading.rep) D_target :=
+        HeckeCosetModule.smul_apply _ _ _
+      rw [hs, ih, one_mul, ← diagElem_mul_diagElem]
+      rw [show diagElem (![1, p] : Fin 2 → ℕ) = heckeTDiag 1 p from
+          (heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _)).symm,
+        show diagElem (![1, p ^ n] : Fin 2 → ℕ) = heckeTDiag 1 (p ^ n) from
+          (heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos n) (one_dvd _)).symm]
+      exact T_ad_one_p_mul_T_ad_one_ppow_eval_leading p hp n
+    calc ∑ x ∈ g.support.erase D_leading, (g x •
+          HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+            (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep x)) D_target +
+          (g D_leading • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+            (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep D_leading)) D_target
+        = 0 + (g D_leading • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+              (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep D_leading))
+              D_target :=
+          by rw [h_sum_zero]
+      _ = (g D_leading • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+            (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep D_leading))
+            D_target :=
+          zero_add _
+      _ = 1 := h_leading_eq
+
+/-- For `a₁ ≠ a₂`, evaluating `(heckeTDiag 1 p)^a₁` at the coset `T(1, p^{a₂})` gives `0`. -/
+private lemma T_ad_one_p_pow_eval_at_one_ppow_of_ne (p : ℕ) (hp : p.Prime) {a₁ a₂ : ℕ}
+    (ha_ne : a₁ ≠ a₂) :
+    ((heckeTDiag 1 p) ^ a₁) (diagCoset (![1, p ^ a₂] : Fin 2 → ℕ)) = 0 := by
+  by_contra h_ne_zero
+  have hg_eq : (heckeTDiag 1 p) ^ a₁ = (heckeGen 2 p 0) ^ a₁ * (heckeGen 2 p 1) ^ 0 := by
+    simp only [pow_zero, mul_one, heckeGen_zero_eq_heckeTDiag p hp.pos]
+  obtain ⟨a, hDa, ha_pos, ha_div, ha_det⟩ := T_gen_pow_support_qpower ⟨p, hp⟩
+      ![a₁, 0] (diagCoset (![1, p ^ a₂] : Fin 2 → ℕ)) (hg_eq ▸ h_ne_zero)
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, mul_zero, add_zero] at ha_det
+  have h_a_eq : a = (![1, p ^ a₂] : Fin 2 → ℕ) :=
+    eq_of_diagCoset_eq ha_pos
+      (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos]) ha_div
+      (divChain_two_of_dvd (one_dvd _)) hDa.symm
+  rw [h_a_eq, Fin.prod_univ_two] at ha_det
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, one_mul] at ha_det
+  exact ha_ne (Nat.pow_right_injective hp.two_le ha_det.symm)
+
+/-- `(heckeTDiag 1 p)^a₁` times the scalar `T(p^b, p^b)`, evaluated at the shifted leading coset
+`T(p^b, p^{a₂+b})`, equals `(heckeTDiag 1 p)^a₁` evaluated at `T(1, p^{a₂})`. -/
+private lemma T_ad_one_p_pow_mul_scalar_eval_at_one_ppow (p : ℕ) (hp : p.Prime) (a₁ a₂ b : ℕ) :
+    ((heckeTDiag 1 p) ^ a₁ * diagElem (fun _ : Fin 2 ↦ p ^ b))
+        (diagCoset (![p ^ b, p ^ (a₂ + b)] : Fin 2 → ℕ)) =
+    ((heckeTDiag 1 p) ^ a₁) (diagCoset (![1, p ^ a₂] : Fin 2 → ℕ)) := by
+  rw [show (![p ^ b, p ^ (a₂ + b)] : Fin 2 → ℕ) =
+      (![1, p ^ a₂] : Fin 2 → ℕ) * (fun _ : Fin 2 ↦ p ^ b) from by
+        funext i; fin_cases i
+        · simp [Pi.mul_apply]
+        · simp [Pi.mul_apply, pow_add]]
+  exact T_mul_T_scalar_eval_shifted (p ^ b) (pow_pos hp.pos _) _ _
+    (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos]) (divChain_two_of_dvd (one_dvd _))
+
+/-- Kronecker delta lemma: evaluating the monomial `heckeGen(p,0)^a₁ * heckeGen(p,1)^b₁` at the
+diagonal coset `T(p^b₂, p^(a₂+b₂))` gives 1 iff `(a₁, b₁) = (a₂, b₂)`, and 0 otherwise,
+under the hypothesis `b₂ ≤ b₁`. -/
+lemma monomial_eval_kronecker (p : ℕ) (hp : p.Prime)
+    (a₁ b₁ a₂ b₂ : ℕ) (h : b₂ ≤ b₁) :
+    (heckeGen 2 p 0 ^ a₁ * heckeGen 2 p 1 ^ b₁)
+        (diagCoset (primePowDiag 2 p ![b₂, a₂ + b₂])) =
+    if a₁ = a₂ ∧ b₁ = b₂ then 1 else 0 := by
+  rw [show (primePowDiag 2 p ![b₂, a₂ + b₂] : Fin 2 → ℕ) = (![p ^ b₂, p ^ (a₂ + b₂)] : Fin 2 → ℕ)
+      from by funext i; fin_cases i <;> simp [primePowDiag_apply],
+    heckeGen_zero_eq_heckeTDiag p hp.pos,
+    heckeGen_one_eq_heckeTScalar p hp.pos,
+    HeckeRing.GL2.heckeTScalar_pow p hp.pos b₁]
+  by_cases hmatch : a₁ = a₂ ∧ b₁ = b₂
+  · obtain ⟨ha, hb⟩ := hmatch
+    rw [if_pos ⟨ha, hb⟩, ha, ← hb, T_ad_one_p_pow_mul_scalar_eval_at_one_ppow p hp,
+      T_ad_one_p_pow_eval_leading p hp a₂]
+  · rw [if_neg hmatch]
+    by_cases hbeq : b₁ = b₂
+    · subst hbeq
+      rw [T_ad_one_p_pow_mul_scalar_eval_at_one_ppow p hp,
+        T_ad_one_p_pow_eval_at_one_ppow_of_ne p hp (fun heq ↦ hmatch ⟨heq, rfl⟩)]
+    · have h_not_dvd : ¬ p ^ b₁ ∣ (![p ^ b₂, p ^ (a₂ + b₂)] : Fin 2 → ℕ) 0 := by
+        simp only [Matrix.cons_val_zero, Nat.pow_dvd_pow_iff_le_right hp.one_lt]
+        omega
+      exact T_mul_T_scalar_eval_zero_of_not_dvd (p ^ b₁) (pow_pos hp.pos _) _ _
+        (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos])
+        (divChain_two_of_dvd (pow_dvd_pow p (by omega))) 0 h_not_dvd
+
+/-- For `n = 2`, the monomial `∏ₖ heckeGen(p,k)^{d k}` over the support of `d` equals
+`heckeGen(p,0)^{d 0} · heckeGen(p,1)^{d 1}` (missing factors contribute `heckeGen^0 = 1`). -/
+private lemma prod_T_gen_pow_eq_two (p : ℕ) (d : Fin 2 →₀ ℕ) :
+    (∏ k ∈ d.support, heckeGen 2 p k ^ d k) = heckeGen 2 p 0 ^ (d 0) * heckeGen 2 p 1 ^ (d 1) := by
+  rw [Finset.prod_subset (Finset.subset_univ d.support) (fun k _ hk ↦ by
+    rw [Finsupp.notMem_support_iff.mp hk, pow_zero])]
+  rw [Fin.prod_univ_two]
+
+/-- Evaluating `evalHom 2 p R` at the coset `D` expands as
+`∑_{d ∈ supp R} (R.coeff d) · (heckeGen(p,0)^{d 0} · heckeGen(p,1)^{d 1}) D`. -/
+private lemma evalHom_apply_eq_sum_monomial (p : ℕ) (R : MvPolynomial (Fin 2) ℤ)
+    (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)) :
+    (evalHom 2 p R) D =
+    ∑ d ∈ R.support, R.coeff d * (heckeGen 2 p 0 ^ (d 0) * heckeGen 2 p 1 ^ (d 1)) D := by
+  rw [evalHom_def]
+  change (MvPolynomial.eval₂ (Int.castRingHom (IntegralHeckeRing 2))
+    (fun k : Fin 2 ↦ heckeGen 2 p k) R) D = _
+  rw [MvPolynomial.eval₂_eq]
+  change (∑ d ∈ R.support, (Int.castRingHom (IntegralHeckeRing 2)) (MvPolynomial.coeff d R) *
+    ∏ i ∈ d.support, heckeGen 2 p i ^ d i) D = _
+  rw [show (∑ d ∈ R.support, (Int.castRingHom (IntegralHeckeRing 2)) (MvPolynomial.coeff d R) *
+        ∏ i ∈ d.support, heckeGen 2 p i ^ d i) D =
+      ∑ d ∈ R.support, ((Int.castRingHom (IntegralHeckeRing 2)) (MvPolynomial.coeff d R) *
+        ∏ i ∈ d.support, heckeGen 2 p i ^ d i) D from Finset.sum_apply' _]
+  refine Finset.sum_congr rfl (fun d _ ↦ ?_)
+  change (((R.coeff d : ℤ) : IntegralHeckeRing 2) * (∏ k ∈ d.support, heckeGen 2 p k ^ d k)) D = _
+  rw [show ((R.coeff d : ℤ) : IntegralHeckeRing 2) = (R.coeff d) • (1 : IntegralHeckeRing 2) from
+    (zsmul_one _).symm, smul_mul_assoc, one_mul]
+  rw [show ((R.coeff d) • (∏ k ∈ d.support, heckeGen 2 p k ^ d k : IntegralHeckeRing 2)) D =
+    R.coeff d • (∏ k ∈ d.support, heckeGen 2 p k ^ d k : IntegralHeckeRing 2) D from
+    Finsupp.smul_apply _ _ _, smul_eq_mul, prod_T_gen_pow_eq_two]
+
+/-- n=2: evalHom is injective. -/
+theorem evalHom_injective_two (p : ℕ) (hp : p.Prime) :
+    Function.Injective (evalHom 2 p) := by
+  intro P Q hPQ
+  rw [← sub_eq_zero]; set R := P - Q
+  have hR : evalHom 2 p R = 0 := by simp [R, map_sub, hPQ]
+  by_contra hR_ne
+  obtain ⟨s, hs_mem, hs_min⟩ := Finset.exists_min_image R.support
+    (fun d : Fin 2 →₀ ℕ ↦ d 1) (MvPolynomial.support_nonempty.mpr hR_ne)
+  have hs_coeff : R.coeff s ≠ 0 := MvPolynomial.mem_support_iff.mp hs_mem
+  have h_zero : (evalHom 2 p R) (diagCoset (primePowDiag 2 p ![s 1, s 0 + s 1])) = 0 := by
+    rw [hR]; rfl
+  rw [evalHom_apply_eq_sum_monomial] at h_zero
+  have h_delta : ∀ d ∈ R.support,
+      R.coeff d * (heckeGen 2 p 0 ^ (d 0) * heckeGen 2 p 1 ^ (d 1))
+          (diagCoset (primePowDiag 2 p ![s 1, s 0 + s 1])) =
+      if d = s then R.coeff d else 0 := by
+    intro d hd_mem
+    rw [monomial_eval_kronecker p hp (d 0) (d 1) (s 0) (s 1) (hs_min d hd_mem)]
+    by_cases hds : d = s
+    · subst hds; simp
+    · rw [if_neg hds, if_neg (fun ⟨h0, h1⟩ ↦ hds (by ext i; fin_cases i; exacts [h0, h1])),
+        mul_zero]
+  rw [Finset.sum_congr rfl h_delta, Finset.sum_ite_eq_of_mem' R.support s _ hs_mem] at h_zero
+  exact hs_coeff h_zero
+
+/-- Surjectivity of `evalHomLocal` follows from surjectivity onto `pLocalSubring`. -/
+lemma evalHomLocal_surjective (n : ℕ) [NeZero n] (p : ℕ)
+    (h_surj : ∀ f ∈ pLocalSubring n p, f ∈ (evalHom n p).range) :
+    Function.Surjective (evalHomLocal n p) := by
+  intro ⟨f, hf⟩
+  obtain ⟨P, hP⟩ := h_surj f hf
+  exact ⟨P, Subtype.ext ((evalHomLocal_coe n p P).trans hP)⟩
+
+/-- Injectivity of `evalHomLocal` follows from injectivity of `evalHom`. -/
+lemma evalHomLocal_injective (n : ℕ) [NeZero n] (p : ℕ) (_hp : p.Prime)
+    (h_inj : Function.Injective (evalHom n p)) :
+    Function.Injective (evalHomLocal n p) := by
+  intro P Q hPQ
+  -- `evalHomLocal` is sealed upstream, so the coercion is read off `evalHomLocal_coe`
+  -- rather than by unfolding.
+  refine h_inj ?_
+  rw [← evalHomLocal_coe n p P, ← evalHomLocal_coe n p Q, hPQ]
+
+end HeckeRing.GLn.Inj
+
+namespace HeckeRing.GLn
+
+variable (p : ℕ) (hp : p.Prime)
+
+/-- **Shimura, Theorem 3.20 for `n = 1`**: the `p`-local Hecke ring of `GL₁` is the
+polynomial ring `ℤ[X]` on the single generator `T(p)`. -/
+noncomputable def R_p_isPolynomialRing_one :
+    MvPolynomial (Fin 1) ℤ ≃+* pLocalSubring 1 p :=
+  RingEquiv.ofBijective (evalHomLocal 1 p)
+    ⟨Inj.evalHomLocal_injective 1 p hp (Inj.evalHom_injective_one p hp),
+     Inj.evalHomLocal_surjective 1 p (pLocalSubring_one_le_evalHom_range p hp.pos)⟩
+
+/-- **Shimura, Theorem 3.20 for `n = 2`**: the `p`-local Hecke ring of `GL₂` is the
+polynomial ring `ℤ[X₁, X₂]` on the generators `T(1, p)` and `T(p, p)`. This is the case the
+classical theory of modular forms uses. -/
+noncomputable def R_p_isPolynomialRing_two :
+    MvPolynomial (Fin 2) ℤ ≃+* pLocalSubring 2 p :=
+  RingEquiv.ofBijective (evalHomLocal 2 p)
+    ⟨Inj.evalHomLocal_injective 2 p hp (Inj.evalHom_injective_two p hp),
+     Inj.evalHomLocal_surjective 2 p (pLocalSubring_two_le_evalHom_range p hp)⟩
+
+end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.NumberTheory.HeckeRing.GLn.PolynomialRing.Basic
 
-@[expose] public section
+public section
 
 /-!
 # `pLocalSubring` is a polynomial ring for `n = 1, 2`
@@ -275,6 +275,12 @@ private lemma det_rep_T_gen_zero_pow_mul (q : {p : ℕ // p.Prime}) (a₀ b₀ :
       ih f D₂ hf_det (Finsupp.mem_support_iff.mp hD₂_mem)]
     push_cast; ring
 
+/-- Every double coset in the support of `T(1,q)^{e₀} · T(q,q)^{e₁}` is a diagonal coset
+`T(a)` for a positive divisibility chain `a`, whose entry product — the determinant of any
+representative — is `q^(e₀ + 2·e₁)`.
+
+This is what makes the exponent pair recoverable: the determinant pins `e₀ + 2·e₁`, and the
+elementary-divisor order then separates the individual exponents. -/
 lemma T_gen_pow_support_qpower (q : {p : ℕ // p.Prime}) (e : Fin 2 → ℕ)
     (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
     (hD : (heckeGen 2 q.1 0 ^ (e 0) * heckeGen 2 q.1 1 ^ (e 1)) D ≠ 0) :
@@ -746,16 +752,8 @@ theorem evalHom_injective_two (p : ℕ) (hp : p.Prime) :
   rw [Finset.sum_congr rfl h_delta, Finset.sum_ite_eq_of_mem' R.support s _ hs_mem] at h_zero
   exact hs_coeff h_zero
 
-/-- Surjectivity of `evalHomLocal` follows from surjectivity onto `pLocalSubring`. -/
-lemma evalHomLocal_surjective (n : ℕ) [NeZero n] (p : ℕ)
-    (h_surj : ∀ f ∈ pLocalSubring n p, f ∈ (evalHom n p).range) :
-    Function.Surjective (evalHomLocal n p) := by
-  intro ⟨f, hf⟩
-  obtain ⟨P, hP⟩ := h_surj f hf
-  exact ⟨P, Subtype.ext ((evalHomLocal_coe n p P).trans hP)⟩
-
 /-- Injectivity of `evalHomLocal` follows from injectivity of `evalHom`. -/
-lemma evalHomLocal_injective (n : ℕ) [NeZero n] (p : ℕ) (_hp : p.Prime)
+lemma evalHomLocal_injective (n : ℕ) [NeZero n] (p : ℕ)
     (h_inj : Function.Injective (evalHom n p)) :
     Function.Injective (evalHomLocal n p) := by
   intro P Q hPQ
@@ -775,8 +773,8 @@ polynomial ring `ℤ[X]` on the single generator `T(p)`. -/
 noncomputable def polynomialRingEquivOne :
     MvPolynomial (Fin 1) ℤ ≃+* pLocalSubring 1 p :=
   RingEquiv.ofBijective (evalHomLocal 1 p)
-    ⟨Inj.evalHomLocal_injective 1 p hp (Inj.evalHom_injective_one p hp),
-     Inj.evalHomLocal_surjective 1 p (pLocalSubring_one_le_evalHom_range p hp.pos)⟩
+    ⟨Inj.evalHomLocal_injective 1 p (Inj.evalHom_injective_one p hp),
+     evalHomLocal_one_surjective p hp.pos⟩
 
 /-- **Shimura, Theorem 3.20 for `n = 2`**: the `p`-local Hecke ring of `GL₂` is the
 polynomial ring `ℤ[X₁, X₂]` on the generators `T(1, p)` and `T(p, p)`. This is the case the
@@ -784,7 +782,7 @@ classical theory of modular forms uses. -/
 noncomputable def polynomialRingEquivTwo :
     MvPolynomial (Fin 2) ℤ ≃+* pLocalSubring 2 p :=
   RingEquiv.ofBijective (evalHomLocal 2 p)
-    ⟨Inj.evalHomLocal_injective 2 p hp (Inj.evalHom_injective_two p hp),
-     Inj.evalHomLocal_surjective 2 p (pLocalSubring_two_le_evalHom_range p hp)⟩
+    ⟨Inj.evalHomLocal_injective 2 p (Inj.evalHom_injective_two p hp),
+     evalHomLocal_two_surjective p hp⟩
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -98,17 +98,6 @@ private lemma heckeGen_pow_one (p : ℕ) (hp : 0 < p) (k : ℕ) :
     rw [heckeGen_def]; exact congrArg diagElem (heckeGenDiag_one_eq_const p)]
   exact diagElem_const_pow 1 p hp k
 
-/-- An integer scalar times the basis element `diagElem a` is the single `Finsupp` at
-`diagCoset a` with that coefficient. -/
-private lemma intCast_mul_diagElem_eq_single {n : ℕ} [NeZero n] (a : Fin n → ℕ) (c : ℤ) :
-    (Int.castRingHom (IntegralHeckeRing n)) c * diagElem a =
-      HeckeCosetModule.single ℤ (diagCoset a) c := by
-  -- no cast lemma reads an `Int.castRingHom` image as a `zsmul` of `1` in this direction, so
-  -- the equation is stated here and discharged by `zsmul_eq_mul`.
-  rw [show (Int.castRingHom (IntegralHeckeRing n)) c = c • (1 : IntegralHeckeRing n) from by
-      rw [zsmul_eq_mul, mul_one]; rfl, smul_mul_assoc, one_mul, diagElem_def]
-  exact HeckeCosetModule.smul_single_one ℤ (diagCoset a) c
-
 /-- For `n = 1` and any base `1 < p`, the cosets `diagCoset (fun _ => p^k)` are injective in `k`:
 if they coincide for `b 0` and `s 0`, then `b 0 = s 0`. -/
 private lemma T_diag_one_ppow_inj (p : ℕ) (hp : 1 < p) {b s : Fin 1 →₀ ℕ}
@@ -694,14 +683,6 @@ private lemma monomial_eval_kronecker (p : ℕ) (hp : p.Prime)
       exact T_mul_T_scalar_eval_zero_of_not_dvd (p ^ b₁) (pow_pos hp.pos _) _ _
         (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos])
         (divChain_two_of_dvd (pow_dvd_pow p (by omega))) 0 h_not_dvd
-
-/-- For `n = 2`, the monomial `∏ₖ heckeGen(p,k)^{d k}` over the support of `d` equals
-`heckeGen(p,0)^{d 0} · heckeGen(p,1)^{d 1}` (missing factors contribute `heckeGen^0 = 1`). -/
-private lemma prod_T_gen_pow_eq_two (p : ℕ) (d : Fin 2 →₀ ℕ) :
-    (∏ k ∈ d.support, heckeGen 2 p k ^ d k) = heckeGen 2 p 0 ^ (d 0) * heckeGen 2 p 1 ^ (d 1) := by
-  rw [Finset.prod_subset (Finset.subset_univ d.support) (fun k _ hk ↦ by
-    rw [Finsupp.notMem_support_iff.mp hk, pow_zero])]
-  rw [Fin.prod_univ_two]
 
 /-- Evaluating `evalHom 2 p R` at the coset `D` expands as
 `∑_{d ∈ supp R} (R.coeff d) · (heckeGen(p,0)^{d 0} · heckeGen(p,1)^{d 1}) D`. -/

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -133,44 +133,24 @@ theorem evalHom_one_injective (p : ℕ) (hp : 1 < p) : Function.Injective (evalH
   obtain ⟨s, hs⟩ := MvPolynomial.support_nonempty.mpr hne
   have hcoeff : R.coeff s ≠ 0 := MvPolynomial.mem_support_iff.mp hs
   set D := diagCoset (n := 1) (fun _ ↦ p ^ (s 0))
-  have h0 : (evalHom 1 p R).toFun D = 0 := by rw [hR]; rfl
+  have h0 : evalHom 1 p R D = 0 := by rw [hR]; rfl
   apply hcoeff
-  suffices h : ((evalHom 1 p) R).toFun D = MvPolynomial.coeff s R from h ▸ h0
-  rw [evalHom_def]
-  -- `evalHom` is sealed (`public section`, no `@[expose]`), so it does not reduce to
-  -- `eval₂Hom` by `rw`/`unfold` here; `evalHom_def` names the equation and this `change`
-  -- takes the resulting term to its `Finsupp` application form.
-  change Finsupp.toFun (MvPolynomial.eval₂Hom (Int.castRingHom (IntegralHeckeRing 1))
-    (fun k ↦ heckeGen 1 p k) R) D = _
-  simp only [MvPolynomial.coe_eval₂Hom, MvPolynomial.eval₂_eq', Fin.prod_univ_one]
-  have h_sum_eq : (∑ x ∈ R.support,
-      (Int.castRingHom (IntegralHeckeRing 1)) (MvPolynomial.coeff x R) * heckeGen 1 p 0 ^ x 0) =
-    (∑ x ∈ R.support, HeckeCosetModule.single ℤ
-      (diagCoset (n := 1) (fun _ ↦ p ^ x 0)) (MvPolynomial.coeff x R)) :=
-    Finset.sum_congr rfl (fun x _ ↦ by
-      rw [heckeGen_pow_one p (Nat.lt_of_lt_of_le Nat.zero_lt_one hp.le)]
-      exact intCast_mul_diagElem_eq_single (n := 1) (fun _ ↦ p ^ x 0) (R.coeff x))
-  -- `IntegralHeckeRing` is a `def` over `Finsupp`, so evaluating a ring element at a coset
-  -- is `Finsupp` application through the wrapper: the equation holds by defeq but no
-  -- `Finsupp` lemma matches syntactically, so the shape is stated rather than rewritten.
-  change (∑ x ∈ R.support,
-      (Int.castRingHom (IntegralHeckeRing 1)) (MvPolynomial.coeff x R) * heckeGen 1 p 0 ^ x 0)
-        D = MvPolynomial.coeff s R
-  rw [h_sum_eq]
-  -- `HeckeCosetModule` is a `Finsupp` by definition, so evaluation commutes with the sum;
-  -- `rw` cannot match through the definition, but the lemma applies by defeq
-  have happ : (∑ x ∈ R.support, HeckeCosetModule.single ℤ
-        (diagCoset (n := 1) (fun _ ↦ p ^ x 0)) (MvPolynomial.coeff x R)) D =
-      ∑ x ∈ R.support, HeckeCosetModule.single ℤ
-        (diagCoset (n := 1) (fun _ ↦ p ^ x 0)) (MvPolynomial.coeff x R) D :=
-    Finsupp.finsetSum_apply _ _ _
-  rw [happ]
+  suffices h : evalHom 1 p R D = MvPolynomial.coeff s R from h ▸ h0
+  rw [evalHom_apply]
   classical
-  simp only [HeckeCosetModule.single_apply, D]
-  rw [Finset.sum_eq_single s (fun b _ hbs ↦ if_neg (fun hb ↦ hbs
-    (Finsupp.ext (fun j ↦ by rw [Fin.fin_one_eq_zero j]; exact T_diag_one_ppow_inj p hp hb))))
-    (fun hns ↦ absurd hs hns)]
-  simp
+  -- each monomial `X^k` evaluates to the basis element at `T(p^k)`, so its contribution at
+  -- `D = T(p^{s 0})` is its own coefficient when `k = s 0` and zero otherwise
+  have hterm : ∀ x ∈ R.support,
+      R.coeff x • (∏ i, heckeGen 1 p i ^ x i : IntegralHeckeRing 1) D =
+        if x = s then R.coeff s else 0 := by
+    intro x _
+    rw [Fin.prod_univ_one, heckeGen_pow_one p (Nat.lt_of_lt_of_le Nat.zero_lt_one hp.le),
+      diagElem_def, HeckeCosetModule.single_apply]
+    by_cases hxs : x = s
+    · subst hxs; simp [D]
+    · rw [if_neg (fun hb ↦ hxs (Finsupp.ext fun j ↦ by
+        rw [Fin.fin_one_eq_zero j]; exact T_diag_one_ppow_inj p hp hb)), if_neg hxs, smul_zero]
+  rw [Finset.sum_congr rfl hterm, Finset.sum_ite_eq_of_mem' R.support s _ hs]
 
 /-- A two-entry diagonal `![a, b]` is a divisibility chain iff `a ∣ b`. -/
 private lemma divChain_two_of_dvd {a b : ℕ} (hab : a ∣ b) :
@@ -388,8 +368,8 @@ private lemma T_mul_T_scalar_eval_shifted (c : ℕ) (hc : 0 < c) (f : IntegralHe
         intro heq
         have h1_eq : a * (fun _ : Fin 2 ↦ c) = b * (fun _ : Fin 2 ↦ c) :=
           eq_of_diagCoset_eq (fun i ↦ Nat.mul_pos (ha_pos i) hc)
-            (fun i ↦ Nat.mul_pos (hb_pos i) hc) (isDvdChain_mul_const 2 ha_div c)
-            (isDvdChain_mul_const 2 hb_div c) heq
+            (fun i ↦ Nat.mul_pos (hb_pos i) hc) (isDvdChain_mul 2 ha_div (isDvdChain_const 2 c))
+            (isDvdChain_mul 2 hb_div (isDvdChain_const 2 c)) heq
         apply hab
         funext i
         have := congr_fun h1_eq i
@@ -435,7 +415,7 @@ private lemma T_mul_T_scalar_eval_zero_of_not_dvd (c : ℕ) (hc : 0 < c) (f : In
       intro heq
       have h_eq : a * (fun _ : Fin 2 ↦ c) = d :=
         eq_of_diagCoset_eq (fun i ↦ Nat.mul_pos (ha_pos i) hc) hd_pos
-          (isDvdChain_mul_const 2 ha_div c) hd_div heq
+          (isDvdChain_mul 2 ha_div (isDvdChain_const 2 c)) hd_div heq
       apply hi₀
       have := congr_fun h_eq i₀
       simp only [Pi.mul_apply] at this
@@ -729,33 +709,9 @@ private lemma evalHom_apply_eq_sum_monomial (p : ℕ) (R : MvPolynomial (Fin 2) 
     (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)) :
     (evalHom 2 p R) D =
     ∑ d ∈ R.support, R.coeff d * (heckeGen 2 p 0 ^ (d 0) * heckeGen 2 p 1 ^ (d 1)) D := by
-  rw [evalHom_def]
-  -- `evalHom` is sealed (`public section`, no `@[expose]`), so it does not reduce to
-  -- `eval₂Hom` by `rw`/`unfold` here; `evalHom_def` names the equation and this `change`
-  -- takes the resulting term to its `Finsupp` application form.
-  change (MvPolynomial.eval₂ (Int.castRingHom (IntegralHeckeRing 2))
-    (fun k : Fin 2 ↦ heckeGen 2 p k) R) D = _
-  rw [MvPolynomial.eval₂_eq]
-  -- `evalHom` is sealed (`public section`, no `@[expose]`), so it does not reduce to
-  -- `eval₂Hom` by `rw`/`unfold` here; `evalHom_def` names the equation and this `change`
-  -- takes the resulting term to its `Finsupp` application form.
-  change (∑ d ∈ R.support, (Int.castRingHom (IntegralHeckeRing 2)) (MvPolynomial.coeff d R) *
-    ∏ i ∈ d.support, heckeGen 2 p i ^ d i) D = _
-  rw [show (∑ d ∈ R.support, (Int.castRingHom (IntegralHeckeRing 2)) (MvPolynomial.coeff d R) *
-        ∏ i ∈ d.support, heckeGen 2 p i ^ d i) D =
-      ∑ d ∈ R.support, ((Int.castRingHom (IntegralHeckeRing 2)) (MvPolynomial.coeff d R) *
-        ∏ i ∈ d.support, heckeGen 2 p i ^ d i) D from Finset.sum_apply' _]
-  refine Finset.sum_congr rfl (fun d _ ↦ ?_)
-  -- `evalHom` is sealed (`public section`, no `@[expose]`), so it does not reduce to
-  -- `eval₂Hom` by `rw`/`unfold` here; `evalHom_def` names the equation and this `change`
-  -- takes the resulting term to its `Finsupp` application form.
-  change (((R.coeff d : ℤ) : IntegralHeckeRing 2) * (∏ k ∈ d.support, heckeGen 2 p k ^ d k)) D = _
-  rw [← zsmul_one (R.coeff d), smul_mul_assoc, one_mul]
-  -- `Finsupp.smul_apply` again: it holds through the `IntegralHeckeRing` wrapper by defeq but
-  -- does not match syntactically, so the pushed-in form is stated and closed by it.
-  rw [show ((R.coeff d) • (∏ k ∈ d.support, heckeGen 2 p k ^ d k : IntegralHeckeRing 2)) D =
-    R.coeff d • (∏ k ∈ d.support, heckeGen 2 p k ^ d k : IntegralHeckeRing 2) D from
-    Finsupp.smul_apply _ _ _, smul_eq_mul, prod_T_gen_pow_eq_two]
+  rw [evalHom_apply]
+  refine Finset.sum_congr rfl fun d _ ↦ ?_
+  rw [Fin.prod_univ_two, smul_eq_mul]
 
 /-- n=2: evalHom is injective. -/
 theorem evalHom_two_injective (p : ℕ) (hp : p.Prime) :
@@ -783,19 +739,16 @@ theorem evalHom_two_injective (p : ℕ) (hp : p.Prime) :
   rw [Finset.sum_congr rfl h_delta, Finset.sum_ite_eq_of_mem' R.support s _ hs_mem] at h_zero
   exact hs_coeff h_zero
 
-/-- Injectivity of `evalHomLocal` follows from injectivity of `evalHom`.
-
-This is *not* an instance of `RingHom.injective_codRestrict`, even though `evalHomLocal` is
-defined as a `codRestrict`: that lemma's `f`, `s` and `h` are implicit and can only be solved
-by unfolding `evalHomLocal`, which is `public` with no `@[expose]` and therefore opaque to
-this module. Elaborating it here reports `evalHomLocal ↦ 662` under "definitions were not
-unfolded because their definition is not exposed". `evalHomLocal_coe` is the exported
-characteristic lemma that replaces the unfolding, so the argument runs through it. -/
+/-- Injectivity transfers from `evalHom` to its codomain restriction `evalHomLocal`: two
+polynomials with the same image in `pLocalSubring` have the same image in the ambient ring. -/
 lemma evalHomLocal_injective (n : ℕ) [NeZero n] (p : ℕ)
     (h_inj : Function.Injective (evalHom n p)) :
     Function.Injective (evalHomLocal n p) := by
   intro P Q hPQ
   refine h_inj ?_
+  -- not `RingHom.injective_codRestrict`: its `f`, `s`, `h` are implicit and only solvable by
+  -- unfolding `evalHomLocal`, which is sealed here ("definition is not exposed").
+  -- `evalHomLocal_coe` is the exported stand-in for that unfolding.
   rw [← evalHomLocal_coe n p P, ← evalHomLocal_coe n p Q, hPQ]
 
 variable (p : ℕ)

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -666,16 +666,6 @@ private lemma monomial_eval_kronecker (p : ℕ) (hp : p.Prime)
         (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos])
         (divChain_two_of_dvd (pow_dvd_pow p (by omega))) 0 h_not_dvd
 
-/-- Evaluating `evalHom 2 p R` at the coset `D` expands as
-`∑_{d ∈ supp R} (R.coeff d) · (heckeGen(p,0)^{d 0} · heckeGen(p,1)^{d 1}) D`. -/
-private lemma evalHom_apply_eq_sum_monomial (p : ℕ) (R : MvPolynomial (Fin 2) ℤ)
-    (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)) :
-    (evalHom 2 p R) D =
-    ∑ d ∈ R.support, R.coeff d * (heckeGen 2 p 0 ^ (d 0) * heckeGen 2 p 1 ^ (d 1)) D := by
-  rw [evalHom_apply]
-  refine Finset.sum_congr rfl fun d _ ↦ ?_
-  rw [Fin.prod_univ_two, smul_eq_mul]
-
 /-- n=2: evalHom is injective. -/
 theorem evalHom_two_injective (p : ℕ) (hp : p.Prime) :
     Function.Injective (evalHom 2 p) := by
@@ -688,7 +678,9 @@ theorem evalHom_two_injective (p : ℕ) (hp : p.Prime) :
   have hs_coeff : R.coeff s ≠ 0 := MvPolynomial.mem_support_iff.mp hs_mem
   have h_zero : (evalHom 2 p R) (diagCoset (primePowDiag 2 p ![s 1, s 0 + s 1])) = 0 := by
     rw [hR]; rfl
-  rw [evalHom_apply_eq_sum_monomial] at h_zero
+  -- expand with the general evaluation rule, then normalise each rank-two summand
+  rw [evalHom_apply] at h_zero
+  rw [Finset.sum_congr rfl fun d _ ↦ by rw [Fin.prod_univ_two, smul_eq_mul]] at h_zero
   have h_delta : ∀ d ∈ R.support,
       R.coeff d * (heckeGen 2 p 0 ^ (d 0) * heckeGen 2 p 1 ^ (d 1))
           (diagCoset (primePowDiag 2 p ![s 1, s 0 + s 1])) =

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -22,7 +22,7 @@ leading elementary-divisor vector, and distinct monomials have distinct leading 
 
 ## Main results
 
-* `HeckeRing.GLn.Inj.evalHom_one_injective`, `HeckeRing.GLn.Inj.evalHom_two_injective`:
+* `HeckeRing.GLn.evalHom_one_injective`, `HeckeRing.GLn.evalHom_two_injective`:
   evaluation at the generators is injective for `n = 1` and `n = 2`.
 * `HeckeRing.GLn.polynomialRingEquivOne`, `HeckeRing.GLn.polynomialRingEquivTwo`:
   **Shimura, Theorem 3.20** for `n = 1` and `n = 2` — `pLocalSubring ≅ ℤ[X₁, …, Xₙ]`.
@@ -47,9 +47,9 @@ open Matrix Subgroup.Commensurable Pointwise HeckeRing DoubleCoset Matrix.Specia
 
 open scoped Pointwise
 
-namespace HeckeRing.GLn.Inj
+namespace HeckeRing.GLn
 
-open HeckeRing.GLn HeckeRing.GL2
+open HeckeRing.GL2
 
 /-- The `CommSemiring` structure this module needs on `IntegralHeckeRing n`, rebuilt locally
 from `HeckeCosetModule.instSemiringHeckeRing` and `HeckeCosetModule.mul_comm_of_antiInvolution`.
@@ -59,7 +59,7 @@ does not cross the module boundary; and `commSemiringIntegralHeckeRing` is a sea
 registering it for typeclass search does not make its body reduce to the ambient
 `NonAssocSemiring`. Writing the structure here makes it transparent exactly where this file
 needs it, leaving the upstream definitions sealed for every other consumer. -/
-noncomputable local instance commSemiringIntegralHeckeRingLocal (n : ℕ) [NeZero n] :
+noncomputable local instance localCommSemiringForInjectivity (n : ℕ) [NeZero n] :
     CommSemiring (IntegralHeckeRing n) :=
   { (HeckeCosetModule.instSemiringHeckeRing ℤ : Semiring (IntegralHeckeRing n)) with
     mul_comm := HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution n)
@@ -738,10 +738,6 @@ lemma evalHomLocal_injective (n : ℕ) [NeZero n] (p : ℕ)
   refine h_inj ?_
   rw [← evalHomLocal_coe n p P, ← evalHomLocal_coe n p Q, hPQ]
 
-end HeckeRing.GLn.Inj
-
-namespace HeckeRing.GLn
-
 variable (p : ℕ)
 
 /-- **Shimura, Theorem 3.20 for `n = 1`**: the `p`-local Hecke ring of `GL₁` is the
@@ -751,7 +747,7 @@ Stated for `1 < p` rather than `p.Prime`: rank one needs only that `k ↦ p^k` i
 noncomputable def polynomialRingEquivOne (hp : 1 < p) :
     MvPolynomial (Fin 1) ℤ ≃+* pLocalSubring 1 p :=
   RingEquiv.ofBijective (evalHomLocal 1 p)
-    ⟨Inj.evalHomLocal_injective 1 p (Inj.evalHom_one_injective p hp),
+    ⟨evalHomLocal_injective 1 p (evalHom_one_injective p hp),
      evalHomLocal_one_surjective p (Nat.zero_lt_of_lt hp)⟩
 
 /-- The rank-one presentation isomorphism is the evaluation map. -/
@@ -766,7 +762,7 @@ Primality is genuine here: the rank-two argument runs through the `GL₂` recurr
 noncomputable def polynomialRingEquivTwo (hp : p.Prime) :
     MvPolynomial (Fin 2) ℤ ≃+* pLocalSubring 2 p :=
   RingEquiv.ofBijective (evalHomLocal 2 p)
-    ⟨Inj.evalHomLocal_injective 2 p (Inj.evalHom_two_injective p hp),
+    ⟨evalHomLocal_injective 2 p (evalHom_two_injective p hp),
      evalHomLocal_two_surjective p hp⟩
 
 /-- The rank-two presentation isomorphism is the evaluation map. -/

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -340,6 +340,10 @@ private noncomputable def evalAddHom (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLn
     IntegralHeckeRing 2 →+ ℤ :=
   AddMonoidHom.mk' (fun f ↦ f D) (fun g h ↦ HeckeCosetModule.add_apply g h D)
 
+/-- `evalAddHom D` is evaluation at `D`. -/
+@[simp] private lemma evalAddHom_apply (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+    (f : IntegralHeckeRing 2) : evalAddHom D f = f D := rfl
+
 /-- Scalar shift identity: for any `f : IntegralHeckeRing 2`, scalar `c > 0`, and positive
 divisibility-chain `b`, evaluating `f * diagElem(c,c)` at `diagCoset(b * c)` equals
 `f(diagCoset b)`. -/
@@ -352,10 +356,7 @@ private lemma T_mul_T_scalar_eval_shifted (c : ℕ) (hc : 0 < c) (f : IntegralHe
   intro D α
   obtain ⟨a, ha_pos, ha_div, hD_eq⟩ := exists_diagonal_representative D
   rw [hD_eq, T_single_diag_mul_T_scalar c hc a ha_pos α]
-  change HeckeCosetModule.single ℤ (diagCoset (a * fun _ : Fin 2 ↦ c)) α
-      (diagCoset (b * fun _ : Fin 2 ↦ c)) =
-    HeckeCosetModule.single ℤ (diagCoset a) α (diagCoset b)
-  rw [HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
+  rw [evalAddHom_apply, HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
   by_cases hab : a = b
   · subst hab; rw [if_pos rfl, if_pos rfl]
   · have h_ne_1 : diagCoset (a * fun _ : Fin 2 ↦ c) ≠ diagCoset (b * fun _ : Fin 2 ↦ c) := by

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -77,13 +77,17 @@ private lemma diagElem_mul_diagElem (a b : Fin 2 → ℕ) :
     diagElem a * diagElem b =
       HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
         (diagCoset a).rep (diagCoset b).rep := by
-  rw [diagElem_def, diagElem_def, HeckeCosetModule.mul_def, HeckeCosetModule.single_mul]
-  -- `rw` cannot match a `Finsupp` lemma through the `HeckeCosetModule` wrapper, so the
-  -- summation equation is supplied as a term
-  have h := HeckeCosetModule.sum_single_index (R := ℤ) (D := diagCoset b) (b := (1 : ℤ))
-    (F := fun D₂ b₂ ↦ (1 : ℤ) • b₂ • HeckeCosetModule.structureConstants ℤ (SLnZ 2)
-      (SLnZ 2) (SLnZ 2) (diagCoset a).rep D₂.rep) (by simp)
-  exact h.trans (by simp)
+  rw [diagElem_def, diagElem_def]
+  -- `single_mul_single` yields `1 • 1 • …` on the `Module ℤ` instance transported to
+  -- `HeckeCosetModule`, which is not the instance `one_smul` picks for `ℤ`, so neither `rw`
+  -- nor `simp` matches it in place. Stating the product `•`-free lets unification supply the
+  -- instance — the idiom already used in `GL2/MultiplicationTable.lean`.
+  have hmul : HeckeCosetModule.single ℤ (diagCoset a) 1 * HeckeCosetModule.single ℤ (diagCoset b) 1
+      = HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+          (diagCoset a).rep (diagCoset b).rep := by
+    rw [HeckeCosetModule.single_mul_single]
+    exact (one_smul ℤ _).trans (one_smul ℤ _)
+  exact hmul
 
 /-- For n=1, `heckeGen(0)^k = diagElem(fun _ => p^k)`. -/
 private lemma heckeGen_pow_one (p : ℕ) (hp : 0 < p) (k : ℕ) :


### PR DESCRIPTION
`evalHom` is injective at `n = 1` and `n = 2`. Combined with the surjectivity that landed in
#2478, that completes **Shimura's Theorem 3.20** in the two cases the classical theory uses: the
`p`-local Hecke ring of `GL_n` *is* the polynomial ring on the diagonal prime cosets.

```lean
noncomputable def polynomialRingEquivOne : MvPolynomial (Fin 1) ℤ ≃+* pLocalSubring 1 p
noncomputable def polynomialRingEquivTwo : MvPolynomial (Fin 2) ℤ ≃+* pLocalSubring 2 p
```

## How injectivity goes

Suppose `evalHom p R = 0` for a nonzero `R`. Evaluating at the double coset `T(p^{e})` attached
to a monomial's exponent vector isolates that monomial's coefficient, because the diagonal
elements `T(a)` are a *basis*: distinct exponent vectors give distinct cosets. At `n = 1` the
monomial `X^k` goes to `T(p^k)` and the isolation is immediate. At `n = 2` the products
`T(1,p)^{a} T(p,p)^{b}` are sorted by the elementary-divisor order, and reading the leading
coset picks out `(a, b)`; the supporting computation is the structure-constant expansion of a
product of two basis elements.

## Two upstream additions, both consumed here

* `evalHom_def` in `GLn/PolynomialRing/Basic.lean` — the characteristic lemma for the sealed
  `evalHom`, in the `heckeGen_def` idiom. Without it a consumer cannot unfold to
  `MvPolynomial.eval₂Hom` at all: `evalHom` is `public` with no `@[expose]`, so `rw [evalHom]`
  and `unfold evalHom` both fail across the module boundary. Two proofs here need that unfolding.
* `isDvdChain_mul_const` in `GLn/DiagonalCosets.lean`, beside `isDvdChain_const` — scaling a
  divisibility chain by a constant keeps it a chain.

## Relation to #2478

This branch was rebuilt on top of the merged #2478 rather than rebased, because that PR changed
most of what this file referenced. Removed as now-duplicate:

* `evalHom_mem_pLocalSubring` — #2478 added it to `Basic.lean`;
* `evalHomR` and its 12 uses — it was the same map as #2478's `evalHomLocal`, hand-bundled
  rather than via `codRestrict`; all uses now point at the merged one.

Adjusted for #2478's other changes: the `Surj`/`SurjOne` namespaces merged into `HeckeRing.GLn`;
`pLocalSubring_*_subset_evalHom_range` renamed to `_le_`; the rank-one results weakened to
`0 < p`, so call sites pass `hp.pos`; and the `attribute [local instance]` line replaced by a
local `CommSemiring` reconstruction, since #2478 removed the `@[expose]` chain and a
`local instance` in `Basic.lean` does not cross the module boundary.

## Provenance

Ported from AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB),
`LeanModularForms/HeckeRIngs/GLn/PolynomialRing.lean` (Chris Birkbeck), the injectivity
sections. The surjectivity sections of the same source landed in #2478.

## Roadmap

`TauCetiRoadmap/ModularForms/README.md`, **Layer 2(a)**: "the `p`-local ring `R_p` with
**Shimura's Theorem 3.20**: `R_p ≅ ℤ[T(p,1,…,1), …, T(p,…,p)]`, a polynomial ring on the `n`
diagonal prime cosets (`GLn/PolynomialRing.lean` — proved for `n = 2`)". This supplies the
`≅`, which #2478 left as a one-sided inclusion. The two steps the roadmap records as still open
at general `n` — uniqueness of the leading double coset in the triangular expansion, and
recovery of the generator exponents from the leading elementary-divisor vector — are not
formalised in the source and are not attempted here.

Roadmap: ModularForms
