### PR TITLE
feat(Modular): the S-translate preserves the orbit

### DIFF
--- a/TauCeti/NumberTheory/Modular/Orbits.lean
+++ b/TauCeti/NumberTheory/Modular/Orbits.lean
@@ -19,6 +19,7 @@ orbit once.
 
 * `TauCeti.ModularGroup.exists_rep_mem_fd`: every orbit meets `𝒟`.
 * `TauCeti.ModularGroup.orbit_mk_int_vadd`: integer translation preserves the orbit.
+* `TauCeti.ModularGroup.orbit_mk_S_smul`: the `S`-translate preserves the orbit.
 * `TauCeti.ModularGroup.orbit_mk_injOn_fdo`: the orbit map is injective on `𝒟ᵒ`.
 -/
 
@@ -61,6 +62,17 @@ lemma orbit_mk_injOn_fdo :
   have hg' : g • q = p := hg
   have hgq : g • q ∈ 𝒟ᵒ := by rw [hg']; exact hp
   exact hg'.symm.trans (_root_.ModularGroup.eq_smul_self_of_mem_fdo_mem_fdo hq hgq).symm
+
+/-- The `S`-translate of a point lies in the same `SL(2, ℤ)`-orbit. Together with
+`orbit_mk_int_vadd` this is the pair of boundary identifications of the standard fundamental
+domain: `T` identifies its two vertical edges, `S` the two halves of its arc. Both are needed to
+count each orbit once when a divisor meets the boundary. -/
+-- Not a `simp` lemma: `UpperHalfPlane.modular_S_smul` already rewrites `S • z`, so this
+-- left-hand side is never in simp normal form and `simpNF` rejects the annotation.
+lemma orbit_mk_S_smul (z : ℍ) :
+    (Quotient.mk'' (_root_.ModularGroup.S • z) :
+      MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) = Quotient.mk'' z :=
+  Quotient.sound' ⟨_root_.ModularGroup.S, rfl⟩
 
 end ModularGroup
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-formula/orbit-S-translate"}-->

The second of the two boundary identifications of the standard fundamental domain, as an orbit
statement:

```lean
Quotient.mk'' (ModularGroup.S • z) = Quotient.mk'' z
```

## Why this is missing

`Modular/Orbits.lean` already has `orbit_mk_int_vadd`: integer translation preserves the orbit —
the `T`-identification of the domain's two **vertical edges**. It has no companion for `S`, which
identifies the two halves of the **arc**.

Both are needed to count each orbit exactly once when a divisor point lies on the boundary. The
valence formula's orbit-indexed form (#2789) currently sidesteps this by requiring every
non-corner divisor point to lie in the *open* domain, where the orbit map is injective and no
identification arises. Admitting boundary points — the next step toward the roadmap's all-orbits
statement — needs both halves of the pairing, and this supplies the missing one.

## Not a simp lemma

`UpperHalfPlane.modular_S_smul` is itself a simp lemma rewriting `S • z`, so this left-hand side
is never in simp normal form and `simpNF` rejects the annotation. Its `T` sibling *is* `@[simp]`
because `+ᵥ` has no such rewrite. The reason is recorded in-source so the asymmetry does not read
as an oversight.

## Main declarations

* `TauCeti.ModularGroup.orbit_mk_S_smul`

Roadmap: ModularForms

Layer 1 of the ModularForms roadmap, *the valence formula (general level)*. That layer describes
the boundary identification explicitly — the two `ρ`-corners "summing to the orbit's `⅓` after
boundary identification" — and this is a prerequisite for stating the divisor sum over orbits when
the divisor meets the boundary.
