### PR TITLE
refactor: share product-model smoothness

### DIFF
--- a/TauCeti/Geometry/Lie/Exponential/Derivative/Basic.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Derivative/Basic.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.Geometry.Lie.Exponential.Smoothness
 public import TauCeti.Geometry.Lie.RightInvariantVectorField
 import TauCeti.Geometry.Lie.Interior
+import TauCeti.Geometry.Manifold.ContMDiff.Prod
 
 /-!
 # Derivative of the Lie-group exponential
@@ -25,6 +26,8 @@ calculation supplies reusable chain rules for functions along translated exponen
 * `hasFDerivAt_extChartAt_lieExp_zero`: the identity-chart derivative of the derivation-based
   exponential is the canonical linear isometry to the model space.
 * `contMDiff_mulInvariantExp_smul`: an exponential line is smooth.
+* `contMDiff_mulInvariantExp_smul_mul_mul_mulInvariantExp_smul`: two exponential lines multiplied
+  around a fixed group element give a smooth two-parameter map.
 * `hasMFDerivAt_mulInvariantExp_smul_zero`: an exponential line has its generator as initial
   velocity.
 * `HasMFDerivAt.hasDerivAt_comp_mulInvariantExp_smul_zero`: the chain rule along an exponential
@@ -77,6 +80,24 @@ theorem contMDiff_mulInvariantExp_smul (X : GroupLieAlgebra I G) :
   dsimp only
   simpa only [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul] using
     contMDiff_mulInvariantOneParameterSubgroup (I := I) (G := G) X
+
+/-- Two exponential lines multiplied around a fixed group element give a smooth two-parameter
+map. -/
+theorem contMDiff_mulInvariantExp_smul_mul_mul_mulInvariantExp_smul
+    (g : G) (X Y : GroupLieAlgebra I G) :
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+    ContMDiff 𝓘(ℝ, ℝ × ℝ) I ∞ (fun p : ℝ × ℝ =>
+      mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
+        mulInvariantExp (I := I) (G := G) (p.2 • Y)) := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
+  have hX := contMDiff_mulInvariantExp_smul (I := I) (G := G) X
+  have hY := contMDiff_mulInvariantExp_smul (I := I) (G := G) Y
+  have hprod : ContMDiff (𝓘(ℝ, ℝ).prod 𝓘(ℝ, ℝ)) I ∞ (fun p : ℝ × ℝ =>
+      mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
+        mulInvariantExp (I := I) (G := G) (p.2 • Y)) :=
+    ((hX.comp contMDiff_fst).mul contMDiff_const).mul (hY.comp contMDiff_snd)
+  exact (contMDiff_prod_modelWithCornersSelf_iff (I' := I)).mp hprod
 
 end Smoothness
 

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -5,9 +5,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 import TauCeti.Analysis.Calculus.ParametricFDeriv
+public import TauCeti.Geometry.Lie.Exponential.Basic
 import TauCeti.Geometry.Lie.Exponential.Derivative.Basic
 public import TauCeti.Geometry.Lie.RightInvariantVectorField
 public import TauCeti.Geometry.Manifold.VectorField.LieBracket
+import TauCeti.Geometry.Manifold.ContMDiff.Prod
 import TauCeti.Geometry.Lie.Interior
 
 /-!
@@ -62,27 +64,21 @@ variable [CompleteSpace E]
 
 /-- A smooth scalar function evaluated on two multiplied exponential lines is smooth in both
 parameters. -/
-private theorem contDiff_comp_mulInvariantExp_mul_mulInvariantExp
+theorem contDiff_comp_mulInvariantExp_mul_mulInvariantExp
+    [T2Space G] [BoundarylessManifold I G]
     {f : G → ℝ} (hf : ContMDiff I 𝓘(ℝ, ℝ) ∞ f) (g : G)
     (X Y : GroupLieAlgebra I G) :
-    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-    ContDiff ℝ 2 (fun p : ℝ × ℝ =>
+    ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
       f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
         mulInvariantExp (I := I) (G := G) (p.2 • Y))) := by
-  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-  dsimp only
   have hX := contMDiff_mulInvariantExp_smul (I := I) (G := G) X
   have hY := contMDiff_mulInvariantExp_smul (I := I) (G := G) Y
   have hMprod : ContMDiff (𝓘(ℝ, ℝ).prod 𝓘(ℝ, ℝ)) I ∞ (fun p : ℝ × ℝ =>
       mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
         mulInvariantExp (I := I) (G := G) (p.2 • Y)) :=
     ((hX.comp contMDiff_fst).mul contMDiff_const).mul (hY.comp contMDiff_snd)
-  have hM : ContMDiff 𝓘(ℝ, ℝ × ℝ) I ∞ (fun p : ℝ × ℝ =>
-      mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
-        mulInvariantExp (I := I) (G := G) (p.2 • Y)) := by
-    rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
-    exact hMprod
-  exact (hf.comp hM).contDiff.of_le two_le_infinite_smoothness
+  have hM := hMprod.of_prod_modelWithCornersSelf
+  exact (hf.comp hM).contDiff
 
 private theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
     (f : C^∞⟮I, G; ℝ⟯) (g : G) (X Y : GroupLieAlgebra I G) (s : ℝ) :
@@ -99,7 +95,8 @@ private theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • Y))
   have hF : ContDiff ℝ 2 F :=
-    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y
+    (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
+      two_le_infinite_smoothness
   have hFdiff : DifferentiableAt ℝ F (s, 0) := hF.differentiable (by norm_num) (s, 0)
   have hslice : DifferentiableAt ℝ (fun t => F (s, t)) 0 :=
     hFdiff.comp 0 ((differentiableAt_const s).prodMk differentiableAt_id)
@@ -132,7 +129,8 @@ private theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • Y))
   have hF : ContDiff ℝ 2 F :=
-    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y
+    (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
+      two_le_infinite_smoothness
   have hFdiff : DifferentiableAt ℝ F (0, t) := hF.differentiable (by norm_num) (0, t)
   have hpartial := hasDerivAt_parameterCurve hFdiff
   have hfAt := f.contMDiff.mdifferentiable (by simp)
@@ -171,7 +169,8 @@ theorem mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute
     ⟨fun h => mvfderiv I f h (mulRightInvariantVectorField X h),
       contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
   have hF : ContDiff ℝ 2 F :=
-    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y
+    (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
+      two_le_infinite_smoothness
   -- Identify the two partial derivatives with the invariant directional derivatives.
   have hspaceFun : (fun s => spatialFDeriv F 0 s 1) =
       fun s => LYf (γX s * g) := by

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -24,6 +24,8 @@ This supplies a prerequisite for Deliverable A, Layer 1 of
 
 ## Main results
 
+* `contDiff_comp_mulInvariantExp_mul_mulInvariantExp`: evaluating a smooth scalar function on two
+  multiplied exponential lines gives a smooth two-parameter function.
 * `mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute`: left- and
   right-invariant scalar differentiation commute at every group point.
 * `mlieBracket_mulRightInvariantVectorField_mulInvariantVectorField`: the corresponding
@@ -53,10 +55,6 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
-
-private theorem two_le_infinite_smoothness :
-    ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) :=
-  WithTop.coe_le_coe.mpr le_top
 
 section Complete
 
@@ -96,7 +94,7 @@ private theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
       mulInvariantExp (I := I) (G := G) (p.2 • Y))
   have hF : ContDiff ℝ 2 F :=
     (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
-      two_le_infinite_smoothness
+      (ENat.natCast_le_of_coe_top_le_withTop le_rfl 2)
   have hFdiff : DifferentiableAt ℝ F (s, 0) := hF.differentiable (by norm_num) (s, 0)
   have hslice : DifferentiableAt ℝ (fun t => F (s, t)) 0 :=
     hFdiff.comp 0 ((differentiableAt_const s).prodMk differentiableAt_id)
@@ -130,7 +128,7 @@ private theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
       mulInvariantExp (I := I) (G := G) (p.2 • Y))
   have hF : ContDiff ℝ 2 F :=
     (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
-      two_le_infinite_smoothness
+      (ENat.natCast_le_of_coe_top_le_withTop le_rfl 2)
   have hFdiff : DifferentiableAt ℝ F (0, t) := hF.differentiable (by norm_num) (0, t)
   have hpartial := hasDerivAt_parameterCurve hFdiff
   have hfAt := f.contMDiff.mdifferentiable (by simp)
@@ -170,7 +168,7 @@ theorem mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute
       contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
   have hF : ContDiff ℝ 2 F :=
     (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
-      two_le_infinite_smoothness
+      (ENat.natCast_le_of_coe_top_le_withTop le_rfl 2)
   -- Identify the two partial derivatives with the invariant directional derivatives.
   have hspaceFun : (fun s => spatialFDeriv F 0 s 1) =
       fun s => LYf (γX s * g) := by
@@ -220,7 +218,7 @@ theorem mlieBracket_mulRightInvariantVectorField_mulInvariantVectorField
     (V := mulRightInvariantVectorField X)
     (W := mulInvariantVectorField Y)
     (x := g)
-    (f.contMDiff.contMDiffAt.of_le two_le_infinite_smoothness)
+    (f.contMDiff.contMDiffAt.of_le (ENat.natCast_le_of_coe_top_le_withTop le_rfl 2))
     (by simp)
     ((contMDiff_mulRightInvariantVectorField_infty X).mdifferentiable
       (by simp)).mdifferentiableAt

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -5,11 +5,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 import TauCeti.Analysis.Calculus.ParametricFDeriv
-public import TauCeti.Geometry.Lie.Exponential.Basic
 import TauCeti.Geometry.Lie.Exponential.Derivative.Basic
 public import TauCeti.Geometry.Lie.RightInvariantVectorField
 public import TauCeti.Geometry.Manifold.VectorField.LieBracket
-import TauCeti.Geometry.Manifold.ContMDiff.Prod
 import TauCeti.Geometry.Lie.Interior
 
 /-!
@@ -24,8 +22,6 @@ This supplies a prerequisite for Deliverable A, Layer 1 of
 
 ## Main results
 
-* `contDiff_comp_mulInvariantExp_mul_mulInvariantExp`: evaluating a smooth scalar function on two
-  multiplied exponential lines gives a smooth two-parameter function.
 * `mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute`: left- and
   right-invariant scalar differentiation commute at every group point.
 * `mlieBracket_mulRightInvariantVectorField_mulInvariantVectorField`: the corresponding
@@ -56,27 +52,27 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
 
+private theorem two_le_infinite_smoothness :
+    ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) :=
+  ENat.natCast_le_of_coe_top_le_withTop le_rfl 2
+
 section Complete
 
 variable [CompleteSpace E]
 
-/-- A smooth scalar function evaluated on two multiplied exponential lines is smooth in both
-parameters. -/
-theorem contDiff_comp_mulInvariantExp_mul_mulInvariantExp
-    [T2Space G] [BoundarylessManifold I G]
+/-- A smooth scalar function evaluated on two exponential lines multiplied around a fixed group
+element is smooth in both parameters. -/
+private theorem contDiff_comp_mulInvariantExp_mul_mulInvariantExp
     {f : G → ℝ} (hf : ContMDiff I 𝓘(ℝ, ℝ) ∞ f) (g : G)
     (X Y : GroupLieAlgebra I G) :
-    ContDiff ℝ ∞ (fun p : ℝ × ℝ =>
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+    ContDiff ℝ 2 (fun p : ℝ × ℝ =>
       f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
         mulInvariantExp (I := I) (G := G) (p.2 • Y))) := by
-  have hX := contMDiff_mulInvariantExp_smul (I := I) (G := G) X
-  have hY := contMDiff_mulInvariantExp_smul (I := I) (G := G) Y
-  have hMprod : ContMDiff (𝓘(ℝ, ℝ).prod 𝓘(ℝ, ℝ)) I ∞ (fun p : ℝ × ℝ =>
-      mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
-        mulInvariantExp (I := I) (G := G) (p.2 • Y)) :=
-    ((hX.comp contMDiff_fst).mul contMDiff_const).mul (hY.comp contMDiff_snd)
-  have hM := hMprod.of_prod_modelWithCornersSelf
-  exact (hf.comp hM).contDiff
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
+  exact (hf.comp (contMDiff_mulInvariantExp_smul_mul_mul_mulInvariantExp_smul g X Y)).contDiff.of_le
+    two_le_infinite_smoothness
 
 private theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
     (f : C^∞⟮I, G; ℝ⟯) (g : G) (X Y : GroupLieAlgebra I G) (s : ℝ) :
@@ -93,8 +89,7 @@ private theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • Y))
   have hF : ContDiff ℝ 2 F :=
-    (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
-      (ENat.natCast_le_of_coe_top_le_withTop le_rfl 2)
+    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y
   have hFdiff : DifferentiableAt ℝ F (s, 0) := hF.differentiable (by norm_num) (s, 0)
   have hslice : DifferentiableAt ℝ (fun t => F (s, t)) 0 :=
     hFdiff.comp 0 ((differentiableAt_const s).prodMk differentiableAt_id)
@@ -127,8 +122,7 @@ private theorem timeFDeriv_mulInvariantExp_mul_mulInvariantExp
     f (mulInvariantExp (I := I) (G := G) (p.1 • X) * g *
       mulInvariantExp (I := I) (G := G) (p.2 • Y))
   have hF : ContDiff ℝ 2 F :=
-    (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
-      (ENat.natCast_le_of_coe_top_le_withTop le_rfl 2)
+    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y
   have hFdiff : DifferentiableAt ℝ F (0, t) := hF.differentiable (by norm_num) (0, t)
   have hpartial := hasDerivAt_parameterCurve hFdiff
   have hfAt := f.contMDiff.mdifferentiable (by simp)
@@ -167,8 +161,7 @@ theorem mvfderiv_mulRightInvariantVectorField_mulInvariantVectorField_commute
     ⟨fun h => mvfderiv I f h (mulRightInvariantVectorField X h),
       contMDiff_mvfderiv_mulRightInvariantVectorField X f⟩
   have hF : ContDiff ℝ 2 F :=
-    (contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y).of_le
-      (ENat.natCast_le_of_coe_top_le_withTop le_rfl 2)
+    contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y
   -- Identify the two partial derivatives with the invariant directional derivatives.
   have hspaceFun : (fun s => spatialFDeriv F 0 s 1) =
       fun s => LYf (γX s * g) := by
@@ -218,7 +211,7 @@ theorem mlieBracket_mulRightInvariantVectorField_mulInvariantVectorField
     (V := mulRightInvariantVectorField X)
     (W := mulInvariantVectorField Y)
     (x := g)
-    (f.contMDiff.contMDiffAt.of_le (ENat.natCast_le_of_coe_top_le_withTop le_rfl 2))
+    (f.contMDiff.contMDiffAt.of_le two_le_infinite_smoothness)
     (by simp)
     ((contMDiff_mulRightInvariantVectorField_infty X).mdifferentiable
       (by simp)).mdifferentiableAt

--- a/TauCeti/Geometry/Manifold/ContMDiff/Prod.lean
+++ b/TauCeti/Geometry/Manifold/ContMDiff/Prod.lean
@@ -4,13 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Geometry.Manifold.ContMDiff.Constructions
+public import Mathlib.Geometry.Manifold.ContMDiff.Defs
 
 /-!
 # Smooth maps from product model spaces
 
 Mathlib equips a product of model vector spaces both with the product of their self-models and
-with the self-model of the product. This file provides the smoothness bridge between those
+with the self-model of the product. This file provides the `C^n` bridge between those
 definitionally distinct presentations.
 
 This supplies reusable two-parameter calculus infrastructure for Deliverable A, Layer 1 of
@@ -18,8 +18,8 @@ This supplies reusable two-parameter calculus infrastructure for Deliverable A, 
 
 ## Main result
 
-* `ContMDiff.of_prod_modelWithCornersSelf`: reinterpret a smooth map from a product of self-models
-  as a smooth map from the self-model of the product.
+* `contMDiff_prod_modelWithCornersSelf_iff`: a map from a product of model vector spaces is `C^n`
+  for the product of the self-models if and only if it is `C^n` for the self-model of the product.
 
 ## References
 
@@ -39,10 +39,9 @@ variable {𝕜 E₁ E₂ E' H' M : Type*} [NontriviallyNormedField 𝕜]
   [TopologicalSpace M] [ChartedSpace H' M]
   {n : WithTop ℕ∞} {f : E₁ × E₂ → M}
 
-/-- Reinterpret a smooth map from the product of two self-models as a smooth map from the
-self-model of the product. -/
-theorem ContMDiff.of_prod_modelWithCornersSelf
-    (hf : ContMDiff (𝓘(𝕜, E₁).prod 𝓘(𝕜, E₂)) I' n f) :
-    ContMDiff 𝓘(𝕜, E₁ × E₂) I' n f := by
+/-- A map from a product of model vector spaces is `C^n` for the product of the self-models if and
+only if it is `C^n` for the self-model of the product. -/
+theorem contMDiff_prod_modelWithCornersSelf_iff :
+    ContMDiff (𝓘(𝕜, E₁).prod 𝓘(𝕜, E₂)) I' n f ↔
+      ContMDiff 𝓘(𝕜, E₁ × E₂) I' n f := by
   rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
-  exact hf

--- a/TauCeti/Geometry/Manifold/ContMDiff/Prod.lean
+++ b/TauCeti/Geometry/Manifold/ContMDiff/Prod.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.ContMDiff.Constructions
+
+/-!
+# Smooth maps from product model spaces
+
+Mathlib equips a product of model vector spaces both with the product of their self-models and
+with the self-model of the product. This file provides the smoothness bridge between those
+definitionally distinct presentations.
+
+This supplies reusable two-parameter calculus infrastructure for Deliverable A, Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
+
+## Main result
+
+* `ContMDiff.of_prod_modelWithCornersSelf`: reinterpret a smooth map from a product of self-models
+  as a smooth map from the self-model of the product.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The infinitesimal adjoint".
+-/
+
+public section
+
+open scoped Manifold
+
+variable {𝕜 E₁ E₂ E' H' M : Type*} [NontriviallyNormedField 𝕜]
+  [NormedAddCommGroup E₁] [NormedSpace 𝕜 E₁]
+  [NormedAddCommGroup E₂] [NormedSpace 𝕜 E₂]
+  [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  [TopologicalSpace H'] {I' : ModelWithCorners 𝕜 E' H'}
+  [TopologicalSpace M] [ChartedSpace H' M]
+  {n : WithTop ℕ∞} {f : E₁ × E₂ → M}
+
+/-- Reinterpret a smooth map from the product of two self-models as a smooth map from the
+self-model of the product. -/
+theorem ContMDiff.of_prod_modelWithCornersSelf
+    (hf : ContMDiff (𝓘(𝕜, E₁).prod 𝓘(𝕜, E₂)) I' n f) :
+    ContMDiff 𝓘(𝕜, E₁ × E₂) I' n f := by
+  rw [modelWithCornersSelf_prod, ← chartedSpaceSelf_prod]
+  exact hf


### PR DESCRIPTION
## Goal

Package the product-domain model conversion and the two-exponential manifold map that invariant-field arguments repeatedly reconstruct. This is a prerequisite for identifying the infinitesimal adjoint in Deliverable A, Layer 1.

## Correctness

- `contMDiff_prod_modelWithCornersSelf_iff` changes only between Mathlib’s equivalent product self-model presentations, at arbitrary `C^n` regularity.
- `contMDiff_mulInvariantExp_smul_mul_mul_mulInvariantExp_smul` combines two smooth exponential lines with multiplication around a fixed group element.
- Existing scalar `C²` consumers compose the general manifold map with their smooth function and specialize using one named smoothness-order bound.

## Impact

The public iff removes duplicated model-with-corners rewrites, while the group-valued exponential-product theorem lets future consumers compose with any smooth codomain map. The specialized scalar composition remains private to the commutation proof. No existing mathematical result changes.

## Validation

- `lake build TauCeti.Geometry.Manifold.ContMDiff.Prod TauCeti.Geometry.Lie.Exponential.Derivative.Basic`
- `lake build TauCeti.Geometry.Lie.InvariantVectorField.Commutation`
- `bash scripts/sandbox-build.sh` (7,502 jobs, axioms/module-system/docstring/lint checks green)
- Independent atomicity/API audit: KEEP

Roadmap target: https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#the-infinitesimal-adjoint

Roadmap: RepresentationTheory