### PR TITLE
feat: transcribe the Monster presentation

### DIFF
--- a/TauCeti/GroupTheory/Presentation/Coxeter.lean
+++ b/TauCeti/GroupTheory/Presentation/Coxeter.lean
@@ -85,6 +85,20 @@ theorem toWord_coxeterRelator (M : CoxeterMatrix B) (i j : B) :
       (List.replicate (M i j) [(i, true), (j, true)]).flatten := by
   simp [coxeterRelator]
 
+/-- A Coxeter relator contains twice as many signed letters as its matrix entry. -/
+@[simp]
+theorem length_toWord_coxeterRelator (M : CoxeterMatrix B) (i j : B) :
+    (coxeterRelator M i j).toWord.length = 2 * M i j := by
+  rw [toWord_coxeterRelator, List.length_flatten]
+  simp [Nat.mul_comm]
+
+/-- The signed word of a Coxeter relator is cyclically reduced. -/
+theorem isCyclicallyReduced_toWord_coxeterRelator (M : CoxeterMatrix B) (i j : B) :
+    FreeGroup.IsCyclicallyReduced (coxeterRelator M i j).toWord := by
+  rw [toWord_coxeterRelator]
+  apply FreeGroup.IsCyclicallyReduced.flatten_replicate
+  simp [FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced]
+
 /-- Interpreting a Coxeter relator in the free group yields Mathlib's Coxeter relation. -/
 @[simp]
 theorem toFreeGroup_coxeterRelator (M : CoxeterMatrix B) (i j : B) :
@@ -101,6 +115,13 @@ The unordered pairs are Mathlib's `List.sym2`; `Sym2.inf` and `Sym2.sup` name th
 larger node, which is the choice of order the free group forces on the transcription. -/
 def coxeterRelatorsOfList [LinearOrder B] (M : CoxeterMatrix B) (l : List B) : List (Relator B) :=
   l.sym2.map fun z => coxeterRelator M z.inf z.sup
+
+/-- The Coxeter relator list is obtained by mapping the canonically ordered representative of
+each unordered pair of list positions to its Coxeter relator. This equation lets a concrete finite
+presentation audit the compiled words without exposing the definition. -/
+theorem coxeterRelatorsOfList_eq [LinearOrder B] (M : CoxeterMatrix B) (l : List B) :
+    coxeterRelatorsOfList M l = l.sym2.map fun z => coxeterRelator M z.inf z.sup := by
+  rw [coxeterRelatorsOfList]
 
 /-- A list of length `n` yields `(n + 1).choose 2` Coxeter relators, the number of unordered pairs
 of list positions with repetition allowed. -/
@@ -144,6 +165,12 @@ private theorem coxeterRelator_mem_or_swap_mem [LinearOrder B] (M : CoxeterMatri
 numbering `0, 1, …, n - 1`. -/
 def coxeterRelators {n : ℕ} (M : CoxeterMatrix (Fin n)) : List (Relator (Fin n)) :=
   coxeterRelatorsOfList M (List.finRange n)
+
+/-- The numbered Coxeter relator list uses the nodes `0, …, n - 1` in that order. This is the
+unfolding equation for the sealed definition. -/
+theorem coxeterRelators_eq {n : ℕ} (M : CoxeterMatrix (Fin n)) :
+    coxeterRelators M = coxeterRelatorsOfList M (List.finRange n) := by
+  rw [coxeterRelators]
 
 /-- Membership in the Coxeter relator list of a `Fin n`-indexed matrix: every pair of nodes
 contributes, so the only condition is that the relator be the one of a pair, written in the

--- a/TauCeti/GroupTheory/Presentation/Coxeter.lean
+++ b/TauCeti/GroupTheory/Presentation/Coxeter.lean
@@ -86,7 +86,6 @@ theorem toWord_coxeterRelator (M : CoxeterMatrix B) (i j : B) :
   simp [coxeterRelator]
 
 /-- A Coxeter relator contains twice as many signed letters as its matrix entry. -/
-@[simp]
 theorem length_toWord_coxeterRelator (M : CoxeterMatrix B) (i j : B) :
     (coxeterRelator M i j).toWord.length = 2 * M i j := by
   rw [toWord_coxeterRelator, List.length_flatten]

--- a/TauCeti/GroupTheory/Presentation/Coxeter.lean
+++ b/TauCeti/GroupTheory/Presentation/Coxeter.lean
@@ -116,9 +116,12 @@ def coxeterRelatorsOfList [LinearOrder B] (M : CoxeterMatrix B) (l : List B) : L
   l.sym2.map fun z => coxeterRelator M z.inf z.sup
 
 /-- The Coxeter relator list is obtained by mapping the canonically ordered representative of
-each unordered pair of list positions to its Coxeter relator. This equation lets a concrete finite
-presentation audit the compiled words without exposing the definition. -/
-theorem coxeterRelatorsOfList_eq [LinearOrder B] (M : CoxeterMatrix B) (l : List B) :
+each unordered pair of list positions to its Coxeter relator.
+
+This is the unfolding lemma for the sealed body, and like `TauCeti.GroupPresentation.relators_def`
+it is deliberately not `@[simp]`: it lets a concrete finite presentation audit the compiled words
+without the definition being exposed. -/
+theorem coxeterRelatorsOfList_def [LinearOrder B] (M : CoxeterMatrix B) (l : List B) :
     coxeterRelatorsOfList M l = l.sym2.map fun z => coxeterRelator M z.inf z.sup := by
   rw [coxeterRelatorsOfList]
 
@@ -166,8 +169,8 @@ def coxeterRelators {n : ℕ} (M : CoxeterMatrix (Fin n)) : List (Relator (Fin n
   coxeterRelatorsOfList M (List.finRange n)
 
 /-- The numbered Coxeter relator list uses the nodes `0, …, n - 1` in that order. This is the
-unfolding equation for the sealed definition. -/
-theorem coxeterRelators_eq {n : ℕ} (M : CoxeterMatrix (Fin n)) :
+unfolding lemma for the sealed body, and like `coxeterRelatorsOfList_def` it is not `@[simp]`. -/
+theorem coxeterRelators_def {n : ℕ} (M : CoxeterMatrix (Fin n)) :
     coxeterRelators M = coxeterRelatorsOfList M (List.finRange n) := by
   rw [coxeterRelators]
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Monster.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Monster.lean
@@ -78,8 +78,9 @@ def edges : List (Fin 12 × Fin 12) :=
     (0, 5), (5, 6), (6, 7), (7, 8),
     (0, 9), (9, 10), (10, 11)]
 
-/-- The explicit edge list of the numbered `Y₄₄₃` diagram. -/
-theorem edges_eq : edges =
+/-- The explicit edge list of the numbered `Y₄₄₃` diagram. This is the unfolding lemma for the
+sealed body. -/
+theorem edges_def : edges =
     [(0, 1), (1, 2), (2, 3), (3, 4),
       (0, 5), (5, 6), (6, 7), (7, 8),
       (0, 9), (9, 10), (10, 11)] := by
@@ -133,8 +134,9 @@ private abbrev d3 : Relator (Fin 12) := .gen 11
 def spiderRelator : Relator (Fin 12) :=
   .pow (a ⬝ b1 ⬝ c1 ⬝ a ⬝ b2 ⬝ c2 ⬝ a ⬝ b3 ⬝ c3) 10
 
-/-- The spider relator spelled out in the numbered alphabet. -/
-theorem spiderRelator_eq : spiderRelator =
+/-- The spider relator spelled out in the numbered alphabet. This is the unfolding lemma for the
+sealed body. -/
+theorem spiderRelator_def : spiderRelator =
     .pow (.gen 0 ⬝ .gen 1 ⬝ .gen 2 ⬝ .gen 0 ⬝ .gen 5 ⬝ .gen 6 ⬝ .gen 0 ⬝
       .gen 9 ⬝ .gen 10) 10 := by
   rw [spiderRelator]
@@ -144,19 +146,22 @@ from `Y₄₄₃ ≅ M × 2` to the Monster group `M`. -/
 def centralInvolutionRelator : Relator (Fin 12) :=
   .pow (a ⬝ b3 ⬝ c3 ⬝ d3 ⬝ b1 ⬝ c1 ⬝ b2) 9
 
-/-- Ivanov's element `f₃₁₂` spelled out in the numbered alphabet. -/
-theorem centralInvolutionRelator_eq : centralInvolutionRelator =
+/-- Ivanov's element `f₃₁₂` spelled out in the numbered alphabet. This is the unfolding lemma for
+the sealed body. -/
+theorem centralInvolutionRelator_def : centralInvolutionRelator =
     .pow (.gen 0 ⬝ .gen 9 ⬝ .gen 10 ⬝ .gen 11 ⬝ .gen 1 ⬝ .gen 2 ⬝ .gen 5) 9 := by
   rw [centralInvolutionRelator]
-
-/-- The spider and central-involution relators appended to the Coxeter relations. -/
-def additionalRelators : List (Relator (Fin 12)) :=
-  [spiderRelator, centralInvolutionRelator]
 
 /-- The eighty relators of the Monster presentation: the `Y₄₄₃` Coxeter relations, followed by
 the spider and central-involution relators. -/
 def relatorList : List (Relator (Fin 12)) :=
-  coxeterRelators coxeterMatrix ++ additionalRelators
+  coxeterRelators coxeterMatrix ++ [spiderRelator, centralInvolutionRelator]
+
+/-- The relator list decomposes into the `Y₄₄₃` Coxeter relations, the spider relator, and the
+central-involution relator. This is the unfolding lemma for the sealed body. -/
+theorem relatorList_def : relatorList =
+    coxeterRelators coxeterMatrix ++ [spiderRelator, centralInvolutionRelator] := by
+  rw [relatorList]
 
 /-! ### The presentation row and its audit interface -/
 
@@ -164,7 +169,11 @@ def relatorList : List (Relator (Fin 12)) :=
 
 Ivanov proves that `Y₄₄₃` is `M × 2` and that quotienting by the central element `f₃₁₂` gives `M`.
 No structural property of the resulting `PresentedGroup` is asserted here; this definition records
-only the cited generators and complete relator data. -/
+only the cited generators and complete relator data.
+
+The body is exposed so that `presentation_transcribed` below can state the exact typed relator
+data: the index type of a transcribed relator is `Fin presentation.generatorNames.length`, which
+is `Fin 12` only by unfolding this definition. -/
 @[expose]
 def presentation : GroupPresentation where
   generatorNames := ["a", "b1", "c1", "d1", "e1", "b2", "c2", "d2", "e2", "b3", "c3", "d3"]
@@ -233,6 +242,12 @@ theorem presentation_expectedGeneratorCount : presentation.expectedGeneratorCoun
 theorem presentation_expectedRelatorCount : presentation.expectedRelatorCount = 80 := by
   rw [presentation]
 
+/-- The relator expressions carried by the Monster presentation are exactly the transcribed
+relator list, whose decomposition is `relatorList_def`. -/
+@[simp]
+theorem presentation_transcribed : presentation.transcribed = relatorList := by
+  simp [presentation]
+
 /-- The compiled relators carried by the Monster presentation, with generator bounds forgotten. -/
 theorem presentation_relatorLetters : presentation.relatorLetters =
     relatorList.map fun r => r.toWord.map fun letter => (letter.1.val, letter.2) := by
@@ -249,61 +264,55 @@ theorem length_coxeterRelators : (coxeterRelators coxeterMatrix).length = 78 := 
 
 /-- The full Monster presentation has eighty relators. -/
 theorem length_relatorList : relatorList.length = 80 := by
-  simp [relatorList, additionalRelators]
+  simp [relatorList_def]
   norm_num [Nat.choose]
 
 /-- The generator and relator counts recorded for the Monster agree with the transcribed data. -/
 theorem presentation_matchesMetadata : presentation.matchesMetadata := by
   rw [GroupPresentation.matchesMetadata_iff]
-  constructor
-  · change presentation.generatorNames.length = 12
-    rw [presentation_generatorNames]
+  refine ⟨?_, ?_⟩
+  · rw [GroupPresentation.generatorCount, presentation_generatorNames,
+      presentation_expectedGeneratorCount]
     rfl
-  · simpa [presentation, relatorList, additionalRelators] using length_relatorList
+  · rw [presentation_transcribed, presentation_expectedRelatorCount]
+    exact length_relatorList
 
 /-- The spider relator has ninety letters. -/
-theorem spiderRelator_length : spiderRelator.toWord.length = 90 := by
+theorem length_spiderRelator : spiderRelator.toWord.length = 90 := by
   simp [spiderRelator]
 
 /-- The seventy-nine relators presenting `M × 2` have the source's total length `400`. -/
 theorem coxeterAndSpider_totalLength :
     ((coxeterRelators coxeterMatrix ++ [spiderRelator]).map
       fun r => r.toWord.length).sum = 400 := by
-  rw [coxeterRelators_eq, coxeterRelatorsOfList_eq]
+  rw [coxeterRelators_def, coxeterRelatorsOfList_def]
   rw [List.map_append, List.sum_append, List.map_map]
-  change
-    (List.map (fun z => (coxeterRelator coxeterMatrix z.inf z.sup).toWord.length)
-        (List.finRange 12).sym2).sum +
-      (List.map (fun r => r.toWord.length) [spiderRelator]).sum = 400
-  simp_rw [length_toWord_coxeterRelator]
+  simp_rw [Function.comp_def, length_toWord_coxeterRelator]
   simp only [coxeterMatrix_apply]
-  rw [edges_eq]
+  rw [edges_def]
   simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, Nat.add_zero,
-    spiderRelator_length]
+    length_spiderRelator]
   decide
 
 /-- The central-involution relator `f₃₁₂` has sixty-three letters. -/
-theorem centralInvolutionRelator_length : centralInvolutionRelator.toWord.length = 63 := by
+theorem length_centralInvolutionRelator : centralInvolutionRelator.toWord.length = 63 := by
   simp [centralInvolutionRelator]
 
 /-- The compiled relators of the Monster presentation contain `463` signed letters in total. -/
 theorem presentation_totalLength : presentation.totalLength = 463 := by
   have h : (relatorList.map fun r => r.toWord.length).sum = 463 := by
-    rw [relatorList, additionalRelators]
-    rw [show coxeterRelators coxeterMatrix ++ [spiderRelator, centralInvolutionRelator] =
-        (coxeterRelators coxeterMatrix ++ [spiderRelator]) ++ [centralInvolutionRelator] by
-          simp]
-    rw [List.map_append, List.sum_append]
+    rw [relatorList_def, ← List.singleton_append, ← List.append_assoc, List.map_append,
+      List.sum_append]
     simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, Nat.add_zero]
-    rw [coxeterAndSpider_totalLength, centralInvolutionRelator_length]
+    rw [coxeterAndSpider_totalLength, length_centralInvolutionRelator]
   rw [← GroupPresentation.sum_map_length_relatorLetters, presentation_relatorLetters,
     List.map_map]
   simpa only [Function.comp_def, List.length_map] using h
 
 /-- Every expression in the Monster relator list compiles to a cyclically reduced word. -/
-theorem relatorList_cyclicallyReduced (r : Relator (Fin 12)) (hr : r ∈ relatorList) :
-    FreeGroup.IsCyclicallyReduced r.toWord := by
-  rw [relatorList, additionalRelators, List.mem_append] at hr
+theorem isCyclicallyReduced_toWord_of_mem_relatorList (r : Relator (Fin 12))
+    (hr : r ∈ relatorList) : FreeGroup.IsCyclicallyReduced r.toWord := by
+  rw [relatorList_def, List.mem_append] at hr
   rcases hr with hr | hr
   · rw [mem_coxeterRelators_iff] at hr
     obtain ⟨i, j, rfl⟩ := hr
@@ -318,6 +327,6 @@ the usual presentation-length convention. -/
 theorem presentation_relatorsCyclicallyReduced :
     presentation.relatorsCyclicallyReduced := by
   simpa [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def,
-    presentation] using relatorList_cyclicallyReduced
+    presentation] using isCyclicallyReduced_toWord_of_mem_relatorList
 
 end TauCeti.Sporadic.Monster

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Monster.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Monster.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.GroupTheory.Presentation.Coxeter
+
+/-!
+# A transcribed presentation of the Monster group
+
+This file carries the `M` row of the sporadic presentation data required by milestone S1 of
+`TauCetiRoadmap/CFSGStatement/README.md`. It records the `Y₄₄₃` presentation of the Monster as a
+`TauCeti.GroupPresentation`, together with the exact diagram, source conventions, expected counts,
+and decidable transcription checks.
+
+The twelve involutory generators are the central node `a` and the nodes on three arms of lengths
+four, four, and three:
+
+```text
+e₁ -- d₁ -- c₁ -- b₁ -- a -- b₂ -- c₂ -- d₂ -- e₂
+                         |
+                         b₃ -- c₃ -- d₃
+```
+
+The Coxeter relations contribute `12` square relations, `11` order-three edge relations, and `55`
+order-two nonedge relations. The spider relation
+
+```text
+(a b₁ c₁ a b₂ c₂ a b₃ c₃)¹⁰ = 1
+```
+
+gives the `79`-relator presentation of `M × 2` displayed by Bray. Ivanov defines
+
+```text
+f₃₁₂ = (a b₃ c₃ d₃ b₁ c₁ b₂)⁹,
+```
+
+proves that it is central, and in Section 3.9 identifies the quotient `Y₄₄₃ / ⟨f₃₁₂⟩` with the
+Monster. Appending `f₃₁₂ = 1` therefore gives the required `80`-relator presentation of `M`.
+
+The source records length `400` for the `M × 2` presentation. The Coxeter words and spider word
+below reproduce that figure; the final central relator has length `63`, giving total length `463`.
+
+This file asserts no order, finiteness, or simplicity result for the presented group. The roadmap's
+independent permutation-group cross-check does not cover `M`, whose smallest faithful permutation
+representation is far too large for that construction.
+
+## Main definitions
+
+* `TauCeti.Sporadic.Monster.coxeterMatrix`: the explicitly numbered `Y₄₄₃` Coxeter matrix.
+* `TauCeti.Sporadic.Monster.spiderRelator`: the `Y₄₄₃` spider relation.
+* `TauCeti.Sporadic.Monster.centralInvolutionRelator`: Ivanov's element `f₃₁₂`.
+* `TauCeti.Sporadic.Monster.presentation`: the resulting finite presentation of `M`.
+
+## References
+
+* J. N. Bray, *Sporadic (Fischer--Griess) Monster group M = F₁*, especially the `Y₄₄₃`
+  presentation of `M × 2`,
+  <https://webspace.maths.qmul.ac.uk/j.n.bray/web/Pres/Mnst.html>.
+* A. A. Ivanov, *Y-groups via Transitive Extension*, Journal of Algebra **218** (1999), 412--435,
+  especially the definition of `Yₚᵩᵣ` on p. 413, Lemma 3.2 on p. 419, and Section 3.9 on
+  pp. 430--431, <https://doi.org/10.1006/jabr.1999.7882>.
+-/
+
+public section
+
+namespace TauCeti.Sporadic.Monster
+
+/-! ### The numbered `Y₄₄₃` diagram -/
+
+/-- The eleven edges of the `Y₄₄₃` diagram. The numbering is
+`a = 0`, `b₁,c₁,d₁,e₁ = 1,2,3,4`, `b₂,c₂,d₂,e₂ = 5,6,7,8`, and
+`b₃,c₃,d₃ = 9,10,11`. Each pair is oriented away from the central node. -/
+def edges : List (Fin 12 × Fin 12) :=
+  [(0, 1), (1, 2), (2, 3), (3, 4),
+    (0, 5), (5, 6), (6, 7), (7, 8),
+    (0, 9), (9, 10), (10, 11)]
+
+/-- The explicit edge list of the numbered `Y₄₄₃` diagram. -/
+theorem edges_eq : edges =
+    [(0, 1), (1, 2), (2, 3), (3, 4),
+      (0, 5), (5, 6), (6, 7), (7, 8),
+      (0, 9), (9, 10), (10, 11)] := by
+  rw [edges]
+
+/-- The Coxeter matrix of `Y₄₄₃`: diagonal entries are one, an edge has label three, and every
+other pair has label two. -/
+def coxeterMatrix : CoxeterMatrix (Fin 12) where
+  M := Matrix.of fun i j =>
+    if i = j then 1 else if (i, j) ∈ edges ∨ (j, i) ∈ edges then 3 else 2
+  isSymm := by
+    ext i j
+    simp only [Matrix.transpose_apply, Matrix.of_apply]
+    rcases eq_or_ne i j with rfl | h
+    · rfl
+    · simp only [h, Ne.symm h, ↓reduceIte]
+      apply if_congr
+      · exact or_comm
+      · rfl
+      · rfl
+  diagonal i := by simp
+  off_diagonal i j h := by
+    simp only [Matrix.of_apply, h, ↓reduceIte]
+    split <;> omega
+
+/-- Evaluation of the `Y₄₄₃` Coxeter matrix directly from its edge list. -/
+theorem coxeterMatrix_apply (i j : Fin 12) :
+    coxeterMatrix i j =
+      if i = j then 1 else if (i, j) ∈ edges ∨ (j, i) ∈ edges then 3 else 2 := by
+  simp only [coxeterMatrix, Matrix.of_apply]
+
+/-! ### The two non-Coxeter relators -/
+
+@[inherit_doc Relator.mul]
+local infixl:70 " ⬝ " => Relator.mul
+
+private abbrev a : Relator (Fin 12) := .gen 0
+private abbrev b1 : Relator (Fin 12) := .gen 1
+private abbrev c1 : Relator (Fin 12) := .gen 2
+private abbrev d1 : Relator (Fin 12) := .gen 3
+private abbrev e1 : Relator (Fin 12) := .gen 4
+private abbrev b2 : Relator (Fin 12) := .gen 5
+private abbrev c2 : Relator (Fin 12) := .gen 6
+private abbrev d2 : Relator (Fin 12) := .gen 7
+private abbrev e2 : Relator (Fin 12) := .gen 8
+private abbrev b3 : Relator (Fin 12) := .gen 9
+private abbrev c3 : Relator (Fin 12) := .gen 10
+private abbrev d3 : Relator (Fin 12) := .gen 11
+
+/-- The spider relator `(a b₁ c₁ a b₂ c₂ a b₃ c₃)¹⁰` of the `Y₄₄₃` presentation. -/
+def spiderRelator : Relator (Fin 12) :=
+  .pow (a ⬝ b1 ⬝ c1 ⬝ a ⬝ b2 ⬝ c2 ⬝ a ⬝ b3 ⬝ c3) 10
+
+/-- The spider relator spelled out in the numbered alphabet. -/
+theorem spiderRelator_eq : spiderRelator =
+    .pow (.gen 0 ⬝ .gen 1 ⬝ .gen 2 ⬝ .gen 0 ⬝ .gen 5 ⬝ .gen 6 ⬝ .gen 0 ⬝
+      .gen 9 ⬝ .gen 10) 10 := by
+  rw [spiderRelator]
+
+/-- Ivanov's central element `f₃₁₂ = (a b₃ c₃ d₃ b₁ c₁ b₂)⁹`, imposed as a relator to pass
+from `Y₄₄₃ ≅ M × 2` to the Monster group `M`. -/
+def centralInvolutionRelator : Relator (Fin 12) :=
+  .pow (a ⬝ b3 ⬝ c3 ⬝ d3 ⬝ b1 ⬝ c1 ⬝ b2) 9
+
+/-- Ivanov's element `f₃₁₂` spelled out in the numbered alphabet. -/
+theorem centralInvolutionRelator_eq : centralInvolutionRelator =
+    .pow (.gen 0 ⬝ .gen 9 ⬝ .gen 10 ⬝ .gen 11 ⬝ .gen 1 ⬝ .gen 2 ⬝ .gen 5) 9 := by
+  rw [centralInvolutionRelator]
+
+/-- The spider and central-involution relators appended to the Coxeter relations. -/
+def additionalRelators : List (Relator (Fin 12)) :=
+  [spiderRelator, centralInvolutionRelator]
+
+/-- The eighty relators of the Monster presentation: the `Y₄₄₃` Coxeter relations, followed by
+the spider and central-involution relators. -/
+def relatorList : List (Relator (Fin 12)) :=
+  coxeterRelators coxeterMatrix ++ additionalRelators
+
+/-! ### The presentation row and its audit interface -/
+
+/-- The `Y₄₄₃` finite presentation of the Fischer--Griess Monster group `M` on twelve involutions.
+
+Ivanov proves that `Y₄₄₃` is `M × 2` and that quotienting by the central element `f₃₁₂` gives `M`.
+No structural property of the resulting `PresentedGroup` is asserted here; this definition records
+only the cited generators and complete relator data. -/
+@[expose]
+def presentation : GroupPresentation where
+  generatorNames := ["a", "b1", "c1", "d1", "e1", "b2", "c2", "d2", "e2", "b3", "c3", "d3"]
+  source := "J. N. Bray, Sporadic (Fischer-Griess) Monster group M = F1; A. A. Ivanov, Y-groups \
+    via Transitive Extension, Journal of Algebra 218 (1999), 412-435"
+  sourceLocator := "Bray's Y443 presentation at \
+    https://webspace.maths.qmul.ac.uk/j.n.bray/web/Pres/Mnst.html; Ivanov, definition on p. 413, \
+    Lemma 3.2 on p. 419, and Section 3.9 on pp. 430-431; doi:10.1006/jabr.1999.7882"
+  generatorConvention := "Indices 0 through 11 are a,b1,c1,d1,e1,b2,c2,d2,e2,b3,c3,d3. Every \
+    node is an involution, adjacent nodes have product of order dividing three, and nonadjacent \
+    nodes commute. Products are read left to right. Ivanov writes f_ijk = \
+    (a*b_i*c_i*d_i*b_j*c_j*b_k)^9."
+  transcriptionNotes := "The Coxeter matrix expands the displayed Y443 diagram to 78 relators. \
+    Append Bray's spider relator to present M x 2, then Ivanov's f_312 to quotient its central \
+    factor and present M. The first 79 relators have the source's length 400; f_312 has length 63. \
+    The independent FiniteSimpleGroups permutation construction does not cover M."
+  expectedGeneratorCount := 12
+  expectedRelatorCount := 80
+  transcribed := relatorList
+
+/-- The generator names recorded for the Monster presentation. -/
+@[simp]
+theorem presentation_generatorNames : presentation.generatorNames =
+    ["a", "b1", "c1", "d1", "e1", "b2", "c2", "d2", "e2", "b3", "c3", "d3"] := by
+  rw [presentation]
+
+/-- The source recorded for the Monster presentation. -/
+@[simp]
+theorem presentation_source : presentation.source =
+    "J. N. Bray, Sporadic (Fischer-Griess) Monster group M = F1; A. A. Ivanov, Y-groups via \
+      Transitive Extension, Journal of Algebra 218 (1999), 412-435" := by
+  rw [presentation]
+
+/-- The exact source locator recorded for the Monster presentation. -/
+@[simp]
+theorem presentation_sourceLocator : presentation.sourceLocator =
+    "Bray's Y443 presentation at \
+      https://webspace.maths.qmul.ac.uk/j.n.bray/web/Pres/Mnst.html; Ivanov, definition on p. 413, \
+      Lemma 3.2 on p. 419, and Section 3.9 on pp. 430-431; doi:10.1006/jabr.1999.7882" := by
+  rw [presentation]
+
+/-- The generator and Coxeter conventions recorded for the Monster presentation. -/
+@[simp]
+theorem presentation_generatorConvention : presentation.generatorConvention =
+    "Indices 0 through 11 are a,b1,c1,d1,e1,b2,c2,d2,e2,b3,c3,d3. Every node is an involution, \
+      adjacent nodes have product of order dividing three, and nonadjacent nodes commute. Products \
+      are read left to right. Ivanov writes f_ijk = (a*b_i*c_i*d_i*b_j*c_j*b_k)^9." := by
+  rw [presentation]
+
+/-- The transcription notes recorded for the Monster presentation. -/
+@[simp]
+theorem presentation_transcriptionNotes : presentation.transcriptionNotes =
+    "The Coxeter matrix expands the displayed Y443 diagram to 78 relators. Append Bray's spider \
+      relator to present M x 2, then Ivanov's f_312 to quotient its central factor and present M. \
+      The first 79 relators have the source's length 400; f_312 has length 63. The independent \
+      FiniteSimpleGroups permutation construction does not cover M." := by
+  rw [presentation]
+
+/-- The expected generator count recorded for the Monster presentation. -/
+@[simp]
+theorem presentation_expectedGeneratorCount : presentation.expectedGeneratorCount = 12 := by
+  rw [presentation]
+
+/-- The expected relator count recorded for the Monster presentation. -/
+@[simp]
+theorem presentation_expectedRelatorCount : presentation.expectedRelatorCount = 80 := by
+  rw [presentation]
+
+/-- The compiled relators carried by the Monster presentation, with generator bounds forgotten. -/
+theorem presentation_relatorLetters : presentation.relatorLetters =
+    relatorList.map fun r => r.toWord.map fun letter => (letter.1.val, letter.2) := by
+  rw [GroupPresentation.relatorLetters_def, GroupPresentation.relators_def, presentation]
+  simp only [List.map_map, Function.comp_def]
+  rfl
+
+/-! ### Decidable transcription checks -/
+
+/-- The `Y₄₄₃` Coxeter diagram contributes seventy-eight relators. -/
+theorem length_coxeterRelators : (coxeterRelators coxeterMatrix).length = 78 := by
+  simp
+  norm_num [Nat.choose]
+
+/-- The full Monster presentation has eighty relators. -/
+theorem length_relatorList : relatorList.length = 80 := by
+  simp [relatorList, additionalRelators]
+  norm_num [Nat.choose]
+
+/-- The generator and relator counts recorded for the Monster agree with the transcribed data. -/
+theorem presentation_matchesMetadata : presentation.matchesMetadata := by
+  rw [GroupPresentation.matchesMetadata_iff]
+  constructor
+  · change presentation.generatorNames.length = 12
+    rw [presentation_generatorNames]
+    rfl
+  · simpa [presentation, relatorList, additionalRelators] using length_relatorList
+
+/-- The spider relator has ninety letters. -/
+theorem spiderRelator_length : spiderRelator.toWord.length = 90 := by
+  simp [spiderRelator]
+
+/-- The seventy-nine relators presenting `M × 2` have the source's total length `400`. -/
+theorem coxeterAndSpider_totalLength :
+    ((coxeterRelators coxeterMatrix ++ [spiderRelator]).map
+      fun r => r.toWord.length).sum = 400 := by
+  rw [coxeterRelators_eq, coxeterRelatorsOfList_eq]
+  rw [List.map_append, List.sum_append, List.map_map]
+  change
+    (List.map (fun z => (coxeterRelator coxeterMatrix z.inf z.sup).toWord.length)
+        (List.finRange 12).sym2).sum +
+      (List.map (fun r => r.toWord.length) [spiderRelator]).sum = 400
+  simp_rw [length_toWord_coxeterRelator]
+  simp only [coxeterMatrix_apply]
+  rw [edges_eq]
+  simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, Nat.add_zero,
+    spiderRelator_length]
+  decide
+
+/-- The central-involution relator `f₃₁₂` has sixty-three letters. -/
+theorem centralInvolutionRelator_length : centralInvolutionRelator.toWord.length = 63 := by
+  simp [centralInvolutionRelator]
+
+/-- The compiled relators of the Monster presentation contain `463` signed letters in total. -/
+theorem presentation_totalLength : presentation.totalLength = 463 := by
+  have h : (relatorList.map fun r => r.toWord.length).sum = 463 := by
+    rw [relatorList, additionalRelators]
+    rw [show coxeterRelators coxeterMatrix ++ [spiderRelator, centralInvolutionRelator] =
+        (coxeterRelators coxeterMatrix ++ [spiderRelator]) ++ [centralInvolutionRelator] by
+          simp]
+    rw [List.map_append, List.sum_append]
+    simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, Nat.add_zero]
+    rw [coxeterAndSpider_totalLength, centralInvolutionRelator_length]
+  rw [← GroupPresentation.sum_map_length_relatorLetters, presentation_relatorLetters,
+    List.map_map]
+  simpa only [Function.comp_def, List.length_map] using h
+
+/-- Every expression in the Monster relator list compiles to a cyclically reduced word. -/
+theorem relatorList_cyclicallyReduced (r : Relator (Fin 12)) (hr : r ∈ relatorList) :
+    FreeGroup.IsCyclicallyReduced r.toWord := by
+  rw [relatorList, additionalRelators, List.mem_append] at hr
+  rcases hr with hr | hr
+  · rw [mem_coxeterRelators_iff] at hr
+    obtain ⟨i, j, rfl⟩ := hr
+    exact isCyclicallyReduced_toWord_coxeterRelator coxeterMatrix _ _
+  · simp only [List.mem_cons, List.not_mem_nil, or_false] at hr
+    rcases hr with rfl | rfl <;>
+      simp [spiderRelator, centralInvolutionRelator, FreeGroup.IsCyclicallyReduced,
+        FreeGroup.IsReduced]
+
+/-- Every compiled Monster relator is cyclically reduced, so the letter counts above agree with
+the usual presentation-length convention. -/
+theorem presentation_relatorsCyclicallyReduced :
+    presentation.relatorsCyclicallyReduced := by
+  simpa [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def,
+    presentation] using relatorList_cyclicallyReduced
+
+end TauCeti.Sporadic.Monster

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Monster.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Monster.lean
@@ -107,6 +107,7 @@ def coxeterMatrix : CoxeterMatrix (Fin 12) where
     split <;> omega
 
 /-- Evaluation of the `Y₄₄₃` Coxeter matrix directly from its edge list. -/
+@[simp]
 theorem coxeterMatrix_apply (i j : Fin 12) :
     coxeterMatrix i j =
       if i = j then 1 else if (i, j) ∈ edges ∨ (j, i) ∈ edges then 3 else 2 := by
@@ -169,12 +170,7 @@ theorem relatorList_def : relatorList =
 
 Ivanov proves that `Y₄₄₃` is `M × 2` and that quotienting by the central element `f₃₁₂` gives `M`.
 No structural property of the resulting `PresentedGroup` is asserted here; this definition records
-only the cited generators and complete relator data.
-
-The body is exposed so that `presentation_transcribed` below can state the exact typed relator
-data: the index type of a transcribed relator is `Fin presentation.generatorNames.length`, which
-is `Fin 12` only by unfolding this definition. -/
-@[expose]
+only the cited generators and complete relator data. -/
 def presentation : GroupPresentation where
   generatorNames := ["a", "b1", "c1", "d1", "e1", "b2", "c2", "d2", "e2", "b3", "c3", "d3"]
   source := "J. N. Bray, Sporadic (Fischer-Griess) Monster group M = F1; A. A. Ivanov, Y-groups \
@@ -245,8 +241,8 @@ theorem presentation_expectedRelatorCount : presentation.expectedRelatorCount = 
 /-- The relator expressions carried by the Monster presentation are exactly the transcribed
 relator list, whose decomposition is `relatorList_def`. -/
 @[simp]
-theorem presentation_transcribed : presentation.transcribed = relatorList := by
-  simp [presentation]
+theorem presentation_transcribed : presentation.transcribed = cast (by simp) relatorList := by
+  rfl
 
 /-- The compiled relators carried by the Monster presentation, with generator bounds forgotten. -/
 theorem presentation_relatorLetters : presentation.relatorLetters =


### PR DESCRIPTION
This PR transcribes the genuine finite `Y₄₄₃` presentation of the Monster group `M`: its twelve Coxeter generators, all seventy-eight Coxeter relators, Bray's spider relator, and Ivanov's central relator `f₃₁₂ = 1`. It records exact source and convention metadata and proves the generator count, relator count, published intermediate length `400`, final length `463`, and cyclic reduction of every compiled relator.

The exact roadmap target is milestone S1, “the twenty-six sporadic presentations,” specifically its Monster requirement to use the twelve nodes of `Y₄₄₃`, the Coxeter relations, the spider relation, and the central-factor relation `Z = 1`. This is the most direct remaining unclaimed S1 row: Co1 and Ly are already in flight, while this source gives a complete, independently locatable presentation rather than a semi-presentation.

The supporting Coxeter changes expose sealed-definition equations and prove reusable signed-word length and cyclic-reduction lemmas. They reuse Mathlib's `CoxeterMatrix`, `List.sym2`, `FreeGroup.IsCyclicallyReduced`, and free-group presentation infrastructure; no Mathlib code is vendored.

After this PR, S1 still needs the Fi24′ and Baby Monster rows, the in-flight Co1 and Ly rows to land, and independent source-to-Lean review artifacts; the downstream A0 assembly milestone also awaits Lie-type milestone L3.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"monster-presentation"}-->

Validated with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex
