### PR TITLE
feat(Quadratic): the field norm on a quadratic number field, positive in the imaginary case

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -365,7 +365,7 @@ theorem exists_smul_quadraticTwistOf_trace_norm_eq {θ θ' : L}
     ∃ C : VariableChange K,
       C • E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)
         = E.quadraticTwistOf (Algebra.trace K L θ') (Algebra.norm K θ') := by
-  obtain ⟨a, b, ha, rfl⟩ := exists_eq_algebraMap_add_algebraMap_mul K L hθ hθ'
+  obtain ⟨a, b, ha, rfl⟩ := exists_ne_zero_eq_algebraMap_add_algebraMap_mul K L hθ hθ'
   simp only [trace_algebraMap_add_algebraMap_mul K L a b θ,
     norm_algebraMap_add_algebraMap_mul K L a b θ]
   exact E.exists_smul_quadraticTwistOf_eq _ _ b (isUnit_iff_ne_zero.mpr ha)

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -15,25 +15,27 @@ order to *choose* and *change* a generator:
 
 `Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap`: a generator exists at all, so a
 construction over `L/K` may pick one.
-`Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul`: any two generators of a
-quadratic extension differ by `θ' = b + aθ` with `a ≠ 0`, so a statement proved for one generator
-transfers to every other. This is what makes a construction defined by "pick any `θ ∈ L ∖ K`"
-well posed up to the ambiguity that `b + aθ` describes.
-`linearIndependent_one_of_notMem_range_algebraMap` is the linear-algebra step behind the second.
+`Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul`: every element is `b + aθ`
+for a fixed generator `θ`, the coordinate presentation over the basis `1, θ` (used by the
+quadratic field-norm computation).
+`Algebra.IsQuadraticExtension.exists_ne_zero_eq_algebraMap_add_algebraMap_mul`: for a *second*
+generator the `θ`-coefficient is nonzero, so any two generators differ by `θ' = b + aθ` with
+`a ≠ 0` and a statement proved for one transfers to every other.
+`linearIndependent_one_of_notMem_range_algebraMap` is the linear-algebra step behind them.
 
-Two of the three ask for no field structure on `L`, and each is stated at the weakest level its
-proof supports. `Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap` needs only a
-*semiring*, the level Mathlib states `Algebra.IsQuadraticExtension` itself at, because it sees
-`L` only as a free `K`-module of rank two and derives nontriviality from that rank rather than
-assuming it. `linearIndependent_one_of_notMem_range_algebraMap` carries no rank hypothesis at
-all — its argument is just that `θ` is not a `K`-multiple of `1`, so it does ask for `L`
-nontrivial — but it stops at a *ring*, because the `LinearIndependent.pair_iff'` it applies is
-stated over an `AddCommGroup`. So both cover the split and non-reduced quadratic algebras
-`K × K` and `K[X]/(X²)`. Only `exists_eq_algebraMap_add_algebraMap_mul` asks for a field.
+None asks for a field on `L`, and each is stated at the weakest level its proof supports. The
+generator-existence and both coordinate theorems need only a *semiring* — the level Mathlib states
+`Algebra.IsQuadraticExtension` itself at — the ring structure the spanning needs being borrowed
+locally through `Algebra.semiringToRing`. `linearIndependent_one_of_notMem_range_algebraMap`
+carries no rank hypothesis at all — its argument is just that `θ` is not a `K`-multiple of `1`, so
+it asks for `L` nontrivial — but it stops at a *ring*, because the `LinearIndependent.pair_iff'`
+it applies is stated over an `AddCommGroup`. So all cover the split and non-reduced quadratic
+algebras `K × K` and `K[X]/(X²)`.
 
 These are consumed by the extension quadratic twist in
 `TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean`, which advances
-`TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists).
+`TauCetiRoadmap/EllipticCurves/README.md` §Layer 5 (twists), and by the quadratic field-norm
+computation in `TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean`.
 
 Adapted from the FLT project (`ImperialCollegeLondon/FLT`,
 `FLT/Mathlib/LinearAlgebra/Dimension/IsQuadraticExtension.lean` at the roadmap's pin
@@ -71,27 +73,36 @@ theorem Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap [Semiring L]
     Module.finrank_of_bijective_algebraMap ⟨FaithfulSMul.algebraMap_injective K L, h⟩
   omega
 
-variable [Field L] [Algebra K L] [Algebra.IsQuadraticExtension K L]
-
-namespace Algebra.IsQuadraticExtension
+/-- **Every element of a quadratic extension is `b + aθ`** for a fixed generator `θ`: the basis
+`1, θ` spans `L` over `K`. The `θ`-coefficient may vanish, exactly when the element lies in the
+base field; `exists_ne_zero_eq_algebraMap_add_algebraMap_mul` records that it does not for a second
+generator. The spanning is `K`-linear algebra, so this needs only a *semiring* on `L`. -/
+theorem Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul [Semiring L]
+    [Algebra K L] [Algebra.IsQuadraticExtension K L] {θ : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) (x : L) :
+    ∃ a b : K, x = algebraMap K L b + algebraMap K L a * θ := by
+  let _ : Ring L := Algebra.semiringToRing K
+  have h2 := Algebra.IsQuadraticExtension.finrank_eq_two K L
+  have : Nontrivial L := Module.nontrivial_of_finrank_pos (R := K) (by rw [h2]; norm_num)
+  have hli := linearIndependent_one_of_notMem_range_algebraMap K L hθ
+  have hmem : x ∈ Submodule.span K (Set.range ![(1 : L), θ]) := by
+    rw [hli.span_eq_top_of_card_eq_finrank (by rw [Fintype.card_fin]; exact h2.symm)]
+    trivial
+  rw [Matrix.range_cons_cons_empty, Submodule.mem_span_pair] at hmem
+  obtain ⟨c, d, hcd⟩ := hmem
+  exact ⟨d, c, by rw [← hcd, Algebra.smul_def, Algebra.smul_def, mul_one]⟩
 
 /-- Any element of a quadratic extension `L/K` is a `K`-linear combination of `1` and a given
 generator `θ`, and the `θ`-coefficient is nonzero if the element also lies outside `K`. So any
 two generators differ by `θ' = b + aθ` with `a ≠ 0`. -/
-theorem exists_eq_algebraMap_add_algebraMap_mul {θ θ' : L}
+theorem Algebra.IsQuadraticExtension.exists_ne_zero_eq_algebraMap_add_algebraMap_mul [Semiring L]
+    [Algebra K L] [Algebra.IsQuadraticExtension K L] {θ θ' : L}
     (hθ : θ ∉ Set.range (algebraMap K L)) (hθ' : θ' ∉ Set.range (algebraMap K L)) :
     ∃ a b : K, a ≠ 0 ∧ θ' = algebraMap K L b + algebraMap K L a * θ := by
-  have hli := linearIndependent_one_of_notMem_range_algebraMap K L hθ
-  have hmem : θ' ∈ Submodule.span K (Set.range ![(1 : L), θ]) := by
-    rw [hli.span_eq_top_of_card_eq_finrank
-      (by rw [Fintype.card_fin]; exact (finrank_eq_two K L).symm)]
-    trivial
-  rw [Matrix.range_cons_cons_empty, Submodule.mem_span_pair] at hmem
-  obtain ⟨c, d, hcd⟩ := hmem
-  refine ⟨d, c, fun hd ↦ hθ' ⟨c, ?_⟩, ?_⟩
-  · rw [← hcd, hd, zero_smul, add_zero, Algebra.algebraMap_eq_smul_one]
-  · rw [← hcd, Algebra.smul_def, Algebra.smul_def, mul_one]
-
-end Algebra.IsQuadraticExtension
+  obtain ⟨a, b, hab⟩ :=
+    Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul K L hθ θ'
+  refine ⟨a, b, ?_, hab⟩
+  rintro rfl
+  exact hθ' ⟨b, by rw [hab, map_zero, zero_mul, add_zero]⟩
 
 end

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -9,14 +9,16 @@ public import Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed
 public import Mathlib.RingTheory.Discriminant
 public import Mathlib.LinearAlgebra.Matrix.Notation
 public import TauCeti.FieldTheory.Trace
+import TauCeti.LinearAlgebra.Dimension.IsQuadraticExtension
 
 /-!
 # Basics for quadratic number fields
 
 Shared facts about a quadratic number field `K` presented by an algebraic integer `θ : 𝓞 K` whose
 minimal polynomial over `ℤ` is `X² - d`. These feed the prime-splitting law
-(`Quadratic/Splitting.lean`), the conjugation automorphism (`Quadratic/Conjugation/Basic.lean`), and
-the ring-of-integers/discriminant computation (`Quadratic/RingOfIntegers.lean`).
+(`Quadratic/Splitting.lean`), the conjugation automorphism (`Quadratic/Conjugation/Basic.lean`), the
+ring-of-integers/discriminant computation (`Quadratic/RingOfIntegers.lean`), and the field-norm
+computation (`Quadratic/Norm.lean`).
 
 ## Main results
 
@@ -25,6 +27,7 @@ the ring-of-integers/discriminant computation (`Quadratic/RingOfIntegers.lean`).
 * `TauCeti.NumberField.coe_gen_sq`: the generator squares to the radicand, `θ² = d` in `K`.
 * `TauCeti.NumberField.coe_gen_sq_ratCast`: the same over `ℚ`, `θ² = (d : ℚ)` in `K`.
 * `TauCeti.NumberField.gen_notMem_range`: the generator is not rational, `θ ∉ ℚ`.
+* `TauCeti.NumberField.exists_eq_add_mul_gen`: every element of `K` is `b + aθ`.
 * `TauCeti.NumberField.not_isSquare_radicand`: the radicand is not a rational square.
 * `TauCeti.NumberField.trace_gen_eq_zero`: the trace of the generator is `0`.
 * `TauCeti.NumberField.discr_one_gen`: the discriminant of `{1, θ}` over `ℚ` is `4d`.
@@ -91,6 +94,14 @@ theorem gen_notMem_range (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     simpa [natDegree_X_sub_C] using Polynomial.natDegree_le_of_dvd hdvd (X_sub_C_ne_zero q)
   rw [hq, minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C] at h1
   norm_num at h1
+
+/-- **Every element of a quadratic field is `b + aθ`** for rationals `a, b`. -/
+theorem exists_eq_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (x : K) :
+    ∃ a b : ℚ, x = algebraMap ℚ K b + algebraMap ℚ K a * (θ : K) := by
+  have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
+  exact Algebra.IsQuadraticExtension.exists_eq_algebraMap_add_algebraMap_mul ℚ K
+    (gen_notMem_range hmin) x
 
 /-- **The radicand of a quadratic presentation is not a rational square.** Were `d = q²`, the
 factorization `(θ - q)(θ + q) = θ² - d = 0` would force `θ = ±q ∈ ℚ`. -/

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.NumberField.Quadratic.Basic
+import TauCeti.RingTheory.Norm.Quadratic
+
+/-!
+# The field norm on a quadratic number field
+
+For a quadratic number field `K = ℚ(√d)` presented by an algebraic integer `θ : 𝓞 K` generating
+`K` over `ℚ` with `minpoly ℤ θ = X² - d`, this file computes the field norm `Algebra.norm ℚ` on
+`K` in terms of the coordinates in the basis `1, θ`:
+
+* `norm_gen_eq_neg_radicand`: the norm of the generator, `N(θ) = -d` (negative of the radicand);
+* `norm_add_mul_gen`: in the coordinates `x = b + aθ` the norm is `N(b + aθ) = b² - d·a²`;
+* `norm_pos_of_radicand_neg`: when `d < 0` — the imaginary quadratic case, where `K` is totally
+  complex — the norm is strictly positive on every nonzero element.
+
+The positivity is a descent input for the genus theory of the multiquadratic roadmap: for a
+norm-`±1` element `α` it upgrades `N(α) = ±1` to `N(α) = 1`, the hypothesis of Hilbert's
+Theorem 90 used to realise a `2`-torsion class by an ambiguous ideal.
+
+See D. A. Cox, *Primes of the Form x² + ny²*, and F. Lemmermeyer, *Reciprocity Laws*.
+-/
+
+public section
+
+open Polynomial NumberField
+
+namespace TauCeti.NumberField
+
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
+
+/-- **The norm of the generator is the negative of the radicand:** `N(θ) = -d`. It is the constant
+coefficient of the minimal polynomial `X² - d`, times the sign `(-1)^{[K:ℚ]} = +1`. -/
+@[simp] theorem norm_gen_eq_neg_radicand (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
+    Algebra.norm ℚ (θ : K) = -(d : ℚ) := by
+  have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
+  have hgen' : (PowerBasis.ofAdjoinEqTop' hint hgen).gen = (θ : K) :=
+    PowerBasis.ofAdjoinEqTop'_gen hint hgen
+  have hdim : (PowerBasis.ofAdjoinEqTop' hint hgen).dim = 2 := by
+    rw [← (PowerBasis.ofAdjoinEqTop' hint hgen).natDegree_minpoly, hgen',
+      minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C]
+  rw [← hgen', Algebra.PowerBasis.norm_gen_eq_coeff_zero_minpoly, hdim, hgen',
+    minpoly_rat_quadratic hmin]
+  simp [coeff_sub, coeff_X_pow]
+
+/-- **The norm in the basis `1, θ`:** `N(b + aθ) = b² - d·a²`. This is the generic quadratic norm
+formula with `Tr(θ) = 0` and `N(θ) = -d`. -/
+@[simp] theorem norm_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (a b : ℚ) :
+    Algebra.norm ℚ ((b : K) + (a : K) * (θ : K)) = b ^ 2 - (d : ℚ) * a ^ 2 := by
+  have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
+  rw [← eq_ratCast (algebraMap ℚ K) b, ← eq_ratCast (algebraMap ℚ K) a,
+    Algebra.IsQuadraticExtension.norm_algebraMap_add_algebraMap_mul, trace_gen_eq_zero hmin,
+    norm_gen_eq_neg_radicand hmin hgen]
+  ring
+
+/-- **The norm is positive in the imaginary case.** When `d < 0` the field `K = ℚ(√d)` is totally
+complex, and `N(b + aθ) = b² + |d|·a²`, so the norm is strictly positive on every nonzero element.
+This is the sign input that turns a norm-`±1` element into a norm-`1` one for Hilbert 90. -/
+theorem norm_pos_of_radicand_neg (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hd : d < 0) {x : K} (hx : x ≠ 0) :
+    0 < Algebra.norm ℚ x := by
+  obtain ⟨a, b, rfl⟩ := exists_eq_add_mul_gen hmin hgen x
+  simp only [eq_ratCast]
+  rw [norm_add_mul_gen hmin hgen]
+  have hdq : (d : ℚ) < 0 := by exact_mod_cast hd
+  have hab : a ≠ 0 ∨ b ≠ 0 := by
+    by_contra h
+    simp only [not_or, not_not] at h
+    exact hx (by rw [h.1, h.2]; simp)
+  rcases hab with ha | hb
+  · nlinarith [mul_self_pos.mpr ha, sq_nonneg b, sq_nonneg a]
+  · nlinarith [mul_self_pos.mpr hb, sq_nonneg a, sq_nonneg b]
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Norm.lean
@@ -49,14 +49,14 @@ coefficient of the minimal polynomial `X² - d`, times the sign `(-1)^{[K:ℚ]} 
     minpoly_rat_quadratic hmin]
   simp [coeff_sub, coeff_X_pow]
 
-/-- **The norm in the basis `1, θ`:** `N(b + aθ) = b² - d·a²`. This is the generic quadratic norm
-formula with `Tr(θ) = 0` and `N(θ) = -d`. -/
-@[simp] theorem norm_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+/-- **The norm in the basis `1, θ`:** `N(b + aθ) = b² - d·a²`, in the `algebraMap` presentation
+shared with `exists_eq_add_mul_gen` and `norm_algebraMap_add_algebraMap_mul`. This is the generic
+quadratic norm formula with `Tr(θ) = 0` and `N(θ) = -d`. -/
+theorem norm_add_mul_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (a b : ℚ) :
-    Algebra.norm ℚ ((b : K) + (a : K) * (θ : K)) = b ^ 2 - (d : ℚ) * a ^ 2 := by
+    Algebra.norm ℚ (algebraMap ℚ K b + algebraMap ℚ K a * (θ : K)) = b ^ 2 - (d : ℚ) * a ^ 2 := by
   have : Algebra.IsQuadraticExtension ℚ K := ⟨finrank_rat_eq_two hmin hgen⟩
-  rw [← eq_ratCast (algebraMap ℚ K) b, ← eq_ratCast (algebraMap ℚ K) a,
-    Algebra.IsQuadraticExtension.norm_algebraMap_add_algebraMap_mul, trace_gen_eq_zero hmin,
+  rw [Algebra.IsQuadraticExtension.norm_algebraMap_add_algebraMap_mul, trace_gen_eq_zero hmin,
     norm_gen_eq_neg_radicand hmin hgen]
   ring
 
@@ -67,7 +67,6 @@ theorem norm_pos_of_radicand_neg (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hd : d < 0) {x : K} (hx : x ≠ 0) :
     0 < Algebra.norm ℚ x := by
   obtain ⟨a, b, rfl⟩ := exists_eq_add_mul_gen hmin hgen x
-  simp only [eq_ratCast]
   rw [norm_add_mul_gen hmin hgen]
   have hdq : (d : ℚ) < 0 := by exact_mod_cast hd
   have hab : a ≠ 0 ∨ b ≠ 0 := by


### PR DESCRIPTION
For a quadratic number field `K = ℚ(√d)` with `minpoly ℤ θ = X² - d`, compute the field norm `Algebra.norm ℚ` in the basis `1, θ`:

- `norm_gen_eq_neg_radicand`: `N(θ) = -d`;
- `norm_add_mul_gen` (`@[simp]`): `N(b + aθ) = b² - d·a²`;
- `norm_pos_of_radicand_neg`: for `d < 0` (imaginary quadratic, `K` totally complex) the norm is strictly positive on nonzero elements.

The positivity is a descent input for genus theory: it upgrades a norm-`±1` element to norm `1`, the hypothesis of Hilbert's Theorem 90 realising a 2-torsion class by an ambiguous ideal (the ambiguous class number formula behind the genus-field 2-rank theorem).

Supporting generalisation in `LinearAlgebra/Dimension/IsQuadraticExtension.lean`: the arbitrary-element coordinate presentation `exists_eq_algebraMap_add_algebraMap_mul` (every `x` is `b + aθ`) is added at the `[Semiring L]` level, and the previous generator-difference lemma is renamed `exists_ne_zero_eq_algebraMap_add_algebraMap_mul` (its `QuadraticTwist` consumer updated).

Supersedes #2784 (whose review round did not converge under CI instability); content identical to that PR's final state.

Roadmap: Multiquadratic