### PR TITLE
feat(SimplicialComplex): complete dimension bounds API

### DIFF
--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Dimension.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Dimension.lean
@@ -46,7 +46,7 @@ roadmap (`TauCetiRoadmap/GeometricTopology/README.md`, layer 11) asks for on top
   finite dimension means that they have a uniform natural-number bound.
 * `TauCeti.PreAbstractSimplicialComplex.dimension_le_card_sub_one`: a finite set containing every
   face gives an explicit dimension bound.
-* `TauCeti.PreAbstractSimplicialComplex.dimension_eq_top_of_infinite`: the full complex on an
+* `TauCeti.PreAbstractSimplicialComplex.dimension_top_eq_top_of_infinite`: the full complex on an
   infinite vertex type has infinite dimension.
 * `TauCeti.PreAbstractSimplicialComplex.dimension_simplex` /
   `TauCeti.PreAbstractSimplicialComplex.dimension_simplexBoundary`: the dimensions of the standard
@@ -155,7 +155,7 @@ theorem dimension_lt_top_of_finite [Finite ι] : dimension K < ⊤ := by
 
 /-- The full complex on an infinite vertex type has infinite dimension. -/
 @[simp]
-theorem dimension_eq_top_of_infinite [Infinite ι] :
+theorem dimension_top_eq_top_of_infinite [Infinite ι] :
     dimension (⊤ : PreAbstractSimplicialComplex ι) = ⊤ := by
   rw [dimension_eq_top_iff]
   intro n
@@ -275,11 +275,11 @@ theorem dimension_lt_top_of_finite [Finite ι] : dimension K < ⊤ := by
 
 /-- The full abstract simplicial complex on an infinite vertex type has infinite dimension. -/
 @[simp]
-theorem dimension_eq_top_of_infinite [Infinite ι] :
+theorem dimension_top_eq_top_of_infinite [Infinite ι] :
     dimension (⊤ : AbstractSimplicialComplex ι) = ⊤ := by
   rw [← dimension_toPreAbstractSimplicialComplex,
     _root_.AbstractSimplicialComplex.top_toPreAbstractSimplicialComplex]
-  exact PreAbstractSimplicialComplex.dimension_eq_top_of_infinite
+  exact PreAbstractSimplicialComplex.dimension_top_eq_top_of_infinite
 
 end AbstractSimplicialComplex
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Dimension.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Dimension.lean
@@ -41,6 +41,13 @@ roadmap (`TauCetiRoadmap/GeometricTopology/README.md`, layer 11) asks for on top
 * `TauCeti.PreAbstractSimplicialComplex.dimension_mono`: dimension is monotone in the complex.
 * `TauCeti.PreAbstractSimplicialComplex.dimension_eq_bot_iff`: only the void complex has dimension
   `⊥`.
+* `TauCeti.PreAbstractSimplicialComplex.dimension_eq_top_iff` /
+  `dimension_lt_top_iff`: infinite dimension means that face cardinalities are unbounded, while
+  finite dimension means that they have a uniform natural-number bound.
+* `TauCeti.PreAbstractSimplicialComplex.dimension_le_card_sub_one`: a finite set containing every
+  face gives an explicit dimension bound.
+* `TauCeti.PreAbstractSimplicialComplex.dimension_top_of_infinite`: the full complex on an infinite
+  vertex type has infinite dimension.
 * `TauCeti.PreAbstractSimplicialComplex.dimension_simplex` /
   `TauCeti.PreAbstractSimplicialComplex.dimension_simplexBoundary`: the dimensions of the standard
   simplex on `V` (namely `V.card - 1`) and of its boundary (namely `V.card - 2`).
@@ -90,6 +97,68 @@ theorem dimension_eq_bot_iff : dimension K = ⊥ ↔ K = ⊥ := by
   have hle := le_dimension hσ
   rw [h] at hle
   exact absurd (le_bot_iff.mp hle) (WithBot.natCast_ne_bot _)
+
+/-- A complex has infinite dimension exactly when its face cardinalities are unbounded. -/
+theorem dimension_eq_top_iff :
+    dimension K = ⊤ ↔ ∀ n : ℕ, ∃ σ ∈ K, n ≤ σ.card := by
+  constructor
+  · intro h n
+    rw [dimension] at h
+    obtain ⟨σ, hσ⟩ := (iSup_eq_top.mp h) (n : WithBot ℕ∞)
+      (WithBot.coe_lt_coe.mpr (ENat.natCast_lt_top n))
+    obtain ⟨hσK, hnσ⟩ := lt_iSup_iff.mp hσ
+    refine ⟨σ, hσK, ?_⟩
+    have : n < σ.card - 1 := by exact_mod_cast hnσ
+    omega
+  · intro h
+    rw [ENat.WithBot.eq_top_iff_forall_ge]
+    intro n
+    obtain ⟨σ, hσK, hcard⟩ := h (n + 1)
+    apply le_trans (b := ((σ.card - 1 : ℕ) : WithBot ℕ∞))
+    · exact_mod_cast (by omega : n ≤ σ.card - 1)
+    · exact le_dimension hσK
+
+/-- A complex has dimension below `⊤` exactly when its face cardinalities have a uniform natural
+number bound. -/
+theorem dimension_lt_top_iff :
+    dimension K < ⊤ ↔ ∃ n : ℕ, ∀ σ ∈ K, σ.card ≤ n := by
+  rw [lt_top_iff_ne_top, Ne, dimension_eq_top_iff]
+  constructor
+  · intro h
+    push Not at h
+    obtain ⟨n, hn⟩ := h
+    exact ⟨n, fun σ hσ => Nat.le_of_lt (hn σ hσ)⟩
+  · rintro ⟨n, hn⟩ h
+    obtain ⟨σ, hσK, hcard⟩ := h (n + 1)
+    exact (Nat.not_succ_le_self n) (hcard.trans (hn σ hσK))
+
+/-- If every face of a complex is contained in a finite set `V`, then its dimension is at most
+`V.card - 1`. -/
+theorem dimension_le_card_sub_one {V : Finset ι} (hV : ∀ σ ∈ K, σ ⊆ V) :
+    dimension K ≤ ((V.card - 1 : ℕ) : WithBot ℕ∞) := by
+  rw [dimension_le_iff]
+  intro σ hσ
+  exact_mod_cast Nat.sub_le_sub_right (Finset.card_le_card (hV σ hσ)) 1
+
+/-- A complex carried by a finite set of vertices has dimension below `⊤`. -/
+theorem dimension_lt_top_of_finite_vertices {V : Finset ι} (hV : ∀ σ ∈ K, σ ⊆ V) :
+    dimension K < ⊤ :=
+  (dimension_le_card_sub_one hV).trans_lt
+    (WithBot.coe_lt_coe.mpr (ENat.natCast_lt_top (V.card - 1)))
+
+/-- A complex on a finite vertex type has dimension below `⊤`. -/
+theorem dimension_lt_top_of_finite [Finite ι] : dimension K < ⊤ := by
+  let _ := Fintype.ofFinite ι
+  exact dimension_lt_top_of_finite_vertices (V := Finset.univ) fun _ _ => Finset.subset_univ _
+
+/-- The full complex on an infinite vertex type has infinite dimension. -/
+theorem dimension_top_of_infinite [Infinite ι] :
+    dimension (⊤ : PreAbstractSimplicialComplex ι) = ⊤ := by
+  rw [dimension_eq_top_iff]
+  intro n
+  obtain ⟨σ, hcard⟩ := Infinite.exists_subset_card_eq ι (n + 1)
+  refine ⟨σ, Finset.card_pos.mp (by omega), ?_⟩
+  omega
 
 /-- The dimension of the standard simplex on a nonempty vertex set `V` is `V.card - 1`. -/
 @[simp]
@@ -151,6 +220,38 @@ theorem dimension_mono (h : K ≤ L) : dimension K ≤ dimension L :=
   PreAbstractSimplicialComplex.dimension_mono
     ((_root_.AbstractSimplicialComplex.toPreAbstractSimplicialComplex_le_iff
       (K := K) (L := L)).mpr h)
+
+/-- An abstract simplicial complex has infinite dimension exactly when its face cardinalities are
+unbounded. -/
+theorem dimension_eq_top_iff :
+    dimension K = ⊤ ↔ ∀ n : ℕ, ∃ σ ∈ K, n ≤ σ.card := by
+  exact PreAbstractSimplicialComplex.dimension_eq_top_iff
+
+/-- An abstract simplicial complex has dimension below `⊤` exactly when its face cardinalities have
+a uniform natural-number bound. -/
+theorem dimension_lt_top_iff :
+    dimension K < ⊤ ↔ ∃ n : ℕ, ∀ σ ∈ K, σ.card ≤ n := by
+  exact PreAbstractSimplicialComplex.dimension_lt_top_iff
+
+/-- If every face of an abstract simplicial complex is contained in a finite set `V`, then its
+dimension is at most `V.card - 1`. -/
+theorem dimension_le_card_sub_one {V : Finset ι} (hV : ∀ σ ∈ K, σ ⊆ V) :
+    dimension K ≤ ((V.card - 1 : ℕ) : WithBot ℕ∞) :=
+  PreAbstractSimplicialComplex.dimension_le_card_sub_one hV
+
+/-- An abstract simplicial complex carried by a finite set of vertices has dimension below `⊤`. -/
+theorem dimension_lt_top_of_finite_vertices {V : Finset ι} (hV : ∀ σ ∈ K, σ ⊆ V) :
+    dimension K < ⊤ :=
+  PreAbstractSimplicialComplex.dimension_lt_top_of_finite_vertices hV
+
+/-- An abstract simplicial complex on a finite vertex type has dimension below `⊤`. -/
+theorem dimension_lt_top_of_finite [Finite ι] : dimension K < ⊤ :=
+  PreAbstractSimplicialComplex.dimension_lt_top_of_finite
+
+/-- The full abstract simplicial complex on an infinite vertex type has infinite dimension. -/
+theorem dimension_top_of_infinite [Infinite ι] :
+    dimension (⊤ : AbstractSimplicialComplex ι) = ⊤ :=
+  PreAbstractSimplicialComplex.dimension_top_of_infinite
 
 end AbstractSimplicialComplex
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Dimension.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Dimension.lean
@@ -46,8 +46,8 @@ roadmap (`TauCetiRoadmap/GeometricTopology/README.md`, layer 11) asks for on top
   finite dimension means that they have a uniform natural-number bound.
 * `TauCeti.PreAbstractSimplicialComplex.dimension_le_card_sub_one`: a finite set containing every
   face gives an explicit dimension bound.
-* `TauCeti.PreAbstractSimplicialComplex.dimension_top_of_infinite`: the full complex on an infinite
-  vertex type has infinite dimension.
+* `TauCeti.PreAbstractSimplicialComplex.dimension_eq_top_of_infinite`: the full complex on an
+  infinite vertex type has infinite dimension.
 * `TauCeti.PreAbstractSimplicialComplex.dimension_simplex` /
   `TauCeti.PreAbstractSimplicialComplex.dimension_simplexBoundary`: the dimensions of the standard
   simplex on `V` (namely `V.card - 1`) and of its boundary (namely `V.card - 2`).
@@ -99,6 +99,7 @@ theorem dimension_eq_bot_iff : dimension K = ⊥ ↔ K = ⊥ := by
   exact absurd (le_bot_iff.mp hle) (WithBot.natCast_ne_bot _)
 
 /-- A complex has infinite dimension exactly when its face cardinalities are unbounded. -/
+@[simp]
 theorem dimension_eq_top_iff :
     dimension K = ⊤ ↔ ∀ n : ℕ, ∃ σ ∈ K, n ≤ σ.card := by
   constructor
@@ -120,6 +121,7 @@ theorem dimension_eq_top_iff :
 
 /-- A complex has dimension below `⊤` exactly when its face cardinalities have a uniform natural
 number bound. -/
+@[simp]
 theorem dimension_lt_top_iff :
     dimension K < ⊤ ↔ ∃ n : ℕ, ∀ σ ∈ K, σ.card ≤ n := by
   rw [lt_top_iff_ne_top, Ne, dimension_eq_top_iff]
@@ -152,7 +154,8 @@ theorem dimension_lt_top_of_finite [Finite ι] : dimension K < ⊤ := by
   exact dimension_lt_top_of_finite_vertices (V := Finset.univ) fun _ _ => Finset.subset_univ _
 
 /-- The full complex on an infinite vertex type has infinite dimension. -/
-theorem dimension_top_of_infinite [Infinite ι] :
+@[simp]
+theorem dimension_eq_top_of_infinite [Infinite ι] :
     dimension (⊤ : PreAbstractSimplicialComplex ι) = ⊤ := by
   rw [dimension_eq_top_iff]
   intro n
@@ -223,35 +226,60 @@ theorem dimension_mono (h : K ≤ L) : dimension K ≤ dimension L :=
 
 /-- An abstract simplicial complex has infinite dimension exactly when its face cardinalities are
 unbounded. -/
+@[simp]
 theorem dimension_eq_top_iff :
     dimension K = ⊤ ↔ ∀ n : ℕ, ∃ σ ∈ K, n ≤ σ.card := by
-  exact PreAbstractSimplicialComplex.dimension_eq_top_iff
+  rw [← dimension_toPreAbstractSimplicialComplex,
+    PreAbstractSimplicialComplex.dimension_eq_top_iff]
+  constructor
+  · intro h n
+    obtain ⟨σ, hσ, hn⟩ := h n
+    exact ⟨σ, mem_toPreAbstractSimplicialComplex.mp hσ, hn⟩
+  · intro h n
+    obtain ⟨σ, hσ, hn⟩ := h n
+    exact ⟨σ, mem_toPreAbstractSimplicialComplex.mpr hσ, hn⟩
 
 /-- An abstract simplicial complex has dimension below `⊤` exactly when its face cardinalities have
 a uniform natural-number bound. -/
+@[simp]
 theorem dimension_lt_top_iff :
     dimension K < ⊤ ↔ ∃ n : ℕ, ∀ σ ∈ K, σ.card ≤ n := by
-  exact PreAbstractSimplicialComplex.dimension_lt_top_iff
+  rw [← dimension_toPreAbstractSimplicialComplex,
+    PreAbstractSimplicialComplex.dimension_lt_top_iff]
+  constructor
+  · rintro ⟨n, hn⟩
+    exact ⟨n, fun σ hσ => hn σ (mem_toPreAbstractSimplicialComplex.mpr hσ)⟩
+  · rintro ⟨n, hn⟩
+    exact ⟨n, fun σ hσ => hn σ (mem_toPreAbstractSimplicialComplex.mp hσ)⟩
 
 /-- If every face of an abstract simplicial complex is contained in a finite set `V`, then its
 dimension is at most `V.card - 1`. -/
 theorem dimension_le_card_sub_one {V : Finset ι} (hV : ∀ σ ∈ K, σ ⊆ V) :
-    dimension K ≤ ((V.card - 1 : ℕ) : WithBot ℕ∞) :=
-  PreAbstractSimplicialComplex.dimension_le_card_sub_one hV
+    dimension K ≤ ((V.card - 1 : ℕ) : WithBot ℕ∞) := by
+  rw [← dimension_toPreAbstractSimplicialComplex]
+  apply PreAbstractSimplicialComplex.dimension_le_card_sub_one
+  intro σ hσ
+  exact hV σ (mem_toPreAbstractSimplicialComplex.mp hσ)
 
 /-- An abstract simplicial complex carried by a finite set of vertices has dimension below `⊤`. -/
 theorem dimension_lt_top_of_finite_vertices {V : Finset ι} (hV : ∀ σ ∈ K, σ ⊆ V) :
-    dimension K < ⊤ :=
-  PreAbstractSimplicialComplex.dimension_lt_top_of_finite_vertices hV
+    dimension K < ⊤ := by
+  rw [← dimension_toPreAbstractSimplicialComplex]
+  exact PreAbstractSimplicialComplex.dimension_lt_top_of_finite_vertices (V := V)
+    fun σ hσ => hV σ (mem_toPreAbstractSimplicialComplex.mp hσ)
 
 /-- An abstract simplicial complex on a finite vertex type has dimension below `⊤`. -/
-theorem dimension_lt_top_of_finite [Finite ι] : dimension K < ⊤ :=
-  PreAbstractSimplicialComplex.dimension_lt_top_of_finite
+theorem dimension_lt_top_of_finite [Finite ι] : dimension K < ⊤ := by
+  rw [← dimension_toPreAbstractSimplicialComplex]
+  exact PreAbstractSimplicialComplex.dimension_lt_top_of_finite
 
 /-- The full abstract simplicial complex on an infinite vertex type has infinite dimension. -/
-theorem dimension_top_of_infinite [Infinite ι] :
-    dimension (⊤ : AbstractSimplicialComplex ι) = ⊤ :=
-  PreAbstractSimplicialComplex.dimension_top_of_infinite
+@[simp]
+theorem dimension_eq_top_of_infinite [Infinite ι] :
+    dimension (⊤ : AbstractSimplicialComplex ι) = ⊤ := by
+  rw [← dimension_toPreAbstractSimplicialComplex,
+    _root_.AbstractSimplicialComplex.top_toPreAbstractSimplicialComplex]
+  exact PreAbstractSimplicialComplex.dimension_eq_top_of_infinite
 
 end AbstractSimplicialComplex
 


### PR DESCRIPTION
This PR characterizes infinite-dimensional complexes by unbounded face cardinalities, characterizes finite dimension by a uniform cardinality bound, and supplies explicit bounds for complexes carried by finitely many vertices. It also computes the full complex on an infinite vertex type and mirrors the API for abstract simplicial complexes. The full library build, lint ratchet, axiom audit, and module-system audit pass.

:robot: Prepared with OpenAI Codex