### PR TITLE
refactor(Huber): ask the target only for ContinuousConstSMul

### DIFF
--- a/TauCeti/RingTheory/Huber/OpenMapping.lean
+++ b/TauCeti/RingTheory/Huber/OpenMapping.lean
@@ -40,6 +40,11 @@ Tate condition is used, and a Huber ring that is not Tate need not admit such a 
 Countable generation of the uniformity gives it for `𝓝 0`, which is the first countability Henkel
 asks of the source.
 
+The target's action hypothesis is `ContinuousConstSMul A N`, which is Henkel's own binder rather
+than a strengthening of it. The asymmetry with `ContinuousSMul A M` on the source is not an
+oversight: the source needs continuity in the *scalar* variable to discharge `hc`, whereas the
+target needs only continuity in the *module* variable, and `ContinuousConstSMul` is exactly that.
+
 The target's completeness deserves a word, since it is not what one would guess Henkel needs.
 Henkel asks the target to be a **Baire** space, and completeness plus a countably generated
 uniformity is how that is obtained here: the two together make `N` completely pseudometrisable
@@ -84,7 +89,7 @@ variable {A M N : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
   [AddCommGroup M] [UniformSpace M] [IsUniformAddGroup M] [CompleteSpace M]
   [(𝓤 M).IsCountablyGenerated] [NonarchimedeanAddGroup M] [Module A M] [ContinuousSMul A M]
   [AddCommGroup N] [UniformSpace N] [IsUniformAddGroup N] [CompleteSpace N]
-  [(𝓤 N).IsCountablyGenerated] [T0Space N] [Module A N] [ContinuousSMul A N]
+  [(𝓤 N).IsCountablyGenerated] [T0Space N] [Module A N] [ContinuousConstSMul A N]
 
 /-- **The open mapping theorem over a Tate ring.** A surjective `A`-linear map from a complete
 pseudometrisable topological `A`-module onto a complete metrisable one is open, when `A` is a Tate


### PR DESCRIPTION
Roadmap: AdicSpaces

Modest generalisation of a lemma already on `main`; no new declaration, so no roadmap target is
claimed — CLAUDE.md puts "fixing or modestly generalising an existing lemma" in scope at any time.
The roadmap named for attribution is the one the file serves, AdicSpaces Layer 0.6.

## The change

`TauCeti.Huber.IsTateRing.isOpenMap` and `.isQuotientMap` asked `[ContinuousSMul A N]` of the
target. Henkel asks only `[ContinuousConstSMul A N]` (`Henkel.lean:61`), and neither theorem uses
the stronger form.

Verified before changing anything: a scratch file reproducing both theorem statements with
`[ContinuousConstSMul A N]` substituted for `[ContinuousSMul A N]`, everything else identical,
elaborates with no errors.

## The asymmetry is deliberate, and now documented

The source keeps `[ContinuousSMul A M]`. That is not an inconsistency:

* the **source** must discharge Henkel's explicit argument
  `hc : ∀ x : M, ContinuousAt (fun a : A ↦ a • x) 0` — continuity in the **scalar** variable;
* the **target** needs only continuity in the **module** variable, which is precisely what
  `ContinuousConstSMul` is.

Stating `ContinuousSMul` on both sides bought visual symmetry at the price of an assumption the
theorem does not use. The module docstring now says which side needs which and why, so a later
reader does not "tidy" it back.

## How this was missed the first time

Worth recording, because the checking method was the problem rather than the checking.

When #2972 was opened I drop-tested all eighteen instance hypotheses individually against a
compiling baseline and reported all eighteen as NEEDED. That was **correct** — removing
`[ContinuousSMul A N]` does break the proof.

But removal is binary, and it is not the question. For a typeclass binder the real question is the
lattice of **parent classes**: a hypothesis can be un-removable and still too strong.
`ContinuousSMul A N` is exactly that case. A drop test answers "removable?" and never "weakenable?".

## Relation to the sibling PR

#3039 corrects documentation in this same file, including two headline sentences that stated the
theorem without its continuity hypothesis. Both PRs come from one read-only cleanup audit. They are
deliberately separate because only this one changes a statement, and the false-statement fix should
not wait behind review of a generality change.

## Provenance

No source material. The weaker binder is read directly off
`TauCeti/Topology/Algebra/OpenMapping/Henkel.lean`, already on `main`.
