### PR TITLE
refactor(Bernstein): rewrite the density identity backwards instead of a calc

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
@@ -467,15 +467,8 @@ private lemma chafaiDensity_neg_derivWithin_pred (f : ℝ → ℝ)
     nlinarith
   rw [hnp, hsub]
   field_simp [ht.ne', hden]
-  calc
-    -(((-1 : ℝ) ^ (n - 1) * t ^ (n - 2) *
-          iteratedDerivWithin n f (Ici 0) t * t))
-        = -((-1 : ℝ) ^ (n - 1)) * (t ^ (n - 2) * t) *
-            iteratedDerivWithin n f (Ici 0) t := by ring
-    _ = (-1 : ℝ) ^ n * t ^ (n - 1) *
-            iteratedDerivWithin n f (Ici 0) t := by rw [hsign, hpow']
-    _ = iteratedDerivWithin n f (Ici 0) t * (-1 : ℝ) ^ n * t ^ (n - 1) := by
-          ring
+  rw [← hsign, ← hpow']
+  ring
 
 private lemma chafaiRescaled_lintegral_coe_eq_chafaiMeasure_neg_derivWithin
     (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) {n : ℕ} (hn : 2 ≤ n) :


### PR DESCRIPTION
`chafaiDensity_neg_derivWithin_pred` relates the Chafaï density of `-f'` at order `n - 1` to that
of `f` at order `n`. After `field_simp` the goal is an identity between two products, and the only
facts still needed are the two already-named ones: `hsign`, that `-((-1) ^ (n - 1)) = (-1) ^ n`,
and `hpow'`, that `t ^ (n - 2) * t = t ^ (n - 1)`.

It closed with a three-step `calc` in which the first and last steps are pure `ring`
rearrangements — regrouping the factors so `hsign` and `hpow'` line up, then permuting them into
the order the right-hand side uses. Only the middle step does anything, and each of the three
restates the whole product `(-1) ^ … * t ^ … * iteratedDerivWithin n f (Ici 0) t`.

Rewriting the goal *backwards* by the two facts turns the right-hand side into the left-hand
side's shape, and `ring` closes what is left:

```lean
  rw [← hsign, ← hpow']
  ring
```

No declaration is added or removed and no statement changes. The proof drops from 45 lines to 38.

The rest is untouched: the truncated-subtraction bookkeeping (`hiter`, `hfact`, `hnp`, `hsub`) and
the nonvanishing side conditions all carry real content, and `hsign` and `hpow'` are still used —
now as the rewrite itself rather than as a step inside a chain.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
