### PR TITLE
feat: the root spaces of a split pair

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
@@ -120,6 +120,23 @@ variable {X : Type*} [Monoid X]
 variable (V : Type*) [AddCommMonoid V] [Module R V] [Comodule R C V]
 variable {A : Type*} [CommSemiring A] [Algebra R A]
 
+/-- Acting through a composite point agrees on pure tensors with first corestricting the coaction
+along the bialgebra morphism and then applying the point. -/
+theorem endOfPoint_tmul_comp (π : C →ₐc[R] MonoidAlgebra R X)
+    (f : MonoidAlgebra R X →ₐ[R] A) (a : A) (v : V) :
+    Comodule.endOfPoint V (f.comp (π : C →ₐ[R] MonoidAlgebra R X)) (a ⊗ₜ[R] v) =
+      a • TensorProduct.comm R V A
+        (LinearMap.lTensor V f.toLinearMap
+          (TensorProduct.map LinearMap.id (π : C →ₗc[R] MonoidAlgebra R X).toLinearMap
+            (Comodule.coact (R := R) (C := C) (M := V) v))) := by
+  have hπ : (π : C →ₐ[R] MonoidAlgebra R X).toLinearMap =
+      (π : C →ₗc[R] MonoidAlgebra R X).toLinearMap := by
+    rw [CoalgHom.toLinearMap_eq_coe]
+    exact BialgHom.toAlgHom_toLinearMap π
+  rw [Comodule.endOfPoint_tmul, LinearMap.lTensor_def, AlgHom.comp_toLinearMap,
+    hπ, ← LinearMap.id_comp LinearMap.id, TensorProduct.map_comp, LinearMap.comp_apply]
+  rfl
+
 /-- **A point of `D(X)` acts on the `x`-weight submodule by the value of the character `x`.**
 
 The point of `G` in question is the composite of the homomorphism `D(X) → G` with the given point
@@ -129,11 +146,7 @@ theorem endOfPoint_tmul_of_mem_weightSpace (π : C →ₐc[R] MonoidAlgebra R X)
     (hv : v ∈ weightSpace V (π : C →ₗc[R] MonoidAlgebra R X) x) :
     Comodule.endOfPoint V (f.comp (π : C →ₐ[R] MonoidAlgebra R X)) (a ⊗ₜ[R] v) =
       (a * f (MonoidAlgebra.single x (1 : R))) ⊗ₜ[R] v := by
-  have hπ : (π : C →ₐ[R] MonoidAlgebra R X).toLinearMap =
-      (π : C →ₗc[R] MonoidAlgebra R X).toLinearMap := rfl
-  rw [Comodule.endOfPoint_tmul, LinearMap.lTensor_def, AlgHom.comp_toLinearMap,
-    hπ, ← LinearMap.id_comp LinearMap.id, TensorProduct.map_comp, LinearMap.comp_apply,
-    mem_weightSpace.mp hv]
+  rw [endOfPoint_tmul_comp, mem_weightSpace.mp hv]
   simp [TensorProduct.smul_tmul']
 
 end Points

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
+public import TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra
+
+/-!
+# Weights of a representation along a homomorphism from a diagonalizable group
+
+A homomorphism of affine group schemes `D(X) → G` is a morphism `π : H → R[X]` of the coordinate
+bialgebras, and a representation of `G` is a right `H`-comodule `V`. Restricting the
+representation along `π` corestricts the comodule along `π`, and the resulting `R[X]`-comodule
+decomposes into the weight submodules of
+`TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra`. This file names that decomposition:
+
+`TauCeti.DiagonalizableGroup.weightSpace V π x` is the submodule of `V` on which `D(X)` acts
+through the character `x`, and `V` is the internal direct sum of these submodules.
+
+Only the coalgebra structure of `π` enters the decomposition, so the definition and the
+decomposition theorems take a `CoalgHom`. The statement identifying the action of a point of
+`D(X)` as multiplication by the value of the character does use that `π` is a morphism of
+bialgebras, since it speaks about points, and takes a `BialgHom`.
+
+## Main definitions
+
+* `TauCeti.DiagonalizableGroup.weightSpace`: the `x`-weight submodule of a representation of `G`
+  restricted along a homomorphism `D(X) → G`.
+
+## Main results
+
+* `TauCeti.DiagonalizableGroup.isInternal_weightSpace`: **a representation restricted along a
+  homomorphism from a diagonalizable group is the internal direct sum of its weight submodules.**
+* `TauCeti.DiagonalizableGroup.finite_setOf_weightSpace_ne_bot`: a representation that is finitely
+  generated as a module has finitely many weights.
+* `TauCeti.DiagonalizableGroup.endOfPoint_tmul_of_mem_weightSpace`: a point of `D(X)` acts on the
+  `x`-weight submodule by multiplication by the value of the character `x` at that point.
+
+## Roadmap
+
+This is the restriction step that Layer 7 of `TauCetiRoadmap/ReductiveGroups/README.md` asks for
+in its split root-datum target: the roots of a split pair `(G, T)` are the nonzero weights of the
+adjoint representation of `G` restricted along the split torus `T`, and that restriction is what
+this file supplies. `TauCeti/Algebra/AlgebraicGroup/RootSpace.lean` performs the specialization.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §3.2.
+* J. S. Milne, *Algebraic Groups* (2017), §12.c and §21.
+-/
+
+public section
+
+open scoped DirectSum TensorProduct
+
+namespace TauCeti
+
+namespace DiagonalizableGroup
+
+attribute [local instance] Classical.decEq
+
+section Decomposition
+
+variable {R : Type*} [CommSemiring R]
+variable {C : Type*} [AddCommMonoid C] [Module R C] [Coalgebra R C]
+variable {X : Type*}
+variable (V : Type*) [AddCommMonoid V] [Module R V] [Comodule R C V]
+
+/-- The `x`-weight submodule of a right `C`-comodule `V` along a coalgebra morphism
+`π : C →ₗc[R] R[X]`.
+
+Geometrically `π` is the coordinate morphism of a homomorphism `D(X) → G` of affine group schemes
+and `V` is a representation of `G`; this is the submodule on which `D(X)` acts through the
+character `x`. -/
+@[expose] noncomputable def weightSpace (π : C →ₗc[R] MonoidAlgebra R X) (x : X) :
+    Submodule R V :=
+  letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
+  Comodule.weightSpace R X V x
+
+variable {V}
+
+/-- Membership in the `x`-weight submodule, in terms of the coaction of the original comodule:
+pushing the coaction of `v` through `π` must give `v ⊗ x`. -/
+theorem mem_weightSpace {π : C →ₗc[R] MonoidAlgebra R X} {x : X} {v : V} :
+    v ∈ weightSpace V π x ↔
+      TensorProduct.map LinearMap.id π.toLinearMap
+          (Comodule.coact (R := R) (C := C) (M := V) v) =
+        v ⊗ₜ[R] MonoidAlgebra.single x (1 : R) :=
+  letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
+  Comodule.mem_weightSpace
+
+variable (V)
+
+/-- **A representation restricted along a homomorphism from a diagonalizable group is the internal
+direct sum of its weight submodules.** -/
+theorem isInternal_weightSpace (π : C →ₗc[R] MonoidAlgebra R X) :
+    DirectSum.IsInternal (weightSpace V π) :=
+  letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
+  Comodule.isInternal_weightSpace R X V
+
+/-- The weight submodules span the representation. -/
+theorem iSup_weightSpace_eq_top (π : C →ₗc[R] MonoidAlgebra R X) :
+    ⨆ x : X, weightSpace V π x = ⊤ :=
+  letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
+  Comodule.iSup_weightSpace_eq_top R X V
+
+/-- The weight submodules are independent. -/
+theorem iSupIndep_weightSpace (π : C →ₗc[R] MonoidAlgebra R X) :
+    iSupIndep (weightSpace V π) :=
+  letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
+  Comodule.iSupIndep_weightSpace R X V
+
+/-- **A representation that is finitely generated as a module has only finitely many weights.** -/
+theorem finite_setOf_weightSpace_ne_bot [Module.Finite R V] (π : C →ₗc[R] MonoidAlgebra R X) :
+    {x : X | weightSpace V π x ≠ ⊥}.Finite :=
+  letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
+  Comodule.finite_setOf_weightSpace_ne_bot R X V
+
+end Decomposition
+
+section Points
+
+variable {R : Type*} [CommSemiring R]
+variable {C : Type*} [Semiring C] [Bialgebra R C]
+variable {X : Type*} [Monoid X]
+variable (V : Type*) [AddCommMonoid V] [Module R V] [Comodule R C V]
+variable {A : Type*} [CommSemiring A] [Algebra R A]
+
+/-- **A point of `D(X)` acts on the `x`-weight submodule by the value of the character `x`.**
+
+The point of `G` in question is the composite of the homomorphism `D(X) → G` with the given point
+of `D(X)`, whose coordinate morphism is `f ∘ π`. -/
+theorem endOfPoint_tmul_of_mem_weightSpace (π : C →ₐc[R] MonoidAlgebra R X)
+    (f : MonoidAlgebra R X →ₐ[R] A) (a : A) {x : X} {v : V}
+    (hv : v ∈ weightSpace V (π : C →ₗc[R] MonoidAlgebra R X) x) :
+    Comodule.endOfPoint V (f.comp (π : C →ₐ[R] MonoidAlgebra R X)) (a ⊗ₜ[R] v) =
+      (a * f (MonoidAlgebra.single x (1 : R))) ⊗ₜ[R] v := by
+  have hmap : ∀ t : V ⊗[R] C,
+      LinearMap.lTensor V (f.comp (π : C →ₐ[R] MonoidAlgebra R X)).toLinearMap t =
+        LinearMap.lTensor V f.toLinearMap
+          (TensorProduct.map LinearMap.id (π : C →ₗc[R] MonoidAlgebra R X).toLinearMap t) := by
+    intro t
+    induction t using TensorProduct.induction_on with
+    | zero => simp
+    | tmul v' c => simp
+    | add s t hs ht => simp only [map_add, hs, ht]
+  rw [Comodule.endOfPoint_tmul, hmap, mem_weightSpace.mp hv]
+  simp [TensorProduct.smul_tmul']
+
+end Points
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
@@ -134,8 +134,7 @@ theorem endOfPoint_tmul_comp (π : C →ₐc[R] MonoidAlgebra R X)
     exact BialgHom.toAlgHom_toLinearMap π
   rw [Comodule.endOfPoint_tmul]
   congr 2
-  rw [LinearMap.lTensor_map]
-  congr 1
+  rw [LinearMap.lTensor_map, AlgHom.comp_toLinearMap, hπ, LinearMap.lTensor_def]
 
 /-- **A point of `D(X)` acts on the `x`-weight submodule by the value of the character `x`.**
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
@@ -8,33 +8,32 @@ public import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 public import TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra
 
 /-!
-# Weights of a representation along a homomorphism from a diagonalizable group
+# Weight spaces by corestriction to a monoid algebra
 
-A homomorphism of affine group schemes `D(X) → G` is a morphism `π : H → R[X]` of the coordinate
-bialgebras, and a representation of `G` is a right `H`-comodule `V`. Restricting the
-representation along `π` corestricts the comodule along `π`, and the resulting `R[X]`-comodule
-decomposes into the weight submodules of
+Given a right `C`-comodule `V` and a coalgebra morphism `π : C → R[X]`, corestriction along `π`
+makes `V` an `R[X]`-comodule. The resulting comodule decomposes into the weight submodules of
 `TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra`. This file names that decomposition:
 
-`TauCeti.DiagonalizableGroup.weightSpace V π x` is the submodule of `V` on which `D(X)` acts
-through the character `x`, and `V` is the internal direct sum of these submodules.
+`TauCeti.DiagonalizableGroup.weightSpace V π x` is the `x`-weight submodule of the corestricted
+comodule, and `V` is the internal direct sum of these submodules.
 
-Only the coalgebra structure of `π` enters the decomposition, so the definition and the
-decomposition theorems take a `CoalgHom`. The statement identifying the action of a point of
-`D(X)` as multiplication by the value of the character does use that `π` is a morphism of
-bialgebras, since it speaks about points, and takes a `BialgHom`.
+When `C` is the coordinate bialgebra of an affine group scheme `G` and `π` underlies a bialgebra
+morphism, it is the coordinate morphism of a homomorphism `D(X) → G`, and these are the weight
+spaces of a representation restricted along that homomorphism. The statement identifying the
+action of a point of `D(X)` as multiplication by the value of the character therefore takes a
+`BialgHom`.
 
 ## Main definitions
 
-* `TauCeti.DiagonalizableGroup.weightSpace`: the `x`-weight submodule of a representation of `G`
-  restricted along a homomorphism `D(X) → G`.
+* `TauCeti.DiagonalizableGroup.weightSpace`: the `x`-weight submodule after corestricting a
+  comodule along a coalgebra morphism to `R[X]`.
 
 ## Main results
 
-* `TauCeti.DiagonalizableGroup.isInternal_weightSpace`: **a representation restricted along a
-  homomorphism from a diagonalizable group is the internal direct sum of its weight submodules.**
-* `TauCeti.DiagonalizableGroup.finite_setOf_weightSpace_ne_bot`: a representation that is finitely
-  generated as a module has finitely many weights.
+* `TauCeti.DiagonalizableGroup.isInternal_weightSpace`: **the corestricted comodule is the internal
+  direct sum of its weight submodules.**
+* `TauCeti.DiagonalizableGroup.finite_setOf_weightSpace_ne_bot`: a comodule that is finitely
+  generated as a module has finitely many nonzero weight submodules after corestriction.
 * `TauCeti.DiagonalizableGroup.endOfPoint_tmul_of_mem_weightSpace`: a point of `D(X)` acts on the
   `x`-weight submodule by multiplication by the value of the character `x` at that point.
 
@@ -71,12 +70,11 @@ variable {C : Type*} [AddCommMonoid C] [Module R C] [Coalgebra R C]
 variable {X : Type*}
 variable (V : Type*) [AddCommMonoid V] [Module R V] [Comodule R C V]
 
-/-- The `x`-weight submodule of a right `C`-comodule `V` along a coalgebra morphism
-`π : C →ₗc[R] R[X]`.
+/-- The `x`-weight submodule obtained by corestricting a right `C`-comodule `V` along a coalgebra
+morphism `π : C →ₗc[R] R[X]`.
 
-Geometrically `π` is the coordinate morphism of a homomorphism `D(X) → G` of affine group schemes
-and `V` is a representation of `G`; this is the submodule on which `D(X)` acts through the
-character `x`. -/
+If `π` underlies the coordinate-bialgebra morphism of a homomorphism `D(X) → G` and `V` is a
+representation of `G`, this is the submodule on which `D(X)` acts through the character `x`. -/
 noncomputable def weightSpace (π : C →ₗc[R] MonoidAlgebra R X) (x : X) :
     Submodule R V :=
   letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
@@ -97,14 +95,15 @@ theorem mem_weightSpace {π : C →ₗc[R] MonoidAlgebra R X} {x : X} {v : V} :
 
 variable (V)
 
-/-- **A representation restricted along a homomorphism from a diagonalizable group is the internal
-direct sum of its weight submodules.** -/
+/-- **A comodule corestricted along a coalgebra morphism to `R[X]` is the internal direct sum of
+its weight submodules.** -/
 theorem isInternal_weightSpace (π : C →ₗc[R] MonoidAlgebra R X) :
     DirectSum.IsInternal (weightSpace V π) :=
   letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
   Comodule.isInternal_weightSpace R X V
 
-/-- **A representation that is finitely generated as a module has only finitely many weights.** -/
+/-- **A comodule that is finitely generated as a module has only finitely many nonzero weight
+submodules after corestriction.** -/
 theorem finite_setOf_weightSpace_ne_bot [Module.Finite R V] (π : C →ₗc[R] MonoidAlgebra R X) :
     {x : X | weightSpace V π x ≠ ⊥}.Finite :=
   letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
@@ -133,9 +132,10 @@ theorem endOfPoint_tmul_comp (π : C →ₐc[R] MonoidAlgebra R X)
       (π : C →ₗc[R] MonoidAlgebra R X).toLinearMap := by
     rw [CoalgHom.toLinearMap_eq_coe]
     exact BialgHom.toAlgHom_toLinearMap π
-  rw [Comodule.endOfPoint_tmul, LinearMap.lTensor_def, AlgHom.comp_toLinearMap,
-    hπ, ← LinearMap.id_comp LinearMap.id, TensorProduct.map_comp, LinearMap.comp_apply]
-  rfl
+  rw [Comodule.endOfPoint_tmul]
+  congr 2
+  rw [LinearMap.lTensor_map]
+  congr 1
 
 /-- **A point of `D(X)` acts on the `x`-weight submodule by the value of the character `x`.**
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
@@ -86,6 +86,7 @@ variable {V}
 
 /-- Membership in the `x`-weight submodule, in terms of the coaction of the original comodule:
 pushing the coaction of `v` through `π` must give `v ⊗ x`. -/
+@[simp]
 theorem mem_weightSpace {π : C →ₗc[R] MonoidAlgebra R X} {x : X} {v : V} :
     v ∈ weightSpace V π x ↔
       TensorProduct.map LinearMap.id π.toLinearMap
@@ -128,16 +129,11 @@ theorem endOfPoint_tmul_of_mem_weightSpace (π : C →ₐc[R] MonoidAlgebra R X)
     (hv : v ∈ weightSpace V (π : C →ₗc[R] MonoidAlgebra R X) x) :
     Comodule.endOfPoint V (f.comp (π : C →ₐ[R] MonoidAlgebra R X)) (a ⊗ₜ[R] v) =
       (a * f (MonoidAlgebra.single x (1 : R))) ⊗ₜ[R] v := by
-  have hmap : ∀ t : V ⊗[R] C,
-      LinearMap.lTensor V (f.comp (π : C →ₐ[R] MonoidAlgebra R X)).toLinearMap t =
-        LinearMap.lTensor V f.toLinearMap
-          (TensorProduct.map LinearMap.id (π : C →ₗc[R] MonoidAlgebra R X).toLinearMap t) := by
-    intro t
-    induction t using TensorProduct.induction_on with
-    | zero => simp
-    | tmul v' c => simp
-    | add s t hs ht => simp only [map_add, hs, ht]
-  rw [Comodule.endOfPoint_tmul, hmap, mem_weightSpace.mp hv]
+  have hπ : (π : C →ₐ[R] MonoidAlgebra R X).toLinearMap =
+      (π : C →ₗc[R] MonoidAlgebra R X).toLinearMap := rfl
+  rw [Comodule.endOfPoint_tmul, LinearMap.lTensor_def, AlgHom.comp_toLinearMap,
+    hπ, ← LinearMap.id_comp LinearMap.id, TensorProduct.map_comp, LinearMap.comp_apply,
+    mem_weightSpace.mp hv]
   simp [TensorProduct.smul_tmul']
 
 end Points

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
@@ -17,11 +17,11 @@ makes `V` an `R[X]`-comodule. The resulting comodule decomposes into the weight 
 `TauCeti.DiagonalizableGroup.weightSpace V π x` is the `x`-weight submodule of the corestricted
 comodule, and `V` is the internal direct sum of these submodules.
 
-When `C` is the coordinate bialgebra of an affine group scheme `G` and `π` underlies a bialgebra
-morphism, it is the coordinate morphism of a homomorphism `D(X) → G`, and these are the weight
-spaces of a representation restricted along that homomorphism. The statement identifying the
-action of a point of `D(X)` as multiplication by the value of the character therefore takes a
-`BialgHom`.
+When `X` is a commutative group, `C` is the coordinate bialgebra of an affine group scheme `G`,
+and `π` underlies a bialgebra morphism, it is the coordinate morphism of a homomorphism
+`D(X) → G`, and these are the weight spaces of a representation restricted along that
+homomorphism. The statement identifying the action of a point of `D(X)` as multiplication by the
+value of the character therefore takes a `BialgHom`.
 
 ## Main definitions
 
@@ -34,8 +34,9 @@ action of a point of `D(X)` as multiplication by the value of the character ther
   direct sum of its weight submodules.**
 * `TauCeti.DiagonalizableGroup.finite_setOf_weightSpace_ne_bot`: a comodule that is finitely
   generated as a module has finitely many nonzero weight submodules after corestriction.
-* `TauCeti.DiagonalizableGroup.endOfPoint_tmul_of_mem_weightSpace`: a point of `D(X)` acts on the
-  `x`-weight submodule by multiplication by the value of the character `x` at that point.
+* `TauCeti.DiagonalizableGroup.endOfPoint_tmul_of_mem_weightSpace`: a monoid-algebra point acts on
+  the `x`-weight submodule by multiplication by its value on `x`; for a commutative group `X`,
+  this is the corresponding action of a point of `D(X)`.
 
 ## Roadmap
 
@@ -73,8 +74,9 @@ variable (V : Type*) [AddCommMonoid V] [Module R V] [Comodule R C V]
 /-- The `x`-weight submodule obtained by corestricting a right `C`-comodule `V` along a coalgebra
 morphism `π : C →ₗc[R] R[X]`.
 
-If `π` underlies the coordinate-bialgebra morphism of a homomorphism `D(X) → G` and `V` is a
-representation of `G`, this is the submodule on which `D(X)` acts through the character `x`. -/
+If `X` is a commutative group, `π` underlies the coordinate-bialgebra morphism of a homomorphism
+`D(X) → G`, and `V` is a representation of `G`, this is the submodule on which `D(X)` acts
+through the character `x`. -/
 noncomputable def weightSpace (π : C →ₗc[R] MonoidAlgebra R X) (x : X) :
     Submodule R V :=
   letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
@@ -136,10 +138,11 @@ theorem endOfPoint_tmul_comp (π : C →ₐc[R] MonoidAlgebra R X)
   congr 2
   rw [LinearMap.lTensor_map, AlgHom.comp_toLinearMap, hπ, LinearMap.lTensor_def]
 
-/-- **A point of `D(X)` acts on the `x`-weight submodule by the value of the character `x`.**
+/-- **A monoid-algebra point acts on the `x`-weight submodule by its value on `x`.**
 
-The point of `G` in question is the composite of the homomorphism `D(X) → G` with the given point
-of `D(X)`, whose coordinate morphism is `f ∘ π`. -/
+When `X` is a commutative group and the bialgebras are coordinate rings, the point of `G` in
+question is the composite of the homomorphism `D(X) → G` with the given point of `D(X)`, whose
+coordinate morphism is `f ∘ π`. -/
 theorem endOfPoint_tmul_of_mem_weightSpace (π : C →ₐc[R] MonoidAlgebra R X)
     (f : MonoidAlgebra R X →ₐ[R] A) (a : A) {x : X} {v : V}
     (hv : v ∈ weightSpace V (π : C →ₗc[R] MonoidAlgebra R X) x) :

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
@@ -42,8 +42,11 @@ bialgebras, since it speaks about points, and takes a `BialgHom`.
 
 This is the restriction step that Layer 7 of `TauCetiRoadmap/ReductiveGroups/README.md` asks for
 in its split root-datum target: the roots of a split pair `(G, T)` are the nonzero weights of the
-adjoint representation of `G` restricted along the split torus `T`, and that restriction is what
-this file supplies. `TauCeti/Algebra/AlgebraicGroup/RootSpace.lean` performs the specialization.
+adjoint representation of `G` restricted along the split maximal torus `T`. This file supplies
+that restriction for an arbitrary homomorphism from a diagonalizable group, carrying no torus,
+maximality or closed-immersion hypotheses;
+`TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean` performs the specialization to the
+adjoint representation.
 
 ## References
 
@@ -74,7 +77,7 @@ variable (V : Type*) [AddCommMonoid V] [Module R V] [Comodule R C V]
 Geometrically `π` is the coordinate morphism of a homomorphism `D(X) → G` of affine group schemes
 and `V` is a representation of `G`; this is the submodule on which `D(X)` acts through the
 character `x`. -/
-@[expose] noncomputable def weightSpace (π : C →ₗc[R] MonoidAlgebra R X) (x : X) :
+noncomputable def weightSpace (π : C →ₗc[R] MonoidAlgebra R X) (x : X) :
     Submodule R V :=
   letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
   Comodule.weightSpace R X V x
@@ -99,18 +102,6 @@ theorem isInternal_weightSpace (π : C →ₗc[R] MonoidAlgebra R X) :
     DirectSum.IsInternal (weightSpace V π) :=
   letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
   Comodule.isInternal_weightSpace R X V
-
-/-- The weight submodules span the representation. -/
-theorem iSup_weightSpace_eq_top (π : C →ₗc[R] MonoidAlgebra R X) :
-    ⨆ x : X, weightSpace V π x = ⊤ :=
-  letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
-  Comodule.iSup_weightSpace_eq_top R X V
-
-/-- The weight submodules are independent. -/
-theorem iSupIndep_weightSpace (π : C →ₗc[R] MonoidAlgebra R X) :
-    iSupIndep (weightSpace V π) :=
-  letI : Comodule R (MonoidAlgebra R X) V := Comodule.Corestrict (M := V) π
-  Comodule.iSupIndep_weightSpace R X V
 
 /-- **A representation that is finitely generated as a module has only finitely many weights.** -/
 theorem finite_setOf_weightSpace_ne_bot [Module.Finite R V] (π : C →ₗc[R] MonoidAlgebra R X) :

--- a/TauCeti/Algebra/AlgebraicGroup/RootSpace.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootSpace.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Weight
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Representation
+
+/-!
+# Root spaces of a split pair
+
+Let `G = Spec H` be an affine group scheme over `R` whose augmentation cotangent space is finite
+projective, so that its Lie algebra is the single `R`-module
+`Module.Dual R (Bialgebra.CotangentSpace R H)` carrying the adjoint comodule of
+`TauCeti.Algebra.AlgebraicGroup.Tangent.Representation`. A split torus in `G` is a homomorphism
+`T = D(M) → G` of affine group schemes, that is, a morphism `π : H →ₐc[R] R[M]` of coordinate
+bialgebras, where `M` is the character lattice written multiplicatively.
+
+Restricting the adjoint representation along `π` decomposes the Lie algebra into weight
+submodules, indexed by the characters of `T`. This file names them: `adjointWeightSpace π α` is
+`𝔤_α`, `roots π` is the set of nonzero characters with a nonzero weight submodule, and the Lie
+algebra is the direct sum of `𝔤_1` and the `𝔤_α` for `α` a root. A point of `T` acts on `𝔤_α`
+by the value of the character `α`, which is what makes `α` a root rather than a bare index.
+
+Nothing here asserts that `π` is a closed immersion, that `T` is a maximal torus, that `G` is
+reductive, or that `roots π` is a root system; those all need hypotheses this file does not carry.
+What is fixed here is the object those statements will be about.
+
+## Main definitions
+
+* `TauCeti.Derivation.adjointWeightSpace`: the weight submodule `𝔤_α` of the Lie algebra of `G`
+  under a split torus.
+* `TauCeti.Derivation.roots`: the set of roots of the pair, the nonzero characters whose weight
+  submodule is nonzero.
+
+## Main results
+
+* `TauCeti.Derivation.isInternal_adjointWeightSpace`: **the Lie algebra of `G` is the internal
+  direct sum of its weight submodules under a split torus.**
+* `TauCeti.Derivation.sup_iSup_adjointWeightSpace_eq_top`: the zero weight submodule together with
+  the root submodules exhaust the Lie algebra.
+* `TauCeti.Derivation.finite_roots`: **the set of roots is finite.**
+* `TauCeti.Derivation.endOfPoint_tmul_of_mem_adjointWeightSpace`: a point of the torus acts on
+  `𝔤_α` by the value of `α` at that point.
+
+## Roadmap
+
+Layer 7 of `TauCetiRoadmap/ReductiveGroups/README.md` asks for the root datum
+`(X*(T), Φ, X_*(T), Φ^∨)` of a split pair `(G, T)`, taking the split case first. The character and
+cocharacter lattices with their pairing are already in
+`TauCeti.Algebra.AlgebraicGroup.Cocharacter`; this file supplies `Φ`, the remaining piece of the
+root datum that is read off the group rather than the torus. Layer 9's split reductive group
+schemes over `ℤ` take the split maximal torus as part of their data and are defined by conditions
+on exactly this decomposition, and milestone `L0` of `TauCetiRoadmap/CFSGStatement/README.md`
+consumes those pinned Chevalley--Demazure groups.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §21.1 (the roots of a split reductive group).
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §3.2.
+* B. Conrad, *Reductive Group Schemes* (SGA3 exposition), §3.2.
+-/
+
+public section
+
+open scoped DirectSum TensorProduct
+
+namespace TauCeti
+
+namespace Derivation
+
+attribute [local instance] Classical.decEq
+
+variable {R : Type*} {H : Type*} [CommRing R] [CommRing H] [HopfAlgebra R H]
+variable [Module.Finite R (Bialgebra.CotangentSpace R H)]
+variable [Module.Projective R (Bialgebra.CotangentSpace R H)]
+variable {M : Type*} [CommGroup M]
+
+/-- The weight submodule `𝔤_α` of the Lie algebra of `G = Spec H` under the split torus
+`T = D(M) → G` with coordinate morphism `π`: the part of the Lie algebra on which `T` acts through
+the character `α`. -/
+noncomputable def adjointWeightSpace (π : H →ₐc[R] MonoidAlgebra R M) (α : M) :
+    Submodule R (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
+  letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
+    adjointComodule (R := R) (H := H)
+  DiagonalizableGroup.weightSpace (Module.Dual R (Bialgebra.CotangentSpace R H))
+    (π : H →ₗc[R] MonoidAlgebra R M) α
+
+/-- **The Lie algebra of `G` is the internal direct sum of its weight submodules under a split
+torus.** -/
+theorem isInternal_adjointWeightSpace (π : H →ₐc[R] MonoidAlgebra R M) :
+    DirectSum.IsInternal (adjointWeightSpace π) :=
+  letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
+    adjointComodule (R := R) (H := H)
+  DiagonalizableGroup.isInternal_weightSpace (Module.Dual R (Bialgebra.CotangentSpace R H))
+    (π : H →ₗc[R] MonoidAlgebra R M)
+
+/-- The weight submodules span the Lie algebra. -/
+theorem iSup_adjointWeightSpace_eq_top (π : H →ₐc[R] MonoidAlgebra R M) :
+    ⨆ α : M, adjointWeightSpace π α = ⊤ :=
+  letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
+    adjointComodule (R := R) (H := H)
+  DiagonalizableGroup.iSup_weightSpace_eq_top (Module.Dual R (Bialgebra.CotangentSpace R H))
+    (π : H →ₗc[R] MonoidAlgebra R M)
+
+/-- The weight submodules are independent. -/
+theorem iSupIndep_adjointWeightSpace (π : H →ₐc[R] MonoidAlgebra R M) :
+    iSupIndep (adjointWeightSpace π) :=
+  letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
+    adjointComodule (R := R) (H := H)
+  DiagonalizableGroup.iSupIndep_weightSpace (Module.Dual R (Bialgebra.CotangentSpace R H))
+    (π : H →ₗc[R] MonoidAlgebra R M)
+
+/-- The roots of the split pair `(G, T)`: the nontrivial characters of `T` whose weight submodule
+in the Lie algebra of `G` is nonzero. -/
+def roots (π : H →ₐc[R] MonoidAlgebra R M) : Set M :=
+  {α | α ≠ 1 ∧ adjointWeightSpace π α ≠ ⊥}
+
+theorem mem_roots {π : H →ₐc[R] MonoidAlgebra R M} {α : M} :
+    α ∈ roots π ↔ α ≠ 1 ∧ adjointWeightSpace π α ≠ ⊥ :=
+  Iff.rfl
+
+theorem ne_one_of_mem_roots {π : H →ₐc[R] MonoidAlgebra R M} {α : M} (hα : α ∈ roots π) :
+    α ≠ 1 :=
+  hα.1
+
+theorem adjointWeightSpace_ne_bot_of_mem_roots {π : H →ₐc[R] MonoidAlgebra R M} {α : M}
+    (hα : α ∈ roots π) : adjointWeightSpace π α ≠ ⊥ :=
+  hα.2
+
+/-- Off the roots and the trivial character the weight submodule vanishes. -/
+theorem adjointWeightSpace_eq_bot_of_notMem_roots {π : H →ₐc[R] MonoidAlgebra R M} {α : M}
+    (hα : α ≠ 1) (h : α ∉ roots π) : adjointWeightSpace π α = ⊥ := by
+  by_contra hbot
+  exact h ⟨hα, hbot⟩
+
+/-- **The set of roots is finite.** The Lie algebra is finitely generated, so only finitely many
+weight submodules are nonzero. -/
+theorem finite_roots (π : H →ₐc[R] MonoidAlgebra R M) : (roots π).Finite :=
+  letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
+    adjointComodule (R := R) (H := H)
+  Set.Finite.subset
+    (DiagonalizableGroup.finite_setOf_weightSpace_ne_bot
+      (Module.Dual R (Bialgebra.CotangentSpace R H)) (π : H →ₗc[R] MonoidAlgebra R M))
+    fun _ hα => hα.2
+
+/-- **The Lie algebra is spanned by the zero weight submodule together with the root
+submodules.** -/
+theorem sup_iSup_adjointWeightSpace_eq_top (π : H →ₐc[R] MonoidAlgebra R M) :
+    (adjointWeightSpace π 1 ⊔ ⨆ α ∈ roots π, adjointWeightSpace π α) = ⊤ := by
+  refine top_unique ?_
+  rw [← iSup_adjointWeightSpace_eq_top π]
+  refine iSup_le fun α => ?_
+  by_cases hα : α = 1
+  · subst hα
+    exact le_sup_left
+  · by_cases hbot : adjointWeightSpace π α = ⊥
+    · rw [hbot]
+      exact bot_le
+    · exact le_sup_of_le_right (le_iSup₂ (f := fun β (_ : β ∈ roots π) => adjointWeightSpace π β)
+        α ⟨hα, hbot⟩)
+
+/-- **A point of the torus acts on the root submodule `𝔤_α` by the value of the character `α`.**
+This is the property that makes `α` a root of `(G, T)` and not merely an index of the
+decomposition. -/
+theorem endOfPoint_tmul_of_mem_adjointWeightSpace {A : Type*} [CommRing A] [Algebra R A]
+    (π : H →ₐc[R] MonoidAlgebra R M) (f : MonoidAlgebra R M →ₐ[R] A) (a : A) {α : M}
+    {x : Module.Dual R (Bialgebra.CotangentSpace R H)} (hx : x ∈ adjointWeightSpace π α) :
+    letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
+      adjointComodule (R := R) (H := H)
+    Comodule.endOfPoint (Module.Dual R (Bialgebra.CotangentSpace R H))
+        (f.comp (π : H →ₐ[R] MonoidAlgebra R M)) (a ⊗ₜ[R] x) =
+      (a * f (MonoidAlgebra.single α (1 : R))) ⊗ₜ[R] x :=
+  letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
+    adjointComodule (R := R) (H := H)
+  DiagonalizableGroup.endOfPoint_tmul_of_mem_weightSpace
+    (Module.Dual R (Bialgebra.CotangentSpace R H)) π f a hx
+
+end Derivation
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
@@ -19,28 +19,30 @@ diagonalizable group on a commutative group `M` written multiplicatively.
 
 Restricting the adjoint representation along `π` decomposes the Lie algebra into weight
 submodules, indexed by `M`. This file names them: `adjointWeightSpace π α` is the `α`-weight
-submodule `𝔤_α`, `roots π` is the set of nontrivial characters whose weight submodule is nonzero,
-and the Lie algebra is spanned by `𝔤_1` together with the `𝔤_α` for `α ∈ roots π`. A point of
-`D(M)` acts on `𝔤_α` by the value of `α` at that point.
+submodule `𝔤_α`, `nontrivialAdjointWeights π` is the set of nontrivial characters whose weight
+submodule is nonzero, and the Lie algebra is spanned by `𝔤_1` together with the `𝔤_α` for
+`α ∈ nontrivialAdjointWeights π`. A point of `D(M)` acts on `𝔤_α` by the value of `α` at that
+point.
 
 Nothing here asserts that `π` is a closed immersion, that `D(M)` is a torus, let alone a maximal
-one, that `G` is reductive, or that `roots π` is a root system; those all need hypotheses this
-file does not carry. When `π` does exhibit a split maximal torus `T` in a reductive `G`, `roots π`
-is the set of roots of the split pair `(G, T)`; fixing that object is what this file is for.
+one, or that `G` is reductive. When `π` does exhibit a split maximal torus `T` in a reductive `G`,
+`nontrivialAdjointWeights π` is the set of roots of the split pair `(G, T)`.
 
 ## Main definitions
 
 * `TauCeti.Derivation.adjointWeightSpace`: the `α`-weight submodule `𝔤_α` of the Lie algebra of
   `G` under a homomorphism from a diagonalizable group.
-* `TauCeti.Derivation.roots`: the nontrivial characters whose weight submodule is nonzero.
+* `TauCeti.Derivation.nontrivialAdjointWeights`: the nontrivial characters whose adjoint weight
+  submodule is nonzero.
 
 ## Main results
 
 * `TauCeti.Derivation.isInternal_adjointWeightSpace`: **the Lie algebra of `G` is the internal
   direct sum of its weight submodules.**
 * `TauCeti.Derivation.sup_iSup_adjointWeightSpace_eq_top`: the trivial weight submodule together
-  with the submodules indexed by `roots π` exhaust the Lie algebra.
-* `TauCeti.Derivation.finite_roots`: **the set of roots is finite.**
+  with the submodules indexed by `nontrivialAdjointWeights π` exhaust the Lie algebra.
+* `TauCeti.Derivation.finite_nontrivialAdjointWeights`: **the set of nontrivial adjoint weights is
+  finite.**
 * `TauCeti.Derivation.endOfPoint_tmul_of_mem_adjointWeightSpace`: a point of `D(M)` acts on the
   `α`-weight submodule by the value of `α` at that point.
 
@@ -113,34 +115,37 @@ theorem isInternal_adjointWeightSpace (π : H →ₐc[R] MonoidAlgebra R M) :
   DiagonalizableGroup.isInternal_weightSpace (Module.Dual R (Bialgebra.CotangentSpace R H))
     (π : H →ₗc[R] MonoidAlgebra R M)
 
-/-- The nontrivial characters of `D(M)` whose weight submodule in the Lie algebra of `G` is
-nonzero. When `π` exhibits a split maximal torus `T` in a reductive `G` these are the roots of the
-split pair `(G, T)`. -/
-def roots (π : H →ₐc[R] MonoidAlgebra R M) : Set M :=
+/-- The nontrivial characters of `D(M)` whose adjoint weight submodule in the Lie algebra of `G`
+is nonzero. When `π` exhibits a split maximal torus `T` in a reductive `G`, these are the roots of
+the split pair `(G, T)`. -/
+def nontrivialAdjointWeights (π : H →ₐc[R] MonoidAlgebra R M) : Set M :=
   {α | α ≠ 1 ∧ adjointWeightSpace π α ≠ ⊥}
 
 @[simp]
-theorem mem_roots {π : H →ₐc[R] MonoidAlgebra R M} {α : M} :
-    α ∈ roots π ↔ α ≠ 1 ∧ adjointWeightSpace π α ≠ ⊥ :=
+theorem mem_nontrivialAdjointWeights {π : H →ₐc[R] MonoidAlgebra R M} {α : M} :
+    α ∈ nontrivialAdjointWeights π ↔ α ≠ 1 ∧ adjointWeightSpace π α ≠ ⊥ :=
   Iff.rfl
 
-theorem ne_one_of_mem_roots {π : H →ₐc[R] MonoidAlgebra R M} {α : M} (hα : α ∈ roots π) :
-    α ≠ 1 :=
+theorem ne_one_of_mem_nontrivialAdjointWeights {π : H →ₐc[R] MonoidAlgebra R M} {α : M}
+    (hα : α ∈ nontrivialAdjointWeights π) : α ≠ 1 :=
   hα.1
 
-theorem adjointWeightSpace_ne_bot_of_mem_roots {π : H →ₐc[R] MonoidAlgebra R M} {α : M}
-    (hα : α ∈ roots π) : adjointWeightSpace π α ≠ ⊥ :=
+theorem adjointWeightSpace_ne_bot_of_mem_nontrivialAdjointWeights
+    {π : H →ₐc[R] MonoidAlgebra R M} {α : M} (hα : α ∈ nontrivialAdjointWeights π) :
+    adjointWeightSpace π α ≠ ⊥ :=
   hα.2
 
-/-- Off the roots and the trivial character the weight submodule vanishes. -/
-theorem adjointWeightSpace_eq_bot_of_notMem_roots {π : H →ₐc[R] MonoidAlgebra R M} {α : M}
-    (hα : α ≠ 1) (h : α ∉ roots π) : adjointWeightSpace π α = ⊥ := by
+/-- Off the nontrivial adjoint weights and the trivial character the weight submodule vanishes. -/
+theorem adjointWeightSpace_eq_bot_of_notMem_nontrivialAdjointWeights
+    {π : H →ₐc[R] MonoidAlgebra R M} {α : M} (hα : α ≠ 1)
+    (h : α ∉ nontrivialAdjointWeights π) : adjointWeightSpace π α = ⊥ := by
   by_contra hbot
   exact h ⟨hα, hbot⟩
 
-/-- **The set of roots is finite.** The Lie algebra is finitely generated, so only finitely many
-weight submodules are nonzero. -/
-theorem finite_roots (π : H →ₐc[R] MonoidAlgebra R M) : (roots π).Finite :=
+/-- **The set of nontrivial adjoint weights is finite.** The Lie algebra is finitely generated, so
+only finitely many weight submodules are nonzero. -/
+theorem finite_nontrivialAdjointWeights (π : H →ₐc[R] MonoidAlgebra R M) :
+    (nontrivialAdjointWeights π).Finite :=
   letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
     adjointComodule (R := R) (H := H)
   Set.Finite.subset
@@ -149,9 +154,10 @@ theorem finite_roots (π : H →ₐc[R] MonoidAlgebra R M) : (roots π).Finite :
     fun _ hα => hα.2
 
 /-- **The Lie algebra is spanned by the trivial weight submodule together with the submodules
-indexed by the roots.** -/
+indexed by the nontrivial adjoint weights.** -/
 theorem sup_iSup_adjointWeightSpace_eq_top (π : H →ₐc[R] MonoidAlgebra R M) :
-    (adjointWeightSpace π 1 ⊔ ⨆ α ∈ roots π, adjointWeightSpace π α) = ⊤ := by
+    (adjointWeightSpace π 1 ⊔
+      ⨆ α ∈ nontrivialAdjointWeights π, adjointWeightSpace π α) = ⊤ := by
   refine top_unique ?_
   rw [← (isInternal_adjointWeightSpace π).submodule_iSup_eq_top]
   refine iSup_le fun α => ?_
@@ -161,8 +167,9 @@ theorem sup_iSup_adjointWeightSpace_eq_top (π : H →ₐc[R] MonoidAlgebra R M)
   · by_cases hbot : adjointWeightSpace π α = ⊥
     · rw [hbot]
       exact bot_le
-    · exact le_sup_of_le_right (le_iSup₂ (f := fun β (_ : β ∈ roots π) => adjointWeightSpace π β)
-        α ⟨hα, hbot⟩)
+    · exact le_sup_of_le_right
+        (le_iSup₂ (f := fun β (_ : β ∈ nontrivialAdjointWeights π) => adjointWeightSpace π β)
+          α ⟨hα, hbot⟩)
 
 /-- **A point of `D(M)` acts on the `α`-weight submodule `𝔤_α` by the value of the character
 `α` at that point.** -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
@@ -74,11 +74,12 @@ namespace TauCeti
 namespace Derivation
 
 attribute [local instance] Classical.decEq
+attribute [local instance] adjointComodule
 
 variable {R : Type*} {H : Type*} [CommRing R] [CommRing H] [HopfAlgebra R H]
 variable [Module.Finite R (Bialgebra.CotangentSpace R H)]
 variable [Module.Projective R (Bialgebra.CotangentSpace R H)]
-variable {M : Type*} [CommGroup M]
+variable {M : Type*} [Monoid M]
 
 /-- The `α`-weight submodule `𝔤_α` of the Lie algebra of `G = Spec H` under a homomorphism
 `D(M) → G` with coordinate morphism `π`: the part of the Lie algebra on which `D(M)` acts through
@@ -95,8 +96,6 @@ coaction of `x` through `π` must give `x ⊗ α`. -/
 @[simp]
 theorem mem_adjointWeightSpace {π : H →ₐc[R] MonoidAlgebra R M} {α : M}
     {x : Module.Dual R (Bialgebra.CotangentSpace R H)} :
-    letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
-      adjointComodule (R := R) (H := H)
     x ∈ adjointWeightSpace π α ↔
       TensorProduct.map LinearMap.id (π : H →ₗc[R] MonoidAlgebra R M).toLinearMap
           (Comodule.coact (R := R) (C := H)
@@ -125,15 +124,6 @@ def nontrivialAdjointWeights (π : H →ₐc[R] MonoidAlgebra R M) : Set M :=
 theorem mem_nontrivialAdjointWeights {π : H →ₐc[R] MonoidAlgebra R M} {α : M} :
     α ∈ nontrivialAdjointWeights π ↔ α ≠ 1 ∧ adjointWeightSpace π α ≠ ⊥ :=
   Iff.rfl
-
-theorem ne_one_of_mem_nontrivialAdjointWeights {π : H →ₐc[R] MonoidAlgebra R M} {α : M}
-    (hα : α ∈ nontrivialAdjointWeights π) : α ≠ 1 :=
-  hα.1
-
-theorem adjointWeightSpace_ne_bot_of_mem_nontrivialAdjointWeights
-    {π : H →ₐc[R] MonoidAlgebra R M} {α : M} (hα : α ∈ nontrivialAdjointWeights π) :
-    adjointWeightSpace π α ≠ ⊥ :=
-  hα.2
 
 /-- Off the nontrivial adjoint weights and the trivial character the weight submodule vanishes. -/
 theorem adjointWeightSpace_eq_bot_of_notMem_nontrivialAdjointWeights
@@ -176,8 +166,6 @@ theorem sup_iSup_adjointWeightSpace_eq_top (π : H →ₐc[R] MonoidAlgebra R M)
 theorem endOfPoint_tmul_of_mem_adjointWeightSpace {A : Type*} [CommSemiring A] [Algebra R A]
     (π : H →ₐc[R] MonoidAlgebra R M) (f : MonoidAlgebra R M →ₐ[R] A) (a : A) {α : M}
     {x : Module.Dual R (Bialgebra.CotangentSpace R H)} (hx : x ∈ adjointWeightSpace π α) :
-    letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
-      adjointComodule (R := R) (H := H)
     Comodule.endOfPoint (Module.Dual R (Bialgebra.CotangentSpace R H))
         (f.comp (π : H →ₐ[R] MonoidAlgebra R M)) (a ⊗ₜ[R] x) =
       (a * f (MonoidAlgebra.single α (1 : R))) ⊗ₜ[R] x :=

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
@@ -8,49 +8,50 @@ public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Weight
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Representation
 
 /-!
-# Root spaces of a split pair
+# Weight spaces of the adjoint representation
 
 Let `G = Spec H` be an affine group scheme over `R` whose augmentation cotangent space is finite
 projective, so that its Lie algebra is the single `R`-module
 `Module.Dual R (Bialgebra.CotangentSpace R H)` carrying the adjoint comodule of
-`TauCeti.Algebra.AlgebraicGroup.Tangent.Representation`. A split torus in `G` is a homomorphism
-`T = D(M) → G` of affine group schemes, that is, a morphism `π : H →ₐc[R] R[M]` of coordinate
-bialgebras, where `M` is the character lattice written multiplicatively.
+`TauCeti.Algebra.AlgebraicGroup.Tangent.Representation`. Let `π : H →ₐc[R] R[M]` be a morphism of
+coordinate bialgebras, that is, a homomorphism `D(M) → G` of affine group schemes out of the
+diagonalizable group on a commutative group `M` written multiplicatively.
 
 Restricting the adjoint representation along `π` decomposes the Lie algebra into weight
-submodules, indexed by the characters of `T`. This file names them: `adjointWeightSpace π α` is
-`𝔤_α`, `roots π` is the set of nonzero characters with a nonzero weight submodule, and the Lie
-algebra is the direct sum of `𝔤_1` and the `𝔤_α` for `α` a root. A point of `T` acts on `𝔤_α`
-by the value of the character `α`, which is what makes `α` a root rather than a bare index.
+submodules, indexed by `M`. This file names them: `adjointWeightSpace π α` is the `α`-weight
+submodule `𝔤_α`, `roots π` is the set of nontrivial characters whose weight submodule is nonzero,
+and the Lie algebra is spanned by `𝔤_1` together with the `𝔤_α` for `α ∈ roots π`. A point of
+`D(M)` acts on `𝔤_α` by the value of `α` at that point.
 
-Nothing here asserts that `π` is a closed immersion, that `T` is a maximal torus, that `G` is
-reductive, or that `roots π` is a root system; those all need hypotheses this file does not carry.
-What is fixed here is the object those statements will be about.
+Nothing here asserts that `π` is a closed immersion, that `D(M)` is a torus, let alone a maximal
+one, that `G` is reductive, or that `roots π` is a root system; those all need hypotheses this
+file does not carry. When `π` does exhibit a split maximal torus `T` in a reductive `G`, `roots π`
+is the set of roots of the split pair `(G, T)`; fixing that object is what this file is for.
 
 ## Main definitions
 
-* `TauCeti.Derivation.adjointWeightSpace`: the weight submodule `𝔤_α` of the Lie algebra of `G`
-  under a split torus.
-* `TauCeti.Derivation.roots`: the set of roots of the pair, the nonzero characters whose weight
-  submodule is nonzero.
+* `TauCeti.Derivation.adjointWeightSpace`: the `α`-weight submodule `𝔤_α` of the Lie algebra of
+  `G` under a homomorphism from a diagonalizable group.
+* `TauCeti.Derivation.roots`: the nontrivial characters whose weight submodule is nonzero.
 
 ## Main results
 
 * `TauCeti.Derivation.isInternal_adjointWeightSpace`: **the Lie algebra of `G` is the internal
-  direct sum of its weight submodules under a split torus.**
-* `TauCeti.Derivation.sup_iSup_adjointWeightSpace_eq_top`: the zero weight submodule together with
-  the root submodules exhaust the Lie algebra.
+  direct sum of its weight submodules.**
+* `TauCeti.Derivation.sup_iSup_adjointWeightSpace_eq_top`: the trivial weight submodule together
+  with the submodules indexed by `roots π` exhaust the Lie algebra.
 * `TauCeti.Derivation.finite_roots`: **the set of roots is finite.**
-* `TauCeti.Derivation.endOfPoint_tmul_of_mem_adjointWeightSpace`: a point of the torus acts on
-  `𝔤_α` by the value of `α` at that point.
+* `TauCeti.Derivation.endOfPoint_tmul_of_mem_adjointWeightSpace`: a point of `D(M)` acts on the
+  `α`-weight submodule by the value of `α` at that point.
 
 ## Roadmap
 
 Layer 7 of `TauCetiRoadmap/ReductiveGroups/README.md` asks for the root datum
 `(X*(T), Φ, X_*(T), Φ^∨)` of a split pair `(G, T)`, taking the split case first. The character and
 cocharacter lattices with their pairing are already in
-`TauCeti.Algebra.AlgebraicGroup.Cocharacter`; this file supplies `Φ`, the remaining piece of the
-root datum that is read off the group rather than the torus. Layer 9's split reductive group
+`TauCeti.Algebra.AlgebraicGroup.Cocharacter`; this file supplies the weight decomposition that
+`Φ` is read off, the remaining piece of the root datum that comes from the group rather than the
+torus. Layer 9's split reductive group
 schemes over `ℤ` take the split maximal torus as part of their data and are defined by conditions
 on exactly this decomposition, and milestone `L0` of `TauCetiRoadmap/CFSGStatement/README.md`
 consumes those pinned Chevalley--Demazure groups.
@@ -77,8 +78,8 @@ variable [Module.Finite R (Bialgebra.CotangentSpace R H)]
 variable [Module.Projective R (Bialgebra.CotangentSpace R H)]
 variable {M : Type*} [CommGroup M]
 
-/-- The weight submodule `𝔤_α` of the Lie algebra of `G = Spec H` under the split torus
-`T = D(M) → G` with coordinate morphism `π`: the part of the Lie algebra on which `T` acts through
+/-- The `α`-weight submodule `𝔤_α` of the Lie algebra of `G = Spec H` under a homomorphism
+`D(M) → G` with coordinate morphism `π`: the part of the Lie algebra on which `D(M)` acts through
 the character `α`. -/
 noncomputable def adjointWeightSpace (π : H →ₐc[R] MonoidAlgebra R M) (α : M) :
     Submodule R (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
@@ -87,8 +88,24 @@ noncomputable def adjointWeightSpace (π : H →ₐc[R] MonoidAlgebra R M) (α :
   DiagonalizableGroup.weightSpace (Module.Dual R (Bialgebra.CotangentSpace R H))
     (π : H →ₗc[R] MonoidAlgebra R M) α
 
-/-- **The Lie algebra of `G` is the internal direct sum of its weight submodules under a split
-torus.** -/
+/-- Membership in the `α`-weight submodule, in terms of the adjoint coaction: pushing the adjoint
+coaction of `x` through `π` must give `x ⊗ α`. -/
+@[simp]
+theorem mem_adjointWeightSpace {π : H →ₐc[R] MonoidAlgebra R M} {α : M}
+    {x : Module.Dual R (Bialgebra.CotangentSpace R H)} :
+    letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
+      adjointComodule (R := R) (H := H)
+    x ∈ adjointWeightSpace π α ↔
+      TensorProduct.map LinearMap.id (π : H →ₗc[R] MonoidAlgebra R M).toLinearMap
+          (Comodule.coact (R := R) (C := H)
+            (M := Module.Dual R (Bialgebra.CotangentSpace R H)) x) =
+        x ⊗ₜ[R] MonoidAlgebra.single α (1 : R) :=
+  letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
+    adjointComodule (R := R) (H := H)
+  DiagonalizableGroup.mem_weightSpace
+
+/-- **The Lie algebra of `G` is the internal direct sum of its weight submodules under a
+homomorphism from a diagonalizable group.** -/
 theorem isInternal_adjointWeightSpace (π : H →ₐc[R] MonoidAlgebra R M) :
     DirectSum.IsInternal (adjointWeightSpace π) :=
   letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
@@ -96,27 +113,13 @@ theorem isInternal_adjointWeightSpace (π : H →ₐc[R] MonoidAlgebra R M) :
   DiagonalizableGroup.isInternal_weightSpace (Module.Dual R (Bialgebra.CotangentSpace R H))
     (π : H →ₗc[R] MonoidAlgebra R M)
 
-/-- The weight submodules span the Lie algebra. -/
-theorem iSup_adjointWeightSpace_eq_top (π : H →ₐc[R] MonoidAlgebra R M) :
-    ⨆ α : M, adjointWeightSpace π α = ⊤ :=
-  letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
-    adjointComodule (R := R) (H := H)
-  DiagonalizableGroup.iSup_weightSpace_eq_top (Module.Dual R (Bialgebra.CotangentSpace R H))
-    (π : H →ₗc[R] MonoidAlgebra R M)
-
-/-- The weight submodules are independent. -/
-theorem iSupIndep_adjointWeightSpace (π : H →ₐc[R] MonoidAlgebra R M) :
-    iSupIndep (adjointWeightSpace π) :=
-  letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=
-    adjointComodule (R := R) (H := H)
-  DiagonalizableGroup.iSupIndep_weightSpace (Module.Dual R (Bialgebra.CotangentSpace R H))
-    (π : H →ₗc[R] MonoidAlgebra R M)
-
-/-- The roots of the split pair `(G, T)`: the nontrivial characters of `T` whose weight submodule
-in the Lie algebra of `G` is nonzero. -/
+/-- The nontrivial characters of `D(M)` whose weight submodule in the Lie algebra of `G` is
+nonzero. When `π` exhibits a split maximal torus `T` in a reductive `G` these are the roots of the
+split pair `(G, T)`. -/
 def roots (π : H →ₐc[R] MonoidAlgebra R M) : Set M :=
   {α | α ≠ 1 ∧ adjointWeightSpace π α ≠ ⊥}
 
+@[simp]
 theorem mem_roots {π : H →ₐc[R] MonoidAlgebra R M} {α : M} :
     α ∈ roots π ↔ α ≠ 1 ∧ adjointWeightSpace π α ≠ ⊥ :=
   Iff.rfl
@@ -145,12 +148,12 @@ theorem finite_roots (π : H →ₐc[R] MonoidAlgebra R M) : (roots π).Finite :
       (Module.Dual R (Bialgebra.CotangentSpace R H)) (π : H →ₗc[R] MonoidAlgebra R M))
     fun _ hα => hα.2
 
-/-- **The Lie algebra is spanned by the zero weight submodule together with the root
-submodules.** -/
+/-- **The Lie algebra is spanned by the trivial weight submodule together with the submodules
+indexed by the roots.** -/
 theorem sup_iSup_adjointWeightSpace_eq_top (π : H →ₐc[R] MonoidAlgebra R M) :
     (adjointWeightSpace π 1 ⊔ ⨆ α ∈ roots π, adjointWeightSpace π α) = ⊤ := by
   refine top_unique ?_
-  rw [← iSup_adjointWeightSpace_eq_top π]
+  rw [← (isInternal_adjointWeightSpace π).submodule_iSup_eq_top]
   refine iSup_le fun α => ?_
   by_cases hα : α = 1
   · subst hα
@@ -161,10 +164,9 @@ theorem sup_iSup_adjointWeightSpace_eq_top (π : H →ₐc[R] MonoidAlgebra R M)
     · exact le_sup_of_le_right (le_iSup₂ (f := fun β (_ : β ∈ roots π) => adjointWeightSpace π β)
         α ⟨hα, hbot⟩)
 
-/-- **A point of the torus acts on the root submodule `𝔤_α` by the value of the character `α`.**
-This is the property that makes `α` a root of `(G, T)` and not merely an index of the
-decomposition. -/
-theorem endOfPoint_tmul_of_mem_adjointWeightSpace {A : Type*} [CommRing A] [Algebra R A]
+/-- **A point of `D(M)` acts on the `α`-weight submodule `𝔤_α` by the value of the character
+`α` at that point.** -/
+theorem endOfPoint_tmul_of_mem_adjointWeightSpace {A : Type*} [CommSemiring A] [Algebra R A]
     (π : H →ₐc[R] MonoidAlgebra R M) (f : MonoidAlgebra R M →ₐ[R] A) (a : A) {α : M}
     {x : Module.Dual R (Bialgebra.CotangentSpace R H)} (hx : x ∈ adjointWeightSpace π α) :
     letI : Comodule R H (Module.Dual R (Bialgebra.CotangentSpace R H)) :=

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
@@ -79,7 +79,7 @@ attribute [local instance] adjointComodule
 variable {R : Type*} {H : Type*} [CommRing R] [CommRing H] [HopfAlgebra R H]
 variable [Module.Finite R (Bialgebra.CotangentSpace R H)]
 variable [Module.Projective R (Bialgebra.CotangentSpace R H)]
-variable {M : Type*} [Monoid M]
+variable {M : Type*} [CommGroup M]
 
 /-- The `α`-weight submodule `𝔤_α` of the Lie algebra of `G = Spec H` under a homomorphism
 `D(M) → G` with coordinate morphism `π`: the part of the Lie algebra on which `D(M)` acts through

--- a/TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra.lean
@@ -53,6 +53,12 @@ spanning and the independence half of the decomposition.
   direct sum of its weight submodules.**
 * `TauCeti.Comodule.endOfPoint_tmul_of_mem_weightSpace`: an algebra map out of `R[G]` acts on the
   `g`-weight submodule by multiplication by its value at the group-like element `single g 1`.
+* `TauCeti.Comodule.Hom.map_mem_weightSpace`: a comodule morphism preserves the weight
+  submodules.
+* `TauCeti.Comodule.range_weightProj`: the `g`-weight submodule is the range of the `g`-weight
+  projection.
+* `TauCeti.Comodule.finite_setOf_weightSpace_ne_bot`: **a comodule finitely generated as a module
+  has only finitely many weights.**
 
 ## Implementation notes
 
@@ -478,6 +484,66 @@ theorem weightSubcomodule_toSubmodule (g : G) :
 theorem mem_weightSubcomodule {g : G} {v : V} :
     v ∈ weightSubcomodule R G V g ↔ v ∈ weightSpace R G V g :=
   (Iff.rfl)
+
+/-! ### Functoriality and finiteness -/
+
+variable {W : Type*} [AddCommMonoid W] [Module R W] [Comodule R (MonoidAlgebra R G) W]
+
+namespace Hom
+
+/-- A morphism of comodules over `R[G]` sends the `g`-weight submodule into the `g`-weight
+submodule. -/
+theorem map_mem_weightSpace (f : Hom R (MonoidAlgebra R G) V W) {g : G} {v : V}
+    (hv : v ∈ weightSpace R G V g) : f v ∈ weightSpace R G W g := by
+  rw [mem_weightSpace] at hv ⊢
+  rw [← Hom.map_coact_apply f v, hv, TensorProduct.map_tmul]
+  rfl
+
+/-- A morphism of comodules over `R[G]` maps the `g`-weight submodule into the `g`-weight
+submodule. -/
+theorem map_weightSpace_le (f : Hom R (MonoidAlgebra R G) V W) (g : G) :
+    (weightSpace R G V g).map f.toLinearMap ≤ weightSpace R G W g := by
+  rintro _ ⟨v, hv, rfl⟩
+  exact f.map_mem_weightSpace hv
+
+end Hom
+
+variable (R G V)
+
+/-- The `g`-weight submodule is the range of the `g`-weight projection: the projection is
+idempotent with image the submodule it projects onto. -/
+theorem range_weightProj (g : G) :
+    LinearMap.range (weightProj R G V g) = weightSpace R G V g := by
+  refine le_antisymm ?_ fun v hv => ⟨v, weightProj_of_mem hv⟩
+  rintro _ ⟨v, rfl⟩
+  exact weightProj_mem_weightSpace g v
+
+/-- **A comodule over `R[G]` that is finitely generated as a module has only finitely many
+weights.** Each weight submodule is the image of a weight projection, and a projection whose
+index misses the finitely many weights of every generator kills the whole comodule.
+
+For a representation of the diagonalizable group `D(G)` this is the finiteness of its set of
+weights, and for the adjoint representation of an affine group scheme under a split torus it is
+the finiteness of the set of roots. -/
+theorem finite_setOf_weightSpace_ne_bot [Module.Finite R V] :
+    {g : G | weightSpace R G V g ≠ ⊥}.Finite := by
+  classical
+  obtain ⟨S, hS⟩ := Module.Finite.fg_top (R := R) (M := V)
+  refine Set.Finite.subset
+    (S.biUnion fun v => (weightDecomposition R G V v).support).finite_toSet fun g hg => ?_
+  by_contra hgS
+  refine hg (le_antisymm ?_ bot_le)
+  have hgS' : g ∉ S.biUnion fun v => (weightDecomposition R G V v).support := by
+    simpa using hgS
+  rw [Finset.mem_biUnion] at hgS'
+  push Not at hgS'
+  rw [← range_weightProj R G V g, LinearMap.range_eq_map, ← hS, Submodule.map_span,
+    Submodule.span_le]
+  rintro _ ⟨v, hv, rfl⟩
+  have : weightDecomposition R G V v g = 0 :=
+    Finsupp.notMem_support_iff.mp (hgS' v (Finset.mem_coe.mp hv))
+  rw [weightDecomposition_apply] at this
+  simp [this]
 
 end WeightSpace
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra.lean
@@ -512,6 +512,7 @@ variable (R G V)
 
 /-- The `g`-weight submodule is the range of the `g`-weight projection: the projection is
 idempotent with image the submodule it projects onto. -/
+@[simp]
 theorem range_weightProj (g : G) :
     LinearMap.range (weightProj R G V g) = weightSpace R G V g := by
   refine le_antisymm ?_ fun v hv => ⟨v, weightProj_of_mem hv⟩
@@ -519,8 +520,7 @@ theorem range_weightProj (g : G) :
   exact weightProj_mem_weightSpace g v
 
 /-- **A comodule over `R[G]` that is finitely generated as a module has only finitely many
-weights.** Each weight submodule is the image of a weight projection, and a projection whose
-index misses the finitely many weights of every generator kills the whole comodule.
+weights.**
 
 For a representation of the diagonalizable group `D(G)` this is the finiteness of its set of
 weights, and for the adjoint representation of an affine group scheme under a split torus it is


### PR DESCRIPTION
This PR defines the root spaces and the set of roots of a split pair `(G, T)`. Restricting a representation of an affine group scheme `G = Spec H` along a homomorphism `D(X) → G` from a diagonalizable group — a morphism `π : H →ₐc[R] R[X]` of coordinate bialgebras — decomposes the representation into weight submodules indexed by the characters `x : X`, and `TauCeti.DiagonalizableGroup.weightSpace V π x` names that submodule. Specializing to the adjoint representation of `G` on its Lie algebra `Module.Dual R (Bialgebra.CotangentSpace R H)` gives `TauCeti.Derivation.adjointWeightSpace π α`, the space `𝔤_α`, and `TauCeti.Derivation.roots π`, the nontrivial characters whose weight submodule is nonzero. The Lie algebra is the internal direct sum of these submodules (`isInternal_adjointWeightSpace`), the zero weight submodule and the root submodules already exhaust it (`sup_iSup_adjointWeightSpace_eq_top`), the set of roots is finite (`finite_roots`), and a point of `T` acts on `𝔤_α` by the value of the character `α` (`endOfPoint_tmul_of_mem_adjointWeightSpace`), which is what makes `α` a root of the pair rather than a bare index of a decomposition. Nothing here asserts that `π` is a closed immersion, that `T` is maximal, that `G` is reductive, or that `roots π` is a root system; those need hypotheses this PR does not carry, and it fixes the object those statements will be about.

The exact target is Layer 7 of `TauCetiRoadmap/ReductiveGroups/README.md`: "**Root datum** `(X*(T), Φ, X_*(T), Φ^∨)` of `(G, T)` with its **Weyl group**: do the **split** case first (split maximal torus, or work over `k̄`)". The character and cocharacter lattices with their pairing are already on `main` (`TauCeti.DiagonalizableGroup.pairing`, from the Layer 4 tori item); `Φ` is the remaining constituent, and it is the one read off the group rather than off the torus. The milestone this serves in the designated roadmap is `L0` of `TauCetiRoadmap/CFSGStatement/README.md`, "pinned ambient groups", which is sent by its own README to Layer 9 of `ReductiveGroups`; the first item of that layer is "**Split reductive group schemes over a base**, at least over `ℤ`: the definition, with the split maximal torus as part of the data rather than an existence statement", and the definition of a split reductive group scheme is a condition on exactly the weight decomposition of `Lie G` under `T` that this PR constructs. After this PR, Layer 9 still owes that definition and the pinning built on it, the Chevalley–Demazure construction itself, base change along `ℤ → k`, the root subgroup maps `x_α`, the isomorphism theorem for pinned groups, and the special isogenies in characteristics two and three; `L0` waits on all of those.

I followed that declared dependency because `CFSGStatement` has no unclaimed local step. `I0` and the numbered conventions are merged (`Index.lean`, `GraphTwisted.lean`, `SuzukiRee.lean`, `Closure.lean`, including the Cartan-matrix automorphism proofs of the diagram permutations and the Suzuki–Ree length conventions); `L1` to `L4` and `A0` all wait on `L0`; and of the `S1` sporadic rows, twenty-five are on `main` and the last, `Fi24′`, is in flight in #2902. Within `ReductiveGroups`, #2969 and #2676 have taken the two halves of the Layer 9 "points over an algebraically closed field" item, the Lie-algebra route to the Chevalley–Demazure carrier is in flight in #2949, #2940 and #2948, and #2894, #2964, #2943 and #2977 hold the unipotence, Jordan-decomposition and identity-component frontier items. The split root decomposition is not covered by any of them and stands on current `main`.

The mathematics reuses rather than reproves. `TauCeti.Comodule.Corestrict` already turns an `H`-comodule into an `R[X]`-comodule along a coalgebra morphism, and `TauCeti.Comodule.isInternal_weightSpace` already decomposes a comodule over a monoid algebra into its weight submodules, so the decomposition theorems here are the composite of those two, and only the coalgebra structure of `π` enters them. The point-action statement does use that `π` is a morphism of bialgebras, since it speaks about points, and takes a `BialgHom`. Three general facts about the weight decomposition were missing and are added to `TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra.lean`, where the rest of that theory lives: `Hom.map_mem_weightSpace` and `Hom.map_weightSpace_le`, that a comodule morphism preserves weight submodules; `range_weightProj`, that the weight submodule is the range of the weight projection; and `finite_setOf_weightSpace_ne_bot`, that a comodule finitely generated as a module has only finitely many weights, which is what makes the set of roots finite. That last one is the only substantive new argument: the weight submodule is the image of the weight projection, so a projection whose index misses the finitely many weights of each of finitely many generators kills the whole comodule. Grepping the pinned Mathlib found no comodules at all, so none of this is available upstream; `Module.dual_finite` supplies the finite generation of the Lie algebra from the finite projectivity of the cotangent space, and no Mathlib infrastructure is vendored.

`TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean` (156 lines) carries the restriction along a diagonalizable subgroup, next to the rest of the diagonalizable-group theory, and `TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean` carries the specialization to the adjoint representation, in the namespace `TauCeti.Derivation` and next to the `adjointComodule` it specializes. The only existing file touched is `MonoidAlgebra.lean`, which gains 66 lines and no renames, moves or removals. The references are Milne, *Algebraic Groups* (2017), §21.1, Waterhouse, *Introduction to Affine Group Schemes*, §3.2, and Conrad, *Reductive Group Schemes*, §3.2.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

Dependency edge: `CFSGStatement` milestone `L0` defines `ValidLieTypeIndex.AmbientGroup` as the points of a pinned Chevalley–Demazure group scheme, which its README assigns to Layer 9 of `ReductiveGroups`; that layer's split reductive group schemes over `ℤ` carry the split maximal torus as data and are cut out by conditions on the weight decomposition of `Lie G` under it, which is `TauCeti.Derivation.isInternal_adjointWeightSpace` together with `TauCeti.Derivation.roots`.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"adjoint-root-spaces-split-torus"}-->

🤖 Prepared with Claude Code

