### PR TITLE
refactor: share the prefix/tail splitting equivalence

### DIFF
--- a/TauCeti/Probability/DeFinetti/PrefixDeletion.lean
+++ b/TauCeti/Probability/DeFinetti/PrefixDeletion.lean
@@ -95,32 +95,6 @@ private lemma phi1_strictMono (r m : ℕ) : StrictMono (phi1 r m) := by
 
 /-! ### Prefix-tail split as a measurable equivalence -/
 
-/-- Split a sequence into its length-`r` prefix `Fin r → α` and the tail `ℕ → α` from index `r`, as
-a measurable equivalence.  The forward map sends `f` to `(fun i => f i.val, fun j => f (r + j))`;
-its inverse glues a prefix/tail pair back into a sequence, taking coordinates below `r` from the
-prefix and the rest (reindexed by `· - r`) from the tail. -/
-private def prefixSplitEquiv (r : ℕ) : (ℕ → α) ≃ᵐ (Fin r → α) × (ℕ → α) :=
-  (MeasurableEquiv.arrowCongr' (finSumNatEquiv r).symm (.refl α)).trans
-    (MeasurableEquiv.sumPiEquivProdPi fun _ => α)
-
-/-- The inverse of `prefixSplitEquiv` glues a prefix/tail pair into a sequence: coordinates below
-`r` come from the prefix `p.1`, the rest (reindexed by `· - r`) from the tail `p.2`. -/
-private lemma prefixSplitEquiv_symm_apply (r : ℕ) (p : (Fin r → α) × (ℕ → α)) (n : ℕ) :
-    (prefixSplitEquiv r).symm p n = if h : n < r then p.1 ⟨n, h⟩ else p.2 (n - r) := by
-  have key : (prefixSplitEquiv r).symm p
-      = fun n => if h : n < r then p.1 ⟨n, h⟩ else p.2 (n - r) := by
-    apply (prefixSplitEquiv r).injective
-    rw [MeasurableEquiv.apply_symm_apply]
-    -- BRITTLE: uses the defeq `prefixSplitEquiv r f = (fun i => f i.val, fun j => f (r + j))`;
-    -- `MeasurableEquiv.arrowCongr'` exposes no coe/apply lemma, so this cannot be a `simp` rewrite.
-    change p = (fun i : Fin r => (if h : (i : ℕ) < r then p.1 ⟨i, h⟩ else p.2 ((i : ℕ) - r)),
-        fun j : ℕ => if h : r + j < r then p.1 ⟨r + j, h⟩ else p.2 (r + j - r))
-    refine Prod.ext (funext fun i => ?_) (funext fun j => ?_)
-    · simp only [dite_eq_left i.isLt, Fin.eta]
-    · have h : ¬ (r + j < r) := Nat.not_lt.mpr (Nat.le_add_right r j)
-      simp only [dite_eq_right h, Nat.add_sub_cancel_left]
-  rw [key]
-
 omit [MeasurableSpace Ω] in
 /-- Gluing the length-`r` prefix `i ↦ X i` onto the shifted tail `processShift X (m+1)` yields the
 `phi0`-reindexing of `X` (evaluated pointwise). -/

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -7,6 +7,8 @@ module
 public import Mathlib.MeasureTheory.Measure.Map
 public import Mathlib.MeasureTheory.Measure.AEMeasurable
 public import Mathlib.MeasureTheory.MeasurableSpace.Constructions
+public import Mathlib.MeasureTheory.MeasurableSpace.Embedding
+public import Mathlib.Logic.Equiv.Fin.Basic
 public import Mathlib.Tactic.Measurability
 
 /-!
@@ -169,6 +171,32 @@ theorem measurable_prefixProj (n : ℕ) : Measurable (prefixProj α n) := by
 theorem measurable_shift : Measurable (shift α) := by
   unfold shift
   measurability
+
+/-- Split a sequence into its length-`r` prefix `Fin r → α` and the tail `ℕ → α` from index `r`, as
+a measurable equivalence.  The forward map sends `f` to `(fun i => f i.val, fun j => f (r + j))`;
+its inverse glues a prefix/tail pair back into a sequence, taking coordinates below `r` from the
+prefix and the rest (reindexed by `· - r`) from the tail. -/
+def prefixSplitEquiv (r : ℕ) : (ℕ → α) ≃ᵐ (Fin r → α) × (ℕ → α) :=
+  (MeasurableEquiv.arrowCongr' (finSumNatEquiv r).symm (.refl α)).trans
+    (MeasurableEquiv.sumPiEquivProdPi fun _ => α)
+
+/-- The inverse of `prefixSplitEquiv` glues a prefix/tail pair into a sequence: coordinates below
+`r` come from the prefix `p.1`, the rest (reindexed by `· - r`) from the tail `p.2`. -/
+theorem prefixSplitEquiv_symm_apply (r : ℕ) (p : (Fin r → α) × (ℕ → α)) (n : ℕ) :
+    (prefixSplitEquiv r).symm p n = if h : n < r then p.1 ⟨n, h⟩ else p.2 (n - r) := by
+  have key : (prefixSplitEquiv r).symm p
+      = fun n => if h : n < r then p.1 ⟨n, h⟩ else p.2 (n - r) := by
+    apply (prefixSplitEquiv r).injective
+    rw [MeasurableEquiv.apply_symm_apply]
+    -- BRITTLE: uses the defeq `prefixSplitEquiv r f = (fun i => f i.val, fun j => f (r + j))`;
+    -- `MeasurableEquiv.arrowCongr'` exposes no coe/apply lemma, so this cannot be a `simp` rewrite.
+    change p = (fun i : Fin r => (if h : (i : ℕ) < r then p.1 ⟨i, h⟩ else p.2 ((i : ℕ) - r)),
+        fun j : ℕ => if h : r + j < r then p.1 ⟨r + j, h⟩ else p.2 (r + j - r))
+    refine Prod.ext (funext fun i => ?_) (funext fun j => ?_)
+    · simp only [dite_eq_left i.isLt, Fin.eta]
+    · have h : ¬ (r + j < r) := Nat.not_lt.mpr (Nat.le_add_right r j)
+      simp only [dite_eq_right h, Nat.add_sub_cancel_left]
+  rw [key]
 
 /-- The prefix law is the pushforward of the path law by `prefixProj`. -/
 theorem map_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -23,7 +23,13 @@ hypotheses enter only in lemmas that compose `Measure.map`s.
 definitions here are about the order structure of `ℕ` (prefixes, shifts, strictly increasing
 selections) and stay sequence-level.
 
-These declarations follow the roadmap signatures in
+The prefix/tail measurable equivalence `prefixSplitEquiv` is an exception on both counts: it is
+neither a roadmap signature nor adapted from the pinned sources, but general infrastructure that
+several exchangeability arguments need in order to reindex a sequence as a length-`r` prefix paired
+with the tail from index `r`. It lives here because it is stated purely in terms of the order
+structure of `ℕ`, with no measure and no process.
+
+The remaining declarations follow the roadmap signatures in
 `TauCetiRoadmap/Exchangeability/README.md` and
 `TauCetiRoadmap/Exchangeability/Suggested.lean`, Layer 0. They are adapted from the
 `cameronfreer/exchangeability` Layer 0 sources pinned at
@@ -180,18 +186,24 @@ def prefixSplitEquiv (r : ℕ) : (ℕ → α) ≃ᵐ (Fin r → α) × (ℕ → 
   (MeasurableEquiv.arrowCongr' (finSumNatEquiv r).symm (.refl α)).trans
     (MeasurableEquiv.sumPiEquivProdPi fun _ => α)
 
+/-- **Applying `prefixSplitEquiv`**: it reads off the length-`r` prefix and the tail from index `r`.
+
+This is the one place that depends on the definitional form of `MeasurableEquiv.arrowCongr'` and
+`sumPiEquivProdPi`, neither of which exposes an apply lemma. Everything else about the equivalence
+is derived from here, so the fragile step is isolated rather than repeated. -/
+@[simp]
+theorem prefixSplitEquiv_apply (r : ℕ) (f : ℕ → α) :
+    prefixSplitEquiv r f = (fun i : Fin r => f (i : ℕ), fun j : ℕ => f (r + j)) := (rfl)
+
 /-- The inverse of `prefixSplitEquiv` glues a prefix/tail pair into a sequence: coordinates below
 `r` come from the prefix `p.1`, the rest (reindexed by `· - r`) from the tail `p.2`. -/
+@[simp]
 theorem prefixSplitEquiv_symm_apply (r : ℕ) (p : (Fin r → α) × (ℕ → α)) (n : ℕ) :
     (prefixSplitEquiv r).symm p n = if h : n < r then p.1 ⟨n, h⟩ else p.2 (n - r) := by
   have key : (prefixSplitEquiv r).symm p
       = fun n => if h : n < r then p.1 ⟨n, h⟩ else p.2 (n - r) := by
     apply (prefixSplitEquiv r).injective
-    rw [MeasurableEquiv.apply_symm_apply]
-    -- BRITTLE: uses the defeq `prefixSplitEquiv r f = (fun i => f i.val, fun j => f (r + j))`;
-    -- `MeasurableEquiv.arrowCongr'` exposes no coe/apply lemma, so this cannot be a `simp` rewrite.
-    change p = (fun i : Fin r => (if h : (i : ℕ) < r then p.1 ⟨i, h⟩ else p.2 ((i : ℕ) - r)),
-        fun j : ℕ => if h : r + j < r then p.1 ⟨r + j, h⟩ else p.2 (r + j - r))
+    rw [MeasurableEquiv.apply_symm_apply, prefixSplitEquiv_apply]
     refine Prod.ext (funext fun i => ?_) (funext fun j => ?_)
     · simp only [dite_eq_left i.isLt, Fin.eta]
     · have h : ¬ (r + j < r) := Nat.not_lt.mpr (Nat.le_add_right r j)


### PR DESCRIPTION
`prefixSplitEquiv (r : ℕ) : (ℕ → α) ≃ᵐ (Fin r → α) × (ℕ → α)` and its `symm_apply` lemma were
`private` to `DeFinetti/PrefixDeletion.lean`. The equivalence is generic in the value type and is
the canonical prefix/tail split; it belongs with `prefixProj`, the prefix projection it refines.

This moves both to `Exchangeability/Basic.lean` and drops the `private` markers. No statement
changes, and `PrefixDeletion` uses them unchanged — it now picks them up transitively through
`Contractability`.

## Why

A second consumer needs exactly this construction. In #2721 the reindexing that reads a strictly
monotone block and then a common future is, precisely,

```lean
(prefixSplitEquiv (α := ℕ) r).symm (k, fun n => c + n)
```

— the equivalence instantiated at `ℕ`, gluing *index* functions rather than paths. That PR
currently carries a private `blockThenFuture` duplicating it, and a `reuse` finding there asks for
this relocation. Per `CLAUDE.md` a prerequisite refactor ships as its own PR rather than inside the
feature, which is what this is; #2721 will be rebased onto it and its duplicate deleted.

Roadmap: none

General infrastructure: a measurable equivalence on path space, with no exchangeability,
contractability, or de Finetti content of its own.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol