### PR TITLE
feat: the spinor Clifford module of a polarized quadratic space

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
+
+/-!
+# Contraction anticommutes with the grade involution
+
+Mathlib's `CliffordAlgebra.contractLeft` lowers the degree of a multivector by one, so it
+exchanges the two halves of the `ℤ/2`-grading and therefore anticommutes with the grade
+involution `CliffordAlgebra.involute`. This file proves that single identity, which Mathlib does
+not record: `involute` interacts with products (`involute` is an algebra homomorphism) and with
+the grading, but never with a contraction.
+
+The identity is what makes the grade involution usable as an odd operator alongside exterior
+multiplication and contraction — for instance as the operator by which an anisotropic vector
+orthogonal to a polarization acts on a spinor module.
+
+## Main results
+
+* `TauCeti.CliffordAlgebra.involute_contractLeft`: `involute (d ⌋ x) = -(d ⌋ involute x)`.
+* `TauCeti.CliffordAlgebra.contractLeft_involute_add`: the anticommutator form of the same
+  identity.
+
+## References
+
+* [D. Grinberg, *The Clifford algebra and the Chevalley map*][grinberg_clifford_2016], for the
+  contraction operators themselves.
+-/
+
+public section
+
+open CliffordAlgebra
+
+universe u v
+
+namespace TauCeti.CliffordAlgebra
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+  {Q : QuadraticForm R M}
+
+/-- **The grade involution anticommutes with contraction.** Contracting against a linear
+functional lowers the degree by one, hence swaps the even and odd parts of the Clifford algebra,
+so it anticommutes with the operator that is `+1` on the even part and `-1` on the odd part. -/
+theorem involute_contractLeft (d : Module.Dual R M) (x : CliffordAlgebra Q) :
+    involute (contractLeft d x) = -contractLeft d (involute x) := by
+  induction x using CliffordAlgebra.left_induction with
+  | algebraMap r => simp
+  | add x y hx hy => simp only [map_add, hx, hy, neg_add]
+  | ι_mul x a hx =>
+    have hlhs : involute (contractLeft d (ι Q a * x))
+        = d a • involute x - ι Q a * contractLeft d (involute x) := by
+      rw [contractLeft_ι_mul, map_sub, map_smul, map_mul, involute_ι, hx, neg_mul_neg]
+    have hrhs : involute (ι Q a * x) = -(ι Q a * involute x) := by
+      rw [map_mul, involute_ι, neg_mul]
+    rw [hlhs, hrhs, map_neg, neg_neg, contractLeft_ι_mul]
+
+/-- The anticommutator form of `TauCeti.CliffordAlgebra.involute_contractLeft`: contraction and
+the grade involution anticommute as endomorphisms. -/
+theorem contractLeft_involute_add (d : Module.Dual R M) (x : CliffordAlgebra Q) :
+    contractLeft d (involute x) + involute (contractLeft d (Q := Q) x) = 0 := by
+  rw [involute_contractLeft, add_neg_cancel]
+
+end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -7,22 +7,20 @@ module
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
 
 /-!
-# The grade involution against the degree-shifting operators
+# Contraction anticommutes with the grade involution
 
-The two operators that shift the exterior degree by one are left multiplication by a vector, which
-raises it, and `CliffordAlgebra.contractLeft`, which lowers it. Both exchange the two halves of the
-`ℤ/2`-grading, so both anticommute with the grade involution `CliffordAlgebra.involute`. This file
-records the two identities, which Mathlib does not: `involute` is related there to products (it is
-an algebra homomorphism) and to the grading, but neither consequence is stated, and the contraction
-is never mentioned alongside it.
+Mathlib's `CliffordAlgebra.contractLeft` lowers the degree of a multivector by one, so it
+exchanges the two halves of the `ℤ/2`-grading and therefore anticommutes with the grade
+involution `CliffordAlgebra.involute`. This file proves that single identity, which Mathlib does
+not record: `involute` interacts with products (`involute` is an algebra homomorphism) and with
+the grading, but never with a contraction.
 
-The identities are what make the grade involution usable as an odd operator alongside exterior
+The identity is what makes the grade involution usable as an odd operator alongside exterior
 multiplication and contraction — for instance as the operator by which an anisotropic vector
 orthogonal to a polarization acts on a spinor module.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.involute_ι_mul`: `involute (ι m * x) = -(ι m * involute x)`.
 * `TauCeti.CliffordAlgebra.involute_contractLeft`: `involute (d ⌋ x) = -(d ⌋ involute x)`.
 
 ## References
@@ -42,15 +40,6 @@ namespace TauCeti.CliffordAlgebra
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   {Q : QuadraticForm R M}
 
-/-- **The grade involution anticommutes with left multiplication by a vector.** A vector is odd,
-so multiplying by it swaps the even and odd parts of the Clifford algebra.
-
-Not a `simp` lemma: `simp` normalizes the left-hand side through `map_mul` and
-`CliffordAlgebra.involute_ι` instead. -/
-theorem involute_ι_mul (m : M) (x : CliffordAlgebra Q) :
-    involute (ι Q m * x) = -(ι Q m * involute x) := by
-  rw [map_mul, involute_ι, neg_mul]
-
 /-- **The grade involution anticommutes with contraction.** Contracting against a linear
 functional lowers the degree by one, hence swaps the even and odd parts of the Clifford algebra,
 so it anticommutes with the operator that is `+1` on the even part and `-1` on the odd part. -/
@@ -64,6 +53,8 @@ theorem involute_contractLeft (d : Module.Dual R M) (x : CliffordAlgebra Q) :
     have hlhs : involute (contractLeft d (ι Q a * x))
         = d a • involute x - ι Q a * contractLeft d (involute x) := by
       rw [contractLeft_ι_mul, map_sub, map_smul, map_mul, involute_ι, hx, neg_mul_neg]
-    rw [hlhs, involute_ι_mul, map_neg, neg_neg, contractLeft_ι_mul]
+    have hrhs : involute (ι Q a * x) = -(ι Q a * involute x) := by
+      rw [map_mul, involute_ι, neg_mul]
+    rw [hlhs, hrhs, map_neg, neg_neg, contractLeft_ι_mul]
 
 end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -54,7 +54,7 @@ theorem involute_ι_mul (m : M) (x : CliffordAlgebra Q) :
 /-- **The grade involution anticommutes with contraction.** Contracting against a linear
 functional lowers the degree by one, hence swaps the even and odd parts of the Clifford algebra,
 so it anticommutes with the operator that is `+1` on the even part and `-1` on the odd part. -/
-@[simp]
+@[simp, grind =]
 theorem involute_contractLeft (d : Module.Dual R M) (x : CliffordAlgebra Q) :
     involute (contractLeft d x) = -contractLeft d (involute x) := by
   induction x using CliffordAlgebra.left_induction with

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -7,20 +7,22 @@ module
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
 
 /-!
-# Contraction anticommutes with the grade involution
+# The grade involution against the degree-shifting operators
 
-Mathlib's `CliffordAlgebra.contractLeft` lowers the degree of a multivector by one, so it
-exchanges the two halves of the `ℤ/2`-grading and therefore anticommutes with the grade
-involution `CliffordAlgebra.involute`. This file proves that single identity, which Mathlib does
-not record: `involute` interacts with products (`involute` is an algebra homomorphism) and with
-the grading, but never with a contraction.
+The two operators that shift the exterior degree by one are left multiplication by a vector, which
+raises it, and `CliffordAlgebra.contractLeft`, which lowers it. Both exchange the two halves of the
+`ℤ/2`-grading, so both anticommute with the grade involution `CliffordAlgebra.involute`. This file
+records the two identities, which Mathlib does not: `involute` is related there to products (it is
+an algebra homomorphism) and to the grading, but neither consequence is stated, and the contraction
+is never mentioned alongside it.
 
-The identity is what makes the grade involution usable as an odd operator alongside exterior
+The identities are what make the grade involution usable as an odd operator alongside exterior
 multiplication and contraction — for instance as the operator by which an anisotropic vector
 orthogonal to a polarization acts on a spinor module.
 
 ## Main results
 
+* `TauCeti.CliffordAlgebra.involute_ι_mul`: `involute (ι m * x) = -(ι m * involute x)`.
 * `TauCeti.CliffordAlgebra.involute_contractLeft`: `involute (d ⌋ x) = -(d ⌋ involute x)`.
 
 ## References
@@ -40,6 +42,15 @@ namespace TauCeti.CliffordAlgebra
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   {Q : QuadraticForm R M}
 
+/-- **The grade involution anticommutes with left multiplication by a vector.** A vector is odd,
+so multiplying by it swaps the even and odd parts of the Clifford algebra.
+
+Not a `simp` lemma: `simp` normalizes the left-hand side through `map_mul` and
+`CliffordAlgebra.involute_ι` instead. -/
+theorem involute_ι_mul (m : M) (x : CliffordAlgebra Q) :
+    involute (ι Q m * x) = -(ι Q m * involute x) := by
+  rw [map_mul, involute_ι, neg_mul]
+
 /-- **The grade involution anticommutes with contraction.** Contracting against a linear
 functional lowers the degree by one, hence swaps the even and odd parts of the Clifford algebra,
 so it anticommutes with the operator that is `+1` on the even part and `-1` on the odd part. -/
@@ -53,8 +64,6 @@ theorem involute_contractLeft (d : Module.Dual R M) (x : CliffordAlgebra Q) :
     have hlhs : involute (contractLeft d (ι Q a * x))
         = d a • involute x - ι Q a * contractLeft d (involute x) := by
       rw [contractLeft_ι_mul, map_sub, map_smul, map_mul, involute_ι, hx, neg_mul_neg]
-    have hrhs : involute (ι Q a * x) = -(ι Q a * involute x) := by
-      rw [map_mul, involute_ι, neg_mul]
-    rw [hlhs, hrhs, map_neg, neg_neg, contractLeft_ι_mul]
+    rw [hlhs, involute_ι_mul, map_neg, neg_neg, contractLeft_ι_mul]
 
 end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -22,8 +22,6 @@ orthogonal to a polarization acts on a spinor module.
 ## Main results
 
 * `TauCeti.CliffordAlgebra.involute_contractLeft`: `involute (d ⌋ x) = -(d ⌋ involute x)`.
-* `TauCeti.CliffordAlgebra.contractLeft_involute_add`: the anticommutator form of the same
-  identity.
 
 ## References
 
@@ -45,6 +43,7 @@ variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 /-- **The grade involution anticommutes with contraction.** Contracting against a linear
 functional lowers the degree by one, hence swaps the even and odd parts of the Clifford algebra,
 so it anticommutes with the operator that is `+1` on the even part and `-1` on the odd part. -/
+@[simp]
 theorem involute_contractLeft (d : Module.Dual R M) (x : CliffordAlgebra Q) :
     involute (contractLeft d x) = -contractLeft d (involute x) := by
   induction x using CliffordAlgebra.left_induction with
@@ -57,11 +56,5 @@ theorem involute_contractLeft (d : Module.Dual R M) (x : CliffordAlgebra Q) :
     have hrhs : involute (ι Q a * x) = -(ι Q a * involute x) := by
       rw [map_mul, involute_ι, neg_mul]
     rw [hlhs, hrhs, map_neg, neg_neg, contractLeft_ι_mul]
-
-/-- The anticommutator form of `TauCeti.CliffordAlgebra.involute_contractLeft`: contraction and
-the grade involution anticommute as endomorphisms. -/
-theorem contractLeft_involute_add (d : Module.Dual R M) (x : CliffordAlgebra Q) :
-    contractLeft d (involute x) + involute (contractLeft d (Q := Q) x) = 0 := by
-  rw [involute_contractLeft, add_neg_cancel]
 
 end TauCeti.CliffordAlgebra

--- a/TauCeti/RepresentationTheory/Spin/CliffordAction.lean
+++ b/TauCeti/RepresentationTheory/Spin/CliffordAction.lean
@@ -1,0 +1,288 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Spin.Polarization.Basic
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
+import TauCeti.LinearAlgebra.CliffordAlgebra.Contraction
+
+/-!
+# The spinor module of a polarized quadratic space
+
+A polarization of a quadratic space `(V, Q)` splits it as `W ⊕ W' ⊕ L`, with `W` and `W'`
+isotropic and in perfect `QuadraticMap.polar`-pairing and `L` an orthogonal remainder carried by a
+scalar coordinate. This file turns the exterior algebra `⋀·W` into a module over the Clifford
+algebra of `Q` — the Fock model of the spinor representation, and the carrier of the spin and
+half-spin representations, which no tensor power of `V` contains.
+
+The three summands act by three visibly different operators on `S = ⋀·W`:
+
+* a vector of `W` acts by exterior multiplication (`TauCeti.SpinPolarizationData.wedge`), a
+  *creation* operator;
+* a vector of `W'` acts by contraction against the functional `QuadraticMap.polar Q · y` that the
+  polarization pairing attaches to it (`TauCeti.SpinPolarizationData.contract`), an
+  *annihilation* operator;
+* a vector of the remainder acts by its scalar coordinate times the grade involution
+  (`TauCeti.SpinPolarizationData.parity`), the operator that supplies the extra anticommuting
+  generator in odd dimension.
+
+Assembled into one linear map `TauCeti.SpinPolarizationData.cliffordOperator`, these satisfy the
+Clifford relation, and the universal property then produces the algebra homomorphism
+`TauCeti.spinAction`. The coefficient in the relation is not a prose "twice": the
+computation of `TauCeti.SpinPolarizationData.cliffordOperator_sq` runs through
+`QuadraticMap.polar`, and the polarized form
+`TauCeti.spinAction_ι_mul_add_swap` records the anticommutator
+`c x ∘ c y + c y ∘ c x = polar Q x y • 1` that pins it.
+
+The exterior algebra is Mathlib's `ExteriorAlgebra K W`, which *is*
+`CliffordAlgebra (0 : QuadraticForm K W)`, so the interior product is the zero-form
+specialization of `CliffordAlgebra.contractLeft` and the parity operator is the zero-form
+specialization of `CliffordAlgebra.involute`; there is no bespoke exterior-algebra vocabulary
+here. Everything holds over an arbitrary commutative ring, since
+`TauCeti.SpinPolarizationData` already carries the isotropy and pairing that the relation needs;
+no invertibility of `2` is used.
+
+Surjectivity of `TauCeti.spinAction` onto `Module.End K S` in even dimension, the restriction to
+`spinGroup Q`, and the half-spin summands are not proved here.
+
+## Main definitions
+
+* `TauCeti.SpinPolarizationData.wedge`, `TauCeti.SpinPolarizationData.contract`,
+  `TauCeti.SpinPolarizationData.parity`: the three component operators on `⋀·W`.
+* `TauCeti.SpinPolarizationData.cliffordOperator`: the operator `c v` on `⋀·W` attached to a
+  vector `v` of `V`, assembled from them.
+* `TauCeti.spinAction`: the resulting `CliffordAlgebra Q`-module structure on `⋀·W`.
+
+## Main results
+
+* `TauCeti.SpinPolarizationData.contract_wedge`, `TauCeti.SpinPolarizationData.parity_wedge` and
+  `TauCeti.SpinPolarizationData.parity_contract`: the anticommutation relations between the
+  component operators.
+* `TauCeti.SpinPolarizationData.cliffordOperator_sq`: the Clifford relation `c v ∘ c v = Q v • 1`.
+* `TauCeti.spinAction_ι_wedge`, `TauCeti.spinAction_ι_contract`, `TauCeti.spinAction_ι_parity`:
+  the three summands act by exterior multiplication, contraction, and the parity operator.
+* `TauCeti.spinAction_ι_mul_add_swap`: the anticommutator identity pinning the coefficient to
+  `QuadraticMap.polar`.
+
+## References
+
+* [Spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
+  Layer 4, "The Clifford module `S = ⋀·W`".
+* H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §5.
+-/
+
+public section
+
+open CliffordAlgebra QuadraticMap
+
+namespace TauCeti
+
+universe u v
+
+namespace SpinPolarizationData
+
+variable {K : Type u} [CommRing K] {V : Type v} [AddCommGroup V] [Module K V]
+  {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
+
+/-- **The creation operator**: a vector of the isotropic summand `W` acts on `⋀·W` by exterior
+multiplication. -/
+noncomputable def wedge : P.W →ₗ[K] Module.End K (ExteriorAlgebra K P.W) :=
+  (LinearMap.mul K (ExteriorAlgebra K P.W)).comp (ExteriorAlgebra.ι K)
+
+@[simp]
+theorem wedge_apply (x : P.W) (s : ExteriorAlgebra K P.W) :
+    P.wedge x s = ExteriorAlgebra.ι K x * s :=
+  -- `(rfl)`, not `rfl`: the body of `wedge` is not `@[expose]`d.
+  (rfl)
+
+/-- **The annihilation operator**: a vector `y` of the second isotropic summand `W'` acts on `⋀·W`
+by contraction against the functional `x ↦ polar Q x y` that the polarization pairing attaches to
+it. -/
+noncomputable def contract : P.W' →ₗ[K] Module.End K (ExteriorAlgebra K P.W) :=
+  (CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm K P.W))).comp
+    P.pairingEquiv.toLinearMap
+
+@[simp]
+theorem contract_apply (y : P.W') (s : ExteriorAlgebra K P.W) :
+    P.contract y s = CliffordAlgebra.contractLeft (P.pairingEquiv y) s :=
+  -- `(rfl)`, not `rfl`: the body of `contract` is not `@[expose]`d.
+  (rfl)
+
+/-- **The parity operator** on `⋀·W`, the grade involution of the exterior algebra. It anticommutes
+with both the creation and the annihilation operators, which is what lets an anisotropic vector
+orthogonal to the polarization act by a multiple of it. -/
+noncomputable def parity : Module.End K (ExteriorAlgebra K P.W) :=
+  (CliffordAlgebra.involute (Q := (0 : QuadraticForm K P.W))).toLinearMap
+
+@[simp]
+theorem parity_apply (s : ExteriorAlgebra K P.W) : P.parity s = CliffordAlgebra.involute s :=
+  -- `(rfl)`, not `rfl`: the body of `parity` is not `@[expose]`d.
+  (rfl)
+
+/-- A vector of the orthogonal remainder acts by its scalar coordinate times the parity
+operator, the normalization that makes its square the scalar `Q z`. -/
+noncomputable def lineOperator : P.line →ₗ[K] Module.End K (ExteriorAlgebra K P.W) :=
+  (LinearMap.toSpanSingleton K (Module.End K (ExteriorAlgebra K P.W)) P.parity).comp
+    P.lineCoordinate
+
+@[simp]
+theorem lineOperator_apply (z : P.line) (s : ExteriorAlgebra K P.W) :
+    P.lineOperator z s = P.lineCoordinate z • CliffordAlgebra.involute s :=
+  -- `(rfl)`, not `rfl`: the body of `lineOperator` is not `@[expose]`d.
+  (rfl)
+
+/-- **The Clifford operator** of a vector: the assembly of the creation, annihilation and parity
+operators along the polarization coordinates. -/
+noncomputable def cliffordOperator : V →ₗ[K] Module.End K (ExteriorAlgebra K P.W) :=
+  ((P.wedge.coprod P.contract).coprod P.lineOperator).comp
+    P.decompositionEquiv.symm.toLinearMap
+
+/-- The Clifford operator of a vector in polarization coordinates is the sum of the three
+component operators. -/
+theorem cliffordOperator_add_apply (x : P.W) (y : P.W') (z : P.line)
+    (s : ExteriorAlgebra K P.W) :
+    P.cliffordOperator ((x : V) + (y : V) + (z : V)) s =
+      P.wedge x s + P.contract y s + P.lineCoordinate z • P.parity s := by
+  simp [cliffordOperator]
+
+/-! ### The anticommutation relations
+
+The Clifford relation is the sum of six anticommutators between the three component operators.
+Each is recorded separately, in the "solved" form that rewrites a composite back to the opposite
+order, since that is what the assembly of `TauCeti.SpinPolarizationData.cliffordOperator_sq`
+consumes. -/
+
+/-- **Exterior multiplication is square-zero**: the isotropy of `W` at the level of operators. -/
+theorem wedge_wedge (x : P.W) (s : ExteriorAlgebra K P.W) : P.wedge x (P.wedge x s) = 0 := by
+  rw [wedge_apply, wedge_apply, ← mul_assoc, ExteriorAlgebra.ι_sq_zero, zero_mul]
+
+/-- **Contraction is square-zero**: the isotropy of `W'` at the level of operators. -/
+theorem contract_contract (y : P.W') (s : ExteriorAlgebra K P.W) :
+    P.contract y (P.contract y s) = 0 := by
+  rw [contract_apply, contract_apply, CliffordAlgebra.contractLeft_contractLeft]
+
+/-- **Creation and annihilation anticommute up to the pairing**: this is the one anticommutator
+that is not zero, and the scalar it produces is the polar form of the two vectors. It is what pins
+the coefficient of the Clifford relation to `QuadraticMap.polar`. -/
+theorem contract_wedge (x : P.W) (y : P.W') (s : ExteriorAlgebra K P.W) :
+    P.contract y (P.wedge x s) =
+      polar Q (x : V) (y : V) • s - P.wedge x (P.contract y s) := by
+  rw [contract_apply, wedge_apply, CliffordAlgebra.contractLeft_ι_mul, P.pairingEquiv_apply,
+    wedge_apply, contract_apply]
+
+/-- **The parity operator is an involution.** -/
+theorem parity_parity (s : ExteriorAlgebra K P.W) : P.parity (P.parity s) = s := by
+  rw [parity_apply, parity_apply, CliffordAlgebra.involute_involute]
+
+/-- **Parity anticommutes with exterior multiplication**, since a vector is odd. -/
+theorem parity_wedge (x : P.W) (s : ExteriorAlgebra K P.W) :
+    P.parity (P.wedge x s) = -P.wedge x (P.parity s) := by
+  rw [parity_apply, wedge_apply, map_mul, CliffordAlgebra.involute_ι, neg_mul, wedge_apply,
+    parity_apply]
+
+/-- **Parity anticommutes with contraction**, since contracting lowers the exterior degree
+by one. -/
+theorem parity_contract (y : P.W') (s : ExteriorAlgebra K P.W) :
+    P.parity (P.contract y s) = -P.contract y (P.parity s) := by
+  rw [parity_apply, contract_apply, TauCeti.CliffordAlgebra.involute_contractLeft, contract_apply,
+    parity_apply]
+
+/-- The quadratic form of a vector in polarization coordinates: both isotropic summands drop out
+and the remainder is orthogonal to them, so only the pairing term and the remainder survive. -/
+theorem quadraticForm_add (x : P.W) (y : P.W') (z : P.line) :
+    Q ((x : V) + (y : V) + (z : V)) = polar Q (x : V) (y : V) + Q (z : V) := by
+  have hxz : polar Q (x : V) (z : V) = 0 := by
+    rw [polar_comm]
+    exact P.line_orthogonal_W z x
+  have hyz : polar Q (y : V) (z : V) = 0 := by
+    rw [polar_comm]
+    exact P.line_orthogonal_W' z y
+  rw [QuadraticMap.map_add Q, QuadraticMap.map_add Q, P.isotropic_W, P.isotropic_W',
+    polar_add_left, hxz, hyz]
+  ring
+
+/-- **The Clifford relation for the spinor operators**: squaring the operator of a vector `v`
+returns the scalar `Q v`. The three cross terms are exactly the three anticommutators — creation
+against annihilation contributes the pairing, and parity against each of the other two cancels —
+so the coefficient is read off `QuadraticMap.polar`, not assumed. -/
+theorem cliffordOperator_sq (v : V) :
+    P.cliffordOperator v * P.cliffordOperator v
+      = algebraMap K (Module.End K (ExteriorAlgebra K P.W)) (Q v) := by
+  obtain ⟨c, rfl⟩ := P.decompositionEquiv.surjective v
+  obtain ⟨⟨x, y⟩, z⟩ := c
+  rw [P.decompositionEquiv_apply]
+  ext s
+  rw [Module.End.mul_apply, Module.algebraMap_end_apply, P.cliffordOperator_add_apply,
+    P.cliffordOperator_add_apply, P.quadraticForm_add, ← P.lineCoordinate_sq z]
+  simp only [map_add, map_smul, P.wedge_wedge, P.contract_contract, P.contract_wedge,
+    P.parity_wedge, P.parity_contract, P.parity_parity]
+  module
+
+end SpinPolarizationData
+
+/-- **The spinor representation of the Clifford algebra**: `CliffordAlgebra Q` acts on the
+exterior algebra `S = ⋀·W` of the isotropic summand of a polarization, by exterior multiplication
+for `W`, by contraction against the polar pairing for `W'`, and by a multiple of the parity
+operator for the orthogonal remainder.
+
+This is the Fock model of the spin module. In even dimension over an algebraically closed field it
+is an isomorphism onto `Module.End K S`, and in odd dimension it factors through one of the two
+central-idempotent summands of the Clifford algebra; neither statement is proved here. -/
+noncomputable def spinAction {K : Type u} [CommRing K] {V : Type v} [AddCommGroup V] [Module K V]
+    (Q : QuadraticForm K V) (P : SpinPolarizationData Q) :
+    CliffordAlgebra Q →ₐ[K] Module.End K (ExteriorAlgebra K P.W) :=
+  CliffordAlgebra.lift Q ⟨P.cliffordOperator, P.cliffordOperator_sq⟩
+
+variable {K : Type u} [CommRing K] {V : Type v} [AddCommGroup V] [Module K V]
+  {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
+
+@[simp]
+theorem spinAction_ι (v : V) :
+    spinAction Q P (CliffordAlgebra.ι Q v) = P.cliffordOperator v :=
+  CliffordAlgebra.lift_ι_apply _ _ v
+
+/-- A vector of the isotropic summand `W` acts on the spin module by exterior multiplication. -/
+theorem spinAction_ι_wedge (x : P.W) (s : ExteriorAlgebra K P.W) :
+    spinAction Q P (CliffordAlgebra.ι Q x) s = ExteriorAlgebra.ι K x * s := by
+  rw [spinAction_ι, show ((x : V)) = (x : V) + ((0 : P.W') : V) + ((0 : P.line) : V) by simp,
+    P.cliffordOperator_add_apply]
+  simp
+
+/-- A vector of the second isotropic summand `W'` acts on the spin module by contraction against
+the functional the polarization pairing attaches to it. -/
+theorem spinAction_ι_contract (y : P.W') (s : ExteriorAlgebra K P.W) :
+    spinAction Q P (CliffordAlgebra.ι Q y) s =
+      CliffordAlgebra.contractLeft (P.pairingEquiv y) s := by
+  rw [spinAction_ι, show ((y : V)) = ((0 : P.W) : V) + (y : V) + ((0 : P.line) : V) by simp,
+    P.cliffordOperator_add_apply]
+  simp
+
+/-- A vector of the orthogonal remainder acts on the spin module by its scalar coordinate times
+the parity operator. -/
+theorem spinAction_ι_parity (z : P.line) (s : ExteriorAlgebra K P.W) :
+    spinAction Q P (CliffordAlgebra.ι Q z) s =
+      P.lineCoordinate z • CliffordAlgebra.involute s := by
+  rw [spinAction_ι,
+    show ((z : V)) = ((0 : P.W) : V) + ((0 : P.W') : V) + (z : V) by simp,
+    P.cliffordOperator_add_apply]
+  simp
+
+/-- **The anticommutator identity** pinning the coefficient of the spinor action: two vectors act
+with anticommutator the scalar `QuadraticMap.polar Q x y`. Taking `y = x` returns the Clifford
+relation, since `polar Q x x = 2 • Q x`. -/
+theorem spinAction_ι_mul_add_swap (a b : V) :
+    spinAction Q P (CliffordAlgebra.ι Q a) * spinAction Q P (CliffordAlgebra.ι Q b)
+        + spinAction Q P (CliffordAlgebra.ι Q b) * spinAction Q P (CliffordAlgebra.ι Q a)
+      = algebraMap K (Module.End K (ExteriorAlgebra K P.W)) (polar Q a b) := by
+  rw [← map_mul (spinAction Q P), ← map_mul (spinAction Q P), ← map_add (spinAction Q P),
+    CliffordAlgebra.ι_mul_ι_add_swap, AlgHom.commutes]
+
+/-- The second isotropic summand annihilates the vacuum vector `1 ∈ ⋀·W`: contraction lowers the
+exterior degree, and the vacuum has degree zero. -/
+theorem spinAction_ι_apply_one (y : P.W') :
+    spinAction Q P (CliffordAlgebra.ι Q y) 1 = 0 := by
+  rw [spinAction_ι_contract, CliffordAlgebra.contractLeft_one]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
@@ -85,6 +85,27 @@ theorem decompositionEquiv_symm_apply {K : Type u} [CommRing K] {V : Type v}
   apply P.decompositionEquiv.injective
   rw [P.decompositionEquiv.apply_symm_apply, P.decompositionEquiv_apply]
 
+/-- A vector of the first isotropic summand has only that coordinate. -/
+@[simp, grind =]
+theorem decompositionEquiv_symm_coe_W {K : Type u} [CommRing K] {V : Type v}
+    [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
+    (x : P.W) : P.decompositionEquiv.symm (x : V) = ((x, 0), 0) := by
+  simpa using P.decompositionEquiv_symm_apply x 0 0
+
+/-- A vector of the second isotropic summand has only that coordinate. -/
+@[simp, grind =]
+theorem decompositionEquiv_symm_coe_W' {K : Type u} [CommRing K] {V : Type v}
+    [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
+    (y : P.W') : P.decompositionEquiv.symm (y : V) = ((0, y), 0) := by
+  simpa using P.decompositionEquiv_symm_apply 0 y 0
+
+/-- A vector of the orthogonal remainder has only that coordinate. -/
+@[simp, grind =]
+theorem decompositionEquiv_symm_coe_line {K : Type u} [CommRing K] {V : Type v}
+    [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
+    (z : P.line) : P.decompositionEquiv.symm (z : V) = ((0, 0), z) := by
+  simpa using P.decompositionEquiv_symm_apply 0 0 z
+
 /-- The polar pairing has trivial right radical. -/
 theorem pairing_separatingRight {K : Type u} [CommRing K] {V : Type v}
     [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} (P : SpinPolarizationData Q)

--- a/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
@@ -152,14 +152,19 @@ theorem cliffordOperator_coe_W' (y : P.W') : P.cliffordOperator (y : V) = P.cont
 theorem cliffordOperator_coe_line (z : P.line) : P.cliffordOperator (z : V) = P.lineOperator z := by
   simp [cliffordOperator]
 
-/-! ### The anticommutation relations
+/-! ### The squares and the anticommutators of the component operators
 
-The Clifford relation is the sum of six anticommutators between the three component operators.
-Five of them are square-zero or anticommutation statements about a single Clifford algebra,
-supplied by `ExteriorAlgebra.ι_sq_zero`, `CliffordAlgebra.contractLeft_contractLeft`,
-`CliffordAlgebra.involute_involute`, `TauCeti.CliffordAlgebra.involute_ι_mul` and
-`TauCeti.CliffordAlgebra.involute_contractLeft`. The sixth is the only one that sees the
-polarization, and it is recorded here. -/
+Expanding the Clifford relation in polarization coordinates produces six terms: the squares of
+the three component operators, and the three anticommutators between distinct ones. Five are
+statements about a single Clifford algebra and come from elsewhere. The two isotropic squares
+vanish — `ExteriorAlgebra.ι_sq_zero` for creation and
+`CliffordAlgebra.contractLeft_contractLeft` for annihilation — whereas the parity square does not:
+it is the identity, by `CliffordAlgebra.involute_involute`, which is what makes the remainder
+coordinate contribute `Q z` rather than `0`. Parity anticommutes with each of the other two, by
+`CliffordAlgebra.involute_ι` through `map_mul` and by
+`TauCeti.CliffordAlgebra.involute_contractLeft`. The sixth term, the creation–annihilation
+anticommutator, is the only one that sees the polarization and the only nonzero one among the
+three; it is recorded here. -/
 
 /-- **Creation and annihilation anticommute up to the pairing**: this is the one anticommutator
 that is not zero, and the scalar it produces is the polar form of the two vectors. It is what pins
@@ -205,7 +210,8 @@ theorem cliffordOperator_sq (v : V) :
     wedge_apply, contract_apply, lineOperator_apply, map_add, map_smul, mul_add,
     ← mul_assoc, ExteriorAlgebra.ι_sq_zero, zero_mul,
     CliffordAlgebra.contractLeft_ι_mul, CliffordAlgebra.contractLeft_contractLeft,
-    TauCeti.CliffordAlgebra.involute_ι_mul, TauCeti.CliffordAlgebra.involute_contractLeft,
+    map_mul, CliffordAlgebra.involute_ι, neg_mul,
+    TauCeti.CliffordAlgebra.involute_contractLeft,
     CliffordAlgebra.involute_involute, P.pairingEquiv_apply]
   module
 

--- a/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
@@ -67,7 +67,6 @@ Surjectivity of `TauCeti.spinAction` onto `Module.End K S` in even dimension, th
 * `TauCeti.spinAction_ι_wedge`, `TauCeti.spinAction_ι_contract` and
   `TauCeti.spinAction_ι_lineOperator`: the three summands act by exterior multiplication,
   contraction, and the parity operator.
-* `TauCeti.spinAction_ι_contract_one`: the second isotropic summand annihilates the vacuum vector.
 
 ## References
 
@@ -256,12 +255,5 @@ theorem spinAction_ι_lineOperator (z : P.line) (s : ExteriorAlgebra K P.W) :
     spinAction Q P (CliffordAlgebra.ι Q z) s =
       P.lineCoordinate z • CliffordAlgebra.involute s := by
   rw [spinAction_ι, P.cliffordOperator_coe_line, P.lineOperator_apply]
-
-/-- The second isotropic summand annihilates the vacuum vector `1 ∈ ⋀·W`: contraction lowers the
-exterior degree, and the vacuum has degree zero. -/
-@[grind =]
-theorem spinAction_ι_contract_one (y : P.W') :
-    spinAction Q P (CliffordAlgebra.ι Q y) 1 = 0 := by
-  rw [spinAction_ι_contract, CliffordAlgebra.contractLeft_one]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
@@ -33,9 +33,8 @@ Assembled into one linear map `TauCeti.SpinPolarizationData.cliffordOperator`, t
 Clifford relation, and the universal property then produces the algebra homomorphism
 `TauCeti.spinAction`. The coefficient in the relation is not a prose "twice": the
 computation of `TauCeti.SpinPolarizationData.cliffordOperator_sq` runs through
-`QuadraticMap.polar`, and the polarized form
-`TauCeti.spinAction_ι_mul_add_swap` records the anticommutator
-`c x ∘ c y + c y ∘ c x = polar Q x y • 1` that pins it.
+`QuadraticMap.polar`, which enters through the creation–annihilation anticommutator
+`TauCeti.SpinPolarizationData.contract_wedge` and through nothing else.
 
 The exterior algebra is Mathlib's `ExteriorAlgebra K W`, which *is*
 `CliffordAlgebra (0 : QuadraticForm K W)`, so the interior product is the zero-form
@@ -69,8 +68,6 @@ Surjectivity of `TauCeti.spinAction` onto `Module.End K S` in even dimension, th
   `TauCeti.spinAction_ι_lineOperator`: the three summands act by exterior multiplication,
   contraction, and the parity operator.
 * `TauCeti.spinAction_ι_contract_one`: the second isotropic summand annihilates the vacuum vector.
-* `TauCeti.spinAction_ι_mul_add_swap`: the anticommutator identity pinning the coefficient to
-  `QuadraticMap.polar`.
 
 ## References
 
@@ -169,6 +166,7 @@ three; it is recorded here. -/
 /-- **Creation and annihilation anticommute up to the pairing**: this is the one anticommutator
 that is not zero, and the scalar it produces is the polar form of the two vectors. It is what pins
 the coefficient of the Clifford relation to `QuadraticMap.polar`. -/
+@[grind =]
 theorem contract_wedge (x : P.W) (y : P.W') (s : ExteriorAlgebra K P.W) :
     P.contract y (P.wedge x s) =
       polar Q (x : V) (y : V) • s - P.wedge x (P.contract y s) := by
@@ -258,17 +256,6 @@ theorem spinAction_ι_lineOperator (z : P.line) (s : ExteriorAlgebra K P.W) :
     spinAction Q P (CliffordAlgebra.ι Q z) s =
       P.lineCoordinate z • CliffordAlgebra.involute s := by
   rw [spinAction_ι, P.cliffordOperator_coe_line, P.lineOperator_apply]
-
-/-- **The anticommutator identity** pinning the coefficient of the spinor action: two vectors `a`
-and `b` act with anticommutator the scalar `QuadraticMap.polar Q a b`. Setting `b = a` gives twice
-the Clifford relation, since `polar Q a a = 2 • Q a`; the relation itself, which does not need `2`
-to be cancellable, is `TauCeti.SpinPolarizationData.cliffordOperator_sq`. -/
-theorem spinAction_ι_mul_add_swap (a b : V) :
-    spinAction Q P (CliffordAlgebra.ι Q a) * spinAction Q P (CliffordAlgebra.ι Q b)
-        + spinAction Q P (CliffordAlgebra.ι Q b) * spinAction Q P (CliffordAlgebra.ι Q a)
-      = algebraMap K (Module.End K (ExteriorAlgebra K P.W)) (polar Q a b) := by
-  rw [← map_mul (spinAction Q P), ← map_mul (spinAction Q P), ← map_add (spinAction Q P),
-    CliffordAlgebra.ι_mul_ι_add_swap, AlgHom.commutes]
 
 /-- The second isotropic summand annihilates the vacuum vector `1 ∈ ⋀·W`: contraction lowers the
 exterior degree, and the vacuum has degree zero. -/

--- a/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
@@ -14,8 +14,9 @@ import TauCeti.LinearAlgebra.CliffordAlgebra.Contraction
 A polarization of a quadratic space `(V, Q)` splits it as `W ⊕ W' ⊕ L`, with `W` and `W'`
 isotropic and in perfect `QuadraticMap.polar`-pairing and `L` an orthogonal remainder carried by a
 scalar coordinate. This file turns the exterior algebra `⋀·W` into a module over the Clifford
-algebra of `Q` — the Fock model of the spinor representation, and the carrier of the spin and
-half-spin representations, which no tensor power of `V` contains.
+algebra of `Q` — the Fock model of the spinor representation. Classically, over `ℂ`, it is the
+carrier of the spin and half-spin representations, which no tensor power of `V` contains; that
+statement belongs to the complex theory and is not proved here.
 
 The three summands act by three visibly different operators on `S = ⋀·W`:
 
@@ -57,6 +58,10 @@ Surjectivity of `TauCeti.spinAction` onto `Module.End K S` in even dimension, th
 
 ## Main results
 
+* `TauCeti.SpinPolarizationData.cliffordOperator_coe_W`,
+  `TauCeti.SpinPolarizationData.cliffordOperator_coe_W'` and
+  `TauCeti.SpinPolarizationData.cliffordOperator_coe_line`: the operator of a vector of a single
+  summand, in terms of the component operator of that summand.
 * `TauCeti.SpinPolarizationData.contract_wedge`, `TauCeti.SpinPolarizationData.parity_wedge` and
   `TauCeti.SpinPolarizationData.parity_contract`: the anticommutation relations between the
   component operators.
@@ -147,6 +152,30 @@ theorem cliffordOperator_add_apply (x : P.W) (y : P.W') (z : P.line)
       P.wedge x s + P.contract y s + P.lineCoordinate z • P.parity s := by
   simp [cliffordOperator]
 
+/-- On the isotropic summand `W` the Clifford operator is the creation operator. -/
+@[simp]
+theorem cliffordOperator_coe_W (x : P.W) : P.cliffordOperator (x : V) = P.wedge x := by
+  have h : P.decompositionEquiv.symm (x : V) = ((x, 0), 0) := by
+    apply P.decompositionEquiv.injective
+    simp
+  simp [cliffordOperator, h]
+
+/-- On the second isotropic summand `W'` the Clifford operator is the annihilation operator. -/
+@[simp]
+theorem cliffordOperator_coe_W' (y : P.W') : P.cliffordOperator (y : V) = P.contract y := by
+  have h : P.decompositionEquiv.symm (y : V) = ((0, y), 0) := by
+    apply P.decompositionEquiv.injective
+    simp
+  simp [cliffordOperator, h]
+
+/-- On the orthogonal remainder the Clifford operator is the scaled parity operator. -/
+@[simp]
+theorem cliffordOperator_coe_line (z : P.line) : P.cliffordOperator (z : V) = P.lineOperator z := by
+  have h : P.decompositionEquiv.symm (z : V) = ((0, 0), z) := by
+    apply P.decompositionEquiv.injective
+    simp
+  simp [cliffordOperator, h]
+
 /-! ### The anticommutation relations
 
 The Clifford relation is the sum of six anticommutators between the three component operators.
@@ -191,7 +220,7 @@ theorem parity_contract (y : P.W') (s : ExteriorAlgebra K P.W) :
 
 /-- The quadratic form of a vector in polarization coordinates: both isotropic summands drop out
 and the remainder is orthogonal to them, so only the pairing term and the remainder survive. -/
-theorem quadraticForm_add (x : P.W) (y : P.W') (z : P.line) :
+theorem quadraticForm_decomposition_apply (x : P.W) (y : P.W') (z : P.line) :
     Q ((x : V) + (y : V) + (z : V)) = polar Q (x : V) (y : V) + Q (z : V) := by
   have hxz : polar Q (x : V) (z : V) = 0 := by
     rw [polar_comm]
@@ -215,7 +244,7 @@ theorem cliffordOperator_sq (v : V) :
   rw [P.decompositionEquiv_apply]
   ext s
   rw [Module.End.mul_apply, Module.algebraMap_end_apply, P.cliffordOperator_add_apply,
-    P.cliffordOperator_add_apply, P.quadraticForm_add, ← P.lineCoordinate_sq z]
+    P.cliffordOperator_add_apply, P.quadraticForm_decomposition_apply, ← P.lineCoordinate_sq z]
   simp only [map_add, map_smul, P.wedge_wedge, P.contract_contract, P.contract_wedge,
     P.parity_wedge, P.parity_contract, P.parity_parity]
   module
@@ -227,9 +256,11 @@ exterior algebra `S = ⋀·W` of the isotropic summand of a polarization, by ext
 for `W`, by contraction against the polar pairing for `W'`, and by a multiple of the parity
 operator for the orthogonal remainder.
 
-This is the Fock model of the spin module. In even dimension over an algebraically closed field it
-is an isomorphism onto `Module.End K S`, and in odd dimension it factors through one of the two
-central-idempotent summands of the Clifford algebra; neither statement is proved here. -/
+This is the Fock model of the spin module. Classically — over an algebraically closed field of
+characteristic different from `2`, with `Q` nondegenerate and finite-dimensional — it is an
+isomorphism onto `Module.End K S` in even dimension, and in odd dimension it factors through one
+of the two central-idempotent summands of the Clifford algebra; neither statement is proved
+here, and neither is claimed at the generality of this definition. -/
 noncomputable def spinAction {K : Type u} [CommRing K] {V : Type v} [AddCommGroup V] [Module K V]
     (Q : QuadraticForm K V) (P : SpinPolarizationData Q) :
     CliffordAlgebra Q →ₐ[K] Module.End K (ExteriorAlgebra K P.W) :=
@@ -246,28 +277,21 @@ theorem spinAction_ι (v : V) :
 /-- A vector of the isotropic summand `W` acts on the spin module by exterior multiplication. -/
 theorem spinAction_ι_wedge (x : P.W) (s : ExteriorAlgebra K P.W) :
     spinAction Q P (CliffordAlgebra.ι Q x) s = ExteriorAlgebra.ι K x * s := by
-  rw [spinAction_ι, show ((x : V)) = (x : V) + ((0 : P.W') : V) + ((0 : P.line) : V) by simp,
-    P.cliffordOperator_add_apply]
-  simp
+  rw [spinAction_ι, P.cliffordOperator_coe_W, P.wedge_apply]
 
 /-- A vector of the second isotropic summand `W'` acts on the spin module by contraction against
 the functional the polarization pairing attaches to it. -/
 theorem spinAction_ι_contract (y : P.W') (s : ExteriorAlgebra K P.W) :
     spinAction Q P (CliffordAlgebra.ι Q y) s =
       CliffordAlgebra.contractLeft (P.pairingEquiv y) s := by
-  rw [spinAction_ι, show ((y : V)) = ((0 : P.W) : V) + (y : V) + ((0 : P.line) : V) by simp,
-    P.cliffordOperator_add_apply]
-  simp
+  rw [spinAction_ι, P.cliffordOperator_coe_W', P.contract_apply]
 
 /-- A vector of the orthogonal remainder acts on the spin module by its scalar coordinate times
 the parity operator. -/
 theorem spinAction_ι_parity (z : P.line) (s : ExteriorAlgebra K P.W) :
     spinAction Q P (CliffordAlgebra.ι Q z) s =
       P.lineCoordinate z • CliffordAlgebra.involute s := by
-  rw [spinAction_ι,
-    show ((z : V)) = ((0 : P.W) : V) + ((0 : P.W') : V) + (z : V) by simp,
-    P.cliffordOperator_add_apply]
-  simp
+  rw [spinAction_ι, P.cliffordOperator_coe_line, P.lineOperator_apply]
 
 /-- **The anticommutator identity** pinning the coefficient of the spinor action: two vectors act
 with anticommutator the scalar `QuadraticMap.polar Q x y`. Taking `y = x` returns the Clifford
@@ -281,7 +305,7 @@ theorem spinAction_ι_mul_add_swap (a b : V) :
 
 /-- The second isotropic summand annihilates the vacuum vector `1 ∈ ⋀·W`: contraction lowers the
 exterior degree, and the vacuum has degree zero. -/
-theorem spinAction_ι_apply_one (y : P.W') :
+theorem spinAction_ι_contract_one (y : P.W') :
     spinAction Q P (CliffordAlgebra.ι Q y) 1 = 0 := by
   rw [spinAction_ι_contract, CliffordAlgebra.contractLeft_one]
 

--- a/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
@@ -65,8 +65,9 @@ Surjectivity of `TauCeti.spinAction` onto `Module.End K S` in even dimension, th
 * `TauCeti.SpinPolarizationData.contract_wedge`: the only anticommutation relation between the
   component operators that is not zero, and the one carrying the polarization pairing.
 * `TauCeti.SpinPolarizationData.cliffordOperator_sq`: the Clifford relation `c v ∘ c v = Q v • 1`.
-* `TauCeti.spinAction_ι_wedge`, `TauCeti.spinAction_ι_contract`, `TauCeti.spinAction_ι_parity`:
-  the three summands act by exterior multiplication, contraction, and the parity operator.
+* `TauCeti.spinAction_ι_wedge`, `TauCeti.spinAction_ι_contract` and
+  `TauCeti.spinAction_ι_lineOperator`: the three summands act by exterior multiplication,
+  contraction, and the parity operator.
 * `TauCeti.spinAction_ι_contract_one`: the second isotropic summand annihilates the vacuum vector.
 * `TauCeti.spinAction_ι_mul_add_swap`: the anticommutator identity pinning the coefficient to
   `QuadraticMap.polar`.
@@ -96,7 +97,7 @@ multiplication. -/
 noncomputable def wedge : P.W →ₗ[K] Module.End K (ExteriorAlgebra K P.W) :=
   (LinearMap.mul K (ExteriorAlgebra K P.W)).comp (ExteriorAlgebra.ι K)
 
-@[simp]
+@[simp, grind =]
 theorem wedge_apply (x : P.W) (s : ExteriorAlgebra K P.W) :
     P.wedge x s = ExteriorAlgebra.ι K x * s :=
   -- `(rfl)`, not `rfl`: the body of `wedge` is not `@[expose]`d.
@@ -109,7 +110,7 @@ noncomputable def contract : P.W' →ₗ[K] Module.End K (ExteriorAlgebra K P.W)
   (CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm K P.W))).comp
     P.pairingEquiv.toLinearMap
 
-@[simp]
+@[simp, grind =]
 theorem contract_apply (y : P.W') (s : ExteriorAlgebra K P.W) :
     P.contract y s = CliffordAlgebra.contractLeft (P.pairingEquiv y) s :=
   -- `(rfl)`, not `rfl`: the body of `contract` is not `@[expose]`d.
@@ -124,7 +125,7 @@ noncomputable def lineOperator : P.line →ₗ[K] Module.End K (ExteriorAlgebra 
     (CliffordAlgebra.involute (Q := (0 : QuadraticForm K P.W))).toLinearMap).comp
     P.lineCoordinate
 
-@[simp]
+@[simp, grind =]
 theorem lineOperator_apply (z : P.line) (s : ExteriorAlgebra K P.W) :
     P.lineOperator z s = P.lineCoordinate z • CliffordAlgebra.involute s :=
   -- `(rfl)`, not `rfl`: the body of `lineOperator` is not `@[expose]`d.
@@ -137,17 +138,17 @@ noncomputable def cliffordOperator : V →ₗ[K] Module.End K (ExteriorAlgebra K
     P.decompositionEquiv.symm.toLinearMap
 
 /-- On the isotropic summand `W` the Clifford operator is the creation operator. -/
-@[simp]
+@[simp, grind =]
 theorem cliffordOperator_coe_W (x : P.W) : P.cliffordOperator (x : V) = P.wedge x := by
   simp [cliffordOperator]
 
 /-- On the second isotropic summand `W'` the Clifford operator is the annihilation operator. -/
-@[simp]
+@[simp, grind =]
 theorem cliffordOperator_coe_W' (y : P.W') : P.cliffordOperator (y : V) = P.contract y := by
   simp [cliffordOperator]
 
 /-- On the orthogonal remainder the Clifford operator is the scaled parity operator. -/
-@[simp]
+@[simp, grind =]
 theorem cliffordOperator_coe_line (z : P.line) : P.cliffordOperator (z : V) = P.lineOperator z := by
   simp [cliffordOperator]
 
@@ -171,7 +172,8 @@ theorem contract_wedge (x : P.W) (y : P.W') (s : ExteriorAlgebra K P.W) :
 
 /-- The quadratic form of a vector in polarization coordinates: both isotropic summands drop out
 and the remainder is orthogonal to them, so only the pairing term and the remainder survive. -/
-theorem quadraticForm_decompositionEquiv_apply (x : P.W) (y : P.W') (z : P.line) :
+@[simp, grind =]
+theorem quadraticForm_coe_add_coe_add_coe (x : P.W) (y : P.W') (z : P.line) :
     Q ((x : V) + (y : V) + (z : V)) = polar Q (x : V) (y : V) + Q (z : V) := by
   have hxz : polar Q (x : V) (z : V) = 0 := by
     rw [polar_comm]
@@ -197,7 +199,7 @@ theorem cliffordOperator_sq (v : V) :
       = P.wedge x + P.contract y + P.lineOperator z := by
     simp only [map_add, P.cliffordOperator_coe_W, P.cliffordOperator_coe_W',
       P.cliffordOperator_coe_line]
-  rw [hc, P.quadraticForm_decompositionEquiv_apply, ← P.lineCoordinate_sq z]
+  rw [hc, P.quadraticForm_coe_add_coe_add_coe, ← P.lineCoordinate_sq z]
   ext s
   simp only [Module.End.mul_apply, LinearMap.add_apply, Module.algebraMap_end_apply,
     wedge_apply, contract_apply, lineOperator_apply, map_add, map_smul, mul_add,
@@ -227,7 +229,7 @@ noncomputable def spinAction {K : Type u} [CommRing K] {V : Type v} [AddCommGrou
 variable {K : Type u} [CommRing K] {V : Type v} [AddCommGroup V] [Module K V]
   {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
 
-@[simp]
+@[simp, grind =]
 theorem spinAction_ι (v : V) :
     spinAction Q P (CliffordAlgebra.ι Q v) = P.cliffordOperator v :=
   CliffordAlgebra.lift_ι_apply _ _ v
@@ -246,7 +248,7 @@ theorem spinAction_ι_contract (y : P.W') (s : ExteriorAlgebra K P.W) :
 
 /-- A vector of the orthogonal remainder acts on the spin module by its scalar coordinate times
 the parity operator. -/
-theorem spinAction_ι_parity (z : P.line) (s : ExteriorAlgebra K P.W) :
+theorem spinAction_ι_lineOperator (z : P.line) (s : ExteriorAlgebra K P.W) :
     spinAction Q P (CliffordAlgebra.ι Q z) s =
       P.lineCoordinate z • CliffordAlgebra.involute s := by
   rw [spinAction_ι, P.cliffordOperator_coe_line, P.lineOperator_apply]
@@ -264,6 +266,7 @@ theorem spinAction_ι_mul_add_swap (a b : V) :
 
 /-- The second isotropic summand annihilates the vacuum vector `1 ∈ ⋀·W`: contraction lowers the
 exterior degree, and the vacuum has degree zero. -/
+@[grind =]
 theorem spinAction_ι_contract_one (y : P.W') :
     spinAction Q P (CliffordAlgebra.ι Q y) 1 = 0 := by
   rw [spinAction_ι_contract, CliffordAlgebra.contractLeft_one]

--- a/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
@@ -25,8 +25,8 @@ The three summands act by three visibly different operators on `S = ⋀·W`:
 * a vector of `W'` acts by contraction against the functional `QuadraticMap.polar Q · y` that the
   polarization pairing attaches to it (`TauCeti.SpinPolarizationData.contract`), an
   *annihilation* operator;
-* a vector of the remainder acts by its scalar coordinate times the grade involution
-  (`TauCeti.SpinPolarizationData.parity`), the operator that supplies the extra anticommuting
+* a vector of the remainder acts by its scalar coordinate times the grade involution, or *parity*
+  operator, of `⋀·W` (`TauCeti.SpinPolarizationData.lineOperator`), which supplies the extra
   generator in odd dimension.
 
 Assembled into one linear map `TauCeti.SpinPolarizationData.cliffordOperator`, these satisfy the
@@ -51,7 +51,7 @@ Surjectivity of `TauCeti.spinAction` onto `Module.End K S` in even dimension, th
 ## Main definitions
 
 * `TauCeti.SpinPolarizationData.wedge`, `TauCeti.SpinPolarizationData.contract`,
-  `TauCeti.SpinPolarizationData.parity`: the three component operators on `⋀·W`.
+  `TauCeti.SpinPolarizationData.lineOperator`: the three component operators on `⋀·W`.
 * `TauCeti.SpinPolarizationData.cliffordOperator`: the operator `c v` on `⋀·W` attached to a
   vector `v` of `V`, assembled from them.
 * `TauCeti.spinAction`: the resulting `CliffordAlgebra Q`-module structure on `⋀·W`.
@@ -62,12 +62,12 @@ Surjectivity of `TauCeti.spinAction` onto `Module.End K S` in even dimension, th
   `TauCeti.SpinPolarizationData.cliffordOperator_coe_W'` and
   `TauCeti.SpinPolarizationData.cliffordOperator_coe_line`: the operator of a vector of a single
   summand, in terms of the component operator of that summand.
-* `TauCeti.SpinPolarizationData.contract_wedge`, `TauCeti.SpinPolarizationData.parity_wedge` and
-  `TauCeti.SpinPolarizationData.parity_contract`: the anticommutation relations between the
-  component operators.
+* `TauCeti.SpinPolarizationData.contract_wedge`: the only anticommutation relation between the
+  component operators that is not zero, and the one carrying the polarization pairing.
 * `TauCeti.SpinPolarizationData.cliffordOperator_sq`: the Clifford relation `c v ∘ c v = Q v • 1`.
 * `TauCeti.spinAction_ι_wedge`, `TauCeti.spinAction_ι_contract`, `TauCeti.spinAction_ι_parity`:
   the three summands act by exterior multiplication, contraction, and the parity operator.
+* `TauCeti.spinAction_ι_contract_one`: the second isotropic summand annihilates the vacuum vector.
 * `TauCeti.spinAction_ι_mul_add_swap`: the anticommutator identity pinning the coefficient to
   `QuadraticMap.polar`.
 
@@ -115,21 +115,13 @@ theorem contract_apply (y : P.W') (s : ExteriorAlgebra K P.W) :
   -- `(rfl)`, not `rfl`: the body of `contract` is not `@[expose]`d.
   (rfl)
 
-/-- **The parity operator** on `⋀·W`, the grade involution of the exterior algebra. It anticommutes
-with both the creation and the annihilation operators, which is what lets an anisotropic vector
-orthogonal to the polarization act by a multiple of it. -/
-noncomputable def parity : Module.End K (ExteriorAlgebra K P.W) :=
-  (CliffordAlgebra.involute (Q := (0 : QuadraticForm K P.W))).toLinearMap
-
-@[simp]
-theorem parity_apply (s : ExteriorAlgebra K P.W) : P.parity s = CliffordAlgebra.involute s :=
-  -- `(rfl)`, not `rfl`: the body of `parity` is not `@[expose]`d.
-  (rfl)
-
-/-- A vector of the orthogonal remainder acts by its scalar coordinate times the parity
-operator, the normalization that makes its square the scalar `Q z`. -/
+/-- **The parity operator**: a vector of the orthogonal remainder acts on `⋀·W` by its scalar
+coordinate times the grade involution `CliffordAlgebra.involute` of the exterior algebra. The
+involution anticommutes with both the creation and the annihilation operators, and the
+scalar coordinate is the normalization that makes the square of this operator `Q z`. -/
 noncomputable def lineOperator : P.line →ₗ[K] Module.End K (ExteriorAlgebra K P.W) :=
-  (LinearMap.toSpanSingleton K (Module.End K (ExteriorAlgebra K P.W)) P.parity).comp
+  (LinearMap.toSpanSingleton K (Module.End K (ExteriorAlgebra K P.W))
+    (CliffordAlgebra.involute (Q := (0 : QuadraticForm K P.W))).toLinearMap).comp
     P.lineCoordinate
 
 @[simp]
@@ -144,53 +136,29 @@ noncomputable def cliffordOperator : V →ₗ[K] Module.End K (ExteriorAlgebra K
   ((P.wedge.coprod P.contract).coprod P.lineOperator).comp
     P.decompositionEquiv.symm.toLinearMap
 
-/-- The Clifford operator of a vector in polarization coordinates is the sum of the three
-component operators. -/
-theorem cliffordOperator_add_apply (x : P.W) (y : P.W') (z : P.line)
-    (s : ExteriorAlgebra K P.W) :
-    P.cliffordOperator ((x : V) + (y : V) + (z : V)) s =
-      P.wedge x s + P.contract y s + P.lineCoordinate z • P.parity s := by
-  simp [cliffordOperator]
-
 /-- On the isotropic summand `W` the Clifford operator is the creation operator. -/
 @[simp]
 theorem cliffordOperator_coe_W (x : P.W) : P.cliffordOperator (x : V) = P.wedge x := by
-  have h : P.decompositionEquiv.symm (x : V) = ((x, 0), 0) := by
-    apply P.decompositionEquiv.injective
-    simp
-  simp [cliffordOperator, h]
+  simp [cliffordOperator]
 
 /-- On the second isotropic summand `W'` the Clifford operator is the annihilation operator. -/
 @[simp]
 theorem cliffordOperator_coe_W' (y : P.W') : P.cliffordOperator (y : V) = P.contract y := by
-  have h : P.decompositionEquiv.symm (y : V) = ((0, y), 0) := by
-    apply P.decompositionEquiv.injective
-    simp
-  simp [cliffordOperator, h]
+  simp [cliffordOperator]
 
 /-- On the orthogonal remainder the Clifford operator is the scaled parity operator. -/
 @[simp]
 theorem cliffordOperator_coe_line (z : P.line) : P.cliffordOperator (z : V) = P.lineOperator z := by
-  have h : P.decompositionEquiv.symm (z : V) = ((0, 0), z) := by
-    apply P.decompositionEquiv.injective
-    simp
-  simp [cliffordOperator, h]
+  simp [cliffordOperator]
 
 /-! ### The anticommutation relations
 
 The Clifford relation is the sum of six anticommutators between the three component operators.
-Each is recorded separately, in the "solved" form that rewrites a composite back to the opposite
-order, since that is what the assembly of `TauCeti.SpinPolarizationData.cliffordOperator_sq`
-consumes. -/
-
-/-- **Exterior multiplication is square-zero**: the isotropy of `W` at the level of operators. -/
-theorem wedge_wedge (x : P.W) (s : ExteriorAlgebra K P.W) : P.wedge x (P.wedge x s) = 0 := by
-  rw [wedge_apply, wedge_apply, ← mul_assoc, ExteriorAlgebra.ι_sq_zero, zero_mul]
-
-/-- **Contraction is square-zero**: the isotropy of `W'` at the level of operators. -/
-theorem contract_contract (y : P.W') (s : ExteriorAlgebra K P.W) :
-    P.contract y (P.contract y s) = 0 := by
-  rw [contract_apply, contract_apply, CliffordAlgebra.contractLeft_contractLeft]
+Five of them are square-zero or anticommutation statements about a single Clifford algebra,
+supplied by `ExteriorAlgebra.ι_sq_zero`, `CliffordAlgebra.contractLeft_contractLeft`,
+`CliffordAlgebra.involute_involute`, `TauCeti.CliffordAlgebra.involute_ι_mul` and
+`TauCeti.CliffordAlgebra.involute_contractLeft`. The sixth is the only one that sees the
+polarization, and it is recorded here. -/
 
 /-- **Creation and annihilation anticommute up to the pairing**: this is the one anticommutator
 that is not zero, and the scalar it produces is the polar form of the two vectors. It is what pins
@@ -201,26 +169,9 @@ theorem contract_wedge (x : P.W) (y : P.W') (s : ExteriorAlgebra K P.W) :
   rw [contract_apply, wedge_apply, CliffordAlgebra.contractLeft_ι_mul, P.pairingEquiv_apply,
     wedge_apply, contract_apply]
 
-/-- **The parity operator is an involution.** -/
-theorem parity_parity (s : ExteriorAlgebra K P.W) : P.parity (P.parity s) = s := by
-  rw [parity_apply, parity_apply, CliffordAlgebra.involute_involute]
-
-/-- **Parity anticommutes with exterior multiplication**, since a vector is odd. -/
-theorem parity_wedge (x : P.W) (s : ExteriorAlgebra K P.W) :
-    P.parity (P.wedge x s) = -P.wedge x (P.parity s) := by
-  rw [parity_apply, wedge_apply, map_mul, CliffordAlgebra.involute_ι, neg_mul, wedge_apply,
-    parity_apply]
-
-/-- **Parity anticommutes with contraction**, since contracting lowers the exterior degree
-by one. -/
-theorem parity_contract (y : P.W') (s : ExteriorAlgebra K P.W) :
-    P.parity (P.contract y s) = -P.contract y (P.parity s) := by
-  rw [parity_apply, contract_apply, TauCeti.CliffordAlgebra.involute_contractLeft, contract_apply,
-    parity_apply]
-
 /-- The quadratic form of a vector in polarization coordinates: both isotropic summands drop out
 and the remainder is orthogonal to them, so only the pairing term and the remainder survive. -/
-theorem quadraticForm_decomposition_apply (x : P.W) (y : P.W') (z : P.line) :
+theorem quadraticForm_decompositionEquiv_apply (x : P.W) (y : P.W') (z : P.line) :
     Q ((x : V) + (y : V) + (z : V)) = polar Q (x : V) (y : V) + Q (z : V) := by
   have hxz : polar Q (x : V) (z : V) = 0 := by
     rw [polar_comm]
@@ -242,11 +193,18 @@ theorem cliffordOperator_sq (v : V) :
   obtain ⟨c, rfl⟩ := P.decompositionEquiv.surjective v
   obtain ⟨⟨x, y⟩, z⟩ := c
   rw [P.decompositionEquiv_apply]
+  have hc : P.cliffordOperator ((x : V) + (y : V) + (z : V))
+      = P.wedge x + P.contract y + P.lineOperator z := by
+    simp only [map_add, P.cliffordOperator_coe_W, P.cliffordOperator_coe_W',
+      P.cliffordOperator_coe_line]
+  rw [hc, P.quadraticForm_decompositionEquiv_apply, ← P.lineCoordinate_sq z]
   ext s
-  rw [Module.End.mul_apply, Module.algebraMap_end_apply, P.cliffordOperator_add_apply,
-    P.cliffordOperator_add_apply, P.quadraticForm_decomposition_apply, ← P.lineCoordinate_sq z]
-  simp only [map_add, map_smul, P.wedge_wedge, P.contract_contract, P.contract_wedge,
-    P.parity_wedge, P.parity_contract, P.parity_parity]
+  simp only [Module.End.mul_apply, LinearMap.add_apply, Module.algebraMap_end_apply,
+    wedge_apply, contract_apply, lineOperator_apply, map_add, map_smul, mul_add,
+    ← mul_assoc, ExteriorAlgebra.ι_sq_zero, zero_mul,
+    CliffordAlgebra.contractLeft_ι_mul, CliffordAlgebra.contractLeft_contractLeft,
+    TauCeti.CliffordAlgebra.involute_ι_mul, TauCeti.CliffordAlgebra.involute_contractLeft,
+    CliffordAlgebra.involute_involute, P.pairingEquiv_apply]
   module
 
 end SpinPolarizationData
@@ -293,9 +251,10 @@ theorem spinAction_ι_parity (z : P.line) (s : ExteriorAlgebra K P.W) :
       P.lineCoordinate z • CliffordAlgebra.involute s := by
   rw [spinAction_ι, P.cliffordOperator_coe_line, P.lineOperator_apply]
 
-/-- **The anticommutator identity** pinning the coefficient of the spinor action: two vectors act
-with anticommutator the scalar `QuadraticMap.polar Q x y`. Taking `y = x` returns the Clifford
-relation, since `polar Q x x = 2 • Q x`. -/
+/-- **The anticommutator identity** pinning the coefficient of the spinor action: two vectors `a`
+and `b` act with anticommutator the scalar `QuadraticMap.polar Q a b`. Setting `b = a` gives twice
+the Clifford relation, since `polar Q a a = 2 • Q a`; the relation itself, which does not need `2`
+to be cancellable, is `TauCeti.SpinPolarizationData.cliffordOperator_sq`. -/
 theorem spinAction_ι_mul_add_swap (a b : V) :
     spinAction Q P (CliffordAlgebra.ι Q a) * spinAction Q P (CliffordAlgebra.ι Q b)
         + spinAction Q P (CliffordAlgebra.ι Q b) * spinAction Q P (CliffordAlgebra.ι Q a)


### PR DESCRIPTION
This PR makes the exterior algebra `⋀·W` of the isotropic summand of a polarization into a module over the Clifford algebra of the ambient quadratic form — the Fock model of the spinor representation, and the carrier of the spin and half-spin representations, which no tensor power of the standard representation contains. It advances Layer 4, "The spin and half-spin representations", of `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`, specifically the bullet "The Clifford module `S = ⋀·W`", whose pinned object is `spinAction` in that roadmap's `Suggested.lean`. It builds directly on the polarization data that already landed in `TauCeti/RepresentationTheory/Spin/Polarization/`, which supplied the decomposition `V = W ⊕ W' ⊕ L` and its pairing but attached no module to it.

`TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean` defines the three component operators on `S = ⋀·W` — exterior multiplication `TauCeti.SpinPolarizationData.wedge` for a vector of `W`, contraction `TauCeti.SpinPolarizationData.contract` against the functional the polarization pairing attaches to a vector of `W'`, and the grade involution `TauCeti.SpinPolarizationData.parity` scaled by the scalar coordinate of a vector of the orthogonal remainder — assembles them along the polarization coordinates into `TauCeti.SpinPolarizationData.cliffordOperator`, records the anticommutation relations between them (`contract_wedge`, `parity_wedge`, `parity_contract`, and the two square-zero relations), and derives the Clifford relation `cliffordOperator_sq` from exactly those six anticommutators. The coefficient is not a prose "twice": the only nonzero anticommutator is creation against annihilation, and the scalar it produces is `QuadraticMap.polar Q x y`, which is where `Q v` comes from. The universal property then gives `TauCeti.spinAction : CliffordAlgebra Q →ₐ[K] Module.End K (ExteriorAlgebra K P.W)`, pinned by the three action lemmas `spinAction_ι_wedge`, `spinAction_ι_contract` and `spinAction_ι_parity`, together with the polarized form `spinAction_ι_mul_add_swap` stating `c a ∘ c b + c b ∘ c a = polar Q a b • 1`.

The exterior algebra is Mathlib's `ExteriorAlgebra K W`, which *is* `CliffordAlgebra (0 : QuadraticForm K W)`, so the interior product is the zero-form specialization of `CliffordAlgebra.contractLeft` and the parity operator the zero-form specialization of `CliffordAlgebra.involute`; no bespoke exterior-algebra vocabulary is introduced, as the roadmap's standing conventions ask. One general Clifford fact was missing upstream and is added as a prerequisite in `TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean`: contraction lowers the degree by one, so it anticommutes with the grade involution (`involute_contractLeft`). Mathlib relates `involute` to products and to the grading but never to a contraction. No Mathlib source was vendored; the proof uses Mathlib's `CliffordAlgebra.left_induction`, `contractLeft_ι_mul` and `involute_ι`.

Everything is stated over an arbitrary commutative ring rather than over `ℂ`: `SpinPolarizationData` already carries the isotropy and the perfect pairing that the Clifford relation consumes, and no invertibility of `2` is used, so the roadmap's complex-field hypotheses belong to the existence of the polarization, not to the module it supports. Surjectivity of `spinAction` onto `Module.End K S` in even dimension (the Layer 1 structure theorem), the restriction along `spinGroup.toUnits` to a group representation, the half-spin summands, and irreducibility are deliberately not proved here and are named as such in the module docstring.

Two files, 372 lines. `lake build`, `lake exe axioms` and a scoped environment lint (`simpNF`, `unusedArguments`, `simpComm`, `synTaut`, `checkType`) are green; the axiom audit reports all 40521 declarations within the allowlist.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"spinaction"}-->

🤖 Prepared with Claude Code

