### PR TITLE
feat: decompose algebraic group points

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
@@ -23,14 +23,16 @@ inside each ambient general linear group.
 
 ## Main declarations
 
-* `TauCeti.HopfAlgebra.semisimplePart`: the semisimple part of an algebraic-group point.
-* `TauCeti.HopfAlgebra.unipotentPart`: the unipotent part of an algebraic-group point.
-* `TauCeti.HopfAlgebra.jordanDecomposition`: the ordered pair of the two parts.
-* `TauCeti.HopfAlgebra.commute_semisimplePart_unipotentPart`: the two parts commute.
-* `TauCeti.HopfAlgebra.semisimplePart_mul_unipotentPart`: their product is the original point.
-* `TauCeti.HopfAlgebra.endOfPoint_semisimplePart` and
-  `TauCeti.HopfAlgebra.endOfPoint_unipotentPart`: every finite-dimensional representation sees
-  the corresponding linear Jordan factors.
+* `TauCeti.HopfAlgebra.Point.semisimplePart`: the semisimple part of an algebraic-group point.
+* `TauCeti.HopfAlgebra.Point.unipotentPart`: the unipotent part of an algebraic-group point.
+* `TauCeti.HopfAlgebra.Point.isSemisimple_isUnipotent_unique`: uniqueness of a commuting
+  semisimple-unipotent factorization.
+* `TauCeti.HopfAlgebra.Point.commute_semisimplePart_unipotentPart`: the two parts commute.
+* `TauCeti.HopfAlgebra.Point.semisimplePart_mul_unipotentPart`: their product is the original
+  point.
+* `TauCeti.HopfAlgebra.Point.endOfPoint_semisimplePart` and
+  `TauCeti.HopfAlgebra.Point.endOfPoint_unipotentPart`: every finite-dimensional representation
+  sees the corresponding linear Jordan factors.
 
 ## References
 
@@ -44,6 +46,7 @@ open WithConv
 open scoped TensorProduct
 
 namespace TauCeti.HopfAlgebra
+namespace Point
 
 universe u
 
@@ -66,24 +69,6 @@ noncomputable def unipotentPart (g : WithConv (H →ₐ[k] K)) : WithConv (H →
   (Tannaka.fgPointTensorIsoEquiv k H K).symm
     (Tannaka.fgPointUnipotentPartTensorIso k H K g)
 
-/-- The multiplicative Jordan decomposition of an algebraic-group point, with the semisimple
-part first and the unipotent part second. -/
-noncomputable def jordanDecomposition (g : WithConv (H →ₐ[k] K)) :
-    WithConv (H →ₐ[k] K) × WithConv (H →ₐ[k] K) :=
-  (semisimplePart k H K g, unipotentPart k H K g)
-
-/-- The first component of a point's Jordan decomposition is its semisimple part. -/
-@[simp]
-theorem jordanDecomposition_fst (g : WithConv (H →ₐ[k] K)) :
-    (jordanDecomposition k H K g).1 = semisimplePart k H K g :=
-  (rfl)
-
-/-- The second component of a point's Jordan decomposition is its unipotent part. -/
-@[simp]
-theorem jordanDecomposition_snd (g : WithConv (H →ₐ[k] K)) :
-    (jordanDecomposition k H K g).2 = unipotentPart k H K g :=
-  (rfl)
-
 /-- The Tannakian action of the semisimple part is the semisimple-factor tensor
 automorphism. -/
 @[simp]
@@ -102,6 +87,19 @@ theorem fgPointTensorIso_unipotentPart (g : WithConv (H →ₐ[k] K)) :
   rw [← Tannaka.fgPointTensorIsoEquiv_apply]
   exact (Tannaka.fgPointTensorIsoEquiv k H K).apply_symm_apply _
 
+omit [PerfectField K] in
+/-- The action of a point reconstructed from a tensor automorphism is that automorphism's
+component on every finite-dimensional comodule. -/
+@[simp]
+theorem endOfPoint_reconstructedPoint
+    (eta : CategoryTheory.Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H K))
+    (M : FGComoduleCat.{u, u, u} k H) :
+    Comodule.endOfPoint M (Tannaka.reconstructedPoint k H K eta).ofConv =
+      Tannaka.scalarExtensionComponent k H K eta M := by
+  rw [← Comodule.pointsAction_toLinearMap,
+    ← Tannaka.scalarExtensionComponent_fgPointTensorIso,
+    Tannaka.fgPointTensorIso_reconstructedPoint]
+
 /-- In every finite-dimensional comodule, the reconstructed semisimple point acts by the
 semisimple part of the original point action. -/
 @[simp]
@@ -111,9 +109,8 @@ theorem endOfPoint_semisimplePart (g : WithConv (H →ₐ[k] K))
       (GeneralLinearGroup.semisimplePart
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
           Module.End K (K ⊗[k] M)) := by
-  rw [← Comodule.pointsAction_toLinearMap,
-    ← Tannaka.scalarExtensionComponent_fgPointTensorIso,
-    fgPointTensorIso_semisimplePart,
+  rw [semisimplePart, Tannaka.fgPointTensorIsoEquiv_symm_apply,
+    endOfPoint_reconstructedPoint,
     Tannaka.scalarExtensionComponent_fgPointSemisimplePartTensorIso]
 
 /-- In every finite-dimensional comodule, the reconstructed unipotent point acts by the
@@ -125,13 +122,13 @@ theorem endOfPoint_unipotentPart (g : WithConv (H →ₐ[k] K))
       (GeneralLinearGroup.unipotentPart
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
           Module.End K (K ⊗[k] M)) := by
-  rw [← Comodule.pointsAction_toLinearMap,
-    ← Tannaka.scalarExtensionComponent_fgPointTensorIso,
-    fgPointTensorIso_unipotentPart,
+  rw [unipotentPart, Tannaka.fgPointTensorIsoEquiv_symm_apply,
+    endOfPoint_reconstructedPoint,
     Tannaka.scalarExtensionComponent_fgPointUnipotentPartTensorIso]
 
 /-- As an element of the general linear group of any finite-dimensional comodule, the action of
 the reconstructed semisimple point is the canonical semisimple part of the original action. -/
+@[simp]
 theorem ofLinearEquiv_pointsAction_semisimplePart (g : WithConv (H →ₐ[k] K))
     (M : FGComoduleCat.{u, u, u} k H) :
     LinearMap.GeneralLinearGroup.ofLinearEquiv
@@ -144,6 +141,7 @@ theorem ofLinearEquiv_pointsAction_semisimplePart (g : WithConv (H →ₐ[k] K))
 
 /-- As an element of the general linear group of any finite-dimensional comodule, the action of
 the reconstructed unipotent point is the canonical unipotent part of the original action. -/
+@[simp]
 theorem ofLinearEquiv_pointsAction_unipotentPart (g : WithConv (H →ₐ[k] K))
     (M : FGComoduleCat.{u, u, u} k H) :
     LinearMap.GeneralLinearGroup.ofLinearEquiv
@@ -172,6 +170,26 @@ theorem isUnipotent_pointsAction_unipotentPart (g : WithConv (H →ₐ[k] K))
   rw [ofLinearEquiv_pointsAction_unipotentPart]
   exact GeneralLinearGroup.isUnipotent_unipotentPart _
 
+omit [PerfectField K] in
+private theorem isSemisimple_pointsAction_one (M : FGComoduleCat.{u, u, u} k H) :
+    GeneralLinearGroup.IsSemisimple
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv
+        (Comodule.pointsAction M (1 : WithConv (H →ₐ[k] K)))) := by
+  rw [map_one]
+  change GeneralLinearGroup.IsSemisimple
+    (1 : LinearMap.GeneralLinearGroup K (K ⊗[k] M))
+  exact GeneralLinearGroup.isSemisimple_one
+
+omit [PerfectField K] in
+private theorem isUnipotent_pointsAction_one (M : FGComoduleCat.{u, u, u} k H) :
+    GeneralLinearGroup.IsUnipotent
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv
+        (Comodule.pointsAction M (1 : WithConv (H →ₐ[k] K)))) := by
+  rw [map_one]
+  change GeneralLinearGroup.IsUnipotent
+    (1 : LinearMap.GeneralLinearGroup K (K ⊗[k] M))
+  exact GeneralLinearGroup.isUnipotent_one
+
 /-- The semisimple and unipotent parts of an algebraic-group point commute. -/
 theorem commute_semisimplePart_unipotentPart (g : WithConv (H →ₐ[k] K)) :
     Commute (semisimplePart k H K g) (unipotentPart k H K g) := by
@@ -191,6 +209,111 @@ theorem semisimplePart_mul_unipotentPart (g : WithConv (H →ₐ[k] K)) :
   simp only [map_mul, Tannaka.fgPointTensorIsoEquiv_apply,
     fgPointTensorIso_semisimplePart, fgPointTensorIso_unipotentPart,
     Tannaka.fgPointSemisimplePartTensorIso_mul_fgPointUnipotentPartTensorIso]
+  -- Both sides are now the same point-induced tensor automorphism; the remaining equality is
+  -- only between the instance paths selected by the two constructions.
   rfl
 
+/-- A commuting factorization of a point into factors acting semisimply and unipotently in every
+finite-dimensional comodule is its canonical Jordan decomposition. -/
+theorem isSemisimple_isUnipotent_unique (g s u : WithConv (H →ₐ[k] K))
+    (hc : Commute s u) (hmul : s * u = g)
+    (hs : ∀ M : FGComoduleCat.{u, u, u} k H,
+      GeneralLinearGroup.IsSemisimple
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M s)))
+    (hu : ∀ M : FGComoduleCat.{u, u, u} k H,
+      GeneralLinearGroup.IsUnipotent
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M u))) :
+    s = semisimplePart k H K g ∧ u = unipotentPart k H K g := by
+  have h_unique (M : FGComoduleCat.{u, u, u} k H) :
+      LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M s) =
+          LinearMap.GeneralLinearGroup.ofLinearEquiv
+            (Comodule.pointsAction M (semisimplePart k H K g)) ∧
+        LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M u) =
+          LinearMap.GeneralLinearGroup.ofLinearEquiv
+            (Comodule.pointsAction M (unipotentPart k H K g)) := by
+    let rho : WithConv (H →ₐ[k] K) →*
+        LinearMap.GeneralLinearGroup K (K ⊗[k] M) :=
+      (LinearMap.GeneralLinearGroup.generalLinearEquiv K (K ⊗[k] M)).symm.toMonoidHom.comp
+        (Comodule.pointsAction M)
+    change rho s = rho (semisimplePart k H K g) ∧
+      rho u = rho (unipotentPart k H K g)
+    apply GeneralLinearGroup.isSemisimple_isUnipotent_unique
+    · exact hs M
+    · exact hu M
+    · exact hc.map rho
+    · exact isSemisimple_pointsAction_semisimplePart k H K g M
+    · exact isUnipotent_pointsAction_unipotentPart k H K g M
+    · exact (commute_semisimplePart_unipotentPart k H K g).map rho
+    · rw [← map_mul, ← map_mul, hmul, semisimplePart_mul_unipotentPart]
+  constructor
+  · apply (Tannaka.fgPointTensorIsoEquiv k H K).injective
+    apply Tannaka.scalarExtensionComponent_ext
+    intro M
+    simp only [Tannaka.fgPointTensorIsoEquiv_apply,
+      Tannaka.scalarExtensionComponent_fgPointTensorIso]
+    apply LinearMap.ext
+    intro x
+    exact congrArg (fun a : LinearMap.GeneralLinearGroup K (K ⊗[k] M) ↦ a.val x) (h_unique M).1
+  · apply (Tannaka.fgPointTensorIsoEquiv k H K).injective
+    apply Tannaka.scalarExtensionComponent_ext
+    intro M
+    simp only [Tannaka.fgPointTensorIsoEquiv_apply,
+      Tannaka.scalarExtensionComponent_fgPointTensorIso]
+    apply LinearMap.ext
+    intro x
+    exact congrArg (fun a : LinearMap.GeneralLinearGroup K (K ⊗[k] M) ↦ a.val x) (h_unique M).2
+
+/-- A point acting semisimply in every finite-dimensional comodule is its own semisimple part. -/
+@[simp]
+theorem semisimplePart_eq_self {g : WithConv (H →ₐ[k] K)}
+    (hg : ∀ M : FGComoduleCat.{u, u, u} k H,
+      GeneralLinearGroup.IsSemisimple
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))) :
+    semisimplePart k H K g = g :=
+  ((isSemisimple_isUnipotent_unique k H K g g 1 (Commute.one_right g) (mul_one g) hg
+    (isUnipotent_pointsAction_one k H K)).1).symm
+
+/-- A point acting semisimply in every finite-dimensional comodule has trivial unipotent part. -/
+@[simp]
+theorem unipotentPart_eq_one_of_isSemisimple {g : WithConv (H →ₐ[k] K)}
+    (hg : ∀ M : FGComoduleCat.{u, u, u} k H,
+      GeneralLinearGroup.IsSemisimple
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))) :
+    unipotentPart k H K g = 1 :=
+  ((isSemisimple_isUnipotent_unique k H K g g 1 (Commute.one_right g) (mul_one g) hg
+    (isUnipotent_pointsAction_one k H K)).2).symm
+
+/-- A point acting unipotently in every finite-dimensional comodule has trivial semisimple part. -/
+@[simp]
+theorem semisimplePart_eq_one_of_isUnipotent {g : WithConv (H →ₐ[k] K)}
+    (hg : ∀ M : FGComoduleCat.{u, u, u} k H,
+      GeneralLinearGroup.IsUnipotent
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))) :
+    semisimplePart k H K g = 1 :=
+  ((isSemisimple_isUnipotent_unique k H K g 1 g (Commute.one_left g) (one_mul g)
+    (isSemisimple_pointsAction_one k H K) hg).1).symm
+
+/-- A point acting unipotently in every finite-dimensional comodule is its own unipotent part. -/
+@[simp]
+theorem unipotentPart_eq_self {g : WithConv (H →ₐ[k] K)}
+    (hg : ∀ M : FGComoduleCat.{u, u, u} k H,
+      GeneralLinearGroup.IsUnipotent
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))) :
+    unipotentPart k H K g = g :=
+  ((isSemisimple_isUnipotent_unique k H K g 1 g (Commute.one_left g) (one_mul g)
+    (isSemisimple_pointsAction_one k H K) hg).2).symm
+
+/-- The semisimple part of the identity point is the identity. -/
+@[simp]
+theorem semisimplePart_one :
+    semisimplePart k H K (1 : WithConv (H →ₐ[k] K)) = 1 :=
+  semisimplePart_eq_self k H K (isSemisimple_pointsAction_one k H K)
+
+/-- The unipotent part of the identity point is the identity. -/
+@[simp]
+theorem unipotentPart_one :
+    unipotentPart k H K (1 : WithConv (H →ₐ[k] K)) = 1 :=
+  unipotentPart_eq_self k H K (isUnipotent_pointsAction_one k H K)
+
+end Point
 end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.Equivalence
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.JordanDecomposition
+
+/-!
+# Jordan decomposition of algebraic-group points
+
+Let `H` be a commutative Hopf algebra over a field `k`, and let `K` be a perfect extension
+field. Every `K`-valued point `g` of the affine group represented by `H` acts on each
+finite-dimensional `H`-comodule. The multiplicative Jordan decompositions of these actions are
+natural in the comodule and compatible with tensor products, so Tannakian reconstruction turns
+their semisimple and unipotent factors back into `K`-valued points of the original group.
+
+This file defines those two reconstructed points. They commute, their product is `g`, and their
+actions in every finite-dimensional representation are exactly the semisimple and unipotent parts
+of the action of `g`. Thus the decomposition stays inside the affine group rather than merely
+inside each ambient general linear group.
+
+## Main declarations
+
+* `TauCeti.HopfAlgebra.semisimplePart`: the semisimple part of an algebraic-group point.
+* `TauCeti.HopfAlgebra.unipotentPart`: the unipotent part of an algebraic-group point.
+* `TauCeti.HopfAlgebra.jordanDecomposition`: the ordered pair of the two parts.
+* `TauCeti.HopfAlgebra.commute_semisimplePart_unipotentPart`: the two parts commute.
+* `TauCeti.HopfAlgebra.semisimplePart_mul_unipotentPart`: their product is the original point.
+* `TauCeti.HopfAlgebra.endOfPoint_semisimplePart` and
+  `TauCeti.HopfAlgebra.endOfPoint_unipotentPart`: every finite-dimensional representation sees
+  the corresponding linear Jordan factors.
+
+## References
+
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+* J. S. Milne, *Algebraic Groups* (2017), §9.4.
+-/
+
+public section
+
+open WithConv
+open scoped TensorProduct
+
+namespace TauCeti.HopfAlgebra
+
+universe u
+
+variable (k H K : Type u) [Field k] [CommRing H] [_root_.HopfAlgebra k H]
+  [Field K] [Algebra k K] [PerfectField K]
+
+/-- The semisimple part of a point of an affine group over a perfect extension field.
+
+It is reconstructed from the tensor automorphism whose component on every finite-dimensional
+comodule is the semisimple part of the original point action. -/
+noncomputable def semisimplePart (g : WithConv (H →ₐ[k] K)) : WithConv (H →ₐ[k] K) :=
+  (Tannaka.fgPointTensorIsoEquiv k H K).symm
+    (Tannaka.fgPointSemisimplePartTensorIso k H K g)
+
+/-- The unipotent part of a point of an affine group over a perfect extension field.
+
+It is reconstructed from the tensor automorphism whose component on every finite-dimensional
+comodule is the unipotent part of the original point action. -/
+noncomputable def unipotentPart (g : WithConv (H →ₐ[k] K)) : WithConv (H →ₐ[k] K) :=
+  (Tannaka.fgPointTensorIsoEquiv k H K).symm
+    (Tannaka.fgPointUnipotentPartTensorIso k H K g)
+
+/-- The multiplicative Jordan decomposition of an algebraic-group point, with the semisimple
+part first and the unipotent part second. -/
+noncomputable def jordanDecomposition (g : WithConv (H →ₐ[k] K)) :
+    WithConv (H →ₐ[k] K) × WithConv (H →ₐ[k] K) :=
+  (semisimplePart k H K g, unipotentPart k H K g)
+
+/-- The first component of a point's Jordan decomposition is its semisimple part. -/
+@[simp]
+theorem jordanDecomposition_fst (g : WithConv (H →ₐ[k] K)) :
+    (jordanDecomposition k H K g).1 = semisimplePart k H K g :=
+  (rfl)
+
+/-- The second component of a point's Jordan decomposition is its unipotent part. -/
+@[simp]
+theorem jordanDecomposition_snd (g : WithConv (H →ₐ[k] K)) :
+    (jordanDecomposition k H K g).2 = unipotentPart k H K g :=
+  (rfl)
+
+/-- The Tannakian action of the semisimple part is the semisimple-factor tensor
+automorphism. -/
+@[simp]
+theorem fgPointTensorIso_semisimplePart (g : WithConv (H →ₐ[k] K)) :
+    Tannaka.fgPointTensorIso k H K (semisimplePart k H K g) =
+      Tannaka.fgPointSemisimplePartTensorIso k H K g := by
+  rw [← Tannaka.fgPointTensorIsoEquiv_apply]
+  exact (Tannaka.fgPointTensorIsoEquiv k H K).apply_symm_apply _
+
+/-- The Tannakian action of the unipotent part is the unipotent-factor tensor
+automorphism. -/
+@[simp]
+theorem fgPointTensorIso_unipotentPart (g : WithConv (H →ₐ[k] K)) :
+    Tannaka.fgPointTensorIso k H K (unipotentPart k H K g) =
+      Tannaka.fgPointUnipotentPartTensorIso k H K g := by
+  rw [← Tannaka.fgPointTensorIsoEquiv_apply]
+  exact (Tannaka.fgPointTensorIsoEquiv k H K).apply_symm_apply _
+
+/-- In every finite-dimensional comodule, the reconstructed semisimple point acts by the
+semisimple part of the original point action. -/
+@[simp]
+theorem endOfPoint_semisimplePart (g : WithConv (H →ₐ[k] K))
+    (M : FGComoduleCat.{u, u, u} k H) :
+    Comodule.endOfPoint M (semisimplePart k H K g).ofConv =
+      (GeneralLinearGroup.semisimplePart
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+          Module.End K (K ⊗[k] M)) := by
+  rw [← Comodule.pointsAction_toLinearMap,
+    ← Tannaka.scalarExtensionComponent_fgPointTensorIso,
+    fgPointTensorIso_semisimplePart,
+    Tannaka.scalarExtensionComponent_fgPointSemisimplePartTensorIso]
+
+/-- In every finite-dimensional comodule, the reconstructed unipotent point acts by the
+unipotent part of the original point action. -/
+@[simp]
+theorem endOfPoint_unipotentPart (g : WithConv (H →ₐ[k] K))
+    (M : FGComoduleCat.{u, u, u} k H) :
+    Comodule.endOfPoint M (unipotentPart k H K g).ofConv =
+      (GeneralLinearGroup.unipotentPart
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+          Module.End K (K ⊗[k] M)) := by
+  rw [← Comodule.pointsAction_toLinearMap,
+    ← Tannaka.scalarExtensionComponent_fgPointTensorIso,
+    fgPointTensorIso_unipotentPart,
+    Tannaka.scalarExtensionComponent_fgPointUnipotentPartTensorIso]
+
+/-- As an element of the general linear group of any finite-dimensional comodule, the action of
+the reconstructed semisimple point is the canonical semisimple part of the original action. -/
+theorem ofLinearEquiv_pointsAction_semisimplePart (g : WithConv (H →ₐ[k] K))
+    (M : FGComoduleCat.{u, u, u} k H) :
+    LinearMap.GeneralLinearGroup.ofLinearEquiv
+        (Comodule.pointsAction M (semisimplePart k H K g)) =
+      GeneralLinearGroup.semisimplePart
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) := by
+  apply Units.ext
+  exact (Comodule.pointsAction_toLinearMap M (semisimplePart k H K g)).trans
+    (endOfPoint_semisimplePart k H K g M)
+
+/-- As an element of the general linear group of any finite-dimensional comodule, the action of
+the reconstructed unipotent point is the canonical unipotent part of the original action. -/
+theorem ofLinearEquiv_pointsAction_unipotentPart (g : WithConv (H →ₐ[k] K))
+    (M : FGComoduleCat.{u, u, u} k H) :
+    LinearMap.GeneralLinearGroup.ofLinearEquiv
+        (Comodule.pointsAction M (unipotentPart k H K g)) =
+      GeneralLinearGroup.unipotentPart
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) := by
+  apply Units.ext
+  exact (Comodule.pointsAction_toLinearMap M (unipotentPart k H K g)).trans
+    (endOfPoint_unipotentPart k H K g M)
+
+/-- The semisimple part acts semisimply in every finite-dimensional representation. -/
+theorem isSemisimple_pointsAction_semisimplePart (g : WithConv (H →ₐ[k] K))
+    (M : FGComoduleCat.{u, u, u} k H) :
+    GeneralLinearGroup.IsSemisimple
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv
+        (Comodule.pointsAction M (semisimplePart k H K g))) := by
+  rw [ofLinearEquiv_pointsAction_semisimplePart]
+  exact GeneralLinearGroup.isSemisimple_semisimplePart _
+
+/-- The unipotent part acts unipotently in every finite-dimensional representation. -/
+theorem isUnipotent_pointsAction_unipotentPart (g : WithConv (H →ₐ[k] K))
+    (M : FGComoduleCat.{u, u, u} k H) :
+    GeneralLinearGroup.IsUnipotent
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv
+        (Comodule.pointsAction M (unipotentPart k H K g))) := by
+  rw [ofLinearEquiv_pointsAction_unipotentPart]
+  exact GeneralLinearGroup.isUnipotent_unipotentPart _
+
+/-- The semisimple and unipotent parts of an algebraic-group point commute. -/
+theorem commute_semisimplePart_unipotentPart (g : WithConv (H →ₐ[k] K)) :
+    Commute (semisimplePart k H K g) (unipotentPart k H K g) := by
+  rw [commute_iff_eq]
+  apply (Tannaka.fgPointTensorIsoEquiv k H K).injective
+  simp only [map_mul, Tannaka.fgPointTensorIsoEquiv_apply,
+    fgPointTensorIso_semisimplePart, fgPointTensorIso_unipotentPart]
+  exact (Tannaka.commute_fgPointSemisimplePartTensorIso_fgPointUnipotentPartTensorIso
+    k H K g).eq
+
+/-- Multiplying the semisimple and unipotent parts recovers the original algebraic-group
+point. -/
+@[simp]
+theorem semisimplePart_mul_unipotentPart (g : WithConv (H →ₐ[k] K)) :
+    semisimplePart k H K g * unipotentPart k H K g = g := by
+  apply (Tannaka.fgPointTensorIsoEquiv k H K).injective
+  simp only [map_mul, Tannaka.fgPointTensorIsoEquiv_apply,
+    fgPointTensorIso_semisimplePart, fgPointTensorIso_unipotentPart,
+    Tannaka.fgPointSemisimplePartTensorIso_mul_fgPointUnipotentPartTensorIso]
+  rfl
+
+end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
@@ -108,19 +108,6 @@ theorem fgPointTensorIso_unipotentPart (g : WithConv (H →ₐ[k] K)) :
   rw [← Tannaka.fgPointTensorIsoEquiv_apply]
   exact (Tannaka.fgPointTensorIsoEquiv k H K).apply_symm_apply _
 
-omit [PerfectField K] in
-/-- The action of a point reconstructed from a tensor automorphism is that automorphism's
-component on every finite-dimensional comodule. -/
-@[simp]
-theorem endOfPoint_reconstructedPoint
-    (eta : CategoryTheory.Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H K))
-    (M : FGComoduleCat.{u, u, u} k H) :
-    Comodule.endOfPoint M (Tannaka.reconstructedPoint k H K eta).ofConv =
-      Tannaka.scalarExtensionComponent k H K eta M := by
-  rw [← Comodule.pointsAction_toLinearMap,
-    ← Tannaka.scalarExtensionComponent_fgPointTensorIso,
-    Tannaka.fgPointTensorIso_reconstructedPoint]
-
 /-- In every finite-dimensional comodule, the reconstructed semisimple point acts by the
 semisimple part of the original point action. -/
 @[simp]
@@ -131,7 +118,7 @@ theorem endOfPoint_semisimplePart (g : WithConv (H →ₐ[k] K))
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
           Module.End K (K ⊗[k] M)) := by
   rw [semisimplePart, Tannaka.fgPointTensorIsoEquiv_symm_apply,
-    endOfPoint_reconstructedPoint,
+    Tannaka.endOfPoint_reconstructedPoint,
     Tannaka.scalarExtensionComponent_fgPointSemisimplePartTensorIso]
 
 /-- In every finite-dimensional comodule, the reconstructed unipotent point acts by the
@@ -144,7 +131,7 @@ theorem endOfPoint_unipotentPart (g : WithConv (H →ₐ[k] K))
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
           Module.End K (K ⊗[k] M)) := by
   rw [unipotentPart, Tannaka.fgPointTensorIsoEquiv_symm_apply,
-    endOfPoint_reconstructedPoint,
+    Tannaka.endOfPoint_reconstructedPoint,
     Tannaka.scalarExtensionComponent_fgPointUnipotentPartTensorIso]
 
 /-- As an element of the general linear group of any finite-dimensional comodule, the action of

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
@@ -267,27 +267,6 @@ theorem isSemisimple_isUnipotent_unique (g s u : WithConv (H →ₐ[k] K))
     intro x
     exact congrArg (fun a : LinearMap.GeneralLinearGroup K (K ⊗[k] M) ↦ a.val x) (h_unique M).2
 
-/-- The canonical point-level Jordan decomposition has the defining semisimple, unipotent,
-commutation, and product properties. -/
-theorem jordanDecomposition_spec (g : WithConv (H →ₐ[k] K)) :
-    (∀ M : FGComoduleCat.{u, u, u} k H,
-      GeneralLinearGroup.IsSemisimple
-        (LinearMap.GeneralLinearGroup.ofLinearEquiv
-          (Comodule.pointsAction M (jordanDecomposition k H K g).1))) ∧
-      (∀ M : FGComoduleCat.{u, u, u} k H,
-        GeneralLinearGroup.IsUnipotent
-          (LinearMap.GeneralLinearGroup.ofLinearEquiv
-            (Comodule.pointsAction M (jordanDecomposition k H K g).2))) ∧
-      Commute (jordanDecomposition k H K g).1 (jordanDecomposition k H K g).2 ∧
-      g = (jordanDecomposition k H K g).1 * (jordanDecomposition k H K g).2 := by
-  refine ⟨?_, ?_, ?_, ?_⟩
-  · intro M
-    exact isSemisimple_pointsAction_semisimplePart k H K g M
-  · intro M
-    exact isUnipotent_pointsAction_unipotentPart k H K g M
-  · exact commute_semisimplePart_unipotentPart k H K g
-  · exact (semisimplePart_mul_unipotentPart k H K g).symm
-
 /-- A pair is the canonical point-level Jordan decomposition exactly when it is a commuting
 semisimple-unipotent factorization in every finite-dimensional comodule. -/
 theorem eq_jordanDecomposition_iff (g s u : WithConv (H →ₐ[k] K)) :
@@ -305,7 +284,13 @@ theorem eq_jordanDecomposition_iff (g s u : WithConv (H →ₐ[k] K)) :
     have hu : u = (jordanDecomposition k H K g).2 := congrArg Prod.snd h
     subst s
     subst u
-    exact jordanDecomposition_spec k H K g
+    refine ⟨?_, ?_, ?_, ?_⟩
+    · intro M
+      exact isSemisimple_pointsAction_semisimplePart k H K g M
+    · intro M
+      exact isUnipotent_pointsAction_unipotentPart k H K g M
+    · exact commute_semisimplePart_unipotentPart k H K g
+    · exact (semisimplePart_mul_unipotentPart k H K g).symm
   · intro h
     have h_unique := isSemisimple_isUnipotent_unique k H K g s u h.2.2.1 h.2.2.2.symm
       h.1 h.2.1

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
@@ -25,8 +25,11 @@ inside each ambient general linear group.
 
 * `TauCeti.HopfAlgebra.Point.semisimplePart`: the semisimple part of an algebraic-group point.
 * `TauCeti.HopfAlgebra.Point.unipotentPart`: the unipotent part of an algebraic-group point.
+* `TauCeti.HopfAlgebra.Point.jordanDecomposition`: the ordered pair of the two parts.
 * `TauCeti.HopfAlgebra.Point.isSemisimple_isUnipotent_unique`: uniqueness of a commuting
   semisimple-unipotent factorization.
+* `TauCeti.HopfAlgebra.Point.eq_jordanDecomposition_iff`: characterization of the canonical
+  ordered pair.
 * `TauCeti.HopfAlgebra.Point.commute_semisimplePart_unipotentPart`: the two parts commute.
 * `TauCeti.HopfAlgebra.Point.semisimplePart_mul_unipotentPart`: their product is the original
   point.
@@ -68,6 +71,24 @@ comodule is the unipotent part of the original point action. -/
 noncomputable def unipotentPart (g : WithConv (H →ₐ[k] K)) : WithConv (H →ₐ[k] K) :=
   (Tannaka.fgPointTensorIsoEquiv k H K).symm
     (Tannaka.fgPointUnipotentPartTensorIso k H K g)
+
+/-- The multiplicative Jordan decomposition of an algebraic-group point, with the semisimple
+part first and the unipotent part second. -/
+noncomputable def jordanDecomposition (g : WithConv (H →ₐ[k] K)) :
+    WithConv (H →ₐ[k] K) × WithConv (H →ₐ[k] K) :=
+  (semisimplePart k H K g, unipotentPart k H K g)
+
+/-- The first component of a point's Jordan decomposition is its semisimple part. -/
+@[simp]
+theorem jordanDecomposition_fst (g : WithConv (H →ₐ[k] K)) :
+    (jordanDecomposition k H K g).1 = semisimplePart k H K g :=
+  (rfl)
+
+/-- The second component of a point's Jordan decomposition is its unipotent part. -/
+@[simp]
+theorem jordanDecomposition_snd (g : WithConv (H →ₐ[k] K)) :
+    (jordanDecomposition k H K g).2 = unipotentPart k H K g :=
+  (rfl)
 
 /-- The Tannakian action of the semisimple part is the semisimple-factor tensor
 automorphism. -/
@@ -176,8 +197,6 @@ private theorem isSemisimple_pointsAction_one (M : FGComoduleCat.{u, u, u} k H) 
       (LinearMap.GeneralLinearGroup.ofLinearEquiv
         (Comodule.pointsAction M (1 : WithConv (H →ₐ[k] K)))) := by
   rw [map_one]
-  change GeneralLinearGroup.IsSemisimple
-    (1 : LinearMap.GeneralLinearGroup K (K ⊗[k] M))
   exact GeneralLinearGroup.isSemisimple_one
 
 omit [PerfectField K] in
@@ -186,8 +205,6 @@ private theorem isUnipotent_pointsAction_one (M : FGComoduleCat.{u, u, u} k H) :
       (LinearMap.GeneralLinearGroup.ofLinearEquiv
         (Comodule.pointsAction M (1 : WithConv (H →ₐ[k] K)))) := by
   rw [map_one]
-  change GeneralLinearGroup.IsUnipotent
-    (1 : LinearMap.GeneralLinearGroup K (K ⊗[k] M))
   exact GeneralLinearGroup.isUnipotent_one
 
 /-- The semisimple and unipotent parts of an algebraic-group point commute. -/
@@ -235,8 +252,6 @@ theorem isSemisimple_isUnipotent_unique (g s u : WithConv (H →ₐ[k] K))
         LinearMap.GeneralLinearGroup K (K ⊗[k] M) :=
       (LinearMap.GeneralLinearGroup.generalLinearEquiv K (K ⊗[k] M)).symm.toMonoidHom.comp
         (Comodule.pointsAction M)
-    change rho s = rho (semisimplePart k H K g) ∧
-      rho u = rho (unipotentPart k H K g)
     apply GeneralLinearGroup.isSemisimple_isUnipotent_unique
     · exact hs M
     · exact hu M
@@ -244,7 +259,9 @@ theorem isSemisimple_isUnipotent_unique (g s u : WithConv (H →ₐ[k] K))
     · exact isSemisimple_pointsAction_semisimplePart k H K g M
     · exact isUnipotent_pointsAction_unipotentPart k H K g M
     · exact (commute_semisimplePart_unipotentPart k H K g).map rho
-    · rw [← map_mul, ← map_mul, hmul, semisimplePart_mul_unipotentPart]
+    · rw [← LinearMap.GeneralLinearGroup.ofLinearEquiv_mul,
+        ← LinearMap.GeneralLinearGroup.ofLinearEquiv_mul, ← map_mul, ← map_mul, hmul,
+        semisimplePart_mul_unipotentPart]
   constructor
   · apply (Tannaka.fgPointTensorIsoEquiv k H K).injective
     apply Tannaka.scalarExtensionComponent_ext
@@ -262,6 +279,50 @@ theorem isSemisimple_isUnipotent_unique (g s u : WithConv (H →ₐ[k] K))
     apply LinearMap.ext
     intro x
     exact congrArg (fun a : LinearMap.GeneralLinearGroup K (K ⊗[k] M) ↦ a.val x) (h_unique M).2
+
+/-- The canonical point-level Jordan decomposition has the defining semisimple, unipotent,
+commutation, and product properties. -/
+theorem jordanDecomposition_spec (g : WithConv (H →ₐ[k] K)) :
+    (∀ M : FGComoduleCat.{u, u, u} k H,
+      GeneralLinearGroup.IsSemisimple
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv
+          (Comodule.pointsAction M (jordanDecomposition k H K g).1))) ∧
+      (∀ M : FGComoduleCat.{u, u, u} k H,
+        GeneralLinearGroup.IsUnipotent
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv
+            (Comodule.pointsAction M (jordanDecomposition k H K g).2))) ∧
+      Commute (jordanDecomposition k H K g).1 (jordanDecomposition k H K g).2 ∧
+      g = (jordanDecomposition k H K g).1 * (jordanDecomposition k H K g).2 := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro M
+    exact isSemisimple_pointsAction_semisimplePart k H K g M
+  · intro M
+    exact isUnipotent_pointsAction_unipotentPart k H K g M
+  · exact commute_semisimplePart_unipotentPart k H K g
+  · exact (semisimplePart_mul_unipotentPart k H K g).symm
+
+/-- A pair is the canonical point-level Jordan decomposition exactly when it is a commuting
+semisimple-unipotent factorization in every finite-dimensional comodule. -/
+theorem eq_jordanDecomposition_iff (g s u : WithConv (H →ₐ[k] K)) :
+    (s, u) = jordanDecomposition k H K g ↔
+      (∀ M : FGComoduleCat.{u, u, u} k H,
+        GeneralLinearGroup.IsSemisimple
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M s))) ∧
+      (∀ M : FGComoduleCat.{u, u, u} k H,
+        GeneralLinearGroup.IsUnipotent
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M u))) ∧
+      Commute s u ∧ g = s * u := by
+  constructor
+  · intro h
+    have hs : s = (jordanDecomposition k H K g).1 := congrArg Prod.fst h
+    have hu : u = (jordanDecomposition k H K g).2 := congrArg Prod.snd h
+    subst s
+    subst u
+    exact jordanDecomposition_spec k H K g
+  · intro h
+    have h_unique := isSemisimple_isUnipotent_unique k H K g s u h.2.2.1 h.2.2.2.symm
+      h.1 h.2.1
+    exact Prod.ext h_unique.1 h_unique.2
 
 /-- A point acting semisimply in every finite-dimensional comodule is its own semisimple part. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean
@@ -26,6 +26,8 @@ inside each ambient general linear group.
 * `TauCeti.HopfAlgebra.Point.semisimplePart`: the semisimple part of an algebraic-group point.
 * `TauCeti.HopfAlgebra.Point.unipotentPart`: the unipotent part of an algebraic-group point.
 * `TauCeti.HopfAlgebra.Point.jordanDecomposition`: the ordered pair of the two parts.
+* `TauCeti.HopfAlgebra.Point.jordanDecomposition_spec`: the defining properties of the ordered
+  decomposition.
 * `TauCeti.HopfAlgebra.Point.isSemisimple_isUnipotent_unique`: uniqueness of a commuting
   semisimple-unipotent factorization.
 * `TauCeti.HopfAlgebra.Point.eq_jordanDecomposition_iff`: characterization of the canonical
@@ -64,6 +66,13 @@ noncomputable def semisimplePart (g : WithConv (H →ₐ[k] K)) : WithConv (H �
   (Tannaka.fgPointTensorIsoEquiv k H K).symm
     (Tannaka.fgPointSemisimplePartTensorIso k H K g)
 
+/-- The semisimple part is reconstructed from the semisimple-factor tensor automorphism. -/
+theorem semisimplePart_def (g : WithConv (H →ₐ[k] K)) :
+    semisimplePart k H K g =
+      (Tannaka.fgPointTensorIsoEquiv k H K).symm
+        (Tannaka.fgPointSemisimplePartTensorIso k H K g) :=
+  (rfl)
+
 /-- The unipotent part of a point of an affine group over a perfect extension field.
 
 It is reconstructed from the tensor automorphism whose component on every finite-dimensional
@@ -72,23 +81,18 @@ noncomputable def unipotentPart (g : WithConv (H →ₐ[k] K)) : WithConv (H →
   (Tannaka.fgPointTensorIsoEquiv k H K).symm
     (Tannaka.fgPointUnipotentPartTensorIso k H K g)
 
+/-- The unipotent part is reconstructed from the unipotent-factor tensor automorphism. -/
+theorem unipotentPart_def (g : WithConv (H →ₐ[k] K)) :
+    unipotentPart k H K g =
+      (Tannaka.fgPointTensorIsoEquiv k H K).symm
+        (Tannaka.fgPointUnipotentPartTensorIso k H K g) :=
+  (rfl)
+
 /-- The multiplicative Jordan decomposition of an algebraic-group point, with the semisimple
 part first and the unipotent part second. -/
 noncomputable def jordanDecomposition (g : WithConv (H →ₐ[k] K)) :
     WithConv (H →ₐ[k] K) × WithConv (H →ₐ[k] K) :=
   (semisimplePart k H K g, unipotentPart k H K g)
-
-/-- The first component of a point's Jordan decomposition is its semisimple part. -/
-@[simp]
-theorem jordanDecomposition_fst (g : WithConv (H →ₐ[k] K)) :
-    (jordanDecomposition k H K g).1 = semisimplePart k H K g :=
-  (rfl)
-
-/-- The second component of a point's Jordan decomposition is its unipotent part. -/
-@[simp]
-theorem jordanDecomposition_snd (g : WithConv (H →ₐ[k] K)) :
-    (jordanDecomposition k H K g).2 = unipotentPart k H K g :=
-  (rfl)
 
 /-- The Tannakian action of the semisimple part is the semisimple-factor tensor
 automorphism. -/
@@ -117,7 +121,7 @@ theorem endOfPoint_semisimplePart (g : WithConv (H →ₐ[k] K))
       (GeneralLinearGroup.semisimplePart
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
           Module.End K (K ⊗[k] M)) := by
-  rw [semisimplePart, Tannaka.fgPointTensorIsoEquiv_symm_apply,
+  rw [semisimplePart_def, Tannaka.fgPointTensorIsoEquiv_symm_apply,
     Tannaka.endOfPoint_reconstructedPoint,
     Tannaka.scalarExtensionComponent_fgPointSemisimplePartTensorIso]
 
@@ -130,7 +134,7 @@ theorem endOfPoint_unipotentPart (g : WithConv (H →ₐ[k] K))
       (GeneralLinearGroup.unipotentPart
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
           Module.End K (K ⊗[k] M)) := by
-  rw [unipotentPart, Tannaka.fgPointTensorIsoEquiv_symm_apply,
+  rw [unipotentPart_def, Tannaka.fgPointTensorIsoEquiv_symm_apply,
     Tannaka.endOfPoint_reconstructedPoint,
     Tannaka.scalarExtensionComponent_fgPointUnipotentPartTensorIso]
 
@@ -177,22 +181,6 @@ theorem isUnipotent_pointsAction_unipotentPart (g : WithConv (H →ₐ[k] K))
         (Comodule.pointsAction M (unipotentPart k H K g))) := by
   rw [ofLinearEquiv_pointsAction_unipotentPart]
   exact GeneralLinearGroup.isUnipotent_unipotentPart _
-
-omit [PerfectField K] in
-private theorem isSemisimple_pointsAction_one (M : FGComoduleCat.{u, u, u} k H) :
-    GeneralLinearGroup.IsSemisimple
-      (LinearMap.GeneralLinearGroup.ofLinearEquiv
-        (Comodule.pointsAction M (1 : WithConv (H →ₐ[k] K)))) := by
-  rw [map_one]
-  exact GeneralLinearGroup.isSemisimple_one
-
-omit [PerfectField K] in
-private theorem isUnipotent_pointsAction_one (M : FGComoduleCat.{u, u, u} k H) :
-    GeneralLinearGroup.IsUnipotent
-      (LinearMap.GeneralLinearGroup.ofLinearEquiv
-        (Comodule.pointsAction M (1 : WithConv (H →ₐ[k] K)))) := by
-  rw [map_one]
-  exact GeneralLinearGroup.isUnipotent_one
 
 /-- The semisimple and unipotent parts of an algebraic-group point commute. -/
 theorem commute_semisimplePart_unipotentPart (g : WithConv (H →ₐ[k] K)) :
@@ -267,6 +255,27 @@ theorem isSemisimple_isUnipotent_unique (g s u : WithConv (H →ₐ[k] K))
     intro x
     exact congrArg (fun a : LinearMap.GeneralLinearGroup K (K ⊗[k] M) ↦ a.val x) (h_unique M).2
 
+/-- The canonical point-level Jordan decomposition has the defining semisimple, unipotent,
+commutation, and product properties. -/
+theorem jordanDecomposition_spec (g : WithConv (H →ₐ[k] K)) :
+    (∀ M : FGComoduleCat.{u, u, u} k H,
+      GeneralLinearGroup.IsSemisimple
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv
+          (Comodule.pointsAction M (jordanDecomposition k H K g).1))) ∧
+      (∀ M : FGComoduleCat.{u, u, u} k H,
+        GeneralLinearGroup.IsUnipotent
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv
+            (Comodule.pointsAction M (jordanDecomposition k H K g).2))) ∧
+      Commute (jordanDecomposition k H K g).1 (jordanDecomposition k H K g).2 ∧
+      g = (jordanDecomposition k H K g).1 * (jordanDecomposition k H K g).2 := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro M
+    exact isSemisimple_pointsAction_semisimplePart k H K g M
+  · intro M
+    exact isUnipotent_pointsAction_unipotentPart k H K g M
+  · exact commute_semisimplePart_unipotentPart k H K g
+  · exact (semisimplePart_mul_unipotentPart k H K g).symm
+
 /-- A pair is the canonical point-level Jordan decomposition exactly when it is a commuting
 semisimple-unipotent factorization in every finite-dimensional comodule. -/
 theorem eq_jordanDecomposition_iff (g s u : WithConv (H →ₐ[k] K)) :
@@ -284,13 +293,7 @@ theorem eq_jordanDecomposition_iff (g s u : WithConv (H →ₐ[k] K)) :
     have hu : u = (jordanDecomposition k H K g).2 := congrArg Prod.snd h
     subst s
     subst u
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · intro M
-      exact isSemisimple_pointsAction_semisimplePart k H K g M
-    · intro M
-      exact isUnipotent_pointsAction_unipotentPart k H K g M
-    · exact commute_semisimplePart_unipotentPart k H K g
-    · exact (semisimplePart_mul_unipotentPart k H K g).symm
+    exact jordanDecomposition_spec k H K g
   · intro h
     have h_unique := isSemisimple_isUnipotent_unique k H K g s u h.2.2.1 h.2.2.2.symm
       h.1 h.2.1
@@ -304,7 +307,7 @@ theorem semisimplePart_eq_self {g : WithConv (H →ₐ[k] K)}
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))) :
     semisimplePart k H K g = g :=
   ((isSemisimple_isUnipotent_unique k H K g g 1 (Commute.one_right g) (mul_one g) hg
-    (isUnipotent_pointsAction_one k H K)).1).symm
+    (by intro M; rw [map_one]; exact GeneralLinearGroup.isUnipotent_one)).1).symm
 
 /-- A point acting semisimply in every finite-dimensional comodule has trivial unipotent part. -/
 @[simp]
@@ -314,7 +317,7 @@ theorem unipotentPart_eq_one_of_isSemisimple {g : WithConv (H →ₐ[k] K)}
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))) :
     unipotentPart k H K g = 1 :=
   ((isSemisimple_isUnipotent_unique k H K g g 1 (Commute.one_right g) (mul_one g) hg
-    (isUnipotent_pointsAction_one k H K)).2).symm
+    (by intro M; rw [map_one]; exact GeneralLinearGroup.isUnipotent_one)).2).symm
 
 /-- A point acting unipotently in every finite-dimensional comodule has trivial semisimple part. -/
 @[simp]
@@ -324,7 +327,7 @@ theorem semisimplePart_eq_one_of_isUnipotent {g : WithConv (H →ₐ[k] K)}
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))) :
     semisimplePart k H K g = 1 :=
   ((isSemisimple_isUnipotent_unique k H K g 1 g (Commute.one_left g) (one_mul g)
-    (isSemisimple_pointsAction_one k H K) hg).1).symm
+    (by intro M; rw [map_one]; exact GeneralLinearGroup.isSemisimple_one) hg).1).symm
 
 /-- A point acting unipotently in every finite-dimensional comodule is its own unipotent part. -/
 @[simp]
@@ -334,19 +337,21 @@ theorem unipotentPart_eq_self {g : WithConv (H →ₐ[k] K)}
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g))) :
     unipotentPart k H K g = g :=
   ((isSemisimple_isUnipotent_unique k H K g 1 g (Commute.one_left g) (one_mul g)
-    (isSemisimple_pointsAction_one k H K) hg).2).symm
+    (by intro M; rw [map_one]; exact GeneralLinearGroup.isSemisimple_one) hg).2).symm
 
 /-- The semisimple part of the identity point is the identity. -/
 @[simp]
 theorem semisimplePart_one :
     semisimplePart k H K (1 : WithConv (H →ₐ[k] K)) = 1 :=
-  semisimplePart_eq_self k H K (isSemisimple_pointsAction_one k H K)
+  semisimplePart_eq_self k H K
+    (by intro M; rw [map_one]; exact GeneralLinearGroup.isSemisimple_one)
 
 /-- The unipotent part of the identity point is the identity. -/
 @[simp]
 theorem unipotentPart_one :
     unipotentPart k H K (1 : WithConv (H →ₐ[k] K)) = 1 :=
-  unipotentPart_eq_self k H K (isUnipotent_pointsAction_one k H K)
+  unipotentPart_eq_self k H K
+    (by intro M; rw [map_one]; exact GeneralLinearGroup.isUnipotent_one)
 
 end Point
 end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
@@ -25,6 +25,8 @@ functional used to reconstruct the point, and the scalar-extended dual separates
 
 * `TauCeti.Tannaka.fgPointTensorIso_reconstructedPoint`: reconstruction is a right inverse to
   the point action.
+* `TauCeti.Tannaka.endOfPoint_reconstructedPoint`: a reconstructed point acts through the
+  corresponding tensor-automorphism component.
 * `TauCeti.Tannaka.fgPointTensorIsoEquiv`: the Tannakian equivalence between algebra-valued
   points and tensor automorphisms of finite-comodule scalar extension.
 
@@ -160,6 +162,18 @@ theorem fgPointTensorIso_reconstructedPoint
     fgPointTensorIso k H A (reconstructedPoint k H A eta) = eta := by
   apply scalarExtensionComponent_ext
   exact scalarExtensionComponent_reconstructedPoint k H A eta
+
+/-- The action of a point reconstructed from a tensor automorphism is that automorphism's
+component on every finite-dimensional comodule. -/
+@[simp]
+theorem endOfPoint_reconstructedPoint
+    (eta : Aut (FGComoduleCat.scalarExtensionMonoidalFunctor k H A))
+    (M : FGComoduleCat.{u, u, u} k H) :
+    Comodule.endOfPoint M (reconstructedPoint k H A eta).ofConv =
+      scalarExtensionComponent k H A eta M := by
+  rw [← Comodule.pointsAction_toLinearMap,
+    ← scalarExtensionComponent_fgPointTensorIso,
+    fgPointTensorIso_reconstructedPoint]
 
 /-- Algebra-valued points of a commutative Hopf algebra over a field are equivalent to tensor
 automorphisms of scalar extension on its finite-dimensional comodules. -/


### PR DESCRIPTION
This PR reconstructs the semisimple and unipotent tensor factors of a perfect-field-valued point as points of the original affine group, and exposes their canonical multiplicative Jordan decomposition.

The exact target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 milestone “Jordan decomposition of elements into semisimple and unipotent parts (geometric, over `k̄`), functorial under representations.” The newly merged Tannakian equivalence turns the tensor automorphisms already constructed from the representation-wise linear Jordan factors back into points. Define `HopfAlgebra.semisimplePart`, `HopfAlgebra.unipotentPart`, and their ordered pair `HopfAlgebra.jordanDecomposition`; prove that the factors commute and multiply to the original point; and identify their actions on every finite-dimensional comodule with `GeneralLinearGroup.semisimplePart` and `GeneralLinearGroup.unipotentPart`. This works over any perfect extension field, hence in particular over an algebraic closure.

This is the most effective current critical-path step because Tannakian reconstruction and tensor compatibility have landed, while no open PR claims the lift of those tensor factors back to group points; the open semisimple- and unipotent-point PRs develop the distinct intrinsic predicate API. After this PR, the milestone still needs those in-flight predicates connected to these factors and functoriality under morphisms of affine groups.

Add `TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean` (196 lines). The construction reuses `Tannaka.fgPointTensorIsoEquiv`, `fgPointSemisimplePartTensorIso`, `fgPointUnipotentPartTensorIso`, and the multiplicative Jordan–Chevalley API already in Tau Ceti. The mathematical construction follows T. A. Springer, *Linear Algebraic Groups*, §2.4, and J. S. Milne, *Algebraic Groups* (2017), §9.4, as credited in the module documentation. Exact-name and concept searches over pinned Mathlib and Tau Ceti found no existing point-level Jordan decomposition; no Mathlib infrastructure or external formalization is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"jordan-decomposition-group-elements"}-->

🤖 Prepared with Codex
