### PR TITLE
chore(EllipticCurve): style pass over Aut.lean

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Aut.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Aut.lean
@@ -117,9 +117,7 @@ private lemma u_eq_one_or_eq_neg_one (hc4 : E.c₄ ≠ 0) (hc6 : E.c₆ ≠ 0) {
     have h := congrArg c₆ hCE
     rwa [variableChange_c₆, Units.val_inv_eq_inv_val, mul_eq_right₀ hc6, inv_pow, inv_eq_one] at h
   have hu2 : (C.u : K) * (C.u : K) = 1 := by linear_combination hu6 - (C.u : K) ^ 2 * hu4
-  rcases mul_self_eq_one_iff.mp hu2 with h | h
-  · exact .inl (Units.val_eq_one.mp h)
-  · exact .inr (Units.val_eq_neg_one.mp h)
+  exact (mul_self_eq_one_iff.mp hu2).imp Units.val_eq_one.mp Units.val_eq_neg_one.mp
 
 /-- If `c₄ ≠ 0` and `c₆ ≠ 0` then the only admissible changes of variables fixing `E` are `1` and
 `negVariableChange E`. This is the form of `Aut(E) = {±1}` phrased via `c₄, c₆` (equivalent to
@@ -158,7 +156,7 @@ injection — `c₄`, `c₆` by `map_c₄`/`map_c₆`, the fixing equation by
 theorem eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq
     (hc4 : E.c₄ ≠ 0) (hc6 : E.c₆ ≠ 0) {C : VariableChange A} (hC : C • E = E) :
     C = 1 ∨ C = E.negVariableChange := by
-  set φ := algebraMap A (FractionRing A) with hφ
+  set φ := algebraMap A (FractionRing A)
   have hinj : Function.Injective φ := IsFractionRing.injective A (FractionRing A)
   have hC' : (C.map φ) • (E.map φ) = E.map φ := by
     rw [map_variableChange, hC]
@@ -179,7 +177,6 @@ theorem eq_one_or_eq_negVariableChange_of_smul_eq [E.IsElliptic] (hj₀ : E.j �
     C = 1 ∨ C = E.negVariableChange :=
   E.eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq
     (E.j_eq_zero_iff.not.mp hj₀) (E.j_eq_1728_iff.not.mp hj₁₇₂₈) hC
-
 
 /-! ### The automorphism group -/
 


### PR DESCRIPTION
A full style-and-golf pass over `AlgebraicGeometry/EllipticCurve/Aut.lean`, declaration by
declaration. The file is an adaptation of FLT's `Aut.lean` and was already close to mathlib
quality, so the yield is small and entirely local; nothing mathematical changes and no statement
is touched.

Three defects:

`eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq` opened with
`set φ := algebraMap A (FractionRing A) with hφ`, and `hφ` was never used. The equation binding is
dropped. The `set` itself stays: `φ` is referenced six times in the proof, so the abbreviation
earns its place even though there is nothing in the goal for `set` to fold.

`u_eq_one_or_eq_neg_one` finished by splitting `mul_self_eq_one_iff.mp hu2` into two branches and
applying one `Units.val_eq_*` lemma in each. The two branches differ only in which lemma they
apply, which is what `Or.imp` is for, so the split collapses to a single line.

A stray second blank line before the `### The automorphism group` section header is removed.

Everything else was already correct and is recorded here so the audit is not repeated: no
`set_option`, no `λ`, no `$`, no `push_neg`, no line over 100 codepoints, no `show` in tactic
position, no bare non-terminal `simp`, and no `≥`/`>` in Lean code (the only `>` in the file is
the `<;>` combinator). Every public declaration has a docstring, and the three helper lemmas are
already `private`.

Two changes a generic mathlib-style pass would have made were considered and deliberately not
made. The private helpers keep their docstrings: this repository's `documentation` rubric wants
them, and stripping them would trade a real review finding for a style preference. The terminal
`simp only` in `autGroupMulEquiv_symm_apply_ofAdd_one` keeps its explicit lemma list rather than
being unsqueezed to a bare `simp`; the squeezed form is the more robust of the two and unsqueezing
buys nothing here.

One near-duplication was examined and left alone. In `u_eq_one_or_eq_neg_one` the `hu4` and `hu6`
blocks run the same four-lemma rewrite chain against `c₄` and `c₆`. Factoring the shared tail out
as a helper needs the two curve-specific rewrites to happen at the call site first, which makes
both call sites longer than the lines the helper saves.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: EllipticCurves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
