### PR TITLE
feat(Topology): the closure of the image of a neighbourhood is a neighbourhood

### DIFF
--- a/TauCeti/Topology/Algebra/Group/Pointwise.lean
+++ b/TauCeti/Topology/Algebra/Group/Pointwise.lean
@@ -10,8 +10,9 @@ public import Mathlib.Topology.Algebra.Group.Pointwise
 # Closures and pointwise quotients
 
 Mathlib relates `closure` to a pointwise product when one factor is *open* — `IsOpen.mul_closure`
-and its neighbours in `Mathlib/Topology/Algebra/Group/Pointwise.lean`. The containment that needs
-no openness hypothesis at all, and follows from continuity of division alone, is not there.
+and its neighbours in `Mathlib/Topology/Algebra/Group/Pointwise.lean` — and to a pointwise scalar
+product when the action is jointly continuous, in `smul_set_closure_subset`. The containment for
+division, which needs neither openness nor a group structure, is not there.
 
 It is what a Baire argument needs. Such an argument produces a set whose *closure* has interior,
 and the step from there to a neighbourhood of the identity runs through `D / D` for that closure
@@ -29,14 +30,14 @@ open Pointwise
 
 namespace TauCeti
 
-variable {G : Type*} [TopologicalSpace G] [Group G] [IsTopologicalGroup G]
+variable {G : Type*} [TopologicalSpace G] [Div G] [ContinuousDiv G]
 
-/-- **Division carries closures into the closure of the quotient.** No openness hypothesis is
-needed, unlike the `IsOpen.mul_closure` family: continuity of `(x, y) ↦ x / y` is the whole
-input, applied to `closure (s ×ˢ t) = closure s ×ˢ closure t`. -/
-@[to_additive /-- **Subtraction carries closures into the closure of the difference.** No openness
-hypothesis is needed: continuity of `(x, y) ↦ x - y` is the whole input, applied to
-`closure (s ×ˢ t) = closure s ×ˢ closure t`. -/]
+/-- **Division carries closures into the closure of the quotient.** Neither set need be open,
+unlike in the `IsOpen.mul_closure` family, and `G` need only carry a continuous division — no
+group structure, and in particular no inverse. -/
+@[to_additive /-- **Subtraction carries closures into the closure of the difference.** Neither set
+need be open, and `G` need only carry a continuous subtraction — no group structure, and in
+particular no negation. -/]
 theorem closure_div_closure_subset (s t : Set G) : closure s / closure t ⊆ closure (s / t) :=
   calc closure s / closure t
       = (fun p : G × G ↦ p.1 / p.2) '' (closure s ×ˢ closure t) := by

--- a/TauCeti/Topology/Algebra/Group/Pointwise.lean
+++ b/TauCeti/Topology/Algebra/Group/Pointwise.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Algebra.Group.Pointwise
+
+/-!
+# Closures and pointwise quotients
+
+Mathlib relates `closure` to a pointwise product when one factor is *open* — `IsOpen.mul_closure`
+and its neighbours in `Mathlib/Topology/Algebra/Group/Pointwise.lean`. The containment that needs
+no openness hypothesis at all, and follows from continuity of division alone, is not there.
+
+It is what a Baire argument needs. Such an argument produces a set whose *closure* has interior,
+and the step from there to a neighbourhood of the identity runs through `D / D` for that closure
+`D`; without this containment there is no way back from `closure s / closure t` to a closure.
+
+## Main results
+
+* `TauCeti.closure_div_closure_subset`, with its additive form
+  `TauCeti.closure_sub_closure_subset`.
+-/
+
+public section
+
+open Pointwise
+
+namespace TauCeti
+
+variable {G : Type*} [TopologicalSpace G] [Group G] [IsTopologicalGroup G]
+
+/-- **Division carries closures into the closure of the quotient.** No openness hypothesis is
+needed, unlike the `IsOpen.mul_closure` family: continuity of `(x, y) ↦ x / y` is the whole
+input, applied to `closure (s ×ˢ t) = closure s ×ˢ closure t`. -/
+@[to_additive /-- **Subtraction carries closures into the closure of the difference.** No openness
+hypothesis is needed: continuity of `(x, y) ↦ x - y` is the whole input, applied to
+`closure (s ×ˢ t) = closure s ×ˢ closure t`. -/]
+theorem closure_div_closure_subset (s t : Set G) : closure s / closure t ⊆ closure (s / t) :=
+  calc closure s / closure t
+      = (fun p : G × G ↦ p.1 / p.2) '' (closure s ×ˢ closure t) := by
+        rw [Set.image_prod, Set.image2_div]
+    _ = (fun p : G × G ↦ p.1 / p.2) '' closure (s ×ˢ t) := by rw [closure_prod_eq]
+    _ ⊆ closure ((fun p : G × G ↦ p.1 / p.2) '' (s ×ˢ t)) :=
+        image_closure_subset_closure_image (continuous_fst.div' continuous_snd)
+    _ = closure (s / t) := by rw [Set.image_prod, Set.image2_div]
+
+end TauCeti
+
+end

--- a/TauCeti/Topology/Algebra/OpenMapping.lean
+++ b/TauCeti/Topology/Algebra/OpenMapping.lean
@@ -137,19 +137,16 @@ end Image
 section Nhds
 
 variable {A M N : Type*} [MonoidWithZero A] [TopologicalSpace A]
-  [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M] [MulActionWithZero A M]
-  [AddCommGroup N] [TopologicalSpace N] [IsTopologicalAddGroup N] [MulAction A N]
+  [AddGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M] [MulActionWithZero A M]
+  [AddGroup N] [TopologicalSpace N] [IsTopologicalAddGroup N] [MulAction A N]
   [ContinuousConstSMul A N]
 
 /-- **The closure of the image of a neighbourhood of zero is a neighbourhood of zero.** This is
-the Baire step's interior turned into a neighbourhood, and the last statement about `f` that holds
-without completeness or first countability.
+the strongest statement about `f` available without completeness or first countability; removing
+the closure needs both and is not done here.
 
-The upgrade is the classical one. Take the neighbourhood `V` symmetric with `V + V ⊆ U`; the Baire
-step puts a point `y` in the interior `W` of `closure (f '' V)`, and then `W - y` is an open
-neighbourhood of zero inside `closure (f '' V) - closure (f '' V)`, which
-`TauCeti.closure_sub_closure_subset` keeps inside `closure (f '' (V - V)) ⊆ closure (f '' U)`.
-Additivity of `f` enters here and nowhere earlier. -/
+Additivity of `f` is used here and by none of the results above, which is why this and its
+class-level companion carry the additive hypotheses on `M` and `N` and those do not. -/
 theorem closure_image_mem_nhds_zero_of_tendsto_zero [BaireSpace N]
     {F : Type*} [FunLike F M N] [MulActionHomClass F A M N] [AddMonoidHomClass F M N] (f : F)
     (hf : Function.Surjective f) {u : ℕ → Aˣ} (hu : Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0))

--- a/TauCeti/Topology/Algebra/OpenMapping.lean
+++ b/TauCeti/Topology/Algebra/OpenMapping.lean
@@ -4,17 +4,18 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Topology.Algebra.Group.Pointwise
 public import TauCeti.Topology.Algebra.ZeroSequenceOfUnits
 public import Mathlib.Topology.Baire.Lemmas
 public import Mathlib.GroupTheory.GroupAction.Pointwise
 
 /-!
-# The Baire step of Henkel's open mapping theorem
+# The Baire steps of Henkel's open mapping theorem
 
 Henkel's open mapping theorem says that a continuous surjective linear map between complete
 Hausdorff first-countable modules over a ring with a zero sequence of units is open. Its first
 half is a Baire-category argument, and that half is what this file isolates. It needs none of
-the hypotheses the second half needs — no completeness, no first countability, not even
+the hypotheses the rest of the proof needs — no completeness, no first countability, not even
 continuity of the map. What it does need is that the target is a Baire space and that the map is
 equivariant, the latter being what lets a dilate pass through it.
 
@@ -25,9 +26,15 @@ that cover to a cover of the target by the corresponding dilates of `f '' U`; Ba
 their closures to have interior; and dilating back by a unit — a homeomorphism of the target —
 moves that interior onto `closure (f '' U)` itself.
 
-What this does **not** give is that `closure (f '' U)` is a *neighbourhood of zero*, still less
-that `f '' U` is. Both are later steps of Henkel's proof and neither is proved here; the second
-is where completeness and first countability enter.
+The interior is then upgraded to a neighbourhood of zero in the usual way: a difference `D - D`
+of the closure with itself absorbs a translate of that interior, and `D - D` stays inside a
+closure by `TauCeti.closure_sub_closure_subset`. Choosing the neighbourhood symmetric — which
+Mathlib's `exists_closed_nhds_zero_neg_eq_add_subset` does in one step — turns that difference
+back into the image of `U`.
+
+What this does **not** give is that `f '' U` itself is a neighbourhood of zero, only its closure.
+Removing that closure is the last step of Henkel's proof and is where completeness and first
+countability enter; it is not proved here.
 
 ## Main results
 
@@ -37,7 +44,10 @@ is where completeness and first countability enter.
 * `TauCeti.nonempty_interior_closure_image_of_tendsto_zero`: the form Henkel's proof uses — along
   a zero sequence of units, the closure of the image of any neighbourhood of zero under a
   surjective equivariant map has nonempty interior.
-* `TauCeti.HasZeroSequenceOfUnits.nonempty_interior_closure_image`: the same, taking the sequence
+* `TauCeti.closure_image_mem_nhds_zero_of_tendsto_zero`: that interior upgraded — the closure of
+  the image of a neighbourhood of zero *is* a neighbourhood of zero.
+* `TauCeti.HasZeroSequenceOfUnits.nonempty_interior_closure_image` and
+  `TauCeti.HasZeroSequenceOfUnits.closure_image_mem_nhds_zero`: the same two, taking the sequence
   from the class rather than from the caller.
 
 ## References
@@ -123,6 +133,53 @@ theorem HasZeroSequenceOfUnits.nonempty_interior_closure_image [HasZeroSequenceO
   nonempty_interior_closure_image_of_tendsto_zero f hf hu hc hU
 
 end Image
+
+section Nhds
+
+variable {A M N : Type*} [MonoidWithZero A] [TopologicalSpace A]
+  [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M] [MulActionWithZero A M]
+  [AddCommGroup N] [TopologicalSpace N] [IsTopologicalAddGroup N] [MulAction A N]
+  [ContinuousConstSMul A N]
+
+/-- **The closure of the image of a neighbourhood of zero is a neighbourhood of zero.** This is
+the Baire step's interior turned into a neighbourhood, and the last statement about `f` that holds
+without completeness or first countability.
+
+The upgrade is the classical one. Take the neighbourhood `V` symmetric with `V + V ⊆ U`; the Baire
+step puts a point `y` in the interior `W` of `closure (f '' V)`, and then `W - y` is an open
+neighbourhood of zero inside `closure (f '' V) - closure (f '' V)`, which
+`TauCeti.closure_sub_closure_subset` keeps inside `closure (f '' (V - V)) ⊆ closure (f '' U)`.
+Additivity of `f` enters here and nowhere earlier. -/
+theorem closure_image_mem_nhds_zero_of_tendsto_zero [BaireSpace N]
+    {F : Type*} [FunLike F M N] [MulActionHomClass F A M N] [AddMonoidHomClass F M N] (f : F)
+    (hf : Function.Surjective f) {u : ℕ → Aˣ} (hu : Tendsto (fun n ↦ ((u n : A))) atTop (𝓝 0))
+    (hc : ∀ x : M, ContinuousAt (fun a : A ↦ a • x) 0) {U : Set M} (hU : U ∈ 𝓝 (0 : M)) :
+    closure (f '' U) ∈ 𝓝 (0 : N) := by
+  obtain ⟨V, hV, -, hVneg, hVU⟩ := exists_closed_nhds_zero_neg_eq_add_subset hU
+  have hVsub : V - V ⊆ U := by rw [sub_eq_add_neg, hVneg]; exact hVU
+  obtain ⟨y, hy⟩ := nonempty_interior_closure_image_of_tendsto_zero f hf hu hc hV
+  -- `W - y` is an open neighbourhood of zero, presented as the preimage of `W` under `· + y`.
+  have hO : IsOpen ((fun x : N ↦ x + y) ⁻¹' interior (closure (f '' V))) :=
+    isOpen_interior.preimage (continuous_id.add continuous_const)
+  refine Filter.mem_of_superset (hO.mem_nhds (by simpa using hy)) fun x hx ↦ ?_
+  have hxy : x ∈ closure (f '' V) - closure (f '' V) :=
+    ⟨x + y, interior_subset hx, y, interior_subset hy, add_sub_cancel_right x y⟩
+  refine closure_mono ?_ (closure_sub_closure_subset _ _ hxy)
+  rw [← Set.image_sub]
+  exact Set.image_mono hVsub
+
+/-- **The neighbourhood step under the class hypothesis.** The same conclusion as
+`TauCeti.closure_image_mem_nhds_zero_of_tendsto_zero`, with the zero sequence taken from
+`TauCeti.HasZeroSequenceOfUnits` instead of supplied by the caller. -/
+theorem HasZeroSequenceOfUnits.closure_image_mem_nhds_zero [HasZeroSequenceOfUnits A]
+    [BaireSpace N] {F : Type*} [FunLike F M N]
+    [MulActionHomClass F A M N] [AddMonoidHomClass F M N] (f : F) (hf : Function.Surjective f)
+    (hc : ∀ x : M, ContinuousAt (fun a : A ↦ a • x) 0) {U : Set M} (hU : U ∈ 𝓝 (0 : M)) :
+    closure (f '' U) ∈ 𝓝 (0 : N) :=
+  let ⟨_, hu⟩ := ‹HasZeroSequenceOfUnits A›.exists_tendsto
+  closure_image_mem_nhds_zero_of_tendsto_zero f hf hu hc hU
+
+end Nhds
 
 end TauCeti
 


### PR DESCRIPTION
**The step of Henkel's open mapping theorem after the Baire argument:** `closure (f '' U)` is a
neighbourhood of zero, not merely a set with interior.

AdicSpaces §0.6 asks for Wedhorn Theorem 6.16 and Propositions 6.17–6.18 "using Henkel's open
mapping theorem". #2544 landed the zero-sequence hypothesis and its countable covering, #2684 the
Baire argument. This is the next link.

* `closure_image_mem_nhds_zero_of_tendsto_zero`, with the class-level
  `HasZeroSequenceOfUnits.closure_image_mem_nhds_zero` beside it. Take `V` symmetric with
  `V + V ⊆ U` — `exists_closed_nhds_zero_neg_eq_add_subset` gives one in a single step — and the
  interior `W` that #2684 produces inside `closure (f '' V)` absorbs a translate: `W - y` is an
  open neighbourhood of zero, and `D - D` for the closure `D` stays inside a closure.
* That last containment, `closure s - closure t ⊆ closure (s - t)`, is **absent from Mathlib** —
  `Mathlib/Topology/Algebra/Group/Pointwise.lean` relates `closure` to pointwise products only
  when one factor is *open* (`IsOpen.mul_closure` and neighbours), and the openness-free version
  that follows from continuity of division alone is not there. It goes into the mirrored
  `TauCeti/Topology/Algebra/Group/Pointwise.lean`, stated multiplicatively with `@[to_additive]`,
  rather than in the Huber-facing file. That is the shape the `placement` rubric asked for on
  #2658 when a general fact was living in a topic module.

Additivity of the map is used here for the first time, so the two neighbourhood results sit in
their own section carrying the additive binders; the Baire results keep the weaker hypotheses they
already had (`[Zero M]`, no additive structure on the target).

Still **not** included: that `f '' U` itself is a neighbourhood — removing the closure is the last
step of Henkel's proof and is where completeness and first countability enter. The module docstring
says so.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0.6-henkel-nhds-step"}-->

🤖 Prepared with Claude Code
