### PR TITLE
refactor(Topology): name the preconnectedness pullback behind the closed-arc classification

### DIFF
--- a/TauCeti/Topology/Circle/Arc.lean
+++ b/TauCeti/Topology/Circle/Arc.lean
@@ -27,9 +27,11 @@ preconnected and not the whole circle, and pick `z ∉ T`. Cutting the circle at
 reading it as `Circle.exp` on the period `[t, t + 2π]` for `Circle.exp t = z` — turns `T` into
 `K = Circle.exp ⁻¹' T ∩ Icc t (t + 2 * π)`, a compact subset of `ℝ` avoiding *both* endpoints of
 that period, so `K ⊆ Ioo t (t + 2 * π)` and `Circle.exp` is injective on `K`. A continuous injection
-of a compact space into a Hausdorff one is a closed map, so
-`IsPreconnected.preimage_of_isClosedMap` carries preconnectedness of `T = Circle.exp '' K` back to
-`K`, and a compact connected subset of `ℝ` is a closed interval (`eq_Icc_of_connected_compact`).
+of a compact space into a Hausdorff one is a closed embedding (`Continuous.isClosedEmbedding`),
+hence inducing, and an inducing map reflects preconnectedness
+(`Topology.IsInducing.isPreconnected_image`), which carries preconnectedness of
+`T = Circle.exp '' K` back to `K`; a compact connected subset of `ℝ` is then a closed interval
+(`eq_Icc_of_connected_compact`).
 Hence `T = Circle.exp '' Icc a b` with `b - a < 2 * π`, the degenerate case `a = b` being a point.
 
 The complement is read off the same period, moved to `Ioc b (b + 2 * π)` so that the closed arc

--- a/TauCeti/Topology/Circle/Arc.lean
+++ b/TauCeti/Topology/Circle/Arc.lean
@@ -62,18 +62,17 @@ private lemma circleExp_image_Icc_add_period (a b : ℝ) :
   exact image_congr fun x _ => Circle.exp_add_two_pi x
 
 /-- **Preconnectedness pulls back along a continuous injection on a compact set.** If `f` is
-continuous and injective on a compact `K` and carries it onto a preconnected set, then `K` itself
-is preconnected. -/
-private lemma isPreconnected_of_injOn_of_image_eq {X Y : Type*} [TopologicalSpace X]
-    [TopologicalSpace Y] [T2Space Y] {f : X → Y} {K : Set X} {T : Set Y} (hK : IsCompact K)
-    (hf : ContinuousOn f K) (hinj : InjOn f K) (himg : f '' K = T) (hpre : IsPreconnected T) :
-    IsPreconnected K := by
+continuous and injective on a compact `K` and its image in a Hausdorff space is preconnected, then
+`K` itself is preconnected. -/
+private lemma isPreconnected_of_injOn {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    [T2Space Y] {f : X → Y} {K : Set X} (hK : IsCompact K) (hf : ContinuousOn f K)
+    (hinj : InjOn f K) (hpre : IsPreconnected (f '' K)) : IsPreconnected K := by
   -- On the subtype the restriction is a closed embedding, so it reflects preconnectedness.
   have : CompactSpace K := isCompact_iff_compactSpace.mp hK
   have hginj : Function.Injective fun x : K => f (x : X) :=
     fun x y hxy => Subtype.ext (hinj x.2 y.2 hxy)
   have hgc : Continuous fun x : K => f (x : X) := continuousOn_iff_continuous_domRestrict.mp hf
-  have hrange : range (fun x : K => f (x : X)) = T := (image_eq_range f K).symm.trans himg
+  have hrange : range (fun x : K => f (x : X)) = f '' K := (image_eq_range f K).symm
   rw [isPreconnected_iff_preconnectedSpace, preconnectedSpace_iff_univ,
     ← (hgc.isClosedEmbedding hginj).isInducing.isPreconnected_image, image_univ, hrange]
   exact hpre
@@ -109,7 +108,7 @@ theorem exists_eq_circleExp_image_Icc {T : Set Circle} (hT : IsClosed T) (hpre :
     rw [← image_nonempty (f := Circle.exp), himg]
     exact hne
   have hKpre : IsPreconnected K :=
-    isPreconnected_of_injOn_of_image_eq hKcompact Circle.exp.continuous.continuousOn hinj himg hpre
+    isPreconnected_of_injOn hKcompact Circle.exp.continuous.continuousOn hinj (himg ▸ hpre)
   have hKeq : K = Icc (sInf K) (sSup K) := eq_Icc_of_connected_compact ⟨hKne, hKpre⟩ hKcompact
   have hIsub : Icc (sInf K) (sSup K) ⊆ Ioo t (t + 2 * π) := hKeq ▸ hKsub
   have hle : sInf K ≤ sSup K := by

--- a/TauCeti/Topology/Circle/Arc.lean
+++ b/TauCeti/Topology/Circle/Arc.lean
@@ -59,25 +59,22 @@ private lemma circleExp_image_Icc_add_period (a b : ℝ) :
   rw [← image_add_const_Icc, ← image_comp]
   exact image_congr fun x _ => Circle.exp_add_two_pi x
 
-/-- **Preconnectedness pulls back along a continuous injection off a compact set.** If `f` is
+/-- **Preconnectedness pulls back along a continuous injection on a compact set.** If `f` is
 continuous and injective on a compact `K` and carries it onto a preconnected set, then `K` itself
 is preconnected. -/
 private lemma isPreconnected_of_injOn_of_image_eq {X Y : Type*} [TopologicalSpace X]
     [TopologicalSpace Y] [T2Space Y] {f : X → Y} {K : Set X} {T : Set Y} (hK : IsCompact K)
     (hf : ContinuousOn f K) (hinj : InjOn f K) (himg : f '' K = T) (hpre : IsPreconnected T) :
     IsPreconnected K := by
-  -- Transfer to the subtype, where the restriction is a closed map onto `T`, and pull `hpre` back
-  -- along it with `IsPreconnected.preimage_of_isClosedMap`.
+  -- On the subtype the restriction is a closed embedding, so it reflects preconnectedness.
   have : CompactSpace K := isCompact_iff_compactSpace.mp hK
   have hginj : Function.Injective fun x : K => f (x : X) :=
     fun x y hxy => Subtype.ext (hinj x.2 y.2 hxy)
   have hgc : Continuous fun x : K => f (x : X) := continuousOn_iff_continuous_domRestrict.mp hf
   have hrange : range (fun x : K => f (x : X)) = T := (image_eq_range f K).symm.trans himg
-  have hpre' := hpre.preimage_of_isClosedMap hginj hgc.isClosedMap hrange.ge
-  have hpreimage : (fun x : K => f (x : X)) ⁻¹' T = univ :=
-    eq_univ_of_forall fun x => himg ▸ ⟨x, x.2, rfl⟩
-  rw [hpreimage] at hpre'
-  exact isPreconnected_iff_preconnectedSpace.mpr ⟨hpre'⟩
+  rw [isPreconnected_iff_preconnectedSpace, preconnectedSpace_iff_univ,
+    ← (hgc.isClosedEmbedding hginj).isInducing.isPreconnected_image, image_univ, hrange]
+  exact hpre
 
 /-- **A nonempty closed preconnected proper subset of the circle is a closed arc.** The two angles
 are less than a full turn apart, so `Circle.exp` is injective on the interval carrying them, and the

--- a/TauCeti/Topology/Circle/Arc.lean
+++ b/TauCeti/Topology/Circle/Arc.lean
@@ -59,6 +59,26 @@ private lemma circleExp_image_Icc_add_period (a b : ℝ) :
   rw [← image_add_const_Icc, ← image_comp]
   exact image_congr fun x _ => Circle.exp_add_two_pi x
 
+/-- **Preconnectedness pulls back along a continuous injection off a compact set.** If `f` is
+continuous and injective on a compact `K` and carries it onto a preconnected set, then `K` itself
+is preconnected. -/
+private lemma isPreconnected_of_injOn_of_image_eq {X Y : Type*} [TopologicalSpace X]
+    [TopologicalSpace Y] [T2Space Y] {f : X → Y} {K : Set X} {T : Set Y} (hK : IsCompact K)
+    (hf : ContinuousOn f K) (hinj : InjOn f K) (himg : f '' K = T) (hpre : IsPreconnected T) :
+    IsPreconnected K := by
+  -- Transfer to the subtype, where the restriction is a closed map onto `T`, and pull `hpre` back
+  -- along it with `IsPreconnected.preimage_of_isClosedMap`.
+  have : CompactSpace K := isCompact_iff_compactSpace.mp hK
+  have hginj : Function.Injective fun x : K => f (x : X) :=
+    fun x y hxy => Subtype.ext (hinj x.2 y.2 hxy)
+  have hgc : Continuous fun x : K => f (x : X) := continuousOn_iff_continuous_domRestrict.mp hf
+  have hrange : range (fun x : K => f (x : X)) = T := (image_eq_range f K).symm.trans himg
+  have hpre' := hpre.preimage_of_isClosedMap hginj hgc.isClosedMap hrange.ge
+  have hpreimage : (fun x : K => f (x : X)) ⁻¹' T = univ :=
+    eq_univ_of_forall fun x => himg ▸ ⟨x, x.2, rfl⟩
+  rw [hpreimage] at hpre'
+  exact isPreconnected_iff_preconnectedSpace.mpr ⟨hpre'⟩
+
 /-- **A nonempty closed preconnected proper subset of the circle is a closed arc.** The two angles
 are less than a full turn apart, so `Circle.exp` is injective on the interval carrying them, and the
 degenerate case `a = b` is a single point.
@@ -89,19 +109,8 @@ theorem exists_eq_circleExp_image_Icc {T : Set Circle} (hT : IsClosed T) (hpre :
   have hKne : K.Nonempty := by
     rw [← image_nonempty (f := Circle.exp), himg]
     exact hne
-  have hKpre : IsPreconnected K := by
-    have : CompactSpace K := isCompact_iff_compactSpace.mp hKcompact
-    have hginj : Function.Injective fun x : K => Circle.exp (x : ℝ) :=
-      fun x y hxy => Subtype.ext (hinj x.2 y.2 hxy)
-    have hgc : Continuous fun x : K => Circle.exp (x : ℝ) :=
-      Circle.exp.continuous.comp continuous_subtype_val
-    have hrange : range (fun x : K => Circle.exp (x : ℝ)) = T :=
-      (image_eq_range Circle.exp K).symm.trans himg
-    have hpre' := hpre.preimage_of_isClosedMap hginj hgc.isClosedMap hrange.ge
-    have hpreimage : (fun x : K => Circle.exp (x : ℝ)) ⁻¹' T = univ :=
-      eq_univ_of_forall fun x => x.2.1
-    rw [hpreimage] at hpre'
-    exact isPreconnected_iff_preconnectedSpace.mpr ⟨hpre'⟩
+  have hKpre : IsPreconnected K :=
+    isPreconnected_of_injOn_of_image_eq hKcompact Circle.exp.continuous.continuousOn hinj himg hpre
   have hKeq : K = Icc (sInf K) (sSup K) := eq_Icc_of_connected_compact ⟨hKne, hKpre⟩ hKcompact
   have hIsub : Icc (sInf K) (sSup K) ⊆ Ioo t (t + 2 * π) := hKeq ▸ hKsub
   have hle : sInf K ≤ sSup K := by


### PR DESCRIPTION
`exists_eq_circleExp_image_Icc` — a nonempty closed preconnected proper subset of the circle is a
closed arc — was forty-seven lines, and twelve of them established one fact that has nothing to do
with circles: that the cut-open set `K ⊆ ℝ` is preconnected.

That step is now `isPreconnected_of_injOn_of_image_eq`: if `f` is continuous and injective on a
compact `K` and carries it onto a preconnected set, then `K` is preconnected. No circle, no
`Circle.exp`, no interval — an arbitrary map between an arbitrary space and a Hausdorff one.

Its hypotheses are re-derived rather than inherited. Compactness of `K` and the Hausdorff codomain
are what make the restriction a closed embedding; injectivity on `K` and the image equation are
what identify its image with `T`. The interval structure of `K`, the fact that `T` lies in the
circle, and the avoidance of the period endpoints — all in scope at the extraction point — are not
used and are not taken.

Mathlib has this once the situation is named correctly. A continuous injection of a compact space
into a Hausdorff one is a closed embedding (`Continuous.isClosedEmbedding`), hence inducing, and
`Topology.IsInducing.isPreconnected_image` says an inducing map neither creates nor destroys
preconnectedness. The lemma is that composition, specialised to a set rather than a space; it does
not restate anything Mathlib already asserts.

The lemma is `private`: its one consumer is here, and the general form belongs in Mathlib rather
than in a file about circle arcs, so exporting it from this module would put a general topology
fact behind a curve-theory import.

Degenerate end: at `K = ∅` the hypotheses hold with `T = ∅` and the conclusion is
`IsPreconnected ∅`, which is true, so the statement is not vacuous at the empty end and not false
there either.

The parent drops from 47 lines to 36; the extracted lemma is 10.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: none

This is cross-cutting topology infrastructure: the file's own header states that "nothing here is
specific to any curve theory", the extracted lemma mentions only topological spaces, and the
transport to any particular development happens downstream in
`TauCeti/Topology/JordanCurve/Subcontinuum.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
