### PR TITLE
feat(Huber): the topological localisation A(T/s) is a Huber ring

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology.lean
@@ -54,7 +54,9 @@ so a consumer holding `A[1/s]` in another presentation can use the topology dire
   basis of zero in `D`, so the subspace topology on `D` is the `J`-adic one. With `fg_locIdeal`
   this completes every condition `TauCeti.Huber.PairOfDefinition` asks of the pair `(D, J)`.
 * `localization` and `isHuberRing_locTopology`: those conditions assembled, so `Aₛ` under
-  `locTopology` is a Huber ring.
+  `locTopology` is a Huber ring. `localization_ringOfDefinition` and
+  `mem_localization_idealOfDefinition` are its contract, since the body of `localization` is not
+  exposed.
 * `isPowerBounded_of_mem_locSubring` and `isPowerBounded_divBy`: every element of `D` — in
   particular each fraction `t/s` — is power-bounded, the fact a converse to the continuity
   criterion needs.
@@ -646,12 +648,13 @@ theorem isAdic_locIdeal [IsTopologicalRing A] (P : PairOfDefinition A) (T : Fins
 
 /-! ### The localisation is a Huber ring -/
 
-/-- **The pair of definition of `A(T/s)`**: the subring `D` together with the ideal `J = I · D`.
+/-- **The pair of definition of `Aₛ`** under `locTopology` — Wedhorn's `A(T/s)` of 5.51, written
+`Aₛ` throughout this file: the subring `D` together with the ideal `J = I · D`.
 
-Every field is one of the facts established above — `isOpen_locSubring`, `fg_locIdeal` and
-`isAdic_locIdeal` — so nothing new is proved here. It exists because
-`TauCeti.Huber.PairOfDefinition` is a structure: the facts are what the work above produces, and
-this is the value that packages them for `isHuberRing_locTopology`.
+`TauCeti.Huber.PairOfDefinition` has two data fields and three proof fields, and every one of them
+is already established above. The data are `locSubring` and `locIdeal`; the three proofs are
+`isOpen_locSubring`, `fg_locIdeal` and `isAdic_locIdeal`. Nothing new is proved here — this is the
+value that packages them for `isHuberRing_locTopology`.
 
 The topology is not an instance on `S`, so it is introduced in the statement; a consumer supplies
 it the same way, or works under `isHuberRing_locTopology` instead. -/
@@ -667,12 +670,36 @@ noncomputable def localization [IsTopologicalRing A] (P : PairOfDefinition A) (T
     fg_idealOfDefinition := fg_locIdeal P T s S
     isAdic_idealOfDefinition := isAdic_locIdeal P T s S hden }
 
+/-- The ring of definition of `localization` is `D`. The body of `localization` is not exposed, so
+this is how a consumer recovers it — the same contract `completion_ringOfDefinition` provides for
+the completion. Unlike that one, the statement has to introduce the topology, because
+`locTopology` is not an instance and `localization`'s own type depends on it. -/
+@[simp]
+theorem localization_ringOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A)
+    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    (P.localization T s S hden).ringOfDefinition = locSubring P T s S := (rfl)
+
+/-- Membership in the ideal of definition of `localization` is membership in `J`. Stated as a
+membership rather than an equation because `idealOfDefinition`'s type depends on
+`ringOfDefinition`, exactly as `mem_completion_idealOfDefinition` is. -/
+@[simp]
+theorem mem_localization_idealOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    {x : letI := locTopology P T s S hden; (P.localization T s S hden).ringOfDefinition} :
+    letI := locTopology P T s S hden
+    x ∈ (P.localization T s S hden).idealOfDefinition ↔
+      (⟨x, by rw [← localization_ringOfDefinition P T s S hden]; exact x.2⟩ :
+        locSubring P T s S) ∈ locIdeal P T s S := (Iff.rfl)
+
 /-- **Wedhorn's topological localisation is a Huber ring.** Under the standing hypothesis, `Aₛ`
 carrying `locTopology` admits a pair of definition, namely `(D, J)`.
 
 This is what the whole file is for. Being Huber is exactly the existence of *some* pair of
-definition, so the content is the four facts assembled in `localization`: `D` is open, `J`
-is finitely generated, and the subspace topology on `D` is the `J`-adic one.
+definition, so the content is the three facts assembled in `localization`: `D` is open, `J` is
+finitely generated, and the subspace topology on `D` is the `J`-adic one.
 
 Both the topology and its ring structure are introduced in the statement, because `locTopology` is
 deliberately not registered as an instance — `Aₛ` is an arbitrary localisation and carries no

--- a/TauCeti/RingTheory/Huber/LocalizationTopology.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology.lean
@@ -53,7 +53,7 @@ so a consumer holding `A[1/s]` in another presentation can use the topology dire
 * `hasBasis_nhds_zero_locSubring` and `isAdic_locIdeal`: the powers of `J` are a neighbourhood
   basis of zero in `D`, so the subspace topology on `D` is the `J`-adic one. With `fg_locIdeal`
   this completes every condition `TauCeti.Huber.PairOfDefinition` asks of the pair `(D, J)`.
-* `locPairOfDefinition` and `isHuberRing_locTopology`: those conditions assembled, so `Aₛ` under
+* `localization` and `isHuberRing_locTopology`: those conditions assembled, so `Aₛ` under
   `locTopology` is a Huber ring.
 * `isPowerBounded_of_mem_locSubring` and `isPowerBounded_divBy`: every element of `D` — in
   particular each fraction `t/s` — is power-bounded, the fact a converse to the continuity
@@ -655,7 +655,7 @@ this is the value that packages them for `isHuberRing_locTopology`.
 
 The topology is not an instance on `S`, so it is introduced in the statement; a consumer supplies
 it the same way, or works under `isHuberRing_locTopology` instead. -/
-noncomputable def locPairOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A)
+noncomputable def localization [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A)
     (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
     (hden : HasDenominatorPower P T s S) :
     letI := locTopology P T s S hden
@@ -671,7 +671,7 @@ noncomputable def locPairOfDefinition [IsTopologicalRing A] (P : PairOfDefinitio
 carrying `locTopology` admits a pair of definition, namely `(D, J)`.
 
 This is what the whole file is for. Being Huber is exactly the existence of *some* pair of
-definition, so the content is the four facts assembled in `locPairOfDefinition`: `D` is open, `J`
+definition, so the content is the four facts assembled in `localization`: `D` is open, `J`
 is finitely generated, and the subspace topology on `D` is the `J`-adic one.
 
 Both the topology and its ring structure are introduced in the statement, because `locTopology` is
@@ -685,7 +685,7 @@ theorem isHuberRing_locTopology [IsTopologicalRing A] (P : PairOfDefinition A) (
     IsHuberRing S :=
   letI := locTopology P T s S hden
   letI := isTopologicalRing_locTopology P T s S hden
-  ⟨⟨locPairOfDefinition P T s S hden⟩⟩
+  ⟨⟨localization P T s S hden⟩⟩
 
 /-! ### A sufficient criterion for continuity -/
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology.lean
@@ -53,6 +53,8 @@ so a consumer holding `A[1/s]` in another presentation can use the topology dire
 * `hasBasis_nhds_zero_locSubring` and `isAdic_locIdeal`: the powers of `J` are a neighbourhood
   basis of zero in `D`, so the subspace topology on `D` is the `J`-adic one. With `fg_locIdeal`
   this completes every condition `TauCeti.Huber.PairOfDefinition` asks of the pair `(D, J)`.
+* `locPairOfDefinition` and `isHuberRing_locTopology`: those conditions assembled, so `Aₛ` under
+  `locTopology` is a Huber ring.
 * `isPowerBounded_of_mem_locSubring` and `isPowerBounded_divBy`: every element of `D` — in
   particular each fraction `t/s` — is power-bounded, the fact a converse to the continuity
   criterion needs.
@@ -641,6 +643,49 @@ theorem isAdic_locIdeal [IsTopologicalRing A] (P : PairOfDefinition A) (T : Fins
       (hbasis.mem_of_mem (i := n) trivial)
   · obtain ⟨n, -, hn⟩ := hbasis.mem_iff.mp hU
     exact ⟨n, hn⟩
+
+/-! ### The localisation is a Huber ring -/
+
+/-- **The pair of definition of `A(T/s)`**: the subring `D` together with the ideal `J = I · D`.
+
+Every field is one of the facts established above — `isOpen_locSubring`, `fg_locIdeal` and
+`isAdic_locIdeal` — so nothing new is proved here. It exists because
+`TauCeti.Huber.PairOfDefinition` is a structure: the facts are what the work above produces, and
+this is the value that packages them for `isHuberRing_locTopology`.
+
+The topology is not an instance on `S`, so it is introduced in the statement; a consumer supplies
+it the same way, or works under `isHuberRing_locTopology` instead. -/
+noncomputable def locPairOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A)
+    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    PairOfDefinition S :=
+  letI := locTopology P T s S hden
+  { ringOfDefinition := locSubring P T s S
+    isOpen_ringOfDefinition := isOpen_locSubring P T s S hden
+    idealOfDefinition := locIdeal P T s S
+    fg_idealOfDefinition := fg_locIdeal P T s S
+    isAdic_idealOfDefinition := isAdic_locIdeal P T s S hden }
+
+/-- **Wedhorn's topological localisation is a Huber ring.** Under the standing hypothesis, `Aₛ`
+carrying `locTopology` admits a pair of definition, namely `(D, J)`.
+
+This is what the whole file is for. Being Huber is exactly the existence of *some* pair of
+definition, so the content is the four facts assembled in `locPairOfDefinition`: `D` is open, `J`
+is finitely generated, and the subspace topology on `D` is the `J`-adic one.
+
+Both the topology and its ring structure are introduced in the statement, because `locTopology` is
+deliberately not registered as an instance — `Aₛ` is an arbitrary localisation and carries no
+topology of its own. -/
+theorem isHuberRing_locTopology [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A)
+    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    letI := isTopologicalRing_locTopology P T s S hden
+    IsHuberRing S :=
+  letI := locTopology P T s S hden
+  letI := isTopologicalRing_locTopology P T s S hden
+  ⟨⟨locPairOfDefinition P T s S hden⟩⟩
 
 /-! ### A sufficient criterion for continuity -/
 


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-0.4-localization-is-huber"}-->

Part of TauCetiProject/TauCetiRoadmap#174.

Layer 0.4 asks for the topological localisation `A(T/s)` of Wedhorn's Proposition and Definition
5.51. Layer 3.1's rational localisation of a Huber *pair* cannot carry an `A⁺` until `A(T/s)` is
known to be Huber, and Layer 4.1 — strongly noetherian Tate rings are sheafy, Wedhorn 8.28 — runs
through 3.1. This supplies the missing step.

## There is no new mathematics here, and that is the point

The file already established every condition. Its own `## Main results` entry said so:

> `hasBasis_nhds_zero_locSubring` and `isAdic_locIdeal`: the powers of `J` are a neighbourhood basis
> of zero in `D`, so the subspace topology on `D` is the `J`-adic one. **With `fg_locIdeal` this
> completes every condition `TauCeti.Huber.PairOfDefinition` asks of the pair `(D, J)`.**

…and then never assembled them. Two declarations close that:

* `PairOfDefinition.localization` — the `PairOfDefinition S` value, used as
  `P.localization T s S hden`. Named after the operation to match the sibling
  `P.completion : PairOfDefinition (Completion A)` in `Completion.lean`; the file's `loc` prefix
  stays on the localization's *components* (`locSubring`, `locIdeal`, `locTopology`), which is what
  it distinguishes. Each of its five fields is a fact already
  on `main`: `locSubring`, `isOpen_locSubring`, `locIdeal`, `fg_locIdeal`, and `isAdic_locIdeal`
  (which landed with #2950).
* `PairOfDefinition.isHuberRing_locTopology` — its consequence, since `IsHuberRing` is by definition the existence of
  *some* pair of definition.

The quoted sentence is updated in the same commit to point at the assembly.

## Why the statements carry `letI`

`locTopology` is deliberately **not** an instance — `Aₛ` is an arbitrary localisation of `A` and
carries no topology of its own, so a consumer has to say which one is meant. Both statements
therefore introduce the topology (and, for `IsHuberRing`, its `IsTopologicalRing`) in the statement
with `letI`, exactly as the file's existing `isAdic_locIdeal`, `isOpen_locSubring` and
`isBounded_locSubring` already do. This is the file's own convention, not a new one.

## Placement

Inserted immediately after the adicity material it consumes, under a new
`/-! ### The localisation is a Huber ring -/` heading, rather than appended at the end of the file
— appending would have put the conclusion past the unrelated "sufficient criterion for continuity"
section. The file is 823 lines after the change (the limit for existing files is 1500).

## Provenance

No source material. Every ingredient is already in this repository; this PR is the assembly.
