### PR TITLE
feat: synchronize affine group scheme base change

### DIFF
--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Basic.lean
@@ -41,14 +41,17 @@ rings; no field or finite-type hypothesis is needed.
   with scalar extension of its coordinate Hopf algebra, first for group objects and then through
   the affine-group-scheme anti-equivalence.
 
+The comparison with base change of coordinate Hopf algebras is developed in
+`TauCeti.AlgebraicGeometry.AffineGroupScheme.BaseChange.Coordinate`.
+
 ## References
 
 The coordinate-algebra counterpart of this construction, base change of commutative Hopf
 algebras, is `TauCeti.CommHopfAlgCat.baseChangeFunctor`; the two sides are related by the
 anti-equivalence `TauCeti.commHopfAlgCatOpEquivAffineGroupSchemeCat`.
-`hopfSpecBaseChangeIso` identifies their values on each Hopf algebra. A natural isomorphism of the
-two resulting functors, including its coherence with the identity and composition comparisons,
-is not asserted here.
+`hopfSpecBaseChangeIso` identifies their values on each Hopf algebra. Their natural compatibility
+is developed in `TauCeti.AlgebraicGeometry.AffineGroupScheme.BaseChange.Coordinate` as
+`TauCeti.AffineGroupSchemeCat.hopfSpecBaseChangeNatIso`.
 
 ## Roadmap
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.BaseChange.Basic
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
 
 /-!
 # Coordinate compatibility of affine-group-scheme base change
@@ -193,6 +191,8 @@ private theorem hopfSpecBaseChangeιNatIso_hom_app (H : (CommHopfAlgCat.{u} R)�
       (hopfSpecBaseChangeIso (R := R) (S := S) H.unop).hom.hom := by
   apply Grp.hom_ext
   apply Over.OverMorphism.ext
+  -- No projection lemma exposes the component of this private composite natural isomorphism;
+  -- unfold that composite definitionally so its constituent component lemmas can simplify it.
   change
     (((Functor.isoWhiskerRight
           (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
@@ -1,0 +1,242 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.BaseChange.Basic
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+
+/-!
+# Coordinate compatibility of affine-group-scheme base change
+
+Let `H` be a commutative Hopf algebra over a commutative ring `R`, and let `S` be a
+commutative `R`-algebra. There are two constructions of the base-changed affine group scheme:
+pull back `Spec H` from `Spec R` to `Spec S`, or first extend scalars on coordinates to
+`S ⊗[R] H` and then take its Hopf spectrum. This file identifies the two constructions.
+
+The underlying scheme isomorphism is Mathlib's `AlgebraicGeometry.pullbackSpecIso'`, preceded
+by pullback symmetry so that the new base ring is the left tensor factor. Mathlib also proves
+that this isomorphism preserves the monoid-object structure. Here it is bundled as an
+isomorphism of affine group schemes and composed with the established Hopf-spectrum
+anti-equivalence.
+
+## Main declarations
+
+* `TauCeti.AffineGroupSchemeCat.hopfSpecBaseChangeIso`: pullback of a Hopf spectrum is the
+  Hopf spectrum of the scalar-extended coordinate Hopf algebra.
+* `TauCeti.AffineGroupSchemeCat.hopfSpecBaseChangeNatIso`: the comparison is natural in the
+  coordinate Hopf algebra.
+
+## References
+
+This is the base-change compatibility in the Hopf-algebra/affine-group-scheme dictionary; see
+J. S. Milne, *Algebraic Groups* (2017), Section 1.f.
+
+## Roadmap
+
+This synchronizes the coordinate and scheme models in the base-change part of Layer 0 of the
+ReductiveGroups roadmap. In particular, it lets later scheme-side constructions, including the
+Layer 4 dictionary for groups of multiplicative type, reuse coordinate scalar extension.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry Opposite
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u
+
+namespace AffineGroupSchemeCat
+
+variable {R S : Type u} [CommRing R] [CommRing S] [Algebra R S]
+
+/-- Pullback symmetry followed by the affine pullback comparison identifies the base-changed
+spectrum with the spectrum of the scalar extension. -/
+private noncomputable def pullbackSpecBaseChangeIso (H : CommHopfAlgCat.{u} R) :
+    Limits.pullback
+        (Spec.map (CommRingCat.ofHom (algebraMap R H)))
+        (Spec.map (CommRingCat.ofHom (algebraMap R S))) ≅
+      Spec (CommRingCat.of (S ⊗[R] H)) :=
+  Limits.pullbackSymmetry
+      (Spec.map (CommRingCat.ofHom (algebraMap R H)))
+      (Spec.map (CommRingCat.ofHom (algebraMap R S))) ≪≫
+    pullbackSpecIso R S H
+
+@[reassoc (attr := simp)]
+private theorem pullbackSpecBaseChangeIso_inv_fst (H : CommHopfAlgCat.{u} R) :
+    (pullbackSpecBaseChangeIso (R := R) (S := S) H).inv ≫
+        Limits.pullback.fst
+          (Spec.map (CommRingCat.ofHom (algebraMap R H)))
+          (Spec.map (CommRingCat.ofHom (algebraMap R S))) =
+      Spec.map (CommRingCat.ofHom
+        (Algebra.TensorProduct.includeRight (R := R) (A := S) (B := H)).toRingHom) := by
+  simp [pullbackSpecBaseChangeIso]
+
+@[reassoc (attr := simp)]
+private theorem pullbackSpecBaseChangeIso_inv_snd (H : CommHopfAlgCat.{u} R) :
+    (pullbackSpecBaseChangeIso (R := R) (S := S) H).inv ≫
+        Limits.pullback.snd
+          (Spec.map (CommRingCat.ofHom (algebraMap R H)))
+          (Spec.map (CommRingCat.ofHom (algebraMap R S))) =
+      Spec.map (CommRingCat.ofHom
+        (Algebra.TensorProduct.includeLeftRingHom : S →+* S ⊗[R] H)) := by
+  simp [pullbackSpecBaseChangeIso]
+
+private theorem hopfSpec_map_left {T : Type u} [CommRing T]
+    {H K : CommHopfAlgCat.{u} T} (f : H ⟶ K) :
+    ((hopfSpec (CommRingCat.of T)).map f.op).hom.hom.left =
+      Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom) := by
+  rfl
+
+private theorem pullbackSpecIso'_natural {H K : CommHopfAlgCat.{u} R}
+    (f : H ⟶ K) :
+    (pullbackSpecBaseChangeIso (R := R) (S := S) K).inv ≫
+        Limits.pullback.lift
+          (Limits.pullback.fst
+              (Spec.map (CommRingCat.ofHom (algebraMap R K)))
+              (Spec.map (CommRingCat.ofHom (algebraMap R S))) ≫
+            Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))
+          (Limits.pullback.snd
+            (Spec.map (CommRingCat.ofHom (algebraMap R K)))
+            (Spec.map (CommRingCat.ofHom (algebraMap R S))))
+          (by
+            have hf :
+                Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom) ≫
+                    Spec.map (CommRingCat.ofHom (algebraMap R H)) =
+                  Spec.map (CommRingCat.ofHom (algebraMap R K)) := by
+              rw [← Spec.map_comp, ← CommRingCat.ofHom_comp]
+              congr 1
+              ext r
+              exact f.hom.toAlgHom.commutes r
+            rw [Category.assoc, hf]
+            exact Limits.pullback.condition) ≫
+      (pullbackSpecBaseChangeIso (R := R) (S := S) H).hom =
+        Spec.map (CommRingCat.ofHom
+          ((CommHopfAlgCat.baseChangeMap (K := S) f).hom).toAlgHom.toRingHom) := by
+  rw [← Category.assoc]
+  apply (pullbackSpecBaseChangeIso (R := R) (S := S) H).eq_comp_inv.mp
+  apply Limits.pullback.hom_ext
+  · simp only [Category.assoc, Limits.pullback.lift_fst]
+    rw [← Category.assoc, pullbackSpecBaseChangeIso_inv_fst,
+      pullbackSpecBaseChangeIso_inv_fst]
+    simp only [← Spec.map_comp, ← CommRingCat.ofHom_comp]
+    congr 1
+  · simp only [Category.assoc, Limits.pullback.lift_snd]
+    rw [pullbackSpecBaseChangeIso_inv_snd]
+    rw [pullbackSpecBaseChangeIso_inv_snd]
+    simp only [← Spec.map_comp, ← CommRingCat.ofHom_comp]
+    congr 1
+    ext x
+    simp
+
+private theorem hopfSpecPullbackIso_natural {H K : CommHopfAlgCat.{u} R}
+    (f : H ⟶ K) :
+    (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap R S)))).mapGrp.map
+          ((hopfSpec (CommRingCat.of R)).map f.op) ≫
+        (hopfSpecBaseChangeGrpIso (R := R) (S := S) H).hom =
+        (hopfSpecBaseChangeGrpIso (R := R) (S := S) K).hom ≫
+        (hopfSpec (CommRingCat.of S)).map
+          (CommHopfAlgCat.baseChangeMap (K := S) f).op := by
+  rw [← cancel_epi (hopfSpecBaseChangeGrpIso (R := R) (S := S) K).inv]
+  simp only [Iso.inv_hom_id_assoc]
+  apply Grp.hom_ext
+  apply Over.OverMorphism.ext
+  rw [Grp.comp_hom_hom, Grp.comp_hom_hom, Over.comp_left, Over.comp_left,
+    hopfSpecBaseChangeGrpIso_inv_hom_hom_left, hopfSpecBaseChangeGrpIso_hom_hom_hom_left]
+  rw [Functor.mapGrp_map_hom_hom]
+  exact pullbackSpecIso'_natural (R := R) (S := S) f
+
+/-- The group-object comparison between pullback of Hopf spectra and Hopf spectra of scalar
+extensions, natural in the coordinate Hopf algebra. -/
+private noncomputable def hopfSpecPullbackNatIso :
+    hopfSpec (CommRingCat.of R) ⋙
+          (Over.pullback
+            (Spec.map (CommRingCat.ofHom (algebraMap R S)))).mapGrp ≅
+      (CommHopfAlgCat.baseChangeFunctor (K := S)).op ⋙
+        hopfSpec (CommRingCat.of S) :=
+  NatIso.ofComponents
+    (fun H ↦ hopfSpecBaseChangeGrpIso (R := R) (S := S) H.unop)
+    (fun f ↦ hopfSpecPullbackIso_natural (R := R) (S := S) f.unop)
+
+/-- The base-change comparison after including affine group schemes into all group objects. -/
+private noncomputable def hopfSpecBaseChangeιNatIso :
+    ((commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of R)).functor ⋙
+          baseChangeFunctor (CommRingCat.ofHom (algebraMap R S))) ⋙
+        (affineGroupSchemeProperty (CommRingCat.of S)).ι ≅
+      ((CommHopfAlgCat.baseChangeFunctor (K := S)).op ⋙
+          (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of S)).functor) ⋙
+        (affineGroupSchemeProperty (CommRingCat.of S)).ι := by
+  change
+    (((commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of R)).functor ⋙
+          (affineGroupSchemeProperty (CommRingCat.of R)).ι) ⋙
+        (Over.pullback
+          (Spec.map (CommRingCat.ofHom (algebraMap R S)))).mapGrp) ≅ _
+  exact
+    Functor.isoWhiskerRight
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+          (CommRingCat.of R)) _ ≪≫
+      hopfSpecPullbackNatIso (R := R) (S := S) ≪≫
+      Functor.isoWhiskerLeft (CommHopfAlgCat.baseChangeFunctor (K := S)).op
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+          (CommRingCat.of S)).symm ≪≫
+      (Functor.associator _ _ _).symm
+
+private theorem hopfSpecBaseChangeιNatIso_hom_app (H : (CommHopfAlgCat.{u} R)ᵒᵖ) :
+    (hopfSpecBaseChangeιNatIso (R := R) (S := S)).hom.app H =
+      (hopfSpecBaseChangeIso (R := R) (S := S) H.unop).hom.hom := by
+  apply Grp.hom_ext
+  apply Over.OverMorphism.ext
+  change
+    (((Functor.isoWhiskerRight
+          (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+            (CommRingCat.of R))
+          (Over.pullback
+            (Spec.map (CommRingCat.ofHom (algebraMap R S)))).mapGrp ≪≫
+        hopfSpecPullbackNatIso (R := R) (S := S) ≪≫
+        Functor.isoWhiskerLeft (CommHopfAlgCat.baseChangeFunctor (K := S)).op
+          (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+            (CommRingCat.of S)).symm ≪≫
+        (Functor.associator _ _ _).symm).hom.app H).hom.hom.left = _)
+  rw [hopfSpecBaseChangeIso_hom_hom]
+  simp [hopfSpecPullbackNatIso]
+
+/-- Scheme-theoretic pullback of affine group schemes corresponds naturally, under the
+Hopf-spectrum anti-equivalence, to scalar extension of their coordinate Hopf algebras. -/
+-- Exposing the definition makes its public component formulas compute without requiring users
+-- to unfold the categorical construction by hand.
+@[expose] noncomputable def hopfSpecBaseChangeNatIso :
+    (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of R)).functor ⋙
+        baseChangeFunctor (CommRingCat.ofHom (algebraMap R S)) ≅
+      (CommHopfAlgCat.baseChangeFunctor (K := S)).op ⋙
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of S)).functor :=
+  NatIso.ofComponents (fun H ↦ hopfSpecBaseChangeIso (R := R) (S := S) H.unop) (fun f ↦ by
+    apply (affineGroupSchemeProperty (CommRingCat.of S)).ι.map_injective
+    simpa only [Functor.comp_map, Functor.map_comp, ObjectProperty.ι_map,
+      ObjectProperty.FullSubcategory.comp_hom,
+      hopfSpecBaseChangeιNatIso_hom_app] using
+      (hopfSpecBaseChangeιNatIso (R := R) (S := S)).hom.naturality f)
+
+/-- The forward component of `hopfSpecBaseChangeNatIso` is
+`hopfSpecBaseChangeIso`. -/
+@[simp]
+theorem hopfSpecBaseChangeNatIso_hom_app (H : (CommHopfAlgCat.{u} R)ᵒᵖ) :
+    (hopfSpecBaseChangeNatIso (R := R) (S := S)).hom.app H =
+      (hopfSpecBaseChangeIso (R := R) (S := S) H.unop).hom :=
+  rfl
+
+/-- The inverse component of `hopfSpecBaseChangeNatIso` is the inverse of
+`hopfSpecBaseChangeIso`. -/
+@[simp]
+theorem hopfSpecBaseChangeNatIso_inv_app (H : (CommHopfAlgCat.{u} R)ᵒᵖ) :
+    (hopfSpecBaseChangeNatIso (R := R) (S := S)).inv.app H =
+      (hopfSpecBaseChangeIso (R := R) (S := S) H.unop).inv :=
+  rfl
+
+end AffineGroupSchemeCat
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
@@ -7,7 +7,6 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.BaseChange.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
 
 /-!
 # Coordinate compatibility of affine-group-scheme base change
@@ -91,6 +90,7 @@ private theorem hopfSpec_map_left {T : Type u} [CommRing T]
     {H K : CommHopfAlgCat.{u} T} (f : H ⟶ K) :
     ((hopfSpec (CommRingCat.of T)).map f.op).hom.hom.left =
       Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom) := by
+  -- `hopfSpec.map` is built by lifting this `Spec.map`; no separate projection lemma is exposed.
   rfl
 
 private theorem pullbackSpecIso'_natural {H K : CommHopfAlgCat.{u} R}
@@ -171,6 +171,8 @@ private noncomputable def hopfSpecBaseChangeιNatIso :
       ((CommHopfAlgCat.baseChangeFunctor (K := S)).op ⋙
           (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of S)).functor) ⋙
         (affineGroupSchemeProperty (CommRingCat.of S)).ι := by
+  -- The equivalence functor followed by the subtype inclusion is definitionally its `hopfSpec`
+  -- model; `functorCompιIso` below supplies the explicit comparison once the goal has that shape.
   change
     (((commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of R)).functor ⋙
           (affineGroupSchemeProperty (CommRingCat.of R)).ι) ⋙
@@ -207,9 +209,7 @@ private theorem hopfSpecBaseChangeιNatIso_hom_app (H : (CommHopfAlgCat.{u} R)�
 
 /-- Scheme-theoretic pullback of affine group schemes corresponds naturally, under the
 Hopf-spectrum anti-equivalence, to scalar extension of their coordinate Hopf algebras. -/
--- Exposing the definition makes its public component formulas compute without requiring users
--- to unfold the categorical construction by hand.
-@[expose] noncomputable def hopfSpecBaseChangeNatIso :
+noncomputable def hopfSpecBaseChangeNatIso :
     (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of R)).functor ⋙
         baseChangeFunctor (CommRingCat.ofHom (algebraMap R S)) ≅
       (CommHopfAlgCat.baseChangeFunctor (K := S)).op ⋙
@@ -227,7 +227,7 @@ Hopf-spectrum anti-equivalence, to scalar extension of their coordinate Hopf alg
 theorem hopfSpecBaseChangeNatIso_hom_app (H : (CommHopfAlgCat.{u} R)ᵒᵖ) :
     (hopfSpecBaseChangeNatIso (R := R) (S := S)).hom.app H =
       (hopfSpecBaseChangeIso (R := R) (S := S) H.unop).hom :=
-  rfl
+  (rfl)
 
 /-- The inverse component of `hopfSpecBaseChangeNatIso` is the inverse of
 `hopfSpecBaseChangeIso`. -/
@@ -235,7 +235,7 @@ theorem hopfSpecBaseChangeNatIso_hom_app (H : (CommHopfAlgCat.{u} R)ᵒᵖ) :
 theorem hopfSpecBaseChangeNatIso_inv_app (H : (CommHopfAlgCat.{u} R)ᵒᵖ) :
     (hopfSpecBaseChangeNatIso (R := R) (S := S)).inv.app H =
       (hopfSpecBaseChangeIso (R := R) (S := S) H.unop).inv :=
-  rfl
+  (rfl)
 
 end AffineGroupSchemeCat
 

--- a/TauCeti/AlgebraicGeometry/PullbackSpecMap.lean
+++ b/TauCeti/AlgebraicGeometry/PullbackSpecMap.lean
@@ -19,7 +19,7 @@ along `Spec.map (𝟙 R)` is the identity functor on schemes over `Spec R`, and 
 
 Nothing here mentions affineness or group objects: these are statements about arbitrary schemes
 over an affine base, and they are the underlying comparisons of the base-change functors on
-affine group schemes in `TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange.lean`.
+affine group schemes in `TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Basic.lean`.
 
 ## Main declarations
 


### PR DESCRIPTION
This PR synchronizes scheme-theoretic base change of affine group schemes with scalar extension of their coordinate Hopf algebras. It bundles Mathlib's affine pullback comparison as an isomorphism of group objects, proves its naturality in the Hopf algebra, and transports it through the established Hopf-spectrum anti-equivalence.

The exact ReductiveGroups milestone is Layer 0, **Base change**: “`K ⊗[k] A` as a Hopf algebra over `K`,” within the three-way dictionary. This closes the missing compatibility between the coordinate and scheme base-change functors. After this PR, Layer 0 still needs the third equivalence with representable group-valued functors.

The immediate consumer is the Layer 4 target **Diagonalizable groups and groups of multiplicative type**: its coordinate construction `M ↦ D(M) = Spec k[M]` can now transfer scalar extension across the anti-equivalence to scheme-side base change.

The implementation reuses Mathlib's `AlgebraicGeometry.pullbackSpecIso`, `AlgebraicGeometry.pullbackSpecIso'`, pullback symmetry, and the existing `IsMonHom` instance for the comparison; no Mathlib infrastructure is vendored.

The required module-layout move changes only the module path, with no declaration renames:

| Old module | New module |
| --- | --- |
| `TauCeti.AlgebraicGeometry.AffineGroupScheme.BaseChange` | `TauCeti.AlgebraicGeometry.AffineGroupScheme.BaseChange.Basic` |

Validation runs `lake build`, `tauceti-axioms --changed-since-merge-base origin/main`, and `tauceti-lint-env --changed-since-merge-base origin/main`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"affine-group-scheme-coordinate-base-change"}-->

🤖 Prepared with Codex
