### PR TITLE
refactor(Quadratic): dedup θ² = (d : ℚ) into coe_gen_sq_ratCast

### DIFF
--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -23,6 +23,7 @@ the ring-of-integers/discriminant computation (`Quadratic/RingOfIntegers.lean`).
 * `TauCeti.NumberField.minpoly_rat_quadratic`: the minimal polynomial of `θ` over `ℚ` is `X² - d`.
 * `TauCeti.NumberField.finrank_rat_eq_two`: `K` has degree `2` over `ℚ`.
 * `TauCeti.NumberField.coe_gen_sq`: the generator squares to the radicand, `θ² = d` in `K`.
+* `TauCeti.NumberField.coe_gen_sq_ratCast`: the same over `ℚ`, `θ² = (d : ℚ)` in `K`.
 * `TauCeti.NumberField.gen_notMem_range`: the generator is not rational, `θ ∉ ℚ`.
 * `TauCeti.NumberField.not_isSquare_radicand`: the radicand is not a rational square.
 * `TauCeti.NumberField.trace_gen_eq_zero`: the trace of the generator is `0`.
@@ -72,6 +73,12 @@ omit [NumberField K] in
   have := congrArg (algebraMap (𝓞 K) K) h
   rwa [map_pow, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K] at this
 
+/-- The generator squares to the radicand viewed over `ℚ`: `θ² = (d : ℚ)` in `K`. This is
+`coe_gen_sq` transported along `ℤ → ℚ → K`, the form fed to the generic square-root-basis API. -/
+theorem coe_gen_sq_ratCast (hmin : minpoly ℤ θ = X ^ 2 - C d) :
+    (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
+  rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
+
 /-- The generator is irrational: `θ ∉ ℚ`. -/
 theorem gen_notMem_range (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     (θ : K) ∉ (algebraMap ℚ K).range := by
@@ -89,8 +96,7 @@ factorization `(θ - q)(θ + q) = θ² - d = 0` would force `θ = ±q ∈ ℚ`. 
 theorem not_isSquare_radicand (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     ¬ IsSquare (((d : ℤ) : ℚ)) := by
   rintro ⟨q, hq⟩
-  have hθ : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
-    rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
+  have hθ : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := coe_gen_sq_ratCast hmin
   have hq' : algebraMap ℚ K ((d : ℤ) : ℚ) = algebraMap ℚ K q * algebraMap ℚ K q := by
     rw [← map_mul, ← hq]
   have hfac : ((θ : K) - algebraMap ℚ K q) * ((θ : K) + algebraMap ℚ K q) = 0 := by
@@ -103,8 +109,7 @@ theorem not_isSquare_radicand (hmin : minpoly ℤ θ = X ^ 2 - C d) :
 theorem trace_gen_eq_zero (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     Algebra.trace ℚ K (θ : K) = 0 := by
   -- Specialise the generic `trace_eq_zero_of_sq_ratCast` to `θ² = d` and the irrationality of `θ`.
-  have hd' : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
-    rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
+  have hd' : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := coe_gen_sq_ratCast hmin
   exact trace_eq_zero_of_sq_ratCast hd' (gen_notMem_range hmin)
 
 /-- The discriminant of the `ℚ`-family `{1, θ}` is `4d`. -/
@@ -112,8 +117,7 @@ theorem discr_one_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
     Algebra.discr ℚ ![(1 : K), (θ : K)] = ((4 * d : ℤ) : ℚ) := by
   -- Specialise the generic square-root-basis discriminant `discr_one_elem_eq_of_sq_algebraMap`.
-  have hd' : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
-    rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
+  have hd' : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := coe_gen_sq_ratCast hmin
   rw [TauCeti.Algebra.discr_one_elem_eq_of_sq_algebraMap (finrank_rat_eq_two hmin hgen) hd'
     (gen_notMem_range hmin)]
   push_cast; ring

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -73,9 +73,10 @@ omit [NumberField K] in
   have := congrArg (algebraMap (𝓞 K) K) h
   rwa [map_pow, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K] at this
 
+omit [NumberField K] in
 /-- The generator squares to the radicand viewed over `ℚ`: `θ² = (d : ℚ)` in `K`. This is
 `coe_gen_sq` transported along `ℤ → ℚ → K`, the form fed to the generic square-root-basis API. -/
-theorem coe_gen_sq_ratCast (hmin : minpoly ℤ θ = X ^ 2 - C d) :
+theorem coe_gen_sq_ratCast [CharZero K] (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
   rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/InfinitePlace.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/InfinitePlace.lean
@@ -32,7 +32,6 @@ imaginary quadratic field `ℚ(√d)`. -/
 theorem isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hd : d < 0) : IsTotallyComplex K :=
   isTotallyComplex_of_sq_ratCast_of_neg (x := (θ : K)) (r := (d : ℚ))
-    (by rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num)
-    (by exact_mod_cast hd)
+    (coe_gen_sq_ratCast hmin) (by exact_mod_cast hd)
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -99,8 +99,7 @@ private theorem exists_intCast_coords (hmin : minpoly ℤ θ = X ^ 2 - C d)
   -- Norm: `z` satisfies `z² - (2a)·z + (a²-dc²) = 0`, so `a²-dc² = (2a)·z - z² ∈ 𝓞 K ∩ ℚ = ℤ`.
   have hroot : (z : K) ^ 2 - algebraMap ℚ K (2 * a) * (z : K)
       + algebraMap ℚ K (a ^ 2 - (d : ℚ) * c ^ 2) = 0 := by
-    have hθ : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
-      rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
+    have hθ : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := coe_gen_sq_ratCast hmin
     rw [hz]
     simp only [map_mul, map_sub, map_pow, map_ofNat]
     linear_combination (algebraMap ℚ K c) ^ 2 * hθ


### PR DESCRIPTION
The fact `(θ : K)² = algebraMap ℚ K ((d : ℤ) : ℚ)` was proved verbatim — `rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num` — at **five** call sites across `Quadratic/{Basic,InfinitePlace,RingOfIntegers}.lean`.

This extracts it once as `coe_gen_sq_ratCast` (the `ℚ`-form of the existing `coe_gen_sq`), placed beside `coe_gen_sq` in `Quadratic/Basic.lean`, and reuses it at all five sites. Pure deduplication — no new mathematics, no axioms.

Roadmap: none