### PR TITLE
refactor: generalize smooth directional derivatives

### DIFF
--- a/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
@@ -198,8 +198,8 @@ theorem contMDiff_mvfderiv_mulRightInvariantVectorField
     (f : C^∞⟮I, G; 𝕜⟯) :
     ContMDiff I (modelWithCornersSelf 𝕜 𝕜) ∞
       (fun g ↦ mvfderiv I f g (mulRightInvariantVectorField v g)) :=
-  f.contMDiff.contMDiff_mvfderiv_apply_tangentBundle
-    (contMDiff_mulRightInvariantVectorField_infty v) (by simp)
+  (f.contMDiff.contMDiff_mvfderiv_apply (by simp)).comp
+    (contMDiff_mulRightInvariantVectorField_infty v)
 
 /-- Right-invariant differentiation of a smooth scalar function, bundled as a smooth scalar
 function. -/

--- a/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
@@ -198,7 +198,7 @@ theorem contMDiff_mvfderiv_mulRightInvariantVectorField
     (f : C^∞⟮I, G; 𝕜⟯) :
     ContMDiff I (modelWithCornersSelf 𝕜 𝕜) ∞
       (fun g ↦ mvfderiv I f g (mulRightInvariantVectorField v g)) :=
-  f.contMDiff.contMDiff_mvfderiv_apply
+  f.contMDiff.contMDiff_mvfderiv_apply_tangentBundle
     (contMDiff_mulRightInvariantVectorField_infty v) (by simp)
 
 /-- Right-invariant differentiation of a smooth scalar function, bundled as a smooth scalar

--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -94,7 +94,7 @@ theorem contMDiff_mvfderiv_mulInvariantVectorField
     (f : C^∞⟮I, G; 𝕜⟯) :
     ContMDiff I (modelWithCornersSelf 𝕜 𝕜) ∞
       (fun g ↦ mvfderiv I f g (mulInvariantVectorField v g)) :=
-  f.contMDiff.contMDiff_mvfderiv_apply
+  f.contMDiff.contMDiff_mvfderiv_apply_tangentBundle
     (contMDiff_mulInvariantVectorField_infty v) (by simp)
 
 /-- The derivation of smooth functions that differentiates along the left-invariant vector

--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -94,8 +94,8 @@ theorem contMDiff_mvfderiv_mulInvariantVectorField
     (f : C^∞⟮I, G; 𝕜⟯) :
     ContMDiff I (modelWithCornersSelf 𝕜 𝕜) ∞
       (fun g ↦ mvfderiv I f g (mulInvariantVectorField v g)) :=
-  f.contMDiff.contMDiff_mvfderiv_apply_tangentBundle
-    (contMDiff_mulInvariantVectorField_infty v) (by simp)
+  (f.contMDiff.contMDiff_mvfderiv_apply (by simp)).comp
+    (contMDiff_mulInvariantVectorField_infty v)
 
 /-- The derivation of smooth functions that differentiates along the left-invariant vector
 field of a tangent vector `v` at the identity. -/

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -11,7 +11,7 @@ import Mathlib.Geometry.Manifold.VectorBundle.Tangent
 # Regularity of tangent-bundle-valued maps and directional derivatives
 
 This file records reusable regularity facts for maps into a tangent bundle and for applying the
-manifold differential of a function to a smooth section.
+manifold differential of a function to tangent vectors whose base point varies.
 
 ## Main results
 
@@ -19,8 +19,8 @@ manifold differential of a function to a smooth section.
 * `contMDiff_tangentBundle_mk_constBase`: smoothness of a varying model vector over a fixed point.
 * `mvfderiv_apply_eq_mfderiv_apply`: identifies `mvfderiv` with `mfderiv` when the target is a
   normed vector space.
-* `ContMDiff.contMDiff_mvfderiv_apply_tangentBundle`: applying a differential along an arbitrary
-  smooth tangent-bundle-valued input is smooth.
+* `ContMDiff.contMDiff_mvfderiv_apply`: applying the differential of a `C^n` function on the
+  tangent bundle is `C^m` when `m + 1 ≤ n`.
 
 ## References
 
@@ -84,20 +84,13 @@ canonical one, so evaluating it agrees with evaluating `mfderiv`. -/
   -- `fromTangentSpace` is Mathlib's explicit interface for this canonical identification.
   rfl
 
-section TangentBundleInputs
-
-variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
-  {H' : Type*} [TopologicalSpace H'] {J : ModelWithCorners 𝕜 E' H'}
-  {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
-
-/-- Applying the differential of a `C^n` function along an arbitrary `C^m`
-tangent-bundle-valued input is `C^m` when `m + 1 ≤ n`. -/
-theorem ContMDiff.contMDiff_mvfderiv_apply_tangentBundle {f : M → F}
-    {V : N → TangentBundle I M}
+/-- The map that applies the differential of a `C^n` function to tangent vectors is `C^m` on the
+tangent bundle when `m + 1 ≤ n`. -/
+theorem ContMDiff.contMDiff_mvfderiv_apply {f : M → F}
     (hf : ContMDiff I 𝓘(𝕜, F) n f)
-    (hV : ContMDiff J I.tangent m V)
     (hmn : m + 1 ≤ n) :
-    ContMDiff J 𝓘(𝕜, F) m (fun x => mvfderiv I f (V x).1 (V x).2) := by
+    ContMDiff I.tangent 𝓘(𝕜, F) m
+      (fun p : TangentBundle I M => mvfderiv I f p.1 p.2) := by
   let df : TangentBundle I M → TangentBundle 𝓘(𝕜, F) F := tangentMap% f
   have hdf : ContMDiff I.tangent 𝓘(𝕜, F).tangent m df :=
     hf.contMDiff_tangentMap hmn
@@ -105,10 +98,10 @@ theorem ContMDiff.contMDiff_mvfderiv_apply_tangentBundle {f : M → F}
       (fun p : TangentBundle 𝓘(𝕜, F) F => p.2) :=
     contMDiff_snd_tangentBundle_modelSpace F 𝓘(𝕜, F)
   simp only [mvfderiv_apply_eq_mfderiv_apply]
-  have h := hsnd.comp (hdf.comp hV)
-  have htangent (x : N) :
-      ((tangentMap% f (V x)).2 : F) = mfderiv I 𝓘(𝕜, F) f (V x).1 (V x).2 := by
+  have h := hsnd.comp hdf
+  have htangent (p : TangentBundle I M) :
+      NormedSpace.fromTangentSpace (f p.1) ((tangentMap% f p).2) =
+        mfderiv I 𝓘(𝕜, F) f p.1 p.2 := by
     rw [tangentMap_snd]
-  exact h.congr fun x => (htangent x).symm
-
-end TangentBundleInputs
+    rfl
+  exact h.congr fun p => (htangent p).symm

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -103,4 +103,6 @@ theorem ContMDiff.contMDiff_mvfderiv_apply {f : M → F}
         mvfderiv I f p.1 p.2 := by
     rw [mvfderiv, ContinuousLinearMap.comp_apply, tangentMap_snd]
     rfl
+  -- On a model vector space, `NormedSpace.fromTangentSpace` is the identity on the underlying
+  -- type, so the second projection computed by `h` agrees definitionally with `mvfderiv`.
   exact h.congr fun p => (htangent p).symm

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -97,11 +97,10 @@ theorem ContMDiff.contMDiff_mvfderiv_apply {f : M → F}
   have hsnd : ContMDiff 𝓘(𝕜, F).tangent 𝓘(𝕜, F) m
       (fun p : TangentBundle 𝓘(𝕜, F) F => p.2) :=
     contMDiff_snd_tangentBundle_modelSpace F 𝓘(𝕜, F)
-  simp only [mvfderiv_apply_eq_mfderiv_apply]
   have h := hsnd.comp hdf
   have htangent (p : TangentBundle I M) :
       NormedSpace.fromTangentSpace (f p.1) ((tangentMap% f p).2) =
-        mfderiv I 𝓘(𝕜, F) f p.1 p.2 := by
-    rw [tangentMap_snd]
+        mvfderiv I f p.1 p.2 := by
+    rw [mvfderiv, ContinuousLinearMap.comp_apply, tangentMap_snd]
     rfl
   exact h.congr fun p => (htangent p).symm

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -21,8 +21,6 @@ manifold differential of a function to a smooth section.
   normed vector space.
 * `ContMDiff.contMDiff_mvfderiv_apply_tangentBundle`: applying a differential along an arbitrary
   smooth tangent-bundle-valued input is smooth.
-* `ContMDiff.contMDiff_mvfderiv_apply`: applying the differential of a `C^n` function to a `C^m`
-  tangent-bundle section is `C^m` when `m + 1 ≤ n`.
 
 ## References
 
@@ -108,16 +106,9 @@ theorem ContMDiff.contMDiff_mvfderiv_apply_tangentBundle {f : M → F}
     contMDiff_snd_tangentBundle_modelSpace F 𝓘(𝕜, F)
   simp only [mvfderiv_apply_eq_mfderiv_apply]
   have h := hsnd.comp (hdf.comp hV)
-  exact h.congr fun x => rfl
+  have htangent (x : N) :
+      ((tangentMap% f (V x)).2 : F) = mfderiv I 𝓘(𝕜, F) f (V x).1 (V x).2 := by
+    rw [tangentMap_snd]
+  exact h.congr fun x => (htangent x).symm
 
 end TangentBundleInputs
-
-/-- Applying the differential of a `C^n` function to a `C^m` tangent-bundle section is `C^m`
-when `m + 1 ≤ n`. -/
-theorem ContMDiff.contMDiff_mvfderiv_apply {f : M → F}
-    {V : ∀ x : M, TangentSpace I x}
-    (hf : ContMDiff I 𝓘(𝕜, F) n f)
-    (hV : ContMDiff I I.tangent m (fun x => (V x : TangentBundle I M)))
-    (hmn : m + 1 ≤ n) :
-    ContMDiff I 𝓘(𝕜, F) m (fun x => mvfderiv I f x (V x)) :=
-  hf.contMDiff_mvfderiv_apply_tangentBundle hV hmn

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -19,6 +19,8 @@ manifold differential of a function to a smooth section.
 * `contMDiff_tangentBundle_mk_constBase`: smoothness of a varying model vector over a fixed point.
 * `mvfderiv_apply_eq_mfderiv_apply`: identifies `mvfderiv` with `mfderiv` when the target is a
   normed vector space.
+* `ContMDiff.contMDiff_mvfderiv_apply_tangentBundle`: applying a differential along an arbitrary
+  smooth tangent-bundle-valued input is smooth.
 * `ContMDiff.contMDiff_mvfderiv_apply`: applying the differential of a `C^n` function to a `C^m`
   tangent-bundle section is `C^m` when `m + 1 ≤ n`.
 
@@ -84,14 +86,20 @@ canonical one, so evaluating it agrees with evaluating `mfderiv`. -/
   -- `fromTangentSpace` is Mathlib's explicit interface for this canonical identification.
   rfl
 
-/-- Applying the differential of a `C^n` function to a `C^m` tangent-bundle section is `C^m`
-when `m + 1 ≤ n`. -/
-theorem ContMDiff.contMDiff_mvfderiv_apply {f : M → F}
-    {V : ∀ x : M, TangentSpace I x}
+section TangentBundleInputs
+
+variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {H' : Type*} [TopologicalSpace H'] {J : ModelWithCorners 𝕜 E' H'}
+  {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
+
+/-- Applying the differential of a `C^n` function along an arbitrary `C^m`
+tangent-bundle-valued input is `C^m` when `m + 1 ≤ n`. -/
+theorem ContMDiff.contMDiff_mvfderiv_apply_tangentBundle {f : M → F}
+    {V : N → TangentBundle I M}
     (hf : ContMDiff I 𝓘(𝕜, F) n f)
-    (hV : ContMDiff I I.tangent m (fun x => (V x : TangentBundle I M)))
+    (hV : ContMDiff J I.tangent m V)
     (hmn : m + 1 ≤ n) :
-    ContMDiff I 𝓘(𝕜, F) m (fun x => mvfderiv I f x (V x)) := by
+    ContMDiff J 𝓘(𝕜, F) m (fun x => mvfderiv I f (V x).1 (V x).2) := by
   let df : TangentBundle I M → TangentBundle 𝓘(𝕜, F) F := tangentMap% f
   have hdf : ContMDiff I.tangent 𝓘(𝕜, F).tangent m df :=
     hf.contMDiff_tangentMap hmn
@@ -101,3 +109,15 @@ theorem ContMDiff.contMDiff_mvfderiv_apply {f : M → F}
   simp only [mvfderiv_apply_eq_mfderiv_apply]
   have h := hsnd.comp (hdf.comp hV)
   exact h.congr fun x => rfl
+
+end TangentBundleInputs
+
+/-- Applying the differential of a `C^n` function to a `C^m` tangent-bundle section is `C^m`
+when `m + 1 ≤ n`. -/
+theorem ContMDiff.contMDiff_mvfderiv_apply {f : M → F}
+    {V : ∀ x : M, TangentSpace I x}
+    (hf : ContMDiff I 𝓘(𝕜, F) n f)
+    (hV : ContMDiff I I.tangent m (fun x => (V x : TangentBundle I M)))
+    (hmn : m + 1 ≤ n) :
+    ContMDiff I 𝓘(𝕜, F) m (fun x => mvfderiv I f x (V x)) :=
+  hf.contMDiff_mvfderiv_apply_tangentBundle hV hmn


### PR DESCRIPTION
## Goal

Expose the existing smooth-directional-derivative argument as regularity of the differential-evaluation map on the tangent bundle, so later Lie-group proofs can compose it with tangent inputs whose base point varies independently of the source manifold.

## Why this is the right generalization

The proof factors through the tangent map and the smooth projection from the target tangent bundle. The resulting canonical theorem states that `fun p : TangentBundle I M => mvfderiv I f p.1 p.2` is `C^m` when `f` is `C^n` and `m + 1 ≤ n`. Consumers then compose this source-free fact with their own tangent-bundle-valued maps; the two merged callers are migrated mechanically to that API.

The proof identifies the tangent map's second projection through Mathlib's public `tangentMap_snd` theorem and makes the target tangent-space identification explicit with `NormedSpace.fromTangentSpace`.

## Verification

- `lake env lean TauCeti/Geometry/Manifold/VectorField/Regularity.lean`
- `lake env lean TauCeti/Geometry/Lie/RightInvariantVectorField.lean`
- `lake env lean TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean`
- `lake build` (7602 jobs)
- `git diff --check`

Roadmap: RepresentationTheory
