### PR TITLE
feat: base change diagonalizable coordinate Hopf algebras

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -6,15 +6,16 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.BaseChange.Basic
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Functoriality
+public import TauCeti.Algebra.Bialgebra.MonoidAlgebra.BaseChange
 
 /-!
 # Base change of diagonalizable-group points
 
 For a commutative group `G`, the diagonalizable group `D(G)` over `k` is represented by the
-Hopf algebra `k[G]`. This file records the corresponding base-change calculation on functors
-of points: if `K` is a `k`-algebra and `A` is a commutative `K`-algebra, then the
-`A`-valued points of the base-changed Hopf algebra `K ⊗[k] k[G]` are still the character group
-`G →* Aˣ`.
+Hopf algebra `k[G]`. The imported `TauCeti.MonoidAlgebra.scalarTensorBialgEquiv` identifies its
+base change `K ⊗[k] k[G]` with `K[G]` as a bialgebra. This file records the corresponding
+calculation on functors of points: if `A` is a commutative `K`-algebra, then the `A`-valued
+points of the base-changed Hopf algebra are still the character group `G →* Aˣ`.
 
 The construction is the composition of two existing Tau Ceti equivalences:
 `AlgHom.baseChangePointsMulEquiv`, which identifies points of `K ⊗[k] k[G]` with
@@ -33,6 +34,8 @@ algebra over `K`") and Layer 4 ("Diagonalizable groups and groups of multiplicat
   from base-changed points of `D(G)` to the character group `G →* Aˣ`.
 * `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv_apply_coe`: the equivalence reads a
   point by evaluating it on `1 ⊗ single g 1`.
+* `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv_mapDomain_scalarTensorBialgEquiv`:
+  the coordinate-ring and points-level base-change equivalences agree.
 * `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv_mapDomain`: under a homomorphism
   `G →* G'`, the base-changed points map is precomposition of characters.
 
@@ -112,6 +115,19 @@ theorem baseChangePointsMulEquiv_symm_apply_single_one (χ : G →* Aˣ) (g : G)
         (1 ⊗ₜ[k] MonoidAlgebra.single g (1 : k)) =
       (χ g : A) := by
   rw [baseChangePointsMulEquiv_symm_apply_tmul_single]
+  simp
+
+/-- The coordinate-ring and functor-of-points base-change identifications agree. A point of
+`K[G]`, restricted along `K ⊗[k] k[G] ≃ₐc[K] K[G]`, gives the same character under
+`baseChangePointsMulEquiv` as it does under the ordinary `pointsMulEquiv` over `K`. -/
+theorem baseChangePointsMulEquiv_mapDomain_scalarTensorBialgEquiv
+    (f : WithConv (MonoidAlgebra K G →ₐ[K] A)) :
+    baseChangePointsMulEquiv (k := k) (K := K) (A := A) (G := G)
+        (AlgHom.mapDomain (A := A)
+          (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G) :
+            K ⊗[k] MonoidAlgebra k G →ₐc[K] MonoidAlgebra K G) f) =
+      pointsMulEquiv (R := K) (A := A) (G := G) f := by
+  ext g
   simp
 
 section MapDomain

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/BaseChange.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/BaseChange.lean
@@ -85,12 +85,8 @@ tensor. -/
 theorem scalarTensorBialgEquiv_symm_single (g : G) (s : K) :
     (scalarTensorBialgEquiv k K).symm (_root_.MonoidAlgebra.single g s) =
       s ⊗ₜ[k] _root_.MonoidAlgebra.single g (1 : k) := by
-  apply (scalarTensorBialgEquiv k K (G := G)).toEquiv.injective
-  change scalarTensorBialgEquiv k K
-      ((scalarTensorBialgEquiv k K).symm (_root_.MonoidAlgebra.single g s)) =
-    scalarTensorBialgEquiv k K
-      (s ⊗ₜ[k] _root_.MonoidAlgebra.single g (1 : k))
-  rw [_root_.BialgEquiv.apply_symm_apply, scalarTensorBialgEquiv_tmul]
+  apply_fun scalarTensorBialgEquiv k K
+  rw [scalarTensorBialgEquiv_tmul]
   simp
 
 /-- Base change of monoid bialgebras is natural in the indexing monoid. Mapping the indices

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/BaseChange.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/BaseChange.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra
+public import Mathlib.RingTheory.HopfAlgebra.TensorProduct
+public import Mathlib.RingTheory.TensorProduct.MonoidAlgebra
+
+/-!
+# Base change of monoid bialgebras
+
+For a commutative semiring extension `k → K` and a commutative monoid `G`, scalar extension of
+the monoid bialgebra `k[G]` is canonically the monoid bialgebra `K[G]`:
+
+```text
+K ⊗[k] k[G] ≃ₐc[K] K[G].
+```
+
+Mathlib supplies the underlying algebra equivalence as `MonoidAlgebra.scalarTensorEquiv`. This
+file records that it preserves the counit and comultiplication, hence promotes it to a bialgebra
+equivalence. The equivalence is natural in `G`. When `G` is a group, both sides carry their
+standard Hopf structures, so this is the coordinate-ring base-change identification for the
+diagonalizable group `D(G)`.
+
+This is the base-change input for the ReductiveGroups roadmap's Layer 4 development of groups of
+multiplicative type and non-split tori: after extension of the base field, a diagonalizable
+coordinate Hopf algebra remains the group algebra of the same character group.
+
+## Main declarations
+
+* `TauCeti.MonoidAlgebra.scalarTensorBialgEquiv`: base change of a monoid bialgebra is the monoid
+  bialgebra over the extended scalars.
+* `TauCeti.MonoidAlgebra.mapDomainBialgHom_comp_scalarTensorBialgEquiv`: the equivalence is natural
+  in the indexing monoid.
+
+## References
+
+The underlying algebra equivalence is Mathlib's `MonoidAlgebra.scalarTensorEquiv` from
+`Mathlib.RingTheory.TensorProduct.MonoidAlgebra`; the bialgebra structures are from
+`Mathlib.RingTheory.Bialgebra.MonoidAlgebra` and
+`Mathlib.RingTheory.Bialgebra.TensorProduct`.
+-/
+
+public section
+
+open TensorProduct
+
+namespace TauCeti.MonoidAlgebra
+
+universe u v w w'
+
+variable (k : Type u) (K : Type v) [CommSemiring k] [CommSemiring K] [Algebra k K]
+variable {G : Type w} {G' : Type w'} [CommMonoid G] [CommMonoid G']
+
+/-- **Monoid bialgebras commute with base change.**
+
+This is Mathlib's algebra equivalence `MonoidAlgebra.scalarTensorEquiv`, promoted using the
+standard tensor-product and monoid-algebra coalgebra structures. For a group `G`, the standard
+Hopf structures on source and target make this the coordinate-ring base-change equivalence
+`K ⊗[k] k[G] ≃ K[G]` for the diagonalizable group `D(G)`. -/
+noncomputable def scalarTensorBialgEquiv :
+    K ⊗[k] _root_.MonoidAlgebra k G ≃ₐc[K] _root_.MonoidAlgebra K G :=
+  BialgEquiv.ofAlgEquiv (_root_.MonoidAlgebra.scalarTensorEquiv k K)
+    (by
+      ext s
+      simp)
+    (by
+      ext s
+      simp)
+
+/-- On a pure tensor, base change applies the scalar and maps the coefficients of the monoid
+algebra along `k → K`. -/
+@[simp]
+theorem scalarTensorBialgEquiv_tmul (s : K) (p : _root_.MonoidAlgebra k G) :
+    scalarTensorBialgEquiv k K (s ⊗ₜ[k] p) =
+      s • _root_.MonoidAlgebra.mapAlgHom G (Algebra.ofId k K) p :=
+  _root_.MonoidAlgebra.scalarTensorEquiv_tmul s p
+
+/-- The inverse base-change equivalence sends a monomial over `K` to the corresponding pure
+tensor. -/
+@[simp]
+theorem scalarTensorBialgEquiv_symm_single (g : G) (s : K) :
+    (scalarTensorBialgEquiv k K).symm (_root_.MonoidAlgebra.single g s) =
+      s ⊗ₜ[k] _root_.MonoidAlgebra.single g (1 : k) :=
+  _root_.MonoidAlgebra.scalarTensorEquiv_symm_single g s
+
+/-- Base change of monoid bialgebras is natural in the indexing monoid. Mapping the indices
+before base change gives the same bialgebra morphism as mapping them afterwards. -/
+theorem mapDomainBialgHom_comp_scalarTensorBialgEquiv (φ : G →* G') :
+    (_root_.MonoidAlgebra.mapDomainBialgHom K φ).comp
+        (scalarTensorBialgEquiv k K (G := G) :
+          K ⊗[k] _root_.MonoidAlgebra k G →ₐc[K] _root_.MonoidAlgebra K G) =
+      (scalarTensorBialgEquiv k K (G := G') :
+          K ⊗[k] _root_.MonoidAlgebra k G' →ₐc[K] _root_.MonoidAlgebra K G').comp
+        (_root_.Bialgebra.TensorProduct.map (_root_.BialgHom.id K K)
+          (_root_.MonoidAlgebra.mapDomainBialgHom k φ)) := by
+  apply _root_.BialgHom.coe_toAlgHom_injective
+  apply Algebra.TensorProduct.ext
+  · ext
+  · apply _root_.MonoidAlgebra.algHom_ext
+    · intro g
+      simp
+    · ext
+
+end TauCeti.MonoidAlgebra

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/BaseChange.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/BaseChange.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra
-public import Mathlib.RingTheory.HopfAlgebra.TensorProduct
+public import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
+public import Mathlib.RingTheory.Bialgebra.TensorProduct
 public import Mathlib.RingTheory.TensorProduct.MonoidAlgebra
 
 /-!
@@ -75,16 +75,23 @@ algebra along `k → K`. -/
 @[simp]
 theorem scalarTensorBialgEquiv_tmul (s : K) (p : _root_.MonoidAlgebra k G) :
     scalarTensorBialgEquiv k K (s ⊗ₜ[k] p) =
-      s • _root_.MonoidAlgebra.mapAlgHom G (Algebra.ofId k K) p :=
-  _root_.MonoidAlgebra.scalarTensorEquiv_tmul s p
+      s • _root_.MonoidAlgebra.mapAlgHom G (Algebra.ofId k K) p := by
+  rw [scalarTensorBialgEquiv, _root_.BialgEquiv.ofAlgEquiv_apply]
+  exact _root_.MonoidAlgebra.scalarTensorEquiv_tmul s p
 
 /-- The inverse base-change equivalence sends a monomial over `K` to the corresponding pure
 tensor. -/
 @[simp]
 theorem scalarTensorBialgEquiv_symm_single (g : G) (s : K) :
     (scalarTensorBialgEquiv k K).symm (_root_.MonoidAlgebra.single g s) =
-      s ⊗ₜ[k] _root_.MonoidAlgebra.single g (1 : k) :=
-  _root_.MonoidAlgebra.scalarTensorEquiv_symm_single g s
+      s ⊗ₜ[k] _root_.MonoidAlgebra.single g (1 : k) := by
+  apply (scalarTensorBialgEquiv k K (G := G)).toEquiv.injective
+  change scalarTensorBialgEquiv k K
+      ((scalarTensorBialgEquiv k K).symm (_root_.MonoidAlgebra.single g s)) =
+    scalarTensorBialgEquiv k K
+      (s ⊗ₜ[k] _root_.MonoidAlgebra.single g (1 : k))
+  rw [_root_.BialgEquiv.apply_symm_apply, scalarTensorBialgEquiv_tmul]
+  simp
 
 /-- Base change of monoid bialgebras is natural in the indexing monoid. Mapping the indices
 before base change gives the same bialgebra morphism as mapping them afterwards. -/


### PR DESCRIPTION
This PR promotes Mathlib's canonical algebra equivalence `K ⊗[k] k[G] ≃ₐ[K] K[G]` to a bialgebra equivalence, proves its formulas on pure tensors and inverse monomials, and proves naturality in the indexing commutative monoid. For a commutative group, this is the coordinate Hopf-algebra base-change identification for the diagonalizable group `D(G)`.

It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 milestone “Diagonalizable groups and groups of multiplicative type,” specifically the base-change prerequisite for defining multiplicative-type groups and non-split tori by becoming diagonalizable after field extension. It also closes the coordinate-algebra specialization of Layer 0's target “Base change: `K ⊗[k] A` as a Hopf algebra over `K`” for group algebras. The existing points-level base-change equivalence is synchronized with the new coordinate equivalence by proving that restricting a `K[G]`-point along it yields the same character under both descriptions.

After this PR, Layer 4 still needs the geometric definition and descent theory for groups of multiplicative type, the non-split torus and its character lattice with Galois action, and Jordan decomposition.

Add `TauCeti/Algebra/Bialgebra/MonoidAlgebra/BaseChange.lean` (107 lines) and update `TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean` to expose and consume the coordinate equivalence. No Mathlib infrastructure is vendored: the construction directly reuses `MonoidAlgebra.scalarTensorEquiv`, `BialgEquiv.ofAlgEquiv`, the standard monoid-algebra and tensor-product Hopf structures, and `MonoidAlgebra.mapDomainBialgHom`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"diagonalizable-coordinate-base-change"}-->

🤖 Prepared with Codex
