### PR TITLE
feat(Quadratic): the field norm on a quadratic number field, positive in the imaginary case

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -365,7 +365,7 @@ theorem exists_smul_quadraticTwistOf_trace_norm_eq {θ θ' : L}
     ∃ C : VariableChange K,
       C • E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)
         = E.quadraticTwistOf (Algebra.trace K L θ') (Algebra.norm K θ') := by
-  obtain ⟨a, b, ha, rfl⟩ := exists_eq_algebraMap_add_algebraMap_mul K L hθ hθ'
+  obtain ⟨a, b, ha, rfl⟩ := exists_ne_zero_eq_algebraMap_add_algebraMap_mul K L hθ hθ'
   simp only [trace_algebraMap_add_algebraMap_mul K L a b θ,
     norm_algebraMap_add_algebraMap_mul K L a b θ]
   exact E.exists_smul_quadraticTwistOf_eq _ _ b (isUnit_iff_ne_zero.mpr ha)

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -81,7 +81,7 @@ theorem Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul [Se
     [Algebra K L] [Algebra.IsQuadraticExtension K L] {θ : L}
     (hθ : θ ∉ Set.range (algebraMap K L)) (x : L) :
     ∃ a b : K, x = algebraMap K L b + algebraMap K L a * θ := by
-  letI : Ring L := Algebra.semiringToRing K
+  let _ : Ring L := Algebra.semiringToRing K
   have h2 := Algebra.IsQuadraticExtension.finrank_eq_two K L
   have : Nontrivial L := Module.nontrivial_of_finrank_pos (R := K) (by rw [h2]; norm_num)
   have hli := linearIndependent_one_of_notMem_range_algebraMap K L hθ

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -92,6 +92,18 @@ theorem exists_eq_algebraMap_add_algebraMap_mul {θ θ' : L}
   · rw [← hcd, hd, zero_smul, add_zero, Algebra.algebraMap_eq_smul_one]
   · rw [← hcd, Algebra.smul_def, Algebra.smul_def, mul_one]
 
+/-- **Every element of a quadratic extension is `b + aθ`** for a fixed generator `θ`: the basis
+`1, θ` spans `L` over `K`. Unlike `exists_eq_algebraMap_add_algebraMap_mul`, the element need not
+itself be a generator, so the `θ`-coefficient may vanish when the element is in the base field. -/
+theorem exists_eq_algebraMap_add_algebraMap_mul' {θ : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) (x : L) :
+    ∃ a b : K, x = algebraMap K L b + algebraMap K L a * θ := by
+  by_cases hx : x ∈ Set.range (algebraMap K L)
+  · obtain ⟨b, hb⟩ := hx
+    exact ⟨0, b, by rw [← hb]; simp⟩
+  · obtain ⟨a, b, _, hab⟩ := exists_eq_algebraMap_add_algebraMap_mul K L hθ hx
+    exact ⟨a, b, hab⟩
+
 end Algebra.IsQuadraticExtension
 
 end

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -103,16 +103,10 @@ two generators differ by `θ' = b + aθ` with `a ≠ 0`. -/
 theorem exists_eq_algebraMap_add_algebraMap_mul {θ θ' : L}
     (hθ : θ ∉ Set.range (algebraMap K L)) (hθ' : θ' ∉ Set.range (algebraMap K L)) :
     ∃ a b : K, a ≠ 0 ∧ θ' = algebraMap K L b + algebraMap K L a * θ := by
-  have hli := linearIndependent_one_of_notMem_range_algebraMap K L hθ
-  have hmem : θ' ∈ Submodule.span K (Set.range ![(1 : L), θ]) := by
-    rw [hli.span_eq_top_of_card_eq_finrank
-      (by rw [Fintype.card_fin]; exact (finrank_eq_two K L).symm)]
-    trivial
-  rw [Matrix.range_cons_cons_empty, Submodule.mem_span_pair] at hmem
-  obtain ⟨c, d, hcd⟩ := hmem
-  refine ⟨d, c, fun hd ↦ hθ' ⟨c, ?_⟩, ?_⟩
-  · rw [← hcd, hd, zero_smul, add_zero, Algebra.algebraMap_eq_smul_one]
-  · rw [← hcd, Algebra.smul_def, Algebra.smul_def, mul_one]
+  obtain ⟨a, b, hab⟩ := exists_eq_algebraMap_add_algebraMap_mul' K L hθ θ'
+  refine ⟨a, b, ?_, hab⟩
+  rintro rfl
+  exact hθ' ⟨b, by rw [hab, map_zero, zero_mul, add_zero]⟩
 
 end Algebra.IsQuadraticExtension
 

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -20,8 +20,11 @@ quadratic extension differ by `θ' = b + aθ` with `a ≠ 0`, so a statement pro
 transfers to every other. This is what makes a construction defined by "pick any `θ ∈ L ∖ K`"
 well posed up to the ambiguity that `b + aθ` describes.
 `linearIndependent_one_of_notMem_range_algebraMap` is the linear-algebra step behind the second.
+`Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul'`: every element — not only a
+generator — is `b + aθ` for a fixed generator `θ`, the coordinate presentation over the basis
+`1, θ` used by the quadratic field-norm computation.
 
-Two of the three ask for no field structure on `L`, and each is stated at the weakest level its
+Two of the four ask for no field structure on `L`, and each is stated at the weakest level its
 proof supports. `Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap` needs only a
 *semiring*, the level Mathlib states `Algebra.IsQuadraticExtension` itself at, because it sees
 `L` only as a free `K`-module of rank two and derives nontriviality from that rank rather than
@@ -29,11 +32,13 @@ assuming it. `linearIndependent_one_of_notMem_range_algebraMap` carries no rank 
 all — its argument is just that `θ` is not a `K`-multiple of `1`, so it does ask for `L`
 nontrivial — but it stops at a *ring*, because the `LinearIndependent.pair_iff'` it applies is
 stated over an `AddCommGroup`. So both cover the split and non-reduced quadratic algebras
-`K × K` and `K[X]/(X²)`. Only `exists_eq_algebraMap_add_algebraMap_mul` asks for a field.
+`K × K` and `K[X]/(X²)`. Both `exists_eq_algebraMap_add_algebraMap_mul` and its all-elements form
+`exists_eq_algebraMap_add_algebraMap_mul'` ask for a field.
 
 These are consumed by the extension quadratic twist in
 `TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean`, which advances
-`TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists).
+`TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists), and by the quadratic field-norm
+computation in `TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean`.
 
 Adapted from the FLT project (`ImperialCollegeLondon/FLT`,
 `FLT/Mathlib/LinearAlgebra/Dimension/IsQuadraticExtension.lean` at the roadmap's pin

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -24,16 +24,16 @@ well posed up to the ambiguity that `b + aθ` describes.
 generator — is `b + aθ` for a fixed generator `θ`, the coordinate presentation over the basis
 `1, θ` used by the quadratic field-norm computation.
 
-Two of the four ask for no field structure on `L`, and each is stated at the weakest level its
+Three of the four ask for no field structure on `L`, and each is stated at the weakest level its
 proof supports. `Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap` needs only a
 *semiring*, the level Mathlib states `Algebra.IsQuadraticExtension` itself at, because it sees
 `L` only as a free `K`-module of rank two and derives nontriviality from that rank rather than
 assuming it. `linearIndependent_one_of_notMem_range_algebraMap` carries no rank hypothesis at
 all — its argument is just that `θ` is not a `K`-multiple of `1`, so it does ask for `L`
 nontrivial — but it stops at a *ring*, because the `LinearIndependent.pair_iff'` it applies is
-stated over an `AddCommGroup`. So both cover the split and non-reduced quadratic algebras
-`K × K` and `K[X]/(X²)`. Both `exists_eq_algebraMap_add_algebraMap_mul` and its all-elements form
-`exists_eq_algebraMap_add_algebraMap_mul'` ask for a field.
+stated over an `AddCommGroup`. `exists_eq_algebraMap_add_algebraMap_mul'` also stops at a *ring*,
+its spanning being `K`-linear algebra. So the three cover the split and non-reduced quadratic
+algebras `K × K` and `K[X]/(X²)`. Only `exists_eq_algebraMap_add_algebraMap_mul` asks for a field.
 
 These are consumed by the extension quadratic twist in
 `TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean`, which advances
@@ -76,6 +76,23 @@ theorem Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap [Semiring L]
     Module.finrank_of_bijective_algebraMap ⟨FaithfulSMul.algebraMap_injective K L, h⟩
   omega
 
+/-- **Every element of a quadratic extension is `b + aθ`** for a fixed generator `θ`: the basis
+`1, θ` spans `L` over `K`. Unlike `exists_eq_algebraMap_add_algebraMap_mul`, the element need not
+itself be a generator, so the `θ`-coefficient may vanish when the element is in the base field. The
+spanning is `K`-linear algebra, so this stops at a *ring*. -/
+theorem Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul' [Ring L] [Algebra K L]
+    [Algebra.IsQuadraticExtension K L] {θ : L} (hθ : θ ∉ Set.range (algebraMap K L)) (x : L) :
+    ∃ a b : K, x = algebraMap K L b + algebraMap K L a * θ := by
+  have h2 := Algebra.IsQuadraticExtension.finrank_eq_two K L
+  have : Nontrivial L := Module.nontrivial_of_finrank_pos (R := K) (by rw [h2]; norm_num)
+  have hli := linearIndependent_one_of_notMem_range_algebraMap K L hθ
+  have hmem : x ∈ Submodule.span K (Set.range ![(1 : L), θ]) := by
+    rw [hli.span_eq_top_of_card_eq_finrank (by rw [Fintype.card_fin]; exact h2.symm)]
+    trivial
+  rw [Matrix.range_cons_cons_empty, Submodule.mem_span_pair] at hmem
+  obtain ⟨c, d, hcd⟩ := hmem
+  exact ⟨d, c, by rw [← hcd, Algebra.smul_def, Algebra.smul_def, mul_one]⟩
+
 variable [Field L] [Algebra K L] [Algebra.IsQuadraticExtension K L]
 
 namespace Algebra.IsQuadraticExtension
@@ -96,18 +113,6 @@ theorem exists_eq_algebraMap_add_algebraMap_mul {θ θ' : L}
   refine ⟨d, c, fun hd ↦ hθ' ⟨c, ?_⟩, ?_⟩
   · rw [← hcd, hd, zero_smul, add_zero, Algebra.algebraMap_eq_smul_one]
   · rw [← hcd, Algebra.smul_def, Algebra.smul_def, mul_one]
-
-/-- **Every element of a quadratic extension is `b + aθ`** for a fixed generator `θ`: the basis
-`1, θ` spans `L` over `K`. Unlike `exists_eq_algebraMap_add_algebraMap_mul`, the element need not
-itself be a generator, so the `θ`-coefficient may vanish when the element is in the base field. -/
-theorem exists_eq_algebraMap_add_algebraMap_mul' {θ : L}
-    (hθ : θ ∉ Set.range (algebraMap K L)) (x : L) :
-    ∃ a b : K, x = algebraMap K L b + algebraMap K L a * θ := by
-  by_cases hx : x ∈ Set.range (algebraMap K L)
-  · obtain ⟨b, hb⟩ := hx
-    exact ⟨0, b, by rw [← hb]; simp⟩
-  · obtain ⟨a, b, _, hab⟩ := exists_eq_algebraMap_add_algebraMap_mul K L hθ hx
-    exact ⟨a, b, hab⟩
 
 end Algebra.IsQuadraticExtension
 

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -15,25 +15,22 @@ order to *choose* and *change* a generator:
 
 `Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap`: a generator exists at all, so a
 construction over `L/K` may pick one.
-`Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul`: any two generators of a
-quadratic extension differ by `θ' = b + aθ` with `a ≠ 0`, so a statement proved for one generator
-transfers to every other. This is what makes a construction defined by "pick any `θ ∈ L ∖ K`"
-well posed up to the ambiguity that `b + aθ` describes.
-`linearIndependent_one_of_notMem_range_algebraMap` is the linear-algebra step behind the second.
-`Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul'`: every element — not only a
-generator — is `b + aθ` for a fixed generator `θ`, the coordinate presentation over the basis
-`1, θ` used by the quadratic field-norm computation.
+`Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul`: every element is `b + aθ`
+for a fixed generator `θ`, the coordinate presentation over the basis `1, θ` (used by the
+quadratic field-norm computation).
+`Algebra.IsQuadraticExtension.exists_ne_zero_eq_algebraMap_add_algebraMap_mul`: for a *second*
+generator the `θ`-coefficient is nonzero, so any two generators differ by `θ' = b + aθ` with
+`a ≠ 0` and a statement proved for one transfers to every other.
+`linearIndependent_one_of_notMem_range_algebraMap` is the linear-algebra step behind them.
 
-Three of the four ask for no field structure on `L`, and each is stated at the weakest level its
-proof supports. `Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap` needs only a
-*semiring*, the level Mathlib states `Algebra.IsQuadraticExtension` itself at, because it sees
-`L` only as a free `K`-module of rank two and derives nontriviality from that rank rather than
-assuming it. `linearIndependent_one_of_notMem_range_algebraMap` carries no rank hypothesis at
-all — its argument is just that `θ` is not a `K`-multiple of `1`, so it does ask for `L`
-nontrivial — but it stops at a *ring*, because the `LinearIndependent.pair_iff'` it applies is
-stated over an `AddCommGroup`. `exists_eq_algebraMap_add_algebraMap_mul'` also stops at a *ring*,
-its spanning being `K`-linear algebra. So the three cover the split and non-reduced quadratic
-algebras `K × K` and `K[X]/(X²)`. Only `exists_eq_algebraMap_add_algebraMap_mul` asks for a field.
+None asks for a field on `L`, and each is stated at the weakest level its proof supports. The
+generator-existence and both coordinate theorems need only a *semiring* — the level Mathlib states
+`Algebra.IsQuadraticExtension` itself at — the ring structure the spanning needs being borrowed
+locally through `Algebra.semiringToRing`. `linearIndependent_one_of_notMem_range_algebraMap`
+carries no rank hypothesis at all — its argument is just that `θ` is not a `K`-multiple of `1`, so
+it asks for `L` nontrivial — but it stops at a *ring*, because the `LinearIndependent.pair_iff'`
+it applies is stated over an `AddCommGroup`. So all cover the split and non-reduced quadratic
+algebras `K × K` and `K[X]/(X²)`.
 
 These are consumed by the extension quadratic twist in
 `TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean`, which advances
@@ -77,12 +74,14 @@ theorem Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap [Semiring L]
   omega
 
 /-- **Every element of a quadratic extension is `b + aθ`** for a fixed generator `θ`: the basis
-`1, θ` spans `L` over `K`. Unlike `exists_eq_algebraMap_add_algebraMap_mul`, the element need not
-itself be a generator, so the `θ`-coefficient may vanish when the element is in the base field. The
-spanning is `K`-linear algebra, so this stops at a *ring*. -/
-theorem Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul' [Ring L] [Algebra K L]
-    [Algebra.IsQuadraticExtension K L] {θ : L} (hθ : θ ∉ Set.range (algebraMap K L)) (x : L) :
+`1, θ` spans `L` over `K`. The `θ`-coefficient may vanish, exactly when the element lies in the
+base field; `exists_ne_zero_eq_algebraMap_add_algebraMap_mul` records that it does not for a second
+generator. The spanning is `K`-linear algebra, so this needs only a *semiring* on `L`. -/
+theorem Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul [Semiring L]
+    [Algebra K L] [Algebra.IsQuadraticExtension K L] {θ : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) (x : L) :
     ∃ a b : K, x = algebraMap K L b + algebraMap K L a * θ := by
+  letI : Ring L := Algebra.semiringToRing K
   have h2 := Algebra.IsQuadraticExtension.finrank_eq_two K L
   have : Nontrivial L := Module.nontrivial_of_finrank_pos (R := K) (by rw [h2]; norm_num)
   have hli := linearIndependent_one_of_notMem_range_algebraMap K L hθ
@@ -93,21 +92,17 @@ theorem Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul' [R
   obtain ⟨c, d, hcd⟩ := hmem
   exact ⟨d, c, by rw [← hcd, Algebra.smul_def, Algebra.smul_def, mul_one]⟩
 
-variable [Field L] [Algebra K L] [Algebra.IsQuadraticExtension K L]
-
-namespace Algebra.IsQuadraticExtension
-
 /-- Any element of a quadratic extension `L/K` is a `K`-linear combination of `1` and a given
 generator `θ`, and the `θ`-coefficient is nonzero if the element also lies outside `K`. So any
 two generators differ by `θ' = b + aθ` with `a ≠ 0`. -/
-theorem exists_eq_algebraMap_add_algebraMap_mul {θ θ' : L}
+theorem Algebra.IsQuadraticExtension.exists_ne_zero_eq_algebraMap_add_algebraMap_mul [Semiring L]
+    [Algebra K L] [Algebra.IsQuadraticExtension K L] {θ θ' : L}
     (hθ : θ ∉ Set.range (algebraMap K L)) (hθ' : θ' ∉ Set.range (algebraMap K L)) :
     ∃ a b : K, a ≠ 0 ∧ θ' = algebraMap K L b + algebraMap K L a * θ := by
-  obtain ⟨a, b, hab⟩ := exists_eq_algebraMap_add_algebraMap_mul' K L hθ θ'
+  obtain ⟨a, b, hab⟩ :=
+    Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul K L hθ θ'
   refine ⟨a, b, ?_, hab⟩
   rintro rfl
   exact hθ' ⟨b, by rw [hab, map_zero, zero_mul, add_zero]⟩
-
-end Algebra.IsQuadraticExtension
 
 end

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -9,7 +9,7 @@ public import Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed
 public import Mathlib.RingTheory.Discriminant
 public import Mathlib.LinearAlgebra.Matrix.Notation
 public import TauCeti.FieldTheory.Trace
-public import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
+import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
 
 /-!
 # Basics for quadratic number fields
@@ -100,13 +100,8 @@ theorem exists_eq_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (x : K) :
     ∃ a b : ℚ, x = algebraMap ℚ K b + algebraMap ℚ K a * (θ : K) := by
   have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
-  by_cases hx : x ∈ Set.range (algebraMap ℚ K)
-  · obtain ⟨b, hb⟩ := hx
-    exact ⟨0, b, by rw [← hb]; simp⟩
-  · obtain ⟨a, b, _, hab⟩ :=
-      Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul ℚ K
-        (gen_notMem_range hmin) hx
-    exact ⟨a, b, hab⟩
+  exact Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul' ℚ K
+    (gen_notMem_range hmin) x
 
 /-- **The radicand of a quadratic presentation is not a rational square.** Were `d = q²`, the
 factorization `(θ - q)(θ + q) = θ² - d = 0` would force `θ = ±q ∈ ℚ`. -/

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -16,8 +16,9 @@ public import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
 
 Shared facts about a quadratic number field `K` presented by an algebraic integer `θ : 𝓞 K` whose
 minimal polynomial over `ℤ` is `X² - d`. These feed the prime-splitting law
-(`Quadratic/Splitting.lean`), the conjugation automorphism (`Quadratic/Conjugation/Basic.lean`), and
-the ring-of-integers/discriminant computation (`Quadratic/RingOfIntegers.lean`).
+(`Quadratic/Splitting.lean`), the conjugation automorphism (`Quadratic/Conjugation/Basic.lean`), the
+ring-of-integers/discriminant computation (`Quadratic/RingOfIntegers.lean`), and the field-norm
+computation (`Quadratic/Norm.lean`).
 
 ## Main results
 
@@ -26,6 +27,7 @@ the ring-of-integers/discriminant computation (`Quadratic/RingOfIntegers.lean`).
 * `TauCeti.NumberField.coe_gen_sq`: the generator squares to the radicand, `θ² = d` in `K`.
 * `TauCeti.NumberField.coe_gen_sq_ratCast`: the same over `ℚ`, `θ² = (d : ℚ)` in `K`.
 * `TauCeti.NumberField.gen_notMem_range`: the generator is not rational, `θ ∉ ℚ`.
+* `TauCeti.NumberField.exists_eq_add_mul_gen`: every element of `K` is `b + aθ`.
 * `TauCeti.NumberField.not_isSquare_radicand`: the radicand is not a rational square.
 * `TauCeti.NumberField.trace_gen_eq_zero`: the trace of the generator is `0`.
 * `TauCeti.NumberField.discr_one_gen`: the discriminant of `{1, θ}` over `ℚ` is `4d`.

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -9,6 +9,7 @@ public import Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed
 public import Mathlib.RingTheory.Discriminant
 public import Mathlib.LinearAlgebra.Matrix.Notation
 public import TauCeti.FieldTheory.Trace
+public import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
 
 /-!
 # Basics for quadratic number fields
@@ -91,6 +92,19 @@ theorem gen_notMem_range (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     simpa [natDegree_X_sub_C] using Polynomial.natDegree_le_of_dvd hdvd (X_sub_C_ne_zero q)
   rw [hq, minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C] at h1
   norm_num at h1
+
+/-- **Every element of a quadratic field is `b + aθ`** for rationals `a, b`. -/
+theorem exists_eq_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (x : K) :
+    ∃ a b : ℚ, x = algebraMap ℚ K b + algebraMap ℚ K a * (θ : K) := by
+  have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
+  by_cases hx : x ∈ Set.range (algebraMap ℚ K)
+  · obtain ⟨b, hb⟩ := hx
+    exact ⟨0, b, by rw [← hb]; simp⟩
+  · obtain ⟨a, b, _, hab⟩ :=
+      Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul ℚ K
+        (gen_notMem_range hmin) hx
+    exact ⟨a, b, hab⟩
 
 /-- **The radicand of a quadratic presentation is not a rational square.** Were `d = q²`, the
 factorization `(θ - q)(θ + q) = θ² - d = 0` would force `θ = ±q ∈ ℚ`. -/

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -100,7 +100,7 @@ theorem exists_eq_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (x : K) :
     ∃ a b : ℚ, x = algebraMap ℚ K b + algebraMap ℚ K a * (θ : K) := by
   have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
-  exact Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul' ℚ K
+  exact Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul ℚ K
     (gen_notMem_range hmin) x
 
 /-- **The radicand of a quadratic presentation is not a rational square.** Were `d = q²`, the

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.NumberTheory.NumberField.Quadratic.Basic
-public import TauCeti.RingTheory.Norm.Quadratic
+import TauCeti.RingTheory.Norm.Quadratic
 
 /-!
 # The field norm on a quadratic number field

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
@@ -56,7 +56,7 @@ theorem norm_gen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin �
   rw [← genPowerBasis_gen hgen,
     Algebra.PowerBasis.norm_gen_eq_coeff_zero_minpoly (genPowerBasis hgen),
     genPowerBasis_dim hmin hgen, genPowerBasis_gen, minpoly_rat_quadratic hmin]
-  simp [coeff_sub, coeff_X_pow, coeff_C]
+  simp [coeff_sub, coeff_X_pow]
 
 /-- **Every element of a quadratic field is `b + aθ`** for rationals `a, b`: the power basis `1, θ`
 spans `K` over `ℚ`, and any polynomial in `θ` reduces modulo the degree-two minimal polynomial. -/
@@ -76,7 +76,7 @@ quadratic norm formula `b² + ab·Tr(θ) + a²·N(θ)` to `Tr(θ) = 0` and `N(θ
 theorem norm_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (a b : ℚ) :
     Algebra.norm ℚ (algebraMap ℚ K b + algebraMap ℚ K a * (θ : K)) = b ^ 2 - (d : ℚ) * a ^ 2 := by
-  haveI : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
+  have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
   rw [Algebra.IsQuadraticExtension.norm_algebraMap_add_algebraMap_mul, trace_gen_eq_zero hmin,
     norm_gen hmin hgen]
   ring

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.Norm.Basic
 public import TauCeti.NumberTheory.NumberField.Quadratic.Basic
 public import TauCeti.RingTheory.Norm.Quadratic
 
@@ -15,13 +14,13 @@ For a quadratic number field `K = ℚ(√d)` presented by an algebraic integer `
 `K` over `ℚ` with `minpoly ℤ θ = X² - d`, this file computes the field norm `Algebra.norm ℚ` on
 `K` in terms of the coordinates in the basis `1, θ`:
 
-* `norm_gen`: the norm of the generator is the negative of the radicand, `N(θ) = -d`;
+* `norm_gen_eq_neg_radicand`: the norm of the generator, `N(θ) = -d` (negative of the radicand);
 * `norm_add_mul_gen`: in the coordinates `x = b + aθ` the norm is `N(b + aθ) = b² - d·a²`;
 * `norm_pos_of_radicand_neg`: when `d < 0` — the imaginary quadratic case, where `K` is totally
   complex — the norm is strictly positive on every nonzero element.
 
 The positivity is a descent input for the genus theory of the multiquadratic roadmap: for a
-norm-one element `α` it upgrades `N(α) = ±1` to `N(α) = 1`, the hypothesis of Hilbert's
+norm-`±1` element `α` it upgrades `N(α) = ±1` to `N(α) = 1`, the hypothesis of Hilbert's
 Theorem 90 used to realise a `2`-torsion class by an ambiguous ideal.
 
 See D. A. Cox, *Primes of the Form x² + ny²*, and F. Lemmermeyer, *Reciprocity Laws*.
@@ -37,7 +36,7 @@ variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
 
 /-- **The norm of the generator is the negative of the radicand:** `N(θ) = -d`. It is the constant
 coefficient of the minimal polynomial `X² - d`, times the sign `(-1)^{[K:ℚ]} = +1`. -/
-@[simp] theorem norm_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+@[simp] theorem norm_gen_eq_neg_radicand (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
     Algebra.norm ℚ (θ : K) = -(d : ℚ) := by
   have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
@@ -58,7 +57,7 @@ formula with `Tr(θ) = 0` and `N(θ) = -d`. -/
   have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
   rw [← eq_ratCast (algebraMap ℚ K) b, ← eq_ratCast (algebraMap ℚ K) a,
     Algebra.IsQuadraticExtension.norm_algebraMap_add_algebraMap_mul, trace_gen_eq_zero hmin,
-    norm_gen hmin hgen]
+    norm_gen_eq_neg_radicand hmin hgen]
   ring
 
 /-- **The norm is positive in the imaginary case.** When `d < 0` the field `K = ℚ(√d)` is totally

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
@@ -13,11 +13,10 @@ public import TauCeti.RingTheory.Norm.Quadratic
 
 For a quadratic number field `K = ℚ(√d)` presented by an algebraic integer `θ : 𝓞 K` generating
 `K` over `ℚ` with `minpoly ℤ θ = X² - d`, this file computes the field norm `Algebra.norm ℚ` on
-`K` in terms of the coordinates in the power basis `1, θ`:
+`K` in terms of the coordinates in the basis `1, θ`:
 
-* `norm_gen`: the norm of the generator is the radicand, `N(θ) = -d`;
-* `exists_eq_add_mul_gen`: every element of `K` is `b + aθ` for rationals `a, b`;
-* `norm_add_mul_gen`: in those coordinates the norm is `N(b + aθ) = b² - d·a²`;
+* `norm_gen`: the norm of the generator is the negative of the radicand, `N(θ) = -d`;
+* `norm_add_mul_gen`: in the coordinates `x = b + aθ` the norm is `N(b + aθ) = b² - d·a²`;
 * `norm_pos_of_radicand_neg`: when `d < 0` — the imaginary quadratic case, where `K` is totally
   complex — the norm is strictly positive on every nonzero element.
 
@@ -36,44 +35,24 @@ namespace TauCeti.NumberField
 
 variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
 
-/-- The `ℚ`-power basis `1, θ` of the quadratic field `K = ℚ(θ)`. -/
-private noncomputable def genPowerBasis (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : PowerBasis ℚ K :=
-  PowerBasis.ofAdjoinEqTop' θ.isIntegral_coe.tower_top hgen
-
-private theorem genPowerBasis_gen (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
-    (genPowerBasis hgen).gen = (θ : K) :=
-  PowerBasis.ofAdjoinEqTop'_gen _ hgen
-
-private theorem genPowerBasis_dim (hmin : minpoly ℤ θ = X ^ 2 - C d)
-    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : (genPowerBasis hgen).dim = 2 := by
-  rw [← (genPowerBasis hgen).natDegree_minpoly, genPowerBasis_gen, minpoly_rat_quadratic hmin,
-    natDegree_X_pow_sub_C]
-
-/-- **The norm of the generator is the radicand:** `N(θ) = -d`. This is the constant coefficient of
-the minimal polynomial `X² - d` (up to the sign `(-1)^{[K:ℚ]}`, here `+1`). -/
-theorem norm_gen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
+/-- **The norm of the generator is the negative of the radicand:** `N(θ) = -d`. It is the constant
+coefficient of the minimal polynomial `X² - d`, times the sign `(-1)^{[K:ℚ]} = +1`. -/
+@[simp] theorem norm_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
     Algebra.norm ℚ (θ : K) = -(d : ℚ) := by
-  rw [← genPowerBasis_gen hgen,
-    Algebra.PowerBasis.norm_gen_eq_coeff_zero_minpoly (genPowerBasis hgen),
-    genPowerBasis_dim hmin hgen, genPowerBasis_gen, minpoly_rat_quadratic hmin]
+  have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
+  have hgen' : (PowerBasis.ofAdjoinEqTop' hint hgen).gen = (θ : K) :=
+    PowerBasis.ofAdjoinEqTop'_gen hint hgen
+  have hdim : (PowerBasis.ofAdjoinEqTop' hint hgen).dim = 2 := by
+    rw [← (PowerBasis.ofAdjoinEqTop' hint hgen).natDegree_minpoly, hgen',
+      minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C]
+  rw [← hgen', Algebra.PowerBasis.norm_gen_eq_coeff_zero_minpoly, hdim, hgen',
+    minpoly_rat_quadratic hmin]
   simp [coeff_sub, coeff_X_pow]
 
-/-- **Every element of a quadratic field is `b + aθ`** for rationals `a, b`: the power basis `1, θ`
-spans `K` over `ℚ`, and any polynomial in `θ` reduces modulo the degree-two minimal polynomial. -/
-theorem exists_eq_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
-    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (x : K) :
-    ∃ a b : ℚ, x = algebraMap ℚ K b + algebraMap ℚ K a * (θ : K) := by
-  obtain ⟨f, hf, rfl⟩ := (genPowerBasis hgen).exists_eq_aeval x
-  rw [genPowerBasis_dim hmin hgen] at hf
-  obtain ⟨a, b, rfl⟩ := exists_eq_X_add_C_of_natDegree_le_one (by omega : f.natDegree ≤ 1)
-  refine ⟨a, b, ?_⟩
-  rw [genPowerBasis_gen]
-  simp only [map_add, map_mul, aeval_C, aeval_X]
-  ring
-
-/-- **The norm in power-basis coordinates:** `N(b + aθ) = b² - d·a²`. Specialises the generic
-quadratic norm formula `b² + ab·Tr(θ) + a²·N(θ)` to `Tr(θ) = 0` and `N(θ) = -d`. -/
-theorem norm_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+/-- **The norm in the basis `1, θ`:** `N(b + aθ) = b² - d·a²`. This is the generic quadratic norm
+formula with `Tr(θ) = 0` and `N(θ) = -d`. -/
+@[simp] theorem norm_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (a b : ℚ) :
     Algebra.norm ℚ (algebraMap ℚ K b + algebraMap ℚ K a * (θ : K)) = b ^ 2 - (d : ℚ) * a ^ 2 := by
   have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
@@ -53,7 +53,8 @@ private theorem genPowerBasis_dim (hmin : minpoly ℤ θ = X ^ 2 - C d)
 the minimal polynomial `X² - d` (up to the sign `(-1)^{[K:ℚ]}`, here `+1`). -/
 theorem norm_gen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
     Algebra.norm ℚ (θ : K) = -(d : ℚ) := by
-  rw [← genPowerBasis_gen hgen, (genPowerBasis hgen).norm_gen_eq_coeff_zero_minpoly,
+  rw [← genPowerBasis_gen hgen,
+    Algebra.PowerBasis.norm_gen_eq_coeff_zero_minpoly (genPowerBasis hgen),
     genPowerBasis_dim hmin hgen, genPowerBasis_gen, minpoly_rat_quadratic hmin]
   simp [coeff_sub, coeff_X_pow, coeff_C]
 
@@ -91,7 +92,7 @@ theorem norm_pos_of_radicand_neg (hmin : minpoly ℤ θ = X ^ 2 - C d)
   have hdq : (d : ℚ) < 0 := by exact_mod_cast hd
   have hab : a ≠ 0 ∨ b ≠ 0 := by
     by_contra h
-    push_neg at h
+    simp only [not_or, not_not] at h
     exact hx (by rw [h.1, h.2]; simp)
   rcases hab with ha | hb
   · nlinarith [mul_self_pos.mpr ha, sq_nonneg b, sq_nonneg a]

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
@@ -54,9 +54,10 @@ coefficient of the minimal polynomial `X² - d`, times the sign `(-1)^{[K:ℚ]} 
 formula with `Tr(θ) = 0` and `N(θ) = -d`. -/
 @[simp] theorem norm_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (a b : ℚ) :
-    Algebra.norm ℚ (algebraMap ℚ K b + algebraMap ℚ K a * (θ : K)) = b ^ 2 - (d : ℚ) * a ^ 2 := by
+    Algebra.norm ℚ ((b : K) + (a : K) * (θ : K)) = b ^ 2 - (d : ℚ) * a ^ 2 := by
   have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
-  rw [Algebra.IsQuadraticExtension.norm_algebraMap_add_algebraMap_mul, trace_gen_eq_zero hmin,
+  rw [← eq_ratCast (algebraMap ℚ K) b, ← eq_ratCast (algebraMap ℚ K) a,
+    Algebra.IsQuadraticExtension.norm_algebraMap_add_algebraMap_mul, trace_gen_eq_zero hmin,
     norm_gen hmin hgen]
   ring
 
@@ -67,6 +68,7 @@ theorem norm_pos_of_radicand_neg (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hd : d < 0) {x : K} (hx : x ≠ 0) :
     0 < Algebra.norm ℚ x := by
   obtain ⟨a, b, rfl⟩ := exists_eq_add_mul_gen hmin hgen x
+  simp only [eq_ratCast]
   rw [norm_add_mul_gen hmin hgen]
   have hdq : (d : ℚ) < 0 := by exact_mod_cast hd
   have hab : a ≠ 0 ∨ b ≠ 0 := by

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Norm.Basic
+public import TauCeti.NumberTheory.NumberField.Quadratic.Basic
+public import TauCeti.RingTheory.Norm.Quadratic
+
+/-!
+# The field norm on a quadratic number field
+
+For a quadratic number field `K = ℚ(√d)` presented by an algebraic integer `θ : 𝓞 K` generating
+`K` over `ℚ` with `minpoly ℤ θ = X² - d`, this file computes the field norm `Algebra.norm ℚ` on
+`K` in terms of the coordinates in the power basis `1, θ`:
+
+* `norm_gen`: the norm of the generator is the radicand, `N(θ) = -d`;
+* `exists_eq_add_mul_gen`: every element of `K` is `b + aθ` for rationals `a, b`;
+* `norm_add_mul_gen`: in those coordinates the norm is `N(b + aθ) = b² - d·a²`;
+* `norm_pos_of_radicand_neg`: when `d < 0` — the imaginary quadratic case, where `K` is totally
+  complex — the norm is strictly positive on every nonzero element.
+
+The positivity is a descent input for the genus theory of the multiquadratic roadmap: for a
+norm-one element `α` it upgrades `N(α) = ±1` to `N(α) = 1`, the hypothesis of Hilbert's
+Theorem 90 used to realise a `2`-torsion class by an ambiguous ideal.
+
+See D. A. Cox, *Primes of the Form x² + ny²*, and F. Lemmermeyer, *Reciprocity Laws*.
+-/
+
+public section
+
+open Polynomial NumberField
+
+namespace TauCeti.NumberField
+
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
+
+/-- The `ℚ`-power basis `1, θ` of the quadratic field `K = ℚ(θ)`. -/
+private noncomputable def genPowerBasis (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : PowerBasis ℚ K :=
+  PowerBasis.ofAdjoinEqTop' θ.isIntegral_coe.tower_top hgen
+
+private theorem genPowerBasis_gen (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
+    (genPowerBasis hgen).gen = (θ : K) :=
+  PowerBasis.ofAdjoinEqTop'_gen _ hgen
+
+private theorem genPowerBasis_dim (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : (genPowerBasis hgen).dim = 2 := by
+  rw [← (genPowerBasis hgen).natDegree_minpoly, genPowerBasis_gen, minpoly_rat_quadratic hmin,
+    natDegree_X_pow_sub_C]
+
+/-- **The norm of the generator is the radicand:** `N(θ) = -d`. This is the constant coefficient of
+the minimal polynomial `X² - d` (up to the sign `(-1)^{[K:ℚ]}`, here `+1`). -/
+theorem norm_gen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
+    Algebra.norm ℚ (θ : K) = -(d : ℚ) := by
+  rw [← genPowerBasis_gen hgen, (genPowerBasis hgen).norm_gen_eq_coeff_zero_minpoly,
+    genPowerBasis_dim hmin hgen, genPowerBasis_gen, minpoly_rat_quadratic hmin]
+  simp [coeff_sub, coeff_X_pow, coeff_C]
+
+/-- **Every element of a quadratic field is `b + aθ`** for rationals `a, b`: the power basis `1, θ`
+spans `K` over `ℚ`, and any polynomial in `θ` reduces modulo the degree-two minimal polynomial. -/
+theorem exists_eq_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (x : K) :
+    ∃ a b : ℚ, x = algebraMap ℚ K b + algebraMap ℚ K a * (θ : K) := by
+  obtain ⟨f, hf, rfl⟩ := (genPowerBasis hgen).exists_eq_aeval x
+  rw [genPowerBasis_dim hmin hgen] at hf
+  obtain ⟨a, b, rfl⟩ := exists_eq_X_add_C_of_natDegree_le_one (by omega : f.natDegree ≤ 1)
+  refine ⟨a, b, ?_⟩
+  rw [genPowerBasis_gen]
+  simp only [map_add, map_mul, aeval_C, aeval_X]
+  ring
+
+/-- **The norm in power-basis coordinates:** `N(b + aθ) = b² - d·a²`. Specialises the generic
+quadratic norm formula `b² + ab·Tr(θ) + a²·N(θ)` to `Tr(θ) = 0` and `N(θ) = -d`. -/
+theorem norm_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (a b : ℚ) :
+    Algebra.norm ℚ (algebraMap ℚ K b + algebraMap ℚ K a * (θ : K)) = b ^ 2 - (d : ℚ) * a ^ 2 := by
+  haveI : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
+  rw [Algebra.IsQuadraticExtension.norm_algebraMap_add_algebraMap_mul, trace_gen_eq_zero hmin,
+    norm_gen hmin hgen]
+  ring
+
+/-- **The norm is positive in the imaginary case.** When `d < 0` the field `K = ℚ(√d)` is totally
+complex, and `N(b + aθ) = b² + |d|·a²`, so the norm is strictly positive on every nonzero element.
+This is the sign input that turns a norm-`±1` element into a norm-`1` one for Hilbert 90. -/
+theorem norm_pos_of_radicand_neg (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hd : d < 0) {x : K} (hx : x ≠ 0) :
+    0 < Algebra.norm ℚ x := by
+  obtain ⟨a, b, rfl⟩ := exists_eq_add_mul_gen hmin hgen x
+  rw [norm_add_mul_gen hmin hgen]
+  have hdq : (d : ℚ) < 0 := by exact_mod_cast hd
+  have hab : a ≠ 0 ∨ b ≠ 0 := by
+    by_contra h
+    push_neg at h
+    exact hx (by rw [h.1, h.2]; simp)
+  rcases hab with ha | hb
+  · nlinarith [mul_self_pos.mpr ha, sq_nonneg b, sq_nonneg a]
+  · nlinarith [mul_self_pos.mpr hb, sq_nonneg a, sq_nonneg b]
+
+end TauCeti.NumberField


### PR DESCRIPTION
For a quadratic number field `K = ℚ(√d)` with `minpoly ℤ θ = X² - d`, compute the field norm `Algebra.norm ℚ` in the power basis `1, θ`:

- `norm_gen`: `N(θ) = -d` (constant coefficient of the minimal polynomial);
- `exists_eq_add_mul_gen`: every element of `K` is `b + aθ` for rationals `a, b`;
- `norm_add_mul_gen`: `N(b + aθ) = b² - d·a²`;
- `norm_pos_of_radicand_neg`: for `d < 0` (imaginary quadratic, `K` totally complex) the norm is strictly positive on nonzero elements.

The positivity is a descent input for genus theory: it upgrades a norm-`±1` element to norm `1`, the hypothesis of Hilbert's Theorem 90 used to realise a 2-torsion class by an ambiguous ideal (the ambiguous class number formula behind the genus-field 2-rank theorem).

Builds on the abstract quadratic norm formula `Algebra.IsQuadraticExtension.norm_algebraMap_add_algebraMap_mul` and `trace_gen_eq_zero`.

Roadmap: Multiquadratic