### PR TITLE
refactor(Fourier): use Mathlib's bounded-integral norm bound in the dominating estimate

### DIFF
--- a/TauCeti/Analysis/Bochner/Fourier/Nonneg.lean
+++ b/TauCeti/Analysis/Bochner/Fourier/Nonneg.lean
@@ -222,17 +222,8 @@ private theorem exists_simpleFunc_tendsto_double_integral (ψ : V → ℂ)
       (fun u => ∫ y, ψ (u - hid.approx n y) ∂μ) μ
   have hbd2 : ∀ n, ∀ᵐ x ∂μ,
       ‖∫ y, ψ (hid.approx n x - hid.approx n y) ∂μ‖ ≤
-        (ψ 0).re * (μ Set.univ).toReal := by
-    intro n
-    refine ae_of_all _ (fun x => ?_)
-    calc ‖∫ y, ψ (hid.approx n x - hid.approx n y) ∂μ‖
-        ≤ ∫ y, ‖ψ (hid.approx n x - hid.approx n y)‖ ∂μ :=
-          norm_integral_le_integral_norm _
-      _ ≤ ∫ _, (ψ 0).re ∂μ :=
-          integral_mono_of_nonneg (ae_of_all _ (fun _ => norm_nonneg _))
-            (integrable_const _) (ae_of_all _ (fun _ => hbound _))
-      _ = (ψ 0).re * (μ Set.univ).toReal := by
-          rw [integral_const, smul_eq_mul, mul_comm, measureReal_def]
+        (ψ 0).re * (μ Set.univ).toReal := fun n =>
+    ae_of_all _ fun _ => norm_integral_le_of_norm_le_const (ae_of_all _ fun _ => hbound _)
   exact tendsto_integral_of_dominated_convergence
     (fun _ => (ψ 0).re * (μ Set.univ).toReal)
     hmeas2 (integrable_const _) hbd2 (ae_of_all _ h_inner_conv)


### PR DESCRIPTION
`exists_simpleFunc_tendsto_double_integral` runs dominated convergence twice, and the dominating
bound for the outer application was proved by hand: a four-step `calc` passing from the norm of an
integral to the integral of the norm, then to the integral of the constant `(ψ 0).re`, then
evaluating that constant integral.

Mathlib states exactly this. `MeasureTheory.norm_integral_le_of_norm_le_const`
(`Mathlib/MeasureTheory/Integral/Bochner/Basic.lean`) says that over a finite measure a pointwise
bound `‖f x‖ ≤ C` gives `‖∫ x, f x ∂μ‖ ≤ C * μ.real univ`, and its own proof is the same two steps
the `calc` was spelling out. The thirteen-line `have` becomes three lines, with the `measureReal_def`
rewrite no longer needed — `μ.real univ` unifies with the `(μ Set.univ).toReal` already in the
statement.

No declaration is added or removed and no statement changes; this is a local proof simplification
that removes a re-derivation of a Mathlib lemma. The parent drops from 45 lines to 36.

I checked whether the same hand-rolled shape occurs elsewhere before writing this up — it does not.
No other file in `TauCeti/` combines `norm_integral_le_integral_norm` with the
`integral_const, smul_eq_mul, mul_comm` evaluation, so this is an isolated occurrence rather than
the first of a sweep.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: OneParameterSemigroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
