### PR TITLE
feat: identify the Clifford associated graded

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
+
+/-!
+# Basic Clifford algebra API
+
+This file records general scalar properties of a Clifford algebra obtained from Mathlib's
+linear equivalence with the exterior algebra.
+-/
+
+public section
+
+open CliffordAlgebra
+
+universe u v
+
+namespace TauCeti.CliffordAlgebra
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+/-- `CliffordAlgebra.equivExterior` sends a scalar to the corresponding scalar of the exterior
+algebra. -/
+theorem equivExterior_algebraMap (Q : QuadraticForm R M) [Invertible (2 : R)] (r : R) :
+    equivExterior Q (algebraMap R (CliffordAlgebra Q) r) = algebraMap R (ExteriorAlgebra R M) r :=
+  changeForm_algebraMap changeForm.associated_neg_proof r
+
+/-- **The scalars of a Clifford algebra are a faithful copy of `R`.** -/
+theorem algebraMap_injective (Q : QuadraticForm R M) [Invertible (2 : R)] :
+    Function.Injective (algebraMap R (CliffordAlgebra Q)) := by
+  intro r s hrs
+  have h := congrArg (equivExterior Q) hrs
+  rwa [equivExterior_algebraMap, equivExterior_algebraMap,
+    ExteriorAlgebra.algebraMap_inj M] at h
+
+/-- The scalar action on a Clifford algebra is faithful when `2` is invertible. With this
+instance, Mathlib's scalar `iff` lemmas apply directly. -/
+instance faithfulSMul (Q : QuadraticForm R M) [Invertible (2 : R)] :
+    FaithfulSMul R (CliffordAlgebra Q) :=
+  (faithfulSMul_iff_algebraMap_injective R (CliffordAlgebra Q)).2 (algebraMap_injective Q)
+
+end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -46,9 +46,6 @@ supremum over the `i` of a fixed parity.
 * `TauCeti.CliffordAlgebra.filtration_zero` and
   `TauCeti.CliffordAlgebra.filtration_one` compute the first two steps, as the scalars and the
   scalars together with `LinearMap.range (ι Q)`.
-* `TauCeti.CliffordAlgebra.equivExterior_algebraMap` and
-  `TauCeti.CliffordAlgebra.algebraMap_injective`: when `2` is invertible, the scalars are a
-  faithful copy of `R` in the Clifford algebra.
 * `TauCeti.CliffordAlgebra.filtration_mul`: the filtration is multiplicative, and in fact exactly
   so: `filtration Q i * filtration Q j = filtration Q (i + j)`. This is the statement that makes
   the associated graded object an algebra, and it is the prerequisite the roadmap asks for before
@@ -98,20 +95,6 @@ namespace TauCeti
 namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
-
-/-- `CliffordAlgebra.equivExterior` sends a scalar to the corresponding scalar of the exterior
-algebra. -/
-theorem equivExterior_algebraMap (Q : QuadraticForm R M) [Invertible (2 : R)] (r : R) :
-    equivExterior Q (algebraMap R (CliffordAlgebra Q) r) = algebraMap R (ExteriorAlgebra R M) r :=
-  changeForm_algebraMap changeForm.associated_neg_proof r
-
-/-- **The scalars of a Clifford algebra are a faithful copy of `R`.** -/
-theorem algebraMap_injective (Q : QuadraticForm R M) [Invertible (2 : R)] :
-    Function.Injective (algebraMap R (CliffordAlgebra Q)) := by
-  intro r s hrs
-  have h := congrArg (equivExterior Q) hrs
-  rwa [equivExterior_algebraMap, equivExterior_algebraMap,
-    ExteriorAlgebra.algebraMap_inj M] at h
 
 /-- The degree filtration of a Clifford algebra: `filtration Q k` is the `R`-submodule spanned by
 the products `ι Q v₁ * ⋯ * ι Q vₙ` of at most `k` generators, the empty product `1` included.

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -46,6 +46,9 @@ supremum over the `i` of a fixed parity.
 * `TauCeti.CliffordAlgebra.filtration_zero` and
   `TauCeti.CliffordAlgebra.filtration_one` compute the first two steps, as the scalars and the
   scalars together with `LinearMap.range (ι Q)`.
+* `TauCeti.CliffordAlgebra.equivExterior_algebraMap` and
+  `TauCeti.CliffordAlgebra.algebraMap_injective`: when `2` is invertible, the scalars are a
+  faithful copy of `R` in the Clifford algebra.
 * `TauCeti.CliffordAlgebra.filtration_mul`: the filtration is multiplicative, and in fact exactly
   so: `filtration Q i * filtration Q j = filtration Q (i + j)`. This is the statement that makes
   the associated graded object an algebra, and it is the prerequisite the roadmap asks for before
@@ -95,6 +98,20 @@ namespace TauCeti
 namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+/-- `CliffordAlgebra.equivExterior` sends a scalar to the corresponding scalar of the exterior
+algebra. -/
+theorem equivExterior_algebraMap (Q : QuadraticForm R M) [Invertible (2 : R)] (r : R) :
+    equivExterior Q (algebraMap R (CliffordAlgebra Q) r) = algebraMap R (ExteriorAlgebra R M) r :=
+  changeForm_algebraMap changeForm.associated_neg_proof r
+
+/-- **The scalars of a Clifford algebra are a faithful copy of `R`.** -/
+theorem algebraMap_injective (Q : QuadraticForm R M) [Invertible (2 : R)] :
+    Function.Injective (algebraMap R (CliffordAlgebra Q)) := by
+  intro r s hrs
+  have h := congrArg (equivExterior Q) hrs
+  rwa [equivExterior_algebraMap, equivExterior_algebraMap,
+    ExteriorAlgebra.algebraMap_inj M] at h
 
 /-- The degree filtration of a Clifford algebra: `filtration Q k` is the `R`-submodule spanned by
 the products `ι Q v₁ * ⋯ * ι Q vₙ` of at most `k` generators, the empty product `1` included.

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+import Mathlib.LinearAlgebra.ExteriorAlgebra.Grading
 public import TauCeti.LinearAlgebra.CliffordAlgebra.AssociatedGraded
+import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 public import TauCeti.LinearAlgebra.CliffordAlgebra.FiltrationGradedEquiv
 
 /-!
@@ -80,6 +82,25 @@ private theorem filtrationGradedPieceEquivExteriorPower_apply_mk_zero (r : R) :
           filtration Q 0)) =
       (exteriorPower.zeroEquiv R M).symm r := by
   exact filtrationGradedPieceZeroEquivExteriorPower_apply_mk Q r
+
+/-- The degree-zero piece equivalence sends a scalar class to the corresponding exterior
+scalar. -/
+@[simp]
+theorem filtrationGradedPieceEquivExteriorPower_apply_algebraMap₀ (r : R) :
+    filtrationGradedPieceEquivExteriorPower Q 0 (filtrationGradedAlgebraMap₀ Q r) =
+      (exteriorPower.zeroEquiv R M).symm r := by
+  rw [filtrationGradedAlgebraMap₀_apply]
+  exact filtrationGradedPieceEquivExteriorPower_apply_mk_zero Q r
+
+/-- The inverse degree-zero piece equivalence sends an exterior scalar to its scalar class. -/
+@[simp]
+theorem filtrationGradedPieceEquivExteriorPower_symm_apply_zeroEquiv_symm (r : R) :
+    (filtrationGradedPieceEquivExteriorPower Q 0).symm
+        ((exteriorPower.zeroEquiv R M).symm r) =
+      filtrationGradedAlgebraMap₀ Q r := by
+  apply (filtrationGradedPieceEquivExteriorPower Q 0).injective
+  rw [LinearEquiv.apply_symm_apply,
+    filtrationGradedPieceEquivExteriorPower_apply_algebraMap₀]
 
 private noncomputable def filtrationLeadingTermAll (n : ℕ) :
     ⋀[R]^n M →ₗ[R] FiltrationGradedPiece Q n :=

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
@@ -1,0 +1,348 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.AssociatedGraded
+public import TauCeti.LinearAlgebra.CliffordAlgebra.FiltrationGradedEquiv
+import TauCeti.LinearAlgebra.CliffordAlgebra.Vectors
+
+/-!
+# PBW equivalence for a Clifford filtration
+
+This file identifies the associated graded algebra of the Clifford degree filtration with the
+exterior algebra when `2` is invertible. It combines the equivalences on the successive quotients
+with their compatibility with homogeneous multiplication.
+
+This completes the associated-graded-algebra part of Layer 0 in the
+[spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-0-the-clifford-algebra-its-universal-property-and-the-two-gradings).
+
+## Main definition
+
+* `TauCeti.CliffordAlgebra.filtrationAssociatedGradedEquivExterior`: the algebra equivalence from
+  the associated graded of the Clifford filtration to the exterior algebra.
+
+## References
+
+* C. Chevalley, *The Algebraic Theory of Spinors* (1954), Chapter II.
+* H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Proposition I.1.2.
+-/
+
+public section
+
+open CliffordAlgebra
+open scoped DirectSum
+
+universe u v
+
+namespace TauCeti.CliffordAlgebra
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+  (Q : QuadraticForm R M) [Invertible (2 : R)]
+
+private noncomputable def scalarEquivFiltrationZero :
+    R ≃ₗ[R] filtration Q 0 :=
+  (LinearEquiv.ofInjective (Algebra.linearMap R (CliffordAlgebra Q))
+    (algebraMap_injective Q)).trans
+    (LinearEquiv.ofEq _ _ (Submodule.one_eq_range.symm.trans (filtration_zero Q).symm))
+
+private noncomputable def filtrationGradedPieceZeroEquivExteriorPower :
+    FiltrationGradedPiece Q 0 ≃ₗ[R] ⋀[R]^0 M :=
+  (Submodule.quotEquivOfEqBot _ (filtrationPreviousRestricted_zero Q)).trans
+    ((scalarEquivFiltrationZero Q).symm.trans (exteriorPower.zeroEquiv R M).symm)
+
+private noncomputable def filtrationGradedPieceEquivExteriorPower :
+    (n : ℕ) → FiltrationGradedPiece Q n ≃ₗ[R] ⋀[R]^n M
+  | 0 => filtrationGradedPieceZeroEquivExteriorPower Q
+  | n + 1 => filtrationGradedEquiv Q n
+
+private theorem scalarEquivFiltrationZero_apply (r : R) :
+    scalarEquivFiltrationZero Q r =
+      ⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩ := by
+  rfl
+
+private theorem filtrationGradedPieceZeroEquivExteriorPower_apply_mk (r : R) :
+    filtrationGradedPieceZeroEquivExteriorPower Q
+      (Submodule.Quotient.mk
+        (⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩ :
+          filtration Q 0)) =
+      (exteriorPower.zeroEquiv R M).symm r := by
+  simp only [filtrationGradedPieceZeroEquivExteriorPower, LinearEquiv.trans_apply,
+    Submodule.quotEquivOfEqBot_apply_mk]
+  rw [← scalarEquivFiltrationZero_apply Q r, LinearEquiv.symm_apply_apply]
+
+private theorem filtrationGradedPieceEquivExteriorPower_apply_mk_zero (r : R) :
+    filtrationGradedPieceEquivExteriorPower Q 0
+      (Submodule.Quotient.mk
+        (⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩ :
+          filtration Q 0)) =
+      (exteriorPower.zeroEquiv R M).symm r := by
+  exact filtrationGradedPieceZeroEquivExteriorPower_apply_mk Q r
+
+private noncomputable def filtrationLeadingTermAll (n : ℕ) :
+    ⋀[R]^n M →ₗ[R] FiltrationGradedPiece Q n :=
+  (filtrationGradedPieceEquivExteriorPower Q n).symm.toLinearMap
+
+private def exteriorPowerGradedMul (i j : ℕ) (x : ⋀[R]^i M) (y : ⋀[R]^j M) :
+    ⋀[R]^(i + j) M :=
+  @GradedMonoid.GMul.mul ℕ (fun n : ℕ => ⋀[R]^n M) _ inferInstance i j x y
+
+private theorem filtrationLeadingTermAll_apply_ιMulti (n : ℕ) (v : Fin n → M) :
+    filtrationLeadingTermAll Q n (exteriorPower.ιMulti R n v) =
+      Submodule.Quotient.mk
+        ⟨(List.ofFn ((ι Q) ∘ v)).prod, by
+          rw [← List.map_ofFn]
+          exact prod_map_ι_mem_filtration Q (l := List.ofFn v) (by simp)⟩ := by
+  cases n with
+  | zero =>
+      apply (filtrationGradedPieceEquivExteriorPower Q 0).injective
+      have hleft :
+          filtrationGradedPieceEquivExteriorPower Q 0
+              (filtrationLeadingTermAll Q 0 (exteriorPower.ιMulti R 0 v)) =
+            exteriorPower.ιMulti R 0 v :=
+        LinearEquiv.apply_symm_apply _ _
+      rw [hleft]
+      have hrep :
+          (Submodule.Quotient.mk
+            ⟨(List.ofFn ((ι Q) ∘ v)).prod, by
+              rw [← List.map_ofFn]
+              exact prod_map_ι_mem_filtration Q (l := List.ofFn v) (by simp)⟩ :
+            FiltrationGradedPiece Q 0) =
+          Submodule.Quotient.mk
+            (⟨algebraMap R (CliffordAlgebra Q) 1,
+              algebraMap_mem_filtration Q 1 0⟩ : filtration Q 0) := by
+        apply congrArg Submodule.Quotient.mk
+        apply Subtype.ext
+        simp
+      rw [hrep, filtrationGradedPieceEquivExteriorPower_apply_mk_zero]
+      apply (exteriorPower.zeroEquiv R M).injective
+      rw [LinearEquiv.apply_symm_apply, exteriorPower.zeroEquiv_ιMulti]
+  | succ n =>
+      simpa only [filtrationLeadingTermAll, filtrationGradedPieceEquivExteriorPower,
+        filtrationLeadingTerm_eq_filtrationGradedEquiv_symm Q n] using
+        filtrationLeadingTerm_apply_ιMulti Q n v
+
+private noncomputable def filtrationLeadingTermMul (i j : ℕ) :
+    ⋀[R]^i M →ₗ[R] ⋀[R]^j M →ₗ[R] FiltrationGradedPiece Q (i + j) :=
+  ((filtrationGradedMul Q i j).compl₂ (filtrationLeadingTermAll Q j)).comp
+    (filtrationLeadingTermAll Q i)
+
+private noncomputable def exteriorPowerMulLeadingTerm (i j : ℕ) :
+    ⋀[R]^i M →ₗ[R] ⋀[R]^j M →ₗ[R] FiltrationGradedPiece Q (i + j) :=
+  (DirectSum.gMulLHom R (fun n : ℕ => ⋀[R]^n M)).compr₂
+    (filtrationLeadingTermAll Q (i + j))
+
+private theorem filtrationLeadingTermAll_mul (i j : ℕ)
+    (x : ⋀[R]^i M) (y : ⋀[R]^j M) :
+    filtrationGradedMul Q i j (filtrationLeadingTermAll Q i x)
+        (filtrationLeadingTermAll Q j y) =
+      filtrationLeadingTermAll Q (i + j)
+        (exteriorPowerGradedMul i j x y) := by
+  have hmaps : filtrationLeadingTermMul Q i j = exteriorPowerMulLeadingTerm Q i j := by
+    apply exteriorPower.linearMap_ext
+    apply AlternatingMap.ext
+    intro a
+    apply exteriorPower.linearMap_ext
+    apply AlternatingMap.ext
+    intro b
+    -- Extensionality leaves the two composed bilinear maps; expose their graded products.
+    change filtrationGradedMul Q i j
+        (filtrationLeadingTermAll Q i (exteriorPower.ιMulti R i a))
+        (filtrationLeadingTermAll Q j (exteriorPower.ιMulti R j b)) =
+      filtrationLeadingTermAll Q (i + j)
+        (exteriorPowerGradedMul i j
+          (exteriorPower.ιMulti R i a) (exteriorPower.ιMulti R j b))
+    have hmul :
+        exteriorPowerGradedMul i j
+            (exteriorPower.ιMulti R i a) (exteriorPower.ιMulti R j b) =
+          exteriorPower.ιMulti R (i + j) (Fin.append a b) := by
+      apply Subtype.ext
+      exact ExteriorAlgebra.ιMulti_mul_ιMulti a b
+    rw [filtrationLeadingTermAll_apply_ιMulti,
+      filtrationLeadingTermAll_apply_ιMulti, hmul,
+      filtrationLeadingTermAll_apply_ιMulti, filtrationGradedMul_apply_mk]
+    apply congrArg Submodule.Quotient.mk
+    apply Subtype.ext
+    -- Quotient and subtype extensionality leave the ambient Clifford products.
+    change (List.ofFn ((ι Q) ∘ a)).prod * (List.ofFn ((ι Q) ∘ b)).prod =
+      (List.ofFn ((ι Q) ∘ Fin.append a b)).prod
+    rw [← List.map_ofFn, ← List.map_ofFn, ← List.map_ofFn,
+      List.ofFn_fin_append, List.map_append, List.prod_append]
+  exact LinearMap.congr_fun (LinearMap.congr_fun hmaps x) y
+
+private theorem filtrationGradedPieceEquivExteriorPower_mul (i j : ℕ)
+    (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j) :
+    filtrationGradedPieceEquivExteriorPower Q (i + j) (filtrationGradedMul Q i j x y) =
+      exteriorPowerGradedMul i j
+        (filtrationGradedPieceEquivExteriorPower Q i x)
+        (filtrationGradedPieceEquivExteriorPower Q j y) := by
+  apply (filtrationGradedPieceEquivExteriorPower Q (i + j)).symm.injective
+  rw [LinearEquiv.symm_apply_apply]
+  have h := filtrationLeadingTermAll_mul Q i j
+      (filtrationGradedPieceEquivExteriorPower Q i x)
+      (filtrationGradedPieceEquivExteriorPower Q j y)
+  have hx : filtrationLeadingTermAll Q i
+      (filtrationGradedPieceEquivExteriorPower Q i x) = x :=
+    LinearEquiv.symm_apply_apply _ x
+  have hy : filtrationLeadingTermAll Q j
+      (filtrationGradedPieceEquivExteriorPower Q j y) = y :=
+    LinearEquiv.symm_apply_apply _ y
+  rw [hx, hy] at h
+  exact h
+
+private noncomputable def filtrationGradedPieceToExteriorDirectSum (n : ℕ) :
+    FiltrationGradedPiece Q n →ₗ[R] ⨁ n : ℕ, ⋀[R]^n M :=
+  DirectSum.lof R ℕ (fun n : ℕ => ⋀[R]^n M) n ∘ₗ
+    (filtrationGradedPieceEquivExteriorPower Q n).toLinearMap
+
+private theorem filtrationGradedPieceToExteriorDirectSum_one :
+    filtrationGradedPieceToExteriorDirectSum Q 0
+      (GradedMonoid.GOne.one : FiltrationGradedPiece Q 0) = 1 := by
+  -- `DirectSum.toAlgebra` states its unit through `GOne`; expose the named graded unit.
+  change filtrationGradedPieceToExteriorDirectSum Q 0 (filtrationGradedOne Q) = 1
+  have honePiece :
+      filtrationGradedPieceEquivExteriorPower Q 0 (filtrationGradedOne Q) =
+        (exteriorPower.zeroEquiv R M).symm 1 := by
+    rw [filtrationGradedOne_def]
+    exact filtrationGradedPieceEquivExteriorPower_apply_mk_zero Q 1
+  rw [DirectSum.one_def]
+  -- Unfold the piece map to compare the two degree-zero summands.
+  change DirectSum.of (fun n : ℕ => ⋀[R]^n M) 0
+      (filtrationGradedPieceEquivExteriorPower Q 0 (filtrationGradedOne Q)) =
+    DirectSum.of (fun n : ℕ => ⋀[R]^n M) 0 _
+  rw [honePiece]
+  apply congrArg (DirectSum.of (fun n : ℕ => ⋀[R]^n M) 0)
+  apply Subtype.ext
+  rw [exteriorPower.zeroEquiv_symm_apply]
+  simp
+
+private theorem filtrationGradedPieceToExteriorDirectSum_mul {i j : ℕ}
+    (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j) :
+    filtrationGradedPieceToExteriorDirectSum Q (i + j) (GradedMonoid.GMul.mul x y) =
+      filtrationGradedPieceToExteriorDirectSum Q i x *
+        filtrationGradedPieceToExteriorDirectSum Q j y := by
+  -- `DirectSum.toAlgebra` states multiplication through `GMul`; expose its named product and maps.
+  change filtrationGradedPieceToExteriorDirectSum Q (i + j) (filtrationGradedMul Q i j x y) = _
+  change DirectSum.of (fun n : ℕ => ⋀[R]^n M) (i + j)
+      (filtrationGradedPieceEquivExteriorPower Q (i + j) (filtrationGradedMul Q i j x y)) =
+    DirectSum.of (fun n : ℕ => ⋀[R]^n M) i
+        (filtrationGradedPieceEquivExteriorPower Q i x) *
+      DirectSum.of (fun n : ℕ => ⋀[R]^n M) j
+        (filtrationGradedPieceEquivExteriorPower Q j y)
+  rw [DirectSum.of_mul_of, filtrationGradedPieceEquivExteriorPower_mul]
+  rfl
+
+private noncomputable def filtrationAssociatedGradedToExteriorDirectSum :
+    filtrationAssociatedGraded Q →ₐ[R] ⨁ n : ℕ, ⋀[R]^n M :=
+  DirectSum.toAlgebra R (FiltrationGradedPiece Q)
+    (filtrationGradedPieceToExteriorDirectSum Q)
+    (filtrationGradedPieceToExteriorDirectSum_one Q)
+    (filtrationGradedPieceToExteriorDirectSum_mul Q)
+
+private theorem filtrationAssociatedGradedToExteriorDirectSum_bijective :
+    Function.Bijective (filtrationAssociatedGradedToExteriorDirectSum Q) := by
+  let e := DirectSum.congrLinearEquiv (filtrationGradedPieceEquivExteriorPower Q)
+  have he :
+      (filtrationAssociatedGradedToExteriorDirectSum Q).toLinearMap = e.toLinearMap := by
+    apply DirectSum.linearMap_ext
+    intro n
+    apply LinearMap.ext
+    intro x
+    -- `toAlgebra` is implemented by `toAddMonoid`; compare that map on each generator.
+    change DirectSum.toAddMonoid
+        (fun n => (filtrationGradedPieceToExteriorDirectSum Q n).toAddMonoidHom)
+          (DirectSum.of (FiltrationGradedPiece Q) n x) = e (DirectSum.of _ n x)
+    rw [DirectSum.toAddMonoid_of]
+    -- Expand the piece map before using the congruence equivalence's generator equation.
+    change DirectSum.of (fun n : ℕ => ⋀[R]^n M) n
+        (filtrationGradedPieceEquivExteriorPower Q n x) = e.toLinearMap (DirectSum.of _ n x)
+    rw [DirectSum.congrLinearEquiv_toLinearMap, DirectSum.lmap_of]
+    rfl
+  have he_apply (x : filtrationAssociatedGraded Q) :
+      filtrationAssociatedGradedToExteriorDirectSum Q x = e x :=
+    LinearMap.congr_fun he x
+  constructor
+  · intro x y hxy
+    apply e.injective
+    rw [← he_apply x, ← he_apply y]
+    exact hxy
+  · intro y
+    obtain ⟨x, rfl⟩ := e.surjective y
+    exact ⟨x, he_apply x⟩
+
+/-- The associated graded of the Clifford filtration is the exterior algebra. -/
+noncomputable def filtrationAssociatedGradedEquivExterior :
+    filtrationAssociatedGraded Q ≃ₐ[R] ExteriorAlgebra R M :=
+  (AlgEquiv.ofBijective (filtrationAssociatedGradedToExteriorDirectSum Q)
+    (filtrationAssociatedGradedToExteriorDirectSum_bijective Q)).trans
+      (DirectSum.decomposeAlgEquiv (fun n : ℕ => ⋀[R]^n M)).symm
+
+private theorem filtrationAssociatedGradedEquivExterior_apply_of (n : ℕ)
+    (x : FiltrationGradedPiece Q n) :
+    filtrationAssociatedGradedEquivExterior Q
+        (DirectSum.of (FiltrationGradedPiece Q) n x) =
+      (filtrationGradedPieceEquivExteriorPower Q n x : ExteriorAlgebra R M) := by
+  -- Expose the two reused maps in the opaque composite on a homogeneous generator.
+  change (DirectSum.decomposeAlgEquiv (fun n : ℕ => ⋀[R]^n M)).symm
+      (DirectSum.toAddMonoid
+        (fun n => (filtrationGradedPieceToExteriorDirectSum Q n).toAddMonoidHom)
+          (DirectSum.of (FiltrationGradedPiece Q) n x)) = _
+  rw [DirectSum.toAddMonoid_of]
+  -- The algebra equivalence reuses the decomposition linear equivalence at this boundary.
+  change (DirectSum.decompose (fun n : ℕ => ⋀[R]^n M)).symm
+      (DirectSum.of (fun n : ℕ => ⋀[R]^n M) n
+        (filtrationGradedPieceEquivExteriorPower Q n x)) = _
+  rw [DirectSum.decompose_symm_of]
+
+private theorem filtrationAssociatedGradedEquivExterior_symm_apply_coe (n : ℕ)
+    (x : ⋀[R]^n M) :
+    (filtrationAssociatedGradedEquivExterior Q).symm (x : ExteriorAlgebra R M) =
+      DirectSum.of (FiltrationGradedPiece Q) n
+        ((filtrationGradedPieceEquivExteriorPower Q n).symm x) := by
+  apply (filtrationAssociatedGradedEquivExterior Q).injective
+  rw [AlgEquiv.apply_symm_apply,
+    filtrationAssociatedGradedEquivExterior_apply_of,
+    LinearEquiv.apply_symm_apply]
+
+/-- On degree-zero scalars, the total equivalence is the exterior-algebra scalar map. -/
+@[simp]
+theorem filtrationAssociatedGradedEquivExterior_apply_of_zero (r : R) :
+    filtrationAssociatedGradedEquivExterior Q
+        (DirectSum.of (FiltrationGradedPiece Q) 0 (filtrationGradedAlgebraMap₀ Q r)) =
+      algebraMap R (ExteriorAlgebra R M) r := by
+  rw [filtrationAssociatedGradedEquivExterior_apply_of,
+    filtrationGradedAlgebraMap₀_apply,
+    filtrationGradedPieceEquivExteriorPower_apply_mk_zero,
+    exteriorPower.zeroEquiv_symm_apply]
+  simp [ExteriorAlgebra.ιMulti_zero_apply, Algebra.smul_def]
+
+/-- The inverse sends an exterior-algebra scalar to its degree-zero graded class. -/
+@[simp 1100]
+theorem filtrationAssociatedGradedEquivExterior_symm_apply_algebraMap (r : R) :
+    (filtrationAssociatedGradedEquivExterior Q).symm
+        (algebraMap R (ExteriorAlgebra R M) r) =
+      DirectSum.of (FiltrationGradedPiece Q) 0 (filtrationGradedAlgebraMap₀ Q r) := by
+  apply (filtrationAssociatedGradedEquivExterior Q).injective
+  rw [AlgEquiv.apply_symm_apply,
+    filtrationAssociatedGradedEquivExterior_apply_of_zero]
+
+/-- On a positive-degree homogeneous piece, the total equivalence is `filtrationGradedEquiv`. -/
+@[simp]
+theorem filtrationAssociatedGradedEquivExterior_apply_of_succ (n : ℕ)
+    (x : FiltrationGradedPiece Q (n + 1)) :
+    filtrationAssociatedGradedEquivExterior Q
+        (DirectSum.of (FiltrationGradedPiece Q) (n + 1) x) =
+      (filtrationGradedEquiv Q n x : ExteriorAlgebra R M) := by
+  exact filtrationAssociatedGradedEquivExterior_apply_of Q (n + 1) x
+
+/-- The inverse on a positive-degree exterior power is the inverse graded equivalence. -/
+@[simp]
+theorem filtrationAssociatedGradedEquivExterior_symm_apply_coe_succ (n : ℕ)
+    (x : ⋀[R]^(n + 1) M) :
+    (filtrationAssociatedGradedEquivExterior Q).symm (x : ExteriorAlgebra R M) =
+      DirectSum.of (FiltrationGradedPiece Q) (n + 1)
+        ((filtrationGradedEquiv Q n).symm x) := by
+  exact filtrationAssociatedGradedEquivExterior_symm_apply_coe Q (n + 1) x
+
+end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
@@ -6,7 +6,6 @@ module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.AssociatedGraded
 public import TauCeti.LinearAlgebra.CliffordAlgebra.FiltrationGradedEquiv
-import TauCeti.LinearAlgebra.CliffordAlgebra.Vectors
 
 /-!
 # PBW equivalence for a Clifford filtration
@@ -52,7 +51,9 @@ private noncomputable def filtrationGradedPieceZeroEquivExteriorPower :
   (Submodule.quotEquivOfEqBot _ (filtrationPreviousRestricted_zero Q)).trans
     ((scalarEquivFiltrationZero Q).symm.trans (exteriorPower.zeroEquiv R M).symm)
 
-private noncomputable def filtrationGradedPieceEquivExteriorPower :
+/-- The canonical equivalence from each graded filtration piece to the corresponding exterior
+power. -/
+noncomputable def filtrationGradedPieceEquivExteriorPower :
     (n : ℕ) → FiltrationGradedPiece Q n ≃ₗ[R] ⋀[R]^n M
   | 0 => filtrationGradedPieceZeroEquivExteriorPower Q
   | n + 1 => filtrationGradedEquiv Q n
@@ -278,7 +279,9 @@ noncomputable def filtrationAssociatedGradedEquivExterior :
     (filtrationAssociatedGradedToExteriorDirectSum_bijective Q)).trans
       (DirectSum.decomposeAlgEquiv (fun n : ℕ => ⋀[R]^n M)).symm
 
-private theorem filtrationAssociatedGradedEquivExterior_apply_of (n : ℕ)
+/-- The associated-graded equivalence on an arbitrary homogeneous piece. -/
+@[simp]
+theorem filtrationAssociatedGradedEquivExterior_apply_of (n : ℕ)
     (x : FiltrationGradedPiece Q n) :
     filtrationAssociatedGradedEquivExterior Q
         (DirectSum.of (FiltrationGradedPiece Q) n x) =
@@ -295,7 +298,9 @@ private theorem filtrationAssociatedGradedEquivExterior_apply_of (n : ℕ)
         (filtrationGradedPieceEquivExteriorPower Q n x)) = _
   rw [DirectSum.decompose_symm_of]
 
-private theorem filtrationAssociatedGradedEquivExterior_symm_apply_coe (n : ℕ)
+/-- The inverse associated-graded equivalence on an arbitrary exterior power. -/
+@[simp]
+theorem filtrationAssociatedGradedEquivExterior_symm_apply_coe (n : ℕ)
     (x : ⋀[R]^n M) :
     (filtrationAssociatedGradedEquivExterior Q).symm (x : ExteriorAlgebra R M) =
       DirectSum.of (FiltrationGradedPiece Q) n
@@ -305,30 +310,8 @@ private theorem filtrationAssociatedGradedEquivExterior_symm_apply_coe (n : ℕ)
     filtrationAssociatedGradedEquivExterior_apply_of,
     LinearEquiv.apply_symm_apply]
 
-/-- On degree-zero scalars, the total equivalence is the exterior-algebra scalar map. -/
-@[simp]
-theorem filtrationAssociatedGradedEquivExterior_apply_of_zero (r : R) :
-    filtrationAssociatedGradedEquivExterior Q
-        (DirectSum.of (FiltrationGradedPiece Q) 0 (filtrationGradedAlgebraMap₀ Q r)) =
-      algebraMap R (ExteriorAlgebra R M) r := by
-  rw [filtrationAssociatedGradedEquivExterior_apply_of,
-    filtrationGradedAlgebraMap₀_apply,
-    filtrationGradedPieceEquivExteriorPower_apply_mk_zero,
-    exteriorPower.zeroEquiv_symm_apply]
-  simp [ExteriorAlgebra.ιMulti_zero_apply, Algebra.smul_def]
-
-/-- The inverse sends an exterior-algebra scalar to its degree-zero graded class. -/
-@[simp 1100]
-theorem filtrationAssociatedGradedEquivExterior_symm_apply_algebraMap (r : R) :
-    (filtrationAssociatedGradedEquivExterior Q).symm
-        (algebraMap R (ExteriorAlgebra R M) r) =
-      DirectSum.of (FiltrationGradedPiece Q) 0 (filtrationGradedAlgebraMap₀ Q r) := by
-  apply (filtrationAssociatedGradedEquivExterior Q).injective
-  rw [AlgEquiv.apply_symm_apply,
-    filtrationAssociatedGradedEquivExterior_apply_of_zero]
-
 /-- On a positive-degree homogeneous piece, the total equivalence is `filtrationGradedEquiv`. -/
-@[simp]
+@[simp 1100]
 theorem filtrationAssociatedGradedEquivExterior_apply_of_succ (n : ℕ)
     (x : FiltrationGradedPiece Q (n + 1)) :
     filtrationAssociatedGradedEquivExterior Q
@@ -337,7 +320,7 @@ theorem filtrationAssociatedGradedEquivExterior_apply_of_succ (n : ℕ)
   exact filtrationAssociatedGradedEquivExterior_apply_of Q (n + 1) x
 
 /-- The inverse on a positive-degree exterior power is the inverse graded equivalence. -/
-@[simp]
+@[simp 1100]
 theorem filtrationAssociatedGradedEquivExterior_symm_apply_coe_succ (n : ℕ)
     (x : ⋀[R]^(n + 1) M) :
     (filtrationAssociatedGradedEquivExterior Q).symm (x : ExteriorAlgebra R M) =

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Vectors
 public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
 public import Mathlib.LinearAlgebra.CliffordAlgebra.SpinGroup

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Vectors.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Vectors.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Filtration
 
 /-!
@@ -87,8 +88,8 @@ variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 /-! ### The comparison with the exterior algebra
 
 Mathlib's `CliffordAlgebra.equivExterior` is only a linear equivalence. Its scalar equation is
-recorded with the Layer 0 filtration API; here we record the generator equation needed for the
-vector API. Both are immediate from its definition as a `changeForm`. -/
+recorded in the general Clifford-algebra API; here we record the generator equation needed for
+the vector API. Both are immediate from its definition as a `changeForm`. -/
 
 /-- `CliffordAlgebra.equivExterior` sends a generator to the corresponding generator of the
 exterior algebra. -/
@@ -137,12 +138,6 @@ theorem ι_inj (m n : M) : ι Q m = ι Q n ↔ m = n := (ι_injective Q).eq_iff
 @[simp]
 theorem ι_eq_zero_iff (m : M) : ι Q m = 0 ↔ m = 0 := by
   rw [← ι_inj Q m 0, map_zero]
-
-/-- With this instance the `iff` forms come from Mathlib: `algebraMap.coe_inj`,
-`FaithfulSMul.algebraMap_eq_zero_iff` and `FaithfulSMul.algebraMap_eq_one_iff` are all `simp`
-lemmas already. -/
-instance faithfulSMul : FaithfulSMul R (CliffordAlgebra Q) :=
-  (faithfulSMul_iff_algebraMap_injective R (CliffordAlgebra Q)).2 (algebraMap_injective Q)
 
 /-! ### Vectors are not scalars -/
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Vectors.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Vectors.lean
@@ -54,9 +54,6 @@ the scalars and the vectors, the disjointness of the two pins that step down to 
 
 * `TauCeti.CliffordAlgebra.ι_injective`, `TauCeti.CliffordAlgebra.ι_inj` and
   `TauCeti.CliffordAlgebra.ι_eq_zero_iff`: the generators are a faithful copy of `M`.
-* `TauCeti.CliffordAlgebra.algebraMap_injective` and the instance
-  `TauCeti.CliffordAlgebra.faithfulSMul` it provides: the scalars are a faithful copy of `R`, so
-  Mathlib's `FaithfulSMul` simp lemmas apply.
 * `TauCeti.CliffordAlgebra.ι_eq_algebraMap_iff`, `TauCeti.CliffordAlgebra.ι_ne_one` and
   `TauCeti.CliffordAlgebra.ι_range_disjoint_one`: a vector is a scalar only when both vanish.
 * `TauCeti.CliffordAlgebra.mem_range_ι_iff`: membership of `range (ι Q)` is detected by the vector
@@ -89,20 +86,14 @@ variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 
 /-! ### The comparison with the exterior algebra
 
-Mathlib's `CliffordAlgebra.equivExterior` is only a linear equivalence, but the two facts that make
-it useful here — that it fixes generators and fixes scalars — are immediate from its definition as
-a `changeForm`, and are recorded once. -/
+Mathlib's `CliffordAlgebra.equivExterior` is only a linear equivalence. Its scalar equation is
+recorded with the Layer 0 filtration API; here we record the generator equation needed for the
+vector API. Both are immediate from its definition as a `changeForm`. -/
 
 /-- `CliffordAlgebra.equivExterior` sends a generator to the corresponding generator of the
 exterior algebra. -/
 theorem equivExterior_ι (m : M) : equivExterior Q (ι Q m) = ExteriorAlgebra.ι R m :=
   changeForm_ι changeForm.associated_neg_proof m
-
-/-- `CliffordAlgebra.equivExterior` sends a scalar to the corresponding scalar of the exterior
-algebra. -/
-theorem equivExterior_algebraMap (r : R) :
-    equivExterior Q (algebraMap R (CliffordAlgebra Q) r) = algebraMap R (ExteriorAlgebra R M) r :=
-  changeForm_algebraMap changeForm.associated_neg_proof r
 
 /-! ### The vector part -/
 
@@ -146,15 +137,6 @@ theorem ι_inj (m n : M) : ι Q m = ι Q n ↔ m = n := (ι_injective Q).eq_iff
 @[simp]
 theorem ι_eq_zero_iff (m : M) : ι Q m = 0 ↔ m = 0 := by
   rw [← ι_inj Q m 0, map_zero]
-
-/-! ### `algebraMap` is injective -/
-
-/-- **The scalars of a Clifford algebra are a faithful copy of `R`.** -/
-theorem algebraMap_injective : Function.Injective (algebraMap R (CliffordAlgebra Q)) := by
-  intro r s hrs
-  have h := congrArg (equivExterior Q) hrs
-  rwa [equivExterior_algebraMap, equivExterior_algebraMap,
-    ExteriorAlgebra.algebraMap_inj M] at h
 
 /-- With this instance the `iff` forms come from Mathlib: `algebraMap.coe_inj`,
 `FaithfulSMul.algebraMap_eq_zero_iff` and `FaithfulSMul.algebraMap_eq_one_iff` are all `simp`


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Identifies the associated graded of the Clifford filtration with the exterior algebra.

- Assembles the merged homogeneous quotient equivalences into one algebra equivalence.
- Provides forward and inverse equations in degree zero and every positive degree.
- Keeps the direct-sum and multiplicativity construction private.

## Roadmap target

Completes the Layer 0 PBW-type associated-graded milestone:
https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-0-the-clifford-algebra-its-universal-property-and-the-two-gradings

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/README.md#associated-graded-algebra"}-->

## Verification

Full builds, audits, lint, forward/inverse consumer probes, golf, and paired current-head review pass at `720b0494ee3355587c270a428fed50da224cc710`.

## Scale and generality

Changes four files by +403/−27 lines. The PBW equivalence and supporting scalar API are generic over a commutative ring, module, quadratic form, and invertible `2`; no basis, freeness, finiteness, field, or nondegeneracy.

## Scope

- **Consumes:** the merged filtration graded algebra and homogeneous exterior-power equivalences.
- **Provides:** one total algebra equivalence with opaque degree-zero and positive-degree equations.
- **Fits:** completes Goal γ's remaining `L0-pbw` node and supplies the PBW boundary for later structure theory.
- **Boundary:** basis, coordinate, and classification consequences are downstream consumers.

<sub>🤖 GPT-5.6 Terra max · rubrics @ [b8161ef](https://github.com/TauCetiProject/TauCetiReview/commit/b8161ef29f1bf922d3f9aea2b1b1e298bcd06078) · local 2+1 review @ [4a3ce2b](https://github.com/utensil/formal-land/commit/4a3ce2ba031ff1c2bece478a842ba6b1e8b74364) fixed: api-design (2), reuse (1), placement (1), naming (1), documentation (1), proof-quality (14)</sub>
