### PR TITLE
feat(Huber): elements of an ideal of definition are topologically nilpotent

### DIFF
--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -238,6 +238,21 @@ theorem hasBasis_nhds_zero (P : PairOfDefinition A) :
   rw [← hmap]
   exact P.isAdic_idealOfDefinition.hasBasis_nhds_zero.map _
 
+/-- **An element of the ideal of definition is topologically nilpotent.** Its powers lie in the
+successive `Iⁿ`, whose images are a neighbourhood basis of zero
+(`TauCeti.Huber.PairOfDefinition.hasBasis_nhds_zero`), so they converge to `0` in `A`.
+
+This is the property Wedhorn uses throughout §7.2: it is what forces a continuous valuation to
+have cofinal values on `I`, and hence `v a < 1` there (Theorem 7.10). -/
+theorem isTopologicallyNilpotent_of_mem_idealOfDefinition (P : PairOfDefinition A)
+    {a : P.ringOfDefinition} (ha : a ∈ P.idealOfDefinition) :
+    IsTopologicallyNilpotent (a : A) := by
+  rw [IsTopologicallyNilpotent, P.hasBasis_nhds_zero.tendsto_right_iff]
+  intro n _
+  filter_upwards [Filter.eventually_ge_atTop n] with m hm
+  refine (P.mem_idealImage n).mpr ⟨a ^ m, ?_, by push_cast; ring⟩
+  exact Ideal.pow_le_pow_right hm (Ideal.pow_mem_pow ha m)
+
 /-- A ring admitting a pair of definition is nonarchimedean. -/
 theorem toNonarchimedeanRing [IsTopologicalRing A] (P : PairOfDefinition A) :
     NonarchimedeanRing A where


### PR DESCRIPTION
**Elements of an ideal of definition are topologically nilpotent.**

```lean
theorem TauCeti.Huber.PairOfDefinition.isTopologicallyNilpotent_of_mem_idealOfDefinition
    (P : PairOfDefinition A) {a : P.ringOfDefinition} (ha : a ∈ P.idealOfDefinition) :
    IsTopologicallyNilpotent (a : A)
```

For a pair of definition `(A₀, I)`, an element of `I` satisfies `aⁿ → 0` in `A`. The proof is
the neighbourhood basis: `aᵐ ∈ Iⁿ` as soon as `m ≥ n`, and the images of the `Iⁿ` are a
neighbourhood basis of zero (`PairOfDefinition.hasBasis_nhds_zero`, Wedhorn Proposition and
Definition 6.1).

## Why this is missing, and why it is wanted

Mathlib defines `IsTopologicallyNilpotent` but supplies no Huber-ring instance of it, and
TauCeti's Huber files so far carry only the converse-facing
`IsPowerBounded.of_isTopologicallyNilpotent`. So the property that *makes* an ideal of
definition behave like one — its elements being topologically nilpotent — was nowhere stated,
even though `hasBasis_nhds_zero` puts it two lines away.

It is the property Wedhorn leans on throughout §7.2. Theorem 7.10 characterises

```text
Cont A = { v ∈ Spv (A, I·A) ; v a < 1 for all a ∈ I }
```

and the forward direction is exactly *"every `a ∈ I` is topologically nilpotent, so for every
`γ` some `aⁿ` lands in the open `{f ; v f < γ}`"* — that is cofinality of `v a`, and `v a < 1`
is the case `γ = 1`. Without this lemma that argument has no starting point.

## Scope

One theorem, in the file that already owns `PairOfDefinition` and its neighbourhood basis. No
new imports, no changes to existing declarations. `[CommRing A] [TopologicalSpace A]` from the
surrounding section suffice — no `IsTopologicalRing` is needed, since only the basis is used.

## Provenance

The corresponding development in AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at commit
`2baa76f742bdb4fb8ee323fabba41203bd390e08`, project `projects/AdicSpaces/`, file
`Adic spaces/SpvAITopology.lean`, was consulted. Its Wedhorn 7.10 work *assumes* topological
nilpotence of ideal-of-definition elements inline rather than proving it, and the neighbouring
sub-leaves it depends on (`cont_to_ideal_le_supp_microbial`,
`isTopologicalRing_of_pairOfDefinition`) are `sorry` there. This lemma is proved here from
`hasBasis_nhds_zero`.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass
(82 grandfathered, 0 ratchetable).

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-0.2-huber-rings-and-tate-rings"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
