### PR TITLE
refactor(DeFinetti): share the block-cylinder integration between routes

### DIFF
--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/BlockCylinder.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/BlockCylinder.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.DeFinetti.DirectingMeasure.Integral
+public import TauCeti.Probability.Exchangeability.Cylinder
+public import TauCeti.Probability.Process.Tail.Basic
+
+/-!
+# The mass of a directing-measure event met with a block cylinder
+
+One lemma, the integration step shared by every de Finetti route:
+
+```text
+μ ((ν ⁻¹' S) ∩ blockCylinder X k B) = ∫⁻ ω in ν ⁻¹' S, ∏ i, directingMeasure μ X ω (B i) ∂μ
+```
+
+given the conditional factorization of the block along `k`. That factorization is a **hypothesis**,
+not a conclusion: this file proves none of it, and so depends on no route that establishes it. Each
+route supplies its own — the martingale route from `TailFactorization`, the `L²` route from
+`ViaL2/BlockFactorization.lean` — and both then instantiate this lemma.
+
+That is the whole point of stating it this way. The routes are required to stay independent at the
+level of imports, so the shared material has to be the part that *neither* proves: here, the
+bookkeeping that turns an a.e. identity of conditional expectations into an identity of measures.
+
+The argument is three steps. A directing-measure event is tail-measurable, so testing the
+factorization against it is `setIntegral_condExp`. The cylinder's mass is the integral of its
+indicator, which is `integral_blockIndicatorProd` read against the restricted measure. And the
+conversion to `ℝ≥0∞` happens once, at the end, via
+`ofReal_integral_eq_lintegral_prod_directingMeasure`.
+
+The result feeds `conditionallyIIDWith_of_measure_inter_blockCylinder_eq_setLIntegral`, whose
+`hcore` hypothesis it is in exactly this shape.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **The mass of a directing-measure event met with a block cylinder**, given the conditional
+factorization of that block along `k`.
+
+The factorization is a hypothesis, so this lemma is neutral between the routes that establish it.
+Note that neither `Contractable μ X` nor `[StandardBorelSpace Ω]` appears: both are needed only to
+*produce* `hfac`, never to integrate it. -/
+theorem measure_inter_blockCylinder_eq_setLIntegral_of_condExp [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n))
+    {r : ℕ} {k : Fin r → ℕ} {B : Fin r → Set α} (hB : ∀ i, MeasurableSet (B i))
+    (hfac : μ[blockIndicatorProd X k B | tailProcess X]
+      =ᵐ[μ] fun ω => ∏ i, (directingMeasure μ X ω).real (B i))
+    {S : Set (ProbabilityMeasure α)} (hS : MeasurableSet S) :
+    μ ((directingProbabilityMeasure μ X ⁻¹' S) ∩ blockCylinder X k B)
+      = ∫⁻ ω in directingProbabilityMeasure μ X ⁻¹' S,
+          ∏ i, directingMeasure μ X ω (B i) ∂μ := by
+  classical
+  have hTail : tailProcess X ≤ ‹MeasurableSpace Ω› :=
+    tailProcess_le_ambient 0 fun j _ => hX_meas j
+  have : IsFiniteMeasure (μ.trim hTail) := isFiniteMeasure_trim hTail
+  set A : Set Ω := directingProbabilityMeasure μ X ⁻¹' S with hA_def
+  have hA_tail : MeasurableSet[tailProcess X] A :=
+    measurable_tailProcess_directingProbabilityMeasure hS
+  have hA : MeasurableSet A := hTail _ hA_tail
+  have hg_int : Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ :=
+    integrable_prod_directingMeasure_real hTail hB
+  have hind_int : Integrable (blockIndicatorProd X k B) μ :=
+    integrable_blockIndicatorProd (fun i => (hX_meas _).aemeasurable) hB
+  -- The factorization, tested against the tail event `A`.
+  have hchain : ∫ ω in A, blockIndicatorProd X k B ω ∂μ
+      = ∫ ω in A, ∏ i, (directingMeasure μ X ω).real (B i) ∂μ := by
+    rw [← setIntegral_condExp hTail hind_int hA_tail]
+    exact setIntegral_congr_ae hA (hfac.mono fun ω hω _ => hω)
+  -- The left side is the real mass of the intersection, via the block-indicator integral read
+  -- against the restricted measure.
+  have hleft : ∫ ω in A, blockIndicatorProd X k B ω ∂μ
+      = μ.real (A ∩ blockCylinder X k B) := by
+    rw [integral_blockIndicatorProd (μ := μ.restrict A) (fun i => (hX_meas _).aemeasurable) hB,
+      blockLaw_blockCylinder X (fun i => (hX_meas _).aemeasurable) hB,
+      Measure.restrict_apply (measurableSet_blockCylinder (fun i => hX_meas _) hB),
+      Set.inter_comm, measureReal_def]
+  have hne : μ (A ∩ blockCylinder X k B) ≠ ⊤ := measure_ne_top μ _
+  rw [← ENNReal.ofReal_toReal hne, ← measureReal_def, ← hleft, hchain,
+    ofReal_integral_eq_lintegral_prod_directingMeasure hg_int.restrict]
+
+end Probability
+
+end TauCeti
+
+end

--- a/TauCeti/Probability/DeFinetti/JointRectangle.lean
+++ b/TauCeti/Probability/DeFinetti/JointRectangle.lean
@@ -11,6 +11,7 @@ public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic
 -- the path-law transfer, and the machinery the symmetry transport runs on.
 -- Public: `directingProbabilityMeasure` names the witness in the exported statement.
 public import TauCeti.Probability.DeFinetti.DirectingMeasure.Basic
+import TauCeti.Probability.DeFinetti.DirectingMeasure.BlockCylinder
 import TauCeti.Probability.DeFinetti.BlockFactorization
 import TauCeti.Probability.DeFinetti.ConditionalCommonEnding
 import TauCeti.Probability.Exchangeability.ConditionallyIID.Map
@@ -98,38 +99,9 @@ private theorem measure_inter_blockCylinder_eq_setLIntegral
     μ ((directingProbabilityMeasure μ X ⁻¹' S)
         ∩ blockCylinder X (fun i : Fin r => (i : ℕ)) B)
       = ∫⁻ ω in directingProbabilityMeasure μ X ⁻¹' S,
-          ∏ i, directingMeasure μ X ω (B i) ∂μ := by
-  classical
-  have hTail : tailProcess X ≤ ‹MeasurableSpace Ω› :=
-    tailProcess_le_ambient 0 fun j _ => hX_meas j
-  have : IsFiniteMeasure (μ.trim hTail) := isFiniteMeasure_trim hTail
-  set A : Set Ω := directingProbabilityMeasure μ X ⁻¹' S with hA_def
-  have hA_tail : MeasurableSet[tailProcess X] A :=
-    measurable_tailProcess_directingProbabilityMeasure hS
-  have hA : MeasurableSet A := hTail _ hA_tail
-  have hg_int : Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ :=
-    integrable_prod_directingMeasure_real hTail hB
-  have hind_int : Integrable (blockIndicatorProd X (fun i : Fin r => (i : ℕ)) B) μ :=
-    integrable_blockIndicatorProd (fun i => (hX_meas _).aemeasurable) hB
-  -- the conditional factorization, tested against the tail event `A`
-  have hchain : ∫ ω in A, blockIndicatorProd X (fun i : Fin r => (i : ℕ)) B ω ∂μ
-      = ∫ ω in A, ∏ i, (directingMeasure μ X ω).real (B i) ∂μ := by
-    rw [← setIntegral_condExp hTail hind_int hA_tail]
-    refine setIntegral_congr_ae hA ?_
-    filter_upwards
-      [condExp_blockIndicatorProd_prefix_ae_eq_prod_directingMeasure hX hX_meas hB] with ω hω _
-    exact hω
-  -- The left side is the real mass of the intersection, via the public block-indicator integral
-  -- read against the restricted measure.
-  have hleft : ∫ ω in A, blockIndicatorProd X (fun i : Fin r => (i : ℕ)) B ω ∂μ
-      = μ.real (A ∩ blockCylinder X (fun i : Fin r => (i : ℕ)) B) := by
-    rw [integral_blockIndicatorProd (μ := μ.restrict A) (fun i => (hX_meas _).aemeasurable) hB,
-      blockLaw_blockCylinder X (fun i => (hX_meas _).aemeasurable) hB,
-      Measure.restrict_apply (measurableSet_blockCylinder (fun i => hX_meas _) hB),
-      Set.inter_comm, measureReal_def]
-  have hne : μ (A ∩ blockCylinder X (fun i : Fin r => (i : ℕ)) B) ≠ ⊤ := measure_ne_top μ _
-  rw [← ENNReal.ofReal_toReal hne, ← measureReal_def, ← hleft, hchain,
-    ofReal_integral_eq_lintegral_prod_directingMeasure hg_int.restrict]
+          ∏ i, directingMeasure μ X ω (B i) ∂μ :=
+  measure_inter_blockCylinder_eq_setLIntegral_of_condExp hX_meas hB
+    (condExp_blockIndicatorProd_prefix_ae_eq_prod_directingMeasure hX hX_meas hB) hS
 
 -- A finitely supported reindexing pulls the prefix cylinder back to the `k`-cylinder, once the
 -- permutation realises `k` on the initial segment. This is a set identity: no measure, no


### PR DESCRIPTION
```lean
theorem measure_inter_blockCylinder_eq_setLIntegral_of_condExp [StandardBorelSpace α] [Nonempty α]
    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n))
    {r : ℕ} {k : Fin r → ℕ} {B : Fin r → Set α} (hB : ∀ i, MeasurableSet (B i))
    (hfac : μ[blockIndicatorProd X k B | tailProcess X]
      =ᵐ[μ] fun ω => ∏ i, (directingMeasure μ X ω).real (B i))
    {S : Set (ProbabilityMeasure α)} (hS : MeasurableSet S) :
    μ ((directingProbabilityMeasure μ X ⁻¹' S) ∩ blockCylinder X k B)
      = ∫⁻ ω in directingProbabilityMeasure μ X ⁻¹' S, ∏ i, directingMeasure μ X ω (B i) ∂μ
```

The step from a conditional factorization to the mass of a directing-measure event met with a block
cylinder — the `hcore` shape that
`conditionallyIIDWith_of_measure_inter_blockCylinder_eq_setLIntegral` consumes.

It was implemented privately in `JointRectangle.lean` for the prefix selection. `JointRectangle`
now delegates to this lemma; its private theorem survives only as the two-line specialization that
supplies the prefix factorization.

## The factorization is a hypothesis, deliberately

This file proves no factorization and imports no route that does: not
`DeFinetti.BlockFactorization`, `TailFactorization`, `JointRectangle`, `Theorem`,
`ViaL2.BlockFactorization`, nor anything under `Probability.Martingale`. Verified on the transitive
import graph — 7 `TauCeti` modules, no leaks.

That is what makes the sharing possible at all. The de Finetti routes are required to stay
independent at the level of imports, so shared material has to be the part *neither* route proves —
here the bookkeeping that turns an a.e. identity of conditional expectations into an identity of
measures. A shared lemma that instead concluded a factorization would put one route's library
beneath the other.

## Generalizations that fell out

Stating the factorization as a hypothesis showed that two of the private version's assumptions were
never used by the integration:

* `Contractable μ X` — only ever needed to *produce* the factorization;
* `[StandardBorelSpace Ω]` — likewise.

Both are gone from the shared lemma. `JointRectangle`'s wrapper still carries
`[StandardBorelSpace Ω]`, because the prefix factorization it feeds in needs it — which is where
the hypothesis actually belongs. The selection is also arbitrary now (`k : Fin r → ℕ`) rather than
the prefix `i ↦ i`.

Roadmap: none

Cross-cutting infrastructure: one lemma shared by both de Finetti routes, proving no new
mathematics. It is the prerequisite for #2946, whose `reuse` finding asked for exactly this
extraction.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
