### PR TITLE
feat: tensor multiplicative Jordan decompositions

### DIFF
--- a/TauCeti/LinearAlgebra/End/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/End/TensorProduct.lean
@@ -21,7 +21,7 @@ original module, and the corresponding one-sided tensor endomorphism acts compon
 
 * `TauCeti.Module.End.IsSemisimple.rTensor`: `f ⊗ 1` is semisimple when `f` is.
 * `TauCeti.Module.End.IsSemisimple.lTensor`: `1 ⊗ f` is semisimple when `f` is.
-* `TauCeti.Module.End.rTensor_commute_lTensor`: one-sided tensor endomorphisms on different factors
+* `TauCeti.Module.End.commute_rTensor_lTensor`: one-sided tensor endomorphisms on different factors
   commute.
 * `TauCeti.Module.End.IsSemisimple.tensorProduct`: tensor products of semisimple endomorphisms are
   semisimple.
@@ -101,10 +101,9 @@ theorem IsSemisimple.lTensor {f : _root_.Module.End K W} (hf : f.IsSemisimple) :
 end Left
 
 /-- One-sided tensor endomorphisms acting on different factors commute. -/
-theorem rTensor_commute_lTensor (f : _root_.Module.End K V) (g : _root_.Module.End K W) :
+theorem commute_rTensor_lTensor (f : _root_.Module.End K V) (g : _root_.Module.End K W) :
     Commute (f.rTensor W) (g.lTensor V) := by
-  change f.rTensor W * g.lTensor V = g.lTensor V * f.rTensor W
-  rw [_root_.Module.End.mul_eq_comp, _root_.Module.End.mul_eq_comp]
+  rw [commute_iff_eq, _root_.Module.End.mul_eq_comp, _root_.Module.End.mul_eq_comp]
   exact (LinearMap.rTensor_comp_lTensor V f g).trans
     (LinearMap.lTensor_comp_rTensor V f g).symm
 
@@ -126,7 +125,7 @@ theorem isNilpotent_map_sub_one {f : _root_.Module.End K V} {g : _root_.Module.E
     -- Expose the algebra homomorphism's action as left tensoring after applying the map laws.
     change IsNilpotent (g.lTensor V - 1) at hm'
     exact hm'
-  have hab := rTensor_commute_lTensor f g
+  have hab := commute_rTensor_lTensor f g
   have hnm : Commute n m := by
     dsimp only [n, m]
     exact (hab.sub_right (Commute.one_right _)).sub_left (Commute.one_left _)
@@ -153,7 +152,7 @@ theorem IsSemisimple.tensorProduct {f : _root_.Module.End K V} {g : _root_.Modul
     (hf : f.IsSemisimple) (hg : g.IsSemisimple) :
     _root_.Module.End.IsSemisimple (TensorProduct.map f g) := by
   rw [← LinearMap.lTensor_comp_rTensor, ← _root_.Module.End.mul_eq_comp]
-  exact _root_.Module.End.IsSemisimple.mul_of_commute (rTensor_commute_lTensor f g).symm
+  exact _root_.Module.End.IsSemisimple.mul_of_commute (commute_rTensor_lTensor f g).symm
     (IsSemisimple.lTensor hg) (IsSemisimple.rTensor hf)
 
 end PerfectField

--- a/TauCeti/LinearAlgebra/End/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/End/TensorProduct.lean
@@ -71,21 +71,13 @@ theorem IsSemisimple.rTensor {f : _root_.Module.End K V} (hf : f.IsSemisimple) :
   let E₀' : (V ⊗[K] W) ≃ₗ[K]
       (Module.Free.ChooseBasisIndex K W →₀ Module.AEval' f) :=
     E₀.trans (Finsupp.mapRange.linearEquiv (Module.AEval'.of f))
-  let _ : IsScalarTower K K[X]
-      (Module.Free.ChooseBasisIndex K W →₀ Module.AEval' f) := {
-    smul_assoc := fun r p x ↦ by
-        ext i
-        exact smul_assoc r p (x i) }
   let E : Module.AEval' (f.rTensor W) ≃ₗ[K[X]]
       (Module.Free.ChooseBasisIndex K W →₀ Module.AEval' f) :=
     LinearEquiv.ofAEval _ E₀' fun x ↦ by
       ext i
       simp only [E₀', LinearEquiv.trans_apply, Finsupp.mapRange.linearEquiv_apply,
-        Finsupp.mapRange_apply, Finsupp.smul_apply, Module.AEval'.X_smul_of]
-      apply (Module.AEval'.of f).injective
-      -- The basis equivalence computes right tensor actions coordinatewise by definition;
-      -- expose that form so tensor induction applies.
-      change E₀ (f.rTensor W x) i = f (E₀ x i)
+        Finsupp.mapRange_apply, Finsupp.smul_apply, Module.AEval'.X_smul_of,
+        _root_.Module.End.smul_def]
       induction x using TensorProduct.induction_on with
       | zero => simp
       | tmul v w => simp [E₀]
@@ -123,14 +115,16 @@ theorem _root_.IsNilpotent.tensorProduct_map_sub_one {f : _root_.Module.End K V}
   have hn : IsNilpotent n := by
     have hn' := hf.map (_root_.Module.End.rTensorAlgHom K V W)
     rw [map_sub, map_one] at hn'
-    -- Expose the algebra homomorphism's action as right tensoring after applying the map laws.
-    change IsNilpotent (f.rTensor W - 1) at hn'
+    rw [show (_root_.Module.End.rTensorAlgHom K V W) f = f.rTensor W by
+      apply LinearMap.ext
+      exact _root_.Module.End.rTensorAlgHom_apply_apply K V W f] at hn'
     exact hn'
   have hm : IsNilpotent m := by
     have hm' := hg.map (_root_.Module.End.lTensorAlgHom K W V)
     rw [map_sub, map_one] at hm'
-    -- Expose the algebra homomorphism's action as left tensoring after applying the map laws.
-    change IsNilpotent (g.lTensor V - 1) at hm'
+    rw [show (_root_.Module.End.lTensorAlgHom K W V) g = g.lTensor V by
+      apply LinearMap.ext
+      exact _root_.Module.End.lTensorAlgHom_apply_apply K W V g] at hm'
     exact hm'
   have hab := commute_rTensor_lTensor f g
   have hnm : Commute n m := by

--- a/TauCeti/LinearAlgebra/End/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/End/TensorProduct.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.TensorProduct.Basis
+public import Mathlib.LinearAlgebra.Semisimple
+public import Mathlib.RingTheory.TensorProduct.Maps
+
+/-!
+# Semisimple endomorphisms of tensor products
+
+Tensoring a semisimple endomorphism with the identity preserves semisimplicity.  After choosing a
+basis of the unchanged factor, the tensor product is a direct sum of copies of the original
+module, and the tensor endomorphism acts componentwise.
+
+## Main declarations
+
+* `TauCeti.Module.End.IsSemisimple.rTensor`: `f ⊗ 1` is semisimple when `f` is.
+* `TauCeti.Module.End.IsSemisimple.lTensor`: `1 ⊗ f` is semisimple when `f` is.
+-/
+
+public section
+
+namespace TauCeti
+
+open Polynomial
+open scoped TensorProduct
+
+namespace Module.End
+
+universe u v w
+
+variable {K : Type u} {V : Type v} {W : Type w}
+variable [CommRing K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
+
+private theorem aeval_rTensor (f : _root_.Module.End K V) (p : K[X]) :
+    aeval (f.rTensor W) p = (aeval f p).rTensor W := by
+  -- Present one-sided tensoring through its algebra homomorphism so `aeval_algHom_apply` applies.
+  change aeval ((_root_.Module.End.rTensorAlgHom K V W) f) p =
+    (_root_.Module.End.rTensorAlgHom K V W) (aeval f p)
+  exact Polynomial.aeval_algHom_apply (_root_.Module.End.rTensorAlgHom K V W) f p
+
+private theorem aeval_lTensor (f : _root_.Module.End K W) (p : K[X]) :
+    aeval (f.lTensor V) p = (aeval f p).lTensor V := by
+  -- Present one-sided tensoring through its algebra homomorphism so `aeval_algHom_apply` applies.
+  change aeval ((_root_.Module.End.lTensorAlgHom K W V) f) p =
+    (_root_.Module.End.lTensorAlgHom K W V) (aeval f p)
+  exact Polynomial.aeval_algHom_apply (_root_.Module.End.lTensorAlgHom K W V) f p
+
+section Right
+
+variable [Module.Free K W]
+
+/-- Tensoring a semisimple endomorphism on the right with an identity endomorphism preserves
+semisimplicity. -/
+theorem IsSemisimple.rTensor {f : _root_.Module.End K V} (hf : f.IsSemisimple) :
+    _root_.Module.End.IsSemisimple (f.rTensor W) := by
+  classical
+  rw [_root_.Module.End.IsSemisimple] at hf ⊢
+  let _ : IsSemisimpleModule K[X] (Module.AEval' f) := hf
+  let b := Module.Free.chooseBasis K W
+  let E₀ : (V ⊗[K] W) ≃ₗ[K] (Module.Free.ChooseBasisIndex K W →₀ V) :=
+    TensorProduct.equivFinsuppOfBasisRight b
+  let E : Module.AEval' (f.rTensor W) ≃ₗ[K[X]]
+      (Module.Free.ChooseBasisIndex K W →₀ Module.AEval' f) := by
+    exact {
+      toFun := fun x ↦ E₀ x
+      invFun := fun x ↦ E₀.symm x
+      left_inv := E₀.left_inv
+      right_inv := E₀.right_inv
+      map_add' := E₀.map_add
+      map_smul' := fun p x ↦ by
+        -- Polynomial scalar multiplication on `AEval'` is evaluation at its endomorphism.
+        change E₀ (aeval (f.rTensor W) p x) = _
+        rw [aeval_rTensor]
+        ext i
+        change E₀ ((aeval f p).rTensor W x) i = aeval f p (E₀ x i)
+        induction x using TensorProduct.induction_on with
+        | zero => simp
+        | tmul v w =>
+            simp [E₀]
+        | add x y hx hy => simp [hx, hy]
+    }
+  exact IsSemisimpleModule.congr E
+
+end Right
+
+section Left
+
+variable [Module.Free K V]
+
+/-- Tensoring a semisimple endomorphism on the left with an identity endomorphism preserves
+semisimplicity. -/
+theorem IsSemisimple.lTensor {f : _root_.Module.End K W} (hf : f.IsSemisimple) :
+    _root_.Module.End.IsSemisimple (f.lTensor V) := by
+  classical
+  rw [_root_.Module.End.IsSemisimple] at hf ⊢
+  let _ : IsSemisimpleModule K[X] (Module.AEval' f) := hf
+  let b := Module.Free.chooseBasis K V
+  let E₀ : (V ⊗[K] W) ≃ₗ[K] (Module.Free.ChooseBasisIndex K V →₀ W) :=
+    TensorProduct.equivFinsuppOfBasisLeft b
+  let E : Module.AEval' (f.lTensor V) ≃ₗ[K[X]]
+      (Module.Free.ChooseBasisIndex K V →₀ Module.AEval' f) := by
+    exact {
+      toFun := fun x ↦ E₀ x
+      invFun := fun x ↦ E₀.symm x
+      left_inv := E₀.left_inv
+      right_inv := E₀.right_inv
+      map_add' := E₀.map_add
+      map_smul' := fun p x ↦ by
+        -- Polynomial scalar multiplication on `AEval'` is evaluation at its endomorphism.
+        change E₀ (aeval (f.lTensor V) p x) = _
+        rw [aeval_lTensor]
+        ext i
+        change E₀ ((aeval f p).lTensor V x) i = aeval f p (E₀ x i)
+        induction x using TensorProduct.induction_on with
+        | zero => simp
+        | tmul v w =>
+            simp [E₀]
+        | add x y hx hy => simp [hx, hy]
+    }
+  exact IsSemisimpleModule.congr E
+
+end Left
+
+end Module.End
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/End/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/End/TensorProduct.lean
@@ -62,6 +62,8 @@ theorem IsSemisimple.rTensor {f : _root_.Module.End K V} (hf : f.IsSemisimple) :
         change E₀ (aeval ((_root_.Module.End.rTensorAlgHom K V W) f) p x) = _
         rw [Polynomial.aeval_algHom_apply]
         ext i
+        -- The basis equivalence computes right tensor actions coordinatewise by definition;
+        -- expose that form so tensor induction applies.
         change E₀ ((aeval f p).rTensor W x) i = aeval f p (E₀ x i)
         induction x using TensorProduct.induction_on with
         | zero => simp
@@ -100,6 +102,8 @@ theorem IsSemisimple.lTensor {f : _root_.Module.End K W} (hf : f.IsSemisimple) :
         change E₀ (aeval ((_root_.Module.End.lTensorAlgHom K W V) f) p x) = _
         rw [Polynomial.aeval_algHom_apply]
         ext i
+        -- The basis equivalence computes left tensor actions coordinatewise by definition;
+        -- expose that form so tensor induction applies.
         change E₀ ((aeval f p).lTensor V x) i = aeval f p (E₀ x i)
         induction x using TensorProduct.induction_on with
         | zero => simp

--- a/TauCeti/LinearAlgebra/End/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/End/TensorProduct.lean
@@ -108,6 +108,12 @@ theorem IsSemisimple.lTensor {f : _root_.Module.End K W} (hf : f.IsSemisimple) :
 
 end Left
 
+end CommRing
+
+section CommSemiring
+
+variable [CommSemiring K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
+
 /-- If `f - 1` and `g - 1` are nilpotent, then `TensorProduct.map f g - 1` is nilpotent. -/
 theorem _root_.IsNilpotent.tensorProduct_map_sub_one {f : _root_.Module.End K V}
     {g : _root_.Module.End K W} (hf : IsNilpotent (f - 1)) (hg : IsNilpotent (g - 1)) :
@@ -141,7 +147,7 @@ theorem _root_.IsNilpotent.tensorProduct_map_sub_one {f : _root_.Module.End K V}
   exact Commute.isNilpotent_add (hn_mul.add_left hm_mul)
     (Commute.isNilpotent_add hnm hn hm) hmul
 
-end CommRing
+end CommSemiring
 
 section PerfectField
 

--- a/TauCeti/LinearAlgebra/End/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/End/TensorProduct.lean
@@ -25,7 +25,7 @@ original module, and the corresponding one-sided tensor endomorphism acts compon
   commute.
 * `TauCeti.Module.End.IsSemisimple.tensorProduct`: tensor products of semisimple endomorphisms are
   semisimple.
-* `TauCeti.Module.End.isNilpotent_map_sub_one`: `TensorProduct.map f g - 1` is nilpotent when
+* `IsNilpotent.tensorProduct_map_sub_one`: `TensorProduct.map f g - 1` is nilpotent when
   `f - 1` and `g - 1` are nilpotent.
 -/
 
@@ -41,6 +41,14 @@ namespace Module.End
 universe u v w
 
 variable {K : Type u} {V : Type v} {W : Type w}
+
+/-- One-sided tensor endomorphisms acting on different factors commute. -/
+theorem commute_rTensor_lTensor [CommSemiring K] [AddCommMonoid V] [Module K V]
+    [AddCommMonoid W] [Module K W] (f : _root_.Module.End K V)
+    (g : _root_.Module.End K W) : Commute (f.rTensor W) (g.lTensor V) := by
+  rw [commute_iff_eq, _root_.Module.End.mul_eq_comp, _root_.Module.End.mul_eq_comp]
+  exact (LinearMap.rTensor_comp_lTensor V f g).trans
+    (LinearMap.lTensor_comp_rTensor V f g).symm
 
 section CommRing
 
@@ -100,16 +108,9 @@ theorem IsSemisimple.lTensor {f : _root_.Module.End K W} (hf : f.IsSemisimple) :
 
 end Left
 
-/-- One-sided tensor endomorphisms acting on different factors commute. -/
-theorem commute_rTensor_lTensor (f : _root_.Module.End K V) (g : _root_.Module.End K W) :
-    Commute (f.rTensor W) (g.lTensor V) := by
-  rw [commute_iff_eq, _root_.Module.End.mul_eq_comp, _root_.Module.End.mul_eq_comp]
-  exact (LinearMap.rTensor_comp_lTensor V f g).trans
-    (LinearMap.lTensor_comp_rTensor V f g).symm
-
 /-- If `f - 1` and `g - 1` are nilpotent, then `TensorProduct.map f g - 1` is nilpotent. -/
-theorem isNilpotent_map_sub_one {f : _root_.Module.End K V} {g : _root_.Module.End K W}
-    (hf : IsNilpotent (f - 1)) (hg : IsNilpotent (g - 1)) :
+theorem _root_.IsNilpotent.tensorProduct_map_sub_one {f : _root_.Module.End K V}
+    {g : _root_.Module.End K W} (hf : IsNilpotent (f - 1)) (hg : IsNilpotent (g - 1)) :
     IsNilpotent (TensorProduct.map f g - 1) := by
   let n : _root_.Module.End K (V ⊗[K] W) := f.rTensor W - 1
   let m : _root_.Module.End K (V ⊗[K] W) := g.lTensor V - 1

--- a/TauCeti/LinearAlgebra/End/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/End/TensorProduct.lean
@@ -14,8 +14,9 @@ import Mathlib.Tactic.NoncommRing
 # Endomorphisms of tensor products
 
 This file establishes semisimplicity and nilpotence properties of tensor-product endomorphisms.
-After choosing a basis of an unchanged factor, the tensor product is a direct sum of copies of the
-original module, and the corresponding one-sided tensor endomorphism acts componentwise.
+After embedding an unchanged projective factor as a direct summand of a free module, the tensor
+product is a direct summand of a direct sum of copies of the original module, and the corresponding
+one-sided tensor endomorphism acts componentwise.
 
 ## Main declarations
 
@@ -42,6 +43,20 @@ universe u v w
 
 variable {K : Type u} {V : Type v} {W : Type w}
 
+/-- The right-tensor algebra homomorphism sends `f` to `f.rTensor W`. -/
+theorem rTensorAlgHom_apply [CommSemiring K] [AddCommMonoid V] [Module K V]
+    [AddCommMonoid W] [Module K W] (f : _root_.Module.End K V) :
+    (_root_.Module.End.rTensorAlgHom K V W) f = f.rTensor W := by
+  apply LinearMap.ext
+  exact _root_.Module.End.rTensorAlgHom_apply_apply K V W f
+
+/-- The left-tensor algebra homomorphism sends `f` to `f.lTensor V`. -/
+theorem lTensorAlgHom_apply [CommSemiring K] [AddCommMonoid V] [Module K V]
+    [AddCommMonoid W] [Module K W] (f : _root_.Module.End K W) :
+    (_root_.Module.End.lTensorAlgHom K W V) f = f.lTensor V := by
+  apply LinearMap.ext
+  exact _root_.Module.End.lTensorAlgHom_apply_apply K W V f
+
 /-- One-sided tensor endomorphisms acting on different factors commute. -/
 theorem commute_rTensor_lTensor [CommSemiring K] [AddCommMonoid V] [Module K V]
     [AddCommMonoid W] [Module K W] (f : _root_.Module.End K V)
@@ -56,7 +71,7 @@ variable [CommRing K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W
 
 section Right
 
-variable [Module.Free K W]
+variable [Module.Projective K W]
 
 /-- Tensoring a semisimple endomorphism on the right with an identity endomorphism preserves
 semisimplicity. -/
@@ -64,31 +79,58 @@ theorem IsSemisimple.rTensor {f : _root_.Module.End K V} (hf : f.IsSemisimple) :
     _root_.Module.End.IsSemisimple (f.rTensor W) := by
   classical
   rw [_root_.Module.End.IsSemisimple] at hf ⊢
-  let _ : IsSemisimpleModule K[X] (Module.AEval' f) := hf
-  let b := Module.Free.chooseBasis K W
-  let E₀ : (V ⊗[K] W) ≃ₗ[K] (Module.Free.ChooseBasisIndex K W →₀ V) :=
-    TensorProduct.equivFinsuppOfBasisRight b
-  let E₀' : (V ⊗[K] W) ≃ₗ[K]
-      (Module.Free.ChooseBasisIndex K W →₀ Module.AEval' f) :=
-    E₀.trans (Finsupp.mapRange.linearEquiv (Module.AEval'.of f))
-  let E : Module.AEval' (f.rTensor W) ≃ₗ[K[X]]
-      (Module.Free.ChooseBasisIndex K W →₀ Module.AEval' f) :=
-    LinearEquiv.ofAEval _ E₀' fun x ↦ by
-      ext i
-      simp only [E₀', LinearEquiv.trans_apply, Finsupp.mapRange.linearEquiv_apply,
-        Finsupp.mapRange_apply, Finsupp.smul_apply, Module.AEval'.X_smul_of,
-        _root_.Module.End.smul_def]
-      induction x using TensorProduct.induction_on with
-      | zero => simp
-      | tmul v w => simp [E₀]
-      | add x y hx hy => simp [hx, hy]
-  exact IsSemisimpleModule.congr E
+  obtain ⟨M, _, _, _, i, s, his⟩ :=
+    (Module.Projective.iff_split (R := K) (P := W)).mp inferInstance
+  have hfree : IsSemisimpleModule K[X] (Module.AEval' (f.rTensor M)) := by
+    let _ : IsSemisimpleModule K[X] (Module.AEval' f) := hf
+    let b := Module.Free.chooseBasis K M
+    let E₀ : (V ⊗[K] M) ≃ₗ[K] (Module.Free.ChooseBasisIndex K M →₀ V) :=
+      TensorProduct.equivFinsuppOfBasisRight b
+    let E₀' : (V ⊗[K] M) ≃ₗ[K]
+        (Module.Free.ChooseBasisIndex K M →₀ Module.AEval' f) :=
+      E₀.trans (Finsupp.mapRange.linearEquiv (Module.AEval'.of f))
+    let E : Module.AEval' (f.rTensor M) ≃ₗ[K[X]]
+        (Module.Free.ChooseBasisIndex K M →₀ Module.AEval' f) :=
+      LinearEquiv.ofAEval _ E₀' fun x ↦ by
+        ext j
+        simp only [E₀', LinearEquiv.trans_apply, Finsupp.mapRange.linearEquiv_apply,
+          Finsupp.mapRange_apply, Finsupp.smul_apply, Module.AEval'.X_smul_of,
+          _root_.Module.End.smul_def]
+        induction x using TensorProduct.induction_on with
+        | zero => simp
+        | tmul v m => simp [E₀]
+        | add x y hx hy => simp [hx, hy]
+    exact IsSemisimpleModule.congr E
+  let iT : V ⊗[K] W →ₗ[K] V ⊗[K] M := i.lTensor V
+  let sT : V ⊗[K] M →ₗ[K] V ⊗[K] W := s.lTensor V
+  have hiT : Function.Injective iT := by
+    apply LinearMap.injective_of_comp_eq_id iT sT
+    rw [← LinearMap.lTensor_comp, his, LinearMap.lTensor_id]
+  have hiT_comm : iT.comp (f.rTensor W) = (f.rTensor M).comp iT := by
+    exact (LinearMap.lTensor_comp_rTensor V f i).trans
+      (LinearMap.rTensor_comp_lTensor V f i).symm
+  let iX : Module.AEval' (f.rTensor W) →ₗ[K[X]] Module.AEval' (f.rTensor M) :=
+    LinearMap.ofAEval _ ((Module.AEval'.of (f.rTensor M)).toLinearMap.comp iT) fun x ↦ by
+      calc
+        _ = (Module.AEval'.of (f.rTensor M)) (iT ((f.rTensor W) x)) := by
+          simp only [LinearMap.comp_apply, _root_.Module.End.smul_def]
+          rfl
+        _ = (Module.AEval'.of (f.rTensor M)) ((f.rTensor M) (iT x)) :=
+          congrArg (Module.AEval'.of (f.rTensor M)) (LinearMap.congr_fun hiT_comm x)
+        _ = _ := (Module.AEval'.X_smul_of (f.rTensor M) (iT x)).symm
+  let _ : IsSemisimpleModule K[X] (Module.AEval' (f.rTensor M)) := hfree
+  apply IsSemisimpleModule.of_injective iX
+  intro x y hxy
+  apply (Module.AEval'.of (f.rTensor W)).symm.injective
+  apply hiT
+  apply (Module.AEval'.of (f.rTensor M)).injective
+  exact hxy
 
 end Right
 
 section Left
 
-variable [Module.Free K V]
+variable [Module.Projective K V]
 
 /-- Tensoring a semisimple endomorphism on the left with an identity endomorphism preserves
 semisimplicity. -/
@@ -114,17 +156,11 @@ theorem _root_.IsNilpotent.tensorProduct_map_sub_one {f : _root_.Module.End K V}
   let m : _root_.Module.End K (V ⊗[K] W) := g.lTensor V - 1
   have hn : IsNilpotent n := by
     have hn' := hf.map (_root_.Module.End.rTensorAlgHom K V W)
-    rw [map_sub, map_one] at hn'
-    rw [show (_root_.Module.End.rTensorAlgHom K V W) f = f.rTensor W by
-      apply LinearMap.ext
-      exact _root_.Module.End.rTensorAlgHom_apply_apply K V W f] at hn'
+    rw [map_sub, map_one, rTensorAlgHom_apply] at hn'
     exact hn'
   have hm : IsNilpotent m := by
     have hm' := hg.map (_root_.Module.End.lTensorAlgHom K W V)
-    rw [map_sub, map_one] at hm'
-    rw [show (_root_.Module.End.lTensorAlgHom K W V) g = g.lTensor V by
-      apply LinearMap.ext
-      exact _root_.Module.End.lTensorAlgHom_apply_apply K W V g] at hm'
+    rw [map_sub, map_one, lTensorAlgHom_apply] at hm'
     exact hm'
   have hab := commute_rTensor_lTensor f g
   have hnm : Commute n m := by

--- a/TauCeti/LinearAlgebra/End/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/End/TensorProduct.lean
@@ -7,18 +7,26 @@ module
 public import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import Mathlib.LinearAlgebra.Semisimple
 public import Mathlib.RingTheory.TensorProduct.Maps
+import Mathlib.RingTheory.TensorProduct.Finite
+import Mathlib.Tactic.NoncommRing
 
 /-!
-# Semisimple endomorphisms of tensor products
+# Endomorphisms of tensor products
 
-Tensoring a semisimple endomorphism with the identity preserves semisimplicity.  After choosing a
-basis of the unchanged factor, the tensor product is a direct sum of copies of the original
-module, and the tensor endomorphism acts componentwise.
+This file establishes semisimplicity and nilpotence properties of tensor-product endomorphisms.
+After choosing a basis of an unchanged factor, the tensor product is a direct sum of copies of the
+original module, and the corresponding one-sided tensor endomorphism acts componentwise.
 
 ## Main declarations
 
 * `TauCeti.Module.End.IsSemisimple.rTensor`: `f ⊗ 1` is semisimple when `f` is.
 * `TauCeti.Module.End.IsSemisimple.lTensor`: `1 ⊗ f` is semisimple when `f` is.
+* `TauCeti.Module.End.rTensor_commute_lTensor`: one-sided tensor endomorphisms on different factors
+  commute.
+* `TauCeti.Module.End.IsSemisimple.tensorProduct`: tensor products of semisimple endomorphisms are
+  semisimple.
+* `TauCeti.Module.End.isNilpotent_map_sub_one`: `TensorProduct.map f g - 1` is nilpotent when
+  `f - 1` and `g - 1` are nilpotent.
 -/
 
 public section
@@ -33,6 +41,9 @@ namespace Module.End
 universe u v w
 
 variable {K : Type u} {V : Type v} {W : Type w}
+
+section CommRing
+
 variable [CommRing K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
 
 section Right
@@ -49,28 +60,28 @@ theorem IsSemisimple.rTensor {f : _root_.Module.End K V} (hf : f.IsSemisimple) :
   let b := Module.Free.chooseBasis K W
   let E₀ : (V ⊗[K] W) ≃ₗ[K] (Module.Free.ChooseBasisIndex K W →₀ V) :=
     TensorProduct.equivFinsuppOfBasisRight b
-  let E : Module.AEval' (f.rTensor W) ≃ₗ[K[X]]
-      (Module.Free.ChooseBasisIndex K W →₀ Module.AEval' f) := by
-    exact {
-      toFun := fun x ↦ E₀ x
-      invFun := fun x ↦ E₀.symm x
-      left_inv := E₀.left_inv
-      right_inv := E₀.right_inv
-      map_add' := E₀.map_add
-      map_smul' := fun p x ↦ by
-        -- Polynomial scalar multiplication on `AEval'` is evaluation at its endomorphism.
-        change E₀ (aeval ((_root_.Module.End.rTensorAlgHom K V W) f) p x) = _
-        rw [Polynomial.aeval_algHom_apply]
+  let E₀' : (V ⊗[K] W) ≃ₗ[K]
+      (Module.Free.ChooseBasisIndex K W →₀ Module.AEval' f) :=
+    E₀.trans (Finsupp.mapRange.linearEquiv (Module.AEval'.of f))
+  let _ : IsScalarTower K K[X]
+      (Module.Free.ChooseBasisIndex K W →₀ Module.AEval' f) := {
+    smul_assoc := fun r p x ↦ by
         ext i
-        -- The basis equivalence computes right tensor actions coordinatewise by definition;
-        -- expose that form so tensor induction applies.
-        change E₀ ((aeval f p).rTensor W x) i = aeval f p (E₀ x i)
-        induction x using TensorProduct.induction_on with
-        | zero => simp
-        | tmul v w =>
-            simp [E₀]
-        | add x y hx hy => simp [hx, hy]
-    }
+        exact smul_assoc r p (x i) }
+  let E : Module.AEval' (f.rTensor W) ≃ₗ[K[X]]
+      (Module.Free.ChooseBasisIndex K W →₀ Module.AEval' f) :=
+    LinearEquiv.ofAEval _ E₀' fun x ↦ by
+      ext i
+      simp only [E₀', LinearEquiv.trans_apply, Finsupp.mapRange.linearEquiv_apply,
+        Finsupp.mapRange_apply, Finsupp.smul_apply, Module.AEval'.X_smul_of]
+      apply (Module.AEval'.of f).injective
+      -- The basis equivalence computes right tensor actions coordinatewise by definition;
+      -- expose that form so tensor induction applies.
+      change E₀ (f.rTensor W x) i = f (E₀ x i)
+      induction x using TensorProduct.induction_on with
+      | zero => simp
+      | tmul v w => simp [E₀]
+      | add x y hx hy => simp [hx, hy]
   exact IsSemisimpleModule.congr E
 
 end Right
@@ -83,37 +94,69 @@ variable [Module.Free K V]
 semisimplicity. -/
 theorem IsSemisimple.lTensor {f : _root_.Module.End K W} (hf : f.IsSemisimple) :
     _root_.Module.End.IsSemisimple (f.lTensor V) := by
-  classical
-  rw [_root_.Module.End.IsSemisimple] at hf ⊢
-  let _ : IsSemisimpleModule K[X] (Module.AEval' f) := hf
-  let b := Module.Free.chooseBasis K V
-  let E₀ : (V ⊗[K] W) ≃ₗ[K] (Module.Free.ChooseBasisIndex K V →₀ W) :=
-    TensorProduct.equivFinsuppOfBasisLeft b
-  let E : Module.AEval' (f.lTensor V) ≃ₗ[K[X]]
-      (Module.Free.ChooseBasisIndex K V →₀ Module.AEval' f) := by
-    exact {
-      toFun := fun x ↦ E₀ x
-      invFun := fun x ↦ E₀.symm x
-      left_inv := E₀.left_inv
-      right_inv := E₀.right_inv
-      map_add' := E₀.map_add
-      map_smul' := fun p x ↦ by
-        -- Polynomial scalar multiplication on `AEval'` is evaluation at its endomorphism.
-        change E₀ (aeval ((_root_.Module.End.lTensorAlgHom K W V) f) p x) = _
-        rw [Polynomial.aeval_algHom_apply]
-        ext i
-        -- The basis equivalence computes left tensor actions coordinatewise by definition;
-        -- expose that form so tensor induction applies.
-        change E₀ ((aeval f p).lTensor V x) i = aeval f p (E₀ x i)
-        induction x using TensorProduct.induction_on with
-        | zero => simp
-        | tmul v w =>
-            simp [E₀]
-        | add x y hx hy => simp [hx, hy]
-    }
-  exact IsSemisimpleModule.congr E
+  exact ((TensorProduct.comm K V W).isSemisimple_iff (f.lTensor V) (f.rTensor V)
+    (LinearMap.rTensor_comp_comm f).symm).mpr
+      (IsSemisimple.rTensor (W := V) hf)
 
 end Left
+
+/-- One-sided tensor endomorphisms acting on different factors commute. -/
+theorem rTensor_commute_lTensor (f : _root_.Module.End K V) (g : _root_.Module.End K W) :
+    Commute (f.rTensor W) (g.lTensor V) := by
+  change f.rTensor W * g.lTensor V = g.lTensor V * f.rTensor W
+  rw [_root_.Module.End.mul_eq_comp, _root_.Module.End.mul_eq_comp]
+  exact (LinearMap.rTensor_comp_lTensor V f g).trans
+    (LinearMap.lTensor_comp_rTensor V f g).symm
+
+/-- If `f - 1` and `g - 1` are nilpotent, then `TensorProduct.map f g - 1` is nilpotent. -/
+theorem isNilpotent_map_sub_one {f : _root_.Module.End K V} {g : _root_.Module.End K W}
+    (hf : IsNilpotent (f - 1)) (hg : IsNilpotent (g - 1)) :
+    IsNilpotent (TensorProduct.map f g - 1) := by
+  let n : _root_.Module.End K (V ⊗[K] W) := f.rTensor W - 1
+  let m : _root_.Module.End K (V ⊗[K] W) := g.lTensor V - 1
+  have hn : IsNilpotent n := by
+    have hn' := hf.map (_root_.Module.End.rTensorAlgHom K V W)
+    rw [map_sub, map_one] at hn'
+    -- Expose the algebra homomorphism's action as right tensoring after applying the map laws.
+    change IsNilpotent (f.rTensor W - 1) at hn'
+    exact hn'
+  have hm : IsNilpotent m := by
+    have hm' := hg.map (_root_.Module.End.lTensorAlgHom K W V)
+    rw [map_sub, map_one] at hm'
+    -- Expose the algebra homomorphism's action as left tensoring after applying the map laws.
+    change IsNilpotent (g.lTensor V - 1) at hm'
+    exact hm'
+  have hab := rTensor_commute_lTensor f g
+  have hnm : Commute n m := by
+    dsimp only [n, m]
+    exact (hab.sub_right (Commute.one_right _)).sub_left (Commute.one_left _)
+  have hmul : IsNilpotent (n * m) := hnm.isNilpotent_mul_left hm
+  have hn_mul : Commute n (n * m) := (Commute.refl n).mul_right hnm
+  have hm_mul : Commute m (n * m) := hnm.symm.mul_right (Commute.refl m)
+  have hmap : TensorProduct.map f g - 1 = n + m + n * m := by
+    rw [← LinearMap.lTensor_comp_rTensor, ← _root_.Module.End.mul_eq_comp]
+    dsimp only [n, m]
+    noncomm_ring [hab.eq]
+  rw [hmap]
+  exact Commute.isNilpotent_add (hn_mul.add_left hm_mul)
+    (Commute.isNilpotent_add hnm hn hm) hmul
+
+end CommRing
+
+section PerfectField
+
+variable [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
+variable [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W]
+
+/-- The tensor product of two semisimple endomorphisms is semisimple. -/
+theorem IsSemisimple.tensorProduct {f : _root_.Module.End K V} {g : _root_.Module.End K W}
+    (hf : f.IsSemisimple) (hg : g.IsSemisimple) :
+    _root_.Module.End.IsSemisimple (TensorProduct.map f g) := by
+  rw [← LinearMap.lTensor_comp_rTensor, ← _root_.Module.End.mul_eq_comp]
+  exact _root_.Module.End.IsSemisimple.mul_of_commute (rTensor_commute_lTensor f g).symm
+    (IsSemisimple.lTensor hg) (IsSemisimple.rTensor hf)
+
+end PerfectField
 
 end Module.End
 

--- a/TauCeti/LinearAlgebra/End/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/End/TensorProduct.lean
@@ -35,20 +35,6 @@ universe u v w
 variable {K : Type u} {V : Type v} {W : Type w}
 variable [CommRing K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
 
-private theorem aeval_rTensor (f : _root_.Module.End K V) (p : K[X]) :
-    aeval (f.rTensor W) p = (aeval f p).rTensor W := by
-  -- Present one-sided tensoring through its algebra homomorphism so `aeval_algHom_apply` applies.
-  change aeval ((_root_.Module.End.rTensorAlgHom K V W) f) p =
-    (_root_.Module.End.rTensorAlgHom K V W) (aeval f p)
-  exact Polynomial.aeval_algHom_apply (_root_.Module.End.rTensorAlgHom K V W) f p
-
-private theorem aeval_lTensor (f : _root_.Module.End K W) (p : K[X]) :
-    aeval (f.lTensor V) p = (aeval f p).lTensor V := by
-  -- Present one-sided tensoring through its algebra homomorphism so `aeval_algHom_apply` applies.
-  change aeval ((_root_.Module.End.lTensorAlgHom K W V) f) p =
-    (_root_.Module.End.lTensorAlgHom K W V) (aeval f p)
-  exact Polynomial.aeval_algHom_apply (_root_.Module.End.lTensorAlgHom K W V) f p
-
 section Right
 
 variable [Module.Free K W]
@@ -73,8 +59,8 @@ theorem IsSemisimple.rTensor {f : _root_.Module.End K V} (hf : f.IsSemisimple) :
       map_add' := E₀.map_add
       map_smul' := fun p x ↦ by
         -- Polynomial scalar multiplication on `AEval'` is evaluation at its endomorphism.
-        change E₀ (aeval (f.rTensor W) p x) = _
-        rw [aeval_rTensor]
+        change E₀ (aeval ((_root_.Module.End.rTensorAlgHom K V W) f) p x) = _
+        rw [Polynomial.aeval_algHom_apply]
         ext i
         change E₀ ((aeval f p).rTensor W x) i = aeval f p (E₀ x i)
         induction x using TensorProduct.induction_on with
@@ -111,8 +97,8 @@ theorem IsSemisimple.lTensor {f : _root_.Module.End K W} (hf : f.IsSemisimple) :
       map_add' := E₀.map_add
       map_smul' := fun p x ↦ by
         -- Polynomial scalar multiplication on `AEval'` is evaluation at its endomorphism.
-        change E₀ (aeval (f.lTensor V) p x) = _
-        rw [aeval_lTensor]
+        change E₀ (aeval ((_root_.Module.End.lTensorAlgHom K W V) f) p x) = _
+        rw [Polynomial.aeval_algHom_apply]
         ext i
         change E₀ ((aeval f p).lTensor V x) i = aeval f p (E₀ x i)
         induction x using TensorProduct.induction_on with

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
+public import Mathlib.RingTheory.TensorProduct.Maps
+
+/-!
+# Tensor products in the general linear group
+
+This file packages the tensor product of two linear automorphisms as an automorphism and records
+its compatibility with multiplication, inverses, and pure tensors.
+
+## Main declarations
+
+* `TauCeti.GeneralLinearGroup.tensorProduct`: the tensor product of two linear automorphisms.
+* `TauCeti.GeneralLinearGroup.tensorProduct_apply_tmul`: its action on a pure tensor.
+-/
+
+public section
+
+namespace TauCeti
+
+open LinearMap
+open scoped TensorProduct
+
+namespace GeneralLinearGroup
+
+universe u v w
+
+variable {K : Type u} {V : Type v} {W : Type w}
+variable [CommSemiring K] [AddCommMonoid V] [Module K V]
+  [AddCommMonoid W] [Module K W]
+
+/-- The tensor product of two linear automorphisms. -/
+def tensorProduct (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
+    GeneralLinearGroup K (V ⊗[K] W) :=
+  LinearMap.GeneralLinearGroup.ofLinearEquiv
+    (TensorProduct.congr g.toLinearEquiv h.toLinearEquiv)
+
+/-- The endomorphism underlying a tensor-product automorphism is `TensorProduct.map`. -/
+theorem coe_tensorProduct (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
+    (tensorProduct g h : Module.End K (V ⊗[K] W)) =
+      TensorProduct.map (g : Module.End K V) (h : Module.End K W) :=
+  (rfl)
+
+/-- A tensor-product automorphism acts factorwise on pure tensors. -/
+@[simp]
+theorem tensorProduct_apply_tmul (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W)
+    (v : V) (w : W) :
+    (tensorProduct g h : Module.End K (V ⊗[K] W)) (v ⊗ₜ[K] w) =
+      (g : Module.End K V) v ⊗ₜ[K] (h : Module.End K W) w :=
+  (rfl)
+
+/-- Tensor products preserve multiplication. -/
+@[simp]
+theorem tensorProduct_mul (g₁ g₂ : GeneralLinearGroup K V)
+    (h₁ h₂ : GeneralLinearGroup K W) :
+    tensorProduct (g₁ * g₂) (h₁ * h₂) =
+      tensorProduct g₁ h₁ * tensorProduct g₂ h₂ := by
+  apply Units.ext
+  -- Reduce equality of units to Mathlib's multiplicativity of `TensorProduct.map`.
+  change TensorProduct.map (↑(g₁ * g₂)) (↑(h₁ * h₂)) =
+    TensorProduct.map (g₁ : Module.End K V) (h₁ : Module.End K W) *
+      TensorProduct.map (g₂ : Module.End K V) (h₂ : Module.End K W)
+  simpa only [Units.val_mul] using TensorProduct.map_mul
+    (g₁ : Module.End K V) (g₂ : Module.End K V)
+    (h₁ : Module.End K W) (h₂ : Module.End K W)
+
+/-- The tensor product of two identity automorphisms is the identity. -/
+@[simp]
+theorem tensorProduct_one :
+    tensorProduct (1 : GeneralLinearGroup K V) (1 : GeneralLinearGroup K W) = 1 := by
+  apply Units.ext
+  -- Reduce equality of units to Mathlib's identity law for `TensorProduct.map`.
+  change TensorProduct.map (1 : Module.End K V) (1 : Module.End K W) = 1
+  exact TensorProduct.map_one
+
+/-- Tensor products preserve inverses. -/
+@[simp]
+theorem tensorProduct_inv (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
+    tensorProduct g⁻¹ h⁻¹ = (tensorProduct g h)⁻¹ := by
+  apply mul_left_cancel (a := tensorProduct g h)
+  rw [← tensorProduct_mul, mul_inv_cancel, mul_inv_cancel, tensorProduct_one,
+    mul_inv_cancel]
+
+end GeneralLinearGroup
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
@@ -60,27 +60,32 @@ theorem tensorProduct_mul (g₁ g₂ : GeneralLinearGroup K V)
     (h₁ h₂ : GeneralLinearGroup K W) :
     tensorProduct (g₁ * g₂) (h₁ * h₂) =
       tensorProduct g₁ h₁ * tensorProduct g₂ h₂ := by
-  apply Units.ext
-  simpa only [Units.val_mul, coe_tensorProduct] using TensorProduct.map_mul
-    (g₁ : Module.End K V) (g₂ : Module.End K V)
-    (h₁ : Module.End K W) (h₂ : Module.End K W)
+  simp only [tensorProduct, LinearMap.GeneralLinearGroup.toLinearEquiv_mul,
+    TensorProduct.congr_mul,
+    LinearMap.GeneralLinearGroup.ofLinearEquiv_mul]
 
 /-- The tensor product of two identity automorphisms is the identity. -/
 @[simp]
 theorem tensorProduct_one :
     tensorProduct (1 : GeneralLinearGroup K V) (1 : GeneralLinearGroup K W) = 1 := by
-  apply Units.ext
-  simpa only [Units.val_one, coe_tensorProduct] using
-    (TensorProduct.map_one : TensorProduct.map (1 : Module.End K V)
-      (1 : Module.End K W) = 1)
+  change LinearMap.GeneralLinearGroup.ofLinearEquiv
+      (TensorProduct.congr (LinearEquiv.refl K V) (LinearEquiv.refl K W)) = 1
+  rw [TensorProduct.congr_refl_refl]
+  rfl
 
 /-- Tensor products preserve inverses. -/
 @[simp]
 theorem tensorProduct_inv (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
     tensorProduct g⁻¹ h⁻¹ = (tensorProduct g h)⁻¹ := by
-  apply mul_left_cancel (a := tensorProduct g h)
-  rw [← tensorProduct_mul, mul_inv_cancel, mul_inv_cancel, tensorProduct_one,
-    mul_inv_cancel]
+  unfold tensorProduct
+  rw [LinearMap.GeneralLinearGroup.toLinearEquiv_inv,
+    LinearMap.GeneralLinearGroup.toLinearEquiv_inv]
+  -- The tensor congruence lemma is stated with `LinearEquiv.symm`; expose that notation before
+  -- transporting the inverse through `ofLinearEquiv`.
+  change LinearMap.GeneralLinearGroup.ofLinearEquiv
+      (TensorProduct.congr g.toLinearEquiv.symm h.toLinearEquiv.symm) = _
+  rw [← TensorProduct.congr_symm]
+  exact LinearMap.GeneralLinearGroup.ofLinearEquiv_inv _
 
 end GeneralLinearGroup
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
-public import Mathlib.RingTheory.TensorProduct.Maps
+public import Mathlib.LinearAlgebra.TensorProduct.Map
 
 /-!
 # Tensor products in the general linear group
@@ -61,11 +61,7 @@ theorem tensorProduct_mul (g₁ g₂ : GeneralLinearGroup K V)
     tensorProduct (g₁ * g₂) (h₁ * h₂) =
       tensorProduct g₁ h₁ * tensorProduct g₂ h₂ := by
   apply Units.ext
-  -- Reduce equality of units to Mathlib's multiplicativity of `TensorProduct.map`.
-  change TensorProduct.map (↑(g₁ * g₂)) (↑(h₁ * h₂)) =
-    TensorProduct.map (g₁ : Module.End K V) (h₁ : Module.End K W) *
-      TensorProduct.map (g₂ : Module.End K V) (h₂ : Module.End K W)
-  simpa only [Units.val_mul] using TensorProduct.map_mul
+  simpa only [Units.val_mul, coe_tensorProduct] using TensorProduct.map_mul
     (g₁ : Module.End K V) (g₂ : Module.End K V)
     (h₁ : Module.End K W) (h₂ : Module.End K W)
 
@@ -74,9 +70,9 @@ theorem tensorProduct_mul (g₁ g₂ : GeneralLinearGroup K V)
 theorem tensorProduct_one :
     tensorProduct (1 : GeneralLinearGroup K V) (1 : GeneralLinearGroup K W) = 1 := by
   apply Units.ext
-  -- Reduce equality of units to Mathlib's identity law for `TensorProduct.map`.
-  change TensorProduct.map (1 : Module.End K V) (1 : Module.End K W) = 1
-  exact TensorProduct.map_one
+  simpa only [Units.val_one, coe_tensorProduct] using
+    (TensorProduct.map_one : TensorProduct.map (1 : Module.End K V)
+      (1 : Module.End K W) = 1)
 
 /-- Tensor products preserve inverses. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
@@ -68,6 +68,8 @@ theorem tensorProduct_mul (g₁ g₂ : GeneralLinearGroup K V)
 @[simp]
 theorem tensorProduct_one :
     tensorProduct (1 : GeneralLinearGroup K V) (1 : GeneralLinearGroup K W) = 1 := by
+  -- Expose the identity units as reflexive linear equivalences so the tensor congruence lemma
+  -- can rewrite them.
   change LinearMap.GeneralLinearGroup.ofLinearEquiv
       (TensorProduct.congr (LinearEquiv.refl K V) (LinearEquiv.refl K W)) = 1
   rw [TensorProduct.congr_refl_refl]

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
@@ -68,26 +68,18 @@ theorem tensorProduct_mul (g₁ g₂ : GeneralLinearGroup K V)
 @[simp]
 theorem tensorProduct_one :
     tensorProduct (1 : GeneralLinearGroup K V) (1 : GeneralLinearGroup K W) = 1 := by
-  -- Expose the identity units as reflexive linear equivalences so the tensor congruence lemma
-  -- can rewrite them.
-  change LinearMap.GeneralLinearGroup.ofLinearEquiv
-      (TensorProduct.congr (LinearEquiv.refl K V) (LinearEquiv.refl K W)) = 1
-  rw [TensorProduct.congr_refl_refl]
-  rfl
+  symm
+  apply mul_left_cancel (a := tensorProduct (1 : GeneralLinearGroup K V)
+    (1 : GeneralLinearGroup K W))
+  simpa only [one_mul, mul_one] using
+    (tensorProduct_mul (1 : GeneralLinearGroup K V) 1 (1 : GeneralLinearGroup K W) 1)
 
 /-- Tensor products preserve inverses. -/
 @[simp]
 theorem tensorProduct_inv (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
     tensorProduct g⁻¹ h⁻¹ = (tensorProduct g h)⁻¹ := by
-  unfold tensorProduct
-  rw [LinearMap.GeneralLinearGroup.toLinearEquiv_inv,
-    LinearMap.GeneralLinearGroup.toLinearEquiv_inv]
-  -- The tensor congruence lemma is stated with `LinearEquiv.symm`; expose that notation before
-  -- transporting the inverse through `ofLinearEquiv`.
-  change LinearMap.GeneralLinearGroup.ofLinearEquiv
-      (TensorProduct.congr g.toLinearEquiv.symm h.toLinearEquiv.symm) = _
-  rw [← TensorProduct.congr_symm]
-  exact LinearMap.GeneralLinearGroup.ofLinearEquiv_inv _
+  exact eq_inv_of_mul_eq_one_left <| by
+    rw [← tensorProduct_mul, inv_mul_cancel, inv_mul_cancel, tensorProduct_one]
 
 end GeneralLinearGroup
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
@@ -16,7 +16,7 @@ its compatibility with multiplication, inverses, and pure tensors.
 ## Main declarations
 
 * `TauCeti.GeneralLinearGroup.tensorProduct`: the tensor product of two linear automorphisms.
-* `TauCeti.GeneralLinearGroup.tensorProduct_apply_tmul`: its action on a pure tensor.
+* `TauCeti.GeneralLinearGroup.tensorProduct_tmul`: its action on a pure tensor.
 -/
 
 public section
@@ -48,7 +48,7 @@ theorem coe_tensorProduct (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K
 
 /-- A tensor-product automorphism acts factorwise on pure tensors. -/
 @[simp]
-theorem tensorProduct_apply_tmul (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W)
+theorem tensorProduct_tmul (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W)
     (v : V) (w : W) :
     (tensorProduct g h : Module.End K (V ⊗[K] W)) (v ⊗ₜ[K] w) =
       (g : Module.End K V) v ⊗ₜ[K] (h : Module.End K W) w :=

--- a/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
@@ -50,7 +50,7 @@ namespace GeneralLinearGroup
 
 open Module
 
-universe u v
+universe u v w x
 
 section Definitions
 
@@ -257,6 +257,31 @@ theorem commute_semisimplePart_unipotentPart (g : GeneralLinearGroup K V) :
 theorem semisimplePart_mul_unipotentPart (g : GeneralLinearGroup K V) :
     semisimplePart g * unipotentPart g = g :=
   (jordanDecomposition_spec g).2.2.2.symm
+
+/-- A binary operation preserving multiplication, semisimplicity, and unipotence preserves the
+multiplicative Jordan decomposition. -/
+theorem jordanDecomposition_map₂
+    {W : Type w} {U : Type x}
+    [AddCommGroup W] [Module K W] [FiniteDimensional K W]
+    [AddCommGroup U] [Module K U] [FiniteDimensional K U]
+    (F : GeneralLinearGroup K V → GeneralLinearGroup K W → GeneralLinearGroup K U)
+    (map_mul : ∀ a c b d, F (a * c) (b * d) = F a b * F c d)
+    (map_isSemisimple : ∀ {a b}, IsSemisimple a → IsSemisimple b → IsSemisimple (F a b))
+    (map_isUnipotent : ∀ {a b}, IsUnipotent a → IsUnipotent b → IsUnipotent (F a b))
+    (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
+    jordanDecomposition (F g h) =
+      (F (semisimplePart g) (semisimplePart h),
+        F (unipotentPart g) (unipotentPart h)) := by
+  symm
+  apply (eq_jordanDecomposition_iff (F g h) _ _).2
+  refine ⟨map_isSemisimple (isSemisimple_semisimplePart g)
+      (isSemisimple_semisimplePart h),
+    map_isUnipotent (isUnipotent_unipotentPart g) (isUnipotent_unipotentPart h), ?_, ?_⟩
+  · rw [commute_iff_eq, ← map_mul, ← map_mul]
+    exact congrArg₂ F (commute_semisimplePart_unipotentPart g).eq
+      (commute_semisimplePart_unipotentPart h).eq
+  · rw [← map_mul, semisimplePart_mul_unipotentPart,
+      semisimplePart_mul_unipotentPart]
 
 /-- The semisimple factor of an automorphism is a polynomial in that automorphism. -/
 theorem coe_semisimplePart_mem_adjoin (g : GeneralLinearGroup K V) :

--- a/TauCeti/LinearAlgebra/JordanChevalley/Prod.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Prod.lean
@@ -75,16 +75,8 @@ the decompositions of its two factors. -/
 theorem jordanDecomposition_prodMap (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
     jordanDecomposition (prodMap g h) =
       (prodMap (semisimplePart g) (semisimplePart h),
-        prodMap (unipotentPart g) (unipotentPart h)) := by
-  symm
-  apply (eq_jordanDecomposition_iff (prodMap g h) _ _).2
-  refine ⟨(isSemisimple_semisimplePart g).prodMap (isSemisimple_semisimplePart h),
-    (isUnipotent_unipotentPart g).prodMap (isUnipotent_unipotentPart h), ?_, ?_⟩
-  · rw [commute_iff_eq, ← prodMap_mul, ← prodMap_mul]
-    exact congrArg₂ prodMap (commute_semisimplePart_unipotentPart g).eq
-      (commute_semisimplePart_unipotentPart h).eq
-  · rw [← prodMap_mul, semisimplePart_mul_unipotentPart,
-      semisimplePart_mul_unipotentPart]
+        prodMap (unipotentPart g) (unipotentPart h)) :=
+  jordanDecomposition_map₂ prodMap prodMap_mul IsSemisimple.prodMap IsUnipotent.prodMap g h
 
 /-- The semisimple factor of a product-map automorphism is computed componentwise. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
@@ -73,7 +73,7 @@ theorem IsUnipotent.tensorProduct {g : GeneralLinearGroup K V}
     IsUnipotent (tensorProduct g h) := by
   rw [isUnipotent_def] at hg hh ⊢
   rw [coe_tensorProduct]
-  exact Module.End.isNilpotent_map_sub_one hg hh
+  exact hg.tensorProduct_map_sub_one hh
 
 end CommRing
 

--- a/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
@@ -8,7 +8,6 @@ public import TauCeti.LinearAlgebra.End.TensorProduct
 public import TauCeti.LinearAlgebra.GeneralLinearGroup.TensorProduct
 public import TauCeti.LinearAlgebra.JordanChevalley.Multiplicative
 public import Mathlib.RingTheory.TensorProduct.Finite
-import Mathlib.Tactic.NoncommRing
 
 /-!
 # Tensor products of multiplicative Jordan decompositions
@@ -58,22 +57,9 @@ variable [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W]
 theorem IsSemisimple.tensorProduct {g : GeneralLinearGroup K V}
     {h : GeneralLinearGroup K W} (hg : IsSemisimple g) (hh : IsSemisimple h) :
     IsSemisimple (tensorProduct g h) := by
-  rw [isSemisimple_def, coe_tensorProduct]
-  rw [← LinearMap.lTensor_comp_rTensor]
-  have hl : Module.End.IsSemisimple ((h : Module.End K W).lTensor V) :=
-    Module.End.IsSemisimple.lTensor (K := K) (V := V) (W := W)
-      ((isSemisimple_def h).mp hh)
-  have hr : Module.End.IsSemisimple ((g : Module.End K V).rTensor W) :=
-    Module.End.IsSemisimple.rTensor (K := K) (V := V) (W := W)
-      ((isSemisimple_def g).mp hg)
-  have hcomm : Commute ((h : Module.End K W).lTensor V)
-      ((g : Module.End K V).rTensor W) := by
-    rw [Commute]
-    exact (LinearMap.lTensor_comp_rTensor V (g : Module.End K V)
-      (h : Module.End K W)).trans
-        (LinearMap.rTensor_comp_lTensor V (g : Module.End K V)
-          (h : Module.End K W)).symm
-  exact Module.End.IsSemisimple.mul_of_commute hcomm hl hr
+  rw [isSemisimple_def] at hg hh ⊢
+  rw [coe_tensorProduct]
+  exact Module.End.IsSemisimple.tensorProduct hg hh
 
 end Semisimple
 
@@ -85,52 +71,9 @@ variable [CommRing K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W
 theorem IsUnipotent.tensorProduct {g : GeneralLinearGroup K V}
     {h : GeneralLinearGroup K W} (hg : IsUnipotent g) (hh : IsUnipotent h) :
     IsUnipotent (tensorProduct g h) := by
-  rw [isUnipotent_def, coe_tensorProduct]
-  let n : Module.End K (V ⊗[K] W) :=
-    (g : Module.End K V).rTensor W - 1
-  let m : Module.End K (V ⊗[K] W) :=
-    (h : Module.End K W).lTensor V - 1
-  have hn : _root_.IsNilpotent n := by
-    have hn' := ((isUnipotent_def g).mp hg).map (Module.End.rTensorAlgHom K V W)
-    -- Expose the algebra homomorphism as one-sided tensoring before normalizing subtraction.
-    change _root_.IsNilpotent (((g : Module.End K V) - 1).rTensor W) at hn'
-    rw [LinearMap.rTensor_sub] at hn'
-    change _root_.IsNilpotent ((g : Module.End K V).rTensor W -
-      (LinearMap.id : Module.End K V).rTensor W) at hn'
-    rw [LinearMap.rTensor_id] at hn'
-    exact hn'
-  have hm : _root_.IsNilpotent m := by
-    have hm' := ((isUnipotent_def h).mp hh).map (Module.End.lTensorAlgHom K W V)
-    -- Expose the algebra homomorphism as one-sided tensoring before normalizing subtraction.
-    change _root_.IsNilpotent (((h : Module.End K W) - 1).lTensor V) at hm'
-    rw [LinearMap.lTensor_sub] at hm'
-    change _root_.IsNilpotent ((h : Module.End K W).lTensor V -
-      (LinearMap.id : Module.End K W).lTensor V) at hm'
-    rw [LinearMap.lTensor_id] at hm'
-    exact hm'
-  have hab : Commute ((g : Module.End K V).rTensor W)
-      ((h : Module.End K W).lTensor V) := by
-    rw [Commute]
-    exact (LinearMap.rTensor_comp_lTensor V (g : Module.End K V)
-      (h : Module.End K W)).trans
-        (LinearMap.lTensor_comp_rTensor V (g : Module.End K V)
-          (h : Module.End K W)).symm
-  have hnm : Commute n m := by
-    dsimp only [n, m]
-    exact (hab.sub_right (Commute.one_right _)).sub_left (Commute.one_left _)
-  have hmul : _root_.IsNilpotent (n * m) := hnm.isNilpotent_mul_left hm
-  have hn_mul : Commute n (n * m) := (Commute.refl n).mul_right hnm
-  have hm_mul : Commute m (n * m) := hnm.symm.mul_right (Commute.refl m)
-  have hmap : TensorProduct.map (g : Module.End K V) (h : Module.End K W) - 1 =
-      n + m + n * m := by
-    rw [← LinearMap.lTensor_comp_rTensor]
-    -- Ring multiplication of endomorphisms is composition; expose it for `noncomm_ring`.
-    change (h : Module.End K W).lTensor V * (g : Module.End K V).rTensor W - 1 = _
-    dsimp only [n, m]
-    noncomm_ring [hab.eq]
-  rw [hmap]
-  exact Commute.isNilpotent_add (hn_mul.add_left hm_mul)
-    (Commute.isNilpotent_add hnm hn hm) hmul
+  rw [isUnipotent_def] at hg hh ⊢
+  rw [coe_tensorProduct]
+  exact Module.End.isNilpotent_map_sub_one hg hh
 
 end CommRing
 

--- a/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
@@ -88,17 +88,9 @@ theorem jordanDecomposition_tensorProduct
     (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
     jordanDecomposition (tensorProduct g h) =
       (tensorProduct (semisimplePart g) (semisimplePart h),
-        tensorProduct (unipotentPart g) (unipotentPart h)) := by
-  symm
-  apply (eq_jordanDecomposition_iff (tensorProduct g h) _ _).2
-  refine ⟨(isSemisimple_semisimplePart g).tensorProduct
-      (isSemisimple_semisimplePart h),
-    (isUnipotent_unipotentPart g).tensorProduct (isUnipotent_unipotentPart h), ?_, ?_⟩
-  · rw [commute_iff_eq, ← tensorProduct_mul, ← tensorProduct_mul]
-    rw [(commute_semisimplePart_unipotentPart g).eq,
-      (commute_semisimplePart_unipotentPart h).eq]
-  · rw [← tensorProduct_mul, semisimplePart_mul_unipotentPart,
-      semisimplePart_mul_unipotentPart]
+        tensorProduct (unipotentPart g) (unipotentPart h)) :=
+  jordanDecomposition_map₂ tensorProduct tensorProduct_mul IsSemisimple.tensorProduct
+    IsUnipotent.tensorProduct g h
 
 /-- The semisimple factor of a tensor product is the tensor product of the semisimple factors. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.LinearAlgebra.End.TensorProduct
 public import TauCeti.LinearAlgebra.GeneralLinearGroup.TensorProduct
-public import TauCeti.LinearAlgebra.JordanChevalley.Functoriality
+public import TauCeti.LinearAlgebra.JordanChevalley.Multiplicative
 public import Mathlib.RingTheory.TensorProduct.Finite
 import Mathlib.Tactic.NoncommRing
 
@@ -48,10 +48,10 @@ namespace GeneralLinearGroup
 universe u v w
 
 variable {K : Type u} {V : Type v} {W : Type w}
-variable [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
 
 section Semisimple
 
+variable [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
 variable [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W]
 
 /-- The tensor product of semisimple linear automorphisms is semisimple. -/
@@ -76,6 +76,10 @@ theorem IsSemisimple.tensorProduct {g : GeneralLinearGroup K V}
   exact Module.End.IsSemisimple.mul_of_commute hcomm hl hr
 
 end Semisimple
+
+section CommRing
+
+variable [CommRing K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
 
 /-- The tensor product of unipotent linear automorphisms is unipotent. -/
 theorem IsUnipotent.tensorProduct {g : GeneralLinearGroup K V}
@@ -117,18 +121,22 @@ theorem IsUnipotent.tensorProduct {g : GeneralLinearGroup K V}
   have hmul : _root_.IsNilpotent (n * m) := hnm.isNilpotent_mul_left hm
   have hn_mul : Commute n (n * m) := (Commute.refl n).mul_right hnm
   have hm_mul : Commute m (n * m) := hnm.symm.mul_right (Commute.refl m)
-  rw [show TensorProduct.map (g : Module.End K V) (h : Module.End K W) - 1 =
-      n + m + n * m by
+  have hmap : TensorProduct.map (g : Module.End K V) (h : Module.End K W) - 1 =
+      n + m + n * m := by
     rw [← LinearMap.lTensor_comp_rTensor]
     -- Ring multiplication of endomorphisms is composition; expose it for `noncomm_ring`.
     change (h : Module.End K W).lTensor V * (g : Module.End K V).rTensor W - 1 = _
     dsimp only [n, m]
-    noncomm_ring [hab.eq]]
+    noncomm_ring [hab.eq]
+  rw [hmap]
   exact Commute.isNilpotent_add (hn_mul.add_left hm_mul)
     (Commute.isNilpotent_add hnm hn hm) hmul
 
+end CommRing
+
 section PerfectField
 
+variable [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
 variable [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W]
 
 /-- The multiplicative Jordan decomposition of a tensor product is the tensor product of the
@@ -143,11 +151,7 @@ theorem jordanDecomposition_tensorProduct
   refine ⟨(isSemisimple_semisimplePart g).tensorProduct
       (isSemisimple_semisimplePart h),
     (isUnipotent_unipotentPart g).tensorProduct (isUnipotent_unipotentPart h), ?_, ?_⟩
-  · change tensorProduct (semisimplePart g) (semisimplePart h) *
-      tensorProduct (unipotentPart g) (unipotentPart h) =
-        tensorProduct (unipotentPart g) (unipotentPart h) *
-          tensorProduct (semisimplePart g) (semisimplePart h)
-    rw [← tensorProduct_mul, ← tensorProduct_mul]
+  · rw [commute_iff_eq, ← tensorProduct_mul, ← tensorProduct_mul]
     rw [(commute_semisimplePart_unipotentPart g).eq,
       (commute_semisimplePart_unipotentPart h).eq]
   · rw [← tensorProduct_mul, semisimplePart_mul_unipotentPart,

--- a/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.End.TensorProduct
+public import TauCeti.LinearAlgebra.GeneralLinearGroup.TensorProduct
+public import TauCeti.LinearAlgebra.JordanChevalley.Functoriality
+public import Mathlib.RingTheory.TensorProduct.Finite
+import Mathlib.Tactic.NoncommRing
+
+/-!
+# Tensor products of multiplicative Jordan decompositions
+
+Over a perfect field, the multiplicative Jordan decomposition of a tensor product of linear
+automorphisms is obtained by tensoring their semisimple factors and their unipotent factors.
+
+This is the tensor-product compatibility needed to assemble the componentwise Jordan factors of
+point actions on finite comodules into tensor automorphisms.  Together with the intertwining
+results in `TauCeti.LinearAlgebra.JordanChevalley.Functoriality`, it is the linear-algebraic bridge
+from Jordan decomposition in general linear groups to Jordan decomposition in an affine group via
+Tannakian reconstruction.
+
+## Main declarations
+
+* `TauCeti.GeneralLinearGroup.IsSemisimple.tensorProduct`: tensor products of semisimple
+  automorphisms are semisimple.
+* `TauCeti.GeneralLinearGroup.IsUnipotent.tensorProduct`: tensor products of unipotent
+  automorphisms are unipotent.
+* `TauCeti.GeneralLinearGroup.jordanDecomposition_tensorProduct`: the canonical decomposition is
+  factorwise on tensor products.
+
+## References
+
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+-/
+
+public section
+
+namespace TauCeti
+
+open LinearMap
+open scoped TensorProduct
+
+namespace GeneralLinearGroup
+
+universe u v w
+
+variable {K : Type u} {V : Type v} {W : Type w}
+variable [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W]
+
+section Semisimple
+
+variable [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W]
+
+/-- The tensor product of semisimple linear automorphisms is semisimple. -/
+theorem IsSemisimple.tensorProduct {g : GeneralLinearGroup K V}
+    {h : GeneralLinearGroup K W} (hg : IsSemisimple g) (hh : IsSemisimple h) :
+    IsSemisimple (tensorProduct g h) := by
+  rw [isSemisimple_def, coe_tensorProduct]
+  rw [← LinearMap.lTensor_comp_rTensor]
+  have hl : Module.End.IsSemisimple ((h : Module.End K W).lTensor V) :=
+    Module.End.IsSemisimple.lTensor (K := K) (V := V) (W := W)
+      ((isSemisimple_def h).mp hh)
+  have hr : Module.End.IsSemisimple ((g : Module.End K V).rTensor W) :=
+    Module.End.IsSemisimple.rTensor (K := K) (V := V) (W := W)
+      ((isSemisimple_def g).mp hg)
+  have hcomm : Commute ((h : Module.End K W).lTensor V)
+      ((g : Module.End K V).rTensor W) := by
+    rw [Commute]
+    exact (LinearMap.lTensor_comp_rTensor V (g : Module.End K V)
+      (h : Module.End K W)).trans
+        (LinearMap.rTensor_comp_lTensor V (g : Module.End K V)
+          (h : Module.End K W)).symm
+  exact Module.End.IsSemisimple.mul_of_commute hcomm hl hr
+
+end Semisimple
+
+/-- The tensor product of unipotent linear automorphisms is unipotent. -/
+theorem IsUnipotent.tensorProduct {g : GeneralLinearGroup K V}
+    {h : GeneralLinearGroup K W} (hg : IsUnipotent g) (hh : IsUnipotent h) :
+    IsUnipotent (tensorProduct g h) := by
+  rw [isUnipotent_def, coe_tensorProduct]
+  let n : Module.End K (V ⊗[K] W) :=
+    (g : Module.End K V).rTensor W - 1
+  let m : Module.End K (V ⊗[K] W) :=
+    (h : Module.End K W).lTensor V - 1
+  have hn : _root_.IsNilpotent n := by
+    have hn' := ((isUnipotent_def g).mp hg).map (Module.End.rTensorAlgHom K V W)
+    -- Expose the algebra homomorphism as one-sided tensoring before normalizing subtraction.
+    change _root_.IsNilpotent (((g : Module.End K V) - 1).rTensor W) at hn'
+    rw [LinearMap.rTensor_sub] at hn'
+    change _root_.IsNilpotent ((g : Module.End K V).rTensor W -
+      (LinearMap.id : Module.End K V).rTensor W) at hn'
+    rw [LinearMap.rTensor_id] at hn'
+    exact hn'
+  have hm : _root_.IsNilpotent m := by
+    have hm' := ((isUnipotent_def h).mp hh).map (Module.End.lTensorAlgHom K W V)
+    -- Expose the algebra homomorphism as one-sided tensoring before normalizing subtraction.
+    change _root_.IsNilpotent (((h : Module.End K W) - 1).lTensor V) at hm'
+    rw [LinearMap.lTensor_sub] at hm'
+    change _root_.IsNilpotent ((h : Module.End K W).lTensor V -
+      (LinearMap.id : Module.End K W).lTensor V) at hm'
+    rw [LinearMap.lTensor_id] at hm'
+    exact hm'
+  have hab : Commute ((g : Module.End K V).rTensor W)
+      ((h : Module.End K W).lTensor V) := by
+    rw [Commute]
+    exact (LinearMap.rTensor_comp_lTensor V (g : Module.End K V)
+      (h : Module.End K W)).trans
+        (LinearMap.lTensor_comp_rTensor V (g : Module.End K V)
+          (h : Module.End K W)).symm
+  have hnm : Commute n m := by
+    dsimp only [n, m]
+    exact (hab.sub_right (Commute.one_right _)).sub_left (Commute.one_left _)
+  have hmul : _root_.IsNilpotent (n * m) := hnm.isNilpotent_mul_left hm
+  have hn_mul : Commute n (n * m) := (Commute.refl n).mul_right hnm
+  have hm_mul : Commute m (n * m) := hnm.symm.mul_right (Commute.refl m)
+  rw [show TensorProduct.map (g : Module.End K V) (h : Module.End K W) - 1 =
+      n + m + n * m by
+    rw [← LinearMap.lTensor_comp_rTensor]
+    -- Ring multiplication of endomorphisms is composition; expose it for `noncomm_ring`.
+    change (h : Module.End K W).lTensor V * (g : Module.End K V).rTensor W - 1 = _
+    dsimp only [n, m]
+    noncomm_ring [hab.eq]]
+  exact Commute.isNilpotent_add (hn_mul.add_left hm_mul)
+    (Commute.isNilpotent_add hnm hn hm) hmul
+
+section PerfectField
+
+variable [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W]
+
+/-- The multiplicative Jordan decomposition of a tensor product is the tensor product of the
+corresponding factors. -/
+theorem jordanDecomposition_tensorProduct
+    (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
+    jordanDecomposition (tensorProduct g h) =
+      (tensorProduct (semisimplePart g) (semisimplePart h),
+        tensorProduct (unipotentPart g) (unipotentPart h)) := by
+  symm
+  apply (eq_jordanDecomposition_iff (tensorProduct g h) _ _).2
+  refine ⟨(isSemisimple_semisimplePart g).tensorProduct
+      (isSemisimple_semisimplePart h),
+    (isUnipotent_unipotentPart g).tensorProduct (isUnipotent_unipotentPart h), ?_, ?_⟩
+  · change tensorProduct (semisimplePart g) (semisimplePart h) *
+      tensorProduct (unipotentPart g) (unipotentPart h) =
+        tensorProduct (unipotentPart g) (unipotentPart h) *
+          tensorProduct (semisimplePart g) (semisimplePart h)
+    rw [← tensorProduct_mul, ← tensorProduct_mul]
+    rw [(commute_semisimplePart_unipotentPart g).eq,
+      (commute_semisimplePart_unipotentPart h).eq]
+  · rw [← tensorProduct_mul, semisimplePart_mul_unipotentPart,
+      semisimplePart_mul_unipotentPart]
+
+/-- The semisimple factor of a tensor product is the tensor product of the semisimple factors. -/
+@[simp]
+theorem semisimplePart_tensorProduct
+    (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
+    semisimplePart (tensorProduct g h) =
+      tensorProduct (semisimplePart g) (semisimplePart h) :=
+  (semisimplePart_def (tensorProduct g h)).trans <|
+    congrArg Prod.fst (jordanDecomposition_tensorProduct g h)
+
+/-- The unipotent factor of a tensor product is the tensor product of the unipotent factors. -/
+@[simp]
+theorem unipotentPart_tensorProduct
+    (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
+    unipotentPart (tensorProduct g h) =
+      tensorProduct (unipotentPart g) (unipotentPart h) :=
+  (unipotentPart_def (tensorProduct g h)).trans <|
+    congrArg Prod.snd (jordanDecomposition_tensorProduct g h)
+
+end PerfectField
+
+end GeneralLinearGroup
+
+end TauCeti


### PR DESCRIPTION
This PR makes the multiplicative Jordan–Chevalley decomposition compatible with tensor products: tensor products of semisimple automorphisms are semisimple, tensor products of unipotent automorphisms are unipotent, and the canonical semisimple and unipotent factors of `g ⊗ h` are respectively the tensor products of the factors of `g` and `h`.

It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 milestone “Jordan decomposition of elements into semisimple and unipotent parts (geometric, over `k̄`), functorial under representations.” The exact dependency edge is that the landed intertwiner theorem makes the componentwise Jordan factors of point actions natural in a finite comodule, while this PR makes those factors tensor-compatible; the Layer 1 Tannakian reconstruction now in flight can therefore recover them as points of the original affine group rather than merely elements of ambient general linear groups. This is the most effective distinct current step because it connects the completed linear Jordan theory directly to the existing tensor-automorphism model without overlapping the open reconstruction PRs.

After this PR, Layer 4 still needs to use Tannakian reconstruction to lift these componentwise tensor automorphisms to semisimple and unipotent group points, prove their geometric and faithful-representation characterizations, and package functoriality for algebraic-group homomorphisms.

Add `TauCeti/LinearAlgebra/End/TensorProduct.lean` (130 lines), proving that one-sided tensoring preserves semisimplicity by identifying the tensor product with a direct sum of copies through a basis. Add `TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean` (91 lines), packaging tensor products of linear automorphisms with their multiplication, identity, inverse, and pure-tensor laws. Add `TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean` (178 lines), proving the semisimple, unipotent, and canonical-factor formulas, for 399 inserted lines total.

No Mathlib infrastructure is vendored. The proofs directly reuse Mathlib's tensor-product basis equivalences, semisimple-module closure under direct sums, `Module.End.IsSemisimple.mul_of_commute`, one-sided tensor algebra homomorphisms, commuting-nilpotent sum and product lemmas, and the existing additive Jordan–Chevalley decomposition; the mathematical organization follows T. A. Springer, *Linear Algebraic Groups*, §2.4, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"jordan-decomposition-tensor-product"}-->

🤖 Prepared with Codex
