### PR TITLE
refactor(HeckeRing): Quotient.map for HeckeCoset.map, and a generic determinant lemma

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -117,12 +117,9 @@ variable {Δ' : Submonoid G} {H₁' H₂' : Subgroup G}
 double cosets, never split them. -/
 noncomputable def map (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ ≤ H₂') :
     HeckeCoset Δ H₁ H₂ → HeckeCoset Δ' H₁' H₂' :=
-  Quotient.lift (fun g ↦ mk H₁' H₂' (Submonoid.inclusion hΔ g)) fun a b hab ↦ by
-    have hab' : doubleCoset (a : G) H₁ H₂ = doubleCoset (b : G) H₁ H₂ := hab
-    obtain ⟨γ₁, hγ₁, γ₂, hγ₂, hb⟩ :=
-      mem_doubleCoset.mp (hab' ▸ mem_doubleCoset_self H₁ H₂ (a : G))
-    exact mk_eq_mk_of_mem (g₁ := Submonoid.inclusion hΔ a) (g₂ := Submonoid.inclusion hΔ b)
-      (mem_doubleCoset.mpr ⟨γ₁, h₁ hγ₁, γ₂, h₂ hγ₂, hb⟩)
+  Quotient.map (Submonoid.inclusion hΔ) fun a b hab ↦ by
+    obtain ⟨γ₁, hγ₁, γ₂, hγ₂, hb⟩ := DoubleCoset.rel_iff.mp hab
+    exact DoubleCoset.rel_iff.mpr ⟨γ₁, h₁ hγ₁, γ₂, h₂ hγ₂, hb⟩
 
 @[simp] lemma map_mk (hΔ : Δ ≤ Δ') (h₁ : H₁ ≤ H₁') (h₂ : H₂ ≤ H₂') (g : Δ) :
     map hΔ h₁ h₂ (mk H₁ H₂ g) = mk H₁' H₂' (Submonoid.inclusion hΔ g) := (rfl)


### PR DESCRIPTION
Two refactors of already-merged generic API, split out of #2748 on a `scope` block ("one topic
per PR"). No new mathematics: both statements already exist, this changes how they are proved
and where they live.

## 1. `HeckeCoset.map` via `Quotient.map`

`HeckeCoset.map` was assembled with `Quotient.lift` applied to a quotient-valued
representative function. `Quotient.map` is the standard unary quotient-mapping combinator and
says exactly this, so the definition becomes

```lean
Quotient.map (Submonoid.inclusion hΔ) fun a b hab ↦ …
```

with the same `map_mk`, `map_id` and `map_map`.

This change was made on #2734 and reviewed green there, but **#2734 merged at an earlier
commit and the fix never reached `main`** — `origin/main` still carries the `Quotient.lift`
version. This re-lands it.

## 2. The determinant-along-a-double-coset lemma moves to a generic module

`det_eq_of_mem_doubleCoset_of_det_eq_one` needs only multiplicativity of `Matrix.det`: no
arithmetic, no `ℚ`, no `Fin n`. It is now stated for `GL ι R` over a commutative ring with a
finite index type, in a new

    TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/DoubleCoset.lean

rather than in the arithmetic `GL_n(ℚ)` Hecke-triple file. The two `SL_n(ℤ)` specialisations
(`det_eq_of_mem_doubleCoset_of_le_SLnZ` and `det_eq_of_mem_doubleCoset_SLnZ`) stay in
`HeckeRing/GLn/Basic.lean`, where their consumers are, and now derive from the generic one.

Both changes were requested by review rounds on #2748 (`generality`, then `placement`); the
`scope` rubric then correctly observed they are a separate topic from that PR's feature.

Roadmap: none
