### PR TITLE
feat(EllipticCurve): the place at infinity is ramified of index two over the base

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -54,6 +54,11 @@ The route is that of the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINT
 `ordAtInfty`, `ordAtInfty_mul`, `ordAtInfty_add_ge_min` (tagged T-ORD-ARITH-12) and
 `ordAtInfty_coordX`/`ordAtInfty_coordY`.
 
+The ramification statement corresponds to that project's `Curves/OrdAtInftyRamification.lean` and
+`Curves/RamificationAtInfinity.lean`; there it is an order identity for a `WithTop ℤ`-valued
+`ordAtInfty` over the `SmoothPlaneCurve` wrapper, where here it is an equality of Mathlib
+`Valuation`s and follows from `Algebra.norm_algebraMap` with `finrank_functionField`.
+
 Changes from the source. There `ordAtInfty` is a definition of its own, valued in `WithTop ℤ`, built
 over a `SmoothPlaneCurve` structure wrapping `WeierstrassCurve.Affine`, with multiplicativity,
 vanishing and the ultrametric bound all proved by hand. Here the norm is Mathlib's `Algebra.norm`
@@ -298,12 +303,21 @@ theorem infinityPlace.mk_Y :
 
 
 open scoped Classical in
+/-- **The place at infinity lies over the infinite place of `F(x)`, with ramification index two.**
+On a rational function of `x` the value is the square of Mathlib's infinite valuation, the extension
+`F(W) / F(x)` being quadratic. -/
+@[simp]
+theorem infinityPlace.algebraMap_eq_sq (r : RatFunc F) :
+    infinityPlace W (algebraMap (RatFunc F) W.FunctionField r)
+      = RatFunc.inftyValuation F r ^ 2 := by
+  rw [infinityPlace_apply, Algebra.norm_algebraMap, finrank_functionField W (RatFunc F), map_pow]
+
+open scoped Classical in
 /-- **The valuation is trivial on the base field**: a nonzero constant has value `1`, so `v_∞`
 restricted to `F` is trivial. The analogue of `RatFunc.inftyValuation.C`. -/
 theorem infinityPlace.C {c : F} (hc : c ≠ 0) :
     infinityPlace W (algebraMap (RatFunc F) W.FunctionField (RatFunc.C c)) = 1 := by
-  rw [infinityPlace_apply, Algebra.norm_algebraMap, finrank_functionField W (RatFunc F), map_pow,
-    RatFunc.inftyValuation.C (F := F) hc, one_pow]
+  rw [infinityPlace.algebraMap_eq_sq, RatFunc.inftyValuation.C (F := F) hc, one_pow]
 
 
 open scoped Classical in
@@ -337,16 +351,6 @@ theorem infinityPlace.adjoinRoot_root :
       (AdjoinRoot.root W.polynomial)) = WithZero.exp 3 :=
   infinityPlace.mk_Y W
 
-
-open scoped Classical in
-/-- **The place at infinity lies over the infinite place of `F(x)`, with ramification index two.**
-On a rational function of `x` the value is the square of Mathlib's infinite valuation, the extension
-`F(W) / F(x)` being quadratic. -/
-@[simp]
-theorem infinityPlace_algebraMap (r : RatFunc F) :
-    infinityPlace W (algebraMap (RatFunc F) W.FunctionField r)
-      = RatFunc.inftyValuation F r ^ 2 := by
-  rw [infinityPlace_apply, Algebra.norm_algebraMap, finrank_functionField W (RatFunc F), map_pow]
 
 end WeierstrassCurve.Affine
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -337,6 +337,17 @@ theorem infinityPlace.adjoinRoot_root :
       (AdjoinRoot.root W.polynomial)) = WithZero.exp 3 :=
   infinityPlace.mk_Y W
 
+
+open scoped Classical in
+/-- **The place at infinity lies over the infinite place of `F(x)`, with ramification index two.**
+On a rational function of `x` the value is the square of Mathlib's infinite valuation, the extension
+`F(W) / F(x)` being quadratic. -/
+@[simp]
+theorem infinityPlace_algebraMap (r : RatFunc F) :
+    infinityPlace W (algebraMap (RatFunc F) W.FunctionField r)
+      = RatFunc.inftyValuation F r ^ 2 := by
+  rw [infinityPlace_apply, Algebra.norm_algebraMap, finrank_functionField W (RatFunc F), map_pow]
+
 end WeierstrassCurve.Affine
 
 end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -26,13 +26,16 @@ at infinity of the curve: `ord_∞ f = -deg N f`, the place where `x` and `y` ha
 The valuation's `map_add_le_max'` rests on an ultrametric inequality in degree form, proved here;
 the other three axioms are the norm's multiplicativity and Mathlib's place at infinity.
 * `WeierstrassCurve.Affine.infinityPlace.X`,
-  `WeierstrassCurve.Affine.infinityPlace.mk_Y`
+  `WeierstrassCurve.Affine.infinityPlace.mk_Y`: `v_∞ x = exp 2` and `v_∞ y = exp 3` — the double
+  and triple poles at infinity, `ord_∞ x = -2` and `ord_∞ y = -3`, which is what Layer 0 asks for
+  by name. They read the norm degrees of `FunctionField/Norm.lean` through the valuation.
+* `WeierstrassCurve.Affine.infinityPlace.algebraMap_eq_sq`: restricting along
+  `RatFunc F → W.FunctionField` squares `RatFunc.inftyValuation`, so the place at infinity is
+  ramified of index two over the infinite place of `F(x)`.
 * `WeierstrassCurve.Affine.infinityPlace.C`: the valuation is trivial on the base field — a
-  nonzero constant has value `1`. The `Valuation.IsTrivialOn F` and `Valuation.IsNontrivial`
-  instances follow, so the place is usable through Mathlib's standard valuation
-  API: `v_∞ x = exp 2` and `v_∞ y = exp 3` —
-  the double and triple poles at infinity, `ord_∞ x = -2` and `ord_∞ y = -3`, which is what Layer 0
-  asks for by name. They read the norm degrees of `FunctionField/Norm.lean` through the valuation.
+  nonzero constant has value `1`, the constant case of the previous result. The
+  `Valuation.IsTrivialOn F` and `Valuation.IsNontrivial` instances follow, so the place is usable
+  through Mathlib's standard valuation API.
 
 Each special value comes in two forms: one stated about the curve's coordinate functions, and a
 `@[simp]` restatement in the shape simp actually normalises them to. The machinery that builds the


### PR DESCRIPTION
The place at infinity exists (#2772) and is distinct from every affine place (#2790). This records how it sits over the base: it is ramified of index two over the infinite place of `F(x)`.

```lean
-- Affine/FunctionField/InfinityPlace.lean, beside infinityPlace
@[simp] theorem WeierstrassCurve.Affine.infinityPlace_algebraMap (r : RatFunc F) :
    infinityPlace W (algebraMap (RatFunc F) W.FunctionField r)
      = RatFunc.inftyValuation F r ^ 2
```

**Why this is the ramification index.** `infinityPlace` is Mathlib's `RatFunc.inftyValuation` composed with the algebra norm, and the norm of an `algebraMap` is the `finrank`-th power of its argument; the extension `F(W) / F(x)` is quadratic (`finrank_functionField`), so a rational function of `x` picks up the square. Reading it additively, `ord_∞ (r) = 2 · ord_{v_∞} (r)` for `r ∈ F(x)`: the place at infinity is the unique place above `v_∞`, totally ramified with `e = 2`.

Note the shape of the statement is not an inequality or a specialisation — it is the exact value on the whole subfield `F(x)`, which is what a ramification statement needs. The earlier `infinityPlace.C` (#2772) is the constant case of it.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 0** (the function field, places, and divisors). §Places records the place at infinity with `ord_∞ x = −2`, `ord_∞ y = −3` and residue field `K`; §`inducedPlace` asks for the place of `F₂` under a place of `F₁` along a `K`-algebra map "with ramification index `e` and residue degree `f`". This is that `e` for the one map the layer needs first, `F(x) ⊆ F(W)`: the value on `F(x)` is the base value squared. The general `inducedPlace` API, the residue degree `f`, and the fundamental identity are separate statements and are not claimed here.

Layer 0 seeds no declaration this competes with: `Suggested.lean` records that the function-field layer's "types are new API and are built there, not pinned here".

## Provenance

Not a port. The AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `dev/hasse-weil` at `a582951fe96b`) has `Curves/OrdAtInftyRamification.lean` and `Curves/RamificationAtInfinity.lean` covering ramification at infinity, but both are built on that development's `SmoothPlaneCurve` wrapper and its own `WithTop ℤ`-valued `ordAtInfty`, and state the result as an order identity rather than an equality of Mathlib valuations. Here the statement is an equality of `Valuation`s into `ℤᵐ⁰` and the proof is two rewrites — `Algebra.norm_algebraMap` and `finrank_functionField` — because #2772 already defines the place as the norm composed with Mathlib's infinite valuation.

## Mathlib absence

Mathlib has `RatFunc.inftyValuation`, `Algebra.norm_algebraMap` and the `Valuation` API, but no place of a curve's function field at all, so no statement relating one to the infinite place of `F(x)` can exist there. An untruncated recursive grep of `Mathlib/AlgebraicGeometry/EllipticCurve/` for `inftyValuation`, `ramification` and `Valuation` finds nothing.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"placeramified"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
