### PR TITLE
feat(EllipticCurve): the place at infinity is distinct from every affine place

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -353,9 +353,7 @@ theorem infinityPlace_ne_heightOneSpectrum_valuation [IsDedekindDomain W.Coordin
   have hx := IsDedekindDomain.HeightOneSpectrum.valuation_le_one P
     (K := W.FunctionField) (algebraMap F[X] W.CoordinateRing Polynomial.X)
   rw [← heq, infinityPlace.X] at hx
-  -- the unit of `ℤᵐ⁰` is `exp 0` by definition, so the bound compares exponents
-  rw [show (1 : WithZero (Multiplicative ℤ)) = WithZero.exp 0 from rfl,
-    WithZero.exp_le_exp] at hx
+  rw [← WithZero.exp_zero, WithZero.exp_le_exp] at hx
   omega
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -27,6 +27,8 @@ The valuation's `map_add_le_max'` rests on an ultrametric inequality in degree f
 the other three axioms are the norm's multiplicativity and Mathlib's place at infinity.
 * `WeierstrassCurve.Affine.infinityPlace.X`,
   `WeierstrassCurve.Affine.infinityPlace.mk_Y`
+* `WeierstrassCurve.Affine.infinityPlace_ne_heightOneSpectrum_valuation`: the place at infinity is
+  distinct from the valuation of every height-one prime of the coordinate ring — the affine places.
 * `WeierstrassCurve.Affine.infinityPlace.C`: the valuation is trivial on the base field — a
   nonzero constant has value `1`. The `Valuation.IsTrivialOn F` and `Valuation.IsNontrivial`
   instances follow, so the place is usable through Mathlib's standard valuation

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -6,7 +6,6 @@ module
 
 public import Mathlib.FieldTheory.RatFunc.Valuation
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Norm
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.Point.Place
 
 /-!
 # The valuation at infinity on the function field of a Weierstrass curve
@@ -339,20 +338,20 @@ theorem infinityPlace.adjoinRoot_root :
   infinityPlace.mk_Y W
 
 
-/-- **The place at infinity is not the place of any affine point.** The coordinate function `x` has
-a pole at infinity, while every element of the coordinate ring is regular at every affine place, so
-the two valuations differ at `x`. With `pointPlace_eq_iff` this completes the injectivity of the
-point-to-place assignment on all of `W.toAffine.Point`. -/
-theorem infinityPlace_ne_pointPlace_valuation [IsDedekindDomain W.CoordinateRing] {x y : F}
-    (h : W.Equation x y) :
-    infinityPlace W ≠
-      (TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace h).valuation W.FunctionField := by
+/-- **The place at infinity is distinct from every affine place.** Together with
+`CoordinateRing.pointPlace_eq_iff` this gives the injectivity of the whole point-to-place
+assignment, the point at infinity included. -/
+@[simp]
+theorem infinityPlace_ne_heightOneSpectrum_valuation [IsDedekindDomain W.CoordinateRing]
+    (P : IsDedekindDomain.HeightOneSpectrum W.CoordinateRing) :
+    infinityPlace W ≠ P.valuation W.FunctionField := by
   intro heq
-  -- `x` lies in the coordinate ring, so an affine place values it at most `1`
-  have hx := IsDedekindDomain.HeightOneSpectrum.valuation_le_one
-    (TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace h)
+  -- `x` lies in the coordinate ring, so an affine place values it at most `1`, while it has a
+  -- double pole at infinity
+  have hx := IsDedekindDomain.HeightOneSpectrum.valuation_le_one P
     (K := W.FunctionField) (algebraMap F[X] W.CoordinateRing Polynomial.X)
   rw [← heq, infinityPlace.X] at hx
+  -- the unit of `ℤᵐ⁰` is `exp 0` by definition, so the bound compares exponents
   rw [show (1 : WithZero (Multiplicative ℤ)) = WithZero.exp 0 from rfl,
     WithZero.exp_le_exp] at hx
   omega

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.FieldTheory.RatFunc.Valuation
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Norm
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.Point.Place
 
 /-!
 # The valuation at infinity on the function field of a Weierstrass curve
@@ -336,6 +337,25 @@ theorem infinityPlace.adjoinRoot_root :
     infinityPlace W (algebraMap W.CoordinateRing W.FunctionField
       (AdjoinRoot.root W.polynomial)) = WithZero.exp 3 :=
   infinityPlace.mk_Y W
+
+
+/-- **The place at infinity is not the place of any affine point.** The coordinate function `x` has
+a pole at infinity, while every element of the coordinate ring is regular at every affine place, so
+the two valuations differ at `x`. With `pointPlace_eq_iff` this completes the injectivity of the
+point-to-place assignment on all of `W.toAffine.Point`. -/
+theorem infinityPlace_ne_pointPlace_valuation [IsDedekindDomain W.CoordinateRing] {x y : F}
+    (h : W.Equation x y) :
+    infinityPlace W ≠
+      (TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace h).valuation W.FunctionField := by
+  intro heq
+  -- `x` lies in the coordinate ring, so an affine place values it at most `1`
+  have hx := IsDedekindDomain.HeightOneSpectrum.valuation_le_one
+    (TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace h)
+    (K := W.FunctionField) (algebraMap F[X] W.CoordinateRing Polynomial.X)
+  rw [← heq, infinityPlace.X] at hx
+  rw [show (1 : WithZero (Multiplicative ℤ)) = WithZero.exp 0 from rfl,
+    WithZero.exp_le_exp] at hx
+  omega
 
 end WeierstrassCurve.Affine
 


### PR DESCRIPTION
Two points of a curve have the same place exactly when they are equal (#2724), and the place at infinity exists (#2772). This adds the remaining distinctness: the place at infinity is not the place of any affine point.

```lean
-- Affine/FunctionField/InfinityPlace.lean, beside infinityPlace
@[simp] theorem WeierstrassCurve.Affine.infinityPlace_ne_heightOneSpectrum_valuation
    [IsDedekindDomain W.CoordinateRing] (P : IsDedekindDomain.HeightOneSpectrum W.CoordinateRing) :
    infinityPlace W ≠ P.valuation W.FunctionField
```

**Stated for every affine place, not just those of rational points.** The witness is the coordinate function `x`: it has a double pole at infinity — `infinityPlace.X` (#2772) gives `v_∞ x = exp 2 > 1` — while `x` lies in the coordinate ring, so `HeightOneSpectrum.valuation_le_one` bounds `v_P x ≤ 1` at every height-one prime. Nothing about the argument needs a point, so the hypothesis is a bare `HeightOneSpectrum`, which also covers places of higher-degree closed points.

**Why it matters.** `pointPlace_eq_iff` (#2724) makes the assignment injective on the affine points; this makes it injective on all of `W.toAffine.Point`, the point at infinity included, since its place is distinct from every affine one. That is the injective half of Layer 0's point–place dictionary. The surjective half — every degree-one place arising from a point — is a separate statement and is not claimed here.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 0** (the function field, places, and divisors). §Places asks for the affine places together with "one further place, `W.infinityPlace`", and §"The point–place dictionary" states that for elliptic `W` the point group is in bijection with the degree-`1` places, `O ↦ infinityPlace` and an affine point going to its maximal ideal. A bijection needs the two families to be disjoint, which is exactly this statement.

Layer 0 seeds no declaration this competes with: `Suggested.lean` records that the function-field layer's "types are new API and are built there, not pinned here".

## Provenance

Not a port. The AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `dev/hasse-weil` at `a582951fe96b`) computes `ordAtInfty` of the coordinate functions in `Curves/Infinity.lean` (`ordAtInfty_coordX`, `ordAtInfty_coordY`) and builds `ord_P` for affine points in `Curves/Valuation.lean`, but states no disjointness between the two families of places; an untruncated recursive grep of `Curves/` for `ne`/`≠` alongside `ordAtInfty` finds nothing. The argument here is the natural one, and it is short because both inputs are already available: `infinityPlace.X` from #2772 and Mathlib's `HeightOneSpectrum.valuation_le_one`.

## Mathlib absence

Mathlib has `HeightOneSpectrum.valuation_le_one` and the adic valuation API, but nothing comparing a curve's place at infinity with its affine places — an untruncated recursive grep of `Mathlib/AlgebraicGeometry/EllipticCurve/` finds no place or valuation on the function field at all, so no such statement can exist there.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"placedisjoint"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
