### PR TITLE
feat(Huber): bound a valuation on a basic neighbourhood of zero

### DIFF
--- a/TauCeti/RingTheory/Huber/ContinuousValuation.lean
+++ b/TauCeti/RingTheory/Huber/ContinuousValuation.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.RingTheory.Huber.Basic
 public import TauCeti.RingTheory.Valuation.Continuous
-public import TauCeti.RingTheory.Valuation.SpanPow
+import TauCeti.RingTheory.Valuation.SpanPow
 
 /-!
 # Continuity of a valuation on a Huber ring
@@ -91,15 +91,22 @@ Theorem 7.10: cofinality supplies an `n` with `δ ^ n` below a given `γ`, and t
 
 The bound is taken **over the ring of definition**, through `v.comap`. That is not a convenience:
 the coefficients occurring in `Iⁿ⁺¹` range over `A₀`, so the hypothesis needed is `v ≤ 1` on `I`,
-which Theorem 7.10 supplies. Asking instead for `v ≤ 1` on the extension `I · A` would be asking
-for something false — `I · A` contains `r * x` for arbitrary `r ∈ A`. -/
+which Theorem 7.10 supplies. The same bound over the extension `I · A` is not available in
+general: `I · A` contains `r * x` for arbitrary `r ∈ A`, so an unbounded `v` violates it. (It is
+not *always* violated — the trivial valuation satisfies it — but it does not follow from the
+hypotheses here, which is what matters.) -/
 theorem map_le_pow_of_mem_idealImage_succ (P : PairOfDefinition A) (v : Valuation A Γ₀)
     {s : Set P.ringOfDefinition} {δ : Γ₀} (hgen : Ideal.span s = P.idealOfDefinition)
     (hs : ∀ t ∈ s, v (t : A) ≤ δ)
     (h1 : ∀ a ∈ P.idealOfDefinition, v ((a : P.ringOfDefinition) : A) ≤ 1)
     {n : ℕ} {x : A} (hx : x ∈ P.idealImage (n + 1)) : v x ≤ δ ^ n := by
   obtain ⟨y, hy, rfl⟩ := (P.mem_idealImage (n + 1)).mp hx
-  exact Valuation.map_le_pow_of_mem_span_pow_succ (v.comap P.ringOfDefinition.subtype) hs
-    (by rwa [hgen]) (by rwa [hgen])
+  set w := v.comap P.ringOfDefinition.subtype with hw
+  have hsw : ∀ t ∈ s, w t ≤ δ := by
+    simpa only [hw, Valuation.comap_apply, Subring.coe_subtype] using hs
+  have h1w : ∀ a ∈ Ideal.span s, w a ≤ 1 := by
+    rw [hgen]; simpa only [hw, Valuation.comap_apply, Subring.coe_subtype] using h1
+  simpa only [hw, Valuation.comap_apply, Subring.coe_subtype] using
+    Valuation.map_le_pow_of_mem_span_pow_succ w hsw h1w (by rwa [hgen])
 
 end TauCeti.Huber.PairOfDefinition

--- a/TauCeti/RingTheory/Huber/ContinuousValuation.lean
+++ b/TauCeti/RingTheory/Huber/ContinuousValuation.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.RingTheory.Huber.Basic
 public import TauCeti.RingTheory.Valuation.Continuous
+public import TauCeti.RingTheory.Valuation.SpanPow
 
 /-!
 # Continuity of a valuation on a Huber ring
@@ -33,6 +34,8 @@ subgroup is therefore built where it is used rather than taken from Mathlib.
 
 * `TauCeti.Huber.PairOfDefinition.isContinuous_iff_forall_exists_idealImage_subset` : the
   criterion, in both directions.
+* `TauCeti.Huber.PairOfDefinition.map_le_pow_of_mem_idealImage_succ` : the bound on `v` over a
+  basic neighbourhood of zero that the criterion is fed with.
 
 ## References
 
@@ -76,5 +79,27 @@ theorem isContinuous_iff_forall_exists_idealImage_subset (P : PairOfDefinition A
         zero_mem' := by simpa using zero_lt_iff.mpr hb
         neg_mem' := fun {x} hx ↦ by simpa [Set.mem_ofPred_eq, v.map_neg] using hx }
     exact AddSubgroup.isOpen_mono (H₁ := P.idealImage n) (H₂ := S) hn (P.isOpen_idealImage n)
+
+omit [IsTopologicalRing A] in
+/-- **A valuation on a basic neighbourhood of zero.** If `v ≤ δ` on a generating set of the ideal
+of definition and `v ≤ 1` on the ideal itself, then `v ≤ δ ^ n` on the image of `Iⁿ⁺¹`.
+
+This is `Valuation.map_le_pow_of_mem_span_pow_succ` transported to the Huber setting, and it is
+the input `isContinuous_iff_forall_exists_idealImage_subset` consumes in Wedhorn's proof of
+Theorem 7.10: cofinality supplies an `n` with `δ ^ n` below a given `γ`, and this turns that into
+`v < γ` on a basic neighbourhood, which is continuity.
+
+The bound is taken **over the ring of definition**, through `v.comap`. That is not a convenience:
+the coefficients occurring in `Iⁿ⁺¹` range over `A₀`, so the hypothesis needed is `v ≤ 1` on `I`,
+which Theorem 7.10 supplies. Asking instead for `v ≤ 1` on the extension `I · A` would be asking
+for something false — `I · A` contains `r * x` for arbitrary `r ∈ A`. -/
+theorem map_le_pow_of_mem_idealImage_succ (P : PairOfDefinition A) (v : Valuation A Γ₀)
+    {s : Set P.ringOfDefinition} {δ : Γ₀} (hgen : Ideal.span s = P.idealOfDefinition)
+    (hs : ∀ t ∈ s, v (t : A) ≤ δ)
+    (h1 : ∀ a ∈ P.idealOfDefinition, v ((a : P.ringOfDefinition) : A) ≤ 1)
+    {n : ℕ} {x : A} (hx : x ∈ P.idealImage (n + 1)) : v x ≤ δ ^ n := by
+  obtain ⟨y, hy, rfl⟩ := (P.mem_idealImage (n + 1)).mp hx
+  exact Valuation.map_le_pow_of_mem_span_pow_succ (v.comap P.ringOfDefinition.subtype) hs
+    (by rwa [hgen]) (by rwa [hgen])
 
 end TauCeti.Huber.PairOfDefinition


### PR DESCRIPTION
**A valuation on a basic neighbourhood of zero.**

```lean
theorem TauCeti.Huber.PairOfDefinition.map_le_pow_of_mem_idealImage_succ
    (P : PairOfDefinition A) (v : Valuation A Γ₀)
    {s : Set P.ringOfDefinition} {δ : Γ₀} (hgen : Ideal.span s = P.idealOfDefinition)
    (hs : ∀ t ∈ s, v (t : A) ≤ δ)
    (h1 : ∀ a ∈ P.idealOfDefinition, v ((a : P.ringOfDefinition) : A) ≤ 1)
    {n : ℕ} {x : A} (hx : x ∈ P.idealImage (n + 1)) : v x ≤ δ ^ n
```

If `v ≤ δ` on a generating set of the ideal of definition and `v ≤ 1` on the ideal itself, then
`v ≤ δ ^ n` on the image of `Iⁿ⁺¹` — that is, on a basic neighbourhood of zero.

## What it is for

This is the input that `isContinuous_iff_forall_exists_idealImage_subset` — the `Iⁿ`-basis
criterion, on `main` since #2858 — consumes in Wedhorn's proof of Theorem 7.10. Cofinality
supplies an `n` with `δ ^ n` below a given `γ`; this lemma turns that into `v < γ` on a basic
neighbourhood of zero, and the criterion turns *that* into continuity. It is the transport of
`Valuation.map_le_pow_of_mem_span_pow_succ` (#2866, merged) into the Huber setting, and joins two
pieces already on `main` that nothing yet connected.

## The bound is taken over the ring of definition, and that is forced

The proof applies the ring-level bound through `v.comap P.ringOfDefinition.subtype`, i.e. over
`A₀`, not over `A`. That is not a convenience: an element of `Iⁿ⁺¹` is a sum of terms whose
coefficients range over **`A₀`**, so the hypothesis the ring-level bound needs is `v ≤ 1` on `I`
— exactly what Theorem 7.10 assumes.

Asking for the analogous hypothesis over the *extension* `I · A` would be asking for something
false: `I · A` contains `r * x` for arbitrary `r ∈ A`, whose valuation is unbounded. This is the
same two-ideals distinction that makes the statement of Theorem 7.10 delicate, and AINTLIB's own
notes flag it independently.

That the ring-level bound applies in this shape was checked by a compiled probe while #2866 was
still open, so this transport is not a guess about how the pieces fit.

## Provenance

AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at commit
`2baa76f742bdb4fb8ee323fabba41203bd390e08`, project `projects/AdicSpaces/`, names
`pow_image_isOpen` and `isContinuous_of_ideal_pow_lt` as the consumers of exactly this kind of
bound, but does not state it, and its surrounding Wedhorn 7.10 sub-leaves are `sorry`. Its Huber
development assumes a principal ideal of definition throughout, where the bound is immediate. The
Huber notions here — `PairOfDefinition`, `idealImage` — are TauCeti's own, so no Mathlib statement
about them can exist.

## Gates

`lake build` (7530 jobs), `lake exe axioms` (39300 declarations), `lake exe module-system`
(1898 modules) and `scripts/lint-env.sh` (72 grandfathered, 0 ratchetable) all exit 0.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-1.5-theorem-7.10-neighbourhood-bound"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
