### PR TITLE
fix(ci): restore the perf gate's fork-head opt-in reverted by #2883

### DIFF
--- a/.github/workflows/pr-profile.yml
+++ b/.github/workflows/pr-profile.yml
@@ -194,6 +194,11 @@ jobs:
           ref: ${{ steps.pr.outputs.sha }}
           path: pr
           persist-credentials: false
+          # actions/checkout refuses to fetch fork PR code under
+          # pull_request_target unless this opt-in is set. Safe here for the
+          # same reasons as pr-build.yml: no credentials in the checkout, and
+          # the fork's code runs only under landrun below (offline, no token).
+          allow-unsafe-pr-checkout: true
 
       - name: Stage workflow-pinned performance tooling into trusted trees
         run: |


### PR DESCRIPTION
Roadmap: none

Restores the five lines #1941 added to the `Checkout candidate head` step of
`.github/workflows/pr-profile.yml`, which #2883's rewrite of that section dropped —
verbatim, including the original safety comment.

## What broke

#2883 (merged 06:11Z today) promoted this workflow's status to the required, fail-closed
`perf` context. Its rewrite of the checkout section lost #1941's opt-in, so for **every fork
PR** the candidate-head checkout is refused in seconds:

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow.
… set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

`BASE_OUTCOME`/`HEAD_OUTCOME`/`REPORT_OUTCOME` all read `skipped`, and the terminal step then
posts `perf: failure` ("see run and report") with nothing measured and no report. Example run:
https://github.com/TauCetiProject/TauCeti/runs/94053972180 (refusal at 08:20:58Z).

Flag count of `allow-unsafe-pr-checkout` in this file, by revision:

| revision | count |
|---|---|
| `5ff6ce0c8` (#1941, the fix) | 1 |
| `6b0ff373f^` (just before #2883) | 1 |
| `6b0ff373f` (#2883) | **0** |

## Why the restored line is safe

The deleted comment already says it: the checkout persists no credentials, and the fork's code
runs only under landrun below (offline, no token in reach) — identical to the rationale on
`pr-build.yml`'s equivalent step, which has carried this flag since July.

## Impact so far, measured

`perf` is red on every sampled open fork PR (7/7, three authors). The 06:56Z merge-sweep's
batch of green PRs — enqueued before the failures started attaching (~08:20Z) — drained
normally through 08:21Z (#2827 last), so merges have not stopped *yet*; the exposure is the
next sweep reading `perf: failure` on otherwise-green PRs.

## Notes for the reviewer

- This PR is itself from a fork, so its own `perf` check shows the very failure it fixes —
  expected, and gone once merged. It touches `.github/`, so it needs a human review and merge
  by repo policy; nothing here can or should auto-merge.
- After merging: existing PRs re-acquire a real `perf` status on their next workflow event, or
  immediately via Actions → re-run failed `pr-profile` runs (needs admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
