### PR TITLE
refactor(HopfIdeal): name the substantive direction of isNormal_iff_quotientPointsSubgroup_normal

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
@@ -109,52 +109,57 @@ theorem quotientPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
     simpa using hn y ((HopfIdeal.mem_toIdeal (I := I)).mp hy)
   exact RingHom.mem_ker.mp (hker (hI.conjugation_mem hx))
 
+/-- If a Hopf ideal cuts out a normal subgroup over every commutative value algebra, then
+it is normal. -/
+private theorem isNormal_of_forall_quotientPointsSubgroup_normal
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H)
+    (hnormal : ∀ A : CommAlgCat.{v} R, (quotientPointsSubgroup H I A).Normal) :
+    I.IsNormal := by
+  rw [HopfIdeal.isNormal_iff_conjugation_mem]
+  intro x hx
+  let Q := H ⧸ I.toIdeal
+  let A : CommAlgCat R := CommAlgCat.of R (TensorProduct R H Q)
+  let g : HopfAlgebra.points (R := R) (H := H) A :=
+    toConv Algebra.TensorProduct.includeLeft
+  let n : HopfAlgebra.points (R := R) (H := H) A :=
+    quotientPointsHom H I A (toConv Algebra.TensorProduct.includeRight)
+  have hn : n ∈ quotientPointsSubgroup H I A :=
+    quotientPointsHom_mem_quotientPointsSubgroup H I A _
+  have hgof : g.ofConv = (Algebra.TensorProduct.includeLeft : H →ₐ[R] TensorProduct R H Q) :=
+    ofConv_toConv _
+  have hnof : n.ofConv =
+      (Algebra.TensorProduct.includeRight : Q →ₐ[R] TensorProduct R H Q).comp
+        (Ideal.Quotient.mkₐ R I.toIdeal) :=
+    AlgHom.ext fun h => quotientPointsHom_apply_apply H I A _ h
+  have hconj := (hnormal A).conj_mem n hn g
+  rw [mem_quotientPointsSubgroup_iff] at hconj
+  have hzero := hconj x hx
+  have heval :
+      (Algebra.TensorProduct.productMap g.ofConv n.ofConv)
+          (HopfAlgebra.conjugationAlgHom (R := R) (H := H) x) = 0 :=
+    (AlgHom.congr_fun
+      (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := H) g n) x).trans hzero
+  have hproduct :
+      Algebra.TensorProduct.productMap g.ofConv n.ofConv =
+        Algebra.TensorProduct.map (AlgHom.id R H) (Ideal.Quotient.mkₐ R I.toIdeal) := by
+    rw [hgof, hnof]
+    refine Algebra.TensorProduct.ext ?_ ?_
+    · rw [Algebra.TensorProduct.productMap_left,
+        Algebra.TensorProduct.map_comp_includeLeft, AlgHom.comp_id]
+    · exact (Algebra.TensorProduct.productMap_right _ _).trans
+        (Algebra.TensorProduct.map_comp_includeRight _ _).symm
+  rw [hproduct] at heval
+  have hmem := RingHom.mem_ker.mpr heval
+  rw [HopfIdeal.ker_tensorProduct_map_id_quotient I.toIdeal] at hmem
+  exact hmem
+
 /-- A Hopf ideal is normal if and only if it cuts out a normal subgroup over every
 commutative value algebra. -/
 theorem isNormal_iff_quotientPointsSubgroup_normal
     (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
-    I.IsNormal ↔ ∀ A : CommAlgCat.{v} R, (quotientPointsSubgroup H I A).Normal := by
-  constructor
-  · intro hI A
-    exact quotientPointsSubgroup_normal H I hI A
-  · intro hnormal
-    rw [HopfIdeal.isNormal_iff_conjugation_mem]
-    intro x hx
-    let Q := H ⧸ I.toIdeal
-    let A : CommAlgCat R := CommAlgCat.of R (TensorProduct R H Q)
-    let g : HopfAlgebra.points (R := R) (H := H) A :=
-      toConv Algebra.TensorProduct.includeLeft
-    let n : HopfAlgebra.points (R := R) (H := H) A :=
-      quotientPointsHom H I A (toConv Algebra.TensorProduct.includeRight)
-    have hn : n ∈ quotientPointsSubgroup H I A :=
-      quotientPointsHom_mem_quotientPointsSubgroup H I A _
-    have hgof : g.ofConv = (Algebra.TensorProduct.includeLeft : H →ₐ[R] TensorProduct R H Q) :=
-      ofConv_toConv _
-    have hnof : n.ofConv =
-        (Algebra.TensorProduct.includeRight : Q →ₐ[R] TensorProduct R H Q).comp
-          (Ideal.Quotient.mkₐ R I.toIdeal) :=
-      AlgHom.ext fun h => quotientPointsHom_apply_apply H I A _ h
-    have hconj := (hnormal A).conj_mem n hn g
-    rw [mem_quotientPointsSubgroup_iff] at hconj
-    have hzero := hconj x hx
-    have heval :
-        (Algebra.TensorProduct.productMap g.ofConv n.ofConv)
-            (HopfAlgebra.conjugationAlgHom (R := R) (H := H) x) = 0 :=
-      (AlgHom.congr_fun
-        (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := H) g n) x).trans hzero
-    have hproduct :
-        Algebra.TensorProduct.productMap g.ofConv n.ofConv =
-          Algebra.TensorProduct.map (AlgHom.id R H) (Ideal.Quotient.mkₐ R I.toIdeal) := by
-      rw [hgof, hnof]
-      refine Algebra.TensorProduct.ext ?_ ?_
-      · rw [Algebra.TensorProduct.productMap_left,
-          Algebra.TensorProduct.map_comp_includeLeft, AlgHom.comp_id]
-      · exact (Algebra.TensorProduct.productMap_right _ _).trans
-          (Algebra.TensorProduct.map_comp_includeRight _ _).symm
-    rw [hproduct] at heval
-    have hmem := RingHom.mem_ker.mpr heval
-    rw [HopfIdeal.ker_tensorProduct_map_id_quotient I.toIdeal] at hmem
-    exact hmem
+    I.IsNormal ↔ ∀ A : CommAlgCat.{v} R, (quotientPointsSubgroup H I A).Normal :=
+  ⟨fun hI A => quotientPointsSubgroup_normal H I hI A,
+    isNormal_of_forall_quotientPointsSubgroup_normal H I⟩
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
@@ -109,11 +109,13 @@ theorem quotientPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
     simpa using hn y ((HopfIdeal.mem_toIdeal (I := I)).mp hy)
   exact RingHom.mem_ker.mp (hker (hI.conjugation_mem hx))
 
-/-- If a Hopf ideal cuts out a normal subgroup over every commutative value algebra, then
-it is normal. -/
-private theorem isNormal_of_forall_quotientPointsSubgroup_normal
+/-- If a Hopf ideal cuts out a normal subgroup over the value algebra `H ⊗ (H ⧸ I)`, then it is
+normal. That single test algebra suffices: it carries the two points whose conjugate detects
+membership in the ideal. -/
+private theorem isNormal_of_quotientPointsSubgroup_normal
     (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H)
-    (hnormal : ∀ A : CommAlgCat.{v} R, (quotientPointsSubgroup H I A).Normal) :
+    (hnormal : (quotientPointsSubgroup H I
+      (CommAlgCat.of R (TensorProduct R H (H ⧸ I.toIdeal)))).Normal) :
     I.IsNormal := by
   rw [HopfIdeal.isNormal_iff_conjugation_mem]
   intro x hx
@@ -131,7 +133,7 @@ private theorem isNormal_of_forall_quotientPointsSubgroup_normal
       (Algebra.TensorProduct.includeRight : Q →ₐ[R] TensorProduct R H Q).comp
         (Ideal.Quotient.mkₐ R I.toIdeal) :=
     AlgHom.ext fun h => quotientPointsHom_apply_apply H I A _ h
-  have hconj := (hnormal A).conj_mem n hn g
+  have hconj := hnormal.conj_mem n hn g
   rw [mem_quotientPointsSubgroup_iff] at hconj
   have hzero := hconj x hx
   have heval :
@@ -159,7 +161,7 @@ theorem isNormal_iff_quotientPointsSubgroup_normal
     (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
     I.IsNormal ↔ ∀ A : CommAlgCat.{v} R, (quotientPointsSubgroup H I A).Normal :=
   ⟨fun hI A => quotientPointsSubgroup_normal H I hI A,
-    isNormal_of_forall_quotientPointsSubgroup_normal H I⟩
+    fun hnormal => isNormal_of_quotientPointsSubgroup_normal H I (hnormal _)⟩
 
 end CommHopfAlgCat
 


### PR DESCRIPTION
`isNormal_iff_quotientPointsSubgroup_normal` is an `iff` whose two halves are very unequal. The
forward direction was two lines delegating to the named `quotientPointsSubgroup_normal`; the
backward direction was thirty-seven lines of anonymous argument inside a `constructor` bullet.

The backward direction now has a name too: `isNormal_of_quotientPointsSubgroup_normal`. That is the
substantive half, and it is where the construction lives: the value algebra `H ⊗ (H ⧸ I)`, the two
points on it, and the identification of their product map with `TensorProduct.map id (mkₐ)`.

The file already treated the two directions asymmetrically — one named, one buried — and the
asymmetry was not mathematical. With both named, the `iff` becomes a term-mode pairing of them and
carries no proof of its own.

The extracted hypothesis is weaker than the one the `iff` supplies. The `iff` assumes normality over
*every* commutative value algebra, but the argument evaluates that assumption once, at
`H ⊗ (H ⧸ I)` — the algebra it builds in order to have the two points whose conjugate detects
membership. So the direction is stated with normality at that single test algebra, and the `iff`
specialises its universal hypothesis when applying it.

The `iff` drops from 42 tactic lines to none; the extracted direction is 38. The file grows by five
lines, which is the cost of the second signature.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: ReductiveGroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
