### PR TITLE
refactor: generalize exists_pow_mul_algebraMap_mem off the localization

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology.lean
@@ -609,8 +609,8 @@ theorem continuous_algebraMap_locTopology [IsTopologicalRing A] (P : PairOfDefin
 any prescribed open subgroup of `B`. This is the `A₀`-level base case of
 `exists_pow_mul_locSubring_mem`. -/
 private theorem exists_pow_mul_algebraMap_mem {B : Type*} [Ring B] [TopologicalSpace B]
-    (P : PairOfDefinition A) (s : A)
-    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S] (f : S →+* B)
+    (P : PairOfDefinition A)
+    (S : Type*) [CommRing S] [Algebra A S] (f : S →+* B)
     (hf : Continuous (f.comp (algebraMap A S))) (G : OpenAddSubgroup B) :
     ∃ m : ℕ, ∀ x ∈ P.ringOfDefinition.map (algebraMap A S),
       ∀ b ∈ P.idealOfDefinition ^ m,
@@ -647,7 +647,7 @@ private theorem exists_pow_mul_locSubring_mem {B : Type*} [Ring B] [TopologicalS
   induction U using Finset.induction with
   | empty =>
     intro _ G
-    obtain ⟨m, hm⟩ := exists_pow_mul_algebraMap_mem P s S f hf G
+    obtain ⟨m, hm⟩ := exists_pow_mul_algebraMap_mem P S f hf G
     exact ⟨m, fun x hx b hb ↦ hm x (locSubring_empty P s S ▸ hx) b hb⟩
   | insert t U' ht ih =>
     intro hpowU G

--- a/TauCeti/RingTheory/Huber/LocalizationTopology.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology.lean
@@ -610,7 +610,7 @@ any prescribed open subgroup of `B`. This is the `A₀`-level base case of
 `exists_pow_mul_locSubring_mem`. -/
 private theorem exists_pow_mul_algebraMap_mem {B : Type*} [Ring B] [TopologicalSpace B]
     (P : PairOfDefinition A)
-    (S : Type*) [CommRing S] [Algebra A S] (f : S →+* B)
+    (S : Type*) [Ring S] [Algebra A S] (f : S →+* B)
     (hf : Continuous (f.comp (algebraMap A S))) (G : OpenAddSubgroup B) :
     ∃ m : ℕ, ∀ x ∈ P.ringOfDefinition.map (algebraMap A S),
       ∀ b ∈ P.idealOfDefinition ^ m,

--- a/scripts/lint-baseline.txt
+++ b/scripts/lint-baseline.txt
@@ -77,7 +77,6 @@ simpNF TauCeti.isComplexLinear_arrowCongr_iff
 simpNF TauCeti.reflectRepMapApp_of_ne✝
 unusedArguments CongruenceSubgroup.Gamma0Map_toHomUnits_surjective
 unusedArguments CongruenceSubgroup.map_apply_of_dvd_lcm✝
-unusedArguments TauCeti.Huber.PairOfDefinition.exists_pow_mul_algebraMap_mem✝
 unusedArguments TauCeti.IsFiniteType
 unusedArguments TauCeti.IsHighestWeightVector
 unusedArguments TauCeti.Measure.instSFiniteGlue


### PR DESCRIPTION
This PR drops the `[IsLocalization.Away s S]` instance from `exists_pow_mul_algebraMap_mem`, and with it the now-purposeless `(s : A)` argument, clearing the last of the standalone `unusedArguments` findings [#2773](https://github.com/TauCetiProject/TauCeti/pull/2773) grandfathered.

Neither the statement nor the proof ever mentions `s`: the lemma says that along `algebraMap A S` some power of the ideal of definition multiplies the image of `A₀` into a prescribed open subgroup, and it argues purely from continuity of `f ∘ algebraMap A S`. So it holds for an arbitrary `A`-algebra `S`, and the localization hypothesis was only ever describing the caller's situation. The single call site passes `S` as the localization as before, so nothing downstream changes.

Removing the instance alone would not compile, because `s` would then be an argument no part of the statement referenced; the two go together.

Verified locally: `lake build --iofail` clean, and `scripts/lint-env.sh` reports `PASS — no new violations (94 grandfathered, 1 ratchetable)`.

Roadmap: none

🤖 Prepared with Claude Code