### PR TITLE
docs(AdicSpace): correct the cofinal branch's stated reason for per-generator exponents

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/SpvOfIdeal/Spectral.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/SpvOfIdeal/Spectral.lean
@@ -203,8 +203,11 @@ private theorem exists_basicOpenFinset_of_characteristicSubgroup_eq_top {v : Spv
 
 /-- **Wedhorn 7.5(ii), the cofinal branch.** Cofinality of each generator below `v(s)` supplies
 an exponent per generator; adjoining those powers to `{f}` gives an admissible numerator set
-inside `Spv(A)(f/s)`. Wedhorn takes one uniform exponent, which would need every generator to
-have value `≤ 1`; a separate exponent per generator avoids that. -/
+inside `Spv(A)(f/s)`. Wedhorn instead takes a single exponent for all generators, which is
+equally available here: cofinality already forces each generator's value below `1`
+(`cofinalValueFor_top_iff` with `CofinalValueFor.lt_one`), so the largest of the individual
+exponents would serve. Nothing downstream needs the exponents to agree, so they are chosen
+separately. -/
 private theorem exists_basicOpenFinset_of_forall_cofinalValue {v : Spv A} (S : Finset A)
     (hcof : ∀ σ ∈ S, CofinalValue v.valuation σ) {f s : A} (hv : v ∈ basicOpen f s) :
     ∃ T : Finset A, f ∈ T ∧ (∀ σ ∈ S, ∃ k : ℕ, σ ^ k ∈ T) ∧ v ∈ basicOpenFinset T s := by


### PR DESCRIPTION
**The stated reason for departing from Wedhorn is false.**

`exists_basicOpenFinset_of_forall_cofinalValue` chooses a separate exponent per generator, and its
docstring justified that by claiming Wedhorn's single exponent "would need every generator to have
value `≤ 1`" — presenting that bound as unavailable. It is not unavailable: cofinality *forces* it.
Taking `γ = 1` in `CofinalValue v σ` gives `∃ n, v(σ)ⁿ < 1`, which is impossible when `1 ≤ v(σ)`.

The repository already knows this, in two places:

* `TauCeti/RingTheory/Valuation/CofinalIdeal/Basic.lean:208` — `CofinalValueFor.lt_one`, "A cofinal
  value lies strictly below `1`", bridged to `CofinalValue` by `cofinalValueFor_top_iff`;
* `TauCeti/RingTheory/Valuation/Continuous/TopologicallyNilpotent.lean:41` — "Cofinality does imply
  `v a < 1`, through `cofinalValueFor_top_iff` and `CofinalValueFor.lt_one`."

So the docstring contradicted a fact stated verbatim elsewhere in the same library.

## What changes

Only the docstring. The lemma, its statement and its proof are untouched — per-generator exponents
remain correct, and nothing downstream requires the exponents to agree. What is corrected is *why*
they are chosen separately: not because a uniform exponent is unavailable, but because it is not
needed.

## How the replacement claim was checked

Before writing it, the implication was compiled as a scratch `example` inside this very file, to
confirm it holds in this context and not merely in the abstract:

```lean
example {v : Spv A} {σ : A} (h : CofinalValue v.valuation σ) :
    v.valuation.restrict σ < 1 := by
  obtain ⟨n, hn⟩ := cofinalValue_iff.mp h 1 one_pos
  exact not_le.mp fun hge ↦ absurd hn (not_lt.mpr (one_le_pow₀ hge))
```

That probe compiled (2030 jobs) and was then **deleted** rather than kept: `CofinalValueFor.lt_one`
already names the fact, so shipping another copy would duplicate it. Note the probe also showed the
naive `h 1 one_pos` does *not* elaborate here — `CofinalValue`'s body is not exposed to this module,
so the route is through `cofinalValue_iff`.

## Gates

`lake build` (7587 jobs), `lake exe axioms` (40783 declarations), `lake exe module-system`
(1946 modules) and `scripts/lint-env.sh` (`LINT-ENV: PASS`, 72 grandfathered, 0 ratchetable) all
exit 0.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-1.4-lemma-7.5-cofinal-branch-rationale"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
