### PR TITLE
refactor(End): name the product of semisimple modules behind IsSemisimple.prodMap

### DIFF
--- a/TauCeti/LinearAlgebra/End/Prod.lean
+++ b/TauCeti/LinearAlgebra/End/Prod.lean
@@ -72,8 +72,7 @@ theorem IsSemisimple.prodMap {f : Module.End K V} {g : Module.End K W}
   rw [Module.End.IsSemisimple] at hf hg ⊢
   let _ : IsSemisimpleModule K[X] (Module.AEval' f) := hf
   let _ : IsSemisimpleModule K[X] (Module.AEval' g) := hg
-  have hprod : IsSemisimpleModule K[X] (Module.AEval' f × Module.AEval' g) :=
-    TauCeti.IsSemisimpleModule.prod
+  have hprod : IsSemisimpleModule K[X] (Module.AEval' f × Module.AEval' g) := inferInstance
   let E : Module.AEval' (f.prodMap g) ≃ₗ[K[X]]
       Module.AEval' f × Module.AEval' g := {
     toFun x := (x.1, x.2)

--- a/TauCeti/LinearAlgebra/End/Prod.lean
+++ b/TauCeti/LinearAlgebra/End/Prod.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Category.ModuleCat.Basic
 public import Mathlib.LinearAlgebra.Prod
 public import Mathlib.LinearAlgebra.Semisimple
+import TauCeti.RingTheory.SimpleModule.Basic
 
 /-!
 # Products of endomorphisms
@@ -72,28 +72,8 @@ theorem IsSemisimple.prodMap {f : Module.End K V} {g : Module.End K W}
   rw [Module.End.IsSemisimple] at hf hg ⊢
   let _ : IsSemisimpleModule K[X] (Module.AEval' f) := hf
   let _ : IsSemisimpleModule K[X] (Module.AEval' g) := hg
-  let M : Fin 2 → ModuleCat.{max v w} K[X] := fun i ↦
-    if i = 0 then ModuleCat.of K[X] (ULift.{max v w} (Module.AEval' f))
-    else ModuleCat.of K[X] (ULift.{max v w} (Module.AEval' g))
-  let _ (i : Fin 2) : IsSemisimpleModule K[X] (M i) := by
-    by_cases hi : i = 0
-    · subst i
-      simpa [M] using IsSemisimpleModule.congr
-        (ULift.moduleEquiv : ULift.{max v w} (Module.AEval' f) ≃ₗ[K[X]] Module.AEval' f)
-    · -- Cross the dependent, universe-lifted family boundary before applying the equivalence.
-      have hM : M i = ModuleCat.of K[X] (ULift.{max v w} (Module.AEval' g)) := by
-        simp [M, hi]
-      rw [hM]
-      exact IsSemisimpleModule.congr
-        (ULift.moduleEquiv : ULift.{max v w} (Module.AEval' g) ≃ₗ[K[X]] Module.AEval' g)
-  have hprod : IsSemisimpleModule K[X] (Module.AEval' f × Module.AEval' g) := by
-    let e₀ : (M 0 × M 1) ≃ₗ[K[X]] Module.AEval' f × Module.AEval' g := by
-      simpa [M] using
-        ((ULift.moduleEquiv : ULift.{max v w} (Module.AEval' f) ≃ₗ[K[X]]
-          Module.AEval' f).prodCongr
-          (ULift.moduleEquiv : ULift.{max v w} (Module.AEval' g) ≃ₗ[K[X]] Module.AEval' g))
-    let e := (LinearEquiv.piFinTwo K[X] (fun i ↦ (M i : Type (max v w)))).trans e₀
-    exact e.isSemisimpleModule_iff.mp inferInstance
+  have hprod : IsSemisimpleModule K[X] (Module.AEval' f × Module.AEval' g) :=
+    TauCeti.IsSemisimpleModule.prod
   let E : Module.AEval' (f.prodMap g) ≃ₗ[K[X]]
       Module.AEval' f × Module.AEval' g := {
     toFun x := (x.1, x.2)

--- a/TauCeti/RingTheory/SimpleModule/Basic.lean
+++ b/TauCeti/RingTheory/SimpleModule/Basic.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Prod
+public import Mathlib.RingTheory.SimpleModule.Basic
+
+/-!
+# Binary products of semisimple modules
+
+Mathlib closes `IsSemisimpleModule` under submodules, quotients, `Finsupp`, and finite dependent
+products `Π i, M i`. The dependent product covers a binary product only when both factors lie in
+the same universe, since the family `M : ι → Type u` is universe-monomorphic; this file supplies
+the binary case with the two factors in unrelated universes.
+
+## Main results
+
+* `TauCeti.IsSemisimpleModule.prod`: a product of two semisimple modules is semisimple.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {R M N : Type*} [Ring R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+
+/-- **A product of two semisimple modules is semisimple.** -/
+theorem IsSemisimpleModule.prod [IsSemisimpleModule R M] [IsSemisimpleModule R N] :
+    IsSemisimpleModule R (M × N) := by
+  -- `M × N` is the join of the two coordinate copies, each of which is a semisimple submodule.
+  have hM : IsSemisimpleModule R (LinearMap.range (LinearMap.inl R M N)) :=
+    .congr (LinearEquiv.ofInjective _ LinearMap.inl_injective).symm
+  have hN : IsSemisimpleModule R (LinearMap.range (LinearMap.inr R M N)) :=
+    .congr (LinearEquiv.ofInjective _ LinearMap.inr_injective).symm
+  have hsup := _root_.IsSemisimpleModule.sup hM hN
+  rw [LinearMap.sup_range_inl_inr] at hsup
+  exact .congr Submodule.topEquiv.symm
+
+end TauCeti

--- a/TauCeti/RingTheory/SimpleModule/Basic.lean
+++ b/TauCeti/RingTheory/SimpleModule/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.Prod
 public import Mathlib.RingTheory.SimpleModule.Basic
 
 /-!
@@ -27,14 +26,13 @@ namespace TauCeti
 variable {R M N : Type*} [Ring R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
 /-- **A product of two semisimple modules is semisimple.** -/
-theorem IsSemisimpleModule.prod [IsSemisimpleModule R M] [IsSemisimpleModule R N] :
+instance IsSemisimpleModule.prod [IsSemisimpleModule R M] [IsSemisimpleModule R N] :
     IsSemisimpleModule R (M × N) := by
+  -- The plan is that of Mathlib's binary-product `IsSemisimpleRing` instance, one level down:
   -- `M × N` is the join of the two coordinate copies, each of which is a semisimple submodule.
-  have hM : IsSemisimpleModule R (LinearMap.range (LinearMap.inl R M N)) :=
-    .congr (LinearEquiv.ofInjective _ LinearMap.inl_injective).symm
-  have hN : IsSemisimpleModule R (LinearMap.range (LinearMap.inr R M N)) :=
-    .congr (LinearEquiv.ofInjective _ LinearMap.inr_injective).symm
-  have hsup := _root_.IsSemisimpleModule.sup hM hN
+  have hsup := _root_.IsSemisimpleModule.sup
+    (_root_.IsSemisimpleModule.range (LinearMap.inl R M N))
+    (_root_.IsSemisimpleModule.range (LinearMap.inr R M N))
   rw [LinearMap.sup_range_inl_inr] at hsup
   exact .congr Submodule.topEquiv.symm
 


### PR DESCRIPTION
`IsSemisimple.prodMap` — the componentwise product of two semisimple endomorphisms is semisimple —
was forty-five lines, and about half of them were spent proving one unrelated fact: that a product
of two semisimple modules is semisimple.

That fact is now `TauCeti.IsSemisimpleModule.prod`, and it mentions no endomorphism, no
`Polynomial`, and no `AEval`. Only the `IsSemisimpleModule` predicate and a binary product appear
in it, so it goes in a new `TauCeti/RingTheory/SimpleModule/Basic.lean`, mirroring Mathlib's
`Mathlib/RingTheory/SimpleModule/Basic.lean`, where the predicate and the rest of its closure
properties live. It is an `instance`, like Mathlib's other closure properties for the predicate, so
the consumer just calls `inferInstance`.

Mathlib does not have it. It closes `IsSemisimpleModule` under submodules, quotients, `Finsupp`,
and the finite dependent product `Π i, M i`, but there is no binary-product instance, and the
dependent one does not supply it: the family is `M : ι → Type u`, so both factors must live in one
universe. That is the whole reason for the machinery being deleted here — the old proof built a
`Fin 2`-indexed `ModuleCat` family, `ULift`ed both `AEval'` modules into `max v w` to make the
family typecheck, transported semisimplicity across each lift, and came back through
`LinearEquiv.piFinTwo`.

None of that is needed, and none of it has to be re-proved either. `M × N` is the join of the
ranges of `LinearMap.inl` and `LinearMap.inr`; `IsSemisimpleModule.range` already gives that each
range is semisimple, `IsSemisimpleModule.sup` closes the predicate under joins of submodules, and
`LinearMap.sup_range_inl_inr` says the join is everything. The two factors never have to share a
universe because nothing indexes them. The proof plan is Mathlib's own binary-product
`IsSemisimpleRing` instance, one level down from rings to modules, and the proof says so.

The parent keeps the `AEval'`-level equivalence it still needs and drops from 45 lines to 25. The
now-unused `Mathlib.Algebra.Category.ModuleCat.Basic` import goes with the machinery; the new
module is imported privately, since it is used only inside a proof and no public statement here
mentions it.

Degenerate ends: with either factor the trivial module the statement is still the intended one —
the trivial module is semisimple, and the product is isomorphic to the other factor.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: ReductiveGroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
