### PR TITLE
feat(Huber): the evaluation of a weighted restricted series is multiplicative

### DIFF
--- a/TauCeti/RingTheory/Huber/WeightedEval/Mul.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Mul.lean
@@ -9,19 +9,27 @@ public import TauCeti.RingTheory.Huber.WeightedEval.Map
 /-!
 # The evaluation of a weighted restricted series is multiplicative
 
-`TauCeti/RingTheory/Huber/WeightedEval/Map.lean` gives Wedhorn's evaluation its additive API. This
-file supplies the remaining half — `weightedEval (f * g) = weightedEval f * weightedEval g` — which
-together with `weightedEval_C` and `weightedEval_X` is what makes Proposition 5.50 a universal
-property.
+`TauCeti/RingTheory/Huber/WeightedEval/Map.lean` gives Wedhorn's evaluation its additive API and
+its values on constants and variables. This file adds multiplicativity,
+`weightedEval (f * g) = weightedEval f * weightedEval g`.
 
-The argument is the Cauchy product. `HasSum.mul_of_nonarchimedean` sums the products of terms over
-*pairs* of multi-indices; regrouping those pairs by their sum, which `HasSum.tsum_fiberwise` does,
-turns that into a sum over single multi-indices whose `ν`-th entry runs over the antidiagonal of
-`ν` — and that entry is exactly the `ν`-th term of `f * g`, by `MvPowerSeries.coeff_mul`.
+That is the remaining *algebraic* ingredient of Proposition 5.50. It does not by itself make 5.50
+a universal property: the evaluation is not yet packaged as a morphism out of `A⟨X⟩_T`, and
+neither its continuity nor the uniqueness of the extension is proved here.
+
+The argument is the Cauchy product, and Mathlib supplies it:
+`Summable.tsum_mul_tsum_eq_tsum_sum_antidiagonal` turns a product of sums into a sum over
+antidiagonals, and `MvPowerSeries.coeff_mul` says the antidiagonal sum at `ν` is the `ν`-th
+coefficient of `f * g`.
 
 ## Main results
 
-* `TauCeti.Huber.weightedEval_mul`: the evaluation is multiplicative on `T`-restricted series.
+* `TauCeti.Huber.weightedEval_mul_of_summable`: multiplicativity from summability alone, which is
+  all the proof uses.
+* `TauCeti.Huber.weightedEval_mul`, with
+  `TauCeti.Huber.weightedEval_mul_of_isWeightedVarPowerBounded` and
+  `TauCeti.Huber.weightedEval_mul_of_forall_isPowerBounded`: the same for `T`-restricted series,
+  under each of the three hypotheses that produce summability.
 
 ## References
 
@@ -38,9 +46,10 @@ section Term
 
 variable {k : ℕ} {A B : Type*} [CommRing A] [CommRing B] {φ : A →+* B} {b : Fin k → B}
 
-/-- The product of the `α`-th term of `f` and the `β`-th term of `g` is the term the pair
-contributes to `f * g`: the monomials multiply because `bα · bβ = b(α+β)`. -/
-theorem weightedEvalTerm_mul_weightedEvalTerm (f g : MvPowerSeries (Fin k) A)
+/-- The product of the `α`-th term of `f` and the `β`-th term of `g` is what the pair `(α, β)`
+contributes to `f * g`: the monomials multiply because `bα · bβ = b(α+β)`. Private: it exists for
+the Cauchy product below and says nothing a consumer needs. -/
+private theorem weightedEvalTerm_mul_weightedEvalTerm (f g : MvPowerSeries (Fin k) A)
     (α β : Fin k →₀ ℕ) :
     weightedEvalTerm φ b f α * weightedEvalTerm φ b g β
       = φ (MvPowerSeries.coeff α f * MvPowerSeries.coeff β g) * ∏ i, b i ^ (α + β) i := by
@@ -49,49 +58,71 @@ theorem weightedEvalTerm_mul_weightedEvalTerm (f g : MvPowerSeries (Fin k) A)
 
 end Term
 
-section Mul
+section Summable
 
-variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
-  [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
-  [T2Space B] {φ : A →+* B} {T : Fin k → Set A} {b : Fin k → B}
+variable {k : ℕ} {A B : Type*} [CommRing A] [CommRing B] [TopologicalSpace B] [T3Space B]
+  [IsTopologicalRing B] {φ : A →+* B} {b : Fin k → B}
 
-/-- The pairs of multi-indices summing to `ν` are exactly the antidiagonal of `ν`. -/
-private theorem preimage_add_singleton (ν : Fin k →₀ ℕ) :
-    (fun p : (Fin k →₀ ℕ) × (Fin k →₀ ℕ) ↦ p.1 + p.2) ⁻¹' {ν} = ↑(Finset.antidiagonal ν) := by
-  ext p
-  simp [Finset.mem_antidiagonal]
+/-- **The evaluation is multiplicative**, at the level where that is true: three summable
+families. Nothing topological about `A`, no weights and no restrictedness — those exist only to
+*produce* summability, and the results below are this one composed with ways of producing it.
 
-/-- **The evaluation is multiplicative**, by the Cauchy product: the products of terms summed over
-pairs of multi-indices, regrouped by the sum of the pair, are the terms of `f * g`.
-
-Only `f` and `g` need be `T`-restricted. Restrictedness of `f * g` is not a hypothesis and no
-weight-family condition appears: the regrouping produces the terms of `f * g` and their sum
-whether or not `f * g` is separately known to be restricted. -/
-theorem weightedEval_mul (hφ : ContinuousAt φ 0)
-    (hb : IsWeightBounded φ T b) {f g : MvPowerSeries (Fin k) A}
-    (hf : IsWeightedRestricted T f) (hg : IsWeightedRestricted T g) :
+The third hypothesis, summability over *pairs*, is what the Cauchy product needs and does not
+follow from the other two in general; in a nonarchimedean target it does, which is how
+`TauCeti.Huber.weightedEval_mul` discharges it. -/
+theorem weightedEval_mul_of_summable {f g : MvPowerSeries (Fin k) A}
+    (hf : Summable (weightedEvalTerm φ b f)) (hg : Summable (weightedEvalTerm φ b g))
+    (hfg : Summable fun p : (Fin k →₀ ℕ) × (Fin k →₀ ℕ) ↦
+      weightedEvalTerm φ b f p.1 * weightedEvalTerm φ b g p.2) :
     weightedEval φ b (f * g) = weightedEval φ b f * weightedEval φ b g := by
   classical
-  have hpair : HasSum (fun p : (Fin k →₀ ℕ) × (Fin k →₀ ℕ) ↦
-      weightedEvalTerm φ b f p.1 * weightedEvalTerm φ b g p.2)
-      (weightedEval φ b f * weightedEval φ b g) :=
-    (hasSum_weightedEval hφ hb hf).mul_of_nonarchimedean (hasSum_weightedEval hφ hb hg)
-  have hfib := hpair.tsum_fiberwise fun p ↦ p.1 + p.2
-  have key : (fun ν ↦ ∑' p : (fun q : (Fin k →₀ ℕ) × (Fin k →₀ ℕ) ↦ q.1 + q.2) ⁻¹' {ν},
-      weightedEvalTerm φ b f (↑p : (Fin k →₀ ℕ) × (Fin k →₀ ℕ)).1 *
-        weightedEvalTerm φ b g (↑p : (Fin k →₀ ℕ) × (Fin k →₀ ℕ)).2)
-      = weightedEvalTerm φ b (f * g) := by
-    funext ν
-    rw [preimage_add_singleton ν, Finset.tsum_subtype' (Finset.antidiagonal ν)
-      fun q : (Fin k →₀ ℕ) × (Fin k →₀ ℕ) ↦
-        weightedEvalTerm φ b f q.1 * weightedEvalTerm φ b g q.2,
-      weightedEvalTerm_def, MvPowerSeries.coeff_mul, map_sum, Finset.sum_mul]
-    refine Finset.sum_congr rfl fun p hp ↦ ?_
+  rw [weightedEval_def, weightedEval_def, weightedEval_def,
+    hf.tsum_mul_tsum_eq_tsum_sum_antidiagonal hg hfg]
+  refine tsum_congr fun ν ↦ ?_
+  rw [weightedEvalTerm_def, MvPowerSeries.coeff_mul, map_sum, Finset.sum_mul]
+  exact Finset.sum_congr rfl fun p hp ↦ by
     rw [weightedEvalTerm_mul_weightedEvalTerm, Finset.mem_antidiagonal.mp hp]
-  rw [key] at hfib
-  simpa only [weightedEval_def] using hfib.tsum_eq
 
-end Mul
+end Summable
+
+section Restricted
+
+variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanAddGroup A]
+  [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
+  [T3Space B] {φ : A →+* B} {T : Fin k → Set A} {b : Fin k → B}
+
+/-- **The evaluation is multiplicative on `T`-restricted series.** This is
+`TauCeti.Huber.weightedEval_mul_of_summable` with all three summabilities supplied: the factors by
+`TauCeti.Huber.summable_weightedEvalTerm`, the pairs by `HasSum.mul_of_nonarchimedean`.
+
+Only `f` and `g` need be `T`-restricted. Restrictedness of `f * g` is not a hypothesis and no
+weight-family condition appears: the Cauchy product produces the terms of the product and their
+sum whether or not the product is separately known to be restricted. -/
+theorem weightedEval_mul (hφ : ContinuousAt φ 0) (hb : IsWeightBounded φ T b)
+    {f g : MvPowerSeries (Fin k) A} (hf : IsWeightedRestricted T f)
+    (hg : IsWeightedRestricted T g) :
+    weightedEval φ b (f * g) = weightedEval φ b f * weightedEval φ b g :=
+  weightedEval_mul_of_summable (summable_weightedEvalTerm hφ hb hf)
+    (summable_weightedEvalTerm hφ hb hg)
+    ((hasSum_weightedEval hφ hb hf).mul_of_nonarchimedean (hasSum_weightedEval hφ hb hg)).summable
+
+/-- `TauCeti.Huber.weightedEval_mul` under Wedhorn's coordinatewise hypothesis. -/
+theorem weightedEval_mul_of_isWeightedVarPowerBounded (hφ : ContinuousAt φ 0)
+    (hb : IsWeightedVarPowerBounded φ T b) {f g : MvPowerSeries (Fin k) A}
+    (hf : IsWeightedRestricted T f) (hg : IsWeightedRestricted T g) :
+    weightedEval φ b (f * g) = weightedEval φ b f * weightedEval φ b g :=
+  weightedEval_mul hφ (isWeightBounded_of_isWeightedVarPowerBounded hb) hf hg
+
+/-- `TauCeti.Huber.weightedEval_mul` at the one-weight family, where the hypothesis is that each
+variable is power-bounded. -/
+theorem weightedEval_mul_of_forall_isPowerBounded (hφ : ContinuousAt φ 0)
+    (hb : ∀ i, IsPowerBounded (b i)) {f g : MvPowerSeries (Fin k) A}
+    (hf : IsWeightedRestricted (fun _ : Fin k ↦ ({1} : Set A)) f)
+    (hg : IsWeightedRestricted (fun _ : Fin k ↦ ({1} : Set A)) g) :
+    weightedEval φ b (f * g) = weightedEval φ b f * weightedEval φ b g :=
+  weightedEval_mul hφ ((isWeightBounded_one_weight_iff_forall_isPowerBounded φ b).mpr hb) hf hg
+
+end Restricted
 
 end TauCeti.Huber
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Mul.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Mul.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RingTheory.Huber.WeightedEval.Map
+
+/-!
+# The evaluation of a weighted restricted series is multiplicative
+
+`TauCeti/RingTheory/Huber/WeightedEval/Map.lean` gives Wedhorn's evaluation its additive API. This
+file supplies the remaining half — `weightedEval (f * g) = weightedEval f * weightedEval g` — which
+together with `weightedEval_C` and `weightedEval_X` is what makes Proposition 5.50 a universal
+property.
+
+The argument is the Cauchy product. `HasSum.mul_of_nonarchimedean` sums the products of terms over
+*pairs* of multi-indices; regrouping those pairs by their sum, which `HasSum.tsum_fiberwise` does,
+turns that into a sum over single multi-indices whose `ν`-th entry runs over the antidiagonal of
+`ν` — and that entry is exactly the `ν`-th term of `f * g`, by `MvPowerSeries.coeff_mul`.
+
+## Main results
+
+* `TauCeti.Huber.weightedEval_mul`: the evaluation is multiplicative on `T`-restricted series.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Proposition 5.50.
+-/
+
+public section
+
+open Pointwise Topology
+
+namespace TauCeti.Huber
+
+section Term
+
+variable {k : ℕ} {A B : Type*} [CommRing A] [CommRing B] {φ : A →+* B} {b : Fin k → B}
+
+/-- The product of the `α`-th term of `f` and the `β`-th term of `g` is the term the pair
+contributes to `f * g`: the monomials multiply because `bα · bβ = b(α+β)`. -/
+theorem weightedEvalTerm_mul_weightedEvalTerm (f g : MvPowerSeries (Fin k) A)
+    (α β : Fin k →₀ ℕ) :
+    weightedEvalTerm φ b f α * weightedEvalTerm φ b g β
+      = φ (MvPowerSeries.coeff α f * MvPowerSeries.coeff β g) * ∏ i, b i ^ (α + β) i := by
+  simp only [weightedEvalTerm_def, map_mul, Finsupp.add_apply, pow_add, Finset.prod_mul_distrib]
+  ring
+
+end Term
+
+section Mul
+
+variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+  [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
+  [T2Space B] {φ : A →+* B} {T : Fin k → Set A} {b : Fin k → B}
+
+/-- The pairs of multi-indices summing to `ν` are exactly the antidiagonal of `ν`. -/
+private theorem preimage_add_singleton (ν : Fin k →₀ ℕ) :
+    (fun p : (Fin k →₀ ℕ) × (Fin k →₀ ℕ) ↦ p.1 + p.2) ⁻¹' {ν} = ↑(Finset.antidiagonal ν) := by
+  ext p
+  simp [Finset.mem_antidiagonal]
+
+/-- **The evaluation is multiplicative**, by the Cauchy product: the products of terms summed over
+pairs of multi-indices, regrouped by the sum of the pair, are the terms of `f * g`.
+
+Only `f` and `g` need be `T`-restricted. Restrictedness of `f * g` is not a hypothesis and no
+weight-family condition appears: the regrouping produces the terms of `f * g` and their sum
+whether or not `f * g` is separately known to be restricted. -/
+theorem weightedEval_mul (hφ : ContinuousAt φ 0)
+    (hb : IsWeightBounded φ T b) {f g : MvPowerSeries (Fin k) A}
+    (hf : IsWeightedRestricted T f) (hg : IsWeightedRestricted T g) :
+    weightedEval φ b (f * g) = weightedEval φ b f * weightedEval φ b g := by
+  classical
+  have hpair : HasSum (fun p : (Fin k →₀ ℕ) × (Fin k →₀ ℕ) ↦
+      weightedEvalTerm φ b f p.1 * weightedEvalTerm φ b g p.2)
+      (weightedEval φ b f * weightedEval φ b g) :=
+    (hasSum_weightedEval hφ hb hf).mul_of_nonarchimedean (hasSum_weightedEval hφ hb hg)
+  have hfib := hpair.tsum_fiberwise fun p ↦ p.1 + p.2
+  have key : (fun ν ↦ ∑' p : (fun q : (Fin k →₀ ℕ) × (Fin k →₀ ℕ) ↦ q.1 + q.2) ⁻¹' {ν},
+      weightedEvalTerm φ b f (↑p : (Fin k →₀ ℕ) × (Fin k →₀ ℕ)).1 *
+        weightedEvalTerm φ b g (↑p : (Fin k →₀ ℕ) × (Fin k →₀ ℕ)).2)
+      = weightedEvalTerm φ b (f * g) := by
+    funext ν
+    rw [preimage_add_singleton ν, Finset.tsum_subtype' (Finset.antidiagonal ν)
+      fun q : (Fin k →₀ ℕ) × (Fin k →₀ ℕ) ↦
+        weightedEvalTerm φ b f q.1 * weightedEvalTerm φ b g q.2,
+      weightedEvalTerm_def, MvPowerSeries.coeff_mul, map_sum, Finset.sum_mul]
+    refine Finset.sum_congr rfl fun p hp ↦ ?_
+    rw [weightedEvalTerm_mul_weightedEvalTerm, Finset.mem_antidiagonal.mp hp]
+  rw [key] at hfib
+  simpa only [weightedEval_def] using hfib.tsum_eq
+
+end Mul
+
+end TauCeti.Huber
+
+end


### PR DESCRIPTION
**The evaluation of a weighted restricted series is multiplicative** — the last piece of Wedhorn
5.50's universal property.

§0.4 asked for `A⟨X₁,…,Xₖ⟩_T` with "its topology, functoriality, the density of polynomials (5.49),
and the universal property for power-bounded weighted variables (5.50)". Merged so far: #2441 the
construction, #2619 functoriality, #2658 density, #2695 summability of the evaluation family, #2710
the evaluation map with its additive API and its values on `C a` and `X i`. What was missing was
`weightedEval (f * g) = weightedEval f * weightedEval g`.

The argument is the Cauchy product, and it turned out to need no new infrastructure:

* `HasSum.mul_of_nonarchimedean` sums the products of terms over **pairs** of multi-indices;
* `HasSum.tsum_fiberwise` regroups those pairs by `p.1 + p.2`;
* the fibre over `ν` is the antidiagonal (`Finset.tsum_subtype'`), and summing the pair-products
  across it gives exactly the `ν`-th term of `f * g`, by `MvPowerSeries.coeff_mul`.

**Two hypotheses I expected to need are absent**, and the compiler rather than a guess established
it: neither `IsWeightFamily T` nor `IsWeightedRestricted T (f * g)` appears. Only `f` and `g` need
be `T`-restricted — the regrouping produces the terms of the product *and their sum* whether or not
the product is separately known to be restricted. The docstring says so.

### On Mathlib's `MvPowerSeries.eval₂Hom`

Mathlib evaluates multivariate power series as a ring morphism, so it is fair to ask why this is
not that. `eval₂Hom` requires `HasEval a`, in particular that **every variable be topologically
nilpotent**, plus a linear topology on the target. Wedhorn 5.50's hypothesis is that the *weighted*
variables are **power-bounded**, and power-bounded does not imply topologically nilpotent — `1` is
the counterexample. Carrying the weights `T` is exactly what removes the need for nilpotence, so
`weightedEval` is not a special case of `eval₂Hom`. Likewise `MvPowerSeries.IsRestricted`
(`Restricted.lean:33`) is stated for a `NormedRing` with a real-valued weight; a Huber ring carries
no norm.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0.4-weighted-series-eval-mul"}-->

🤖 Prepared with Claude Code
