### PR TITLE
refactor(Fourier): name the bounded convergence of the overlap-ratio weights

### DIFF
--- a/TauCeti/Analysis/Bochner/Fourier/Nonneg.lean
+++ b/TauCeti/Analysis/Bochner/Fourier/Nonneg.lean
@@ -517,6 +517,31 @@ private theorem fejer_avg_eq_integral (ψ : V → ℂ) (hcont : Continuous ψ)
 
 /-! ### Step C: the integral of a positive-definite function has nonnegative real part -/
 
+/-- **The overlap-ratio weights converge to the integral.** For an integrable continuous `ψ`, the
+integrals of `ψ` against the weights `overlapRatio n` converge to `∫ ψ` as `n → ∞`. -/
+private theorem tendsto_integral_overlapRatio_mul (ψ : V → ℂ) (hint : Integrable ψ)
+    (hcont : Continuous ψ) :
+    Tendsto (fun n : ℕ => ∫ v, (overlapRatio (n : ℝ) v : ℂ) * ψ v) atTop (nhds (∫ x, ψ x)) := by
+  have hone : (∫ x, ψ x) = ∫ x, (1 : ℂ) * ψ x := by simp
+  rw [hone]
+  apply tendsto_integral_of_dominated_convergence (fun v => ‖ψ v‖)
+  · intro n
+    exact (continuous_ofReal.measurable.comp
+      (measurable_overlapRatio n)).aestronglyMeasurable.mul
+      hcont.aestronglyMeasurable
+  · exact hint.norm
+  · intro n
+    filter_upwards with v
+    rw [norm_mul, Complex.norm_real]
+    exact mul_le_of_le_one_left (norm_nonneg _)
+      (abs_le.mpr ⟨by linarith [overlapRatio_nonneg (n : ℝ) v],
+        overlapRatio_le_one (n : ℝ) v⟩)
+  · filter_upwards with v
+    have h2 : Tendsto (fun n : ℕ => (overlapRatio (n : ℝ) v : ℂ))
+        atTop (nhds (1 : ℂ)) :=
+      (Complex.continuous_ofReal.tendsto 1).comp (overlapRatio_tendsto_one v)
+    exact h2.mul tendsto_const_nhds
+
 /-- For a continuous integrable positive-definite function `ψ`, the integral `∫ ψ` has
 nonnegative real part: the Fejér-averaged double integral `J_R` converges to `∫ ψ` and has
 nonnegative real part for each radius `R`. -/
@@ -548,25 +573,7 @@ private theorem pd_integral_re_nonneg (ψ : V → ℂ)
       filter_upwards [Filter.eventually_ne_atTop 0] with n hn
       simp only [J, ite_eq_right hn]
       exact (fejer_avg_eq_integral ψ hcont n (Nat.cast_pos.mpr (Nat.pos_of_ne_zero hn))).symm
-    have hone : (∫ x, ψ x) = ∫ x, (1 : ℂ) * ψ x := by simp
-    rw [hone]
-    apply tendsto_integral_of_dominated_convergence (fun v => ‖ψ v‖)
-    · intro n
-      exact (continuous_ofReal.measurable.comp
-        (measurable_overlapRatio n)).aestronglyMeasurable.mul
-        hcont.aestronglyMeasurable
-    · exact hint.norm
-    · intro n
-      filter_upwards with v
-      rw [norm_mul, Complex.norm_real]
-      exact mul_le_of_le_one_left (norm_nonneg _)
-        (abs_le.mpr ⟨by linarith [overlapRatio_nonneg (n : ℝ) v],
-          overlapRatio_le_one (n : ℝ) v⟩)
-    · filter_upwards with v
-      have h2 : Tendsto (fun n : ℕ => (overlapRatio (n : ℝ) v : ℂ))
-          atTop (nhds (1 : ℂ)) :=
-        (Complex.continuous_ofReal.tendsto 1).comp (overlapRatio_tendsto_one v)
-      exact h2.mul tendsto_const_nhds
+    exact tendsto_integral_overlapRatio_mul ψ hint hcont
   exact ge_of_tendsto' ((Complex.continuous_re.tendsto _).comp hconv) hnn
 
 /-! ### The main theorems -/

--- a/TauCeti/Analysis/Bochner/Fourier/Nonneg.lean
+++ b/TauCeti/Analysis/Bochner/Fourier/Nonneg.lean
@@ -517,8 +517,8 @@ private theorem fejer_avg_eq_integral (ψ : V → ℂ) (hcont : Continuous ψ)
 
 /-! ### Step C: the integral of a positive-definite function has nonnegative real part -/
 
-/-- **The overlap-ratio weights converge to the integral.** For an integrable continuous `ψ`, the
-integrals of `ψ` against the weights `overlapRatio n` converge to `∫ ψ` as `n → ∞`. -/
+/-- **The overlap-ratio weights converge to the integral.** For an integrable `ψ`, the integrals
+of `ψ` against the weights `overlapRatio n` converge to `∫ ψ` as `n → ∞`. -/
 private theorem tendsto_integral_overlapRatio_mul (ψ : V → ℂ) (hint : Integrable ψ) :
     Tendsto (fun n : ℕ => ∫ v, (overlapRatio (n : ℝ) v : ℂ) * ψ v) atTop (nhds (∫ x, ψ x)) := by
   have hone : (∫ x, ψ x) = ∫ x, (1 : ℂ) * ψ x := by simp

--- a/TauCeti/Analysis/Bochner/Fourier/Nonneg.lean
+++ b/TauCeti/Analysis/Bochner/Fourier/Nonneg.lean
@@ -519,8 +519,7 @@ private theorem fejer_avg_eq_integral (ψ : V → ℂ) (hcont : Continuous ψ)
 
 /-- **The overlap-ratio weights converge to the integral.** For an integrable continuous `ψ`, the
 integrals of `ψ` against the weights `overlapRatio n` converge to `∫ ψ` as `n → ∞`. -/
-private theorem tendsto_integral_overlapRatio_mul (ψ : V → ℂ) (hint : Integrable ψ)
-    (hcont : Continuous ψ) :
+private theorem tendsto_integral_overlapRatio_mul (ψ : V → ℂ) (hint : Integrable ψ) :
     Tendsto (fun n : ℕ => ∫ v, (overlapRatio (n : ℝ) v : ℂ) * ψ v) atTop (nhds (∫ x, ψ x)) := by
   have hone : (∫ x, ψ x) = ∫ x, (1 : ℂ) * ψ x := by simp
   rw [hone]
@@ -528,7 +527,7 @@ private theorem tendsto_integral_overlapRatio_mul (ψ : V → ℂ) (hint : Integ
   · intro n
     exact (continuous_ofReal.measurable.comp
       (measurable_overlapRatio n)).aestronglyMeasurable.mul
-      hcont.aestronglyMeasurable
+      hint.aestronglyMeasurable
   · exact hint.norm
   · intro n
     filter_upwards with v
@@ -573,7 +572,7 @@ private theorem pd_integral_re_nonneg (ψ : V → ℂ)
       filter_upwards [Filter.eventually_ne_atTop 0] with n hn
       simp only [J, ite_eq_right hn]
       exact (fejer_avg_eq_integral ψ hcont n (Nat.cast_pos.mpr (Nat.pos_of_ne_zero hn))).symm
-    exact tendsto_integral_overlapRatio_mul ψ hint hcont
+    exact tendsto_integral_overlapRatio_mul ψ hint
   exact ge_of_tendsto' ((Complex.continuous_re.tendsto _).comp hconv) hnn
 
 /-! ### The main theorems -/


### PR DESCRIPTION
`pd_integral_re_nonneg` shows `∫ ψ` has nonnegative real part for a positive-definite `ψ`, by squeezing it between the Fejér averages `J n`: each has nonnegative real part, and they converge to `∫ ψ`. The convergence half took twenty-seven of its forty-five lines, and all but five of those are a dominated-convergence argument that mentions neither `J` nor positive-definiteness.

`tendsto_integral_overlapRatio_mul` states that argument: for an integrable `ψ`, the integrals of `ψ` against the weights `overlapRatio n` converge to `∫ ψ`.

Its hypotheses are re-derived rather than inherited, and only one survives. `hpd` is in scope throughout the block and is unused — the limit is bounded convergence, nothing more: the weights are dominated by `1` (`overlapRatio_nonneg`, `overlapRatio_le_one`), `‖ψ‖` is the integrable majorant, and the weights tend to `1` pointwise. `hcont` is unused too: it served only to supply a.e. strong measurability of `ψ`, which `Integrable` already carries. So the statement takes `ψ` and `hint` alone, and the parent keeps its continuity hypothesis for the Fejér identity, which does need it.

The parent's `set J` stays where it is. The new statement is about the weighted integrals rather than about `J`, so nothing folds between them; the identification of the two — `fejer_avg_eq_integral`, valid for `n ≠ 0` — remains in the parent's `suffices`, which is where the `n = 0` branch of `J` is handled.

The parent drops from 45 lines to 27.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: OneParameterSemigroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
