### PR TITLE
refactor(HeckeRing): rewrite with the ring lemmas instead of restating them

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean
@@ -112,26 +112,13 @@ private lemma heckeT_prime_pow_recurrence_step (k : ℕ) (hk_pos : 0 < k)
   simp only [show k + 2 ≠ 1 by omega, ite_false, show k + 2 - 1 = k + 1 by omega] at h5
   rw [heckeTDiag_one_prime_pow_eq p hp (k + 2) (by omega)] at h5
   -- distribute `T(p)` over the telescoped difference
-  have hdist₁ : heckeT ⟨p, hp.pos⟩ *
-      (heckeT ⟨p ^ (k + 2), pow_pos hp.pos (k + 2)⟩ -
-        heckeTScalar p * heckeT ⟨p ^ (k + 2 - 2), pow_pos hp.pos (k + 2 - 2)⟩) =
-      heckeT ⟨p, hp.pos⟩ * heckeT ⟨p ^ (k + 2), pow_pos hp.pos (k + 2)⟩ -
-        heckeT ⟨p, hp.pos⟩ *
-          (heckeTScalar p * heckeT ⟨p ^ (k + 2 - 2), pow_pos hp.pos (k + 2 - 2)⟩) :=
-    mul_sub _ _ _
-  rw [hdist₁] at h5
+  rw [mul_sub] at h5
   have h2k1 := heckeTDiag_one_prime_pow_eq p hp (k + 1) (by omega)
   conv at h2k1 => rhs; rw [show (k + 1) - 2 = k - 1 by omega]
   rw [h2k1] at h5
   conv at h5 => lhs; rw [show k + 2 - 2 = k by omega]
   -- and `T(p,p)` over the difference on the right
-  have hdist₂ : heckeTScalar p *
-      (heckeT ⟨p ^ (k + 1), pow_pos hp.pos (k + 1)⟩ -
-        heckeTScalar p * heckeT ⟨p ^ (k - 1), pow_pos hp.pos (k - 1)⟩) =
-      heckeTScalar p * heckeT ⟨p ^ (k + 1), pow_pos hp.pos (k + 1)⟩ -
-        heckeTScalar p * (heckeTScalar p * heckeT ⟨p ^ (k - 1), pow_pos hp.pos (k - 1)⟩) :=
-    mul_sub _ _ _
-  conv at h5 => rhs; rw [hdist₂]
+  conv at h5 => rhs; rw [mul_sub]
   -- the scalar operator is central, and the induction hypothesis rewrites `T(p) · T(pᵏ)`
   have hcomm : heckeT ⟨p, hp.pos⟩ * heckeTScalar p =
       heckeTScalar p * heckeT ⟨p, hp.pos⟩ := by
@@ -179,22 +166,12 @@ theorem heckeT_prime_pow_recurrence : ∀ k : ℕ, 0 < k →
     rw [heckeTDiag_one_prime_pow_one, heckeT_prime p hp] at h5
     rw [heckeT_prime p hp]
     -- split the `k = 1` coefficient `p + 1` into `p` and the unit
-    have hsplit : ((p : ℤ) + 1) • heckeTScalar p =
-        (p : ℤ) • heckeTScalar p + heckeTScalar p := by
-      rw [add_smul, one_smul]
-    rw [hsplit] at h5
+    rw [add_smul, one_smul] at h5
     linear_combination (norm := module) -h5
   rcases k with _ | k
   · simp only [show (2 : ℕ) ≠ 1 by omega, ite_false, show (2 : ℕ) - 1 = 1 by omega] at h5 ⊢
     rw [heckeTDiag_one_prime_pow_eq p hp 2 (by omega)] at h5
-    have hdist : heckeT ⟨p, hp.pos⟩ *
-        (heckeT ⟨p ^ 2, pow_pos hp.pos 2⟩ -
-          heckeTScalar p * heckeT ⟨p ^ (2 - 2), pow_pos hp.pos (2 - 2)⟩) =
-        heckeT ⟨p, hp.pos⟩ * heckeT ⟨p ^ 2, pow_pos hp.pos 2⟩ -
-          heckeT ⟨p, hp.pos⟩ *
-            (heckeTScalar p * heckeT ⟨p ^ (2 - 2), pow_pos hp.pos (2 - 2)⟩) :=
-      mul_sub _ _ _
-    rw [hdist] at h5
+    rw [mul_sub] at h5
     simp only [show 2 - 2 = 0 from rfl] at h5 ⊢
     rw [heckeT_prime_pow_zero p hp, mul_one, heckeTDiag_one_prime_pow_one, heckeT_prime p hp] at h5
     rw [heckeT_prime_pow_one p hp] at h5 ⊢


### PR DESCRIPTION
Four steps of the prime-power recurrence introduced a `have` whose statement was an instance of a
ring or module lemma, closed it by that lemma applied to explicit arguments, and then rewrote with
the `have`. Three were `mul_sub`; one was `add_smul` followed by `one_smul`.

Each restatement spelled out both sides of the equation in full. In
`heckeT_prime_pow_recurrence_step` that is eight lines for
`T(p) * (T(p^(k+2)) - T(p,p) * T(p^(k+2-2)))` distributed, and seven for the matching
`T(p,p)` distribution on the right; `heckeT_prime_pow_recurrence` carries a third at `k = 2` and
the `(p + 1) • T(p,p) = p • T(p,p) + T(p,p)` split at `k = 1`.

Rewriting with the lemma directly does the same work: `rw [mul_sub] at h5`, and
`rw [add_smul, one_smul] at h5`. The two `conv ... => rhs` scopes are kept, so the rewrite that
was already targeted at one side still is.

The comments naming what each step does — distributing `T(p)` over the telescoped difference,
distributing `T(p,p)` on the right, splitting the `k = 1` coefficient — are unchanged, so the
proof reads the same; what goes is the restatement of the lemma being applied.

No declaration is added or removed and no statement changes. `heckeT_prime_pow_recurrence_step`
drops from 48 lines to 35 and `heckeT_prime_pow_recurrence` from 42 to 32.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
