### PR TITLE
refactor(Probability): stop re-deriving the indicator identities in condIndep_of_indicator_condExp_eq

### DIFF
--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -71,7 +71,7 @@ theorem condIndep_of_indicator_condExp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω
   set f2 : Ω → ℝ := tH.indicator (fun _ : Ω => (1 : ℝ)) with hf2
   -- The product of the two indicators is the indicator of the intersection; named once and reused.
   have h_f1f2 : (fun ω => f1 ω * f2 ω) = (tF ∩ tH).indicator (fun _ => (1 : ℝ)) := by
-    funext ω; simp [hf1, hf2, ← Set.inter_indicator_mul]
+    rw [hf1, hf2]; exact (Set.inter_indicator_one (s := tF) (t := tH) (M₀ := ℝ)).symm
   have hf1_int : Integrable f1 μ := Integrable.indicator (integrable_const (1 : ℝ)) (hmF _ htF)
   have hf2_int : Integrable f2 μ := Integrable.indicator (integrable_const (1 : ℝ)) (hmH _ htH)
   have hf1_aesm : AEStronglyMeasurable[mF ⊔ mG] f1 μ :=

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -47,6 +47,14 @@ namespace TauCeti
 
 namespace Probability
 
+/-- Pointwise product with the constant-`1` indicator of `s` restricts a function to the
+indicator of `s`. Lets indicator products be rewritten without pointwise case splits. -/
+private lemma mul_indicator_one_eq_indicator {Ω : Type*} (s : Set Ω) (φ : Ω → ℝ) :
+    φ * s.indicator (fun _ => (1 : ℝ)) = s.indicator φ := by
+  funext ω
+  rw [Pi.mul_apply, ← Set.indicator_mul_right]
+  simp
+
 /-- **Conditional independence from the drop-information criterion.** If conditioning `𝟙_H` on
 `mF ⊔ mG` is a.e. the same as conditioning on `mG` (for every `mH`-measurable `H`), then `mF` and
 `mH` are conditionally independent given `mG`. -/
@@ -63,8 +71,7 @@ theorem condIndep_of_indicator_condExp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω
   set f2 : Ω → ℝ := tH.indicator (fun _ : Ω => (1 : ℝ)) with hf2
   -- The product of the two indicators is the indicator of the intersection; named once and reused.
   have h_f1f2 : (fun ω => f1 ω * f2 ω) = (tF ∩ tH).indicator (fun _ => (1 : ℝ)) := by
-    funext ω; by_cases h1 : ω ∈ tF <;> by_cases h2 : ω ∈ tH <;>
-      simp [hf1, hf2, Set.indicator, h1, h2, Set.mem_inter_iff] at *
+    funext ω; simp [hf1, hf2, ← Set.inter_indicator_mul]
   have hf1_int : Integrable f1 μ := Integrable.indicator (integrable_const (1 : ℝ)) (hmF _ htF)
   have hf2_int : Integrable f2 μ := Integrable.indicator (integrable_const (1 : ℝ)) (hmH _ htH)
   have hf1_aesm : AEStronglyMeasurable[mF ⊔ mG] f1 μ :=
@@ -85,7 +92,7 @@ theorem condIndep_of_indicator_condExp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω
     h_pull_middle.trans <| Filter.EventuallyEq.mul Filter.EventuallyEq.rfl hProj
   have hf1_condExp_int : Integrable (f1 * μ[f2 | mG]) μ := by
     have heq : f1 * μ[f2 | mG] = tF.indicator (fun ω => μ[f2 | mG] ω) := by
-      funext ω; by_cases hω : ω ∈ tF <;> simp [hf1, Set.indicator, hω]
+      rw [hf1, mul_comm]; exact mul_indicator_one_eq_indicator tF _
     rw [heq]
     exact Integrable.indicator (integrable_condExp (μ := μ) (m := mG) (f := f2)) (hmF _ htF)
   have h_pull_outer : μ[f1 * μ[f2 | mG] | mG] =ᵐ[μ] μ[f1 | mG] * μ[f2 | mG] :=
@@ -96,14 +103,6 @@ theorem condIndep_of_indicator_condExp_eq {Ω : Type*} {mΩ : MeasurableSpace Ω
     h_tower.trans ((condExp_congr_ae h_middle_to_G).trans h_pull_outer)
   rw [h_f1f2] at h_prod
   simpa only [hf1, hf2] using h_prod
-
-/-- Pointwise product with the constant-`1` indicator of `s` restricts a function to the
-indicator of `s`. Lets indicator products be rewritten without pointwise case splits. -/
-private lemma mul_indicator_one_eq_indicator {Ω : Type*} (s : Set Ω) (φ : Ω → ℝ) :
-    φ * s.indicator (fun _ => (1 : ℝ)) = s.indicator φ := by
-  funext ω
-  rw [Pi.mul_apply, ← Set.indicator_mul_right]
-  simp
 
 /-- Multiplying by the constant-`1` indicator of `s` trades a product against a restriction:
 integrating `φ * 1_s` over `t` is integrating `φ` over the rectangle `s ∩ t`. -/


### PR DESCRIPTION
`condIndep_of_indicator_condExp_eq` proved two indicator identities inline by pointwise case
analysis, and both were already available — one from the file itself, one from Mathlib.

The file declares

```lean
private lemma mul_indicator_one_eq_indicator (s : Set Ω) (φ : Ω → ℝ) :
    φ * s.indicator (fun _ => (1 : ℝ)) = s.indicator φ
```

forty-odd lines *below* the theorem, so the theorem could not reach it and re-derived the same fact
with a `by_cases` on membership. Moving the lemma above its first consumer lets the theorem use it;
the factors are the other way round there, so the call is `rw [hf1, mul_comm]` and then the lemma.
The lemma itself is unchanged.

The other identity — the product of two constant-`1` indicators is the indicator of the intersection
— is Mathlib's `Set.inter_indicator_one`, applied directly in place of the two-way `by_cases`. It is
worth naming the specific lemma rather than the general `Set.inter_indicator_mul`: Mathlib derives
`inter_indicator_one` from `inter_indicator_mul` by exactly the `funext`-and-rewrite step the proof
here would otherwise repeat.

No declaration is added or removed and no statement changes. The theorem drops from 41 lines to 40,
which is not the point: the point is that neither identity is established twice any more.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: none

Cross-cutting probability infrastructure: the change is confined to the proof of one lemma about
conditional independence and to the position of a `private` helper in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
