### PR TITLE
feat: the strong exchange condition for the Weyl group

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/FundamentalDomain.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FundamentalDomain.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.LinearAlgebra.RootSystem.Chamber
-public import TauCeti.LinearAlgebra.RootSystem.Inversions.Deletion
+public import TauCeti.LinearAlgebra.RootSystem.Inversions.StrongExchange
 
 /-!
 # The closed dominant chamber is a strict fundamental domain

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Deletion.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Deletion.lean
@@ -10,24 +10,31 @@ public import TauCeti.LinearAlgebra.RootSystem.SimpleReflections
 public section
 
 /-!
-# The deletion condition and the identity criterion for inversion sets
+# The strong exchange condition and the identity criterion for inversion sets
 
-If a word in the simple reflections spells a Weyl-group element sending a simple root to a negative
-root, then appending that simple reflection to the word can be spelled by a word two letters
-shorter. This is the deletion condition, and it is the missing half of the identification of the
-inversion set as the obstruction to being the identity: an element with an empty inversion set is
-spelled by the empty word, so it is the identity.
+If a word in the simple reflections spells a Weyl-group element sending a positive root to a
+negative root, then appending the reflection in that root to the word is spelled by the word with
+one of its letters deleted. This is the strong exchange condition, and it is the missing half of
+the identification of the inversion set as the obstruction to being the identity: an element with
+an empty inversion set is spelled by the empty word, so it is the identity.
 
-The proof of the deletion condition is an induction on the word. Peeling off the leading simple
-reflection `sⱼ`, either the shorter word already sends the simple root to a negative root, and the
-inductive hypothesis deletes a letter from it, or the shorter word sends it to a positive root that
-`sⱼ` makes negative. In the second case that positive root must be the simple root `αⱼ` itself,
-because a simple reflection permutes the remaining positive roots, and then conjugation identifies
-`sⱼ` with the appended reflection, so both letters cancel.
+Two features of the statement are what make it usable and are not shared by the weaker "some
+shorter word exists" form. The reflecting root ranges over *all* positive roots, not just the
+simple ones, so the condition applies to an arbitrary reflection of the Weyl group; and the
+shorter word is a *subword* of the given one, obtained by deleting a single letter in a named
+position. Only the subword form transports along a group homomorphism, which is why it is the form
+the word property behind Tits' theorem consumes.
+
+The proof is an induction on the word. Peeling off the leading simple reflection `sⱼ`, either the
+shorter word already sends the root to a negative root, and the inductive hypothesis deletes a
+letter from it, or the shorter word sends it to a positive root that `sⱼ` makes negative. In the
+second case that positive root must be the simple root `αⱼ` itself, because a simple reflection
+permutes the remaining positive roots, and then conjugation identifies `sⱼ` with the appended
+reflection, so the leading letter is the one deleted.
 
 ## Main results
 
-* `TauCeti.exists_wordProd_eq_mul_ofIdx_of_not_isPos` is the deletion condition.
+* `TauCeti.exists_wordProd_eraseIdx_eq_mul_ofIdx` is the strong exchange condition.
 * `TauCeti.eq_one_of_inversions_eq_empty` and `TauCeti.inversions_eq_empty_iff_eq_one` say that the
   inversion set of a Weyl-group element is empty exactly when the element is the identity.
 * `TauCeti.eq_one_of_mapsTo_posRoots` restates this as: a Weyl-group element keeping every positive
@@ -57,40 +64,41 @@ variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
   (P : RootPairing ι R M N) [Finite ι] [CharZero R] [IsDomain R]
   [P.IsCrystallographic] [P.IsReduced] (b : P.Base)
 
-/-- **The deletion condition.** If the word `l` spells a Weyl-group element sending the simple root
-`αₖ` to a negative root, then the word `l` with `sₖ` appended is spelled by a word one letter
-shorter than `l`, hence two letters shorter than `l` with `sₖ` appended. -/
-theorem exists_wordProd_eq_mul_ofIdx_of_not_isPos {k : ι} (hk : k ∈ b.support)
+/-- **The strong exchange condition.** If the word `l` spells a Weyl-group element sending the
+positive root `αₖ` to a negative root, then the word `l` with the reflection `sₖ` appended is
+spelled by `l` with one of its letters deleted. The root `αₖ` is an arbitrary positive root, not
+necessarily a simple one, and the shorter word is a subword of `l`. -/
+theorem exists_wordProd_eraseIdx_eq_mul_ofIdx {k : ι} (hk : b.IsPos k)
     (l : List b.support) (h : ¬ b.IsPos (P.weylGroupToPerm (wordProd P b l) k)) :
-    ∃ l' : List b.support,
-      wordProd P b l' = wordProd P b l * RootPairing.weylGroup.ofIdx P k ∧
-        l'.length + 1 = l.length := by
+    ∃ j < l.length,
+      wordProd P b (l.eraseIdx j) = wordProd P b l * RootPairing.weylGroup.ofIdx P k := by
   induction l with
   | nil =>
-    exact absurd (by simpa using b.isPos_of_mem_support hk) h
+    exact absurd (by simpa using hk) h
   | cons j l ih =>
     rw [wordProd_cons, RootPairing.weylGroupToPerm_ofIdx_mul_apply] at h
     by_cases hpos : b.IsPos (P.weylGroupToPerm (wordProd P b l) k)
     · -- The shorter word keeps `αₖ` positive, so the image is the simple root `αⱼ` itself.
-      refine ⟨l, ?_, by simp⟩
+      refine ⟨0, by simp, ?_⟩
       have hkey : P.weylGroupToPerm (wordProd P b l) k = (j : ι) := by
         by_contra hne
         have hmem : P.weylGroupToPerm (wordProd P b l) k ∈ posRoots P b \ {(j : ι)} :=
           ⟨(mem_posRoots P b _).mpr hpos, by simpa using hne⟩
         exact h ((mem_posRoots P b _).mp
           ((reflectionPerm_mem_posRoots_diff_singleton_iff P b j.2 _).mpr hmem).1)
-      rw [wordProd_cons, ← hkey, RootPairing.weylGroup.ofIdx_weylGroupToPerm_eq_conj,
+      rw [List.eraseIdx_cons_zero, wordProd_cons, ← hkey,
+        RootPairing.weylGroup.ofIdx_weylGroupToPerm_eq_conj,
         inv_mul_cancel_right, mul_assoc, RootPairing.weylGroup.ofIdx_mul_self, mul_one]
     · -- The shorter word already makes `αₖ` negative, so a letter is deleted from it.
-      obtain ⟨l', hl', hlen⟩ := ih hpos
-      refine ⟨j :: l', ?_, by simp only [List.length_cons]; omega⟩
-      rw [wordProd_cons, hl', wordProd_cons, mul_assoc]
+      obtain ⟨j', hj', hl'⟩ := ih hpos
+      refine ⟨j' + 1, by simpa using hj', ?_⟩
+      rw [List.eraseIdx_cons_succ, wordProd_cons, hl', wordProd_cons, mul_assoc]
 
 variable {P b}
 
 /-- **A Weyl-group element with an empty inversion set is the identity.** A shortest word spelling
 it must be empty: otherwise its final simple reflection is an inversion of the word it follows, and
-the deletion condition produces a shorter word. -/
+the strong exchange condition produces a shorter word. -/
 theorem eq_one_of_inversions_eq_empty {w : P.weylGroup} (h : inversions P b w = ∅) : w = 1 := by
   classical
   have hex : ∃ n : ℕ, ∃ l : List b.support, l.length = n ∧ wordProd P b l = w := by
@@ -106,12 +114,14 @@ theorem eq_one_of_inversions_eq_empty {w : P.weylGroup} (h : inversions P b w = 
     have hkw : k.1 ∉ inversions P b w := by simp [h]
     have hkv : k.1 ∈ inversions P b (wordProd P b l₁) := by
       by_contra hc
-      exact hkw (hl ▸ (mem_inversions_mul_ofIdx_iff_not_mem P _ b k.2).mpr hc)
-    obtain ⟨l', hl'w, hl'len⟩ :=
-      exists_wordProd_eq_mul_ofIdx_of_not_isPos P b k.2 l₁
+      exact hkw (hl ▸ (mem_inversions_mul_ofIdx_iff_not_mem P _ b
+        (b.isPos_of_mem_support k.2)).mpr hc)
+    obtain ⟨j, hj, hl'w⟩ :=
+      exists_wordProd_eraseIdx_eq_mul_ofIdx P b (b.isPos_of_mem_support k.2) l₁
         ((mem_inversions P b _ _).mp hkv).2
     -- The resulting word spells `w` and is two letters shorter, contradicting minimality.
-    refine Nat.find_min hex (m := l'.length) ?_ ⟨l', rfl, hl'w.trans hl⟩
+    refine Nat.find_min hex (m := (l₁.eraseIdx j).length) ?_ ⟨l₁.eraseIdx j, rfl, hl'w.trans hl⟩
+    have hlen' := List.length_eraseIdx_add_one hj
     rw [← hlen, List.concat_eq_append, List.length_append]
     omega
 

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/DominantChamber.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/DominantChamber.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.LinearAlgebra.RootSystem.Chamber
-public import TauCeti.LinearAlgebra.RootSystem.Inversions.Deletion
+public import TauCeti.LinearAlgebra.RootSystem.Inversions.StrongExchange
 
 /-!
 # Inversions of a Weyl-group element that preserves dominance
@@ -34,9 +34,9 @@ there. The general case, where a weight on a wall of the chamber is fixed by the
 wall and the moving element need not be the identity, is
 `TauCeti/LinearAlgebra/RootSystem/FundamentalDomain.lean`. The proof rests on the chamber
 definitions in `TauCeti/LinearAlgebra/RootSystem/Chamber.lean` and the identity criterion for
-inversion sets in `TauCeti/LinearAlgebra/RootSystem/Inversions/Deletion.lean`. The argument is the
-one in J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, Ch. III,
-§10.
+inversion sets in `TauCeti/LinearAlgebra/RootSystem/Inversions/StrongExchange.lean`. The argument
+is the one in J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9,
+Ch. III, §10.
 -/
 
 public section

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
@@ -20,8 +20,9 @@ identification of Coxeter length with the number of inversions.
 
 ## Main results
 
-* `TauCeti.mem_inversions_mul_ofIdx_iff_not_mem` shows that the defining simple root toggles
-  membership in the inversion set.
+* `TauCeti.mem_inversions_mul_ofIdx_iff_not_mem` shows that the reflecting root toggles
+  membership in the inversion set. It needs only that the root is positive, so it covers the
+  reflection in an arbitrary positive root and not just a simple one.
 * `TauCeti.ncard_inversions_mul_ofIdx_of_notMem` and `TauCeti.ncard_inversions_mul_ofIdx_of_mem`
   say in which direction the count moves: it goes up exactly when the defining simple root is not
   already an inversion.
@@ -81,14 +82,14 @@ private noncomputable def puncturedInversionsEquiv {i : ι} (hi : i ∈ b.suppor
     exact P.reflectionPerm_self i x.1
 
 omit [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced] in
-/-- Right multiplication by a simple reflection toggles whether its defining simple root is an
+/-- Right multiplication by the reflection in a positive root toggles whether that root is an
 inversion. -/
-lemma mem_inversions_mul_ofIdx_iff_not_mem {i : ι} (hi : i ∈ b.support) :
+lemma mem_inversions_mul_ofIdx_iff_not_mem {i : ι} (hi : b.IsPos i) :
     i ∈ inversions P b (w * RootPairing.weylGroup.ofIdx P i) ↔
       i ∉ inversions P b w := by
   classical
   let := P.indexNeg
-  simp only [mem_inversions, b.isPos_of_mem_support hi, true_and,
+  simp only [mem_inversions, hi, true_and,
     RootPairing.weylGroupToPerm_mul_ofIdx_apply, ← RootPairing.indexNeg_neg,
     RootPairing.weylGroupToPerm_neg, RootPairing.Base.IsPos.neg_iff_not]
 
@@ -106,7 +107,7 @@ theorem ncard_inversions_mul_ofIdx_of_notMem {i : ι} (hi : i ∈ b.support)
     (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard =
       (inversions P b w).ncard + 1 := by
   have hiws : i ∈ inversions P b (w * RootPairing.weylGroup.ofIdx P i) :=
-    (mem_inversions_mul_ofIdx_iff_not_mem P w b hi).mpr hiw
+    (mem_inversions_mul_ofIdx_iff_not_mem P w b (b.isPos_of_mem_support hi)).mpr hiw
   calc
     (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard =
         (inversions P b (w * RootPairing.weylGroup.ofIdx P i) \ {i}).ncard + 1 :=
@@ -122,7 +123,7 @@ theorem ncard_inversions_mul_ofIdx_of_mem {i : ι} (hi : i ∈ b.support)
     (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard + 1 =
       (inversions P b w).ncard := by
   have hiws : i ∉ inversions P b (w * RootPairing.weylGroup.ofIdx P i) := fun h ↦
-    (mem_inversions_mul_ofIdx_iff_not_mem P w b hi).mp h hiw
+    (mem_inversions_mul_ofIdx_iff_not_mem P w b (b.isPos_of_mem_support hi)).mp h hiw
   calc
     (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard + 1 =
         (inversions P b (w * RootPairing.weylGroup.ofIdx P i) \ {i}).ncard + 1 := by

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Length.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Length.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.LinearAlgebra.RootSystem.Inversions.Deletion
+public import TauCeti.LinearAlgebra.RootSystem.Inversions.StrongExchange
 
 public section
 
@@ -48,7 +48,8 @@ length-function axioms in their inversion-count spelling.
   `TauCeti.lt_ncard_inversions_mul_ofIdx_iff`: right multiplication by the reflection in a
   positive root lowers the inversion count exactly when that root is an inversion. The reflecting
   root need not be simple, because the strong exchange condition does not require it to be.
-* `TauCeti.ncard_inversions_ofIdx_mul_lt_iff`: the same criterion for left multiplication, read off
+* `TauCeti.ncard_inversions_ofIdx_mul_lt_iff` and
+  `TauCeti.lt_ncard_inversions_ofIdx_mul_iff`: the same criteria for left multiplication, read off
   the inverse element.
 
 ## References
@@ -58,7 +59,7 @@ exchange step" in Layer 1 of `TauCetiRoadmap/RepresentationTheory/RootSystems/RE
 that asks for exactly that iteration: the step "iterated, is the exchange/deletion condition for
 the geometric action and the combinatorial core that Layer 2's generation and presentation
 consume". Nothing beyond that Layer 1 material is consumed, and all of it is on `main`
-(`TauCeti/LinearAlgebra/RootSystem/Inversions/Deletion.lean` and its imports).
+(`TauCeti/LinearAlgebra/RootSystem/Inversions/StrongExchange.lean` and its imports).
 
 What Layer 2's presentation takes from the iteration is that a nonempty word of least length
 spells an element other than the identity, equivalently that its inversion set is nonempty: that
@@ -178,10 +179,9 @@ theorem ncard_inversions_mul_le (v w : P.weylGroup) :
     _ = (inversions P b v).ncard + (inversions P b w).ncard := by
       rw [List.length_append, hlen, hlen']
 
-/-- **Right multiplication by the reflection in an inversion shortens.** Deleting from a shortest
-word the letter supplied by the strong exchange condition spells the product, so the product needs
-strictly fewer letters. The reflecting root is an arbitrary inversion, not necessarily a simple
-root, so this is the length inequality for a general reflection of the Weyl group. -/
+/-- **Right multiplication by the reflection in an inversion shortens.** The reflecting root is an
+arbitrary inversion, not necessarily a simple root, so this is the length inequality for a general
+reflection of the Weyl group. -/
 theorem ncard_inversions_mul_ofIdx_lt_of_mem (w : P.weylGroup) {i : ι}
     (hi : i ∈ inversions P b w) :
     (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard < (inversions P b w).ncard := by
@@ -219,16 +219,30 @@ theorem lt_ncard_inversions_mul_ofIdx_iff (w : P.weylGroup) {i : ι} (hi : b.IsP
       ((mem_inversions_mul_ofIdx_iff_not_mem P w b hi).mpr h)
     rwa [mul_assoc, RootPairing.weylGroup.ofIdx_mul_self, mul_one] at hback
 
+/-- Left multiplication by a reflection has the same inversion count as right multiplication by it
+on the inverse element; this is what turns the left criteria into the right ones. -/
+private theorem ncard_inversions_ofIdx_mul (w : P.weylGroup) (i : ι) :
+    (inversions P b (RootPairing.weylGroup.ofIdx P i * w)).ncard =
+      (inversions P b (w⁻¹ * RootPairing.weylGroup.ofIdx P i)).ncard := by
+  rw [← ncard_inversions_inv P b (w⁻¹ * RootPairing.weylGroup.ofIdx P i), mul_inv_rev,
+    RootPairing.weylGroup.ofIdx_inv_eq, inv_inv]
+
 /-- **Left descent criterion.** Left multiplication by the reflection in a positive root shortens
-an element exactly when that root is an inversion of the inverse element: reversing a shortest
-word turns left multiplication into right multiplication. -/
+an element exactly when that root is an inversion of the inverse element. -/
+@[simp]
 theorem ncard_inversions_ofIdx_mul_lt_iff (w : P.weylGroup) {i : ι} (hi : b.IsPos i) :
     (inversions P b (RootPairing.weylGroup.ofIdx P i * w)).ncard < (inversions P b w).ncard ↔
       i ∈ inversions P b w⁻¹ := by
-  have hmirror : (inversions P b (RootPairing.weylGroup.ofIdx P i * w)).ncard =
-      (inversions P b (w⁻¹ * RootPairing.weylGroup.ofIdx P i)).ncard := by
-    rw [← ncard_inversions_inv P b (w⁻¹ * RootPairing.weylGroup.ofIdx P i), mul_inv_rev,
-      RootPairing.weylGroup.ofIdx_inv_eq, inv_inv]
-  rw [hmirror, ← ncard_inversions_inv P b w, ncard_inversions_mul_ofIdx_lt_iff P b w⁻¹ hi]
+  rw [ncard_inversions_ofIdx_mul, ← ncard_inversions_inv P b w,
+    ncard_inversions_mul_ofIdx_lt_iff P b w⁻¹ hi]
+
+/-- **Left ascent criterion.** Left multiplication by the reflection in a positive root lengthens
+an element exactly when that root is not yet an inversion of the inverse element. -/
+@[simp]
+theorem lt_ncard_inversions_ofIdx_mul_iff (w : P.weylGroup) {i : ι} (hi : b.IsPos i) :
+    (inversions P b w).ncard < (inversions P b (RootPairing.weylGroup.ofIdx P i * w)).ncard ↔
+      i ∉ inversions P b w⁻¹ := by
+  rw [ncard_inversions_ofIdx_mul, ← ncard_inversions_inv P b w,
+    lt_ncard_inversions_mul_ofIdx_iff P b w⁻¹ hi]
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Length.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Length.lean
@@ -43,9 +43,13 @@ length-function axioms in their inversion-count spelling.
   length parity, namely that of the inversion count.
 * `TauCeti.ncard_inversions_inv` and `TauCeti.ncard_inversions_mul_le`: the inversion count is
   invariant under inversion and subadditive.
-* `TauCeti.ncard_inversions_mul_ofIdx_lt_iff` and
-  `TauCeti.lt_ncard_inversions_mul_ofIdx_iff`: right multiplication by a simple reflection lowers
-  the inversion count exactly when its simple root is an inversion.
+* `TauCeti.ncard_inversions_mul_ofIdx_lt_of_mem`,
+  `TauCeti.ncard_inversions_mul_ofIdx_lt_iff` and
+  `TauCeti.lt_ncard_inversions_mul_ofIdx_iff`: right multiplication by the reflection in a
+  positive root lowers the inversion count exactly when that root is an inversion. The reflecting
+  root need not be simple, because the strong exchange condition does not require it to be.
+* `TauCeti.ncard_inversions_ofIdx_mul_lt_iff`: the same criterion for left multiplication, read off
+  the inverse element.
 
 ## References
 
@@ -174,28 +178,57 @@ theorem ncard_inversions_mul_le (v w : P.weylGroup) :
     _ = (inversions P b v).ncard + (inversions P b w).ncard := by
       rw [List.length_append, hlen, hlen']
 
-/-- **Descent criterion.** Right multiplication by a simple reflection shortens an element exactly
-when its simple root is already an inversion. -/
+/-- **Right multiplication by the reflection in an inversion shortens.** Deleting from a shortest
+word the letter supplied by the strong exchange condition spells the product, so the product needs
+strictly fewer letters. The reflecting root is an arbitrary inversion, not necessarily a simple
+root, so this is the length inequality for a general reflection of the Weyl group. -/
+theorem ncard_inversions_mul_ofIdx_lt_of_mem (w : P.weylGroup) {i : ι}
+    (hi : i ∈ inversions P b w) :
+    (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard < (inversions P b w).ncard := by
+  obtain ⟨hipos, hineg⟩ := (mem_inversions P b w i).mp hi
+  obtain ⟨l, hl, hlen⟩ := exists_wordProd_eq_and_length_eq_ncard_inversions P b w
+  obtain ⟨j, hj, hj'⟩ :=
+    exists_wordProd_eraseIdx_eq_mul_ofIdx P b hipos l (by rw [hl]; exact hineg)
+  have hle := ncard_inversions_wordProd_le_length P b (l.eraseIdx j)
+  rw [hj', hl] at hle
+  have hlen' := List.length_eraseIdx_add_one hj
+  omega
+
+/-- **Descent criterion.** Right multiplication by the reflection in a positive root shortens an
+element exactly when that root is already an inversion. -/
 @[simp]
-theorem ncard_inversions_mul_ofIdx_lt_iff (w : P.weylGroup) {i : ι} (hi : i ∈ b.support) :
+theorem ncard_inversions_mul_ofIdx_lt_iff (w : P.weylGroup) {i : ι} (hi : b.IsPos i) :
     (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard < (inversions P b w).ncard ↔
       i ∈ inversions P b w := by
-  refine ⟨fun h ↦ by_contra fun hc ↦ ?_, fun h ↦ ?_⟩
-  · rw [ncard_inversions_mul_ofIdx_of_notMem P w b hi hc] at h
-    omega
-  · have hdrop := ncard_inversions_mul_ofIdx_of_mem P w b hi h
-    omega
+  refine ⟨fun h ↦ by_contra fun hc ↦ ?_, ncard_inversions_mul_ofIdx_lt_of_mem P b w⟩
+  have hback := ncard_inversions_mul_ofIdx_lt_of_mem P b (w * RootPairing.weylGroup.ofIdx P i)
+    ((mem_inversions_mul_ofIdx_iff_not_mem P w b hi).mpr hc)
+  rw [mul_assoc, RootPairing.weylGroup.ofIdx_mul_self, mul_one] at hback
+  omega
 
-/-- **Ascent criterion.** Right multiplication by a simple reflection lengthens an element exactly
-when its simple root is not yet an inversion. -/
+/-- **Ascent criterion.** Right multiplication by the reflection in a positive root lengthens an
+element exactly when that root is not yet an inversion. -/
 @[simp]
-theorem lt_ncard_inversions_mul_ofIdx_iff (w : P.weylGroup) {i : ι} (hi : i ∈ b.support) :
+theorem lt_ncard_inversions_mul_ofIdx_iff (w : P.weylGroup) {i : ι} (hi : b.IsPos i) :
     (inversions P b w).ncard < (inversions P b (w * RootPairing.weylGroup.ofIdx P i)).ncard ↔
       i ∉ inversions P b w := by
   refine ⟨fun h hc ↦ ?_, fun h ↦ ?_⟩
-  · have hdrop := ncard_inversions_mul_ofIdx_of_mem P w b hi hc
+  · have hdrop := ncard_inversions_mul_ofIdx_lt_of_mem P b w hc
     omega
-  · rw [ncard_inversions_mul_ofIdx_of_notMem P w b hi h]
-    omega
+  · have hback := ncard_inversions_mul_ofIdx_lt_of_mem P b (w * RootPairing.weylGroup.ofIdx P i)
+      ((mem_inversions_mul_ofIdx_iff_not_mem P w b hi).mpr h)
+    rwa [mul_assoc, RootPairing.weylGroup.ofIdx_mul_self, mul_one] at hback
+
+/-- **Left descent criterion.** Left multiplication by the reflection in a positive root shortens
+an element exactly when that root is an inversion of the inverse element: reversing a shortest
+word turns left multiplication into right multiplication. -/
+theorem ncard_inversions_ofIdx_mul_lt_iff (w : P.weylGroup) {i : ι} (hi : b.IsPos i) :
+    (inversions P b (RootPairing.weylGroup.ofIdx P i * w)).ncard < (inversions P b w).ncard ↔
+      i ∈ inversions P b w⁻¹ := by
+  have hmirror : (inversions P b (RootPairing.weylGroup.ofIdx P i * w)).ncard =
+      (inversions P b (w⁻¹ * RootPairing.weylGroup.ofIdx P i)).ncard := by
+    rw [← ncard_inversions_inv P b (w⁻¹ * RootPairing.weylGroup.ofIdx P i), mul_inv_rev,
+      RootPairing.weylGroup.ofIdx_inv_eq, inv_inv]
+  rw [hmirror, ← ncard_inversions_inv P b w, ncard_inversions_mul_ofIdx_lt_iff P b w⁻¹ hi]
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/StrongExchange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/StrongExchange.lean
@@ -21,9 +21,12 @@ an empty inversion set is spelled by the empty word, so it is the identity.
 Two features of the statement are what make it usable and are not shared by the weaker "some
 shorter word exists" form. The reflecting root ranges over *all* positive roots, not just the
 simple ones, so the condition applies to an arbitrary reflection of the Weyl group; and the
-shorter word is a *subword* of the given one, obtained by deleting a single letter in a named
-position. Only the subword form transports along a group homomorphism, which is why it is the form
-the word property behind Tits' theorem consumes.
+shorter word is `l.eraseIdx j` for a named position `j`, a deletion that can be replayed verbatim
+on the corresponding word over any other family of generators indexed by `b.support`, in particular
+over the generators of the presented Coxeter group. The weaker form asserts only that some shorter
+word exists inside the Weyl group; it names no word over those generators to carry the assertion
+back through the presentation map, which is why the word property behind Tits' theorem consumes the
+deletion form.
 
 The proof is an induction on the word. Peeling off the leading simple reflection `sⱼ`, either the
 shorter word already sends the root to a negative root, and the inductive hypothesis deletes a

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Subword.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Subword.lean
@@ -21,10 +21,12 @@ The prefix one letter shorter is not wasteful, so the letter just read is an inv
 element that prefix spells, and the strong exchange condition deletes a letter from that prefix.
 Deleting the letter just read as well leaves a word two letters shorter spelling the same element.
 
-The subword form is what makes these statements usable downstream. A homomorphism out of the Weyl
-group carries a subword relation between two words to the same relation between their images,
-whereas the bare existence of some shorter word says nothing about any other group; this is the
-form in which the deletion condition enters the word property behind Tits' theorem.
+The subword form is what makes these statements usable downstream. The deleted positions are named,
+so the same deletions can be replayed verbatim on the corresponding word over any other family of
+generators indexed by `b.support`, in particular over the generators of the presented Coxeter
+group. The bare existence of some shorter word inside the Weyl group names no word over those
+generators to carry the assertion back through the presentation map; this is the form in which the
+deletion condition enters the word property behind Tits' theorem.
 
 ## Main results
 
@@ -118,9 +120,9 @@ theorem exists_wordProd_eraseIdx_eraseIdx_eq (l : List b.support)
     have h₃ := List.length_eraseIdx_add_one h₂
     omega
 
-/-- **The subword property.** Every word in the simple reflections contains a subword of least
-length spelling the same Weyl-group element: repeatedly deleting the two letters supplied by the
-deletion condition ends at a word whose length is the inversion count. -/
+/-- **The subword property.** Every word in the simple reflections has a sublist that spells the
+same Weyl-group element and whose length is the inversion count of that element, hence is of least
+length. -/
 theorem exists_sublist_wordProd_eq_and_length_eq_ncard_inversions (l : List b.support) :
     ∃ l' : List b.support, l'.Sublist l ∧ wordProd P b l' = wordProd P b l ∧
       l'.length = (inversions P b (wordProd P b l)).ncard := by

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Subword.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Subword.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.Inversions.Length
+
+public section
+
+/-!
+# The deletion condition and the subword property
+
+A word in the simple reflections whose length exceeds the number of inversions of the element it
+spells is wasteful, and the strong exchange condition says exactly where the waste is: two of its
+letters can be deleted without changing the element. Iterating the deletion until no waste is left
+extracts from any word a *subword* of least length spelling the same element.
+
+The deletion is located by walking along the word until the first prefix that is already wasteful.
+The prefix one letter shorter is not wasteful, so the letter just read is an inversion of the
+element that prefix spells, and the strong exchange condition deletes a letter from that prefix.
+Deleting the letter just read as well leaves a word two letters shorter spelling the same element.
+
+The subword form is what makes these statements usable downstream. A homomorphism out of the Weyl
+group carries a subword relation between two words to the same relation between their images,
+whereas the bare existence of some shorter word says nothing about any other group; this is the
+form in which the deletion condition enters the word property behind Tits' theorem.
+
+## Main results
+
+* `TauCeti.exists_wordProd_eraseIdx_eraseIdx_eq` is the deletion condition: a word longer than the
+  inversion count of the element it spells has two letters that can be deleted.
+* `TauCeti.exists_sublist_wordProd_eq_and_length_eq_ncard_inversions` is the subword property:
+  every word contains a subword of least length spelling the same element.
+* `TauCeti.ncard_inversions_wordProd_eq_length_iff` records that a word is of least length exactly
+  when no two of its letters can be deleted.
+
+## References
+
+This file continues the "inversion sets and the exchange step" item of Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md` towards the Coxeter presentation
+`weylCoxeterSystem` of Layer 2, whose completeness half is proved through the exchange condition at
+root level. The deletion condition and the subword property are the standard packaging of that
+step; see J. E. Humphreys, *Reflection Groups and Coxeter Groups*, CUP (1990), §1.7 and §5.8, and
+Bourbaki, *Lie Groups and Lie Algebras*, Chapters 4--6, Ch. IV, §1.5.
+-/
+
+namespace TauCeti
+
+open Set
+
+universe u v w x
+
+variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  (P : RootPairing ι R M N) [Finite ι] [CharZero R] [IsDomain R]
+  [P.IsCrystallographic] [P.IsReduced] (b : P.Base)
+
+/-- **The deletion condition.** If a word has more letters than the element it spells has
+inversions, then two of its letters can be deleted without changing the element it spells. -/
+theorem exists_wordProd_eraseIdx_eraseIdx_eq (l : List b.support)
+    (h : (inversions P b (wordProd P b l)).ncard < l.length) :
+    ∃ j k, j < k ∧ k < l.length ∧
+      wordProd P b ((l.eraseIdx k).eraseIdx j) = wordProd P b l ∧
+      ((l.eraseIdx k).eraseIdx j).length + 2 = l.length := by
+  classical
+  -- Some prefix is already too long for the element it spells; the whole word is one.
+  have hex : ∃ k, k < l.length ∧
+      (inversions P b (wordProd P b (l.take (k + 1)))).ncard < k + 1 := by
+    refine ⟨l.length - 1, by omega, ?_⟩
+    have hsub : l.length - 1 + 1 = l.length := by omega
+    rw [hsub, List.take_length]
+    exact h
+  -- Take the shortest such prefix.
+  obtain ⟨k, ⟨hklt, hkinv⟩, hkmin⟩ :
+      ∃ k, (k < l.length ∧ (inversions P b (wordProd P b (l.take (k + 1)))).ncard < k + 1) ∧
+        ∀ m < k, ¬(m < l.length ∧
+          (inversions P b (wordProd P b (l.take (m + 1)))).ncard < m + 1) :=
+    ⟨Nat.find hex, Nat.find_spec hex, fun _ hm ↦ Nat.find_min hex hm⟩
+  -- One letter earlier the prefix is of least length.
+  have hprefix : (inversions P b (wordProd P b (l.take k))).ncard = k := by
+    have hle := ncard_inversions_wordProd_le_length P b (l.take k)
+    rw [List.length_take] at hle
+    rcases Nat.eq_zero_or_pos k with rfl | hkpos
+    · simp [wordProd_nil]
+    · have hnot := hkmin (k - 1) (by omega)
+      push Not at hnot
+      have hge := hnot (by omega)
+      rw [Nat.sub_add_cancel hkpos] at hge
+      omega
+  -- The letter just read is an inversion of the element the shorter prefix spells.
+  have hsucc : l.take (k + 1) = l.take k ++ [l[k]] := by
+    rw [List.take_add_one, List.getElem?_eq_getElem hklt]
+    rfl
+  have hword : wordProd P b (l.take (k + 1)) =
+      wordProd P b (l.take k) * RootPairing.weylGroup.ofIdx P (l[k] : ι) := by
+    rw [hsucc, wordProd_append, wordProd_cons, wordProd_nil, mul_one]
+  have hmem : (l[k] : ι) ∈ inversions P b (wordProd P b (l.take k)) := by
+    rw [← ncard_inversions_mul_ofIdx_lt_iff P b _ (b.isPos_of_mem_support l[k].2), ← hword,
+      hprefix]
+    have hstep := ncard_inversions_mul_ofIdx P (wordProd P b (l.take k)) b l[k].2
+    rw [← hword, hprefix] at hstep
+    omega
+  obtain ⟨hmempos, hmemneg⟩ := (mem_inversions P b _ _).mp hmem
+  -- The strong exchange condition deletes a letter from the shorter prefix.
+  obtain ⟨j, hj, hjeq⟩ :=
+    exists_wordProd_eraseIdx_eq_mul_ofIdx P b hmempos (l.take k) hmemneg
+  rw [List.length_take] at hj
+  have hjk : j < k := by omega
+  have hjlt : j < (l.take k).length := by rw [List.length_take]; omega
+  have hinner : l.eraseIdx k = l.take k ++ l.drop (k + 1) := List.eraseIdx_eq_take_drop_succ ..
+  have hlist : (l.eraseIdx k).eraseIdx j = (l.take k).eraseIdx j ++ l.drop (k + 1) := by
+    rw [hinner, List.eraseIdx_append_of_lt_length hjlt]
+  refine ⟨j, k, hjk, hklt, ?_, ?_⟩
+  · rw [hlist, wordProd_append, hjeq, ← hword, ← wordProd_append, List.take_append_drop]
+  · have h₁ := List.length_eraseIdx_add_one hklt
+    have h₂ : j < (l.eraseIdx k).length := by omega
+    have h₃ := List.length_eraseIdx_add_one h₂
+    omega
+
+/-- **The subword property.** Every word in the simple reflections contains a subword of least
+length spelling the same Weyl-group element: repeatedly deleting the two letters supplied by the
+deletion condition ends at a word whose length is the inversion count. -/
+theorem exists_sublist_wordProd_eq_and_length_eq_ncard_inversions (l : List b.support) :
+    ∃ l' : List b.support, l'.Sublist l ∧ wordProd P b l' = wordProd P b l ∧
+      l'.length = (inversions P b (wordProd P b l)).ncard := by
+  suffices H : ∀ n : ℕ, ∀ l : List b.support, l.length ≤ n →
+      ∃ l' : List b.support, l'.Sublist l ∧ wordProd P b l' = wordProd P b l ∧
+        l'.length = (inversions P b (wordProd P b l)).ncard from H l.length l le_rfl
+  intro n
+  induction n with
+  | zero =>
+    intro l hl
+    exact ⟨l, List.Sublist.refl l, rfl, by
+      have := ncard_inversions_wordProd_le_length P b l
+      omega⟩
+  | succ n ih =>
+    intro l hl
+    rcases eq_or_lt_of_le (ncard_inversions_wordProd_le_length P b l) with heq | hlt
+    · exact ⟨l, List.Sublist.refl l, rfl, heq.symm⟩
+    · obtain ⟨j, k, -, -, hword, hlen⟩ := exists_wordProd_eraseIdx_eraseIdx_eq P b l hlt
+      obtain ⟨l', hsub, hl'word, hl'len⟩ := ih ((l.eraseIdx k).eraseIdx j) (by omega)
+      exact ⟨l', hsub.trans ((List.eraseIdx_sublist (l.eraseIdx k) j).trans
+        (List.eraseIdx_sublist l k)), hl'word.trans hword, by rw [hl'len, hword]⟩
+
+/-- **A word is of least length exactly when no two of its letters can be deleted.** -/
+theorem ncard_inversions_wordProd_eq_length_iff (l : List b.support) :
+    (inversions P b (wordProd P b l)).ncard = l.length ↔
+      ∀ j k, j < k → k < l.length →
+        wordProd P b ((l.eraseIdx k).eraseIdx j) ≠ wordProd P b l := by
+  refine ⟨fun heq j k hjk hk hword ↦ ?_, fun h ↦ ?_⟩
+  · -- A deletion would spell the same element with two letters fewer than its inversion count.
+    have h₁ := List.length_eraseIdx_add_one hk
+    have h₂ : j < (l.eraseIdx k).length := by omega
+    have h₃ := List.length_eraseIdx_add_one h₂
+    have hle := ncard_inversions_wordProd_le_length P b ((l.eraseIdx k).eraseIdx j)
+    rw [hword, heq] at hle
+    omega
+  · by_contra hne
+    have hlt : (inversions P b (wordProd P b l)).ncard < l.length :=
+      lt_of_le_of_ne (ncard_inversions_wordProd_le_length P b l) hne
+    obtain ⟨j, k, hjk, hk, hword, -⟩ := exists_wordProd_eraseIdx_eraseIdx_eq P b l hlt
+    exact h j k hjk hk hword
+
+end TauCeti


### PR DESCRIPTION
This PR strengthens the root-level exchange step of the Weyl group to the **strong exchange condition**, and derives from it the deletion condition and the subword property. The milestone it serves is Layer 2's Coxeter presentation `weylCoxeterSystem b : CoxeterSystem (coxeterMatrixOfBase P b) P.weylGroup` (Tits' theorem) in `RepresentationTheory/RootSystems/README.md`, whose completeness half the README says is "proved through the root-level exchange condition of Layer 1"; after this PR what remains for that milestone is the word property (any two least-length words for the same element are connected by braid moves, and any word that is not of least length can be braid-moved until two adjacent letters agree), and then the assembly of the presentation itself.

The form of the exchange step on `main`, `exists_wordProd_eq_mul_ofIdx_of_not_isPos`, produces *some* word one letter shorter. That is enough for the identity criterion it was built for, but it is not enough for Tits' theorem, because a bare "there exists a shorter word" statement transports along no homomorphism, and the whole point of the injectivity argument is to move a relation from `P.weylGroup` into the presented Coxeter group. The strengthened statement `exists_wordProd_eraseIdx_eq_mul_ofIdx` fixes both gaps at once: the shorter word is `l.eraseIdx j` for a named `j`, a genuine *subword* of `l`, and the reflecting root ranges over all positive roots rather than only the simple ones, so the condition covers an arbitrary reflection of the Weyl group. The proof is the same induction as before — the existing argument already deleted the leading letter in one branch and recursed in the other, and used the simplicity of the root only to rule out the empty word — so this is a generalisation of an existing lemma rather than a new argument, and the old name is removed rather than kept as an alias.

Three consequences follow, all previously unavailable. `ncard_inversions_mul_ofIdx_lt_of_mem` and the generalised `ncard_inversions_mul_ofIdx_lt_iff` / `lt_ncard_inversions_mul_ofIdx_iff` give the descent and ascent criteria for the reflection in an arbitrary positive root, where `main` had them only for simple reflections through the `±1` count of `Inversions/Exchange.lean` (that `±1` step is genuinely simple-root-specific and is untouched); `ncard_inversions_ofIdx_mul_lt_iff` is the mirror statement for left multiplication. The new `Inversions/Subword.lean` proves the **deletion condition** `exists_wordProd_eraseIdx_eraseIdx_eq` — a word with more letters than the element it spells has inversions loses two of them, located by walking to the first wasteful prefix and applying strong exchange there — the **subword property** `exists_sublist_wordProd_eq_and_length_eq_ncard_inversions`, that every word contains a `List.Sublist` of least length spelling the same element, and the characterisation `ncard_inversions_wordProd_eq_length_iff` of the words of least length.

Along the way `mem_inversions_mul_ofIdx_iff_not_mem` in `Inversions/Exchange.lean` is generalised from `i ∈ b.support` to `b.IsPos i`, which is all its proof used, and its three call sites are updated; no declaration outside these files referred to any of the changed names.

No Mathlib source was vendored. Mathlib's own Coxeter development states the strong exchange condition and Matsumoto's theorem as TODOs (`Mathlib/GroupTheory/Coxeter/Basic.lean`), so nothing here duplicates it; `RootPairing.weylGroup.ofIdx_inv_eq` from `TauCeti/LinearAlgebra/RootSystem/Weyl/Group.lean` is reused rather than reproved.

Files: `TauCeti/LinearAlgebra/RootSystem/Inversions/Subword.lean` (new, 165 lines); `Inversions/Deletion.lean`, `Inversions/Exchange.lean`, `Inversions/Length.lean` (edited).

Roadmap: RepresentationTheory

Consumer roadmap: CFSGStatement

The dependency edge: `CFSGStatement/README.md`'s Layer L0 consumes `DynkinType.simplyConnectedRootDatum` / `simplyConnectedBase` from RootSystems Layer 6 and says to "Claim those in the roadmap that owns them"; every CFSGStatement lane is blocked at its own head (`I0` complete, `L0`–`L3` waiting on ReductiveGroups Layer 9, `A0` waiting on `L3` + `S1`, and `S1` source-blocked for want of an admissible ATLAS presentation), so this PR works the prerequisite roadmap, on the RootSystems milestone whose summit `weylCoxeterSystem` the Layer 6 datum work sits above.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"strong-exchange-condition-weyl-group"}-->

🤖 Prepared with Claude Code
