### PR TITLE
feat: characterize geometric connectedness by idempotents

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Geometrically.Connected
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+public import TauCeti.RingTheory.Idempotents.ConnectedSpectrum
+import Mathlib.RingTheory.Flat.Basic
+
+/-!
+# Geometric connectedness of affine group schemes
+
+For a commutative Hopf algebra `H` over a field `k`, the affine group scheme `Spec H` is
+geometrically connected precisely when every field extension has connected coordinate-ring
+spectrum.  Since the base change to a field `K` has coordinate ring `H ⊗[k] K`, this is
+equivalent to saying that `H ⊗[k] K` has no idempotents other than zero and one for every
+extension field `K / k`.
+
+The quantification over extensions is essential: connectedness of `Spec H` over `k` alone is
+strictly weaker than geometric connectedness.  This file keeps geometric connectedness as an
+explicit predicate, in parallel with the finite-type and smoothness predicates already used for
+affine group schemes.
+
+## Main declarations
+
+* `TauCeti.geometricallyConnectedCommHopfAlgProperty`: the coordinate-ring predicate.
+* `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff`: its connected-spectrum form.
+* `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff_idempotents`: its idempotent form.
+* `TauCeti.geometricallyConnected_hopfSpec_iff`: compatibility with Mathlib's scheme-theoretic
+  `GeometricallyConnected` predicate.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §2.a.
+
+This is the geometric-connectedness prerequisite for Layer 3, "Identity component and component
+group", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+universe u
+
+/-- A Hopf algebra remains nontrivial after extension of its base field. -/
+private theorem nontrivial_tensorField
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
+    (K : Type u) [Field K] [Algebra k K] :
+    Nontrivial ((H : Type u) ⊗[k] K) := by
+  have hinjective : Function.Injective (algebraMap k H) := by
+    intro x y hxy
+    have h := congrArg (Coalgebra.counit (R := k)) hxy
+    simpa only [Bialgebra.counit_algebraMap] using h
+  let : Nontrivial (H : Type u) := hinjective.nontrivial
+  exact Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_flat_left
+    k H K (algebraMap k K).injective
+
+/-- A commutative Hopf algebra over a field is geometrically connected when the spectrum of its
+coordinate ring remains connected after every extension of the base field. -/
+def geometricallyConnectedCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (CommHopfAlgCat.{u} k) :=
+  fun H ↦ ∀ (K : Type u) [Field K] [Algebra k K],
+    ConnectedSpace (PrimeSpectrum ((H : Type u) ⊗[k] K))
+
+/-- The coordinate-ring geometric-connectedness predicate unfolds to connectedness of every
+base-changed prime spectrum. -/
+theorem geometricallyConnectedCommHopfAlgProperty_iff
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    geometricallyConnectedCommHopfAlgProperty k H ↔
+      ∀ (K : Type u) [Field K] [Algebra k K],
+        ConnectedSpace (PrimeSpectrum ((H : Type u) ⊗[k] K)) :=
+  Iff.rfl
+
+/-- **A commutative Hopf algebra is geometrically connected exactly when every field extension
+of its coordinate ring has only the trivial idempotents.** -/
+theorem geometricallyConnectedCommHopfAlgProperty_iff_idempotents
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    geometricallyConnectedCommHopfAlgProperty k H ↔
+      ∀ (K : Type u) [Field K] [Algebra k K] (e : (H : Type u) ⊗[k] K),
+        IsIdempotentElem e → e = 0 ∨ e = 1 := by
+  rw [geometricallyConnectedCommHopfAlgProperty_iff]
+  constructor
+  · intro h K _ _
+    let := nontrivial_tensorField k H K
+    exact connectedSpace_primeSpectrum_iff.mp (h K)
+  · intro h K _ _
+    let := nontrivial_tensorField k H K
+    exact connectedSpace_primeSpectrum_iff.mpr (h K)
+
+/-- **Geometric connectedness agrees across the coordinate-ring and affine-group-scheme
+models.** A commutative Hopf algebra is geometrically connected after every field extension if
+and only if the structural morphism of its Hopf spectrum is geometrically connected. -/
+theorem geometricallyConnected_hopfSpec_iff
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    geometricallyConnectedCommHopfAlgProperty k H ↔
+      GeometricallyConnected
+        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) := by
+  let : MorphismProperty.RespectsIso @GeometricallyConnected :=
+    MorphismProperty.IsStableUnderBaseChange.respectsIso
+  rw [geometricallyConnectedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
+  rw [MorphismProperty.cancel_left_of_respectsIso
+    (P := @GeometricallyConnected) (eqToHom (hopfSpec_obj_X_left k H))]
+  rw [GeometricallyConnected.eq_geometrically,
+    geometrically_iff_of_commRing_of_isClosedUnderIsomorphisms]
+  constructor
+  · intro h K _ _
+    exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mpr (h K)
+  · intro h K _ _
+    exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mp (h K)
+
+/-- The structural morphism of a Hopf spectrum is geometrically connected exactly when every
+field extension of its coordinate ring has only zero and one as idempotents. -/
+theorem geometricallyConnected_hopfSpec_iff_idempotents
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    GeometricallyConnected
+        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) ↔
+      ∀ (K : Type u) [Field K] [Algebra k K] (e : (H : Type u) ⊗[k] K),
+        IsIdempotentElem e → e = 0 ∨ e = 1 := by
+  rw [← geometricallyConnected_hopfSpec_iff,
+    geometricallyConnectedCommHopfAlgProperty_iff_idempotents]
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
@@ -11,19 +11,17 @@ import Mathlib.RingTheory.Flat.Basic
 /-!
 # Geometric connectedness of commutative Hopf algebras
 
-For a commutative Hopf algebra `H` over a field `k`, geometric connectedness means that every
-field extension of its coordinate ring has connected prime spectrum. Since the base change to a
-field `K` has coordinate ring `H ⊗[k] K`, this is equivalent to saying that `H ⊗[k] K` has
-no idempotents other than zero and one for every extension field `K / k`.
-
-The quantification over extensions is essential: connectedness of `Spec H` over `k` alone is
-strictly weaker than geometric connectedness.
+For a commutative Hopf algebra `H` over a field `k`, geometric connectedness means that after
+every extension `K / k` of the base field, the base-changed coordinate ring `H ⊗[k] K` has
+connected prime spectrum. This is equivalent to saying that every such base change has no
+idempotents other than zero and one.
 
 ## Main declarations
 
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty`: the coordinate-ring predicate.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff`: its connected-spectrum form.
-* `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff_idempotents`: its idempotent form.
+* `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff_idempotent_eq_zero_or_one`: its
+  idempotent form.
 
 ## References
 
@@ -43,15 +41,11 @@ namespace TauCeti
 universe u
 
 /-- A Hopf algebra remains nontrivial after extension of its base field. -/
-private theorem nontrivial_tensorField
+private theorem nontrivial_tensorProduct
     (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
     (K : Type u) [Field K] [Algebra k K] :
     Nontrivial ((H : Type u) ⊗[k] K) := by
-  have hinjective : Function.Injective (algebraMap k H) := by
-    intro x y hxy
-    have h := congrArg (Coalgebra.counit (R := k)) hxy
-    simpa only [Bialgebra.counit_algebraMap] using h
-  let : Nontrivial (H : Type u) := hinjective.nontrivial
+  let : Nontrivial (H : Type u) := Bialgebra.nontrivial k
   exact Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_flat_left
     k H K (algebraMap k K).injective
 
@@ -71,6 +65,14 @@ theorem geometricallyConnectedCommHopfAlgProperty_iff
         ConnectedSpace (PrimeSpectrum ((H : Type u) ⊗[k] K)) :=
   Iff.rfl
 
+/-- A geometrically connected commutative Hopf algebra has connected prime spectrum. -/
+theorem geometricallyConnectedCommHopfAlgProperty.connectedSpace
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
+    (h : geometricallyConnectedCommHopfAlgProperty k H) :
+    ConnectedSpace (PrimeSpectrum (H : Type u)) :=
+  (PrimeSpectrum.homeomorphOfRingEquiv
+    (Algebra.TensorProduct.rid k k H).toRingEquiv).connectedSpace_iff.mp (h k)
+
 /-- Geometric connectedness is invariant under isomorphisms of commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :
     (geometricallyConnectedCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
@@ -81,9 +83,9 @@ instance (k : Type u) [Field k] :
       (CommHopfAlgCat.ofIso e).toAlgEquiv (AlgEquiv.refl : K ≃ₐ[k] K)
     exact (PrimeSpectrum.homeomorphOfRingEquiv eK.toRingEquiv).connectedSpace_iff.mp (hH K)
 
-/-- **A commutative Hopf algebra is geometrically connected exactly when every field extension
-of its coordinate ring has only the trivial idempotents.** -/
-theorem geometricallyConnectedCommHopfAlgProperty_iff_idempotents
+/-- **A commutative Hopf algebra is geometrically connected exactly when, after every extension
+`K / k` of the base field, every idempotent of `H ⊗[k] K` is zero or one.** -/
+theorem geometricallyConnectedCommHopfAlgProperty_iff_idempotent_eq_zero_or_one
     (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
     geometricallyConnectedCommHopfAlgProperty k H ↔
       ∀ (K : Type u) [Field K] [Algebra k K] (e : (H : Type u) ⊗[k] K),
@@ -91,10 +93,10 @@ theorem geometricallyConnectedCommHopfAlgProperty_iff_idempotents
   rw [geometricallyConnectedCommHopfAlgProperty_iff]
   constructor
   · intro h K _ _
-    let := nontrivial_tensorField k H K
-    exact connectedSpace_primeSpectrum_iff.mp (h K)
+    let := nontrivial_tensorProduct k H K
+    exact connectedSpace_primeSpectrum_iff_idempotent_eq_zero_or_one.mp (h K)
   · intro h K _ _
-    let := nontrivial_tensorField k H K
-    exact connectedSpace_primeSpectrum_iff.mpr (h K)
+    let := nontrivial_tensorProduct k H K
+    exact connectedSpace_primeSpectrum_iff_idempotent_eq_zero_or_one.mpr (h K)
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
@@ -4,32 +4,26 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.AlgebraicGeometry.Geometrically.Connected
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
 public import TauCeti.RingTheory.Idempotents.ConnectedSpectrum
 import Mathlib.RingTheory.Flat.Basic
 
 /-!
-# Geometric connectedness of affine group schemes
+# Geometric connectedness of commutative Hopf algebras
 
-For a commutative Hopf algebra `H` over a field `k`, the affine group scheme `Spec H` is
-geometrically connected precisely when every field extension has connected coordinate-ring
-spectrum.  Since the base change to a field `K` has coordinate ring `H ⊗[k] K`, this is
-equivalent to saying that `H ⊗[k] K` has no idempotents other than zero and one for every
-extension field `K / k`.
+For a commutative Hopf algebra `H` over a field `k`, geometric connectedness means that every
+field extension of its coordinate ring has connected prime spectrum. Since the base change to a
+field `K` has coordinate ring `H ⊗[k] K`, this is equivalent to saying that `H ⊗[k] K` has
+no idempotents other than zero and one for every extension field `K / k`.
 
 The quantification over extensions is essential: connectedness of `Spec H` over `k` alone is
-strictly weaker than geometric connectedness.  This file keeps geometric connectedness as an
-explicit predicate, in parallel with the finite-type and smoothness predicates already used for
-affine group schemes.
+strictly weaker than geometric connectedness.
 
 ## Main declarations
 
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty`: the coordinate-ring predicate.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff`: its connected-spectrum form.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff_idempotents`: its idempotent form.
-* `TauCeti.geometricallyConnected_hopfSpec_iff`: compatibility with Mathlib's scheme-theoretic
-  `GeometricallyConnected` predicate.
 
 ## References
 
@@ -45,8 +39,6 @@ open CategoryTheory
 open scoped TensorProduct
 
 namespace TauCeti
-
-open AlgebraicGeometry
 
 universe u
 
@@ -70,14 +62,24 @@ def geometricallyConnectedCommHopfAlgProperty (k : Type u) [Field k] :
   fun H ↦ ∀ (K : Type u) [Field K] [Algebra k K],
     ConnectedSpace (PrimeSpectrum ((H : Type u) ⊗[k] K))
 
-/-- The coordinate-ring geometric-connectedness predicate unfolds to connectedness of every
-base-changed prime spectrum. -/
+/-- Membership in the geometrically connected commutative-Hopf-algebra object property. -/
+@[simp]
 theorem geometricallyConnectedCommHopfAlgProperty_iff
     (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
     geometricallyConnectedCommHopfAlgProperty k H ↔
       ∀ (K : Type u) [Field K] [Algebra k K],
         ConnectedSpace (PrimeSpectrum ((H : Type u) ⊗[k] K)) :=
   Iff.rfl
+
+/-- Geometric connectedness is invariant under isomorphisms of commutative Hopf algebras. -/
+instance (k : Type u) [Field k] :
+    (geometricallyConnectedCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
+  of_iso e hH := by
+    rw [geometricallyConnectedCommHopfAlgProperty_iff] at hH ⊢
+    intro K _ _
+    let eK := Algebra.TensorProduct.congr
+      (CommHopfAlgCat.ofIso e).toAlgEquiv (AlgEquiv.refl : K ≃ₐ[k] K)
+    exact (PrimeSpectrum.homeomorphOfRingEquiv eK.toRingEquiv).connectedSpace_iff.mp (hH K)
 
 /-- **A commutative Hopf algebra is geometrically connected exactly when every field extension
 of its coordinate ring has only the trivial idempotents.** -/
@@ -94,37 +96,5 @@ theorem geometricallyConnectedCommHopfAlgProperty_iff_idempotents
   · intro h K _ _
     let := nontrivial_tensorField k H K
     exact connectedSpace_primeSpectrum_iff.mpr (h K)
-
-/-- **Geometric connectedness agrees across the coordinate-ring and affine-group-scheme
-models.** A commutative Hopf algebra is geometrically connected after every field extension if
-and only if the structural morphism of its Hopf spectrum is geometrically connected. -/
-theorem geometricallyConnected_hopfSpec_iff
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
-    geometricallyConnectedCommHopfAlgProperty k H ↔
-      GeometricallyConnected
-        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) := by
-  let : MorphismProperty.RespectsIso @GeometricallyConnected :=
-    MorphismProperty.IsStableUnderBaseChange.respectsIso
-  rw [geometricallyConnectedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
-  rw [MorphismProperty.cancel_left_of_respectsIso
-    (P := @GeometricallyConnected) (eqToHom (hopfSpec_obj_X_left k H))]
-  rw [GeometricallyConnected.eq_geometrically,
-    geometrically_iff_of_commRing_of_isClosedUnderIsomorphisms]
-  constructor
-  · intro h K _ _
-    exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mpr (h K)
-  · intro h K _ _
-    exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mp (h K)
-
-/-- The structural morphism of a Hopf spectrum is geometrically connected exactly when every
-field extension of its coordinate ring has only zero and one as idempotents. -/
-theorem geometricallyConnected_hopfSpec_iff_idempotents
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
-    GeometricallyConnected
-        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) ↔
-      ∀ (K : Type u) [Field K] [Algebra k K] (e : (H : Type u) ⊗[k] K),
-        IsIdempotentElem e → e = 0 ∨ e = 1 := by
-  rw [← geometricallyConnected_hopfSpec_iff,
-    geometricallyConnectedCommHopfAlgProperty_iff_idempotents]
 
 end TauCeti

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
@@ -6,9 +6,9 @@ module
 
 public import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
 public import Mathlib.RingTheory.Coalgebra.GroupLike
-public import Mathlib.RingTheory.Spectrum.Prime.Topology
 public import Mathlib.RingTheory.TensorProduct.MonoidAlgebra
 public import TauCeti.Algebra.Coalgebra.Subcoalgebra.GroupLike
+public import TauCeti.RingTheory.Idempotents.ConnectedSpectrum
 
 /-!
 # Group-like elements of monoid algebras
@@ -44,22 +44,6 @@ universe u v w
 namespace MonoidAlgebra
 
 variable (R : Type u)
-
-private theorem eq_zero_or_eq_one_of_isIdempotentElem
-    [CommRing R] [ConnectedSpace (PrimeSpectrum R)] (e : R) (he : IsIdempotentElem e) :
-    e = 0 ∨ e = 1 := by
-  have hopen : IsClopen
-      (PrimeSpectrum.basicOpen e : Set (PrimeSpectrum R)) :=
-    PrimeSpectrum.isClopen_iff.mpr ⟨e, he, rfl⟩
-  rcases _root_.isClopen_iff.mp hopen with hempty | huniv
-  · left
-    apply PrimeSpectrum.basicOpen_injOn_isIdempotentElem he .zero
-    apply SetLike.ext'
-    simpa only [PrimeSpectrum.basicOpen_zero, TopologicalSpace.Opens.coe_bot] using hempty
-  · right
-    apply PrimeSpectrum.basicOpen_injOn_isIdempotentElem he .one
-    apply SetLike.ext'
-    simpa only [PrimeSpectrum.basicOpen_one, TopologicalSpace.Opens.coe_top] using huniv
 
 /-- The group-like elements of a monoid algebra span the whole algebra: every standard basis
 element is group-like, and the standard basis spans. -/
@@ -107,7 +91,7 @@ theorem isGroupLikeElem_iff_eq_single [CommRing R]
       rw [tensorEquiv_comul_apply] at hcomul
       simpa using hcomul
     have hcoeff_zero_or_one (g : H) : x.coeff g = 0 ∨ x.coeff g = 1 := by
-      apply eq_zero_or_eq_one_of_isIdempotentElem R
+      apply connectedSpace_primeSpectrum_iff.mp inferInstance
       exact isIdempotentElem_iff.mpr (by simpa using (hcoeff g g).symm)
     have hx_coeff_ne : x.coeff ≠ 0 := by
       intro hzero

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
@@ -91,7 +91,7 @@ theorem isGroupLikeElem_iff_eq_single [CommRing R]
       rw [tensorEquiv_comul_apply] at hcomul
       simpa using hcomul
     have hcoeff_zero_or_one (g : H) : x.coeff g = 0 ∨ x.coeff g = 1 := by
-      apply connectedSpace_primeSpectrum_iff.mp inferInstance
+      apply eq_zero_or_eq_one_of_isIdempotentElem
       exact isIdempotentElem_iff.mpr (by simpa using (hcoeff g g).symm)
     have hx_coeff_ne : x.coeff ≠ 0 := by
       intro hzero

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Geometrically.Connected
+public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+
+/-!
+# Geometric connectedness of affine group schemes
+
+This file compares geometric connectedness of a commutative Hopf algebra with Mathlib's
+scheme-theoretic `GeometricallyConnected` predicate on its Hopf spectrum.
+
+## Main declarations
+
+* `TauCeti.geometricallyConnected_hopfSpec_iff`: compatibility of the scheme-theoretic and
+  coordinate-ring predicates.
+* `TauCeti.geometricallyConnected_hopfSpec_iff_idempotents`: the idempotent characterization of
+  geometric connectedness for a Hopf spectrum.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §2.a.
+
+This is the geometric-connectedness prerequisite for Layer 3, "Identity component and component
+group", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+universe u
+
+/-- **Geometric connectedness agrees across the affine-group-scheme and coordinate-ring
+models.** The structural morphism of a Hopf spectrum is geometrically connected if and only if
+its coordinate algebra is geometrically connected after every field extension. -/
+theorem geometricallyConnected_hopfSpec_iff
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    GeometricallyConnected
+        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) ↔
+      geometricallyConnectedCommHopfAlgProperty k H := by
+  let : MorphismProperty.RespectsIso @GeometricallyConnected :=
+    MorphismProperty.IsStableUnderBaseChange.respectsIso
+  rw [geometricallyConnectedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
+  rw [MorphismProperty.cancel_left_of_respectsIso
+    (P := @GeometricallyConnected) (eqToHom (hopfSpec_obj_X_left k H))]
+  rw [GeometricallyConnected.eq_geometrically,
+    geometrically_iff_of_commRing_of_isClosedUnderIsomorphisms]
+  constructor
+  · intro h K _ _
+    exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mp (h K)
+  · intro h K _ _
+    exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mpr (h K)
+
+/-- The structural morphism of a Hopf spectrum is geometrically connected exactly when every
+field extension of its coordinate ring has only zero and one as idempotents. -/
+theorem geometricallyConnected_hopfSpec_iff_idempotents
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    GeometricallyConnected
+        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) ↔
+      ∀ (K : Type u) [Field K] [Algebra k K] (e : (H : Type u) ⊗[k] K),
+        IsIdempotentElem e → e = 0 ∨ e = 1 := by
+  rw [geometricallyConnected_hopfSpec_iff,
+    geometricallyConnectedCommHopfAlgProperty_iff_idempotents]
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
@@ -16,10 +16,10 @@ scheme-theoretic `GeometricallyConnected` predicate on its Hopf spectrum.
 
 ## Main declarations
 
-* `TauCeti.geometricallyConnected_hopfSpec_iff`: compatibility of the scheme-theoretic and
-  coordinate-ring predicates.
-* `TauCeti.geometricallyConnected_hopfSpec_iff_idempotents`: the idempotent characterization of
-  geometric connectedness for a Hopf spectrum.
+* `TauCeti.geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec`: compatibility
+  of the coordinate-ring and scheme-theoretic predicates.
+* `TauCeti.geometricallyConnected_hopfSpec_iff_idempotent_eq_zero_or_one`: the idempotent
+  characterization of geometric connectedness for a Hopf spectrum.
 
 ## References
 
@@ -43,11 +43,12 @@ universe u
 /-- **Geometric connectedness agrees across the affine-group-scheme and coordinate-ring
 models.** The structural morphism of a Hopf spectrum is geometrically connected if and only if
 its coordinate algebra is geometrically connected after every field extension. -/
-theorem geometricallyConnected_hopfSpec_iff
+theorem geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec
     (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
-    GeometricallyConnected
-        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) ↔
-      geometricallyConnectedCommHopfAlgProperty k H := by
+    geometricallyConnectedCommHopfAlgProperty k H ↔
+      GeometricallyConnected
+        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) := by
+  -- This witness is not a global instance, but `cancel_left_of_respectsIso` needs it below.
   let : MorphismProperty.RespectsIso @GeometricallyConnected :=
     MorphismProperty.IsStableUnderBaseChange.respectsIso
   rw [geometricallyConnectedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
@@ -57,19 +58,19 @@ theorem geometricallyConnected_hopfSpec_iff
     geometrically_iff_of_commRing_of_isClosedUnderIsomorphisms]
   constructor
   · intro h K _ _
-    exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mp (h K)
-  · intro h K _ _
     exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mpr (h K)
+  · intro h K _ _
+    exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mp (h K)
 
-/-- The structural morphism of a Hopf spectrum is geometrically connected exactly when every
-field extension of its coordinate ring has only zero and one as idempotents. -/
-theorem geometricallyConnected_hopfSpec_iff_idempotents
+/-- The structural morphism of a Hopf spectrum is geometrically connected exactly when, after
+every extension `K / k` of the base field, every idempotent of `H ⊗[k] K` is zero or one. -/
+theorem geometricallyConnected_hopfSpec_iff_idempotent_eq_zero_or_one
     (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
     GeometricallyConnected
         (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) ↔
       ∀ (K : Type u) [Field K] [Algebra k K] (e : (H : Type u) ⊗[k] K),
         IsIdempotentElem e → e = 0 ∨ e = 1 := by
-  rw [geometricallyConnected_hopfSpec_iff,
-    geometricallyConnectedCommHopfAlgProperty_iff_idempotents]
+  rw [← geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec,
+    geometricallyConnectedCommHopfAlgProperty_iff_idempotent_eq_zero_or_one]
 
 end TauCeti

--- a/TauCeti/RingTheory/Idempotents/ConnectedSpectrum.lean
+++ b/TauCeti/RingTheory/Idempotents/ConnectedSpectrum.lean
@@ -15,37 +15,50 @@ idempotents other than zero and one.  Mathlib identifies idempotents with clopen
 prime spectrum; this file records the resulting connectedness criterion in the form used by
 coordinate rings of geometrically connected affine schemes.
 
-## Main declaration
+## Main declarations
 
-* `TauCeti.connectedSpace_primeSpectrum_iff`: `Spec R` is connected if and only if every
-  idempotent of `R` is zero or one.
+* `TauCeti.eq_zero_or_eq_one_of_isIdempotentElem`: an idempotent is zero or one when `Spec R`
+  is connected.
+* `TauCeti.connectedSpace_primeSpectrum_iff_idempotent_eq_zero_or_one`: `Spec R` is connected
+  if and only if every idempotent of `R` is zero or one.
 -/
 
 public section
 
 namespace TauCeti
 
-variable {R : Type*} [CommRing R] [Nontrivial R]
+variable {R : Type*} [CommRing R]
+
+/-- An idempotent in a commutative ring with connected prime spectrum is zero or one. -/
+theorem eq_zero_or_eq_one_of_isIdempotentElem [ConnectedSpace (PrimeSpectrum R)]
+    {e : R} (he : IsIdempotentElem e) : e = 0 ∨ e = 1 := by
+  let : Nontrivial R := PrimeSpectrum.nonempty_iff_nontrivial.mp inferInstance
+  have hconnected := (connectedSpace_iff_clopen.mp
+    (inferInstance : ConnectedSpace (PrimeSpectrum R))).2
+  rcases hconnected (PrimeSpectrum.basicOpen e)
+      ((PrimeSpectrum.isClopen_iff).2 ⟨e, he, rfl⟩) with hempty | huniv
+  · left
+    apply PrimeSpectrum.basicOpen_injOn_isIdempotentElem he IsIdempotentElem.zero
+    rw [PrimeSpectrum.basicOpen_zero]
+    exact TopologicalSpace.Opens.ext hempty
+  · right
+    apply PrimeSpectrum.basicOpen_injOn_isIdempotentElem he IsIdempotentElem.one
+    rw [PrimeSpectrum.basicOpen_one]
+    exact TopologicalSpace.Opens.ext huniv
+
+variable [Nontrivial R]
 
 /-- **The prime spectrum of a nontrivial commutative ring is connected exactly when its only
 idempotents are zero and one.** -/
-theorem connectedSpace_primeSpectrum_iff :
+theorem connectedSpace_primeSpectrum_iff_idempotent_eq_zero_or_one :
     ConnectedSpace (PrimeSpectrum R) ↔
       ∀ e : R, IsIdempotentElem e → e = 0 ∨ e = 1 := by
-  rw [connectedSpace_iff_clopen]
   constructor
-  · rintro ⟨_, hconnected⟩ e he
-    rcases hconnected (PrimeSpectrum.basicOpen e)
-        ((PrimeSpectrum.isClopen_iff).2 ⟨e, he, rfl⟩) with hempty | huniv
-    · left
-      apply PrimeSpectrum.basicOpen_injOn_isIdempotentElem he IsIdempotentElem.zero
-      rw [PrimeSpectrum.basicOpen_zero]
-      exact TopologicalSpace.Opens.ext hempty
-    · right
-      apply PrimeSpectrum.basicOpen_injOn_isIdempotentElem he IsIdempotentElem.one
-      rw [PrimeSpectrum.basicOpen_one]
-      exact TopologicalSpace.Opens.ext huniv
+  · intro h
+    let := h
+    exact fun _ he ↦ eq_zero_or_eq_one_of_isIdempotentElem he
   · intro hidempotent
+    rw [connectedSpace_iff_clopen]
     refine ⟨inferInstance, ?_⟩
     intro s hs
     obtain ⟨e, he, rfl⟩ := (PrimeSpectrum.isClopen_iff).1 hs

--- a/TauCeti/RingTheory/Idempotents/ConnectedSpectrum.lean
+++ b/TauCeti/RingTheory/Idempotents/ConnectedSpectrum.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Spectrum.Prime.Topology
+public import Mathlib.Topology.Connected.Clopen
+
+/-!
+# Connected prime spectra and idempotents
+
+The prime spectrum of a nontrivial commutative ring is connected exactly when the ring has no
+idempotents other than zero and one.  Mathlib identifies idempotents with clopen subsets of the
+prime spectrum; this file records the resulting connectedness criterion in the form used by
+coordinate rings of geometrically connected affine schemes.
+
+## Main declaration
+
+* `TauCeti.connectedSpace_primeSpectrum_iff`: `Spec R` is connected if and only if every
+  idempotent of `R` is zero or one.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {R : Type*} [CommRing R] [Nontrivial R]
+
+/-- **The prime spectrum of a nontrivial commutative ring is connected exactly when its only
+idempotents are zero and one.** -/
+theorem connectedSpace_primeSpectrum_iff :
+    ConnectedSpace (PrimeSpectrum R) ↔
+      ∀ e : R, IsIdempotentElem e → e = 0 ∨ e = 1 := by
+  rw [connectedSpace_iff_clopen]
+  constructor
+  · rintro ⟨_, hconnected⟩ e he
+    rcases hconnected (PrimeSpectrum.basicOpen e)
+        ((PrimeSpectrum.isClopen_iff).2 ⟨e, he, rfl⟩) with hempty | huniv
+    · left
+      apply PrimeSpectrum.basicOpen_injOn_isIdempotentElem he IsIdempotentElem.zero
+      rw [PrimeSpectrum.basicOpen_zero]
+      exact TopologicalSpace.Opens.ext hempty
+    · right
+      apply PrimeSpectrum.basicOpen_injOn_isIdempotentElem he IsIdempotentElem.one
+      rw [PrimeSpectrum.basicOpen_one]
+      exact TopologicalSpace.Opens.ext huniv
+  · intro hidempotent
+    refine ⟨inferInstance, ?_⟩
+    intro s hs
+    obtain ⟨e, he, rfl⟩ := (PrimeSpectrum.isClopen_iff).1 hs
+    rcases hidempotent e he with rfl | rfl
+    · simp
+    · simp
+
+end TauCeti


### PR DESCRIPTION
This PR establishes the coordinate-ring criterion for geometric connectedness of an affine group scheme: `Spec H → Spec k` is geometrically connected exactly when `Spec (H ⊗[k] K)` is connected for every field extension `K / k`, equivalently when every such tensor product has only zero and one as idempotents. It advances the exact `TauCetiRoadmap/ReductiveGroups/README.md` Layer 3 milestone “Identity component `G°` and component group `π₀(G)`,” specifically its requirement that connectedness be geometric rather than connectedness only over `k`.

This is the most effective distinct current step because the affine Hopf/group-scheme equivalence and field base-change spectrum isomorphism are already available, while the open ReductiveGroups PRs own separate Tannakian reconstruction, finite-subcomodule multiplication, Jordan decomposition, and scheme base-change slices. The identity component must be built from the geometrically connected component containing the identity, so fixing and synchronizing this predicate is the immediate type-level prerequisite rather than later component-group machinery.

Add `TauCeti/RingTheory/Idempotents/ConnectedSpectrum.lean` (56 lines), proving for a nontrivial commutative ring that its prime spectrum is connected exactly when all idempotents are trivial. Add `TauCeti/Algebra/AlgebraicGroup/Connected.lean` (130 lines), defining the coordinate-side object property, proving its idempotent characterization, and identifying it with Mathlib’s scheme-theoretic `AlgebraicGeometry.GeometricallyConnected` predicate on `hopfSpec`.

After this PR, Layer 3 still needs the reduction from all field extensions to one algebraic closure where desired, the construction and universal property of `G°`, and the finite étale component group under the roadmap’s smoothness and perfect-field hypotheses.

No Mathlib infrastructure is vendored. The proof reuses Mathlib’s order equivalence between idempotents and clopen subsets of `PrimeSpectrum`, `connectedSpace_iff_clopen`, the affine pullback isomorphism `pullbackSpecIso`, and the general `geometrically_iff_of_commRing_of_isClosedUnderIsomorphisms` criterion. The mathematical formulation follows J. S. Milne, *Algebraic Groups* (2017), §2.a, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geometric-connectedness-idempotents"}-->

🤖 Prepared with Codex
