### PR TITLE
refactor(Multiquadratic): chain the inclusions instead of proving an equality

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/Subfield.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/Subfield.lean
@@ -137,13 +137,8 @@ theorem eq_of_adjoin_prod_root_eq [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = 
   rw [hE, Finset.sdiff_nonempty]
   intro hsub
   apply hne
-  have h3 : S ∪ T = S ∩ T := Finset.Subset.antisymm hsub Finset.inter_subset_union
-  refine Finset.Subset.antisymm ?_ ?_
-  · calc S ⊆ S ∪ T := Finset.subset_union_left
-      _ = S ∩ T := h3
-      _ ⊆ T := Finset.inter_subset_right
-  · calc T ⊆ S ∪ T := Finset.subset_union_right
-      _ = S ∩ T := h3
-      _ ⊆ S := Finset.inter_subset_left
+  exact Finset.Subset.antisymm
+    (Finset.subset_union_left.trans (hsub.trans Finset.inter_subset_right))
+    (Finset.subset_union_right.trans (hsub.trans Finset.inter_subset_left))
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/Subfield.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/Subfield.lean
@@ -137,8 +137,7 @@ theorem eq_of_adjoin_prod_root_eq [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = 
   rw [hE, Finset.sdiff_nonempty]
   intro hsub
   apply hne
-  exact Finset.Subset.antisymm
-    (Finset.subset_union_left.trans (hsub.trans Finset.inter_subset_right))
-    (Finset.subset_union_right.trans (hsub.trans Finset.inter_subset_left))
+  rw [← Finset.sup_eq_union, ← Finset.inf_eq_inter] at hsub
+  exact sup_le_inf.mp hsub
 
 end TauCeti.Multiquadratic


### PR DESCRIPTION
`eq_of_adjoin_prod_root_eq` ends by deriving `S = T` from the inclusion `S ∪ T ⊆ S ∩ T`, which the
symmetric-difference argument has just produced.

It got there in two stages: upgrade the inclusion to the equality `S ∪ T = S ∩ T` by antisymmetry
against `Finset.inter_subset_union`, then run two symmetric three-step `calc` chains through that
equality — `S ⊆ S ∪ T = S ∩ T ⊆ T`, and the same with the roles swapped.

That is Mathlib's `sup_le_inf` (`Order/Lattice.lean:413`), which states `a ⊔ b ≤ a ⊓ b ↔ a = b` for
any lattice. Reading `∪` and `∩` as the lattice operations — `Finset.sup_eq_union` and
`Finset.inf_eq_inter` — makes the hypothesis literally its left-hand side, so the whole tail is one
application:

```lean
  rw [← Finset.sup_eq_union, ← Finset.inf_eq_inter] at hsub
  exact sup_le_inf.mp hsub
```

The intermediate equality is not needed and neither chain survives. The rest of the proof is
untouched — the square-class step, the factorisation of the product through the symmetric
difference, and the division by the square factor all carry real content.

No declaration is added or removed and no statement changes. The proof drops from 40 lines to 34.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
