### PR TITLE
feat: uniqueness of the BCR Laplace-Fourier representing measure

### DIFF
--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Basic.lean
@@ -57,6 +57,11 @@ theorem laplaceAtom_def (p : ℝ≥0) (t : ℝ≥0) :
     laplaceAtom p t = (Real.exp (-(t : ℝ) * (p : ℝ)) : ℂ) :=
   by simp [laplaceAtom]
 
+/-- The Laplace atom is symmetric in its two nonnegative arguments: the frequency and the time
+enter `exp (-t p)` in the same way. -/
+theorem laplaceAtom_comm (p t : ℝ≥0) : laplaceAtom p t = laplaceAtom t p := by
+  rw [laplaceAtom_def, laplaceAtom_def, show -(t : ℝ) * (p : ℝ) = -(p : ℝ) * (t : ℝ) from by ring]
+
 /-- Laplace atoms turn time addition into a rank-one positive-definite kernel. -/
 theorem laplaceAtom_add (p t u : ℝ≥0) :
     laplaceAtom p (t + u) = conj (laplaceAtom p t) * laplaceAtom p u := by

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Basic.lean
@@ -60,7 +60,7 @@ theorem laplaceAtom_def (p : ℝ≥0) (t : ℝ≥0) :
 /-- The Laplace atom is symmetric in its two nonnegative arguments: the frequency and the time
 enter `exp (-t p)` in the same way. -/
 theorem laplaceAtom_comm (p t : ℝ≥0) : laplaceAtom p t = laplaceAtom t p := by
-  rw [laplaceAtom_def, laplaceAtom_def, show -(t : ℝ) * (p : ℝ) = -(p : ℝ) * (t : ℝ) from by ring]
+  rw [laplaceAtom_def, laplaceAtom_def, neg_mul, neg_mul, mul_comm]
 
 /-- Laplace atoms turn time addition into a rank-one positive-definite kernel. -/
 theorem laplaceAtom_add (p t u : ℝ≥0) :

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Transform.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Transform.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Basic
+public import Mathlib.MeasureTheory.Integral.Bochner.Basic
+
+/-!
+# The Laplace--Fourier transform of a measure on `ℝ≥0 × V`
+
+The Berg--Christensen--Ressel representation writes a bounded continuous positive-definite
+function on the involutive semigroup `ℝ≥0 × V` as the Laplace--Fourier transform
+
+`F (t, a) = ∫ (p, q), exp (-t p) * exp (-2πi⟪a, q⟫) ∂μ`
+
+of a finite measure `μ` on `ℝ≥0 × V`. This file defines that transform, through the atoms of
+`TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Basic`, and packages the
+predicate that a finite measure represents a given function this way. It is the material both
+halves of the representation theorem share: the uniqueness half
+(`TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Uniqueness`) and the existence
+half, which consumes Bochner's theorem on `V`.
+
+## Main declarations
+
+* `TauCeti.laplaceFourierTransform`: the Laplace--Fourier transform of a measure on `ℝ≥0 × V`,
+  in Mathlib's `2π` Fourier convention.
+* `TauCeti.laplaceFourierTransform_apply_exp`: the transform in the exponential form used by the
+  Berg--Christensen--Ressel statement.
+* `TauCeti.RepresentsLaplaceFourier`: the predicate that a finite measure represents a function
+  on `ℝ≥0 × V` by its Laplace--Fourier transform.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Theorem 4.1.13.
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
+  ("BCR semigroup--Bochner"), whose statement this transform expresses.
+-/
+
+public section
+
+open MeasureTheory Set
+open scoped ENNReal NNReal
+
+namespace TauCeti
+
+/-! ## The Laplace--Fourier atoms of a fixed evaluation point -/
+
+section Atoms
+
+variable {V : Type*} [SeminormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- The Laplace--Fourier atoms are bounded by `1` in norm: the Laplace factor is at most `1`
+because both parameters are nonnegative, and the Fourier factor is unimodular. -/
+theorem norm_laplaceAtom_mul_fourierAtom_le_one (t p : ℝ≥0) (a q : V) :
+    ‖laplaceAtom t p * fourierAtom a q‖ ≤ 1 := by
+  rw [norm_mul, laplaceAtom_def, fourierAtom_eq_fourierChar, Complex.norm_real,
+    Circle.norm_coe, mul_one, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _),
+    Real.exp_le_one_iff]
+  exact mul_nonpos_of_nonpos_of_nonneg (neg_nonpos.2 p.coe_nonneg) t.coe_nonneg
+
+/-- The integrand of the Laplace--Fourier transform is continuous in the integration
+variable. -/
+theorem continuous_laplaceAtom_mul_fourierAtom (t : ℝ≥0) (a : V) :
+    Continuous fun y : ℝ≥0 × V => laplaceAtom t y.1 * fourierAtom a y.2 :=
+  ((continuous_laplaceAtom t).comp continuous_fst).mul
+    ((continuous_fourierAtom a).comp continuous_snd)
+
+end Atoms
+
+/-! ## The Laplace--Fourier transform of a measure -/
+
+section Defs
+
+variable {V : Type*} [SeminormedAddCommGroup V] [InnerProductSpace ℝ V] [MeasurableSpace V]
+
+/-- The **Laplace--Fourier transform** of a measure on `ℝ≥0 × V`, evaluated at a point
+`x = (t, a)` of the involutive semigroup `ℝ≥0 × V`:
+
+`(t, a) ↦ ∫ (p, q), exp (-t p) * exp (-2πi⟪a, q⟫) ∂μ`.
+
+The integrand is the separated Laplace--Fourier atom of
+`TauCeti.isSemigroupGroupPD_laplaceFourierAtom`, so a finite measure produces a bounded
+semigroup-group positive-definite function; the Berg--Christensen--Ressel theorem asserts that
+every bounded continuous one arises this way. -/
+noncomputable def laplaceFourierTransform (μ : Measure (ℝ≥0 × V)) (x : ℝ≥0 × V) : ℂ :=
+  ∫ y, laplaceAtom x.1 y.1 * fourierAtom x.2 y.2 ∂μ
+
+/-- The defining formula for `laplaceFourierTransform`. Not `@[simp]`: simp should not unfold
+the abstraction into a raw integral. -/
+theorem laplaceFourierTransform_apply (μ : Measure (ℝ≥0 × V)) (x : ℝ≥0 × V) :
+    laplaceFourierTransform μ x = ∫ y, laplaceAtom x.1 y.1 * fourierAtom x.2 y.2 ∂μ := by
+  rw [laplaceFourierTransform]
+
+/-- The Laplace--Fourier transform in the exponential form used by the Berg--Christensen--Ressel
+statement: the transform at `(t, a)` integrates `exp (-t p) * exp (-2πi⟪a, q⟫)`. -/
+theorem laplaceFourierTransform_apply_exp (μ : Measure (ℝ≥0 × V)) (t : ℝ≥0) (a : V) :
+    laplaceFourierTransform μ (t, a) =
+      ∫ y, (Real.exp (-(t : ℝ) * (y.1 : ℝ)) : ℂ) *
+        Complex.exp (-2 * ((Real.pi : ℝ) : ℂ) * Complex.I * ((inner ℝ a y.2 : ℝ) : ℂ)) ∂μ := by
+  rw [laplaceFourierTransform_apply]
+  refine integral_congr_ae (.of_forall fun y => ?_)
+  -- beta-reduce the two integrands and the projections of the pair `(t, a)`
+  dsimp only
+  rw [laplaceAtom_comm, laplaceAtom_def, fourierAtom_apply, real_inner_comm]
+
+/-- The integrand of the Laplace--Fourier transform is integrable against a finite measure. -/
+theorem integrable_laplaceAtom_mul_fourierAtom [OpensMeasurableSpace V]
+    (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ] (t : ℝ≥0) (a : V) :
+    Integrable (fun y : ℝ≥0 × V => laplaceAtom t y.1 * fourierAtom a y.2) μ :=
+  (integrable_const (1 : ℝ)).mono'
+    (continuous_laplaceAtom_mul_fourierAtom t a).aestronglyMeasurable
+    (.of_forall fun y => norm_laplaceAtom_mul_fourierAtom_le_one t y.1 a y.2)
+
+/-! ## The representation predicate -/
+
+/-- A finite measure represents a function on `ℝ≥0 × V` by its Laplace--Fourier transform. This
+is the representation asserted by the Berg--Christensen--Ressel theorem. -/
+def RepresentsLaplaceFourier (μ : Measure (ℝ≥0 × V)) (F : ℝ≥0 × V → ℂ) : Prop :=
+  IsFiniteMeasure μ ∧ ∀ x, F x = laplaceFourierTransform μ x
+
+/-- `RepresentsLaplaceFourier μ F` unfolds to finiteness of `μ` together with the
+Laplace--Fourier representation of `F`. -/
+theorem representsLaplaceFourier_iff {μ : Measure (ℝ≥0 × V)} {F : ℝ≥0 × V → ℂ} :
+    RepresentsLaplaceFourier μ F ↔
+      IsFiniteMeasure μ ∧ ∀ x, F x = laplaceFourierTransform μ x :=
+  Iff.rfl
+
+namespace RepresentsLaplaceFourier
+
+variable {μ : Measure (ℝ≥0 × V)} {F : ℝ≥0 × V → ℂ}
+
+/-- A representing measure is finite. -/
+@[grind →]
+theorem isFiniteMeasure (h : RepresentsLaplaceFourier μ F) : IsFiniteMeasure μ := h.1
+
+/-- A representing measure has the advertised Laplace--Fourier transform. -/
+@[grind =>]
+theorem eq_laplaceFourierTransform (h : RepresentsLaplaceFourier μ F) (x : ℝ≥0 × V) :
+    F x = laplaceFourierTransform μ x :=
+  h.2 x
+
+/-- The value of a represented function at the identity of `ℝ≥0 × V` is the total mass of the
+representing measure. (Not `@[simp]`: the left-hand side has a variable head symbol.) -/
+theorem apply_zero (h : RepresentsLaplaceFourier μ F) : F 0 = (μ.real univ : ℂ) := by
+  have := h.isFiniteMeasure
+  rw [h.eq_laplaceFourierTransform 0, laplaceFourierTransform_apply]
+  simp [laplaceAtom_def, fourierAtom_apply, Measure.real]
+
+end RepresentsLaplaceFourier
+
+end Defs
+
+end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Transform.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Transform.lean
@@ -83,9 +83,12 @@ variable {V : Type*} [SeminormedAddCommGroup V] [InnerProductSpace ℝ V] [Measu
 `(t, a) ↦ ∫ (p, q), exp (-t p) * exp (-2πi⟪a, q⟫) ∂μ`.
 
 The integrand is the separated Laplace--Fourier atom of
-`TauCeti.isSemigroupGroupPD_laplaceFourierAtom`, so a finite measure produces a bounded
-semigroup-group positive-definite function; the Berg--Christensen--Ressel theorem asserts that
-every bounded continuous one arises this way. -/
+`TauCeti.isSemigroupGroupPD_laplaceFourierAtom`. Nothing here relates the measurable structure
+on `V` to its topology, so the integral need not converge; integrability of the atoms against a
+finite measure is `TauCeti.integrable_laplaceAtom_mul_fourierAtom`, which additionally assumes
+`OpensMeasurableSpace V`. The Berg--Christensen--Ressel theorem asserts that every bounded
+continuous semigroup-group positive-definite function on `ℝ≥0 × V` is the transform of a finite
+measure. -/
 noncomputable def laplaceFourierTransform (μ : Measure (ℝ≥0 × V)) (x : ℝ≥0 × V) : ℂ :=
   ∫ y, laplaceAtom x.1 y.1 * fourierAtom x.2 y.2 ∂μ
 
@@ -114,6 +117,47 @@ theorem integrable_laplaceAtom_mul_fourierAtom [OpensMeasurableSpace V]
   (integrable_const (1 : ℝ)).mono'
     (continuous_laplaceAtom_mul_fourierAtom t a).aestronglyMeasurable
     (.of_forall fun y => norm_laplaceAtom_mul_fourierAtom_le_one t y.1 a y.2)
+
+/-! ## Values and elementary measure operations -/
+
+/-- The Laplace--Fourier transform at the identity `0` of `ℝ≥0 × V` is the total mass: both
+atoms are `1` there. -/
+@[simp]
+theorem laplaceFourierTransform_zero (μ : Measure (ℝ≥0 × V)) :
+    laplaceFourierTransform μ 0 = (μ.real univ : ℂ) := by
+  rw [laplaceFourierTransform_apply]
+  simp [laplaceAtom_def, fourierAtom_apply, Complex.real_smul]
+
+/-- The zero measure has zero Laplace--Fourier transform. -/
+@[simp]
+theorem laplaceFourierTransform_zero_measure (x : ℝ≥0 × V) :
+    laplaceFourierTransform (0 : Measure (ℝ≥0 × V)) x = 0 := by
+  rw [laplaceFourierTransform_apply, integral_zero_measure]
+
+/-- The Laplace--Fourier transform of a Dirac mass is the atom at its point. -/
+@[simp]
+theorem laplaceFourierTransform_dirac [OpensMeasurableSpace V] (y x : ℝ≥0 × V) :
+    laplaceFourierTransform (Measure.dirac y) x = laplaceAtom x.1 y.1 * fourierAtom x.2 y.2 := by
+  rw [laplaceFourierTransform_apply,
+    integral_dirac' _ y (continuous_laplaceAtom_mul_fourierAtom x.1 x.2).stronglyMeasurable]
+
+/-- The Laplace--Fourier transform is additive in the measure. -/
+@[simp]
+theorem laplaceFourierTransform_add_measure [OpensMeasurableSpace V] (μ ν : Measure (ℝ≥0 × V))
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν] (x : ℝ≥0 × V) :
+    laplaceFourierTransform (μ + ν) x =
+      laplaceFourierTransform μ x + laplaceFourierTransform ν x := by
+  simp only [laplaceFourierTransform_apply]
+  exact integral_add_measure (integrable_laplaceAtom_mul_fourierAtom μ x.1 x.2)
+    (integrable_laplaceAtom_mul_fourierAtom ν x.1 x.2)
+
+/-- Scaling the measure scales its Laplace--Fourier transform. -/
+@[simp]
+theorem laplaceFourierTransform_smul_measure (μ : Measure (ℝ≥0 × V)) (c : ℝ≥0∞)
+    (x : ℝ≥0 × V) :
+    laplaceFourierTransform (c • μ) x = c.toReal • laplaceFourierTransform μ x := by
+  simp only [laplaceFourierTransform_apply]
+  exact integral_smul_measure _ c
 
 /-! ## The representation predicate -/
 
@@ -146,9 +190,7 @@ theorem eq_laplaceFourierTransform (h : RepresentsLaplaceFourier μ F) (x : ℝ�
 /-- The value of a represented function at the identity of `ℝ≥0 × V` is the total mass of the
 representing measure. (Not `@[simp]`: the left-hand side has a variable head symbol.) -/
 theorem apply_zero (h : RepresentsLaplaceFourier μ F) : F 0 = (μ.real univ : ℂ) := by
-  have := h.isFiniteMeasure
-  rw [h.eq_laplaceFourierTransform 0, laplaceFourierTransform_apply]
-  simp [laplaceAtom_def, fourierAtom_apply, Measure.real]
+  rw [h.eq_laplaceFourierTransform 0, laplaceFourierTransform_zero]
 
 end RepresentsLaplaceFourier
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Transform.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Transform.lean
@@ -10,12 +10,14 @@ public import Mathlib.MeasureTheory.Integral.Bochner.Basic
 /-!
 # The Laplace--Fourier transform of a measure on `ℝ≥0 × V`
 
-The Berg--Christensen--Ressel representation writes a bounded continuous positive-definite
-function on the involutive semigroup `ℝ≥0 × V` as the Laplace--Fourier transform
+For a *finite-dimensional* real inner product space `V`, the Berg--Christensen--Ressel
+representation writes a bounded continuous positive-definite function on the involutive
+semigroup `ℝ≥0 × V` as the Laplace--Fourier transform
 
 `F (t, a) = ∫ (p, q), exp (-t p) * exp (-2πi⟪a, q⟫) ∂μ`
 
-of a finite measure `μ` on `ℝ≥0 × V`. This file defines that transform, through the atoms of
+of a finite measure `μ` on `ℝ≥0 × V`. This file defines that transform for an arbitrary `V`
+— no finite-dimensionality is needed to write it down — through the atoms of
 `TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Basic`, and packages the
 predicate that a finite measure represents a given function this way. It is the material both
 halves of the representation theorem share: the uniqueness half
@@ -79,9 +81,9 @@ The integrand is the separated Laplace--Fourier atom of
 `TauCeti.isSemigroupGroupPD_laplaceFourierAtom`. Nothing here relates the measurable structure
 on `V` to its topology, so the integral need not converge; integrability of the atoms against a
 finite measure is `TauCeti.integrable_laplaceAtom_mul_fourierAtom`, which additionally assumes
-`OpensMeasurableSpace V`. The Berg--Christensen--Ressel theorem asserts that every bounded
-continuous semigroup-group positive-definite function on `ℝ≥0 × V` is the transform of a finite
-measure. -/
+`OpensMeasurableSpace V`. For a finite-dimensional `V`, the Berg--Christensen--Ressel theorem
+asserts that every bounded continuous semigroup-group positive-definite function on `ℝ≥0 × V`
+is the transform of a finite measure. -/
 noncomputable def laplaceFourierTransform (μ : Measure (ℝ≥0 × V)) (x : ℝ≥0 × V) : ℂ :=
   ∫ y, laplaceAtom x.1 y.1 * fourierAtom x.2 y.2 ∂μ
 
@@ -187,7 +189,38 @@ representing measure. (Not `@[simp]`: the left-hand side has a variable head sym
 theorem apply_zero (h : RepresentsLaplaceFourier μ F) : F 0 = (μ.real univ : ℂ) := by
   rw [h.eq_laplaceFourierTransform 0, laplaceFourierTransform_zero]
 
+/-- The sum of two representing measures represents the sum of the functions. -/
+protected theorem add [OpensMeasurableSpace V] {G : ℝ≥0 × V → ℂ} {ν : Measure (ℝ≥0 × V)}
+    (hF : RepresentsLaplaceFourier μ F) (hG : RepresentsLaplaceFourier ν G) :
+    RepresentsLaplaceFourier (μ + ν) (F + G) := by
+  have := hF.isFiniteMeasure
+  have := hG.isFiniteMeasure
+  refine ⟨inferInstance, fun x => ?_⟩
+  rw [Pi.add_apply, hF.eq_laplaceFourierTransform x, hG.eq_laplaceFourierTransform x,
+    laplaceFourierTransform_add_measure]
+
+/-- Scaling a representing measure by `c : ℝ≥0` represents the scaled function. -/
+protected theorem smul (c : ℝ≥0) (hF : RepresentsLaplaceFourier μ F) :
+    RepresentsLaplaceFourier ((c : ℝ≥0∞) • μ) (fun x => (c : ℝ) • F x) := by
+  have := hF.isFiniteMeasure
+  have : IsFiniteMeasure ((c : ℝ≥0∞) • μ) := μ.smul_finite ENNReal.coe_ne_top
+  refine ⟨inferInstance, fun x => ?_⟩
+  -- beta-reduce the scaled function at `x`
+  dsimp only
+  rw [laplaceFourierTransform_smul_measure, ENNReal.coe_toReal, hF.eq_laplaceFourierTransform x]
+
 end RepresentsLaplaceFourier
+
+/-- The zero measure represents the zero function. -/
+theorem representsLaplaceFourier_zero :
+    RepresentsLaplaceFourier (0 : Measure (ℝ≥0 × V)) 0 :=
+  ⟨inferInstance, fun x => by simp⟩
+
+/-- The Dirac mass at `y` represents the Laplace--Fourier atom of `y`. -/
+theorem representsLaplaceFourier_dirac [OpensMeasurableSpace V] (y : ℝ≥0 × V) :
+    RepresentsLaplaceFourier (Measure.dirac y)
+      (fun x => laplaceAtom x.1 y.1 * fourierAtom x.2 y.2) :=
+  ⟨inferInstance, fun x => by rw [laplaceFourierTransform_dirac]⟩
 
 end Defs
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Transform.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Transform.lean
@@ -62,13 +62,6 @@ theorem norm_laplaceAtom_mul_fourierAtom_le_one (t p : ℝ≥0) (a q : V) :
     Real.exp_le_one_iff]
   exact mul_nonpos_of_nonpos_of_nonneg (neg_nonpos.2 p.coe_nonneg) t.coe_nonneg
 
-/-- The integrand of the Laplace--Fourier transform is continuous in the integration
-variable. -/
-theorem continuous_laplaceAtom_mul_fourierAtom (t : ℝ≥0) (a : V) :
-    Continuous fun y : ℝ≥0 × V => laplaceAtom t y.1 * fourierAtom a y.2 :=
-  ((continuous_laplaceAtom t).comp continuous_fst).mul
-    ((continuous_fourierAtom a).comp continuous_snd)
-
 end Atoms
 
 /-! ## The Laplace--Fourier transform of a measure -/
@@ -115,7 +108,8 @@ theorem integrable_laplaceAtom_mul_fourierAtom [OpensMeasurableSpace V]
     (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ] (t : ℝ≥0) (a : V) :
     Integrable (fun y : ℝ≥0 × V => laplaceAtom t y.1 * fourierAtom a y.2) μ :=
   (integrable_const (1 : ℝ)).mono'
-    (continuous_laplaceAtom_mul_fourierAtom t a).aestronglyMeasurable
+    (continuous_mul_time_spatial (continuous_laplaceAtom t)
+      (continuous_fourierAtom a)).aestronglyMeasurable
     (.of_forall fun y => norm_laplaceAtom_mul_fourierAtom_le_one t y.1 a y.2)
 
 /-! ## Values and elementary measure operations -/
@@ -139,7 +133,8 @@ theorem laplaceFourierTransform_zero_measure (x : ℝ≥0 × V) :
 theorem laplaceFourierTransform_dirac [OpensMeasurableSpace V] (y x : ℝ≥0 × V) :
     laplaceFourierTransform (Measure.dirac y) x = laplaceAtom x.1 y.1 * fourierAtom x.2 y.2 := by
   rw [laplaceFourierTransform_apply,
-    integral_dirac' _ y (continuous_laplaceAtom_mul_fourierAtom x.1 x.2).stronglyMeasurable]
+    integral_dirac' _ y (continuous_mul_time_spatial (continuous_laplaceAtom x.1)
+      (continuous_fourierAtom x.2)).stronglyMeasurable]
 
 /-- The Laplace--Fourier transform is additive in the measure. -/
 @[simp]

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Basic
-public import TauCeti.Analysis.Bochner.FourierConvention
--- Non-public: the two determinacy inputs (Laplace on `ℝ≥0`, Fourier on `V`) and the
--- product-`σ`-algebra plumbing, all consumed inside proofs only.
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Transform
+-- Non-public: the two determinacy inputs (Fourier on `V` through the convention conversion,
+-- Laplace on `ℝ≥0`) and the product-`σ`-algebra plumbing, all consumed inside proofs only.
+import TauCeti.Analysis.Bochner.FourierConvention
 import TauCeti.Probability.Moments.LaplaceDeterminacy
 import Mathlib.MeasureTheory.MeasurableSpace.Prod
 import Mathlib.MeasureTheory.Measure.CharacteristicFunction.Basic
@@ -22,7 +22,10 @@ function on the involutive semigroup `ℝ≥0 × V` as the Laplace--Fourier tran
 
 of a finite measure `μ` on `ℝ≥0 × V`. This file supplies the **uniqueness half**: a finite
 measure on `ℝ≥0 × V` is determined by its Laplace--Fourier transform. It is independent of the
-existence half, which consumes Bochner's theorem on `V`.
+existence half, which consumes Bochner's theorem on `V`; the transform itself and the
+representation predicate live in
+`TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Transform`, which both halves
+share.
 
 The proof separates the two variables. Weighting `μ` by the Laplace factor `exp (-t p)` and
 pushing forward to `V` gives a finite spatial measure whose characteristic function is, after
@@ -35,13 +38,11 @@ generating the product σ-algebra.
 
 ## Main declarations
 
-* `TauCeti.laplaceFourierTransform`: the Laplace--Fourier transform of a measure on `ℝ≥0 × V`,
-  in Mathlib's `2π` Fourier convention.
 * `TauCeti.Measure.ext_of_forall_laplaceFourierTransform_eq`: **finite measures on `ℝ≥0 × V`
   are determined by their Laplace--Fourier transforms**. This is the statement the roadmap
   calls `laplaceFourier_unique`.
-* `TauCeti.RepresentsLaplaceFourier`: the predicate that a finite measure represents a function
-  on `ℝ≥0 × V` by its Laplace--Fourier transform, with `RepresentsLaplaceFourier.unique`.
+* `TauCeti.RepresentsLaplaceFourier.unique`: a function has at most one representing finite
+  measure.
 
 ## References
 
@@ -58,110 +59,6 @@ open MeasureTheory Set
 open scoped ENNReal NNReal
 
 namespace TauCeti
-
-/-! ## The Laplace--Fourier atoms of a fixed evaluation point -/
-
-section Atoms
-
-variable {V : Type*} [SeminormedAddCommGroup V] [InnerProductSpace ℝ V]
-
-/-- The Laplace--Fourier atoms are bounded by `1` in norm: the Laplace factor is at most `1`
-because both parameters are nonnegative, and the Fourier factor is unimodular. -/
-theorem norm_laplaceAtom_mul_fourierAtom_le_one (t p : ℝ≥0) (a q : V) :
-    ‖laplaceAtom t p * fourierAtom a q‖ ≤ 1 := by
-  rw [norm_mul, laplaceAtom_def, fourierAtom_eq_fourierChar, Complex.norm_real,
-    Circle.norm_coe, mul_one, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _),
-    Real.exp_le_one_iff]
-  exact mul_nonpos_of_nonpos_of_nonneg (neg_nonpos.2 p.coe_nonneg) t.coe_nonneg
-
-/-- The integrand of the Laplace--Fourier transform is continuous in the integration
-variable. -/
-theorem continuous_laplaceAtom_mul_fourierAtom (t : ℝ≥0) (a : V) :
-    Continuous fun y : ℝ≥0 × V => laplaceAtom t y.1 * fourierAtom a y.2 :=
-  ((continuous_laplaceAtom t).comp continuous_fst).mul
-    ((continuous_fourierAtom a).comp continuous_snd)
-
-end Atoms
-
-/-! ## The Laplace--Fourier transform of a measure -/
-
-section Defs
-
-variable {V : Type*} [SeminormedAddCommGroup V] [InnerProductSpace ℝ V] [MeasurableSpace V]
-
-/-- The **Laplace--Fourier transform** of a measure on `ℝ≥0 × V`, evaluated at a point
-`x = (t, a)` of the involutive semigroup `ℝ≥0 × V`:
-
-`(t, a) ↦ ∫ (p, q), exp (-t p) * exp (-2πi⟪a, q⟫) ∂μ`.
-
-The integrand is the separated Laplace--Fourier atom of
-`TauCeti.isSemigroupGroupPD_laplaceFourierAtom`, so a finite measure produces a bounded
-semigroup-group positive-definite function; the Berg--Christensen--Ressel theorem asserts that
-every bounded continuous one arises this way. -/
-noncomputable def laplaceFourierTransform (μ : Measure (ℝ≥0 × V)) (x : ℝ≥0 × V) : ℂ :=
-  ∫ y, laplaceAtom x.1 y.1 * fourierAtom x.2 y.2 ∂μ
-
-/-- The defining formula for `laplaceFourierTransform`. Not `@[simp]`: simp should not unfold
-the abstraction into a raw integral. -/
-theorem laplaceFourierTransform_apply (μ : Measure (ℝ≥0 × V)) (x : ℝ≥0 × V) :
-    laplaceFourierTransform μ x = ∫ y, laplaceAtom x.1 y.1 * fourierAtom x.2 y.2 ∂μ := by
-  rw [laplaceFourierTransform]
-
-/-- The Laplace--Fourier transform in the exponential form used by the Berg--Christensen--Ressel
-statement: the transform at `(t, a)` integrates `exp (-t p) * exp (-2πi⟪a, q⟫)`. -/
-theorem laplaceFourierTransform_apply_exp (μ : Measure (ℝ≥0 × V)) (t : ℝ≥0) (a : V) :
-    laplaceFourierTransform μ (t, a) =
-      ∫ y, (Real.exp (-(t : ℝ) * (y.1 : ℝ)) : ℂ) *
-        Complex.exp (-2 * ((Real.pi : ℝ) : ℂ) * Complex.I * ((inner ℝ a y.2 : ℝ) : ℂ)) ∂μ := by
-  rw [laplaceFourierTransform_apply]
-  refine integral_congr_ae (.of_forall fun y => ?_)
-  change laplaceAtom t y.1 * fourierAtom a y.2 = _
-  rw [laplaceAtom_comm, laplaceAtom_def, fourierAtom_apply, real_inner_comm]
-
-/-- The integrand of the Laplace--Fourier transform is integrable against a finite measure. -/
-theorem integrable_laplaceAtom_mul_fourierAtom [OpensMeasurableSpace V]
-    (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ] (t : ℝ≥0) (a : V) :
-    Integrable (fun y : ℝ≥0 × V => laplaceAtom t y.1 * fourierAtom a y.2) μ :=
-  (integrable_const (1 : ℝ)).mono'
-    (continuous_laplaceAtom_mul_fourierAtom t a).aestronglyMeasurable
-    (.of_forall fun y => norm_laplaceAtom_mul_fourierAtom_le_one t y.1 a y.2)
-
-/-! ## The representation predicate -/
-
-/-- A finite measure represents a function on `ℝ≥0 × V` by its Laplace--Fourier transform. This
-is the representation asserted by the Berg--Christensen--Ressel theorem. -/
-def RepresentsLaplaceFourier (μ : Measure (ℝ≥0 × V)) (F : ℝ≥0 × V → ℂ) : Prop :=
-  IsFiniteMeasure μ ∧ ∀ x, F x = laplaceFourierTransform μ x
-
-/-- `RepresentsLaplaceFourier μ F` unfolds to finiteness of `μ` together with the
-Laplace--Fourier representation of `F`. -/
-theorem representsLaplaceFourier_iff {μ : Measure (ℝ≥0 × V)} {F : ℝ≥0 × V → ℂ} :
-    RepresentsLaplaceFourier μ F ↔
-      IsFiniteMeasure μ ∧ ∀ x, F x = laplaceFourierTransform μ x :=
-  Iff.rfl
-
-namespace RepresentsLaplaceFourier
-
-variable {μ : Measure (ℝ≥0 × V)} {F : ℝ≥0 × V → ℂ}
-
-/-- A representing measure is finite. -/
-theorem isFiniteMeasure (h : RepresentsLaplaceFourier μ F) : IsFiniteMeasure μ := h.1
-
-/-- A representing measure has the advertised Laplace--Fourier transform. -/
-theorem eq_laplaceFourierTransform (h : RepresentsLaplaceFourier μ F) (x : ℝ≥0 × V) :
-    F x = laplaceFourierTransform μ x :=
-  h.2 x
-
-/-- The value of a represented function at the identity of `ℝ≥0 × V` is the total mass of the
-representing measure. (Not `@[simp]`: the left-hand side has a variable head symbol.) -/
-theorem map_zero (h : RepresentsLaplaceFourier μ F) : F 0 = (μ.real univ : ℂ) := by
-  have := h.isFiniteMeasure
-  rw [h.eq_laplaceFourierTransform 0, laplaceFourierTransform_apply]
-  simp [laplaceAtom_def, fourierAtom_apply, Measure.real]
-
-end RepresentsLaplaceFourier
-
-end Defs
 
 /-! ## Slicing a measure on `ℝ≥0 × V` -/
 
@@ -224,7 +121,7 @@ private theorem ofReal_integral_slab (μ : Measure (ℝ≥0 × V)) [IsFiniteMeas
     exact exp_neg_mul_le_one t y.1
   rw [spatialSlice_apply μ t hB,
     ofReal_integral_eq_lintegral_ofReal hint (.of_forall fun y => (Real.exp_pos _).le)]
-  rfl
+  simp_rw [ENNReal.ofNNReal_toNNReal]
 
 /-- The **time-marginal** of the slab `ℝ≥0 × B`, as a measure on `ℝ≥0`. -/
 private noncomputable def timeMarginal (μ : Measure (ℝ≥0 × V)) (B : Set V) : Measure ℝ≥0 :=
@@ -261,7 +158,8 @@ private theorem integral_spatialSlice (μ : Measure (ℝ≥0 × V)) (t : ℝ≥0
   rw [spatialSlice, integral_map measurable_snd.aemeasurable hf.aestronglyMeasurable,
     integral_withDensity_eq_integral_smul (measurable_laplaceWeight t)]
   refine integral_congr_ae (.of_forall fun y => ?_)
-  change (Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) • f y.2 = _
+  -- beta-reduce the two integrands left by `integral_congr_ae`
+  dsimp only
   rw [NNReal.smul_def, Real.coe_toNNReal _ (Real.exp_nonneg _), Complex.real_smul]
 
 omit [SecondCountableTopology V] [CompleteSpace V] in
@@ -274,7 +172,8 @@ private theorem charFun_spatialSlice (μ : Measure (ℝ≥0 × V)) [IsFiniteMeas
   rw [← integral_fourierAtom_eq_charFun_neg_two_pi_smul,
     integral_spatialSlice μ t (continuous_fourierAtom a), laplaceFourierTransform_apply]
   refine integral_congr_ae (.of_forall fun y => ?_)
-  change _ = laplaceAtom t y.1 * fourierAtom a y.2
+  -- beta-reduce the two integrands and the projections of the pair `(t, a)`
+  dsimp only
   rw [laplaceAtom_comm, laplaceAtom_def]
 
 /-- **A finite measure on `ℝ≥0 × V` is determined by its Laplace--Fourier transform.**

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean
@@ -18,15 +18,17 @@ import Mathlib.MeasureTheory.Measure.Prod
 /-!
 # Uniqueness of the Berg--Christensen--Ressel representing measure
 
-The Berg--Christensen--Ressel representation writes a bounded continuous positive-definite
-function on the involutive semigroup `ℝ≥0 × V` as the Laplace--Fourier transform
+For a *finite-dimensional* real inner product space `V`, the Berg--Christensen--Ressel
+representation writes a bounded continuous positive-definite function on the involutive
+semigroup `ℝ≥0 × V` as the Laplace--Fourier transform
 
 `F (t, a) = ∫ (p, q), exp (-t p) * exp (-2πi⟪a, q⟫) ∂μ`
 
 of a finite measure `μ` on `ℝ≥0 × V`. This file supplies the **uniqueness half**: a finite
-measure on `ℝ≥0 × V` is determined by its Laplace--Fourier transform. It is independent of the
-existence half, which consumes Bochner's theorem on `V`; the transform itself and the
-representation predicate live in
+measure on `ℝ≥0 × V` is determined by its Laplace--Fourier transform. Uniqueness needs no
+finite-dimensionality — a complete, second-countable `V` with its Borel σ-algebra suffices —
+and it is independent of the existence half, which consumes Bochner's theorem on the
+finite-dimensional `V`; the transform itself and the representation predicate live in
 `TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Transform`, which both halves
 share.
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean
@@ -1,0 +1,335 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Basic
+public import TauCeti.Analysis.Bochner.FourierConvention
+-- Non-public: the two determinacy inputs (Laplace on `ℝ≥0`, Fourier on `V`) and the
+-- product-`σ`-algebra plumbing, all consumed inside proofs only.
+import TauCeti.Probability.Moments.LaplaceDeterminacy
+import Mathlib.MeasureTheory.MeasurableSpace.Prod
+import Mathlib.MeasureTheory.Measure.CharacteristicFunction.Basic
+
+/-!
+# Uniqueness of the Berg--Christensen--Ressel representing measure
+
+The Berg--Christensen--Ressel representation writes a bounded continuous positive-definite
+function on the involutive semigroup `ℝ≥0 × V` as the Laplace--Fourier transform
+
+`F (t, a) = ∫ (p, q), exp (-t p) * exp (-2πi⟪a, q⟫) ∂μ`
+
+of a finite measure `μ` on `ℝ≥0 × V`. This file supplies the **uniqueness half**: a finite
+measure on `ℝ≥0 × V` is determined by its Laplace--Fourier transform. It is independent of the
+existence half, which consumes Bochner's theorem on `V`.
+
+The proof separates the two variables. Weighting `μ` by the Laplace factor `exp (-t p)` and
+pushing forward to `V` gives a finite spatial measure whose characteristic function is, after
+the `-2π` rescaling of Mathlib's Fourier convention, the Laplace--Fourier transform at time
+`t`; Fourier uniqueness for finite measures on `V` therefore pins down every spatial slice.
+Testing a slice against a measurable set `B ⊆ V` leaves the Laplace transform of the finite
+time-marginal of the slab `ℝ≥0 × B`, and Laplace determinacy pins that down in turn. The two
+steps together evaluate `μ` on every measurable rectangle, and rectangles form a π-system
+generating the product σ-algebra.
+
+## Main declarations
+
+* `TauCeti.laplaceFourierTransform`: the Laplace--Fourier transform of a measure on `ℝ≥0 × V`,
+  in Mathlib's `2π` Fourier convention.
+* `TauCeti.Measure.ext_of_forall_laplaceFourierTransform_eq`: **finite measures on `ℝ≥0 × V`
+  are determined by their Laplace--Fourier transforms**. This is the statement the roadmap
+  calls `laplaceFourier_unique`.
+* `TauCeti.RepresentsLaplaceFourier`: the predicate that a finite measure represents a function
+  on `ℝ≥0 × V` by its Laplace--Fourier transform, with `RepresentsLaplaceFourier.unique`.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Theorem 4.1.13.
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
+  ("BCR semigroup--Bochner"), whose uniqueness half this file is.
+-/
+
+public section
+
+open MeasureTheory Set
+open scoped ENNReal NNReal
+
+namespace TauCeti
+
+/-! ## The Laplace--Fourier atoms of a fixed evaluation point -/
+
+section Atoms
+
+variable {V : Type*} [SeminormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- The Laplace--Fourier atoms are bounded by `1` in norm: the Laplace factor is at most `1`
+because both parameters are nonnegative, and the Fourier factor is unimodular. -/
+theorem norm_laplaceAtom_mul_fourierAtom_le_one (t p : ℝ≥0) (a q : V) :
+    ‖laplaceAtom t p * fourierAtom a q‖ ≤ 1 := by
+  rw [norm_mul, laplaceAtom_def, fourierAtom_eq_fourierChar, Complex.norm_real,
+    Circle.norm_coe, mul_one, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _),
+    Real.exp_le_one_iff]
+  exact mul_nonpos_of_nonpos_of_nonneg (neg_nonpos.2 p.coe_nonneg) t.coe_nonneg
+
+/-- The integrand of the Laplace--Fourier transform is continuous in the integration
+variable. -/
+theorem continuous_laplaceAtom_mul_fourierAtom (t : ℝ≥0) (a : V) :
+    Continuous fun y : ℝ≥0 × V => laplaceAtom t y.1 * fourierAtom a y.2 :=
+  ((continuous_laplaceAtom t).comp continuous_fst).mul
+    ((continuous_fourierAtom a).comp continuous_snd)
+
+end Atoms
+
+/-! ## The Laplace--Fourier transform of a measure -/
+
+section Defs
+
+variable {V : Type*} [SeminormedAddCommGroup V] [InnerProductSpace ℝ V] [MeasurableSpace V]
+
+/-- The **Laplace--Fourier transform** of a measure on `ℝ≥0 × V`, evaluated at a point
+`x = (t, a)` of the involutive semigroup `ℝ≥0 × V`:
+
+`(t, a) ↦ ∫ (p, q), exp (-t p) * exp (-2πi⟪a, q⟫) ∂μ`.
+
+The integrand is the separated Laplace--Fourier atom of
+`TauCeti.isSemigroupGroupPD_laplaceFourierAtom`, so a finite measure produces a bounded
+semigroup-group positive-definite function; the Berg--Christensen--Ressel theorem asserts that
+every bounded continuous one arises this way. -/
+noncomputable def laplaceFourierTransform (μ : Measure (ℝ≥0 × V)) (x : ℝ≥0 × V) : ℂ :=
+  ∫ y, laplaceAtom x.1 y.1 * fourierAtom x.2 y.2 ∂μ
+
+/-- The defining formula for `laplaceFourierTransform`. Not `@[simp]`: simp should not unfold
+the abstraction into a raw integral. -/
+theorem laplaceFourierTransform_apply (μ : Measure (ℝ≥0 × V)) (x : ℝ≥0 × V) :
+    laplaceFourierTransform μ x = ∫ y, laplaceAtom x.1 y.1 * fourierAtom x.2 y.2 ∂μ := by
+  rw [laplaceFourierTransform]
+
+/-- The Laplace--Fourier transform in the exponential form used by the Berg--Christensen--Ressel
+statement: the transform at `(t, a)` integrates `exp (-t p) * exp (-2πi⟪a, q⟫)`. -/
+theorem laplaceFourierTransform_apply_exp (μ : Measure (ℝ≥0 × V)) (t : ℝ≥0) (a : V) :
+    laplaceFourierTransform μ (t, a) =
+      ∫ y, (Real.exp (-(t : ℝ) * (y.1 : ℝ)) : ℂ) *
+        Complex.exp (-2 * ((Real.pi : ℝ) : ℂ) * Complex.I * ((inner ℝ a y.2 : ℝ) : ℂ)) ∂μ := by
+  rw [laplaceFourierTransform_apply]
+  refine integral_congr_ae (.of_forall fun y => ?_)
+  change laplaceAtom t y.1 * fourierAtom a y.2 = _
+  rw [laplaceAtom_comm, laplaceAtom_def, fourierAtom_apply, real_inner_comm]
+
+/-- The integrand of the Laplace--Fourier transform is integrable against a finite measure. -/
+theorem integrable_laplaceAtom_mul_fourierAtom [OpensMeasurableSpace V]
+    (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ] (t : ℝ≥0) (a : V) :
+    Integrable (fun y : ℝ≥0 × V => laplaceAtom t y.1 * fourierAtom a y.2) μ :=
+  (integrable_const (1 : ℝ)).mono'
+    (continuous_laplaceAtom_mul_fourierAtom t a).aestronglyMeasurable
+    (.of_forall fun y => norm_laplaceAtom_mul_fourierAtom_le_one t y.1 a y.2)
+
+/-! ## The representation predicate -/
+
+/-- A finite measure represents a function on `ℝ≥0 × V` by its Laplace--Fourier transform. This
+is the representation asserted by the Berg--Christensen--Ressel theorem. -/
+def RepresentsLaplaceFourier (μ : Measure (ℝ≥0 × V)) (F : ℝ≥0 × V → ℂ) : Prop :=
+  IsFiniteMeasure μ ∧ ∀ x, F x = laplaceFourierTransform μ x
+
+/-- `RepresentsLaplaceFourier μ F` unfolds to finiteness of `μ` together with the
+Laplace--Fourier representation of `F`. -/
+theorem representsLaplaceFourier_iff {μ : Measure (ℝ≥0 × V)} {F : ℝ≥0 × V → ℂ} :
+    RepresentsLaplaceFourier μ F ↔
+      IsFiniteMeasure μ ∧ ∀ x, F x = laplaceFourierTransform μ x :=
+  Iff.rfl
+
+namespace RepresentsLaplaceFourier
+
+variable {μ : Measure (ℝ≥0 × V)} {F : ℝ≥0 × V → ℂ}
+
+/-- A representing measure is finite. -/
+theorem isFiniteMeasure (h : RepresentsLaplaceFourier μ F) : IsFiniteMeasure μ := h.1
+
+/-- A representing measure has the advertised Laplace--Fourier transform. -/
+theorem eq_laplaceFourierTransform (h : RepresentsLaplaceFourier μ F) (x : ℝ≥0 × V) :
+    F x = laplaceFourierTransform μ x :=
+  h.2 x
+
+/-- The value of a represented function at the identity of `ℝ≥0 × V` is the total mass of the
+representing measure. (Not `@[simp]`: the left-hand side has a variable head symbol.) -/
+theorem map_zero (h : RepresentsLaplaceFourier μ F) : F 0 = (μ.real univ : ℂ) := by
+  have := h.isFiniteMeasure
+  rw [h.eq_laplaceFourierTransform 0, laplaceFourierTransform_apply]
+  simp [laplaceAtom_def, fourierAtom_apply, Measure.real]
+
+end RepresentsLaplaceFourier
+
+end Defs
+
+/-! ## Slicing a measure on `ℝ≥0 × V` -/
+
+section Slices
+
+variable {V : Type*} [MeasurableSpace V]
+
+/-- The **spatial slice** of a measure on `ℝ≥0 × V` at time `t`: weight by the Laplace factor
+`exp (-t p)`, then forget the time coordinate. Its characteristic function is the
+Laplace--Fourier transform at time `t`, up to the `-2π` Fourier rescaling. -/
+private noncomputable def spatialSlice (μ : Measure (ℝ≥0 × V)) (t : ℝ≥0) : Measure V :=
+  (μ.withDensity fun y => ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞)).map
+    Prod.snd
+
+private theorem measurable_laplaceWeight (t : ℝ≥0) :
+    Measurable fun y : ℝ≥0 × V => Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) := by
+  fun_prop
+
+private theorem exp_neg_mul_le_one (t : ℝ≥0) (p : ℝ≥0) :
+    Real.exp (-(t : ℝ) * (p : ℝ)) ≤ 1 := by
+  rw [Real.exp_le_one_iff]
+  exact mul_nonpos_of_nonpos_of_nonneg (neg_nonpos.2 t.coe_nonneg) p.coe_nonneg
+
+private theorem isFiniteMeasure_laplaceWithDensity (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ]
+    (t : ℝ≥0) :
+    IsFiniteMeasure (μ.withDensity fun y =>
+      ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞)) := by
+  refine ⟨?_⟩
+  rw [withDensity_apply _ MeasurableSet.univ, Measure.restrict_univ]
+  calc ∫⁻ y, ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞) ∂μ
+      ≤ ∫⁻ _, 1 ∂μ := by
+        refine lintegral_mono fun y => ?_
+        rw [← ENNReal.coe_one, ENNReal.coe_le_coe, ← Real.toNNReal_one]
+        exact Real.toNNReal_le_toNNReal (exp_neg_mul_le_one t y.1)
+    _ < ⊤ := by simp
+
+private instance isFiniteMeasure_spatialSlice (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ]
+    (t : ℝ≥0) : IsFiniteMeasure (spatialSlice μ t) :=
+  have := isFiniteMeasure_laplaceWithDensity μ t
+  Measure.isFiniteMeasure_map _ _
+
+/-- The measure a spatial slice assigns to a measurable set is the Laplace-weighted mass of the
+corresponding slab. -/
+private theorem spatialSlice_apply (μ : Measure (ℝ≥0 × V)) (t : ℝ≥0) {B : Set V}
+    (hB : MeasurableSet B) :
+    spatialSlice μ t B =
+      ∫⁻ y in Prod.snd ⁻¹' B,
+        ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞) ∂μ := by
+  rw [spatialSlice, Measure.map_apply measurable_snd hB, withDensity_apply _ (measurable_snd hB)]
+
+/-- The Laplace-weighted mass of a slab, as a Bochner integral. -/
+private theorem ofReal_integral_slab (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ] (t : ℝ≥0)
+    {B : Set V} (hB : MeasurableSet B) :
+    ENNReal.ofReal (∫ y in Prod.snd ⁻¹' B, Real.exp (-(t : ℝ) * (y.1 : ℝ)) ∂μ) =
+      spatialSlice μ t B := by
+  have hint : Integrable (fun y : ℝ≥0 × V => Real.exp (-(t : ℝ) * (y.1 : ℝ)))
+      (μ.restrict (Prod.snd ⁻¹' B)) := by
+    refine (integrable_const (1 : ℝ)).mono' (by fun_prop) (.of_forall fun y => ?_)
+    rw [Real.norm_eq_abs, abs_of_pos (Real.exp_pos _)]
+    exact exp_neg_mul_le_one t y.1
+  rw [spatialSlice_apply μ t hB,
+    ofReal_integral_eq_lintegral_ofReal hint (.of_forall fun y => (Real.exp_pos _).le)]
+  rfl
+
+/-- The **time-marginal** of the slab `ℝ≥0 × B`, as a measure on `ℝ≥0`. -/
+private noncomputable def timeMarginal (μ : Measure (ℝ≥0 × V)) (B : Set V) : Measure ℝ≥0 :=
+  (μ.restrict (Prod.snd ⁻¹' B)).map Prod.fst
+
+private instance isFiniteMeasure_timeMarginal (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ]
+    (B : Set V) : IsFiniteMeasure (timeMarginal μ B) :=
+  Measure.isFiniteMeasure_map _ _
+
+private theorem integral_exp_timeMarginal (μ : Measure (ℝ≥0 × V)) (B : Set V) (t : ℝ) :
+    ∫ p, Real.exp (-t * (p : ℝ)) ∂(timeMarginal μ B) =
+      ∫ y in Prod.snd ⁻¹' B, Real.exp (-t * (y.1 : ℝ)) ∂μ := by
+  rw [timeMarginal, integral_map measurable_fst.aemeasurable (by fun_prop)]
+
+private theorem timeMarginal_apply (μ : Measure (ℝ≥0 × V)) {A : Set ℝ≥0} (hA : MeasurableSet A)
+    (B : Set V) : timeMarginal μ B A = μ (A ×ˢ B) := by
+  rw [timeMarginal, Measure.map_apply measurable_fst hA,
+    Measure.restrict_apply (measurable_fst hA), Set.prod_eq]
+
+end Slices
+
+/-! ## Uniqueness -/
+
+section Uniqueness
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MeasurableSpace V]
+  [BorelSpace V] [SecondCountableTopology V] [CompleteSpace V]
+
+omit [InnerProductSpace ℝ V] [SecondCountableTopology V] [CompleteSpace V] in
+/-- Integration against a spatial slice reinstates the Laplace weight. -/
+private theorem integral_spatialSlice (μ : Measure (ℝ≥0 × V)) (t : ℝ≥0) {f : V → ℂ}
+    (hf : Continuous f) :
+    ∫ q, f q ∂(spatialSlice μ t) = ∫ y, (Real.exp (-(t : ℝ) * (y.1 : ℝ)) : ℂ) * f y.2 ∂μ := by
+  rw [spatialSlice, integral_map measurable_snd.aemeasurable hf.aestronglyMeasurable,
+    integral_withDensity_eq_integral_smul (measurable_laplaceWeight t)]
+  refine integral_congr_ae (.of_forall fun y => ?_)
+  change (Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) • f y.2 = _
+  rw [NNReal.smul_def, Real.coe_toNNReal _ (Real.exp_nonneg _), Complex.real_smul]
+
+omit [SecondCountableTopology V] [CompleteSpace V] in
+/-- The characteristic function of a spatial slice is the Laplace--Fourier transform, after the
+`-2π` rescaling that converts Mathlib's Fourier convention into the characteristic-function
+convention. -/
+private theorem charFun_spatialSlice (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ] (t : ℝ≥0)
+    (a : V) :
+    charFun (spatialSlice μ t) ((-2 * Real.pi) • a) = laplaceFourierTransform μ (t, a) := by
+  rw [← integral_fourierAtom_eq_charFun_neg_two_pi_smul,
+    integral_spatialSlice μ t (continuous_fourierAtom a), laplaceFourierTransform_apply]
+  refine integral_congr_ae (.of_forall fun y => ?_)
+  change _ = laplaceAtom t y.1 * fourierAtom a y.2
+  rw [laplaceAtom_comm, laplaceAtom_def]
+
+/-- **A finite measure on `ℝ≥0 × V` is determined by its Laplace--Fourier transform.**
+
+This is the uniqueness half of the Berg--Christensen--Ressel representation theorem; the
+roadmap calls it `laplaceFourier_unique`. Its proof uses no positive-definiteness: it is pure
+transform injectivity, Fourier in the spatial variable and Laplace in the time variable. -/
+theorem Measure.ext_of_forall_laplaceFourierTransform_eq {μ ν : Measure (ℝ≥0 × V)}
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (h : ∀ x, laplaceFourierTransform μ x = laplaceFourierTransform ν x) :
+    μ = ν := by
+  -- Step 1: Fourier uniqueness on `V` identifies every spatial slice.
+  have hslice : ∀ t : ℝ≥0, spatialSlice μ t = spatialSlice ν t := by
+    intro t
+    refine MeasureTheory.Measure.ext_of_charFun (funext fun b => ?_)
+    have hpi : (-2 * Real.pi) ≠ 0 := by simp
+    have hb : ((-2 * Real.pi) • ((-2 * Real.pi)⁻¹ • b) : V) = b := by
+      rw [smul_smul, mul_inv_cancel₀ hpi, one_smul]
+    rw [← hb, charFun_spatialSlice, charFun_spatialSlice, h]
+  -- Step 2: Laplace determinacy on `ℝ≥0` identifies every measurable rectangle.
+  have hrect : ∀ B : Set V, MeasurableSet B → ∀ A : Set ℝ≥0, MeasurableSet A →
+      μ (A ×ˢ B) = ν (A ×ˢ B) := by
+    intro B hB
+    have hmarg : timeMarginal μ B = timeMarginal ν B := by
+      refine TauCeti.Measure.ext_of_forall_integral_exp_neg_mul_eq fun t ht => ?_
+      rw [integral_exp_timeMarginal, integral_exp_timeMarginal]
+      have hofReal := congrArg (fun ρ : Measure V => ρ B) (hslice t.toNNReal)
+      rw [← ofReal_integral_slab μ t.toNNReal hB, ← ofReal_integral_slab ν t.toNNReal hB,
+        Real.coe_toNNReal t ht] at hofReal
+      have hnonneg : ∀ ρ : Measure (ℝ≥0 × V),
+          0 ≤ ∫ y in Prod.snd ⁻¹' B, Real.exp (-t * (y.1 : ℝ)) ∂ρ := fun _ =>
+        integral_nonneg fun _ => (Real.exp_pos _).le
+      exact (ENNReal.ofReal_eq_ofReal_iff (hnonneg μ) (hnonneg ν)).1 hofReal
+    intro A hA
+    rw [← timeMarginal_apply μ hA B, ← timeMarginal_apply ν hA B, hmarg]
+  -- Step 3: rectangles form a π-system generating the product σ-algebra.
+  refine MeasureTheory.ext_of_generate_finite _ _root_.generateFrom_prod.symm
+    _root_.isPiSystem_prod ?_ ?_
+  · rintro s ⟨A, hA, B, hB, rfl⟩
+    exact hrect B hB A hA
+  · rw [← Set.univ_prod_univ]
+    exact hrect univ MeasurableSet.univ univ MeasurableSet.univ
+
+namespace RepresentsLaplaceFourier
+
+/-- **A function has at most one representing finite measure.** -/
+protected theorem unique {μ ν : Measure (ℝ≥0 × V)} {F : ℝ≥0 × V → ℂ}
+    (hμ : RepresentsLaplaceFourier μ F) (hν : RepresentsLaplaceFourier ν F) : μ = ν := by
+  have := hμ.isFiniteMeasure
+  have := hν.isFiniteMeasure
+  exact Measure.ext_of_forall_laplaceFourierTransform_eq fun x => by
+    rw [← hμ.eq_laplaceFourierTransform x, hν.eq_laplaceFourierTransform x]
+
+end RepresentsLaplaceFourier
+
+end Uniqueness
+
+end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean
@@ -6,11 +6,14 @@ module
 
 public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Transform
 -- Non-public: the two determinacy inputs (Fourier on `V` through the convention conversion,
--- Laplace on `ℝ≥0`) and the product-`σ`-algebra plumbing, all consumed inside proofs only.
+-- Laplace on `ℝ≥0`), the bound on the Laplace kernel, and the product-`σ`-algebra plumbing, all
+-- consumed inside proofs only.
 import TauCeti.Analysis.Bochner.FourierConvention
+import TauCeti.Analysis.CompletelyMonotone.Laplace.Kernel
 import TauCeti.Probability.Moments.LaplaceDeterminacy
 import Mathlib.MeasureTheory.MeasurableSpace.Prod
 import Mathlib.MeasureTheory.Measure.CharacteristicFunction.Basic
+import Mathlib.MeasureTheory.Measure.Prod
 
 /-!
 # Uniqueness of the Berg--Christensen--Ressel representing measure
@@ -70,35 +73,29 @@ variable {V : Type*} [MeasurableSpace V]
 `exp (-t p)`, then forget the time coordinate. Its characteristic function is the
 Laplace--Fourier transform at time `t`, up to the `-2π` Fourier rescaling. -/
 private noncomputable def spatialSlice (μ : Measure (ℝ≥0 × V)) (t : ℝ≥0) : Measure V :=
-  (μ.withDensity fun y => ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞)).map
-    Prod.snd
+  (μ.withDensity fun y =>
+    ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞)).snd
 
 private theorem measurable_laplaceWeight (t : ℝ≥0) :
     Measurable fun y : ℝ≥0 × V => Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) := by
   fun_prop
 
-private theorem exp_neg_mul_le_one (t : ℝ≥0) (p : ℝ≥0) :
-    Real.exp (-(t : ℝ) * (p : ℝ)) ≤ 1 := by
-  rw [Real.exp_le_one_iff]
-  exact mul_nonpos_of_nonpos_of_nonneg (neg_nonpos.2 t.coe_nonneg) p.coe_nonneg
-
 private theorem isFiniteMeasure_laplaceWithDensity (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ]
     (t : ℝ≥0) :
     IsFiniteMeasure (μ.withDensity fun y =>
-      ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞)) := by
-  refine ⟨?_⟩
-  rw [withDensity_apply _ MeasurableSet.univ, Measure.restrict_univ]
-  calc ∫⁻ y, ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞) ∂μ
-      ≤ ∫⁻ _, 1 ∂μ := by
-        refine lintegral_mono fun y => ?_
-        rw [← ENNReal.coe_one, ENNReal.coe_le_coe, ← Real.toNNReal_one]
-        exact Real.toNNReal_le_toNNReal (exp_neg_mul_le_one t y.1)
-    _ < ⊤ := by simp
+      ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞)) :=
+  isFiniteMeasure_withDensity <| ne_of_lt <|
+    calc ∫⁻ y, ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞) ∂μ
+        ≤ ∫⁻ _, 1 ∂μ := by
+          refine lintegral_mono fun y => ?_
+          rw [← ENNReal.coe_one, ENNReal.coe_le_coe, ← Real.toNNReal_one, neg_mul]
+          exact Real.toNNReal_le_toNNReal (exp_neg_mul_le_one t.coe_nonneg y.1)
+      _ < ⊤ := by simp
 
 private instance isFiniteMeasure_spatialSlice (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ]
     (t : ℝ≥0) : IsFiniteMeasure (spatialSlice μ t) :=
   have := isFiniteMeasure_laplaceWithDensity μ t
-  Measure.isFiniteMeasure_map _ _
+  Measure.snd.instIsFiniteMeasure
 
 /-- The measure a spatial slice assigns to a measurable set is the Laplace-weighted mass of the
 corresponding slab. -/
@@ -107,7 +104,7 @@ private theorem spatialSlice_apply (μ : Measure (ℝ≥0 × V)) (t : ℝ≥0) {
     spatialSlice μ t B =
       ∫⁻ y in Prod.snd ⁻¹' B,
         ((Real.toNNReal (Real.exp (-(t : ℝ) * (y.1 : ℝ))) : ℝ≥0) : ℝ≥0∞) ∂μ := by
-  rw [spatialSlice, Measure.map_apply measurable_snd hB, withDensity_apply _ (measurable_snd hB)]
+  rw [spatialSlice, Measure.snd_apply hB, withDensity_apply _ (measurable_snd hB)]
 
 /-- The Laplace-weighted mass of a slab, as a Bochner integral. -/
 private theorem ofReal_integral_slab (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ] (t : ℝ≥0)
@@ -117,29 +114,29 @@ private theorem ofReal_integral_slab (μ : Measure (ℝ≥0 × V)) [IsFiniteMeas
   have hint : Integrable (fun y : ℝ≥0 × V => Real.exp (-(t : ℝ) * (y.1 : ℝ)))
       (μ.restrict (Prod.snd ⁻¹' B)) := by
     refine (integrable_const (1 : ℝ)).mono' (by fun_prop) (.of_forall fun y => ?_)
-    rw [Real.norm_eq_abs, abs_of_pos (Real.exp_pos _)]
-    exact exp_neg_mul_le_one t y.1
+    rw [Real.norm_eq_abs, abs_of_pos (Real.exp_pos _), neg_mul]
+    exact exp_neg_mul_le_one t.coe_nonneg y.1
   rw [spatialSlice_apply μ t hB,
     ofReal_integral_eq_lintegral_ofReal hint (.of_forall fun y => (Real.exp_pos _).le)]
   simp_rw [ENNReal.ofNNReal_toNNReal]
 
 /-- The **time-marginal** of the slab `ℝ≥0 × B`, as a measure on `ℝ≥0`. -/
 private noncomputable def timeMarginal (μ : Measure (ℝ≥0 × V)) (B : Set V) : Measure ℝ≥0 :=
-  (μ.restrict (Prod.snd ⁻¹' B)).map Prod.fst
+  (μ.restrict (Prod.snd ⁻¹' B)).fst
 
 private instance isFiniteMeasure_timeMarginal (μ : Measure (ℝ≥0 × V)) [IsFiniteMeasure μ]
     (B : Set V) : IsFiniteMeasure (timeMarginal μ B) :=
-  Measure.isFiniteMeasure_map _ _
+  Measure.fst.instIsFiniteMeasure
 
 private theorem integral_exp_timeMarginal (μ : Measure (ℝ≥0 × V)) (B : Set V) (t : ℝ) :
     ∫ p, Real.exp (-t * (p : ℝ)) ∂(timeMarginal μ B) =
       ∫ y in Prod.snd ⁻¹' B, Real.exp (-t * (y.1 : ℝ)) ∂μ := by
-  rw [timeMarginal, integral_map measurable_fst.aemeasurable (by fun_prop)]
+  rw [timeMarginal, Measure.fst, integral_map measurable_fst.aemeasurable (by fun_prop)]
 
 private theorem timeMarginal_apply (μ : Measure (ℝ≥0 × V)) {A : Set ℝ≥0} (hA : MeasurableSet A)
     (B : Set V) : timeMarginal μ B A = μ (A ×ˢ B) := by
-  rw [timeMarginal, Measure.map_apply measurable_fst hA,
-    Measure.restrict_apply (measurable_fst hA), Set.prod_eq]
+  rw [timeMarginal, Measure.fst_apply hA, Measure.restrict_apply (measurable_fst hA),
+    Set.prod_eq]
 
 end Slices
 
@@ -155,7 +152,7 @@ omit [InnerProductSpace ℝ V] [SecondCountableTopology V] [CompleteSpace V] in
 private theorem integral_spatialSlice (μ : Measure (ℝ≥0 × V)) (t : ℝ≥0) {f : V → ℂ}
     (hf : Continuous f) :
     ∫ q, f q ∂(spatialSlice μ t) = ∫ y, (Real.exp (-(t : ℝ) * (y.1 : ℝ)) : ℂ) * f y.2 ∂μ := by
-  rw [spatialSlice, integral_map measurable_snd.aemeasurable hf.aestronglyMeasurable,
+  rw [spatialSlice, Measure.snd, integral_map measurable_snd.aemeasurable hf.aestronglyMeasurable,
     integral_withDensity_eq_integral_smul (measurable_laplaceWeight t)]
   refine integral_congr_ae (.of_forall fun y => ?_)
   -- beta-reduce the two integrands left by `integral_congr_ae`


### PR DESCRIPTION
This PR proves that a finite measure on the involutive semigroup `ℝ≥0 × V` is determined by its Laplace–Fourier transform `(t, a) ↦ ∫ (p, q), exp (-t p) · exp (-2πi⟪a, q⟫) ∂μ`. This is the uniqueness half of `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, **Milestone 2 — BCR semigroup–Bochner (Berg–Christensen–Ressel 4.1.13)**, whose text asks for exactly this piece: "develop existence (consuming Milestone 1) and uniqueness (`laplaceFourier_unique`, Fourier/Laplace injectivity, Mathlib-only)". The roadmap flags uniqueness as "independent and portable early", and #2611 (Bochner on `V`, Milestone 1) records the same split — "its uniqueness half is unblocked and its existence half consumes this theorem". After this PR the milestone needs only the existence half: extracting a representing measure on `ℝ≥0 × V` from a bounded continuous positive-definite `F`, which gates on Bochner's theorem on `V`.

`TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean` (335 lines) defines `laplaceFourierTransform`, the transform of a measure on `ℝ≥0 × V` written through the atoms that already live in this directory — `laplaceAtom` for the time factor and `fourierAtom` for the spatial factor, in Mathlib's `2π` convention — together with the exponential form `laplaceFourierTransform_apply_exp` matching the roadmap's statement, the unit bound on the atoms, and integrability against a finite measure. It then proves `Measure.ext_of_forall_laplaceFourierTransform_eq`, and packages the predicate `RepresentsLaplaceFourier` with `RepresentsLaplaceFourier.unique`, mirroring the `RepresentsLaplace` API that the Bernstein half of the roadmap already uses on `ℝ≥0`.

The proof separates the two variables and uses no positive-definiteness at all; it is pure transform injectivity. Weighting `μ` by the Laplace factor `exp (-t p)` and pushing forward along `Prod.snd` produces a finite spatial measure whose characteristic function is, after the `-2π` rescaling supplied by the landed `integral_fourierAtom_eq_charFun_neg_two_pi_smul`, the Laplace–Fourier transform at time `t`; Mathlib's `Measure.ext_of_charFun` therefore pins down every spatial slice, the rescaling being invertible because `-2π ≠ 0`. Evaluating a slice on a measurable `B ⊆ V` leaves the Laplace transform of the time-marginal of the slab `ℝ≥0 × B`, and the repository's `Measure.ext_of_forall_integral_exp_neg_mul_eq` pins that down in turn — this is where the nonnegativity of the time variable is used, so `ℝ≥0` is the right home for it rather than a support side-condition. The two steps evaluate `μ` on every measurable rectangle, and `generateFrom_prod` / `isPiSystem_prod` with `ext_of_generate_finite` finish. The intermediate slice and marginal constructions are `private`: they are proof scaffolding, not API a downstream user of the theorem should see.

`V` is asked only to be a complete, second-countable real inner-product space with its Borel σ-algebra — the hypotheses `Measure.ext_of_charFun` needs — so the finite-dimensional `V` of the roadmap statement is a special case and no `Fin d` coordinates appear. The transform itself, its exponential form and the representation predicate are stated over a seminormed `V` with only a measurable-space structure.

Since this file joins `FourierLaplace.lean` in the same directory, the module becomes a directory in the same PR, with imports and module headers the only change:

| old module | new module |
| --- | --- |
| `TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace` | `TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Basic` |

Nothing in the repository imported the old module. The moved file also gains `laplaceAtom_comm`, the symmetry of the atom in its two nonnegative arguments, used to line the atoms up with the `exp (-t p)` form. No Mathlib source was vendored.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"laplacefourier-unique"}-->

🤖 Prepared with Claude Code
