### PR TITLE
feat: assemble the sporadic group presentations

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
@@ -37,7 +37,7 @@ public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Thompson
 This file assembles the twenty-six independently transcribed sporadic-group presentations into the
 total function `TauCeti.SporadicName.presentation`. Each branch is the explicit, cited
 `TauCeti.GroupPresentation` defined in its group-specific module. The theorem
-`TauCeti.SporadicName.presentation_matchesMetadata` combines the individual generator- and
+`TauCeti.presentation_matchesMetadata` combines the individual generator- and
 relator-count checks, while `TauCeti.SporadicName.Group` is the concrete group defined by the
 selected presentation.
 
@@ -53,7 +53,7 @@ imported module.
 
 ## Main results
 
-* `TauCeti.SporadicName.presentation_matchesMetadata`: every selected presentation has the stated
+* `TauCeti.presentation_matchesMetadata`: every selected presentation has the stated
   number of generators and relators.
 -/
 
@@ -91,7 +91,7 @@ def SporadicName.presentation : SporadicName → GroupPresentation
   | .M => Sporadic.Monster.presentation
 
 /-- Every sporadic presentation has the generator and relator counts stated in its metadata. -/
-theorem SporadicName.presentation_matchesMetadata (s : SporadicName) :
+theorem presentation_matchesMetadata (s : SporadicName) :
     s.presentation.matchesMetadata := by
   cases s with
   | M11 => exact Sporadic.m11Presentation_matchesMetadata

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
@@ -62,6 +62,7 @@ public section
 namespace TauCeti
 
 /-- The explicit, cited finite presentation attached to each sporadic-group name. -/
+@[simp]
 def SporadicName.presentation : SporadicName → GroupPresentation
   | .M11 => Sporadic.m11Presentation
   | .M12 => Sporadic.m12Presentation

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
@@ -62,6 +62,7 @@ public section
 namespace TauCeti
 
 /-- The explicit, cited finite presentation attached to each sporadic-group name. -/
+@[simp]
 def SporadicName.presentation : SporadicName → GroupPresentation
   | .M11 => Sporadic.m11Presentation
   | .M12 => Sporadic.m12Presentation
@@ -91,6 +92,7 @@ def SporadicName.presentation : SporadicName → GroupPresentation
   | .M => Sporadic.Monster.presentation
 
 /-- Every sporadic presentation has the generator and relator counts stated in its metadata. -/
+@[simp]
 theorem SporadicName.presentation_matchesMetadata (s : SporadicName) :
     s.presentation.matchesMetadata := by
   cases s with

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
@@ -91,7 +91,12 @@ def SporadicName.presentation : SporadicName → GroupPresentation
   | .B => Sporadic.BabyMonster.presentation
   | .M => Sporadic.Monster.presentation
 
-/-- Every sporadic presentation has the generator and relator counts stated in its metadata. -/
+/-- Every sporadic presentation has the generator and relator counts stated in its metadata.
+
+This is deliberately not `@[simp]`: `GroupPresentation.matchesMetadata_iff` is itself a `simp`
+lemma, so the left-hand side `s.presentation.matchesMetadata` simplifies to the pair of count
+equations and is not in simp normal form, which the `simpNF` linter rejects. Apply the theorem
+directly, or pass it to `simp` as an argument. -/
 theorem presentation_matchesMetadata (s : SporadicName) :
     s.presentation.matchesMetadata := by
   cases s with

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Index
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.BabyMonster
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Conway.One
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Conway.Three
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Conway.Two
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Fischer.TwentyFour
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Fischer.TwentyThree
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Fischer.TwentyTwo
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.HaradaNorton
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Held
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.HigmanSims
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Janko.Four
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Janko.One
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Janko.Three
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Janko.Two
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Lyons
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Mathieu
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Mathieu.TwentyFour
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Mathieu.TwentyThree
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.McLaughlin
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Monster
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.ONan
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Rudvalis
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Suzuki
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Sporadic.Thompson
+
+/-!
+# Presentations of the sporadic groups
+
+This file assembles the twenty-six independently transcribed sporadic-group presentations into the
+total function `TauCeti.SporadicName.presentation`. Each branch is the explicit, cited
+`TauCeti.GroupPresentation` defined in its group-specific module. The theorem
+`TauCeti.SporadicName.presentation_matchesMetadata` combines the individual generator- and
+relator-count checks, while `TauCeti.SporadicName.Group` is the concrete group defined by the
+selected presentation.
+
+This is milestone S1 of `TauCetiRoadmap/CFSGStatement/README.md`. The dispatcher and its interface
+follow the target signatures in the human-authored roadmap's `CFSGStatement/Suggested.lean`; the
+mathematical and bibliographic sources for each presentation are recorded in the corresponding
+imported module.
+
+## Main definitions
+
+* `TauCeti.SporadicName.presentation`: the complete presentation attached to a sporadic name.
+* `TauCeti.SporadicName.Group`: the group defined by that presentation.
+
+## Main results
+
+* `TauCeti.SporadicName.presentation_matchesMetadata`: every selected presentation has the stated
+  number of generators and relators.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- The explicit, cited finite presentation attached to each sporadic-group name. -/
+def SporadicName.presentation : SporadicName → GroupPresentation
+  | .M11 => Sporadic.m11Presentation
+  | .M12 => Sporadic.m12Presentation
+  | .M22 => Sporadic.m22Presentation
+  | .M23 => Sporadic.m23Presentation
+  | .M24 => Sporadic.m24Presentation
+  | .J1 => Sporadic.j1Presentation
+  | .J2 => Sporadic.j2Presentation
+  | .J3 => Sporadic.j3Presentation
+  | .J4 => Sporadic.j4Presentation
+  | .HS => Sporadic.hsPresentation
+  | .McL => Sporadic.mclPresentation
+  | .He => Sporadic.hePresentation
+  | .Ru => Sporadic.ruPresentation
+  | .Suz => Sporadic.suzPresentation
+  | .ONan => Sporadic.onanPresentation
+  | .Co1 => Sporadic.co1Presentation
+  | .Co2 => Sporadic.co2Presentation
+  | .Co3 => Sporadic.co3Presentation
+  | .Fi22 => Sporadic.fi22Presentation
+  | .Fi23 => Sporadic.fi23Presentation
+  | .Fi24Prime => Sporadic.fi24PrimePresentation
+  | .HN => Sporadic.hnPresentation
+  | .Ly => Sporadic.lyPresentation
+  | .Th => Sporadic.Thompson.presentation
+  | .B => Sporadic.BabyMonster.presentation
+  | .M => Sporadic.Monster.presentation
+
+/-- Every sporadic presentation has the generator and relator counts stated in its metadata. -/
+theorem SporadicName.presentation_matchesMetadata (s : SporadicName) :
+    s.presentation.matchesMetadata := by
+  cases s with
+  | M11 => exact Sporadic.m11Presentation_matchesMetadata
+  | M12 => exact Sporadic.m12Presentation_matchesMetadata
+  | M22 => exact Sporadic.m22Presentation_matchesMetadata
+  | M23 => exact Sporadic.matchesMetadata_m23Presentation
+  | M24 => exact Sporadic.matchesMetadata_m24Presentation
+  | J1 => exact Sporadic.j1Presentation_matchesMetadata
+  | J2 => exact Sporadic.j2Presentation_matchesMetadata
+  | J3 => exact Sporadic.j3Presentation_matchesMetadata
+  | J4 => exact Sporadic.matchesMetadata_j4Presentation
+  | HS => exact Sporadic.matchesMetadata_hsPresentation
+  | McL => exact Sporadic.matchesMetadata_mclPresentation
+  | He => exact Sporadic.hePresentation_matchesMetadata
+  | Ru => exact Sporadic.ruPresentation_matchesMetadata
+  | Suz => exact Sporadic.suzPresentation_matchesMetadata
+  | ONan => exact Sporadic.onanPresentation_matchesMetadata
+  | Co1 => exact Sporadic.co1Presentation_matchesMetadata
+  | Co2 => exact Sporadic.matchesMetadata_co2Presentation
+  | Co3 => exact Sporadic.matchesMetadata_co3Presentation
+  | Fi22 => exact Sporadic.matchesMetadata_fi22Presentation
+  | Fi23 => exact Sporadic.fi23Presentation_matchesMetadata
+  | Fi24Prime => exact Sporadic.fi24PrimePresentation_matchesMetadata
+  | HN => exact Sporadic.matchesMetadata_hnPresentation
+  | Ly => exact Sporadic.matchesMetadata_lyPresentation
+  | Th => exact Sporadic.Thompson.matchesMetadata_presentation
+  | B => exact Sporadic.BabyMonster.matchesMetadata_presentation
+  | M => exact Sporadic.Monster.presentation_matchesMetadata
+
+/-- The sporadic group concretely defined by its selected finite presentation. -/
+abbrev SporadicName.Group (s : SporadicName) : Type := s.presentation.Group
+
+end TauCeti

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
@@ -62,7 +62,6 @@ public section
 namespace TauCeti
 
 /-- The explicit, cited finite presentation attached to each sporadic-group name. -/
-@[simp]
 def SporadicName.presentation : SporadicName → GroupPresentation
   | .M11 => Sporadic.m11Presentation
   | .M12 => Sporadic.m12Presentation
@@ -92,7 +91,6 @@ def SporadicName.presentation : SporadicName → GroupPresentation
   | .M => Sporadic.Monster.presentation
 
 /-- Every sporadic presentation has the generator and relator counts stated in its metadata. -/
-@[simp]
 theorem SporadicName.presentation_matchesMetadata (s : SporadicName) :
     s.presentation.matchesMetadata := by
   cases s with


### PR DESCRIPTION
This PR completes `CFSGStatement` milestone S1, “the twenty-six sporadic presentations,” by assembling the twenty-six independently transcribed rows now on `main` into the total `SporadicName.presentation` function required by `TauCetiRoadmap/CFSGStatement/README.md`: “Fill every `SporadicName.presentation` branch with the complete signed relator words from the S0 manifest.” Each branch selects the explicit `GroupPresentation` from its group-specific module; no presentation is chosen from an existence theorem and no relator data is duplicated. Nothing remains in S1 after this PR; the classification-statement endpoint still needs the L0–L3 explicit Lie-type construction and then A0 assembly and universe transport.

This is the most effective current critical-path step because the last outstanding row, `Fi24Prime`, has landed, so the previously blocked total dispatcher can now be written, while the independent Lie-type lane remains gated by the RootSystems Layer 6 and ReductiveGroups Layer 9 constructions represented by several open PRs. No open PR or `CFSGStatement` intention claims this dispatcher.

Add `TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean` (127 lines). It defines `SporadicName.presentation`, proves `SporadicName.presentation_matchesMetadata` by reusing the individual count theorem from every one of the twenty-six imported rows, and defines `SporadicName.Group` as the concrete Mathlib `PresentedGroup` already exposed by `GroupPresentation.Group`. The dependent `Group` instance synthesizes from that carrier without an additional instance declaration.

The interface follows the human-authored target signatures in `CFSGStatement/Suggested.lean`. Every mathematical and bibliographic presentation source remains recorded beside its relators in the imported group-specific module; this assembly introduces no new transcription or external source. It reuses Tau Ceti’s `GroupPresentation`, every existing row and metadata theorem, and Mathlib’s `PresentedGroup`; no Mathlib infrastructure is vendored.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"sporadicname-presentation"}-->

🤖 Prepared with Codex
