### PR TITLE
refactor(Bernstein): name the iterated-derivative shift behind the Chafai density recursion

### DIFF
--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -16,6 +16,8 @@ completely-monotone or Bernstein-function structure.
 
 * `TauCeti.ContDiffOn.hasDerivAt_iteratedDerivWithin`: differentiability of an
   `iteratedDerivWithin` on a neighbourhood inside a unique-differentiability set.
+* `TauCeti.iteratedDerivWithin_neg_derivWithin_succ`: differentiating the negated derivative
+  absorbs one order.
 For the plain fundamental-theorem identity on a compact interval use Mathlib's
 `intervalIntegral.integral_derivWithin_Icc_of_contDiffOn_Icc` together with
 `iteratedDerivWithin_one`.
@@ -39,5 +41,14 @@ theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
   rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]
   exact (hf.differentiableOn_iteratedDerivWithin
     (by exact_mod_cast Nat.lt_succ_self k) hs).hasDerivAt hx
+
+/-- **Differentiating the negated derivative absorbs one order.** The `m`-th iterated derivative
+of `-f'` is minus the `(m+1)`-st iterated derivative of `f`. -/
+theorem iteratedDerivWithin_neg_derivWithin_succ {f : ℝ → ℝ} {m : ℕ} {s : Set ℝ} {t : ℝ} :
+    iteratedDerivWithin m (fun u => -derivWithin f s u) s t =
+      -iteratedDerivWithin (m + 1) f s t := by
+  -- The negated function elaborates as negation of `derivWithin`; expose that defeq.
+  change iteratedDerivWithin m (-(derivWithin f s)) s t = -iteratedDerivWithin (m + 1) f s t
+  rw [iteratedDerivWithin_neg, ← iteratedDerivWithin_succ']
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
@@ -427,6 +427,19 @@ private lemma aemeasurable_chafaiDensity_ofReal (f : ℝ → ℝ) (hcm : IsCompl
     continuousOn_chafaiDensity (n := n) (hcm.contDiffOn.of_le (nat_le_top n))
   exact ((hcont.mono Ioi_subset_Ici_self).aemeasurable measurableSet_Ioi).ennreal_ofReal
 
+/-- **Differentiating the negated derivative one time fewer.** The `(n-1)`-st iterated derivative
+of `-f'` is minus the `n`-th iterated derivative of `f`. -/
+private lemma iteratedDerivWithin_neg_derivWithin {f : ℝ → ℝ} {n : ℕ} (hn : n ≠ 0) {s : Set ℝ}
+    {t : ℝ} : iteratedDerivWithin (n - 1) (fun u => -derivWithin f s u) s t =
+      -iteratedDerivWithin n f s t := by
+  -- The negated function elaborates as negation of `derivWithin`; expose that defeq.
+  change iteratedDerivWithin (n - 1) (-(derivWithin f s)) s t = -iteratedDerivWithin n f s t
+  rw [iteratedDerivWithin_neg]
+  congr 1
+  rw [← iteratedDerivWithin_succ']
+  congr 1
+  omega
+
 private lemma chafaiDensity_neg_derivWithin_pred (f : ℝ → ℝ)
     {n : ℕ} (hn : 2 ≤ n) {t : ℝ} (ht : 0 < t) :
     chafaiDensity (fun t => -derivWithin f (Ici 0) t) (n - 1) t =
@@ -434,18 +447,7 @@ private lemma chafaiDensity_neg_derivWithin_pred (f : ℝ → ℝ)
   have hn0 : n ≠ 0 := by omega
   have hn10 : n - 1 ≠ 0 := by omega
   rw [chafaiDensity_of_ne_zero hn10, chafaiDensity_of_ne_zero hn0]
-  have hiter : iteratedDerivWithin (n - 1)
-        (fun t => -derivWithin f (Ici 0) t) (Ici 0) t =
-      -iteratedDerivWithin n f (Ici 0) t := by
-    -- The negated function elaborates as negation of `derivWithin`; expose that defeq.
-    change iteratedDerivWithin (n - 1) (-(derivWithin f (Ici 0))) (Ici 0) t =
-      -iteratedDerivWithin n f (Ici 0) t
-    rw [iteratedDerivWithin_neg]
-    congr 1
-    rw [← iteratedDerivWithin_succ']
-    congr 1
-    omega
-  rw [hiter]
+  rw [iteratedDerivWithin_neg_derivWithin hn0]
   have hfact : ((n - 1).factorial : ℝ) =
       ((n - 1 : ℕ) : ℝ) * ((n - 2).factorial : ℝ) := by
     rw [show n - 1 = (n - 2) + 1 by omega, Nat.factorial_succ]

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
@@ -10,6 +10,8 @@ import TauCeti.Analysis.CompletelyMonotone.Closure
 public import TauCeti.Analysis.CompletelyMonotone.Integral
 -- Non-public: the bundled Laplace kernel and its integrability.
 import TauCeti.Analysis.CompletelyMonotone.Laplace.Kernel
+-- Non-public: the iterated-derivative shift is used only inside a proof.
+import TauCeti.Analysis.Calculus.IteratedDerivWithin
 
 /-!
 # Approximating measures for Bernstein's theorem
@@ -427,19 +429,6 @@ private lemma aemeasurable_chafaiDensity_ofReal (f : ℝ → ℝ) (hcm : IsCompl
     continuousOn_chafaiDensity (n := n) (hcm.contDiffOn.of_le (nat_le_top n))
   exact ((hcont.mono Ioi_subset_Ici_self).aemeasurable measurableSet_Ioi).ennreal_ofReal
 
-/-- **Differentiating the negated derivative one time fewer.** The `(n-1)`-st iterated derivative
-of `-f'` is minus the `n`-th iterated derivative of `f`. -/
-private lemma iteratedDerivWithin_neg_derivWithin {f : ℝ → ℝ} {n : ℕ} (hn : n ≠ 0) {s : Set ℝ}
-    {t : ℝ} : iteratedDerivWithin (n - 1) (fun u => -derivWithin f s u) s t =
-      -iteratedDerivWithin n f s t := by
-  -- The negated function elaborates as negation of `derivWithin`; expose that defeq.
-  change iteratedDerivWithin (n - 1) (-(derivWithin f s)) s t = -iteratedDerivWithin n f s t
-  rw [iteratedDerivWithin_neg]
-  congr 1
-  rw [← iteratedDerivWithin_succ']
-  congr 1
-  omega
-
 private lemma chafaiDensity_neg_derivWithin_pred (f : ℝ → ℝ)
     {n : ℕ} (hn : 2 ≤ n) {t : ℝ} (ht : 0 < t) :
     chafaiDensity (fun t => -derivWithin f (Ici 0) t) (n - 1) t =
@@ -447,7 +436,7 @@ private lemma chafaiDensity_neg_derivWithin_pred (f : ℝ → ℝ)
   have hn0 : n ≠ 0 := by omega
   have hn10 : n - 1 ≠ 0 := by omega
   rw [chafaiDensity_of_ne_zero hn10, chafaiDensity_of_ne_zero hn0]
-  rw [iteratedDerivWithin_neg_derivWithin hn0]
+  rw [iteratedDerivWithin_neg_derivWithin_succ, show n - 1 + 1 = n by omega]
   have hfact : ((n - 1).factorial : ℝ) =
       ((n - 1 : ℕ) : ℝ) * ((n - 2).factorial : ℝ) := by
     rw [show n - 1 = (n - 2) + 1 by omega, Nat.factorial_succ]


### PR DESCRIPTION
`chafaiDensity_neg_derivWithin_pred` relates the Chafaï density of `-f'` at order `n-1` to that of
`f` at order `n`. Its forty-six lines are mostly arithmetic bookkeeping — factorials, powers of `t`,
and the sign `(-1)^(n-1)` versus `(-1)^n` — but ten of them proved a fact about iterated derivatives
that has nothing to do with densities, factorials or Chafaï.

That fact is now `iteratedDerivWithin_neg_derivWithin_succ` in
`TauCeti/Analysis/Calculus/IteratedDerivWithin.lean`: the `m`-th iterated derivative of `-f'` is
minus the `(m+1)`-st iterated derivative of `f`.

It is stated unconditionally, over an arbitrary set, in the `m` / `m+1` form rather than the
`n-1` / `n` form the caller happens to need. That is what the identity actually says: nothing in the
argument uses the half-line `Ici 0`, the completely-monotone hypothesis on `f`, the bound `2 ≤ n` or
the positivity `0 < t`, and — once the orders are written as `m` and `m+1` rather than `n-1` and `n`
— no hypothesis on the order either. Truncated subtraction was the only reason a side condition
looked necessary; stating the shift directly removes it, and the proof loses the `congr`/`omega`
steps that were reconciling `n - 1 + 1` with `n`. The caller supplies `m := n - 1` and discharges
`n - 1 + 1 = n` itself, which is where that arithmetic belongs.

It goes in the shared calculus file rather than staying beside its consumer. That file exists to
record "calculus lemmas about `iteratedDerivWithin` that are independent of any completely-monotone
or Bernstein-function structure", which is precisely what this is; leaving it in the Bernstein file
would have put a generic derivative identity behind a Bernstein import. `Measures.lean` imports it
privately, since it is used only inside a proof.

The parent drops from 46 lines to 35; the lemma is 4.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: none

Cross-cutting calculus infrastructure: the lemma mentions only `iteratedDerivWithin`, `derivWithin`
and an arbitrary set, and joins an existing file of such lemmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
