### PR TITLE
feat: multiply finite regular subcomodules

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Regular.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Regular.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.RingTheory.Bialgebra.TensorProduct
 public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Basic
+public import TauCeti.Algebra.Coalgebra.Comodule.TensorProduct
 public import TauCeti.Algebra.Coalgebra.Comodule.Trivial
 
 /-!
@@ -13,7 +15,8 @@ public import TauCeti.Algebra.Coalgebra.Comodule.Trivial
 This file packages the regular right comodule of a coalgebra as a bundled object of
 `ComoduleCat`, and, when the coalgebra is finitely generated as a module, as an object of
 `FGComoduleCat`. It also records the canonical morphism from the group-like comodule on
-the rank-one free module `R` into the regular comodule.
+the rank-one free module `R` into the regular comodule, and multiplication of a bialgebra
+as a morphism from the tensor square of its regular comodule.
 
 This is Layer 1 infrastructure for the Tau Ceti reductive-groups roadmap target
 "Comodules over a coalgebra/Hopf algebra", specifically the regular-representation part of
@@ -25,14 +28,16 @@ the finitely generated comodule category.
 * `TauCeti.Comodule.Hom.groupLikeToRegular`: the map `r ↦ r • g` from the group-like
   comodule on `R` into the regular comodule.
 * `TauCeti.Comodule.Hom.trivialToRegular`: the bialgebraic special case `g = 1`.
+* `TauCeti.Comodule.Hom.regularMul`: bialgebra multiplication as a morphism from the
+  tensor square of the regular comodule.
 * `TauCeti.FGComoduleCat.regular`: the regular comodule as a finitely generated comodule,
   when the underlying coalgebra is finitely generated as an `R`-module.
 
 ## References
 
 This is the standard regular right comodule of a coalgebra; see Sweedler, *Hopf Algebras*,
-Chapter 2. It reuses Mathlib's `GroupLike` API from
-`Mathlib.RingTheory.Bialgebra.GroupLike`.
+Chapter 2. The group-like morphisms reuse Mathlib's `GroupLike` API, and the multiplication
+morphism reuses `Bialgebra.mulCoalgHom`.
 -/
 
 public section
@@ -116,6 +121,62 @@ theorem trivialToRegular_apply (r : R) :
     exact LinearMap.congr_fun (trivialToRegular_toLinearMap (R := R) (C := C)) r
 
 end Bialgebra
+
+section Multiplication
+
+variable {R : Type u} {H : Type v} [CommSemiring R] [Semiring H] [Bialgebra R H]
+
+attribute [local instance] Comodule.tensor
+
+/-- Multiplication of a bialgebra, regarded as a morphism from the tensor square of its
+regular right comodule to the regular right comodule. -/
+noncomputable def regularMul : Hom R H (H ⊗[R] H) H where
+  toLinearMap := LinearMap.mul' R H
+  map_coact := by
+    apply TensorProduct.ext'
+    intro x y
+    simp only [LinearMap.comp_apply, LinearMap.mul'_apply, Comodule.tensor_coact,
+      Comodule.tensorCoact_tmul, Comodule.instSelf_coact]
+    have combine_mul (a b : H ⊗[R] H) :
+        TensorProduct.map (LinearMap.mul' R H) LinearMap.id
+            (Comodule.tensorCombine (R := R) (C := H) (M := H) (N := H) (a ⊗ₜ[R] b)) =
+          TensorProduct.map (LinearMap.mul' R H) (LinearMap.mul' R H)
+            (TensorProduct.tensorTensorTensorComm R H H H H (a ⊗ₜ[R] b)) := by
+      induction a using TensorProduct.induction_on with
+      | zero => simp
+      | add a₁ a₂ ha₁ ha₂ =>
+        simp only [TensorProduct.add_tmul, map_add, ha₁, ha₂]
+      | tmul a₁ a₂ =>
+        induction b using TensorProduct.induction_on with
+        | zero => simp
+        | add b₁ b₂ hb₁ hb₂ =>
+          simp only [TensorProduct.tmul_add, map_add, hb₁, hb₂]
+        | tmul b₁ b₂ => simp
+    rw [combine_mul]
+    convert CoalgHomClass.map_comp_comul_apply (Bialgebra.mulCoalgHom R H) (x ⊗ₜ[R] y)
+      using 1 <;> rfl
+
+private theorem regularMul_toLinearMap_def :
+    (regularMul (R := R) (H := H)).toLinearMap = LinearMap.mul' R H :=
+  rfl
+
+/-- The underlying linear map of regular-comodule multiplication is bialgebra
+multiplication. -/
+@[simp]
+theorem regularMul_toLinearMap :
+    (regularMul (R := R) (H := H)).toLinearMap = LinearMap.mul' R H :=
+  by exact regularMul_toLinearMap_def
+
+private theorem regularMul_tmul_def (x y : H) :
+    regularMul (R := R) (H := H) (x ⊗ₜ[R] y) = x * y :=
+  rfl
+
+/-- Regular-comodule multiplication sends a pure tensor to the product of its factors. -/
+@[simp]
+theorem regularMul_tmul (x y : H) : regularMul (R := R) (H := H) (x ⊗ₜ[R] y) = x * y :=
+  by exact regularMul_tmul_def x y
+
+end Multiplication
 
 end Hom
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
@@ -24,6 +24,8 @@ subcomodules to be usable as comodules in their own right.
 * `TauCeti.Subcomodule.inducedCoact`: the coaction on the subtype of a subcomodule.
 * `TauCeti.Subcomodule.instComodule`: the induced right-comodule structure.
 * `TauCeti.Subcomodule.subtype`: the inclusion as a comodule morphism.
+* `TauCeti.Comodule.Hom.codRestrict`: a comodule morphism corestricted to a
+  subcomodule containing its image.
 
 ## References
 
@@ -231,5 +233,57 @@ theorem subtype_apply (n : N) : Subcomodule.subtype N n = n :=
   (rfl)
 
 end Subcomodule
+
+namespace Comodule.Hom
+
+variable {N : Type*}
+variable [AddCommMonoid N] [Module R N] [Comodule R C N]
+
+/-- Corestrict a comodule morphism to a subcomodule containing its image. -/
+@[expose]
+noncomputable def codRestrict (f : Hom R C M N) (P : Subcomodule R C N)
+    (h : ∀ m, f m ∈ P) : Hom R C M P :=
+  let g : M →ₗ[R] P :=
+    { toFun := fun m ↦ ⟨f m, h m⟩
+      map_add' := fun x y ↦ Subtype.ext (map_add f.toLinearMap x y)
+      map_smul' := fun r x ↦ Subtype.ext (map_smul f.toLinearMap r x) }
+  { toLinearMap := g
+    map_coact := by
+      ext m
+      apply Module.Flat.rTensor_preserves_injective_linearMap
+        (SMulMemClass.subtype P) Subtype.val_injective
+      simp only [LinearMap.comp_apply]
+      calc
+        (SMulMemClass.subtype P).rTensor C
+            (TensorProduct.map g LinearMap.id
+              (Comodule.coact (R := R) (C := C) (M := M) m)) =
+          TensorProduct.map f.toLinearMap LinearMap.id
+            (Comodule.coact (R := R) (C := C) (M := M) m) := by
+              induction Comodule.coact (R := R) (C := C) (M := M) m using
+                TensorProduct.induction_on with
+              | zero => simp
+              | add x y hx hy => simpa only [map_add] using congrArg₂ (· + ·) hx hy
+              | tmul n c => rfl
+        _ = Comodule.coact (R := R) (C := C) (M := N) (f m) :=
+          f.map_coact_apply m
+        _ = (SMulMemClass.subtype P).rTensor C
+            (Comodule.coact (R := R) (C := C) (M := P) ⟨f m, h m⟩) :=
+          (Subcomodule.subtype_rTensor_coact P ⟨f m, h m⟩).symm }
+
+/-- The underlying linear map of a corestricted comodule morphism is the ordinary linear
+corestriction. -/
+@[simp]
+theorem codRestrict_toLinearMap (f : Hom R C M N) (P : Subcomodule R C N)
+    (h : ∀ m, f m ∈ P) :
+    (f.codRestrict P h).toLinearMap = f.toLinearMap.codRestrict P.toSubmodule h :=
+  LinearMap.ext fun _ ↦ rfl
+
+/-- Corestricting a comodule morphism changes only its codomain. -/
+@[simp]
+theorem codRestrict_apply (f : Hom R C M N) (P : Subcomodule R C N)
+    (h : ∀ m, f m ∈ P) (m : M) : (f.codRestrict P h m : N) = f m :=
+  rfl
+
+end Comodule.Hom
 
 end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
@@ -240,7 +240,6 @@ variable {N : Type*}
 variable [AddCommMonoid N] [Module R N] [Comodule R C N]
 
 /-- Corestrict a comodule morphism to a subcomodule containing its image. -/
-@[expose]
 noncomputable def codRestrict (f : Hom R C M N) (P : Subcomodule R C N)
     (h : ∀ m, f m ∈ P) : Hom R C M P :=
   let g : M →ₗ[R] P :=
@@ -270,19 +269,28 @@ noncomputable def codRestrict (f : Hom R C M N) (P : Subcomodule R C N)
             (Comodule.coact (R := R) (C := C) (M := P) ⟨f m, h m⟩) :=
           (Subcomodule.subtype_rTensor_coact P ⟨f m, h m⟩).symm }
 
+private theorem codRestrict_toLinearMap_def (f : Hom R C M N) (P : Subcomodule R C N)
+    (h : ∀ m, f m ∈ P) :
+    (f.codRestrict P h).toLinearMap = f.toLinearMap.codRestrict P.toSubmodule h :=
+  LinearMap.ext fun _ ↦ rfl
+
+private theorem codRestrict_apply_def (f : Hom R C M N) (P : Subcomodule R C N)
+    (h : ∀ m, f m ∈ P) (m : M) : (f.codRestrict P h m : N) = f m :=
+  rfl
+
 /-- The underlying linear map of a corestricted comodule morphism is the ordinary linear
 corestriction. -/
 @[simp]
 theorem codRestrict_toLinearMap (f : Hom R C M N) (P : Subcomodule R C N)
     (h : ∀ m, f m ∈ P) :
     (f.codRestrict P h).toLinearMap = f.toLinearMap.codRestrict P.toSubmodule h :=
-  LinearMap.ext fun _ ↦ rfl
+  by exact codRestrict_toLinearMap_def f P h
 
 /-- Corestricting a comodule morphism changes only its codomain. -/
 @[simp]
 theorem codRestrict_apply (f : Hom R C M N) (P : Subcomodule R C N)
     (h : ∀ m, f m ∈ P) (m : M) : (f.codRestrict P h m : N) = f m :=
-  rfl
+  by exact codRestrict_apply_def f P h m
 
 end Comodule.Hom
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
@@ -258,11 +258,8 @@ noncomputable def codRestrict (f : Hom R C M N) (P : Subcomodule R C N)
               (Comodule.coact (R := R) (C := C) (M := M) m)) =
           TensorProduct.map f.toLinearMap LinearMap.id
             (Comodule.coact (R := R) (C := C) (M := M) m) := by
-              induction Comodule.coact (R := R) (C := C) (M := M) m using
-                TensorProduct.induction_on with
-              | zero => simp
-              | add x y hx hy => simpa only [map_add] using congrArg₂ (· + ·) hx hy
-              | tmul n c => rfl
+              rw [LinearMap.rTensor_def, TensorProduct.map_map]
+              rfl
         _ = Comodule.coact (R := R) (C := C) (M := N) (f m) :=
           f.map_coact_apply m
         _ = (SMulMemClass.subtype P).rTensor C
@@ -291,6 +288,15 @@ theorem codRestrict_toLinearMap (f : Hom R C M N) (P : Subcomodule R C N)
 theorem codRestrict_apply (f : Hom R C M N) (P : Subcomodule R C N)
     (h : ∀ m, f m ∈ P) (m : M) : (f.codRestrict P h m : N) = f m :=
   by exact codRestrict_apply_def f P h m
+
+/-- Composing a corestricted comodule morphism with the subcomodule inclusion recovers the
+original morphism. -/
+@[simp]
+theorem subtype_comp_codRestrict (f : Hom R C M N) (P : Subcomodule R C N)
+    (h : ∀ m, f m ∈ P) :
+    Comodule.Hom.comp (Subcomodule.subtype P) (f.codRestrict P h) = f := by
+  ext m
+  simp
 
 end Comodule.Hom
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.TensorProduct.Submodule
+public import Mathlib.RingTheory.Bialgebra.TensorProduct
+public import Mathlib.RingTheory.TensorProduct.Finite
+public import TauCeti.Algebra.Coalgebra.Comodule.TensorProduct
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Finite
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Induced
+
+/-!
+# Multiplication of regular subcomodules
+
+For a bialgebra `H`, multiplication is a morphism from the tensor square of the regular
+right comodule to the regular right comodule. Consequently, if `N` and `P` are
+subcomodules of the regular comodule and a third subcomodule `Q` contains all products
+`n * p`, multiplication corestricts to a comodule morphism `N ⊗ P ⟶ Q`.
+
+When `H` is free over the base semiring and `N` and `P` are finite, the products of their
+elements lie in some finite regular subcomodule. This packages the multiplication map needed
+to compare tensor-compatible natural transformations on finite regular subcomodules.
+
+## Main declarations
+
+* `TauCeti.Comodule.Hom.regularMul`: multiplication as a morphism from the tensor square
+  of the regular comodule.
+* `TauCeti.Subcomodule.mulHom`: multiplication corestricted to a containing regular
+  subcomodule.
+* `TauCeti.Subcomodule.exists_finite_mul_le`: two finite regular subcomodules have all
+  their pairwise products in a third finite regular subcomodule.
+
+## References
+
+The regular-comodule multiplication is the coalgebra-homomorphism part of the bialgebra
+axioms; see Sweedler, *Hopf Algebras*, Chapter 2. The finite containment argument uses the
+finite-subcomodule theorem from the same chapter.
+
+This advances the Layer 1 Tannakian reconstruction milestone of the reductive-groups
+roadmap, `ReductiveGroups/README.md` in TauCetiRoadmap: tensor naturality applied to these
+multiplication morphisms supplies the multiplicativity law for the reconstructed point.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v
+
+namespace Comodule.Hom
+
+variable {R : Type u} {H : Type v}
+variable [CommSemiring R] [Semiring H] [Bialgebra R H]
+
+attribute [local instance] Comodule.tensor
+
+/-- Multiplication of a bialgebra, regarded as a morphism from the tensor square of its
+regular right comodule to the regular right comodule. -/
+@[expose]
+noncomputable def regularMul : Hom R H (H ⊗[R] H) H where
+  toLinearMap := LinearMap.mul' R H
+  map_coact := by
+    apply TensorProduct.ext'
+    intro x y
+    simp only [LinearMap.comp_apply, LinearMap.mul'_apply]
+    change TensorProduct.map (LinearMap.mul' R H) LinearMap.id
+        (Comodule.tensorCoact (R := R) (C := H) (M := H) (N := H) (x ⊗ₜ[R] y)) =
+      Coalgebra.comul (R := R) (A := H) (x * y)
+    rw [Comodule.tensorCoact_tmul]
+    have combine_mul (a b : H ⊗[R] H) :
+        TensorProduct.map (LinearMap.mul' R H) LinearMap.id
+            (Comodule.tensorCombine (R := R) (C := H) (M := H) (N := H) (a ⊗ₜ[R] b)) =
+          TensorProduct.map (LinearMap.mul' R H) (LinearMap.mul' R H)
+            (TensorProduct.tensorTensorTensorComm R H H H H (a ⊗ₜ[R] b)) := by
+      induction a using TensorProduct.induction_on with
+      | zero => simp
+      | add a₁ a₂ ha₁ ha₂ =>
+        simp only [TensorProduct.add_tmul, map_add, ha₁, ha₂]
+      | tmul a₁ a₂ =>
+        induction b using TensorProduct.induction_on with
+        | zero => simp
+        | add b₁ b₂ hb₁ hb₂ =>
+          simp only [TensorProduct.tmul_add, map_add, hb₁, hb₂]
+        | tmul b₁ b₂ => simp
+    rw [combine_mul]
+    have h := CoalgHomClass.map_comp_comul_apply (Bialgebra.mulCoalgHom R H) (x ⊗ₜ[R] y)
+    change TensorProduct.map (LinearMap.mul' R H) (LinearMap.mul' R H)
+        (TensorProduct.tensorTensorTensorComm R H H H H
+          (Coalgebra.comul (R := R) (A := H) x ⊗ₜ[R]
+            Coalgebra.comul (R := R) (A := H) y)) =
+      Coalgebra.comul (R := R) (A := H) (x * y) at h
+    exact h
+
+/-- The underlying linear map of regular-comodule multiplication is bialgebra
+multiplication. -/
+@[simp]
+theorem regularMul_toLinearMap :
+    (regularMul (R := R) (H := H)).toLinearMap = LinearMap.mul' R H :=
+  rfl
+
+/-- Regular-comodule multiplication sends a pure tensor to the product of its factors. -/
+@[simp]
+theorem regularMul_tmul (x y : H) : regularMul (R := R) (H := H) (x ⊗ₜ[R] y) = x * y :=
+  rfl
+
+end Comodule.Hom
+
+namespace Subcomodule
+
+variable {R : Type u} {H : Type v}
+variable [CommSemiring R] [Semiring H] [Bialgebra R H]
+
+attribute [local instance] Comodule.tensor
+
+/-- Multiplication from `N ⊗ P`, corestricted to a regular subcomodule `Q` containing
+every product `n * p`. -/
+@[expose]
+noncomputable def mulHom (N P Q : Subcomodule R H H)
+    [Module.Flat R H]
+    (h : ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q) :
+    Comodule.Hom R H (N ⊗[R] P) Q :=
+  let ambient : Comodule.Hom R H (N ⊗[R] P) H :=
+    (Comodule.Hom.regularMul (R := R) (H := H)).comp
+      (Comodule.Hom.tensorMap (Subcomodule.subtype N) (Subcomodule.subtype P))
+  ambient.codRestrict Q (by
+    intro x
+    induction x using TensorProduct.induction_on with
+    | zero => exact Q.toSubmodule.zero_mem
+    | add x y hx hy =>
+      change ambient.toLinearMap (x + y) ∈ Q
+      rw [map_add]
+      exact Q.toSubmodule.add_mem hx hy
+    | tmul n p => simpa [ambient] using h n p)
+
+/-- Corestricted regular multiplication sends a pure tensor to the product of its
+factors. -/
+@[simp]
+theorem mulHom_tmul (N P Q : Subcomodule R H H)
+    [Module.Flat R H]
+    (h : ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q) (n : N) (p : P) :
+    ((mulHom N P Q h) (n ⊗ₜ[R] p) : H) = (n : H) * (p : H) := by
+  simp [mulHom]
+
+/-- The underlying linear map of corestricted regular multiplication is Mathlib's
+`Submodule.mulMap`, with codomain restricted to `Q`. -/
+@[simp]
+theorem mulHom_toLinearMap (N P Q : Subcomodule R H H)
+    [Module.Flat R H]
+    (h : ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q) :
+    (mulHom N P Q h).toLinearMap =
+      (Submodule.mulMap N.toSubmodule P.toSubmodule).codRestrict Q.toSubmodule (by
+        intro x
+        induction x using TensorProduct.induction_on with
+        | zero => exact Q.toSubmodule.zero_mem
+        | add x y hx hy =>
+          rw [map_add]
+          exact Q.toSubmodule.add_mem hx hy
+        | tmul n p => exact h n p) := by
+  apply TensorProduct.ext'
+  intro n p
+  exact Subtype.ext (mulHom_tmul N P Q h n p)
+
+/-- Pairwise products from two finite regular subcomodules lie in a third finite regular
+subcomodule.
+
+The image of `Submodule.mulMap` is finitely generated because its tensor-product source is
+finite. The finite-subcomodule theorem then supplies a regular subcomodule containing that
+image. -/
+theorem exists_finite_mul_le [Module.Free R H] (N P : Subcomodule R H H)
+    [Module.Finite R N.toSubmodule] [Module.Finite R P.toSubmodule] :
+    ∃ Q : Subcomodule R H H, Module.Finite R Q.toSubmodule ∧
+      ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q := by
+  let f := Submodule.mulMap N.toSubmodule P.toSubmodule
+  obtain ⟨Q, hQfinite, hQ⟩ :=
+    exists_finite_subcomodule_of_fg (R := R) (C := H) (M := H)
+      f.range (Submodule.fg_range f)
+  refine ⟨Q, hQfinite, fun n p ↦ hQ ?_⟩
+  exact ⟨n ⊗ₜ[R] p, rfl⟩
+
+end Subcomodule
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
@@ -70,11 +70,10 @@ noncomputable def mulHom (N P Q : Subcomodule R H H)
     intro x
     induction x using TensorProduct.induction_on with
     | zero =>
-      rw [show ambient 0 = 0 from map_zero ambient.toLinearMap]
+      rw [← Comodule.Hom.coe_toLinearMap ambient, map_zero]
       exact Q.toSubmodule.zero_mem
     | add x y hx hy =>
-      rw [show ambient (x + y) = ambient x + ambient y from
-        map_add ambient.toLinearMap x y]
+      rw [← Comodule.Hom.coe_toLinearMap ambient, map_add]
       exact Q.toSubmodule.add_mem hx hy
     | tmul n p =>
       simpa only [ambient, Comodule.Hom.comp_apply, Comodule.Hom.tensorMap_tmul,

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
@@ -5,9 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.TensorProduct.Submodule
-public import Mathlib.RingTheory.Bialgebra.TensorProduct
 public import Mathlib.RingTheory.TensorProduct.Finite
-public import TauCeti.Algebra.Coalgebra.Comodule.TensorProduct
+public import TauCeti.Algebra.Coalgebra.Comodule.Regular
 public import TauCeti.Algebra.Coalgebra.Subcomodule.Finite
 public import TauCeti.Algebra.Coalgebra.Subcomodule.Induced
 
@@ -25,10 +24,10 @@ to compare tensor-compatible natural transformations on finite regular subcomodu
 
 ## Main declarations
 
-* `TauCeti.Comodule.Hom.regularMul`: multiplication as a morphism from the tensor square
-  of the regular comodule.
 * `TauCeti.Subcomodule.mulHom`: multiplication corestricted to a containing regular
   subcomodule.
+* `TauCeti.Subcomodule.exists_finite_mul_le_of_exists_mem`: pairwise products lie in a
+  finite regular subcomodule whenever every element does.
 * `TauCeti.Subcomodule.exists_finite_mul_le`: two finite regular subcomodules have all
   their pairwise products in a third finite regular subcomodule.
 
@@ -51,64 +50,6 @@ namespace TauCeti
 
 universe u v
 
-namespace Comodule.Hom
-
-variable {R : Type u} {H : Type v}
-variable [CommSemiring R] [Semiring H] [Bialgebra R H]
-
-attribute [local instance] Comodule.tensor
-
-/-- Multiplication of a bialgebra, regarded as a morphism from the tensor square of its
-regular right comodule to the regular right comodule. -/
-@[expose]
-noncomputable def regularMul : Hom R H (H ⊗[R] H) H where
-  toLinearMap := LinearMap.mul' R H
-  map_coact := by
-    apply TensorProduct.ext'
-    intro x y
-    simp only [LinearMap.comp_apply, LinearMap.mul'_apply]
-    change TensorProduct.map (LinearMap.mul' R H) LinearMap.id
-        (Comodule.tensorCoact (R := R) (C := H) (M := H) (N := H) (x ⊗ₜ[R] y)) =
-      Coalgebra.comul (R := R) (A := H) (x * y)
-    rw [Comodule.tensorCoact_tmul]
-    have combine_mul (a b : H ⊗[R] H) :
-        TensorProduct.map (LinearMap.mul' R H) LinearMap.id
-            (Comodule.tensorCombine (R := R) (C := H) (M := H) (N := H) (a ⊗ₜ[R] b)) =
-          TensorProduct.map (LinearMap.mul' R H) (LinearMap.mul' R H)
-            (TensorProduct.tensorTensorTensorComm R H H H H (a ⊗ₜ[R] b)) := by
-      induction a using TensorProduct.induction_on with
-      | zero => simp
-      | add a₁ a₂ ha₁ ha₂ =>
-        simp only [TensorProduct.add_tmul, map_add, ha₁, ha₂]
-      | tmul a₁ a₂ =>
-        induction b using TensorProduct.induction_on with
-        | zero => simp
-        | add b₁ b₂ hb₁ hb₂ =>
-          simp only [TensorProduct.tmul_add, map_add, hb₁, hb₂]
-        | tmul b₁ b₂ => simp
-    rw [combine_mul]
-    have h := CoalgHomClass.map_comp_comul_apply (Bialgebra.mulCoalgHom R H) (x ⊗ₜ[R] y)
-    change TensorProduct.map (LinearMap.mul' R H) (LinearMap.mul' R H)
-        (TensorProduct.tensorTensorTensorComm R H H H H
-          (Coalgebra.comul (R := R) (A := H) x ⊗ₜ[R]
-            Coalgebra.comul (R := R) (A := H) y)) =
-      Coalgebra.comul (R := R) (A := H) (x * y) at h
-    exact h
-
-/-- The underlying linear map of regular-comodule multiplication is bialgebra
-multiplication. -/
-@[simp]
-theorem regularMul_toLinearMap :
-    (regularMul (R := R) (H := H)).toLinearMap = LinearMap.mul' R H :=
-  rfl
-
-/-- Regular-comodule multiplication sends a pure tensor to the product of its factors. -/
-@[simp]
-theorem regularMul_tmul (x y : H) : regularMul (R := R) (H := H) (x ⊗ₜ[R] y) = x * y :=
-  rfl
-
-end Comodule.Hom
-
 namespace Subcomodule
 
 variable {R : Type u} {H : Type v}
@@ -118,23 +59,34 @@ attribute [local instance] Comodule.tensor
 
 /-- Multiplication from `N ⊗ P`, corestricted to a regular subcomodule `Q` containing
 every product `n * p`. -/
-@[expose]
 noncomputable def mulHom (N P Q : Subcomodule R H H)
     [Module.Flat R H]
     (h : ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q) :
     Comodule.Hom R H (N ⊗[R] P) Q :=
   let ambient : Comodule.Hom R H (N ⊗[R] P) H :=
-    (Comodule.Hom.regularMul (R := R) (H := H)).comp
+    Comodule.Hom.comp (Comodule.Hom.regularMul (R := R) (H := H))
       (Comodule.Hom.tensorMap (Subcomodule.subtype N) (Subcomodule.subtype P))
-  ambient.codRestrict Q (by
+  have hmem : ∀ x, ambient x ∈ Q := by
     intro x
     induction x using TensorProduct.induction_on with
-    | zero => exact Q.toSubmodule.zero_mem
+    | zero =>
+      rw [show ambient 0 = 0 from map_zero ambient.toLinearMap]
+      exact Q.toSubmodule.zero_mem
     | add x y hx hy =>
-      change ambient.toLinearMap (x + y) ∈ Q
-      rw [map_add]
+      rw [show ambient (x + y) = ambient x + ambient y from
+        map_add ambient.toLinearMap x y]
       exact Q.toSubmodule.add_mem hx hy
-    | tmul n p => simpa [ambient] using h n p)
+    | tmul n p =>
+      simpa only [ambient, Comodule.Hom.comp_apply, Comodule.Hom.tensorMap_tmul,
+        Subcomodule.subtype_apply, Comodule.Hom.regularMul_tmul] using h n p
+  Comodule.Hom.codRestrict ambient Q hmem
+
+private theorem mulHom_tmul_def (N P Q : Subcomodule R H H)
+    [Module.Flat R H]
+    (h : ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q) (n : N) (p : P) :
+    ((mulHom N P Q h) (n ⊗ₜ[R] p) : H) = (n : H) * (p : H) := by
+  simp only [mulHom, Comodule.Hom.codRestrict_apply, Comodule.Hom.comp_apply,
+    Comodule.Hom.tensorMap_tmul, Subcomodule.subtype_apply, Comodule.Hom.regularMul_tmul]
 
 /-- Corestricted regular multiplication sends a pure tensor to the product of its
 factors. -/
@@ -143,7 +95,7 @@ theorem mulHom_tmul (N P Q : Subcomodule R H H)
     [Module.Flat R H]
     (h : ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q) (n : N) (p : P) :
     ((mulHom N P Q h) (n ⊗ₜ[R] p) : H) = (n : H) * (p : H) := by
-  simp [mulHom]
+  exact mulHom_tmul_def N P Q h n p
 
 /-- The underlying linear map of corestricted regular multiplication is Mathlib's
 `Submodule.mulMap`, with codomain restricted to `Q`. -/
@@ -164,22 +116,29 @@ theorem mulHom_toLinearMap (N P Q : Subcomodule R H H)
   intro n p
   exact Subtype.ext (mulHom_tmul N P Q h n p)
 
-/-- Pairwise products from two finite regular subcomodules lie in a third finite regular
-subcomodule.
-
-The image of `Submodule.mulMap` is finitely generated because its tensor-product source is
-finite. The finite-subcomodule theorem then supplies a regular subcomodule containing that
-image. -/
-theorem exists_finite_mul_le [Module.Free R H] (N P : Subcomodule R H H)
+/-- If every element of `H` belongs to a finite regular subcomodule, then pairwise products
+from two finite regular subcomodules lie in a third finite regular subcomodule. -/
+theorem exists_finite_mul_le_of_exists_mem
+    (hH : ∀ h : H, ∃ Q : Subcomodule R H H, Module.Finite R Q.toSubmodule ∧ h ∈ Q)
+    (N P : Subcomodule R H H)
     [Module.Finite R N.toSubmodule] [Module.Finite R P.toSubmodule] :
     ∃ Q : Subcomodule R H H, Module.Finite R Q.toSubmodule ∧
       ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q := by
   let f := Submodule.mulMap N.toSubmodule P.toSubmodule
   obtain ⟨Q, hQfinite, hQ⟩ :=
-    exists_finite_subcomodule_of_fg (R := R) (C := H) (M := H)
+    exists_finite_subcomodule_of_fg_of_exists_mem hH
       f.range (Submodule.fg_range f)
   refine ⟨Q, hQfinite, fun n p ↦ hQ ?_⟩
   exact ⟨n ⊗ₜ[R] p, rfl⟩
+
+/-- If `H` is free over `R`, pairwise products from two finite regular subcomodules lie in a
+third finite regular subcomodule. -/
+theorem exists_finite_mul_le [Module.Free R H] (N P : Subcomodule R H H)
+    [Module.Finite R N.toSubmodule] [Module.Finite R P.toSubmodule] :
+    ∃ Q : Subcomodule R H H, Module.Finite R Q.toSubmodule ∧
+      ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q :=
+  exists_finite_mul_le_of_exists_mem
+    (exists_finite_subcomodule_mem (R := R) (C := H) (M := H)) N P
 
 end Subcomodule
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
@@ -54,9 +54,29 @@ universe u v
 namespace Subcomodule
 
 variable {R : Type u} {H : Type v}
-variable [CommSemiring R] [Semiring H] [Bialgebra R H]
+variable [CommSemiring R] [Semiring H]
 
 attribute [local instance] Comodule.tensor
+
+section MulMap
+
+variable [Algebra R H] [Coalgebra R H]
+
+/-- If a regular subcomodule contains every pairwise product from `N` and `P`, it contains
+every value of `Submodule.mulMap N.toSubmodule P.toSubmodule`. -/
+theorem mulMap_mem (N P Q : Subcomodule R H H)
+    (h : ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q) (x : N ⊗[R] P) :
+    Submodule.mulMap N.toSubmodule P.toSubmodule x ∈ Q := by
+  have hmul : N.toSubmodule * P.toSubmodule ≤ Q.toSubmodule :=
+    Submodule.mul_le.2 fun n hn p hp ↦ h ⟨n, hn⟩ ⟨p, hp⟩
+  rw [← Submodule.mulMap_range] at hmul
+  exact hmul (LinearMap.mem_range_self _ x)
+
+end MulMap
+
+section MulHom
+
+variable [Bialgebra R H]
 
 /-- Multiplication from `N ⊗ P`, corestricted to a regular subcomodule `Q` containing
 every product `n * p`. -/
@@ -67,18 +87,17 @@ noncomputable def mulHom (N P Q : Subcomodule R H H)
   let ambient : Comodule.Hom R H (N ⊗[R] P) H :=
     Comodule.Hom.comp (Comodule.Hom.regularMul (R := R) (H := H))
       (Comodule.Hom.tensorMap (Subcomodule.subtype N) (Subcomodule.subtype P))
+  have hambient : ambient.toLinearMap = Submodule.mulMap N.toSubmodule P.toSubmodule := by
+    apply TensorProduct.ext'
+    intro n p
+    simp only [Comodule.Hom.coe_toLinearMap, ambient, Comodule.Hom.comp_apply,
+      Comodule.Hom.tensorMap_tmul, Subcomodule.subtype_apply,
+      Comodule.Hom.regularMul_tmul]
+    erw [Submodule.mulMap_tmul]
   have hmem : ∀ x, ambient x ∈ Q := by
     intro x
-    induction x using TensorProduct.induction_on with
-    | zero =>
-      rw [← Comodule.Hom.coe_toLinearMap ambient, map_zero]
-      exact Q.toSubmodule.zero_mem
-    | add x y hx hy =>
-      rw [← Comodule.Hom.coe_toLinearMap ambient, map_add]
-      exact Q.toSubmodule.add_mem hx hy
-    | tmul n p =>
-      simpa only [ambient, Comodule.Hom.comp_apply, Comodule.Hom.tensorMap_tmul,
-        Subcomodule.subtype_apply, Comodule.Hom.regularMul_tmul] using h n p
+    rw [← Comodule.Hom.coe_toLinearMap ambient, hambient]
+    exact mulMap_mem N P Q h x
   Comodule.Hom.codRestrict ambient Q hmem
 
 private theorem mulHom_tmul_def (N P Q : Subcomodule R H H)
@@ -104,17 +123,17 @@ theorem mulHom_toLinearMap (N P Q : Subcomodule R H H)
     [Module.Flat R H]
     (h : ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q) :
     (mulHom N P Q h).toLinearMap =
-      (Submodule.mulMap N.toSubmodule P.toSubmodule).codRestrict Q.toSubmodule (by
-        intro x
-        induction x using TensorProduct.induction_on with
-        | zero => exact Q.toSubmodule.zero_mem
-        | add x y hx hy =>
-          rw [map_add]
-          exact Q.toSubmodule.add_mem hx hy
-        | tmul n p => exact h n p) := by
+      (Submodule.mulMap N.toSubmodule P.toSubmodule).codRestrict Q.toSubmodule
+        (mulMap_mem N P Q h) := by
   apply TensorProduct.ext'
   intro n p
   exact Subtype.ext (mulHom_tmul N P Q h n p)
+
+end MulHom
+
+section FiniteContainment
+
+variable [Algebra R H] [Coalgebra R H]
 
 /-- If every element of `H` belongs to a finite regular subcomodule, then pairwise products
 from two finite submodules lie in a finite regular subcomodule. -/
@@ -139,6 +158,8 @@ theorem exists_finite_mul_le [Module.Free R H] (N P : Submodule R H)
       ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q :=
   exists_finite_mul_le_of_exists_mem
     (exists_finite_subcomodule_mem (R := R) (C := H) (M := H)) N P
+
+end FiniteContainment
 
 end Subcomodule
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
@@ -18,9 +18,10 @@ right comodule to the regular right comodule. Consequently, if `N` and `P` are
 subcomodules of the regular comodule and a third subcomodule `Q` contains all products
 `n * p`, multiplication corestricts to a comodule morphism `N ⊗ P ⟶ Q`.
 
-When `H` is free over the base semiring and `N` and `P` are finite, the products of their
-elements lie in some finite regular subcomodule. This packages the multiplication map needed
-to compare tensor-compatible natural transformations on finite regular subcomodules.
+When `H` is free over the base semiring and `N` and `P` are finite submodules, the products
+of their elements lie in some finite regular subcomodule. This packages the multiplication
+map needed to compare tensor-compatible natural transformations on finite regular
+subcomodules.
 
 ## Main declarations
 
@@ -28,7 +29,7 @@ to compare tensor-compatible natural transformations on finite regular subcomodu
   subcomodule.
 * `TauCeti.Subcomodule.exists_finite_mul_le_of_exists_mem`: pairwise products lie in a
   finite regular subcomodule whenever every element does.
-* `TauCeti.Subcomodule.exists_finite_mul_le`: two finite regular subcomodules have all
+* `TauCeti.Subcomodule.exists_finite_mul_le`: two finite submodules have all
   their pairwise products in a third finite regular subcomodule.
 
 ## References
@@ -116,24 +117,24 @@ theorem mulHom_toLinearMap (N P Q : Subcomodule R H H)
   exact Subtype.ext (mulHom_tmul N P Q h n p)
 
 /-- If every element of `H` belongs to a finite regular subcomodule, then pairwise products
-from two finite regular subcomodules lie in a third finite regular subcomodule. -/
+from two finite submodules lie in a finite regular subcomodule. -/
 theorem exists_finite_mul_le_of_exists_mem
     (hH : ∀ h : H, ∃ Q : Subcomodule R H H, Module.Finite R Q.toSubmodule ∧ h ∈ Q)
-    (N P : Subcomodule R H H)
-    [Module.Finite R N.toSubmodule] [Module.Finite R P.toSubmodule] :
+    (N P : Submodule R H)
+    [Module.Finite R N] [Module.Finite R P] :
     ∃ Q : Subcomodule R H H, Module.Finite R Q.toSubmodule ∧
       ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q := by
-  let f := Submodule.mulMap N.toSubmodule P.toSubmodule
+  let f := Submodule.mulMap N P
   obtain ⟨Q, hQfinite, hQ⟩ :=
     exists_finite_subcomodule_of_fg_of_exists_mem hH
       f.range (Submodule.fg_range f)
   refine ⟨Q, hQfinite, fun n p ↦ hQ ?_⟩
   exact ⟨n ⊗ₜ[R] p, rfl⟩
 
-/-- If `H` is free over `R`, pairwise products from two finite regular subcomodules lie in a
-third finite regular subcomodule. -/
-theorem exists_finite_mul_le [Module.Free R H] (N P : Subcomodule R H H)
-    [Module.Finite R N.toSubmodule] [Module.Finite R P.toSubmodule] :
+/-- If `H` is free over `R`, pairwise products from two finite submodules lie in a finite
+regular subcomodule. -/
+theorem exists_finite_mul_le [Module.Free R H] (N P : Submodule R H)
+    [Module.Finite R N] [Module.Finite R P] :
     ∃ Q : Subcomodule R H H, Module.Finite R Q.toSubmodule ∧
       ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q :=
   exists_finite_mul_le_of_exists_mem


### PR DESCRIPTION
This PR packages bialgebra multiplication as a morphism from the tensor square of the regular comodule, corestricts any comodule morphism to a subcomodule containing its image, and proves that the pairwise products of two finite regular subcomodules lie in a third finite regular subcomodule.

The selected target is the Layer 1 **Tannakian reconstruction** milestone in `ReductiveGroups/README.md`, specifically the step needed to recover the algebra-map laws from tensor-compatible automorphisms of finite comodules. The dependency edge is: the reconstructed local functionals consume `Subcomodule.mulHom` on a finite target supplied by `Subcomodule.exists_finite_mul_le` to prove multiplicativity. What remains after this PR is to glue those compatible local functionals over all finite regular subcomodules and prove the unit, multiplicativity, and inverse laws needed to identify them with a group-scheme point.

The multiplication compatibility is derived from Mathlib's `Bialgebra.mulCoalgHom`; the finite-containment proof reuses Mathlib's `Submodule.mulMap`, tensor-product finiteness, and `Submodule.fg_range`. No Mathlib implementation is vendored. The mathematical reference is Sweedler, *Hopf Algebras*, Chapter 2.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-regular-subcomodule-multiplication"}-->

🤖 Prepared with Codex
