### PR TITLE
ci: restore performance checks for fork PRs

### DIFF
--- a/.github/workflows/pr-profile.yml
+++ b/.github/workflows/pr-profile.yml
@@ -190,6 +190,9 @@ jobs:
       - name: Checkout candidate head (untrusted, no credentials)
         uses: actions/checkout@v4
         with:
+          # pull_request_target intentionally fetches untrusted source for a
+          # data-only overlay; it is executed only later, offline in landrun.
+          allow-unsafe-pr-checkout: true
           repository: ${{ steps.pr.outputs.head_repo }}
           ref: ${{ steps.pr.outputs.sha }}
           path: pr


### PR DESCRIPTION
This PR restores the performance workflow for fork PRs by explicitly opting its credential-free candidate checkout into `pull_request_target` checkout. The checkout remains data-only: submodules are disabled, credentials are not persisted, and candidate Lean code is executed only later inside the existing offline landrun sandbox.

Validated with the nine performance-gate regression tests and Python compilation; a branch-defined workflow run against fork PR #2937 exercises the GitHub checkout policy and full confinement path.

:robot: Prepared with OpenAI Codex
