### PR TITLE
feat(AdicSpace): the adic spectrum Spa (A, A+)

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
@@ -37,10 +37,11 @@ them: spectrality (Wedhorn Theorem 7.35) is the first such theorem, and it lives
 
 ## Main results
 
-* `TauCeti.ValuationSpectrum.mem_spa_iff` : membership is continuity plus the sub-unit
-  condition on the plus ring.
-* `TauCeti.ValuationSpectrum.spa_subset_cont` and `TauCeti.ValuationSpectrum.spa_antitone` :
-  the spectrum sits inside `Cont A` and shrinks as the plus ring grows.
+* `TauCeti.ValuationSpectrum.spa_def` and `TauCeti.ValuationSpectrum.mem_spa_iff` : the
+  set-level and membership-level characterizations — the definition is not exposed across the
+  module boundary, so these two are the exported interface.
+* `TauCeti.ValuationSpectrum.spa_antitone` : the spectrum shrinks as the plus ring grows. Its
+  inclusion into `Cont A` is `spa_def ▸ Set.inter_subset_left`.
 
 ## References
 
@@ -60,14 +61,19 @@ integral elements is a hypothesis of later theorems, not of the definition. -/
 def spa (Aplus : Subring A) : Set (Spv A) :=
   cont A ∩ {v : Spv A | ∀ a ∈ Aplus, v.toValuativeRel.vle a 1}
 
+/-- The set-level characterization of the adic spectrum: `spa` is the intersection of the
+continuous locus with the sub-unit locus of the plus ring. The definition is not exposed
+across the module boundary, so this equation is how consumers apply set-level results to
+`spa` — for instance `spa_def ▸ Set.inter_subset_left : spa Aplus ⊆ cont A`. -/
+theorem spa_def (Aplus : Subring A) :
+    spa Aplus = cont A ∩ {v : Spv A | ∀ a ∈ Aplus, v.toValuativeRel.vle a 1} := (rfl)
+
+/-- Membership in the adic spectrum is continuity together with the sub-unit condition on the
+plus ring: `v ∈ Spa (A, A⁺)` iff `v` is continuous and `v(a) ≤ 1` for every `a ∈ A⁺`. -/
 @[simp]
 theorem mem_spa_iff (Aplus : Subring A) (v : Spv A) :
     v ∈ spa Aplus ↔ v.IsContinuous ∧ ∀ a ∈ Aplus, v.toValuativeRel.vle a 1 := by
-  rw [spa, Set.mem_inter_iff, mem_cont_iff, Set.mem_ofPred_eq]
-
-/-- The adic spectrum sits inside the continuous locus. -/
-theorem spa_subset_cont (Aplus : Subring A) : spa Aplus ⊆ cont A :=
-  Set.inter_subset_left
+  rw [spa_def, Set.mem_inter_iff, mem_cont_iff, Set.mem_ofPred_eq]
 
 /-- Enlarging the plus ring shrinks the adic spectrum. -/
 theorem spa_antitone : Antitone (spa (A := A)) := fun _ _ hle ↦

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
@@ -8,16 +8,26 @@ module
 public import TauCeti.AlgebraicGeometry.AdicSpace.Cont.Basic
 
 /-!
-# The adic spectrum `Spa (A, A⁺)`
+# The underlying set of the adic spectrum `Spa (A, A⁺)`
 
-**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Definition 7.23.**
+**The set-level construction beneath Wedhorn, *Adic Spaces* (arXiv:1910.05934v1),
+Definition 7.23.**
 
-For a subring `A⁺` of a topological ring `A`, the adic spectrum is the set of continuous points
-of `Spv A` that are sub-unit on `A⁺`:
+For a subring `A⁺` of a commutative ring `A` with a topology, `spa A⁺` is the set of continuous
+points of `Spv A` that are sub-unit on `A⁺`:
 
 ```text
-Spa (A, A⁺) = {v ∈ Cont A ; v(a) ≤ 1 for every a ∈ A⁺}.
+spa A⁺ = {v ∈ cont A ; v(a) ≤ 1 for every a ∈ A⁺}.
 ```
+
+This is stated for arbitrary data — the file assumes `[TopologicalSpace A]` and nothing
+relating the topology to the ring operations, and asks nothing of the subring. It **is**
+Wedhorn's adic spectrum `Spa (A, A⁺)` under the hypotheses his Definition 7.23 carries: `A` a
+Huber ring (so in particular a topological ring, which is also what makes membership in
+`cont A` Wedhorn's Definition 7.7) and `A⁺` a ring of integral elements. Those hypotheses
+enter only where theorems need them — spectrality (Wedhorn Theorem 7.35) is the first such
+theorem, and it lives with the `Spv (A, I)` machinery it consumes, not in this file. This
+mirrors how `cont` itself is defined below its Wedhorn hypotheses.
 
 Following the roadmap's conventions, the plus ring is an explicit `Subring A` argument and the
 spectrum is a `Set (Spv A)`, so a point is a valuation up to equivalence with no chosen value
@@ -25,11 +35,6 @@ group, and the subspace topology is the one the coercion `↥(spa Aplus)` carrie
 in-flight `SpaPoint` of mathlib4#42315 instead bundles a representative valuation with a chosen
 value group — the representation the roadmap warns must be compared before later layers may use
 it; the subspace form here needs no such comparison.)
-
-Nothing here asks `A⁺` to be a ring of integral elements or `A` to be a Huber ring. The
-definition makes sense for any subring, and those hypotheses enter only where theorems need
-them: spectrality (Wedhorn Theorem 7.35) is the first such theorem, and it lives with the
-`Spv (A, I)` machinery it consumes, not in this file.
 
 ## Main definitions
 
@@ -54,10 +59,13 @@ namespace TauCeti.ValuationSpectrum
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A]
 
-/-- **Wedhorn's `Spa (A, A⁺)`** (Definition 7.23): the continuous points of `Spv A` that are
-sub-unit on the subring `A⁺`, as a `Set (Spv A)` — the subspace topology is the one the
-coercion `↥(spa Aplus)` carries. The plus ring is an arbitrary subring: that it is a ring of
-integral elements is a hypothesis of later theorems, not of the definition. -/
+/-- The continuous points of `Spv A` that are sub-unit on the subring `A⁺`, as a
+`Set (Spv A)` — the subspace topology is the one the coercion `↥(spa Aplus)` carries.
+
+For a Huber ring `A` and a ring of integral elements `A⁺` this is **Wedhorn's adic spectrum
+`Spa (A, A⁺)`** (Definition 7.23); the definition itself asks for neither — an arbitrary
+subring of an arbitrary commutative ring with a topology — and the Wedhorn hypotheses enter
+only in later theorems. -/
 def spa (Aplus : Subring A) : Set (Spv A) :=
   cont A ∩ {v : Spv A | ∀ a ∈ Aplus, v.toValuativeRel.vle a 1}
 
@@ -76,8 +84,9 @@ theorem mem_spa_iff (Aplus : Subring A) (v : Spv A) :
   rw [spa_def, Set.mem_inter_iff, mem_cont_iff, Set.mem_ofPred_eq]
 
 /-- Enlarging the plus ring shrinks the adic spectrum. -/
-theorem spa_antitone : Antitone (spa (A := A)) := fun _ _ hle ↦
-  Set.inter_subset_inter_right _ fun _ hv a ha ↦ hv a (hle ha)
+theorem spa_antitone : Antitone (spa (A := A)) := fun _ _ hle ↦ by
+  rw [spa_def, spa_def]
+  exact Set.inter_subset_inter_right _ fun _ hv a ha ↦ hv a (hle ha)
 
 end TauCeti.ValuationSpectrum
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AdicSpace.Cont.Basic
+
+/-!
+# The adic spectrum `Spa (A, A⁺)`
+
+**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Definition 7.23.**
+
+For a subring `A⁺` of a topological ring `A`, the adic spectrum is the set of continuous points
+of `Spv A` that are sub-unit on `A⁺`:
+
+```text
+Spa (A, A⁺) = {v ∈ Cont A ; v(a) ≤ 1 for every a ∈ A⁺}.
+```
+
+Following the roadmap's conventions, the plus ring is an explicit `Subring A` argument and the
+spectrum is a `Set (Spv A)`, so a point is a valuation up to equivalence with no chosen value
+group, and the subspace topology is the one the coercion `↥(spa Aplus)` carries. (Mathlib's
+in-flight `SpaPoint` of mathlib4#42315 instead bundles a representative valuation with a chosen
+value group — the representation the roadmap warns must be compared before later layers may use
+it; the subspace form here needs no such comparison.)
+
+Nothing here asks `A⁺` to be a ring of integral elements or `A` to be a Huber ring. The
+definition makes sense for any subring, and those hypotheses enter only where theorems need
+them: spectrality (Wedhorn Theorem 7.35) is the first such theorem, and it lives with the
+`Spv (A, I)` machinery it consumes, not in this file.
+
+## Main definitions
+
+* `TauCeti.ValuationSpectrum.spa` : the adic spectrum of `(A, A⁺)`, as a `Set (Spv A)`.
+
+## Main results
+
+* `TauCeti.ValuationSpectrum.mem_spa_iff` : membership is continuity plus the sub-unit
+  condition on the plus ring.
+* `TauCeti.ValuationSpectrum.spa_subset_cont` and `TauCeti.ValuationSpectrum.spa_antitone` :
+  the spectrum sits inside `Cont A` and shrinks as the plus ring grows.
+
+## References
+
+* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.23.
+-/
+
+public section
+
+namespace TauCeti.ValuationSpectrum
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A]
+
+/-- **Wedhorn's `Spa (A, A⁺)`** (Definition 7.23): the continuous points of `Spv A` that are
+sub-unit on the subring `A⁺`, as a `Set (Spv A)` — the subspace topology is the one the
+coercion `↥(spa Aplus)` carries. The plus ring is an arbitrary subring: that it is a ring of
+integral elements is a hypothesis of later theorems, not of the definition. -/
+def spa (Aplus : Subring A) : Set (Spv A) :=
+  cont A ∩ {v : Spv A | ∀ a ∈ Aplus, v.toValuativeRel.vle a 1}
+
+@[simp]
+theorem mem_spa_iff (Aplus : Subring A) (v : Spv A) :
+    v ∈ spa Aplus ↔ v.IsContinuous ∧ ∀ a ∈ Aplus, v.toValuativeRel.vle a 1 := by
+  rw [spa, Set.mem_inter_iff, mem_cont_iff, Set.mem_ofPred_eq]
+
+/-- The adic spectrum sits inside the continuous locus. -/
+theorem spa_subset_cont (Aplus : Subring A) : spa Aplus ⊆ cont A :=
+  Set.inter_subset_left
+
+/-- Enlarging the plus ring shrinks the adic spectrum. -/
+theorem spa_antitone : Antitone (spa (A := A)) := fun _ _ hle ↦
+  Set.inter_subset_inter_right _ fun _ hv a ha ↦ hv a (hle ha)
+
+end TauCeti.ValuationSpectrum
+
+end


### PR DESCRIPTION
**The underlying set of the adic spectrum `Spa (A, A⁺)`, as a `Set (Spv A)`** — the set-level
construction beneath Wedhorn Definition 7.23, opening roadmap Layer 2.1 for the sheafiness
campaign (strongly Noetherian Tate rings are sheafy). It is Wedhorn's adic spectrum under his
hypotheses (Huber ring, ring of integral elements), which enter only in later theorems — the
round-2 `documentation` finding sharpened the prose to say exactly this.

```lean
def spa (Aplus : Subring A) : Set (Spv A) :=
  cont A ∩ {v : Spv A | ∀ a ∈ Aplus, v.toValuativeRel.vle a 1}
```

with the set-level characterization (`spa_def` — the definition is unexposed, so this equation
is the consumers' interface, e.g. `spa_def ▸ Set.inter_subset_left` for the inclusion into
`Cont A`), membership (`mem_spa_iff`), and antitonicity in the plus ring (`spa_antitone`). New
file `AdicSpace/Spa/Basic.lean`.

Round 2 addressed: the module/docstring framing no longer identifies the unrestricted
construction with Wedhorn's spectrum (`documentation`), and `spa_antitone` rewrites through
`spa_def` instead of silently unfolding the hidden wrapper (`proof-quality`).

Round 1 addressed: `spa_def` added and `mem_spa_iff` proved through it (`api-design`), the thin
`spa_subset_cont` wrapper deleted in its favour (`reuse` — note the finding's suggested
`simpa [spa]` route cannot work for external consumers, since the definition body is not
exposed across the module boundary; `spa_def` is what makes the deletion sound), and
`mem_spa_iff` documented (`documentation`).

Representation choices follow the roadmap's stated conventions, and one is a deliberate
divergence from an in-flight Mathlib PR, so it is worth recording here:

- **The plus ring is an explicit `Subring A`** ("there is no global typeclass selecting `A⁺`"),
  and the definition asks nothing of it — being a ring of integral elements, like `A` being
  Huber, is a hypothesis of later theorems (spectrality, Theorem 7.35), not of the set.
- **A point is a valuation up to equivalence**: `spa Aplus` is a subset of `Spv A`, with the
  subspace topology through its coercion. mathlib4#42315's in-flight `SpaPoint` instead bundles
  a representative with a chosen value group — the representation the roadmap conventions warn
  "must prove that it gives the same space before it is used by later layers". The subspace
  form here needs no such comparison; when the Mathlib API finalizes, whichever side differs
  adapts.

Where it goes next: Theorem 7.35 (`Spa` is spectral) is the trace argument combining Theorem
7.10 (in flight: #2989/#3009 + the staged assembly) with the pro-constructibility of the
sub-unit locus (#3044); rational subsets and their basis (Layer 2.2) build on this definition.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
(`LINT-ENV: PASS`) — all exit 0, each run separately.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-2.1-spa-definition"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
