### PR TITLE
feat: identify the kernel of the Spin double cover

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -226,7 +226,8 @@ theorem exists_eq_algebraMap_of_contractLeft_eq_zero (Q : QuadraticForm K M)
   let r := b.ExteriorAlgebra.repr y ∅
   refine ⟨r, ?_⟩
   apply (equivExterior Q).injective
-  simpa [y, r] using eq_algebraMap_of_all_contractLeft_eq_zero b y hycontract
+  simpa only [y, r, equivExterior_algebraMap] using
+    eq_algebraMap_of_all_contractLeft_eq_zero b y hycontract
 
 /-- An even Clifford element that commutes with every generating vector is a scalar. -/
 theorem exists_eq_algebraMap_of_mem_even_of_commute

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -5,6 +5,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
+public import Mathlib.LinearAlgebra.QuadraticForm.Radical
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Even
+import Mathlib.LinearAlgebra.ExteriorAlgebra.Basis
+import Mathlib.LinearAlgebra.BilinearForm.Properties
+import Mathlib.Tactic.NoncommRing
 
 /-!
 # Basic Clifford algebra API
@@ -42,5 +47,201 @@ instance, Mathlib's scalar `iff` lemmas apply directly. -/
 instance faithfulSMul (Q : QuadraticForm R M) [Invertible (2 : R)] :
     FaithfulSMul R (CliffordAlgebra Q) :=
   (faithfulSMul_iff_algebraMap_injective R (CliffordAlgebra Q)).2 (algebraMap_injective Q)
+
+private theorem two_smul_contractLeft_associated [Invertible (2 : R)]
+    (Q : QuadraticForm R M) (v : M) (x : CliffordAlgebra Q) :
+    (2 : R) • contractLeft (Q.associated v) x =
+      ι Q v * x - involute x * ι Q v := by
+  induction x using CliffordAlgebra.left_induction with
+  | algebraMap r => simp [Algebra.commutes]
+  | add x y hx hy =>
+      rw [map_add, smul_add, hx, hy, map_add, mul_add, add_mul]
+      abel
+  | ι_mul a x hx =>
+      rw [contractLeft_ι_mul, smul_sub, smul_smul, ← mul_smul_comm, hx, map_mul, involute_ι]
+      simp only [neg_mul, sub_neg_eq_add]
+      have hpolar := LinearMap.congr_fun (LinearMap.congr_fun
+        (QuadraticMap.two_nsmul_associated R Q) v) x
+      simp only [LinearMap.smul_apply, nsmul_eq_mul, QuadraticMap.polarBilin_apply_apply] at hpolar
+      have hpolar' : (2 : R) * Q.associated v x = QuadraticMap.polar (⇑Q) v x := by
+        simpa only [Nat.cast_ofNat] using hpolar
+      rw [hpolar', Algebra.smul_def, ← ι_mul_ι_add_swap]
+      noncomm_ring
+
+private theorem contractLeft_associated_eq_zero_of_commute_of_mem_even
+    [Invertible (2 : R)] (Q : QuadraticForm R M) {x : CliffordAlgebra Q}
+    (hx_even : x ∈ even Q) (hx_comm : ∀ v : M, Commute x (ι Q v)) (v : M) :
+    contractLeft (Q.associated v) x = 0 := by
+  apply (isUnit_of_invertible (2 : R)).smul_eq_zero.mp
+  rw [two_smul_contractLeft_associated Q, involute_eq_of_mem_even hx_even,
+    (hx_comm v).eq, sub_self]
+
+section Exterior
+
+private theorem contractLeft_ιMulti_eq_zero {n : ℕ}
+    (d : Module.Dual R M) (v : Fin n → M) (h : ∀ i, d (v i) = 0) :
+    contractLeft (Q := (0 : QuadraticForm R M)) d (ExteriorAlgebra.ιMulti R n v) = 0 := by
+  induction n with
+  | zero =>
+      rw [ExteriorAlgebra.ιMulti_zero_apply]
+      exact contractLeft_one (Q := (0 : QuadraticForm R M)) d
+  | succ n ih =>
+      rw [ExteriorAlgebra.ιMulti_succ_apply, contractLeft_ι_mul, h 0, zero_smul,
+        ih (Matrix.vecTail v) (fun i => h i.succ), mul_zero, sub_zero]
+
+private theorem contractLeft_basis_eq_zero_of_not_mem {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
+    contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) = 0 := by
+  rw [ExteriorAlgebra.basis_apply]
+  apply contractLeft_ιMulti_eq_zero
+  intro j
+  simp only [Function.comp_apply, Module.Basis.coord_apply,
+    Module.Basis.repr_self, Finsupp.single_apply]
+  split_ifs with h
+  · exfalso
+    apply hi
+    rw [← h]
+    have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
+      (Set.powersetCard.prodEquiv.symm s).2
+      (Set.powersetCard.ofFinEmbEquiv.symm (Set.powersetCard.prodEquiv.symm s).2 j)).mp
+      ⟨j, rfl⟩
+    exact hj
+  · rfl
+
+private noncomputable def exteriorCoordProj {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) :
+    ExteriorAlgebra R M →ₗ[R] ExteriorAlgebra R M :=
+  (LinearMap.mulLeft R (ExteriorAlgebra.ι R (b i))).comp
+    (contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i))
+
+private theorem exteriorCoordProj_basis_of_not_mem {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
+    exteriorCoordProj b i (b.ExteriorAlgebra s) = 0 := by
+  rw [exteriorCoordProj, LinearMap.comp_apply, LinearMap.mulLeft_apply,
+    contractLeft_basis_eq_zero_of_not_mem b i s hi, mul_zero]
+
+private theorem basis_exteriorAlgebra_singleton_eq_ι {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) :
+    b.ExteriorAlgebra {i} = ExteriorAlgebra.ι R (b i) := by
+  let a : Set.powersetCard (Fin n) 1 :=
+    Set.powersetCard.ofCard (s := {i}) (Finset.card_singleton i)
+  rw [ExteriorAlgebra.basis_apply_ofCard b (Finset.card_singleton i)]
+  rw [ExteriorAlgebra.ιMulti_family]
+  rw [ExteriorAlgebra.ιMulti_succ_apply, ExteriorAlgebra.ιMulti_zero_apply, mul_one]
+  have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
+    a (Set.powersetCard.ofFinEmbEquiv.symm a 0)).mp ⟨0, rfl⟩
+  have hj' : Set.powersetCard.ofFinEmbEquiv.symm a 0 ∈ ({i} : Finset (Fin n)) := hj
+  have heq : Set.powersetCard.ofFinEmbEquiv.symm a 0 = i := Finset.eq_of_mem_singleton hj'
+  exact congrArg (fun j ↦ ExteriorAlgebra.ι R (b j)) heq
+
+private theorem exteriorCoordProj_basis_of_mem {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∈ s) :
+    exteriorCoordProj b i (b.ExteriorAlgebra s) = b.ExteriorAlgebra s := by
+  let a : Set.powersetCard (Fin n) 1 := ⟨{i}, Finset.card_singleton i⟩
+  let t : Set.powersetCard (Fin n) (s.erase i).card := ⟨s.erase i, rfl⟩
+  have hdisj : Disjoint a.val t.val := by simp [a, t]
+  have hunion : Set.powersetCard.disjUnion hdisj =
+      (Set.powersetCard.ofCard (s := s) (by
+        rw [Finset.card_erase_of_mem hi]
+        have : 0 < s.card := Finset.card_pos.mpr ⟨i, hi⟩
+        omega) : Set.powersetCard (Fin n) (1 + (s.erase i).card)) := by
+    apply Subtype.ext
+    simp [Set.powersetCard.disjUnion, a, t, hi]
+  have hprod := ExteriorAlgebra.basis_mul_of_disjoint b a t hdisj
+  rw [hunion] at hprod
+  simp only [a, t, Set.powersetCard.val_ofCard] at hprod
+  have hfixed : exteriorCoordProj b i
+      (b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i)) =
+      b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i) := by
+    rw [exteriorCoordProj, LinearMap.comp_apply, LinearMap.mulLeft_apply,
+      basis_exteriorAlgebra_singleton_eq_ι]
+    rw [contractLeft_ι_mul]
+    simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
+    rw [contractLeft_basis_eq_zero_of_not_mem b i (s.erase i) (by simp),
+      mul_zero, sub_zero]
+    simp
+  rw [hprod] at hfixed
+  rcases Int.units_eq_one_or (Equiv.Perm.sign
+    (Set.powersetCard.permOfDisjoint hdisj)) with hsign | hsign <;>
+    rw [hsign] at hfixed <;> simpa using hfixed
+
+private theorem exteriorCoordProj_repr_of_mem {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∈ s)
+    (x : ExteriorAlgebra R M) :
+    b.ExteriorAlgebra.repr (exteriorCoordProj b i x) s =
+      b.ExteriorAlgebra.repr x s := by
+  have hmap : (b.ExteriorAlgebra.coord s).comp (exteriorCoordProj b i) =
+      b.ExteriorAlgebra.coord s := by
+    apply b.ExteriorAlgebra.ext
+    intro t
+    by_cases hit : i ∈ t
+    · rw [LinearMap.comp_apply, exteriorCoordProj_basis_of_mem b i t hit]
+    · rw [LinearMap.comp_apply, exteriorCoordProj_basis_of_not_mem b i t hit, map_zero]
+      simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
+      split_ifs with hts
+      · subst t
+        exact (hit hi).elim
+      · rfl
+  exact LinearMap.congr_fun hmap x
+
+private theorem eq_algebraMap_of_all_contractLeft_eq_zero {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (x : ExteriorAlgebra R M)
+    (hx : ∀ d : Module.Dual R M,
+      contractLeft (Q := (0 : QuadraticForm R M)) d x = 0) :
+    x = algebraMap R (ExteriorAlgebra R M) (b.ExteriorAlgebra.repr x ∅) := by
+  have hbempty : b.ExteriorAlgebra (∅ : Finset (Fin n)) = 1 := by
+    rw [ExteriorAlgebra.basis_apply]
+    simp
+  apply b.ExteriorAlgebra.repr.injective
+  ext s
+  rw [Algebra.algebraMap_eq_smul_one, ← hbempty, map_smul,
+    Module.Basis.repr_self, Finsupp.smul_single, Finsupp.single_apply]
+  by_cases hs : s = ∅
+  · subst s
+    simp
+  · obtain ⟨i, hi⟩ := Finset.nonempty_iff_ne_empty.mpr hs
+    have hproject : exteriorCoordProj b i x = 0 := by
+      rw [exteriorCoordProj, LinearMap.comp_apply, hx, LinearMap.mulLeft_apply, mul_zero]
+    have hcoord := exteriorCoordProj_repr_of_mem b i s hi x
+    rw [hproject, map_zero, Finsupp.zero_apply] at hcoord
+    rw [← hcoord]
+    simp [Ne.symm hs]
+
+end Exterior
+
+variable {K : Type u} [Field K] [Module K M] [FiniteDimensional K M]
+  [Invertible (2 : K)]
+
+/-- A Clifford element annihilated by every left contraction is a scalar. -/
+theorem exists_eq_algebraMap_of_contractLeft_eq_zero (Q : QuadraticForm K M)
+    (x : CliffordAlgebra Q) (hx : ∀ d : Module.Dual K M, contractLeft d x = 0) :
+    ∃ r : K, x = algebraMap K (CliffordAlgebra Q) r := by
+  let b := Module.finBasis K M
+  let y : ExteriorAlgebra K M := equivExterior Q x
+  have hycontract (d : Module.Dual K M) :
+      contractLeft (Q := (0 : QuadraticForm K M)) d y = 0 := by
+    dsimp only [y, equivExterior, changeFormEquiv_apply]
+    rw [changeFormEquiv_apply]
+    rw [← changeForm_contractLeft changeForm.associated_neg_proof d x, hx, map_zero]
+  let r := b.ExteriorAlgebra.repr y ∅
+  refine ⟨r, ?_⟩
+  apply (equivExterior Q).injective
+  simpa [y, r] using eq_algebraMap_of_all_contractLeft_eq_zero b y hycontract
+
+/-- An even Clifford element that commutes with every generating vector is a scalar. -/
+theorem exists_eq_algebraMap_of_mem_even_of_commute
+    (Q : QuadraticForm K M) (hQ : Q.Nondegenerate) (x : CliffordAlgebra Q)
+    (hx_even : x ∈ even Q) (hx_comm : ∀ v : M, Commute x (ι Q v)) :
+    ∃ r : K, x = algebraMap K (CliffordAlgebra Q) r := by
+  let B : LinearMap.BilinForm K M := QuadraticMap.associated Q
+  have hB : B.Nondegenerate := by
+    simpa only [B] using QuadraticMap.nondegenerate_associated_iff.mpr hQ
+  apply exists_eq_algebraMap_of_contractLeft_eq_zero Q x
+  intro d
+  obtain ⟨v, rfl⟩ := (B.toDual hB).surjective d
+  have htoDual : B.toDual hB v = Q.associated v :=
+    LinearMap.ext fun w ↦ (LinearMap.BilinForm.toDual_def hB).trans (by rfl)
+  rw [htoDual]
+  exact contractLeft_associated_eq_zero_of_commute_of_mem_even Q hx_even hx_comm v
 
 end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/PinAction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/PinAction.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Action
+import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 
 /-!
 # The Pin group acting on its quadratic space by twisted conjugation
@@ -46,6 +47,10 @@ Twisted conjugation is the one that extends to the odd part.
   orthogonal hyperplane.** This is the identification of the generators referred to above.
 * `TauCeti.CliffordAlgebra.lipschitzVectorAction_map_app`: twisted conjugation by a Lipschitz
   element preserves the quadratic form.
+* `TauCeti.CliffordAlgebra.neg_one_mem_spinGroup_of_isUnit`: the scalar `-1` is in the Spin group
+  when the form takes a unit value.
+* `TauCeti.CliffordAlgebra.spinGroup.negOne`: the canonical scalar `-1` in the Spin group of a
+  nonzero quadratic form over a field.
 * `TauCeti.CliffordAlgebra.ι_mem_pinGroup`: a vector `v` with `Q v = -1` lies in the Pin group, and
   `TauCeti.CliffordAlgebra.pinToOrthogonal_ι_apply` computes the reflection it induces. The sign is
   forced by Mathlib's conventions: `star` is the reversal composed with the grade involution, so
@@ -108,7 +113,7 @@ private theorem twistedConj_mul (x y : (CliffordAlgebra Q)ˣ) (a : CliffordAlgeb
   simp only [twistedConj_apply, Units.val_mul, mul_inv_rev, map_mul]
   noncomm_ring
 
-/-! ### Vectors of invertible norm as Lipschitz elements -/
+/-! ### Vectors of invertible norm and the scalar `-1` -/
 
 /-- A vector of invertible norm, as a unit of the Clifford algebra. These units generate the
 Lipschitz group (`unitι_mem_lipschitzGroup`), and they act on the quadratic space by the
@@ -128,6 +133,71 @@ theorem coe_unitι (v : M) [Invertible (Q v)] : (unitι Q v : CliffordAlgebra Q)
 theorem unitι_mem_lipschitzGroup (v : M) [Invertible (Q v)] : unitι Q v ∈ lipschitzGroup Q := by
   unfold lipschitzGroup
   exact Subgroup.subset_closure ⟨v, (coe_unitι v).symm⟩
+
+/-- The scalar `-1` belongs to the Spin group when the quadratic form is a unit
+on some vector. -/
+theorem neg_one_mem_spinGroup_of_isUnit (Q : QuadraticForm R M) (v : M)
+    (hvQ : IsUnit (Q v)) :
+    (-1 : CliffordAlgebra Q) ∈ spinGroup Q := by
+  let _ : Invertible (Q v) := hvQ.invertible
+  let a : R := -⅟(Q v)
+  have ha : IsUnit a := (isUnit_of_invertible (⅟(Q v))).neg
+  let _ : Invertible a := ha.invertible
+  have havQ : IsUnit (Q (a • v)) := by
+    rw [QuadraticMap.map_smul]
+    simpa [smul_eq_mul, mul_assoc] using ha.mul (ha.mul hvQ)
+  let _ : Invertible (Q (a • v)) := havQ.invertible
+  let x := unitι Q (a • v) * unitι Q v
+  have hx : (x : CliffordAlgebra Q) = -1 := by
+    simp only [x, Units.val_mul, coe_unitι, map_smul, Algebra.smul_def]
+    rw [mul_assoc, ι_sq_scalar, ← map_mul]
+    simp [a]
+  rw [spinGroup.mem_iff]
+  refine ⟨?_, ?_⟩
+  · refine ⟨⟨x, mul_mem (unitι_mem_lipschitzGroup _) (unitι_mem_lipschitzGroup _), hx⟩,
+      ?_⟩
+    simp [Unitary.mem_iff]
+  · exact (CliffordAlgebra.even Q).neg_mem (CliffordAlgebra.even Q).one_mem
+
+section NegOne
+
+variable {K : Type u} [Field K] [Module K M]
+
+/-- The scalar `-1` belongs to the Spin group of a nonzero quadratic form over a field. -/
+theorem neg_one_mem_spinGroup (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
+    (-1 : CliffordAlgebra Q) ∈ spinGroup Q := by
+  obtain ⟨v, hv⟩ := DFunLike.ne_iff.mp hQ
+  exact neg_one_mem_spinGroup_of_isUnit Q v
+    (isUnit_iff_ne_zero.mpr (by simpa using hv))
+
+namespace spinGroup
+
+/-- The canonical scalar `-1` in the Spin group of a nonzero quadratic form over a field. -/
+def negOne (Q : QuadraticForm K M) (hQ : Q ≠ 0) : spinGroup Q :=
+  ⟨-1, neg_one_mem_spinGroup Q hQ⟩
+
+/-- The underlying Clifford element of `spinGroup.negOne` is the scalar `-1`. -/
+@[simp]
+theorem coe_negOne (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
+    (negOne Q hQ : CliffordAlgebra Q) = -1 :=
+  (rfl)
+
+/-- The canonical scalar `-1` in the Spin group is not the identity when `2` is invertible. -/
+theorem negOne_ne_one (Q : QuadraticForm K M) [Invertible (2 : K)] (hQ : Q ≠ 0) :
+    negOne Q hQ ≠ 1 := by
+  intro h
+  have hK : (-1 : K) = 1 := by
+    apply algebraMap_injective Q
+    simpa using congrArg (fun x : spinGroup Q ↦ (x : CliffordAlgebra Q)) h
+  apply Invertible.ne_zero (2 : K)
+  calc
+    (2 : K) = 1 - (-1) := by ring
+    _ = 1 - 1 := by rw [hK]
+    _ = 0 := sub_self 1
+
+end spinGroup
+
+end NegOne
 
 /-- A vector of norm `-1` lies in the Pin group. The sign is Mathlib's convention: `star` is the
 reversal composed with the grade involution, so `star (ι Q v) = -ι Q v`, and the unitarity

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/PinAction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/PinAction.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Action
-import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 
 /-!
 # The Pin group acting on its quadratic space by twisted conjugation
@@ -47,10 +46,6 @@ Twisted conjugation is the one that extends to the odd part.
   orthogonal hyperplane.** This is the identification of the generators referred to above.
 * `TauCeti.CliffordAlgebra.lipschitzVectorAction_map_app`: twisted conjugation by a Lipschitz
   element preserves the quadratic form.
-* `TauCeti.CliffordAlgebra.neg_one_mem_spinGroup_of_isUnit`: the scalar `-1` is in the Spin group
-  when the form takes a unit value.
-* `TauCeti.CliffordAlgebra.spinGroup.negOne`: the canonical scalar `-1` in the Spin group of a
-  nonzero quadratic form over a field.
 * `TauCeti.CliffordAlgebra.ι_mem_pinGroup`: a vector `v` with `Q v = -1` lies in the Pin group, and
   `TauCeti.CliffordAlgebra.pinToOrthogonal_ι_apply` computes the reflection it induces. The sign is
   forced by Mathlib's conventions: `star` is the reversal composed with the grade involution, so
@@ -113,7 +108,7 @@ private theorem twistedConj_mul (x y : (CliffordAlgebra Q)ˣ) (a : CliffordAlgeb
   simp only [twistedConj_apply, Units.val_mul, mul_inv_rev, map_mul]
   noncomm_ring
 
-/-! ### Vectors of invertible norm and the scalar `-1` -/
+/-! ### Vectors of invertible norm -/
 
 /-- A vector of invertible norm, as a unit of the Clifford algebra. These units generate the
 Lipschitz group (`unitι_mem_lipschitzGroup`), and they act on the quadratic space by the
@@ -133,71 +128,6 @@ theorem coe_unitι (v : M) [Invertible (Q v)] : (unitι Q v : CliffordAlgebra Q)
 theorem unitι_mem_lipschitzGroup (v : M) [Invertible (Q v)] : unitι Q v ∈ lipschitzGroup Q := by
   unfold lipschitzGroup
   exact Subgroup.subset_closure ⟨v, (coe_unitι v).symm⟩
-
-/-- The scalar `-1` belongs to the Spin group when the quadratic form is a unit
-on some vector. -/
-theorem neg_one_mem_spinGroup_of_isUnit (Q : QuadraticForm R M) (v : M)
-    (hvQ : IsUnit (Q v)) :
-    (-1 : CliffordAlgebra Q) ∈ spinGroup Q := by
-  let _ : Invertible (Q v) := hvQ.invertible
-  let a : R := -⅟(Q v)
-  have ha : IsUnit a := (isUnit_of_invertible (⅟(Q v))).neg
-  let _ : Invertible a := ha.invertible
-  have havQ : IsUnit (Q (a • v)) := by
-    rw [QuadraticMap.map_smul]
-    simpa [smul_eq_mul, mul_assoc] using ha.mul (ha.mul hvQ)
-  let _ : Invertible (Q (a • v)) := havQ.invertible
-  let x := unitι Q (a • v) * unitι Q v
-  have hx : (x : CliffordAlgebra Q) = -1 := by
-    simp only [x, Units.val_mul, coe_unitι, map_smul, Algebra.smul_def]
-    rw [mul_assoc, ι_sq_scalar, ← map_mul]
-    simp [a]
-  rw [spinGroup.mem_iff]
-  refine ⟨?_, ?_⟩
-  · refine ⟨⟨x, mul_mem (unitι_mem_lipschitzGroup _) (unitι_mem_lipschitzGroup _), hx⟩,
-      ?_⟩
-    simp [Unitary.mem_iff]
-  · exact (CliffordAlgebra.even Q).neg_mem (CliffordAlgebra.even Q).one_mem
-
-section NegOne
-
-variable {K : Type u} [Field K] [Module K M]
-
-/-- The scalar `-1` belongs to the Spin group of a nonzero quadratic form over a field. -/
-theorem neg_one_mem_spinGroup (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
-    (-1 : CliffordAlgebra Q) ∈ spinGroup Q := by
-  obtain ⟨v, hv⟩ := DFunLike.ne_iff.mp hQ
-  exact neg_one_mem_spinGroup_of_isUnit Q v
-    (isUnit_iff_ne_zero.mpr (by simpa using hv))
-
-namespace spinGroup
-
-/-- The canonical scalar `-1` in the Spin group of a nonzero quadratic form over a field. -/
-def negOne (Q : QuadraticForm K M) (hQ : Q ≠ 0) : spinGroup Q :=
-  ⟨-1, neg_one_mem_spinGroup Q hQ⟩
-
-/-- The underlying Clifford element of `spinGroup.negOne` is the scalar `-1`. -/
-@[simp]
-theorem coe_negOne (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
-    (negOne Q hQ : CliffordAlgebra Q) = -1 :=
-  (rfl)
-
-/-- The canonical scalar `-1` in the Spin group is not the identity when `2` is invertible. -/
-theorem negOne_ne_one (Q : QuadraticForm K M) [Invertible (2 : K)] (hQ : Q ≠ 0) :
-    negOne Q hQ ≠ 1 := by
-  intro h
-  have hK : (-1 : K) = 1 := by
-    apply algebraMap_injective Q
-    simpa using congrArg (fun x : spinGroup Q ↦ (x : CliffordAlgebra Q)) h
-  apply Invertible.ne_zero (2 : K)
-  calc
-    (2 : K) = 1 - (-1) := by ring
-    _ = 1 - 1 := by rw [hK]
-    _ = 0 := sub_self 1
-
-end spinGroup
-
-end NegOne
 
 /-- A vector of norm `-1` lies in the Pin group. The sign is Mathlib's convention: `star` is the
 reversal composed with the grade involution, so `star (ι Q v) = -ι Q v`, and the unitarity

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -5,11 +5,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpecialOrthogonal
-public import Mathlib.LinearAlgebra.QuadraticForm.Radical
+public import TauCeti.LinearAlgebra.QuadraticForm.Radical
 import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 
 /-!
-# The kernel of the Spin double cover
+# The kernel of the Spin action
 
 For a positive-dimensional finite nondegenerate quadratic space over a field where `2` is
 invertible, the kernel of the Spin action consists of the two scalar elements. The proof first
@@ -26,7 +26,7 @@ the special orthogonal group has cardinality two.
 ## References
 
 This completes Layer 2's kernel target, `card_ker_spinToSpecialOrthogonal`, in
-`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. See H. B. Lawson and
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean`. See H. B. Lawson and
 M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 -/
 
@@ -207,22 +207,6 @@ end spinGroup
 end NegOne
 
 end TauCeti.CliffordAlgebra
-
-namespace QuadraticMap.Nondegenerate
-
-variable {K : Type u} {M : Type v} [Field K] [AddCommGroup M] [Module K M]
-
-/-- A nondegenerate quadratic form on a nontrivial module is nonzero. -/
-theorem ne_zero [Nontrivial M] {Q : QuadraticForm K M} (hQ : Q.Nondegenerate) : Q ≠ 0 := by
-  intro hzero
-  obtain ⟨v, hv⟩ := exists_ne (0 : M)
-  apply hv
-  have hm : v ∈ Q.radical := by
-    rw [hzero, QuadraticMap.mem_radical_iff']
-    simp
-  rwa [hQ.radical_eq_bot, Submodule.mem_bot] at hm
-
-end QuadraticMap.Nondegenerate
 
 namespace TauCeti.CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -6,8 +6,6 @@ module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpecialOrthogonal
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
-import Mathlib.LinearAlgebra.ExteriorAlgebra.Basis
-import Mathlib.LinearAlgebra.BilinearForm.Properties
 import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 
 /-!
@@ -43,208 +41,85 @@ universe u v
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   (Q : QuadraticForm R M)
 
-private theorem two_smul_contractLeft_associated [Invertible (2 : R)]
-    (v : M) (x : CliffordAlgebra Q) :
-    (2 : R) • contractLeft (Q.associated v) x =
-      ι Q v * x - involute x * ι Q v := by
-  induction x using CliffordAlgebra.left_induction with
-  | algebraMap r =>
-      simp [Algebra.commutes]
-  | add x y hx hy =>
-      rw [map_add, smul_add, hx, hy, map_add, mul_add, add_mul]
-      abel
-  | ι_mul a x hx =>
-      rw [contractLeft_ι_mul, smul_sub, smul_smul, ← mul_smul_comm, hx, map_mul, involute_ι]
-      simp only [neg_mul, sub_neg_eq_add]
-      have hpolar := LinearMap.congr_fun (LinearMap.congr_fun
-        (QuadraticMap.two_nsmul_associated R Q) v) x
-      simp only [LinearMap.smul_apply, nsmul_eq_mul, QuadraticMap.polarBilin_apply_apply] at hpolar
-      have hpolar' : (2 : R) * Q.associated v x =
-          QuadraticMap.polar (⇑Q) v x := by
-        simpa only [Nat.cast_ofNat] using hpolar
-      rw [hpolar']
-      rw [Algebra.smul_def, ← ι_mul_ι_add_swap]
-      noncomm_ring
-
-private theorem contractLeft_associated_eq_zero_of_commute_of_mem_even
-    [Invertible (2 : R)] {x : CliffordAlgebra Q} (hx_even : x ∈ even Q)
-    (hx_comm : ∀ v : M, Commute x (ι Q v)) (v : M) :
-    contractLeft (Q.associated v) x = 0 := by
-  apply (isUnit_of_invertible (2 : R)).smul_eq_zero.mp
-  rw [two_smul_contractLeft_associated Q, involute_eq_of_mem_even hx_even,
-    (hx_comm v).eq, sub_self]
-
-section Exterior
-
-private theorem contractLeft_ιMulti_eq_zero {n : ℕ}
-    (d : Module.Dual R M) (v : Fin n → M) (h : ∀ i, d (v i) = 0) :
-    contractLeft (Q := (0 : QuadraticForm R M)) d (ExteriorAlgebra.ιMulti R n v) = 0 := by
-  induction n with
-  | zero =>
-      rw [ExteriorAlgebra.ιMulti_zero_apply]
-      exact contractLeft_one (Q := (0 : QuadraticForm R M)) d
-  | succ n ih =>
-      rw [ExteriorAlgebra.ιMulti_succ_apply, contractLeft_ι_mul, h 0, zero_smul,
-        ih (Matrix.vecTail v) (fun i => h i.succ), mul_zero, sub_zero]
-
-private theorem contractLeft_basis_eq_zero_of_not_mem {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
-    contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) = 0 := by
-  rw [ExteriorAlgebra.basis_apply]
-  apply contractLeft_ιMulti_eq_zero
-  intro j
-  simp only [Function.comp_apply, Module.Basis.coord_apply,
-    Module.Basis.repr_self, Finsupp.single_apply]
-  split_ifs with h
-  · exfalso
-    apply hi
-    rw [← h]
-    have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
-      (Set.powersetCard.prodEquiv.symm s).2
-      (Set.powersetCard.ofFinEmbEquiv.symm (Set.powersetCard.prodEquiv.symm s).2 j)).mp
-      ⟨j, rfl⟩
-    exact hj
-  · rfl
-
-private noncomputable def exteriorCoordProj {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) :
-    ExteriorAlgebra R M →ₗ[R] ExteriorAlgebra R M :=
-  (LinearMap.mulLeft R (ExteriorAlgebra.ι R (b i))).comp
-    (contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i))
-
-private theorem exteriorCoordProj_basis_of_not_mem {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
-    exteriorCoordProj b i (b.ExteriorAlgebra s) = 0 := by
-  rw [exteriorCoordProj, LinearMap.comp_apply, LinearMap.mulLeft_apply,
-    contractLeft_basis_eq_zero_of_not_mem b i s hi, mul_zero]
-
-private theorem basis_exteriorAlgebra_singleton_eq_ι {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) :
-    b.ExteriorAlgebra {i} = ExteriorAlgebra.ι R (b i) := by
-  let a : Set.powersetCard (Fin n) 1 :=
-    Set.powersetCard.ofCard (s := {i}) (Finset.card_singleton i)
-  rw [ExteriorAlgebra.basis_apply_ofCard b (Finset.card_singleton i)]
-  rw [ExteriorAlgebra.ιMulti_family]
-  rw [ExteriorAlgebra.ιMulti_succ_apply, ExteriorAlgebra.ιMulti_zero_apply, mul_one]
-  have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
-    a (Set.powersetCard.ofFinEmbEquiv.symm a 0)).mp ⟨0, rfl⟩
-  have hj' : Set.powersetCard.ofFinEmbEquiv.symm a 0 ∈ ({i} : Finset (Fin n)) := hj
-  have heq : Set.powersetCard.ofFinEmbEquiv.symm a 0 = i := Finset.eq_of_mem_singleton hj'
-  -- Expose the singleton index hidden by the ordered powerset basis wrapper.
-  change ExteriorAlgebra.ι R
-    (b (Set.powersetCard.ofFinEmbEquiv.symm a 0)) = ExteriorAlgebra.ι R (b i)
-  rw [heq]
-
-private theorem exteriorCoordProj_basis_of_mem {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∈ s) :
-    exteriorCoordProj b i (b.ExteriorAlgebra s) = b.ExteriorAlgebra s := by
-  let a : Set.powersetCard (Fin n) 1 := ⟨{i}, Finset.card_singleton i⟩
-  let t : Set.powersetCard (Fin n) (s.erase i).card := ⟨s.erase i, rfl⟩
-  have hdisj : Disjoint a.val t.val := by simp [a, t]
-  have hunion : Set.powersetCard.disjUnion hdisj =
-      (Set.powersetCard.ofCard (s := s) (by
-        rw [Finset.card_erase_of_mem hi]
-        have : 0 < s.card := Finset.card_pos.mpr ⟨i, hi⟩
-        omega) : Set.powersetCard (Fin n) (1 + (s.erase i).card)) := by
-    apply Subtype.ext
-    simp [Set.powersetCard.disjUnion, a, t, hi]
-  have hprod := ExteriorAlgebra.basis_mul_of_disjoint b a t hdisj
-  rw [hunion] at hprod
-  simp only [a, t, Set.powersetCard.val_ofCard] at hprod
-  have hfixed : exteriorCoordProj b i
-      (b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i)) =
-      b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i) := by
-    rw [exteriorCoordProj, LinearMap.comp_apply, LinearMap.mulLeft_apply,
-      basis_exteriorAlgebra_singleton_eq_ι]
-    rw [contractLeft_ι_mul]
-    simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
-    rw [contractLeft_basis_eq_zero_of_not_mem b i (s.erase i) (by simp),
-      mul_zero, sub_zero]
-    simp
-  rw [hprod] at hfixed
-  rcases Int.units_eq_one_or (Equiv.Perm.sign
-    (Set.powersetCard.permOfDisjoint hdisj)) with hsign | hsign <;>
-    rw [hsign] at hfixed <;> simpa using hfixed
-
-private theorem exteriorCoordProj_repr_of_mem {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∈ s)
-    (x : ExteriorAlgebra R M) :
-    b.ExteriorAlgebra.repr (exteriorCoordProj b i x) s =
-      b.ExteriorAlgebra.repr x s := by
-  have hmap : (b.ExteriorAlgebra.coord s).comp (exteriorCoordProj b i) =
-      b.ExteriorAlgebra.coord s := by
-    apply b.ExteriorAlgebra.ext
-    intro t
-    by_cases hit : i ∈ t
-    · rw [LinearMap.comp_apply, exteriorCoordProj_basis_of_mem b i t hit]
-    · rw [LinearMap.comp_apply, exteriorCoordProj_basis_of_not_mem b i t hit, map_zero]
-      simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
-      split_ifs with hts
-      · subst t
-        exact (hit hi).elim
-      · rfl
-  exact LinearMap.congr_fun hmap x
-
-private theorem eq_algebraMap_of_all_contractLeft_eq_zero {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (x : ExteriorAlgebra R M)
-    (hx : ∀ d : Module.Dual R M,
-      contractLeft (Q := (0 : QuadraticForm R M)) d x = 0) :
-    x = algebraMap R (ExteriorAlgebra R M) (b.ExteriorAlgebra.repr x ∅) := by
-  have hbempty : b.ExteriorAlgebra (∅ : Finset (Fin n)) = 1 := by
-    rw [ExteriorAlgebra.basis_apply]
-    simp
-  apply b.ExteriorAlgebra.repr.injective
-  ext s
-  rw [Algebra.algebraMap_eq_smul_one, ← hbempty, map_smul,
-    Module.Basis.repr_self, Finsupp.smul_single, Finsupp.single_apply]
-  by_cases hs : s = ∅
-  · subst s
-    simp
-  · obtain ⟨i, hi⟩ := Finset.nonempty_iff_ne_empty.mpr hs
-    have hproject : exteriorCoordProj b i x = 0 := by
-      rw [exteriorCoordProj, LinearMap.comp_apply, hx, LinearMap.mulLeft_apply, mul_zero]
-    have hcoord := exteriorCoordProj_repr_of_mem b i s hi x
-    rw [hproject, map_zero, Finsupp.zero_apply] at hcoord
-    rw [← hcoord]
-    simp [Ne.symm hs]
-
-end Exterior
-
 section Scalar
 
-variable {K : Type u} [Field K] [Module K M] [FiniteDimensional K M]
-  (Q : QuadraticForm K M) [Invertible (2 : K)]
+variable {K : Type u} [Field K] [Module K M]
 
-/-- A Clifford element annihilated by every left contraction is a scalar. -/
-theorem exists_eq_algebraMap_of_contractLeft_eq_zero (x : CliffordAlgebra Q)
-    (hx : ∀ d : Module.Dual K M, contractLeft d x = 0) :
-    ∃ r : K, x = algebraMap K (CliffordAlgebra Q) r := by
-  let b := Module.finBasis K M
-  let y : ExteriorAlgebra K M := equivExterior Q x
-  have hycontract (d : Module.Dual K M) :
-      contractLeft (Q := (0 : QuadraticForm K M)) d y = 0 := by
-    dsimp only [y, equivExterior, changeFormEquiv_apply]
-    rw [changeFormEquiv_apply]
-    rw [← changeForm_contractLeft changeForm.associated_neg_proof d x, hx, map_zero]
-  let r := b.ExteriorAlgebra.repr y ∅
-  refine ⟨r, ?_⟩
-  apply (equivExterior Q).injective
-  simpa [y, r] using eq_algebraMap_of_all_contractLeft_eq_zero b y hycontract
+/-! ### The scalar `-1` in the Spin group -/
 
-/-- An even Clifford element that commutes with every generating vector is a scalar. -/
-theorem exists_eq_algebraMap_of_mem_even_of_commute
-    (hQ : Q.Nondegenerate) (x : CliffordAlgebra Q) (hx_even : x ∈ even Q)
-    (hx_comm : ∀ v : M, Commute x (ι Q v)) :
-    ∃ r : K, x = algebraMap K (CliffordAlgebra Q) r := by
-  let B : LinearMap.BilinForm K M := QuadraticMap.associated Q
-  have hB : B.Nondegenerate := by
-    simpa only [B] using QuadraticMap.nondegenerate_associated_iff.mpr hQ
-  apply exists_eq_algebraMap_of_contractLeft_eq_zero Q x
-  intro d
-  obtain ⟨v, rfl⟩ := (B.toDual hB).surjective d
-  rw [show B.toDual hB v = Q.associated v from
-    LinearMap.ext fun w ↦ (LinearMap.BilinForm.toDual_def hB).trans (by rfl)]
-  exact contractLeft_associated_eq_zero_of_commute_of_mem_even Q hx_even hx_comm v
+/-- The scalar `-1` belongs to the Spin group when the quadratic form is a unit
+on some vector. -/
+theorem neg_one_mem_spinGroup_of_isUnit (Q : QuadraticForm R M) (v : M)
+    (hvQ : IsUnit (Q v)) :
+    (-1 : CliffordAlgebra Q) ∈ spinGroup Q := by
+  let _ : Invertible (Q v) := hvQ.invertible
+  let a : R := -⅟(Q v)
+  have ha : IsUnit a := (isUnit_of_invertible (⅟(Q v))).neg
+  let _ : Invertible a := ha.invertible
+  have havQ : IsUnit (Q (a • v)) := by
+    rw [QuadraticMap.map_smul]
+    simpa [smul_eq_mul, mul_assoc] using ha.mul (ha.mul hvQ)
+  let _ : Invertible (Q (a • v)) := havQ.invertible
+  let x := unitι Q (a • v) * unitι Q v
+  have hx : (x : CliffordAlgebra Q) = -1 := by
+    simp only [x, Units.val_mul, coe_unitι, map_smul, Algebra.smul_def]
+    rw [mul_assoc, ι_sq_scalar, ← map_mul]
+    simp [a]
+  rw [spinGroup.mem_iff]
+  refine ⟨?_, ?_⟩
+  · refine ⟨⟨x, mul_mem (unitι_mem_lipschitzGroup _) (unitι_mem_lipschitzGroup _), hx⟩,
+      ?_⟩
+    simp [Unitary.mem_iff]
+  · exact (CliffordAlgebra.even Q).neg_mem (CliffordAlgebra.even Q).one_mem
+
+/-- The scalar `-1` belongs to the Spin group of a nonzero quadratic form over a field. -/
+theorem neg_one_mem_spinGroup (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
+    (-1 : CliffordAlgebra Q) ∈ spinGroup Q := by
+  obtain ⟨v, hv⟩ := DFunLike.ne_iff.mp hQ
+  exact neg_one_mem_spinGroup_of_isUnit Q v
+    (isUnit_iff_ne_zero.mpr (by simpa using hv))
+
+namespace spinGroup
+
+/-- The canonical scalar `-1` in the Spin group of a nonzero quadratic form over a field. -/
+def negOne (Q : QuadraticForm K M) (hQ : Q ≠ 0) : spinGroup Q :=
+  ⟨-1, neg_one_mem_spinGroup Q hQ⟩
+
+/-- The underlying Clifford element of `spinGroup.negOne` is the scalar `-1`. -/
+@[simp]
+theorem coe_negOne (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
+    (negOne Q hQ : CliffordAlgebra Q) = -1 :=
+  (rfl)
+
+/-- The canonical scalar `-1` squares to the identity. -/
+@[simp]
+theorem negOne_mul_self (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
+    negOne Q hQ * negOne Q hQ = 1 := by
+  apply Subtype.ext
+  simp
+
+/-- Reversion fixes the canonical scalar `-1`. -/
+@[simp]
+theorem star_negOne (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
+    star (negOne Q hQ : CliffordAlgebra Q) = negOne Q hQ := by
+  simp
+
+/-- The canonical scalar `-1` in the Spin group is not the identity when `2` is invertible. -/
+theorem negOne_ne_one (Q : QuadraticForm K M) [Invertible (2 : K)] (hQ : Q ≠ 0) :
+    negOne Q hQ ≠ 1 := by
+  intro h
+  have hK : (-1 : K) = 1 := by
+    apply algebraMap_injective Q
+    simpa using congrArg (fun x : spinGroup Q ↦ (x : CliffordAlgebra Q)) h
+  apply Invertible.ne_zero (2 : K)
+  calc
+    (2 : K) = 1 - (-1) := by ring
+    _ = 1 - 1 := by rw [hK]
+    _ = 0 := sub_self 1
+
+end spinGroup
+
+variable [FiniteDimensional K M] (Q : QuadraticForm K M) [Invertible (2 : K)]
 
 omit [FiniteDimensional K M] in
 private theorem commute_ι_of_mem_ker_spinToOrthogonal
@@ -292,9 +167,11 @@ end Scalar
 
 section NegOne
 
+variable [Invertible (2 : R)]
+
 /-- A Spin element whose Clifford value is `-1` lies in the kernel of the Spin action. -/
 theorem mem_ker_spinToSpecialOrthogonal_of_coe_eq_neg_one
-    [Invertible (2 : R)] (x : spinGroup Q) (h : (x : CliffordAlgebra Q) = -1) :
+    (x : spinGroup Q) (h : (x : CliffordAlgebra Q) = -1) :
     x ∈ MonoidHom.ker (spinToSpecialOrthogonal Q) := by
   rw [MonoidHom.mem_ker]
   apply Subtype.ext
@@ -308,30 +185,41 @@ theorem mem_ker_spinToSpecialOrthogonal_of_coe_eq_neg_one
 namespace spinGroup
 
 variable {K : Type u} [Field K] [Module K M]
+  [Invertible (2 : K)]
 
 /-- The scalar `-1` lies in the kernel of the Spin action. -/
 theorem negOne_mem_ker_spinToSpecialOrthogonal
-    (Q : QuadraticForm K M) [Invertible (2 : K)] (hQ : Q ≠ 0) :
+    (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
     negOne Q hQ ∈ MonoidHom.ker (spinToSpecialOrthogonal Q) :=
   mem_ker_spinToSpecialOrthogonal_of_coe_eq_neg_one Q _ (coe_negOne Q hQ)
 
 /-- The scalar `-1` acts trivially on the quadratic space. -/
 @[simp]
 theorem spinToSpecialOrthogonal_negOne
-    (Q : QuadraticForm K M) [Invertible (2 : K)] (hQ : Q ≠ 0) :
+    (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
     spinToSpecialOrthogonal Q (negOne Q hQ) = 1 :=
   MonoidHom.mem_ker.mp (negOne_mem_ker_spinToSpecialOrthogonal Q hQ)
+
+/-- The scalar `-1` acts trivially under the primary orthogonal Spin action. -/
+@[simp]
+theorem spinToOrthogonal_negOne
+    (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
+    spinToOrthogonal Q (negOne Q hQ) = 1 := by
+  rw [← MonoidHom.mem_ker, ← ker_spinToSpecialOrthogonal]
+  exact negOne_mem_ker_spinToSpecialOrthogonal Q hQ
 
 end spinGroup
 
 end NegOne
 
-section Kernel
+end TauCeti.CliffordAlgebra
 
-variable {K : Type u} [Field K] [Module K M]
+namespace QuadraticMap.Nondegenerate
 
-theorem nondegenerate_ne_zero [Nontrivial M]
-    (Q : QuadraticForm K M) (hQ : Q.Nondegenerate) : Q ≠ 0 := by
+variable {K : Type u} {M : Type v} [Field K] [AddCommGroup M] [Module K M]
+
+/-- A nondegenerate quadratic form on a nontrivial module is nonzero. -/
+theorem ne_zero [Nontrivial M] {Q : QuadraticForm K M} (hQ : Q.Nondegenerate) : Q ≠ 0 := by
   intro hzero
   obtain ⟨v, hv⟩ := exists_ne (0 : M)
   apply hv
@@ -340,7 +228,14 @@ theorem nondegenerate_ne_zero [Nontrivial M]
     simp
   rwa [hQ.radical_eq_bot, Submodule.mem_bot] at hm
 
-variable [FiniteDimensional K M]
+end QuadraticMap.Nondegenerate
+
+namespace TauCeti.CliffordAlgebra
+
+section Kernel
+
+variable {K : Type u} {M : Type v} [Field K] [AddCommGroup M] [Module K M]
+  [FiniteDimensional K M]
 
 /-- A Spin element lies in the kernel of the special-orthogonal action exactly when it is
 the scalar `1` or the canonical scalar `-1`. -/
@@ -349,7 +244,7 @@ theorem mem_ker_spinToSpecialOrthogonal_iff
     (hQ : Q.Nondegenerate)
     (x : spinGroup Q) :
     x ∈ MonoidHom.ker (spinToSpecialOrthogonal Q) ↔
-      x = 1 ∨ x = spinGroup.negOne Q (nondegenerate_ne_zero Q hQ) := by
+      x = 1 ∨ x = spinGroup.negOne Q hQ.ne_zero := by
   constructor
   · intro hx
     rcases coe_eq_one_or_eq_neg_one_of_mem_ker_spinToOrthogonal Q hQ x
@@ -362,7 +257,17 @@ theorem mem_ker_spinToSpecialOrthogonal_iff
       simpa using h
   · rintro (rfl | rfl)
     · exact Subgroup.one_mem _
-    · exact spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q (nondegenerate_ne_zero Q hQ)
+    · exact spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q hQ.ne_zero
+
+/-- A Spin element lies in the kernel of the orthogonal action exactly when it is
+the scalar `1` or the canonical scalar `-1`. -/
+theorem mem_ker_spinToOrthogonal_iff
+    (Q : QuadraticForm K M) [Invertible (2 : K)] [Nontrivial M]
+    (hQ : Q.Nondegenerate) (x : spinGroup Q) :
+    x ∈ MonoidHom.ker (spinToOrthogonal Q) ↔
+      x = 1 ∨ x = spinGroup.negOne Q hQ.ne_zero := by
+  rw [← ker_spinToSpecialOrthogonal]
+  exact mem_ker_spinToSpecialOrthogonal_iff Q hQ x
 
 /-- The kernel of the Spin action on a positive-dimensional finite nondegenerate quadratic space
 over a field where `2` is invertible has cardinality two. -/
@@ -371,7 +276,7 @@ theorem card_ker_spinToSpecialOrthogonal (hM : 0 < Module.finrank K M)
     Nat.card (MonoidHom.ker (spinToSpecialOrthogonal Q)) = 2 := by
   let _ : Nontrivial M := Module.nontrivial_of_finrank_pos hM
   rw [Nat.card_eq_two_iff' (1 : MonoidHom.ker (spinToSpecialOrthogonal Q))]
-  have hQ0 := nondegenerate_ne_zero Q hQ
+  have hQ0 := hQ.ne_zero
   let z : MonoidHom.ker (spinToSpecialOrthogonal Q) :=
     ⟨spinGroup.negOne Q hQ0, spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q hQ0⟩
   refine ⟨z, ?_, ?_⟩

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -1,0 +1,391 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpecialOrthogonal
+public import Mathlib.LinearAlgebra.QuadraticForm.Radical
+import Mathlib.LinearAlgebra.ExteriorAlgebra.Basis
+import Mathlib.LinearAlgebra.BilinearForm.Properties
+import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
+
+/-!
+# The kernel of the Spin double cover
+
+For a positive-dimensional finite nondegenerate quadratic space over a field where `2` is
+invertible, the kernel of the Spin action consists of the two scalar elements. The proof first
+shows that an even Clifford element commuting with every generating vector is scalar, using
+contraction and the exterior-algebra basis. Unitarity then restricts the scalar to `1` or `-1`.
+
+## Main results
+
+* `TauCeti.CliffordAlgebra.mem_ker_spinToSpecialOrthogonal_iff`: a Spin element is in the kernel
+exactly when it is `1` or the canonical scalar `-1`.
+* `TauCeti.CliffordAlgebra.card_ker_spinToSpecialOrthogonal`: the kernel of the Spin action on
+the special orthogonal group has cardinality two.
+
+## References
+
+This completes Layer 2's kernel target, `card_ker_spinToSpecialOrthogonal`, in
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. See H. B. Lawson and
+M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+-/
+
+public section
+
+open CliffordAlgebra
+
+namespace TauCeti.CliffordAlgebra
+
+universe u v
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+  (Q : QuadraticForm R M)
+
+private theorem two_smul_contractLeft_associated [Invertible (2 : R)]
+    (v : M) (x : CliffordAlgebra Q) :
+    (2 : R) • contractLeft (Q.associated v) x =
+      ι Q v * x - involute x * ι Q v := by
+  induction x using CliffordAlgebra.left_induction with
+  | algebraMap r =>
+      simp [Algebra.commutes]
+  | add x y hx hy =>
+      rw [map_add, smul_add, hx, hy, map_add, mul_add, add_mul]
+      abel
+  | ι_mul a x hx =>
+      rw [contractLeft_ι_mul, smul_sub, smul_smul, ← mul_smul_comm, hx, map_mul, involute_ι]
+      simp only [neg_mul, sub_neg_eq_add]
+      have hpolar := LinearMap.congr_fun (LinearMap.congr_fun
+        (QuadraticMap.two_nsmul_associated R Q) v) x
+      simp only [LinearMap.smul_apply, nsmul_eq_mul, QuadraticMap.polarBilin_apply_apply] at hpolar
+      have hpolar' : (2 : R) * Q.associated v x =
+          QuadraticMap.polar (⇑Q) v x := by
+        simpa only [Nat.cast_ofNat] using hpolar
+      rw [hpolar']
+      rw [Algebra.smul_def, ← ι_mul_ι_add_swap]
+      noncomm_ring
+
+private theorem contractLeft_associated_eq_zero_of_commute_of_mem_even
+    [Invertible (2 : R)] {x : CliffordAlgebra Q} (hx_even : x ∈ even Q)
+    (hx_comm : ∀ v : M, Commute x (ι Q v)) (v : M) :
+    contractLeft (Q.associated v) x = 0 := by
+  apply (isUnit_of_invertible (2 : R)).smul_eq_zero.mp
+  rw [two_smul_contractLeft_associated Q, involute_eq_of_mem_even hx_even,
+    (hx_comm v).eq, sub_self]
+
+section Exterior
+
+private theorem contractLeft_ιMulti_eq_zero {n : ℕ}
+    (d : Module.Dual R M) (v : Fin n → M) (h : ∀ i, d (v i) = 0) :
+    contractLeft (Q := (0 : QuadraticForm R M)) d (ExteriorAlgebra.ιMulti R n v) = 0 := by
+  induction n with
+  | zero =>
+      rw [ExteriorAlgebra.ιMulti_zero_apply]
+      exact contractLeft_one (Q := (0 : QuadraticForm R M)) d
+  | succ n ih =>
+      rw [ExteriorAlgebra.ιMulti_succ_apply, contractLeft_ι_mul, h 0, zero_smul,
+        ih (Matrix.vecTail v) (fun i => h i.succ), mul_zero, sub_zero]
+
+private theorem contractLeft_basis_eq_zero_of_not_mem {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
+    contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) = 0 := by
+  rw [ExteriorAlgebra.basis_apply]
+  apply contractLeft_ιMulti_eq_zero
+  intro j
+  simp only [Function.comp_apply, Module.Basis.coord_apply,
+    Module.Basis.repr_self, Finsupp.single_apply]
+  split_ifs with h
+  · exfalso
+    apply hi
+    rw [← h]
+    have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
+      (Set.powersetCard.prodEquiv.symm s).2
+      (Set.powersetCard.ofFinEmbEquiv.symm (Set.powersetCard.prodEquiv.symm s).2 j)).mp
+      ⟨j, rfl⟩
+    exact hj
+  · rfl
+
+private noncomputable def exteriorCoordProj {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) :
+    ExteriorAlgebra R M →ₗ[R] ExteriorAlgebra R M :=
+  (LinearMap.mulLeft R (ExteriorAlgebra.ι R (b i))).comp
+    (contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i))
+
+private theorem exteriorCoordProj_basis_of_not_mem {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
+    exteriorCoordProj b i (b.ExteriorAlgebra s) = 0 := by
+  rw [exteriorCoordProj, LinearMap.comp_apply, LinearMap.mulLeft_apply,
+    contractLeft_basis_eq_zero_of_not_mem b i s hi, mul_zero]
+
+private theorem basis_exteriorAlgebra_singleton_eq_ι {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) :
+    b.ExteriorAlgebra {i} = ExteriorAlgebra.ι R (b i) := by
+  let a : Set.powersetCard (Fin n) 1 :=
+    Set.powersetCard.ofCard (s := {i}) (Finset.card_singleton i)
+  rw [ExteriorAlgebra.basis_apply_ofCard b (Finset.card_singleton i)]
+  rw [ExteriorAlgebra.ιMulti_family]
+  rw [ExteriorAlgebra.ιMulti_succ_apply, ExteriorAlgebra.ιMulti_zero_apply, mul_one]
+  have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
+    a (Set.powersetCard.ofFinEmbEquiv.symm a 0)).mp ⟨0, rfl⟩
+  have hj' : Set.powersetCard.ofFinEmbEquiv.symm a 0 ∈ ({i} : Finset (Fin n)) := hj
+  have heq : Set.powersetCard.ofFinEmbEquiv.symm a 0 = i := Finset.eq_of_mem_singleton hj'
+  -- Expose the singleton index hidden by the ordered powerset basis wrapper.
+  change ExteriorAlgebra.ι R
+    (b (Set.powersetCard.ofFinEmbEquiv.symm a 0)) = ExteriorAlgebra.ι R (b i)
+  rw [heq]
+
+private theorem exteriorCoordProj_basis_of_mem {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∈ s) :
+    exteriorCoordProj b i (b.ExteriorAlgebra s) = b.ExteriorAlgebra s := by
+  let a : Set.powersetCard (Fin n) 1 := ⟨{i}, Finset.card_singleton i⟩
+  let t : Set.powersetCard (Fin n) (s.erase i).card := ⟨s.erase i, rfl⟩
+  have hdisj : Disjoint a.val t.val := by simp [a, t]
+  have hunion : Set.powersetCard.disjUnion hdisj =
+      (Set.powersetCard.ofCard (s := s) (by
+        rw [Finset.card_erase_of_mem hi]
+        have : 0 < s.card := Finset.card_pos.mpr ⟨i, hi⟩
+        omega) : Set.powersetCard (Fin n) (1 + (s.erase i).card)) := by
+    apply Subtype.ext
+    simp [Set.powersetCard.disjUnion, a, t, hi]
+  have hprod := ExteriorAlgebra.basis_mul_of_disjoint b a t hdisj
+  rw [hunion] at hprod
+  simp only [a, t, Set.powersetCard.val_ofCard] at hprod
+  have hfixed : exteriorCoordProj b i
+      (b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i)) =
+      b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i) := by
+    rw [exteriorCoordProj, LinearMap.comp_apply, LinearMap.mulLeft_apply,
+      basis_exteriorAlgebra_singleton_eq_ι]
+    rw [contractLeft_ι_mul]
+    simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
+    rw [contractLeft_basis_eq_zero_of_not_mem b i (s.erase i) (by simp),
+      mul_zero, sub_zero]
+    simp
+  rw [hprod] at hfixed
+  rcases Int.units_eq_one_or (Equiv.Perm.sign
+    (Set.powersetCard.permOfDisjoint hdisj)) with hsign | hsign <;>
+    rw [hsign] at hfixed <;> simpa using hfixed
+
+private theorem exteriorCoordProj_repr_of_mem {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∈ s)
+    (x : ExteriorAlgebra R M) :
+    b.ExteriorAlgebra.repr (exteriorCoordProj b i x) s =
+      b.ExteriorAlgebra.repr x s := by
+  have hmap : (b.ExteriorAlgebra.coord s).comp (exteriorCoordProj b i) =
+      b.ExteriorAlgebra.coord s := by
+    apply b.ExteriorAlgebra.ext
+    intro t
+    by_cases hit : i ∈ t
+    · rw [LinearMap.comp_apply, exteriorCoordProj_basis_of_mem b i t hit]
+    · rw [LinearMap.comp_apply, exteriorCoordProj_basis_of_not_mem b i t hit, map_zero]
+      simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
+      split_ifs with hts
+      · subst t
+        exact (hit hi).elim
+      · rfl
+  exact LinearMap.congr_fun hmap x
+
+private theorem eq_algebraMap_of_all_contractLeft_eq_zero {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (x : ExteriorAlgebra R M)
+    (hx : ∀ d : Module.Dual R M,
+      contractLeft (Q := (0 : QuadraticForm R M)) d x = 0) :
+    x = algebraMap R (ExteriorAlgebra R M) (b.ExteriorAlgebra.repr x ∅) := by
+  have hbempty : b.ExteriorAlgebra (∅ : Finset (Fin n)) = 1 := by
+    rw [ExteriorAlgebra.basis_apply]
+    simp
+  apply b.ExteriorAlgebra.repr.injective
+  ext s
+  rw [Algebra.algebraMap_eq_smul_one, ← hbempty, map_smul,
+    Module.Basis.repr_self, Finsupp.smul_single, Finsupp.single_apply]
+  by_cases hs : s = ∅
+  · subst s
+    simp
+  · obtain ⟨i, hi⟩ := Finset.nonempty_iff_ne_empty.mpr hs
+    have hproject : exteriorCoordProj b i x = 0 := by
+      rw [exteriorCoordProj, LinearMap.comp_apply, hx, LinearMap.mulLeft_apply, mul_zero]
+    have hcoord := exteriorCoordProj_repr_of_mem b i s hi x
+    rw [hproject, map_zero, Finsupp.zero_apply] at hcoord
+    rw [← hcoord]
+    simp [Ne.symm hs]
+
+end Exterior
+
+section Scalar
+
+variable {K : Type u} [Field K] [Module K M] [FiniteDimensional K M]
+  (Q : QuadraticForm K M) [Invertible (2 : K)]
+
+/-- A Clifford element annihilated by every left contraction is a scalar. -/
+theorem exists_eq_algebraMap_of_contractLeft_eq_zero (x : CliffordAlgebra Q)
+    (hx : ∀ d : Module.Dual K M, contractLeft d x = 0) :
+    ∃ r : K, x = algebraMap K (CliffordAlgebra Q) r := by
+  let b := Module.finBasis K M
+  let y : ExteriorAlgebra K M := equivExterior Q x
+  have hycontract (d : Module.Dual K M) :
+      contractLeft (Q := (0 : QuadraticForm K M)) d y = 0 := by
+    dsimp only [y, equivExterior, changeFormEquiv_apply]
+    rw [changeFormEquiv_apply]
+    rw [← changeForm_contractLeft changeForm.associated_neg_proof d x, hx, map_zero]
+  let r := b.ExteriorAlgebra.repr y ∅
+  refine ⟨r, ?_⟩
+  apply (equivExterior Q).injective
+  simpa [y, r] using eq_algebraMap_of_all_contractLeft_eq_zero b y hycontract
+
+/-- An even Clifford element that commutes with every generating vector is a scalar. -/
+theorem exists_eq_algebraMap_of_mem_even_of_commute
+    (hQ : Q.Nondegenerate) (x : CliffordAlgebra Q) (hx_even : x ∈ even Q)
+    (hx_comm : ∀ v : M, Commute x (ι Q v)) :
+    ∃ r : K, x = algebraMap K (CliffordAlgebra Q) r := by
+  let B : LinearMap.BilinForm K M := QuadraticMap.associated Q
+  have hB : B.Nondegenerate := by
+    simpa only [B] using QuadraticMap.nondegenerate_associated_iff.mpr hQ
+  apply exists_eq_algebraMap_of_contractLeft_eq_zero Q x
+  intro d
+  obtain ⟨v, rfl⟩ := (B.toDual hB).surjective d
+  rw [show B.toDual hB v = Q.associated v from
+    LinearMap.ext fun w ↦ (LinearMap.BilinForm.toDual_def hB).trans (by rfl)]
+  exact contractLeft_associated_eq_zero_of_commute_of_mem_even Q hx_even hx_comm v
+
+omit [FiniteDimensional K M] in
+private theorem commute_ι_of_mem_ker_spinToOrthogonal
+    (x : spinGroup Q) (hx : x ∈ MonoidHom.ker (spinToOrthogonal Q)) (v : M) :
+    Commute (x : CliffordAlgebra Q) (ι Q v) := by
+  rw [MonoidHom.mem_ker] at hx
+  have hfix : spinVectorAction Q x v = v := by
+    have h := congrArg
+      (fun g : QuadraticMap.orthogonalGroup Q => ((g : M ≃ₗ[K] M) v)) hx
+    rw [coe_spinToOrthogonal_apply] at h
+    simpa using h
+  have hconj :
+      (x : CliffordAlgebra Q) * ι Q v * star (x : CliffordAlgebra Q) = ι Q v := by
+    rw [← ι_spinVectorAction_apply Q x v, hfix]
+  rw [commute_iff_eq]
+  calc
+    (x : CliffordAlgebra Q) * ι Q v =
+        ((x : CliffordAlgebra Q) * ι Q v * star (x : CliffordAlgebra Q)) * x := by
+          rw [mul_assoc, spinGroup.star_mul_self_of_mem x.2, mul_one]
+    _ = ι Q v * x := by rw [hconj]
+
+private theorem exists_coe_eq_algebraMap_of_mem_ker_spinToOrthogonal
+    (hQ : Q.Nondegenerate) (x : spinGroup Q)
+    (hx : x ∈ MonoidHom.ker (spinToOrthogonal Q)) :
+    ∃ r : K, (x : CliffordAlgebra Q) = algebraMap K (CliffordAlgebra Q) r := by
+  exact exists_eq_algebraMap_of_mem_even_of_commute Q hQ x (spinGroup.mem_even x.2)
+    (commute_ι_of_mem_ker_spinToOrthogonal Q x hx)
+
+private theorem coe_eq_one_or_eq_neg_one_of_mem_ker_spinToOrthogonal
+    (hQ : Q.Nondegenerate) (x : spinGroup Q)
+    (hx : x ∈ MonoidHom.ker (spinToOrthogonal Q)) :
+    (x : CliffordAlgebra Q) = 1 ∨ (x : CliffordAlgebra Q) = -1 := by
+  obtain ⟨r, hr⟩ := exists_coe_eq_algebraMap_of_mem_ker_spinToOrthogonal Q hQ x hx
+  have hr_sq : r * r = 1 := by
+    apply algebraMap_injective Q
+    simpa only [hr, star_algebraMap, map_mul, map_one] using
+      spinGroup.star_mul_self_of_mem x.2
+  rcases (mul_self_eq_one_iff.mp hr_sq) with rfl | rfl
+  · left
+    simpa using hr
+  · right
+    simpa using hr
+
+end Scalar
+
+section NegOne
+
+/-- A Spin element whose Clifford value is `-1` lies in the kernel of the Spin action. -/
+theorem mem_ker_spinToSpecialOrthogonal_of_coe_eq_neg_one
+    [Invertible (2 : R)] (x : spinGroup Q) (h : (x : CliffordAlgebra Q) = -1) :
+    x ∈ MonoidHom.ker (spinToSpecialOrthogonal Q) := by
+  rw [MonoidHom.mem_ker]
+  apply Subtype.ext
+  apply LinearEquiv.ext
+  intro m
+  rw [coe_spinToSpecialOrthogonal_apply]
+  apply ι_injective Q
+  rw [ι_spinVectorAction_apply]
+  simp [h]
+
+namespace spinGroup
+
+variable {K : Type u} [Field K] [Module K M]
+
+/-- The scalar `-1` lies in the kernel of the Spin action. -/
+theorem negOne_mem_ker_spinToSpecialOrthogonal
+    (Q : QuadraticForm K M) [Invertible (2 : K)] (hQ : Q ≠ 0) :
+    negOne Q hQ ∈ MonoidHom.ker (spinToSpecialOrthogonal Q) :=
+  mem_ker_spinToSpecialOrthogonal_of_coe_eq_neg_one Q _ (coe_negOne Q hQ)
+
+/-- The scalar `-1` acts trivially on the quadratic space. -/
+@[simp]
+theorem spinToSpecialOrthogonal_negOne
+    (Q : QuadraticForm K M) [Invertible (2 : K)] (hQ : Q ≠ 0) :
+    spinToSpecialOrthogonal Q (negOne Q hQ) = 1 :=
+  MonoidHom.mem_ker.mp (negOne_mem_ker_spinToSpecialOrthogonal Q hQ)
+
+end spinGroup
+
+end NegOne
+
+section Kernel
+
+variable {K : Type u} [Field K] [Module K M]
+
+theorem nondegenerate_ne_zero [Nontrivial M]
+    (Q : QuadraticForm K M) (hQ : Q.Nondegenerate) : Q ≠ 0 := by
+  intro hzero
+  obtain ⟨v, hv⟩ := exists_ne (0 : M)
+  apply hv
+  have hm : v ∈ Q.radical := by
+    rw [hzero, QuadraticMap.mem_radical_iff']
+    simp
+  rwa [hQ.radical_eq_bot, Submodule.mem_bot] at hm
+
+variable [FiniteDimensional K M]
+
+/-- A Spin element lies in the kernel of the special-orthogonal action exactly when it is
+the scalar `1` or the canonical scalar `-1`. -/
+theorem mem_ker_spinToSpecialOrthogonal_iff
+    (Q : QuadraticForm K M) [Invertible (2 : K)] [Nontrivial M]
+    (hQ : Q.Nondegenerate)
+    (x : spinGroup Q) :
+    x ∈ MonoidHom.ker (spinToSpecialOrthogonal Q) ↔
+      x = 1 ∨ x = spinGroup.negOne Q (nondegenerate_ne_zero Q hQ) := by
+  constructor
+  · intro hx
+    rcases coe_eq_one_or_eq_neg_one_of_mem_ker_spinToOrthogonal Q hQ x
+      (ker_spinToSpecialOrthogonal Q ▸ hx) with h | h
+    · left
+      apply Subtype.ext
+      exact h
+    · right
+      apply Subtype.ext
+      simpa using h
+  · rintro (rfl | rfl)
+    · exact Subgroup.one_mem _
+    · exact spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q (nondegenerate_ne_zero Q hQ)
+
+/-- The kernel of the Spin action on a positive-dimensional finite nondegenerate quadratic space
+over a field where `2` is invertible has cardinality two. -/
+theorem card_ker_spinToSpecialOrthogonal (hM : 0 < Module.finrank K M)
+    (Q : QuadraticForm K M) [Invertible (2 : K)] (hQ : Q.Nondegenerate) :
+    Nat.card (MonoidHom.ker (spinToSpecialOrthogonal Q)) = 2 := by
+  let _ : Nontrivial M := Module.nontrivial_of_finrank_pos hM
+  rw [Nat.card_eq_two_iff' (1 : MonoidHom.ker (spinToSpecialOrthogonal Q))]
+  have hQ0 := nondegenerate_ne_zero Q hQ
+  let z : MonoidHom.ker (spinToSpecialOrthogonal Q) :=
+    ⟨spinGroup.negOne Q hQ0, spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q hQ0⟩
+  refine ⟨z, ?_, ?_⟩
+  · intro hz
+    exact spinGroup.negOne_ne_one Q hQ0 (congrArg Subtype.val hz)
+  · intro y hy
+    apply Subtype.ext
+    rcases (mem_ker_spinToSpecialOrthogonal_iff Q hQ y).mp y.2 with h | h
+    · exfalso
+      apply hy
+      apply Subtype.ext
+      exact h
+    · simpa [z] using h
+
+end Kernel
+
+end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -98,12 +98,6 @@ theorem negOne_mul_self (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
   apply Subtype.ext
   simp
 
-/-- Reversion fixes the canonical scalar `-1`. -/
-@[simp]
-theorem star_negOne (Q : QuadraticForm K M) (hQ : Q ≠ 0) :
-    star (negOne Q hQ : CliffordAlgebra Q) = negOne Q hQ := by
-  simp
-
 /-- The canonical scalar `-1` in the Spin group is not the identity when `2` is invertible. -/
 theorem negOne_ne_one (Q : QuadraticForm K M) [Invertible (2 : K)] (hQ : Q ≠ 0) :
     negOne Q hQ ≠ 1 := by

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
@@ -19,6 +19,8 @@ remains canonical.
 
 * `TauCeti.CliffordAlgebra.spinToSpecialOrthogonal` is the Spin action with codomain restricted to
   the special orthogonal group.
+* `TauCeti.CliffordAlgebra.ker_spinToSpecialOrthogonal` identifies its kernel with that of the
+  orthogonal Spin action.
 * `TauCeti.CliffordAlgebra.coe_spinToSpecialOrthogonal_apply` identifies its underlying action
   with the Spin action on the quadratic module.
 
@@ -231,6 +233,13 @@ noncomputable def spinToSpecialOrthogonal (Q : QuadraticForm R M) :
     (QuadraticMap.specialOrthogonalGroup Q) fun x =>
       (QuadraticMap.mem_specialOrthogonalGroup_iff).2
         ⟨(spinToOrthogonal Q x).2, det_spinToOrthogonal_eq_one Q x⟩)
+
+/-- Restricting the codomain of the Spin action to the special orthogonal group does not change
+its kernel. -/
+theorem ker_spinToSpecialOrthogonal (Q : QuadraticForm R M) :
+    MonoidHom.ker (spinToSpecialOrthogonal Q) = MonoidHom.ker (spinToOrthogonal Q) := by
+  rw [spinToSpecialOrthogonal, MonoidHom.ker_codRestrict,
+    MonoidHom.ker_comp_of_injective _ _ (Subgroup.subtype_injective _)]
 
 /-- A Spin element has the same underlying action whether regarded as orthogonal or special
 orthogonal. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
@@ -236,6 +236,7 @@ noncomputable def spinToSpecialOrthogonal (Q : QuadraticForm R M) :
 
 /-- Restricting the codomain of the Spin action to the special orthogonal group does not change
 its kernel. -/
+@[simp]
 theorem ker_spinToSpecialOrthogonal (Q : QuadraticForm R M) :
     MonoidHom.ker (spinToSpecialOrthogonal Q) = MonoidHom.ker (spinToOrthogonal Q) := by
   rw [spinToSpecialOrthogonal, MonoidHom.ker_codRestrict,

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.QuadraticForm.Radical
+
+/-!
+# Radical API for quadratic forms
+
+This file records general consequences of nondegeneracy for quadratic forms.
+-/
+
+public section
+
+namespace QuadraticMap.Nondegenerate
+
+variable {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+
+/-- A nondegenerate quadratic form on a nontrivial module is nonzero. -/
+theorem ne_zero [Nontrivial M] {Q : QuadraticForm R M} (hQ : Q.Nondegenerate) : Q ≠ 0 := by
+  intro hzero
+  obtain ⟨v, hv⟩ := exists_ne (0 : M)
+  apply hv
+  have hm : v ∈ Q.radical := by
+    rw [hzero, QuadraticMap.mem_radical_iff']
+    simp
+  rwa [hQ.radical_eq_bot, Submodule.mem_bot] at hm
+
+end QuadraticMap.Nondegenerate


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Identifies the kernel of the Spin action.

- Constructs the canonical scalar `-1` at the Pin-action boundary.
- Proves that an even Clifford element commuting with every vector is scalar.
- Characterizes the kernel as `{1, -1}` and derives its cardinality.

## Roadmap target

Completes Layer 2 `card_ker_spinToSpecialOrthogonal`:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L126-L132

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#card_ker_spinToSpecialOrthogonal"}-->

## Verification

Full builds, `--iofail`, axiom and module audits, environment lint, public consumers, bare-`simp` probes, collision checks, structural golf, and fresh aggregate `2+1` review pass at `78d11edf57e68c2e4027183cc1cffdc8ab86bbde`.

## Scale and generality

Changes three files by +471/−1 lines. The negative Spin element starts over a commutative ring with a unit-valued vector, specializes to nonzero forms over fields, and only the kernel characterization adds finite dimension and nondegeneracy.

## Scope

- **Consumes:** the merged Spin-to-special-orthogonal action, Clifford contractions, and exterior-basis equivalence.
- **Provides:** the canonical negative Spin element, reusable scalarity and kernel-comparison lemmas, the `{1, -1}` kernel characterization, and cardinality two.
- **Fits:** completes the kernel half of the Layer 2 Spin double cover and supplies the boundary for its short exact sequence.
- **Boundary:** exact-sequence packaging, spinor norm, and covering-space consequences remain downstream.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [a66b04d](https://github.com/TauCetiProject/TauCetiReview/commit/a66b04d97721565b13c8abe07f750fb1d2959ad5) · local 2+1 review @ [4a3ce2b](https://github.com/utensil/formal-land/commit/4a3ce2ba031ff1c2bece478a842ba6b1e8b74364) fixed: placement (1), proof-quality (1), ut-aggregate-reuse (1)</sub>
