### PR TITLE
refactor(HeckeRing): stop re-deriving coprimality and matrix associativity

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -149,12 +149,7 @@ private lemma first_invariant_dvd_p_of_product (p : ℕ) (S : SpecialLinearGroup
   have hRadj : R_ℤ * R_ℤ.adjugate = 1 := by rw [Matrix.mul_adjugate, R.prop, one_smul]
   have hM_eq : M = L_ℤ.adjugate * Matrix.diagonal (fun i ↦ (a i : ℤ)) * R_ℤ.adjugate :=
     matrix_isolate_middle L_ℤ M R_ℤ _ hLadj hRadj (by
-      have hre : L_ℤ * M * R_ℤ = L_ℤ * dp * S_ℤ * dpk * R_ℤ := by
-        ext i j
-        simp only [M, S_ℤ, Matrix.mul_apply, Fin.sum_univ_two]
-        ring
-      rw [hre]
-      exact heq)
+      simpa only [M, mul_assoc] using heq)
   have h_dvd_entry : ∀ i j : Fin 2, (a 0 : ℤ) ∣ M i j := by
     intro i j
     rw [hM_eq]
@@ -174,13 +169,7 @@ private lemma first_invariant_dvd_p_of_product (p : ℕ) (S : SpecialLinearGroup
   have h_cop : IsCoprime (S_ℤ 0 0) (S_ℤ 1 0) := S.isCoprime_col 0
   have h1 : (a 0 : ℤ) ∣ S_ℤ 0 0 := h_M00 ▸ h_dvd_entry 0 0
   have h2 : (a 0 : ℤ) ∣ (p : ℤ) * S_ℤ 1 0 := h_M10 ▸ h_dvd_entry 1 0
-  have h_cop_a : IsCoprime ((a 0 : ℤ)) (S_ℤ 1 0) := by
-    obtain ⟨u, v, huv⟩ := h_cop
-    obtain ⟨t, ht⟩ := h1
-    refine ⟨u * t, v, ?_⟩
-    have hshuffle : u * t * (a 0 : ℤ) = u * ((a 0 : ℤ) * t) := by ring
-    rw [hshuffle, ← ht]
-    exact huv
+  have h_cop_a : IsCoprime (a 0 : ℤ) (S_ℤ 1 0) := h_cop.of_isCoprime_of_dvd_left h1
   exact_mod_cast h_cop_a.dvd_of_dvd_mul_right h2
 
 /-- Determinant balance: if a `T(1,p) · T(1,pᵏ)`-shaped product lies in the double coset


### PR DESCRIPTION
`first_invariant_dvd_p_of_product` establishes that the first invariant factor divides `p`. Two
steps of that argument prove facts that already exist.

**Coprimality along a divisor.** The proof needs `IsCoprime (a 0) (S 1 0)` from
`IsCoprime (S 0 0) (S 1 0)` and `a 0 ∣ S 0 0`. It got there by destructing the Bézout witness of
the first, destructing the divisibility, reassembling a new Bézout pair, and closing with a `ring`
step to shuffle the product into place — seven lines. That is
`IsCoprime.of_isCoprime_of_dvd_left` (`Mathlib/RingTheory/Coprime/Basic.lean:154`), whose statement
is exactly this implication.

**Matrix associativity.** To feed `matrix_isolate_middle` it needed
`L * M * R = L * dp * S * dpk * R` where `M` is `dp * S * dpk` — pure reassociation. It was proved
entrywise, by `ext` followed by `Matrix.mul_apply`, `Fin.sum_univ_two` and `ring`, which expands
both sides into sums over `Fin 2` and compares them coefficient by coefficient. `mul_assoc` does
it directly, and once the step is one rewrite the named `hre` is no longer worth stating: it folds
into the `simpa` that consumed it.

No declaration is added or removed and no statement changes. The proof drops from 43 lines to 32.

The neighbouring `mem_SLnZ_of_coprime_scaling` in `GLn/CoprimeMul.lean` also destructs an
`IsCoprime`, but genuinely needs the Bézout coefficients to build an integer combination, so it is
left alone; this was the only re-derivation of the divisor lemma in the repository.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
