### PR TITLE
feat(Huber): the evaluation of a weighted restricted series is summable

### DIFF
--- a/TauCeti/RingTheory/Huber/Bounded.lean
+++ b/TauCeti/RingTheory/Huber/Bounded.lean
@@ -176,10 +176,9 @@ section CommMonoidWithZero
 
 variable {M : Type*} [CommMonoidWithZero M] [TopologicalSpace M]
 
-/-- **A finite pointwise product of bounded sets is bounded.** This is
-`Finset.prod_induction` with `TauCeti.Huber.IsBounded.mul` for the step; commutativity is what
-makes the `Finset` product of sets available in the first place. No continuity is needed: the
-unit case is `{1}`, which `TauCeti.Huber.isBounded_pair_zero_one` already bounds. -/
+/-- **A finite pointwise product of bounded sets is bounded.** Commutativity is
+what makes the `Finset` product of sets available in the first place, and no continuity is
+required. -/
 theorem isBounded_finsetProd {ι : Type*} (s : Finset ι) {S : ι → Set M}
     (hS : ∀ i ∈ s, IsBounded (S i)) : IsBounded (∏ i ∈ s, S i) :=
   s.prod_induction S IsBounded (fun _ _ ↦ IsBounded.mul)

--- a/TauCeti/RingTheory/Huber/Bounded.lean
+++ b/TauCeti/RingTheory/Huber/Bounded.lean
@@ -174,18 +174,20 @@ end MonoidWithZero
 
 section CommMonoidWithZero
 
-variable {M : Type*} [CommMonoidWithZero M] [TopologicalSpace M] [ContinuousMul M]
+variable {M : Type*} [CommMonoidWithZero M] [TopologicalSpace M]
 
 /-- **A finite pointwise product of bounded sets is bounded.** This iterates
 `TauCeti.Huber.IsBounded.mul` from the bounded singleton `{1}`; commutativity is what makes the
-`Finset` product of sets available in the first place. -/
+`Finset` product of sets available in the first place. No continuity is needed: the empty product
+is `{1}`, which `TauCeti.Huber.isBounded_pair_zero_one` already bounds. -/
 theorem isBounded_finset_prod {ι : Type*} (s : Finset ι) {S : ι → Set M}
     (hS : ∀ i ∈ s, IsBounded (S i)) : IsBounded (∏ i ∈ s, S i) := by
   classical
   induction s using Finset.induction with
   | empty =>
-    rw [Finset.prod_empty, show (1 : Set M) = {1} from rfl]
-    exact isBounded_singleton (1 : M)
+    rw [Finset.prod_empty]
+    exact isBounded_pair_zero_one.subset
+      (Set.singleton_subset_iff.mpr (Set.mem_insert_iff.mpr (Or.inr rfl)))
   | insert i s hi ih =>
     rw [Finset.prod_insert hi]
     exact (hS i (Finset.mem_insert_self i s)).mul

--- a/TauCeti/RingTheory/Huber/Bounded.lean
+++ b/TauCeti/RingTheory/Huber/Bounded.lean
@@ -32,6 +32,7 @@ prior formalisation of this layer; its proofs were not used.
 ## Main results
 
 * `TauCeti.Huber.isBounded_iff`: unfolding lemma for `IsBounded`.
+* `TauCeti.Huber.isBounded_finset_prod`: a finite pointwise product of bounded sets is bounded.
 * `TauCeti.Huber.isBounded_finite`: finite sets are bounded.
 * `TauCeti.Huber.IsBounded.union`, `TauCeti.Huber.IsBounded.mul`: unions and pointwise products
   of bounded sets are bounded.
@@ -170,6 +171,27 @@ theorem isBounded_finite {S : Set M} (hS : S.Finite) : IsBounded S := by
 end ContinuousMul
 
 end MonoidWithZero
+
+section CommMonoidWithZero
+
+variable {M : Type*} [CommMonoidWithZero M] [TopologicalSpace M] [ContinuousMul M]
+
+/-- **A finite pointwise product of bounded sets is bounded.** This iterates
+`TauCeti.Huber.IsBounded.mul` from the bounded singleton `{1}`; commutativity is what makes the
+`Finset` product of sets available in the first place. -/
+theorem isBounded_finset_prod {ι : Type*} (s : Finset ι) {S : ι → Set M}
+    (hS : ∀ i ∈ s, IsBounded (S i)) : IsBounded (∏ i ∈ s, S i) := by
+  classical
+  induction s using Finset.induction with
+  | empty =>
+    rw [Finset.prod_empty, show (1 : Set M) = {1} from rfl]
+    exact isBounded_singleton (1 : M)
+  | insert i s hi ih =>
+    rw [Finset.prod_insert hi]
+    exact (hS i (Finset.mem_insert_self i s)).mul
+      (ih fun j hj ↦ hS j (Finset.mem_insert_of_mem hj))
+
+end CommMonoidWithZero
 
 section Nonarchimedean
 

--- a/TauCeti/RingTheory/Huber/Bounded.lean
+++ b/TauCeti/RingTheory/Huber/Bounded.lean
@@ -32,7 +32,7 @@ prior formalisation of this layer; its proofs were not used.
 ## Main results
 
 * `TauCeti.Huber.isBounded_iff`: unfolding lemma for `IsBounded`.
-* `TauCeti.Huber.isBounded_finset_prod`: a finite pointwise product of bounded sets is bounded.
+* `TauCeti.Huber.isBounded_finsetProd`: a finite pointwise product of bounded sets is bounded.
 * `TauCeti.Huber.isBounded_finite`: finite sets are bounded.
 * `TauCeti.Huber.IsBounded.union`, `TauCeti.Huber.IsBounded.mul`: unions and pointwise products
   of bounded sets are bounded.
@@ -176,22 +176,15 @@ section CommMonoidWithZero
 
 variable {M : Type*} [CommMonoidWithZero M] [TopologicalSpace M]
 
-/-- **A finite pointwise product of bounded sets is bounded.** This iterates
-`TauCeti.Huber.IsBounded.mul` from the bounded singleton `{1}`; commutativity is what makes the
-`Finset` product of sets available in the first place. No continuity is needed: the empty product
-is `{1}`, which `TauCeti.Huber.isBounded_pair_zero_one` already bounds. -/
-theorem isBounded_finset_prod {ι : Type*} (s : Finset ι) {S : ι → Set M}
-    (hS : ∀ i ∈ s, IsBounded (S i)) : IsBounded (∏ i ∈ s, S i) := by
-  classical
-  induction s using Finset.induction with
-  | empty =>
-    rw [Finset.prod_empty]
-    exact isBounded_pair_zero_one.subset
-      (Set.singleton_subset_iff.mpr (Set.mem_insert_iff.mpr (Or.inr rfl)))
-  | insert i s hi ih =>
-    rw [Finset.prod_insert hi]
-    exact (hS i (Finset.mem_insert_self i s)).mul
-      (ih fun j hj ↦ hS j (Finset.mem_insert_of_mem hj))
+/-- **A finite pointwise product of bounded sets is bounded.** This is
+`Finset.prod_induction` with `TauCeti.Huber.IsBounded.mul` for the step; commutativity is what
+makes the `Finset` product of sets available in the first place. No continuity is needed: the
+unit case is `{1}`, which `TauCeti.Huber.isBounded_pair_zero_one` already bounds. -/
+theorem isBounded_finsetProd {ι : Type*} (s : Finset ι) {S : ι → Set M}
+    (hS : ∀ i ∈ s, IsBounded (S i)) : IsBounded (∏ i ∈ s, S i) :=
+  s.prod_induction S IsBounded (fun _ _ ↦ IsBounded.mul)
+    (isBounded_pair_zero_one.subset
+      (Set.singleton_subset_iff.mpr (Set.mem_insert_iff.mpr (Or.inr rfl)))) hS
 
 end CommMonoidWithZero
 

--- a/TauCeti/RingTheory/Huber/WeightedEval.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval.lean
@@ -117,10 +117,9 @@ omit [TopologicalSpace A] in
 /-- **At the one-weight family the hypothesis is exactly Wedhorn's**: the weighted monomials are
 bounded precisely when every variable is power-bounded.
 
-Both directions are elementary once the monomials are in view. Forwards, the monomial at
-`ν = Finsupp.single i n` is `bᵢ ^ n`, so the one bounded set already contains every power of every
-`bᵢ`. Backwards, every monomial `bν` lies in the pointwise product of the power-sets, which is
-bounded by `TauCeti.Huber.isBounded_finsetProd`. -/
+This is the case in which the weights impose nothing, so the hypothesis on the tuple is the
+familiar one; for a general `T` it is `TauCeti.Huber.IsWeightedVarPowerBounded` that plays this
+role. -/
 theorem isWeightBounded_one_weight_iff_forall_isPowerBounded (φ : A →+* B)
     (b : Fin k → B) :
     IsWeightBounded φ (fun _ : Fin k ↦ ({1} : Set A)) b ↔ ∀ i, IsPowerBounded (b i) := by
@@ -202,10 +201,10 @@ completeness; completeness is what makes it *sufficient*, in
 `TauCeti.Huber.summable_weightedEvalTerm`.
 
 The three hypotheses each do one thing: `T`-restrictedness puts all but finitely many coefficients
-into `Tν · U`, continuity of `φ` makes `U` small enough that `φ(U)` shrinks the bounded family,
-and `IsWeightBounded` is what makes one `U` work for every `ν` at once. -/
-theorem tendsto_weightedEvalTerm_cofinite_zero {φ : A →+* B} (hφ : Continuous φ) {T : Fin k → Set A}
-    {b : Fin k → B} (hb : IsWeightBounded φ T b) {f : MvPowerSeries (Fin k) A}
+into `Tν · U`, continuity of `φ` at zero makes `U` small enough that `φ(U)` shrinks the bounded
+family, and `IsWeightBounded` is what makes one `U` work for every `ν` at once. -/
+theorem tendsto_weightedEvalTerm_cofinite_zero {φ : A →+* B} (hφ : ContinuousAt φ 0)
+    {T : Fin k → Set A} {b : Fin k → B} (hb : IsWeightBounded φ T b) {f : MvPowerSeries (Fin k) A}
     (hf : IsWeightedRestricted T f) :
     Filter.Tendsto (weightedEvalTerm φ b f) Filter.cofinite (𝓝 0) := by
   refine Filter.tendsto_def.mpr fun W hW ↦ ?_
@@ -213,7 +212,7 @@ theorem tendsto_weightedEvalTerm_cofinite_zero {φ : A →+* B} (hφ : Continuou
   -- Shrink `G` by the bounded family of weighted monomials, then pull the result back along `φ`.
   obtain ⟨V, hV, hVG⟩ := isBounded_iff.mp ((isWeightBounded_iff φ T b).mp hb) (G : Set B)
     (G.isOpen.mem_nhds G.zero_mem)
-  obtain ⟨U, hUV⟩ := NonarchimedeanAddGroup.is_nonarchimedean _ (hφ.continuousAt.preimage_mem_nhds
+  obtain ⟨U, hUV⟩ := NonarchimedeanAddGroup.is_nonarchimedean _ (hφ.preimage_mem_nhds
     (by simpa only [map_zero] using hV))
   -- All but finitely many coefficients lie in `Tν · U`, and every such term lands in `G`.
   filter_upwards [isWeightedRestricted_iff.mp hf U] with ν hν
@@ -245,7 +244,7 @@ variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [Nonarchimede
 
 /-- **The evaluation of a `T`-restricted series is summable.** Its terms tend to zero along the
 cofinite filter, which in a complete nonarchimedean group is summability. -/
-theorem summable_weightedEvalTerm {φ : A →+* B} (hφ : Continuous φ) {T : Fin k → Set A}
+theorem summable_weightedEvalTerm {φ : A →+* B} (hφ : ContinuousAt φ 0) {T : Fin k → Set A}
     {b : Fin k → B} (hb : IsWeightBounded φ T b) {f : MvPowerSeries (Fin k) A}
     (hf : IsWeightedRestricted T f) :
     Summable (weightedEvalTerm φ b f) :=
@@ -256,7 +255,8 @@ theorem summable_weightedEvalTerm {φ : A →+* B} (hφ : Continuous φ) {T : Fi
 each weighted variable power-bounded as a set is enough. This is the theorem above read through
 `TauCeti.Huber.isWeightBounded_of_isWeightedVarPowerBounded`, and it is the form Proposition 5.50
 states. -/
-theorem summable_weightedEvalTerm_of_isWeightedVarPowerBounded {φ : A →+* B} (hφ : Continuous φ)
+theorem summable_weightedEvalTerm_of_isWeightedVarPowerBounded {φ : A →+* B}
+    (hφ : ContinuousAt φ 0)
     {T : Fin k → Set A} {b : Fin k → B} (hb : IsWeightedVarPowerBounded φ T b)
     {f : MvPowerSeries (Fin k) A} (hf : IsWeightedRestricted T f) :
     Summable (weightedEvalTerm φ b f) :=
@@ -267,7 +267,7 @@ tuple is that each variable be power-bounded, which is how Proposition 5.50 stat
 theorem above read through
 `TauCeti.Huber.isWeightBounded_one_weight_iff_forall_isPowerBounded`. -/
 theorem summable_weightedEvalTerm_of_forall_isPowerBounded {φ : A →+* B}
-    (hφ : Continuous φ) {b : Fin k → B} (hb : ∀ i, IsPowerBounded (b i))
+    (hφ : ContinuousAt φ 0) {b : Fin k → B} (hb : ∀ i, IsPowerBounded (b i))
     {f : MvPowerSeries (Fin k) A}
     (hf : IsWeightedRestricted (fun _ : Fin k ↦ ({1} : Set A)) f) :
     Summable (weightedEvalTerm φ b f) :=

--- a/TauCeti/RingTheory/Huber/WeightedEval.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RingTheory.Huber.Bounded
+public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries
+public import Mathlib.Topology.Algebra.InfiniteSum.Nonarchimedean
+
+/-!
+# Evaluating a weighted restricted power series
+
+Wedhorn's universal property of `A⟨X₁, …, Xₖ⟩_T` (Proposition 5.50) sends a `T`-restricted series
+to the sum of its terms at a chosen tuple `b`. Before there is a map to speak of, that sum has to
+exist, and this file supplies exactly that: the family of terms is summable.
+
+Summability is where the defining condition earns its keep. `T`-restrictedness says that for each
+open subgroup `U` of `A`, all but finitely many coefficients lie in `Tν · U`; so all but finitely
+many terms lie in `(φ(Tν) · bν) · φ(U)`. If the weighted monomials `φ(Tν) · bν` stay inside one
+bounded set — `TauCeti.Huber.IsWeightBounded` below, which is Wedhorn's hypothesis that the
+variables are power-bounded *relative to the weights* — then shrinking `U` shrinks every one of
+those terms at once, so the terms tend to zero along the cofinite filter. In a complete
+nonarchimedean group that is already summability.
+
+## Main definitions
+
+* `TauCeti.Huber.weightedEvalTerm`: the term `φ(coeff ν f) · bν` of the evaluation.
+* `TauCeti.Huber.IsWeightBounded`: the weighted monomials `φ(Tν) · bν` form a bounded set. This is
+  the hypothesis on `b`; taking `T` the one-weight family recovers "each `bᵢ` is power-bounded".
+
+## Main results
+
+* `TauCeti.Huber.tendsto_cofinite_weightedEvalTerm`: the terms tend to zero along `cofinite`. This
+  is the content, and it needs no completeness.
+* `TauCeti.Huber.summable_weightedEvalTerm`: hence they are summable, once `B` is complete.
+
+The evaluation map itself, its continuity, and the uniqueness that makes Proposition 5.50 a
+universal property are not proved here.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Proposition 5.50, whose analytic core this is.
+-/
+
+public section
+
+open Pointwise Topology
+
+namespace TauCeti.Huber
+
+section Terms
+
+variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [CommRing B] [TopologicalSpace B]
+
+/-- The `ν`-th term of the evaluation of `f` at `b` along `φ`, namely `φ(coeff ν f) · bν`. -/
+def weightedEvalTerm (φ : A →+* B) (b : Fin k → B) (f : MvPowerSeries (Fin k) A)
+    (ν : Fin k →₀ ℕ) : B :=
+  φ (MvPowerSeries.coeff ν f) * ∏ i, b i ^ ν i
+
+omit [TopologicalSpace A] [TopologicalSpace B] in
+/-- Unfolding lemma for `TauCeti.Huber.weightedEvalTerm`. -/
+theorem weightedEvalTerm_def (φ : A →+* B) (b : Fin k → B) (f : MvPowerSeries (Fin k) A)
+    (ν : Fin k →₀ ℕ) :
+    weightedEvalTerm φ b f ν = φ (MvPowerSeries.coeff ν f) * ∏ i, b i ^ ν i := (rfl)
+
+/-- **The hypothesis on the tuple `b`**: the weighted monomials `φ(Tν) · bν`, over all
+multi-indices at once, form a bounded subset of `B`.
+
+This is Wedhorn's requirement that the variables be power-bounded *relative to the weights*, in
+the form the summability argument uses. It is a condition on the whole family rather than on each
+`bᵢ` separately, because the bound has to be uniform in `ν`; for the one-weight family `T ≡ {1}`
+it says exactly that the set of monomials `bν` is bounded, i.e. that each `bᵢ` is power-bounded
+and the bounds combine. -/
+def IsWeightBounded (φ : A →+* B) (T : Fin k → Set A) (b : Fin k → B) : Prop :=
+  IsBounded (⋃ ν : Fin k →₀ ℕ, (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν)
+
+omit [TopologicalSpace A] in
+/-- Unfolding lemma for `TauCeti.Huber.IsWeightBounded`. The body is not exported, so this is how
+a consumer supplies one or takes one apart. -/
+theorem isWeightBounded_iff (φ : A →+* B) (T : Fin k → Set A) (b : Fin k → B) :
+    IsWeightBounded φ T b ↔
+      IsBounded (⋃ ν : Fin k →₀ ℕ, (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν) := (Iff.rfl)
+
+variable [NonarchimedeanRing A] [NonarchimedeanRing B]
+
+/-- **The terms of the evaluation tend to zero along the cofinite filter.** This is the whole
+content of summability, and it needs no completeness.
+
+The three hypotheses each do one thing: `T`-restrictedness puts all but finitely many coefficients
+into `Tν · U`, continuity of `φ` makes `U` small enough that `φ(U)` shrinks the bounded family,
+and `IsWeightBounded` is what makes one `U` work for every `ν` at once. -/
+theorem tendsto_cofinite_weightedEvalTerm {φ : A →+* B} (hφ : Continuous φ) {T : Fin k → Set A}
+    {b : Fin k → B} (hb : IsWeightBounded φ T b) {f : MvPowerSeries (Fin k) A}
+    (hf : IsWeightedRestricted T f) :
+    Filter.Tendsto (weightedEvalTerm φ b f) Filter.cofinite (𝓝 0) := by
+  refine Filter.tendsto_def.mpr fun W hW ↦ ?_
+  obtain ⟨G, hGW⟩ := NonarchimedeanAddGroup.is_nonarchimedean W hW
+  -- Shrink `G` by the bounded family of weighted monomials, then pull the result back along `φ`.
+  obtain ⟨V, hV, hVG⟩ := isBounded_iff.mp ((isWeightBounded_iff φ T b).mp hb) (G : Set B)
+    (G.isOpen.mem_nhds G.zero_mem)
+  obtain ⟨U, hUV⟩ := NonarchimedeanAddGroup.is_nonarchimedean _ (hφ.continuousAt.preimage_mem_nhds
+    (by simpa only [map_zero] using hV))
+  -- All but finitely many coefficients lie in `Tν · U`, and every such term lands in `G`.
+  filter_upwards [isWeightedRestricted_iff.mp hf U] with ν hν
+  refine hGW ?_
+  -- Multiplying by `bν` is additive, so `Tν · U` lands in `G` as soon as its generators do.
+  let ψ : A →+ B := (AddMonoidHom.mulRight (∏ i, b i ^ ν i)).comp (φ : A →+ B)
+  refine weightMul_le (V := G.toAddSubgroup.comap ψ) |>.mpr (fun t ht u hu ↦ ?_) hν
+  -- On a generator the term is `φ u * (φ t * bν)`: a small element times a bounded one.
+  have hgen : ψ (t * u) = φ u * (φ t * ∏ i, b i ^ ν i) := by
+    simp only [ψ, AddMonoidHom.coe_comp, Function.comp_apply, AddMonoidHom.coe_mulRight,
+      AddMonoidHom.coe_coe, map_mul]
+    ring
+  simp only [AddSubgroup.mem_comap, hgen]
+  exact hVG (Set.mul_mem_mul (hUV hu) (Set.mem_iUnion.mpr ⟨ν, ⟨t, ht, rfl⟩⟩))
+
+end Terms
+
+section Summable
+
+variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+  [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
+
+/-- **The evaluation of a `T`-restricted series is summable.** Its terms tend to zero along the
+cofinite filter, which in a complete nonarchimedean group is summability. -/
+theorem summable_weightedEvalTerm {φ : A →+* B} (hφ : Continuous φ) {T : Fin k → Set A}
+    {b : Fin k → B} (hb : IsWeightBounded φ T b) {f : MvPowerSeries (Fin k) A}
+    (hf : IsWeightedRestricted T f) :
+    Summable (weightedEvalTerm φ b f) :=
+  NonarchimedeanAddGroup.summable_of_tendsto_cofinite_zero
+    (tendsto_cofinite_weightedEvalTerm hφ hb hf)
+
+end Summable
+
+end TauCeti.Huber
+
+end

--- a/TauCeti/RingTheory/Huber/WeightedEval.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval.lean
@@ -28,8 +28,12 @@ it to summability, through Mathlib's
 ## Main definitions
 
 * `TauCeti.Huber.weightedEvalTerm`: the term `φ(coeff ν f) · bν` of the evaluation.
+* `TauCeti.Huber.weightedVar` and `TauCeti.Huber.IsWeightedVarPowerBounded`: Wedhorn's own
+  coordinatewise hypothesis — each weighted variable `φ(Tᵢ) · bᵢ` is power-bounded as a set.
 * `TauCeti.Huber.IsWeightBounded`: the weighted monomials `φ(Tν) · bν` form a bounded set. This is
-  the hypothesis on `b`. At the one-weight family it is *equivalent* to each `bᵢ` being
+  the hypothesis the summability proof uses, and
+  `TauCeti.Huber.isWeightBounded_of_isWeightedVarPowerBounded` derives it from the coordinatewise
+  one for an arbitrary `T`. At the one-weight family it is *equivalent* to each `bᵢ` being
   power-bounded, which is Wedhorn's condition —
   `TauCeti.Huber.isWeightBounded_one_weight_iff_forall_isPowerBounded`.
 
@@ -39,8 +43,10 @@ it to summability, through Mathlib's
   cofinite filter. This is the analytic input, and it needs no completeness.
 * `TauCeti.Huber.summable_weightedEvalTerm`: completeness upgrades that convergence to
   summability.
-* `TauCeti.Huber.summable_weightedEvalTerm_of_forall_isPowerBounded`: the same at the one-weight
-  family, stated with Wedhorn's own hypothesis that each variable is power-bounded.
+* `TauCeti.Huber.summable_weightedEvalTerm_of_isWeightedVarPowerBounded`: the same stated with
+  Wedhorn's coordinatewise hypothesis, for an arbitrary weight family.
+* `TauCeti.Huber.summable_weightedEvalTerm_of_forall_isPowerBounded`: its one-weight reading, where
+  the hypothesis is that each variable is power-bounded.
 
 The evaluation map itself, its continuity, and the uniqueness that makes Proposition 5.50 a
 universal property are not proved here.
@@ -128,6 +134,67 @@ theorem isWeightBounded_one_weight_iff_forall_isPowerBounded (φ : A →+* B)
     exact Set.finsetProd_mem_finsetProd Finset.univ _ _ fun i _ ↦ ⟨ν i, rfl⟩
 
 
+/-- The **weighted variables** of Proposition 5.50: the sets `φ(Tᵢ) · bᵢ`. The hypothesis 5.50
+places on the tuple is about these, not about the `bᵢ` alone. -/
+def weightedVar (φ : A →+* B) (T : Fin k → Set A) (b : Fin k → B) (i : Fin k) : Set B :=
+  φ '' T i * {b i}
+
+omit [TopologicalSpace A] [TopologicalSpace B] in
+/-- Unfolding lemma for `TauCeti.Huber.weightedVar`. -/
+@[simp]
+theorem weightedVar_def (φ : A →+* B) (T : Fin k → Set A) (b : Fin k → B) (i : Fin k) :
+    weightedVar φ T b i = φ '' T i * {b i} := (rfl)
+
+/-- **Wedhorn's coordinatewise hypothesis**: each weighted variable is power-bounded *as a set*,
+its powers all lying in one bounded subset of `B`.
+
+This is the condition Proposition 5.50 actually states, one index at a time, and
+`TauCeti.Huber.isWeightBounded_of_isWeightedVarPowerBounded` derives the uniform bound
+`TauCeti.Huber.IsWeightBounded` from it. At the one-weight family `weightedVar` is `{bᵢ}`, so it
+reduces to each `bᵢ` being power-bounded. -/
+def IsWeightedVarPowerBounded (φ : A →+* B) (T : Fin k → Set A) (b : Fin k → B) : Prop :=
+  ∀ i, IsBounded (⋃ n : ℕ, weightedVar φ T b i ^ n)
+
+omit [TopologicalSpace A] in
+/-- Unfolding lemma for `TauCeti.Huber.IsWeightedVarPowerBounded`. The body is not exported, so
+this is how a consumer supplies one or takes one apart. -/
+theorem isWeightedVarPowerBounded_iff (φ : A →+* B) (T : Fin k → Set A) (b : Fin k → B) :
+    IsWeightedVarPowerBounded φ T b ↔
+      ∀ i, IsBounded (⋃ n : ℕ, weightedVar φ T b i ^ n) := (Iff.rfl)
+
+omit [TopologicalSpace A] [TopologicalSpace B] in
+/-- The weighted monomials at `ν` are the pointwise product of the `νᵢ`-th powers of the weighted
+variables. Private: it is the bookkeeping behind the bridge below and says nothing on its own. -/
+private theorem image_weightPow_mul_monomial (φ : A →+* B) (T : Fin k → Set A) (b : Fin k → B)
+    (ν : Fin k →₀ ℕ) :
+    (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν = ∏ i, weightedVar φ T b i ^ ν i := by
+  have h1 : (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν
+      = (φ '' weightPow T ν) * {∏ i, b i ^ ν i} := by
+    rw [Set.mul_singleton, Set.image_image]
+  have h2 : φ '' weightPow T ν = ∏ i, (φ '' T i) ^ ν i := by
+    rw [weightPow_def, Set.image_finsetProd]
+    exact Finset.prod_congr rfl fun i _ ↦ Set.image_pow ..
+  have h3 : ({∏ i, b i ^ ν i} : Set B) = ∏ i, ({b i} : Set B) ^ ν i := by
+    rw [← Set.finsetProd_singleton]
+    exact Finset.prod_congr rfl fun i _ ↦ (Set.singleton_pow ..).symm
+  rw [h1, h2, h3, ← Finset.prod_mul_distrib]
+  exact Finset.prod_congr rfl fun i _ ↦ by rw [weightedVar_def, mul_pow]
+
+omit [TopologicalSpace A] in
+/-- **Wedhorn's coordinatewise hypothesis gives the uniform bound.** Each weighted monomial set is
+a finite pointwise product of powers of the weighted variables, so it lies in the product of the
+bounded sets containing those powers — and a finite pointwise product of bounded sets is bounded.
+
+This is what makes `TauCeti.Huber.IsWeightBounded` the right hypothesis for the summability
+theorem rather than a stronger one invented for it: the two are reached from the same place. -/
+theorem isWeightBounded_of_isWeightedVarPowerBounded {φ : A →+* B} {T : Fin k → Set A}
+    {b : Fin k → B} (h : IsWeightedVarPowerBounded φ T b) : IsWeightBounded φ T b := by
+  rw [isWeightBounded_iff]
+  refine (isBounded_finset_prod Finset.univ
+    (fun i _ ↦ (isWeightedVarPowerBounded_iff φ T b).mp h i)).subset (Set.iUnion_subset fun ν ↦ ?_)
+  rw [image_weightPow_mul_monomial]
+  exact Set.finsetProd_subset_finsetProd _ _ _ fun i _ ↦ Set.subset_iUnion _ _
+
 variable [NonarchimedeanAddGroup A] [NonarchimedeanAddGroup B]
 
 /-- **The terms of the evaluation tend to zero along the cofinite filter.** This is the whole
@@ -185,6 +252,16 @@ theorem summable_weightedEvalTerm {φ : A →+* B} (hφ : Continuous φ) {T : Fi
     Summable (weightedEvalTerm φ b f) :=
   NonarchimedeanAddGroup.summable_of_tendsto_cofinite_zero
     (tendsto_weightedEvalTerm_cofinite_zero hφ hb hf)
+
+/-- **Summability under Wedhorn's coordinatewise hypothesis**, for an arbitrary weight family:
+each weighted variable power-bounded as a set is enough. This is the theorem above read through
+`TauCeti.Huber.isWeightBounded_of_isWeightedVarPowerBounded`, and it is the form Proposition 5.50
+states. -/
+theorem summable_weightedEvalTerm_of_isWeightedVarPowerBounded {φ : A →+* B} (hφ : Continuous φ)
+    {T : Fin k → Set A} {b : Fin k → B} (hb : IsWeightedVarPowerBounded φ T b)
+    {f : MvPowerSeries (Fin k) A} (hf : IsWeightedRestricted T f) :
+    Summable (weightedEvalTerm φ b f) :=
+  summable_weightedEvalTerm hφ (isWeightBounded_of_isWeightedVarPowerBounded hb) hf
 
 /-- **Summability under Wedhorn's own hypothesis.** At the one-weight family the condition on the
 tuple is that each variable be power-bounded, which is how Proposition 5.50 states it; this is the

--- a/TauCeti/RingTheory/Huber/WeightedEval.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval.lean
@@ -120,7 +120,7 @@ bounded precisely when every variable is power-bounded.
 Both directions are elementary once the monomials are in view. Forwards, the monomial at
 `ν = Finsupp.single i n` is `bᵢ ^ n`, so the one bounded set already contains every power of every
 `bᵢ`. Backwards, every monomial `bν` lies in the pointwise product of the power-sets, which is
-bounded by `TauCeti.Huber.isBounded_finset_prod`. -/
+bounded by `TauCeti.Huber.isBounded_finsetProd`. -/
 theorem isWeightBounded_one_weight_iff_forall_isPowerBounded (φ : A →+* B)
     (b : Fin k → B) :
     IsWeightBounded φ (fun _ : Fin k ↦ ({1} : Set A)) b ↔ ∀ i, IsPowerBounded (b i) := by
@@ -128,7 +128,7 @@ theorem isWeightBounded_one_weight_iff_forall_isPowerBounded (φ : A →+* B)
   refine ⟨fun hb i ↦ isPowerBounded_iff.mpr (hb.subset ?_), fun hb ↦ ?_⟩
   · rintro _ ⟨n, rfl⟩
     exact ⟨Finsupp.single i n, by simp [Finsupp.single_apply, Finset.prod_ite_eq]⟩
-  · refine (isBounded_finset_prod Finset.univ
+  · refine (isBounded_finsetProd Finset.univ
       (fun i _ ↦ isPowerBounded_iff.mp (hb i))).subset ?_
     rintro _ ⟨ν, rfl⟩
     exact Set.finsetProd_mem_finsetProd Finset.univ _ _ fun i _ ↦ ⟨ν i, rfl⟩
@@ -172,8 +172,7 @@ private theorem image_weightPow_mul_monomial (φ : A →+* B) (T : Fin k → Set
       = (φ '' weightPow T ν) * {∏ i, b i ^ ν i} := by
     rw [Set.mul_singleton, Set.image_image]
   have h2 : φ '' weightPow T ν = ∏ i, (φ '' T i) ^ ν i := by
-    rw [weightPow_def, Set.image_finsetProd]
-    exact Finset.prod_congr rfl fun i _ ↦ Set.image_pow ..
+    rw [image_weightPow, weightPow_def]
   have h3 : ({∏ i, b i ^ ν i} : Set B) = ∏ i, ({b i} : Set B) ^ ν i := by
     rw [← Set.finsetProd_singleton]
     exact Finset.prod_congr rfl fun i _ ↦ (Set.singleton_pow ..).symm
@@ -190,7 +189,7 @@ theorem rather than a stronger one invented for it: the two are reached from the
 theorem isWeightBounded_of_isWeightedVarPowerBounded {φ : A →+* B} {T : Fin k → Set A}
     {b : Fin k → B} (h : IsWeightedVarPowerBounded φ T b) : IsWeightBounded φ T b := by
   rw [isWeightBounded_iff]
-  refine (isBounded_finset_prod Finset.univ
+  refine (isBounded_finsetProd Finset.univ
     (fun i _ ↦ (isWeightedVarPowerBounded_iff φ T b).mp h i)).subset (Set.iUnion_subset fun ν ↦ ?_)
   rw [image_weightPow_mul_monomial]
   exact Set.finsetProd_subset_finsetProd _ _ _ fun i _ ↦ Set.subset_iUnion _ _

--- a/TauCeti/RingTheory/Huber/WeightedEval.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.RingTheory.Huber.Bounded
+public import TauCeti.RingTheory.Huber.PowerBounded
 public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries
 public import Mathlib.Topology.Algebra.InfiniteSum.Nonarchimedean
 
@@ -20,20 +21,26 @@ open subgroup `U` of `A`, all but finitely many coefficients lie in `Tν · U`; 
 many terms lie in `(φ(Tν) · bν) · φ(U)`. If the weighted monomials `φ(Tν) · bν` stay inside one
 bounded set — `TauCeti.Huber.IsWeightBounded` below, which is Wedhorn's hypothesis that the
 variables are power-bounded *relative to the weights* — then shrinking `U` shrinks every one of
-those terms at once, so the terms tend to zero along the cofinite filter. In a complete
-nonarchimedean group that is already summability.
+those terms at once, so the terms tend to zero along the cofinite filter. That convergence is the
+*necessary* condition, not yet the sufficient one: it is completeness of the target that upgrades
+it to summability, through Mathlib's
+`NonarchimedeanAddGroup.summable_of_tendsto_cofinite_zero`.
 
 ## Main definitions
 
 * `TauCeti.Huber.weightedEvalTerm`: the term `φ(coeff ν f) · bν` of the evaluation.
 * `TauCeti.Huber.IsWeightBounded`: the weighted monomials `φ(Tν) · bν` form a bounded set. This is
-  the hypothesis on `b`; taking `T` the one-weight family recovers "each `bᵢ` is power-bounded".
+  the hypothesis on `b`. At the one-weight family it is boundedness of the set of monomials `bν`
+  (`TauCeti.Huber.isWeightBounded_one_weight_iff`), which implies that each `bᵢ` is power-bounded;
+  the converse needs a finite pointwise product of bounded sets to be bounded, so it is not stated
+  here.
 
 ## Main results
 
-* `TauCeti.Huber.tendsto_cofinite_weightedEvalTerm`: the terms tend to zero along `cofinite`. This
-  is the content, and it needs no completeness.
-* `TauCeti.Huber.summable_weightedEvalTerm`: hence they are summable, once `B` is complete.
+* `TauCeti.Huber.tendsto_weightedEvalTerm_cofinite_zero`: the terms tend to zero along the
+  cofinite filter. This is the analytic input, and it needs no completeness.
+* `TauCeti.Huber.summable_weightedEvalTerm`: completeness upgrades that convergence to
+  summability.
 
 The evaluation map itself, its continuity, and the uniqueness that makes Proposition 5.50 a
 universal property are not proved here.
@@ -69,9 +76,10 @@ multi-indices at once, form a bounded subset of `B`.
 
 This is Wedhorn's requirement that the variables be power-bounded *relative to the weights*, in
 the form the summability argument uses. It is a condition on the whole family rather than on each
-`bᵢ` separately, because the bound has to be uniform in `ν`; for the one-weight family `T ≡ {1}`
-it says exactly that the set of monomials `bν` is bounded, i.e. that each `bᵢ` is power-bounded
-and the bounds combine. -/
+`bᵢ` separately, because the bound has to be uniform in `ν`. For the one-weight family `T ≡ {1}`
+it says exactly that the set of monomials `bν` is bounded, which is strictly a statement about the
+family: it gives that each `bᵢ` is power-bounded, but recovering it from the individual bounds
+needs those bounds to combine multiplicatively. -/
 def IsWeightBounded (φ : A →+* B) (T : Fin k → Set A) (b : Fin k → B) : Prop :=
   IsBounded (⋃ ν : Fin k →₀ ℕ, (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν)
 
@@ -82,15 +90,46 @@ theorem isWeightBounded_iff (φ : A →+* B) (T : Fin k → Set A) (b : Fin k �
     IsWeightBounded φ T b ↔
       IsBounded (⋃ ν : Fin k →₀ ℕ, (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν) := (Iff.rfl)
 
-variable [NonarchimedeanRing A] [NonarchimedeanRing B]
+omit [TopologicalSpace A] in
+/-- **At the one-weight family the hypothesis is boundedness of the monomials.** With every weight
+equal to `{1}` the weighted monomials are just the `bν`, so `IsWeightBounded` says exactly that
+they form a bounded set — the condition a reader expects to see, and the bridge from the roadmap's
+power-bounded-variable hypothesis. -/
+theorem isWeightBounded_one_weight_iff (φ : A →+* B) (b : Fin k → B) :
+    IsWeightBounded φ (fun _ : Fin k ↦ ({1} : Set A)) b ↔
+      IsBounded (Set.range fun ν : Fin k →₀ ℕ ↦ ∏ i, b i ^ ν i) := by
+  have hset : (⋃ ν : Fin k →₀ ℕ,
+      (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow (fun _ : Fin k ↦ ({1} : Set A)) ν)
+      = Set.range fun ν : Fin k →₀ ℕ ↦ ∏ i, b i ^ ν i := by
+    ext x
+    simp [weightPow_one_weight]
+  rw [isWeightBounded_iff, hset]
+
+omit [TopologicalSpace A] in
+/-- **Each variable is power-bounded.** The monomial at `ν = single i n` is `bᵢ ^ n`, so the
+one-weight hypothesis contains every power of every `bᵢ` in one bounded set. The converse — that
+individually power-bounded variables satisfy the hypothesis — needs a finite pointwise product of
+bounded sets to be bounded, which the repo does not yet have, and is not claimed here. -/
+theorem IsWeightBounded.isPowerBounded {φ : A →+* B} {b : Fin k → B}
+    (hb : IsWeightBounded φ (fun _ : Fin k ↦ ({1} : Set A)) b) (i : Fin k) :
+    IsPowerBounded (b i) := by
+  refine isPowerBounded_iff.mpr (((isWeightBounded_one_weight_iff φ b).mp hb).subset ?_)
+  rintro _ ⟨n, rfl⟩
+  refine ⟨Finsupp.single i n, ?_⟩
+  simp [Finsupp.single_apply, Finset.prod_ite_eq]
+
+
+variable [NonarchimedeanAddGroup A] [NonarchimedeanAddGroup B]
 
 /-- **The terms of the evaluation tend to zero along the cofinite filter.** This is the whole
-content of summability, and it needs no completeness.
+analytic input to summability — the convergence a summable family must have. It needs no
+completeness; completeness is what makes it *sufficient*, in
+`TauCeti.Huber.summable_weightedEvalTerm`.
 
 The three hypotheses each do one thing: `T`-restrictedness puts all but finitely many coefficients
 into `Tν · U`, continuity of `φ` makes `U` small enough that `φ(U)` shrinks the bounded family,
 and `IsWeightBounded` is what makes one `U` work for every `ν` at once. -/
-theorem tendsto_cofinite_weightedEvalTerm {φ : A →+* B} (hφ : Continuous φ) {T : Fin k → Set A}
+theorem tendsto_weightedEvalTerm_cofinite_zero {φ : A →+* B} (hφ : Continuous φ) {T : Fin k → Set A}
     {b : Fin k → B} (hb : IsWeightBounded φ T b) {f : MvPowerSeries (Fin k) A}
     (hf : IsWeightedRestricted T f) :
     Filter.Tendsto (weightedEvalTerm φ b f) Filter.cofinite (𝓝 0) := by
@@ -103,24 +142,30 @@ theorem tendsto_cofinite_weightedEvalTerm {φ : A →+* B} (hφ : Continuous φ)
     (by simpa only [map_zero] using hV))
   -- All but finitely many coefficients lie in `Tν · U`, and every such term lands in `G`.
   filter_upwards [isWeightedRestricted_iff.mp hf U] with ν hν
-  refine hGW ?_
   -- Multiplying by `bν` is additive, so `Tν · U` lands in `G` as soon as its generators do.
   let ψ : A →+ B := (AddMonoidHom.mulRight (∏ i, b i ^ ν i)).comp (φ : A →+ B)
-  refine weightMul_le (V := G.toAddSubgroup.comap ψ) |>.mpr (fun t ht u hu ↦ ?_) hν
-  -- On a generator the term is `φ u * (φ t * bν)`: a small element times a bounded one.
-  have hgen : ψ (t * u) = φ u * (φ t * ∏ i, b i ^ ν i) := by
-    simp only [ψ, AddMonoidHom.coe_comp, Function.comp_apply, AddMonoidHom.coe_mulRight,
-      AddMonoidHom.coe_coe, map_mul]
-    ring
-  simp only [AddSubgroup.mem_comap, hgen]
-  exact hVG (Set.mul_mem_mul (hUV hu) (Set.mem_iUnion.mpr ⟨ν, ⟨t, ht, rfl⟩⟩))
+  have hgen : ∀ t ∈ weightPow T ν, ∀ u ∈ U.toAddSubgroup, t * u ∈ G.toAddSubgroup.comap ψ := by
+    intro t ht u hu
+    -- On a generator the term is `φ u * (φ t * bν)`: a small element times a bounded one.
+    have hval : ψ (t * u) = φ u * (φ t * ∏ i, b i ^ ν i) := by
+      simp only [ψ, AddMonoidHom.coe_comp, Function.comp_apply, AddMonoidHom.coe_mulRight,
+        AddMonoidHom.coe_coe, map_mul]
+      ring
+    simp only [AddSubgroup.mem_comap, hval]
+    exact hVG (Set.mul_mem_mul (hUV hu) (Set.mem_iUnion.mpr ⟨ν, ⟨t, ht, rfl⟩⟩))
+  have hcomap : MvPowerSeries.coeff ν f ∈ G.toAddSubgroup.comap ψ := weightMul_le.mpr hgen hν
+  -- `ψ` applied to the coefficient is the term `φ (coeff ν f) * bν`, which is `weightedEvalTerm`
+  -- by definition. Stated here rather than left to close the goal by unfolding.
+  have hterm : weightedEvalTerm φ b f ν ∈ (G : Set B) := hcomap
+  exact hGW hterm
+
 
 end Terms
 
 section Summable
 
-variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
-  [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
+variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanAddGroup A]
+  [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanAddGroup B] [CompleteSpace B]
 
 /-- **The evaluation of a `T`-restricted series is summable.** Its terms tend to zero along the
 cofinite filter, which in a complete nonarchimedean group is summability. -/
@@ -129,7 +174,7 @@ theorem summable_weightedEvalTerm {φ : A →+* B} (hφ : Continuous φ) {T : Fi
     (hf : IsWeightedRestricted T f) :
     Summable (weightedEvalTerm φ b f) :=
   NonarchimedeanAddGroup.summable_of_tendsto_cofinite_zero
-    (tendsto_cofinite_weightedEvalTerm hφ hb hf)
+    (tendsto_weightedEvalTerm_cofinite_zero hφ hb hf)
 
 end Summable
 

--- a/TauCeti/RingTheory/Huber/WeightedEval.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval.lean
@@ -78,9 +78,9 @@ multi-indices at once, form a bounded subset of `B`.
 This is Wedhorn's requirement that the variables be power-bounded *relative to the weights*, in
 the form the summability argument uses. It is a condition on the whole family rather than on each
 `bᵢ` separately, because the bound has to be uniform in `ν`. For the one-weight family `T ≡ {1}`
-it is equivalent to each `bᵢ` being power-bounded, which is Wedhorn's condition; recovering it
-from the individual bounds is where continuity of multiplication is needed, since the bounds have
-to be multiplied together. -/
+it is equivalent to each `bᵢ` being power-bounded, which is Wedhorn's condition: every monomial
+`bν` lies in the pointwise product of the power-sets, and a finite pointwise product of bounded
+sets is bounded. -/
 def IsWeightBounded (φ : A →+* B) (T : Fin k → Set A) (b : Fin k → B) : Prop :=
   IsBounded (⋃ ν : Fin k →₀ ℕ, (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν)
 
@@ -107,19 +107,6 @@ theorem isWeightBounded_one_weight_iff (φ : A →+* B) (b : Fin k → B) :
     simp [weightPow_one_weight]
   rw [isWeightBounded_iff, hset]
 
-omit [TopologicalSpace B] in
-/-- A product of members of finitely many sets lies in their pointwise product. Private: it is
-elementary, Mathlib does not name it, and it is used only to prove the characterisation below. -/
-private theorem prod_mem_finset_prod {ι : Type*} (s : Finset ι) {S : ι → Set B} {f : ι → B}
-    (hf : ∀ i ∈ s, f i ∈ S i) : (∏ i ∈ s, f i) ∈ ∏ i ∈ s, S i := by
-  classical
-  induction s using Finset.induction with
-  | empty => simp
-  | insert i s hi ih =>
-    rw [Finset.prod_insert hi, Finset.prod_insert hi]
-    exact Set.mul_mem_mul (hf i (Finset.mem_insert_self i s))
-      (ih fun j hj ↦ hf j (Finset.mem_insert_of_mem hj))
-
 omit [TopologicalSpace A] in
 /-- **At the one-weight family the hypothesis is exactly Wedhorn's**: the weighted monomials are
 bounded precisely when every variable is power-bounded.
@@ -127,9 +114,8 @@ bounded precisely when every variable is power-bounded.
 Both directions are elementary once the monomials are in view. Forwards, the monomial at
 `ν = Finsupp.single i n` is `bᵢ ^ n`, so the one bounded set already contains every power of every
 `bᵢ`. Backwards, every monomial `bν` lies in the pointwise product of the power-sets, which is
-bounded by `TauCeti.Huber.isBounded_finset_prod` — this is the direction that needs the
-multiplication of `B` to be continuous, since it multiplies the individual bounds together. -/
-theorem isWeightBounded_one_weight_iff_forall_isPowerBounded [ContinuousMul B] (φ : A →+* B)
+bounded by `TauCeti.Huber.isBounded_finset_prod`. -/
+theorem isWeightBounded_one_weight_iff_forall_isPowerBounded (φ : A →+* B)
     (b : Fin k → B) :
     IsWeightBounded φ (fun _ : Fin k ↦ ({1} : Set A)) b ↔ ∀ i, IsPowerBounded (b i) := by
   rw [isWeightBounded_one_weight_iff]
@@ -139,7 +125,7 @@ theorem isWeightBounded_one_weight_iff_forall_isPowerBounded [ContinuousMul B] (
   · refine (isBounded_finset_prod Finset.univ
       (fun i _ ↦ isPowerBounded_iff.mp (hb i))).subset ?_
     rintro _ ⟨ν, rfl⟩
-    exact prod_mem_finset_prod Finset.univ fun i _ ↦ ⟨ν i, rfl⟩
+    exact Set.finsetProd_mem_finsetProd Finset.univ _ _ fun i _ ↦ ⟨ν i, rfl⟩
 
 
 variable [NonarchimedeanAddGroup A] [NonarchimedeanAddGroup B]
@@ -204,7 +190,7 @@ theorem summable_weightedEvalTerm {φ : A →+* B} (hφ : Continuous φ) {T : Fi
 tuple is that each variable be power-bounded, which is how Proposition 5.50 states it; this is the
 theorem above read through
 `TauCeti.Huber.isWeightBounded_one_weight_iff_forall_isPowerBounded`. -/
-theorem summable_weightedEvalTerm_of_forall_isPowerBounded [ContinuousMul B] {φ : A →+* B}
+theorem summable_weightedEvalTerm_of_forall_isPowerBounded {φ : A →+* B}
     (hφ : Continuous φ) {b : Fin k → B} (hb : ∀ i, IsPowerBounded (b i))
     {f : MvPowerSeries (Fin k) A}
     (hf : IsWeightedRestricted (fun _ : Fin k ↦ ({1} : Set A)) f) :

--- a/TauCeti/RingTheory/Huber/WeightedEval.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.RingTheory.Huber.Bounded
 public import TauCeti.RingTheory.Huber.PowerBounded
 public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries
 public import Mathlib.Topology.Algebra.InfiniteSum.Nonarchimedean
@@ -30,10 +29,9 @@ it to summability, through Mathlib's
 
 * `TauCeti.Huber.weightedEvalTerm`: the term `φ(coeff ν f) · bν` of the evaluation.
 * `TauCeti.Huber.IsWeightBounded`: the weighted monomials `φ(Tν) · bν` form a bounded set. This is
-  the hypothesis on `b`. At the one-weight family it is boundedness of the set of monomials `bν`
-  (`TauCeti.Huber.isWeightBounded_one_weight_iff`), which implies that each `bᵢ` is power-bounded;
-  the converse needs a finite pointwise product of bounded sets to be bounded, so it is not stated
-  here.
+  the hypothesis on `b`. At the one-weight family it is *equivalent* to each `bᵢ` being
+  power-bounded, which is Wedhorn's condition —
+  `TauCeti.Huber.isWeightBounded_one_weight_iff_forall_isPowerBounded`.
 
 ## Main results
 
@@ -41,6 +39,8 @@ it to summability, through Mathlib's
   cofinite filter. This is the analytic input, and it needs no completeness.
 * `TauCeti.Huber.summable_weightedEvalTerm`: completeness upgrades that convergence to
   summability.
+* `TauCeti.Huber.summable_weightedEvalTerm_of_forall_isPowerBounded`: the same at the one-weight
+  family, stated with Wedhorn's own hypothesis that each variable is power-bounded.
 
 The evaluation map itself, its continuity, and the uniqueness that makes Proposition 5.50 a
 universal property are not proved here.
@@ -67,6 +67,7 @@ def weightedEvalTerm (φ : A →+* B) (b : Fin k → B) (f : MvPowerSeries (Fin 
 
 omit [TopologicalSpace A] [TopologicalSpace B] in
 /-- Unfolding lemma for `TauCeti.Huber.weightedEvalTerm`. -/
+@[simp]
 theorem weightedEvalTerm_def (φ : A →+* B) (b : Fin k → B) (f : MvPowerSeries (Fin k) A)
     (ν : Fin k →₀ ℕ) :
     weightedEvalTerm φ b f ν = φ (MvPowerSeries.coeff ν f) * ∏ i, b i ^ ν i := (rfl)
@@ -77,9 +78,9 @@ multi-indices at once, form a bounded subset of `B`.
 This is Wedhorn's requirement that the variables be power-bounded *relative to the weights*, in
 the form the summability argument uses. It is a condition on the whole family rather than on each
 `bᵢ` separately, because the bound has to be uniform in `ν`. For the one-weight family `T ≡ {1}`
-it says exactly that the set of monomials `bν` is bounded, which is strictly a statement about the
-family: it gives that each `bᵢ` is power-bounded, but recovering it from the individual bounds
-needs those bounds to combine multiplicatively. -/
+it is equivalent to each `bᵢ` being power-bounded, which is Wedhorn's condition; recovering it
+from the individual bounds is where continuity of multiplication is needed, since the bounds have
+to be multiplied together. -/
 def IsWeightBounded (φ : A →+* B) (T : Fin k → Set A) (b : Fin k → B) : Prop :=
   IsBounded (⋃ ν : Fin k →₀ ℕ, (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν)
 
@@ -95,6 +96,7 @@ omit [TopologicalSpace A] in
 equal to `{1}` the weighted monomials are just the `bν`, so `IsWeightBounded` says exactly that
 they form a bounded set — the condition a reader expects to see, and the bridge from the roadmap's
 power-bounded-variable hypothesis. -/
+@[simp]
 theorem isWeightBounded_one_weight_iff (φ : A →+* B) (b : Fin k → B) :
     IsWeightBounded φ (fun _ : Fin k ↦ ({1} : Set A)) b ↔
       IsBounded (Set.range fun ν : Fin k →₀ ℕ ↦ ∏ i, b i ^ ν i) := by
@@ -105,18 +107,39 @@ theorem isWeightBounded_one_weight_iff (φ : A →+* B) (b : Fin k → B) :
     simp [weightPow_one_weight]
   rw [isWeightBounded_iff, hset]
 
+omit [TopologicalSpace B] in
+/-- A product of members of finitely many sets lies in their pointwise product. Private: it is
+elementary, Mathlib does not name it, and it is used only to prove the characterisation below. -/
+private theorem prod_mem_finset_prod {ι : Type*} (s : Finset ι) {S : ι → Set B} {f : ι → B}
+    (hf : ∀ i ∈ s, f i ∈ S i) : (∏ i ∈ s, f i) ∈ ∏ i ∈ s, S i := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp
+  | insert i s hi ih =>
+    rw [Finset.prod_insert hi, Finset.prod_insert hi]
+    exact Set.mul_mem_mul (hf i (Finset.mem_insert_self i s))
+      (ih fun j hj ↦ hf j (Finset.mem_insert_of_mem hj))
+
 omit [TopologicalSpace A] in
-/-- **Each variable is power-bounded.** The monomial at `ν = single i n` is `bᵢ ^ n`, so the
-one-weight hypothesis contains every power of every `bᵢ` in one bounded set. The converse — that
-individually power-bounded variables satisfy the hypothesis — needs a finite pointwise product of
-bounded sets to be bounded, which the repo does not yet have, and is not claimed here. -/
-theorem IsWeightBounded.isPowerBounded {φ : A →+* B} {b : Fin k → B}
-    (hb : IsWeightBounded φ (fun _ : Fin k ↦ ({1} : Set A)) b) (i : Fin k) :
-    IsPowerBounded (b i) := by
-  refine isPowerBounded_iff.mpr (((isWeightBounded_one_weight_iff φ b).mp hb).subset ?_)
-  rintro _ ⟨n, rfl⟩
-  refine ⟨Finsupp.single i n, ?_⟩
-  simp [Finsupp.single_apply, Finset.prod_ite_eq]
+/-- **At the one-weight family the hypothesis is exactly Wedhorn's**: the weighted monomials are
+bounded precisely when every variable is power-bounded.
+
+Both directions are elementary once the monomials are in view. Forwards, the monomial at
+`ν = Finsupp.single i n` is `bᵢ ^ n`, so the one bounded set already contains every power of every
+`bᵢ`. Backwards, every monomial `bν` lies in the pointwise product of the power-sets, which is
+bounded by `TauCeti.Huber.isBounded_finset_prod` — this is the direction that needs the
+multiplication of `B` to be continuous, since it multiplies the individual bounds together. -/
+theorem isWeightBounded_one_weight_iff_forall_isPowerBounded [ContinuousMul B] (φ : A →+* B)
+    (b : Fin k → B) :
+    IsWeightBounded φ (fun _ : Fin k ↦ ({1} : Set A)) b ↔ ∀ i, IsPowerBounded (b i) := by
+  rw [isWeightBounded_one_weight_iff]
+  refine ⟨fun hb i ↦ isPowerBounded_iff.mpr (hb.subset ?_), fun hb ↦ ?_⟩
+  · rintro _ ⟨n, rfl⟩
+    exact ⟨Finsupp.single i n, by simp [Finsupp.single_apply, Finset.prod_ite_eq]⟩
+  · refine (isBounded_finset_prod Finset.univ
+      (fun i _ ↦ isPowerBounded_iff.mp (hb i))).subset ?_
+    rintro _ ⟨ν, rfl⟩
+    exact prod_mem_finset_prod Finset.univ fun i _ ↦ ⟨ν i, rfl⟩
 
 
 variable [NonarchimedeanAddGroup A] [NonarchimedeanAddGroup B]
@@ -154,9 +177,10 @@ theorem tendsto_weightedEvalTerm_cofinite_zero {φ : A →+* B} (hφ : Continuou
     simp only [AddSubgroup.mem_comap, hval]
     exact hVG (Set.mul_mem_mul (hUV hu) (Set.mem_iUnion.mpr ⟨ν, ⟨t, ht, rfl⟩⟩))
   have hcomap : MvPowerSeries.coeff ν f ∈ G.toAddSubgroup.comap ψ := weightMul_le.mpr hgen hν
-  -- `ψ` applied to the coefficient is the term `φ (coeff ν f) * bν`, which is `weightedEvalTerm`
-  -- by definition. Stated here rather than left to close the goal by unfolding.
-  have hterm : weightedEvalTerm φ b f ν ∈ (G : Set B) := hcomap
+  -- `ψ` applied to the coefficient is the term `φ (coeff ν f) * bν`; rewriting rather than
+  -- relying on the wrappers and coercions agreeing definitionally.
+  have hterm : weightedEvalTerm φ b f ν ∈ (G : Set B) := by
+    simpa [weightedEvalTerm_def, ψ] using hcomap
   exact hGW hterm
 
 
@@ -175,6 +199,18 @@ theorem summable_weightedEvalTerm {φ : A →+* B} (hφ : Continuous φ) {T : Fi
     Summable (weightedEvalTerm φ b f) :=
   NonarchimedeanAddGroup.summable_of_tendsto_cofinite_zero
     (tendsto_weightedEvalTerm_cofinite_zero hφ hb hf)
+
+/-- **Summability under Wedhorn's own hypothesis.** At the one-weight family the condition on the
+tuple is that each variable be power-bounded, which is how Proposition 5.50 states it; this is the
+theorem above read through
+`TauCeti.Huber.isWeightBounded_one_weight_iff_forall_isPowerBounded`. -/
+theorem summable_weightedEvalTerm_of_forall_isPowerBounded [ContinuousMul B] {φ : A →+* B}
+    (hφ : Continuous φ) {b : Fin k → B} (hb : ∀ i, IsPowerBounded (b i))
+    {f : MvPowerSeries (Fin k) A}
+    (hf : IsWeightedRestricted (fun _ : Fin k ↦ ({1} : Set A)) f) :
+    Summable (weightedEvalTerm φ b f) :=
+  summable_weightedEvalTerm hφ
+    ((isWeightBounded_one_weight_iff_forall_isPowerBounded φ b).mpr hb) hf
 
 end Summable
 


### PR DESCRIPTION
**The analytic core of Wedhorn 5.50: the evaluation of a `T`-restricted series is summable.**

AdicSpaces §0.4's first bullet asks for `A⟨X₁,…,Xₖ⟩_T` together with "its topology, functoriality,
the density of polynomials (5.49), and the universal property for power-bounded weighted variables
(5.50)". The first three landed in #2441, #2619 and #2658. 5.50 sends a series to the sum of its
terms at a chosen tuple — so before there is a map to define, that sum has to exist. This PR
supplies exactly that and nothing more.

* `IsWeightBounded φ T b` is the hypothesis on the tuple: the weighted monomials `φ(Tν) · bν`, over
  **all** multi-indices at once, form a single bounded subset of `B`. This is Wedhorn's requirement
  that the variables be power-bounded *relative to the weights*, in the form the argument uses. It
  is deliberately a condition on the family rather than on each `bᵢ` separately, because the bound
  has to be uniform in `ν`; at the one-weight family it says the monomials `bν` are bounded.
* `tendsto_cofinite_weightedEvalTerm` is the content, and it needs **no completeness**.
  `T`-restrictedness puts all but finitely many coefficients into `Tν · U`; continuity of `φ`
  chooses `U` so that `φ(U)` shrinks the bounded family into a prescribed open subgroup; and the
  uniformity in `ν` is precisely what lets one `U` serve every index simultaneously.
* `summable_weightedEvalTerm` then reads the conclusion off Mathlib's
  `NonarchimedeanAddGroup.summable_of_tendsto_cofinite_zero`.

The target's uniformity lives in its own section, so the `tendsto` result keeps the weaker
`[TopologicalSpace B]` and no `TopologicalSpace`/`UniformSpace` diamond arises.

**Not** included, deliberately: the evaluation map itself, its continuity, and the uniqueness that
turns 5.50 into a universal property. Those are the next step and the module docstring says so.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0.4-weighted-series-eval-summable"}-->

🤖 Prepared with Claude Code
