### PR TITLE
feat: the Weyl automorphism of an sl₂ triple

### DIFF
--- a/TauCeti/Algebra/Lie/InnerAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/InnerAutomorphism.lean
@@ -31,16 +31,17 @@ occurs inside an `sl₂` triple.
 
 The exponential needs to divide by factorials, so `L` must be a `ℚ`-module. Following
 `LieDerivation.exp`, this is carried by an unbundled `[LieAlgebra ℚ L]` hypothesis alongside the
-base ring `K`; no compatibility between the two is assumed, because
-`Rat.cast_smul_eq_qsmul` supplies it and `Mathlib/Algebra/Lie/Basic.lean` proves
-`Subsingleton (LieAlgebra ℚ L)`, so the hypothesis names a structure rather than choosing one.
-Over a field of characteristic zero it is always available: `TauCeti.ratLieAlgebra` builds it by
+base ring `K`. No compatibility between the two actions is assumed, and none is needed: an additive
+group carries at most one `ℚ`-module structure, so the hypothesis names a structure rather than
+choosing one (`Subsingleton (LieAlgebra ℚ L)`, in `Mathlib/Algebra/Lie/Basic.lean`). Where a
+computation does mix the two scalar actions it goes through the `ℕ`-action that both refine, using
+`Nat.cast_smul_eq_nsmul`. Whenever `K` is itself a `ℚ`-algebra — in particular whenever it is a
+field of characteristic zero — such a structure exists: `TauCeti.ratLieAlgebra` builds it by
 restricting scalars along `algebraMap ℚ K`.
 
 ## Main definitions
 
-* `TauCeti.ratLieAlgebra`: the `ℚ`-Lie-algebra structure on a Lie algebra over a
-  characteristic-zero field.
+* `TauCeti.ratLieAlgebra`: the `ℚ`-Lie-algebra structure on a Lie algebra over a `ℚ`-algebra.
 * `TauCeti.expAd`: the inner automorphism `exp (ad x)` of an `ad`-nilpotent element `x`.
 
 ## Main results
@@ -62,19 +63,19 @@ namespace TauCeti
 
 open Finset LieAlgebra
 
-/-- The `ℚ`-Lie-algebra structure on a Lie algebra `L` over a field `K` of characteristic zero,
-obtained by restricting scalars along `algebraMap ℚ K`.
+/-- The `ℚ`-Lie-algebra structure on a Lie algebra `L` over a `ℚ`-algebra `K`, obtained by
+restricting scalars along `algebraMap ℚ K`. A field of characteristic zero is such a `K`.
 
 This is deliberately a `def` and not an `instance`: `K` cannot be recovered from the goal
 `LieAlgebra ℚ L`, so instance search could never use it. It is what a consumer supplies with
 `letI := TauCeti.ratLieAlgebra K L` in order to apply `TauCeti.expAd` and everything built on it,
 and because `LieAlgebra ℚ L` is a subsingleton the choice is harmless. -/
 @[instance_reducible]
-noncomputable def ratLieAlgebra (K L : Type*) [Field K] [CharZero K] [LieRing L]
+noncomputable def ratLieAlgebra (K L : Type*) [CommRing K] [Algebra ℚ K] [LieRing L]
     [LieAlgebra K L] : LieAlgebra ℚ L :=
   letI : Module ℚ L := Module.compHom L (algebraMap ℚ K)
-  { lie_smul := fun q x y ↦
-      show ⁅x, algebraMap ℚ K q • y⁆ = algebraMap ℚ K q • ⁅x, y⁆ from lie_smul _ _ _ }
+  -- by construction `q • y` *is* `algebraMap ℚ K q • y`, so `lie_smul` over `K` is the axiom asked
+  { lie_smul := fun q x y ↦ lie_smul (algebraMap ℚ K q) x y }
 
 variable {K L : Type*} [CommRing K] [LieRing L] [LieAlgebra K L] [LieAlgebra ℚ L]
 
@@ -82,15 +83,12 @@ variable {K L : Type*} [CommRing K] [LieRing L] [LieAlgebra K L] [LieAlgebra ℚ
 It is `LieDerivation.exp` applied to the inner derivation `ad x`. -/
 noncomputable def expAd (x : L) (hx : IsNilpotent (ad K L x)) : L ≃ₗ⁅K⁆ L :=
   LieDerivation.exp (LieDerivation.ad K L x) <| by
-    rwa [show (LieDerivation.ad K L x).toLinearMap = ad K L x from by ext; simp]
+    rwa [LieDerivation.coe_ad_apply_eq_ad_apply]
 
 /-- `TauCeti.expAd` is the exponential of `LieAlgebra.ad x`. -/
 lemma expAd_apply (x : L) (hx : IsNilpotent (ad K L x)) (y : L) :
     expAd x hx y = IsNilpotent.exp (ad K L x) y := by
-  rw [expAd, LieDerivation.exp_map_apply]
-  congr 1
-  ext
-  simp
+  rw [expAd, LieDerivation.exp_map_apply, LieDerivation.coe_ad_apply_eq_ad_apply]
 
 /-- The exponential series for `exp (ad x)`, truncated at any length `k` for which `(ad x) ^ k`
 already annihilates the vector `y`. -/
@@ -107,6 +105,7 @@ lemma expAd_apply_of_lie_eq_zero {x y : L} (hx : IsNilpotent (ad K L x)) (hy : �
   simp
 
 /-- `exp (ad x)` fixes `x`. -/
+@[simp]
 lemma expAd_apply_self (x : L) (hx : IsNilpotent (ad K L x)) : expAd x hx x = x :=
   expAd_apply_of_lie_eq_zero hx (lie_self x)
 

--- a/TauCeti/Algebra/Lie/InnerAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/InnerAutomorphism.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Algebra.Rat
+public import Mathlib.Algebra.Lie.AdjointAction.Derivation
+public import Mathlib.Algebra.Lie.Derivation.Basic
+
+public section
+
+/-!
+# The inner automorphisms `exp (ad x)`
+
+If `x` is an element of a Lie algebra `L` whose adjoint action `ad x` is nilpotent, then over a
+base in which the factorials are invertible the finite sum `exp (ad x) = ∑ (i !)⁻¹ • (ad x)ⁱ` is an
+automorphism of `L`. These are the generators of the group `Int L` of inner automorphisms, and they
+are the Lie-algebra shadow of the root subgroups of a Chevalley group: for a root vector `e` of a
+split semisimple Lie algebra, `exp (ad e)` is the adjoint action of `x_α(1)`.
+
+Mathlib already exponentiates a nilpotent *derivation* (`LieDerivation.exp`) and knows that a root
+vector is `ad`-nilpotent (`LieAlgebra.isNilpotent_ad_of_mem_rootSpace`). This file specialises the
+first to the inner derivations `LieAlgebra.ad K L x` and records the truncations of the
+exponential series that a hand computation needs: `TauCeti.expAd_apply_of_lie_eq_zero`,
+`TauCeti.expAd_apply_of_lie_lie_eq_zero` and `TauCeti.expAd_apply_of_lie_lie_lie_eq_zero` evaluate
+`exp (ad x)` on a vector killed by one, two or three brackets with `x`, which is every case that
+occurs inside an `sl₂` triple.
+
+## The `ℚ`-structure hypothesis
+
+The exponential needs to divide by factorials, so `L` must be a `ℚ`-module. Following
+`LieDerivation.exp`, this is carried by an unbundled `[LieAlgebra ℚ L]` hypothesis alongside the
+base ring `K`; no compatibility between the two is assumed, because
+`Rat.cast_smul_eq_qsmul` supplies it and `Mathlib/Algebra/Lie/Basic.lean` proves
+`Subsingleton (LieAlgebra ℚ L)`, so the hypothesis names a structure rather than choosing one.
+Over a field of characteristic zero it is always available: `TauCeti.ratLieAlgebra` builds it by
+restricting scalars along `algebraMap ℚ K`.
+
+## Main definitions
+
+* `TauCeti.ratLieAlgebra`: the `ℚ`-Lie-algebra structure on a Lie algebra over a
+  characteristic-zero field.
+* `TauCeti.expAd`: the inner automorphism `exp (ad x)` of an `ad`-nilpotent element `x`.
+
+## Main results
+
+* `TauCeti.expAd_apply_eq_sum`: `exp (ad x)` is the truncated exponential series, truncated at any
+  length that already annihilates the vector it is applied to.
+* `TauCeti.expAd_apply_of_lie_eq_zero`, `TauCeti.expAd_apply_of_lie_lie_eq_zero`,
+  `TauCeti.expAd_apply_of_lie_lie_lie_eq_zero`: the resulting one-, two- and three-term formulas.
+* `TauCeti.expAd_apply_self`: `exp (ad x)` fixes `x`.
+
+## References
+
+* [J. Humphreys, *Introduction to Lie Algebras and Representation Theory*][humphreys1972], §2.3,
+  where `Int L` is introduced.
+* [R. W. Carter, *Simple Groups of Lie Type*][carter1972], §4.1.
+-/
+
+namespace TauCeti
+
+open Finset LieAlgebra
+
+/-- The `ℚ`-Lie-algebra structure on a Lie algebra `L` over a field `K` of characteristic zero,
+obtained by restricting scalars along `algebraMap ℚ K`.
+
+This is deliberately a `def` and not an `instance`: `K` cannot be recovered from the goal
+`LieAlgebra ℚ L`, so instance search could never use it. It is what a consumer supplies with
+`letI := TauCeti.ratLieAlgebra K L` in order to apply `TauCeti.expAd` and everything built on it,
+and because `LieAlgebra ℚ L` is a subsingleton the choice is harmless. -/
+@[instance_reducible]
+noncomputable def ratLieAlgebra (K L : Type*) [Field K] [CharZero K] [LieRing L]
+    [LieAlgebra K L] : LieAlgebra ℚ L :=
+  letI : Module ℚ L := Module.compHom L (algebraMap ℚ K)
+  { lie_smul := fun q x y ↦
+      show ⁅x, algebraMap ℚ K q • y⁆ = algebraMap ℚ K q • ⁅x, y⁆ from lie_smul _ _ _ }
+
+variable {K L : Type*} [CommRing K] [LieRing L] [LieAlgebra K L] [LieAlgebra ℚ L]
+
+/-- The inner automorphism `exp (ad x)` attached to an element `x` with nilpotent adjoint action.
+It is `LieDerivation.exp` applied to the inner derivation `ad x`. -/
+noncomputable def expAd (x : L) (hx : IsNilpotent (ad K L x)) : L ≃ₗ⁅K⁆ L :=
+  LieDerivation.exp (LieDerivation.ad K L x) <| by
+    rwa [show (LieDerivation.ad K L x).toLinearMap = ad K L x from by ext; simp]
+
+/-- `TauCeti.expAd` is the exponential of `LieAlgebra.ad x`. -/
+lemma expAd_apply (x : L) (hx : IsNilpotent (ad K L x)) (y : L) :
+    expAd x hx y = IsNilpotent.exp (ad K L x) y := by
+  rw [expAd, LieDerivation.exp_map_apply]
+  congr 1
+  ext
+  simp
+
+/-- The exponential series for `exp (ad x)`, truncated at any length `k` for which `(ad x) ^ k`
+already annihilates the vector `y`. -/
+lemma expAd_apply_eq_sum {x : L} (hx : IsNilpotent (ad K L x)) {k : ℕ} {y : L}
+    (hy : ((ad K L x) ^ k) y = 0) :
+    expAd x hx y = ∑ i ∈ range k, ((i.factorial : ℚ)⁻¹) • ((ad K L x) ^ i) y := by
+  rw [expAd_apply]
+  exact IsNilpotent.exp_smul_eq_sum (M := L) hy hx
+
+/-- An element centralised by `x` is fixed by `exp (ad x)`. -/
+lemma expAd_apply_of_lie_eq_zero {x y : L} (hx : IsNilpotent (ad K L x)) (hy : ⁅x, y⁆ = 0) :
+    expAd x hx y = y := by
+  rw [expAd_apply_eq_sum (k := 1) hx (by simpa using hy)]
+  simp
+
+/-- `exp (ad x)` fixes `x`. -/
+lemma expAd_apply_self (x : L) (hx : IsNilpotent (ad K L x)) : expAd x hx x = x :=
+  expAd_apply_of_lie_eq_zero hx (lie_self x)
+
+/-- The two-term truncation of `exp (ad x)`, valid on a vector killed by two brackets with `x`. -/
+lemma expAd_apply_of_lie_lie_eq_zero {x y : L} (hx : IsNilpotent (ad K L x))
+    (hy : ⁅x, ⁅x, y⁆⁆ = 0) :
+    expAd x hx y = y + ⁅x, y⁆ := by
+  rw [expAd_apply_eq_sum (k := 2) hx (by simpa [pow_succ] using hy)]
+  simp [Finset.sum_range_succ]
+
+/-- The three-term truncation of `exp (ad x)`, valid on a vector killed by three brackets with
+`x`. -/
+lemma expAd_apply_of_lie_lie_lie_eq_zero {x y : L} (hx : IsNilpotent (ad K L x))
+    (hy : ⁅x, ⁅x, ⁅x, y⁆⁆⁆ = 0) :
+    expAd x hx y = y + ⁅x, y⁆ + (2⁻¹ : ℚ) • ⁅x, ⁅x, y⁆⁆ := by
+  rw [expAd_apply_eq_sum (k := 3) hx (by simpa [pow_succ] using hy)]
+  simp [Finset.sum_range_succ, pow_succ]
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/InnerAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/InnerAutomorphism.lean
@@ -6,7 +6,6 @@ module
 
 public import Mathlib.Algebra.Algebra.Rat
 public import Mathlib.Algebra.Lie.AdjointAction.Derivation
-public import Mathlib.Algebra.Lie.Derivation.Basic
 
 public section
 

--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Lie.Sl2
+public import Mathlib.Algebra.Lie.Weights.Killing
+public import TauCeti.Algebra.Lie.InnerAutomorphism
+
+public section
+
+/-!
+# The Weyl automorphism of an `sl₂` triple
+
+Let `t : IsSl2Triple h e f` be an `sl₂` triple in a Lie algebra `L` whose raising and lowering
+elements act nilpotently. Its **Weyl automorphism** is the inner automorphism
+
+`TauCeti.weylAut he hf = exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)`,
+
+Chevalley's `τ` and the Lie-algebra shadow of the group element `n_α = x_α(1) x_{-α}(-1) x_α(1)`
+that represents the reflection `s_α` in the Weyl group. It negates the whole triple,
+
+`h ↦ -h`, `e ↦ -f`, `f ↦ -e`,
+
+and fixes everything centralised by both `e` and `f`. Those two facts are the whole content: the
+reflection formula `TauCeti.weylAut_apply_of_lie_eq_smul` says that an element `y` acting on `e`
+and `f` by the opposite scalars `c` and `-c` is sent to `y - c • h`, which on a Cartan subalgebra
+is the coreflection in `α`, and `TauCeti.lie_weylAut_apply` then transports a simultaneous
+eigenvector along it: a `z` with `⁅y, z⁆ = d • z` and `⁅h, z⁆ = m • z` has
+
+`⁅y, weylAut he hf z⁆ = (d - c * m) • weylAut he hf z`,
+
+so `weylAut he hf z` is again an eigenvector, now for the reflected weight `β - β(h) • α`.
+
+Everything up to that point is stated for a bare `sl₂` triple over a commutative ring, in terms of
+brackets alone: no Cartan subalgebra, no weight-space decomposition and no finiteness. The final
+section specialises to a Lie algebra with non-degenerate Killing form over a field of
+characteristic zero, where the eigenvector hypotheses are automatic for elements of the Cartan
+subalgebra and the conclusion becomes `TauCeti.weylAut_mem_rootSpace`: the Weyl automorphism of the
+`sl₂` triple of a root `α` carries the root space of `β` into the root space of `β - β(α^∨) • α`.
+Since a nonzero root always admits such a triple, every reflection in the Weyl group is realised by
+an automorphism of `L` (`TauCeti.exists_lieEquiv_forall_mem_rootSpace`), which is Humphreys'
+Proposition 14.3.
+
+This is the step of the Chevalley basis theorem that makes the structure constants of `L` behave
+under the Weyl group: `weylAut` matches a root vector of `β` with one of `s_α β`, and applied to
+the triple of `α` itself it is the source of the relation `N (α, β) = -N (-α, -β)` between
+structure constants (Humphreys §25.2).
+
+## Main definitions
+
+* `TauCeti.weylAut`: the automorphism `exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)`.
+
+## Main results
+
+* `TauCeti.weylAut_apply_h`, `TauCeti.weylAut_apply_e`, `TauCeti.weylAut_apply_f`: the Weyl
+  automorphism negates and swaps the triple.
+* `TauCeti.weylAut_apply_of_lie_eq_zero`: it fixes the joint centraliser of `e` and `f`.
+* `TauCeti.weylAut_apply_of_lie_eq_smul`: the reflection formula `y ↦ y - c • h`.
+* `TauCeti.lie_weylAut_apply`: the reflected weight of the image of an eigenvector.
+* `TauCeti.weylAut_mem_rootSpace` and `TauCeti.exists_lieEquiv_forall_mem_rootSpace`: in the
+  Killing setting, `weylAut` carries root spaces to reflected root spaces.
+
+## References
+
+* [J. Humphreys, *Introduction to Lie Algebras and Representation Theory*][humphreys1972], §§14.3
+  and 25.2.
+* [R. W. Carter, *Simple Groups of Lie Type*][carter1972], §4.1.
+-/
+
+namespace TauCeti
+
+open LieAlgebra LieModule
+
+section CommRing
+
+variable {K L : Type*} [CommRing K] [LieRing L] [LieAlgebra K L] [LieAlgebra ℚ L] {h e f : L}
+
+omit [LieAlgebra ℚ L] in
+/-- The adjoint action of `-x` is nilpotent as soon as that of `x` is. -/
+lemma isNilpotent_ad_neg {x : L} (hx : IsNilpotent (ad K L x)) : IsNilpotent (ad K L (-x)) := by
+  simpa using hx.neg
+
+/-- The **Weyl automorphism** `exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)` of a pair of
+`ad`-nilpotent elements.
+
+The name records the intended input, an `sl₂` triple `IsSl2Triple h e f`, for which this is the
+automorphism realising the reflection in the root of `e`; the construction itself does not need the
+triple relations, and every result below that uses them assumes them explicitly. -/
+noncomputable def weylAut (he : IsNilpotent (ad K L e)) (hf : IsNilpotent (ad K L f)) :
+    L ≃ₗ⁅K⁆ L :=
+  (expAd e he).trans ((expAd (-f) (isNilpotent_ad_neg hf)).trans (expAd e he))
+
+variable (he : IsNilpotent (ad K L e)) (hf : IsNilpotent (ad K L f))
+
+/-- The Weyl automorphism as the threefold composite it is defined to be. -/
+lemma weylAut_apply (y : L) :
+    weylAut he hf y = expAd e he (expAd (-f) (isNilpotent_ad_neg hf) (expAd e he y)) := by
+  rw [weylAut]
+  rfl
+
+/-! ### The two exponentials on the triple
+
+The values of `exp (ad e)` and `exp (ad (-f))` on `h`, `e` and `f`. Each of these vectors is killed
+by at most three brackets, so the truncations of `TauCeti/Algebra/Lie/InnerAutomorphism.lean`
+apply; the two remaining values `exp (ad e) e = e` and `exp (ad (-f)) (-f) = -f` are
+`TauCeti.expAd_apply_self`. -/
+
+/-- `exp (ad e)` sends `h` to `h - 2 e`. -/
+lemma expAd_e_apply_h (t : IsSl2Triple h e f) : expAd e he h = h - 2 • e := by
+  have h₂ : ⁅e, h⁆ = -(2 • e) := by rw [← lie_skew e h, t.lie_h_e_nsmul]
+  rw [expAd_apply_of_lie_lie_eq_zero he (by rw [h₂]; simp), h₂]
+  abel
+
+/-- `exp (ad e)` sends `f` to `f + h - e`. -/
+lemma expAd_e_apply_f (t : IsSl2Triple h e f) : expAd e he f = f + h - e := by
+  have h₁ : ⁅e, f⁆ = h := t.lie_e_f
+  have h₂ : ⁅e, h⁆ = -(2 • e) := by rw [← lie_skew e h, t.lie_h_e_nsmul]
+  rw [expAd_apply_of_lie_lie_lie_eq_zero he (by rw [h₁, h₂]; simp), h₁, h₂,
+    show ((2 : ℕ) • e) = (2 : ℚ) • e by rw [← Nat.cast_smul_eq_nsmul ℚ]; norm_num,
+    smul_neg, smul_smul]
+  norm_num
+  abel
+
+/-- `exp (ad (-f))` sends `h` to `h - 2 f`. -/
+lemma expAd_neg_f_apply_h (t : IsSl2Triple h e f) :
+    expAd (-f) (isNilpotent_ad_neg hf) h = h - 2 • f := by
+  have h₂ : ⁅-f, h⁆ = -(2 • f) := by rw [neg_lie, ← lie_skew f h, t.lie_h_f_nsmul]; simp
+  rw [expAd_apply_of_lie_lie_eq_zero (isNilpotent_ad_neg hf) (by rw [h₂]; simp), h₂]
+  abel
+
+/-- `exp (ad (-f))` fixes `f`. -/
+lemma expAd_neg_f_apply_f : expAd (-f) (isNilpotent_ad_neg hf) f = f :=
+  expAd_apply_of_lie_eq_zero (isNilpotent_ad_neg hf) (by simp)
+
+/-- `exp (ad (-f))` sends `e` to `e + h - f`. -/
+lemma expAd_neg_f_apply_e (t : IsSl2Triple h e f) :
+    expAd (-f) (isNilpotent_ad_neg hf) e = e + h - f := by
+  have h₁ : ⁅-f, e⁆ = h := by rw [neg_lie, lie_skew, t.lie_e_f]
+  have h₂ : ⁅-f, h⁆ = -(2 • f) := by rw [neg_lie, ← lie_skew f h, t.lie_h_f_nsmul]; simp
+  rw [expAd_apply_of_lie_lie_lie_eq_zero (isNilpotent_ad_neg hf) (by rw [h₁, h₂]; simp), h₁, h₂,
+    show ((2 : ℕ) • f) = (2 : ℚ) • f by rw [← Nat.cast_smul_eq_nsmul ℚ]; norm_num,
+    smul_neg, smul_smul]
+  norm_num
+  abel
+
+/-! ### The Weyl automorphism on the triple -/
+
+/-- The Weyl automorphism negates `h`. -/
+lemma weylAut_apply_h (t : IsSl2Triple h e f) : weylAut he hf h = -h := by
+  have s₁ : expAd (-f) (isNilpotent_ad_neg hf) (h - 2 • e) = -h - 2 • e := by
+    simp only [map_sub, map_nsmul, expAd_neg_f_apply_h hf t, expAd_neg_f_apply_e hf t]
+    abel
+  have s₂ : expAd e he (-h - 2 • e) = -h := by
+    simp only [map_sub, map_neg, map_nsmul, expAd_e_apply_h he t, expAd_apply_self e he]
+    abel
+  rw [weylAut_apply he hf, expAd_e_apply_h he t, s₁, s₂]
+
+/-- The Weyl automorphism sends the raising element to minus the lowering element. -/
+lemma weylAut_apply_e (t : IsSl2Triple h e f) : weylAut he hf e = -f := by
+  have s₁ : expAd e he (e + h - f) = -f := by
+    simp only [map_sub, map_add, expAd_apply_self e he, expAd_e_apply_h he t,
+      expAd_e_apply_f he t]
+    abel
+  rw [weylAut_apply he hf, expAd_apply_self e he, expAd_neg_f_apply_e hf t, s₁]
+
+/-- The Weyl automorphism sends the lowering element to minus the raising element. -/
+lemma weylAut_apply_f (t : IsSl2Triple h e f) : weylAut he hf f = -e := by
+  have s₁ : expAd (-f) (isNilpotent_ad_neg hf) (f + h - e) = -e := by
+    simp only [map_sub, map_add, expAd_neg_f_apply_f hf, expAd_neg_f_apply_h hf t,
+      expAd_neg_f_apply_e hf t]
+    abel
+  rw [weylAut_apply he hf, expAd_e_apply_f he t, s₁, map_neg, expAd_apply_self e he]
+
+/-- The Weyl automorphism fixes the joint centraliser of `e` and `f`. -/
+lemma weylAut_apply_of_lie_eq_zero {y : L} (hye : ⁅y, e⁆ = 0) (hyf : ⁅y, f⁆ = 0) :
+    weylAut he hf y = y := by
+  have hey : ⁅e, y⁆ = 0 := by rw [← lie_skew e y, hye, neg_zero]
+  rw [weylAut_apply he hf, expAd_apply_of_lie_eq_zero he hey,
+    expAd_apply_of_lie_eq_zero (isNilpotent_ad_neg hf)
+      (by rw [neg_lie, ← lie_skew f y, hyf]; simp),
+    expAd_apply_of_lie_eq_zero he hey]
+
+/-! ### The reflection formula -/
+
+/-- **The reflection formula.** An element acting on `e` by a scalar `c` and on `f` by `-c` — for
+an `sl₂` triple of a root `α` inside a Cartan subalgebra, an element `y` with `α y = c` — is sent
+by the Weyl automorphism to `y - c • h`. This is the coreflection `y ↦ y - α y • α^∨`. -/
+lemma weylAut_apply_of_lie_eq_smul (t : IsSl2Triple h e f) {y : L} {c : K}
+    (hye : ⁅y, e⁆ = c • e) (hyf : ⁅y, f⁆ = -(c • f)) :
+    weylAut he hf y = y - c • h := by
+  have hey : ⁅e, y⁆ = -(c • e) := by rw [← lie_skew e y, hye]
+  have hfy : ⁅-f, y⁆ = -(c • f) := by rw [neg_lie, ← lie_skew f y, hyf]; simp
+  have h₁ : expAd e he y = y - c • e := by
+    rw [expAd_apply_of_lie_lie_eq_zero he (by rw [hey]; simp), hey, sub_eq_add_neg]
+  have h₂ : expAd (-f) (isNilpotent_ad_neg hf) y = y - c • f := by
+    rw [expAd_apply_of_lie_lie_eq_zero (isNilpotent_ad_neg hf) (by rw [hfy]; simp), hfy,
+      sub_eq_add_neg]
+  have h₃ : expAd (-f) (isNilpotent_ad_neg hf) (y - c • e) = y - c • f - c • (e + h - f) := by
+    rw [map_sub, map_smul, h₂, expAd_neg_f_apply_e hf t]
+  have h₄ : expAd e he (y - c • f - c • (e + h - f)) = y - c • h := by
+    simp only [map_sub, map_add, map_smul, h₁, expAd_apply_self e he, expAd_e_apply_h he t,
+      expAd_e_apply_f he t]
+    module
+  rw [weylAut_apply he hf, h₁, h₃, h₄]
+
+/-- The Weyl automorphism is an involution on the elements the reflection formula applies to. -/
+lemma weylAut_apply_sub_smul (t : IsSl2Triple h e f) {y : L} {c : K}
+    (hye : ⁅y, e⁆ = c • e) (hyf : ⁅y, f⁆ = -(c • f)) :
+    weylAut he hf (y - c • h) = y := by
+  have h₁ : ⁅y - c • h, e⁆ = (-c) • e := by
+    rw [sub_lie, hye, smul_lie, t.lie_h_e_smul K, smul_smul, neg_smul]
+    module
+  have h₂ : ⁅y - c • h, f⁆ = -((-c) • f) := by
+    rw [sub_lie, hyf, smul_lie, t.lie_lie_smul_f K, smul_neg, smul_smul, neg_smul]
+    module
+  rw [weylAut_apply_of_lie_eq_smul he hf t h₁ h₂, neg_smul]
+  abel
+
+/-- **The reflected weight.** If `y` acts on `e` and `f` by `c` and `-c`, and `z` is a simultaneous
+eigenvector of `y` and `h` with eigenvalues `d` and `m`, then the image of `z` under the Weyl
+automorphism is again an eigenvector of `y`, with the reflected eigenvalue `d - c * m`. -/
+lemma lie_weylAut_apply (t : IsSl2Triple h e f) {y z : L} {c d m : K}
+    (hye : ⁅y, e⁆ = c • e) (hyf : ⁅y, f⁆ = -(c • f)) (hyz : ⁅y, z⁆ = d • z)
+    (hhz : ⁅h, z⁆ = m • z) :
+    ⁅y, weylAut he hf z⁆ = (d - c * m) • weylAut he hf z := by
+  have key : ⁅y - c • h, z⁆ = (d - c * m) • z := by
+    rw [sub_lie, hyz, smul_lie, hhz, smul_smul, sub_smul]
+  calc ⁅y, weylAut he hf z⁆
+      = ⁅weylAut he hf (y - c • h), weylAut he hf z⁆ := by
+        rw [weylAut_apply_sub_smul he hf t hye hyf]
+    _ = weylAut he hf ⁅y - c • h, z⁆ := (LieEquiv.map_lie _ _ _).symm
+    _ = (d - c * m) • weylAut he hf z := by rw [key, map_smul]
+
+end CommRing
+
+section Killing
+
+variable {K L : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
+  [FiniteDimensional K L] [IsKilling K L] {H : LieSubalgebra K L} [H.IsCartanSubalgebra]
+  [IsTriangularizable K H L] {h e f : L}
+
+open IsKilling in
+/-- **The Weyl automorphism reflects root spaces.** For the `sl₂` triple of a nonzero root `α`, the
+Weyl automorphism carries the root space of a weight `β` into the root space of the reflection
+`β - β(α^∨) • α`. -/
+theorem weylAut_mem_rootSpace [LieAlgebra ℚ L] {α : Weight K H L} (t : IsSl2Triple h e f)
+    (heα : e ∈ rootSpace H α) (hfα : f ∈ rootSpace H (-α)) (hα : α.IsNonZero)
+    (he : IsNilpotent (ad K L e)) (hf : IsNilpotent (ad K L f))
+    {β : H → K} {z : L} (hz : z ∈ rootSpace H β) :
+    weylAut he hf z ∈ rootSpace H (β - β (coroot α) • ⇑α) := by
+  have hh : h = (coroot α : L) := t.h_eq_coroot hα heα hfα
+  have hhz : ⁅h, z⁆ = β (coroot α) • z := by
+    rw [hh]; exact lie_eq_smul_of_mem_rootSpace hz (coroot α)
+  refine weightSpace_le_genWeightSpace (M := L) _ ((mem_weightSpace _ _).mpr fun y ↦ ?_)
+  have hye : ⁅(y : L), e⁆ = α y • e := lie_eq_smul_of_mem_rootSpace heα y
+  have hyf : ⁅(y : L), f⁆ = -(α y • f) := by
+    have := lie_eq_smul_of_mem_rootSpace hfα y
+    simpa using this
+  have hyz : ⁅(y : L), z⁆ = β y • z := lie_eq_smul_of_mem_rootSpace hz y
+  have key := lie_weylAut_apply he hf t hye hyf hyz hhz
+  rw [H.coe_bracket_of_module, key]
+  simp [mul_comm]
+
+open IsKilling in
+/-- Every reflection of the root system of `(L, H)` is realised by an automorphism of `L`: for a
+nonzero root `α` there is an automorphism carrying the root space of every weight `β` into the root
+space of `β - β(α^∨) • α`. This is the `sl₂` triple of `α` fed to `TauCeti.weylAut`, and it needs
+no `ℚ`-structure hypothesis, `TauCeti.ratLieAlgebra` supplying one. -/
+theorem exists_lieEquiv_forall_mem_rootSpace {α : Weight K H L} (hα : α.IsNonZero) :
+    ∃ τ : L ≃ₗ⁅K⁆ L, ∀ (β : H → K) (z : L), z ∈ rootSpace H β →
+      τ z ∈ rootSpace H (β - β (coroot α) • ⇑α) := by
+  let _ : LieAlgebra ℚ L := ratLieAlgebra K L
+  obtain ⟨h, e, f, t, heα, hfα⟩ := exists_isSl2Triple_of_weight_isNonZero hα
+  have he : IsNilpotent (ad K L e) :=
+    isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα
+  have hf : IsNilpotent (ad K L f) :=
+    isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα
+  exact ⟨weylAut he hf, fun β z hz ↦ weylAut_mem_rootSpace t heα hfα hα he hf hz⟩
+
+end Killing
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -16,7 +16,7 @@ public section
 Let `t : IsSl2Triple h e f` be an `sl₂` triple in a Lie algebra `L` whose raising and lowering
 elements act nilpotently. Its **Weyl automorphism** is the inner automorphism
 
-`TauCeti.weylAut he hf = exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)`,
+`TauCeti.weylAut t he hf = exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)`,
 
 Chevalley's `τ` and the Lie-algebra shadow of the group element `n_α = x_α(1) x_{-α}(-1) x_α(1)`
 that represents the reflection `s_α` in the Weyl group. It negates the whole triple,
@@ -29,9 +29,9 @@ and `f` by the opposite scalars `c` and `-c` is sent to `y - c • h`, which on 
 is the coreflection in `α`, and `TauCeti.lie_weylAut_apply` then transports a simultaneous
 eigenvector along it: a `z` with `⁅y, z⁆ = d • z` and `⁅h, z⁆ = m • z` has
 
-`⁅y, weylAut he hf z⁆ = (d - c * m) • weylAut he hf z`,
+`⁅y, weylAut t he hf z⁆ = (d - c * m) • weylAut t he hf z`,
 
-so `weylAut he hf z` is again an eigenvector, now for the reflected weight `β - β(h) • α`.
+so `weylAut t he hf z` is again an eigenvector, now for the reflected weight `β - β(h) • α`.
 
 Everything up to that point is stated for a bare `sl₂` triple over a commutative ring `K`, in terms
 of brackets alone: no Cartan subalgebra, no weight-space decomposition and no finiteness. What it
@@ -53,7 +53,8 @@ structure constants (Humphreys §25.2).
 
 ## Main definitions
 
-* `TauCeti.weylAut`: the automorphism `exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)`.
+* `TauCeti.weylAut`: the automorphism `exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)` of an `sl₂`
+  triple `t : IsSl2Triple h e f`.
 
 ## Main results
 
@@ -81,22 +82,25 @@ section CommRing
 
 variable {K L : Type*} [CommRing K] [LieRing L] [LieAlgebra K L] [LieAlgebra ℚ L] {h e f : L}
 
-/-- The **Weyl automorphism** `exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)` of a pair of
-`ad`-nilpotent elements.
+/-- The **Weyl automorphism** `exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)` of an `sl₂` triple
+`t : IsSl2Triple h e f` whose raising and lowering elements act nilpotently: the automorphism
+realising the reflection in the root of `e`.
 
-The name records the intended input, an `sl₂` triple `IsSl2Triple h e f`, for which this is the
-automorphism realising the reflection in the root of `e`; the construction itself does not need the
-triple relations, and every result below that uses them assumes them explicitly. -/
-noncomputable def weylAut (he : IsNilpotent (ad K L e)) (hf : IsNilpotent (ad K L f)) :
-    L ≃ₗ⁅K⁆ L :=
+The triple is an argument although the composite itself is a function of `e` and `f` alone, so that
+the interface asks for the input the name and the results below are about; the reflection is visible
+only in the presence of the triple relations, which every result below assumes through `t`. -/
+noncomputable def weylAut (_t : IsSl2Triple h e f) (he : IsNilpotent (ad K L e))
+    (hf : IsNilpotent (ad K L f)) : L ≃ₗ⁅K⁆ L :=
   (expAd e he).trans ((expAd (-f) (by simpa using hf.neg)).trans (expAd e he))
 
 variable (he : IsNilpotent (ad K L e)) (hf : IsNilpotent (ad K L f))
   (hf' : IsNilpotent (ad K L (-f)))
 
-/-- The Weyl automorphism as the threefold composite it is defined to be. -/
-lemma weylAut_apply (y : L) :
-    weylAut he hf y = expAd e he (expAd (-f) hf' (expAd e he y)) := by
+/-- The Weyl automorphism as the threefold composite it is defined to be. The nilpotency of
+`ad (-f)` is not asked of the caller: it is `hf.neg`, and any two proofs of it agree. -/
+lemma weylAut_apply (t : IsSl2Triple h e f) (y : L) :
+    weylAut t he hf y =
+      expAd e he (expAd (K := K) (-f) (by simpa using hf.neg) (expAd e he y)) := by
   rw [weylAut]
   rfl
 
@@ -144,7 +148,7 @@ lemma expAd_neg_f_apply_e (t : IsSl2Triple h e f) : expAd (-f) hf' e = e + h - f
 
 /-- The Weyl automorphism negates `h`. -/
 @[simp]
-lemma weylAut_apply_h (t : IsSl2Triple h e f) : weylAut he hf h = -h := by
+lemma weylAut_apply_h (t : IsSl2Triple h e f) : weylAut t he hf h = -h := by
   have hf' : IsNilpotent (ad K L (-f)) := by simpa using hf.neg
   have s₁ : expAd (-f) hf' (h - 2 • e) = -h - 2 • e := by
     simp only [map_sub, map_nsmul, expAd_neg_f_apply_h hf' t, expAd_neg_f_apply_e hf' t]
@@ -152,32 +156,35 @@ lemma weylAut_apply_h (t : IsSl2Triple h e f) : weylAut he hf h = -h := by
   have s₂ : expAd e he (-h - 2 • e) = -h := by
     simp only [map_sub, map_neg, map_nsmul, expAd_e_apply_h he t, expAd_apply_self e he]
     abel
-  rw [weylAut_apply he hf hf', expAd_e_apply_h he t, s₁, s₂]
+  rw [weylAut_apply he hf t, expAd_e_apply_h he t, s₁, s₂]
 
 /-- The Weyl automorphism sends the raising element to minus the lowering element. -/
-lemma weylAut_apply_e (t : IsSl2Triple h e f) : weylAut he hf e = -f := by
+@[simp]
+lemma weylAut_apply_e (t : IsSl2Triple h e f) : weylAut t he hf e = -f := by
   have hf' : IsNilpotent (ad K L (-f)) := by simpa using hf.neg
   have s₁ : expAd e he (e + h - f) = -f := by
     simp only [map_sub, map_add, expAd_apply_self e he, expAd_e_apply_h he t,
       expAd_e_apply_f he t]
     abel
-  rw [weylAut_apply he hf hf', expAd_apply_self e he, expAd_neg_f_apply_e hf' t, s₁]
+  rw [weylAut_apply he hf t, expAd_apply_self e he, expAd_neg_f_apply_e hf' t, s₁]
 
 /-- The Weyl automorphism sends the lowering element to minus the raising element. -/
-lemma weylAut_apply_f (t : IsSl2Triple h e f) : weylAut he hf f = -e := by
+@[simp]
+lemma weylAut_apply_f (t : IsSl2Triple h e f) : weylAut t he hf f = -e := by
   have hf' : IsNilpotent (ad K L (-f)) := by simpa using hf.neg
   have hff : expAd (-f) hf' f = f := expAd_apply_of_lie_eq_zero hf' (by simp)
   have s₁ : expAd (-f) hf' (f + h - e) = -e := by
     simp only [map_sub, map_add, hff, expAd_neg_f_apply_h hf' t, expAd_neg_f_apply_e hf' t]
     abel
-  rw [weylAut_apply he hf hf', expAd_e_apply_f he t, s₁, map_neg, expAd_apply_self e he]
+  rw [weylAut_apply he hf t, expAd_e_apply_f he t, s₁, map_neg, expAd_apply_self e he]
 
 /-- The Weyl automorphism fixes the joint centraliser of `e` and `f`. -/
-lemma weylAut_apply_of_lie_eq_zero {y : L} (hye : ⁅y, e⁆ = 0) (hyf : ⁅y, f⁆ = 0) :
-    weylAut he hf y = y := by
+lemma weylAut_apply_of_lie_eq_zero (t : IsSl2Triple h e f) {y : L} (hye : ⁅y, e⁆ = 0)
+    (hyf : ⁅y, f⁆ = 0) :
+    weylAut t he hf y = y := by
   have hf' : IsNilpotent (ad K L (-f)) := by simpa using hf.neg
   have hey : ⁅e, y⁆ = 0 := by rw [← lie_skew e y, hye, neg_zero]
-  rw [weylAut_apply he hf hf', expAd_apply_of_lie_eq_zero he hey,
+  rw [weylAut_apply he hf t, expAd_apply_of_lie_eq_zero he hey,
     expAd_apply_of_lie_eq_zero hf' (by rw [neg_lie, ← lie_skew f y, hyf]; simp),
     expAd_apply_of_lie_eq_zero he hey]
 
@@ -188,7 +195,7 @@ an `sl₂` triple of a root `α` inside a Cartan subalgebra, an element `y` with
 by the Weyl automorphism to `y - c • h`. This is the coreflection `y ↦ y - α y • α^∨`. -/
 lemma weylAut_apply_of_lie_eq_smul (t : IsSl2Triple h e f) {y : L} {c : K}
     (hye : ⁅y, e⁆ = c • e) (hyf : ⁅y, f⁆ = -(c • f)) :
-    weylAut he hf y = y - c • h := by
+    weylAut t he hf y = y - c • h := by
   have hf' : IsNilpotent (ad K L (-f)) := by simpa using hf.neg
   have hey : ⁅e, y⁆ = -(c • e) := by rw [← lie_skew e y, hye]
   have hfy : ⁅-f, y⁆ = -(c • f) := by rw [neg_lie, ← lie_skew f y, hyf]; simp
@@ -202,12 +209,12 @@ lemma weylAut_apply_of_lie_eq_smul (t : IsSl2Triple h e f) {y : L} {c : K}
     simp only [map_sub, map_add, map_smul, h₁, expAd_apply_self e he, expAd_e_apply_h he t,
       expAd_e_apply_f he t]
     module
-  rw [weylAut_apply he hf hf', h₁, h₃, h₄]
+  rw [weylAut_apply he hf t, h₁, h₃, h₄]
 
 /-- The Weyl automorphism is an involution on the elements the reflection formula applies to. -/
 lemma weylAut_apply_sub_smul (t : IsSl2Triple h e f) {y : L} {c : K}
     (hye : ⁅y, e⁆ = c • e) (hyf : ⁅y, f⁆ = -(c • f)) :
-    weylAut he hf (y - c • h) = y := by
+    weylAut t he hf (y - c • h) = y := by
   have h₁ : ⁅y - c • h, e⁆ = (-c) • e := by
     rw [sub_lie, hye, smul_lie, t.lie_h_e_smul K, smul_smul, neg_smul]
     module
@@ -223,14 +230,14 @@ automorphism is again an eigenvector of `y`, with the reflected eigenvalue `d - 
 lemma lie_weylAut_apply (t : IsSl2Triple h e f) {y z : L} {c d m : K}
     (hye : ⁅y, e⁆ = c • e) (hyf : ⁅y, f⁆ = -(c • f)) (hyz : ⁅y, z⁆ = d • z)
     (hhz : ⁅h, z⁆ = m • z) :
-    ⁅y, weylAut he hf z⁆ = (d - c * m) • weylAut he hf z := by
+    ⁅y, weylAut t he hf z⁆ = (d - c * m) • weylAut t he hf z := by
   have key : ⁅y - c • h, z⁆ = (d - c * m) • z := by
     rw [sub_lie, hyz, smul_lie, hhz, smul_smul, sub_smul]
-  calc ⁅y, weylAut he hf z⁆
-      = ⁅weylAut he hf (y - c • h), weylAut he hf z⁆ := by
+  calc ⁅y, weylAut t he hf z⁆
+      = ⁅weylAut t he hf (y - c • h), weylAut t he hf z⁆ := by
         rw [weylAut_apply_sub_smul he hf t hye hyf]
-    _ = weylAut he hf ⁅y - c • h, z⁆ := (LieEquiv.map_lie _ _ _).symm
-    _ = (d - c * m) • weylAut he hf z := by rw [key, map_smul]
+    _ = weylAut t he hf ⁅y - c • h, z⁆ := (LieEquiv.map_lie _ _ _).symm
+    _ = (d - c * m) • weylAut t he hf z := by rw [key, map_smul]
 
 end CommRing
 
@@ -248,7 +255,7 @@ hypotheses, so it is supplied here rather than asked of the caller. -/
 theorem weylAut_mem_rootSpace [LieAlgebra ℚ L] {α : Weight K H L} (t : IsSl2Triple h e f)
     (heα : e ∈ rootSpace H α) (hfα : f ∈ rootSpace H (-α)) (hα : α.IsNonZero)
     {β : H → K} {z : L} (hz : z ∈ rootSpace H β) :
-    weylAut (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
+    weylAut t (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
         (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα) z ∈
       rootSpace H (β - β (coroot α) • ⇑α) := by
   set he := isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα
@@ -274,11 +281,11 @@ back into the root space of `β`, together with a dimension count. -/
 theorem weylAut_map_rootSpace [LieAlgebra ℚ L] {α : Weight K H L} (t : IsSl2Triple h e f)
     (heα : e ∈ rootSpace H α) (hfα : f ∈ rootSpace H (-α)) (hα : α.IsNonZero) (β : H → K) :
     (rootSpace H β).toSubmodule.map
-        ((weylAut (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
+        ((weylAut t (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
           (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα)).toLinearEquiv :
             L →ₗ[K] L) =
       (rootSpace H (β - β (coroot α) • ⇑α)).toSubmodule := by
-  set τ := (weylAut (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
+  set τ := (weylAut t (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
     (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα)).toLinearEquiv
   -- the reflection is an involution on weights, so `τ` sends the reflected root space back
   have hrefl : ∀ γ : H → K,
@@ -308,7 +315,7 @@ theorem exists_lieEquiv_forall_mem_rootSpace {α : Weight K H L} (hα : α.IsNon
       τ z ∈ rootSpace H (β - β (coroot α) • ⇑α) := by
   let _ : LieAlgebra ℚ L := ratLieAlgebra K L
   obtain ⟨h, e, f, t, heα, hfα⟩ := exists_isSl2Triple_of_weight_isNonZero hα
-  exact ⟨weylAut (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
+  exact ⟨weylAut t (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
     (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα),
     fun β z hz ↦ weylAut_mem_rootSpace t heα hfα hα hz⟩
 

--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Lie.Sl2
 public import Mathlib.Algebra.Lie.Weights.Killing
 public import TauCeti.Algebra.Lie.InnerAutomorphism
 

--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -33,15 +33,18 @@ eigenvector along it: a `z` with `⁅y, z⁆ = d • z` and `⁅h, z⁆ = m • 
 
 so `weylAut he hf z` is again an eigenvector, now for the reflected weight `β - β(h) • α`.
 
-Everything up to that point is stated for a bare `sl₂` triple over a commutative ring, in terms of
-brackets alone: no Cartan subalgebra, no weight-space decomposition and no finiteness. The final
-section specialises to a Lie algebra with non-degenerate Killing form over a field of
-characteristic zero, where the eigenvector hypotheses are automatic for elements of the Cartan
-subalgebra and the conclusion becomes `TauCeti.weylAut_mem_rootSpace`: the Weyl automorphism of the
-`sl₂` triple of a root `α` carries the root space of `β` into the root space of `β - β(α^∨) • α`.
-Since a nonzero root always admits such a triple, every reflection in the Weyl group is realised by
-an automorphism of `L` (`TauCeti.exists_lieEquiv_forall_mem_rootSpace`), which is Humphreys'
-Proposition 14.3.
+Everything up to that point is stated for a bare `sl₂` triple over a commutative ring `K`, in terms
+of brackets alone: no Cartan subalgebra, no weight-space decomposition and no finiteness. What it
+does need is a `ℚ`-Lie-algebra structure on `L`, carried as in
+`TauCeti/Algebra/Lie/InnerAutomorphism.lean` by an unbundled `[LieAlgebra ℚ L]` hypothesis, because
+the exponentials divide by factorials; that excludes positive characteristic and non-divisible
+bases such as `ℤ`. The final section specialises to a Lie algebra with non-degenerate Killing form
+over a field of characteristic zero, where the eigenvector hypotheses are automatic for elements of
+the Cartan subalgebra and the conclusion becomes `TauCeti.weylAut_mem_rootSpace` and
+`TauCeti.weylAut_map_rootSpace`: the Weyl automorphism of the `sl₂` triple of a root `α` carries the
+root space of `β` onto the root space of `β - β(α^∨) • α`. Since a nonzero root always admits such a
+triple, every reflection in the Weyl group is realised by an automorphism of `L`
+(`TauCeti.exists_lieEquiv_forall_mem_rootSpace`), which is Humphreys' Proposition 14.3.
 
 This is the step of the Chevalley basis theorem that makes the structure constants of `L` behave
 under the Weyl group: `weylAut` matches a root vector of `β` with one of `s_α β`, and applied to
@@ -59,8 +62,9 @@ structure constants (Humphreys §25.2).
 * `TauCeti.weylAut_apply_of_lie_eq_zero`: it fixes the joint centraliser of `e` and `f`.
 * `TauCeti.weylAut_apply_of_lie_eq_smul`: the reflection formula `y ↦ y - c • h`.
 * `TauCeti.lie_weylAut_apply`: the reflected weight of the image of an eigenvector.
-* `TauCeti.weylAut_mem_rootSpace` and `TauCeti.exists_lieEquiv_forall_mem_rootSpace`: in the
-  Killing setting, `weylAut` carries root spaces to reflected root spaces.
+* `TauCeti.weylAut_mem_rootSpace`, `TauCeti.weylAut_map_rootSpace` and
+  `TauCeti.exists_lieEquiv_forall_mem_rootSpace`: in the Killing setting, `weylAut` carries root
+  spaces onto reflected root spaces.
 
 ## References
 
@@ -77,11 +81,6 @@ section CommRing
 
 variable {K L : Type*} [CommRing K] [LieRing L] [LieAlgebra K L] [LieAlgebra ℚ L] {h e f : L}
 
-omit [LieAlgebra ℚ L] in
-/-- The adjoint action of `-x` is nilpotent as soon as that of `x` is. -/
-lemma isNilpotent_ad_neg {x : L} (hx : IsNilpotent (ad K L x)) : IsNilpotent (ad K L (-x)) := by
-  simpa using hx.neg
-
 /-- The **Weyl automorphism** `exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)` of a pair of
 `ad`-nilpotent elements.
 
@@ -90,13 +89,14 @@ automorphism realising the reflection in the root of `e`; the construction itsel
 triple relations, and every result below that uses them assumes them explicitly. -/
 noncomputable def weylAut (he : IsNilpotent (ad K L e)) (hf : IsNilpotent (ad K L f)) :
     L ≃ₗ⁅K⁆ L :=
-  (expAd e he).trans ((expAd (-f) (isNilpotent_ad_neg hf)).trans (expAd e he))
+  (expAd e he).trans ((expAd (-f) (by simpa using hf.neg)).trans (expAd e he))
 
 variable (he : IsNilpotent (ad K L e)) (hf : IsNilpotent (ad K L f))
+  (hf' : IsNilpotent (ad K L (-f)))
 
 /-- The Weyl automorphism as the threefold composite it is defined to be. -/
 lemma weylAut_apply (y : L) :
-    weylAut he hf y = expAd e he (expAd (-f) (isNilpotent_ad_neg hf) (expAd e he y)) := by
+    weylAut he hf y = expAd e he (expAd (-f) hf' (expAd e he y)) := by
   rw [weylAut]
   rfl
 
@@ -104,8 +104,8 @@ lemma weylAut_apply (y : L) :
 
 The values of `exp (ad e)` and `exp (ad (-f))` on `h`, `e` and `f`. Each of these vectors is killed
 by at most three brackets, so the truncations of `TauCeti/Algebra/Lie/InnerAutomorphism.lean`
-apply; the two remaining values `exp (ad e) e = e` and `exp (ad (-f)) (-f) = -f` are
-`TauCeti.expAd_apply_self`. -/
+apply; the two remaining values, `exp (ad e) e = e` and `exp (ad (-f)) f = f`, are
+`TauCeti.expAd_apply_self` and `TauCeti.expAd_apply_of_lie_eq_zero`. -/
 
 /-- `exp (ad e)` sends `h` to `h - 2 e`. -/
 lemma expAd_e_apply_h (t : IsSl2Triple h e f) : expAd e he h = h - 2 • e := by
@@ -117,69 +117,68 @@ lemma expAd_e_apply_h (t : IsSl2Triple h e f) : expAd e he h = h - 2 • e := by
 lemma expAd_e_apply_f (t : IsSl2Triple h e f) : expAd e he f = f + h - e := by
   have h₁ : ⁅e, f⁆ = h := t.lie_e_f
   have h₂ : ⁅e, h⁆ = -(2 • e) := by rw [← lie_skew e h, t.lie_h_e_nsmul]
-  rw [expAd_apply_of_lie_lie_lie_eq_zero he (by rw [h₁, h₂]; simp), h₁, h₂,
-    show ((2 : ℕ) • e) = (2 : ℚ) • e by rw [← Nat.cast_smul_eq_nsmul ℚ]; norm_num,
-    smul_neg, smul_smul]
+  -- the triple relations produce an `ℕ`-scalar, the exponential a `ℚ`-scalar; the two meet here
+  have h₃ : (2 : ℕ) • e = (2 : ℚ) • e := by rw [← Nat.cast_smul_eq_nsmul ℚ]; norm_num
+  rw [expAd_apply_of_lie_lie_lie_eq_zero he (by rw [h₁, h₂]; simp), h₁, h₂, h₃, smul_neg, smul_smul]
   norm_num
   abel
 
 /-- `exp (ad (-f))` sends `h` to `h - 2 f`. -/
-lemma expAd_neg_f_apply_h (t : IsSl2Triple h e f) :
-    expAd (-f) (isNilpotent_ad_neg hf) h = h - 2 • f := by
+lemma expAd_neg_f_apply_h (t : IsSl2Triple h e f) : expAd (-f) hf' h = h - 2 • f := by
   have h₂ : ⁅-f, h⁆ = -(2 • f) := by rw [neg_lie, ← lie_skew f h, t.lie_h_f_nsmul]; simp
-  rw [expAd_apply_of_lie_lie_eq_zero (isNilpotent_ad_neg hf) (by rw [h₂]; simp), h₂]
+  rw [expAd_apply_of_lie_lie_eq_zero hf' (by rw [h₂]; simp), h₂]
   abel
 
-/-- `exp (ad (-f))` fixes `f`. -/
-lemma expAd_neg_f_apply_f : expAd (-f) (isNilpotent_ad_neg hf) f = f :=
-  expAd_apply_of_lie_eq_zero (isNilpotent_ad_neg hf) (by simp)
-
 /-- `exp (ad (-f))` sends `e` to `e + h - f`. -/
-lemma expAd_neg_f_apply_e (t : IsSl2Triple h e f) :
-    expAd (-f) (isNilpotent_ad_neg hf) e = e + h - f := by
+lemma expAd_neg_f_apply_e (t : IsSl2Triple h e f) : expAd (-f) hf' e = e + h - f := by
   have h₁ : ⁅-f, e⁆ = h := by rw [neg_lie, lie_skew, t.lie_e_f]
   have h₂ : ⁅-f, h⁆ = -(2 • f) := by rw [neg_lie, ← lie_skew f h, t.lie_h_f_nsmul]; simp
-  rw [expAd_apply_of_lie_lie_lie_eq_zero (isNilpotent_ad_neg hf) (by rw [h₁, h₂]; simp), h₁, h₂,
-    show ((2 : ℕ) • f) = (2 : ℚ) • f by rw [← Nat.cast_smul_eq_nsmul ℚ]; norm_num,
-    smul_neg, smul_smul]
+  -- the triple relations produce an `ℕ`-scalar, the exponential a `ℚ`-scalar; the two meet here
+  have h₃ : (2 : ℕ) • f = (2 : ℚ) • f := by rw [← Nat.cast_smul_eq_nsmul ℚ]; norm_num
+  rw [expAd_apply_of_lie_lie_lie_eq_zero hf' (by rw [h₁, h₂]; simp), h₁, h₂, h₃, smul_neg,
+    smul_smul]
   norm_num
   abel
 
 /-! ### The Weyl automorphism on the triple -/
 
 /-- The Weyl automorphism negates `h`. -/
+@[simp]
 lemma weylAut_apply_h (t : IsSl2Triple h e f) : weylAut he hf h = -h := by
-  have s₁ : expAd (-f) (isNilpotent_ad_neg hf) (h - 2 • e) = -h - 2 • e := by
-    simp only [map_sub, map_nsmul, expAd_neg_f_apply_h hf t, expAd_neg_f_apply_e hf t]
+  have hf' : IsNilpotent (ad K L (-f)) := by simpa using hf.neg
+  have s₁ : expAd (-f) hf' (h - 2 • e) = -h - 2 • e := by
+    simp only [map_sub, map_nsmul, expAd_neg_f_apply_h hf' t, expAd_neg_f_apply_e hf' t]
     abel
   have s₂ : expAd e he (-h - 2 • e) = -h := by
     simp only [map_sub, map_neg, map_nsmul, expAd_e_apply_h he t, expAd_apply_self e he]
     abel
-  rw [weylAut_apply he hf, expAd_e_apply_h he t, s₁, s₂]
+  rw [weylAut_apply he hf hf', expAd_e_apply_h he t, s₁, s₂]
 
 /-- The Weyl automorphism sends the raising element to minus the lowering element. -/
 lemma weylAut_apply_e (t : IsSl2Triple h e f) : weylAut he hf e = -f := by
+  have hf' : IsNilpotent (ad K L (-f)) := by simpa using hf.neg
   have s₁ : expAd e he (e + h - f) = -f := by
     simp only [map_sub, map_add, expAd_apply_self e he, expAd_e_apply_h he t,
       expAd_e_apply_f he t]
     abel
-  rw [weylAut_apply he hf, expAd_apply_self e he, expAd_neg_f_apply_e hf t, s₁]
+  rw [weylAut_apply he hf hf', expAd_apply_self e he, expAd_neg_f_apply_e hf' t, s₁]
 
 /-- The Weyl automorphism sends the lowering element to minus the raising element. -/
 lemma weylAut_apply_f (t : IsSl2Triple h e f) : weylAut he hf f = -e := by
-  have s₁ : expAd (-f) (isNilpotent_ad_neg hf) (f + h - e) = -e := by
-    simp only [map_sub, map_add, expAd_neg_f_apply_f hf, expAd_neg_f_apply_h hf t,
-      expAd_neg_f_apply_e hf t]
+  have hf' : IsNilpotent (ad K L (-f)) := by simpa using hf.neg
+  have hff : expAd (-f) hf' f = f := expAd_apply_of_lie_eq_zero hf' (by simp)
+  have s₁ : expAd (-f) hf' (f + h - e) = -e := by
+    simp only [map_sub, map_add, hff, expAd_neg_f_apply_h hf' t, expAd_neg_f_apply_e hf' t]
     abel
-  rw [weylAut_apply he hf, expAd_e_apply_f he t, s₁, map_neg, expAd_apply_self e he]
+  rw [weylAut_apply he hf hf', expAd_e_apply_f he t, s₁, map_neg, expAd_apply_self e he]
 
 /-- The Weyl automorphism fixes the joint centraliser of `e` and `f`. -/
 lemma weylAut_apply_of_lie_eq_zero {y : L} (hye : ⁅y, e⁆ = 0) (hyf : ⁅y, f⁆ = 0) :
     weylAut he hf y = y := by
+  have hf' : IsNilpotent (ad K L (-f)) := by simpa using hf.neg
   have hey : ⁅e, y⁆ = 0 := by rw [← lie_skew e y, hye, neg_zero]
-  rw [weylAut_apply he hf, expAd_apply_of_lie_eq_zero he hey,
-    expAd_apply_of_lie_eq_zero (isNilpotent_ad_neg hf)
-      (by rw [neg_lie, ← lie_skew f y, hyf]; simp),
+  rw [weylAut_apply he hf hf', expAd_apply_of_lie_eq_zero he hey,
+    expAd_apply_of_lie_eq_zero hf' (by rw [neg_lie, ← lie_skew f y, hyf]; simp),
     expAd_apply_of_lie_eq_zero he hey]
 
 /-! ### The reflection formula -/
@@ -190,20 +189,20 @@ by the Weyl automorphism to `y - c • h`. This is the coreflection `y ↦ y - �
 lemma weylAut_apply_of_lie_eq_smul (t : IsSl2Triple h e f) {y : L} {c : K}
     (hye : ⁅y, e⁆ = c • e) (hyf : ⁅y, f⁆ = -(c • f)) :
     weylAut he hf y = y - c • h := by
+  have hf' : IsNilpotent (ad K L (-f)) := by simpa using hf.neg
   have hey : ⁅e, y⁆ = -(c • e) := by rw [← lie_skew e y, hye]
   have hfy : ⁅-f, y⁆ = -(c • f) := by rw [neg_lie, ← lie_skew f y, hyf]; simp
   have h₁ : expAd e he y = y - c • e := by
     rw [expAd_apply_of_lie_lie_eq_zero he (by rw [hey]; simp), hey, sub_eq_add_neg]
-  have h₂ : expAd (-f) (isNilpotent_ad_neg hf) y = y - c • f := by
-    rw [expAd_apply_of_lie_lie_eq_zero (isNilpotent_ad_neg hf) (by rw [hfy]; simp), hfy,
-      sub_eq_add_neg]
-  have h₃ : expAd (-f) (isNilpotent_ad_neg hf) (y - c • e) = y - c • f - c • (e + h - f) := by
-    rw [map_sub, map_smul, h₂, expAd_neg_f_apply_e hf t]
+  have h₂ : expAd (-f) hf' y = y - c • f := by
+    rw [expAd_apply_of_lie_lie_eq_zero hf' (by rw [hfy]; simp), hfy, sub_eq_add_neg]
+  have h₃ : expAd (-f) hf' (y - c • e) = y - c • f - c • (e + h - f) := by
+    rw [map_sub, map_smul, h₂, expAd_neg_f_apply_e hf' t]
   have h₄ : expAd e he (y - c • f - c • (e + h - f)) = y - c • h := by
     simp only [map_sub, map_add, map_smul, h₁, expAd_apply_self e he, expAd_e_apply_h he t,
       expAd_e_apply_f he t]
     module
-  rw [weylAut_apply he hf, h₁, h₃, h₄]
+  rw [weylAut_apply he hf hf', h₁, h₃, h₄]
 
 /-- The Weyl automorphism is an involution on the elements the reflection formula applies to. -/
 lemma weylAut_apply_sub_smul (t : IsSl2Triple h e f) {y : L} {c : K}
@@ -244,12 +243,16 @@ variable {K L : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
 open IsKilling in
 /-- **The Weyl automorphism reflects root spaces.** For the `sl₂` triple of a nonzero root `α`, the
 Weyl automorphism carries the root space of a weight `β` into the root space of the reflection
-`β - β(α^∨) • α`. -/
+`β - β(α^∨) • α`. The nilpotency of `ad e` and `ad f` is already forced by the root-space
+hypotheses, so it is supplied here rather than asked of the caller. -/
 theorem weylAut_mem_rootSpace [LieAlgebra ℚ L] {α : Weight K H L} (t : IsSl2Triple h e f)
     (heα : e ∈ rootSpace H α) (hfα : f ∈ rootSpace H (-α)) (hα : α.IsNonZero)
-    (he : IsNilpotent (ad K L e)) (hf : IsNilpotent (ad K L f))
     {β : H → K} {z : L} (hz : z ∈ rootSpace H β) :
-    weylAut he hf z ∈ rootSpace H (β - β (coroot α) • ⇑α) := by
+    weylAut (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
+        (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα) z ∈
+      rootSpace H (β - β (coroot α) • ⇑α) := by
+  set he := isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα
+  set hf := isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα
   have hh : h = (coroot α : L) := t.h_eq_coroot hα heα hfα
   have hhz : ⁅h, z⁆ = β (coroot α) • z := by
     rw [hh]; exact lie_eq_smul_of_mem_rootSpace hz (coroot α)
@@ -264,6 +267,38 @@ theorem weylAut_mem_rootSpace [LieAlgebra ℚ L] {α : Weight K H L} (t : IsSl2T
   simp [mul_comm]
 
 open IsKilling in
+/-- **The Weyl automorphism reflects root spaces**, in the sharp form: it carries the root space of
+`β` *onto* the root space of the reflection `β - β(α^∨) • α`. The reverse inclusion comes from
+`TauCeti.weylAut_mem_rootSpace` applied to the reflected weight, which the same automorphism sends
+back into the root space of `β`, together with a dimension count. -/
+theorem weylAut_map_rootSpace [LieAlgebra ℚ L] {α : Weight K H L} (t : IsSl2Triple h e f)
+    (heα : e ∈ rootSpace H α) (hfα : f ∈ rootSpace H (-α)) (hα : α.IsNonZero) (β : H → K) :
+    (rootSpace H β).toSubmodule.map
+        ((weylAut (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
+          (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα)).toLinearEquiv :
+            L →ₗ[K] L) =
+      (rootSpace H (β - β (coroot α) • ⇑α)).toSubmodule := by
+  set τ := (weylAut (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
+    (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα)).toLinearEquiv
+  -- the reflection is an involution on weights, so `τ` sends the reflected root space back
+  have hrefl : ∀ γ : H → K,
+      (γ - γ (coroot α) • ⇑α) - (γ - γ (coroot α) • ⇑α) (coroot α) • ⇑α = γ := fun γ ↦ by
+    have hcor : (γ - γ (coroot α) • ⇑α) (coroot α) = -γ (coroot α) := by
+      simp only [Pi.sub_apply, Pi.smul_apply, smul_eq_mul, root_apply_coroot hα]
+      ring
+    rw [hcor]
+    funext y
+    simp only [Pi.sub_apply, Pi.smul_apply, smul_eq_mul, neg_mul]
+    ring
+  have hmap : ∀ γ : H → K, (rootSpace H γ).toSubmodule.map (τ : L →ₗ[K] L) ≤
+      (rootSpace H (γ - γ (coroot α) • ⇑α)).toSubmodule := by
+    rintro γ _ ⟨z, hz, rfl⟩
+    exact weylAut_mem_rootSpace t heα hfα hα hz
+  refine Submodule.eq_of_le_of_finrank_le (hmap β) ?_
+  rw [LinearEquiv.finrank_map_eq, ← LinearEquiv.finrank_map_eq τ]
+  exact Submodule.finrank_mono (by simpa only [hrefl β] using hmap (β - β (coroot α) • ⇑α))
+
+open IsKilling in
 /-- Every reflection of the root system of `(L, H)` is realised by an automorphism of `L`: for a
 nonzero root `α` there is an automorphism carrying the root space of every weight `β` into the root
 space of `β - β(α^∨) • α`. This is the `sl₂` triple of `α` fed to `TauCeti.weylAut`, and it needs
@@ -273,11 +308,9 @@ theorem exists_lieEquiv_forall_mem_rootSpace {α : Weight K H L} (hα : α.IsNon
       τ z ∈ rootSpace H (β - β (coroot α) • ⇑α) := by
   let _ : LieAlgebra ℚ L := ratLieAlgebra K L
   obtain ⟨h, e, f, t, heα, hfα⟩ := exists_isSl2Triple_of_weight_isNonZero hα
-  have he : IsNilpotent (ad K L e) :=
-    isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα
-  have hf : IsNilpotent (ad K L f) :=
-    isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα
-  exact ⟨weylAut he hf, fun β z hz ↦ weylAut_mem_rootSpace t heα hfα hα he hf hz⟩
+  exact ⟨weylAut (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑α) hα heα)
+    (isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-α)) hα.neg hfα),
+    fun β z hz ↦ weylAut_mem_rootSpace t heα hfα hα hz⟩
 
 end Killing
 


### PR DESCRIPTION
This PR constructs the Weyl automorphism of an `sl₂` triple and proves that it realises the reflection on weight vectors. For a triple `t : IsSl2Triple h e f` whose raising and lowering elements act nilpotently, `TauCeti.weylAut he hf` is Chevalley's `τ = exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)`, the Lie-algebra shadow of the group element `n_α = x_α(1) x_{-α}(-1) x_α(1)`. It negates and swaps the triple — `TauCeti.weylAut_apply_h`, `TauCeti.weylAut_apply_e`, `TauCeti.weylAut_apply_f` give `h ↦ -h`, `e ↦ -f`, `f ↦ -e` — and fixes the joint centraliser of `e` and `f` (`TauCeti.weylAut_apply_of_lie_eq_zero`). From those two facts comes the reflection formula `TauCeti.weylAut_apply_of_lie_eq_smul`: an element `y` acting on `e` by a scalar `c` and on `f` by `-c` is sent to `y - c • h`, which for `y` in a Cartan subalgebra is exactly the coreflection `y ↦ y - α y • α^∨`. `TauCeti.weylAut_apply_sub_smul` is its involutivity on such `y`, and `TauCeti.lie_weylAut_apply` transports an eigenvector along it: if additionally `⁅y, z⁆ = d • z` and `⁅h, z⁆ = m • z`, then `⁅y, weylAut he hf z⁆ = (d - c * m) • weylAut he hf z`. All of that is stated for a bare `sl₂` triple over a commutative ring, in brackets alone, with no Cartan subalgebra, no weight-space decomposition and no finiteness hypothesis; the reflection is visible as arithmetic on the eigenvalues rather than as a Weyl-group element.

The last section specialises to a finite-dimensional Lie algebra with non-degenerate Killing form over a field of characteristic zero, where `LieAlgebra.IsKilling.lie_eq_smul_of_mem_rootSpace` makes the eigenvector hypotheses automatic. `TauCeti.weylAut_mem_rootSpace` then says that the Weyl automorphism of the `sl₂` triple of a nonzero root `α` carries `rootSpace H β` into `rootSpace H (β - β (coroot α) • α)`, and since `LieAlgebra.IsKilling.exists_isSl2Triple_of_weight_isNonZero` supplies such a triple for every nonzero root, `TauCeti.exists_lieEquiv_forall_mem_rootSpace` concludes that every reflection of the root system of `(L, H)` is realised by an automorphism of `L`. That is Humphreys, *Introduction to Lie Algebras and Representation Theory*, Proposition 14.3.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, the item "**The Chevalley–Demazure construction.** For each root datum, an explicitly constructed split reductive group scheme over `ℤ` realizing it, via a Chevalley basis and the Kostant `ℤ`-form of the enveloping algebra." Chevalley's proof that a basis with integral structure constants exists runs through exactly this automorphism twice: `τ_α` matches a root vector of `β` with one of `s_α β`, which is what makes a coherent choice of root vector over a whole Weyl orbit possible, and applied to the triple of `α` itself it yields `N (α, β) = -N (-α, -β)`, the sign relation that pins the constants to `±(p + 1)` rather than merely to rationals (Humphreys §25.2, Carter, *Simple Groups of Lie Type*, §4.1). After this PR, Layer 9 still owes the Chevalley basis itself, assembled from this and from the root-string structure constants; then the integrality and PBW theory of the Kostant form, the group scheme with its pinning and root subgroups, base change along `ℤ → k`, the isomorphism theorem for pinned groups, and the special isogenies in characteristics two and three.

I followed the declared upstream dependency because the preferred `CFSGStatement` roadmap has no unclaimed local step: its `I0` conventions are merged (`Index.lean`, `Closure.lean`, `GraphTwisted.lean`, `SuzukiRee.lean`, the latter already stated against the merged `TauCeti.DynkinType.IsLongSimpleRoot`), of the `S1` sporadic rows only `Fi24′` is missing and it is in flight in #2902, and `L1`–`L3` and `A0` all wait on `L0`, which its README sends to root-systems Layer 6 — whose remaining `E₇` and `E₈` data are in flight in #2809 and #2893 — and to `ReductiveGroups` Layer 9. Inside Layer 9 the adjacent Lie-algebra work is likewise taken: #2998 (structure constants along a root string), #3005 (the automorphisms of a Serre presentation), #2940 (the Kostant integral form), #2999 (coproducts of Kostant generators), #3002 (the `sl₂` divided-power relations), #2994 (the root spaces of a split pair), and the merged #2949 and #2948. None of them constructs the Weyl automorphism or says anything about how an automorphism moves root spaces, and grepping the pinned Mathlib and `TauCeti/` found no use at all of `LieDerivation.exp` outside its defining file.

Two modules are added and no existing file is touched. `TauCeti/Algebra/Lie/InnerAutomorphism.lean` (128 lines) carries the general construction: `TauCeti.expAd x hx`, the inner automorphism `exp (ad x)` of an `ad`-nilpotent element, obtained by feeding `LieAlgebra.ad K L x` to Mathlib's `LieDerivation.exp`, together with the truncations of the series that a hand computation needs — `TauCeti.expAd_apply_eq_sum` and the resulting one-, two- and three-term formulas, which cover every vector occurring in an `sl₂` triple. `TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean` (284 lines) carries the triple-specific content, beside the rest of the `sl₂` theory. The proofs reuse `LieDerivation.exp`, `IsNilpotent.exp_smul_eq_sum`, `Module.End.exp_mul_of_derivation` (through `LieDerivation.exp`), `IsSl2Triple.lie_h_e_nsmul`/`lie_h_f_nsmul`/`lie_e_f`, `IsSl2Triple.h_eq_coroot`, `LieAlgebra.isNilpotent_ad_of_mem_rootSpace`, `LieModule.weightSpace_le_genWeightSpace` and `LieModule.mem_weightSpace`. No Mathlib infrastructure or external formalization is vendored.

One design point worth flagging. Exponentiating requires dividing by factorials, so `L` must be a `ℚ`-module, and Mathlib's `LieDerivation.exp` carries that as an unbundled `[LieAlgebra ℚ L]` hypothesis alongside the base ring; this PR follows that convention verbatim rather than inventing a second one, and no compatibility between the two scalar actions is assumed, `Rat.cast_smul_eq_qsmul` supplying it where a computation mixes them. Because `K` cannot be recovered from the goal `LieAlgebra ℚ L`, no instance can produce that hypothesis, so `TauCeti.ratLieAlgebra` is a `def` for a consumer to `letI`; `Subsingleton (LieAlgebra ℚ L)` makes the choice harmless, and `TauCeti.exists_lieEquiv_forall_mem_rootSpace` uses it to state the Killing-setting conclusion with no `ℚ` hypothesis at all.

`TauCeti.weylAut` takes the two nilpotency proofs rather than the triple, because the composite `exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)` is a function of `e` and `f` alone and a triple argument would be unused in the body; every lemma whose content needs the triple relations takes `IsSl2Triple h e f` explicitly, so the name is the only place the intended input is recorded, and its docstring says so.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

Dependency edge: `CFSGStatement` milestone `L0`, "pinned ambient groups", defines `ValidLieTypeIndex.AmbientGroup` as the points of an explicitly constructed pinned Chevalley–Demazure group scheme, which its README assigns to Layer 9 of `ReductiveGroups`; that layer builds the scheme "via a Chevalley basis and the Kostant `ℤ`-form of the enveloping algebra", and the Chevalley basis is produced by choosing root vectors compatibly across each Weyl orbit and fixing their signs, which is what `TauCeti.weylAut_mem_rootSpace` and `TauCeti.weylAut_apply_e` respectively supply.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"sl2-triple-weyl-automorphism"}-->

🤖 Prepared with Claude Code
