### PR TITLE
feat(HeckeRing/GL2): compare the Γ₀(N) and level-one double cosets

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -133,7 +133,7 @@ noncomputable def map (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ �
 
 variable {Δ'' : Submonoid G} {H₁'' H₂'' : Subgroup G}
 
-lemma map_map (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ ≤ H₂') (hΔ' : Δ' ≤ Δ'')
+@[simp] lemma map_map (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ ≤ H₂') (hΔ' : Δ' ≤ Δ'')
     (h₁' : H₁' ≤ H₁'') (h₂' : H₂' ≤ H₂'') (D : HeckeCoset Δ H₁ H₂) :
     map hΔ' h₁' h₂' (map hΔ h₁ h₂ D) = map (hΔ.trans hΔ') (h₁.trans h₁') (h₂.trans h₂') D :=
   Quotient.inductionOn D fun _ ↦ rfl

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -127,6 +127,17 @@ noncomputable def map (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ �
 @[simp] lemma map_mk (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ ≤ H₂') (g : Δ) :
     map hΔ h₁ h₂ (mk H₁ H₂ g) = mk H₁' H₂' (Submonoid.inclusion hΔ g) := (rfl)
 
+@[simp] lemma map_id (D : HeckeCoset Δ H₁ H₂) :
+    map (le_refl Δ) (le_refl H₁) (le_refl H₂) D = D :=
+  Quotient.inductionOn D fun _ ↦ rfl
+
+variable {Δ'' : Submonoid G} {H₁'' H₂'' : Subgroup G}
+
+lemma map_map (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ ≤ H₂') (hΔ' : Δ' ≤ Δ'')
+    (h₁' : H₁' ≤ H₁'') (h₂' : H₂' ≤ H₂'') (D : HeckeCoset Δ H₁ H₂) :
+    map hΔ' h₁' h₂' (map hΔ h₁ h₂ D) = map (hΔ.trans hΔ') (h₁.trans h₁') (h₂.trans h₂') D :=
+  Quotient.inductionOn D fun _ ↦ rfl
+
 end Map
 
 /-- Induction: to prove something for all double cosets, prove it for `mk H₁ H₂ g`. -/

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -108,6 +108,27 @@ lemma mk_eq_mk_of_mem {g₁ g₂ : Δ} (h : (g₁ : G) ∈ doubleCoset (g₂ : G
     mk H₁ H₂ g₁ = mk H₁ H₂ g₂ :=
   eq_iff.mpr (doubleCoset_eq_of_mem h)
 
+section Map
+
+variable {Δ' : Submonoid G} {H₁' H₂' : Subgroup G}
+
+/-- **Functoriality of `HeckeCoset` in its triple.** Inclusions `Δ ≤ Δ'`, `H₁ ≤ H₁'` and
+`H₂ ≤ H₂'` send `H₁ g H₂` to `H₁' g H₂'`: widening the coefficient subgroups can only merge
+double cosets, never split them. -/
+noncomputable def map (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ ≤ H₂') :
+    HeckeCoset Δ H₁ H₂ → HeckeCoset Δ' H₁' H₂' :=
+  Quotient.lift (fun g ↦ mk H₁' H₂' (Submonoid.inclusion hΔ g)) fun a b hab ↦ by
+    have hab' : doubleCoset (a : G) H₁ H₂ = doubleCoset (b : G) H₁ H₂ := hab
+    obtain ⟨γ₁, hγ₁, γ₂, hγ₂, hb⟩ :=
+      mem_doubleCoset.mp (hab' ▸ mem_doubleCoset_self H₁ H₂ (a : G))
+    exact mk_eq_mk_of_mem (g₁ := Submonoid.inclusion hΔ a) (g₂ := Submonoid.inclusion hΔ b)
+      (mem_doubleCoset.mpr ⟨γ₁, h₁ hγ₁, γ₂, h₂ hγ₂, hb⟩)
+
+@[simp] lemma map_mk (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ ≤ H₂') (g : Δ) :
+    map hΔ h₁ h₂ (mk H₁ H₂ g) = mk H₁' H₂' (Submonoid.inclusion hΔ g) := (rfl)
+
+end Map
+
 /-- Induction: to prove something for all double cosets, prove it for `mk H₁ H₂ g`. -/
 protected lemma induction {motive : HeckeCoset Δ H₁ H₂ → Prop}
     (h : ∀ g : Δ, motive (mk H₁ H₂ g)) :

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -117,12 +117,11 @@ variable {Δ' : Submonoid G} {H₁' H₂' : Subgroup G}
 double cosets, never split them. -/
 noncomputable def map (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ ≤ H₂') :
     HeckeCoset Δ H₁ H₂ → HeckeCoset Δ' H₁' H₂' :=
-  Quotient.lift (fun g ↦ mk H₁' H₂' (Submonoid.inclusion hΔ g)) fun a b hab ↦ by
+  Quotient.map (Submonoid.inclusion hΔ) fun a b hab ↦ by
     have hab' : doubleCoset (a : G) H₁ H₂ = doubleCoset (b : G) H₁ H₂ := hab
-    obtain ⟨γ₁, hγ₁, γ₂, hγ₂, hb⟩ :=
+    obtain ⟨γ₁, hγ₁, γ₂, hγ₂, ha⟩ :=
       mem_doubleCoset.mp (hab' ▸ mem_doubleCoset_self H₁ H₂ (a : G))
-    exact mk_eq_mk_of_mem (g₁ := Submonoid.inclusion hΔ a) (g₂ := Submonoid.inclusion hΔ b)
-      (mem_doubleCoset.mpr ⟨γ₁, h₁ hγ₁, γ₂, h₂ hγ₂, hb⟩)
+    exact doubleCoset_eq_of_mem (mem_doubleCoset.mpr ⟨γ₁, h₁ hγ₁, γ₂, h₂ hγ₂, ha⟩)
 
 @[simp] lemma map_mk (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ ≤ H₂') (g : Δ) :
     map hΔ h₁ h₂ (mk H₁ H₂ g) = mk H₁' H₂' (Submonoid.inclusion hΔ g) := (rfl)

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Delta0.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Delta0.lean
@@ -30,7 +30,8 @@ as that entire fibre.
 
 Ported from the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GL2/Gamma1Pair.lean`](https://github.com/CBirkbeck/AINTLIB),
-Chris Birkbeck).
+Chris Birkbeck), with `CoprimeDet` and `coprimeDet_iff` from the `CoprimeDet` section of
+`LeanModularForms/HeckeRIngs/GLn/CongruenceHecke/Props.lean` (Chris Birkbeck).
 
 ## Main definitions
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Delta0.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Delta0.lean
@@ -39,6 +39,8 @@ Chris Birkbeck).
 ## Main results
 
 * `HeckeRing.GL2.mem_Delta0_iff`: membership, unfolded.
+* `HeckeRing.GL2.CoprimeDet`, `HeckeRing.GL2.coprimeDet_iff`: the elements whose integral
+  representative has determinant coprime to `N`, and the fact that one witness decides it.
 * `HeckeRing.GL2.Delta0_le_posDetInt`: `Δ₀(N)` consists of integral matrices of positive
   determinant, which is what puts it in the commensurator of `SL₂(ℤ)`.
 
@@ -88,6 +90,26 @@ noncomputable def Delta0 : Submonoid (GL (Fin 2) ℚ) where
         0 < (↑g : Matrix (Fin 2) (Fin 2) ℚ).det ∧ (N : ℤ) ∣ A 1 0 ∧
           IsUnit (A 0 0 : ZMod N) :=
   Iff.rfl
+
+/-- An element of `Δ₀(N)` has **coprime determinant** when every integral matrix representing
+it has determinant coprime to `N`.
+
+Quantifying over all representatives rather than choosing one keeps the predicate free of a
+choice; the representative is unique anyway, since `ℤ → ℚ` is injective. -/
+def CoprimeDet (g : Delta0 N) : Prop :=
+  ∀ A : Matrix (Fin 2) (Fin 2) ℤ,
+    (↑(g : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ) →
+      Int.gcd A.det N = 1
+
+/-- `CoprimeDet` is decided by any single integral witness: the witness is unique, because the
+entrywise cast `ℤ → ℚ` is injective. This is the introduction rule for the definition, whose
+universal quantifier only eliminates. -/
+lemma coprimeDet_iff {g : Delta0 N} {A : Matrix (Fin 2) (Fin 2) ℤ}
+    (hA : (↑(g : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ)) :
+    CoprimeDet N g ↔ Int.gcd A.det N = 1 := by
+  refine ⟨fun h ↦ h A hA, fun h A' hA' ↦ ?_⟩
+  have : A' = A := Matrix.map_injective Int.cast_injective (hA'.symm.trans hA)
+  exact this ▸ h
 
 /-- `Δ₀(N)` consists of integral matrices with positive determinant. -/
 lemma Delta0_le_posDetInt : Delta0 N ≤ posDetInt 2 := by

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -21,7 +21,7 @@ noncomputable def toLevelOneCoset :
 ```
 
 and it is **injective on the cosets whose determinant is coprime to the level**
-(`injOn_toLevelOneCoset`). Injectivity is the content: two `Γ₀(N)`-double cosets
+(`toLevelOneCoset_injOn`). Injectivity is the content: two `Γ₀(N)`-double cosets
 with the same level-one double coset are recovered from it by intersecting with `Δ₀(N)`, which
 is exactly `doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image`.
 
@@ -49,7 +49,7 @@ here, and AINTLIB's `HeckePair` bundle is Mathlib's `HeckeCoset`.
 * `HeckeRing.GL2.coprimeDet_iff`: `CoprimeDet` is decided by any one integral witness.
 * `HeckeRing.GL2.toLevelOneCoset_mk`, `HeckeRing.GL2.coprimeDetCoset_mk`: the computation rules
   on a representative.
-* `HeckeRing.GL2.injOn_toLevelOneCoset`: **Shimura, Proposition 3.31** — `toLevelOneCoset` is
+* `HeckeRing.GL2.toLevelOneCoset_injOn`: **Shimura, Proposition 3.31** — `toLevelOneCoset` is
   injective on the set of coprime-determinant double cosets.
 
 ## References
@@ -147,7 +147,7 @@ def CoprimeDetCoset : HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) → 
 /-- **Shimura, Proposition 3.31.** `toLevelOneCoset` is injective on the double cosets whose
 determinant is coprime to `N`: the level-one double coset determines the `Γ₀(N)` one, because
 intersecting it with `Δ₀(N)` returns the latter. -/
-theorem injOn_toLevelOneCoset :
+theorem toLevelOneCoset_injOn :
     Set.InjOn (toLevelOneCoset N) {D | CoprimeDetCoset N D} := by
   rintro D₁ hD₁ D₂ hD₂ h
   -- work with representatives, so that `toLevelOneCoset_mk` applies

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -21,7 +21,7 @@ noncomputable def toLevelOneCoset :
 ```
 
 and it is **injective on the cosets whose determinant is coprime to the level**
-(`toLevelOneCoset_injOn_coprimeDet`). Injectivity is the content: two `Γ₀(N)`-double cosets
+(`injOn_toLevelOneCoset`). Injectivity is the content: two `Γ₀(N)`-double cosets
 with the same level-one double coset are recovered from it by intersecting with `Δ₀(N)`, which
 is exactly `doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image`.
 
@@ -41,7 +41,8 @@ here, and AINTLIB's `HeckePair` bundle is Mathlib's `HeckeCoset`.
   determinant coprime to `N`.
 * `HeckeRing.GL2.CoprimeDetCoset`: the same condition on a `Γ₀(N)`-double coset — well defined
   because the coefficients have determinant one, so the determinant is constant on a coset.
-* `HeckeRing.GL2.toLevelOneCoset`: the map `Γ₀(N) α Γ₀(N) ↦ SL₂(ℤ) α SL₂(ℤ)`.
+* `HeckeRing.GL2.toLevelOneCoset`: the map `Γ₀(N) α Γ₀(N) ↦ SL₂(ℤ) α SL₂(ℤ)`, the `Γ₀`
+  specialisation of `HeckeCoset.map`.
 
 ## Main results
 
@@ -77,27 +78,19 @@ def CoprimeDet (g : Delta0 N) : Prop :=
       Int.gcd A.det N = 1
 
 /-- **Shimura, Proposition 3.30.** Passing from a `Γ₀(N)`-double coset to the level-one double
-coset of the same element is well defined: `Γ₀(N) ≤ SL₂(ℤ)`, so `Γ₀(N) a Γ₀(N) = Γ₀(N) b Γ₀(N)`
-forces `SL₂(ℤ) a SL₂(ℤ) = SL₂(ℤ) b SL₂(ℤ)`. -/
+coset of the same element, as the `HeckeCoset.map` of the three inclusions `Δ₀(N) ≤ Δ`,
+`Γ₀(N) ≤ SL₂(ℤ)` (twice). -/
 noncomputable def toLevelOneCoset :
     HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) →
       HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2) :=
-  Quotient.lift
-    (fun g ↦ HeckeCoset.mk (SLnZ 2) (SLnZ 2) (Submonoid.inclusion (Delta0_le_posDetInt N) g))
-    (fun a b hab ↦ by
-      -- the setoid relation on `HeckeCoset` *is* equality of the double cosets
-      have hab' : DoubleCoset.doubleCoset (a : GL (Fin 2) ℚ) (Gamma0Image N) (Gamma0Image N) =
-          DoubleCoset.doubleCoset (b : GL (Fin 2) ℚ) (Gamma0Image N) (Gamma0Image N) := hab
-      refine HeckeCoset.eq_iff.mpr (DoubleCoset.doubleCoset_eq_of_mem ?_).symm
-      -- `b` lies in the `Γ₀(N)`-double coset of `a`, hence in its level-one one
-      exact doubleCoset_Gamma0Image_le_doubleCoset_SLnZ N (a : GL (Fin 2) ℚ)
-        (hab' ▸ DoubleCoset.mem_doubleCoset_self _ _ _))
+  HeckeCoset.map (Delta0_le_posDetInt N) (Gamma0Image_le_SLnZ N) (Gamma0Image_le_SLnZ N)
 
 /-- The computation rule for `toLevelOneCoset`: it keeps the representative and forgets the
 level. -/
 @[simp] lemma toLevelOneCoset_mk (g : Delta0 N) :
     toLevelOneCoset N (HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) g) =
-      HeckeCoset.mk (SLnZ 2) (SLnZ 2) (Submonoid.inclusion (Delta0_le_posDetInt N) g) := (rfl)
+      HeckeCoset.mk (SLnZ 2) (SLnZ 2) (Submonoid.inclusion (Delta0_le_posDetInt N) g) :=
+  HeckeCoset.map_mk _ _ _ g
 
 /-- An `SL₂(ℤ)`-coefficient has determinant one, so multiplying by it does not change the
 determinant of the integral matrix. -/
@@ -125,7 +118,7 @@ private lemma intMatrix_det_eq_of_mem_doubleCoset {a b : GL (Fin 2) ℚ}
   exact_mod_cast hcast
 
 /-- Coprimality of the determinant to the level depends only on the double coset. -/
-lemma coprimeDet_congr {a b : Delta0 N}
+private lemma coprimeDet_congr {a b : Delta0 N}
     (h : HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) a =
       HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) b) :
     CoprimeDet N a ↔ CoprimeDet N b := by
@@ -158,17 +151,21 @@ intersecting it with `Δ₀(N)` returns the latter. -/
 theorem injOn_toLevelOneCoset :
     Set.InjOn (toLevelOneCoset N) {D | CoprimeDetCoset N D} := by
   rintro D₁ hD₁ D₂ hD₂ h
-  obtain ⟨a, rfl⟩ := Quotient.exists_rep D₁
-  obtain ⟨b, rfl⟩ := Quotient.exists_rep D₂
-  obtain ⟨Aa, hAa, -, -, -⟩ := (mem_Delta0_iff N).mp a.2
-  obtain ⟨Ab, hAb, -, -, -⟩ := (mem_Delta0_iff N).mp b.2
-  replace h : HeckeCoset.mk (SLnZ 2) (SLnZ 2)
-      (Submonoid.inclusion (Delta0_le_posDetInt N) a) =
-    HeckeCoset.mk (SLnZ 2) (SLnZ 2) (Submonoid.inclusion (Delta0_le_posDetInt N) b) := h
-  rw [HeckeCoset.eq_iff, Submonoid.coe_inclusion, Submonoid.coe_inclusion] at h
+  -- work with representatives, so that `toLevelOneCoset_mk` applies
+  have hD₁' : CoprimeDet N D₁.rep :=
+    (coprimeDetCoset_mk N D₁.rep).mp (by rwa [HeckeCoset.mk_rep])
+  have hD₂' : CoprimeDet N D₂.rep :=
+    (coprimeDetCoset_mk N D₂.rep).mp (by rwa [HeckeCoset.mk_rep])
+  rw [← HeckeCoset.mk_rep D₁, ← HeckeCoset.mk_rep D₂] at h ⊢
+  rw [toLevelOneCoset_mk, toLevelOneCoset_mk, HeckeCoset.eq_iff, Submonoid.coe_inclusion,
+    Submonoid.coe_inclusion] at h
+  obtain ⟨Aa, hAa, -, -, -⟩ := (mem_Delta0_iff N).mp D₁.rep.2
+  obtain ⟨Ab, hAb, -, -, -⟩ := (mem_Delta0_iff N).mp D₂.rep.2
   refine HeckeCoset.eq_iff.mpr ?_
   -- each `Γ₀(N)`-double coset is its level-one one cut down to `Δ₀(N)`, and those agree
-  rw [← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ a.2 Aa hAa (hD₁ Aa hAa),
-    ← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ b.2 Ab hAb (hD₂ Ab hAb), h]
+  rw [← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ D₁.rep.2 Aa hAa
+      (hD₁' Aa hAa),
+    ← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ D₂.rep.2 Ab hAb
+      (hD₂' Ab hAb), h]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -103,11 +103,7 @@ private lemma intMatrix_det_eq_of_mem_doubleCoset {a b : GL (Fin 2) ℚ}
   have hdet := det_eq_of_mem_doubleCoset_SLnZ 2 (DoubleCoset.mem_doubleCoset.mpr
     ⟨γ₁, Gamma0Image_le_SLnZ N hγ₁, γ₂, Gamma0Image_le_SLnZ N hγ₂, hb'⟩)
   have hcast : ((B.det : ℤ) : ℚ) = ((A.det : ℤ) : ℚ) := by
-    rw [show ((B.det : ℤ) : ℚ) = (↑b : Matrix (Fin 2) (Fin 2) ℚ).det by
-        rw [hB]; simpa [RingHom.mapMatrix_apply] using RingHom.map_det (Int.castRingHom ℚ) B,
-      show ((A.det : ℤ) : ℚ) = (↑a : Matrix (Fin 2) (Fin 2) ℚ).det by
-        rw [hA]; simpa [RingHom.mapMatrix_apply] using RingHom.map_det (Int.castRingHom ℚ) A]
-    exact hdet
+    rw [intCast_det_eq_det 2 hB, intCast_det_eq_det 2 hA]; exact hdet
   exact_mod_cast hcast
 
 /-- Coprimality of the determinant to the level depends only on the double coset. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -92,29 +92,22 @@ level. -/
       HeckeCoset.mk (SLnZ 2) (SLnZ 2) (Submonoid.inclusion (Delta0_le_posDetInt N) g) :=
   HeckeCoset.map_mk _ _ _ g
 
-/-- An `SL₂(ℤ)`-coefficient has determinant one, so multiplying by it does not change the
-determinant of the integral matrix. -/
+/-- The integral matrices of two elements of one `Γ₀(N)`-double coset have equal determinant:
+`Γ₀(N) ≤ SL₂(ℤ)`, and the determinant is constant on an `SL₂(ℤ)`-double coset. -/
 private lemma intMatrix_det_eq_of_mem_doubleCoset {a b : GL (Fin 2) ℚ}
     (hb : b ∈ DoubleCoset.doubleCoset a (Gamma0Image N) (Gamma0Image N))
     {A B : Matrix (Fin 2) (Fin 2) ℤ}
     (hA : (↑a : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
     (hB : (↑b : Matrix (Fin 2) (Fin 2) ℚ) = B.map (Int.cast : ℤ → ℚ)) : B.det = A.det := by
-  obtain ⟨γ₁, hγ₁, γ₂, hγ₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hb
-  obtain ⟨σ₁, rfl⟩ := (mem_SLnZ_iff 2).mp (Gamma0Image_le_SLnZ N hγ₁)
-  obtain ⟨σ₂, rfl⟩ := (mem_SLnZ_iff 2).mp (Gamma0Image_le_SLnZ N hγ₂)
-  -- over `ℚ` the two determinants agree, and `ℤ → ℚ` is injective
+  obtain ⟨γ₁, hγ₁, γ₂, hγ₂, hb'⟩ := DoubleCoset.mem_doubleCoset.mp hb
+  have hdet := det_eq_of_mem_doubleCoset_SLnZ 2 (DoubleCoset.mem_doubleCoset.mpr
+    ⟨γ₁, Gamma0Image_le_SLnZ N hγ₁, γ₂, Gamma0Image_le_SLnZ N hγ₂, hb'⟩)
   have hcast : ((B.det : ℤ) : ℚ) = ((A.det : ℤ) : ℚ) := by
-    have hB' : ((B.det : ℤ) : ℚ) = (↑(mapGL ℚ σ₁ * a * mapGL ℚ σ₂) :
-        Matrix (Fin 2) (Fin 2) ℚ).det := by
-      rw [hB]; simpa [RingHom.mapMatrix_apply] using RingHom.map_det (Int.castRingHom ℚ) B
-    have hA' : ((A.det : ℤ) : ℚ) = (↑a : Matrix (Fin 2) (Fin 2) ℚ).det := by
-      rw [hA]; simpa [RingHom.mapMatrix_apply] using RingHom.map_det (Int.castRingHom ℚ) A
-    -- `det_mapGL` is about the *unit* determinant, so `← val_det_apply` moves the matrix
-    -- determinant of an `SL₂(ℤ)` coefficient into its range first
-    rw [hB', hA', GeneralLinearGroup.coe_mul, GeneralLinearGroup.coe_mul, Matrix.det_mul,
-      Matrix.det_mul]
-    simp only [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL,
-      Units.val_one, one_mul, mul_one]
+    rw [show ((B.det : ℤ) : ℚ) = (↑b : Matrix (Fin 2) (Fin 2) ℚ).det by
+        rw [hB]; simpa [RingHom.mapMatrix_apply] using RingHom.map_det (Int.castRingHom ℚ) B,
+      show ((A.det : ℤ) : ℚ) = (↑a : Matrix (Fin 2) (Fin 2) ℚ).det by
+        rw [hA]; simpa [RingHom.mapMatrix_apply] using RingHom.map_det (Int.castRingHom ℚ) A]
+    exact hdet
   exact_mod_cast hcast
 
 /-- Coprimality of the determinant to the level depends only on the double coset. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, Claude
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.Basic
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.DoubleCoset
+
+/-!
+# Comparing the `Γ₀(N)` and level-one double cosets
+
+**Shimura, Propositions 3.30 and 3.31.** Since `Γ₀(N) ≤ SL₂(ℤ)` and `Δ₀(N) ≤ Δ`, sending
+`Γ₀(N) α Γ₀(N)` to `SL₂(ℤ) α SL₂(ℤ)` is well defined on double cosets:
+
+```lean
+noncomputable def toLevelOneCoset :
+    HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) →
+      HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)
+```
+
+and it is **injective on the cosets whose determinant is coprime to the level**
+(`toLevelOneCoset_injOn_coprimeDet`). Injectivity is the content: two `Γ₀(N)`-double cosets
+with the same level-one double coset are recovered from it by intersecting with `Δ₀(N)`, which
+is exactly `doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image`.
+
+This is what identifies the good-prime part of `R(Γ₀(N), Δ₀(N))` with the level-one Hecke ring,
+and so the step by which `T_n` for `gcd(n, N) = 1` inherits its level-one behaviour.
+
+Ported from the AINTLIB `LeanModularForms` project
+(`LeanModularForms/HeckeRIngs/GLn/CongruenceHecke/Props.lean`, Chris Birkbeck,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), the `cosetMap`
+and `shimura_prop_3_31` section. The bespoke `Delta0_inclusion` there is `Submonoid.inclusion`
+here, and AINTLIB's `HeckePair` bundle is Mathlib's `HeckeCoset`.
+
+## Main definitions
+
+* `HeckeRing.GL2.CoprimeDet`: an element of `Δ₀(N)` whose integral representative has
+  determinant coprime to `N`.
+* `HeckeRing.GL2.toLevelOneCoset`: the map `Γ₀(N) α Γ₀(N) ↦ SL₂(ℤ) α SL₂(ℤ)`.
+
+## Main results
+
+* `HeckeRing.GL2.toLevelOneCoset_mk`: its computation rule on a representative.
+* `HeckeRing.GL2.toLevelOneCoset_injOn_coprimeDet`: **Shimura, Proposition 3.31** — it is
+  injective on coprime-determinant double cosets.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  Propositions 3.30 and 3.31.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup CongruenceSubgroup Subgroup HeckeRing.GLn
+
+open scoped Pointwise MatrixGroups
+
+namespace HeckeRing.GL2
+
+variable (N : ℕ)
+
+/-- An element of `Δ₀(N)` has **coprime determinant** when every integral matrix representing
+it has determinant coprime to `N`.
+
+Quantifying over all representatives rather than choosing one keeps the predicate free of a
+choice; the representative is unique anyway, since `ℤ → ℚ` is injective. -/
+def CoprimeDet (g : Delta0 N) : Prop :=
+  ∀ A : Matrix (Fin 2) (Fin 2) ℤ,
+    (↑(g : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ) →
+      Int.gcd A.det N = 1
+
+/-- **Shimura, Proposition 3.30.** Passing from a `Γ₀(N)`-double coset to the level-one double
+coset of the same element is well defined: `Γ₀(N) ≤ SL₂(ℤ)`, so `Γ₀(N) a Γ₀(N) = Γ₀(N) b Γ₀(N)`
+forces `SL₂(ℤ) a SL₂(ℤ) = SL₂(ℤ) b SL₂(ℤ)`. -/
+noncomputable def toLevelOneCoset :
+    HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) →
+      HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2) :=
+  Quotient.lift
+    (fun g ↦ HeckeCoset.mk (SLnZ 2) (SLnZ 2) (Submonoid.inclusion (Delta0_le_posDetInt N) g))
+    (fun a b hab ↦ by
+      -- the setoid relation on `HeckeCoset` *is* equality of the double cosets
+      have hab' : DoubleCoset.doubleCoset (a : GL (Fin 2) ℚ) (Gamma0Image N) (Gamma0Image N) =
+          DoubleCoset.doubleCoset (b : GL (Fin 2) ℚ) (Gamma0Image N) (Gamma0Image N) := hab
+      refine HeckeCoset.eq_iff.mpr (DoubleCoset.doubleCoset_eq_of_mem ?_).symm
+      -- `b` lies in the `Γ₀(N)`-double coset of `a`, hence in its level-one one
+      exact doubleCoset_Gamma0Image_le_doubleCoset_SLnZ N (a : GL (Fin 2) ℚ)
+        (hab' ▸ DoubleCoset.mem_doubleCoset_self _ _ _))
+
+/-- The computation rule for `toLevelOneCoset`: it keeps the representative and forgets the
+level. -/
+@[simp] lemma toLevelOneCoset_mk (g : Delta0 N) :
+    toLevelOneCoset N (HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) g) =
+      HeckeCoset.mk (SLnZ 2) (SLnZ 2) (Submonoid.inclusion (Delta0_le_posDetInt N) g) := (rfl)
+
+/-- **Shimura, Proposition 3.31.** `toLevelOneCoset` is injective on the double cosets whose
+determinant is coprime to `N`: the level-one double coset determines the `Γ₀(N)` one, because
+intersecting it with `Δ₀(N)` returns the latter. -/
+theorem toLevelOneCoset_injOn_coprimeDet {a b : Delta0 N} (ha : CoprimeDet N a)
+    (hb : CoprimeDet N b)
+    (h : toLevelOneCoset N (HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) a) =
+      toLevelOneCoset N (HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) b)) :
+    HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) a =
+      HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) b := by
+  obtain ⟨Aa, hAa, -, hAaN, -⟩ := (mem_Delta0_iff N).mp a.2
+  obtain ⟨Ab, hAb, -, hAbN, -⟩ := (mem_Delta0_iff N).mp b.2
+  rw [toLevelOneCoset_mk, toLevelOneCoset_mk, HeckeCoset.eq_iff,
+    Submonoid.coe_inclusion, Submonoid.coe_inclusion] at h
+  refine HeckeCoset.eq_iff.mpr ?_
+  -- each `Γ₀(N)`-double coset is its level-one one cut down to `Δ₀(N)`, and those agree
+  rw [← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ a.2 Aa hAa (ha Aa hAa),
+    ← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ b.2 Ab hAb (hb Ab hAb), h]
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -46,6 +46,7 @@ here, and AINTLIB's `HeckePair` bundle is Mathlib's `HeckeCoset`.
 
 ## Main results
 
+* `HeckeRing.GL2.coprimeDet_iff`: `CoprimeDet` is decided by any one integral witness.
 * `HeckeRing.GL2.toLevelOneCoset_mk`, `HeckeRing.GL2.coprimeDetCoset_mk`: the computation rules
   on a representative.
 * `HeckeRing.GL2.injOn_toLevelOneCoset`: **Shimura, Proposition 3.31** — `toLevelOneCoset` is
@@ -77,6 +78,16 @@ def CoprimeDet (g : Delta0 N) : Prop :=
     (↑(g : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ) →
       Int.gcd A.det N = 1
 
+/-- `CoprimeDet` is decided by any single integral witness: the witness is unique, because the
+entrywise cast `ℤ → ℚ` is injective. This is the introduction rule for the definition, whose
+universal quantifier only eliminates. -/
+lemma coprimeDet_iff {g : Delta0 N} {A : Matrix (Fin 2) (Fin 2) ℤ}
+    (hA : (↑(g : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ)) :
+    CoprimeDet N g ↔ Int.gcd A.det N = 1 := by
+  refine ⟨fun h ↦ h A hA, fun h A' hA' ↦ ?_⟩
+  have : A' = A := Matrix.map_injective Int.cast_injective (hA'.symm.trans hA)
+  exact this ▸ h
+
 /-- **Shimura, Proposition 3.30.** Passing from a `Γ₀(N)`-double coset to the level-one double
 coset of the same element, as the `HeckeCoset.map` of the three inclusions `Δ₀(N) ≤ Δ`,
 `Γ₀(N) ≤ SL₂(ℤ)` (twice). -/
@@ -103,7 +114,7 @@ private lemma intMatrix_det_eq_of_mem_doubleCoset {a b : GL (Fin 2) ℚ}
   have hdet := det_eq_of_mem_doubleCoset_SLnZ 2 (DoubleCoset.mem_doubleCoset.mpr
     ⟨γ₁, Gamma0Image_le_SLnZ N hγ₁, γ₂, Gamma0Image_le_SLnZ N hγ₂, hb'⟩)
   have hcast : ((B.det : ℤ) : ℚ) = ((A.det : ℤ) : ℚ) := by
-    rw [intCast_det_eq_det 2 hB, intCast_det_eq_det 2 hA]; exact hdet
+    rw [Int.cast_det B, Int.cast_det A, ← hB, ← hA]; exact hdet
   exact_mod_cast hcast
 
 /-- Coprimality of the determinant to the level depends only on the double coset. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -25,8 +25,9 @@ and it is **injective on the cosets whose determinant is coprime to the level**
 with the same level-one double coset are recovered from it by intersecting with `Δ₀(N)`, which
 is exactly `doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image`.
 
-This is what identifies the good-prime part of `R(Γ₀(N), Δ₀(N))` with the level-one Hecke ring,
-and so the step by which `T_n` for `gcd(n, N) = 1` inherits its level-one behaviour.
+This is the injectivity step towards a later good-prime comparison of `R(Γ₀(N), Δ₀(N))` with
+the level-one Hecke ring. Neither surjectivity nor compatibility with the Hecke-ring operations
+is proved here: this file compares the two *coset types* only.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/HeckeRIngs/GLn/CongruenceHecke/Props.lean`, Chris Birkbeck,
@@ -38,13 +39,16 @@ here, and AINTLIB's `HeckePair` bundle is Mathlib's `HeckeCoset`.
 
 * `HeckeRing.GL2.CoprimeDet`: an element of `Δ₀(N)` whose integral representative has
   determinant coprime to `N`.
+* `HeckeRing.GL2.CoprimeDetCoset`: the same condition on a `Γ₀(N)`-double coset — well defined
+  because the coefficients have determinant one, so the determinant is constant on a coset.
 * `HeckeRing.GL2.toLevelOneCoset`: the map `Γ₀(N) α Γ₀(N) ↦ SL₂(ℤ) α SL₂(ℤ)`.
 
 ## Main results
 
-* `HeckeRing.GL2.toLevelOneCoset_mk`: its computation rule on a representative.
-* `HeckeRing.GL2.toLevelOneCoset_injOn_coprimeDet`: **Shimura, Proposition 3.31** — it is
-  injective on coprime-determinant double cosets.
+* `HeckeRing.GL2.toLevelOneCoset_mk`, `HeckeRing.GL2.coprimeDetCoset_mk`: the computation rules
+  on a representative.
+* `HeckeRing.GL2.injOn_toLevelOneCoset`: **Shimura, Proposition 3.31** — `toLevelOneCoset` is
+  injective on the set of coprime-determinant double cosets.
 
 ## References
 
@@ -95,22 +99,76 @@ level. -/
     toLevelOneCoset N (HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) g) =
       HeckeCoset.mk (SLnZ 2) (SLnZ 2) (Submonoid.inclusion (Delta0_le_posDetInt N) g) := (rfl)
 
+/-- An `SL₂(ℤ)`-coefficient has determinant one, so multiplying by it does not change the
+determinant of the integral matrix. -/
+private lemma intMatrix_det_eq_of_mem_doubleCoset {a b : GL (Fin 2) ℚ}
+    (hb : b ∈ DoubleCoset.doubleCoset a (Gamma0Image N) (Gamma0Image N))
+    {A B : Matrix (Fin 2) (Fin 2) ℤ}
+    (hA : (↑a : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
+    (hB : (↑b : Matrix (Fin 2) (Fin 2) ℚ) = B.map (Int.cast : ℤ → ℚ)) : B.det = A.det := by
+  obtain ⟨γ₁, hγ₁, γ₂, hγ₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hb
+  obtain ⟨σ₁, rfl⟩ := (mem_SLnZ_iff 2).mp (Gamma0Image_le_SLnZ N hγ₁)
+  obtain ⟨σ₂, rfl⟩ := (mem_SLnZ_iff 2).mp (Gamma0Image_le_SLnZ N hγ₂)
+  -- over `ℚ` the two determinants agree, and `ℤ → ℚ` is injective
+  have hcast : ((B.det : ℤ) : ℚ) = ((A.det : ℤ) : ℚ) := by
+    have hB' : ((B.det : ℤ) : ℚ) = (↑(mapGL ℚ σ₁ * a * mapGL ℚ σ₂) :
+        Matrix (Fin 2) (Fin 2) ℚ).det := by
+      rw [hB]; simpa [RingHom.mapMatrix_apply] using RingHom.map_det (Int.castRingHom ℚ) B
+    have hA' : ((A.det : ℤ) : ℚ) = (↑a : Matrix (Fin 2) (Fin 2) ℚ).det := by
+      rw [hA]; simpa [RingHom.mapMatrix_apply] using RingHom.map_det (Int.castRingHom ℚ) A
+    -- `det_mapGL` is about the *unit* determinant, so `← val_det_apply` moves the matrix
+    -- determinant of an `SL₂(ℤ)` coefficient into its range first
+    rw [hB', hA', GeneralLinearGroup.coe_mul, GeneralLinearGroup.coe_mul, Matrix.det_mul,
+      Matrix.det_mul]
+    simp only [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL,
+      Units.val_one, one_mul, mul_one]
+  exact_mod_cast hcast
+
+/-- Coprimality of the determinant to the level depends only on the double coset. -/
+lemma coprimeDet_congr {a b : Delta0 N}
+    (h : HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) a =
+      HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) b) :
+    CoprimeDet N a ↔ CoprimeDet N b := by
+  obtain ⟨Aa, hAa, -, -, -⟩ := (mem_Delta0_iff N).mp a.2
+  obtain ⟨Ab, hAb, -, -, -⟩ := (mem_Delta0_iff N).mp b.2
+  have hdc := HeckeCoset.eq_iff.mp h
+  have hba : Ab.det = Aa.det := intMatrix_det_eq_of_mem_doubleCoset N
+    (hdc ▸ DoubleCoset.mem_doubleCoset_self _ _ _) hAa hAb
+  constructor
+  · intro ha A hA
+    obtain rfl : A = Ab := Matrix.map_injective Int.cast_injective (hA.symm.trans hAb)
+    exact hba ▸ ha Aa hAa
+  · intro hb A hA
+    obtain rfl : A = Aa := Matrix.map_injective Int.cast_injective (hA.symm.trans hAa)
+    exact hba ▸ hb Ab hAb
+
+/-- Coprimality of the determinant to the level, as a predicate on `Γ₀(N)`-double cosets. -/
+def CoprimeDetCoset : HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) → Prop :=
+  Quotient.lift (CoprimeDet N)
+    (fun _ _ hab ↦ propext (coprimeDet_congr N (Quotient.sound hab)))
+
+/-- `CoprimeDetCoset` is `CoprimeDet` on any representative. -/
+@[simp] lemma coprimeDetCoset_mk (g : Delta0 N) :
+    CoprimeDetCoset N (HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) g) ↔ CoprimeDet N g :=
+  Iff.rfl
+
 /-- **Shimura, Proposition 3.31.** `toLevelOneCoset` is injective on the double cosets whose
 determinant is coprime to `N`: the level-one double coset determines the `Γ₀(N)` one, because
 intersecting it with `Δ₀(N)` returns the latter. -/
-theorem toLevelOneCoset_injOn_coprimeDet {a b : Delta0 N} (ha : CoprimeDet N a)
-    (hb : CoprimeDet N b)
-    (h : toLevelOneCoset N (HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) a) =
-      toLevelOneCoset N (HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) b)) :
-    HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) a =
-      HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) b := by
-  obtain ⟨Aa, hAa, -, hAaN, -⟩ := (mem_Delta0_iff N).mp a.2
-  obtain ⟨Ab, hAb, -, hAbN, -⟩ := (mem_Delta0_iff N).mp b.2
-  rw [toLevelOneCoset_mk, toLevelOneCoset_mk, HeckeCoset.eq_iff,
-    Submonoid.coe_inclusion, Submonoid.coe_inclusion] at h
+theorem injOn_toLevelOneCoset :
+    Set.InjOn (toLevelOneCoset N) {D | CoprimeDetCoset N D} := by
+  rintro D₁ hD₁ D₂ hD₂ h
+  obtain ⟨a, rfl⟩ := Quotient.exists_rep D₁
+  obtain ⟨b, rfl⟩ := Quotient.exists_rep D₂
+  obtain ⟨Aa, hAa, -, -, -⟩ := (mem_Delta0_iff N).mp a.2
+  obtain ⟨Ab, hAb, -, -, -⟩ := (mem_Delta0_iff N).mp b.2
+  replace h : HeckeCoset.mk (SLnZ 2) (SLnZ 2)
+      (Submonoid.inclusion (Delta0_le_posDetInt N) a) =
+    HeckeCoset.mk (SLnZ 2) (SLnZ 2) (Submonoid.inclusion (Delta0_le_posDetInt N) b) := h
+  rw [HeckeCoset.eq_iff, Submonoid.coe_inclusion, Submonoid.coe_inclusion] at h
   refine HeckeCoset.eq_iff.mpr ?_
   -- each `Γ₀(N)`-double coset is its level-one one cut down to `Δ₀(N)`, and those agree
-  rw [← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ a.2 Aa hAa (ha Aa hAa),
-    ← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ b.2 Ab hAb (hb Ab hAb), h]
+  rw [← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ a.2 Aa hAa (hD₁ Aa hAa),
+    ← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ b.2 Ab hAb (hD₂ Ab hAb), h]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -37,8 +37,6 @@ here, and AINTLIB's `HeckePair` bundle is Mathlib's `HeckeCoset`.
 
 ## Main definitions
 
-* `HeckeRing.GL2.CoprimeDet`: an element of `Δ₀(N)` whose integral representative has
-  determinant coprime to `N`.
 * `HeckeRing.GL2.CoprimeDetCoset`: the same condition on a `Γ₀(N)`-double coset — well defined
   because the coefficients have determinant one, so the determinant is constant on a coset.
 * `HeckeRing.GL2.toLevelOneCoset`: the map `Γ₀(N) α Γ₀(N) ↦ SL₂(ℤ) α SL₂(ℤ)`, the `Γ₀`
@@ -46,7 +44,6 @@ here, and AINTLIB's `HeckePair` bundle is Mathlib's `HeckeCoset`.
 
 ## Main results
 
-* `HeckeRing.GL2.coprimeDet_iff`: `CoprimeDet` is decided by any one integral witness.
 * `HeckeRing.GL2.toLevelOneCoset_mk`, `HeckeRing.GL2.coprimeDetCoset_mk`: the computation rules
   on a representative.
 * `HeckeRing.GL2.toLevelOneCoset_injOn`: **Shimura, Proposition 3.31** — `toLevelOneCoset` is
@@ -67,26 +64,6 @@ open scoped Pointwise MatrixGroups
 namespace HeckeRing.GL2
 
 variable (N : ℕ)
-
-/-- An element of `Δ₀(N)` has **coprime determinant** when every integral matrix representing
-it has determinant coprime to `N`.
-
-Quantifying over all representatives rather than choosing one keeps the predicate free of a
-choice; the representative is unique anyway, since `ℤ → ℚ` is injective. -/
-def CoprimeDet (g : Delta0 N) : Prop :=
-  ∀ A : Matrix (Fin 2) (Fin 2) ℤ,
-    (↑(g : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ) →
-      Int.gcd A.det N = 1
-
-/-- `CoprimeDet` is decided by any single integral witness: the witness is unique, because the
-entrywise cast `ℤ → ℚ` is injective. This is the introduction rule for the definition, whose
-universal quantifier only eliminates. -/
-lemma coprimeDet_iff {g : Delta0 N} {A : Matrix (Fin 2) (Fin 2) ℤ}
-    (hA : (↑(g : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ)) :
-    CoprimeDet N g ↔ Int.gcd A.det N = 1 := by
-  refine ⟨fun h ↦ h A hA, fun h A' hA' ↦ ?_⟩
-  have : A' = A := Matrix.map_injective Int.cast_injective (hA'.symm.trans hA)
-  exact this ▸ h
 
 /-- **Shimura, Proposition 3.30.** Passing from a `Γ₀(N)`-double coset to the level-one double
 coset of the same element, as the `HeckeCoset.map` of the three inclusions `Δ₀(N) ≤ Δ`,
@@ -123,16 +100,9 @@ private lemma coprimeDet_congr {a b : Delta0 N}
     CoprimeDet N a ↔ CoprimeDet N b := by
   obtain ⟨Aa, hAa, -, -, -⟩ := (mem_Delta0_iff N).mp a.2
   obtain ⟨Ab, hAb, -, -, -⟩ := (mem_Delta0_iff N).mp b.2
-  have hdc := HeckeCoset.eq_iff.mp h
   have hba : Ab.det = Aa.det := intMatrix_det_eq_of_mem_doubleCoset N
-    (hdc ▸ DoubleCoset.mem_doubleCoset_self _ _ _) hAa hAb
-  constructor
-  · intro ha A hA
-    obtain rfl : A = Ab := Matrix.map_injective Int.cast_injective (hA.symm.trans hAb)
-    exact hba ▸ ha Aa hAa
-  · intro hb A hA
-    obtain rfl : A = Aa := Matrix.map_injective Int.cast_injective (hA.symm.trans hAa)
-    exact hba ▸ hb Ab hAb
+    (HeckeCoset.eq_iff.mp h ▸ DoubleCoset.mem_doubleCoset_self _ _ _) hAa hAb
+  rw [coprimeDet_iff N hAa, coprimeDet_iff N hAb, hba]
 
 /-- Coprimality of the determinant to the level, as a predicate on `Γ₀(N)`-double cosets. -/
 def CoprimeDetCoset : HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) → Prop :=
@@ -163,8 +133,8 @@ theorem toLevelOneCoset_injOn :
   refine HeckeCoset.eq_iff.mpr ?_
   -- each `Γ₀(N)`-double coset is its level-one one cut down to `Δ₀(N)`, and those agree
   rw [← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ D₁.rep.2 Aa hAa
-      (hD₁' Aa hAa),
+      ((coprimeDet_iff N hAa).mp hD₁'),
     ← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ D₂.rep.2 Ab hAb
-      (hD₂' Ab hAb), h]
+      ((coprimeDet_iff N hAb).mp hD₂'), h]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -110,9 +110,8 @@ private lemma intMatrix_det_eq_of_mem_doubleCoset {a b : GL (Fin 2) ℚ}
     {A B : Matrix (Fin 2) (Fin 2) ℤ}
     (hA : (↑a : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
     (hB : (↑b : Matrix (Fin 2) (Fin 2) ℚ) = B.map (Int.cast : ℤ → ℚ)) : B.det = A.det := by
-  obtain ⟨γ₁, hγ₁, γ₂, hγ₂, hb'⟩ := DoubleCoset.mem_doubleCoset.mp hb
-  have hdet := det_eq_of_mem_doubleCoset_SLnZ 2 (DoubleCoset.mem_doubleCoset.mpr
-    ⟨γ₁, Gamma0Image_le_SLnZ N hγ₁, γ₂, Gamma0Image_le_SLnZ N hγ₂, hb'⟩)
+  have hdet := det_eq_of_mem_doubleCoset_of_le_SLnZ 2 (Gamma0Image_le_SLnZ N)
+    (Gamma0Image_le_SLnZ N) hb
   have hcast : ((B.det : ℤ) : ℚ) = ((A.det : ℤ) : ℚ) := by
     rw [Int.cast_det B, Int.cast_det A, ← hB, ← hA]; exact hdet
   exact_mod_cast hcast

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -341,12 +341,9 @@ private lemma mulSupport_pp_subset (k : ℕ)
       (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)) ((A.rep : GL (Fin 2) ℚ)) ≠ 0) :
     A = diagCoset ![1, p ^ (k + 1)] ∨ A = diagCoset ![p, p ^ k] := by
   classical
-  -- Mathlib's `det_mapGL` is about the *unit* determinant `(mapGL ℚ S).det : ℚˣ`, while every
-  -- goal below is about the matrix determinant `(↑(mapGL ℚ S)).det : ℚ`. This is the bridge
-  -- between the two, used four times in the determinant bookkeeping of stage 4.
-  have hdet : ∀ S : SpecialLinearGroup (Fin 2) ℤ, (mapGL ℚ S).val.det = 1 := fun S ↦ by
-    simpa only [Matrix.GeneralLinearGroup.val_det_apply, Units.val_one] using
-      congrArg Units.val (Matrix.SpecialLinearGroup.det_mapGL (S := ℚ) S)
+  -- the matrix determinant of an `SL₂(ℤ)` element, used four times in stage 4's bookkeeping
+  have hdet : ∀ S : SpecialLinearGroup (Fin 2) ℤ, (mapGL ℚ S).val.det = 1 := fun S ↦
+    det_eq_one_of_mem_SLnZ 2 ((mem_SLnZ_iff 2).2 ⟨S, rfl⟩)
   -- Stage 1: positivity of the two input diagonals, and a diagonal representative `a` for `A`.
   have h1p_pos : ∀ i : Fin 2, 0 < (![1, p] : Fin 2 → ℕ) i := fun i ↦ by
     fin_cases i <;> simp [hp.pos]

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
@@ -79,6 +79,25 @@ downstream cannot unfold it to `MonoidHom.range`; this lemma is how they extract
     g ∈ SLnZ n ↔ ∃ σ : SpecialLinearGroup (Fin n) ℤ, (σ : GL (Fin n) ℚ) = g := by
   rw [SLnZ, MonoidHom.mem_range]
 
+/-- An element of `SL_n(ℤ)` has matrix determinant one over `ℚ`.
+
+`SpecialLinearGroup.det_mapGL` is the same fact for `GeneralLinearGroup.det`, which is
+`ℚˣ`-valued; every consumer needs the `Matrix.det` of the coerced matrix, so this is the
+`Units.val` bridge rather than a second proof. -/
+lemma det_eq_one_of_mem_SLnZ {g : GL (Fin n) ℚ} (hg : g ∈ SLnZ n) :
+    (↑g : Matrix (Fin n) (Fin n) ℚ).det = 1 := by
+  obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff n).mp hg
+  exact congrArg Units.val (SpecialLinearGroup.det_mapGL (S := ℚ) σ)
+
+/-- The determinant is constant on an `SL_n(ℤ)`-double coset: both coefficients have
+determinant one. -/
+lemma det_eq_of_mem_doubleCoset_SLnZ {a b : GL (Fin n) ℚ}
+    (hb : b ∈ DoubleCoset.doubleCoset a (SLnZ n) (SLnZ n)) :
+    (↑b : Matrix (Fin n) (Fin n) ℚ).det = (↑a : Matrix (Fin n) (Fin n) ℚ).det := by
+  obtain ⟨γ₁, hγ₁, γ₂, hγ₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hb
+  simp only [GeneralLinearGroup.coe_mul, Matrix.det_mul, det_eq_one_of_mem_SLnZ n hγ₁,
+    det_eq_one_of_mem_SLnZ n hγ₂, one_mul, mul_one]
+
 /-- The image in `GL_n(ℚ)` of a finite-index subgroup of `SL_n(ℤ)` is commensurable with
 `SL_n(ℤ)`. Since `mapGL ℚ` is injective, both relative indices transport along it: one is the
 index of `H`, finite by hypothesis, and the other is `1`.

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
@@ -79,6 +79,15 @@ downstream cannot unfold it to `MonoidHom.range`; this lemma is how they extract
     g ∈ SLnZ n ↔ ∃ σ : SpecialLinearGroup (Fin n) ℤ, (σ : GL (Fin n) ℚ) = g := by
   rw [SLnZ, MonoidHom.mem_range]
 
+/-- The determinant of an integral witness, cast to `ℚ`, is the determinant of the element it
+represents. This is the bridge every consumer of an integral witness needs in order to move
+between `A.det : ℤ` and the rational determinant. -/
+lemma intCast_det_eq_det {g : GL (Fin n) ℚ} {A : Matrix (Fin n) (Fin n) ℤ}
+    (hA : (↑g : Matrix (Fin n) (Fin n) ℚ) = A.map (Int.cast : ℤ → ℚ)) :
+    ((A.det : ℤ) : ℚ) = (↑g : Matrix (Fin n) (Fin n) ℚ).det := by
+  rw [hA]
+  simpa [RingHom.mapMatrix_apply] using RingHom.map_det (Int.castRingHom ℚ) A
+
 /-- An element of `SL_n(ℤ)` has matrix determinant one over `ℚ`.
 
 `SpecialLinearGroup.det_mapGL` is the same fact for `GeneralLinearGroup.det`, which is

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
@@ -89,14 +89,22 @@ lemma det_eq_one_of_mem_SLnZ {g : GL (Fin n) ℚ} (hg : g ∈ SLnZ n) :
   obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff n).mp hg
   exact congrArg Units.val (SpecialLinearGroup.det_mapGL (S := ℚ) σ)
 
-/-- The determinant is constant on an `SL_n(ℤ)`-double coset: both coefficients have
-determinant one. -/
-lemma det_eq_of_mem_doubleCoset_SLnZ {a b : GL (Fin n) ℚ}
-    (hb : b ∈ DoubleCoset.doubleCoset a (SLnZ n) (SLnZ n)) :
+/-- The determinant is constant on a double coset whose coefficient subgroups lie in
+`SL_n(ℤ)` — the proof needs only that each coefficient has determinant one, so the
+congruence subgroups get it as well as `SL_n(ℤ)` itself. -/
+lemma det_eq_of_mem_doubleCoset_of_le_SLnZ {H₁ H₂ : Subgroup (GL (Fin n) ℚ)}
+    (h₁ : H₁ ≤ SLnZ n) (h₂ : H₂ ≤ SLnZ n) {a b : GL (Fin n) ℚ}
+    (hb : b ∈ DoubleCoset.doubleCoset a H₁ H₂) :
     (↑b : Matrix (Fin n) (Fin n) ℚ).det = (↑a : Matrix (Fin n) (Fin n) ℚ).det := by
   obtain ⟨γ₁, hγ₁, γ₂, hγ₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hb
-  simp only [GeneralLinearGroup.coe_mul, Matrix.det_mul, det_eq_one_of_mem_SLnZ n hγ₁,
-    det_eq_one_of_mem_SLnZ n hγ₂, one_mul, mul_one]
+  simp only [GeneralLinearGroup.coe_mul, Matrix.det_mul, det_eq_one_of_mem_SLnZ n (h₁ hγ₁),
+    det_eq_one_of_mem_SLnZ n (h₂ hγ₂), one_mul, mul_one]
+
+/-- The `SL_n(ℤ)` case of `det_eq_of_mem_doubleCoset_of_le_SLnZ`. -/
+lemma det_eq_of_mem_doubleCoset_SLnZ {a b : GL (Fin n) ℚ}
+    (hb : b ∈ DoubleCoset.doubleCoset a (SLnZ n) (SLnZ n)) :
+    (↑b : Matrix (Fin n) (Fin n) ℚ).det = (↑a : Matrix (Fin n) (Fin n) ℚ).det :=
+  det_eq_of_mem_doubleCoset_of_le_SLnZ n le_rfl le_rfl hb
 
 /-- The image in `GL_n(ℚ)` of a finite-index subgroup of `SL_n(ℤ)` is commensurable with
 `SL_n(ℤ)`. Since `mapGL ℚ` is injective, both relative indices transport along it: one is the

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
@@ -79,15 +79,6 @@ downstream cannot unfold it to `MonoidHom.range`; this lemma is how they extract
     g ∈ SLnZ n ↔ ∃ σ : SpecialLinearGroup (Fin n) ℤ, (σ : GL (Fin n) ℚ) = g := by
   rw [SLnZ, MonoidHom.mem_range]
 
-/-- The determinant of an integral witness, cast to `ℚ`, is the determinant of the element it
-represents. This is the bridge every consumer of an integral witness needs in order to move
-between `A.det : ℤ` and the rational determinant. -/
-lemma intCast_det_eq_det {g : GL (Fin n) ℚ} {A : Matrix (Fin n) (Fin n) ℤ}
-    (hA : (↑g : Matrix (Fin n) (Fin n) ℚ) = A.map (Int.cast : ℤ → ℚ)) :
-    ((A.det : ℤ) : ℚ) = (↑g : Matrix (Fin n) (Fin n) ℚ).det := by
-  rw [hA]
-  simpa [RingHom.mapMatrix_apply] using RingHom.map_det (Int.castRingHom ℚ) A
-
 /-- An element of `SL_n(ℤ)` has matrix determinant one over `ℚ`.
 
 `SpecialLinearGroup.det_mapGL` is the same fact for `GeneralLinearGroup.det`, which is

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
@@ -89,16 +89,24 @@ lemma det_eq_one_of_mem_SLnZ {g : GL (Fin n) ℚ} (hg : g ∈ SLnZ n) :
   obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff n).mp hg
   exact congrArg Units.val (SpecialLinearGroup.det_mapGL (S := ℚ) σ)
 
-/-- The determinant is constant on a double coset whose coefficient subgroups lie in
-`SL_n(ℤ)` — the proof needs only that each coefficient has determinant one, so the
-congruence subgroups get it as well as `SL_n(ℤ)` itself. -/
-lemma det_eq_of_mem_doubleCoset_of_le_SLnZ {H₁ H₂ : Subgroup (GL (Fin n) ℚ)}
-    (h₁ : H₁ ≤ SLnZ n) (h₂ : H₂ ≤ SLnZ n) {a b : GL (Fin n) ℚ}
+/-- The determinant is constant on a double coset whose coefficients all have determinant
+one — the only property of the coefficient subgroups the argument uses. -/
+lemma det_eq_of_mem_doubleCoset_of_det_eq_one {H₁ H₂ : Subgroup (GL (Fin n) ℚ)}
+    (h₁ : ∀ γ ∈ H₁, (↑γ : Matrix (Fin n) (Fin n) ℚ).det = 1)
+    (h₂ : ∀ γ ∈ H₂, (↑γ : Matrix (Fin n) (Fin n) ℚ).det = 1) {a b : GL (Fin n) ℚ}
     (hb : b ∈ DoubleCoset.doubleCoset a H₁ H₂) :
     (↑b : Matrix (Fin n) (Fin n) ℚ).det = (↑a : Matrix (Fin n) (Fin n) ℚ).det := by
   obtain ⟨γ₁, hγ₁, γ₂, hγ₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hb
-  simp only [GeneralLinearGroup.coe_mul, Matrix.det_mul, det_eq_one_of_mem_SLnZ n (h₁ hγ₁),
-    det_eq_one_of_mem_SLnZ n (h₂ hγ₂), one_mul, mul_one]
+  simp only [GeneralLinearGroup.coe_mul, Matrix.det_mul, h₁ γ₁ hγ₁, h₂ γ₂ hγ₂, one_mul, mul_one]
+
+/-- The case of coefficient subgroups inside `SL_n(ℤ)`, which is how the congruence subgroups
+get it. -/
+lemma det_eq_of_mem_doubleCoset_of_le_SLnZ {H₁ H₂ : Subgroup (GL (Fin n) ℚ)}
+    (h₁ : H₁ ≤ SLnZ n) (h₂ : H₂ ≤ SLnZ n) {a b : GL (Fin n) ℚ}
+    (hb : b ∈ DoubleCoset.doubleCoset a H₁ H₂) :
+    (↑b : Matrix (Fin n) (Fin n) ℚ).det = (↑a : Matrix (Fin n) (Fin n) ℚ).det :=
+  det_eq_of_mem_doubleCoset_of_det_eq_one n (fun _ hγ ↦ det_eq_one_of_mem_SLnZ n (h₁ hγ))
+    (fun _ hγ ↦ det_eq_one_of_mem_SLnZ n (h₂ hγ)) hb
 
 /-- The `SL_n(ℤ)` case of `det_eq_of_mem_doubleCoset_of_le_SLnZ`. -/
 lemma det_eq_of_mem_doubleCoset_SLnZ {a b : GL (Fin n) ℚ}

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -146,31 +146,14 @@ private lemma divChain_two_of_dvd {a b : ℕ} (hab : a ∣ b) :
   isDvdChain_iff.mpr fun i j hij ↦ by
     fin_cases i <;> fin_cases j <;> simp_all
 
-/-- Determinant of an SL_n(ℤ) element embedded in GL_n(ℚ) is 1.
-
-`SpecialLinearGroup.det_mapGL` is the same fact for `GeneralLinearGroup.det`, which is
-`ℚˣ`-valued; every use here needs the `Matrix.det` of the coerced matrix, so this is the
-`Units.val` bridge rather than a second proof. -/
-private lemma det_SLnZ_eq_one {g : GL (Fin 2) ℚ} (hg : g ∈ SLnZ 2) :
-    (↑g : Matrix (Fin 2) (Fin 2) ℚ).det = 1 := by
-  obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff 2).mp hg
-  exact congrArg Units.val (SpecialLinearGroup.det_mapGL (S := ℚ) σ)
-
-/-- Elements in the same SL_n double coset have the same determinant. -/
+/-- Elements in the same SL_n double coset have the same determinant. The general fact is
+`det_eq_of_mem_doubleCoset_SLnZ`; this is its `HeckeCoset` phrasing. -/
 private lemma det_doubleCoset_eq {g₁ g₂ : posDetInt 2}
     (h : HeckeCoset.mk (SLnZ 2) (SLnZ 2) g₁ = HeckeCoset.mk (SLnZ 2) (SLnZ 2) g₂) :
     (↑(↑g₁ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
-      (↑(↑g₂ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det := by
-  rw [HeckeCoset.eq_iff] at h
-  have hg₁_mem : (g₁ : GL (Fin 2) ℚ) ∈
-      DoubleCoset.doubleCoset (g₂ : GL (Fin 2) ℚ) (SLnZ 2) (SLnZ 2) := by
-    rw [← h]; exact DoubleCoset.mem_doubleCoset_self _ _ _
-  obtain ⟨h₁, hh₁, h₂, hh₂, heq⟩ := DoubleCoset.mem_doubleCoset.mp hg₁_mem
-  have : (↑(↑g₁ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
-      (h₁ * (↑g₂ : GL (Fin 2) ℚ) * h₂).1.det := by rw [heq]
-  simp only [GeneralLinearGroup.coe_mul, Matrix.det_mul, det_SLnZ_eq_one hh₁,
-    det_SLnZ_eq_one hh₂, one_mul, mul_one] at this
-  exact this
+      (↑(↑g₂ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det :=
+  det_eq_of_mem_doubleCoset_SLnZ 2
+    (HeckeCoset.eq_iff.mp h ▸ DoubleCoset.mem_doubleCoset_self _ _ _)
 
 /-- The diagonal product of rep(diagCoset a) equals ∏ a. -/
 private lemma prod_rep_T_diag (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i) :
@@ -196,8 +179,8 @@ private lemma det_mulMap_eq (g₁ g₂ : posDetInt 2)
     (HeckeCoset.mulMap_eq_mk (SLnZ 2) (SLnZ 2) (SLnZ 2) g₁ g₂ p)
   rw [det_doubleCoset_eq h_eq]
   simp only [GeneralLinearGroup.coe_mul, Matrix.det_mul]
-  have h1 := det_SLnZ_eq_one (p.1.out.2)
-  have h2 := det_SLnZ_eq_one (p.2.out.2)
+  have h1 := det_eq_one_of_mem_SLnZ 2 (p.1.out.2)
+  have h2 := det_eq_one_of_mem_SLnZ 2 (p.2.out.2)
   rw [h1, h2]; ring
 
 /-- If `D'` appears in the support of `m(rep D₁, rep D₂)`, then the determinant of its


### PR DESCRIPTION
**Shimura, Propositions 3.30 and 3.31.** Since `Γ₀(N) ≤ SL₂(ℤ)` and `Δ₀(N) ≤ Δ`, sending a
`Γ₀(N)`-double coset to the level-one double coset of the same element is well defined, and it
is **injective on the cosets whose determinant is coprime to the level**:

```lean
noncomputable def toLevelOneCoset :
    HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) →
      HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)

theorem toLevelOneCoset_injOn_coprimeDet {a b : Delta0 N}
    (ha : CoprimeDet N a) (hb : CoprimeDet N b)
    (h : toLevelOneCoset N (HeckeCoset.mk _ _ a) = toLevelOneCoset N (HeckeCoset.mk _ _ b)) :
    HeckeCoset.mk _ _ a = HeckeCoset.mk _ _ b
```

Well-definedness (3.30) is `Γ₀(N) ≤ SL₂(ℤ)`. The content is injectivity (3.31): the level-one
double coset determines the `Γ₀(N)` one, because intersecting it with `Δ₀(N)` gives that one
back — which is exactly #2717's
`doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image`. So the whole proof is: rewrite both
sides as intersections and use the hypothesis.

This is the step that identifies the good-prime part of `R(Γ₀(N), Δ₀(N))` with the level-one
Hecke ring, and hence how `T_n` for `gcd(n, N) = 1` inherits its level-one behaviour.

## Notes on the port

* AINTLIB's bespoke `Delta0_inclusion` is Mathlib's `Submonoid.inclusion` applied to
  `Delta0_le_posDetInt`; no new definition is needed for it.
* AINTLIB's `HeckePair` bundle is Mathlib's `HeckeCoset` here, so `cosetMap` is a
  `Quotient.lift` against `HeckeCoset.eq_iff` rather than against a `dcRel`.
* `CoprimeDet` quantifies over *all* integral representatives rather than choosing one. The
  representative is unique (the entrywise cast `ℤ → ℚ` is injective), so this is equivalent and
  avoids a choice in the definition.
* No `NeZero N` anywhere: #2717's double-coset theorem does not need it, so neither does this.

## Provenance

Ported from AINTLIB [`LeanModularForms`](https://github.com/CBirkbeck/AINTLIB),
`LeanModularForms/HeckeRIngs/GLn/CongruenceHecke/Props.lean` (Chris Birkbeck) — the
`Delta0_inclusion` / `cosetMap` / `CoprimeDet` / `shimura_prop_3_31` section, i.e. the first
~90 lines of that file. The rest of `Props.lean` (Prop 3.33, the bad-prime degree and
`T_bad_mul`) is not in this PR.

Earlier parts of the same AINTLIB chapter landed in #2680 (`Δ₀(N)`, the `Γ₀(N)` Hecke triple),
#2704 (the Chinese-remainder decomposition) and #2717 (the double-coset identity this consumes).

## Roadmap

`TauCetiRoadmap/ModularForms/README.md`, **Layer 2(a)**: "Congruence level stays at `n = 2`
(Shimura §3.3; AINTLIB `GLn/CongruenceHecke/*`): the pairs `(Γ₀(N), Δ₀(N))`, `Γ₁(N)`
(`Gamma0_pair`, `Gamma1Pair.lean`), the surjection `R(SL₂(ℤ), Δ) →+* R(Γ₀(N), Δ₀(N))` of Shimura
Thm 3.35 …". This is the comparison map between the two rings' double cosets that the Thm 3.35
surjection is built on.

Roadmap: ModularForms
