### PR TITLE
refactor(Eigenspace): name the semisimplicity of a single eigenspace

### DIFF
--- a/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -31,6 +31,34 @@ open Module Polynomial
 
 variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V] {f : End K V}
 
+/-- **An eigenspace is semisimple as a `K[X]`-module.** Carried through `AEval` along a proof
+`hinv` that it is invariant, the `μ`-eigenspace of `f` is a semisimple `K[X]`-module. -/
+private theorem isSemisimpleModule_mapSubmodule_eigenspace (f : End K V) (μ : K)
+    (hinv : f.eigenspace μ ∈ (Algebra.lsmul K K V f).invtSubmodule) :
+    IsSemisimpleModule K[X] (AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv⟩) := by
+  -- `AEval.restrict_equiv_mapSubmodule` restricts `Algebra.lsmul K K V f`, not `f`, to the
+  -- `μ`-eigenspace, and it hands `LinearMap.restrict` an invariance proof of type
+  -- `p ∈ (Algebra.lsmul K K V f).invtSubmodule`, where `LinearMap.restrict` asks for
+  -- `∀ x ∈ p, g x ∈ p`. Those two types are definitionally equal only at default transparency,
+  -- so `LinearMap.coe_restrict_apply` cannot be instantiated against the goal below directly.
+  -- Recording the composite coercion here once, with the submodules supplied explicitly, keeps
+  -- the step below lemma-driven.
+  have hrestrict (w : f.eigenspace μ) :
+      (LinearMap.restrict (p := f.eigenspace μ) (q := f.eigenspace μ)
+        (Algebra.lsmul K K V f) hinv w : V) = f w :=
+    (LinearMap.coe_restrict_apply _ _).trans
+      ((Algebra.lsmul_apply (R := K) (B := K) V f w).trans (Module.End.smul_def f w))
+  refine (AEval.restrict_equiv_mapSubmodule f _ hinv).isSemisimpleModule_iff.mp ?_
+  refine End.isSemisimple_of_squarefree_aeval_eq_zero (p := X - C μ)
+    (irreducible_X_sub_C μ).squarefree ?_
+  ext v
+  have hv := v.2
+  rw [End.mem_eigenspace_iff] at hv
+  simp only [map_sub, aeval_X, aeval_C, LinearMap.sub_apply, LinearMap.zero_apply,
+    Module.algebraMap_end_apply, Submodule.coe_sub, Submodule.coe_smul, ZeroMemClass.coe_zero]
+  -- the restriction of `f` to the `μ`-eigenspace is multiplication by `μ`
+  rw [hrestrict, hv, sub_self]
+
 /-- **A diagonalizable endomorphism is semisimple.** If the eigenspaces of `f` span the space then
 `f` is semisimple.
 
@@ -47,29 +75,8 @@ theorem isSemisimple_of_iSup_eigenspace_eq_top (hf : ⨆ μ : K, f.eigenspace μ
     rw [End.mem_eigenspace_iff] at hv
     simp [hv]
   have hss : ∀ μ : K,
-      IsSemisimpleModule K[X] (AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv μ⟩) := fun μ ↦ by
-    -- `AEval.restrict_equiv_mapSubmodule` restricts `Algebra.lsmul K K V f`, not `f`, to the
-    -- `μ`-eigenspace, and it hands `LinearMap.restrict` an invariance proof of type
-    -- `p ∈ (Algebra.lsmul K K V f).invtSubmodule`, where `LinearMap.restrict` asks for
-    -- `∀ x ∈ p, g x ∈ p`. Those two types are definitionally equal only at default transparency,
-    -- so `LinearMap.coe_restrict_apply` cannot be instantiated against the goal below directly.
-    -- Recording the composite coercion here once, with the submodules supplied explicitly, keeps
-    -- the step below lemma-driven.
-    have hrestrict (w : f.eigenspace μ) :
-        (LinearMap.restrict (p := f.eigenspace μ) (q := f.eigenspace μ)
-          (Algebra.lsmul K K V f) (hinv μ) w : V) = f w :=
-      (LinearMap.coe_restrict_apply _ _).trans
-        ((Algebra.lsmul_apply (R := K) (B := K) V f w).trans (Module.End.smul_def f w))
-    refine (AEval.restrict_equiv_mapSubmodule f _ (hinv μ)).isSemisimpleModule_iff.mp ?_
-    refine End.isSemisimple_of_squarefree_aeval_eq_zero (p := X - C μ)
-      (irreducible_X_sub_C μ).squarefree ?_
-    ext v
-    have hv := v.2
-    rw [End.mem_eigenspace_iff] at hv
-    simp only [map_sub, aeval_X, aeval_C, LinearMap.sub_apply, LinearMap.zero_apply,
-      Module.algebraMap_end_apply, Submodule.coe_sub, Submodule.coe_smul, ZeroMemClass.coe_zero]
-    -- the restriction of `f` to the `μ`-eigenspace is multiplication by `μ`
-    rw [hrestrict, hv, sub_self]
+      IsSemisimpleModule K[X] (AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv μ⟩) :=
+    fun μ ↦ isSemisimpleModule_mapSubmodule_eigenspace f μ (hinv μ)
   have htop : ⨆ μ : K, AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv μ⟩ = ⊤ := by
     set Q := ⨆ μ : K, AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv μ⟩
     have hle : (⊤ : Submodule K V) ≤ (Q.restrictScalars K).comap (AEval'.of f).toLinearMap := by

--- a/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -31,17 +31,23 @@ open Module Polynomial
 
 variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V] {f : End K V}
 
+/-- **The `lsmul` restriction is the restriction of the endomorphism.** `Algebra.lsmul K K V f`
+acts as `f`, and membership in its `invtSubmodule` is the invariance condition
+`LinearMap.restrict` asks for, so the two restrictions are the same map. -/
+private theorem restrict_lsmul_eq_restrict {p : Submodule K V} (f : End K V)
+    (hinv : p ∈ (Algebra.lsmul K K V f).invtSubmodule) (h : ∀ x ∈ p, f x ∈ p) :
+    LinearMap.restrict (Algebra.lsmul K K V f) hinv = f.restrict h := rfl
+
 /-- **An eigenspace is semisimple as a `K[X]`-module.** Carried through `AEval` along a proof
 `hinv` that it is invariant, the `μ`-eigenspace of `f` is a semisimple `K[X]`-module. -/
 private theorem isSemisimpleModule_mapSubmodule_eigenspace (f : End K V) (μ : K)
     (hinv : f.eigenspace μ ∈ (Algebra.lsmul K K V f).invtSubmodule) :
     IsSemisimpleModule K[X] (AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv⟩) := by
-  -- `AEval.restrict_equiv_mapSubmodule` restricts `Algebra.lsmul K K V f` rather than `f`, but
-  -- the two restrictions and their invariance proofs agree at default transparency
+  -- `AEval.restrict_equiv_mapSubmodule` restricts `Algebra.lsmul K K V f` rather than `f`;
+  -- `restrict_lsmul_eq_restrict` is that identification, stated once
   have hres : LinearMap.restrict (p := f.eigenspace μ) (q := f.eigenspace μ)
-      (Algebra.lsmul K K V f) hinv = μ • LinearMap.id := by
-    ext w
-    exact congrArg Subtype.val (LinearMap.congr_fun (Module.End.restrict_eigenspace f μ) w)
+      (Algebra.lsmul K K V f) hinv = μ • LinearMap.id :=
+    (restrict_lsmul_eq_restrict f hinv _).trans (Module.End.restrict_eigenspace f μ)
   refine (AEval.restrict_equiv_mapSubmodule f _ hinv).isSemisimpleModule_iff.mp ?_
   refine End.isSemisimple_of_squarefree_aeval_eq_zero (p := X - C μ)
     (irreducible_X_sub_C μ).squarefree ?_

--- a/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -35,8 +35,8 @@ variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V] {f : End K V}
 acts as `f`, and membership in its `invtSubmodule` is the invariance condition
 `LinearMap.restrict` asks for, so the two restrictions are the same map. -/
 private theorem restrict_lsmul_eq_restrict {p : Submodule K V} (f : End K V)
-    (hinv : p ∈ (Algebra.lsmul K K V f).invtSubmodule) (h : ∀ x ∈ p, f x ∈ p) :
-    LinearMap.restrict (Algebra.lsmul K K V f) hinv = f.restrict h := rfl
+    (hinv : p ∈ (Algebra.lsmul K K V f).invtSubmodule) :
+    LinearMap.restrict (Algebra.lsmul K K V f) hinv = f.restrict hinv := rfl
 
 /-- **An eigenspace is semisimple as a `K[X]`-module.** Carried through `AEval` along a proof
 `hinv` that it is invariant, the `μ`-eigenspace of `f` is a semisimple `K[X]`-module. -/
@@ -47,7 +47,7 @@ private theorem isSemisimpleModule_mapSubmodule_eigenspace (f : End K V) (μ : K
   -- `restrict_lsmul_eq_restrict` is that identification, stated once
   have hres : LinearMap.restrict (p := f.eigenspace μ) (q := f.eigenspace μ)
       (Algebra.lsmul K K V f) hinv = μ • LinearMap.id :=
-    (restrict_lsmul_eq_restrict f hinv _).trans (Module.End.restrict_eigenspace f μ)
+    (restrict_lsmul_eq_restrict f hinv).trans (Module.End.restrict_eigenspace f μ)
   refine (AEval.restrict_equiv_mapSubmodule f _ hinv).isSemisimpleModule_iff.mp ?_
   refine End.isSemisimple_of_squarefree_aeval_eq_zero (p := X - C μ)
     (irreducible_X_sub_C μ).squarefree ?_

--- a/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -39,8 +39,9 @@ private theorem isSemisimpleModule_mapSubmodule_eigenspace (f : End K V) (μ : K
   -- `AEval.restrict_equiv_mapSubmodule` restricts `Algebra.lsmul K K V f` rather than `f`, but
   -- the two restrictions and their invariance proofs agree at default transparency
   have hres : LinearMap.restrict (p := f.eigenspace μ) (q := f.eigenspace μ)
-      (Algebra.lsmul K K V f) hinv = μ • LinearMap.id :=
-    Module.End.restrict_eigenspace f μ
+      (Algebra.lsmul K K V f) hinv = μ • LinearMap.id := by
+    ext w
+    exact congrArg Subtype.val (LinearMap.congr_fun (Module.End.restrict_eigenspace f μ) w)
   refine (AEval.restrict_equiv_mapSubmodule f _ hinv).isSemisimpleModule_iff.mp ?_
   refine End.isSemisimple_of_squarefree_aeval_eq_zero (p := X - C μ)
     (irreducible_X_sub_C μ).squarefree ?_

--- a/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -36,28 +36,15 @@ variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V] {f : End K V}
 private theorem isSemisimpleModule_mapSubmodule_eigenspace (f : End K V) (μ : K)
     (hinv : f.eigenspace μ ∈ (Algebra.lsmul K K V f).invtSubmodule) :
     IsSemisimpleModule K[X] (AEval.mapSubmodule K V f ⟨f.eigenspace μ, hinv⟩) := by
-  -- `AEval.restrict_equiv_mapSubmodule` restricts `Algebra.lsmul K K V f`, not `f`, to the
-  -- `μ`-eigenspace, and it hands `LinearMap.restrict` an invariance proof of type
-  -- `p ∈ (Algebra.lsmul K K V f).invtSubmodule`, where `LinearMap.restrict` asks for
-  -- `∀ x ∈ p, g x ∈ p`. Those two types are definitionally equal only at default transparency,
-  -- so `LinearMap.coe_restrict_apply` cannot be instantiated against the goal below directly.
-  -- Recording the composite coercion here once, with the submodules supplied explicitly, keeps
-  -- the step below lemma-driven.
-  have hrestrict (w : f.eigenspace μ) :
-      (LinearMap.restrict (p := f.eigenspace μ) (q := f.eigenspace μ)
-        (Algebra.lsmul K K V f) hinv w : V) = f w :=
-    (LinearMap.coe_restrict_apply _ _).trans
-      ((Algebra.lsmul_apply (R := K) (B := K) V f w).trans (Module.End.smul_def f w))
+  -- `AEval.restrict_equiv_mapSubmodule` restricts `Algebra.lsmul K K V f` rather than `f`, but
+  -- the two restrictions and their invariance proofs agree at default transparency
+  have hres : LinearMap.restrict (p := f.eigenspace μ) (q := f.eigenspace μ)
+      (Algebra.lsmul K K V f) hinv = μ • LinearMap.id :=
+    Module.End.restrict_eigenspace f μ
   refine (AEval.restrict_equiv_mapSubmodule f _ hinv).isSemisimpleModule_iff.mp ?_
   refine End.isSemisimple_of_squarefree_aeval_eq_zero (p := X - C μ)
     (irreducible_X_sub_C μ).squarefree ?_
-  ext v
-  have hv := v.2
-  rw [End.mem_eigenspace_iff] at hv
-  simp only [map_sub, aeval_X, aeval_C, LinearMap.sub_apply, LinearMap.zero_apply,
-    Module.algebraMap_end_apply, Submodule.coe_sub, Submodule.coe_smul, ZeroMemClass.coe_zero]
-  -- the restriction of `f` to the `μ`-eigenspace is multiplication by `μ`
-  rw [hrestrict, hv, sub_self]
+  rw [hres, map_sub, aeval_X, aeval_C, Module.algebraMap_end_eq_smul_id, sub_self]
 
 /-- **A diagonalizable endomorphism is semisimple.** If the eigenspaces of `f` span the space then
 `f` is semisimple.


### PR DESCRIPTION
`isSemisimple_of_iSup_eigenspace_eq_top` proves that an endomorphism whose eigenspaces span is semisimple, by checking the two hypotheses of `isSemisimpleModule_of_isSemisimpleModule_submodule'`: that each eigenspace is a semisimple `K[X]`-submodule, and that they span. The first took twenty-four of its forty lines and never mentions the spanning hypothesis.

`isSemisimpleModule_mapSubmodule_eigenspace` states it: carried through `AEval` along a proof that it is invariant, the `μ`-eigenspace of `f` is a semisimple `K[X]`-module.

Its hypotheses are re-derived rather than inherited. The parent's `hf : ⨆ μ, f.eigenspace μ = ⊤` is in scope throughout the block and is not used — a single eigenspace is semisimple whether or not the eigenspaces span. What remains is `f`, the eigenvalue `μ`, and the invariance of that eigenspace, which is not an assumption so much as part of the statement: `AEval.mapSubmodule` takes an element of `(Algebra.lsmul K K V f).invtSubmodule`, so the proof has to appear in the type. The parent still supplies it from its own `hinv`.

The extracted proof is shorter than the block it replaces. The original recorded the restriction of `f` to the eigenspace by hand, with a seven-line comment explaining that `AEval.restrict_equiv_mapSubmodule` restricts `Algebra.lsmul K K V f` rather than `f`. Mathlib already has the restriction formula, `Module.End.restrict_eigenspace f μ : f.restrict … = μ • LinearMap.id`, so the proof cites that instead.

`restrict_lsmul_eq_restrict` names the step between the two. `Algebra.lsmul K K V f` acts as `f`, and membership in its `invtSubmodule` *is* the invariance condition `LinearMap.restrict` asks for, so the two restrictions are the same map and one invariance proof serves both; the lemma is `rfl`. Stating it makes that identification a proposition with a docstring rather than an unremarked step inside a proof, which is what lets the rest of the argument be `restrict_eigenspace`, `aeval` on `X - C μ`, and `Module.algebraMap_end_eq_smul_id`.

The parent's `set Q` stays where it is, inside `htop`. It abbreviates the supremum, which the new statement does not mention, so nothing folds between them.

The parent drops from 40 lines to 19: the invariance of the eigenspaces, one line per hypothesis of the module-theoretic criterion, and the criterion itself.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: RepresentationTheory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
