### PR TITLE
fix: align merge workflow checkout pins

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -67,7 +67,7 @@ jobs:
     uses: TauCetiProject/TauCetiReview/.github/workflows/merge-only.yml@a66b04d97721565b13c8abe07f750fb1d2959ad5
     with:
       pr: ${{ needs.resolve.outputs.pr }}
-      review_ref: eeed9637d7e2af319a04de8120b35f0c52318f0d
+      review_ref: a66b04d97721565b13c8abe07f750fb1d2959ad5
     # Pass only the App credentials merge-only needs, not all of TauCeti's secrets.
     secrets:
       APP_ID: ${{ secrets.APP_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           python3 scripts/pr_status/test_pr_labels.py
           python3 scripts/pr_status/test_zulip.py
           python3 scripts/test_structure_nudge.py
+          python3 scripts/test_workflow_pins.py
 
       # The two-library split is build convenience, not a trust boundary.
       # This guard is what actually stops the AI-owned library from inheriting

--- a/.github/workflows/merge-sweep.yml
+++ b/.github/workflows/merge-sweep.yml
@@ -35,7 +35,7 @@ jobs:
     uses: TauCetiProject/TauCetiReview/.github/workflows/merge-sweep.yml@a66b04d97721565b13c8abe07f750fb1d2959ad5
     with:
       dry_run: ${{ inputs.dry-run || false }}
-      review_ref: eeed9637d7e2af319a04de8120b35f0c52318f0d
+      review_ref: a66b04d97721565b13c8abe07f750fb1d2959ad5
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/scripts/test_workflow_pins.py
+++ b/scripts/test_workflow_pins.py
@@ -1,0 +1,40 @@
+"""Ensure reusable TauCetiReview workflows execute their pinned checkout.
+
+Run with: python3 scripts/test_workflow_pins.py
+"""
+
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+WORKFLOWS = (
+    ROOT / ".github/workflows/auto-merge.yml",
+    ROOT / ".github/workflows/merge-sweep.yml",
+    ROOT / ".github/workflows/review.yml",
+)
+CALL_PIN = re.compile(
+    r"uses:\s+TauCetiProject/TauCetiReview/\.github/workflows/[^@\s]+@([0-9a-f]{40})"
+)
+CHECKOUT_PIN = re.compile(r"^\s+review_ref:\s+([0-9a-f]{40})\s*$", re.MULTILINE)
+
+
+class WorkflowPins(unittest.TestCase):
+    def test_workflow_and_checkout_pins_match(self):
+        for workflow in WORKFLOWS:
+            with self.subTest(workflow=workflow.name):
+                text = workflow.read_text()
+                call = CALL_PIN.findall(text)
+                checkout = CHECKOUT_PIN.findall(text)
+                self.assertEqual(len(call), 1, f"expected one pinned reusable call in {workflow}")
+                self.assertEqual(len(checkout), 1, f"expected one review_ref in {workflow}")
+                self.assertEqual(
+                    call[0],
+                    checkout[0],
+                    f"{workflow.name} runs one TauCetiReview SHA but checks out another",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR aligns the `review_ref` checkout in the automatic merge and merge-sweep workflows with the immutable TauCetiReview SHA that supplies their reusable workflow. The previous split pin made the workflow call `runner/queue_reservation.py` from a checkout predating that file, breaking queue admission. It also adds a dependency-free post-merge regression test requiring every TauCetiReview reusable-workflow pin to match its `review_ref`.

Tested with `python3 scripts/test_workflow_pins.py` and `git diff --check`.

:robot: Prepared with OpenAI Codex
