### PR TITLE
refactor(CofinalIdeal): name the units-to-value-group bridge once

### DIFF
--- a/TauCeti/RingTheory/Valuation/CofinalIdeal/Restrict.lean
+++ b/TauCeti/RingTheory/Valuation/CofinalIdeal/Restrict.lean
@@ -78,6 +78,18 @@ open MonoidWithZeroHom TauCeti
 
 variable {A : Type*} [CommRing A] {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
 
+/-- The image of a unit of `WithZero α` under `OrderMonoidIso.unitsWithZero`, read back in
+`WithZero α`, is the value that unit carries.
+
+This is `WithZero.coe_unitsWithZeroEquiv_eq_units_val` in the order-isomorphism spelling.
+`OrderMonoidIso.unitsWithZero` is built on `WithZero.unitsWithZeroEquiv`, so the two agree
+definitionally, but they are distinct terms and only this spelling matches a goal stated
+through the order isomorphism. -/
+private theorem coe_unitsWithZero_eq_units_val {α : Type*} [Group α] [Preorder α]
+    (γ : (WithZero α)ˣ) :
+    ((OrderMonoidIso.unitsWithZero γ : α) : WithZero α) = γ.val :=
+  WithZero.coe_unitsWithZeroEquiv_eq_units_val _
+
 /-- The units identification takes the unit of a restricted value to the value-group element it
 names. This is the bridge between membership in a transported convex subgroup, which is phrased
 through `OrderMonoidIso.unitsWithZero`, and the introduction rules for `cΓ_v(I)`, which are
@@ -318,25 +330,12 @@ private theorem characteristicSubgroup_restrictToIdeal_eq_top_of_meets (w : Valu
       Valuation.embedding_restrict, ← hu,
       inv_le_comm₀ (zero_lt_one.trans_le h1a) (pos_iff_ne_zero.mpr WithZero.coe_ne_zero),
       ← WithZero.coe_inv, coe_le_restrictToIdeal_iff, hga]
-    have hcoe : ((OrderMonoidIso.unitsWithZero
-          ((u⁻¹ : (ConvexSubgroup.comapUnitsWithZero
-            (characteristicSubgroupOfIdeal w I hfg)).toSubgroup) :
-            (ValueGroup₀ (.ofClass w))ˣ) :
-          valueGroup (.ofClass w)) : ValueGroup₀ (.ofClass w)) =
-        (((u⁻¹ : (ConvexSubgroup.comapUnitsWithZero
-            (characteristicSubgroupOfIdeal w I hfg)).toSubgroup) :
-          (ValueGroup₀ (.ofClass w))ˣ) : ValueGroup₀ (.ofClass w)) :=
-      WithZero.coe_unitsWithZeroEquiv_eq_units_val _
-    rw [← hcoe, WithZero.coe_le_coe]
+    rw [← coe_unitsWithZero_eq_units_val, WithZero.coe_le_coe]
     simp only [map_inv, InvMemClass.coe_inv]
     simpa using inv_le_inv_iff.mpr hginv
   · rw [← ValueGroup₀.embedding_strictMono.le_iff_le, Valuation.embedding_restrict, ← hu,
       coe_le_restrictToIdeal_iff, hga]
-    have hcoe : ((OrderMonoidIso.unitsWithZero (u : (ValueGroup₀ (.ofClass w))ˣ) :
-        valueGroup (.ofClass w)) : ValueGroup₀ (.ofClass w)) =
-        ((u : (ValueGroup₀ (.ofClass w))ˣ) : ValueGroup₀ (.ofClass w)) :=
-      WithZero.coe_unitsWithZeroEquiv_eq_units_val _
-    rw [← hcoe, WithZero.coe_le_coe]
+    rw [← coe_unitsWithZero_eq_units_val, WithZero.coe_le_coe]
     exact hgle
 
 /-- The **not-meets** branch of `characteristicSubgroupOfIdeal_restrictToIdeal_eq_top`. When
@@ -366,13 +365,7 @@ private theorem cofinalValue_restrictToIdeal_of_not_meets (w : Valuation A Γ₀
   refine ⟨n, ?_⟩
   rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, ← hu,
     restrictToIdeal_lt_coe_iff, map_pow]
-  -- `OrderMonoidIso.unitsWithZero` and `WithZero.unitsWithZeroEquiv` agree, but only up to
-  -- defeq, so the bridge has to be stated rather than rewritten with
-  have hcoe : ((OrderMonoidIso.unitsWithZero (u : (ValueGroup₀ (.ofClass w))ˣ) :
-      valueGroup (.ofClass w)) : ValueGroup₀ (.ofClass w)) =
-      ((u : (ValueGroup₀ (.ofClass w))ˣ) : ValueGroup₀ (.ofClass w)) :=
-    WithZero.coe_unitsWithZeroEquiv_eq_units_val _
-  rwa [hcoe] at hn
+  rwa [coe_unitsWithZero_eq_units_val] at hn
 
 /-- **Wedhorn §7.1.2: the restricted valuation has full characteristic subgroup for `I`.** This
 is the valuation-level content of the landing law — the restriction `v|cΓ_v(I)` satisfies the very


### PR DESCRIPTION
`OrderMonoidIso.unitsWithZero` is built on `WithZero.unitsWithZeroEquiv` — the former's
`toMulEquiv` field is literally the latter. So Mathlib's
`WithZero.coe_unitsWithZeroEquiv_eq_units_val` is definitionally what a goal phrased through the
order isomorphism needs, but it is a different term, and `rw` is syntactic: it does not fire.

Three proofs in this file each worked around that separately, by restating the bridge inline as a
fully type-ascribed `have` closed by that Mathlib lemma. Spelling out both sides of the equation
in the `ValueGroup₀ (.ofClass w)` / `valueGroup (.ofClass w)` coercion tower costs six to ten
lines apiece, and two of the three are the same statement twice.

The bridge is now stated once, as a private lemma over `WithZero α` with the two typeclasses
`OrderMonoidIso.unitsWithZero` itself asks for, and rewritten with at all three sites. The
workaround comment at the third site goes with it.

`characteristicSubgroup_restrictToIdeal_eq_top_of_meets` drops from 43 lines to 30 and
`cofinalValue_restrictToIdeal_of_not_meets` from 24 to 18; the file loses 7 lines net.

The generated `OrderMonoidIso.unitsWithZero_apply` does not serve instead — it rewrites to the
unfolded `WithZero.unzero` normal form, which no longer matches the hypothesis being rewritten.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: AdicSpaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
