### PR TITLE
refactor: give the Lax-Milgram API dot notation on IsCoercive

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/LaxMilgram.lean
+++ b/TauCeti/Analysis/InnerProductSpace/LaxMilgram.lean
@@ -39,8 +39,6 @@ public section
 
 noncomputable section
 
-namespace TauCeti
-
 open scoped InnerProductSpace
 
 namespace IsCoercive
@@ -151,5 +149,3 @@ theorem exists_forall_eq (hB : IsCoercive B) (ℓ : StrongDual ℝ V) :
   (existsUnique_forall_eq hB ℓ).exists
 
 end IsCoercive
-
-end TauCeti


### PR DESCRIPTION
This PR drops the enclosing `namespace TauCeti` from `Analysis/InnerProductSpace/LaxMilgram.lean`, so that its fifteen declarations sit directly in `IsCoercive`.

Every declaration in the file takes `(hB : IsCoercive B)` as its first explicit argument, where `IsCoercive` is Mathlib's (`Analysis/Normed/Operator/NormedSpace.lean`). Under the enclosing namespace they were `TauCeti.IsCoercive.solutionOfInner` and so on, so `hB.solutionOfInner F` did not elaborate and every use had to spell out the full path. The file's own module docstring already lists them as `IsCoercive.solutionOfInner`, `IsCoercive.apply_solutionOfInner_eq_inner` and so on, without the prefix, so the wrapper was already inconsistent with the documentation.

The convention this follows: material goes in the `TauCeti` namespace, except when it is dot notation on something already defined in Lean or Mathlib, which is what this file is throughout. No declaration is renamed and no proof changes; nothing imports this module, so there are no call sites to update.

Roadmap: none

🤖 Prepared with Claude Code