### PR TITLE
ci: serialize the main cache publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,17 @@ on:
 permissions:
   contents: read
 
+# Keep the cache publisher live under a burst of main pushes. GitHub retains at
+# most one running and one pending run in this group: the running build is never
+# cancelled before it can publish, while superseded pending commits do not each
+# start an expensive cache-miss rebuild. In a burst, this deliberately coalesces
+# intermediate commits' post-merge checks too; the newest pending tip rechecks
+# the entire tree, though localizing a failure may then require bisection. No
+# merge decision consumes this post-merge workflow's per-commit conclusion.
+concurrency:
+  group: main-ci-cache-publisher
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR serializes post-merge CI so a burst of main pushes can retain at most one running and one newest pending cache publisher. A running build is never canceled before upload; superseded pending commits do not each start an expensive cache-miss rebuild.

In the happy case, with no overlapping push, this adds no job, step, network request, or runner scheduling boundary, so CI duration is unchanged. During a burst it intentionally coalesces intermediate post-merge checks; the newest pending tip still rechecks the entire tree, while failure attribution may require bisection. Required PR builds remain separately sandboxed under landrun and are unaffected.

Validated by parsing the workflow YAML and checking the exact concurrency mapping. An independent review confirmed the GitHub concurrency semantics, absence of group collisions, cache-publication safety, and zero happy-path overhead.

:robot: Prepared with OpenAI Codex
