### PR TITLE
refactor(ClassicalTypeD): read the half-total off the sum in one step

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
@@ -857,9 +857,7 @@ private lemma typeDSimpleRootCoordinates_nonneg_of_pairVector (hn : 4 ≤ n) (x 
     have htot : ∑ i : Fin n, x.1 i = 0 := by
       simp [hv, Finset.sum_sub_distrib]
     have hhalf : typeDHalfTotal x = 0 := by
-      have h2 := two_mul_typeDHalfTotal x
-      rw [htot] at h2
-      linarith
+      linarith [two_mul_typeDHalfTotal x, htot]
     simp only [typeDSimpleRootCoordinates]
     split_ifs
     · rw [hv]
@@ -875,9 +873,7 @@ private lemma typeDSimpleRootCoordinates_nonneg_of_pairVector (hn : 4 ≤ n) (x 
     have htot : ∑ i : Fin n, x.1 i = 2 := by
       simp [hv, Finset.sum_add_distrib]
     have hhalf : typeDHalfTotal x = 1 := by
-      have h2 := two_mul_typeDHalfTotal x
-      rw [htot] at h2
-      linarith
+      linarith [two_mul_typeDHalfTotal x, htot]
     simp only [typeDSimpleRootCoordinates]
     split_ifs
     · rw [hv]


### PR DESCRIPTION
`typeDSimpleRootCoordinates_nonneg_of_pairVector` splits on which of the two positive classical
root shapes it is looking at, `e_a - e_b` or `e_a + e_b`. Both branches then compute the half-total
from the coordinate sum, and both do it the same way:

```lean
    have hhalf : typeDHalfTotal x = 0 := by
      have h2 := two_mul_typeDHalfTotal x
      rw [htot] at h2
      linarith
```

`two_mul_typeDHalfTotal` says `2 * typeDHalfTotal x = ∑ i, x.1 i`, and `htot` fixes that sum (`0`
in the first branch, `2` in the second). Naming the first fact and rewriting it by the second only
prepares what `linarith` can already do from the two together, so each branch collapses to
`linarith [two_mul_typeDHalfTotal x, htot]`.

No declaration is added or removed and no statement changes. The proof drops from 41 lines to 37.

I did not factor the two branches into a shared lemma. The natural statement — the half-total is
half the coordinate sum — has exactly these two uses, both inside this proof, and its proof is a
three-line composition, which is the shape `reuse` rejects. Collapsing each branch in place removes
the duplication without adding a declaration.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
