### PR TITLE
docs(Huber): point the WeightedEval forward references at what now exists

### DIFF
--- a/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
@@ -51,8 +51,10 @@ it to summability, through Mathlib's
 This file proves only the summability that the evaluation needs. The evaluation map itself is
 `TauCeti.Huber.weightedEval` in `WeightedEval/Map.lean`, its packaging as a ring homomorphism is
 `TauCeti.Huber.weightedEvalHom` in `WeightedEval/Hom.lean`, and its continuity is
-`TauCeti.Huber.continuous_weightedEvalHom` in `WeightedEval/Continuous.lean`. The uniqueness that
-makes Proposition 5.50 a universal property is still unproved.
+`TauCeti.Huber.continuous_weightedEvalHom` in `WeightedEval/Continuous.lean`, and the uniqueness
+that makes Proposition 5.50 a universal property is
+`TauCeti.Huber.weightedRestrictedSubring_ringHom_ext_of_continuous` in
+`WeightedRestrictedSeries.lean`.
 
 ## References
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
@@ -48,8 +48,11 @@ it to summability, through Mathlib's
 * `TauCeti.Huber.summable_weightedEvalTerm_of_forall_isPowerBounded`: its one-weight reading, where
   the hypothesis is that each variable is power-bounded.
 
-The evaluation map itself, its continuity, and the uniqueness that makes Proposition 5.50 a
-universal property are not proved here.
+This file proves only the summability that the evaluation needs. The evaluation map itself is
+`TauCeti.Huber.weightedEval` in `WeightedEval/Map.lean`, its packaging as a ring homomorphism is
+`TauCeti.Huber.weightedEvalHom` in `WeightedEval/Hom.lean`, and its continuity is
+`TauCeti.Huber.continuous_weightedEvalHom` in `WeightedEval/Continuous.lean`. The uniqueness that
+makes Proposition 5.50 a universal property is still unproved.
 
 ## References
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
@@ -10,8 +10,8 @@ public import TauCeti.RingTheory.Huber.WeightedEval.Hom
 # The evaluation of `A⟨X⟩_T` is continuous
 
 `WeightedEval/Hom.lean` packages Wedhorn's evaluation as a ring homomorphism `A⟨X⟩_T →+* B`. This
-file proves it continuous for the topology of `A⟨X⟩_T`, which is the last property Proposition
-5.50 asks of the extension apart from its uniqueness.
+file proves it continuous for the topology of `A⟨X⟩_T`. Together with the uniqueness in
+`WeightedRestrictedSeries.lean`, that completes what Proposition 5.50 asks of the extension.
 
 The argument is the one that made the terms summable, run at a fixed series rather than along the
 cofinite filter, and it shares its estimate: a basic neighbourhood `U⟨X⟩` of zero bounds *every*
@@ -43,7 +43,8 @@ variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [Nonarchimede
 it exist: `φ` continuous at zero and the weighted monomials `φ(Tν) · bν` bounded.
 
 With `weightedEvalHom_weightedC` and `weightedEvalHom_weightedX`, this gives every property
-Proposition 5.50 asks of the extension except the uniqueness, which is not proved here. -/
+Proposition 5.50 asks of the extension except its uniqueness, which is
+`TauCeti.Huber.weightedRestrictedSubring_ringHom_ext_of_continuous`. -/
 theorem continuous_weightedEvalHom (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0)
     (hb : IsWeightBounded φ T b) : Continuous (weightedEvalHom hT hφ hb) := by
   have _ : IsTopologicalRing (weightedRestrictedSubring T hT) :=

--- a/TauCeti/RingTheory/Huber/WeightedEval/Hom.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Hom.lean
@@ -15,8 +15,8 @@ The additive and multiplicative laws of Wedhorn's evaluation are proved in
 than by a hypothesis — they assemble into a ring homomorphism, which is the shape Proposition 5.50
 needs.
 
-Its continuity, and the uniqueness that makes 5.50 a *universal* property, are still not proved
-here.
+Its continuity is `TauCeti.Huber.continuous_weightedEvalHom` in `WeightedEval/Continuous.lean`.
+The uniqueness that makes 5.50 a *universal* property is still unproved.
 
 ## Main definitions
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Hom.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Hom.lean
@@ -15,8 +15,10 @@ The additive and multiplicative laws of Wedhorn's evaluation are proved in
 than by a hypothesis — they assemble into a ring homomorphism, which is the shape Proposition 5.50
 needs.
 
-Its continuity is `TauCeti.Huber.continuous_weightedEvalHom` in `WeightedEval/Continuous.lean`.
-The uniqueness that makes 5.50 a *universal* property is still unproved.
+Its continuity is `TauCeti.Huber.continuous_weightedEvalHom` in `WeightedEval/Continuous.lean`,
+and the uniqueness that makes 5.50 a *universal* property is
+`TauCeti.Huber.weightedRestrictedSubring_ringHom_ext_of_continuous` in
+`WeightedRestrictedSeries.lean`.
 
 ## Main definitions
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Mul.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Mul.lean
@@ -13,9 +13,12 @@ public import TauCeti.RingTheory.Huber.WeightedEval.Map
 its values on constants and variables. This file adds multiplicativity,
 `weightedEval (f * g) = weightedEval f * weightedEval g`.
 
-That is the remaining *algebraic* ingredient of Proposition 5.50. It does not by itself make 5.50
-a universal property: the evaluation is not yet packaged as a morphism out of `A⟨X⟩_T`, and
-neither its continuity nor the uniqueness of the extension is proved here.
+That is the remaining *algebraic* ingredient of Proposition 5.50, but not by itself the universal
+property, since it speaks about individual series. The packaging as a ring homomorphism out of
+`A⟨X⟩_T` is `TauCeti.Huber.weightedEvalHom` in `WeightedEval/Hom.lean`, which consumes
+`weightedEval_mul` below, and its continuity is `TauCeti.Huber.continuous_weightedEvalHom` in
+`WeightedEval/Continuous.lean`. Only the uniqueness of the extension, which is what makes 5.50
+*universal*, is still unproved.
 
 The argument is the Cauchy product, and Mathlib supplies it:
 `Summable.tsum_mul_tsum_eq_tsum_sum_antidiagonal` turns a product of sums into a sum over

--- a/TauCeti/RingTheory/Huber/WeightedEval/Mul.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Mul.lean
@@ -17,8 +17,9 @@ That is the remaining *algebraic* ingredient of Proposition 5.50, but not by its
 property, since it speaks about individual series. The packaging as a ring homomorphism out of
 `A⟨X⟩_T` is `TauCeti.Huber.weightedEvalHom` in `WeightedEval/Hom.lean`, which consumes
 `weightedEval_mul` below, and its continuity is `TauCeti.Huber.continuous_weightedEvalHom` in
-`WeightedEval/Continuous.lean`. Only the uniqueness of the extension, which is what makes 5.50
-*universal*, is still unproved.
+`WeightedEval/Continuous.lean`. The uniqueness that makes 5.50 *universal* is
+`TauCeti.Huber.weightedRestrictedSubring_ringHom_ext_of_continuous` in
+`WeightedRestrictedSeries.lean`.
 
 The argument is the Cauchy product, and Mathlib supplies it:
 `Summable.tsum_mul_tsum_eq_tsum_sum_antidiagonal` turns a product of sums into a sum over


### PR DESCRIPTION
**Three module docstrings claim things are missing that the next file in the chain provides.**

The `WeightedEval` cluster is a chain — `Basic` → `Map` → `Mul` → `Hom` → `Continuous` — and each
file's docstring lists what Proposition 5.50 still lacks, as of when that file was written. Two of
those lists have since become wrong, and the contradiction is with each file's own *direct
dependent*.

| File | Claim | Reality |
|---|---|---|
| `Mul.lean` | "the evaluation is **not yet** packaged as a morphism out of `A⟨X⟩_T`" | `weightedEvalHom : A⟨X⟩_T →+* B` — `Hom.lean:55`, which `public import`s `Mul.lean` and builds the homomorphism out of `weightedEval_mul` defined there |
| `Hom.lean` | "Its continuity … [is] **still not proved**" | `continuous_weightedEvalHom` — `Continuous.lean:47`, which `public import`s `Hom.lean` |
| `Basic.lean` | names three missing items | two of the three now exist; the docstring says only "not proved here", without saying where |

`Basic.lean`'s wording was scoped by "here" and so not strictly false, but it sends a reader
looking for things that are two files away. All three now name the declaration and the file.

## What is deliberately *not* changed

The uniqueness of the extension — the part that makes 5.50 a *universal* property — really is
unproved, so every docstring still says so. That was checked by grepping the whole cluster for
`uniq`: the only occurrences are the "not proved" notes themselves.

`Continuous.lean:46` ("except the uniqueness, which is not proved here") is therefore correct and
is left alone.

## Scope

Module docstrings only. No declaration, statement or proof is touched, and the diff contains no
Lean code.

## Gates

`lake build` (7587 jobs), `lake exe axioms` (40783 declarations), `lake exe module-system`
(1946 modules) and `scripts/lint-env.sh` (`LINT-ENV: PASS`, 72 grandfathered, 0 ratchetable) all
exit 0.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-0.4-weightedeval-forward-references"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
