### PR TITLE
refactor(SmithNormalForm): cancel the change-of-basis factors instead of a calc

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -783,17 +783,8 @@ theorem smith_normal_form_unique {c d : Fin n → ℤ} (hc_pos : ∀ i, 0 ≤ c 
       (R : Matrix (Fin n) (Fin n) ℤ) = Matrix.diagonal d) : c = d := by
   have h' : (↑L⁻¹ : Matrix (Fin n) (Fin n) ℤ) * Matrix.diagonal d *
       (↑R⁻¹ : Matrix (Fin n) (Fin n) ℤ) = Matrix.diagonal c := by
-    calc (↑L⁻¹ : Matrix (Fin n) (Fin n) ℤ) * Matrix.diagonal d *
-        (↑R⁻¹ : Matrix (Fin n) (Fin n) ℤ)
-        = (↑L⁻¹ : Matrix (Fin n) (Fin n) ℤ) *
-            ((L : Matrix (Fin n) (Fin n) ℤ) * Matrix.diagonal c *
-              (R : Matrix (Fin n) (Fin n) ℤ)) *
-            (↑R⁻¹ : Matrix (Fin n) (Fin n) ℤ) := by rw [h]
-      _ = ((↑L⁻¹ : Matrix (Fin n) (Fin n) ℤ) * ↑L) * Matrix.diagonal c *
-            (↑R * (↑R⁻¹ : Matrix (Fin n) (Fin n) ℤ)) := by
-          simp only [Matrix.mul_assoc]
-      _ = Matrix.diagonal c := by
-          rw [Units.inv_mul, Units.mul_inv, Matrix.one_mul, Matrix.mul_one]
+    rw [← h]
+    simp [Matrix.mul_assoc]
   have key : ∀ k (hk : k ≤ n),
       ∏ j : Fin k, c ⟨j.val, by omega⟩ = ∏ j : Fin k, d ⟨j.val, by omega⟩ := fun k hk ↦
     Int.dvd_antisymm


### PR DESCRIPTION
`smith_normal_form_unique` starts by inverting its hypothesis
`L * diagonal c * R = diagonal d` into `L⁻¹ * diagonal d * R⁻¹ = diagonal c`, which the rest of
the proof needs to run the divisibility comparison in both directions.

That inversion was an eleven-line `calc`: substitute `L * diagonal c * R` for `diagonal d`,
reassociate the five factors with `simp only [Matrix.mul_assoc]`, then cancel with four explicit
rewrites (`Units.inv_mul`, `Units.mul_inv`, `Matrix.one_mul`, `Matrix.mul_one`). Each step
restates the whole product, with the `Matrix (Fin n) (Fin n) ℤ` ascriptions written out on every
coercion.

Rewriting backwards with the hypothesis puts the goal into the form
`L⁻¹ * (L * diagonal c * R) * R⁻¹ = diagonal c`, which is associativity together with the two unit
cancellations — `simp [Matrix.mul_assoc]` closes it.

No declaration is added or removed and no statement changes. The proof drops from 40 lines to 31.

The rest of the proof is untouched: `key`, `split_eq` and `chain_zero` each carry real content
(`chain_zero` is the fact that a divisibility chain vanishes from its first zero on), and the
comment explaining the vanishing-threshold argument still describes what follows it.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
