### PR TITLE
feat: tell a red build apart from a changes request, and label without a second queue wait

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -574,7 +574,7 @@ jobs:
           # abort the step and leave the commit with a partial set. A MISSING required status is
           # worse than a red one. `build` never appears, so GitHub holds the PR at BLOCKED
           # forever; core.derive reads no `build` status, so labels.py pins the PR at
-          # `awaiting-CI` (its ci=None branch) rather than `awaiting-author`; and nothing re-runs
+          # `awaiting-CI` (its ci=None branch) rather than `ci-failed`; and nothing re-runs
           # pr-build without a push, so no event ever corrects it. That wedged PR #1358 for seven
           # days, invisible to both the author path and the review path.
           #

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -5,10 +5,11 @@ name: PR status labels
 #   awaiting-CI         CI has not yet reported on the latest commit
 #   awaiting-review     CI is green; waiting for review verdicts
 #   review-in-progress  a review is running on this exact commit right now
-#   awaiting-author     the build failed or a review requested changes
+#   ci-failed           the build failed on the latest commit
+#   awaiting-author     a review requested changes
 #   ready-to-merge      CI green and every rubric approved
 #
-# scripts/pr_status/labels.py is the SOLE writer of these labels and derives all five from GitHub
+# scripts/pr_status/labels.py is the SOLE writer of these labels and derives all six from GitHub
 # truth alone (core.derive): the `build` commit status, the canonical <!--tauceti-scoreboard--> meta,
 # and the review engine's <!--tauceti-review-in-progress--> marker. It assumes nothing about any
 # worker or review harness -- a harness that posts the (optional) in-progress marker gets a
@@ -24,7 +25,7 @@ on:
   # New commit / open / reopen / close -> awaiting-CI, or strip labels on close.
   pull_request_target:
     types: [opened, reopened, synchronize, closed]
-  # Build finished -> awaiting-author / review / ready. (We do NOT react to "requested": a late
+  # Build finished -> ci-failed / review / ready. (We do NOT react to "requested": a late
   # requested event for an old head could force awaiting-CI onto a moved PR, and a new commit already
   # paints awaiting-CI via pull_request_target: synchronize.)
   workflow_run:
@@ -50,21 +51,84 @@ permissions:
   contents: read
 
 jobs:
-  # Resolve the PR number ONCE, so the mutation job can serialize on it. Keeping resolution in its own
-  # job lets `label` key its concurrency on needs.resolve.outputs.pr, which unifies the concurrency
-  # group across every trigger (pull_request_target/issue_comment know the PR up front; workflow_run
-  # only knows the head sha) so two events for one PR can never interleave a label add/remove.
-  resolve:
+  # The PR number has to key the concurrency group, and a group expression is evaluated before the job
+  # starts, so it can never read a step output: a number that must be COMPUTED needs its own upstream
+  # job. Most events don't need computing, though -- pull_request_target, issue_comment and same-repo
+  # workflow_run all carry the number in the payload -- and under runner contention a second job costs
+  # a second queue wait, which is exactly the lag this workflow is trying not to add.
+  #
+  # So the events split in two, by whether the number is already known:
+  #
+  #   label           payload knows the number: one job, one queue wait.
+  #   resolve+labelr  it has to be worked out: a fork PR's workflow_run (pull_requests[] is empty, so
+  #                   the head sha is scanned for) or a workflow_dispatch (an untrusted input string
+  #                   that must be validated down to digits before it can key anything).
+  #
+  # The two `if` conditions are mutually exclusive, so exactly one path runs per event, and both label
+  # jobs use the SAME pr-labels-<number> group. That shared key is what stops two events for one PR
+  # interleaving a label add/remove, and it holds across the split because both paths end up keyed on
+  # the same number by different routes. Keep the two label jobs in step: they differ only in where
+  # the number comes from.
+  label:
     if: >
       github.repository == 'TauCetiProject/TauCeti' && (
         github.event_name == 'pull_request_target'
-        || github.event_name == 'workflow_dispatch'
         || (github.event_name == 'workflow_run'
-            && github.event.workflow_run.event == 'pull_request_target')
+            && github.event.workflow_run.event == 'pull_request_target'
+            && github.event.workflow_run.pull_requests[0] != null)
         || (github.event_name == 'issue_comment'
             && github.event.issue.pull_request != null
             && (contains(github.event.comment.body, 'tauceti-scoreboard')
                 || contains(github.event.comment.body, 'tauceti-review-in-progress')))
+      )
+    runs-on: ubuntu-latest
+    # Serialize all events for one PR on its number. Don't cancel: GitHub already collapses a burst
+    # (one run in progress, one pending, and a third cancels the pending one), so cancelling would buy
+    # only the tail of a run that is already executing -- and it would buy it by interrupting a
+    # non-atomic mutation. reconcile removes labels one API call at a time before adding the right
+    # one, so a run killed mid-sequence can leave a PR carrying two status labels, and `sweep` would
+    # not repair it: the hourly backstop only looks at PRs holding review-in-progress.
+    concurrency:
+      group: pr-labels-${{ github.event.pull_request.number || github.event.issue.number || github.event.workflow_run.pull_requests[0].number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: TauCetiProject
+          repositories: TauCeti
+          permission-issues: write
+          permission-pull-requests: read
+          permission-statuses: read
+      # The trusted base checkout: the labels script that runs is the one on the target branch, never
+      # the version proposed by the PR.
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/pr_status
+          persist-credentials: false
+      - name: Reconcile status label
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number || github.event.issue.number || github.event.workflow_run.pull_requests[0].number }}
+          # Only the number is taken from the payload. core.derive can also be handed the PR's state
+          # and head sha through PR_STATE/PR_MERGED/PR_HEAD to save an API call, and this workflow
+          # used to do that -- but a payload is a snapshot of the moment the event fired, and after a
+          # queue wait it can describe a commit the PR has already moved past. One API call is a good
+          # price for a label that always reflects live truth. A PR's NUMBER cannot go stale.
+        run: python3 scripts/pr_status/labels.py reconcile "$PR"
+
+  # Resolve the PR number for the events whose payload doesn't carry it, so `label-resolved` can key
+  # its concurrency on the result. See the `label` job above for why this exists for these events only.
+  resolve:
+    if: >
+      github.repository == 'TauCetiProject/TauCeti' && (
+        github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'workflow_run'
+            && github.event.workflow_run.event == 'pull_request_target'
+            && github.event.workflow_run.pull_requests[0] == null)
       )
     runs-on: ubuntu-latest
     outputs:
@@ -84,32 +148,24 @@ jobs:
           REPO: ${{ github.repository }}
           EVENT: ${{ github.event_name }}
           WF_HEAD: ${{ github.event.workflow_run.head_sha }}
-          WF_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
           INPUT_PR: ${{ github.event.inputs.pr }}
         run: |
           set -euo pipefail
           case "$EVENT" in
-            pull_request_target) pr="$PR_NUMBER" ;;
-            issue_comment)       pr="$ISSUE_NUMBER" ;;
             workflow_dispatch)   pr="$INPUT_PR" ;;
             workflow_run)
-              pr="$WF_PR"
-              if [ -z "$pr" ]; then
-                # Fork PRs leave pull_requests[] empty, and GitHub's
-                # commits/<sha>/pulls endpoint need not associate their head
-                # commit with the base repository. Scan every open PR instead
-                # and accept EXACTLY ONE head-SHA match, so an ambiguous match
-                # can never label the wrong PR.
-                matches=$(gh api --paginate "repos/$REPO/pulls?state=open&per_page=100" \
-                  --jq ".[] | select(.head.sha == \"$WF_HEAD\") | .number")
-                mapfile -t prs <<< "$matches"
-                if [ -n "$matches" ] && [ "${#prs[@]}" -eq 1 ]; then
-                  pr="${prs[0]}"
-                else
-                  pr=""
-                fi
+              # This job only runs when pull_requests[] came back empty, which is
+              # what a fork PR looks like, and GitHub's commits/<sha>/pulls
+              # endpoint need not associate a fork's head commit with the base
+              # repository. Scan every open PR instead and accept EXACTLY ONE
+              # head-SHA match, so an ambiguous match can never label the wrong PR.
+              matches=$(gh api --paginate "repos/$REPO/pulls?state=open&per_page=100" \
+                --jq ".[] | select(.head.sha == \"$WF_HEAD\") | .number")
+              mapfile -t prs <<< "$matches"
+              if [ -n "$matches" ] && [ "${#prs[@]}" -eq 1 ]; then
+                pr="${prs[0]}"
+              else
+                pr=""
               fi
               ;;
           esac
@@ -120,12 +176,13 @@ jobs:
             echo "no single PR resolved (pr='${pr:-}'); skipping"
           fi
 
-  label:
+  # Identical to `label` above except that the number comes from `resolve`; change the two together.
+  label-resolved:
     needs: resolve
     if: needs.resolve.outputs.pr != ''
     runs-on: ubuntu-latest
-    # Serialize all events for one PR on its resolved number. Don't cancel: each run reconciles fresh
-    # truth and we want the last word, not a dropped one.
+    # The same group as `label`, so the two paths serialize against each other. See that job for why
+    # cancel-in-progress stays false.
     concurrency:
       group: pr-labels-${{ needs.resolve.outputs.pr }}
       cancel-in-progress: false
@@ -151,18 +208,19 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           PR: ${{ needs.resolve.outputs.pr }}
-          # Fast-path the PR's state from the event payload (no /pulls API call); only
-          # pull_request_target carries a pull_request object, other events leave these empty and the
-          # script falls back to the REST API. Passed via env (never interpolated into the shell).
-          PR_STATE: ${{ github.event.pull_request.state }}
-          PR_MERGED: ${{ github.event.pull_request.merged }}
-          PR_HEAD: ${{ github.event.pull_request.head.sha }}
         run: python3 scripts/pr_status/labels.py reconcile "$PR"
 
   # Scheduled backstop: reconcile the PRs currently carrying review-in-progress, so an expired
   # in-flight marker (a crashed review) drops the label even though nothing else fired. It is the only
-  # label that can go stale with no event; the other four are always refreshed by a build/scoreboard/PR
-  # event. Its own concurrency group keeps two sweeps from overlapping.
+  # label that can go stale with no event; the other five are always refreshed by a build/scoreboard/PR
+  # event. Note the deliberately narrow scope -- this is NOT a general repair pass over every open PR,
+  # so nothing here rescues a PR whose label is wrong for some other reason.
+  #
+  # Its own concurrency group keeps two sweeps from overlapping. It is a different group from the
+  # per-PR one, so a sweep CAN run alongside a per-PR job for a PR it happens to be reconciling. That
+  # is tolerable rather than intended: both are convergent reconcilers reading live truth, so the
+  # worst case is a PR that briefly shows two labels until the next event settles it. Closing the gap
+  # properly means one job per swept PR, which costs more runner time than the drift is worth.
   sweep:
     if: github.event_name == 'schedule' && github.repository == 'TauCetiProject/TauCeti'
     runs-on: ubuntu-latest

--- a/scripts/pr_stats_graphs.md
+++ b/scripts/pr_stats_graphs.md
@@ -15,7 +15,10 @@ It requires an authenticated `gh` CLI. In GitHub Actions, set `GH_TOKEN` to
 ## Definitions
 
 - **Total time open** is snapshot time minus PR creation time for every open PR.
-- **Awaiting author** starts when the current `awaiting-author` label was applied.
+- **Awaiting author** covers both states that put the ball in the author's court,
+  `ci-failed` and `awaiting-author`, and starts when the PR entered that pair. Swapping
+  one for the other continues the same clock; going back through `awaiting-CI` starts a
+  new one.
 - **In review** starts when the current review cycle began; the pipeline's swap to
   `review-in-progress`, and any later restoration of `awaiting-review`, remain part of
   that same clock.

--- a/scripts/pr_stats_graphs.py
+++ b/scripts/pr_stats_graphs.py
@@ -51,10 +51,14 @@ SCOREBOARD_MARKER = "<!--tauceti-scoreboard-->"
 # when it derives a single PR's review state.
 SCOREBOARD_META_KIND = "scoreboard"
 STATE_REVIEW = {"awaiting-review", "review-in-progress"}
-STATE_LABELS = {"awaiting-author", *STATE_REVIEW}
+# The two states that put the ball in the author's court. They are separate labels because the
+# author reads a build log for one and the review threads for the other, but every measurement
+# here treats them as one state: the PR is waiting on a human either way.
+STATE_AUTHOR_ACTION = {"awaiting-author", "ci-failed"}
+STATE_LABELS = {*STATE_AUTHOR_ACTION, *STATE_REVIEW}
 # States in which the PR has left the review queue: the author owns it, or CI is judging a
 # new commit before review resumes.
-STATE_AUTHOR = {"awaiting-author", "awaiting-CI"}
+STATE_AUTHOR = {*STATE_AUTHOR_ACTION, "awaiting-CI"}
 LIFECYCLE_LABELS = {*STATE_REVIEW, *STATE_AUTHOR, "ready-to-merge"}
 # The lifecycle-label workflow first landed on 2026-07-22. A PR closed before
 # that UTC day cannot contain one of its label events and needs no timeline query.
@@ -356,20 +360,33 @@ def fetch_snapshot(repo: str) -> dict:
     }
 
 
-def last_labeled(pr: dict, label: str) -> datetime | None:
-    matches = [
-        parse_dt(event["created_at"])
-        for event in pr.get("labeled_events") or [] if event["label"] == label
-    ]
-    return max(matches, default=None)
-
-
 def latest_lifecycle_label(pr: dict) -> str | None:
     events = [
         event for event in pr.get("labeled_events") or []
         if event["label"] in LIFECYCLE_LABELS
     ]
     return events[-1]["label"] if events else None
+
+
+def author_episode_start(pr: dict) -> datetime | None:
+    """When the PR's current spell of waiting on its author began, or None if it is not in one.
+
+    ``ci-failed`` and ``awaiting-author`` are separate labels because the author has to do
+    different things about them, but for the queue-age clock they are one state: the PR is out of
+    the pipeline's hands either way.  So the clock runs from where the PR *entered* that state, and
+    swapping one of the two for the other inside it -- a red build arriving on a PR that already
+    had changes requested, or the migration that first split the labels -- continues the spell
+    rather than starting a new one.  Any other lifecycle label ends it: a push that sends the PR
+    back to ``awaiting-CI`` is a genuinely fresh wait, even if it fails again straight afterwards.
+    """
+    start = None
+    for event in sorted(pr.get("labeled_events") or [], key=lambda item: item["created_at"]):
+        if event["label"] in STATE_AUTHOR_ACTION:
+            if start is None:
+                start = parse_dt(event["created_at"])
+        elif event["label"] in LIFECYCLE_LABELS:
+            start = None
+    return start
 
 
 def review_cycle_starts(pr: dict) -> list[datetime]:
@@ -407,11 +424,8 @@ def queue_age_metrics(prs: list[dict], snapshot: datetime) -> dict:
         labels = set(pr.get("labels") or [])
         if pr.get("is_draft"):
             other += 1
-        elif "awaiting-author" in labels:
-            start = (
-                last_labeled(pr, "awaiting-author")
-                if latest_lifecycle_label(pr) == "awaiting-author" else None
-            )
+        elif labels & STATE_AUTHOR_ACTION:
+            start = author_episode_start(pr)
             if start is None:
                 start = created
                 missing_transition += 1

--- a/scripts/pr_status/README.md
+++ b/scripts/pr_status/README.md
@@ -21,7 +21,7 @@ reactions can never disagree:
 | lifecycle `merged` / `closed` | *(no label)* | `:merge:` / `:closed-pr:` |
 | ci `running` | `awaiting-CI` | 🟡 `yellow` |
 | ci not reported | `awaiting-CI` | 🟡 `yellow` |
-| ci `failure` | `awaiting-author` | 🔴 `red_circle` |
+| ci `failure` | `ci-failed` | 🔴 `red_circle` |
 | ci `success`, review `changes` | `awaiting-author` | 🟢 + ✍️ `writing` |
 | ci `success`, review `approved` | `ready-to-merge` | 🟢 + ✔️ `check` |
 | ci `success`, review pending, live marker | `review-in-progress` | 🟢 + 👀 |
@@ -37,14 +37,14 @@ and an authenticated `gh` CLI, nothing from PyPI.
 
 ## Labels
 
-The five labels are mutually exclusive; [`labels.py`](labels.py) sets one and
+The six labels are mutually exclusive; [`labels.py`](labels.py) sets one and
 removes any other, so exactly one is present on an open PR (none on a terminal
-PR). All five are provisioned on first use, and **`labels.py` is the sole writer
+PR). All six are provisioned on first use, and **`labels.py` is the sole writer
 of them**: the "exactly one" invariant is CI's alone to keep, and it assumes
 nothing about any worker or review harness. That is deliberate: anyone can point
 their own review harness at TauCeti, and CI must not depend on a particular one.
 
-`review-in-progress` is derived, like the other four, from a signal CI reads
+`review-in-progress` is derived, like the other five, from a signal CI reads
 rather than from anyone writing the label. The signal is the review engine's
 in-flight marker (`<!--tauceti-review-in-progress-->`, carrying a `head` and an
 `expires_at`), treated as an **optional, documented** contract that any review
@@ -167,7 +167,7 @@ a persistent Zulip config break, exactly like the healthcheck.
 
 The labels need no secret: `pr-labels.yml` uses the same GitHub App
 (`APP_ID` / `APP_PRIVATE_KEY`) already configured for the roadmap and merge
-workflows, scoped to this repo, and provisions the five labels on first use.
+workflows, scoped to this repo, and provisions the six labels on first use.
 
 ## Failure modes (Zulip)
 

--- a/scripts/pr_status/core.py
+++ b/scripts/pr_status/core.py
@@ -8,7 +8,7 @@ is in flight right now (from the engine's `<!--tauceti-review-in-progress-->`
 marker). Every status *sink* imports it and renders that one truth its own way:
 
   * zulip.py   -> two independent groups of emoji reactions on the PR's message
-  * labels.py  -> exactly one of the five status labels on the PR itself
+  * labels.py  -> exactly one of the six status labels on the PR itself
 
 Keeping the derivation here means the two sinks can never disagree about what a
 PR's state is: they read the same `derive()` and only differ in how they show it.

--- a/scripts/pr_status/labels.py
+++ b/scripts/pr_status/labels.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
 """Keep exactly one status label on every open TauCeti PR.
 
-The five labels are mutually exclusive; together they say, at a glance in the PR
+The six labels are mutually exclusive; together they say, at a glance in the PR
 list, where a PR is in the pipeline:
 
     awaiting-CI         CI has not yet reported on the latest commit
     awaiting-review     CI is green; waiting for review verdicts
     review-in-progress  a review is running on this exact commit right now
-    awaiting-author     the build failed or a review requested changes
+    ci-failed           the build failed on the latest commit
+    awaiting-author     a review requested changes
     ready-to-merge      CI green and every rubric approved
 
-All five are derived here from the PR's status (core.derive) and this sink is the
+`ci-failed` and `awaiting-author` both mean "the author owns it now", but they are
+kept apart because the fix is completely different -- read the build log, or read
+the review threads -- and collapsing them cost real time when a PR sat red while
+its reviews were being watched.
+
+All six are derived here from the PR's status (core.derive) and this sink is the
 SOLE writer of them, so the "exactly one" invariant is CI's alone to keep -- it
 never depends on any worker or review harness behaving a particular way. reconcile
 is idempotent and convergent: it reads GitHub truth afresh and drives the label
@@ -37,6 +43,7 @@ Environment:
 Only python3's standard library and an authenticated `gh` CLI are required.
 """
 
+import json
 import subprocess
 import sys
 
@@ -50,7 +57,10 @@ LABELS = {
     "awaiting-CI":        ("fbca04", "CI has not yet reported on the latest commit"),
     "awaiting-review":    ("1d76db", "CI is green; waiting for review verdicts"),
     "review-in-progress": ("a371f7", "A review is running on this exact commit right now"),
-    "awaiting-author":    ("d93f0b", "The build failed or a review requested changes; author action needed"),
+    # Distinct colours on purpose: telling a red build apart from a changes request AT A GLANCE in
+    # the PR list is the whole reason these are two labels rather than one.
+    "ci-failed":          ("d93f0b", "The build failed on the latest commit; author action needed"),
+    "awaiting-author":    ("e99695", "A review requested changes; author action needed"),
     "ready-to-merge":     ("0e8a16", "CI green and every rubric approved; ready to merge"),
 }
 STATUS_LABELS = list(LABELS)
@@ -66,7 +76,7 @@ def derived_label(status):
     Precedence:
         PR merged/closed                       -> None (no status label)
         CI not reported yet / running          -> awaiting-CI
-        CI failed                              -> awaiting-author
+        CI failed                              -> ci-failed
         CI green, review requested changes     -> awaiting-author
         CI green, every rubric approved        -> ready-to-merge
         CI green, review pending + live marker -> review-in-progress
@@ -78,7 +88,7 @@ def derived_label(status):
     if ci in (None, "running"):
         return "awaiting-CI"
     if ci == "failure":
-        return "awaiting-author"
+        return "ci-failed"
     # ci == "success"
     review = status["review"]
     if review == "changes":
@@ -107,11 +117,18 @@ def current_status_labels(pr):
 
 
 def ensure_label(name):
-    """Create the label if it does not exist yet (idempotent). Only a clear 404 on the probe means
-    'absent, create it'; any other probe failure is left alone (the add may still succeed, and we do
-    not want to mask a token/permission error as a missing label)."""
+    """Create the label if absent, and keep its colour and description matching LABELS (idempotent).
+
+    Only a clear 404 on the probe means 'absent, create it'; any other probe failure is left alone
+    (the add may still succeed, and we do not want to mask a token/permission error as a missing
+    label). When the label already exists we reconcile its presentation rather than returning
+    straight away: a label is created once and then lives forever, so editing a description in
+    LABELS would otherwise never reach GitHub and the live label would keep describing behaviour
+    this file no longer has. The probe already fetched it, so the comparison is free and only a
+    genuine mismatch costs a PATCH."""
     probe = _run([f"/repos/{REPO}/labels/{name}"])
     if probe.returncode == 0:
+        _reconcile_label_presentation(name, probe.stdout)
         return
     if "404" not in probe.stderr:
         return
@@ -123,6 +140,27 @@ def ensure_label(name):
     # A concurrent create (422 already_exists) is fine; anything else is a real error.
     if create.returncode != 0 and "already_exists" not in create.stderr:
         raise RuntimeError(f"gh api create label {name} failed: {create.stderr.strip()}")
+
+
+def _reconcile_label_presentation(name, probe_stdout):
+    """PATCH an existing label whose colour or description has drifted from LABELS.
+
+    Presentation is cosmetic, so this never raises: an unparseable probe body or a failed PATCH
+    leaves the label as it is and lets the caller get on with the actual add, which is what keeps
+    the PR list correct."""
+    color, description = LABELS[name]
+    try:
+        live = json.loads(probe_stdout)
+    except (ValueError, TypeError):
+        return
+    if live.get("color") == color and (live.get("description") or "") == description:
+        return
+    patch = _run([
+        "--method", "PATCH", f"/repos/{REPO}/labels/{name}",
+        "-f", f"color={color}", "-f", f"description={description}",
+    ])
+    if patch.returncode != 0:
+        log(f"note: could not update the {name} label's colour/description: {patch.stderr.strip()}")
 
 
 def add_label(pr, name):

--- a/scripts/pr_status/stuck_alerts.py
+++ b/scripts/pr_status/stuck_alerts.py
@@ -363,7 +363,7 @@ def detect_missing_required_status():
     A MISSING required status is worse than a red one and cannot self-heal. GitHub holds the PR
     at BLOCKED because the required check never arrives; core.derive sees no `build` status, so
     labels.py takes its ci=None branch and pins the PR at `awaiting-CI` instead of moving it to
-    `awaiting-author`; and nothing re-runs pr-build without a push, so no event ever corrects
+    `ci-failed`; and nothing re-runs pr-build without a push, so no event ever corrects
     it. PR #1358 sat wedged this way for seven days, invisible to the author and review paths
     alike, after a transient API error killed the status-reporting step mid-way.
     """

--- a/scripts/pr_status/test_pr_labels.py
+++ b/scripts/pr_status/test_pr_labels.py
@@ -5,9 +5,11 @@ Pure logic only: the GitHub-reading helpers in core and the label writes in labe
 these run with no network and no `gh`. Run with:  python3 -m unittest test_pr_labels
 """
 
+import json
 import os
 import sys
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -162,11 +164,18 @@ class DerivedLabel(unittest.TestCase):
         self.assertEqual(self.label(ci=None), "awaiting-CI")
         self.assertEqual(self.label(ci="running"), "awaiting-CI")
 
-    def test_ci_failure_is_awaiting_author(self):
-        self.assertEqual(self.label(ci="failure"), "awaiting-author")
+    def test_ci_failure_is_ci_failed(self):
+        self.assertEqual(self.label(ci="failure"), "ci-failed")
 
     def test_green_changes_is_awaiting_author(self):
         self.assertEqual(self.label(ci="success", review="changes"), "awaiting-author")
+
+    def test_a_red_build_outranks_the_review_verdict(self):
+        # Both states want the author, but they are told apart on purpose: a red build is read in the
+        # build log and a changes request in the review threads. A PR that is red AND has a changes
+        # request shows ci-failed, because nothing about the review can be trusted until it builds.
+        self.assertEqual(self.label(ci="failure", review="changes"), "ci-failed")
+        self.assertEqual(self.label(ci="failure", review="approved"), "ci-failed")
 
     def test_green_approved_is_ready(self):
         self.assertEqual(self.label(ci="success", review="approved"), "ready-to-merge")
@@ -182,7 +191,7 @@ class DerivedLabel(unittest.TestCase):
     def test_marker_only_overlays_the_awaiting_review_slot(self):
         # A live marker never overrides a more important state.
         self.assertEqual(self.label(ci="running", inprogress=True), "awaiting-CI")
-        self.assertEqual(self.label(ci="failure", inprogress=True), "awaiting-author")
+        self.assertEqual(self.label(ci="failure", inprogress=True), "ci-failed")
         self.assertEqual(self.label(ci="success", review="changes", inprogress=True), "awaiting-author")
         self.assertEqual(self.label(ci="success", review="approved", inprogress=True), "ready-to-merge")
 
@@ -284,6 +293,55 @@ class Reconcile(unittest.TestCase):
         labels.reconcile("1")
         self.assertEqual(self.added, [])
         self.assertEqual(sorted(self.removed), ["ready-to-merge", "review-in-progress"])
+
+
+class EnsureLabel(unittest.TestCase):
+    """A label is created once and then lives forever, so ensure_label has to keep an EXISTING
+    label's colour and description in step with LABELS -- otherwise editing a description here
+    would never reach GitHub and the live label would go on describing behaviour we changed."""
+
+    def setUp(self):
+        self._run = labels._run
+        self.calls = []
+        self.probe = None
+        labels._run = self.fake_run
+
+    def tearDown(self):
+        labels._run = self._run
+
+    def fake_run(self, args):
+        self.calls.append(args)
+        if args[0].startswith("/repos/") and len(args) == 1:      # the GET probe
+            if self.probe is None:
+                return SimpleNamespace(returncode=1, stdout="", stderr="gh: Not Found (HTTP 404)")
+            return SimpleNamespace(returncode=0, stdout=json.dumps(self.probe), stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def methods(self):
+        return [args[1] for args in self.calls if args[0] == "--method"]
+
+    def test_absent_label_is_created(self):
+        labels.ensure_label("ci-failed")
+        self.assertEqual(self.methods(), ["POST"])
+
+    def test_matching_label_is_left_alone(self):
+        color, description = labels.LABELS["ci-failed"]
+        self.probe = {"color": color, "description": description}
+        labels.ensure_label("ci-failed")
+        self.assertEqual(self.methods(), [])
+
+    def test_drifted_description_is_patched(self):
+        color, _ = labels.LABELS["awaiting-author"]
+        self.probe = {"color": color, "description": "The build failed or a review requested changes"}
+        labels.ensure_label("awaiting-author")
+        self.assertEqual(self.methods(), ["PATCH"])
+
+    def test_an_unreadable_probe_body_never_breaks_the_add(self):
+        labels._run = lambda args: (
+            self.calls.append(args)
+            or SimpleNamespace(returncode=0, stdout="not json", stderr="")
+        )
+        labels.ensure_label("ci-failed")   # must not raise; presentation is cosmetic
 
 
 if __name__ == "__main__":

--- a/scripts/test_pr_stats_graphs.py
+++ b/scripts/test_pr_stats_graphs.py
@@ -197,6 +197,31 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(len(metrics["in_review_hours"]), 1)
         self.assertEqual(metrics["other_open_prs"], 2)
 
+    def test_author_clock_survives_the_awaiting_author_to_ci_failed_split(self):
+        # The migration that introduced ci-failed relabels PRs that were already waiting on their
+        # author. That is the same wait continuing, not a new one, so the clock must still run from
+        # the original awaiting-author and not reset to the relabelling instant.
+        item = pr(1, 1, state="OPEN", labels=("ci-failed",))
+        item["labeled_events"] = [
+            {"created_at": timestamp(1, 0), "label": "awaiting-author"},
+            {"created_at": timestamp(4, 0), "label": "ci-failed"},
+        ]
+        metrics = stats.queue_age_metrics([item], datetime(2026, 1, 5, tzinfo=UTC))
+        self.assertEqual(metrics["awaiting_author_hours"], [96.0])
+        self.assertEqual(metrics["missing_transition_fallbacks"], 0)
+
+    def test_author_clock_restarts_when_the_pr_goes_back_through_ci(self):
+        # A push is a real fresh wait: the author acted, CI judged it, and it failed again.
+        item = pr(1, 1, state="OPEN", labels=("ci-failed",))
+        item["labeled_events"] = [
+            {"created_at": timestamp(1, 0), "label": "awaiting-author"},
+            {"created_at": timestamp(2, 0), "label": "awaiting-CI"},
+            {"created_at": timestamp(4, 0), "label": "ci-failed"},
+        ]
+        metrics = stats.queue_age_metrics([item], datetime(2026, 1, 5, tzinfo=UTC))
+        self.assertEqual(metrics["awaiting_author_hours"], [24.0])
+        self.assertEqual(metrics["missing_transition_fallbacks"], 0)
+
     def test_current_state_clock_rejects_stale_historical_transition(self):
         item = pr(1, 1, state="OPEN", labels=("awaiting-review",), cycles=1)
         item["labeled_events"].append({

--- a/web/Site/Stats.lean
+++ b/web/Site/Stats.lean
@@ -54,7 +54,7 @@ private def prPipelineGraphs : Html := {{
       <img class="loc-graph" src="static/pr-queue-age.svg"
            alt="Open pull request age, followed by time awaiting author and time in review"
            loading="lazy"/>
-      <figcaption>"Age of every open PR, then elapsed time in its current awaiting-author or review cycle."</figcaption>
+      <figcaption>"Age of every open PR, then elapsed time in its current author-action or review cycle."</figcaption>
     </figure>
     <figure class="loc-figure">
       <img class="loc-graph" src="static/rolling-seven-day-history.svg"
@@ -116,8 +116,10 @@ Infrastructure and refactor PRs, which advance no roadmap, are left out.
 :::
 
 How is the contribution and review pipeline behaving? The first chart separates a
-PR's total age from the clock on its current state. PRs outside the awaiting-author
-and review states appear in total time open but not in the two current-state panels.
+PR's total age from the clock on its current state. The author-action clock covers both
+states that wait on a human, a failed build and a review that requested changes. PRs
+outside the author-action and review states appear in total time open but not in the two
+current-state panels.
 The rolling history uses complete UTC days. The review-cycle chart counts durable label
 transitions rather than scoreboard comments, because a scoreboard
 may be edited in place as later rounds complete. A cycle is one entry into review from


### PR DESCRIPTION
This PR splits the `awaiting-author` status label in two and removes the `resolve` job from the path of every event whose payload already carries the PR number.

`awaiting-author` meant either "the build failed" or "a reviewer requested changes". Both wait on the author, but one is read in the build log and the other in the review threads, and a PR list that cannot tell them apart sends you to the wrong place. A red build now shows `ci-failed`, in its own colour; `awaiting-author` narrows to a changes request. The Zulip sink already drew this distinction (🔴 versus 🟢 + ✍️) and `core.derive` already returned `ci` and `review` separately, so only the label was collapsing them.

The PR number has to key the concurrency group, and a group expression is evaluated before the job starts, so a number that must be *computed* needs its own upstream job. Most events do not need computing: `pull_request_target`, `issue_comment` and same-repo `workflow_run` all carry the number in the payload, and under runner contention that second job costs a second queue wait. Those events now run a single `label` job. `resolve` survives for the two cases that earn it: a fork PR's `workflow_run`, where `pull_requests[]` is empty and the head SHA has to be scanned for, and a `workflow_dispatch`, whose untrusted input string must be validated down to digits. Both paths share the same `pr-labels-<number>` group, so events for one PR still cannot interleave a label add/remove.

`reconcile` no longer takes the PR's state and head SHA from the event payload. A payload is a snapshot of the moment the event fired, and after a queue wait it can describe a commit the PR has already moved past; one API call is a good price for a label that always reflects live truth. `ensure_label` now reconciles an existing label's colour and description instead of returning as soon as it exists, so an edit to a description in `LABELS` actually reaches GitHub rather than leaving the live label describing behaviour the code no longer has.

For the queue-age charts, `ci-failed` and `awaiting-author` are one state: `author_episode_start` runs the clock from where the PR entered the pair, so swapping one label for the other continues the same wait, while a trip back through `awaiting-CI` starts a fresh one. Without that, the migration itself would have reset every red PR's author clock.

Open PRs that are already red may receive no further event, and the hourly `sweep` only reconciles PRs holding `review-in-progress`, so they need one reconcile pass over every open PR once this merges. That pass has to run after the deploy and never before, since the currently deployed writer does not know `ci-failed` and would add a second label without removing the new one. `TauCetiWorker` hard-codes the five status labels for its dashboard line and needs the same update; its work selection reads build statuses and scoreboard state, so nothing there breaks in the meantime.

🤖 Prepared with Claude Code