### PR TITLE
feat: the symmetric powers of the standard representation of SU(2)

### DIFF
--- a/TauCeti/Data/Sym/Basic.lean
+++ b/TauCeti/Data/Sym/Basic.lean
@@ -6,8 +6,12 @@ module
 
 public import Mathlib.Data.Fin.Tuple.Basic
 public import Mathlib.Data.Sym.Basic
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Data.Finset.NatAntidiagonal
+import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Data.Fintype.EquivFin
 import Mathlib.Data.List.FinRange
+import Mathlib.Logic.Equiv.Fin.Basic
 
 /-!
 # Basic lemmas for symmetric powers
@@ -26,6 +30,8 @@ orbits of the permutation action, by `TauCeti.Sym.ofFn_eq_ofFn_iff`. Nothing her
   `TauCeti.Sym.ofFn_surjective`, that every unordered tuple arises this way.
 * `TauCeti.Sym.ofFn_eq_ofFn_iff`: two ordered tuples have the same underlying unordered tuple
   exactly when one is a reindexing of the other by a permutation.
+* `TauCeti.symFinTwoEquiv`: an unordered `d`-tuple over `Fin 2` is determined by how many of its
+  entries are `0`, so there are `d + 1` of them.
 -/
 
 public section
@@ -112,5 +118,29 @@ theorem ofFn_eq_ofFn_iff {f g : Fin n → α} :
     exact (ofFn_comp_perm σ f).symm
 
 end Sym
+
+/-! ### Unordered tuples over a two-element type -/
+
+/-- **A multiset of size `d` over `Fin 2` is determined by how many of its entries are `0`**, and
+that count can be anything from `0` to `d`: the two counts sum to `d`, so the pair of them runs
+over the antidiagonal of `d`.  This is the rank-two instance of the count
+`#(Sym α d) = (#α + d - 1).choose d`. -/
+noncomputable def symFinTwoEquiv (d : ℕ) : Sym (Fin 2) d ≃ Fin (d + 1) :=
+  (Sym.equivNatSumOfFintype (Fin 2) d).trans <|
+    ((finTwoArrowEquiv ℕ).subtypeEquiv fun _ => by
+      simp [Fin.sum_univ_two, Finset.mem_antidiagonal]).trans
+        (Finset.Nat.antidiagonalEquivFin d)
+
+/-- `TauCeti.symFinTwoEquiv` is the number of entries equal to `0`. -/
+@[simp]
+theorem coe_symFinTwoEquiv_apply (d : ℕ) (s : Sym (Fin 2) d) :
+    (symFinTwoEquiv d s : ℕ) = Multiset.count 0 (s : Multiset (Fin 2)) := (rfl)
+
+/-- The inverse of `TauCeti.symFinTwoEquiv` spelled out: `i` many `0`s and `d - i` many `1`s. -/
+@[simp]
+theorem coe_symFinTwoEquiv_symm_apply (d : ℕ) (i : Fin (d + 1)) :
+    (((symFinTwoEquiv d).symm i : Sym (Fin 2) d) : Multiset (Fin 2))
+      = Multiset.replicate (i : ℕ) 0 + Multiset.replicate (d - (i : ℕ)) 1 := by
+  simp [symFinTwoEquiv, Fin.sum_univ_two, Multiset.nsmul_singleton]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
@@ -29,6 +29,8 @@ elementary symmetric polynomial the exterior power gives.
 
 ## Main results
 
+* `TauCeti.eval_hsymm` evaluates the complete homogeneous symmetric polynomial as a sum over the
+  unordered `d`-tuples of indices.
 * `TauCeti.char_symPowerRep_diagonal` identifies the character on diagonal matrices with a
   complete homogeneous symmetric polynomial.
 
@@ -46,6 +48,16 @@ open Matrix
 open scoped TensorProduct
 
 namespace TauCeti
+
+/-- **The complete homogeneous symmetric polynomial evaluated**: `h_d(f)` is the sum, over the
+unordered `d`-tuples of indices, of the product of the values `f` takes on the tuple. -/
+theorem eval_hsymm {σ R : Type*} [Fintype σ] [DecidableEq σ] [CommSemiring R] (f : σ → R)
+    (d : ℕ) : MvPolynomial.eval f (MvPolynomial.hsymm σ R d)
+      = ∑ s : Sym σ d, ((s : Multiset σ).map f).prod := by
+  rw [MvPolynomial.hsymm, map_sum]
+  refine Finset.sum_congr rfl fun s _ => ?_
+  rw [map_multiset_prod, Multiset.map_map]
+  simp [Function.comp_def]
 
 variable (k : Type) (n d : ℕ)
 
@@ -77,11 +89,7 @@ theorem char_symPowerRep_diagonal (t : Fin n → kˣ) : (symPowerRep k n d).char
     SymmetricPower.trace_map_of_apply_basis (Pi.basisFun k (Fin n))
       (stdRep k n (diagGL t)) (fun i => (t i : k)) d (stdRep_diagGL_apply_basisFun t)]
   -- both sides sum, over the unordered `d`-tuples of indices, the product of the entries listed
-  rw [MvPolynomial.hsymm, map_sum]
-  refine Finset.sum_congr rfl fun s _ => ?_
-  rw [map_multiset_prod, Multiset.map_map]
-  simp only [Function.comp_def, MvPolynomial.eval_X]
-  rfl
+  rw [eval_hsymm]
 
 /-- The character of the bundled `d`th symmetric power on a diagonal matrix is the `d`th complete
 homogeneous symmetric polynomial in its diagonal entries. -/

--- a/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
@@ -4,6 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Data.Finset.NatAntidiagonal
+public import Mathlib.Data.Finsupp.Multiset
+public import Mathlib.Logic.Equiv.Fin.Basic
 public import Mathlib.RingTheory.MvPolynomial.Symmetric.Defs
 public import TauCeti.LinearAlgebra.SymmetricPower.Basis
 public import TauCeti.RepresentationTheory.ClassicalGroups.Diagonal
@@ -24,6 +27,7 @@ elementary symmetric polynomial the exterior power gives.
 
 ## Main definitions
 
+* `TauCeti.symFinTwoEquiv` counts the unordered `d`-tuples of indices in two variables.
 * `TauCeti.symPowerRep` is the symmetric-power representation of `GL n k`.
 * `TauCeti.symPowerFDRep` is its bundled finite-dimensional form.
 
@@ -31,6 +35,7 @@ elementary symmetric polynomial the exterior power gives.
 
 * `TauCeti.eval_hsymm` evaluates the complete homogeneous symmetric polynomial as a sum over the
   unordered `d`-tuples of indices.
+* `TauCeti.eval_hsymm_fin_two` reads that off in two variables: `h_d(x, y) = ∑_{i ≤ d} xⁱ y^{d-i}`.
 * `TauCeti.char_symPowerRep_diagonal` identifies the character on diagonal matrices with a
   complete homogeneous symmetric polynomial.
 
@@ -58,6 +63,40 @@ theorem eval_hsymm {σ R : Type*} [Fintype σ] [DecidableEq σ] [CommSemiring R]
   refine Finset.sum_congr rfl fun s _ => ?_
   rw [map_multiset_prod, Multiset.map_map]
   simp [Function.comp_def]
+
+/-- **A multiset of size `d` over `Fin 2` is determined by how many of its entries are `0`**, and
+that count can be anything from `0` to `d`: the two counts sum to `d`, so the pair of them runs
+over the antidiagonal of `d`.  This is the rank-two instance of the count
+`#(Sym α d) = (#α + d - 1).choose d`, in the form the symmetric-polynomial computation below
+consumes. -/
+noncomputable def symFinTwoEquiv (d : ℕ) : Sym (Fin 2) d ≃ Fin (d + 1) :=
+  (Sym.equivNatSumOfFintype (Fin 2) d).trans <|
+    ((finTwoArrowEquiv ℕ).subtypeEquiv fun _ => by
+      simp [Fin.sum_univ_two, Finset.mem_antidiagonal]).trans
+        (Finset.Nat.antidiagonalEquivFin d)
+
+/-- `TauCeti.symFinTwoEquiv` is the number of entries equal to `0`. -/
+@[simp]
+theorem coe_symFinTwoEquiv_apply (d : ℕ) (s : Sym (Fin 2) d) :
+    (symFinTwoEquiv d s : ℕ) = Multiset.count 0 (s : Multiset (Fin 2)) := (rfl)
+
+/-- The inverse of `TauCeti.symFinTwoEquiv` spelled out: `i` many `0`s and `d - i` many `1`s. -/
+@[simp]
+theorem coe_symFinTwoEquiv_symm_apply (d : ℕ) (i : Fin (d + 1)) :
+    (((symFinTwoEquiv d).symm i : Sym (Fin 2) d) : Multiset (Fin 2))
+      = Multiset.replicate (i : ℕ) 0 + Multiset.replicate (d - (i : ℕ)) 1 := by
+  simp [symFinTwoEquiv, Fin.sum_univ_two, Multiset.nsmul_singleton]
+
+/-- **The complete homogeneous symmetric polynomial in two variables**: `h_d(x, y)` is the sum of
+all `d + 1` monomials `xⁱ y^{d-i}` of degree `d`. -/
+theorem eval_hsymm_fin_two {R : Type*} [CommSemiring R] (f : Fin 2 → R) (d : ℕ) :
+    MvPolynomial.eval f (MvPolynomial.hsymm (Fin 2) R d)
+      = ∑ i ∈ Finset.range (d + 1), f 0 ^ i * f 1 ^ (d - i) := by
+  rw [eval_hsymm, ← Fin.sum_univ_eq_sum_range _ (d + 1),
+    ← Equiv.sum_comp (symFinTwoEquiv d).symm]
+  refine Fintype.sum_congr _ _ fun i => ?_
+  rw [coe_symFinTwoEquiv_symm_apply]
+  simp
 
 variable (k : Type) (n d : ℕ)
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
@@ -4,13 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Data.Finset.NatAntidiagonal
-public import Mathlib.Data.Finsupp.Multiset
-public import Mathlib.Logic.Equiv.Fin.Basic
 public import Mathlib.RingTheory.MvPolynomial.Symmetric.Defs
 public import TauCeti.LinearAlgebra.SymmetricPower.Basis
 public import TauCeti.RepresentationTheory.ClassicalGroups.Diagonal
 public import TauCeti.RepresentationTheory.SymmetricPower
+import TauCeti.RingTheory.MvPolynomial.Symmetric.Complete
 
 /-!
 # Symmetric powers of the standard representation
@@ -27,15 +25,11 @@ elementary symmetric polynomial the exterior power gives.
 
 ## Main definitions
 
-* `TauCeti.symFinTwoEquiv` counts the unordered `d`-tuples of indices in two variables.
 * `TauCeti.symPowerRep` is the symmetric-power representation of `GL n k`.
 * `TauCeti.symPowerFDRep` is its bundled finite-dimensional form.
 
 ## Main results
 
-* `TauCeti.eval_hsymm` evaluates the complete homogeneous symmetric polynomial as a sum over the
-  unordered `d`-tuples of indices.
-* `TauCeti.eval_hsymm_fin_two` reads that off in two variables: `h_d(x, y) = ∑_{i ≤ d} xⁱ y^{d-i}`.
 * `TauCeti.char_symPowerRep_diagonal` identifies the character on diagonal matrices with a
   complete homogeneous symmetric polynomial.
 
@@ -53,50 +47,6 @@ open Matrix
 open scoped TensorProduct
 
 namespace TauCeti
-
-/-- **The complete homogeneous symmetric polynomial evaluated**: `h_d(f)` is the sum, over the
-unordered `d`-tuples of indices, of the product of the values `f` takes on the tuple. -/
-theorem eval_hsymm {σ R : Type*} [Fintype σ] [DecidableEq σ] [CommSemiring R] (f : σ → R)
-    (d : ℕ) : MvPolynomial.eval f (MvPolynomial.hsymm σ R d)
-      = ∑ s : Sym σ d, ((s : Multiset σ).map f).prod := by
-  rw [MvPolynomial.hsymm, map_sum]
-  refine Finset.sum_congr rfl fun s _ => ?_
-  rw [map_multiset_prod, Multiset.map_map]
-  simp [Function.comp_def]
-
-/-- **A multiset of size `d` over `Fin 2` is determined by how many of its entries are `0`**, and
-that count can be anything from `0` to `d`: the two counts sum to `d`, so the pair of them runs
-over the antidiagonal of `d`.  This is the rank-two instance of the count
-`#(Sym α d) = (#α + d - 1).choose d`, in the form the symmetric-polynomial computation below
-consumes. -/
-noncomputable def symFinTwoEquiv (d : ℕ) : Sym (Fin 2) d ≃ Fin (d + 1) :=
-  (Sym.equivNatSumOfFintype (Fin 2) d).trans <|
-    ((finTwoArrowEquiv ℕ).subtypeEquiv fun _ => by
-      simp [Fin.sum_univ_two, Finset.mem_antidiagonal]).trans
-        (Finset.Nat.antidiagonalEquivFin d)
-
-/-- `TauCeti.symFinTwoEquiv` is the number of entries equal to `0`. -/
-@[simp]
-theorem coe_symFinTwoEquiv_apply (d : ℕ) (s : Sym (Fin 2) d) :
-    (symFinTwoEquiv d s : ℕ) = Multiset.count 0 (s : Multiset (Fin 2)) := (rfl)
-
-/-- The inverse of `TauCeti.symFinTwoEquiv` spelled out: `i` many `0`s and `d - i` many `1`s. -/
-@[simp]
-theorem coe_symFinTwoEquiv_symm_apply (d : ℕ) (i : Fin (d + 1)) :
-    (((symFinTwoEquiv d).symm i : Sym (Fin 2) d) : Multiset (Fin 2))
-      = Multiset.replicate (i : ℕ) 0 + Multiset.replicate (d - (i : ℕ)) 1 := by
-  simp [symFinTwoEquiv, Fin.sum_univ_two, Multiset.nsmul_singleton]
-
-/-- **The complete homogeneous symmetric polynomial in two variables**: `h_d(x, y)` is the sum of
-all `d + 1` monomials `xⁱ y^{d-i}` of degree `d`. -/
-theorem eval_hsymm_fin_two {R : Type*} [CommSemiring R] (f : Fin 2 → R) (d : ℕ) :
-    MvPolynomial.eval f (MvPolynomial.hsymm (Fin 2) R d)
-      = ∑ i ∈ Finset.range (d + 1), f 0 ^ i * f 1 ^ (d - i) := by
-  rw [eval_hsymm, ← Fin.sum_univ_eq_sum_range _ (d + 1),
-    ← Equiv.sum_comp (symFinTwoEquiv d).symm]
-  refine Fintype.sum_congr _ _ fun i => ?_
-  rw [coe_symFinTwoEquiv_symm_apply]
-  simp
 
 variable (k : Type) (n d : ℕ)
 

--- a/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.RepresentationTheory.ClassicalGroups.SymmetricPower
 public import TauCeti.RepresentationTheory.SU2.Basic
+import TauCeti.RingTheory.MvPolynomial.Symmetric.Complete
 
 /-!
 # The symmetric powers of the standard representation of `SU(2)`
@@ -22,7 +23,7 @@ The character computation is the **weight string**: on `diag(z, z⁻¹)` the cha
 
 each of the `d + 1` weights `d, d-2, …, -d` occurring exactly once.  This is what the
 highest-weight classification of the irreducible representations of `SU(2)` runs on, and the
-value `d + 1` at the identity is read off it at `z = 1`.
+value at the identity is the dimension `d + 1`, the number of those weights.
 
 The route is Layer 1's `TauCeti.char_symPowerRep_diagonal`, which gives the character at a
 diagonal matrix as the complete homogeneous symmetric polynomial `h_d` in the diagonal entries,
@@ -41,7 +42,8 @@ together with its rank-two evaluation `TauCeti.eval_hsymm_fin_two`: the geometri
   the weight string `∑_{i ≤ d} z^{2i - d}`.
 * `TauCeti.SU2.character_symPower_torusExp`: the same in exponential coordinates,
   `∑_{i ≤ d} e^{i(2i - d)θ}`.
-* `TauCeti.SU2.character_symPower_one`: the dimension is `d + 1`.
+* `TauCeti.SU2.finrank_symPower` and `TauCeti.SU2.character_symPower_one`: the dimension, and so
+  the character at the identity, is `d + 1`.
 
 ## References
 
@@ -97,6 +99,13 @@ noncomputable def symPower : Representation ℂ SU2 (Sym[ℂ]^d (Fin 2 → ℂ))
 @[simp]
 theorem symPower_apply (g : SU2) : symPower d g = symPowerRep ℂ 2 d (toGL g) := (rfl)
 
+/-- **The space `Symᵈ(ℂ²)` carrying `TauCeti.SU2.symPower d` has dimension `d + 1`**: a symmetric
+power of a free module is free on the unordered tuples of basis indices, of which there are
+`Nat.multichoose 2 d = d + 1` in two variables. -/
+@[simp]
+theorem finrank_symPower : Module.finrank ℂ (Sym[ℂ]^d (Fin 2 → ℂ)) = d + 1 := by
+  rw [SymmetricPower.finrank_eq, Module.finrank_fin_fun, Nat.multichoose_two]
+
 /-- **The weight string.**  On the maximal torus the character of `Symᵈ(ℂ²)` is
 `z^{-d} + z^{2-d} + ⋯ + z^d`: the `d + 1` weights `-d, 2-d, …, d` each occur once. -/
 theorem character_symPower_torusHom (z : Circle) :
@@ -131,13 +140,12 @@ theorem character_symPower_torusExp (θ : ℝ) :
   push_cast
   ring_nf
 
-/-- **The dimension is `d + 1`**, read off the weight string at `z = 1`: there are `d + 1`
-weights, each of multiplicity one. -/
+/-- **The dimension is `d + 1`**: the character at the identity is the rank of the underlying
+space, which is the number `d + 1` of weights of the string above, each of multiplicity one. -/
 theorem character_symPower_one : (symPower d).character 1 = (d : ℂ) + 1 := by
-  have h := character_symPower_torusHom d 1
-  rw [map_one] at h
-  rw [h]
-  simp
+  rw [Representation.char_one, finrank_symPower]
+  push_cast
+  ring
 
 end SU2
 

--- a/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
@@ -25,20 +25,17 @@ highest-weight classification of the irreducible representations of `SU(2)` runs
 value `d + 1` at the identity is read off it at `z = 1`.
 
 The route is Layer 1's `TauCeti.char_symPowerRep_diagonal`, which gives the character at a
-diagonal matrix as the complete homogeneous symmetric polynomial `h_d` in the diagonal entries.
-The rank-two case of that polynomial is the geometric-looking sum `∑ᵢ x^i y^{d-i}`, proved here
-from the bijection `TauCeti.symFinTwoEquiv` between the `d`-element multisets over a two-element
-type and `Fin (d + 1)`, which records how many of the entries are `0`.
+diagonal matrix as the complete homogeneous symmetric polynomial `h_d` in the diagonal entries,
+together with its rank-two evaluation `TauCeti.eval_hsymm_fin_two`: the geometric-looking sum
+`∑ᵢ x^i y^{d-i}`.
 
 ## Main definitions
 
-* `TauCeti.symFinTwoEquiv`: multisets of size `d` over `Fin 2` are counted by `Fin (d + 1)`.
 * `TauCeti.SU2.toGL`: `SU(2)` as a subgroup of `GL₂(ℂ)`.
 * `TauCeti.SU2.symPower`: the `d`-th symmetric power of the standard representation of `SU(2)`.
 
 ## Main results
 
-* `TauCeti.eval_hsymm_fin_two`: `h_d(x, y) = ∑_{i ≤ d} xⁱ y^{d-i}`.
 * `TauCeti.SU2.character_symPower_torusHom` and
   `TauCeti.SU2.character_symPower_torusHom_zpow`: the character of `Symᵈ` on the maximal torus is
   the weight string `∑_{i ≤ d} z^{2i - d}`.
@@ -61,56 +58,6 @@ open scoped TensorProduct
 
 namespace TauCeti
 
-/-! ### Multisets over a two-element type -/
-
-/-- **A multiset of size `d` over `Fin 2` is determined by how many of its entries are `0`**, and
-that count can be anything from `0` to `d`.  This is the rank-two instance of the count
-`#(Sym α d) = (#α + d - 1).choose d`, in the form the symmetric-polynomial computation below
-consumes. -/
-noncomputable def symFinTwoEquiv (d : ℕ) : Sym (Fin 2) d ≃ Fin (d + 1) where
-  toFun s := ⟨Multiset.count 0 s.1, by
-    have h := Multiset.count_le_card (0 : Fin 2) s.1
-    rw [s.2] at h
-    omega⟩
-  invFun i := ⟨Multiset.replicate (i : ℕ) 0 + Multiset.replicate (d - (i : ℕ)) 1, by
-    have hi : (i : ℕ) ≤ d := Nat.lt_succ_iff.mp i.2
-    simp only [Multiset.card_add, Multiset.card_replicate]
-    omega⟩
-  left_inv s := by
-    obtain ⟨m, hm⟩ := s
-    have hcount : Multiset.count (0 : Fin 2) m + Multiset.count (1 : Fin 2) m = d := by
-      have := Multiset.sum_count_eq_card (s := (univ : Finset (Fin 2))) (m := m)
-        (fun a _ => mem_univ a)
-      rw [Fin.sum_univ_two, hm] at this
-      exact this
-    refine Subtype.ext (Multiset.ext.mpr fun a => ?_)
-    have ha : a = 0 ∨ a = 1 := by fin_cases a <;> simp
-    rcases ha with rfl | rfl
-    · simp [Multiset.count_add, Multiset.count_replicate]
-    · simp only [Multiset.count_add, Multiset.count_replicate]
-      norm_num
-      omega
-  right_inv i := by
-    have hi : (i : ℕ) ≤ d := Nat.lt_succ_iff.mp i.2
-    refine Fin.ext ?_
-    simp [Multiset.count_replicate]
-
-/-- The inverse of `TauCeti.symFinTwoEquiv` spelled out: `i` many `0`s and `d - i` many `1`s. -/
-theorem coe_symFinTwoEquiv_symm_apply (d : ℕ) (i : Fin (d + 1)) :
-    (((symFinTwoEquiv d).symm i : Sym (Fin 2) d) : Multiset (Fin 2))
-      = Multiset.replicate (i : ℕ) 0 + Multiset.replicate (d - (i : ℕ)) 1 := (rfl)
-
-/-- **The complete homogeneous symmetric polynomial in two variables**: `h_d(x, y)` is the sum of
-all `d + 1` monomials `xⁱ y^{d-i}` of degree `d`. -/
-theorem eval_hsymm_fin_two {R : Type*} [CommSemiring R] (f : Fin 2 → R) (d : ℕ) :
-    MvPolynomial.eval f (MvPolynomial.hsymm (Fin 2) R d)
-      = ∑ i ∈ range (d + 1), f 0 ^ i * f 1 ^ (d - i) := by
-  rw [eval_hsymm, ← Fin.sum_univ_eq_sum_range _ (d + 1),
-    ← Equiv.sum_comp (symFinTwoEquiv d).symm]
-  refine Fintype.sum_congr _ _ fun i => ?_
-  rw [coe_symFinTwoEquiv_symm_apply]
-  simp
-
 /-! ### The symmetric powers of the standard representation -/
 
 namespace SU2
@@ -123,6 +70,10 @@ def toGL : SU2 →* GL (Fin 2) ℂ :=
 @[simp]
 theorem coe_toGL (g : SU2) :
     (toGL g : Matrix (Fin 2) (Fin 2) ℂ) = (g : Matrix (Fin 2) (Fin 2) ℂ) := (rfl)
+
+/-- The inclusion of `SU(2)` into `GL₂(ℂ)` is injective: it does not move the underlying matrix. -/
+theorem toGL_injective : Function.Injective (toGL : SU2 → GL (Fin 2) ℂ) := fun g h hgh =>
+  Subtype.ext (by rw [← coe_toGL, ← coe_toGL, hgh])
 
 /-- **The maximal torus of `SU(2)` inside the diagonal torus of `GL₂(ℂ)`**: `torusHom z` is the
 diagonal matrix `diag(z, z⁻¹)`. -/
@@ -163,8 +114,9 @@ theorem character_symPower_torusHom_zpow (z : Circle) :
   rw [character_symPower_torusHom]
   refine sum_congr rfl fun i hi => ?_
   have hi' : (i : ℕ) ≤ d := Nat.lt_succ_iff.mp (mem_range.mp hi)
-  rw [show (2 * (i : ℤ) - d) = (i : ℤ) - ((d - i : ℕ) : ℤ) by omega,
-    zpow_sub₀ (Circle.coe_ne_zero z), zpow_natCast, zpow_natCast, inv_pow,
+  -- the weight `2i - d` is the exponent of `z` minus the exponent of `z⁻¹`
+  have hexp : 2 * (i : ℤ) - d = (i : ℤ) - ((d - i : ℕ) : ℤ) := by omega
+  rw [hexp, zpow_sub₀ (Circle.coe_ne_zero z), zpow_natCast, zpow_natCast, inv_pow,
     div_eq_mul_inv]
 
 /-- **The weight string in exponential coordinates.**  Writing the torus element as
@@ -183,7 +135,7 @@ theorem character_symPower_torusExp (θ : ℝ) :
 weights, each of multiplicity one. -/
 theorem character_symPower_one : (symPower d).character 1 = (d : ℂ) + 1 := by
   have h := character_symPower_torusHom d 1
-  rw [show torusHom (1 : Circle) = 1 from map_one _] at h
+  rw [map_one] at h
   rw [h]
   simp
 

--- a/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.RepresentationTheory.ClassicalGroups.SymmetricPower
+public import TauCeti.RepresentationTheory.SU2.Basic
+
+/-!
+# The symmetric powers of the standard representation of `SU(2)`
+
+The candidate irreducible representations of `SU(2)` are the symmetric powers `Symᵈ(ℂ²)` of the
+standard representation, of dimension `d + 1`.  This file builds them, as the restriction of the
+symmetric powers of the standard representation of `GL₂(ℂ)` along the inclusion of `SU(2)`, and
+computes their characters on the maximal torus.
+
+The character computation is the **weight string**: on `diag(z, z⁻¹)` the character of `Symᵈ` is
+
+`z^d + z^{d-2} + ⋯ + z^{-d}`,
+
+each of the `d + 1` weights `d, d-2, …, -d` occurring exactly once.  This is what the
+highest-weight classification of the irreducible representations of `SU(2)` runs on, and the
+value `d + 1` at the identity is read off it at `z = 1`.
+
+The route is Layer 1's `TauCeti.char_symPowerRep_diagonal`, which gives the character at a
+diagonal matrix as the complete homogeneous symmetric polynomial `h_d` in the diagonal entries.
+The rank-two case of that polynomial is the geometric-looking sum `∑ᵢ x^i y^{d-i}`, proved here
+from the bijection `TauCeti.symFinTwoEquiv` between the `d`-element multisets over a two-element
+type and `Fin (d + 1)`, which records how many of the entries are `0`.
+
+## Main definitions
+
+* `TauCeti.symFinTwoEquiv`: multisets of size `d` over `Fin 2` are counted by `Fin (d + 1)`.
+* `TauCeti.SU2.toGL`: `SU(2)` as a subgroup of `GL₂(ℂ)`.
+* `TauCeti.SU2.symPower`: the `d`-th symmetric power of the standard representation of `SU(2)`.
+
+## Main results
+
+* `TauCeti.card_sym_fin_two`: there are `d + 1` multisets of size `d` over `Fin 2`.
+* `TauCeti.eval_hsymm_fin_two`: `h_d(x, y) = ∑_{i ≤ d} xⁱ y^{d-i}`.
+* `TauCeti.SU2.character_symPower_torusHom` and
+  `TauCeti.SU2.character_symPower_torusHom_zpow`: the character of `Symᵈ` on the maximal torus is
+  the weight string `∑_{i ≤ d} z^{2i - d}`.
+* `TauCeti.SU2.character_symPower_torusExp`: the same in exponential coordinates,
+  `∑_{i ≤ d} e^{i(2i - d)θ}`.
+* `TauCeti.SU2.character_symPower_one`: the dimension is `d + 1`.
+
+## References
+
+* [Compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
+  Layer 6, the `SU(2)` engine: the irreducibles `Symⁿ(ℂ²)` and the weight/string decomposition of
+  their characters on the maximal torus.
+* Daniel Bump, *Lie Groups*, second edition, Chapter 3.
+-/
+
+public section
+
+open Finset Matrix
+open scoped TensorProduct
+
+namespace TauCeti
+
+/-! ### Multisets over a two-element type -/
+
+/-- **A multiset of size `d` over `Fin 2` is determined by how many of its entries are `0`**, and
+that count can be anything from `0` to `d`.  This is the rank-two instance of the count
+`#(Sym α d) = (#α + d - 1).choose d`, in the form the symmetric-polynomial computation below
+consumes. -/
+noncomputable def symFinTwoEquiv (d : ℕ) : Sym (Fin 2) d ≃ Fin (d + 1) where
+  toFun s := ⟨Multiset.count 0 s.1, by
+    have h := Multiset.count_le_card (0 : Fin 2) s.1
+    rw [s.2] at h
+    omega⟩
+  invFun i := ⟨Multiset.replicate (i : ℕ) 0 + Multiset.replicate (d - (i : ℕ)) 1, by
+    have hi : (i : ℕ) ≤ d := Nat.lt_succ_iff.mp i.2
+    simp only [Multiset.card_add, Multiset.card_replicate]
+    omega⟩
+  left_inv s := by
+    obtain ⟨m, hm⟩ := s
+    have hcount : Multiset.count (0 : Fin 2) m + Multiset.count (1 : Fin 2) m = d := by
+      have := Multiset.sum_count_eq_card (s := (univ : Finset (Fin 2))) (m := m)
+        (fun a _ => mem_univ a)
+      rw [Fin.sum_univ_two, hm] at this
+      exact this
+    refine Subtype.ext (Multiset.ext.mpr fun a => ?_)
+    have ha : a = 0 ∨ a = 1 := by fin_cases a <;> simp
+    rcases ha with rfl | rfl
+    · simp [Multiset.count_add, Multiset.count_replicate]
+    · simp only [Multiset.count_add, Multiset.count_replicate]
+      norm_num
+      omega
+  right_inv i := by
+    have hi : (i : ℕ) ≤ d := Nat.lt_succ_iff.mp i.2
+    refine Fin.ext ?_
+    simp [Multiset.count_replicate]
+
+/-- The inverse of `TauCeti.symFinTwoEquiv` spelled out: `i` many `0`s and `d - i` many `1`s.
+Not a `simp` lemma, since `Sym.val_eq_coe` rewrites its left-hand side. -/
+theorem symFinTwoEquiv_symm_apply_val (d : ℕ) (i : Fin (d + 1)) :
+    ((symFinTwoEquiv d).symm i).val
+      = Multiset.replicate (i : ℕ) 0 + Multiset.replicate (d - (i : ℕ)) 1 := (rfl)
+
+/-- There are `d + 1` multisets of size `d` over a two-element type. -/
+@[simp]
+theorem card_sym_fin_two (d : ℕ) : Fintype.card (Sym (Fin 2) d) = d + 1 := by
+  rw [Fintype.card_congr (symFinTwoEquiv d), Fintype.card_fin]
+
+/-- **The complete homogeneous symmetric polynomial in two variables**: `h_d(x, y)` is the sum of
+all `d + 1` monomials `xⁱ y^{d-i}` of degree `d`. -/
+theorem eval_hsymm_fin_two {R : Type*} [CommSemiring R] (f : Fin 2 → R) (d : ℕ) :
+    MvPolynomial.eval f (MvPolynomial.hsymm (Fin 2) R d)
+      = ∑ i ∈ range (d + 1), f 0 ^ i * f 1 ^ (d - i) := by
+  rw [MvPolynomial.hsymm, map_sum, ← Fin.sum_univ_eq_sum_range _ (d + 1),
+    ← Equiv.sum_comp (symFinTwoEquiv d).symm]
+  refine Fintype.sum_congr _ _ fun i => ?_
+  rw [symFinTwoEquiv_symm_apply_val]
+  simp
+
+/-! ### The symmetric powers of the standard representation -/
+
+namespace SU2
+
+/-- `SU(2)` as a subgroup of `GL₂(ℂ)`: a special unitary matrix is invertible, its inverse being
+its conjugate transpose. -/
+def toGL : SU2 →* GL (Fin 2) ℂ where
+  toFun g := ⟨(g : Matrix (Fin 2) (Fin 2) ℂ), ((g⁻¹ : SU2) : Matrix (Fin 2) (Fin 2) ℂ),
+    by rw [← Submonoid.coe_mul, mul_inv_cancel]; rfl,
+    by rw [← Submonoid.coe_mul, inv_mul_cancel]; rfl⟩
+  map_one' := Units.ext rfl
+  map_mul' _ _ := Units.ext rfl
+
+@[simp]
+theorem coe_toGL (g : SU2) :
+    (toGL g : Matrix (Fin 2) (Fin 2) ℂ) = (g : Matrix (Fin 2) (Fin 2) ℂ) := (rfl)
+
+/-- The unit of `ℂ` underlying a point of the circle. -/
+noncomputable def circleUnit (z : Circle) : ℂˣ :=
+  Units.mk0 (z : ℂ) (Circle.coe_ne_zero z)
+
+@[simp]
+theorem coe_circleUnit (z : Circle) : (circleUnit z : ℂ) = (z : ℂ) := (rfl)
+
+/-- **The maximal torus of `SU(2)` inside the diagonal torus of `GL₂(ℂ)`**: `torusHom z` is the
+diagonal matrix `diag(z, z⁻¹)`. -/
+theorem toGL_torusHom (z : Circle) :
+    toGL (torusHom z) = diagGL ![circleUnit z, (circleUnit z)⁻¹] := by
+  refine Units.ext (Matrix.ext fun i j => ?_)
+  rw [coe_toGL, coe_torusHom, diagGL_coe]
+  fin_cases i <;> fin_cases j <;>
+    simp [torusMatrix_apply_zero_zero, torusMatrix_apply_zero_one, torusMatrix_apply_one_zero,
+      torusMatrix_apply_one_one, Matrix.diagonal_apply_eq, Matrix.diagonal_apply_ne,
+      Units.val_inv_eq_inv_val]
+
+variable (d : ℕ)
+
+/-- **The `d`-th symmetric power of the standard representation of `SU(2)`**, the candidate
+irreducible of dimension `d + 1`: the restriction along `TauCeti.SU2.toGL` of the symmetric power
+of the standard representation of `GL₂(ℂ)`. -/
+noncomputable def symPower : Representation ℂ SU2 (Sym[ℂ]^d (Fin 2 → ℂ)) :=
+  (symPowerRep ℂ 2 d).comp toGL
+
+@[simp]
+theorem symPower_apply (g : SU2) : symPower d g = symPowerRep ℂ 2 d (toGL g) := (rfl)
+
+/-- **The weight string.**  On the maximal torus the character of `Symᵈ(ℂ²)` is
+`z^{-d} + z^{2-d} + ⋯ + z^d`: the `d + 1` weights `-d, 2-d, …, d` each occur once. -/
+theorem character_symPower_torusHom (z : Circle) :
+    (symPower d).character (torusHom z)
+      = ∑ i ∈ range (d + 1), (z : ℂ) ^ i * ((z : ℂ)⁻¹) ^ (d - i) := by
+  rw [Representation.character, symPower_apply, toGL_torusHom, ← Representation.character,
+    char_symPowerRep_diagonal, eval_hsymm_fin_two]
+  refine sum_congr rfl fun i _ => ?_
+  simp
+
+/-- The weight string with the weights displayed as integer exponents `2i - d`. -/
+theorem character_symPower_torusHom_zpow (z : Circle) :
+    (symPower d).character (torusHom z)
+      = ∑ i ∈ range (d + 1), (z : ℂ) ^ (2 * (i : ℤ) - d) := by
+  rw [character_symPower_torusHom]
+  refine sum_congr rfl fun i hi => ?_
+  have hi' : (i : ℕ) ≤ d := Nat.lt_succ_iff.mp (mem_range.mp hi)
+  rw [show (2 * (i : ℤ) - d) = (i : ℤ) - ((d - i : ℕ) : ℤ) by omega,
+    zpow_sub₀ (Circle.coe_ne_zero z), zpow_natCast, zpow_natCast, inv_pow,
+    div_eq_mul_inv]
+
+/-- **The weight string in exponential coordinates.**  Writing the torus element as
+`diag(e^{iθ}, e^{-iθ})`, the character of `Symᵈ(ℂ²)` is `∑ᵢ e^{i(2i-d)θ}`: the classical
+`e^{idθ} + e^{i(d-2)θ} + ⋯ + e^{-idθ}`. -/
+theorem character_symPower_torusExp (θ : ℝ) :
+    (symPower d).character (torusExp θ)
+      = ∑ i ∈ range (d + 1), Complex.exp ((2 * (i : ℂ) - d) * (θ * Complex.I)) := by
+  rw [torusExp_def, character_symPower_torusHom_zpow]
+  refine sum_congr rfl fun i _ => ?_
+  rw [Circle.coe_exp, ← Complex.exp_int_mul]
+  push_cast
+  ring_nf
+
+/-- **The dimension is `d + 1`**, read off the weight string at `z = 1`: there are `d + 1`
+weights, each of multiplicity one. -/
+theorem character_symPower_one : (symPower d).character 1 = (d : ℂ) + 1 := by
+  have h := character_symPower_torusHom d 1
+  rw [show torusHom (1 : Circle) = 1 from map_one _] at h
+  rw [h]
+  simp
+
+end SU2
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
@@ -38,7 +38,6 @@ type and `Fin (d + 1)`, which records how many of the entries are `0`.
 
 ## Main results
 
-* `TauCeti.card_sym_fin_two`: there are `d + 1` multisets of size `d` over `Fin 2`.
 * `TauCeti.eval_hsymm_fin_two`: `h_d(x, y) = ∑_{i ≤ d} xⁱ y^{d-i}`.
 * `TauCeti.SU2.character_symPower_torusHom` and
   `TauCeti.SU2.character_symPower_torusHom_zpow`: the character of `Symᵈ` on the maximal torus is
@@ -96,56 +95,39 @@ noncomputable def symFinTwoEquiv (d : ℕ) : Sym (Fin 2) d ≃ Fin (d + 1) where
     refine Fin.ext ?_
     simp [Multiset.count_replicate]
 
-/-- The inverse of `TauCeti.symFinTwoEquiv` spelled out: `i` many `0`s and `d - i` many `1`s.
-Not a `simp` lemma, since `Sym.val_eq_coe` rewrites its left-hand side. -/
-theorem symFinTwoEquiv_symm_apply_val (d : ℕ) (i : Fin (d + 1)) :
-    ((symFinTwoEquiv d).symm i).val
+/-- The inverse of `TauCeti.symFinTwoEquiv` spelled out: `i` many `0`s and `d - i` many `1`s. -/
+theorem coe_symFinTwoEquiv_symm_apply (d : ℕ) (i : Fin (d + 1)) :
+    (((symFinTwoEquiv d).symm i : Sym (Fin 2) d) : Multiset (Fin 2))
       = Multiset.replicate (i : ℕ) 0 + Multiset.replicate (d - (i : ℕ)) 1 := (rfl)
-
-/-- There are `d + 1` multisets of size `d` over a two-element type. -/
-@[simp]
-theorem card_sym_fin_two (d : ℕ) : Fintype.card (Sym (Fin 2) d) = d + 1 := by
-  rw [Fintype.card_congr (symFinTwoEquiv d), Fintype.card_fin]
 
 /-- **The complete homogeneous symmetric polynomial in two variables**: `h_d(x, y)` is the sum of
 all `d + 1` monomials `xⁱ y^{d-i}` of degree `d`. -/
 theorem eval_hsymm_fin_two {R : Type*} [CommSemiring R] (f : Fin 2 → R) (d : ℕ) :
     MvPolynomial.eval f (MvPolynomial.hsymm (Fin 2) R d)
       = ∑ i ∈ range (d + 1), f 0 ^ i * f 1 ^ (d - i) := by
-  rw [MvPolynomial.hsymm, map_sum, ← Fin.sum_univ_eq_sum_range _ (d + 1),
+  rw [eval_hsymm, ← Fin.sum_univ_eq_sum_range _ (d + 1),
     ← Equiv.sum_comp (symFinTwoEquiv d).symm]
   refine Fintype.sum_congr _ _ fun i => ?_
-  rw [symFinTwoEquiv_symm_apply_val]
+  rw [coe_symFinTwoEquiv_symm_apply]
   simp
 
 /-! ### The symmetric powers of the standard representation -/
 
 namespace SU2
 
-/-- `SU(2)` as a subgroup of `GL₂(ℂ)`: a special unitary matrix is invertible, its inverse being
-its conjugate transpose. -/
-def toGL : SU2 →* GL (Fin 2) ℂ where
-  toFun g := ⟨(g : Matrix (Fin 2) (Fin 2) ℂ), ((g⁻¹ : SU2) : Matrix (Fin 2) (Fin 2) ℂ),
-    by rw [← Submonoid.coe_mul, mul_inv_cancel]; rfl,
-    by rw [← Submonoid.coe_mul, inv_mul_cancel]; rfl⟩
-  map_one' := Units.ext rfl
-  map_mul' _ _ := Units.ext rfl
+/-- `SU(2)` as a subgroup of `GL₂(ℂ)`: an element of the group `SU(2)` is a unit there, and a unit
+of a submonoid of the matrices is a unit of the matrices. -/
+def toGL : SU2 →* GL (Fin 2) ℂ :=
+  (Units.map (Submonoid.subtype _)).comp toUnits.toMonoidHom
 
 @[simp]
 theorem coe_toGL (g : SU2) :
     (toGL g : Matrix (Fin 2) (Fin 2) ℂ) = (g : Matrix (Fin 2) (Fin 2) ℂ) := (rfl)
 
-/-- The unit of `ℂ` underlying a point of the circle. -/
-noncomputable def circleUnit (z : Circle) : ℂˣ :=
-  Units.mk0 (z : ℂ) (Circle.coe_ne_zero z)
-
-@[simp]
-theorem coe_circleUnit (z : Circle) : (circleUnit z : ℂ) = (z : ℂ) := (rfl)
-
 /-- **The maximal torus of `SU(2)` inside the diagonal torus of `GL₂(ℂ)`**: `torusHom z` is the
 diagonal matrix `diag(z, z⁻¹)`. -/
 theorem toGL_torusHom (z : Circle) :
-    toGL (torusHom z) = diagGL ![circleUnit z, (circleUnit z)⁻¹] := by
+    toGL (torusHom z) = diagGL ![Circle.toUnits z, (Circle.toUnits z)⁻¹] := by
   refine Units.ext (Matrix.ext fun i j => ?_)
   rw [coe_toGL, coe_torusHom, diagGL_coe]
   fin_cases i <;> fin_cases j <;>

--- a/TauCeti/RingTheory/MvPolynomial/Symmetric/Complete.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Symmetric/Complete.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.RingTheory.MvPolynomial.Symmetric.Defs
+import TauCeti.Data.Sym.Basic
+
+/-!
+# Evaluating the complete homogeneous symmetric polynomial
+
+The complete homogeneous symmetric polynomial `h_d` in variables indexed by a finite type `σ` is
+the sum of all monomials of degree `d`, one for each unordered `d`-tuple of indices.  Evaluating it
+at a family `f : σ → R` therefore sums, over those unordered tuples, the product of the values `f`
+takes on the tuple: `TauCeti.eval_hsymm`.
+
+In two variables the unordered `d`-tuples are the `d + 1` splittings counted by
+`TauCeti.symFinTwoEquiv`, and the evaluation reads `h_d(x, y) = ∑_{i ≤ d} xⁱ y^{d-i}`:
+`TauCeti.eval_hsymm_fin_two`.
+
+## Main results
+
+* `TauCeti.eval_hsymm` evaluates the complete homogeneous symmetric polynomial as a sum over the
+  unordered `d`-tuples of indices.
+* `TauCeti.eval_hsymm_fin_two` reads that off in two variables: `h_d(x, y) = ∑_{i ≤ d} xⁱ y^{d-i}`.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- **The complete homogeneous symmetric polynomial evaluated**: `h_d(f)` is the sum, over the
+unordered `d`-tuples of indices, of the product of the values `f` takes on the tuple. -/
+theorem eval_hsymm {σ R : Type*} [Fintype σ] [DecidableEq σ] [CommSemiring R] (f : σ → R)
+    (d : ℕ) : MvPolynomial.eval f (MvPolynomial.hsymm σ R d)
+      = ∑ s : Sym σ d, ((s : Multiset σ).map f).prod := by
+  rw [MvPolynomial.hsymm, map_sum]
+  refine Finset.sum_congr rfl fun s _ => ?_
+  rw [map_multiset_prod, Multiset.map_map]
+  simp [Function.comp_def]
+
+/-- **The complete homogeneous symmetric polynomial in two variables**: `h_d(x, y)` is the sum of
+all `d + 1` monomials `xⁱ y^{d-i}` of degree `d`. -/
+theorem eval_hsymm_fin_two {R : Type*} [CommSemiring R] (f : Fin 2 → R) (d : ℕ) :
+    MvPolynomial.eval f (MvPolynomial.hsymm (Fin 2) R d)
+      = ∑ i ∈ Finset.range (d + 1), f 0 ^ i * f 1 ^ (d - i) := by
+  rw [eval_hsymm, ← Fin.sum_univ_eq_sum_range _ (d + 1),
+    ← Equiv.sum_comp (symFinTwoEquiv d).symm]
+  refine Fintype.sum_congr _ _ fun i => ?_
+  rw [coe_symFinTwoEquiv_symm_apply]
+  simp
+
+end TauCeti


### PR DESCRIPTION
This PR builds the symmetric powers `Symᵈ(ℂ²)` of the standard representation of `SU(2)` and computes their characters on the maximal torus, as the weight string `z^d + z^{d-2} + ⋯ + z^{-d}`.

The target is `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`, Layer 6 (the `SU(2)` engine), whose `Suggested.lean` pins `su2Irrep n` ("the representation on `Sym^n(ℂ²)`, of dimension `n+1`"), `su2Irrep_character_one` ("the character at the identity is the dimension `n+1`") and `su2Irrep_character_torus` ("the character on the torus is the weight string `e^{inθ} + e^{i(n-2)θ} + ⋯ + e^{-inθ}`; the weights are `{n, n-2, …, -n}`, each with multiplicity one — computed directly from the diagonal action, and what the highest-weight argument runs on"). The `SU(2)` group-theoretic layer is already on `main` — the maximal torus `TauCeti.SU2.torusHom`/`torusExp`, torus conjugacy, and the Weyl group — but nothing acts on anything yet; this supplies the representations themselves and their torus characters, the classification input that layer's remaining milestones (irreducibility, inequivalence, exhaustion) are stated about.

The new module is `TauCeti/RepresentationTheory/SU2/SymmetricPower.lean` (210 lines). `TauCeti.SU2.toGL` embeds `SU(2)` into `GL₂(ℂ)` (a special unitary matrix is invertible, its inverse being its conjugate transpose), `TauCeti.SU2.toGL_torusHom` identifies the image of the maximal torus with the diagonal matrix `diag(z, z⁻¹)`, and `TauCeti.SU2.symPower d` is the restriction along that embedding of Layer 1's `TauCeti.symPowerRep`. Restricting an existing `GL₂` construction rather than building a bespoke action is what lets the character be read off `TauCeti.char_symPowerRep_diagonal`, already on `main`, which gives the character at a diagonal matrix as the complete homogeneous symmetric polynomial in its diagonal entries.

What that leaves to prove is the rank-two case of `h_d`, and it is the arithmetic heart of the file. `TauCeti.symFinTwoEquiv` is the bijection between the multisets of size `d` over `Fin 2` — the index set of the monomials of `h_d`, and of the basis of `Symᵈ` — and `Fin (d + 1)`, recording how many entries are `0`; a multiset over a two-element type is reconstructed from that one count because the two counts sum to the cardinality. From it, `TauCeti.eval_hsymm_fin_two` reads `h_d(x, y) = ∑_{i ≤ d} xⁱ y^{d-i}`, and `TauCeti.card_sym_fin_two` records the count `d + 1`. Both are stated over an arbitrary commutative semiring and for an arbitrary `Fin 2`-indexed family, not just for the torus, since neither the polynomial identity nor the counting has anything to do with `SU(2)`.

The character then comes in the three spellings the downstream arguments want: `TauCeti.SU2.character_symPower_torusHom` with natural-number exponents, `TauCeti.SU2.character_symPower_torusHom_zpow` with the weights displayed as the integer exponents `2i - d`, and `TauCeti.SU2.character_symPower_torusExp` in the exponential coordinates `∑_{i ≤ d} e^{i(2i-d)θ}` of the roadmap's statement. Each of the `d + 1` weights occurs exactly once, which is the multiplicity-one input to the highest-weight argument. The dimension `TauCeti.SU2.character_symPower_one` is read off the weight string at `z = 1` rather than from a separate rank computation, since `torusHom 1 = 1`.

Two things are deliberately not done here. Irreducibility, pairwise inequivalence and exhaustion are the classification proper, and the roadmap splits them into their own milestones downstream of exactly this weight decomposition; and the representations are built as `Representation ℂ SU2 _` rather than as bundled `ContRepresentation`s on `EuclideanSpace ℂ (Fin (d+1))`, because the roadmap states the classification input as a character computation and the analytic packaging belongs with the layer that integrates against Haar measure. Nothing was vendored from Mathlib; the symmetric-power notation `Sym[ℂ]^d` and the complete homogeneous symmetric polynomial `MvPolynomial.hsymm` are consumed from it unchanged.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"su2irrep-sympower-character-torus"}-->

🤖 Prepared with Claude Code
