### PR TITLE
chore: bump the merge workflow pins to a66b04d9

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-only.yml@eeed9637d7e2af319a04de8120b35f0c52318f0d
+    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-only.yml@a66b04d97721565b13c8abe07f750fb1d2959ad5
     with:
       pr: ${{ needs.resolve.outputs.pr }}
       review_ref: eeed9637d7e2af319a04de8120b35f0c52318f0d

--- a/.github/workflows/merge-sweep.yml
+++ b/.github/workflows/merge-sweep.yml
@@ -32,7 +32,7 @@ jobs:
   sweep:
     # Pinned to a TauCetiReview commit; bump deliberately. The reusable workflow receives the App
     # secrets, so a floating @main would be a supply-chain risk.
-    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-sweep.yml@eeed9637d7e2af319a04de8120b35f0c52318f0d
+    uses: TauCetiProject/TauCetiReview/.github/workflows/merge-sweep.yml@a66b04d97721565b13c8abe07f750fb1d2959ad5
     with:
       dry_run: ${{ inputs.dry-run || false }}
       review_ref: eeed9637d7e2af319a04de8120b35f0c52318f0d


### PR DESCRIPTION
This PR moves the TauCetiReview pins in `auto-merge.yml` and `merge-sweep.yml` from `eeed9637` to [`a66b04d9`](https://github.com/TauCetiProject/TauCetiReview/commit/a66b04d97721565b13c8abe07f750fb1d2959ad5), which is what actually turns the merge-queue reservation on: the workflows call a pinned commit rather than TauCetiReview's `main`, so [TauCetiReview#115](https://github.com/TauCetiProject/TauCetiReview/pull/115) has been merged but dormant.

The pin spans ten commits, but only two of them touch code these workflows execute: #115 itself, and [#108 "fix: remove lakefile auto-merge exception"](https://github.com/TauCetiProject/TauCetiReview/pull/108), which tightens auto-merge by removing an exception rather than widening it. The other eight are review-side changes that the merge path never calls.

With this in place, a PR moving `lake-manifest.json` or `lean-toolchain` takes the merge queue to itself while it is enqueued: the queue is cleared before it is enqueued, other PRs are held out while it builds, and the reservation lifts on its own when it merges or is evicted. That is the fix for the eviction loop [#2739](https://github.com/TauCetiProject/TauCeti/pull/2739) hit this morning, when roughly ten PRs merged underneath the bump's rebuild and broke it, and it is item 3 of [#2026](https://github.com/TauCetiProject/TauCeti/issues/2026).

The first pin-moving PR after this lands is the end-to-end test; the reservation logic itself is unit-tested in TauCetiReview and was dry-run against this repo with no bump queued, reproducing the sweep's existing decisions exactly.

Roadmap: none

🤖 Prepared with Claude Code