### PR TITLE
feat: the Schur multiplier and the class of a projective representation

### DIFF
--- a/TauCeti/RepresentationTheory/ProjectiveRepresentation/Basic.lean
+++ b/TauCeti/RepresentationTheory/ProjectiveRepresentation/Basic.lean
@@ -144,6 +144,13 @@ theorem rescale (h : IsProjectiveRep ρ α) (c : G → kˣ) (hc : c 1 = 1) :
     simp only [LinearEquiv.trans_apply, LinearEquiv.smulOfUnit_apply, map_smul, h.mul_apply,
       smul_smul, ← Units.val_mul, hunit]
 
+/-- Transporting a projective representation along an equality of factor sets. Rescaling delivers
+the new factor set in a form that has still to be recognized as the intended one, and this is that
+rewriting step. -/
+theorem congr_factorSet {β : G → G → kˣ} (h : IsProjectiveRep ρ α) (hα : α = β) :
+    IsProjectiveRep ρ β :=
+  hα ▸ h
+
 /-- A linear representation, presented as a homomorphism into the group of linear automorphisms, is
 a projective representation with trivial factor set. -/
 theorem of_monoidHom (π : G →* (V ≃ₗ[k] V)) : IsProjectiveRep (⇑π) (1 : G → G → kˣ) where

--- a/TauCeti/RepresentationTheory/ProjectiveRepresentation/Basic.lean
+++ b/TauCeti/RepresentationTheory/ProjectiveRepresentation/Basic.lean
@@ -23,7 +23,7 @@ displayed relation for every `α`, so without them nothing below is true.
 Working with a normalized lift rather than with a homomorphism `G → PGL(V)` keeps the theory
 basis-free and puts the factor set in the statement, where the rest of the theory needs it.
 
-That `α` is a factor set is rarely something to check by hand: as soon as `k` acts faithfully on
+That `α` is a factor set is rarely something to check by hand: as soon as `kˣ` acts faithfully on
 `V` it is *determined* by `ρ`, and `TauCeti.IsProjectiveRep.of_map_one_mul_apply` derives its
 normalization and its multiplicative `2`-cocycle identity from associativity of composition, so
 there only the two conditions on `ρ` remain. The main results then identify projective
@@ -45,7 +45,7 @@ itself becomes the **twisted regular representation**, which realizes every fact
 
 ## Main results
 
-* `TauCeti.IsProjectiveRep.of_map_one_mul_apply`: when `k` acts faithfully on `V` the factor-set
+* `TauCeti.IsProjectiveRep.of_map_one_mul_apply`: when `kˣ` acts faithfully on `V` the factor-set
   axioms are automatic, and `TauCeti.IsProjectiveRep.factorSet_eq`: there the factor set is
   determined by the lift.
 * `TauCeti.IsProjectiveRep.rescale`: rescaling the lift by `c : G → kˣ` multiplies the factor set by
@@ -85,7 +85,7 @@ variable [CommSemiring k] [Monoid G] [AddCommMonoid V] [Module k V]
 that is multiplicative up to the scalars `α`. Invertibility of the `ρ g` is carried by the type
 `V ≃ₗ[k] V` and normalization by `map_one`; without them the zero family would satisfy `mul_apply`
 for every `α`, and on the zero module it still does, which is why the factor-set axioms are
-recorded here rather than left to be derived. When `k` acts faithfully on `V` they *are*
+recorded here rather than left to be derived. When `kˣ` acts faithfully on `V` they *are*
 derivable, and `TauCeti.IsProjectiveRep.of_map_one_mul_apply` derives them. -/
 structure IsProjectiveRep (ρ : G → V ≃ₗ[k] V) (α : G → G → kˣ) : Prop where
   /-- The scalars are a normalized multiplicative `2`-cocycle. -/
@@ -144,13 +144,6 @@ theorem rescale (h : IsProjectiveRep ρ α) (c : G → kˣ) (hc : c 1 = 1) :
     simp only [LinearEquiv.trans_apply, LinearEquiv.smulOfUnit_apply, map_smul, h.mul_apply,
       smul_smul, ← Units.val_mul, hunit]
 
-/-- Transporting a projective representation along an equality of factor sets. Rescaling delivers
-the new factor set in a form that has still to be recognized as the intended one, and this is that
-rewriting step. -/
-theorem congr_factorSet {β : G → G → kˣ} (h : IsProjectiveRep ρ α) (hα : α = β) :
-    IsProjectiveRep ρ β :=
-  hα ▸ h
-
 /-- A linear representation, presented as a homomorphism into the group of linear automorphisms, is
 a projective representation with trivial factor set. -/
 theorem of_monoidHom (π : G →* (V ≃ₗ[k] V)) : IsProjectiveRep (⇑π) (1 : G → G → kˣ) where
@@ -176,18 +169,20 @@ end IsProjectiveRep
 end Defs
 
 /-!
-## For a faithful scalar action the factor-set axioms are automatic
+## For a faithful action of the units the factor-set axioms are automatic
 
-When `k` acts faithfully on `V` the scalars in the defining relation are determined by the lift,
+When `kˣ` acts faithfully on `V` the scalars in the defining relation are determined by the lift,
 and associativity of composition forces the cocycle identity on them. So there a normalized lift
 that is multiplicative up to `α` is already a projective representation, and its factor set is
-unique. Faithfulness is exactly what lets a scalar be read off from its action; a nonzero
-torsion-free module, a nonzero vector space in particular, has it.
+unique. Faithfulness is exactly what lets a scalar be read off from its action, and only the
+scalars in `kˣ` are ever compared, so `[FaithfulSMul kˣ V]` is what is asked for; `k` acting
+faithfully — as it does on a nonzero torsion-free module, a nonzero vector space in particular —
+supplies it.
 -/
 
 section Faithful
 
-variable [CommSemiring k] [Monoid G] [AddCommMonoid V] [Module k V] [FaithfulSMul k V]
+variable [CommSemiring k] [Monoid G] [AddCommMonoid V] [Module k V] [FaithfulSMul kˣ V]
   {ρ : G → V ≃ₗ[k] V} {α : G → G → kˣ}
 
 namespace IsProjectiveRep
@@ -201,7 +196,7 @@ theorem of_map_one_mul_apply (h₁ : ρ 1 = 1)
     IsProjectiveRep ρ α where
   isFactorSet :=
     { cocycle g₁ g₂ g₃ := by
-        refine Units.ext (FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_)
+        refine FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_
         obtain ⟨y, rfl⟩ := (ρ (g₁ * g₂ * g₃)).surjective x
         have outer : ρ g₁ (ρ g₂ (ρ g₃ y))
             = ((α g₁ g₂ : k) * α (g₁ * g₂) g₃) • ρ (g₁ * g₂ * g₃) y := by
@@ -209,29 +204,30 @@ theorem of_map_one_mul_apply (h₁ : ρ 1 = 1)
         have inner : ρ g₁ (ρ g₂ (ρ g₃ y))
             = ((α g₂ g₃ : k) * α g₁ (g₂ * g₃)) • ρ (g₁ * g₂ * g₃) y := by
           rw [h₂ g₂ g₃, map_smul, h₂ g₁ (g₂ * g₃), smul_smul, mul_assoc]
-        rw [Units.val_mul, Units.val_mul, ← inner, outer, mul_comm]
+        rw [Units.smul_def, Units.smul_def, Units.val_mul, Units.val_mul, ← inner, outer, mul_comm]
       one_left g := by
-        refine Units.ext (FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_)
+        refine FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_
         obtain ⟨y, rfl⟩ := (ρ g).surjective x
         have hy := h₂ 1 g y
         rw [h₁, one_mul] at hy
-        simpa using hy.symm
+        simpa [Units.smul_def] using hy.symm
       one_right g := by
-        refine Units.ext (FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_)
+        refine FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_
         obtain ⟨y, rfl⟩ := (ρ g).surjective x
         have hy := h₂ g 1 y
         rw [h₁, mul_one] at hy
-        simpa using hy.symm }
+        simpa [Units.smul_def] using hy.symm }
   map_one := h₁
   mul_apply := h₂
 
-/-- **The factor set is determined by the lift**: for a faithful scalar action a projective
+/-- **The factor set is determined by the lift**: for a faithful action of the units a projective
 representation has at most one factor set, so `α` is not extra data but an invariant of `ρ`. -/
 theorem factorSet_eq {β : G → G → kˣ} (h : IsProjectiveRep ρ α) (h' : IsProjectiveRep ρ β) :
     α = β := by
   funext g₁ g₂
-  refine Units.ext (FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_)
+  refine FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_
   obtain ⟨y, rfl⟩ := (ρ (g₁ * g₂)).surjective x
+  simp only [Units.smul_def]
   exact (h.mul_apply g₁ g₂ y).symm.trans (h'.mul_apply g₁ g₂ y)
 
 end IsProjectiveRep

--- a/TauCeti/RepresentationTheory/ProjectiveRepresentation/Extension.lean
+++ b/TauCeti/RepresentationTheory/ProjectiveRepresentation/Extension.lean
@@ -114,6 +114,21 @@ abbrev trivialMulDistribMulAction (G M : Type*) [Monoid G] [Monoid M] :
     MulDistribMulAction G M :=
   MulDistribMulAction.compHom M (1 : G →* MulAut M)
 
+section TrivialActionSmul
+
+attribute [local instance] trivialMulDistribMulAction
+
+/-- Under `TauCeti.trivialMulDistribMulAction` every element is fixed. This is the triviality
+hypothesis that `TauCeti.FactorSet.isFactorSet_curry`, `TauCeti.IsFactorSet.toFactorSet` and
+`TauCeti.FactorSet.inl_range_le_center` take, supplied once so that their callers can name a
+constant rather than an inlined proof. -/
+@[simp]
+theorem trivialMulDistribMulAction_smul {G M : Type*} [Monoid G] [Monoid M] (g : G) (a : M) :
+    g • a = a :=
+  rfl
+
+end TrivialActionSmul
+
 section GeneralAction
 
 variable [MulDistribMulAction G kˣ]
@@ -384,7 +399,7 @@ theorem IsProjectiveRep.exists_factorSet_linearization {α : G → G → kˣ}
         (∀ a : kˣ, π (FactorSet.inl β a) = LinearEquiv.smulOfUnit a) ∧
           ∀ g : G, π (β.canonicalSection g) = ρ g := by
   have hα : IsFactorSet α := hρ.isFactorSet
-  have htriv (g : G) (a : kˣ) : g • a = a := rfl
+  have htriv (g : G) (a : kˣ) : g • a = a := trivialMulDistribMulAction_smul g a
   have hρ' : IsProjectiveRep ρ (Function.curry ⇑(IsFactorSet.toFactorSet α htriv)) := by
     rwa [IsFactorSet.curry_coe_toFactorSet]
   exact ⟨IsFactorSet.toFactorSet α htriv, hρ'.linearization htriv,

--- a/TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean
+++ b/TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean
@@ -183,8 +183,10 @@ theorem IsProjectiveRep.cohomologyClass_def (h : IsProjectiveRep ρ α) :
     h.cohomologyClass = h.factorSet.cohomologyClass :=
   (rfl)
 
-/-- The class of a projective representation depends on the lift only through its factor set. -/
-theorem IsProjectiveRep.cohomologyClass_congr {ρ₁ ρ₂ : G → V ≃ₗ[k] V} {α₁ α₂ : G → G → kˣ}
+/-- The class of a projective representation depends on the lift only through its factor set — not
+even through the module it acts on. -/
+theorem IsProjectiveRep.cohomologyClass_congr {W : Type*} [AddCommMonoid W] [Module k W]
+    {ρ₁ : G → V ≃ₗ[k] V} {ρ₂ : G → W ≃ₗ[k] W} {α₁ α₂ : G → G → kˣ}
     (h₁ : IsProjectiveRep ρ₁ α₁) (h₂ : IsProjectiveRep ρ₂ α₂) (hα : α₁ = α₂) :
     h₁.cohomologyClass = h₂.cohomologyClass := by
   subst hα
@@ -266,9 +268,8 @@ theorem IsProjectiveRep.exists_monoidHom_of_cohomologyClass_eq_zero (h : IsProje
   refine LinearEquiv.ext fun v ↦ ?_
   have hg : hrs.toMonoidHom g = (ρ g).trans (LinearEquiv.smulOfUnit (x g)⁻¹) :=
     congrFun hrs.coe_toMonoidHom g
-  rw [LinearEquiv.trans_apply, hg, LinearEquiv.smulOfUnit_apply, LinearEquiv.trans_apply,
-    LinearEquiv.smulOfUnit_apply, smul_smul, ← Units.val_mul, mul_inv_cancel, Units.val_one,
-    one_smul]
+  -- rescaling by `(x g)⁻¹` and then by `x g` multiplies by `↑(x g) * ↑(x g)⁻¹ = 1`
+  simp [hg, smul_smul]
 
 /-- **A linear representation rescaled by scalars has vanishing class.** Faithfulness is what makes
 the factor set of the rescaled lift *be* the coboundary of `c`, rather than merely some factor set

--- a/TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean
+++ b/TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean
@@ -1,0 +1,332 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.GroupTheory.GroupExtension.Cohomology
+public import TauCeti.RepresentationTheory.ProjectiveRepresentation.Extension
+
+/-!
+# The Schur multiplier and the class of a projective representation
+
+The factor set `α` of a projective representation `ρ : G → (V ≃ₗ[k] V)` is a normalized
+multiplicative `2`-cocycle of `G` with values in `kˣ`, so it has a class in
+
+`H²(G, kˣ) = TauCeti.schurMultiplier k G`,
+
+the **Schur multiplier** of `G` over `k`. The factor set itself is not an invariant of the
+projective action: replacing the lift `ρ` by `g ↦ c g • ρ g` multiplies `α` by the coboundary of
+`c`. Its class is, and that is the point of this file.
+
+Because the lift can be rescaled, the honest statements are these. The class is unchanged by
+rescaling (`TauCeti.IsProjectiveRep.cohomologyClass_rescale`), so two lifts of the same projective
+action have the same class (`TauCeti.IsProjectiveRep.cohomologyClass_eq_of_eq_smul`). The class
+**vanishes exactly when the projective representation is a linear representation in disguise**
+(`TauCeti.IsProjectiveRep.cohomologyClass_eq_zero_iff`): the obstruction to rescaling `ρ` into a
+homomorphism `G →* (V ≃ₗ[k] V)` is precisely the class of its factor set. Every class occurs
+(`TauCeti.exists_isProjectiveRep_cohomologyClass_eq`), already on the twisted regular
+representation, so `H²(G, kˣ)` is exactly the set of classes of projective representations of `G`
+over `k`. And the twisted monoid algebra `k_α[G]` sees only the class
+(`TauCeti.TwistedMonoidAlgebra.nonempty_algEquiv_of_cohomologyClass_eq`).
+
+Two of these need `k` to act faithfully on `V`, and genuinely so: on `V = 0` every lift is the zero
+map and every normalized factor set whatsoever is a factor set for it, so nothing about `α` can be
+read off `ρ` there. The two directions of the lifting criterion are therefore also recorded
+separately, the direction that does not need faithfulness being stated for an arbitrary module.
+
+## The action on the scalars
+
+`TauCeti.FactorSet` and its cohomology class are set up for an arbitrary `MulDistribMulAction` of
+`G` on the coefficients, whereas a projective representation carries none: its factor set takes
+values in the *central* `kˣ`. So the whole file runs under the trivial action
+`TauCeti.trivialMulDistribMulAction`, installed as a local instance exactly as in
+`TauCeti/RepresentationTheory/ProjectiveRepresentation/Extension.lean`. The roadmap spells the
+coefficient module `Rep.trivial ℤ G (Additive kˣ)`; `Rep.ofMulDistribMulAction G kˣ` for the
+trivial action is that module, and it is the spelling that both Mathlib's multiplicative interface
+to `groupCohomology.cocycles₂` and `TauCeti.FactorSet.cohomologyClass` are stated in, so it is the
+one used here.
+
+`Rep ℤ G` puts the group and the coefficients in the universe of `ℤ`, so `k` and `G` are pinned to
+`Type`; this is the same restriction `TauCeti/GroupTheory/GroupExtension/Cohomology.lean` carries.
+The module `V` stays universe-polymorphic.
+
+`TauCeti.schurMultiplier` deliberately carries no result-type ascription. Writing `ModuleCat ℤ`
+would elaborate the `Ring ℤ` argument by instance search, whereas `groupCohomology.H2` produces it
+from the `CommRing ℤ` of `Rep ℤ G`; the two are the same instance up to unfolding but not
+syntactically, and rewriting across the difference then fails.
+
+## Main definitions
+
+* `TauCeti.schurMultiplier`: the Schur multiplier `H²(G, kˣ)`.
+* `TauCeti.IsProjectiveRep.factorSet`: the factor set of a projective representation, bundled as a
+  `TauCeti.FactorSet` for the trivial action.
+* `TauCeti.IsProjectiveRep.cohomologyClass`: its class in the Schur multiplier.
+
+## Main results
+
+* `TauCeti.IsProjectiveRep.cohomologyClass_of_monoidHom`: a linear representation has vanishing
+  class.
+* `TauCeti.IsProjectiveRep.cohomologyClass_rescale`: rescaling the lift does not move the class,
+  and `TauCeti.IsProjectiveRep.cohomologyClass_eq_of_eq_smul`: two lifts differing by scalars have
+  the same class.
+* `TauCeti.IsProjectiveRep.cohomologyClass_eq_zero_iff`: **the class vanishes exactly when the lift
+  is a linear representation rescaled by scalars**, with
+  `TauCeti.IsProjectiveRep.exists_monoidHom_of_cohomologyClass_eq_zero` and
+  `TauCeti.IsProjectiveRep.cohomologyClass_eq_zero_of_monoidHom` its two directions.
+* `TauCeti.exists_isProjectiveRep_cohomologyClass_eq`: **every class in the Schur multiplier is the
+  class of a projective representation**, so the Schur multiplier is exactly the set of classes of
+  factor sets of projective representations of `G` over `k`.
+* `TauCeti.TwistedMonoidAlgebra.nonempty_algEquiv_of_cohomologyClass_eq`: the twisted monoid algebra
+  depends only on the class.
+
+## References
+
+This is the Schur-multiplier target of Layer 7 of the
+[induction and restriction roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/RepresentationTheory/InductionRestriction/README.md),
+"projective representations, factor sets, and the Schur multiplier", whose `schurMultiplier` is the
+group defined here.
+
+* G. Karpilovsky, *Projective Representations of Finite Groups*, Marcel Dekker (1985), Ch. 1 and 3.
+* I. M. Isaacs, *Character Theory of Finite Groups*, AMS Chelsea (1976), Ch. 11.
+-/
+
+public section
+
+namespace TauCeti
+
+open groupCohomology
+
+/-! ### Rearrangements in a commutative group
+
+The coboundary bookkeeping below is a handful of identities in the commutative group `kˣ`, isolated
+here so that the arguments about factor sets are not interrupted by them. Read `a, b, d` as the
+values of a rescaling at `g₁`, `g₂` and `g₁ * g₂`.
+-/
+
+private theorem coboundary_aux {M : Type*} [CommGroup M] (a b d : M) : b / d * a = a * b * d⁻¹ := by
+  apply Additive.ofMul.injective
+  simp only [ofMul_mul, ofMul_div, ofMul_inv]
+  abel
+
+private theorem coboundary_inv_aux {M : Type*} [CommGroup M] (a b d : M) :
+    a⁻¹ * b⁻¹ * (d⁻¹)⁻¹ * (b / d * a) = 1 := by
+  apply Additive.ofMul.injective
+  simp only [ofMul_mul, ofMul_div, ofMul_inv, ofMul_one]
+  abel
+
+private theorem cohomologous_aux {M : Type*} [CommGroup M] (a b u v z : M)
+    (h : v / z * u = a / b) : a * z = b * (u * v) := by
+  have ha : a = v / z * u * b := div_eq_iff_eq_mul.1 h.symm
+  subst ha
+  apply Additive.ofMul.injective
+  simp only [ofMul_mul, ofMul_div]
+  abel
+
+section TrivialAction
+
+attribute [local instance] trivialMulDistribMulAction
+
+variable {k G : Type} [CommSemiring k] [Group G] {V : Type*} [AddCommMonoid V] [Module k V]
+
+/-- Under `TauCeti.trivialMulDistribMulAction` the units of `k` are fixed by `G`. This is the
+triviality hypothesis that `TauCeti.IsFactorSet.toFactorSet` and
+`TauCeti.FactorSet.isFactorSet_curry` take, supplied once so that the statements below name a
+constant rather than an inlined proof. -/
+theorem trivialMulDistribMulAction_smul (g : G) (a : kˣ) : g • a = a :=
+  rfl
+
+/-- **The Schur multiplier** `H²(G, kˣ)` of a group `G` over a commutative semiring `k`: the second
+cohomology of `G` with coefficients in the units of `k` under the trivial action. By
+`TauCeti.exists_isProjectiveRep_cohomologyClass_eq` and
+`TauCeti.IsProjectiveRep.cohomologyClass_rescale` it is exactly the set of classes of factor sets
+of projective representations of `G` over `k`, equivalently — through
+`TauCeti.FactorSet.cohomologyClassEquiv` — the set of central extensions of `G` by `kˣ` up to
+equivalence. -/
+noncomputable def schurMultiplier (k G : Type) [CommSemiring k] [Group G] :=
+  H2 (Rep.ofMulDistribMulAction G kˣ)
+
+variable {ρ : G → V ≃ₗ[k] V} {α : G → G → kˣ}
+
+/-- The factor set of a projective representation, bundled as a `TauCeti.FactorSet` over the
+trivial action of `G` on `kˣ` — the action for which the extension it names is central. This is
+`TauCeti.IsFactorSet.toFactorSet` applied to the factor-set axioms the projective representation
+carries, so no `TauCeti.IsFactorSet` instance need be in scope. -/
+def IsProjectiveRep.factorSet (h : IsProjectiveRep ρ α) : FactorSet G kˣ :=
+  letI := h.isFactorSet
+  IsFactorSet.toFactorSet α trivialMulDistribMulAction_smul
+
+@[simp]
+theorem IsProjectiveRep.factorSet_apply (h : IsProjectiveRep ρ α) (p : G × G) :
+    h.factorSet p = α p.1 p.2 :=
+  letI := h.isFactorSet
+  IsFactorSet.toFactorSet_apply α trivialMulDistribMulAction_smul p
+
+/-- Transporting a projective representation along an equality of factor sets. Rescaling delivers
+the new factor set in a form that has still to be recognized as the intended one, and this is that
+rewriting step. -/
+theorem IsProjectiveRep.congr_factorSet {β : G → G → kˣ} (h : IsProjectiveRep ρ α) (hα : α = β) :
+    IsProjectiveRep ρ β :=
+  hα ▸ h
+
+/-- **The class of a projective representation in the Schur multiplier**: the class of its factor
+set in `H²(G, kˣ)`. Unlike the factor set itself it depends only on the underlying projective
+action, by `TauCeti.IsProjectiveRep.cohomologyClass_eq_of_eq_smul`. -/
+noncomputable def IsProjectiveRep.cohomologyClass (h : IsProjectiveRep ρ α) :
+    schurMultiplier k G :=
+  h.factorSet.cohomologyClass
+
+/-- The class of a projective representation depends on the lift only through its factor set. -/
+theorem IsProjectiveRep.cohomologyClass_congr {ρ₁ ρ₂ : G → V ≃ₗ[k] V} {α₁ α₂ : G → G → kˣ}
+    (h₁ : IsProjectiveRep ρ₁ α₁) (h₂ : IsProjectiveRep ρ₂ α₂) (hα : α₁ = α₂) :
+    h₁.cohomologyClass = h₂.cohomologyClass := by
+  subst hα
+  rfl
+
+/-- **A linear representation has vanishing class**: its factor set is the trivial one. This is the
+easy half of `TauCeti.IsProjectiveRep.cohomologyClass_eq_zero_iff`, stated before any rescaling and
+so without a faithfulness hypothesis. -/
+theorem IsProjectiveRep.cohomologyClass_of_monoidHom (π : G →* (V ≃ₗ[k] V)) :
+    (IsProjectiveRep.of_monoidHom π).cohomologyClass = 0 := by
+  have h : (IsProjectiveRep.of_monoidHom π).factorSet = FactorSet.trivial G kˣ :=
+    FactorSet.ext fun p ↦ by simp
+  rw [IsProjectiveRep.cohomologyClass, h]
+  exact FactorSet.cohomologyClass_trivial
+
+/-! ### Rescaling the lift -/
+
+/-- **Rescaling the lift does not move the class.** Multiplying `ρ` by units `c : G → kˣ`
+multiplies its factor set by the coboundary of `c` (`TauCeti.IsProjectiveRep.rescale`), and that is
+exactly what `H²` quotients out. -/
+theorem IsProjectiveRep.cohomologyClass_rescale (h : IsProjectiveRep ρ α) (c : G → kˣ)
+    (hc : c 1 = 1) : (h.rescale c hc).cohomologyClass = h.cohomologyClass := by
+  refine (FactorSet.cohomologyClass_eq_iff _ _).2 ⟨c, fun g₁ g₂ ↦ ?_⟩
+  simp only [IsProjectiveRep.factorSet_apply, trivialMulDistribMulAction_smul]
+  rw [mul_div_cancel_right]
+  exact coboundary_aux _ _ _
+
+/-- A lift obtained from another by multiplying by units is again normalized: the scalars take the
+value `1` at `1`. Faithfulness is what lets a scalar be read off from its action. -/
+theorem IsProjectiveRep.eq_one_of_eq_smul [FaithfulSMul k V] {ρ' : G → V ≃ₗ[k] V}
+    {β : G → G → kˣ} (h : IsProjectiveRep ρ α) (h' : IsProjectiveRep ρ' β) (c : G → kˣ)
+    (hc : ∀ g, ρ' g = (ρ g).trans (LinearEquiv.smulOfUnit (c g))) : c 1 = 1 := by
+  refine Units.ext (FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_)
+  have hx : ρ' 1 x = (c 1 : k) • ρ 1 x := by
+    rw [hc 1, LinearEquiv.trans_apply, LinearEquiv.smulOfUnit_apply]
+  rw [h.map_one, h'.map_one] at hx
+  simpa using hx.symm
+
+/-- **Two lifts of the same projective action have the same class.** The hypothesis is that the two
+lifts differ by the units `c`, which is what it means for them to induce the same homomorphism into
+the projective linear group. -/
+theorem IsProjectiveRep.cohomologyClass_eq_of_eq_smul [FaithfulSMul k V] {ρ' : G → V ≃ₗ[k] V}
+    {β : G → G → kˣ} (h : IsProjectiveRep ρ α) (h' : IsProjectiveRep ρ' β) (c : G → kˣ)
+    (hc : ∀ g, ρ' g = (ρ g).trans (LinearEquiv.smulOfUnit (c g))) :
+    h'.cohomologyClass = h.cohomologyClass := by
+  have hc1 : c 1 = 1 := h.eq_one_of_eq_smul h' c hc
+  have hρ : ρ' = fun g ↦ (ρ g).trans (LinearEquiv.smulOfUnit (c g)) := funext hc
+  subst hρ
+  exact (h'.cohomologyClass_congr (h.rescale c hc1) (h'.factorSet_eq (h.rescale c hc1))).trans
+    (h.cohomologyClass_rescale c hc1)
+
+/-! ### The class as the obstruction to linearizing -/
+
+/-- **A projective representation whose class vanishes is a linear representation rescaled by
+scalars.** The factor set is then the coboundary of some `x : G → kˣ`, and dividing the lift by `x`
+turns it into a homomorphism. No faithfulness is needed in this direction. -/
+theorem IsProjectiveRep.exists_monoidHom_of_cohomologyClass_eq_zero (h : IsProjectiveRep ρ α)
+    (h0 : h.cohomologyClass = 0) :
+    ∃ (c : G → kˣ) (π : G →* (V ≃ₗ[k] V)),
+      c 1 = 1 ∧ ∀ g, ρ g = (π g).trans (LinearEquiv.smulOfUnit (c g)) := by
+  obtain ⟨x, hx⟩ := (FactorSet.cohomologyClass_eq_zero_iff h.factorSet).1 h0
+  have hx' : ∀ g₁ g₂ : G, x g₂ / x (g₁ * g₂) * x g₁ = α g₁ g₂ := fun g₁ g₂ ↦ by
+    simpa only [trivialMulDistribMulAction_smul, IsProjectiveRep.factorSet_apply] using hx g₁ g₂
+  have hx1 : x 1 = 1 := by
+    have h11 := hx' 1 1
+    rw [mul_one, h.isFactorSet.one_left] at h11
+    simpa using h11
+  have hrs : IsProjectiveRep (fun g ↦ (ρ g).trans (LinearEquiv.smulOfUnit (x g)⁻¹))
+      (1 : G → G → kˣ) := by
+    refine (h.rescale (fun g ↦ (x g)⁻¹) (by simp [hx1])).congr_factorSet (funext fun g₁ ↦ ?_)
+    funext g₂
+    simp only [Pi.one_apply]
+    rw [← hx' g₁ g₂]
+    exact coboundary_inv_aux _ _ _
+  refine ⟨x, hrs.toMonoidHom, hx1, fun g ↦ ?_⟩
+  refine LinearEquiv.ext fun v ↦ ?_
+  have hg : hrs.toMonoidHom g = (ρ g).trans (LinearEquiv.smulOfUnit (x g)⁻¹) :=
+    congrFun hrs.coe_toMonoidHom g
+  rw [LinearEquiv.trans_apply, hg, LinearEquiv.smulOfUnit_apply, LinearEquiv.trans_apply,
+    LinearEquiv.smulOfUnit_apply, smul_smul, ← Units.val_mul, mul_inv_cancel, Units.val_one,
+    one_smul]
+
+/-- **A linear representation rescaled by scalars has vanishing class.** Faithfulness is what makes
+the factor set of the rescaled lift *be* the coboundary of `c`, rather than merely some factor set
+acting the same way. -/
+theorem IsProjectiveRep.cohomologyClass_eq_zero_of_monoidHom [FaithfulSMul k V]
+    (h : IsProjectiveRep ρ α) (c : G → kˣ) (π : G →* (V ≃ₗ[k] V))
+    (hc : ∀ g, ρ g = (π g).trans (LinearEquiv.smulOfUnit (c g))) : h.cohomologyClass = 0 := by
+  have hπ := IsProjectiveRep.of_monoidHom π
+  have hc1 : c 1 = 1 := hπ.eq_one_of_eq_smul h c hc
+  have hρ : ρ = fun g ↦ ((π : G → V ≃ₗ[k] V) g).trans (LinearEquiv.smulOfUnit (c g)) := funext hc
+  subst hρ
+  have hα := h.factorSet_eq (hπ.rescale c hc1)
+  refine (FactorSet.cohomologyClass_eq_zero_iff h.factorSet).2 ⟨c, fun g₁ g₂ ↦ ?_⟩
+  simp only [IsProjectiveRep.factorSet_apply, trivialMulDistribMulAction_smul,
+    congrFun (congrFun hα g₁) g₂, Pi.one_apply, mul_one]
+  exact coboundary_aux _ _ _
+
+/-- **The class of a projective representation vanishes exactly when it linearizes**: exactly when
+its lift is a homomorphism `G →* (V ≃ₗ[k] V)` rescaled by units of `k`. So the Schur-multiplier
+class is the complete obstruction to a projective representation being an ordinary linear
+representation in disguise. -/
+theorem IsProjectiveRep.cohomologyClass_eq_zero_iff [FaithfulSMul k V]
+    (h : IsProjectiveRep ρ α) :
+    h.cohomologyClass = 0 ↔
+      ∃ (c : G → kˣ) (π : G →* (V ≃ₗ[k] V)),
+        ∀ g, ρ g = (π g).trans (LinearEquiv.smulOfUnit (c g)) :=
+  ⟨fun h0 ↦
+      let ⟨c, π, _, hc⟩ := h.exists_monoidHom_of_cohomologyClass_eq_zero h0
+      ⟨c, π, hc⟩,
+    fun ⟨c, π, hc⟩ ↦ h.cohomologyClass_eq_zero_of_monoidHom c π hc⟩
+
+/-! ### Every class is realized -/
+
+/-- **Every class in the Schur multiplier is the class of a projective representation of `G` over
+`k`**, already on `G →₀ k`: normalize a cocycle representing the class to a factor set
+(`TauCeti.FactorSet.exists_cohomologyClass_eq`) and take the twisted regular representation of that
+factor set. Together with `TauCeti.IsProjectiveRep.cohomologyClass_rescale` this says that
+`H²(G, kˣ)` is exactly the set of classes of projective representations of `G` over `k`. -/
+theorem exists_isProjectiveRep_cohomologyClass_eq (x : schurMultiplier k G) :
+    ∃ (α : G → G → kˣ) (ρ : G → (G →₀ k) ≃ₗ[k] (G →₀ k)) (h : IsProjectiveRep ρ α),
+      h.cohomologyClass = x := by
+  obtain ⟨γ, hγ⟩ := FactorSet.exists_cohomologyClass_eq (G := G) (M := kˣ) x
+  have hfs : IsFactorSet (Function.curry ⇑γ) :=
+    γ.isFactorSet_curry trivialMulDistribMulAction_smul
+  refine ⟨Function.curry ⇑γ, twistedRegularRep k G (Function.curry ⇑γ),
+    isProjectiveRep_twistedRegularRep k G (Function.curry ⇑γ), ?_⟩
+  have hfactorSet : (isProjectiveRep_twistedRegularRep k G (Function.curry ⇑γ)).factorSet = γ :=
+    FactorSet.ext fun p ↦
+      (isProjectiveRep_twistedRegularRep k G (Function.curry ⇑γ)).factorSet_apply p
+  rw [← hγ, IsProjectiveRep.cohomologyClass, hfactorSet]
+
+/-! ### The twisted monoid algebra sees only the class -/
+
+/-- **The twisted monoid algebra depends only on the class of its factor set.** Cohomologous factor
+sets differ by a coboundary, and rescaling the basis elements by it is an algebra isomorphism
+(`TauCeti.TwistedMonoidAlgebra.equivOfCoboundary`). So `k_α[G]` is an invariant of the class of `α`
+in the Schur multiplier. -/
+theorem TwistedMonoidAlgebra.nonempty_algEquiv_of_cohomologyClass_eq {α β : G → G → kˣ}
+    [IsFactorSet α] [IsFactorSet β]
+    (h : (IsFactorSet.toFactorSet α trivialMulDistribMulAction_smul).cohomologyClass
+      = (IsFactorSet.toFactorSet β trivialMulDistribMulAction_smul).cohomologyClass) :
+    Nonempty (twistedMonoidAlgebra k G α ≃ₐ[k] twistedMonoidAlgebra k G β) := by
+  obtain ⟨y, hy⟩ := (FactorSet.cohomologyClass_eq_iff _ _).1 h
+  refine ⟨TwistedMonoidAlgebra.equivOfCoboundary β α y fun g₁ g₂ ↦ ?_⟩
+  have hy' := hy g₁ g₂
+  simp only [trivialMulDistribMulAction_smul, IsFactorSet.toFactorSet_apply] at hy'
+  exact cohomologous_aux _ _ _ _ _ hy'
+
+end TrivialAction
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean
+++ b/TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean
@@ -65,8 +65,8 @@ syntactically, and rewriting across the difference then fails.
 
 ## Main results
 
-* `TauCeti.IsProjectiveRep.cohomologyClass_of_monoidHom`: a linear representation has vanishing
-  class.
+* `TauCeti.IsProjectiveRep.cohomologyClass_of_monoidHom_eq_zero`: a linear representation has
+  vanishing class.
 * `TauCeti.IsProjectiveRep.cohomologyClass_rescale`: rescaling the lift does not move the class,
   and `TauCeti.IsProjectiveRep.cohomologyClass_eq_of_eq_smul`: two lifts differing by scalars have
   the same class.
@@ -129,22 +129,26 @@ attribute [local instance] trivialMulDistribMulAction
 
 variable {k G : Type} [CommSemiring k] [Group G] {V : Type*} [AddCommMonoid V] [Module k V]
 
-/-- Under `TauCeti.trivialMulDistribMulAction` the units of `k` are fixed by `G`. This is the
-triviality hypothesis that `TauCeti.IsFactorSet.toFactorSet` and
-`TauCeti.FactorSet.isFactorSet_curry` take, supplied once so that the statements below name a
-constant rather than an inlined proof. -/
-theorem trivialMulDistribMulAction_smul (g : G) (a : kˣ) : g • a = a :=
-  rfl
-
 /-- **The Schur multiplier** `H²(G, kˣ)` of a group `G` over a commutative semiring `k`: the second
 cohomology of `G` with coefficients in the units of `k` under the trivial action. By
 `TauCeti.exists_isProjectiveRep_cohomologyClass_eq` and
 `TauCeti.IsProjectiveRep.cohomologyClass_rescale` it is exactly the set of classes of factor sets
 of projective representations of `G` over `k`, equivalently — through
 `TauCeti.FactorSet.cohomologyClassEquiv` — the set of central extensions of `G` by `kˣ` up to
-equivalence. -/
+equivalence.
+
+The body is exposed because `TauCeti.schurMultiplier k G` is used in type position, through the
+`CoeSort` on `ModuleCat ℤ`: a statement relating an element of it to an element of
+`groupCohomology.H2 (Rep.ofMulDistribMulAction G kˣ)` — such as
+`TauCeti.IsProjectiveRep.cohomologyClass_def` below — does not elaborate otherwise. -/
+@[expose]
 noncomputable def schurMultiplier (k G : Type) [CommSemiring k] [Group G] :=
   H2 (Rep.ofMulDistribMulAction G kˣ)
+
+/-- The Schur multiplier is the second cohomology of `G` with coefficients in the units of `k`. -/
+theorem schurMultiplier_def (k G : Type) [CommSemiring k] [Group G] :
+    schurMultiplier k G = H2 (Rep.ofMulDistribMulAction G kˣ) :=
+  rfl
 
 variable {ρ : G → V ≃ₗ[k] V} {α : G → G → kˣ}
 
@@ -162,19 +166,20 @@ theorem IsProjectiveRep.factorSet_apply (h : IsProjectiveRep ρ α) (p : G × G)
   letI := h.isFactorSet
   IsFactorSet.toFactorSet_apply α trivialMulDistribMulAction_smul p
 
-/-- Transporting a projective representation along an equality of factor sets. Rescaling delivers
-the new factor set in a form that has still to be recognized as the intended one, and this is that
-rewriting step. -/
-theorem IsProjectiveRep.congr_factorSet {β : G → G → kˣ} (h : IsProjectiveRep ρ α) (hα : α = β) :
-    IsProjectiveRep ρ β :=
-  hα ▸ h
-
 /-- **The class of a projective representation in the Schur multiplier**: the class of its factor
 set in `H²(G, kˣ)`. Unlike the factor set itself it depends only on the underlying projective
 action, by `TauCeti.IsProjectiveRep.cohomologyClass_eq_of_eq_smul`. -/
 noncomputable def IsProjectiveRep.cohomologyClass (h : IsProjectiveRep ρ α) :
     schurMultiplier k G :=
   h.factorSet.cohomologyClass
+
+/-- The class of a projective representation is the class of its bundled factor set. The body of
+`TauCeti.IsProjectiveRep.cohomologyClass` is not exposed, so this is how an importing module unfolds
+it. It is deliberately not a `simp` lemma: the class is the normal form, and the lemmas below
+evaluate it directly. -/
+theorem IsProjectiveRep.cohomologyClass_def (h : IsProjectiveRep ρ α) :
+    h.cohomologyClass = h.factorSet.cohomologyClass :=
+  (rfl)
 
 /-- The class of a projective representation depends on the lift only through its factor set. -/
 theorem IsProjectiveRep.cohomologyClass_congr {ρ₁ ρ₂ : G → V ≃ₗ[k] V} {α₁ α₂ : G → G → kˣ}
@@ -186,11 +191,12 @@ theorem IsProjectiveRep.cohomologyClass_congr {ρ₁ ρ₂ : G → V ≃ₗ[k] V
 /-- **A linear representation has vanishing class**: its factor set is the trivial one. This is the
 easy half of `TauCeti.IsProjectiveRep.cohomologyClass_eq_zero_iff`, stated before any rescaling and
 so without a faithfulness hypothesis. -/
-theorem IsProjectiveRep.cohomologyClass_of_monoidHom (π : G →* (V ≃ₗ[k] V)) :
+@[simp]
+theorem IsProjectiveRep.cohomologyClass_of_monoidHom_eq_zero (π : G →* (V ≃ₗ[k] V)) :
     (IsProjectiveRep.of_monoidHom π).cohomologyClass = 0 := by
   have h : (IsProjectiveRep.of_monoidHom π).factorSet = FactorSet.trivial G kˣ :=
     FactorSet.ext fun p ↦ by simp
-  rw [IsProjectiveRep.cohomologyClass, h]
+  rw [IsProjectiveRep.cohomologyClass_def, h]
   exact FactorSet.cohomologyClass_trivial
 
 /-! ### Rescaling the lift -/
@@ -308,7 +314,7 @@ theorem exists_isProjectiveRep_cohomologyClass_eq (x : schurMultiplier k G) :
   have hfactorSet : (isProjectiveRep_twistedRegularRep k G (Function.curry ⇑γ)).factorSet = γ :=
     FactorSet.ext fun p ↦
       (isProjectiveRep_twistedRegularRep k G (Function.curry ⇑γ)).factorSet_apply p
-  rw [← hγ, IsProjectiveRep.cohomologyClass, hfactorSet]
+  rw [← hγ, IsProjectiveRep.cohomologyClass_def, hfactorSet]
 
 /-! ### The twisted monoid algebra sees only the class -/
 

--- a/TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean
+++ b/TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean
@@ -30,10 +30,12 @@ representation, so `H²(G, kˣ)` is exactly the set of classes of projective rep
 over `k`. And the twisted monoid algebra `k_α[G]` sees only the class
 (`TauCeti.TwistedMonoidAlgebra.nonempty_algEquiv_of_cohomologyClass_eq`).
 
-Two of these need `k` to act faithfully on `V`, and genuinely so: on `V = 0` every lift is the zero
-map and every normalized factor set whatsoever is a factor set for it, so nothing about `α` can be
-read off `ρ` there. The two directions of the lifting criterion are therefore also recorded
-separately, the direction that does not need faithfulness being stated for an arbitrary module.
+Two of these need `kˣ` to act faithfully on `V`, and genuinely so: on `V = 0` every lift is the
+zero map and every normalized factor set whatsoever is a factor set for it, so nothing about `α`
+can be read off `ρ` there. Only scalars in `kˣ` are ever compared, so faithfulness is asked of the
+units; `k` itself acting faithfully — on a nonzero vector space, say — supplies it. The two
+directions of the lifting criterion are therefore also recorded separately, the direction that does
+not need faithfulness being stated for an arbitrary module.
 
 ## The action on the scalars
 
@@ -65,7 +67,7 @@ syntactically, and rewriting across the difference then fails.
 
 ## Main results
 
-* `TauCeti.IsProjectiveRep.cohomologyClass_of_monoidHom_eq_zero`: a linear representation has
+* `TauCeti.IsProjectiveRep.cohomologyClass_of_monoidHom`: a linear representation has
   vanishing class.
 * `TauCeti.IsProjectiveRep.cohomologyClass_rescale`: rescaling the lift does not move the class,
   and `TauCeti.IsProjectiveRep.cohomologyClass_eq_of_eq_smul`: two lifts differing by scalars have
@@ -192,7 +194,7 @@ theorem IsProjectiveRep.cohomologyClass_congr {ρ₁ ρ₂ : G → V ≃ₗ[k] V
 easy half of `TauCeti.IsProjectiveRep.cohomologyClass_eq_zero_iff`, stated before any rescaling and
 so without a faithfulness hypothesis. -/
 @[simp]
-theorem IsProjectiveRep.cohomologyClass_of_monoidHom_eq_zero (π : G →* (V ≃ₗ[k] V)) :
+theorem IsProjectiveRep.cohomologyClass_of_monoidHom (π : G →* (V ≃ₗ[k] V)) :
     (IsProjectiveRep.of_monoidHom π).cohomologyClass = 0 := by
   have h : (IsProjectiveRep.of_monoidHom π).factorSet = FactorSet.trivial G kˣ :=
     FactorSet.ext fun p ↦ by simp
@@ -212,20 +214,21 @@ theorem IsProjectiveRep.cohomologyClass_rescale (h : IsProjectiveRep ρ α) (c :
   exact coboundary_aux _ _ _
 
 /-- A lift obtained from another by multiplying by units is again normalized: the scalars take the
-value `1` at `1`. Faithfulness is what lets a scalar be read off from its action. -/
-theorem IsProjectiveRep.eq_one_of_eq_smul [FaithfulSMul k V] {ρ' : G → V ≃ₗ[k] V}
+value `1` at `1`. Faithfulness is what lets a scalar be read off from its action, and only scalars
+in `kˣ` are compared, so the faithful action of the units is what is asked for. -/
+theorem IsProjectiveRep.eq_one_of_eq_smul [FaithfulSMul kˣ V] {ρ' : G → V ≃ₗ[k] V}
     {β : G → G → kˣ} (h : IsProjectiveRep ρ α) (h' : IsProjectiveRep ρ' β) (c : G → kˣ)
     (hc : ∀ g, ρ' g = (ρ g).trans (LinearEquiv.smulOfUnit (c g))) : c 1 = 1 := by
-  refine Units.ext (FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_)
+  refine FaithfulSMul.eq_of_smul_eq_smul fun x : V ↦ ?_
   have hx : ρ' 1 x = (c 1 : k) • ρ 1 x := by
     rw [hc 1, LinearEquiv.trans_apply, LinearEquiv.smulOfUnit_apply]
   rw [h.map_one, h'.map_one] at hx
-  simpa using hx.symm
+  simpa [Units.smul_def] using hx.symm
 
 /-- **Two lifts of the same projective action have the same class.** The hypothesis is that the two
 lifts differ by the units `c`, which is what it means for them to induce the same homomorphism into
 the projective linear group. -/
-theorem IsProjectiveRep.cohomologyClass_eq_of_eq_smul [FaithfulSMul k V] {ρ' : G → V ≃ₗ[k] V}
+theorem IsProjectiveRep.cohomologyClass_eq_of_eq_smul [FaithfulSMul kˣ V] {ρ' : G → V ≃ₗ[k] V}
     {β : G → G → kˣ} (h : IsProjectiveRep ρ α) (h' : IsProjectiveRep ρ' β) (c : G → kˣ)
     (hc : ∀ g, ρ' g = (ρ g).trans (LinearEquiv.smulOfUnit (c g))) :
     h'.cohomologyClass = h.cohomologyClass := by
@@ -251,13 +254,14 @@ theorem IsProjectiveRep.exists_monoidHom_of_cohomologyClass_eq_zero (h : IsProje
     have h11 := hx' 1 1
     rw [mul_one, h.isFactorSet.one_left] at h11
     simpa using h11
-  have hrs : IsProjectiveRep (fun g ↦ (ρ g).trans (LinearEquiv.smulOfUnit (x g)⁻¹))
-      (1 : G → G → kˣ) := by
-    refine (h.rescale (fun g ↦ (x g)⁻¹) (by simp [hx1])).congr_factorSet (funext fun g₁ ↦ ?_)
-    funext g₂
+  have hrs := h.rescale (fun g ↦ (x g)⁻¹) (by simp [hx1])
+  have hone : (fun g₁ g₂ ↦ (x g₁)⁻¹ * (x g₂)⁻¹ * ((x (g₁ * g₂))⁻¹)⁻¹ * α g₁ g₂)
+      = (1 : G → G → kˣ) := by
+    funext g₁ g₂
     simp only [Pi.one_apply]
     rw [← hx' g₁ g₂]
     exact coboundary_inv_aux _ _ _
+  rw [hone] at hrs
   refine ⟨x, hrs.toMonoidHom, hx1, fun g ↦ ?_⟩
   refine LinearEquiv.ext fun v ↦ ?_
   have hg : hrs.toMonoidHom g = (ρ g).trans (LinearEquiv.smulOfUnit (x g)⁻¹) :=
@@ -269,7 +273,7 @@ theorem IsProjectiveRep.exists_monoidHom_of_cohomologyClass_eq_zero (h : IsProje
 /-- **A linear representation rescaled by scalars has vanishing class.** Faithfulness is what makes
 the factor set of the rescaled lift *be* the coboundary of `c`, rather than merely some factor set
 acting the same way. -/
-theorem IsProjectiveRep.cohomologyClass_eq_zero_of_monoidHom [FaithfulSMul k V]
+theorem IsProjectiveRep.cohomologyClass_eq_zero_of_monoidHom [FaithfulSMul kˣ V]
     (h : IsProjectiveRep ρ α) (c : G → kˣ) (π : G →* (V ≃ₗ[k] V))
     (hc : ∀ g, ρ g = (π g).trans (LinearEquiv.smulOfUnit (c g))) : h.cohomologyClass = 0 := by
   have hπ := IsProjectiveRep.of_monoidHom π
@@ -286,7 +290,7 @@ theorem IsProjectiveRep.cohomologyClass_eq_zero_of_monoidHom [FaithfulSMul k V]
 its lift is a homomorphism `G →* (V ≃ₗ[k] V)` rescaled by units of `k`. So the Schur-multiplier
 class is the complete obstruction to a projective representation being an ordinary linear
 representation in disguise. -/
-theorem IsProjectiveRep.cohomologyClass_eq_zero_iff [FaithfulSMul k V]
+theorem IsProjectiveRep.cohomologyClass_eq_zero_iff [FaithfulSMul kˣ V]
     (h : IsProjectiveRep ρ α) :
     h.cohomologyClass = 0 ↔
       ∃ (c : G → kˣ) (π : G →* (V ≃ₗ[k] V)),


### PR DESCRIPTION
This PR defines the Schur multiplier `H²(G, kˣ)` of a group `G` over a commutative semiring `k`, attaches to every projective representation the class of its factor set in it, and proves that this class — unlike the factor set itself — is an invariant of the underlying projective action. It advances Layer 7 ("projective representations, factor sets, and the Schur multiplier") of `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, whose build list asks for "the **Schur multiplier** `H²(G, k^×)` classifying projective representations and central extensions"; the pinned signature is `schurMultiplier` in that roadmap's `Suggested.lean`. Layer 7's neighbouring targets are already in the repository — the twisted group algebra (`TauCeti/Algebra/MonoidAlgebra/Twisted.lean`), projective representations and their factor sets (`ProjectiveRepresentation/Basic.lean`), the linearization over the central extension (`ProjectiveRepresentation/Extension.lean`), and the classification of factor sets by `H²` (`TauCeti/GroupTheory/GroupExtension/Cohomology.lean`) — so this is the step that joins them: it is the projective-representation side of a cohomology theory the repository already has for factor sets and group extensions.

The new file `TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean` (332 lines) defines `TauCeti.schurMultiplier k G`, bundles the factor set of a projective representation as a `TauCeti.FactorSet` over the trivial action (`TauCeti.IsProjectiveRep.factorSet`), and takes its class (`TauCeti.IsProjectiveRep.cohomologyClass`). It then proves the four statements that make the class worth having. Rescaling the lift by units `c : G → kˣ` does not move the class (`cohomologyClass_rescale`), so two lifts of the same homomorphism into the projective linear group have the same class (`cohomologyClass_eq_of_eq_smul`). The class vanishes exactly when the lift is a homomorphism `G →* (V ≃ₗ[k] V)` rescaled by units (`cohomologyClass_eq_zero_iff`), so it is the complete obstruction to a projective representation being an ordinary linear representation in disguise. Every class in `H²(G, kˣ)` is the class of a projective representation, already on `G →₀ k` (`exists_isProjectiveRep_cohomologyClass_eq`), so the Schur multiplier is exactly the set of classes of factor sets of projective representations. And the twisted monoid algebra `k_α[G]` depends only on the class (`TwistedMonoidAlgebra.nonempty_algEquiv_of_cohomologyClass_eq`).

Two of these carry `[FaithfulSMul k V]`, and the hypothesis is load-bearing rather than decorative: on `V = 0` every lift is the zero map and every normalized factor set whatsoever is a factor set for it, so nothing about `α` can be read off `ρ` there. The two directions of the lifting criterion are therefore also recorded separately, and the direction that does not need faithfulness — a vanishing class produces the homomorphism and the scalars — is stated for an arbitrary module. `cohomologyClass_of_monoidHom`, that a linear representation has vanishing class, needs no faithfulness either.

Nothing is vendored from Mathlib. The file consumes Mathlib's `groupCohomology.H2`, `cocycles₂` and the multiplicative interface `IsMulCocycle₂` / `IsMulCoboundary₂` through the repository's existing `TauCeti.FactorSet.cohomologyClass`, and reuses `TauCeti.IsProjectiveRep.rescale`, `of_monoidHom`, `toMonoidHom`, `factorSet_eq`, `TauCeti.IsFactorSet.toFactorSet`, `TauCeti.twistedRegularRep` and `TauCeti.TwistedMonoidAlgebra.equivOfCoboundary` rather than reproving any of them. Two conventions are worth flagging for review. The coefficient module is spelled `Rep.ofMulDistribMulAction G kˣ` for the trivial action rather than the roadmap's `Rep.trivial ℤ G (Additive kˣ)`; the roadmap's own "what Mathlib already has" section notes the module is "also reachable via `Rep.ofMulDistribMulAction`", and that is the spelling both Mathlib's multiplicative cocycle interface and the repository's `FactorSet.cohomologyClass` are stated in, so using it is what makes the reuse possible. And `schurMultiplier` deliberately carries no result-type ascription: writing `ModuleCat ℤ` elaborates the `Ring ℤ` argument by instance search while `groupCohomology.H2` produces it from the `CommRing ℤ` of `Rep ℤ G`, and rewriting across that syntactic difference then fails; the module docstring records this.

`lake build` and `lake exe axioms` are green (40156 declarations audited, allowlist only), and the environment linters report no violations in the affected namespaces.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"schurmultiplier"}-->

🤖 Prepared with Claude Code
