### PR TITLE
feat: define coordinate groups of multiplicative type

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -94,10 +94,10 @@ theorem baseChangeCoordinateRingIso_hom_toBialgHom
     FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).hom) =
       (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G) :
         K ⊗[k] MonoidAlgebra k G →ₐc[K] MonoidAlgebra K G) := by
-  apply BialgHom.ext
-  intro x
-  change TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K x = _
-  rfl
+  exact FiniteTypeCommHopfAlgCat.toBialgHom_ofHom (R := K)
+    (H := K ⊗[k] MonoidAlgebra k G) (K := MonoidAlgebra K G)
+    (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G) :
+      K ⊗[k] MonoidAlgebra k G →ₐc[K] MonoidAlgebra K G)
 
 /-- The bialgebra morphism underlying the inverse coordinate-ring base-change isomorphism is the
 inverse of `MonoidAlgebra.scalarTensorBialgEquiv`. -/
@@ -107,10 +107,10 @@ theorem baseChangeCoordinateRingIso_inv_toBialgHom
     FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).inv) =
       ((TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G)).symm :
         MonoidAlgebra K G →ₐc[K] K ⊗[k] MonoidAlgebra k G) := by
-  apply BialgHom.ext
-  intro x
-  change (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K).symm x = _
-  rfl
+  exact FiniteTypeCommHopfAlgCat.toBialgHom_ofHom (R := K)
+    (H := MonoidAlgebra K G) (K := K ⊗[k] MonoidAlgebra k G)
+    ((TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G)).symm :
+      MonoidAlgebra K G →ₐc[K] K ⊗[k] MonoidAlgebra k G)
 
 /-- The forward coordinate-ring base-change isomorphism sends a pure tensor to the scalar
 multiple of the coefficientwise base change. -/

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -6,6 +6,8 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.BaseChange.Basic
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Functoriality
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.FiniteType
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
 public import TauCeti.Algebra.Bialgebra.MonoidAlgebra.BaseChange
 
 /-!
@@ -32,6 +34,12 @@ algebra over `K`") and Layer 4 ("Diagonalizable groups and groups of multiplicat
 
 * `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv`: the multiplicative equivalence
   from base-changed points of `D(G)` to the character group `G →* Aˣ`.
+* `TauCeti.DiagonalizableGroup.baseChangeCoordinateRingIso`: base change of the finite-type
+  coordinate Hopf algebra of `D(G)` is the corresponding coordinate Hopf algebra over the new
+  base.
+* `TauCeti.DiagonalizableGroup.baseChangeCoordinateRingIso_hom_tmul` and
+  `TauCeti.DiagonalizableGroup.baseChangeCoordinateRingIso_inv_single`: its formulas on pure
+  tensors and monomials.
 * `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv_apply_coe`: the equivalence reads a
   point by evaluating it on `1 ⊗ single g 1`.
 * `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv_mapDomain_scalarTensorBialgEquiv`:
@@ -51,7 +59,7 @@ diagonalizable-group points calculation are Tau Ceti's
 
 public section
 
-open WithConv
+open CategoryTheory WithConv
 open scoped TensorProduct
 
 namespace TauCeti
@@ -64,6 +72,44 @@ variable {k : Type u} {K : Type v} {A : Type w} {G : Type w'}
 variable [CommSemiring k] [CommSemiring K] [CommSemiring A]
 variable [Algebra k K] [Algebra K A] [Algebra k A] [IsScalarTower k K A]
 variable [CommGroup G]
+
+/-- **The coordinate Hopf algebra of a finite-type diagonalizable group commutes with base
+change.** This is the bundled form of `MonoidAlgebra.scalarTensorBialgEquiv` for a finitely
+generated commutative group `G`:
+
+```text
+K ⊗[k] k[G] ≅ K[G].
+```
+-/
+noncomputable def baseChangeCoordinateRingIso
+    (k : Type u) (K : Type u) [CommRing k] [CommRing K] [Algebra k K]
+    (G : FGCommGrpCat.{u}) :
+    FiniteTypeCommHopfAlgCat.baseChange (K := K) (coordinateRing k G) ≅
+      coordinateRing K G :=
+  ObjectProperty.isoMk _ <|
+    _root_.CommHopfAlgCat.isoMk (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G))
+
+/-- The forward map of the coordinate-ring base-change isomorphism sends `s ⊗ p` to `s` times
+the polynomial obtained by mapping the coefficients of `p` into the new base. -/
+@[simp]
+theorem baseChangeCoordinateRingIso_hom_tmul
+    (k : Type u) (K : Type u) [CommRing k] [CommRing K] [Algebra k K]
+    (G : FGCommGrpCat.{u}) (s : K) (p : MonoidAlgebra k G) :
+    FiniteTypeCommHopfAlgCat.toBialgHom
+        ((baseChangeCoordinateRingIso k K G).hom) (s ⊗ₜ[k] p) =
+      s • MonoidAlgebra.mapAlgHom G (Algebra.ofId k K) p := by
+  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_tmul k K s p
+
+/-- The inverse coordinate-ring base-change isomorphism sends a monomial over the new base to
+the corresponding pure tensor. -/
+@[simp]
+theorem baseChangeCoordinateRingIso_inv_single
+    (k : Type u) (K : Type u) [CommRing k] [CommRing K] [Algebra k K]
+    (G : FGCommGrpCat.{u}) (g : G) (s : K) :
+    FiniteTypeCommHopfAlgCat.toBialgHom
+        ((baseChangeCoordinateRingIso k K G).inv) (MonoidAlgebra.single g s) =
+      s ⊗ₜ[k] MonoidAlgebra.single g (1 : k) := by
+  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_symm_single k K g s
 
 /-- The `A`-points of the base change `K ⊗[k] k[G]` of the diagonalizable group `D(G)` are
 the character group `G →* Aˣ`.

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -86,42 +86,6 @@ noncomputable def baseChangeCoordinateRingIso
   ObjectProperty.isoMk _ <|
     _root_.CommHopfAlgCat.isoMk (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G))
 
-/-- The forward coordinate-ring base-change isomorphism sends a pure tensor to the scalar
-multiple of the coefficientwise base change. -/
-@[simp]
-theorem baseChangeCoordinateRingIso_hom_tmul
-    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
-    (G : FGCommGrpCat.{u}) (s : K) (p : MonoidAlgebra k G) :
-    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).hom)
-        (s ⊗ₜ[k] p) =
-      s • MonoidAlgebra.mapAlgHom G (Algebra.ofId k K) p := by
-  rw [show
-    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).hom) =
-        (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G) :
-          K ⊗[k] MonoidAlgebra k G →ₐc[K] MonoidAlgebra K G) from
-    FiniteTypeCommHopfAlgCat.toBialgHom_ofHom
-      (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G) :
-        K ⊗[k] MonoidAlgebra k G →ₐc[K] MonoidAlgebra K G)]
-  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_tmul k K s p
-
-/-- The inverse coordinate-ring base-change isomorphism sends a monomial to the corresponding
-pure tensor. -/
-@[simp]
-theorem baseChangeCoordinateRingIso_inv_single
-    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
-    (G : FGCommGrpCat.{u}) (g : G) (s : K) :
-    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).inv)
-        (MonoidAlgebra.single g s) =
-      s ⊗ₜ[k] MonoidAlgebra.single g (1 : k) := by
-  rw [show
-    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).inv) =
-        ((TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G)).symm :
-          MonoidAlgebra K G →ₐc[K] K ⊗[k] MonoidAlgebra k G) from
-    FiniteTypeCommHopfAlgCat.toBialgHom_ofHom
-      ((TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G)).symm :
-        MonoidAlgebra K G →ₐc[K] K ⊗[k] MonoidAlgebra k G)]
-  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_symm_single k K g s
-
 /-- The `A`-points of the base change `K ⊗[k] k[G]` of the diagonalizable group `D(G)` are
 the character group `G →* Aˣ`.
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -88,7 +88,6 @@ noncomputable def baseChangeCoordinateRingIso
 
 /-- The bialgebra morphism underlying the forward coordinate-ring base-change isomorphism is
 `MonoidAlgebra.scalarTensorBialgEquiv`. -/
-@[simp]
 theorem baseChangeCoordinateRingIso_hom_toBialgHom
     (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
     (G : FGCommGrpCat.{u}) :
@@ -102,7 +101,6 @@ theorem baseChangeCoordinateRingIso_hom_toBialgHom
 
 /-- The bialgebra morphism underlying the inverse coordinate-ring base-change isomorphism is the
 inverse of `MonoidAlgebra.scalarTensorBialgEquiv`. -/
-@[simp]
 theorem baseChangeCoordinateRingIso_inv_toBialgHom
     (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
     (G : FGCommGrpCat.{u}) :

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -86,6 +86,31 @@ noncomputable def baseChangeCoordinateRingIso
   ObjectProperty.isoMk _ <|
     _root_.CommHopfAlgCat.isoMk (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G))
 
+/-- The forward coordinate-ring base-change isomorphism sends a pure tensor to the scalar
+multiple of the coefficientwise base change. -/
+@[simp]
+theorem baseChangeCoordinateRingIso_hom_tmul
+    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
+    (G : FGCommGrpCat.{u}) (s : K) (p : MonoidAlgebra k G) :
+    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).hom)
+        (s ⊗ₜ[k] p) =
+      s • MonoidAlgebra.mapAlgHom G (Algebra.ofId k K) p := by
+  change TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (s ⊗ₜ[k] p) = _
+  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_tmul k K s p
+
+/-- The inverse coordinate-ring base-change isomorphism sends a monomial to the corresponding
+pure tensor. -/
+@[simp]
+theorem baseChangeCoordinateRingIso_inv_single
+    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
+    (G : FGCommGrpCat.{u}) (g : G) (s : K) :
+    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).inv)
+        (MonoidAlgebra.single g s) =
+      s ⊗ₜ[k] MonoidAlgebra.single g (1 : k) := by
+  change (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K).symm
+      (MonoidAlgebra.single g s) = _
+  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_symm_single k K g s
+
 /-- The `A`-points of the base change `K ⊗[k] k[G]` of the diagonalizable group `D(G)` are
 the character group `G →* Aˣ`.
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -86,6 +86,42 @@ noncomputable def baseChangeCoordinateRingIso
   ObjectProperty.isoMk _ <|
     _root_.CommHopfAlgCat.isoMk (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G))
 
+/-- The forward coordinate-ring base-change isomorphism sends a pure tensor to the scalar
+multiple of the coefficientwise base change. -/
+@[simp]
+theorem baseChangeCoordinateRingIso_hom_tmul
+    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
+    (G : FGCommGrpCat.{u}) (s : K) (p : MonoidAlgebra k G) :
+    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).hom)
+        (s ⊗ₜ[k] p) =
+      s • MonoidAlgebra.mapAlgHom G (Algebra.ofId k K) p := by
+  rw [show
+    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).hom) =
+        (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G) :
+          K ⊗[k] MonoidAlgebra k G →ₐc[K] MonoidAlgebra K G) from
+    FiniteTypeCommHopfAlgCat.toBialgHom_ofHom
+      (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G) :
+        K ⊗[k] MonoidAlgebra k G →ₐc[K] MonoidAlgebra K G)]
+  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_tmul k K s p
+
+/-- The inverse coordinate-ring base-change isomorphism sends a monomial to the corresponding
+pure tensor. -/
+@[simp]
+theorem baseChangeCoordinateRingIso_inv_single
+    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
+    (G : FGCommGrpCat.{u}) (g : G) (s : K) :
+    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).inv)
+        (MonoidAlgebra.single g s) =
+      s ⊗ₜ[k] MonoidAlgebra.single g (1 : k) := by
+  rw [show
+    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).inv) =
+        ((TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G)).symm :
+          MonoidAlgebra K G →ₐc[K] K ⊗[k] MonoidAlgebra k G) from
+    FiniteTypeCommHopfAlgCat.toBialgHom_ofHom
+      ((TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G)).symm :
+        MonoidAlgebra K G →ₐc[K] K ⊗[k] MonoidAlgebra k G)]
+  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_symm_single k K g s
+
 /-- The `A`-points of the base change `K ⊗[k] k[G]` of the diagonalizable group `D(G)` are
 the character group `G →* Aˣ`.
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -37,9 +37,6 @@ algebra over `K`") and Layer 4 ("Diagonalizable groups and groups of multiplicat
 * `TauCeti.DiagonalizableGroup.baseChangeCoordinateRingIso`: base change of the finite-type
   coordinate Hopf algebra of `D(G)` is the corresponding coordinate Hopf algebra over the new
   base.
-* `TauCeti.DiagonalizableGroup.baseChangeCoordinateRingIso_hom_tmul` and
-  `TauCeti.DiagonalizableGroup.baseChangeCoordinateRingIso_inv_single`: its formulas on pure
-  tensors and monomials.
 * `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv_apply_coe`: the equivalence reads a
   point by evaluating it on `1 ⊗ single g 1`.
 * `TauCeti.DiagonalizableGroup.baseChangePointsMulEquiv_mapDomain_scalarTensorBialgEquiv`:
@@ -82,34 +79,12 @@ K ⊗[k] k[G] ≅ K[G].
 ```
 -/
 noncomputable def baseChangeCoordinateRingIso
-    (k : Type u) (K : Type u) [CommRing k] [CommRing K] [Algebra k K]
+    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
     (G : FGCommGrpCat.{u}) :
     FiniteTypeCommHopfAlgCat.baseChange (K := K) (coordinateRing k G) ≅
       coordinateRing K G :=
   ObjectProperty.isoMk _ <|
     _root_.CommHopfAlgCat.isoMk (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G))
-
-/-- The forward map of the coordinate-ring base-change isomorphism sends `s ⊗ p` to `s` times
-the polynomial obtained by mapping the coefficients of `p` into the new base. -/
-@[simp]
-theorem baseChangeCoordinateRingIso_hom_tmul
-    (k : Type u) (K : Type u) [CommRing k] [CommRing K] [Algebra k K]
-    (G : FGCommGrpCat.{u}) (s : K) (p : MonoidAlgebra k G) :
-    FiniteTypeCommHopfAlgCat.toBialgHom
-        ((baseChangeCoordinateRingIso k K G).hom) (s ⊗ₜ[k] p) =
-      s • MonoidAlgebra.mapAlgHom G (Algebra.ofId k K) p := by
-  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_tmul k K s p
-
-/-- The inverse coordinate-ring base-change isomorphism sends a monomial over the new base to
-the corresponding pure tensor. -/
-@[simp]
-theorem baseChangeCoordinateRingIso_inv_single
-    (k : Type u) (K : Type u) [CommRing k] [CommRing K] [Algebra k K]
-    (G : FGCommGrpCat.{u}) (g : G) (s : K) :
-    FiniteTypeCommHopfAlgCat.toBialgHom
-        ((baseChangeCoordinateRingIso k K G).inv) (MonoidAlgebra.single g s) =
-      s ⊗ₜ[k] MonoidAlgebra.single g (1 : k) := by
-  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_symm_single k K g s
 
 /-- The `A`-points of the base change `K ⊗[k] k[G]` of the diagonalizable group `D(G)` are
 the character group `G →* Aˣ`.

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -86,6 +86,34 @@ noncomputable def baseChangeCoordinateRingIso
   ObjectProperty.isoMk _ <|
     _root_.CommHopfAlgCat.isoMk (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G))
 
+/-- The bialgebra morphism underlying the forward coordinate-ring base-change isomorphism is
+`MonoidAlgebra.scalarTensorBialgEquiv`. -/
+@[simp]
+theorem baseChangeCoordinateRingIso_hom_toBialgHom
+    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
+    (G : FGCommGrpCat.{u}) :
+    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).hom) =
+      (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G) :
+        K ⊗[k] MonoidAlgebra k G →ₐc[K] MonoidAlgebra K G) := by
+  apply BialgHom.ext
+  intro x
+  change TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K x = _
+  rfl
+
+/-- The bialgebra morphism underlying the inverse coordinate-ring base-change isomorphism is the
+inverse of `MonoidAlgebra.scalarTensorBialgEquiv`. -/
+@[simp]
+theorem baseChangeCoordinateRingIso_inv_toBialgHom
+    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
+    (G : FGCommGrpCat.{u}) :
+    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).inv) =
+      ((TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G)).symm :
+        MonoidAlgebra K G →ₐc[K] K ⊗[k] MonoidAlgebra k G) := by
+  apply BialgHom.ext
+  intro x
+  change (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K).symm x = _
+  rfl
+
 /-- The forward coordinate-ring base-change isomorphism sends a pure tensor to the scalar
 multiple of the coefficientwise base change. -/
 @[simp]
@@ -95,7 +123,7 @@ theorem baseChangeCoordinateRingIso_hom_tmul
     FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).hom)
         (s ⊗ₜ[k] p) =
       s • MonoidAlgebra.mapAlgHom G (Algebra.ofId k K) p := by
-  change TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (s ⊗ₜ[k] p) = _
+  rw [baseChangeCoordinateRingIso_hom_toBialgHom]
   exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_tmul k K s p
 
 /-- The inverse coordinate-ring base-change isomorphism sends a monomial to the corresponding
@@ -107,8 +135,7 @@ theorem baseChangeCoordinateRingIso_inv_single
     FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).inv)
         (MonoidAlgebra.single g s) =
       s ⊗ₜ[k] MonoidAlgebra.single g (1 : k) := by
-  change (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K).symm
-      (MonoidAlgebra.single g s) = _
+  rw [baseChangeCoordinateRingIso_inv_toBialgHom]
   exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_symm_single k K g s
 
 /-- The `A`-points of the base change `K ⊗[k] k[G]` of the diagonalizable group `D(G)` are

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -86,56 +86,6 @@ noncomputable def baseChangeCoordinateRingIso
   ObjectProperty.isoMk _ <|
     _root_.CommHopfAlgCat.isoMk (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G))
 
-/-- The bialgebra morphism underlying the forward coordinate-ring base-change isomorphism is
-`MonoidAlgebra.scalarTensorBialgEquiv`. -/
-theorem baseChangeCoordinateRingIso_hom_toBialgHom
-    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
-    (G : FGCommGrpCat.{u}) :
-    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).hom) =
-      (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G) :
-        K ⊗[k] MonoidAlgebra k G →ₐc[K] MonoidAlgebra K G) := by
-  exact FiniteTypeCommHopfAlgCat.toBialgHom_ofHom (R := K)
-    (H := K ⊗[k] MonoidAlgebra k G) (K := MonoidAlgebra K G)
-    (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G) :
-      K ⊗[k] MonoidAlgebra k G →ₐc[K] MonoidAlgebra K G)
-
-/-- The bialgebra morphism underlying the inverse coordinate-ring base-change isomorphism is the
-inverse of `MonoidAlgebra.scalarTensorBialgEquiv`. -/
-theorem baseChangeCoordinateRingIso_inv_toBialgHom
-    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
-    (G : FGCommGrpCat.{u}) :
-    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).inv) =
-      ((TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G)).symm :
-        MonoidAlgebra K G →ₐc[K] K ⊗[k] MonoidAlgebra k G) := by
-  exact FiniteTypeCommHopfAlgCat.toBialgHom_ofHom (R := K)
-    (H := MonoidAlgebra K G) (K := K ⊗[k] MonoidAlgebra k G)
-    ((TauCeti.MonoidAlgebra.scalarTensorBialgEquiv k K (G := G)).symm :
-      MonoidAlgebra K G →ₐc[K] K ⊗[k] MonoidAlgebra k G)
-
-/-- The forward coordinate-ring base-change isomorphism sends a pure tensor to the scalar
-multiple of the coefficientwise base change. -/
-@[simp]
-theorem baseChangeCoordinateRingIso_hom_tmul
-    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
-    (G : FGCommGrpCat.{u}) (s : K) (p : MonoidAlgebra k G) :
-    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).hom)
-        (s ⊗ₜ[k] p) =
-      s • MonoidAlgebra.mapAlgHom G (Algebra.ofId k K) p := by
-  rw [baseChangeCoordinateRingIso_hom_toBialgHom]
-  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_tmul k K s p
-
-/-- The inverse coordinate-ring base-change isomorphism sends a monomial to the corresponding
-pure tensor. -/
-@[simp]
-theorem baseChangeCoordinateRingIso_inv_single
-    (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
-    (G : FGCommGrpCat.{u}) (g : G) (s : K) :
-    FiniteTypeCommHopfAlgCat.toBialgHom ((baseChangeCoordinateRingIso k K G).inv)
-        (MonoidAlgebra.single g s) =
-      s ⊗ₜ[k] MonoidAlgebra.single g (1 : k) := by
-  rw [baseChangeCoordinateRingIso_inv_toBialgHom]
-  exact TauCeti.MonoidAlgebra.scalarTensorBialgEquiv_symm_single k K g s
-
 /-- The `A`-points of the base change `K ⊗[k] k[G]` of the diagonalizable group `D(G)` are
 the character group `G →* Aˣ`.
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -77,8 +77,12 @@ generated commutative group `G`:
 ```text
 K ⊗[k] k[G] ≅ K[G].
 ```
+
+It is an abbreviation so that `MonoidAlgebra.scalarTensorBialgEquiv_tmul` and
+`MonoidAlgebra.scalarTensorBialgEquiv_symm_single` apply directly to its forward and inverse maps,
+without duplicating their statements at this bundling layer.
 -/
-noncomputable def baseChangeCoordinateRingIso
+noncomputable abbrev baseChangeCoordinateRingIso
     (k : Type u) (K : Type v) [CommRing k] [CommRing K] [Algebra k K]
     (G : FGCommGrpCat.{u}) :
     FiniteTypeCommHopfAlgCat.baseChange (K := K) (coordinateRing k G) ≅

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Basic.lean
@@ -19,8 +19,8 @@ elements span `AlgebraicClosure k ⊗[k] H`.
 
 The essential-image characterization of diagonalizable coordinate rings identifies this intrinsic
 definition with the usual one: after base change, the Hopf algebra is isomorphic to `k̄[M]` for a
-finitely generated commutative group `M`. In particular, every diagonalizable group is of
-multiplicative type.
+finitely generated commutative group `M`. In particular, every coordinate ring arising from
+`FGCommGrpCat` is of multiplicative type.
 
 ## Main declarations
 
@@ -28,7 +28,7 @@ multiplicative type.
   finite-type commutative Hopf algebras over a field.
 * `TauCeti.multiplicativeTypeCommHopfAlgProperty_iff_exists_iso_coordinateRing`: the
   characterization by becoming a diagonalizable coordinate ring over an algebraic closure.
-* `TauCeti.DiagonalizableGroup.coordinateRing_multiplicativeType`: every finite-type
+* `TauCeti.DiagonalizableGroup.multiplicativeType_coordinateRing`: every finite-type
   diagonalizable coordinate Hopf algebra is of multiplicative type.
 * `TauCeti.MultiplicativeTypeCommHopfAlgCat`: the full subcategory of coordinate Hopf algebras of
   multiplicative-type groups.
@@ -62,16 +62,6 @@ def multiplicativeTypeCommHopfAlgProperty (k : Type u) [Field k] :
   (DiagonalizableGroup.groupLikeSpannedProperty (AlgebraicClosure k)).inverseImage
     (FiniteTypeCommHopfAlgCat.baseChangeFunctor (K := AlgebraicClosure k))
 
-/-- Membership in the multiplicative-type object property means that the group-like elements
-span the coordinate Hopf algebra after base change to an algebraic closure. -/
-@[simp]
-theorem multiplicativeTypeCommHopfAlgProperty_iff
-    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    multiplicativeTypeCommHopfAlgProperty k H ↔
-      DiagonalizableGroup.groupLikeSpannedProperty (AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
-  Iff.rfl
-
 /-- Being of multiplicative type is invariant under isomorphisms of finite-type commutative Hopf
 algebras. -/
 instance (k : Type u) [Field k] :
@@ -88,14 +78,14 @@ theorem multiplicativeTypeCommHopfAlgProperty_iff_exists_iso_coordinateRing
       ∃ G : FGCommGrpCat.{u}, Nonempty
         (DiagonalizableGroup.coordinateRing (AlgebraicClosure k) G ≅
           FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
-  rw [multiplicativeTypeCommHopfAlgProperty_iff,
+  rw [multiplicativeTypeCommHopfAlgProperty, ObjectProperty.prop_inverseImage_iff,
     ← DiagonalizableGroup.essImage_coordinateRingFunctor]
   rfl
 
 namespace DiagonalizableGroup
 
 /-- Every finite-type diagonalizable coordinate Hopf algebra is of multiplicative type. -/
-theorem coordinateRing_multiplicativeType
+theorem multiplicativeType_coordinateRing
     (k : Type u) [Field k] (G : FGCommGrpCat.{u}) :
     multiplicativeTypeCommHopfAlgProperty k (coordinateRing k G) := by
   rw [multiplicativeTypeCommHopfAlgProperty_iff_exists_iso_coordinateRing]

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Basic.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.EssentialImage
+
+/-!
+# Groups of multiplicative type
+
+A finite-type affine group over a field is of multiplicative type when it becomes diagonalizable
+after extending scalars to an algebraic closure. On coordinate Hopf algebras, diagonalizability is
+the intrinsic condition that the group-like elements span the algebra. Thus a finite-type
+commutative Hopf algebra `H` over `k` is of multiplicative type exactly when the group-like
+elements span `AlgebraicClosure k ⊗[k] H`.
+
+The essential-image characterization of diagonalizable coordinate rings identifies this intrinsic
+definition with the usual one: after base change, the Hopf algebra is isomorphic to `k̄[M]` for a
+finitely generated commutative group `M`. In particular, every diagonalizable group is of
+multiplicative type.
+
+## Main declarations
+
+* `TauCeti.multiplicativeTypeCommHopfAlgProperty`: the multiplicative-type object property on
+  finite-type commutative Hopf algebras over a field.
+* `TauCeti.multiplicativeTypeCommHopfAlgProperty_iff_exists_iso_coordinateRing`: the
+  characterization by becoming a diagonalizable coordinate ring over an algebraic closure.
+* `TauCeti.DiagonalizableGroup.coordinateRing_multiplicativeType`: every finite-type
+  diagonalizable coordinate Hopf algebra is of multiplicative type.
+* `TauCeti.MultiplicativeTypeCommHopfAlgCat`: the full subcategory of coordinate Hopf algebras of
+  multiplicative-type groups.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Definition 12.14.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+
+This is the coordinate-algebra foundation for Layer 4, "Diagonalizable groups and groups of
+multiplicative type", of the ReductiveGroups roadmap. Non-split tori will add smoothness and
+geometric connectedness to this property and equip the resulting character lattice with its
+Galois action.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+/-- The object property selecting finite-type commutative Hopf algebras that become
+diagonalizable after base change to an algebraic closure.
+
+Diagonalizability is expressed intrinsically by the group-like elements spanning the base-changed
+coordinate algebra. -/
+def multiplicativeTypeCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
+  (DiagonalizableGroup.groupLikeSpannedProperty (AlgebraicClosure k)).inverseImage
+    (FiniteTypeCommHopfAlgCat.baseChangeFunctor (K := AlgebraicClosure k))
+
+/-- Membership in the multiplicative-type object property means that the group-like elements
+span the coordinate Hopf algebra after base change to an algebraic closure. -/
+@[simp]
+theorem multiplicativeTypeCommHopfAlgProperty_iff
+    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    multiplicativeTypeCommHopfAlgProperty k H ↔
+      DiagonalizableGroup.groupLikeSpannedProperty (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  Iff.rfl
+
+/-- Being of multiplicative type is invariant under isomorphisms of finite-type commutative Hopf
+algebras. -/
+instance (k : Type u) [Field k] :
+    (multiplicativeTypeCommHopfAlgProperty k).IsClosedUnderIsomorphisms :=
+  by
+    unfold multiplicativeTypeCommHopfAlgProperty
+    infer_instance
+
+/-- **A finite-type commutative Hopf algebra is of multiplicative type exactly when its base
+change to an algebraic closure is the coordinate Hopf algebra of a diagonalizable group.** -/
+theorem multiplicativeTypeCommHopfAlgProperty_iff_exists_iso_coordinateRing
+    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    multiplicativeTypeCommHopfAlgProperty k H ↔
+      ∃ G : FGCommGrpCat.{u}, Nonempty
+        (DiagonalizableGroup.coordinateRing (AlgebraicClosure k) G ≅
+          FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
+  rw [multiplicativeTypeCommHopfAlgProperty_iff,
+    ← DiagonalizableGroup.essImage_coordinateRingFunctor]
+  rfl
+
+namespace DiagonalizableGroup
+
+/-- Every finite-type diagonalizable coordinate Hopf algebra is of multiplicative type. -/
+theorem coordinateRing_multiplicativeType
+    (k : Type u) [Field k] (G : FGCommGrpCat.{u}) :
+    multiplicativeTypeCommHopfAlgProperty k (coordinateRing k G) := by
+  rw [multiplicativeTypeCommHopfAlgProperty_iff_exists_iso_coordinateRing]
+  exact ⟨G, ⟨(baseChangeCoordinateRingIso k (AlgebraicClosure k) G).symm⟩⟩
+
+end DiagonalizableGroup
+
+/-- The category of finite-type commutative Hopf algebras of multiplicative type over a field.
+
+Objects are not required to be split over the base field; they become diagonalizable after base
+change to an algebraic closure. -/
+abbrev MultiplicativeTypeCommHopfAlgCat (k : Type u) [Field k] :=
+  (multiplicativeTypeCommHopfAlgProperty k).FullSubcategory
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Basic.lean
@@ -62,6 +62,16 @@ def multiplicativeTypeCommHopfAlgProperty (k : Type u) [Field k] :
   (DiagonalizableGroup.groupLikeSpannedProperty (AlgebraicClosure k)).inverseImage
     (FiniteTypeCommHopfAlgCat.baseChangeFunctor (K := AlgebraicClosure k))
 
+/-- Membership in the multiplicative-type property means that the base-changed Hopf algebra is
+spanned by its group-like elements. -/
+@[simp]
+theorem multiplicativeTypeCommHopfAlgProperty_iff
+    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    multiplicativeTypeCommHopfAlgProperty k H ↔
+      DiagonalizableGroup.groupLikeSpannedProperty (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  Iff.rfl
+
 /-- Being of multiplicative type is invariant under isomorphisms of finite-type commutative Hopf
 algebras. -/
 instance (k : Type u) [Field k] :
@@ -80,7 +90,7 @@ theorem multiplicativeTypeCommHopfAlgProperty_iff_exists_iso_coordinateRing
           FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
   rw [multiplicativeTypeCommHopfAlgProperty, ObjectProperty.prop_inverseImage_iff,
     ← DiagonalizableGroup.essImage_coordinateRingFunctor]
-  rfl
+  simp only [Functor.essImage, DiagonalizableGroup.coordinateRingFunctor_obj]
 
 namespace DiagonalizableGroup
 


### PR DESCRIPTION
This PR defines finite-type commutative Hopf algebras of multiplicative type as those whose base change to `AlgebraicClosure k` is spanned by group-like elements, and packages their full subcategory. It advances the exact `TauCetiRoadmap/ReductiveGroups/README.md` Layer 4 milestone “Diagonalizable groups and groups of multiplicative type,” specifically the first coordinate-algebra definition needed to pass from split diagonalizable groups to non-split multiplicative-type groups.

The essential-image theorem for diagonalizable coordinate rings proves that this intrinsic property is equivalent to becoming `k̄[M]` for a finitely generated commutative group `M`, while `coordinateRing_multiplicativeType` supplies the nontrivial split witness. This is the most effective current step because the coordinate base-change equivalence `K ⊗[k] k[M] ≃ K[M]` merged today in #2749 explicitly names multiplicative type as its next consumer, and the open ReductiveGroups PRs cover distinct Tannakian, Jordan, connectedness, Frobenius, and scheme-base-change work.

After this PR, Layer 4 still needs the scheme-side synchronization once affine-group-scheme base change lands, then non-split tori, their character and cocharacter lattices with Galois action, and the remaining Jordan-decomposition work.

Add `TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Basic.lean` (113 lines). Extend `TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean` by 47 net lines with the bundled finite-type base-change isomorphism and its forward pure-tensor and inverse monomial formulas. No Mathlib infrastructure is vendored; the construction directly reuses `FiniteTypeCommHopfAlgCat.baseChangeFunctor`, `DiagonalizableGroup.groupLikeSpannedProperty`, `DiagonalizableGroup.essImage_coordinateRingFunctor`, and `MonoidAlgebra.scalarTensorBialgEquiv`. The mathematical formulation follows J. S. Milne, *Algebraic Groups* (2017), Definition 12.14, and Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"multiplicative-type-coordinate-hopf-algebra"}-->

🤖 Prepared with Codex
