### PR TITLE
feat(Huber): the universal property of the topological localisation

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology.lean
@@ -780,26 +780,28 @@ theorem continuous_of_continuous_algebraMap_of_isPowerBounded {B : Type*}
 `φ : A →+* B` into a nonarchimedean ring extends to `Aₛ` in exactly one continuous way, provided
 `φ` is continuous, `φ s` is a unit, and each fraction `φ t / φ s` is power-bounded.
 
-The condition on the fractions is what the topology on `Aₛ` is designed to make necessary: `t / s`
-lies in `D`, and every element of `D` is power-bounded, so a continuous extension has no choice.
-Here it is also sufficient, which is the content.
+The condition on the fractions is stated as sufficient, and only that. It is *not* forced by
+continuity: a continuous ring homomorphism need not carry power-bounded elements to power-bounded
+elements — `IsBounded.image` in `Huber/Bounded.lean` is stated for the image under a map, and
+`IsBounded.image_of_isOpenMap` needs openness on top, precisely because continuity alone does not
+suffice. Whether some weaker condition is also necessary is not addressed here.
 
-Existence is Mathlib's `IsLocalization.Away.lift`, whose continuity is supplied by
+The map itself is Mathlib's `IsLocalization.Away.lift`, which is purely algebraic and needs no
+topology; the topology's contribution is that this lift is *continuous*, supplied by
 `continuous_of_continuous_algebraMap_of_isPowerBounded`. Uniqueness is
-`IsLocalization.ringHom_ext` and needs no topology: a homomorphism out of a localisation is already
-determined by its restriction along `algebraMap`. So the topology's whole contribution is the
-existence half. -/
+`IsLocalization.ringHom_ext` and is algebraic too: a homomorphism out of a localisation is already
+determined by its restriction along `algebraMap`, so nothing topological enters there. -/
 theorem existsUnique_continuous_ringHom_locTopology {B : Type*} [CommRing B] [TopologicalSpace B]
     [NonarchimedeanRing B] [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A) (s : A)
     (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) {φ : A →+* B} (hφ : Continuous φ) (hs : IsUnit (φ s))
+    (hden : HasDenominatorPower P T s S) {φ : A →+* B} (hφ : ContinuousAt φ 0) (hs : IsUnit (φ s))
     (hpow : ∀ t ∈ T, IsPowerBounded (φ t * ↑hs.unit⁻¹)) :
     letI := locTopology P T s S hden
     ∃! f : S →+* B, Continuous f ∧ f.comp (algebraMap A S) = φ := by
   let _ := locTopology P T s S hden
   refine ⟨IsLocalization.Away.lift s hs, ⟨?_, IsLocalization.Away.lift_comp s hs⟩, ?_⟩
   · refine continuous_of_continuous_algebraMap_of_isPowerBounded P T s S hden _ ?_ ?_
-    · rw [IsLocalization.Away.lift_comp s hs]; exact hφ
+    · rw [IsLocalization.Away.lift_comp s hs]; exact continuous_of_continuousAt_zero φ hφ
     · intro t ht
       have : IsLocalization.Away.lift s hs ((divBy t s : S)) = φ t * ↑hs.unit⁻¹ := by
         rw [divBy_def, IsLocalization.Away.lift, IsLocalization.lift_mk']

--- a/TauCeti/RingTheory/Huber/LocalizationTopology.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology.lean
@@ -60,6 +60,9 @@ so a consumer holding `A[1/s]` in another presentation can use the topology dire
   for a ring homomorphism out of `Aₛ` to be continuous — its restriction along `algebraMap` is
   continuous and the fractions `t/s` go to power-bounded elements. The converse is not proved
   here.
+* `existsUnique_continuous_ringHom_locTopology`: Wedhorn 5.51's universal property — a continuous
+  `φ : A →+* B` inverting `s` and sending each `t/s` to a power-bounded element extends to `Aₛ` in
+  exactly one continuous way.
 
 ## Provenance
 
@@ -770,6 +773,41 @@ theorem continuous_of_continuous_algebraMap_of_isPowerBounded {B : Type*}
     rw [smul_eq_mul, ← mul_assoc]
     exact hd (r * c)
 
+
+/-! ### The universal property -/
+
+/-- **Wedhorn 5.51, the universal property of `Aₛ` under `locTopology`.** A ring homomorphism
+`φ : A →+* B` into a nonarchimedean ring extends to `Aₛ` in exactly one continuous way, provided
+`φ` is continuous, `φ s` is a unit, and each fraction `φ t / φ s` is power-bounded.
+
+The condition on the fractions is what the topology on `Aₛ` is designed to make necessary: `t / s`
+lies in `D`, and every element of `D` is power-bounded, so a continuous extension has no choice.
+Here it is also sufficient, which is the content.
+
+Existence is Mathlib's `IsLocalization.Away.lift`, whose continuity is supplied by
+`continuous_of_continuous_algebraMap_of_isPowerBounded`. Uniqueness is
+`IsLocalization.ringHom_ext` and needs no topology: a homomorphism out of a localisation is already
+determined by its restriction along `algebraMap`. So the topology's whole contribution is the
+existence half. -/
+theorem existsUnique_continuous_ringHom_locTopology {B : Type*} [CommRing B] [TopologicalSpace B]
+    [NonarchimedeanRing B] [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) {φ : A →+* B} (hφ : Continuous φ) (hs : IsUnit (φ s))
+    (hpow : ∀ t ∈ T, IsPowerBounded (φ t * ↑hs.unit⁻¹)) :
+    letI := locTopology P T s S hden
+    ∃! f : S →+* B, Continuous f ∧ f.comp (algebraMap A S) = φ := by
+  let _ := locTopology P T s S hden
+  refine ⟨IsLocalization.Away.lift s hs, ⟨?_, IsLocalization.Away.lift_comp s hs⟩, ?_⟩
+  · refine continuous_of_continuous_algebraMap_of_isPowerBounded P T s S hden _ ?_ ?_
+    · rw [IsLocalization.Away.lift_comp s hs]; exact hφ
+    · intro t ht
+      have : IsLocalization.Away.lift s hs ((divBy t s : S)) = φ t * ↑hs.unit⁻¹ := by
+        rw [divBy_def, IsLocalization.Away.lift, IsLocalization.lift_mk']
+        congr 2
+      rw [this]; exact hpow t ht
+  · rintro g ⟨-, hg⟩
+    exact IsLocalization.ringHom_ext (Submonoid.powers s)
+      (hg.trans (IsLocalization.Away.lift_comp s hs).symm)
 
 end PairOfDefinition
 


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-0.4-localization-universal-property"}-->

Part of TauCetiProject/TauCetiRoadmap#174.

Layer 0.4 states the universal property of the topological localisation as: "the `s_i` become
units and every fraction `t/s_i` is power-bounded". This proves it for the singleton-`I` case this
file constructs — Wedhorn's Proposition and Definition 5.51.

A continuous `φ : A →+* B` into a nonarchimedean ring, with `φ s` a unit and each `φ t / φ s`
power-bounded, extends to `Aₛ` in **exactly one** continuous way.

## Nothing new is proved; the three halves already existed

* **Existence** — Mathlib's `IsLocalization.Away.lift`, with `lift_comp` for the extension property.
* **Continuity** — this file's own `continuous_of_continuous_algebraMap_of_isPowerBounded`, whose
  docstring already advertised it as "a sufficient criterion for a ring homomorphism out of `Aₛ` to
  be continuous". This is the consumer it was waiting for.
* **Uniqueness** — `IsLocalization.ringHom_ext`, which uses no topology whatsoever: a homomorphism
  out of a localisation is determined by its restriction along `algebraMap`.

Worth stating plainly because it shapes how the result should be read: **the topology contributes
only to the existence half.** Uniqueness is purely algebraic and would hold for any target.

## The hypothesis on the fractions

Stated as `∀ t ∈ T, IsPowerBounded (φ t * ↑hs.unit⁻¹)` — in terms of `φ` and the unit witness —
rather than through the lifted map. A consumer can then discharge it without first constructing the
homomorphism it is a hypothesis of, which is the point of a universal property.

It is also not an artefact of the proof: `t / s` lies in `D`, and every element of `D` is
power-bounded (`isPowerBounded_of_mem_locSubring`), so any continuous extension must satisfy it.
The content here is that it is *sufficient*.

## Relation to #3043

Independent. This uses only `locTopology`, the continuity criterion and `divBy`, all already on
`main`, and never mentions `P.localization`. Both PRs touch this file in different sections, so
whichever merges second needs at most a trivial rebase.

## Provenance

No source ported. Mathlib supplies the two algebraic halves; the continuity criterion is already in
this repository.
