### PR TITLE
refactor(Comodule): name the universal-point direction of map_coact_iff_baseChange_comp_endOfPoint

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Morphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Morphism.lean
@@ -83,6 +83,52 @@ section IndependentCarrierUniverses
 
 variable {W : Type x} [AddCommMonoid W] [Module R W]
 
+/-- **Intertwining at the universal point suffices for colinearity.** A linear map between two
+right comodules is colinear as soon as its scalar extension to `ULift H` intertwines the point
+actions of the universal point; no condition at other value algebras is needed. -/
+private theorem map_coact_of_baseChange_comp_endOfPoint_universal
+    (rho : Comodule R H V) (sigma : Comodule R H W) (f : V →ₗ[R] W)
+    (huniv : f.baseChange (CommAlgCat.of R (ULift.{max u v w x} H)) ∘ₗ
+          Comodule.endOfPoint V
+            (toConv ULift.algEquiv.symm.toAlgHom :
+              points (H := H) (CommAlgCat.of R (ULift.{max u v w x} H))).ofConv =
+        Comodule.endOfPoint W
+            (toConv ULift.algEquiv.symm.toAlgHom :
+              points (H := H) (CommAlgCat.of R (ULift.{max u v w x} H))).ofConv ∘ₗ
+          f.baseChange (CommAlgCat.of R (ULift.{max u v w x} H))) :
+    TensorProduct.map f LinearMap.id ∘ₗ rho.coact = sigma.coact ∘ₗ f := by
+  apply LinearMap.ext
+  intro z
+  simp only [LinearMap.comp_apply]
+  rw [coact_apply_eq_universal_endOfPoint W rho z,
+    coact_apply_eq_universal_endOfPoint V sigma (f z)]
+  have huniversal := LinearMap.congr_fun huniv (1 ⊗ₜ[R] z)
+  simp only [LinearMap.comp_apply, LinearMap.baseChange_tmul] at huniversal
+  have hdown := congrArg
+    (TensorProduct.map ULift.algEquiv.toLinearMap
+      (LinearMap.id : W →ₗ[R] W)) huniversal
+  calc
+    TensorProduct.map f LinearMap.id
+        (TensorProduct.comm R H V
+          (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
+            (Comodule.endOfPoint V ULift.algEquiv.symm.toAlgHom (1 ⊗ₜ[R] z)))) =
+      TensorProduct.comm R H W
+        (f.lTensor H
+          (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
+            (Comodule.endOfPoint V ULift.algEquiv.symm.toAlgHom (1 ⊗ₜ[R] z)))) := by
+        exact LinearMap.rTensor_comm f _
+    _ = TensorProduct.comm R H W
+        (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
+          (f.baseChange (ULift.{max u v w x} H)
+            (Comodule.endOfPoint V ULift.algEquiv.symm.toAlgHom (1 ⊗ₜ[R] z)))) := by
+        congr 1
+        simp only [LinearMap.baseChange_eq_ltensor, LinearMap.lTensor_def,
+          TensorProduct.map_map, LinearMap.comp_id, LinearMap.id_comp]
+    _ = TensorProduct.comm R H W
+        (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
+          (Comodule.endOfPoint W ULift.algEquiv.symm.toAlgHom (1 ⊗ₜ[R] f z))) := by
+        rw [hdown]
+
 /-- A linear map between two right comodules is colinear if and only if all its scalar extensions
 intertwine their point actions.
 
@@ -103,39 +149,8 @@ theorem map_coact_iff_baseChange_comp_endOfPoint
     intro A p
     simpa only [fHom] using Comodule.baseChange_comp_endOfPoint fHom p.ofConv
   · intro hintertwines
-    apply LinearMap.ext
-    intro z
-    simp only [LinearMap.comp_apply]
-    rw [coact_apply_eq_universal_endOfPoint W rho z,
-      coact_apply_eq_universal_endOfPoint V sigma (f z)]
-    have huniversal := LinearMap.congr_fun
-      (hintertwines (CommAlgCat.of R (ULift.{max u v w x} H))
-        (toConv ULift.algEquiv.symm.toAlgHom)) (1 ⊗ₜ[R] z)
-    simp only [LinearMap.comp_apply, LinearMap.baseChange_tmul] at huniversal
-    have hdown := congrArg
-      (TensorProduct.map ULift.algEquiv.toLinearMap
-        (LinearMap.id : W →ₗ[R] W)) huniversal
-    calc
-      TensorProduct.map f LinearMap.id
-          (TensorProduct.comm R H V
-            (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
-              (Comodule.endOfPoint V ULift.algEquiv.symm.toAlgHom (1 ⊗ₜ[R] z)))) =
-        TensorProduct.comm R H W
-          (f.lTensor H
-            (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
-              (Comodule.endOfPoint V ULift.algEquiv.symm.toAlgHom (1 ⊗ₜ[R] z)))) := by
-          exact LinearMap.rTensor_comm f _
-      _ = TensorProduct.comm R H W
-          (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
-            (f.baseChange (ULift.{max u v w x} H)
-              (Comodule.endOfPoint V ULift.algEquiv.symm.toAlgHom (1 ⊗ₜ[R] z)))) := by
-          congr 1
-          simp only [LinearMap.baseChange_eq_ltensor, LinearMap.lTensor_def,
-            TensorProduct.map_map, LinearMap.comp_id, LinearMap.id_comp]
-      _ = TensorProduct.comm R H W
-          (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
-            (Comodule.endOfPoint W ULift.algEquiv.symm.toAlgHom (1 ⊗ₜ[R] f z))) := by
-          rw [hdown]
+    exact map_coact_of_baseChange_comp_endOfPoint_universal rho sigma f
+      (hintertwines _ _)
 
 end IndependentCarrierUniverses
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Morphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Morphism.lean
@@ -21,6 +21,8 @@ algebras, including nonreduced ones.
 
 ## Main declarations
 
+* `TauCeti.HopfAlgebra.PointRepresentation.map_coact_of_baseChange_comp_endOfPoint_universal`:
+  intertwining at the universal point alone already forces colinearity.
 * `TauCeti.HopfAlgebra.PointRepresentation.map_coact_iff_baseChange_comp_endOfPoint`: the
   fixed-morphism criterion for explicit comodules with carriers in independent universes.
 * `TauCeti.HopfAlgebra.PointRepresentation.map_coact_iff_baseChange_comp_action`: the
@@ -86,7 +88,7 @@ variable {W : Type x} [AddCommMonoid W] [Module R W]
 /-- **Intertwining at the universal point suffices for colinearity.** A linear map between two
 right comodules is colinear as soon as its scalar extension to `ULift H` intertwines the point
 actions of the universal point; no condition at other value algebras is needed. -/
-private theorem map_coact_of_baseChange_comp_endOfPoint_universal
+theorem map_coact_of_baseChange_comp_endOfPoint_universal
     (rho : Comodule R H V) (sigma : Comodule R H W) (f : V →ₗ[R] W)
     (huniv : f.baseChange (CommAlgCat.of R (ULift.{max u v w x} H)) ∘ₗ
           Comodule.endOfPoint V


### PR DESCRIPTION
`map_coact_iff_baseChange_comp_endOfPoint` is an `iff` with very unequal halves. The forward
direction is six lines bundling `f` as a `Comodule.Hom` and quoting
`Comodule.baseChange_comp_endOfPoint`. The backward direction was thirty-two lines of anonymous
`calc` inside a `constructor` bullet.

That half is now `map_coact_of_baseChange_comp_endOfPoint_universal`, and naming it exposes what the
argument actually proves. The `iff`'s right-hand side quantifies over every value algebra and every
point, but the proof consumes that hypothesis exactly once, at the universal point — the algebra
`ULift H` with the point `toConv ULift.algEquiv.symm.toAlgHom`. So the extracted statement assumes
only that one intertwining equation, and it says something the `iff` does not: intertwining at the
universal point already forces colinearity, and no condition at any other value algebra is needed.

The `iff` then applies it with `hintertwines _ _`, specialising its universal hypothesis at the point
of use.

Because that statement is strictly stronger than the direction it replaces — it needs one equation
where the `iff` demands a family of them — it is exported rather than kept `private`, and listed in
the module's main declarations alongside the three criteria it now sits under.

The `iff` drops from 42 lines to 11; the extracted direction is 32. The file grows by fifteen lines,
which is the cost of spelling out the universal point in a signature rather than leaving it inside
the proof.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: ReductiveGroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
