### PR TITLE
refactor(LinearAlgebra/Matrix): the determinant is constant on a double coset

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/DoubleCoset.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/DoubleCoset.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, Claude
+-/
+module
+
+public import Mathlib.GroupTheory.DoubleCoset
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+
+/-!
+# Determinants along a double coset of `GL ι R`
+
+The determinant is constant on a double coset `H₁ g H₂` as soon as every coefficient has
+determinant one. Nothing here is arithmetic: the argument is multiplicativity of `Matrix.det`,
+so it holds over any commutative ring and any finite index type.
+
+The arithmetic consumers — `SL_n(ℤ)` and the congruence subgroups inside it — specialise this
+in `TauCeti.NumberTheory.HeckeRing.GLn.Basic`.
+
+## Main results
+
+* `DoubleCoset.det_eq_of_mem_doubleCoset_of_det_eq_one`: the determinant is constant on a
+  double coset with determinant-one coefficients.
+-/
+
+public section
+
+open Matrix
+
+namespace DoubleCoset
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι] {R : Type*} [CommRing R]
+
+/-- The determinant is constant on a double coset whose coefficients all have determinant one
+— the only property of the coefficient subgroups the argument uses. -/
+lemma det_eq_of_mem_doubleCoset_of_det_eq_one {H₁ H₂ : Subgroup (GL ι R)}
+    (h₁ : ∀ γ ∈ H₁, (↑γ : Matrix ι ι R).det = 1)
+    (h₂ : ∀ γ ∈ H₂, (↑γ : Matrix ι ι R).det = 1) {a b : GL ι R}
+    (hb : b ∈ DoubleCoset.doubleCoset a H₁ H₂) :
+    (↑b : Matrix ι ι R).det = (↑a : Matrix ι ι R).det := by
+  obtain ⟨γ₁, hγ₁, γ₂, hγ₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hb
+  simp only [Matrix.GeneralLinearGroup.coe_mul, Matrix.det_mul, h₁ γ₁ hγ₁, h₂ γ₂ hγ₂,
+    one_mul, mul_one]
+
+end DoubleCoset

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Data.ZMod.Basic
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 public import Mathlib.NumberTheory.HeckeRing.Defs
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.DoubleCoset
 
 /-!
 # The arithmetic Hecke triple for `GL_n`
@@ -89,24 +90,14 @@ lemma det_eq_one_of_mem_SLnZ {g : GL (Fin n) ℚ} (hg : g ∈ SLnZ n) :
   obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff n).mp hg
   exact congrArg Units.val (SpecialLinearGroup.det_mapGL (S := ℚ) σ)
 
-/-- The determinant is constant on a double coset whose coefficients all have determinant
-one — the only property of the coefficient subgroups the argument uses. -/
-lemma det_eq_of_mem_doubleCoset_of_det_eq_one {H₁ H₂ : Subgroup (GL (Fin n) ℚ)}
-    (h₁ : ∀ γ ∈ H₁, (↑γ : Matrix (Fin n) (Fin n) ℚ).det = 1)
-    (h₂ : ∀ γ ∈ H₂, (↑γ : Matrix (Fin n) (Fin n) ℚ).det = 1) {a b : GL (Fin n) ℚ}
-    (hb : b ∈ DoubleCoset.doubleCoset a H₁ H₂) :
-    (↑b : Matrix (Fin n) (Fin n) ℚ).det = (↑a : Matrix (Fin n) (Fin n) ℚ).det := by
-  obtain ⟨γ₁, hγ₁, γ₂, hγ₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hb
-  simp only [GeneralLinearGroup.coe_mul, Matrix.det_mul, h₁ γ₁ hγ₁, h₂ γ₂ hγ₂, one_mul, mul_one]
-
 /-- The case of coefficient subgroups inside `SL_n(ℤ)`, which is how the congruence subgroups
 get it. -/
 lemma det_eq_of_mem_doubleCoset_of_le_SLnZ {H₁ H₂ : Subgroup (GL (Fin n) ℚ)}
     (h₁ : H₁ ≤ SLnZ n) (h₂ : H₂ ≤ SLnZ n) {a b : GL (Fin n) ℚ}
     (hb : b ∈ DoubleCoset.doubleCoset a H₁ H₂) :
     (↑b : Matrix (Fin n) (Fin n) ℚ).det = (↑a : Matrix (Fin n) (Fin n) ℚ).det :=
-  det_eq_of_mem_doubleCoset_of_det_eq_one n (fun _ hγ ↦ det_eq_one_of_mem_SLnZ n (h₁ hγ))
-    (fun _ hγ ↦ det_eq_one_of_mem_SLnZ n (h₂ hγ)) hb
+  DoubleCoset.det_eq_of_mem_doubleCoset_of_det_eq_one
+    (fun _ hγ ↦ det_eq_one_of_mem_SLnZ n (h₁ hγ)) (fun _ hγ ↦ det_eq_one_of_mem_SLnZ n (h₂ hγ)) hb
 
 /-- The `SL_n(ℤ)` case of `det_eq_of_mem_doubleCoset_of_le_SLnZ`. -/
 lemma det_eq_of_mem_doubleCoset_SLnZ {a b : GL (Fin n) ℚ}


### PR DESCRIPTION
`det_eq_of_mem_doubleCoset_of_det_eq_one` needs only multiplicativity of `Matrix.det`: the
determinant is constant on a double coset `H₁ g H₂` as soon as every coefficient has
determinant one. No arithmetic, no `ℚ`, no `Fin n`.

It is now stated for `GL ι R` over a commutative ring with a finite index type, in a new

    TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/DoubleCoset.lean

instead of sitting in the arithmetic `GL_n(ℚ)` Hecke-triple file. The two `SL_n(ℤ)`
specialisations, `det_eq_of_mem_doubleCoset_of_le_SLnZ` and `det_eq_of_mem_doubleCoset_SLnZ`,
stay in `HeckeRing/GLn/Basic.lean` where their consumers are, and derive from the generic one.

No new mathematics: the statement already existed, this generalises its hypotheses off `ℚ`/`Fin n`
and moves it to a module that matches its generality.

Split out of #2748 and then #2753 on `scope` blocks ("one topic per PR") — the `generality` and
`placement` rounds on #2748 asked for exactly this change, and `scope` then observed it is a
separate topic from that PR's feature and from the `HeckeCoset.map` refactor in #2753.

Roadmap: none
