### PR TITLE
refactor: fix ten simp-normal-form findings

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -134,12 +134,10 @@ private lemma conj_apply (x : W.CoordinateRing) : conj W x = conjHom W x := by
   simp [conj]
 
 /-- Conjugation sends the coordinate `y` to `-y - (a₁X + a₃)`. -/
-@[simp]
 lemma conj_mk_Y : conj W (AdjoinRoot.root W.polynomial) = mk W W.negPolynomial := by
   rw [conj_apply, conjHom_mk_Y]
 
 /-- Conjugation fixes the coefficient ring `R[X]`. -/
-@[simp]
 lemma conj_mk_C (r : R[X]) : conj W (AdjoinRoot.of W.polynomial r) = mk W (C r) := by
   rw [conj_apply, conjHom_mk_C]
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -129,15 +129,16 @@ noncomputable def conj : W.CoordinateRing ≃ₐ[R[X]] W.CoordinateRing :=
   AlgEquiv.ofAlgHom (conjHom W) (conjHom W) (by ext; exact conjHom_conjHom W _)
     (by ext; exact conjHom_conjHom W _)
 
-@[simp]
 private lemma conj_apply (x : W.CoordinateRing) : conj W x = conjHom W x := by
   simp [conj]
 
 /-- Conjugation sends the coordinate `y` to `-y - (a₁X + a₃)`. -/
+@[simp]
 lemma conj_mk_Y : conj W (AdjoinRoot.root W.polynomial) = mk W W.negPolynomial := by
   rw [conj_apply, conjHom_mk_Y]
 
 /-- Conjugation fixes the coefficient ring `R[X]`. -/
+@[simp]
 lemma conj_mk_C (r : R[X]) : conj W (AdjoinRoot.of W.polynomial r) = mk W (C r) := by
   rw [conj_apply, conjHom_mk_C]
 

--- a/TauCeti/Geometry/Manifold/Boundary/Charts.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Charts.lean
@@ -248,7 +248,6 @@ theorem boundaryChartedSpace_atlas :
 variable (M) in
 /-- The source of the preferred boundary chart at `p` is the part of the boundary the ambient
 preferred chart at `p` sees. -/
-@[simp]
 theorem boundaryChartedSpace_chartAt_source (p : ↥((𝓡∂ (n + 1)).boundary M)) :
     (chartAt (EuclideanSpace ℝ (Fin n)) p).source =
       Subtype.val ⁻¹' (chartAt (EuclideanHalfSpace (n + 1)) (p : M)).source :=
@@ -259,7 +258,6 @@ theorem boundaryChartedSpace_chartAt_source (p : ↥((𝓡∂ (n + 1)).boundary 
 variable (M) in
 /-- The target of the preferred boundary chart at `p` is the ambient target, pulled back to the
 coordinate hyperplane. -/
-@[simp]
 theorem boundaryChartedSpace_chartAt_target (p : ↥((𝓡∂ (n + 1)).boundary M)) :
     (chartAt (EuclideanSpace ℝ (Fin n)) p).target =
       EuclideanHalfSpace.boundaryParam n ⁻¹'
@@ -271,7 +269,6 @@ theorem boundaryChartedSpace_chartAt_target (p : ↥((𝓡∂ (n + 1)).boundary 
 variable (M) in
 /-- The preferred boundary chart at `p` reads a point through the ambient preferred chart at `p`
 and deletes the zeroth coordinate. -/
-@[simp]
 theorem boundaryChartedSpace_chartAt_apply (p q : ↥((𝓡∂ (n + 1)).boundary M)) :
     chartAt (EuclideanSpace ℝ (Fin n)) p q =
       EuclideanHalfSpace.boundaryProj n
@@ -283,7 +280,6 @@ theorem boundaryChartedSpace_chartAt_apply (p q : ↥((𝓡∂ (n + 1)).boundary
 variable (M) in
 /-- On its target, the inverse of the preferred boundary chart at `p` is the inverse of the ambient
 preferred chart at `p`, applied to the parametrized point. -/
-@[simp]
 theorem boundaryChartedSpace_chartAt_symm_apply (p : ↥((𝓡∂ (n + 1)).boundary M))
     {z : EuclideanSpace ℝ (Fin n)}
     (hz : EuclideanHalfSpace.boundaryParam n z ∈

--- a/TauCeti/KnotTheory/Grid/ChainCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/ChainCardinality.lean
@@ -52,7 +52,6 @@ theorem card (R : Type*) [Zero R] [Fintype R] (n : ℕ) :
   rw [Fintype.card_finsupp, GridState.card]
 
 /-- The natural cardinality of chains over a finite coefficient type is `Nat.card R ^ n!`. -/
-@[simp]
 theorem natCard (R : Type*) [Zero R] [Finite R] (n : ℕ) :
     Nat.card (GridChain R n) = Nat.card R ^ n.factorial := by
   classical

--- a/TauCeti/NumberTheory/ModularForms/Petersson/Orthogonal.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Orthogonal.lean
@@ -163,7 +163,6 @@ noncomputable local instance peterssonInnerProductSpace :
 
 /-- The inner product induced locally from the Petersson core evaluates to the Petersson
 pairing. -/
-@[simp]
 private theorem peterssonInner_apply (f g : CuspForm (Γ.map (mapGL ℝ)) k) :
     inner ℂ f g = peterssonInnerCosets f g :=
   peterssonInnerCosetsCore_inner f g

--- a/scripts/lint-baseline.txt
+++ b/scripts/lint-baseline.txt
@@ -34,7 +34,6 @@ simpNF TauCeti.ComoduleCat.sum_apply
 simpNF TauCeti.ComoduleCat.transportIso_hom_apply
 simpNF TauCeti.ComoduleCat.transportIso_inv_apply
 simpNF TauCeti.ComoduleCat.zsmul_apply
-simpNF TauCeti.CuspForm.peterssonInner_apply✝
 simpNF TauCeti.Deck.conjMulEquivTrans
 simpNF TauCeti.Deck.fiberOrbitQuotientEquiv_trans
 simpNF TauCeti.Deck.subgroupFiberOrbitQuotientEquiv_trans
@@ -44,7 +43,6 @@ simpNF TauCeti.FGComoduleCat.corestrict_obj_coact_apply
 simpNF TauCeti.FGComoduleCat.incl_cofree
 simpNF TauCeti.FGComoduleCat.ofHom_comp
 simpNF TauCeti.FGComoduleCat.ofHom_id
-simpNF TauCeti.GridChain.natCard
 simpNF TauCeti.HopfAlgebra.PointRepresentation.ofComodule_action_tmul
 simpNF TauCeti.HopfAlgebra.PointRepresentation.ofComodule_action_universal_one_tmul
 simpNF TauCeti.HopfIdeal.coefficientLinearEquiv_apply✝
@@ -65,13 +63,7 @@ simpNF TauCeti.Subgroup.normalizerEquivMap_symm_apply_coe'
 simpNF TauCeti.Subgroup.normalizerEquivMap_trans_apply_coe
 simpNF TauCeti.Subgroup.normalizerQuotientEquivMap_symm_mk'
 simpNF TauCeti.WeierstrassCurve.Affine.CoordinateRing.conj_conj
-simpNF TauCeti.WeierstrassCurve.Affine.CoordinateRing.conj_mk_C
-simpNF TauCeti.WeierstrassCurve.Affine.CoordinateRing.conj_mk_Y
 simpNF TauCeti.WeierstrassCurve.Affine.CoordinateRing.mul_conj
-simpNF TauCeti.boundaryChartedSpace_chartAt_apply
-simpNF TauCeti.boundaryChartedSpace_chartAt_source
-simpNF TauCeti.boundaryChartedSpace_chartAt_symm_apply
-simpNF TauCeti.boundaryChartedSpace_chartAt_target
 simpNF TauCeti.integral_normalizedChebyshevT_mul_normalizedChebyshevT_measureT_eq_ite
 simpNF TauCeti.isComplexLinear_arrowCongr_iff
 simpNF TauCeti.reflectRepMapApp_of_ne✝

--- a/scripts/lint-baseline.txt
+++ b/scripts/lint-baseline.txt
@@ -62,8 +62,6 @@ simpNF TauCeti.Subgroup.normalizerEquivMap_symm_apply_coe
 simpNF TauCeti.Subgroup.normalizerEquivMap_symm_apply_coe'
 simpNF TauCeti.Subgroup.normalizerEquivMap_trans_apply_coe
 simpNF TauCeti.Subgroup.normalizerQuotientEquivMap_symm_mk'
-simpNF TauCeti.WeierstrassCurve.Affine.CoordinateRing.conj_conj
-simpNF TauCeti.WeierstrassCurve.Affine.CoordinateRing.mul_conj
 simpNF TauCeti.integral_normalizedChebyshevT_mul_normalizedChebyshevT_measureT_eq_ite
 simpNF TauCeti.isComplexLinear_arrowCongr_iff
 simpNF TauCeti.reflectRepMapApp_of_ne✝


### PR DESCRIPTION
This PR clears ten of the sixteen `simpNF` findings [#2773](https://github.com/TauCetiProject/TauCeti/pull/2773) grandfathered when the environment lint began reaching declarations the module-style driver could not see.

Six are lemmas simp already proves from their neighbours, so the `@[simp]` adds work to every simp call without adding reach: the four `boundaryChartedSpace_chartAt_*` lemmas, `GridChain.natCard`, and the private `CuspForm.peterssonInner_apply`. The statements stay; only the attribute goes.

The other four are the coordinate-ring conjugation family, and they had a common cause worth naming. The private `conj_apply` was tagged `@[simp]`, so simp rewrote the public `conj` into the private `conjHom`; that made `conj` a non-normal form and left every public lemma stated about it — `conj_conj` and `mul_conj` — reported as having a left-hand side that simplifies, while `conj_mk_Y` and `conj_mk_C` were reported as redundant because simp reached them through that same unfolding. Dropping `@[simp]` from the private helper instead makes the public `conj` the normal form, which fixes all four at once and keeps `conj_mk_Y` and `conj_mk_C` doing useful work as simp lemmas.

Six findings remain, all of the "left-hand side is not in normal form" kind in the Hopf-algebra and reflection material, and they need their statements restated rather than an attribute moved.

Verified locally: `lake build --iofail` clean, and `scripts/lint-env.sh` reports `PASS — no new violations (85 grandfathered, 2 ratchetable)`.

Roadmap: none

🤖 Prepared with Claude Code