### PR TITLE
feat: complete Tannakian reconstruction

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
@@ -64,15 +64,20 @@ private theorem counitEvaluation_matrixCoefficientSubcoalgebraHom
           (M := M)).toRegularSubcomodule
         ((Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi).toLinearMap.baseChange A z) =
       Module.Dual.baseChange A phi z := by
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | add z w hz hw => simp only [map_add, hz, hw]
-  | tmul b n =>
-      simp only [LinearMap.baseChange_tmul, counitEvaluation_tmul]
-      rw [Comodule.Hom.coe_toLinearMap,
-        Comodule.matrixCoefficientSubcoalgebraHom_apply_coe,
-        Comodule.matrixCoefficientHom_apply, Comodule.counit_matrixCoefficient]
-      simp [Module.Dual.baseChange_apply_tmul, Algebra.smul_def, mul_comm]
+  rw [counitEvaluation_apply, ← LinearMap.comp_apply, ← LinearMap.baseChange_comp]
+  have hcomp :
+      (Coalgebra.counit (R := k) (A := H)).comp
+          (SMulMemClass.subtype
+            (Comodule.matrixCoefficientSubcoalgebra (R := k) (C := H)
+              (M := M)).toRegularSubcomodule) ∘ₗ
+        (Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi).toLinearMap =
+      (Coalgebra.counit (R := k) (A := H)).comp
+        (Comodule.matrixCoefficientHom (C := H) phi).toLinearMap := by
+    ext m
+    exact congrArg (Coalgebra.counit (R := k) (A := H))
+      (Comodule.matrixCoefficientSubcoalgebraHom_apply_coe phi m)
+  rw [hcomp, LinearMap.baseChange_comp]
+  exact Comodule.counit_baseChange_matrixCoefficientHom (C := H) A phi z
 
 private theorem scalarExtensionComponent_reconstructedPoint_tmul
     (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
@@ -47,12 +47,6 @@ universe u
 variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
   [CommRing A] [Algebra k A]
 
-private theorem baseChange_eq_baseChangeEvaluation_one
-    (M : FGComoduleCat.{u, u, u} k H) (phi : Module.Dual k M) (z : A ⊗[k] M) :
-    Module.Dual.baseChange A phi z =
-      TauCeti.Module.Dual.baseChangeEvaluation (1 ⊗ₜ[k] phi) z := by
-  rw [TauCeti.Module.Dual.baseChangeEvaluation_one_tmul]
-
 private theorem counitEvaluation_matrixCoefficientSubcoalgebraHom
     (M : FGComoduleCat.{u, u, u} k H) (phi : Module.Dual k M) (z : A ⊗[k] M) :
     counitEvaluation k H A
@@ -86,7 +80,6 @@ private theorem scalarExtensionComponent_reconstructedPoint_tmul
   let D := Comodule.matrixCoefficientSubcoalgebra (R := k) (C := H) (M := M)
   let N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H) :=
     ⟨D.toRegularSubcomodule, Subcomodule.mem_finiteSubcomodules.mpr inferInstance⟩
-  let hNfinite : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
   let q := Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi
   let f : M ⟶ finiteRegularObject k H N :=
     ⟨ComoduleCat.ofHom (R := k) (C := H) q⟩
@@ -118,7 +111,7 @@ private theorem scalarExtensionComponent_reconstructedPoint_tmul
             rfl
     _ = (reconstructedPoint k H A eta).ofConv
           (Comodule.matrixCoefficient (R := k) (C := H) phi m) := by
-            rw [baseChange_eq_baseChangeEvaluation_one k H A M phi, hpointAction]
+            rw [← TauCeti.Module.Dual.baseChangeEvaluation_one_tmul phi, hpointAction]
             simpa only [one_mul] using
               Comodule.baseChangeEvaluation_endOfPoint_tmul
                 (reconstructedPoint k H A eta).ofConv (1 : A) (1 : A) phi m
@@ -165,7 +158,7 @@ automorphism. Thus reconstruction is a right inverse to the tensor action of poi
 theorem fgPointTensorIso_reconstructedPoint
     (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) :
     fgPointTensorIso k H A (reconstructedPoint k H A eta) = eta := by
-  apply eq_of_scalarExtensionComponent_eq
+  apply scalarExtensionComponent_ext
   exact scalarExtensionComponent_reconstructedPoint k H A eta
 
 /-- Algebra-valued points of a commutative Hopf algebra over a field are equivalent to tensor

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
@@ -69,10 +69,8 @@ private theorem counitEvaluation_matrixCoefficientSubcoalgebraHom
   | add z w hz hw => simp only [map_add, hz, hw]
   | tmul b n =>
       simp only [LinearMap.baseChange_tmul, counitEvaluation_tmul]
-      rw [show
-        ((Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi).toLinearMap n : H) =
-          (Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi n : H) from rfl]
-      rw [Comodule.matrixCoefficientSubcoalgebraHom_apply_coe,
+      rw [Comodule.Hom.coe_toLinearMap,
+        Comodule.matrixCoefficientSubcoalgebraHom_apply_coe,
         Comodule.matrixCoefficientHom_apply, Comodule.counit_matrixCoefficient]
       simp [Module.Dual.baseChange_apply_tmul, Algebra.smul_def, mul_comm]
 
@@ -149,17 +147,11 @@ private theorem scalarExtensionComponent_reconstructedPoint
     scalarExtensionComponent k H A
         (fgPointTensorIso k H A (reconstructedPoint k H A eta)) M =
       scalarExtensionComponent k H A eta M := by
+  apply (LinearMap.liftBaseChangeEquiv A).symm.injective
   apply LinearMap.ext
-  intro x
-  induction x using TensorProduct.induction_on with
-  | zero => simp
-  | add x y hx hy => simpa only [map_add] using congrArg₂ (· + ·) hx hy
-  | tmul a m =>
-      have htmul : a ⊗ₜ[k] m = a • (1 ⊗ₜ[k] m) := by
-        simp [TensorProduct.smul_tmul']
-      rw [htmul, map_smul, map_smul]
-      congr 1
-      exact scalarExtensionComponent_reconstructedPoint_tmul k H A eta M m
+  intro m
+  simpa only [LinearMap.liftBaseChangeEquiv_symm_apply] using
+    scalarExtensionComponent_reconstructedPoint_tmul k H A eta M m
 
 /-- The tensor automorphism induced by a reconstructed point is the original tensor
 automorphism. Thus reconstruction is a right inverse to the tensor action of points. -/
@@ -167,26 +159,8 @@ automorphism. Thus reconstruction is a right inverse to the tensor action of poi
 theorem fgPointTensorIso_reconstructedPoint
     (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) :
     fgPointTensorIso k H A (reconstructedPoint k H A eta) = eta := by
-  apply Aut.ext
-  apply LaxMonoidalFunctor.hom_ext
-  apply NatTrans.ext
-  funext M
-  let hM : (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).obj M =
-      SemimoduleCat.of A (A ⊗[k] M) :=
-    FGComoduleCat.scalarExtensionFunctor_obj k H A M
-  have hcomponent := congrArg SemimoduleCat.ofHom
-    (scalarExtensionComponent_reconstructedPoint k H A eta M)
-  rw [ofHom_scalarExtensionComponent k H A
-      (fgPointTensorIso k H A (reconstructedPoint k H A eta)) M hM,
-    ofHom_scalarExtensionComponent k H A eta M hM] at hcomponent
-  have hpre :
-      eqToHom hM.symm ≫
-          (fgPointTensorIso k H A (reconstructedPoint k H A eta)).hom.hom.app M =
-        eqToHom hM.symm ≫ eta.hom.hom.app M := by
-    apply (cancel_mono (eqToHom hM)).mp
-    rw [Category.assoc, Category.assoc]
-    exact hcomponent
-  exact (cancel_epi (eqToHom hM.symm)).mp hpre
+  apply eq_of_scalarExtensionComponent_eq
+  exact scalarExtensionComponent_reconstructedPoint k H A eta
 
 /-- Algebra-valued points of a commutative Hopf algebra over a field are equivalent to tensor
 automorphisms of scalar extension on its finite-dimensional comodules. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
@@ -51,11 +51,7 @@ private theorem baseChange_eq_baseChangeEvaluation_one
     (M : FGComoduleCat.{u, u, u} k H) (phi : Module.Dual k M) (z : A ⊗[k] M) :
     Module.Dual.baseChange A phi z =
       TauCeti.Module.Dual.baseChangeEvaluation (1 ⊗ₜ[k] phi) z := by
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | add z w hz hw => simp only [map_add, hz, hw]
-  | tmul b n =>
-      simp [Module.Dual.baseChange_apply_tmul, Algebra.smul_def, mul_comm]
+  rw [TauCeti.Module.Dual.baseChangeEvaluation_one_tmul]
 
 private theorem counitEvaluation_matrixCoefficientSubcoalgebraHom
     (M : FGComoduleCat.{u, u, u} k H) (phi : Module.Dual k M) (z : A ⊗[k] M) :
@@ -98,7 +94,13 @@ private theorem scalarExtensionComponent_reconstructedPoint_tmul
   -- to the finite regular subcomodule on which reconstruction is defined.
   have hnatural := LinearMap.congr_fun
     (scalarExtensionComponent_natural k H A eta f) (1 ⊗ₜ[k] m)
-  simp only [LinearMap.comp_apply, LinearMap.baseChange_tmul] at hnatural
+  simp only [LinearMap.comp_apply] at hnatural
+  have hf_baseChange_tmul :
+      f.hom.toLinearMap.baseChange A (1 ⊗ₜ[k] m) =
+        1 ⊗ₜ[k] Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi m := by
+    rw [LinearMap.baseChange_tmul]
+    exact congrArg (fun n => (1 : A) ⊗ₜ[k] n)
+      (ComoduleCat.ofHom_apply (R := k) (C := H) q m)
   have hpointAction :
       Comodule.pointsAction M (reconstructedPoint k H A eta) (1 ⊗ₜ[k] m) =
         Comodule.endOfPoint M (reconstructedPoint k H A eta).ofConv (1 ⊗ₜ[k] m) :=
@@ -136,8 +138,7 @@ private theorem scalarExtensionComponent_reconstructedPoint_tmul
     _ = counitEvaluation k H A N.1
           (f.hom.toLinearMap.baseChange A
             (scalarExtensionComponent k H A eta M (1 ⊗ₜ[k] m))) := by
-            rw [hnatural]
-            rfl
+            rw [← hf_baseChange_tmul, ← hnatural]
     _ = Module.Dual.baseChange A phi
           (scalarExtensionComponent k H A eta M (1 ⊗ₜ[k] m)) := by
             simpa only [f, q, N, D] using

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.Reconstruction
+import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.Morphism
+
+/-!
+# Tannakian reconstruction for affine group schemes
+
+Let `H` be a commutative Hopf algebra over a field `k`, and let `A` be a commutative
+`k`-algebra. This file identifies the `A`-valued points of `H` with the tensor automorphisms of
+scalar extension on finite-dimensional `H`-comodules.
+
+The remaining inverse direction in the reconstruction theorem is detected by matrix
+coefficients. For a finite comodule `M`, every coefficient map is a comodule morphism from `M`
+to a finite subcomodule of the regular comodule. Naturality compares an arbitrary tensor
+automorphism on these two objects. Applying the counit then reads the comparison as the global
+functional used to reconstruct the point, and the scalar-extended dual separates elements of
+`A ⊗[k] M`.
+
+## Main declarations
+
+* `TauCeti.Tannaka.fgPointTensorIso_reconstructedPoint`: reconstruction is a right inverse to
+  the point action.
+* `TauCeti.Tannaka.fgPointTensorIsoEquiv`: the Tannakian equivalence between algebra-valued
+  points and tensor automorphisms of finite-comodule scalar extension.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §9.4.
+* `Mathlib/RepresentationTheory/Tannaka.lean`: the final `MulEquiv.ofBijective` packaging follows
+  the finite-group Tannaka theorem there.
+-/
+
+public section
+
+open CategoryTheory WithConv
+open scoped TensorProduct
+
+namespace TauCeti.Tannaka
+
+universe u
+
+variable (k H A : Type u) [Field k] [CommRing H] [HopfAlgebra k H]
+  [CommRing A] [Algebra k A]
+
+private theorem baseChange_eq_baseChangeEvaluation_one
+    (M : FGComoduleCat.{u, u, u} k H) (phi : Module.Dual k M) (z : A ⊗[k] M) :
+    Module.Dual.baseChange A phi z =
+      TauCeti.Module.Dual.baseChangeEvaluation (1 ⊗ₜ[k] phi) z := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z w hz hw => simp only [map_add, hz, hw]
+  | tmul b n =>
+      simp [Module.Dual.baseChange_apply_tmul, Algebra.smul_def, mul_comm]
+
+private theorem counitEvaluation_matrixCoefficientSubcoalgebraHom
+    (M : FGComoduleCat.{u, u, u} k H) (phi : Module.Dual k M) (z : A ⊗[k] M) :
+    counitEvaluation k H A
+        (Comodule.matrixCoefficientSubcoalgebra (R := k) (C := H)
+          (M := M)).toRegularSubcomodule
+        ((Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi).toLinearMap.baseChange A z) =
+      Module.Dual.baseChange A phi z := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z w hz hw => simp only [map_add, hz, hw]
+  | tmul b n =>
+      simp only [LinearMap.baseChange_tmul, counitEvaluation_tmul]
+      rw [show
+        ((Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi).toLinearMap n : H) =
+          (Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi n : H) from rfl]
+      rw [Comodule.matrixCoefficientSubcoalgebraHom_apply_coe,
+        Comodule.matrixCoefficientHom_apply, Comodule.counit_matrixCoefficient]
+      simp [Module.Dual.baseChange_apply_tmul, Algebra.smul_def, mul_comm]
+
+private theorem scalarExtensionComponent_reconstructedPoint_tmul
+    (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
+    (M : FGComoduleCat.{u, u, u} k H) (m : M) :
+    scalarExtensionComponent k H A
+        (fgPointTensorIso k H A (reconstructedPoint k H A eta)) M (1 ⊗ₜ[k] m) =
+      scalarExtensionComponent k H A eta M (1 ⊗ₜ[k] m) := by
+  apply TauCeti.Module.Dual.eq_of_baseChange_eq (A := A)
+  intro phi
+  let D := Comodule.matrixCoefficientSubcoalgebra (R := k) (C := H) (M := M)
+  let N : Subcomodule.finiteSubcomodules (R := k) (C := H) (M := H) :=
+    ⟨D.toRegularSubcomodule, Subcomodule.mem_finiteSubcomodules.mpr inferInstance⟩
+  let hNfinite : Module.Finite k N.1 := Subcomodule.mem_finiteSubcomodules.mp N.2
+  let q := Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi
+  let f : M ⟶ finiteRegularObject k H N :=
+    ⟨ComoduleCat.ofHom (R := k) (C := H) q⟩
+  -- Naturality along the corestricted coefficient morphism moves the comparison from `M`
+  -- to the finite regular subcomodule on which reconstruction is defined.
+  have hnatural := LinearMap.congr_fun
+    (scalarExtensionComponent_natural k H A eta f) (1 ⊗ₜ[k] m)
+  simp only [LinearMap.comp_apply, LinearMap.baseChange_tmul] at hnatural
+  have hpointAction :
+      Comodule.pointsAction M (reconstructedPoint k H A eta) (1 ⊗ₜ[k] m) =
+        Comodule.endOfPoint M (reconstructedPoint k H A eta).ofConv (1 ⊗ₜ[k] m) :=
+    LinearMap.congr_fun
+      (Comodule.pointsAction_toLinearMap M (reconstructedPoint k H A eta)) _
+  -- Evaluate both components against `phi`: point action gives the reconstructed functional,
+  -- while naturality and counit evaluation give the same local functional.
+  calc
+    Module.Dual.baseChange A phi
+        (scalarExtensionComponent k H A
+          (fgPointTensorIsoHom k H A (reconstructedPoint k H A eta)) M (1 ⊗ₜ[k] m)) =
+        Module.Dual.baseChange A phi
+          (Comodule.pointsAction M (reconstructedPoint k H A eta) (1 ⊗ₜ[k] m)) := by
+            rw [fgPointTensorIsoHom_apply, scalarExtensionComponent_fgPointTensorIso]
+            rfl
+    _ = (reconstructedPoint k H A eta).ofConv
+          (Comodule.matrixCoefficient (R := k) (C := H) phi m) := by
+            rw [baseChange_eq_baseChangeEvaluation_one k H A M phi, hpointAction]
+            simpa only [one_mul] using
+              Comodule.baseChangeEvaluation_endOfPoint_tmul
+                (reconstructedPoint k H A eta).ofConv (1 : A) (1 : A) phi m
+    _ = globalFunctional k H A eta
+          (Comodule.matrixCoefficient (R := k) (C := H) phi m) := by
+            rw [reconstructedPoint_apply]
+    _ = localFunctional k H A eta N
+          (Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi m) := by
+            rw [← globalFunctional_apply k H A eta N]
+            congr 1
+            simpa only [Comodule.matrixCoefficientHom_apply] using
+              (Comodule.matrixCoefficientSubcoalgebraHom_apply_coe phi m).symm
+    _ = counitEvaluation k H A N.1
+          (scalarExtensionComponent k H A eta (finiteRegularObject k H N)
+            (1 ⊗ₜ[k] Comodule.matrixCoefficientSubcoalgebraHom (C := H) phi m)) := by
+            rw [localFunctional_apply]
+    _ = counitEvaluation k H A N.1
+          (f.hom.toLinearMap.baseChange A
+            (scalarExtensionComponent k H A eta M (1 ⊗ₜ[k] m))) := by
+            rw [hnatural]
+            rfl
+    _ = Module.Dual.baseChange A phi
+          (scalarExtensionComponent k H A eta M (1 ⊗ₜ[k] m)) := by
+            simpa only [f, q, N, D] using
+              counitEvaluation_matrixCoefficientSubcoalgebraHom k H A M phi
+                (scalarExtensionComponent k H A eta M (1 ⊗ₜ[k] m))
+
+/-- The component of the point reconstructed from a tensor automorphism is the original
+component on every finite-dimensional comodule. -/
+private theorem scalarExtensionComponent_reconstructedPoint
+    (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
+    (M : FGComoduleCat.{u, u, u} k H) :
+    scalarExtensionComponent k H A
+        (fgPointTensorIso k H A (reconstructedPoint k H A eta)) M =
+      scalarExtensionComponent k H A eta M := by
+  apply LinearMap.ext
+  intro x
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simpa only [map_add] using congrArg₂ (· + ·) hx hy
+  | tmul a m =>
+      have htmul : a ⊗ₜ[k] m = a • (1 ⊗ₜ[k] m) := by
+        simp [TensorProduct.smul_tmul']
+      rw [htmul, map_smul, map_smul]
+      congr 1
+      exact scalarExtensionComponent_reconstructedPoint_tmul k H A eta M m
+
+/-- The tensor automorphism induced by a reconstructed point is the original tensor
+automorphism. Thus reconstruction is a right inverse to the tensor action of points. -/
+@[simp]
+theorem fgPointTensorIso_reconstructedPoint
+    (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) :
+    fgPointTensorIso k H A (reconstructedPoint k H A eta) = eta := by
+  apply Aut.ext
+  apply LaxMonoidalFunctor.hom_ext
+  apply NatTrans.ext
+  funext M
+  let hM : (FGComoduleCat.scalarExtensionMonoidalFunctor k H A).obj M =
+      SemimoduleCat.of A (A ⊗[k] M) :=
+    FGComoduleCat.scalarExtensionFunctor_obj k H A M
+  have hcomponent := congrArg SemimoduleCat.ofHom
+    (scalarExtensionComponent_reconstructedPoint k H A eta M)
+  rw [ofHom_scalarExtensionComponent k H A
+      (fgPointTensorIso k H A (reconstructedPoint k H A eta)) M hM,
+    ofHom_scalarExtensionComponent k H A eta M hM] at hcomponent
+  have hpre :
+      eqToHom hM.symm ≫
+          (fgPointTensorIso k H A (reconstructedPoint k H A eta)).hom.hom.app M =
+        eqToHom hM.symm ≫ eta.hom.hom.app M := by
+    apply (cancel_mono (eqToHom hM)).mp
+    rw [Category.assoc, Category.assoc]
+    exact hcomponent
+  exact (cancel_epi (eqToHom hM.symm)).mp hpre
+
+/-- Algebra-valued points of a commutative Hopf algebra over a field are equivalent to tensor
+automorphisms of scalar extension on its finite-dimensional comodules. -/
+noncomputable def fgPointTensorIsoEquiv :
+    WithConv (H →ₐ[k] A) ≃*
+      Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A) :=
+  MulEquiv.ofBijective (fgPointTensorIsoHom k H A) ⟨
+    Function.LeftInverse.injective (reconstructedPoint_fgPointTensorIso k H A),
+    Function.RightInverse.surjective (fgPointTensorIso_reconstructedPoint k H A)⟩
+
+/-- The Tannakian equivalence sends a point to its tensor action. -/
+@[simp]
+theorem fgPointTensorIsoEquiv_apply (g : WithConv (H →ₐ[k] A)) :
+    fgPointTensorIsoEquiv k H A g = fgPointTensorIso k H A g :=
+  (rfl)
+
+/-- The inverse Tannakian equivalence reconstructs the point of a tensor automorphism. -/
+@[simp]
+theorem fgPointTensorIsoEquiv_symm_apply
+    (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A)) :
+    (fgPointTensorIsoEquiv k H A).symm eta = reconstructedPoint k H A eta := by
+  apply (fgPointTensorIsoEquiv k H A).injective
+  rw [MulEquiv.apply_symm_apply, fgPointTensorIsoEquiv_apply,
+    fgPointTensorIso_reconstructedPoint]
+
+end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
@@ -88,10 +88,10 @@ theorem counitEvaluation_apply (N : Subcomodule k H H) (z : A ⊗[k] N) :
       (TensorProduct.AlgebraTensorModule.rid k A A)
         (((Coalgebra.counit (R := k) (A := H)).comp
           (SMulMemClass.subtype N)).baseChange A z) := by
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | add x y hx hy => simp only [map_add, hx, hy]
-  | tmul a n => simp [Algebra.smul_def, mul_comm]
+  simp only [counitEvaluation, TauCeti.Module.Dual.baseChangeEvaluation_one_tmul,
+    Module.Dual.baseChange,
+    LinearMap.compRight_apply, LinearMap.baseChangeHom_apply, LinearMap.coe_comp,
+    Function.comp_apply, LinearEquiv.coe_coe]
 
 end CounitEvaluation
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
@@ -81,6 +81,18 @@ theorem counitEvaluation_tmul (N : Subcomodule k H H) (a : A) (n : N) :
       a * algebraMap k A (Coalgebra.counit (R := k) (A := H) (n : H)) := by
   simp [counitEvaluation]
 
+/-- Counit evaluation is the base change of the counit restricted to the regular
+subcomodule. -/
+theorem counitEvaluation_apply (N : Subcomodule k H H) (z : A ⊗[k] N) :
+    counitEvaluation k H A N z =
+      (TensorProduct.AlgebraTensorModule.rid k A A)
+        (((Coalgebra.counit (R := k) (A := H)).comp
+          (SMulMemClass.subtype N)).baseChange A z) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [map_add, hx, hy]
+  | tmul a n => simp [Algebra.smul_def, mul_comm]
+
 end CounitEvaluation
 
 section LocalFunctional

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -83,7 +83,9 @@ theorem scalarExtensionComponent_apply
           (eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm x)) := by
   rfl
 
-private theorem ofHom_scalarExtensionComponent
+/-- Bundling a transported tensor-automorphism component as a semimodule morphism recovers the
+conjugation of the original component by the scalar-extension object's defining equality. -/
+theorem ofHom_scalarExtensionComponent
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
     (M : FGComoduleCat.{u, v, u} R H)
     (h : (FGComoduleCat.scalarExtensionFunctor R H A).obj M =

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -98,7 +98,7 @@ private theorem ofHom_scalarExtensionComponent
 /-- Tensor automorphisms of scalar extension are equal when all their explicitly transported
 components are equal. -/
 @[ext]
-theorem eq_of_scalarExtensionComponent_eq
+theorem scalarExtensionComponent_ext
     (η θ : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
     (h : ∀ M, scalarExtensionComponent R H A η M =
       scalarExtensionComponent R H A θ M) :

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -97,6 +97,7 @@ private theorem ofHom_scalarExtensionComponent
 
 /-- Tensor automorphisms of scalar extension are equal when all their explicitly transported
 components are equal. -/
+@[ext]
 theorem eq_of_scalarExtensionComponent_eq
     (η θ : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
     (h : ∀ M, scalarExtensionComponent R H A η M =

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -83,9 +83,7 @@ theorem scalarExtensionComponent_apply
           (eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm x)) := by
   rfl
 
-/-- Bundling a transported tensor-automorphism component as a semimodule morphism recovers the
-conjugation of the original component by the scalar-extension object's defining equality. -/
-theorem ofHom_scalarExtensionComponent
+private theorem ofHom_scalarExtensionComponent
     (η : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
     (M : FGComoduleCat.{u, v, u} R H)
     (h : (FGComoduleCat.scalarExtensionFunctor R H A).obj M =
@@ -96,6 +94,31 @@ theorem ofHom_scalarExtensionComponent
           eqToHom h := by
   cases Subsingleton.elim h (FGComoduleCat.scalarExtensionFunctor_obj R H A M)
   rfl
+
+/-- Tensor automorphisms of scalar extension are equal when all their explicitly transported
+components are equal. -/
+theorem eq_of_scalarExtensionComponent_eq
+    (η θ : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
+    (h : ∀ M, scalarExtensionComponent R H A η M =
+      scalarExtensionComponent R H A θ M) :
+    η = θ := by
+  apply Aut.ext
+  apply LaxMonoidalFunctor.hom_ext
+  apply NatTrans.ext
+  funext M
+  let hM : (FGComoduleCat.scalarExtensionMonoidalFunctor R H A).obj M =
+      SemimoduleCat.of A (A ⊗[R] M) :=
+    FGComoduleCat.scalarExtensionFunctor_obj R H A M
+  have hcomponent := congrArg SemimoduleCat.ofHom (h M)
+  rw [ofHom_scalarExtensionComponent R H A η M hM,
+    ofHom_scalarExtensionComponent R H A θ M hM] at hcomponent
+  have hpre :
+      eqToHom hM.symm ≫ η.hom.hom.app M =
+        eqToHom hM.symm ≫ θ.hom.hom.app M := by
+    apply (cancel_mono (eqToHom hM)).mp
+    rw [Category.assoc, Category.assoc]
+    exact hcomponent
+  exact (cancel_epi (eqToHom hM.symm)).mp hpre
 
 /-- Naturality of the explicitly transported components of a tensor automorphism. -/
 theorem scalarExtensionComponent_natural

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Morphism.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Morphism.lean
@@ -36,6 +36,8 @@ then recovers the original finite-comodule component.
 * `TauCeti.Comodule.matrixCoefficientHom`: a matrix coefficient as a comodule morphism to the
   regular comodule.
 * `TauCeti.Comodule.matrixCoefficientHomLinear`: linearity in the functional.
+* `TauCeti.Comodule.counit_baseChange_matrixCoefficientHom`: counit evaluation after scalar
+  extension recovers the original functional.
 * `TauCeti.Comodule.eq_of_matrixCoefficientHom_eq`: coefficient morphisms jointly separate
   vectors in a free module.
 * `TauCeti.Comodule.eq_of_baseChange_matrixCoefficientHom_eq`: joint separation after
@@ -149,7 +151,9 @@ variable (A : Type x) [CommSemiring A] [Algebra R A]
 variable [Module.Free R M]
 
 omit [Module.Free R M] in
-private theorem counit_baseChange_matrixCoefficientHom (φ : Module.Dual R M)
+/-- Applying the scalar-extended counit after a scalar-extended matrix-coefficient morphism
+recovers the scalar extension of the original functional. -/
+theorem counit_baseChange_matrixCoefficientHom (φ : Module.Dual R M)
     (z : A ⊗[R] M) :
     (TensorProduct.AlgebraTensorModule.rid R A A)
         ((Coalgebra.counit (R := R) (A := C)).baseChange A

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -18,6 +18,8 @@ extension.
 ## Main declarations
 
 * `TauCeti.Module.Dual.baseChangeEvaluation`: the canonical scalar-extended evaluation map.
+* `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul`: evaluation at a scalar-extended
+  functional with coefficient one is its base change.
 * `TauCeti.Module.Dual.baseChangeEvaluation_tmul`: its value on two pure tensors.
 * `TauCeti.Module.Dual.baseChange_coord`: base-changed dual basis elements recover the
   coordinates in the base-changed basis.
@@ -44,6 +46,12 @@ This map requires no finiteness hypothesis and is not asserted to be an equivale
 def baseChangeEvaluation :
     A ⊗[R] Module.Dual R M →ₗ[A] Module.Dual A (A ⊗[R] M) :=
   (Module.Dual.baseChange A).liftBaseChange A
+
+/-- Evaluating at the pure tensor `1 ⊗ φ` is the base change of `φ`. -/
+theorem baseChangeEvaluation_one_tmul (φ : Module.Dual R M) :
+    baseChangeEvaluation (R := R) (M := M) (A := A) (1 ⊗ₜ[R] φ) =
+      Module.Dual.baseChange A φ := by
+  simp only [baseChangeEvaluation, LinearMap.liftBaseChange_tmul, one_smul]
 
 /-- On pure tensors, scalar-extended evaluation is
 `⟨a ⊗ φ, b ⊗ m⟩ = a * b * algebraMap R A (φ m)`. -/


### PR DESCRIPTION
This PR completes Tannakian reconstruction for commutative Hopf algebras over a field: identify every tensor automorphism of finite-comodule scalar extension with the action of its reconstructed algebra-valued point, then package algebra-valued points and tensor automorphisms as a multiplicative equivalence.

The exact target is `ReductiveGroups/README.md`, Layer 1, milestone **“Tannakian reconstruction: recover `G` from its tensor category of representations.”** The preceding reconstruction module already turns a tensor automorphism into a point and proves that reconstructing a point action returns the point. This PR proves the converse `fgPointTensorIso_reconstructedPoint` and defines `fgPointTensorIsoEquiv`, closing the milestone. After this PR, Layer 1 has no remaining roadmap target; the next unresolved critical-path target is the Layer 2 adjoint action `Ad : G → GL(Lie G)`.

For a finite comodule `M` and a functional `φ : Mᵛ`, corestrict the associated matrix-coefficient morphism `M → H` to its finite coefficient subcoalgebra. Naturality moves the tensor-automorphism component from `M` to that finite regular subcomodule, where counit evaluation is exactly the local functional used by reconstruction. The reconstructed point therefore agrees with the original component after every scalar-extended functional; the scalar-extended dual separates vectors because `M` is finite free over the field. Tensor induction upgrades the equality from `1 ⊗ m` to the whole scalar extension, and extensionality gives equality of tensor automorphisms.

Add `TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean` (215 lines). Also expose and document `ofHom_scalarExtensionComponent` in `Tannaka/Monoidal.lean`, the characteristic categorical bridge needed to turn equality of transported components into equality of natural automorphisms. The public equivalence includes simp equations for both directions; proof-only matrix-coefficient infrastructure remains a private import.

The mathematical construction follows J. S. Milne, *Algebraic Groups* (2017), §9.4, as cited in the new module. The final `MulEquiv.ofBijective` packaging follows the pattern of Mathlib's finite-group Tannaka theorem in `Mathlib/RepresentationTheory/Tannaka.lean`; no Mathlib source is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tannaka-reconstruction-right-inverse"}-->

🤖 Prepared with Codex
