### PR TITLE
feat: define coordinate tori over a field

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Basic.lean
@@ -5,7 +5,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Basic
+public import TauCeti.Algebra.Category.CommGrpCat.FiniteGeneration
 public import TauCeti.Algebra.Group.FreeAbelianCharacter
+public import Mathlib.RingTheory.Finiteness.Finsupp
 
 /-!
 # The split torus and its functor of points
@@ -35,6 +37,8 @@ as the existing multiplicative group `𝔾ₘ`, roots of unity `μ_n`, and diago
 
 ## Main definitions
 
+* `TauCeti.SplitTorus.characterGroup`: the finitely generated character group of a finite-rank
+  split torus.
 * `TauCeti.SplitTorus.pointsMulEquiv`: the multiplicative equivalence from the convolution
   group of `A`-points of the rank-`σ` split torus to `σ → Aˣ`.
 * `TauCeti.SplitTorus.pointsMulEquiv_apply_coe`: a point is sent to its values on the standard
@@ -61,6 +65,17 @@ universe u v w
 
 variable {R : Type u} {A : Type v} {σ : Type w}
 variable [CommSemiring R] [CommSemiring A] [Algebra R A]
+
+/-- A finite-rank free character lattice, written multiplicatively, is finitely generated. -/
+instance instFGMultiplicativeFinsuppInt {sigma : Type u} [Finite sigma] :
+    Group.FG (Multiplicative (sigma →₀ ℤ)) := by
+  exact AddGroup.fg_iff_mul_fg.mp
+    (Module.Finite.iff_addGroup_fg.mp
+      (inferInstance : Module.Finite ℤ (sigma →₀ ℤ)))
+
+/-- The finitely generated character group of the split torus indexed by `sigma`. -/
+noncomputable abbrev characterGroup (sigma : Type u) [Finite sigma] : FGCommGrpCat.{u} :=
+  FGCommGrpCat.of (Multiplicative (sigma →₀ ℤ))
 
 /-- The functor of points of the rank-`σ` split torus `D(Multiplicative (σ →₀ ℤ))`: for every
 commutative `R`-algebra `A`, the convolution group of `R`-algebra maps out of

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Cocharacter.lean
@@ -6,10 +6,8 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Cocharacter
 public import TauCeti.Algebra.AlgebraicGroup.SplitTorus.Basic
-public import TauCeti.Algebra.Category.CommGrpCat.FiniteGeneration
 public import Mathlib.Algebra.Group.Equiv.TypeTags
 public import Mathlib.LinearAlgebra.PerfectPairing.Basic
-public import Mathlib.RingTheory.Finiteness.Finsupp
 
 /-!
 # The character–cocharacter perfect pairing of a split torus
@@ -88,17 +86,6 @@ namespace SplitTorus
 universe u v w
 
 variable {σ : Type w}
-
-/-- A finite-rank free character lattice, written multiplicatively, is finitely generated. -/
-instance instFGMultiplicativeFinsuppInt {sigma : Type u} [Finite sigma] :
-    Group.FG (Multiplicative (sigma →₀ ℤ)) := by
-  exact AddGroup.fg_iff_mul_fg.mp
-    (Module.Finite.iff_addGroup_fg.mp
-      (inferInstance : Module.Finite ℤ (sigma →₀ ℤ)))
-
-/-- The finitely generated character group of the split torus indexed by `sigma`. -/
-noncomputable abbrev characterGroup (sigma : Type u) [Finite sigma] : FGCommGrpCat.{u} :=
-  FGCommGrpCat.of (Multiplicative (sigma →₀ ℤ))
 
 /-- The **cocharacter lattice `X_*(T)`** of the rank-`σ` split torus
 `T = D(Multiplicative (σ →₀ ℤ))`, identified with `σ → ℤ`. A cocharacter

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
@@ -153,6 +153,7 @@ theorem torusCommHopfAlgProperty.multiplicativeType
 namespace SplitTorus
 
 /-- The coordinate Hopf algebra of a finite-rank split torus satisfies the split-torus property. -/
+@[grind =>]
 theorem splitTorus_coordinateRing (k : Type u) [CommRing k] (σ : Type u) [Finite σ] :
     splitTorusCommHopfAlgProperty k
       (DiagonalizableGroup.coordinateRing k (characterGroup σ)) := by

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
@@ -130,7 +130,7 @@ abbrev TorusCommHopfAlgCat (k : Type u) [Field k] :=
   (torusCommHopfAlgProperty k).FullSubcategory
 
 /-- Every split torus is a torus. -/
-@[grind]
+@[grind →]
 theorem splitTorusCommHopfAlgProperty.torus
     (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (hH : splitTorusCommHopfAlgProperty k H) :
@@ -142,7 +142,7 @@ theorem splitTorusCommHopfAlgProperty.torus
     (FiniteTypeCommHopfAlgCat.baseChangeFunctor (K := AlgebraicClosure k)).mapIso i⟩⟩
 
 /-- Every torus is a group of multiplicative type. -/
-@[grind]
+@[grind →]
 theorem torusCommHopfAlgProperty.multiplicativeType
     (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (hH : torusCommHopfAlgProperty k H) :

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeType.Basic
+public import TauCeti.Algebra.AlgebraicGroup.SplitTorus.Cocharacter
+
+/-!
+# Tori over a field
+
+A finite-type affine group over a field is a torus when it becomes a finite-rank split torus
+after extending scalars to an algebraic closure. On coordinate Hopf algebras, the rank-`n` split
+torus has coordinate ring
+
+```text
+k[Multiplicative (Fin n →₀ ℤ)].
+```
+
+This file records both the split and geometric forms of that definition as object properties on
+finite-type commutative Hopf algebras. Keeping them as properties, rather than building them into
+the ambient category, leaves finite, non-smooth groups such as `μ_p` in the general theory.
+
+Every split torus is a torus: after base change, the standard coordinate-ring comparison
+identifies `K ⊗[k] k[ℤⁿ]` with `K[ℤⁿ]`. Every torus is of multiplicative type, since its
+base change is a diagonalizable coordinate Hopf algebra. Thus this definition extends the
+existing multiplicative-type theory while imposing the free finite-rank character lattice that
+distinguishes tori from general groups of multiplicative type.
+
+## Main declarations
+
+* `TauCeti.splitTorusCommHopfAlgProperty`: finite-type coordinate Hopf algebras isomorphic over
+  the base field to the coordinate ring of a finite-rank split torus.
+* `TauCeti.torusCommHopfAlgProperty`: finite-type coordinate Hopf algebras that become a
+  finite-rank split torus over `AlgebraicClosure k`.
+* `TauCeti.splitTorusCommHopfAlgProperty.torus`: every split torus is a torus.
+* `TauCeti.torusCommHopfAlgProperty.multiplicativeType`: every torus is of multiplicative type.
+* `TauCeti.SplitTorus.splitTorus_coordinateRing`: the standard finite-rank split tori satisfy the
+  split predicate.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Definitions 12.14 and 12.17.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+
+This is the coordinate-algebra definition required by Layer 4, "Tori: split and non-split", of
+the ReductiveGroups roadmap. The next steps are the character lattice with its Galois action and
+the smoothness and geometric-connectedness characterizations.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+/-- The object property selecting finite-type commutative Hopf algebras that are coordinate
+rings of split tori of finite rank.
+
+The witness `n` is the rank. The finite index type is universe-lifted so that its character group
+lives in the same universe as `k`; this does not change the represented rank-`n` torus. -/
+def splitTorusCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
+  fun H ↦ ∃ n : ℕ, Nonempty
+    (DiagonalizableGroup.coordinateRing k
+        (SplitTorus.characterGroup (ULift.{u} (Fin n))) ≅ H)
+
+/-- Membership in the split-torus property means being isomorphic to the coordinate Hopf algebra
+of a finite-rank split torus. -/
+@[simp]
+theorem splitTorusCommHopfAlgProperty_iff
+    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    splitTorusCommHopfAlgProperty k H ↔
+      ∃ n : ℕ, Nonempty
+        (DiagonalizableGroup.coordinateRing k
+          (SplitTorus.characterGroup (ULift.{u} (Fin n))) ≅ H) :=
+  Iff.rfl
+
+/-- Being a split torus is invariant under isomorphisms of finite-type commutative Hopf
+algebras. -/
+instance (k : Type u) [Field k] :
+    (splitTorusCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
+  of_iso e := by
+    rintro ⟨n, ⟨i⟩⟩
+    exact ⟨n, ⟨i ≪≫ e⟩⟩
+
+/-- The category of finite-type split-torus coordinate Hopf algebras over a field. -/
+abbrev SplitTorusCommHopfAlgCat (k : Type u) [Field k] :=
+  (splitTorusCommHopfAlgProperty k).FullSubcategory
+
+/-- The object property selecting finite-type commutative Hopf algebras that become coordinate
+rings of split tori of finite rank after base change to an algebraic closure.
+
+This is the coordinate-Hopf-algebra definition of a not-necessarily-split torus over `k`. -/
+def torusCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
+  fun H ↦ ∃ n : ℕ, Nonempty
+    (DiagonalizableGroup.coordinateRing (AlgebraicClosure k)
+        (SplitTorus.characterGroup (ULift.{u} (Fin n))) ≅
+      FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+
+/-- Membership in the torus property means becoming a finite-rank split torus after base change
+to an algebraic closure. -/
+@[simp]
+theorem torusCommHopfAlgProperty_iff
+    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    torusCommHopfAlgProperty k H ↔
+      ∃ n : ℕ, Nonempty
+        (DiagonalizableGroup.coordinateRing (AlgebraicClosure k)
+            (SplitTorus.characterGroup (ULift.{u} (Fin n))) ≅
+          FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  Iff.rfl
+
+/-- Being a torus is invariant under isomorphisms of finite-type commutative Hopf algebras. -/
+instance (k : Type u) [Field k] :
+    (torusCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
+  of_iso e := by
+    rintro ⟨n, ⟨i⟩⟩
+    exact ⟨n, ⟨i ≪≫
+      (FiniteTypeCommHopfAlgCat.baseChangeFunctor (K := AlgebraicClosure k)).mapIso e⟩⟩
+
+/-- The category of finite-type torus coordinate Hopf algebras over a field.
+
+Objects need not be split over the base field; they become split after extension to an algebraic
+closure. -/
+abbrev TorusCommHopfAlgCat (k : Type u) [Field k] :=
+  (torusCommHopfAlgProperty k).FullSubcategory
+
+/-- Every split torus is a torus. -/
+theorem splitTorusCommHopfAlgProperty.torus
+    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : splitTorusCommHopfAlgProperty k H) :
+    torusCommHopfAlgProperty k H := by
+  obtain ⟨n, ⟨i⟩⟩ := hH
+  exact ⟨n, ⟨
+    (DiagonalizableGroup.baseChangeCoordinateRingIso k (AlgebraicClosure k)
+      (SplitTorus.characterGroup (ULift.{u} (Fin n)))).symm ≪≫
+    (FiniteTypeCommHopfAlgCat.baseChangeFunctor (K := AlgebraicClosure k)).mapIso i⟩⟩
+
+/-- Every torus is a group of multiplicative type. -/
+theorem torusCommHopfAlgProperty.multiplicativeType
+    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : torusCommHopfAlgProperty k H) :
+    multiplicativeTypeCommHopfAlgProperty k H := by
+  rw [multiplicativeTypeCommHopfAlgProperty_iff_exists_iso_coordinateRing]
+  obtain ⟨n, hn⟩ := hH
+  exact ⟨SplitTorus.characterGroup (ULift.{u} (Fin n)), hn⟩
+
+namespace SplitTorus
+
+/-- The coordinate Hopf algebra of a finite-rank split torus satisfies the split-torus property.
+
+The proof reindexes the finite basis by `Fin (Nat.card σ)` and then applies the standard
+bialgebra equivalence between group algebras of isomorphic groups. -/
+theorem splitTorus_coordinateRing (k : Type u) [Field k] (σ : Type u) [Finite σ] :
+    splitTorusCommHopfAlgProperty k
+      (DiagonalizableGroup.coordinateRing k (characterGroup σ)) := by
+  let eσ : σ ≃ ULift.{u} (Fin (Nat.card σ)) :=
+    (Finite.equivFin σ).trans Equiv.ulift.symm
+  let e : Multiplicative (σ →₀ ℤ) ≃*
+      Multiplicative (ULift.{u} (Fin (Nat.card σ)) →₀ ℤ) :=
+    AddEquiv.toMultiplicative (Finsupp.domCongr eσ)
+  let i : DiagonalizableGroup.coordinateRing k (characterGroup σ) ≅
+      DiagonalizableGroup.coordinateRing k
+        (characterGroup (ULift.{u} (Fin (Nat.card σ)))) :=
+    ObjectProperty.isoMk _ <|
+      _root_.CommHopfAlgCat.isoMk (MonoidAlgebra.domCongrBialgEquiv k k e)
+  exact ⟨Nat.card σ, ⟨i.symm⟩⟩
+
+/-- The coordinate Hopf algebra of a finite-rank split torus is a torus. -/
+theorem torus_coordinateRing (k : Type u) [Field k] (σ : Type u) [Finite σ] :
+    torusCommHopfAlgProperty k
+      (DiagonalizableGroup.coordinateRing k (characterGroup σ)) :=
+  (splitTorus_coordinateRing k σ).torus k _
+
+end SplitTorus
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
@@ -31,7 +31,7 @@ distinguishes tori from general groups of multiplicative type.
 ## Main declarations
 
 * `TauCeti.splitTorusCommHopfAlgProperty`: finite-type coordinate Hopf algebras isomorphic over
-  the base field to the coordinate ring of a finite-rank split torus.
+  the base ring to the coordinate ring of a finite-rank split torus.
 * `TauCeti.torusCommHopfAlgProperty`: finite-type coordinate Hopf algebras that become a
   finite-rank split torus over `AlgebraicClosure k`.
 * `TauCeti.splitTorusCommHopfAlgProperty.torus`: every split torus is a torus.
@@ -62,7 +62,7 @@ rings of split tori of finite rank.
 
 The witness `n` is the rank. The finite index type is universe-lifted so that its character group
 lives in the same universe as `k`; this does not change the represented rank-`n` torus. -/
-def splitTorusCommHopfAlgProperty (k : Type u) [Field k] :
+def splitTorusCommHopfAlgProperty (k : Type u) [CommRing k] :
     ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
   fun H ↦ ∃ n : ℕ, Nonempty
     (DiagonalizableGroup.coordinateRing k
@@ -72,7 +72,7 @@ def splitTorusCommHopfAlgProperty (k : Type u) [Field k] :
 of a finite-rank split torus. -/
 @[simp]
 theorem splitTorusCommHopfAlgProperty_iff
-    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    (k : Type u) [CommRing k] (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     splitTorusCommHopfAlgProperty k H ↔
       ∃ n : ℕ, Nonempty
         (DiagonalizableGroup.coordinateRing k
@@ -81,14 +81,14 @@ theorem splitTorusCommHopfAlgProperty_iff
 
 /-- Being a split torus is invariant under isomorphisms of finite-type commutative Hopf
 algebras. -/
-instance (k : Type u) [Field k] :
+instance (k : Type u) [CommRing k] :
     (splitTorusCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
   of_iso e := by
     rintro ⟨n, ⟨i⟩⟩
     exact ⟨n, ⟨i ≪≫ e⟩⟩
 
-/-- The category of finite-type split-torus coordinate Hopf algebras over a field. -/
-abbrev SplitTorusCommHopfAlgCat (k : Type u) [Field k] :=
+/-- The category of finite-type split-torus coordinate Hopf algebras over a commutative ring. -/
+abbrev SplitTorusCommHopfAlgCat (k : Type u) [CommRing k] :=
   (splitTorusCommHopfAlgProperty k).FullSubcategory
 
 /-- The object property selecting finite-type commutative Hopf algebras that become coordinate
@@ -97,10 +97,8 @@ rings of split tori of finite rank after base change to an algebraic closure.
 This is the coordinate-Hopf-algebra definition of a not-necessarily-split torus over `k`. -/
 def torusCommHopfAlgProperty (k : Type u) [Field k] :
     ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
-  fun H ↦ ∃ n : ℕ, Nonempty
-    (DiagonalizableGroup.coordinateRing (AlgebraicClosure k)
-        (SplitTorus.characterGroup (ULift.{u} (Fin n))) ≅
-      FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+  (splitTorusCommHopfAlgProperty (AlgebraicClosure k)).inverseImage
+    (FiniteTypeCommHopfAlgCat.baseChangeFunctor (K := AlgebraicClosure k))
 
 /-- Membership in the torus property means becoming a finite-rank split torus after base change
 to an algebraic closure. -/
@@ -116,11 +114,9 @@ theorem torusCommHopfAlgProperty_iff
 
 /-- Being a torus is invariant under isomorphisms of finite-type commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :
-    (torusCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
-  of_iso e := by
-    rintro ⟨n, ⟨i⟩⟩
-    exact ⟨n, ⟨i ≪≫
-      (FiniteTypeCommHopfAlgCat.baseChangeFunctor (K := AlgebraicClosure k)).mapIso e⟩⟩
+    (torusCommHopfAlgProperty k).IsClosedUnderIsomorphisms := by
+  unfold torusCommHopfAlgProperty
+  infer_instance
 
 /-- The category of finite-type torus coordinate Hopf algebras over a field.
 
@@ -154,7 +150,7 @@ theorem torusCommHopfAlgProperty.multiplicativeType
 namespace SplitTorus
 
 /-- The coordinate Hopf algebra of a finite-rank split torus satisfies the split-torus property. -/
-theorem splitTorus_coordinateRing (k : Type u) [Field k] (σ : Type u) [Finite σ] :
+theorem splitTorus_coordinateRing (k : Type u) [CommRing k] (σ : Type u) [Finite σ] :
     splitTorusCommHopfAlgProperty k
       (DiagonalizableGroup.coordinateRing k (characterGroup σ)) := by
   let eσ : σ ≃ ULift.{u} (Fin (Nat.card σ)) :=

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
@@ -130,6 +130,7 @@ abbrev TorusCommHopfAlgCat (k : Type u) [Field k] :=
   (torusCommHopfAlgProperty k).FullSubcategory
 
 /-- Every split torus is a torus. -/
+@[grind]
 theorem splitTorusCommHopfAlgProperty.torus
     (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (hH : splitTorusCommHopfAlgProperty k H) :
@@ -141,6 +142,7 @@ theorem splitTorusCommHopfAlgProperty.torus
     (FiniteTypeCommHopfAlgCat.baseChangeFunctor (K := AlgebraicClosure k)).mapIso i⟩⟩
 
 /-- Every torus is a group of multiplicative type. -/
+@[grind]
 theorem torusCommHopfAlgProperty.multiplicativeType
     (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (hH : torusCommHopfAlgProperty k H) :
@@ -151,10 +153,7 @@ theorem torusCommHopfAlgProperty.multiplicativeType
 
 namespace SplitTorus
 
-/-- The coordinate Hopf algebra of a finite-rank split torus satisfies the split-torus property.
-
-The proof reindexes the finite basis by `Fin (Nat.card σ)` and then applies the standard
-bialgebra equivalence between group algebras of isomorphic groups. -/
+/-- The coordinate Hopf algebra of a finite-rank split torus satisfies the split-torus property. -/
 theorem splitTorus_coordinateRing (k : Type u) [Field k] (σ : Type u) [Finite σ] :
     splitTorusCommHopfAlgProperty k
       (DiagonalizableGroup.coordinateRing k (characterGroup σ)) := by
@@ -169,12 +168,6 @@ theorem splitTorus_coordinateRing (k : Type u) [Field k] (σ : Type u) [Finite �
     ObjectProperty.isoMk _ <|
       _root_.CommHopfAlgCat.isoMk (MonoidAlgebra.domCongrBialgEquiv k k e)
   exact ⟨Nat.card σ, ⟨i.symm⟩⟩
-
-/-- The coordinate Hopf algebra of a finite-rank split torus is a torus. -/
-theorem torus_coordinateRing (k : Type u) [Field k] (σ : Type u) [Finite σ] :
-    torusCommHopfAlgProperty k
-      (DiagonalizableGroup.coordinateRing k (characterGroup σ)) :=
-  (splitTorus_coordinateRing k σ).torus k _
 
 end SplitTorus
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
@@ -131,6 +131,8 @@ theorem splitTorusCommHopfAlgProperty.torus
     (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (hH : splitTorusCommHopfAlgProperty k H) :
     torusCommHopfAlgProperty k H := by
+  rw [splitTorusCommHopfAlgProperty_iff] at hH
+  rw [torusCommHopfAlgProperty_iff]
   obtain ⟨n, ⟨i⟩⟩ := hH
   exact ⟨n, ⟨
     (DiagonalizableGroup.baseChangeCoordinateRingIso k (AlgebraicClosure k)
@@ -144,6 +146,7 @@ theorem torusCommHopfAlgProperty.multiplicativeType
     (hH : torusCommHopfAlgProperty k H) :
     multiplicativeTypeCommHopfAlgProperty k H := by
   rw [multiplicativeTypeCommHopfAlgProperty_iff_exists_iso_coordinateRing]
+  rw [torusCommHopfAlgProperty_iff] at hH
   obtain ⟨n, hn⟩ := hH
   exact ⟨SplitTorus.characterGroup (ULift.{u} (Fin n)), hn⟩
 
@@ -153,6 +156,7 @@ namespace SplitTorus
 theorem splitTorus_coordinateRing (k : Type u) [CommRing k] (σ : Type u) [Finite σ] :
     splitTorusCommHopfAlgProperty k
       (DiagonalizableGroup.coordinateRing k (characterGroup σ)) := by
+  rw [splitTorusCommHopfAlgProperty_iff]
   let eσ : σ ≃ ULift.{u} (Fin (Nat.card σ)) :=
     (Finite.equivFin σ).trans Equiv.ulift.symm
   let e : Multiplicative (σ →₀ ℤ) ≃*

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeType.Basic
-public import TauCeti.Algebra.AlgebraicGroup.SplitTorus.Cocharacter
+public import TauCeti.Algebra.AlgebraicGroup.SplitTorus.Basic
 
 /-!
 # Tori over a field


### PR DESCRIPTION
This PR defines split and not-necessarily-split tori on finite-type commutative coordinate Hopf algebras: a split torus is isomorphic over `k` to `k[ℤⁿ]`, while a torus becomes isomorphic to `k̄[ℤⁿ]` after scalar extension to `AlgebraicClosure k`. It packages both object properties as full subcategories, proves isomorphism invariance, proves every split torus is a torus, and proves every torus is of multiplicative type.

It advances the exact `TauCetiRoadmap/ReductiveGroups/README.md` Layer 4 milestone **“Tori: split and non-split; the character lattice `X*(T)` and cocharacter lattice `X_*(T)` with their perfect pairing”**, specifically the missing coordinate-algebra definition of a torus. This is the most effective unclaimed next step because multiplicative type and diagonalizable coordinate-ring base change are already on `main`, and the definition now narrows the geometric character group from an arbitrary finitely generated commutative group to a free group of finite rank. After this PR, the milestone still needs the character and cocharacter lattices of a non-split torus with their Galois action, the perfect pairing, and the smoothness/geometric-connectedness characterizations.

Add `TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean` (181 lines). The finite-rank split witness works for every finite index type by reindexing it with `Finite.equivFin` and transporting the group algebra along Mathlib's `MonoidAlgebra.domCongrBialgEquiv`; the passage from split to geometric tori reuses `DiagonalizableGroup.baseChangeCoordinateRingIso`, and the multiplicative-type implication reuses `multiplicativeTypeCommHopfAlgProperty_iff_exists_iso_coordinateRing`. No Mathlib infrastructure is vendored. The formulation follows J. S. Milne, *Algebraic Groups* (2017), Definitions 12.14 and 12.17, and W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"torus-comm-hopf-algebra"}-->

🤖 Prepared with Codex
