### PR TITLE
feat: add finite Hopf duals

### DIFF
--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
@@ -68,11 +68,6 @@ noncomputable def evalTensorEquiv :
     FiniteDual k H ⊗[k] FiniteDual k H ≃ₗ[k] Module.Dual k (H ⊗[k] H) :=
   (tensorUnwrap k H).trans (TensorProduct.dualDistribEquiv k H H)
 
-/-- Evaluate a tensor of finite-dual functionals on a tensor of elements of `H`. -/
-noncomputable def evalTensor :
-    FiniteDual k H ⊗[k] FiniteDual k H →ₗ[k] Module.Dual k (H ⊗[k] H) :=
-  (evalTensorEquiv k H).toLinearMap
-
 /-- The comultiplication on the finite dual, obtained by transposing multiplication on `H`. -/
 noncomputable def comul : FiniteDual k H →ₗ[k] FiniteDual k H ⊗[k] FiniteDual k H :=
   (evalTensorEquiv k H).symm.toLinearMap ∘ₗ
@@ -85,10 +80,10 @@ def counit : FiniteDual k H →ₗ[k] k :=
 
 /-- Evaluating the transposed comultiplication on `x tensor y` gives `phi (x * y)`. -/
 @[simp]
-theorem dualDistrib_comul (phi : FiniteDual k H) :
-    evalTensor k H (comul k H phi) =
+theorem evalTensor_comul (phi : FiniteDual k H) :
+    evalTensorEquiv k H (comul k H phi) =
       phi.ofConv.comp (LinearMap.mul' k H) := by
-  simp only [evalTensor, comul, LinearMap.comp_apply]
+  simp only [comul, LinearMap.comp_apply]
   simp only [LinearEquiv.coe_toLinearMap]
   let psi : Module.Dual k (H ⊗[k] H) :=
     phi.ofConv.comp (LinearMap.mul' k H)
@@ -98,16 +93,16 @@ theorem dualDistrib_comul (phi : FiniteDual k H) :
 /-- A pure tensor of finite-dual functionals evaluates componentwise. -/
 @[simp]
 theorem evalTensor_tmul_apply (phi psi : FiniteDual k H) (x y : H) :
-    evalTensor k H (phi ⊗ₜ[k] psi) (x ⊗ₜ[k] y) =
+    evalTensorEquiv k H (phi ⊗ₜ[k] psi) (x ⊗ₜ[k] y) =
       phi.ofConv x * psi.ofConv y := by
-  simp [evalTensor, evalTensorEquiv, tensorUnwrap]
+  simp [evalTensorEquiv, tensorUnwrap]
 
 /-- Pointwise form of the characteristic equation for the finite-dual comultiplication. -/
-theorem dualDistrib_comul_apply (phi : FiniteDual k H) (x y : H) :
-    evalTensor k H (comul k H phi) (x ⊗ₜ[k] y) =
+theorem evalTensor_comul_apply (phi : FiniteDual k H) (x y : H) :
+    evalTensorEquiv k H (comul k H phi) (x ⊗ₜ[k] y) =
       phi.ofConv (x * y) := by
-  rw [dualDistrib_comul]
-  rfl
+  rw [evalTensor_comul]
+  simp only [LinearMap.comp_apply, LinearMap.mul'_apply]
 
 omit [FiniteDimensional k H] in
 /-- The finite-dual counit is evaluation at one. -/
@@ -131,7 +126,7 @@ private theorem evalTripleEquiv_tmul_tmul_apply
 private theorem evalTripleEquiv_tmul_apply
     (phi : FiniteDual k H) (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y z : H) :
     evalTripleEquiv k H (phi ⊗ₜ[k] w) (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
-      phi.ofConv x * evalTensor k H w (y ⊗ₜ[k] z) := by
+      phi.ofConv x * evalTensorEquiv k H w (y ⊗ₜ[k] z) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
@@ -143,7 +138,7 @@ private theorem evalTripleEquiv_assoc_tmul_apply
     (w : FiniteDual k H ⊗[k] FiniteDual k H) (chi : FiniteDual k H) (x y z : H) :
     evalTripleEquiv k H ((TensorProduct.assoc k _ _ _).toLinearMap (w ⊗ₜ[k] chi))
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
-      evalTensor k H w (x ⊗ₜ[k] y) * chi.ofConv z := by
+      evalTensorEquiv k H w (x ⊗ₜ[k] y) * chi.ofConv z := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
@@ -158,25 +153,25 @@ private theorem evalTriple_assoc_comul_rTensor
     evalTripleEquiv k H
         ((TensorProduct.assoc k _ _ _).toLinearMap ((comul k H).rTensor _ w))
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
-      evalTensor k H w ((x * y) ⊗ₜ[k] z) := by
+      evalTensorEquiv k H w ((x * y) ⊗ₜ[k] z) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ => simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.rTensor_tmul, evalTripleEquiv_assoc_tmul_apply,
-        dualDistrib_comul_apply, evalTensor_tmul_apply]
+        evalTensor_comul_apply, evalTensor_tmul_apply]
 
 private theorem evalTriple_comul_lTensor
     (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y z : H) :
     evalTripleEquiv k H ((comul k H).lTensor _ w)
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
-      evalTensor k H w (x ⊗ₜ[k] (y * z)) := by
+      evalTensorEquiv k H w (x ⊗ₜ[k] (y * z)) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ => simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.lTensor_tmul, evalTripleEquiv_tmul_apply,
-        dualDistrib_comul_apply, evalTensor_tmul_apply]
+        evalTensor_comul_apply, evalTensor_tmul_apply]
 
 /-- The transposed multiplication is coassociative. -/
 theorem comul_coassoc :
@@ -200,13 +195,13 @@ theorem comul_coassoc :
       | tmul y z =>
           simp only [LinearMap.comp_apply]
           rw [evalTriple_assoc_comul_rTensor, evalTriple_comul_lTensor,
-            dualDistrib_comul_apply, dualDistrib_comul_apply]
+            evalTensor_comul_apply, evalTensor_comul_apply]
           simp only [mul_assoc]
 
 private theorem lid_counit_rTensor_apply
     (w : FiniteDual k H ⊗[k] FiniteDual k H) (x : H) :
     ((TensorProduct.lid k (FiniteDual k H)) ((counit k H).rTensor _ w)).ofConv x =
-      evalTensor k H w ((1 : H) ⊗ₜ[k] x) := by
+      evalTensorEquiv k H w ((1 : H) ⊗ₜ[k] x) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
@@ -220,7 +215,7 @@ private theorem lid_counit_rTensor_apply
 private theorem rid_counit_lTensor_apply
     (w : FiniteDual k H ⊗[k] FiniteDual k H) (x : H) :
     ((TensorProduct.rid k (FiniteDual k H)) ((counit k H).lTensor _ w)).ofConv x =
-      evalTensor k H w (x ⊗ₜ[k] (1 : H)) := by
+      evalTensorEquiv k H w (x ⊗ₜ[k] (1 : H)) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
@@ -239,7 +234,7 @@ theorem rTensor_counit_comp_comul :
   apply (TensorProduct.lid k (FiniteDual k H)).injective
   apply WithConv.ofConv_injective
   ext x
-  rw [LinearMap.comp_apply, lid_counit_rTensor_apply, dualDistrib_comul_apply]
+  rw [LinearMap.comp_apply, lid_counit_rTensor_apply, evalTensor_comul_apply]
   simp only [one_mul, TensorProduct.lid_tmul, TensorProduct.mk_apply, one_smul]
 
 /-- Evaluation at one is a right counit for the transposed multiplication. -/
@@ -250,7 +245,7 @@ theorem lTensor_counit_comp_comul :
   apply (TensorProduct.rid k (FiniteDual k H)).injective
   apply WithConv.ofConv_injective
   ext x
-  rw [LinearMap.comp_apply, rid_counit_lTensor_apply, dualDistrib_comul_apply]
+  rw [LinearMap.comp_apply, rid_counit_lTensor_apply, evalTensor_comul_apply]
   simp only [mul_one, TensorProduct.rid_tmul, LinearMap.flip_apply,
     TensorProduct.mk_apply, one_smul]
 
@@ -263,11 +258,11 @@ noncomputable instance instCoalgebra : Coalgebra k (FiniteDual k H) where
   rTensor_counit_comp_comul := rTensor_counit_comp_comul k H
   lTensor_counit_comp_comul := lTensor_counit_comp_comul k H
 
-/-- `evalTensor` packaged in the convolution algebra on functionals on the tensor square. -/
+/-- `evalTensorEquiv` packaged in the convolution algebra on functionals on the tensor square. -/
 private noncomputable def evalTensorConv :
     FiniteDual k H ⊗[k] FiniteDual k H →ₗ[k]
       WithConv (Module.Dual k (H ⊗[k] H)) :=
-  (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ evalTensor k H
+  (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ (evalTensorEquiv k H).toLinearMap
 
 private theorem evalTensorConv_tmul (phi psi : FiniteDual k H) :
     evalTensorConv k H (phi ⊗ₜ[k] psi) = LinearMap.mulTensor phi psi := by
@@ -288,7 +283,17 @@ private theorem evalTensorConv_comul (phi : FiniteDual k H) :
     evalTensorConv k H (comul k H phi) =
       WithConv.toConv (phi.ofConv.comp (LinearMap.mul' k H)) := by
   apply WithConv.ofConv_injective
-  exact dualDistrib_comul k H phi
+  exact evalTensor_comul k H phi
+
+@[simp]
+private theorem evalTensorConv_ofConv (w : FiniteDual k H ⊗[k] FiniteDual k H) :
+    (evalTensorConv k H w).ofConv = evalTensorEquiv k H w :=
+  rfl
+
+omit [FiniteDimensional k H] in
+private theorem mulCoalgHom_toLinearMap :
+    (Bialgebra.mulCoalgHom k H).toLinearMap = LinearMap.mul' k H :=
+  rfl
 
 omit [FiniteDimensional k H] in
 /-- The finite-dual counit preserves one. -/
@@ -315,15 +320,9 @@ theorem comul_one : comul k H (1 : FiniteDual k H) = 1 := by
   | add xy₁ xy₂ hxy₁ hxy₂ =>
       simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxy₁ hxy₂
   | tmul x y =>
-      rw [show (evalTensorEquiv k H) (comul k H (1 : FiniteDual k H)) =
-          evalTensor k H (comul k H (1 : FiniteDual k H)) from rfl,
-        show (evalTensorEquiv k H) (1 : FiniteDual k H ⊗[k] FiniteDual k H) =
-          evalTensor k H (1 : FiniteDual k H ⊗[k] FiniteDual k H) from rfl]
-      rw [dualDistrib_comul_apply]
+      rw [evalTensor_comul_apply]
       simp only [LinearMap.convOne_apply, Bialgebra.counit_mul, map_mul]
-      rw [show (1 : FiniteDual k H ⊗[k] FiniteDual k H) =
-        (1 : FiniteDual k H) ⊗ₜ[k] (1 : FiniteDual k H) from rfl,
-        evalTensor_tmul_apply]
+      rw [Algebra.TensorProduct.one_def, evalTensor_tmul_apply]
       simp only [LinearMap.convOne_apply]
 
 /-- The finite-dual comultiplication preserves multiplication. -/
@@ -331,16 +330,11 @@ theorem comul_one : comul k H (1 : FiniteDual k H) = 1 := by
 theorem comul_mul (phi psi : FiniteDual k H) :
     comul k H (phi * psi) = comul k H phi * comul k H psi := by
   apply (evalTensorEquiv k H).injective
-  apply congrArg WithConv.ofConv
-  rw [show WithConv.toConv ((evalTensorEquiv k H) (comul k H (phi * psi))) =
-      evalTensorConv k H (comul k H (phi * psi)) from rfl,
-    show WithConv.toConv ((evalTensorEquiv k H) (comul k H phi * comul k H psi)) =
-      evalTensorConv k H (comul k H phi * comul k H psi) from rfl,
-    evalTensorConv_mul, evalTensorConv_comul, evalTensorConv_comul,
-    evalTensorConv_comul]
+  rw [← evalTensorConv_ofConv, ← evalTensorConv_ofConv, evalTensorConv_mul,
+    evalTensorConv_comul, evalTensorConv_comul, evalTensorConv_comul]
   have h := LinearMap.convMul_comp_coalgHom_distrib phi psi (Bialgebra.mulCoalgHom k H)
-  rw [show (Bialgebra.mulCoalgHom k H).toLinearMap = LinearMap.mul' k H from rfl] at h
-  simpa only [WithConv.toConv_ofConv] using congrArg WithConv.toConv h
+  rw [mulCoalgHom_toLinearMap] at h
+  simpa only [WithConv.toConv_ofConv] using h
 
 /-- The bialgebra structure on the finite dual. Multiplication is convolution and the coalgebra
 operations are transposes of multiplication and unit on the original bialgebra. -/
@@ -357,8 +351,8 @@ variable (k : Type u) (H : Type v) [Field k] [CommRing H] [Bialgebra k H]
 
 private theorem evalTensor_comm_apply
     (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y : H) :
-    evalTensor k H (TensorProduct.comm k _ _ w) (x ⊗ₜ[k] y) =
-      evalTensor k H w (y ⊗ₜ[k] x) := by
+    evalTensorEquiv k H (TensorProduct.comm k _ _ w) (x ⊗ₜ[k] y) =
+      evalTensorEquiv k H w (y ⊗ₜ[k] x) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
@@ -381,12 +375,7 @@ theorem comm_comp_comul :
   | tmul x y =>
       simp only [LinearMap.comp_apply]
       rw [LinearEquiv.coe_toLinearMap]
-      rw [show (evalTensorEquiv k H)
-          ((TensorProduct.comm k (FiniteDual k H) (FiniteDual k H)) (comul k H phi)) =
-        evalTensor k H
-          ((TensorProduct.comm k (FiniteDual k H) (FiniteDual k H)) (comul k H phi)) from rfl,
-        show (evalTensorEquiv k H) (comul k H phi) = evalTensor k H (comul k H phi) from rfl,
-        evalTensor_comm_apply, dualDistrib_comul_apply, dualDistrib_comul_apply]
+      rw [evalTensor_comm_apply, evalTensor_comul_apply, evalTensor_comul_apply]
       simp only [mul_comm]
 
 /-- The coalgebra underlying the finite dual is cocommutative. -/
@@ -415,10 +404,20 @@ theorem antipode_apply (phi : FiniteDual k H) (x : H) :
     (antipode k H phi).ofConv x = phi.ofConv (HopfAlgebra.antipode k x) :=
   by simp [antipode]
 
-private theorem mul_apply_eq_evalTensor
+@[simp]
+private theorem coalgebra_comul_eq_comul (phi : FiniteDual k H) :
+    Coalgebra.comul (R := k) (A := FiniteDual k H) phi = comul k H phi :=
+  rfl
+
+@[simp]
+private theorem coalgebra_counit_eq_counit (phi : FiniteDual k H) :
+    Coalgebra.counit (R := k) (A := FiniteDual k H) phi = counit k H phi :=
+  rfl
+
+private theorem mul_apply_eq_evalTensorEquiv
     (w : FiniteDual k H ⊗[k] FiniteDual k H) (x : H) :
     (LinearMap.mul' k (FiniteDual k H) w).ofConv x =
-      evalTensor k H w (Coalgebra.comul x) := by
+      evalTensorEquiv k H w (Coalgebra.comul x) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
@@ -436,9 +435,9 @@ private theorem mul_apply_eq_evalTensor
 
 private theorem evalTensor_map_antipode_left
     (w : FiniteDual k H ⊗[k] FiniteDual k H) (z : H ⊗[k] H) :
-    evalTensor k H
+    evalTensorEquiv k H
         (TensorProduct.map (antipode k H) LinearMap.id w) z =
-      evalTensor k H w
+      evalTensorEquiv k H w
         (TensorProduct.map (HopfAlgebra.antipode k (A := H)) LinearMap.id z) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
@@ -456,9 +455,9 @@ private theorem evalTensor_map_antipode_left
 
 private theorem evalTensor_map_antipode_right
     (w : FiniteDual k H ⊗[k] FiniteDual k H) (z : H ⊗[k] H) :
-    evalTensor k H
+    evalTensorEquiv k H
         (TensorProduct.map LinearMap.id (antipode k H) w) z =
-      evalTensor k H w
+      evalTensorEquiv k H w
         (TensorProduct.map LinearMap.id (HopfAlgebra.antipode k (A := H)) z) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
@@ -476,53 +475,44 @@ private theorem evalTensor_map_antipode_right
 
 /-- Precomposition by the original antipode is a left convolution inverse to the identity on the
 finite dual. -/
-theorem antipode_convMul_id :
+theorem antipode_mul_id :
     WithConv.toConv (antipode k H) *
         WithConv.toConv (LinearMap.id : FiniteDual k H →ₗ[k] FiniteDual k H) = 1 := by
   apply WithConv.ofConv_injective
   ext phi x
-  rw [LinearMap.convMul_apply, mul_apply_eq_evalTensor,
+  rw [LinearMap.convMul_apply, mul_apply_eq_evalTensorEquiv,
     evalTensor_map_antipode_left]
-  change evalTensor k H (comul k H phi)
-      (TensorProduct.map (HopfAlgebra.antipode k (A := H)) LinearMap.id
-        (Coalgebra.comul x)) = _
-  rw [dualDistrib_comul]
+  rw [coalgebra_comul_eq_comul, evalTensor_comul]
   simp only [LinearMap.comp_apply]
   rw [← LinearMap.rTensor_def, HopfAlgebra.mul_antipode_rTensor_comul_apply]
-  change phi.ofConv (algebraMap k H (Coalgebra.counit x)) =
-    (algebraMap k (FiniteDual k H) (counit k H phi)).ofConv x
-  rw [counit_apply, LinearMap.convAlgebraMap_apply,
+  rw [LinearMap.convOne_apply, coalgebra_counit_eq_counit, counit_apply,
+    LinearMap.convAlgebraMap_apply,
     Algebra.algebraMap_eq_smul_one, map_smul]
   simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
   rw [mul_comm]
 
 /-- Precomposition by the original antipode is a right convolution inverse to the identity on the
 finite dual. -/
-theorem id_convMul_antipode :
+theorem id_mul_antipode :
     WithConv.toConv (LinearMap.id : FiniteDual k H →ₗ[k] FiniteDual k H) *
         WithConv.toConv (antipode k H) = 1 := by
   apply WithConv.ofConv_injective
   ext phi x
-  rw [LinearMap.convMul_apply, mul_apply_eq_evalTensor,
+  rw [LinearMap.convMul_apply, mul_apply_eq_evalTensorEquiv,
     evalTensor_map_antipode_right]
-  change evalTensor k H (comul k H phi)
-      (TensorProduct.map LinearMap.id (HopfAlgebra.antipode k (A := H))
-        (Coalgebra.comul x)) = _
-  rw [dualDistrib_comul]
+  rw [coalgebra_comul_eq_comul, evalTensor_comul]
   simp only [LinearMap.comp_apply]
   rw [← LinearMap.lTensor_def, HopfAlgebra.mul_antipode_lTensor_comul_apply]
-  change phi.ofConv (algebraMap k H (Coalgebra.counit x)) =
-    (algebraMap k (FiniteDual k H) (counit k H phi)).ofConv x
-  rw [counit_apply, LinearMap.convAlgebraMap_apply,
+  rw [LinearMap.convOne_apply, coalgebra_counit_eq_counit, counit_apply,
+    LinearMap.convAlgebraMap_apply,
     Algebra.algebraMap_eq_smul_one, map_smul]
   simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
   rw [mul_comm]
 
 /-- The Hopf algebra structure on the finite dual. Its antipode is precomposition with the
-antipode of the original finite-dimensional commutative and cocommutative Hopf algebra. -/
+antipode of the original finite-dimensional Hopf algebra. -/
 noncomputable instance instHopfAlgebra : HopfAlgebra k (FiniteDual k H) :=
-  HopfAlgebra.ofConvInverse (antipode k H) (antipode_convMul_id k H)
-    (id_convMul_antipode k H)
+  HopfAlgebra.ofConvInverse (antipode k H) (antipode_mul_id k H) (id_mul_antipode k H)
 
 end HopfAlgebra
 

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
@@ -51,12 +51,14 @@ universe u v
 available.
 
 The `WithConv` wrapper selects Mathlib's convolution multiplication on linear maps. -/
-abbrev ConvolutionDual (k : Type u) (H : Type v) [Field k] [AddCommMonoid H] [Module k H] :=
+abbrev ConvolutionDual (k : Type u) (H : Type v) [CommSemiring k] [AddCommMonoid H] [Module k H] :=
   WithConv (Module.Dual k H)
 
 namespace ConvolutionDual
 
-variable (k : Type u) (H : Type v) [Field k] [Ring H] [Bialgebra k H]
+section LinearAlgebra
+
+variable (k : Type u) (H : Type v) [Field k] [AddCommGroup H] [Module k H]
   [FiniteDimensional k H]
 
 /-- Forget the convolution wrappers on both factors of a tensor of finite-dual elements. -/
@@ -76,32 +78,24 @@ private theorem dualDistribEquiv_apply
       TensorProduct.dualDistrib k H H ((tensorUnwrap k H) w) z :=
   rfl
 
-/-- The private construction used for the finite-dimensional dual comultiplication. -/
-private noncomputable def comulAux :
-    ConvolutionDual k H →ₗ[k] ConvolutionDual k H ⊗[k] ConvolutionDual k H :=
-  (dualDistribEquiv k H).symm.toLinearMap ∘ₗ
-      (LinearMap.mul' k H).dualMap ∘ₗ
-        (WithConv.linearEquiv k _).toLinearMap
+end LinearAlgebra
 
-private theorem comulAux_def :
-    comulAux k H = (dualDistribEquiv k H).symm.toLinearMap ∘ₗ
-      (LinearMap.mul' k H).dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap :=
-  rfl
+section Coalgebra
 
-/-- The private construction used for the finite-dimensional dual counit. -/
-private def counitAux : ConvolutionDual k H →ₗ[k] k :=
-  LinearMap.applyₗ (1 : H) ∘ₗ (WithConv.linearEquiv k _).toLinearMap
+variable (k : Type u) (H : Type v) [Field k] [Ring H] [Algebra k H]
+  [FiniteDimensional k H]
 
-omit [FiniteDimensional k H] in
-private theorem counitAux_def :
-    counitAux k H = LinearMap.applyₗ (1 : H) ∘ₗ
-      (WithConv.linearEquiv k _).toLinearMap :=
-  rfl
+/-- The comultiplication and counit on the finite dual, obtained by transposing multiplication
+and unit on the original algebra. -/
+noncomputable instance instCoalgebraStruct : CoalgebraStruct k (ConvolutionDual k H) where
+  comul := (dualDistribEquiv k H).symm.toLinearMap ∘ₗ
+    (LinearMap.mul' k H).dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap
+  counit := LinearMap.applyₗ (1 : H) ∘ₗ (WithConv.linearEquiv k _).toLinearMap
 
-private theorem dualDistribEquiv_comulAux (phi : ConvolutionDual k H) :
-    dualDistribEquiv k H (comulAux k H phi) =
+private theorem dualDistribEquiv_comul' (phi : ConvolutionDual k H) :
+    dualDistribEquiv k H (Coalgebra.comul phi) =
       phi.ofConv.comp (LinearMap.mul' k H) := by
-  simp only [comulAux, LinearMap.comp_apply]
+  dsimp only [CoalgebraStruct.comul, instCoalgebraStruct, LinearMap.comp_apply]
   simp only [LinearEquiv.coe_toLinearMap]
   let psi : Module.Dual k (H ⊗[k] H) :=
     phi.ofConv.comp (LinearMap.mul' k H)
@@ -115,15 +109,15 @@ theorem dualDistribEquiv_tmul_apply (phi psi : ConvolutionDual k H) (x y : H) :
       phi.ofConv x * psi.ofConv y := by
   simp [dualDistribEquiv, tensorUnwrap]
 
-private theorem dualDistribEquiv_comulAux_apply (phi : ConvolutionDual k H) (x y : H) :
-    dualDistribEquiv k H (comulAux k H phi) (x ⊗ₜ[k] y) =
+private theorem dualDistribEquiv_comul_apply' (phi : ConvolutionDual k H) (x y : H) :
+    dualDistribEquiv k H (Coalgebra.comul phi) (x ⊗ₜ[k] y) =
       phi.ofConv (x * y) := by
-  rw [dualDistribEquiv_comulAux]
+  rw [dualDistribEquiv_comul']
   simp only [LinearMap.comp_apply, LinearMap.mul'_apply]
 
-omit [FiniteDimensional k H] in
-private theorem counitAux_apply (phi : ConvolutionDual k H) : counitAux k H phi = phi.ofConv 1 :=
-  by simp [counitAux]
+private theorem counit_apply' (phi : ConvolutionDual k H) :
+    Coalgebra.counit (R := k) phi = phi.ofConv 1 := by
+  simp [CoalgebraStruct.counit]
 
 /-- Evaluate three finite-dual functionals on a right-associated triple tensor. -/
 private noncomputable def evalTripleEquiv :
@@ -163,10 +157,11 @@ private theorem evalTripleEquiv_assoc_tmul_apply
       rw [LinearEquiv.coe_toLinearMap, TensorProduct.assoc_tmul,
         evalTripleEquiv_tmul_tmul_apply, dualDistribEquiv_tmul_apply, mul_assoc]
 
-private theorem evalTripleEquiv_assoc_comul_rTensor
+private theorem evalTripleEquiv_assoc_comul_rTensor_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H
-        ((TensorProduct.assoc k _ _ _).toLinearMap ((comulAux k H).rTensor _ w))
+        ((TensorProduct.assoc k _ _ _).toLinearMap
+          ((Coalgebra.comul (R := k) (A := ConvolutionDual k H)).rTensor _ w))
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
       dualDistribEquiv k H w ((x * y) ⊗ₜ[k] z) := by
   induction w using TensorProduct.induction_on with
@@ -175,11 +170,12 @@ private theorem evalTripleEquiv_assoc_comul_rTensor
       simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.rTensor_tmul, evalTripleEquiv_assoc_tmul_apply,
-        dualDistribEquiv_comulAux_apply, dualDistribEquiv_tmul_apply]
+        dualDistribEquiv_comul_apply', dualDistribEquiv_tmul_apply]
 
-private theorem evalTripleEquiv_comul_lTensor
+private theorem evalTripleEquiv_comul_lTensor_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y z : H) :
-    evalTripleEquiv k H ((comulAux k H).lTensor _ w)
+    evalTripleEquiv k H
+        ((Coalgebra.comul (R := k) (A := ConvolutionDual k H)).lTensor _ w)
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
       dualDistribEquiv k H w (x ⊗ₜ[k] (y * z)) := by
   induction w using TensorProduct.induction_on with
@@ -188,11 +184,12 @@ private theorem evalTripleEquiv_comul_lTensor
       simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.lTensor_tmul, evalTripleEquiv_tmul_apply,
-        dualDistribEquiv_comulAux_apply, dualDistribEquiv_tmul_apply]
+        dualDistribEquiv_comul_apply', dualDistribEquiv_tmul_apply]
 
 private theorem lid_counit_rTensor_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
-    ((TensorProduct.lid k (ConvolutionDual k H)) ((counitAux k H).rTensor _ w)).ofConv x =
+    ((TensorProduct.lid k (ConvolutionDual k H))
+        ((Coalgebra.counit (R := k) (A := ConvolutionDual k H)).rTensor _ w)).ofConv x =
       dualDistribEquiv k H w ((1 : H) ⊗ₜ[k] x) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
@@ -201,12 +198,13 @@ private theorem lid_counit_rTensor_apply
         using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.rTensor_tmul, TensorProduct.lid_tmul, dualDistribEquiv_tmul_apply,
-        WithConv.ofConv_smul, LinearMap.smul_apply, counitAux_apply]
+        WithConv.ofConv_smul, LinearMap.smul_apply, counit_apply']
       simp only [smul_eq_mul]
 
 private theorem rid_counit_lTensor_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
-    ((TensorProduct.rid k (ConvolutionDual k H)) ((counitAux k H).lTensor _ w)).ofConv x =
+    ((TensorProduct.rid k (ConvolutionDual k H))
+        ((Coalgebra.counit (R := k) (A := ConvolutionDual k H)).lTensor _ w)).ofConv x =
       dualDistribEquiv k H w (x ⊗ₜ[k] (1 : H)) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
@@ -215,17 +213,13 @@ private theorem rid_counit_lTensor_apply
         using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.lTensor_tmul, TensorProduct.rid_tmul, dualDistribEquiv_tmul_apply,
-        WithConv.ofConv_smul, LinearMap.smul_apply, counitAux_apply]
+        WithConv.ofConv_smul, LinearMap.smul_apply, counit_apply']
       simp only [smul_eq_mul, mul_comm]
 
 /-- The coalgebra structure on the finite dual, obtained by transposing multiplication and unit
 on the original bialgebra. -/
 noncomputable instance instCoalgebra : Coalgebra k (ConvolutionDual k H) where
-  comul := (dualDistribEquiv k H).symm.toLinearMap ∘ₗ
-    (LinearMap.mul' k H).dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap
-  counit := LinearMap.applyₗ (1 : H) ∘ₗ (WithConv.linearEquiv k _).toLinearMap
   coassoc := by
-    rw [← comulAux_def]
     ext phi
     apply (evalTripleEquiv k H).injective
     apply LinearMap.ext
@@ -242,24 +236,22 @@ noncomputable instance instCoalgebra : Coalgebra k (ConvolutionDual k H) where
               using congrArg₂ (· + ·) hyz₁ hyz₂
         | tmul y z =>
             simp only [LinearMap.comp_apply]
-            rw [evalTripleEquiv_assoc_comul_rTensor, evalTripleEquiv_comul_lTensor,
-              dualDistribEquiv_comulAux_apply, dualDistribEquiv_comulAux_apply]
+            rw [evalTripleEquiv_assoc_comul_rTensor_apply, evalTripleEquiv_comul_lTensor_apply,
+              dualDistribEquiv_comul_apply', dualDistribEquiv_comul_apply']
             simp only [mul_assoc]
   rTensor_counit_comp_comul := by
-    rw [← counitAux_def, ← comulAux_def]
     ext phi
     apply (TensorProduct.lid k (ConvolutionDual k H)).injective
     apply WithConv.ofConv_injective
     ext x
-    rw [LinearMap.comp_apply, lid_counit_rTensor_apply, dualDistribEquiv_comulAux_apply]
+    rw [LinearMap.comp_apply, lid_counit_rTensor_apply, dualDistribEquiv_comul_apply']
     simp only [one_mul, TensorProduct.lid_tmul, TensorProduct.mk_apply, one_smul]
   lTensor_counit_comp_comul := by
-    rw [← counitAux_def, ← comulAux_def]
     ext phi
     apply (TensorProduct.rid k (ConvolutionDual k H)).injective
     apply WithConv.ofConv_injective
     ext x
-    rw [LinearMap.comp_apply, rid_counit_lTensor_apply, dualDistribEquiv_comulAux_apply]
+    rw [LinearMap.comp_apply, rid_counit_lTensor_apply, dualDistribEquiv_comul_apply']
     simp only [mul_one, TensorProduct.rid_tmul, LinearMap.flip_apply,
       TensorProduct.mk_apply, one_smul]
 
@@ -268,20 +260,27 @@ noncomputable instance instCoalgebra : Coalgebra k (ConvolutionDual k H) where
 theorem dualDistribEquiv_comul (phi : ConvolutionDual k H) :
     dualDistribEquiv k H (Coalgebra.comul phi) =
       phi.ofConv.comp (LinearMap.mul' k H) :=
-  dualDistribEquiv_comulAux k H phi
+  dualDistribEquiv_comul' k H phi
 
 /-- Pointwise form of the characteristic equation for the finite-dual comultiplication. -/
 @[grind =]
 theorem dualDistribEquiv_comul_apply (phi : ConvolutionDual k H) (x y : H) :
     dualDistribEquiv k H (Coalgebra.comul phi) (x ⊗ₜ[k] y) =
       phi.ofConv (x * y) :=
-  dualDistribEquiv_comulAux_apply k H phi x y
+  dualDistribEquiv_comul_apply' k H phi x y
 
 /-- The finite-dual counit is evaluation at one. -/
 @[simp, grind =]
 theorem counit_apply (phi : ConvolutionDual k H) :
     Coalgebra.counit (R := k) phi = phi.ofConv 1 :=
-  counitAux_apply k H phi
+  counit_apply' k H phi
+
+end Coalgebra
+
+section Bialgebra
+
+variable (k : Type u) (H : Type v) [Field k] [Ring H] [Bialgebra k H]
+  [FiniteDimensional k H]
 
 /-- `dualDistribEquiv` packaged in the convolution algebra on functionals on the tensor square. -/
 private noncomputable def evalTensorConv :
@@ -349,11 +348,13 @@ noncomputable instance instBialgebra : Bialgebra k (ConvolutionDual k H) :=
       rw [hmul] at h
       simpa only [WithConv.toConv_ofConv] using h)
 
+end Bialgebra
+
 end ConvolutionDual
 
 namespace ConvolutionDual
 
-variable (k : Type u) (H : Type v) [Field k] [CommRing H] [Bialgebra k H]
+variable (k : Type u) (H : Type v) [Field k] [CommRing H] [Algebra k H]
   [FiniteDimensional k H]
 
 private theorem dualDistribEquiv_comm_apply
@@ -397,24 +398,18 @@ section HopfAlgebra
 variable (k : Type u) (H : Type v) [Field k] [Ring H] [HopfAlgebra k H]
   [FiniteDimensional k H]
 
-/-- The private construction used for the finite-dimensional dual antipode. -/
-private noncomputable def antipodeAux :
-    ConvolutionDual k H →ₗ[k] ConvolutionDual k H :=
-  (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
-    (HopfAlgebra.antipode k (A := H)).dualMap ∘ₗ
-      (WithConv.linearEquiv k _).toLinearMap
-
-omit [FiniteDimensional k H] in
-private theorem antipodeAux_def :
-    antipodeAux k H = (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
+/-- The antipode operation on the finite dual, obtained by transposing the antipode of the
+original Hopf algebra. -/
+noncomputable instance instHopfAlgebraStruct :
+    HopfAlgebraStruct k (ConvolutionDual k H) where
+  antipode := (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
       (HopfAlgebra.antipode k (A := H)).dualMap ∘ₗ
-        (WithConv.linearEquiv k _).toLinearMap :=
-  rfl
+        (WithConv.linearEquiv k _).toLinearMap
 
-omit [FiniteDimensional k H] in
-private theorem antipodeAux_apply (phi : ConvolutionDual k H) (x : H) :
-    (antipodeAux k H phi).ofConv x = phi.ofConv (HopfAlgebra.antipode k x) :=
-  by simp [antipodeAux]
+private theorem antipode_apply' (phi : ConvolutionDual k H) (x : H) :
+    (HopfAlgebra.antipode k (A := ConvolutionDual k H) phi).ofConv x =
+      phi.ofConv (HopfAlgebra.antipode k x) := by
+  simp [HopfAlgebraStruct.antipode]
 
 private theorem ofConv_mul_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
@@ -436,10 +431,11 @@ private theorem ofConv_mul_apply
       | tmul y z =>
           rw [TensorProduct.map_tmul, LinearMap.mul'_apply, dualDistribEquiv_tmul_apply]
 
-private theorem dualDistribEquiv_map_antipode_left
+private theorem dualDistribEquiv_map_antipode_left_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
     dualDistribEquiv k H
-        (TensorProduct.map (antipodeAux k H) LinearMap.id w) z =
+        (TensorProduct.map (HopfAlgebra.antipode k (A := ConvolutionDual k H))
+          LinearMap.id w) z =
       dualDistribEquiv k H w
         (TensorProduct.map (HopfAlgebra.antipode k (A := H)) LinearMap.id z) := by
   induction w using TensorProduct.induction_on with
@@ -453,13 +449,14 @@ private theorem dualDistribEquiv_map_antipode_left
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
       | tmul x y =>
           rw [TensorProduct.map_tmul, TensorProduct.map_tmul, dualDistribEquiv_tmul_apply,
-            dualDistribEquiv_tmul_apply, antipodeAux_apply]
+            dualDistribEquiv_tmul_apply, antipode_apply']
           rfl
 
-private theorem dualDistribEquiv_map_antipode_right
+private theorem dualDistribEquiv_map_antipode_right_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
     dualDistribEquiv k H
-        (TensorProduct.map LinearMap.id (antipodeAux k H) w) z =
+        (TensorProduct.map LinearMap.id
+          (HopfAlgebra.antipode k (A := ConvolutionDual k H)) w) z =
       dualDistribEquiv k H w
         (TensorProduct.map LinearMap.id (HopfAlgebra.antipode k (A := H)) z) := by
   induction w using TensorProduct.induction_on with
@@ -473,21 +470,18 @@ private theorem dualDistribEquiv_map_antipode_right
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
       | tmul x y =>
           rw [TensorProduct.map_tmul, TensorProduct.map_tmul, dualDistribEquiv_tmul_apply,
-            dualDistribEquiv_tmul_apply, antipodeAux_apply]
+            dualDistribEquiv_tmul_apply, antipode_apply']
           rfl
 
 /-- The Hopf algebra structure on the finite dual. Its antipode is precomposition with the
 antipode of the original finite-dimensional Hopf algebra. -/
 noncomputable instance instHopfAlgebra : HopfAlgebra k (ConvolutionDual k H) :=
   HopfAlgebra.ofConvInverse
-    ((WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
-      (HopfAlgebra.antipode k (A := H)).dualMap ∘ₗ
-        (WithConv.linearEquiv k _).toLinearMap)
+    (HopfAlgebra.antipode k (A := ConvolutionDual k H))
     (by
-      rw [← antipodeAux_def]
       apply WithConv.ofConv_injective
       ext phi x
-      rw [LinearMap.convMul_apply, ofConv_mul_apply, dualDistribEquiv_map_antipode_left]
+      rw [LinearMap.convMul_apply, ofConv_mul_apply, dualDistribEquiv_map_antipode_left_apply]
       rw [dualDistribEquiv_comul]
       simp only [LinearMap.comp_apply]
       rw [← LinearMap.rTensor_def, HopfAlgebra.mul_antipode_rTensor_comul_apply]
@@ -496,10 +490,9 @@ noncomputable instance instHopfAlgebra : HopfAlgebra k (ConvolutionDual k H) :=
       simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
       rw [mul_comm])
     (by
-      rw [← antipodeAux_def]
       apply WithConv.ofConv_injective
       ext phi x
-      rw [LinearMap.convMul_apply, ofConv_mul_apply, dualDistribEquiv_map_antipode_right]
+      rw [LinearMap.convMul_apply, ofConv_mul_apply, dualDistribEquiv_map_antipode_right_apply]
       rw [dualDistribEquiv_comul]
       simp only [LinearMap.comp_apply]
       rw [← LinearMap.lTensor_def, HopfAlgebra.mul_antipode_lTensor_comul_apply]
@@ -513,7 +506,7 @@ noncomputable instance instHopfAlgebra : HopfAlgebra k (ConvolutionDual k H) :=
 theorem antipode_apply (phi : ConvolutionDual k H) (x : H) :
     (HopfAlgebra.antipode k phi).ofConv x =
       phi.ofConv (HopfAlgebra.antipode k x) :=
-  antipodeAux_apply k H phi x
+  antipode_apply' k H phi x
 
 end HopfAlgebra
 

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
@@ -1,0 +1,531 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Contraction
+public import Mathlib.RingTheory.HopfAlgebra.Basic
+import Mathlib.RingTheory.TensorProduct.Finite
+import TauCeti.Algebra.Coalgebra.Convolution
+
+/-!
+# The finite dual of a Hopf algebra
+
+For a finite-dimensional bialgebra `H` over a field `k`, the linear dual carries the transposed
+bialgebra structure. Its multiplication is convolution, while its comultiplication and counit are
+characterized by
+
+```text
+Delta(phi)(x tensor y) = phi (x * y),        epsilon(phi) = phi(1).
+```
+
+If `H` is a Hopf algebra, precomposition with its antipode is the antipode of the dual. This is
+the algebraic construction underlying Cartier duality for finite group schemes. The present file
+builds the finite-dimensional Hopf dual over a field; the scheme-level duality and the extension
+to finite locally free Hopf algebras over a general base remain separate steps.
+
+## Main declarations
+
+* `TauCeti.FiniteDual`: the convolution algebra on the linear dual.
+* `TauCeti.FiniteDual.instBialgebra`: the bialgebra obtained by transposing multiplication and
+  unit.
+* `TauCeti.FiniteDual.instHopfAlgebra`: the Hopf structure obtained by transposing the antipode.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+* J. S. Milne, *Algebraic Groups* (2017), Section 12.e.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v
+
+/-- The finite dual of a coalgebra, carrying the convolution algebra structure.
+
+The `WithConv` wrapper selects Mathlib's convolution multiplication on linear maps. -/
+abbrev FiniteDual (k : Type u) (H : Type v) [Field k] [AddCommMonoid H] [Module k H] :=
+  WithConv (Module.Dual k H)
+
+namespace FiniteDual
+
+variable (k : Type u) (H : Type v) [Field k] [Ring H] [Bialgebra k H]
+  [FiniteDimensional k H]
+
+/-- Forget the convolution wrappers on both factors of a tensor of finite-dual elements. -/
+private noncomputable def tensorUnwrap :
+    FiniteDual k H ⊗[k] FiniteDual k H ≃ₗ[k]
+      Module.Dual k H ⊗[k] Module.Dual k H :=
+  TensorProduct.congr (WithConv.linearEquiv k _) (WithConv.linearEquiv k _)
+
+/-- A tensor of finite-dual functionals is equivalently a functional on the tensor square. -/
+noncomputable def evalTensorEquiv :
+    FiniteDual k H ⊗[k] FiniteDual k H ≃ₗ[k] Module.Dual k (H ⊗[k] H) :=
+  (tensorUnwrap k H).trans (TensorProduct.dualDistribEquiv k H H)
+
+/-- Evaluate a tensor of finite-dual functionals on a tensor of elements of `H`. -/
+noncomputable def evalTensor :
+    FiniteDual k H ⊗[k] FiniteDual k H →ₗ[k] Module.Dual k (H ⊗[k] H) :=
+  (evalTensorEquiv k H).toLinearMap
+
+/-- The comultiplication on the finite dual, obtained by transposing multiplication on `H`. -/
+noncomputable def comul : FiniteDual k H →ₗ[k] FiniteDual k H ⊗[k] FiniteDual k H :=
+  (evalTensorEquiv k H).symm.toLinearMap ∘ₗ
+      LinearMap.lcomp k k (LinearMap.mul' k H) ∘ₗ
+        (WithConv.linearEquiv k _).toLinearMap
+
+/-- The counit on the finite dual is evaluation at the unit of `H`. -/
+def counit : FiniteDual k H →ₗ[k] k :=
+  LinearMap.applyₗ (1 : H) ∘ₗ (WithConv.linearEquiv k _).toLinearMap
+
+/-- Evaluating the transposed comultiplication on `x tensor y` gives `phi (x * y)`. -/
+@[simp]
+theorem dualDistrib_comul (phi : FiniteDual k H) :
+    evalTensor k H (comul k H phi) =
+      phi.ofConv.comp (LinearMap.mul' k H) := by
+  simp only [evalTensor, comul, LinearMap.comp_apply]
+  simp only [LinearEquiv.coe_toLinearMap]
+  let psi : Module.Dual k (H ⊗[k] H) :=
+    phi.ofConv.comp (LinearMap.mul' k H)
+  simpa only [psi, LinearMap.lcomp_apply', WithConv.linearEquiv_apply]
+    using (evalTensorEquiv k H).apply_symm_apply psi
+
+/-- A pure tensor of finite-dual functionals evaluates componentwise. -/
+@[simp]
+theorem evalTensor_tmul_apply (phi psi : FiniteDual k H) (x y : H) :
+    evalTensor k H (phi ⊗ₜ[k] psi) (x ⊗ₜ[k] y) =
+      phi.ofConv x * psi.ofConv y := by
+  simp [evalTensor, evalTensorEquiv, tensorUnwrap]
+
+/-- Pointwise form of the characteristic equation for the finite-dual comultiplication. -/
+theorem dualDistrib_comul_apply (phi : FiniteDual k H) (x y : H) :
+    evalTensor k H (comul k H phi) (x ⊗ₜ[k] y) =
+      phi.ofConv (x * y) := by
+  rw [dualDistrib_comul]
+  rfl
+
+omit [FiniteDimensional k H] in
+/-- The finite-dual counit is evaluation at one. -/
+@[simp]
+theorem counit_apply (phi : FiniteDual k H) : counit k H phi = phi.ofConv 1 :=
+  by simp [counit]
+
+/-- Evaluate three finite-dual functionals on a right-associated triple tensor. -/
+private noncomputable def evalTripleEquiv :
+    FiniteDual k H ⊗[k] (FiniteDual k H ⊗[k] FiniteDual k H) ≃ₗ[k]
+      Module.Dual k (H ⊗[k] (H ⊗[k] H)) :=
+  (TensorProduct.congr (WithConv.linearEquiv k _) (evalTensorEquiv k H)).trans
+    (TensorProduct.dualDistribEquiv k H (H ⊗[k] H))
+
+private theorem evalTripleEquiv_tmul_tmul_apply
+    (phi psi chi : FiniteDual k H) (x y z : H) :
+    evalTripleEquiv k H (phi ⊗ₜ[k] (psi ⊗ₜ[k] chi)) (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
+      phi.ofConv x * (psi.ofConv y * chi.ofConv z) := by
+  simp [evalTripleEquiv, evalTensorEquiv, tensorUnwrap]
+
+private theorem evalTripleEquiv_tmul_apply
+    (phi : FiniteDual k H) (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y z : H) :
+    evalTripleEquiv k H (phi ⊗ₜ[k] w) (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
+      phi.ofConv x * evalTensor k H w (y ⊗ₜ[k] z) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [TensorProduct.tmul_add, map_add, LinearMap.add_apply, mul_add]
+        using congrArg₂ (· + ·) hw₁ hw₂
+  | tmul psi chi => rw [evalTripleEquiv_tmul_tmul_apply, evalTensor_tmul_apply]
+
+private theorem evalTripleEquiv_assoc_tmul_apply
+    (w : FiniteDual k H ⊗[k] FiniteDual k H) (chi : FiniteDual k H) (x y z : H) :
+    evalTripleEquiv k H ((TensorProduct.assoc k _ _ _).toLinearMap (w ⊗ₜ[k] chi))
+        (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
+      evalTensor k H w (x ⊗ₜ[k] y) * chi.ofConv z := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [TensorProduct.add_tmul, map_add, LinearMap.add_apply, add_mul]
+        using congrArg₂ (· + ·) hw₁ hw₂
+  | tmul phi psi =>
+      rw [LinearEquiv.coe_toLinearMap, TensorProduct.assoc_tmul,
+        evalTripleEquiv_tmul_tmul_apply, evalTensor_tmul_apply, mul_assoc]
+
+private theorem evalTriple_assoc_comul_rTensor
+    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y z : H) :
+    evalTripleEquiv k H
+        ((TensorProduct.assoc k _ _ _).toLinearMap ((comul k H).rTensor _ w))
+        (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
+      evalTensor k H w ((x * y) ⊗ₜ[k] z) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ => simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
+  | tmul phi psi =>
+      rw [LinearMap.rTensor_tmul, evalTripleEquiv_assoc_tmul_apply,
+        dualDistrib_comul_apply, evalTensor_tmul_apply]
+
+private theorem evalTriple_comul_lTensor
+    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y z : H) :
+    evalTripleEquiv k H ((comul k H).lTensor _ w)
+        (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
+      evalTensor k H w (x ⊗ₜ[k] (y * z)) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ => simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
+  | tmul phi psi =>
+      rw [LinearMap.lTensor_tmul, evalTripleEquiv_tmul_apply,
+        dualDistrib_comul_apply, evalTensor_tmul_apply]
+
+/-- The transposed multiplication is coassociative. -/
+theorem comul_coassoc :
+    TensorProduct.assoc k (FiniteDual k H) (FiniteDual k H) (FiniteDual k H) ∘ₗ
+        (comul k H).rTensor (FiniteDual k H) ∘ₗ comul k H =
+      (comul k H).lTensor (FiniteDual k H) ∘ₗ comul k H := by
+  ext phi
+  apply (evalTripleEquiv k H).injective
+  apply LinearMap.ext
+  intro xyz
+  induction xyz using TensorProduct.induction_on with
+  | zero => simp
+  | add xyz₁ xyz₂ hxyz₁ hxyz₂ =>
+      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxyz₁ hxyz₂
+  | tmul x yz =>
+      induction yz using TensorProduct.induction_on with
+      | zero => simp
+      | add yz₁ yz₂ hyz₁ hyz₂ =>
+          simpa only [TensorProduct.tmul_add, map_add, LinearMap.add_apply]
+            using congrArg₂ (· + ·) hyz₁ hyz₂
+      | tmul y z =>
+          simp only [LinearMap.comp_apply]
+          rw [evalTriple_assoc_comul_rTensor, evalTriple_comul_lTensor,
+            dualDistrib_comul_apply, dualDistrib_comul_apply]
+          simp only [mul_assoc]
+
+private theorem lid_counit_rTensor_apply
+    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x : H) :
+    ((TensorProduct.lid k (FiniteDual k H)) ((counit k H).rTensor _ w)).ofConv x =
+      evalTensor k H w ((1 : H) ⊗ₜ[k] x) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [map_add, WithConv.ofConv_add, LinearMap.add_apply]
+        using congrArg₂ (· + ·) hw₁ hw₂
+  | tmul phi psi =>
+      rw [LinearMap.rTensor_tmul, TensorProduct.lid_tmul, evalTensor_tmul_apply,
+        WithConv.ofConv_smul, LinearMap.smul_apply, counit_apply]
+      simp only [smul_eq_mul]
+
+private theorem rid_counit_lTensor_apply
+    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x : H) :
+    ((TensorProduct.rid k (FiniteDual k H)) ((counit k H).lTensor _ w)).ofConv x =
+      evalTensor k H w (x ⊗ₜ[k] (1 : H)) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [map_add, WithConv.ofConv_add, LinearMap.add_apply]
+        using congrArg₂ (· + ·) hw₁ hw₂
+  | tmul phi psi =>
+      rw [LinearMap.lTensor_tmul, TensorProduct.rid_tmul, evalTensor_tmul_apply,
+        WithConv.ofConv_smul, LinearMap.smul_apply, counit_apply]
+      simp only [smul_eq_mul, mul_comm]
+
+/-- Evaluation at one is a left counit for the transposed multiplication. -/
+theorem rTensor_counit_comp_comul :
+    (counit k H).rTensor (FiniteDual k H) ∘ₗ comul k H =
+      TensorProduct.mk k k (FiniteDual k H) 1 := by
+  ext phi
+  apply (TensorProduct.lid k (FiniteDual k H)).injective
+  apply WithConv.ofConv_injective
+  ext x
+  rw [LinearMap.comp_apply, lid_counit_rTensor_apply, dualDistrib_comul_apply]
+  simp only [one_mul, TensorProduct.lid_tmul, TensorProduct.mk_apply, one_smul]
+
+/-- Evaluation at one is a right counit for the transposed multiplication. -/
+theorem lTensor_counit_comp_comul :
+    (counit k H).lTensor (FiniteDual k H) ∘ₗ comul k H =
+      (TensorProduct.mk k (FiniteDual k H) k).flip 1 := by
+  ext phi
+  apply (TensorProduct.rid k (FiniteDual k H)).injective
+  apply WithConv.ofConv_injective
+  ext x
+  rw [LinearMap.comp_apply, rid_counit_lTensor_apply, dualDistrib_comul_apply]
+  simp only [mul_one, TensorProduct.rid_tmul, LinearMap.flip_apply,
+    TensorProduct.mk_apply, one_smul]
+
+/-- The coalgebra structure on the finite dual, obtained by transposing multiplication and unit
+on the original bialgebra. -/
+noncomputable instance instCoalgebra : Coalgebra k (FiniteDual k H) where
+  comul := comul k H
+  counit := counit k H
+  coassoc := comul_coassoc k H
+  rTensor_counit_comp_comul := rTensor_counit_comp_comul k H
+  lTensor_counit_comp_comul := lTensor_counit_comp_comul k H
+
+/-- `evalTensor` packaged in the convolution algebra on functionals on the tensor square. -/
+private noncomputable def evalTensorConv :
+    FiniteDual k H ⊗[k] FiniteDual k H →ₗ[k]
+      WithConv (Module.Dual k (H ⊗[k] H)) :=
+  (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ evalTensor k H
+
+private theorem evalTensorConv_tmul (phi psi : FiniteDual k H) :
+    evalTensorConv k H (phi ⊗ₜ[k] psi) = LinearMap.mulTensor phi psi := by
+  apply WithConv.ofConv_injective
+  apply TensorProduct.ext'
+  intro x y
+  simp [evalTensorConv]
+
+private theorem evalTensorConv_mul
+    (w z : FiniteDual k H ⊗[k] FiniteDual k H) :
+    evalTensorConv k H (w * z) = evalTensorConv k H w * evalTensorConv k H z := by
+  apply LinearMap.map_mul_of_map_mul_tmul
+  intro phi chi psi omega
+  rw [evalTensorConv_tmul, evalTensorConv_tmul, evalTensorConv_tmul,
+    LinearMap.mulTensor_convMul]
+
+private theorem evalTensorConv_comul (phi : FiniteDual k H) :
+    evalTensorConv k H (comul k H phi) =
+      WithConv.toConv (phi.ofConv.comp (LinearMap.mul' k H)) := by
+  apply WithConv.ofConv_injective
+  exact dualDistrib_comul k H phi
+
+omit [FiniteDimensional k H] in
+/-- The finite-dual counit preserves one. -/
+theorem counit_one : counit k H (1 : FiniteDual k H) = 1 := by
+  rw [counit_apply]
+  rw [LinearMap.convOne_apply, Bialgebra.counit_one, map_one]
+
+omit [FiniteDimensional k H] in
+/-- The finite-dual counit preserves multiplication. -/
+theorem counit_mul (phi psi : FiniteDual k H) :
+    counit k H (phi * psi) = counit k H phi * counit k H psi := by
+  rw [counit_apply, counit_apply, counit_apply, LinearMap.convMul_apply,
+    Bialgebra.comul_one, Algebra.TensorProduct.one_def, TensorProduct.map_tmul,
+    LinearMap.mul'_apply]
+
+/-- The finite-dual comultiplication preserves one. -/
+@[simp]
+theorem comul_one : comul k H (1 : FiniteDual k H) = 1 := by
+  apply (evalTensorEquiv k H).injective
+  apply LinearMap.ext
+  intro xy
+  induction xy using TensorProduct.induction_on with
+  | zero => simp
+  | add xy₁ xy₂ hxy₁ hxy₂ =>
+      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxy₁ hxy₂
+  | tmul x y =>
+      rw [show (evalTensorEquiv k H) (comul k H (1 : FiniteDual k H)) =
+          evalTensor k H (comul k H (1 : FiniteDual k H)) from rfl,
+        show (evalTensorEquiv k H) (1 : FiniteDual k H ⊗[k] FiniteDual k H) =
+          evalTensor k H (1 : FiniteDual k H ⊗[k] FiniteDual k H) from rfl]
+      rw [dualDistrib_comul_apply]
+      simp only [LinearMap.convOne_apply, Bialgebra.counit_mul, map_mul]
+      rw [show (1 : FiniteDual k H ⊗[k] FiniteDual k H) =
+        (1 : FiniteDual k H) ⊗ₜ[k] (1 : FiniteDual k H) from rfl,
+        evalTensor_tmul_apply]
+      simp only [LinearMap.convOne_apply]
+
+/-- The finite-dual comultiplication preserves multiplication. -/
+@[simp]
+theorem comul_mul (phi psi : FiniteDual k H) :
+    comul k H (phi * psi) = comul k H phi * comul k H psi := by
+  apply (evalTensorEquiv k H).injective
+  apply congrArg WithConv.ofConv
+  rw [show WithConv.toConv ((evalTensorEquiv k H) (comul k H (phi * psi))) =
+      evalTensorConv k H (comul k H (phi * psi)) from rfl,
+    show WithConv.toConv ((evalTensorEquiv k H) (comul k H phi * comul k H psi)) =
+      evalTensorConv k H (comul k H phi * comul k H psi) from rfl,
+    evalTensorConv_mul, evalTensorConv_comul, evalTensorConv_comul,
+    evalTensorConv_comul]
+  have h := LinearMap.convMul_comp_coalgHom_distrib phi psi (Bialgebra.mulCoalgHom k H)
+  rw [show (Bialgebra.mulCoalgHom k H).toLinearMap = LinearMap.mul' k H from rfl] at h
+  simpa only [WithConv.toConv_ofConv] using congrArg WithConv.toConv h
+
+/-- The bialgebra structure on the finite dual. Multiplication is convolution and the coalgebra
+operations are transposes of multiplication and unit on the original bialgebra. -/
+noncomputable instance instBialgebra : Bialgebra k (FiniteDual k H) :=
+  Bialgebra.mk' k (FiniteDual k H) (counit_one k H) (fun {_ _} ↦ counit_mul k H _ _)
+    (comul_one k H) (fun {_ _} ↦ comul_mul k H _ _)
+
+end FiniteDual
+
+namespace FiniteDual
+
+variable (k : Type u) (H : Type v) [Field k] [CommRing H] [Bialgebra k H]
+  [FiniteDimensional k H]
+
+private theorem evalTensor_comm_apply
+    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y : H) :
+    evalTensor k H (TensorProduct.comm k _ _ w) (x ⊗ₜ[k] y) =
+      evalTensor k H w (y ⊗ₜ[k] x) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
+  | tmul phi psi =>
+      rw [TensorProduct.comm_tmul, evalTensor_tmul_apply, evalTensor_tmul_apply, mul_comm]
+
+/-- The finite-dual comultiplication is cocommutative when multiplication on `H` is commutative. -/
+theorem comm_comp_comul :
+    (TensorProduct.comm k (FiniteDual k H) (FiniteDual k H)).toLinearMap ∘ₗ comul k H =
+      comul k H := by
+  ext phi
+  apply (evalTensorEquiv k H).injective
+  apply LinearMap.ext
+  intro xy
+  induction xy using TensorProduct.induction_on with
+  | zero => simp
+  | add xy₁ xy₂ hxy₁ hxy₂ =>
+      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxy₁ hxy₂
+  | tmul x y =>
+      simp only [LinearMap.comp_apply]
+      rw [LinearEquiv.coe_toLinearMap]
+      rw [show (evalTensorEquiv k H)
+          ((TensorProduct.comm k (FiniteDual k H) (FiniteDual k H)) (comul k H phi)) =
+        evalTensor k H
+          ((TensorProduct.comm k (FiniteDual k H) (FiniteDual k H)) (comul k H phi)) from rfl,
+        show (evalTensorEquiv k H) (comul k H phi) = evalTensor k H (comul k H phi) from rfl,
+        evalTensor_comm_apply, dualDistrib_comul_apply, dualDistrib_comul_apply]
+      simp only [mul_comm]
+
+/-- The coalgebra underlying the finite dual is cocommutative. -/
+noncomputable instance instIsCocomm : Coalgebra.IsCocomm k (FiniteDual k H) where
+  comm_comp_comul := comm_comp_comul k H
+
+end FiniteDual
+
+namespace FiniteDual
+
+section HopfAlgebra
+
+variable (k : Type u) (H : Type v) [Field k] [Ring H] [HopfAlgebra k H]
+  [FiniteDimensional k H]
+
+/-- The antipode on the finite dual is precomposition with the antipode of `H`. -/
+noncomputable def antipode : FiniteDual k H →ₗ[k] FiniteDual k H :=
+  (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
+    LinearMap.lcomp k k (HopfAlgebra.antipode k (A := H)) ∘ₗ
+      (WithConv.linearEquiv k _).toLinearMap
+
+omit [FiniteDimensional k H] in
+/-- The finite-dual antipode acts by precomposition. -/
+@[simp]
+theorem antipode_apply (phi : FiniteDual k H) (x : H) :
+    (antipode k H phi).ofConv x = phi.ofConv (HopfAlgebra.antipode k x) :=
+  by simp [antipode]
+
+private theorem mul_apply_eq_evalTensor
+    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x : H) :
+    (LinearMap.mul' k (FiniteDual k H) w).ofConv x =
+      evalTensor k H w (Coalgebra.comul x) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [map_add, WithConv.ofConv_add, LinearMap.add_apply]
+        using congrArg₂ (· + ·) hw₁ hw₂
+  | tmul phi psi =>
+      rw [LinearMap.mul'_apply]
+      rw [LinearMap.convMul_apply]
+      generalize Coalgebra.comul (R := k) (A := H) x = z
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | add z₁ z₂ hz₁ hz₂ =>
+          simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
+      | tmul y z => rw [TensorProduct.map_tmul, LinearMap.mul'_apply, evalTensor_tmul_apply]
+
+private theorem evalTensor_map_antipode_left
+    (w : FiniteDual k H ⊗[k] FiniteDual k H) (z : H ⊗[k] H) :
+    evalTensor k H
+        (TensorProduct.map (antipode k H) LinearMap.id w) z =
+      evalTensor k H w
+        (TensorProduct.map (HopfAlgebra.antipode k (A := H)) LinearMap.id z) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
+  | tmul phi psi =>
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | add z₁ z₂ hz₁ hz₂ =>
+          simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
+      | tmul x y =>
+          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, evalTensor_tmul_apply,
+            evalTensor_tmul_apply, antipode_apply]
+          rfl
+
+private theorem evalTensor_map_antipode_right
+    (w : FiniteDual k H ⊗[k] FiniteDual k H) (z : H ⊗[k] H) :
+    evalTensor k H
+        (TensorProduct.map LinearMap.id (antipode k H) w) z =
+      evalTensor k H w
+        (TensorProduct.map LinearMap.id (HopfAlgebra.antipode k (A := H)) z) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
+  | tmul phi psi =>
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | add z₁ z₂ hz₁ hz₂ =>
+          simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
+      | tmul x y =>
+          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, evalTensor_tmul_apply,
+            evalTensor_tmul_apply, antipode_apply]
+          rfl
+
+/-- Precomposition by the original antipode is a left convolution inverse to the identity on the
+finite dual. -/
+theorem antipode_convMul_id :
+    WithConv.toConv (antipode k H) *
+        WithConv.toConv (LinearMap.id : FiniteDual k H →ₗ[k] FiniteDual k H) = 1 := by
+  apply WithConv.ofConv_injective
+  ext phi x
+  rw [LinearMap.convMul_apply, mul_apply_eq_evalTensor,
+    evalTensor_map_antipode_left]
+  change evalTensor k H (comul k H phi)
+      (TensorProduct.map (HopfAlgebra.antipode k (A := H)) LinearMap.id
+        (Coalgebra.comul x)) = _
+  rw [dualDistrib_comul]
+  simp only [LinearMap.comp_apply]
+  rw [← LinearMap.rTensor_def, HopfAlgebra.mul_antipode_rTensor_comul_apply]
+  change phi.ofConv (algebraMap k H (Coalgebra.counit x)) =
+    (algebraMap k (FiniteDual k H) (counit k H phi)).ofConv x
+  rw [counit_apply, LinearMap.convAlgebraMap_apply,
+    Algebra.algebraMap_eq_smul_one, map_smul]
+  simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
+  rw [mul_comm]
+
+/-- Precomposition by the original antipode is a right convolution inverse to the identity on the
+finite dual. -/
+theorem id_convMul_antipode :
+    WithConv.toConv (LinearMap.id : FiniteDual k H →ₗ[k] FiniteDual k H) *
+        WithConv.toConv (antipode k H) = 1 := by
+  apply WithConv.ofConv_injective
+  ext phi x
+  rw [LinearMap.convMul_apply, mul_apply_eq_evalTensor,
+    evalTensor_map_antipode_right]
+  change evalTensor k H (comul k H phi)
+      (TensorProduct.map LinearMap.id (HopfAlgebra.antipode k (A := H))
+        (Coalgebra.comul x)) = _
+  rw [dualDistrib_comul]
+  simp only [LinearMap.comp_apply]
+  rw [← LinearMap.lTensor_def, HopfAlgebra.mul_antipode_lTensor_comul_apply]
+  change phi.ofConv (algebraMap k H (Coalgebra.counit x)) =
+    (algebraMap k (FiniteDual k H) (counit k H phi)).ofConv x
+  rw [counit_apply, LinearMap.convAlgebraMap_apply,
+    Algebra.algebraMap_eq_smul_one, map_smul]
+  simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
+  rw [mul_comm]
+
+/-- The Hopf algebra structure on the finite dual. Its antipode is precomposition with the
+antipode of the original finite-dimensional commutative and cocommutative Hopf algebra. -/
+noncomputable instance instHopfAlgebra : HopfAlgebra k (FiniteDual k H) :=
+  HopfAlgebra.ofConvInverse (antipode k H) (antipode_convMul_id k H)
+    (id_convMul_antipode k H)
+
+end HopfAlgebra
+
+end FiniteDual
+
+end TauCeti

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
@@ -77,7 +77,7 @@ private noncomputable def comulAux :
       (LinearMap.mul' k H).dualMap ∘ₗ
         (WithConv.linearEquiv k _).toLinearMap
 
-private theorem comulAux_eq :
+private theorem comulAux_def :
     comulAux k H = (evalTensorEquiv k H).symm.toLinearMap ∘ₗ
       (LinearMap.mul' k H).dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap :=
   rfl
@@ -87,12 +87,12 @@ private def counitAux : ConvolutionDual k H →ₗ[k] k :=
   LinearMap.applyₗ (1 : H) ∘ₗ (WithConv.linearEquiv k _).toLinearMap
 
 omit [FiniteDimensional k H] in
-private theorem counitAux_eq :
+private theorem counitAux_def :
     counitAux k H = LinearMap.applyₗ (1 : H) ∘ₗ
       (WithConv.linearEquiv k _).toLinearMap :=
   rfl
 
-private theorem evalTensor_comulAux (phi : ConvolutionDual k H) :
+private theorem evalTensorEquiv_comulAux (phi : ConvolutionDual k H) :
     evalTensorEquiv k H (comulAux k H phi) =
       phi.ofConv.comp (LinearMap.mul' k H) := by
   simp only [comulAux, LinearMap.comp_apply]
@@ -103,16 +103,16 @@ private theorem evalTensor_comulAux (phi : ConvolutionDual k H) :
     using (evalTensorEquiv k H).apply_symm_apply psi
 
 /-- A pure tensor of finite-dual functionals evaluates componentwise. -/
-@[simp]
-theorem evalTensor_tmul_apply (phi psi : ConvolutionDual k H) (x y : H) :
+@[simp, grind =]
+theorem evalTensorEquiv_tmul_apply (phi psi : ConvolutionDual k H) (x y : H) :
     evalTensorEquiv k H (phi ⊗ₜ[k] psi) (x ⊗ₜ[k] y) =
       phi.ofConv x * psi.ofConv y := by
   simp [evalTensorEquiv, tensorUnwrap]
 
-private theorem evalTensor_comulAux_apply (phi : ConvolutionDual k H) (x y : H) :
+private theorem evalTensorEquiv_comulAux_apply (phi : ConvolutionDual k H) (x y : H) :
     evalTensorEquiv k H (comulAux k H phi) (x ⊗ₜ[k] y) =
       phi.ofConv (x * y) := by
-  rw [evalTensor_comulAux]
+  rw [evalTensorEquiv_comulAux]
   simp only [LinearMap.comp_apply, LinearMap.mul'_apply]
 
 omit [FiniteDimensional k H] in
@@ -141,7 +141,7 @@ private theorem evalTripleEquiv_tmul_apply
   | add w₁ w₂ hw₁ hw₂ =>
       simpa only [TensorProduct.tmul_add, map_add, LinearMap.add_apply, mul_add]
         using congrArg₂ (· + ·) hw₁ hw₂
-  | tmul psi chi => rw [evalTripleEquiv_tmul_tmul_apply, evalTensor_tmul_apply]
+  | tmul psi chi => rw [evalTripleEquiv_tmul_tmul_apply, evalTensorEquiv_tmul_apply]
 
 private theorem evalTripleEquiv_assoc_tmul_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (chi : ConvolutionDual k H) (x y z : H) :
@@ -155,9 +155,9 @@ private theorem evalTripleEquiv_assoc_tmul_apply
         using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearEquiv.coe_toLinearMap, TensorProduct.assoc_tmul,
-        evalTripleEquiv_tmul_tmul_apply, evalTensor_tmul_apply, mul_assoc]
+        evalTripleEquiv_tmul_tmul_apply, evalTensorEquiv_tmul_apply, mul_assoc]
 
-private theorem evalTriple_assoc_comul_rTensor
+private theorem evalTripleEquiv_assoc_comul_rTensor
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H
         ((TensorProduct.assoc k _ _ _).toLinearMap ((comulAux k H).rTensor _ w))
@@ -169,9 +169,9 @@ private theorem evalTriple_assoc_comul_rTensor
       simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.rTensor_tmul, evalTripleEquiv_assoc_tmul_apply,
-        evalTensor_comulAux_apply, evalTensor_tmul_apply]
+        evalTensorEquiv_comulAux_apply, evalTensorEquiv_tmul_apply]
 
-private theorem evalTriple_comul_lTensor
+private theorem evalTripleEquiv_comul_lTensor
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H ((comulAux k H).lTensor _ w)
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
@@ -182,7 +182,7 @@ private theorem evalTriple_comul_lTensor
       simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.lTensor_tmul, evalTripleEquiv_tmul_apply,
-        evalTensor_comulAux_apply, evalTensor_tmul_apply]
+        evalTensorEquiv_comulAux_apply, evalTensorEquiv_tmul_apply]
 
 private theorem lid_counit_rTensor_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
@@ -194,7 +194,7 @@ private theorem lid_counit_rTensor_apply
       simpa only [map_add, WithConv.ofConv_add, LinearMap.add_apply]
         using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
-      rw [LinearMap.rTensor_tmul, TensorProduct.lid_tmul, evalTensor_tmul_apply,
+      rw [LinearMap.rTensor_tmul, TensorProduct.lid_tmul, evalTensorEquiv_tmul_apply,
         WithConv.ofConv_smul, LinearMap.smul_apply, counitAux_apply]
       simp only [smul_eq_mul]
 
@@ -208,7 +208,7 @@ private theorem rid_counit_lTensor_apply
       simpa only [map_add, WithConv.ofConv_add, LinearMap.add_apply]
         using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
-      rw [LinearMap.lTensor_tmul, TensorProduct.rid_tmul, evalTensor_tmul_apply,
+      rw [LinearMap.lTensor_tmul, TensorProduct.rid_tmul, evalTensorEquiv_tmul_apply,
         WithConv.ofConv_smul, LinearMap.smul_apply, counitAux_apply]
       simp only [smul_eq_mul, mul_comm]
 
@@ -219,7 +219,7 @@ noncomputable instance instCoalgebra : Coalgebra k (ConvolutionDual k H) where
     (LinearMap.mul' k H).dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap
   counit := LinearMap.applyₗ (1 : H) ∘ₗ (WithConv.linearEquiv k _).toLinearMap
   coassoc := by
-    rw [← comulAux_eq]
+    rw [← comulAux_def]
     ext phi
     apply (evalTripleEquiv k H).injective
     apply LinearMap.ext
@@ -236,42 +236,43 @@ noncomputable instance instCoalgebra : Coalgebra k (ConvolutionDual k H) where
               using congrArg₂ (· + ·) hyz₁ hyz₂
         | tmul y z =>
             simp only [LinearMap.comp_apply]
-            rw [evalTriple_assoc_comul_rTensor, evalTriple_comul_lTensor,
-              evalTensor_comulAux_apply, evalTensor_comulAux_apply]
+            rw [evalTripleEquiv_assoc_comul_rTensor, evalTripleEquiv_comul_lTensor,
+              evalTensorEquiv_comulAux_apply, evalTensorEquiv_comulAux_apply]
             simp only [mul_assoc]
   rTensor_counit_comp_comul := by
-    rw [← counitAux_eq, ← comulAux_eq]
+    rw [← counitAux_def, ← comulAux_def]
     ext phi
     apply (TensorProduct.lid k (ConvolutionDual k H)).injective
     apply WithConv.ofConv_injective
     ext x
-    rw [LinearMap.comp_apply, lid_counit_rTensor_apply, evalTensor_comulAux_apply]
+    rw [LinearMap.comp_apply, lid_counit_rTensor_apply, evalTensorEquiv_comulAux_apply]
     simp only [one_mul, TensorProduct.lid_tmul, TensorProduct.mk_apply, one_smul]
   lTensor_counit_comp_comul := by
-    rw [← counitAux_eq, ← comulAux_eq]
+    rw [← counitAux_def, ← comulAux_def]
     ext phi
     apply (TensorProduct.rid k (ConvolutionDual k H)).injective
     apply WithConv.ofConv_injective
     ext x
-    rw [LinearMap.comp_apply, rid_counit_lTensor_apply, evalTensor_comulAux_apply]
+    rw [LinearMap.comp_apply, rid_counit_lTensor_apply, evalTensorEquiv_comulAux_apply]
     simp only [mul_one, TensorProduct.rid_tmul, LinearMap.flip_apply,
       TensorProduct.mk_apply, one_smul]
 
 /-- Evaluating the finite-dual comultiplication gives the transpose of multiplication on `H`. -/
-@[simp]
-theorem evalTensor_comul (phi : ConvolutionDual k H) :
+@[simp, grind =]
+theorem evalTensorEquiv_comul (phi : ConvolutionDual k H) :
     evalTensorEquiv k H (Coalgebra.comul phi) =
       phi.ofConv.comp (LinearMap.mul' k H) :=
-  evalTensor_comulAux k H phi
+  evalTensorEquiv_comulAux k H phi
 
 /-- Pointwise form of the characteristic equation for the finite-dual comultiplication. -/
-theorem evalTensor_comul_apply (phi : ConvolutionDual k H) (x y : H) :
+@[grind =]
+theorem evalTensorEquiv_comul_apply (phi : ConvolutionDual k H) (x y : H) :
     evalTensorEquiv k H (Coalgebra.comul phi) (x ⊗ₜ[k] y) =
       phi.ofConv (x * y) :=
-  evalTensor_comulAux_apply k H phi x y
+  evalTensorEquiv_comulAux_apply k H phi x y
 
 /-- The finite-dual counit is evaluation at one. -/
-@[simp]
+@[simp, grind =]
 theorem counit_apply (phi : ConvolutionDual k H) :
     Coalgebra.counit (R := k) phi = phi.ofConv 1 :=
   counitAux_apply k H phi
@@ -301,16 +302,11 @@ private theorem evalTensorConv_comul (phi : ConvolutionDual k H) :
     evalTensorConv k H (Coalgebra.comul phi) =
       WithConv.toConv (phi.ofConv.comp (LinearMap.mul' k H)) := by
   apply WithConv.ofConv_injective
-  exact evalTensor_comul k H phi
+  exact evalTensorEquiv_comul k H phi
 
 @[simp]
 private theorem evalTensorConv_ofConv (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) :
     (evalTensorConv k H w).ofConv = evalTensorEquiv k H w :=
-  rfl
-
-omit [FiniteDimensional k H] in
-private theorem mulCoalgHom_toLinearMap :
-    (Bialgebra.mulCoalgHom k H).toLinearMap = LinearMap.mul' k H :=
   rfl
 
 /-- The bialgebra structure on the finite dual. Multiplication is convolution and the coalgebra
@@ -333,16 +329,16 @@ noncomputable instance instBialgebra : Bialgebra k (ConvolutionDual k H) :=
       | add xy₁ xy₂ hxy₁ hxy₂ =>
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxy₁ hxy₂
       | tmul x y =>
-          rw [evalTensor_comul_apply]
+          rw [evalTensorEquiv_comul_apply]
           simp only [LinearMap.convOne_apply, Bialgebra.counit_mul, map_mul]
-          rw [Algebra.TensorProduct.one_def, evalTensor_tmul_apply]
+          rw [Algebra.TensorProduct.one_def, evalTensorEquiv_tmul_apply]
           simp only [LinearMap.convOne_apply])
     (fun {phi psi} ↦ by
       apply (evalTensorEquiv k H).injective
       rw [← evalTensorConv_ofConv, ← evalTensorConv_ofConv, evalTensorConv_mul,
         evalTensorConv_comul, evalTensorConv_comul, evalTensorConv_comul]
       have h := LinearMap.convMul_comp_coalgHom_distrib phi psi (Bialgebra.mulCoalgHom k H)
-      rw [mulCoalgHom_toLinearMap] at h
+      rw [show (Bialgebra.mulCoalgHom k H).toLinearMap = LinearMap.mul' k H from rfl] at h
       simpa only [WithConv.toConv_ofConv] using h)
 
 end ConvolutionDual
@@ -352,16 +348,22 @@ namespace ConvolutionDual
 variable (k : Type u) (H : Type v) [Field k] [CommRing H] [Bialgebra k H]
   [FiniteDimensional k H]
 
-private theorem evalTensor_comm_apply
+private theorem evalTensorEquiv_comm_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y : H) :
     evalTensorEquiv k H (TensorProduct.comm k _ _ w) (x ⊗ₜ[k] y) =
       evalTensorEquiv k H w (y ⊗ₜ[k] x) := by
-  induction w using TensorProduct.induction_on with
-  | zero => simp
-  | add w₁ w₂ hw₁ hw₂ =>
-      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
-  | tmul phi psi =>
-      rw [TensorProduct.comm_tmul, evalTensor_tmul_apply, evalTensor_tmul_apply, mul_comm]
+  have hcomm :
+      (tensorUnwrap k H) (TensorProduct.comm k _ _ w) =
+        TensorProduct.comm k _ _ ((tensorUnwrap k H) w) := by
+    induction w using TensorProduct.induction_on with
+    | zero => simp
+    | add w₁ w₂ hw₁ hw₂ => simpa only [map_add] using congrArg₂ (· + ·) hw₁ hw₂
+    | tmul phi psi => simp [tensorUnwrap]
+  change TensorProduct.dualDistrib k H H
+      ((tensorUnwrap k H) (TensorProduct.comm k _ _ w)) (x ⊗ₜ[k] y) =
+    TensorProduct.dualDistrib k H H ((tensorUnwrap k H) w) (y ⊗ₜ[k] x)
+  rw [hcomm]
+  exact (TensorProduct.dualDistrib_apply_comm ((tensorUnwrap k H) w) (x ⊗ₜ[k] y)).symm
 
 /-- The coalgebra underlying the finite dual is cocommutative. -/
 noncomputable instance instIsCocomm : Coalgebra.IsCocomm k (ConvolutionDual k H) where
@@ -377,7 +379,8 @@ noncomputable instance instIsCocomm : Coalgebra.IsCocomm k (ConvolutionDual k H)
     | tmul x y =>
         simp only [LinearMap.comp_apply]
         rw [LinearEquiv.coe_toLinearMap]
-        rw [evalTensor_comm_apply, evalTensor_comul_apply, evalTensor_comul_apply]
+        rw [evalTensorEquiv_comm_apply, evalTensorEquiv_comul_apply,
+          evalTensorEquiv_comul_apply]
         simp only [mul_comm]
 
 end ConvolutionDual
@@ -397,7 +400,7 @@ private noncomputable def antipodeAux :
       (WithConv.linearEquiv k _).toLinearMap
 
 omit [FiniteDimensional k H] in
-private theorem antipodeAux_eq :
+private theorem antipodeAux_def :
     antipodeAux k H = (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
       (HopfAlgebra.antipode k (A := H)).dualMap ∘ₗ
         (WithConv.linearEquiv k _).toLinearMap :=
@@ -408,7 +411,7 @@ private theorem antipodeAux_apply (phi : ConvolutionDual k H) (x : H) :
     (antipodeAux k H phi).ofConv x = phi.ofConv (HopfAlgebra.antipode k x) :=
   by simp [antipodeAux]
 
-private theorem mul_apply_eq_evalTensorEquiv
+private theorem ofConv_mul_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
     (LinearMap.mul' k (ConvolutionDual k H) w).ofConv x =
       evalTensorEquiv k H w (Coalgebra.comul x) := by
@@ -425,9 +428,10 @@ private theorem mul_apply_eq_evalTensorEquiv
       | zero => simp
       | add z₁ z₂ hz₁ hz₂ =>
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
-      | tmul y z => rw [TensorProduct.map_tmul, LinearMap.mul'_apply, evalTensor_tmul_apply]
+      | tmul y z =>
+          rw [TensorProduct.map_tmul, LinearMap.mul'_apply, evalTensorEquiv_tmul_apply]
 
-private theorem evalTensor_map_antipode_left
+private theorem evalTensorEquiv_map_antipode_left
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
     evalTensorEquiv k H
         (TensorProduct.map (antipodeAux k H) LinearMap.id w) z =
@@ -443,11 +447,11 @@ private theorem evalTensor_map_antipode_left
       | add z₁ z₂ hz₁ hz₂ =>
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
       | tmul x y =>
-          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, evalTensor_tmul_apply,
-            evalTensor_tmul_apply, antipodeAux_apply]
+          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, evalTensorEquiv_tmul_apply,
+            evalTensorEquiv_tmul_apply, antipodeAux_apply]
           rfl
 
-private theorem evalTensor_map_antipode_right
+private theorem evalTensorEquiv_map_antipode_right
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
     evalTensorEquiv k H
         (TensorProduct.map LinearMap.id (antipodeAux k H) w) z =
@@ -463,8 +467,8 @@ private theorem evalTensor_map_antipode_right
       | add z₁ z₂ hz₁ hz₂ =>
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
       | tmul x y =>
-          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, evalTensor_tmul_apply,
-            evalTensor_tmul_apply, antipodeAux_apply]
+          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, evalTensorEquiv_tmul_apply,
+            evalTensorEquiv_tmul_apply, antipodeAux_apply]
           rfl
 
 /-- The Hopf algebra structure on the finite dual. Its antipode is precomposition with the
@@ -475,36 +479,32 @@ noncomputable instance instHopfAlgebra : HopfAlgebra k (ConvolutionDual k H) :=
       (HopfAlgebra.antipode k (A := H)).dualMap ∘ₗ
         (WithConv.linearEquiv k _).toLinearMap)
     (by
-      rw [← antipodeAux_eq]
+      rw [← antipodeAux_def]
       apply WithConv.ofConv_injective
       ext phi x
-      rw [LinearMap.convMul_apply, mul_apply_eq_evalTensorEquiv,
-        evalTensor_map_antipode_left]
-      rw [evalTensor_comul]
+      rw [LinearMap.convMul_apply, ofConv_mul_apply, evalTensorEquiv_map_antipode_left]
+      rw [evalTensorEquiv_comul]
       simp only [LinearMap.comp_apply]
       rw [← LinearMap.rTensor_def, HopfAlgebra.mul_antipode_rTensor_comul_apply]
-      rw [LinearMap.convOne_apply, counit_apply,
-        LinearMap.convAlgebraMap_apply,
+      rw [LinearMap.convOne_apply, counit_apply, LinearMap.convAlgebraMap_apply,
         Algebra.algebraMap_eq_smul_one, map_smul]
       simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
       rw [mul_comm])
     (by
-      rw [← antipodeAux_eq]
+      rw [← antipodeAux_def]
       apply WithConv.ofConv_injective
       ext phi x
-      rw [LinearMap.convMul_apply, mul_apply_eq_evalTensorEquiv,
-        evalTensor_map_antipode_right]
-      rw [evalTensor_comul]
+      rw [LinearMap.convMul_apply, ofConv_mul_apply, evalTensorEquiv_map_antipode_right]
+      rw [evalTensorEquiv_comul]
       simp only [LinearMap.comp_apply]
       rw [← LinearMap.lTensor_def, HopfAlgebra.mul_antipode_lTensor_comul_apply]
-      rw [LinearMap.convOne_apply, counit_apply,
-        LinearMap.convAlgebraMap_apply,
+      rw [LinearMap.convOne_apply, counit_apply, LinearMap.convAlgebraMap_apply,
         Algebra.algebraMap_eq_smul_one, map_smul]
       simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
       rw [mul_comm])
 
 /-- The finite-dual antipode acts by precomposition with the original antipode. -/
-@[simp]
+@[simp, grind =]
 theorem antipode_apply (phi : ConvolutionDual k H) (x : H) :
     (HopfAlgebra.antipode k phi).ofConv x =
       phi.ofConv (HopfAlgebra.antipode k x) :=

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
@@ -66,25 +66,25 @@ private noncomputable def tensorUnwrap :
   TensorProduct.congr (WithConv.linearEquiv k _) (WithConv.linearEquiv k _)
 
 /-- A tensor of finite-dual functionals is equivalently a functional on the tensor square. -/
-noncomputable def evalTensorEquiv :
+noncomputable def dualDistribEquiv :
     ConvolutionDual k H ⊗[k] ConvolutionDual k H ≃ₗ[k] Module.Dual k (H ⊗[k] H) :=
   (tensorUnwrap k H).trans (TensorProduct.dualDistribEquiv k H H)
 
-private theorem evalTensorEquiv_apply
+private theorem dualDistribEquiv_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
-    evalTensorEquiv k H w z =
+    dualDistribEquiv k H w z =
       TensorProduct.dualDistrib k H H ((tensorUnwrap k H) w) z :=
   rfl
 
 /-- The private construction used for the finite-dimensional dual comultiplication. -/
 private noncomputable def comulAux :
     ConvolutionDual k H →ₗ[k] ConvolutionDual k H ⊗[k] ConvolutionDual k H :=
-  (evalTensorEquiv k H).symm.toLinearMap ∘ₗ
+  (dualDistribEquiv k H).symm.toLinearMap ∘ₗ
       (LinearMap.mul' k H).dualMap ∘ₗ
         (WithConv.linearEquiv k _).toLinearMap
 
 private theorem comulAux_def :
-    comulAux k H = (evalTensorEquiv k H).symm.toLinearMap ∘ₗ
+    comulAux k H = (dualDistribEquiv k H).symm.toLinearMap ∘ₗ
       (LinearMap.mul' k H).dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap :=
   rfl
 
@@ -98,27 +98,27 @@ private theorem counitAux_def :
       (WithConv.linearEquiv k _).toLinearMap :=
   rfl
 
-private theorem evalTensorEquiv_comulAux (phi : ConvolutionDual k H) :
-    evalTensorEquiv k H (comulAux k H phi) =
+private theorem dualDistribEquiv_comulAux (phi : ConvolutionDual k H) :
+    dualDistribEquiv k H (comulAux k H phi) =
       phi.ofConv.comp (LinearMap.mul' k H) := by
   simp only [comulAux, LinearMap.comp_apply]
   simp only [LinearEquiv.coe_toLinearMap]
   let psi : Module.Dual k (H ⊗[k] H) :=
     phi.ofConv.comp (LinearMap.mul' k H)
   simpa only [psi, LinearMap.dualMap_apply', WithConv.linearEquiv_apply]
-    using (evalTensorEquiv k H).apply_symm_apply psi
+    using (dualDistribEquiv k H).apply_symm_apply psi
 
 /-- A pure tensor of finite-dual functionals evaluates componentwise. -/
 @[simp, grind =]
-theorem evalTensorEquiv_tmul_apply (phi psi : ConvolutionDual k H) (x y : H) :
-    evalTensorEquiv k H (phi ⊗ₜ[k] psi) (x ⊗ₜ[k] y) =
+theorem dualDistribEquiv_tmul_apply (phi psi : ConvolutionDual k H) (x y : H) :
+    dualDistribEquiv k H (phi ⊗ₜ[k] psi) (x ⊗ₜ[k] y) =
       phi.ofConv x * psi.ofConv y := by
-  simp [evalTensorEquiv, tensorUnwrap]
+  simp [dualDistribEquiv, tensorUnwrap]
 
-private theorem evalTensorEquiv_comulAux_apply (phi : ConvolutionDual k H) (x y : H) :
-    evalTensorEquiv k H (comulAux k H phi) (x ⊗ₜ[k] y) =
+private theorem dualDistribEquiv_comulAux_apply (phi : ConvolutionDual k H) (x y : H) :
+    dualDistribEquiv k H (comulAux k H phi) (x ⊗ₜ[k] y) =
       phi.ofConv (x * y) := by
-  rw [evalTensorEquiv_comulAux]
+  rw [dualDistribEquiv_comulAux]
   simp only [LinearMap.comp_apply, LinearMap.mul'_apply]
 
 omit [FiniteDimensional k H] in
@@ -129,31 +129,31 @@ private theorem counitAux_apply (phi : ConvolutionDual k H) : counitAux k H phi 
 private noncomputable def evalTripleEquiv :
     ConvolutionDual k H ⊗[k] (ConvolutionDual k H ⊗[k] ConvolutionDual k H) ≃ₗ[k]
       Module.Dual k (H ⊗[k] (H ⊗[k] H)) :=
-  (TensorProduct.congr (WithConv.linearEquiv k _) (evalTensorEquiv k H)).trans
+  (TensorProduct.congr (WithConv.linearEquiv k _) (dualDistribEquiv k H)).trans
     (TensorProduct.dualDistribEquiv k H (H ⊗[k] H))
 
 private theorem evalTripleEquiv_tmul_tmul_apply
     (phi psi chi : ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H (phi ⊗ₜ[k] (psi ⊗ₜ[k] chi)) (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
       phi.ofConv x * (psi.ofConv y * chi.ofConv z) := by
-  simp [evalTripleEquiv, evalTensorEquiv, tensorUnwrap]
+  simp [evalTripleEquiv, dualDistribEquiv, tensorUnwrap]
 
 private theorem evalTripleEquiv_tmul_apply
     (phi : ConvolutionDual k H) (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H (phi ⊗ₜ[k] w) (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
-      phi.ofConv x * evalTensorEquiv k H w (y ⊗ₜ[k] z) := by
+      phi.ofConv x * dualDistribEquiv k H w (y ⊗ₜ[k] z) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
       simpa only [TensorProduct.tmul_add, map_add, LinearMap.add_apply, mul_add]
         using congrArg₂ (· + ·) hw₁ hw₂
-  | tmul psi chi => rw [evalTripleEquiv_tmul_tmul_apply, evalTensorEquiv_tmul_apply]
+  | tmul psi chi => rw [evalTripleEquiv_tmul_tmul_apply, dualDistribEquiv_tmul_apply]
 
 private theorem evalTripleEquiv_assoc_tmul_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (chi : ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H ((TensorProduct.assoc k _ _ _).toLinearMap (w ⊗ₜ[k] chi))
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
-      evalTensorEquiv k H w (x ⊗ₜ[k] y) * chi.ofConv z := by
+      dualDistribEquiv k H w (x ⊗ₜ[k] y) * chi.ofConv z := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
@@ -161,67 +161,67 @@ private theorem evalTripleEquiv_assoc_tmul_apply
         using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearEquiv.coe_toLinearMap, TensorProduct.assoc_tmul,
-        evalTripleEquiv_tmul_tmul_apply, evalTensorEquiv_tmul_apply, mul_assoc]
+        evalTripleEquiv_tmul_tmul_apply, dualDistribEquiv_tmul_apply, mul_assoc]
 
 private theorem evalTripleEquiv_assoc_comul_rTensor
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H
         ((TensorProduct.assoc k _ _ _).toLinearMap ((comulAux k H).rTensor _ w))
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
-      evalTensorEquiv k H w ((x * y) ⊗ₜ[k] z) := by
+      dualDistribEquiv k H w ((x * y) ⊗ₜ[k] z) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
       simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.rTensor_tmul, evalTripleEquiv_assoc_tmul_apply,
-        evalTensorEquiv_comulAux_apply, evalTensorEquiv_tmul_apply]
+        dualDistribEquiv_comulAux_apply, dualDistribEquiv_tmul_apply]
 
 private theorem evalTripleEquiv_comul_lTensor
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H ((comulAux k H).lTensor _ w)
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
-      evalTensorEquiv k H w (x ⊗ₜ[k] (y * z)) := by
+      dualDistribEquiv k H w (x ⊗ₜ[k] (y * z)) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
       simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.lTensor_tmul, evalTripleEquiv_tmul_apply,
-        evalTensorEquiv_comulAux_apply, evalTensorEquiv_tmul_apply]
+        dualDistribEquiv_comulAux_apply, dualDistribEquiv_tmul_apply]
 
 private theorem lid_counit_rTensor_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
     ((TensorProduct.lid k (ConvolutionDual k H)) ((counitAux k H).rTensor _ w)).ofConv x =
-      evalTensorEquiv k H w ((1 : H) ⊗ₜ[k] x) := by
+      dualDistribEquiv k H w ((1 : H) ⊗ₜ[k] x) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
       simpa only [map_add, WithConv.ofConv_add, LinearMap.add_apply]
         using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
-      rw [LinearMap.rTensor_tmul, TensorProduct.lid_tmul, evalTensorEquiv_tmul_apply,
+      rw [LinearMap.rTensor_tmul, TensorProduct.lid_tmul, dualDistribEquiv_tmul_apply,
         WithConv.ofConv_smul, LinearMap.smul_apply, counitAux_apply]
       simp only [smul_eq_mul]
 
 private theorem rid_counit_lTensor_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
     ((TensorProduct.rid k (ConvolutionDual k H)) ((counitAux k H).lTensor _ w)).ofConv x =
-      evalTensorEquiv k H w (x ⊗ₜ[k] (1 : H)) := by
+      dualDistribEquiv k H w (x ⊗ₜ[k] (1 : H)) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
       simpa only [map_add, WithConv.ofConv_add, LinearMap.add_apply]
         using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
-      rw [LinearMap.lTensor_tmul, TensorProduct.rid_tmul, evalTensorEquiv_tmul_apply,
+      rw [LinearMap.lTensor_tmul, TensorProduct.rid_tmul, dualDistribEquiv_tmul_apply,
         WithConv.ofConv_smul, LinearMap.smul_apply, counitAux_apply]
       simp only [smul_eq_mul, mul_comm]
 
 /-- The coalgebra structure on the finite dual, obtained by transposing multiplication and unit
 on the original bialgebra. -/
 noncomputable instance instCoalgebra : Coalgebra k (ConvolutionDual k H) where
-  comul := (evalTensorEquiv k H).symm.toLinearMap ∘ₗ
+  comul := (dualDistribEquiv k H).symm.toLinearMap ∘ₗ
     (LinearMap.mul' k H).dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap
   counit := LinearMap.applyₗ (1 : H) ∘ₗ (WithConv.linearEquiv k _).toLinearMap
   coassoc := by
@@ -243,7 +243,7 @@ noncomputable instance instCoalgebra : Coalgebra k (ConvolutionDual k H) where
         | tmul y z =>
             simp only [LinearMap.comp_apply]
             rw [evalTripleEquiv_assoc_comul_rTensor, evalTripleEquiv_comul_lTensor,
-              evalTensorEquiv_comulAux_apply, evalTensorEquiv_comulAux_apply]
+              dualDistribEquiv_comulAux_apply, dualDistribEquiv_comulAux_apply]
             simp only [mul_assoc]
   rTensor_counit_comp_comul := by
     rw [← counitAux_def, ← comulAux_def]
@@ -251,7 +251,7 @@ noncomputable instance instCoalgebra : Coalgebra k (ConvolutionDual k H) where
     apply (TensorProduct.lid k (ConvolutionDual k H)).injective
     apply WithConv.ofConv_injective
     ext x
-    rw [LinearMap.comp_apply, lid_counit_rTensor_apply, evalTensorEquiv_comulAux_apply]
+    rw [LinearMap.comp_apply, lid_counit_rTensor_apply, dualDistribEquiv_comulAux_apply]
     simp only [one_mul, TensorProduct.lid_tmul, TensorProduct.mk_apply, one_smul]
   lTensor_counit_comp_comul := by
     rw [← counitAux_def, ← comulAux_def]
@@ -259,23 +259,23 @@ noncomputable instance instCoalgebra : Coalgebra k (ConvolutionDual k H) where
     apply (TensorProduct.rid k (ConvolutionDual k H)).injective
     apply WithConv.ofConv_injective
     ext x
-    rw [LinearMap.comp_apply, rid_counit_lTensor_apply, evalTensorEquiv_comulAux_apply]
+    rw [LinearMap.comp_apply, rid_counit_lTensor_apply, dualDistribEquiv_comulAux_apply]
     simp only [mul_one, TensorProduct.rid_tmul, LinearMap.flip_apply,
       TensorProduct.mk_apply, one_smul]
 
 /-- Evaluating the finite-dual comultiplication gives the transpose of multiplication on `H`. -/
 @[simp, grind =]
-theorem evalTensorEquiv_comul (phi : ConvolutionDual k H) :
-    evalTensorEquiv k H (Coalgebra.comul phi) =
+theorem dualDistribEquiv_comul (phi : ConvolutionDual k H) :
+    dualDistribEquiv k H (Coalgebra.comul phi) =
       phi.ofConv.comp (LinearMap.mul' k H) :=
-  evalTensorEquiv_comulAux k H phi
+  dualDistribEquiv_comulAux k H phi
 
 /-- Pointwise form of the characteristic equation for the finite-dual comultiplication. -/
 @[grind =]
-theorem evalTensorEquiv_comul_apply (phi : ConvolutionDual k H) (x y : H) :
-    evalTensorEquiv k H (Coalgebra.comul phi) (x ⊗ₜ[k] y) =
+theorem dualDistribEquiv_comul_apply (phi : ConvolutionDual k H) (x y : H) :
+    dualDistribEquiv k H (Coalgebra.comul phi) (x ⊗ₜ[k] y) =
       phi.ofConv (x * y) :=
-  evalTensorEquiv_comulAux_apply k H phi x y
+  dualDistribEquiv_comulAux_apply k H phi x y
 
 /-- The finite-dual counit is evaluation at one. -/
 @[simp, grind =]
@@ -283,11 +283,11 @@ theorem counit_apply (phi : ConvolutionDual k H) :
     Coalgebra.counit (R := k) phi = phi.ofConv 1 :=
   counitAux_apply k H phi
 
-/-- `evalTensorEquiv` packaged in the convolution algebra on functionals on the tensor square. -/
+/-- `dualDistribEquiv` packaged in the convolution algebra on functionals on the tensor square. -/
 private noncomputable def evalTensorConv :
     ConvolutionDual k H ⊗[k] ConvolutionDual k H →ₗ[k]
       WithConv (Module.Dual k (H ⊗[k] H)) :=
-  (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ (evalTensorEquiv k H).toLinearMap
+  (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ (dualDistribEquiv k H).toLinearMap
 
 private theorem evalTensorConv_tmul (phi psi : ConvolutionDual k H) :
     evalTensorConv k H (phi ⊗ₜ[k] psi) = LinearMap.mulTensor phi psi := by
@@ -308,11 +308,11 @@ private theorem evalTensorConv_comul (phi : ConvolutionDual k H) :
     evalTensorConv k H (Coalgebra.comul phi) =
       WithConv.toConv (phi.ofConv.comp (LinearMap.mul' k H)) := by
   apply WithConv.ofConv_injective
-  exact evalTensorEquiv_comul k H phi
+  exact dualDistribEquiv_comul k H phi
 
 @[simp]
 private theorem evalTensorConv_ofConv (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) :
-    (evalTensorConv k H w).ofConv = evalTensorEquiv k H w :=
+    (evalTensorConv k H w).ofConv = dualDistribEquiv k H w :=
   rfl
 
 /-- The bialgebra structure on the finite dual. Multiplication is convolution and the coalgebra
@@ -327,7 +327,7 @@ noncomputable instance instBialgebra : Bialgebra k (ConvolutionDual k H) :=
         Bialgebra.comul_one, Algebra.TensorProduct.one_def, TensorProduct.map_tmul,
         LinearMap.mul'_apply])
     (by
-      apply (evalTensorEquiv k H).injective
+      apply (dualDistribEquiv k H).injective
       apply LinearMap.ext
       intro xy
       induction xy using TensorProduct.induction_on with
@@ -335,12 +335,12 @@ noncomputable instance instBialgebra : Bialgebra k (ConvolutionDual k H) :=
       | add xy₁ xy₂ hxy₁ hxy₂ =>
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxy₁ hxy₂
       | tmul x y =>
-          rw [evalTensorEquiv_comul_apply]
+          rw [dualDistribEquiv_comul_apply]
           simp only [LinearMap.convOne_apply, Bialgebra.counit_mul, map_mul]
-          rw [Algebra.TensorProduct.one_def, evalTensorEquiv_tmul_apply]
+          rw [Algebra.TensorProduct.one_def, dualDistribEquiv_tmul_apply]
           simp only [LinearMap.convOne_apply])
     (fun {phi psi} ↦ by
-      apply (evalTensorEquiv k H).injective
+      apply (dualDistribEquiv k H).injective
       rw [← evalTensorConv_ofConv, ← evalTensorConv_ofConv, evalTensorConv_mul,
         evalTensorConv_comul, evalTensorConv_comul, evalTensorConv_comul]
       have h := LinearMap.convMul_comp_coalgHom_distrib phi psi (Bialgebra.mulCoalgHom k H)
@@ -356,10 +356,10 @@ namespace ConvolutionDual
 variable (k : Type u) (H : Type v) [Field k] [CommRing H] [Bialgebra k H]
   [FiniteDimensional k H]
 
-private theorem evalTensorEquiv_comm_apply
+private theorem dualDistribEquiv_comm_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y : H) :
-    evalTensorEquiv k H (TensorProduct.comm k _ _ w) (x ⊗ₜ[k] y) =
-      evalTensorEquiv k H w (y ⊗ₜ[k] x) := by
+    dualDistribEquiv k H (TensorProduct.comm k _ _ w) (x ⊗ₜ[k] y) =
+      dualDistribEquiv k H w (y ⊗ₜ[k] x) := by
   have hcomm :
       (tensorUnwrap k H) (TensorProduct.comm k _ _ w) =
         TensorProduct.comm k _ _ ((tensorUnwrap k H) w) := by
@@ -367,14 +367,14 @@ private theorem evalTensorEquiv_comm_apply
     | zero => simp
     | add w₁ w₂ hw₁ hw₂ => simpa only [map_add] using congrArg₂ (· + ·) hw₁ hw₂
     | tmul phi psi => simp [tensorUnwrap]
-  rw [evalTensorEquiv_apply, evalTensorEquiv_apply, hcomm]
+  rw [dualDistribEquiv_apply, dualDistribEquiv_apply, hcomm]
   exact (TensorProduct.dualDistrib_apply_comm ((tensorUnwrap k H) w) (x ⊗ₜ[k] y)).symm
 
 /-- The coalgebra underlying the finite dual is cocommutative. -/
 noncomputable instance instIsCocomm : Coalgebra.IsCocomm k (ConvolutionDual k H) where
   comm_comp_comul := by
     ext phi
-    apply (evalTensorEquiv k H).injective
+    apply (dualDistribEquiv k H).injective
     apply LinearMap.ext
     intro xy
     induction xy using TensorProduct.induction_on with
@@ -384,8 +384,8 @@ noncomputable instance instIsCocomm : Coalgebra.IsCocomm k (ConvolutionDual k H)
     | tmul x y =>
         simp only [LinearMap.comp_apply]
         rw [LinearEquiv.coe_toLinearMap]
-        rw [evalTensorEquiv_comm_apply, evalTensorEquiv_comul_apply,
-          evalTensorEquiv_comul_apply]
+        rw [dualDistribEquiv_comm_apply, dualDistribEquiv_comul_apply,
+          dualDistribEquiv_comul_apply]
         simp only [mul_comm]
 
 end ConvolutionDual
@@ -419,7 +419,7 @@ private theorem antipodeAux_apply (phi : ConvolutionDual k H) (x : H) :
 private theorem ofConv_mul_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
     (LinearMap.mul' k (ConvolutionDual k H) w).ofConv x =
-      evalTensorEquiv k H w (Coalgebra.comul x) := by
+      dualDistribEquiv k H w (Coalgebra.comul x) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
   | add w₁ w₂ hw₁ hw₂ =>
@@ -434,13 +434,13 @@ private theorem ofConv_mul_apply
       | add z₁ z₂ hz₁ hz₂ =>
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
       | tmul y z =>
-          rw [TensorProduct.map_tmul, LinearMap.mul'_apply, evalTensorEquiv_tmul_apply]
+          rw [TensorProduct.map_tmul, LinearMap.mul'_apply, dualDistribEquiv_tmul_apply]
 
-private theorem evalTensorEquiv_map_antipode_left
+private theorem dualDistribEquiv_map_antipode_left
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
-    evalTensorEquiv k H
+    dualDistribEquiv k H
         (TensorProduct.map (antipodeAux k H) LinearMap.id w) z =
-      evalTensorEquiv k H w
+      dualDistribEquiv k H w
         (TensorProduct.map (HopfAlgebra.antipode k (A := H)) LinearMap.id z) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
@@ -452,15 +452,15 @@ private theorem evalTensorEquiv_map_antipode_left
       | add z₁ z₂ hz₁ hz₂ =>
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
       | tmul x y =>
-          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, evalTensorEquiv_tmul_apply,
-            evalTensorEquiv_tmul_apply, antipodeAux_apply]
+          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, dualDistribEquiv_tmul_apply,
+            dualDistribEquiv_tmul_apply, antipodeAux_apply]
           rfl
 
-private theorem evalTensorEquiv_map_antipode_right
+private theorem dualDistribEquiv_map_antipode_right
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
-    evalTensorEquiv k H
+    dualDistribEquiv k H
         (TensorProduct.map LinearMap.id (antipodeAux k H) w) z =
-      evalTensorEquiv k H w
+      dualDistribEquiv k H w
         (TensorProduct.map LinearMap.id (HopfAlgebra.antipode k (A := H)) z) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
@@ -472,8 +472,8 @@ private theorem evalTensorEquiv_map_antipode_right
       | add z₁ z₂ hz₁ hz₂ =>
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
       | tmul x y =>
-          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, evalTensorEquiv_tmul_apply,
-            evalTensorEquiv_tmul_apply, antipodeAux_apply]
+          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, dualDistribEquiv_tmul_apply,
+            dualDistribEquiv_tmul_apply, antipodeAux_apply]
           rfl
 
 /-- The Hopf algebra structure on the finite dual. Its antipode is precomposition with the
@@ -487,8 +487,8 @@ noncomputable instance instHopfAlgebra : HopfAlgebra k (ConvolutionDual k H) :=
       rw [← antipodeAux_def]
       apply WithConv.ofConv_injective
       ext phi x
-      rw [LinearMap.convMul_apply, ofConv_mul_apply, evalTensorEquiv_map_antipode_left]
-      rw [evalTensorEquiv_comul]
+      rw [LinearMap.convMul_apply, ofConv_mul_apply, dualDistribEquiv_map_antipode_left]
+      rw [dualDistribEquiv_comul]
       simp only [LinearMap.comp_apply]
       rw [← LinearMap.rTensor_def, HopfAlgebra.mul_antipode_rTensor_comul_apply]
       rw [LinearMap.convOne_apply, counit_apply, LinearMap.convAlgebraMap_apply,
@@ -499,8 +499,8 @@ noncomputable instance instHopfAlgebra : HopfAlgebra k (ConvolutionDual k H) :=
       rw [← antipodeAux_def]
       apply WithConv.ofConv_injective
       ext phi x
-      rw [LinearMap.convMul_apply, ofConv_mul_apply, evalTensorEquiv_map_antipode_right]
-      rw [evalTensorEquiv_comul]
+      rw [LinearMap.convMul_apply, ofConv_mul_apply, dualDistribEquiv_map_antipode_right]
+      rw [dualDistribEquiv_comul]
       simp only [LinearMap.comp_apply]
       rw [← LinearMap.lTensor_def, HopfAlgebra.mul_antipode_lTensor_comul_apply]
       rw [LinearMap.convOne_apply, counit_apply, LinearMap.convAlgebraMap_apply,

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
@@ -173,31 +173,6 @@ private theorem evalTriple_comul_lTensor
       rw [LinearMap.lTensor_tmul, evalTripleEquiv_tmul_apply,
         evalTensor_comul_apply, evalTensor_tmul_apply]
 
-/-- The transposed multiplication is coassociative. -/
-theorem comul_coassoc :
-    TensorProduct.assoc k (FiniteDual k H) (FiniteDual k H) (FiniteDual k H) ∘ₗ
-        (comul k H).rTensor (FiniteDual k H) ∘ₗ comul k H =
-      (comul k H).lTensor (FiniteDual k H) ∘ₗ comul k H := by
-  ext phi
-  apply (evalTripleEquiv k H).injective
-  apply LinearMap.ext
-  intro xyz
-  induction xyz using TensorProduct.induction_on with
-  | zero => simp
-  | add xyz₁ xyz₂ hxyz₁ hxyz₂ =>
-      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxyz₁ hxyz₂
-  | tmul x yz =>
-      induction yz using TensorProduct.induction_on with
-      | zero => simp
-      | add yz₁ yz₂ hyz₁ hyz₂ =>
-          simpa only [TensorProduct.tmul_add, map_add, LinearMap.add_apply]
-            using congrArg₂ (· + ·) hyz₁ hyz₂
-      | tmul y z =>
-          simp only [LinearMap.comp_apply]
-          rw [evalTriple_assoc_comul_rTensor, evalTriple_comul_lTensor,
-            evalTensor_comul_apply, evalTensor_comul_apply]
-          simp only [mul_assoc]
-
 private theorem lid_counit_rTensor_apply
     (w : FiniteDual k H ⊗[k] FiniteDual k H) (x : H) :
     ((TensorProduct.lid k (FiniteDual k H)) ((counit k H).rTensor _ w)).ofConv x =
@@ -226,37 +201,46 @@ private theorem rid_counit_lTensor_apply
         WithConv.ofConv_smul, LinearMap.smul_apply, counit_apply]
       simp only [smul_eq_mul, mul_comm]
 
-/-- Evaluation at one is a left counit for the transposed multiplication. -/
-theorem rTensor_counit_comp_comul :
-    (counit k H).rTensor (FiniteDual k H) ∘ₗ comul k H =
-      TensorProduct.mk k k (FiniteDual k H) 1 := by
-  ext phi
-  apply (TensorProduct.lid k (FiniteDual k H)).injective
-  apply WithConv.ofConv_injective
-  ext x
-  rw [LinearMap.comp_apply, lid_counit_rTensor_apply, evalTensor_comul_apply]
-  simp only [one_mul, TensorProduct.lid_tmul, TensorProduct.mk_apply, one_smul]
-
-/-- Evaluation at one is a right counit for the transposed multiplication. -/
-theorem lTensor_counit_comp_comul :
-    (counit k H).lTensor (FiniteDual k H) ∘ₗ comul k H =
-      (TensorProduct.mk k (FiniteDual k H) k).flip 1 := by
-  ext phi
-  apply (TensorProduct.rid k (FiniteDual k H)).injective
-  apply WithConv.ofConv_injective
-  ext x
-  rw [LinearMap.comp_apply, rid_counit_lTensor_apply, evalTensor_comul_apply]
-  simp only [mul_one, TensorProduct.rid_tmul, LinearMap.flip_apply,
-    TensorProduct.mk_apply, one_smul]
-
 /-- The coalgebra structure on the finite dual, obtained by transposing multiplication and unit
 on the original bialgebra. -/
 noncomputable instance instCoalgebra : Coalgebra k (FiniteDual k H) where
   comul := comul k H
   counit := counit k H
-  coassoc := comul_coassoc k H
-  rTensor_counit_comp_comul := rTensor_counit_comp_comul k H
-  lTensor_counit_comp_comul := lTensor_counit_comp_comul k H
+  coassoc := by
+    ext phi
+    apply (evalTripleEquiv k H).injective
+    apply LinearMap.ext
+    intro xyz
+    induction xyz using TensorProduct.induction_on with
+    | zero => simp
+    | add xyz₁ xyz₂ hxyz₁ hxyz₂ =>
+        simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxyz₁ hxyz₂
+    | tmul x yz =>
+        induction yz using TensorProduct.induction_on with
+        | zero => simp
+        | add yz₁ yz₂ hyz₁ hyz₂ =>
+            simpa only [TensorProduct.tmul_add, map_add, LinearMap.add_apply]
+              using congrArg₂ (· + ·) hyz₁ hyz₂
+        | tmul y z =>
+            simp only [LinearMap.comp_apply]
+            rw [evalTriple_assoc_comul_rTensor, evalTriple_comul_lTensor,
+              evalTensor_comul_apply, evalTensor_comul_apply]
+            simp only [mul_assoc]
+  rTensor_counit_comp_comul := by
+    ext phi
+    apply (TensorProduct.lid k (FiniteDual k H)).injective
+    apply WithConv.ofConv_injective
+    ext x
+    rw [LinearMap.comp_apply, lid_counit_rTensor_apply, evalTensor_comul_apply]
+    simp only [one_mul, TensorProduct.lid_tmul, TensorProduct.mk_apply, one_smul]
+  lTensor_counit_comp_comul := by
+    ext phi
+    apply (TensorProduct.rid k (FiniteDual k H)).injective
+    apply WithConv.ofConv_injective
+    ext x
+    rw [LinearMap.comp_apply, rid_counit_lTensor_apply, evalTensor_comul_apply]
+    simp only [mul_one, TensorProduct.rid_tmul, LinearMap.flip_apply,
+      TensorProduct.mk_apply, one_smul]
 
 /-- `evalTensorEquiv` packaged in the convolution algebra on functionals on the tensor square. -/
 private noncomputable def evalTensorConv :
@@ -295,52 +279,41 @@ private theorem mulCoalgHom_toLinearMap :
     (Bialgebra.mulCoalgHom k H).toLinearMap = LinearMap.mul' k H :=
   rfl
 
-omit [FiniteDimensional k H] in
-/-- The finite-dual counit preserves one. -/
-theorem counit_one : counit k H (1 : FiniteDual k H) = 1 := by
-  rw [counit_apply]
-  rw [LinearMap.convOne_apply, Bialgebra.counit_one, map_one]
-
-omit [FiniteDimensional k H] in
-/-- The finite-dual counit preserves multiplication. -/
-theorem counit_mul (phi psi : FiniteDual k H) :
-    counit k H (phi * psi) = counit k H phi * counit k H psi := by
-  rw [counit_apply, counit_apply, counit_apply, LinearMap.convMul_apply,
-    Bialgebra.comul_one, Algebra.TensorProduct.one_def, TensorProduct.map_tmul,
-    LinearMap.mul'_apply]
-
-/-- The finite-dual comultiplication preserves one. -/
-@[simp]
-theorem comul_one : comul k H (1 : FiniteDual k H) = 1 := by
-  apply (evalTensorEquiv k H).injective
-  apply LinearMap.ext
-  intro xy
-  induction xy using TensorProduct.induction_on with
-  | zero => simp
-  | add xy₁ xy₂ hxy₁ hxy₂ =>
-      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxy₁ hxy₂
-  | tmul x y =>
-      rw [evalTensor_comul_apply]
-      simp only [LinearMap.convOne_apply, Bialgebra.counit_mul, map_mul]
-      rw [Algebra.TensorProduct.one_def, evalTensor_tmul_apply]
-      simp only [LinearMap.convOne_apply]
-
-/-- The finite-dual comultiplication preserves multiplication. -/
-@[simp]
-theorem comul_mul (phi psi : FiniteDual k H) :
-    comul k H (phi * psi) = comul k H phi * comul k H psi := by
-  apply (evalTensorEquiv k H).injective
-  rw [← evalTensorConv_ofConv, ← evalTensorConv_ofConv, evalTensorConv_mul,
-    evalTensorConv_comul, evalTensorConv_comul, evalTensorConv_comul]
-  have h := LinearMap.convMul_comp_coalgHom_distrib phi psi (Bialgebra.mulCoalgHom k H)
-  rw [mulCoalgHom_toLinearMap] at h
-  simpa only [WithConv.toConv_ofConv] using h
-
 /-- The bialgebra structure on the finite dual. Multiplication is convolution and the coalgebra
 operations are transposes of multiplication and unit on the original bialgebra. -/
 noncomputable instance instBialgebra : Bialgebra k (FiniteDual k H) :=
-  Bialgebra.mk' k (FiniteDual k H) (counit_one k H) (fun {_ _} ↦ counit_mul k H _ _)
-    (comul_one k H) (fun {_ _} ↦ comul_mul k H _ _)
+  Bialgebra.mk' k (FiniteDual k H)
+    (by
+      change counit k H (1 : FiniteDual k H) = 1
+      rw [counit_apply]
+      rw [LinearMap.convOne_apply, Bialgebra.counit_one, map_one])
+    (fun {phi psi} ↦ by
+      change counit k H (phi * psi) = counit k H phi * counit k H psi
+      rw [counit_apply, counit_apply, counit_apply, LinearMap.convMul_apply,
+        Bialgebra.comul_one, Algebra.TensorProduct.one_def, TensorProduct.map_tmul,
+        LinearMap.mul'_apply])
+    (by
+      change comul k H (1 : FiniteDual k H) = 1
+      apply (evalTensorEquiv k H).injective
+      apply LinearMap.ext
+      intro xy
+      induction xy using TensorProduct.induction_on with
+      | zero => simp
+      | add xy₁ xy₂ hxy₁ hxy₂ =>
+          simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxy₁ hxy₂
+      | tmul x y =>
+          rw [evalTensor_comul_apply]
+          simp only [LinearMap.convOne_apply, Bialgebra.counit_mul, map_mul]
+          rw [Algebra.TensorProduct.one_def, evalTensor_tmul_apply]
+          simp only [LinearMap.convOne_apply])
+    (fun {phi psi} ↦ by
+      change comul k H (phi * psi) = comul k H phi * comul k H psi
+      apply (evalTensorEquiv k H).injective
+      rw [← evalTensorConv_ofConv, ← evalTensorConv_ofConv, evalTensorConv_mul,
+        evalTensorConv_comul, evalTensorConv_comul, evalTensorConv_comul]
+      have h := LinearMap.convMul_comp_coalgHom_distrib phi psi (Bialgebra.mulCoalgHom k H)
+      rw [mulCoalgHom_toLinearMap] at h
+      simpa only [WithConv.toConv_ofConv] using h)
 
 end FiniteDual
 
@@ -360,27 +333,24 @@ private theorem evalTensor_comm_apply
   | tmul phi psi =>
       rw [TensorProduct.comm_tmul, evalTensor_tmul_apply, evalTensor_tmul_apply, mul_comm]
 
-/-- The finite-dual comultiplication is cocommutative when multiplication on `H` is commutative. -/
-theorem comm_comp_comul :
-    (TensorProduct.comm k (FiniteDual k H) (FiniteDual k H)).toLinearMap ∘ₗ comul k H =
-      comul k H := by
-  ext phi
-  apply (evalTensorEquiv k H).injective
-  apply LinearMap.ext
-  intro xy
-  induction xy using TensorProduct.induction_on with
-  | zero => simp
-  | add xy₁ xy₂ hxy₁ hxy₂ =>
-      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxy₁ hxy₂
-  | tmul x y =>
-      simp only [LinearMap.comp_apply]
-      rw [LinearEquiv.coe_toLinearMap]
-      rw [evalTensor_comm_apply, evalTensor_comul_apply, evalTensor_comul_apply]
-      simp only [mul_comm]
-
 /-- The coalgebra underlying the finite dual is cocommutative. -/
 noncomputable instance instIsCocomm : Coalgebra.IsCocomm k (FiniteDual k H) where
-  comm_comp_comul := comm_comp_comul k H
+  comm_comp_comul := by
+    change (TensorProduct.comm k (FiniteDual k H) (FiniteDual k H)).toLinearMap ∘ₗ
+      comul k H = comul k H
+    ext phi
+    apply (evalTensorEquiv k H).injective
+    apply LinearMap.ext
+    intro xy
+    induction xy using TensorProduct.induction_on with
+    | zero => simp
+    | add xy₁ xy₂ hxy₁ hxy₂ =>
+        simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hxy₁ hxy₂
+    | tmul x y =>
+        simp only [LinearMap.comp_apply]
+        rw [LinearEquiv.coe_toLinearMap]
+        rw [evalTensor_comm_apply, evalTensor_comul_apply, evalTensor_comul_apply]
+        simp only [mul_comm]
 
 end FiniteDual
 
@@ -473,46 +443,36 @@ private theorem evalTensor_map_antipode_right
             evalTensor_tmul_apply, antipode_apply]
           rfl
 
-/-- Precomposition by the original antipode is a left convolution inverse to the identity on the
-finite dual. -/
-theorem antipode_mul_id :
-    WithConv.toConv (antipode k H) *
-        WithConv.toConv (LinearMap.id : FiniteDual k H →ₗ[k] FiniteDual k H) = 1 := by
-  apply WithConv.ofConv_injective
-  ext phi x
-  rw [LinearMap.convMul_apply, mul_apply_eq_evalTensorEquiv,
-    evalTensor_map_antipode_left]
-  rw [coalgebra_comul_eq_comul, evalTensor_comul]
-  simp only [LinearMap.comp_apply]
-  rw [← LinearMap.rTensor_def, HopfAlgebra.mul_antipode_rTensor_comul_apply]
-  rw [LinearMap.convOne_apply, coalgebra_counit_eq_counit, counit_apply,
-    LinearMap.convAlgebraMap_apply,
-    Algebra.algebraMap_eq_smul_one, map_smul]
-  simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
-  rw [mul_comm]
-
-/-- Precomposition by the original antipode is a right convolution inverse to the identity on the
-finite dual. -/
-theorem id_mul_antipode :
-    WithConv.toConv (LinearMap.id : FiniteDual k H →ₗ[k] FiniteDual k H) *
-        WithConv.toConv (antipode k H) = 1 := by
-  apply WithConv.ofConv_injective
-  ext phi x
-  rw [LinearMap.convMul_apply, mul_apply_eq_evalTensorEquiv,
-    evalTensor_map_antipode_right]
-  rw [coalgebra_comul_eq_comul, evalTensor_comul]
-  simp only [LinearMap.comp_apply]
-  rw [← LinearMap.lTensor_def, HopfAlgebra.mul_antipode_lTensor_comul_apply]
-  rw [LinearMap.convOne_apply, coalgebra_counit_eq_counit, counit_apply,
-    LinearMap.convAlgebraMap_apply,
-    Algebra.algebraMap_eq_smul_one, map_smul]
-  simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
-  rw [mul_comm]
-
 /-- The Hopf algebra structure on the finite dual. Its antipode is precomposition with the
 antipode of the original finite-dimensional Hopf algebra. -/
 noncomputable instance instHopfAlgebra : HopfAlgebra k (FiniteDual k H) :=
-  HopfAlgebra.ofConvInverse (antipode k H) (antipode_mul_id k H) (id_mul_antipode k H)
+  HopfAlgebra.ofConvInverse (antipode k H)
+    (by
+      apply WithConv.ofConv_injective
+      ext phi x
+      rw [LinearMap.convMul_apply, mul_apply_eq_evalTensorEquiv,
+        evalTensor_map_antipode_left]
+      rw [coalgebra_comul_eq_comul, evalTensor_comul]
+      simp only [LinearMap.comp_apply]
+      rw [← LinearMap.rTensor_def, HopfAlgebra.mul_antipode_rTensor_comul_apply]
+      rw [LinearMap.convOne_apply, coalgebra_counit_eq_counit, counit_apply,
+        LinearMap.convAlgebraMap_apply,
+        Algebra.algebraMap_eq_smul_one, map_smul]
+      simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
+      rw [mul_comm])
+    (by
+      apply WithConv.ofConv_injective
+      ext phi x
+      rw [LinearMap.convMul_apply, mul_apply_eq_evalTensorEquiv,
+        evalTensor_map_antipode_right]
+      rw [coalgebra_comul_eq_comul, evalTensor_comul]
+      simp only [LinearMap.comp_apply]
+      rw [← LinearMap.lTensor_def, HopfAlgebra.mul_antipode_lTensor_comul_apply]
+      rw [LinearMap.convOne_apply, coalgebra_counit_eq_counit, counit_apply,
+        LinearMap.convAlgebraMap_apply,
+        Algebra.algebraMap_eq_smul_one, map_smul]
+      simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
+      rw [mul_comm])
 
 end HopfAlgebra
 

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
@@ -70,6 +70,12 @@ noncomputable def evalTensorEquiv :
     ConvolutionDual k H ⊗[k] ConvolutionDual k H ≃ₗ[k] Module.Dual k (H ⊗[k] H) :=
   (tensorUnwrap k H).trans (TensorProduct.dualDistribEquiv k H H)
 
+private theorem evalTensorEquiv_apply
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
+    evalTensorEquiv k H w z =
+      TensorProduct.dualDistrib k H H ((tensorUnwrap k H) w) z :=
+  rfl
+
 /-- The private construction used for the finite-dimensional dual comultiplication. -/
 private noncomputable def comulAux :
     ConvolutionDual k H →ₗ[k] ConvolutionDual k H ⊗[k] ConvolutionDual k H :=
@@ -338,7 +344,9 @@ noncomputable instance instBialgebra : Bialgebra k (ConvolutionDual k H) :=
       rw [← evalTensorConv_ofConv, ← evalTensorConv_ofConv, evalTensorConv_mul,
         evalTensorConv_comul, evalTensorConv_comul, evalTensorConv_comul]
       have h := LinearMap.convMul_comp_coalgHom_distrib phi psi (Bialgebra.mulCoalgHom k H)
-      rw [show (Bialgebra.mulCoalgHom k H).toLinearMap = LinearMap.mul' k H from rfl] at h
+      have hmul : (Bialgebra.mulCoalgHom k H).toLinearMap = LinearMap.mul' k H :=
+        Bialgebra.toLinearMap_mulCoalgHom
+      rw [hmul] at h
       simpa only [WithConv.toConv_ofConv] using h)
 
 end ConvolutionDual
@@ -359,10 +367,7 @@ private theorem evalTensorEquiv_comm_apply
     | zero => simp
     | add w₁ w₂ hw₁ hw₂ => simpa only [map_add] using congrArg₂ (· + ·) hw₁ hw₂
     | tmul phi psi => simp [tensorUnwrap]
-  change TensorProduct.dualDistrib k H H
-      ((tensorUnwrap k H) (TensorProduct.comm k _ _ w)) (x ⊗ₜ[k] y) =
-    TensorProduct.dualDistrib k H H ((tensorUnwrap k H) w) (y ⊗ₜ[k] x)
-  rw [hcomm]
+  rw [evalTensorEquiv_apply, evalTensorEquiv_apply, hcomm]
   exact (TensorProduct.dualDistrib_apply_comm ((tensorUnwrap k H) w) (x ⊗ₜ[k] y)).symm
 
 /-- The coalgebra underlying the finite dual is cocommutative. -/

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual.lean
@@ -27,10 +27,11 @@ to finite locally free Hopf algebras over a general base remain separate steps.
 
 ## Main declarations
 
-* `TauCeti.FiniteDual`: the convolution algebra on the linear dual.
-* `TauCeti.FiniteDual.instBialgebra`: the bialgebra obtained by transposing multiplication and
+* `TauCeti.ConvolutionDual`: the convolution algebra on the linear dual.
+* `TauCeti.ConvolutionDual.instBialgebra`: the bialgebra obtained by transposing multiplication and
   unit.
-* `TauCeti.FiniteDual.instHopfAlgebra`: the Hopf structure obtained by transposing the antipode.
+* `TauCeti.ConvolutionDual.instHopfAlgebra`: the Hopf structure obtained by transposing the
+  antipode.
 
 ## References
 
@@ -46,85 +47,93 @@ namespace TauCeti
 
 universe u v
 
-/-- The finite dual of a coalgebra, carrying the convolution algebra structure.
+/-- The linear dual, wrapped to select convolution multiplication when a coalgebra structure is
+available.
 
 The `WithConv` wrapper selects Mathlib's convolution multiplication on linear maps. -/
-abbrev FiniteDual (k : Type u) (H : Type v) [Field k] [AddCommMonoid H] [Module k H] :=
+abbrev ConvolutionDual (k : Type u) (H : Type v) [Field k] [AddCommMonoid H] [Module k H] :=
   WithConv (Module.Dual k H)
 
-namespace FiniteDual
+namespace ConvolutionDual
 
 variable (k : Type u) (H : Type v) [Field k] [Ring H] [Bialgebra k H]
   [FiniteDimensional k H]
 
 /-- Forget the convolution wrappers on both factors of a tensor of finite-dual elements. -/
 private noncomputable def tensorUnwrap :
-    FiniteDual k H ⊗[k] FiniteDual k H ≃ₗ[k]
+    ConvolutionDual k H ⊗[k] ConvolutionDual k H ≃ₗ[k]
       Module.Dual k H ⊗[k] Module.Dual k H :=
   TensorProduct.congr (WithConv.linearEquiv k _) (WithConv.linearEquiv k _)
 
 /-- A tensor of finite-dual functionals is equivalently a functional on the tensor square. -/
 noncomputable def evalTensorEquiv :
-    FiniteDual k H ⊗[k] FiniteDual k H ≃ₗ[k] Module.Dual k (H ⊗[k] H) :=
+    ConvolutionDual k H ⊗[k] ConvolutionDual k H ≃ₗ[k] Module.Dual k (H ⊗[k] H) :=
   (tensorUnwrap k H).trans (TensorProduct.dualDistribEquiv k H H)
 
-/-- The comultiplication on the finite dual, obtained by transposing multiplication on `H`. -/
-noncomputable def comul : FiniteDual k H →ₗ[k] FiniteDual k H ⊗[k] FiniteDual k H :=
+/-- The private construction used for the finite-dimensional dual comultiplication. -/
+private noncomputable def comulAux :
+    ConvolutionDual k H →ₗ[k] ConvolutionDual k H ⊗[k] ConvolutionDual k H :=
   (evalTensorEquiv k H).symm.toLinearMap ∘ₗ
-      LinearMap.lcomp k k (LinearMap.mul' k H) ∘ₗ
+      (LinearMap.mul' k H).dualMap ∘ₗ
         (WithConv.linearEquiv k _).toLinearMap
 
-/-- The counit on the finite dual is evaluation at the unit of `H`. -/
-def counit : FiniteDual k H →ₗ[k] k :=
+private theorem comulAux_eq :
+    comulAux k H = (evalTensorEquiv k H).symm.toLinearMap ∘ₗ
+      (LinearMap.mul' k H).dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap :=
+  rfl
+
+/-- The private construction used for the finite-dimensional dual counit. -/
+private def counitAux : ConvolutionDual k H →ₗ[k] k :=
   LinearMap.applyₗ (1 : H) ∘ₗ (WithConv.linearEquiv k _).toLinearMap
 
-/-- Evaluating the transposed comultiplication on `x tensor y` gives `phi (x * y)`. -/
-@[simp]
-theorem evalTensor_comul (phi : FiniteDual k H) :
-    evalTensorEquiv k H (comul k H phi) =
+omit [FiniteDimensional k H] in
+private theorem counitAux_eq :
+    counitAux k H = LinearMap.applyₗ (1 : H) ∘ₗ
+      (WithConv.linearEquiv k _).toLinearMap :=
+  rfl
+
+private theorem evalTensor_comulAux (phi : ConvolutionDual k H) :
+    evalTensorEquiv k H (comulAux k H phi) =
       phi.ofConv.comp (LinearMap.mul' k H) := by
-  simp only [comul, LinearMap.comp_apply]
+  simp only [comulAux, LinearMap.comp_apply]
   simp only [LinearEquiv.coe_toLinearMap]
   let psi : Module.Dual k (H ⊗[k] H) :=
     phi.ofConv.comp (LinearMap.mul' k H)
-  simpa only [psi, LinearMap.lcomp_apply', WithConv.linearEquiv_apply]
+  simpa only [psi, LinearMap.dualMap_apply', WithConv.linearEquiv_apply]
     using (evalTensorEquiv k H).apply_symm_apply psi
 
 /-- A pure tensor of finite-dual functionals evaluates componentwise. -/
 @[simp]
-theorem evalTensor_tmul_apply (phi psi : FiniteDual k H) (x y : H) :
+theorem evalTensor_tmul_apply (phi psi : ConvolutionDual k H) (x y : H) :
     evalTensorEquiv k H (phi ⊗ₜ[k] psi) (x ⊗ₜ[k] y) =
       phi.ofConv x * psi.ofConv y := by
   simp [evalTensorEquiv, tensorUnwrap]
 
-/-- Pointwise form of the characteristic equation for the finite-dual comultiplication. -/
-theorem evalTensor_comul_apply (phi : FiniteDual k H) (x y : H) :
-    evalTensorEquiv k H (comul k H phi) (x ⊗ₜ[k] y) =
+private theorem evalTensor_comulAux_apply (phi : ConvolutionDual k H) (x y : H) :
+    evalTensorEquiv k H (comulAux k H phi) (x ⊗ₜ[k] y) =
       phi.ofConv (x * y) := by
-  rw [evalTensor_comul]
+  rw [evalTensor_comulAux]
   simp only [LinearMap.comp_apply, LinearMap.mul'_apply]
 
 omit [FiniteDimensional k H] in
-/-- The finite-dual counit is evaluation at one. -/
-@[simp]
-theorem counit_apply (phi : FiniteDual k H) : counit k H phi = phi.ofConv 1 :=
-  by simp [counit]
+private theorem counitAux_apply (phi : ConvolutionDual k H) : counitAux k H phi = phi.ofConv 1 :=
+  by simp [counitAux]
 
 /-- Evaluate three finite-dual functionals on a right-associated triple tensor. -/
 private noncomputable def evalTripleEquiv :
-    FiniteDual k H ⊗[k] (FiniteDual k H ⊗[k] FiniteDual k H) ≃ₗ[k]
+    ConvolutionDual k H ⊗[k] (ConvolutionDual k H ⊗[k] ConvolutionDual k H) ≃ₗ[k]
       Module.Dual k (H ⊗[k] (H ⊗[k] H)) :=
   (TensorProduct.congr (WithConv.linearEquiv k _) (evalTensorEquiv k H)).trans
     (TensorProduct.dualDistribEquiv k H (H ⊗[k] H))
 
 private theorem evalTripleEquiv_tmul_tmul_apply
-    (phi psi chi : FiniteDual k H) (x y z : H) :
+    (phi psi chi : ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H (phi ⊗ₜ[k] (psi ⊗ₜ[k] chi)) (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
       phi.ofConv x * (psi.ofConv y * chi.ofConv z) := by
   simp [evalTripleEquiv, evalTensorEquiv, tensorUnwrap]
 
 private theorem evalTripleEquiv_tmul_apply
-    (phi : FiniteDual k H) (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y z : H) :
+    (phi : ConvolutionDual k H) (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H (phi ⊗ₜ[k] w) (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
       phi.ofConv x * evalTensorEquiv k H w (y ⊗ₜ[k] z) := by
   induction w using TensorProduct.induction_on with
@@ -135,7 +144,7 @@ private theorem evalTripleEquiv_tmul_apply
   | tmul psi chi => rw [evalTripleEquiv_tmul_tmul_apply, evalTensor_tmul_apply]
 
 private theorem evalTripleEquiv_assoc_tmul_apply
-    (w : FiniteDual k H ⊗[k] FiniteDual k H) (chi : FiniteDual k H) (x y z : H) :
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (chi : ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H ((TensorProduct.assoc k _ _ _).toLinearMap (w ⊗ₜ[k] chi))
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
       evalTensorEquiv k H w (x ⊗ₜ[k] y) * chi.ofConv z := by
@@ -149,33 +158,35 @@ private theorem evalTripleEquiv_assoc_tmul_apply
         evalTripleEquiv_tmul_tmul_apply, evalTensor_tmul_apply, mul_assoc]
 
 private theorem evalTriple_assoc_comul_rTensor
-    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y z : H) :
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H
-        ((TensorProduct.assoc k _ _ _).toLinearMap ((comul k H).rTensor _ w))
+        ((TensorProduct.assoc k _ _ _).toLinearMap ((comulAux k H).rTensor _ w))
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
       evalTensorEquiv k H w ((x * y) ⊗ₜ[k] z) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
-  | add w₁ w₂ hw₁ hw₂ => simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.rTensor_tmul, evalTripleEquiv_assoc_tmul_apply,
-        evalTensor_comul_apply, evalTensor_tmul_apply]
+        evalTensor_comulAux_apply, evalTensor_tmul_apply]
 
 private theorem evalTriple_comul_lTensor
-    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y z : H) :
-    evalTripleEquiv k H ((comul k H).lTensor _ w)
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y z : H) :
+    evalTripleEquiv k H ((comulAux k H).lTensor _ w)
         (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
       evalTensorEquiv k H w (x ⊗ₜ[k] (y * z)) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
-  | add w₁ w₂ hw₁ hw₂ => simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.lTensor_tmul, evalTripleEquiv_tmul_apply,
-        evalTensor_comul_apply, evalTensor_tmul_apply]
+        evalTensor_comulAux_apply, evalTensor_tmul_apply]
 
 private theorem lid_counit_rTensor_apply
-    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x : H) :
-    ((TensorProduct.lid k (FiniteDual k H)) ((counit k H).rTensor _ w)).ofConv x =
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
+    ((TensorProduct.lid k (ConvolutionDual k H)) ((counitAux k H).rTensor _ w)).ofConv x =
       evalTensorEquiv k H w ((1 : H) ⊗ₜ[k] x) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
@@ -184,12 +195,12 @@ private theorem lid_counit_rTensor_apply
         using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.rTensor_tmul, TensorProduct.lid_tmul, evalTensor_tmul_apply,
-        WithConv.ofConv_smul, LinearMap.smul_apply, counit_apply]
+        WithConv.ofConv_smul, LinearMap.smul_apply, counitAux_apply]
       simp only [smul_eq_mul]
 
 private theorem rid_counit_lTensor_apply
-    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x : H) :
-    ((TensorProduct.rid k (FiniteDual k H)) ((counit k H).lTensor _ w)).ofConv x =
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
+    ((TensorProduct.rid k (ConvolutionDual k H)) ((counitAux k H).lTensor _ w)).ofConv x =
       evalTensorEquiv k H w (x ⊗ₜ[k] (1 : H)) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
@@ -198,15 +209,17 @@ private theorem rid_counit_lTensor_apply
         using congrArg₂ (· + ·) hw₁ hw₂
   | tmul phi psi =>
       rw [LinearMap.lTensor_tmul, TensorProduct.rid_tmul, evalTensor_tmul_apply,
-        WithConv.ofConv_smul, LinearMap.smul_apply, counit_apply]
+        WithConv.ofConv_smul, LinearMap.smul_apply, counitAux_apply]
       simp only [smul_eq_mul, mul_comm]
 
 /-- The coalgebra structure on the finite dual, obtained by transposing multiplication and unit
 on the original bialgebra. -/
-noncomputable instance instCoalgebra : Coalgebra k (FiniteDual k H) where
-  comul := comul k H
-  counit := counit k H
+noncomputable instance instCoalgebra : Coalgebra k (ConvolutionDual k H) where
+  comul := (evalTensorEquiv k H).symm.toLinearMap ∘ₗ
+    (LinearMap.mul' k H).dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap
+  counit := LinearMap.applyₗ (1 : H) ∘ₗ (WithConv.linearEquiv k _).toLinearMap
   coassoc := by
+    rw [← comulAux_eq]
     ext phi
     apply (evalTripleEquiv k H).injective
     apply LinearMap.ext
@@ -224,31 +237,52 @@ noncomputable instance instCoalgebra : Coalgebra k (FiniteDual k H) where
         | tmul y z =>
             simp only [LinearMap.comp_apply]
             rw [evalTriple_assoc_comul_rTensor, evalTriple_comul_lTensor,
-              evalTensor_comul_apply, evalTensor_comul_apply]
+              evalTensor_comulAux_apply, evalTensor_comulAux_apply]
             simp only [mul_assoc]
   rTensor_counit_comp_comul := by
+    rw [← counitAux_eq, ← comulAux_eq]
     ext phi
-    apply (TensorProduct.lid k (FiniteDual k H)).injective
+    apply (TensorProduct.lid k (ConvolutionDual k H)).injective
     apply WithConv.ofConv_injective
     ext x
-    rw [LinearMap.comp_apply, lid_counit_rTensor_apply, evalTensor_comul_apply]
+    rw [LinearMap.comp_apply, lid_counit_rTensor_apply, evalTensor_comulAux_apply]
     simp only [one_mul, TensorProduct.lid_tmul, TensorProduct.mk_apply, one_smul]
   lTensor_counit_comp_comul := by
+    rw [← counitAux_eq, ← comulAux_eq]
     ext phi
-    apply (TensorProduct.rid k (FiniteDual k H)).injective
+    apply (TensorProduct.rid k (ConvolutionDual k H)).injective
     apply WithConv.ofConv_injective
     ext x
-    rw [LinearMap.comp_apply, rid_counit_lTensor_apply, evalTensor_comul_apply]
+    rw [LinearMap.comp_apply, rid_counit_lTensor_apply, evalTensor_comulAux_apply]
     simp only [mul_one, TensorProduct.rid_tmul, LinearMap.flip_apply,
       TensorProduct.mk_apply, one_smul]
 
+/-- Evaluating the finite-dual comultiplication gives the transpose of multiplication on `H`. -/
+@[simp]
+theorem evalTensor_comul (phi : ConvolutionDual k H) :
+    evalTensorEquiv k H (Coalgebra.comul phi) =
+      phi.ofConv.comp (LinearMap.mul' k H) :=
+  evalTensor_comulAux k H phi
+
+/-- Pointwise form of the characteristic equation for the finite-dual comultiplication. -/
+theorem evalTensor_comul_apply (phi : ConvolutionDual k H) (x y : H) :
+    evalTensorEquiv k H (Coalgebra.comul phi) (x ⊗ₜ[k] y) =
+      phi.ofConv (x * y) :=
+  evalTensor_comulAux_apply k H phi x y
+
+/-- The finite-dual counit is evaluation at one. -/
+@[simp]
+theorem counit_apply (phi : ConvolutionDual k H) :
+    Coalgebra.counit (R := k) phi = phi.ofConv 1 :=
+  counitAux_apply k H phi
+
 /-- `evalTensorEquiv` packaged in the convolution algebra on functionals on the tensor square. -/
 private noncomputable def evalTensorConv :
-    FiniteDual k H ⊗[k] FiniteDual k H →ₗ[k]
+    ConvolutionDual k H ⊗[k] ConvolutionDual k H →ₗ[k]
       WithConv (Module.Dual k (H ⊗[k] H)) :=
   (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ (evalTensorEquiv k H).toLinearMap
 
-private theorem evalTensorConv_tmul (phi psi : FiniteDual k H) :
+private theorem evalTensorConv_tmul (phi psi : ConvolutionDual k H) :
     evalTensorConv k H (phi ⊗ₜ[k] psi) = LinearMap.mulTensor phi psi := by
   apply WithConv.ofConv_injective
   apply TensorProduct.ext'
@@ -256,21 +290,21 @@ private theorem evalTensorConv_tmul (phi psi : FiniteDual k H) :
   simp [evalTensorConv]
 
 private theorem evalTensorConv_mul
-    (w z : FiniteDual k H ⊗[k] FiniteDual k H) :
+    (w z : ConvolutionDual k H ⊗[k] ConvolutionDual k H) :
     evalTensorConv k H (w * z) = evalTensorConv k H w * evalTensorConv k H z := by
   apply LinearMap.map_mul_of_map_mul_tmul
   intro phi chi psi omega
   rw [evalTensorConv_tmul, evalTensorConv_tmul, evalTensorConv_tmul,
     LinearMap.mulTensor_convMul]
 
-private theorem evalTensorConv_comul (phi : FiniteDual k H) :
-    evalTensorConv k H (comul k H phi) =
+private theorem evalTensorConv_comul (phi : ConvolutionDual k H) :
+    evalTensorConv k H (Coalgebra.comul phi) =
       WithConv.toConv (phi.ofConv.comp (LinearMap.mul' k H)) := by
   apply WithConv.ofConv_injective
   exact evalTensor_comul k H phi
 
 @[simp]
-private theorem evalTensorConv_ofConv (w : FiniteDual k H ⊗[k] FiniteDual k H) :
+private theorem evalTensorConv_ofConv (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) :
     (evalTensorConv k H w).ofConv = evalTensorEquiv k H w :=
   rfl
 
@@ -281,19 +315,16 @@ private theorem mulCoalgHom_toLinearMap :
 
 /-- The bialgebra structure on the finite dual. Multiplication is convolution and the coalgebra
 operations are transposes of multiplication and unit on the original bialgebra. -/
-noncomputable instance instBialgebra : Bialgebra k (FiniteDual k H) :=
-  Bialgebra.mk' k (FiniteDual k H)
+noncomputable instance instBialgebra : Bialgebra k (ConvolutionDual k H) :=
+  Bialgebra.mk' k (ConvolutionDual k H)
     (by
-      change counit k H (1 : FiniteDual k H) = 1
       rw [counit_apply]
       rw [LinearMap.convOne_apply, Bialgebra.counit_one, map_one])
     (fun {phi psi} ↦ by
-      change counit k H (phi * psi) = counit k H phi * counit k H psi
       rw [counit_apply, counit_apply, counit_apply, LinearMap.convMul_apply,
         Bialgebra.comul_one, Algebra.TensorProduct.one_def, TensorProduct.map_tmul,
         LinearMap.mul'_apply])
     (by
-      change comul k H (1 : FiniteDual k H) = 1
       apply (evalTensorEquiv k H).injective
       apply LinearMap.ext
       intro xy
@@ -307,7 +338,6 @@ noncomputable instance instBialgebra : Bialgebra k (FiniteDual k H) :=
           rw [Algebra.TensorProduct.one_def, evalTensor_tmul_apply]
           simp only [LinearMap.convOne_apply])
     (fun {phi psi} ↦ by
-      change comul k H (phi * psi) = comul k H phi * comul k H psi
       apply (evalTensorEquiv k H).injective
       rw [← evalTensorConv_ofConv, ← evalTensorConv_ofConv, evalTensorConv_mul,
         evalTensorConv_comul, evalTensorConv_comul, evalTensorConv_comul]
@@ -315,15 +345,15 @@ noncomputable instance instBialgebra : Bialgebra k (FiniteDual k H) :=
       rw [mulCoalgHom_toLinearMap] at h
       simpa only [WithConv.toConv_ofConv] using h)
 
-end FiniteDual
+end ConvolutionDual
 
-namespace FiniteDual
+namespace ConvolutionDual
 
 variable (k : Type u) (H : Type v) [Field k] [CommRing H] [Bialgebra k H]
   [FiniteDimensional k H]
 
 private theorem evalTensor_comm_apply
-    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x y : H) :
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y : H) :
     evalTensorEquiv k H (TensorProduct.comm k _ _ w) (x ⊗ₜ[k] y) =
       evalTensorEquiv k H w (y ⊗ₜ[k] x) := by
   induction w using TensorProduct.induction_on with
@@ -334,10 +364,8 @@ private theorem evalTensor_comm_apply
       rw [TensorProduct.comm_tmul, evalTensor_tmul_apply, evalTensor_tmul_apply, mul_comm]
 
 /-- The coalgebra underlying the finite dual is cocommutative. -/
-noncomputable instance instIsCocomm : Coalgebra.IsCocomm k (FiniteDual k H) where
+noncomputable instance instIsCocomm : Coalgebra.IsCocomm k (ConvolutionDual k H) where
   comm_comp_comul := by
-    change (TensorProduct.comm k (FiniteDual k H) (FiniteDual k H)).toLinearMap ∘ₗ
-      comul k H = comul k H
     ext phi
     apply (evalTensorEquiv k H).injective
     apply LinearMap.ext
@@ -352,41 +380,37 @@ noncomputable instance instIsCocomm : Coalgebra.IsCocomm k (FiniteDual k H) wher
         rw [evalTensor_comm_apply, evalTensor_comul_apply, evalTensor_comul_apply]
         simp only [mul_comm]
 
-end FiniteDual
+end ConvolutionDual
 
-namespace FiniteDual
+namespace ConvolutionDual
 
 section HopfAlgebra
 
 variable (k : Type u) (H : Type v) [Field k] [Ring H] [HopfAlgebra k H]
   [FiniteDimensional k H]
 
-/-- The antipode on the finite dual is precomposition with the antipode of `H`. -/
-noncomputable def antipode : FiniteDual k H →ₗ[k] FiniteDual k H :=
+/-- The private construction used for the finite-dimensional dual antipode. -/
+private noncomputable def antipodeAux :
+    ConvolutionDual k H →ₗ[k] ConvolutionDual k H :=
   (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
-    LinearMap.lcomp k k (HopfAlgebra.antipode k (A := H)) ∘ₗ
+    (HopfAlgebra.antipode k (A := H)).dualMap ∘ₗ
       (WithConv.linearEquiv k _).toLinearMap
 
 omit [FiniteDimensional k H] in
-/-- The finite-dual antipode acts by precomposition. -/
-@[simp]
-theorem antipode_apply (phi : FiniteDual k H) (x : H) :
-    (antipode k H phi).ofConv x = phi.ofConv (HopfAlgebra.antipode k x) :=
-  by simp [antipode]
-
-@[simp]
-private theorem coalgebra_comul_eq_comul (phi : FiniteDual k H) :
-    Coalgebra.comul (R := k) (A := FiniteDual k H) phi = comul k H phi :=
+private theorem antipodeAux_eq :
+    antipodeAux k H = (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
+      (HopfAlgebra.antipode k (A := H)).dualMap ∘ₗ
+        (WithConv.linearEquiv k _).toLinearMap :=
   rfl
 
-@[simp]
-private theorem coalgebra_counit_eq_counit (phi : FiniteDual k H) :
-    Coalgebra.counit (R := k) (A := FiniteDual k H) phi = counit k H phi :=
-  rfl
+omit [FiniteDimensional k H] in
+private theorem antipodeAux_apply (phi : ConvolutionDual k H) (x : H) :
+    (antipodeAux k H phi).ofConv x = phi.ofConv (HopfAlgebra.antipode k x) :=
+  by simp [antipodeAux]
 
 private theorem mul_apply_eq_evalTensorEquiv
-    (w : FiniteDual k H ⊗[k] FiniteDual k H) (x : H) :
-    (LinearMap.mul' k (FiniteDual k H) w).ofConv x =
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
+    (LinearMap.mul' k (ConvolutionDual k H) w).ofConv x =
       evalTensorEquiv k H w (Coalgebra.comul x) := by
   induction w using TensorProduct.induction_on with
   | zero => simp
@@ -404,9 +428,9 @@ private theorem mul_apply_eq_evalTensorEquiv
       | tmul y z => rw [TensorProduct.map_tmul, LinearMap.mul'_apply, evalTensor_tmul_apply]
 
 private theorem evalTensor_map_antipode_left
-    (w : FiniteDual k H ⊗[k] FiniteDual k H) (z : H ⊗[k] H) :
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
     evalTensorEquiv k H
-        (TensorProduct.map (antipode k H) LinearMap.id w) z =
+        (TensorProduct.map (antipodeAux k H) LinearMap.id w) z =
       evalTensorEquiv k H w
         (TensorProduct.map (HopfAlgebra.antipode k (A := H)) LinearMap.id z) := by
   induction w using TensorProduct.induction_on with
@@ -420,13 +444,13 @@ private theorem evalTensor_map_antipode_left
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
       | tmul x y =>
           rw [TensorProduct.map_tmul, TensorProduct.map_tmul, evalTensor_tmul_apply,
-            evalTensor_tmul_apply, antipode_apply]
+            evalTensor_tmul_apply, antipodeAux_apply]
           rfl
 
 private theorem evalTensor_map_antipode_right
-    (w : FiniteDual k H ⊗[k] FiniteDual k H) (z : H ⊗[k] H) :
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
     evalTensorEquiv k H
-        (TensorProduct.map LinearMap.id (antipode k H) w) z =
+        (TensorProduct.map LinearMap.id (antipodeAux k H) w) z =
       evalTensorEquiv k H w
         (TensorProduct.map LinearMap.id (HopfAlgebra.antipode k (A := H)) z) := by
   induction w using TensorProduct.induction_on with
@@ -440,42 +464,54 @@ private theorem evalTensor_map_antipode_right
           simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
       | tmul x y =>
           rw [TensorProduct.map_tmul, TensorProduct.map_tmul, evalTensor_tmul_apply,
-            evalTensor_tmul_apply, antipode_apply]
+            evalTensor_tmul_apply, antipodeAux_apply]
           rfl
 
 /-- The Hopf algebra structure on the finite dual. Its antipode is precomposition with the
 antipode of the original finite-dimensional Hopf algebra. -/
-noncomputable instance instHopfAlgebra : HopfAlgebra k (FiniteDual k H) :=
-  HopfAlgebra.ofConvInverse (antipode k H)
+noncomputable instance instHopfAlgebra : HopfAlgebra k (ConvolutionDual k H) :=
+  HopfAlgebra.ofConvInverse
+    ((WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
+      (HopfAlgebra.antipode k (A := H)).dualMap ∘ₗ
+        (WithConv.linearEquiv k _).toLinearMap)
     (by
+      rw [← antipodeAux_eq]
       apply WithConv.ofConv_injective
       ext phi x
       rw [LinearMap.convMul_apply, mul_apply_eq_evalTensorEquiv,
         evalTensor_map_antipode_left]
-      rw [coalgebra_comul_eq_comul, evalTensor_comul]
+      rw [evalTensor_comul]
       simp only [LinearMap.comp_apply]
       rw [← LinearMap.rTensor_def, HopfAlgebra.mul_antipode_rTensor_comul_apply]
-      rw [LinearMap.convOne_apply, coalgebra_counit_eq_counit, counit_apply,
+      rw [LinearMap.convOne_apply, counit_apply,
         LinearMap.convAlgebraMap_apply,
         Algebra.algebraMap_eq_smul_one, map_smul]
       simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
       rw [mul_comm])
     (by
+      rw [← antipodeAux_eq]
       apply WithConv.ofConv_injective
       ext phi x
       rw [LinearMap.convMul_apply, mul_apply_eq_evalTensorEquiv,
         evalTensor_map_antipode_right]
-      rw [coalgebra_comul_eq_comul, evalTensor_comul]
+      rw [evalTensor_comul]
       simp only [LinearMap.comp_apply]
       rw [← LinearMap.lTensor_def, HopfAlgebra.mul_antipode_lTensor_comul_apply]
-      rw [LinearMap.convOne_apply, coalgebra_counit_eq_counit, counit_apply,
+      rw [LinearMap.convOne_apply, counit_apply,
         LinearMap.convAlgebraMap_apply,
         Algebra.algebraMap_eq_smul_one, map_smul]
       simp only [smul_eq_mul, Algebra.algebraMap_self_apply]
       rw [mul_comm])
 
+/-- The finite-dual antipode acts by precomposition with the original antipode. -/
+@[simp]
+theorem antipode_apply (phi : ConvolutionDual k H) (x : H) :
+    (HopfAlgebra.antipode k phi).ofConv x =
+      phi.ofConv (HopfAlgebra.antipode k x) :=
+  antipodeAux_apply k H phi x
+
 end HopfAlgebra
 
-end FiniteDual
+end ConvolutionDual
 
 end TauCeti


### PR DESCRIPTION
This PR constructs the finite-dimensional Hopf dual of a bialgebra over a field: use Mathlib's convolution algebra on the linear dual, transpose multiplication and the unit to obtain comultiplication and counit, prove the bialgebra compatibility, and transpose the antipode to obtain a Hopf algebra. When the original multiplication is commutative, prove the dual coalgebra cocommutative.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 milestone **“Cartier duality proper is the duality of finite locally free commutative group schemes, a related but distinct statement to develop separately.”** This is the next effective step because Cartier duality starts by dualizing the finite locally free coordinate Hopf algebra, and no open PR or pinned Mathlib module supplies that construction. After this PR, the milestone still needs morphism-level contravariant functoriality, the bidual isomorphism, extension from finite-dimensional vector spaces to finite locally free modules over a general base, and transport through the Hopf-spectrum equivalence to finite commutative group schemes.

Add `TauCeti/Algebra/HopfAlgebra/FiniteDual.lean` (531 lines). `TauCeti.FiniteDual.evalTensorEquiv` identifies tensors of dual functionals with functionals on the tensor square; `comul` and `counit` satisfy the evaluation equations, and `instBialgebra` is proved using `Bialgebra.mulCoalgHom`. For Hopf algebras, `antipode` is precomposition with the original antipode, and `antipode_convMul_id`/`id_convMul_antipode` establish both inverse laws before `instHopfAlgebra` packages them.

Reuse Mathlib's `TensorProduct.dualDistribEquiv`, convolution algebra on linear maps, `Bialgebra.mulCoalgHom`, and `HopfAlgebra.ofConvInverse`; no Mathlib infrastructure or external formalization is vendored. The construction follows Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2, and Milne, *Algebraic Groups* (2017), §12.e, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-hopf-dual"}-->

🤖 Prepared with Codex
