### PR TITLE
feat: prove the Tannakian global unit law

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/GlobalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/GlobalFunctional.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.LocalFunctional
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.Unit
 public import TauCeti.Algebra.Coalgebra.Subcomodule.DirectedUnion
 
 /-!
@@ -30,6 +30,7 @@ next show that `g_η` preserves multiplication and one, upgrading it to an algeb
   subcomodule is the prescribed local functional.
 * `TauCeti.Tannaka.globalFunctional_unique`: the restriction property uniquely characterizes
   the global functional.
+* `TauCeti.Tannaka.globalFunctional_one`: the global functional preserves the unit.
 * `TauCeti.Tannaka.globalFunctional_fgPointTensorIso`: a point-induced tensor automorphism
   recovers the point's underlying linear map.
 
@@ -91,6 +92,23 @@ theorem globalFunctional_unique
   Subcomodule.finiteSubcomoduleLift_unique
     (fun N ↦ localFunctional k H A η N)
     (localFunctional_eq_comp_inclusion k H A η) g hg
+
+/-- The global functional extracted from a tensor automorphism sends the unit of the coordinate
+Hopf algebra to the unit of the value algebra. -/
+@[simp high]
+theorem globalFunctional_one
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) :
+    globalFunctional k H A η 1 = 1 := by
+  obtain ⟨N, hNfinite, hOne⟩ :=
+    Subcomodule.exists_finite_subcomodule_mem (R := k) (C := H) (M := H) (1 : H)
+  let N' : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H) :=
+    ⟨N, Subcomodule.mem_finiteSubcomodules.mpr hNfinite⟩
+  calc
+    globalFunctional k H A η 1 =
+        globalFunctional k H A η (⟨1, hOne⟩ : N'.1) := rfl
+    _ = localFunctional k H A η N' ⟨1, hOne⟩ :=
+      globalFunctional_apply k H A η N' ⟨1, hOne⟩
+    _ = 1 := localFunctional_one k H A η N' hOne
 
 /-- The global functional associated to the tensor automorphism induced by an algebra-valued
 point is the underlying linear map of that point. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/GlobalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/GlobalFunctional.lean
@@ -19,9 +19,10 @@ cover `H`, the local functionals glue uniquely to a linear map
 g_η : H → A.
 ```
 
-This file performs that gluing and proves that a tensor automorphism arising from an
-`A`-valued point recovers the underlying linear map of that point. Tensor compatibility will
-next show that `g_η` preserves multiplication and one, upgrading it to an algebra-valued point.
+This file performs that gluing, proves that `g_η` preserves one, and proves that a tensor
+automorphism arising from an `A`-valued point recovers the underlying linear map of that point.
+Tensor compatibility will next show that `g_η` preserves multiplication, upgrading it to an
+algebra-valued point.
 
 ## Main declarations
 
@@ -105,7 +106,8 @@ theorem globalFunctional_one
     ⟨N, Subcomodule.mem_finiteSubcomodules.mpr hNfinite⟩
   calc
     globalFunctional k H A η 1 =
-        globalFunctional k H A η (⟨1, hOne⟩ : N'.1) := rfl
+        globalFunctional k H A η (⟨1, hOne⟩ : N'.1) :=
+      congrArg (globalFunctional k H A η) (Subtype.coe_mk 1 hOne).symm
     _ = localFunctional k H A η N' ⟨1, hOne⟩ :=
       globalFunctional_apply k H A η N' ⟨1, hOne⟩
     _ = 1 := localFunctional_one k H A η N' hOne


### PR DESCRIPTION
This PR proves that the global functional reconstructed from a tensor automorphism sends `1 : H` to `1 : A`. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 milestone **“Tannakian reconstruction: recover `G` from its tensor category of representations”**, specifically the global tensor-unit law needed to upgrade the glued linear functional `H →ₗ[k] A` to an algebra-valued point.

The exact dependency edge is that the reconstructed algebra homomorphism consumes `globalFunctional_one` as its `map_one` proof, alongside the global multiplicativity proof supplied by the independently in-flight tensor-product lane. This is the most effective distinct current step because `globalFunctional` and `localFunctional_one` are now on `main`, while open PR #2765 owns local multiplicativity and no open PR transfers the unit law to the glued functional. After this PR, the milestone still needs global multiplicativity, the algebra-homomorphism packaging, the componentwise inverse theorem, and the resulting equivalence between points and tensor automorphisms.

Update `TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/GlobalFunctional.lean` by 19 insertions and one import replacement. The proof chooses a finite regular subcomodule containing `1`, uses `globalFunctional_apply` to restrict the glued functional, and applies `localFunctional_one`; no Mathlib infrastructure or external formalization is vendored. The mathematical formulation follows J. S. Milne, *Algebraic Groups* (2017), §9.4, already cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tannaka-global-functional-one"}-->

🤖 Prepared with Codex
