### PR TITLE
feat: tensor Jordan factors of point actions

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Representation.ScalarExtension
 public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.Monoidal
 public import TauCeti.LinearAlgebra.JordanChevalley.Functoriality
 public import TauCeti.LinearAlgebra.JordanChevalley.TensorProduct
@@ -363,74 +362,6 @@ open MonoidalCategory
 variable (k : Type u) (H : Type v) (K : Type u) [CommSemiring k] [Semiring H]
   [HopfAlgebra k H] [Field K] [Algebra k K]
 
-private theorem ofLinearEquiv_pointsAction_tensorUnit_eq_one
-    (g : WithConv (H →ₐ[k] K)) :
-    LinearMap.GeneralLinearGroup.ofLinearEquiv
-        (Comodule.pointsAction (𝟙_ (FGComoduleCat k H)) g) = 1 := by
-  apply Units.ext
-  -- Equality in the general linear group reduces to the underlying point endomorphism, where
-  -- the trivial-comodule action theorem applies directly.
-  change (Comodule.pointsAction (𝟙_ (FGComoduleCat k H)) g :
-    K ⊗[k] (𝟙_ (FGComoduleCat k H)) →ₗ[K] K ⊗[k] (𝟙_ (FGComoduleCat k H))) =
-      LinearMap.id
-  rw [Comodule.pointsAction_toLinearMap, Comodule.endOfPoint_trivial]
-
-private theorem distribBaseChange_comp_pointsAction
-    (g : WithConv (H →ₐ[k] K)) (M N : FGComoduleCat.{u, v, u} k H) :
-    (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
-        (GeneralLinearGroup.tensorProduct
-          (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))
-          (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g)) :
-          Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
-      (LinearMap.GeneralLinearGroup.ofLinearEquiv
-          (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g) :
-        Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
-          (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap := by
-  let _ : Comodule k H (M ⊗[k] N) :=
-    inferInstanceAs (Comodule k H ((M ⊗ N : FGComoduleCat k H) : Type u))
-  let d := (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap
-  let a := GeneralLinearGroup.tensorProduct
-    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))
-    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g))
-  let b := LinearMap.GeneralLinearGroup.ofLinearEquiv
-    (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)
-  let dc :
-      (SemimoduleCat.of K (K ⊗[k] M) ⊗ SemimoduleCat.of K (K ⊗[k] N)) ⟶
-        SemimoduleCat.of K (K ⊗[k] (M ⊗[k] N)) :=
-    SemimoduleCat.ofHom d
-  have htensor :
-        (SemimoduleCat.ofHom (Comodule.endOfPoint M g.ofConv) ⊗ₘ
-            SemimoduleCat.ofHom (Comodule.endOfPoint N g.ofConv)) ≫ dc =
-      dc ≫ SemimoduleCat.ofHom (Comodule.endOfPoint
-        ((M ⊗ N : FGComoduleCat k H) : Type u) g.ofConv) := by
-    apply SemimoduleCat.hom_ext
-    exact Comodule.endOfPoint_tensor_of_coact_eq (R := k) (H := H) (A := K)
-      (V := M) (W := N) (FGComoduleCat.tensor_coact (R := k) (C := H) M N) g.ofConv
-  have hlin := congrArg SemimoduleCat.Hom.hom htensor
-  simp only [SemimoduleCat.hom_comp] at hlin
-  rw [SemimoduleCat.hom_tensorHom] at hlin
-  -- The categorical tensor source and the explicit tensor-product module are definitionally
-  -- identified only inside `SemimoduleCat`; display the resulting linear maps after forgetting.
-  change d.comp (TensorProduct.map (Comodule.endOfPoint M g.ofConv)
-      (Comodule.endOfPoint N g.ofConv)) =
-    (Comodule.endOfPoint ((M ⊗ N : FGComoduleCat k H) : Type u) g.ofConv).comp d at hlin
-  have hM :
-      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g) :
-        Module.End K (K ⊗[k] M)) = Comodule.endOfPoint M g.ofConv :=
-    Comodule.pointsAction_toLinearMap M g
-  have hN :
-      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g) :
-        Module.End K (K ⊗[k] N)) = Comodule.endOfPoint N g.ofConv :=
-    Comodule.pointsAction_toLinearMap N g
-  have hMN :
-      (LinearMap.GeneralLinearGroup.ofLinearEquiv
-          (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g) :
-        Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))) =
-          Comodule.endOfPoint ((M ⊗ N : FGComoduleCat k H) : Type u) g.ofConv :=
-    Comodule.pointsAction_toLinearMap (M ⊗ N : FGComoduleCat k H) g
-  rw [GeneralLinearGroup.coe_tensorProduct, hM, hN, hMN]
-  exact hlin
-
 private theorem distribBaseChange_comp_pointFactor
     (F : ∀ (V : Type u) [AddCommGroup V] [Module K V] [FiniteDimensional K V],
       LinearMap.GeneralLinearGroup K V → LinearMap.GeneralLinearGroup K V)
@@ -465,73 +396,13 @@ private theorem distribBaseChange_comp_pointFactor
   let b := LinearMap.GeneralLinearGroup.ofLinearEquiv
     (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)
   have hab : d.comp (a : Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
-      (b : Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp d :=
-    distribBaseChange_comp_pointsAction k H K g M N
+      (b : Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp d := by
+    simpa only [d, a, b, GeneralLinearGroup.coe_tensorProduct] using
+      distribBaseChange_comp_pointsAction k H K g M N
   have h := hcomp
     (V := (K ⊗[k] M) ⊗[K] (K ⊗[k] N))
     (W := K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u)) d a b hab
   simpa only [d, a, b, htensor] using h
-
-private theorem isMonoidal_fgPointFactorNatIso_hom
-    (F : ∀ M : FGComoduleCat.{u, v, u} k H,
-      LinearMap.GeneralLinearGroup K (K ⊗[k] M))
-    (hF : ∀ {M N : FGComoduleCat.{u, v, u} k H} (f : M ⟶ N),
-      (f.hom.toLinearMap.baseChange K).comp (F M : Module.End K (K ⊗[k] M)) =
-        (F N : Module.End K (K ⊗[k] N)).comp (f.hom.toLinearMap.baseChange K))
-    (hunit : F (𝟙_ (FGComoduleCat k H)) = 1)
-    (htensor : ∀ M N : FGComoduleCat.{u, v, u} k H,
-      (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
-          (GeneralLinearGroup.tensorProduct (F M) (F N) :
-            Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
-        (F (M ⊗ N : FGComoduleCat k H) :
-          Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
-            (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap) :
-    NatTrans.IsMonoidal (fgPointFactorNatIso k H K F hF).hom := by
-  constructor
-  · rw [FGComoduleCat.scalarExtensionFunctor_ε, fgPointFactorNatIso_hom_app]
-    apply SemimoduleCat.hom_ext
-    apply LinearMap.ext
-    intro a
-    simp only [Category.assoc, SemimoduleCat.comp_apply,
-      LinearEquiv.toModuleIsoₛ_hom]
-    rw [hunit]
-    simp
-  · intro M N
-    have htensor :
-        SemimoduleCat.ofHom
-              (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap ≫
-            SemimoduleCat.ofHom
-              (F (M ⊗ N : FGComoduleCat k H) :
-                Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))) =
-          (SemimoduleCat.ofHom
-                (F M : Module.End K (K ⊗[k] M)) ⊗ₘ
-              SemimoduleCat.ofHom
-                (F N : Module.End K (K ⊗[k] N))) ≫
-            SemimoduleCat.ofHom
-              (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap := by
-      apply SemimoduleCat.hom_ext
-      -- Forget the categorical tensor product so the transported intertwining identity is stated
-      -- directly with `TensorProduct.map` on the explicit scalar extensions.
-      change
-        (F (M ⊗ N : FGComoduleCat k H) :
-          Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
-            (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap =
-          (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
-            (TensorProduct.map (F M : Module.End K (K ⊗[k] M))
-              (F N : Module.End K (K ⊗[k] N)))
-      simpa only [GeneralLinearGroup.coe_tensorProduct] using
-        (htensor M N).symm
-    erw [FGComoduleCat.scalarExtensionFunctor_μ,
-      fgPointFactorNatIso_hom_app, fgPointFactorNatIso_hom_app,
-      fgPointFactorNatIso_hom_app]
-    rw [← MonoidalCategory.tensorHom_comp_tensorHom,
-      ← MonoidalCategory.tensorHom_comp_tensorHom]
-    simp only [Category.assoc]
-    rw [cancel_epi]
-    erw [Category.assoc, eqToHom_trans_assoc]
-    simp only [MonoidalCategory.tensorHom_comp_tensorHom_assoc, eqToHom_trans,
-      eqToHom_refl, Category.id_comp, Category.comp_id, LinearEquiv.toModuleIsoₛ_hom]
-    erw [← Category.assoc, htensor, Category.assoc]
 
 private theorem scalarExtensionComponent_eq_of_hom_app
     (M : FGComoduleCat.{u, v, u} k H)
@@ -546,6 +417,9 @@ private theorem scalarExtensionComponent_eq_of_hom_app
   intro x
   rw [scalarExtensionComponent_apply, happ]
   let hM := FGComoduleCat.scalarExtensionFunctor_obj k H K M
+  -- The functor object is definitionally the explicit scalar extension, but this equality is
+  -- hidden by the categorical and linear-map wrappers. Displaying the four transports lets the
+  -- standard `eqToHom` simp lemmas cancel them without unfolding either public construction.
   change (eqToHom hM.symm ≫
       (eqToHom hM ≫ F.toLinearEquiv.toModuleIsoₛ.hom ≫ eqToHom hM.symm) ≫
         eqToHom hM) x = _
@@ -559,33 +433,41 @@ variable [PerfectField K]
 theorem isMonoidal_fgPointSemisimplePartNatIso_hom
     (g : WithConv (H →ₐ[k] K)) :
     NatTrans.IsMonoidal (fgPointSemisimplePartNatIso k H K g).hom := by
-  unfold fgPointSemisimplePartNatIso
-  apply isMonoidal_fgPointFactorNatIso_hom
+  apply isMonoidal_of_linear_components k H K
+    (fun M ↦ GeneralLinearGroup.semisimplePart
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)))
+    (fgPointSemisimplePartNatIso k H K g)
+  · exact fgPointSemisimplePartNatIso_hom_app k H K g
   · rw [ofLinearEquiv_pointsAction_tensorUnit_eq_one k H K g,
       GeneralLinearGroup.semisimplePart_eq_self GeneralLinearGroup.isSemisimple_one]
   · intro M N
-    exact distribBaseChange_comp_pointFactor k H K
-      (fun V _ _ _ a ↦ GeneralLinearGroup.semisimplePart a)
-      GeneralLinearGroup.comp_semisimplePart_eq_of_comp_eq
-      GeneralLinearGroup.semisimplePart_tensorProduct g M N
+    simpa only [GeneralLinearGroup.coe_tensorProduct] using
+      distribBaseChange_comp_pointFactor k H K
+        (fun V _ _ _ a ↦ GeneralLinearGroup.semisimplePart a)
+        GeneralLinearGroup.comp_semisimplePart_eq_of_comp_eq
+        GeneralLinearGroup.semisimplePart_tensorProduct g M N
 
 /-- The natural unipotent-factor automorphism preserves the tensor unit and tensor products. -/
 theorem isMonoidal_fgPointUnipotentPartNatIso_hom
     (g : WithConv (H →ₐ[k] K)) :
     NatTrans.IsMonoidal (fgPointUnipotentPartNatIso k H K g).hom := by
-  unfold fgPointUnipotentPartNatIso
-  apply isMonoidal_fgPointFactorNatIso_hom
+  apply isMonoidal_of_linear_components k H K
+    (fun M ↦ GeneralLinearGroup.unipotentPart
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)))
+    (fgPointUnipotentPartNatIso k H K g)
+  · exact fgPointUnipotentPartNatIso_hom_app k H K g
   · rw [ofLinearEquiv_pointsAction_tensorUnit_eq_one k H K g,
       GeneralLinearGroup.unipotentPart_eq_self GeneralLinearGroup.isUnipotent_one]
   · intro M N
-    exact distribBaseChange_comp_pointFactor k H K
-      (fun V _ _ _ a ↦ GeneralLinearGroup.unipotentPart a)
-      GeneralLinearGroup.comp_unipotentPart_eq_of_comp_eq
-      GeneralLinearGroup.unipotentPart_tensorProduct g M N
+    simpa only [GeneralLinearGroup.coe_tensorProduct] using
+      distribBaseChange_comp_pointFactor k H K
+        (fun V _ _ _ a ↦ GeneralLinearGroup.unipotentPart a)
+        GeneralLinearGroup.comp_unipotentPart_eq_of_comp_eq
+        GeneralLinearGroup.unipotentPart_tensorProduct g M N
 
 /-- The semisimple factors of a point's actions on finite comodules, as an automorphism of the
 monoidal scalar-extension functor. -/
-@[expose] noncomputable def fgPointSemisimplePartTensorIso (g : WithConv (H →ₐ[k] K)) :
+noncomputable def fgPointSemisimplePartTensorIso (g : WithConv (H →ₐ[k] K)) :
     Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H K) :=
   @LaxMonoidalFunctor.isoMk _ _ _ _ _ _ _ _
     (fgPointSemisimplePartNatIso k H K g)
@@ -593,7 +475,7 @@ monoidal scalar-extension functor. -/
 
 /-- The unipotent factors of a point's actions on finite comodules, as an automorphism of the
 monoidal scalar-extension functor. -/
-@[expose] noncomputable def fgPointUnipotentPartTensorIso (g : WithConv (H →ₐ[k] K)) :
+noncomputable def fgPointUnipotentPartTensorIso (g : WithConv (H →ₐ[k] K)) :
     Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H K) :=
   @LaxMonoidalFunctor.isoMk _ _ _ _ _ _ _ _
     (fgPointUnipotentPartNatIso k H K g)
@@ -621,7 +503,9 @@ the inverse underlying natural automorphism. -/
 theorem fgPointSemisimplePartTensorIso_inv_hom (g : WithConv (H →ₐ[k] K)) :
     (fgPointSemisimplePartTensorIso k H K g).inv.hom =
       (fgPointSemisimplePartNatIso k H K g).inv :=
-  rfl
+  by
+    unfold fgPointSemisimplePartTensorIso
+    rfl
 
 /-- Forgetting tensor compatibility from the inverse unipotent-factor automorphism recovers
 the inverse underlying natural automorphism. -/
@@ -629,7 +513,9 @@ the inverse underlying natural automorphism. -/
 theorem fgPointUnipotentPartTensorIso_inv_hom (g : WithConv (H →ₐ[k] K)) :
     (fgPointUnipotentPartTensorIso k H K g).inv.hom =
       (fgPointUnipotentPartNatIso k H K g).inv :=
-  rfl
+  by
+    unfold fgPointUnipotentPartTensorIso
+    rfl
 
 /-- The transported component of the semisimple-factor tensor automorphism is the semisimple
 part of the point action. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
@@ -246,6 +246,8 @@ private theorem fgPointFactorNatIso_congr
   funext M
   simp only [fgPointFactorNatIso_hom_app, h M]
 
+section PerfectField
+
 variable [PerfectField K]
 
 /-- The semisimple parts of a point's actions on finite comodules form an automorphism of scalar
@@ -352,14 +354,15 @@ theorem fgPointSemisimplePartNatIso_mul_fgPointUnipotentPartNatIso
       (Comodule.pointsAction M g)
   rw [haction]
 
+end PerfectField
+
 section Monoidal
 
 open MonoidalCategory
 
-variable (k : Type u) (H : Type v) (K : Type u) [Field k] [Semiring H]
-  [HopfAlgebra k H] [Field K] [Algebra k K] [PerfectField K]
+variable (k : Type u) (H : Type v) (K : Type u) [CommSemiring k] [Semiring H]
+  [HopfAlgebra k H] [Field K] [Algebra k K]
 
-omit [PerfectField K] in
 private theorem ofLinearEquiv_pointsAction_tensorUnit_eq_one
     (g : WithConv (H →ₐ[k] K)) :
     LinearMap.GeneralLinearGroup.ofLinearEquiv
@@ -372,14 +375,6 @@ private theorem ofLinearEquiv_pointsAction_tensorUnit_eq_one
       LinearMap.id
   rw [Comodule.pointsAction_toLinearMap, Comodule.endOfPoint_trivial]
 
-omit [PerfectField K] in
-private theorem coe_ofLinearEquiv_pointsAction
-    (g : WithConv (H →ₐ[k] K)) (M : FGComoduleCat.{u, v, u} k H) :
-    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g) :
-      Module.End K (K ⊗[k] M)) = Comodule.endOfPoint M g.ofConv :=
-  Comodule.pointsAction_toLinearMap M g
-
-omit [PerfectField K] in
 private theorem distribBaseChange_comp_pointsAction
     (g : WithConv (H →ₐ[k] K)) (M N : FGComoduleCat.{u, v, u} k H) :
     (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
@@ -419,19 +414,46 @@ private theorem distribBaseChange_comp_pointsAction
   change d.comp (TensorProduct.map (Comodule.endOfPoint M g.ofConv)
       (Comodule.endOfPoint N g.ofConv)) =
     (Comodule.endOfPoint ((M ⊗ N : FGComoduleCat k H) : Type u) g.ofConv).comp d at hlin
-  simpa only [d, a, b, GeneralLinearGroup.coe_tensorProduct,
-    coe_ofLinearEquiv_pointsAction] using hlin
+  have hM :
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g) :
+        Module.End K (K ⊗[k] M)) = Comodule.endOfPoint M g.ofConv :=
+    Comodule.pointsAction_toLinearMap M g
+  have hN :
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g) :
+        Module.End K (K ⊗[k] N)) = Comodule.endOfPoint N g.ofConv :=
+    Comodule.pointsAction_toLinearMap N g
+  have hMN :
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv
+          (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g) :
+        Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))) =
+          Comodule.endOfPoint ((M ⊗ N : FGComoduleCat k H) : Type u) g.ofConv :=
+    Comodule.pointsAction_toLinearMap (M ⊗ N : FGComoduleCat k H) g
+  rw [GeneralLinearGroup.coe_tensorProduct, hM, hN, hMN]
+  exact hlin
 
-private theorem distribBaseChange_comp_semisimplePart_pointsAction
+private theorem distribBaseChange_comp_pointFactor
+    (F : ∀ (V : Type u) [AddCommGroup V] [Module K V] [FiniteDimensional K V],
+      LinearMap.GeneralLinearGroup K V → LinearMap.GeneralLinearGroup K V)
+    (hcomp : ∀ {V W : Type u} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
+      [AddCommGroup W] [Module K W] [FiniteDimensional K W]
+      (f : V →ₗ[K] W) (a : LinearMap.GeneralLinearGroup K V)
+      (b : LinearMap.GeneralLinearGroup K W),
+      f.comp (a : Module.End K V) = (b : Module.End K W).comp f →
+        f.comp (F V a : Module.End K V) = (F W b : Module.End K W).comp f)
+    (htensor : ∀ {V W : Type u} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
+      [AddCommGroup W] [Module K W] [FiniteDimensional K W]
+      (a : LinearMap.GeneralLinearGroup K V) (b : LinearMap.GeneralLinearGroup K W),
+      F (V ⊗[K] W) (GeneralLinearGroup.tensorProduct a b) =
+        GeneralLinearGroup.tensorProduct (F V a) (F W b))
     (g : WithConv (H →ₐ[k] K)) (M N : FGComoduleCat.{u, v, u} k H) :
     (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
         (GeneralLinearGroup.tensorProduct
-          (GeneralLinearGroup.semisimplePart
+          (F (K ⊗[k] M)
             (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)))
-          (GeneralLinearGroup.semisimplePart
+          (F (K ⊗[k] N)
             (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g))) :
           Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
-      (GeneralLinearGroup.semisimplePart
+      (F (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))
           (LinearMap.GeneralLinearGroup.ofLinearEquiv
             (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
         Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
@@ -445,95 +467,63 @@ private theorem distribBaseChange_comp_semisimplePart_pointsAction
   have hab : d.comp (a : Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
       (b : Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp d :=
     distribBaseChange_comp_pointsAction k H K g M N
-  have h := GeneralLinearGroup.comp_semisimplePart_eq_of_comp_eq
-    (K := K) (V := (K ⊗[k] M) ⊗[K] (K ⊗[k] N))
-      (W := K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u)) d a b hab
-  simpa only [d, a, b, GeneralLinearGroup.semisimplePart_tensorProduct] using h
+  have h := hcomp
+    (V := (K ⊗[k] M) ⊗[K] (K ⊗[k] N))
+    (W := K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u)) d a b hab
+  simpa only [d, a, b, htensor] using h
 
-private theorem distribBaseChange_comp_unipotentPart_pointsAction
-    (g : WithConv (H →ₐ[k] K)) (M N : FGComoduleCat.{u, v, u} k H) :
-    (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
-        (GeneralLinearGroup.tensorProduct
-          (GeneralLinearGroup.unipotentPart
-            (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)))
-          (GeneralLinearGroup.unipotentPart
-            (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g))) :
-          Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
-      (GeneralLinearGroup.unipotentPart
-          (LinearMap.GeneralLinearGroup.ofLinearEquiv
-            (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
-        Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
-          (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap := by
-  let d := (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap
-  let a := GeneralLinearGroup.tensorProduct
-    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))
-    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g))
-  let b := LinearMap.GeneralLinearGroup.ofLinearEquiv
-    (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)
-  have hab : d.comp (a : Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
-      (b : Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp d :=
-    distribBaseChange_comp_pointsAction k H K g M N
-  have h := GeneralLinearGroup.comp_unipotentPart_eq_of_comp_eq
-    (K := K) (V := (K ⊗[k] M) ⊗[K] (K ⊗[k] N))
-      (W := K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u)) d a b hab
-  simpa only [d, a, b, GeneralLinearGroup.unipotentPart_tensorProduct] using h
-
-private theorem isMonoidal_fgPointSemisimplePartNatIso_hom
-    (g : WithConv (H →ₐ[k] K)) :
-    NatTrans.IsMonoidal (fgPointSemisimplePartNatIso k H K g).hom := by
+private theorem isMonoidal_fgPointFactorNatIso_hom
+    (F : ∀ M : FGComoduleCat.{u, v, u} k H,
+      LinearMap.GeneralLinearGroup K (K ⊗[k] M))
+    (hF : ∀ {M N : FGComoduleCat.{u, v, u} k H} (f : M ⟶ N),
+      (f.hom.toLinearMap.baseChange K).comp (F M : Module.End K (K ⊗[k] M)) =
+        (F N : Module.End K (K ⊗[k] N)).comp (f.hom.toLinearMap.baseChange K))
+    (hunit : F (𝟙_ (FGComoduleCat k H)) = 1)
+    (htensor : ∀ M N : FGComoduleCat.{u, v, u} k H,
+      (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
+          (GeneralLinearGroup.tensorProduct (F M) (F N) :
+            Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
+        (F (M ⊗ N : FGComoduleCat k H) :
+          Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
+            (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap) :
+    NatTrans.IsMonoidal (fgPointFactorNatIso k H K F hF).hom := by
   constructor
-  · rw [FGComoduleCat.scalarExtensionFunctor_ε,
-      fgPointSemisimplePartNatIso_hom_app]
+  · rw [FGComoduleCat.scalarExtensionFunctor_ε, fgPointFactorNatIso_hom_app]
     apply SemimoduleCat.hom_ext
     apply LinearMap.ext
     intro a
     simp only [Category.assoc, SemimoduleCat.comp_apply,
       LinearEquiv.toModuleIsoₛ_hom]
-    rw [ofLinearEquiv_pointsAction_tensorUnit_eq_one k H K g,
-      GeneralLinearGroup.semisimplePart_eq_self GeneralLinearGroup.isSemisimple_one]
+    rw [hunit]
     simp
   · intro M N
     have htensor :
         SemimoduleCat.ofHom
               (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap ≫
             SemimoduleCat.ofHom
-              (GeneralLinearGroup.semisimplePart
-                (LinearMap.GeneralLinearGroup.ofLinearEquiv
-                  (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
+              (F (M ⊗ N : FGComoduleCat k H) :
                 Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))) =
           (SemimoduleCat.ofHom
-                (GeneralLinearGroup.semisimplePart
-                  (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
-                  Module.End K (K ⊗[k] M)) ⊗ₘ
+                (F M : Module.End K (K ⊗[k] M)) ⊗ₘ
               SemimoduleCat.ofHom
-                (GeneralLinearGroup.semisimplePart
-                  (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g)) :
-                  Module.End K (K ⊗[k] N))) ≫
+                (F N : Module.End K (K ⊗[k] N))) ≫
             SemimoduleCat.ofHom
               (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap := by
       apply SemimoduleCat.hom_ext
       -- Forget the categorical tensor product so the transported intertwining identity is stated
       -- directly with `TensorProduct.map` on the explicit scalar extensions.
       change
-        (GeneralLinearGroup.semisimplePart
-            (LinearMap.GeneralLinearGroup.ofLinearEquiv
-              (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
+        (F (M ⊗ N : FGComoduleCat k H) :
           Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
             (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap =
           (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
-            (TensorProduct.map
-              (GeneralLinearGroup.semisimplePart
-                (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
-                Module.End K (K ⊗[k] M))
-              (GeneralLinearGroup.semisimplePart
-                (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g)) :
-                Module.End K (K ⊗[k] N)))
+            (TensorProduct.map (F M : Module.End K (K ⊗[k] M))
+              (F N : Module.End K (K ⊗[k] N)))
       simpa only [GeneralLinearGroup.coe_tensorProduct] using
-        (distribBaseChange_comp_semisimplePart_pointsAction k H K g M N).symm
+        (htensor M N).symm
     erw [FGComoduleCat.scalarExtensionFunctor_μ,
-      fgPointSemisimplePartNatIso_hom_app,
-      fgPointSemisimplePartNatIso_hom_app,
-      fgPointSemisimplePartNatIso_hom_app]
+      fgPointFactorNatIso_hom_app, fgPointFactorNatIso_hom_app,
+      fgPointFactorNatIso_hom_app]
     rw [← MonoidalCategory.tensorHom_comp_tensorHom,
       ← MonoidalCategory.tensorHom_comp_tensorHom]
     simp only [Category.assoc]
@@ -543,73 +533,59 @@ private theorem isMonoidal_fgPointSemisimplePartNatIso_hom
       eqToHom_refl, Category.id_comp, Category.comp_id, LinearEquiv.toModuleIsoₛ_hom]
     erw [← Category.assoc, htensor, Category.assoc]
 
-private theorem isMonoidal_fgPointUnipotentPartNatIso_hom
+private theorem scalarExtensionComponent_eq_of_hom_app
+    (M : FGComoduleCat.{u, v, u} k H)
+    (F : LinearMap.GeneralLinearGroup K (K ⊗[k] M))
+    (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H K))
+    (happ : eta.hom.hom.app M =
+      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H K M) ≫
+        F.toLinearEquiv.toModuleIsoₛ.hom ≫
+          eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H K M).symm) :
+    scalarExtensionComponent k H K eta M = (F : Module.End K (K ⊗[k] M)) := by
+  apply LinearMap.ext
+  intro x
+  rw [scalarExtensionComponent_apply, happ]
+  let hM := FGComoduleCat.scalarExtensionFunctor_obj k H K M
+  change (eqToHom hM.symm ≫
+      (eqToHom hM ≫ F.toLinearEquiv.toModuleIsoₛ.hom ≫ eqToHom hM.symm) ≫
+        eqToHom hM) x = _
+  simp
+
+section PerfectField
+
+variable [PerfectField K]
+
+/-- The natural semisimple-factor automorphism preserves the tensor unit and tensor products. -/
+theorem isMonoidal_fgPointSemisimplePartNatIso_hom
+    (g : WithConv (H →ₐ[k] K)) :
+    NatTrans.IsMonoidal (fgPointSemisimplePartNatIso k H K g).hom := by
+  unfold fgPointSemisimplePartNatIso
+  apply isMonoidal_fgPointFactorNatIso_hom
+  · rw [ofLinearEquiv_pointsAction_tensorUnit_eq_one k H K g,
+      GeneralLinearGroup.semisimplePart_eq_self GeneralLinearGroup.isSemisimple_one]
+  · intro M N
+    exact distribBaseChange_comp_pointFactor k H K
+      (fun V _ _ _ a ↦ GeneralLinearGroup.semisimplePart a)
+      GeneralLinearGroup.comp_semisimplePart_eq_of_comp_eq
+      GeneralLinearGroup.semisimplePart_tensorProduct g M N
+
+/-- The natural unipotent-factor automorphism preserves the tensor unit and tensor products. -/
+theorem isMonoidal_fgPointUnipotentPartNatIso_hom
     (g : WithConv (H →ₐ[k] K)) :
     NatTrans.IsMonoidal (fgPointUnipotentPartNatIso k H K g).hom := by
-  constructor
-  · rw [FGComoduleCat.scalarExtensionFunctor_ε,
-      fgPointUnipotentPartNatIso_hom_app]
-    apply SemimoduleCat.hom_ext
-    apply LinearMap.ext
-    intro a
-    simp only [Category.assoc, SemimoduleCat.comp_apply,
-      LinearEquiv.toModuleIsoₛ_hom]
-    rw [ofLinearEquiv_pointsAction_tensorUnit_eq_one k H K g,
+  unfold fgPointUnipotentPartNatIso
+  apply isMonoidal_fgPointFactorNatIso_hom
+  · rw [ofLinearEquiv_pointsAction_tensorUnit_eq_one k H K g,
       GeneralLinearGroup.unipotentPart_eq_self GeneralLinearGroup.isUnipotent_one]
-    simp
   · intro M N
-    have htensor :
-        SemimoduleCat.ofHom
-              (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap ≫
-            SemimoduleCat.ofHom
-              (GeneralLinearGroup.unipotentPart
-                (LinearMap.GeneralLinearGroup.ofLinearEquiv
-                  (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
-                Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))) =
-          (SemimoduleCat.ofHom
-                (GeneralLinearGroup.unipotentPart
-                  (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
-                  Module.End K (K ⊗[k] M)) ⊗ₘ
-              SemimoduleCat.ofHom
-                (GeneralLinearGroup.unipotentPart
-                  (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g)) :
-                  Module.End K (K ⊗[k] N))) ≫
-            SemimoduleCat.ofHom
-              (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap := by
-      apply SemimoduleCat.hom_ext
-      -- As in the semisimple case, expose the linear maps beneath the categorical tensor square.
-      change
-        (GeneralLinearGroup.unipotentPart
-            (LinearMap.GeneralLinearGroup.ofLinearEquiv
-              (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
-          Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
-            (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap =
-          (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
-            (TensorProduct.map
-              (GeneralLinearGroup.unipotentPart
-                (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
-                Module.End K (K ⊗[k] M))
-              (GeneralLinearGroup.unipotentPart
-                (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g)) :
-                Module.End K (K ⊗[k] N)))
-      simpa only [GeneralLinearGroup.coe_tensorProduct] using
-        (distribBaseChange_comp_unipotentPart_pointsAction k H K g M N).symm
-    erw [FGComoduleCat.scalarExtensionFunctor_μ,
-      fgPointUnipotentPartNatIso_hom_app,
-      fgPointUnipotentPartNatIso_hom_app,
-      fgPointUnipotentPartNatIso_hom_app]
-    rw [← MonoidalCategory.tensorHom_comp_tensorHom,
-      ← MonoidalCategory.tensorHom_comp_tensorHom]
-    simp only [Category.assoc]
-    rw [cancel_epi]
-    erw [Category.assoc, eqToHom_trans_assoc]
-    simp only [MonoidalCategory.tensorHom_comp_tensorHom_assoc, eqToHom_trans,
-      eqToHom_refl, Category.id_comp, Category.comp_id, LinearEquiv.toModuleIsoₛ_hom]
-    erw [← Category.assoc, htensor, Category.assoc]
+    exact distribBaseChange_comp_pointFactor k H K
+      (fun V _ _ _ a ↦ GeneralLinearGroup.unipotentPart a)
+      GeneralLinearGroup.comp_unipotentPart_eq_of_comp_eq
+      GeneralLinearGroup.unipotentPart_tensorProduct g M N
 
 /-- The semisimple factors of a point's actions on finite comodules, as an automorphism of the
 monoidal scalar-extension functor. -/
-noncomputable def fgPointSemisimplePartTensorIso (g : WithConv (H →ₐ[k] K)) :
+@[expose] noncomputable def fgPointSemisimplePartTensorIso (g : WithConv (H →ₐ[k] K)) :
     Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H K) :=
   @LaxMonoidalFunctor.isoMk _ _ _ _ _ _ _ _
     (fgPointSemisimplePartNatIso k H K g)
@@ -617,7 +593,7 @@ noncomputable def fgPointSemisimplePartTensorIso (g : WithConv (H →ₐ[k] K)) 
 
 /-- The unipotent factors of a point's actions on finite comodules, as an automorphism of the
 monoidal scalar-extension functor. -/
-noncomputable def fgPointUnipotentPartTensorIso (g : WithConv (H →ₐ[k] K)) :
+@[expose] noncomputable def fgPointUnipotentPartTensorIso (g : WithConv (H →ₐ[k] K)) :
     Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H K) :=
   @LaxMonoidalFunctor.isoMk _ _ _ _ _ _ _ _
     (fgPointUnipotentPartNatIso k H K g)
@@ -638,6 +614,48 @@ theorem fgPointUnipotentPartTensorIso_hom_hom (g : WithConv (H →ₐ[k] K)) :
     (fgPointUnipotentPartTensorIso k H K g).hom.hom =
       (fgPointUnipotentPartNatIso k H K g).hom :=
   (rfl)
+
+/-- Forgetting tensor compatibility from the inverse semisimple-factor automorphism recovers
+the inverse underlying natural automorphism. -/
+@[simp]
+theorem fgPointSemisimplePartTensorIso_inv_hom (g : WithConv (H →ₐ[k] K)) :
+    (fgPointSemisimplePartTensorIso k H K g).inv.hom =
+      (fgPointSemisimplePartNatIso k H K g).inv :=
+  rfl
+
+/-- Forgetting tensor compatibility from the inverse unipotent-factor automorphism recovers
+the inverse underlying natural automorphism. -/
+@[simp]
+theorem fgPointUnipotentPartTensorIso_inv_hom (g : WithConv (H →ₐ[k] K)) :
+    (fgPointUnipotentPartTensorIso k H K g).inv.hom =
+      (fgPointUnipotentPartNatIso k H K g).inv :=
+  rfl
+
+/-- The transported component of the semisimple-factor tensor automorphism is the semisimple
+part of the point action. -/
+@[simp]
+theorem scalarExtensionComponent_fgPointSemisimplePartTensorIso
+    (g : WithConv (H →ₐ[k] K)) (M : FGComoduleCat.{u, v, u} k H) :
+    scalarExtensionComponent k H K (fgPointSemisimplePartTensorIso k H K g) M =
+      (GeneralLinearGroup.semisimplePart
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+          Module.End K (K ⊗[k] M)) := by
+  apply scalarExtensionComponent_eq_of_hom_app
+  rw [fgPointSemisimplePartTensorIso_hom_hom]
+  exact fgPointSemisimplePartNatIso_hom_app k H K g M
+
+/-- The transported component of the unipotent-factor tensor automorphism is the unipotent
+part of the point action. -/
+@[simp]
+theorem scalarExtensionComponent_fgPointUnipotentPartTensorIso
+    (g : WithConv (H →ₐ[k] K)) (M : FGComoduleCat.{u, v, u} k H) :
+    scalarExtensionComponent k H K (fgPointUnipotentPartTensorIso k H K g) M =
+      (GeneralLinearGroup.unipotentPart
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+          Module.End K (K ⊗[k] M)) := by
+  apply scalarExtensionComponent_eq_of_hom_app
+  rw [fgPointUnipotentPartTensorIso_hom_hom]
+  exact fgPointUnipotentPartNatIso_hom_app k H K g M
 
 /-- The tensor automorphisms formed by the semisimple and unipotent factors commute. -/
 theorem commute_fgPointSemisimplePartTensorIso_fgPointUnipotentPartTensorIso
@@ -662,6 +680,8 @@ theorem fgPointSemisimplePartTensorIso_mul_fgPointUnipotentPartTensorIso
   rw [fgPointTensorIso_hom_hom]
   exact congrArg Iso.hom
     (fgPointSemisimplePartNatIso_mul_fgPointUnipotentPartNatIso k H K g)
+
+end PerfectField
 
 end Monoidal
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
@@ -5,7 +5,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Representation.ScalarExtension
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.Monoidal
 public import TauCeti.LinearAlgebra.JordanChevalley.Functoriality
+public import TauCeti.LinearAlgebra.JordanChevalley.TensorProduct
 
 /-!
 # Jordan factors of point actions
@@ -21,17 +23,24 @@ from functoriality of the multiplicative Jordan--Chevalley decomposition under a
 intertwiners. The two natural factors commute and their product recovers the original point action
 in the automorphism group of the scalar-extension functor.
 
-Tensor compatibility is a separate downstream step. In the commutative coordinate-Hopf-algebra
-setting of the roadmap, once the factors are tensor automorphisms, Tannakian reconstruction can
-lift them from compatible actions on representations to points of the original affine group. This
-is the representation-theoretic bridge in Layer 4 of the ReductiveGroups roadmap.
+The final section combines this naturality with tensor-product compatibility of multiplicative
+Jordan decomposition. Thus both factors are tensor automorphisms. In the commutative
+coordinate-Hopf-algebra setting of the roadmap, Tannakian reconstruction can now lift them from
+compatible actions on representations to points of the original affine group. This is the
+representation-theoretic bridge in Layer 4 of the ReductiveGroups roadmap.
 
 ## Main declarations
 
 * `TauCeti.Tannaka.fgPointSemisimplePartNatIso`: the natural semisimple part of a point action.
 * `TauCeti.Tannaka.fgPointUnipotentPartNatIso`: the natural unipotent part of a point action.
+* `TauCeti.Tannaka.fgPointSemisimplePartTensorIso`: the semisimple factors as a tensor
+  automorphism.
+* `TauCeti.Tannaka.fgPointUnipotentPartTensorIso`: the unipotent factors as a tensor
+  automorphism.
 * `TauCeti.Tannaka.fgPointSemisimplePartNatIso_mul_fgPointUnipotentPartNatIso`: their product is
   the original point action.
+* `TauCeti.Tannaka.fgPointSemisimplePartTensorIso_mul_fgPointUnipotentPartTensorIso`: the same
+  factorization among tensor automorphisms.
 
 ## References
 
@@ -342,5 +351,318 @@ theorem fgPointSemisimplePartNatIso_mul_fgPointUnipotentPartNatIso
     (LinearMap.GeneralLinearGroup.generalLinearEquiv K (K ⊗[k] M)).apply_symm_apply
       (Comodule.pointsAction M g)
   rw [haction]
+
+section Monoidal
+
+open MonoidalCategory
+
+variable (k : Type u) (H : Type v) (K : Type u) [Field k] [Semiring H]
+  [HopfAlgebra k H] [Field K] [Algebra k K] [PerfectField K]
+
+omit [PerfectField K] in
+private theorem ofLinearEquiv_pointsAction_tensorUnit_eq_one
+    (g : WithConv (H →ₐ[k] K)) :
+    LinearMap.GeneralLinearGroup.ofLinearEquiv
+        (Comodule.pointsAction (𝟙_ (FGComoduleCat k H)) g) = 1 := by
+  apply Units.ext
+  -- Equality in the general linear group reduces to the underlying point endomorphism, where
+  -- the trivial-comodule action theorem applies directly.
+  change (Comodule.pointsAction (𝟙_ (FGComoduleCat k H)) g :
+    K ⊗[k] (𝟙_ (FGComoduleCat k H)) →ₗ[K] K ⊗[k] (𝟙_ (FGComoduleCat k H))) =
+      LinearMap.id
+  rw [Comodule.pointsAction_toLinearMap, Comodule.endOfPoint_trivial]
+
+omit [PerfectField K] in
+private theorem coe_ofLinearEquiv_pointsAction
+    (g : WithConv (H →ₐ[k] K)) (M : FGComoduleCat.{u, v, u} k H) :
+    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g) :
+      Module.End K (K ⊗[k] M)) = Comodule.endOfPoint M g.ofConv :=
+  Comodule.pointsAction_toLinearMap M g
+
+omit [PerfectField K] in
+private theorem distribBaseChange_comp_pointsAction
+    (g : WithConv (H →ₐ[k] K)) (M N : FGComoduleCat.{u, v, u} k H) :
+    (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
+        (GeneralLinearGroup.tensorProduct
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g)) :
+          Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv
+          (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g) :
+        Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
+          (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap := by
+  let _ : Comodule k H (M ⊗[k] N) :=
+    inferInstanceAs (Comodule k H ((M ⊗ N : FGComoduleCat k H) : Type u))
+  let d := (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap
+  let a := GeneralLinearGroup.tensorProduct
+    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))
+    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g))
+  let b := LinearMap.GeneralLinearGroup.ofLinearEquiv
+    (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)
+  let dc :
+      (SemimoduleCat.of K (K ⊗[k] M) ⊗ SemimoduleCat.of K (K ⊗[k] N)) ⟶
+        SemimoduleCat.of K (K ⊗[k] (M ⊗[k] N)) :=
+    SemimoduleCat.ofHom d
+  have htensor :
+        (SemimoduleCat.ofHom (Comodule.endOfPoint M g.ofConv) ⊗ₘ
+            SemimoduleCat.ofHom (Comodule.endOfPoint N g.ofConv)) ≫ dc =
+      dc ≫ SemimoduleCat.ofHom (Comodule.endOfPoint
+        ((M ⊗ N : FGComoduleCat k H) : Type u) g.ofConv) := by
+    apply SemimoduleCat.hom_ext
+    exact Comodule.endOfPoint_tensor_of_coact_eq (R := k) (H := H) (A := K)
+      (V := M) (W := N) (FGComoduleCat.tensor_coact (R := k) (C := H) M N) g.ofConv
+  have hlin := congrArg SemimoduleCat.Hom.hom htensor
+  simp only [SemimoduleCat.hom_comp] at hlin
+  rw [SemimoduleCat.hom_tensorHom] at hlin
+  -- The categorical tensor source and the explicit tensor-product module are definitionally
+  -- identified only inside `SemimoduleCat`; display the resulting linear maps after forgetting.
+  change d.comp (TensorProduct.map (Comodule.endOfPoint M g.ofConv)
+      (Comodule.endOfPoint N g.ofConv)) =
+    (Comodule.endOfPoint ((M ⊗ N : FGComoduleCat k H) : Type u) g.ofConv).comp d at hlin
+  simpa only [d, a, b, GeneralLinearGroup.coe_tensorProduct,
+    coe_ofLinearEquiv_pointsAction] using hlin
+
+private theorem distribBaseChange_comp_semisimplePart_pointsAction
+    (g : WithConv (H →ₐ[k] K)) (M N : FGComoduleCat.{u, v, u} k H) :
+    (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
+        (GeneralLinearGroup.tensorProduct
+          (GeneralLinearGroup.semisimplePart
+            (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)))
+          (GeneralLinearGroup.semisimplePart
+            (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g))) :
+          Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
+      (GeneralLinearGroup.semisimplePart
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv
+            (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
+        Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
+          (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap := by
+  let d := (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap
+  let a := GeneralLinearGroup.tensorProduct
+    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))
+    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g))
+  let b := LinearMap.GeneralLinearGroup.ofLinearEquiv
+    (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)
+  have hab : d.comp (a : Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
+      (b : Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp d :=
+    distribBaseChange_comp_pointsAction k H K g M N
+  have h := GeneralLinearGroup.comp_semisimplePart_eq_of_comp_eq
+    (K := K) (V := (K ⊗[k] M) ⊗[K] (K ⊗[k] N))
+      (W := K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u)) d a b hab
+  simpa only [d, a, b, GeneralLinearGroup.semisimplePart_tensorProduct] using h
+
+private theorem distribBaseChange_comp_unipotentPart_pointsAction
+    (g : WithConv (H →ₐ[k] K)) (M N : FGComoduleCat.{u, v, u} k H) :
+    (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
+        (GeneralLinearGroup.tensorProduct
+          (GeneralLinearGroup.unipotentPart
+            (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)))
+          (GeneralLinearGroup.unipotentPart
+            (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g))) :
+          Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
+      (GeneralLinearGroup.unipotentPart
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv
+            (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
+        Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
+          (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap := by
+  let d := (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap
+  let a := GeneralLinearGroup.tensorProduct
+    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))
+    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g))
+  let b := LinearMap.GeneralLinearGroup.ofLinearEquiv
+    (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)
+  have hab : d.comp (a : Module.End K ((K ⊗[k] M) ⊗[K] (K ⊗[k] N))) =
+      (b : Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp d :=
+    distribBaseChange_comp_pointsAction k H K g M N
+  have h := GeneralLinearGroup.comp_unipotentPart_eq_of_comp_eq
+    (K := K) (V := (K ⊗[k] M) ⊗[K] (K ⊗[k] N))
+      (W := K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u)) d a b hab
+  simpa only [d, a, b, GeneralLinearGroup.unipotentPart_tensorProduct] using h
+
+private theorem isMonoidal_fgPointSemisimplePartNatIso_hom
+    (g : WithConv (H →ₐ[k] K)) :
+    NatTrans.IsMonoidal (fgPointSemisimplePartNatIso k H K g).hom := by
+  constructor
+  · rw [FGComoduleCat.scalarExtensionFunctor_ε,
+      fgPointSemisimplePartNatIso_hom_app]
+    apply SemimoduleCat.hom_ext
+    apply LinearMap.ext
+    intro a
+    simp only [Category.assoc, SemimoduleCat.comp_apply,
+      LinearEquiv.toModuleIsoₛ_hom]
+    rw [ofLinearEquiv_pointsAction_tensorUnit_eq_one k H K g,
+      GeneralLinearGroup.semisimplePart_eq_self GeneralLinearGroup.isSemisimple_one]
+    simp
+  · intro M N
+    have htensor :
+        SemimoduleCat.ofHom
+              (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap ≫
+            SemimoduleCat.ofHom
+              (GeneralLinearGroup.semisimplePart
+                (LinearMap.GeneralLinearGroup.ofLinearEquiv
+                  (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
+                Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))) =
+          (SemimoduleCat.ofHom
+                (GeneralLinearGroup.semisimplePart
+                  (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+                  Module.End K (K ⊗[k] M)) ⊗ₘ
+              SemimoduleCat.ofHom
+                (GeneralLinearGroup.semisimplePart
+                  (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g)) :
+                  Module.End K (K ⊗[k] N))) ≫
+            SemimoduleCat.ofHom
+              (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap := by
+      apply SemimoduleCat.hom_ext
+      -- Forget the categorical tensor product so the transported intertwining identity is stated
+      -- directly with `TensorProduct.map` on the explicit scalar extensions.
+      change
+        (GeneralLinearGroup.semisimplePart
+            (LinearMap.GeneralLinearGroup.ofLinearEquiv
+              (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
+          Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
+            (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap =
+          (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
+            (TensorProduct.map
+              (GeneralLinearGroup.semisimplePart
+                (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+                Module.End K (K ⊗[k] M))
+              (GeneralLinearGroup.semisimplePart
+                (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g)) :
+                Module.End K (K ⊗[k] N)))
+      simpa only [GeneralLinearGroup.coe_tensorProduct] using
+        (distribBaseChange_comp_semisimplePart_pointsAction k H K g M N).symm
+    erw [FGComoduleCat.scalarExtensionFunctor_μ,
+      fgPointSemisimplePartNatIso_hom_app,
+      fgPointSemisimplePartNatIso_hom_app,
+      fgPointSemisimplePartNatIso_hom_app]
+    rw [← MonoidalCategory.tensorHom_comp_tensorHom,
+      ← MonoidalCategory.tensorHom_comp_tensorHom]
+    simp only [Category.assoc]
+    rw [cancel_epi]
+    erw [Category.assoc, eqToHom_trans_assoc]
+    simp only [MonoidalCategory.tensorHom_comp_tensorHom_assoc, eqToHom_trans,
+      eqToHom_refl, Category.id_comp, Category.comp_id, LinearEquiv.toModuleIsoₛ_hom]
+    erw [← Category.assoc, htensor, Category.assoc]
+
+private theorem isMonoidal_fgPointUnipotentPartNatIso_hom
+    (g : WithConv (H →ₐ[k] K)) :
+    NatTrans.IsMonoidal (fgPointUnipotentPartNatIso k H K g).hom := by
+  constructor
+  · rw [FGComoduleCat.scalarExtensionFunctor_ε,
+      fgPointUnipotentPartNatIso_hom_app]
+    apply SemimoduleCat.hom_ext
+    apply LinearMap.ext
+    intro a
+    simp only [Category.assoc, SemimoduleCat.comp_apply,
+      LinearEquiv.toModuleIsoₛ_hom]
+    rw [ofLinearEquiv_pointsAction_tensorUnit_eq_one k H K g,
+      GeneralLinearGroup.unipotentPart_eq_self GeneralLinearGroup.isUnipotent_one]
+    simp
+  · intro M N
+    have htensor :
+        SemimoduleCat.ofHom
+              (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap ≫
+            SemimoduleCat.ofHom
+              (GeneralLinearGroup.unipotentPart
+                (LinearMap.GeneralLinearGroup.ofLinearEquiv
+                  (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
+                Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))) =
+          (SemimoduleCat.ofHom
+                (GeneralLinearGroup.unipotentPart
+                  (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+                  Module.End K (K ⊗[k] M)) ⊗ₘ
+              SemimoduleCat.ofHom
+                (GeneralLinearGroup.unipotentPart
+                  (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g)) :
+                  Module.End K (K ⊗[k] N))) ≫
+            SemimoduleCat.ofHom
+              (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap := by
+      apply SemimoduleCat.hom_ext
+      -- As in the semisimple case, expose the linear maps beneath the categorical tensor square.
+      change
+        (GeneralLinearGroup.unipotentPart
+            (LinearMap.GeneralLinearGroup.ofLinearEquiv
+              (Comodule.pointsAction (M ⊗ N : FGComoduleCat k H) g)) :
+          Module.End K (K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u))).comp
+            (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap =
+          (TensorProduct.AlgebraTensorModule.distribBaseChange k K M N).symm.toLinearMap.comp
+            (TensorProduct.map
+              (GeneralLinearGroup.unipotentPart
+                (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+                Module.End K (K ⊗[k] M))
+              (GeneralLinearGroup.unipotentPart
+                (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g)) :
+                Module.End K (K ⊗[k] N)))
+      simpa only [GeneralLinearGroup.coe_tensorProduct] using
+        (distribBaseChange_comp_unipotentPart_pointsAction k H K g M N).symm
+    erw [FGComoduleCat.scalarExtensionFunctor_μ,
+      fgPointUnipotentPartNatIso_hom_app,
+      fgPointUnipotentPartNatIso_hom_app,
+      fgPointUnipotentPartNatIso_hom_app]
+    rw [← MonoidalCategory.tensorHom_comp_tensorHom,
+      ← MonoidalCategory.tensorHom_comp_tensorHom]
+    simp only [Category.assoc]
+    rw [cancel_epi]
+    erw [Category.assoc, eqToHom_trans_assoc]
+    simp only [MonoidalCategory.tensorHom_comp_tensorHom_assoc, eqToHom_trans,
+      eqToHom_refl, Category.id_comp, Category.comp_id, LinearEquiv.toModuleIsoₛ_hom]
+    erw [← Category.assoc, htensor, Category.assoc]
+
+/-- The semisimple factors of a point's actions on finite comodules, as an automorphism of the
+monoidal scalar-extension functor. -/
+noncomputable def fgPointSemisimplePartTensorIso (g : WithConv (H →ₐ[k] K)) :
+    Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H K) :=
+  @LaxMonoidalFunctor.isoMk _ _ _ _ _ _ _ _
+    (fgPointSemisimplePartNatIso k H K g)
+    (isMonoidal_fgPointSemisimplePartNatIso_hom k H K g)
+
+/-- The unipotent factors of a point's actions on finite comodules, as an automorphism of the
+monoidal scalar-extension functor. -/
+noncomputable def fgPointUnipotentPartTensorIso (g : WithConv (H →ₐ[k] K)) :
+    Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H K) :=
+  @LaxMonoidalFunctor.isoMk _ _ _ _ _ _ _ _
+    (fgPointUnipotentPartNatIso k H K g)
+    (isMonoidal_fgPointUnipotentPartNatIso_hom k H K g)
+
+/-- Forgetting tensor compatibility from the semisimple-factor automorphism recovers its
+underlying natural automorphism. -/
+@[simp]
+theorem fgPointSemisimplePartTensorIso_hom_hom (g : WithConv (H →ₐ[k] K)) :
+    (fgPointSemisimplePartTensorIso k H K g).hom.hom =
+      (fgPointSemisimplePartNatIso k H K g).hom :=
+  (rfl)
+
+/-- Forgetting tensor compatibility from the unipotent-factor automorphism recovers its
+underlying natural automorphism. -/
+@[simp]
+theorem fgPointUnipotentPartTensorIso_hom_hom (g : WithConv (H →ₐ[k] K)) :
+    (fgPointUnipotentPartTensorIso k H K g).hom.hom =
+      (fgPointUnipotentPartNatIso k H K g).hom :=
+  (rfl)
+
+/-- The tensor automorphisms formed by the semisimple and unipotent factors commute. -/
+theorem commute_fgPointSemisimplePartTensorIso_fgPointUnipotentPartTensorIso
+    (g : WithConv (H →ₐ[k] K)) :
+    Commute (fgPointSemisimplePartTensorIso k H K g)
+      (fgPointUnipotentPartTensorIso k H K g) := by
+  rw [commute_iff_eq]
+  apply Aut.ext
+  apply LaxMonoidalFunctor.hom_ext
+  exact congrArg Iso.hom
+    (commute_fgPointSemisimplePartNatIso_fgPointUnipotentPartNatIso k H K g).eq
+
+/-- Multiplying the tensor automorphisms formed by the semisimple and unipotent factors recovers
+the tensor automorphism induced by the original point. -/
+@[simp]
+theorem fgPointSemisimplePartTensorIso_mul_fgPointUnipotentPartTensorIso
+    (g : WithConv (H →ₐ[k] K)) :
+    fgPointSemisimplePartTensorIso k H K g * fgPointUnipotentPartTensorIso k H K g =
+      fgPointTensorIso k H K g := by
+  apply Aut.ext
+  apply LaxMonoidalFunctor.hom_ext
+  rw [fgPointTensorIso_hom_hom]
+  exact congrArg Iso.hom
+    (fgPointSemisimplePartNatIso_mul_fgPointUnipotentPartNatIso k H K g)
+
+end Monoidal
 
 end TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
@@ -404,27 +404,6 @@ private theorem distribBaseChange_comp_pointFactor
     (W := K ⊗[k] ((M ⊗ N : FGComoduleCat k H) : Type u)) d a b hab
   simpa only [d, a, b, htensor] using h
 
-private theorem scalarExtensionComponent_eq_of_hom_app
-    (M : FGComoduleCat.{u, v, u} k H)
-    (F : LinearMap.GeneralLinearGroup K (K ⊗[k] M))
-    (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H K))
-    (happ : eta.hom.hom.app M =
-      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H K M) ≫
-        F.toLinearEquiv.toModuleIsoₛ.hom ≫
-          eqToHom (FGComoduleCat.scalarExtensionFunctor_obj k H K M).symm) :
-    scalarExtensionComponent k H K eta M = (F : Module.End K (K ⊗[k] M)) := by
-  apply LinearMap.ext
-  intro x
-  rw [scalarExtensionComponent_apply, happ]
-  let hM := FGComoduleCat.scalarExtensionFunctor_obj k H K M
-  -- The functor object is definitionally the explicit scalar extension, but this equality is
-  -- hidden by the categorical and linear-map wrappers. Displaying the four transports lets the
-  -- standard `eqToHom` simp lemmas cancel them without unfolding either public construction.
-  change (eqToHom hM.symm ≫
-      (eqToHom hM ≫ F.toLinearEquiv.toModuleIsoₛ.hom ≫ eqToHom hM.symm) ≫
-        eqToHom hM) x = _
-  simp
-
 section PerfectField
 
 variable [PerfectField K]

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -289,6 +289,8 @@ theorem isMonoidal_of_linear_components
             SemimoduleCat.ofHom
               (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap := by
       apply SemimoduleCat.hom_ext
+      -- `hom_ext` leaves categorical composition and tensoring wrapped by `ofHom`; rewriting
+      -- cannot reach their linear maps, so reduce those wrappers to `comp` and `TensorProduct.map`.
       change
         (F (M ⊗ N : FGComoduleCat R H) :
           Module.End A (A ⊗[R] ((M ⊗ N : FGComoduleCat R H) : Type u))).comp
@@ -314,6 +316,8 @@ theorem ofLinearEquiv_pointsAction_tensorUnit_eq_one
     LinearMap.GeneralLinearGroup.ofLinearEquiv
         (Comodule.pointsAction (𝟙_ (FGComoduleCat R H)) g) = 1 := by
   apply Units.ext
+  -- `Units.ext` still hides the values of `ofLinearEquiv` and `1` behind unit and equivalence
+  -- wrappers, so expose their definitionally equal underlying linear maps before rewriting.
   change (Comodule.pointsAction (𝟙_ (FGComoduleCat R H)) g :
     A ⊗[R] (𝟙_ (FGComoduleCat R H)) →ₗ[A] A ⊗[R] (𝟙_ (FGComoduleCat R H))) =
       LinearMap.id
@@ -351,6 +355,8 @@ theorem distribBaseChange_comp_pointsAction
   have hlin := congrArg SemimoduleCat.Hom.hom htensor
   simp only [SemimoduleCat.hom_comp] at hlin
   rw [SemimoduleCat.hom_tensorHom] at hlin
+  -- The extracted hom equality still contains the categorical `ofHom` tensor and composition;
+  -- rewriting cannot see through them, so reduce them to linear-map composition and tensoring.
   change d.comp (TensorProduct.map (Comodule.endOfPoint M g.ofConv)
       (Comodule.endOfPoint N g.ofConv)) =
     (Comodule.endOfPoint ((M ⊗ N : FGComoduleCat R H) : Type u) g.ofConv).comp d at hlin
@@ -394,6 +400,29 @@ theorem fgPointTensorIso_hom_hom (g : WithConv (H →ₐ[R] A)) :
     (fgPointTensorIso R H A g).hom.hom = (fgPointNatIsoHom R H A g).hom :=
   (rfl)
 
+/-- Evaluate a transported scalar-extension component from the corresponding natural
+transformation component. -/
+theorem scalarExtensionComponent_eq_of_hom_app
+    (M : FGComoduleCat.{u, v, u} R H)
+    (F : LinearMap.GeneralLinearGroup A (A ⊗[R] M))
+    (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor R H A))
+    (happ : eta.hom.hom.app M =
+      eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
+        F.toLinearEquiv.toModuleIsoₛ.hom ≫
+          eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm) :
+    scalarExtensionComponent R H A eta M = (F : Module.End A (A ⊗[R] M)) := by
+  apply LinearMap.ext
+  intro x
+  rw [scalarExtensionComponent_apply, happ]
+  let hM := FGComoduleCat.scalarExtensionFunctor_obj R H A M
+  -- The functor object is definitionally the explicit scalar extension, but this equality is
+  -- hidden by the categorical and linear-map wrappers. Displaying the four transports lets the
+  -- standard `eqToHom` simp lemmas cancel them without unfolding either public construction.
+  change (eqToHom hM.symm ≫
+      (eqToHom hM ≫ F.toLinearEquiv.toModuleIsoₛ.hom ≫ eqToHom hM.symm) ≫
+        eqToHom hM) x = _
+  simp
+
 /-- The transported component of the tensor automorphism induced by a point is the usual point
 action on every finite comodule. -/
 @[simp]
@@ -401,17 +430,12 @@ theorem scalarExtensionComponent_fgPointTensorIso
     (g : WithConv (H →ₐ[R] A)) (M : FGComoduleCat.{u, v, u} R H) :
     scalarExtensionComponent R H A (fgPointTensorIso R H A g) M =
       (Comodule.pointsAction M g).toLinearMap := by
-  apply LinearMap.ext
-  intro x
-  unfold scalarExtensionComponent
-  rw [fgPointTensorIso_hom_hom, fgPointNatIsoHom_hom_app]
-  let hM := FGComoduleCat.scalarExtensionFunctor_obj R H A M
-  -- After rewriting the point-induced component, only transport along `hM` remains; displaying
-  -- the four `eqToHom`s lets the category simp lemmas cancel this object equality.
-  change (eqToHom hM.symm ≫
-      (eqToHom hM ≫ (Comodule.pointsAction M g).toModuleIsoₛ.hom ≫
-        eqToHom hM.symm) ≫ eqToHom hM) x = _
-  simp
+  have h := scalarExtensionComponent_eq_of_hom_app R H A M
+    (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))
+    (fgPointTensorIso R H A g) (by
+      rw [fgPointTensorIso_hom_hom]
+      exact fgPointNatIsoHom_hom_app R H A g M)
+  exact h
 
 /-- Forgetting tensor compatibility from the inverse point automorphism recovers the inverse
 underlying natural automorphism. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -246,43 +246,139 @@ variable (A : Type u) [CommSemiring A] [Algebra R A]
 
 open Functor.LaxMonoidal
 
-/-- The natural automorphism induced by an algebra-valued point is monoidal. -/
-theorem isMonoidal_fgPointNatIsoHom_hom (g : WithConv (H →ₐ[R] A)) :
-    NatTrans.IsMonoidal (fgPointNatIsoHom R H A g).hom := by
+/-- A natural automorphism of scalar extension is monoidal when its transported linear
+components preserve the tensor unit and tensor products. -/
+theorem isMonoidal_of_linear_components
+    (F : ∀ M : FGComoduleCat.{u, v, u} R H,
+      LinearMap.GeneralLinearGroup A (A ⊗[R] M))
+    (η : Aut (FGComoduleCat.scalarExtensionFunctor R H A))
+    (happ : ∀ M : FGComoduleCat.{u, v, u} R H,
+      η.hom.app M =
+        eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M) ≫
+          (F M).toLinearEquiv.toModuleIsoₛ.hom ≫
+            eqToHom (FGComoduleCat.scalarExtensionFunctor_obj R H A M).symm)
+    (hunit : F (𝟙_ (FGComoduleCat R H)) = 1)
+    (htensor : ∀ M N : FGComoduleCat.{u, v, u} R H,
+      (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap.comp
+          (TensorProduct.map (F M : Module.End A (A ⊗[R] M))
+            (F N : Module.End A (A ⊗[R] N))) =
+        (F (M ⊗ N : FGComoduleCat R H) :
+          Module.End A (A ⊗[R] ((M ⊗ N : FGComoduleCat R H) : Type u))).comp
+            (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap) :
+    NatTrans.IsMonoidal η.hom := by
   constructor
-  · rw [FGComoduleCat.scalarExtensionFunctor_ε, fgPointNatIsoHom_hom_app]
+  · rw [FGComoduleCat.scalarExtensionFunctor_ε, happ]
     apply SemimoduleCat.hom_ext
     apply LinearMap.ext
     intro a
-    simp [Comodule.pointsAction_toLinearMap, Comodule.endOfPoint_trivial]
+    simp only [Category.assoc, SemimoduleCat.comp_apply,
+      LinearEquiv.toModuleIsoₛ_hom]
+    rw [hunit]
+    simp
   · intro M N
-    let _ : Comodule R H (M ⊗[R] N) :=
-      inferInstanceAs (Comodule R H ((M ⊗ N : FGComoduleCat R H) : Type u))
-    have htensor :
-            SemimoduleCat.ofHom
+    have htensor' :
+        SemimoduleCat.ofHom
               (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap ≫
-            SemimoduleCat.ofHom (Comodule.endOfPoint
-              ((M ⊗ N : FGComoduleCat R H) : Type u) g.ofConv) =
-          (SemimoduleCat.ofHom (Comodule.endOfPoint M g.ofConv) ⊗ₘ
-              SemimoduleCat.ofHom (Comodule.endOfPoint N g.ofConv)) ≫
+            SemimoduleCat.ofHom
+              (F (M ⊗ N : FGComoduleCat R H) :
+                Module.End A (A ⊗[R] ((M ⊗ N : FGComoduleCat R H) : Type u))) =
+          (SemimoduleCat.ofHom
+                (F M : Module.End A (A ⊗[R] M)) ⊗ₘ
+              SemimoduleCat.ofHom
+                (F N : Module.End A (A ⊗[R] N))) ≫
             SemimoduleCat.ofHom
               (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap := by
       apply SemimoduleCat.hom_ext
-      exact (Comodule.endOfPoint_tensor_of_coact_eq (R := R) (H := H) (A := A)
-        (V := M) (W := N) (FGComoduleCat.tensor_coact (R := R) (C := H) M N)
-          g.ofConv).symm
+      change
+        (F (M ⊗ N : FGComoduleCat R H) :
+          Module.End A (A ⊗[R] ((M ⊗ N : FGComoduleCat R H) : Type u))).comp
+            (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap =
+          (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap.comp
+            (TensorProduct.map (F M : Module.End A (A ⊗[R] M))
+              (F N : Module.End A (A ⊗[R] N)))
+      exact (htensor M N).symm
     erw [FGComoduleCat.scalarExtensionFunctor_μ,
-      fgPointNatIsoHom_hom_app, fgPointNatIsoHom_hom_app,
-      fgPointNatIsoHom_hom_app]
+      happ, happ, happ]
     rw [← MonoidalCategory.tensorHom_comp_tensorHom,
       ← MonoidalCategory.tensorHom_comp_tensorHom]
     simp only [Category.assoc]
     rw [cancel_epi]
     erw [Category.assoc, eqToHom_trans_assoc]
     simp only [MonoidalCategory.tensorHom_comp_tensorHom_assoc, eqToHom_trans,
-      eqToHom_refl, Category.id_comp, Category.comp_id, LinearEquiv.toModuleIsoₛ_hom,
-      Comodule.pointsAction_toLinearMap]
-    erw [← Category.assoc, htensor, Category.assoc]
+      eqToHom_refl, Category.id_comp, Category.comp_id, LinearEquiv.toModuleIsoₛ_hom]
+    erw [← Category.assoc, htensor', Category.assoc]
+
+/-- The point action on the tensor unit is the identity automorphism. -/
+theorem ofLinearEquiv_pointsAction_tensorUnit_eq_one
+    (g : WithConv (H →ₐ[R] A)) :
+    LinearMap.GeneralLinearGroup.ofLinearEquiv
+        (Comodule.pointsAction (𝟙_ (FGComoduleCat R H)) g) = 1 := by
+  apply Units.ext
+  change (Comodule.pointsAction (𝟙_ (FGComoduleCat R H)) g :
+    A ⊗[R] (𝟙_ (FGComoduleCat R H)) →ₗ[A] A ⊗[R] (𝟙_ (FGComoduleCat R H))) =
+      LinearMap.id
+  rw [Comodule.pointsAction_toLinearMap, Comodule.endOfPoint_trivial]
+
+/-- The scalar-extension tensorator intertwines the tensor product of two point actions with the
+point action on the tensor product comodule. -/
+theorem distribBaseChange_comp_pointsAction
+    (g : WithConv (H →ₐ[R] A)) (M N : FGComoduleCat.{u, v, u} R H) :
+    (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap.comp
+        (TensorProduct.map
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g) :
+            Module.End A (A ⊗[R] M))
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g) :
+            Module.End A (A ⊗[R] N))) =
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv
+          (Comodule.pointsAction (M ⊗ N : FGComoduleCat R H) g) :
+        Module.End A (A ⊗[R] ((M ⊗ N : FGComoduleCat R H) : Type u))).comp
+          (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap := by
+  let _ : Comodule R H (M ⊗[R] N) :=
+    inferInstanceAs (Comodule R H ((M ⊗ N : FGComoduleCat R H) : Type u))
+  let d := (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap
+  let dc :
+      (SemimoduleCat.of A (A ⊗[R] M) ⊗ SemimoduleCat.of A (A ⊗[R] N)) ⟶
+        SemimoduleCat.of A (A ⊗[R] (M ⊗[R] N)) :=
+    SemimoduleCat.ofHom d
+  have htensor :
+        (SemimoduleCat.ofHom (Comodule.endOfPoint M g.ofConv) ⊗ₘ
+            SemimoduleCat.ofHom (Comodule.endOfPoint N g.ofConv)) ≫ dc =
+      dc ≫ SemimoduleCat.ofHom (Comodule.endOfPoint
+        ((M ⊗ N : FGComoduleCat R H) : Type u) g.ofConv) := by
+    apply SemimoduleCat.hom_ext
+    exact Comodule.endOfPoint_tensor_of_coact_eq (R := R) (H := H) (A := A)
+      (V := M) (W := N) (FGComoduleCat.tensor_coact (R := R) (C := H) M N) g.ofConv
+  have hlin := congrArg SemimoduleCat.Hom.hom htensor
+  simp only [SemimoduleCat.hom_comp] at hlin
+  rw [SemimoduleCat.hom_tensorHom] at hlin
+  change d.comp (TensorProduct.map (Comodule.endOfPoint M g.ofConv)
+      (Comodule.endOfPoint N g.ofConv)) =
+    (Comodule.endOfPoint ((M ⊗ N : FGComoduleCat R H) : Type u) g.ofConv).comp d at hlin
+  have hM :
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g) :
+        Module.End A (A ⊗[R] M)) = Comodule.endOfPoint M g.ofConv :=
+    Comodule.pointsAction_toLinearMap M g
+  have hN :
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g) :
+        Module.End A (A ⊗[R] N)) = Comodule.endOfPoint N g.ofConv :=
+    Comodule.pointsAction_toLinearMap N g
+  have hMN :
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv
+          (Comodule.pointsAction (M ⊗ N : FGComoduleCat R H) g) :
+        Module.End A (A ⊗[R] ((M ⊗ N : FGComoduleCat R H) : Type u))) =
+          Comodule.endOfPoint ((M ⊗ N : FGComoduleCat R H) : Type u) g.ofConv :=
+    Comodule.pointsAction_toLinearMap (M ⊗ N : FGComoduleCat R H) g
+  rw [hM, hN, hMN]
+  exact hlin
+
+/-- The natural automorphism induced by an algebra-valued point is monoidal. -/
+theorem isMonoidal_fgPointNatIsoHom_hom (g : WithConv (H →ₐ[R] A)) :
+    NatTrans.IsMonoidal (fgPointNatIsoHom R H A g).hom := by
+  apply isMonoidal_of_linear_components R H A
+    (fun M ↦ LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))
+  · exact fgPointNatIsoHom_hom_app R H A g
+  · exact ofLinearEquiv_pointsAction_tensorUnit_eq_one R H A g
+  · exact distribBaseChange_comp_pointsAction R H A g
 
 /-- An algebra-valued point as a tensor automorphism of finite-comodule scalar extension. -/
 @[expose] noncomputable def fgPointTensorIso (g : WithConv (H →ₐ[R] A)) :

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -311,6 +311,7 @@ theorem isMonoidal_of_linear_components
     erw [← Category.assoc, htensor', Category.assoc]
 
 /-- The point action on the tensor unit is the identity automorphism. -/
+@[simp]
 theorem ofLinearEquiv_pointsAction_tensorUnit_eq_one
     (g : WithConv (H →ₐ[R] A)) :
     LinearMap.GeneralLinearGroup.ofLinearEquiv
@@ -337,45 +338,12 @@ theorem distribBaseChange_comp_pointsAction
           (Comodule.pointsAction (M ⊗ N : FGComoduleCat R H) g) :
         Module.End A (A ⊗[R] ((M ⊗ N : FGComoduleCat R H) : Type u))).comp
           (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap := by
-  let _ : Comodule R H (M ⊗[R] N) :=
-    inferInstanceAs (Comodule R H ((M ⊗ N : FGComoduleCat R H) : Type u))
-  let d := (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toLinearMap
-  let dc :
-      (SemimoduleCat.of A (A ⊗[R] M) ⊗ SemimoduleCat.of A (A ⊗[R] N)) ⟶
-        SemimoduleCat.of A (A ⊗[R] (M ⊗[R] N)) :=
-    SemimoduleCat.ofHom d
-  have htensor :
-        (SemimoduleCat.ofHom (Comodule.endOfPoint M g.ofConv) ⊗ₘ
-            SemimoduleCat.ofHom (Comodule.endOfPoint N g.ofConv)) ≫ dc =
-      dc ≫ SemimoduleCat.ofHom (Comodule.endOfPoint
-        ((M ⊗ N : FGComoduleCat R H) : Type u) g.ofConv) := by
-    apply SemimoduleCat.hom_ext
-    exact Comodule.endOfPoint_tensor_of_coact_eq (R := R) (H := H) (A := A)
-      (V := M) (W := N) (FGComoduleCat.tensor_coact (R := R) (C := H) M N) g.ofConv
-  have hlin := congrArg SemimoduleCat.Hom.hom htensor
-  simp only [SemimoduleCat.hom_comp] at hlin
-  rw [SemimoduleCat.hom_tensorHom] at hlin
-  -- The extracted hom equality still contains the categorical `ofHom` tensor and composition;
-  -- rewriting cannot see through them, so reduce them to linear-map composition and tensoring.
-  change d.comp (TensorProduct.map (Comodule.endOfPoint M g.ofConv)
-      (Comodule.endOfPoint N g.ofConv)) =
-    (Comodule.endOfPoint ((M ⊗ N : FGComoduleCat R H) : Type u) g.ofConv).comp d at hlin
-  have hM :
-      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g) :
-        Module.End A (A ⊗[R] M)) = Comodule.endOfPoint M g.ofConv :=
-    Comodule.pointsAction_toLinearMap M g
-  have hN :
-      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction N g) :
-        Module.End A (A ⊗[R] N)) = Comodule.endOfPoint N g.ofConv :=
-    Comodule.pointsAction_toLinearMap N g
-  have hMN :
-      (LinearMap.GeneralLinearGroup.ofLinearEquiv
-          (Comodule.pointsAction (M ⊗ N : FGComoduleCat R H) g) :
-        Module.End A (A ⊗[R] ((M ⊗ N : FGComoduleCat R H) : Type u))) =
-          Comodule.endOfPoint ((M ⊗ N : FGComoduleCat R H) : Type u) g.ofConv :=
-    Comodule.pointsAction_toLinearMap (M ⊗ N : FGComoduleCat R H) g
-  rw [hM, hN, hMN]
-  exact hlin
+  have hpoint (P : FGComoduleCat.{u, v, u} R H) :
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction P g) :
+        Module.End A (A ⊗[R] P)) = Comodule.endOfPoint P g.ofConv :=
+    Comodule.pointsAction_toLinearMap P g
+  rw [hpoint M, hpoint N, hpoint (M ⊗ N : FGComoduleCat R H)]
+  exact Comodule.endOfPoint_tensor g.ofConv
 
 /-- The natural automorphism induced by an algebra-valued point is monoidal. -/
 theorem isMonoidal_fgPointNatIsoHom_hom (g : WithConv (H →ₐ[R] A)) :


### PR DESCRIPTION
This PR packages the semisimple and unipotent Jordan factors of a perfect-field-valued point's actions on finite comodules as automorphisms of the monoidal scalar-extension functor. Prove compatibility with the tensor unit and tensorator, prove that the resulting tensor automorphisms commute, and identify their product with the tensor automorphism induced by the original point.

The exact target is `ReductiveGroups/README.md`, Layer 4, milestone **“Jordan decomposition of elements into semisimple and unipotent parts (geometric, over `k̄`), functorial under representations.”** The landed naturality and tensor-product theorems provide the two inputs: the scalar-extension tensorator intertwines the tensor product of the point actions with the action on the tensor-product comodule, and functoriality of multiplicative Jordan decomposition transports that intertwining relation to both factors. The tensor-product formulas then identify those transported factors with the tensor products of the componentwise factors.

This is the missing bridge from componentwise linear Jordan decomposition to Tannakian reconstruction: the reconstruction API consumes tensor automorphisms, not arbitrary natural automorphisms. After this PR, the milestone still needs to reconstruct the two factors as points, prove their intrinsic semisimple and unipotent characterizations, and establish functoriality under algebraic-group homomorphisms.

Extend `TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean` by 326 insertions and 4 deletions. Reuse `Comodule.endOfPoint_tensor_of_coact_eq`, `GeneralLinearGroup.comp_semisimplePart_eq_of_comp_eq`, `comp_unipotentPart_eq_of_comp_eq`, `semisimplePart_tensorProduct`, `unipotentPart_tensorProduct`, and the existing monoidal scalar-extension packaging. The mathematical construction follows T. A. Springer, *Linear Algebraic Groups*, §2.4, as cited in the module documentation. No Mathlib source is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"jordan-factors-tensor-automorphisms"}-->

🤖 Prepared with Codex
