### PR TITLE
feat(AdicSpace): the rational subsets of Spv (A, I) are quasi-compact

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/SpvOfIdeal/Spectral.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/SpvOfIdeal/Spectral.lean
@@ -21,8 +21,11 @@ spectral with the sets
 Spv (A, I)(T/s) = { v ∈ Spv (A, I) ; v(t) ≤ v(s) ≠ 0 for all t ∈ T },   I ⊆ √(T · A)
 ```
 
-as a generating family. (Wedhorn states them as a basis of quasi-compact opens; what is
-proved here is that they generate the topology, which is what the patch criterion consumes.)
+as a generating family. (Wedhorn states them as a basis of quasi-compact opens. Both halves that
+are about individual members are proved here: they generate the topology, which is what the patch
+criterion consumes, and each is quasi-compact. The *basis* property itself — every open a union
+of them — is not, since it needs stability under finite intersection, Wedhorn's step (i), which
+the criterion absorbs rather than proves.)
 No second topology on the subtype is introduced here: the
 `Subtype` instance *is* that topology, which is the content of
 `instTopologicalSpace_spvOfIdeal_eq_generateFrom`.
@@ -63,6 +66,8 @@ below is the public neighbourhood interface that merges them.)
   that `R` generates the subspace topology.
 * `TauCeti.ValuationSpectrum.restrictToIdealCodRestrict_preimage` : **step (iii)**,
   `r_I⁻¹(Spv(A,I)(T/s)) = Spv(A)(T/s)`.
+* `TauCeti.ValuationSpectrum.isCompact_of_mem_rationalFamily` : the members of `R` are
+  quasi-compact, the other half of what Lemma 7.5(1) asserts about them.
 
 ## References
 
@@ -374,6 +379,16 @@ theorem restrictToIdealCodRestrict_preimage (I : Ideal A)
 
 /-! ### Wedhorn Lemma 7.5(1) -/
 
+/-- Every member of `R` is clopen for the witness topology: step (iii) computes its `r_I`-preimage
+to be `Spv(A)(T/u)`, which is patch-clopen in `Spv A`. -/
+private lemma isClopen_patchTopologyOfIdeal_of_mem_rationalFamily (I : Ideal A)
+    (hfg : ∃ J : Ideal A, J.FG ∧ I.radical = J.radical) :
+    ∀ V ∈ rationalFamily I hfg, @IsClopen _ (patchTopologyOfIdeal I hfg) V := by
+  rintro _ ⟨T, u, hadm, rfl⟩
+  exact isClopen_patchTopologyOfIdeal_of_preimage I hfg
+    (by rw [restrictToIdealCodRestrict_preimage I hfg hadm]
+        exact isClopen_patchTopology_basicOpenFinset T u)
+
 /-- **Wedhorn, Lemma 7.5(1)**: `Spv (A, I)` is a spectral space.
 
 The patch criterion is applied with the subspace topology as the generated one — the admissible
@@ -384,10 +399,21 @@ theorem spectralSpace_spvOfIdeal (I : Ideal A)
     (hfg : ∃ J : Ideal A, J.FG ∧ I.radical = J.radical) :
     SpectralSpace (spvOfIdeal I hfg) :=
   spectralSpace_of_isClopen_generateFrom (instTopologicalSpace_spvOfIdeal_eq_generateFrom I hfg)
-    (compactSpace_patchTopologyOfIdeal I hfg) (by
-      rintro _ ⟨T, u, hadm, rfl⟩
-      exact isClopen_patchTopologyOfIdeal_of_preimage I hfg
-        (by rw [restrictToIdealCodRestrict_preimage I hfg hadm]
-            exact isClopen_patchTopology_basicOpenFinset T u))
+    (compactSpace_patchTopologyOfIdeal I hfg)
+    (isClopen_patchTopologyOfIdeal_of_mem_rationalFamily I hfg)
+
+/-- **Wedhorn Lemma 7.5(1), the quasi-compactness half.** Every member of `R` is a quasi-compact
+open of `Spv (A, I)` — the property Wedhorn states alongside "basis", and the one that
+quasi-compactness in `Spv A` does *not* supply, since `Spv (A, I)` is not closed there.
+
+Same witness topology as the spectrality proof, so the patch criterion's
+`isCompact_of_isClopen_generateFrom` applies directly. -/
+theorem isCompact_of_mem_rationalFamily (I : Ideal A)
+    (hfg : ∃ J : Ideal A, J.FG ∧ I.radical = J.radical) {V : Set (spvOfIdeal I hfg)}
+    (hV : V ∈ rationalFamily I hfg) : IsCompact V :=
+  isCompact_of_isClopen_generateFrom (t' := patchTopologyOfIdeal I hfg)
+    (instTopologicalSpace_spvOfIdeal_eq_generateFrom I hfg)
+    (compactSpace_patchTopologyOfIdeal I hfg)
+    (isClopen_patchTopologyOfIdeal_of_mem_rationalFamily I hfg) hV
 
 end TauCeti.ValuationSpectrum


### PR DESCRIPTION
**Wedhorn Lemma 7.5(1), the quasi-compactness half.** The members of `R` are quasi-compact opens
of `Spv (A, I)`.

```lean
theorem TauCeti.ValuationSpectrum.isCompact_of_mem_rationalFamily (I : Ideal A)
    (hfg : ∃ J : Ideal A, J.FG ∧ I.radical = J.radical) {V : Set (spvOfIdeal I hfg)}
    (hV : V ∈ rationalFamily I hfg) : IsCompact V
```

Lemma 7.5(1) asserts two things about `R`: that it generates the topology, and that its members
are **quasi-compact** opens. `main` had only the first, and said so in the module docstring:

> (Wedhorn states them as a basis of quasi-compact opens; what is proved here is that they
> generate the topology, which is what the patch criterion consumes.)

This supplies the second.

## Why it does not follow from the `Spv A` side

`Spv(A)(T/u)` being quasi-compact says nothing here: `spvOfIdeal I hfg` is **not closed** in
`Spv A`, so quasi-compactness does not pass to the trace `Subtype.val ⁻¹' basicOpenFinset T u`.
The `Spv (A, I)` side needs its own witness topology — and it already has one, the
`patchTopologyOfIdeal` coinduced along `r_I` that the spectrality proof uses. The patch
criterion's `isCompact_of_isClopen_generateFrom` then applies verbatim, at that topology.

## It deduplicates the spectrality proof

The clopen-ness of a member of `R` in the witness topology was written inline inside
`spectralSpace_spvOfIdeal`. Both statements need it, so it is now the private
`isClopen_patchTopologyOfIdeal_of_mem_rationalFamily`, and `spectralSpace_spvOfIdeal` consumes it
instead of repeating the `rintro`/`rw` block. Net effect on that proof: four lines shorter.

## What is still not claimed

The **basis** property — every open of `Spv (A, I)` a union of members of `R` — remains unproved,
because it needs stability under finite intersection (Wedhorn's step (i)), which the patch
criterion absorbs rather than establishes. The module docstring now separates the three claims
instead of grouping them.

## Provenance

AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at commit
`2baa76f742bdb4fb8ee323fabba41203bd390e08` reaches spectrality of its `SpvAI` through
`isSpectralSpace_of_qcKolmogorov_oc_basis` and returns a `CompactSpace ∧ T0Space ∧ QuasiSober`
conjunction; it has no statement isolating quasi-compactness of a single rational subset of
`Spv (A, I)`. Nothing was copied — the witness topology and step (iii) used here are TauCeti's,
already on `main`.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all exit 0.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-1.4-lemma-7.5-quasicompact-basis"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
