### PR TITLE
feat: reconstruct points from tensor automorphisms

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Reconstruction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Reconstruction.lean
@@ -91,35 +91,30 @@ noncomputable def reconstructedPoint
   toConv (AlgHom.ofLinearMap (globalFunctional k H A η)
     (globalFunctional_one k H A η) (globalFunctional_mul k H A η))
 
-private theorem reconstructedPoint_ofConv
-    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) :
-    (reconstructedPoint k H A η).ofConv =
-      AlgHom.ofLinearMap (globalFunctional k H A η)
-        (globalFunctional_one k H A η) (globalFunctional_mul k H A η) :=
-  (rfl)
-
 /-- The reconstructed point evaluates as its defining global functional. -/
 @[simp]
 theorem reconstructedPoint_apply
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) (x : H) :
     (reconstructedPoint k H A η).ofConv x = globalFunctional k H A η x := by
-  rw [reconstructedPoint_ofConv, AlgHom.ofLinearMap_apply]
+  rw [reconstructedPoint, WithConv.ofConv_toConv, AlgHom.ofLinearMap_apply]
+
+/-- The underlying linear map of the reconstructed point is the global functional. -/
+@[simp]
+theorem reconstructedPoint_toLinearMap
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) :
+    (reconstructedPoint k H A η).ofConv.toLinearMap = globalFunctional k H A η := by
+  ext x
+  exact reconstructedPoint_apply k H A η x
 
 /-- Reconstructing the tensor automorphism induced by an algebra-valued point returns that
 point. Thus reconstruction is a left inverse to the tensor action of points. -/
 @[simp]
 theorem reconstructedPoint_fgPointTensorIso (g : WithConv (H →ₐ[k] A)) :
     reconstructedPoint k H A (fgPointTensorIso k H A g) = g := by
-  have h : reconstructedPoint k H A (fgPointTensorIsoHom k H A g) = g := by
-    apply WithConv.ofConv_injective
-    apply AlgHom.toLinearMap_injective
-    rw [reconstructedPoint_ofConv, AlgHom.toLinearMap_ofLinearMap,
-      fgPointTensorIsoHom_apply, globalFunctional_fgPointTensorIso]
-  simpa only [fgPointTensorIsoHom_apply] using h
-
-/-- Reconstructing points is a left inverse to their action by tensor automorphisms. -/
-theorem reconstructedPoint_leftInverse :
-    Function.LeftInverse (reconstructedPoint k H A) (fgPointTensorIso k H A) :=
-  reconstructedPoint_fgPointTensorIso k H A
+  apply WithConv.ofConv_injective
+  apply AlgHom.toLinearMap_injective
+  rw [← fgPointTensorIsoHom_apply]
+  rw [reconstructedPoint_toLinearMap, fgPointTensorIsoHom_apply,
+    globalFunctional_fgPointTensorIso]
 
 end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Reconstruction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Reconstruction.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.GlobalFunctional
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.Multiplication
+
+/-!
+# Reconstructing algebra-valued points from tensor automorphisms
+
+Let `H` be a commutative Hopf algebra over a field `k`, and let `A` be a commutative
+`k`-algebra. A tensor automorphism of scalar extension on the finite-dimensional
+`H`-comodules determines a linear functional `H → A`. Tensor compatibility makes this
+functional multiplicative, while compatibility with the tensor unit makes it preserve one.
+It therefore defines an `A`-valued point of the affine group represented by `H`.
+
+This file packages that reconstructed point and proves that reconstructing the tensor
+automorphism induced by a point returns the original point. The converse equality, that the
+reconstructed point induces the original component on every finite comodule, requires the
+matrix-coefficient separation argument developed separately.
+
+## Main declarations
+
+* `TauCeti.Tannaka.globalFunctional_mul`: the glued functional preserves multiplication.
+* `TauCeti.Tannaka.reconstructedPoint`: the algebra-valued point reconstructed from a tensor
+  automorphism.
+* `TauCeti.Tannaka.reconstructedPoint_fgPointTensorIso`: reconstruction recovers every
+  algebra-valued point.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §9.4.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.Tannaka
+
+universe u
+
+variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
+  [CommRing A] [Algebra k A]
+
+/-- The global functional reconstructed from a tensor automorphism preserves multiplication. -/
+@[simp high]
+theorem globalFunctional_mul
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) (x y : H) :
+    globalFunctional k H A η (x * y) =
+      globalFunctional k H A η x * globalFunctional k H A η y := by
+  obtain ⟨N, hNfinite, hx⟩ :=
+    Subcomodule.exists_finite_subcomodule_mem (R := k) (C := H) (M := H) x
+  obtain ⟨P, hPfinite, hy⟩ :=
+    Subcomodule.exists_finite_subcomodule_mem (R := k) (C := H) (M := H) y
+  let N' : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H) :=
+    ⟨N, Subcomodule.mem_finiteSubcomodules.mpr hNfinite⟩
+  let P' : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H) :=
+    ⟨P, Subcomodule.mem_finiteSubcomodules.mpr hPfinite⟩
+  let _ : Module.Finite k N'.1.toSubmodule :=
+    Subcomodule.mem_finiteSubcomodules.mp N'.2
+  let _ : Module.Finite k P'.1.toSubmodule :=
+    Subcomodule.mem_finiteSubcomodules.mp P'.2
+  obtain ⟨Q, hQfinite, hmul⟩ :=
+    Subcomodule.exists_finite_mul_le N'.1.toSubmodule P'.1.toSubmodule
+  let Q' : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H) :=
+    ⟨Q, Subcomodule.mem_finiteSubcomodules.mpr hQfinite⟩
+  let xn : N'.1 := ⟨x, hx⟩
+  let yp : P'.1 := ⟨y, hy⟩
+  have hxy : x * y ∈ Q'.1 := hmul xn yp
+  have hlocal := localFunctional_mul k H A η N' P' Q' hmul xn yp
+  calc
+    globalFunctional k H A η (x * y) =
+        globalFunctional k H A η (⟨x * y, hxy⟩ : Q'.1) :=
+      congrArg (globalFunctional k H A η) (Subtype.coe_mk (x * y) hxy).symm
+    _ = localFunctional k H A η Q' ⟨x * y, hxy⟩ :=
+      globalFunctional_apply k H A η Q' ⟨x * y, hxy⟩
+    _ = localFunctional k H A η N' xn * localFunctional k H A η P' yp :=
+      by simpa only [xn, yp] using hlocal
+    _ = globalFunctional k H A η x * globalFunctional k H A η y := by
+      rw [← globalFunctional_apply k H A η N' xn,
+        ← globalFunctional_apply k H A η P' yp]
+
+/-- The algebra-valued point reconstructed from a tensor automorphism of finite-comodule
+scalar extension. Its underlying map is the global functional extracted from the automorphism. -/
+noncomputable def reconstructedPoint
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) :
+    WithConv (H →ₐ[k] A) :=
+  toConv (AlgHom.ofLinearMap (globalFunctional k H A η)
+    (globalFunctional_one k H A η) (globalFunctional_mul k H A η))
+
+/-- Forgetting the convolution wrapper from the reconstructed point gives the algebra
+homomorphism built from the global functional. -/
+@[simp]
+theorem reconstructedPoint_ofConv
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) :
+    (reconstructedPoint k H A η).ofConv =
+      AlgHom.ofLinearMap (globalFunctional k H A η)
+        (globalFunctional_one k H A η) (globalFunctional_mul k H A η) :=
+  (rfl)
+
+/-- Reconstructing the tensor automorphism induced by an algebra-valued point returns that
+point. Thus reconstruction is a left inverse to the tensor action of points. -/
+@[simp]
+theorem reconstructedPoint_fgPointTensorIso (g : WithConv (H →ₐ[k] A)) :
+    reconstructedPoint k H A (fgPointTensorIso k H A g) = g := by
+  have h : reconstructedPoint k H A (fgPointTensorIsoHom k H A g) = g := by
+    apply WithConv.ofConv_injective
+    apply AlgHom.toLinearMap_injective
+    rw [reconstructedPoint_ofConv, AlgHom.toLinearMap_ofLinearMap,
+      fgPointTensorIsoHom_apply, globalFunctional_fgPointTensorIso]
+  simpa only [fgPointTensorIsoHom_apply] using h
+
+/-- Reconstructing points is a left inverse to their action by tensor automorphisms. -/
+theorem reconstructedPoint_leftInverse :
+    Function.LeftInverse (reconstructedPoint k H A) (fgPointTensorIso k H A) :=
+  reconstructedPoint_fgPointTensorIso k H A
+
+end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Reconstruction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Reconstruction.lean
@@ -91,15 +91,19 @@ noncomputable def reconstructedPoint
   toConv (AlgHom.ofLinearMap (globalFunctional k H A η)
     (globalFunctional_one k H A η) (globalFunctional_mul k H A η))
 
-/-- Forgetting the convolution wrapper from the reconstructed point gives the algebra
-homomorphism built from the global functional. -/
-@[simp]
-theorem reconstructedPoint_ofConv
+private theorem reconstructedPoint_ofConv
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) :
     (reconstructedPoint k H A η).ofConv =
       AlgHom.ofLinearMap (globalFunctional k H A η)
         (globalFunctional_one k H A η) (globalFunctional_mul k H A η) :=
   (rfl)
+
+/-- The reconstructed point evaluates as its defining global functional. -/
+@[simp]
+theorem reconstructedPoint_apply
+    (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) (x : H) :
+    (reconstructedPoint k H A η).ofConv x = globalFunctional k H A η x := by
+  rw [reconstructedPoint_ofConv, AlgHom.ofLinearMap_apply]
 
 /-- Reconstructing the tensor automorphism induced by an algebra-valued point returns that
 point. Thus reconstruction is a left inverse to the tensor action of points. -/


### PR DESCRIPTION
This PR reconstructs an algebra-valued point from a tensor automorphism of scalar extension on finite comodules. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1 milestone **“Tannakian reconstruction: recover `G` from its tensor category of representations”**, specifically the step that upgrades the landed glued functional to a point of the affine group. After this PR, the milestone still needs the componentwise right-inverse theorem using the matrix-coefficient morphisms in open PR #2771, followed by packaging the two inverse maps as the Tannakian equivalence.

This is the most effective current critical-path step because the compatible local functionals, their global gluing, and their tensor-unit and local multiplication laws are all on `main`, while #2771 owns the distinct matrix-coefficient separation bridge. Prove `globalFunctional_mul` by placing two elements and all their products in finite regular subcomodules, then use `AlgHom.ofLinearMap` with the landed unit law to define `reconstructedPoint`. Finally prove that reconstruction returns every original algebra-valued point, giving the left-inverse half of the desired correspondence without overlapping the in-flight right-inverse work.

Add `TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Reconstruction.lean` (121 lines). The module exposes the global multiplication law, the reconstructed convolution-valued point with its characteristic underlying-algebra-homomorphism theorem, and the point-recovery/left-inverse theorems. It reuses `Subcomodule.exists_finite_mul_le`, `localFunctional_mul`, `globalFunctional_one`, `globalFunctional_fgPointTensorIso`, and Mathlib's `AlgHom.ofLinearMap`; no Mathlib infrastructure is vendored. The mathematical construction follows J. S. Milne, *Algebraic Groups* (2017), §9.4, as cited in the module documentation. Exact-name and concept searches over pinned Mathlib and Tau Ceti found no existing reconstruction map.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tannaka-reconstructed-point"}-->

🤖 Prepared with Codex
