### PR TITLE
refactor(Character): name the intertwining step behind the class-function collapse

### DIFF
--- a/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
+++ b/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
@@ -96,13 +96,33 @@ theorem inner_matrixCoeffLp_map_map (hunitary : IsUnitary π) {f : Lp 𝕜 2 (ha
     _ = ⟪matrixCoeffLp π hπ v w, f⟫_𝕜 :=
       (conjLpₗᵢ (E := 𝕜) (p := 2) (μ := haarProb G) 𝕜 h⁻¹).toLinearIsometry.inner_map_map _ _
 
+omit [FiniteDimensional 𝕜 V] in
+/-- **An endomorphism that represents the pairing against a class function is an intertwiner.**
+If `⟪w, T v⟫ = ⟪(π)_{v,w}, f⟫` for all `v, w` and `f` is a class function, then `T` commutes with
+the action of `π`. -/
+private lemma map_apply_comm_of_inner_matrixCoeffLp_eq (hunitary : IsUnitary π)
+    {f : Lp 𝕜 2 (haarProb G)} (hf : f ∈ classFunctionLp 𝕜 𝕜 2 (haarProb G)) (T : V →ₗ[𝕜] V)
+    (hT : ∀ v w : V, ⟪w, T v⟫_𝕜 = ⟪matrixCoeffLp π hπ v w, f⟫_𝕜) (g : G) (v : V) :
+    T (π g v) = π g (T v) := by
+  refine ext_inner_left 𝕜 fun u ↦ ?_
+  -- Conjugation invariance of `f` is what moves `g` across the coefficient.
+  have hu : π g (π g⁻¹ u) = u := Representation.self_inv_apply π.toRepresentation g u
+  calc ⟪u, T (π g v)⟫_𝕜
+      = ⟪π g (π g⁻¹ u), T (π g v)⟫_𝕜 := by rw [hu]
+    _ = ⟪matrixCoeffLp π hπ (π g v) (π g (π g⁻¹ u)), f⟫_𝕜 := hT _ _
+    _ = ⟪matrixCoeffLp π hπ v (π g⁻¹ u), f⟫_𝕜 :=
+        inner_matrixCoeffLp_map_map hπ hunitary hf g v (π g⁻¹ u)
+    _ = ⟪π g⁻¹ u, T v⟫_𝕜 := (hT _ _).symm
+    _ = ⟪π g (π g⁻¹ u), π g (T v)⟫_𝕜 := (hunitary.inner_map_map g _ _).symm
+    _ = ⟪u, π g (T v)⟫_𝕜 := by rw [hu]
+
 /-- **Against a class function, the matrix coefficients of an irreducible collapse to one scalar.**
 For `π` irreducible unitary and `f` a class function there is a `c` with
 `⟪(π)_{v,w}, f⟫ = c · ⟪w, v⟫` for all `v, w`.
 
 The pairing is `⟪w, T v⟫` for an endomorphism `T` of the carrier, and
-`TauCeti.ContRepresentation.inner_matrixCoeffLp_map_map` makes `T` an intertwiner; Schur's lemma
-over an algebraically closed field turns it into a scalar. -/
+`TauCeti.ContRepresentation.map_apply_comm_of_inner_matrixCoeffLp_eq` makes `T` an intertwiner;
+Schur's lemma over an algebraically closed field turns it into a scalar. -/
 theorem exists_forall_inner_matrixCoeffLp_eq [IsAlgClosed 𝕜] (hunitary : IsUnitary π)
     (hirr : Representation.IsIrreducible π.toRepresentation) {f : Lp 𝕜 2 (haarProb G)}
     (hf : f ∈ classFunctionLp 𝕜 𝕜 2 (haarProb G)) :
@@ -127,19 +147,8 @@ theorem exists_forall_inner_matrixCoeffLp_eq [IsAlgClosed 𝕜] (hunitary : IsUn
     simp only [LinearMap.coe_mk, AddHom.coe_mk, inner_sum, inner_smul_right, sum_inner,
       inner_smul_left]
     exact Finset.sum_congr rfl fun a _ ↦ by rw [inner_conj_symm, mul_comm]
-  -- Conjugation invariance of `f` makes `T` an intertwiner.
-  have hcomm : ∀ (g : G) (v : V), T (π g v) = π g (T v) := by
-    intro g v
-    refine ext_inner_left 𝕜 fun u ↦ ?_
-    have hu : π g (π g⁻¹ u) = u := Representation.self_inv_apply π.toRepresentation g u
-    calc ⟪u, T (π g v)⟫_𝕜
-        = ⟪π g (π g⁻¹ u), T (π g v)⟫_𝕜 := by rw [hu]
-      _ = ⟪matrixCoeffLp π hπ (π g v) (π g (π g⁻¹ u)), f⟫_𝕜 := hT _ _
-      _ = ⟪matrixCoeffLp π hπ v (π g⁻¹ u), f⟫_𝕜 :=
-          inner_matrixCoeffLp_map_map hπ hunitary hf g v (π g⁻¹ u)
-      _ = ⟪π g⁻¹ u, T v⟫_𝕜 := (hT _ _).symm
-      _ = ⟪π g (π g⁻¹ u), π g (T v)⟫_𝕜 := (hunitary.inner_map_map g _ _).symm
-      _ = ⟪u, π g (T v)⟫_𝕜 := by rw [hu]
+  have hcomm : ∀ (g : G) (v : V), T (π g v) = π g (T v) :=
+    map_apply_comm_of_inner_matrixCoeffLp_eq hπ hunitary hf T hT
   -- Schur's lemma turns it into a scalar.
   obtain ⟨c, hc⟩ := exists_eq_smul_one_of_irreducible π hirr
     { toContinuousLinearMap := LinearMap.toContinuousLinearMap T

--- a/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
+++ b/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
@@ -121,8 +121,8 @@ For `π` irreducible unitary and `f` a class function there is a `c` with
 `⟪(π)_{v,w}, f⟫ = c · ⟪w, v⟫` for all `v, w`.
 
 The pairing is `⟪w, T v⟫` for an endomorphism `T` of the carrier, and
-`TauCeti.ContRepresentation.map_apply_comm_of_inner_matrixCoeffLp_eq` makes `T` an intertwiner;
-Schur's lemma over an algebraically closed field turns it into a scalar. -/
+`TauCeti.ContRepresentation.inner_matrixCoeffLp_map_map` makes `T` an intertwiner; Schur's lemma
+over an algebraically closed field turns it into a scalar. -/
 theorem exists_forall_inner_matrixCoeffLp_eq [IsAlgClosed 𝕜] (hunitary : IsUnitary π)
     (hirr : Representation.IsIrreducible π.toRepresentation) {f : Lp 𝕜 2 (haarProb G)}
     (hf : f ∈ classFunctionLp 𝕜 𝕜 2 (haarProb G)) :

--- a/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
+++ b/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
@@ -98,13 +98,13 @@ theorem inner_matrixCoeffLp_map_map (hunitary : IsUnitary π) {f : Lp 𝕜 2 (ha
 
 omit [FiniteDimensional 𝕜 V] in
 /-- **An endomorphism that represents the pairing against a class function is an intertwiner.**
-If `⟪w, T v⟫ = ⟪(π)_{v,w}, f⟫` for all `v, w` and `f` is a class function, then `T` commutes with
-the action of `π`. -/
-private lemma map_apply_comm_of_inner_matrixCoeffLp_eq (hunitary : IsUnitary π)
+If `⟪w, T v⟫ = ⟪(π)_{v,w}, f⟫` for all `v, w` and `f` is a class function, then `T` intertwines `π`
+with itself. -/
+private lemma isIntertwiningMap_of_inner_matrixCoeffLp_eq (hunitary : IsUnitary π)
     {f : Lp 𝕜 2 (haarProb G)} (hf : f ∈ classFunctionLp 𝕜 𝕜 2 (haarProb G)) (T : V →ₗ[𝕜] V)
-    (hT : ∀ v w : V, ⟪w, T v⟫_𝕜 = ⟪matrixCoeffLp π hπ v w, f⟫_𝕜) (g : G) (v : V) :
-    T (π g v) = π g (T v) := by
-  refine ext_inner_left 𝕜 fun u ↦ ?_
+    (hT : ∀ v w : V, ⟪w, T v⟫_𝕜 = ⟪matrixCoeffLp π hπ v w, f⟫_𝕜) :
+    π.toRepresentation.IsIntertwiningMap π.toRepresentation T := by
+  refine ⟨fun g v ↦ ext_inner_left 𝕜 fun u ↦ ?_⟩
   -- Conjugation invariance of `f` is what moves `g` across the coefficient.
   have hu : π g (π g⁻¹ u) = u := Representation.self_inv_apply π.toRepresentation g u
   calc ⟪u, T (π g v)⟫_𝕜
@@ -148,7 +148,7 @@ theorem exists_forall_inner_matrixCoeffLp_eq [IsAlgClosed 𝕜] (hunitary : IsUn
       inner_smul_left]
     exact Finset.sum_congr rfl fun a _ ↦ by rw [inner_conj_symm, mul_comm]
   have hcomm : ∀ (g : G) (v : V), T (π g v) = π g (T v) :=
-    map_apply_comm_of_inner_matrixCoeffLp_eq hπ hunitary hf T hT
+    (isIntertwiningMap_of_inner_matrixCoeffLp_eq hπ hunitary hf T hT).isIntertwining
   -- Schur's lemma turns it into a scalar.
   obtain ⟨c, hc⟩ := exists_eq_smul_one_of_irreducible π hirr
     { toContinuousLinearMap := LinearMap.toContinuousLinearMap T


### PR DESCRIPTION
`exists_forall_inner_matrixCoeffLp_eq` says that against a class function the matrix coefficients of
an irreducible collapse to a single scalar. Its proof builds an endomorphism `T` representing the
pairing, shows `T` is an intertwiner, and hands that to Schur's lemma. The middle step took thirteen
of the forty-four lines.

`isIntertwiningMap_of_inner_matrixCoeffLp_eq` now states it: an endomorphism satisfying
`⟪w, T v⟫ = ⟪(π)_{v,w}, f⟫` for all `v, w`, with `f` a class function, intertwines `π` with itself.
The conclusion is Mathlib's `Representation.IsIntertwiningMap` rather than the pointwise equation,
so the lemma names the standard concept instead of restating it; the parent takes the pointwise form
back off the structure's `isIntertwining` field.

The point of the extraction is that this step never looks at how `T` was built. Inside the parent
`T` arrives via `set` as an explicit `LinearMap` with hand-written `map_add'` and `map_smul'` fields,
and the intertwining argument uses none of that — only the defining property, conjugation invariance
of `f` through `inner_matrixCoeffLp_map_map`, and unitarity. So the lemma takes `T` and that property
as hypotheses, and the construction stays in the parent where it belongs.

Re-deriving the hypotheses rather than inheriting them also dropped two. Irreducibility of `π` and
algebraic closedness of `𝕜` are what Schur's lemma needs, not what makes `T` an intertwiner, and both
are absent. `[FiniteDimensional 𝕜 V]` is `omit`ted, so the linter confirms it is genuinely unused
rather than merely unmentioned — the statement holds on any inner product space.

The parent drops from 44 lines to 33; the extracted lemma is 12. The parent's docstring is left
alone, still pointing at the public `inner_matrixCoeffLp_map_map`: the new helper is `private`, and
a public docstring should not name a declaration its readers cannot resolve.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: RepresentationTheory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
