### PR TITLE
feat(Valuation): one exponent serves finitely many cofinal values

### DIFF
--- a/TauCeti/RingTheory/Valuation/CharacteristicGroup.lean
+++ b/TauCeti/RingTheory/Valuation/CharacteristicGroup.lean
@@ -50,7 +50,7 @@ formalised here.
 ## Main results
 
 * `TauCeti.Valuation.exists_pow_lt_of_forall_cofinalValue` : one exponent serves finitely many
-  cofinal values, given that each has value at most `1`.
+  cofinal values.
 * `TauCeti.Valuation.mem_characteristicSubgroup_iff` : Membership in `cΓ_v` is bounding by a
   single attained value `≥ 1`.
 * `TauCeti.Valuation.hasFullCharacteristicGroup_iff_characteristicSubgroup_eq_top` : The
@@ -93,21 +93,20 @@ theorem cofinalValue_iff {v : Valuation A Γ₀} {a : A} :
   Iff.rfl
 
 /-- **A uniform exponent for finitely many cofinal values.** If every member of a finite set has
-cofinal value and value at most `1`, then a single exponent works for all of them at once.
+cofinal value, then a single exponent works for all of them at once.
 
-The bound `v a ≤ 1` is what makes the exponent uniform: taking the largest of the individual
-exponents only helps because raising a value `≤ 1` to a higher power decreases it. Wedhorn's proof
-of Lemma 7.5 avoids this by choosing an exponent per generator, precisely because the bound is not
-available there (see `exists_basicOpenFinset_of_forall_cofinalValue`); in Theorem 7.10 it is, being
-the second conjunct of the hypothesis. -/
+No bound on the values need be assumed: cofinality already forces `v.restrict a ≤ 1`, by taking
+`γ = 1`. That is what makes the exponent uniform, since raising a value `≤ 1` to a higher power
+only decreases it, so the largest of the individual exponents serves. -/
 theorem exists_pow_lt_of_forall_cofinalValue {v : Valuation A Γ₀} (S : Finset A)
-    (hle : ∀ a ∈ S, v.restrict a ≤ 1) (hcof : ∀ a ∈ S, CofinalValue v a)
-    {γ : ValueGroup₀ (.ofClass v)} (hγ : 0 < γ) :
+    (hcof : ∀ a ∈ S, CofinalValue v a) {γ : ValueGroup₀ (.ofClass v)} (hγ : 0 < γ) :
     ∃ n : ℕ, ∀ a ∈ S, v.restrict a ^ n < γ := by
-  classical
-  choose! f hf using fun a (ha : a ∈ S) ↦ cofinalValue_iff.mp (hcof a ha) γ hγ
-  refine ⟨S.sup f, fun a ha ↦ lt_of_le_of_lt ?_ (hf a ha)⟩
-  exact pow_le_pow_right_of_le_one' (hle a ha) (Finset.le_sup ha)
+  have hle : ∀ a ∈ S, v.restrict a ≤ 1 := fun a ha ↦ by
+    obtain ⟨n, hn⟩ := hcof a ha 1 one_pos
+    exact not_lt.mp fun h ↦ absurd hn (not_lt.mpr (one_le_pow₀ h.le))
+  choose! f hf using fun a (ha : a ∈ S) ↦ hcof a ha γ hγ
+  exact ⟨S.sup f, fun a ha ↦
+    (pow_le_pow_right_of_le_one' (hle a ha) (Finset.le_sup ha)).trans_lt (hf a ha)⟩
 
 /-- Cofinality transports along an equivalence of valuations, through the ordered
 isomorphism of their value groups. -/

--- a/TauCeti/RingTheory/Valuation/CharacteristicGroup.lean
+++ b/TauCeti/RingTheory/Valuation/CharacteristicGroup.lean
@@ -49,6 +49,8 @@ formalised here.
 
 ## Main results
 
+* `TauCeti.Valuation.exists_pow_lt_of_forall_cofinalValue` : one exponent serves finitely many
+  cofinal values, given that each has value at most `1`.
 * `TauCeti.Valuation.mem_characteristicSubgroup_iff` : Membership in `cΓ_v` is bounding by a
   single attained value `≥ 1`.
 * `TauCeti.Valuation.hasFullCharacteristicGroup_iff_characteristicSubgroup_eq_top` : The
@@ -89,6 +91,23 @@ def CofinalValue (v : Valuation A Γ₀) (a : A) : Prop :=
 theorem cofinalValue_iff {v : Valuation A Γ₀} {a : A} :
     CofinalValue v a ↔ ∀ γ : ValueGroup₀ (.ofClass v), 0 < γ → ∃ n : ℕ, v.restrict a ^ n < γ :=
   Iff.rfl
+
+/-- **A uniform exponent for finitely many cofinal values.** If every member of a finite set has
+cofinal value and value at most `1`, then a single exponent works for all of them at once.
+
+The bound `v a ≤ 1` is what makes the exponent uniform: taking the largest of the individual
+exponents only helps because raising a value `≤ 1` to a higher power decreases it. Wedhorn's proof
+of Lemma 7.5 avoids this by choosing an exponent per generator, precisely because the bound is not
+available there (see `exists_basicOpenFinset_of_forall_cofinalValue`); in Theorem 7.10 it is, being
+the second conjunct of the hypothesis. -/
+theorem exists_pow_lt_of_forall_cofinalValue {v : Valuation A Γ₀} (S : Finset A)
+    (hle : ∀ a ∈ S, v.restrict a ≤ 1) (hcof : ∀ a ∈ S, CofinalValue v a)
+    {γ : ValueGroup₀ (.ofClass v)} (hγ : 0 < γ) :
+    ∃ n : ℕ, ∀ a ∈ S, v.restrict a ^ n < γ := by
+  classical
+  choose! f hf using fun a (ha : a ∈ S) ↦ cofinalValue_iff.mp (hcof a ha) γ hγ
+  refine ⟨S.sup f, fun a ha ↦ lt_of_le_of_lt ?_ (hf a ha)⟩
+  exact pow_le_pow_right_of_le_one' (hle a ha) (Finset.le_sup ha)
 
 /-- Cofinality transports along an equivalence of valuations, through the ordered
 isomorphism of their value groups. -/


### PR DESCRIPTION
**One exponent for finitely many cofinal values.**

```lean
theorem TauCeti.Valuation.exists_pow_lt_of_forall_cofinalValue {v : Valuation A Γ₀} (S : Finset A)
    (hle : ∀ a ∈ S, v.restrict a ≤ 1) (hcof : ∀ a ∈ S, CofinalValue v a)
    {γ : ValueGroup₀ (.ofClass v)} (hγ : 0 < γ) :
    ∃ n : ℕ, ∀ a ∈ S, v.restrict a ^ n < γ
```

Cofinality gives an exponent per element; this makes it uniform over a finite set.

## Why the `≤ 1` hypothesis, and why the lemma is not already there

Taking the largest of the individual exponents only works because raising a value `≤ 1` to a
higher power *decreases* it. `main` already records that this is the obstruction, in the docstring
of `exists_basicOpenFinset_of_forall_cofinalValue` (`SpvOfIdeal/Spectral.lean`):

> Wedhorn takes one uniform exponent, which would need every generator to have value `≤ 1`;
> a separate exponent per generator avoids that.

That was the right call there — Wedhorn 7.5(ii) has no such bound available. **Theorem 7.10 does**:
`v a < 1` for every `a ∈ I` is the second conjunct of its hypothesis, so the uniform form is
exactly what that proof can use, and the per-generator dodge is unnecessary.

## Where it is used

Wedhorn's proof of Theorem 7.10 (`⊇`) needs, for a given `γ`, a single `n` with `δ ^ n < γ` where
`δ` bounds `v` on a finite generating set of the ideal of definition; that `n` then feeds
`Huber.PairOfDefinition.isContinuous_iff_forall_exists_idealImage_subset` (already on `main`) to
produce continuity. This is that step. The cofinality it consumes comes from membership in
`Spv (A, I·A)` through Lemma 7.4, also on `main`.

## Provenance

AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at commit
`2baa76f742bdb4fb8ee323fabba41203bd390e08`, project `projects/AdicSpaces/`, has no uniform-exponent
statement: its Wedhorn 7.10 sub-leaves are `sorry` and its 7.5 material takes Wedhorn's route.
The proof here is a `Finset.sup` of the individual exponents with Mathlib's
`pow_le_pow_right_of_le_one'`; nothing was copied.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all exit 0.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#15-continuous-valuations"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
