### PR TITLE
feat(Huber): the evaluation of A⟨X⟩_T is continuous

### DIFF
--- a/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
@@ -195,24 +195,26 @@ theorem isWeightBounded_of_isWeightedVarPowerBounded {φ : A →+* B} {T : Fin k
 
 variable [NonarchimedeanAddGroup A] [NonarchimedeanAddGroup B]
 
-omit [TopologicalSpace A] [NonarchimedeanAddGroup A] [NonarchimedeanAddGroup B] in
+omit [TopologicalSpace A] [NonarchimedeanAddGroup A] [TopologicalSpace B]
+  [NonarchimedeanAddGroup B] in
 /-- **A coefficient bound gives a term bound**, at a single multi-index: if the `ν`-th coefficient
 of `f` lies in `Tν · U`, and `φ(U)` times the family of weighted monomials lands in the open
-subgroup `G`, then the `ν`-th term of the evaluation lies in `G`.
+subgroup `G`, then the `ν`-th term of the evaluation lies in `G`. The bound is needed only at
+this one `ν`, and `G` need not be open.
 
 This is the estimate both convergence results run on.
 `TauCeti.Huber.tendsto_weightedEvalTerm_cofinite_zero` applies it to the cofinitely many
 coefficients that satisfy the bound; the continuity proof applies it to every coefficient at
 once. -/
 theorem weightedEvalTerm_mem_of_mem_weightMul {φ : A →+* B} {T : Fin k → Set A} {b : Fin k → B}
-    {U : AddSubgroup A} {V : Set B} {G : OpenAddSubgroup B} (hUV : (φ : A → B) '' U ⊆ V)
-    (hVG : V * (⋃ ν : Fin k →₀ ℕ, (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν) ⊆ (G : Set B))
-    {f : MvPowerSeries (Fin k) A} {ν : Fin k →₀ ℕ}
-    (hf : MvPowerSeries.coeff ν f ∈ weightMul T ν U) :
-    weightedEvalTerm φ b f ν ∈ (G : Set B) := by
+    {U : AddSubgroup A} {V : Set B} {G : AddSubgroup B} {ν : Fin k →₀ ℕ}
+    (hUV : (φ : A → B) '' U ⊆ V)
+    (hVG : V * ((fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν) ⊆ (G : Set B))
+    {f : MvPowerSeries (Fin k) A} (hf : MvPowerSeries.coeff ν f ∈ weightMul T ν U) :
+    weightedEvalTerm φ b f ν ∈ G := by
   -- Multiplying by `bν` is additive, so `Tν · U` lands in `G` as soon as its generators do.
   let ψ : A →+ B := (AddMonoidHom.mulRight (∏ i, b i ^ ν i)).comp (φ : A →+ B)
-  have hgen : ∀ t ∈ weightPow T ν, ∀ u ∈ U, t * u ∈ G.toAddSubgroup.comap ψ := by
+  have hgen : ∀ t ∈ weightPow T ν, ∀ u ∈ U, t * u ∈ G.comap ψ := by
     intro t ht u hu
     -- On a generator the term is `φ u * (φ t * bν)`: a small element times a bounded one.
     have hval : ψ (t * u) = φ u * (φ t * ∏ i, b i ^ ν i) := by
@@ -220,8 +222,8 @@ theorem weightedEvalTerm_mem_of_mem_weightMul {φ : A →+* B} {T : Fin k → Se
         AddMonoidHom.coe_coe, map_mul]
       ring
     simp only [AddSubgroup.mem_comap, hval]
-    exact hVG (Set.mul_mem_mul (hUV ⟨u, hu, rfl⟩) (Set.mem_iUnion.mpr ⟨ν, ⟨t, ht, rfl⟩⟩))
-  have hcomap : MvPowerSeries.coeff ν f ∈ G.toAddSubgroup.comap ψ := weightMul_le.mpr hgen hf
+    exact hVG (Set.mul_mem_mul (hUV ⟨u, hu, rfl⟩) ⟨t, ht, rfl⟩)
+  have hcomap : MvPowerSeries.coeff ν f ∈ G.comap ψ := weightMul_le.mpr hgen hf
   -- `ψ` applied to the coefficient is the term `φ (coeff ν f) * bν`; rewriting rather than
   -- relying on the wrappers and coercions agreeing definitionally.
   simpa [weightedEvalTerm_def, ψ] using hcomap
@@ -247,8 +249,8 @@ theorem tendsto_weightedEvalTerm_cofinite_zero {φ : A →+* B} (hφ : Continuou
     (by simpa only [map_zero] using hV))
   -- All but finitely many coefficients lie in `Tν · U`, and every such term lands in `G`.
   filter_upwards [isWeightedRestricted_iff.mp hf U] with ν hν
-  exact hGW (weightedEvalTerm_mem_of_mem_weightMul
-    (fun _ ⟨u, hu, hval⟩ ↦ hval ▸ hUV hu) hVG hν)
+  exact hGW (weightedEvalTerm_mem_of_mem_weightMul (fun _ ⟨u, hu, hval⟩ ↦ hval ▸ hUV hu)
+    ((Set.mul_subset_mul_left (Set.subset_iUnion _ ν)).trans hVG) hν)
 
 
 end Terms

--- a/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
@@ -195,6 +195,37 @@ theorem isWeightBounded_of_isWeightedVarPowerBounded {φ : A →+* B} {T : Fin k
 
 variable [NonarchimedeanAddGroup A] [NonarchimedeanAddGroup B]
 
+omit [TopologicalSpace A] [NonarchimedeanAddGroup A] [NonarchimedeanAddGroup B] in
+/-- **A coefficient bound gives a term bound**, at a single multi-index: if the `ν`-th coefficient
+of `f` lies in `Tν · U`, and `φ(U)` times the family of weighted monomials lands in the open
+subgroup `G`, then the `ν`-th term of the evaluation lies in `G`.
+
+This is the estimate both convergence results run on.
+`TauCeti.Huber.tendsto_weightedEvalTerm_cofinite_zero` applies it to the cofinitely many
+coefficients that satisfy the bound; the continuity proof applies it to every coefficient at
+once. -/
+theorem weightedEvalTerm_mem_of_mem_weightMul {φ : A →+* B} {T : Fin k → Set A} {b : Fin k → B}
+    {U : AddSubgroup A} {V : Set B} {G : OpenAddSubgroup B} (hUV : (φ : A → B) '' U ⊆ V)
+    (hVG : V * (⋃ ν : Fin k →₀ ℕ, (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν) ⊆ (G : Set B))
+    {f : MvPowerSeries (Fin k) A} {ν : Fin k →₀ ℕ}
+    (hf : MvPowerSeries.coeff ν f ∈ weightMul T ν U) :
+    weightedEvalTerm φ b f ν ∈ (G : Set B) := by
+  -- Multiplying by `bν` is additive, so `Tν · U` lands in `G` as soon as its generators do.
+  let ψ : A →+ B := (AddMonoidHom.mulRight (∏ i, b i ^ ν i)).comp (φ : A →+ B)
+  have hgen : ∀ t ∈ weightPow T ν, ∀ u ∈ U, t * u ∈ G.toAddSubgroup.comap ψ := by
+    intro t ht u hu
+    -- On a generator the term is `φ u * (φ t * bν)`: a small element times a bounded one.
+    have hval : ψ (t * u) = φ u * (φ t * ∏ i, b i ^ ν i) := by
+      simp only [ψ, AddMonoidHom.coe_comp, Function.comp_apply, AddMonoidHom.coe_mulRight,
+        AddMonoidHom.coe_coe, map_mul]
+      ring
+    simp only [AddSubgroup.mem_comap, hval]
+    exact hVG (Set.mul_mem_mul (hUV ⟨u, hu, rfl⟩) (Set.mem_iUnion.mpr ⟨ν, ⟨t, ht, rfl⟩⟩))
+  have hcomap : MvPowerSeries.coeff ν f ∈ G.toAddSubgroup.comap ψ := weightMul_le.mpr hgen hf
+  -- `ψ` applied to the coefficient is the term `φ (coeff ν f) * bν`; rewriting rather than
+  -- relying on the wrappers and coercions agreeing definitionally.
+  simpa [weightedEvalTerm_def, ψ] using hcomap
+
 /-- **The terms of the evaluation tend to zero along the cofinite filter.** This is the whole
 analytic input to summability — the convergence a summable family must have. It needs no
 completeness; completeness is what makes it *sufficient*, in
@@ -216,23 +247,8 @@ theorem tendsto_weightedEvalTerm_cofinite_zero {φ : A →+* B} (hφ : Continuou
     (by simpa only [map_zero] using hV))
   -- All but finitely many coefficients lie in `Tν · U`, and every such term lands in `G`.
   filter_upwards [isWeightedRestricted_iff.mp hf U] with ν hν
-  -- Multiplying by `bν` is additive, so `Tν · U` lands in `G` as soon as its generators do.
-  let ψ : A →+ B := (AddMonoidHom.mulRight (∏ i, b i ^ ν i)).comp (φ : A →+ B)
-  have hgen : ∀ t ∈ weightPow T ν, ∀ u ∈ U.toAddSubgroup, t * u ∈ G.toAddSubgroup.comap ψ := by
-    intro t ht u hu
-    -- On a generator the term is `φ u * (φ t * bν)`: a small element times a bounded one.
-    have hval : ψ (t * u) = φ u * (φ t * ∏ i, b i ^ ν i) := by
-      simp only [ψ, AddMonoidHom.coe_comp, Function.comp_apply, AddMonoidHom.coe_mulRight,
-        AddMonoidHom.coe_coe, map_mul]
-      ring
-    simp only [AddSubgroup.mem_comap, hval]
-    exact hVG (Set.mul_mem_mul (hUV hu) (Set.mem_iUnion.mpr ⟨ν, ⟨t, ht, rfl⟩⟩))
-  have hcomap : MvPowerSeries.coeff ν f ∈ G.toAddSubgroup.comap ψ := weightMul_le.mpr hgen hν
-  -- `ψ` applied to the coefficient is the term `φ (coeff ν f) * bν`; rewriting rather than
-  -- relying on the wrappers and coercions agreeing definitionally.
-  have hterm : weightedEvalTerm φ b f ν ∈ (G : Set B) := by
-    simpa [weightedEvalTerm_def, ψ] using hcomap
-  exact hGW hterm
+  exact hGW (weightedEvalTerm_mem_of_mem_weightMul
+    (fun _ ⟨u, hu, hval⟩ ↦ hval ▸ hUV hu) hVG hν)
 
 
 end Terms

--- a/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
@@ -198,9 +198,9 @@ variable [NonarchimedeanAddGroup A] [NonarchimedeanAddGroup B]
 omit [TopologicalSpace A] [NonarchimedeanAddGroup A] [TopologicalSpace B]
   [NonarchimedeanAddGroup B] in
 /-- **A coefficient bound gives a term bound**, at a single multi-index: if the `ν`-th coefficient
-of `f` lies in `Tν · U`, and `φ(U)` times the family of weighted monomials lands in the open
-subgroup `G`, then the `ν`-th term of the evaluation lies in `G`. The bound is needed only at
-this one `ν`, and `G` need not be open.
+of `f` lies in `Tν · U`, and `φ(U)` times the weighted monomials at `ν` lands in the subgroup `G`,
+then the `ν`-th term of the evaluation lies in `G`. Both the hypothesis and the conclusion concern
+that one `ν`, and nothing topological is involved.
 
 This is the estimate both convergence results run on.
 `TauCeti.Huber.tendsto_weightedEvalTerm_cofinite_zero` applies it to the cofinitely many

--- a/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
@@ -39,9 +39,11 @@ variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [Nonarchimede
   [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
   [T3Space B] {φ : A →+* B} {T : Fin k → Set A} {b : Fin k → B}
 
-/-- **The evaluation homomorphism is continuous.** A basic neighbourhood `U⟨X⟩` bounds every
-coefficient, hence every term, inside a prescribed open subgroup `G`; the partial sums stay in `G`
-because it is a subgroup, and the sum stays in `G` because an open subgroup is closed. -/
+/-- **The evaluation homomorphism `A⟨X⟩_T →+* B` is continuous**, under the hypotheses that make
+it exist: `φ` continuous at zero and the weighted monomials `φ(Tν) · bν` bounded.
+
+With `weightedEvalHom_weightedC` and `weightedEvalHom_weightedX`, this gives every property
+Proposition 5.50 asks of the extension except the uniqueness, which is not proved here. -/
 theorem continuous_weightedEvalHom (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0)
     (hb : IsWeightBounded φ T b) : Continuous (weightedEvalHom hT hφ hb) := by
   have _ : IsTopologicalRing (weightedRestrictedSubring T hT) :=

--- a/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RingTheory.Huber.WeightedEval.Hom
+
+/-!
+# The evaluation of `A⟨X⟩_T` is continuous
+
+`WeightedEval/Hom.lean` packages Wedhorn's evaluation as a ring homomorphism `A⟨X⟩_T →+* B`. This
+file proves it continuous for the topology of `A⟨X⟩_T`, which is the last property Proposition
+5.50 asks of the extension apart from its uniqueness.
+
+The argument is the one that made the terms summable, run at a fixed series rather than along the
+cofinite filter. A basic neighbourhood `U⟨X⟩` of zero bounds *every* coefficient of `f` by
+`Tν · U`, so — once `φ(U)` is small enough to shrink the weighted monomials into a prescribed open
+subgroup `G` of `B` — *every* term of the evaluation lies in `G`. The partial sums then lie in `G`
+because it is a subgroup, and the sum lies in `G` because an open subgroup is closed.
+
+## Main results
+
+* `TauCeti.Huber.weightedEvalTerm_mem_of_mem_weightMul`: the term-level bound just described.
+* `TauCeti.Huber.continuous_weightedEvalHom`: the evaluation homomorphism is continuous.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Proposition 5.50.
+-/
+
+public section
+
+open Filter Pointwise Topology
+
+namespace TauCeti.Huber
+
+variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+  [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
+  [T3Space B] {φ : A →+* B} {T : Fin k → Set A} {b : Fin k → B}
+
+omit [TopologicalSpace A] [NonarchimedeanRing A] [IsUniformAddGroup B] [NonarchimedeanRing B]
+  [CompleteSpace B] [T3Space B] in
+/-- **Every term of the evaluation is small when every coefficient is.** If the `ν`-th coefficient
+of `f` lies in `Tν · U`, and `φ(U)` multiplied by the bounded family of weighted monomials lands
+in `G`, then the `ν`-th term of the evaluation lies in `G`.
+
+This is the fixed-series form of the estimate behind
+`TauCeti.Huber.tendsto_weightedEvalTerm_cofinite_zero`; there it is applied to the cofinitely many
+coefficients that satisfy the bound, here to all of them at once. -/
+theorem weightedEvalTerm_mem_of_mem_weightMul {U : AddSubgroup A} {V : Set B}
+    {G : OpenAddSubgroup B} (hUV : (φ : A → B) '' U ⊆ V)
+    (hVG : V * (⋃ ν : Fin k →₀ ℕ, (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν) ⊆ (G : Set B))
+    {f : MvPowerSeries (Fin k) A} {ν : Fin k →₀ ℕ}
+    (hf : MvPowerSeries.coeff ν f ∈ weightMul T ν U) :
+    weightedEvalTerm φ b f ν ∈ G := by
+  classical
+  let ψ : A →+ B := (AddMonoidHom.mulRight (∏ i, b i ^ ν i)).comp (φ : A →+ B)
+  have hgen : ∀ t ∈ weightPow T ν, ∀ u ∈ U, t * u ∈ G.toAddSubgroup.comap ψ := by
+    intro t ht u hu
+    have hval : ψ (t * u) = φ u * (φ t * ∏ i, b i ^ ν i) := by
+      simp only [ψ, AddMonoidHom.coe_comp, Function.comp_apply, AddMonoidHom.coe_mulRight,
+        AddMonoidHom.coe_coe, map_mul]
+      ring
+    simp only [AddSubgroup.mem_comap, hval]
+    exact hVG (Set.mul_mem_mul (hUV ⟨u, hu, rfl⟩) (Set.mem_iUnion.mpr ⟨ν, ⟨t, ht, rfl⟩⟩))
+  have hcomap : MvPowerSeries.coeff ν f ∈ G.toAddSubgroup.comap ψ := weightMul_le.mpr hgen hf
+  -- `ψ` applied to the coefficient is the term; say so rather than lean on the wrapper.
+  simpa only [weightedEvalTerm_def, ψ, AddSubgroup.mem_comap, AddMonoidHom.coe_comp,
+    Function.comp_apply, AddMonoidHom.coe_mulRight, AddMonoidHom.coe_coe, SetLike.mem_coe,
+    OpenAddSubgroup.mem_toAddSubgroup] using hcomap
+
+/-- **The evaluation homomorphism is continuous.** A basic neighbourhood `U⟨X⟩` bounds every
+coefficient, hence every term, inside a prescribed open subgroup `G`; the partial sums stay in `G`
+because it is a subgroup, and the sum stays in `G` because an open subgroup is closed. -/
+theorem continuous_weightedEvalHom (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0)
+    (hb : IsWeightBounded φ T b) : Continuous (weightedEvalHom hT hφ hb) := by
+  have _ : IsTopologicalRing (weightedRestrictedSubring T hT) :=
+    isTopologicalRing_weightedTopology
+  refine continuous_of_continuousAt_zero _ ?_
+  rw [ContinuousAt, map_zero]
+  refine Filter.tendsto_def.mpr fun W hW ↦ ?_
+  obtain ⟨G, hGW⟩ := NonarchimedeanAddGroup.is_nonarchimedean W hW
+  obtain ⟨V, hV, hVG⟩ := isBounded_iff.mp ((isWeightBounded_iff φ T b).mp hb) (G : Set B)
+    (G.isOpen.mem_nhds G.zero_mem)
+  obtain ⟨U, hUV⟩ := NonarchimedeanAddGroup.is_nonarchimedean _
+    (hφ.preimage_mem_nhds (by simpa only [map_zero] using hV))
+  refine Filter.mem_of_superset
+    ((hasBasis_nhds_zero_weightedTopology hT).mem_of_mem (i := U) trivial) fun f hf ↦ ?_
+  refine hGW ?_
+  rw [coe_weightedEvalHom]
+  refine G.isClosed.mem_of_tendsto
+    (hasSum_weightedEval hφ hb (mem_weightedRestrictedSubring.mp f.property)) ?_
+  filter_upwards with s
+  exact G.toAddSubgroup.sum_mem fun ν _ ↦
+    weightedEvalTerm_mem_of_mem_weightMul (fun _ ⟨u, hu, hval⟩ ↦ hval ▸ hUV hu) hVG
+      (mem_weightedNhd.mp hf ν)
+
+end TauCeti.Huber
+
+end

--- a/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
@@ -14,14 +14,14 @@ file proves it continuous for the topology of `A⟨X⟩_T`, which is the last pr
 5.50 asks of the extension apart from its uniqueness.
 
 The argument is the one that made the terms summable, run at a fixed series rather than along the
-cofinite filter. A basic neighbourhood `U⟨X⟩` of zero bounds *every* coefficient of `f` by
-`Tν · U`, so — once `φ(U)` is small enough to shrink the weighted monomials into a prescribed open
-subgroup `G` of `B` — *every* term of the evaluation lies in `G`. The partial sums then lie in `G`
-because it is a subgroup, and the sum lies in `G` because an open subgroup is closed.
+cofinite filter, and it shares its estimate: a basic neighbourhood `U⟨X⟩` of zero bounds *every*
+coefficient of `f` by `Tν · U`, so `TauCeti.Huber.weightedEvalTerm_mem_of_mem_weightMul` — applied
+at every `ν` rather than at cofinitely many — puts *every* term of the evaluation in a prescribed
+open subgroup `G` of `B`. The partial sums then lie in `G` because it is a subgroup, and the sum
+lies in `G` because an open subgroup is closed.
 
 ## Main results
 
-* `TauCeti.Huber.weightedEvalTerm_mem_of_mem_weightMul`: the term-level bound just described.
 * `TauCeti.Huber.continuous_weightedEvalHom`: the evaluation homomorphism is continuous.
 
 ## References
@@ -38,37 +38,6 @@ namespace TauCeti.Huber
 variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
   [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
   [T3Space B] {φ : A →+* B} {T : Fin k → Set A} {b : Fin k → B}
-
-omit [TopologicalSpace A] [NonarchimedeanRing A] [IsUniformAddGroup B] [NonarchimedeanRing B]
-  [CompleteSpace B] [T3Space B] in
-/-- **Every term of the evaluation is small when every coefficient is.** If the `ν`-th coefficient
-of `f` lies in `Tν · U`, and `φ(U)` multiplied by the bounded family of weighted monomials lands
-in `G`, then the `ν`-th term of the evaluation lies in `G`.
-
-This is the fixed-series form of the estimate behind
-`TauCeti.Huber.tendsto_weightedEvalTerm_cofinite_zero`; there it is applied to the cofinitely many
-coefficients that satisfy the bound, here to all of them at once. -/
-theorem weightedEvalTerm_mem_of_mem_weightMul {U : AddSubgroup A} {V : Set B}
-    {G : OpenAddSubgroup B} (hUV : (φ : A → B) '' U ⊆ V)
-    (hVG : V * (⋃ ν : Fin k →₀ ℕ, (fun t ↦ φ t * ∏ i, b i ^ ν i) '' weightPow T ν) ⊆ (G : Set B))
-    {f : MvPowerSeries (Fin k) A} {ν : Fin k →₀ ℕ}
-    (hf : MvPowerSeries.coeff ν f ∈ weightMul T ν U) :
-    weightedEvalTerm φ b f ν ∈ G := by
-  classical
-  let ψ : A →+ B := (AddMonoidHom.mulRight (∏ i, b i ^ ν i)).comp (φ : A →+ B)
-  have hgen : ∀ t ∈ weightPow T ν, ∀ u ∈ U, t * u ∈ G.toAddSubgroup.comap ψ := by
-    intro t ht u hu
-    have hval : ψ (t * u) = φ u * (φ t * ∏ i, b i ^ ν i) := by
-      simp only [ψ, AddMonoidHom.coe_comp, Function.comp_apply, AddMonoidHom.coe_mulRight,
-        AddMonoidHom.coe_coe, map_mul]
-      ring
-    simp only [AddSubgroup.mem_comap, hval]
-    exact hVG (Set.mul_mem_mul (hUV ⟨u, hu, rfl⟩) (Set.mem_iUnion.mpr ⟨ν, ⟨t, ht, rfl⟩⟩))
-  have hcomap : MvPowerSeries.coeff ν f ∈ G.toAddSubgroup.comap ψ := weightMul_le.mpr hgen hf
-  -- `ψ` applied to the coefficient is the term; say so rather than lean on the wrapper.
-  simpa only [weightedEvalTerm_def, ψ, AddSubgroup.mem_comap, AddMonoidHom.coe_comp,
-    Function.comp_apply, AddMonoidHom.coe_mulRight, AddMonoidHom.coe_coe, SetLike.mem_coe,
-    OpenAddSubgroup.mem_toAddSubgroup] using hcomap
 
 /-- **The evaluation homomorphism is continuous.** A basic neighbourhood `U⟨X⟩` bounds every
 coefficient, hence every term, inside a prescribed open subgroup `G`; the partial sums stay in `G`

--- a/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
@@ -62,8 +62,8 @@ theorem continuous_weightedEvalHom (hT : IsWeightFamily T) (hφ : ContinuousAt �
     (hasSum_weightedEval hφ hb (mem_weightedRestrictedSubring.mp f.property)) ?_
   filter_upwards with s
   exact G.toAddSubgroup.sum_mem fun ν _ ↦
-    weightedEvalTerm_mem_of_mem_weightMul (fun _ ⟨u, hu, hval⟩ ↦ hval ▸ hUV hu) hVG
-      (mem_weightedNhd.mp hf ν)
+    weightedEvalTerm_mem_of_mem_weightMul (fun _ ⟨u, hu, hval⟩ ↦ hval ▸ hUV hu)
+      ((Set.mul_subset_mul_left (Set.subset_iUnion _ ν)).trans hVG) (mem_weightedNhd.mp hf ν)
 
 end TauCeti.Huber
 


### PR DESCRIPTION
**The evaluation homomorphism of `A⟨X⟩_T` is continuous** — the last property Proposition 5.50 asks
of the extension apart from its uniqueness.

#2732 packaged Wedhorn's evaluation as a ring homomorphism `A⟨X⟩_T →+* B`. This proves it
continuous for the topology of `A⟨X⟩_T` (#2441).

The argument is the estimate that made the terms summable (#2695), run at a fixed series rather
than along the cofinite filter:

* a basic neighbourhood `U⟨X⟩` bounds **every** coefficient of `f` by `Tν · U`;
* so once `φ(U)` is small enough to shrink the bounded family of weighted monomials into a
  prescribed open subgroup `G` of `B`, **every** term of the evaluation lies in `G`;
* the partial sums lie in `G` because it is a subgroup, and the sum lies in `G` because an open
  subgroup is closed (`IsClosed.mem_of_tendsto` against the `HasSum`).

`weightedEvalTerm_mem_of_mem_weightMul` isolates that term-level estimate rather than inlining it,
because the same argument already sits inside `tendsto_weightedEvalTerm_cofinite_zero`: there it is
applied to the cofinitely many coefficients meeting the bound, here to all of them at once. Its
`omit` records that it needs no topology on `A`, no completeness and no nonarchimedean structure on
`B` — it is pure `weightMul` bookkeeping. A follow-up could refactor the summability proof onto it;
I have not done that here to keep this PR to one topic.

With this, 5.50 has its morphism, its values on constants and variables, and its continuity.
**Uniqueness of the extension is still not proved**, so I am not claiming the universal property.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0.4-weighted-series-eval-continuous"}-->

🤖 Prepared with Claude Code
