### PR TITLE
feat: the centralizers of the regular semisimple elements of GL₂

### DIFF
--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -29,8 +29,9 @@ conjugation action.
   `TauCeti.isRealClass_iff_inv_eq` identifying it with being fixed by inversion.
 * `TauCeti.ConjClasses.ncard_carrier_inv` and `TauCeti.ConjClasses.card_carrier_inv`: a conjugacy
   class and its inverse have the same size, in `Set.ncard` and in `Nat.card` form.
-* `TauCeti.ConjClasses.ncard_carrier_mk`: the size of a conjugacy class is the index of the
-  centralizer of any of its members.
+* `TauCeti.ConjClasses.ncard_carrier_mk` and `TauCeti.ConjClasses.card_carrier_mk`: the size of a
+  conjugacy class is the index of the centralizer of any of its members, in `Set.ncard` and in
+  `Nat.card` form.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
   the group, with `TauCeti.ConjClasses.card_carrier_cast_ne_zero` the consequence that the size of
   a class is nonzero in any semiring where the group order is.
@@ -121,12 +122,22 @@ theorem ncard_carrier_mk (g : G) :
     Subgroup.centralizer_eq_comap_stabilizer]
   exact hcomap.symm
 
+/-- **The size of a conjugacy class is the index of the centralizer of any of its members**, in
+`Nat.card` form.
+
+Not `@[simp]`: Mathlib's `Nat.card_coe_set_eq` is itself `simp`, so the left-hand side simplifies
+to `(ConjClasses.mk g).carrier.ncard` and the simp normal form linter rejects the pair; that
+normalized form is `TauCeti.ConjClasses.ncard_carrier_mk`. -/
+theorem card_carrier_mk (g : G) :
+    Nat.card (ConjClasses.mk g).carrier = (Subgroup.centralizer {g}).index := by
+  rw [Nat.card_coe_set_eq, ncard_carrier_mk]
+
 /-- **The size of a conjugacy class divides the order of the group**, being the index of a
 centralizer. -/
 theorem card_carrier_dvd_card (C : ConjClasses G) : Nat.card C.carrier ∣ Nat.card G := by
   obtain ⟨x, rfl⟩ := ConjClasses.exists_rep C
   calc Nat.card (ConjClasses.mk x).carrier
-      = (Subgroup.centralizer {x}).index := by rw [Nat.card_coe_set_eq, ncard_carrier_mk]
+      = (Subgroup.centralizer {x}).index := card_carrier_mk x
     _ ∣ Nat.card G := Subgroup.index_dvd_card _
 
 /-- The size of a conjugacy class is nonzero in any semiring in which the order of the group is

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -17,8 +17,9 @@ involution, recorded here as an `InvolutiveInv (ConjClasses G)` instance; `C⁻�
 inverses of the members of `C`, and it has the same size as `C`. A class fixed by this involution is
 a **real** class (`TauCeti.IsRealClass`).
 
-The other fact collected here is that the size of a conjugacy class divides the order of the group,
-a consequence of the orbit-stabilizer theorem for the conjugation action.
+The other fact collected here is that the size of a conjugacy class is the index of the centralizer
+of any of its members, and so divides the order of the group: the orbit-stabilizer theorem for the
+conjugation action.
 
 ## Main statements
 
@@ -28,6 +29,8 @@ a consequence of the orbit-stabilizer theorem for the conjugation action.
   `TauCeti.isRealClass_iff_inv_eq` identifying it with being fixed by inversion.
 * `TauCeti.ConjClasses.ncard_carrier_inv` and `TauCeti.ConjClasses.card_carrier_inv`: a conjugacy
   class and its inverse have the same size, in `Set.ncard` and in `Nat.card` form.
+* `TauCeti.ConjClasses.ncard_carrier_mk`: the size of a conjugacy class is the index of the
+  centralizer of any of its members.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
   the group, with `TauCeti.ConjClasses.card_carrier_cast_ne_zero` the consequence that the size of
   a class is nonzero in any semiring where the group order is.
@@ -107,16 +110,24 @@ to `(C⁻¹).carrier.ncard` and the simp normal form linter rejects the pair; th
 theorem card_carrier_inv (C : ConjClasses G) : Nat.card (C⁻¹).carrier = Nat.card C.carrier :=
   ncard_carrier_inv C
 
-/-- **The size of a conjugacy class divides the order of the group.** The class is the orbit of any
-of its members under the conjugation action, so its size is the index of a centralizer. -/
+/-- **The size of a conjugacy class is the index of the centralizer of any of its members.** The
+class is the orbit of `g` under the conjugation action and the centralizer is the stabilizer, so
+this is the orbit-stabilizer theorem. -/
+theorem ncard_carrier_mk (g : G) :
+    (ConjClasses.mk g).carrier.ncard = (Subgroup.centralizer {g}).index := by
+  have hcomap := (MulAction.stabilizer (ConjAct G) g).index_comap_of_surjective
+    (f := ConjAct.toConjAct.toMonoidHom) ConjAct.toConjAct.surjective
+  rw [← ConjAct.orbit_eq_carrier_conjClasses, ← MulAction.index_stabilizer,
+    Subgroup.centralizer_eq_comap_stabilizer]
+  exact hcomap.symm
+
+/-- **The size of a conjugacy class divides the order of the group**, being the index of a
+centralizer. -/
 theorem card_carrier_dvd_card (C : ConjClasses G) : Nat.card C.carrier ∣ Nat.card G := by
   obtain ⟨x, rfl⟩ := ConjClasses.exists_rep C
   calc Nat.card (ConjClasses.mk x).carrier
-      = (MulAction.stabilizer (ConjAct G) x).index := by
-        rw [Nat.card_coe_set_eq, ← ConjAct.orbit_eq_carrier_conjClasses,
-          MulAction.index_stabilizer]
-    _ ∣ Nat.card (ConjAct G) := Subgroup.index_dvd_card _
-    _ = Nat.card G := Nat.card_congr ConjAct.ofConjAct.toEquiv
+      = (Subgroup.centralizer {x}).index := by rw [Nat.card_coe_set_eq, ncard_carrier_mk]
+    _ ∣ Nat.card G := Subgroup.index_dvd_card _
 
 /-- The size of a conjugacy class is nonzero in any semiring in which the order of the group is
 nonzero: it divides that order. -/

--- a/TauCeti/Algebra/Group/Subgroup/Centralizer.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Centralizer.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- `Subgroup.centralizer` occurs in the statement below.
+public import Mathlib.GroupTheory.Subgroup.Centralizer
+-- `Commute.units_val_iff` transports commutation between units and their values.
+public import Mathlib.Algebra.Group.Commute.Units
+
+/-!
+# The centralizer of a single unit
+
+Centralizers of a group of units are computed on the underlying monoid: a unit centralizes another
+exactly when their values commute. Mathlib has both halves —
+`Subgroup.mem_centralizer_singleton_iff` turns membership into an equation, and
+`Commute.units_val_iff` transports that equation between `Mˣ` and `M` — but not their combination,
+which is the form every concrete centralizer computation in a matrix group starts from.
+
+## Main results
+
+* `TauCeti.mem_centralizer_singleton_iff_commute_val`: a unit lies in the centralizer of a unit `g`
+  exactly when the two commute as elements of the monoid.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- Membership in the centralizer of a unit `g`, read on the underlying monoid. -/
+theorem mem_centralizer_singleton_iff_commute_val {M : Type*} [Monoid M] {g h : Mˣ} :
+    h ∈ Subgroup.centralizer {g} ↔ Commute (g : M) (h : M) :=
+  ⟨fun hh => Commute.units_val_iff.mpr (Subgroup.mem_centralizer_singleton_iff.mp hh).symm,
+    fun hh => Subgroup.mem_centralizer_singleton_iff.mpr (Commute.units_val_iff.mp hh).symm⟩
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/Commute.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Commute.lean
@@ -26,14 +26,13 @@ with *everything*; what is proved here is the commutant of a *single* matrix, in
 the three independent entry equations of `M * N = N * M` by splitting on which of the two
 off-diagonal entries or the diagonal difference is nonzero.
 
-Being scalar, and the entrywise reading of the normal form `a • 1 + b • M`, are recorded over a
-semiring; only the commutant computation itself, which divides by a matrix entry, needs a field.
+Being scalar is recorded over a semiring; only the commutant computation itself, which divides by a
+matrix entry, needs a field.
 
 ## Main results
 
 * `TauCeti.mem_range_scalar_fin_two_iff`: a `2 × 2` matrix is scalar exactly when its off-diagonal
   entries vanish and its two diagonal entries agree.
-* `TauCeti.scalar_add_smul_apply`: the entries of the normal form `a • 1 + b • M`.
 * `TauCeti.commute_fin_two_iff`: a matrix commutes with a non-scalar `2 × 2` matrix `M` exactly when
   it is of the form `a • 1 + b • M`.
 * `TauCeti.commute_of_commute_fin_two`: two matrices commuting with a common non-scalar `2 × 2`
@@ -71,19 +70,12 @@ theorem mem_range_scalar_fin_two_iff :
     ext i j
     fin_cases i <;> fin_cases j <;> simp [Matrix.scalar_apply, h01, h10, h00]
 
-/-- The entries of `a • 1 + b • M`, for a `2 × 2` matrix `M`: this reads the normal form handed
-out by `TauCeti.commute_fin_two_iff` entrywise. -/
-theorem scalar_add_smul_apply (a b : F) (i j : Fin 2) :
-    (Matrix.scalar (Fin 2) a + b • M) i j = (if i = j then a else 0) + b * M i j := by
-  simp [Matrix.scalar_apply, Matrix.diagonal_apply]
-
 /-- A `2 × 2` matrix is `a • 1 + b • M` as soon as its four entries are. -/
 private theorem eq_scalar_add_smul_fin_two {a b : F} (h00 : N 0 0 = a + b * M 0 0)
     (h01 : N 0 1 = b * M 0 1) (h10 : N 1 0 = b * M 1 0) (h11 : N 1 1 = a + b * M 1 1) :
     N = Matrix.scalar (Fin 2) a + b • M := by
   ext i j
-  rw [scalar_add_smul_apply]
-  fin_cases i <;> fin_cases j <;> simp [h00, h01, h10, h11]
+  fin_cases i <;> fin_cases j <;> simp [Matrix.scalar_apply, h00, h01, h10, h11]
 
 end Semiring
 

--- a/TauCeti/LinearAlgebra/Matrix/Commute.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Commute.lean
@@ -26,13 +26,17 @@ with *everything*; what is proved here is the commutant of a *single* matrix, in
 the three independent entry equations of `M * N = N * M` by splitting on which of the two
 off-diagonal entries or the diagonal difference is nonzero.
 
+Being scalar, and the entrywise reading of the normal form `a • 1 + b • M`, are recorded over a
+semiring; only the commutant computation itself, which divides by a matrix entry, needs a field.
+
 ## Main results
 
-* `TauCeti.mem_range_scalar_finTwo_iff`: a `2 × 2` matrix is scalar exactly when its off-diagonal
+* `TauCeti.mem_range_scalar_fin_two_iff`: a `2 × 2` matrix is scalar exactly when its off-diagonal
   entries vanish and its two diagonal entries agree.
-* `TauCeti.commute_finTwo_iff`: a matrix commutes with a non-scalar `2 × 2` matrix `M` exactly when
+* `TauCeti.scalar_add_smul_apply`: the entries of the normal form `a • 1 + b • M`.
+* `TauCeti.commute_fin_two_iff`: a matrix commutes with a non-scalar `2 × 2` matrix `M` exactly when
   it is of the form `a • 1 + b • M`.
-* `TauCeti.commute_of_commute_finTwo`: two matrices commuting with a common non-scalar `2 × 2`
+* `TauCeti.commute_of_commute_fin_two`: two matrices commuting with a common non-scalar `2 × 2`
   matrix commute with each other.
 
 ## References
@@ -49,11 +53,15 @@ open Matrix
 
 namespace TauCeti
 
-variable {F : Type*} [Field F] {M N P : Matrix (Fin 2) (Fin 2) F}
+variable {F : Type*} {M N P : Matrix (Fin 2) (Fin 2) F}
+
+section Semiring
+
+variable [Semiring F]
 
 /-- A `2 × 2` matrix is scalar exactly when its off-diagonal entries vanish and its two diagonal
 entries agree. -/
-theorem mem_range_scalar_finTwo_iff :
+theorem mem_range_scalar_fin_two_iff :
     M ∈ Set.range (Matrix.scalar (Fin 2)) ↔ M 0 1 = 0 ∧ M 1 0 = 0 ∧ M 0 0 = M 1 1 := by
   constructor
   · rintro ⟨c, rfl⟩
@@ -63,25 +71,32 @@ theorem mem_range_scalar_finTwo_iff :
     ext i j
     fin_cases i <;> fin_cases j <;> simp [Matrix.scalar_apply, h01, h10, h00]
 
-/-- The entries of `a • 1 + b • M`, for a `2 × 2` matrix `M`. -/
-private theorem scalar_add_smul_apply (a b : F) (i j : Fin 2) :
+/-- The entries of `a • 1 + b • M`, for a `2 × 2` matrix `M`: this reads the normal form handed
+out by `TauCeti.commute_fin_two_iff` entrywise. -/
+theorem scalar_add_smul_apply (a b : F) (i j : Fin 2) :
     (Matrix.scalar (Fin 2) a + b • M) i j = (if i = j then a else 0) + b * M i j := by
   simp [Matrix.scalar_apply, Matrix.diagonal_apply]
 
 /-- A `2 × 2` matrix is `a • 1 + b • M` as soon as its four entries are. -/
-private theorem eq_scalar_add_smul_finTwo {a b : F} (h00 : N 0 0 = a + b * M 0 0)
+private theorem eq_scalar_add_smul_fin_two {a b : F} (h00 : N 0 0 = a + b * M 0 0)
     (h01 : N 0 1 = b * M 0 1) (h10 : N 1 0 = b * M 1 0) (h11 : N 1 1 = a + b * M 1 1) :
     N = Matrix.scalar (Fin 2) a + b • M := by
   ext i j
   rw [scalar_add_smul_apply]
   fin_cases i <;> fin_cases j <;> simp [h00, h01, h10, h11]
 
+end Semiring
+
+section Field
+
+variable [Field F]
+
 /-- **The commutant of a non-scalar `2 × 2` matrix.** A matrix commutes with a non-scalar
 `M : Matrix (Fin 2) (Fin 2) F` exactly when it lies in the two-dimensional subalgebra spanned by
 `1` and `M`; equivalently, a non-scalar `2 × 2` matrix is cyclic, so its commutant is `F[M]`.
 
 The hypothesis is necessary: everything commutes with a scalar matrix. -/
-theorem commute_finTwo_iff (hM : M ∉ Set.range (Matrix.scalar (Fin 2))) :
+theorem commute_fin_two_iff (hM : M ∉ Set.range (Matrix.scalar (Fin 2))) :
     Commute M N ↔ ∃ a b : F, N = Matrix.scalar (Fin 2) a + b • M := by
   constructor
   · intro h
@@ -93,7 +108,7 @@ theorem commute_finTwo_iff (hM : M ∉ Set.range (Matrix.scalar (Fin 2))) :
     have e01 := key 0 1
     have e10 := key 1 0
     -- Being non-scalar, `M` has a nonzero off-diagonal entry or distinct diagonal entries.
-    rw [mem_range_scalar_finTwo_iff] at hM
+    rw [mem_range_scalar_fin_two_iff] at hM
     push Not at hM
     by_cases h01 : M 0 1 = 0
     · by_cases h10 : M 1 0 = 0
@@ -105,17 +120,17 @@ theorem commute_finTwo_iff (hM : M ∉ Set.range (Matrix.scalar (Fin 2))) :
           mul_right_cancel₀ hdiag (by linear_combination e01 + (N 0 0 - N 1 1) * h01)
         have hN10 : N 1 0 = 0 :=
           mul_right_cancel₀ hdiag (by linear_combination -e10 + (N 0 0 - N 1 1) * h10)
-        exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring)
+        exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_fin_two (by ring)
           (by rw [hN01, h01, mul_zero]) (by rw [hN10, h10, mul_zero])
           (by linear_combination hb)⟩
       · -- The lower-left entry is nonzero and determines the coefficient of `M`.
         obtain ⟨b, hb⟩ : ∃ b : F, b * M 1 0 = N 1 0 := ⟨N 1 0 / M 1 0, div_mul_cancel₀ _ h10⟩
-        exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring)
+        exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_fin_two (by ring)
           (mul_left_cancel₀ h10 (by linear_combination -e00 - M 0 1 * hb)) hb.symm
           (mul_left_cancel₀ h10 (by linear_combination -e10 + (M 0 0 - M 1 1) * hb))⟩
     · -- The upper-right entry is nonzero and determines the coefficient of `M`.
       obtain ⟨b, hb⟩ : ∃ b : F, b * M 0 1 = N 0 1 := ⟨N 0 1 / M 0 1, div_mul_cancel₀ _ h01⟩
-      exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring) hb.symm
+      exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_fin_two (by ring) hb.symm
         (mul_left_cancel₀ h01 (by linear_combination e00 - M 1 0 * hb))
         (mul_left_cancel₀ h01 (by linear_combination e01 + (M 0 0 - M 1 1) * hb))⟩
   · rintro ⟨a, b, rfl⟩
@@ -124,10 +139,10 @@ theorem commute_finTwo_iff (hM : M ∉ Set.range (Matrix.scalar (Fin 2))) :
 
 /-- Two matrices commuting with a common non-scalar `2 × 2` matrix commute with each other: both
 lie in the commutative algebra `F[M]`. -/
-theorem commute_of_commute_finTwo (hM : M ∉ Set.range (Matrix.scalar (Fin 2)))
+theorem commute_of_commute_fin_two (hM : M ∉ Set.range (Matrix.scalar (Fin 2)))
     (hN : Commute M N) (hP : Commute M P) : Commute N P := by
-  obtain ⟨a, b, rfl⟩ := (commute_finTwo_iff hM).mp hN
-  obtain ⟨c, d, rfl⟩ := (commute_finTwo_iff hM).mp hP
+  obtain ⟨a, b, rfl⟩ := (commute_fin_two_iff hM).mp hN
+  obtain ⟨c, d, rfl⟩ := (commute_fin_two_iff hM).mp hP
   have hs : ∀ x : F, Commute (Matrix.scalar (Fin 2) x) M :=
     fun x => Matrix.scalar_commute x (Commute.all x) M
   have h1 : Commute (Matrix.scalar (Fin 2) a) (Matrix.scalar (Fin 2) c) :=
@@ -136,5 +151,7 @@ theorem commute_of_commute_finTwo (hM : M ∉ Set.range (Matrix.scalar (Fin 2)))
   have h3 : Commute (b • M) (Matrix.scalar (Fin 2) c) := (hs c).symm.smul_left b
   have h4 : Commute (b • M) (d • M) := ((Commute.refl M).smul_right d).smul_left b
   exact (h1.add_right h2).add_left (h3.add_right h4)
+
+end Field
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/Commute.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Commute.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- `Matrix.scalar` occurs in the statements below, and the `2 × 2` entry lemma `Fin.sum_univ_two`
+-- in the proofs.
+public import Mathlib.LinearAlgebra.Matrix.Notation
+-- Non-public: the entry equations are solved by `linear_combination` and `ring`, in the proofs
+-- only.
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Ring
+
+/-!
+# The commutant of a `2 × 2` matrix
+
+A `2 × 2` matrix over a field is **regular** as soon as it is not scalar: it is then cyclic
+(nonderogatory), and the matrices commuting with it are exactly the polynomials in it. In size `2`
+those polynomials are the affine combinations `a • 1 + b • M`, so the commutant of a non-scalar
+`M : Matrix (Fin 2) (Fin 2) F` is the two-dimensional algebra `F[M]` — in particular it is
+commutative.
+
+Mathlib's `Matrix.mem_range_scalar_iff_commute_transvectionStruct` describes the matrices commuting
+with *everything*; what is proved here is the commutant of a *single* matrix, in size two, read off
+the three independent entry equations of `M * N = N * M` by splitting on which of the two
+off-diagonal entries or the diagonal difference is nonzero.
+
+## Main results
+
+* `TauCeti.mem_range_scalar_finTwo_iff`: a `2 × 2` matrix is scalar exactly when its off-diagonal
+  entries vanish and its two diagonal entries agree.
+* `TauCeti.commute_finTwo_iff`: a matrix commutes with a non-scalar `2 × 2` matrix `M` exactly when
+  it is of the form `a • 1 + b • M`.
+* `TauCeti.commute_of_commute_finTwo`: two matrices commuting with a common non-scalar `2 × 2`
+  matrix commute with each other.
+
+## References
+
+The commutant is used to compute centralizers in `GL₂` in
+`TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Centralizer`, for the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+Layer 9, "The conjugacy classes (a build target)".
+-/
+
+public section
+
+open Matrix
+
+namespace TauCeti
+
+variable {F : Type*} [Field F] {M N P : Matrix (Fin 2) (Fin 2) F}
+
+/-- A `2 × 2` matrix is scalar exactly when its off-diagonal entries vanish and its two diagonal
+entries agree. -/
+theorem mem_range_scalar_finTwo_iff :
+    M ∈ Set.range (Matrix.scalar (Fin 2)) ↔ M 0 1 = 0 ∧ M 1 0 = 0 ∧ M 0 0 = M 1 1 := by
+  constructor
+  · rintro ⟨c, rfl⟩
+    simp [Matrix.scalar_apply]
+  · rintro ⟨h01, h10, h00⟩
+    refine ⟨M 0 0, ?_⟩
+    ext i j
+    fin_cases i <;> fin_cases j <;> simp [Matrix.scalar_apply, h01, h10, h00]
+
+/-- The entries of `a • 1 + b • M`, for a `2 × 2` matrix `M`. -/
+private theorem scalar_add_smul_apply (a b : F) (i j : Fin 2) :
+    (Matrix.scalar (Fin 2) a + b • M) i j = (if i = j then a else 0) + b * M i j := by
+  simp [Matrix.scalar_apply, Matrix.diagonal_apply]
+
+/-- A `2 × 2` matrix is `a • 1 + b • M` as soon as its four entries are. -/
+private theorem eq_scalar_add_smul_finTwo {a b : F} (h00 : N 0 0 = a + b * M 0 0)
+    (h01 : N 0 1 = b * M 0 1) (h10 : N 1 0 = b * M 1 0) (h11 : N 1 1 = a + b * M 1 1) :
+    N = Matrix.scalar (Fin 2) a + b • M := by
+  ext i j
+  rw [scalar_add_smul_apply]
+  fin_cases i <;> fin_cases j <;> simp [h00, h01, h10, h11]
+
+/-- **The commutant of a non-scalar `2 × 2` matrix.** A matrix commutes with a non-scalar
+`M : Matrix (Fin 2) (Fin 2) F` exactly when it lies in the two-dimensional subalgebra spanned by
+`1` and `M`; equivalently, a non-scalar `2 × 2` matrix is cyclic, so its commutant is `F[M]`.
+
+The hypothesis is necessary: everything commutes with a scalar matrix. -/
+theorem commute_finTwo_iff (hM : M ∉ Set.range (Matrix.scalar (Fin 2))) :
+    Commute M N ↔ ∃ a b : F, N = Matrix.scalar (Fin 2) a + b • M := by
+  constructor
+  · intro h
+    -- The entry equations of `M * N = N * M`; only three of the four are used.
+    have key : ∀ i j : Fin 2,
+        M i 0 * N 0 j + M i 1 * N 1 j = N i 0 * M 0 j + N i 1 * M 1 j := fun i j => by
+      simpa [Matrix.mul_apply, Fin.sum_univ_two] using congrFun (congrFun h.eq i) j
+    have e00 := key 0 0
+    have e01 := key 0 1
+    have e10 := key 1 0
+    -- Being non-scalar, `M` has a nonzero off-diagonal entry or distinct diagonal entries.
+    rw [mem_range_scalar_finTwo_iff] at hM
+    push Not at hM
+    by_cases h01 : M 0 1 = 0
+    · by_cases h10 : M 1 0 = 0
+      · -- `M` is diagonal with distinct entries: everything commuting with it is diagonal.
+        have hdiag : M 0 0 - M 1 1 ≠ 0 := sub_ne_zero.mpr (hM h01 h10)
+        obtain ⟨b, hb⟩ : ∃ b : F, b * (M 0 0 - M 1 1) = N 0 0 - N 1 1 :=
+          ⟨(N 0 0 - N 1 1) / (M 0 0 - M 1 1), div_mul_cancel₀ _ hdiag⟩
+        have hN01 : N 0 1 = 0 :=
+          mul_right_cancel₀ hdiag (by linear_combination e01 + (N 0 0 - N 1 1) * h01)
+        have hN10 : N 1 0 = 0 :=
+          mul_right_cancel₀ hdiag (by linear_combination -e10 + (N 0 0 - N 1 1) * h10)
+        exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring)
+          (by rw [hN01, h01, mul_zero]) (by rw [hN10, h10, mul_zero])
+          (by linear_combination hb)⟩
+      · -- The lower-left entry is nonzero and determines the coefficient of `M`.
+        obtain ⟨b, hb⟩ : ∃ b : F, b * M 1 0 = N 1 0 := ⟨N 1 0 / M 1 0, div_mul_cancel₀ _ h10⟩
+        exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring)
+          (mul_left_cancel₀ h10 (by linear_combination -e00 - M 0 1 * hb)) hb.symm
+          (mul_left_cancel₀ h10 (by linear_combination -e10 + (M 0 0 - M 1 1) * hb))⟩
+    · -- The upper-right entry is nonzero and determines the coefficient of `M`.
+      obtain ⟨b, hb⟩ : ∃ b : F, b * M 0 1 = N 0 1 := ⟨N 0 1 / M 0 1, div_mul_cancel₀ _ h01⟩
+      exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring) hb.symm
+        (mul_left_cancel₀ h01 (by linear_combination e00 - M 1 0 * hb))
+        (mul_left_cancel₀ h01 (by linear_combination e01 + (M 0 0 - M 1 1) * hb))⟩
+  · rintro ⟨a, b, rfl⟩
+    exact ((Matrix.scalar_commute a (Commute.all a) M).symm).add_right
+      ((Commute.refl M).smul_right b)
+
+/-- Two matrices commuting with a common non-scalar `2 × 2` matrix commute with each other: both
+lie in the commutative algebra `F[M]`. -/
+theorem commute_of_commute_finTwo (hM : M ∉ Set.range (Matrix.scalar (Fin 2)))
+    (hN : Commute M N) (hP : Commute M P) : Commute N P := by
+  obtain ⟨a, b, rfl⟩ := (commute_finTwo_iff hM).mp hN
+  obtain ⟨c, d, rfl⟩ := (commute_finTwo_iff hM).mp hP
+  have hs : ∀ x : F, Commute (Matrix.scalar (Fin 2) x) M :=
+    fun x => Matrix.scalar_commute x (Commute.all x) M
+  have h1 : Commute (Matrix.scalar (Fin 2) a) (Matrix.scalar (Fin 2) c) :=
+    Matrix.scalar_commute a (Commute.all a) _
+  have h2 : Commute (Matrix.scalar (Fin 2) a) (d • M) := (hs a).smul_right d
+  have h3 : Commute (b • M) (Matrix.scalar (Fin 2) c) := (hs c).symm.smul_left b
+  have h4 : Commute (b • M) (d • M) := ((Commute.refl M).smul_right d).smul_left b
+  exact (h1.add_right h2).add_left (h3.add_right h4)
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Borel.lean
@@ -15,10 +15,9 @@ public import Mathlib.GroupTheory.Index
 public import Mathlib.LinearAlgebra.Matrix.Block
 -- `TauCeti.diagGL` is the body of `TauCeti.GL2Borel.torusHom`, so it must be imported publicly.
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal
--- Non-public: the cardinality of the general linear group over a finite field, and the number of
--- units of a finite field, are used only inside the counting proofs, so downstream importers do
--- not pay for them.
-import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Card
+-- Non-public: the order of `GL₂` over a finite field, and the number of units of a finite field,
+-- are used only inside the counting proofs, so downstream importers do not pay for them.
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Card
 import Mathlib.Algebra.GroupWithZero.Units.Fintype
 
 /-!
@@ -446,22 +445,14 @@ theorem card_eq :
 /-- **The index of the Borel subgroup** of `GL₂(𝔽_q)` is `q + 1`, the number of points of the
 projective line — hence the dimension of the principal series induced from `B`. -/
 theorem index_eq : (GL2Borel F).index = Fintype.card F + 1 := by
-  set q := Fintype.card F with hq
-  have hq2 : 2 ≤ q := Fintype.one_lt_card
-  have hG : Nat.card (GL (Fin 2) F) = (q ^ 2 - 1) * (q ^ 2 - q) := by
-    rw [Matrix.card_GL_field, ← hq]
-    simp [Fin.prod_univ_two]
-  have hcard := Subgroup.card_mul_index (GL2Borel F)
-  rw [card_eq, hG] at hcard
-  have hkey : q * (q - 1) ^ 2 * (q + 1) = (q ^ 2 - 1) * (q ^ 2 - q) := by
-    have h1 : 1 ≤ q := by omega
-    have h2 : 1 ≤ q ^ 2 := Nat.one_le_pow _ _ (by omega)
-    have h3 : q ≤ q ^ 2 := Nat.le_self_pow two_ne_zero q
-    zify [h1, h2, h3]
-    ring
-  have hpos : 0 < q * (q - 1) ^ 2 :=
+  have hq2 : 2 ≤ Fintype.card F := Fintype.one_lt_card
+  have hpos : 0 < Fintype.card F * (Fintype.card F - 1) ^ 2 :=
     Nat.mul_pos (by omega) (pow_pos (by omega) 2)
-  exact Nat.eq_of_mul_eq_mul_left hpos (hcard.trans hkey.symm)
+  have hcard := Subgroup.card_mul_index (GL2Borel F)
+  rw [card_eq, natCard_GL_fin_two] at hcard
+  refine Nat.eq_of_mul_eq_mul_left hpos ?_
+  rw [hcard]
+  ring
 
 end GL2Borel
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- `GL` occurs in the statements below.
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+-- Non-public: `Matrix.card_GL_field` is what the two factorizations below are read off, in the
+-- proofs only.
+import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Card
+
+/-!
+# The order of `GL₂` over a finite field
+
+Mathlib's `Matrix.card_GL_field` gives `|GL n 𝔽_q| = ∏ i, (qⁿ - qⁱ)`, which in size two reads
+`(q² - 1)(q² - q)`. That form is a product of differences, and every index computation in `GL₂`
+divides it by the order of a subgroup, so what is wanted is the factored form
+`(q - 1)² · q · (q + 1)`, where the natural subtraction has already been carried out. It is
+recorded here in the two associations the two maximal tori call for: the split torus has order
+`(q - 1)²` and the non-split one `q² - 1`.
+
+## Main results
+
+* `TauCeti.natCard_GL_fin_two`: `|GL₂(𝔽_q)| = (q - 1)² · q(q + 1)`.
+* `TauCeti.natCard_GL_fin_two_eq_sq_sub_one_mul`: `|GL₂(𝔽_q)| = (q² - 1) · q(q - 1)`.
+
+## References
+
+* [Character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+  Layer 9, "The conjugacy classes (a build target)".
+-/
+
+public section
+
+namespace TauCeti
+
+variable (F : Type*) [Field F] [Fintype F]
+
+/-- **The order of `GL₂` over a finite field**, in the factored form `(q - 1)² · q(q + 1)`: the
+first factor is the order of the split torus and the second its index. -/
+theorem natCard_GL_fin_two :
+    Nat.card (GL (Fin 2) F) =
+      (Fintype.card F - 1) ^ 2 * (Fintype.card F * (Fintype.card F + 1)) := by
+  obtain ⟨m, hm⟩ : ∃ m, Fintype.card F = m + 1 :=
+    ⟨Fintype.card F - 1, (Nat.succ_pred_eq_of_pos Fintype.card_pos).symm⟩
+  have h1 : (m + 1) ^ 2 - 1 = m * (m + 2) := by
+    have : (m + 1) ^ 2 = m * (m + 2) + 1 := by ring
+    omega
+  have h2 : (m + 1) ^ 2 - (m + 1) = m * (m + 1) := by
+    have : (m + 1) ^ 2 = m * (m + 1) + (m + 1) := by ring
+    omega
+  rw [Matrix.card_GL_field, Fin.prod_univ_two, hm]
+  simp only [Fin.val_zero, Fin.val_one, pow_zero, pow_one, Nat.add_sub_cancel, h1, h2]
+  ring
+
+/-- **The order of `GL₂` over a finite field**, in the factored form `(q² - 1) · q(q - 1)`: the
+first factor is the order of the non-split torus and the second its index. -/
+theorem natCard_GL_fin_two_eq_sq_sub_one_mul :
+    Nat.card (GL (Fin 2) F) =
+      (Fintype.card F ^ 2 - 1) * (Fintype.card F * (Fintype.card F - 1)) := by
+  obtain ⟨m, hm⟩ : ∃ m, Fintype.card F = m + 1 :=
+    ⟨Fintype.card F - 1, (Nat.succ_pred_eq_of_pos Fintype.card_pos).symm⟩
+  have h1 : (m + 1) ^ 2 - 1 = m * (m + 2) := by
+    have : (m + 1) ^ 2 = m * (m + 2) + 1 := by ring
+    omega
+  rw [natCard_GL_fin_two, hm]
+  simp only [Nat.add_sub_cancel, h1]
+  ring
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
@@ -128,28 +128,36 @@ theorem notMem_range_scalar_diagGL {k : Type*} [Semiring k] {t : Fin 2 → kˣ} 
   rintro ⟨-, -, h⟩
   exact ht (Units.ext (by simpa using h))
 
-variable {F : Type*} [Field F] {t : Fin 2 → Fˣ}
+section CommRing
+
+variable {k : Type*} [CommRing k] [NoZeroDivisors k] {t : Fin 2 → kˣ}
 
 /-- **The centralizer of a split regular semisimple element of `GL₂`.** An invertible diagonal
 matrix with *distinct* diagonal entries has, as its centralizer, exactly the split torus
-`TauCeti.diagonalTorus F 2` of all invertible diagonal matrices: the maximal torus containing it.
+`TauCeti.diagonalTorus k 2` of all invertible diagonal matrices: the maximal torus containing it.
 
 Both inclusions come from the diagonal API: a matrix commuting with a diagonal matrix of distinct
 entries is diagonal (`TauCeti.isDiag_of_commute_diagonal`), and conversely the torus is
-commutative, so it centralizes each of its own elements. -/
+commutative, so it centralizes each of its own elements. Only the first of these needs anything of
+the ring, and only that a difference of the two diagonal entries be a non-zero-divisor, so the
+statement holds over any integral domain; a field is needed just for the counting below. -/
 theorem centralizer_diagGL (ht : t 0 ≠ t 1) :
-    Subgroup.centralizer {diagGL t} = diagonalTorus F 2 := by
-  have hne : (t 0 : F) ≠ (t 1 : F) := fun h => ht (Units.ext h)
-  have hinj : Function.Injective fun i => (t i : F) := by
+    Subgroup.centralizer {diagGL t} = diagonalTorus k 2 := by
+  have hne : (t 0 : k) ≠ (t 1 : k) := fun h => ht (Units.ext h)
+  have hinj : Function.Injective fun i => (t i : k) := by
     intro i j hij
     fin_cases i <;> fin_cases j <;> simp_all
   refine le_antisymm (fun h hh => mem_diagonalTorus_iff.mpr ?_) ?_
   · refine isDiag_of_commute_diagonal hinj ?_
     have hcomm := mem_centralizer_singleton_iff_commute_val.mp hh
     rwa [diagGL_coe] at hcomm
-  · exact (Subgroup.le_centralizer (diagonalTorus F 2)).trans
+  · exact (Subgroup.le_centralizer (diagonalTorus k 2)).trans
       (Subgroup.centralizer_le (Set.singleton_subset_iff.mpr
         (mem_diagonalTorus_iff_exists_diagGL.mpr ⟨t, rfl⟩)))
+
+end CommRing
+
+variable {F : Type*} [Field F] {t : Fin 2 → Fˣ}
 
 /-- **The order of the centralizer of a split regular semisimple element**: over a field with `q`
 elements the split torus has `(q - 1)²` elements, one invertible scalar per diagonal entry.  No
@@ -252,9 +260,12 @@ theorem centralizer_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (algebraMap 
   · rintro ⟨z, rfl⟩
     exact Commute.units_val_iff.mpr ((Commute.all x z).map (GL2NonSplitTorusHom F E hE))
 
-/-- **The order of the centralizer of an elliptic element**: over a field with `q` elements the
-non-split torus is a copy of `E ∖ {0}`, so it has `q² - 1` elements.  As for
-`TauCeti.GL2NonSplitTorus.natCard_eq`, no finiteness is assumed. -/
+/-- **The order of the centralizer of an element of `GL₂` coming from a quadratic extension**: the
+centralizer is `TauCeti.GL2NonSplitTorus F E hE`, a copy of `Eˣ`, so over a field with `q` elements
+it has `q² - 1` elements.  As for `TauCeti.GL2NonSplitTorus.natCard_eq`, no finiteness is assumed:
+over an infinite `F` both sides are `0`.  When `E/F` is separable — always so over a finite field —
+this is the order of the elliptic maximal torus containing the element; nothing here needs that
+hypothesis. -/
 theorem natCard_centralizer_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (algebraMap F E)) :
     Nat.card (Subgroup.centralizer {GL2NonSplitTorusHom F E hE x}) = Nat.card F ^ 2 - 1 := by
   rw [centralizer_gl2NonSplitTorusHom hE hx, natCard_eq]

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
--- `Matrix.scalar` occurs in the statements below.
-public import Mathlib.LinearAlgebra.Matrix.Notation
 -- `Subgroup.centralizer` occurs in the statements below, and
 -- `TauCeti.mem_centralizer_singleton_iff_commute_val` reads membership in it on matrices.
 public import TauCeti.Algebra.Group.Subgroup.Centralizer

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
@@ -4,11 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
--- `Matrix.scalar` occurs in the statements below, and the `2 × 2` entry lemmas
--- (`Matrix.det_fin_two`, `Fin.sum_univ_two`) in the proofs.
+-- `Matrix.scalar` occurs in the statements below, and the `2 × 2` entry lemma
+-- `Matrix.det_fin_two` in the proofs.
 public import Mathlib.LinearAlgebra.Matrix.Notation
 -- `Subgroup.centralizer` occurs in the statements below.
 public import Mathlib.GroupTheory.Subgroup.Centralizer
+-- `TauCeti.commute_finTwo_iff` is the engine of every centralizer computation below.
+public import TauCeti.LinearAlgebra.Matrix.Commute
 -- `ConjClasses.carrier` occurs in the statements below, and `TauCeti.ConjClasses.ncard_carrier_mk`
 -- is what turns a centralizer order into a class size.
 public import TauCeti.Algebra.Group.Conj
@@ -22,28 +24,36 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Card
 import Mathlib.Algebra.GroupWithZero.Units.Fintype
 
 /-!
-# Centralizers of the regular semisimple elements of `GL₂`
+# Centralizers of the regular elements of `GL₂`
 
 A `2 × 2` matrix over a field is **regular** as soon as it is not scalar: it is then cyclic
-(nonderogatory), and the matrices commuting with it are exactly the polynomials in it. In size `2`
-those polynomials are the affine combinations `a • 1 + b • M`, and that is the content of
-`TauCeti.commute_finTwo_iff`, the engine of this file: the commutant of a non-scalar
-`M : Matrix (Fin 2) (Fin 2) F` is the two-dimensional algebra `F[M]`.
+(nonderogatory), and the matrices commuting with it are exactly the polynomials in it, the
+two-dimensional algebra `F[M]`. That is `TauCeti.commute_finTwo_iff`, from
+`TauCeti.LinearAlgebra.Matrix.Commute`, and it is the engine of this file.
 
 Two consequences organize the conjugacy classes of `GL₂(F)`. First, the commutant of a non-scalar
 matrix is commutative, so the centralizer of a non-central element of `GL₂(F)` is an **abelian**
-subgroup (`TauCeti.isMulCommutative_centralizer_of_notMem_range_scalar`). Second, for a **regular
-semisimple** element — one with two distinct eigenvalues, over `F` or over a quadratic extension
-`E/F` — that centralizer is exactly the **maximal torus** containing it:
+subgroup (`TauCeti.isMulCommutative_centralizer_of_notMem_range_scalar`). Second, when a regular
+element generates a maximal commutative subalgebra of `Matrix (Fin 2) (Fin 2) F` — a split one,
+`F × F`, or a quadratic field extension `E/F` — its centralizer is that subalgebra's unit group:
 
 * the *split* case, an invertible diagonal matrix with distinct diagonal entries: its centralizer
   is the split torus `TauCeti.diagGL` of all invertible diagonal matrices
   (`TauCeti.centralizer_diagGL`), of order `(q - 1)²`, so its conjugacy class has `q (q + 1)`
   elements;
-* the *elliptic* case, an element of the non-split torus `TauCeti.GL2NonSplitTorus` not coming from
-  `F`: its centralizer is that whole torus
+* the *non-split* case, an element of `TauCeti.GL2NonSplitTorus` — the unit group of a quadratic
+  field extension `E/F` — that does not come from `F`: its centralizer is that whole group
   (`TauCeti.GL2NonSplitTorus.centralizer_gl2NonSplitTorusHom`), of order `q² - 1`, so its
   conjugacy class has `q (q - 1)` elements.
+
+Over a finite field — more generally whenever `E/F` is separable — both elements are **regular
+semisimple** and both centralizers are the **maximal torus** containing the element, split in the
+first case and elliptic in the second. Those words are used only under that hypothesis: over an
+imperfect field of characteristic two a purely inseparable quadratic extension `E/F` satisfies the
+hypotheses of `TauCeti.GL2NonSplitTorus.centralizer_gl2NonSplitTorusHom`, and there multiplication
+by an element of `E ∖ F` is not semisimple and `Eˣ` is not a torus; the general statement is proved
+and read as a centralizer computation for a quadratic extension, with no semisimplicity claimed.
+The counting results all assume `F` finite, where the torus language is unconditionally correct.
 
 The remaining conjugacy classes of `GL₂(𝔽_q)` are the central ones, whose centralizer is
 everything, and the non-semisimple ones `!![a, 1; 0, a]`, whose centralizer is again `F[M]ˣ` but
@@ -55,21 +65,17 @@ The class sizes are read off the centralizer orders by orbit-stabilizer
 
 ## Main results
 
-* `TauCeti.commute_finTwo_iff`: a matrix commutes with a non-scalar `2 × 2` matrix `M` exactly when
-  it is of the form `a • 1 + b • M`.
-* `TauCeti.commute_of_commute_finTwo`: two matrices commuting with a common non-scalar `2 × 2`
-  matrix commute with each other.
 * `TauCeti.isMulCommutative_centralizer_of_notMem_range_scalar`: the centralizer of a non-central
   element of `GL (Fin 2) F` is abelian.
 * `TauCeti.centralizer_diagGL`, `TauCeti.natCard_centralizer_diagGL`,
-  `TauCeti.ncard_carrier_conjClasses_diagGL`: the centralizer of an invertible diagonal matrix with
+  `TauCeti.ncard_carrier_mk_diagGL`: the centralizer of an invertible diagonal matrix with
   distinct entries is the split torus, of order `(q - 1)²`, and its conjugacy class has `q (q + 1)`
   elements.
 * `TauCeti.GL2NonSplitTorus.centralizer_gl2NonSplitTorusHom`,
   `TauCeti.GL2NonSplitTorus.natCard_centralizer_gl2NonSplitTorusHom`,
-  `TauCeti.GL2NonSplitTorus.ncard_carrier_conjClasses_gl2NonSplitTorusHom`: the centralizer of an
-  elliptic element is the non-split torus, of order `q² - 1`, and its conjugacy class has
-  `q (q - 1)` elements.
+  `TauCeti.GL2NonSplitTorus.ncard_carrier_mk_gl2NonSplitTorusHom`: the centralizer of an element of
+  the non-split torus not coming from `F` — an elliptic element, over a finite field — is that
+  whole torus, of order `q² - 1`, and its conjugacy class has `q (q - 1)` elements.
 
 ## References
 
@@ -84,98 +90,6 @@ public section
 open Matrix
 
 namespace TauCeti
-
-section Commutant
-
-variable {F : Type*} [Field F] {M N P : Matrix (Fin 2) (Fin 2) F}
-
-/-- A `2 × 2` matrix is scalar exactly when its off-diagonal entries vanish and its two diagonal
-entries agree. -/
-theorem mem_range_scalar_finTwo_iff :
-    M ∈ Set.range (Matrix.scalar (Fin 2)) ↔ M 0 1 = 0 ∧ M 1 0 = 0 ∧ M 0 0 = M 1 1 := by
-  constructor
-  · rintro ⟨c, rfl⟩
-    simp [Matrix.scalar_apply]
-  · rintro ⟨h01, h10, h00⟩
-    refine ⟨M 0 0, ?_⟩
-    ext i j
-    fin_cases i <;> fin_cases j <;> simp [Matrix.scalar_apply, h01, h10, h00]
-
-/-- The entries of `a • 1 + b • M`, for a `2 × 2` matrix `M`. -/
-private theorem scalar_add_smul_apply (a b : F) (i j : Fin 2) :
-    (Matrix.scalar (Fin 2) a + b • M) i j = (if i = j then a else 0) + b * M i j := by
-  simp [Matrix.scalar_apply, Matrix.diagonal_apply]
-
-/-- A `2 × 2` matrix is `a • 1 + b • M` as soon as its four entries are. -/
-private theorem eq_scalar_add_smul_finTwo {a b : F} (h00 : N 0 0 = a + b * M 0 0)
-    (h01 : N 0 1 = b * M 0 1) (h10 : N 1 0 = b * M 1 0) (h11 : N 1 1 = a + b * M 1 1) :
-    N = Matrix.scalar (Fin 2) a + b • M := by
-  ext i j
-  rw [scalar_add_smul_apply]
-  fin_cases i <;> fin_cases j <;> simp [h00, h01, h10, h11]
-
-/-- **The commutant of a non-scalar `2 × 2` matrix.** A matrix commutes with a non-scalar
-`M : Matrix (Fin 2) (Fin 2) F` exactly when it lies in the two-dimensional subalgebra spanned by
-`1` and `M`; equivalently, a non-scalar `2 × 2` matrix is cyclic, so its commutant is `F[M]`.
-
-The hypothesis is necessary: everything commutes with a scalar matrix. -/
-theorem commute_finTwo_iff (hM : M ∉ Set.range (Matrix.scalar (Fin 2))) :
-    Commute M N ↔ ∃ a b : F, N = Matrix.scalar (Fin 2) a + b • M := by
-  constructor
-  · intro h
-    -- The entry equations of `M * N = N * M`; only three of the four are used.
-    have key : ∀ i j : Fin 2,
-        M i 0 * N 0 j + M i 1 * N 1 j = N i 0 * M 0 j + N i 1 * M 1 j := fun i j => by
-      simpa [Matrix.mul_apply, Fin.sum_univ_two] using congrFun (congrFun h.eq i) j
-    have e00 := key 0 0
-    have e01 := key 0 1
-    have e10 := key 1 0
-    -- Being non-scalar, `M` has a nonzero off-diagonal entry or distinct diagonal entries.
-    rw [mem_range_scalar_finTwo_iff] at hM
-    push Not at hM
-    by_cases h01 : M 0 1 = 0
-    · by_cases h10 : M 1 0 = 0
-      · -- `M` is diagonal with distinct entries: everything commuting with it is diagonal.
-        have hdiag : M 0 0 - M 1 1 ≠ 0 := sub_ne_zero.mpr (hM h01 h10)
-        obtain ⟨b, hb⟩ : ∃ b : F, b * (M 0 0 - M 1 1) = N 0 0 - N 1 1 :=
-          ⟨(N 0 0 - N 1 1) / (M 0 0 - M 1 1), div_mul_cancel₀ _ hdiag⟩
-        have hN01 : N 0 1 = 0 :=
-          mul_right_cancel₀ hdiag (by linear_combination e01 + (N 0 0 - N 1 1) * h01)
-        have hN10 : N 1 0 = 0 :=
-          mul_right_cancel₀ hdiag (by linear_combination -e10 + (N 0 0 - N 1 1) * h10)
-        exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring)
-          (by rw [hN01, h01, mul_zero]) (by rw [hN10, h10, mul_zero])
-          (by linear_combination hb)⟩
-      · -- The lower-left entry is nonzero and determines the coefficient of `M`.
-        obtain ⟨b, hb⟩ : ∃ b : F, b * M 1 0 = N 1 0 := ⟨N 1 0 / M 1 0, div_mul_cancel₀ _ h10⟩
-        exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring)
-          (mul_left_cancel₀ h10 (by linear_combination -e00 - M 0 1 * hb)) hb.symm
-          (mul_left_cancel₀ h10 (by linear_combination -e10 + (M 0 0 - M 1 1) * hb))⟩
-    · -- The upper-right entry is nonzero and determines the coefficient of `M`.
-      obtain ⟨b, hb⟩ : ∃ b : F, b * M 0 1 = N 0 1 := ⟨N 0 1 / M 0 1, div_mul_cancel₀ _ h01⟩
-      exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring) hb.symm
-        (mul_left_cancel₀ h01 (by linear_combination e00 - M 1 0 * hb))
-        (mul_left_cancel₀ h01 (by linear_combination e01 + (M 0 0 - M 1 1) * hb))⟩
-  · rintro ⟨a, b, rfl⟩
-    exact ((Matrix.scalar_commute a (Commute.all a) M).symm).add_right
-      ((Commute.refl M).smul_right b)
-
-/-- Two matrices commuting with a common non-scalar `2 × 2` matrix commute with each other: both
-lie in the commutative algebra `F[M]`. -/
-theorem commute_of_commute_finTwo (hM : M ∉ Set.range (Matrix.scalar (Fin 2)))
-    (hN : Commute M N) (hP : Commute M P) : Commute N P := by
-  obtain ⟨a, b, rfl⟩ := (commute_finTwo_iff hM).mp hN
-  obtain ⟨c, d, rfl⟩ := (commute_finTwo_iff hM).mp hP
-  have hs : ∀ x : F, Commute (Matrix.scalar (Fin 2) x) M :=
-    fun x => Matrix.scalar_commute x (Commute.all x) M
-  have h1 : Commute (Matrix.scalar (Fin 2) a) (Matrix.scalar (Fin 2) c) :=
-    Matrix.scalar_commute a (Commute.all a) _
-  have h2 : Commute (Matrix.scalar (Fin 2) a) (d • M) := (hs a).smul_right d
-  have h3 : Commute (b • M) (Matrix.scalar (Fin 2) c) := (hs c).symm.smul_left b
-  have h4 : Commute (b • M) (d • M) := ((Commute.refl M).smul_right d).smul_left b
-  exact (h1.add_right h2).add_left (h3.add_right h4)
-
-end Commutant
 
 section GeneralLinearGroup
 
@@ -223,7 +137,8 @@ theorem centralizer_diagGL (ht : t 0 ≠ t 1) :
     obtain ⟨a, b, hab⟩ := (commute_finTwo_iff (notMem_range_scalar_diagGL ht)).mp hcomm
     have hentry : ∀ i j : Fin 2, (h : Matrix (Fin 2) (Fin 2) F) i j =
         (if i = j then a else 0) + b * (diagGL t : Matrix (Fin 2) (Fin 2) F) i j := fun i j => by
-      rw [hab, scalar_add_smul_apply]
+      rw [hab]
+      simp [Matrix.scalar_apply, Matrix.diagonal_apply]
     -- The commuting matrix is diagonal, and it is invertible, so its entries are units.
     have h01 : (h : Matrix (Fin 2) (Fin 2) F) 0 1 = 0 := by simp [hentry 0 1]
     have h10 : (h : Matrix (Fin 2) (Fin 2) F) 1 0 = 0 := by simp [hentry 1 0]
@@ -284,7 +199,7 @@ private theorem sub_one_sq_pos : 0 < (Fintype.card F - 1) ^ 2 :=
 
 /-- **The size of a split regular semisimple conjugacy class of `GL₂(𝔽_q)`**: it is
 `q (q + 1) = [GL₂(𝔽_q) : T]` for the split torus `T`. -/
-theorem ncard_carrier_conjClasses_diagGL {t : Fin 2 → Fˣ} (ht : t 0 ≠ t 1) :
+theorem ncard_carrier_mk_diagGL {t : Fin 2 → Fˣ} (ht : t 0 ≠ t 1) :
     (ConjClasses.mk (diagGL t)).carrier.ncard = Fintype.card F * (Fintype.card F + 1) := by
   have key := Subgroup.index_mul_card (Subgroup.centralizer {diagGL t})
   rw [natCard_centralizer_diagGL ht, natCard_gl2] at key
@@ -316,10 +231,16 @@ theorem notMem_range_scalar_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (alg
   rw [(Algebra.leftMulMatrix (nonSplitTorusBasis F E hE)).commutes c,
     ← coe_gl2NonSplitTorusHom hE, ← hc, scalar_eq_algebraMap]
 
-/-- **The centralizer of an elliptic element of `GL₂`.** An element of the non-split torus not
-coming from `F` has that whole torus as its centralizer: the maximal torus containing it. Together
+/-- **The centralizer of an element of `GL₂` coming from a quadratic field extension.** An element
+of `TauCeti.GL2NonSplitTorus F E hE`, the unit group of a quadratic extension `E/F` acting on `E`
+by multiplication, that does not come from `F` has that whole group as its centralizer.
+
+When `E/F` is separable — always so over a finite field — such an element is elliptic regular
+semisimple and `TauCeti.GL2NonSplitTorus F E hE` is the maximal torus containing it, so together
 with `TauCeti.centralizer_diagGL` this says that the centralizer of a regular semisimple element of
-`GL₂` is the maximal torus containing it, split or not. -/
+`GL₂` is the maximal torus containing it, split or not. Separability is not needed below: for a
+purely inseparable `E/F` in characteristic two the statement computes the centralizer of an element
+that is *not* semisimple, and `Eˣ` is then not a torus. -/
 theorem centralizer_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (algebraMap F E)) :
     Subgroup.centralizer {GL2NonSplitTorusHom F E hE x} = GL2NonSplitTorus F E hE := by
   ext h
@@ -353,7 +274,7 @@ theorem natCard_centralizer_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (alg
 
 /-- **The size of an elliptic conjugacy class of `GL₂(𝔽_q)`**: it is `q (q - 1) = [GL₂(𝔽_q) : T]`
 for the non-split torus `T`. -/
-theorem ncard_carrier_conjClasses_gl2NonSplitTorusHom
+theorem ncard_carrier_mk_gl2NonSplitTorusHom
     (hx : (x : E) ∉ Set.range (algebraMap F E)) :
     (ConjClasses.mk (GL2NonSplitTorusHom F E hE x)).carrier.ncard =
       Fintype.card F * (Fintype.card F - 1) := by

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
@@ -117,28 +117,34 @@ end GeneralLinearGroup
 
 section SplitTorus
 
-/-- An invertible diagonal matrix with distinct diagonal entries is not scalar, so
-`TauCeti.isMulCommutative_centralizer_of_notMem_range_scalar` applies to it.  Like `diagGL`
-itself, this needs only a semiring. -/
+/-- An invertible diagonal matrix with distinct diagonal entries is not scalar.  Like `diagGL`
+itself, this needs only a semiring; specialized to a field it is what supplies the non-scalarity
+hypothesis of `TauCeti.isMulCommutative_centralizer_of_notMem_range_scalar`, which is stated over
+a field. -/
 theorem notMem_range_scalar_diagGL {k : Type*} [Semiring k] {t : Fin 2 → kˣ} (ht : t 0 ≠ t 1) :
     (diagGL t : Matrix (Fin 2) (Fin 2) k) ∉ Set.range (Matrix.scalar (Fin 2)) := by
   rw [mem_range_scalar_fin_two_iff]
   rintro ⟨-, -, h⟩
   exact ht (Units.ext (by simpa using h))
 
-section CommRing
+section CommSemiring
 
-variable {k : Type*} [CommRing k] [NoZeroDivisors k] {t : Fin 2 → kˣ}
+variable {k : Type*} [CommSemiring k] [IsCancelMulZero k] {t : Fin 2 → kˣ}
 
-/-- **The centralizer of a split regular semisimple element of `GL₂`.** An invertible diagonal
-matrix with *distinct* diagonal entries has, as its centralizer, exactly the split torus
-`TauCeti.diagonalTorus k 2` of all invertible diagonal matrices: the maximal torus containing it.
+/-- **The centralizer of an invertible diagonal matrix with distinct entries.** Over a commutative
+semiring in which every nonzero element cancels, such a matrix has, as its centralizer, exactly the
+diagonal torus `TauCeti.diagonalTorus k 2` of all invertible diagonal matrices.
 
 Both inclusions come from the diagonal API: a matrix commuting with a diagonal matrix of distinct
 entries is diagonal (`TauCeti.isDiag_of_commute_diagonal`), and conversely the torus is
 commutative, so it centralizes each of its own elements. Only the first of these needs anything of
-the ring, and only that a difference of the two diagonal entries be a non-zero-divisor, so the
-statement holds over any integral domain; a field is needed just for the counting below. -/
+`k`, and only that its two distinct diagonal entries be separated by cancellation, so neither
+subtraction nor inverses are used; a field is needed just for the counting below.
+
+Over a field — where `IsCancelMulZero` is automatic — this is **the centralizer of a split regular
+semisimple element of `GL₂`**: a diagonal matrix with distinct entries is then regular semisimple,
+`TauCeti.diagonalTorus k 2` is the split maximal torus, and the theorem says that the centralizer
+of the element is the maximal torus containing it. -/
 theorem centralizer_diagGL (ht : t 0 ≠ t 1) :
     Subgroup.centralizer {diagGL t} = diagonalTorus k 2 := by
   have hne : (t 0 : k) ≠ (t 1 : k) := fun h => ht (Units.ext h)
@@ -153,7 +159,7 @@ theorem centralizer_diagGL (ht : t 0 ≠ t 1) :
       (Subgroup.centralizer_le (Set.singleton_subset_iff.mpr
         (mem_diagonalTorus_iff_exists_diagGL.mpr ⟨t, rfl⟩)))
 
-end CommRing
+end CommSemiring
 
 variable {F : Type*} [Field F] {t : Fin 2 → Fˣ}
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
@@ -1,0 +1,381 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- `Matrix.scalar` occurs in the statements below, and the `2 × 2` entry lemmas
+-- (`Matrix.det_fin_two`, `Fin.sum_univ_two`) in the proofs.
+public import Mathlib.LinearAlgebra.Matrix.Notation
+-- `Subgroup.centralizer` occurs in the statements below.
+public import Mathlib.GroupTheory.Subgroup.Centralizer
+-- `ConjClasses.carrier` occurs in the statements below, and `TauCeti.ConjClasses.ncard_carrier_mk`
+-- is what turns a centralizer order into a class size.
+public import TauCeti.Algebra.Group.Conj
+-- `TauCeti.diagGL` occurs in the statements below.
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal
+-- `TauCeti.GL2NonSplitTorus` occurs in the statements below.
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.NonSplitTorus
+-- Non-public: the order of `GL (Fin 2) F` and the number of units of a finite field are used only
+-- inside the counting proofs, so downstream importers do not pay for them.
+import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Card
+import Mathlib.Algebra.GroupWithZero.Units.Fintype
+
+/-!
+# Centralizers of the regular semisimple elements of `GL₂`
+
+A `2 × 2` matrix over a field is **regular** as soon as it is not scalar: it is then cyclic
+(nonderogatory), and the matrices commuting with it are exactly the polynomials in it. In size `2`
+those polynomials are the affine combinations `a • 1 + b • M`, and that is the content of
+`TauCeti.commute_finTwo_iff`, the engine of this file: the commutant of a non-scalar
+`M : Matrix (Fin 2) (Fin 2) F` is the two-dimensional algebra `F[M]`.
+
+Two consequences organize the conjugacy classes of `GL₂(F)`. First, the commutant of a non-scalar
+matrix is commutative, so the centralizer of a non-central element of `GL₂(F)` is an **abelian**
+subgroup (`TauCeti.isMulCommutative_centralizer_of_notMem_range_scalar`). Second, for a **regular
+semisimple** element — one with two distinct eigenvalues, over `F` or over a quadratic extension
+`E/F` — that centralizer is exactly the **maximal torus** containing it:
+
+* the *split* case, an invertible diagonal matrix with distinct diagonal entries: its centralizer
+  is the split torus `TauCeti.diagGL` of all invertible diagonal matrices
+  (`TauCeti.centralizer_diagGL`), of order `(q - 1)²`, so its conjugacy class has `q (q + 1)`
+  elements;
+* the *elliptic* case, an element of the non-split torus `TauCeti.GL2NonSplitTorus` not coming from
+  `F`: its centralizer is that whole torus
+  (`TauCeti.GL2NonSplitTorus.centralizer_gl2NonSplitTorusHom`), of order `q² - 1`, so its
+  conjugacy class has `q (q - 1)` elements.
+
+The remaining conjugacy classes of `GL₂(𝔽_q)` are the central ones, whose centralizer is
+everything, and the non-semisimple ones `!![a, 1; 0, a]`, whose centralizer is again `F[M]ˣ` but
+for a matrix with a repeated eigenvalue; the latter is not proved here.
+
+The class sizes are read off the centralizer orders by orbit-stabilizer
+(`TauCeti.ConjClasses.ncard_carrier_mk`), together with `Matrix.card_GL_field`, which gives
+`|GL₂(𝔽_q)| = (q² - 1)(q² - q)`.
+
+## Main results
+
+* `TauCeti.commute_finTwo_iff`: a matrix commutes with a non-scalar `2 × 2` matrix `M` exactly when
+  it is of the form `a • 1 + b • M`.
+* `TauCeti.commute_of_commute_finTwo`: two matrices commuting with a common non-scalar `2 × 2`
+  matrix commute with each other.
+* `TauCeti.isMulCommutative_centralizer_of_notMem_range_scalar`: the centralizer of a non-central
+  element of `GL (Fin 2) F` is abelian.
+* `TauCeti.centralizer_diagGL`, `TauCeti.natCard_centralizer_diagGL`,
+  `TauCeti.ncard_carrier_conjClasses_diagGL`: the centralizer of an invertible diagonal matrix with
+  distinct entries is the split torus, of order `(q - 1)²`, and its conjugacy class has `q (q + 1)`
+  elements.
+* `TauCeti.GL2NonSplitTorus.centralizer_gl2NonSplitTorusHom`,
+  `TauCeti.GL2NonSplitTorus.natCard_centralizer_gl2NonSplitTorusHom`,
+  `TauCeti.GL2NonSplitTorus.ncard_carrier_conjClasses_gl2NonSplitTorusHom`: the centralizer of an
+  elliptic element is the non-split torus, of order `q² - 1`, and its conjugacy class has
+  `q (q - 1)` elements.
+
+## References
+
+* [Character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+  Layer 9, "The conjugacy classes (a build target)".
+* C. Bonnafé, *Representations of `SL₂(𝔽_q)`* (2011), Chapter 1.
+* W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), Lecture 5.2.
+-/
+
+public section
+
+open Matrix
+
+namespace TauCeti
+
+section Commutant
+
+variable {F : Type*} [Field F] {M N P : Matrix (Fin 2) (Fin 2) F}
+
+/-- A `2 × 2` matrix is scalar exactly when its off-diagonal entries vanish and its two diagonal
+entries agree. -/
+theorem mem_range_scalar_finTwo_iff :
+    M ∈ Set.range (Matrix.scalar (Fin 2)) ↔ M 0 1 = 0 ∧ M 1 0 = 0 ∧ M 0 0 = M 1 1 := by
+  constructor
+  · rintro ⟨c, rfl⟩
+    simp [Matrix.scalar_apply]
+  · rintro ⟨h01, h10, h00⟩
+    refine ⟨M 0 0, ?_⟩
+    ext i j
+    fin_cases i <;> fin_cases j <;> simp [Matrix.scalar_apply, h01, h10, h00]
+
+/-- The entries of `a • 1 + b • M`, for a `2 × 2` matrix `M`. -/
+private theorem scalar_add_smul_apply (a b : F) (i j : Fin 2) :
+    (Matrix.scalar (Fin 2) a + b • M) i j = (if i = j then a else 0) + b * M i j := by
+  simp [Matrix.scalar_apply, Matrix.diagonal_apply]
+
+/-- A `2 × 2` matrix is `a • 1 + b • M` as soon as its four entries are. -/
+private theorem eq_scalar_add_smul_finTwo {a b : F} (h00 : N 0 0 = a + b * M 0 0)
+    (h01 : N 0 1 = b * M 0 1) (h10 : N 1 0 = b * M 1 0) (h11 : N 1 1 = a + b * M 1 1) :
+    N = Matrix.scalar (Fin 2) a + b • M := by
+  ext i j
+  rw [scalar_add_smul_apply]
+  fin_cases i <;> fin_cases j <;> simp [h00, h01, h10, h11]
+
+/-- **The commutant of a non-scalar `2 × 2` matrix.** A matrix commutes with a non-scalar
+`M : Matrix (Fin 2) (Fin 2) F` exactly when it lies in the two-dimensional subalgebra spanned by
+`1` and `M`; equivalently, a non-scalar `2 × 2` matrix is cyclic, so its commutant is `F[M]`.
+
+The hypothesis is necessary: everything commutes with a scalar matrix. -/
+theorem commute_finTwo_iff (hM : M ∉ Set.range (Matrix.scalar (Fin 2))) :
+    Commute M N ↔ ∃ a b : F, N = Matrix.scalar (Fin 2) a + b • M := by
+  constructor
+  · intro h
+    -- The entry equations of `M * N = N * M`; only three of the four are used.
+    have key : ∀ i j : Fin 2,
+        M i 0 * N 0 j + M i 1 * N 1 j = N i 0 * M 0 j + N i 1 * M 1 j := fun i j => by
+      simpa [Matrix.mul_apply, Fin.sum_univ_two] using congrFun (congrFun h.eq i) j
+    have e00 := key 0 0
+    have e01 := key 0 1
+    have e10 := key 1 0
+    -- Being non-scalar, `M` has a nonzero off-diagonal entry or distinct diagonal entries.
+    rw [mem_range_scalar_finTwo_iff] at hM
+    push Not at hM
+    by_cases h01 : M 0 1 = 0
+    · by_cases h10 : M 1 0 = 0
+      · -- `M` is diagonal with distinct entries: everything commuting with it is diagonal.
+        have hdiag : M 0 0 - M 1 1 ≠ 0 := sub_ne_zero.mpr (hM h01 h10)
+        obtain ⟨b, hb⟩ : ∃ b : F, b * (M 0 0 - M 1 1) = N 0 0 - N 1 1 :=
+          ⟨(N 0 0 - N 1 1) / (M 0 0 - M 1 1), div_mul_cancel₀ _ hdiag⟩
+        have hN01 : N 0 1 = 0 :=
+          mul_right_cancel₀ hdiag (by linear_combination e01 + (N 0 0 - N 1 1) * h01)
+        have hN10 : N 1 0 = 0 :=
+          mul_right_cancel₀ hdiag (by linear_combination -e10 + (N 0 0 - N 1 1) * h10)
+        exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring)
+          (by rw [hN01, h01, mul_zero]) (by rw [hN10, h10, mul_zero])
+          (by linear_combination hb)⟩
+      · -- The lower-left entry is nonzero and determines the coefficient of `M`.
+        obtain ⟨b, hb⟩ : ∃ b : F, b * M 1 0 = N 1 0 := ⟨N 1 0 / M 1 0, div_mul_cancel₀ _ h10⟩
+        exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring)
+          (mul_left_cancel₀ h10 (by linear_combination -e00 - M 0 1 * hb)) hb.symm
+          (mul_left_cancel₀ h10 (by linear_combination -e10 + (M 0 0 - M 1 1) * hb))⟩
+    · -- The upper-right entry is nonzero and determines the coefficient of `M`.
+      obtain ⟨b, hb⟩ : ∃ b : F, b * M 0 1 = N 0 1 := ⟨N 0 1 / M 0 1, div_mul_cancel₀ _ h01⟩
+      exact ⟨N 0 0 - b * M 0 0, b, eq_scalar_add_smul_finTwo (by ring) hb.symm
+        (mul_left_cancel₀ h01 (by linear_combination e00 - M 1 0 * hb))
+        (mul_left_cancel₀ h01 (by linear_combination e01 + (M 0 0 - M 1 1) * hb))⟩
+  · rintro ⟨a, b, rfl⟩
+    exact ((Matrix.scalar_commute a (Commute.all a) M).symm).add_right
+      ((Commute.refl M).smul_right b)
+
+/-- Two matrices commuting with a common non-scalar `2 × 2` matrix commute with each other: both
+lie in the commutative algebra `F[M]`. -/
+theorem commute_of_commute_finTwo (hM : M ∉ Set.range (Matrix.scalar (Fin 2)))
+    (hN : Commute M N) (hP : Commute M P) : Commute N P := by
+  obtain ⟨a, b, rfl⟩ := (commute_finTwo_iff hM).mp hN
+  obtain ⟨c, d, rfl⟩ := (commute_finTwo_iff hM).mp hP
+  have hs : ∀ x : F, Commute (Matrix.scalar (Fin 2) x) M :=
+    fun x => Matrix.scalar_commute x (Commute.all x) M
+  have h1 : Commute (Matrix.scalar (Fin 2) a) (Matrix.scalar (Fin 2) c) :=
+    Matrix.scalar_commute a (Commute.all a) _
+  have h2 : Commute (Matrix.scalar (Fin 2) a) (d • M) := (hs a).smul_right d
+  have h3 : Commute (b • M) (Matrix.scalar (Fin 2) c) := (hs c).symm.smul_left b
+  have h4 : Commute (b • M) (d • M) := ((Commute.refl M).smul_right d).smul_left b
+  exact (h1.add_right h2).add_left (h3.add_right h4)
+
+end Commutant
+
+section GeneralLinearGroup
+
+variable {F : Type*} [Field F] {g h : GL (Fin 2) F}
+
+/-- Membership in the centralizer of `g`, read on the underlying matrices. -/
+theorem mem_centralizer_singleton_iff_commute_coe :
+    h ∈ Subgroup.centralizer {g} ↔
+      Commute (g : Matrix (Fin 2) (Fin 2) F) (h : Matrix (Fin 2) (Fin 2) F) :=
+  ⟨fun hh => Commute.units_val_iff.mpr (Subgroup.mem_centralizer_singleton_iff.mp hh).symm,
+    fun hh => Subgroup.mem_centralizer_singleton_iff.mpr (Commute.units_val_iff.mp hh).symm⟩
+
+/-- A non-central element of `GL (Fin 2) F` is one whose matrix is not scalar; the matrices
+commuting with it then form a commutative algebra, so its centralizer is an **abelian** subgroup.
+This is what makes the centralizers of the regular elements of `GL₂` tori. -/
+theorem isMulCommutative_centralizer_of_notMem_range_scalar
+    (hg : (g : Matrix (Fin 2) (Fin 2) F) ∉ Set.range (Matrix.scalar (Fin 2))) :
+    IsMulCommutative ↥(Subgroup.centralizer {g}) :=
+  ⟨⟨fun x y => Subtype.ext (Commute.units_val_iff.mp (commute_of_commute_finTwo hg
+    (mem_centralizer_singleton_iff_commute_coe.mp x.2)
+    (mem_centralizer_singleton_iff_commute_coe.mp y.2))).eq⟩⟩
+
+end GeneralLinearGroup
+
+section SplitTorus
+
+variable {F : Type*} [Field F] {t : Fin 2 → Fˣ}
+
+/-- An invertible diagonal matrix with distinct diagonal entries is not scalar. -/
+theorem notMem_range_scalar_diagGL (ht : t 0 ≠ t 1) :
+    (diagGL t : Matrix (Fin 2) (Fin 2) F) ∉ Set.range (Matrix.scalar (Fin 2)) := by
+  rw [mem_range_scalar_finTwo_iff]
+  rintro ⟨-, -, h⟩
+  exact ht (Units.ext (by simpa using h))
+
+/-- **The centralizer of a split regular semisimple element of `GL₂`.** An invertible diagonal
+matrix with *distinct* diagonal entries has, as its centralizer, exactly the split torus of all
+invertible diagonal matrices: the maximal torus containing it. -/
+theorem centralizer_diagGL (ht : t 0 ≠ t 1) :
+    Subgroup.centralizer {diagGL t} = (diagGL (k := F) (n := 2)).range := by
+  ext h
+  rw [mem_centralizer_singleton_iff_commute_coe, MonoidHom.mem_range]
+  constructor
+  · intro hcomm
+    obtain ⟨a, b, hab⟩ := (commute_finTwo_iff (notMem_range_scalar_diagGL ht)).mp hcomm
+    have hentry : ∀ i j : Fin 2, (h : Matrix (Fin 2) (Fin 2) F) i j =
+        (if i = j then a else 0) + b * (diagGL t : Matrix (Fin 2) (Fin 2) F) i j := fun i j => by
+      rw [hab, scalar_add_smul_apply]
+    -- The commuting matrix is diagonal, and it is invertible, so its entries are units.
+    have h01 : (h : Matrix (Fin 2) (Fin 2) F) 0 1 = 0 := by simp [hentry 0 1]
+    have h10 : (h : Matrix (Fin 2) (Fin 2) F) 1 0 = 0 := by simp [hentry 1 0]
+    have hdet : (h : Matrix (Fin 2) (Fin 2) F) 0 0 * (h : Matrix (Fin 2) (Fin 2) F) 1 1 ≠ 0 := by
+      have hu := (Matrix.GeneralLinearGroup.det h).isUnit.ne_zero
+      rw [Matrix.GeneralLinearGroup.val_det_apply, Matrix.det_fin_two, h01, h10] at hu
+      simpa using hu
+    refine ⟨fun i => Units.mk0 ((h : Matrix (Fin 2) (Fin 2) F) i i) ?_, ?_⟩
+    · fin_cases i
+      · exact left_ne_zero_of_mul hdet
+      · exact right_ne_zero_of_mul hdet
+    · refine Units.ext ?_
+      ext i j
+      rcases eq_or_ne i j with rfl | hij
+      · simp
+      · simp [hentry i j, hij]
+  · rintro ⟨s, rfl⟩
+    exact Commute.units_val_iff.mpr ((Commute.all t s).map diagGL)
+
+variable [Fintype F]
+
+/-- **The order of the centralizer of a split regular semisimple element**: over a field with `q`
+elements the split torus has `(q - 1)²` elements, one invertible scalar per diagonal entry. -/
+theorem natCard_centralizer_diagGL (ht : t 0 ≠ t 1) :
+    Nat.card (Subgroup.centralizer {diagGL t}) = (Fintype.card F - 1) ^ 2 := by
+  classical
+  rw [centralizer_diagGL ht, ← Nat.card_congr (MonoidHom.ofInjective
+    (diagGL_injective (k := F) (n := 2))).toEquiv, Nat.card_eq_fintype_card, Fintype.card_fun,
+    Fintype.card_fin, ← Nat.card_eq_fintype_card, Nat.card_units, Nat.card_eq_fintype_card]
+
+end SplitTorus
+
+section Counting
+
+variable {F : Type*} [Field F] [Fintype F]
+
+/-- The order of `GL₂` over a field with `q` elements, in the factored form
+`(q - 1)² · q · (q + 1)` that divides out against the centralizer orders. -/
+private theorem natCard_gl2 :
+    Nat.card (GL (Fin 2) F) =
+      (Fintype.card F - 1) ^ 2 * (Fintype.card F * (Fintype.card F + 1)) := by
+  obtain ⟨m, hm⟩ : ∃ m, Fintype.card F = m + 1 :=
+    ⟨Fintype.card F - 1, (Nat.succ_pred_eq_of_pos Fintype.card_pos).symm⟩
+  have h1 : (m + 1) ^ 2 - 1 = m * (m + 2) := by
+    have : (m + 1) ^ 2 = m * (m + 2) + 1 := by ring
+    omega
+  have h2 : (m + 1) ^ 2 - (m + 1) = m * (m + 1) := by
+    have : (m + 1) ^ 2 = m * (m + 1) + (m + 1) := by ring
+    omega
+  rw [Matrix.card_GL_field, Fin.prod_univ_two, hm]
+  simp only [Fin.val_zero, Fin.val_one, pow_zero, pow_one, Nat.add_sub_cancel, h1, h2]
+  ring
+
+/-- The factor the split class-size computation cancels by is positive: `(q - 1)² > 0` for a field
+with `q > 1` elements. -/
+private theorem sub_one_sq_pos : 0 < (Fintype.card F - 1) ^ 2 :=
+  pow_pos (Nat.sub_pos_of_lt Fintype.one_lt_card) 2
+
+/-- **The size of a split regular semisimple conjugacy class of `GL₂(𝔽_q)`**: it is
+`q (q + 1) = [GL₂(𝔽_q) : T]` for the split torus `T`. -/
+theorem ncard_carrier_conjClasses_diagGL {t : Fin 2 → Fˣ} (ht : t 0 ≠ t 1) :
+    (ConjClasses.mk (diagGL t)).carrier.ncard = Fintype.card F * (Fintype.card F + 1) := by
+  have key := Subgroup.index_mul_card (Subgroup.centralizer {diagGL t})
+  rw [natCard_centralizer_diagGL ht, natCard_gl2] at key
+  rw [ConjClasses.ncard_carrier_mk]
+  refine Nat.eq_of_mul_eq_mul_right (sub_one_sq_pos (F := F)) ?_
+  rw [key]
+  ring
+
+end Counting
+
+namespace GL2NonSplitTorus
+
+variable {F : Type*} [Field F] {E : Type*} [Field E] [Algebra F E]
+  (hE : Module.finrank F E = 2) {x : Eˣ}
+
+/-- A scalar matrix over `F` is the image of the algebra map of the matrix algebra, so that the
+commutant description of `TauCeti.commute_finTwo_iff` can be compared with `Algebra.leftMulMatrix`
+through `AlgHom.commutes`. -/
+private theorem scalar_eq_algebraMap (c : F) :
+    Matrix.scalar (Fin 2) c = algebraMap F (Matrix (Fin 2) (Fin 2) F) c := (rfl)
+
+/-- An element of the non-split torus not coming from `F` is not a scalar matrix: multiplication by
+`x` on `E` is multiplication by an element of `F` exactly when `x` lies in `F`. -/
+theorem notMem_range_scalar_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (algebraMap F E)) :
+    (GL2NonSplitTorusHom F E hE x : Matrix (Fin 2) (Fin 2) F) ∉
+      Set.range (Matrix.scalar (Fin 2)) := by
+  rintro ⟨c, hc⟩
+  refine hx ⟨c, Algebra.leftMulMatrix_injective (nonSplitTorusBasis F E hE) ?_⟩
+  rw [(Algebra.leftMulMatrix (nonSplitTorusBasis F E hE)).commutes c,
+    ← coe_gl2NonSplitTorusHom hE, ← hc, scalar_eq_algebraMap]
+
+/-- **The centralizer of an elliptic element of `GL₂`.** An element of the non-split torus not
+coming from `F` has that whole torus as its centralizer: the maximal torus containing it. Together
+with `TauCeti.centralizer_diagGL` this says that the centralizer of a regular semisimple element of
+`GL₂` is the maximal torus containing it, split or not. -/
+theorem centralizer_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (algebraMap F E)) :
+    Subgroup.centralizer {GL2NonSplitTorusHom F E hE x} = GL2NonSplitTorus F E hE := by
+  ext h
+  rw [mem_centralizer_singleton_iff_commute_coe, mem_iff]
+  constructor
+  · intro hcomm
+    obtain ⟨a, b, hab⟩ :=
+      (commute_finTwo_iff (notMem_range_scalar_gl2NonSplitTorusHom hE hx)).mp hcomm
+    -- The commuting matrix is multiplication by `a + b x`, which is nonzero as it is invertible.
+    have hmat : (h : Matrix (Fin 2) (Fin 2) F) = Algebra.leftMulMatrix (nonSplitTorusBasis F E hE)
+        (algebraMap F E a + b • (x : E)) := by
+      rw [map_add, map_smul, (Algebra.leftMulMatrix (nonSplitTorusBasis F E hE)).commutes a,
+        ← coe_gl2NonSplitTorusHom hE, ← scalar_eq_algebraMap]
+      exact hab
+    have hy0 : algebraMap F E a + b • (x : E) ≠ 0 := by
+      intro h0
+      refine (Matrix.GeneralLinearGroup.det h).isUnit.ne_zero ?_
+      rw [Matrix.GeneralLinearGroup.val_det_apply, hmat, h0, map_zero]
+      exact Matrix.det_zero
+    exact ⟨Units.mk0 _ hy0, Units.ext (by rw [coe_gl2NonSplitTorusHom, Units.val_mk0, hmat])⟩
+  · rintro ⟨z, rfl⟩
+    exact Commute.units_val_iff.mpr ((Commute.all x z).map (GL2NonSplitTorusHom F E hE))
+
+variable [Fintype F]
+
+/-- **The order of the centralizer of an elliptic element**: over a field with `q` elements the
+non-split torus is a copy of `E ∖ {0}`, so it has `q² - 1` elements. -/
+theorem natCard_centralizer_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (algebraMap F E)) :
+    Nat.card (Subgroup.centralizer {GL2NonSplitTorusHom F E hE x}) = Fintype.card F ^ 2 - 1 := by
+  rw [centralizer_gl2NonSplitTorusHom hE hx, natCard_eq, Nat.card_eq_fintype_card]
+
+/-- **The size of an elliptic conjugacy class of `GL₂(𝔽_q)`**: it is `q (q - 1) = [GL₂(𝔽_q) : T]`
+for the non-split torus `T`. -/
+theorem ncard_carrier_conjClasses_gl2NonSplitTorusHom
+    (hx : (x : E) ∉ Set.range (algebraMap F E)) :
+    (ConjClasses.mk (GL2NonSplitTorusHom F E hE x)).carrier.ncard =
+      Fintype.card F * (Fintype.card F - 1) := by
+  obtain ⟨m, hm⟩ : ∃ m, Fintype.card F = m + 1 :=
+    ⟨Fintype.card F - 1, (Nat.succ_pred_eq_of_pos Fintype.card_pos).symm⟩
+  have hm1 : 1 ≤ m := by
+    have := Fintype.one_lt_card (α := F)
+    omega
+  have h1 : (m + 1) ^ 2 - 1 = m * (m + 2) := by
+    have : (m + 1) ^ 2 = m * (m + 2) + 1 := by ring
+    omega
+  have hpos : 0 < Fintype.card F ^ 2 - 1 := by
+    rw [hm, h1]
+    exact Nat.mul_pos (by omega) (by omega)
+  have key := Subgroup.index_mul_card (Subgroup.centralizer {GL2NonSplitTorusHom F E hE x})
+  rw [natCard_centralizer_gl2NonSplitTorusHom hE hx, natCard_gl2] at key
+  rw [ConjClasses.ncard_carrier_mk]
+  refine Nat.eq_of_mul_eq_mul_right hpos ?_
+  rw [key, hm]
+  simp only [Nat.add_sub_cancel, h1]
+  ring
+
+end GL2NonSplitTorus
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
@@ -4,32 +4,31 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
--- `Matrix.scalar` occurs in the statements below, and the `2 × 2` entry lemma
--- `Matrix.det_fin_two` in the proofs.
+-- `Matrix.scalar` occurs in the statements below.
 public import Mathlib.LinearAlgebra.Matrix.Notation
--- `Subgroup.centralizer` occurs in the statements below.
-public import Mathlib.GroupTheory.Subgroup.Centralizer
--- `TauCeti.commute_finTwo_iff` is the engine of every centralizer computation below.
+-- `Subgroup.centralizer` occurs in the statements below, and
+-- `TauCeti.mem_centralizer_singleton_iff_commute_val` reads membership in it on matrices.
+public import TauCeti.Algebra.Group.Subgroup.Centralizer
+-- `TauCeti.commute_fin_two_iff` is the engine of the centralizer computations below.
 public import TauCeti.LinearAlgebra.Matrix.Commute
 -- `ConjClasses.carrier` occurs in the statements below, and `TauCeti.ConjClasses.ncard_carrier_mk`
 -- is what turns a centralizer order into a class size.
 public import TauCeti.Algebra.Group.Conj
--- `TauCeti.diagGL` occurs in the statements below.
+-- `TauCeti.diagGL` and `TauCeti.diagonalTorus` occur in the statements below.
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal
 -- `TauCeti.GL2NonSplitTorus` occurs in the statements below.
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.NonSplitTorus
--- Non-public: the order of `GL (Fin 2) F` and the number of units of a finite field are used only
--- inside the counting proofs, so downstream importers do not pay for them.
-import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Card
-import Mathlib.Algebra.GroupWithZero.Units.Fintype
+-- Non-public: the order of `GL (Fin 2) F` over a finite field is used only inside the counting
+-- proofs, so downstream importers do not pay for it.
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Card
 
 /-!
 # Centralizers of the regular elements of `GL₂`
 
 A `2 × 2` matrix over a field is **regular** as soon as it is not scalar: it is then cyclic
 (nonderogatory), and the matrices commuting with it are exactly the polynomials in it, the
-two-dimensional algebra `F[M]`. That is `TauCeti.commute_finTwo_iff`, from
-`TauCeti.LinearAlgebra.Matrix.Commute`, and it is the engine of this file.
+two-dimensional algebra `F[M]`. That is `TauCeti.commute_fin_two_iff`, from
+`TauCeti.LinearAlgebra.Matrix.Commute`, and it is what organizes this file.
 
 Two consequences organize the conjugacy classes of `GL₂(F)`. First, the commutant of a non-scalar
 matrix is commutative, so the centralizer of a non-central element of `GL₂(F)` is an **abelian**
@@ -38,13 +37,18 @@ element generates a maximal commutative subalgebra of `Matrix (Fin 2) (Fin 2) F`
 `F × F`, or a quadratic field extension `E/F` — its centralizer is that subalgebra's unit group:
 
 * the *split* case, an invertible diagonal matrix with distinct diagonal entries: its centralizer
-  is the split torus `TauCeti.diagGL` of all invertible diagonal matrices
+  is the split torus `TauCeti.diagonalTorus F 2` of all invertible diagonal matrices
   (`TauCeti.centralizer_diagGL`), of order `(q - 1)²`, so its conjugacy class has `q (q + 1)`
   elements;
 * the *non-split* case, an element of `TauCeti.GL2NonSplitTorus` — the unit group of a quadratic
   field extension `E/F` — that does not come from `F`: its centralizer is that whole group
   (`TauCeti.GL2NonSplitTorus.centralizer_gl2NonSplitTorusHom`), of order `q² - 1`, so its
   conjugacy class has `q (q - 1)` elements.
+
+The split computation needs no commutant: a matrix commuting with a diagonal matrix of distinct
+entries is diagonal (`TauCeti.isDiag_of_commute_diagonal`), and the torus is commutative. It is the
+non-split case, and the abelianness of a general non-central centralizer, that consume
+`TauCeti.commute_fin_two_iff`.
 
 Over a finite field — more generally whenever `E/F` is separable — both elements are **regular
 semisimple** and both centralizers are the **maximal torus** containing the element, split in the
@@ -55,13 +59,18 @@ by an element of `E ∖ F` is not semisimple and `Eˣ` is not a torus; the gener
 and read as a centralizer computation for a quadratic extension, with no semisimplicity claimed.
 The counting results all assume `F` finite, where the torus language is unconditionally correct.
 
+Both computations are stated for a normal form — a diagonal matrix, and an element of the non-split
+torus in the basis `TauCeti.nonSplitTorusBasis` — rather than for an arbitrary regular semisimple
+element. Every regular semisimple element of `GL₂(𝔽_q)` is conjugate to one of the two, but that
+classification, and the transport of a centralizer along a conjugation, are not proved here.
+
 The remaining conjugacy classes of `GL₂(𝔽_q)` are the central ones, whose centralizer is
 everything, and the non-semisimple ones `!![a, 1; 0, a]`, whose centralizer is again `F[M]ˣ` but
-for a matrix with a repeated eigenvalue; the latter is not proved here.
+for a matrix with a repeated eigenvalue; neither is proved here.
 
 The class sizes are read off the centralizer orders by orbit-stabilizer
-(`TauCeti.ConjClasses.ncard_carrier_mk`), together with `Matrix.card_GL_field`, which gives
-`|GL₂(𝔽_q)| = (q² - 1)(q² - q)`.
+(`TauCeti.ConjClasses.ncard_carrier_mk`), together with `TauCeti.natCard_GL_fin_two`, which gives
+`|GL₂(𝔽_q)| = (q - 1)² q (q + 1)`.
 
 ## Main results
 
@@ -93,81 +102,61 @@ namespace TauCeti
 
 section GeneralLinearGroup
 
-variable {F : Type*} [Field F] {g h : GL (Fin 2) F}
-
-/-- Membership in the centralizer of `g`, read on the underlying matrices. -/
-theorem mem_centralizer_singleton_iff_commute_coe :
-    h ∈ Subgroup.centralizer {g} ↔
-      Commute (g : Matrix (Fin 2) (Fin 2) F) (h : Matrix (Fin 2) (Fin 2) F) :=
-  ⟨fun hh => Commute.units_val_iff.mpr (Subgroup.mem_centralizer_singleton_iff.mp hh).symm,
-    fun hh => Subgroup.mem_centralizer_singleton_iff.mpr (Commute.units_val_iff.mp hh).symm⟩
+variable {F : Type*} [Field F] {g : GL (Fin 2) F}
 
 /-- A non-central element of `GL (Fin 2) F` is one whose matrix is not scalar; the matrices
 commuting with it then form a commutative algebra, so its centralizer is an **abelian** subgroup.
-This is what makes the centralizers of the regular elements of `GL₂` tori. -/
+This is the prerequisite for the centralizers computed below being tori: an abelian overgroup of
+the torus can be no larger than it. -/
 theorem isMulCommutative_centralizer_of_notMem_range_scalar
     (hg : (g : Matrix (Fin 2) (Fin 2) F) ∉ Set.range (Matrix.scalar (Fin 2))) :
     IsMulCommutative ↥(Subgroup.centralizer {g}) :=
-  ⟨⟨fun x y => Subtype.ext (Commute.units_val_iff.mp (commute_of_commute_finTwo hg
-    (mem_centralizer_singleton_iff_commute_coe.mp x.2)
-    (mem_centralizer_singleton_iff_commute_coe.mp y.2))).eq⟩⟩
+  ⟨⟨fun x y => Subtype.ext (Commute.units_val_iff.mp (commute_of_commute_fin_two hg
+    (mem_centralizer_singleton_iff_commute_val.mp x.2)
+    (mem_centralizer_singleton_iff_commute_val.mp y.2))).eq⟩⟩
 
 end GeneralLinearGroup
 
 section SplitTorus
 
-variable {F : Type*} [Field F] {t : Fin 2 → Fˣ}
-
-/-- An invertible diagonal matrix with distinct diagonal entries is not scalar. -/
-theorem notMem_range_scalar_diagGL (ht : t 0 ≠ t 1) :
-    (diagGL t : Matrix (Fin 2) (Fin 2) F) ∉ Set.range (Matrix.scalar (Fin 2)) := by
-  rw [mem_range_scalar_finTwo_iff]
+/-- An invertible diagonal matrix with distinct diagonal entries is not scalar, so
+`TauCeti.isMulCommutative_centralizer_of_notMem_range_scalar` applies to it.  Like `diagGL`
+itself, this needs only a semiring. -/
+theorem notMem_range_scalar_diagGL {k : Type*} [Semiring k] {t : Fin 2 → kˣ} (ht : t 0 ≠ t 1) :
+    (diagGL t : Matrix (Fin 2) (Fin 2) k) ∉ Set.range (Matrix.scalar (Fin 2)) := by
+  rw [mem_range_scalar_fin_two_iff]
   rintro ⟨-, -, h⟩
   exact ht (Units.ext (by simpa using h))
 
-/-- **The centralizer of a split regular semisimple element of `GL₂`.** An invertible diagonal
-matrix with *distinct* diagonal entries has, as its centralizer, exactly the split torus of all
-invertible diagonal matrices: the maximal torus containing it. -/
-theorem centralizer_diagGL (ht : t 0 ≠ t 1) :
-    Subgroup.centralizer {diagGL t} = (diagGL (k := F) (n := 2)).range := by
-  ext h
-  rw [mem_centralizer_singleton_iff_commute_coe, MonoidHom.mem_range]
-  constructor
-  · intro hcomm
-    obtain ⟨a, b, hab⟩ := (commute_finTwo_iff (notMem_range_scalar_diagGL ht)).mp hcomm
-    have hentry : ∀ i j : Fin 2, (h : Matrix (Fin 2) (Fin 2) F) i j =
-        (if i = j then a else 0) + b * (diagGL t : Matrix (Fin 2) (Fin 2) F) i j := fun i j => by
-      rw [hab]
-      simp [Matrix.scalar_apply, Matrix.diagonal_apply]
-    -- The commuting matrix is diagonal, and it is invertible, so its entries are units.
-    have h01 : (h : Matrix (Fin 2) (Fin 2) F) 0 1 = 0 := by simp [hentry 0 1]
-    have h10 : (h : Matrix (Fin 2) (Fin 2) F) 1 0 = 0 := by simp [hentry 1 0]
-    have hdet : (h : Matrix (Fin 2) (Fin 2) F) 0 0 * (h : Matrix (Fin 2) (Fin 2) F) 1 1 ≠ 0 := by
-      have hu := (Matrix.GeneralLinearGroup.det h).isUnit.ne_zero
-      rw [Matrix.GeneralLinearGroup.val_det_apply, Matrix.det_fin_two, h01, h10] at hu
-      simpa using hu
-    refine ⟨fun i => Units.mk0 ((h : Matrix (Fin 2) (Fin 2) F) i i) ?_, ?_⟩
-    · fin_cases i
-      · exact left_ne_zero_of_mul hdet
-      · exact right_ne_zero_of_mul hdet
-    · refine Units.ext ?_
-      ext i j
-      rcases eq_or_ne i j with rfl | hij
-      · simp
-      · simp [hentry i j, hij]
-  · rintro ⟨s, rfl⟩
-    exact Commute.units_val_iff.mpr ((Commute.all t s).map diagGL)
+variable {F : Type*} [Field F] {t : Fin 2 → Fˣ}
 
-variable [Fintype F]
+/-- **The centralizer of a split regular semisimple element of `GL₂`.** An invertible diagonal
+matrix with *distinct* diagonal entries has, as its centralizer, exactly the split torus
+`TauCeti.diagonalTorus F 2` of all invertible diagonal matrices: the maximal torus containing it.
+
+Both inclusions come from the diagonal API: a matrix commuting with a diagonal matrix of distinct
+entries is diagonal (`TauCeti.isDiag_of_commute_diagonal`), and conversely the torus is
+commutative, so it centralizes each of its own elements. -/
+theorem centralizer_diagGL (ht : t 0 ≠ t 1) :
+    Subgroup.centralizer {diagGL t} = diagonalTorus F 2 := by
+  have hne : (t 0 : F) ≠ (t 1 : F) := fun h => ht (Units.ext h)
+  have hinj : Function.Injective fun i => (t i : F) := by
+    intro i j hij
+    fin_cases i <;> fin_cases j <;> simp_all
+  refine le_antisymm (fun h hh => mem_diagonalTorus_iff.mpr ?_) ?_
+  · refine isDiag_of_commute_diagonal hinj ?_
+    have hcomm := mem_centralizer_singleton_iff_commute_val.mp hh
+    rwa [diagGL_coe] at hcomm
+  · exact (Subgroup.le_centralizer (diagonalTorus F 2)).trans
+      (Subgroup.centralizer_le (Set.singleton_subset_iff.mpr
+        (mem_diagonalTorus_iff_exists_diagGL.mpr ⟨t, rfl⟩)))
 
 /-- **The order of the centralizer of a split regular semisimple element**: over a field with `q`
-elements the split torus has `(q - 1)²` elements, one invertible scalar per diagonal entry. -/
+elements the split torus has `(q - 1)²` elements, one invertible scalar per diagonal entry.  No
+finiteness is assumed: over an infinite field both sides vanish. -/
 theorem natCard_centralizer_diagGL (ht : t 0 ≠ t 1) :
-    Nat.card (Subgroup.centralizer {diagGL t}) = (Fintype.card F - 1) ^ 2 := by
-  classical
-  rw [centralizer_diagGL ht, ← Nat.card_congr (MonoidHom.ofInjective
-    (diagGL_injective (k := F) (n := 2))).toEquiv, Nat.card_eq_fintype_card, Fintype.card_fun,
-    Fintype.card_fin, ← Nat.card_eq_fintype_card, Nat.card_units, Nat.card_eq_fintype_card]
+    Nat.card (Subgroup.centralizer {diagGL t}) = (Nat.card F - 1) ^ 2 := by
+  rw [centralizer_diagGL ht, natCard_diagonalTorus]
 
 end SplitTorus
 
@@ -175,38 +164,32 @@ section Counting
 
 variable {F : Type*} [Field F] [Fintype F]
 
-/-- The order of `GL₂` over a field with `q` elements, in the factored form
-`(q - 1)² · q · (q + 1)` that divides out against the centralizer orders. -/
-private theorem natCard_gl2 :
-    Nat.card (GL (Fin 2) F) =
-      (Fintype.card F - 1) ^ 2 * (Fintype.card F * (Fintype.card F + 1)) := by
-  obtain ⟨m, hm⟩ : ∃ m, Fintype.card F = m + 1 :=
-    ⟨Fintype.card F - 1, (Nat.succ_pred_eq_of_pos Fintype.card_pos).symm⟩
-  have h1 : (m + 1) ^ 2 - 1 = m * (m + 2) := by
-    have : (m + 1) ^ 2 = m * (m + 2) + 1 := by ring
-    omega
-  have h2 : (m + 1) ^ 2 - (m + 1) = m * (m + 1) := by
-    have : (m + 1) ^ 2 = m * (m + 1) + (m + 1) := by ring
-    omega
-  rw [Matrix.card_GL_field, Fin.prod_univ_two, hm]
-  simp only [Fin.val_zero, Fin.val_one, pow_zero, pow_one, Nat.add_sub_cancel, h1, h2]
-  ring
+/-- Orbit-stabilizer arithmetic: a subgroup of known nonzero order in a group whose order it
+divides in a known way has the complementary factor as its index. -/
+private theorem index_eq_of_natCard_eq_mul {G : Type*} [Group G] {H : Subgroup G} {c d : ℕ}
+    (hpos : 0 < c) (hH : Nat.card H = c) (hG : Nat.card G = c * d) : H.index = d := by
+  refine Nat.eq_of_mul_eq_mul_left hpos ?_
+  calc c * H.index = Nat.card H * H.index := by rw [hH]
+    _ = Nat.card G := Subgroup.card_mul_index H
+    _ = c * d := hG
 
 /-- The factor the split class-size computation cancels by is positive: `(q - 1)² > 0` for a field
 with `q > 1` elements. -/
-private theorem sub_one_sq_pos : 0 < (Fintype.card F - 1) ^ 2 :=
+private theorem card_sub_one_sq_pos : 0 < (Fintype.card F - 1) ^ 2 :=
   pow_pos (Nat.sub_pos_of_lt Fintype.one_lt_card) 2
+
+/-- The factor the elliptic class-size computation cancels by is positive: `q² - 1 > 0` for a field
+with `q > 1` elements. -/
+private theorem card_sq_sub_one_pos : 0 < Fintype.card F ^ 2 - 1 :=
+  Nat.sub_pos_of_lt (Nat.one_lt_pow two_ne_zero Fintype.one_lt_card)
 
 /-- **The size of a split regular semisimple conjugacy class of `GL₂(𝔽_q)`**: it is
 `q (q + 1) = [GL₂(𝔽_q) : T]` for the split torus `T`. -/
 theorem ncard_carrier_mk_diagGL {t : Fin 2 → Fˣ} (ht : t 0 ≠ t 1) :
     (ConjClasses.mk (diagGL t)).carrier.ncard = Fintype.card F * (Fintype.card F + 1) := by
-  have key := Subgroup.index_mul_card (Subgroup.centralizer {diagGL t})
-  rw [natCard_centralizer_diagGL ht, natCard_gl2] at key
   rw [ConjClasses.ncard_carrier_mk]
-  refine Nat.eq_of_mul_eq_mul_right (sub_one_sq_pos (F := F)) ?_
-  rw [key]
-  ring
+  refine index_eq_of_natCard_eq_mul card_sub_one_sq_pos ?_ (natCard_GL_fin_two F)
+  rw [natCard_centralizer_diagGL ht, Nat.card_eq_fintype_card]
 
 end Counting
 
@@ -216,10 +199,13 @@ variable {F : Type*} [Field F] {E : Type*} [Field E] [Algebra F E]
   (hE : Module.finrank F E = 2) {x : Eˣ}
 
 /-- A scalar matrix over `F` is the image of the algebra map of the matrix algebra, so that the
-commutant description of `TauCeti.commute_finTwo_iff` can be compared with `Algebra.leftMulMatrix`
+commutant description of `TauCeti.commute_fin_two_iff` can be compared with `Algebra.leftMulMatrix`
 through `AlgHom.commutes`. -/
 private theorem scalar_eq_algebraMap (c : F) :
-    Matrix.scalar (Fin 2) c = algebraMap F (Matrix (Fin 2) (Fin 2) F) c := (rfl)
+    Matrix.scalar (Fin 2) c = algebraMap F (Matrix (Fin 2) (Fin 2) F) c := by
+  ext i j
+  rw [Matrix.algebraMap_matrix_apply, Matrix.scalar_apply, Matrix.diagonal_apply]
+  simp
 
 /-- An element of the non-split torus not coming from `F` is not a scalar matrix: multiplication by
 `x` on `E` is multiplication by an element of `F` exactly when `x` lies in `F`. -/
@@ -236,19 +222,21 @@ of `TauCeti.GL2NonSplitTorus F E hE`, the unit group of a quadratic extension `E
 by multiplication, that does not come from `F` has that whole group as its centralizer.
 
 When `E/F` is separable — always so over a finite field — such an element is elliptic regular
-semisimple and `TauCeti.GL2NonSplitTorus F E hE` is the maximal torus containing it, so together
-with `TauCeti.centralizer_diagGL` this says that the centralizer of a regular semisimple element of
-`GL₂` is the maximal torus containing it, split or not. Separability is not needed below: for a
-purely inseparable `E/F` in characteristic two the statement computes the centralizer of an element
-that is *not* semisimple, and `Eˣ` is then not a torus. -/
+semisimple and `TauCeti.GL2NonSplitTorus F E hE` is the maximal torus containing it. Together with
+`TauCeti.centralizer_diagGL` this computes the centralizer of each of the two standard regular
+semisimple normal forms of `GL₂`, split and elliptic; that every regular semisimple element is
+conjugate to one of them, and that a centralizer transports along such a conjugation, are not
+proved here. Separability is not needed below: for a purely inseparable `E/F` in characteristic
+two the statement computes the centralizer of an element that is *not* semisimple, and `Eˣ` is then
+not a torus. -/
 theorem centralizer_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (algebraMap F E)) :
     Subgroup.centralizer {GL2NonSplitTorusHom F E hE x} = GL2NonSplitTorus F E hE := by
   ext h
-  rw [mem_centralizer_singleton_iff_commute_coe, mem_iff]
+  rw [mem_centralizer_singleton_iff_commute_val, mem_iff]
   constructor
   · intro hcomm
     obtain ⟨a, b, hab⟩ :=
-      (commute_finTwo_iff (notMem_range_scalar_gl2NonSplitTorusHom hE hx)).mp hcomm
+      (commute_fin_two_iff (notMem_range_scalar_gl2NonSplitTorusHom hE hx)).mp hcomm
     -- The commuting matrix is multiplication by `a + b x`, which is nonzero as it is invertible.
     have hmat : (h : Matrix (Fin 2) (Fin 2) F) = Algebra.leftMulMatrix (nonSplitTorusBasis F E hE)
         (algebraMap F E a + b • (x : E)) := by
@@ -264,38 +252,23 @@ theorem centralizer_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (algebraMap 
   · rintro ⟨z, rfl⟩
     exact Commute.units_val_iff.mpr ((Commute.all x z).map (GL2NonSplitTorusHom F E hE))
 
-variable [Fintype F]
-
 /-- **The order of the centralizer of an elliptic element**: over a field with `q` elements the
-non-split torus is a copy of `E ∖ {0}`, so it has `q² - 1` elements. -/
+non-split torus is a copy of `E ∖ {0}`, so it has `q² - 1` elements.  As for
+`TauCeti.GL2NonSplitTorus.natCard_eq`, no finiteness is assumed. -/
 theorem natCard_centralizer_gl2NonSplitTorusHom (hx : (x : E) ∉ Set.range (algebraMap F E)) :
-    Nat.card (Subgroup.centralizer {GL2NonSplitTorusHom F E hE x}) = Fintype.card F ^ 2 - 1 := by
-  rw [centralizer_gl2NonSplitTorusHom hE hx, natCard_eq, Nat.card_eq_fintype_card]
+    Nat.card (Subgroup.centralizer {GL2NonSplitTorusHom F E hE x}) = Nat.card F ^ 2 - 1 := by
+  rw [centralizer_gl2NonSplitTorusHom hE hx, natCard_eq]
 
 /-- **The size of an elliptic conjugacy class of `GL₂(𝔽_q)`**: it is `q (q - 1) = [GL₂(𝔽_q) : T]`
 for the non-split torus `T`. -/
-theorem ncard_carrier_mk_gl2NonSplitTorusHom
+theorem ncard_carrier_mk_gl2NonSplitTorusHom [Fintype F]
     (hx : (x : E) ∉ Set.range (algebraMap F E)) :
     (ConjClasses.mk (GL2NonSplitTorusHom F E hE x)).carrier.ncard =
       Fintype.card F * (Fintype.card F - 1) := by
-  obtain ⟨m, hm⟩ : ∃ m, Fintype.card F = m + 1 :=
-    ⟨Fintype.card F - 1, (Nat.succ_pred_eq_of_pos Fintype.card_pos).symm⟩
-  have hm1 : 1 ≤ m := by
-    have := Fintype.one_lt_card (α := F)
-    omega
-  have h1 : (m + 1) ^ 2 - 1 = m * (m + 2) := by
-    have : (m + 1) ^ 2 = m * (m + 2) + 1 := by ring
-    omega
-  have hpos : 0 < Fintype.card F ^ 2 - 1 := by
-    rw [hm, h1]
-    exact Nat.mul_pos (by omega) (by omega)
-  have key := Subgroup.index_mul_card (Subgroup.centralizer {GL2NonSplitTorusHom F E hE x})
-  rw [natCard_centralizer_gl2NonSplitTorusHom hE hx, natCard_gl2] at key
   rw [ConjClasses.ncard_carrier_mk]
-  refine Nat.eq_of_mul_eq_mul_right hpos ?_
-  rw [key, hm]
-  simp only [Nat.add_sub_cancel, h1]
-  ring
+  refine index_eq_of_natCard_eq_mul card_sq_sub_one_pos ?_
+    (natCard_GL_fin_two_eq_sq_sub_one_mul F)
+  rw [natCard_centralizer_gl2NonSplitTorusHom hE hx, Nat.card_eq_fintype_card]
 
 end GL2NonSplitTorus
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean
@@ -45,6 +45,10 @@ the point being that invertibility upgrades the diagonal entries of a diagonal m
 (`TauCeti.centralizer_diagonalTorus`), so it is a maximal abelian subgroup: no larger subgroup of
 `GL n k` contains it and is commutative.
 
+The embedding, the torus, the equivalence and the membership criterion ask only that `k` be a
+semiring; commutativity of `k` enters with the determinant, and the absence of zero divisors with
+the self-centralization.
+
 Self-centralization is proved under two hypotheses, neither of them idle.  The absence of zero
 divisors is a sufficient hypothesis rather than a necessary one: an off-diagonal entry `g i j` of
 a centralizing matrix satisfies `g i j * (t i - t j) = 0` for diagonal entries `t i ≠ t j`, and
@@ -130,56 +134,27 @@ theorem diagGL_injective : Function.Injective (diagGL (k := k) (n := n)) := by
   have := congrArg (fun g : GL (Fin n) k => (g : Matrix (Fin n) (Fin n) k) i i) h
   simpa using this
 
-end Semiring
+/-- The diagonal entries of an invertible diagonal matrix are units: the inverse matrix supplies
+the inverse entry, because for a diagonal matrix each of the two products defining invertibility
+collapses on the diagonal to a single term.
 
-variable [CommRing k]
-
-/-- The determinant of a diagonal matrix is the product of its diagonal entries. -/
-@[simp]
-theorem det_diagGL (t : Fin n → kˣ) :
-    Matrix.GeneralLinearGroup.det (diagGL t) = ∏ i, t i := by
-  apply Units.ext
-  simp [Matrix.GeneralLinearGroup.val_det_apply, diagGL_coe, Matrix.det_diagonal]
-
-section Diagonal
-
-variable {ι : Type*} [Fintype ι] [DecidableEq ι]
-
-/-- The diagonal entries of an invertible diagonal matrix are units, because a diagonal matrix
-is invertible exactly when its diagonal is invertible coordinatewise. -/
-theorem isUnit_apply_of_isDiag {g : GL ι k} (hg : (g : Matrix ι ι k).IsDiag) (i : ι) :
-    IsUnit ((g : Matrix ι ι k) i i) := by
-  have h : IsUnit (Matrix.diagonal (Matrix.diag (g : Matrix ι ι k))) := by
-    rw [hg.diagonal_diag]
-    exact Units.isUnit g
-  exact (Matrix.isUnit_diagonal.mp h).apply i
-
-section NoZeroDivisors
-
-variable [NoZeroDivisors k]
-
-/-- A matrix commuting with a diagonal matrix has vanishing `(i, j)` entry whenever the diagonal
-matrix separates the coordinates `i` and `j`. -/
-theorem apply_eq_zero_of_commute_diagonal {t : ι → k} {g : Matrix ι ι k}
-    (hg : Commute (Matrix.diagonal t) g) {i j : ι} (hij : t i ≠ t j) : g i j = 0 := by
-  have hentry : (Matrix.diagonal t * g) i j = (g * Matrix.diagonal t) i j := by rw [hg.eq]
-  rw [Matrix.diagonal_mul, Matrix.mul_diagonal] at hentry
-  have hzero : g i j * (t i - t j) = 0 := by
-    rw [mul_sub, ← hentry]
-    ring
-  exact (mul_eq_zero.mp hzero).resolve_right (sub_ne_zero.mpr hij)
-
-/-- **A matrix commuting with a diagonal matrix of pairwise distinct entries is diagonal.** -/
-theorem isDiag_of_commute_diagonal {t : ι → k} (ht : Function.Injective t)
-    {g : Matrix ι ι k} (hg : Commute (Matrix.diagonal t) g) : g.IsDiag :=
-  fun _ _ hij => apply_eq_zero_of_commute_diagonal hg (ht.ne hij)
-
-end NoZeroDivisors
-
-end Diagonal
+(Mathlib's `Matrix.isUnit_diagonal` says the same thing over a `CommRing`, where it is proved
+through the adjugate; the fact itself needs no commutativity, and the diagonal torus below is a
+subgroup of `GL n k` already over a semiring.) -/
+theorem isUnit_apply_of_isDiag {ι : Type*} [Fintype ι] [DecidableEq ι] {g : GL ι k}
+    (hg : (g : Matrix ι ι k).IsDiag) (i : ι) : IsUnit ((g : Matrix ι ι k) i i) := by
+  refine ⟨⟨(g : Matrix ι ι k) i i, ((g⁻¹ : GL ι k) : Matrix ι ι k) i i, ?_, ?_⟩, rfl⟩
+  · have h : ((g : Matrix ι ι k) * ((g⁻¹ : GL ι k) : Matrix ι ι k)) i i =
+        (1 : Matrix ι ι k) i i := by rw [g.mul_inv]
+    rwa [Matrix.mul_apply, Finset.sum_eq_single_of_mem i (Finset.mem_univ i)
+      (fun b _ hb => by rw [hg (Ne.symm hb), zero_mul]), Matrix.one_apply_eq] at h
+  · have h : (((g⁻¹ : GL ι k) : Matrix ι ι k) * (g : Matrix ι ι k)) i i =
+        (1 : Matrix ι ι k) i i := by rw [g.inv_mul]
+    rwa [Matrix.mul_apply, Finset.sum_eq_single_of_mem i (Finset.mem_univ i)
+      (fun b _ hb => by rw [hg hb, mul_zero]), Matrix.one_apply_eq] at h
 
 /-- The **diagonal torus** of `GL n k`: the image of the coordinatewise units under `diagGL`. -/
-def diagonalTorus (k : Type u) [CommRing k] (n : ℕ) : Subgroup (GL (Fin n) k) :=
+def diagonalTorus (k : Type u) [Semiring k] (n : ℕ) : Subgroup (GL (Fin n) k) :=
   MonoidHom.range (diagGL (k := k) (n := n))
 
 /-- Membership in the diagonal torus, read off its definition as a range: an element lies in it
@@ -208,7 +183,7 @@ theorem isDiag_of_mem_diagonalTorus {g : GL (Fin n) k} (hg : g ∈ diagonalTorus
   mem_diagonalTorus_iff.mp hg
 
 /-- The diagonal torus is the group of coordinatewise units. -/
-noncomputable def diagonalTorusEquiv (k : Type u) [CommRing k] (n : ℕ) :
+noncomputable def diagonalTorusEquiv (k : Type u) [Semiring k] (n : ℕ) :
     (Fin n → kˣ) ≃* diagonalTorus k n :=
   MonoidHom.ofInjective diagGL_injective
 
@@ -228,20 +203,6 @@ theorem coe_diagonalTorusEquiv_symm_apply (g : diagonalTorus k n) (i : Fin n) :
   conv_rhs => rw [← h, diagGL_coe]
   rw [Matrix.diagonal_apply_eq]
 
-/-- The diagonal torus is commutative: diagonal matrices multiply coordinatewise. -/
-instance instIsMulCommutativeDiagonalTorus : IsMulCommutative (diagonalTorus k n) :=
-  ⟨⟨by
-    rintro ⟨-, t, rfl⟩ ⟨-, s, rfl⟩
-    refine Subtype.ext ?_
-    rw [Subgroup.coe_mul, Subgroup.coe_mul, ← map_mul, ← map_mul, mul_comm]⟩⟩
-
-/-- The determinant of an element of the diagonal torus is the product of its diagonal entries. -/
-theorem det_of_mem_diagonalTorus {g : GL (Fin n) k} (hg : g ∈ diagonalTorus k n) :
-    (Matrix.GeneralLinearGroup.det g : k) = ∏ i, (g : Matrix (Fin n) (Fin n) k) i i := by
-  rw [Matrix.GeneralLinearGroup.val_det_apply,
-    ← (isDiag_of_mem_diagonalTorus hg).diagonal_diag, Matrix.det_diagonal]
-  simp [Matrix.diag]
-
 /-- An element centralizing the diagonal torus commutes, as a matrix, with every diagonal matrix
 of units. -/
 theorem commute_diagonal_of_mem_centralizer {g : GL (Fin n) k}
@@ -253,9 +214,88 @@ theorem commute_diagonal_of_mem_centralizer {g : GL (Fin n) k}
       ((g * diagGL t : GL (Fin n) k) : Matrix (Fin n) (Fin n) k) := congrArg _ hcomm.eq
   rwa [Units.val_mul, Units.val_mul, diagGL_coe] at h
 
+section Subsingleton
+
+variable [Subsingleton kˣ]
+
+/-- Over a ring with only one unit, such as `𝔽₂`, the diagonal torus is trivial. -/
+theorem diagonalTorus_eq_bot : diagonalTorus k n = ⊥ := by
+  refine eq_bot_iff.mpr ?_
+  rintro - ⟨t, rfl⟩
+  rw [Subgroup.mem_bot, Subsingleton.elim t 1, map_one]
+
+/-- Over a ring with only one unit the centralizer of the diagonal torus is the whole group,
+while the torus itself is trivial by `TauCeti.diagonalTorus_eq_bot`.  So the hypothesis
+`Nontrivial kˣ` of `TauCeti.centralizer_diagonalTorus` cannot simply be dropped: the two
+subgroups differ as soon as `GL n k` is nontrivial, as it is over `𝔽₂` for `n ≥ 2`.  For `n ≤ 1`
+the group is trivial and the present theorem says nothing more than `⊤ = ⊥`. -/
+theorem centralizer_diagonalTorus_eq_top :
+    Subgroup.centralizer (diagonalTorus k n : Set (GL (Fin n) k)) = ⊤ := by
+  refine eq_top_iff.mpr fun g _ => Subgroup.mem_centralizer_iff.mpr fun h hh => ?_
+  rw [diagonalTorus_eq_bot, SetLike.mem_coe, Subgroup.mem_bot] at hh
+  rw [hh, one_mul, mul_one]
+
+end Subsingleton
+
+end Semiring
+
+section CommSemiring
+
+variable [CommSemiring k]
+
+/-- The diagonal torus is commutative: diagonal matrices multiply coordinatewise.  This is where
+commutativity of `k` is first needed: `kˣ` is commutative only then. -/
+instance instIsMulCommutativeDiagonalTorus : IsMulCommutative (diagonalTorus k n) :=
+  ⟨⟨by
+    rintro ⟨-, t, rfl⟩ ⟨-, s, rfl⟩
+    refine Subtype.ext ?_
+    rw [Subgroup.coe_mul, Subgroup.coe_mul, ← map_mul, ← map_mul, mul_comm]⟩⟩
+
+end CommSemiring
+
+variable [CommRing k]
+
+/-- The determinant of a diagonal matrix is the product of its diagonal entries. -/
+@[simp]
+theorem det_diagGL (t : Fin n → kˣ) :
+    Matrix.GeneralLinearGroup.det (diagGL t) = ∏ i, t i := by
+  apply Units.ext
+  simp [Matrix.GeneralLinearGroup.val_det_apply, diagGL_coe, Matrix.det_diagonal]
+
+/-- The determinant of an element of the diagonal torus is the product of its diagonal entries. -/
+theorem det_of_mem_diagonalTorus {g : GL (Fin n) k} (hg : g ∈ diagonalTorus k n) :
+    (Matrix.GeneralLinearGroup.det g : k) = ∏ i, (g : Matrix (Fin n) (Fin n) k) i i := by
+  rw [Matrix.GeneralLinearGroup.val_det_apply,
+    ← (isDiag_of_mem_diagonalTorus hg).diagonal_diag, Matrix.det_diagonal]
+  simp [Matrix.diag]
+
 section NoZeroDivisors
 
-variable [NoZeroDivisors k] [Nontrivial kˣ]
+variable [NoZeroDivisors k]
+
+section Diagonal
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+/-- A matrix commuting with a diagonal matrix has vanishing `(i, j)` entry whenever the diagonal
+matrix separates the coordinates `i` and `j`. -/
+theorem apply_eq_zero_of_commute_diagonal {t : ι → k} {g : Matrix ι ι k}
+    (hg : Commute (Matrix.diagonal t) g) {i j : ι} (hij : t i ≠ t j) : g i j = 0 := by
+  have hentry : (Matrix.diagonal t * g) i j = (g * Matrix.diagonal t) i j := by rw [hg.eq]
+  rw [Matrix.diagonal_mul, Matrix.mul_diagonal] at hentry
+  have hzero : g i j * (t i - t j) = 0 := by
+    rw [mul_sub, ← hentry]
+    ring
+  exact (mul_eq_zero.mp hzero).resolve_right (sub_ne_zero.mpr hij)
+
+/-- **A matrix commuting with a diagonal matrix of pairwise distinct entries is diagonal.** -/
+theorem isDiag_of_commute_diagonal {t : ι → k} (ht : Function.Injective t)
+    {g : Matrix ι ι k} (hg : Commute (Matrix.diagonal t) g) : g.IsDiag :=
+  fun _ _ hij => apply_eq_zero_of_commute_diagonal hg (ht.ne hij)
+
+end Diagonal
+
+variable [Nontrivial kˣ]
 
 /-- **The diagonal torus is its own centralizer**, hence a maximal abelian subgroup of `GL n k`. -/
 theorem centralizer_diagonalTorus :
@@ -281,29 +321,6 @@ theorem eq_diagonalTorus_of_le_of_isMulCommutative (H : Subgroup (GL (Fin n) k))
     hle
 
 end NoZeroDivisors
-
-section Subsingleton
-
-variable [Subsingleton kˣ]
-
-/-- Over a ring with only one unit, such as `𝔽₂`, the diagonal torus is trivial. -/
-theorem diagonalTorus_eq_bot : diagonalTorus k n = ⊥ := by
-  refine eq_bot_iff.mpr ?_
-  rintro - ⟨t, rfl⟩
-  rw [Subgroup.mem_bot, Subsingleton.elim t 1, map_one]
-
-/-- Over a ring with only one unit the centralizer of the diagonal torus is the whole group,
-while the torus itself is trivial by `TauCeti.diagonalTorus_eq_bot`.  So the hypothesis
-`Nontrivial kˣ` of `TauCeti.centralizer_diagonalTorus` cannot simply be dropped: the two
-subgroups differ as soon as `GL n k` is nontrivial, as it is over `𝔽₂` for `n ≥ 2`.  For `n ≤ 1`
-the group is trivial and the present theorem says nothing more than `⊤ = ⊥`. -/
-theorem centralizer_diagonalTorus_eq_top :
-    Subgroup.centralizer (diagonalTorus k n : Set (GL (Fin n) k)) = ⊤ := by
-  refine eq_top_iff.mpr fun g _ => Subgroup.mem_centralizer_iff.mpr fun h hh => ?_
-  rw [diagonalTorus_eq_bot, SetLike.mem_coe, Subgroup.mem_bot] at hh
-  rw [hh, one_mul, mul_one]
-
-end Subsingleton
 
 /-- **The order of the diagonal torus**: over a field with `q` elements it has `(q - 1)ⁿ`
 elements, one invertible scalar per diagonal entry.  Over an infinite field both sides vanish. -/

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean
@@ -15,8 +15,8 @@ public import Mathlib.LinearAlgebra.Matrix.IsDiag
 public import Mathlib.GroupTheory.Subgroup.Centralizer
 -- `Nat.card` occurs in the statement of `TauCeti.natCard_diagonalTorus`.
 public import Mathlib.SetTheory.Cardinal.Finite
--- Non-public: the number of units of a field is used only inside the proof of
--- `TauCeti.natCard_diagonalTorus`, so downstream importers do not pay for it.
+-- Non-public: `Nat.card_units`, the number of units of a `GroupWithZero`, is used only inside the
+-- proof of `TauCeti.natCard_diagonalTorus`, so downstream importers do not pay for it.
 import Mathlib.Algebra.GroupWithZero.Units.Fintype
 
 /-!
@@ -37,7 +37,7 @@ the **diagonal torus** of `GL n k`, and what makes it a *maximal* torus is prove
 
 Three descriptions of the same subgroup are given.  It is the range of `diagGL`, so it is
 isomorphic as a group to the coordinatewise units `Fin n → kˣ`
-(`TauCeti.diagonalTorusEquiv`), whence its order `(q - 1)ⁿ` over a field with `q` elements
+(`TauCeti.diagonalTorusEquiv`), whence its order `(q - 1)ⁿ` over a division ring with `q` elements
 (`TauCeti.natCard_diagonalTorus`).  It is cut out inside `GL n k` by a condition on matrix entries:
 an invertible matrix lies in it exactly when it is diagonal (`TauCeti.mem_diagonalTorus_iff`),
 the point being that invertibility upgrades the diagonal entries of a diagonal matrix to units
@@ -46,8 +46,9 @@ the point being that invertibility upgrades the diagonal entries of a diagonal m
 `GL n k` contains it and is commutative.
 
 The embedding, the torus, the equivalence and the membership criterion ask only that `k` be a
-semiring; commutativity of `k` enters with the determinant, and the absence of zero divisors with
-the self-centralization.
+semiring; commutativity of `k` enters with the determinant, the absence of zero divisors with
+the self-centralization, and the order asks for a division ring, where the nonzero elements are
+exactly the units.
 
 Self-centralization is proved under two hypotheses, neither of them idle.  The absence of zero
 divisors is a sufficient hypothesis rather than a necessary one: an off-diagonal entry `g i j` of
@@ -81,7 +82,7 @@ The action of the torus on the coordinate lines of the standard representation i
 * `TauCeti.isDiag_of_commute_diagonal`: a matrix commuting with a diagonal matrix of pairwise
   distinct entries is itself diagonal.
 * `TauCeti.mem_diagonalTorus_iff`: membership in the torus is diagonality of the matrix.
-* `TauCeti.natCard_diagonalTorus`: the torus has `(q - 1)ⁿ` elements over a field with `q`
+* `TauCeti.natCard_diagonalTorus`: the torus has `(q - 1)ⁿ` elements over a division ring with `q`
   elements.
 * `TauCeti.centralizer_diagonalTorus`: the diagonal torus is its own centralizer.
 * `TauCeti.centralizer_diagonalTorus_eq_top`: over a ring with a single unit the centralizer is
@@ -322,9 +323,10 @@ theorem eq_diagonalTorus_of_le_of_isMulCommutative (H : Subgroup (GL (Fin n) k))
 
 end NoZeroDivisors
 
-/-- **The order of the diagonal torus**: over a field with `q` elements it has `(q - 1)ⁿ`
-elements, one invertible scalar per diagonal entry.  Over an infinite field both sides vanish. -/
-theorem natCard_diagonalTorus (k : Type u) [Field k] (n : ℕ) :
+/-- **The order of the diagonal torus**: over a division ring with `q` elements it has `(q - 1)ⁿ`
+elements, one invertible scalar per diagonal entry.  Over an infinite division ring both sides
+vanish. -/
+theorem natCard_diagonalTorus (k : Type u) [DivisionRing k] (n : ℕ) :
     Nat.card (diagonalTorus k n) = (Nat.card k - 1) ^ n := by
   rw [← Nat.card_congr (diagonalTorusEquiv k n).toEquiv, Nat.card_fun, Nat.card_units,
     Nat.card_fin]

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean
@@ -46,16 +46,17 @@ the point being that invertibility upgrades the diagonal entries of a diagonal m
 `GL n k` contains it and is commutative.
 
 The embedding, the torus, the equivalence and the membership criterion ask only that `k` be a
-semiring; commutativity of `k` enters with the determinant, the absence of zero divisors with
-the self-centralization, and the order asks for a division ring, where the nonzero elements are
-exactly the units.
+semiring; commutativity of `k` enters with the self-centralization and with the determinant,
+cancellation by nonzero elements with the self-centralization as well, and the order asks for a
+division ring, where the nonzero elements are exactly the units.
 
-Self-centralization is proved under two hypotheses, neither of them idle.  The absence of zero
-divisors is a sufficient hypothesis rather than a necessary one: an off-diagonal entry `g i j` of
-a centralizing matrix satisfies `g i j * (t i - t j) = 0` for diagonal entries `t i ≠ t j`, and
-`NoZeroDivisors k` is what cancels the second factor — not invertibility of that factor, which it
-need not have (`TauCeti.apply_eq_zero_of_commute_diagonal`).  All the argument asks of the ring is
-that the two units it separates the coordinates with differ by a regular element.  The second
+Self-centralization is proved under two hypotheses, neither of them idle.  Cancellation is a
+sufficient hypothesis rather than a necessary one: an off-diagonal entry `g i j` of a centralizing
+matrix satisfies `g i j * t i = g i j * t j` for diagonal entries `t i ≠ t j`, and
+`IsCancelMulZero k` is what forces that entry to vanish — no subtraction is involved, so a
+commutative semiring suffices, and the two diagonal entries need not differ by a unit
+(`TauCeti.apply_eq_zero_of_commute_diagonal`).  Over a ring, `IsCancelMulZero` is exactly
+`NoZeroDivisors`.  The second
 hypothesis, that the unit group has two distinct elements, is there because a diagonal matrix can
 only separate the coordinate lines it distinguishes; two units already suffice, because only one
 pair of coordinates is separated at a time.  That one cannot simply be dropped, and what happens
@@ -252,27 +253,9 @@ instance instIsMulCommutativeDiagonalTorus : IsMulCommutative (diagonalTorus k n
     refine Subtype.ext ?_
     rw [Subgroup.coe_mul, Subgroup.coe_mul, ← map_mul, ← map_mul, mul_comm]⟩⟩
 
-end CommSemiring
+section IsCancelMulZero
 
-variable [CommRing k]
-
-/-- The determinant of a diagonal matrix is the product of its diagonal entries. -/
-@[simp]
-theorem det_diagGL (t : Fin n → kˣ) :
-    Matrix.GeneralLinearGroup.det (diagGL t) = ∏ i, t i := by
-  apply Units.ext
-  simp [Matrix.GeneralLinearGroup.val_det_apply, diagGL_coe, Matrix.det_diagonal]
-
-/-- The determinant of an element of the diagonal torus is the product of its diagonal entries. -/
-theorem det_of_mem_diagonalTorus {g : GL (Fin n) k} (hg : g ∈ diagonalTorus k n) :
-    (Matrix.GeneralLinearGroup.det g : k) = ∏ i, (g : Matrix (Fin n) (Fin n) k) i i := by
-  rw [Matrix.GeneralLinearGroup.val_det_apply,
-    ← (isDiag_of_mem_diagonalTorus hg).diagonal_diag, Matrix.det_diagonal]
-  simp [Matrix.diag]
-
-section NoZeroDivisors
-
-variable [NoZeroDivisors k]
+variable [IsCancelMulZero k]
 
 section Diagonal
 
@@ -284,10 +267,9 @@ theorem apply_eq_zero_of_commute_diagonal {t : ι → k} {g : Matrix ι ι k}
     (hg : Commute (Matrix.diagonal t) g) {i j : ι} (hij : t i ≠ t j) : g i j = 0 := by
   have hentry : (Matrix.diagonal t * g) i j = (g * Matrix.diagonal t) i j := by rw [hg.eq]
   rw [Matrix.diagonal_mul, Matrix.mul_diagonal] at hentry
-  have hzero : g i j * (t i - t j) = 0 := by
-    rw [mul_sub, ← hentry]
-    ring
-  exact (mul_eq_zero.mp hzero).resolve_right (sub_ne_zero.mpr hij)
+  -- `hentry : t i * g i j = g i j * t j`; cancelling `g i j` on the left would give `t i = t j`.
+  by_contra h
+  exact hij (mul_left_cancel₀ h (by rw [mul_comm (g i j) (t i)]; exact hentry))
 
 /-- **A matrix commuting with a diagonal matrix of pairwise distinct entries is diagonal.** -/
 theorem isDiag_of_commute_diagonal {t : ι → k} (ht : Function.Injective t)
@@ -321,7 +303,25 @@ theorem eq_diagonalTorus_of_le_of_isMulCommutative (H : Subgroup (GL (Fin n) k))
         (Subgroup.centralizer_le (SetLike.coe_subset_coe.mpr hle)))
     hle
 
-end NoZeroDivisors
+end IsCancelMulZero
+
+end CommSemiring
+
+variable [CommRing k]
+
+/-- The determinant of a diagonal matrix is the product of its diagonal entries. -/
+@[simp]
+theorem det_diagGL (t : Fin n → kˣ) :
+    Matrix.GeneralLinearGroup.det (diagGL t) = ∏ i, t i := by
+  apply Units.ext
+  simp [Matrix.GeneralLinearGroup.val_det_apply, diagGL_coe, Matrix.det_diagonal]
+
+/-- The determinant of an element of the diagonal torus is the product of its diagonal entries. -/
+theorem det_of_mem_diagonalTorus {g : GL (Fin n) k} (hg : g ∈ diagonalTorus k n) :
+    (Matrix.GeneralLinearGroup.det g : k) = ∏ i, (g : Matrix (Fin n) (Fin n) k) i i := by
+  rw [Matrix.GeneralLinearGroup.val_det_apply,
+    ← (isDiag_of_mem_diagonalTorus hg).diagonal_diag, Matrix.det_diagonal]
+  simp [Matrix.diag]
 
 /-- **The order of the diagonal torus**: over a division ring with `q` elements it has `(q - 1)ⁿ`
 elements, one invertible scalar per diagonal entry.  Over an infinite division ring both sides

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean
@@ -9,22 +9,84 @@ public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 -- `MulEquiv.piUnits` identifies the units of a product with the product of the units, and is what
 -- makes the diagonal embedding a homomorphism.
 public import Mathlib.Algebra.Group.Pi.Units
+-- `Matrix.IsDiag` occurs in the statements below.
+public import Mathlib.LinearAlgebra.Matrix.IsDiag
+-- `Subgroup.centralizer` occurs in the statements below.
+public import Mathlib.GroupTheory.Subgroup.Centralizer
+-- `Nat.card` occurs in the statement of `TauCeti.natCard_diagonalTorus`.
+public import Mathlib.SetTheory.Cardinal.Finite
+-- Non-public: the number of units of a field is used only inside the proof of
+-- `TauCeti.natCard_diagonalTorus`, so downstream importers do not pay for it.
+import Mathlib.Algebra.GroupWithZero.Units.Fintype
 
 /-!
-# Diagonal elements of the general linear group
+# Diagonal elements of the general linear group, and the diagonal torus
 
 A family of units `t : Fin n → kˣ` is the diagonal of an invertible diagonal matrix, and this
 assignment is a group homomorphism `TauCeti.diagGL : (Fin n → kˣ) →* GL (Fin n) k`. Its entries,
-its determinant and its injectivity are recorded here.
+its determinant and its injectivity are recorded here, together with two facts about diagonal
+matrices proper: invertibility of a diagonal matrix upgrades its diagonal entries to units, and a
+matrix commuting with a diagonal matrix has no entries away from the diagonal wherever that
+diagonal matrix separates two coordinates.
+
+The image of `diagGL` is gathered into a subgroup
+
+`TauCeti.diagonalTorus k n = (TauCeti.diagGL : (Fin n → kˣ) →* GL (Fin n) k).range`,
+
+the **diagonal torus** of `GL n k`, and what makes it a *maximal* torus is proved.
+
+Three descriptions of the same subgroup are given.  It is the range of `diagGL`, so it is
+isomorphic as a group to the coordinatewise units `Fin n → kˣ`
+(`TauCeti.diagonalTorusEquiv`), whence its order `(q - 1)ⁿ` over a field with `q` elements
+(`TauCeti.natCard_diagonalTorus`).  It is cut out inside `GL n k` by a condition on matrix entries:
+an invertible matrix lies in it exactly when it is diagonal (`TauCeti.mem_diagonalTorus_iff`),
+the point being that invertibility upgrades the diagonal entries of a diagonal matrix to units
+(`TauCeti.isUnit_apply_of_isDiag`).  And it is its own centralizer
+(`TauCeti.centralizer_diagonalTorus`), so it is a maximal abelian subgroup: no larger subgroup of
+`GL n k` contains it and is commutative.
+
+Self-centralization is proved under two hypotheses, neither of them idle.  The absence of zero
+divisors is a sufficient hypothesis rather than a necessary one: an off-diagonal entry `g i j` of
+a centralizing matrix satisfies `g i j * (t i - t j) = 0` for diagonal entries `t i ≠ t j`, and
+`NoZeroDivisors k` is what cancels the second factor — not invertibility of that factor, which it
+need not have (`TauCeti.apply_eq_zero_of_commute_diagonal`).  All the argument asks of the ring is
+that the two units it separates the coordinates with differ by a regular element.  The second
+hypothesis, that the unit group has two distinct elements, is there because a diagonal matrix can
+only separate the coordinate lines it distinguishes; two units already suffice, because only one
+pair of coordinates is separated at a time.  That one cannot simply be dropped, and what happens
+without it is recorded here: over a ring with only one unit, such as `𝔽₂`, the torus is trivial
+(`TauCeti.diagonalTorus_eq_bot`) while its centralizer is the whole of `GL n k`
+(`TauCeti.centralizer_diagonalTorus_eq_top`).  These two subgroups differ, so self-centralization
+genuinely fails, exactly when `GL n k` is itself nontrivial — over `𝔽₂` that is the case for
+`n ≥ 2`, while for `n ≤ 1` the whole group is trivial and the conclusion survives for want of
+anything to contradict it.
+
+The action of the torus on the coordinate lines of the standard representation is in
+`TauCeti.RepresentationTheory.ClassicalGroups.Torus`.
 
 ## Main definitions
 
 * `TauCeti.diagGL` embeds a family of units as an invertible diagonal matrix.
+* `TauCeti.diagonalTorus`: the subgroup of invertible diagonal matrices in `GL n k`.
+* `TauCeti.diagonalTorusEquiv`: the identification `(Fin n → kˣ) ≃* diagonalTorus k n`.
+
+## Main statements
+
+* `TauCeti.isUnit_apply_of_isDiag`: the diagonal entries of an invertible diagonal matrix are
+  units.
+* `TauCeti.isDiag_of_commute_diagonal`: a matrix commuting with a diagonal matrix of pairwise
+  distinct entries is itself diagonal.
+* `TauCeti.mem_diagonalTorus_iff`: membership in the torus is diagonality of the matrix.
+* `TauCeti.natCard_diagonalTorus`: the torus has `(q - 1)ⁿ` elements over a field with `q`
+  elements.
+* `TauCeti.centralizer_diagonalTorus`: the diagonal torus is its own centralizer.
+* `TauCeti.centralizer_diagonalTorus_eq_top`: over a ring with a single unit the centralizer is
+  instead the whole group.
 
 ## References
 
 * [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
-  Layer 1.
+  Layers 1 and 3.
 * W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), Lecture 15.
 -/
 
@@ -70,11 +132,184 @@ theorem diagGL_injective : Function.Injective (diagGL (k := k) (n := n)) := by
 
 end Semiring
 
+variable [CommRing k]
+
 /-- The determinant of a diagonal matrix is the product of its diagonal entries. -/
 @[simp]
-theorem det_diagGL [CommRing k] (t : Fin n → kˣ) :
+theorem det_diagGL (t : Fin n → kˣ) :
     Matrix.GeneralLinearGroup.det (diagGL t) = ∏ i, t i := by
   apply Units.ext
   simp [Matrix.GeneralLinearGroup.val_det_apply, diagGL_coe, Matrix.det_diagonal]
+
+section Diagonal
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+/-- The diagonal entries of an invertible diagonal matrix are units, because a diagonal matrix
+is invertible exactly when its diagonal is invertible coordinatewise. -/
+theorem isUnit_apply_of_isDiag {g : GL ι k} (hg : (g : Matrix ι ι k).IsDiag) (i : ι) :
+    IsUnit ((g : Matrix ι ι k) i i) := by
+  have h : IsUnit (Matrix.diagonal (Matrix.diag (g : Matrix ι ι k))) := by
+    rw [hg.diagonal_diag]
+    exact Units.isUnit g
+  exact (Matrix.isUnit_diagonal.mp h).apply i
+
+section NoZeroDivisors
+
+variable [NoZeroDivisors k]
+
+/-- A matrix commuting with a diagonal matrix has vanishing `(i, j)` entry whenever the diagonal
+matrix separates the coordinates `i` and `j`. -/
+theorem apply_eq_zero_of_commute_diagonal {t : ι → k} {g : Matrix ι ι k}
+    (hg : Commute (Matrix.diagonal t) g) {i j : ι} (hij : t i ≠ t j) : g i j = 0 := by
+  have hentry : (Matrix.diagonal t * g) i j = (g * Matrix.diagonal t) i j := by rw [hg.eq]
+  rw [Matrix.diagonal_mul, Matrix.mul_diagonal] at hentry
+  have hzero : g i j * (t i - t j) = 0 := by
+    rw [mul_sub, ← hentry]
+    ring
+  exact (mul_eq_zero.mp hzero).resolve_right (sub_ne_zero.mpr hij)
+
+/-- **A matrix commuting with a diagonal matrix of pairwise distinct entries is diagonal.** -/
+theorem isDiag_of_commute_diagonal {t : ι → k} (ht : Function.Injective t)
+    {g : Matrix ι ι k} (hg : Commute (Matrix.diagonal t) g) : g.IsDiag :=
+  fun _ _ hij => apply_eq_zero_of_commute_diagonal hg (ht.ne hij)
+
+end NoZeroDivisors
+
+end Diagonal
+
+/-- The **diagonal torus** of `GL n k`: the image of the coordinatewise units under `diagGL`. -/
+def diagonalTorus (k : Type u) [CommRing k] (n : ℕ) : Subgroup (GL (Fin n) k) :=
+  MonoidHom.range (diagGL (k := k) (n := n))
+
+/-- Membership in the diagonal torus, read off its definition as a range: an element lies in it
+exactly when it is `diagGL t` for a family of units `t`. -/
+theorem mem_diagonalTorus_iff_exists_diagGL {g : GL (Fin n) k} :
+    g ∈ diagonalTorus k n ↔ ∃ t : Fin n → kˣ, diagGL t = g :=
+  MonoidHom.mem_range
+
+/-- An invertible matrix lies in the diagonal torus exactly when it is a diagonal matrix. -/
+@[simp]
+theorem mem_diagonalTorus_iff {g : GL (Fin n) k} :
+    g ∈ diagonalTorus k n ↔ (g : Matrix (Fin n) (Fin n) k).IsDiag := by
+  constructor
+  · rintro ⟨t, rfl⟩
+    rw [diagGL_coe]
+    exact Matrix.isDiag_diagonal _
+  · intro hg
+    refine ⟨fun i => (isUnit_apply_of_isDiag hg i).unit, Units.ext ?_⟩
+    rw [diagGL_coe]
+    simp only [IsUnit.unit_spec]
+    exact hg.diagonal_diag
+
+/-- The matrix of an element of the diagonal torus is diagonal. -/
+theorem isDiag_of_mem_diagonalTorus {g : GL (Fin n) k} (hg : g ∈ diagonalTorus k n) :
+    (g : Matrix (Fin n) (Fin n) k).IsDiag :=
+  mem_diagonalTorus_iff.mp hg
+
+/-- The diagonal torus is the group of coordinatewise units. -/
+noncomputable def diagonalTorusEquiv (k : Type u) [CommRing k] (n : ℕ) :
+    (Fin n → kˣ) ≃* diagonalTorus k n :=
+  MonoidHom.ofInjective diagGL_injective
+
+/-- The torus element attached to a family of units is `diagGL t`. -/
+@[simp]
+theorem coe_diagonalTorusEquiv_apply (t : Fin n → kˣ) :
+    ((diagonalTorusEquiv k n t : diagonalTorus k n) : GL (Fin n) k) = diagGL t :=
+  MonoidHom.ofInjective_apply diagGL_injective
+
+/-- The `i`-th coordinate character of a torus element is its `(i, i)` matrix entry. -/
+@[simp]
+theorem coe_diagonalTorusEquiv_symm_apply (g : diagonalTorus k n) (i : Fin n) :
+    (((diagonalTorusEquiv k n).symm g i : kˣ) : k) =
+      ((g : GL (Fin n) k) : Matrix (Fin n) (Fin n) k) i i := by
+  have h : diagGL ((diagonalTorusEquiv k n).symm g) = (g : GL (Fin n) k) :=
+    MonoidHom.apply_ofInjective_symm diagGL_injective g
+  conv_rhs => rw [← h, diagGL_coe]
+  rw [Matrix.diagonal_apply_eq]
+
+/-- The diagonal torus is commutative: diagonal matrices multiply coordinatewise. -/
+instance instIsMulCommutativeDiagonalTorus : IsMulCommutative (diagonalTorus k n) :=
+  ⟨⟨by
+    rintro ⟨-, t, rfl⟩ ⟨-, s, rfl⟩
+    refine Subtype.ext ?_
+    rw [Subgroup.coe_mul, Subgroup.coe_mul, ← map_mul, ← map_mul, mul_comm]⟩⟩
+
+/-- The determinant of an element of the diagonal torus is the product of its diagonal entries. -/
+theorem det_of_mem_diagonalTorus {g : GL (Fin n) k} (hg : g ∈ diagonalTorus k n) :
+    (Matrix.GeneralLinearGroup.det g : k) = ∏ i, (g : Matrix (Fin n) (Fin n) k) i i := by
+  rw [Matrix.GeneralLinearGroup.val_det_apply,
+    ← (isDiag_of_mem_diagonalTorus hg).diagonal_diag, Matrix.det_diagonal]
+  simp [Matrix.diag]
+
+/-- An element centralizing the diagonal torus commutes, as a matrix, with every diagonal matrix
+of units. -/
+theorem commute_diagonal_of_mem_centralizer {g : GL (Fin n) k}
+    (hg : g ∈ Subgroup.centralizer (diagonalTorus k n : Set (GL (Fin n) k))) (t : Fin n → kˣ) :
+    Commute (Matrix.diagonal fun i => (t i : k)) (g : Matrix (Fin n) (Fin n) k) := by
+  have hcomm : Commute (diagGL t) g :=
+    Subgroup.mem_centralizer_iff.mp hg _ (MonoidHom.mem_range.mpr ⟨t, rfl⟩)
+  have h : ((diagGL t * g : GL (Fin n) k) : Matrix (Fin n) (Fin n) k) =
+      ((g * diagGL t : GL (Fin n) k) : Matrix (Fin n) (Fin n) k) := congrArg _ hcomm.eq
+  rwa [Units.val_mul, Units.val_mul, diagGL_coe] at h
+
+section NoZeroDivisors
+
+variable [NoZeroDivisors k] [Nontrivial kˣ]
+
+/-- **The diagonal torus is its own centralizer**, hence a maximal abelian subgroup of `GL n k`. -/
+theorem centralizer_diagonalTorus :
+    Subgroup.centralizer (diagonalTorus k n : Set (GL (Fin n) k)) = diagonalTorus k n := by
+  refine le_antisymm (fun g hg => mem_diagonalTorus_iff.mpr fun i j hij => ?_)
+    (Subgroup.le_centralizer _)
+  obtain ⟨u, v, huv⟩ := exists_pair_ne kˣ
+  refine apply_eq_zero_of_commute_diagonal
+    (commute_diagonal_of_mem_centralizer hg fun m => if m = i then u else v) ?_
+  rw [ite_eq_left rfl, ite_eq_right (Ne.symm hij)]
+  exact fun h => huv (Units.ext h)
+
+/-- A commutative subgroup of `GL n k` containing the diagonal torus equals it: this is the
+maximality of the torus among abelian subgroups. -/
+theorem eq_diagonalTorus_of_le_of_isMulCommutative (H : Subgroup (GL (Fin n) k))
+    [IsMulCommutative H] (hle : diagonalTorus k n ≤ H) :
+    H = diagonalTorus k n :=
+  le_antisymm
+    (by
+      rw [← centralizer_diagonalTorus (k := k) (n := n)]
+      exact (Subgroup.le_centralizer (H := H)).trans
+        (Subgroup.centralizer_le (SetLike.coe_subset_coe.mpr hle)))
+    hle
+
+end NoZeroDivisors
+
+section Subsingleton
+
+variable [Subsingleton kˣ]
+
+/-- Over a ring with only one unit, such as `𝔽₂`, the diagonal torus is trivial. -/
+theorem diagonalTorus_eq_bot : diagonalTorus k n = ⊥ := by
+  refine eq_bot_iff.mpr ?_
+  rintro - ⟨t, rfl⟩
+  rw [Subgroup.mem_bot, Subsingleton.elim t 1, map_one]
+
+/-- Over a ring with only one unit the centralizer of the diagonal torus is the whole group,
+while the torus itself is trivial by `TauCeti.diagonalTorus_eq_bot`.  So the hypothesis
+`Nontrivial kˣ` of `TauCeti.centralizer_diagonalTorus` cannot simply be dropped: the two
+subgroups differ as soon as `GL n k` is nontrivial, as it is over `𝔽₂` for `n ≥ 2`.  For `n ≤ 1`
+the group is trivial and the present theorem says nothing more than `⊤ = ⊥`. -/
+theorem centralizer_diagonalTorus_eq_top :
+    Subgroup.centralizer (diagonalTorus k n : Set (GL (Fin n) k)) = ⊤ := by
+  refine eq_top_iff.mpr fun g _ => Subgroup.mem_centralizer_iff.mpr fun h hh => ?_
+  rw [diagonalTorus_eq_bot, SetLike.mem_coe, Subgroup.mem_bot] at hh
+  rw [hh, one_mul, mul_one]
+
+end Subsingleton
+
+/-- **The order of the diagonal torus**: over a field with `q` elements it has `(q - 1)ⁿ`
+elements, one invertible scalar per diagonal entry.  Over an infinite field both sides vanish. -/
+theorem natCard_diagonalTorus (k : Type u) [Field k] (n : ℕ) :
+    Nat.card (diagonalTorus k n) = (Nat.card k - 1) ^ n := by
+  rw [← Nat.card_congr (diagonalTorusEquiv k n).toEquiv, Nat.card_fun, Nat.card_units,
+    Nat.card_fin]
 
 end TauCeti

--- a/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
@@ -9,7 +9,7 @@ public import TauCeti.NumberTheory.HeckeRing.GLn.Basic
 public import TauCeti.NumberTheory.HeckeRing.One
 
 import TauCeti.LinearAlgebra.Matrix.SmithNormalForm
-import TauCeti.RepresentationTheory.ClassicalGroups.Diagonal
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal
 
 /-!
 # Diagonal coset representatives for the `GL_n` Hecke ring

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -10,7 +10,7 @@ public import Mathlib.RingTheory.PowerSeries.Expand
 public import TauCeti.NumberTheory.ModularForms.Basic
 public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 public import TauCeti.NumberTheory.ModularForms.DiamondOperators
-public import TauCeti.RepresentationTheory.ClassicalGroups.Diagonal
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal
 
 /-!
 # The level-raising degeneracy maps `V_d`

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Diagonal.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Diagonal.lean
@@ -6,32 +6,24 @@ module
 
 public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal
-public import Mathlib.LinearAlgebra.Matrix.IsDiag
 
 /-!
 # Diagonal elements in the standard representation
 
 This file describes the action of the invertible diagonal matrices `TauCeti.diagGL t` in the
 standard representation. These elements are the concrete points of the diagonal torus used to
-compute characters and weight spaces.
-
-Two facts about diagonal matrices proper are recorded alongside: invertibility of a diagonal
-matrix upgrades its diagonal entries to units, and a matrix commuting with a diagonal matrix
-has no entries away from the diagonal wherever that diagonal matrix separates two coordinates.
+compute characters and weight spaces; the matrices themselves, and the torus they form, are in
+`TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal`.
 
 ## Main statements
 
 * `TauCeti.stdRep_diagGL_apply_basisFun`: every standard basis vector is an eigenvector of a
   diagonal matrix.
-* `TauCeti.isUnit_apply_of_isDiag`: the diagonal entries of an invertible diagonal matrix are
-  units.
-* `TauCeti.isDiag_of_commute_diagonal`: a matrix commuting with a diagonal matrix of pairwise
-  distinct entries is itself diagonal.
 
 ## References
 
 * [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
-  Layers 1 and 3.
+  Layer 1.
 * W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), Lecture 15.
 -/
 
@@ -63,42 +55,5 @@ theorem stdRep_diagGL_apply_basisFun (t : Fin n → kˣ) (i : Fin n) :
   · subst j
     simp
   · simp [Pi.basisFun_apply, hji]
-
-section Diagonal
-
-variable {ι : Type*} [Fintype ι] [DecidableEq ι]
-
-/-- The diagonal entries of an invertible diagonal matrix are units, because a diagonal matrix
-is invertible exactly when its diagonal is invertible coordinatewise. -/
-theorem isUnit_apply_of_isDiag {g : GL ι k} (hg : (g : Matrix ι ι k).IsDiag) (i : ι) :
-    IsUnit ((g : Matrix ι ι k) i i) := by
-  have h : IsUnit (Matrix.diagonal (Matrix.diag (g : Matrix ι ι k))) := by
-    rw [hg.diagonal_diag]
-    exact Units.isUnit g
-  exact (Matrix.isUnit_diagonal.mp h).apply i
-
-section NoZeroDivisors
-
-variable [NoZeroDivisors k]
-
-/-- A matrix commuting with a diagonal matrix has vanishing `(i, j)` entry whenever the diagonal
-matrix separates the coordinates `i` and `j`. -/
-theorem apply_eq_zero_of_commute_diagonal {t : ι → k} {g : Matrix ι ι k}
-    (hg : Commute (Matrix.diagonal t) g) {i j : ι} (hij : t i ≠ t j) : g i j = 0 := by
-  have hentry : (Matrix.diagonal t * g) i j = (g * Matrix.diagonal t) i j := by rw [hg.eq]
-  rw [Matrix.diagonal_mul, Matrix.mul_diagonal] at hentry
-  have hzero : g i j * (t i - t j) = 0 := by
-    rw [mul_sub, ← hentry]
-    ring
-  exact (mul_eq_zero.mp hzero).resolve_right (sub_ne_zero.mpr hij)
-
-/-- **A matrix commuting with a diagonal matrix of pairwise distinct entries is diagonal.** -/
-theorem isDiag_of_commute_diagonal {t : ι → k} (ht : Function.Injective t)
-    {g : Matrix ι ι k} (hg : Commute (Matrix.diagonal t) g) : g.IsDiag :=
-  fun _ _ hij => apply_eq_zero_of_commute_diagonal hg (ht.ne hij)
-
-end NoZeroDivisors
-
-end Diagonal
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Torus.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Torus.lean
@@ -5,62 +5,25 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.RepresentationTheory.ClassicalGroups.Diagonal
-public import Mathlib.GroupTheory.Subgroup.Centralizer
 
 /-!
-# The diagonal torus of the general linear group
+# The diagonal torus in the standard representation
 
-`TauCeti.diagGL` embeds a family of units `t : Fin n → kˣ` as the invertible diagonal matrix with
-entries `t i`.  This file gathers its image into a subgroup
-
-`TauCeti.diagonalTorus k n = (TauCeti.diagGL : (Fin n → kˣ) →* GL (Fin n) k).range`,
-
-the **diagonal torus** of `GL n k`, and proves what makes it a *maximal* torus.
-
-Three descriptions of the same subgroup are given.  It is the range of `diagGL`, so it is
-isomorphic as a group to the coordinatewise units `Fin n → kˣ`
-(`TauCeti.diagonalTorusEquiv`).  It is cut out inside `GL n k` by a condition on matrix entries:
-an invertible matrix lies in it exactly when it is diagonal (`TauCeti.mem_diagonalTorus_iff`),
-the point being that invertibility upgrades the diagonal entries of a diagonal matrix to units
-(`TauCeti.isUnit_apply_of_isDiag`, from `ClassicalGroups/Diagonal.lean`).  And it is its own
-centralizer
-(`TauCeti.centralizer_diagonalTorus`), so it is a maximal abelian subgroup: no larger subgroup of
-`GL n k` contains it and is commutative.
-
-Self-centralization is proved under two hypotheses, neither of them idle.  The absence of zero
-divisors is a sufficient hypothesis rather than a necessary one: an off-diagonal entry `g i j` of
-a centralizing matrix satisfies `g i j * (t i - t j) = 0` for diagonal entries `t i ≠ t j`, and
-`NoZeroDivisors k` is what cancels the second factor — not invertibility of that factor, which it
-need not have (`TauCeti.apply_eq_zero_of_commute_diagonal`).  All the argument asks of the ring is
-that the two units it separates the coordinates with differ by a regular element.  The second
-hypothesis, that the unit group has two distinct elements, is there because a diagonal matrix can
-only separate the coordinate lines it distinguishes; two units already suffice, because only one
-pair of coordinates is separated at a time.  That one cannot simply be dropped, and what happens
-without it is recorded here: over a ring with only one unit, such as `𝔽₂`, the torus is trivial
-(`TauCeti.diagonalTorus_eq_bot`) while its centralizer is the whole of `GL n k`
-(`TauCeti.centralizer_diagonalTorus_eq_top`).  These two subgroups differ, so self-centralization
-genuinely fails, exactly when `GL n k` is itself nontrivial — over `𝔽₂` that is the case for
-`n ≥ 2`, while for `n ≤ 1` the whole group is trivial and the conclusion survives for want of
-anything to contradict it.
-
-Finally the action of the torus on the coordinate lines `k ∙ eᵢ` of the standard representation
-is recorded: every torus element scales `eᵢ` by its `i`-th diagonal entry
+The **diagonal torus** `TauCeti.diagonalTorus k n` of `GL n k`, the subgroup of invertible
+diagonal matrices, is built in
+`TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal`, where its three descriptions — as the
+range of `TauCeti.diagGL`, by diagonality of the matrix, and as its own centralizer — are proved.
+What is recorded here is its action on the coordinate lines `k ∙ eᵢ` of the standard
+representation: every torus element scales `eᵢ` by its `i`-th diagonal entry
 (`TauCeti.stdRep_apply_basisFun_of_mem_diagonalTorus`), so each line is stable
-(`TauCeti.map_stdRep_span_basisFun`).  Over a general `k` these lines are not yet the *weight
-spaces* of the torus: that identification needs the coordinate characters to be pairwise
-distinct, and it fails outright when the torus is trivial, as it is over `𝔽₂`.
+(`TauCeti.map_stdRep_span_basisFun`).
 
-## Main definitions
-
-* `TauCeti.diagonalTorus`: the subgroup of invertible diagonal matrices in `GL n k`.
-* `TauCeti.diagonalTorusEquiv`: the identification `(Fin n → kˣ) ≃* diagonalTorus k n`.
+Over a general `k` these lines are not yet the *weight spaces* of the torus: that identification
+needs the coordinate characters to be pairwise distinct, and it fails outright when the torus is
+trivial, as it is over `𝔽₂` (`TauCeti.diagonalTorus_eq_bot`).
 
 ## Main statements
 
-* `TauCeti.mem_diagonalTorus_iff`: membership in the torus is diagonality of the matrix.
-* `TauCeti.centralizer_diagonalTorus`: the diagonal torus is its own centralizer.
-* `TauCeti.centralizer_diagonalTorus_eq_top`: over a ring with a single unit the centralizer is
-  instead the whole group.
 * `TauCeti.map_stdRep_span_basisFun`: the coordinate lines of the standard representation are
   stable under the diagonal torus.
 
@@ -81,129 +44,6 @@ namespace TauCeti
 
 variable {k : Type u} [CommRing k] {n : ℕ}
 
-/-- The **diagonal torus** of `GL n k`: the image of the coordinatewise units under `diagGL`. -/
-def diagonalTorus (k : Type u) [CommRing k] (n : ℕ) : Subgroup (GL (Fin n) k) :=
-  MonoidHom.range (diagGL (k := k) (n := n))
-
-/-- An invertible matrix lies in the diagonal torus exactly when it is a diagonal matrix. -/
-@[simp]
-theorem mem_diagonalTorus_iff {g : GL (Fin n) k} :
-    g ∈ diagonalTorus k n ↔ (g : Matrix (Fin n) (Fin n) k).IsDiag := by
-  constructor
-  · rintro ⟨t, rfl⟩
-    rw [diagGL_coe]
-    exact Matrix.isDiag_diagonal _
-  · intro hg
-    refine ⟨fun i => (isUnit_apply_of_isDiag hg i).unit, Units.ext ?_⟩
-    rw [diagGL_coe]
-    simp only [IsUnit.unit_spec]
-    exact hg.diagonal_diag
-
-/-- The matrix of an element of the diagonal torus is diagonal. -/
-theorem isDiag_of_mem_diagonalTorus {g : GL (Fin n) k} (hg : g ∈ diagonalTorus k n) :
-    (g : Matrix (Fin n) (Fin n) k).IsDiag :=
-  mem_diagonalTorus_iff.mp hg
-
-/-- The diagonal torus is the group of coordinatewise units. -/
-noncomputable def diagonalTorusEquiv (k : Type u) [CommRing k] (n : ℕ) :
-    (Fin n → kˣ) ≃* diagonalTorus k n :=
-  MonoidHom.ofInjective diagGL_injective
-
-/-- The torus element attached to a family of units is `diagGL t`. -/
-@[simp]
-theorem coe_diagonalTorusEquiv_apply (t : Fin n → kˣ) :
-    ((diagonalTorusEquiv k n t : diagonalTorus k n) : GL (Fin n) k) = diagGL t :=
-  MonoidHom.ofInjective_apply diagGL_injective
-
-/-- The `i`-th coordinate character of a torus element is its `(i, i)` matrix entry. -/
-@[simp]
-theorem coe_diagonalTorusEquiv_symm_apply (g : diagonalTorus k n) (i : Fin n) :
-    (((diagonalTorusEquiv k n).symm g i : kˣ) : k) =
-      ((g : GL (Fin n) k) : Matrix (Fin n) (Fin n) k) i i := by
-  have h : diagGL ((diagonalTorusEquiv k n).symm g) = (g : GL (Fin n) k) :=
-    MonoidHom.apply_ofInjective_symm diagGL_injective g
-  conv_rhs => rw [← h, diagGL_coe]
-  rw [Matrix.diagonal_apply_eq]
-
-/-- The diagonal torus is commutative: diagonal matrices multiply coordinatewise. -/
-instance instIsMulCommutativeDiagonalTorus : IsMulCommutative (diagonalTorus k n) :=
-  ⟨⟨by
-    rintro ⟨-, t, rfl⟩ ⟨-, s, rfl⟩
-    refine Subtype.ext ?_
-    rw [Subgroup.coe_mul, Subgroup.coe_mul, ← map_mul, ← map_mul, mul_comm]⟩⟩
-
-/-- The determinant of an element of the diagonal torus is the product of its diagonal entries. -/
-theorem det_of_mem_diagonalTorus {g : GL (Fin n) k} (hg : g ∈ diagonalTorus k n) :
-    (Matrix.GeneralLinearGroup.det g : k) = ∏ i, (g : Matrix (Fin n) (Fin n) k) i i := by
-  rw [Matrix.GeneralLinearGroup.val_det_apply,
-    ← (isDiag_of_mem_diagonalTorus hg).diagonal_diag, Matrix.det_diagonal]
-  simp [Matrix.diag]
-
-/-- An element centralizing the diagonal torus commutes, as a matrix, with every diagonal matrix
-of units. -/
-theorem commute_diagonal_of_mem_centralizer {g : GL (Fin n) k}
-    (hg : g ∈ Subgroup.centralizer (diagonalTorus k n : Set (GL (Fin n) k))) (t : Fin n → kˣ) :
-    Commute (Matrix.diagonal fun i => (t i : k)) (g : Matrix (Fin n) (Fin n) k) := by
-  have hcomm : Commute (diagGL t) g :=
-    Subgroup.mem_centralizer_iff.mp hg _ (MonoidHom.mem_range.mpr ⟨t, rfl⟩)
-  have h : ((diagGL t * g : GL (Fin n) k) : Matrix (Fin n) (Fin n) k) =
-      ((g * diagGL t : GL (Fin n) k) : Matrix (Fin n) (Fin n) k) := congrArg _ hcomm.eq
-  rwa [Units.val_mul, Units.val_mul, diagGL_coe] at h
-
-section NoZeroDivisors
-
-variable [NoZeroDivisors k] [Nontrivial kˣ]
-
-/-- **The diagonal torus is its own centralizer**, hence a maximal abelian subgroup of `GL n k`. -/
-theorem centralizer_diagonalTorus :
-    Subgroup.centralizer (diagonalTorus k n : Set (GL (Fin n) k)) = diagonalTorus k n := by
-  refine le_antisymm (fun g hg => mem_diagonalTorus_iff.mpr fun i j hij => ?_)
-    (Subgroup.le_centralizer _)
-  obtain ⟨u, v, huv⟩ := exists_pair_ne kˣ
-  refine apply_eq_zero_of_commute_diagonal
-    (commute_diagonal_of_mem_centralizer hg fun m => if m = i then u else v) ?_
-  rw [ite_eq_left rfl, ite_eq_right (Ne.symm hij)]
-  exact fun h => huv (Units.ext h)
-
-/-- A commutative subgroup of `GL n k` containing the diagonal torus equals it: this is the
-maximality of the torus among abelian subgroups. -/
-theorem eq_diagonalTorus_of_le_of_isMulCommutative (H : Subgroup (GL (Fin n) k))
-    [IsMulCommutative H] (hle : diagonalTorus k n ≤ H) :
-    H = diagonalTorus k n :=
-  le_antisymm
-    (by
-      rw [← centralizer_diagonalTorus (k := k) (n := n)]
-      exact (Subgroup.le_centralizer (H := H)).trans
-        (Subgroup.centralizer_le (SetLike.coe_subset_coe.mpr hle)))
-    hle
-
-end NoZeroDivisors
-
-section Subsingleton
-
-variable [Subsingleton kˣ]
-
-/-- Over a ring with only one unit, such as `𝔽₂`, the diagonal torus is trivial. -/
-theorem diagonalTorus_eq_bot : diagonalTorus k n = ⊥ := by
-  refine eq_bot_iff.mpr ?_
-  rintro - ⟨t, rfl⟩
-  rw [Subgroup.mem_bot, Subsingleton.elim t 1, map_one]
-
-/-- Over a ring with only one unit the centralizer of the diagonal torus is the whole group,
-while the torus itself is trivial by `TauCeti.diagonalTorus_eq_bot`.  So the hypothesis
-`Nontrivial kˣ` of `TauCeti.centralizer_diagonalTorus` cannot simply be dropped: the two
-subgroups differ as soon as `GL n k` is nontrivial, as it is over `𝔽₂` for `n ≥ 2`.  For `n ≤ 1`
-the group is trivial and the present theorem says nothing more than `⊤ = ⊥`. -/
-theorem centralizer_diagonalTorus_eq_top :
-    Subgroup.centralizer (diagonalTorus k n : Set (GL (Fin n) k)) = ⊤ := by
-  refine eq_top_iff.mpr fun g _ => Subgroup.mem_centralizer_iff.mpr fun h hh => ?_
-  rw [diagonalTorus_eq_bot, SetLike.mem_coe, Subgroup.mem_bot] at hh
-  rw [hh, one_mul, mul_one]
-
-end Subsingleton
-
-section StandardRepresentation
-
 /-- An element of the diagonal torus scales the standard basis vector `eᵢ` by its `(i, i)` matrix
 entry, the `i`-th coordinate character of the torus read off `diagGL` through
 `TauCeti.diagonalTorusEquiv`.  This is an eigen-relation rather than an eigenvector statement:
@@ -212,7 +52,7 @@ theorem stdRep_apply_basisFun_of_mem_diagonalTorus {g : GL (Fin n) k}
     (hg : g ∈ diagonalTorus k n) (i : Fin n) :
     stdRep k n g (Pi.basisFun k (Fin n) i) =
       (g : Matrix (Fin n) (Fin n) k) i i • Pi.basisFun k (Fin n) i := by
-  obtain ⟨t, rfl⟩ := MonoidHom.mem_range.mp hg
+  obtain ⟨t, rfl⟩ := mem_diagonalTorus_iff_exists_diagGL.mp hg
   rw [stdRep_diagGL_apply_basisFun, diagGL_coe, Matrix.diagonal_apply_eq]
 
 /-- Each coordinate line of the standard representation is stable under the diagonal torus, a
@@ -223,7 +63,5 @@ theorem map_stdRep_span_basisFun {g : GL (Fin n) k} (hg : g ∈ diagonalTorus k 
   rw [Submodule.map_span, Set.image_singleton, stdRep_apply_basisFun_of_mem_diagonalTorus hg i]
   exact Submodule.span_singleton_smul_eq (isUnit_apply_of_isDiag
     (isDiag_of_mem_diagonalTorus hg) i) _
-
-end StandardRepresentation
 
 end TauCeti


### PR DESCRIPTION
This PR proves that the centralizer of a regular semisimple element of `GL₂(F)` is the maximal torus containing it, and computes its order and the resulting conjugacy class size over a finite field. It advances `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`, Layer 9 ("the representation theory of GL₂(𝔽_q)"), whose first bullet, "**The conjugacy classes (a build target)**", asks for "class representatives, centralizer orders, class sizes" for the four families of classes; the split semisimple and the elliptic families are supplied here.

The engine is `TauCeti.commute_finTwo_iff`, which is new mathematics in its own right: a `2 × 2` matrix over a field is cyclic as soon as it is not scalar, so the matrices commuting with a non-scalar `M` are exactly the affine combinations `a • 1 + b • M`, the two-dimensional algebra `F[M]`. Mathlib has no commutant-of-a-single-matrix result (its `Matrix.mem_range_scalar_iff_commute_transvectionStruct` describes the matrices commuting with *everything*, not with one element), so this is proved from the three independent entry equations of `M * N = N * M`, splitting on which of the two off-diagonal entries or the diagonal difference is nonzero. Two consequences follow: the centralizer of a non-central element of `GL (Fin 2) F` is abelian, and for a regular semisimple element it is a torus. In the split case, an invertible diagonal matrix with distinct diagonal entries has as its centralizer the whole split torus `TauCeti.diagGL` of invertible diagonal matrices, of order `(q - 1)²`, with class size `q (q + 1)`. In the elliptic case, an element of the non-split torus `TauCeti.GL2NonSplitTorus` not coming from `F` has that whole torus as its centralizer, of order `q² - 1`, with class size `q (q - 1)`. The two class sizes are the indices of the two tori, obtained from `Matrix.card_GL_field` and the factorization `|GL₂(𝔽_q)| = (q - 1)² · q · (q + 1)`.

The elliptic half reuses the roadmap's existing vocabulary rather than rebuilding it: `TauCeti.GL2NonSplitTorusHom`, `TauCeti.nonSplitTorusBasis` and `TauCeti.GL2NonSplitTorus.natCard_eq` come from `TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/NonSplitTorus.lean`, and the split half from `TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean`. The class sizes are read off the centralizer orders by orbit-stabilizer, for which the small general lemma `TauCeti.ConjClasses.ncard_carrier_mk` — the size of a conjugacy class is the index of the centralizer of any of its members — is added to the existing `TauCeti/Algebra/Group/Conj.lean`, which already performed that computation inline inside `card_carrier_dvd_card`; that proof is shortened to consume the new lemma. No Mathlib infrastructure was vendored.

The remaining two families of `GL₂(𝔽_q)` classes are out of scope here and are flagged as such in the module docstring: the central classes, whose centralizer is everything, and the non-semisimple classes `!![a, 1; 0, a]`, whose centralizer is again `F[M]ˣ` but for a matrix with a repeated eigenvalue. The count `q² - 1 = #ConjClasses` needs the completeness of the four families and is likewise not claimed.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"gl2-centralizer-orders"}-->

🤖 Prepared with Claude Code
