### PR TITLE
refactor(Asymptotics): rewrite with sub_add_eq_sub_sub and merge the scaling step

### DIFF
--- a/TauCeti/Analysis/Contour/HigherOrder/Asymptotics.lean
+++ b/TauCeti/Analysis/Contour/HigherOrder/Asymptotics.lean
@@ -311,18 +311,14 @@ theorem antiderivative_diff_at_tangent_target_tendsto_zero
       2 ^ k * (‖γ t - s - (‖γ t - s‖ / ‖T‖ : ℝ) • T‖ / ‖γ t - s‖ ^ k) := by
     filter_upwards [h_ne, h_chord_le_d] with t h_ne hcd
     have hcd' : ‖γ t - (s + (‖γ t - s‖ / ‖T‖ : ℝ) • T)‖ ≤ ‖γ t - s‖ := by
-      rwa [show γ t - (s + (‖γ t - s‖ / ‖T‖ : ℝ) • T) =
-            γ t - s - (‖γ t - s‖ / ‖T‖ : ℝ) • T by ring]
+      rwa [sub_add_eq_sub_sub]
     have h_bound := norm_antiderivative_diff_at_tangent_target_le hk hT h_ne hcd'
-    rw [show ‖γ t - (s + (‖γ t - s‖ / ‖T‖ : ℝ) • T)‖ =
-          ‖γ t - s - (‖γ t - s‖ / ‖T‖ : ℝ) • T‖ by congr 1; ring] at h_bound
+    rw [sub_add_eq_sub_sub] at h_bound
     calc ‖_‖
         ≤ (1 : ℝ) / (‖γ t - s‖ / 2) ^ k *
             ‖γ t - s - (‖γ t - s‖ / ‖T‖ : ℝ) • T‖ := h_bound
-      _ = 2 ^ k / ‖γ t - s‖ ^ k *
-            ‖γ t - s - (‖γ t - s‖ / ‖T‖ : ℝ) • T‖ := by
-          congr 1; rw [div_pow]; field_simp
-      _ = 2 ^ k * (‖γ t - s - (‖γ t - s‖ / ‖T‖ : ℝ) • T‖ / ‖γ t - s‖ ^ k) := by ring
+      _ = 2 ^ k * (‖γ t - s - (‖γ t - s‖ / ‖T‖ : ℝ) • T‖ / ‖γ t - s‖ ^ k) := by
+          rw [div_pow]; field_simp
   exact tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds h_const_ratio
     (Eventually.of_forall fun _ => norm_nonneg _) h_F_diff_le
 


### PR DESCRIPTION
Two pieces of `antiderivative_diff_at_tangent_target_tendsto_zero` restate things that already
have names.

**The chord identity.** The proof twice moves between `γ t - (s + c • T)` and `γ t - s - c • T` —
once to put the chord bound in the shape the pointwise estimate wants, and once to put that
estimate's conclusion back into the shape the outer bound is stated in. Each time it spelled the
identity out inside a `show ... by ring`, the second wrapped in a `congr 1` to get under the norm.
That is `sub_add_eq_sub_sub`, so both are plain rewrites, and the one under the norm needs no
`congr` because the rewrite reaches the argument directly.

**The scaling step.** The closing `calc` went from `1 / (d / 2) ^ k * c` to `2 ^ k / d ^ k * c` and
only then regrouped to `2 ^ k * (c / d ^ k)`, as two steps with the middle form written out in
full. `field_simp` reaches the regrouped form in one step from `div_pow`, and closes the goal
without the trailing `ring` the second step used.

No declaration is added or removed and no statement changes. The proof drops from 40 lines to 36.

The estimates themselves are untouched: the `o(‖γ t - s‖ ^ n)` bound, the `2 ^ k` ratio limit and
the squeeze at the end all carry real content, and the neighbouring `_right` and `_left` corollaries
are unaffected.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
