### PR TITLE
refactor(Isogeny): pass the integrality witness instead of rebuilding it

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
@@ -133,13 +133,11 @@ theorem pullback_injective (φ : Isogeny W₁ W₂) : Function.Injective φ.pull
       (algebraMap F[X] W₁.CoordinateRing X)
   have hx₁_over_target :
       @IsIntegral W₂.CoordinateRing W₁.FunctionField _ _
-        φ.pullback.toRingHom.toAlgebra x₁ := by
-    exact (CoordinatePullback.mapsInfinity_iff φ.pullback).1 φ.mapsInfinity
+        φ.pullback.toRingHom.toAlgebra x₁ :=
+    (CoordinatePullback.mapsInfinity_iff φ.pullback).1 φ.mapsInfinity
       (algebraMap F[X] W₁.CoordinateRing X)
-  obtain ⟨Q, hQmonic, hQx⟩ := hx₁_over_target
-  have hx₁ : IsIntegral F x₁ := by
-    exact isIntegral_of_isIntegral_map φ.pullback.toRingHom himage
-      ⟨Q, hQmonic, hQx⟩
+  have hx₁ : IsIntegral F x₁ :=
+    isIntegral_of_isIntegral_map φ.pullback.toRingHom himage hx₁_over_target
   have hx₁_transcendental : Transcendental F x₁ := by
     have hx₁_eq : x₁ = algebraMap F[X] W₁.FunctionField X :=
       (IsScalarTower.algebraMap_apply F[X] W₁.CoordinateRing W₁.FunctionField X).symm


### PR DESCRIPTION
`pullback_injective` proves that the coordinate pullback of an isogeny is injective by deriving a
contradiction: if some `z` is killed, then `X` becomes integral over the base field, contradicting
its transcendence.

Two steps of that were scaffolding.

`hx₁_over_target` records that `x₁` is integral over the target coordinate ring. The proof then
took it apart with `obtain ⟨Q, hQmonic, hQx⟩` and immediately handed the three pieces back to
`isIntegral_of_isIntegral_map` as `⟨Q, hQmonic, hQx⟩` — the same witness, disassembled and
reassembled with nothing done to it in between. It is now passed as it stands, and the three names
disappear.

Both surrounding `have`s were `by exact` applied to a single term, so they are now term-mode.

No declaration is added or removed and no statement changes. The proof drops from 47 lines to 45 —
this is a small cleanup rather than a decomposition; the proof stays in the same size band.

The rest is untouched. In particular `heval` stays: it states the pullback applied to
`algebraMap … N`, which is the form `hnorm` rewrites against. Rewriting with
`AlgHom.congr_fun hhom N` alone leaves the goal headed by `AlgHom.comp`, and `hnorm` then fails to
match — so that `have` is carrying its statement, not just naming a term.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: EllipticCurves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
