### PR TITLE
feat(EllipticCurve): x/y is a uniformiser at the place at infinity

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -50,7 +50,7 @@ ultrametric inequality is `private`, and the norm-degree theory it rests on live
   value group is a nontrivial subgroup of the cyclic `ℤᵐ⁰ˣ`, so Mathlib's `IsRankOneDiscrete`
   instance fires by itself — but the *generator* does: discreteness alone permits `exp (-n)` with
   `n ≥ 1`, and the proper subgroup `2ℤ` genuinely occurs, being the value group of the restriction
-  of `v_∞` to `F(x)`. Surjectivity of `v_∞` rules it out and is proved `private` here.
+  of `v_∞` to `F(x)`. One element of value `exp (-1)` settles it, which is what the value above is.
 
 The quotient value is the one special value whose restatement is not `@[simp]`; the comment above it
 gives the simpNF reason.
@@ -87,13 +87,12 @@ reproved.
 
 The uniformiser corresponds to that project's `HasseWeil/LocalExpansion.lean`, `localParam` — the
 local parameter `t = -x/y` at `O` (Silverman IV.1) — whose uniformising property is recorded there
-through a Laurent-series embedding (`localExpand_localParam`). The surjectivity argument, that the
-integer powers of an element of value `exp (-1)` realise every value, is that project's private
-`surjective_of_eq_exp_neg_one` in `HasseWeil/EC/IsogenyOrdTransport.lean`, used there for the affine
-`pointValuation_surjective'`; the same two-line rewrite serves here. There is no Laurent series and
-no `SmoothPlaneCurve` wrapper in this file: the conclusion is Mathlib's `Valuation.IsUniformizer`
-against Mathlib's discrete-valuation API, and the sign is dropped, `x / y` and `-x / y` having the
-same valuation.
+through a Laurent-series embedding (`localExpand_localParam`), over a `SmoothPlaneCurve` wrapper and
+that development's own `WithTop ℤ`-valued `ordAtInfty`. None of that apparatus is needed here: the
+value of `x / y` is two rewrites from the two pole orders, and Mathlib's
+`Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_mem_range` turns that single value into the
+generator, so the conclusion is Mathlib's `Valuation.IsUniformizer` directly. The sign is dropped,
+`x / y` and `-x / y` having the same valuation.
 -/
 
 public section
@@ -408,31 +407,12 @@ theorem infinityPlace.adjoinRoot_of_X_div_root :
   infinityPlace.X_div_mk_Y W
 
 open scoped Classical in
--- Private: it exists to identify Mathlib's `IsRankOneDiscrete.generator`, and nothing outside this
--- file consumes it yet. The general criterion it specialises — a `ℤᵐ⁰`-valued valuation on a field
--- is surjective as soon as some element has value `exp (-1)` — is not extracted either: Mathlib has
--- no such criterion and inlines this same `WithZero.log` construction in both of its analogues,
--- `RatFunc.valuation_surjective` and `HeightOneSpectrum.valuation_surjective`. When a consumer
--- appears (§Divisors' `deg (div f) = 0`, or the ramification index of §`inducedPlace`, which needs
--- the value groups of both places exactly), that PR should export whichever form it needs.
-/-- **The value group at infinity is all of `ℤ`**: `v_∞` is surjective, so `ord_∞` attains every
-integer value, the powers of the uniformiser `x / y` realising them. -/
-private theorem infinityPlace_surjective : Function.Surjective (infinityPlace W) := by
-  intro g
-  obtain rfl | hg := eq_or_ne g 0
-  · exact ⟨0, map_zero _⟩
-  refine ⟨(algebraMap W.CoordinateRing W.FunctionField
-      (algebraMap F[X] W.CoordinateRing Polynomial.X) /
-    algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W Y)) ^ (-WithZero.log g), ?_⟩
-  rw [map_zpow₀, infinityPlace.X_div_mk_Y, ← WithZero.exp_zsmul, smul_eq_mul, neg_mul_neg, mul_one,
-    WithZero.exp_log hg]
-
-open scoped Classical in
 -- The place is discrete of rank one for free — its value group is a subgroup of the cyclic group
 -- `ℤᵐ⁰ˣ`, nontrivial by `instIsNontrivial` — but discreteness alone leaves the generator as
 -- `exp (-n)` for an unspecified `n ≥ 1`, and the proper subgroup genuinely occurs: the restriction
--- of `v_∞` to `F(x)` has value group `2ℤ` by `infinityPlace.algebraMap_eq_sq`. Surjectivity is what
--- pins the generator to `exp (-1)`, and that is the content of this proof.
+-- of `v_∞` to `F(x)` has value group `2ℤ` by `infinityPlace.algebraMap_eq_sq`. What pins the
+-- generator to `exp (-1)` is a single element of that value, so `X_div_mk_Y` is exactly the witness
+-- Mathlib's `generator_eq_exp_neg_one_of_mem_range` asks for.
 /-- **`x / y` is a uniformiser at the place at infinity**, in Mathlib's sense: its value generates
 the value group and is `< 1`. -/
 theorem infinityPlace.isUniformizer_X_div_mk_Y :
@@ -440,8 +420,8 @@ theorem infinityPlace.isUniformizer_X_div_mk_Y :
         (algebraMap F[X] W.CoordinateRing Polynomial.X) /
       algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W Y)) := by
   rw [Valuation.IsUniformizer.iff,
-    Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_surjective
-      (infinityPlace_surjective W),
+    Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_mem_range
+      ⟨_, infinityPlace.X_div_mk_Y W⟩,
     Units.val_mk0]
   exact infinityPlace.X_div_mk_Y W
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -39,13 +39,24 @@ Each special value comes in two forms: one stated about the curve's coordinate f
 ultrametric inequality is `private`, and the norm-degree theory it rests on lives in
 `FunctionField/Norm.lean`.
 
+* `WeierstrassCurve.Affine.infinityPlace.X_div_mk_Y`,
+  `WeierstrassCurve.Affine.infinityPlace_surjective`,
+  `WeierstrassCurve.Affine.infinityPlace.isUniformizer_X_div_mk_Y`: **`x / y` is a uniformiser at
+  infinity.** Its value is `exp (-1)`, the value group is all of `ℤ`, and it is a uniformiser in
+  Mathlib's `Valuation.IsUniformizer` sense. That the place is discrete of rank one needs no proof
+  here — its value group is a subgroup of the cyclic `ℤᵐ⁰ˣ` and is nontrivial — but surjectivity
+  does: discreteness alone permits a generator `exp (-n)` with `n ≥ 1`, and the proper subgroup `2ℤ`
+  genuinely occurs, being the value group of the restriction of `v_∞` to `F(x)`.
+
 ## Roadmap
 
 `TauCetiRoadmap/EllipticCurves/README.md`, **Layer 0** (the function field, places, and divisors),
 whose §Places asks for the one further place `W.infinityPlace` beyond the affine ones, sitting
 "where `x` and `y` have their poles", with `ord_∞ x = -2`, `ord_∞ y = -3`. This file supplies the
-valuation and those two degrees; `Suggested.lean` seeds no declaration it competes with, recording
-that the function-field layer's "types are new API and are built there, not pinned here".
+valuation, those two degrees, and the **uniformiser** `x / y` — §Places lists "`ord_v`,
+uniformisers, residue fields, the degree `deg v`" as the API the later layers consume.
+`Suggested.lean` seeds no declaration it competes with, recording that the function-field layer's
+"types are new API and are built there, not pinned here".
 
 ## Provenance
 
@@ -61,6 +72,16 @@ and the target is Mathlib's `ℤᵐ⁰`, so the result is a genuine `Valuation` 
 `RatFunc.inftyValuation` and `IsDedekindDomain.HeightOneSpectrum.valuation`; multiplicativity and
 vanishing are `map_mul` and `Algebra.norm_eq_zero_iff`, and only the ultrametric inequality is
 reproved.
+
+The uniformiser corresponds to that project's `HasseWeil/LocalExpansion.lean`, `localParam` — the
+local parameter `t = -x/y` at `O` (Silverman IV.1) — whose uniformising property is recorded there
+through a Laurent-series embedding (`localExpand_localParam`). The surjectivity argument, that the
+integer powers of an element of value `exp (-1)` realise every value, is that project's private
+`surjective_of_eq_exp_neg_one` in `HasseWeil/EC/IsogenyOrdTransport.lean`, used there for the affine
+`pointValuation_surjective'`; the same two-line rewrite serves here. There is no Laurent series and
+no `SmoothPlaneCurve` wrapper in this file: the conclusion is Mathlib's `Valuation.IsUniformizer`
+against Mathlib's discrete-valuation API, and the sign is dropped, `x / y` and `-x / y` having the
+same valuation.
 -/
 
 public section
@@ -336,6 +357,52 @@ theorem infinityPlace.adjoinRoot_root :
     infinityPlace W (algebraMap W.CoordinateRing W.FunctionField
       (AdjoinRoot.root W.polynomial)) = WithZero.exp 3 :=
   infinityPlace.mk_Y W
+
+
+open scoped Classical in
+/-- **`x / y` is a uniformiser at infinity**: `v_∞ (x / y) = exp (-1)`, that is
+`ord_∞ (x / y) = 1`, a simple zero at the point at infinity. The double pole of `x` and the triple
+pole of `y` differ by one, which is what makes the quotient a uniformiser. -/
+theorem infinityPlace.X_div_mk_Y :
+    infinityPlace W (algebraMap W.CoordinateRing W.FunctionField
+        (algebraMap F[X] W.CoordinateRing Polynomial.X) /
+      algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W Y))
+      = WithZero.exp (-1) := by
+  rw [map_div₀, infinityPlace.X, infinityPlace.mk_Y, ← WithZero.exp_sub]
+  norm_num
+
+open scoped Classical in
+/-- **The value group at infinity is all of `ℤ`**: `v_∞` is surjective, so `ord_∞` attains every
+integer value. Powers of the uniformiser `x / y` realise them. This is the analogue for the place
+at infinity of `IsDedekindDomain.HeightOneSpectrum.valuation_surjective` for the affine places. -/
+theorem infinityPlace_surjective : Function.Surjective (infinityPlace W) := by
+  intro g
+  obtain rfl | hg := eq_or_ne g 0
+  · exact ⟨0, map_zero _⟩
+  refine ⟨(algebraMap W.CoordinateRing W.FunctionField
+      (algebraMap F[X] W.CoordinateRing Polynomial.X) /
+    algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W Y)) ^ (-WithZero.log g), ?_⟩
+  rw [map_zpow₀, infinityPlace.X_div_mk_Y, ← WithZero.exp_zsmul, smul_eq_mul, neg_mul_neg, mul_one,
+    WithZero.exp_log hg]
+
+open scoped Classical in
+/-- **`x / y` is a uniformiser at the place at infinity**, in Mathlib's sense: its value generates
+the value group and is `< 1`.
+
+The place is discrete of rank one for free — its value group is a subgroup of the cyclic group
+`ℤᵐ⁰ˣ`, nontrivial by `instIsNontrivial` — but discreteness alone leaves the generator as `exp (-n)`
+for an unspecified `n ≥ 1`; the restriction of `v_∞` to `F(x)` really does have value group `2ℤ`
+(`infinityPlace.algebraMap_eq_sq`). Surjectivity is what pins the generator to `exp (-1)`, and that
+is the whole content here. -/
+theorem infinityPlace.isUniformizer_X_div_mk_Y :
+    (infinityPlace W).IsUniformizer (algebraMap W.CoordinateRing W.FunctionField
+        (algebraMap F[X] W.CoordinateRing Polynomial.X) /
+      algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W Y)) := by
+  rw [Valuation.IsUniformizer.iff,
+    Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_surjective
+      (infinityPlace_surjective W),
+    Units.val_mk0]
+  exact infinityPlace.X_div_mk_Y W
 
 end WeierstrassCurve.Affine
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -43,17 +43,17 @@ ultrametric inequality is `private`, and the norm-degree theory it rests on live
 `FunctionField/Norm.lean`.
 
 * `WeierstrassCurve.Affine.infinityPlace.X_div_mk_Y` (with
-  `WeierstrassCurve.Affine.infinityPlace.adjoinRoot_of_X_div_root` in the other spelling),
-  `WeierstrassCurve.Affine.infinityPlace_surjective`,
+  `WeierstrassCurve.Affine.infinityPlace.adjoinRoot_of_X_div_root` in the other spelling) and
   `WeierstrassCurve.Affine.infinityPlace.isUniformizer_X_div_mk_Y`: **`x / y` is a uniformiser at
-  infinity.** Its value is `exp (-1)`, the value group is all of `ℤ`, and it is a uniformiser in
-  Mathlib's `Valuation.IsUniformizer` sense. That the place is discrete of rank one needs no proof
-  here — its value group is a subgroup of the cyclic `ℤᵐ⁰ˣ` and is nontrivial — but surjectivity
-  does: discreteness alone permits a generator `exp (-n)` with `n ≥ 1`, and the proper subgroup `2ℤ`
-  genuinely occurs, being the value group of the restriction of `v_∞` to `F(x)`.
+  infinity.** Its value is `exp (-1)`, and it is a uniformiser in Mathlib's
+  `Valuation.IsUniformizer` sense. That the place is discrete of rank one needs no proof here — its
+  value group is a nontrivial subgroup of the cyclic `ℤᵐ⁰ˣ`, so Mathlib's `IsRankOneDiscrete`
+  instance fires by itself — but the *generator* does: discreteness alone permits `exp (-n)` with
+  `n ≥ 1`, and the proper subgroup `2ℤ` genuinely occurs, being the value group of the restriction
+  of `v_∞` to `F(x)`. Surjectivity of `v_∞` rules it out and is proved `private` here.
 
-The quotient value is the one special value whose restatement is not `@[simp]`; its docstring gives
-the simpNF reason.
+The quotient value is the one special value whose restatement is not `@[simp]`; the comment above it
+gives the simpNF reason.
 
 ## Roadmap
 
@@ -393,14 +393,13 @@ theorem infinityPlace.X_div_mk_Y :
   norm_num
 
 open scoped Classical in
-/-- `infinityPlace.X_div_mk_Y` in the spelling simp normalises the coordinate functions to.
-
-Deliberately **not** `@[simp]`, unlike the atomic `infinityPlace.adjoinRoot_of_X` and
-`infinityPlace.adjoinRoot_root`: `map_div₀` is itself a simp lemma, so simp decomposes the quotient
-and rewrites this left-hand side to `exp 2 / exp 3`, leaving the residual goal
-`exp 2 / exp 3 = (exp 1)⁻¹`. A quotient-shaped left-hand side is therefore not in simp-normal form
-and the repository's simpNF gate rejects the tag, so the closed value is supplied here for `rw` and
-`exact` instead. -/
+-- NB this one is deliberately NOT `@[simp]`, unlike the atomic `infinityPlace.adjoinRoot_of_X` and
+-- `infinityPlace.adjoinRoot_root`: `map_div₀` is itself a simp lemma, so simp decomposes the
+-- quotient and rewrites this left-hand side to `exp 2 / exp 3`, leaving the residual goal
+-- `exp 2 / exp 3 = (exp 1)⁻¹`.
+-- A quotient-shaped left-hand side is therefore not in simp-normal form and the repository's simpNF
+-- gate rejects the tag, so the closed value is supplied for `rw` and `exact` instead.
+/-- `infinityPlace.X_div_mk_Y` in the spelling simp normalises the coordinate functions to. -/
 theorem infinityPlace.adjoinRoot_of_X_div_root :
     infinityPlace W (algebraMap W.CoordinateRing W.FunctionField
         (AdjoinRoot.of W.polynomial Polynomial.X) /
@@ -409,16 +408,16 @@ theorem infinityPlace.adjoinRoot_of_X_div_root :
   infinityPlace.X_div_mk_Y W
 
 open scoped Classical in
+-- Private: it exists to identify Mathlib's `IsRankOneDiscrete.generator`, and nothing outside this
+-- file consumes it yet. The general criterion it specialises — a `ℤᵐ⁰`-valued valuation on a field
+-- is surjective as soon as some element has value `exp (-1)` — is not extracted either: Mathlib has
+-- no such criterion and inlines this same `WithZero.log` construction in both of its analogues,
+-- `RatFunc.valuation_surjective` and `HeightOneSpectrum.valuation_surjective`. When a consumer
+-- appears (§Divisors' `deg (div f) = 0`, or the ramification index of §`inducedPlace`, which needs
+-- the value groups of both places exactly), that PR should export whichever form it needs.
 /-- **The value group at infinity is all of `ℤ`**: `v_∞` is surjective, so `ord_∞` attains every
-integer value. Powers of the uniformiser `x / y` realise them. This is the analogue for the place
-at infinity of `IsDedekindDomain.HeightOneSpectrum.valuation_surjective` for the affine places.
-
-The four-line construction is not factored into a general criterion ("a `ℤᵐ⁰`-valued valuation on a
-field is surjective as soon as some element has value `exp (-1)`") on purpose. Mathlib has no such
-criterion, and its own `RatFunc.valuation_surjective` — the same statement for `F(x)` — proves it
-inline by this very `WithZero.log` construction rather than factoring one out. General valuation API
-does not belong in a curve file, and at four lines it does not earn a file of its own. -/
-theorem infinityPlace_surjective : Function.Surjective (infinityPlace W) := by
+integer value, the powers of the uniformiser `x / y` realising them. -/
+private theorem infinityPlace_surjective : Function.Surjective (infinityPlace W) := by
   intro g
   obtain rfl | hg := eq_or_ne g 0
   · exact ⟨0, map_zero _⟩
@@ -429,14 +428,13 @@ theorem infinityPlace_surjective : Function.Surjective (infinityPlace W) := by
     WithZero.exp_log hg]
 
 open scoped Classical in
+-- The place is discrete of rank one for free — its value group is a subgroup of the cyclic group
+-- `ℤᵐ⁰ˣ`, nontrivial by `instIsNontrivial` — but discreteness alone leaves the generator as
+-- `exp (-n)` for an unspecified `n ≥ 1`, and the proper subgroup genuinely occurs: the restriction
+-- of `v_∞` to `F(x)` has value group `2ℤ` by `infinityPlace.algebraMap_eq_sq`. Surjectivity is what
+-- pins the generator to `exp (-1)`, and that is the content of this proof.
 /-- **`x / y` is a uniformiser at the place at infinity**, in Mathlib's sense: its value generates
-the value group and is `< 1`.
-
-The place is discrete of rank one for free — its value group is a subgroup of the cyclic group
-`ℤᵐ⁰ˣ`, nontrivial by `instIsNontrivial` — but discreteness alone leaves the generator as `exp (-n)`
-for an unspecified `n ≥ 1`; the restriction of `v_∞` to `F(x)` really does have value group `2ℤ`
-(`infinityPlace.algebraMap_eq_sq`). Surjectivity is what pins the generator to `exp (-1)`, and that
-is the whole content here. -/
+the value group and is `< 1`. -/
 theorem infinityPlace.isUniformizer_X_div_mk_Y :
     (infinityPlace W).IsUniformizer (algebraMap W.CoordinateRing W.FunctionField
         (algebraMap F[X] W.CoordinateRing Polynomial.X) /

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -39,7 +39,8 @@ Each special value comes in two forms: one stated about the curve's coordinate f
 ultrametric inequality is `private`, and the norm-degree theory it rests on lives in
 `FunctionField/Norm.lean`.
 
-* `WeierstrassCurve.Affine.infinityPlace.X_div_mk_Y`,
+* `WeierstrassCurve.Affine.infinityPlace.X_div_mk_Y` (with
+  `WeierstrassCurve.Affine.infinityPlace.adjoinRoot_of_X_div_root` in the other spelling),
   `WeierstrassCurve.Affine.infinityPlace_surjective`,
   `WeierstrassCurve.Affine.infinityPlace.isUniformizer_X_div_mk_Y`: **`x / y` is a uniformiser at
   infinity.** Its value is `exp (-1)`, the value group is all of `ℤ`, and it is a uniformiser in
@@ -47,6 +48,9 @@ ultrametric inequality is `private`, and the norm-degree theory it rests on live
   here — its value group is a subgroup of the cyclic `ℤᵐ⁰ˣ` and is nontrivial — but surjectivity
   does: discreteness alone permits a generator `exp (-n)` with `n ≥ 1`, and the proper subgroup `2ℤ`
   genuinely occurs, being the value group of the restriction of `v_∞` to `F(x)`.
+
+The quotient value is the one special value whose restatement is not `@[simp]`; its docstring gives
+the simpNF reason.
 
 ## Roadmap
 
@@ -372,9 +376,31 @@ theorem infinityPlace.X_div_mk_Y :
   norm_num
 
 open scoped Classical in
+/-- `infinityPlace.X_div_mk_Y` in the spelling simp normalises the coordinate functions to.
+
+Deliberately **not** `@[simp]`, unlike the atomic `infinityPlace.adjoinRoot_of_X` and
+`infinityPlace.adjoinRoot_root`: `map_div₀` is itself a simp lemma, so simp decomposes the quotient
+and rewrites this left-hand side to `exp 2 / exp 3`, leaving the residual goal
+`exp 2 / exp 3 = (exp 1)⁻¹`. A quotient-shaped left-hand side is therefore not in simp-normal form
+and the repository's simpNF gate rejects the tag, so the closed value is supplied here for `rw` and
+`exact` instead. -/
+theorem infinityPlace.adjoinRoot_of_X_div_root :
+    infinityPlace W (algebraMap W.CoordinateRing W.FunctionField
+        (AdjoinRoot.of W.polynomial Polynomial.X) /
+      algebraMap W.CoordinateRing W.FunctionField (AdjoinRoot.root W.polynomial))
+      = WithZero.exp (-1) :=
+  infinityPlace.X_div_mk_Y W
+
+open scoped Classical in
 /-- **The value group at infinity is all of `ℤ`**: `v_∞` is surjective, so `ord_∞` attains every
 integer value. Powers of the uniformiser `x / y` realise them. This is the analogue for the place
-at infinity of `IsDedekindDomain.HeightOneSpectrum.valuation_surjective` for the affine places. -/
+at infinity of `IsDedekindDomain.HeightOneSpectrum.valuation_surjective` for the affine places.
+
+The four-line construction is not factored into a general criterion ("a `ℤᵐ⁰`-valued valuation on a
+field is surjective as soon as some element has value `exp (-1)`") on purpose. Mathlib has no such
+criterion, and its own `RatFunc.valuation_surjective` — the same statement for `F(x)` — proves it
+inline by this very `WithZero.log` construction rather than factoring one out. General valuation API
+does not belong in a curve file, and at four lines it does not earn a file of its own. -/
 theorem infinityPlace_surjective : Function.Surjective (infinityPlace W) := by
   intro g
   obtain rfl | hg := eq_or_ne g 0

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -42,9 +42,9 @@ Each special value comes in two forms: one stated about the curve's coordinate f
 ultrametric inequality is `private`, and the norm-degree theory it rests on lives in
 `FunctionField/Norm.lean`.
 
-* `WeierstrassCurve.Affine.infinityPlace.X_div_mk_Y` (with
-  `WeierstrassCurve.Affine.infinityPlace.adjoinRoot_of_X_div_root` in the other spelling) and
-  `WeierstrassCurve.Affine.infinityPlace.isUniformizer_X_div_mk_Y`: **`x / y` is a uniformiser at
+* `WeierstrassCurve.Affine.infinityPlace.X_div_mk_Y` and
+  `WeierstrassCurve.Affine.infinityPlace.isUniformizer_X_div_mk_Y` (each with an
+  `adjoinRoot_of_X_div_root` twin in the other spelling): **`x / y` is a uniformiser at
   infinity.** Its value is `exp (-1)`, and it is a uniformiser in Mathlib's
   `Valuation.IsUniformizer` sense. That the place is discrete of rank one needs no proof here — its
   value group is a nontrivial subgroup of the cyclic `ℤᵐ⁰ˣ`, so Mathlib's `IsRankOneDiscrete`
@@ -424,6 +424,15 @@ theorem infinityPlace.isUniformizer_X_div_mk_Y :
       ⟨_, infinityPlace.X_div_mk_Y W⟩,
     Units.val_mk0]
   exact infinityPlace.X_div_mk_Y W
+
+open scoped Classical in
+/-- `infinityPlace.isUniformizer_X_div_mk_Y` in the spelling simp normalises the coordinate
+functions to. -/
+theorem infinityPlace.isUniformizer_adjoinRoot_of_X_div_root :
+    (infinityPlace W).IsUniformizer (algebraMap W.CoordinateRing W.FunctionField
+        (AdjoinRoot.of W.polynomial Polynomial.X) /
+      algebraMap W.CoordinateRing W.FunctionField (AdjoinRoot.root W.polynomial)) :=
+  infinityPlace.isUniformizer_X_div_mk_Y W
 
 end WeierstrassCurve.Affine
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -43,8 +43,7 @@ ultrametric inequality is `private`, and the norm-degree theory it rests on live
 `FunctionField/Norm.lean`.
 
 * `WeierstrassCurve.Affine.infinityPlace.X_div_mk_Y` and
-  `WeierstrassCurve.Affine.infinityPlace.isUniformizer_X_div_mk_Y` (each with an
-  `adjoinRoot_of_X_div_root` twin in the other spelling): **`x / y` is a uniformiser at
+  `WeierstrassCurve.Affine.infinityPlace.isUniformizer_X_div_mk_Y`: **`x / y` is a uniformiser at
   infinity.** Its value is `exp (-1)`, and it is a uniformiser in Mathlib's
   `Valuation.IsUniformizer` sense. That the place is discrete of rank one needs no proof here — its
   value group is a nontrivial subgroup of the cyclic `ℤᵐ⁰ˣ`, so Mathlib's `IsRankOneDiscrete`
@@ -52,8 +51,9 @@ ultrametric inequality is `private`, and the norm-degree theory it rests on live
   `n ≥ 1`, and the proper subgroup `2ℤ` genuinely occurs, being the value group of the restriction
   of `v_∞` to `F(x)`. One element of value `exp (-1)` settles it, which is what the value above is.
 
-The quotient value is the one special value whose restatement is not `@[simp]`; the comment above it
-gives the simpNF reason.
+The quotient value gets no `@[simp]` restatement of its own: `map_div₀` is a simp lemma, so simp
+decomposes the quotient through the two atomic restatements rather than matching a quotient-shaped
+left-hand side, and the `AdjoinRoot` spelling of `x / y` is definitionally the one written here.
 
 ## Roadmap
 
@@ -85,9 +85,10 @@ and the target is Mathlib's `ℤᵐ⁰`, so the result is a genuine `Valuation` 
 vanishing are `map_mul` and `Algebra.norm_eq_zero_iff`, and only the ultrametric inequality is
 reproved.
 
-The uniformiser corresponds to that project's `HasseWeil/LocalExpansion.lean`, `localParam` — the
-local parameter `t = -x/y` at `O` (Silverman IV.1) — whose uniformising property is recorded there
-through a Laurent-series embedding (`localExpand_localParam`), over a `SmoothPlaneCurve` wrapper and
+The uniformiser corresponds to that project's
+`projects/HasseWeil/HasseWeil/Foundation/LocalExpansion.lean` at `main` `1c1c7466`, `localParam` —
+the local parameter `t = -x/y` at `O` (Silverman IV.1) — whose uniformising property is recorded
+there through a Laurent-series embedding (`localExpand_localParam`), over a `SmoothPlaneCurve` and
 that development's own `WithTop ℤ`-valued `ordAtInfty`. None of that apparatus is needed here: the
 value of `x / y` is two rewrites from the two pole orders, and Mathlib's
 `Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_mem_range` turns that single value into the
@@ -392,21 +393,6 @@ theorem infinityPlace.X_div_mk_Y :
   norm_num
 
 open scoped Classical in
--- NB this one is deliberately NOT `@[simp]`, unlike the atomic `infinityPlace.adjoinRoot_of_X` and
--- `infinityPlace.adjoinRoot_root`: `map_div₀` is itself a simp lemma, so simp decomposes the
--- quotient and rewrites this left-hand side to `exp 2 / exp 3`, leaving the residual goal
--- `exp 2 / exp 3 = (exp 1)⁻¹`.
--- A quotient-shaped left-hand side is therefore not in simp-normal form and the repository's simpNF
--- gate rejects the tag, so the closed value is supplied for `rw` and `exact` instead.
-/-- `infinityPlace.X_div_mk_Y` in the spelling simp normalises the coordinate functions to. -/
-theorem infinityPlace.adjoinRoot_of_X_div_root :
-    infinityPlace W (algebraMap W.CoordinateRing W.FunctionField
-        (AdjoinRoot.of W.polynomial Polynomial.X) /
-      algebraMap W.CoordinateRing W.FunctionField (AdjoinRoot.root W.polynomial))
-      = WithZero.exp (-1) :=
-  infinityPlace.X_div_mk_Y W
-
-open scoped Classical in
 -- The place is discrete of rank one for free — its value group is a subgroup of the cyclic group
 -- `ℤᵐ⁰ˣ`, nontrivial by `instIsNontrivial` — but discreteness alone leaves the generator as
 -- `exp (-n)` for an unspecified `n ≥ 1`, and the proper subgroup genuinely occurs: the restriction
@@ -424,15 +410,6 @@ theorem infinityPlace.isUniformizer_X_div_mk_Y :
       ⟨_, infinityPlace.X_div_mk_Y W⟩,
     Units.val_mk0]
   exact infinityPlace.X_div_mk_Y W
-
-open scoped Classical in
-/-- `infinityPlace.isUniformizer_X_div_mk_Y` in the spelling simp normalises the coordinate
-functions to. -/
-theorem infinityPlace.isUniformizer_adjoinRoot_of_X_div_root :
-    (infinityPlace W).IsUniformizer (algebraMap W.CoordinateRing W.FunctionField
-        (AdjoinRoot.of W.polynomial Polynomial.X) /
-      algebraMap W.CoordinateRing W.FunctionField (AdjoinRoot.root W.polynomial)) :=
-  infinityPlace.isUniformizer_X_div_mk_Y W
 
 end WeierstrassCurve.Affine
 


### PR DESCRIPTION
The place at infinity exists (#2772) and is ramified of index two over `F(x)` (#2795). This adds the
**uniformiser** there, which §Places names in its API list.

```lean
-- Affine/FunctionField/InfinityPlace.lean, beside the special values
theorem WeierstrassCurve.Affine.infinityPlace.X_div_mk_Y :
    infinityPlace W (x / y) = WithZero.exp (-1)

theorem WeierstrassCurve.Affine.infinityPlace.isUniformizer_X_div_mk_Y :
    (infinityPlace W).IsUniformizer (x / y)
```

(`x` and `y` abbreviate the two coordinate functions pushed into `W.FunctionField`, as in the
existing `infinityPlace.X` and `infinityPlace.mk_Y`. Two declarations, no private scaffolding and no
alternate-spelling twins: the `AdjoinRoot` spelling of `x / y` is definitionally the one written here,
so these apply to a normalised goal directly.)

**What is not being proved, because Mathlib gives it away.** That the place at infinity is discrete
of rank one is already available on `main` with no work: its value group is a subgroup of the cyclic
group `ℤᵐ⁰ˣ`, and it is nontrivial by the `Valuation.IsNontrivial` instance from #2772, so Mathlib's
`Valuation.IsRankOneDiscrete.mk'` fires and `valuationSubring_isDiscreteValuationRing`,
`valuationSubring_isPrincipalIdealRing` and `maximalIdeal = Ideal.span {π}` all come with it. I
verified this with an `inferInstance` probe before writing anything, and no declaration here restates
any of it.

**What discreteness does not give, and this does.** Discreteness leaves the generator as `exp (-n)`
for an unspecified `n ≥ 1`. The proper subgroup is not a hypothetical: the restriction of `v_∞` to
`F(x)` has value group exactly `2ℤ`, since a rational function of `x` picks up the *square* of
Mathlib's infinite valuation — that is `infinityPlace.algebraMap_eq_sq` from #2795, which this branch
merges `main` to pick up. What settles the generator is a single element of value `exp (-1)`, and
Mathlib's `Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_mem_range` takes exactly that
witness, so `X_div_mk_Y` feeds it directly.

The double pole of `x` and the triple pole of `y` differ by one — that is the whole reason the
quotient has value `exp (-1)`, and it is why this could not be read off either pole alone.

**No `@[simp]` restatement, and no spelling twin.** The file's atomic special values each carry a
`@[simp]` restatement in the spelling simp normalises the coordinate functions to. The quotient value
gets neither, on purpose. `map_div₀` is itself a simp lemma, so simp decomposes the quotient through
those two atomic restatements rather than matching a quotient-shaped left-hand side: I compiled
`example ... := by simp` and it stalls on the residual goal `exp 2 / exp 3 = (exp 1)⁻¹`, so tagging a
quotient LHS would fail the simpNF gate. An untagged `AdjoinRoot`-spelling twin would add nothing
either, since the two spellings are definitionally equal — the declarations here apply to a normalised
goal as they stand.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 0** (the function field, places, and divisors).
§Places lists the API the later layers consume as "`ord_v`, **uniformisers**, residue fields, the
**degree** `deg v` (the residue finrank), evaluation of functions away from their poles", for the
affine places together with "one further place, `W.infinityPlace`". This is that uniformiser for the
place at infinity — named in the roadmap, not inferred from a directory name. The residue field and
`deg v` at infinity are separate statements and are not claimed here.

Layer 0 seeds no declaration this competes with: `Suggested.lean` records that the function-field
layer's "types are new API and are built there, not pinned here".

## Provenance

The corresponding source material is the AINTLIB `HasseWeil` project
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c7466`),
`projects/HasseWeil/HasseWeil/Foundation/LocalExpansion.lean`: `localParam` — the local parameter `t = -x/y` at `O`
(Silverman IV.1) — with `localParam_ne_zero` and `localExpand_localParam`.

Changes from the source. There the uniformising property of `-x/y` is recorded through a
Laurent-series embedding (`localExpand`, landing in `HahnSeries`), over a `SmoothPlaneCurve` wrapper
and a `WithTop ℤ`-valued `ordAtInfty` of that development's own. None of that apparatus is needed
here: the value of `x / y` is two rewrites from the two pole orders of #2772, and Mathlib's
`generator_eq_exp_neg_one_of_mem_range` turns that one value into the generator, so the conclusion is
Mathlib's `Valuation.IsUniformizer` directly. The sign is dropped, `x / y` and `-x / y` having the
same valuation.

## Mathlib absence

Mathlib has the whole discrete-valuation apparatus (`Valuation.IsRankOneDiscrete`,
`Valuation.IsUniformizer`, `generator_eq_exp_neg_one_of_mem_range`,
`valuationSubring_isDiscreteValuationRing`) and this PR consumes it rather than restating any of it.
What Mathlib does not have is any place of a curve's function field, so no uniformiser at one: an
untruncated recursive grep of `Mathlib/AlgebraicGeometry/EllipticCurve/` finds no valuation on the
function field at all.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"inftyuniformizer"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
