### PR TITLE
refactor(PeterWeyl): span the matrix coefficients through the bundled sesquilinear map

### DIFF
--- a/TauCeti/RepresentationTheory/Compact/PeterWeyl.lean
+++ b/TauCeti/RepresentationTheory/Compact/PeterWeyl.lean
@@ -398,35 +398,19 @@ theorem matrixCoeffLp_mem_span_peterWeylFamily (models : ι → IrrepModel 𝕜 
   have hspan : Submodule.span 𝕜 (Set.range ⇑(models i).basis) = ⊤ := by
     rw [← OrthonormalBasis.coe_toBasis]
     exact (models i).basis.toBasis.span_eq
-  -- the second vector may be spread over the basis
+  -- Each slot of the bundled sesquilinear coefficient map is (semi)linear, so membership in `P`
+  -- spreads from the basis over the whole span; `hspan` says that span is everything.
   have hright : ∀ (a : Fin (models i).dim) (u : EuclideanSpace 𝕜 (Fin (models i).dim)),
       ContRepresentation.matrixCoeffLp (models i).rep (models i).continuous_rep
-        ((models i).basis a) u ∈ P := by
-    intro a u
-    have key : ∀ u ∈ Submodule.span 𝕜 (Set.range ⇑(models i).basis),
-        ContRepresentation.matrixCoeffLp (models i).rep (models i).continuous_rep
-          ((models i).basis a) u ∈ P := by
-      intro u hu
-      induction hu using Submodule.span_induction with
-      | mem x hx =>
-          obtain ⟨b, rfl⟩ := hx
-          exact hbase a b
-      | zero => simp
-      | add x y _ _ hx hy => simpa using add_mem hx hy
-      | smul c x _ hx => simpa using Submodule.smul_mem P c hx
-    exact key u (hspan ▸ Submodule.mem_top)
-  -- and then so may the first
-  have key : ∀ u ∈ Submodule.span 𝕜 (Set.range ⇑(models i).basis),
-      ContRepresentation.matrixCoeffLp (models i).rep (models i).continuous_rep u w ∈ P := by
-    intro u hu
-    induction hu using Submodule.span_induction with
-    | mem x hx =>
-        obtain ⟨a, rfl⟩ := hx
-        exact hright a w
-    | zero => simp
-    | add x y _ _ hx hy => simpa using add_mem hx hy
-    | smul c x _ hx => simpa using Submodule.smul_mem P _ hx
-  exact key v (hspan ▸ Submodule.mem_top)
+        ((models i).basis a) u ∈ P := fun a u => by
+    have hle := Submodule.span_le.2 (show Set.range ⇑(models i).basis ⊆
+      ↑(P.comap (ContRepresentation.matrixCoeffLpₛₗ (models i).rep (models i).continuous_rep
+        ((models i).basis a))) from by rintro _ ⟨b, rfl⟩; simpa using hbase a b)
+    simpa using hle (hspan ▸ Submodule.mem_top)
+  have hle := Submodule.span_le.2 (show Set.range ⇑(models i).basis ⊆
+    ↑(P.comap ((ContRepresentation.matrixCoeffLpₛₗ (models i).rep
+      (models i).continuous_rep).flip w)) from by rintro _ ⟨a, rfl⟩; simpa using hright a w)
+  simpa using hle (hspan ▸ Submodule.mem_top)
 
 namespace IsIrrepSkeleton
 

--- a/TauCeti/RepresentationTheory/Compact/PeterWeyl.lean
+++ b/TauCeti/RepresentationTheory/Compact/PeterWeyl.lean
@@ -403,14 +403,15 @@ theorem matrixCoeffLp_mem_span_peterWeylFamily (models : ι → IrrepModel 𝕜 
   have hright : ∀ (a : Fin (models i).dim) (u : EuclideanSpace 𝕜 (Fin (models i).dim)),
       ContRepresentation.matrixCoeffLp (models i).rep (models i).continuous_rep
         ((models i).basis a) u ∈ P := fun a u => by
-    have hle := Submodule.span_le.2 (show Set.range ⇑(models i).basis ⊆
-      ↑(P.comap (ContRepresentation.matrixCoeffLpₛₗ (models i).rep (models i).continuous_rep
-        ((models i).basis a))) from by rintro _ ⟨b, rfl⟩; simpa using hbase a b)
-    simpa using hle (hspan ▸ Submodule.mem_top)
-  have hle := Submodule.span_le.2 (show Set.range ⇑(models i).basis ⊆
-    ↑(P.comap ((ContRepresentation.matrixCoeffLpₛₗ (models i).rep
-      (models i).continuous_rep).flip w)) from by rintro _ ⟨a, rfl⟩; simpa using hright a w)
-  simpa using hle (hspan ▸ Submodule.mem_top)
+    have himg := (Submodule.image_span_subset
+      (ContRepresentation.matrixCoeffLpₛₗ (models i).rep (models i).continuous_rep
+        ((models i).basis a)) (Set.range ⇑(models i).basis) P).2
+      (by rintro _ ⟨b, rfl⟩; simpa using hbase a b)
+    simpa using himg ⟨u, hspan ▸ Submodule.mem_top, rfl⟩
+  have himg := (Submodule.image_span_subset
+    ((ContRepresentation.matrixCoeffLpₛₗ (models i).rep (models i).continuous_rep).flip w)
+    (Set.range ⇑(models i).basis) P).2 (by rintro _ ⟨a, rfl⟩; simpa using hright a w)
+  simpa using himg ⟨v, hspan ▸ Submodule.mem_top, rfl⟩
 
 namespace IsIrrepSkeleton
 


### PR DESCRIPTION
`matrixCoeffLp_mem_span_peterWeylFamily` spread membership in `P` from the basis matrix
coefficients to arbitrary vectors, one argument slot at a time. Each slot was done by an explicit
`Submodule.span_induction` with four cases — `mem`, `zero`, `add`, `smul` — and the two inductions
were the same argument written twice, once for the second vector and once for the first.

Both are `Submodule.image_span_subset`: for a semilinear `f`, a spanning set sent into `N` sends its
whole span into `N`. The four induction cases are the `Submodule` structure that lemma already
consumes.

The map to feed it is also already there. `MatrixCoefficient.lean` bundles the coefficient map as
`ContRepresentation.matrixCoeffLpₛₗ : V →ₗ⋆[𝕜] V →ₗ[𝕜] Lp 𝕜 2 (haarProb G)`, conjugate-linear in the
first vector and linear in the second, with `matrixCoeffLpₛₗ_apply_apply` a `simp` lemma back to
`matrixCoeffLp`. The second slot uses it directly; the first uses `(matrixCoeffLpₛₗ …).flip w`, since
`LinearMap.flip` is stated for semilinear maps and so applies to the conjugate-linear slot unchanged.

No declaration is added or removed and no statement changes; the sesquilinearity the docstring
already advertises is now taken from the bundled map rather than re-established case by case. The
proof drops from 46 lines to 31.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: RepresentationTheory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
