### PR TITLE
feat: add the first-order weak Sobolev space

### DIFF
--- a/TauCeti/Analysis/Sobolev/W1p.lean
+++ b/TauCeti/Analysis/Sobolev/W1p.lean
@@ -172,7 +172,7 @@ private theorem norm_gradient_le_ambient (J : Sobolev1JetLp mu Omega p) :
 
 omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
 /-- At exponent two, the Sobolev jet norm is the Hilbert graph norm of its components. -/
-private theorem norm_sq_eq_value_add_gradient_ambient
+private theorem norm_sq_eq_norm_value_sq_add_norm_gradient_sq_ambient
     (J : Sobolev1JetLp mu Omega 2) :
     ‖J‖ ^ 2 = ‖Sobolev1JetLp.value J‖ ^ 2 + ‖Sobolev1JetLp.gradient J‖ ^ 2 := by
   rw [← real_inner_self_eq_norm_sq J,
@@ -473,9 +473,9 @@ theorem W1p.norm_gradient_le (u : W1p mu Omega p) : ‖W1p.gradient u‖ ≤ ‖
 
 omit [FiniteDimensional ℝ E] in
 /-- At exponent two, the norm on `W1p` is the Hilbert graph norm. -/
-theorem W1p.norm_sq_eq_value_add_gradient (u : W1p mu Omega 2) :
+theorem W1p.norm_sq_eq_norm_value_sq_add_norm_gradient_sq (u : W1p mu Omega 2) :
     ‖u‖ ^ 2 = ‖W1p.value u‖ ^ 2 + ‖W1p.gradient u‖ ^ 2 :=
-  norm_sq_eq_value_add_gradient_ambient u.1
+  norm_sq_eq_norm_value_sq_add_norm_gradient_sq_ambient u.1
 
 /-- `W^{1,p}(Ω)` is complete in its value-gradient graph norm. -/
 instance : CompleteSpace (W1p mu Omega p) :=

--- a/TauCeti/Analysis/Sobolev/W1p.lean
+++ b/TauCeti/Analysis/Sobolev/W1p.lean
@@ -69,7 +69,7 @@ variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpa
 
 /-- The fibre of a first-order scalar Sobolev jet: a value and its gradient, with the Euclidean
 product norm. -/
-abbrev Sobolev1Jet (E : Type*) [NormedAddCommGroup E] [InnerProductSpace ℝ E] :=
+abbrev Sobolev1Jet (E : Type*) :=
   WithLp 2 (ℝ × E)
 
 /-- The ambient Bochner `Lᵖ` space of value-gradient jets on `Ω`. -/
@@ -88,14 +88,14 @@ omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= 
 @[simp]
 theorem Sobolev1JetLp.value_apply_ae (J : Sobolev1JetLp mu Omega p) :
     ∀ᵐ x ∂mu.restrict Omega,
-      Sobolev1JetLp.value J x = (WithLp.ofLp (J x)).1 := by
+      Sobolev1JetLp.value J x = WithLp.fst (J x) := by
   simpa [Sobolev1JetLp.value] using (WithLp.fstL 2 ℝ ℝ E).coeFn_compLp J
 
 omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
 @[simp]
 theorem Sobolev1JetLp.gradient_apply_ae (J : Sobolev1JetLp mu Omega p) :
     ∀ᵐ x ∂mu.restrict Omega,
-      Sobolev1JetLp.gradient J x = (WithLp.ofLp (J x)).2 := by
+      Sobolev1JetLp.gradient J x = WithLp.snd (J x) := by
   simpa [Sobolev1JetLp.gradient] using (WithLp.sndL 2 ℝ ℝ E).coeFn_compLp J
 
 /-- The candidate weak Fréchet derivative recorded by the gradient component of a Sobolev jet. -/
@@ -147,15 +147,14 @@ private theorem weakDerivativeTestFunction_memLp (q : ENNReal) (phi : 𝓓(Omega
 
 /-- The compactly supported jet `(∂_v φ, φ v)` used to test whether an `Lᵖ` jet is a weak
 derivative.  Its exponent is Hölder-conjugate to `p`, including the endpoints `p = 1, ∞`. -/
-def weakDerivativeTestJet (p : ENNReal) [Fact (1 <= p)] (phi : 𝓓(Omega, ℝ)) (v : E) :
+def weakDerivativeTestJet (p : ENNReal) (phi : 𝓓(Omega, ℝ)) (v : E) :
     Lp (Sobolev1Jet E) (ENNReal.conjExponent p) (mu.restrict Omega) :=
   (weakDerivativeTestFunction_memLp (mu := mu) (ENNReal.conjExponent p) phi v).toLp
     (weakDerivativeTestFunction phi v)
 
 omit [FiniteDimensional ℝ E] in
 @[simp]
-theorem weakDerivativeTestJet_apply_ae (p : ENNReal) [Fact (1 <= p)]
-    (phi : 𝓓(Omega, ℝ)) (v : E) :
+theorem weakDerivativeTestJet_apply_ae (p : ENNReal) (phi : 𝓓(Omega, ℝ)) (v : E) :
     ∀ᵐ x ∂mu.restrict Omega,
       weakDerivativeTestJet (mu := mu) p phi v x =
         WithLp.toLp 2 (lineDeriv ℝ (phi : E → ℝ) x v, phi x • v) := by

--- a/TauCeti/Analysis/Sobolev/W1p.lean
+++ b/TauCeti/Analysis/Sobolev/W1p.lean
@@ -187,14 +187,14 @@ private theorem norm_sq_eq_norm_value_sq_add_norm_gradient_sq_ambient
   rw [WithLp.prod_inner_apply, WithLp.ofLp_fst, WithLp.ofLp_snd, ← hvalue, ← hgradient]
 
 /-- The candidate weak Fréchet derivative recorded by the gradient component of a Sobolev jet. -/
-def Sobolev1JetLp.weakFDeriv (J : Sobolev1JetLp mu Omega p) : E → E →L[ℝ] ℝ :=
+def Sobolev1JetLp.candidateWeakFDeriv (J : Sobolev1JetLp mu Omega p) : E → E →L[ℝ] ℝ :=
   fun x => innerSL ℝ (Sobolev1JetLp.gradient J x)
 
 omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
 @[simp]
-theorem Sobolev1JetLp.weakFDeriv_apply (J : Sobolev1JetLp mu Omega p) (x v : E) :
-    Sobolev1JetLp.weakFDeriv J x v = ⟪v, Sobolev1JetLp.gradient J x⟫_ℝ := by
-  rw [Sobolev1JetLp.weakFDeriv, innerSL_apply_apply, real_inner_comm]
+theorem Sobolev1JetLp.candidateWeakFDeriv_apply (J : Sobolev1JetLp mu Omega p) (x v : E) :
+    Sobolev1JetLp.candidateWeakFDeriv J x v = ⟪v, Sobolev1JetLp.gradient J x⟫_ℝ := by
+  rw [Sobolev1JetLp.candidateWeakFDeriv, innerSL_apply_apply, real_inner_comm]
 
 private def weakDerivativeTestFunction (phi : 𝓓(Omega, ℝ)) (v : E) (x : E) :
     Sobolev1Jet E :=
@@ -269,7 +269,7 @@ private theorem weakDerivativeTestFunctional_apply (J : Sobolev1JetLp mu Omega p
     (phi : 𝓓(Omega, ℝ)) (v : E) :
     weakDerivativeTestFunctional (mu := mu) p phi v J =
       ∫ x in Omega, (lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x +
-        phi x * Sobolev1JetLp.weakFDeriv J x v) ∂mu := by
+        phi x * Sobolev1JetLp.candidateWeakFDeriv J x v) ∂mu := by
   let _ : (ENNReal.conjExponent p).HolderConjugate p := ENNReal.HolderConjugate.symm
   let _ : Fact (1 <= ENNReal.conjExponent p) :=
     ⟨ENNReal.HolderConjugate.one_le _ p⟩
@@ -281,7 +281,7 @@ private theorem weakDerivativeTestFunctional_apply (J : Sobolev1JetLp mu Omega p
   filter_upwards [weakDerivativeTestJet_apply_ae (mu := mu) p phi v,
     Sobolev1JetLp.value_apply_ae J, Sobolev1JetLp.gradient_apply_ae J] with x htest hvalue hgradient
   rw [htest, innerSL_apply_apply, WithLp.prod_inner_apply,
-    Sobolev1JetLp.weakFDeriv_apply, hvalue, hgradient]
+    Sobolev1JetLp.candidateWeakFDeriv_apply, hvalue, hgradient]
   simp only [WithLp.ofLp_fst, RCLike.inner_apply, conj_trivial, WithLp.ofLp_snd,
     add_right_inj]
   rw [inner_smul_right, real_inner_comm]
@@ -299,7 +299,7 @@ theorem mem_w1pSubmodule_iff (J : Sobolev1JetLp mu Omega p) :
     J ∈ w1pSubmodule mu Omega p ↔
       ∀ (phi : 𝓓(Omega, ℝ)) (v : E),
         ∫ x in Omega, (lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x +
-          phi x * Sobolev1JetLp.weakFDeriv J x v) ∂mu = 0 := by
+          phi x * Sobolev1JetLp.candidateWeakFDeriv J x v) ∂mu = 0 := by
   -- Pass through the private kernel presentation once, keeping it out of the public statement.
   rw [show J ∈ w1pSubmodule mu Omega p ↔
       ∀ (phi : 𝓓(Omega, ℝ)) (v : E),
@@ -336,17 +336,17 @@ its weak Fréchet derivative. -/
 theorem mem_w1pSubmodule_iff_hasWeakFDerivOn (J : Sobolev1JetLp mu Omega p) :
     J ∈ w1pSubmodule mu Omega p ↔
       HasWeakFDerivOn mu Omega (Sobolev1JetLp.value J)
-        (Sobolev1JetLp.weakFDeriv J) := by
+        (Sobolev1JetLp.candidateWeakFDeriv J) := by
   have hvalue : LocallyIntegrableOn (Sobolev1JetLp.value J) Omega mu :=
     locallyIntegrableOn_of_locallyIntegrable_restrict
       ((Lp.memLp (Sobolev1JetLp.value J)).locallyIntegrable Fact.out)
   have hderiv (v : E) : LocallyIntegrableOn
-      (fun x => Sobolev1JetLp.weakFDeriv J x v) Omega mu := by
+      (fun x => Sobolev1JetLp.candidateWeakFDeriv J x v) Omega mu := by
     apply locallyIntegrableOn_of_locallyIntegrable_restrict
     have hinner := (Lp.memLp (Sobolev1JetLp.gradient J)).const_inner (𝕜 := ℝ) v
     exact (hinner.locallyIntegrable Fact.out).congr <| by
       filter_upwards with x
-      simp only [Sobolev1JetLp.weakFDeriv_apply]
+      simp only [Sobolev1JetLp.candidateWeakFDeriv_apply]
   rw [mem_w1pSubmodule_iff]
   constructor
   · intro h
@@ -432,7 +432,7 @@ def W1p.mk (u : Lp ℝ p (mu.restrict Omega)) (g : Lp E p (mu.restrict Omega))
     rw [value_assembleSobolev1JetLp]
     convert h using 1
     funext x
-    rw [Sobolev1JetLp.weakFDeriv, gradient_assembleSobolev1JetLp])⟩
+    rw [Sobolev1JetLp.candidateWeakFDeriv, gradient_assembleSobolev1JetLp])⟩
 
 @[simp]
 theorem W1p.value_mk (u : Lp ℝ p (mu.restrict Omega)) (g : Lp E p (mu.restrict Omega))

--- a/TauCeti/Analysis/Sobolev/W1p.lean
+++ b/TauCeti/Analysis/Sobolev/W1p.lean
@@ -1,0 +1,309 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Sobolev.WeakDeriv
+public import Mathlib.MeasureTheory.Function.Holder
+public import Mathlib.MeasureTheory.Function.L2Space
+public import Mathlib.Analysis.InnerProductSpace.ProdL2
+
+/-!
+# First-order weak Sobolev spaces
+
+This file constructs the first-order, real-valued Sobolev space `W^{1,p}(Ω)` on an open subset
+of a finite-dimensional real inner product space.  An element is an `Lᵖ` value-gradient jet
+`(u, ∇u)` satisfying the distributional integration-by-parts identity from
+`TauCeti.HasWeakFDerivOn`.
+
+The quotient issue is handled at the definition boundary.  Both components of a jet are `Lp`
+classes for `μ.restrict Ω`; the weak relation is imposed by the continuous Hölder pairing with
+the test jet
+
+`(∂_v φ, φ v)`.
+
+Consequently the admissible jets form an intersection of kernels of continuous linear
+functionals.  This makes `TauCeti.W1p` a closed subspace of the ambient Bochner `Lᵖ` space, and
+hence complete.  The theorem `TauCeti.mem_w1pSubmodule_iff_hasWeakFDerivOn` identifies this closed
+subspace definition with the weak-derivative predicate, so the construction does not replace the
+distributional condition by a merely formal closedness assumption.
+
+The pointwise jet uses the Euclidean product norm on `ℝ × E`.  Thus at `p = 2` the inherited norm
+is the usual Hilbert norm
+
+`(∥u∥²₂ + ∥∇u∥²₂)¹⁄²`,
+
+which is the space needed by the energy-method lane of the PDE roadmap.  No boundedness or
+boundary regularity of `Ω` is used.
+
+## Main declarations
+
+* `TauCeti.Sobolev1Jet`: the value-gradient fibre `ℝ × E` with its Euclidean product norm.
+* `TauCeti.weakDerivativeTestJet`: the `Lᶜ` test jet `(∂_v φ, φ v)` dual to an `Lᵖ` jet.
+* `TauCeti.w1pSubmodule`: the closed subspace of jets annihilating every weak-derivative test.
+* `TauCeti.W1p`: the corresponding complete normed space.
+* `TauCeti.mem_w1pSubmodule_iff_hasWeakFDerivOn`: membership is exactly weak
+  differentiability of the value component with the recorded gradient.
+
+## References
+
+This is the first-order part of Lane A.1 of `TauCetiRoadmap/PDE/README.md`.  The graph-space
+construction and completeness argument follow L. C. Evans, *Partial Differential Equations*,
+Chapter 5, §5.2.  The continuous annihilator presentation is the quotient-respecting version of
+the standard proof that weak differentiation is a closed operator on `Lᵖ`.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open MeasureTheory Set TopologicalSpace
+open scoped ContDiff Distributions ENNReal InnerProductSpace
+
+variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
+  {Omega : Opens E} {p : ENNReal} [Fact (1 <= p)]
+
+/-- The fibre of a first-order scalar Sobolev jet: a value and its gradient, with the Euclidean
+product norm. -/
+abbrev Sobolev1Jet (E : Type*) [NormedAddCommGroup E] [InnerProductSpace ℝ E] :=
+  WithLp 2 (ℝ × E)
+
+/-- The ambient Bochner `Lᵖ` space of value-gradient jets on `Ω`. -/
+abbrev Sobolev1JetLp (mu : Measure E) (Omega : Opens E) (p : ENNReal) :=
+  Lp (Sobolev1Jet E) p (mu.restrict Omega)
+
+/-- The value component of an `Lᵖ` Sobolev jet. -/
+def Sobolev1JetLp.value (J : Sobolev1JetLp mu Omega p) : Lp ℝ p (mu.restrict Omega) :=
+  (WithLp.fstL 2 ℝ ℝ E).compLp J
+
+/-- The gradient component of an `Lᵖ` Sobolev jet. -/
+def Sobolev1JetLp.gradient (J : Sobolev1JetLp mu Omega p) : Lp E p (mu.restrict Omega) :=
+  (WithLp.sndL 2 ℝ ℝ E).compLp J
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+@[simp]
+theorem Sobolev1JetLp.value_apply_ae (J : Sobolev1JetLp mu Omega p) :
+    ∀ᵐ x ∂mu.restrict Omega,
+      Sobolev1JetLp.value J x = (WithLp.ofLp (J x)).1 := by
+  simpa [Sobolev1JetLp.value] using (WithLp.fstL 2 ℝ ℝ E).coeFn_compLp J
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+@[simp]
+theorem Sobolev1JetLp.gradient_apply_ae (J : Sobolev1JetLp mu Omega p) :
+    ∀ᵐ x ∂mu.restrict Omega,
+      Sobolev1JetLp.gradient J x = (WithLp.ofLp (J x)).2 := by
+  simpa [Sobolev1JetLp.gradient] using (WithLp.sndL 2 ℝ ℝ E).coeFn_compLp J
+
+/-- The candidate weak Fréchet derivative recorded by the gradient component of a Sobolev jet. -/
+def Sobolev1JetLp.weakFDeriv (J : Sobolev1JetLp mu Omega p) : E → E →L[ℝ] ℝ :=
+  fun x => innerSL ℝ (Sobolev1JetLp.gradient J x)
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+@[simp]
+theorem Sobolev1JetLp.weakFDeriv_apply (J : Sobolev1JetLp mu Omega p) (x v : E) :
+    Sobolev1JetLp.weakFDeriv J x v = ⟪v, Sobolev1JetLp.gradient J x⟫_ℝ := by
+  rw [Sobolev1JetLp.weakFDeriv, innerSL_apply_apply, real_inner_comm]
+
+private def weakDerivativeTestFunction (phi : 𝓓(Omega, ℝ)) (v : E) (x : E) :
+    Sobolev1Jet E :=
+  WithLp.toLp 2 (lineDeriv ℝ (phi : E → ℝ) x v, phi x • v)
+
+omit [FiniteDimensional ℝ E] in
+private theorem weakDerivativeTestFunction_memLp (q : ENNReal) (phi : 𝓓(Omega, ℝ)) (v : E) :
+    MemLp (weakDerivativeTestFunction phi v) q (mu.restrict Omega) := by
+  let dphi : 𝓓(Omega, ℝ) := TestFunction.lineDerivCLM ℝ v phi
+  have hdphi : (dphi : E → ℝ) = fun x => lineDeriv ℝ (phi : E → ℝ) x v := by
+    funext x
+    exact TestFunction.lineDerivCLM_apply_of_le le_top
+  let f : E → Sobolev1Jet E := fun x => WithLp.toLp 2 (dphi x, phi x • v)
+  have hf_cont : Continuous f :=
+    (WithLp.prodContinuousLinearEquiv 2 ℝ ℝ E).symm.continuous.comp
+      (dphi.continuous.prodMk (phi.continuous.smul continuous_const))
+  have hd_support : HasCompactSupport (fun x => WithLp.toLp 2 (dphi x, (0 : E))) :=
+    dphi.hasCompactSupport.mono fun x hx hzero => hx (by simp [hzero])
+  have hv_support : HasCompactSupport (fun x => WithLp.toLp 2 ((0 : ℝ), phi x • v)) :=
+    phi.hasCompactSupport.mono fun x hx hzero => hx (by simp [hzero])
+  have hf_support : HasCompactSupport f := by
+    have hf_eq : f = (fun x => WithLp.toLp 2 (dphi x, (0 : E))) +
+        fun x => WithLp.toLp 2 ((0 : ℝ), phi x • v) := by
+      funext x
+      change WithLp.toLp 2 (dphi x, phi x • v) =
+        WithLp.toLp 2 (dphi x, 0) + WithLp.toLp 2 (0, phi x • v)
+      rw [show (dphi x, phi x • v) =
+          (dphi x, (0 : E)) + ((0 : ℝ), phi x • v) by ext <;> simp]
+      exact (WithLp.prodContinuousLinearEquiv 2 ℝ ℝ E).symm.map_add _ _
+    rw [hf_eq]
+    exact hd_support.add hv_support
+  have hfun : weakDerivativeTestFunction phi v = f := by
+    funext x
+    simp only [weakDerivativeTestFunction, f]
+    rw [congrFun hdphi x]
+  rw [hfun]
+  exact hf_cont.memLp_of_hasCompactSupport (μ := mu.restrict Omega) (p := q) hf_support
+
+/-- The compactly supported jet `(∂_v φ, φ v)` used to test whether an `Lᵖ` jet is a weak
+derivative.  Its exponent is Hölder-conjugate to `p`, including the endpoints `p = 1, ∞`. -/
+def weakDerivativeTestJet (p : ENNReal) [Fact (1 <= p)] (phi : 𝓓(Omega, ℝ)) (v : E) :
+    Lp (Sobolev1Jet E) (ENNReal.conjExponent p) (mu.restrict Omega) :=
+  (weakDerivativeTestFunction_memLp (mu := mu) (ENNReal.conjExponent p) phi v).toLp
+    (weakDerivativeTestFunction phi v)
+
+omit [FiniteDimensional ℝ E] in
+@[simp]
+theorem weakDerivativeTestJet_apply_ae (p : ENNReal) [Fact (1 <= p)]
+    (phi : 𝓓(Omega, ℝ)) (v : E) :
+    ∀ᵐ x ∂mu.restrict Omega,
+      weakDerivativeTestJet (mu := mu) p phi v x =
+        WithLp.toLp 2 (lineDeriv ℝ (phi : E → ℝ) x v, phi x • v) := by
+  filter_upwards [MemLp.coeFn_toLp (weakDerivativeTestFunction_memLp (mu := mu)
+    (ENNReal.conjExponent p) phi v)] with x hx
+  simpa only [weakDerivativeTestJet, weakDerivativeTestFunction] using hx
+
+/-- The continuous functional expressing the weak-derivative identity against `φ` in direction
+`v`.  It pairs the candidate jet with `(∂_v φ, φ v)`. -/
+def weakDerivativeTestFunctional (p : ENNReal) [Fact (1 <= p)]
+    (phi : 𝓓(Omega, ℝ)) (v : E) : Sobolev1JetLp mu Omega p →L[ℝ] ℝ := by
+  let _ : (ENNReal.conjExponent p).HolderConjugate p := ENNReal.HolderConjugate.symm
+  let _ : Fact (1 <= ENNReal.conjExponent p) :=
+    ⟨ENNReal.HolderConjugate.one_le _ p⟩
+  exact ((innerSL ℝ (E := Sobolev1Jet E)).lpPairing (mu.restrict Omega) p
+    (ENNReal.conjExponent p)).flip (weakDerivativeTestJet (mu := mu) p phi v)
+
+omit [FiniteDimensional ℝ E] in
+/-- The test functional is the sum of the value and candidate-gradient terms in the weak
+integration-by-parts identity. -/
+theorem weakDerivativeTestFunctional_apply (J : Sobolev1JetLp mu Omega p)
+    (phi : 𝓓(Omega, ℝ)) (v : E) :
+    weakDerivativeTestFunctional (mu := mu) p phi v J =
+      ∫ x in Omega, (lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x +
+        phi x * Sobolev1JetLp.weakFDeriv J x v) ∂mu := by
+  let _ : (ENNReal.conjExponent p).HolderConjugate p := ENNReal.HolderConjugate.symm
+  let _ : Fact (1 <= ENNReal.conjExponent p) :=
+    ⟨ENNReal.HolderConjugate.one_le _ p⟩
+  change (innerSL ℝ (E := Sobolev1Jet E)).lpPairing (mu.restrict Omega) p
+      (ENNReal.conjExponent p) J (weakDerivativeTestJet (mu := mu) p phi v) = _
+  rw [ContinuousLinearMap.lpPairing_eq_integral]
+  apply integral_congr_ae
+  filter_upwards [weakDerivativeTestJet_apply_ae (mu := mu) p phi v,
+    Sobolev1JetLp.value_apply_ae J, Sobolev1JetLp.gradient_apply_ae J] with x htest hvalue hgradient
+  rw [htest, innerSL_apply_apply, WithLp.prod_inner_apply,
+    Sobolev1JetLp.weakFDeriv_apply, hvalue, hgradient]
+  simp only [WithLp.ofLp_fst, RCLike.inner_apply, conj_trivial, WithLp.ofLp_snd,
+    add_right_inj]
+  rw [inner_smul_right, real_inner_comm]
+
+/-- The first-order weak Sobolev subspace.  It consists of the `Lᵖ` value-gradient jets that
+annihilate every test jet `(∂_v φ, φ v)`. -/
+def w1pSubmodule (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
+    [Fact (1 <= p)] : Submodule ℝ (Sobolev1JetLp mu Omega p) :=
+  ⨅ phi : 𝓓(Omega, ℝ), ⨅ v : E,
+    LinearMap.ker (weakDerivativeTestFunctional (mu := mu) p phi v).toLinearMap
+
+omit [FiniteDimensional ℝ E] in
+/-- Membership in `w1pSubmodule` is the family of weak integration-by-parts identities. -/
+theorem mem_w1pSubmodule_iff (J : Sobolev1JetLp mu Omega p) :
+    J ∈ w1pSubmodule mu Omega p ↔
+      ∀ (phi : 𝓓(Omega, ℝ)) (v : E),
+        weakDerivativeTestFunctional (mu := mu) p phi v J = 0 := by
+  simp [w1pSubmodule]
+
+/-- A jet belongs to `w1pSubmodule` exactly when its value component has the recorded gradient as
+its weak Fréchet derivative. -/
+theorem mem_w1pSubmodule_iff_hasWeakFDerivOn (J : Sobolev1JetLp mu Omega p) :
+    J ∈ w1pSubmodule mu Omega p ↔
+      HasWeakFDerivOn mu Omega (Sobolev1JetLp.value J)
+        (Sobolev1JetLp.weakFDeriv J) := by
+  have hvalue : LocallyIntegrableOn (Sobolev1JetLp.value J) Omega mu :=
+    locallyIntegrableOn_of_locallyIntegrable_restrict
+      ((Lp.memLp (Sobolev1JetLp.value J)).locallyIntegrable Fact.out)
+  have hderiv (v : E) : LocallyIntegrableOn
+      (fun x => Sobolev1JetLp.weakFDeriv J x v) Omega mu := by
+    apply locallyIntegrableOn_of_locallyIntegrable_restrict
+    have hinner := (Lp.memLp (Sobolev1JetLp.gradient J)).const_inner (𝕜 := ℝ) v
+    exact (hinner.locallyIntegrable Fact.out).congr <| by
+      filter_upwards with x
+      simp only [Sobolev1JetLp.weakFDeriv_apply]
+  rw [mem_w1pSubmodule_iff]
+  constructor
+  · intro h
+    rw [hasWeakFDerivOn_iff]
+    intro v
+    rw [hasWeakLineDerivOn_iff_testFunction]
+    refine ⟨inferInstance, hvalue, hderiv v, fun phi => ?_⟩
+    have hleft : Integrable
+        (fun x => lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x) mu := by
+      simpa only [smul_eq_mul] using
+        integrable_lineDeriv_smul_of_locallyIntegrableOn hvalue phi v
+    have hright : Integrable
+        (fun x => phi x * Sobolev1JetLp.weakFDeriv J x v) mu := by
+      simpa only [smul_eq_mul] using integrable_smul_of_locallyIntegrableOn (hderiv v) phi
+    have hsupport : ∀ x, x ∉ (Omega : Set E) →
+        lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x +
+          phi x * Sobolev1JetLp.weakFDeriv J x v = 0 := by
+      intro x hx
+      have hxt : x ∉ tsupport (phi : E → ℝ) := fun hmem => hx (phi.tsupport_subset hmem)
+      rw [lineDeriv_eq_zero_of_notMem_tsupport phi hxt v,
+        image_eq_zero_of_notMem_tsupport hxt]
+      simp
+    have hzero := h phi v
+    rw [weakDerivativeTestFunctional_apply,
+      setIntegral_eq_integral_of_forall_compl_eq_zero hsupport,
+      integral_add hleft hright] at hzero
+    simpa only [smul_eq_mul] using (show
+      (∫ x, lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x ∂mu) =
+        -(∫ x, phi x * Sobolev1JetLp.weakFDeriv J x v ∂mu) by linarith)
+  · intro h
+    rw [hasWeakFDerivOn_iff] at h
+    intro phi v
+    rw [weakDerivativeTestFunctional_apply]
+    have hleft : Integrable
+        (fun x => lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x) mu := by
+      simpa only [smul_eq_mul] using
+        integrable_lineDeriv_smul_of_locallyIntegrableOn (h v).locallyIntegrableOn phi v
+    have hright : Integrable
+        (fun x => phi x * Sobolev1JetLp.weakFDeriv J x v) mu := by
+      simpa only [smul_eq_mul] using
+        integrable_smul_of_locallyIntegrableOn (h v).locallyIntegrableOn_deriv phi
+    rw [setIntegral_eq_integral_of_forall_compl_eq_zero (fun x hx => by
+      have hxt : x ∉ tsupport (phi : E → ℝ) := fun hmem => hx (phi.tsupport_subset hmem)
+      rw [lineDeriv_eq_zero_of_notMem_tsupport phi hxt v,
+        image_eq_zero_of_notMem_tsupport hxt]
+      simp), integral_add hleft hright]
+    have hid := (h v).integral_lineDeriv_smul_eq_neg_integral_smul phi
+    simp only [smul_eq_mul] at hid
+    linarith
+
+omit [FiniteDimensional ℝ E] in
+/-- The first-order weak Sobolev subspace is closed in its ambient Bochner `Lᵖ` space. -/
+theorem isClosed_w1pSubmodule :
+    IsClosed (w1pSubmodule mu Omega p : Set (Sobolev1JetLp mu Omega p)) := by
+  rw [show (w1pSubmodule mu Omega p : Set (Sobolev1JetLp mu Omega p)) =
+      ⋂ phi : 𝓓(Omega, ℝ), ⋂ v : E,
+        (LinearMap.ker (weakDerivativeTestFunctional (mu := mu) p phi v).toLinearMap :
+          Set (Sobolev1JetLp mu Omega p)) by
+    ext J
+    simp [w1pSubmodule]]
+  exact isClosed_iInter fun phi => isClosed_iInter fun v =>
+    ContinuousLinearMap.isClosed_ker (weakDerivativeTestFunctional (mu := mu) p phi v)
+
+/-- The first-order, real-valued weak Sobolev space `W^{1,p}(Ω)`, represented by its value and
+weak gradient. -/
+abbrev W1p (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
+    [Fact (1 <= p)] := w1pSubmodule mu Omega p
+
+/-- The value-gradient pair represented by an element of `W1p` satisfies the weak derivative
+identity. -/
+theorem W1p.hasWeakFDerivOn (u : W1p mu Omega p) :
+    HasWeakFDerivOn mu Omega (Sobolev1JetLp.value u.1)
+      (Sobolev1JetLp.weakFDeriv u.1) :=
+  (mem_w1pSubmodule_iff_hasWeakFDerivOn u.1).mp u.2
+
+/-- `W^{1,p}(Ω)` is complete in its value-gradient graph norm. -/
+instance : CompleteSpace (W1p mu Omega p) :=
+  isClosed_w1pSubmodule.completeSpace_coe
+
+end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p.lean
+++ b/TauCeti/Analysis/Sobolev/W1p.lean
@@ -75,65 +75,43 @@ abbrev Sobolev1Jet (E : Type*) :=
 abbrev Sobolev1JetLp (mu : Measure E) (Omega : Opens E) (p : ENNReal) :=
   Lp (Sobolev1Jet E) p (mu.restrict Omega)
 
+/-- The continuous linear projection from an `Lᵖ` Sobolev jet to its value component. -/
+def Sobolev1JetLp.valueL :
+    Sobolev1JetLp mu Omega p →L[ℝ] Lp ℝ p (mu.restrict Omega) :=
+  (WithLp.fstL 2 ℝ ℝ E).compLpL p (mu.restrict Omega)
+
 /-- The value component of an `Lᵖ` Sobolev jet. -/
 def Sobolev1JetLp.value (J : Sobolev1JetLp mu Omega p) : Lp ℝ p (mu.restrict Omega) :=
-  (WithLp.fstL 2 ℝ ℝ E).compLp J
+  Sobolev1JetLp.valueL J
+
+/-- The continuous linear projection from an `Lᵖ` Sobolev jet to its gradient component. -/
+def Sobolev1JetLp.gradientL :
+    Sobolev1JetLp mu Omega p →L[ℝ] Lp E p (mu.restrict Omega) :=
+  (WithLp.sndL 2 ℝ ℝ E).compLpL p (mu.restrict Omega)
 
 /-- The gradient component of an `Lᵖ` Sobolev jet. -/
 def Sobolev1JetLp.gradient (J : Sobolev1JetLp mu Omega p) : Lp E p (mu.restrict Omega) :=
-  (WithLp.sndL 2 ℝ ℝ E).compLp J
+  Sobolev1JetLp.gradientL J
 
-omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
 @[simp]
 theorem Sobolev1JetLp.value_apply_ae (J : Sobolev1JetLp mu Omega p) :
     ∀ᵐ x ∂mu.restrict Omega,
       Sobolev1JetLp.value J x = WithLp.fst (J x) := by
-  simpa [Sobolev1JetLp.value] using (WithLp.fstL 2 ℝ ℝ E).coeFn_compLp J
+  change ∀ᵐ x ∂mu.restrict Omega,
+    (WithLp.fstL 2 ℝ ℝ E).compLp J x = (WithLp.fstL 2 ℝ ℝ E) (J x)
+  exact (WithLp.fstL 2 ℝ ℝ E).coeFn_compLp J
 
-omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
 @[simp]
 theorem Sobolev1JetLp.gradient_apply_ae (J : Sobolev1JetLp mu Omega p) :
     ∀ᵐ x ∂mu.restrict Omega,
       Sobolev1JetLp.gradient J x = WithLp.snd (J x) := by
-  simpa [Sobolev1JetLp.gradient] using (WithLp.sndL 2 ℝ ℝ E).coeFn_compLp J
+  change ∀ᵐ x ∂mu.restrict Omega,
+    (WithLp.sndL 2 ℝ ℝ E).compLp J x = (WithLp.sndL 2 ℝ ℝ E) (J x)
+  exact (WithLp.sndL 2 ℝ ℝ E).coeFn_compLp J
 
-omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
-@[simp]
-theorem Sobolev1JetLp.value_zero :
-    Sobolev1JetLp.value (0 : Sobolev1JetLp mu Omega p) = 0 := by
-  exact map_zero ((WithLp.fstL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega))
-
-omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
-@[simp]
-theorem Sobolev1JetLp.gradient_zero :
-    Sobolev1JetLp.gradient (0 : Sobolev1JetLp mu Omega p) = 0 := by
-  exact map_zero ((WithLp.sndL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega))
-
-omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
-@[simp]
-theorem Sobolev1JetLp.value_add (J K : Sobolev1JetLp mu Omega p) :
-    Sobolev1JetLp.value (J + K) = Sobolev1JetLp.value J + Sobolev1JetLp.value K := by
-  exact map_add ((WithLp.fstL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega)) J K
-
-omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
-@[simp]
-theorem Sobolev1JetLp.gradient_add (J K : Sobolev1JetLp mu Omega p) :
-    Sobolev1JetLp.gradient (J + K) = Sobolev1JetLp.gradient J + Sobolev1JetLp.gradient K := by
-  exact map_add ((WithLp.sndL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega)) J K
-
-omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
-@[simp]
-theorem Sobolev1JetLp.value_smul (c : ℝ) (J : Sobolev1JetLp mu Omega p) :
-    Sobolev1JetLp.value (c • J) = c • Sobolev1JetLp.value J := by
-  exact map_smul ((WithLp.fstL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega)) c J
-
-omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
-@[simp]
-theorem Sobolev1JetLp.gradient_smul (c : ℝ) (J : Sobolev1JetLp mu Omega p) :
-    Sobolev1JetLp.gradient (c • J) = c • Sobolev1JetLp.gradient J := by
-  exact map_smul ((WithLp.sndL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega)) c J
-
-omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
 /-- Two Sobolev jets are equal when their value and gradient components are equal. -/
 @[ext]
 theorem Sobolev1JetLp.ext {J K : Sobolev1JetLp mu Omega p}
@@ -155,11 +133,59 @@ theorem Sobolev1JetLp.ext {J K : Sobolev1JetLp mu Omega p}
   · simpa only [WithLp.prodContinuousLinearEquiv_apply, WithLp.snd, hJgradient, hKgradient]
       using hgradient
 
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
+/-- The norm of the value component is bounded by the norm of the ambient Sobolev jet. -/
+private theorem norm_value_le_ambient (J : Sobolev1JetLp mu Omega p) :
+    ‖Sobolev1JetLp.value J‖ ≤ ‖J‖ := by
+  have hfst : ‖WithLp.fstL 2 ℝ ℝ E‖ ≤ 1 := by
+    refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one fun x => ?_
+    simpa only [WithLp.fstL_apply, one_mul] using WithLp.norm_fst_le ℝ x
+  have hvalueL : ‖Sobolev1JetLp.valueL (mu := mu) (Omega := Omega) (p := p)‖ ≤ 1 :=
+    (ContinuousLinearMap.norm_compLpL_le (WithLp.fstL 2 ℝ ℝ E)).trans hfst
+  calc
+    ‖Sobolev1JetLp.value J‖ ≤
+        ‖Sobolev1JetLp.valueL (mu := mu) (Omega := Omega) (p := p)‖ * ‖J‖ :=
+      (Sobolev1JetLp.valueL (mu := mu) (Omega := Omega) (p := p)).le_opNorm J
+    _ ≤ 1 * ‖J‖ := mul_le_mul_of_nonneg_right hvalueL (norm_nonneg J)
+    _ = ‖J‖ := one_mul _
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
+/-- The norm of the gradient component is bounded by the norm of the ambient Sobolev jet. -/
+private theorem norm_gradient_le_ambient (J : Sobolev1JetLp mu Omega p) :
+    ‖Sobolev1JetLp.gradient J‖ ≤ ‖J‖ := by
+  have hsnd : ‖WithLp.sndL 2 ℝ ℝ E‖ ≤ 1 := by
+    refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one fun x => ?_
+    simpa only [WithLp.sndL_apply, one_mul] using WithLp.norm_snd_le ℝ x
+  have hgradientL : ‖Sobolev1JetLp.gradientL (mu := mu) (Omega := Omega) (p := p)‖ ≤ 1 :=
+    (ContinuousLinearMap.norm_compLpL_le (WithLp.sndL 2 ℝ ℝ E)).trans hsnd
+  calc
+    ‖Sobolev1JetLp.gradient J‖ ≤
+        ‖Sobolev1JetLp.gradientL (mu := mu) (Omega := Omega) (p := p)‖ * ‖J‖ :=
+      (Sobolev1JetLp.gradientL (mu := mu) (Omega := Omega) (p := p)).le_opNorm J
+    _ ≤ 1 * ‖J‖ := mul_le_mul_of_nonneg_right hgradientL (norm_nonneg J)
+    _ = ‖J‖ := one_mul _
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
+/-- At exponent two, the Sobolev jet norm is the Hilbert graph norm of its components. -/
+private theorem norm_sq_eq_value_add_gradient_ambient
+    (J : Sobolev1JetLp mu Omega 2) :
+    ‖J‖ ^ 2 = ‖Sobolev1JetLp.value J‖ ^ 2 + ‖Sobolev1JetLp.gradient J‖ ^ 2 := by
+  rw [← real_inner_self_eq_norm_sq J,
+    ← real_inner_self_eq_norm_sq (Sobolev1JetLp.value J),
+    ← real_inner_self_eq_norm_sq (Sobolev1JetLp.gradient J),
+    L2.inner_def, L2.inner_def, L2.inner_def,
+    ← integral_add (L2.integrable_inner (Sobolev1JetLp.value J) (Sobolev1JetLp.value J))
+      (L2.integrable_inner (Sobolev1JetLp.gradient J) (Sobolev1JetLp.gradient J))]
+  apply integral_congr_ae
+  filter_upwards [Sobolev1JetLp.value_apply_ae J,
+    Sobolev1JetLp.gradient_apply_ae J] with x hvalue hgradient
+  rw [WithLp.prod_inner_apply, WithLp.ofLp_fst, WithLp.ofLp_snd, ← hvalue, ← hgradient]
+
 /-- The candidate weak Fréchet derivative recorded by the gradient component of a Sobolev jet. -/
 def Sobolev1JetLp.weakFDeriv (J : Sobolev1JetLp mu Omega p) : E → E →L[ℝ] ℝ :=
   fun x => innerSL ℝ (Sobolev1JetLp.gradient J x)
 
-omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
 @[simp]
 theorem Sobolev1JetLp.weakFDeriv_apply (J : Sobolev1JetLp mu Omega p) (x v : E) :
     Sobolev1JetLp.weakFDeriv J x v = ⟪v, Sobolev1JetLp.gradient J x⟫_ℝ := by
@@ -258,9 +284,9 @@ private theorem weakDerivativeTestFunctional_apply (J : Sobolev1JetLp mu Omega p
 /-- The first-order weak Sobolev subspace.  It consists of the `Lᵖ` value-gradient jets that
 annihilate every test jet `(∂_v φ, φ v)`. -/
 def w1pSubmodule (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
-    [Fact (1 <= p)] : Submodule ℝ (Sobolev1JetLp mu Omega p) :=
+    [Fact (1 <= p)] : ClosedSubmodule ℝ (Sobolev1JetLp mu Omega p) :=
   ⨅ phi : 𝓓(Omega, ℝ), ⨅ v : E,
-    LinearMap.ker (weakDerivativeTestFunctional (mu := mu) p phi v).toLinearMap
+    (⊥ : ClosedSubmodule ℝ ℝ).comap (weakDerivativeTestFunctional (mu := mu) p phi v)
 
 omit [FiniteDimensional ℝ E] in
 /-- Membership in `w1pSubmodule` is the family of weak integration-by-parts identities. -/
@@ -275,6 +301,30 @@ theorem mem_w1pSubmodule_iff (J : Sobolev1JetLp mu Omega p) :
         weakDerivativeTestFunctional (mu := mu) p phi v J = 0 by
     simp [w1pSubmodule]]
   simp only [weakDerivativeTestFunctional_apply]
+
+omit [FiniteDimensional ℝ E] [mu.IsAddHaarMeasure] in
+private theorem testIntegral_eq_zero_iff
+    (f f' : E → ℝ) (hf : LocallyIntegrableOn f Omega mu)
+    (hf' : LocallyIntegrableOn f' Omega mu) (phi : 𝓓(Omega, ℝ)) (v : E) :
+    (∫ x in Omega,
+        lineDeriv ℝ (phi : E → ℝ) x v * f x + phi x * f' x ∂mu) = 0 ↔
+      (∫ x, lineDeriv ℝ (phi : E → ℝ) x v • f x ∂mu) =
+        -(∫ x, phi x • f' x ∂mu) := by
+  have hleft : Integrable (fun x => lineDeriv ℝ (phi : E → ℝ) x v * f x) mu := by
+    simpa only [smul_eq_mul] using integrable_lineDeriv_smul_of_locallyIntegrableOn hf phi v
+  have hright : Integrable (fun x => phi x * f' x) mu := by
+    simpa only [smul_eq_mul] using integrable_smul_of_locallyIntegrableOn hf' phi
+  have hsupport : ∀ x, x ∉ (Omega : Set E) →
+      lineDeriv ℝ (phi : E → ℝ) x v * f x + phi x * f' x = 0 := by
+    intro x hx
+    have hxt : x ∉ tsupport (phi : E → ℝ) := fun hmem => hx (phi.tsupport_subset hmem)
+    rw [lineDeriv_eq_zero_of_notMem_tsupport phi hxt v,
+      image_eq_zero_of_notMem_tsupport hxt]
+    simp
+  rw [setIntegral_eq_integral_of_forall_compl_eq_zero hsupport,
+    integral_add hleft hright]
+  simp only [smul_eq_mul]
+  constructor <;> intro h <;> linarith
 
 /-- A jet belongs to `w1pSubmodule` exactly when its value component has the recorded gradient as
 its weak Fréchet derivative. -/
@@ -299,81 +349,71 @@ theorem mem_w1pSubmodule_iff_hasWeakFDerivOn (J : Sobolev1JetLp mu Omega p) :
     intro v
     rw [hasWeakLineDerivOn_iff_testFunction]
     refine ⟨inferInstance, hvalue, hderiv v, fun phi => ?_⟩
-    have hleft : Integrable
-        (fun x => lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x) mu := by
-      simpa only [smul_eq_mul] using
-        integrable_lineDeriv_smul_of_locallyIntegrableOn hvalue phi v
-    have hright : Integrable
-        (fun x => phi x * Sobolev1JetLp.weakFDeriv J x v) mu := by
-      simpa only [smul_eq_mul] using integrable_smul_of_locallyIntegrableOn (hderiv v) phi
-    have hsupport : ∀ x, x ∉ (Omega : Set E) →
-        lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x +
-          phi x * Sobolev1JetLp.weakFDeriv J x v = 0 := by
-      intro x hx
-      have hxt : x ∉ tsupport (phi : E → ℝ) := fun hmem => hx (phi.tsupport_subset hmem)
-      rw [lineDeriv_eq_zero_of_notMem_tsupport phi hxt v,
-        image_eq_zero_of_notMem_tsupport hxt]
-      simp
-    have hzero := h phi v
-    rw [setIntegral_eq_integral_of_forall_compl_eq_zero hsupport,
-      integral_add hleft hright] at hzero
-    -- Rearrange the scalar zero-sum identity after rewriting both integrals out of set form.
-    simpa only [smul_eq_mul] using (show
-      (∫ x, lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x ∂mu) =
-        -(∫ x, phi x * Sobolev1JetLp.weakFDeriv J x v ∂mu) by linarith)
+    exact (testIntegral_eq_zero_iff _ _ hvalue (hderiv v) phi v).mp (h phi v)
   · intro h
     rw [hasWeakFDerivOn_iff] at h
     intro phi v
-    have hleft : Integrable
-        (fun x => lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x) mu := by
-      simpa only [smul_eq_mul] using
-        integrable_lineDeriv_smul_of_locallyIntegrableOn (h v).locallyIntegrableOn phi v
-    have hright : Integrable
-        (fun x => phi x * Sobolev1JetLp.weakFDeriv J x v) mu := by
-      simpa only [smul_eq_mul] using
-        integrable_smul_of_locallyIntegrableOn (h v).locallyIntegrableOn_deriv phi
-    rw [setIntegral_eq_integral_of_forall_compl_eq_zero (fun x hx => by
-      have hxt : x ∉ tsupport (phi : E → ℝ) := fun hmem => hx (phi.tsupport_subset hmem)
-      rw [lineDeriv_eq_zero_of_notMem_tsupport phi hxt v,
-        image_eq_zero_of_notMem_tsupport hxt]
-      simp), integral_add hleft hright]
-    have hid := (h v).integral_lineDeriv_smul_eq_neg_integral_smul phi
-    simp only [smul_eq_mul] at hid
-    linarith
+    exact (testIntegral_eq_zero_iff _ _ (h v).locallyIntegrableOn
+      (h v).locallyIntegrableOn_deriv phi v).mpr
+        ((h v).integral_lineDeriv_smul_eq_neg_integral_smul phi)
 
 omit [FiniteDimensional ℝ E] in
 /-- The first-order weak Sobolev subspace is closed in its ambient Bochner `Lᵖ` space. -/
 theorem isClosed_w1pSubmodule :
-    IsClosed (w1pSubmodule mu Omega p : Set (Sobolev1JetLp mu Omega p)) := by
-  -- Expose the coerced intersection of kernels so closedness follows from the continuous kernels.
-  rw [show (w1pSubmodule mu Omega p : Set (Sobolev1JetLp mu Omega p)) =
-      ⋂ phi : 𝓓(Omega, ℝ), ⋂ v : E,
-        (LinearMap.ker (weakDerivativeTestFunctional (mu := mu) p phi v).toLinearMap :
-          Set (Sobolev1JetLp mu Omega p)) by
-    ext J
-    simp [w1pSubmodule]]
-  exact isClosed_iInter fun phi => isClosed_iInter fun v =>
-    ContinuousLinearMap.isClosed_ker (weakDerivativeTestFunctional (mu := mu) p phi v)
+    IsClosed (w1pSubmodule mu Omega p : Set (Sobolev1JetLp mu Omega p)) :=
+  (w1pSubmodule mu Omega p).isClosed
 
 /-- The first-order, real-valued weak Sobolev space `W^{1,p}(Ω)`, represented by its value and
 weak gradient. -/
 abbrev W1p (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
-    [Fact (1 <= p)] := w1pSubmodule mu Omega p
+    [Fact (1 <= p)] := (w1pSubmodule mu Omega p).toSubmodule
+
+/-- The continuous linear projection from `W1p` to its `Lᵖ` value component. -/
+def W1p.valueL : W1p mu Omega p →L[ℝ] Lp ℝ p (mu.restrict Omega) :=
+  Sobolev1JetLp.valueL.comp (w1pSubmodule mu Omega p).toSubmodule.subtypeL
+
+/-- The `Lᵖ` value component of a Sobolev function. -/
+def W1p.value (u : W1p mu Omega p) : Lp ℝ p (mu.restrict Omega) :=
+  W1p.valueL u
+
+/-- The continuous linear projection from `W1p` to its `Lᵖ` weak-gradient component. -/
+def W1p.gradientL : W1p mu Omega p →L[ℝ] Lp E p (mu.restrict Omega) :=
+  Sobolev1JetLp.gradientL.comp (w1pSubmodule mu Omega p).toSubmodule.subtypeL
+
+/-- The `Lᵖ` weak-gradient component of a Sobolev function. -/
+def W1p.gradient (u : W1p mu Omega p) : Lp E p (mu.restrict Omega) :=
+  W1p.gradientL u
 
 omit [FiniteDimensional ℝ E] in
 /-- Two Sobolev functions are equal when their value and weak-gradient components are equal. -/
 @[ext]
 theorem W1p.ext {u v : W1p mu Omega p}
-    (hvalue : Sobolev1JetLp.value u.1 = Sobolev1JetLp.value v.1)
-    (hgradient : Sobolev1JetLp.gradient u.1 = Sobolev1JetLp.gradient v.1) : u = v :=
+    (hvalue : W1p.value u = W1p.value v)
+    (hgradient : W1p.gradient u = W1p.gradient v) : u = v :=
   Subtype.ext (Sobolev1JetLp.ext hvalue hgradient)
 
 /-- The value-gradient pair represented by an element of `W1p` satisfies the weak derivative
 identity. -/
 theorem W1p.hasWeakFDerivOn (u : W1p mu Omega p) :
-    HasWeakFDerivOn mu Omega (Sobolev1JetLp.value u.1)
-      (Sobolev1JetLp.weakFDeriv u.1) :=
+    HasWeakFDerivOn mu Omega (W1p.value u)
+      (fun x => innerSL ℝ (W1p.gradient u x)) :=
   (mem_w1pSubmodule_iff_hasWeakFDerivOn u.1).mp u.2
+
+omit [FiniteDimensional ℝ E] in
+/-- The norm of a Sobolev function controls the norm of its value component. -/
+theorem W1p.norm_value_le (u : W1p mu Omega p) : ‖W1p.value u‖ ≤ ‖u‖ :=
+  norm_value_le_ambient u.1
+
+omit [FiniteDimensional ℝ E] in
+/-- The norm of a Sobolev function controls the norm of its weak gradient. -/
+theorem W1p.norm_gradient_le (u : W1p mu Omega p) : ‖W1p.gradient u‖ ≤ ‖u‖ :=
+  norm_gradient_le_ambient u.1
+
+omit [FiniteDimensional ℝ E] in
+/-- At exponent two, the norm on `W1p` is the Hilbert graph norm. -/
+theorem W1p.norm_sq_eq_value_add_gradient (u : W1p mu Omega 2) :
+    ‖u‖ ^ 2 = ‖W1p.value u‖ ^ 2 + ‖W1p.gradient u‖ ^ 2 :=
+  norm_sq_eq_value_add_gradient_ambient u.1
 
 /-- `W^{1,p}(Ω)` is complete in its value-gradient graph norm. -/
 instance : CompleteSpace (W1p mu Omega p) :=

--- a/TauCeti/Analysis/Sobolev/W1p.lean
+++ b/TauCeti/Analysis/Sobolev/W1p.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.Analysis.Sobolev.WeakDeriv
 public import Mathlib.MeasureTheory.Function.Holder
 public import Mathlib.MeasureTheory.Function.L2Space
+public import Mathlib.MeasureTheory.SpecificCodomains.WithLp
 public import Mathlib.Analysis.InnerProductSpace.ProdL2
 
 /-!
@@ -98,6 +99,8 @@ omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
 theorem Sobolev1JetLp.value_apply_ae (J : Sobolev1JetLp mu Omega p) :
     ∀ᵐ x ∂mu.restrict Omega,
       Sobolev1JetLp.value J x = WithLp.fst (J x) := by
+  -- `coeFn_compLp` is stated for the unbundled `compLp`; expose that implementation of
+  -- `valueL` so its pointwise theorem applies.
   change ∀ᵐ x ∂mu.restrict Omega,
     (WithLp.fstL 2 ℝ ℝ E).compLp J x = (WithLp.fstL 2 ℝ ℝ E) (J x)
   exact (WithLp.fstL 2 ℝ ℝ E).coeFn_compLp J
@@ -107,6 +110,8 @@ omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
 theorem Sobolev1JetLp.gradient_apply_ae (J : Sobolev1JetLp mu Omega p) :
     ∀ᵐ x ∂mu.restrict Omega,
       Sobolev1JetLp.gradient J x = WithLp.snd (J x) := by
+  -- As for `value_apply_ae`, expose the unbundled `compLp` implementation consumed by
+  -- Mathlib's pointwise coercion theorem.
   change ∀ᵐ x ∂mu.restrict Omega,
     (WithLp.sndL 2 ℝ ℝ E).compLp J x = (WithLp.sndL 2 ℝ ℝ E) (J x)
   exact (WithLp.sndL 2 ℝ ℝ E).coeFn_compLp J
@@ -357,12 +362,6 @@ theorem mem_w1pSubmodule_iff_hasWeakFDerivOn (J : Sobolev1JetLp mu Omega p) :
       (h v).locallyIntegrableOn_deriv phi v).mpr
         ((h v).integral_lineDeriv_smul_eq_neg_integral_smul phi)
 
-omit [FiniteDimensional ℝ E] in
-/-- The first-order weak Sobolev subspace is closed in its ambient Bochner `Lᵖ` space. -/
-theorem isClosed_w1pSubmodule :
-    IsClosed (w1pSubmodule mu Omega p : Set (Sobolev1JetLp mu Omega p)) :=
-  (w1pSubmodule mu Omega p).isClosed
-
 /-- The first-order, real-valued weak Sobolev space `W^{1,p}(Ω)`, represented by its value and
 weak gradient. -/
 abbrev W1p (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
@@ -383,6 +382,69 @@ def W1p.gradientL : W1p mu Omega p →L[ℝ] Lp E p (mu.restrict Omega) :=
 /-- The `Lᵖ` weak-gradient component of a Sobolev function. -/
 def W1p.gradient (u : W1p mu Omega p) : Lp E p (mu.restrict Omega) :=
   W1p.gradientL u
+
+omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure]
+    [Fact (1 <= p)] in
+private theorem memLp_assembleSobolev1Jet (u : Lp ℝ p (mu.restrict Omega))
+    (g : Lp E p (mu.restrict Omega)) :
+    MemLp (fun x => WithLp.toLp 2 (u x, g x)) p (mu.restrict Omega) := by
+  apply MemLp.of_fst_of_snd_prodLp
+  exact ⟨by simpa only [WithLp.toLp_fst] using Lp.memLp u,
+    by simpa only [WithLp.toLp_snd] using Lp.memLp g⟩
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
+private def assembleSobolev1JetLp (u : Lp ℝ p (mu.restrict Omega))
+    (g : Lp E p (mu.restrict Omega)) : Sobolev1JetLp mu Omega p :=
+  (memLp_assembleSobolev1Jet u g).toLp fun x => WithLp.toLp 2 (u x, g x)
+
+omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure]
+    [Fact (1 <= p)] in
+private theorem assembleSobolev1JetLp_apply_ae (u : Lp ℝ p (mu.restrict Omega))
+    (g : Lp E p (mu.restrict Omega)) :
+    ∀ᵐ x ∂mu.restrict Omega,
+      assembleSobolev1JetLp u g x = WithLp.toLp 2 (u x, g x) := by
+  exact (memLp_assembleSobolev1Jet u g).coeFn_toLp
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
+@[simp]
+private theorem value_assembleSobolev1JetLp (u : Lp ℝ p (mu.restrict Omega))
+    (g : Lp E p (mu.restrict Omega)) :
+    Sobolev1JetLp.value (assembleSobolev1JetLp u g) = u := by
+  apply Lp.ext
+  filter_upwards [Sobolev1JetLp.value_apply_ae (assembleSobolev1JetLp u g),
+    assembleSobolev1JetLp_apply_ae u g] with x hvalue hassemble
+  simpa only [hassemble, WithLp.toLp_fst] using hvalue
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
+@[simp]
+private theorem gradient_assembleSobolev1JetLp (u : Lp ℝ p (mu.restrict Omega))
+    (g : Lp E p (mu.restrict Omega)) :
+    Sobolev1JetLp.gradient (assembleSobolev1JetLp u g) = g := by
+  apply Lp.ext
+  filter_upwards [Sobolev1JetLp.gradient_apply_ae (assembleSobolev1JetLp u g),
+    assembleSobolev1JetLp_apply_ae u g] with x hgradient hassemble
+  simpa only [hassemble, WithLp.toLp_snd] using hgradient
+
+/-- Construct a Sobolev function from its `Lᵖ` value and weak-gradient components. -/
+def W1p.mk (u : Lp ℝ p (mu.restrict Omega)) (g : Lp E p (mu.restrict Omega))
+    (h : HasWeakFDerivOn mu Omega u (fun x => innerSL ℝ (g x))) : W1p mu Omega p :=
+  ⟨assembleSobolev1JetLp u g, (mem_w1pSubmodule_iff_hasWeakFDerivOn _).mpr (by
+    rw [value_assembleSobolev1JetLp]
+    convert h using 1
+    funext x
+    rw [Sobolev1JetLp.weakFDeriv, gradient_assembleSobolev1JetLp])⟩
+
+@[simp]
+theorem W1p.value_mk (u : Lp ℝ p (mu.restrict Omega)) (g : Lp E p (mu.restrict Omega))
+    (h : HasWeakFDerivOn mu Omega u (fun x => innerSL ℝ (g x))) :
+    W1p.value (W1p.mk u g h) = u :=
+  value_assembleSobolev1JetLp u g
+
+@[simp]
+theorem W1p.gradient_mk (u : Lp ℝ p (mu.restrict Omega)) (g : Lp E p (mu.restrict Omega))
+    (h : HasWeakFDerivOn mu Omega u (fun x => innerSL ℝ (g x))) :
+    W1p.gradient (W1p.mk u g h) = g :=
+  gradient_assembleSobolev1JetLp u g
 
 omit [FiniteDimensional ℝ E] in
 /-- Two Sobolev functions are equal when their value and weak-gradient components are equal. -/
@@ -417,6 +479,6 @@ theorem W1p.norm_sq_eq_value_add_gradient (u : W1p mu Omega 2) :
 
 /-- `W^{1,p}(Ω)` is complete in its value-gradient graph norm. -/
 instance : CompleteSpace (W1p mu Omega p) :=
-  isClosed_w1pSubmodule.completeSpace_coe
+  (w1pSubmodule mu Omega p).isClosed.completeSpace_coe
 
 end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p.lean
+++ b/TauCeti/Analysis/Sobolev/W1p.lean
@@ -40,7 +40,6 @@ boundary regularity of `Ω` is used.
 ## Main declarations
 
 * `TauCeti.Sobolev1Jet`: the value-gradient fibre `ℝ × E` with its Euclidean product norm.
-* `TauCeti.weakDerivativeTestJet`: the `Lᶜ` test jet `(∂_v φ, φ v)` dual to an `Lᵖ` jet.
 * `TauCeti.w1pSubmodule`: the closed subspace of jets annihilating every weak-derivative test.
 * `TauCeti.W1p`: the corresponding complete normed space.
 * `TauCeti.mem_w1pSubmodule_iff_hasWeakFDerivOn`: membership is exactly weak
@@ -98,6 +97,64 @@ theorem Sobolev1JetLp.gradient_apply_ae (J : Sobolev1JetLp mu Omega p) :
       Sobolev1JetLp.gradient J x = WithLp.snd (J x) := by
   simpa [Sobolev1JetLp.gradient] using (WithLp.sndL 2 ℝ ℝ E).coeFn_compLp J
 
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+@[simp]
+theorem Sobolev1JetLp.value_zero :
+    Sobolev1JetLp.value (0 : Sobolev1JetLp mu Omega p) = 0 := by
+  exact map_zero ((WithLp.fstL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega))
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+@[simp]
+theorem Sobolev1JetLp.gradient_zero :
+    Sobolev1JetLp.gradient (0 : Sobolev1JetLp mu Omega p) = 0 := by
+  exact map_zero ((WithLp.sndL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega))
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+@[simp]
+theorem Sobolev1JetLp.value_add (J K : Sobolev1JetLp mu Omega p) :
+    Sobolev1JetLp.value (J + K) = Sobolev1JetLp.value J + Sobolev1JetLp.value K := by
+  exact map_add ((WithLp.fstL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega)) J K
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+@[simp]
+theorem Sobolev1JetLp.gradient_add (J K : Sobolev1JetLp mu Omega p) :
+    Sobolev1JetLp.gradient (J + K) = Sobolev1JetLp.gradient J + Sobolev1JetLp.gradient K := by
+  exact map_add ((WithLp.sndL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega)) J K
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+@[simp]
+theorem Sobolev1JetLp.value_smul (c : ℝ) (J : Sobolev1JetLp mu Omega p) :
+    Sobolev1JetLp.value (c • J) = c • Sobolev1JetLp.value J := by
+  exact map_smul ((WithLp.fstL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega)) c J
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+@[simp]
+theorem Sobolev1JetLp.gradient_smul (c : ℝ) (J : Sobolev1JetLp mu Omega p) :
+    Sobolev1JetLp.gradient (c • J) = c • Sobolev1JetLp.gradient J := by
+  exact map_smul ((WithLp.sndL 2 ℝ ℝ E).compLpₗ p (mu.restrict Omega)) c J
+
+omit [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] [Fact (1 <= p)] in
+/-- Two Sobolev jets are equal when their value and gradient components are equal. -/
+@[ext]
+theorem Sobolev1JetLp.ext {J K : Sobolev1JetLp mu Omega p}
+    (hvalue : Sobolev1JetLp.value J = Sobolev1JetLp.value K)
+    (hgradient : Sobolev1JetLp.gradient J = Sobolev1JetLp.gradient K) : J = K := by
+  apply Lp.ext
+  have hvalue_ae : Sobolev1JetLp.value J =ᵐ[mu.restrict Omega]
+      Sobolev1JetLp.value K := by
+    rwa [← Lp.ext_iff]
+  have hgradient_ae : Sobolev1JetLp.gradient J =ᵐ[mu.restrict Omega]
+      Sobolev1JetLp.gradient K := by
+    rwa [← Lp.ext_iff]
+  filter_upwards [Sobolev1JetLp.value_apply_ae J, Sobolev1JetLp.value_apply_ae K,
+    Sobolev1JetLp.gradient_apply_ae J, Sobolev1JetLp.gradient_apply_ae K,
+    hvalue_ae, hgradient_ae] with x hJvalue hKvalue hJgradient hKgradient hvalue hgradient
+  apply (WithLp.prodContinuousLinearEquiv 2 ℝ ℝ E).injective
+  apply Prod.ext
+  · simpa only [WithLp.prodContinuousLinearEquiv_apply, WithLp.fst, hJvalue, hKvalue] using hvalue
+  · simpa only [WithLp.prodContinuousLinearEquiv_apply, WithLp.snd, hJgradient, hKgradient]
+      using hgradient
+
 /-- The candidate weak Fréchet derivative recorded by the gradient component of a Sobolev jet. -/
 def Sobolev1JetLp.weakFDeriv (J : Sobolev1JetLp mu Omega p) : E → E →L[ℝ] ℝ :=
   fun x => innerSL ℝ (Sobolev1JetLp.gradient J x)
@@ -131,8 +188,10 @@ private theorem weakDerivativeTestFunction_memLp (q : ENNReal) (phi : 𝓓(Omega
     have hf_eq : f = (fun x => WithLp.toLp 2 (dphi x, (0 : E))) +
         fun x => WithLp.toLp 2 ((0 : ℝ), phi x • v) := by
       funext x
+      -- Reduce pointwise addition to the product equality consumed by the linear equivalence.
       change WithLp.toLp 2 (dphi x, phi x • v) =
         WithLp.toLp 2 (dphi x, 0) + WithLp.toLp 2 (0, phi x • v)
+      -- This product identity supplies the input to `map_add`; `WithLp.toLp` is otherwise opaque.
       rw [show (dphi x, phi x • v) =
           (dphi x, (0 : E)) + ((0 : ℝ), phi x • v) by ext <;> simp]
       exact (WithLp.prodContinuousLinearEquiv 2 ℝ ℝ E).symm.map_add _ _
@@ -147,14 +206,14 @@ private theorem weakDerivativeTestFunction_memLp (q : ENNReal) (phi : 𝓓(Omega
 
 /-- The compactly supported jet `(∂_v φ, φ v)` used to test whether an `Lᵖ` jet is a weak
 derivative.  Its exponent is Hölder-conjugate to `p`, including the endpoints `p = 1, ∞`. -/
-def weakDerivativeTestJet (p : ENNReal) (phi : 𝓓(Omega, ℝ)) (v : E) :
+private def weakDerivativeTestJet (p : ENNReal) (phi : 𝓓(Omega, ℝ)) (v : E) :
     Lp (Sobolev1Jet E) (ENNReal.conjExponent p) (mu.restrict Omega) :=
   (weakDerivativeTestFunction_memLp (mu := mu) (ENNReal.conjExponent p) phi v).toLp
     (weakDerivativeTestFunction phi v)
 
 omit [FiniteDimensional ℝ E] in
 @[simp]
-theorem weakDerivativeTestJet_apply_ae (p : ENNReal) (phi : 𝓓(Omega, ℝ)) (v : E) :
+private theorem weakDerivativeTestJet_apply_ae (p : ENNReal) (phi : 𝓓(Omega, ℝ)) (v : E) :
     ∀ᵐ x ∂mu.restrict Omega,
       weakDerivativeTestJet (mu := mu) p phi v x =
         WithLp.toLp 2 (lineDeriv ℝ (phi : E → ℝ) x v, phi x • v) := by
@@ -164,7 +223,7 @@ theorem weakDerivativeTestJet_apply_ae (p : ENNReal) (phi : 𝓓(Omega, ℝ)) (v
 
 /-- The continuous functional expressing the weak-derivative identity against `φ` in direction
 `v`.  It pairs the candidate jet with `(∂_v φ, φ v)`. -/
-def weakDerivativeTestFunctional (p : ENNReal) [Fact (1 <= p)]
+private def weakDerivativeTestFunctional (p : ENNReal) [Fact (1 <= p)]
     (phi : 𝓓(Omega, ℝ)) (v : E) : Sobolev1JetLp mu Omega p →L[ℝ] ℝ := by
   let _ : (ENNReal.conjExponent p).HolderConjugate p := ENNReal.HolderConjugate.symm
   let _ : Fact (1 <= ENNReal.conjExponent p) :=
@@ -175,7 +234,7 @@ def weakDerivativeTestFunctional (p : ENNReal) [Fact (1 <= p)]
 omit [FiniteDimensional ℝ E] in
 /-- The test functional is the sum of the value and candidate-gradient terms in the weak
 integration-by-parts identity. -/
-theorem weakDerivativeTestFunctional_apply (J : Sobolev1JetLp mu Omega p)
+private theorem weakDerivativeTestFunctional_apply (J : Sobolev1JetLp mu Omega p)
     (phi : 𝓓(Omega, ℝ)) (v : E) :
     weakDerivativeTestFunctional (mu := mu) p phi v J =
       ∫ x in Omega, (lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x +
@@ -183,6 +242,7 @@ theorem weakDerivativeTestFunctional_apply (J : Sobolev1JetLp mu Omega p)
   let _ : (ENNReal.conjExponent p).HolderConjugate p := ENNReal.HolderConjugate.symm
   let _ : Fact (1 <= ENNReal.conjExponent p) :=
     ⟨ENNReal.HolderConjugate.one_le _ p⟩
+  -- Unfold the private test functional to the `lpPairing` form required by its integral theorem.
   change (innerSL ℝ (E := Sobolev1Jet E)).lpPairing (mu.restrict Omega) p
       (ENNReal.conjExponent p) J (weakDerivativeTestJet (mu := mu) p phi v) = _
   rw [ContinuousLinearMap.lpPairing_eq_integral]
@@ -207,8 +267,14 @@ omit [FiniteDimensional ℝ E] in
 theorem mem_w1pSubmodule_iff (J : Sobolev1JetLp mu Omega p) :
     J ∈ w1pSubmodule mu Omega p ↔
       ∀ (phi : 𝓓(Omega, ℝ)) (v : E),
-        weakDerivativeTestFunctional (mu := mu) p phi v J = 0 := by
-  simp [w1pSubmodule]
+        ∫ x in Omega, (lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x +
+          phi x * Sobolev1JetLp.weakFDeriv J x v) ∂mu = 0 := by
+  -- Pass through the private kernel presentation once, keeping it out of the public statement.
+  rw [show J ∈ w1pSubmodule mu Omega p ↔
+      ∀ (phi : 𝓓(Omega, ℝ)) (v : E),
+        weakDerivativeTestFunctional (mu := mu) p phi v J = 0 by
+    simp [w1pSubmodule]]
+  simp only [weakDerivativeTestFunctional_apply]
 
 /-- A jet belongs to `w1pSubmodule` exactly when its value component has the recorded gradient as
 its weak Fréchet derivative. -/
@@ -249,16 +315,15 @@ theorem mem_w1pSubmodule_iff_hasWeakFDerivOn (J : Sobolev1JetLp mu Omega p) :
         image_eq_zero_of_notMem_tsupport hxt]
       simp
     have hzero := h phi v
-    rw [weakDerivativeTestFunctional_apply,
-      setIntegral_eq_integral_of_forall_compl_eq_zero hsupport,
+    rw [setIntegral_eq_integral_of_forall_compl_eq_zero hsupport,
       integral_add hleft hright] at hzero
+    -- Rearrange the scalar zero-sum identity after rewriting both integrals out of set form.
     simpa only [smul_eq_mul] using (show
       (∫ x, lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x ∂mu) =
         -(∫ x, phi x * Sobolev1JetLp.weakFDeriv J x v ∂mu) by linarith)
   · intro h
     rw [hasWeakFDerivOn_iff] at h
     intro phi v
-    rw [weakDerivativeTestFunctional_apply]
     have hleft : Integrable
         (fun x => lineDeriv ℝ (phi : E → ℝ) x v * Sobolev1JetLp.value J x) mu := by
       simpa only [smul_eq_mul] using
@@ -280,6 +345,7 @@ omit [FiniteDimensional ℝ E] in
 /-- The first-order weak Sobolev subspace is closed in its ambient Bochner `Lᵖ` space. -/
 theorem isClosed_w1pSubmodule :
     IsClosed (w1pSubmodule mu Omega p : Set (Sobolev1JetLp mu Omega p)) := by
+  -- Expose the coerced intersection of kernels so closedness follows from the continuous kernels.
   rw [show (w1pSubmodule mu Omega p : Set (Sobolev1JetLp mu Omega p)) =
       ⋂ phi : 𝓓(Omega, ℝ), ⋂ v : E,
         (LinearMap.ker (weakDerivativeTestFunctional (mu := mu) p phi v).toLinearMap :
@@ -293,6 +359,14 @@ theorem isClosed_w1pSubmodule :
 weak gradient. -/
 abbrev W1p (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
     [Fact (1 <= p)] := w1pSubmodule mu Omega p
+
+omit [FiniteDimensional ℝ E] in
+/-- Two Sobolev functions are equal when their value and weak-gradient components are equal. -/
+@[ext]
+theorem W1p.ext {u v : W1p mu Omega p}
+    (hvalue : Sobolev1JetLp.value u.1 = Sobolev1JetLp.value v.1)
+    (hgradient : Sobolev1JetLp.gradient u.1 = Sobolev1JetLp.gradient v.1) : u = v :=
+  Subtype.ext (Sobolev1JetLp.ext hvalue hgradient)
 
 /-- The value-gradient pair represented by an element of `W1p` satisfies the weak derivative
 identity. -/

--- a/TauCeti/Analysis/Sobolev/WeakDeriv.lean
+++ b/TauCeti/Analysis/Sobolev/WeakDeriv.lean
@@ -191,7 +191,9 @@ def HasWeakLineDerivOn (μ : Measure E) (Ω : Opens E) (u u' : E → F) (v : E) 
   CompleteSpace F ∧ LocallyIntegrableOn u Ω μ ∧ LocallyIntegrableOn u' Ω μ ∧
     ∀ φ : 𝓓(Ω, ℝ), ∫ x, lineDeriv ℝ (φ : E → ℝ) x v • u x ∂μ = -∫ x, (φ : E → ℝ) x • u' x ∂μ
 
-/-- The constructor-and-eliminator form of `HasWeakLineDerivOn`, using bundled test functions. -/
+/-- The constructor-and-eliminator form of `HasWeakLineDerivOn`, using bundled test functions.
+The definition is sealed by the module system, so downstream modules use this theorem rather than
+unfolding it. -/
 theorem hasWeakLineDerivOn_iff_testFunction :
     HasWeakLineDerivOn μ Ω u u' v ↔
       CompleteSpace F ∧ LocallyIntegrableOn u Ω μ ∧ LocallyIntegrableOn u' Ω μ ∧
@@ -228,7 +230,8 @@ def HasWeakFDerivOn (μ : Measure E) (Ω : Opens E) (u : E → F) (U : E → E �
   ∀ v : E, HasWeakLineDerivOn μ Ω u (fun x => U x v) v
 
 /-- A weak Fréchet derivative is equivalently a weak directional derivative in every direction.
-This is the constructor-and-eliminator form of `HasWeakFDerivOn`. -/
+This is the constructor-and-eliminator form of `HasWeakFDerivOn`; its sealed definition cannot be
+unfolded from a downstream module. -/
 theorem hasWeakFDerivOn_iff {U : E → E →L[ℝ] F} :
     HasWeakFDerivOn μ Ω u U ↔
       ∀ v : E, HasWeakLineDerivOn μ Ω u (fun x => U x v) v :=

--- a/TauCeti/Analysis/Sobolev/WeakDeriv.lean
+++ b/TauCeti/Analysis/Sobolev/WeakDeriv.lean
@@ -191,6 +191,15 @@ def HasWeakLineDerivOn (μ : Measure E) (Ω : Opens E) (u u' : E → F) (v : E) 
   CompleteSpace F ∧ LocallyIntegrableOn u Ω μ ∧ LocallyIntegrableOn u' Ω μ ∧
     ∀ φ : 𝓓(Ω, ℝ), ∫ x, lineDeriv ℝ (φ : E → ℝ) x v • u x ∂μ = -∫ x, (φ : E → ℝ) x • u' x ∂μ
 
+/-- The constructor-and-eliminator form of `HasWeakLineDerivOn`, using bundled test functions. -/
+theorem hasWeakLineDerivOn_iff_testFunction :
+    HasWeakLineDerivOn μ Ω u u' v ↔
+      CompleteSpace F ∧ LocallyIntegrableOn u Ω μ ∧ LocallyIntegrableOn u' Ω μ ∧
+        ∀ φ : 𝓓(Ω, ℝ),
+          ∫ x, lineDeriv ℝ (φ : E → ℝ) x v • u x ∂μ =
+            -∫ x, (φ : E → ℝ) x • u' x ∂μ :=
+  Iff.rfl
+
 /-- The codomain of a weak derivative is complete; use as `have := h.completeSpace`. -/
 theorem HasWeakLineDerivOn.completeSpace (h : HasWeakLineDerivOn μ Ω u u' v) :
     CompleteSpace F := h.1
@@ -217,6 +226,13 @@ Requiring `u` and `U` to be `Lᵖ` on `Ω` is what cuts out the first-order Sobo
 `W^{1,p}(Ω)`. -/
 def HasWeakFDerivOn (μ : Measure E) (Ω : Opens E) (u : E → F) (U : E → E →L[ℝ] F) : Prop :=
   ∀ v : E, HasWeakLineDerivOn μ Ω u (fun x => U x v) v
+
+/-- A weak Fréchet derivative is equivalently a weak directional derivative in every direction.
+This is the constructor-and-eliminator form of `HasWeakFDerivOn`. -/
+theorem hasWeakFDerivOn_iff {U : E → E →L[ℝ] F} :
+    HasWeakFDerivOn μ Ω u U ↔
+      ∀ v : E, HasWeakLineDerivOn μ Ω u (fun x => U x v) v :=
+  Iff.rfl
 
 /-- The codomain of a weak Fréchet derivative is complete; use as `have := h.completeSpace`. -/
 theorem HasWeakFDerivOn.completeSpace {U : E → E →L[ℝ] F} (h : HasWeakFDerivOn μ Ω u U) :


### PR DESCRIPTION
This PR constructs the first-order weak Sobolev space `W^{1,p}(Ω)` as the closed subspace of `Lᵖ` value-gradient jets satisfying the distributional integration-by-parts identity, and proves completeness for every `1 ≤ p ≤ ∞`.

The preferred `CFSGStatement` roadmap has no currently viable unclaimed critical-path step: I0 is complete, the remaining S1 sporadic rows are already in flight, and L0 is waiting on the in-flight E7/E8 root-system work and its reductive-group consumer. I therefore take PDE Lane A.1, target 1 (“`W^{k,p}(Ω)` via weak derivatives”), whose first-order graph space is the next unclaimed prerequisite for the energy-method and zero-boundary Sobolev lanes.

Define the ambient fibre with the Euclidean product norm, build compactly supported Hölder-conjugate test jets `(∂_v φ, φ v)`, and cut out `W1p` as the intersection of the kernels of their continuous `Lp` pairings. Identify this annihilator condition exactly with `HasWeakFDerivOn`, rather than merely postulating a closed graph, and expose the resulting weak-derivative theorem on each `W1p` element. Add definitional constructor-and-eliminator characterizations for the existing weak line and Fréchet derivative predicates so the new module can construct them through their public API.

This advances PDE milestone Lane A.1, target 1, by completing the honest first-order `W^{1,p}` space and its completeness proof. After this PR, the milestone still needs the higher-order `W^{k,p}` construction; Lane A.2 then adds Meyers–Serrin density and `W^{k,p}_0`.

The implementation reuses Mathlib's `ContinuousLinearMap.lpPairing`, Bochner `Lp` spaces, Hölder conjugates, and closed-submodule completeness infrastructure; no Mathlib code is vendored.

Roadmap: PDE

<!--tauceti-target:v1 {"focus":"PDE","id":"w1p-weak-sobolev-space"}-->

🤖 Prepared with Codex
