### PR TITLE
feat: n-th roots of n-divisible fractional ideals and the n-th root class map

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/Basic.lean
@@ -28,7 +28,9 @@ is invertible, `FractionalIdeal R⁰ K` being a semifield) to the free Weil-divi
 homomorphism is an **isomorphism**: a fractional ideal is recovered from its multiplicities by the
 factorization `I = ∏_v v^(count K v I)` (injectivity), and every finite integer combination of
 primes is the divisor of the corresponding product of prime ideals (surjectivity). This is the
-scheme-free, affine-chart form of the roadmap's **`Weil ≃ Cartier` dictionary**.
+scheme-free, affine-chart form of the roadmap's **`Weil ≃ Cartier` dictionary**. Injectivity is
+also recorded coefficientwise as `units_eq_of_forall_count_eq`, the form in which it is used: to
+prove two invertible fractional ideals equal, compare `count` at each prime.
 
 We also connect it to the order system already built: the divisor of the principal fractional ideal
 `(x)` is exactly the principal divisor of the rational function `x`, so the isomorphism carries the
@@ -112,6 +114,19 @@ lemma fractionalIdealDivisor_injective :
           (Units.ne_zero (Additive.toMul J))]
     exact finprod_congr fun v => by rw [hcount v]
   exact Additive.toMul.injective (Units.ext key)
+
+/-- An invertible fractional ideal is determined by its multiplicities. This is
+`fractionalIdealDivisor_injective` read coefficientwise, which is the form a consumer uses: to
+prove two invertible fractional ideals equal, compare `FractionalIdeal.count` at each height-one
+prime. -/
+lemma units_eq_of_forall_count_eq {I J : (FractionalIdeal R⁰ K)ˣ}
+    (h : ∀ v : HeightOneSpectrum R, FractionalIdeal.count K v (I : FractionalIdeal R⁰ K) =
+      FractionalIdeal.count K v (J : FractionalIdeal R⁰ K)) :
+    I = J :=
+  Additive.ofMul.injective <| fractionalIdealDivisor_injective R K <| by
+    ext v
+    rw [coeff_fractionalIdealDivisor, coeff_fractionalIdealDivisor]
+    exact h v
 
 /-- The product `∏_v v^(D v)` of prime fractional ideals `v.asIdeal` raised to the multiplicities
 `D v` of a Weil divisor `D` is nonzero, hence an invertible fractional ideal. This is the value of

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/NthRoot.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/NthRoot.lean
@@ -1,0 +1,307 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.WeilDivisor.FractionalIdealDivisor.Basic
+public import TauCeti.RingTheory.ClassGroup.Basic
+
+/-!
+# `n`-th roots of invertible fractional ideals, and the `n`-th root class map
+
+Let `R` be a Dedekind domain with fraction field `K`. `FractionalIdealDivisor.Basic` identifies the
+group of invertible fractional ideals of `R` with the free Weil-divisor group on the height-one
+primes, by `fractionalIdealDivisorAddEquiv`. In a free abelian group, an element all of whose
+coefficients are divisible by `n` is `n` times an element, and for `n ≠ 0` that element is unique.
+This file transports that division back to fractional ideals and records what it says about the
+ideal class group.
+
+Everything below is stated for all `n : ℕ`, including the degenerate `n = 0`. There `nDivisible R K
+0` is the trivial subgroup (divisibility by `0` is vanishing), `nthRootFun R K 0` is constantly `1`,
+and the results remain true but say nothing: `1 ^ 0 = 1` is the only instance of `nthRootHom_pow`.
+
+## Main definitions
+
+* `nDivisible R K n`: the subgroup of invertible fractional ideals all of whose multiplicities
+  `FractionalIdeal.count K v` are divisible by `n`.
+* `nthRootFun R K n`: coefficientwise integer division of the Weil divisor by `n`, as a bare
+  function on all invertible fractional ideals. It is a genuine `n`-th root on `nDivisible R K n`
+  and a candidate elsewhere — integer division rounds.
+* `nthRootHom R K n`: the **`n`-th root homomorphism** from `nDivisible R K n` to the group of
+  invertible fractional ideals. Restricting to `nDivisible R K n` is what makes `nthRootFun`
+  multiplicative for `n ≠ 0`, integer division being additive on multiples of `n`; for `n = 0` it
+  is multiplicative on the whole group, being constant.
+* `unitsNDivisible R K n`: the subgroup of `x : Kˣ` whose principal fractional ideal `(x)` lies in
+  `nDivisible R K n`.
+* `nthRootClass R K n`: the **`n`-th root class map** `unitsNDivisible R K n →* ClassGroup R`,
+  sending `u` to the ideal class of the `n`-th root of `(u)`. Its codomain is taken to be the whole
+  class group, with `nthRootClass_pow` recording that the image lands in the `n`-torsion.
+
+## Main results
+
+* `nthRootHom_pow`: the `n`-th root homomorphism is a genuine `n`-th root — its value raised to the
+  `n`-th power is the original ideal.
+* `mem_nDivisible_iff_exists_pow`: `nDivisible R K n` is exactly the subgroup of `n`-th powers.
+  The forward direction is `exists_pow_eq_of_nDivisible` — an invertible fractional ideal whose
+  multiplicities are all divisible by `n` is an `n`-th power — and the converse is
+  `pow_mem_nDivisible`, with `pow_mem_unitsNDivisible` the corresponding statement for `Kˣ`.
+* `nthRootClass_pow`: every value of the `n`-th root class map is `n`-torsion.
+* `nthRootClass_eq_one_iff`: the `n`-th root class of `u` is trivial exactly when `u` is a unit of
+  `R` times an `n`-th power in `Kˣ`.
+
+The last two are the torsion and kernel statements that will become exactness at the middle term of
+the fundamental sequence `1 → Rˣ/(Rˣ)ⁿ → K(∅, n) → Cl(R)[n] → 1` once the quotients are formed and
+the codomain is restricted along `nthRootClass_pow`. Neither step is taken here: this file supplies
+the `n`-th root map, the torsion bound and the kernel description, and states no exactness or
+finiteness result.
+
+These are ingredients for `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6 (Mordell–Weil), whose
+weak Mordell–Weil argument needs the Selmer group `K(S, n)` of
+`Mathlib.RingTheory.DedekindDomain.SelmerGroup` to be finite; Mathlib leaves that finiteness as a
+`TODO` and the roadmap assigns it to this repository. The finiteness proof is not in this file.
+
+None of the definitions here is `@[expose]`: the interface is the membership, coefficient, coercion
+and application lemmas, not the construction bodies. The characteristic lemmas that hold by
+definition are therefore written `:= (rfl)` and `:= (Iff.rfl)` rather than `:= rfl` — the
+parentheses keep the proof elaborating where the definition is still available, which is what lets
+the bodies stay unexposed. Do not "simplify" them back.
+
+Adapted from Michael Stoll's elliptic-curves formalisation
+(`github.com/MichaelStollBayreuth/EllipticCurves`, `EllipticCurves/Mathlib/FractionalIdeal.lean`
+at the roadmap's pin `66889eada51a`, Apache 2.0, by Michael Stoll). Following this repository's
+convention for adapted material, the upstream authorship is credited here rather than in the
+copyright header. The `n`-th root is built here by dividing the coefficients of a Weil divisor and
+transporting along `fractionalIdealDivisorAddEquiv`, where the source builds it from its own
+`ofFinsupp`/`toFinsupp` pair; that pair duplicates the isomorphism this repository already has, so
+it is not ported.
+-/
+
+public section
+
+open IsDedekindDomain IsDedekindDomain.HeightOneSpectrum FractionalIdeal
+open scoped nonZeroDivisors
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+namespace WeilDivisor
+
+variable (R : Type*) [CommRing R] [IsDedekindDomain R]
+variable (K : Type*) [Field K] [Algebra R K] [IsFractionRing R K]
+
+/-! ### The `n`-th root homomorphism -/
+
+/-- The subgroup of invertible fractional ideals all of whose multiplicities are divisible by `n`,
+equivalently those whose Weil divisor is `n` times a divisor. -/
+def nDivisible (n : ℕ) : Subgroup (FractionalIdeal R⁰ K)ˣ where
+  carrier := {I | ∀ v : HeightOneSpectrum R, (n : ℤ) ∣ count K v (I : FractionalIdeal R⁰ K)}
+  one_mem' v := by rw [Units.val_one, count_one]; exact dvd_zero _
+  mul_mem' {I J} hI hJ v := by
+    rw [Units.val_mul, count_mul K v (Units.ne_zero I) (Units.ne_zero J)]
+    exact dvd_add (hI v) (hJ v)
+  inv_mem' {I} hI v := by
+    rw [Units.val_inv_eq_inv_val, count_inv]
+    exact (hI v).neg_right
+
+variable {R K} in
+/-- Membership in `nDivisible R K n` is divisibility of every multiplicity by `n`. -/
+@[simp]
+lemma mem_nDivisible {n : ℕ} {I : (FractionalIdeal R⁰ K)ˣ} :
+    I ∈ nDivisible R K n ↔
+      ∀ v : HeightOneSpectrum R, (n : ℤ) ∣ count K v (I : FractionalIdeal R⁰ K) :=
+  (Iff.rfl)
+
+/-- An `n`-th power is `n`-divisible: every multiplicity of `J ^ n` is `n` times one of `J`. This
+is the introduction rule for `nDivisible R K n`, converse to `exists_pow_eq_of_nDivisible`. -/
+lemma pow_mem_nDivisible (n : ℕ) (J : (FractionalIdeal R⁰ K)ˣ) : J ^ n ∈ nDivisible R K n :=
+  mem_nDivisible.mpr fun v ↦ by
+    rw [Units.val_pow_eq_pow_val, count_pow]
+    exact dvd_mul_right _ _
+
+/-- Coefficientwise integer division of the Weil divisor of an invertible fractional ideal by `n`,
+transported back along `fractionalIdealDivisorAddEquiv`. Since integer division rounds, this is a
+genuine `n`-th root exactly on `nDivisible R K n`, where `nthRootHom` bundles it as a group
+homomorphism; off that subgroup it is only a candidate. -/
+noncomputable def nthRootFun (n : ℕ) (I : (FractionalIdeal R⁰ K)ˣ) : (FractionalIdeal R⁰ K)ˣ :=
+  Additive.toMul ((fractionalIdealDivisorAddEquiv R K).symm
+    (Finsupp.mapRange (· / (n : ℤ)) (Int.zero_ediv _)
+      (fractionalIdealDivisor R K (Additive.ofMul I))))
+
+/-- The Weil divisor of the `n`-th root is the Weil divisor of `I` with every coefficient divided
+by `n`: `nthRootFun` read back through the isomorphism defining it. -/
+@[simp]
+lemma fractionalIdealDivisor_nthRootFun (n : ℕ) (I : (FractionalIdeal R⁰ K)ˣ) :
+    fractionalIdealDivisor R K (Additive.ofMul (nthRootFun R K n I)) =
+      Finsupp.mapRange (· / (n : ℤ)) (Int.zero_ediv _)
+        (fractionalIdealDivisor R K (Additive.ofMul I)) := by
+  conv_lhs => rw [nthRootFun]
+  simp only [ofMul_toMul, ← fractionalIdealDivisorAddEquiv_apply, AddEquiv.apply_symm_apply]
+
+/-- The multiplicities of the `n`-th root are those of `I`, divided by `n`. -/
+@[simp]
+lemma count_nthRootFun (n : ℕ) (I : (FractionalIdeal R⁰ K)ˣ) (v : HeightOneSpectrum R) :
+    count K v (nthRootFun R K n I : FractionalIdeal R⁰ K) =
+      count K v (I : FractionalIdeal R⁰ K) / n := by
+  have key : ∀ J : (FractionalIdeal R⁰ K)ˣ, count K v (J : FractionalIdeal R⁰ K) =
+      coeff (fractionalIdealDivisor R K (Additive.ofMul J)) v :=
+    fun J ↦ (coeff_fractionalIdealDivisor R K (Additive.ofMul J) v).symm
+  rw [key, key I, fractionalIdealDivisor_nthRootFun]
+  simp only [coeff, Finsupp.mapRange_apply]
+
+/-- The **`n`-th root homomorphism**: on the subgroup of ideals whose multiplicities are all
+divisible by `n`, dividing every multiplicity by `n` is a group homomorphism. For `n ≠ 0` the
+restriction is what makes this multiplicative, integer division being additive on multiples of `n`
+and not in general; for `n = 0` the map is constantly `1` and the subgroup is trivial. -/
+noncomputable def nthRootHom (n : ℕ) : nDivisible R K n →* (FractionalIdeal R⁰ K)ˣ where
+  toFun I := nthRootFun R K n (I : (FractionalIdeal R⁰ K)ˣ)
+  map_one' := units_eq_of_forall_count_eq R K fun v ↦ by
+    simp only [count_nthRootFun, Subgroup.coe_one, Units.val_one, count_one, Int.zero_ediv]
+  map_mul' I J := units_eq_of_forall_count_eq R K fun v ↦ by
+    rw [count_nthRootFun, Units.val_mul, count_mul K v (Units.ne_zero _) (Units.ne_zero _),
+      count_nthRootFun, count_nthRootFun, Subgroup.coe_mul, Units.val_mul,
+      count_mul K v (Units.ne_zero _) (Units.ne_zero _),
+      Int.add_ediv_of_dvd_left (mem_nDivisible.mp I.2 v)]
+
+variable {R K} in
+/-- The `n`-th root homomorphism acts by `nthRootFun` on the underlying fractional ideal. -/
+@[simp]
+lemma nthRootHom_apply (n : ℕ) (I : nDivisible R K n) :
+    nthRootHom R K n I = nthRootFun R K n (I : (FractionalIdeal R⁰ K)ˣ) :=
+  (rfl)
+
+/-- The `n`-th root homomorphism is a genuine `n`-th root: raising its value to the `n`-th power
+returns the original ideal. -/
+lemma nthRootHom_pow (n : ℕ) (I : nDivisible R K n) :
+    nthRootHom R K n I ^ n = (I : (FractionalIdeal R⁰ K)ˣ) :=
+  units_eq_of_forall_count_eq R K fun v ↦ by
+    rw [Units.val_pow_eq_pow_val, count_pow, nthRootHom_apply, count_nthRootFun,
+      Int.mul_ediv_cancel' (mem_nDivisible.mp I.2 v)]
+
+/-- **`n`-th roots of invertible fractional ideals.** An invertible fractional ideal all of whose
+multiplicities are divisible by `n` is an `n`-th power. -/
+lemma exists_pow_eq_of_nDivisible (n : ℕ) {I : (FractionalIdeal R⁰ K)ˣ}
+    (hI : I ∈ nDivisible R K n) : ∃ J : (FractionalIdeal R⁰ K)ˣ, J ^ n = I :=
+  ⟨nthRootHom R K n ⟨I, hI⟩, nthRootHom_pow R K n ⟨I, hI⟩⟩
+
+variable {R K} in
+/-- **`nDivisible R K n` is exactly the subgroup of `n`-th powers.** Combining
+`exists_pow_eq_of_nDivisible` with its converse `pow_mem_nDivisible`. -/
+lemma mem_nDivisible_iff_exists_pow {n : ℕ} {I : (FractionalIdeal R⁰ K)ˣ} :
+    I ∈ nDivisible R K n ↔ ∃ J : (FractionalIdeal R⁰ K)ˣ, J ^ n = I :=
+  ⟨exists_pow_eq_of_nDivisible R K n, by rintro ⟨J, rfl⟩; exact pow_mem_nDivisible R K n J⟩
+
+/-! ### The `n`-th root class map -/
+
+/-- The subgroup of those `x : Kˣ` whose principal fractional ideal `(x)` has all multiplicities
+divisible by `n`. These are exactly the elements for which an `n`-th root of `(x)` exists, so they
+are exactly the elements the `n`-th root class map is defined on. -/
+def unitsNDivisible (n : ℕ) : Subgroup Kˣ :=
+  Subgroup.comap (toPrincipalIdeal R K) (nDivisible R K n)
+
+variable {R K} in
+/-- Membership in `unitsNDivisible R K n` is divisibility by `n` of every multiplicity of the
+principal fractional ideal generated by `u`. -/
+@[simp]
+lemma mem_unitsNDivisible {n : ℕ} {u : Kˣ} :
+    u ∈ unitsNDivisible R K n ↔
+      ∀ v : HeightOneSpectrum R, (n : ℤ) ∣ count K v (spanSingleton R⁰ (u : K)) := by
+  rw [unitsNDivisible, Subgroup.mem_comap, mem_nDivisible]
+  simp only [coe_toPrincipalIdeal]
+
+/-- An `n`-th power of a unit of `K` lies in `unitsNDivisible R K n`: the introduction rule, and
+the reason the subgroup contains the `n`-th powers that the quotient `Kˣ/(Kˣ)ⁿ` divides out. -/
+lemma pow_mem_unitsNDivisible (n : ℕ) (w : Kˣ) : w ^ n ∈ unitsNDivisible R K n := by
+  rw [unitsNDivisible, Subgroup.mem_comap, map_pow]
+  exact pow_mem_nDivisible R K n _
+
+/-- The principal-ideal map restricted to `unitsNDivisible R K n`, with codomain cut down to the
+subgroup `nDivisible R K n` that it lands in by definition. -/
+noncomputable def unitsNDivisibleToNDivisible (n : ℕ) :
+    unitsNDivisible R K n →* nDivisible R K n :=
+  ((toPrincipalIdeal R K).comp (unitsNDivisible R K n).subtype).codRestrict _ fun x ↦ x.2
+
+/-- Underneath the codomain restriction, `unitsNDivisibleToNDivisible` is `toPrincipalIdeal`. -/
+@[simp]
+lemma coe_unitsNDivisibleToNDivisible (n : ℕ) (u : unitsNDivisible R K n) :
+    (unitsNDivisibleToNDivisible R K n u : (FractionalIdeal R⁰ K)ˣ) =
+      toPrincipalIdeal R K (u : Kˣ) :=
+  (rfl)
+
+/-- The **`n`-th root class map**: send `u : Kˣ` whose principal ideal `(u)` is `n`-divisible to the
+ideal class of the `n`-th root of `(u)`. This is the map that becomes the right-hand map of
+`1 → Rˣ/(Rˣ)ⁿ → K(∅, n) → Cl(R)[n] → 1` once quotients are formed and the codomain is cut down to
+the `n`-torsion; here it is taken with its full codomain `ClassGroup R`. -/
+noncomputable def nthRootClass (n : ℕ) : unitsNDivisible R K n →* ClassGroup R :=
+  (ClassGroup.mk K).comp ((nthRootHom R K n).comp (unitsNDivisibleToNDivisible R K n))
+
+/-- The `n`-th root class map is the class of the `n`-th root of the principal ideal, by
+definition. -/
+@[simp]
+lemma nthRootClass_apply (n : ℕ) (u : unitsNDivisible R K n) :
+    nthRootClass R K n u =
+      ClassGroup.mk K (nthRootHom R K n (unitsNDivisibleToNDivisible R K n u)) :=
+  (rfl)
+
+/-- **Every value of the `n`-th root class map is `n`-torsion.** The `n`-th power of the class of
+the `n`-th root of `(u)` is the class of `(u)` itself, which is trivial because `(u)` is principal.
+This is what lets a consumer cut the codomain down to the `n`-torsion of `ClassGroup R`. -/
+-- Deliberately not `@[simp]`: `nthRootClass_apply` is already `simp`, so `simp` rewrites this
+-- left-hand side before this lemma could fire, exactly as for `nthRootClass_eq_one_iff` below.
+lemma nthRootClass_pow (n : ℕ) (u : unitsNDivisible R K n) : nthRootClass R K n u ^ n = 1 := by
+  rw [nthRootClass_apply, ← map_pow, nthRootHom_pow, coe_unitsNDivisibleToNDivisible,
+    ClassGroup.mk_toPrincipalIdeal]
+
+/-- **The kernel of the `n`-th root class map.** The `n`-th root class of `u` is trivial exactly
+when `u` is a unit of `R` times an `n`-th power in `Kˣ`. Passing to quotients, this is what will
+give exactness at the middle term of `1 → Rˣ/(Rˣ)ⁿ → K(∅, n) → Cl(R)[n] → 1`; the quotients are not
+formed here. -/
+-- Deliberately not `@[simp]`: `nthRootClass_apply`, `nthRootHom_apply` and
+-- `coe_unitsNDivisibleToNDivisible` are already `simp` lemmas, so `simp` rewrites this left-hand
+-- side to `ClassGroup.mk K (nthRootFun R K n (toPrincipalIdeal R K ↑u)) = 1` before this lemma
+-- could fire. Tagging it is a `simpNF` violation for exactly that reason.
+lemma nthRootClass_eq_one_iff {n : ℕ} (u : unitsNDivisible R K n) :
+    nthRootClass R K n u = 1 ↔
+      ∃ (a : Rˣ) (w : Kˣ), Units.map (algebraMap R K : R →* K) a * w ^ n = (u : Kˣ) := by
+  rcases eq_or_ne n 0 with rfl | hn
+  · -- Every multiplicity of `(u)` is divisible by `0`, hence zero, so `(u)` is already trivial and
+    -- both sides hold.
+    have hu1 : toPrincipalIdeal R K (u : Kˣ) = 1 :=
+      units_eq_of_forall_count_eq R K fun v ↦ by
+        rw [coe_toPrincipalIdeal, Units.val_one, count_one]
+        exact zero_dvd_iff.mp (by simpa using mem_unitsNDivisible.mp u.2 v)
+    obtain ⟨a, ha⟩ := (toPrincipalIdeal_eq_one_iff _).mp hu1
+    have hroot : nthRootHom R K 0 (unitsNDivisibleToNDivisible R K 0 u) = 1 :=
+      units_eq_of_forall_count_eq R K fun v ↦ by
+        rw [nthRootHom_apply, count_nthRootFun, Nat.cast_zero, Int.ediv_zero, Units.val_one,
+          count_one]
+    exact iff_of_true (by rw [nthRootClass_apply, hroot, map_one])
+      ⟨a, 1, by rw [pow_zero, mul_one, ha]⟩
+  rw [nthRootClass_apply, ClassGroup.mk_eq_one_iff_exists]
+  constructor
+  · rintro ⟨w, hw⟩
+    -- The `n`-th power of the generator `w` of the root generates `(u)`, so `u / wⁿ` is a unit.
+    have hpow : toPrincipalIdeal R K (w ^ n) = toPrincipalIdeal R K (u : Kˣ) := by
+      rw [map_pow, hw, nthRootHom_pow, coe_unitsNDivisibleToNDivisible]
+    have h1 : toPrincipalIdeal R K ((u : Kˣ) * (w ^ n)⁻¹) = 1 := by
+      rw [map_mul, map_inv, hpow, mul_inv_cancel]
+    obtain ⟨a, ha⟩ := (toPrincipalIdeal_eq_one_iff _).mp h1
+    exact ⟨a, w, by rw [ha]; group⟩
+  · rintro ⟨a, w, hw⟩
+    -- Conversely `w` generates the `n`-th root: its multiplicities are those of `(u)` over `n`.
+    refine ⟨w, units_eq_of_forall_count_eq R K fun v ↦ ?_⟩
+    have hcu : count K v ((toPrincipalIdeal R K (u : Kˣ) : (FractionalIdeal R⁰ K)ˣ) :
+        FractionalIdeal R⁰ K) = n * count K v
+          ((toPrincipalIdeal R K w : (FractionalIdeal R⁰ K)ˣ) : FractionalIdeal R⁰ K) := by
+      rw [← hw, map_mul, map_pow, Units.val_mul, Units.val_pow_eq_pow_val,
+        count_mul K v (Units.ne_zero _) (pow_ne_zero _ (Units.ne_zero _)), count_pow,
+        (toPrincipalIdeal_eq_one_iff _).mpr ⟨a, rfl⟩, Units.val_one, count_one, zero_add]
+    rw [nthRootHom_apply, count_nthRootFun, coe_unitsNDivisibleToNDivisible, hcu,
+      Int.mul_ediv_cancel_left _ (Int.natCast_ne_zero.mpr hn)]
+
+end WeilDivisor
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/NthRoot.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/NthRoot.lean
@@ -18,20 +18,19 @@ This file transports that division back to fractional ideals and records what it
 ideal class group.
 
 Everything below is stated for all `n : ℕ`, including the degenerate `n = 0`. There `nDivisible R K
-0` is the trivial subgroup (divisibility by `0` is vanishing), `nthRootFun R K 0` is constantly `1`,
+0` is the trivial subgroup (divisibility by `0` is vanishing), `nthRootHom R K 0` is constantly `1`,
 and the results remain true but say nothing: `1 ^ 0 = 1` is the only instance of `nthRootHom_pow`.
 
 ## Main definitions
 
 * `nDivisible R K n`: the subgroup of invertible fractional ideals all of whose multiplicities
   `FractionalIdeal.count K v` are divisible by `n`.
-* `nthRootFun R K n`: coefficientwise integer division of the Weil divisor by `n`, as a bare
-  function on all invertible fractional ideals. It is a genuine `n`-th root on `nDivisible R K n`
-  and a candidate elsewhere — integer division rounds.
 * `nthRootHom R K n`: the **`n`-th root homomorphism** from `nDivisible R K n` to the group of
-  invertible fractional ideals. Restricting to `nDivisible R K n` is what makes `nthRootFun`
-  multiplicative for `n ≠ 0`, integer division being additive on multiples of `n`; for `n = 0` it
-  is multiplicative on the whole group, being constant.
+  invertible fractional ideals. It is built from a private helper performing coefficientwise
+  integer division of the Weil divisor by `n`; that helper is deliberately not public, since off
+  `nDivisible R K n` integer division rounds and the value obeys no law worth depending on.
+  Restricting to the subgroup is what makes it multiplicative for `n ≠ 0`, integer division being
+  additive on multiples of `n`; for `n = 0` it is constant.
 * `unitsNDivisible R K n`: the subgroup of `x : Kˣ` whose principal fractional ideal `(x)` lies in
   `nDivisible R K n`.
 * `nthRootClass R K n`: the **`n`-th root class map** `unitsNDivisible R K n →* ClassGroup R`,
@@ -61,9 +60,9 @@ weak Mordell–Weil argument needs the Selmer group `K(S, n)` of
 `Mathlib.RingTheory.DedekindDomain.SelmerGroup` to be finite; Mathlib leaves that finiteness as a
 `TODO` and the roadmap assigns it to this repository. The finiteness proof is not in this file.
 
-None of the definitions here is `@[expose]`: the interface is the membership, coefficient, coercion
-and application lemmas, not the construction bodies. The characteristic lemmas that hold by
-definition are therefore written `:= (rfl)` and `:= (Iff.rfl)` rather than `:= rfl` — the
+None of the definitions here is `@[expose]`: the interface is the membership, coefficient and
+coercion lemmas, not the construction bodies. The characteristic lemmas that hold by
+definition are therefore written `:= (rfl)`, `:= (Iff.rfl)` and `:= (proof)` rather than bare — the
 parentheses keep the proof elaborating where the definition is still available, which is what lets
 the bodies stay unexposed. Do not "simplify" them back.
 
@@ -124,15 +123,15 @@ lemma pow_mem_nDivisible (n : ℕ) (J : (FractionalIdeal R⁰ K)ˣ) : J ^ n ∈ 
 transported back along `fractionalIdealDivisorAddEquiv`. Since integer division rounds, this is a
 genuine `n`-th root exactly on `nDivisible R K n`, where `nthRootHom` bundles it as a group
 homomorphism; off that subgroup it is only a candidate. -/
-noncomputable def nthRootFun (n : ℕ) (I : (FractionalIdeal R⁰ K)ˣ) : (FractionalIdeal R⁰ K)ˣ :=
+private noncomputable def nthRootFun (n : ℕ) (I : (FractionalIdeal R⁰ K)ˣ) :
+    (FractionalIdeal R⁰ K)ˣ :=
   Additive.toMul ((fractionalIdealDivisorAddEquiv R K).symm
     (Finsupp.mapRange (· / (n : ℤ)) (Int.zero_ediv _)
       (fractionalIdealDivisor R K (Additive.ofMul I))))
 
 /-- The Weil divisor of the `n`-th root is the Weil divisor of `I` with every coefficient divided
 by `n`: `nthRootFun` read back through the isomorphism defining it. -/
-@[simp]
-lemma fractionalIdealDivisor_nthRootFun (n : ℕ) (I : (FractionalIdeal R⁰ K)ˣ) :
+private lemma fractionalIdealDivisor_nthRootFun (n : ℕ) (I : (FractionalIdeal R⁰ K)ˣ) :
     fractionalIdealDivisor R K (Additive.ofMul (nthRootFun R K n I)) =
       Finsupp.mapRange (· / (n : ℤ)) (Int.zero_ediv _)
         (fractionalIdealDivisor R K (Additive.ofMul I)) := by
@@ -140,8 +139,7 @@ lemma fractionalIdealDivisor_nthRootFun (n : ℕ) (I : (FractionalIdeal R⁰ K)�
   simp only [ofMul_toMul, ← fractionalIdealDivisorAddEquiv_apply, AddEquiv.apply_symm_apply]
 
 /-- The multiplicities of the `n`-th root are those of `I`, divided by `n`. -/
-@[simp]
-lemma count_nthRootFun (n : ℕ) (I : (FractionalIdeal R⁰ K)ˣ) (v : HeightOneSpectrum R) :
+private lemma count_nthRootFun (n : ℕ) (I : (FractionalIdeal R⁰ K)ˣ) (v : HeightOneSpectrum R) :
     count K v (nthRootFun R K n I : FractionalIdeal R⁰ K) =
       count K v (I : FractionalIdeal R⁰ K) / n := by
   have key : ∀ J : (FractionalIdeal R⁰ K)ˣ, count K v (J : FractionalIdeal R⁰ K) =
@@ -165,18 +163,21 @@ noncomputable def nthRootHom (n : ℕ) : nDivisible R K n →* (FractionalIdeal 
       Int.add_ediv_of_dvd_left (mem_nDivisible.mp I.2 v)]
 
 variable {R K} in
-/-- The `n`-th root homomorphism acts by `nthRootFun` on the underlying fractional ideal. -/
+/-- The multiplicities of the `n`-th root are those of `I`, divided by `n`. Together with
+`units_eq_of_forall_count_eq` this determines `nthRootHom` completely, so no lemma below needs to
+unfold it. -/
 @[simp]
-lemma nthRootHom_apply (n : ℕ) (I : nDivisible R K n) :
-    nthRootHom R K n I = nthRootFun R K n (I : (FractionalIdeal R⁰ K)ˣ) :=
-  (rfl)
+lemma count_nthRootHom (n : ℕ) (I : nDivisible R K n) (v : HeightOneSpectrum R) :
+    count K v (nthRootHom R K n I : FractionalIdeal R⁰ K) =
+      count K v ((I : (FractionalIdeal R⁰ K)ˣ) : FractionalIdeal R⁰ K) / n :=
+  (count_nthRootFun R K n _ v)
 
 /-- The `n`-th root homomorphism is a genuine `n`-th root: raising its value to the `n`-th power
 returns the original ideal. -/
 lemma nthRootHom_pow (n : ℕ) (I : nDivisible R K n) :
     nthRootHom R K n I ^ n = (I : (FractionalIdeal R⁰ K)ˣ) :=
   units_eq_of_forall_count_eq R K fun v ↦ by
-    rw [Units.val_pow_eq_pow_val, count_pow, nthRootHom_apply, count_nthRootFun,
+    rw [Units.val_pow_eq_pow_val, count_pow, count_nthRootHom,
       Int.mul_ediv_cancel' (mem_nDivisible.mp I.2 v)]
 
 /-- **`n`-th roots of invertible fractional ideals.** An invertible fractional ideal all of whose
@@ -274,8 +275,7 @@ lemma nthRootClass_eq_one_iff {n : ℕ} (u : unitsNDivisible R K n) :
     obtain ⟨a, ha⟩ := (toPrincipalIdeal_eq_one_iff _).mp hu1
     have hroot : nthRootHom R K 0 (unitsNDivisibleToNDivisible R K 0 u) = 1 :=
       units_eq_of_forall_count_eq R K fun v ↦ by
-        rw [nthRootHom_apply, count_nthRootFun, Nat.cast_zero, Int.ediv_zero, Units.val_one,
-          count_one]
+        rw [count_nthRootHom, Nat.cast_zero, Int.ediv_zero, Units.val_one, count_one]
     exact iff_of_true (by rw [nthRootClass_apply, hroot, map_one])
       ⟨a, 1, by rw [pow_zero, mul_one, ha]⟩
   rw [nthRootClass_apply, ClassGroup.mk_eq_one_iff_exists]
@@ -297,7 +297,7 @@ lemma nthRootClass_eq_one_iff {n : ℕ} (u : unitsNDivisible R K n) :
       rw [← hw, map_mul, map_pow, Units.val_mul, Units.val_pow_eq_pow_val,
         count_mul K v (Units.ne_zero _) (pow_ne_zero _ (Units.ne_zero _)), count_pow,
         (toPrincipalIdeal_eq_one_iff _).mpr ⟨a, rfl⟩, Units.val_one, count_one, zero_add]
-    rw [nthRootHom_apply, count_nthRootFun, coe_unitsNDivisibleToNDivisible, hcu,
+    rw [count_nthRootHom, coe_unitsNDivisibleToNDivisible, hcu,
       Int.mul_ediv_cancel_left _ (Int.natCast_ne_zero.mpr hn)]
 
 end WeilDivisor

--- a/TauCeti/RingTheory/ClassGroup/Basic.lean
+++ b/TauCeti/RingTheory/ClassGroup/Basic.lean
@@ -10,9 +10,9 @@ public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
 /-!
 # Complements on the ideal class group
 
-Three facts about Mathlib's `ClassGroup R` that its own file does not carry: the generator form of
-triviality of a class, that a principal fractional ideal has trivial class, and the class `[v]` of
-a height one prime.
+Four facts about Mathlib's `ClassGroup R` and its principal-ideal map that Mathlib's own file does
+not carry: the kernel of `toPrincipalIdeal`, the generator form of triviality of a class, that a
+principal fractional ideal has trivial class, and the class `[v]` of a height one prime.
 
 ## Main definitions
 
@@ -21,6 +21,10 @@ a height one prime.
 
 ## Main results
 
+* `FractionalIdeal.toPrincipalIdeal_eq_one_iff`: the kernel of the principal-ideal homomorphism is
+  the image of `Rˣ`, that is, `(u)` is trivial exactly when `u` comes from a unit of `R`. This is
+  the left end of the ideal class exact sequence. The underlying computation is Mathlib's
+  `Submodule.span_singleton_eq_one_iff`, reached by coercing the fractional ideal to a submodule.
 * `ClassGroup.mk_eq_one_iff_exists`: a class is trivial exactly when some `x : Kˣ` generates it.
   This is Mathlib's `ClassGroup.mk_eq_one_iff` with `Submodule.IsPrincipal` traded for the range
   of `toPrincipalIdeal`, which is the form a consumer that wants to *name* the generator can use.
@@ -32,10 +36,12 @@ a height one prime.
 * `IsDedekindDomain.HeightOneSpectrum.classGroupMk_eq_mk`: `[v]` is the class of `v.asIdeal` seen
   as an invertible fractional ideal of any fraction field `K`.
 
-All are stated at the weakest hypotheses their proofs need — `ClassGroup.mk_eq_one_iff_exists`
-and `ClassGroup.mk_toPrincipalIdeal` over `[IsDomain R]`, since nothing in either is
-Dedekind-specific. None of them needs the factorization of a fractional ideal into primes, so
-this file does not import it; the results that do live in
+All are stated at the weakest hypotheses their proofs need: the two class-triviality results over
+`[IsDomain R]`, since nothing in either is Dedekind-specific, and `toPrincipalIdeal_eq_one_iff`
+over a plain `[CommRing R]`, since routing it through Mathlib's submodule lemma needs no domain
+hypothesis at all. None
+of them needs the factorization of a fractional ideal into primes, so this file does not import
+it; the results that do live in
 `TauCeti.RingTheory.ClassGroup.HeightOneSpectrum`, which every consumer of *those* pays for and
 consumers of these do not.
 
@@ -50,6 +56,16 @@ public section
 
 open IsDedekindDomain IsDedekindDomain.HeightOneSpectrum
 open scoped nonZeroDivisors
+
+/-- The kernel of the principal-ideal map is the image of `Rˣ`: `toPrincipalIdeal R K u` is trivial
+exactly when `u` comes from a unit of `R`. This is the left end of the ideal class exact
+sequence. -/
+lemma FractionalIdeal.toPrincipalIdeal_eq_one_iff {R : Type*} [CommRing R]
+    {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K] (u : Kˣ) :
+    toPrincipalIdeal R K u = 1 ↔ ∃ a : Rˣ, Units.map (algebraMap R K : R →* K) a = u := by
+  rw [← Units.val_inj, coe_toPrincipalIdeal, Units.val_one, ← coeToSubmodule_inj,
+    coe_spanSingleton, coe_one, Submodule.span_singleton_eq_one_iff]
+  exact ⟨fun ⟨a, ha⟩ ↦ ⟨a, Units.ext ha.symm⟩, fun ⟨a, ha⟩ ↦ ⟨a, by rw [← ha]; rfl⟩⟩
 
 /-- A unit fractional ideal has trivial class exactly when it is principal, with the generator
 delivered as a unit of `K`. This is Mathlib's `ClassGroup.mk_eq_one_iff` with


### PR DESCRIPTION
The `n`-th root of an invertible fractional ideal whose multiplicities are all divisible by `n`,
as a group homomorphism, and the class-group map it induces.

```
WeilDivisor.units_eq_of_forall_count_eq        -- (in FractionalIdealDivisor/Basic.lean)
WeilDivisor.nDivisible / mem_nDivisible        -- the n-divisible subgroup
WeilDivisor.pow_mem_nDivisible                 -- J^n is n-divisible
WeilDivisor.mem_nDivisible_iff_exists_pow      -- nDivisible IS the subgroup of n-th powers
WeilDivisor.nthRootFun                         -- I ↦ I^(1/n), as a bare function
WeilDivisor.fractionalIdealDivisor_nthRootFun  -- its divisor is the divisor of I, divided by n
WeilDivisor.count_nthRootFun                   -- @[simp]
WeilDivisor.nthRootHom / nthRootHom_apply      -- the n-th root as a group homomorphism
WeilDivisor.nthRootHom_pow                     -- (I^(1/n))^n = I
WeilDivisor.exists_pow_eq_of_nDivisible        -- n ∣ every multiplicity ⇒ I is an n-th power
WeilDivisor.unitsNDivisible / mem_             -- the u : Kˣ with (u) n-divisible
WeilDivisor.pow_mem_unitsNDivisible            -- and it contains the n-th powers
WeilDivisor.unitsNDivisibleToNDivisible / coe_
WeilDivisor.nthRootClass / nthRootClass_apply  -- u ↦ [(u)^(1/n)] ∈ Cl(R)
WeilDivisor.nthRootClass_pow                   -- every value is n-torsion
WeilDivisor.nthRootClass_eq_one_iff            -- its kernel

FractionalIdeal.toPrincipalIdeal_eq_one_iff    -- (in ClassGroup/Basic.lean)
```

## What is here

`FractionalIdealDivisor/Basic.lean` already identifies the group of invertible fractional ideals of
a Dedekind domain with the free Weil-divisor group on the height one primes
(`fractionalIdealDivisorAddEquiv`). A free abelian group has unique division, and this PR cashes
that in: if `n` divides every multiplicity of `I`, dividing them all by `n` produces a genuine
`n`-th root of `I`, and the assignment is a group homomorphism on the subgroup where it is defined
— and only there, since integer division is additive on multiples of `n` and not in general.

`nthRootClass` then sends `u : Kˣ` whose principal ideal `(u)` is `n`-divisible to the ideal class
of the `n`-th root of `(u)`, and `nthRootClass_eq_one_iff` computes its kernel: the class is
trivial exactly when `u` is a unit of `R` times an `n`-th power in `Kˣ`. Passing to quotients and
cutting the codomain down to the `n`-torsion, that becomes exactness at the middle term of

```
1 → Rˣ/(Rˣ)ⁿ → K(∅, n) → Cl(R)[n] → 1
```

but neither step is taken here: `nthRootClass` keeps the full `ClassGroup R` as its codomain, and
this PR states no exactness or finiteness result. `nthRootClass_pow` does supply the torsion half —
every value satisfies `x ^ n = 1`, because the `n`-th power of the class of the root is the class of
the principal ideal `(u)` — which is what a later consumer needs in order to restrict the codomain
to `Cl(R)[n]` at all.

## Why the construction goes through Weil divisors

The source builds the `n`-th root from its own `toFinsupp`/`ofFinsupp` pair, which packages
`I ↦ (v ↦ count v I)` as a multiplicative isomorphism onto the finitely supported integer tuples.
That is exactly `fractionalIdealDivisorAddEquiv`, which this repository already has, so the pair is
**not** ported: `nthRootFun` divides the coefficients of the Weil divisor and transports back along
`(fractionalIdealDivisorAddEquiv R K).symm`. The same reason retires the source's `count_injective`
— `units_eq_of_forall_count_eq` is `fractionalIdealDivisor_injective` read coefficientwise, not a
second proof of it. (A previous attempt at this material, #2802, added the `toFinsupp`/`ofFinsupp`
pair and was closed for exactly this duplication; this is that slice rebuilt on the existing
isomorphism.)

## The one lemma in `ClassGroup/Basic.lean`

`nthRootClass_eq_one_iff` needs to recognise when a principal fractional ideal is trivial, which is
the kernel of `toPrincipalIdeal`. Mathlib has `ClassGroup.mk_eq_one_iff`, but not that; the lemma
supplying it is `FractionalIdeal.toPrincipalIdeal_eq_one_iff`. It goes in
`TauCeti/RingTheory/ClassGroup/Basic.lean`, next to `ClassGroup.mk_eq_one_iff_exists` and
`ClassGroup.mk_toPrincipalIdeal`, which that file already carries from the same source and at the
same `[IsDomain R]` strength. Its module docstring is updated in the same commit. Nothing is
removed: the declaration count there goes 5 → 6.

The source proves it through its own `spanSingleton_eq_one_iff`. That lemma is **not** ported: it
is the fractional-ideal wrapper of Mathlib's `Submodule.span_singleton_eq_one_iff`, so the proof
here coerces to submodules and calls Mathlib's version instead.

## Why the `rfl` proofs are parenthesised

No definition here is `@[expose]`: the interface is the membership, coefficient, coercion and
application lemmas, not the construction bodies. That has one visible consequence. Written plainly,
`coe_unitsNDivisibleToNDivisible := rfl` fails under the module system with

```
Not a definitional equality: the left-hand side
  ↑((unitsNDivisibleToNDivisible R K n) u)
is not definitionally equal to the right-hand side
  (toPrincipalIdeal R K) ↑u

Note: This theorem is exported from the current module. This requires that all definitions that
need to be unfolded to prove this theorem must be exposed.
```

Parenthesising the proof — `:= (rfl)`, `:= (Iff.rfl)` — keeps it elaborating where the definition
is still available, so the four characteristic lemmas compile with every body left unexposed. The
module docstring says so, since the parentheses otherwise look like noise a later cleanup would
remove.

## Which characteristic lemmas are `@[simp]`

`mem_nDivisible`, `mem_unitsNDivisible`, `fractionalIdealDivisor_nthRootFun`, `count_nthRootFun`,
`nthRootHom_apply`, `coe_unitsNDivisibleToNDivisible` and `nthRootClass_apply` are.

`nthRootClass_pow`, `nthRootClass_eq_one_iff` and `FractionalIdeal.toPrincipalIdeal_eq_one_iff`
deliberately are **not**, because tagging them is a `simpNF` violation: their left-hand sides are
already reduced by the simp lemmas above (and, for the last, by Mathlib's `toPrincipalIdeal_eq_iff`),
so they could never fire. `scripts/lint-env.sh` rejects them, verbatim:

```
[simpNF]
#check TauCeti.AlgebraicGeometry.WeilDivisor.nthRootClass_eq_one_iff /- Left-hand side simplifies from
  (TauCeti.AlgebraicGeometry.WeilDivisor.nthRootClass R K n) u = 1
to
  (ClassGroup.mk K) (TauCeti.AlgebraicGeometry.WeilDivisor.nthRootFun R K n ((toPrincipalIdeal R K) ↑u)) = 1
using
  simp only [*, nthRootClass_apply, @nthRootHom_apply, coe_unitsNDivisibleToNDivisible]
Try to change the left-hand side to the simplified term! -/

#check @FractionalIdeal.toPrincipalIdeal_eq_one_iff /- Left-hand side simplifies from
  (toPrincipalIdeal R K) u = 1
to
  ∃ a, (algebraMap R K) ↑a = ↑u
```

(the second because Mathlib's `toPrincipalIdeal_eq_iff` is already `simp` and hands the goal to
`spanSingleton_eq_one_iff`). Both carry a comment at the declaration saying so, so the exception is
not silent.

## Roadmap

`Roadmap: EllipticCurves`

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"selmerfinite"}-->

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 6 (Mordell–Weil). That layer's weak Mordell–Weil
argument needs the Selmer group `K(S, n)` to be finite — Mathlib defines `K(S, n)` in
`RingTheory/DedekindDomain/SelmerGroup.lean` and records its finiteness as a `TODO`, which the
roadmap assigns to this repository. The route is the fundamental exact sequence above, whose middle
map is built from the `n`-th root of an `n`-divisible fractional ideal; this PR supplies that
`n`-th root and the kernel of the induced class map, and nothing further. The two flanking
finiteness inputs are already on `main` (`RingTheory/DedekindDomain/SInteger/ClassGroup.lean`,
`SInteger/Unit.lean`).

**This PR does not discharge the roadmap target.** It stops at the class map and its kernel, and
claims no Selmer, exactness, torsion or finiteness result.

## Provenance

Adapted from Michael Stoll's elliptic-curves formalisation
(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache 2.0, by Michael Stoll) at the roadmap's
§Provenance pin `66889eada51a`.

| declaration | source |
|---|---|
| `nDivisible`, `mem_nDivisible`, `nthRootFun`, `count_nthRootFun`, `nthRootHom`, `nthRootHom_apply`, `nthRootHom_pow` | `EllipticCurves/Mathlib/FractionalIdeal.lean:302-345` |
| `exists_pow_eq_of_nDivisible` | ibid. `:349-352` (`exists_pow_eq`) |
| `unitsNDivisible`, `mem_unitsNDivisible`, `unitsNDivisibleToNDivisible`, `coe_unitsNDivisibleToNDivisible`, `nthRootClass`, `nthRootClass_apply`, `nthRootClass_eq_one_iff` | ibid. `:372-426` |
| `nthRootClass_pow`, `pow_mem_nDivisible`, `mem_nDivisible_iff_exists_pow`, `pow_mem_unitsNDivisible` | not in the source; new here. The source has only the forward direction `exists_pow_eq`; the introduction rules and the resulting characterisation of `nDivisible` as *the* subgroup of `n`-th powers are what a consumer forming `Kˣ/(Kˣ)ⁿ` needs, and `nthRootClass_pow` is what lets that consumer restrict the codomain to `Cl(R)[n]` |
| `FractionalIdeal.toPrincipalIdeal_eq_one_iff` | ibid. `:65-68`; the source's `spanSingleton_eq_one_iff` at `:50-61` is **not** ported, being Mathlib's `Submodule.span_singleton_eq_one_iff` wrapped |

Deviations:

| deviation | why |
|---|---|
| `nthRootFun` is built from `fractionalIdealDivisorAddEquiv.symm`, not from `ofFinsupp` | the source's `toFinsupp`/`ofFinsupp` pair duplicates the isomorphism this repository already has; see above |
| `units_eq_of_forall_count_eq` replaces the source's `count_injective`, and lives in `FractionalIdealDivisor/Basic.lean` rather than here | it is `fractionalIdealDivisor_injective` read coefficientwise, so no second proof of injectivity is introduced, and it is general divisor API with nothing to do with `n`-th roots — so it belongs beside the injectivity statement it restates |
| `fractionalIdealDivisor_nthRootFun` is new | the divisor-level statement is what the construction actually proves; `count_nthRootFun` follows from it in two lines, where the source proves the count statement directly from `count_ofFinsupp` |
| `exists_pow_eq` renamed `exists_pow_eq_of_nDivisible`, taking membership rather than the unfolded `∀ v` hypothesis | `exists_pow_eq` is too generic a name in a namespace that is not `FractionalIdeal`, and the hypothesis is `mem_nDivisible` by definition |
| `nthRootClass_eq_one_iff` drops the source's `hn : n ≠ 0`, and `spanSingleton_eq_one_iff` drops its `hx : x ≠ 0` | both statements are true in the excluded case, so the hypotheses were only artefacts of the proofs. For `n = 0`, membership forces every multiplicity of `(u)` to vanish, so `(u) = 1` and both sides hold; for `x = 0`, `spanSingleton R⁰ 0 = 0 ≠ 1` and no unit maps to `0`, so both sides fail |
| the declarations live in `TauCeti.AlgebraicGeometry.WeilDivisor`, not `FractionalIdeal` | they are stated and proved through the Weil-divisor dictionary and sit beside it |

## Absence

1. Untruncated full-name grep over `.lake/packages/mathlib/Mathlib` and `TauCeti/` for
   `nDivisible`, `NDivisible`, `nthRoot` applied to ideals, `nthRootHom`, `nthRootClass`,
   `unitsNDivisible`: no hits at all for the first two; `nthRoot` occurs only in
   `RingTheory/RootsOfUnity/*`, `RingTheory/IntegralDomain.lean` and
   `RingTheory/Polynomial/Cyclotomic/*` (roots of unity in a field, unrelated), and in
   `TauCeti/Analysis/Complex/BranchLogRoot.lean` and
   `TauCeti/RepresentationTheory/CharacterTable/Dixon/Prime.lean`.
2. **By subject, not by name** — and this is what caught a duplicate. Searching TauCeti for the
   *statement* "a class is trivial iff some `x : Kˣ` generates it" found
   `ClassGroup.mk_eq_one_iff_exists` and `ClassGroup.mk_toPrincipalIdeal` already present in
   `TauCeti/RingTheory/ClassGroup/Basic.lean`, adapted from the same source file. Porting the
   source's section verbatim would have added second copies of both; only the two lemmas that were
   genuinely missing are added.
3. Mathlib's `RingTheory/DedekindDomain/Factorization.lean` has the whole `count` API
   (`count_mul`, `count_pow`, `count_inv`, `count_one`, `count_finsuppProd`, …) but nothing that
   divides multiplicities or extracts an `n`-th root; `SelmerGroup.lean` defines `K(S, n)` and
   leaves its finiteness as a `TODO`.
4. Open `mathlib4` PRs searched by subject — "fractional ideal n-th root", "n-divisible fractional
   ideal", "Selmer group finite Dedekind", "class group n torsion fractional ideal" — return
   nothing.

## Gates

`lake build` exit 0 (7470 jobs, full project); `scripts/lint-env.sh` PASS, no new violations
(84 grandfathered, 0 ratchetable); `#print axioms` on all nineteen public declarations gives
`[propext, Classical.choice, Quot.sound]`; no line over 100 codepoints; no `sorry`, no
`set_option`, no debug commands. The declaration diff is +16 in the new `NthRoot.lean`, +1 in
`FractionalIdealDivisor/Basic.lean` (11 → 12) and +2 in `ClassGroup/Basic.lean` (5 → 7), with
nothing removed from either existing file.
