### PR TITLE
feat: the standard polytabloids are linearly independent

### DIFF
--- a/TauCeti/Combinatorics/Young/StandardTableau/Order.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Order.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.Combinatorics.Young.StandardTableau.Basic
 public import TauCeti.Combinatorics.Young.Tableau
+import Mathlib.Order.Preorder.Finite
 
 /-!
 # The labels of a standard Young tableau, ordered by their cells
@@ -20,8 +21,8 @@ The consequence this file is written for is that **a standard Young tableau is d
 row of each of its labels** (`TauCeti.StandardYoungTableau.rowIndex_injective`): the labels of a row
 are placed there in increasing order, so nothing is left to choose once the rows are known.  Two
 standard tableaux with the same rows differ by a permutation preserving every row of the first,
-which is increasing on each row and therefore the identity; the increasing-permutation step is
-`TauCeti.perm_apply_eq_self_of_lt_iff_lt`, stated for a permutation of any linear order.
+which restricts to a strictly monotone self-map of that row and is therefore the identity there by
+Mathlib's `StrictMono.apply_eq`.
 
 In the language of the Specht modules, the injectivity says that distinct standard tableaux have
 distinct tabloids, and that is how
@@ -29,9 +30,6 @@ distinct tabloids, and that is how
 
 ## Main results
 
-* `TauCeti.YoungTableau.rowIndex_lt_card`: the row of a label is below the number of cells.
-* `TauCeti.perm_apply_eq_self_of_lt_iff_lt`: an increasing permutation of a finite set fixes it
-  pointwise.
 * `TauCeti.StandardYoungTableau.lt_iff_rowIndex_lt`: labels in one column are ordered by row.
 * `TauCeti.StandardYoungTableau.lt_iff_colIndex_lt`: labels in one row are ordered by column.
 * `TauCeti.StandardYoungTableau.rowIndex_injective`: a standard Young tableau is determined by the
@@ -50,19 +48,6 @@ public section
 namespace TauCeti
 
 open YoungTableau
-
-namespace YoungTableau
-
-variable {μ : YoungDiagram}
-
-/-- **The row of a label is below the number of cells.** The cells of `μ` above a label in its own
-column are already that many. -/
-theorem rowIndex_lt_card (t : YoungTableau μ) (x : Fin μ.card) : rowIndex t x < μ.card := by
-  refine lt_of_lt_of_le (YoungDiagram.mem_iff_lt_colLen.mp (rowIndex_colIndex_mem t x)) ?_
-  rw [YoungDiagram.colLen_eq_card]
-  exact Finset.card_le_card (Finset.filter_subset _ _)
-
-end YoungTableau
 
 namespace StandardYoungTableau
 
@@ -117,34 +102,6 @@ end StandardYoungTableau
 
 /-! ### A standard Young tableau is determined by the rows of its labels -/
 
-/-- **An increasing permutation of a finite set is the identity on it.** If `σ` preserves a finite
-set `s` and is increasing on it, then it fixes every element of `s`: it preserves the number of
-elements of `s` lying below a given one, and that number determines the element. -/
-theorem perm_apply_eq_self_of_lt_iff_lt {α : Type*} [LinearOrder α] {s : Finset α}
-    {σ : Equiv.Perm α} (hs : ∀ y, y ∈ s ↔ σ y ∈ s)
-    (hmono : ∀ y ∈ s, ∀ y' ∈ s, (σ y < σ y' ↔ y < y')) {x : α} (hx : x ∈ s) : σ x = x := by
-  classical
-  -- the number of elements of `s` below an element is strictly increasing on `s`
-  have hrank : ∀ a ∈ s, ∀ b ∈ s, a < b →
-      (s.filter (· < a)).card < (s.filter (· < b)).card := by
-    intro a ha b hb hab
-    refine Finset.card_lt_card ⟨fun y hy => ?_, fun hsub => ?_⟩
-    · exact Finset.mem_filter.mpr ⟨(Finset.mem_filter.mp hy).1,
-        (Finset.mem_filter.mp hy).2.trans hab⟩
-    · exact absurd (Finset.mem_filter.mp (hsub (Finset.mem_filter.mpr ⟨ha, hab⟩))).2
-        (lt_irrefl a)
-  -- and `σ` preserves it
-  have hcard : (s.filter (· < x)).card = (s.filter (· < σ x)).card := by
-    refine Finset.card_equiv σ fun y => ?_
-    simp only [Finset.mem_filter]
-    constructor
-    · exact fun hy => ⟨(hs y).mp hy.1, (hmono y hy.1 x hx).mpr hy.2⟩
-    · exact fun hy => ⟨(hs y).mpr hy.1, (hmono y ((hs y).mpr hy.1) x hx).mp hy.2⟩
-  rcases lt_trichotomy (σ x) x with h | h | h
-  · exact absurd hcard (hrank _ ((hs x).mp hx) _ hx h).ne'
-  · exact h
-  · exact absurd hcard (hrank _ hx _ ((hs x).mp hx) h).ne
-
 /-- **A standard Young tableau is determined by the rows of its labels.** -/
 theorem StandardYoungTableau.rowIndex_injective (μ : YoungDiagram) :
     Function.Injective fun T : StandardYoungTableau μ => rowIndex T.toEquiv := by
@@ -167,13 +124,18 @@ theorem StandardYoungTableau.rowIndex_injective (μ : YoungDiagram) :
   -- on each row of `T` the permutation `σ` is increasing, so it is the identity there
   have hσ : σ = 1 := by
     refine Equiv.ext fun x => ?_
-    have hfix : σ x = x := by
-      refine perm_apply_eq_self_of_lt_iff_lt
-        (s := Finset.univ.filter fun y => rowIndex T.toEquiv y = rowIndex T.toEquiv x)
-        (fun y => by simp [hrow y]) (fun y hy y' hy' => ?_) (by simp)
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy hy'
-      rw [StandardYoungTableau.lt_iff_colIndex_lt U (by rw [hrowU y, hrowU y', hy, hy']),
+    -- `σ` preserves the row of `x`, so it restricts to a permutation of that row
+    have hs : ∀ y, rowIndex T.toEquiv (σ y) = rowIndex T.toEquiv x ↔
+        rowIndex T.toEquiv y = rowIndex T.toEquiv x := fun y => by rw [hrow y]
+    have hmono : StrictMono (σ.subtypePerm hs :
+        Equiv.Perm {y // rowIndex T.toEquiv y = rowIndex T.toEquiv x}) := by
+      rintro ⟨y, hy⟩ ⟨y', hy'⟩ hlt
+      rw [Equiv.Perm.subtypePerm_apply, Equiv.Perm.subtypePerm_apply, Subtype.mk_lt_mk,
+        StandardYoungTableau.lt_iff_colIndex_lt U (by rw [hrowU y, hrowU y', hy, hy']),
         hcolU y, hcolU y', ← StandardYoungTableau.lt_iff_colIndex_lt T (hy.trans hy'.symm)]
+      exact hlt
+    have hfix : σ x = x := by
+      simpa using congrArg Subtype.val (StrictMono.apply_eq (x := ⟨x, rfl⟩) hmono)
     simpa using hfix
   have htu : T.toEquiv = U.toEquiv := by rw [← hrel, hσ, relabel_one]
   exact StandardYoungTableau.ext fun c => by

--- a/TauCeti/Combinatorics/Young/StandardTableau/Order.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Order.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Combinatorics.Young.StandardTableau.Basic
+public import TauCeti.Combinatorics.Young.Tableau
+
+/-!
+# The labels of a standard Young tableau, ordered by their cells
+
+A standard Young tableau increases along its rows and down its columns, so the order of two of its
+labels is decided by their cells as soon as those cells share a row or a column: two labels in one
+column are ordered as their rows are (`TauCeti.StandardYoungTableau.lt_iff_rowIndex_lt`), and two
+labels in one row are ordered as their columns are
+(`TauCeti.StandardYoungTableau.lt_iff_colIndex_lt`).
+
+The consequence this file is written for is that **a standard Young tableau is determined by the
+row of each of its labels** (`TauCeti.StandardYoungTableau.rowIndex_injective`): the labels of a row
+are placed there in increasing order, so nothing is left to choose once the rows are known.  Two
+standard tableaux with the same rows differ by a permutation preserving every row of the first,
+which is increasing on each row and therefore the identity; the increasing-permutation step is
+`TauCeti.perm_apply_eq_self_of_lt_iff_lt`, stated for a permutation of any linear order.
+
+In the language of the Specht modules, the injectivity says that distinct standard tableaux have
+distinct tabloids, and that is how
+`TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean` uses it.
+
+## Main results
+
+* `TauCeti.YoungTableau.rowIndex_lt_card`: the row of a label is below the number of cells.
+* `TauCeti.perm_apply_eq_self_of_lt_iff_lt`: an increasing permutation of a finite set fixes it
+  pointwise.
+* `TauCeti.StandardYoungTableau.lt_iff_rowIndex_lt`: labels in one column are ordered by row.
+* `TauCeti.StandardYoungTableau.lt_iff_colIndex_lt`: labels in one row are ordered by column.
+* `TauCeti.StandardYoungTableau.rowIndex_injective`: a standard Young tableau is determined by the
+  rows of its labels.
+
+## References
+
+* [B. E. Sagan, *The Symmetric Group*][sagan2001], Section 2.5, where the standard tableaux are
+  ordered by their tabloids.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 5, whose standard basis of the Specht module this serves.
+-/
+
+public section
+
+namespace TauCeti
+
+open YoungTableau
+
+namespace YoungTableau
+
+variable {μ : YoungDiagram}
+
+/-- **The row of a label is below the number of cells.** The cells of `μ` above a label in its own
+column are already that many. -/
+theorem rowIndex_lt_card (t : YoungTableau μ) (x : Fin μ.card) : rowIndex t x < μ.card := by
+  refine lt_of_lt_of_le (YoungDiagram.mem_iff_lt_colLen.mp (rowIndex_colIndex_mem t x)) ?_
+  rw [YoungDiagram.colLen_eq_card]
+  exact Finset.card_le_card (Finset.filter_subset _ _)
+
+end YoungTableau
+
+namespace StandardYoungTableau
+
+variable {μ : YoungDiagram}
+
+/-! ### Comparing two labels in a common row or column -/
+
+/-- Naming a cell by the row and the column of a label recovers that label. -/
+private theorem apply_eq_of_coe_eq (T : StandardYoungTableau μ) (x : Fin μ.card) {c : ↥μ.cells}
+    (h : (c : ℕ × ℕ) = (rowIndex T.toEquiv x, colIndex T.toEquiv x)) : T c = x := by
+  have hc : c = T.toEquiv.symm x := Subtype.ext (by rw [h, rowIndex_def, colIndex_def])
+  rw [hc]
+  exact T.toEquiv.apply_symm_apply x
+
+/-- Of two labels of a standard Young tableau lying in a common column, the one in the earlier row
+is the smaller. -/
+theorem lt_of_rowIndex_lt (T : StandardYoungTableau μ) {x y : Fin μ.card}
+    (hcol : colIndex T.toEquiv x = colIndex T.toEquiv y)
+    (hrow : rowIndex T.toEquiv x < rowIndex T.toEquiv y) : x < y := by
+  have hlt := T.col_strict hrow (rowIndex_colIndex_mem T.toEquiv y)
+  rwa [apply_eq_of_coe_eq T x (by simp [hcol]), apply_eq_of_coe_eq T y rfl] at hlt
+
+/-- Of two labels of a standard Young tableau lying in a common row, the one in the earlier column
+is the smaller. -/
+theorem lt_of_colIndex_lt (T : StandardYoungTableau μ) {x y : Fin μ.card}
+    (hrow : rowIndex T.toEquiv x = rowIndex T.toEquiv y)
+    (hcol : colIndex T.toEquiv x < colIndex T.toEquiv y) : x < y := by
+  have hlt := T.row_strict hcol (rowIndex_colIndex_mem T.toEquiv y)
+  rwa [apply_eq_of_coe_eq T x (by simp [hrow]), apply_eq_of_coe_eq T y rfl] at hlt
+
+/-- **Two labels of a standard Young tableau in a common column are ordered as their rows are.** -/
+theorem lt_iff_rowIndex_lt (T : StandardYoungTableau μ) {x y : Fin μ.card}
+    (hcol : colIndex T.toEquiv x = colIndex T.toEquiv y) :
+    x < y ↔ rowIndex T.toEquiv x < rowIndex T.toEquiv y := by
+  refine ⟨fun hxy => ?_, lt_of_rowIndex_lt T hcol⟩
+  rcases lt_trichotomy (rowIndex T.toEquiv x) (rowIndex T.toEquiv y) with hr | hr | hr
+  · exact hr
+  · exact absurd (rowIndex_colIndex_injective T.toEquiv (Prod.ext hr hcol)) hxy.ne
+  · exact absurd (lt_of_rowIndex_lt T hcol.symm hr) (asymm hxy)
+
+/-- **Two labels of a standard Young tableau in a common row are ordered as their columns are.** -/
+theorem lt_iff_colIndex_lt (T : StandardYoungTableau μ) {x y : Fin μ.card}
+    (hrow : rowIndex T.toEquiv x = rowIndex T.toEquiv y) :
+    x < y ↔ colIndex T.toEquiv x < colIndex T.toEquiv y := by
+  refine ⟨fun hxy => ?_, lt_of_colIndex_lt T hrow⟩
+  rcases lt_trichotomy (colIndex T.toEquiv x) (colIndex T.toEquiv y) with hc | hc | hc
+  · exact hc
+  · exact absurd (rowIndex_colIndex_injective T.toEquiv (Prod.ext hrow hc)) hxy.ne
+  · exact absurd (lt_of_colIndex_lt T hrow.symm hc) (asymm hxy)
+
+end StandardYoungTableau
+
+/-! ### A standard Young tableau is determined by the rows of its labels -/
+
+/-- **An increasing permutation of a finite set is the identity on it.** If `σ` preserves a finite
+set `s` and is increasing on it, then it fixes every element of `s`: it preserves the number of
+elements of `s` lying below a given one, and that number determines the element. -/
+theorem perm_apply_eq_self_of_lt_iff_lt {α : Type*} [LinearOrder α] {s : Finset α}
+    {σ : Equiv.Perm α} (hs : ∀ y, y ∈ s ↔ σ y ∈ s)
+    (hmono : ∀ y ∈ s, ∀ y' ∈ s, (σ y < σ y' ↔ y < y')) {x : α} (hx : x ∈ s) : σ x = x := by
+  classical
+  -- the number of elements of `s` below an element is strictly increasing on `s`
+  have hrank : ∀ a ∈ s, ∀ b ∈ s, a < b →
+      (s.filter (· < a)).card < (s.filter (· < b)).card := by
+    intro a ha b hb hab
+    refine Finset.card_lt_card ⟨fun y hy => ?_, fun hsub => ?_⟩
+    · exact Finset.mem_filter.mpr ⟨(Finset.mem_filter.mp hy).1,
+        (Finset.mem_filter.mp hy).2.trans hab⟩
+    · exact absurd (Finset.mem_filter.mp (hsub (Finset.mem_filter.mpr ⟨ha, hab⟩))).2
+        (lt_irrefl a)
+  -- and `σ` preserves it
+  have hcard : (s.filter (· < x)).card = (s.filter (· < σ x)).card := by
+    refine Finset.card_equiv σ fun y => ?_
+    simp only [Finset.mem_filter]
+    constructor
+    · exact fun hy => ⟨(hs y).mp hy.1, (hmono y hy.1 x hx).mpr hy.2⟩
+    · exact fun hy => ⟨(hs y).mpr hy.1, (hmono y ((hs y).mpr hy.1) x hx).mp hy.2⟩
+  rcases lt_trichotomy (σ x) x with h | h | h
+  · exact absurd hcard (hrank _ ((hs x).mp hx) _ hx h).ne'
+  · exact h
+  · exact absurd hcard (hrank _ hx _ ((hs x).mp hx) h).ne
+
+/-- **A standard Young tableau is determined by the rows of its labels.** -/
+theorem StandardYoungTableau.rowIndex_injective (μ : YoungDiagram) :
+    Function.Injective fun T : StandardYoungTableau μ => rowIndex T.toEquiv := by
+  classical
+  intro T U h
+  have hrow' : rowIndex T.toEquiv = rowIndex U.toEquiv := h
+  obtain ⟨σ, hrel⟩ := exists_relabel_eq T.toEquiv U.toEquiv
+  -- `σ` carries `T` to `U`, so the row and the column that `U` gives to `σ k` are those that `T`
+  -- gives to `k`
+  have hrowU : ∀ k, rowIndex U.toEquiv (σ k) = rowIndex T.toEquiv k := by
+    intro k
+    rw [← hrel, rowIndex_relabel]
+    simp
+  have hcolU : ∀ k, colIndex U.toEquiv (σ k) = colIndex T.toEquiv k := by
+    intro k
+    rw [← hrel, colIndex_relabel]
+    simp
+  have hrow : ∀ k, rowIndex T.toEquiv (σ k) = rowIndex T.toEquiv k := fun k => by
+    rw [congrFun hrow' (σ k), hrowU k]
+  -- on each row of `T` the permutation `σ` is increasing, so it is the identity there
+  have hσ : σ = 1 := by
+    refine Equiv.ext fun x => ?_
+    have hfix : σ x = x := by
+      refine perm_apply_eq_self_of_lt_iff_lt
+        (s := Finset.univ.filter fun y => rowIndex T.toEquiv y = rowIndex T.toEquiv x)
+        (fun y => by simp [hrow y]) (fun y hy y' hy' => ?_) (by simp)
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy hy'
+      rw [StandardYoungTableau.lt_iff_colIndex_lt U (by rw [hrowU y, hrowU y', hy, hy']),
+        hcolU y, hcolU y', ← StandardYoungTableau.lt_iff_colIndex_lt T (hy.trans hy'.symm)]
+    simpa using hfix
+  have htu : T.toEquiv = U.toEquiv := by rw [← hrel, hσ, relabel_one]
+  exact StandardYoungTableau.ext fun c => by
+    rw [← StandardYoungTableau.toEquiv_apply, ← StandardYoungTableau.toEquiv_apply, htu]
+
+end TauCeti

--- a/TauCeti/Combinatorics/Young/Tableau.lean
+++ b/TauCeti/Combinatorics/Young/Tableau.lean
@@ -162,12 +162,12 @@ theorem colIndex_lt_rowLen (t : YoungTableau μ) (x : Fin μ.card) :
     colIndex t x < μ.rowLen (rowIndex t x) :=
   YoungDiagram.mem_iff_lt_rowLen.mp (rowIndex_colIndex_mem t x)
 
-/-- **The row of a label is below the number of cells.** The cells of `μ` above a label in its own
-column are already that many. -/
-theorem rowIndex_lt_card (t : YoungTableau μ) (x : Fin μ.card) : rowIndex t x < μ.card := by
-  refine lt_of_lt_of_le (YoungDiagram.mem_iff_lt_colLen.mp (rowIndex_colIndex_mem t x)) ?_
-  rw [YoungDiagram.colLen_eq_card]
-  exact Finset.card_le_card (Finset.filter_subset _ _)
+/-- **The row of a label is below the number of rows.** The label lies in its own column, which is
+no longer than the zeroth one. -/
+theorem rowIndex_lt_colLen_zero (t : YoungTableau μ) (x : Fin μ.card) :
+    rowIndex t x < μ.colLen 0 :=
+  (YoungDiagram.mem_iff_lt_colLen.mp (rowIndex_colIndex_mem t x)).trans_le
+    (μ.colLen_anti 0 _ (Nat.zero_le _))
 
 /-- Every cell of `μ` carries a label. -/
 theorem exists_rowIndex_colIndex (t : YoungTableau μ) {i j : ℕ} (h : (i, j) ∈ μ) :

--- a/TauCeti/Combinatorics/Young/Tableau.lean
+++ b/TauCeti/Combinatorics/Young/Tableau.lean
@@ -162,6 +162,13 @@ theorem colIndex_lt_rowLen (t : YoungTableau μ) (x : Fin μ.card) :
     colIndex t x < μ.rowLen (rowIndex t x) :=
   YoungDiagram.mem_iff_lt_rowLen.mp (rowIndex_colIndex_mem t x)
 
+/-- **The row of a label is below the number of cells.** The cells of `μ` above a label in its own
+column are already that many. -/
+theorem rowIndex_lt_card (t : YoungTableau μ) (x : Fin μ.card) : rowIndex t x < μ.card := by
+  refine lt_of_lt_of_le (YoungDiagram.mem_iff_lt_colLen.mp (rowIndex_colIndex_mem t x)) ?_
+  rw [YoungDiagram.colLen_eq_card]
+  exact Finset.card_le_card (Finset.filter_subset _ _)
+
 /-- Every cell of `μ` carries a label. -/
 theorem exists_rowIndex_colIndex (t : YoungTableau μ) {i j : ℕ} (h : (i, j) ∈ μ) :
     ∃ x, rowIndex t x = i ∧ colIndex t x = j :=

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Module.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Module.lean
@@ -55,7 +55,11 @@ the irreducibility it yields.
 
 * `TauCeti.YoungTableau.smul_tabloid_eq_self_iff`: the stabilizer of the tabloid of `t` is the row
   group of `t`.
+* `TauCeti.YoungTableau.tabloid_eq_iff_rowIndex_eq`: two tableaux have the same tabloid exactly when
+  they put every label in the same row.
 * `TauCeti.YoungTableau.polytabloid_relabel`: relabeling translates the polytabloid.
+* `TauCeti.YoungTableau.polytabloid_coeff_eq_zero_of_forall_ne`: only the tabloids reachable from
+  `{t}` by a column permutation occur in `e_t`.
 * `TauCeti.YoungTableau.polytabloid_ne_zero` and
   `TauCeti.YoungTableau.tabloidForm_polytabloid_self`: polytabloids are nonzero, and the tabloid
   form pairs one with itself to the order of the column group.
@@ -123,6 +127,21 @@ element of the row group of `t`. -/
 theorem smul_tabloid_eq_iff {t : YoungTableau μ} {σ τ : Equiv.Perm (Fin μ.card)} :
     σ • tabloid t = τ • tabloid t ↔ σ⁻¹ * τ ∈ rowSubgroup t := by
   rw [← smul_tabloid_eq_self_iff, mul_smul, inv_smul_eq_iff, eq_comm]
+
+/-- **Two tableaux have the same tabloid exactly when they put every label in the same row.** -/
+@[simp]
+theorem tabloid_eq_iff_rowIndex_eq {t u : YoungTableau μ} :
+    tabloid t = tabloid u ↔ rowIndex t = rowIndex u := by
+  obtain ⟨σ, rfl⟩ := exists_relabel_eq t u
+  rw [tabloid_relabel, eq_comm, smul_tabloid_eq_self_iff, mem_rowSubgroup]
+  constructor
+  · intro hσ
+    funext k
+    simpa using hσ (σ⁻¹ k)
+  · intro hσ k
+    have hk := congrFun hσ (σ k)
+    rw [rowIndex_relabel] at hk
+    simpa using hk
 
 /-- Distinct elements of the column group of `t` move the tabloid of `t` to distinct tabloids: the
 column group meets the row group, which is the stabilizer, only in the identity. -/
@@ -203,6 +222,17 @@ theorem polytabloid_coeff_tabloid (t : YoungTableau μ) :
     (polytabloid t).coeff (tabloid t) = 1 := by
   have h := polytabloid_coeff_smul_tabloid t 1
   simpa using h
+
+/-- Only the tabloids reachable from `{t}` by a column permutation occur in the polytabloid
+`e_t`. -/
+theorem polytabloid_coeff_eq_zero_of_forall_ne (t : YoungTableau μ)
+    {X : Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)}
+    (h : ∀ q ∈ colSubgroup t, q • tabloid t ≠ X) : (polytabloid t).coeff X = 0 := by
+  classical
+  rw [polytabloid_eq_sum, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
+  refine Finset.sum_eq_zero fun q _ => ?_
+  have hne := h (q : Equiv.Perm (Fin μ.card)) q.2
+  simp [MonoidAlgebra.coeff_single, hne]
 
 /-- Polytabloids are nonzero. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean
@@ -39,25 +39,24 @@ that order do the work.
   (`TauCeti.StandardYoungTableau.rowIndex_injective`), since a standard tableau writes the labels
   of each row in increasing order.
 
-Dominance is only a partial order, so the maximum is taken along the numerical weight
-`TauCeti.YoungTableau.rowWeight`, the sum of all the counts in the range where they can differ:
-dominance makes it larger, and it is unchanged only when every count agrees, which pins the rows
-down.  Taking the standard tableau of largest weight among those with a nonzero coefficient, its
-tabloid can occur in no other standard polytabloid of the combination, and its coefficient is the
-coefficient of that tabloid in the combination, hence zero.
+Dominance is only a partial order (antisymmetric up to equality of tabloids,
+`TauCeti.YoungTableau.TabloidDominates.antisymm`), so the maximum is taken along a numerical
+weight private to this file, the sum of all the counts in the range where they can differ:
+dominance makes it larger, and a dominating tableau of no greater weight has every count equal,
+which pins the rows down.  Taking the standard tableau of largest weight among those with a nonzero
+coefficient, its tabloid can occur in no other standard polytabloid of the combination, and its
+coefficient is the coefficient of that tabloid in the combination, hence zero.
 
 ## Main definitions
 
 * `TauCeti.YoungTableau.rowCount`: how many of the first `m` labels lie in the first `i + 1` rows.
 * `TauCeti.YoungTableau.TabloidDominates`: the dominance order on tabloids.
-* `TauCeti.YoungTableau.rowWeight`: a numerical refinement of dominance.
 
 ## Main results
 
+* `TauCeti.YoungTableau.TabloidDominates.antisymm`: dominance both ways is equality of tabloids.
 * `TauCeti.YoungTableau.tabloidDominates_relabel_of_mem_colSubgroup`: a column permutation of a
   standard tableau lowers its tabloid.
-* `TauCeti.YoungTableau.tabloid_eq_iff_rowIndex_eq`: two tableaux have the same tabloid exactly
-  when they put every label in the same row.
 * `TauCeti.linearIndependent_polytabloid`: the standard polytabloids are linearly independent.
 * `TauCeti.standardCount_le_finrank_spechtModule`: hence `f^μ ≤ dim S^μ`.
 
@@ -146,21 +145,35 @@ theorem tabloidDominates_refl (t : YoungTableau μ) : TabloidDominates t t := fu
 theorem TabloidDominates.trans {t u v : YoungTableau μ} (h : TabloidDominates t u)
     (h' : TabloidDominates u v) : TabloidDominates t v := fun m i => (h' m i).trans (h m i)
 
+/-- **Dominance depends on the tableaux only through their tabloids.** -/
+theorem tabloidDominates_congr {t t' u u' : YoungTableau μ} (ht : tabloid t = tabloid t')
+    (hu : tabloid u = tabloid u') : TabloidDominates t u ↔ TabloidDominates t' u' := by
+  rw [tabloid_eq_iff_rowIndex_eq] at ht hu
+  exact forall_congr' fun m => forall_congr' fun i => by
+    rw [rowCount_congr ht m i, rowCount_congr hu m i]
+
+/-- **Dominance is antisymmetric up to equality of tabloids.** -/
+theorem TabloidDominates.antisymm {t u : YoungTableau μ} (h : TabloidDominates t u)
+    (h' : TabloidDominates u t) : tabloid t = tabloid u :=
+  tabloid_eq_iff_rowIndex_eq.mpr
+    (rowIndex_eq_of_rowCount_eq fun m _ i _ => le_antisymm (h' m i) (h m i))
+
 /-- A numerical refinement of dominance: the total of all the counts that can differ.  Dominance
-increases it, and only tableaux with the same rows share its value. -/
-def rowWeight (t : YoungTableau μ) : ℕ :=
+increases it, and a dominating tableau of no greater weight has the same rows
+(`rowIndex_eq_of_tabloidDominates`). -/
+private def rowWeight (t : YoungTableau μ) : ℕ :=
   ∑ m ∈ Finset.range (μ.card + 1), ∑ i ∈ Finset.range (μ.card + 1), rowCount t m i
 
-theorem rowWeight_congr {t u : YoungTableau μ} (h : rowIndex t = rowIndex u) :
+private theorem rowWeight_congr {t u : YoungTableau μ} (h : rowIndex t = rowIndex u) :
     rowWeight t = rowWeight u := by
   refine Finset.sum_congr rfl fun m _ => Finset.sum_congr rfl fun i _ => rowCount_congr h m i
 
-theorem rowWeight_le_of_tabloidDominates {t u : YoungTableau μ} (h : TabloidDominates t u) :
+private theorem rowWeight_le_of_tabloidDominates {t u : YoungTableau μ} (h : TabloidDominates t u) :
     rowWeight u ≤ rowWeight t :=
   Finset.sum_le_sum fun m _ => Finset.sum_le_sum fun i _ => h m i
 
 /-- **Dominance with no gain of weight is equality of tabloids.** -/
-theorem rowIndex_eq_of_tabloidDominates {t u : YoungTableau μ} (h : TabloidDominates t u)
+private theorem rowIndex_eq_of_tabloidDominates {t u : YoungTableau μ} (h : TabloidDominates t u)
     (hw : rowWeight t ≤ rowWeight u) : rowIndex u = rowIndex t := by
   have hinner := (Finset.sum_eq_sum_iff_of_le
     fun m (_ : m ∈ Finset.range (μ.card + 1)) => Finset.sum_le_sum fun i _ => h m i).mp
@@ -169,22 +182,6 @@ theorem rowIndex_eq_of_tabloidDominates {t u : YoungTableau μ} (h : TabloidDomi
   exact (Finset.sum_eq_sum_iff_of_le fun i _ => h m i).mp
     (hinner m (Finset.mem_range.mpr (Nat.lt_succ_of_le hm))) i
     (Finset.mem_range.mpr (Nat.lt_succ_of_le hi))
-
-/-! ### Tabloids and rows -/
-
-/-- **Two tableaux have the same tabloid exactly when they put every label in the same row.** -/
-theorem tabloid_eq_iff_rowIndex_eq {t u : YoungTableau μ} :
-    tabloid t = tabloid u ↔ rowIndex t = rowIndex u := by
-  obtain ⟨σ, rfl⟩ := exists_relabel_eq t u
-  rw [tabloid_relabel, eq_comm, smul_tabloid_eq_self_iff, mem_rowSubgroup]
-  constructor
-  · intro hσ
-    funext k
-    simpa using hσ (σ⁻¹ k)
-  · intro hσ k
-    have hk := congrFun hσ (σ k)
-    rw [rowIndex_relabel] at hk
-    simpa using hk
 
 /-! ### A column permutation lowers the tabloid of a standard tableau -/
 
@@ -267,19 +264,6 @@ theorem tabloidDominates_relabel_of_mem_colSubgroup (T : StandardYoungTableau μ
   · simp only [hA, Finset.mem_filter, Finset.mem_univ, true_and] at hx hy ⊢
     refine ⟨hy, le_of_lt (lt_of_lt_of_le ?_ hx.2)⟩
     exact (T.lt_iff_rowIndex_lt (hy.trans hx.1.symm)).mp hlt
-
-/-! ### The coefficient of a tabloid in a polytabloid -/
-
-/-- Only the tabloids reachable from `{t}` by a column permutation occur in the polytabloid
-`e_t`. -/
-theorem polytabloid_coeff_eq_zero_of_forall_ne (t : YoungTableau μ)
-    {X : Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)}
-    (h : ∀ q ∈ colSubgroup t, q • tabloid t ≠ X) : (polytabloid t).coeff X = 0 := by
-  classical
-  rw [polytabloid_eq_sum, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
-  refine Finset.sum_eq_zero fun q _ => ?_
-  have hne := h (q : Equiv.Perm (Fin μ.card)) q.2
-  simp [MonoidAlgebra.coeff_single, hne]
 
 end YoungTableau
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean
@@ -1,0 +1,348 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Combinatorics.Young.StandardTableau.Order
+public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
+
+/-!
+# The standard polytabloids are linearly independent
+
+The polytabloid `e_t` of a `μ`-tableau `t` is the signed sum, over the column group of `t`, of the
+tabloids `{q t}`, and the Specht module `S^μ` is the span of all of them.  This file proves that
+the polytabloids of the **standard** tableaux -- those increasing along rows and down columns --
+are linearly independent (`TauCeti.linearIndependent_polytabloid`), so that
+
+`f^μ = standardCount μ ≤ finrank ℚ S^μ`
+
+(`TauCeti.standardCount_le_finrank_spechtModule`).  Together with the reverse inequality, which
+needs the straightening algorithm and is not proved here, this is the standard basis theorem of
+Layer 5 of the Schur--Weyl roadmap.
+
+## The dominance order on tabloids
+
+The argument is the triangularity of the standard polytabloids against the tabloid basis.  Order
+the tabloids by **dominance**: `{t}` dominates `{u}` when, for every `m` and every `i`, at least as
+many of the labels below `m` sit in the first `i + 1` rows of `t` as sit in the first `i + 1` rows
+of `u` (`TauCeti.YoungTableau.rowCount`, `TauCeti.YoungTableau.TabloidDominates`).  Two facts about
+that order do the work.
+
+* **The tabloid of a standard tableau is the largest one occurring in its polytabloid**
+  (`TauCeti.YoungTableau.tabloidDominates_relabel_of_mem_colSubgroup`).  Fix a column `j` and a row
+  bound `i`.  The labels of `T` in column `j` and in the first `i + 1` rows are, because `T`
+  increases down its columns, exactly the smallest ones of that column, so no other set of that
+  many labels of the column has more members below a given `m`.  A column permutation `q` replaces
+  them by another such set, and summing the resulting inequality over the columns is the claim.
+* **A standard tableau is determined by its tabloid**
+  (`TauCeti.StandardYoungTableau.rowIndex_injective`), since a standard tableau writes the labels
+  of each row in increasing order.
+
+Dominance is only a partial order, so the maximum is taken along the numerical weight
+`TauCeti.YoungTableau.rowWeight`, the sum of all the counts in the range where they can differ:
+dominance makes it larger, and it is unchanged only when every count agrees, which pins the rows
+down.  Taking the standard tableau of largest weight among those with a nonzero coefficient, its
+tabloid can occur in no other standard polytabloid of the combination, and its coefficient is the
+coefficient of that tabloid in the combination, hence zero.
+
+## Main definitions
+
+* `TauCeti.YoungTableau.rowCount`: how many of the first `m` labels lie in the first `i + 1` rows.
+* `TauCeti.YoungTableau.TabloidDominates`: the dominance order on tabloids.
+* `TauCeti.YoungTableau.rowWeight`: a numerical refinement of dominance.
+
+## Main results
+
+* `TauCeti.YoungTableau.tabloidDominates_relabel_of_mem_colSubgroup`: a column permutation of a
+  standard tableau lowers its tabloid.
+* `TauCeti.YoungTableau.tabloid_eq_iff_rowIndex_eq`: two tableaux have the same tabloid exactly
+  when they put every label in the same row.
+* `TauCeti.linearIndependent_polytabloid`: the standard polytabloids are linearly independent.
+* `TauCeti.standardCount_le_finrank_spechtModule`: hence `f^μ ≤ dim S^μ`.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Section 8.
+* [B. E. Sagan, *The Symmetric Group*][sagan2001], Section 2.5.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 5, the standard basis of the Specht module.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+namespace YoungTableau
+
+variable {μ : YoungDiagram}
+
+/-! ### Counting the labels of a tableau by row -/
+
+/-- The number of labels below `m` that the `μ`-tableau `t` places in one of its first `i + 1`
+rows.  It depends on `t` only through its tabloid. -/
+def rowCount (t : YoungTableau μ) (m i : ℕ) : ℕ :=
+  (Finset.univ.filter fun k : Fin μ.card => (k : ℕ) < m ∧ rowIndex t k ≤ i).card
+
+theorem rowCount_congr {t u : YoungTableau μ} (h : rowIndex t = rowIndex u) (m i : ℕ) :
+    rowCount t m i = rowCount u m i := by
+  rw [rowCount, rowCount, h]
+
+/-- Passing from the labels below `k` to the labels below `k + 1` adds the label `k` itself. -/
+theorem rowCount_succ (t : YoungTableau μ) (k : Fin μ.card) (i : ℕ) :
+    rowCount t ((k : ℕ) + 1) i = rowCount t (k : ℕ) i + if rowIndex t k ≤ i then 1 else 0 := by
+  classical
+  have hsingle : (if rowIndex t k ≤ i then 1 else 0) =
+      ∑ x : Fin μ.card, if x = k then (if rowIndex t x ≤ i then 1 else 0) else 0 := by
+    simp
+  rw [rowCount, rowCount, Finset.card_filter, Finset.card_filter, hsingle,
+    ← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl fun x _ => ?_
+  rcases lt_trichotomy (x : ℕ) (k : ℕ) with h | h | h
+  · have hx : x ≠ k := fun he => absurd (congrArg Fin.val he) h.ne
+    simp [h, Nat.lt_succ_of_lt h, hx]
+  · have hx : x = k := Fin.ext h
+    subst hx
+    simp
+  · have hx : x ≠ k := fun he => absurd (congrArg Fin.val he) h.ne'
+    simp [Nat.not_lt.mpr h.le, Nat.not_lt.mpr h, hx]
+
+/-- **The counts determine the rows.**  A tableau puts a label in the first row for which the
+count jumps. -/
+theorem rowIndex_eq_of_rowCount_eq {t u : YoungTableau μ}
+    (h : ∀ m ≤ μ.card, ∀ i ≤ μ.card, rowCount t m i = rowCount u m i) :
+    rowIndex t = rowIndex u := by
+  funext k
+  have key : ∀ i ≤ μ.card, (rowIndex t k ≤ i ↔ rowIndex u k ≤ i) := by
+    intro i hi
+    have h1 := h ((k : ℕ) + 1) k.isLt i hi
+    rw [rowCount_succ, rowCount_succ, h (k : ℕ) k.isLt.le i hi] at h1
+    have h2 : (if rowIndex t k ≤ i then 1 else 0) = if rowIndex u k ≤ i then (1 : ℕ) else 0 :=
+      Nat.add_left_cancel h1
+    constructor
+    · intro hp
+      by_contra hq
+      rw [if_pos hp, if_neg hq] at h2
+      exact absurd h2 one_ne_zero
+    · intro hq
+      by_contra hp
+      rw [if_neg hp, if_pos hq] at h2
+      exact absurd h2 zero_ne_one
+  exact le_antisymm ((key (rowIndex u k) (rowIndex_lt_card u k).le).mpr le_rfl)
+    ((key (rowIndex t k) (rowIndex_lt_card t k).le).mp le_rfl)
+
+/-! ### The dominance order on tabloids -/
+
+/-- **The dominance order on tabloids.** The tabloid of `t` dominates the tabloid of `u` when, for
+every `m` and `i`, the labels below `m` that `t` puts in its first `i + 1` rows are at least as
+many as those that `u` does. -/
+def TabloidDominates (t u : YoungTableau μ) : Prop :=
+  ∀ m i : ℕ, rowCount u m i ≤ rowCount t m i
+
+theorem tabloidDominates_refl (t : YoungTableau μ) : TabloidDominates t t := fun _ _ => le_rfl
+
+theorem TabloidDominates.trans {t u v : YoungTableau μ} (h : TabloidDominates t u)
+    (h' : TabloidDominates u v) : TabloidDominates t v := fun m i => (h' m i).trans (h m i)
+
+/-- A numerical refinement of dominance: the total of all the counts that can differ.  Dominance
+increases it, and only tableaux with the same rows share its value. -/
+def rowWeight (t : YoungTableau μ) : ℕ :=
+  ∑ m ∈ Finset.range (μ.card + 1), ∑ i ∈ Finset.range (μ.card + 1), rowCount t m i
+
+theorem rowWeight_congr {t u : YoungTableau μ} (h : rowIndex t = rowIndex u) :
+    rowWeight t = rowWeight u := by
+  refine Finset.sum_congr rfl fun m _ => Finset.sum_congr rfl fun i _ => rowCount_congr h m i
+
+theorem rowWeight_le_of_tabloidDominates {t u : YoungTableau μ} (h : TabloidDominates t u) :
+    rowWeight u ≤ rowWeight t :=
+  Finset.sum_le_sum fun m _ => Finset.sum_le_sum fun i _ => h m i
+
+/-- **Dominance with no gain of weight is equality of tabloids.** -/
+theorem rowIndex_eq_of_tabloidDominates {t u : YoungTableau μ} (h : TabloidDominates t u)
+    (hw : rowWeight t ≤ rowWeight u) : rowIndex u = rowIndex t := by
+  have hinner := (Finset.sum_eq_sum_iff_of_le
+    fun m (_ : m ∈ Finset.range (μ.card + 1)) => Finset.sum_le_sum fun i _ => h m i).mp
+      (le_antisymm (rowWeight_le_of_tabloidDominates h) hw)
+  refine rowIndex_eq_of_rowCount_eq fun m hm i hi => ?_
+  exact (Finset.sum_eq_sum_iff_of_le fun i _ => h m i).mp
+    (hinner m (Finset.mem_range.mpr (Nat.lt_succ_of_le hm))) i
+    (Finset.mem_range.mpr (Nat.lt_succ_of_le hi))
+
+/-! ### Tabloids and rows -/
+
+/-- **Two tableaux have the same tabloid exactly when they put every label in the same row.** -/
+theorem tabloid_eq_iff_rowIndex_eq {t u : YoungTableau μ} :
+    tabloid t = tabloid u ↔ rowIndex t = rowIndex u := by
+  obtain ⟨σ, rfl⟩ := exists_relabel_eq t u
+  rw [tabloid_relabel, eq_comm, smul_tabloid_eq_self_iff, mem_rowSubgroup]
+  constructor
+  · intro hσ
+    funext k
+    simpa using hσ (σ⁻¹ k)
+  · intro hσ k
+    have hk := congrFun hσ (σ k)
+    rw [rowIndex_relabel] at hk
+    simpa using hk
+
+/-! ### A column permutation lowers the tabloid of a standard tableau -/
+
+/-- If `A` is a lower set of `S`, then no subset of `S` with at most as many members as `A` meets a
+lower set `p` in more members than `A` does: either `p` contains all of `A`, and cardinality
+settles it, or `p` misses a member of `A` and hence lies inside `A` already. -/
+private theorem card_filter_le_of_isLowerSet {α : Type*} [LinearOrder α]
+    {S A C : Finset α} {p : α → Prop} [DecidablePred p] (hCS : C ⊆ S) (hcard : C.card ≤ A.card)
+    (hdown : ∀ x ∈ A, ∀ y ∈ S, y < x → y ∈ A) (hp : ∀ x y : α, y < x → p x → p y) :
+    (C.filter p).card ≤ (A.filter p).card := by
+  by_cases hall : ∀ x ∈ A, p x
+  · rw [Finset.filter_true_of_mem hall]
+    exact (Finset.card_le_card (Finset.filter_subset _ _)).trans hcard
+  · obtain ⟨a, ha, hpa⟩ : ∃ a ∈ A, ¬ p a := by
+      by_contra hc
+      exact hall fun x hx => not_not.mp fun hpx => hc ⟨x, hx, hpx⟩
+    refine Finset.card_le_card fun y hy => ?_
+    obtain ⟨hyC, hpy⟩ := Finset.mem_filter.mp hy
+    have hlt : y < a := by
+      rcases lt_trichotomy y a with h | h | h
+      · exact h
+      · exact absurd (h ▸ hpy) hpa
+      · exact absurd (hp y a h hpy) hpa
+    exact Finset.mem_filter.mpr ⟨hdown a ha y (hCS hyC) hlt, hpy⟩
+
+/-- **A column permutation lowers the tabloid of a standard Young tableau.**  In each column of a
+standard tableau the labels of the first rows are the smallest ones of the column, so moving them
+about inside their columns can only push labels down. -/
+theorem tabloidDominates_relabel_of_mem_colSubgroup (T : StandardYoungTableau μ)
+    {q : Equiv.Perm (Fin μ.card)} (hq : q ∈ colSubgroup T.toEquiv) :
+    TabloidDominates T.toEquiv (relabel q T.toEquiv) := by
+  classical
+  have hcol : ∀ k, colIndex T.toEquiv (q k) = colIndex T.toEquiv k := mem_colSubgroup.mp hq
+  intro m i
+  -- index the labels of the relabelled tableau by their preimages
+  have hreindex : rowCount (relabel q T.toEquiv) m i =
+      (Finset.univ.filter fun x : Fin μ.card =>
+        ((q x : Fin μ.card) : ℕ) < m ∧ rowIndex T.toEquiv x ≤ i).card := by
+    refine Finset.card_equiv (q⁻¹ : Equiv.Perm (Fin μ.card)) fun k => ?_
+    simp [rowIndex_relabel]
+  -- both counts split over the columns of `T`
+  have hmemJ : ∀ x : Fin μ.card,
+      colIndex T.toEquiv x ∈ Finset.image (colIndex T.toEquiv) Finset.univ := fun x =>
+    Finset.mem_image_of_mem _ (Finset.mem_univ x)
+  rw [hreindex, rowCount,
+    Finset.card_eq_sum_card_fiberwise (f := colIndex T.toEquiv)
+      (t := Finset.image (colIndex T.toEquiv) Finset.univ) fun x _ => hmemJ x,
+    Finset.card_eq_sum_card_fiberwise (f := colIndex T.toEquiv)
+      (t := Finset.image (colIndex T.toEquiv) Finset.univ) fun x _ => hmemJ x]
+  refine Finset.sum_le_sum fun j _ => ?_
+  -- the labels of column `j` in the first `i + 1` rows, and their images under `q`
+  set A : Finset (Fin μ.card) :=
+    Finset.univ.filter fun x => colIndex T.toEquiv x = j ∧ rowIndex T.toEquiv x ≤ i with hA
+  have hleft : ((Finset.univ.filter fun x : Fin μ.card =>
+        ((q x : Fin μ.card) : ℕ) < m ∧ rowIndex T.toEquiv x ≤ i).filter
+      fun x => colIndex T.toEquiv x = j) =
+      A.filter fun x => ((q x : Fin μ.card) : ℕ) < m := by
+    ext x
+    simp only [hA, Finset.mem_filter, Finset.mem_univ, true_and]
+    tauto
+  have hright : ((Finset.univ.filter fun x : Fin μ.card =>
+        (x : ℕ) < m ∧ rowIndex T.toEquiv x ≤ i).filter fun x => colIndex T.toEquiv x = j) =
+      A.filter fun x : Fin μ.card => (x : ℕ) < m := by
+    ext x
+    simp only [hA, Finset.mem_filter, Finset.mem_univ, true_and]
+    tauto
+  rw [hleft, hright]
+  -- the image of `A` under `q` is another set of that many labels of the column
+  have himage : (A.filter fun x : Fin μ.card => ((q x : Fin μ.card) : ℕ) < m).card =
+      ((A.image q).filter fun y : Fin μ.card => (y : ℕ) < m).card := by
+    rw [Finset.filter_image, Finset.card_image_of_injective _ q.injective]
+  rw [himage]
+  refine card_filter_le_of_isLowerSet (S := Finset.univ.filter fun x => colIndex T.toEquiv x = j)
+    (fun y hy => ?_) (le_of_eq (Finset.card_image_of_injective _ q.injective))
+    (fun x hx y hy hlt => ?_) fun _ _ hxy hx => (Fin.lt_def.mp hxy).trans hx
+  · obtain ⟨x, hx, rfl⟩ := Finset.mem_image.mp hy
+    simp only [hA, Finset.mem_filter, Finset.mem_univ, true_and] at hx ⊢
+    rw [hcol x]
+    exact hx.1
+  · simp only [hA, Finset.mem_filter, Finset.mem_univ, true_and] at hx hy ⊢
+    refine ⟨hy, le_of_lt (lt_of_lt_of_le ?_ hx.2)⟩
+    exact (T.lt_iff_rowIndex_lt (hy.trans hx.1.symm)).mp hlt
+
+/-! ### The coefficient of a tabloid in a polytabloid -/
+
+/-- Only the tabloids reachable from `{t}` by a column permutation occur in the polytabloid
+`e_t`. -/
+theorem polytabloid_coeff_eq_zero_of_forall_ne (t : YoungTableau μ)
+    {X : Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)}
+    (h : ∀ q ∈ colSubgroup t, q • tabloid t ≠ X) : (polytabloid t).coeff X = 0 := by
+  classical
+  rw [polytabloid_eq_sum, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
+  refine Finset.sum_eq_zero fun q _ => ?_
+  have hne := h (q : Equiv.Perm (Fin μ.card)) q.2
+  simp [MonoidAlgebra.coeff_single, hne]
+
+end YoungTableau
+
+/-! ### Linear independence of the standard polytabloids -/
+
+open YoungTableau
+
+/-- **The standard polytabloids are linearly independent.**  Among the standard tableaux carrying
+a nonzero coefficient, one of largest weight has a tabloid that no other standard polytabloid of
+the combination reaches, so its coefficient is read off the combination. -/
+theorem linearIndependent_polytabloid (μ : YoungDiagram) :
+    LinearIndependent ℚ fun T : StandardYoungTableau μ => polytabloid T.toEquiv := by
+  classical
+  rw [linearIndependent_iff']
+  intro s g hsum T₁ hT₁
+  by_contra hg
+  obtain ⟨T₀, hT₀, hmax⟩ := Finset.exists_max_image (s.filter fun T => g T ≠ 0)
+    (fun T => rowWeight T.toEquiv) ⟨T₁, Finset.mem_filter.mpr ⟨hT₁, hg⟩⟩
+  obtain ⟨hT₀s, hg₀⟩ := Finset.mem_filter.mp hT₀
+  -- no other standard polytabloid of the combination reaches the tabloid of `T₀`
+  have hzero : ∀ T ∈ s, T ≠ T₀ →
+      (g T • polytabloid T.toEquiv).coeff (tabloid T₀.toEquiv) = 0 := by
+    intro T hTs hTne
+    rcases eq_or_ne (g T) 0 with h0 | h0
+    · simp [h0]
+    have hvanish : (polytabloid T.toEquiv).coeff (tabloid T₀.toEquiv) = 0 := by
+      refine polytabloid_coeff_eq_zero_of_forall_ne _ fun q hq hcontra => hTne ?_
+      have hdom : TabloidDominates T.toEquiv (relabel q T.toEquiv) :=
+        tabloidDominates_relabel_of_mem_colSubgroup T hq
+      have hrow : rowIndex (relabel q T.toEquiv) = rowIndex T₀.toEquiv := by
+        rw [← tabloid_eq_iff_rowIndex_eq, tabloid_relabel, hcontra]
+      have hw : rowWeight T.toEquiv ≤ rowWeight (relabel q T.toEquiv) := by
+        rw [rowWeight_congr hrow]
+        exact hmax T (Finset.mem_filter.mpr ⟨hTs, h0⟩)
+      exact StandardYoungTableau.rowIndex_injective μ
+        ((rowIndex_eq_of_tabloidDominates hdom hw).symm.trans hrow)
+    simp [hvanish]
+  -- so the coefficient of that tabloid in the combination is the coefficient of `T₀`
+  have hcoeff : (∑ T ∈ s, g T • polytabloid T.toEquiv).coeff (tabloid T₀.toEquiv) = 0 := by
+    rw [hsum]
+    simp
+  rw [MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply,
+    Finset.sum_eq_single_of_mem T₀ hT₀s hzero] at hcoeff
+  simp only [MonoidAlgebra.coeff_smul, Finsupp.smul_apply, polytabloid_coeff_tabloid,
+    smul_eq_mul, mul_one] at hcoeff
+  exact hg₀ hcoeff
+
+/-- **There are at least `f^μ` dimensions in the Specht module.**  Equality holds, but the reverse
+inequality is the straightening algorithm and is not proved here. -/
+theorem standardCount_le_finrank_spechtSubrepresentation (μ : YoungDiagram) :
+    standardCount μ ≤ Module.finrank ℚ (spechtSubrepresentation μ).toSubmodule := by
+  classical
+  have hli : LinearIndependent ℚ fun T : StandardYoungTableau μ =>
+      (⟨polytabloid T.toEquiv, polytabloid_mem_spechtSubrepresentation T.toEquiv⟩ :
+        (spechtSubrepresentation μ).toSubmodule) :=
+    LinearIndependent.of_comp (spechtSubrepresentation μ).toSubmodule.subtype
+      (linearIndependent_polytabloid μ)
+  simpa [standardCount_def] using hli.fintype_card_le_finrank
+
+/-- **The number of standard Young tableaux of shape `μ` is at most the dimension of the Specht
+module `S^μ`.** -/
+theorem standardCount_le_finrank_spechtModule {n : ℕ} (μ : n.Partition) :
+    standardCount (diagramOf μ) ≤ Module.finrank ℚ (spechtModule μ) :=
+  standardCount_le_finrank_spechtSubrepresentation (diagramOf μ)
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean
@@ -111,10 +111,10 @@ theorem rowCount_succ (t : YoungTableau μ) (k : Fin μ.card) (i : ℕ) :
 /-- **The counts determine the rows.**  A tableau puts a label in the first row for which the
 count jumps. -/
 theorem rowIndex_eq_of_rowCount_eq {t u : YoungTableau μ}
-    (h : ∀ m ≤ μ.card, ∀ i ≤ μ.card, rowCount t m i = rowCount u m i) :
+    (h : ∀ m ≤ μ.card, ∀ i < μ.colLen 0, rowCount t m i = rowCount u m i) :
     rowIndex t = rowIndex u := by
   funext k
-  have key : ∀ i ≤ μ.card, (rowIndex t k ≤ i ↔ rowIndex u k ≤ i) := by
+  have key : ∀ i < μ.colLen 0, (rowIndex t k ≤ i ↔ rowIndex u k ≤ i) := by
     intro i hi
     have h1 := h ((k : ℕ) + 1) k.isLt i hi
     rw [rowCount_succ, rowCount_succ, h (k : ℕ) k.isLt.le i hi] at h1
@@ -129,8 +129,8 @@ theorem rowIndex_eq_of_rowCount_eq {t u : YoungTableau μ}
       by_contra hp
       rw [if_neg hp, if_pos hq] at h2
       exact absurd h2 zero_ne_one
-  exact le_antisymm ((key (rowIndex u k) (rowIndex_lt_card u k).le).mpr le_rfl)
-    ((key (rowIndex t k) (rowIndex_lt_card t k).le).mp le_rfl)
+  exact le_antisymm ((key (rowIndex u k) (rowIndex_lt_colLen_zero u k)).mpr le_rfl)
+    ((key (rowIndex t k) (rowIndex_lt_colLen_zero t k)).mp le_rfl)
 
 /-! ### The dominance order on tabloids -/
 
@@ -162,7 +162,7 @@ theorem TabloidDominates.antisymm {t u : YoungTableau μ} (h : TabloidDominates 
 increases it, and a dominating tableau of no greater weight has the same rows
 (`rowIndex_eq_of_tabloidDominates`). -/
 private def rowWeight (t : YoungTableau μ) : ℕ :=
-  ∑ m ∈ Finset.range (μ.card + 1), ∑ i ∈ Finset.range (μ.card + 1), rowCount t m i
+  ∑ m ∈ Finset.range (μ.card + 1), ∑ i ∈ Finset.range (μ.colLen 0), rowCount t m i
 
 private theorem rowWeight_congr {t u : YoungTableau μ} (h : rowIndex t = rowIndex u) :
     rowWeight t = rowWeight u := by
@@ -180,8 +180,7 @@ private theorem rowIndex_eq_of_tabloidDominates {t u : YoungTableau μ} (h : Tab
       (le_antisymm (rowWeight_le_of_tabloidDominates h) hw)
   refine rowIndex_eq_of_rowCount_eq fun m hm i hi => ?_
   exact (Finset.sum_eq_sum_iff_of_le fun i _ => h m i).mp
-    (hinner m (Finset.mem_range.mpr (Nat.lt_succ_of_le hm))) i
-    (Finset.mem_range.mpr (Nat.lt_succ_of_le hi))
+    (hinner m (Finset.mem_range.mpr (Nat.lt_succ_of_le hm))) i (Finset.mem_range.mpr hi)
 
 /-! ### A column permutation lowers the tabloid of a standard tableau -/
 


### PR DESCRIPTION
This PR proves that the polytabloids of the standard Young tableaux of a shape are linearly independent, so that `f^μ = standardCount μ` is at most `finrank ℚ S^μ`. It orders the tabloids by dominance -- `{t}` dominates `{u}` when, for every `m` and `i`, at least as many of the labels below `m` sit in the first `i + 1` rows of `t` as of `u` -- and proves the two facts that make the standard polytabloids triangular against the tabloid basis: a column permutation of a standard tableau lowers its tabloid, and a standard tableau is determined by its tabloid. The first is proved column by column, with no straightening induction: in each column of a standard tableau the labels of the first rows are the smallest ones of that column, so no other set of that many labels of the column has more members below a bound. Taking the standard tableau of largest weight among those carrying a nonzero coefficient, its tabloid occurs in no other standard polytabloid of the combination, and its coefficient is read off directly.

This serves the Schur-Weyl roadmap's Layer 5 milestone, the standard basis of the Specht module: "The polytabloids `{e_t : t ∈ StandardYoungTableau μ}` form a basis of `spechtModule μ` ... hence `finrank ℚ (spechtModule μ) = standardCount μ = f^λ`." What remains for that milestone after this PR is the reverse inequality, the straightening algorithm expressing an arbitrary polytabloid in the standard ones through the Garnir relations, which the roadmap flags as a target of its own; the hook-length formula sits behind it.

Files added:

- `TauCeti/Combinatorics/Young/StandardTableau/Order.lean` (182 lines): two labels of a standard tableau sharing a column are ordered as their rows are, two sharing a row as their columns are, and a standard tableau is determined by the row of each label. The last rests on `perm_apply_eq_self_of_lt_iff_lt`, that a permutation preserving a finite set and increasing on it fixes it pointwise.
- `TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean` (348 lines): `rowCount`, `TabloidDominates` and the numerical refinement `rowWeight`; `tabloid_eq_iff_rowIndex_eq`; `tabloidDominates_relabel_of_mem_colSubgroup`; `linearIndependent_polytabloid`; `standardCount_le_finrank_spechtModule`.

Dominance on tabloids is only a partial order, so the maximum is taken along `rowWeight`, the total of the counts over the range where they can differ: dominance raises it, and it is unchanged only when every count agrees, which pins the rows down.

Nothing was migrated from the supplementary source snapshot, and no Mathlib infrastructure was vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"standard-polytabloids-linearly-independent"}-->

🤖 Prepared with Claude Code
