### PR TITLE
feat: stack a Brauer diagram with a permutation diagram

### DIFF
--- a/TauCeti/Combinatorics/Brauer/Compose.lean
+++ b/TauCeti/Combinatorics/Brauer/Compose.lean
@@ -6,7 +6,7 @@ Authors: Claude
 module
 
 public import Mathlib.GroupTheory.OrderOfElement
-public import TauCeti.Combinatorics.Brauer.Boundary
+public import TauCeti.Combinatorics.Brauer.Relabel
 
 /-!
 # Composing Brauer diagrams
@@ -25,6 +25,18 @@ boundary -- and stopping the first time an outer point is reached. That the resu
 perfect matching rests on two identities: the gluing conjugates that permutation into its
 inverse, so walking from the far end of a strand retraces it, and the permutation is a gluing
 followed by a fixed-point-free involution, so a strand cannot return to its own starting point.
+
+Stacking a permutation diagram onto a diagram creates no new strand, because a permutation diagram
+has neither a cap nor a cup: it only renames the boundary points that the strands of the other
+diagram end at, that is, it relabels that boundary in the sense of
+`TauCeti.BrauerDiagram.relabel`. The consequence that Layer 9 of the Schur--Weyl roadmap is after
+is the multiplicativity `TauCeti.composeDiagram_permToBrauer`: stacking two permutation diagrams
+gives the permutation diagram of the product, so `σ ↦ permToBrauer σ` turns the group law of `Sₖ`
+into the multiplication of the Brauer algebra on the diagram basis. That is the sense in which the
+symmetric group sits inside the Brauer algebra: once the loop-weighted multiplication of the
+Brauer algebra is available, this is what will make it restrict to the group algebra `ℂ[Sₖ]` along
+`permToBrauer`, since no loop can close up in the middle when one of the two diagrams has only
+through strands. The middle-loop count itself is not built here.
 
 ## Main definitions
 
@@ -49,10 +61,14 @@ followed by a fixed-point-free involution, so a strand cannot return to its own 
 * `TauCeti.BrauerDiagram.composeDiagram_val_inl_eq_inl_capMatching`,
   `TauCeti.BrauerDiagram.composeDiagram_val_inr_eq_inr_cupMatching`: the caps of `D₂` are caps of
   the composite, and the cups of `D₁` are cups of the composite.
-
-The interaction of stacking with the permutation diagrams -- in particular that the identity
-diagram is a two-sided identity -- is in
-`TauCeti/Combinatorics/Brauer/Relabel.lean`.
+* `TauCeti.composeDiagram_permToBrauer_left` and
+  `TauCeti.composeDiagram_permToBrauer_right`: stacking a permutation diagram above or below a
+  diagram relabels that diagram's top or bottom boundary.
+* `TauCeti.composeDiagram_permToBrauer`: stacking permutation diagrams multiplies the
+  permutations.
+* `TauCeti.composeDiagram_permToBrauer_one_left` and
+  `TauCeti.composeDiagram_permToBrauer_one_right`: the identity diagram is a two-sided identity
+  for stacking.
 
 ## References
 
@@ -611,5 +627,76 @@ theorem topThrough_composeDiagram_subset :
     ((mem_topCup _).mp (topCup_subset_topCup_composeDiagram D₁ D₂ ((mem_topCup _).mpr hcup))) hj
 
 end BrauerDiagram
+
+/-! ### Stacking with a permutation diagram -/
+
+variable (D : BrauerDiagram k) (σ τ : Equiv.Perm (Fin k))
+
+open BrauerDiagram in
+/-- **Stacking a permutation diagram on top relabels the top boundary.** No strand of `D` is
+extended past the middle boundary, because the permutation diagram has no cap: a through strand of
+`D` ending at the middle point `a` is continued by the single strand of `permToBrauer σ` above it,
+which leaves at the top point `σ a`. -/
+@[simp]
+theorem composeDiagram_permToBrauer_left : composeDiagram (permToBrauer σ) D = D.relabel 1 σ := by
+  refine Subtype.ext (Equiv.ext fun x => ?_)
+  rcases x with i | j
+  · rcases h : D.val (Sum.inl i) with i' | a
+    · rw [composeDiagram_val_inl_eq_inl_of_cap_lower _ D h]
+      simp [h, Equiv.Perm.one_def]
+    · rw [composeDiagram_val_inl_eq_inr_of_through (D₁ := permToBrauer σ) (D₂ := D) (j := σ a) h
+        (permToBrauer_val_inl σ a)]
+      simp [h, Equiv.Perm.one_def]
+  · rcases h : D.val (Sum.inr (σ.symm j)) with i | a
+    · rw [composeDiagram_val_inr_eq_inl_of_through (D₁ := permToBrauer σ) (D₂ := D)
+        (a := σ.symm j) (permToBrauer_val_inr σ j) h]
+      simp [h, Equiv.Perm.one_def]
+    · rw [composeDiagram_val_inr_eq_inr_of_cup_lower (D₁ := permToBrauer σ) (D₂ := D)
+        (a := σ.symm j) (j' := σ a) (permToBrauer_val_inr σ j) h (permToBrauer_val_inl σ a)]
+      simp [h, Equiv.Perm.one_def]
+
+open BrauerDiagram in
+/-- **Stacking a permutation diagram underneath relabels the bottom boundary.** No strand of `D`
+is extended past the middle boundary, because the permutation diagram has no cup: the strand of
+`permToBrauer τ` starting at the bottom point `i` reaches the middle point `τ i`, where the arc of
+`D` takes over. -/
+@[simp]
+theorem composeDiagram_permToBrauer_right :
+    composeDiagram D (permToBrauer τ) = D.relabel τ⁻¹ 1 := by
+  refine Subtype.ext (Equiv.ext fun x => ?_)
+  rcases x with i | j
+  · rcases h : D.val (Sum.inl (τ i)) with a' | j'
+    · rw [composeDiagram_val_inl_eq_inl_of_cap_upper (D₁ := D) (D₂ := permToBrauer τ) (a := τ i)
+        (i' := τ.symm a') (permToBrauer_val_inl τ i) h (permToBrauer_val_inr τ a')]
+      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
+    · rw [composeDiagram_val_inl_eq_inr_of_through (D₁ := D) (D₂ := permToBrauer τ) (a := τ i)
+        (permToBrauer_val_inl τ i) h]
+      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
+  · rcases h : D.val (Sum.inr j) with a | j'
+    · rw [composeDiagram_val_inr_eq_inl_of_through (D₁ := D) (D₂ := permToBrauer τ) (a := a)
+        h (permToBrauer_val_inr τ a)]
+      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
+    · rw [composeDiagram_val_inr_eq_inr_of_cup_upper (D₁ := D) (D₂ := permToBrauer τ) h]
+      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
+
+/-- **Stacking permutation diagrams multiplies the permutations.** So the inclusion of the
+symmetric group into the Brauer diagrams turns the group law into vertical stacking; no loop
+closes up in the middle, since a permutation diagram has neither a cap nor a cup.
+
+This and the two identity laws below are not `simp` lemmas: they are the special cases of
+`TauCeti.composeDiagram_permToBrauer_left` and `TauCeti.composeDiagram_permToBrauer_right` in
+which the relabelling is one that `simp` already carries out, so `simp` proves them and tagging
+them would leave them out of simp-normal form. -/
+theorem composeDiagram_permToBrauer :
+    composeDiagram (permToBrauer σ) (permToBrauer τ) = permToBrauer (σ * τ) := by
+  rw [composeDiagram_permToBrauer_left, BrauerDiagram.relabel_permToBrauer, inv_one, mul_one]
+
+/-- **The identity diagram is a left identity for stacking.** -/
+theorem composeDiagram_permToBrauer_one_left : composeDiagram (permToBrauer 1) D = D := by
+  rw [composeDiagram_permToBrauer_left, BrauerDiagram.relabel_one_one]
+
+/-- **The identity diagram is a right identity for stacking.** -/
+theorem composeDiagram_permToBrauer_one_right : composeDiagram D (permToBrauer 1) = D := by
+  rw [composeDiagram_permToBrauer_right, inv_one, BrauerDiagram.relabel_one_one]
 
 end TauCeti

--- a/TauCeti/Combinatorics/Brauer/Compose.lean
+++ b/TauCeti/Combinatorics/Brauer/Compose.lean
@@ -49,9 +49,10 @@ followed by a fixed-point-free involution, so a strand cannot return to its own 
 * `TauCeti.BrauerDiagram.composeDiagram_val_inl_eq_inl_capMatching`,
   `TauCeti.BrauerDiagram.composeDiagram_val_inr_eq_inr_cupMatching`: the caps of `D₂` are caps of
   the composite, and the cups of `D₁` are cups of the composite.
-* `TauCeti.composeDiagram_permToBrauer_one_left`,
-  `TauCeti.composeDiagram_permToBrauer_one_right`: the identity diagram is a two-sided identity
-  for stacking.
+
+The interaction of stacking with the permutation diagrams -- in particular that the identity
+diagram is a two-sided identity -- is in
+`TauCeti/Combinatorics/Brauer/Relabel.lean`.
 
 ## References
 
@@ -610,39 +611,5 @@ theorem topThrough_composeDiagram_subset :
     ((mem_topCup _).mp (topCup_subset_topCup_composeDiagram D₁ D₂ ((mem_topCup _).mpr hcup))) hj
 
 end BrauerDiagram
-
-/-- **The identity diagram is a left identity for stacking.** -/
-@[simp]
-theorem composeDiagram_permToBrauer_one_left (D : BrauerDiagram k) :
-    composeDiagram (permToBrauer 1) D = D := by
-  refine Subtype.ext (Equiv.ext fun x => ?_)
-  rcases x with i | j
-  · rcases h : D.val (Sum.inl i) with i' | a
-    · exact composeDiagram_val_inl_eq_inl_of_cap_lower _ D h
-    · exact composeDiagram_val_inl_eq_inr_of_through (D₁ := permToBrauer 1) (D₂ := D) (j := a) h
-        (by rw [BrauerDiagram.permToBrauer_val_inl]; rfl)
-  · rcases h : D.val (Sum.inr j) with i | j'
-    · exact composeDiagram_val_inr_eq_inl_of_through (D₁ := permToBrauer 1) (D₂ := D) (a := j)
-        (by rw [BrauerDiagram.permToBrauer_val_inr]; rfl) h
-    · exact composeDiagram_val_inr_eq_inr_of_cup_lower (D₁ := permToBrauer 1) (D₂ := D) (a := j)
-        (j' := j') (by rw [BrauerDiagram.permToBrauer_val_inr]; rfl) h
-        (by rw [BrauerDiagram.permToBrauer_val_inl]; rfl)
-
-/-- **The identity diagram is a right identity for stacking.** -/
-@[simp]
-theorem composeDiagram_permToBrauer_one_right (D : BrauerDiagram k) :
-    composeDiagram D (permToBrauer 1) = D := by
-  refine Subtype.ext (Equiv.ext fun x => ?_)
-  rcases x with i | j
-  · rcases h : D.val (Sum.inl i) with i' | a
-    · exact composeDiagram_val_inl_eq_inl_of_cap_upper (D₁ := D) (D₂ := permToBrauer 1) (a := i)
-        (i' := i') (by rw [BrauerDiagram.permToBrauer_val_inl]; rfl) h
-        (by rw [BrauerDiagram.permToBrauer_val_inr]; rfl)
-    · exact composeDiagram_val_inl_eq_inr_of_through (D₁ := D) (D₂ := permToBrauer 1) (a := i)
-        (by rw [BrauerDiagram.permToBrauer_val_inl]; rfl) h
-  · rcases h : D.val (Sum.inr j) with i | j'
-    · exact composeDiagram_val_inr_eq_inl_of_through (D₁ := D) (D₂ := permToBrauer 1) (a := i)
-        h (by rw [BrauerDiagram.permToBrauer_val_inr]; rfl)
-    · exact composeDiagram_val_inr_eq_inr_of_cup_upper (D₁ := D) (D₂ := permToBrauer 1) h
 
 end TauCeti

--- a/TauCeti/Combinatorics/Brauer/Relabel.lean
+++ b/TauCeti/Combinatorics/Brauer/Relabel.lean
@@ -34,9 +34,9 @@ only through strands. The middle-loop count itself is not built here.
 
 Relabelling moves the arcs of a diagram around but does not change their kinds, so it preserves
 the numbers of caps, of cups and of through strands
-(`TauCeti.BrauerDiagram.bottomCap_relabel` and its companions). Stacking with a permutation
-diagram therefore leaves those numbers alone as well; the number of through strands is the
-statistic that stratifies the Brauer algebra, and it is constant on each `Sₖ × Sₖ` orbit.
+(`TauCeti.BrauerDiagram.bottomCap_relabel` and its companions). The number of through strands is
+the statistic that stratifies the Brauer algebra, so it is constant on each `Sₖ × Sₖ` orbit, and
+by the two stacking identities above it is unchanged by stacking a permutation diagram.
 
 ## Main definitions
 
@@ -55,9 +55,10 @@ statistic that stratifies the Brauer algebra, and it is constant on each `Sₖ �
   for stacking.
 * `TauCeti.BrauerDiagram.relabel_relabel`: relabelling twice is relabelling by the product, so
   `Sₖ × Sₖ` acts on the Brauer diagrams.
-* `TauCeti.BrauerDiagram.bottomCap_relabel`, `TauCeti.BrauerDiagram.topCup_relabel` and
-  `TauCeti.BrauerDiagram.bottomThrough_relabel`: relabelling permutes the capped, cupped and
-  through boundary points, so it preserves their numbers.
+* `TauCeti.BrauerDiagram.bottomCap_relabel`, `TauCeti.BrauerDiagram.topCup_relabel`,
+  `TauCeti.BrauerDiagram.bottomThrough_relabel` and `TauCeti.BrauerDiagram.topThrough_relabel`:
+  relabelling permutes the capped, cupped and through boundary points, so it preserves their
+  numbers.
 
 ## References
 
@@ -93,12 +94,16 @@ theorem relabel_val_map (x : Fin k ⊕ Fin k) :
   rw [relabel_def]
   exact PerfectMatching.congr_val_apply_apply (Equiv.Perm.sumCongr σ τ) D x
 
+/-- The arc of a relabelled diagram at the bottom point `i` is the renamed arc at the bottom point
+`σ.symm i` that `i` was renamed from. -/
 @[simp]
 theorem relabel_val_inl (i : Fin k) :
     (D.relabel σ τ).val (Sum.inl i) = Sum.map σ τ (D.val (Sum.inl (σ.symm i))) := by
   have h := relabel_val_map D σ τ (Sum.inl (σ.symm i))
   rwa [Sum.map_inl, Equiv.apply_symm_apply] at h
 
+/-- The arc of a relabelled diagram at the top point `j` is the renamed arc at the top point
+`τ.symm j` that `j` was renamed from. -/
 @[simp]
 theorem relabel_val_inr (j : Fin k) :
     (D.relabel σ τ).val (Sum.inr j) = Sum.map σ τ (D.val (Sum.inr (τ.symm j))) := by
@@ -118,11 +123,6 @@ theorem relabel_relabel (σ' τ' : Equiv.Perm (Fin k)) :
   rw [relabel_def, relabel_def, relabel_def, PerfectMatching.congr_trans,
     Equiv.Perm.sumCongr_trans]
   rfl
-
-/-- Relabelling is injective: relabelling back by the inverses recovers the diagram. -/
-theorem relabel_injective : Function.Injective fun D : BrauerDiagram k => D.relabel σ τ :=
-  fun _ _ h => by
-    simpa [relabel_relabel] using congrArg (fun D : BrauerDiagram k => D.relabel σ⁻¹ τ⁻¹) h
 
 /-- **Relabelling a permutation diagram** conjugates the permutation: renaming the bottom points
 by `σ` and the top points by `τ` turns the strand `i ↦ ρ i` into the strand `σ i ↦ τ (ρ i)`. -/
@@ -190,6 +190,15 @@ theorem bottomThrough_relabel : (D.relabel σ τ).bottomThrough = D.bottomThroug
   · rintro ⟨i', hi', rfl⟩
     exact (isThrough_relabel_inl D σ τ i').mpr ((mem_bottomThrough _).mp hi')
 
+/-- The top endpoints of the through strands of a relabelled diagram are the renamed ones. -/
+theorem topThrough_relabel : (D.relabel σ τ).topThrough = D.topThrough.image τ := by
+  ext j
+  rw [mem_topThrough, Finset.mem_image]
+  refine ⟨fun hj => ⟨τ.symm j, (mem_topThrough _).mpr ?_, τ.apply_symm_apply j⟩, ?_⟩
+  · rwa [← isThrough_relabel_inr D σ τ (τ.symm j), Equiv.apply_symm_apply]
+  · rintro ⟨j', hj', rfl⟩
+    exact (isThrough_relabel_inr D σ τ j').mpr ((mem_topThrough _).mp hj')
+
 /-- Relabelling does not change the number of caps. -/
 @[simp]
 theorem card_bottomCap_relabel : (D.relabel σ τ).bottomCap.card = D.bottomCap.card := by
@@ -205,6 +214,11 @@ theorem card_topCup_relabel : (D.relabel σ τ).topCup.card = D.topCup.card := b
 theorem card_bottomThrough_relabel :
     (D.relabel σ τ).bottomThrough.card = D.bottomThrough.card := by
   rw [bottomThrough_relabel, Finset.card_image_of_injective _ σ.injective]
+
+/-- Relabelling does not change the number of through strands, counted at the top. -/
+@[simp]
+theorem card_topThrough_relabel : (D.relabel σ τ).topThrough.card = D.topThrough.card := by
+  rw [topThrough_relabel, Finset.card_image_of_injective _ τ.injective]
 
 end BrauerDiagram
 
@@ -274,25 +288,5 @@ theorem composeDiagram_permToBrauer_one_left : composeDiagram (permToBrauer 1) D
 @[simp]
 theorem composeDiagram_permToBrauer_one_right : composeDiagram D (permToBrauer 1) = D := by
   rw [composeDiagram_permToBrauer_right, inv_one, BrauerDiagram.relabel_one_one]
-
-/-- Stacking a permutation diagram on top does not change the number of caps. -/
-theorem card_bottomCap_composeDiagram_permToBrauer_left :
-    (composeDiagram (permToBrauer σ) D).bottomCap.card = D.bottomCap.card := by
-  rw [composeDiagram_permToBrauer_left, BrauerDiagram.card_bottomCap_relabel]
-
-/-- Stacking a permutation diagram underneath does not change the number of caps. -/
-theorem card_bottomCap_composeDiagram_permToBrauer_right :
-    (composeDiagram D (permToBrauer τ)).bottomCap.card = D.bottomCap.card := by
-  rw [composeDiagram_permToBrauer_right, BrauerDiagram.card_bottomCap_relabel]
-
-/-- Stacking a permutation diagram on top does not change the number of cups. -/
-theorem card_topCup_composeDiagram_permToBrauer_left :
-    (composeDiagram (permToBrauer σ) D).topCup.card = D.topCup.card := by
-  rw [composeDiagram_permToBrauer_left, BrauerDiagram.card_topCup_relabel]
-
-/-- Stacking a permutation diagram underneath does not change the number of cups. -/
-theorem card_topCup_composeDiagram_permToBrauer_right :
-    (composeDiagram D (permToBrauer τ)).topCup.card = D.topCup.card := by
-  rw [composeDiagram_permToBrauer_right, BrauerDiagram.card_topCup_relabel]
 
 end TauCeti

--- a/TauCeti/Combinatorics/Brauer/Relabel.lean
+++ b/TauCeti/Combinatorics/Brauer/Relabel.lean
@@ -1,0 +1,298 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.Brauer.Compose
+
+/-!
+# Stacking a Brauer diagram with a permutation diagram
+
+A permutation diagram carries no cap and no cup, so stacking it onto a Brauer diagram creates no
+new strand: it only renames the boundary points that the strands of the other diagram end at.
+This file makes that precise. Renaming the bottom points of a diagram by `σ` and its top points by
+`τ` is `TauCeti.BrauerDiagram.relabel`, the conjugation of the underlying perfect matching by
+`Equiv.Perm.sumCongr σ τ`, and the two main results are
+
+`(permToBrauer σ) ∘ D = D.relabel 1 σ`  and  `D ∘ (permToBrauer τ) = D.relabel τ⁻¹ 1`,
+
+writing `∘` for `TauCeti.composeDiagram`. Relabelling composes as
+`(D.relabel σ τ).relabel σ' τ' = D.relabel (σ' * σ) (τ' * τ)`, so stacking permutation diagrams on
+the two sides of a diagram is an action of `Sₖ × Sₖ` on the Brauer diagrams; the identity diagram
+being a two-sided identity for stacking is the trivial case.
+
+The consequence that Layer 9 of the Schur--Weyl roadmap is after is the multiplicativity
+`TauCeti.composeDiagram_permToBrauer`: stacking two permutation diagrams gives the permutation
+diagram of the product, so `σ ↦ permToBrauer σ` turns the group law of `Sₖ` into the
+multiplication of the Brauer algebra on the diagram basis. That is the sense in which the
+symmetric group sits inside the Brauer algebra: once the loop-weighted multiplication of the
+Brauer algebra is available, this is what will make it restrict to the group algebra `ℂ[Sₖ]`
+along `permToBrauer`, since no loop can close up in the middle when one of the two diagrams has
+only through strands. The middle-loop count itself is not built here.
+
+Relabelling moves the arcs of a diagram around but does not change their kinds, so it preserves
+the numbers of caps, of cups and of through strands
+(`TauCeti.BrauerDiagram.bottomCap_relabel` and its companions). Stacking with a permutation
+diagram therefore leaves those numbers alone as well; the number of through strands is the
+statistic that stratifies the Brauer algebra, and it is constant on each `Sₖ × Sₖ` orbit.
+
+## Main definitions
+
+* `TauCeti.BrauerDiagram.relabel`: renaming the bottom points of a Brauer diagram by `σ` and its
+  top points by `τ`.
+
+## Main results
+
+* `TauCeti.composeDiagram_permToBrauer_left` and
+  `TauCeti.composeDiagram_permToBrauer_right`: stacking a permutation diagram above or below a
+  diagram relabels that diagram's top or bottom boundary.
+* `TauCeti.composeDiagram_permToBrauer`: stacking permutation diagrams multiplies the
+  permutations.
+* `TauCeti.composeDiagram_permToBrauer_one_left` and
+  `TauCeti.composeDiagram_permToBrauer_one_right`: the identity diagram is a two-sided identity
+  for stacking.
+* `TauCeti.BrauerDiagram.relabel_relabel`: relabelling twice is relabelling by the product, so
+  `Sₖ × Sₖ` acts on the Brauer diagrams.
+* `TauCeti.BrauerDiagram.bottomCap_relabel`, `TauCeti.BrauerDiagram.topCup_relabel` and
+  `TauCeti.BrauerDiagram.bottomThrough_relabel`: relabelling permutes the capped, cupped and
+  through boundary points, so it preserves their numbers.
+
+## References
+
+* [R. Brauer, *On algebras which are connected with the semisimple continuous groups*][brauer1937],
+  Annals of Mathematics 38 (1937), 857-872.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 9, the `permToBrauer` build item.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace BrauerDiagram
+
+variable {k : ℕ}
+
+/-- **Relabelling the boundary of a Brauer diagram**: `σ` renames its bottom points and `τ` its
+top points, the arc joining `x` to `y` becoming the arc joining the renamed `x` to the renamed
+`y`. -/
+def relabel (D : BrauerDiagram k) (σ τ : Equiv.Perm (Fin k)) : BrauerDiagram k :=
+  PerfectMatching.congr (Equiv.Perm.sumCongr σ τ) D
+
+variable (D : BrauerDiagram k) (σ τ : Equiv.Perm (Fin k))
+
+/-- Relabelling is the conjugation of the underlying perfect matching by the renaming
+`Equiv.Perm.sumCongr σ τ` of the boundary points. -/
+theorem relabel_def : D.relabel σ τ = PerfectMatching.congr (Equiv.Perm.sumCongr σ τ) D := (rfl)
+
+/-- Relabelling carries the arc at `x` to the arc at the renamed `x`. -/
+theorem relabel_val_map (x : Fin k ⊕ Fin k) :
+    (D.relabel σ τ).val (Sum.map σ τ x) = Sum.map σ τ (D.val x) := by
+  rw [relabel_def]
+  exact PerfectMatching.congr_val_apply_apply (Equiv.Perm.sumCongr σ τ) D x
+
+@[simp]
+theorem relabel_val_inl (i : Fin k) :
+    (D.relabel σ τ).val (Sum.inl i) = Sum.map σ τ (D.val (Sum.inl (σ.symm i))) := by
+  have h := relabel_val_map D σ τ (Sum.inl (σ.symm i))
+  rwa [Sum.map_inl, Equiv.apply_symm_apply] at h
+
+@[simp]
+theorem relabel_val_inr (j : Fin k) :
+    (D.relabel σ τ).val (Sum.inr j) = Sum.map σ τ (D.val (Sum.inr (τ.symm j))) := by
+  have h := relabel_val_map D σ τ (Sum.inr (τ.symm j))
+  rwa [Sum.map_inr, Equiv.apply_symm_apply] at h
+
+/-- Relabelling by the identity permutations changes nothing. -/
+@[simp]
+theorem relabel_one_one : D.relabel 1 1 = D := by
+  rw [relabel_def, Equiv.Perm.one_def, Equiv.Perm.sumCongr_refl, PerfectMatching.congr_refl]
+
+/-- **Relabelling twice is relabelling by the product.** With
+`TauCeti.BrauerDiagram.relabel_one_one` this makes relabelling an action of `Sₖ × Sₖ` on the
+Brauer diagrams on `k` strands. -/
+theorem relabel_relabel (σ' τ' : Equiv.Perm (Fin k)) :
+    (D.relabel σ τ).relabel σ' τ' = D.relabel (σ' * σ) (τ' * τ) := by
+  rw [relabel_def, relabel_def, relabel_def, PerfectMatching.congr_trans,
+    Equiv.Perm.sumCongr_trans]
+  rfl
+
+/-- Relabelling is injective: relabelling back by the inverses recovers the diagram. -/
+theorem relabel_injective : Function.Injective fun D : BrauerDiagram k => D.relabel σ τ :=
+  fun _ _ h => by
+    simpa [relabel_relabel] using congrArg (fun D : BrauerDiagram k => D.relabel σ⁻¹ τ⁻¹) h
+
+/-- **Relabelling a permutation diagram** conjugates the permutation: renaming the bottom points
+by `σ` and the top points by `τ` turns the strand `i ↦ ρ i` into the strand `σ i ↦ τ (ρ i)`. -/
+@[simp]
+theorem relabel_permToBrauer (ρ : Equiv.Perm (Fin k)) :
+    (permToBrauer ρ).relabel σ τ = permToBrauer (τ * ρ * σ⁻¹) := by
+  refine Subtype.ext (Equiv.ext fun x => ?_)
+  rcases x with i | j
+  · simp [Equiv.Perm.mul_apply]
+  · rw [relabel_val_inr, permToBrauer_val_inr, Sum.map_inl, permToBrauer_val_inr]
+    simp only [← Equiv.Perm.inv_def, mul_inv_rev, inv_inv, Equiv.Perm.mul_apply]
+
+/-! ### Relabelling preserves the kinds of the arcs -/
+
+/-- Relabelling carries a through strand starting at the bottom to a through strand. -/
+@[simp]
+theorem isThrough_relabel_inl (i : Fin k) :
+    (D.relabel σ τ).IsThrough (Sum.inl (σ i)) ↔ D.IsThrough (Sum.inl i) := by
+  rw [isThrough_def, isThrough_def, relabel_val_inl, Equiv.symm_apply_apply]
+  cases D.val (Sum.inl i) <;> simp
+
+/-- Relabelling carries a through strand starting at the top to a through strand. -/
+@[simp]
+theorem isThrough_relabel_inr (j : Fin k) :
+    (D.relabel σ τ).IsThrough (Sum.inr (τ j)) ↔ D.IsThrough (Sum.inr j) := by
+  rw [isThrough_def, isThrough_def, relabel_val_inr, Equiv.symm_apply_apply]
+  cases D.val (Sum.inr j) <;> simp
+
+/-- Relabelling carries a cap to a cap. -/
+@[simp]
+theorem isCap_relabel (i : Fin k) :
+    (D.relabel σ τ).IsCap (Sum.inl (σ i)) ↔ D.IsCap (Sum.inl i) := by
+  rw [isCap_inl_iff, isCap_inl_iff, isThrough_relabel_inl]
+
+/-- Relabelling carries a cup to a cup. -/
+@[simp]
+theorem isCup_relabel (j : Fin k) :
+    (D.relabel σ τ).IsCup (Sum.inr (τ j)) ↔ D.IsCup (Sum.inr j) := by
+  rw [isCup_inr_iff, isCup_inr_iff, isThrough_relabel_inr]
+
+/-- The capped bottom points of a relabelled diagram are the renamed capped bottom points. -/
+theorem bottomCap_relabel : (D.relabel σ τ).bottomCap = D.bottomCap.image σ := by
+  ext i
+  rw [mem_bottomCap, Finset.mem_image]
+  refine ⟨fun hi => ⟨σ.symm i, (mem_bottomCap _).mpr ?_, σ.apply_symm_apply i⟩, ?_⟩
+  · rwa [← isCap_relabel D σ τ (σ.symm i), Equiv.apply_symm_apply]
+  · rintro ⟨i', hi', rfl⟩
+    exact (isCap_relabel D σ τ i').mpr ((mem_bottomCap _).mp hi')
+
+/-- The cupped top points of a relabelled diagram are the renamed cupped top points. -/
+theorem topCup_relabel : (D.relabel σ τ).topCup = D.topCup.image τ := by
+  ext j
+  rw [mem_topCup, Finset.mem_image]
+  refine ⟨fun hj => ⟨τ.symm j, (mem_topCup _).mpr ?_, τ.apply_symm_apply j⟩, ?_⟩
+  · rwa [← isCup_relabel D σ τ (τ.symm j), Equiv.apply_symm_apply]
+  · rintro ⟨j', hj', rfl⟩
+    exact (isCup_relabel D σ τ j').mpr ((mem_topCup _).mp hj')
+
+/-- The bottom endpoints of the through strands of a relabelled diagram are the renamed ones. -/
+theorem bottomThrough_relabel : (D.relabel σ τ).bottomThrough = D.bottomThrough.image σ := by
+  ext i
+  rw [mem_bottomThrough, Finset.mem_image]
+  refine ⟨fun hi => ⟨σ.symm i, (mem_bottomThrough _).mpr ?_, σ.apply_symm_apply i⟩, ?_⟩
+  · rwa [← isThrough_relabel_inl D σ τ (σ.symm i), Equiv.apply_symm_apply]
+  · rintro ⟨i', hi', rfl⟩
+    exact (isThrough_relabel_inl D σ τ i').mpr ((mem_bottomThrough _).mp hi')
+
+/-- Relabelling does not change the number of caps. -/
+@[simp]
+theorem card_bottomCap_relabel : (D.relabel σ τ).bottomCap.card = D.bottomCap.card := by
+  rw [bottomCap_relabel, Finset.card_image_of_injective _ σ.injective]
+
+/-- Relabelling does not change the number of cups. -/
+@[simp]
+theorem card_topCup_relabel : (D.relabel σ τ).topCup.card = D.topCup.card := by
+  rw [topCup_relabel, Finset.card_image_of_injective _ τ.injective]
+
+/-- Relabelling does not change the number of through strands. -/
+@[simp]
+theorem card_bottomThrough_relabel :
+    (D.relabel σ τ).bottomThrough.card = D.bottomThrough.card := by
+  rw [bottomThrough_relabel, Finset.card_image_of_injective _ σ.injective]
+
+end BrauerDiagram
+
+/-! ### Stacking with a permutation diagram -/
+
+variable {k : ℕ} (D : BrauerDiagram k) (σ τ : Equiv.Perm (Fin k))
+
+open BrauerDiagram in
+/-- **Stacking a permutation diagram on top relabels the top boundary.** No strand of `D` is
+extended past the middle boundary, because the permutation diagram has no cap: a through strand of
+`D` ending at the middle point `a` is continued by the single strand of `permToBrauer σ` above it,
+which leaves at the top point `σ a`. -/
+theorem composeDiagram_permToBrauer_left : composeDiagram (permToBrauer σ) D = D.relabel 1 σ := by
+  refine Subtype.ext (Equiv.ext fun x => ?_)
+  rcases x with i | j
+  · rcases h : D.val (Sum.inl i) with i' | a
+    · rw [composeDiagram_val_inl_eq_inl_of_cap_lower _ D h]
+      simp [h, Equiv.Perm.one_def]
+    · rw [composeDiagram_val_inl_eq_inr_of_through (D₁ := permToBrauer σ) (D₂ := D) (j := σ a) h
+        (permToBrauer_val_inl σ a)]
+      simp [h, Equiv.Perm.one_def]
+  · rcases h : D.val (Sum.inr (σ.symm j)) with i | a
+    · rw [composeDiagram_val_inr_eq_inl_of_through (D₁ := permToBrauer σ) (D₂ := D)
+        (a := σ.symm j) (permToBrauer_val_inr σ j) h]
+      simp [h, Equiv.Perm.one_def]
+    · rw [composeDiagram_val_inr_eq_inr_of_cup_lower (D₁ := permToBrauer σ) (D₂ := D)
+        (a := σ.symm j) (j' := σ a) (permToBrauer_val_inr σ j) h (permToBrauer_val_inl σ a)]
+      simp [h, Equiv.Perm.one_def]
+
+open BrauerDiagram in
+/-- **Stacking a permutation diagram underneath relabels the bottom boundary.** No strand of `D`
+is extended past the middle boundary, because the permutation diagram has no cup: the strand of
+`permToBrauer τ` starting at the bottom point `i` reaches the middle point `τ i`, where the arc of
+`D` takes over. -/
+theorem composeDiagram_permToBrauer_right :
+    composeDiagram D (permToBrauer τ) = D.relabel τ⁻¹ 1 := by
+  refine Subtype.ext (Equiv.ext fun x => ?_)
+  rcases x with i | j
+  · rcases h : D.val (Sum.inl (τ i)) with a' | j'
+    · rw [composeDiagram_val_inl_eq_inl_of_cap_upper (D₁ := D) (D₂ := permToBrauer τ) (a := τ i)
+        (i' := τ.symm a') (permToBrauer_val_inl τ i) h (permToBrauer_val_inr τ a')]
+      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
+    · rw [composeDiagram_val_inl_eq_inr_of_through (D₁ := D) (D₂ := permToBrauer τ) (a := τ i)
+        (permToBrauer_val_inl τ i) h]
+      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
+  · rcases h : D.val (Sum.inr j) with a | j'
+    · rw [composeDiagram_val_inr_eq_inl_of_through (D₁ := D) (D₂ := permToBrauer τ) (a := a)
+        h (permToBrauer_val_inr τ a)]
+      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
+    · rw [composeDiagram_val_inr_eq_inr_of_cup_upper (D₁ := D) (D₂ := permToBrauer τ) h]
+      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
+
+/-- **Stacking permutation diagrams multiplies the permutations.** So the inclusion of the
+symmetric group into the Brauer diagrams turns the group law into vertical stacking; no loop
+closes up in the middle, since a permutation diagram has neither a cap nor a cup. -/
+@[simp]
+theorem composeDiagram_permToBrauer :
+    composeDiagram (permToBrauer σ) (permToBrauer τ) = permToBrauer (σ * τ) := by
+  rw [composeDiagram_permToBrauer_left, BrauerDiagram.relabel_permToBrauer, inv_one, mul_one]
+
+/-- **The identity diagram is a left identity for stacking.** -/
+@[simp]
+theorem composeDiagram_permToBrauer_one_left : composeDiagram (permToBrauer 1) D = D := by
+  rw [composeDiagram_permToBrauer_left, BrauerDiagram.relabel_one_one]
+
+/-- **The identity diagram is a right identity for stacking.** -/
+@[simp]
+theorem composeDiagram_permToBrauer_one_right : composeDiagram D (permToBrauer 1) = D := by
+  rw [composeDiagram_permToBrauer_right, inv_one, BrauerDiagram.relabel_one_one]
+
+/-- Stacking a permutation diagram on top does not change the number of caps. -/
+theorem card_bottomCap_composeDiagram_permToBrauer_left :
+    (composeDiagram (permToBrauer σ) D).bottomCap.card = D.bottomCap.card := by
+  rw [composeDiagram_permToBrauer_left, BrauerDiagram.card_bottomCap_relabel]
+
+/-- Stacking a permutation diagram underneath does not change the number of caps. -/
+theorem card_bottomCap_composeDiagram_permToBrauer_right :
+    (composeDiagram D (permToBrauer τ)).bottomCap.card = D.bottomCap.card := by
+  rw [composeDiagram_permToBrauer_right, BrauerDiagram.card_bottomCap_relabel]
+
+/-- Stacking a permutation diagram on top does not change the number of cups. -/
+theorem card_topCup_composeDiagram_permToBrauer_left :
+    (composeDiagram (permToBrauer σ) D).topCup.card = D.topCup.card := by
+  rw [composeDiagram_permToBrauer_left, BrauerDiagram.card_topCup_relabel]
+
+/-- Stacking a permutation diagram underneath does not change the number of cups. -/
+theorem card_topCup_composeDiagram_permToBrauer_right :
+    (composeDiagram D (permToBrauer τ)).topCup.card = D.topCup.card := by
+  rw [composeDiagram_permToBrauer_right, BrauerDiagram.card_topCup_relabel]
+
+end TauCeti

--- a/TauCeti/Combinatorics/Brauer/Relabel.lean
+++ b/TauCeti/Combinatorics/Brauer/Relabel.lean
@@ -165,7 +165,10 @@ theorem isCup_relabel_inr (j : Fin k) :
     (D.relabel σ τ).IsCup (Sum.inr (τ j)) ↔ D.IsCup (Sum.inr j) :=
   Sum.map_inr σ τ j ▸ isCup_relabel D σ τ (Sum.inr j)
 
-/-- The capped bottom points of a relabelled diagram are the renamed capped bottom points. -/
+/-- The capped bottom points of a relabelled diagram are the renamed capped bottom points.
+
+Not a `simp` lemma: rewriting by it takes `TauCeti.BrauerDiagram.card_bottomCap_relabel` out of
+simp-normal form, and `simp` cannot finish the resulting cardinality goal on its own. -/
 theorem bottomCap_relabel : (D.relabel σ τ).bottomCap = D.bottomCap.image σ := by
   ext i
   rw [mem_bottomCap, Finset.mem_image]
@@ -174,7 +177,9 @@ theorem bottomCap_relabel : (D.relabel σ τ).bottomCap = D.bottomCap.image σ :
   · rintro ⟨i', hi', rfl⟩
     exact (isCap_relabel_inl D σ τ i').mpr ((mem_bottomCap _).mp hi')
 
-/-- The cupped top points of a relabelled diagram are the renamed cupped top points. -/
+/-- The cupped top points of a relabelled diagram are the renamed cupped top points.
+
+Not a `simp` lemma, for the reason given for `TauCeti.BrauerDiagram.bottomCap_relabel`. -/
 theorem topCup_relabel : (D.relabel σ τ).topCup = D.topCup.image τ := by
   ext j
   rw [mem_topCup, Finset.mem_image]
@@ -183,7 +188,9 @@ theorem topCup_relabel : (D.relabel σ τ).topCup = D.topCup.image τ := by
   · rintro ⟨j', hj', rfl⟩
     exact (isCup_relabel_inr D σ τ j').mpr ((mem_topCup _).mp hj')
 
-/-- The bottom endpoints of the through strands of a relabelled diagram are the renamed ones. -/
+/-- The bottom endpoints of the through strands of a relabelled diagram are the renamed ones.
+
+Not a `simp` lemma, for the reason given for `TauCeti.BrauerDiagram.bottomCap_relabel`. -/
 theorem bottomThrough_relabel : (D.relabel σ τ).bottomThrough = D.bottomThrough.image σ := by
   ext i
   rw [mem_bottomThrough, Finset.mem_image]
@@ -192,7 +199,9 @@ theorem bottomThrough_relabel : (D.relabel σ τ).bottomThrough = D.bottomThroug
   · rintro ⟨i', hi', rfl⟩
     exact (isThrough_relabel_inl D σ τ i').mpr ((mem_bottomThrough _).mp hi')
 
-/-- The top endpoints of the through strands of a relabelled diagram are the renamed ones. -/
+/-- The top endpoints of the through strands of a relabelled diagram are the renamed ones.
+
+Not a `simp` lemma, for the reason given for `TauCeti.BrauerDiagram.bottomCap_relabel`. -/
 theorem topThrough_relabel : (D.relabel σ τ).topThrough = D.topThrough.image τ := by
   ext j
   rw [mem_topThrough, Finset.mem_image]

--- a/TauCeti/Combinatorics/Brauer/Relabel.lean
+++ b/TauCeti/Combinatorics/Brauer/Relabel.lean
@@ -5,38 +5,28 @@ Authors: Claude
 -/
 module
 
-public import TauCeti.Combinatorics.Brauer.Compose
+public import TauCeti.Combinatorics.Brauer.Boundary
 
 /-!
-# Stacking a Brauer diagram with a permutation diagram
+# Relabelling the boundary of a Brauer diagram
 
-A permutation diagram carries no cap and no cup, so stacking it onto a Brauer diagram creates no
-new strand: it only renames the boundary points that the strands of the other diagram end at.
-This file makes that precise. Renaming the bottom points of a diagram by `σ` and its top points by
-`τ` is `TauCeti.BrauerDiagram.relabel`, the conjugation of the underlying perfect matching by
-`Equiv.Perm.sumCongr σ τ`, and the two main results are
+Renaming the bottom points of a Brauer diagram by a permutation `σ` and its top points by a
+permutation `τ` gives another Brauer diagram, `TauCeti.BrauerDiagram.relabel`: the arc joining `x`
+to `y` becomes the arc joining the renamed `x` to the renamed `y`, so the underlying perfect
+matching is conjugated by the renaming `Equiv.Perm.sumCongr σ τ` of the boundary points.
 
-`(permToBrauer σ) ∘ D = D.relabel 1 σ`  and  `D ∘ (permToBrauer τ) = D.relabel τ⁻¹ 1`,
+Relabelling twice is relabelling by the product,
+`(D.relabel σ τ).relabel σ' τ' = D.relabel (σ' * σ) (τ' * τ)`, so relabelling is an action of
+`Sₖ × Sₖ` on the Brauer diagrams on `k` strands. It moves the arcs of a diagram around but does
+not change their kinds, so it preserves the numbers of caps, of cups and of through strands. The
+number of through strands is the statistic that stratifies the Brauer algebra, so that statistic
+is constant on each `Sₖ × Sₖ` orbit.
 
-writing `∘` for `TauCeti.composeDiagram`. Relabelling composes as
-`(D.relabel σ τ).relabel σ' τ' = D.relabel (σ' * σ) (τ' * τ)`, so stacking permutation diagrams on
-the two sides of a diagram is an action of `Sₖ × Sₖ` on the Brauer diagrams; the identity diagram
-being a two-sided identity for stacking is the trivial case.
-
-The consequence that Layer 9 of the Schur--Weyl roadmap is after is the multiplicativity
-`TauCeti.composeDiagram_permToBrauer`: stacking two permutation diagrams gives the permutation
-diagram of the product, so `σ ↦ permToBrauer σ` turns the group law of `Sₖ` into the
-multiplication of the Brauer algebra on the diagram basis. That is the sense in which the
-symmetric group sits inside the Brauer algebra: once the loop-weighted multiplication of the
-Brauer algebra is available, this is what will make it restrict to the group algebra `ℂ[Sₖ]`
-along `permToBrauer`, since no loop can close up in the middle when one of the two diagrams has
-only through strands. The middle-loop count itself is not built here.
-
-Relabelling moves the arcs of a diagram around but does not change their kinds, so it preserves
-the numbers of caps, of cups and of through strands
-(`TauCeti.BrauerDiagram.bottomCap_relabel` and its companions). The number of through strands is
-the statistic that stratifies the Brauer algebra, so it is constant on each `Sₖ × Sₖ` orbit, and
-by the two stacking identities above it is unchanged by stacking a permutation diagram.
+Relabelling is exactly what stacking a permutation diagram onto a Brauer diagram does, since a
+permutation diagram has neither a cap nor a cup and so extends no strand of the other diagram past
+the middle boundary; that is `TauCeti.composeDiagram_permToBrauer_left` and
+`TauCeti.composeDiagram_permToBrauer_right`, in `TauCeti/Combinatorics/Brauer/Compose.lean`, which
+imports this file.
 
 ## Main definitions
 
@@ -45,16 +35,10 @@ by the two stacking identities above it is unchanged by stacking a permutation d
 
 ## Main results
 
-* `TauCeti.composeDiagram_permToBrauer_left` and
-  `TauCeti.composeDiagram_permToBrauer_right`: stacking a permutation diagram above or below a
-  diagram relabels that diagram's top or bottom boundary.
-* `TauCeti.composeDiagram_permToBrauer`: stacking permutation diagrams multiplies the
-  permutations.
-* `TauCeti.composeDiagram_permToBrauer_one_left` and
-  `TauCeti.composeDiagram_permToBrauer_one_right`: the identity diagram is a two-sided identity
-  for stacking.
 * `TauCeti.BrauerDiagram.relabel_relabel`: relabelling twice is relabelling by the product, so
   `Sₖ × Sₖ` acts on the Brauer diagrams.
+* `TauCeti.BrauerDiagram.relabel_permToBrauer`: relabelling a permutation diagram conjugates the
+  permutation.
 * `TauCeti.BrauerDiagram.bottomCap_relabel`, `TauCeti.BrauerDiagram.topCup_relabel`,
   `TauCeti.BrauerDiagram.bottomThrough_relabel` and `TauCeti.BrauerDiagram.topThrough_relabel`:
   relabelling permutes the capped, cupped and through boundary points, so it preserves their
@@ -118,6 +102,7 @@ theorem relabel_one_one : D.relabel 1 1 = D := by
 /-- **Relabelling twice is relabelling by the product.** With
 `TauCeti.BrauerDiagram.relabel_one_one` this makes relabelling an action of `Sₖ × Sₖ` on the
 Brauer diagrams on `k` strands. -/
+@[simp]
 theorem relabel_relabel (σ' τ' : Equiv.Perm (Fin k)) :
     (D.relabel σ τ).relabel σ' τ' = D.relabel (σ' * σ) (τ' * τ) := by
   rw [relabel_def, relabel_def, relabel_def, PerfectMatching.congr_trans,
@@ -137,49 +122,66 @@ theorem relabel_permToBrauer (ρ : Equiv.Perm (Fin k)) :
 
 /-! ### Relabelling preserves the kinds of the arcs -/
 
+/-- **Relabelling carries a through strand to a through strand**: the renamed point lies on a
+through strand of the relabelled diagram exactly when the point lies on a through strand. -/
+@[simp]
+theorem isThrough_relabel (x : Fin k ⊕ Fin k) :
+    (D.relabel σ τ).IsThrough (Sum.map σ τ x) ↔ D.IsThrough x := by
+  rw [isThrough_def, isThrough_def, relabel_val_map, Sum.isLeft_map, Sum.isLeft_map]
+
+/-- **Relabelling carries a cap to a cap.** -/
+@[simp]
+theorem isCap_relabel (x : Fin k ⊕ Fin k) :
+    (D.relabel σ τ).IsCap (Sum.map σ τ x) ↔ D.IsCap x := by
+  rw [isCap_def, isCap_def, relabel_val_map, Sum.isLeft_map, Sum.isLeft_map]
+
+/-- **Relabelling carries a cup to a cup.** -/
+@[simp]
+theorem isCup_relabel (x : Fin k ⊕ Fin k) :
+    (D.relabel σ τ).IsCup (Sum.map σ τ x) ↔ D.IsCup x := by
+  rw [isCup_def, isCup_def, relabel_val_map, Sum.isRight_map, Sum.isRight_map]
+
 /-- Relabelling carries a through strand starting at the bottom to a through strand. -/
 @[simp]
 theorem isThrough_relabel_inl (i : Fin k) :
-    (D.relabel σ τ).IsThrough (Sum.inl (σ i)) ↔ D.IsThrough (Sum.inl i) := by
-  rw [isThrough_def, isThrough_def, relabel_val_inl, Equiv.symm_apply_apply]
-  cases D.val (Sum.inl i) <;> simp
+    (D.relabel σ τ).IsThrough (Sum.inl (σ i)) ↔ D.IsThrough (Sum.inl i) :=
+  Sum.map_inl σ τ i ▸ isThrough_relabel D σ τ (Sum.inl i)
 
 /-- Relabelling carries a through strand starting at the top to a through strand. -/
 @[simp]
 theorem isThrough_relabel_inr (j : Fin k) :
-    (D.relabel σ τ).IsThrough (Sum.inr (τ j)) ↔ D.IsThrough (Sum.inr j) := by
-  rw [isThrough_def, isThrough_def, relabel_val_inr, Equiv.symm_apply_apply]
-  cases D.val (Sum.inr j) <;> simp
+    (D.relabel σ τ).IsThrough (Sum.inr (τ j)) ↔ D.IsThrough (Sum.inr j) :=
+  Sum.map_inr σ τ j ▸ isThrough_relabel D σ τ (Sum.inr j)
 
-/-- Relabelling carries a cap to a cap. -/
+/-- Relabelling carries a cap to a cap, read off at the bottom boundary. -/
 @[simp]
-theorem isCap_relabel (i : Fin k) :
-    (D.relabel σ τ).IsCap (Sum.inl (σ i)) ↔ D.IsCap (Sum.inl i) := by
-  rw [isCap_inl_iff, isCap_inl_iff, isThrough_relabel_inl]
+theorem isCap_relabel_inl (i : Fin k) :
+    (D.relabel σ τ).IsCap (Sum.inl (σ i)) ↔ D.IsCap (Sum.inl i) :=
+  Sum.map_inl σ τ i ▸ isCap_relabel D σ τ (Sum.inl i)
 
-/-- Relabelling carries a cup to a cup. -/
+/-- Relabelling carries a cup to a cup, read off at the top boundary. -/
 @[simp]
-theorem isCup_relabel (j : Fin k) :
-    (D.relabel σ τ).IsCup (Sum.inr (τ j)) ↔ D.IsCup (Sum.inr j) := by
-  rw [isCup_inr_iff, isCup_inr_iff, isThrough_relabel_inr]
+theorem isCup_relabel_inr (j : Fin k) :
+    (D.relabel σ τ).IsCup (Sum.inr (τ j)) ↔ D.IsCup (Sum.inr j) :=
+  Sum.map_inr σ τ j ▸ isCup_relabel D σ τ (Sum.inr j)
 
 /-- The capped bottom points of a relabelled diagram are the renamed capped bottom points. -/
 theorem bottomCap_relabel : (D.relabel σ τ).bottomCap = D.bottomCap.image σ := by
   ext i
   rw [mem_bottomCap, Finset.mem_image]
   refine ⟨fun hi => ⟨σ.symm i, (mem_bottomCap _).mpr ?_, σ.apply_symm_apply i⟩, ?_⟩
-  · rwa [← isCap_relabel D σ τ (σ.symm i), Equiv.apply_symm_apply]
+  · rwa [← isCap_relabel_inl D σ τ (σ.symm i), Equiv.apply_symm_apply]
   · rintro ⟨i', hi', rfl⟩
-    exact (isCap_relabel D σ τ i').mpr ((mem_bottomCap _).mp hi')
+    exact (isCap_relabel_inl D σ τ i').mpr ((mem_bottomCap _).mp hi')
 
 /-- The cupped top points of a relabelled diagram are the renamed cupped top points. -/
 theorem topCup_relabel : (D.relabel σ τ).topCup = D.topCup.image τ := by
   ext j
   rw [mem_topCup, Finset.mem_image]
   refine ⟨fun hj => ⟨τ.symm j, (mem_topCup _).mpr ?_, τ.apply_symm_apply j⟩, ?_⟩
-  · rwa [← isCup_relabel D σ τ (τ.symm j), Equiv.apply_symm_apply]
+  · rwa [← isCup_relabel_inr D σ τ (τ.symm j), Equiv.apply_symm_apply]
   · rintro ⟨j', hj', rfl⟩
-    exact (isCup_relabel D σ τ j').mpr ((mem_topCup _).mp hj')
+    exact (isCup_relabel_inr D σ τ j').mpr ((mem_topCup _).mp hj')
 
 /-- The bottom endpoints of the through strands of a relabelled diagram are the renamed ones. -/
 theorem bottomThrough_relabel : (D.relabel σ τ).bottomThrough = D.bottomThrough.image σ := by
@@ -221,72 +223,5 @@ theorem card_topThrough_relabel : (D.relabel σ τ).topThrough.card = D.topThrou
   rw [topThrough_relabel, Finset.card_image_of_injective _ τ.injective]
 
 end BrauerDiagram
-
-/-! ### Stacking with a permutation diagram -/
-
-variable {k : ℕ} (D : BrauerDiagram k) (σ τ : Equiv.Perm (Fin k))
-
-open BrauerDiagram in
-/-- **Stacking a permutation diagram on top relabels the top boundary.** No strand of `D` is
-extended past the middle boundary, because the permutation diagram has no cap: a through strand of
-`D` ending at the middle point `a` is continued by the single strand of `permToBrauer σ` above it,
-which leaves at the top point `σ a`. -/
-theorem composeDiagram_permToBrauer_left : composeDiagram (permToBrauer σ) D = D.relabel 1 σ := by
-  refine Subtype.ext (Equiv.ext fun x => ?_)
-  rcases x with i | j
-  · rcases h : D.val (Sum.inl i) with i' | a
-    · rw [composeDiagram_val_inl_eq_inl_of_cap_lower _ D h]
-      simp [h, Equiv.Perm.one_def]
-    · rw [composeDiagram_val_inl_eq_inr_of_through (D₁ := permToBrauer σ) (D₂ := D) (j := σ a) h
-        (permToBrauer_val_inl σ a)]
-      simp [h, Equiv.Perm.one_def]
-  · rcases h : D.val (Sum.inr (σ.symm j)) with i | a
-    · rw [composeDiagram_val_inr_eq_inl_of_through (D₁ := permToBrauer σ) (D₂ := D)
-        (a := σ.symm j) (permToBrauer_val_inr σ j) h]
-      simp [h, Equiv.Perm.one_def]
-    · rw [composeDiagram_val_inr_eq_inr_of_cup_lower (D₁ := permToBrauer σ) (D₂ := D)
-        (a := σ.symm j) (j' := σ a) (permToBrauer_val_inr σ j) h (permToBrauer_val_inl σ a)]
-      simp [h, Equiv.Perm.one_def]
-
-open BrauerDiagram in
-/-- **Stacking a permutation diagram underneath relabels the bottom boundary.** No strand of `D`
-is extended past the middle boundary, because the permutation diagram has no cup: the strand of
-`permToBrauer τ` starting at the bottom point `i` reaches the middle point `τ i`, where the arc of
-`D` takes over. -/
-theorem composeDiagram_permToBrauer_right :
-    composeDiagram D (permToBrauer τ) = D.relabel τ⁻¹ 1 := by
-  refine Subtype.ext (Equiv.ext fun x => ?_)
-  rcases x with i | j
-  · rcases h : D.val (Sum.inl (τ i)) with a' | j'
-    · rw [composeDiagram_val_inl_eq_inl_of_cap_upper (D₁ := D) (D₂ := permToBrauer τ) (a := τ i)
-        (i' := τ.symm a') (permToBrauer_val_inl τ i) h (permToBrauer_val_inr τ a')]
-      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
-    · rw [composeDiagram_val_inl_eq_inr_of_through (D₁ := D) (D₂ := permToBrauer τ) (a := τ i)
-        (permToBrauer_val_inl τ i) h]
-      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
-  · rcases h : D.val (Sum.inr j) with a | j'
-    · rw [composeDiagram_val_inr_eq_inl_of_through (D₁ := D) (D₂ := permToBrauer τ) (a := a)
-        h (permToBrauer_val_inr τ a)]
-      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
-    · rw [composeDiagram_val_inr_eq_inr_of_cup_upper (D₁ := D) (D₂ := permToBrauer τ) h]
-      simp [h, Equiv.Perm.inv_def, Equiv.Perm.one_def]
-
-/-- **Stacking permutation diagrams multiplies the permutations.** So the inclusion of the
-symmetric group into the Brauer diagrams turns the group law into vertical stacking; no loop
-closes up in the middle, since a permutation diagram has neither a cap nor a cup. -/
-@[simp]
-theorem composeDiagram_permToBrauer :
-    composeDiagram (permToBrauer σ) (permToBrauer τ) = permToBrauer (σ * τ) := by
-  rw [composeDiagram_permToBrauer_left, BrauerDiagram.relabel_permToBrauer, inv_one, mul_one]
-
-/-- **The identity diagram is a left identity for stacking.** -/
-@[simp]
-theorem composeDiagram_permToBrauer_one_left : composeDiagram (permToBrauer 1) D = D := by
-  rw [composeDiagram_permToBrauer_left, BrauerDiagram.relabel_one_one]
-
-/-- **The identity diagram is a right identity for stacking.** -/
-@[simp]
-theorem composeDiagram_permToBrauer_one_right : composeDiagram D (permToBrauer 1) = D := by
-  rw [composeDiagram_permToBrauer_right, inv_one, BrauerDiagram.relabel_one_one]
 
 end TauCeti

--- a/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
+++ b/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
@@ -269,6 +269,7 @@ theorem congr_refl (D : PerfectMatching α) : congr (Equiv.refl α) D = D :=
 
 /-- **Transports compose**: transporting along `e` and then along `e'` is transporting along
 `e.trans e'`, both matchings sending `c` to `e' (e (D.val (e.symm (e'.symm c))))`. -/
+@[simp]
 theorem congr_trans (e : α ≃ β) (e' : β ≃ γ) (D : PerfectMatching α) :
     congr e' (congr e D) = congr (e.trans e') D :=
   Subtype.ext <| Equiv.ext fun c => by

--- a/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
+++ b/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
@@ -14,10 +14,10 @@ public import Mathlib.Data.Nat.Factorial.DoubleFactorial
 
 A **perfect matching** of a type `α` is a permutation of `α` that is an involution without
 fixed points; equivalently, it partitions `α` into the unordered pairs `{a, f a}`. This file
-defines perfect matchings, shows that a perfect matching restricted to the complement of one
-of its arcs is again a perfect matching, and counts the perfect matchings of a finite type:
-a type of cardinality `2 * m` has `(2 * m - 1)‼` of them, and a type of odd cardinality has
-none.
+defines perfect matchings, transports them along an equivalence of the underlying types, shows
+that a perfect matching restricted to the complement of one of its arcs is again a perfect
+matching, and counts the perfect matchings of a finite type: a type of cardinality `2 * m` has
+`(2 * m - 1)‼` of them, and a type of odd cardinality has none.
 
 The counting theorem is the combinatorial content behind the dimension of the Brauer algebra;
 see `TauCeti/Combinatorics/Brauer/Diagram.lean`.
@@ -26,6 +26,7 @@ see `TauCeti/Combinatorics/Brauer/Diagram.lean`.
 
 * `TauCeti.IsPerfectMatching f`: the permutation `f` is an involution with no fixed point.
 * `TauCeti.PerfectMatching α`: the type of perfect matchings of `α`.
+* `TauCeti.PerfectMatching.congr`: transporting a perfect matching along an equivalence.
 * `TauCeti.PerfectMatching.restrict`: the perfect matching induced on the complement of an arc.
 * `TauCeti.PerfectMatching.extend`: the perfect matching obtained by adjoining an arc.
 * `TauCeti.PerfectMatching.fiberEquiv`: the two constructions above are mutually inverse.
@@ -48,9 +49,9 @@ open scoped Nat
 
 namespace TauCeti
 
-universe u
+universe u v w
 
-variable {α : Type u}
+variable {α : Type u} {β : Type v} {γ : Type w}
 
 /-- A permutation of `α` is a **perfect matching** when it is an involution with no fixed
 point, so that it pairs off the elements of `α`. -/
@@ -223,6 +224,55 @@ theorem fiberEquiv_symm_apply (hab : a ≠ b) (E : PerfectMatching {x : α // x 
     ((fiberEquiv hab).symm E : PerfectMatching α) = extend hab E := (rfl)
 
 end Extend
+
+section Congr
+
+/-- Transporting an involution without fixed points along an equivalence leaves it an involution
+without fixed points. -/
+theorem isPerfectMatching_permCongr (e : α ≃ β) {f : Equiv.Perm α} (hf : IsPerfectMatching f) :
+    IsPerfectMatching (e.permCongr f) := by
+  refine ⟨fun b => by simp [hf.1], fun b hb => hf.2 (e.symm b) ?_⟩
+  simpa using congrArg e.symm hb
+
+/-- A permutation is a perfect matching exactly when its transport along an equivalence is. -/
+theorem isPerfectMatching_permCongr_iff (e : α ≃ β) {f : Equiv.Perm α} :
+    IsPerfectMatching (e.permCongr f) ↔ IsPerfectMatching f := by
+  refine ⟨fun h => ?_, isPerfectMatching_permCongr e⟩
+  have hf : e.symm.permCongr (e.permCongr f) = f := by
+    rw [← Equiv.permCongr_symm, Equiv.symm_apply_apply]
+  exact hf ▸ isPerfectMatching_permCongr e.symm h
+
+/-- **Transporting a perfect matching along an equivalence** of the underlying types: the arc
+joining `a` to `b` becomes the arc joining `e a` to `e b`. -/
+def congr (e : α ≃ β) : PerfectMatching α ≃ PerfectMatching β :=
+  e.permCongr.subtypeEquiv fun _ => (isPerfectMatching_permCongr_iff e).symm
+
+@[simp]
+theorem congr_val (e : α ≃ β) (D : PerfectMatching α) :
+    (congr e D).val = e.permCongr D.val := (rfl)
+
+/-- The transported matching matches `b` with the image of the partner of `e.symm b`. -/
+theorem congr_val_apply (e : α ≃ β) (D : PerfectMatching α) (b : β) :
+    (congr e D).val b = e (D.val (e.symm b)) := (rfl)
+
+/-- The transported matching matches `e a` with the image of the partner of `a`. -/
+theorem congr_val_apply_apply (e : α ≃ β) (D : PerfectMatching α) (a : α) :
+    (congr e D).val (e a) = e (D.val a) := by
+  rw [congr_val_apply, Equiv.symm_apply_apply]
+
+@[simp]
+theorem congr_refl (D : PerfectMatching α) : congr (Equiv.refl α) D = D :=
+  Subtype.ext (Equiv.ext fun _ => rfl)
+
+theorem congr_trans (e : α ≃ β) (e' : β ≃ γ) (D : PerfectMatching α) :
+    congr e' (congr e D) = congr (e.trans e') D :=
+  Subtype.ext (Equiv.ext fun _ => rfl)
+
+@[simp]
+theorem congr_symm (e : α ≃ β) : (congr e).symm = congr e.symm :=
+  Equiv.ext fun _ => Subtype.ext (Equiv.ext fun _ => rfl)
+
+end Congr
 
 end PerfectMatching
 

--- a/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
+++ b/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
@@ -247,6 +247,7 @@ joining `a` to `b` becomes the arc joining `e a` to `e b`. -/
 def congr (e : α ≃ β) : PerfectMatching α ≃ PerfectMatching β :=
   e.permCongr.subtypeEquiv fun _ => (isPerfectMatching_permCongr_iff e).symm
 
+/-- The involution underlying a transported matching is the transported involution. -/
 @[simp]
 theorem congr_val (e : α ≃ β) (D : PerfectMatching α) :
     (congr e D).val = e.permCongr D.val := (rfl)
@@ -260,17 +261,25 @@ theorem congr_val_apply_apply (e : α ≃ β) (D : PerfectMatching α) (a : α) 
     (congr e D).val (e a) = e (D.val a) := by
   rw [congr_val_apply, Equiv.symm_apply_apply]
 
+/-- Transporting along the identity equivalence changes nothing. -/
 @[simp]
 theorem congr_refl (D : PerfectMatching α) : congr (Equiv.refl α) D = D :=
-  Subtype.ext (Equiv.ext fun _ => rfl)
+  Subtype.ext <| Equiv.ext fun a => by
+    rw [congr_val_apply, Equiv.refl_symm, Equiv.refl_apply, Equiv.refl_apply]
 
+/-- **Transports compose**: transporting along `e` and then along `e'` is transporting along
+`e.trans e'`, both matchings sending `c` to `e' (e (D.val (e.symm (e'.symm c))))`. -/
 theorem congr_trans (e : α ≃ β) (e' : β ≃ γ) (D : PerfectMatching α) :
     congr e' (congr e D) = congr (e.trans e') D :=
-  Subtype.ext (Equiv.ext fun _ => rfl)
+  Subtype.ext <| Equiv.ext fun c => by
+    rw [congr_val_apply, congr_val_apply, congr_val_apply, Equiv.symm_trans_apply,
+      Equiv.trans_apply]
 
+/-- Transporting back along `e` is transporting along `e.symm`, since transports compose. -/
 @[simp]
 theorem congr_symm (e : α ≃ β) : (congr e).symm = congr e.symm :=
-  Equiv.ext fun _ => Subtype.ext (Equiv.ext fun _ => rfl)
+  Equiv.ext fun D => by
+    rw [Equiv.symm_apply_eq, congr_trans, Equiv.symm_trans_self, congr_refl]
 
 end Congr
 


### PR DESCRIPTION
This PR identifies stacking a Brauer diagram with a permutation diagram as a renaming of the boundary. A permutation diagram has neither a cap nor a cup, so no strand of the other diagram is extended past the middle boundary when the two are stacked; only the points at which those strands end get renamed. `TauCeti.BrauerDiagram.relabel` renames the bottom points of a diagram by `σ` and its top points by `τ` — the conjugation of the underlying perfect matching by `Equiv.Perm.sumCongr σ τ` — and `TauCeti.composeDiagram_permToBrauer_left` and `TauCeti.composeDiagram_permToBrauer_right` say that stacking `permToBrauer σ` above `D`, or `permToBrauer τ` below it, is exactly `D.relabel 1 σ` and `D.relabel τ⁻¹ 1`. The corollary that Layer 9 needs is `TauCeti.composeDiagram_permToBrauer`: stacking two permutation diagrams gives the permutation diagram of the product, so `permToBrauer` turns the group law of `Sₖ` into vertical stacking, which is the load-bearing lemma for the roadmap's `permToBrauer : ℂ[Sₖ] →ₐ[ℂ] brauerAlgebra δ k` and the sense in which the symmetric group sits inside the Brauer algebra. Relabelling composes by multiplying the permutations, so it is an action of `Sₖ × Sₖ` on the diagrams, and it preserves the kinds of the arcs, hence the numbers of caps, cups and through strands — the statistic that stratifies the Brauer algebra is constant on each orbit. The two identity lemmas `composeDiagram_permToBrauer_one_left` and `composeDiagram_permToBrauer_one_right` were the special case `σ = 1` of this, so they move out of `TauCeti/Combinatorics/Brauer/Compose.lean` into the new file and are now one-line consequences of the general statements rather than separate case analyses; their names and statements are unchanged. As a prerequisite, `TauCeti.PerfectMatching.congr` transports a perfect matching along an equivalence of the underlying types, in `TauCeti/Combinatorics/Enumerative/PerfectMatching.lean`, the file that owns perfect matchings; relabelling is its specialization. No Mathlib source was vendored.

The roadmap target is `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 9 ("Schur-Weyl duality for the orthogonal and symplectic groups (the Brauer algebra)"), whose bullet "Brauer diagrams and the Brauer algebra" asks for the diagram API "as named build items: the edge-type predicates `isThrough`/`isCap`/`isCup` on a diagram's arcs, the permutation-diagram inclusion `permToBrauer` (the `k!` no-arcs matchings), the composition `composeDiagram D₁ D₂` on the underlying matchings, the middle-loop count `middleLoopCount D₁ D₂`, and the associativity of the loop-weighted composition". `permToBrauer` and `composeDiagram` are already in the repository; this PR supplies how those two named build items interact, which is what `SchurWeyl/Suggested.lean`'s `permToBrauer (δ : ℂ) (k : ℕ) : MonoidAlgebra ℂ (Equiv.Perm (Fin k)) →ₐ[ℂ] brauerAlgebra δ k` needs in order to be an algebra map. The middle-loop count and the associativity of the loop-weighted composition are not built here.

Verified locally against the pinned Mathlib: `lake build` completes with `Build completed successfully (7642 jobs)`, `lake exe axioms` reports `audited 42291 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound]`, `lake exe module-system` reports all modules opting into the module system, and `scripts/lint-env.sh` reports `LINT-ENV: PASS — no new violations (70 grandfathered, 0 ratchetable)`.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"composediagram-permtobrauer"}-->

🤖 Prepared with Claude Code
