### PR TITLE
feat: extract induced chains from finite-type diagrams

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Diagram.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Diagram.lean
@@ -37,6 +37,10 @@ the root-system case is irreducibility, which Mathlib packages as
 * `TauCeti.IsFiniteType.isAcyclic_diagramGraph`: **the diagram of a finite-type matrix is a
   forest**. The affine diagrams `Ãₙ` for `n ≥ 2`, the ones whose diagrams are cycles, are excluded
   here in one theorem.
+* `TauCeti.IsFiniteType.exists_chain_of_reachable`: two vertices in the same component are joined
+  by a chain of distinct indices whose consecutive matrix entries are nonzero and whose
+  nonconsecutive entries vanish. This is the bridge from graph paths to the principal-submatrix
+  arguments used in the classification.
 * `TauCeti.IsFiniteType.degree_le_three`: **the degree bound**, in graph form.
 * `TauCeti.IsFiniteType.isTree_diagramGraph` and
   `TauCeti.IsFiniteType.card_edgeFinset_add_one_eq_card`: a connected finite-type diagram is a tree,
@@ -110,6 +114,54 @@ theorem isAcyclic_diagramGraph (h : IsFiniteType A) : (diagramGraph A).IsAcyclic
       Nat.mod_eq_of_lt (by omega)]
     exact Or.inr rfl
   exact (diagramGraph_adj.mp (f.toHom.map_adj hadj)).2.1 hk
+
+/-- A path in an acyclic graph has no chord: vertices separated by at least one intermediate
+vertex cannot be adjacent. -/
+private theorem not_adj_getVert_of_add_one_lt {V : Type*} {G : SimpleGraph V} {u v : V}
+    (hG : G.IsAcyclic) {p : G.Walk u v} (hp : p.IsPath) {i j : ℕ} (hij : i + 1 < j)
+    (hj : j ≤ p.length) : ¬G.Adj (p.getVert i) (p.getVert j) := by
+  intro hadj
+  have hij' : i ≤ j := by omega
+  have hmem : p.getVert j ∈ (p.drop i).support := by
+    simpa [Nat.add_sub_of_le hij'] using (p.drop i).getVert_mem_support (j - i)
+  have heq := hG.eq_snd_of_adj_start (hp.drop i) hadj hmem
+  have hsnd : (p.drop i).snd = p.getVert (i + 1) := by simp [SimpleGraph.Walk.snd]
+  rw [hsnd] at heq
+  have := hp.getVert_injOn (by omega : i + 1 ≤ p.length) hj heq.symm
+  omega
+
+/-- **A reachable pair in a finite-type diagram is joined by an induced matrix chain.** More
+precisely, there are vertices `w 0, ..., w n` with the prescribed endpoints, no repetitions,
+nonzero entries between consecutive vertices, and zero entries between vertices separated by at
+least one intermediate vertex.
+
+The no-chord conclusion is the part not supplied merely by choosing a graph path. It follows from
+the diagram being acyclic, and is what lets a classification argument identify the corresponding
+principal submatrix with a chain-shaped model rather than only a matrix containing the chain's
+edges. Nothing is asserted about vertices outside the chain. -/
+theorem exists_chain_of_reachable (h : IsFiniteType A) {u v : B}
+    (huv : (diagramGraph A).Reachable u v) :
+    ∃ (n : ℕ) (w : ℕ → B), w 0 = u ∧ w n = v ∧
+      Set.InjOn w {i | i ≤ n} ∧
+      (∀ i, i < n → A (w i) (w (i + 1)) ≠ 0) ∧
+      ∀ i j, i + 1 < j → j ≤ n → A (w i) (w j) = 0 := by
+  classical
+  let p : (diagramGraph A).Path u v := huv.some.toPath
+  let q : (diagramGraph A).Walk u v := p
+  have hq : q.IsPath := p.isPath
+  refine ⟨q.length, q.getVert, ?_, ?_, ?_, ?_, ?_⟩
+  · exact q.getVert_zero
+  · exact q.getVert_length
+  · exact hq.getVert_injOn
+  · intro i hi
+    exact (h.diagramGraph_adj_iff.mp (q.adj_getVert_succ hi)).2
+  · intro i j hij hj
+    by_contra hne
+    have hne' : q.getVert i ≠ q.getVert j := fun heq ↦ by
+      have := hq.getVert_injOn (by omega : i ≤ q.length) hj heq
+      omega
+    exact not_adj_getVert_of_add_one_lt h.isAcyclic_diagramGraph hq hij hj
+      (h.diagramGraph_adj_iff.mpr ⟨hne', hne⟩)
 
 /-- **The degree bound in graph form**: no index of a finite-type matrix has four neighbours in the
 diagram, so a finite-type diagram branches into at most three arms. -/


### PR DESCRIPTION
This PR extracts an induced matrix chain from every reachable pair in a finite-type diagram. Given reachable vertices `u` and `v`, `IsFiniteType.exists_chain_of_reachable` returns distinct vertices `w 0, ..., w n` with the prescribed endpoints, nonzero consecutive matrix entries, and zero entries between every pair separated by an intermediate vertex. The zero-entry clause is the essential bridge from a graph path to the principal-submatrix hypotheses used by the finite-type obstruction lemmas.

The exact target is `RepresentationTheory/RootSystems/README.md`, Layer 5 milestone “the classification of finite-type Cartan matrices,” specifically its next extraction step: producing embedded chains from a connected finite-type diagram before reindexing it onto `DynkinType.cartanMatrix`. After this PR, the milestone still needs to extract and distinguish the branch, single-multiple-edge, and simply-laced cases using the landed and in-flight obstruction theorems, then assemble the final reindexing and existence half of `existsUnique_dynkinType`.

The preferred `CFSGStatement` roadmap has no viable unclaimed direct step: I0 and its numbered conventions are complete; the remaining S1 rows `Fi24Prime`, `B`, and `M` lack roadmap-admissible full presentation sources; L0--L3 wait on ReductiveGroups Layer 9; and the remaining concrete RootSystems Layer 6 datum branches are already in flight. This therefore follows CFSGStatement's explicit prerequisite through RootSystems Layer 6 to the Layer 5 classification machinery that supplies its pinned root data.

The proof reuses Mathlib's `SimpleGraph.Walk.IsPath.getVert_injOn`, `SimpleGraph.IsAcyclic.eq_snd_of_adj_start`, and the existing Tau Ceti theorems `IsFiniteType.isAcyclic_diagramGraph` and `IsFiniteType.diagramGraph_adj_iff`. No Mathlib source is vendored. The graph-only no-chord helper stays private; the public result is stated directly in the matrix form consumed by the classification.

Roadmap: RepresentationTheory

Consumer roadmap: CFSGStatement

Dependency edge: CFSGStatement milestone L0 consumes `DynkinType.simplyConnectedRootDatum` and `DynkinType.simplyConnectedBase` from RootSystems Layer 6; that layer's pinned data are organized by `DynkinType`, while this PR advances the Layer 5 finite-type classification's stated extraction step toward producing the standard Dynkin reindexing.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"isfinitetype-exists-chain-of-reachable"}-->

🤖 Prepared with Codex
