### PR TITLE
feat: prove Tannakian local multiplicativity

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
@@ -9,10 +9,11 @@ public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.Monoidal
 /-!
 # Local functionals from tensor automorphisms
 
-Let `H` be a Hopf algebra over a field `k`, and let `A` be a commutative `k`-algebra. A tensor
-automorphism `η` of scalar extension on the finite-dimensional `H`-comodules acts, in particular,
-on every finite subcomodule `N` of the regular comodule `H`. Applying that component to
-`1 ⊗ n` and then applying the counit to the `N`-factor gives a linear functional
+Let `H` be a bialgebra over a commutative semiring `k`, and let `A` be a commutative
+`k`-algebra. A tensor automorphism `η` of scalar extension on the finitely generated
+`H`-comodules acts, in particular, on every finite subcomodule `N` of the regular comodule `H`.
+Applying that component to `1 ⊗ n` and then applying the counit to the `N`-factor gives a linear
+functional
 
 ```text
 g_{η,N} : N → A.
@@ -64,7 +65,7 @@ end FiniteRegularObject
 section CounitEvaluation
 
 variable (k : Type u) [CommSemiring k]
-variable (H : Type u) [Semiring H] [Bialgebra k H]
+variable (H : Type u) [AddCommMonoid H] [Module k H] [Coalgebra k H]
 variable (A : Type u) [CommSemiring A] [Algebra k A]
 
 /-- Evaluation after scalar extension by applying the counit on a regular subcomodule. -/
@@ -84,8 +85,8 @@ end CounitEvaluation
 
 section LocalFunctional
 
-variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
-  [CommRing A] [Algebra k A]
+variable (k H A : Type u) [CommSemiring k] [Semiring H] [Bialgebra k H]
+  [Module.Flat k H] [CommSemiring A] [Algebra k A]
 
 /-- Inclusion of finite regular subcomodules as a morphism in the finite comodule category. -/
 noncomputable def regularInclusion
@@ -194,6 +195,13 @@ theorem localFunctional_eq_comp_inclusion
         rfl
   exact (hcounit _).symm
 
+end LocalFunctional
+
+section Point
+
+variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
+  [CommRing A] [Algebra k A]
+
 /-- For a tensor automorphism induced by an algebra-valued point `g`, the local functional is
 the restriction of `g` to the chosen finite subcomodule of the regular comodule. -/
 @[simp]
@@ -214,6 +222,6 @@ theorem localFunctional_fgPointTensorIso
   simpa only [φ, one_mul, hcoeff] using
     Comodule.baseChangeEvaluation_endOfPoint_tmul g.ofConv (1 : A) (1 : A) φ n
 
-end LocalFunctional
+end Point
 
 end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
@@ -47,7 +47,7 @@ open scoped TensorProduct
 
 namespace TauCeti.Tannaka
 
-universe u
+universe u v w
 
 section FiniteRegularObject
 
@@ -65,8 +65,8 @@ end FiniteRegularObject
 section CounitEvaluation
 
 variable (k : Type u) [CommSemiring k]
-variable (H : Type u) [AddCommMonoid H] [Module k H] [Coalgebra k H]
-variable (A : Type u) [CommSemiring A] [Algebra k A]
+variable (H : Type v) [AddCommMonoid H] [Module k H] [Coalgebra k H]
+variable (A : Type w) [CommSemiring A] [Algebra k A]
 
 /-- Evaluation after scalar extension by applying the counit on a regular subcomodule. -/
 noncomputable def counitEvaluation (N : Subcomodule k H H) : A ⊗[k] N →ₗ[A] A :=

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
@@ -25,10 +25,8 @@ glue them; tensor and unit compatibility will supply the algebra-map laws.
 
 ## Main declarations
 
-* `TauCeti.Tannaka.scalarExtensionComponent`: a tensor-automorphism component on an arbitrary
-  finite comodule, transported to an explicit scalar-extension tensor product.
-* `TauCeti.Tannaka.scalarExtensionComponent_tensor`: the elementwise tensor law for those
-  transported components.
+* `TauCeti.Tannaka.counitEvaluation`: counit evaluation after scalar extension on a regular
+  subcomodule.
 * `TauCeti.Tannaka.localFunctional`: the functional extracted from one finite subcomodule.
 * `TauCeti.Tannaka.localFunctional_eq_comp_inclusion`: compatibility under inclusion.
 * `TauCeti.Tannaka.localFunctional_fgPointTensorIso`: a point recovers its restriction to every
@@ -37,6 +35,8 @@ glue them; tensor and unit compatibility will supply the algebra-map laws.
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), §9.4.
+* `Mathlib/RepresentationTheory/Tannaka.lean`: the naturality and monoidal-transport pattern is
+  adapted here from the proof of `map_mul_toRightFDRepComp`.
 -/
 
 public section
@@ -48,8 +48,9 @@ namespace TauCeti.Tannaka
 
 universe u
 
-variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
-  [CommRing A] [Algebra k A]
+section FiniteRegularObject
+
+variable (k H : Type u) [CommSemiring k] [Semiring H] [Bialgebra k H] [Module.Flat k H]
 
 /-- A finite subcomodule of the regular comodule, bundled as an object of the finite comodule
 category. -/
@@ -57,6 +58,13 @@ noncomputable abbrev finiteRegularObject
     (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H)) :
     FGComoduleCat.{u, u, u} k H :=
   ⟨ComoduleCat.of k H N.1, Subcomodule.mem_finiteSubcomodules.mp N.2⟩
+
+end FiniteRegularObject
+
+section LocalFunctional
+
+variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
+  [CommRing A] [Algebra k A]
 
 /-- Inclusion of finite regular subcomodules as a morphism in the finite comodule category. -/
 noncomputable def regularInclusion
@@ -111,169 +119,18 @@ theorem regularInclusion_toLinearMap
   unfold regularInclusion
   rfl
 
-/-- The component of a tensor automorphism, transported from the object chosen by the
-scalar-extension functor to the explicit tensor product `A ⊗[k] M`. -/
-noncomputable def scalarExtensionComponent
-    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
-    (M : FGComoduleCat.{u, u, u} k H) :
-    A ⊗[k] M →ₗ[A] A ⊗[k] M := by
-  exact (eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
-      M).symm ≫
-    η.hom.hom.app M ≫
-      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
-        M)).hom
+/-- Evaluation after scalar extension by applying the counit on a regular subcomodule. -/
+noncomputable def counitEvaluation (N : Subcomodule k H H) : A ⊗[k] N →ₗ[A] A :=
+  TauCeti.Module.Dual.baseChangeEvaluation (R := k) (M := N) (A := A)
+    (1 ⊗ₜ[k] ((Coalgebra.counit (R := k) (A := H)).comp
+      (SMulMemClass.subtype N)))
 
-/-- Naturality of the explicitly transported components of a tensor automorphism. -/
-theorem scalarExtensionComponent_natural
-    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
-    {M N : FGComoduleCat.{u, u, u} k H} (f : M ⟶ N) :
-    f.hom.toLinearMap.baseChange A ∘ₗ scalarExtensionComponent k H A η M =
-      scalarExtensionComponent k H A η N ∘ₗ f.hom.toLinearMap.baseChange A := by
-  let aM : (FGComoduleCat.scalarExtensionFunctor k H A).obj M ⟶
-      (FGComoduleCat.scalarExtensionFunctor k H A).obj M :=
-    η.hom.hom.app M
-  let aN : (FGComoduleCat.scalarExtensionFunctor k H A).obj N ⟶
-      (FGComoduleCat.scalarExtensionFunctor k H A).obj N :=
-    η.hom.hom.app N
-  have hnat :
-      (FGComoduleCat.scalarExtensionFunctor k H A).map f ≫ aN =
-        aM ≫ (FGComoduleCat.scalarExtensionFunctor k H A).map f :=
-    η.hom.hom.naturality f
-  let hM := FGComoduleCat.scalarExtensionFunctor_obj k H A M
-  let hN := FGComoduleCat.scalarExtensionFunctor_obj k H A N
-  let iM := eqToIso hM
-  let iN := eqToIso hN
-  let bmap := SemimoduleCat.ofHom (f.hom.toLinearMap.baseChange A)
-  have hfmap :
-      (FGComoduleCat.scalarExtensionFunctor k H A).map f =
-        iM.hom ≫ bmap ≫ iN.inv := by
-    simpa only [hM, hN, iM, iN, bmap, eqToIso.hom, eqToIso.inv] using
-      FGComoduleCat.scalarExtensionFunctor_map k H A f
-  rw [hfmap] at hnat
-  have hcat :
-      (iM.inv ≫ aM ≫ iM.hom) ≫ bmap =
-        bmap ≫ (iN.inv ≫ aN ≫ iN.hom) := by
-    rw [← cancel_epi iM.hom]
-    rw [← cancel_mono iN.inv]
-    slice_lhs 1 2 => rw [iM.hom_inv_id]
-    slice_rhs 4 6 => rw [iN.hom_inv_id, Category.comp_id]
-    simpa only [Category.id_comp, Category.comp_id, Category.assoc] using hnat.symm
-  change bmap.hom ∘ₗ
-      (iM.inv ≫ aM ≫ iM.hom).hom =
-    (iN.inv ≫ aN ≫ iN.hom).hom ∘ₗ bmap.hom
-  simpa only [SemimoduleCat.hom_comp] using congrArg SemimoduleCat.Hom.hom hcat
-
-/-- Tensor compatibility of the explicitly transported components of a tensor automorphism. -/
-theorem scalarExtensionComponent_tensor
-    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
-    (M N : FGComoduleCat.{u, u, u} k H) (x : A ⊗[k] M) (y : A ⊗[k] N) :
-    scalarExtensionComponent k H A η (M ⊗ N : FGComoduleCat k H)
-        ((TensorProduct.AlgebraTensorModule.distribBaseChange k A M N).symm
-          (x ⊗ₜ[A] y)) =
-      (TensorProduct.AlgebraTensorModule.distribBaseChange k A M N).symm
-        (scalarExtensionComponent k H A η M x ⊗ₜ[A]
-          scalarExtensionComponent k H A η N y) := by
-  let aM : (FGComoduleCat.scalarExtensionFunctor k H A).obj M ⟶
-      (FGComoduleCat.scalarExtensionFunctor k H A).obj M :=
-    η.hom.hom.app M
-  let aN : (FGComoduleCat.scalarExtensionFunctor k H A).obj N ⟶
-      (FGComoduleCat.scalarExtensionFunctor k H A).obj N :=
-    η.hom.hom.app N
-  let aMN : (FGComoduleCat.scalarExtensionFunctor k H A).obj
-      (M ⊗ N : FGComoduleCat k H) ⟶
-      (FGComoduleCat.scalarExtensionFunctor k H A).obj
-        (M ⊗ N : FGComoduleCat k H) :=
-    η.hom.hom.app (M ⊗ N : FGComoduleCat k H)
-  have htensor := NatTrans.IsMonoidal.tensor (τ := η.hom.hom) M N
-  change Functor.LaxMonoidal.μ (FGComoduleCat.scalarExtensionFunctor k H A) M N ≫ aMN =
-    (aM ⊗ₘ aN) ≫
-      Functor.LaxMonoidal.μ (FGComoduleCat.scalarExtensionFunctor k H A) M N at htensor
-  rw [FGComoduleCat.scalarExtensionFunctor_μ] at htensor
-  let iM := eqToIso (FGComoduleCat.scalarExtensionFunctor_obj k H A M)
-  let iN := eqToIso (FGComoduleCat.scalarExtensionFunctor_obj k H A N)
-  let iMN := eqToIso (FGComoduleCat.scalarExtensionFunctor_obj k H A
-    (M ⊗ N : FGComoduleCat k H))
-  let d :
-      (SemimoduleCat.of A (A ⊗[k] M) ⊗ SemimoduleCat.of A (A ⊗[k] N)) ⟶
-        SemimoduleCat.of A (A ⊗[k] (M ⊗[k] N)) :=
-    SemimoduleCat.ofHom
-      (TensorProduct.AlgebraTensorModule.distribBaseChange k A M N).symm.toLinearMap
-  have hmon :
-      (((iM.hom ⊗ₘ iN.hom) ≫ d ≫ iMN.inv) ≫ aMN) =
-        (aM ⊗ₘ aN) ≫ ((iM.hom ⊗ₘ iN.hom) ≫ d ≫ iMN.inv) := by
-    simpa only [iM, iN, iMN, d, eqToIso.hom, eqToIso.inv] using htensor
-  have he :
-      (iM.hom ⊗ₘ iN.hom) ≫
-          ((iM.inv ≫ aM ≫ iM.hom) ⊗ₘ (iN.inv ≫ aN ≫ iN.hom)) =
-        ((aM ≫ iM.hom) ⊗ₘ (aN ≫ iN.hom)) := by
-    rw [MonoidalCategory.tensorHom_comp_tensorHom]
-    simp only [Iso.hom_inv_id_assoc]
-  have he' :
-      (aM ⊗ₘ aN) ≫ (iM.hom ⊗ₘ iN.hom) =
-        ((aM ≫ iM.hom) ⊗ₘ (aN ≫ iN.hom)) :=
-    MonoidalCategory.tensorHom_comp_tensorHom _ _ _ _
-  have hcat :
-      d ≫ (iMN.inv ≫ aMN ≫ iMN.hom) =
-        ((iM.inv ≫ aM ≫ iM.hom) ⊗ₘ (iN.inv ≫ aN ≫ iN.hom)) ≫ d := by
-    rw [← cancel_epi (iM.hom ⊗ₘ iN.hom)]
-    rw [← cancel_mono iMN.inv]
-    simp only [Category.assoc, Iso.hom_inv_id, Category.comp_id]
-    conv_rhs => rw [← Category.assoc]
-    rw [he, ← he']
-    simpa only [Category.assoc] using hmon
-  have hlin := congrArg SemimoduleCat.Hom.hom hcat
-  change (iMN.inv ≫ aMN ≫ iMN.hom).hom.comp d.hom =
-      d.hom.comp
-        ((iM.inv ≫ aM ≫ iM.hom) ⊗ₘ (iN.inv ≫ aN ≫ iN.hom)).hom at hlin
-  rw [SemimoduleCat.hom_tensorHom] at hlin
-  have happ := LinearMap.congr_fun hlin (x ⊗ₜ[A] y)
-  change (iMN.inv ≫ aMN ≫ iMN.hom).hom (d.hom (x ⊗ₜ[A] y)) =
-      d.hom (TensorProduct.map
-        (iM.inv ≫ aM ≫ iM.hom).hom
-        (iN.inv ≫ aN ≫ iN.hom).hom (x ⊗ₜ[A] y)) at happ
-  rw [TensorProduct.map_tmul] at happ
-  change scalarExtensionComponent k H A η (M ⊗ N : FGComoduleCat k H)
-      ((TensorProduct.AlgebraTensorModule.distribBaseChange k A M N).symm
-        (x ⊗ₜ[A] y)) =
-    (TensorProduct.AlgebraTensorModule.distribBaseChange k A M N).symm
-      (scalarExtensionComponent k H A η M x ⊗ₜ[A]
-        scalarExtensionComponent k H A η N y) at happ
-  exact happ
-
-/-- The component of a tensor automorphism on a finite regular subcomodule, transported from the
-object chosen by the scalar-extension functor to the explicit tensor product `A ⊗[k] N`. -/
-@[expose] noncomputable def finiteRegularComponent
-    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
-    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H)) :
-    A ⊗[k] N.1 →ₗ[A] A ⊗[k] N.1 :=
-  scalarExtensionComponent k H A η (finiteRegularObject k H N)
-
-/-- Evaluation formula for the transported component of a tensor automorphism on a finite
-regular subcomodule. -/
-theorem finiteRegularComponent_apply
-    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
-    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
-    (x : A ⊗[k] N.1) :
-    finiteRegularComponent k H A η N x =
-      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
-          (finiteRegularObject k H N))
-        (η.hom.hom.app (finiteRegularObject k H N)
-          (eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
-            (finiteRegularObject k H N)).symm x)) := by
-  unfold finiteRegularComponent
-  rfl
-
-/-- Naturality of a tensor automorphism on an inclusion of finite regular subcomodules. -/
-theorem finiteRegularComponent_natural
-    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
-    (N Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
-    (hNQ : N.1 ≤ Q.1) :
-    (Submodule.inclusion hNQ).baseChange A ∘ₗ finiteRegularComponent k H A η N =
-      finiteRegularComponent k H A η Q ∘ₗ (Submodule.inclusion hNQ).baseChange A := by
-  let _ : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
-  let _ : Module.Finite k Q.1 := Subcomodule.mem_finiteSubcomodules.mp Q.2
-  simpa only [finiteRegularComponent, regularInclusion_toLinearMap] using
-    scalarExtensionComponent_natural k H A η (regularInclusion k H hNQ)
+/-- Counit evaluation on a pure scalar-extension tensor. -/
+@[simp]
+theorem counitEvaluation_tmul (N : Subcomodule k H H) (a : A) (n : N) :
+    counitEvaluation k H A N (a ⊗ₜ[k] n) =
+      a * algebraMap k A (Coalgebra.counit (R := k) (A := H) (n : H)) := by
+  simp [counitEvaluation]
 
 /-- The linear functional on a finite subcomodule of the regular comodule extracted from a
 tensor automorphism. It applies the automorphism to `1 ⊗ n` and then evaluates the regular
@@ -283,10 +140,9 @@ noncomputable def localFunctional
     (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H)) :
     N.1 →ₗ[k] A := by
   let _ : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
-  exact ((TauCeti.Module.Dual.baseChangeEvaluation (R := k) (M := N.1) (A := A)
-    (1 ⊗ₜ[k] ((Coalgebra.counit (R := k) (A := H)).comp
-      (SMulMemClass.subtype N.1)))).restrictScalars k).comp <|
-    ((finiteRegularComponent k H A η N).restrictScalars k).comp
+  exact ((counitEvaluation k H A N.1).restrictScalars k).comp <|
+    ((scalarExtensionComponent k H A η
+      (finiteRegularObject k H N)).restrictScalars k).comp
       (TensorProduct.mk k A N.1 (1 : A))
 
 /-- Evaluation formula for the functional extracted from a finite regular subcomodule. -/
@@ -295,10 +151,8 @@ theorem localFunctional_apply
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
     (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H)) (n : N.1) :
     localFunctional k H A η N n =
-      TauCeti.Module.Dual.baseChangeEvaluation (R := k) (M := N.1) (A := A)
-        (1 ⊗ₜ[k] ((Coalgebra.counit (R := k) (A := H)).comp
-          (SMulMemClass.subtype N.1)))
-        (finiteRegularComponent k H A η N (1 ⊗ₜ[k] n)) :=
+      counitEvaluation k H A N.1
+        (scalarExtensionComponent k H A η (finiteRegularObject k H N) (1 ⊗ₜ[k] n)) :=
   by
     unfold localFunctional
     rfl
@@ -314,42 +168,23 @@ theorem localFunctional_eq_comp_inclusion
   apply LinearMap.ext
   intro n
   rw [LinearMap.comp_apply, localFunctional_apply, localFunctional_apply]
-  have happ := LinearMap.congr_fun (finiteRegularComponent_natural k H A η N Q hNQ)
-    (1 ⊗ₜ[k] n)
-  simp only [LinearMap.comp_apply, LinearMap.baseChange_tmul] at happ
+  have happ := LinearMap.congr_fun
+    (scalarExtensionComponent_natural k H A η (regularInclusion k H hNQ)) (1 ⊗ₜ[k] n)
+  simp only [regularInclusion_toLinearMap, LinearMap.comp_apply,
+    LinearMap.baseChange_tmul] at happ
   rw [← happ]
-  induction finiteRegularComponent k H A η N (1 ⊗ₜ[k] n) using
-    TensorProduct.induction_on with
-  | zero => simp
-  | add x y hx hy => simp [hx, hy]
-  | tmul a m =>
-      simp only [LinearMap.baseChange_tmul,
-        TauCeti.Module.Dual.baseChangeEvaluation_tmul, LinearMap.comp_apply,
-        SMulMemClass.subtype_apply, one_mul]
-      rfl
-
-/-- The finite regular component of the tensor automorphism induced by a point is the usual
-point action on that finite subcomodule. -/
-@[simp]
-theorem finiteRegularComponent_fgPointTensorIso
-    (g : WithConv (H →ₐ[k] A))
-    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H)) :
-    finiteRegularComponent k H A (fgPointTensorIso k H A g) N =
-      (Comodule.pointsAction N.1 g).toLinearMap := by
-  let _ : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
-  apply LinearMap.ext
-  intro x
-  unfold finiteRegularComponent scalarExtensionComponent
-  rw [fgPointTensorIso_hom_hom, fgPointNatIsoHom_hom_app]
-  let hN := FGComoduleCat.scalarExtensionFunctor_obj k H A
-    (finiteRegularObject k H N)
-  -- After rewriting the point-induced component, the only remaining wrappers are the
-  -- transports along `hN`.  There is no carrier-level rewrite theorem for this object
-  -- equality; displaying the four `eqToHom`s lets the category simp lemmas cancel them.
-  change (eqToHom hN.symm ≫
-      (eqToHom hN ≫ (Comodule.pointsAction N.1 g).toModuleIsoₛ.hom ≫
-        eqToHom hN.symm) ≫ eqToHom hN) x = _
-  simp
+  have hcounit (x : A ⊗[k] N.1) :
+      counitEvaluation k H A Q.1 ((Submodule.inclusion hNQ).baseChange A x) =
+        counitEvaluation k H A N.1 x := by
+    induction x using TensorProduct.induction_on with
+    | zero => simp
+    | add x y hx hy => simp [hx, hy]
+    | tmul a m =>
+        rw [LinearMap.baseChange_tmul,
+          counitEvaluation_tmul k H A Q.1 a (Submodule.inclusion hNQ m),
+          counitEvaluation_tmul k H A N.1 a m]
+        rfl
+  exact (hcounit _).symm
 
 /-- For a tensor automorphism induced by an algebra-valued point `g`, the local functional is
 the restriction of `g` to the chosen finite subcomodule of the regular comodule. -/
@@ -360,8 +195,9 @@ theorem localFunctional_fgPointTensorIso
     localFunctional k H A (fgPointTensorIso k H A g) N n = g.ofConv n := by
   rw [← fgPointTensorIsoHom_apply]
   rw [localFunctional_apply, fgPointTensorIsoHom_apply,
-    finiteRegularComponent_fgPointTensorIso]
+    scalarExtensionComponent_fgPointTensorIso]
   rw [Comodule.pointsAction_toLinearMap]
+  unfold counitEvaluation
   let φ : Module.Dual k N.1 :=
     (Coalgebra.counit (R := k) (A := H)).comp (SMulMemClass.subtype N.1)
   have hcoeff : Comodule.matrixCoefficient (R := k) (C := H) φ n = (n : H) := by
@@ -369,5 +205,7 @@ theorem localFunctional_fgPointTensorIso
       (R := k) (C := H) N.1 n
   simpa only [φ, one_mul, hcoeff] using
     Comodule.baseChangeEvaluation_endOfPoint_tmul g.ofConv (1 : A) (1 : A) φ n
+
+end LocalFunctional
 
 end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
@@ -61,6 +61,27 @@ noncomputable abbrev finiteRegularObject
 
 end FiniteRegularObject
 
+section CounitEvaluation
+
+variable (k : Type u) [CommSemiring k]
+variable (H : Type u) [Semiring H] [Bialgebra k H]
+variable (A : Type u) [CommSemiring A] [Algebra k A]
+
+/-- Evaluation after scalar extension by applying the counit on a regular subcomodule. -/
+noncomputable def counitEvaluation (N : Subcomodule k H H) : A ⊗[k] N →ₗ[A] A :=
+  TauCeti.Module.Dual.baseChangeEvaluation (R := k) (M := N) (A := A)
+    (1 ⊗ₜ[k] ((Coalgebra.counit (R := k) (A := H)).comp
+      (SMulMemClass.subtype N)))
+
+/-- Counit evaluation on a pure scalar-extension tensor. -/
+@[simp]
+theorem counitEvaluation_tmul (N : Subcomodule k H H) (a : A) (n : N) :
+    counitEvaluation k H A N (a ⊗ₜ[k] n) =
+      a * algebraMap k A (Coalgebra.counit (R := k) (A := H) (n : H)) := by
+  simp [counitEvaluation]
+
+end CounitEvaluation
+
 section LocalFunctional
 
 variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
@@ -118,19 +139,6 @@ theorem regularInclusion_toLinearMap
     (regularInclusion k H hNQ).hom.toLinearMap = Submodule.inclusion hNQ := by
   unfold regularInclusion
   rfl
-
-/-- Evaluation after scalar extension by applying the counit on a regular subcomodule. -/
-noncomputable def counitEvaluation (N : Subcomodule k H H) : A ⊗[k] N →ₗ[A] A :=
-  TauCeti.Module.Dual.baseChangeEvaluation (R := k) (M := N) (A := A)
-    (1 ⊗ₜ[k] ((Coalgebra.counit (R := k) (A := H)).comp
-      (SMulMemClass.subtype N)))
-
-/-- Counit evaluation on a pure scalar-extension tensor. -/
-@[simp]
-theorem counitEvaluation_tmul (N : Subcomodule k H H) (a : A) (n : N) :
-    counitEvaluation k H A N (a ⊗ₜ[k] n) =
-      a * algebraMap k A (Coalgebra.counit (R := k) (A := H) (n : H)) := by
-  simp [counitEvaluation]
 
 /-- The linear functional on a finite subcomodule of the regular comodule extracted from a
 tensor automorphism. It applies the automorphism to `1 ⊗ n` and then evaluates the regular

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
@@ -25,6 +25,10 @@ glue them; tensor and unit compatibility will supply the algebra-map laws.
 
 ## Main declarations
 
+* `TauCeti.Tannaka.scalarExtensionComponent`: a tensor-automorphism component on an arbitrary
+  finite comodule, transported to an explicit scalar-extension tensor product.
+* `TauCeti.Tannaka.scalarExtensionComponent_tensor`: the elementwise tensor law for those
+  transported components.
 * `TauCeti.Tannaka.localFunctional`: the functional extracted from one finite subcomodule.
 * `TauCeti.Tannaka.localFunctional_eq_comp_inclusion`: compatibility under inclusion.
 * `TauCeti.Tannaka.localFunctional_fgPointTensorIso`: a point recovers its restriction to every
@@ -37,7 +41,7 @@ glue them; tensor and unit compatibility will supply the algebra-map laws.
 
 public section
 
-open CategoryTheory
+open CategoryTheory MonoidalCategory
 open scoped TensorProduct
 
 namespace TauCeti.Tannaka
@@ -107,18 +111,142 @@ theorem regularInclusion_toLinearMap
   unfold regularInclusion
   rfl
 
+/-- The component of a tensor automorphism, transported from the object chosen by the
+scalar-extension functor to the explicit tensor product `A ⊗[k] M`. -/
+noncomputable def scalarExtensionComponent
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
+    (M : FGComoduleCat.{u, u, u} k H) :
+    A ⊗[k] M →ₗ[A] A ⊗[k] M := by
+  exact (eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
+      M).symm ≫
+    η.hom.hom.app M ≫
+      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
+        M)).hom
+
+/-- Naturality of the explicitly transported components of a tensor automorphism. -/
+theorem scalarExtensionComponent_natural
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
+    {M N : FGComoduleCat.{u, u, u} k H} (f : M ⟶ N) :
+    f.hom.toLinearMap.baseChange A ∘ₗ scalarExtensionComponent k H A η M =
+      scalarExtensionComponent k H A η N ∘ₗ f.hom.toLinearMap.baseChange A := by
+  let aM : (FGComoduleCat.scalarExtensionFunctor k H A).obj M ⟶
+      (FGComoduleCat.scalarExtensionFunctor k H A).obj M :=
+    η.hom.hom.app M
+  let aN : (FGComoduleCat.scalarExtensionFunctor k H A).obj N ⟶
+      (FGComoduleCat.scalarExtensionFunctor k H A).obj N :=
+    η.hom.hom.app N
+  have hnat :
+      (FGComoduleCat.scalarExtensionFunctor k H A).map f ≫ aN =
+        aM ≫ (FGComoduleCat.scalarExtensionFunctor k H A).map f :=
+    η.hom.hom.naturality f
+  let hM := FGComoduleCat.scalarExtensionFunctor_obj k H A M
+  let hN := FGComoduleCat.scalarExtensionFunctor_obj k H A N
+  let iM := eqToIso hM
+  let iN := eqToIso hN
+  let bmap := SemimoduleCat.ofHom (f.hom.toLinearMap.baseChange A)
+  have hfmap :
+      (FGComoduleCat.scalarExtensionFunctor k H A).map f =
+        iM.hom ≫ bmap ≫ iN.inv := by
+    simpa only [hM, hN, iM, iN, bmap, eqToIso.hom, eqToIso.inv] using
+      FGComoduleCat.scalarExtensionFunctor_map k H A f
+  rw [hfmap] at hnat
+  have hcat :
+      (iM.inv ≫ aM ≫ iM.hom) ≫ bmap =
+        bmap ≫ (iN.inv ≫ aN ≫ iN.hom) := by
+    rw [← cancel_epi iM.hom]
+    rw [← cancel_mono iN.inv]
+    slice_lhs 1 2 => rw [iM.hom_inv_id]
+    slice_rhs 4 6 => rw [iN.hom_inv_id, Category.comp_id]
+    simpa only [Category.id_comp, Category.comp_id, Category.assoc] using hnat.symm
+  change bmap.hom ∘ₗ
+      (iM.inv ≫ aM ≫ iM.hom).hom =
+    (iN.inv ≫ aN ≫ iN.hom).hom ∘ₗ bmap.hom
+  simpa only [SemimoduleCat.hom_comp] using congrArg SemimoduleCat.Hom.hom hcat
+
+/-- Tensor compatibility of the explicitly transported components of a tensor automorphism. -/
+theorem scalarExtensionComponent_tensor
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
+    (M N : FGComoduleCat.{u, u, u} k H) (x : A ⊗[k] M) (y : A ⊗[k] N) :
+    scalarExtensionComponent k H A η (M ⊗ N : FGComoduleCat k H)
+        ((TensorProduct.AlgebraTensorModule.distribBaseChange k A M N).symm
+          (x ⊗ₜ[A] y)) =
+      (TensorProduct.AlgebraTensorModule.distribBaseChange k A M N).symm
+        (scalarExtensionComponent k H A η M x ⊗ₜ[A]
+          scalarExtensionComponent k H A η N y) := by
+  let aM : (FGComoduleCat.scalarExtensionFunctor k H A).obj M ⟶
+      (FGComoduleCat.scalarExtensionFunctor k H A).obj M :=
+    η.hom.hom.app M
+  let aN : (FGComoduleCat.scalarExtensionFunctor k H A).obj N ⟶
+      (FGComoduleCat.scalarExtensionFunctor k H A).obj N :=
+    η.hom.hom.app N
+  let aMN : (FGComoduleCat.scalarExtensionFunctor k H A).obj
+      (M ⊗ N : FGComoduleCat k H) ⟶
+      (FGComoduleCat.scalarExtensionFunctor k H A).obj
+        (M ⊗ N : FGComoduleCat k H) :=
+    η.hom.hom.app (M ⊗ N : FGComoduleCat k H)
+  have htensor := NatTrans.IsMonoidal.tensor (τ := η.hom.hom) M N
+  change Functor.LaxMonoidal.μ (FGComoduleCat.scalarExtensionFunctor k H A) M N ≫ aMN =
+    (aM ⊗ₘ aN) ≫
+      Functor.LaxMonoidal.μ (FGComoduleCat.scalarExtensionFunctor k H A) M N at htensor
+  rw [FGComoduleCat.scalarExtensionFunctor_μ] at htensor
+  let iM := eqToIso (FGComoduleCat.scalarExtensionFunctor_obj k H A M)
+  let iN := eqToIso (FGComoduleCat.scalarExtensionFunctor_obj k H A N)
+  let iMN := eqToIso (FGComoduleCat.scalarExtensionFunctor_obj k H A
+    (M ⊗ N : FGComoduleCat k H))
+  let d :
+      (SemimoduleCat.of A (A ⊗[k] M) ⊗ SemimoduleCat.of A (A ⊗[k] N)) ⟶
+        SemimoduleCat.of A (A ⊗[k] (M ⊗[k] N)) :=
+    SemimoduleCat.ofHom
+      (TensorProduct.AlgebraTensorModule.distribBaseChange k A M N).symm.toLinearMap
+  have hmon :
+      (((iM.hom ⊗ₘ iN.hom) ≫ d ≫ iMN.inv) ≫ aMN) =
+        (aM ⊗ₘ aN) ≫ ((iM.hom ⊗ₘ iN.hom) ≫ d ≫ iMN.inv) := by
+    simpa only [iM, iN, iMN, d, eqToIso.hom, eqToIso.inv] using htensor
+  have he :
+      (iM.hom ⊗ₘ iN.hom) ≫
+          ((iM.inv ≫ aM ≫ iM.hom) ⊗ₘ (iN.inv ≫ aN ≫ iN.hom)) =
+        ((aM ≫ iM.hom) ⊗ₘ (aN ≫ iN.hom)) := by
+    rw [MonoidalCategory.tensorHom_comp_tensorHom]
+    simp only [Iso.hom_inv_id_assoc]
+  have he' :
+      (aM ⊗ₘ aN) ≫ (iM.hom ⊗ₘ iN.hom) =
+        ((aM ≫ iM.hom) ⊗ₘ (aN ≫ iN.hom)) :=
+    MonoidalCategory.tensorHom_comp_tensorHom _ _ _ _
+  have hcat :
+      d ≫ (iMN.inv ≫ aMN ≫ iMN.hom) =
+        ((iM.inv ≫ aM ≫ iM.hom) ⊗ₘ (iN.inv ≫ aN ≫ iN.hom)) ≫ d := by
+    rw [← cancel_epi (iM.hom ⊗ₘ iN.hom)]
+    rw [← cancel_mono iMN.inv]
+    simp only [Category.assoc, Iso.hom_inv_id, Category.comp_id]
+    conv_rhs => rw [← Category.assoc]
+    rw [he, ← he']
+    simpa only [Category.assoc] using hmon
+  have hlin := congrArg SemimoduleCat.Hom.hom hcat
+  change (iMN.inv ≫ aMN ≫ iMN.hom).hom.comp d.hom =
+      d.hom.comp
+        ((iM.inv ≫ aM ≫ iM.hom) ⊗ₘ (iN.inv ≫ aN ≫ iN.hom)).hom at hlin
+  rw [SemimoduleCat.hom_tensorHom] at hlin
+  have happ := LinearMap.congr_fun hlin (x ⊗ₜ[A] y)
+  change (iMN.inv ≫ aMN ≫ iMN.hom).hom (d.hom (x ⊗ₜ[A] y)) =
+      d.hom (TensorProduct.map
+        (iM.inv ≫ aM ≫ iM.hom).hom
+        (iN.inv ≫ aN ≫ iN.hom).hom (x ⊗ₜ[A] y)) at happ
+  rw [TensorProduct.map_tmul] at happ
+  change scalarExtensionComponent k H A η (M ⊗ N : FGComoduleCat k H)
+      ((TensorProduct.AlgebraTensorModule.distribBaseChange k A M N).symm
+        (x ⊗ₜ[A] y)) =
+    (TensorProduct.AlgebraTensorModule.distribBaseChange k A M N).symm
+      (scalarExtensionComponent k H A η M x ⊗ₜ[A]
+        scalarExtensionComponent k H A η N y) at happ
+  exact happ
+
 /-- The component of a tensor automorphism on a finite regular subcomodule, transported from the
 object chosen by the scalar-extension functor to the explicit tensor product `A ⊗[k] N`. -/
-noncomputable def finiteRegularComponent
+@[expose] noncomputable def finiteRegularComponent
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
     (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H)) :
-    A ⊗[k] N.1 →ₗ[A] A ⊗[k] N.1 := by
-  letI : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
-  exact (eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
-      (finiteRegularObject k H N)).symm ≫
-    η.hom.hom.app (finiteRegularObject k H N) ≫
-      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H A
-        (finiteRegularObject k H N))).hom
+    A ⊗[k] N.1 →ₗ[A] A ⊗[k] N.1 :=
+  scalarExtensionComponent k H A η (finiteRegularObject k H N)
 
 /-- Evaluation formula for the transported component of a tensor automorphism on a finite
 regular subcomodule. -/
@@ -144,48 +272,8 @@ theorem finiteRegularComponent_natural
       finiteRegularComponent k H A η Q ∘ₗ (Submodule.inclusion hNQ).baseChange A := by
   let _ : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
   let _ : Module.Finite k Q.1 := Subcomodule.mem_finiteSubcomodules.mp Q.2
-  let aN : (FGComoduleCat.scalarExtensionFunctor k H A).obj
-      (finiteRegularObject k H N) ⟶
-        (FGComoduleCat.scalarExtensionFunctor k H A).obj (finiteRegularObject k H N) :=
-    η.hom.hom.app (finiteRegularObject k H N)
-  let aQ : (FGComoduleCat.scalarExtensionFunctor k H A).obj
-      (finiteRegularObject k H Q) ⟶
-        (FGComoduleCat.scalarExtensionFunctor k H A).obj (finiteRegularObject k H Q) :=
-    η.hom.hom.app (finiteRegularObject k H Q)
-  have hnat :
-      (FGComoduleCat.scalarExtensionFunctor k H A).map (regularInclusion k H hNQ) ≫ aQ =
-        aN ≫
-          (FGComoduleCat.scalarExtensionFunctor k H A).map (regularInclusion k H hNQ) :=
-    η.hom.hom.naturality (regularInclusion k H hNQ)
-  let hN := FGComoduleCat.scalarExtensionFunctor_obj k H A
-    (finiteRegularObject k H N)
-  let hQ := FGComoduleCat.scalarExtensionFunctor_obj k H A
-    (finiteRegularObject k H Q)
-  let iN := eqToIso hN
-  let iQ := eqToIso hQ
-  let bmap := SemimoduleCat.ofHom ((Submodule.inclusion hNQ).baseChange A)
-  have hfmap :
-      (FGComoduleCat.scalarExtensionFunctor k H A).map (regularInclusion k H hNQ) =
-        iN.hom ≫ bmap ≫ iQ.inv := by
-    simpa only [hN, hQ, iN, iQ, bmap, eqToIso.hom, eqToIso.inv,
-      regularInclusion_toLinearMap] using
-      FGComoduleCat.scalarExtensionFunctor_map k H A (regularInclusion k H hNQ)
-  rw [hfmap] at hnat
-  have hcat :
-      (iN.inv ≫ aN ≫ iN.hom) ≫ bmap =
-        bmap ≫ (iQ.inv ≫ aQ ≫ iQ.hom) := by
-    rw [← cancel_epi iN.hom]
-    rw [← cancel_mono iQ.inv]
-    slice_lhs 1 2 => rw [iN.hom_inv_id]
-    slice_rhs 4 6 => rw [iQ.hom_inv_id, Category.comp_id]
-    simpa only [Category.id_comp, Category.comp_id, Category.assoc] using hnat.symm
-  -- `finiteRegularComponent` is defined by transporting along `hN` and `hQ`.  The scalar
-  -- extension functor does not expose a carrier-level rewriting lemma for these object
-  -- equalities, so expose the transported linear maps before applying `hom_comp`.
-  change bmap.hom ∘ₗ
-      (iN.inv ≫ aN ≫ iN.hom).hom =
-    (iQ.inv ≫ aQ ≫ iQ.hom).hom ∘ₗ bmap.hom
-  simpa only [SemimoduleCat.hom_comp] using congrArg SemimoduleCat.Hom.hom hcat
+  simpa only [finiteRegularComponent, regularInclusion_toLinearMap] using
+    scalarExtensionComponent_natural k H A η (regularInclusion k H hNQ)
 
 /-- The linear functional on a finite subcomodule of the regular comodule extracted from a
 tensor automorphism. It applies the automorphism to `1 ⊗ n` and then evaluates the regular
@@ -251,7 +339,7 @@ theorem finiteRegularComponent_fgPointTensorIso
   let _ : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
   apply LinearMap.ext
   intro x
-  unfold finiteRegularComponent
+  unfold finiteRegularComponent scalarExtensionComponent
   rw [fgPointTensorIso_hom_hom, fgPointNatIsoHom_hom_app]
   let hN := FGComoduleCat.scalarExtensionFunctor_obj k H A
     (finiteRegularObject k H N)

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -141,6 +141,7 @@ theorem scalarExtensionComponent_natural
     congrArg SemimoduleCat.Hom.hom hcat'
 
 /-- Tensor compatibility of the explicitly transported components of a tensor automorphism. -/
+@[simp]
 theorem scalarExtensionComponent_tensor
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
     (M N : FGComoduleCat.{u, v, u} R H) (x : A ⊗[R] M) (y : A ⊗[R] N) :
@@ -162,10 +163,11 @@ theorem scalarExtensionComponent_tensor
         (M ⊗ N : FGComoduleCat R H) :=
     η.hom.hom.app (M ⊗ N : FGComoduleCat R H)
   -- First unpack the bundled monoidal axiom into the tensor-component square.
-  have htensor := NatTrans.IsMonoidal.tensor (τ := η.hom.hom) M N
-  change Functor.LaxMonoidal.μ (FGComoduleCat.scalarExtensionFunctor R H A) M N ≫ aMN =
-    (aM ⊗ₘ aN) ≫
-      Functor.LaxMonoidal.μ (FGComoduleCat.scalarExtensionFunctor R H A) M N at htensor
+  have htensor :
+      Functor.LaxMonoidal.μ (FGComoduleCat.scalarExtensionFunctor R H A) M N ≫ aMN =
+        (aM ⊗ₘ aN) ≫
+          Functor.LaxMonoidal.μ (FGComoduleCat.scalarExtensionFunctor R H A) M N :=
+    NatTrans.IsMonoidal.tensor (τ := η.hom.hom) M N
   rw [FGComoduleCat.scalarExtensionFunctor_μ] at htensor
   let hM := FGComoduleCat.scalarExtensionFunctor_obj R H A M
   let hN := FGComoduleCat.scalarExtensionFunctor_obj R H A N

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -73,6 +73,16 @@ noncomputable def scalarExtensionComponent
     η.hom.hom.app M ≫
       eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M)).hom
 
+/-- Evaluation formula for a transported tensor-automorphism component. -/
+theorem scalarExtensionComponent_apply
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
+    (M : FGComoduleCat.{u, v, u} R H) (x : A ⊗[R] M) :
+    scalarExtensionComponent R H A η M x =
+      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M)
+        (η.hom.hom.app M
+          (eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm x)) := by
+  rfl
+
 /-- The categorical morphism underlying a transported tensor-automorphism component. -/
 theorem ofHom_scalarExtensionComponent
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -29,6 +29,10 @@ separate theorem.
 
 ## Main declarations
 
+* `TauCeti.Tannaka.scalarExtensionComponent`: a tensor-automorphism component transported to an
+  explicit scalar-extension tensor product.
+* `TauCeti.Tannaka.scalarExtensionComponent_tensor`: the elementwise tensor law for transported
+  components.
 * `TauCeti.Tannaka.isMonoidal_fgPointNatIsoHom_hom`: point actions on finite comodules preserve the
   tensor unit and tensor product.
 * `TauCeti.Tannaka.fgPointTensorIsoHom`: points act on finite-comodule scalar extension by
@@ -39,8 +43,9 @@ separate theorem.
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), §§4.5 and 9.4.
-* `Mathlib/RepresentationTheory/Tannaka.lean`: the bundled monoidal forgetful functor `forget`
-  and point homomorphism `equivHom` provide the formal pattern adapted here to comodules.
+* `Mathlib/RepresentationTheory/Tannaka.lean`: the bundled monoidal forgetful functor `forget`,
+  point homomorphism `equivHom`, and tensor step in `map_mul_toRightFDRepComp` provide the formal
+  pattern adapted here to comodules and scalar extension.
 -/
 
 public section
@@ -51,6 +56,176 @@ open scoped TensorProduct
 namespace TauCeti.Tannaka
 
 universe u v
+
+section Component
+
+variable (R : Type u) [CommSemiring R]
+variable (H : Type v) [Semiring H] [Bialgebra R H]
+variable (A : Type u) [CommSemiring A] [Algebra R A]
+
+/-- The component of a tensor automorphism, transported from the object chosen by the
+scalar-extension functor to the explicit tensor product `A ⊗[R] M`. -/
+noncomputable def scalarExtensionComponent
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
+    (M : FGComoduleCat.{u, v, u} R H) :
+    A ⊗[R] M →ₗ[A] A ⊗[R] M :=
+  (eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm ≫
+    η.hom.hom.app M ≫
+      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M)).hom
+
+/-- The categorical morphism underlying a transported tensor-automorphism component. -/
+theorem ofHom_scalarExtensionComponent
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
+    (M : FGComoduleCat.{u, v, u} R H)
+    (h : (FGComoduleCat.scalarExtensionFunctor R H A).obj M =
+      SemimoduleCat.of A (A ⊗[R] M)) :
+    SemimoduleCat.ofHom (scalarExtensionComponent R H A η M) =
+      eqToHom h.symm ≫
+        η.hom.hom.app M ≫
+          eqToHom h := by
+  cases Subsingleton.elim h (FGComoduleCat.scalarExtensionFunctor_obj R H A M)
+  rfl
+
+/-- Naturality of the explicitly transported components of a tensor automorphism. -/
+theorem scalarExtensionComponent_natural
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
+    {M N : FGComoduleCat.{u, v, u} R H} (f : M ⟶ N) :
+    f.hom.toLinearMap.baseChange A ∘ₗ scalarExtensionComponent R H A η M =
+      scalarExtensionComponent R H A η N ∘ₗ f.hom.toLinearMap.baseChange A := by
+  let aM : (FGComoduleCat.scalarExtensionFunctor R H A).obj M ⟶
+      (FGComoduleCat.scalarExtensionFunctor R H A).obj M :=
+    η.hom.hom.app M
+  let aN : (FGComoduleCat.scalarExtensionFunctor R H A).obj N ⟶
+      (FGComoduleCat.scalarExtensionFunctor R H A).obj N :=
+    η.hom.hom.app N
+  have hnat :
+      (FGComoduleCat.scalarExtensionFunctor R H A).map f ≫ aN =
+        aM ≫ (FGComoduleCat.scalarExtensionFunctor R H A).map f :=
+    η.hom.hom.naturality f
+  let hM := FGComoduleCat.scalarExtensionFunctor_obj R H A M
+  let hN := FGComoduleCat.scalarExtensionFunctor_obj R H A N
+  let iM := eqToIso hM
+  let iN := eqToIso hN
+  let bmap := SemimoduleCat.ofHom (f.hom.toLinearMap.baseChange A)
+  have hfmap :
+      (FGComoduleCat.scalarExtensionFunctor R H A).map f =
+        iM.hom ≫ bmap ≫ iN.inv := by
+    simpa only [hM, hN, iM, iN, bmap, eqToIso.hom, eqToIso.inv] using
+      FGComoduleCat.scalarExtensionFunctor_map R H A f
+  rw [hfmap] at hnat
+  have hcat :
+      (iM.inv ≫ aM ≫ iM.hom) ≫ bmap =
+        bmap ≫ (iN.inv ≫ aN ≫ iN.hom) := by
+    rw [← cancel_epi iM.hom]
+    rw [← cancel_mono iN.inv]
+    slice_lhs 1 2 => rw [iM.hom_inv_id]
+    slice_rhs 4 6 => rw [iN.hom_inv_id, Category.comp_id]
+    simpa only [Category.id_comp, Category.comp_id, Category.assoc] using hnat.symm
+  have hcat' :
+      SemimoduleCat.ofHom (scalarExtensionComponent R H A η M) ≫ bmap =
+        bmap ≫ SemimoduleCat.ofHom (scalarExtensionComponent R H A η N) := by
+    rw [ofHom_scalarExtensionComponent R H A η M hM,
+      ofHom_scalarExtensionComponent R H A η N hN]
+    convert hcat using 1 <;>
+      simp only [iM, iN, aM, aN, eqToIso.inv, eqToIso.hom] <;> rfl
+  simpa only [bmap, SemimoduleCat.hom_comp, SemimoduleCat.hom_ofHom] using
+    congrArg SemimoduleCat.Hom.hom hcat'
+
+/-- Tensor compatibility of the explicitly transported components of a tensor automorphism. -/
+theorem scalarExtensionComponent_tensor
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
+    (M N : FGComoduleCat.{u, v, u} R H) (x : A ⊗[R] M) (y : A ⊗[R] N) :
+    scalarExtensionComponent R H A η (M ⊗ N : FGComoduleCat R H)
+        ((TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm
+          (x ⊗ₜ[A] y)) =
+      (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm
+        (scalarExtensionComponent R H A η M x ⊗ₜ[A]
+          scalarExtensionComponent R H A η N y) := by
+  let aM : (FGComoduleCat.scalarExtensionFunctor R H A).obj M ⟶
+      (FGComoduleCat.scalarExtensionFunctor R H A).obj M :=
+    η.hom.hom.app M
+  let aN : (FGComoduleCat.scalarExtensionFunctor R H A).obj N ⟶
+      (FGComoduleCat.scalarExtensionFunctor R H A).obj N :=
+    η.hom.hom.app N
+  let aMN : (FGComoduleCat.scalarExtensionFunctor R H A).obj
+      (M ⊗ N : FGComoduleCat R H) ⟶
+      (FGComoduleCat.scalarExtensionFunctor R H A).obj
+        (M ⊗ N : FGComoduleCat R H) :=
+    η.hom.hom.app (M ⊗ N : FGComoduleCat R H)
+  -- First unpack the bundled monoidal axiom into the tensor-component square.
+  have htensor := NatTrans.IsMonoidal.tensor (τ := η.hom.hom) M N
+  change Functor.LaxMonoidal.μ (FGComoduleCat.scalarExtensionFunctor R H A) M N ≫ aMN =
+    (aM ⊗ₘ aN) ≫
+      Functor.LaxMonoidal.μ (FGComoduleCat.scalarExtensionFunctor R H A) M N at htensor
+  rw [FGComoduleCat.scalarExtensionFunctor_μ] at htensor
+  let hM := FGComoduleCat.scalarExtensionFunctor_obj R H A M
+  let hN := FGComoduleCat.scalarExtensionFunctor_obj R H A N
+  let hMN := FGComoduleCat.scalarExtensionFunctor_obj R H A
+    (M ⊗ N : FGComoduleCat R H)
+  let iM := eqToIso hM
+  let iN := eqToIso hN
+  let iMN := eqToIso hMN
+  let d :
+      (SemimoduleCat.of A (A ⊗[R] M) ⊗ SemimoduleCat.of A (A ⊗[R] N)) ⟶
+        SemimoduleCat.of A (A ⊗[R] (M ⊗[R] N)) :=
+    SemimoduleCat.ofHom
+      (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap
+  have hmon :
+      (((iM.hom ⊗ₘ iN.hom) ≫ d ≫ iMN.inv) ≫ aMN) =
+        (aM ⊗ₘ aN) ≫ ((iM.hom ⊗ₘ iN.hom) ≫ d ≫ iMN.inv) := by
+    simpa only [iM, iN, iMN, d, eqToIso.hom, eqToIso.inv] using htensor
+  -- Next cancel the object transports, leaving only explicit scalar-extension components.
+  have he :
+      (iM.hom ⊗ₘ iN.hom) ≫
+          ((iM.inv ≫ aM ≫ iM.hom) ⊗ₘ (iN.inv ≫ aN ≫ iN.hom)) =
+        ((aM ≫ iM.hom) ⊗ₘ (aN ≫ iN.hom)) := by
+    rw [MonoidalCategory.tensorHom_comp_tensorHom]
+    simp only [Iso.hom_inv_id_assoc]
+  have he' :
+      (aM ⊗ₘ aN) ≫ (iM.hom ⊗ₘ iN.hom) =
+        ((aM ≫ iM.hom) ⊗ₘ (aN ≫ iN.hom)) :=
+    MonoidalCategory.tensorHom_comp_tensorHom _ _ _ _
+  have hcat :
+      d ≫ (iMN.inv ≫ aMN ≫ iMN.hom) =
+        ((iM.inv ≫ aM ≫ iM.hom) ⊗ₘ (iN.inv ≫ aN ≫ iN.hom)) ≫ d := by
+    rw [← cancel_epi (iM.hom ⊗ₘ iN.hom)]
+    rw [← cancel_mono iMN.inv]
+    simp only [Category.assoc, Iso.hom_inv_id, Category.comp_id]
+    conv_rhs => rw [← Category.assoc]
+    rw [he, ← he']
+    simpa only [Category.assoc] using hmon
+  -- Use the same bridge to replace all three transported maps before passing to linear maps.
+  have hcat' :
+      d ≫ SemimoduleCat.ofHom
+          (scalarExtensionComponent R H A η (M ⊗ N : FGComoduleCat R H)) =
+        (SemimoduleCat.ofHom (scalarExtensionComponent R H A η M) ⊗ₘ
+          SemimoduleCat.ofHom (scalarExtensionComponent R H A η N)) ≫ d := by
+    rw [ofHom_scalarExtensionComponent R H A η (M ⊗ N : FGComoduleCat R H) hMN,
+      ofHom_scalarExtensionComponent R H A η M hM,
+      ofHom_scalarExtensionComponent R H A η N hN]
+    convert hcat using 1 <;>
+      simp only [iM, iN, iMN, aM, aN, aMN, eqToIso.inv, eqToIso.hom] <;> rfl
+  have hlin := congrArg SemimoduleCat.Hom.hom hcat'
+  simp only [SemimoduleCat.hom_comp, SemimoduleCat.hom_ofHom] at hlin
+  rw [SemimoduleCat.hom_tensorHom] at hlin
+  -- Finally evaluate the linear-map equality on a pure tensor.
+  have happ := LinearMap.congr_fun hlin (x ⊗ₜ[A] y)
+  -- No carrier-level rewrite theorem unfolds these two categorical applications, so display
+  -- their underlying linear maps before evaluating `TensorProduct.map`.
+  change scalarExtensionComponent R H A η (M ⊗ N : FGComoduleCat R H)
+      (d.hom (x ⊗ₜ[A] y)) =
+    d.hom (TensorProduct.map (scalarExtensionComponent R H A η M)
+      (scalarExtensionComponent R H A η N) (x ⊗ₜ[A] y)) at happ
+  rw [TensorProduct.map_tmul] at happ
+  change scalarExtensionComponent R H A η (M ⊗ N : FGComoduleCat R H)
+      ((TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm
+        (x ⊗ₜ[A] y)) =
+    (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm
+      (scalarExtensionComponent R H A η M x ⊗ₜ[A]
+        scalarExtensionComponent R H A η N y) at happ
+  exact happ
+
+end Component
 
 section Generic
 
@@ -111,6 +286,25 @@ automorphism. -/
 theorem fgPointTensorIso_hom_hom (g : WithConv (H →ₐ[R] A)) :
     (fgPointTensorIso R H A g).hom.hom = (fgPointNatIsoHom R H A g).hom :=
   (rfl)
+
+/-- The transported component of the tensor automorphism induced by a point is the usual point
+action on every finite comodule. -/
+@[simp]
+theorem scalarExtensionComponent_fgPointTensorIso
+    (g : WithConv (H →ₐ[R] A)) (M : FGComoduleCat.{u, v, u} R H) :
+    scalarExtensionComponent R H A (fgPointTensorIso R H A g) M =
+      (Comodule.pointsAction M g).toLinearMap := by
+  apply LinearMap.ext
+  intro x
+  unfold scalarExtensionComponent
+  rw [fgPointTensorIso_hom_hom, fgPointNatIsoHom_hom_app]
+  let hM := FGComoduleCat.scalarExtensionFunctor_obj R H A M
+  -- After rewriting the point-induced component, only transport along `hM` remains; displaying
+  -- the four `eqToHom`s lets the category simp lemmas cancel this object equality.
+  change (eqToHom hM.symm ≫
+      (eqToHom hM ≫ (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
+        eqToHom hM.symm) ≫ eqToHom hM) x = _
+  simp
 
 /-- Forgetting tensor compatibility from the inverse point automorphism recovers the inverse
 underlying natural automorphism. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -83,8 +83,7 @@ theorem scalarExtensionComponent_apply
           (eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm x)) := by
   rfl
 
-/-- The categorical morphism underlying a transported tensor-automorphism component. -/
-theorem ofHom_scalarExtensionComponent
+private theorem ofHom_scalarExtensionComponent
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
     (M : FGComoduleCat.{u, v, u} R H)
     (h : (FGComoduleCat.scalarExtensionFunctor R H A).obj M =

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.LocalFunctional
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Multiplication
+
+/-!
+# Multiplicativity of Tannakian local functionals
+
+Let `H` be a commutative Hopf algebra over a field `k`, let `A` be a commutative `k`-algebra,
+and let `η` be a tensor automorphism of scalar extension on finite-dimensional `H`-comodules.
+The functional extracted from `η` on a finite subcomodule of the regular comodule is compatible
+with multiplication.
+
+More precisely, if finite regular subcomodules `N` and `P` have all their pairwise products in a
+third finite regular subcomodule `Q`, then
+
+```text
+g_{η,Q}(n * p) = g_{η,N}(n) * g_{η,P}(p).
+```
+
+The proof applies naturality to the corestricted regular-comodule multiplication
+`Subcomodule.mulHom` and applies the tensor law for `η` to `1 ⊗ n` and `1 ⊗ p`.
+Evaluation by the counit turns multiplication in the regular comodule into multiplication in
+`A`. Together with the separately developed unit law and gluing construction, this is the
+algebra-map law needed to reconstruct an `A`-valued point from a tensor automorphism.
+
+## Main declarations
+
+* `TauCeti.Tannaka.regularMul`: multiplication of two finite regular subcomodules, corestricted
+  to a finite regular subcomodule containing their products.
+* `TauCeti.Tannaka.localFunctional_mul`: the extracted local functionals preserve these products.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), section 9.4.
+-/
+
+public section
+
+open CategoryTheory MonoidalCategory
+open scoped TensorProduct
+
+namespace TauCeti.Tannaka
+
+universe u
+
+variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
+  [CommRing A] [Algebra k A]
+
+attribute [local instance] Comodule.tensor
+
+/-- Multiplication of two finite regular subcomodules, corestricted to a finite regular
+subcomodule containing all their pairwise products. -/
+noncomputable def regularMul
+    (N P Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (h : ∀ (n : N.1) (p : P.1), (n : H) * (p : H) ∈ Q.1) :
+    finiteRegularObject k H N ⊗ finiteRegularObject k H P ⟶ finiteRegularObject k H Q := by
+  letI : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
+  letI : Module.Finite k P.1 := Subcomodule.mem_finiteSubcomodules.mp P.2
+  letI : Module.Finite k Q.1 := Subcomodule.mem_finiteSubcomodules.mp Q.2
+  exact FGComoduleCat.ofHom (Subcomodule.mulHom N.1 P.1 Q.1 h)
+
+/-- Corestricted multiplication of finite regular subcomodules sends a pure tensor to the
+product of its factors. -/
+@[simp]
+theorem regularMul_tmul
+    (N P Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (h : ∀ (n : N.1) (p : P.1), (n : H) * (p : H) ∈ Q.1)
+    (n : N.1) (p : P.1) :
+    ((regularMul k H N P Q h (n ⊗ₜ[k] p) : Q.1) : H) = (n : H) * (p : H) := by
+  exact Subcomodule.mulHom_tmul N.1 P.1 Q.1 h n p
+
+/-- The underlying linear map of corestricted multiplication is the base map used by scalar
+extension. -/
+@[simp]
+theorem regularMul_toLinearMap
+    (N P Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (h : ∀ (n : N.1) (p : P.1), (n : H) * (p : H) ∈ Q.1) :
+    (regularMul k H N P Q h).hom.toLinearMap =
+      (Subcomodule.mulHom N.1 P.1 Q.1 h).toLinearMap := by
+  rfl
+
+private noncomputable def counitEvaluation
+    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H)) :
+    A ⊗[k] N.1 →ₗ[A] A :=
+  TauCeti.Module.Dual.baseChangeEvaluation (R := k) (M := N.1) (A := A)
+    (1 ⊗ₜ[k] ((Coalgebra.counit (R := k) (A := H)).comp
+      (SMulMemClass.subtype N.1)))
+
+@[simp]
+private theorem counitEvaluation_tmul
+    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (a : A) (n : N.1) :
+    counitEvaluation k H A N (a ⊗ₜ[k] n) =
+      a * algebraMap k A (Coalgebra.counit (R := k) (A := H) (n : H)) := by
+  simp [counitEvaluation]
+
+private theorem counitEvaluation_mul
+    (N P Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (h : ∀ (n : N.1) (p : P.1), (n : H) * (p : H) ∈ Q.1)
+    (x : A ⊗[k] N.1) (y : A ⊗[k] P.1) :
+    counitEvaluation k H A Q
+        ((Subcomodule.mulHom N.1 P.1 Q.1 h).toLinearMap.baseChange A
+          ((TensorProduct.AlgebraTensorModule.distribBaseChange k A N.1 P.1).symm
+            (x ⊗ₜ[A] y))) =
+      counitEvaluation k H A N x * counitEvaluation k H A P y := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | add x x' hx hx' =>
+      rw [TensorProduct.add_tmul, map_add, map_add, map_add, hx, hx', map_add, add_mul]
+  | tmul a n =>
+      induction y using TensorProduct.induction_on with
+      | zero => simp
+      | add y y' hy hy' =>
+          rw [TensorProduct.tmul_add, map_add, map_add, map_add, hy, hy', map_add, mul_add]
+      | tmul b p =>
+          rw [TensorProduct.AlgebraTensorModule.distribBaseChange_symm_tmul,
+            LinearMap.baseChange_tmul]
+          change counitEvaluation k H A Q
+              ((a * b) ⊗ₜ[k] Subcomodule.mulHom N.1 P.1 Q.1 h (n ⊗ₜ[k] p)) = _
+          rw [counitEvaluation_tmul, counitEvaluation_tmul, counitEvaluation_tmul]
+          rw [show Coalgebra.counit (R := k) (A := H)
+              ((Subcomodule.mulHom N.1 P.1 Q.1 h (n ⊗ₜ[k] p) : Q.1) : H) =
+                Coalgebra.counit (R := k) (A := H) ((n : H) * (p : H)) by
+            rw [Subcomodule.mulHom_tmul]]
+          rw [Bialgebra.counit_mul, map_mul]
+          ring
+
+/-- Local functionals extracted from a tensor automorphism preserve products whenever the
+products of the two source subcomodules lie in the chosen target subcomodule. -/
+theorem localFunctional_mul
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
+    (N P Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
+    (h : ∀ (n : N.1) (p : P.1), (n : H) * (p : H) ∈ Q.1)
+    (n : N.1) (p : P.1) :
+    localFunctional k H A η Q ⟨(n : H) * (p : H), h n p⟩ =
+      localFunctional k H A η N n * localFunctional k H A η P p := by
+  let _ : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
+  let _ : Module.Finite k P.1 := Subcomodule.mem_finiteSubcomodules.mp P.2
+  let _ : Module.Finite k Q.1 := Subcomodule.mem_finiteSubcomodules.mp Q.2
+  let q : Q.1 := ⟨(n : H) * (p : H), h n p⟩
+  have hq : (regularMul k H N P Q h).hom.toLinearMap (n ⊗ₜ[k] p) = q := by
+    apply Subtype.ext
+    exact regularMul_tmul k H N P Q h n p
+  have hnat := LinearMap.congr_fun
+    (scalarExtensionComponent_natural k H A η (regularMul k H N P Q h))
+      (1 ⊗ₜ[k] (n ⊗ₜ[k] p))
+  change (regularMul k H N P Q h).hom.toLinearMap.baseChange A
+      (scalarExtensionComponent k H A η
+        (finiteRegularObject k H N ⊗ finiteRegularObject k H P)
+          (1 ⊗ₜ[k] (n ⊗ₜ[k] p))) =
+    scalarExtensionComponent k H A η (finiteRegularObject k H Q)
+      ((regularMul k H N P Q h).hom.toLinearMap.baseChange A
+        (1 ⊗ₜ[k] (n ⊗ₜ[k] p))) at hnat
+  rw [LinearMap.baseChange_tmul, hq] at hnat
+  have htensor := scalarExtensionComponent_tensor k H A η
+    (finiteRegularObject k H N) (finiteRegularObject k H P)
+      (1 ⊗ₜ[k] n) (1 ⊗ₜ[k] p)
+  rw [TensorProduct.AlgebraTensorModule.distribBaseChange_symm_tmul, one_mul] at htensor
+  rw [localFunctional_apply, localFunctional_apply, localFunctional_apply]
+  change counitEvaluation k H A Q
+      (finiteRegularComponent k H A η Q
+        (1 ⊗ₜ[k] (⟨(n : H) * (p : H), h n p⟩ : Q.1))) =
+    counitEvaluation k H A N
+        (finiteRegularComponent k H A η N (1 ⊗ₜ[k] n)) *
+      counitEvaluation k H A P
+        (finiteRegularComponent k H A η P (1 ⊗ₜ[k] p))
+  rw [show (⟨(n : H) * (p : H), h n p⟩ : Q.1) = q by rfl]
+  simp only [finiteRegularComponent]
+  change counitEvaluation k H A Q
+      (scalarExtensionComponent k H A η (finiteRegularObject k H Q)
+        (1 ⊗ₜ[k] q)) =
+    counitEvaluation k H A N
+        (scalarExtensionComponent k H A η (finiteRegularObject k H N) (1 ⊗ₜ[k] n)) *
+      counitEvaluation k H A P
+        (scalarExtensionComponent k H A η (finiteRegularObject k H P) (1 ⊗ₜ[k] p))
+  rw [← hnat, htensor, regularMul_toLinearMap]
+  exact counitEvaluation_mul k H A N P Q h _ _
+
+end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
@@ -120,6 +120,7 @@ private theorem counitEvaluation_mul
 
 /-- Local functionals extracted from a tensor automorphism preserve products whenever the
 products of the two source subcomodules lie in the chosen target subcomodule. -/
+@[simp high]
 theorem localFunctional_mul
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
     (N P Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
@@ -10,8 +10,8 @@ public import TauCeti.Algebra.Coalgebra.Subcomodule.Multiplication
 /-!
 # Multiplicativity of Tannakian local functionals
 
-Let `H` be a commutative Hopf algebra over a field `k`, let `A` be a commutative `k`-algebra,
-and let `η` be a tensor automorphism of scalar extension on finite-dimensional `H`-comodules.
+Let `H` be a bialgebra over a commutative semiring `k`, let `A` be a commutative `k`-algebra,
+and let `η` be a tensor automorphism of scalar extension on finitely generated `H`-comodules.
 The functional extracted from `η` on a finite subcomodule of the regular comodule is compatible
 with multiplication.
 
@@ -82,8 +82,8 @@ end RegularMulHom
 
 section LocalMultiplicativity
 
-variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
-  [CommRing A] [Algebra k A]
+variable (k H A : Type u) [CommSemiring k] [Semiring H] [Bialgebra k H]
+  [Module.Flat k H] [CommSemiring A] [Algebra k A]
 
 private theorem counitEvaluation_mul
     (N P Q : Subcomodule k H H)

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
@@ -25,18 +25,21 @@ g_{η,Q}(n * p) = g_{η,N}(n) * g_{η,P}(p).
 The proof applies naturality to the corestricted regular-comodule multiplication
 `Subcomodule.mulHom` and applies the tensor law for `η` to `1 ⊗ n` and `1 ⊗ p`.
 Evaluation by the counit turns multiplication in the regular comodule into multiplication in
-`A`. Together with the separately developed unit law and gluing construction, this is the
-algebra-map law needed to reconstruct an `A`-valued point from a tensor automorphism.
+`A`. Together with the gluing construction and a unit law still to be developed, this supplies
+the algebra-map law needed to reconstruct an `A`-valued point from a tensor automorphism.
 
 ## Main declarations
 
-* `TauCeti.Tannaka.regularMul`: multiplication of two finite regular subcomodules, corestricted
-  to a finite regular subcomodule containing their products.
+* `TauCeti.Tannaka.regularMulHom`: multiplication of two finite regular subcomodules, corestricted
+  to a finite regular subcomodule containing their products and packaged in `FGComoduleCat`.
 * `TauCeti.Tannaka.localFunctional_mul`: the extracted local functionals preserve these products.
 
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), section 9.4.
+* `Mathlib/RepresentationTheory/Tannaka.lean`: `mulRepHom` and
+  `map_mul_toRightFDRepComp` supply the formal pattern of a categorical multiplication morphism
+  followed by naturality and the monoidal tensor law, adapted here to comodules.
 -/
 
 public section
@@ -48,14 +51,15 @@ namespace TauCeti.Tannaka
 
 universe u
 
-variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
-  [CommRing A] [Algebra k A]
-
 attribute [local instance] Comodule.tensor
+
+section RegularMulHom
+
+variable (k H : Type u) [CommSemiring k] [Semiring H] [Bialgebra k H] [Module.Flat k H]
 
 /-- Multiplication of two finite regular subcomodules, corestricted to a finite regular
 subcomodule containing all their pairwise products. -/
-noncomputable def regularMul
+noncomputable def regularMulHom
     (N P Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
     (h : ∀ (n : N.1) (p : P.1), (n : H) * (p : H) ∈ Q.1) :
     finiteRegularObject k H N ⊗ finiteRegularObject k H P ⟶ finiteRegularObject k H Q := by
@@ -64,48 +68,30 @@ noncomputable def regularMul
   letI : Module.Finite k Q.1 := Subcomodule.mem_finiteSubcomodules.mp Q.2
   exact FGComoduleCat.ofHom (Subcomodule.mulHom N.1 P.1 Q.1 h)
 
-/-- Corestricted multiplication of finite regular subcomodules sends a pure tensor to the
-product of its factors. -/
+/-- The linear map underlying corestricted multiplication of finite regular subcomodules is the
+one underlying `Subcomodule.mulHom`. -/
 @[simp]
-theorem regularMul_tmul
-    (N P Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
-    (h : ∀ (n : N.1) (p : P.1), (n : H) * (p : H) ∈ Q.1)
-    (n : N.1) (p : P.1) :
-    ((regularMul k H N P Q h (n ⊗ₜ[k] p) : Q.1) : H) = (n : H) * (p : H) := by
-  exact Subcomodule.mulHom_tmul N.1 P.1 Q.1 h n p
-
-/-- The underlying linear map of corestricted multiplication is the base map used by scalar
-extension. -/
-@[simp]
-theorem regularMul_toLinearMap
+theorem regularMulHom_toLinearMap
     (N P Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
     (h : ∀ (n : N.1) (p : P.1), (n : H) * (p : H) ∈ Q.1) :
-    (regularMul k H N P Q h).hom.toLinearMap =
+    (regularMulHom k H N P Q h).hom.toLinearMap =
       (Subcomodule.mulHom N.1 P.1 Q.1 h).toLinearMap := by
   rfl
 
-private noncomputable def counitEvaluation
-    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H)) :
-    A ⊗[k] N.1 →ₗ[A] A :=
-  TauCeti.Module.Dual.baseChangeEvaluation (R := k) (M := N.1) (A := A)
-    (1 ⊗ₜ[k] ((Coalgebra.counit (R := k) (A := H)).comp
-      (SMulMemClass.subtype N.1)))
+end RegularMulHom
 
-@[simp]
-private theorem counitEvaluation_tmul
-    (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
-    (a : A) (n : N.1) :
-    counitEvaluation k H A N (a ⊗ₜ[k] n) =
-      a * algebraMap k A (Coalgebra.counit (R := k) (A := H) (n : H)) := by
-  simp [counitEvaluation]
+section LocalMultiplicativity
+
+variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
+  [CommRing A] [Algebra k A]
 
 private theorem counitEvaluation_mul
-    (N P Q : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
-    (h : ∀ (n : N.1) (p : P.1), (n : H) * (p : H) ∈ Q.1)
-    (x : A ⊗[k] N.1) (y : A ⊗[k] P.1) :
+    (N P Q : Subcomodule k H H)
+    (h : ∀ (n : N) (p : P), (n : H) * (p : H) ∈ Q)
+    (x : A ⊗[k] N) (y : A ⊗[k] P) :
     counitEvaluation k H A Q
-        ((Subcomodule.mulHom N.1 P.1 Q.1 h).toLinearMap.baseChange A
-          ((TensorProduct.AlgebraTensorModule.distribBaseChange k A N.1 P.1).symm
+        ((Subcomodule.mulHom N P Q h).toLinearMap.baseChange A
+          ((TensorProduct.AlgebraTensorModule.distribBaseChange k A N P).symm
             (x ⊗ₜ[A] y))) =
       counitEvaluation k H A N x * counitEvaluation k H A P y := by
   induction x using TensorProduct.induction_on with
@@ -120,11 +106,13 @@ private theorem counitEvaluation_mul
       | tmul b p =>
           rw [TensorProduct.AlgebraTensorModule.distribBaseChange_symm_tmul,
             LinearMap.baseChange_tmul]
-          change counitEvaluation k H A Q
-              ((a * b) ⊗ₜ[k] Subcomodule.mulHom N.1 P.1 Q.1 h (n ⊗ₜ[k] p)) = _
+          have hcoe : (Subcomodule.mulHom N P Q h).toLinearMap (n ⊗ₜ[k] p) =
+              Subcomodule.mulHom N P Q h (n ⊗ₜ[k] p) :=
+            congrFun (Comodule.Hom.coe_toLinearMap (Subcomodule.mulHom N P Q h)) _
+          rw [hcoe]
           rw [counitEvaluation_tmul, counitEvaluation_tmul, counitEvaluation_tmul]
           rw [show Coalgebra.counit (R := k) (A := H)
-              ((Subcomodule.mulHom N.1 P.1 Q.1 h (n ⊗ₜ[k] p) : Q.1) : H) =
+              ((Subcomodule.mulHom N P Q h (n ⊗ₜ[k] p) : Q) : H) =
                 Coalgebra.counit (R := k) (A := H) ((n : H) * (p : H)) by
             rw [Subcomodule.mulHom_tmul]]
           rw [Bialgebra.counit_mul, map_mul]
@@ -143,42 +131,23 @@ theorem localFunctional_mul
   let _ : Module.Finite k P.1 := Subcomodule.mem_finiteSubcomodules.mp P.2
   let _ : Module.Finite k Q.1 := Subcomodule.mem_finiteSubcomodules.mp Q.2
   let q : Q.1 := ⟨(n : H) * (p : H), h n p⟩
-  have hq : (regularMul k H N P Q h).hom.toLinearMap (n ⊗ₜ[k] p) = q := by
+  have hq : (regularMulHom k H N P Q h).hom.toLinearMap (n ⊗ₜ[k] p) = q := by
+    rw [regularMulHom_toLinearMap]
     apply Subtype.ext
-    exact regularMul_tmul k H N P Q h n p
+    exact Subcomodule.mulHom_tmul N.1 P.1 Q.1 h n p
   have hnat := LinearMap.congr_fun
-    (scalarExtensionComponent_natural k H A η (regularMul k H N P Q h))
+    (scalarExtensionComponent_natural k H A η (regularMulHom k H N P Q h))
       (1 ⊗ₜ[k] (n ⊗ₜ[k] p))
-  change (regularMul k H N P Q h).hom.toLinearMap.baseChange A
-      (scalarExtensionComponent k H A η
-        (finiteRegularObject k H N ⊗ finiteRegularObject k H P)
-          (1 ⊗ₜ[k] (n ⊗ₜ[k] p))) =
-    scalarExtensionComponent k H A η (finiteRegularObject k H Q)
-      ((regularMul k H N P Q h).hom.toLinearMap.baseChange A
-        (1 ⊗ₜ[k] (n ⊗ₜ[k] p))) at hnat
-  rw [LinearMap.baseChange_tmul, hq] at hnat
+  simp only [LinearMap.comp_apply, LinearMap.baseChange_tmul] at hnat
+  rw [hq] at hnat
   have htensor := scalarExtensionComponent_tensor k H A η
     (finiteRegularObject k H N) (finiteRegularObject k H P)
       (1 ⊗ₜ[k] n) (1 ⊗ₜ[k] p)
   rw [TensorProduct.AlgebraTensorModule.distribBaseChange_symm_tmul, one_mul] at htensor
   rw [localFunctional_apply, localFunctional_apply, localFunctional_apply]
-  change counitEvaluation k H A Q
-      (finiteRegularComponent k H A η Q
-        (1 ⊗ₜ[k] (⟨(n : H) * (p : H), h n p⟩ : Q.1))) =
-    counitEvaluation k H A N
-        (finiteRegularComponent k H A η N (1 ⊗ₜ[k] n)) *
-      counitEvaluation k H A P
-        (finiteRegularComponent k H A η P (1 ⊗ₜ[k] p))
-  rw [show (⟨(n : H) * (p : H), h n p⟩ : Q.1) = q by rfl]
-  simp only [finiteRegularComponent]
-  change counitEvaluation k H A Q
-      (scalarExtensionComponent k H A η (finiteRegularObject k H Q)
-        (1 ⊗ₜ[k] q)) =
-    counitEvaluation k H A N
-        (scalarExtensionComponent k H A η (finiteRegularObject k H N) (1 ⊗ₜ[k] n)) *
-      counitEvaluation k H A P
-        (scalarExtensionComponent k H A η (finiteRegularObject k H P) (1 ⊗ₜ[k] p))
-  rw [← hnat, htensor, regularMul_toLinearMap]
-  exact counitEvaluation_mul k H A N P Q h _ _
+  rw [← hnat, htensor, regularMulHom_toLinearMap]
+  exact counitEvaluation_mul k H A N.1 P.1 Q.1 h _ _
+
+end LocalMultiplicativity
 
 end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
@@ -111,10 +111,10 @@ private theorem counitEvaluation_mul
             congrFun (Comodule.Hom.coe_toLinearMap (Subcomodule.mulHom N P Q h)) _
           rw [hcoe]
           rw [counitEvaluation_tmul, counitEvaluation_tmul, counitEvaluation_tmul]
-          rw [show Coalgebra.counit (R := k) (A := H)
-              ((Subcomodule.mulHom N P Q h (n ⊗ₜ[k] p) : Q) : H) =
-                Coalgebra.counit (R := k) (A := H) ((n : H) * (p : H)) by
-            rw [Subcomodule.mulHom_tmul]]
+          have hmul : ((Subcomodule.mulHom N P Q h (n ⊗ₜ[k] p) : Q) : H) =
+              (n : H) * (p : H) := by
+            exact Subcomodule.mulHom_tmul N P Q h n p
+          rw [hmul]
           rw [Bialgebra.counit_mul, map_mul]
           ring
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean
@@ -45,6 +45,7 @@ universe u
 variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
   [CommRing A] [Algebra k A]
 
+/-- The comodule morphism from the tensor unit to a finite regular subcomodule containing one. -/
 private noncomputable def regularUnitHom
     (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
     (hOne : (1 : H) ∈ N.1) :
@@ -122,11 +123,12 @@ private theorem map_regularUnitHom_ε_one
 /-- The transported component of a tensor automorphism fixes `1 ⊗ 1` in every finite
 regular subcomodule containing the unit. -/
 @[simp]
-theorem finiteRegularComponent_one_tmul
+theorem scalarExtensionComponent_one_tmul
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
     (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
     (hOne : (1 : H) ∈ N.1) :
-    finiteRegularComponent k H A η N (1 ⊗ₜ[k] ⟨1, hOne⟩) = 1 ⊗ₜ[k] ⟨1, hOne⟩ := by
+    scalarExtensionComponent k H A η (finiteRegularObject k H N)
+        (1 ⊗ₜ[k] ⟨1, hOne⟩) = 1 ⊗ₜ[k] ⟨1, hOne⟩ := by
   let _ : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
   let i := regularUnitHom k H N hOne
   have hnat := η.hom.hom.naturality i
@@ -155,7 +157,7 @@ theorem finiteRegularComponent_one_tmul
   rw [map_regularUnitHom_ε_one] at happ
   let hN := FGComoduleCat.scalarExtensionFunctor_obj k H A
     (finiteRegularObject k H N)
-  rw [finiteRegularComponent_apply]
+  rw [scalarExtensionComponent_apply]
   exact (congrArg (fun z ↦ eqToHom hN z) happ).trans
     ((eqToIso hN).inv_hom_id_apply _)
 
@@ -168,7 +170,8 @@ theorem localFunctional_one
     (N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H))
     (hOne : (1 : H) ∈ N.1) :
     localFunctional k H A η N ⟨1, hOne⟩ = 1 := by
-  rw [localFunctional_apply, finiteRegularComponent_one_tmul]
-  simp
+  rw [localFunctional_apply, scalarExtensionComponent_one_tmul]
+  rw [counitEvaluation_tmul k H A N.1 (1 : A) ⟨1, hOne⟩]
+  simp only [Bialgebra.counit_one, map_one, one_mul]
 
 end TauCeti.Tannaka


### PR DESCRIPTION
This PR proves that the local functional extracted from a tensor automorphism preserves products: when finite regular subcomodules `N` and `P` multiply into `Q`, `localFunctional_mul` identifies the value on `n * p` in `Q` with the product of the values on `n` and `p`.

It advances the exact target in `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 milestone “Tannakian reconstruction: recover `G` from its tensor category of representations,” specifically the tensor-product argument needed to upgrade the reconstructed functional `H →ₗ[k] A` to an algebra-valued point. The dependency edge is that the global functional glued from these local functionals consumes `localFunctional_mul`, together with a finite regular subcomodule containing the relevant products, to prove `map_mul`. This is the most effective current step because finite regular subcomodules are already closed under multiplication on `main`, while the complementary gluing and tensor-unit steps are independently in flight.

After this PR, the Layer 1 milestone still needs to transfer this local product law to the glued global functional, combine it with the unit law to construct an algebra homomorphism, and prove that reconstruction and point action are inverse.

Add `TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean` (184 lines). Refactor `LocalFunctional.lean` by generalizing its transported component from finite regular subcomodules to arbitrary finite comodules and proving its naturality and elementwise tensor law (140 insertions and 52 deletions there). The new multiplication morphism directly wraps the existing `Subcomodule.mulHom`; counit evaluation reuses `TensorProduct.AlgebraTensorModule.distribBaseChange`, `LinearMap.baseChange_tmul`, and `Bialgebra.counit_mul`. No Mathlib infrastructure is vendored. The mathematical formulation follows J. S. Milne, *Algebraic Groups* (2017), §9.4, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tannaka-local-functional-mul"}-->

🤖 Prepared with Codex
