### PR TITLE
fix(ci): keep main-red alerts across moving tips

### DIFF
--- a/scripts/pr_status/stuck_alerts.py
+++ b/scripts/pr_status/stuck_alerts.py
@@ -32,8 +32,8 @@ Detectors (each names the infra failure it implies):
   5. dead-scheduler  A scheduled workflow is missing, disabled, or its last
                      SCHEDULED run is older than its cadence + slack. GitHub
                      disabled the cron (60-day inactivity), or it errors at dispatch.
-  6. main-red        The CI run for main's tip commit reached a non-success terminal
-                     conclusion. The "main is always green" invariant is broken.
+  6. main-red        The newest conclusive CI run on main is red, with no newer
+                     successful run. The "main is always green" invariant is broken.
   7. stale-fkb       An open first-known-bad issue (label `dependency-incompatibility`)
                      has been open past a grace window. A regression against TauCeti
                      nobody has landed the fix for.
@@ -152,6 +152,8 @@ HOLD_LABELS = {"keep", "hold", "wip", "human", "do-not-close", "blocked"}
 FKB_LABEL = "dependency-incompatibility"
 # CI conclusions that mean main is broken (not just `failure`).
 RED_CONCLUSIONS = {"failure", "timed_out", "startup_failure"}
+CONCLUSIVE_CI = RED_CONCLUSIONS | {"success"}
+MAIN_CI_WINDOW = 100
 
 
 def now_utc():
@@ -611,22 +613,40 @@ def detect_main_red():
     tip = gh_scalar(f"/repos/{REPO}/commits/main", jq='.sha // ""')
     if not tip:
         return []
-    # Evaluate the CI run for main's CURRENT tip specifically, so an old green run
-    # cannot mask a red (or never-completed) run on the commit that is actually
-    # main right now.
-    run = gh_obj(
-        f"/repos/{REPO}/actions/workflows/ci.yml/runs?head_sha={tip}&per_page=1",
-        jq='.workflow_runs[0] | {status: (.status // ""), conclusion: (.conclusion // "")}')
-    if not run or run.get("status") != "completed":
-        return []  # in progress or not yet run — not (yet) a red-main emergency
-    if run.get("conclusion") not in RED_CONCLUSIONS:
+
+    # Runs are newest first. Do not look only at the instantaneous tip: when main
+    # advances faster than CI finishes, every failed run may stop being "the tip"
+    # before this hourly detector observes it. Keep a known-red state active until
+    # a newer successful run proves recovery. Cancelled/skipped runs are not
+    # evidence either way (the main-CI concurrency policy may supersede pending
+    # runs deliberately), so scan past every non-conclusive result as well as
+    # queued/in-progress runs. Serialization keeps completed runs in creation
+    # order; do not remove that policy without revisiting this detector.
+    runs = gh_stream(
+        f"/repos/{REPO}/actions/workflows/ci.yml/runs?branch=main&event=push"
+        f"&per_page={MAIN_CI_WINDOW}",
+        jq='.workflow_runs[] | {head_sha: (.head_sha // ""), '
+           'status: (.status // ""), conclusion: (.conclusion // "")}',
+        paginate=False)
+    run = next((r for r in runs
+                if r.get("status") == "completed"
+                and r.get("conclusion") in CONCLUSIVE_CI), None)
+    if not run and len(runs) >= MAIN_CI_WINDOW:
+        # A full page with no success or red result proves only that the last
+        # known state fell outside our bounded window. Raise so reconciliation
+        # retains any live alert instead of silently declaring recovery.
+        raise RuntimeError(
+            f"no conclusive main CI run in the newest {MAIN_CI_WINDOW} runs")
+    if not run or run.get("conclusion") not in RED_CONCLUSIONS:
         return []
+    failed = run.get("head_sha", "")
     return [{
         "key": "main-red",
         "title": "main is RED",
         "body": (
-            f"CI on main's tip (`{tip[:10]}`) concluded `{run['conclusion']}`. The "
-            f"\"main is always green\" invariant is broken.\n\n"
+            f"The newest conclusive CI run on main (`{failed[:10]}`) concluded "
+            f"`{run['conclusion']}`, and current tip `{tip[:10]}` has no newer "
+            f"successful run. The \"main is always green\" invariant is broken.\n\n"
             f"**Fix:** identify the merge or environment change that broke it and land a "
             f"revert or forward-fix immediately — a red main blocks every bump and merge."),
     }]

--- a/scripts/pr_status/test_stuck_alerts.py
+++ b/scripts/pr_status/test_stuck_alerts.py
@@ -74,6 +74,78 @@ class GhStreamTest(unittest.TestCase):
                          ["TauCeti/Foo.lean", "lean-toolchain"])
 
 
+class MainRedTest(unittest.TestCase):
+    """A moving main tip must not hide the last conclusive red CI run."""
+
+    @staticmethod
+    def _run(head, status="completed", conclusion="success"):
+        return {"head_sha": head, "status": status, "conclusion": conclusion}
+
+    def _install_runs(self, runs, tip="tip"):
+        import json
+        payload = "".join(json.dumps(run) + "\n" for run in runs)
+        return _install(self, [("/commits/main", tip), ("ci.yml/runs", payload)])
+
+    def test_tip_failure_alerts(self):
+        fake = self._install_runs([self._run("tip", conclusion="failure")])
+        self.assertEqual([a["key"] for a in sa.detect_main_red()], ["main-red"])
+        runs_request = next(path for path, _jq, _paginate in fake.requests
+                            if "ci.yml/runs" in path)
+        self.assertIn("branch=main", runs_request)
+        self.assertIn("event=push", runs_request)
+        self.assertIn("per_page=100", runs_request)
+        self.assertFalse(next(paginate for path, _jq, paginate in fake.requests
+                              if "ci.yml/runs" in path))
+
+    def test_moving_tip_does_not_hide_previous_failure(self):
+        # Regression: the old detector returned early because `tip` was still
+        # running, even though every completed main run behind it was red.
+        self._install_runs([
+            self._run("tip", status="in_progress", conclusion=""),
+            self._run("bad", conclusion="failure"),
+        ])
+        alert = sa.detect_main_red()[0]
+        self.assertIn("`bad`", alert["body"])
+        self.assertIn("current tip `tip`", alert["body"])
+
+    def test_known_green_before_running_tip_is_not_an_alert(self):
+        self._install_runs([
+            self._run("tip", status="queued", conclusion=""),
+            self._run("green"),
+            self._run("old-bad", conclusion="failure"),
+        ])
+        self.assertEqual(sa.detect_main_red(), [])
+
+    def test_cancellation_does_not_clear_known_red(self):
+        self._install_runs([
+            self._run("tip", conclusion="cancelled"),
+            self._run("bad", conclusion="timed_out"),
+        ])
+        self.assertEqual([a["key"] for a in sa.detect_main_red()], ["main-red"])
+
+    def test_new_success_clears_older_failure(self):
+        self._install_runs([
+            self._run("tip"),
+            self._run("old-bad", conclusion="startup_failure"),
+        ])
+        self.assertEqual(sa.detect_main_red(), [])
+
+    def test_no_conclusive_run_is_not_an_alert(self):
+        self._install_runs([
+            self._run("tip", status="in_progress", conclusion=""),
+            self._run("old", conclusion="cancelled"),
+        ])
+        self.assertEqual(sa.detect_main_red(), [])
+
+    def test_full_inconclusive_window_fails_closed(self):
+        self._install_runs([
+            self._run(f"run-{i}", conclusion="cancelled")
+            for i in range(sa.MAIN_CI_WINDOW)
+        ])
+        with self.assertRaisesRegex(RuntimeError, "no conclusive main CI run"):
+            sa.detect_main_red()
+
+
 class FailClosedTest(unittest.TestCase):
     def test_failing_detector_records_prefix_and_keeps_others(self):
         self.addCleanup(setattr, sa, "DETECTORS", sa.DETECTORS)
@@ -229,8 +301,10 @@ class RoutedGh:
 
     def __init__(self, routes):
         self.routes = routes
+        self.requests = []
 
     def __call__(self, path, jq=None, paginate=False):
+        self.requests.append((path, jq, paginate))
         request = f"{path} {jq or ''}"
         for needle, payload in self.routes:
             if needle in request:
@@ -240,7 +314,9 @@ class RoutedGh:
 
 def _install(test, routes):
     test.addCleanup(setattr, core, "gh_api", core.gh_api)
-    core.gh_api = RoutedGh(routes)
+    fake = RoutedGh(routes)
+    core.gh_api = fake
+    return fake
 
 
 class ReadyLabelClockTest(unittest.TestCase):


### PR DESCRIPTION
This PR keeps the `main-red` emergency alert active while main advances faster than CI. It now uses the newest conclusive main-push CI result, scanning past queued, running, canceled, skipped, and other inconclusive runs until a newer success proves recovery.

The query remains one bounded 100-run API page per hourly poll. A full page with no conclusive result fails closed, preserving any live alert instead of silently declaring recovery. Alert rendering remains restricted to GitHub-provided commit hashes and a constrained conclusion value.

Validated with 45 focused alert tests, the complete nine-suite infrastructure-policy command from main CI (177 tests/cases), Python compilation, a live incident probe, and independent review.

:robot: Prepared with OpenAI Codex
