### PR TITLE
fix(ci): restore the main cache publisher

### DIFF
--- a/scripts/lint-env.sh
+++ b/scripts/lint-env.sh
@@ -183,10 +183,19 @@ ALLOWLIST="scripts/lint-nolints-allowlist.txt"
 UPDATE=0
 [ "${1:-}" = "--update" ] && UPDATE=1
 
-# This script runs inside the required landrun build. Its two direct `lean`
-# invocations do not go through Lake's LAKE_OVERRIDE_LEAN hook, so route them
-# explicitly through the same trusted per-process watchdog as `lake build`.
-run_lean() { lake env "$WATCHDOG_TOOLCHAIN/bin/lean" "$@"; }
+# In the required landrun build, route this script's two direct `lean`
+# invocations through the same trusted watchdog as `lake build`; they do not go
+# through Lake's LAKE_OVERRIDE_LEAN hook themselves. The trusted post-merge CI
+# also runs this script, but deliberately has no watchdog toolchain, so retain
+# its ordinary `lake env lean` path. scripts/sandbox-build.sh independently
+# requires an executable watchdog before any required build reaches this file.
+run_lean() {
+  if [ -n "${WATCHDOG_TOOLCHAIN:-}" ]; then
+    lake env "$WATCHDOG_TOOLCHAIN/bin/lean" "$@"
+  else
+    lake env lean "$@"
+  fi
+}
 
 fail() { echo "::error::lint-env: $*"; echo "LINT-ENV: FAIL — $*"; exit 1; }
 

--- a/scripts/sandbox-build.sh
+++ b/scripts/sandbox-build.sh
@@ -24,7 +24,8 @@ export TMPDIR="$PWD/.lake/tmp"
 # trusted base copies; the PR can overlay only TauCeti/, and landrun does not
 # pass timeout-control variables, so PR code cannot raise or disable the 300s
 # deadline. The wrapper and Lean both remain inside the same landrun sandbox.
-test -n "${WATCHDOG_TOOLCHAIN:-}" && test -x "$WATCHDOG_TOOLCHAIN/bin/lean"
+test -n "${WATCHDOG_TOOLCHAIN:-}"
+test -x "$WATCHDOG_TOOLCHAIN/bin/lean"
 export LAKE_OVERRIDE_LEAN=true
 export LEAN="$WATCHDOG_TOOLCHAIN/bin/lean"
 


### PR DESCRIPTION
This PR restores post-merge CI and Tau Ceti cache publication by making the environment linter use the Lean watchdog only when a watchdog toolchain is supplied. Required sandbox builds remain fail-closed: `scripts/sandbox-build.sh` rejects both a missing and a non-executable watchdog before invoking the linter, while trusted main CI retains its ordinary `lake env lean` path.

Validated with shell syntax checking, all nine performance-gate regression tests, Python compilation, direct `set -u` routing probes for both watchdog and non-watchdog modes, and fail-closed guard probes for unset, empty, non-executable, and executable watchdog paths. A full local environment-lint run could not be completed because the clean v4.34 worktree has no Tau Ceti oleans; post-merge CI is the end-to-end cache-publisher validation.

:robot: Prepared with OpenAI Codex
