### PR TITLE
refactor: align the Hermite files with their upstream form

### DIFF
--- a/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
@@ -40,8 +40,10 @@ open Polynomial
 
 /-- **Lowering (derivative) identity for the Hermite polynomials.** Differentiating the
 `(n + 1)`-st probabilists' Hermite polynomial lowers the index:
-`H'_{n+1} = (n + 1) · Hₙ`. -/
-@[simp]
+`H'_{n+1} = (n + 1) · Hₙ`.
+
+This is not a `simp` lemma because its left-hand side is already reduced by the `n`-indexed
+form `Polynomial.derivative_hermite`. -/
 theorem _root_.Polynomial.derivative_hermite_succ (n : ℕ) :
     derivative (hermite (n + 1)) = (n + 1) • hermite n := by
   induction n with

--- a/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
@@ -30,6 +30,13 @@ content behind the weighted-pairing integration-by-parts recursion
 recurrence is the standard form `Hₙ₊₁ = X·Hₙ - n·Hₙ₋₁` that orthogonal-polynomial arguments
 consume. The parity theorem records `Hₙ(-x) = (-1)ⁿ Hₙ(x)` over any commutative ring. They mirror
 Mathlib's existing Hermite file and are stated in the `Polynomial` namespace as upstream candidates.
+
+## References
+
+* [Mathlib PR #42724](https://github.com/leanprover-community/mathlib4/pull/42724)
+  (Kim Morrison) — the draft upstream adaptation of this file and of `GeneratingFunction.lean`;
+  the removal of `@[simp]` from `Polynomial.derivative_hermite_succ` here follows the
+  simp-normal-form analysis made for that PR.
 -/
 
 public section

--- a/TauCeti/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
@@ -8,9 +8,7 @@ module
 public import Mathlib.Analysis.Complex.TaylorSeries
 public import Mathlib.Analysis.Calculus.Deriv.Polynomial
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
-public import Mathlib.Analysis.Complex.Exponential
 public import Mathlib.RingTheory.Polynomial.Hermite.Basic
-public import Mathlib.Algebra.Polynomial.AlgebraMap
 
 /-!
 # The exponential generating function of the probabilists' Hermite polynomials
@@ -40,9 +38,11 @@ complex differentiable everywhere, Mathlib's `Complex.hasSum_taylorSeries_of_ent
 its Taylor series about `0` at every point, which is exactly the summability statement of the
 generating function at an arbitrary complex `t`.
 
-The primary statement is the complex `HasSum` form `TauCeti.hasSum_hermite_generating_function`,
-which is where the analytic content actually lives; the real `tsum` form
-`TauCeti.hermite_generating_function` (the roadmap target A1) follows from it by casting `ℝ → ℂ`.
+The primary statement is the complex `HasSum` form
+`Polynomial.hasSum_hermite_generating_function`, which is where the analytic content actually
+lives; the real `tsum` form `Polynomial.hermite_generating_function` (the roadmap target A1)
+follows from it by casting `ℝ → ℂ`. Both are stated in the `Polynomial` namespace, matching the
+existing Hermite API, as upstream candidates.
 -/
 
 public section
@@ -103,7 +103,7 @@ For all complex `x` and `t`, the family `Hₙ(x) · tⁿ / n!` is summable with 
 This is the analytic heart of the identity: it carries the summability that the `tsum` form
 `hermite_generating_function` discards, and it holds over all of `ℂ` (the real case is a
 specialization by casting). -/
-theorem hasSum_hermite_generating_function (x t : ℂ) :
+theorem _root_.Polynomial.hasSum_hermite_generating_function (x t : ℂ) :
     HasSum (fun n : ℕ => aeval x (hermite n) * t ^ n / (n.factorial : ℂ))
       (Complex.exp (x * t - t ^ 2 / 2)) := by
   -- The entire function `f z = exp (x·z - z²/2)` on the complex plane.
@@ -136,7 +136,7 @@ and `t`,
 `∑' n, Hₙ(x) · tⁿ / n! = exp (x · t - t² / 2)`,
 where `Hₙ = Polynomial.hermite n`. This is target **A1** of the `OrthogonalL2Bases` roadmap; it is
 the real specialization of `hasSum_hermite_generating_function`. -/
-theorem hermite_generating_function (x t : ℝ) :
+theorem _root_.Polynomial.hermite_generating_function (x t : ℝ) :
     ∑' n : ℕ, aeval x (hermite n) * t ^ n / (n.factorial : ℝ)
       = Real.exp (x * t - t ^ 2 / 2) := by
   -- Compatibility of `aeval` with the coercion `ℝ → ℂ`.

--- a/TauCeti/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
@@ -43,6 +43,13 @@ The primary statement is the complex `HasSum` form
 lives; the real `tsum` form `Polynomial.hermite_generating_function` (the roadmap target A1)
 follows from it by casting `ℝ → ℂ`. Both are stated in the `Polynomial` namespace, matching the
 existing Hermite API, as upstream candidates.
+
+## References
+
+* [Mathlib PR #42724](https://github.com/leanprover-community/mathlib4/pull/42724)
+  (Kim Morrison) — the draft upstream adaptation of this file and of `Derivative.lean`; the
+  `Polynomial`-namespace names (after `Polynomial.bernoulli_generating_function`) and the trimmed
+  imports here follow the choices made for that PR.
 -/
 
 public section


### PR DESCRIPTION
This PR aligns the two Hermite files with their upstream form (mathlib PR https://github.com/leanprover-community/mathlib4/pull/42724, "feat(RingTheory/Polynomial/Hermite): derivatives, recurrence, parity, and the generating function", currently in review as a draft), fixing the one lint debt the material carried:

- `Polynomial.derivative_hermite_succ` loses its `@[simp]` attribute, resolving the `simpNF` baseline entry for it: its left-hand side is already reduced by the `n`-indexed simp lemma `Polynomial.derivative_hermite`, so the attribute was a "simp can prove this" violation. No proof in the repository used the attribute (all call sites `rw` it explicitly). The corresponding `scripts/lint-baseline.txt` entry is now fixed and can be ratcheted out by a maintainer.
- The generating-function theorems move from the `TauCeti` namespace to the `Polynomial` namespace as `Polynomial.hasSum_hermite_generating_function` and `Polynomial.hermite_generating_function`, matching `Derivative.lean`'s existing convention for upstream candidates and the names the upstream PR proposes (following `Polynomial.bernoulli_generating_function`). Nothing outside the file referenced the old names.
- Two imports of `GeneratingFunction.lean` (`Mathlib.Analysis.Complex.Exponential`, `Mathlib.Algebra.Polynomial.AlgebraMap`) are dropped; the upstream adaptation verified the file builds without them.

Roadmap: OrthogonalL2Bases

🤖 Prepared with Claude Code

