### PR TITLE
docs(Huber): correct the comparison with Mathlib's IsRestricted

### DIFF
--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -30,10 +30,13 @@ namespace, opts into the Lean module system with the definition bodies unexposed
 `Set.mem_setOf_eq` to `Set.mem_ofPred_eq`, renames the predicate from AINTLIB's `IsRestrictedAdic`
 (nothing here is adic), and drops hypotheses that the individual proofs never used.
 
-This is *not* Mathlib's `PowerSeries.IsRestricted`, which asks a one-variable series over a ring
-with a linear topology to be restricted with respect to a submodule filtration. `IsRestricted`
-here is Wedhorn's multivariate cofinite-tendsto condition, and needs only a topology on `A`; the
-nonarchimedean hypothesis enters only for closure under multiplication and hence for the subring.
+This is *not* Mathlib's `MvPowerSeries.IsRestricted`, which is stated over a normed ring and
+relative to a polyradius `c : σ → ℝ`, asking that `‖coeff t f‖ * ∏ i, c i ^ t i` tend to `0` along
+the cofinite filter. The two conditions agree over a normed ring at `c = 1`, but neither is more
+general: Mathlib's varies the radius, while `IsRestricted` here needs only a topology on `A` and
+no norm. It is the latter that Huber theory requires, a Huber ring being topologised by an ideal
+of definition rather than by a norm. The nonarchimedean hypothesis enters only for closure under
+multiplication and hence for the subring.
 
 ## Implementation notes
 

--- a/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/RestrictedPowerSeries.lean
@@ -34,9 +34,9 @@ This is *not* Mathlib's `MvPowerSeries.IsRestricted`, which is stated over a nor
 relative to a polyradius `c : σ → ℝ`, asking that `‖coeff t f‖ * ∏ i, c i ^ t i` tend to `0` along
 the cofinite filter. The two conditions agree over a normed ring at `c = 1`, but neither is more
 general: Mathlib's varies the radius, while `IsRestricted` here needs only a topology on `A` and
-no norm. It is the latter that Huber theory requires, a Huber ring being topologised by an ideal
-of definition rather than by a norm. The nonarchimedean hypothesis enters only for closure under
-multiplication and hence for the subring.
+no norm. It is the latter that Huber theory requires: Huber ring topologies are defined using an
+ideal of definition and need not be induced by a norm. The nonarchimedean hypothesis enters only
+for closure under multiplication and hence for the subring.
 
 ## Implementation notes
 


### PR DESCRIPTION
`RestrictedPowerSeries.lean` distinguishes its `IsRestricted` from Mathlib's, and the description
it gives of Mathlib's is wrong on every count. It reads:

> This is *not* Mathlib's `PowerSeries.IsRestricted`, which asks a one-variable series over a ring
> with a linear topology to be restricted with respect to a submodule filtration.

Mathlib's condition (`Mathlib/RingTheory/MvPowerSeries/Restricted.lean`) is stated over a
`NormedRing` relative to a polyradius `c : σ → ℝ`, and asks that `‖coeff t f‖ * ∏ i, c i ^ t i`
tend to `0` along the cofinite filter. So it is not one-variable — `MvPowerSeries.IsRestricted` is
the primitive and `PowerSeries.IsRestricted` is its `σ = Unit` case — the topology is a norm rather
than a linear topology, and no submodule filtration appears.

The correction also states the relationship, which is the useful part and which the old text got
backwards by implying the two are unrelated. Over a normed ring at `c = 1` the two conditions are
literally the same statement: `‖coeff t f‖ → 0` cofinite is convergence of the coefficients to `0`
in the norm topology. Neither is more general than the other, though. Mathlib varies the radius but
demands a norm; the condition here varies the topology but fixes the radius. Huber theory needs the
second, since a Huber ring is topologised by an ideal of definition and its topology is not in
general induced by a norm — this file carries no `NormedRing` hypothesis anywhere, and neither does
its consumer `WeightedRestrictedSeries.lean`.

Docstring only; no statement, proof or import changes.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: AdicSpaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
