### PR TITLE
refactor(JordanChevalley): name the passage of intertwining to inverses

### DIFF
--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean
@@ -39,13 +39,17 @@ theorem comp_inv_eq_of_comp_eq (f : V →ₗ[K] W) (a : GeneralLinearGroup K V)
     (b : GeneralLinearGroup K W)
     (hab : f.comp (a : Module.End K V) = (b : Module.End K W).comp f) :
     f.comp (↑a⁻¹ : Module.End K V) = (↑b⁻¹ : Module.End K W).comp f := by
-  -- `↑a⁻¹` is the inverse equivalence's map, so the transposition lemma for equivalences applies
-  change f.comp a.toLinearEquiv.symm.toLinearMap = _
-  rw [LinearEquiv.comp_toLinearMap_symm_eq, LinearMap.comp_assoc]
-  change _ = (↑b⁻¹ : Module.End K W).comp (f.comp (a : Module.End K V))
-  rw [hab, ← LinearMap.comp_assoc]
-  ext x
-  exact (b.toLinearEquiv.symm_apply_apply _).symm
+  have hb : (↑b⁻¹ : Module.End K W).comp (b : Module.End K W) = LinearMap.id := b.inv_val
+  have ha : (a : Module.End K V).comp (↑a⁻¹ : Module.End K V) = LinearMap.id := a.val_inv
+  calc f.comp (↑a⁻¹ : Module.End K V)
+      = ((LinearMap.id : Module.End K W).comp f).comp (↑a⁻¹ : Module.End K V) := by
+        rw [LinearMap.id_comp]
+    _ = (↑b⁻¹ : Module.End K W).comp ((f.comp (a : Module.End K V)).comp
+          (↑a⁻¹ : Module.End K V)) := by
+        rw [← hb, hab]
+        simp only [LinearMap.comp_assoc]
+    _ = (↑b⁻¹ : Module.End K W).comp f := by
+        rw [LinearMap.comp_assoc, ha, LinearMap.comp_id]
 
 end GeneralLinearGroup
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
+
+/-!
+# Intertwiners of linear automorphisms
+
+A linear map `f : V →ₗ[K] W` **intertwines** automorphisms `a` of `V` and `b` of `W` when
+`f ∘ a = b ∘ f`. This is the heterogeneous form of `SemiconjBy`: source and target live in
+different modules, so the relation is not a statement inside one monoid and Mathlib's
+`SemiconjBy` API does not apply to it.
+
+## Main declarations
+
+* `TauCeti.GeneralLinearGroup.comp_inv_eq_of_comp_eq`: an intertwiner of two automorphisms also
+  intertwines their inverses.
+-/
+
+public section
+
+namespace TauCeti
+
+open LinearMap
+
+namespace GeneralLinearGroup
+
+universe u v w
+
+variable {K : Type u} {V : Type v} {W : Type w}
+variable [Semiring K] [AddCommMonoid V] [Module K V] [AddCommMonoid W] [Module K W]
+
+/-- **Intertwining passes to inverses.** If `f` intertwines the automorphisms `a` and `b`, then it
+intertwines `a⁻¹` and `b⁻¹`. -/
+theorem comp_inv_eq_of_comp_eq (f : V →ₗ[K] W) (a : GeneralLinearGroup K V)
+    (b : GeneralLinearGroup K W)
+    (hab : f.comp (a : Module.End K V) = (b : Module.End K W).comp f) :
+    f.comp (↑a⁻¹ : Module.End K V) = (↑b⁻¹ : Module.End K W).comp f := by
+  -- `↑a⁻¹` is the inverse equivalence's map, so the transposition lemma for equivalences applies
+  change f.comp a.toLinearEquiv.symm.toLinearMap = _
+  rw [LinearEquiv.comp_toLinearMap_symm_eq, LinearMap.comp_assoc]
+  change _ = (↑b⁻¹ : Module.End K W).comp (f.comp (a : Module.End K V))
+  rw [hab, ← LinearMap.comp_assoc]
+  ext x
+  exact (b.toLinearEquiv.symm_apply_apply _).symm
+
+end GeneralLinearGroup
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
@@ -178,6 +178,29 @@ theorem comp_semisimplePart_eq_of_comp_eq
     LinearMap.prodMap_apply] at hpx
   exact hpx.symm
 
+omit [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W] in
+/-- **Intertwining passes to inverses.** If `f` intertwines the automorphisms `a` and `b`, then it
+intertwines `a⁻¹` and `b⁻¹`. -/
+theorem comp_inv_eq_of_comp_eq (f : V →ₗ[K] W) (a : GeneralLinearGroup K V)
+    (b : GeneralLinearGroup K W)
+    (hab : f.comp (a : Module.End K V) = (b : Module.End K W).comp f) :
+    f.comp (↑a⁻¹ : Module.End K V) = (↑b⁻¹ : Module.End K W).comp f := by
+  apply LinearMap.ext
+  intro x
+  calc
+    f ((↑a⁻¹ : Module.End K V) x) =
+        (↑b⁻¹ : Module.End K W)
+          ((b : Module.End K W) (f ((↑a⁻¹ : Module.End K V) x))) := by
+      exact ((b.toLinearEquiv.symm_apply_apply _).symm)
+    _ = (↑b⁻¹ : Module.End K W)
+        (f ((a : Module.End K V) ((↑a⁻¹ : Module.End K V) x))) := by
+      exact congrArg (↑b⁻¹ : Module.End K W)
+        (LinearMap.congr_fun hab ((↑a⁻¹ : Module.End K V) x)).symm
+    _ = (↑b⁻¹ : Module.End K W) (f x) := by
+      have hxa : (a : Module.End K V) ((↑a⁻¹ : Module.End K V) x) = x :=
+        LinearMap.congr_fun a.val_inv x
+      rw [hxa]
+
 /-- A linear map intertwining two automorphisms also intertwines their unipotent factors. -/
 theorem comp_unipotentPart_eq_of_comp_eq
     (f : V →ₗ[K] W) (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W)
@@ -185,28 +208,7 @@ theorem comp_unipotentPart_eq_of_comp_eq
     f.comp (unipotentPart g : Module.End K V) =
       (unipotentPart h : Module.End K W).comp f := by
   have hs := comp_semisimplePart_eq_of_comp_eq f g h hfg
-  have hs_inv :
-      f.comp (↑((semisimplePart g)⁻¹) : Module.End K V) =
-        (↑((semisimplePart h)⁻¹) : Module.End K W).comp f := by
-    apply LinearMap.ext
-    intro x
-    calc
-      f ((↑((semisimplePart g)⁻¹) : Module.End K V) x) =
-          (↑((semisimplePart h)⁻¹) : Module.End K W)
-            ((semisimplePart h : Module.End K W)
-              (f ((↑((semisimplePart g)⁻¹) : Module.End K V) x))) := by
-        exact ((semisimplePart h).toLinearEquiv.symm_apply_apply _).symm
-      _ = (↑((semisimplePart h)⁻¹) : Module.End K W)
-          (f ((semisimplePart g : Module.End K V)
-            ((↑((semisimplePart g)⁻¹) : Module.End K V) x))) := by
-        exact congrArg (↑((semisimplePart h)⁻¹) : Module.End K W)
-          (LinearMap.congr_fun hs
-            ((↑((semisimplePart g)⁻¹) : Module.End K V) x)).symm
-      _ = (↑((semisimplePart h)⁻¹) : Module.End K W) (f x) := by
-        have hxg : (semisimplePart g : Module.End K V)
-            ((↑((semisimplePart g)⁻¹) : Module.End K V) x) = x :=
-          LinearMap.congr_fun (semisimplePart g).val_inv x
-        rw [hxg]
+  have hs_inv := comp_inv_eq_of_comp_eq f (semisimplePart g) (semisimplePart h) hs
   have hug : unipotentPart g = (semisimplePart g)⁻¹ * g := by
     apply mul_left_cancel (a := semisimplePart g)
     simp

--- a/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.LinearAlgebra.JordanChevalley.Prod
+public import TauCeti.LinearAlgebra.GeneralLinearGroup.Intertwining
 
 /-!
 # Functoriality of the multiplicative Jordan decomposition
@@ -177,29 +178,6 @@ theorem comp_semisimplePart_eq_of_comp_eq
   rw [semisimplePart_prodMap, LinearMap.mem_graph_iff, coe_prodMap,
     LinearMap.prodMap_apply] at hpx
   exact hpx.symm
-
-omit [PerfectField K] [FiniteDimensional K V] [FiniteDimensional K W] in
-/-- **Intertwining passes to inverses.** If `f` intertwines the automorphisms `a` and `b`, then it
-intertwines `a⁻¹` and `b⁻¹`. -/
-theorem comp_inv_eq_of_comp_eq (f : V →ₗ[K] W) (a : GeneralLinearGroup K V)
-    (b : GeneralLinearGroup K W)
-    (hab : f.comp (a : Module.End K V) = (b : Module.End K W).comp f) :
-    f.comp (↑a⁻¹ : Module.End K V) = (↑b⁻¹ : Module.End K W).comp f := by
-  apply LinearMap.ext
-  intro x
-  calc
-    f ((↑a⁻¹ : Module.End K V) x) =
-        (↑b⁻¹ : Module.End K W)
-          ((b : Module.End K W) (f ((↑a⁻¹ : Module.End K V) x))) := by
-      exact ((b.toLinearEquiv.symm_apply_apply _).symm)
-    _ = (↑b⁻¹ : Module.End K W)
-        (f ((a : Module.End K V) ((↑a⁻¹ : Module.End K V) x))) := by
-      exact congrArg (↑b⁻¹ : Module.End K W)
-        (LinearMap.congr_fun hab ((↑a⁻¹ : Module.End K V) x)).symm
-    _ = (↑b⁻¹ : Module.End K W) (f x) := by
-      have hxa : (a : Module.End K V) ((↑a⁻¹ : Module.End K V) x) = x :=
-        LinearMap.congr_fun a.val_inv x
-      rw [hxa]
 
 /-- A linear map intertwining two automorphisms also intertwines their unipotent factors. -/
 theorem comp_unipotentPart_eq_of_comp_eq


### PR DESCRIPTION
`comp_unipotentPart_eq_of_comp_eq` transports the unipotent part of a Jordan decomposition across an intertwiner. It writes `unipotentPart g = (semisimplePart g)⁻¹ * g`, so it needs the intertwining relation for the *inverse* of the semisimple part — and proving that took twenty-two of its forty-two lines.

`GeneralLinearGroup.comp_inv_eq_of_comp_eq` states it: if `f` intertwines the automorphisms `a` and `b`, then it intertwines `a⁻¹` and `b⁻¹`.

Nothing in that is about Jordan decompositions, so it does not live in `JordanChevalley/`. It goes in a new `TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean`, beside the existing `GeneralLinearGroup/Prod.lean`, which already carries exactly the right assumptions: `[Semiring K] [AddCommMonoid V] [Module K V] [AddCommMonoid W] [Module K W]`. The enclosing section in `Functoriality.lean` had `[Field K]`, `[PerfectField K]` and finite-dimensionality of both modules; the statement needs none of them, and it is about invertible endomorphisms, which exist over a semiring.

Its hypotheses are re-derived rather than inherited. The parent's `g`, `h`, `hfg` and the semisimple parts are all in scope and none appear; the statement takes an arbitrary pair of automorphisms and the intertwining relation between them, and the parent instantiates it at the semisimple parts.

The proof is unit algebra rather than a pointwise argument. `b.inv_val` and `a.val_inv` are the two unit relations, already stated as compositions of endomorphisms; inserting `b⁻¹ ∘ b` for the identity, rewriting with the hypothesis and cancelling `a ∘ a⁻¹` is the whole of it. That is a nine-line `calc` with no `ext`, no coercion reshaping and no appeal to definitional equality, against the original twenty-two lines.

This is the heterogeneous form of `SemiconjBy`: source and target are different modules, so `f ∘ a = b ∘ f` is not a relation inside a single monoid and Mathlib's `SemiconjBy` API — including `SemiconjBy.units_inv_right`, which is exactly this statement in the homogeneous case — does not apply. The module docstring records that.

The parent drops from 42 lines to 21.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: ReductiveGroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
