### PR TITLE
fix: align merge workflow engine refs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -67,7 +67,7 @@ jobs:
     uses: TauCetiProject/TauCetiReview/.github/workflows/merge-only.yml@a66b04d97721565b13c8abe07f750fb1d2959ad5
     with:
       pr: ${{ needs.resolve.outputs.pr }}
-      review_ref: eeed9637d7e2af319a04de8120b35f0c52318f0d
+      review_ref: a66b04d97721565b13c8abe07f750fb1d2959ad5
     # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.
     secrets:
       APP_ID: ${{ secrets.APP_ID }}

--- a/.github/workflows/merge-sweep.yml
+++ b/.github/workflows/merge-sweep.yml
@@ -35,7 +35,7 @@ jobs:
     uses: TauCetiProject/TauCetiReview/.github/workflows/merge-sweep.yml@a66b04d97721565b13c8abe07f750fb1d2959ad5
     with:
       dry_run: ${{ inputs.dry-run || false }}
-      review_ref: eeed9637d7e2af319a04de8120b35f0c52318f0d
+      review_ref: a66b04d97721565b13c8abe07f750fb1d2959ad5
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## What changed

Update the `review_ref` passed by both merge entrypoints to the same immutable TauCetiReview commit already used for their reusable workflows.

## Why

TauCetiReview commit `a66b04d` added merge-queue reservation logic. The callers already invoke the reusable workflows at that commit, but they still check out engine commit `eeed9637`, which predates `runner/queue_reservation.py`. As a result, every otherwise-green auto-merge run fails before enqueueing; #2841 exposed the failure in run 31529253831.

Keeping the workflow ref and engine checkout on `a66b04d` restores the required runner file for both event-driven auto-merge and scheduled merge sweeps. This intentionally touches human-owned workflow files and therefore requires human review.

## Validation

- `actionlint .github/workflows/auto-merge.yml .github/workflows/merge-sweep.yml`
- `git diff --check`
- verified immutable TauCetiReview tree `a66b04d` contains both reusable workflows plus `runner/queue_reservation.py`, `runner/merge_from_scoreboard.py`, and `runner/sweep.py`

Roadmap: none