### PR TITLE
feat: finish de Finetti via L2 averaging

### DIFF
--- a/TauCeti/Probability/DeFinetti/ViaL2/Theorem.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/Theorem.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.DeFinetti.ViaL2.ConditionallyIID
+import TauCeti.Probability.Exchangeability.ConditionallyIID.Implications
+import TauCeti.Probability.Exchangeability.Contractability
+
+/-!
+# De Finetti's theorem via `L²` averaging
+
+This file is the endpoint of the martingale-free `L²` route to de Finetti's theorem. The route's
+substantive conclusion,
+`Contractable.conditionallyIIDWith_directingProbabilityMeasure`, names the tail-conditional
+directing measure and proves the joint-law disintegration of every finite block. Here that named
+witness is packaged into `ConditionallyIID`, and the standard exchangeable and equivalence forms
+are derived from the elementary implication lattice.
+
+The suffix `_viaL2` records the proof route. The corresponding unsuffixed public theorems in
+`TauCeti.Probability.DeFinetti.Theorem` use the reverse-martingale route and are deliberately not
+imported here. Thus importing this module gives a complete de Finetti theorem without importing
+reverse-martingale convergence or the unsuffixed summit.
+
+## Main results
+
+* `conditionallyIID_of_contractable_viaL2` — a contractable process is conditionally i.i.d.;
+* `deFinetti_viaL2` — an exchangeable process is conditionally i.i.d.;
+* `deFinetti_RyllNardzewski_equivalence_viaL2` — contractability is equivalent to the conjunction
+  of exchangeability and conditional i.i.d.-ness.
+
+These route wrappers are the final target of Layer 3 of
+`TauCetiRoadmap/Exchangeability/README.md`. They are not adapted from the legacy theorem wrappers in
+`cameronfreer/exchangeability`: those wrappers conclude only the mixture identity, whereas the
+results here package Tau Ceti's stronger joint-law disintegration.
+
+## References
+
+* O. Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Springer, 2005, Chapter 1,
+  Theorem 1.1.
+* C. Ryll-Nardzewski, "On stationary sequences of random variables and the de Finetti
+  equivalence", 1957.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **The contractable form of de Finetti's theorem via `L²` averaging.** A contractable process
+valued in a nonempty standard Borel space is conditionally i.i.d.
+
+The directing measure witnessing the conclusion is
+`directingProbabilityMeasure μ X`; its stronger witness-level statement is
+`Contractable.conditionallyIIDWith_directingProbabilityMeasure`. -/
+theorem conditionallyIID_of_contractable_viaL2 [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX : Contractable μ X)
+    (hX_meas : ∀ n, Measurable (X n)) :
+    ConditionallyIID μ X :=
+  ConditionallyIID.of_directing
+    (hX.conditionallyIIDWith_directingProbabilityMeasure hX_meas)
+
+/-- **De Finetti's theorem via `L²` averaging.** An exchangeable process valued in a nonempty
+standard Borel space is conditionally i.i.d. -/
+theorem deFinetti_viaL2 [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω}
+    [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n))
+    (hX : Exchangeable μ X) :
+    ConditionallyIID μ X :=
+  conditionallyIID_of_contractable_viaL2
+    (hX.contractable fun n => (hX_meas n).aemeasurable) hX_meas
+
+/-- **The de Finetti--Ryll-Nardzewski equivalence via `L²` averaging.** For a measurable process
+on a nonempty standard Borel state space, contractability is equivalent to being both exchangeable
+and conditionally i.i.d. -/
+theorem deFinetti_RyllNardzewski_equivalence_viaL2 [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hX_meas : ∀ n, Measurable (X n)) :
+    Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X := by
+  constructor
+  · intro hX
+    have hX_cond := conditionallyIID_of_contractable_viaL2 hX hX_meas
+    exact ⟨hX_cond.exchangeable, hX_cond⟩
+  · exact fun hX => hX.2.contractable
+
+end Probability
+
+end TauCeti
+
+end


### PR DESCRIPTION
This PR packages the martingale-free `L²` joint-law disintegration into the three route-specific summit theorems named by the exchangeability roadmap. Convert `Contractable.conditionallyIIDWith_directingProbabilityMeasure` into the existential conditional representation `conditionallyIID_of_contractable_viaL2`, derive `deFinetti_viaL2` from exchangeability through contractability, and state the full `deFinetti_RyllNardzewski_equivalence_viaL2`.

The exact target is `TauCetiRoadmap/Exchangeability/README.md`, Layer 3, whose key milestones name `conditionallyIID_of_contractable_viaL2`, `deFinetti_viaL2`, and `deFinetti_RyllNardzewski_equivalence_viaL2`. The substantive witness-level theorem merged in #2946 and explicitly left these existential wrappers and the route summit for a separate PR. After this PR, the Layer 3 `L²` route reaches its named standard-Borel de Finetti summit; the independent reverse-martingale and Koopman routes remain, while the unsuffixed public theorem continues to use the default reverse-martingale route.

The preferred `CFSGStatement` roadmap has no viable unclaimed critical-path step. Its index lane I0 is complete, the only S1 row not on `main` is `Fi24Prime` in #2902, and L0 still consumes the E7 and E8 root-data PRs #2809 and #2893 together with the pinned Chevalley--Demazure construction whose current Serre, PBW, Kostant-form, bialgebra, and antipode prerequisites are already in flight. I therefore fall back to the explicitly unclaimed endpoint of Exchangeability Layer 3 rather than duplicate any of that work; the only open Exchangeability intention, TauCetiRoadmap#131, expressly excludes all three declarations added here.

The new module `TauCeti/Probability/DeFinetti/ViaL2/Theorem.lean` is 97 lines. It adds no definitions and no parallel mathematical construction: the first theorem packages the existing named directing measure, the exchangeable theorem reuses `Exchangeable.contractable`, and the reverse implication of the Ryll-Nardzewski equivalence reuses `ConditionallyIID.contractable`. Its import graph deliberately does not reach `TauCeti.Probability.DeFinetti.Theorem` or reverse-martingale convergence, so the route suffix records a genuine independent proof path. No Mathlib infrastructure is vendored.

The mathematical statement follows O. Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Chapter 1, Theorem 1.1, and C. Ryll-Nardzewski, “On stationary sequences of random variables and the de Finetti equivalence” (1957), both cited in the module. These wrappers are not adapted from `cameronfreer/exchangeability`: its legacy endpoint concludes the weaker mixture identity, whereas the Tau Ceti theorem packaged here concludes the joint-law conditional representation.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"definetti-vial2"}-->

🤖 Prepared with Codex
