### PR TITLE
feat: prove the Tannakian local unit law

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
@@ -120,6 +120,22 @@ noncomputable def finiteRegularComponent
       eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
         (finiteRegularObject k H N))).hom
 
+/-- Evaluation formula for the transported component of a tensor automorphism on a finite
+regular subcomodule. -/
+@[simp]
+theorem finiteRegularComponent_apply
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
+    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (x : A ⊗[k] N.1) :
+    finiteRegularComponent k H A η N x =
+      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
+          (finiteRegularObject k H N))
+        (η.hom.hom.app (finiteRegularObject k H N)
+          (eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
+            (finiteRegularObject k H N)).symm x)) := by
+  unfold finiteRegularComponent
+  rfl
+
 /-- Naturality of a tensor automorphism on an inclusion of finite regular subcomodules. -/
 theorem finiteRegularComponent_natural
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
@@ -122,7 +122,6 @@ noncomputable def finiteRegularComponent
 
 /-- Evaluation formula for the transported component of a tensor automorphism on a finite
 regular subcomodule. -/
-@[simp]
 theorem finiteRegularComponent_apply
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
     (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean
@@ -63,6 +63,8 @@ private theorem regularUnitHom_apply
       ⟨r • (1 : H), N.1.toSubmodule.smul_mem r hOne⟩ :=
   by
     let _ : Comodule k H k := Comodule.trivial (R := k) (C := H) (M := k)
+    -- The application lemmas below do not rewrite through the bundled `FGComoduleCat`
+    -- coercion, so expose first the underlying comodule map and then its `codRestrict`.
     change (regularUnitHom k H N hOne).hom.toLinearMap r = _
     unfold regularUnitHom
     change ((Comodule.Hom.trivialToRegular (R := k) (C := H)).codRestrict N.1 _ r) = _

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.LocalFunctional
+
+/-!
+# The unit law for Tannakian local functionals
+
+Let `H` be a commutative Hopf algebra over a field `k`, and let `A` be a commutative
+`k`-algebra. A tensor automorphism of scalar extension on the finite-dimensional
+`H`-comodules determines compatible linear functionals on the finite subcomodules of the
+regular comodule. This file proves the tensor-unit part of the algebra-map laws for those
+functionals: whenever a finite regular subcomodule contains `1`, its local functional sends
+that element to `1 : A`.
+
+The proof maps the trivial tensor-unit comodule into the chosen regular subcomodule by
+`r ↦ r • 1`. Naturality transports the tensor automorphism along this map, while its
+monoidal unit axiom says that its component on the tensor unit fixes the canonical generator.
+The resulting theorem is the unit-law prerequisite for gluing the local functionals into the
+algebra-valued point in Tannakian reconstruction.
+
+## Main declaration
+
+* `TauCeti.Tannaka.localFunctional_one`: every local functional sends the unit of a finite
+  regular subcomodule to one.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §9.4.
+-/
+
+public section
+
+open CategoryTheory MonoidalCategory
+open CategoryTheory.Functor.LaxMonoidal
+open scoped TensorProduct
+
+namespace TauCeti.Tannaka
+
+universe u
+
+variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
+  [CommRing A] [Algebra k A]
+
+private noncomputable def regularUnitHom
+    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (hOne : (1 : H) ∈ N.1) :
+    𝟙_ (FGComoduleCat.{u, u, u} k H) ⟶ finiteRegularObject k H N := by
+  letI : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
+  letI : Comodule k H k := Comodule.trivial (R := k) (C := H) (M := k)
+  let f : k →ₗ[k] N.1 :=
+    { toFun := fun r ↦ ⟨r • (1 : H), N.1.toSubmodule.smul_mem r hOne⟩
+      map_add' := fun r s ↦ by ext; simp [add_smul]
+      map_smul' := fun r s ↦ by ext; simp [mul_smul] }
+  refine FGComoduleCat.ofHom (R := k) (C := H)
+    { toLinearMap := f
+      map_coact := ?_ }
+  apply LinearMap.ext
+  intro r
+  apply Module.Flat.rTensor_preserves_injective_linearMap
+    (SMulMemClass.subtype N.1) Subtype.val_injective
+  simp only [LinearMap.comp_apply]
+  rw [Subcomodule.subtype_rTensor_coact]
+  simp only [Comodule.trivial_coact_apply, TensorProduct.map_tmul,
+    LinearMap.id_apply, LinearMap.rTensor_tmul, SMulMemClass.subtype_apply]
+  -- After including the induced coaction into `H ⊗ H`, both sides are the standard
+  -- group-like identity for `1`; display the ambient comultiplication explicitly.
+  change (r • (1 : H)) ⊗ₜ[k] (1 : H) =
+    Coalgebra.comul (R := k) (A := H) (r • (1 : H))
+  rw [map_smul, Bialgebra.comul_one, Algebra.TensorProduct.one_def]
+  rfl
+
+@[simp]
+private theorem regularUnitHom_apply
+    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (hOne : (1 : H) ∈ N.1) (r : k) :
+    regularUnitHom k H N hOne r =
+      ⟨r • (1 : H), N.1.toSubmodule.smul_mem r hOne⟩ :=
+  by
+    unfold regularUnitHom
+    rfl
+
+private theorem map_regularUnitHom_ε_one
+    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (hOne : (1 : H) ∈ N.1) :
+    (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).map
+          (regularUnitHom k H N hOne)
+        (ε (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).toFunctor (1 : A)) =
+      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
+        (finiteRegularObject k H N)).symm (1 ⊗ₜ[k] ⟨1, hOne⟩) := by
+  let _ : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
+  let hN := FGComoduleCat.scalarExtensionFunctor_obj k H A
+    (finiteRegularObject k H N)
+  have hExplicit :
+      eqToHom hN
+          ((FGComoduleCat.scalarExtensionMonoidalFunctor k H A).map
+              (regularUnitHom k H N hOne)
+            (ε (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).toFunctor (1 : A))) =
+        1 ⊗ₜ[k] ⟨1, hOne⟩ := by
+    -- The bundled monoidal functor hides the two object transports. Reassociate the maps
+    -- categorically so the inverse transports cancel before evaluating the pure tensor.
+    change eqToHom hN
+        ((FGComoduleCat.scalarExtensionFunctor k H A).map (regularUnitHom k H N hOne)
+          (ε (FGComoduleCat.scalarExtensionFunctor k H A) (1 : A))) = _
+    rw [← SemimoduleCat.comp_apply, ← SemimoduleCat.comp_apply]
+    rw [FGComoduleCat.scalarExtensionFunctor_ε,
+      FGComoduleCat.scalarExtensionFunctor_map]
+    simp only [FGComoduleCat.of_obj, Category.assoc, eqToHom_trans, eqToHom_refl,
+      Category.comp_id, eqToHom_trans_assoc, Category.id_comp, SemimoduleCat.hom_comp,
+      ConcreteCategory.hom_ofHom, LinearMap.coe_comp, LinearEquiv.coe_coe,
+      Function.comp_apply]
+    change (regularUnitHom k H N hOne).hom.toLinearMap.baseChange A
+      ((1 : A) ⊗ₜ[k] (1 : k)) = _
+    rw [LinearMap.baseChange_tmul]
+    change (1 : A) ⊗ₜ[k] regularUnitHom k H N hOne (1 : k) = _
+    rw [regularUnitHom_apply]
+    congr 1
+    ext
+    simp
+  have h := congrArg (fun z ↦ eqToHom hN.symm z) hExplicit
+  calc
+    _ = eqToHom hN.symm
+        (eqToHom hN
+          ((FGComoduleCat.scalarExtensionMonoidalFunctor k H A).map
+              (regularUnitHom k H N hOne)
+            (ε (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).toFunctor (1 : A)))) :=
+      ((eqToIso hN).hom_inv_id_apply _).symm
+    _ = _ := h
+
+/-- The transported component of a tensor automorphism fixes `1 ⊗ 1` in every finite
+regular subcomodule containing the unit. -/
+theorem finiteRegularComponent_one_tmul
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
+    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (hOne : (1 : H) ∈ N.1) :
+    finiteRegularComponent k H A η N (1 ⊗ₜ[k] ⟨1, hOne⟩) = 1 ⊗ₜ[k] ⟨1, hOne⟩ := by
+  let _ : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
+  let i := regularUnitHom k H N hOne
+  have hnat := η.hom.hom.naturality i
+  have hunit := CategoryTheory.NatTrans.IsMonoidal.unit (τ := η.hom.hom)
+  have hcat :
+      ε (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).toFunctor ≫
+          (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).map i ≫
+            η.hom.hom.app (finiteRegularObject k H N) =
+        ε (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).toFunctor ≫
+          (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).map i := by
+    calc
+      _ = ε (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).toFunctor ≫
+          (η.hom.hom.app (𝟙_ (FGComoduleCat k H)) ≫
+            (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).map i) :=
+        congrArg (fun f ↦
+          ε (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).toFunctor ≫ f) hnat
+      _ = (ε (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).toFunctor ≫
+          η.hom.hom.app (𝟙_ (FGComoduleCat k H))) ≫
+            (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).map i :=
+        (Category.assoc _ _ _).symm
+      _ = _ := congrArg (fun f ↦
+        f ≫ (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).map i) hunit
+  have happ := congrArg (fun f ↦ f (1 : A)) hcat
+  simp only [SemimoduleCat.comp_apply] at happ
+  dsimp only [i] at happ
+  rw [map_regularUnitHom_ε_one] at happ
+  let hN := FGComoduleCat.scalarExtensionFunctor_obj k H A
+    (finiteRegularObject k H N)
+  rw [finiteRegularComponent_apply]
+  exact (congrArg (fun z ↦ eqToHom hN z) happ).trans
+    ((eqToIso hN).inv_hom_id_apply _)
+
+/-- A local functional extracted from a tensor automorphism sends the unit of every finite
+regular subcomodule containing it to `1`. This is the tensor-unit law needed to upgrade the
+glued functional on `H` to an algebra homomorphism. -/
+@[simp high]
+theorem localFunctional_one
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
+    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (hOne : (1 : H) ∈ N.1) :
+    localFunctional k H A η N ⟨1, hOne⟩ = 1 := by
+  rw [localFunctional_apply, finiteRegularComponent_one_tmul]
+  simp
+
+end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean
@@ -51,27 +51,9 @@ private noncomputable def regularUnitHom
     𝟙_ (FGComoduleCat.{u, u, u} k H) ⟶ finiteRegularObject k H N := by
   letI : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
   letI : Comodule k H k := Comodule.trivial (R := k) (C := H) (M := k)
-  let f : k →ₗ[k] N.1 :=
-    { toFun := fun r ↦ ⟨r • (1 : H), N.1.toSubmodule.smul_mem r hOne⟩
-      map_add' := fun r s ↦ by ext; simp [add_smul]
-      map_smul' := fun r s ↦ by ext; simp [mul_smul] }
-  refine FGComoduleCat.ofHom (R := k) (C := H)
-    { toLinearMap := f
-      map_coact := ?_ }
-  apply LinearMap.ext
-  intro r
-  apply Module.Flat.rTensor_preserves_injective_linearMap
-    (SMulMemClass.subtype N.1) Subtype.val_injective
-  simp only [LinearMap.comp_apply]
-  rw [Subcomodule.subtype_rTensor_coact]
-  simp only [Comodule.trivial_coact_apply, TensorProduct.map_tmul,
-    LinearMap.id_apply, LinearMap.rTensor_tmul, SMulMemClass.subtype_apply]
-  -- After including the induced coaction into `H ⊗ H`, both sides are the standard
-  -- group-like identity for `1`; display the ambient comultiplication explicitly.
-  change (r • (1 : H)) ⊗ₜ[k] (1 : H) =
-    Coalgebra.comul (R := k) (A := H) (r • (1 : H))
-  rw [map_smul, Bialgebra.comul_one, Algebra.TensorProduct.one_def]
-  rfl
+  exact FGComoduleCat.ofHom (R := k) (C := H)
+    ((Comodule.Hom.trivialToRegular (R := k) (C := H)).codRestrict N.1 fun r ↦ by
+      simpa [Algebra.smul_def] using N.1.toSubmodule.smul_mem r hOne)
 
 @[simp]
 private theorem regularUnitHom_apply
@@ -80,8 +62,13 @@ private theorem regularUnitHom_apply
     regularUnitHom k H N hOne r =
       ⟨r • (1 : H), N.1.toSubmodule.smul_mem r hOne⟩ :=
   by
+    let _ : Comodule k H k := Comodule.trivial (R := k) (C := H) (M := k)
+    change (regularUnitHom k H N hOne).hom.toLinearMap r = _
     unfold regularUnitHom
-    rfl
+    change ((Comodule.Hom.trivialToRegular (R := k) (C := H)).codRestrict N.1 _ r) = _
+    apply Subtype.ext
+    rw [Comodule.Hom.codRestrict_apply, Comodule.Hom.trivialToRegular_apply]
+    simp [Algebra.smul_def]
 
 private theorem map_regularUnitHom_ε_one
     (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
@@ -132,6 +119,7 @@ private theorem map_regularUnitHom_ε_one
 
 /-- The transported component of a tensor automorphism fixes `1 ⊗ 1` in every finite
 regular subcomodule containing the unit. -/
+@[simp]
 theorem finiteRegularComponent_one_tmul
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
     (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))


### PR DESCRIPTION
This PR proves the tensor-unit law for the compatible local functionals extracted from a tensor automorphism of finite-comodule scalar extension: if a finite regular subcomodule contains `1`, its local functional sends that element to `1`. It also adds the characteristic application equation for the intentionally opaque transported component, allowing the unit proof to use its canonical tensor model without exposing the definition body.

It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 milestone “Tannakian reconstruction: recover `G` from its tensor category of representations,” specifically the tensor-unit argument needed to upgrade the reconstructed functional `H →ₗ[k] A` to an algebra-valued point. The exact dependency edge is that the global functional glued from these compatible local functionals consumes `localFunctional_one` to prove `map_one`; the independently developed finite-regular-subcomodule multiplication lane supplies the corresponding `map_mul` argument.

After this PR, the Layer 1 Tannakian reconstruction milestone still needs multiplicativity of the glued functional, its upgrade to an algebra homomorphism, and the proof that reconstruction is inverse to the point action.

Add `TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean` (184 lines) and add a 16-line characteristic application lemma beside `finiteRegularComponent` in `LocalFunctional.lean`, for 200 inserted lines total. No Mathlib infrastructure is vendored: the proof directly reuses `NatTrans.IsMonoidal.unit`, naturality of the tensor automorphism, Tau Ceti's scalar-extension unit and map formulas, the trivial comodule, and the induced subcomodule coaction. The mathematical formulation follows J. S. Milne, *Algebraic Groups* (2017), §9.4, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tannaka-local-functional-one"}-->

🤖 Prepared with Codex
