### PR TITLE
feat: the Mayer-Vietoris sequence for scheme cohomology

### DIFF
--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -7,7 +7,6 @@ module
 public import TauCeti.CategoryTheory.Sites.SheafCohomology.Terminal
 public import Mathlib.AlgebraicGeometry.Modules.Sheaf
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.HasExt
-public import Mathlib.CategoryTheory.Sites.SheafCohomology.Basic
 public import Mathlib.Topology.Sheaves.Abelian
 
 /-!

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.CategoryTheory.Sites.SheafCohomology.Terminal
 public import Mathlib.AlgebraicGeometry.Modules.Sheaf
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.HasExt
 public import Mathlib.CategoryTheory.Sites.SheafCohomology.Basic
@@ -21,7 +22,10 @@ For a scheme `X` and `M : X.Modules`, the main declarations are:
 * `Scheme.Modules.Cohomology M i`, the group `Hⁱ(X, M)`;
 * `Scheme.Modules.cohomologyFunctor X i`, functoriality in the coefficient sheaf;
 * `Scheme.Modules.cohomologyZeroEquiv`, the canonical equivalence
-  `H⁰(X, M) ≃+ Γ(M, ⊤)` with global sections.
+  `H⁰(X, M) ≃+ Γ(M, ⊤)` with global sections;
+* `Scheme.Modules.cohomologyOn M n U`, the cohomology `Hⁿ(U, M)` of an open subset,
+  `Scheme.Modules.cohomologyOnRes` its restriction maps, and
+  `Scheme.Modules.cohomologyOnTopIso` the identification of `Hⁿ(⊤, M)` with `Hⁿ(X, M)`.
 
 The construction is stated for every sheaf of modules, which is the natural generality of sheaf
 cohomology. In particular it applies to finitely presented sheaves through their underlying
@@ -30,12 +34,13 @@ objects, and hence supplies the `Hⁱ(X, ℱ)` used for coherent sheaves in
 vanishing on curves, and the comparison with Čech cohomology remain later Layer B work.
 
 No formalization is vendored. The definitions reuse Mathlib's `Sheaf.H`, `Sheaf.functorH`,
-and `Sheaf.H.equiv₀`.
+`Sheaf.H.equiv₀` and `Sheaf.H'`, and the comparison at the terminal open subset is
+`TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean`.
 -/
 
 public section
 
-open CategoryTheory Limits AlgebraicGeometry
+open CategoryTheory Limits TopologicalSpace AlgebraicGeometry
 
 namespace TauCeti
 
@@ -76,6 +81,44 @@ def cohomologyZeroEquiv (M : X.Modules) :
     Cohomology M 0 ≃+ Γ(M, ⊤) :=
   CategoryTheory.Sheaf.H.equiv₀
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) isTerminalTop
+
+section Opens
+
+variable (M : X.Modules)
+
+/-- The cohomology `Hⁿ(U, M)` of an open subset `U` of a scheme `X` with coefficients in a sheaf
+of modules `M`, as an abelian group.
+
+This is `CategoryTheory.Sheaf.H'` applied to the underlying abelian sheaf of `M`. At `U = ⊤` it
+agrees with `Scheme.Modules.Cohomology`, by `Scheme.Modules.cohomologyOnTopIso`. -/
+abbrev cohomologyOn (n : ℕ) (U : Opens X) : AddCommGrpCat.{u} :=
+  CategoryTheory.Sheaf.H'.{u} ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n U
+
+/-- Restriction in cohomology along an inclusion of open subsets. -/
+abbrev cohomologyOnRes (n : ℕ) {U V : Opens X} (h : U ≤ V) :
+    cohomologyOn M n V ⟶ cohomologyOn M n U :=
+  (CategoryTheory.Sheaf.cohomologyPresheaf.{u}
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n).map (homOfLE h).op
+
+@[simp]
+lemma cohomologyOnRes_refl (n : ℕ) (U : Opens X) :
+    cohomologyOnRes M n (le_refl U) = 𝟙 _ := by
+  dsimp only [cohomologyOnRes]
+  rw [Subsingleton.elim (homOfLE (le_refl U)) (𝟙 U), op_id, CategoryTheory.Functor.map_id]
+
+@[simp, reassoc]
+lemma cohomologyOnRes_comp (n : ℕ) {U V W : Opens X} (hUV : U ≤ V) (hVW : V ≤ W) :
+    cohomologyOnRes M n hVW ≫ cohomologyOnRes M n hUV =
+      cohomologyOnRes M n (hUV.trans hVW) := by
+  dsimp only [cohomologyOnRes]
+  rw [← CategoryTheory.Functor.map_comp, ← op_comp, homOfLE_comp]
+
+/-- The cohomology of the whole space is the cohomology of the scheme. -/
+def cohomologyOnTopIso (n : ℕ) :
+    cohomologyOn M n ⊤ ≅ AddCommGrpCat.of (Cohomology M n) :=
+  TauCeti.CategoryTheory.cohomologyPresheafObjIsoH n isTerminalTop _
+
+end Opens
 
 end Scheme.Modules
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -103,7 +103,7 @@ abbrev cohomologyOnRes (n : ℕ) {U V : Opens X} (h : U ≤ V) :
 lemma cohomologyOnRes_refl (n : ℕ) (U : Opens X) :
     cohomologyOnRes M n (le_refl U) = 𝟙 _ := by
   dsimp only [cohomologyOnRes]
-  rw [Subsingleton.elim (homOfLE (le_refl U)) (𝟙 U), op_id, CategoryTheory.Functor.map_id]
+  simp only [homOfLE_refl, op_id, CategoryTheory.Functor.map_id]
 
 @[simp, reassoc]
 lemma cohomologyOnRes_comp (n : ℕ) {U V W : Opens X} (hUV : U ≤ V) (hVW : V ≤ W) :
@@ -113,9 +113,9 @@ lemma cohomologyOnRes_comp (n : ℕ) {U V W : Opens X} (hUV : U ≤ V) (hVW : V 
   rw [← CategoryTheory.Functor.map_comp, ← op_comp, homOfLE_comp]
 
 /-- The cohomology of the whole space is the cohomology of the scheme. -/
-def cohomologyOnTopIso (n : ℕ) :
+noncomputable abbrev cohomologyOnTopIso (n : ℕ) :
     cohomologyOn M n ⊤ ≅ AddCommGrpCat.of (Cohomology M n) :=
-  TauCeti.CategoryTheory.cohomologyPresheafObjIsoH n isTerminalTop _
+  TauCeti.CategoryTheory.Sheaf.cohomologyPresheafObjIsoH n isTerminalTop _
 
 end Opens
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.Cohomology.Basic
+public import TauCeti.CategoryTheory.Sites.SheafCohomology.Terminal
+public import Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris
+public import Mathlib.Topology.Sheaves.MayerVietoris
+
+/-!
+# Mayer-Vietoris for the cohomology of a sheaf of modules on a scheme
+
+`TauCeti/AlgebraicGeometry/Cohomology/Basic.lean` defines the cohomology `Hⁿ(X, M)` of a sheaf of
+modules on a scheme. This file adds the cohomology `Hⁿ(U, M)` of an open subset, and the long
+exact Mayer-Vietoris sequence of a covering of `X` by two open subsets `U` and `V`:
+
+`⋯ ⟶ Hⁿ(X, M) ⟶ Hⁿ(U, M) ⊞ Hⁿ(V, M) ⟶ Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(X, M) ⟶ ⋯`
+
+## Main declarations
+
+* `Scheme.Modules.cohomologyOn M n U` is `Hⁿ(U, M)`, and `Scheme.Modules.cohomologyOnRes` is
+  restriction along an inclusion of open subsets;
+* `Scheme.Modules.cohomologyOnTopIso` identifies `Hⁿ(⊤, M)` with `Hⁿ(X, M)`;
+* `Scheme.Modules.coverSquare` is the Mayer-Vietoris square of a covering of `X` by two opens,
+  `Scheme.Modules.mayerVietorisSequence` is the six-term piece of the resulting long exact
+  sequence and `Scheme.Modules.mayerVietorisSequence_exact` is its exactness;
+* `Scheme.Modules.epi_mayerVietorisδ`: if `Hⁿ⁺¹(U, M)` and `Hⁿ⁺¹(V, M)` vanish, then the
+  connecting map `Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(X, M)` is an epimorphism;
+* `Scheme.Modules.subsingleton_cohomology_succ`: if moreover `Hⁿ(U ⊓ V, M)` vanishes, then
+  `Hⁿ⁺¹(X, M)` vanishes, and `Scheme.Modules.subsingleton_cohomology_of_two_le` iterates this
+  over an open cover which is acyclic in positive degrees.
+
+The last two statements are the shape in which Mayer-Vietoris is used on a curve: a separated
+scheme covered by two affine opens has no cohomology above degree one, once the acyclicity of
+affines is available. That acyclicity is not proved here.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer B, "coherent sheaves and
+cohomology `Hⁱ(X, ℱ)`: … vanishing above dimension (`H² = 0` on a curve)". No formalization is
+vendored: the long exact sequence is Mathlib's
+`CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sequence_exact`, the square attached to
+two open subsets is Mathlib's `TopologicalSpace.Opens.mayerVietorisSquare'`, and the comparison
+between the cohomology of the terminal open subset and the cohomology of the site is
+`TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean`.
+-/
+
+public section
+
+open CategoryTheory Limits TopologicalSpace AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+noncomputable section
+
+namespace Scheme.Modules
+
+variable {X : Scheme.{u}} (M : X.Modules)
+
+/-- The cohomology `Hⁿ(U, M)` of an open subset `U` of a scheme `X` with coefficients in a sheaf
+of modules `M`, as an abelian group.
+
+This is `CategoryTheory.Sheaf.H'` applied to the underlying abelian sheaf of `M`. At `U = ⊤` it
+agrees with `Scheme.Modules.Cohomology`, by `Scheme.Modules.cohomologyOnTopIso`. -/
+abbrev cohomologyOn (n : ℕ) (U : Opens X) : AddCommGrpCat.{u} :=
+  CategoryTheory.Sheaf.H'.{u} ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n U
+
+/-- Restriction in cohomology along an inclusion of open subsets. -/
+abbrev cohomologyOnRes (n : ℕ) {U V : Opens X} (h : U ≤ V) :
+    cohomologyOn M n V ⟶ cohomologyOn M n U :=
+  (CategoryTheory.Sheaf.cohomologyPresheaf.{u}
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n).map (homOfLE h).op
+
+@[simp]
+lemma cohomologyOnRes_refl (n : ℕ) (U : Opens X) :
+    cohomologyOnRes M n (le_refl U) = 𝟙 _ := by
+  change (CategoryTheory.Sheaf.cohomologyPresheaf.{u}
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n).map (homOfLE (le_refl U)).op = 𝟙 _
+  rw [Subsingleton.elim (homOfLE (le_refl U)) (𝟙 U), op_id, CategoryTheory.Functor.map_id]
+
+@[reassoc]
+lemma cohomologyOnRes_comp (n : ℕ) {U V W : Opens X} (hUV : U ≤ V) (hVW : V ≤ W) :
+    cohomologyOnRes M n hVW ≫ cohomologyOnRes M n hUV =
+      cohomologyOnRes M n (hUV.trans hVW) := by
+  change (CategoryTheory.Sheaf.cohomologyPresheaf.{u}
+      ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n).map (homOfLE hVW).op ≫
+    (CategoryTheory.Sheaf.cohomologyPresheaf.{u}
+      ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n).map (homOfLE hUV).op = _
+  rw [← CategoryTheory.Functor.map_comp, ← op_comp,
+    Subsingleton.elim (homOfLE hUV ≫ homOfLE hVW) (homOfLE (hUV.trans hVW))]
+
+/-- The cohomology of the whole space is the cohomology of the scheme. -/
+def cohomologyOnTopIso (n : ℕ) :
+    cohomologyOn M n ⊤ ≅ AddCommGrpCat.of (Cohomology M n) :=
+  TauCeti.CategoryTheory.cohomologyPresheafObjIsoH n isTerminalTop _
+
+/-- The cohomology of the whole space is the cohomology of the scheme. -/
+def cohomologyOnTopAddEquiv (n : ℕ) : cohomologyOn M n ⊤ ≃+ Cohomology M n :=
+  TauCeti.CategoryTheory.cohomologyPresheafObjAddEquivH n isTerminalTop _
+
+section Cover
+
+variable {U V : Opens X} (hUV : U ⊔ V = ⊤)
+
+/-- The Mayer-Vietoris square of a covering of a scheme by two open subsets. Its corners are
+`U ⊓ V`, `U`, `V` and the whole space. -/
+@[expose]
+def coverSquare : (Opens.grothendieckTopology X).MayerVietorisSquare :=
+  Opens.mayerVietorisSquare'
+    { X₁ := U ⊓ V, X₂ := U, X₃ := V, X₄ := ⊤
+      f₁₂ := homOfLE inf_le_left
+      f₁₃ := homOfLE inf_le_right
+      f₂₄ := homOfLE le_top
+      f₃₄ := homOfLE le_top
+      fac := Subsingleton.elim _ _ }
+    hUV.symm rfl
+
+@[simp] lemma coverSquare_X₁ : (coverSquare hUV).X₁ = U ⊓ V := rfl
+
+@[simp] lemma coverSquare_X₂ : (coverSquare hUV).X₂ = U := rfl
+
+@[simp] lemma coverSquare_X₃ : (coverSquare hUV).X₃ = V := rfl
+
+@[simp] lemma coverSquare_X₄ : (coverSquare hUV).X₄ = ⊤ := rfl
+
+/-- The map `Hⁿ(X, M) ⟶ Hⁿ(U, M) ⊞ Hⁿ(V, M)` of the Mayer-Vietoris sequence is the pair of
+restriction maps. -/
+lemma coverSquare_toBiprod (n : ℕ) :
+    (coverSquare hUV).toBiprod ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n =
+      biprod.lift (cohomologyOnRes M n (le_top : U ≤ ⊤))
+        (cohomologyOnRes M n (le_top : V ≤ ⊤)) :=
+  rfl
+
+/-- The map `Hⁿ(U, M) ⊞ Hⁿ(V, M) ⟶ Hⁿ(U ⊓ V, M)` of the Mayer-Vietoris sequence is the difference
+of the two restriction maps. -/
+lemma coverSquare_fromBiprod (n : ℕ) :
+    (coverSquare hUV).fromBiprod ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n =
+      biprod.desc (cohomologyOnRes M n (inf_le_left : U ⊓ V ≤ U))
+        (-cohomologyOnRes M n (inf_le_right : U ⊓ V ≤ V)) :=
+  rfl
+
+/-- The connecting map `Hⁿ⁰(U ⊓ V, M) ⟶ Hⁿ¹(X, M)` of the Mayer-Vietoris sequence. -/
+def mayerVietorisδ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    cohomologyOn M n₀ (U ⊓ V) ⟶ cohomologyOn M n₁ ⊤ :=
+  (coverSquare hUV).δ ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
+
+/-- Six consecutive terms of the Mayer-Vietoris long exact sequence, running from `Hⁿ⁰(X, M)` to
+`Hⁿ¹(U ⊓ V, M)`. -/
+def mayerVietorisSequence (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) : ComposableArrows AddCommGrpCat.{u} 5 :=
+  (coverSquare hUV).sequence ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
+
+/-- The Mayer-Vietoris sequence of a covering by two open subsets is exact. -/
+theorem mayerVietorisSequence_exact (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    (mayerVietorisSequence M hUV n₀ n₁ h).Exact :=
+  (coverSquare hUV).sequence_exact _ _ _ _
+
+include hUV in
+/-- If the degree `n + 1` cohomology of both members of a two-element open cover vanishes, then
+the Mayer-Vietoris connecting map onto `Hⁿ⁺¹(X, M)` is an epimorphism. -/
+theorem epi_mayerVietorisδ (n : ℕ)
+    (hU : Subsingleton (cohomologyOn M (n + 1) U))
+    (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
+    Epi (mayerVietorisδ M hUV n (n + 1) rfl) := by
+  set F := (_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M
+  set S := coverSquare hUV
+  -- both components of the map to the biproduct land in a zero object
+  have hg : S.toBiprod F (n + 1) = 0 := by
+    refine biprod.hom_ext _ _ ?_ ?_
+    · exact (AddCommGrpCat.isZero_of_subsingleton (G := cohomologyOn M (n + 1) U)).eq_of_tgt _ _
+    · exact (AddCommGrpCat.isZero_of_subsingleton (G := cohomologyOn M (n + 1) V)).eq_of_tgt _ _
+  -- the piece of the Mayer-Vietoris sequence around `Hⁿ⁺¹(X, M)`
+  have hex : (ShortComplex.mk (S.δ F n (n + 1) rfl) (S.toBiprod F (n + 1))
+      (S.δ_toBiprod _ _ _ _)).Exact :=
+    (mayerVietorisSequence_exact M hUV n (n + 1) rfl).exact' 2 3 4
+  exact hex.epi_f hg
+
+include hUV in
+/-- A scheme covered by two open subsets whose degree `n + 1` cohomology vanishes, and whose
+intersection has vanishing degree `n` cohomology, has vanishing degree `n + 1` cohomology. -/
+theorem subsingleton_cohomology_succ (n : ℕ)
+    (hInter : Subsingleton (cohomologyOn M n (U ⊓ V)))
+    (hU : Subsingleton (cohomologyOn M (n + 1) U))
+    (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
+    Subsingleton (Cohomology M (n + 1)) := by
+  have hsurj : Function.Surjective (mayerVietorisδ M hUV n (n + 1) rfl) :=
+    (AddCommGrpCat.epi_iff_surjective _).mp (epi_mayerVietorisδ M hUV n hU hV)
+  have hTop : Subsingleton (cohomologyOn M (n + 1) ⊤) := by
+    refine ⟨fun a b => ?_⟩
+    obtain ⟨x, rfl⟩ := hsurj a
+    obtain ⟨y, rfl⟩ := hsurj b
+    exact congrArg _ (hInter.elim x y)
+  exact (cohomologyOnTopIso M (n + 1)).symm.addCommGroupIsoToAddEquiv.toEquiv.subsingleton
+
+include hUV in
+/-- A scheme covered by two open subsets which, together with their intersection, are acyclic in
+positive degrees has no cohomology in degrees at least two.
+
+This is the form Mayer-Vietoris takes on a separated scheme covered by two affine opens: the
+intersection is then affine as well, and Serre's acyclicity of affines supplies the hypotheses. -/
+theorem subsingleton_cohomology_of_two_le (n : ℕ) (hn : 2 ≤ n)
+    (hU : ∀ i, 0 < i → Subsingleton (cohomologyOn M i U))
+    (hV : ∀ i, 0 < i → Subsingleton (cohomologyOn M i V))
+    (hInter : ∀ i, 0 < i → Subsingleton (cohomologyOn M i (U ⊓ V))) :
+    Subsingleton (Cohomology M n) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  exact subsingleton_cohomology_succ M hUV m (hInter m (by omega)) (hU _ (by omega))
+    (hV _ (by omega))
+
+end Cover
+
+end Scheme.Modules
+
+end
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -13,22 +13,24 @@ public import Mathlib.Topology.Sheaves.MayerVietoris
 
 `TauCeti/AlgebraicGeometry/Cohomology/Basic.lean` defines the cohomology `Hⁿ(X, M)` of a sheaf of
 modules on a scheme, and the cohomology `Hⁿ(U, M)` of an open subset. This file adds the long
-exact Mayer-Vietoris sequence of a covering of `X` by two open subsets `U` and `V`:
+exact Mayer-Vietoris sequence of two open subsets `U` and `V`:
 
-`⋯ ⟶ Hⁿ(X, M) ⟶ Hⁿ(U, M) ⊞ Hⁿ(V, M) ⟶ Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(X, M) ⟶ ⋯`
+`⋯ ⟶ Hⁿ(U ⊔ V, M) ⟶ Hⁿ(U, M) ⊞ Hⁿ(V, M) ⟶ Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(U ⊔ V, M) ⟶ ⋯`
+
+together with the vanishing it gives when `U` and `V` cover `X`.
 
 ## Main declarations
 
-* `Scheme.Modules.mayerVietorisCoverSquare` is the Mayer-Vietoris square of a covering of `X` by
-  two opens, `Scheme.Modules.mayerVietorisSequence` is the six-term piece of the resulting long
-  exact sequence, `Scheme.Modules.mayerVietorisSequence_eq` identifies each of its objects and
-  arrows with restriction maps and the connecting map `Scheme.Modules.mayerVietorisδ`, and
+* `Scheme.Modules.mayerVietorisSequence` is the six-term piece of the long exact sequence,
+  `Scheme.Modules.mayerVietorisSequence_eq` identifies each of its objects and arrows with
+  restriction maps and the connecting map `Scheme.Modules.mayerVietorisδ`, and
   `Scheme.Modules.mayerVietorisSequence_exact` is its exactness;
 * `Scheme.Modules.epi_mayerVietorisδ`: if `Hⁿ⁺¹(U, M)` and `Hⁿ⁺¹(V, M)` vanish, then the
-  connecting map `Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(X, M)` is an epimorphism;
-* `Scheme.Modules.subsingleton_cohomology_succ`: if moreover `Hⁿ(U ⊓ V, M)` vanishes, then
-  `Hⁿ⁺¹(X, M)` vanishes, and `Scheme.Modules.subsingleton_cohomology_of_two_le` applies this at
-  degree `n - 1` under uniform positive-degree acyclicity hypotheses.
+  connecting map `Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(U ⊔ V, M)` is an epimorphism;
+* `Scheme.Modules.subsingleton_cohomology_succ`: if moreover `Hⁿ(U ⊓ V, M)` vanishes and
+  `U ⊔ V = ⊤`, then `Hⁿ⁺¹(X, M)` vanishes, and
+  `Scheme.Modules.subsingleton_cohomology_of_two_le` applies this at degree `n - 1` under
+  uniform positive-degree acyclicity hypotheses.
 
 The last two statements are the shape in which Mayer-Vietoris is used on a curve: a separated
 scheme covered by two affine opens has no cohomology above degree one, once the acyclicity of
@@ -38,7 +40,7 @@ This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer B, "coherent s
 cohomology `Hⁱ(X, ℱ)`: … vanishing above dimension (`H² = 0` on a curve)". No formalization is
 vendored: the long exact sequence is Mathlib's
 `CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sequence_exact`, the square attached to
-two open subsets is Mathlib's `TopologicalSpace.Opens.mayerVietorisSquare'`, and the comparison
+two open subsets is Mathlib's `TopologicalSpace.Opens.mayerVietorisSquare`, and the comparison
 between the cohomology of the terminal open subset and the cohomology of the site comes from
 `TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean` through
 `Scheme.Modules.cohomologyOnTopIso`.
@@ -60,111 +62,88 @@ namespace Scheme.Modules
 
 variable {X : Scheme.{u}} (M : X.Modules)
 
-section Cover
+section MayerVietoris
 
-variable {U V : Opens X} (hUV : U ⊔ V = ⊤)
+variable (U V : Opens X)
 
-/-- The Mayer-Vietoris square of a covering of a scheme by two open subsets. Its corners are
-`U ⊓ V`, `U`, `V` and the whole space, as recorded by `mayerVietorisCoverSquare_X₁` and friends. -/
-def mayerVietorisCoverSquare : (Opens.grothendieckTopology X).MayerVietorisSquare :=
-  Opens.mayerVietorisSquare'
-    { X₁ := U ⊓ V, X₂ := U, X₃ := V, X₄ := ⊤
-      f₁₂ := homOfLE inf_le_left
-      f₁₃ := homOfLE inf_le_right
-      f₂₄ := homOfLE le_top
-      f₃₄ := homOfLE le_top
-      fac := Subsingleton.elim _ _ }
-    hUV.symm rfl
-
--- The four corner lemmas hold by definition. Their proofs are written `(rfl)` rather than `rfl`
--- so that they are checked as ordinary proofs rather than as exported definitional unfoldings,
--- which lets `mayerVietorisCoverSquare` keep its body private.
-@[simp] lemma mayerVietorisCoverSquare_X₁ : (mayerVietorisCoverSquare hUV).X₁ = U ⊓ V := (rfl)
-
-@[simp] lemma mayerVietorisCoverSquare_X₂ : (mayerVietorisCoverSquare hUV).X₂ = U := (rfl)
-
-@[simp] lemma mayerVietorisCoverSquare_X₃ : (mayerVietorisCoverSquare hUV).X₃ = V := (rfl)
-
-@[simp] lemma mayerVietorisCoverSquare_X₄ : (mayerVietorisCoverSquare hUV).X₄ = ⊤ := (rfl)
-
-/-- The connecting map `Hⁿ⁰(U ⊓ V, M) ⟶ Hⁿ¹(X, M)` of the Mayer-Vietoris sequence. -/
+/-- The connecting map `Hⁿ⁰(U ⊓ V, M) ⟶ Hⁿ¹(U ⊔ V, M)` of the Mayer-Vietoris sequence of two
+open subsets. -/
 def mayerVietorisδ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
-    cohomologyOn M n₀ (U ⊓ V) ⟶ cohomologyOn M n₁ ⊤ :=
-  (mayerVietorisCoverSquare hUV).δ ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
+    cohomologyOn M n₀ (U ⊓ V) ⟶ cohomologyOn M n₁ (U ⊔ V) :=
+  (Opens.mayerVietorisSquare U V).δ
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
 
-/-- Six consecutive terms of the Mayer-Vietoris long exact sequence, running from `Hⁿ⁰(X, M)` to
-`Hⁿ¹(U ⊓ V, M)`. -/
+/-- Six consecutive terms of the Mayer-Vietoris long exact sequence of two open subsets, running
+from `Hⁿ⁰(U ⊔ V, M)` to `Hⁿ¹(U ⊓ V, M)`. -/
 def mayerVietorisSequence (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) : ComposableArrows AddCommGrpCat.{u} 5 :=
-  (mayerVietorisCoverSquare hUV).sequence
+  (Opens.mayerVietorisSquare U V).sequence
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
 
 /-- Every object and every arrow of the Mayer-Vietoris sequence: the two maps to a biproduct are
-the pairs of restriction maps from `X`, the two maps out of a biproduct are the differences of the
-restriction maps to `U ⊓ V`, and the middle map is the connecting map. -/
+the pairs of restriction maps from `U ⊔ V`, the two maps out of a biproduct are the differences of
+the restriction maps to `U ⊓ V`, and the middle map is the connecting map. -/
 @[simp]
 lemma mayerVietorisSequence_eq (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
-    mayerVietorisSequence M hUV n₀ n₁ h =
+    mayerVietorisSequence M U V n₀ n₁ h =
       ComposableArrows.mk₅
-        (biprod.lift (cohomologyOnRes M n₀ (le_top : U ≤ ⊤))
-          (cohomologyOnRes M n₀ (le_top : V ≤ ⊤)))
+        (biprod.lift (cohomologyOnRes M n₀ (le_sup_left : U ≤ U ⊔ V))
+          (cohomologyOnRes M n₀ (le_sup_right : V ≤ U ⊔ V)))
         (biprod.desc (cohomologyOnRes M n₀ (inf_le_left : U ⊓ V ≤ U))
           (-cohomologyOnRes M n₀ (inf_le_right : U ⊓ V ≤ V)))
-        (mayerVietorisδ M hUV n₀ n₁ h)
-        (biprod.lift (cohomologyOnRes M n₁ (le_top : U ≤ ⊤))
-          (cohomologyOnRes M n₁ (le_top : V ≤ ⊤)))
+        (mayerVietorisδ M U V n₀ n₁ h)
+        (biprod.lift (cohomologyOnRes M n₁ (le_sup_left : U ≤ U ⊔ V))
+          (cohomologyOnRes M n₁ (le_sup_right : V ≤ U ⊔ V)))
         (biprod.desc (cohomologyOnRes M n₁ (inf_le_left : U ⊓ V ≤ U))
           (-cohomologyOnRes M n₁ (inf_le_right : U ⊓ V ≤ V))) :=
+  -- `(rfl)` rather than `rfl`, so that this is checked as an ordinary proof rather than as an
+  -- exported definitional unfolding, which lets `mayerVietorisSequence` keep its body private.
   (rfl)
 
-/-- The Mayer-Vietoris sequence of a covering by two open subsets is exact. -/
+/-- The Mayer-Vietoris sequence of two open subsets is exact. -/
 theorem mayerVietorisSequence_exact (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
-    (mayerVietorisSequence M hUV n₀ n₁ h).Exact :=
-  (mayerVietorisCoverSquare hUV).sequence_exact _ _ _ _
+    (mayerVietorisSequence M U V n₀ n₁ h).Exact :=
+  (Opens.mayerVietorisSquare U V).sequence_exact _ _ _ _
 
-include hUV in
-/-- If the degree `n + 1` cohomology of both members of a two-element open cover vanishes, then
-the Mayer-Vietoris connecting map onto `Hⁿ⁺¹(X, M)` is an epimorphism. -/
+/-- If the degree `n + 1` cohomology of both of two open subsets vanishes, then the Mayer-Vietoris
+connecting map onto `Hⁿ⁺¹(U ⊔ V, M)` is an epimorphism. -/
 theorem epi_mayerVietorisδ (n : ℕ)
     (hU : Subsingleton (cohomologyOn M (n + 1) U))
     (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
-    Epi (mayerVietorisδ M hUV n (n + 1) rfl) := by
+    Epi (mayerVietorisδ M U V n (n + 1) rfl) := by
   set F := (_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M
-  set S := mayerVietorisCoverSquare hUV
+  set S := Opens.mayerVietorisSquare U V
   -- both components of the map to the biproduct land in a zero object
   have hg : S.toBiprod F (n + 1) = 0 := by
     refine biprod.hom_ext _ _ ?_ ?_
     · exact (AddCommGrpCat.isZero_of_subsingleton (G := cohomologyOn M (n + 1) U)).eq_of_tgt _ _
     · exact (AddCommGrpCat.isZero_of_subsingleton (G := cohomologyOn M (n + 1) V)).eq_of_tgt _ _
-  -- the piece of the Mayer-Vietoris sequence around `Hⁿ⁺¹(X, M)`
+  -- the piece of the Mayer-Vietoris sequence around `Hⁿ⁺¹(U ⊔ V, M)`
   have hex : (ShortComplex.mk (S.δ F n (n + 1) rfl) (S.toBiprod F (n + 1))
       (S.δ_toBiprod _ _ _ _)).Exact :=
-    (mayerVietorisSequence_exact M hUV n (n + 1) rfl).exact' 2 3 4
+    (mayerVietorisSequence_exact M U V n (n + 1) rfl).exact' 2 3 4
   exact hex.epi_f hg
 
-include hUV in
+variable {U V}
+
 /-- A scheme covered by two open subsets whose degree `n + 1` cohomology vanishes, and whose
 intersection has vanishing degree `n` cohomology, has vanishing degree `n + 1` cohomology. -/
-theorem subsingleton_cohomology_succ (n : ℕ)
+theorem subsingleton_cohomology_succ (hUV : U ⊔ V = ⊤) (n : ℕ)
     (hInter : Subsingleton (cohomologyOn M n (U ⊓ V)))
     (hU : Subsingleton (cohomologyOn M (n + 1) U))
     (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
     Subsingleton (Cohomology M (n + 1)) := by
-  have hsurj : Function.Surjective (mayerVietorisδ M hUV n (n + 1) rfl) :=
-    (AddCommGrpCat.epi_iff_surjective _).mp (epi_mayerVietorisδ M hUV n hU hV)
-  have hTop : Subsingleton (cohomologyOn M (n + 1) ⊤) := by
-    refine ⟨fun a b => ?_⟩
-    obtain ⟨x, rfl⟩ := hsurj a
-    obtain ⟨y, rfl⟩ := hsurj b
-    exact congrArg _ (hInter.elim x y)
+  have hsurj : Function.Surjective (mayerVietorisδ M U V n (n + 1) rfl) :=
+    (AddCommGrpCat.epi_iff_surjective _).mp (epi_mayerVietorisδ M U V n hU hV)
+  have hTop : Subsingleton (cohomologyOn M (n + 1) (U ⊔ V)) := hsurj.subsingleton
+  rw [hUV] at hTop
   exact (cohomologyOnTopIso M (n + 1)).symm.addCommGroupIsoToAddEquiv.toEquiv.subsingleton
 
-include hUV in
 /-- A scheme covered by two open subsets which, together with their intersection, are acyclic in
 positive degrees has no cohomology in degrees at least two.
 
 This is the form Mayer-Vietoris takes on a separated scheme covered by two affine opens: the
 intersection is then affine as well, and Serre's acyclicity of affines supplies the hypotheses. -/
-theorem subsingleton_cohomology_of_two_le (n : ℕ) (hn : 2 ≤ n)
+theorem subsingleton_cohomology_of_two_le (hUV : U ⊔ V = ⊤) (n : ℕ) (hn : 2 ≤ n)
     (hU : ∀ i, 0 < i → Subsingleton (cohomologyOn M i U))
     (hV : ∀ i, 0 < i → Subsingleton (cohomologyOn M i V))
     (hInter : ∀ i, 0 < i → Subsingleton (cohomologyOn M i (U ⊓ V))) :
@@ -173,7 +152,7 @@ theorem subsingleton_cohomology_of_two_le (n : ℕ) (hn : 2 ≤ n)
   exact subsingleton_cohomology_succ M hUV m (hInter m (by omega)) (hU _ (by omega))
     (hV _ (by omega))
 
-end Cover
+end MayerVietoris
 
 end Scheme.Modules
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -27,8 +27,8 @@ exact Mayer-Vietoris sequence of a covering of `X` by two open subsets `U` and `
 * `Scheme.Modules.epi_mayerVietorisδ`: if `Hⁿ⁺¹(U, M)` and `Hⁿ⁺¹(V, M)` vanish, then the
   connecting map `Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(X, M)` is an epimorphism;
 * `Scheme.Modules.subsingleton_cohomology_succ`: if moreover `Hⁿ(U ⊓ V, M)` vanishes, then
-  `Hⁿ⁺¹(X, M)` vanishes, and `Scheme.Modules.subsingleton_cohomology_of_two_le` iterates this
-  over an open cover which is acyclic in positive degrees.
+  `Hⁿ⁺¹(X, M)` vanishes, and `Scheme.Modules.subsingleton_cohomology_of_two_le` applies this at
+  degree `n - 1` under uniform positive-degree acyclicity hypotheses.
 
 The last two statements are the shape in which Mayer-Vietoris is used on a curve: a separated
 scheme covered by two affine opens has no cohomology above degree one, once the acyclicity of

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -22,7 +22,7 @@ together with the vanishing it gives when `U` and `V` cover `X`.
 ## Main declarations
 
 * `Scheme.Modules.mayerVietorisSequence` is the six-term piece of the long exact sequence,
-  `Scheme.Modules.mayerVietorisSequence_eq` identifies each of its objects and arrows with
+  `Scheme.Modules.mayerVietorisSequence_def` identifies each of its objects and arrows with
   restriction maps and the connecting map `Scheme.Modules.mayerVietorisδ`, and
   `Scheme.Modules.mayerVietorisSequence_exact` is its exactness;
 * `Scheme.Modules.epi_mayerVietorisδ`: if `Hⁿ⁺¹(U, M)` and `Hⁿ⁺¹(V, M)` vanish, then the
@@ -34,8 +34,10 @@ together with the vanishing it gives when `U` and `V` cover `X`.
   uniform positive-degree acyclicity hypotheses.
 
 The last two statements are the shape in which Mayer-Vietoris is used on a curve: a separated
-scheme covered by two affine opens has no cohomology above degree one, once the acyclicity of
-affines is available. That acyclicity is not proved here.
+scheme covered by two affine opens has no cohomology above degree one in coefficients for which
+the affine opens are acyclic. Serre's acyclicity of affines supplies that input for a
+quasi-coherent `M`; the coefficients `M : X.Modules` here are arbitrary, and the acyclicity is
+taken as a hypothesis rather than proved.
 
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer B, "coherent sheaves and
 cohomology `Hⁱ(X, ℱ)`: … vanishing above dimension (`H² = 0` on a curve)". No formalization is
@@ -84,7 +86,7 @@ def mayerVietorisSequence (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) : ComposableAr
 the pairs of restriction maps from `U ⊔ V`, the two maps out of a biproduct are the differences of
 the restriction maps to `U ⊓ V`, and the middle map is the connecting map. -/
 @[simp]
-lemma mayerVietorisSequence_eq (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+lemma mayerVietorisSequence_def (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
     mayerVietorisSequence M U V n₀ n₁ h =
       ComposableArrows.mk₅
         (biprod.lift (cohomologyOnRes M n₀ (le_sup_left : U ≤ U ⊔ V))
@@ -152,7 +154,8 @@ theorem subsingleton_cohomology_succ (hUV : U ⊔ V = ⊤) (n : ℕ)
 positive degrees has no cohomology in degrees at least two.
 
 This is the form Mayer-Vietoris takes on a separated scheme covered by two affine opens: the
-intersection is then affine as well, and Serre's acyclicity of affines supplies the hypotheses. -/
+intersection is then affine as well, so for quasi-coherent `M` Serre's acyclicity of affines
+supplies the hypotheses. For a general `M : X.Modules` they have to come from elsewhere. -/
 theorem subsingleton_cohomology_of_two_le (hUV : U ⊔ V = ⊤) (n : ℕ) (hn : 2 ≤ n)
     (hU : ∀ i, 0 < i → Subsingleton (cohomologyOn M i U))
     (hV : ∀ i, 0 < i → Subsingleton (cohomologyOn M i V))

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -115,11 +115,11 @@ theorem epi_mayerVietorisδ (n : ℕ)
     Epi (mayerVietorisδ M U V n (n + 1) rfl) := by
   set F := (_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M
   set S := Opens.mayerVietorisSquare U V
-  -- both components of the map to the biproduct land in a zero object
-  have hg : S.toBiprod F (n + 1) = 0 := by
-    refine biprod.hom_ext _ _ ?_ ?_
-    · exact (AddCommGrpCat.isZero_of_subsingleton (G := cohomologyOn M (n + 1) U)).eq_of_tgt _ _
-    · exact (AddCommGrpCat.isZero_of_subsingleton (G := cohomologyOn M (n + 1) V)).eq_of_tgt _ _
+  -- the biproduct the map lands in is a zero object
+  have hg : S.toBiprod F (n + 1) = 0 :=
+    ((biprod_isZero_iff _ _).2
+      ⟨AddCommGrpCat.isZero_of_subsingleton (cohomologyOn M (n + 1) U),
+        AddCommGrpCat.isZero_of_subsingleton (cohomologyOn M (n + 1) V)⟩).eq_of_tgt _ _
   -- the piece of the Mayer-Vietoris sequence around `Hⁿ⁺¹(U ⊔ V, M)`
   have hex : (ShortComplex.mk (S.δ F n (n + 1) rfl) (S.toBiprod F (n + 1))
       (S.δ_toBiprod _ _ _ _)).Exact :=

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicGeometry.Cohomology.Basic
-public import TauCeti.CategoryTheory.Sites.SheafCohomology.Terminal
 public import Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris
 public import Mathlib.Topology.Sheaves.MayerVietoris
 
@@ -13,16 +12,13 @@ public import Mathlib.Topology.Sheaves.MayerVietoris
 # Mayer-Vietoris for the cohomology of a sheaf of modules on a scheme
 
 `TauCeti/AlgebraicGeometry/Cohomology/Basic.lean` defines the cohomology `Hⁿ(X, M)` of a sheaf of
-modules on a scheme. This file adds the cohomology `Hⁿ(U, M)` of an open subset, and the long
+modules on a scheme, and the cohomology `Hⁿ(U, M)` of an open subset. This file adds the long
 exact Mayer-Vietoris sequence of a covering of `X` by two open subsets `U` and `V`:
 
 `⋯ ⟶ Hⁿ(X, M) ⟶ Hⁿ(U, M) ⊞ Hⁿ(V, M) ⟶ Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(X, M) ⟶ ⋯`
 
 ## Main declarations
 
-* `Scheme.Modules.cohomologyOn M n U` is `Hⁿ(U, M)`, and `Scheme.Modules.cohomologyOnRes` is
-  restriction along an inclusion of open subsets;
-* `Scheme.Modules.cohomologyOnTopIso` identifies `Hⁿ(⊤, M)` with `Hⁿ(X, M)`;
 * `Scheme.Modules.coverSquare` is the Mayer-Vietoris square of a covering of `X` by two opens,
   `Scheme.Modules.mayerVietorisSequence` is the six-term piece of the resulting long exact
   sequence and `Scheme.Modules.mayerVietorisSequence_exact` is its exactness;
@@ -41,8 +37,9 @@ cohomology `Hⁱ(X, ℱ)`: … vanishing above dimension (`H² = 0` on a curve)"
 vendored: the long exact sequence is Mathlib's
 `CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sequence_exact`, the square attached to
 two open subsets is Mathlib's `TopologicalSpace.Opens.mayerVietorisSquare'`, and the comparison
-between the cohomology of the terminal open subset and the cohomology of the site is
-`TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean`.
+between the cohomology of the terminal open subset and the cohomology of the site comes from
+`TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean` through
+`Scheme.Modules.cohomologyOnTopIso`.
 -/
 
 public section
@@ -61,53 +58,16 @@ namespace Scheme.Modules
 
 variable {X : Scheme.{u}} (M : X.Modules)
 
-/-- The cohomology `Hⁿ(U, M)` of an open subset `U` of a scheme `X` with coefficients in a sheaf
-of modules `M`, as an abelian group.
-
-This is `CategoryTheory.Sheaf.H'` applied to the underlying abelian sheaf of `M`. At `U = ⊤` it
-agrees with `Scheme.Modules.Cohomology`, by `Scheme.Modules.cohomologyOnTopIso`. -/
-abbrev cohomologyOn (n : ℕ) (U : Opens X) : AddCommGrpCat.{u} :=
-  CategoryTheory.Sheaf.H'.{u} ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n U
-
-/-- Restriction in cohomology along an inclusion of open subsets. -/
-abbrev cohomologyOnRes (n : ℕ) {U V : Opens X} (h : U ≤ V) :
-    cohomologyOn M n V ⟶ cohomologyOn M n U :=
-  (CategoryTheory.Sheaf.cohomologyPresheaf.{u}
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n).map (homOfLE h).op
-
-@[simp]
-lemma cohomologyOnRes_refl (n : ℕ) (U : Opens X) :
-    cohomologyOnRes M n (le_refl U) = 𝟙 _ := by
-  change (CategoryTheory.Sheaf.cohomologyPresheaf.{u}
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n).map (homOfLE (le_refl U)).op = 𝟙 _
-  rw [Subsingleton.elim (homOfLE (le_refl U)) (𝟙 U), op_id, CategoryTheory.Functor.map_id]
-
-@[reassoc]
-lemma cohomologyOnRes_comp (n : ℕ) {U V W : Opens X} (hUV : U ≤ V) (hVW : V ≤ W) :
-    cohomologyOnRes M n hVW ≫ cohomologyOnRes M n hUV =
-      cohomologyOnRes M n (hUV.trans hVW) := by
-  change (CategoryTheory.Sheaf.cohomologyPresheaf.{u}
-      ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n).map (homOfLE hVW).op ≫
-    (CategoryTheory.Sheaf.cohomologyPresheaf.{u}
-      ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n).map (homOfLE hUV).op = _
-  rw [← CategoryTheory.Functor.map_comp, ← op_comp,
-    Subsingleton.elim (homOfLE hUV ≫ homOfLE hVW) (homOfLE (hUV.trans hVW))]
-
-/-- The cohomology of the whole space is the cohomology of the scheme. -/
-def cohomologyOnTopIso (n : ℕ) :
-    cohomologyOn M n ⊤ ≅ AddCommGrpCat.of (Cohomology M n) :=
-  TauCeti.CategoryTheory.cohomologyPresheafObjIsoH n isTerminalTop _
-
-/-- The cohomology of the whole space is the cohomology of the scheme. -/
-def cohomologyOnTopAddEquiv (n : ℕ) : cohomologyOn M n ⊤ ≃+ Cohomology M n :=
-  TauCeti.CategoryTheory.cohomologyPresheafObjAddEquivH n isTerminalTop _
-
 section Cover
 
 variable {U V : Opens X} (hUV : U ⊔ V = ⊤)
 
 /-- The Mayer-Vietoris square of a covering of a scheme by two open subsets. Its corners are
-`U ⊓ V`, `U`, `V` and the whole space. -/
+`U ⊓ V`, `U`, `V` and the whole space.
+
+The body is `@[expose]`d because the characteristic lemmas below (`coverSquare_X₁` and friends,
+`coverSquare_toBiprod`, `coverSquare_fromBiprod`) hold by definition, and the module system
+requires the definitions unfolded by an exported theorem to be exposed. -/
 @[expose]
 def coverSquare : (Opens.grothendieckTopology X).MayerVietorisSquare :=
   Opens.mayerVietorisSquare'
@@ -129,6 +89,7 @@ def coverSquare : (Opens.grothendieckTopology X).MayerVietorisSquare :=
 
 /-- The map `Hⁿ(X, M) ⟶ Hⁿ(U, M) ⊞ Hⁿ(V, M)` of the Mayer-Vietoris sequence is the pair of
 restriction maps. -/
+@[simp]
 lemma coverSquare_toBiprod (n : ℕ) :
     (coverSquare hUV).toBiprod ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n =
       biprod.lift (cohomologyOnRes M n (le_top : U ≤ ⊤))
@@ -137,6 +98,7 @@ lemma coverSquare_toBiprod (n : ℕ) :
 
 /-- The map `Hⁿ(U, M) ⊞ Hⁿ(V, M) ⟶ Hⁿ(U ⊓ V, M)` of the Mayer-Vietoris sequence is the difference
 of the two restriction maps. -/
+@[simp]
 lemma coverSquare_fromBiprod (n : ℕ) :
     (coverSquare hUV).fromBiprod ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n =
       biprod.desc (cohomologyOnRes M n (inf_le_left : U ⊓ V ≤ U))

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -19,10 +19,10 @@ exact Mayer-Vietoris sequence of a covering of `X` by two open subsets `U` and `
 
 ## Main declarations
 
-* `Scheme.Modules.coverSquare` is the Mayer-Vietoris square of a covering of `X` by two opens,
-  `Scheme.Modules.mayerVietorisSequence` is the six-term piece of the resulting long exact
-  sequence, `Scheme.Modules.mayerVietorisSequence_eq` identifies each of its objects and arrows
-  with restriction maps and the connecting map `Scheme.Modules.mayerVietorisδ`, and
+* `Scheme.Modules.mayerVietorisCoverSquare` is the Mayer-Vietoris square of a covering of `X` by
+  two opens, `Scheme.Modules.mayerVietorisSequence` is the six-term piece of the resulting long
+  exact sequence, `Scheme.Modules.mayerVietorisSequence_eq` identifies each of its objects and
+  arrows with restriction maps and the connecting map `Scheme.Modules.mayerVietorisδ`, and
   `Scheme.Modules.mayerVietorisSequence_exact` is its exactness;
 * `Scheme.Modules.epi_mayerVietorisδ`: if `Hⁿ⁺¹(U, M)` and `Hⁿ⁺¹(V, M)` vanish, then the
   connecting map `Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(X, M)` is an epimorphism;
@@ -65,8 +65,8 @@ section Cover
 variable {U V : Opens X} (hUV : U ⊔ V = ⊤)
 
 /-- The Mayer-Vietoris square of a covering of a scheme by two open subsets. Its corners are
-`U ⊓ V`, `U`, `V` and the whole space, as recorded by `coverSquare_X₁` and friends. -/
-def coverSquare : (Opens.grothendieckTopology X).MayerVietorisSquare :=
+`U ⊓ V`, `U`, `V` and the whole space, as recorded by `mayerVietorisCoverSquare_X₁` and friends. -/
+def mayerVietorisCoverSquare : (Opens.grothendieckTopology X).MayerVietorisSquare :=
   Opens.mayerVietorisSquare'
     { X₁ := U ⊓ V, X₂ := U, X₃ := V, X₄ := ⊤
       f₁₂ := homOfLE inf_le_left
@@ -78,24 +78,25 @@ def coverSquare : (Opens.grothendieckTopology X).MayerVietorisSquare :=
 
 -- The four corner lemmas hold by definition. Their proofs are written `(rfl)` rather than `rfl`
 -- so that they are checked as ordinary proofs rather than as exported definitional unfoldings,
--- which lets `coverSquare` keep its body private.
-@[simp] lemma coverSquare_X₁ : (coverSquare hUV).X₁ = U ⊓ V := (rfl)
+-- which lets `mayerVietorisCoverSquare` keep its body private.
+@[simp] lemma mayerVietorisCoverSquare_X₁ : (mayerVietorisCoverSquare hUV).X₁ = U ⊓ V := (rfl)
 
-@[simp] lemma coverSquare_X₂ : (coverSquare hUV).X₂ = U := (rfl)
+@[simp] lemma mayerVietorisCoverSquare_X₂ : (mayerVietorisCoverSquare hUV).X₂ = U := (rfl)
 
-@[simp] lemma coverSquare_X₃ : (coverSquare hUV).X₃ = V := (rfl)
+@[simp] lemma mayerVietorisCoverSquare_X₃ : (mayerVietorisCoverSquare hUV).X₃ = V := (rfl)
 
-@[simp] lemma coverSquare_X₄ : (coverSquare hUV).X₄ = ⊤ := (rfl)
+@[simp] lemma mayerVietorisCoverSquare_X₄ : (mayerVietorisCoverSquare hUV).X₄ = ⊤ := (rfl)
 
 /-- The connecting map `Hⁿ⁰(U ⊓ V, M) ⟶ Hⁿ¹(X, M)` of the Mayer-Vietoris sequence. -/
 def mayerVietorisδ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
     cohomologyOn M n₀ (U ⊓ V) ⟶ cohomologyOn M n₁ ⊤ :=
-  (coverSquare hUV).δ ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
+  (mayerVietorisCoverSquare hUV).δ ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
 
 /-- Six consecutive terms of the Mayer-Vietoris long exact sequence, running from `Hⁿ⁰(X, M)` to
 `Hⁿ¹(U ⊓ V, M)`. -/
 def mayerVietorisSequence (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) : ComposableArrows AddCommGrpCat.{u} 5 :=
-  (coverSquare hUV).sequence ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
+  (mayerVietorisCoverSquare hUV).sequence
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
 
 /-- Every object and every arrow of the Mayer-Vietoris sequence: the two maps to a biproduct are
 the pairs of restriction maps from `X`, the two maps out of a biproduct are the differences of the
@@ -118,7 +119,7 @@ lemma mayerVietorisSequence_eq (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
 /-- The Mayer-Vietoris sequence of a covering by two open subsets is exact. -/
 theorem mayerVietorisSequence_exact (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
     (mayerVietorisSequence M hUV n₀ n₁ h).Exact :=
-  (coverSquare hUV).sequence_exact _ _ _ _
+  (mayerVietorisCoverSquare hUV).sequence_exact _ _ _ _
 
 include hUV in
 /-- If the degree `n + 1` cohomology of both members of a two-element open cover vanishes, then
@@ -128,7 +129,7 @@ theorem epi_mayerVietorisδ (n : ℕ)
     (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
     Epi (mayerVietorisδ M hUV n (n + 1) rfl) := by
   set F := (_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M
-  set S := coverSquare hUV
+  set S := mayerVietorisCoverSquare hUV
   -- both components of the map to the biproduct land in a zero object
   have hg : S.toBiprod F (n + 1) = 0 := by
     refine biprod.hom_ext _ _ ?_ ?_

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -21,7 +21,9 @@ exact Mayer-Vietoris sequence of a covering of `X` by two open subsets `U` and `
 
 * `Scheme.Modules.coverSquare` is the Mayer-Vietoris square of a covering of `X` by two opens,
   `Scheme.Modules.mayerVietorisSequence` is the six-term piece of the resulting long exact
-  sequence and `Scheme.Modules.mayerVietorisSequence_exact` is its exactness;
+  sequence, `Scheme.Modules.mayerVietorisSequence_eq` identifies each of its objects and arrows
+  with restriction maps and the connecting map `Scheme.Modules.mayerVietorisδ`, and
+  `Scheme.Modules.mayerVietorisSequence_exact` is its exactness;
 * `Scheme.Modules.epi_mayerVietorisδ`: if `Hⁿ⁺¹(U, M)` and `Hⁿ⁺¹(V, M)` vanish, then the
   connecting map `Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(X, M)` is an epimorphism;
 * `Scheme.Modules.subsingleton_cohomology_succ`: if moreover `Hⁿ(U ⊓ V, M)` vanishes, then
@@ -63,12 +65,7 @@ section Cover
 variable {U V : Opens X} (hUV : U ⊔ V = ⊤)
 
 /-- The Mayer-Vietoris square of a covering of a scheme by two open subsets. Its corners are
-`U ⊓ V`, `U`, `V` and the whole space.
-
-The body is `@[expose]`d because the characteristic lemmas below (`coverSquare_X₁` and friends,
-`coverSquare_toBiprod`, `coverSquare_fromBiprod`) hold by definition, and the module system
-requires the definitions unfolded by an exported theorem to be exposed. -/
-@[expose]
+`U ⊓ V`, `U`, `V` and the whole space, as recorded by `coverSquare_X₁` and friends. -/
 def coverSquare : (Opens.grothendieckTopology X).MayerVietorisSquare :=
   Opens.mayerVietorisSquare'
     { X₁ := U ⊓ V, X₂ := U, X₃ := V, X₄ := ⊤
@@ -79,31 +76,16 @@ def coverSquare : (Opens.grothendieckTopology X).MayerVietorisSquare :=
       fac := Subsingleton.elim _ _ }
     hUV.symm rfl
 
-@[simp] lemma coverSquare_X₁ : (coverSquare hUV).X₁ = U ⊓ V := rfl
+-- The four corner lemmas hold by definition. Their proofs are written `(rfl)` rather than `rfl`
+-- so that they are checked as ordinary proofs rather than as exported definitional unfoldings,
+-- which lets `coverSquare` keep its body private.
+@[simp] lemma coverSquare_X₁ : (coverSquare hUV).X₁ = U ⊓ V := (rfl)
 
-@[simp] lemma coverSquare_X₂ : (coverSquare hUV).X₂ = U := rfl
+@[simp] lemma coverSquare_X₂ : (coverSquare hUV).X₂ = U := (rfl)
 
-@[simp] lemma coverSquare_X₃ : (coverSquare hUV).X₃ = V := rfl
+@[simp] lemma coverSquare_X₃ : (coverSquare hUV).X₃ = V := (rfl)
 
-@[simp] lemma coverSquare_X₄ : (coverSquare hUV).X₄ = ⊤ := rfl
-
-/-- The map `Hⁿ(X, M) ⟶ Hⁿ(U, M) ⊞ Hⁿ(V, M)` of the Mayer-Vietoris sequence is the pair of
-restriction maps. -/
-@[simp]
-lemma coverSquare_toBiprod (n : ℕ) :
-    (coverSquare hUV).toBiprod ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n =
-      biprod.lift (cohomologyOnRes M n (le_top : U ≤ ⊤))
-        (cohomologyOnRes M n (le_top : V ≤ ⊤)) :=
-  rfl
-
-/-- The map `Hⁿ(U, M) ⊞ Hⁿ(V, M) ⟶ Hⁿ(U ⊓ V, M)` of the Mayer-Vietoris sequence is the difference
-of the two restriction maps. -/
-@[simp]
-lemma coverSquare_fromBiprod (n : ℕ) :
-    (coverSquare hUV).fromBiprod ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n =
-      biprod.desc (cohomologyOnRes M n (inf_le_left : U ⊓ V ≤ U))
-        (-cohomologyOnRes M n (inf_le_right : U ⊓ V ≤ V)) :=
-  rfl
+@[simp] lemma coverSquare_X₄ : (coverSquare hUV).X₄ = ⊤ := (rfl)
 
 /-- The connecting map `Hⁿ⁰(U ⊓ V, M) ⟶ Hⁿ¹(X, M)` of the Mayer-Vietoris sequence. -/
 def mayerVietorisδ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
@@ -114,6 +96,24 @@ def mayerVietorisδ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
 `Hⁿ¹(U ⊓ V, M)`. -/
 def mayerVietorisSequence (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) : ComposableArrows AddCommGrpCat.{u} 5 :=
   (coverSquare hUV).sequence ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
+
+/-- Every object and every arrow of the Mayer-Vietoris sequence: the two maps to a biproduct are
+the pairs of restriction maps from `X`, the two maps out of a biproduct are the differences of the
+restriction maps to `U ⊓ V`, and the middle map is the connecting map. -/
+@[simp]
+lemma mayerVietorisSequence_eq (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    mayerVietorisSequence M hUV n₀ n₁ h =
+      ComposableArrows.mk₅
+        (biprod.lift (cohomologyOnRes M n₀ (le_top : U ≤ ⊤))
+          (cohomologyOnRes M n₀ (le_top : V ≤ ⊤)))
+        (biprod.desc (cohomologyOnRes M n₀ (inf_le_left : U ⊓ V ≤ U))
+          (-cohomologyOnRes M n₀ (inf_le_right : U ⊓ V ≤ V)))
+        (mayerVietorisδ M hUV n₀ n₁ h)
+        (biprod.lift (cohomologyOnRes M n₁ (le_top : U ≤ ⊤))
+          (cohomologyOnRes M n₁ (le_top : V ≤ ⊤)))
+        (biprod.desc (cohomologyOnRes M n₁ (inf_le_left : U ⊓ V ≤ U))
+          (-cohomologyOnRes M n₁ (inf_le_right : U ⊓ V ≤ V))) :=
+  (rfl)
 
 /-- The Mayer-Vietoris sequence of a covering by two open subsets is exact. -/
 theorem mayerVietorisSequence_exact (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicGeometry.Cohomology.Basic
-public import Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris
+public import TauCeti.CategoryTheory.Sites.SheafCohomology.MayerVietoris
 public import Mathlib.Topology.Sheaves.MayerVietoris
 
 /-!
@@ -35,9 +35,10 @@ together with the vanishing it gives when `U` and `V` cover `X`.
 
 The last two statements are the shape in which Mayer-Vietoris is used on a curve: a separated
 scheme covered by two affine opens has no cohomology above degree one in coefficients for which
-the affine opens are acyclic. Serre's acyclicity of affines supplies that input for a
-quasi-coherent `M`; the coefficients `M : X.Modules` here are arbitrary, and the acyclicity is
-taken as a hypothesis rather than proved.
+the affine opens are acyclic. For quasi-coherent `M`, Serre's acyclicity of affines will supply
+that input after the still-missing comparison `Sheaf.H' F i U ≅ Sheaf.H (F.over U) i` is
+established. The coefficients `M : X.Modules` here are arbitrary, and the acyclicity is taken as
+a hypothesis rather than proved.
 
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer B, "coherent sheaves and
 cohomology `Hⁱ(X, ℱ)`: … vanishing above dimension (`H² = 0` on a curve)". No formalization is
@@ -71,14 +72,15 @@ variable (U V : Opens X)
 
 /-- The connecting map `Hⁿ⁰(U ⊓ V, M) ⟶ Hⁿ¹(U ⊔ V, M)` of the Mayer-Vietoris sequence of two
 open subsets. -/
-def mayerVietorisδ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+noncomputable abbrev mayerVietorisδ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
     cohomologyOn M n₀ (U ⊓ V) ⟶ cohomologyOn M n₁ (U ⊔ V) :=
   (Opens.mayerVietorisSquare U V).δ
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
 
 /-- Six consecutive terms of the Mayer-Vietoris long exact sequence of two open subsets, running
 from `Hⁿ⁰(U ⊔ V, M)` to `Hⁿ¹(U ⊓ V, M)`. -/
-def mayerVietorisSequence (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) : ComposableArrows AddCommGrpCat.{u} 5 :=
+noncomputable abbrev mayerVietorisSequence (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    ComposableArrows AddCommGrpCat.{u} 5 :=
   (Opens.mayerVietorisSquare U V).sequence
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n₀ n₁ h
 
@@ -98,9 +100,9 @@ lemma mayerVietorisSequence_def (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
           (cohomologyOnRes M n₁ (le_sup_right : V ≤ U ⊔ V)))
         (biprod.desc (cohomologyOnRes M n₁ (inf_le_left : U ⊓ V ≤ U))
           (-cohomologyOnRes M n₁ (inf_le_right : U ⊓ V ≤ V))) :=
-  -- `(rfl)` rather than `rfl`, so that this is checked as an ordinary proof rather than as an
-  -- exported definitional unfolding, which lets `mayerVietorisSequence` keep its body private.
-  (rfl)
+  -- This is definitional after unfolding Mathlib's `toBiprod` and `fromBiprod` together with
+  -- the four structure maps of `Opens.mayerVietorisSquare`.
+  rfl
 
 /-- The Mayer-Vietoris sequence of two open subsets is exact. -/
 theorem mayerVietorisSequence_exact (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
@@ -112,19 +114,10 @@ connecting map onto `Hⁿ⁺¹(U ⊔ V, M)` is an epimorphism. -/
 theorem epi_mayerVietorisδ (n : ℕ)
     (hU : Subsingleton (cohomologyOn M (n + 1) U))
     (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
-    Epi (mayerVietorisδ M U V n (n + 1) rfl) := by
-  set F := (_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M
-  set S := Opens.mayerVietorisSquare U V
-  -- the biproduct the map lands in is a zero object
-  have hg : S.toBiprod F (n + 1) = 0 :=
-    ((biprod_isZero_iff _ _).2
-      ⟨AddCommGrpCat.isZero_of_subsingleton (cohomologyOn M (n + 1) U),
-        AddCommGrpCat.isZero_of_subsingleton (cohomologyOn M (n + 1) V)⟩).eq_of_tgt _ _
-  -- the piece of the Mayer-Vietoris sequence around `Hⁿ⁺¹(U ⊔ V, M)`
-  have hex : (ShortComplex.mk (S.δ F n (n + 1) rfl) (S.toBiprod F (n + 1))
-      (S.δ_toBiprod _ _ _ _)).Exact :=
-    (mayerVietorisSequence_exact M U V n (n + 1) rfl).exact' 2 3 4
-  exact hex.epi_f hg
+    Epi (mayerVietorisδ M U V n (n + 1) rfl) :=
+  TauCeti.CategoryTheory.GrothendieckTopology.MayerVietorisSquare.epi_δ
+    (Opens.mayerVietorisSquare U V)
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n (n + 1) rfl hU hV
 
 variable {U V}
 
@@ -134,10 +127,10 @@ theorem subsingleton_cohomologyOn_sup_succ (n : ℕ)
     (hInter : Subsingleton (cohomologyOn M n (U ⊓ V)))
     (hU : Subsingleton (cohomologyOn M (n + 1) U))
     (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
-    Subsingleton (cohomologyOn M (n + 1) (U ⊔ V)) := by
-  have hsurj : Function.Surjective (mayerVietorisδ M U V n (n + 1) rfl) :=
-    (AddCommGrpCat.epi_iff_surjective _).mp (epi_mayerVietorisδ M U V n hU hV)
-  exact hsurj.subsingleton
+    Subsingleton (cohomologyOn M (n + 1) (U ⊔ V)) :=
+  TauCeti.CategoryTheory.GrothendieckTopology.MayerVietorisSquare.subsingleton_H'_X₄
+    (Opens.mayerVietorisSquare U V)
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n (n + 1) rfl hInter hU hV
 
 /-- A scheme covered by two open subsets whose degree `n + 1` cohomology vanishes, and whose
 intersection has vanishing degree `n` cohomology, has vanishing degree `n + 1` cohomology. -/
@@ -154,8 +147,9 @@ theorem subsingleton_cohomology_succ (hUV : U ⊔ V = ⊤) (n : ℕ)
 positive degrees has no cohomology in degrees at least two.
 
 This is the form Mayer-Vietoris takes on a separated scheme covered by two affine opens: the
-intersection is then affine as well, so for quasi-coherent `M` Serre's acyclicity of affines
-supplies the hypotheses. For a general `M : X.Modules` they have to come from elsewhere. -/
+intersection is then affine as well. For quasi-coherent `M`, applying Serre's acyclicity requires
+the still-missing comparison `Sheaf.H' F i U ≅ Sheaf.H (F.over U) i`; for a general
+`M : X.Modules` the hypotheses have to come from elsewhere. -/
 theorem subsingleton_cohomology_of_two_le (hUV : U ⊔ V = ⊤) (n : ℕ) (hn : 2 ≤ n)
     (hU : ∀ i, 0 < i → Subsingleton (cohomologyOn M i U))
     (hV : ∀ i, 0 < i → Subsingleton (cohomologyOn M i V))

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -27,8 +27,9 @@ together with the vanishing it gives when `U` and `V` cover `X`.
   `Scheme.Modules.mayerVietorisSequence_exact` is its exactness;
 * `Scheme.Modules.epi_mayerVietorisδ`: if `Hⁿ⁺¹(U, M)` and `Hⁿ⁺¹(V, M)` vanish, then the
   connecting map `Hⁿ(U ⊓ V, M) ⟶ Hⁿ⁺¹(U ⊔ V, M)` is an epimorphism;
-* `Scheme.Modules.subsingleton_cohomology_succ`: if moreover `Hⁿ(U ⊓ V, M)` vanishes and
-  `U ⊔ V = ⊤`, then `Hⁿ⁺¹(X, M)` vanishes, and
+* `Scheme.Modules.subsingleton_cohomologyOn_sup_succ`: if moreover `Hⁿ(U ⊓ V, M)` vanishes,
+  then `Hⁿ⁺¹(U ⊔ V, M)` vanishes; `Scheme.Modules.subsingleton_cohomology_succ` specializes
+  this to `Hⁿ⁺¹(X, M)` when `U ⊔ V = ⊤`, and
   `Scheme.Modules.subsingleton_cohomology_of_two_le` applies this at degree `n - 1` under
   uniform positive-degree acyclicity hypotheses.
 
@@ -125,6 +126,17 @@ theorem epi_mayerVietorisδ (n : ℕ)
 
 variable {U V}
 
+/-- If the degree `n + 1` cohomology of both of two open subsets vanishes, and their intersection
+has vanishing degree `n` cohomology, then their union has vanishing degree `n + 1` cohomology. -/
+theorem subsingleton_cohomologyOn_sup_succ (n : ℕ)
+    (hInter : Subsingleton (cohomologyOn M n (U ⊓ V)))
+    (hU : Subsingleton (cohomologyOn M (n + 1) U))
+    (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
+    Subsingleton (cohomologyOn M (n + 1) (U ⊔ V)) := by
+  have hsurj : Function.Surjective (mayerVietorisδ M U V n (n + 1) rfl) :=
+    (AddCommGrpCat.epi_iff_surjective _).mp (epi_mayerVietorisδ M U V n hU hV)
+  exact hsurj.subsingleton
+
 /-- A scheme covered by two open subsets whose degree `n + 1` cohomology vanishes, and whose
 intersection has vanishing degree `n` cohomology, has vanishing degree `n + 1` cohomology. -/
 theorem subsingleton_cohomology_succ (hUV : U ⊔ V = ⊤) (n : ℕ)
@@ -132,9 +144,7 @@ theorem subsingleton_cohomology_succ (hUV : U ⊔ V = ⊤) (n : ℕ)
     (hU : Subsingleton (cohomologyOn M (n + 1) U))
     (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
     Subsingleton (Cohomology M (n + 1)) := by
-  have hsurj : Function.Surjective (mayerVietorisδ M U V n (n + 1) rfl) :=
-    (AddCommGrpCat.epi_iff_surjective _).mp (epi_mayerVietorisδ M U V n hU hV)
-  have hTop : Subsingleton (cohomologyOn M (n + 1) (U ⊔ V)) := hsurj.subsingleton
+  have hTop := subsingleton_cohomologyOn_sup_succ M n hInter hU hV
   rw [hUV] at hTop
   exact (cohomologyOnTopIso M (n + 1)).symm.addCommGroupIsoToAddEquiv.toEquiv.subsingleton
 

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/MayerVietoris.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/MayerVietoris.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris
+
+/-!
+# Vanishing consequences of the Mayer-Vietoris sequence
+
+This file records general consequences of Mathlib's Mayer-Vietoris sequence for sheaf
+cohomology. They are used for the scheme-cohomology vanishing results required by
+`TauCetiRoadmap/JacobianChallenge/README.md`, Layer B.
+-/
+
+public section
+
+open CategoryTheory Limits
+
+namespace TauCeti
+
+namespace CategoryTheory.GrothendieckTopology.MayerVietorisSquare
+
+universe w v u
+
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+  [HasWeakSheafify J (Type v)] [HasSheafify J AddCommGrpCat.{v}]
+  [HasExt.{w} (Sheaf J AddCommGrpCat.{v})]
+
+variable (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
+
+/-- If the cohomology of the two side objects vanishes in degree `n₁`, then the connecting map
+from degree `n₀` to degree `n₁` is an epimorphism. -/
+theorem epi_δ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+    (h₂ : Subsingleton (F.H' n₁ S.X₂)) (h₃ : Subsingleton (F.H' n₁ S.X₃)) :
+    Epi (S.δ F n₀ n₁ h) := by
+  have hg : S.toBiprod F n₁ = 0 :=
+    ((biprod_isZero_iff _ _).2
+      ⟨AddCommGrpCat.isZero_of_subsingleton _,
+        AddCommGrpCat.isZero_of_subsingleton _⟩).eq_of_tgt _ _
+  have hex := (S.sequence_exact F n₀ n₁ h).exact' 2 3 4
+  exact hex.epi_f hg
+
+/-- If the lower-left and the two side cohomology groups in consecutive degrees vanish, then the
+upper-right cohomology group vanishes. -/
+theorem subsingleton_H'_X₄ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+    (h₁ : Subsingleton (F.H' n₀ S.X₁))
+    (h₂ : Subsingleton (F.H' n₁ S.X₂)) (h₃ : Subsingleton (F.H' n₁ S.X₃)) :
+    Subsingleton (F.H' n₁ S.X₄) := by
+  have hsurj : Function.Surjective (S.δ F n₀ n₁ h) :=
+    (AddCommGrpCat.epi_iff_surjective _).mp (epi_δ S F n₀ n₁ h h₂ h₃)
+  exact hsurj.subsingleton
+
+end CategoryTheory.GrothendieckTopology.MayerVietorisSquare
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
@@ -23,13 +23,9 @@ in terms of `Sheaf.H'`, so the comparison is what lets a covering of the whole s
 
 ## Main declarations
 
-* `TauCeti.CategoryTheory.yonedaObjIsoConst`: the presheaf of points of a terminal object is the
-  constant presheaf on a point;
-* `TauCeti.CategoryTheory.freeYonedaObjIsoConst`: consequently the free abelian presheaf on it is
-  the constant presheaf `ℤ`, and `freeYonedaSheafIsoConstantSheaf` sheafifies this;
-* `TauCeti.CategoryTheory.cohomologyPresheafObjIsoH`: the resulting comparison
+* `TauCeti.CategoryTheory.Sheaf.cohomologyPresheafObjIsoH`: the comparison
   `Hⁿ(T, F) ≅ Hⁿ(F)` at a terminal object `T`, as an isomorphism of abelian groups;
-* `TauCeti.CategoryTheory.cohomologyPresheafEvaluationIsoFunctorH`: the same comparison as a
+* `TauCeti.CategoryTheory.Sheaf.cohomologyPresheafEvaluationIsoFunctorH`: the same comparison as a
   natural isomorphism in the coefficient sheaf.
 
 This settles the first item of the `## TODO` list of
@@ -37,7 +33,7 @@ This settles the first item of the `## TODO` list of
 `TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean` to obtain the Mayer-Vietoris sequence
 for the cohomology of a scheme, which is Layer B infrastructure for
 `TauCetiRoadmap/JacobianChallenge/README.md`. No formalization is vendored: the ingredients are
-Mathlib's `CategoryTheory.isTerminalEquivUnique`, `FreeAbelianGroup.uniqueEquiv`,
+Mathlib's `CategoryTheory.Limits.IsTerminal.isTerminalObj`, `FreeAbelianGroup.uniqueEquiv`,
 `CategoryTheory.Functor.constComp` and `CategoryTheory.Abelian.extFunctor`.
 -/
 
@@ -45,29 +41,23 @@ public section
 
 open CategoryTheory Limits Opposite
 
-namespace TauCeti
-
 universe w v u
+
+namespace TauCeti
 
 namespace CategoryTheory
 
 variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
 
-/-- The presheaf of points of a terminal object is the constant presheaf on a point. -/
-def yonedaObjIsoConst {T : C} (hT : IsTerminal T) :
+private noncomputable def yonedaObjIsoConst {T : C} (hT : IsTerminal T) :
     yoneda.obj T ≅ (Functor.const Cᵒᵖ).obj PUnit.{v + 1} :=
-  have (U : Cᵒᵖ) : Unique (U.unop ⟶ T) := isTerminalEquivUnique _ T hT _
-  NatIso.ofComponents (fun _ => Equiv.toIso (Equiv.equivPUnit _))
-    (by intros; ext; exact Subsingleton.elim (α := PUnit.{v + 1}) _ _)
+  (hT.isTerminalObj yoneda).uniqueUpToIso (Functor.isTerminalConst Cᵒᵖ Types.isTerminalPUnit)
 
-/-- The free abelian group on a one-element type is `ℤ`. -/
-def freeObjPUnitIso :
+private def freeObjPUnitIso :
     AddCommGrpCat.free.obj PUnit.{v + 1} ≅ AddCommGrpCat.of (ULift.{v} ℤ) :=
   AddEquiv.toAddCommGrpIso ((FreeAbelianGroup.uniqueEquiv PUnit).trans AddEquiv.ulift.symm)
 
-/-- The free abelian presheaf on the presheaf of points of a terminal object is the constant
-presheaf `ℤ`. -/
-def freeYonedaObjIsoConst {T : C} (hT : IsTerminal T) :
+private noncomputable def freeYonedaObjIsoConst {T : C} (hT : IsTerminal T) :
     yoneda.obj T ⋙ AddCommGrpCat.free.{v} ≅
       (Functor.const Cᵒᵖ).obj (AddCommGrpCat.of (ULift.{v} ℤ)) :=
   Functor.isoWhiskerRight (yonedaObjIsoConst hT) AddCommGrpCat.free ≪≫
@@ -78,9 +68,7 @@ noncomputable section
 
 variable [HasWeakSheafify J AddCommGrpCat.{v}]
 
-/-- The free abelian sheaf on a terminal object is the constant sheaf `ℤ`. This is the object
-that `CategoryTheory.Sheaf.H` takes `Ext`-groups out of. -/
-def freeYonedaSheafIsoConstantSheaf {T : C} (hT : IsTerminal T) :
+private def freeYonedaSheafIsoConstantSheaf {T : C} (hT : IsTerminal T) :
     (presheafToSheaf J AddCommGrpCat.{v}).obj (yoneda.obj T ⋙ AddCommGrpCat.free) ≅
       (constantSheaf J AddCommGrpCat.{v}).obj (AddCommGrpCat.of (ULift.{v} ℤ)) :=
   (presheafToSheaf J _).mapIso (freeYonedaObjIsoConst hT)
@@ -89,23 +77,43 @@ end
 
 noncomputable section
 
+namespace Sheaf
+
 variable [HasSheafify J AddCommGrpCat.{v}] [HasExt.{w} (Sheaf J AddCommGrpCat.{v})]
+
+-- Mathlib's `functorH` and `extFunctorObj` use definitionally equal object and map data.
+-- Naming that identification here isolates the definitional coincidence used below.
+set_option backward.isDefEq.respectTransparency false in
+private noncomputable def functorHIso (n : ℕ) :
+    _root_.CategoryTheory.Sheaf.functorH J n ≅
+      (_root_.CategoryTheory.Abelian.extFunctor n).obj
+        (op ((constantSheaf J AddCommGrpCat.{v}).obj (AddCommGrpCat.of (ULift ℤ)))) :=
+  NatIso.ofComponents (fun _ => Iso.refl _)
+    (by
+      intros
+      ext
+      rfl)
 
 variable (J) in
 /-- At a terminal object `T`, the cohomology presheaf evaluated at `T` is the cohomology of the
 site, naturally in the coefficient sheaf. -/
 def cohomologyPresheafEvaluationIsoFunctorH (n : ℕ) {T : C} (hT : IsTerminal T) :
-    Sheaf.cohomologyPresheafFunctor J n ⋙ (evaluation Cᵒᵖ AddCommGrpCat.{w}).obj (op T) ≅
-      Sheaf.functorH J n :=
+    _root_.CategoryTheory.Sheaf.cohomologyPresheafFunctor J n ⋙
+        (evaluation Cᵒᵖ AddCommGrpCat.{w}).obj (op T) ≅
+      _root_.CategoryTheory.Sheaf.functorH J n :=
   (_root_.CategoryTheory.Abelian.extFunctor n).mapIso
-    (freeYonedaSheafIsoConstantSheaf hT).symm.op
+      (freeYonedaSheafIsoConstantSheaf hT).symm.op ≪≫
+    functorHIso n
 
 variable (n : ℕ) {T : C} (hT : IsTerminal T)
 
 /-- At a terminal object, the cohomology of the object is the cohomology of the site. -/
-def cohomologyPresheafObjIsoH (F : Sheaf J AddCommGrpCat.{v}) :
-    Sheaf.H' F n T ≅ AddCommGrpCat.of (Sheaf.H F n) :=
+noncomputable abbrev cohomologyPresheafObjIsoH (F : Sheaf J AddCommGrpCat.{v}) :
+    _root_.CategoryTheory.Sheaf.H' F n T ≅
+      AddCommGrpCat.of (_root_.CategoryTheory.Sheaf.H F n) :=
   (cohomologyPresheafEvaluationIsoFunctorH J n hT).app F
+
+end Sheaf
 
 end
 

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.CategoryTheory.Sites.SheafCohomology.Basic
+
+/-!
+# Sheaf cohomology at a terminal object
+
+Mathlib carries two accounts of the cohomology of an abelian sheaf `F` on a site `(C, J)`:
+
+* `CategoryTheory.Sheaf.H F n`, the `Ext`-groups from the constant sheaf `ℤ`, which is the
+  cohomology of the site as a whole;
+* `CategoryTheory.Sheaf.H' F n X`, the `Ext`-groups from the sheafification of the free abelian
+  presheaf on `yoneda.obj X`, which is the cohomology of the object `X`.
+
+They agree when `X` is a terminal object, and this file supplies that comparison. The abstract
+Mayer-Vietoris sequence of `Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris` is stated
+in terms of `Sheaf.H'`, so the comparison is what lets a covering of the whole site compute
+`Sheaf.H`.
+
+## Main declarations
+
+* `TauCeti.CategoryTheory.yonedaObjIsoConst`: the presheaf of points of a terminal object is the
+  constant presheaf on a point;
+* `TauCeti.CategoryTheory.freeYonedaObjIsoConst`: consequently the free abelian presheaf on it is
+  the constant presheaf `ℤ`, and `freeYonedaSheafIsoConstantSheaf` sheafifies this;
+* `TauCeti.CategoryTheory.cohomologyPresheafObjIsoH` and
+  `TauCeti.CategoryTheory.cohomologyPresheafObjAddEquivH`: the resulting comparison
+  `Hⁿ(T, F) ≅ Hⁿ(F)` at a terminal object `T`, as an isomorphism of abelian groups and as an
+  additive equivalence;
+* `TauCeti.CategoryTheory.cohomologyPresheafEvaluationIsoFunctorH`: the same comparison as a
+  natural isomorphism in the coefficient sheaf.
+
+This settles the first item of the `## TODO` list of
+`Mathlib/CategoryTheory/Sites/SheafCohomology/Basic.lean`. It is used in
+`TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean` to obtain the Mayer-Vietoris sequence
+for the cohomology of a scheme, which is Layer B infrastructure for
+`TauCetiRoadmap/JacobianChallenge/README.md`. No formalization is vendored: the ingredients are
+Mathlib's `CategoryTheory.isTerminalEquivUnique`, `FreeAbelianGroup.uniqueEquiv`,
+`CategoryTheory.Functor.constComp` and `CategoryTheory.Abelian.extFunctor`.
+-/
+
+public section
+
+open CategoryTheory Limits Opposite
+
+namespace TauCeti
+
+universe w v u
+
+namespace CategoryTheory
+
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+
+/-- The presheaf of points of a terminal object is the constant presheaf on a point. -/
+def yonedaObjIsoConst {T : C} (hT : IsTerminal T) :
+    yoneda.obj T ≅ (Functor.const Cᵒᵖ).obj PUnit.{v + 1} :=
+  have (U : Cᵒᵖ) : Unique (U.unop ⟶ T) := isTerminalEquivUnique _ T hT _
+  NatIso.ofComponents (fun _ => Equiv.toIso (Equiv.equivPUnit _))
+    (by intros; ext; exact Subsingleton.elim (α := PUnit.{v + 1}) _ _)
+
+/-- The free abelian group on a one-element type is `ℤ`. -/
+def freeObjPUnitIso :
+    AddCommGrpCat.free.obj PUnit.{v + 1} ≅ AddCommGrpCat.of (ULift.{v} ℤ) :=
+  AddEquiv.toAddCommGrpIso ((FreeAbelianGroup.uniqueEquiv PUnit).trans AddEquiv.ulift.symm)
+
+/-- The free abelian presheaf on the presheaf of points of a terminal object is the constant
+presheaf `ℤ`. -/
+def freeYonedaObjIsoConst {T : C} (hT : IsTerminal T) :
+    yoneda.obj T ⋙ AddCommGrpCat.free.{v} ≅
+      (Functor.const Cᵒᵖ).obj (AddCommGrpCat.of (ULift.{v} ℤ)) :=
+  Functor.isoWhiskerRight (yonedaObjIsoConst hT) AddCommGrpCat.free ≪≫
+    Functor.constComp (J := Cᵒᵖ) PUnit.{v + 1} AddCommGrpCat.free ≪≫
+      (Functor.const Cᵒᵖ).mapIso freeObjPUnitIso
+
+noncomputable section
+
+variable [HasWeakSheafify J AddCommGrpCat.{v}]
+
+/-- The free abelian sheaf on a terminal object is the constant sheaf `ℤ`. This is the object
+that `CategoryTheory.Sheaf.H` takes `Ext`-groups out of. -/
+def freeYonedaSheafIsoConstantSheaf {T : C} (hT : IsTerminal T) :
+    (presheafToSheaf J AddCommGrpCat.{v}).obj (yoneda.obj T ⋙ AddCommGrpCat.free) ≅
+      (constantSheaf J AddCommGrpCat.{v}).obj (AddCommGrpCat.of (ULift.{v} ℤ)) :=
+  (presheafToSheaf J _).mapIso (freeYonedaObjIsoConst hT)
+
+variable [HasSheafify J AddCommGrpCat.{v}] [HasExt.{w} (Sheaf J AddCommGrpCat.{v})]
+
+variable (J) in
+/-- At a terminal object `T`, the cohomology presheaf evaluated at `T` is the cohomology of the
+site, naturally in the coefficient sheaf. -/
+def cohomologyPresheafEvaluationIsoFunctorH (n : ℕ) {T : C} (hT : IsTerminal T) :
+    Sheaf.cohomologyPresheafFunctor J n ⋙ (evaluation Cᵒᵖ AddCommGrpCat.{w}).obj (op T) ≅
+      Sheaf.functorH J n :=
+  (_root_.CategoryTheory.Abelian.extFunctor n).mapIso
+    (freeYonedaSheafIsoConstantSheaf hT).symm.op
+
+variable (n : ℕ) {T : C} (hT : IsTerminal T)
+
+/-- At a terminal object, the cohomology of the object is the cohomology of the site. -/
+def cohomologyPresheafObjIsoH (F : Sheaf J AddCommGrpCat.{v}) :
+    Sheaf.H' F n T ≅ AddCommGrpCat.of (Sheaf.H F n) :=
+  (cohomologyPresheafEvaluationIsoFunctorH J n hT).app F
+
+/-- At a terminal object, the cohomology of the object is the cohomology of the site. -/
+def cohomologyPresheafObjAddEquivH (F : Sheaf J AddCommGrpCat.{v}) :
+    Sheaf.H' F n T ≃+ Sheaf.H F n :=
+  (cohomologyPresheafObjIsoH n hT F).addCommGroupIsoToAddEquiv
+
+end
+
+end CategoryTheory
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
@@ -83,7 +83,6 @@ variable [HasSheafify J AddCommGrpCat.{v}] [HasExt.{w} (Sheaf J AddCommGrpCat.{v
 
 -- Mathlib's `functorH` and `extFunctorObj` use definitionally equal object and map data.
 -- Naming that identification here isolates the definitional coincidence used below.
-set_option backward.isDefEq.respectTransparency false in
 private noncomputable def functorHIso (n : ℕ) :
     _root_.CategoryTheory.Sheaf.functorH J n ≅
       (_root_.CategoryTheory.Abelian.extFunctor n).obj

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
@@ -27,10 +27,8 @@ in terms of `Sheaf.H'`, so the comparison is what lets a covering of the whole s
   constant presheaf on a point;
 * `TauCeti.CategoryTheory.freeYonedaObjIsoConst`: consequently the free abelian presheaf on it is
   the constant presheaf `ℤ`, and `freeYonedaSheafIsoConstantSheaf` sheafifies this;
-* `TauCeti.CategoryTheory.cohomologyPresheafObjIsoH` and
-  `TauCeti.CategoryTheory.cohomologyPresheafObjAddEquivH`: the resulting comparison
-  `Hⁿ(T, F) ≅ Hⁿ(F)` at a terminal object `T`, as an isomorphism of abelian groups and as an
-  additive equivalence;
+* `TauCeti.CategoryTheory.cohomologyPresheafObjIsoH`: the resulting comparison
+  `Hⁿ(T, F) ≅ Hⁿ(F)` at a terminal object `T`, as an isomorphism of abelian groups;
 * `TauCeti.CategoryTheory.cohomologyPresheafEvaluationIsoFunctorH`: the same comparison as a
   natural isomorphism in the coefficient sheaf.
 
@@ -87,6 +85,10 @@ def freeYonedaSheafIsoConstantSheaf {T : C} (hT : IsTerminal T) :
       (constantSheaf J AddCommGrpCat.{v}).obj (AddCommGrpCat.of (ULift.{v} ℤ)) :=
   (presheafToSheaf J _).mapIso (freeYonedaObjIsoConst hT)
 
+end
+
+noncomputable section
+
 variable [HasSheafify J AddCommGrpCat.{v}] [HasExt.{w} (Sheaf J AddCommGrpCat.{v})]
 
 variable (J) in
@@ -104,11 +106,6 @@ variable (n : ℕ) {T : C} (hT : IsTerminal T)
 def cohomologyPresheafObjIsoH (F : Sheaf J AddCommGrpCat.{v}) :
     Sheaf.H' F n T ≅ AddCommGrpCat.of (Sheaf.H F n) :=
   (cohomologyPresheafEvaluationIsoFunctorH J n hT).app F
-
-/-- At a terminal object, the cohomology of the object is the cohomology of the site. -/
-def cohomologyPresheafObjAddEquivH (F : Sheaf J AddCommGrpCat.{v}) :
-    Sheaf.H' F n T ≃+ Sheaf.H F n :=
-  (cohomologyPresheafObjIsoH n hT F).addCommGroupIsoToAddEquiv
 
 end
 


### PR DESCRIPTION
This PR adds the Mayer-Vietoris long exact sequence for the cohomology of a sheaf of modules on a scheme, together with the comparison, at a terminal object of a site, between the cohomology of that object and the cohomology of the site.

`TauCeti/AlgebraicGeometry/Cohomology/Basic.lean` already defines `Hⁿ(X, M)` for `M : X.Modules` as an `Ext`-group out of the constant sheaf `ℤ`, and Mathlib already supplies the abstract Mayer-Vietoris sequence of a `GrothendieckTopology.MayerVietorisSquare`. The two do not meet: Mathlib's sequence is stated in terms of `CategoryTheory.Sheaf.H' F n U`, the cohomology of an *object* of the site, which is an `Ext`-group out of the sheafified free abelian presheaf on `yoneda.obj U`. `TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean` (117 lines) identifies that sheaf, at a terminal object, with the constant sheaf `ℤ`, and so gives `Hⁿ(T, F) ≃+ Hⁿ(F)`; this is the first item of the `## TODO` list of `Mathlib/CategoryTheory/Sites/SheafCohomology/Basic.lean`. `TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean` (221 lines) then defines `Hⁿ(U, M)` for an open subset `U` together with its restriction maps, builds the Mayer-Vietoris square of a covering `U ⊔ V = ⊤`, identifies the three maps of the sequence with the restriction maps and the connecting map, and records the six-term exact sequence

```
Hⁿ⁰(X, M) ⟶ Hⁿ⁰(U, M) ⊞ Hⁿ⁰(V, M) ⟶ Hⁿ⁰(U ⊓ V, M) ⟶ Hⁿ¹(X, M) ⟶ Hⁿ¹(U, M) ⊞ Hⁿ¹(V, M) ⟶ Hⁿ¹(U ⊓ V, M)
```

The consequence the roadmap wants is `subsingleton_cohomology_of_two_le`: if `U`, `V` and `U ⊓ V` are acyclic in positive degrees, then `Hⁿ(X, M)` vanishes for every `n ≥ 2`. This is the statement that will give `H² = 0` on a curve, applied to a separated scheme covered by two affine opens.

Milestone: `TauCetiRoadmap/JacobianChallenge/README.md`, Layer B, "coherent sheaves and cohomology `Hⁱ(X, ℱ)`: acyclicity of affines, Čech ≃ derived on a separated scheme, finite-dimensionality for proper `X/k`, vanishing above dimension (`H² = 0` on a curve)". The `STATUS.md` frontier names coherent cohomology over `k` as the largest gap, and scheme sheaf cohomology itself landed only recently (TauCeti#2281), so this is the first tool built on top of it. What remains for the milestone after this PR is the input the sequence consumes and the results downstream of it: Serre's acyclicity of affine schemes, finite-dimensionality of `Hⁱ` for proper `X/k`, and the comparison with Čech cohomology; genus and Riemann-Roch sit behind those.

Nothing is vendored. The exactness is Mathlib's `GrothendieckTopology.MayerVietorisSquare.sequence_exact`, the square of two open subsets is Mathlib's `TopologicalSpace.Opens.mayerVietorisSquare'`, and the terminal comparison is assembled from `CategoryTheory.isTerminalEquivUnique`, `FreeAbelianGroup.uniqueEquiv`, `CategoryTheory.Functor.constComp` and `CategoryTheory.Abelian.extFunctor`.

Roadmap: JacobianChallenge

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"mayer-vietoris-scheme-modules-cohomology"}-->

🤖 Prepared with Claude Code
