### PR TITLE
feat: package the Spin double cover

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
@@ -6,30 +6,33 @@ module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Kernel
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Surjectivity
-public import Mathlib.GroupTheory.GroupExtension.Defs
-import Mathlib.GroupTheory.SpecificGroups.Cyclic
+public import TauCeti.GroupTheory.GroupExtension.Of.Surjective
 
 /-!
 # The Spin double cover as a group extension
 
 For a positive-dimensional finite nondegenerate quadratic space over a field in which `2` is
-invertible, the kernel of the Spin action is canonically identified with the multiplicative group
-underlying `ZMod 2`. Any proof that the action is surjective then packages the Spin double cover as
-a `GroupExtension`; in particular, the action is surjective over a separably closed field.
+invertible, the kernel equivalence from `Spin.Kernel` and any proof that the action is surjective
+package the Spin double cover as a `GroupExtension`; in particular, the action is surjective over a
+separably closed field.
 
-## Main definitions
+## Main definitions and results
 
-* `TauCeti.CliffordAlgebra.zmodTwoMulEquivSpinKernel` identifies the kernel with
-  `Multiplicative (ZMod 2)`.
 * `TauCeti.CliffordAlgebra.spinDoubleCoverOfSurjective` packages any surjective Spin action as a
   group extension.
 * `TauCeti.CliffordAlgebra.spinDoubleCover` packages
   `1 → ZMod 2 → Spin(Q) → SO(Q) → 1` as a group extension.
+* `TauCeti.CliffordAlgebra.spinDoubleCoverOfSurjective_inl_ofAdd_one` and
+  `TauCeti.CliffordAlgebra.spinDoubleCoverOfSurjective_rightHom` characterize the generic
+  extension.
+* `TauCeti.CliffordAlgebra.spinDoubleCover_inl_ofAdd_one` and
+  `TauCeti.CliffordAlgebra.spinDoubleCover_rightHom` characterize the separably closed case.
 
 ## References
 
-This completes the short-exact-sequence part of Layer 2 in
-`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. See H. B. Lawson and
+This supplies the Spin short exact sequence of Layer 2 over a separably closed field; the Pin/O(V)
+sequence and the general-field spinor-norm version are not covered. See
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. H. B. Lawson and
 M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 -/
 
@@ -44,77 +47,15 @@ universe u v
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
   [FiniteDimensional K V] [Invertible (2 : K)]
 
-/-- The kernel of the Spin action on a positive-dimensional nondegenerate quadratic space over a
-field in which `2` is invertible is canonically the cyclic group of order two, with its generator
-sent to the scalar `-1`. -/
-noncomputable def zmodTwoMulEquivSpinKernel
-    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
-    Multiplicative (ZMod 2) ≃* MonoidHom.ker (spinToSpecialOrthogonal Q) := by
-  let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-  let z : MonoidHom.ker (spinToSpecialOrthogonal Q) :=
-    ⟨spinGroup.negOne Q hQ.ne_zero,
-      spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q hQ.ne_zero⟩
-  apply zmodMulEquivOfGenerator (g := z)
-  · intro x
-    rcases (mem_ker_spinToSpecialOrthogonal_iff Q hQ x).mp x.2 with hx | hx
-    · have hx' : x = 1 := Subtype.ext hx
-      rw [hx']
-      exact Subgroup.one_mem _
-    · have hx' : x = z := Subtype.ext hx
-      rw [hx']
-      exact Subgroup.mem_zpowers z
-  · exact card_ker_spinToSpecialOrthogonal hV Q hQ
-
-/-- The chosen generator of `Multiplicative (ZMod 2)` maps to the scalar `-1` in the Spin
-kernel. -/
-@[simp]
-theorem zmodTwoMulEquivSpinKernel_apply_ofAdd_one
-    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
-    zmodTwoMulEquivSpinKernel hV Q hQ (Multiplicative.ofAdd 1) =
-      ⟨spinGroup.negOne Q (by
-          let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-          exact hQ.ne_zero),
-        spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q
-          (by
-            let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-            exact hQ.ne_zero)⟩ := by
-  let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-  rw [zmodTwoMulEquivSpinKernel, zmodMulEquivOfGenerator_apply_ofAdd_one]
-
-/-- The inverse kernel equivalence sends the scalar `-1` to the chosen generator of
-`Multiplicative (ZMod 2)`. -/
-@[simp]
-theorem zmodTwoMulEquivSpinKernel_symm_apply_negOne
-    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
-    (zmodTwoMulEquivSpinKernel hV Q hQ).symm
-        ⟨spinGroup.negOne Q (by
-            let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-            exact hQ.ne_zero),
-          spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q
-            (by
-              let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-              exact hQ.ne_zero)⟩ =
-      Multiplicative.ofAdd 1 := by
-  rw [MulEquiv.symm_apply_eq, zmodTwoMulEquivSpinKernel_apply_ofAdd_one]
-
 /-- A surjective Spin action on a positive-dimensional nondegenerate quadratic space over a field
 in which `2` is invertible is the group extension `1 → ZMod 2 → Spin(Q) → SO(Q) → 1`. -/
 noncomputable def spinDoubleCoverOfSurjective
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
     (hsurj : Function.Surjective (spinToSpecialOrthogonal Q)) :
     GroupExtension (Multiplicative (ZMod 2)) (spinGroup Q)
-      (QuadraticMap.specialOrthogonalGroup Q) where
-  inl := (MonoidHom.ker (spinToSpecialOrthogonal Q)).subtype.comp
-    (zmodTwoMulEquivSpinKernel hV Q hQ).toMonoidHom
-  rightHom := spinToSpecialOrthogonal Q
-  inl_injective := fun x y h =>
-    (zmodTwoMulEquivSpinKernel hV Q hQ).injective (Subtype.ext h)
-  range_inl_eq_ker_rightHom := by
-    rw [MonoidHom.range_comp]
-    have hrange : (zmodTwoMulEquivSpinKernel hV Q hQ).toMonoidHom.range = ⊤ :=
-      MonoidHom.range_eq_top.mpr (zmodTwoMulEquivSpinKernel hV Q hQ).surjective
-    rw [hrange, ← MonoidHom.range_eq_map, Subgroup.range_subtype]
-  rightHom_surjective := hsurj
+      (QuadraticMap.specialOrthogonalGroup Q) :=
+  GroupExtension.ofMulEquivKer hsurj
+    (zmodTwoMulEquivKerSpinToSpecialOrthogonal hV Q hQ)
 
 /-- The inclusion in a Spin double cover built from a surjectivity proof sends the generator to
 the scalar `-1`. -/
@@ -123,30 +64,36 @@ theorem spinDoubleCoverOfSurjective_inl_ofAdd_one
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
     (hsurj : Function.Surjective (spinToSpecialOrthogonal Q)) :
     (spinDoubleCoverOfSurjective hV Q hQ hsurj).inl (Multiplicative.ofAdd 1) =
-      spinGroup.negOne Q (by
-        let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-        exact hQ.ne_zero) := by
-  let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-  -- Expose the kernel subtype beneath the bundled extension inclusion.
-  change ((zmodTwoMulEquivSpinKernel hV Q hQ (Multiplicative.ofAdd 1) :
-    MonoidHom.ker (spinToSpecialOrthogonal Q)) : spinGroup Q) = _
-  rw [zmodTwoMulEquivSpinKernel_apply_ofAdd_one]
+      spinGroup.negOne Q (hQ.ne_zero_of_finrank_pos hV) := by
+  rw [spinDoubleCoverOfSurjective, GroupExtension.ofMulEquivKer_inl,
+    MonoidHom.comp_apply]
+  exact congrArg Subtype.val
+    (zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one hV Q hQ)
 
 /-- The projection in a Spin double cover built from a surjectivity proof is the Spin action. -/
 @[simp]
 theorem spinDoubleCoverOfSurjective_rightHom
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
     (hsurj : Function.Surjective (spinToSpecialOrthogonal Q)) :
-    (spinDoubleCoverOfSurjective hV Q hQ hsurj).rightHom = spinToSpecialOrthogonal Q := by
-  rfl
+    (spinDoubleCoverOfSurjective hV Q hQ hsurj).rightHom = spinToSpecialOrthogonal Q :=
+  GroupExtension.ofMulEquivKer_rightHom _ _
 
-/-- Over a separably closed field in which `2` is invertible, the Spin action is the group
-extension `1 → ZMod 2 → Spin(Q) → SO(Q) → 1`. -/
+/-- For a positive-dimensional nondegenerate quadratic space over a separably closed field in
+which `2` is invertible, the Spin action is the group extension
+`1 → ZMod 2 → Spin(Q) → SO(Q) → 1`. -/
 noncomputable def spinDoubleCover [IsSepClosed K]
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     GroupExtension (Multiplicative (ZMod 2)) (spinGroup Q)
       (QuadraticMap.specialOrthogonalGroup Q) :=
   spinDoubleCoverOfSurjective hV Q hQ (spinToSpecialOrthogonal_surjective Q hQ)
+
+/-- The separably closed Spin double cover is the generic construction applied to canonical
+surjectivity. -/
+theorem spinDoubleCover_eq [IsSepClosed K]
+    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    spinDoubleCover hV Q hQ =
+      spinDoubleCoverOfSurjective hV Q hQ (spinToSpecialOrthogonal_surjective Q hQ) :=
+  (rfl)
 
 /-- The inclusion in the separably closed Spin double cover sends the generator to the scalar
 `-1`. -/
@@ -154,16 +101,14 @@ noncomputable def spinDoubleCover [IsSepClosed K]
 theorem spinDoubleCover_inl_ofAdd_one [IsSepClosed K]
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     (spinDoubleCover hV Q hQ).inl (Multiplicative.ofAdd 1) =
-      spinGroup.negOne Q (by
-        let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-        exact hQ.ne_zero) := by
-  rw [spinDoubleCover, spinDoubleCoverOfSurjective_inl_ofAdd_one]
+      spinGroup.negOne Q (hQ.ne_zero_of_finrank_pos hV) := by
+  rw [spinDoubleCover_eq, spinDoubleCoverOfSurjective_inl_ofAdd_one]
 
 /-- The projection in the separably closed Spin double cover is the Spin action. -/
 @[simp]
 theorem spinDoubleCover_rightHom [IsSepClosed K]
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     (spinDoubleCover hV Q hQ).rightHom = spinToSpecialOrthogonal Q := by
-  rw [spinDoubleCover, spinDoubleCoverOfSurjective_rightHom]
+  rw [spinDoubleCover_eq, spinDoubleCoverOfSurjective_rightHom]
 
 end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
@@ -12,15 +12,17 @@ import Mathlib.GroupTheory.SpecificGroups.Cyclic
 /-!
 # The Spin double cover as a group extension
 
-For a positive-dimensional finite nondegenerate quadratic space, the kernel of the Spin action
-is canonically identified with the multiplicative group underlying `ZMod 2`. Over a separably
-closed field, surjectivity of the action then packages the Spin double cover as a
-`GroupExtension`.
+For a positive-dimensional finite nondegenerate quadratic space over a field in which `2` is
+invertible, the kernel of the Spin action is canonically identified with the multiplicative group
+underlying `ZMod 2`. Any proof that the action is surjective then packages the Spin double cover as
+a `GroupExtension`; in particular, the action is surjective over a separably closed field.
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.spinKernelEquivZModTwo` identifies the kernel with
+* `TauCeti.CliffordAlgebra.zmodTwoMulEquivSpinKernel` identifies the kernel with
   `Multiplicative (ZMod 2)`.
+* `TauCeti.CliffordAlgebra.spinDoubleCoverOfSurjective` packages any surjective Spin action as a
+  group extension.
 * `TauCeti.CliffordAlgebra.spinDoubleCover` packages
   `1 → ZMod 2 → Spin(Q) → SO(Q) → 1` as a group extension.
 
@@ -42,9 +44,10 @@ universe u v
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
   [FiniteDimensional K V] [Invertible (2 : K)]
 
-/-- The kernel of the Spin action on a positive-dimensional nondegenerate quadratic space is
-canonically the cyclic group of order two, with its generator sent to the scalar `-1`. -/
-noncomputable def spinKernelEquivZModTwo
+/-- The kernel of the Spin action on a positive-dimensional nondegenerate quadratic space over a
+field in which `2` is invertible is canonically the cyclic group of order two, with its generator
+sent to the scalar `-1`. -/
+noncomputable def zmodTwoMulEquivSpinKernel
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     Multiplicative (ZMod 2) ≃* MonoidHom.ker (spinToSpecialOrthogonal Q) := by
   let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
@@ -65,9 +68,9 @@ noncomputable def spinKernelEquivZModTwo
 /-- The chosen generator of `Multiplicative (ZMod 2)` maps to the scalar `-1` in the Spin
 kernel. -/
 @[simp]
-theorem spinKernelEquivZModTwo_apply_ofAdd_one
+theorem zmodTwoMulEquivSpinKernel_apply_ofAdd_one
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
-    spinKernelEquivZModTwo hV Q hQ (Multiplicative.ofAdd 1) =
+    zmodTwoMulEquivSpinKernel hV Q hQ (Multiplicative.ofAdd 1) =
       ⟨spinGroup.negOne Q (by
           let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
           exact hQ.ne_zero),
@@ -76,27 +79,77 @@ theorem spinKernelEquivZModTwo_apply_ofAdd_one
             let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
             exact hQ.ne_zero)⟩ := by
   let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-  rw [spinKernelEquivZModTwo, zmodMulEquivOfGenerator_apply_ofAdd_one]
+  rw [zmodTwoMulEquivSpinKernel, zmodMulEquivOfGenerator_apply_ofAdd_one]
 
-/-- Over a separably closed field, the Spin action is the group extension
-`1 → ZMod 2 → Spin(Q) → SO(Q) → 1`. -/
-noncomputable def spinDoubleCover [IsSepClosed K]
+/-- The inverse kernel equivalence sends the scalar `-1` to the chosen generator of
+`Multiplicative (ZMod 2)`. -/
+@[simp]
+theorem zmodTwoMulEquivSpinKernel_symm_apply_negOne
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    (zmodTwoMulEquivSpinKernel hV Q hQ).symm
+        ⟨spinGroup.negOne Q (by
+            let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
+            exact hQ.ne_zero),
+          spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q
+            (by
+              let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
+              exact hQ.ne_zero)⟩ =
+      Multiplicative.ofAdd 1 := by
+  rw [MulEquiv.symm_apply_eq, zmodTwoMulEquivSpinKernel_apply_ofAdd_one]
+
+/-- A surjective Spin action on a positive-dimensional nondegenerate quadratic space over a field
+in which `2` is invertible is the group extension `1 → ZMod 2 → Spin(Q) → SO(Q) → 1`. -/
+noncomputable def spinDoubleCoverOfSurjective
+    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (hsurj : Function.Surjective (spinToSpecialOrthogonal Q)) :
     GroupExtension (Multiplicative (ZMod 2)) (spinGroup Q)
       (QuadraticMap.specialOrthogonalGroup Q) where
   inl := (MonoidHom.ker (spinToSpecialOrthogonal Q)).subtype.comp
-    (spinKernelEquivZModTwo hV Q hQ).toMonoidHom
+    (zmodTwoMulEquivSpinKernel hV Q hQ).toMonoidHom
   rightHom := spinToSpecialOrthogonal Q
   inl_injective := fun x y h =>
-    (spinKernelEquivZModTwo hV Q hQ).injective (Subtype.ext h)
+    (zmodTwoMulEquivSpinKernel hV Q hQ).injective (Subtype.ext h)
   range_inl_eq_ker_rightHom := by
     rw [MonoidHom.range_comp]
-    have hrange : (spinKernelEquivZModTwo hV Q hQ).toMonoidHom.range = ⊤ :=
-      MonoidHom.range_eq_top.mpr (spinKernelEquivZModTwo hV Q hQ).surjective
+    have hrange : (zmodTwoMulEquivSpinKernel hV Q hQ).toMonoidHom.range = ⊤ :=
+      MonoidHom.range_eq_top.mpr (zmodTwoMulEquivSpinKernel hV Q hQ).surjective
     rw [hrange, ← MonoidHom.range_eq_map, Subgroup.range_subtype]
-  rightHom_surjective := spinToSpecialOrthogonal_surjective Q hQ
+  rightHom_surjective := hsurj
 
-/-- The inclusion in the Spin double cover sends the generator to the scalar `-1`. -/
+/-- The inclusion in a Spin double cover built from a surjectivity proof sends the generator to
+the scalar `-1`. -/
+@[simp]
+theorem spinDoubleCoverOfSurjective_inl_ofAdd_one
+    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (hsurj : Function.Surjective (spinToSpecialOrthogonal Q)) :
+    (spinDoubleCoverOfSurjective hV Q hQ hsurj).inl (Multiplicative.ofAdd 1) =
+      spinGroup.negOne Q (by
+        let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
+        exact hQ.ne_zero) := by
+  let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
+  -- Expose the kernel subtype beneath the bundled extension inclusion.
+  change ((zmodTwoMulEquivSpinKernel hV Q hQ (Multiplicative.ofAdd 1) :
+    MonoidHom.ker (spinToSpecialOrthogonal Q)) : spinGroup Q) = _
+  rw [zmodTwoMulEquivSpinKernel_apply_ofAdd_one]
+
+/-- The projection in a Spin double cover built from a surjectivity proof is the Spin action. -/
+@[simp]
+theorem spinDoubleCoverOfSurjective_rightHom
+    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (hsurj : Function.Surjective (spinToSpecialOrthogonal Q)) :
+    (spinDoubleCoverOfSurjective hV Q hQ hsurj).rightHom = spinToSpecialOrthogonal Q := by
+  rfl
+
+/-- Over a separably closed field in which `2` is invertible, the Spin action is the group
+extension `1 → ZMod 2 → Spin(Q) → SO(Q) → 1`. -/
+noncomputable def spinDoubleCover [IsSepClosed K]
+    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    GroupExtension (Multiplicative (ZMod 2)) (spinGroup Q)
+      (QuadraticMap.specialOrthogonalGroup Q) :=
+  spinDoubleCoverOfSurjective hV Q hQ (spinToSpecialOrthogonal_surjective Q hQ)
+
+/-- The inclusion in the separably closed Spin double cover sends the generator to the scalar
+`-1`. -/
 @[simp]
 theorem spinDoubleCover_inl_ofAdd_one [IsSepClosed K]
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
@@ -104,17 +157,13 @@ theorem spinDoubleCover_inl_ofAdd_one [IsSepClosed K]
       spinGroup.negOne Q (by
         let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
         exact hQ.ne_zero) := by
-  let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
-  -- Expose the kernel subtype beneath the bundled extension inclusion.
-  change ((spinKernelEquivZModTwo hV Q hQ (Multiplicative.ofAdd 1) :
-    MonoidHom.ker (spinToSpecialOrthogonal Q)) : spinGroup Q) = _
-  rw [spinKernelEquivZModTwo_apply_ofAdd_one]
+  rw [spinDoubleCover, spinDoubleCoverOfSurjective_inl_ofAdd_one]
 
-/-- The projection in the Spin double cover is the Spin action. -/
+/-- The projection in the separably closed Spin double cover is the Spin action. -/
 @[simp]
 theorem spinDoubleCover_rightHom [IsSepClosed K]
     (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     (spinDoubleCover hV Q hQ).rightHom = spinToSpecialOrthogonal Q := by
-  rfl
+  rw [spinDoubleCover, spinDoubleCoverOfSurjective_rightHom]
 
 end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Kernel
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Surjectivity
+public import Mathlib.GroupTheory.GroupExtension.Defs
+import Mathlib.GroupTheory.SpecificGroups.Cyclic
+
+/-!
+# The Spin double cover as a group extension
+
+For a positive-dimensional finite nondegenerate quadratic space, the kernel of the Spin action
+is canonically identified with the multiplicative group underlying `ZMod 2`. Over a separably
+closed field, surjectivity of the action then packages the Spin double cover as a
+`GroupExtension`.
+
+## Main definitions
+
+* `TauCeti.CliffordAlgebra.spinKernelEquivZModTwo` identifies the kernel with
+  `Multiplicative (ZMod 2)`.
+* `TauCeti.CliffordAlgebra.spinDoubleCover` packages
+  `1 → ZMod 2 → Spin(Q) → SO(Q) → 1` as a group extension.
+
+## References
+
+This completes the short-exact-sequence part of Layer 2 in
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. See H. B. Lawson and
+M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+-/
+
+public section
+
+open CliffordAlgebra
+
+namespace TauCeti.CliffordAlgebra
+
+universe u v
+
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+  [FiniteDimensional K V] [Invertible (2 : K)]
+
+/-- The kernel of the Spin action on a positive-dimensional nondegenerate quadratic space is
+canonically the cyclic group of order two, with its generator sent to the scalar `-1`. -/
+noncomputable def spinKernelEquivZModTwo
+    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    Multiplicative (ZMod 2) ≃* MonoidHom.ker (spinToSpecialOrthogonal Q) := by
+  let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
+  let z : MonoidHom.ker (spinToSpecialOrthogonal Q) :=
+    ⟨spinGroup.negOne Q hQ.ne_zero,
+      spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q hQ.ne_zero⟩
+  apply zmodMulEquivOfGenerator (g := z)
+  · intro x
+    rcases (mem_ker_spinToSpecialOrthogonal_iff Q hQ x).mp x.2 with hx | hx
+    · have hx' : x = 1 := Subtype.ext hx
+      rw [hx']
+      exact Subgroup.one_mem _
+    · have hx' : x = z := Subtype.ext hx
+      rw [hx']
+      exact Subgroup.mem_zpowers z
+  · exact card_ker_spinToSpecialOrthogonal hV Q hQ
+
+/-- The chosen generator of `Multiplicative (ZMod 2)` maps to the scalar `-1` in the Spin
+kernel. -/
+@[simp]
+theorem spinKernelEquivZModTwo_apply_ofAdd_one
+    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    spinKernelEquivZModTwo hV Q hQ (Multiplicative.ofAdd 1) =
+      ⟨spinGroup.negOne Q (by
+          let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
+          exact hQ.ne_zero),
+        spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q
+          (by
+            let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
+            exact hQ.ne_zero)⟩ := by
+  let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
+  rw [spinKernelEquivZModTwo, zmodMulEquivOfGenerator_apply_ofAdd_one]
+
+/-- Over a separably closed field, the Spin action is the group extension
+`1 → ZMod 2 → Spin(Q) → SO(Q) → 1`. -/
+noncomputable def spinDoubleCover [IsSepClosed K]
+    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    GroupExtension (Multiplicative (ZMod 2)) (spinGroup Q)
+      (QuadraticMap.specialOrthogonalGroup Q) where
+  inl := (MonoidHom.ker (spinToSpecialOrthogonal Q)).subtype.comp
+    (spinKernelEquivZModTwo hV Q hQ).toMonoidHom
+  rightHom := spinToSpecialOrthogonal Q
+  inl_injective := fun x y h =>
+    (spinKernelEquivZModTwo hV Q hQ).injective (Subtype.ext h)
+  range_inl_eq_ker_rightHom := by
+    rw [MonoidHom.range_comp]
+    have hrange : (spinKernelEquivZModTwo hV Q hQ).toMonoidHom.range = ⊤ :=
+      MonoidHom.range_eq_top.mpr (spinKernelEquivZModTwo hV Q hQ).surjective
+    rw [hrange, ← MonoidHom.range_eq_map, Subgroup.range_subtype]
+  rightHom_surjective := spinToSpecialOrthogonal_surjective Q hQ
+
+/-- The inclusion in the Spin double cover sends the generator to the scalar `-1`. -/
+@[simp]
+theorem spinDoubleCover_inl_ofAdd_one [IsSepClosed K]
+    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    (spinDoubleCover hV Q hQ).inl (Multiplicative.ofAdd 1) =
+      spinGroup.negOne Q (by
+        let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
+        exact hQ.ne_zero) := by
+  let _ : Nontrivial V := Module.nontrivial_of_finrank_pos hV
+  -- Expose the kernel subtype beneath the bundled extension inclusion.
+  change ((spinKernelEquivZModTwo hV Q hQ (Multiplicative.ofAdd 1) :
+    MonoidHom.ker (spinToSpecialOrthogonal Q)) : spinGroup Q) = _
+  rw [spinKernelEquivZModTwo_apply_ofAdd_one]
+
+/-- The projection in the Spin double cover is the Spin action. -/
+@[simp]
+theorem spinDoubleCover_rightHom [IsSepClosed K]
+    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    (spinDoubleCover hV Q hQ).rightHom = spinToSpecialOrthogonal Q := by
+  rfl
+
+end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
@@ -44,71 +44,70 @@ namespace TauCeti.CliffordAlgebra
 
 universe u v
 
-variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V] [Nontrivial V]
   [FiniteDimensional K V] [Invertible (2 : K)]
 
 /-- A surjective Spin action on a positive-dimensional nondegenerate quadratic space over a field
 in which `2` is invertible is the group extension `1 → ZMod 2 → Spin(Q) → SO(Q) → 1`. -/
 noncomputable def spinDoubleCoverOfSurjective
-    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
     (hsurj : Function.Surjective (spinToSpecialOrthogonal Q)) :
     GroupExtension (Multiplicative (ZMod 2)) (spinGroup Q)
       (QuadraticMap.specialOrthogonalGroup Q) :=
   GroupExtension.ofMulEquivKer hsurj
-    (zmodTwoMulEquivKerSpinToSpecialOrthogonal hV Q hQ)
+    (zmodTwoMulEquivKerSpinToSpecialOrthogonal Q hQ)
 
 /-- The inclusion in a Spin double cover built from a surjectivity proof sends the generator to
 the scalar `-1`. -/
 @[simp]
 theorem spinDoubleCoverOfSurjective_inl_ofAdd_one
-    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
     (hsurj : Function.Surjective (spinToSpecialOrthogonal Q)) :
-    (spinDoubleCoverOfSurjective hV Q hQ hsurj).inl (Multiplicative.ofAdd 1) =
-      spinGroup.negOne Q (hQ.ne_zero_of_finrank_pos hV) := by
+    (spinDoubleCoverOfSurjective Q hQ hsurj).inl (Multiplicative.ofAdd 1) =
+      spinGroup.negOne Q hQ.ne_zero := by
   rw [spinDoubleCoverOfSurjective, GroupExtension.ofMulEquivKer_inl,
     MonoidHom.comp_apply]
   exact congrArg Subtype.val
-    (zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one hV Q hQ)
+    (zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one Q hQ)
 
 /-- The projection in a Spin double cover built from a surjectivity proof is the Spin action. -/
 @[simp]
 theorem spinDoubleCoverOfSurjective_rightHom
-    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
     (hsurj : Function.Surjective (spinToSpecialOrthogonal Q)) :
-    (spinDoubleCoverOfSurjective hV Q hQ hsurj).rightHom = spinToSpecialOrthogonal Q :=
+    (spinDoubleCoverOfSurjective Q hQ hsurj).rightHom = spinToSpecialOrthogonal Q :=
   GroupExtension.ofMulEquivKer_rightHom _ _
 
 /-- For a positive-dimensional nondegenerate quadratic space over a separably closed field in
 which `2` is invertible, the Spin action is the group extension
 `1 → ZMod 2 → Spin(Q) → SO(Q) → 1`. -/
 noncomputable def spinDoubleCover [IsSepClosed K]
-    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     GroupExtension (Multiplicative (ZMod 2)) (spinGroup Q)
       (QuadraticMap.specialOrthogonalGroup Q) :=
-  spinDoubleCoverOfSurjective hV Q hQ (spinToSpecialOrthogonal_surjective Q hQ)
+  spinDoubleCoverOfSurjective Q hQ (spinToSpecialOrthogonal_surjective Q hQ)
 
 /-- The separably closed Spin double cover is the generic construction applied to canonical
 surjectivity. -/
-theorem spinDoubleCover_eq [IsSepClosed K]
-    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
-    spinDoubleCover hV Q hQ =
-      spinDoubleCoverOfSurjective hV Q hQ (spinToSpecialOrthogonal_surjective Q hQ) :=
+theorem spinDoubleCover_def [IsSepClosed K]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    spinDoubleCover Q hQ =
+      spinDoubleCoverOfSurjective Q hQ (spinToSpecialOrthogonal_surjective Q hQ) :=
   (rfl)
 
 /-- The inclusion in the separably closed Spin double cover sends the generator to the scalar
 `-1`. -/
 @[simp]
 theorem spinDoubleCover_inl_ofAdd_one [IsSepClosed K]
-    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
-    (spinDoubleCover hV Q hQ).inl (Multiplicative.ofAdd 1) =
-      spinGroup.negOne Q (hQ.ne_zero_of_finrank_pos hV) := by
-  rw [spinDoubleCover_eq, spinDoubleCoverOfSurjective_inl_ofAdd_one]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    (spinDoubleCover Q hQ).inl (Multiplicative.ofAdd 1) = spinGroup.negOne Q hQ.ne_zero := by
+  rw [spinDoubleCover_def, spinDoubleCoverOfSurjective_inl_ofAdd_one]
 
 /-- The projection in the separably closed Spin double cover is the Spin action. -/
 @[simp]
 theorem spinDoubleCover_rightHom [IsSepClosed K]
-    (hV : 0 < Module.finrank K V) (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
-    (spinDoubleCover hV Q hQ).rightHom = spinToSpecialOrthogonal Q := by
-  rw [spinDoubleCover_eq, spinDoubleCoverOfSurjective_rightHom]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    (spinDoubleCover Q hQ).rightHom = spinToSpecialOrthogonal Q := by
+  rw [spinDoubleCover_def, spinDoubleCoverOfSurjective_rightHom]
 
 end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -316,8 +316,8 @@ theorem zmodTwoMulEquivKerSpinToSpecialOrthogonal_symm_apply_negOne
           spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q
             (hQ.ne_zero_of_finrank_pos hM)⟩ =
       Multiplicative.ofAdd 1 := by
-  rw [MulEquiv.symm_apply_eq,
-    zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one]
+  simp only [zmodTwoMulEquivKerSpinToSpecialOrthogonal,
+    zmodMulEquivOfGenerator_symm_apply_generator]
 
 end Kernel
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -278,43 +278,40 @@ theorem card_ker_spinToSpecialOrthogonal (hM : 0 < Module.finrank K M)
 /-- The kernel of the Spin action on a positive-dimensional nondegenerate quadratic space over a
 field in which `2` is invertible is canonically the cyclic group of order two, with its generator
 sent to the scalar `-1`. -/
-noncomputable def zmodTwoMulEquivKerSpinToSpecialOrthogonal
-    (hM : 0 < Module.finrank K M) (Q : QuadraticForm K M) [Invertible (2 : K)]
+noncomputable def zmodTwoMulEquivKerSpinToSpecialOrthogonal [Nontrivial M]
+    (Q : QuadraticForm K M) [Invertible (2 : K)]
     (hQ : Q.Nondegenerate) :
     Multiplicative (ZMod 2) ≃* MonoidHom.ker (spinToSpecialOrthogonal Q) :=
-  let _ : Nontrivial M := Module.nontrivial_of_finrank_pos hM
   let z : MonoidHom.ker (spinToSpecialOrthogonal Q) :=
     ⟨spinGroup.negOne Q hQ.ne_zero,
       spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q hQ.ne_zero⟩
   zmodMulEquivOfGenerator (g := z)
     (fun _ ↦ mem_zpowers_of_prime_card (p := 2)
-      (card_ker_spinToSpecialOrthogonal hM Q hQ)
+      (card_ker_spinToSpecialOrthogonal Module.finrank_pos Q hQ)
       (fun h ↦ spinGroup.negOne_ne_one Q hQ.ne_zero (congrArg Subtype.val h)))
-    (card_ker_spinToSpecialOrthogonal hM Q hQ)
+    (card_ker_spinToSpecialOrthogonal Module.finrank_pos Q hQ)
 
 /-- The chosen generator of `Multiplicative (ZMod 2)` maps to the scalar `-1` in the Spin
 kernel. -/
 @[simp]
-theorem zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one
-    (hM : 0 < Module.finrank K M) (Q : QuadraticForm K M) [Invertible (2 : K)]
+theorem zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one [Nontrivial M]
+    (Q : QuadraticForm K M) [Invertible (2 : K)]
     (hQ : Q.Nondegenerate) :
-    zmodTwoMulEquivKerSpinToSpecialOrthogonal hM Q hQ (Multiplicative.ofAdd 1) =
-      ⟨spinGroup.negOne Q (hQ.ne_zero_of_finrank_pos hM),
-        spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q
-          (hQ.ne_zero_of_finrank_pos hM)⟩ := by
+    zmodTwoMulEquivKerSpinToSpecialOrthogonal Q hQ (Multiplicative.ofAdd 1) =
+      ⟨spinGroup.negOne Q hQ.ne_zero,
+        spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q hQ.ne_zero⟩ := by
   simp only [zmodTwoMulEquivKerSpinToSpecialOrthogonal,
     zmodMulEquivOfGenerator_apply_ofAdd_one]
 
 /-- The inverse kernel equivalence sends the scalar `-1` to the chosen generator of
 `Multiplicative (ZMod 2)`. -/
 @[simp]
-theorem zmodTwoMulEquivKerSpinToSpecialOrthogonal_symm_apply_negOne
-    (hM : 0 < Module.finrank K M) (Q : QuadraticForm K M) [Invertible (2 : K)]
+theorem zmodTwoMulEquivKerSpinToSpecialOrthogonal_symm_apply_negOne [Nontrivial M]
+    (Q : QuadraticForm K M) [Invertible (2 : K)]
     (hQ : Q.Nondegenerate) :
-    (zmodTwoMulEquivKerSpinToSpecialOrthogonal hM Q hQ).symm
-        ⟨spinGroup.negOne Q (hQ.ne_zero_of_finrank_pos hM),
-          spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q
-            (hQ.ne_zero_of_finrank_pos hM)⟩ =
+    (zmodTwoMulEquivKerSpinToSpecialOrthogonal Q hQ).symm
+        ⟨spinGroup.negOne Q hQ.ne_zero,
+          spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q hQ.ne_zero⟩ =
       Multiplicative.ofAdd 1 := by
   simp only [zmodTwoMulEquivKerSpinToSpecialOrthogonal,
     zmodMulEquivOfGenerator_symm_apply_generator]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -22,6 +22,12 @@ contraction and the exterior-algebra basis. Unitarity then restricts the scalar 
 exactly when it is `1` or the canonical scalar `-1`.
 * `TauCeti.CliffordAlgebra.card_ker_spinToSpecialOrthogonal`: the kernel of the Spin action on
 the special orthogonal group has cardinality two.
+* `TauCeti.CliffordAlgebra.zmodTwoMulEquivKerSpinToSpecialOrthogonal`: the kernel is canonically
+  equivalent to `Multiplicative (ZMod 2)`.
+* `TauCeti.CliffordAlgebra.zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one`: the chosen
+  generator maps to the scalar `-1`.
+* `TauCeti.CliffordAlgebra.zmodTwoMulEquivKerSpinToSpecialOrthogonal_symm_apply_negOne`: the inverse
+  sends the scalar `-1` to the chosen generator.
 
 ## References
 
@@ -268,6 +274,50 @@ theorem card_ker_spinToSpecialOrthogonal (hM : 0 < Module.finrank K M)
       apply Subtype.ext
       exact h
     · simpa [z] using h
+
+/-- The kernel of the Spin action on a positive-dimensional nondegenerate quadratic space over a
+field in which `2` is invertible is canonically the cyclic group of order two, with its generator
+sent to the scalar `-1`. -/
+noncomputable def zmodTwoMulEquivKerSpinToSpecialOrthogonal
+    (hM : 0 < Module.finrank K M) (Q : QuadraticForm K M) [Invertible (2 : K)]
+    (hQ : Q.Nondegenerate) :
+    Multiplicative (ZMod 2) ≃* MonoidHom.ker (spinToSpecialOrthogonal Q) :=
+  let _ : Nontrivial M := Module.nontrivial_of_finrank_pos hM
+  let z : MonoidHom.ker (spinToSpecialOrthogonal Q) :=
+    ⟨spinGroup.negOne Q hQ.ne_zero,
+      spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q hQ.ne_zero⟩
+  zmodMulEquivOfGenerator (g := z)
+    (fun _ ↦ mem_zpowers_of_prime_card (p := 2)
+      (card_ker_spinToSpecialOrthogonal hM Q hQ)
+      (fun h ↦ spinGroup.negOne_ne_one Q hQ.ne_zero (congrArg Subtype.val h)))
+    (card_ker_spinToSpecialOrthogonal hM Q hQ)
+
+/-- The chosen generator of `Multiplicative (ZMod 2)` maps to the scalar `-1` in the Spin
+kernel. -/
+@[simp]
+theorem zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one
+    (hM : 0 < Module.finrank K M) (Q : QuadraticForm K M) [Invertible (2 : K)]
+    (hQ : Q.Nondegenerate) :
+    zmodTwoMulEquivKerSpinToSpecialOrthogonal hM Q hQ (Multiplicative.ofAdd 1) =
+      ⟨spinGroup.negOne Q (hQ.ne_zero_of_finrank_pos hM),
+        spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q
+          (hQ.ne_zero_of_finrank_pos hM)⟩ := by
+  simp only [zmodTwoMulEquivKerSpinToSpecialOrthogonal,
+    zmodMulEquivOfGenerator_apply_ofAdd_one]
+
+/-- The inverse kernel equivalence sends the scalar `-1` to the chosen generator of
+`Multiplicative (ZMod 2)`. -/
+@[simp]
+theorem zmodTwoMulEquivKerSpinToSpecialOrthogonal_symm_apply_negOne
+    (hM : 0 < Module.finrank K M) (Q : QuadraticForm K M) [Invertible (2 : K)]
+    (hQ : Q.Nondegenerate) :
+    (zmodTwoMulEquivKerSpinToSpecialOrthogonal hM Q hQ).symm
+        ⟨spinGroup.negOne Q (hQ.ne_zero_of_finrank_pos hM),
+          spinGroup.negOne_mem_ker_spinToSpecialOrthogonal Q
+            (hQ.ne_zero_of_finrank_pos hM)⟩ =
+      Multiplicative.ofAdd 1 := by
+  rw [MulEquiv.symm_apply_eq,
+    zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one]
 
 end Kernel
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -28,4 +28,11 @@ theorem ne_zero [Nontrivial M] {Q : QuadraticForm R M} (hQ : Q.Nondegenerate) : 
     simp
   rwa [hQ.radical_eq_bot, Submodule.mem_bot] at hm
 
+/-- A nondegenerate quadratic form on a positive-dimensional finite module is nonzero. -/
+theorem ne_zero_of_finrank_pos {R M : Type*} [CommRing R] [Nontrivial R]
+    [AddCommGroup M] [Module R M] {Q : QuadraticForm R M}
+    (hQ : Q.Nondegenerate) (hM : 0 < Module.finrank R M) : Q ≠ 0 := by
+  let _ : Nontrivial M := Module.nontrivial_of_finrank_pos hM
+  exact hQ.ne_zero
+
 end QuadraticMap.Nondegenerate

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -28,11 +28,4 @@ theorem ne_zero [Nontrivial M] {Q : QuadraticForm R M} (hQ : Q.Nondegenerate) : 
     simp
   rwa [hQ.radical_eq_bot, Submodule.mem_bot] at hm
 
-/-- A nondegenerate quadratic form on a positive-dimensional finite module is nonzero. -/
-theorem ne_zero_of_finrank_pos {R M : Type*} [CommRing R] [Nontrivial R]
-    [AddCommGroup M] [Module R M] {Q : QuadraticForm R M}
-    (hQ : Q.Nondegenerate) (hM : 0 < Module.finrank R M) : Q ≠ 0 := by
-  let _ : Nontrivial M := Module.nontrivial_of_finrank_pos hM
-  exact hQ.ne_zero
-
 end QuadraticMap.Nondegenerate


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Packages the algebraic Spin double cover as a group extension.

- Identifies the kernel of the Spin action with `Multiplicative (ZMod 2)`.
- Sends its chosen generator to the scalar `-1`.
- Bundles `1 → ZMod 2 → Spin(Q) → SO(Q) → 1`.

## Roadmap target

Completes the Layer 2 short-exact-sequence boundary:
https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-2-the-double-cover-spin--so

## Verification

Full builds, audits, lint, consumers, golf, and fresh aggregate review pass at `62305607cdf98e4ffb19145e09983718f57797b3`.

## Scale and generality

Adds one 169-line file. The kernel equivalence uses a positive-dimensional finite nondegenerate quadratic space over a field with invertible `2`. The general extension takes a Spin-action surjectivity proof; separable closure supplies the canonical specialization.

## Scope

- **Consumes:** merged Spin-kernel classification and Spin-to-SO surjectivity.
- **Provides:** the kernel equivalence and bundled `GroupExtension`, with generator and projection equations.
- **Fits:** completes the algebraic short-exact-sequence boundary for later Spin structure theory.
- **Boundary:** general-field spinor norm and topological covering structure require separate input.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [a66b04d](https://github.com/TauCetiProject/TauCetiReview/commit/a66b04d97721565b13c8abe07f750fb1d2959ad5) · local 2+1 review @ [4a3ce2b](https://github.com/utensil/formal-land/commit/4a3ce2ba031ff1c2bece478a842ba6b1e8b74364) fixed: api-design (2), naming (2), proof-quality (1), reuse (1)</sub>