### PR TITLE
feat: an intermediate quotient of a quotient covering map is a covering map

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Existence.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Existence.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.SubgroupQuotient
+public import TauCeti.Topology.Covering.Quotient
 
 /-!
 # The covering associated to a subgroup
@@ -14,10 +15,19 @@ the orbit quotient of the universal cover by `H`, and `UniversalCover.subgroupQu
 is its descended endpoint projection. This file proves that the descended projection is a
 covering map.
 
-The proof descends the standard sheet decomposition of the universal cover. Over a connected
-good neighbourhood `U`, the `H`-orbits of the sheets are exactly the sheets of the quotient.
-The only bookkeeping needed is that a fundamental-group element carries the sheet through a
-point of one fibre onto the sheet through its translate.
+The two inputs are that `UniversalCover.proj` and `UniversalCover.subgroupQuotientMap` are
+quotient covering maps, for `π₁(X, x₀)` and for `H` respectively, and that the first factors
+through the second. `TauCeti.IsQuotientCoveringMap.isCoveringMap_of_comp` turns exactly that
+data into a covering map: the sheets of the descended projection over the image of a locally
+disjoint set `U` are the images of the translates of `U`. Nothing about good neighbourhoods of
+the base, their path-connectedness, or the transport of a sheet of `proj` along the
+fundamental-group action enters here, because the general statement uses only the disjointness
+built into `IsQuotientCoveringMap`.
+
+The conclusion is not inherited formally from the two quotient maps being covering maps: the
+deck group of `UniversalCover x₀ / H` over `X` is the normalizer quotient `N(H) / H`, which is
+transitive on the fibres only for normal `H`, so the descended projection is generally not
+itself a quotient covering map for any group.
 
 ## Main declaration
 
@@ -27,280 +37,25 @@ point of one fibre onto the sheet through its translate.
 ## References
 
 This completes the existence half in `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2,
-item 7: construct the pointed connected cover `UniversalCover x₀ / H`. It uses the
-based-path sheet construction adapted from Kim Morrison's
+item 7: construct the pointed connected cover `UniversalCover x₀ / H`. It uses the universal
+cover adapted from Kim Morrison's
 [mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292) and Mathlib's
 quotient-covering-map interface due to Junyan Xu.
 -/
 
 public section
-noncomputable section
 
-open Topology
-
-variable {X : Type*} [TopologicalSpace X] {x₀ x : X}
+variable {X : Type*} [TopologicalSpace X]
 
 namespace TauCeti.UniversalCover
-
-/-- A point in a fibre of the universal cover determines a homotopy class with the fibre's
-fixed endpoint. -/
-private def fiberPath (e : (proj : UniversalCover x₀ → X) ⁻¹' {x}) :
-    Path.Homotopic.Quotient x₀ x :=
-  e.1.path.cast rfl (Set.mem_singleton_iff.mp e.2).symm
-
-/-- Rebuilding a point of a fibre from its endpoint-adjusted path class returns that point. -/
-private theorem mk_fiberPath (e : (proj : UniversalCover x₀ → X) ⁻¹' {x}) :
-    mk x (fiberPath e) = e.1 := by
-  let he := (Set.mem_singleton_iff.mp e.2).symm
-  apply UniversalCover.ext he
-  exact Path.Homotopic.Quotient.cast_heq rfl he
-
-/-- The canonical point of a fibre associated to a path class. -/
-private def fiberPoint (q : Path.Homotopic.Quotient x₀ x) :
-    (proj : UniversalCover x₀ → X) ⁻¹' {x} :=
-  ⟨mk x q, rfl⟩
-
-/-- Extracting the path class from its canonical fibre point returns that class. -/
-@[simp]
-private theorem fiberPath_fiberPoint (q : Path.Homotopic.Quotient x₀ x) :
-    fiberPath (fiberPoint q) = q := by
-  simp only [fiberPath, fiberPoint, Path.Homotopic.Quotient.cast_rfl_rfl]
-
-/-- The point represented by a path class belongs to the sheet indexed by that class. -/
-private theorem mk_mem_sheet (U : Set X) (hxU : x ∈ U)
-    (q : Path.Homotopic.Quotient x₀ x) : mk x q ∈ sheet U hxU q := by
-  obtain ⟨p, hp⟩ := Quotient.exists_rep q
-  rw [← hp]
-  have hq : (⟦p⟧ : Path.Homotopic.Quotient x₀ x) =
-      Path.Homotopic.Quotient.mk p :=
-    Path.Homotopic.Quotient.mk''_eq_mk p
-  rw [hq, ← ofBasedPath_ofPath]
-  exact mem_sheet_self (x₀ := x₀) hxU p
-
-/-- Every sheet over a path-connected good neighbourhood is path-connected. -/
-private theorem isPathConnected_sheet [LocallyPathConnectedSpace X]
-    [SemilocallySimplyConnectedSpace X] (U : Set X) (hU_open : IsOpen U)
-    (hU_pathConn : IsPathConnected U) (hU_slsc : IsPathHomotopyTrivial U) (hxU : x ∈ U)
-    (q : Path.Homotopic.Quotient x₀ x) : IsPathConnected (sheet U hxU q) := by
-  let f : sheet U hxU q → U :=
-    Subtype.map proj (sheet_subset_proj_preimage U hxU q)
-  have hf_bij : Function.Bijective f := by
-    constructor
-    · intro e₁ e₂ he
-      apply Subtype.ext
-      exact proj_injOn_sheet hU_slsc hxU q e₁.2 e₂.2 (congrArg Subtype.val he)
-    · intro y
-      obtain ⟨e, he, hey⟩ := proj_surjOn_sheet hU_pathConn hxU q y.2
-      exact ⟨⟨e, he⟩, Subtype.ext hey⟩
-  let e : sheet U hxU q ≃ U := Equiv.ofBijective f hf_bij
-  have hf_cont : Continuous f :=
-    ((continuous_proj x₀).comp continuous_subtype_val).subtype_mk _
-  have hf_open : IsOpenMap f :=
-    ((isOpenMap_proj x₀).domRestrict (isOpen_sheet U hU_open hxU q)).subtype_mk _
-  let h : sheet U hxU q ≃ₜ U := e.toHomeomorphOfContinuousOpen hf_cont hf_open
-  rw [isPathConnected_iff_pathConnectedSpace]
-  let : PathConnectedSpace U := isPathConnected_iff_pathConnectedSpace.mp hU_pathConn
-  exact h.symm.surjective.pathConnectedSpace h.symm.continuous
-
-/-- A preconnected subset of the preimage of a good neighbourhood which meets one sheet is
-contained in that sheet. -/
-private theorem subset_sheet_of_isPreconnected [LocallyPathConnectedSpace X]
-    [SemilocallySimplyConnectedSpace X] {C : Set (UniversalCover x₀)}
-    {V : Set X} (hV_open : IsOpen V) (hV_pathConn : IsPathConnected V) (hxV : x ∈ V)
-    (hV_slsc : IsPathHomotopyTrivial V) (q : Path.Homotopic.Quotient x₀ x)
-    (hC : IsPreconnected C) (hCV : C ⊆ proj ⁻¹' V)
-    (hCq : (C ∩ sheet V hxV q).Nonempty) : C ⊆ sheet V hxV q := by
-  let otherSheets : Set (UniversalCover x₀) :=
-    ⋃ q' : {q' : Path.Homotopic.Quotient x₀ x // q' ≠ q}, sheet V hxV q'.1
-  have hother_open : IsOpen otherSheets :=
-    isOpen_iUnion fun q' ↦ isOpen_sheet V hV_open hxV q'.1
-  have hdisjoint : Disjoint (sheet V hxV q) otherSheets := by
-    refine Set.disjoint_left.mpr ?_
-    intro e heq heother
-    rcases Set.mem_iUnion.mp heother with ⟨q', heq'⟩
-    exact Set.disjoint_left.mp (pairwise_disjoint_sheet hV_slsc hxV q'.2.symm) heq heq'
-  have hcover : C ⊆ sheet V hxV q ∪ otherSheets := by
-    intro e heC
-    rcases Set.mem_iUnion.mp (sheet_exhaustive hV_pathConn hxV (hCV heC)) with ⟨q', heq'⟩
-    by_cases hq' : q' = q
-    · exact Set.mem_union_left _ (hq' ▸ heq')
-    · exact Set.mem_union_right _ (Set.mem_iUnion_of_mem ⟨q', hq'⟩ heq')
-  rcases hC.subset_or_subset (isOpen_sheet V hV_open hxV q)
-      hother_open hdisjoint hcover with h | h
-  · exact h
-  · obtain ⟨e, heC, heq⟩ := hCq
-    exact (Set.disjoint_left.mp hdisjoint heq (h heC)).elim
-
-/-- A fundamental-group element carries a sheet to the sheet through the translated point in
-the fibre. -/
-private theorem smul_sheet [LocallyPathConnectedSpace X] [PathConnectedSpace X]
-    [SemilocallySimplyConnectedSpace X] (U : Set X) (hU_open : IsOpen U)
-    (hU_pathConn : IsPathConnected U) (hU_slsc : IsPathHomotopyTrivial U) (hxU : x ∈ U)
-    (g : FundamentalGroup X x₀) (e : (proj : UniversalCover x₀ → X) ⁻¹' {x}) :
-    letI := (isQuotientCoveringMap (x₀ := x₀)).mulActionFiber x
-    (g • ·) '' sheet U hxU (fiberPath e) = sheet U hxU (fiberPath (g • e)) := by
-  let hquot := isQuotientCoveringMap (x₀ := x₀)
-  let := hquot.mulActionFiber x
-  have map_subset (g : FundamentalGroup X x₀)
-      (e : (proj : UniversalCover x₀ → X) ⁻¹' {x}) :
-      (g • ·) '' sheet U hxU (fiberPath e) ⊆ sheet U hxU (fiberPath (g • e)) := by
-    have hcenter : (e : UniversalCover x₀) ∈ sheet U hxU (fiberPath e) := by
-      rw [← mk_fiberPath e]
-      exact mk_mem_sheet U hxU (fiberPath e)
-    have htranslated : ((g • e : (proj : UniversalCover x₀ → X) ⁻¹' {x}) :
-        UniversalCover x₀) ∈ sheet U hxU (fiberPath (g • e)) := by
-      rw [← mk_fiberPath (g • e)]
-      exact mk_mem_sheet U hxU (fiberPath (g • e))
-    refine subset_sheet_of_isPreconnected
-      (C := (g • ·) '' sheet U hxU (fiberPath e)) hU_open hU_pathConn hxU hU_slsc
-      (fiberPath (g • e)) ?_ ?_ ?_
-    · exact ((isPathConnected_sheet U hU_open hU_pathConn hU_slsc hxU (fiberPath e)).image
-        (continuous_const_smul g)).isConnected.isPreconnected
-    · rintro _ ⟨z, hz, rfl⟩
-      simpa only [Set.mem_preimage, proj_smul] using
-        sheet_subset_proj_preimage U hxU (fiberPath e) hz
-    · refine ⟨g • (e : UniversalCover x₀), ⟨⟨e, hcenter, rfl⟩, ?_⟩⟩
-      simpa only [hquot.coe_mulActionFiber_smul] using htranslated
-  apply Set.Subset.antisymm (map_subset g e)
-  have hinv := map_subset g⁻¹ (g • e)
-  have hinv' : (g⁻¹ • ·) '' sheet U hxU (fiberPath (g • e)) ⊆
-      sheet U hxU (fiberPath e) := by
-    simpa only [inv_smul_smul] using hinv
-  intro z hz
-  exact ⟨g⁻¹ • z, hinv' ⟨z, hz, rfl⟩, by simp⟩
 
 /-- The endpoint projection on the quotient of the universal cover by `H` is a covering map. -/
 theorem isCoveringMap_subgroupQuotientProj [LocallyPathConnectedSpace X]
     [PathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
     (x₀ : X) (H : Subgroup (FundamentalGroup X x₀)) :
-    IsCoveringMap (subgroupQuotientProj x₀ H) := by
-  intro x
-  obtain ⟨U, hU_open, hxU, hU_pathConn, hU_slsc⟩ :=
-    exists_isOpen_mem_isPathConnected_isPathHomotopyTrivial x
-  let hq := isQuotientCoveringMap_subgroupQuotientMap x₀ H
-  let hfull := isQuotientCoveringMap (x₀ := x₀)
-  let := hfull.mulActionFiber x
-  let I := MulAction.orbitRel.Quotient H ((proj : UniversalCover x₀ → X) ⁻¹' {x})
-  let S (a : I) : Set (SubgroupQuotient x₀ H) :=
-    subgroupQuotientMap x₀ H '' sheet U hxU (fiberPath a.out)
-  let eₓ : (proj : UniversalCover x₀ → X) ⁻¹' {x} :=
-    fiberPoint (Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath x₀ x))
-  have : Nonempty I := ⟨Quotient.mk'' eₓ⟩
-  let : TopologicalSpace I := ⊥
-  have : DiscreteTopology I := ⟨rfl⟩
-  have : Nonempty (X → SubgroupQuotient x₀ H) :=
-    ⟨fun _ ↦ SubgroupQuotient.basepoint x₀ H⟩
-  have hopen_r : IsOpenMap (subgroupQuotientProj x₀ H) := by
-    apply IsOpenMap.of_comp (f := subgroupQuotientMap x₀ H)
-      hq.isCoveringMap.continuous hq.surjective
-    simpa only [subgroupQuotientProj_comp_subgroupQuotientMap] using isOpenMap_proj x₀
-  have hrq (e : UniversalCover x₀) :
-      subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e) = proj e :=
-    congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e
-  have hS_open (a : I) : IsOpen (S a) :=
-    hq.isOpenQuotientMap.isOpenMap _ (isOpen_sheet U hU_open hxU (fiberPath a.out))
-  have hS_inj (a : I) : (S a).InjOn (subgroupQuotientProj x₀ H) := by
-    rintro z₁ ⟨e₁, he₁, rfl⟩ z₂ ⟨e₂, he₂, rfl⟩ heq
-    apply congrArg (subgroupQuotientMap x₀ H)
-    apply proj_injOn_sheet hU_slsc hxU (fiberPath a.out) he₁ he₂
-    simpa only [hrq] using heq
-  have hS_surj (a : I) : (S a).SurjOn (subgroupQuotientProj x₀ H) U := by
-    intro y hyU
-    obtain ⟨e, he, hey⟩ := proj_surjOn_sheet hU_pathConn hxU (fiberPath a.out) hyU
-    refine ⟨subgroupQuotientMap x₀ H e, ⟨e, he, rfl⟩, ?_⟩
-    calc
-      subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e) = proj e := hrq e
-      _ = y := hey
-  have hq_smul (g : H) (e : UniversalCover x₀) :
-      subgroupQuotientMap x₀ H (g • e) = subgroupQuotientMap x₀ H e := by
-    apply (subgroupQuotientMap_eq_iff x₀ H).2
-    exact ⟨g, rfl⟩
-  have hS_eq_of_orbit
-      {e₁ e₂ : (proj : UniversalCover x₀ → X) ⁻¹' {x}} (he : e₁ ∈ MulAction.orbit H e₂) :
-      subgroupQuotientMap x₀ H '' sheet U hxU (fiberPath e₁) =
-        subgroupQuotientMap x₀ H '' sheet U hxU (fiberPath e₂) := by
-    rcases he with ⟨g, hg⟩
-    have hg' : (g.1 • e₂ : (proj : UniversalCover x₀ → X) ⁻¹' {x}) = e₁ := by
-      simpa only [Subgroup.smul_def] using hg
-    rw [← hg', ← smul_sheet U hU_open hU_pathConn hU_slsc hxU g.1 e₂]
-    ext z
-    constructor
-    · rintro ⟨_, ⟨e, he, rfl⟩, rfl⟩
-      exact ⟨e, he, (hq_smul g e).symm⟩
-    · rintro ⟨e, he, rfl⟩
-      exact ⟨g • e, ⟨e, he, rfl⟩, hq_smul g e⟩
-  have hS_disjoint : Pairwise fun a b : I ↦ Disjoint (S a) (S b) := by
-    intro a b hab
-    refine Set.disjoint_left.mpr ?_
-    intro z hza hzb
-    rcases hza with ⟨e₁, he₁, rfl⟩
-    rcases hzb with ⟨e₂, he₂, heq⟩
-    have he_orbit : e₁ ∈ MulAction.orbit H e₂ :=
-      (subgroupQuotientMap_eq_iff x₀ H).1 heq.symm
-    rcases he_orbit with ⟨g, hg⟩
-    have hge₂ : g.1 • e₂ ∈ sheet U hxU
-        (fiberPath (g.1 • b.out : (proj : UniversalCover x₀ → X) ⁻¹' {x})) := by
-      rw [← smul_sheet U hU_open hU_pathConn hU_slsc hxU g.1 b.out]
-      exact ⟨e₂, he₂, rfl⟩
-    have hpaths : fiberPath a.out =
-        fiberPath (g.1 • b.out : (proj : UniversalCover x₀ → X) ⁻¹' {x}) := by
-      by_contra hne
-      exact Set.disjoint_left.mp (pairwise_disjoint_sheet hU_slsc hxU hne)
-        he₁ (hg ▸ hge₂)
-    have hcenters : a.out =
-        (g.1 • b.out : (proj : UniversalCover x₀ → X) ⁻¹' {x}) := by
-      apply Subtype.ext
-      rw [← mk_fiberPath a.out,
-        ← mk_fiberPath (g.1 • b.out : (proj : UniversalCover x₀ → X) ⁻¹' {x}), hpaths]
-    have hout_eq : (Quotient.mk'' a.out : I) = Quotient.mk'' b.out := by
-      rw [Quotient.eq'', MulAction.orbitRel_apply]
-      exact ⟨g, by simpa only [Subgroup.smul_def] using hcenters.symm⟩
-    apply hab
-    calc
-      a = Quotient.mk'' a.out := (Quotient.out_eq' a).symm
-      _ = Quotient.mk'' b.out := hout_eq
-      _ = b := Quotient.out_eq' b
-  have hS_exhaustive : subgroupQuotientProj x₀ H ⁻¹' U ⊆ ⋃ a, S a := by
-    intro z hz
-    induction z using Quotient.inductionOn' with
-    | h e =>
-      have heU : proj e ∈ U := by
-        rw [Set.mem_preimage, subgroupQuotientProj_mk] at hz
-        exact hz
-      rcases Set.mem_iUnion.mp (sheet_exhaustive hU_pathConn hxU heU) with ⟨qₓ, heqₓ⟩
-      let center : (proj : UniversalCover x₀ → X) ⁻¹' {x} := fiberPoint qₓ
-      let a : I := Quotient.mk'' center
-      have ha_orbit : a.out ∈ MulAction.orbit H center := by
-        rw [← MulAction.orbitRel_apply, ← Quotient.eq'']
-        exact (Quotient.out_eq' a).trans rfl
-      have heqₓ' : e ∈ sheet U hxU (fiberPath center) := by
-        simpa only [center, fiberPath_fiberPoint] using heqₓ
-      refine Set.mem_iUnion_of_mem a ?_
-      rw [← subgroupQuotientMap_apply]
-      -- Expose the let-bound definition of `S` so `hS_eq_of_orbit` can match its left side.
-      rw [show S a = subgroupQuotientMap x₀ H '' sheet U hxU (fiberPath a.out) from rfl,
-        hS_eq_of_orbit ha_orbit]
-      exact ⟨e, heqₓ', rfl⟩
-  have hopen_iff (a : I) {W : Set X} (hWU : W ⊆ U) :
-      IsOpen W ↔ IsOpen (subgroupQuotientProj x₀ H ⁻¹' W ∩ S a) := by
-    constructor
-    · intro hW
-      exact (hW.preimage (continuous_subgroupQuotientProj x₀ H)).inter (hS_open a)
-    · intro hopen
-      have himage_open := hopen_r _ hopen
-      have himage : subgroupQuotientProj x₀ H ''
-          (subgroupQuotientProj x₀ H ⁻¹' W ∩ S a) = W := by
-        ext y
-        constructor
-        · rintro ⟨z, ⟨hzW, -⟩, rfl⟩
-          exact hzW
-        · intro hyW
-          obtain ⟨z, hzS, hzy⟩ := hS_surj a (hWU hyW)
-          refine ⟨z, ⟨?_, hzS⟩, hzy⟩
-          simpa only [Set.mem_preimage, hzy] using hyW
-      rwa [himage] at himage_open
-  refine ((IsEvenlyCovered.of_trivialization (t :=
-    IsOpen.trivializationDiscrete S U hU_open hopen_iff hS_inj hS_surj hS_disjoint
-      hS_exhaustive) hxU).to_isEvenlyCovered_preimage)
+    IsCoveringMap (subgroupQuotientProj x₀ H) :=
+  IsQuotientCoveringMap.isCoveringMap_of_comp (isQuotientCoveringMap (x₀ := x₀))
+    (isQuotientCoveringMap_subgroupQuotientMap x₀ H)
+    (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H)
 
 end TauCeti.UniversalCover

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -34,8 +34,13 @@ application is `TauCeti.UniversalCover.isCoveringMap_subgroupQuotientProj`.
 ## Implementation notes
 
 The sheets are produced by hand rather than by exhibiting `r` as a quotient covering map for some
-group, because in general it is not one: the deck group of `E / H → E / G` is the normalizer
-quotient `N_G(H) / H`, which acts transitively on the fibres of `r` only when `H` is normal in `G`.
+group, because in general it is not one. The fibre of `r` over `q e` consists of the classes of
+the points `g • e` for `g : G`, two of which agree exactly when `g` differs by an element of `H`;
+the normalizer quotient `N_G(H) / H` acts on `E / H` over `X` by deck transformations of `r`, but
+on that fibre it acts transitively only when `H` is normal in `G`. (Whether it exhausts the deck
+transformations of `r` is a further question, needing connectedness hypotheses that are not
+assumed here.)
+
 So the construction goes through Mathlib's `IsOpen.trivializationDiscrete`, which turns a family
 of pairwise disjoint sets on which the map is injective into a `Bundle.Trivialization`. The index
 type of that family is the set of translate images itself, which makes the family injective and
@@ -54,12 +59,6 @@ variable {E X Y : Type*} [TopologicalSpace E] [TopologicalSpace X] [TopologicalS
 
 namespace IsQuotientCoveringMap
 
-/-- A quotient covering map for a subgroup `H` of `G` is unchanged by translating its argument by
-an element of `H`, viewed inside the ambient group `G`. -/
-private theorem apply_smul_of_mem (hqH : IsQuotientCoveringMap qH H) {g : G} (hg : g ∈ H)
-    (y : E) : qH (g • y) = qH y :=
-  hqH.apply_eq_iff_mem_orbit.mpr ⟨⟨g, hg⟩, rfl⟩
-
 /-- Translating a set by an element of `H` does not change its image under a quotient covering map
 for `H`. -/
 private theorem image_smul_of_mem (hqH : IsQuotientCoveringMap qH H) {g : G} (hg : g ∈ H)
@@ -68,9 +67,9 @@ private theorem image_smul_of_mem (hqH : IsQuotientCoveringMap qH H) {g : G} (hg
   constructor
   · rintro ⟨w, hw, rfl⟩
     obtain ⟨s, hs, rfl⟩ := Set.mem_smul_set.mp hw
-    exact ⟨s, hs, (apply_smul_of_mem hqH hg s).symm⟩
+    exact ⟨s, hs, (hqH.map_smul ⟨g, hg⟩).symm⟩
   · rintro ⟨s, hs, rfl⟩
-    exact ⟨g • s, Set.smul_mem_smul_set hs, apply_smul_of_mem hqH hg s⟩
+    exact ⟨g • s, Set.smul_mem_smul_set hs, hqH.map_smul ⟨g, hg⟩⟩
 
 /-- Two points of `E` with the same image under a quotient covering map for `H` differ by an
 element of `H`, viewed inside the ambient group `G`. -/

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Covering.Quotient
+
+/-!
+# Intermediate quotients of a quotient covering map
+
+Let a group `G` act on a space `E` so that `q : E → X` presents `X` as the quotient `E / G` in
+the strong sense of Mathlib's `IsQuotientCoveringMap`: the fibres of `q` are the orbits, and every
+point of `E` has a neighbourhood whose `G`-translates are pairwise disjoint. Let `H` be a subgroup
+of `G`, and let `qH : E → Y` present `Y` as `E / H` in the same sense. The projection `q` then
+factors through `qH`, and the theorem of this file is that the factor
+
+`r : E / H → E / G`
+
+is a covering map. Neither space is assumed connected, and no local connectedness of `X` is
+needed: the sheets of `r` over the base set `q '' U` are the images in `Y` of the translates
+`g • U`, whose overlaps the disjointness hypothesis controls directly.
+
+The intended reading is that a subgroup of the deck group of a regular covering cuts out an
+intermediate covering. That is the shape of the subgroup-to-cover half of the classification of
+covering spaces, where `E` is the universal cover of `X` and `G` is its fundamental group; that
+application is `TauCeti.UniversalCover.isCoveringMap_subgroupQuotientProj`.
+
+## Main results
+
+* `TauCeti.IsQuotientCoveringMap.isCoveringMap_of_comp`: the map from the quotient by a subgroup
+  down to the quotient by the whole group is a covering map.
+
+## Implementation notes
+
+The sheets are produced by hand rather than by exhibiting `r` as a quotient covering map for some
+group, because in general it is not one: the deck group of `E / H → E / G` is the normalizer
+quotient `N_G(H) / H`, which acts transitively on the fibres of `r` only when `H` is normal in `G`.
+So the construction goes through Mathlib's `IsOpen.trivializationDiscrete`, which turns a family
+of pairwise disjoint sets on which the map is injective into a `Bundle.Trivialization`. The index
+type of that family is the set of translate images itself, which makes the family injective and
+its pairwise disjointness exactly the statement that two meeting translate images coincide.
+-/
+
+public section
+
+namespace TauCeti
+
+open Pointwise Topology
+
+variable {E X Y : Type*} [TopologicalSpace E] [TopologicalSpace X] [TopologicalSpace Y]
+  {G : Type*} [Group G] [MulAction G E] {H : Subgroup G}
+  {q : E → X} {qH : E → Y} {r : Y → X}
+
+namespace IsQuotientCoveringMap
+
+/-- A quotient covering map for a subgroup `H` of `G` is unchanged by translating its argument by
+an element of `H`, viewed inside the ambient group `G`. -/
+private theorem apply_smul_of_mem (hqH : IsQuotientCoveringMap qH H) {g : G} (hg : g ∈ H)
+    (y : E) : qH (g • y) = qH y :=
+  hqH.apply_eq_iff_mem_orbit.mpr ⟨⟨g, hg⟩, rfl⟩
+
+/-- Translating a set by an element of `H` does not change its image under a quotient covering map
+for `H`. -/
+private theorem image_smul_of_mem (hqH : IsQuotientCoveringMap qH H) {g : G} (hg : g ∈ H)
+    (S : Set E) : qH '' (g • S) = qH '' S := by
+  ext z
+  constructor
+  · rintro ⟨w, hw, rfl⟩
+    obtain ⟨s, hs, rfl⟩ := Set.mem_smul_set.mp hw
+    exact ⟨s, hs, (apply_smul_of_mem hqH hg s).symm⟩
+  · rintro ⟨s, hs, rfl⟩
+    exact ⟨g • s, Set.smul_mem_smul_set hs, apply_smul_of_mem hqH hg s⟩
+
+/-- Two points of `E` with the same image under a quotient covering map for `H` differ by an
+element of `H`, viewed inside the ambient group `G`. -/
+private theorem exists_mem_smul_eq (hqH : IsQuotientCoveringMap qH H) {y y' : E}
+    (h : qH y = qH y') : ∃ g ∈ H, g • y' = y := by
+  obtain ⟨⟨g, hg⟩, hgy⟩ := hqH.apply_eq_iff_mem_orbit.mp h
+  exact ⟨g, hg, hgy⟩
+
+/-- The evenly covered neighbourhood of `q e` cut out by a set `U` around `e` whose `G`-translates
+are pairwise disjoint. Its sheets are the images in `Y` of the translates `g • U`. -/
+private theorem isEvenlyCovered_of_smul_disjoint (hq : IsQuotientCoveringMap q G)
+    (hqH : IsQuotientCoveringMap qH H) (hr : r ∘ qH = q) {U : Set E} (hUo : IsOpen U)
+    (hdisj : ∀ g : G, (g • U ∩ U).Nonempty → g = 1) {e : E} (heU : e ∈ U) :
+    IsEvenlyCovered r (q e) (r ⁻¹' {q e}) := by
+  have hrqH : ∀ y : E, r (qH y) = q y := congrFun hr
+  have hcsG : ContinuousConstSMul G E := hq.toContinuousConstSMul
+  have hrc : Continuous r := by
+    rw [hqH.toIsQuotientMap.continuous_iff, hr]
+    exact hq.continuous
+  have hsheet_open : ∀ g : G, IsOpen (qH '' (g • U)) := fun g =>
+    hqH.isOpenQuotientMap.isOpenMap _ (hUo.smul g)
+  have hVo : IsOpen (q '' U) := hq.isOpenQuotientMap.isOpenMap _ hUo
+  -- Two translates of `U` whose images in `Y` meet differ by an element of `H`, so their images
+  -- coincide.
+  have hsheet_eq : ∀ g g' : G, (qH '' (g • U) ∩ qH '' (g' • U)).Nonempty →
+      qH '' (g • U) = qH '' (g' • U) := by
+    rintro g g' ⟨z, ⟨w, hw, rfl⟩, w', hw', hww'⟩
+    obtain ⟨u, hu, rfl⟩ := Set.mem_smul_set.mp hw
+    obtain ⟨u', hu', rfl⟩ := Set.mem_smul_set.mp hw'
+    obtain ⟨h, hh, hhu⟩ := exists_mem_smul_eq hqH hww'.symm
+    have hone : g⁻¹ * h * g' = 1 := by
+      refine hdisj _ ⟨u, Set.mem_smul_set.mpr ⟨u', hu', ?_⟩, hu⟩
+      rw [mul_smul, mul_smul, hhu, inv_smul_smul]
+    have hgg' : g = h * g' := by
+      have h2 : g * (g⁻¹ * h * g') = h * g' := by
+        rw [← mul_assoc, mul_inv_cancel_left]
+      rw [hone, mul_one] at h2
+      exact h2
+    rw [hgg', mul_smul, image_smul_of_mem hqH hh]
+  let : TopologicalSpace {S : Set Y // ∃ g : G, S = qH '' (g • U)} := ⊥
+  have : DiscreteTopology {S : Set Y // ∃ g : G, S = qH '' (g • U)} := ⟨rfl⟩
+  have : Nonempty {S : Set Y // ∃ g : G, S = qH '' (g • U)} :=
+    ⟨⟨qH '' ((1 : G) • U), 1, rfl⟩⟩
+  have : Nonempty (X → Y) := ⟨fun _ => qH e⟩
+  refine IsEvenlyCovered.to_isEvenlyCovered_preimage
+    (IsEvenlyCovered.of_trivialization (f := r)
+      (t := hVo.trivializationDiscrete
+        (Subtype.val : {S : Set Y // ∃ g : G, S = qH '' (g • U)} → Set Y) (q '' U)
+        ?_ ?_ ?_ ?_ ?_) ⟨e, heU, rfl⟩)
+  · -- Openness inside the base set is detected on any single sheet.
+    rintro ⟨S, g, rfl⟩ W hWV
+    refine ⟨fun hW => (hW.preimage hrc).inter (hsheet_open g), fun hW => ?_⟩
+    have hSopen : IsOpen (q ⁻¹' W ∩ g • U) := by
+      have hpull : IsOpen (qH ⁻¹' (r ⁻¹' W ∩ qH '' (g • U))) := hW.preimage hqH.continuous
+      have hinter : qH ⁻¹' (r ⁻¹' W ∩ qH '' (g • U)) ∩ g • U = q ⁻¹' W ∩ g • U := by
+        ext w
+        simp only [Set.mem_inter_iff, Set.mem_preimage, hrqH]
+        exact and_congr_left fun hw => and_iff_left ⟨w, hw, rfl⟩
+      exact hinter ▸ hpull.inter (hUo.smul g)
+    rw [← hq.toIsQuotientMap.isOpen_preimage]
+    have hcover : q ⁻¹' W = ⋃ k : G, k • (q ⁻¹' W ∩ g • U) := by
+      refine Set.Subset.antisymm (fun w hw => ?_) (Set.iUnion_subset fun k w hw => ?_)
+      · obtain ⟨u, hu, hqu⟩ := hWV hw
+        obtain ⟨m, hm⟩ := hq.apply_eq_iff_mem_orbit.mp hqu.symm
+        refine Set.mem_iUnion.mpr ⟨m * g⁻¹, Set.mem_smul_set.mpr ⟨g • u, ⟨?_, ?_⟩, ?_⟩⟩
+        · rw [Set.mem_preimage, hq.map_smul, hqu]
+          exact hw
+        · exact Set.smul_mem_smul_set hu
+        · rw [mul_smul, inv_smul_smul]
+          exact hm
+      · obtain ⟨w', ⟨hw', -⟩, rfl⟩ := Set.mem_smul_set.mp hw
+        rw [Set.mem_preimage, hq.map_smul]
+        exact hw'
+    rw [hcover]
+    exact isOpen_iUnion fun k => hSopen.smul k
+  · -- The map is injective on each sheet.
+    rintro ⟨S, g, rfl⟩ z hz z' hz' hzz'
+    obtain ⟨w, hw, rfl⟩ := hz
+    obtain ⟨w', hw', rfl⟩ := hz'
+    obtain ⟨u, hu, rfl⟩ := Set.mem_smul_set.mp hw
+    obtain ⟨u', hu', rfl⟩ := Set.mem_smul_set.mp hw'
+    rw [hrqH, hrqH, hq.map_smul, hq.map_smul] at hzz'
+    obtain ⟨k, hk⟩ := hq.apply_eq_iff_mem_orbit.mp hzz'
+    have hk1 : k • u' = u := hk
+    rw [hdisj k ⟨u, Set.mem_smul_set.mpr ⟨u', hu', hk1⟩, hu⟩, one_smul] at hk1
+    rw [hk1]
+  · -- Each sheet surjects onto the base set.
+    rintro ⟨S, g, rfl⟩ v ⟨u, hu, rfl⟩
+    exact ⟨qH (g • u), ⟨g • u, Set.smul_mem_smul_set hu, rfl⟩, by rw [hrqH, hq.map_smul]⟩
+  · -- Distinct sheets are disjoint.
+    rintro ⟨S, g, rfl⟩ ⟨S', g', rfl⟩ hne
+    simp only [Function.onFun, Set.disjoint_iff_inter_eq_empty]
+    by_contra hcon
+    exact hne (Subtype.ext (hsheet_eq g g' (Set.nonempty_iff_ne_empty.mpr hcon)))
+  · -- The sheets exhaust the preimage of the base set.
+    intro z hz
+    obtain ⟨w, rfl⟩ := hqH.surjective z
+    rw [Set.mem_preimage, hrqH] at hz
+    obtain ⟨u, hu, hqu⟩ := hz
+    obtain ⟨k, hk⟩ := hq.apply_eq_iff_mem_orbit.mp hqu.symm
+    exact Set.mem_iUnion.mpr
+      ⟨⟨qH '' (k • U), k, rfl⟩, ⟨w, Set.mem_smul_set.mpr ⟨u, hu, hk⟩, rfl⟩⟩
+
+/-- **An intermediate quotient of a quotient covering map is a covering map.**
+
+If `q : E → X` presents `X` as the quotient of `E` by a group `G` in the sense of
+`IsQuotientCoveringMap`, and `qH : E → Y` presents `Y` as the quotient of `E` by a subgroup `H`
+of `G`, then the map `r : Y → X` through which `q` factors is a covering map. -/
+theorem isCoveringMap_of_comp (hq : IsQuotientCoveringMap q G)
+    (hqH : IsQuotientCoveringMap qH H) (hr : r ∘ qH = q) : IsCoveringMap r := by
+  intro x
+  obtain ⟨e, rfl⟩ := hq.surjective x
+  obtain ⟨U, hU, hdisj⟩ := hq.disjoint e
+  refine isEvenlyCovered_of_smul_disjoint hq hqH hr isOpen_interior (fun g hg => hdisj g ?_)
+    (mem_interior_iff_mem_nhds.mpr hU)
+  rw [← Set.image_smul] at hg
+  exact Set.Nonempty.mono
+    (Set.inter_subset_inter (Set.image_mono interior_subset) interior_subset) hg
+
+end IsQuotientCoveringMap
+
+end TauCeti

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -59,25 +59,6 @@ variable {E X Y : Type*} [TopologicalSpace E] [TopologicalSpace X] [TopologicalS
 
 namespace IsQuotientCoveringMap
 
-/-- Translating a set by an element of `H` does not change its image under a quotient covering map
-for `H`. -/
-private theorem image_smul_of_mem (hqH : IsQuotientCoveringMap qH H) {g : G} (hg : g ∈ H)
-    (S : Set E) : qH '' (g • S) = qH '' S := by
-  ext z
-  constructor
-  · rintro ⟨w, hw, rfl⟩
-    obtain ⟨s, hs, rfl⟩ := Set.mem_smul_set.mp hw
-    exact ⟨s, hs, (hqH.map_smul ⟨g, hg⟩).symm⟩
-  · rintro ⟨s, hs, rfl⟩
-    exact ⟨g • s, Set.smul_mem_smul_set hs, hqH.map_smul ⟨g, hg⟩⟩
-
-/-- Two points of `E` with the same image under a quotient covering map for `H` differ by an
-element of `H`, viewed inside the ambient group `G`. -/
-private theorem exists_mem_smul_eq (hqH : IsQuotientCoveringMap qH H) {y y' : E}
-    (h : qH y = qH y') : ∃ g ∈ H, g • y' = y := by
-  obtain ⟨⟨g, hg⟩, hgy⟩ := hqH.apply_eq_iff_mem_orbit.mp h
-  exact ⟨g, hg, hgy⟩
-
 /-- The evenly covered neighbourhood of `q e` cut out by a set `U` around `e` whose `G`-translates
 are pairwise disjoint. Its sheets are the images in `Y` of the translates `g • U`. -/
 private theorem isEvenlyCovered_of_smul_disjoint (hq : IsQuotientCoveringMap q G)
@@ -99,7 +80,10 @@ private theorem isEvenlyCovered_of_smul_disjoint (hq : IsQuotientCoveringMap q G
     rintro g g' ⟨z, ⟨w, hw, rfl⟩, w', hw', hww'⟩
     obtain ⟨u, hu, rfl⟩ := Set.mem_smul_set.mp hw
     obtain ⟨u', hu', rfl⟩ := Set.mem_smul_set.mp hw'
-    obtain ⟨h, hh, hhu⟩ := exists_mem_smul_eq hqH hww'.symm
+    obtain ⟨⟨h, hh⟩, hhu'⟩ := hqH.apply_eq_iff_mem_orbit.mp hww'.symm
+    -- `H` acts on `E` through `G`, so the orbit witness is an element of `G` fixing `qH`.
+    have hhu : h • (g' • u') = g • u := hhu'
+    have hmap : ∀ e : E, qH (h • e) = qH e := fun _ => hqH.map_smul ⟨h, hh⟩
     have hone : g⁻¹ * h * g' = 1 := by
       refine hdisj _ ⟨u, Set.mem_smul_set.mpr ⟨u', hu', ?_⟩, hu⟩
       rw [mul_smul, mul_smul, hhu, inv_smul_smul]
@@ -108,7 +92,8 @@ private theorem isEvenlyCovered_of_smul_disjoint (hq : IsQuotientCoveringMap q G
         rw [← mul_assoc, mul_inv_cancel_left]
       rw [hone, mul_one] at h2
       exact h2
-    rw [hgg', mul_smul, image_smul_of_mem hqH hh]
+    rw [hgg', mul_smul]
+    simp only [← Set.image_smul, Set.image_image, hmap]
   let : TopologicalSpace {S : Set Y // ∃ g : G, S = qH '' (g • U)} := ⊥
   have : DiscreteTopology {S : Set Y // ∃ g : G, S = qH '' (g • U)} := ⟨rfl⟩
   have : Nonempty {S : Set Y // ∃ g : G, S = qH '' (g • U)} :=

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -45,6 +45,12 @@ So the construction goes through Mathlib's `IsOpen.trivializationDiscrete`, whic
 of pairwise disjoint sets on which the map is injective into a `Bundle.Trivialization`. The index
 type of that family is the set of translate images itself, which makes the family injective and
 its pairwise disjointness exactly the statement that two meeting translate images coincide.
+
+## References
+
+The `IsQuotientCoveringMap` interface this file is built on — the predicate itself, its
+`disjoint` and `apply_eq_iff_mem_orbit` fields, and `IsQuotientCoveringMap.isOpenQuotientMap` —
+is Junyan Xu's, in `Mathlib/Topology/Covering/Quotient.lean`.
 -/
 
 public section


### PR DESCRIPTION
This PR adds `TauCeti.IsQuotientCoveringMap.isCoveringMap_of_comp`, in the new module `TauCeti/Topology/Covering/Quotient.lean`: if `q : E → X` presents `X` as the quotient of `E` by a group `G` in the sense of Mathlib's `IsQuotientCoveringMap`, and `qH : E → Y` presents `Y` as the quotient of `E` by a subgroup `H` of `G`, then the map `r : Y → X` through which `q` factors is a covering map. It then derives `TauCeti.UniversalCover.isCoveringMap_subgroupQuotientProj` from it, which is the target of `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 7, "Cover associated to `H ≤ π₁(X, x₀)`: `UniversalCover x₀ / H` with the quotient basepoint `⟦e₀⟧` is a pointed connected cover". That target already holds on `main`; what changes is that its proof is now an instance of a general statement rather than a bespoke argument about the universal cover, and `TauCeti/AlgebraicTopology/UniversalCover/Classification/Existence.lean` shrinks from 306 lines to 61, all 266 removed lines being private helpers with no other user. After this PR, Stage 2 item 7 is untouched in substance and the milestone's remaining work is elsewhere: item 8's Galois correspondence bookkeeping, which `Classification/Pointed.lean`, `Unpointed.lean`, `Regular.lean` and `DeckGroup.lean` already carry a large part of.

My designated roadmap is `CFSGStatement`, and it has no milestone I can advance. `I0` is complete on `main` (`CFSG/Index.lean`, `Closure.lean`, `GraphTwisted.lean`, `SuzukiRee.lean`); `L0` through `L3` wait on root-systems Layer 6 and reductive-groups Layer 9, and Layer 6's last two branches, `E₇` and `E₈`, are themselves in flight in #2809 and #2893, so the `DynkinType`-indexed dispatcher `L0` consumes cannot be written yet; `A0` waits on `L3`; and the three sporadic rows still missing from `S1`, `Fi₂₄'`, `Ly` and `B`, are in flight in #2902, #2839 and #2899. Rather than force a lookalike there I moved to `UniversalCovers`, whose recorded frontier named this statement.

The mathematical content is that the disjointness axiom of `IsQuotientCoveringMap` already produces the sheets of the intermediate map, with no connectedness anywhere. Given a set `U` around `e` whose `G`-translates are pairwise disjoint, the base set is `q '' U` and the sheets over it are the images `qH '' (g • U)` for `g : G`. Two of those images meet only when `g` and `g'` differ by an element of `H`, in which case they are equal, so the family indexed by the set of such images is pairwise disjoint; `r` is injective on each of them because `q` is injective on `U`; each surjects onto `q '' U`; and they exhaust `r ⁻¹' (q '' U)`. The one genuinely topological step is that an open set of the base is detected on a single sheet: pulling back to `E` and intersecting with `g • U` gives an open set whose `G`-translates cover `q ⁻¹' W`, which is open because `q` is a quotient map. Mathlib's `IsOpen.trivializationDiscrete` assembles those five facts into a `Bundle.Trivialization`, and `IsEvenlyCovered.of_trivialization` and `to_isEvenlyCovered_preimage` convert it to the fibre-indexed form that `IsCoveringMap` unfolds to.

The hypotheses are weaker than what the removed proof used. That proof worked over a path-connected, path-homotopy-trivial neighbourhood `U` of a point of `X`, decomposed `proj ⁻¹' U` into sheets indexed by homotopy classes, and needed a separate lemma that a fundamental-group element carries the sheet through a point of a fibre onto the sheet through its translate, proved by a preconnectedness argument. None of that is available in the general setting, and none of it is needed: `LocallyPathConnectedSpace X` and the rest survive in `isCoveringMap_subgroupQuotientProj` only because `UniversalCover.isQuotientCoveringMap` and `isQuotientCoveringMap_subgroupQuotientMap` require them, not because the covering-map argument does. The statement of `isCoveringMap_subgroupQuotientProj` is unchanged, in name, hypotheses and conclusion, so `Classification/DeckGroup.lean`, its only consumer, is untouched.

The conclusion is deliberately not phrased as `r` being a quotient covering map, because in general it is not one. The deck group of `E / H` over `E / G` is the normalizer quotient `N_G(H) / H`, which acts transitively on the fibres of `r` only when `H` is normal in `G`, so there is no group for which `r` could satisfy `apply_eq_iff_mem_orbit`. That is why the sheets are built by hand rather than by appealing to `IsQuotientCoveringMap.isCoveringMap`, and the implementation note in the new module says so.

No Mathlib infrastructure is vendored. `IsQuotientCoveringMap` with its `disjoint` and `apply_eq_iff_mem_orbit` fields, `IsQuotientCoveringMap.isOpenQuotientMap`, `IsOpen.trivializationDiscrete`, `IsEvenlyCovered.of_trivialization`, `IsEvenlyCovered.to_isEvenlyCovered_preimage`, `Set.mem_smul_set` and `IsOpen.smul` are all consumed from `Mathlib/Topology/Covering/*` and `Mathlib/Topology/Algebra/ConstMulAction.lean`; the quotient-covering-map interface there is due to Junyan Xu, and the universal-cover material it is applied to is adapted from Kim Morrison's mathlib4#38292, as the existing file headers record. I checked that Mathlib has no statement of this kind: `Mathlib/Topology/Covering/Quotient.lean` relates a single group action to a single quotient and says nothing about a subgroup of the acting group.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"iscoveringmap-of-comp"}-->

🤖 Prepared with Claude Code
