### PR TITLE
feat(ModularForms): the diamond operator indexed by a natural number

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
+++ b/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
@@ -39,6 +39,8 @@ re-founded slash action with built-in character) and their names. The Hecke pair
   by `coe_diamondOp`/`coe_diamondOpCusp` as slashing by any representative.
 * `diamondOpHom`/`diamondOpCuspHom`: the diamond operators as monoid homomorphisms into the
   endomorphism algebras.
+* `diamondOpNat`: the same operator indexed by a natural number, `⟨n⟩` of
+  Diamond–Shurman §5.3, extended by zero when `n` is not coprime to `N`.
 * `modFormCharSpace`/`cuspFormCharSpace`: the nebentypus character spaces `M_k(Γ₁(N), χ)` and
   `S_k(Γ₁(N), χ)`, cut out as simultaneous diamond eigenspaces.
 
@@ -335,3 +337,25 @@ theorem mem_cuspFormCharSpace_iff_nebentypus [NeZero N] (k : ℤ) (χ₀ : (ZMod
   · obtain ⟨g, hg⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
     rw [diamondOpCuspHom_apply, diamondOpCusp_eq_diamondOpCuspAux k d g hg, ← hg]
     exact CuspForm.ext (congr_fun (h g))
+
+/-- The diamond operator indexed by a natural number: `⟨n⟩` is `diamondOp` at the unit `n mod N`
+when `n` is coprime to `N`, and `0` otherwise.
+
+This is `⟨n⟩` as Diamond–Shurman §5.3 writes it. Extending the index from `(ZMod N)ˣ` to `ℕ` by
+zero is what lets the Hecke recurrence at a prime power be stated uniformly: the `⟨p⟩` term
+simply vanishes when `p ∣ N`, instead of the recurrence needing a separate case. -/
+noncomputable def diamondOpNat [NeZero N] (k : ℤ) (n : ℕ) :
+    ModularForm ((Gamma1 N).map (mapGL ℝ)) k →ₗ[ℂ] ModularForm ((Gamma1 N).map (mapGL ℝ)) k :=
+  if h : Nat.Coprime n N then diamondOp k (ZMod.unitOfCoprime n h) else 0
+
+-- Not a `simp` lemma: the right-hand side mentions the coprimality proof `h`, which `simp`
+-- cannot recover from the left-hand side, so it could never apply. Its negative counterpart is
+-- `simp`-able because that right-hand side is just `0`.
+lemma diamondOpNat_of_coprime [NeZero N] (k : ℤ) {n : ℕ} (h : Nat.Coprime n N) :
+    diamondOpNat k n = diamondOp k (ZMod.unitOfCoprime n h) :=
+  dite_eq_left_of_eq_true (by simpa using h)
+
+@[simp]
+lemma diamondOpNat_of_not_coprime [NeZero N] (k : ℤ) {n : ℕ} (h : ¬ Nat.Coprime n N) :
+    diamondOpNat (N := N) k n = 0 :=
+  dite_eq_right_of_eq_false (by simpa using h)

--- a/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
+++ b/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
@@ -347,9 +347,9 @@ simply vanishes when `p ∣ N`, instead of the recurrence needing a separate cas
 
 Follows `diamondOp_n` of the AINTLIB `LeanModularForms` project
 (`HeckeRIngs/GL2/HeckeT_n.lean`, <https://github.com/CBirkbeck/AINTLIB>, commit
-`ce76186b5f61c846d770d2f87eb76ba5b9c9117a`, Apache-2.0). The statement is that project's; the
-proofs are re-derived against the current Mathlib pin, where `dif_pos`/`dif_neg` are deprecated
-and the coprime lemma cannot carry `@[simp]`. -/
+`ce76186b5f61c846d770d2f87eb76ba5b9c9117a`, Apache-2.0). -/
+-- The statement is that project's; the proofs below are re-derived against the current Mathlib
+-- pin, where `dif_pos`/`dif_neg` are deprecated and the coprime lemma cannot carry `@[simp]`.
 noncomputable def diamondOpNat [NeZero N] (k : ℤ) (n : ℕ) :
     ModularForm ((Gamma1 N).map (mapGL ℝ)) k →ₗ[ℂ] ModularForm ((Gamma1 N).map (mapGL ℝ)) k :=
   if h : Nat.Coprime n N then diamondOp k (ZMod.unitOfCoprime n h) else 0

--- a/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
+++ b/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
@@ -53,7 +53,7 @@ re-founded slash action with built-in character) and their names. The Hecke pair
 ## References
 
 * Miyake, *Modular forms*, §4.5
-* Diamond–Shurman, *A first course in modular forms*, §5.1
+* Diamond–Shurman, *A first course in modular forms*, §5.1 and §5.3
 -/
 
 public section
@@ -343,11 +343,18 @@ when `n` is coprime to `N`, and `0` otherwise.
 
 This is `⟨n⟩` as Diamond–Shurman §5.3 writes it. Extending the index from `(ZMod N)ˣ` to `ℕ` by
 zero is what lets the Hecke recurrence at a prime power be stated uniformly: the `⟨p⟩` term
-simply vanishes when `p ∣ N`, instead of the recurrence needing a separate case. -/
+simply vanishes when `p ∣ N`, instead of the recurrence needing a separate case.
+
+Follows `diamondOp_n` of the AINTLIB `LeanModularForms` project
+(`HeckeRIngs/GL2/HeckeT_n.lean`, <https://github.com/CBirkbeck/AINTLIB>, commit
+`ce76186b5f61c846d770d2f87eb76ba5b9c9117a`, Apache-2.0). The statement is that project's; the
+proofs are re-derived against the current Mathlib pin, where `dif_pos`/`dif_neg` are deprecated
+and the coprime lemma cannot carry `@[simp]`. -/
 noncomputable def diamondOpNat [NeZero N] (k : ℤ) (n : ℕ) :
     ModularForm ((Gamma1 N).map (mapGL ℝ)) k →ₗ[ℂ] ModularForm ((Gamma1 N).map (mapGL ℝ)) k :=
   if h : Nat.Coprime n N then diamondOp k (ZMod.unitOfCoprime n h) else 0
 
+/-- When `n` is coprime to `N`, `⟨n⟩` is the diamond operator at the unit `n mod N`. -/
 -- Not a `simp` lemma: the right-hand side mentions the coprimality proof `h`, which `simp`
 -- cannot recover from the left-hand side, so it could never apply. Its negative counterpart is
 -- `simp`-able because that right-hand side is just `0`.
@@ -355,6 +362,8 @@ lemma diamondOpNat_of_coprime [NeZero N] (k : ℤ) {n : ℕ} (h : Nat.Coprime n 
     diamondOpNat k n = diamondOp k (ZMod.unitOfCoprime n h) :=
   dite_eq_left_of_eq_true (by simpa using h)
 
+/-- When `n` is not coprime to `N`, `⟨n⟩` vanishes. This is the case that lets the prime-power
+Hecke recurrence be stated without splitting on whether `p` divides the level. -/
 @[simp]
 lemma diamondOpNat_of_not_coprime [NeZero N] (k : ℤ) {n : ℕ} (h : ¬ Nat.Coprime n N) :
     diamondOpNat (N := N) k n = 0 :=


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke/diamond-op-nat"}-->

The diamond operator indexed by a natural number:

```lean
diamondOpNat k n = if h : Nat.Coprime n N then diamondOp k (ZMod.unitOfCoprime n h) else 0
```

This is `⟨n⟩` as Diamond–Shurman §5.3 writes it.

## Why extend the index to `ℕ`

`diamondOp` is indexed by `(ZMod N)ˣ`, which is the honest home for `⟨d⟩`. But the Hecke
recurrence at a prime power is stated over `ℕ`, and its `⟨p⟩` term must **vanish** when `p ∣ N`.
Extending by zero is what lets that recurrence be written uniformly, instead of splitting into
`p ∤ N` and `p ∣ N` cases at every use.

That is the whole content here: the definition and its two reduction lemmas. It is the first
piece of Layer 2(b) — the Hecke operators acting on forms — none of which is on `main` yet.

## Source and attribution

Derived from the AINTLIB `LeanModularForms` project:

* **Repository:** <https://github.com/CBirkbeck/AINTLIB>
* **Commit:** `ce76186b5f61c846d770d2f87eb76ba5b9c9117a`
* **License:** Apache-2.0 (same as Tau Ceti, so migration is permitted)
* **File:** `projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/HeckeT_n.lean`,
  the `diamondOp_n` declaration and its two lemmas

The source is supplementary; the ModularForms roadmap is authoritative, and the statement was
checked against Diamond–Shurman §5.3 rather than taken on trust.

## What could not be carried over

AINTLIB is pinned to an older Mathlib, so the proofs and attributes were re-derived rather than
copied:

* `dif_pos` / `dif_neg` are deprecated on the current pin, and their suggested replacement
  `dite_cond_eq_true` is deprecated in turn; the live spellings are `dite_eq_left_of_eq_true` and
  `dite_eq_right_of_eq_false`.
* `simp` cannot discharge either lemma, because the `dite` branch depends on the coprimality
  proof itself.
* `diamondOpNat_of_coprime` cannot carry `@[simp]` here: its right-hand side mentions that proof,
  which `simp` cannot recover from the left-hand side, so `simpNF` reports it would never apply.
  AINTLIB marks it `@[simp]`. The negative counterpart keeps the attribute, its right-hand side
  being `0`. The reason is recorded in-source so the asymmetry does not read as an oversight.

## Main declarations

* `diamondOpNat`, `diamondOpNat_of_coprime`, `diamondOpNat_of_not_coprime`

Roadmap: ModularForms

Layer 2(b) of the ModularForms roadmap, *the action on forms* — the operators `Tₙ`, `Tₚ` as
`ℂ`-linear endomorphisms with their `q`-expansion recurrences. `diamondOp`, `diamondOpHom` and
the character spaces are already on `main`; this supplies the `ℕ`-indexed `⟨n⟩` those recurrences
are written in terms of, and is the first step toward the Hecke operators the layer targets.
