### PR TITLE
feat(AdicSpace): the retraction is a spectral map

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/SpvOfIdeal/Spectral.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/SpvOfIdeal/Spectral.lean
@@ -5,8 +5,10 @@ Authors: Chris Birkbeck
 -/
 module
 
+public import Mathlib.Topology.Spectral.Hom
 public import TauCeti.AlgebraicGeometry.AdicSpace.RestrictToIdeal
 public import TauCeti.AlgebraicGeometry.AdicSpace.PatchPresentation
+import TauCeti.Topology.Spectral.SpectralMap
 import TauCeti.Topology.Spectral.PatchCriterion
 
 /-!
@@ -74,10 +76,10 @@ below is the public neighbourhood interface that merges them.)
 * `TauCeti.ValuationSpectrum.isCompact_of_mem_rationalFamily` : the members of `R` are
   quasi-compact, the other half of what Lemma 7.5(1) asserts about them.
 * `TauCeti.ValuationSpectrum.continuous_restrictToIdealCodRestrict` : **Lemma 7.5(2)**, the
-  continuity half — steps (ii) and (iii) give it at once. Wedhorn's further claim that `r_I` is
-  a *spectral* map is not recorded here; the quasi-compactness and the basis property that claim
-  needs are available as `isCompact_of_mem_rationalFamily` and
-  `isTopologicalBasis_rationalFamily` just above.
+  continuity half — steps (ii) and (iii) give it at once.
+* `TauCeti.ValuationSpectrum.isSpectralMap_restrictToIdealCodRestrict` : **Lemma 7.5(2)**, the
+  spectral-map half, closing out Lemma 7.5: spectrality is tested on the basis `R`, whose
+  preimages step (iii) computes and `isCompact_basicOpenFinset` bounds.
 
 ## References
 
@@ -492,8 +494,7 @@ theorem isCompact_of_mem_rationalFamily (I : Ideal A)
 /-- **Wedhorn Lemma 7.5(2)**, the continuity half: the retraction `r_I : Spv A → Spv (A, I)`
 is continuous.
 
-Wedhorn also calls `r_I` a *spectral* map; that half is not recorded here. The quasi-compactness
-of the rational subsets which it additionally needs is `isCompact_of_mem_rationalFamily` above. -/
+The spectral-map half is `isSpectralMap_restrictToIdealCodRestrict` below. -/
 @[fun_prop]
 theorem continuous_restrictToIdealCodRestrict (I : Ideal A)
     (hfg : ∃ J : Ideal A, J.FG ∧ I.radical = J.radical) :
@@ -505,5 +506,20 @@ theorem continuous_restrictToIdealCodRestrict (I : Ideal A)
     rw [restrictToIdealCodRestrict_preimage I hfg hadm]
     exact isOpen_basicOpenFinset T u
   rwa [← instTopologicalSpace_spvOfIdeal_eq_generateFrom I hfg] at h
+
+/-- **Wedhorn Lemma 7.5(2)**, the spectral-map half: the retraction `r_I : Spv A → Spv (A, I)`
+is a spectral map. This closes out Lemma 7.5.
+
+Spectrality is tested on the basis `R` (`isSpectralMap_of_isTopologicalBasis` with
+`isTopologicalBasis_rationalFamily`), where the preimage of a rational subset is computed by
+step (iii) and is quasi-compact in `Spv A` unconditionally. -/
+theorem isSpectralMap_restrictToIdealCodRestrict (I : Ideal A)
+    (hfg : ∃ J : Ideal A, J.FG ∧ I.radical = J.radical) :
+    IsSpectralMap (restrictToIdealCodRestrict I hfg) := by
+  refine isSpectralMap_of_isTopologicalBasis (isTopologicalBasis_rationalFamily I hfg)
+    (continuous_restrictToIdealCodRestrict I hfg) ?_
+  rintro _ ⟨T, u, hadm, rfl⟩
+  rw [restrictToIdealCodRestrict_preimage I hfg hadm]
+  exact isCompact_basicOpenFinset T u
 
 end TauCeti.ValuationSpectrum


### PR DESCRIPTION
**Wedhorn Lemma 7.5, closed out: the retraction `r_I : Spv A → Spv (A, I)` is a spectral map.**

```lean
theorem isSpectralMap_restrictToIdealCodRestrict (I : Ideal A)
    (hfg : ∃ J : Ideal A, J.FG ∧ I.radical = J.radical) :
    IsSpectralMap (restrictToIdealCodRestrict I hfg)
```

This is the one-theorem assembly the last two Lemma 7.5 PRs were built for, and it lands the
final claim of the lemma: #2973 supplied the basis criterion for spectral maps
(`isSpectralMap_of_isTopologicalBasis`), #2975 made the rational family a basis of `Spv (A, I)`
(`isTopologicalBasis_rationalFamily`), and the preimage formula plus quasi-compactness were
already on `main` (`restrictToIdealCodRestrict_preimage`, `isCompact_basicOpenFinset`). The proof
is the seven-line composition of exactly those four results, mirroring the shape of the
continuity half directly above it.

The two docstring caveats that said the spectral-map half "is not recorded here" (module
Main-results bullet, and `continuous_restrictToIdealCodRestrict`'s docstring) are replaced by
pointers to the new theorem in the same diff.

Import note: `Mathlib.Topology.Spectral.Hom` is a `public import` because `IsSpectralMap` is in
the public signature; `TauCeti.Topology.Spectral.SpectralMap` (the basis criterion) is used only
inside the proof and stays a plain `import`.

## Where this leaves Layer 1.4

Lemma 7.5 is now fully formalised: (1) the rational family is a quasi-compact basis (#2973,
#2975, `isCompact_of_mem_rationalFamily`), (2) `r_I` is continuous (#2895) and spectral (this
PR), (3) the preimage formula (on `main`). Next in the lane: the Spv-level packaging of
Theorem 7.10 once #2989 and #3009 merge, then Corollary 7.12 via #2987's closedness.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
(`LINT-ENV: PASS`) — all exit 0, each run separately, on this head merged with current `main`.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-1.4-retraction-spectral-map"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
