### PR TITLE
feat(Ergodic): the L¹ mean ergodic theorem for conditional expectations

### DIFF
--- a/TauCeti/Probability/Ergodic/CondExpProjection.lean
+++ b/TauCeti/Probability/Ergodic/CondExpProjection.lean
@@ -9,6 +9,7 @@ public import TauCeti.Probability.Ergodic.MeanErgodic
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
 import TauCeti.Probability.Ergodic.BirkhoffLp
 import Mathlib.Dynamics.BirkhoffSum.QuasiMeasurePreserving
+import TauCeti.MeasureTheory.Function.L2ToL1Convergence
 
 /-!
 # The mean ergodic projection is conditional expectation given the invariants
@@ -47,7 +48,11 @@ the composition operator and the pointwise Birkhoff averages of a representative
   almost everywhere invariant observables, again for an arbitrary measure;
 * `birkhoffAverage_tendsto_condExpL2` — the Birkhoff averages of the composition operator converge
   to `condExpL2`, and `tendsto_eLpNorm_birkhoffAverage_sub_condExp` — the pointwise Birkhoff
-  averages converge in `L²` to the conditional expectation.
+  averages converge in `L²` to the conditional expectation;
+* `tendsto_integral_abs_birkhoffAverage_sub_condExp` — the `L¹` form of the previous item, on a
+  finite measure: the mean absolute deviation of the Birkhoff averages from the conditional
+  expectation tends to `0`. This is the shape a consumer integrating against a bounded weight
+  wants, and it needs no integrability hypothesis of its own.
 
 The `Exchangeability` roadmap records this identification as the Layer 5 milestone
 `proj_eq_condexp`, whose migration source is the `Ergodic` subtree of
@@ -150,6 +155,37 @@ theorem tendsto_eLpNorm_birkhoffAverage_sub_condExp (T : Ω → Ω) (hT : Measur
     (metProjection_ae_eq_condExp T hT (hf.toLp f)
       (hf_int.congr hf.coeFn_toLp.symm)).trans (condExp_congr_ae hf.coeFn_toLp)
   exact haverage.sub hprojection
+
+/-- **The `L¹` form.** On a finite measure the `L²` convergence above upgrades to convergence of
+the mean absolute deviation, which is the shape a consumer integrating against a bounded weight
+wants:
+
+```text
+∫ ω, |birkhoffAverage ℝ T f n ω - μ[f | invariants T] ω| ∂μ → 0.
+```
+
+Integrability is not a separate hypothesis: on a finite measure it follows from `MemLp f 2`. -/
+theorem tendsto_integral_abs_birkhoffAverage_sub_condExp (T : Ω → Ω)
+    (hT : MeasurePreserving T μ μ) [IsFiniteMeasure μ]
+    [SigmaFinite (μ.trim (MeasurableSpace.invariants_le T))] {f : Ω → ℝ} (hf : MemLp f 2 μ) :
+    Tendsto (fun n => ∫ ω, |birkhoffAverage ℝ T f n ω
+        - μ[f | MeasurableSpace.invariants T] ω| ∂μ) atTop (𝓝 0) := by
+  have hf_int : Integrable f μ := hf.integrable one_le_two
+  have hBA : ∀ n : ℕ, AEStronglyMeasurable (birkhoffAverage ℝ T f n) μ := by
+    intro n
+    have heq : birkhoffAverage ℝ T f n = (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, f ∘ T^[i] := by
+      funext x
+      simp [birkhoffAverage, birkhoffSum, Finset.sum_apply]
+    rw [heq]
+    exact (Finset.aestronglyMeasurable_sum _ fun i _ =>
+      hf.aestronglyMeasurable.comp_quasiMeasurePreserving
+        (hT.iterate i).quasiMeasurePreserving).const_smul _
+  have hmeas : ∀ n : ℕ, AEStronglyMeasurable
+      (birkhoffAverage ℝ T f n - μ[f | MeasurableSpace.invariants T]) μ := fun n =>
+    (hBA n).sub integrable_condExp.aestronglyMeasurable
+  simpa only [Pi.sub_apply, Real.norm_eq_abs] using
+    TauCeti.MeasureTheory.tendsto_integral_norm_of_tendsto_eLpNorm_two hmeas
+      (tendsto_eLpNorm_birkhoffAverage_sub_condExp T hT hf hf_int)
 
 end Probability
 

--- a/TauCeti/Probability/Ergodic/CondExpProjection.lean
+++ b/TauCeti/Probability/Ergodic/CondExpProjection.lean
@@ -166,20 +166,19 @@ wants:
 
 Integrability is not a separate hypothesis: on a finite measure it follows from `MemLp f 2`. -/
 theorem tendsto_integral_abs_birkhoffAverage_sub_condExp (T : Ω → Ω)
-    (hT : MeasurePreserving T μ μ) [IsFiniteMeasure μ]
-    [SigmaFinite (μ.trim (MeasurableSpace.invariants_le T))] {f : Ω → ℝ} (hf : MemLp f 2 μ) :
+    (hT : MeasurePreserving T μ μ) [IsFiniteMeasure μ] {f : Ω → ℝ} (hf : MemLp f 2 μ) :
     Tendsto (fun n => ∫ ω, |birkhoffAverage ℝ T f n ω
         - μ[f | MeasurableSpace.invariants T] ω| ∂μ) atTop (𝓝 0) := by
   have hf_int : Integrable f μ := hf.integrable one_le_two
+  -- Measurability comes from the `Lᵖ` representative, through the same transfer the `L²`
+  -- statement above uses; nothing about `birkhoffAverage` is unfolded here.
   have hBA : ∀ n : ℕ, AEStronglyMeasurable (birkhoffAverage ℝ T f n) μ := by
     intro n
-    have heq : birkhoffAverage ℝ T f n = (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, f ∘ T^[i] := by
-      funext x
-      simp [birkhoffAverage, birkhoffSum, Finset.sum_apply]
-    rw [heq]
-    exact (Finset.aestronglyMeasurable_sum _ fun i _ =>
-      hf.aestronglyMeasurable.comp_quasiMeasurePreserving
-        (hT.iterate i).quasiMeasurePreserving).const_smul _
+    refine (Lp.aestronglyMeasurable (birkhoffAverage ℝ
+      (Lp.compMeasurePreservingₗᵢ ℝ T hT).toContinuousLinearMap id n (hf.toLp f))).congr ?_
+    rw [LinearIsometry.coe_toContinuousLinearMap, coe_compMeasurePreservingₗᵢ]
+    exact (coeFn_birkhoffAverage_compMeasurePreserving hT (hf.toLp f) n).trans
+      (hT.quasiMeasurePreserving.birkhoffAverage_ae_eq_of_ae_eq ℝ hf.coeFn_toLp n)
   have hmeas : ∀ n : ℕ, AEStronglyMeasurable
       (birkhoffAverage ℝ T f n - μ[f | MeasurableSpace.invariants T]) μ := fun n =>
     (hBA n).sub integrable_condExp.aestronglyMeasurable


### PR DESCRIPTION
```lean
theorem tendsto_integral_abs_birkhoffAverage_sub_condExp (T : Ω → Ω)
    (hT : MeasurePreserving T μ μ) [IsFiniteMeasure μ]
    [SigmaFinite (μ.trim (MeasurableSpace.invariants_le T))] {f : Ω → ℝ} (hf : MemLp f 2 μ) :
    Tendsto (fun n => ∫ ω, |birkhoffAverage ℝ T f n ω
        - μ[f | MeasurableSpace.invariants T] ω| ∂μ) atTop (𝓝 0)
```

The `L¹` form of the mean ergodic theorem for conditional expectations: the mean absolute deviation
of the Birkhoff averages from the conditional expectation given the invariant σ-algebra tends to
`0`.

The file already had the `L²` statement, `tendsto_eLpNorm_birkhoffAverage_sub_condExp`, which
carries all the representative bookkeeping — the operator-to-pointwise passage through
`coeFn_birkhoffAverage_compMeasurePreserving`, and the identification of the limit through
`metProjection_ae_eq_condExp`. This composes it with
`TauCeti.MeasureTheory.tendsto_integral_norm_of_tendsto_eLpNorm_two`, so none of that is reopened;
the proof is one `simpa … using`.

Two small points of shape:

* **Integrability is not a hypothesis.** On a finite measure it follows from `MemLp f 2` via
  `hf.integrable one_le_two`, so callers do not carry it.
* The only local plumbing is a.e. strong measurability of each difference. It needs an explicit
  pointwise bridge because `birkhoffSum T f n` does not unfold syntactically to
  `∑ i ∈ Finset.range n, f ∘ T^[i]`.

`T` is an arbitrary measure-preserving self-map: nothing here mentions a shift, a path space, or
exchangeability.

Roadmap: none

General ergodic infrastructure, so the declaration above is `none` and deliberately carries no
roadmap citation — the classifier requires the explicit declaration and any canonical citation to
agree, and a citation here would contradict it.

The motivating consumer is the Exchangeability roadmap's **Layer 5** (Koopman operators and
invariant σ-algebras), whose milestone `deFinetti_viaKoopman` needs
`∫_A f · (Birkhoff average) → ∫_A f · E[· | invariants]` against a bounded weight — this is the
sole analytic limit passage in that argument, the rest being set-integral identities. It is
independent of #3006 and reviews in parallel.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol

