### PR TITLE
feat(AdicSpace): assemble Wedhorn Theorem 7.10

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Cont/OfIdeal.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Cont/OfIdeal.lean
@@ -127,13 +127,9 @@ theorem not_vle_one_of_isContinuous_of_mem_idealOfDefinition (P : PairOfDefiniti
 /-- **Wedhorn Theorem 7.10, the converse inclusion.** A point of `Spv (A, IA)` that is sub-unit
 on the ideal of definition is continuous.
 
-Lemma 7.4 reads membership as cofinality on `IA` or a full characteristic group, and both
-branches funnel into the cofinality engine `isContinuous_of_forall_cofinalValue` at a finite
-generating set of `I`: on the cofinal branch the generators' values are cofinal outright, being
-values on `IA`, and on the other branch the sub-unit bound turns the full characteristic group
-into cofinality through `cofinalValue_of_hasFullCharacteristicGroup`. The sub-unit bound
-quantifies over `I` itself, not over `IA`: over the extension it would not hand the engine its
-`v ≤ 1`. -/
+The sub-unit hypothesis quantifies over the ideal of definition `I` itself — through the
+subring inclusion — and not over the extension `IA`, where the coefficients range over all of
+`A` and the bound would say something strictly weaker. -/
 theorem isContinuous_of_mem_spvOfIdeal_of_forall_vlt_one (P : PairOfDefinition A) {v : Spv A}
     (hmem : v ∈ spvOfIdeal P.extendedIdealOfDefinition
       ⟨P.extendedIdealOfDefinition, P.fg_extendedIdealOfDefinition, rfl⟩)

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Cont/OfIdeal.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Cont/OfIdeal.lean
@@ -20,9 +20,9 @@ Theorem 7.10 identifies `Cont A` inside `Spv (A, IA)` for a pair of definition `
 locus where additionally `v(a) < 1` for every `a ∈ I`. This file proves the two conjuncts of the
 inclusion — a continuous point lies in `Spv (A, IA)`, and it is sub-unit on the ideal of
 definition — then the converse, and assembles the identification
-`cont_eq_spvOfIdeal_inter_setOf_forall_vlt_one`.
+`cont_eq_spvOfIdeal_inter_setOfPred_forall_vlt_one`.
 
-The argument needs no estimate, and it needs no pair of definition either. Membership in
+For the inclusion, the argument needs no estimate and no pair of definition either. Membership in
 `Spv (A, I)` is `cΓ_v(I) = Γ_v`, which by Lemma 7.4 follows from cofinality of `v` at every
 element of a *spanning set*; and continuity turns topological nilpotence into cofinality. So the
 hypothesis that carries the proof is exactly "spanned by topologically nilpotent elements", which
@@ -49,7 +49,7 @@ nilpotent — the nilpotence is a property of the generators, not of the ideal t
   Lemma 7.4 reads membership as cofinality on `IA` or a full characteristic group, and either
   branch feeds the cofinality engine
   `TauCeti.Huber.PairOfDefinition.isContinuous_of_forall_cofinalValue`.
-* `TauCeti.ValuationSpectrum.cont_eq_spvOfIdeal_inter_setOf_forall_vlt_one` : **Theorem 7.10**,
+* `TauCeti.ValuationSpectrum.cont_eq_spvOfIdeal_inter_setOfPred_forall_vlt_one` : **Theorem 7.10**,
   the resulting identification of `Cont A` inside `Spv (A, IA)`.
 
 ## References
@@ -128,8 +128,9 @@ theorem not_vle_one_of_isContinuous_of_mem_idealOfDefinition (P : PairOfDefiniti
 on the ideal of definition is continuous.
 
 The sub-unit hypothesis quantifies over the ideal of definition `I` itself — through the
-subring inclusion — and not over the extension `IA`, where the coefficients range over all of
-`A` and the bound would say something strictly weaker. -/
+subring inclusion — and not over the extension `IA`. The `IA`-form would be the stronger
+demand (the extension contains the image of `I` among much else), and it is not what Theorem
+7.10's right-hand side supplies. -/
 theorem isContinuous_of_mem_spvOfIdeal_of_forall_vlt_one (P : PairOfDefinition A) {v : Spv A}
     (hmem : v ∈ spvOfIdeal P.extendedIdealOfDefinition
       ⟨P.extendedIdealOfDefinition, P.fg_extendedIdealOfDefinition, rfl⟩)
@@ -151,7 +152,7 @@ theorem isContinuous_of_mem_spvOfIdeal_of_forall_vlt_one (P : PairOfDefinition A
 
 /-- **Wedhorn Theorem 7.10.** The continuous points of the valuation spectrum of a Huber ring
 are exactly the points of `Spv (A, IA)` that are sub-unit on the ideal of definition. -/
-theorem cont_eq_spvOfIdeal_inter_setOf_forall_vlt_one (P : PairOfDefinition A) :
+theorem cont_eq_spvOfIdeal_inter_setOfPred_forall_vlt_one (P : PairOfDefinition A) :
     cont A = spvOfIdeal P.extendedIdealOfDefinition
         ⟨P.extendedIdealOfDefinition, P.fg_extendedIdealOfDefinition, rfl⟩ ∩
       {v : Spv A | ∀ a ∈ P.idealOfDefinition,

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Cont/OfIdeal.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Cont/OfIdeal.lean
@@ -8,17 +8,19 @@ module
 public import TauCeti.AlgebraicGeometry.AdicSpace.Cont.Basic
 public import TauCeti.AlgebraicGeometry.AdicSpace.SpvOfIdeal.Basic
 public import TauCeti.RingTheory.Huber.Basic
+import TauCeti.RingTheory.Huber.Continuous.OfCofinal
 import TauCeti.RingTheory.Valuation.Continuous.TopologicallyNilpotent
 
 /-!
-# Continuous points in `Spv (A, I)`: the inclusion half of Theorem 7.10
+# Continuous points in `Spv (A, I)`: Wedhorn's Theorem 7.10
 
-**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Theorem 7.10, the inclusion `Cont A ⊆ Spv(A, IA)`.**
+**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Theorem 7.10.**
 
 Theorem 7.10 identifies `Cont A` inside `Spv (A, IA)` for a pair of definition `(A₀, I)`, as the
-locus where additionally `v(a) < 1` for every `a ∈ I`. This file proves both conjuncts of the
-inclusion: a continuous point lies in `Spv (A, IA)`, and it is sub-unit on the ideal of
-definition.
+locus where additionally `v(a) < 1` for every `a ∈ I`. This file proves the two conjuncts of the
+inclusion — a continuous point lies in `Spv (A, IA)`, and it is sub-unit on the ideal of
+definition — then the converse, and assembles the identification
+`cont_eq_spvOfIdeal_inter_setOf_forall_vlt_one`.
 
 The argument needs no estimate, and it needs no pair of definition either. Membership in
 `Spv (A, I)` is `cΓ_v(I) = Γ_v`, which by Lemma 7.4 follows from cofinality of `v` at every
@@ -43,13 +45,12 @@ nilpotent — the nilpotence is a property of the generators, not of the ideal t
   pair of definition, in membership and subset form.
 * `TauCeti.ValuationSpectrum.not_vle_one_of_isContinuous_of_mem_idealOfDefinition` : the other
   conjunct of the inclusion `⊆` — a continuous point is sub-unit on the ideal of definition.
-
-The converse inclusion, which is the substance of Theorem 7.10, is still not assembled here.
-Its cofinality engine is on `main`, as
-`TauCeti.Huber.PairOfDefinition.isContinuous_of_forall_cofinalValue`, so membership supplies
-continuity through Lemma 7.4's cofinal branch; what remains open is the
-full-characteristic-group branch, where cofinality of the generators' values is not yet
-supplied by anything on `main`.
+* `TauCeti.ValuationSpectrum.isContinuous_of_mem_spvOfIdeal_of_forall_vlt_one` : the converse.
+  Lemma 7.4 reads membership as cofinality on `IA` or a full characteristic group, and either
+  branch feeds the cofinality engine
+  `TauCeti.Huber.PairOfDefinition.isContinuous_of_forall_cofinalValue`.
+* `TauCeti.ValuationSpectrum.cont_eq_spvOfIdeal_inter_setOf_forall_vlt_one` : **Theorem 7.10**,
+  the resulting identification of `Cont A` inside `Spv (A, IA)`.
 
 ## References
 
@@ -122,6 +123,50 @@ theorem not_vle_one_of_isContinuous_of_mem_idealOfDefinition (P : PairOfDefiniti
   have hle : (1 : _) ≤ v.valuation (a : A) := by
     simpa using (valuation_le_iff v 1 (a : A)).mpr h
   exact absurd hle (not_le.mpr hlt)
+
+/-- **Wedhorn Theorem 7.10, the converse inclusion.** A point of `Spv (A, IA)` that is sub-unit
+on the ideal of definition is continuous.
+
+Lemma 7.4 reads membership as cofinality on `IA` or a full characteristic group, and both
+branches funnel into the cofinality engine `isContinuous_of_forall_cofinalValue` at a finite
+generating set of `I`: on the cofinal branch the generators' values are cofinal outright, being
+values on `IA`, and on the other branch the sub-unit bound turns the full characteristic group
+into cofinality through `cofinalValue_of_hasFullCharacteristicGroup`. The sub-unit bound
+quantifies over `I` itself, not over `IA`: over the extension it would not hand the engine its
+`v ≤ 1`. -/
+theorem isContinuous_of_mem_spvOfIdeal_of_forall_vlt_one (P : PairOfDefinition A) {v : Spv A}
+    (hmem : v ∈ spvOfIdeal P.extendedIdealOfDefinition
+      ⟨P.extendedIdealOfDefinition, P.fg_extendedIdealOfDefinition, rfl⟩)
+    (h1 : ∀ a ∈ P.idealOfDefinition, v.toValuativeRel.vlt ((a : P.ringOfDefinition) : A) 1) :
+    v.IsContinuous := by
+  have hlt : ∀ a ∈ P.idealOfDefinition, v.valuation ((a : P.ringOfDefinition) : A) < 1 :=
+    fun a ha ↦ not_le.mp fun hle ↦ h1 a ha ((valuation_le_iff v 1 _).mp (by simpa using hle))
+  obtain ⟨s, hs⟩ := P.fg_idealOfDefinition
+  rw [isContinuous_def]
+  refine P.isContinuous_of_forall_cofinalValue v.valuation hs (fun a ha ↦ (hlt a ha).le) ?_
+  rcases mem_spvOfIdeal_iff_forall_cofinalValue_or_characteristicSubgroup_eq_top.mp hmem
+    with hcof | htop
+  · refine fun t ht ↦ hcof _ ?_
+    rw [P.extendedIdealOfDefinition_def]
+    exact Ideal.mem_map_of_mem _ (hs ▸ Ideal.subset_span ht)
+  · exact fun t ht ↦ P.cofinalValue_of_hasFullCharacteristicGroup v.valuation
+      (hasFullCharacteristicGroup_iff_characteristicSubgroup_eq_top.mpr htop) hlt
+      (hs ▸ Ideal.subset_span ht)
+
+/-- **Wedhorn Theorem 7.10.** The continuous points of the valuation spectrum of a Huber ring
+are exactly the points of `Spv (A, IA)` that are sub-unit on the ideal of definition. -/
+theorem cont_eq_spvOfIdeal_inter_setOf_forall_vlt_one (P : PairOfDefinition A) :
+    cont A = spvOfIdeal P.extendedIdealOfDefinition
+        ⟨P.extendedIdealOfDefinition, P.fg_extendedIdealOfDefinition, rfl⟩ ∩
+      {v : Spv A | ∀ a ∈ P.idealOfDefinition,
+        v.toValuativeRel.vlt ((a : P.ringOfDefinition) : A) 1} := by
+  ext v
+  constructor
+  · intro hv
+    exact ⟨cont_subset_spvOfIdeal_extendedIdealOfDefinition P hv, fun a ha ↦
+      not_vle_one_of_isContinuous_of_mem_idealOfDefinition P ((mem_cont_iff v).mp hv) ha⟩
+  · rintro ⟨hmem, h1⟩
+    exact (mem_cont_iff v).mpr (isContinuous_of_mem_spvOfIdeal_of_forall_vlt_one P hmem h1)
 
 end TauCeti.ValuationSpectrum
 


### PR DESCRIPTION
**Wedhorn Theorem 7.10, assembled.** The converse inclusion and the resulting identification
of `Cont A` inside `Spv (A, IA)`:

```lean
theorem isContinuous_of_mem_spvOfIdeal_of_forall_vlt_one (P : PairOfDefinition A) {v : Spv A}
    (hmem : v ∈ spvOfIdeal P.extendedIdealOfDefinition ⟨_, P.fg_extendedIdealOfDefinition, rfl⟩)
    (h1 : ∀ a ∈ P.idealOfDefinition, v.toValuativeRel.vlt ((a : P.ringOfDefinition) : A) 1) :
    v.IsContinuous

theorem cont_eq_spvOfIdeal_inter_setOfPred_forall_vlt_one (P : PairOfDefinition A) :
    cont A = spvOfIdeal P.extendedIdealOfDefinition ⟨_, P.fg_extendedIdealOfDefinition, rfl⟩ ∩
      {v : Spv A | ∀ a ∈ P.idealOfDefinition, v.toValuativeRel.vlt ((a : P.ringOfDefinition) : A) 1}
```

The converse case-splits Lemma 7.4
(`mem_spvOfIdeal_iff_forall_cofinalValue_or_characteristicSubgroup_eq_top`) and funnels both
branches into the cofinality engine `isContinuous_of_forall_cofinalValue` (#2959) at a finite
generating set of `I`: on the cofinal branch the generators' values are cofinal outright as
values on `IA`; on the full-characteristic-group branch the sub-unit bound turns the
characteristic group into cofinality through `cofinalValue_of_hasFullCharacteristicGroup`
(#3009, merged today). The sub-unit hypothesis quantifies over `I` itself, not `IA` — over the
extension it would not hand the engine its `v ≤ 1`. The identification then combines the two
inclusion conjuncts already on `main` (#2947, #2989) with the converse.

Statement forms: the sub-unit conditions use `ValuativeRel.vlt`, definitionally `¬ vle` — so
they compose with #2989's `¬ vle` conjunct by `rfl` and match the closedness set of #2987 for
Corollary 7.12, which follows next. The cofinal branch rewrites through
`extendedIdealOfDefinition_def` (the definition is unexposed, so the defeq route is closed —
the `(rfl)` unfolding lemma exists for exactly this).

The module docstring's "the converse inclusion … is still not assembled here" paragraph is
retired in the same diff, and the module is retitled to cover the whole theorem.

This closes roadmap Layer 1.5's Theorem 7.10 target; Corollary 7.12 (closedness of `Cont A`,
via #2987) is the remaining 1.5 item and follows directly on this.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
(`LINT-ENV: PASS`) — all exit 0, each run separately, on this head atop current `main`.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-1.5-thm-7.10-assembly"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
