### PR TITLE
feat(AdicSpace): rational subsets of the adic spectrum

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Basic
+
+/-!
+# Rational subsets of the adic spectrum
+
+**The set-level constructions beneath Wedhorn, *Adic Spaces* (arXiv:1910.05934v1),
+Definition 7.29 and Remark 7.30.**
+
+For a finite numerator set `T` and a denominator `s`, the rational subset is the trace on
+`spa A⁺` of the basic open `Spv(A)(T/s)`:
+
+```text
+R(T/s) = {v ∈ spa A⁺ ; v(t) ≤ v(s) ≠ 0 for every t ∈ T} = spa A⁺ ∩ Spv(A)(T/s).
+```
+
+As with `spa` itself, the definition is stated for arbitrary data: no hypothesis relates the
+topology of `A` to its ring operations, the subring is arbitrary, and Wedhorn's standing
+condition that the ideal `T · A` be open is not assumed. It is Wedhorn's rational subset of
+`Spa (A, A⁺)` under his hypotheses (a Huber ring, a ring of integral elements, `T · A` open);
+the open-ideal condition enters only in the results that need it — the basis claims of
+Definition 7.29 and the quasi-compactness of Theorem 7.35 — none of which is in this file.
+
+What is here is the part of Remark 7.30 that holds with no hypotheses at all, inherited from
+the corresponding facts about `Spv(A)(T/s)`:
+
+* inserting the denominator among the numerators changes nothing (Wedhorn's "one may replace
+  `T` by `T ∪ {s}`"), and
+* rational subsets are stable under finite intersection — Remark 7.30(5), the part Theorem
+  7.35's own proof consumes — with the same product presentation as at the `Spv A` level.
+
+## Main definitions
+
+* `TauCeti.ValuationSpectrum.rationalSubset` : the rational subset `R(T/s)` of `spa A⁺`, as a
+  `Set (Spv A)`.
+
+## Main results
+
+* `TauCeti.ValuationSpectrum.rationalSubset_insert_self` : the denominator may be inserted
+  among the numerators.
+* `TauCeti.ValuationSpectrum.rationalSubset_inter` : **Remark 7.30(5)** — the intersection of
+  two rational subsets is the rational subset of the numerator products over the denominator
+  product.
+
+## References
+
+* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.29 and Remark 7.30.
+-/
+
+public section
+
+namespace TauCeti.ValuationSpectrum
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A]
+
+/-- The rational subset `R(T/s)` of the adic spectrum: the trace on `spa A⁺` of the basic open
+`Spv(A)(T/s)`. Under Wedhorn's hypotheses — a Huber ring, a ring of integral elements, and the
+ideal `T · A` open — this is his Definition 7.29; the definition itself asks for none of them,
+and the open-ideal condition first matters for the basis claims, which are not in this file. -/
+def rationalSubset (Aplus : Subring A) (T : Finset A) (s : A) : Set (Spv A) :=
+  spa Aplus ∩ basicOpenFinset T s
+
+/-- The set-level characterization of a rational subset, mirroring `spa_def`. -/
+theorem rationalSubset_def (Aplus : Subring A) (T : Finset A) (s : A) :
+    rationalSubset Aplus T s = spa Aplus ∩ basicOpenFinset T s := (rfl)
+
+/-- Membership in `R(T/s)`: a point of the adic spectrum where every numerator is dominated by
+the denominator and the denominator is not in the support. -/
+@[simp]
+theorem mem_rationalSubset_iff (Aplus : Subring A) (T : Finset A) (s : A) (v : Spv A) :
+    v ∈ rationalSubset Aplus T s ↔
+      v ∈ spa Aplus ∧ (∀ t ∈ T, v.toValuativeRel.vle t s) ∧ ¬ v.toValuativeRel.vle s 0 := by
+  rw [rationalSubset_def, Set.mem_inter_iff, mem_basicOpenFinset_iff]
+
+open scoped Classical in
+/-- Inserting the denominator among the numerators changes nothing — Wedhorn's "one may
+replace `T` by `T ∪ {s}`" (Definition 7.29). -/
+@[simp]
+theorem rationalSubset_insert_self (Aplus : Subring A) (T : Finset A) (s : A) :
+    rationalSubset Aplus (insert s T) s = rationalSubset Aplus T s := by
+  rw [rationalSubset_def, rationalSubset_def, basicOpenFinset_insert_self]
+
+open scoped Classical Pointwise in
+/-- **Wedhorn Remark 7.30(5)**: rational subsets are stable under finite intersection, with
+the numerator products over the denominator product presenting the intersection. This is the
+form Theorem 7.35's own proof consumes. -/
+theorem rationalSubset_inter (Aplus : Subring A) (T₁ T₂ : Finset A) (s₁ s₂ : A) :
+    rationalSubset Aplus T₁ s₁ ∩ rationalSubset Aplus T₂ s₂
+      = rationalSubset Aplus (insert s₁ T₁ * insert s₂ T₂) (s₁ * s₂) := by
+  rw [rationalSubset_def, rationalSubset_def, rationalSubset_def, ← basicOpenFinset_inter]
+  ext v
+  simp only [Set.mem_inter_iff]
+  tauto
+
+end TauCeti.ValuationSpectrum
+
+end

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset.lean
@@ -88,9 +88,8 @@ theorem rationalSubset_insert_self (Aplus : Subring A) (T : Finset A) (s : A) :
     rationalSubset Aplus (insert s T) s = rationalSubset Aplus T s := by
   rw [rationalSubset_def, rationalSubset_def, basicOpenFinset_insert_self]
 
-/-- A rational subset is open in the subspace `spa A⁺`: its trace along the coercion is the
-trace of the basic open `Spv(A)(T/s)`, whose openness descends along the continuous coercion.
-This is the form basis consumers use, with no unfolding of `rationalSubset`. -/
+/-- The preimage of `R(T/s)` under the coercion of the subtype `spa A⁺` is open: a rational
+subset is relatively open in the adic spectrum. -/
 theorem isOpen_val_preimage_rationalSubset (Aplus : Subring A) (T : Finset A) (s : A) :
     IsOpen (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)) := by
   have h : (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus))

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset.lean
@@ -42,6 +42,8 @@ the corresponding facts about `Spv(A)(T/s)`:
 
 ## Main results
 
+* `TauCeti.ValuationSpectrum.isOpen_val_preimage_rationalSubset` : a rational subset is open
+  in the subspace `spa A⁺`.
 * `TauCeti.ValuationSpectrum.rationalSubset_insert_self` : the denominator may be inserted
   among the numerators.
 * `TauCeti.ValuationSpectrum.rationalSubset_inter` : **Remark 7.30(5)** — the intersection of
@@ -85,6 +87,19 @@ replace `T` by `T ∪ {s}`" (Definition 7.29). -/
 theorem rationalSubset_insert_self (Aplus : Subring A) (T : Finset A) (s : A) :
     rationalSubset Aplus (insert s T) s = rationalSubset Aplus T s := by
   rw [rationalSubset_def, rationalSubset_def, basicOpenFinset_insert_self]
+
+/-- A rational subset is open in the subspace `spa A⁺`: its trace along the coercion is the
+trace of the basic open `Spv(A)(T/s)`, whose openness descends along the continuous coercion.
+This is the form basis consumers use, with no unfolding of `rationalSubset`. -/
+theorem isOpen_val_preimage_rationalSubset (Aplus : Subring A) (T : Finset A) (s : A) :
+    IsOpen (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)) := by
+  have h : (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus))
+      = Subtype.val ⁻¹' basicOpenFinset T s := by
+    ext v
+    simp only [rationalSubset_def, Set.preimage_inter, Set.mem_inter_iff, Set.mem_preimage]
+    exact and_iff_right v.2
+  rw [h]
+  exact (isOpen_basicOpenFinset T s).preimage continuous_subtype_val
 
 open scoped Classical Pointwise in
 /-- **Wedhorn Remark 7.30(5)**: rational subsets are stable under finite intersection, with

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset.lean
@@ -105,6 +105,7 @@ open scoped Classical Pointwise in
 /-- **Wedhorn Remark 7.30(5)**: rational subsets are stable under finite intersection, with
 the numerator products over the denominator product presenting the intersection. This is the
 form Theorem 7.35's own proof consumes. -/
+@[simp]
 theorem rationalSubset_inter (Aplus : Subring A) (T₁ T₂ : Finset A) (s₁ s₂ : A) :
     rationalSubset Aplus T₁ s₁ ∩ rationalSubset Aplus T₂ s₂
       = rationalSubset Aplus (insert s₁ T₁ * insert s₂ T₂) (s₁ * s₂) := by

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset.lean
@@ -27,13 +27,22 @@ condition that the ideal `T · A` be open is not assumed. It is Wedhorn's ration
 the open-ideal condition enters only in the results that need it — the basis claims of
 Definition 7.29 and the quasi-compactness of Theorem 7.35 — none of which is in this file.
 
-What is here is the part of Remark 7.30 that holds with no hypotheses at all, inherited from
-the corresponding facts about `Spv(A)(T/s)`:
+What is here is what holds with no hypotheses at all: the exported interface of the
+definition, the normalizations and the intersection identity inherited from `Spv(A)(T/s)`,
+the whole-space case, containment in `spa A⁺`, and relative openness in the subspace.
 
-* inserting the denominator among the numerators changes nothing (Wedhorn's "one may replace
-  `T` by `T ∪ {s}`"), and
-* rational subsets are stable under finite intersection — Remark 7.30(5), the part Theorem
-  7.35's own proof consumes — with the same product presentation as at the `Spv A` level.
+On the intersection identity, writing `Uᵢ = insert sᵢ Tᵢ` for each numerator set augmented by
+its own denominator (which costs nothing, by `rationalSubset_insert_self`),
+
+```text
+R(T₁/s₁) ∩ R(T₂/s₂) = R(U₁U₂ / s₁s₂).
+```
+
+The augmentation is essential: with the bare products `T₁T₂` the identity is false — for
+`T₁ = {t}` and `T₂ = ∅` the right-hand side would forget the condition `v(t) ≤ v(s₁)`. This
+identity is the set-level half of Wedhorn's Remark 7.30(5); his full statement also says the
+right-hand pair is again *admissible* (`U₁U₂ · A` open), which belongs to the open-ideal
+layer deferred above.
 
 ## Main definitions
 
@@ -42,17 +51,34 @@ the corresponding facts about `Spv(A)(T/s)`:
 
 ## Main results
 
-* `TauCeti.ValuationSpectrum.isOpen_val_preimage_rationalSubset` : a rational subset is open
-  in the subspace `spa A⁺`.
+* `TauCeti.ValuationSpectrum.rationalSubset_def` and
+  `TauCeti.ValuationSpectrum.mem_rationalSubset_iff` : the set-level and membership-level
+  characterizations — the definition is not exposed across the module boundary, so these two
+  are the exported interface, as for `spa_def`/`mem_spa_iff`.
+* `TauCeti.ValuationSpectrum.rationalSubset_subset_spa` : every rational subset is contained
+  in the adic spectrum.
 * `TauCeti.ValuationSpectrum.rationalSubset_insert_self` : the denominator may be inserted
   among the numerators.
-* `TauCeti.ValuationSpectrum.rationalSubset_inter` : **Remark 7.30(5)** — the intersection of
-  two rational subsets is the rational subset of the numerator products over the denominator
-  product.
+* `TauCeti.ValuationSpectrum.rationalSubset_singleton_one` : the whole spectrum is the
+  rational subset `R({1}/1)` — Wedhorn's "`Spa (A, A⁺)` itself is rational".
+* `TauCeti.ValuationSpectrum.isOpen_val_preimage_rationalSubset` : a rational subset is
+  relatively open in the subspace `spa A⁺`.
+* `TauCeti.ValuationSpectrum.rationalSubset_inter` : the intersection identity above — the
+  set-level half of Remark 7.30(5).
 
 ## References
 
 * T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.29 and Remark 7.30.
+* AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at commit
+  `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
+  `projects/AdicSpaces/Adic spaces/RationalSubsets.lean`, is the roadmap's designated prior
+  formalisation of this material and was consulted. It develops the same statements around a
+  standalone `rationalOpen` and an existential `IsRationalSubset` predicate, with the
+  intersection identity conditioned on each denominator lying in its numerator set and the
+  same insert-absorption discharging that condition. Here the rational subset is instead the
+  trace of the merged `Spv A`-level `basicOpenFinset`, so the identities are inherited from
+  `basicOpenFinset_insert_self` and `basicOpenFinset_inter` rather than reproved; nothing was
+  copied.
 -/
 
 public section
@@ -68,7 +94,10 @@ and the open-ideal condition first matters for the basis claims, which are not i
 def rationalSubset (Aplus : Subring A) (T : Finset A) (s : A) : Set (Spv A) :=
   spa Aplus ∩ basicOpenFinset T s
 
-/-- The set-level characterization of a rational subset, mirroring `spa_def`. -/
+/-- The set-level characterization of a rational subset. The definition is not exposed across
+the module boundary, so this equation is how consumers apply set-level results to
+`rationalSubset` — for instance `rationalSubset_def _ _ _ ▸ Set.inter_subset_left` for the
+containment in `spa A⁺`, which `rationalSubset_subset_spa` records. -/
 theorem rationalSubset_def (Aplus : Subring A) (T : Finset A) (s : A) :
     rationalSubset Aplus T s = spa Aplus ∩ basicOpenFinset T s := (rfl)
 
@@ -80,6 +109,11 @@ theorem mem_rationalSubset_iff (Aplus : Subring A) (T : Finset A) (s : A) (v : S
       v ∈ spa Aplus ∧ (∀ t ∈ T, v.toValuativeRel.vle t s) ∧ ¬ v.toValuativeRel.vle s 0 := by
   rw [rationalSubset_def, Set.mem_inter_iff, mem_basicOpenFinset_iff]
 
+/-- Every rational subset is contained in the adic spectrum. -/
+theorem rationalSubset_subset_spa (Aplus : Subring A) (T : Finset A) (s : A) :
+    rationalSubset Aplus T s ⊆ spa Aplus :=
+  rationalSubset_def Aplus T s ▸ Set.inter_subset_left
+
 open scoped Classical in
 /-- Inserting the denominator among the numerators changes nothing — Wedhorn's "one may
 replace `T` by `T ∪ {s}`" (Definition 7.29). -/
@@ -88,30 +122,38 @@ theorem rationalSubset_insert_self (Aplus : Subring A) (T : Finset A) (s : A) :
     rationalSubset Aplus (insert s T) s = rationalSubset Aplus T s := by
   rw [rationalSubset_def, rationalSubset_def, basicOpenFinset_insert_self]
 
+/-- The whole adic spectrum is the rational subset `R({1}/1)` — Wedhorn's observation that
+`Spa (A, A⁺)` itself is rational. The single condition `v(1) ≤ v(1) ≠ 0` holds at every
+point. -/
+@[simp]
+theorem rationalSubset_singleton_one (Aplus : Subring A) :
+    rationalSubset Aplus {1} 1 = spa Aplus := by
+  rw [rationalSubset_def]
+  refine Set.inter_eq_left.mpr fun v _ => (mem_basicOpenFinset_iff _ _ _).mpr ?_
+  exact ⟨fun t ht => by simp [Finset.mem_singleton.mp ht],
+    v.toValuativeRel.not_vle_one_zero⟩
+
 /-- The preimage of `R(T/s)` under the coercion of the subtype `spa A⁺` is open: a rational
 subset is relatively open in the adic spectrum. -/
 theorem isOpen_val_preimage_rationalSubset (Aplus : Subring A) (T : Finset A) (s : A) :
     IsOpen (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)) := by
-  have h : (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus))
-      = Subtype.val ⁻¹' basicOpenFinset T s := by
-    ext v
-    simp only [rationalSubset_def, Set.preimage_inter, Set.mem_inter_iff, Set.mem_preimage]
-    exact and_iff_right v.2
-  rw [h]
+  rw [rationalSubset_def, Set.preimage_inter, Subtype.coe_preimage_self, Set.univ_inter]
   exact (isOpen_basicOpenFinset T s).preimage continuous_subtype_val
 
 open scoped Classical Pointwise in
-/-- **Wedhorn Remark 7.30(5)**: rational subsets are stable under finite intersection, with
-the numerator products over the denominator product presenting the intersection. This is the
-form Theorem 7.35's own proof consumes. -/
+/-- **The set-level half of Wedhorn Remark 7.30(5)**: writing `Uᵢ = insert sᵢ Tᵢ` for each
+numerator set augmented by its own denominator,
+`R(T₁/s₁) ∩ R(T₂/s₂) = R(U₁U₂ / s₁s₂)`. The augmentation costs nothing
+(`rationalSubset_insert_self`) and is essential — with the bare products the identity fails
+for `T₂ = ∅`. Wedhorn's full Remark 7.30(5) additionally says the right-hand pair is again
+admissible; that lives with the deferred open-ideal layer. This identity is the form Theorem
+7.35's own proof consumes. -/
 @[simp]
 theorem rationalSubset_inter (Aplus : Subring A) (T₁ T₂ : Finset A) (s₁ s₂ : A) :
     rationalSubset Aplus T₁ s₁ ∩ rationalSubset Aplus T₂ s₂
       = rationalSubset Aplus (insert s₁ T₁ * insert s₂ T₂) (s₁ * s₂) := by
   rw [rationalSubset_def, rationalSubset_def, rationalSubset_def, ← basicOpenFinset_inter]
-  ext v
-  simp only [Set.mem_inter_iff]
-  tauto
+  exact (Set.inter_inter_distrib_left _ _ _).symm
 
 end TauCeti.ValuationSpectrum
 


### PR DESCRIPTION
**Rational subsets of the adic spectrum** — the set-level constructions beneath Wedhorn
Definition 7.29 and Remark 7.30, continuing roadmap Layer 2.2 for the sheafiness campaign on
top of the just-merged `spa` (#3046).

```lean
def rationalSubset (Aplus : Subring A) (T : Finset A) (s : A) : Set (Spv A) :=
  spa Aplus ∩ basicOpenFinset T s
```

with `rationalSubset_def` (the exported set-level equation, `(rfl)` over the unexposed
definition), the membership characterization, the denominator-insertion normalization
(Wedhorn's "one may replace `T` by `T ∪ {s}`"), and the **set-level half of Remark 7.30(5)** — the intersection identity
`R(T₁/s₁) ∩ R(T₂/s₂) = R(U₁U₂/s₁s₂)` with `Uᵢ = insert sᵢ Tᵢ` (the augmentation is essential:
with bare products the identity fails for `T₂ = ∅`) — each inherited from the corresponding
`Spv A`-level fact. Wedhorn's full 7.30(5) also asserts admissibility of the product pair,
which belongs to the deferred open-ideal layer.

Round 4 rewrote the module prose whole (the drift had accumulated: a false bare-products
description caught by `correctness` with a counterexample, an overclaim on 7.30(5), a stale
overview) and added `rationalSubset_subset_spa`, `rationalSubset_singleton_one` (the whole
spectrum is `R({1}/1)`), the two `reuse` proof golfs, and the AINTLIB relationship in the
References per `attribution`.

Round 1 added `isOpen_val_preimage_rationalSubset` (relative openness in the subspace
`spa A⁺`) and made `rationalSubset_inter` `@[simp]`, matching its `Spv`-level sibling
(`api-design`).

Framing follows the pattern the #3046 review settled: the definition is stated for arbitrary
data (no topological-ring hypothesis, arbitrary subring, no open-ideal condition on `T · A`),
and the docstrings state explicitly that it is Wedhorn's rational subset under his hypotheses.
The open-ideal condition first matters for the basis claims of Definition 7.29 and the
quasi-compactness in Theorem 7.35, which are deliberately not in this file — they come with
the spectrality work that consumes them.

New file `AdicSpace/Spa/RationalSubset.lean`; built and gated against post-bump main
(mathlib f5809ef).

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
(`LINT-ENV: PASS`) — all exit 0, each run separately.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-2.2-rational-subsets"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
