### PR TITLE
refactor(HomologyCauchy): collect the sum bookkeeping into one calc step

### DIFF
--- a/TauCeti/Analysis/Contour/Cycle/HomologyCauchy.lean
+++ b/TauCeti/Analysis/Contour/Cycle/HomologyCauchy.lean
@@ -122,26 +122,13 @@ private theorem cycleDixonH1_eq_cycleDixonH2_sub {f : ℂ → ℂ} {C : Cycle} {
         (TauCeti.Contour.dixonH2 f γ γ.a γ.b w - 2 * (Real.pi : ℂ) * Complex.I *
           TauCeti.Contour.windingNumber γ γ.a γ.b w * f w) :=
       Finset.sum_congr rfl fun γ hγ ↦ by rw [hterm γ hγ]
-    _ = ∑ γ ∈ FreeAbelianGroup.support C,
-        ((FreeAbelianGroup.coeff γ C : ℂ) * TauCeti.Contour.dixonH2 f γ γ.a γ.b w -
-          (FreeAbelianGroup.coeff γ C : ℂ) * (2 * (Real.pi : ℂ) * Complex.I *
-            TauCeti.Contour.windingNumber γ γ.a γ.b w * f w)) :=
-      Finset.sum_congr rfl fun _ _ ↦ by ring
-    _ = (∑ γ ∈ FreeAbelianGroup.support C,
-          (FreeAbelianGroup.coeff γ C : ℂ) * TauCeti.Contour.dixonH2 f γ γ.a γ.b w) -
-        ∑ γ ∈ FreeAbelianGroup.support C, (FreeAbelianGroup.coeff γ C : ℂ) *
-          (2 * (Real.pi : ℂ) * Complex.I *
-            TauCeti.Contour.windingNumber γ γ.a γ.b w * f w) :=
-      by rw [Finset.sum_sub_distrib]
     _ = (∑ γ ∈ FreeAbelianGroup.support C,
           (FreeAbelianGroup.coeff γ C : ℂ) * TauCeti.Contour.dixonH2 f γ γ.a γ.b w) -
         2 * (Real.pi : ℂ) * Complex.I *
           (∑ γ ∈ FreeAbelianGroup.support C, (FreeAbelianGroup.coeff γ C : ℂ) *
             TauCeti.Contour.windingNumber γ γ.a γ.b w) * f w := by
-      congr 1
-      rw [Finset.mul_sum, Finset.sum_mul]
-      refine Finset.sum_congr rfl fun _ _ ↦ ?_
-      ring
+      simp only [Finset.mul_sum, Finset.sum_mul, ← Finset.sum_sub_distrib]
+      exact Finset.sum_congr rfl fun _ _ ↦ by ring
 
 /-- The cycle Dixon function agrees with `h₂` at an off-trace point where the cycle winding
 number vanishes. -/


### PR DESCRIPTION
`cycleDixonH1_eq_cycleDixonH2_sub` sums the single-curve identity
`h₁ = h₂ − 2πi·n(γ,w)·f(w)` over the support of a cycle. Once `hterm` has rewritten each
generator, what remains is finite-sum bookkeeping, and it was spelled out in three further `calc`
steps: distribute the coefficient over the subtraction, split with `Finset.sum_sub_distrib`, then
pull `2πi` and `f w` back out of the second sum.

Every one of those steps restated the whole sum over `FreeAbelianGroup.support C`, with the
coefficient cast and the four-factor product written out, so two full copies of the sum existed
only to be passed through.

The three steps are one rewrite by the same sum lemmas followed by a termwise `ring`, so they
collapse into the final step:

```lean
      simp only [Finset.mul_sum, Finset.sum_mul, ← Finset.sum_sub_distrib]
      exact Finset.sum_congr rfl fun _ _ ↦ by ring
```

The first `calc` step is untouched — it carries the mathematical content, applying `hterm` under
the coefficient — and the conclusion is unchanged, so the calc still ends on the statement it
always did.

No declaration is added or removed and no statement changes. The proof drops from 41 lines to 28.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
