### PR TITLE
feat: finite connected components of affine groups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/FiniteType/ConnectedComponents.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteType/ConnectedComponents.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.FiniteType
+public import Mathlib.RingTheory.Spectrum.Prime.Noetherian
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
+public import TauCeti.Topology.NoetherianSpace.ConnectedComponents
+
+/-!
+# Connected components of finite-type affine groups
+
+The prime spectrum of the coordinate ring of a finite-type affine group over a field has
+finitely many connected components, and each component is clopen. The Hopf structure is not
+needed for this finiteness statement: finite type over a field makes the coordinate ring
+Noetherian, and a Noetherian topological space has finitely many connected components.
+
+## Main declaration
+
+* `TauCeti.FiniteTypeCommHopfAlgCat.instFiniteConnectedComponents`: the connected components of
+  the spectrum of a finite-type commutative Hopf algebra form a finite type.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Section 2.a.
+* The Stacks Project, Tag 0052, *Noetherian topological spaces*.
+
+This is the finiteness prerequisite for Layer 3 of the ReductiveGroups roadmap. The later
+component-group construction will put a finite group-scheme structure on these components; this
+file establishes the underlying finiteness and clopen decomposition.
+-/
+
+public section
+
+namespace TauCeti.FiniteTypeCommHopfAlgCat
+
+universe u v
+
+variable {k : Type u} [Field k]
+
+/-- The spectrum of the coordinate ring of a finite-type affine group over a field has finitely
+many connected components. -/
+instance instFiniteConnectedComponents (H : FiniteTypeCommHopfAlgCat.{u, v} k) :
+    Finite (ConnectedComponents (PrimeSpectrum H)) := by
+  let _ : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+  exact TauCeti.finite_connectedComponents_of_noetherianSpace
+
+end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteType/ConnectedComponents.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteType/ConnectedComponents.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.Spectrum.Prime.Noetherian
 public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
 public import TauCeti.Topology.NoetherianSpace.ConnectedComponents
@@ -12,10 +11,11 @@ public import TauCeti.Topology.NoetherianSpace.ConnectedComponents
 /-!
 # Connected components of finite-type affine groups
 
-The prime spectrum of the coordinate ring of a finite-type affine group over a field has
-finitely many connected components, and each component is clopen. The Hopf structure is not
-needed for this finiteness statement: finite type over a field makes the coordinate ring
-Noetherian, and a Noetherian topological space has finitely many connected components.
+The prime spectrum of the coordinate ring of a finite-type affine group over a Noetherian
+commutative ring has finitely many connected components, and each component is clopen. The Hopf
+structure is not needed for this finiteness statement: finite type over a Noetherian ring makes
+the coordinate ring Noetherian, and a Noetherian topological space has finitely many connected
+components.
 
 ## Main declaration
 
@@ -38,13 +38,13 @@ namespace TauCeti.FiniteTypeCommHopfAlgCat
 
 universe u v
 
-variable {k : Type u} [Field k]
+variable {R : Type u} [CommRing R] [IsNoetherianRing R]
 
-/-- The spectrum of the coordinate ring of a finite-type affine group over a field has finitely
-many connected components. -/
-instance instFiniteConnectedComponents (H : FiniteTypeCommHopfAlgCat.{u, v} k) :
+/-- The spectrum of the coordinate ring of a finite-type affine group over a Noetherian
+commutative ring has finitely many connected components. -/
+instance instFiniteConnectedComponents (H : FiniteTypeCommHopfAlgCat.{u, v} R) :
     Finite (ConnectedComponents (PrimeSpectrum H)) := by
-  let _ : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+  let _ : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing R H
   exact TauCeti.finite_connectedComponents_of_noetherianSpace
 
 end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Components/Finite.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Components/Finite.lean
@@ -11,10 +11,10 @@ public import TauCeti.Topology.NoetherianSpace.ConnectedComponents
 /-!
 # Finiteness of the components of an affine group scheme
 
-An affine group scheme of finite type over a field has finitely many connected components. This
-is the scheme-side form of the corresponding coordinate-ring fact: its structural morphism is
-locally of finite type over the Noetherian scheme `Spec k`, so its source is locally Noetherian;
-affineness makes the source compact, hence Noetherian.
+An affine group scheme of finite type over a Noetherian commutative ring has finitely many
+connected components. This is the scheme-side form of the corresponding coordinate-ring fact:
+its structural morphism is locally of finite type over the Noetherian scheme `Spec R`, so its
+source is locally Noetherian; affineness makes the source compact, hence Noetherian.
 
 ## Main declaration
 
@@ -39,12 +39,12 @@ open AlgebraicGeometry
 
 universe u
 
-variable {k : Type u} [Field k]
+variable {R : Type u} [CommRing R] [IsNoetherianRing R]
 
-/-- The underlying scheme of a finite-type affine group scheme over a field has finitely many
-connected components. -/
+/-- The underlying scheme of a finite-type affine group scheme over a Noetherian commutative ring
+has finitely many connected components. -/
 instance instFiniteConnectedComponents
-    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of R)) :
     Finite (ConnectedComponents G.obj.obj.X.left) := by
   let _ : IsLocallyNoetherian G.obj.obj.X.left :=
     LocallyOfFiniteType.isLocallyNoetherian G.obj.obj.X.hom

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Components/Finite.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Components/Finite.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Noetherian
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
+public import TauCeti.Topology.NoetherianSpace.ConnectedComponents
+
+/-!
+# Finiteness of the components of an affine group scheme
+
+An affine group scheme of finite type over a field has finitely many connected components. This
+is the scheme-side form of the corresponding coordinate-ring fact: its structural morphism is
+locally of finite type over the Noetherian scheme `Spec k`, so its source is locally Noetherian;
+affineness makes the source compact, hence Noetherian.
+
+## Main declaration
+
+* `TauCeti.FiniteTypeAffineGroupSchemeCat.instFiniteConnectedComponents`: the connected
+  components of the underlying scheme form a finite type.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Section 2.a.
+* The Stacks Project, Tag 01T6, *Properties of schemes, more on morphisms*.
+
+This is the scheme-side finiteness prerequisite for the identity component and component group
+in Layer 3 of the ReductiveGroups roadmap. Constructing the finite group scheme `π₀` and proving
+it étale under the roadmap's smoothness hypotheses remain later steps.
+-/
+
+public section
+
+namespace TauCeti.FiniteTypeAffineGroupSchemeCat
+
+open AlgebraicGeometry
+
+universe u
+
+variable {k : Type u} [Field k]
+
+/-- The underlying scheme of a finite-type affine group scheme over a field has finitely many
+connected components. -/
+instance instFiniteConnectedComponents
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :
+    Finite (ConnectedComponents G.obj.obj.X.left) := by
+  let _ : IsLocallyNoetherian G.obj.obj.X.left :=
+    LocallyOfFiniteType.isLocallyNoetherian G.obj.obj.X.hom
+  let _ : IsNoetherian G.obj.obj.X.left :=
+    { toIsLocallyNoetherian := inferInstance
+      toCompactSpace := inferInstance }
+  exact TauCeti.finite_connectedComponents_of_noetherianSpace
+
+end TauCeti.FiniteTypeAffineGroupSchemeCat

--- a/TauCeti/Topology/ConnectedComponents.lean
+++ b/TauCeti/Topology/ConnectedComponents.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Connected.Clopen
+
+/-!
+# Connected components
+
+This file records general topological properties of the quotient of a space by its connected
+components.
+
+## Main declaration
+
+* `TauCeti.instT1SpaceConnectedComponents`: the connected-components quotient of any topological
+  space is a T1 space.
+-/
+
+public section
+
+open Topology
+
+universe u
+
+variable {X : Type u} [TopologicalSpace X]
+
+namespace TauCeti
+
+/-- The quotient of a topological space by its connected components is a T1 space. -/
+instance instT1SpaceConnectedComponents : T1Space (ConnectedComponents X) :=
+  ⟨fun c => by
+    obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe c
+    rw [← ConnectedComponents.isQuotientMap_coe.isClosed_preimage,
+      connectedComponents_preimage_singleton]
+    exact isClosed_connectedComponent⟩
+
+end TauCeti

--- a/TauCeti/Topology/ConnectedComponents.lean
+++ b/TauCeti/Topology/ConnectedComponents.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Topology.Connected.Clopen
+public import Mathlib.Topology.Irreducible
 
 /-!
 # Connected components
@@ -12,15 +13,17 @@ public import Mathlib.Topology.Connected.Clopen
 This file records general topological properties of the quotient of a space by its connected
 components.
 
-## Main declaration
+## Main declarations
 
 * `TauCeti.instT1SpaceConnectedComponents`: the connected-components quotient of any topological
   space is a T1 space.
+* `TauCeti.finite_connectedComponents_of_finite_irreducibleComponents`: finiteness of the
+  irreducible components implies finiteness of the connected components.
 -/
 
 public section
 
-open Topology
+open Set Topology
 
 universe u
 
@@ -35,5 +38,28 @@ instance instT1SpaceConnectedComponents : T1Space (ConnectedComponents X) :=
     rw [← ConnectedComponents.isQuotientMap_coe.isClosed_preimage,
       connectedComponents_preimage_singleton]
     exact isClosed_connectedComponent⟩
+
+/-- A space with finitely many irreducible components has finitely many connected components. -/
+theorem finite_connectedComponents_of_finite_irreducibleComponents
+    (h : (irreducibleComponents X).Finite) : Finite (ConnectedComponents X) := by
+  let C : Set (ConnectedComponents X) :=
+    ⋃ Z ∈ irreducibleComponents X, ConnectedComponents.mk '' Z
+  have hC : C.Finite := h.biUnion fun Z hZ =>
+    Set.Subsingleton.finite <| by
+      rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩
+      rw [ConnectedComponents.coe_eq_coe']
+      exact hZ.1.isConnected.isPreconnected.subset_connectedComponent hy hx
+  have hC_eq : C = Set.univ := by
+    rw [eq_univ_iff_forall]
+    intro c
+    obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe c
+    have hx : x ∈ ⋃₀ irreducibleComponents X := by
+      rw [sUnion_irreducibleComponents]
+      simp
+    obtain ⟨Z, hZ, hxZ⟩ := Set.mem_sUnion.mp hx
+    exact Set.mem_iUnion_of_mem Z <| Set.mem_iUnion_of_mem hZ ⟨x, hxZ, rfl⟩
+  apply Finite.of_finite_univ
+  rw [← hC_eq]
+  exact hC
 
 end TauCeti

--- a/TauCeti/Topology/NoetherianSpace/ConnectedComponents.lean
+++ b/TauCeti/Topology/NoetherianSpace/ConnectedComponents.lean
@@ -18,8 +18,6 @@ components is a finite discrete space, and every connected component is open as 
 
 ## Main declarations
 
-* `TauCeti.finite_connectedComponents_of_finite_irreducibleComponents`: finiteness of the
-  irreducible components implies finiteness of the connected components.
 * `TauCeti.finite_connectedComponents_of_noetherianSpace`: a Noetherian space has finitely
   many connected components.
 * `TauCeti.instLocallyConnectedSpaceOfNoetherianSpace`: a Noetherian space is locally
@@ -43,29 +41,6 @@ universe u
 variable {X : Type u} [TopologicalSpace X]
 
 namespace TauCeti
-
-/-- A space with finitely many irreducible components has finitely many connected components. -/
-theorem finite_connectedComponents_of_finite_irreducibleComponents
-    (h : (irreducibleComponents X).Finite) : Finite (ConnectedComponents X) := by
-  let C : Set (ConnectedComponents X) :=
-    ⋃ Z ∈ irreducibleComponents X, ConnectedComponents.mk '' Z
-  have hC : C.Finite := h.biUnion fun Z hZ =>
-    Set.Subsingleton.finite <| by
-      rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩
-      rw [ConnectedComponents.coe_eq_coe']
-      exact hZ.1.isConnected.isPreconnected.subset_connectedComponent hy hx
-  have hC_eq : C = Set.univ := by
-    rw [eq_univ_iff_forall]
-    intro c
-    obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe c
-    have hx : x ∈ ⋃₀ irreducibleComponents X := by
-      rw [sUnion_irreducibleComponents]
-      simp
-    obtain ⟨Z, hZ, hxZ⟩ := Set.mem_sUnion.mp hx
-    exact Set.mem_iUnion_of_mem Z <| Set.mem_iUnion_of_mem hZ ⟨x, hxZ, rfl⟩
-  apply Finite.of_finite_univ
-  rw [← hC_eq]
-  exact hC
 
 /-- A Noetherian space has finitely many connected components. -/
 theorem finite_connectedComponents_of_noetherianSpace [TopologicalSpace.NoetherianSpace X] :

--- a/TauCeti/Topology/NoetherianSpace/ConnectedComponents.lean
+++ b/TauCeti/Topology/NoetherianSpace/ConnectedComponents.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Topology.Connected.LocallyConnected
 public import Mathlib.Topology.NoetherianSpace
+public import TauCeti.Topology.ConnectedComponents
 
 /-!
 # Connected components of Noetherian spaces
@@ -42,14 +43,6 @@ universe u
 variable {X : Type u} [TopologicalSpace X]
 
 namespace TauCeti
-
-/-- The quotient of a topological space by its connected components is a T1 space. -/
-instance instT1SpaceConnectedComponents : T1Space (ConnectedComponents X) :=
-  ⟨fun c => by
-    obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe c
-    rw [← ConnectedComponents.isQuotientMap_coe.isClosed_preimage,
-      connectedComponents_preimage_singleton]
-    exact isClosed_connectedComponent⟩
 
 /-- A space with finitely many irreducible components has finitely many connected components. -/
 theorem finite_connectedComponents_of_finite_irreducibleComponents

--- a/TauCeti/Topology/NoetherianSpace/ConnectedComponents.lean
+++ b/TauCeti/Topology/NoetherianSpace/ConnectedComponents.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Connected.LocallyConnected
+public import Mathlib.Topology.NoetherianSpace
+
+/-!
+# Connected components of Noetherian spaces
+
+A Noetherian topological space has only finitely many connected components. Indeed, it has
+finitely many irreducible components, every irreducible set lies in one connected component,
+and the irreducible components cover the space. Consequently the quotient by connected
+components is a finite discrete space, and every connected component is open as well as closed.
+
+## Main declarations
+
+* `TauCeti.finite_connectedComponents_of_finite_irreducibleComponents`: finiteness of the
+  irreducible components implies finiteness of the connected components.
+* `TauCeti.finite_connectedComponents_of_noetherianSpace`: a Noetherian space has finitely
+  many connected components.
+* `TauCeti.instLocallyConnectedSpaceOfNoetherianSpace`: a Noetherian space is locally
+  connected.
+
+## References
+
+* The Stacks Project, Tag 0052, *Noetherian topological spaces*.
+
+The finite-component conclusion is used for the identity-component and component-group
+milestone in Layer 3 of the ReductiveGroups roadmap. Applied to the spectrum of a finite-type
+coordinate algebra, it supplies the finiteness input for the construction of `π₀`.
+-/
+
+public section
+
+open Set Topology
+
+universe u
+
+variable {X : Type u} [TopologicalSpace X]
+
+namespace TauCeti
+
+/-- The quotient of a topological space by its connected components is a T1 space. -/
+instance instT1SpaceConnectedComponents : T1Space (ConnectedComponents X) :=
+  ⟨fun c => by
+    obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe c
+    rw [← ConnectedComponents.isQuotientMap_coe.isClosed_preimage,
+      connectedComponents_preimage_singleton]
+    exact isClosed_connectedComponent⟩
+
+/-- A space with finitely many irreducible components has finitely many connected components. -/
+theorem finite_connectedComponents_of_finite_irreducibleComponents
+    (h : (irreducibleComponents X).Finite) : Finite (ConnectedComponents X) := by
+  let C : Set (ConnectedComponents X) :=
+    ⋃ Z ∈ irreducibleComponents X, ConnectedComponents.mk '' Z
+  have hC : C.Finite := h.biUnion fun Z hZ =>
+    Set.Subsingleton.finite <| by
+      rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩
+      rw [ConnectedComponents.coe_eq_coe']
+      exact hZ.1.isConnected.isPreconnected.subset_connectedComponent hy hx
+  have hC_eq : C = Set.univ := by
+    rw [eq_univ_iff_forall]
+    intro c
+    obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe c
+    have hx : x ∈ ⋃₀ irreducibleComponents X := by
+      rw [sUnion_irreducibleComponents]
+      simp
+    obtain ⟨Z, hZ, hxZ⟩ := Set.mem_sUnion.mp hx
+    exact Set.mem_iUnion_of_mem Z <| Set.mem_iUnion_of_mem hZ ⟨x, hxZ, rfl⟩
+  apply Finite.of_finite_univ
+  rw [← hC_eq]
+  exact hC
+
+/-- A Noetherian space has finitely many connected components. -/
+theorem finite_connectedComponents_of_noetherianSpace [TopologicalSpace.NoetherianSpace X] :
+    Finite (ConnectedComponents X) :=
+  finite_connectedComponents_of_finite_irreducibleComponents
+    TopologicalSpace.NoetherianSpace.finite_irreducibleComponents
+
+/-- A Noetherian space is locally connected. In particular, each connected component is
+clopen. -/
+instance instLocallyConnectedSpaceOfNoetherianSpace [TopologicalSpace.NoetherianSpace X] :
+    LocallyConnectedSpace X := by
+  rw [locallyConnectedSpace_iff_connectedComponentIn_open]
+  intro U hU x hx
+  let _ : TopologicalSpace.NoetherianSpace U := TopologicalSpace.NoetherianSpace.set U
+  let _ : Finite (ConnectedComponents U) := finite_connectedComponents_of_noetherianSpace
+  have hopen : IsOpen (connectedComponent (⟨x, hx⟩ : U)) := by
+    rw [← connectedComponents_preimage_singleton]
+    exact (isOpen_discrete
+      ({((⟨x, hx⟩ : U) : ConnectedComponents U)} : Set (ConnectedComponents U))).preimage
+        ConnectedComponents.continuous_coe
+  rw [connectedComponentIn_eq_image hx]
+  exact hU.isOpenEmbedding_subtypeVal.isOpenMap _ hopen
+
+end TauCeti


### PR DESCRIPTION
This PR proves that a space with finitely many irreducible components has finitely many connected components, derives that every Noetherian space is locally connected with clopen components, and applies the result to both coordinate Hopf algebras and finite-type affine group schemes over a field.

The exact target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3 milestone **“Identity component `G°` and component group `π₀(G)`”**, specifically the finiteness input for the component group. A finite-type coordinate algebra over a field is Noetherian, while the underlying scheme of a finite-type affine group is locally Noetherian and affine, hence Noetherian; the resulting `Finite (ConnectedComponents ...)` instances keep the coordinate and scheme models synchronized. After this PR, the milestone still needs the construction and universal property of `G°`, the group-scheme structure on `π₀(G)`, and the proof that `π₀(G)` is finite étale under the roadmap's smoothness and field hypotheses.

The implementation adds `TauCeti/Topology/NoetherianSpace/ConnectedComponents.lean` (99 lines), `TauCeti/Algebra/AlgebraicGroup/FiniteType/ConnectedComponents.lean` (50 lines), and `TauCeti/AlgebraicGeometry/AffineGroupScheme/Components/Finite.lean` (56 lines). It reuses Mathlib's `NoetherianSpace.finite_irreducibleComponents`, the connected-component quotient API, `Algebra.FiniteType.isNoetherianRing`, and `LocallyOfFiniteType.isLocallyNoetherian`; no Mathlib code is vendored. The mathematical statements follow the Stacks Project, Tag 0052, and J. S. Milne, *Algebraic Groups* (2017), §2.a, as cited in the module documentation.

Validation completed with `lake build`, `tauceti-axioms --changed-since-merge-base origin/main`, and `tauceti-lint-env --changed-since-merge-base origin/main`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-connected-components-affine-group-scheme"}-->

🤖 Prepared with Codex
