### PR TITLE
refactor(RootSystem): name the shifted indicator sum used twice in the pairing

### DIFF
--- a/TauCeti/Data/Fin/Basic.lean
+++ b/TauCeti/Data/Fin/Basic.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Fin
+
+/-!
+# Indicator sums over `Fin n` keyed by a natural number
+
+`Fintype.sum_ite_eq` evaluates a sum whose indicator compares two elements of the index type.
+When the comparison is instead between a natural number and the `Fin.val` of the index — as it is
+whenever a family is indexed by `ℕ` and summed over `Fin n` — the index may fall outside the
+range, so the value is a `dite` rather than a plain application.
+
+## Main results
+
+* `TauCeti.sum_ite_val_add`: a sum against the indicator of `b = k + j` picks out the summand at
+  `b - j`, or vanishes when there is no such index.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- **A shifted indicator picks out one summand.** Summing `f` over `Fin n` against the indicator
+of `b = k + j` gives `f` at the index `b - j` when that is a valid index and `j ≤ b`, and `0`
+otherwise. -/
+theorem sum_ite_val_add {M : Type*} [AddCommMonoid M] {n : ℕ} (f : Fin n → M) (b j : ℕ) :
+    ∑ k : Fin n, (if b = (k : ℕ) + j then f k else 0)
+      = if h : b - j < n ∧ j ≤ b then f ⟨b - j, h.1⟩ else 0 := by
+  by_cases h : b - j < n ∧ j ≤ b
+  · have hb : ∀ k : Fin n, (b = (k : ℕ) + j) = (k = (⟨b - j, h.1⟩ : Fin n)) := by
+      intro k
+      have := h.2
+      simp only [Fin.ext_iff, eq_iff_iff]
+      omega
+    simp only [hb, dite_eq_left h, Finset.sum_ite_eq', Finset.mem_univ, ite_true]
+  · rw [dite_eq_right h, Finset.sum_eq_zero]
+    intro k _
+    have := k.isLt
+    exact ite_eq_right (by omega)
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Data.Fin.Basic
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Basic
 
 public section

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -94,31 +94,6 @@ the coordinates of `e_a - e_b`; the `k`-th potential is `[a ≤ k]`. -/
 private def typeACoweight (n a : ℕ) : Fin n → ℤ :=
   fun k => if a ≤ (k : ℕ) then 1 else 0
 
-/-- **A shifted natural-number indicator picks out one summand.** Summing `g` over `Fin n` against
-the indicator of `b = k + j` gives `g` at the index `b - j` when that is a valid index and `j ≤ b`,
-and `0` otherwise. -/
-private lemma sum_ite_natCast_add_mul (b j : ℕ) (g : Fin n → ℤ) :
-    ∑ k : Fin n, (if b = (k : ℕ) + j then (1 : ℤ) else 0) * g k
-      = if h : b - j < n ∧ j ≤ b then g ⟨b - j, h.1⟩ else 0 := by
-  simp only [ite_mul, one_mul, zero_mul]
-  by_cases h : b - j < n ∧ j ≤ b
-  · rw [dite_eq_left h]
-    calc
-      _ = ∑ k : Fin n, if (⟨b - j, h.1⟩ : Fin n) = k then g k else 0 := by
-        refine Finset.sum_congr rfl fun k _ => ?_
-        congr 1
-        apply propext
-        constructor
-        · intro hb
-          exact Fin.ext (by simp only; omega)
-        · intro hk
-          have hkval := congrArg Fin.val hk
-          simp only at hkval
-          omega
-      _ = _ := Fintype.sum_ite_eq _ _
-  · rw [dite_eq_right h]
-    exact Finset.sum_eq_zero fun k _ => ite_eq_right (by omega)
-
 /-- The fundamental pairing identity of type `Aₙ`: in the classical model `⟨e_a, e_c^∨⟩` would be
 `[a = c]`, and the two pinned lattices see that up to the single correction `[a = n]`, which
 cancels in the differences that are the roots and coroots. -/
@@ -128,12 +103,15 @@ private lemma typeAWeight_dotProduct_typeACoweight {a c : ℕ} (ha : a ≤ n) (h
   have key : ∀ b : ℕ, ∑ k : Fin n, (if b = (k : ℕ) then (1 : ℤ) else 0) *
       (if c ≤ (k : ℕ) then 1 else 0) = if h : b < n then (if c ≤ b then (1 : ℤ) else 0) else 0 :=
     fun b => by
-      simpa only [Nat.add_zero, Nat.sub_zero, Nat.zero_le, and_true, Fin.val_mk] using
-        sum_ite_natCast_add_mul b 0 (fun k : Fin n => if c ≤ (k : ℕ) then (1 : ℤ) else 0)
+      simp only [ite_mul, one_mul, zero_mul]
+      simpa only [Nat.add_zero, Nat.sub_zero, Nat.zero_le, and_true] using
+        sum_ite_val_add (fun k : Fin n => if c ≤ (k : ℕ) then (1 : ℤ) else 0) b 0
   have key' : ∀ b : ℕ, ∑ k : Fin n, (if b = (k : ℕ) + 1 then (1 : ℤ) else 0) *
       (if c ≤ (k : ℕ) then 1 else 0)
         = if h : b - 1 < n ∧ 1 ≤ b then (if c ≤ b - 1 then (1 : ℤ) else 0) else 0 :=
-    fun b => sum_ite_natCast_add_mul b 1 _
+    fun b => by
+      simp only [ite_mul, one_mul, zero_mul]
+      exact sum_ite_val_add (fun k : Fin n => if c ≤ (k : ℕ) then (1 : ℤ) else 0) b 1
   simp only [dotProduct, typeAWeight, typeACoweight, sub_mul, Finset.sum_sub_distrib,
     key a, key' a]
   split_ifs <;> omega

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -94,6 +94,31 @@ the coordinates of `e_a - e_b`; the `k`-th potential is `[a ≤ k]`. -/
 private def typeACoweight (n a : ℕ) : Fin n → ℤ :=
   fun k => if a ≤ (k : ℕ) then 1 else 0
 
+/-- **A shifted natural-number indicator picks out one summand.** Summing `g` over `Fin n` against
+the indicator of `b = k + j` gives `g` at the index `b - j` when that is a valid index and `j ≤ b`,
+and `0` otherwise. -/
+private lemma sum_ite_natCast_add_mul (b j : ℕ) (g : Fin n → ℤ) :
+    ∑ k : Fin n, (if b = (k : ℕ) + j then (1 : ℤ) else 0) * g k
+      = if h : b - j < n ∧ j ≤ b then g ⟨b - j, h.1⟩ else 0 := by
+  simp only [ite_mul, one_mul, zero_mul]
+  by_cases h : b - j < n ∧ j ≤ b
+  · rw [dite_eq_left h]
+    calc
+      _ = ∑ k : Fin n, if (⟨b - j, h.1⟩ : Fin n) = k then g k else 0 := by
+        refine Finset.sum_congr rfl fun k _ => ?_
+        congr 1
+        apply propext
+        constructor
+        · intro hb
+          exact Fin.ext (by simp only; omega)
+        · intro hk
+          have hkval := congrArg Fin.val hk
+          simp only at hkval
+          omega
+      _ = _ := Fintype.sum_ite_eq _ _
+  · rw [dite_eq_right h]
+    exact Finset.sum_eq_zero fun k _ => ite_eq_right (by omega)
+
 /-- The fundamental pairing identity of type `Aₙ`: in the classical model `⟨e_a, e_c^∨⟩` would be
 `[a = c]`, and the two pinned lattices see that up to the single correction `[a = n]`, which
 cancels in the differences that are the roots and coroots. -/
@@ -101,42 +126,14 @@ private lemma typeAWeight_dotProduct_typeACoweight {a c : ℕ} (ha : a ≤ n) (h
     typeAWeight n a ⬝ᵥ typeACoweight n c
       = (if a = c then 1 else 0) - (if a = n then 1 else 0) := by
   have key : ∀ b : ℕ, ∑ k : Fin n, (if b = (k : ℕ) then (1 : ℤ) else 0) *
-      (if c ≤ (k : ℕ) then 1 else 0) = if h : b < n then (if c ≤ b then (1 : ℤ) else 0) else 0 := by
-    intro b
-    simp only [ite_mul, one_mul, zero_mul]
-    by_cases h : b < n
-    · rw [dite_eq_left h]
-      convert Fintype.sum_ite_eq (⟨b, h⟩ : Fin n)
-        (fun k => if c ≤ (k : ℕ) then (1 : ℤ) else 0) using 1 with k
-      simp [Fin.ext_iff]
-    · rw [dite_eq_right h]
-      exact Finset.sum_eq_zero fun k _ => ite_eq_right (by omega)
+      (if c ≤ (k : ℕ) then 1 else 0) = if h : b < n then (if c ≤ b then (1 : ℤ) else 0) else 0 :=
+    fun b => by
+      simpa only [Nat.add_zero, Nat.sub_zero, Nat.zero_le, and_true, Fin.val_mk] using
+        sum_ite_natCast_add_mul b 0 (fun k : Fin n => if c ≤ (k : ℕ) then (1 : ℤ) else 0)
   have key' : ∀ b : ℕ, ∑ k : Fin n, (if b = (k : ℕ) + 1 then (1 : ℤ) else 0) *
       (if c ≤ (k : ℕ) then 1 else 0)
-        = if h : b - 1 < n ∧ 1 ≤ b then (if c ≤ b - 1 then (1 : ℤ) else 0) else 0 := by
-    intro b
-    simp only [ite_mul, one_mul, zero_mul]
-    by_cases h : b - 1 < n ∧ 1 ≤ b
-    · rw [dite_eq_left h]
-      calc
-        _ = ∑ k : Fin n, if (⟨b - 1, h.1⟩ : Fin n) = k then
-            (if c ≤ (k : ℕ) then (1 : ℤ) else 0) else 0 := by
-          apply Finset.sum_congr rfl
-          intro k _
-          congr 1
-          apply propext
-          constructor
-          · intro hb
-            apply Fin.ext
-            simp only
-            omega
-          · intro hk
-            have hkval := congrArg Fin.val hk
-            simp only at hkval
-            omega
-        _ = _ := Fintype.sum_ite_eq _ _
-    · rw [dite_eq_right h]
-      exact Finset.sum_eq_zero fun k _ => ite_eq_right (by omega)
+        = if h : b - 1 < n ∧ 1 ≤ b then (if c ≤ b - 1 then (1 : ℤ) else 0) else 0 :=
+    fun b => sum_ite_natCast_add_mul b 1 _
   simp only [dotProduct, typeAWeight, typeACoweight, sub_mul, Finset.sum_sub_distrib,
     key a, key' a]
   split_ifs <;> omega

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Basic.lean
@@ -125,30 +125,6 @@ theorem sub_mem_closure_of_le {n : ℕ} (f : ℕ → M) {a b : ℕ} (hb : b ≤ 
 
 end Closure
 
-/-! ## Indicator sums over a finite index -/
-
-section IndicatorSum
-
-/-- **A shifted indicator picks out one summand.** Summing `f` over `Fin n` against the indicator
-of `b = k + j` gives `f` at the index `b - j` when that is a valid index and `j ≤ b`, and `0`
-otherwise. -/
-theorem sum_ite_val_add {M : Type*} [AddCommMonoid M] {n : ℕ} (f : Fin n → M) (b j : ℕ) :
-    ∑ k : Fin n, (if b = (k : ℕ) + j then f k else 0)
-      = if h : b - j < n ∧ j ≤ b then f ⟨b - j, h.1⟩ else 0 := by
-  by_cases h : b - j < n ∧ j ≤ b
-  · have hb : ∀ k : Fin n, (b = (k : ℕ) + j) = (k = (⟨b - j, h.1⟩ : Fin n)) := by
-      intro k
-      have := h.2
-      simp only [Fin.ext_iff, eq_iff_iff]
-      omega
-    simp only [hb, dite_eq_left h, Finset.sum_ite_eq', Finset.mem_univ, ite_true]
-  · rw [dite_eq_right h, Finset.sum_eq_zero]
-    intro k _
-    have := k.isLt
-    exact ite_eq_right (by omega)
-
-end IndicatorSum
-
 /-! ## Recognizing the pinned data -/
 
 section RootPairing

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Basic.lean
@@ -125,6 +125,30 @@ theorem sub_mem_closure_of_le {n : ℕ} (f : ℕ → M) {a b : ℕ} (hb : b ≤ 
 
 end Closure
 
+/-! ## Indicator sums over a finite index -/
+
+section IndicatorSum
+
+/-- **A shifted indicator picks out one summand.** Summing `f` over `Fin n` against the indicator
+of `b = k + j` gives `f` at the index `b - j` when that is a valid index and `j ≤ b`, and `0`
+otherwise. -/
+theorem sum_ite_val_add {n : ℕ} (f : Fin n → ℤ) (b j : ℕ) :
+    ∑ k : Fin n, (if b = (k : ℕ) + j then f k else 0)
+      = if h : b - j < n ∧ j ≤ b then f ⟨b - j, h.1⟩ else 0 := by
+  by_cases h : b - j < n ∧ j ≤ b
+  · have hb : ∀ k : Fin n, (b = (k : ℕ) + j) = (k = (⟨b - j, h.1⟩ : Fin n)) := by
+      intro k
+      have := h.2
+      simp only [Fin.ext_iff, eq_iff_iff]
+      omega
+    simp only [hb, dite_eq_left h, Finset.sum_ite_eq', Finset.mem_univ, ite_true]
+  · rw [dite_eq_right h, Finset.sum_eq_zero]
+    intro k _
+    have := k.isLt
+    exact ite_eq_right (by omega)
+
+end IndicatorSum
+
 /-! ## Recognizing the pinned data -/
 
 section RootPairing

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Basic.lean
@@ -132,7 +132,7 @@ section IndicatorSum
 /-- **A shifted indicator picks out one summand.** Summing `f` over `Fin n` against the indicator
 of `b = k + j` gives `f` at the index `b - j` when that is a valid index and `j ≤ b`, and `0`
 otherwise. -/
-theorem sum_ite_val_add {n : ℕ} (f : Fin n → ℤ) (b j : ℕ) :
+theorem sum_ite_val_add {M : Type*} [AddCommMonoid M] {n : ℕ} (f : Fin n → M) (b j : ℕ) :
     ∑ k : Fin n, (if b = (k : ℕ) + j then f k else 0)
       = if h : b - j < n ∧ j ≤ b then f ⟨b - j, h.1⟩ else 0 := by
   by_cases h : b - j < n ∧ j ≤ b

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Basic
+public import TauCeti.Data.Fin.Basic
 public import Mathlib.LinearAlgebra.Matrix.Dual
 public import Mathlib.LinearAlgebra.Reflection
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Basic
 public import Mathlib.LinearAlgebra.Matrix.Dual
 public import Mathlib.LinearAlgebra.Reflection
 
@@ -115,32 +116,6 @@ lemma coweight_eq_zero_of_le {a : ℕ} (ha : n ≤ a) : coweight n a = 0 := by
   have := k.isLt
   exact ite_eq_right (by omega)
 
-private lemma sum_ite_val (f : Fin n → ℤ) (b : ℕ) :
-    ∑ k : Fin n, (if b = (k : ℕ) then f k else 0) = if h : b < n then f ⟨b, h⟩ else 0 := by
-  by_cases h : b < n
-  · have hb : ∀ k : Fin n, (b = (k : ℕ)) = (k = (⟨b, h⟩ : Fin n)) := by
-      intro k; simp [Fin.ext_iff, eq_comm]
-    simp only [hb, dite_eq_left h, Finset.sum_ite_eq', Finset.mem_univ, ite_true]
-  · rw [dite_eq_right h, Finset.sum_eq_zero]
-    intro k _
-    have := k.isLt
-    exact ite_eq_right (by omega)
-
-private lemma sum_ite_val_succ (f : Fin n → ℤ) (b : ℕ) :
-    ∑ k : Fin n, (if b = (k : ℕ) + 1 then f k else 0)
-      = if h : b - 1 < n ∧ 1 ≤ b then f ⟨b - 1, h.1⟩ else 0 := by
-  by_cases h : b - 1 < n ∧ 1 ≤ b
-  · have hb : ∀ k : Fin n, (b = (k : ℕ) + 1) = (k = (⟨b - 1, h.1⟩ : Fin n)) := by
-      intro k
-      have := h.2
-      simp only [Fin.ext_iff, eq_iff_iff]
-      omega
-    simp only [hb, dite_eq_left h, Finset.sum_ite_eq', Finset.mem_univ, ite_true]
-  · rw [dite_eq_right h, Finset.sum_eq_zero]
-    intro k _
-    have := k.isLt
-    exact ite_eq_right (by omega)
-
 /-- The fundamental pairing identity of type `Cₙ`: the two pinned lattices see the classical
 pairing `⟨e_a, e_c⟩ = [a = c]` exactly, with no correction term, because the simple coroots of `Cₙ`
 are a basis of the classical lattice. -/
@@ -150,13 +125,14 @@ lemma weight_dotProduct_coweight {a c : ℕ} (ha : a < n) :
       (if c ≤ (k : ℕ) then 1 else 0) = if h : b < n then (if c ≤ b then (1 : ℤ) else 0) else 0 := by
     intro b
     simp only [ite_mul, one_mul, zero_mul]
-    exact sum_ite_val (fun k => if c ≤ (k : ℕ) then (1 : ℤ) else 0) b
+    simpa only [Nat.add_zero, Nat.sub_zero, Nat.zero_le, and_true] using
+      sum_ite_val_add (fun k : Fin n => if c ≤ (k : ℕ) then (1 : ℤ) else 0) b 0
   have key' : ∀ b : ℕ, ∑ k : Fin n, (if b = (k : ℕ) + 1 then (1 : ℤ) else 0) *
       (if c ≤ (k : ℕ) then 1 else 0)
         = if h : b - 1 < n ∧ 1 ≤ b then (if c ≤ b - 1 then (1 : ℤ) else 0) else 0 := by
     intro b
     simp only [ite_mul, one_mul, zero_mul]
-    exact sum_ite_val_succ (fun k => if c ≤ (k : ℕ) then (1 : ℤ) else 0) b
+    exact sum_ite_val_add (fun k : Fin n => if c ≤ (k : ℕ) then (1 : ℤ) else 0) b 1
   simp only [dotProduct, weight, coweight, sub_mul, Finset.sum_sub_distrib,
     key a, key' a]
   split_ifs <;> omega


### PR DESCRIPTION
The pairing identity of type `Aₙ` spent thirty-seven of its forty-one lines on two `have`s, `key` and `key'`, which are the same fact twice: summing over `Fin n` against the indicator of an index equation picks out the single matching summand. They differ only in whether the equation is `b = k` or `b = k + 1`, and correspondingly in whether the out-of-range condition is `b < n` or `b - 1 < n ∧ 1 ≤ b`.

Type `Cₙ` had already met this and named the two cases separately, as the private lemmas `sum_ite_val` and `sum_ite_val_succ` in `C/Model.lean`. So the fact was stated twice in one file and inlined twice in another.

`sum_ite_val_add` in `SimplyConnectedRootDatum/Basic.lean` states it once with the shift as a parameter: summing `f` over `Fin n` against the indicator of `b = k + j` gives `f` at the index `b - j` when that is a valid index and `j ≤ b`, and `0` otherwise. `sum_ite_val` is the case `j = 0` and `sum_ite_val_succ` the case `j = 1`; both are deleted, and their two call sites in type `C` now use the shared lemma, as do the two `have`s in type `A`.

It lives in a new `TauCeti/Data/Fin/Basic.lean`, not in the root-datum scaffolding: it mentions no root-system concept, needing only `Fin`, finite sums, `ℕ` and an additive monoid. Putting it with the root data would have made `C/Model.lean` import `DynkinType` and `RootSystem.Base` for an indexing fact. Both `A.lean` and `C/Model.lean` import the new module.

The summand type is an arbitrary `AddCommMonoid`, not `ℤ`. Both deleted lemmas fixed `f : Fin n → ℤ`, but the argument uses only finite addition and zero; the integer call sites specialise it.

Mathlib does not have this. `Fintype.sum_ite_eq` is keyed on an equation in the index type itself; here the equation is between a natural number and the `Fin.val` of the index, which is why the argument needs the range case split and a `Fin.ext` step. The new lemma is that bridge, and hands the `Fin`-keyed Mathlib lemma the shape it wants.

Both degenerate ends are why the condition has two conjuncts. At `n = 0` the sum is empty and `b - j < 0` is false, so both sides are `0`. At `b < j` — in particular `b = 0, j = 1` — the equation `b = k + j` has no solution, and it is the `j ≤ b` conjunct rather than the index bound that makes the right-hand side vanish; without it the statement would be false at `b = 0`, where `b - j` truncates to `0`.

Type `Bₙ`'s pairing identity is *not* a fourth instance and is left alone: it sums over `Finset.range n` rather than `Fin n`, its summands carry the index-dependent short/long root factors `if m + 1 = n then 2 else 1`, and it picks out its term with `Finset.sum_eq_single` rather than by an indicator.

The type `A` parent drops from 41 lines to 16, and the repository loses two declarations and 22 lines net.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

Roadmap: RepresentationTheory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
