### PR TITLE
chore: defer connected categorical restriction

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
@@ -16,6 +16,9 @@ every extension `K / k` of the base field, the base-changed coordinate ring `H â
 connected prime spectrum. This is equivalent to saying that every such base change has no
 idempotents other than zero and one.
 
+The condition is exposed as an `ObjectProperty` on the ambient Hopf-algebra category; consumers
+can impose it without introducing a separate bundled category of connected objects.
+
 ## Main declarations
 
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty`: the coordinate-ring predicate.

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
@@ -22,6 +22,8 @@ idempotents other than zero and one.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff`: its connected-spectrum form.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff_idempotent_eq_zero_or_one`: its
   idempotent form.
+* `TauCeti.GeometricallyConnectedCommHopfAlgCat`: the full subcategory of geometrically
+  connected commutative Hopf algebras.
 
 ## References
 
@@ -98,5 +100,10 @@ theorem geometricallyConnectedCommHopfAlgProperty_iff_idempotent_eq_zero_or_one
   · intro h K _ _
     let := nontrivial_tensorProduct k H K
     exact connectedSpace_primeSpectrum_iff_idempotent_eq_zero_or_one.mpr (h K)
+
+/-- The category of geometrically connected commutative Hopf algebras over a field. Geometric
+connectedness remains an object property rather than part of the ambient Hopf-algebra category. -/
+abbrev GeometricallyConnectedCommHopfAlgCat (k : Type u) [Field k] :=
+  (geometricallyConnectedCommHopfAlgProperty k).FullSubcategory
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
@@ -29,6 +29,10 @@ idempotents other than zero and one.
 
 * J. S. Milne, *Algebraic Groups* (2017), §2.a.
 
+The full-subcategory abbreviation follows the finite-type model
+`TauCeti.FiniteTypeCommHopfAlgCat` from
+`TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat`.
+
 This is the geometric-connectedness prerequisite for Layer 3, "Identity component and component
 group", of the ReductiveGroups roadmap.
 -/

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
@@ -22,16 +22,10 @@ idempotents other than zero and one.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff`: its connected-spectrum form.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff_idempotent_eq_zero_or_one`: its
   idempotent form.
-* `TauCeti.GeometricallyConnectedCommHopfAlgCat`: the full subcategory of geometrically
-  connected commutative Hopf algebras.
 
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), §2.a.
-
-The full-subcategory abbreviation follows the finite-type model
-`TauCeti.FiniteTypeCommHopfAlgCat` from
-`TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat`.
 
 This is the geometric-connectedness prerequisite for Layer 3, "Identity component and component
 group", of the ReductiveGroups roadmap.
@@ -104,10 +98,5 @@ theorem geometricallyConnectedCommHopfAlgProperty_iff_idempotent_eq_zero_or_one
   · intro h K _ _
     let := nontrivial_tensorProduct k H K
     exact connectedSpace_primeSpectrum_iff_idempotent_eq_zero_or_one.mpr (h K)
-
-/-- The category of geometrically connected commutative Hopf algebras over a field. Geometric
-connectedness remains an object property rather than part of the ambient Hopf-algebra category. -/
-abbrev GeometricallyConnectedCommHopfAlgCat (k : Type u) [Field k] :=
-  (geometricallyConnectedCommHopfAlgProperty k).FullSubcategory
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
@@ -5,14 +5,22 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.Geometrically.Connected
+public import Mathlib.CategoryTheory.ObjectProperty.Opposite
 public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
 
 /-!
 # Geometric connectedness of affine group schemes
 
 This file compares geometric connectedness of a commutative Hopf algebra with Mathlib's
-scheme-theoretic `GeometricallyConnected` predicate on its Hopf spectrum.
+scheme-theoretic `GeometricallyConnected` predicate on its Hopf spectrum. It then restricts the
+affine Hopf/group-scheme anti-equivalence to geometrically connected objects:
+
+```text
+(GeometricallyConnectedCommHopfAlgCat k)ᵒᵖ ≌
+  GeometricallyConnectedAffineGroupSchemeCat (Spec k).
+```
 
 ## Main declarations
 
@@ -20,6 +28,8 @@ scheme-theoretic `GeometricallyConnected` predicate on its Hopf spectrum.
   of the coordinate-ring and scheme-theoretic predicates.
 * `TauCeti.geometricallyConnected_hopfSpec_iff_idempotent_eq_zero_or_one`: the idempotent
   characterization of geometric connectedness for a Hopf spectrum.
+* `TauCeti.geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCat`: the restricted
+  anti-equivalence.
 
 ## References
 
@@ -39,6 +49,42 @@ namespace TauCeti
 open AlgebraicGeometry
 
 universe u
+
+private instance geometricallyConnected_respectsIso :
+    MorphismProperty.RespectsIso @GeometricallyConnected :=
+  MorphismProperty.IsStableUnderBaseChange.respectsIso
+
+/-- The object property on affine group schemes selecting those whose structural morphism is
+geometrically connected. -/
+def geometricallyConnectedAffineGroupSchemeProperty (S : CommRingCat.{u}) :
+    ObjectProperty (AffineGroupSchemeCat S) :=
+  fun G => GeometricallyConnected G.obj.X.hom
+
+/-- Membership in the geometrically connected affine-group-scheme object property. -/
+@[simp]
+lemma geometricallyConnectedAffineGroupSchemeProperty_iff (S : CommRingCat.{u})
+    (G : AffineGroupSchemeCat S) :
+    geometricallyConnectedAffineGroupSchemeProperty S G ↔
+      GeometricallyConnected G.obj.X.hom :=
+  Iff.rfl
+
+/-- Geometric connectedness of the structural morphism is invariant under isomorphism of affine
+group schemes. -/
+instance (S : CommRingCat.{u}) :
+    (geometricallyConnectedAffineGroupSchemeProperty S).IsClosedUnderIsomorphisms where
+  of_iso e hG :=
+    (MorphismProperty.over_iso_iff (@GeometricallyConnected)
+      ((Grp.forget _).mapIso ((affineGroupSchemeProperty S).ι.mapIso e))).mp hG
+
+/-- The category of geometrically connected affine group schemes over the affine base `Spec S`. -/
+abbrev GeometricallyConnectedAffineGroupSchemeCat (S : CommRingCat.{u}) :=
+  (geometricallyConnectedAffineGroupSchemeProperty S).FullSubcategory
+
+/-- An object of `GeometricallyConnectedAffineGroupSchemeCat S` has geometrically connected
+structural morphism by construction. -/
+instance (G : GeometricallyConnectedAffineGroupSchemeCat S) :
+    GeometricallyConnected G.obj.obj.X.hom :=
+  G.property
 
 /-- **Geometric connectedness agrees across the affine-group-scheme and coordinate-ring
 models.** The structural morphism of a Hopf spectrum is geometrically connected if and only if
@@ -72,5 +118,78 @@ theorem geometricallyConnected_hopfSpec_iff_idempotent_eq_zero_or_one
         IsIdempotentElem e → e = 0 ∨ e = 1 := by
   rw [← geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec,
     geometricallyConnectedCommHopfAlgProperty_iff_idempotent_eq_zero_or_one]
+
+/-- Under the affine Hopf/group-scheme anti-equivalence, the inverse image of geometric
+connectedness is geometric connectedness of the coordinate Hopf algebra. -/
+theorem geometricallyConnectedAffineGroupSchemeProperty_inverseImage
+    (k : Type u) [Field k] :
+    (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).inverseImage
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor =
+      (geometricallyConnectedCommHopfAlgProperty k).op := by
+  ext H
+  let G : AffineGroupSchemeCat (CommRingCat.of k) :=
+    ⟨(hopfSpec (CommRingCat.of k)).obj H, by
+      apply (affineGroupSchemeProperty_iff _).mpr
+      rw [← essImage_hopfSpec]
+      exact ⟨H, ⟨Iso.refl _⟩⟩⟩
+  let e : (commHopfAlgCatOpEquivAffineGroupSchemeCat
+      (CommRingCat.of k)).functor.obj H ≅ G :=
+    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+        (CommRingCat.of k)).app H)
+  rw [ObjectProperty.prop_inverseImage_iff,
+    geometricallyConnectedAffineGroupSchemeProperty_iff, ObjectProperty.op_iff]
+  constructor
+  · intro h
+    have hG : geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k) G :=
+      (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso e h
+    exact (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H.unop).mpr hG
+  · intro h
+    apply (geometricallyConnectedAffineGroupSchemeProperty
+      (CommRingCat.of k)).prop_of_iso e.symm
+    exact (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H.unop).mp h
+
+/-- `Spec` as an anti-equivalence from geometrically connected commutative Hopf algebras to
+geometrically connected affine group schemes over a field. -/
+noncomputable def geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCat
+    (k : Type u) [Field k] :
+    (GeometricallyConnectedCommHopfAlgCat.{u} k)ᵒᵖ ≌
+      GeometricallyConnectedAffineGroupSchemeCat (CommRingCat.of k) :=
+  (ObjectProperty.opEquivalence (geometricallyConnectedCommHopfAlgProperty k)).symm.trans <|
+    (commHopfAlgCatOpEquivAffineGroupSchemeCat
+      (CommRingCat.of k)).congrFullSubcategory
+        (geometricallyConnectedAffineGroupSchemeProperty_inverseImage k)
+
+/-- The forward restricted equivalence followed by the geometrically connected inclusion is the
+unrestricted affine Hopf/group-scheme equivalence after forgetting the connectedness proof. -/
+private noncomputable def
+    geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCatFunctorCompιIso
+    (k : Type u) [Field k] :
+    (geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCat k).functor ⋙
+        (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).ι ≅
+      (forget₂ (GeometricallyConnectedCommHopfAlgCat.{u} k)
+          (CommHopfAlgCat.{u} k)).op ⋙
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor :=
+  Iso.refl _
+
+/-- The forward geometrically connected anti-equivalence, followed by the inclusions into affine
+group schemes and then all group schemes, is `hopfSpec` after forgetting the connectedness proof. -/
+noncomputable def
+    geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+    (k : Type u) [Field k] :
+    (geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCat k).functor ⋙
+          (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
+        (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
+      (forget₂ (GeometricallyConnectedCommHopfAlgCat.{u} k)
+          (CommHopfAlgCat.{u} k)).op ⋙ hopfSpec (CommRingCat.of k) :=
+  Functor.isoWhiskerRight
+      (geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCatFunctorCompιIso k)
+      (affineGroupSchemeProperty (CommRingCat.of k)).ι ≪≫
+    Functor.associator _ _ _ ≪≫
+    Functor.isoWhiskerLeft
+      (forget₂ (GeometricallyConnectedCommHopfAlgCat.{u} k)
+        (CommHopfAlgCat.{u} k)).op
+      (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+        (CommRingCat.of k))
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
@@ -5,22 +5,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.Geometrically.Connected
-public import Mathlib.CategoryTheory.ObjectProperty.Opposite
 public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
 
 /-!
 # Geometric connectedness of affine group schemes
 
 This file compares geometric connectedness of a commutative Hopf algebra with Mathlib's
-scheme-theoretic `GeometricallyConnected` predicate on its Hopf spectrum. It then restricts the
-affine Hopf/group-scheme anti-equivalence to geometrically connected objects:
-
-```text
-(GeometricallyConnectedCommHopfAlgCat k)ᵒᵖ ≌
-  GeometricallyConnectedAffineGroupSchemeCat (CommRingCat.of k).
-```
+scheme-theoretic `GeometricallyConnected` predicate on its Hopf spectrum.
 
 ## Main declarations
 
@@ -28,22 +20,10 @@ affine Hopf/group-scheme anti-equivalence to geometrically connected objects:
   of the coordinate-ring and scheme-theoretic predicates.
 * `TauCeti.geometricallyConnected_hopfSpec_iff_idempotent_eq_zero_or_one`: the idempotent
   characterization of geometric connectedness for a Hopf spectrum.
-* `TauCeti.geometricallyConnectedAffineGroupSchemeProperty`: the geometrically connected
-  object property on affine group schemes.
-* `TauCeti.GeometricallyConnectedAffineGroupSchemeCat`: the resulting full subcategory.
-* `TauCeti.geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat`:
-  the restricted anti-equivalence.
-* `functorCompιIso` in the restricted anti-equivalence's namespace: after both inclusions,
-  the forward functor is Mathlib's `AlgebraicGeometry.hopfSpec`.
 
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), §2.a.
-
-The categorical restriction follows
-`TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType`, especially
-`TauCeti.finiteTypeAffineGroupSchemeProperty_inverseImage` and
-`TauCeti.finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat`.
 
 This is the geometric-connectedness prerequisite for Layer 3, "Identity component and component
 group", of the ReductiveGroups roadmap.
@@ -60,42 +40,6 @@ open AlgebraicGeometry
 
 universe u
 
-private instance geometricallyConnected_respectsIso :
-    MorphismProperty.RespectsIso @GeometricallyConnected :=
-  MorphismProperty.IsStableUnderBaseChange.respectsIso
-
-/-- The object property on affine group schemes selecting those whose structural morphism is
-geometrically connected. -/
-def geometricallyConnectedAffineGroupSchemeProperty (S : CommRingCat.{u}) :
-    ObjectProperty (AffineGroupSchemeCat S) :=
-  fun G => GeometricallyConnected G.obj.X.hom
-
-/-- Membership in the geometrically connected affine-group-scheme object property. -/
-@[simp]
-lemma geometricallyConnectedAffineGroupSchemeProperty_iff (S : CommRingCat.{u})
-    (G : AffineGroupSchemeCat S) :
-    geometricallyConnectedAffineGroupSchemeProperty S G ↔
-      GeometricallyConnected G.obj.X.hom :=
-  Iff.rfl
-
-/-- Geometric connectedness of the structural morphism is invariant under isomorphism of affine
-group schemes. -/
-instance (S : CommRingCat.{u}) :
-    (geometricallyConnectedAffineGroupSchemeProperty S).IsClosedUnderIsomorphisms where
-  of_iso e hG :=
-    (MorphismProperty.over_iso_iff (@GeometricallyConnected)
-      ((Grp.forget _).mapIso ((affineGroupSchemeProperty S).ι.mapIso e))).mp hG
-
-/-- The category of geometrically connected affine group schemes over the affine base `Spec S`. -/
-abbrev GeometricallyConnectedAffineGroupSchemeCat (S : CommRingCat.{u}) :=
-  (geometricallyConnectedAffineGroupSchemeProperty S).FullSubcategory
-
-/-- An object of `GeometricallyConnectedAffineGroupSchemeCat S` has geometrically connected
-structural morphism by construction. -/
-instance (G : GeometricallyConnectedAffineGroupSchemeCat S) :
-    GeometricallyConnected G.obj.obj.X.hom :=
-  G.property
-
 /-- **Geometric connectedness agrees across the affine-group-scheme and coordinate-ring
 models.** The structural morphism of a Hopf spectrum is geometrically connected if and only if
 its coordinate algebra is geometrically connected after every field extension. -/
@@ -104,6 +48,9 @@ theorem geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec
     geometricallyConnectedCommHopfAlgProperty k H ↔
       GeometricallyConnected
         (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) := by
+  -- This witness is not a global instance, but `cancel_left_of_respectsIso` needs it below.
+  let : MorphismProperty.RespectsIso @GeometricallyConnected :=
+    MorphismProperty.IsStableUnderBaseChange.respectsIso
   rw [geometricallyConnectedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
   rw [MorphismProperty.cancel_left_of_respectsIso
     (P := @GeometricallyConnected) (eqToHom (hopfSpec_obj_X_left k H))]
@@ -125,78 +72,5 @@ theorem geometricallyConnected_hopfSpec_iff_idempotent_eq_zero_or_one
         IsIdempotentElem e → e = 0 ∨ e = 1 := by
   rw [← geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec,
     geometricallyConnectedCommHopfAlgProperty_iff_idempotent_eq_zero_or_one]
-
-/-- Under the affine Hopf/group-scheme anti-equivalence, the inverse image of geometric
-connectedness is geometric connectedness of the coordinate Hopf algebra. -/
-theorem geometricallyConnectedAffineGroupSchemeProperty_inverseImage
-    (k : Type u) [Field k] :
-    (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).inverseImage
-        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor =
-      (geometricallyConnectedCommHopfAlgProperty k).op := by
-  ext H
-  let G : AffineGroupSchemeCat (CommRingCat.of k) :=
-    ⟨(hopfSpec (CommRingCat.of k)).obj H, by
-      apply (affineGroupSchemeProperty_iff _).mpr
-      rw [← essImage_hopfSpec]
-      exact ⟨H, ⟨Iso.refl _⟩⟩⟩
-  let e : (commHopfAlgCatOpEquivAffineGroupSchemeCat
-      (CommRingCat.of k)).functor.obj H ≅ G :=
-    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
-      ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-        (CommRingCat.of k)).app H)
-  rw [ObjectProperty.prop_inverseImage_iff,
-    geometricallyConnectedAffineGroupSchemeProperty_iff, ObjectProperty.op_iff]
-  exact ((geometricallyConnectedAffineGroupSchemeProperty
-    (CommRingCat.of k)).prop_iff_of_iso e).trans
-      (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H.unop).symm
-
-/-- `Spec` as an anti-equivalence from geometrically connected commutative Hopf algebras to
-geometrically connected affine group schemes over a field. -/
-noncomputable def
-    geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat
-    (k : Type u) [Field k] :
-    (GeometricallyConnectedCommHopfAlgCat.{u} k)ᵒᵖ ≌
-      GeometricallyConnectedAffineGroupSchemeCat (CommRingCat.of k) :=
-  (ObjectProperty.opEquivalence (geometricallyConnectedCommHopfAlgProperty k)).symm.trans <|
-    (commHopfAlgCatOpEquivAffineGroupSchemeCat
-      (CommRingCat.of k)).congrFullSubcategory
-        (geometricallyConnectedAffineGroupSchemeProperty_inverseImage k)
-
-namespace geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat
-
-/-- The forward restricted equivalence followed by the geometrically connected inclusion is
-definitionally the unrestricted equivalence applied after forgetting the connectedness proof.
-This private isomorphism isolates the representation boundary of `opEquivalence`, `trans`, and
-`congrFullSubcategory` from the public compatibility isomorphism below. -/
-private noncomputable def functorCompιIsoAux (k : Type u) [Field k] :
-    (geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat
-        k).functor ⋙
-        (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).ι ≅
-      (forget₂ (GeometricallyConnectedCommHopfAlgCat.{u} k)
-          (CommHopfAlgCat.{u} k)).op ⋙
-        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor :=
-  Iso.refl _
-
-/-- The forward geometrically connected anti-equivalence, followed by the inclusions into affine
-group schemes and then all group schemes, is `hopfSpec` after forgetting the connectedness proof. -/
-noncomputable def
-    functorCompιIso (k : Type u) [Field k] :
-    (geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat
-        k).functor ⋙
-          (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
-        (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
-      (forget₂ (GeometricallyConnectedCommHopfAlgCat.{u} k)
-          (CommHopfAlgCat.{u} k)).op ⋙ hopfSpec (CommRingCat.of k) :=
-  Functor.isoWhiskerRight
-      (functorCompιIsoAux k)
-      (affineGroupSchemeProperty (CommRingCat.of k)).ι ≪≫
-    Functor.associator _ _ _ ≪≫
-    Functor.isoWhiskerLeft
-      (forget₂ (GeometricallyConnectedCommHopfAlgCat.{u} k)
-        (CommHopfAlgCat.{u} k)).op
-      (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-        (CommRingCat.of k))
-
-end geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
@@ -19,7 +19,7 @@ affine Hopf/group-scheme anti-equivalence to geometrically connected objects:
 
 ```text
 (GeometricallyConnectedCommHopfAlgCat k)ᵒᵖ ≌
-  GeometricallyConnectedAffineGroupSchemeCat (Spec k).
+  GeometricallyConnectedAffineGroupSchemeCat (CommRingCat.of k).
 ```
 
 ## Main declarations
@@ -28,12 +28,22 @@ affine Hopf/group-scheme anti-equivalence to geometrically connected objects:
   of the coordinate-ring and scheme-theoretic predicates.
 * `TauCeti.geometricallyConnected_hopfSpec_iff_idempotent_eq_zero_or_one`: the idempotent
   characterization of geometric connectedness for a Hopf spectrum.
-* `TauCeti.geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCat`: the restricted
-  anti-equivalence.
+* `TauCeti.geometricallyConnectedAffineGroupSchemeProperty`: the geometrically connected
+  object property on affine group schemes.
+* `TauCeti.GeometricallyConnectedAffineGroupSchemeCat`: the resulting full subcategory.
+* `TauCeti.geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat`:
+  the restricted anti-equivalence.
+* `functorCompιIso` in the restricted anti-equivalence's namespace: after both inclusions,
+  the forward functor is Mathlib's `AlgebraicGeometry.hopfSpec`.
 
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), §2.a.
+
+The categorical restriction follows
+`TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType`, especially
+`TauCeti.finiteTypeAffineGroupSchemeProperty_inverseImage` and
+`TauCeti.finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat`.
 
 This is the geometric-connectedness prerequisite for Layer 3, "Identity component and component
 group", of the ReductiveGroups roadmap.
@@ -94,9 +104,6 @@ theorem geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec
     geometricallyConnectedCommHopfAlgProperty k H ↔
       GeometricallyConnected
         (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) := by
-  -- This witness is not a global instance, but `cancel_left_of_respectsIso` needs it below.
-  let : MorphismProperty.RespectsIso @GeometricallyConnected :=
-    MorphismProperty.IsStableUnderBaseChange.respectsIso
   rw [geometricallyConnectedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
   rw [MorphismProperty.cancel_left_of_respectsIso
     (P := @GeometricallyConnected) (eqToHom (hopfSpec_obj_X_left k H))]
@@ -139,19 +146,14 @@ theorem geometricallyConnectedAffineGroupSchemeProperty_inverseImage
         (CommRingCat.of k)).app H)
   rw [ObjectProperty.prop_inverseImage_iff,
     geometricallyConnectedAffineGroupSchemeProperty_iff, ObjectProperty.op_iff]
-  constructor
-  · intro h
-    have hG : geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k) G :=
-      (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso e h
-    exact (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H.unop).mpr hG
-  · intro h
-    apply (geometricallyConnectedAffineGroupSchemeProperty
-      (CommRingCat.of k)).prop_of_iso e.symm
-    exact (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H.unop).mp h
+  exact ((geometricallyConnectedAffineGroupSchemeProperty
+    (CommRingCat.of k)).prop_iff_of_iso e).trans
+      (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H.unop).symm
 
 /-- `Spec` as an anti-equivalence from geometrically connected commutative Hopf algebras to
 geometrically connected affine group schemes over a field. -/
-noncomputable def geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCat
+noncomputable def
+    geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat
     (k : Type u) [Field k] :
     (GeometricallyConnectedCommHopfAlgCat.{u} k)ᵒᵖ ≌
       GeometricallyConnectedAffineGroupSchemeCat (CommRingCat.of k) :=
@@ -160,12 +162,15 @@ noncomputable def geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCa
       (CommRingCat.of k)).congrFullSubcategory
         (geometricallyConnectedAffineGroupSchemeProperty_inverseImage k)
 
-/-- The forward restricted equivalence followed by the geometrically connected inclusion is the
-unrestricted affine Hopf/group-scheme equivalence after forgetting the connectedness proof. -/
-private noncomputable def
-    geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCatFunctorCompιIso
-    (k : Type u) [Field k] :
-    (geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCat k).functor ⋙
+namespace geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat
+
+/-- The forward restricted equivalence followed by the geometrically connected inclusion is
+definitionally the unrestricted equivalence applied after forgetting the connectedness proof.
+This private isomorphism isolates the representation boundary of `opEquivalence`, `trans`, and
+`congrFullSubcategory` from the public compatibility isomorphism below. -/
+private noncomputable def functorCompιIsoAux (k : Type u) [Field k] :
+    (geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat
+        k).functor ⋙
         (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).ι ≅
       (forget₂ (GeometricallyConnectedCommHopfAlgCat.{u} k)
           (CommHopfAlgCat.{u} k)).op ⋙
@@ -175,15 +180,15 @@ private noncomputable def
 /-- The forward geometrically connected anti-equivalence, followed by the inclusions into affine
 group schemes and then all group schemes, is `hopfSpec` after forgetting the connectedness proof. -/
 noncomputable def
-    geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-    (k : Type u) [Field k] :
-    (geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCat k).functor ⋙
+    functorCompιIso (k : Type u) [Field k] :
+    (geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat
+        k).functor ⋙
           (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
         (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
       (forget₂ (GeometricallyConnectedCommHopfAlgCat.{u} k)
           (CommHopfAlgCat.{u} k)).op ⋙ hopfSpec (CommRingCat.of k) :=
   Functor.isoWhiskerRight
-      (geometricallyConnectedCommHopfAlgCatOpEquivAffineGroupSchemeCatFunctorCompιIso k)
+      (functorCompιIsoAux k)
       (affineGroupSchemeProperty (CommRingCat.of k)).ι ≪≫
     Functor.associator _ _ _ ≪≫
     Functor.isoWhiskerLeft
@@ -191,5 +196,7 @@ noncomputable def
         (CommHopfAlgCat.{u} k)).op
       (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
         (CommRingCat.of k))
+
+end geometricallyConnectedCommHopfAlgCatOpEquivGeometricallyConnectedAffineGroupSchemeCat
 
 end TauCeti


### PR DESCRIPTION
AI review correctly found that the geometrically connected full subcategories and restricted anti-equivalence have no direct identity-component consumer yet. This PR now removes that premature categorical layer and restores the branch tree to origin/main.

The restriction should return only when the geometric identity-component construction consumes it directly. At that point, the Hopf-algebra full subcategory should also receive the standard bundled-category interface identified by API review. No Lean declarations remain changed by this PR.

Roadmap: none