### PR TITLE
feat: relate geometric reducedness and smoothness

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean
@@ -40,8 +40,8 @@ universe u v
 
 /-- **Geometric reducedness is preserved by extension of the base field.** -/
 theorem geometricallyReducedCommHopfAlgProperty.baseChange
-    (k : Type u) (K : Type (max u v)) [Field k] [Field K] [Algebra k K]
-    (H : CommHopfAlgCat.{v} k)
+    {k : Type u} (K : Type (max u v)) [Field k] [Field K] [Algebra k K]
+    {H : CommHopfAlgCat.{v} k}
     (hH : geometricallyReducedCommHopfAlgProperty k H) :
     geometricallyReducedCommHopfAlgProperty K
       (CommHopfAlgCat.baseChange (K := K) H) := by

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean
@@ -45,7 +45,7 @@ theorem geometricallyReducedCommHopfAlgProperty.baseChange
     (hH : geometricallyReducedCommHopfAlgProperty k H) :
     geometricallyReducedCommHopfAlgProperty K
       (CommHopfAlgCat.baseChange (K := K) H) := by
-  rw [geometricallyReducedCommHopfAlgProperty_iff]
+  rw [geometricallyReducedCommHopfAlgProperty_iff] at hH ⊢
   intro L _ _
   let _ : Algebra k L := Algebra.compHom L (algebraMap k K)
   let _ : IsScalarTower k K L := IsScalarTower.of_algebraMap_eq' rfl

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean
@@ -40,7 +40,7 @@ universe u v
 
 /-- **Geometric reducedness is preserved by extension of the base field.** -/
 theorem geometricallyReducedCommHopfAlgProperty.baseChange
-    (k K : Type u) [Field k] [Field K] [Algebra k K]
+    (k : Type u) (K : Type (max u v)) [Field k] [Field K] [Algebra k K]
     (H : CommHopfAlgCat.{v} k)
     (hH : geometricallyReducedCommHopfAlgProperty k H) :
     geometricallyReducedCommHopfAlgProperty K
@@ -52,7 +52,7 @@ theorem geometricallyReducedCommHopfAlgProperty.baseChange
   let e := (Algebra.TensorProduct.comm K (K ⊗[k] H) L).toRingEquiv.trans
     ((Algebra.TensorProduct.cancelBaseChange k K L L H).toRingEquiv.trans
       (Algebra.TensorProduct.comm k L H).toRingEquiv)
-  let _ := hH.isReduced_tensorProduct L
+  let _ := hH L
   exact isReduced_of_injective e.toRingHom e.injective
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.GeometricallyReduced.CommHopfAlgCat
+
+/-!
+# Geometric reducedness under base change
+
+Geometric reducedness of a commutative Hopf algebra is preserved by extension of the base
+field. If `H` is geometrically reduced over `k`, then the scalar extension `K ⊗[k] H` is
+geometrically reduced over every field extension `K / k`.
+
+## Main declaration
+
+* `TauCeti.geometricallyReducedCommHopfAlgProperty.baseChange`: geometric reducedness is
+  preserved by extension of the base field.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), for the geometric-reducedness terminology.
+
+The argument follows `TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange`, with reducedness
+transported along the scalar-extension equivalence in place of connectedness.
+
+This advances Layer 2, "Smoothness and dimension tools via `Lie(G)`", of the ReductiveGroups
+roadmap.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v
+
+/-- **Geometric reducedness is preserved by extension of the base field.** -/
+theorem geometricallyReducedCommHopfAlgProperty.baseChange
+    (k K : Type u) [Field k] [Field K] [Algebra k K]
+    (H : CommHopfAlgCat.{v} k)
+    (hH : geometricallyReducedCommHopfAlgProperty k H) :
+    geometricallyReducedCommHopfAlgProperty K
+      (CommHopfAlgCat.baseChange (K := K) H) := by
+  rw [geometricallyReducedCommHopfAlgProperty_iff]
+  intro L _ _
+  let _ : Algebra k L := Algebra.compHom L (algebraMap k K)
+  let _ : IsScalarTower k K L := IsScalarTower.of_algebraMap_eq' rfl
+  let e := (Algebra.TensorProduct.comm K (K ⊗[k] H) L).toRingEquiv.trans
+    ((Algebra.TensorProduct.cancelBaseChange k K L L H).toRingEquiv.trans
+      (Algebra.TensorProduct.comm k L H).toRingEquiv)
+  let _ := hH.isReduced_tensorProduct L
+  exact isReduced_of_injective e.toRingHom e.injective
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
@@ -68,17 +68,6 @@ theorem geometricallyReducedCommHopfAlgProperty_iff
         IsReduced ((H : Type v) ⊗[k] K) :=
   Iff.rfl
 
-/-- The coordinate ring stays reduced after any chosen extension of the base field, with the
-extension field as the left tensor factor. -/
-theorem geometricallyReducedCommHopfAlgProperty.isReduced_tensorProduct_comm
-    {k : Type u} [Field k] {H : CommHopfAlgCat.{v} k}
-    (hH : geometricallyReducedCommHopfAlgProperty k H)
-    (K : Type (max u v)) [Field K] [Algebra k K] :
-    IsReduced (K ⊗[k] (H : Type v)) := by
-  let _ := hH K
-  exact isReduced_of_injective (Algebra.TensorProduct.comm k H K).symm.toRingHom
-    (Algebra.TensorProduct.comm k H K).symm.injective
-
 /-- The all-extension coordinate condition implies Mathlib's algebraic geometric-reducedness
 predicate, which over a field tests the base change to an algebraic closure. -/
 theorem geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
@@ -23,8 +23,6 @@ as a TODO. The all-extension condition used here implies Mathlib's existing alge
 
 * `TauCeti.geometricallyReducedCommHopfAlgProperty`: geometric reducedness after every field
   extension.
-* `TauCeti.geometricallyReducedCommHopfAlgProperty.isReduced_tensorProduct`: the direct
-  eliminator for a chosen field extension.
 * `TauCeti.geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced`: comparison with
   Mathlib's algebra predicate.
 * `TauCeti.geometricallyReducedCommHopfAlgProperty.isReduced`: reducedness over the base field.
@@ -70,14 +68,6 @@ theorem geometricallyReducedCommHopfAlgProperty_iff
         IsReduced ((H : Type v) ⊗[k] K) :=
   Iff.rfl
 
-/-- The coordinate ring stays reduced after any chosen extension of the base field. -/
-theorem geometricallyReducedCommHopfAlgProperty.isReduced_tensorProduct
-    {k : Type u} [Field k] {H : CommHopfAlgCat.{v} k}
-    (hH : geometricallyReducedCommHopfAlgProperty k H)
-    (K : Type (max u v)) [Field K] [Algebra k K] :
-    IsReduced ((H : Type v) ⊗[k] K) :=
-  hH K
-
 /-- The coordinate ring stays reduced after any chosen extension of the base field, with the
 extension field as the left tensor factor. -/
 theorem geometricallyReducedCommHopfAlgProperty.isReduced_tensorProduct_comm
@@ -85,7 +75,7 @@ theorem geometricallyReducedCommHopfAlgProperty.isReduced_tensorProduct_comm
     (hH : geometricallyReducedCommHopfAlgProperty k H)
     (K : Type (max u v)) [Field K] [Algebra k K] :
     IsReduced (K ⊗[k] (H : Type v)) := by
-  let _ := hH.isReduced_tensorProduct K
+  let _ := hH K
   exact isReduced_of_injective (Algebra.TensorProduct.comm k H K).symm.toRingHom
     (Algebra.TensorProduct.comm k H K).symm.injective
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.Nilpotent.GeometricallyReduced
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
 import Mathlib.Algebra.Field.ULift
 
 /-!
@@ -23,12 +23,21 @@ as a TODO. The all-extension condition used here implies Mathlib's existing alge
 
 * `TauCeti.geometricallyReducedCommHopfAlgProperty`: geometric reducedness after every field
   extension.
+* `TauCeti.geometricallyReducedCommHopfAlgProperty.isReduced_tensorProduct`: the direct
+  eliminator for a chosen field extension.
 * `TauCeti.geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced`: comparison with
   Mathlib's algebra predicate.
+* `TauCeti.geometricallyReducedCommHopfAlgProperty.isReduced`: reducedness over the base field.
+* The `ObjectProperty.IsClosedUnderIsomorphisms` instance records invariance under Hopf-algebra
+  isomorphisms.
 
 ## References
 
-* J. S. Milne, *Algebraic Groups* (2017), Proposition 1.26 and Corollary 1.27.
+* J. S. Milne, *Algebraic Groups* (2017), for the geometric-reducedness terminology.
+
+The object-property organization follows
+`TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat` with reducedness replacing
+connectedness.
 
 This advances Layer 2, "Smoothness and dimension tools via `Lie(G)`", of the ReductiveGroups
 roadmap.
@@ -61,6 +70,25 @@ theorem geometricallyReducedCommHopfAlgProperty_iff
         IsReduced ((H : Type v) ⊗[k] K) :=
   Iff.rfl
 
+/-- The coordinate ring stays reduced after any chosen extension of the base field. -/
+theorem geometricallyReducedCommHopfAlgProperty.isReduced_tensorProduct
+    {k : Type u} [Field k] {H : CommHopfAlgCat.{v} k}
+    (hH : geometricallyReducedCommHopfAlgProperty k H)
+    (K : Type (max u v)) [Field K] [Algebra k K] :
+    IsReduced ((H : Type v) ⊗[k] K) :=
+  hH K
+
+/-- The coordinate ring stays reduced after any chosen extension of the base field, with the
+extension field as the left tensor factor. -/
+theorem geometricallyReducedCommHopfAlgProperty.isReduced_tensorProduct_comm
+    {k : Type u} [Field k] {H : CommHopfAlgCat.{v} k}
+    (hH : geometricallyReducedCommHopfAlgProperty k H)
+    (K : Type (max u v)) [Field K] [Algebra k K] :
+    IsReduced (K ⊗[k] (H : Type v)) := by
+  let _ := hH.isReduced_tensorProduct K
+  exact isReduced_of_injective (Algebra.TensorProduct.comm k H K).symm.toRingHom
+    (Algebra.TensorProduct.comm k H K).symm.injective
+
 /-- The all-extension coordinate condition implies Mathlib's algebraic geometric-reducedness
 predicate, which over a field tests the base change to an algebraic closure. -/
 theorem geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced
@@ -82,24 +110,6 @@ theorem geometricallyReducedCommHopfAlgProperty.isReduced
     IsReduced H := by
   let _ : Algebra.IsGeometricallyReduced k H := hH.isGeometricallyReduced
   exact Algebra.isReduced_of_isGeometricallyReduced k
-
-/-- Geometric reducedness is preserved by extension of the base field. -/
-theorem geometricallyReducedCommHopfAlgProperty.baseChange
-    (k K : Type u) [Field k] [Field K] [Algebra k K]
-    (H : CommHopfAlgCat.{u} k)
-    (hH : geometricallyReducedCommHopfAlgProperty k H) :
-    geometricallyReducedCommHopfAlgProperty K
-      (CommHopfAlgCat.baseChange (K := K) H) := by
-  rw [geometricallyReducedCommHopfAlgProperty_iff]
-  intro L _ _
-  let _ : Algebra k L := Algebra.compHom L (algebraMap k K)
-  let _ : IsScalarTower k K L := IsScalarTower.of_algebraMap_eq' rfl
-  let e := (Algebra.TensorProduct.comm K (K ⊗[k] H) L).toRingEquiv.trans
-    ((Algebra.TensorProduct.cancelBaseChange k K L L H).toRingEquiv.trans
-      (Algebra.TensorProduct.comm k L H).toRingEquiv)
-  rw [geometricallyReducedCommHopfAlgProperty_iff] at hH
-  let _ := hH L
-  exact isReduced_of_injective e.toRingHom e.injective
 
 /-- Geometric reducedness is invariant under isomorphisms of commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Nilpotent.GeometricallyReduced
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
+import Mathlib.Algebra.Field.ULift
+
+/-!
+# Geometric reducedness of commutative Hopf algebras
+
+For a commutative Hopf algebra `H` over a field `k`, geometric reducedness means that every
+field extension `K / k` in their common universe gives a reduced coordinate ring `H ⊗[k] K`.
+The base field and Hopf algebra may live in independent universes.
+
+Mathlib's `Algebra.IsGeometricallyReduced` tests the base change to algebraic closures of residue
+fields. Its source currently lists equivalence with reducedness after arbitrary field extension
+as a TODO. The all-extension condition used here implies Mathlib's existing algebra predicate.
+
+## Main declarations
+
+* `TauCeti.geometricallyReducedCommHopfAlgProperty`: geometric reducedness after every field
+  extension.
+* `TauCeti.geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced`: comparison with
+  Mathlib's algebra predicate.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 1.26 and Corollary 1.27.
+
+This advances Layer 2, "Smoothness and dimension tools via `Lie(G)`", of the ReductiveGroups
+roadmap.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v
+
+noncomputable section
+
+/-- A commutative Hopf algebra over a field is geometrically reduced when its coordinate ring
+remains reduced after every extension of the base field. -/
+def geometricallyReducedCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (CommHopfAlgCat.{v} k) :=
+  fun H ↦ ∀ (K : Type (max u v)) [Field K] [Algebra k K],
+    IsReduced ((H : Type v) ⊗[k] K)
+
+/-- Membership in the geometrically reduced commutative-Hopf-algebra object property. -/
+@[simp]
+theorem geometricallyReducedCommHopfAlgProperty_iff
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k) :
+    geometricallyReducedCommHopfAlgProperty k H ↔
+      ∀ (K : Type (max u v)) [Field K] [Algebra k K],
+        IsReduced ((H : Type v) ⊗[k] K) :=
+  Iff.rfl
+
+/-- The all-extension coordinate condition implies Mathlib's algebraic geometric-reducedness
+predicate, which over a field tests the base change to an algebraic closure. -/
+theorem geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k)
+    (hH : geometricallyReducedCommHopfAlgProperty k H) :
+    Algebra.IsGeometricallyReduced k H := by
+  rw [Algebra.isGeometricallyReduced_field_iff]
+  let _ : IsReduced ((H : Type v) ⊗[k] ULift.{v} (AlgebraicClosure k)) :=
+    hH (ULift.{v} (AlgebraicClosure k))
+  let e := (Algebra.TensorProduct.comm k H (ULift.{v} (AlgebraicClosure k))).trans
+    (Algebra.TensorProduct.congr ULift.algEquiv (AlgEquiv.refl : H ≃ₐ[k] H))
+  exact isReduced_of_injective e.symm.toRingHom e.symm.injective
+
+/-- A geometrically reduced commutative Hopf algebra has reduced coordinate ring over its base
+field. -/
+theorem geometricallyReducedCommHopfAlgProperty.isReduced
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k)
+    (hH : geometricallyReducedCommHopfAlgProperty k H) :
+    IsReduced H := by
+  let _ : Algebra.IsGeometricallyReduced k H := hH.isGeometricallyReduced k H
+  exact Algebra.isReduced_of_isGeometricallyReduced k
+
+/-- Geometric reducedness is invariant under isomorphisms of commutative Hopf algebras. -/
+instance (k : Type u) [Field k] :
+    (geometricallyReducedCommHopfAlgProperty k :
+      ObjectProperty (CommHopfAlgCat.{v} k)).IsClosedUnderIsomorphisms where
+  of_iso e hH := by
+    rw [geometricallyReducedCommHopfAlgProperty_iff] at hH ⊢
+    intro K _ _
+    let _ := hH K
+    let eK := Algebra.TensorProduct.congr
+      (CommHopfAlgCat.ofIso e).toAlgEquiv (AlgEquiv.refl : K ≃ₐ[k] K)
+    exact isReduced_of_injective eK.symm.toRingHom eK.symm.injective
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.Nilpotent.GeometricallyReduced
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
 import Mathlib.Algebra.Field.ULift
 
 /-!
@@ -64,7 +64,7 @@ theorem geometricallyReducedCommHopfAlgProperty_iff
 /-- The all-extension coordinate condition implies Mathlib's algebraic geometric-reducedness
 predicate, which over a field tests the base change to an algebraic closure. -/
 theorem geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k)
+    {k : Type u} [Field k] {H : CommHopfAlgCat.{v} k}
     (hH : geometricallyReducedCommHopfAlgProperty k H) :
     Algebra.IsGeometricallyReduced k H := by
   rw [Algebra.isGeometricallyReduced_field_iff]
@@ -77,11 +77,29 @@ theorem geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced
 /-- A geometrically reduced commutative Hopf algebra has reduced coordinate ring over its base
 field. -/
 theorem geometricallyReducedCommHopfAlgProperty.isReduced
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k)
+    {k : Type u} [Field k] {H : CommHopfAlgCat.{v} k}
     (hH : geometricallyReducedCommHopfAlgProperty k H) :
     IsReduced H := by
-  let _ : Algebra.IsGeometricallyReduced k H := hH.isGeometricallyReduced k H
+  let _ : Algebra.IsGeometricallyReduced k H := hH.isGeometricallyReduced
   exact Algebra.isReduced_of_isGeometricallyReduced k
+
+/-- Geometric reducedness is preserved by extension of the base field. -/
+theorem geometricallyReducedCommHopfAlgProperty.baseChange
+    (k K : Type u) [Field k] [Field K] [Algebra k K]
+    (H : CommHopfAlgCat.{u} k)
+    (hH : geometricallyReducedCommHopfAlgProperty k H) :
+    geometricallyReducedCommHopfAlgProperty K
+      (CommHopfAlgCat.baseChange (K := K) H) := by
+  rw [geometricallyReducedCommHopfAlgProperty_iff]
+  intro L _ _
+  let _ : Algebra k L := Algebra.compHom L (algebraMap k K)
+  let _ : IsScalarTower k K L := IsScalarTower.of_algebraMap_eq' rfl
+  let e := (Algebra.TensorProduct.comm K (K ⊗[k] H) L).toRingEquiv.trans
+    ((Algebra.TensorProduct.cancelBaseChange k K L L H).toRingEquiv.trans
+      (Algebra.TensorProduct.comm k L H).toRingEquiv)
+  rw [geometricallyReducedCommHopfAlgProperty_iff] at hH
+  let _ := hH L
+  exact isReduced_of_injective e.toRingHom e.injective
 
 /-- Geometric reducedness is invariant under isomorphisms of commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
@@ -51,10 +51,7 @@ universe u
 noncomputable section
 
 /-- **A finite-type geometrically reduced commutative Hopf algebra over a field is smooth.**
-
-This is the coordinate-algebra form of Mathlib's `AlgebraicGeometry.smooth_of_grpObj`. The
-finite-type comparison supplies local finite type for the structural morphism of the Hopf
-spectrum, and the geometric-reducedness comparison supplies its other hypothesis. -/
+-/
 theorem smoothCommHopfAlgProperty_of_geometricallyReduced
     (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
     [Algebra.FiniteType k H]

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
@@ -27,8 +27,6 @@ reducedness nor smoothness is built into the category of commutative Hopf algebr
 
 * `TauCeti.smoothCommHopfAlgProperty_of_geometricallyReduced`: a finite-type geometrically
   reduced commutative Hopf algebra over a field is smooth.
-* `TauCeti.finiteType_inf_geometricallyReduced_le_smooth`: the same implication as an inequality
-  of object properties.
 
 ## References
 
@@ -63,21 +61,13 @@ theorem smoothCommHopfAlgProperty_of_geometricallyReduced
   let _ : GeometricallyReduced
       (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) :=
     (geometricallyReducedCommHopfAlg_iff_geometricallyReduced_hopfSpec k H).mp hH
+  -- `smooth_of_grpObj` asks for the `Over.mk X.hom` spelling of the Hopf spectrum object `X`.
   let _ : GrpObj
       (Over.mk (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom)) :=
     inferInstanceAs (GrpObj ((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X)
   apply (algebraSmooth_iff_smooth_hopfSpec k H).mpr
   rw [smoothAffineGroupSchemeProperty_iff]
   exact smooth_of_grpObj _
-
-/-- Among commutative Hopf algebras over a field, finite type together with geometric
-reducedness implies smoothness. -/
-theorem finiteType_inf_geometricallyReduced_le_smooth (k : Type u) [Field k] :
-    (finiteTypeCommHopfAlgProperty k : ObjectProperty (CommHopfAlgCat.{u} k)) ⊓
-        geometricallyReducedCommHopfAlgProperty k ≤ smoothCommHopfAlgProperty k := by
-  intro H hH
-  let _ : Algebra.FiniteType k H := hH.1
-  exact smoothCommHopfAlgProperty_of_geometricallyReduced k H hH.2
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Group.Smooth
+public import Mathlib.RingTheory.Nilpotent.GeometricallyReduced
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Smooth
+
+/-!
+# Smoothness of geometrically reduced affine groups
+
+For a commutative Hopf algebra `H` over a field `k`, geometric reducedness means that every
+field extension `K / k` gives a reduced coordinate ring `H ⊗[k] K`. This file compares that
+coordinate condition with Mathlib's scheme-theoretic `GeometricallyReduced` predicate on the
+structural morphism of `Spec H`.
+
+Mathlib proves that a geometrically reduced group scheme locally of finite type over a field is
+smooth. Transporting that theorem through Tau Ceti's affine Hopf/group-scheme dictionary gives
+the coordinate criterion
+
+```text
+finite type + geometrically reduced ⇒ smooth.
+```
+
+The finite-type hypothesis is kept separate throughout. In particular, neither geometric
+reducedness nor smoothness is built into the category of commutative Hopf algebras.
+
+Mathlib's `Algebra.IsGeometricallyReduced` tests the base change to algebraic closures of residue
+fields. Its source currently lists equivalence with reducedness after arbitrary field extension
+as a TODO. The all-extension condition used here is chosen because it agrees directly with the
+scheme-theoretic predicate; `geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced`
+records the implication to Mathlib's existing algebra predicate.
+
+## Main declarations
+
+* `TauCeti.geometricallyReducedCommHopfAlgProperty`: geometric reducedness after every field
+  extension.
+* `TauCeti.geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced`: comparison with
+  Mathlib's algebra predicate.
+* `TauCeti.geometricallyReducedCommHopfAlg_iff_geometricallyReduced_hopfSpec`: agreement with
+  scheme-theoretic geometric reducedness.
+* `TauCeti.smoothCommHopfAlgProperty_of_geometricallyReduced`: a finite-type geometrically
+  reduced commutative Hopf algebra over a field is smooth.
+* `TauCeti.finiteType_inf_geometricallyReduced_le_smooth`: the same implication as an inequality
+  of object properties.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 1.26 and Corollary 1.27.
+
+This advances Layer 2, "Smoothness and dimension tools via `Lie(G)`", of the ReductiveGroups
+roadmap. The scheme-theoretic input is Mathlib's `AlgebraicGeometry.smooth_of_grpObj`.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+universe u
+
+noncomputable section
+
+/-- A commutative Hopf algebra over a field is geometrically reduced when its coordinate ring
+remains reduced after every extension of the base field. -/
+def geometricallyReducedCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (CommHopfAlgCat.{u} k) :=
+  fun H ↦ ∀ (K : Type u) [Field K] [Algebra k K],
+    IsReduced ((H : Type u) ⊗[k] K)
+
+/-- Membership in the geometrically reduced commutative-Hopf-algebra object property. -/
+@[simp]
+theorem geometricallyReducedCommHopfAlgProperty_iff
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    geometricallyReducedCommHopfAlgProperty k H ↔
+      ∀ (K : Type u) [Field K] [Algebra k K],
+        IsReduced ((H : Type u) ⊗[k] K) :=
+  Iff.rfl
+
+/-- A geometrically reduced commutative Hopf algebra has reduced coordinate ring over its base
+field. -/
+theorem geometricallyReducedCommHopfAlgProperty.isReduced
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
+    (hH : geometricallyReducedCommHopfAlgProperty k H) :
+    IsReduced H := by
+  let _ : IsReduced ((H : Type u) ⊗[k] k) := hH k
+  exact isReduced_of_injective (Algebra.TensorProduct.rid k k H).symm.toRingHom
+    (Algebra.TensorProduct.rid k k H).symm.injective
+
+/-- The all-extension coordinate condition implies Mathlib's algebraic geometric-reducedness
+predicate, which over a field tests the base change to an algebraic closure. -/
+theorem geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
+    (hH : geometricallyReducedCommHopfAlgProperty k H) :
+    Algebra.IsGeometricallyReduced k H := by
+  rw [Algebra.isGeometricallyReduced_field_iff]
+  let _ : IsReduced ((H : Type u) ⊗[k] AlgebraicClosure k) := hH (AlgebraicClosure k)
+  exact isReduced_of_injective
+    (Algebra.TensorProduct.comm k (AlgebraicClosure k) H).toRingHom
+    (Algebra.TensorProduct.comm k (AlgebraicClosure k) H).injective
+
+/-- Geometric reducedness is invariant under isomorphisms of commutative Hopf algebras. -/
+instance (k : Type u) [Field k] :
+    (geometricallyReducedCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
+  of_iso e hH := by
+    rw [geometricallyReducedCommHopfAlgProperty_iff] at hH ⊢
+    intro K _ _
+    let _ := hH K
+    let eK := Algebra.TensorProduct.congr
+      (CommHopfAlgCat.ofIso e).toAlgEquiv (AlgEquiv.refl : K ≃ₐ[k] K)
+    exact isReduced_of_injective eK.symm.toRingHom eK.symm.injective
+
+/-- **Geometric reducedness agrees across the affine-group-scheme and coordinate-ring models.**
+The structural morphism of a Hopf spectrum is geometrically reduced if and only if every field
+extension of its coordinate algebra is reduced. -/
+theorem geometricallyReducedCommHopfAlg_iff_geometricallyReduced_hopfSpec
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    geometricallyReducedCommHopfAlgProperty k H ↔
+      GeometricallyReduced
+        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) := by
+  let : MorphismProperty.RespectsIso @GeometricallyReduced :=
+    MorphismProperty.IsStableUnderBaseChange.respectsIso
+  rw [geometricallyReducedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
+  rw [MorphismProperty.cancel_left_of_respectsIso
+    (P := @GeometricallyReduced) (eqToHom (hopfSpec_obj_X_left k H))]
+  rw [GeometricallyReduced.eq_geometrically,
+    geometrically_iff_of_commRing_of_isClosedUnderIsomorphisms]
+  constructor
+  · intro h K _ _
+    let _ : IsReduced ((H : Type u) ⊗[k] K) := h K
+    have : IsReduced (Spec (CommRingCat.of ((H : Type u) ⊗[k] K))) := inferInstance
+    exact isReduced_of_isOpenImmersion (pullbackSpecIso k H K).hom
+  · intro h K _ _
+    let _ : IsReduced
+        (Limits.pullback (Spec.map (CommRingCat.ofHom (algebraMap k H)))
+          (Spec.map (CommRingCat.ofHom (algebraMap k K)))) := h K
+    have : IsReduced (Spec (CommRingCat.of ((H : Type u) ⊗[k] K))) :=
+      isReduced_of_isOpenImmersion (pullbackSpecIso k H K).inv
+    exact (affine_isReduced_iff (CommRingCat.of ((H : Type u) ⊗[k] K))).mp this
+
+/-- **A finite-type geometrically reduced commutative Hopf algebra over a field is smooth.**
+
+This is the coordinate-algebra form of Mathlib's `AlgebraicGeometry.smooth_of_grpObj`. The
+finite-type comparison supplies local finite type for the structural morphism of the Hopf
+spectrum, and the geometric-reducedness comparison supplies its other hypothesis. -/
+theorem smoothCommHopfAlgProperty_of_geometricallyReduced
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
+    [Algebra.FiniteType k H]
+    (hH : geometricallyReducedCommHopfAlgProperty k H) :
+    smoothCommHopfAlgProperty k H := by
+  let _ : LocallyOfFiniteType
+      (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) :=
+    (algebraFiniteType_iff_locallyOfFiniteType_hopfSpec k H).mp inferInstance
+  let _ : GeometricallyReduced
+      (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) :=
+    (geometricallyReducedCommHopfAlg_iff_geometricallyReduced_hopfSpec k H).mp hH
+  let _ : GrpObj
+      (Over.mk (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom)) :=
+    inferInstanceAs (GrpObj ((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X)
+  apply (algebraSmooth_iff_smooth_hopfSpec k H).mpr
+  rw [smoothAffineGroupSchemeProperty_iff]
+  exact smooth_of_grpObj _
+
+/-- Among commutative Hopf algebras over a field, finite type together with geometric
+reducedness implies smoothness. -/
+theorem finiteType_inf_geometricallyReduced_le_smooth (k : Type u) [Field k] :
+    finiteTypeCommHopfAlgProperty k ⊓ geometricallyReducedCommHopfAlgProperty k ≤
+      smoothCommHopfAlgProperty k := by
+  intro H hH
+  let _ : Algebra.FiniteType k H := hH.1
+  exact smoothCommHopfAlgProperty_of_geometricallyReduced k H hH.2
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
@@ -5,19 +5,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.Group.Smooth
-public import Mathlib.RingTheory.Nilpotent.GeometricallyReduced
-public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
-public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.GeometricallyReduced
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Smooth
 
 /-!
 # Smoothness of geometrically reduced affine groups
-
-For a commutative Hopf algebra `H` over a field `k`, geometric reducedness means that every
-field extension `K / k` gives a reduced coordinate ring `H ⊗[k] K`. This file compares that
-coordinate condition with Mathlib's scheme-theoretic `GeometricallyReduced` predicate on the
-structural morphism of `Spec H`.
 
 Mathlib proves that a geometrically reduced group scheme locally of finite type over a field is
 smooth. Transporting that theorem through Tau Ceti's affine Hopf/group-scheme dictionary gives
@@ -30,20 +23,8 @@ finite type + geometrically reduced ⇒ smooth.
 The finite-type hypothesis is kept separate throughout. In particular, neither geometric
 reducedness nor smoothness is built into the category of commutative Hopf algebras.
 
-Mathlib's `Algebra.IsGeometricallyReduced` tests the base change to algebraic closures of residue
-fields. Its source currently lists equivalence with reducedness after arbitrary field extension
-as a TODO. The all-extension condition used here is chosen because it agrees directly with the
-scheme-theoretic predicate; `geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced`
-records the implication to Mathlib's existing algebra predicate.
-
 ## Main declarations
 
-* `TauCeti.geometricallyReducedCommHopfAlgProperty`: geometric reducedness after every field
-  extension.
-* `TauCeti.geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced`: comparison with
-  Mathlib's algebra predicate.
-* `TauCeti.geometricallyReducedCommHopfAlg_iff_geometricallyReduced_hopfSpec`: agreement with
-  scheme-theoretic geometric reducedness.
 * `TauCeti.smoothCommHopfAlgProperty_of_geometricallyReduced`: a finite-type geometrically
   reduced commutative Hopf algebra over a field is smooth.
 * `TauCeti.finiteType_inf_geometricallyReduced_le_smooth`: the same implication as an inequality
@@ -60,7 +41,6 @@ roadmap. The scheme-theoretic input is Mathlib's `AlgebraicGeometry.smooth_of_gr
 public section
 
 open CategoryTheory
-open scoped TensorProduct
 
 namespace TauCeti
 
@@ -69,83 +49,6 @@ open AlgebraicGeometry
 universe u
 
 noncomputable section
-
-/-- A commutative Hopf algebra over a field is geometrically reduced when its coordinate ring
-remains reduced after every extension of the base field. -/
-def geometricallyReducedCommHopfAlgProperty (k : Type u) [Field k] :
-    ObjectProperty (CommHopfAlgCat.{u} k) :=
-  fun H ↦ ∀ (K : Type u) [Field K] [Algebra k K],
-    IsReduced ((H : Type u) ⊗[k] K)
-
-/-- Membership in the geometrically reduced commutative-Hopf-algebra object property. -/
-@[simp]
-theorem geometricallyReducedCommHopfAlgProperty_iff
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
-    geometricallyReducedCommHopfAlgProperty k H ↔
-      ∀ (K : Type u) [Field K] [Algebra k K],
-        IsReduced ((H : Type u) ⊗[k] K) :=
-  Iff.rfl
-
-/-- A geometrically reduced commutative Hopf algebra has reduced coordinate ring over its base
-field. -/
-theorem geometricallyReducedCommHopfAlgProperty.isReduced
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
-    (hH : geometricallyReducedCommHopfAlgProperty k H) :
-    IsReduced H := by
-  let _ : IsReduced ((H : Type u) ⊗[k] k) := hH k
-  exact isReduced_of_injective (Algebra.TensorProduct.rid k k H).symm.toRingHom
-    (Algebra.TensorProduct.rid k k H).symm.injective
-
-/-- The all-extension coordinate condition implies Mathlib's algebraic geometric-reducedness
-predicate, which over a field tests the base change to an algebraic closure. -/
-theorem geometricallyReducedCommHopfAlgProperty.isGeometricallyReduced
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
-    (hH : geometricallyReducedCommHopfAlgProperty k H) :
-    Algebra.IsGeometricallyReduced k H := by
-  rw [Algebra.isGeometricallyReduced_field_iff]
-  let _ : IsReduced ((H : Type u) ⊗[k] AlgebraicClosure k) := hH (AlgebraicClosure k)
-  exact isReduced_of_injective
-    (Algebra.TensorProduct.comm k (AlgebraicClosure k) H).toRingHom
-    (Algebra.TensorProduct.comm k (AlgebraicClosure k) H).injective
-
-/-- Geometric reducedness is invariant under isomorphisms of commutative Hopf algebras. -/
-instance (k : Type u) [Field k] :
-    (geometricallyReducedCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
-  of_iso e hH := by
-    rw [geometricallyReducedCommHopfAlgProperty_iff] at hH ⊢
-    intro K _ _
-    let _ := hH K
-    let eK := Algebra.TensorProduct.congr
-      (CommHopfAlgCat.ofIso e).toAlgEquiv (AlgEquiv.refl : K ≃ₐ[k] K)
-    exact isReduced_of_injective eK.symm.toRingHom eK.symm.injective
-
-/-- **Geometric reducedness agrees across the affine-group-scheme and coordinate-ring models.**
-The structural morphism of a Hopf spectrum is geometrically reduced if and only if every field
-extension of its coordinate algebra is reduced. -/
-theorem geometricallyReducedCommHopfAlg_iff_geometricallyReduced_hopfSpec
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
-    geometricallyReducedCommHopfAlgProperty k H ↔
-      GeometricallyReduced
-        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) := by
-  let : MorphismProperty.RespectsIso @GeometricallyReduced :=
-    MorphismProperty.IsStableUnderBaseChange.respectsIso
-  rw [geometricallyReducedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
-  rw [MorphismProperty.cancel_left_of_respectsIso
-    (P := @GeometricallyReduced) (eqToHom (hopfSpec_obj_X_left k H))]
-  rw [GeometricallyReduced.eq_geometrically,
-    geometrically_iff_of_commRing_of_isClosedUnderIsomorphisms]
-  constructor
-  · intro h K _ _
-    let _ : IsReduced ((H : Type u) ⊗[k] K) := h K
-    have : IsReduced (Spec (CommRingCat.of ((H : Type u) ⊗[k] K))) := inferInstance
-    exact isReduced_of_isOpenImmersion (pullbackSpecIso k H K).hom
-  · intro h K _ _
-    let _ : IsReduced
-        (Limits.pullback (Spec.map (CommRingCat.ofHom (algebraMap k H)))
-          (Spec.map (CommRingCat.ofHom (algebraMap k K)))) := h K
-    have : IsReduced (Spec (CommRingCat.of ((H : Type u) ⊗[k] K))) :=
-      isReduced_of_isOpenImmersion (pullbackSpecIso k H K).inv
-    exact (affine_isReduced_iff (CommRingCat.of ((H : Type u) ⊗[k] K))).mp this
 
 /-- **A finite-type geometrically reduced commutative Hopf algebra over a field is smooth.**
 
@@ -173,8 +76,8 @@ theorem smoothCommHopfAlgProperty_of_geometricallyReduced
 /-- Among commutative Hopf algebras over a field, finite type together with geometric
 reducedness implies smoothness. -/
 theorem finiteType_inf_geometricallyReduced_le_smooth (k : Type u) [Field k] :
-    finiteTypeCommHopfAlgProperty k ⊓ geometricallyReducedCommHopfAlgProperty k ≤
-      smoothCommHopfAlgProperty k := by
+    (finiteTypeCommHopfAlgProperty k : ObjectProperty (CommHopfAlgCat.{u} k)) ⊓
+        geometricallyReducedCommHopfAlgProperty k ≤ smoothCommHopfAlgProperty k := by
   intro H hH
   let _ : Algebra.FiniteType k H := hH.1
   exact smoothCommHopfAlgProperty_of_geometricallyReduced k H hH.2

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/GeometricallyReduced.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/GeometricallyReduced.lean
@@ -21,7 +21,11 @@ Mathlib's scheme-theoretic `GeometricallyReduced` predicate on its Hopf spectrum
 
 ## References
 
-* J. S. Milne, *Algebraic Groups* (2017), Proposition 1.26 and Corollary 1.27.
+* J. S. Milne, *Algebraic Groups* (2017), for the geometric-reducedness terminology.
+
+The comparison follows
+`TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected`, especially its Hopf-spectrum
+comparison between the coordinate and scheme models.
 
 This advances Layer 2, "Smoothness and dimension tools via `Lie(G)`", of the ReductiveGroups
 roadmap.
@@ -41,13 +45,15 @@ universe u
 noncomputable section
 
 /-- **Geometric reducedness agrees across the affine-group-scheme and coordinate-ring models.**
-The structural morphism of a Hopf spectrum is geometrically reduced if and only if every field
-extension of its coordinate algebra is reduced. -/
+The structural morphism of a Hopf spectrum is geometrically reduced if and only if its
+coordinate algebra stays reduced after every extension `K / k` of the base field, meaning that
+`H ⊗[k] K` is reduced for every such `K`. -/
 theorem geometricallyReducedCommHopfAlg_iff_geometricallyReduced_hopfSpec
     (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
     geometricallyReducedCommHopfAlgProperty k H ↔
       GeometricallyReduced
         (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) := by
+  -- This witness is not a global instance, but `cancel_left_of_respectsIso` needs it below.
   let : MorphismProperty.RespectsIso @GeometricallyReduced :=
     MorphismProperty.IsStableUnderBaseChange.respectsIso
   rw [geometricallyReducedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
@@ -55,18 +61,15 @@ theorem geometricallyReducedCommHopfAlg_iff_geometricallyReduced_hopfSpec
     (P := @GeometricallyReduced) (eqToHom (hopfSpec_obj_X_left k H))]
   rw [GeometricallyReduced.eq_geometrically,
     geometrically_iff_of_commRing_of_isClosedUnderIsomorphisms]
-  constructor
-  · intro h K _ _
-    let _ : IsReduced ((H : Type u) ⊗[k] K) := h K
-    have : IsReduced (Spec (CommRingCat.of ((H : Type u) ⊗[k] K))) := inferInstance
-    exact isReduced_of_isOpenImmersion (pullbackSpecIso k H K).hom
-  · intro h K _ _
-    let _ : IsReduced
-        (Limits.pullback (Spec.map (CommRingCat.ofHom (algebraMap k H)))
-          (Spec.map (CommRingCat.ofHom (algebraMap k K)))) := h K
-    have : IsReduced (Spec (CommRingCat.of ((H : Type u) ⊗[k] K))) :=
-      isReduced_of_isOpenImmersion (pullbackSpecIso k H K).inv
-    exact (affine_isReduced_iff (CommRingCat.of ((H : Type u) ⊗[k] K))).mp this
+  have key (K : Type u) [Field K] [Algebra k K] :
+      IsReduced
+          (Limits.pullback (Spec.map (CommRingCat.ofHom (algebraMap k H)))
+            (Spec.map (CommRingCat.ofHom (algebraMap k K)))) ↔
+        IsReduced ((H : Type u) ⊗[k] K) := by
+    rw [← affine_isReduced_iff (CommRingCat.of ((H : Type u) ⊗[k] K))]
+    exact ⟨fun _ ↦ isReduced_of_isOpenImmersion (pullbackSpecIso k H K).inv,
+      fun _ ↦ isReduced_of_isOpenImmersion (pullbackSpecIso k H K).hom⟩
+  exact ⟨fun h K _ _ ↦ (key K).mpr (h K), fun h K _ _ ↦ (key K).mp (h K)⟩
 
 end
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/GeometricallyReduced.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/GeometricallyReduced.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Geometrically.Reduced
+public import TauCeti.Algebra.AlgebraicGroup.GeometricallyReduced.CommHopfAlgCat
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+
+/-!
+# Geometric reducedness of affine group schemes
+
+This file compares geometric reducedness of a same-universe commutative Hopf algebra with
+Mathlib's scheme-theoretic `GeometricallyReduced` predicate on its Hopf spectrum.
+
+## Main declarations
+
+* `TauCeti.geometricallyReducedCommHopfAlg_iff_geometricallyReduced_hopfSpec`: agreement of the
+  coordinate-ring and scheme-theoretic predicates.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 1.26 and Corollary 1.27.
+
+This advances Layer 2, "Smoothness and dimension tools via `Lie(G)`", of the ReductiveGroups
+roadmap.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+universe u
+
+noncomputable section
+
+/-- **Geometric reducedness agrees across the affine-group-scheme and coordinate-ring models.**
+The structural morphism of a Hopf spectrum is geometrically reduced if and only if every field
+extension of its coordinate algebra is reduced. -/
+theorem geometricallyReducedCommHopfAlg_iff_geometricallyReduced_hopfSpec
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    geometricallyReducedCommHopfAlgProperty k H ↔
+      GeometricallyReduced
+        (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) := by
+  let : MorphismProperty.RespectsIso @GeometricallyReduced :=
+    MorphismProperty.IsStableUnderBaseChange.respectsIso
+  rw [geometricallyReducedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
+  rw [MorphismProperty.cancel_left_of_respectsIso
+    (P := @GeometricallyReduced) (eqToHom (hopfSpec_obj_X_left k H))]
+  rw [GeometricallyReduced.eq_geometrically,
+    geometrically_iff_of_commRing_of_isClosedUnderIsomorphisms]
+  constructor
+  · intro h K _ _
+    let _ : IsReduced ((H : Type u) ⊗[k] K) := h K
+    have : IsReduced (Spec (CommRingCat.of ((H : Type u) ⊗[k] K))) := inferInstance
+    exact isReduced_of_isOpenImmersion (pullbackSpecIso k H K).hom
+  · intro h K _ _
+    let _ : IsReduced
+        (Limits.pullback (Spec.map (CommRingCat.ofHom (algebraMap k H)))
+          (Spec.map (CommRingCat.ofHom (algebraMap k K)))) := h K
+    have : IsReduced (Spec (CommRingCat.of ((H : Type u) ⊗[k] K))) :=
+      isReduced_of_isOpenImmersion (pullbackSpecIso k H K).inv
+    exact (affine_isReduced_iff (CommRingCat.of ((H : Type u) ⊗[k] K))).mp this
+
+end
+
+end TauCeti


### PR DESCRIPTION
This PR defines geometric reducedness of a commutative Hopf algebra by reducedness after every field extension, proves that this coordinate condition agrees exactly with Mathlib's scheme-theoretic `GeometricallyReduced` predicate on the Hopf spectrum, and deduces that a finite-type geometrically reduced commutative Hopf algebra over a field is smooth.

This advances `ReductiveGroups/README.md`, Layer 2, milestone **"Smoothness and dimension tools via `Lie(G)`"**: the exact dependency edge is that the finite-type and geometric-reducedness comparisons provide the two hypotheses consumed by `AlgebraicGeometry.smooth_of_grpObj`, while after this PR the milestone still needs the converse smooth-to-geometrically-reduced implication and the tangent/local-dimension form of the smoothness criterion.

This is the most effective distinct current step because Layer 1's embedding and faithfulness targets and Layer 2's adjoint representation and kernel-Lie calculation are already on `main`, while open ReductiveGroups PRs own the cotangent localization comparison, Tannakian reconstruction, Jordan decomposition, multiplicative type, non-split tori, and geometric connectedness. The result keeps finite type and smoothness as separate predicates and uses the full base-change condition, so non-smooth finite group schemes remain in the ambient Hopf category.

The implementation reuses Mathlib's `AlgebraicGeometry.smooth_of_grpObj`, `AlgebraicGeometry.pullbackSpecIso`, `AlgebraicGeometry.affine_isReduced_iff`, and Tau Ceti's existing finite-type and smooth Hopf-spectrum comparisons. It also relates the new scheme-exact condition to Mathlib's `Algebra.IsGeometricallyReduced`; no Mathlib infrastructure is vendored. The mathematical statement follows J. S. Milne, *Algebraic Groups* (2017), Proposition 1.26 and Corollary 1.27, as cited in the module documentation.

Add `TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean` (118 lines), `TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean` (58 lines), `TauCeti/AlgebraicGeometry/AffineGroupScheme/GeometricallyReduced.lean` (76 lines), and `TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean` (74 lines).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geometrically-reduced-hopf-algebra-smooth"}-->

🤖 Prepared with Codex
