### PR TITLE
refactor: expose the fixed-parameter derivative

### DIFF
--- a/TauCeti/Analysis/Calculus/ParametricFDeriv.lean
+++ b/TauCeti/Analysis/Calculus/ParametricFDeriv.lean
@@ -28,6 +28,8 @@ This supplies a prerequisite for Deliverable A, Layer 1 of
 
 * `hasDerivAt_parameterCurve`: the parameter velocity differentiates the corresponding parameter
   curve.
+* `hasFDerivAt_timeSlice`: the spatial Jacobian differentiates the corresponding fixed-parameter
+  slice.
 * `fderiv_timeSlice`: the derivative of a fixed-parameter slice is its spatial Jacobian.
 * `hasDerivAt_spatialFDeriv`: the spatial Jacobian differentiates to the spatial derivative of the
   parameter velocity.
@@ -115,12 +117,18 @@ theorem hasDerivAt_parameterCurve {F : 𝕜 × E → F'} {t : 𝕜} {x : E}
   simpa only [timeFDeriv_apply, Function.comp_def, ContinuousLinearMap.inl_apply] using
     hF.hasFDerivAt.comp_hasDerivAt t (hasFDerivAt_prodMk_left t x).hasDerivAt
 
+/-- The spatial Jacobian is the derivative of the fixed-parameter slice `fun y ↦ F (t, y)`. -/
+theorem hasFDerivAt_timeSlice {F : 𝕜 × E → F'} {t : 𝕜} {x : E}
+    (hF : DifferentiableAt 𝕜 F (t, x)) :
+    HasFDerivAt (fun y => F (t, y)) (spatialFDeriv F x t) x := by
+  rw [spatialFDeriv_def]
+  exact hF.hasFDerivAt.comp x (hasFDerivAt_prodMk_right t x)
+
 /-- The derivative of the fixed-parameter slice `fun y ↦ F (t, y)` is its spatial Jacobian. -/
 theorem fderiv_timeSlice {F : 𝕜 × E → F'} {t : 𝕜} {x : E}
     (hF : DifferentiableAt 𝕜 F (t, x)) :
-    fderiv 𝕜 (fun y => F (t, y)) x = spatialFDeriv F x t := by
-  rw [spatialFDeriv_def]
-  exact (hF.hasFDerivAt.comp x (hasFDerivAt_prodMk_right t x)).fderiv
+    fderiv 𝕜 (fun y => F (t, y)) x = spatialFDeriv F x t :=
+  (hasFDerivAt_timeSlice hF).fderiv
 
 private theorem hasDerivAt_spatialFDeriv_apply_mixed {F : 𝕜 × E → F'}
     {t : 𝕜} {x w : E} (hF : ContDiffAt 𝕜 (minSmoothness 𝕜 2) F (t, x)) :

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -91,10 +91,7 @@ private theorem spatialFDeriv_mulInvariantExp_mul_mulInvariantExp
   have hF : ContDiff ℝ 2 F :=
     contDiff_comp_mulInvariantExp_mul_mulInvariantExp f.contMDiff g X Y
   have hFdiff : DifferentiableAt ℝ F (s, 0) := hF.differentiable (by norm_num) (s, 0)
-  have hslice : DifferentiableAt ℝ (fun t => F (s, t)) 0 :=
-    hFdiff.comp 0 ((differentiableAt_const s).prodMk differentiableAt_id)
-  have hpartial := hslice.hasDerivAt
-  rw [← fderiv_apply_one_eq_deriv, fderiv_timeSlice hFdiff] at hpartial
+  have hpartial := (hasFDerivAt_timeSlice hFdiff).hasDerivAt
   have hfAt := f.contMDiff.mdifferentiable (by simp)
     (mulInvariantExp (I := I) (G := G) (s • X) * g) |>.hasMFDerivAt
   have hdirection := HasMFDerivAt.hasDerivAt_comp_mul_mulInvariantExp_smul_zero hfAt Y


### PR DESCRIPTION
## Goal

Expose the derivative witness for a fixed-parameter slice of a two-variable map, then use it in the invariant-vector-field calculation that previously rebuilt the same coordinate embedding by hand. This is reusable calculus infrastructure for Deliverable A, Layer 1.

## Correctness

- hasFDerivAt_timeSlice composes the full derivative witness with the canonical right product inclusion y maps to (t, y).
- fderiv_timeSlice is now the direct fderiv consequence of that stronger witness.
- The Commutation proof consumes the witness through HasFDerivAt.hasDerivAt, preserving its existing derivative identity.

## Impact

Callers can reuse the full derivative fact instead of reconstructing the fixed-parameter embedding. The existing fderiv theorem remains canonical and is proved from the stronger API; no compatibility alias or duplicate theorem is introduced.

## Validation

- lake env lean TauCeti/Analysis/Calculus/ParametricFDeriv.lean
- lake env lean TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
- bash scripts/sandbox-build.sh (7501 jobs, including axioms check)
- Atomicity audit: KEEP after splitting from the independent product-model smoothness work

Roadmap target: https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#the-infinitesimal-adjoint

Roadmap: RepresentationTheory