### PR TITLE
feat: identify the infinitesimal tangent adjoint

### DIFF
--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -72,7 +72,8 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • (-X)))
   have hF : ContDiff ℝ 2 F :=
-    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X (-X)
+    (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X (-X)).of_le
+      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
   have hdiag : HasDerivAt (fun t : ℝ => F (t, t))
       (fderiv ℝ F (0, 0) (1, 1)) 0 := by
     have hemb : HasDerivAt (fun t : ℝ => (t, t)) (1, 1) 0 :=
@@ -110,22 +111,45 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
     rw [sub_eq_add_neg, map_add, map_neg]
   simpa only [F] using hdiag.congr_deriv hder
 
+/-- Right-invariant differentiation of `f` by `X`, bundled as a smooth scalar function. -/
+private noncomputable def ContMDiffMap.rightGenerator
+    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) : C^∞⟮I, G; ℝ⟯ := by
+  exact ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
+    contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
+
+/-- Left-invariant differentiation of `f` by `X`, bundled as a smooth scalar function. -/
+private noncomputable def ContMDiffMap.leftGenerator
+    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) : C^∞⟮I, G; ℝ⟯ := by
+  exact ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
+    contMDiff_mvfderiv_mulInvariantVectorField X f⟩
+
 /-- The smooth scalar infinitesimal generator of conjugation by the exponential line of `X`. -/
 private noncomputable def ContMDiffMap.conjugationGenerator
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) : C^∞⟮I, G; ℝ⟯ := by
-  let RXf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
-      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
-  let LXf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
-      contMDiff_mvfderiv_mulInvariantVectorField X f⟩
   refine ⟨fun g => mvfderiv I f g
     (mulRightInvariantVectorField X g - mulInvariantVectorField X g), ?_⟩
-  have hsub := RXf.contMDiff.sub LXf.contMDiff
+  have hsub := (ContMDiffMap.rightGenerator (I := I) f X).contMDiff.sub
+    (ContMDiffMap.leftGenerator (I := I) f X).contMDiff
   apply hsub.congr
   intro g
   -- Coercing the bundled maps exposes their carrier functions; linearity supplies the equality.
   change mvfderiv I f g (_ - _) = mvfderiv I f g _ - mvfderiv I f g _
+  exact map_sub (mvfderiv I f g) _ _
+
+omit [FiniteDimensional ℝ E] in
+private theorem ContMDiffMap.conjugationGenerator_apply
+    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
+    ContMDiffMap.conjugationGenerator (I := I) f X g = mvfderiv I f g
+      (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := rfl
+
+omit [FiniteDimensional ℝ E] in
+private theorem ContMDiffMap.conjugationGenerator_coe
+    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) :
+    (ContMDiffMap.conjugationGenerator (I := I) f X : G → ℝ) =
+      (ContMDiffMap.rightGenerator (I := I) f X : G → ℝ) -
+        (ContMDiffMap.leftGenerator (I := I) f X : G → ℝ) := by
+  funext g
+  rw [ContMDiffMap.conjugationGenerator_apply]
   exact map_sub (mvfderiv I f g) _ _
 
 /-- Differentiating the scalar conjugation generator along a left-invariant direction gives the
@@ -135,21 +159,14 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
     mvfderiv I (ContMDiffMap.conjugationGenerator (I := I) f X) 1 Y =
       mvfderiv I f 1 ⁅X, Y⁆ := by
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-  let RXf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
-      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
-  let LXf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
-      contMDiff_mvfderiv_mulInvariantVectorField X f⟩
+  let RXf := ContMDiffMap.rightGenerator (I := I) f X
+  let LXf := ContMDiffMap.leftGenerator (I := I) f X
   let LYf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mvfderiv I f g (mulInvariantVectorField Y g),
       contMDiff_mvfderiv_mulInvariantVectorField Y f⟩
   let H := ContMDiffMap.conjugationGenerator (I := I) f X
-  have hH : (H : G → ℝ) = (RXf : G → ℝ) - (LXf : G → ℝ) := by
-    funext g
-    -- Coercing `H`, `RXf`, and `LXf` exposes their carrier functions before applying linearity.
-    change mvfderiv I f g (_ - _) = mvfderiv I f g _ - mvfderiv I f g _
-    rw [map_sub]
+  have hH : (H : G → ℝ) = (RXf : G → ℝ) - (LXf : G → ℝ) :=
+    ContMDiffMap.conjugationGenerator_coe f X
   -- Unfold only the private bundle `H`; its underlying function is the displayed generator.
   change mvfderiv I H 1 Y = _
   rw [hH]
@@ -168,7 +185,8 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
     (V := mulInvariantVectorField X)
     (W := mulInvariantVectorField Y)
     (x := (1 : G))
-    (f.contMDiff.contMDiffAt.of_le two_le_infinite_smoothness)
+    (f.contMDiff.contMDiffAt.of_le
+      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out))
     (by simp)
     ((contMDiff_mulInvariantVectorField_infty X).mdifferentiable
       (by simp)).mdifferentiableAt
@@ -253,7 +271,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
       mulInvariantExp (I := I) (G := G) (p.1 • (-X)))
   have hF : ContDiff ℝ 2 F :=
     (ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp f X Y).of_le
-      two_le_infinite_smoothness
+      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
   -- Varying the second parameter conjugates the `Y`-line by `γX t`, so this spatial partial
   -- evaluates the tangent adjoint orbit against the chosen test function.
   have hspace (t : ℝ) : spatialFDeriv F 0 t 1 = q (A t) := by
@@ -280,8 +298,8 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
         (fun s : ℝ => f (mulInvariantExp (I := I) (G := G)
           (s • tangentAd (I := I) (γX t) Y))) (q (A t)) 0 := by
       apply hdirection.congr_deriv
-      -- The tangent Lie algebra and the model vector space are definitionally the same here.
-      with_unfolding_all rfl
+      change mfderiv I 𝓘(ℝ, ℝ) (f : G → ℝ) 1 _ = mvfderiv I (f : G → ℝ) 1 _
+      exact (mvfderiv_apply_eq_mfderiv_apply (I := I) (f := (f : G → ℝ)) _ _).symm
     exact hpartial.unique hdirection'
   -- Varying the first parameter is the infinitesimal conjugation generator `R_X - L_X` along
   -- the `Y`-line.
@@ -323,16 +341,11 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
   have hleftDeriv : deriv (fun t => q (A t)) 0 = q (deriv A 0) := by
     simpa only [q] using hq.deriv
   let H := ContMDiffMap.conjugationGenerator (I := I) f X
-  have hH (g : G) : H g = mvfderiv I f g
-      (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := by
-    -- Coercing the private bundled map `H` exposes exactly its defining carrier function.
-    change mvfderiv I f g (_ - _) = _
-    rfl
   have hHmf := H.contMDiff.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
   have hHcurve := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_zero hHmf Y
-  -- The exponential-line chain rule is expressed through the same canonical `mvfderiv` map;
-  -- unfolding identifies its model-space continuous linear map with that public notation.
-  with_unfolding_all change HasDerivAt (fun s => H (γY s)) (mvfderiv I H 1 Y) 0 at hHcurve
+  have hHcurve' : HasDerivAt (fun s => H (γY s)) (mvfderiv I H 1 Y) 0 := by
+    apply hHcurve.congr_deriv
+    exact (mvfderiv_apply_eq_mfderiv_apply (I := I) (f := (H : G → ℝ)) _ _).symm
   have hrightDeriv : deriv (fun s =>
       mvfderiv I f (γY s)
         (mulRightInvariantVectorField X (γY s) -
@@ -342,13 +355,13 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
         (mulRightInvariantVectorField X (γY s) -
           mulInvariantVectorField X (γY s))) = fun s => H (γY s) by
       funext s
-      exact (hH (γY s)).symm]
-    rw [hHcurve.deriv]
+      exact (ContMDiffMap.conjugationGenerator_apply f X (γY s)).symm]
+    rw [hHcurve'.deriv]
     -- The left side is the bundled scalar conjugation generator differentiated along `Y`.
     have hbracket := mvfderiv_conjugationGenerator_eq_bracket f X Y
     have hqBracket : q bracketModel = mvfderiv I f 1 bracketTangent := by
-      -- Both sides evaluate the same model tangent vector against the pointed smooth function.
-      with_unfolding_all rfl
+      dsimp only [q, bracketModel, bracketTangent]
+      rfl
     rw [hqBracket]
     exact hbracket
   rw [hleftDeriv, hrightDeriv] at hmixed
@@ -377,8 +390,7 @@ theorem mvfderiv_tangentAd_apply_one (X Y : GroupLieAlgebra I G) :
       (fun t : ℝ => T (mulInvariantExp (I := I) (G := G) (t • X)))
       (mvfderiv I T 1 X) 0 := by
     apply hchainRaw.congr_deriv
-    -- The chain-rule derivative and `mvfderiv` use the same canonical tangent model.
-    with_unfolding_all rfl
+    exact (mvfderiv_apply_eq_mfderiv_apply (I := I) (f := T) _ _).symm
   have hpath := hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
     (I := I) (G := G) X Y
   have hpathModel : HasDerivAt

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -48,14 +48,8 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
   [FiniteDimensional ℝ E] [LieGroup I ∞ G]
 
-local instance lieGroupMinSmoothnessThreeInfinitesimalAdjoint :
-    LieGroup I (minSmoothness ℝ 3) G :=
-  LieGroup.of_le (I := I) (G := G) (m := minSmoothness ℝ 3) (n := ∞)
-    (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
-
-local instance lieGroupBoundarylessManifoldInfinitesimalAdjoint : BoundarylessManifold I G where
-  isInteriorPoint' g :=
-    ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) g
+attribute [local instance] LieGroup.minSmoothnessThree
+attribute [local instance] ContMDiffMul.boundarylessManifold
 
 /-- A smooth scalar function on a conjugation orbit is smooth in the two exponential
 parameters. -/

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -6,9 +6,9 @@ module
 
 public import TauCeti.Geometry.Lie.Adjoint.Smooth
 public import TauCeti.Geometry.Lie.Adjoint.Exponential
-public import TauCeti.Geometry.Lie.InvariantVectorField.Commutation
 import TauCeti.Analysis.Calculus.ParametricFDeriv
 import TauCeti.Geometry.Lie.Exponential.Derivative.Basic
+import TauCeti.Geometry.Lie.InvariantVectorField.Commutation
 import TauCeti.Geometry.Manifold.VectorField.Regularity
 
 /-!

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -56,10 +56,6 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
 
-private theorem two_le_infinite_smoothness_adjoint :
-    ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) :=
-  ENat.natCast_le_of_coe_top_le_withTop le_rfl 2
-
 /-- The infinitesimal generator of conjugation acts on scalar functions by the difference of
 right- and left-invariant differentiation. -/
 private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
@@ -75,59 +71,31 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
   let F : ℝ × ℝ → ℝ := fun p =>
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • (-X)))
-  have hF : ContDiff ℝ ∞ F :=
-    (f.contMDiff.comp
-      (contMDiff_mulInvariantExp_smul_mul_mul_mulInvariantExp_smul g X (-X))).contDiff
+  have hF : ContDiff ℝ 2 F :=
+    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X (-X)
   have hdiag : HasDerivAt (fun t : ℝ => F (t, t))
       (fderiv ℝ F (0, 0) (1, 1)) 0 := by
     have hemb : HasDerivAt (fun t : ℝ => (t, t)) (1, 1) 0 :=
       (hasDerivAt_id (𝕜 := ℝ) 0).prodMk (hasDerivAt_id (𝕜 := ℝ) 0)
     exact (hF.differentiable (by simp) (0, 0)).hasFDerivAt.comp_hasDerivAt
       (f := fun t : ℝ => (t, t)) 0 hemb
-  have hfAt := f.contMDiff.mdifferentiable (by simp) g |>.hasMFDerivAt
-  have hright := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_mul_zero hfAt X
-  have hleftNeg := HasMFDerivAt.hasDerivAt_comp_mul_mulInvariantExp_smul_zero hfAt (-X)
   have ht : fderiv ℝ F (0, 0) (1, 0) =
       mvfderiv I f g (mulRightInvariantVectorField X g) := by
-    have hpartial : HasDerivAt (fun t : ℝ => F (t, 0))
-        (fderiv ℝ F (0, 0) (1, 0)) 0 := by
-      simpa only [timeFDeriv_apply] using
-        hasDerivAt_parameterCurve (hF.differentiable (by simp) (0, 0))
-    have hright' : HasDerivAt (fun t : ℝ => F (t, 0))
-        (mvfderiv I f g (mulRightInvariantVectorField X g)) 0 := by
-      have hfun : (fun t : ℝ => F (t, 0)) =
-          fun t => f (mulInvariantExp (I := I) (G := G) (t • X) * g) := by
-        funext t
-        simp only [F, zero_smul, mulInvariantExp_zero, mul_one]
-      rw [hfun]
-      apply hright.congr_deriv
-      -- `mvfderiv` and the derivative supplied by `HasMFDerivAt` share the canonical real model.
-      with_unfolding_all rfl
-    exact hpartial.unique hright'
+    have h := timeFDeriv_mulInvariantExp_mul_mulInvariantExp f g X (-X) 0
+    dsimp only at h
+    rw [zero_smul, mulInvariantExp_zero, mul_one] at h
+    simpa only [F, timeFDeriv_apply] using h
   have hs : fderiv ℝ F (0, 0) (0, 1) =
       mvfderiv I f g (-mulInvariantVectorField X g) := by
-    have hFdiff : DifferentiableAt ℝ F (0, 0) := hF.differentiable (by simp) (0, 0)
-    have hslice : DifferentiableAt ℝ (fun t => F (0, t)) 0 :=
-      hFdiff.comp 0 ((differentiableAt_const 0).prodMk differentiableAt_id)
-    have hpartial := hslice.hasDerivAt
-    rw [← fderiv_apply_one_eq_deriv, fderiv_timeSlice hFdiff] at hpartial
-    have hleftNeg' : HasDerivAt (fun t : ℝ => F (0, t))
-        (mvfderiv I f g (-mulInvariantVectorField X g)) 0 := by
-      have hfun : (fun t : ℝ => F (0, t)) =
-          fun t => f (g * mulInvariantExp (I := I) (G := G) (t • (-X))) := by
-        funext t
-        simp only [F, zero_smul, mulInvariantExp_zero, one_mul]
-      have hvec : mulInvariantVectorField (-X) g = -mulInvariantVectorField X g := by
-        rw [show -X = (-1 : ℝ) • X by simp]
-        exact congrFun (mulInvariantVectorField_smul (I := I) (G := G) (-1) X) g |>.trans
-          (by simp)
-      rw [hfun]
-      rw [hvec] at hleftNeg
-      apply hleftNeg.congr_deriv
-      -- `mvfderiv` and the derivative supplied by `HasMFDerivAt` share the canonical real model.
-      with_unfolding_all rfl
-    simpa only [spatialFDeriv_apply, zero_smul, one_smul] using
-      hpartial.unique hleftNeg'
+    have hvec : mulInvariantVectorField (-X) g = -mulInvariantVectorField X g := by
+      -- Rewrite negation as scalar multiplication to use linearity of the invariant vector field.
+      rw [show -X = (-1 : ℝ) • X by simp]
+      exact congrFun (mulInvariantVectorField_smul (I := I) (G := G) (-1) X) g |>.trans
+        (by simp)
+    have h := spatialFDeriv_mulInvariantExp_mul_mulInvariantExp f g X (-X) 0
+    dsimp only at h
+    rw [zero_smul, mulInvariantExp_zero, one_mul, hvec] at h
+    simpa only [F, spatialFDeriv_apply] using h
   have hder : fderiv ℝ F (0, 0) (1, 1) =
       mvfderiv I f g
         (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := by
@@ -156,6 +124,7 @@ private noncomputable def ContMDiffMap.conjugationGenerator
   have hsub := RXf.contMDiff.sub LXf.contMDiff
   apply hsub.congr
   intro g
+  -- Coercing the bundled maps exposes their carrier functions; linearity supplies the equality.
   change mvfderiv I f g (_ - _) = mvfderiv I f g _ - mvfderiv I f g _
   exact map_sub (mvfderiv I f g) _ _
 
@@ -178,6 +147,7 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
   let H := ContMDiffMap.conjugationGenerator (I := I) f X
   have hH : (H : G → ℝ) = (RXf : G → ℝ) - (LXf : G → ℝ) := by
     funext g
+    -- Coercing `H`, `RXf`, and `LXf` exposes their carrier functions before applying linearity.
     change mvfderiv I f g (_ - _) = mvfderiv I f g _ - mvfderiv I f g _
     rw [map_sub]
   -- Unfold only the private bundle `H`; its underlying function is the displayed generator.
@@ -198,7 +168,7 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
     (V := mulInvariantVectorField X)
     (W := mulInvariantVectorField Y)
     (x := (1 : G))
-    (f.contMDiff.contMDiffAt.of_le two_le_infinite_smoothness_adjoint)
+    (f.contMDiff.contMDiffAt.of_le two_le_infinite_smoothness)
     (by simp)
     ((contMDiff_mulInvariantVectorField_infty X).mdifferentiable
       (by simp)).mdifferentiableAt
@@ -283,15 +253,12 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
       mulInvariantExp (I := I) (G := G) (p.1 • (-X)))
   have hF : ContDiff ℝ 2 F :=
     (ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp f X Y).of_le
-      two_le_infinite_smoothness_adjoint
+      two_le_infinite_smoothness
   -- Varying the second parameter conjugates the `Y`-line by `γX t`, so this spatial partial
   -- evaluates the tangent adjoint orbit against the chosen test function.
   have hspace (t : ℝ) : spatialFDeriv F 0 t 1 = q (A t) := by
     have hFdiff : DifferentiableAt ℝ F (t, 0) := hF.differentiable (by norm_num) (t, 0)
-    have hslice : DifferentiableAt ℝ (fun s => F (t, s)) 0 :=
-      hFdiff.comp 0 ((differentiableAt_const (c := t)).prodMk differentiableAt_id)
-    have hpartial := hslice.hasDerivAt
-    rw [← fderiv_apply_one_eq_deriv, fderiv_timeSlice hFdiff] at hpartial
+    have hpartial := (hasFDerivAt_timeSlice hFdiff).hasDerivAt
     have hfOne := f.contMDiff.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
     have hdirection := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_zero hfOne
       (tangentAd (I := I) (γX t) Y)
@@ -299,6 +266,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
         fun s => f (mulInvariantExp (I := I) (G := G)
           (s • tangentAd (I := I) (γX t) Y)) := by
       funext s
+      -- Scalar negation in the Lie algebra matches inversion of the exponential curve.
       have hinv : mulInvariantExp (I := I) (G := G) (t • (-X)) = (γX t)⁻¹ := by
         rw [show t • (-X) = -(t • X) by module, mulInvariantExp_neg]
       simp only [F]
@@ -357,6 +325,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
   let H := ContMDiffMap.conjugationGenerator (I := I) f X
   have hH (g : G) : H g = mvfderiv I f g
       (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := by
+    -- Coercing the private bundled map `H` exposes exactly its defining carrier function.
     change mvfderiv I f g (_ - _) = _
     rfl
   have hHmf := H.contMDiff.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -69,12 +69,10 @@ private theorem ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters
   dsimp only
   have hX : ContMDiff 𝓘(ℝ, ℝ) I ∞
       (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • X)) := by
-    simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
-      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) X
+    exact contMDiff_mulInvariantExp_smul (I := I) (G := G) X
   have hnegX : ContMDiff 𝓘(ℝ, ℝ) I ∞
       (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • (-X))) := by
-    simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
-      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) (-X)
+    exact contMDiff_mulInvariantExp_smul (I := I) (G := G) (-X)
   have hMprod : ContMDiff (𝓘(ℝ, ℝ).prod 𝓘(ℝ, ℝ)) I ∞
       (fun p : ℝ × ℝ =>
         mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
@@ -178,8 +176,7 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   let RXf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
-      ContMDiff.contMDiff_mvfderiv_apply f.contMDiff
-        (contMDiff_mulRightInvariantVectorField_infty X) (by simp)⟩
+      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
   let LXf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
       contMDiff_mvfderiv_mulInvariantVectorField X f⟩
@@ -236,16 +233,13 @@ private theorem ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp
   dsimp only
   have hX : ContMDiff 𝓘(ℝ, ℝ) I ∞
       (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • X)) := by
-    simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
-      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) X
+    exact contMDiff_mulInvariantExp_smul (I := I) (G := G) X
   have hY : ContMDiff 𝓘(ℝ, ℝ) I ∞
       (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • Y)) := by
-    simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
-      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) Y
+    exact contMDiff_mulInvariantExp_smul (I := I) (G := G) Y
   have hnegX : ContMDiff 𝓘(ℝ, ℝ) I ∞
       (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • (-X))) := by
-    simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
-      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) (-X)
+    exact contMDiff_mulInvariantExp_smul (I := I) (G := G) (-X)
   have hMprod : ContMDiff (𝓘(ℝ, ℝ).prod 𝓘(ℝ, ℝ)) I ∞
       (fun p : ℝ × ℝ =>
         mulInvariantExp (I := I) (G := G) (p.1 • X) *
@@ -276,8 +270,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
   let γY : ℝ → G := fun t => mulInvariantExp (I := I) (G := G) (t • Y)
   let A : ℝ → E := fun t => @id E (tangentAd (I := I) (γX t) Y)
   have hγX : ContMDiff 𝓘(ℝ, ℝ) I ∞ γX := by
-    simpa only [γX, mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
-      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) X
+    simpa only [γX] using contMDiff_mulInvariantExp_smul (I := I) (G := G) X
   have hA : ContDiff ℝ ∞ A := by
     have hpair : ContMDiff 𝓘(ℝ, ℝ) (I.prod 𝓘(ℝ, E)) ∞
         (fun t => (γX t, @id E Y)) := hγX.prodMk contMDiff_const
@@ -376,8 +369,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     simpa only [q] using hq.deriv
   let RXf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
-      ContMDiff.contMDiff_mvfderiv_apply f.contMDiff
-        (contMDiff_mulRightInvariantVectorField_infty X) (by simp)⟩
+      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
   let LXf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
       contMDiff_mvfderiv_mulInvariantVectorField X f⟩
@@ -431,23 +423,13 @@ theorem mvfderiv_tangentAd_apply (X Y : GroupLieAlgebra I G) :
     have hpair : ContMDiff I (I.prod 𝓘(ℝ, E)) ∞
         (fun g : G => (g, @id E Y)) := contMDiff_id.prodMk contMDiff_const
     exact (contMDiff_tangentAd_apply (I := I) (G := G)).comp hpair
-  have hX := hasMFDerivAt_mulInvariantExp_smul (I := I) (G := G) X
-  have hzero : mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) = 1 := by
-    rw [zero_smul, mulInvariantExp_zero]
   have hTmf := hT.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
-  rw [← hzero] at hTmf
-  have hcomp := hTmf.comp 0 hX
-  rw [hzero] at hcomp
-  have hcompF : HasFDerivAt
-      (T ∘ fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • X))
-      ((mvfderiv I T 1).comp ((1 : ℝ →L[ℝ] ℝ).smulRight X)) 0 := by
-    with_unfolding_all exact hcomp.hasFDerivAt
+  have hchainRaw := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul hTmf X
   have hchain : HasDerivAt
       (fun t : ℝ => T (mulInvariantExp (I := I) (G := G) (t • X)))
       (mvfderiv I T 1 X) 0 := by
-    apply hcompF.hasDerivAt.congr_deriv
-    simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smulRight_apply,
-      one_apply_eq_self, one_smul]
+    apply hchainRaw.congr_deriv
+    with_unfolding_all rfl
   have hpath := hasDerivAt_tangentAd_mulInvariantExp_smul_apply (I := I) (G := G) X Y
   have hpathModel : HasDerivAt
       (fun t : ℝ => T (mulInvariantExp (I := I) (G := G) (t • X)))

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -1,0 +1,417 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Lie.Adjoint.Smooth
+public import TauCeti.Geometry.Lie.Adjoint.Exponential
+public import TauCeti.Geometry.Lie.InvariantVectorField.Commutation
+
+/-!
+# The infinitesimal adjoint action
+
+This file identifies the derivative of the group adjoint representation at the identity with
+Mathlib's Lie-algebra adjoint map.
+
+This advances Deliverable A, Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The infinitesimal adjoint".
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Lie
+
+open Bundle Manifold
+open scoped ContDiff Manifold
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
+
+local instance lieGroupMinSmoothnessThreeInfinitesimalAdjoint :
+    LieGroup I (minSmoothness ℝ 3) G :=
+  LieGroup.of_le (I := I) (G := G) (m := minSmoothness ℝ 3) (n := ∞)
+    (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
+
+local instance lieGroupBoundarylessManifoldInfinitesimalAdjoint : BoundarylessManifold I G where
+  isInteriorPoint' g :=
+    ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) g
+
+/-- A smooth scalar function on a conjugation orbit is smooth in the two exponential
+parameters. -/
+theorem ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters
+    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
+    ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
+      f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
+        mulInvariantExp (I := I) (G := G) (p.2 • (-X)))) := by
+  have hX : ContMDiff 𝓘(ℝ, ℝ) I ∞
+      (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • X)) := by
+    simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
+      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) X
+  have hnegX : ContMDiff 𝓘(ℝ, ℝ) I ∞
+      (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • (-X))) := by
+    simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
+      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) (-X)
+  have hMprod : ContMDiff (𝓘(ℝ, ℝ).prod 𝓘(ℝ, ℝ)) I ∞
+      (fun p : ℝ × ℝ =>
+        mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
+          mulInvariantExp (I := I) (G := G) (p.2 • (-X))) :=
+    ((hX.comp contMDiff_fst).mul contMDiff_const).mul (hnegX.comp contMDiff_snd)
+  have hM : ContMDiff 𝓘(ℝ, ℝ × ℝ) I ∞
+      (fun p : ℝ × ℝ =>
+        mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
+          mulInvariantExp (I := I) (G := G) (p.2 • (-X))) := by
+    rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
+    exact hMprod
+  exact (f.contMDiff.comp hM).contDiff
+
+/-- The infinitesimal generator of conjugation acts on scalar functions by the difference of
+right- and left-invariant differentiation. -/
+theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
+    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
+    HasDerivAt
+      (fun t : ℝ => f (mulInvariantExp (I := I) (G := G) (t • X) * g *
+        mulInvariantExp (I := I) (G := G) (t • (-X))))
+      (mvfderiv I f g
+        (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) 0 := by
+  let F : ℝ × ℝ → ℝ := fun p =>
+    f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
+      mulInvariantExp (I := I) (G := G) (p.2 • (-X)))
+  have hF : ContDiff ℝ ∞ F :=
+    ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters f X g
+  have hdiag : HasDerivAt (fun t : ℝ => F (t, t))
+      (fderiv ℝ F (0, 0) (1, 1)) 0 := by
+    have hemb : HasDerivAt (fun t : ℝ => (t, t)) (1, 1) 0 :=
+      (hasDerivAt_id (𝕜 := ℝ) 0).prodMk (hasDerivAt_id (𝕜 := ℝ) 0)
+    exact (hF.differentiable (by simp) (0, 0)).hasFDerivAt.comp_hasDerivAt
+      (f := fun t : ℝ => (t, t)) 0 hemb
+  have hfAt := f.contMDiff.mdifferentiable (by simp) g |>.hasMFDerivAt
+  have hright := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_mul hfAt X
+  have hleftNeg := HasMFDerivAt.hasDerivAt_comp_mul_mulInvariantExp_smul hfAt (-X)
+  have ht : fderiv ℝ F (0, 0) (1, 0) =
+      mvfderiv I f g (mulRightInvariantVectorField X g) := by
+    have hemb : HasDerivAt (fun t : ℝ => (t, (0 : ℝ))) (1, 0) 0 :=
+      (hasDerivAt_id (𝕜 := ℝ) 0).prodMk (hasDerivAt_const (x := (0 : ℝ)) (0 : ℝ))
+    have hpartial :=
+      (hF.differentiable (by simp) (0, 0)).hasFDerivAt.comp_hasDerivAt
+        (f := fun t : ℝ => (t, (0 : ℝ))) 0 hemb
+    have hright' : HasDerivAt (fun t : ℝ => F (t, 0))
+        (mvfderiv I f g (mulRightInvariantVectorField X g)) 0 := by
+      have hfun : (fun t : ℝ => F (t, 0)) =
+          fun t => f (mulInvariantExp (I := I) (G := G) (t • X) * g) := by
+        funext t
+        simp only [F, zero_smul, mulInvariantExp_zero, mul_one]
+      rw [hfun]
+      apply hright.congr_deriv
+      with_unfolding_all rfl
+    exact hpartial.unique hright'
+  have hs : fderiv ℝ F (0, 0) (0, 1) =
+      mvfderiv I f g (-mulInvariantVectorField X g) := by
+    have hemb : HasDerivAt (fun t : ℝ => ((0 : ℝ), t)) (0, 1) 0 :=
+      (hasDerivAt_const (x := (0 : ℝ)) (0 : ℝ)).prodMk
+        (hasDerivAt_id (𝕜 := ℝ) 0)
+    have hpartial :=
+      (hF.differentiable (by simp) (0, 0)).hasFDerivAt.comp_hasDerivAt
+        (f := fun t : ℝ => ((0 : ℝ), t)) 0 hemb
+    have hleftNeg' : HasDerivAt (fun t : ℝ => F (0, t))
+        (mvfderiv I f g (-mulInvariantVectorField X g)) 0 := by
+      have hfun : (fun t : ℝ => F (0, t)) =
+          fun t => f (g * mulInvariantExp (I := I) (G := G) (t • (-X))) := by
+        funext t
+        simp only [F, zero_smul, mulInvariantExp_zero, one_mul]
+      have hvec : mulInvariantVectorField (-X) g = -mulInvariantVectorField X g := by
+        simp [mulInvariantVectorField]
+        rfl
+      rw [hfun]
+      rw [hvec] at hleftNeg
+      apply hleftNeg.congr_deriv
+      with_unfolding_all rfl
+    exact hpartial.unique hleftNeg'
+  have hder : fderiv ℝ F (0, 0) (1, 1) =
+      mvfderiv I f g
+        (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := by
+    have hsplit : fderiv ℝ F (0, 0) (1, 1) =
+        fderiv ℝ F (0, 0) (1, 0) + fderiv ℝ F (0, 0) (0, 1) := by
+      calc
+        fderiv ℝ F (0, 0) (1, 1) =
+            fderiv ℝ F (0, 0) ((1, 0) + (0, 1)) :=
+          congrArg (fderiv ℝ F (0, 0)) (by norm_num)
+        _ = _ := map_add _ _ _
+    rw [hsplit, ht, hs]
+    rw [sub_eq_add_neg, map_add, map_neg]
+  simpa only [F] using hdiag.congr_deriv hder
+
+omit [T2Space G] in
+/-- Differentiating the scalar conjugation generator along a left-invariant direction gives the
+Lie bracket. -/
+theorem mfderiv_conjugationGenerator_eq_bracket
+    (f : C^∞⟮I, G; ℝ⟯) (X Y : GroupLieAlgebra I G) :
+    mvfderiv I
+        (fun g => mfderiv I 𝓘(ℝ, ℝ) f g
+          (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) 1 Y =
+      mvfderiv I f 1 ⁅X, Y⁆ := by
+  let RXf : C^∞⟮I, G; ℝ⟯ :=
+    ⟨fun g => mfderiv I 𝓘(ℝ, ℝ) f g (mulRightInvariantVectorField X g),
+      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
+  let LXf : C^∞⟮I, G; ℝ⟯ :=
+    ⟨fun g => mfderiv I 𝓘(ℝ, ℝ) f g (mulInvariantVectorField X g),
+      contMDiff_mvfderiv_mulInvariantVectorField X f⟩
+  let LYf : C^∞⟮I, G; ℝ⟯ :=
+    ⟨fun g => mfderiv I 𝓘(ℝ, ℝ) f g (mulInvariantVectorField Y g),
+      contMDiff_mvfderiv_mulInvariantVectorField Y f⟩
+  have hgenerator :
+      (fun g => mfderiv I 𝓘(ℝ, ℝ) f g
+        (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) =
+        (RXf : G → ℝ) - (LXf : G → ℝ) := by
+    funext g
+    change mfderiv I 𝓘(ℝ, ℝ) f g (_ - _) = _ - _
+    rw [map_sub]
+    rfl
+  rw [hgenerator]
+  rw [mvfderiv_sub
+    (RXf.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
+    (LXf.contMDiff.mdifferentiable (by simp)).mdifferentiableAt]
+  simp only [sub_apply]
+  have hcomm := mvfderiv_mulInvariant_mulRightInvariant_commute f X Y
+  change mvfderiv I LYf 1 X = mvfderiv I RXf 1 Y at hcomm
+  rw [← hcomm]
+  have hbridge := mvfderiv_mlieBracket
+    (f := (f : G → ℝ))
+    (V := mulInvariantVectorField X)
+    (W := mulInvariantVectorField Y)
+    (x := (1 : G))
+    (f.contMDiff.contMDiffAt.of_le (show
+      ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) from
+        WithTop.coe_le_coe.mpr le_top))
+    (by simp)
+    ((contMDiff_mulInvariantVectorField_infty X).mdifferentiable
+      (by simp)).mdifferentiableAt
+    ((contMDiff_mulInvariantVectorField_infty Y).mdifferentiable
+      (by simp)).mdifferentiableAt
+  rw [mulInvariantVectorField_one, mulInvariantVectorField_one] at hbridge
+  change mvfderiv I f 1
+      (VectorField.mlieBracket I (mulInvariantVectorField X) (mulInvariantVectorField Y) 1) =
+    mvfderiv I LYf 1 X - mvfderiv I LXf 1 Y at hbridge
+  rw [← hbridge]
+  congr 1
+
+/-- A smooth scalar function evaluated on a conjugated exponential line is jointly smooth in the
+conjugating and conjugated parameters. -/
+theorem ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp
+    (f : C^∞⟮I, G; ℝ⟯) (X Y : GroupLieAlgebra I G) :
+    ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
+      f (mulInvariantExp (I := I) (G := G) (p.1 • X) *
+        mulInvariantExp (I := I) (G := G) (p.2 • Y) *
+        mulInvariantExp (I := I) (G := G) (p.1 • (-X)))) := by
+  have hX : ContMDiff 𝓘(ℝ, ℝ) I ∞
+      (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • X)) := by
+    simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
+      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) X
+  have hY : ContMDiff 𝓘(ℝ, ℝ) I ∞
+      (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • Y)) := by
+    simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
+      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) Y
+  have hnegX : ContMDiff 𝓘(ℝ, ℝ) I ∞
+      (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • (-X))) := by
+    simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
+      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) (-X)
+  have hMprod : ContMDiff (𝓘(ℝ, ℝ).prod 𝓘(ℝ, ℝ)) I ∞
+      (fun p : ℝ × ℝ =>
+        mulInvariantExp (I := I) (G := G) (p.1 • X) *
+          mulInvariantExp (I := I) (G := G) (p.2 • Y) *
+          mulInvariantExp (I := I) (G := G) (p.1 • (-X))) :=
+    ((hX.comp contMDiff_fst).mul (hY.comp contMDiff_snd)).mul
+      (hnegX.comp contMDiff_fst)
+  have hM : ContMDiff 𝓘(ℝ, ℝ × ℝ) I ∞
+      (fun p : ℝ × ℝ =>
+        mulInvariantExp (I := I) (G := G) (p.1 • X) *
+          mulInvariantExp (I := I) (G := G) (p.2 • Y) *
+          mulInvariantExp (I := I) (G := G) (p.1 • (-X))) := by
+    rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
+    exact hMprod
+  exact (f.contMDiff.comp hM).contDiff
+
+/-- Along an exponential line, the derivative of the tangent adjoint action is the Lie bracket. -/
+theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
+    (X Y : GroupLieAlgebra I G) :
+    HasDerivAt
+      (fun t : ℝ => @id E (tangentAd (I := I)
+        (mulInvariantExp (I := I) (G := G) (t • X)) Y))
+      (@id E (LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y)) 0 := by
+  let γX : ℝ → G := fun t => mulInvariantExp (I := I) (G := G) (t • X)
+  let γY : ℝ → G := fun t => mulInvariantExp (I := I) (G := G) (t • Y)
+  let A : ℝ → E := fun t => @id E (tangentAd (I := I) (γX t) Y)
+  have hγX : ContMDiff 𝓘(ℝ, ℝ) I ∞ γX := by
+    simpa only [γX, mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
+      contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) X
+  have hA : ContDiff ℝ ∞ A := by
+    have hpair : ContMDiff 𝓘(ℝ, ℝ) (I.prod 𝓘(ℝ, E)) ∞
+        (fun t => (γX t, @id E Y)) := hγX.prodMk contMDiff_const
+    exact (contMDiff_tangentAd_apply (I := I) (G := G)).comp hpair |>.contDiff
+  have hAder : HasDerivAt A (deriv A 0) 0 :=
+    (hA.differentiable (by simp) 0).hasDerivAt
+  let bracketTangent : GroupLieAlgebra I G :=
+    LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y
+  let bracketModel : E := @id E bracketTangent
+  apply hAder.congr_deriv
+  with_unfolding_all apply tangentToPointDerivation_injective (I := I) (1 : G)
+  ext f
+  let q : E →L[ℝ] ℝ := by
+    with_unfolding_all exact mvfderiv I f 1
+  let F : ℝ × ℝ → ℝ := fun p =>
+    f (γX p.1 * γY p.2 *
+      mulInvariantExp (I := I) (G := G) (p.1 • (-X)))
+  have hF : ContDiff ℝ 2 F :=
+    (ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp f X Y).of_le
+      (show ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) from
+        WithTop.coe_le_coe.mpr le_top)
+  have hspace (t : ℝ) : spatialFDeriv F 0 t 1 = q (A t) := by
+    have hemb : HasDerivAt (fun s : ℝ => (t, s)) (0, 1) 0 :=
+      (hasDerivAt_const (x := 0) t).prodMk (hasDerivAt_id (𝕜 := ℝ) 0)
+    have hpartialRaw := (hF.differentiable (by norm_num) (t, 0)).hasFDerivAt
+      |>.comp_hasDerivAt (f := fun s : ℝ => (t, s)) 0 hemb
+    have hpartial : HasDerivAt (fun s => F (t, s)) (spatialFDeriv F 0 t 1) 0 := by
+      simpa only [Function.comp_def, spatialFDeriv_apply, zero_smul, one_smul] using hpartialRaw
+    have hfOne := f.contMDiff.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
+    have hdirection := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul hfOne
+      (tangentAd (I := I) (γX t) Y)
+    have hcurve : (fun s : ℝ => F (t, s)) =
+        fun s => f (mulInvariantExp (I := I) (G := G)
+          (s • tangentAd (I := I) (γX t) Y)) := by
+      funext s
+      have hinv : mulInvariantExp (I := I) (G := G) (t • (-X)) = (γX t)⁻¹ := by
+        rw [show t • (-X) = -(t • X) by module, mulInvariantExp_neg]
+      simp only [F]
+      rw [hinv, conj_mulInvariantExp]
+      change f (mulInvariantExp (I := I) (G := G)
+        (tangentAd (I := I) (γX t) (s • Y))) = _
+      rw [map_smul]
+    rw [hcurve] at hpartial
+    have hdirection' : HasDerivAt
+        (fun s : ℝ => f (mulInvariantExp (I := I) (G := G)
+          (s • tangentAd (I := I) (γX t) Y))) (q (A t)) 0 := by
+      apply hdirection.congr_deriv
+      with_unfolding_all rfl
+    exact hpartial.unique hdirection'
+  have htime (s : ℝ) : timeFDeriv F 0 s =
+      mvfderiv I f (γY s)
+        (mulRightInvariantVectorField X (γY s) - mulInvariantVectorField X (γY s)) := by
+    have hemb : HasDerivAt (fun t : ℝ => (t, s)) (1, 0) 0 :=
+      (hasDerivAt_id (𝕜 := ℝ) 0).prodMk (hasDerivAt_const (x := 0) s)
+    have hpartialRaw := (hF.differentiable (by norm_num) (0, s)).hasFDerivAt
+      |>.comp_hasDerivAt (f := fun t : ℝ => (t, s)) 0 hemb
+    have hpartial : HasDerivAt (fun t => F (t, s)) (timeFDeriv F 0 s) 0 := by
+      simpa only [Function.comp_def, timeFDeriv_apply, zero_smul, one_smul] using hpartialRaw
+    have hdirection := ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul f X (γY s)
+    have hdirection' : HasDerivAt (fun t => F (t, s))
+        (mvfderiv I f (γY s)
+          (mulRightInvariantVectorField X (γY s) -
+            mulInvariantVectorField X (γY s))) 0 := by
+      convert hdirection using 1
+      all_goals rfl
+    exact hpartial.unique hdirection'
+  have hFmin : ContDiffAt ℝ (minSmoothness ℝ 2) F (0, 0) := by
+    simpa using hF.contDiffAt
+  have hmixed := deriv_spatialFDeriv_apply (F := F) (x := (0 : ℝ)) (w := (1 : ℝ))
+    hFmin
+  have hspaceFun : (fun t => spatialFDeriv F 0 t 1) =
+      fun t => q (A t) := by
+    funext t
+    exact hspace t
+  have htimeFun : timeFDeriv F 0 = fun s =>
+      mvfderiv I f (γY s)
+        (mulRightInvariantVectorField X (γY s) -
+          mulInvariantVectorField X (γY s)) := by
+    funext s
+    exact htime s
+  rw [hspaceFun, htimeFun, fderiv_apply_one_eq_deriv] at hmixed
+  with_unfolding_all change q (deriv A 0) = q bracketModel
+  have hq : HasDerivAt (fun t => q (A t)) (q (deriv A 0)) 0 :=
+    q.hasFDerivAt.comp_hasDerivAt (f := A) 0 hAder
+  have hleftDeriv : deriv (fun t => q (A t)) 0 = q (deriv A 0) := by
+    simpa only [q] using hq.deriv
+  let RXf : C^∞⟮I, G; ℝ⟯ :=
+    ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
+      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
+  let LXf : C^∞⟮I, G; ℝ⟯ :=
+    ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
+      contMDiff_mvfderiv_mulInvariantVectorField X f⟩
+  have hgeneratorSmooth : ContMDiff I 𝓘(ℝ, ℝ) ∞
+      (fun g => mvfderiv I f g
+        (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) := by
+    have hsub := RXf.contMDiff.sub LXf.contMDiff
+    apply hsub.congr
+    intro g
+    change mvfderiv I f g (_ - _) = _ - _
+    rw [map_sub]
+    rfl
+  let H : C^∞⟮I, G; ℝ⟯ :=
+    ⟨fun g => mvfderiv I f g
+      (mulRightInvariantVectorField X g - mulInvariantVectorField X g), hgeneratorSmooth⟩
+  have hHmf := H.contMDiff.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
+  have hHcurve := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul hHmf Y
+  with_unfolding_all change HasDerivAt (fun s => H (γY s)) (mvfderiv I H 1 Y) 0 at hHcurve
+  have hrightDeriv : deriv (fun s =>
+      mvfderiv I f (γY s)
+        (mulRightInvariantVectorField X (γY s) -
+          mulInvariantVectorField X (γY s))) 0 = q bracketModel := by
+    rw [show (fun s => mvfderiv I f (γY s)
+        (mulRightInvariantVectorField X (γY s) -
+          mulInvariantVectorField X (γY s))) = fun s => H (γY s) by rfl]
+    rw [hHcurve.deriv]
+    change mvfderiv I
+        (fun g => mfderiv I 𝓘(ℝ, ℝ) f g
+          (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) 1 Y = _
+    have hbracket := mfderiv_conjugationGenerator_eq_bracket f X Y
+    have hqBracket : q bracketModel = mvfderiv I f 1 bracketTangent := by
+      with_unfolding_all rfl
+    rw [hqBracket]
+    exact hbracket
+  rw [hleftDeriv, hrightDeriv] at hmixed
+  exact hmixed
+
+/-- The differential at the identity of the group adjoint action, evaluated on `X` and `Y`, is
+the Lie-algebra adjoint `ad X Y`. -/
+theorem mvfderiv_tangentAd_apply (X Y : GroupLieAlgebra I G) :
+    mvfderiv I
+        (fun g : G => @id E (tangentAd (I := I) g Y)) 1 X =
+      @id E (LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y) := by
+  let T : G → E := fun g => @id E (tangentAd (I := I) g Y)
+  have hT : ContMDiff I 𝓘(ℝ, E) ∞ T := by
+    have hpair : ContMDiff I (I.prod 𝓘(ℝ, E)) ∞
+        (fun g : G => (g, @id E Y)) := contMDiff_id.prodMk contMDiff_const
+    exact (contMDiff_tangentAd_apply (I := I) (G := G)).comp hpair
+  have hX := hasMFDerivAt_mulInvariantExp_smul (I := I) (G := G) X
+  have hzero : mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) = 1 := by
+    rw [zero_smul, mulInvariantExp_zero]
+  have hTmf := hT.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
+  rw [← hzero] at hTmf
+  have hcomp := hTmf.comp 0 hX
+  rw [hzero] at hcomp
+  have hcompF : HasFDerivAt
+      (T ∘ fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • X))
+      ((mvfderiv I T 1).comp ((1 : ℝ →L[ℝ] ℝ).smulRight X)) 0 := by
+    with_unfolding_all exact hcomp.hasFDerivAt
+  have hchain : HasDerivAt
+      (fun t : ℝ => T (mulInvariantExp (I := I) (G := G) (t • X)))
+      (mvfderiv I T 1 X) 0 := by
+    apply hcompF.hasDerivAt.congr_deriv
+    simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smulRight_apply,
+      one_apply_eq_self, one_smul]
+  have hpath := hasDerivAt_tangentAd_mulInvariantExp_smul_apply (I := I) (G := G) X Y
+  have hpathModel : HasDerivAt
+      (fun t : ℝ => T (mulInvariantExp (I := I) (G := G) (t • X)))
+      (@id E (LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y)) 0 := by
+    with_unfolding_all simpa only [T] using hpath
+  exact hchain.unique hpathModel
+
+end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.Geometry.Lie.Adjoint.Smooth
 public import TauCeti.Geometry.Lie.Adjoint.Exponential
 public import TauCeti.Geometry.Lie.InvariantVectorField.Commutation
+import TauCeti.Geometry.Manifold.VectorField.Regularity
 
 /-!
 # The infinitesimal adjoint action
@@ -161,7 +162,8 @@ theorem mfderiv_conjugationGenerator_eq_bracket
       mvfderiv I f 1 ⁅X, Y⁆ := by
   let RXf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mfderiv I 𝓘(ℝ, ℝ) f g (mulRightInvariantVectorField X g),
-      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
+      ContMDiff.contMDiff_mvfderiv_apply f.contMDiff
+        (contMDiff_mulRightInvariantVectorField_infty X) (by simp)⟩
   let LXf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mfderiv I 𝓘(ℝ, ℝ) f g (mulInvariantVectorField X g),
       contMDiff_mvfderiv_mulInvariantVectorField X f⟩
@@ -341,7 +343,8 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     simpa only [q] using hq.deriv
   let RXf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
-      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
+      ContMDiff.contMDiff_mvfderiv_apply f.contMDiff
+        (contMDiff_mulRightInvariantVectorField_infty X) (by simp)⟩
   let LXf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
       contMDiff_mvfderiv_mulInvariantVectorField X f⟩

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -390,7 +390,6 @@ adjoint `LieAlgebra.ad ℝ _ X Y`.
 
 `GroupLieAlgebra I G` reduces definitionally to the model `E`; the `show E from` ascriptions expose
 that model to the manifold derivative API. -/
-@[simp]
 theorem mvfderiv_tangentAd_apply_one (X Y : GroupLieAlgebra I G) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     mvfderiv I

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -20,6 +20,13 @@ Mathlib's Lie-algebra adjoint map.
 This advances Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
 
+## Main results
+
+* `TauCeti.Lie.hasDerivAt_tangentAd_mulInvariantExp_smul_apply`: along an exponential line,
+  the derivative of the tangent adjoint action is the Lie bracket.
+* `TauCeti.Lie.mvfderiv_tangentAd_apply`: the differential of the tangent adjoint action at the
+  identity is the Lie-algebra adjoint action.
+
 ## References
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
@@ -51,7 +58,7 @@ local instance lieGroupBoundarylessManifoldInfinitesimalAdjoint : BoundarylessMa
 
 /-- A smooth scalar function on a conjugation orbit is smooth in the two exponential
 parameters. -/
-theorem ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters
+private theorem ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
     ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
       f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
@@ -79,7 +86,7 @@ theorem ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters
 
 /-- The infinitesimal generator of conjugation acts on scalar functions by the difference of
 right- and left-invariant differentiation. -/
-theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
+private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
     HasDerivAt
       (fun t : ℝ => f (mulInvariantExp (I := I) (G := G) (t • X) * g *
@@ -156,7 +163,7 @@ theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
 omit [T2Space G] in
 /-- Differentiating the scalar conjugation generator along a left-invariant direction gives the
 Lie bracket. -/
-theorem mfderiv_conjugationGenerator_eq_bracket
+private theorem mfderiv_conjugationGenerator_eq_bracket
     (f : C^∞⟮I, G; ℝ⟯) (X Y : GroupLieAlgebra I G) :
     mvfderiv I
         (fun g => mfderiv I 𝓘(ℝ, ℝ) f g
@@ -211,7 +218,7 @@ theorem mfderiv_conjugationGenerator_eq_bracket
 
 /-- A smooth scalar function evaluated on a conjugated exponential line is jointly smooth in the
 conjugating and conjugated parameters. -/
-theorem ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp
+private theorem ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp
     (f : C^∞⟮I, G; ℝ⟯) (X Y : GroupLieAlgebra I G) :
     ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
       f (mulInvariantExp (I := I) (G := G) (p.1 • X) *

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -9,6 +9,7 @@ public import TauCeti.Geometry.Lie.Adjoint.Exponential
 import TauCeti.Analysis.Calculus.ParametricFDeriv
 import TauCeti.Geometry.Lie.Exponential.Derivative.Basic
 import TauCeti.Geometry.Lie.InvariantVectorField.Commutation
+import TauCeti.Geometry.Lie.Tangent.LieEquiv
 import TauCeti.Geometry.Manifold.ContMDiff.Prod
 import TauCeti.Geometry.Manifold.VectorField.Regularity
 
@@ -111,38 +112,27 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
     rw [sub_eq_add_neg, map_add, map_neg]
   simpa only [F] using hdiag.congr_deriv hder
 
-/-- Right-invariant differentiation of `f` by `X`, bundled as a smooth scalar function. -/
-private noncomputable def ContMDiffMap.rightGenerator
-    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) : C^∞⟮I, G; ℝ⟯ := by
-  exact ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
-    contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
-
-/-- Left-invariant differentiation of `f` by `X`, bundled as a smooth scalar function. -/
-private noncomputable def ContMDiffMap.leftGenerator
-    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) : C^∞⟮I, G; ℝ⟯ := by
-  exact ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
-    contMDiff_mvfderiv_mulInvariantVectorField X f⟩
-
 /-- The smooth scalar infinitesimal generator of conjugation by the exponential line of `X`. -/
 private noncomputable def ContMDiffMap.conjugationGenerator
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) : C^∞⟮I, G; ℝ⟯ :=
-  ContMDiffMap.rightGenerator (I := I) f X - ContMDiffMap.leftGenerator (I := I) f X
+  rightInvariantDerivative (I := I) X f - tangentToLeftInvariantDerivation X f
 
 omit [FiniteDimensional ℝ E] in
 private theorem ContMDiffMap.conjugationGenerator_apply
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
     ContMDiffMap.conjugationGenerator (I := I) f X g = mvfderiv I f g
       (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := by
-  change mvfderiv I f g (mulRightInvariantVectorField X g) -
-      mvfderiv I f g (mulInvariantVectorField X g) = _
+  rw [ContMDiffMap.conjugationGenerator]
+  change rightInvariantDerivative X f g - tangentToLeftInvariantDerivation X f g = _
+  rw [rightInvariantDerivative_apply, tangentToLeftInvariantDerivation_apply]
   exact (map_sub (mvfderiv I f g) _ _).symm
 
 omit [FiniteDimensional ℝ E] in
 private theorem ContMDiffMap.conjugationGenerator_coe
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) :
     (ContMDiffMap.conjugationGenerator (I := I) f X : G → ℝ) =
-      (ContMDiffMap.rightGenerator (I := I) f X : G → ℝ) -
-      (ContMDiffMap.leftGenerator (I := I) f X : G → ℝ) :=
+      (rightInvariantDerivative (I := I) X f : G → ℝ) -
+      (tangentToLeftInvariantDerivation X f : G → ℝ) :=
   ContMDiffMap.coe_sub _ _
 
 /-- Differentiating the scalar conjugation generator along a left-invariant direction gives the
@@ -152,9 +142,9 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
     mvfderiv I (ContMDiffMap.conjugationGenerator (I := I) f X) 1 Y =
       mvfderiv I f 1 ⁅X, Y⁆ := by
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-  let RXf := ContMDiffMap.rightGenerator (I := I) f X
-  let LXf := ContMDiffMap.leftGenerator (I := I) f X
-  let LYf := ContMDiffMap.leftGenerator (I := I) f Y
+  let RXf := rightInvariantDerivative (I := I) X f
+  let LXf := tangentToLeftInvariantDerivation (I := I) (G := G) X f
+  let LYf := tangentToLeftInvariantDerivation (I := I) (G := G) Y f
   let H := ContMDiffMap.conjugationGenerator (I := I) f X
   have hH : (H : G → ℝ) = (RXf : G → ℝ) - (LXf : G → ℝ) :=
     ContMDiffMap.conjugationGenerator_coe f X
@@ -168,28 +158,25 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
   have hcomm :=
     mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute f (1 : G) X Y
   rw [mulRightInvariantVectorField_one, mulInvariantVectorField_one] at hcomm
-  -- The bundled maps `LYf` and `RXf` have exactly the underlying functions in `hcomm`.
-  change mvfderiv I LYf 1 X = mvfderiv I RXf 1 Y at hcomm
+  have hLYfun : (LYf : G → ℝ) =
+      fun h => mvfderiv I f h (mulInvariantVectorField Y h) := by
+    funext h
+    exact tangentToLeftInvariantDerivation_apply Y f h
+  have hRXfun : (RXf : G → ℝ) =
+      fun h => mvfderiv I f h (mulRightInvariantVectorField X h) := by
+    funext h
+    exact rightInvariantDerivative_apply X f h
+  rw [← hLYfun, ← hRXfun] at hcomm
   rw [← hcomm]
-  have hbridge := mvfderiv_mlieBracket
-    (f := (f : G → ℝ))
-    (V := mulInvariantVectorField X)
-    (W := mulInvariantVectorField Y)
-    (x := (1 : G))
-    (f.contMDiff.contMDiffAt.of_le
-      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out))
-    (by simp)
-    ((contMDiff_mulInvariantVectorField_infty X).mdifferentiable
-      (by simp)).mdifferentiableAt
-    ((contMDiff_mulInvariantVectorField_infty Y).mdifferentiable
-      (by simp)).mdifferentiableAt
-  rw [mulInvariantVectorField_one, mulInvariantVectorField_one] at hbridge
-  -- Expose the underlying functions of `LYf` and `LXf` in the vector-field bracket identity.
-  change mvfderiv I f 1
-      (VectorField.mlieBracket I (mulInvariantVectorField X) (mulInvariantVectorField Y) 1) =
+  have hbridge := congrArg
+    (fun D : LeftInvariantDerivation I G => D f 1)
+    (tangentToLeftInvariantDerivation_lie (I := I) (G := G) X Y)
+  simp only [tangentToLeftInvariantDerivation_apply,
+    LeftInvariantDerivation.commutator_apply, ContMDiffMap.coe_sub, Pi.sub_apply,
+    mulInvariantVectorField_one] at hbridge
+  change mvfderiv I f 1 ⁅X, Y⁆ =
     mvfderiv I LYf 1 X - mvfderiv I LXf 1 Y at hbridge
-  rw [← hbridge]
-  congr 1
+  exact hbridge.symm
 
 /-- A smooth scalar function evaluated on a conjugated exponential line is jointly smooth in the
 conjugating and conjugated parameters. -/

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -123,17 +123,11 @@ private theorem ContMDiffMap.conjugationGenerator_apply
     ContMDiffMap.conjugationGenerator (I := I) f X g = mvfderiv I f g
       (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := by
   rw [ContMDiffMap.conjugationGenerator]
+  -- Expose the bundled subtraction at `g`; the two public application lemmas then identify its
+  -- summands with the corresponding invariant directional derivatives.
   change rightInvariantDerivative X f g - tangentToLeftInvariantDerivation X f g = _
   rw [rightInvariantDerivative_apply, tangentToLeftInvariantDerivation_apply]
   exact (map_sub (mvfderiv I f g) _ _).symm
-
-omit [FiniteDimensional ℝ E] in
-private theorem ContMDiffMap.conjugationGenerator_coe
-    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) :
-    (ContMDiffMap.conjugationGenerator (I := I) f X : G → ℝ) =
-      (rightInvariantDerivative (I := I) X f : G → ℝ) -
-      (tangentToLeftInvariantDerivation X f : G → ℝ) :=
-  ContMDiffMap.coe_sub _ _
 
 /-- Differentiating the scalar conjugation generator along a left-invariant direction gives the
 Lie bracket. -/
@@ -147,7 +141,7 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
   let LYf := tangentToLeftInvariantDerivation (I := I) (G := G) Y f
   let H := ContMDiffMap.conjugationGenerator (I := I) f X
   have hH : (H : G → ℝ) = (RXf : G → ℝ) - (LXf : G → ℝ) :=
-    ContMDiffMap.conjugationGenerator_coe f X
+    ContMDiffMap.coe_sub _ _
   -- Unfold only the private bundle `H`; its underlying function is the displayed generator.
   change mvfderiv I H 1 Y = _
   rw [hH]
@@ -165,6 +159,8 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
   simp only [tangentToLeftInvariantDerivation_apply,
     LeftInvariantDerivation.commutator_apply, ContMDiffMap.coe_sub, Pi.sub_apply,
     mulInvariantVectorField_one] at hbridge
+  -- Express the evaluated derivation identity through the named smooth-map bundles `LYf` and
+  -- `LXf`, whose applications the preceding simplification has exposed.
   change mvfderiv I f 1 ⁅X, Y⁆ =
     mvfderiv I LYf 1 X - mvfderiv I LXf 1 Y at hbridge
   exact hbridge.symm
@@ -228,9 +224,12 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
     LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y
   apply hAder.congr_deriv
   let derivTangent : GroupLieAlgebra I G := deriv A 0
+  -- Move from the model-space derivative used by `HasDerivAt` to its canonical identity tangent
+  -- space so pointed smooth functions can separate the two vectors.
   change derivTangent = bracketTangent
   apply tangentToPointDerivation_injective (I := I) (1 : G)
   ext f
+  -- Evaluation of the two point derivations is definitionally `mvfderiv` on the chosen test map.
   change mvfderiv I f 1 derivTangent = mvfderiv I f 1 bracketTangent
   let q : GroupLieAlgebra I G →L[ℝ] ℝ := mvfderiv I f 1
   let F : ℝ × ℝ → ℝ := fun p =>
@@ -265,6 +264,8 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
         (fun s : ℝ => f (mulInvariantExp (I := I) (G := G)
           (s • tangentAd (I := I) (γX t) Y))) (q (A t)) 0 := by
       apply hdirection.congr_deriv
+      -- The exponential-line chain rule returns `mfderiv`; use the public bridge to the
+      -- model-space directional derivative used by `q`.
       change mfderiv I 𝓘(ℝ, ℝ) (f : G → ℝ) 1 _ = mvfderiv I (f : G → ℝ) 1 _
       exact (mvfderiv_apply_eq_mfderiv_apply (I := I) (f := (f : G → ℝ)) _ _).symm
     exact hpartial.unique hdirection'
@@ -301,6 +302,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
     funext s
     exact htime s
   rw [hspaceFun, htimeFun, fderiv_apply_one_eq_deriv] at hmixed
+  -- Restate the scalar mixed-partial identity through the tangent-space functional `q`.
   change q derivTangent = q bracketTangent
   have hq : HasDerivAt (fun t => q (A t)) (q (deriv A 0)) 0 :=
     q.hasFDerivAt.comp_hasDerivAt (f := A) 0 hAder
@@ -361,6 +363,8 @@ theorem mvfderiv_tangentAd_apply_one (X Y : GroupLieAlgebra I G) :
   have hpathModel : HasDerivAt
       (fun t : ℝ => T (mulInvariantExp (I := I) (G := G) (t • X)))
       (show E from LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y) 0 := by
+    -- Unfold only the local path abbreviation `T`; the tangent/model conversion is the explicit
+    -- `show E from` boundary already present in the theorem statement.
     change HasDerivAt
       (fun t : ℝ => show E from tangentAd (I := I)
         (mulInvariantExp (I := I) (G := G) (t • X)) Y)

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -196,7 +196,8 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
     (RXf.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
     (LXf.contMDiff.mdifferentiable (by simp)).mdifferentiableAt]
   simp only [sub_apply]
-  have hcomm := mvfderiv_mulInvariant_mulRightInvariant_commute f (1 : G) X Y
+  have hcomm :=
+    mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute f (1 : G) X Y
   rw [mulRightInvariantVectorField_one, mulInvariantVectorField_one] at hcomm
   change mvfderiv I LYf 1 X = mvfderiv I RXf 1 Y at hcomm
   rw [← hcomm]

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -23,15 +23,19 @@ This advances Deliverable A, Layer 1 of
 
 ## Main results
 
-* `TauCeti.Lie.hasDerivAt_tangentAd_mulInvariantExp_smul_apply`: along an exponential line,
-  the derivative of the tangent adjoint action is the Lie bracket.
-* `TauCeti.Lie.mvfderiv_tangentAd_apply`: the differential of the tangent adjoint action at the
+* `TauCeti.Lie.hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero`: at `t = 0`, the derivative
+  of the tangent adjoint action along the exponential line of `X` is the Lie bracket.
+* `TauCeti.Lie.mvfderiv_tangentAd_apply_one`: the differential of the tangent adjoint action at the
   identity is the Lie-algebra adjoint action.
 
 ## References
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
   Deliverable A, Layer 1, "The infinitesimal adjoint".
+* The two-parameter Clairaut argument adapts
+  `TauCeti.Lie.mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute`; its
+  mixed-partial step uses `TauCeti.Analysis.Calculus.ParametricFDeriv`, which in turn adapts
+  Sébastien Gouëzel's `ContDiffAt.isSymmSndFDerivAt`.
 -/
 
 public section
@@ -51,8 +55,8 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
 
-/-- A smooth scalar function on a conjugation orbit is smooth in the two exponential
-parameters. -/
+/-- A smooth scalar function is jointly smooth in the two independent parameters of
+`(s, t) ↦ f (exp (s • X) * g * exp (t • (-X)))`, whose diagonal is conjugation of `g`. -/
 private theorem ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
@@ -108,11 +112,10 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
   have hleftNeg := HasMFDerivAt.hasDerivAt_comp_mul_mulInvariantExp_smul_zero hfAt (-X)
   have ht : fderiv ℝ F (0, 0) (1, 0) =
       mvfderiv I f g (mulRightInvariantVectorField X g) := by
-    have hemb : HasDerivAt (fun t : ℝ => (t, (0 : ℝ))) (1, 0) 0 :=
-      (hasDerivAt_id (𝕜 := ℝ) 0).prodMk (hasDerivAt_const (x := (0 : ℝ)) (0 : ℝ))
-    have hpartial :=
-      (hF.differentiable (by simp) (0, 0)).hasFDerivAt.comp_hasDerivAt
-        (f := fun t : ℝ => (t, (0 : ℝ))) 0 hemb
+    have hpartial : HasDerivAt (fun t : ℝ => F (t, 0))
+        (fderiv ℝ F (0, 0) (1, 0)) 0 := by
+      simpa only [timeFDeriv_apply] using
+        hasDerivAt_parameterCurve (hF.differentiable (by simp) (0, 0))
     have hright' : HasDerivAt (fun t : ℝ => F (t, 0))
         (mvfderiv I f g (mulRightInvariantVectorField X g)) 0 := by
       have hfun : (fun t : ℝ => F (t, 0)) =
@@ -121,16 +124,16 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
         simp only [F, zero_smul, mulInvariantExp_zero, mul_one]
       rw [hfun]
       apply hright.congr_deriv
+      -- `mvfderiv` and the derivative supplied by `HasMFDerivAt` share the canonical real model.
       with_unfolding_all rfl
     exact hpartial.unique hright'
   have hs : fderiv ℝ F (0, 0) (0, 1) =
       mvfderiv I f g (-mulInvariantVectorField X g) := by
-    have hemb : HasDerivAt (fun t : ℝ => ((0 : ℝ), t)) (0, 1) 0 :=
-      (hasDerivAt_const (x := (0 : ℝ)) (0 : ℝ)).prodMk
-        (hasDerivAt_id (𝕜 := ℝ) 0)
-    have hpartial :=
-      (hF.differentiable (by simp) (0, 0)).hasFDerivAt.comp_hasDerivAt
-        (f := fun t : ℝ => ((0 : ℝ), t)) 0 hemb
+    have hFdiff : DifferentiableAt ℝ F (0, 0) := hF.differentiable (by simp) (0, 0)
+    have hslice : DifferentiableAt ℝ (fun t => F (0, t)) 0 :=
+      hFdiff.comp 0 ((differentiableAt_const 0).prodMk differentiableAt_id)
+    have hpartial := hslice.hasDerivAt
+    rw [← fderiv_apply_one_eq_deriv, fderiv_timeSlice hFdiff] at hpartial
     have hleftNeg' : HasDerivAt (fun t : ℝ => F (0, t))
         (mvfderiv I f g (-mulInvariantVectorField X g)) 0 := by
       have hfun : (fun t : ℝ => F (0, t)) =
@@ -138,13 +141,16 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
         funext t
         simp only [F, zero_smul, mulInvariantExp_zero, one_mul]
       have hvec : mulInvariantVectorField (-X) g = -mulInvariantVectorField X g := by
-        simp [mulInvariantVectorField]
-        rfl
+        rw [show -X = (-1 : ℝ) • X by simp]
+        exact congrFun (mulInvariantVectorField_smul (I := I) (G := G) (-1) X) g |>.trans
+          (by simp)
       rw [hfun]
       rw [hvec] at hleftNeg
       apply hleftNeg.congr_deriv
+      -- `mvfderiv` and the derivative supplied by `HasMFDerivAt` share the canonical real model.
       with_unfolding_all rfl
-    exact hpartial.unique hleftNeg'
+    simpa only [spatialFDeriv_apply, zero_smul, one_smul] using
+      hpartial.unique hleftNeg'
   have hder : fderiv ℝ F (0, 0) (1, 1) =
       mvfderiv I f g
         (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := by
@@ -159,13 +165,28 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
     rw [sub_eq_add_neg, map_add, map_neg]
   simpa only [F] using hdiag.congr_deriv hder
 
+/-- The smooth scalar infinitesimal generator of conjugation by the exponential line of `X`. -/
+private noncomputable def ContMDiffMap.conjugationGenerator
+    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) : C^∞⟮I, G; ℝ⟯ := by
+  let RXf : C^∞⟮I, G; ℝ⟯ :=
+    ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
+      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
+  let LXf : C^∞⟮I, G; ℝ⟯ :=
+    ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
+      contMDiff_mvfderiv_mulInvariantVectorField X f⟩
+  refine ⟨fun g => mvfderiv I f g
+    (mulRightInvariantVectorField X g - mulInvariantVectorField X g), ?_⟩
+  have hsub := RXf.contMDiff.sub LXf.contMDiff
+  apply hsub.congr
+  intro g
+  change mvfderiv I f g (_ - _) = mvfderiv I f g _ - mvfderiv I f g _
+  exact map_sub (mvfderiv I f g) _ _
+
 /-- Differentiating the scalar conjugation generator along a left-invariant direction gives the
 Lie bracket. -/
 private theorem mvfderiv_conjugationGenerator_eq_bracket
     (f : C^∞⟮I, G; ℝ⟯) (X Y : GroupLieAlgebra I G) :
-    mvfderiv I
-        (fun g => mvfderiv I f g
-          (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) 1 Y =
+    mvfderiv I (ContMDiffMap.conjugationGenerator (I := I) f X) 1 Y =
       mvfderiv I f 1 ⁅X, Y⁆ := by
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   let RXf : C^∞⟮I, G; ℝ⟯ :=
@@ -177,15 +198,14 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
   let LYf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mvfderiv I f g (mulInvariantVectorField Y g),
       contMDiff_mvfderiv_mulInvariantVectorField Y f⟩
-  have hgenerator :
-      (fun g => mvfderiv I f g
-        (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) =
-        (RXf : G → ℝ) - (LXf : G → ℝ) := by
+  let H := ContMDiffMap.conjugationGenerator (I := I) f X
+  have hH : (H : G → ℝ) = (RXf : G → ℝ) - (LXf : G → ℝ) := by
     funext g
-    change mvfderiv I f g (_ - _) = _ - _
+    change mvfderiv I f g (_ - _) = mvfderiv I f g _ - mvfderiv I f g _
     rw [map_sub]
-    rfl
-  rw [hgenerator]
+  -- Unfold only the private bundle `H`; its underlying function is the displayed generator.
+  change mvfderiv I H 1 Y = _
+  rw [hH]
   rw [mvfderiv_sub
     (RXf.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
     (LXf.contMDiff.mdifferentiable (by simp)).mdifferentiableAt]
@@ -193,6 +213,7 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
   have hcomm :=
     mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute f (1 : G) X Y
   rw [mulRightInvariantVectorField_one, mulInvariantVectorField_one] at hcomm
+  -- The bundled maps `LYf` and `RXf` have exactly the underlying functions in `hcomm`.
   change mvfderiv I LYf 1 X = mvfderiv I RXf 1 Y at hcomm
   rw [← hcomm]
   have hbridge := mvfderiv_mlieBracket
@@ -209,6 +230,7 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
     ((contMDiff_mulInvariantVectorField_infty Y).mdifferentiable
       (by simp)).mdifferentiableAt
   rw [mulInvariantVectorField_one, mulInvariantVectorField_one] at hbridge
+  -- Expose the underlying functions of `LYf` and `LXf` in the vector-field bracket identity.
   change mvfderiv I f 1
       (VectorField.mlieBracket I (mulInvariantVectorField X) (mulInvariantVectorField Y) 1) =
     mvfderiv I LYf 1 X - mvfderiv I LXf 1 Y at hbridge
@@ -251,19 +273,23 @@ private theorem ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp
     exact hMprod
   exact (f.contMDiff.comp hM).contDiff
 
-/-- Along an exponential line, the derivative of the tangent adjoint action is the Lie bracket. -/
-theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
+/-- At `t = 0`, the derivative of `t ↦ tangentAd (mulInvariantExp (t • X)) Y` along the
+exponential line of `X` is `⁅X, Y⁆`.
+
+`GroupLieAlgebra I G` reduces definitionally to the model `E`; the `show E from` ascriptions expose
+that model to the normed-space derivative API. -/
+theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
     (X Y : GroupLieAlgebra I G) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     HasDerivAt
-      (fun t : ℝ => @id E (tangentAd (I := I)
-        (mulInvariantExp (I := I) (G := G) (t • X)) Y))
-      (@id E (LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y)) 0 := by
+      (fun t : ℝ => show E from tangentAd (I := I)
+        (mulInvariantExp (I := I) (G := G) (t • X)) Y)
+      (show E from LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y) 0 := by
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   dsimp only
   let γX : ℝ → G := fun t => mulInvariantExp (I := I) (G := G) (t • X)
   let γY : ℝ → G := fun t => mulInvariantExp (I := I) (G := G) (t • Y)
-  let A : ℝ → E := fun t => @id E (tangentAd (I := I) (γX t) Y)
+  let A : ℝ → E := fun t => show E from tangentAd (I := I) (γX t) Y
   have hγX : ContMDiff 𝓘(ℝ, ℝ) I ∞ γX := by
     simpa only [γX] using contMDiff_mulInvariantExp_smul (I := I) (G := G) X
   have hA : ContDiff ℝ ∞ A := by
@@ -276,10 +302,12 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y
   let bracketModel : E := @id E bracketTangent
   apply hAder.congr_deriv
-  -- Tangent vectors at the identity are determined by their action on pointed smooth functions.
+  -- Tangent vectors at the identity are determined by their action on pointed smooth functions;
+  -- unfolding exposes the model-space representatives hidden in `GroupLieAlgebra`.
   with_unfolding_all apply tangentToPointDerivation_injective (I := I) (1 : G)
   ext f
   let q : E →L[ℝ] ℝ := by
+    -- `mvfderiv` is the canonical continuous-linear action of a model tangent vector on `f`.
     with_unfolding_all exact mvfderiv I f 1
   let F : ℝ × ℝ → ℝ := fun p =>
     f (γX p.1 * γY p.2 *
@@ -291,12 +319,11 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
   -- Varying the second parameter conjugates the `Y`-line by `γX t`, so this spatial partial
   -- evaluates the tangent adjoint orbit against the chosen test function.
   have hspace (t : ℝ) : spatialFDeriv F 0 t 1 = q (A t) := by
-    have hemb : HasDerivAt (fun s : ℝ => (t, s)) (0, 1) 0 :=
-      (hasDerivAt_const (x := 0) t).prodMk (hasDerivAt_id (𝕜 := ℝ) 0)
-    have hpartialRaw := (hF.differentiable (by norm_num) (t, 0)).hasFDerivAt
-      |>.comp_hasDerivAt (f := fun s : ℝ => (t, s)) 0 hemb
-    have hpartial : HasDerivAt (fun s => F (t, s)) (spatialFDeriv F 0 t 1) 0 := by
-      simpa only [Function.comp_def, spatialFDeriv_apply, zero_smul, one_smul] using hpartialRaw
+    have hFdiff : DifferentiableAt ℝ F (t, 0) := hF.differentiable (by norm_num) (t, 0)
+    have hslice : DifferentiableAt ℝ (fun s => F (t, s)) 0 :=
+      hFdiff.comp 0 ((differentiableAt_const (c := t)).prodMk differentiableAt_id)
+    have hpartial := hslice.hasDerivAt
+    rw [← fderiv_apply_one_eq_deriv, fderiv_timeSlice hFdiff] at hpartial
     have hfOne := f.contMDiff.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
     have hdirection := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_zero hfOne
       (tangentAd (I := I) (γX t) Y)
@@ -317,6 +344,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
         (fun s : ℝ => f (mulInvariantExp (I := I) (G := G)
           (s • tangentAd (I := I) (γX t) Y))) (q (A t)) 0 := by
       apply hdirection.congr_deriv
+      -- The tangent Lie algebra and the model vector space are definitionally the same here.
       with_unfolding_all rfl
     exact hpartial.unique hdirection'
   -- Varying the first parameter is the infinitesimal conjugation generator `R_X - L_X` along
@@ -324,12 +352,8 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
   have htime (s : ℝ) : timeFDeriv F 0 s =
       mvfderiv I f (γY s)
         (mulRightInvariantVectorField X (γY s) - mulInvariantVectorField X (γY s)) := by
-    have hemb : HasDerivAt (fun t : ℝ => (t, s)) (1, 0) 0 :=
-      (hasDerivAt_id (𝕜 := ℝ) 0).prodMk (hasDerivAt_const (x := 0) s)
-    have hpartialRaw := (hF.differentiable (by norm_num) (0, s)).hasFDerivAt
-      |>.comp_hasDerivAt (f := fun t : ℝ => (t, s)) 0 hemb
-    have hpartial : HasDerivAt (fun t => F (t, s)) (timeFDeriv F 0 s) 0 := by
-      simpa only [Function.comp_def, timeFDeriv_apply, zero_smul, one_smul] using hpartialRaw
+    have hpartial : HasDerivAt (fun t => F (t, s)) (timeFDeriv F 0 s) 0 :=
+      hasDerivAt_parameterCurve (hF.differentiable (by norm_num) (0, s))
     have hdirection := ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul f X (γY s)
     have hdirection' : HasDerivAt (fun t => F (t, s))
         (mvfderiv I f (γY s)
@@ -362,58 +386,51 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     q.hasFDerivAt.comp_hasDerivAt (f := A) 0 hAder
   have hleftDeriv : deriv (fun t => q (A t)) 0 = q (deriv A 0) := by
     simpa only [q] using hq.deriv
-  let RXf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
-      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
-  let LXf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
-      contMDiff_mvfderiv_mulInvariantVectorField X f⟩
-  have hgeneratorSmooth : ContMDiff I 𝓘(ℝ, ℝ) ∞
-      (fun g => mvfderiv I f g
-        (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) := by
-    have hsub := RXf.contMDiff.sub LXf.contMDiff
-    apply hsub.congr
-    intro g
-    change mvfderiv I f g (_ - _) = _ - _
-    rw [map_sub]
+  let H := ContMDiffMap.conjugationGenerator (I := I) f X
+  have hH (g : G) : H g = mvfderiv I f g
+      (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := by
+    change mvfderiv I f g (_ - _) = _
     rfl
-  let H : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mvfderiv I f g
-      (mulRightInvariantVectorField X g - mulInvariantVectorField X g), hgeneratorSmooth⟩
   have hHmf := H.contMDiff.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
   have hHcurve := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_zero hHmf Y
-  -- The exponential-line chain rule is expressed through the same canonical `mvfderiv` map.
+  -- The exponential-line chain rule is expressed through the same canonical `mvfderiv` map;
+  -- unfolding identifies its model-space continuous linear map with that public notation.
   with_unfolding_all change HasDerivAt (fun s => H (γY s)) (mvfderiv I H 1 Y) 0 at hHcurve
   have hrightDeriv : deriv (fun s =>
       mvfderiv I f (γY s)
         (mulRightInvariantVectorField X (γY s) -
           mulInvariantVectorField X (γY s))) 0 = q bracketModel := by
+    -- `H` packages exactly the scalar generator displayed on the left.
     rw [show (fun s => mvfderiv I f (γY s)
         (mulRightInvariantVectorField X (γY s) -
-          mulInvariantVectorField X (γY s))) = fun s => H (γY s) by rfl]
+          mulInvariantVectorField X (γY s))) = fun s => H (γY s) by
+      funext s
+      exact (hH (γY s)).symm]
     rw [hHcurve.deriv]
-    change mvfderiv I
-        (fun g => mvfderiv I f g
-          (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) 1 Y = _
-    -- The left side is now exactly the scalar conjugation generator differentiated along `Y`.
+    -- The left side is the bundled scalar conjugation generator differentiated along `Y`.
     have hbracket := mvfderiv_conjugationGenerator_eq_bracket f X Y
     have hqBracket : q bracketModel = mvfderiv I f 1 bracketTangent := by
+      -- Both sides evaluate the same model tangent vector against the pointed smooth function.
       with_unfolding_all rfl
     rw [hqBracket]
     exact hbracket
   rw [hleftDeriv, hrightDeriv] at hmixed
   exact hmixed
 
-/-- The differential at the identity of the tangent adjoint action, evaluated on `X` and `Y`, is
-the Lie-algebra adjoint `ad X Y`. -/
-theorem mvfderiv_tangentAd_apply (X Y : GroupLieAlgebra I G) :
+/-- The derivative at `1` of `g ↦ tangentAd g Y`, in the direction `X`, is the Lie-algebra
+adjoint `LieAlgebra.ad ℝ _ X Y`.
+
+`GroupLieAlgebra I G` reduces definitionally to the model `E`; the `show E from` ascriptions expose
+that model to the manifold derivative API. -/
+@[simp]
+theorem mvfderiv_tangentAd_apply_one (X Y : GroupLieAlgebra I G) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     mvfderiv I
-        (fun g : G => @id E (tangentAd (I := I) g Y)) 1 X =
-      @id E (LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y) := by
+        (fun g : G => show E from tangentAd (I := I) g Y) 1 X =
+      (show E from LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y) := by
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   dsimp only
-  let T : G → E := fun g => @id E (tangentAd (I := I) g Y)
+  let T : G → E := fun g => show E from tangentAd (I := I) g Y
   have hT : ContMDiff I 𝓘(ℝ, E) ∞ T := by
     have hpair : ContMDiff I (I.prod 𝓘(ℝ, E)) ∞
         (fun g : G => (g, @id E Y)) := contMDiff_id.prodMk contMDiff_const
@@ -424,11 +441,14 @@ theorem mvfderiv_tangentAd_apply (X Y : GroupLieAlgebra I G) :
       (fun t : ℝ => T (mulInvariantExp (I := I) (G := G) (t • X)))
       (mvfderiv I T 1 X) 0 := by
     apply hchainRaw.congr_deriv
+    -- The chain-rule derivative and `mvfderiv` use the same canonical tangent model.
     with_unfolding_all rfl
-  have hpath := hasDerivAt_tangentAd_mulInvariantExp_smul_apply (I := I) (G := G) X Y
+  have hpath := hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
+    (I := I) (G := G) X Y
   have hpathModel : HasDerivAt
       (fun t : ℝ => T (mulInvariantExp (I := I) (G := G) (t • X)))
-      (@id E (LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y)) 0 := by
+      (show E from LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y) 0 := by
+    -- Unfold `T` and the model-space ascriptions to compare the identical paths and derivatives.
     with_unfolding_all simpa only [T] using hpath
   exact hchain.unique hpathModel
 

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -7,6 +7,8 @@ module
 public import TauCeti.Geometry.Lie.Adjoint.Smooth
 public import TauCeti.Geometry.Lie.Adjoint.Exponential
 public import TauCeti.Geometry.Lie.InvariantVectorField.Commutation
+import TauCeti.Analysis.Calculus.ParametricFDeriv
+import TauCeti.Geometry.Lie.Exponential.Derivative.Basic
 import TauCeti.Geometry.Manifold.VectorField.Regularity
 
 /-!
@@ -183,7 +185,8 @@ theorem mfderiv_conjugationGenerator_eq_bracket
     (RXf.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
     (LXf.contMDiff.mdifferentiable (by simp)).mdifferentiableAt]
   simp only [sub_apply]
-  have hcomm := mvfderiv_mulInvariant_mulRightInvariant_commute f X Y
+  have hcomm := mvfderiv_mulInvariant_mulRightInvariant_commute f (1 : G) X Y
+  rw [mulRightInvariantVectorField_one, mulInvariantVectorField_one] at hcomm
   change mvfderiv I LYf 1 X = mvfderiv I RXf 1 Y at hcomm
   rw [← hcomm]
   have hbridge := mvfderiv_mlieBracket

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -110,8 +110,8 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
     exact (hF.differentiable (by simp) (0, 0)).hasFDerivAt.comp_hasDerivAt
       (f := fun t : ℝ => (t, t)) 0 hemb
   have hfAt := f.contMDiff.mdifferentiable (by simp) g |>.hasMFDerivAt
-  have hright := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_mul hfAt X
-  have hleftNeg := HasMFDerivAt.hasDerivAt_comp_mul_mulInvariantExp_smul hfAt (-X)
+  have hright := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_mul_zero hfAt X
+  have hleftNeg := HasMFDerivAt.hasDerivAt_comp_mul_mulInvariantExp_smul_zero hfAt (-X)
   have ht : fderiv ℝ F (0, 0) (1, 0) =
       mvfderiv I f g (mulRightInvariantVectorField X g) := by
     have hemb : HasDerivAt (fun t : ℝ => (t, (0 : ℝ))) (1, 0) 0 :=
@@ -304,7 +304,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     have hpartial : HasDerivAt (fun s => F (t, s)) (spatialFDeriv F 0 t 1) 0 := by
       simpa only [Function.comp_def, spatialFDeriv_apply, zero_smul, one_smul] using hpartialRaw
     have hfOne := f.contMDiff.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
-    have hdirection := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul hfOne
+    have hdirection := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_zero hfOne
       (tangentAd (I := I) (γX t) Y)
     have hcurve : (fun s : ℝ => F (t, s)) =
         fun s => f (mulInvariantExp (I := I) (G := G)
@@ -387,7 +387,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     ⟨fun g => mvfderiv I f g
       (mulRightInvariantVectorField X g - mulInvariantVectorField X g), hgeneratorSmooth⟩
   have hHmf := H.contMDiff.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
-  have hHcurve := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul hHmf Y
+  have hHcurve := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_zero hHmf Y
   -- The exponential-line chain rule is expressed through the same canonical `mvfderiv` map.
   with_unfolding_all change HasDerivAt (fun s => H (γY s)) (mvfderiv I H 1 Y) 0 at hHcurve
   have hrightDeriv : deriv (fun s =>
@@ -425,7 +425,7 @@ theorem mvfderiv_tangentAd_apply (X Y : GroupLieAlgebra I G) :
         (fun g : G => (g, @id E Y)) := contMDiff_id.prodMk contMDiff_const
     exact (contMDiff_tangentAd_apply (I := I) (G := G)).comp hpair
   have hTmf := hT.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
-  have hchainRaw := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul hTmf X
+  have hchainRaw := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_zero hTmf X
   have hchain : HasDerivAt
       (fun t : ℝ => T (mulInvariantExp (I := I) (G := G) (t • X)))
       (mvfderiv I T 1 X) 0 := by

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -158,15 +158,6 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
   have hcomm :=
     mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute f (1 : G) X Y
   rw [mulRightInvariantVectorField_one, mulInvariantVectorField_one] at hcomm
-  have hLYfun : (LYf : G → ℝ) =
-      fun h => mvfderiv I f h (mulInvariantVectorField Y h) := by
-    funext h
-    exact tangentToLeftInvariantDerivation_apply Y f h
-  have hRXfun : (RXf : G → ℝ) =
-      fun h => mvfderiv I f h (mulRightInvariantVectorField X h) := by
-    funext h
-    exact rightInvariantDerivative_apply X f h
-  rw [← hLYfun, ← hRXfun] at hcomm
   rw [← hcomm]
   have hbridge := congrArg
     (fun D : LeftInvariantDerivation I G => D f 1)
@@ -370,8 +361,11 @@ theorem mvfderiv_tangentAd_apply_one (X Y : GroupLieAlgebra I G) :
   have hpathModel : HasDerivAt
       (fun t : ℝ => T (mulInvariantExp (I := I) (G := G) (t • X)))
       (show E from LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y) 0 := by
-    -- Unfold `T` and the model-space ascriptions to compare the identical paths and derivatives.
-    with_unfolding_all simpa only [T] using hpath
+    change HasDerivAt
+      (fun t : ℝ => show E from tangentAd (I := I)
+        (mulInvariantExp (I := I) (G := G) (t • X)) Y)
+      (show E from LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y) 0
+    exact hpath
   exact hchain.unique hpathModel
 
 end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -125,32 +125,25 @@ private noncomputable def ContMDiffMap.leftGenerator
 
 /-- The smooth scalar infinitesimal generator of conjugation by the exponential line of `X`. -/
 private noncomputable def ContMDiffMap.conjugationGenerator
-    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) : C^∞⟮I, G; ℝ⟯ := by
-  refine ⟨fun g => mvfderiv I f g
-    (mulRightInvariantVectorField X g - mulInvariantVectorField X g), ?_⟩
-  have hsub := (ContMDiffMap.rightGenerator (I := I) f X).contMDiff.sub
-    (ContMDiffMap.leftGenerator (I := I) f X).contMDiff
-  apply hsub.congr
-  intro g
-  -- Coercing the bundled maps exposes their carrier functions; linearity supplies the equality.
-  change mvfderiv I f g (_ - _) = mvfderiv I f g _ - mvfderiv I f g _
-  exact map_sub (mvfderiv I f g) _ _
+    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) : C^∞⟮I, G; ℝ⟯ :=
+  ContMDiffMap.rightGenerator (I := I) f X - ContMDiffMap.leftGenerator (I := I) f X
 
 omit [FiniteDimensional ℝ E] in
 private theorem ContMDiffMap.conjugationGenerator_apply
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
     ContMDiffMap.conjugationGenerator (I := I) f X g = mvfderiv I f g
-      (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := rfl
+      (mulRightInvariantVectorField X g - mulInvariantVectorField X g) := by
+  change mvfderiv I f g (mulRightInvariantVectorField X g) -
+      mvfderiv I f g (mulInvariantVectorField X g) = _
+  exact (map_sub (mvfderiv I f g) _ _).symm
 
 omit [FiniteDimensional ℝ E] in
 private theorem ContMDiffMap.conjugationGenerator_coe
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) :
     (ContMDiffMap.conjugationGenerator (I := I) f X : G → ℝ) =
       (ContMDiffMap.rightGenerator (I := I) f X : G → ℝ) -
-        (ContMDiffMap.leftGenerator (I := I) f X : G → ℝ) := by
-  funext g
-  rw [ContMDiffMap.conjugationGenerator_apply]
-  exact map_sub (mvfderiv I f g) _ _
+      (ContMDiffMap.leftGenerator (I := I) f X : G → ℝ) :=
+  ContMDiffMap.coe_sub _ _
 
 /-- Differentiating the scalar conjugation generator along a left-invariant direction gives the
 Lie bracket. -/
@@ -161,9 +154,7 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   let RXf := ContMDiffMap.rightGenerator (I := I) f X
   let LXf := ContMDiffMap.leftGenerator (I := I) f X
-  let LYf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mvfderiv I f g (mulInvariantVectorField Y g),
-      contMDiff_mvfderiv_mulInvariantVectorField Y f⟩
+  let LYf := ContMDiffMap.leftGenerator (I := I) f Y
   let H := ContMDiffMap.conjugationGenerator (I := I) f X
   have hH : (H : G → ℝ) = (RXf : G → ℝ) - (LXf : G → ℝ) :=
     ContMDiffMap.conjugationGenerator_coe f X
@@ -257,15 +248,13 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
     (hA.differentiable (by simp) 0).hasDerivAt
   let bracketTangent : GroupLieAlgebra I G :=
     LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y
-  let bracketModel : E := @id E bracketTangent
   apply hAder.congr_deriv
-  -- Tangent vectors at the identity are determined by their action on pointed smooth functions;
-  -- unfolding exposes the model-space representatives hidden in `GroupLieAlgebra`.
-  with_unfolding_all apply tangentToPointDerivation_injective (I := I) (1 : G)
+  let derivTangent : GroupLieAlgebra I G := deriv A 0
+  change derivTangent = bracketTangent
+  apply tangentToPointDerivation_injective (I := I) (1 : G)
   ext f
-  let q : E →L[ℝ] ℝ := by
-    -- `mvfderiv` is the canonical continuous-linear action of a model tangent vector on `f`.
-    with_unfolding_all exact mvfderiv I f 1
+  change mvfderiv I f 1 derivTangent = mvfderiv I f 1 bracketTangent
+  let q : GroupLieAlgebra I G →L[ℝ] ℝ := mvfderiv I f 1
   let F : ℝ × ℝ → ℝ := fun p =>
     f (γX p.1 * γY p.2 *
       mulInvariantExp (I := I) (G := G) (p.1 • (-X)))
@@ -334,8 +323,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
     funext s
     exact htime s
   rw [hspaceFun, htimeFun, fderiv_apply_one_eq_deriv] at hmixed
-  -- Unfold the canonical model-space and point-derivation identifications on both sides.
-  with_unfolding_all change q (deriv A 0) = q bracketModel
+  change q derivTangent = q bracketTangent
   have hq : HasDerivAt (fun t => q (A t)) (q (deriv A 0)) 0 :=
     q.hasFDerivAt.comp_hasDerivAt (f := A) 0 hAder
   have hleftDeriv : deriv (fun t => q (A t)) 0 = q (deriv A 0) := by
@@ -349,7 +337,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
   have hrightDeriv : deriv (fun s =>
       mvfderiv I f (γY s)
         (mulRightInvariantVectorField X (γY s) -
-          mulInvariantVectorField X (γY s))) 0 = q bracketModel := by
+          mulInvariantVectorField X (γY s))) 0 = q bracketTangent := by
     -- `H` packages exactly the scalar generator displayed on the left.
     rw [show (fun s => mvfderiv I f (γY s)
         (mulRightInvariantVectorField X (γY s) -
@@ -359,9 +347,8 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
     rw [hHcurve'.deriv]
     -- The left side is the bundled scalar conjugation generator differentiated along `Y`.
     have hbracket := mvfderiv_conjugationGenerator_eq_bracket f X Y
-    have hqBracket : q bracketModel = mvfderiv I f 1 bracketTangent := by
-      dsimp only [q, bracketModel, bracketTangent]
-      rfl
+    have hqBracket : q bracketTangent = mvfderiv I f 1 bracketTangent := by
+      dsimp only [q]
     rw [hqBracket]
     exact hbracket
   rw [hleftDeriv, hrightDeriv] at hmixed

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -14,8 +14,9 @@ import TauCeti.Geometry.Manifold.VectorField.Regularity
 /-!
 # The infinitesimal adjoint action
 
-This file identifies the derivative of the group adjoint representation at the identity with
-Mathlib's Lie-algebra adjoint map.
+This file identifies the derivative of the tangent-space adjoint action at the identity with
+Mathlib's Lie-algebra adjoint map. This is the geometric prerequisite for transporting the result
+to the derivation-valued group adjoint representation.
 
 This advances Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
@@ -45,7 +46,7 @@ open scoped ContDiff Manifold
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G]
 
 local instance lieGroupMinSmoothnessThreeInfinitesimalAdjoint :
     LieGroup I (minSmoothness ℝ 3) G :=
@@ -60,9 +61,12 @@ local instance lieGroupBoundarylessManifoldInfinitesimalAdjoint : BoundarylessMa
 parameters. -/
 private theorem ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
       f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
         mulInvariantExp (I := I) (G := G) (p.2 • (-X)))) := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
   have hX : ContMDiff 𝓘(ℝ, ℝ) I ∞
       (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • X)) := by
     simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
@@ -88,11 +92,14 @@ private theorem ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters
 right- and left-invariant differentiation. -/
 private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
     (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     HasDerivAt
       (fun t : ℝ => f (mulInvariantExp (I := I) (G := G) (t • X) * g *
         mulInvariantExp (I := I) (G := G) (t • (-X))))
       (mvfderiv I f g
         (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) 0 := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
   let F : ℝ × ℝ → ℝ := fun p =>
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • (-X)))
@@ -160,7 +167,6 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
     rw [sub_eq_add_neg, map_add, map_neg]
   simpa only [F] using hdiag.congr_deriv hder
 
-omit [T2Space G] in
 /-- Differentiating the scalar conjugation generator along a left-invariant direction gives the
 Lie bracket. -/
 private theorem mfderiv_conjugationGenerator_eq_bracket
@@ -169,6 +175,7 @@ private theorem mfderiv_conjugationGenerator_eq_bracket
         (fun g => mfderiv I 𝓘(ℝ, ℝ) f g
           (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) 1 Y =
       mvfderiv I f 1 ⁅X, Y⁆ := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   let RXf : C^∞⟮I, G; ℝ⟯ :=
     ⟨fun g => mfderiv I 𝓘(ℝ, ℝ) f g (mulRightInvariantVectorField X g),
       ContMDiff.contMDiff_mvfderiv_apply f.contMDiff
@@ -220,10 +227,13 @@ private theorem mfderiv_conjugationGenerator_eq_bracket
 conjugating and conjugated parameters. -/
 private theorem ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp
     (f : C^∞⟮I, G; ℝ⟯) (X Y : GroupLieAlgebra I G) :
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
       f (mulInvariantExp (I := I) (G := G) (p.1 • X) *
         mulInvariantExp (I := I) (G := G) (p.2 • Y) *
         mulInvariantExp (I := I) (G := G) (p.1 • (-X)))) := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
   have hX : ContMDiff 𝓘(ℝ, ℝ) I ∞
       (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • X)) := by
     simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
@@ -255,10 +265,13 @@ private theorem ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp
 /-- Along an exponential line, the derivative of the tangent adjoint action is the Lie bracket. -/
 theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     (X Y : GroupLieAlgebra I G) :
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     HasDerivAt
       (fun t : ℝ => @id E (tangentAd (I := I)
         (mulInvariantExp (I := I) (G := G) (t • X)) Y))
       (@id E (LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y)) 0 := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
   let γX : ℝ → G := fun t => mulInvariantExp (I := I) (G := G) (t • X)
   let γY : ℝ → G := fun t => mulInvariantExp (I := I) (G := G) (t • Y)
   let A : ℝ → E := fun t => @id E (tangentAd (I := I) (γX t) Y)
@@ -275,6 +288,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y
   let bracketModel : E := @id E bracketTangent
   apply hAder.congr_deriv
+  -- Tangent vectors at the identity are determined by their action on pointed smooth functions.
   with_unfolding_all apply tangentToPointDerivation_injective (I := I) (1 : G)
   ext f
   let q : E →L[ℝ] ℝ := by
@@ -286,6 +300,8 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     (ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp f X Y).of_le
       (show ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) from
         WithTop.coe_le_coe.mpr le_top)
+  -- Varying the second parameter conjugates the `Y`-line by `γX t`, so this spatial partial
+  -- evaluates the tangent adjoint orbit against the chosen test function.
   have hspace (t : ℝ) : spatialFDeriv F 0 t 1 = q (A t) := by
     have hemb : HasDerivAt (fun s : ℝ => (t, s)) (0, 1) 0 :=
       (hasDerivAt_const (x := 0) t).prodMk (hasDerivAt_id (𝕜 := ℝ) 0)
@@ -304,6 +320,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
         rw [show t • (-X) = -(t • X) by module, mulInvariantExp_neg]
       simp only [F]
       rw [hinv, conj_mulInvariantExp]
+      -- Expose the tangent-space representative so linearity of `tangentAd` can move the scalar.
       change f (mulInvariantExp (I := I) (G := G)
         (tangentAd (I := I) (γX t) (s • Y))) = _
       rw [map_smul]
@@ -314,6 +331,8 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
       apply hdirection.congr_deriv
       with_unfolding_all rfl
     exact hpartial.unique hdirection'
+  -- Varying the first parameter is the infinitesimal conjugation generator `R_X - L_X` along
+  -- the `Y`-line.
   have htime (s : ℝ) : timeFDeriv F 0 s =
       mvfderiv I f (γY s)
         (mulRightInvariantVectorField X (γY s) - mulInvariantVectorField X (γY s)) := by
@@ -328,11 +347,14 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
         (mvfderiv I f (γY s)
           (mulRightInvariantVectorField X (γY s) -
             mulInvariantVectorField X (γY s))) 0 := by
+      -- Only the abbreviation `F` and the association of the three group factors differ.
       convert hdirection using 1
       all_goals rfl
     exact hpartial.unique hdirection'
   have hFmin : ContDiffAt ℝ (minSmoothness ℝ 2) F (0, 0) := by
     simpa using hF.contDiffAt
+  -- Clairaut symmetry identifies the derivative of the adjoint orbit with the derivative of its
+  -- scalar conjugation generator along `Y`.
   have hmixed := deriv_spatialFDeriv_apply (F := F) (x := (0 : ℝ)) (w := (1 : ℝ))
     hFmin
   have hspaceFun : (fun t => spatialFDeriv F 0 t 1) =
@@ -346,6 +368,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     funext s
     exact htime s
   rw [hspaceFun, htimeFun, fderiv_apply_one_eq_deriv] at hmixed
+  -- Unfold the canonical model-space and point-derivation identifications on both sides.
   with_unfolding_all change q (deriv A 0) = q bracketModel
   have hq : HasDerivAt (fun t => q (A t)) (q (deriv A 0)) 0 :=
     q.hasFDerivAt.comp_hasDerivAt (f := A) 0 hAder
@@ -372,6 +395,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
       (mulRightInvariantVectorField X g - mulInvariantVectorField X g), hgeneratorSmooth⟩
   have hHmf := H.contMDiff.mdifferentiable (by simp) (1 : G) |>.hasMFDerivAt
   have hHcurve := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul hHmf Y
+  -- The exponential-line chain rule is expressed through the same canonical `mvfderiv` map.
   with_unfolding_all change HasDerivAt (fun s => H (γY s)) (mvfderiv I H 1 Y) 0 at hHcurve
   have hrightDeriv : deriv (fun s =>
       mvfderiv I f (γY s)
@@ -384,6 +408,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
     change mvfderiv I
         (fun g => mfderiv I 𝓘(ℝ, ℝ) f g
           (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) 1 Y = _
+    -- The left side is now exactly the scalar conjugation generator differentiated along `Y`.
     have hbracket := mfderiv_conjugationGenerator_eq_bracket f X Y
     have hqBracket : q bracketModel = mvfderiv I f 1 bracketTangent := by
       with_unfolding_all rfl
@@ -392,12 +417,15 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
   rw [hleftDeriv, hrightDeriv] at hmixed
   exact hmixed
 
-/-- The differential at the identity of the group adjoint action, evaluated on `X` and `Y`, is
+/-- The differential at the identity of the tangent adjoint action, evaluated on `X` and `Y`, is
 the Lie-algebra adjoint `ad X Y`. -/
 theorem mvfderiv_tangentAd_apply (X Y : GroupLieAlgebra I G) :
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     mvfderiv I
         (fun g : G => @id E (tangentAd (I := I) g Y)) 1 X =
       @id E (LieAlgebra.ad ℝ (GroupLieAlgebra I G) X Y) := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
   let T : G → E := fun g => @id E (tangentAd (I := I) g Y)
   have hT : ContMDiff I 𝓘(ℝ, E) ∞ T := by
     have hpair : ContMDiff I (I.prod 𝓘(ℝ, E)) ∞

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -9,6 +9,7 @@ public import TauCeti.Geometry.Lie.Adjoint.Exponential
 import TauCeti.Analysis.Calculus.ParametricFDeriv
 import TauCeti.Geometry.Lie.Exponential.Derivative.Basic
 import TauCeti.Geometry.Lie.InvariantVectorField.Commutation
+import TauCeti.Geometry.Manifold.ContMDiff.Prod
 import TauCeti.Geometry.Manifold.VectorField.Regularity
 
 /-!
@@ -55,34 +56,9 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
 
-/-- A smooth scalar function is jointly smooth in the two independent parameters of
-`(s, t) ↦ f (exp (s • X) * g * exp (t • (-X)))`, whose diagonal is conjugation of `g`. -/
-private theorem ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters
-    (f : C^∞⟮I, G; ℝ⟯) (X : GroupLieAlgebra I G) (g : G) :
-    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-    ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
-      f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
-        mulInvariantExp (I := I) (G := G) (p.2 • (-X)))) := by
-  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-  dsimp only
-  have hX : ContMDiff 𝓘(ℝ, ℝ) I ∞
-      (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • X)) := by
-    exact contMDiff_mulInvariantExp_smul (I := I) (G := G) X
-  have hnegX : ContMDiff 𝓘(ℝ, ℝ) I ∞
-      (fun t : ℝ => mulInvariantExp (I := I) (G := G) (t • (-X))) := by
-    exact contMDiff_mulInvariantExp_smul (I := I) (G := G) (-X)
-  have hMprod : ContMDiff (𝓘(ℝ, ℝ).prod 𝓘(ℝ, ℝ)) I ∞
-      (fun p : ℝ × ℝ =>
-        mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
-          mulInvariantExp (I := I) (G := G) (p.2 • (-X))) :=
-    ((hX.comp contMDiff_fst).mul contMDiff_const).mul (hnegX.comp contMDiff_snd)
-  have hM : ContMDiff 𝓘(ℝ, ℝ × ℝ) I ∞
-      (fun p : ℝ × ℝ =>
-        mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
-          mulInvariantExp (I := I) (G := G) (p.2 • (-X))) := by
-    rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
-    exact hMprod
-  exact (f.contMDiff.comp hM).contDiff
+private theorem two_le_infinite_smoothness_adjoint :
+    ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) :=
+  ENat.natCast_le_of_coe_top_le_withTop le_rfl 2
 
 /-- The infinitesimal generator of conjugation acts on scalar functions by the difference of
 right- and left-invariant differentiation. -/
@@ -100,7 +76,8 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • (-X)))
   have hF : ContDiff ℝ ∞ F :=
-    ContMDiffMap.contDiff_comp_mulInvariantExp_conjParameters f X g
+    (f.contMDiff.comp
+      (contMDiff_mulInvariantExp_smul_mul_mul_mulInvariantExp_smul g X (-X))).contDiff
   have hdiag : HasDerivAt (fun t : ℝ => F (t, t))
       (fderiv ℝ F (0, 0) (1, 1)) 0 := by
     have hemb : HasDerivAt (fun t : ℝ => (t, t)) (1, 1) 0 :=
@@ -221,9 +198,7 @@ private theorem mvfderiv_conjugationGenerator_eq_bracket
     (V := mulInvariantVectorField X)
     (W := mulInvariantVectorField Y)
     (x := (1 : G))
-    (f.contMDiff.contMDiffAt.of_le (show
-      ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) from
-        WithTop.coe_le_coe.mpr le_top))
+    (f.contMDiff.contMDiffAt.of_le two_le_infinite_smoothness_adjoint)
     (by simp)
     ((contMDiff_mulInvariantVectorField_infty X).mdifferentiable
       (by simp)).mdifferentiableAt
@@ -264,13 +239,7 @@ private theorem ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp
           mulInvariantExp (I := I) (G := G) (p.1 • (-X))) :=
     ((hX.comp contMDiff_fst).mul (hY.comp contMDiff_snd)).mul
       (hnegX.comp contMDiff_fst)
-  have hM : ContMDiff 𝓘(ℝ, ℝ × ℝ) I ∞
-      (fun p : ℝ × ℝ =>
-        mulInvariantExp (I := I) (G := G) (p.1 • X) *
-          mulInvariantExp (I := I) (G := G) (p.2 • Y) *
-          mulInvariantExp (I := I) (G := G) (p.1 • (-X))) := by
-    rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
-    exact hMprod
+  have hM := (contMDiff_prod_modelWithCornersSelf_iff (I' := I)).mp hMprod
   exact (f.contMDiff.comp hM).contDiff
 
 /-- At `t = 0`, the derivative of `t ↦ tangentAd (mulInvariantExp (t • X)) Y` along the
@@ -314,8 +283,7 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply_zero
       mulInvariantExp (I := I) (G := G) (p.1 • (-X)))
   have hF : ContDiff ℝ 2 F :=
     (ContMDiffMap.contDiff_comp_conj_mulInvariantExp_mulInvariantExp f X Y).of_le
-      (show ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) from
-        WithTop.coe_le_coe.mpr le_top)
+      two_le_infinite_smoothness_adjoint
   -- Varying the second parameter conjugates the `Y`-line by `γX t`, so this spatial partial
   -- evaluates the tangent adjoint orbit against the chosen test function.
   have hspace (t : ℝ) : spatialFDeriv F 0 t 1 = q (A t) := by

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -169,29 +169,29 @@ private theorem ContMDiffMap.hasDerivAt_comp_conj_mulInvariantExp_smul
 
 /-- Differentiating the scalar conjugation generator along a left-invariant direction gives the
 Lie bracket. -/
-private theorem mfderiv_conjugationGenerator_eq_bracket
+private theorem mvfderiv_conjugationGenerator_eq_bracket
     (f : C^∞⟮I, G; ℝ⟯) (X Y : GroupLieAlgebra I G) :
     mvfderiv I
-        (fun g => mfderiv I 𝓘(ℝ, ℝ) f g
+        (fun g => mvfderiv I f g
           (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) 1 Y =
       mvfderiv I f 1 ⁅X, Y⁆ := by
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   let RXf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mfderiv I 𝓘(ℝ, ℝ) f g (mulRightInvariantVectorField X g),
+    ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField X g),
       ContMDiff.contMDiff_mvfderiv_apply f.contMDiff
         (contMDiff_mulRightInvariantVectorField_infty X) (by simp)⟩
   let LXf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mfderiv I 𝓘(ℝ, ℝ) f g (mulInvariantVectorField X g),
+    ⟨fun g => mvfderiv I f g (mulInvariantVectorField X g),
       contMDiff_mvfderiv_mulInvariantVectorField X f⟩
   let LYf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun g => mfderiv I 𝓘(ℝ, ℝ) f g (mulInvariantVectorField Y g),
+    ⟨fun g => mvfderiv I f g (mulInvariantVectorField Y g),
       contMDiff_mvfderiv_mulInvariantVectorField Y f⟩
   have hgenerator :
-      (fun g => mfderiv I 𝓘(ℝ, ℝ) f g
+      (fun g => mvfderiv I f g
         (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) =
         (RXf : G → ℝ) - (LXf : G → ℝ) := by
     funext g
-    change mfderiv I 𝓘(ℝ, ℝ) f g (_ - _) = _ - _
+    change mvfderiv I f g (_ - _) = _ - _
     rw [map_sub]
     rfl
   rw [hgenerator]
@@ -406,10 +406,10 @@ theorem hasDerivAt_tangentAd_mulInvariantExp_smul_apply
           mulInvariantVectorField X (γY s))) = fun s => H (γY s) by rfl]
     rw [hHcurve.deriv]
     change mvfderiv I
-        (fun g => mfderiv I 𝓘(ℝ, ℝ) f g
+        (fun g => mvfderiv I f g
           (mulRightInvariantVectorField X g - mulInvariantVectorField X g)) 1 Y = _
     -- The left side is now exactly the scalar conjugation generator differentiated along `Y`.
-    have hbracket := mfderiv_conjugationGenerator_eq_bracket f X Y
+    have hbracket := mvfderiv_conjugationGenerator_eq_bracket f X Y
     have hqBracket : q bracketModel = mvfderiv I f 1 bracketTangent := by
       with_unfolding_all rfl
     rw [hqBracket]

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -57,11 +57,6 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
 
-/-- Twice differentiable regularity is bounded by infinite smoothness. -/
-theorem two_le_infinite_smoothness :
-    ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) :=
-  ENat.natCast_le_of_coe_top_le_withTop le_rfl 2
-
 section Complete
 
 variable [CompleteSpace E]
@@ -72,13 +67,12 @@ theorem contDiff_comp_mulInvariantExp_mul_mulInvariantExp
     {f : G → ℝ} (hf : ContMDiff I 𝓘(ℝ, ℝ) ∞ f) (g : G)
     (X Y : GroupLieAlgebra I G) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-    ContDiff ℝ 2 (fun p : ℝ × ℝ =>
+    ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
       f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
         mulInvariantExp (I := I) (G := G) (p.2 • Y))) := by
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   dsimp only
-  exact (hf.comp (contMDiff_mulInvariantExp_smul_mul_mul_mulInvariantExp_smul g X Y)).contDiff.of_le
-    two_le_infinite_smoothness
+  exact (hf.comp (contMDiff_mulInvariantExp_smul_mul_mul_mulInvariantExp_smul g X Y)).contDiff
 
 theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
     (f : C^∞⟮I, G; ℝ⟯) (g : G) (X Y : GroupLieAlgebra I G) (s : ℝ) :
@@ -95,7 +89,8 @@ theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • Y))
   have hF : ContDiff ℝ 2 F :=
-    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y
+    (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
+      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
   have hFdiff : DifferentiableAt ℝ F (s, 0) := hF.differentiable (by norm_num) (s, 0)
   have hpartial := (hasFDerivAt_timeSlice hFdiff).hasDerivAt
   have hfAt := f.contMDiff.mdifferentiable (by simp)
@@ -125,7 +120,8 @@ theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • Y))
   have hF : ContDiff ℝ 2 F :=
-    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y
+    (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
+      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
   have hFdiff : DifferentiableAt ℝ F (0, t) := hF.differentiable (by norm_num) (0, t)
   have hpartial := hasDerivAt_parameterCurve hFdiff
   have hfAt := f.contMDiff.mdifferentiable (by simp)
@@ -164,7 +160,8 @@ theorem mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute
     ⟨fun h => mvfderiv I f h (mulRightInvariantVectorField X h),
       contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
   have hF : ContDiff ℝ 2 F :=
-    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y
+    (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
+      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
   -- Identify the two partial derivatives with the invariant directional derivatives.
   have hspaceFun : (fun s => spatialFDeriv F 0 s 1) =
       fun s => LYf (γX s * g) := by
@@ -214,7 +211,8 @@ theorem mlieBracket_mulRightInvariantVectorField_mulInvariantVectorField
     (V := mulRightInvariantVectorField X)
     (W := mulInvariantVectorField Y)
     (x := g)
-    (f.contMDiff.contMDiffAt.of_le two_le_infinite_smoothness)
+    (f.contMDiff.contMDiffAt.of_le
+      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out))
     (by simp)
     ((contMDiff_mulRightInvariantVectorField_infty X).mdifferentiable
       (by simp)).mdifferentiableAt

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -23,7 +23,7 @@ This supplies a prerequisite for Deliverable A, Layer 1 of
 ## Main results
 
 * `contDiff_comp_mulInvariantExp_mul_mulInvariantExp`: a scalar function on two exponential lines
-  multiplied around a fixed group element is twice continuously differentiable.
+  multiplied around a fixed group element is smooth in both parameters.
 * `spatialFDeriv_mulInvariantExp_mul_mulInvariantExp` and
   `timeFDeriv_mulInvariantExp_mul_mulInvariantExp`: identify its two partial derivatives with
   left- and right-invariant differentiation.

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -22,8 +22,8 @@ This supplies a prerequisite for Deliverable A, Layer 1 of
 
 ## Main results
 
-* `contDiff_comp_mulInvariantExp_mul_mulInvariantExp`: a scalar function on two exponential lines
-  multiplied around a fixed group element is smooth in both parameters.
+* `contDiff_comp_mulInvariantExp_mul_mulInvariantExp`: a vector-valued function on two exponential
+  lines multiplied around a fixed group element is smooth in both parameters.
 * `spatialFDeriv_mulInvariantExp_mul_mulInvariantExp` and
   `timeFDeriv_mulInvariantExp_mul_mulInvariantExp`: identify its two partial derivatives with
   left- and right-invariant differentiation.
@@ -60,11 +60,12 @@ attribute [local instance] ContMDiffMul.boundarylessManifold
 section Complete
 
 variable [CompleteSpace E]
+variable {F' : Type*} [NormedAddCommGroup F'] [NormedSpace ℝ F']
 
-/-- A smooth scalar function evaluated on two exponential lines multiplied around a fixed group
-element is smooth in both parameters. -/
+/-- A smooth vector-valued function evaluated on two exponential lines multiplied around a fixed
+group element is smooth in both parameters. -/
 theorem contDiff_comp_mulInvariantExp_mul_mulInvariantExp
-    {f : G → ℝ} (hf : ContMDiff I 𝓘(ℝ, ℝ) ∞ f) (g : G)
+    {f : G → F'} (hf : ContMDiff I 𝓘(ℝ, F') ∞ f) (g : G)
     (X Y : GroupLieAlgebra I G) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
@@ -74,8 +75,11 @@ theorem contDiff_comp_mulInvariantExp_mul_mulInvariantExp
   dsimp only
   exact (hf.comp (contMDiff_mulInvariantExp_smul_mul_mul_mulInvariantExp_smul g X Y)).contDiff
 
+/-- Differentiating the second exponential parameter gives left-invariant differentiation by
+`Y`. -/
 theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
-    (f : C^∞⟮I, G; ℝ⟯) (g : G) (X Y : GroupLieAlgebra I G) (s : ℝ) :
+    (f : C^∞⟮I, G; 𝓘(ℝ, F'), F'⟯) (g : G)
+    (X Y : GroupLieAlgebra I G) (s : ℝ) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     spatialFDeriv (fun p : ℝ × ℝ =>
       f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
@@ -85,7 +89,7 @@ theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
           (mulInvariantExp (I := I) (G := G) (s • X) * g)) := by
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   dsimp only
-  let F : ℝ × ℝ → ℝ := fun p =>
+  let F : ℝ × ℝ → F' := fun p =>
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • Y))
   have hF : ContDiff ℝ 2 F :=
@@ -97,7 +101,7 @@ theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
     (mulInvariantExp (I := I) (G := G) (s • X) * g) |>.hasMFDerivAt
   have hdirection := HasMFDerivAt.hasDerivAt_comp_mul_mulInvariantExp_smul_zero hfAt Y
   have hdirection' : HasDerivAt (fun t => F (s, t))
-      ((mfderiv I 𝓘(ℝ, ℝ) f (mulInvariantExp (I := I) (G := G) (s • X) * g))
+      ((mfderiv I 𝓘(ℝ, F') f (mulInvariantExp (I := I) (G := G) (s • X) * g))
         (mulInvariantVectorField Y
           (mulInvariantExp (I := I) (G := G) (s • X) * g))) 0 := by
     -- Naming the hypothesis makes the canonical real scalar-structure identification explicit.
@@ -105,8 +109,11 @@ theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
   rw [mvfderiv_apply_eq_mfderiv_apply]
   exact hpartial.unique hdirection'
 
+/-- Differentiating the first exponential parameter gives right-invariant differentiation by
+`X`. -/
 theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
-    (f : C^∞⟮I, G; ℝ⟯) (g : G) (X Y : GroupLieAlgebra I G) (t : ℝ) :
+    (f : C^∞⟮I, G; 𝓘(ℝ, F'), F'⟯) (g : G)
+    (X Y : GroupLieAlgebra I G) (t : ℝ) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     timeFDeriv (fun p : ℝ × ℝ =>
       f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
@@ -116,7 +123,7 @@ theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
           (g * mulInvariantExp (I := I) (G := G) (t • Y))) := by
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   dsimp only
-  let F : ℝ × ℝ → ℝ := fun p =>
+  let F : ℝ × ℝ → F' := fun p =>
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • Y))
   have hF : ContDiff ℝ 2 F :=
@@ -128,7 +135,7 @@ theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
     (g * mulInvariantExp (I := I) (G := G) (t • Y)) |>.hasMFDerivAt
   have hdirection := HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_mul_zero hfAt X
   have hdirection' : HasDerivAt (fun s => F (s, t))
-      ((mfderiv I 𝓘(ℝ, ℝ) f (g * mulInvariantExp (I := I) (G := G) (t • Y)))
+      ((mfderiv I 𝓘(ℝ, F') f (g * mulInvariantExp (I := I) (G := G) (t • Y)))
         (mulRightInvariantVectorField X
           (g * mulInvariantExp (I := I) (G := G) (t • Y)))) 0 := by
     -- Reassociate the product while naming the canonical real scalar-structure identification.

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -153,12 +153,8 @@ theorem mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute
   let γX : ℝ → G := fun t => mulInvariantExp (I := I) (G := G) (t • X)
   let γY : ℝ → G := fun t => mulInvariantExp (I := I) (G := G) (t • Y)
   let F : ℝ × ℝ → ℝ := fun p => f (γX p.1 * g * γY p.2)
-  let LYf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun h => mvfderiv I f h (mulInvariantVectorField Y h),
-      contMDiff_mvfderiv_mulInvariantVectorField Y f⟩
-  let RXf : C^∞⟮I, G; ℝ⟯ :=
-    ⟨fun h => mvfderiv I f h (mulRightInvariantVectorField X h),
-      contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
+  let LYf := tangentToLeftInvariantDerivation (I := I) (G := G) Y f
+  let RXf := rightInvariantDerivative (I := I) X f
   have hF : ContDiff ℝ 2 F :=
     (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
       (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
@@ -166,12 +162,12 @@ theorem mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute
   have hspaceFun : (fun s => spatialFDeriv F 0 s 1) =
       fun s => LYf (γX s * g) := by
     funext s
-    simpa only [LYf, ContMDiffMap.coeFn_mk] using
+    simpa only [LYf, tangentToLeftInvariantDerivation_apply] using
       spatialFDeriv_mulInvariantExp_mul_mulInvariantExp f g X Y s
   have htimeFun : timeFDeriv F 0 =
       fun t => RXf (g * γY t) := by
     funext t
-    simpa only [RXf, ContMDiffMap.coeFn_mk] using
+    simpa only [RXf, rightInvariantDerivative_apply] using
       timeFDeriv_mulInvariantExp_mul_mulInvariantExp f g X Y t
   -- Clairaut symmetry equates the derivatives of those two partial-derivative functions.
   have hFmin : ContDiffAt ℝ (minSmoothness ℝ 2) F (0, 0) := by
@@ -185,6 +181,15 @@ theorem mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute
     (RXf.contMDiff.mdifferentiable (by simp) g |>.hasMFDerivAt) Y
   rw [hLY.deriv, hRX.deriv] at hmixed
   rw [mvfderiv_apply_eq_mfderiv_apply, mvfderiv_apply_eq_mfderiv_apply]
+  have hLYfun : (LYf : G → ℝ) =
+      fun h => mvfderiv I f h (mulInvariantVectorField Y h) := by
+    funext h
+    exact tangentToLeftInvariantDerivation_apply Y f h
+  have hRXfun : (RXf : G → ℝ) =
+      fun h => mvfderiv I f h (mulRightInvariantVectorField X h) := by
+    funext h
+    exact rightInvariantDerivative_apply X f h
+  rw [← hLYfun, ← hRXfun]
   exact hmixed
 
 end Complete

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -4,11 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-import TauCeti.Analysis.Calculus.ParametricFDeriv
-import TauCeti.Geometry.Lie.Exponential.Derivative.Basic
+public import TauCeti.Analysis.Calculus.ParametricFDeriv
+public import TauCeti.Geometry.Lie.Exponential.Derivative.Basic
 public import TauCeti.Geometry.Lie.RightInvariantVectorField
 public import TauCeti.Geometry.Manifold.VectorField.LieBracket
-import TauCeti.Geometry.Lie.Interior
+public import TauCeti.Geometry.Lie.Interior
 
 /-!
 # Commutation of left- and right-invariant vector fields
@@ -22,6 +22,11 @@ This supplies a prerequisite for Deliverable A, Layer 1 of
 
 ## Main results
 
+* `contDiff_comp_mulInvariantExp_mul_mulInvariantExp`: a scalar function on two exponential lines
+  multiplied around a fixed group element is twice continuously differentiable.
+* `spatialFDeriv_mulInvariantExp_mul_mulInvariantExp` and
+  `timeFDeriv_mulInvariantExp_mul_mulInvariantExp`: identify its two partial derivatives with
+  left- and right-invariant differentiation.
 * `mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute`: left- and
   right-invariant scalar differentiation commute at every group point.
 * `mlieBracket_mulRightInvariantVectorField_mulInvariantVectorField`: the corresponding
@@ -52,7 +57,8 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
 
-private theorem two_le_infinite_smoothness :
+/-- Twice differentiable regularity is bounded by infinite smoothness. -/
+theorem two_le_infinite_smoothness :
     ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) :=
   ENat.natCast_le_of_coe_top_le_withTop le_rfl 2
 
@@ -62,7 +68,7 @@ variable [CompleteSpace E]
 
 /-- A smooth scalar function evaluated on two exponential lines multiplied around a fixed group
 element is smooth in both parameters. -/
-private theorem contDiff_comp_mulInvariantExp_mul_mulInvariantExp
+theorem contDiff_comp_mulInvariantExp_mul_mulInvariantExp
     {f : G → ℝ} (hf : ContMDiff I 𝓘(ℝ, ℝ) ∞ f) (g : G)
     (X Y : GroupLieAlgebra I G) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
@@ -74,7 +80,7 @@ private theorem contDiff_comp_mulInvariantExp_mul_mulInvariantExp
   exact (hf.comp (contMDiff_mulInvariantExp_smul_mul_mul_mulInvariantExp_smul g X Y)).contDiff.of_le
     two_le_infinite_smoothness
 
-private theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
+theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
     (f : C^∞⟮I, G; ℝ⟯) (g : G) (X Y : GroupLieAlgebra I G) (s : ℝ) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     spatialFDeriv (fun p : ℝ × ℝ =>
@@ -104,7 +110,7 @@ private theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
   rw [mvfderiv_apply_eq_mfderiv_apply]
   exact hpartial.unique hdirection'
 
-private theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
+theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
     (f : C^∞⟮I, G; ℝ⟯) (g : G) (X Y : GroupLieAlgebra I G) (t : ℝ) :
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
     timeFDeriv (fun p : ℝ × ℝ =>

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -148,8 +148,7 @@ theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
   rw [mvfderiv_apply_eq_mfderiv_apply]
   exact hpartial.unique hdirection'
 
-/-- Left- and right-invariant scalar differentiation commute at every group point. This is
-Clairaut symmetry for `(s, t) ↦ f (exp(sX) * g * exp(tY))`. -/
+/-- Left- and right-invariant scalar differentiation commute at every group point. -/
 theorem mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute
     (f : C^∞⟮I, G; ℝ⟯) (g : G) (X Y : GroupLieAlgebra I G) :
     mvfderiv I (tangentToLeftInvariantDerivation Y f) g

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -145,9 +145,9 @@ theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
 Clairaut symmetry for `(s, t) ↦ f (exp(sX) * g * exp(tY))`. -/
 theorem mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute
     (f : C^∞⟮I, G; ℝ⟯) (g : G) (X Y : GroupLieAlgebra I G) :
-    mvfderiv I (fun h => mvfderiv I f h (mulInvariantVectorField Y h)) g
+    mvfderiv I (tangentToLeftInvariantDerivation Y f) g
         (mulRightInvariantVectorField X g) =
-      mvfderiv I (fun h => mvfderiv I f h (mulRightInvariantVectorField X h)) g
+      mvfderiv I (rightInvariantDerivative X f) g
         (mulInvariantVectorField Y g) := by
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   let γX : ℝ → G := fun t => mulInvariantExp (I := I) (G := G) (t • X)
@@ -181,15 +181,6 @@ theorem mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute
     (RXf.contMDiff.mdifferentiable (by simp) g |>.hasMFDerivAt) Y
   rw [hLY.deriv, hRX.deriv] at hmixed
   rw [mvfderiv_apply_eq_mfderiv_apply, mvfderiv_apply_eq_mfderiv_apply]
-  have hLYfun : (LYf : G → ℝ) =
-      fun h => mvfderiv I f h (mulInvariantVectorField Y h) := by
-    funext h
-    exact tangentToLeftInvariantDerivation_apply Y f h
-  have hRXfun : (RXf : G → ℝ) =
-      fun h => mvfderiv I f h (mulRightInvariantVectorField X h) := by
-    funext h
-    exact rightInvariantDerivative_apply X f h
-  rw [← hLYfun, ← hRXfun]
   exact hmixed
 
 end Complete
@@ -223,8 +214,18 @@ theorem mlieBracket_mulRightInvariantVectorField_mulInvariantVectorField
       (by simp)).mdifferentiableAt
     ((contMDiff_mulInvariantVectorField_infty Y).mdifferentiable
       (by simp)).mdifferentiableAt]
-  exact sub_eq_zero.mpr
-    (mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute f g X Y)
+  have hcomm :=
+    mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute f g X Y
+  have hLY : (fun y => mvfderiv I f y (mulInvariantVectorField Y y)) =
+      tangentToLeftInvariantDerivation Y f := by
+    funext y
+    exact (tangentToLeftInvariantDerivation_apply Y f y).symm
+  have hRX : (fun y => mvfderiv I f y (mulRightInvariantVectorField X y)) =
+      rightInvariantDerivative X f := by
+    funext y
+    exact (rightInvariantDerivative_apply X f y).symm
+  rw [hLY, hRX]
+  exact sub_eq_zero.mpr hcomm
 
 /-- Left- and right-invariant vector fields commute everywhere, with the bracket arguments in the
 opposite order. -/

--- a/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
@@ -36,6 +36,7 @@ This supplies a prerequisite for Deliverable A, Layer 1 of
 * `contMDiff_mulRightInvariantVectorField_infty`: a right-invariant field is smooth.
 * `contMDiff_mvfderiv_mulRightInvariantVectorField`: differentiating a smooth scalar function
   along a right-invariant field gives a smooth function.
+* `rightInvariantDerivative`: right-invariant differentiation bundled as a smooth scalar function.
 
 ## References
 
@@ -199,3 +200,20 @@ theorem contMDiff_mvfderiv_mulRightInvariantVectorField
       (fun g ↦ mvfderiv I f g (mulRightInvariantVectorField v g)) :=
   f.contMDiff.contMDiff_mvfderiv_apply
     (contMDiff_mulRightInvariantVectorField_infty v) (by simp)
+
+/-- Right-invariant differentiation of a smooth scalar function, bundled as a smooth scalar
+function. -/
+noncomputable def rightInvariantDerivative
+    [ContMDiffMul I ∞ G] (v : GroupLieAlgebra I G)
+    (f : C^∞⟮I, G; 𝕜⟯) : C^∞⟮I, G; 𝕜⟯ :=
+  ⟨fun g => mvfderiv I f g (mulRightInvariantVectorField v g),
+    contMDiff_mvfderiv_mulRightInvariantVectorField v f⟩
+
+/-- Right-invariant differentiation acts pointwise along the corresponding vector field. -/
+@[simp]
+theorem rightInvariantDerivative_apply
+    [ContMDiffMul I ∞ G] (v : GroupLieAlgebra I G)
+    (f : C^∞⟮I, G; 𝕜⟯) (g : G) :
+    rightInvariantDerivative v f g =
+      mvfderiv I f g (mulRightInvariantVectorField v g) :=
+  by simp only [rightInvariantDerivative, ContMDiffMap.coeFn_mk]

--- a/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
@@ -217,3 +217,13 @@ theorem rightInvariantDerivative_apply
     rightInvariantDerivative v f g =
       mvfderiv I f g (mulRightInvariantVectorField v g) :=
   by simp only [rightInvariantDerivative, ContMDiffMap.coeFn_mk]
+
+/-- The function underlying right-invariant differentiation. -/
+@[simp]
+theorem rightInvariantDerivative_coe
+    [ContMDiffMul I ∞ G] (v : GroupLieAlgebra I G)
+    (f : C^∞⟮I, G; 𝕜⟯) :
+    (rightInvariantDerivative v f : G → 𝕜) =
+      fun g => mvfderiv I f g (mulRightInvariantVectorField v g) := by
+  funext g
+  exact rightInvariantDerivative_apply v f g

--- a/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
@@ -217,13 +217,3 @@ theorem rightInvariantDerivative_apply
     rightInvariantDerivative v f g =
       mvfderiv I f g (mulRightInvariantVectorField v g) :=
   by simp only [rightInvariantDerivative, ContMDiffMap.coeFn_mk]
-
-/-- The function underlying right-invariant differentiation. -/
-@[simp]
-theorem rightInvariantDerivative_coe
-    [ContMDiffMul I ∞ G] (v : GroupLieAlgebra I G)
-    (f : C^∞⟮I, G; 𝕜⟯) :
-    (rightInvariantDerivative v f : G → 𝕜) =
-      fun g => mvfderiv I f g (mulRightInvariantVectorField v g) := by
-  funext g
-  exact rightInvariantDerivative_apply v f g


### PR DESCRIPTION
## Goal

Establish the tangent-space form of the infinitesimal-adjoint identity: differentiating conjugation at the identity sends `X` and `Y` to Mathlib's `LieAlgebra.ad ℝ _ X Y`. This is the geometric prerequisite for transporting the result to the derivation-valued adjoint representation.

## Argument

1. Along `t ↦ exp(tX)`, infinitesimal conjugation acts on smooth scalar functions as `R_X - L_X`.
2. Left- and right-invariant differentiation commute, so differentiating this generator in the left-invariant `Y` direction reduces to `X(Yf) - Y(Xf)`, namely `[X, Y]f`.
3. Mixed-partial symmetry applies that scalar identity to the conjugated exponential variation. Pointed smooth functions separate tangent vectors, so the derivative of `tangentAd (exp(tX)) Y` at zero is `LieAlgebra.ad ℝ _ X Y`.
4. The existing exponential-line chain rule identifies the same path derivative with `mvfderiv` of `tangentAd` at the identity.

The analytic and manifold-calculus helpers remain private; the public surface is the reusable path derivative and its identity-at-the-group-unit differential corollary.

This advances [Deliverable A, Layer 1, "The infinitesimal adjoint"](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-1-the-adjoint-representations-ad-and-ad).

## Verification

- `bash scripts/sandbox-build.sh`
- Independent full-file policy, atomicity, reuse, API, placement, naming, and proof-quality audit: no findings

Roadmap: RepresentationTheory
