### PR TITLE
feat: make point Jordan decomposition natural

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.lean
@@ -95,6 +95,18 @@ noncomputable def jordanDecomposition (g : WithConv (H →ₐ[k] K)) :
     WithConv (H →ₐ[k] K) × WithConv (H →ₐ[k] K) :=
   (semisimplePart k H K g, unipotentPart k H K g)
 
+/-- The first component of the Jordan decomposition is the semisimple part. -/
+@[simp]
+theorem jordanDecomposition_fst (g : WithConv (H →ₐ[k] K)) :
+    (jordanDecomposition k H K g).1 = semisimplePart k H K g :=
+  (rfl)
+
+/-- The second component of the Jordan decomposition is the unipotent part. -/
+@[simp]
+theorem jordanDecomposition_snd (g : WithConv (H →ₐ[k] K)) :
+    (jordanDecomposition k H K g).2 = unipotentPart k H K g :=
+  (rfl)
+
 /-- The Tannakian action of the semisimple part is the semisimple-factor tensor
 automorphism. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.JordanDecomposition.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Representation.SemisimplePoint
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
+public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Corestrict
+
+/-!
+# Naturality of Jordan decomposition for algebraic-group points
+
+A bialgebra morphism `φ : H₁ →ₐc[k] H₂` between coordinate Hopf algebras represents a
+homomorphism in the opposite direction between the corresponding affine groups. On points this
+homomorphism is precomposition, `TauCeti.AlgHom.mapDomain φ`.
+
+This file proves that point-level Jordan decomposition is natural under these homomorphisms. The
+key compatibility is representation-theoretic: acting by the precomposed point on an
+`H₁`-comodule is the same as first corestricting that comodule along `φ` and then acting by the
+original `H₂`-point. Consequently `mapDomain φ` preserves semisimple points, and uniqueness of
+the commuting semisimple--unipotent factorization identifies the images of both Jordan factors.
+
+This is the functoriality-under-homomorphisms part of Layer 4, "Jordan decomposition", in the
+ReductiveGroups roadmap.
+
+## Main declarations
+
+* `TauCeti.Comodule.endOfPoint_corestrict`: compatibility of point endomorphisms with
+  corestriction and precomposition.
+* `TauCeti.Comodule.pointsAction_corestrict`: the corresponding equality of point actions.
+* `TauCeti.HopfAlgebra.IsSemisimplePoint.mapDomain`: a homomorphism of affine groups preserves
+  semisimple points.
+* `TauCeti.HopfAlgebra.Point.jordanDecomposition_mapDomain`: Jordan decomposition commutes with
+  a homomorphism of affine groups.
+* `TauCeti.HopfAlgebra.Point.semisimplePart_mapDomain` and
+  `TauCeti.HopfAlgebra.Point.unipotentPart_mapDomain`: the two component formulas.
+
+## References
+
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+* J. S. Milne, *Algebraic Groups* (2017), §9.4.
+-/
+
+public section
+
+open WithConv
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w x
+
+namespace Comodule
+
+variable {k : Type u} {H₁ : Type v} {H₂ : Type w} {K : Type x}
+variable [CommSemiring k] [Semiring H₁] [Semiring H₂]
+variable [CommSemiring K] [Algebra k K]
+
+section Bialgebra
+
+variable [_root_.Bialgebra k H₁] [_root_.Bialgebra k H₂]
+variable {V : Type*} [AddCommMonoid V] [Module k V] [Comodule k H₁ V]
+
+/-- Acting on a comodule by a point precomposed with a bialgebra morphism is the same as
+corestricting the comodule along that morphism and acting by the original point. -/
+theorem endOfPoint_corestrict (φ : H₁ →ₐc[k] H₂)
+    (g : WithConv (H₂ →ₐ[k] K)) :
+    (letI : Comodule k H₂ V := Corestrict φ.toCoalgHom
+     endOfPoint V g.ofConv) = endOfPoint V (AlgHom.mapDomain φ g).ofConv := by
+  apply TensorProduct.AlgebraTensorModule.ext
+  intro a v
+  rw [endOfPoint_tmul, endOfPoint_tmul]
+  simp only [corestrict_coact_apply, AlgHom.mapDomain_apply,
+    AlgHom.comp_toLinearMap]
+  rw [LinearMap.lTensor_comp, LinearMap.comp_apply]
+  rfl
+
+end Bialgebra
+
+section HopfAlgebra
+
+variable [_root_.HopfAlgebra k H₁] [_root_.HopfAlgebra k H₂]
+variable {V : Type*} [AddCommMonoid V] [Module k V] [Comodule k H₁ V]
+
+/-- The linear action of a precomposed point agrees with the action of the original point on
+the corestricted comodule. -/
+theorem pointsAction_corestrict (φ : H₁ →ₐc[k] H₂)
+    (g : WithConv (H₂ →ₐ[k] K)) :
+    (letI : Comodule k H₂ V := Corestrict φ.toCoalgHom
+     pointsAction V g) = pointsAction V (AlgHom.mapDomain φ g) := by
+  let : Comodule k H₂ V := Corestrict φ.toCoalgHom
+  apply LinearEquiv.ext
+  exact LinearMap.congr_fun <|
+    (pointsAction_toLinearMap V g).trans <|
+      (endOfPoint_corestrict φ g).trans <|
+        (pointsAction_toLinearMap V (AlgHom.mapDomain φ g)).symm
+
+end HopfAlgebra
+
+end Comodule
+
+namespace HopfAlgebra
+
+variable {k H₁ H₂ K : Type u}
+variable [Field k] [CommRing H₁] [CommRing H₂]
+variable [_root_.HopfAlgebra k H₁] [_root_.HopfAlgebra k H₂]
+variable [Field K] [Algebra k K]
+
+/-- A homomorphism of affine groups sends semisimple points to semisimple points. In coordinate
+algebras the homomorphism is represented contravariantly by a bialgebra morphism. -/
+theorem IsSemisimplePoint.mapDomain {g : WithConv (H₂ →ₐ[k] K)}
+    (hg : IsSemisimplePoint g) (φ : H₁ →ₐc[k] H₂) :
+    IsSemisimplePoint (AlgHom.mapDomain φ g) := by
+  rw [isSemisimplePoint_def] at hg ⊢
+  intro M
+  rw [← Comodule.pointsAction_corestrict (V := M) φ g]
+  exact hg ((FGComoduleCat.corestrict φ.toCoalgHom).obj M)
+
+namespace Point
+
+variable [PerfectField K]
+
+/-- The Jordan decomposition of an algebraic-group point commutes with a homomorphism of affine
+groups. The coordinate-algebra morphism points in the opposite direction. -/
+theorem jordanDecomposition_mapDomain (φ : H₁ →ₐc[k] H₂)
+    (g : WithConv (H₂ →ₐ[k] K)) :
+    jordanDecomposition k H₁ K (AlgHom.mapDomain φ g) =
+      (AlgHom.mapDomain φ (semisimplePart k H₂ K g),
+        AlgHom.mapDomain φ (unipotentPart k H₂ K g)) := by
+  symm
+  apply (eq_jordanDecomposition_iff k H₁ K (AlgHom.mapDomain φ g) _ _).2
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro M
+    rw [← Comodule.pointsAction_corestrict (V := M) φ]
+    exact isSemisimple_pointsAction_semisimplePart k H₂ K g
+      ((FGComoduleCat.corestrict φ.toCoalgHom).obj M)
+  · intro M
+    rw [← Comodule.pointsAction_corestrict (V := M) φ]
+    exact isUnipotent_pointsAction_unipotentPart k H₂ K g
+      ((FGComoduleCat.corestrict φ.toCoalgHom).obj M)
+  · exact (commute_semisimplePart_unipotentPart k H₂ K g).map (AlgHom.mapDomain φ)
+  · rw [← map_mul, semisimplePart_mul_unipotentPart]
+
+/-- The semisimple part of a point is preserved by homomorphisms of affine groups. -/
+@[simp]
+theorem semisimplePart_mapDomain (φ : H₁ →ₐc[k] H₂)
+    (g : WithConv (H₂ →ₐ[k] K)) :
+    semisimplePart k H₁ K (toConv (g.ofConv.comp (φ : H₁ →ₐ[k] H₂))) =
+      toConv ((semisimplePart k H₂ K g).ofConv.comp (φ : H₁ →ₐ[k] H₂)) := by
+  simpa only [jordanDecomposition_fst, AlgHom.mapDomain_apply] using
+      congrArg Prod.fst (jordanDecomposition_mapDomain φ g)
+
+/-- The unipotent part of a point is preserved by homomorphisms of affine groups. -/
+@[simp]
+theorem unipotentPart_mapDomain (φ : H₁ →ₐc[k] H₂)
+    (g : WithConv (H₂ →ₐ[k] K)) :
+    unipotentPart k H₁ K (toConv (g.ofConv.comp (φ : H₁ →ₐ[k] H₂))) =
+      toConv ((unipotentPart k H₂ K g).ofConv.comp (φ : H₁ →ₐ[k] H₂)) := by
+  simpa only [jordanDecomposition_snd, AlgHom.mapDomain_apply] using
+      congrArg Prod.snd (jordanDecomposition_mapDomain φ g)
+
+end Point
+end HopfAlgebra
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
@@ -72,7 +72,8 @@ theorem jordanDecomposition_mapDomain (φ : H₁ →ₐc[k] H₂)
     apply IsSemisimplePoint.mapDomain ?_ φ
     rw [isSemisimplePoint_def]
     exact fun M ↦ isSemisimple_pointsAction_semisimplePart k H₂ K g M
-  · intro M
+  · rw [isUnipotentPoint_def]
+    intro M
     rw [← Comodule.pointsAction_corestrict_obj φ M]
     exact isUnipotent_pointsAction_unipotentPart k H₂ K g
       ((FGComoduleCat.corestrict φ.toCoalgHom).obj M)

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
@@ -29,7 +29,8 @@ ReductiveGroups roadmap.
 * `TauCeti.HopfAlgebra.Point.jordanDecomposition_mapDomain`: Jordan decomposition commutes with
   a homomorphism of affine groups.
 * `TauCeti.HopfAlgebra.Point.semisimplePart_mapDomain` and
-  `TauCeti.HopfAlgebra.Point.unipotentPart_mapDomain`: the two component formulas.
+  `TauCeti.HopfAlgebra.Point.unipotentPart_mapDomain`: the two component formulas, with
+  `semisimplePart_toConv_comp` and `unipotentPart_toConv_comp` as their simp-normal forms.
 
 ## References
 
@@ -72,29 +73,47 @@ theorem jordanDecomposition_mapDomain (φ : H₁ →ₐc[k] H₂)
     rw [isSemisimplePoint_def]
     exact fun M ↦ isSemisimple_pointsAction_semisimplePart k H₂ K g M
   · intro M
-    rw [← Comodule.pointsAction_corestrict (V := M) φ]
+    rw [← Comodule.pointsAction_corestrict_obj φ M]
     exact isUnipotent_pointsAction_unipotentPart k H₂ K g
       ((FGComoduleCat.corestrict φ.toCoalgHom).obj M)
   · exact (commute_semisimplePart_unipotentPart k H₂ K g).map (AlgHom.mapDomain φ)
   · rw [← map_mul, semisimplePart_mul_unipotentPart]
 
-/-- The semisimple part of a point is preserved by homomorphisms of affine groups. -/
-@[simp]
+/-- Taking the semisimple part commutes with precomposition by a bialgebra morphism, the
+contravariant coordinate-algebra form of an affine-group homomorphism. -/
 theorem semisimplePart_mapDomain (φ : H₁ →ₐc[k] H₂)
+    (g : WithConv (H₂ →ₐ[k] K)) :
+    semisimplePart k H₁ K (AlgHom.mapDomain φ g) =
+      AlgHom.mapDomain φ (semisimplePart k H₂ K g) := by
+  simpa only [jordanDecomposition_fst] using
+      congrArg Prod.fst (jordanDecomposition_mapDomain φ g)
+
+/-- Taking the unipotent part commutes with precomposition by a bialgebra morphism, the
+contravariant coordinate-algebra form of an affine-group homomorphism. -/
+theorem unipotentPart_mapDomain (φ : H₁ →ₐc[k] H₂)
+    (g : WithConv (H₂ →ₐ[k] K)) :
+    unipotentPart k H₁ K (AlgHom.mapDomain φ g) =
+      AlgHom.mapDomain φ (unipotentPart k H₂ K g) := by
+  simpa only [jordanDecomposition_snd] using
+      congrArg Prod.snd (jordanDecomposition_mapDomain φ g)
+
+/-- Simp-normal form of `semisimplePart_mapDomain`: taking the semisimple part commutes
+with `AlgHom.mapDomain φ`, written after normalization by `AlgHom.mapDomain_apply`. -/
+@[simp]
+theorem semisimplePart_toConv_comp (φ : H₁ →ₐc[k] H₂)
     (g : WithConv (H₂ →ₐ[k] K)) :
     semisimplePart k H₁ K (toConv (g.ofConv.comp (φ : H₁ →ₐ[k] H₂))) =
       toConv ((semisimplePart k H₂ K g).ofConv.comp (φ : H₁ →ₐ[k] H₂)) := by
-  simpa only [jordanDecomposition_fst, AlgHom.mapDomain_apply] using
-      congrArg Prod.fst (jordanDecomposition_mapDomain φ g)
+  simpa only [AlgHom.mapDomain_apply] using semisimplePart_mapDomain φ g
 
-/-- The unipotent part of a point is preserved by homomorphisms of affine groups. -/
+/-- Simp-normal form of `unipotentPart_mapDomain`: taking the unipotent part commutes
+with `AlgHom.mapDomain φ`, written after normalization by `AlgHom.mapDomain_apply`. -/
 @[simp]
-theorem unipotentPart_mapDomain (φ : H₁ →ₐc[k] H₂)
+theorem unipotentPart_toConv_comp (φ : H₁ →ₐc[k] H₂)
     (g : WithConv (H₂ →ₐ[k] K)) :
     unipotentPart k H₁ K (toConv (g.ofConv.comp (φ : H₁ →ₐ[k] H₂))) =
       toConv ((unipotentPart k H₂ K g).ofConv.comp (φ : H₁ →ₐ[k] H₂)) := by
-  simpa only [jordanDecomposition_snd, AlgHom.mapDomain_apply] using
-      congrArg Prod.snd (jordanDecomposition_mapDomain φ g)
+  simpa only [AlgHom.mapDomain_apply] using unipotentPart_mapDomain φ g
 
 end Point
 end HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
@@ -6,8 +6,6 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Representation.JordanDecomposition.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Representation.SemisimplePoint
-public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
-public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Corestrict
 
 /-!
 # Naturality of Jordan decomposition for algebraic-group points
@@ -19,19 +17,15 @@ homomorphism is precomposition, `TauCeti.AlgHom.mapDomain φ`.
 This file proves that point-level Jordan decomposition is natural under these homomorphisms. The
 key compatibility is representation-theoretic: acting by the precomposed point on an
 `H₁`-comodule is the same as first corestricting that comodule along `φ` and then acting by the
-original `H₂`-point. Consequently `mapDomain φ` preserves semisimple points, and uniqueness of
-the commuting semisimple--unipotent factorization identifies the images of both Jordan factors.
+original `H₂`-point. The earlier point-action and semisimple-point APIs provide this compatibility;
+uniqueness of the commuting semisimple--unipotent factorization then identifies the images of both
+Jordan factors.
 
 This is the functoriality-under-homomorphisms part of Layer 4, "Jordan decomposition", in the
 ReductiveGroups roadmap.
 
 ## Main declarations
 
-* `TauCeti.Comodule.endOfPoint_corestrict`: compatibility of point endomorphisms with
-  corestriction and precomposition.
-* `TauCeti.Comodule.pointsAction_corestrict`: the corresponding equality of point actions.
-* `TauCeti.HopfAlgebra.IsSemisimplePoint.mapDomain`: a homomorphism of affine groups preserves
-  semisimple points.
 * `TauCeti.HopfAlgebra.Point.jordanDecomposition_mapDomain`: Jordan decomposition commutes with
   a homomorphism of affine groups.
 * `TauCeti.HopfAlgebra.Point.semisimplePart_mapDomain` and
@@ -50,56 +44,7 @@ open scoped TensorProduct
 
 namespace TauCeti
 
-universe u v w x
-
-namespace Comodule
-
-variable {k : Type u} {H₁ : Type v} {H₂ : Type w} {K : Type x}
-variable [CommSemiring k] [Semiring H₁] [Semiring H₂]
-variable [CommSemiring K] [Algebra k K]
-
-section Bialgebra
-
-variable [_root_.Bialgebra k H₁] [_root_.Bialgebra k H₂]
-variable {V : Type*} [AddCommMonoid V] [Module k V] [Comodule k H₁ V]
-
-/-- Acting on a comodule by a point precomposed with a bialgebra morphism is the same as
-corestricting the comodule along that morphism and acting by the original point. -/
-theorem endOfPoint_corestrict (φ : H₁ →ₐc[k] H₂)
-    (g : WithConv (H₂ →ₐ[k] K)) :
-    (letI : Comodule k H₂ V := Corestrict φ.toCoalgHom
-     endOfPoint V g.ofConv) = endOfPoint V (AlgHom.mapDomain φ g).ofConv := by
-  apply TensorProduct.AlgebraTensorModule.ext
-  intro a v
-  rw [endOfPoint_tmul, endOfPoint_tmul]
-  simp only [corestrict_coact_apply, AlgHom.mapDomain_apply,
-    AlgHom.comp_toLinearMap]
-  rw [LinearMap.lTensor_comp, LinearMap.comp_apply]
-  rfl
-
-end Bialgebra
-
-section HopfAlgebra
-
-variable [_root_.HopfAlgebra k H₁] [_root_.HopfAlgebra k H₂]
-variable {V : Type*} [AddCommMonoid V] [Module k V] [Comodule k H₁ V]
-
-/-- The linear action of a precomposed point agrees with the action of the original point on
-the corestricted comodule. -/
-theorem pointsAction_corestrict (φ : H₁ →ₐc[k] H₂)
-    (g : WithConv (H₂ →ₐ[k] K)) :
-    (letI : Comodule k H₂ V := Corestrict φ.toCoalgHom
-     pointsAction V g) = pointsAction V (AlgHom.mapDomain φ g) := by
-  let : Comodule k H₂ V := Corestrict φ.toCoalgHom
-  apply LinearEquiv.ext
-  exact LinearMap.congr_fun <|
-    (pointsAction_toLinearMap V g).trans <|
-      (endOfPoint_corestrict φ g).trans <|
-        (pointsAction_toLinearMap V (AlgHom.mapDomain φ g)).symm
-
-end HopfAlgebra
-
-end Comodule
+universe u
 
 namespace HopfAlgebra
 
@@ -107,16 +52,6 @@ variable {k H₁ H₂ K : Type u}
 variable [Field k] [CommRing H₁] [CommRing H₂]
 variable [_root_.HopfAlgebra k H₁] [_root_.HopfAlgebra k H₂]
 variable [Field K] [Algebra k K]
-
-/-- A homomorphism of affine groups sends semisimple points to semisimple points. In coordinate
-algebras the homomorphism is represented contravariantly by a bialgebra morphism. -/
-theorem IsSemisimplePoint.mapDomain {g : WithConv (H₂ →ₐ[k] K)}
-    (hg : IsSemisimplePoint g) (φ : H₁ →ₐc[k] H₂) :
-    IsSemisimplePoint (AlgHom.mapDomain φ g) := by
-  rw [isSemisimplePoint_def] at hg ⊢
-  intro M
-  rw [← Comodule.pointsAction_corestrict (V := M) φ g]
-  exact hg ((FGComoduleCat.corestrict φ.toCoalgHom).obj M)
 
 namespace Point
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
@@ -80,6 +80,16 @@ theorem jordanDecomposition_mapDomain (φ : H₁ →ₐc[k] H₂)
   · exact (commute_semisimplePart_unipotentPart k H₂ K g).map (AlgHom.mapDomain φ)
   · rw [← map_mul, semisimplePart_mul_unipotentPart]
 
+/-- Simp-normal form of `jordanDecomposition_mapDomain`, with each precomposed point written
+after normalization by `AlgHom.mapDomain_apply`. -/
+@[simp]
+theorem jordanDecomposition_toConv_comp (φ : H₁ →ₐc[k] H₂)
+    (g : WithConv (H₂ →ₐ[k] K)) :
+    jordanDecomposition k H₁ K (toConv (g.ofConv.comp (φ : H₁ →ₐ[k] H₂))) =
+      (toConv ((semisimplePart k H₂ K g).ofConv.comp (φ : H₁ →ₐ[k] H₂)),
+        toConv ((unipotentPart k H₂ K g).ofConv.comp (φ : H₁ →ₐ[k] H₂))) := by
+  simpa only [AlgHom.mapDomain_apply] using jordanDecomposition_mapDomain φ g
+
 /-- Taking the semisimple part commutes with precomposition by a bialgebra morphism, the
 contravariant coordinate-algebra form of an affine-group homomorphism. -/
 theorem semisimplePart_mapDomain (φ : H₁ →ₐc[k] H₂)

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
@@ -67,10 +67,10 @@ theorem jordanDecomposition_mapDomain (φ : H₁ →ₐc[k] H₂)
   symm
   apply (eq_jordanDecomposition_iff k H₁ K (AlgHom.mapDomain φ g) _ _).2
   refine ⟨?_, ?_, ?_, ?_⟩
-  · intro M
-    rw [← Comodule.pointsAction_corestrict (V := M) φ]
-    exact isSemisimple_pointsAction_semisimplePart k H₂ K g
-      ((FGComoduleCat.corestrict φ.toCoalgHom).obj M)
+  · rw [← isSemisimplePoint_def]
+    apply IsSemisimplePoint.mapDomain ?_ φ
+    rw [isSemisimplePoint_def]
+    exact fun M ↦ isSemisimple_pointsAction_semisimplePart k H₂ K g M
   · intro M
     rw [← Comodule.pointsAction_corestrict (V := M) φ]
     exact isUnipotent_pointsAction_unipotentPart k H₂ K g

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -113,6 +113,16 @@ theorem pointsAction_corestrict_obj (φ : H₁ →ₐc[R] H₂)
     pointsAction M g) = pointsAction M (AlgHom.mapDomain φ g)
   exact pointsAction_corestrict φ g
 
+/-- Simp-normal form of `pointsAction_corestrict_obj`, with the precomposed point written
+after normalization by `AlgHom.mapDomain_apply`. -/
+-- Prefer this bundled normal form before `corestrict_obj_coe` exposes the carrier.
+@[simp↓ high]
+theorem pointsAction_corestrict_obj_toConv_comp (φ : H₁ →ₐc[R] H₂)
+    (M : FGComoduleCat.{u, v, y} R H₁) (g : WithConv (H₂ →ₐ[R] A)) :
+    pointsAction ((FGComoduleCat.corestrict φ.toCoalgHom).obj M) g =
+      pointsAction M (toConv (g.ofConv.comp (φ : H₁ →ₐ[R] H₂))) := by
+  simpa only [AlgHom.mapDomain_apply] using pointsAction_corestrict_obj φ M g
+
 end HopfAlgebra
 
 end Corestrict

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
+public import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 public import TauCeti.Algebra.Coalgebra.Comodule.PointsAction
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 
@@ -23,6 +25,9 @@ than by an antipode computation.
 
 * `TauCeti.Comodule.pointsAction`: the action of the group of points by linear
   automorphisms of `A ⊗[R] V`.
+* `TauCeti.Comodule.endOfPoint_corestrict` and
+  `TauCeti.Comodule.pointsAction_corestrict`: compatibility of point actions with
+  corestriction and precomposition.
 -/
 
 public section
@@ -56,6 +61,57 @@ lemma pointsAction_toLinearMap (g : WithConv (H →ₐ[R] A)) :
     ((pointsRepresentation V).asGroupHom g) : A ⊗[R] V →ₗ[A] A ⊗[R] V) = _
   rw [LinearMap.GeneralLinearGroup.generalLinearEquiv_to_linearMap,
     Representation.asGroupHom_apply, pointsRepresentation_apply]
+
+universe u v w x
+
+section Corestrict
+
+variable {R : Type u} {H₁ : Type v} {H₂ : Type w} {A : Type x}
+variable [CommSemiring R] [Semiring H₁] [Semiring H₂]
+variable [CommSemiring A] [Algebra R A]
+
+section Bialgebra
+
+variable [Bialgebra R H₁] [Bialgebra R H₂]
+variable {V : Type*} [AddCommMonoid V] [Module R V] [Comodule R H₁ V]
+
+/-- Acting on a comodule by a point precomposed with a bialgebra morphism is the same as
+corestricting the comodule along that morphism and acting by the original point. -/
+theorem endOfPoint_corestrict (φ : H₁ →ₐc[R] H₂)
+    (g : WithConv (H₂ →ₐ[R] A)) :
+    (letI : Comodule R H₂ V := Corestrict φ.toCoalgHom
+     endOfPoint V g.ofConv) = endOfPoint V (AlgHom.mapDomain φ g).ofConv := by
+  apply TensorProduct.AlgebraTensorModule.ext
+  intro a v
+  rw [endOfPoint_tmul, endOfPoint_tmul]
+  simp only [corestrict_coact_apply, AlgHom.mapDomain_apply,
+    AlgHom.comp_toLinearMap]
+  rw [LinearMap.lTensor_comp, LinearMap.comp_apply]
+  rfl
+
+end Bialgebra
+
+section HopfAlgebra
+
+variable [HopfAlgebra R H₁] [HopfAlgebra R H₂]
+variable {V : Type*} [AddCommMonoid V] [Module R V] [Comodule R H₁ V]
+
+/-- The linear action of a precomposed point agrees with the action of the original point on
+the corestricted comodule. -/
+theorem pointsAction_corestrict (φ : H₁ →ₐc[R] H₂)
+    (g : WithConv (H₂ →ₐ[R] A)) :
+    (letI : Comodule R H₂ V := Corestrict φ.toCoalgHom
+     pointsAction V g) = pointsAction V (AlgHom.mapDomain φ g) := by
+  let : Comodule R H₂ V := Corestrict φ.toCoalgHom
+  apply LinearEquiv.ext
+  exact LinearMap.congr_fun <|
+    (pointsAction_toLinearMap V g).trans <|
+      (endOfPoint_corestrict φ g).trans <|
+        (pointsAction_toLinearMap V (AlgHom.mapDomain φ g)).symm
+
+end HopfAlgebra
+
+end Corestrict
 
 end Comodule
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
-public import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
+public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Corestrict
 public import TauCeti.Algebra.Coalgebra.Comodule.PointsAction
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 
@@ -25,9 +25,9 @@ than by an antipode computation.
 
 * `TauCeti.Comodule.pointsAction`: the action of the group of points by linear
   automorphisms of `A ⊗[R] V`.
-* `TauCeti.Comodule.endOfPoint_corestrict` and
-  `TauCeti.Comodule.pointsAction_corestrict`: compatibility of point actions with
-  corestriction and precomposition.
+* `TauCeti.Comodule.pointsAction_corestrict`: compatibility of point actions with
+  corestriction and precomposition, also provided for bundled finite comodules by
+  `TauCeti.Comodule.pointsAction_corestrict_obj`.
 -/
 
 public section
@@ -62,34 +62,13 @@ lemma pointsAction_toLinearMap (g : WithConv (H →ₐ[R] A)) :
   rw [LinearMap.GeneralLinearGroup.generalLinearEquiv_to_linearMap,
     Representation.asGroupHom_apply, pointsRepresentation_apply]
 
-universe u v w x
+universe u v w x y
 
 section Corestrict
 
 variable {R : Type u} {H₁ : Type v} {H₂ : Type w} {A : Type x}
 variable [CommSemiring R] [Semiring H₁] [Semiring H₂]
 variable [CommSemiring A] [Algebra R A]
-
-section Bialgebra
-
-variable [Bialgebra R H₁] [Bialgebra R H₂]
-variable {V : Type*} [AddCommMonoid V] [Module R V] [Comodule R H₁ V]
-
-/-- Acting on a comodule by a point precomposed with a bialgebra morphism is the same as
-corestricting the comodule along that morphism and acting by the original point. -/
-theorem endOfPoint_corestrict (φ : H₁ →ₐc[R] H₂)
-    (g : WithConv (H₂ →ₐ[R] A)) :
-    (letI : Comodule R H₂ V := Corestrict φ.toCoalgHom
-     endOfPoint V g.ofConv) = endOfPoint V (AlgHom.mapDomain φ g).ofConv := by
-  apply TensorProduct.AlgebraTensorModule.ext
-  intro a v
-  rw [endOfPoint_tmul, endOfPoint_tmul]
-  simp only [corestrict_coact_apply, AlgHom.mapDomain_apply,
-    AlgHom.comp_toLinearMap]
-  rw [LinearMap.lTensor_comp, LinearMap.comp_apply]
-  rfl
-
-end Bialgebra
 
 section HopfAlgebra
 
@@ -106,8 +85,23 @@ theorem pointsAction_corestrict (φ : H₁ →ₐc[R] H₂)
   apply LinearEquiv.ext
   exact LinearMap.congr_fun <|
     (pointsAction_toLinearMap V g).trans <|
-      (endOfPoint_corestrict φ g).trans <|
-        (pointsAction_toLinearMap V (AlgHom.mapDomain φ g)).symm
+      (endOfPoint_corestrict φ g.ofConv).trans <|
+        (by
+          rw [AlgHom.mapDomain_apply, ofConv_toConv]
+          exact (pointsAction_toLinearMap V
+            (toConv (g.ofConv.comp (φ : H₁ →ₐ[R] H₂)))).symm)
+
+/-- Bundled finite-comodule form of `pointsAction_corestrict`. This avoids exposing the
+definitionally equal comodule instance carried by the corestricted object to callers. -/
+theorem pointsAction_corestrict_obj (φ : H₁ →ₐc[R] H₂)
+    (M : FGComoduleCat.{u, v, y} R H₁) (g : WithConv (H₂ →ₐ[R] A)) :
+    pointsAction ((FGComoduleCat.corestrict φ.toCoalgHom).obj M) g =
+      pointsAction M (AlgHom.mapDomain φ g) := by
+  -- The bundled object's comodule instance is definitionally `Corestrict`; expose that
+  -- identification once here so downstream proofs can rewrite by a named theorem.
+  change (letI : Comodule R H₂ M := Corestrict φ.toCoalgHom
+    pointsAction M g) = pointsAction M (AlgHom.mapDomain φ g)
+  exact pointsAction_corestrict φ g
 
 end HopfAlgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -91,6 +91,16 @@ theorem pointsAction_corestrict (φ : H₁ →ₐc[R] H₂)
           exact (pointsAction_toLinearMap V
             (toConv (g.ofConv.comp (φ : H₁ →ₐ[R] H₂)))).symm)
 
+/-- Simp-normal form of `pointsAction_corestrict`, with the precomposed point written
+after normalization by `AlgHom.mapDomain_apply`. -/
+@[simp]
+theorem pointsAction_corestrict_toConv_comp (φ : H₁ →ₐc[R] H₂)
+    (g : WithConv (H₂ →ₐ[R] A)) :
+    (letI : Comodule R H₂ V := Corestrict φ.toCoalgHom
+     pointsAction V g) =
+      pointsAction V (toConv (g.ofConv.comp (φ : H₁ →ₐ[R] H₂))) := by
+  simpa only [AlgHom.mapDomain_apply] using pointsAction_corestrict φ g
+
 /-- Bundled finite-comodule form of `pointsAction_corestrict`. This avoids exposing the
 definitionally equal comodule instance carried by the corestricted object to callers. -/
 theorem pointsAction_corestrict_obj (φ : H₁ →ₐc[R] H₂)
@@ -102,6 +112,15 @@ theorem pointsAction_corestrict_obj (φ : H₁ →ₐc[R] H₂)
   change (letI : Comodule R H₂ M := Corestrict φ.toCoalgHom
     pointsAction M g) = pointsAction M (AlgHom.mapDomain φ g)
   exact pointsAction_corestrict φ g
+
+/-- Simp-normal form of `pointsAction_corestrict_obj`, with the precomposed point written
+after normalization by `AlgHom.mapDomain_apply`. -/
+@[simp]
+theorem pointsAction_corestrict_obj_toConv_comp (φ : H₁ →ₐc[R] H₂)
+    (M : FGComoduleCat.{u, v, y} R H₁) (g : WithConv (H₂ →ₐ[R] A)) :
+    pointsAction ((FGComoduleCat.corestrict φ.toCoalgHom).obj M) g =
+      pointsAction M (toConv (g.ofConv.comp (φ : H₁ →ₐ[R] H₂))) := by
+  simpa only [AlgHom.mapDomain_apply] using pointsAction_corestrict_obj φ M g
 
 end HopfAlgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -113,15 +113,6 @@ theorem pointsAction_corestrict_obj (φ : H₁ →ₐc[R] H₂)
     pointsAction M g) = pointsAction M (AlgHom.mapDomain φ g)
   exact pointsAction_corestrict φ g
 
-/-- Simp-normal form of `pointsAction_corestrict_obj`, with the precomposed point written
-after normalization by `AlgHom.mapDomain_apply`. -/
-@[simp]
-theorem pointsAction_corestrict_obj_toConv_comp (φ : H₁ →ₐc[R] H₂)
-    (M : FGComoduleCat.{u, v, y} R H₁) (g : WithConv (H₂ →ₐ[R] A)) :
-    pointsAction ((FGComoduleCat.corestrict φ.toCoalgHom).obj M) g =
-      pointsAction M (toConv (g.ofConv.comp (φ : H₁ →ₐ[R] H₂))) := by
-  simpa only [AlgHom.mapDomain_apply] using pointsAction_corestrict_obj φ M g
-
 end HopfAlgebra
 
 end Corestrict

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Representation.ScalarExtension
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
+public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Corestrict
 public import TauCeti.LinearAlgebra.JordanChevalley.Functoriality
 
 /-!
@@ -31,6 +33,8 @@ invariant under conjugation.
   formulation using the underlying comodule action endomorphisms.
 * `TauCeti.HopfAlgebra.IsSemisimplePoint.inv`, `.mul_of_commute`, and `.zpow`: closure under
   inversion, commuting products, and integer powers.
+* `TauCeti.HopfAlgebra.IsSemisimplePoint.mapDomain`: a homomorphism of affine groups preserves
+  semisimple points.
 * `TauCeti.HopfAlgebra.isSemisimplePoint_conj_iff`: invariance under conjugation.
 
 ## References
@@ -52,7 +56,7 @@ namespace TauCeti
 
 namespace HopfAlgebra
 
-universe u v x
+universe u v w x
 
 variable {k : Type u} {H : Type v} {K : Type x}
 variable [CommSemiring k] [Semiring H] [_root_.HopfAlgebra k H] [Field K] [Algebra k K]
@@ -76,6 +80,24 @@ theorem isSemisimplePoint_def (g : WithConv (H →ₐ[k] K)) :
       GeneralLinearGroup.IsSemisimple
         (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :=
   Iff.rfl
+
+section MapDomain
+
+variable {H₁ : Type v} {H₂ : Type w}
+variable [Semiring H₁] [Semiring H₂]
+variable [_root_.HopfAlgebra k H₁] [_root_.HopfAlgebra k H₂]
+
+/-- A homomorphism of affine groups sends semisimple points to semisimple points. In coordinate
+algebras the homomorphism is represented contravariantly by a bialgebra morphism. -/
+theorem IsSemisimplePoint.mapDomain {g : WithConv (H₂ →ₐ[k] K)}
+    (hg : IsSemisimplePoint g) (φ : H₁ →ₐc[k] H₂) :
+    IsSemisimplePoint (AlgHom.mapDomain φ g) := by
+  rw [isSemisimplePoint_def] at hg ⊢
+  intro M
+  rw [← Comodule.pointsAction_corestrict (V := M) φ g]
+  exact hg ((FGComoduleCat.corestrict φ.toCoalgHom).obj M)
+
+end MapDomain
 
 private theorem isSemisimple_pointAction_iff_endOfPoint
     (g : WithConv (H →ₐ[k] K)) (M : FGComoduleCat.{u, v, u} k H) :

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
@@ -94,7 +94,7 @@ theorem IsSemisimplePoint.mapDomain {g : WithConv (H₂ →ₐ[k] K)}
     IsSemisimplePoint (AlgHom.mapDomain φ g) := by
   rw [isSemisimplePoint_def] at hg ⊢
   intro M
-  rw [← Comodule.pointsAction_corestrict (V := M) φ g]
+  rw [← Comodule.pointsAction_corestrict_obj φ M g]
   exact hg ((FGComoduleCat.corestrict φ.toCoalgHom).obj M)
 
 end MapDomain

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
@@ -31,8 +31,8 @@ invariant under conjugation.
   formulation using the underlying comodule action endomorphisms.
 * `TauCeti.HopfAlgebra.IsSemisimplePoint.inv`, `.mul_of_commute`, and `.zpow`: closure under
   inversion, commuting products, and integer powers.
-* `TauCeti.HopfAlgebra.IsSemisimplePoint.mapDomain`: a homomorphism of affine groups preserves
-  semisimple points.
+* `TauCeti.HopfAlgebra.IsSemisimplePoint.mapDomain`: precomposition by a bialgebra morphism
+  preserves semisimple points.
 * `TauCeti.HopfAlgebra.isSemisimplePoint_conj_iff`: invariance under conjugation.
 
 ## References
@@ -85,8 +85,9 @@ variable {H₁ : Type v} {H₂ : Type w}
 variable [Semiring H₁] [Semiring H₂]
 variable [_root_.HopfAlgebra k H₁] [_root_.HopfAlgebra k H₂]
 
-/-- A homomorphism of affine groups sends semisimple points to semisimple points. In coordinate
-algebras the homomorphism is represented contravariantly by a bialgebra morphism. -/
+/-- Precomposition by a bialgebra morphism preserves semisimple points. For commutative coordinate
+Hopf algebras, this says that a homomorphism of affine groups sends semisimple points to semisimple
+points. -/
 theorem IsSemisimplePoint.mapDomain {g : WithConv (H₂ →ₐ[k] K)}
     (hg : IsSemisimplePoint g) (φ : H₁ →ₐc[k] H₂) :
     IsSemisimplePoint (AlgHom.mapDomain φ g) := by

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
@@ -5,8 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Representation.ScalarExtension
-public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
-public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Corestrict
 public import TauCeti.LinearAlgebra.JordanChevalley.Functoriality
 
 /-!

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 public import TauCeti.Algebra.Coalgebra.Comodule.TensorProduct
 public import TauCeti.Algebra.Coalgebra.Comodule.Trivial
 public import Mathlib.RingTheory.Bialgebra.Convolution
@@ -29,6 +30,7 @@ the functor of points on scalar extensions of `V`.
 ## Main declarations
 
 * `TauCeti.Comodule.endOfPoint`: the endomorphism of `A ⊗[R] V` attached to a point.
+* `TauCeti.Comodule.endOfPoint_corestrict`: compatibility with corestriction in the coalgebra.
 * `TauCeti.Comodule.endOfPoint_tensor`: point actions preserve the diagonal tensor product.
 * `TauCeti.Comodule.endOfPoint_trivial`: every point acts identically on a trivial comodule.
 * `TauCeti.Comodule.pointsRepresentation`: the action, as a `Representation` of the
@@ -136,6 +138,28 @@ lemma baseChange_comp_endOfPoint (f : Hom R H V W) (g : H →ₐ[R] A) :
 end Functorial
 
 end Coalgebra
+
+section Corestrict
+
+variable {R H₁ H₂ V A : Type*} [CommSemiring R]
+variable [Semiring H₁] [Semiring H₂] [Bialgebra R H₁] [Bialgebra R H₂]
+variable [AddCommMonoid V] [Module R V] [Comodule R H₁ V]
+variable [CommSemiring A] [Algebra R A]
+
+/-- Acting on a comodule corestricted along a bialgebra morphism agrees with acting by the
+point precomposed with the underlying algebra morphism. -/
+theorem endOfPoint_corestrict (φ : H₁ →ₐc[R] H₂) (g : H₂ →ₐ[R] A) :
+    (letI : Comodule R H₂ V := Corestrict φ.toCoalgHom
+     endOfPoint V g) = endOfPoint V (g.comp (φ : H₁ →ₐ[R] H₂)) := by
+  apply TensorProduct.AlgebraTensorModule.ext
+  intro a v
+  rw [endOfPoint_tmul, endOfPoint_tmul]
+  simp only [corestrict_coact_apply, AlgHom.comp_toLinearMap]
+  rw [LinearMap.lTensor_comp, LinearMap.comp_apply]
+  have hφ : φ.toCoalgHom.toLinearMap = (φ : H₁ →ₐ[R] H₂).toLinearMap := rfl
+  simp only [LinearMap.lTensor_def, hφ]
+
+end Corestrict
 
 section Bialgebra
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -157,7 +157,8 @@ theorem endOfPoint_corestrict (φ : H₁ →ₐc[R] H₂) (g : H₂ →ₐ[R] A)
   rw [endOfPoint_tmul, endOfPoint_tmul]
   simp only [corestrict_coact_apply, AlgHom.comp_toLinearMap]
   rw [LinearMap.lTensor_comp, LinearMap.comp_apply]
-  have hφ : φ.toCoalgHom.toLinearMap = (φ : H₁ →ₐ[R] H₂).toLinearMap := rfl
+  have hφ : φ.toCoalgHom.toLinearMap = (φ : H₁ →ₐ[R] H₂).toLinearMap :=
+    (_root_.BialgHom.toAlgHom_toLinearMap φ).symm
   simp only [LinearMap.lTensor_def, hφ]
 
 end Corestrict

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -148,6 +148,7 @@ variable [CommSemiring A] [Algebra R A]
 
 /-- Acting on a comodule corestricted along a bialgebra morphism agrees with acting by the
 point precomposed with the underlying algebra morphism. -/
+@[simp]
 theorem endOfPoint_corestrict (φ : H₁ →ₐc[R] H₂) (g : H₂ →ₐ[R] A) :
     (letI : Comodule R H₂ V := Corestrict φ.toCoalgHom
      endOfPoint V g) = endOfPoint V (g.comp (φ : H₁ →ₐ[R] H₂)) := by


### PR DESCRIPTION
This PR proves that point-level Jordan decomposition commutes with homomorphisms of affine groups, expressed contravariantly by a bialgebra morphism of coordinate Hopf algebras. Corestrict a comodule along the coordinate morphism and identify its point action with the action of the precomposed point; use this compatibility and uniqueness of the commuting semisimple--unipotent factorization to identify both mapped Jordan factors.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 milestone **"Jordan decomposition of elements into semisimple and unipotent parts (geometric, over `k̄`), functorial under representations."** This is the most effective current step because reconstruction of both factors, their action in every finite-dimensional comodule, and uniqueness are already on `main`, while no open PR supplies naturality under affine-group homomorphisms. After this PR, integration with the in-flight intrinsic unipotent-point predicate remains; the point-level construction, representation compatibility, uniqueness, and homomorphism naturality are otherwise in place.

Add `TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean` (166 lines). Move `TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition.lean` to `TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.lean` as required when the topic gains a second module; the move adds only the two projection lemmas needed to use the bundled decomposition without unfolding it. Old-to-new module path: `TauCeti.Algebra.AlgebraicGroup.Representation.JordanDecomposition` → `TauCeti.Algebra.AlgebraicGroup.Representation.JordanDecomposition.Basic`.

Reuse `TauCeti.FGComoduleCat.corestrict`, `TauCeti.AlgHom.mapDomain`, the existing point-action API, and `TauCeti.HopfAlgebra.Point.eq_jordanDecomposition_iff`. No Mathlib infrastructure or external formalization is vendored. The mathematical naturality statement follows T. A. Springer, *Linear Algebraic Groups*, §2.4, and J. S. Milne, *Algebraic Groups* (2017), §9.4, as credited in the new module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"jordan-decomposition-map-domain"}-->

🤖 Prepared with Codex
