### PR TITLE
Use YoungTableau as the standard-tableau labeling

### DIFF
--- a/TauCeti/Combinatorics/Young/StandardTableau/Basic.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Basic.lean
@@ -6,14 +6,16 @@ Authors: Codex
 module
 
 public import Mathlib.Data.FunLike.Fintype
-public import TauCeti.Combinatorics.Young.Diagram
+public import TauCeti.Combinatorics.Young.Tableau
 
 /-!
 # Standard Young tableaux
 
 A standard Young tableau of shape `μ` is a bijective labeling of the cells of `μ` by
 `Fin μ.card` that increases strictly from left to right and from top to bottom. This file
-defines standard Young tableaux, their finite cardinality `standardCount`, and transposition.
+defines standard Young tableaux, their finite cardinality `standardCount`, and transposition. Its
+underlying labeling is the existing `YoungTableau μ` type, so the general tableau API applies
+without converting between parallel representations.
 
 The labels start at zero, following the `Fin μ.card` convention in the Schur--Weyl roadmap.
 
@@ -33,20 +35,20 @@ namespace TauCeti
 /-- A standard Young tableau of shape `μ` is a bijective labeling of its cells by
 `Fin μ.card`, strictly increasing along rows and columns. -/
 structure StandardYoungTableau (μ : YoungDiagram) where
-  /-- The bijection from cells of the diagram to their labels. -/
-  toEquiv : ↥μ.cells ≃ Fin μ.card
+  /-- The underlying Young tableau. -/
+  toTableau : YoungTableau μ
   /-- Labels increase strictly from left to right. -/
   row_strict' : ∀ {i j₁ j₂ : ℕ} (h : j₁ < j₂) (hcell : (i, j₂) ∈ μ),
-    toEquiv ⟨(i, j₁), μ.up_left_mem (by rfl) h.le hcell⟩ < toEquiv ⟨(i, j₂), hcell⟩
+    toTableau ⟨(i, j₁), μ.up_left_mem (by rfl) h.le hcell⟩ < toTableau ⟨(i, j₂), hcell⟩
   /-- Labels increase strictly from top to bottom. -/
   col_strict' : ∀ {i₁ i₂ j : ℕ} (h : i₁ < i₂) (hcell : (i₂, j) ∈ μ),
-    toEquiv ⟨(i₁, j), μ.up_left_mem h.le (by rfl) hcell⟩ < toEquiv ⟨(i₂, j), hcell⟩
+    toTableau ⟨(i₁, j), μ.up_left_mem h.le (by rfl) hcell⟩ < toTableau ⟨(i₂, j), hcell⟩
 
 namespace StandardYoungTableau
 
 instance instFunLike {μ : YoungDiagram} :
     FunLike (StandardYoungTableau μ) ↥μ.cells (Fin μ.card) where
-  coe T := T.toEquiv
+  coe T := T.toTableau
   coe_injective T U h := by
     cases T with
     | mk e _ _ =>
@@ -55,16 +57,16 @@ instance instFunLike {μ : YoungDiagram} :
         congr
         exact Equiv.ext fun c => congrFun h c
 
-/-- The underlying function of a standard Young tableau is its labeling equivalence. -/
+/-- The underlying function of a standard Young tableau is its underlying tableau. -/
 @[simp]
-theorem coe_toEquiv {μ : YoungDiagram} (T : StandardYoungTableau μ) :
-    ⇑T.toEquiv = T :=
+theorem coe_toTableau {μ : YoungDiagram} (T : StandardYoungTableau μ) :
+    ⇑T.toTableau = T :=
   rfl
 
-/-- Evaluating the labeling equivalence agrees with evaluating the tableau. -/
+/-- Evaluating the underlying tableau agrees with evaluating the standard tableau. -/
 @[simp]
-theorem toEquiv_apply {μ : YoungDiagram} (T : StandardYoungTableau μ) (c : ↥μ.cells) :
-    T.toEquiv c = T c :=
+theorem toTableau_apply {μ : YoungDiagram} (T : StandardYoungTableau μ) (c : ↥μ.cells) :
+    T.toTableau c = T c :=
   rfl
 
 /-- Two standard Young tableaux are equal when all of their entries agree. -/
@@ -75,17 +77,17 @@ theorem ext {μ : YoungDiagram} {T U : StandardYoungTableau μ} (h : ∀ c, T c 
 /-- The entries of a standard Young tableau form a bijection. -/
 theorem bijective {μ : YoungDiagram} (T : StandardYoungTableau μ) :
     Function.Bijective T :=
-  T.toEquiv.bijective
+  T.toTableau.bijective
 
 /-- The entries of a standard Young tableau are injective. -/
 theorem injective {μ : YoungDiagram} (T : StandardYoungTableau μ) :
     Function.Injective T :=
-  T.toEquiv.injective
+  T.toTableau.injective
 
 /-- Every label occurs in a standard Young tableau. -/
 theorem surjective {μ : YoungDiagram} (T : StandardYoungTableau μ) :
     Function.Surjective T :=
-  T.toEquiv.surjective
+  T.toTableau.surjective
 
 /-- Entries of a standard Young tableau increase strictly from left to right. -/
 theorem row_strict {μ : YoungDiagram} (T : StandardYoungTableau μ)
@@ -123,16 +125,16 @@ private theorem transposeCellEquiv_symm_apply (μ : YoungDiagram) (c : ↥μ.cel
 labels. -/
 def transpose {μ : YoungDiagram} (T : StandardYoungTableau μ) :
     StandardYoungTableau μ.transpose where
-  toEquiv :=
+  toTableau :=
     (transposeCellEquiv μ).trans
-      (T.toEquiv.trans (finCongr (YoungDiagram.card_transpose μ).symm))
+      (T.toTableau.trans (finCongr (YoungDiagram.card_transpose μ).symm))
   row_strict' h hcell := by
     simpa only [Equiv.trans_apply, transposeCellEquiv_apply, Prod.swap, finCongr,
-      Equiv.coe_fn_mk, Fin.cast_lt_cast, toEquiv_apply] using
+      Equiv.coe_fn_mk, Fin.cast_lt_cast, toTableau_apply] using
       T.col_strict h (YoungDiagram.mem_transpose.mp hcell)
   col_strict' h hcell := by
     simpa only [Equiv.trans_apply, transposeCellEquiv_apply, Prod.swap, finCongr,
-      Equiv.coe_fn_mk, Fin.cast_lt_cast, toEquiv_apply] using
+      Equiv.coe_fn_mk, Fin.cast_lt_cast, toTableau_apply] using
       T.row_strict h (YoungDiagram.mem_transpose.mp hcell)
 
 /-- Transposition preserves the numeric label of each cell. -/
@@ -141,35 +143,35 @@ theorem transpose_apply_val {μ : YoungDiagram} (T : StandardYoungTableau μ)
     (c : ↥μ.transpose.cells) : (T.transpose c).val =
       (T ⟨c.1.swap, YoungDiagram.mem_transpose.mp c.2⟩).val :=
   calc
-    (T.transpose c).val = (T.transpose.toEquiv c).val :=
-      congrArg Fin.val (toEquiv_apply T.transpose c).symm
+    (T.transpose c).val = (T.transpose.toTableau c).val :=
+      congrArg Fin.val (toTableau_apply T.transpose c).symm
     _ = (T ⟨c.1.swap, YoungDiagram.mem_transpose.mp c.2⟩).val := by
       simp only [transpose, Equiv.trans_apply, transposeCellEquiv_apply,
-        finCongr, Equiv.coe_fn_mk, Fin.val_cast, toEquiv_apply]
+        finCongr, Equiv.coe_fn_mk, Fin.val_cast, toTableau_apply]
 
 private def untranspose {μ : YoungDiagram} (T : StandardYoungTableau μ.transpose) :
     StandardYoungTableau μ where
-  toEquiv :=
+  toTableau :=
     (transposeCellEquiv μ).symm.trans
-      (T.toEquiv.trans (finCongr (YoungDiagram.card_transpose μ)))
+      (T.toTableau.trans (finCongr (YoungDiagram.card_transpose μ)))
   row_strict' h hcell := by
     simpa only [Equiv.trans_apply, transposeCellEquiv_symm_apply, Prod.swap, finCongr,
-      Equiv.coe_fn_mk, Fin.cast_lt_cast, toEquiv_apply] using
+      Equiv.coe_fn_mk, Fin.cast_lt_cast, toTableau_apply] using
       T.col_strict h (YoungDiagram.mem_transpose.mpr hcell)
   col_strict' h hcell := by
     simpa only [Equiv.trans_apply, transposeCellEquiv_symm_apply, Prod.swap, finCongr,
-      Equiv.coe_fn_mk, Fin.cast_lt_cast, toEquiv_apply] using
+      Equiv.coe_fn_mk, Fin.cast_lt_cast, toTableau_apply] using
       T.row_strict h (YoungDiagram.mem_transpose.mpr hcell)
 
 private theorem untranspose_apply_val {μ : YoungDiagram}
     (T : StandardYoungTableau μ.transpose) (c : ↥μ.cells) : (untranspose T c).val =
       (T ⟨c.1.swap, YoungDiagram.mem_transpose.mpr c.2⟩).val :=
   calc
-    (untranspose T c).val = ((untranspose T).toEquiv c).val :=
-      congrArg Fin.val (toEquiv_apply (untranspose T) c).symm
+    (untranspose T c).val = ((untranspose T).toTableau c).val :=
+      congrArg Fin.val (toTableau_apply (untranspose T) c).symm
     _ = (T ⟨c.1.swap, YoungDiagram.mem_transpose.mpr c.2⟩).val := by
       simp only [untranspose, Equiv.trans_apply, transposeCellEquiv_symm_apply,
-        finCongr, Equiv.coe_fn_mk, Fin.val_cast, toEquiv_apply]
+        finCongr, Equiv.coe_fn_mk, Fin.val_cast, toTableau_apply]
 
 /-- Transposition is an equivalence between standard Young tableaux of conjugate shapes. -/
 def transposeEquiv (μ : YoungDiagram) :

--- a/TauCeti/Combinatorics/Young/StandardTableau/Corner.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Corner.lean
@@ -63,16 +63,16 @@ variable {μ : YoungDiagram} {c : ℕ × ℕ}
 /-- The cell of a standard Young tableau of a nonempty shape that carries the largest label,
 `μ.card - 1`. -/
 def maxCell (hμ : 0 < μ.card) (T : StandardYoungTableau μ) : ℕ × ℕ :=
-  (T.toEquiv.symm ⟨μ.card - 1, Nat.sub_lt hμ Nat.one_pos⟩ : ↥μ.cells)
+  (T.toTableau.symm ⟨μ.card - 1, Nat.sub_lt hμ Nat.one_pos⟩ : ↥μ.cells)
 
 theorem maxCell_mem (hμ : 0 < μ.card) (T : StandardYoungTableau μ) : maxCell hμ T ∈ μ :=
-  (T.toEquiv.symm ⟨μ.card - 1, Nat.sub_lt hμ Nat.one_pos⟩).2
+  (T.toTableau.symm ⟨μ.card - 1, Nat.sub_lt hμ Nat.one_pos⟩).2
 
 /-- The label at `TauCeti.StandardYoungTableau.maxCell` is the largest one. -/
 theorem apply_maxCell (hμ : 0 < μ.card) (T : StandardYoungTableau μ) :
     (T ⟨maxCell hμ T, maxCell_mem hμ T⟩).val + 1 = μ.card := by
   have h : T ⟨maxCell hμ T, maxCell_mem hμ T⟩ = ⟨μ.card - 1, Nat.sub_lt hμ Nat.one_pos⟩ :=
-    T.toEquiv.apply_symm_apply _
+    T.toTableau.apply_symm_apply _
   have hval : (⟨μ.card - 1, Nat.sub_lt hμ Nat.one_pos⟩ : Fin μ.card).val = μ.card - 1 := rfl
   rw [h]
   omega
@@ -143,7 +143,7 @@ so that the shape of the result does not depend on `T`. -/
 noncomputable def restrict (hc : YoungDiagram.IsCorner μ c) (T : StandardYoungTableau μ)
     (hT : (T ⟨c, hc.mem⟩).val + 1 = μ.card) :
     StandardYoungTableau (YoungDiagram.erase μ c) where
-  toEquiv := Equiv.ofBijective _ (restrictFun_bijective hc T hT)
+  toTableau := Equiv.ofBijective _ (restrictFun_bijective hc T hT)
   row_strict' h hcell := T.row_strict h (YoungDiagram.mem_of_mem_erase hcell)
   col_strict' h hcell := T.col_strict h (YoungDiagram.mem_of_mem_erase hcell)
 
@@ -244,7 +244,7 @@ private theorem extendFun_col (hc : YoungDiagram.IsCorner μ c)
 shape `μ` by giving the corner `c` the largest label. -/
 noncomputable def extend (hc : YoungDiagram.IsCorner μ c)
     (T : StandardYoungTableau (YoungDiagram.erase μ c)) : StandardYoungTableau μ where
-  toEquiv := Equiv.ofBijective _ (extendFun_bijective hc T)
+  toTableau := Equiv.ofBijective _ (extendFun_bijective hc T)
   row_strict' h hcell := extendFun_row hc T h hcell
   col_strict' h hcell := extendFun_col hc T h hcell
 

--- a/TauCeti/Combinatorics/Young/StandardTableau/Order.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Order.lean
@@ -57,45 +57,45 @@ variable {μ : YoungDiagram}
 
 /-- Naming a cell by the row and the column of a label recovers that label. -/
 private theorem apply_eq_of_coe_eq (T : StandardYoungTableau μ) (x : Fin μ.card) {c : ↥μ.cells}
-    (h : (c : ℕ × ℕ) = (rowIndex T.toEquiv x, colIndex T.toEquiv x)) : T c = x := by
-  have hc : c = T.toEquiv.symm x := Subtype.ext (by rw [h, rowIndex_def, colIndex_def])
+    (h : (c : ℕ × ℕ) = (rowIndex T.toTableau x, colIndex T.toTableau x)) : T c = x := by
+  have hc : c = T.toTableau.symm x := Subtype.ext (by rw [h, rowIndex_def, colIndex_def])
   rw [hc]
-  exact T.toEquiv.apply_symm_apply x
+  exact T.toTableau.apply_symm_apply x
 
 /-- Of two labels of a standard Young tableau lying in a common column, the one in the earlier row
 is the smaller. -/
 theorem lt_of_rowIndex_lt (T : StandardYoungTableau μ) {x y : Fin μ.card}
-    (hcol : colIndex T.toEquiv x = colIndex T.toEquiv y)
-    (hrow : rowIndex T.toEquiv x < rowIndex T.toEquiv y) : x < y := by
-  have hlt := T.col_strict hrow (rowIndex_colIndex_mem T.toEquiv y)
+    (hcol : colIndex T.toTableau x = colIndex T.toTableau y)
+    (hrow : rowIndex T.toTableau x < rowIndex T.toTableau y) : x < y := by
+  have hlt := T.col_strict hrow (rowIndex_colIndex_mem T.toTableau y)
   rwa [apply_eq_of_coe_eq T x (by simp [hcol]), apply_eq_of_coe_eq T y rfl] at hlt
 
 /-- Of two labels of a standard Young tableau lying in a common row, the one in the earlier column
 is the smaller. -/
 theorem lt_of_colIndex_lt (T : StandardYoungTableau μ) {x y : Fin μ.card}
-    (hrow : rowIndex T.toEquiv x = rowIndex T.toEquiv y)
-    (hcol : colIndex T.toEquiv x < colIndex T.toEquiv y) : x < y := by
-  have hlt := T.row_strict hcol (rowIndex_colIndex_mem T.toEquiv y)
+    (hrow : rowIndex T.toTableau x = rowIndex T.toTableau y)
+    (hcol : colIndex T.toTableau x < colIndex T.toTableau y) : x < y := by
+  have hlt := T.row_strict hcol (rowIndex_colIndex_mem T.toTableau y)
   rwa [apply_eq_of_coe_eq T x (by simp [hrow]), apply_eq_of_coe_eq T y rfl] at hlt
 
 /-- **Two labels of a standard Young tableau in a common column are ordered as their rows are.** -/
 theorem lt_iff_rowIndex_lt (T : StandardYoungTableau μ) {x y : Fin μ.card}
-    (hcol : colIndex T.toEquiv x = colIndex T.toEquiv y) :
-    x < y ↔ rowIndex T.toEquiv x < rowIndex T.toEquiv y := by
+    (hcol : colIndex T.toTableau x = colIndex T.toTableau y) :
+    x < y ↔ rowIndex T.toTableau x < rowIndex T.toTableau y := by
   refine ⟨fun hxy => ?_, lt_of_rowIndex_lt T hcol⟩
-  rcases lt_trichotomy (rowIndex T.toEquiv x) (rowIndex T.toEquiv y) with hr | hr | hr
+  rcases lt_trichotomy (rowIndex T.toTableau x) (rowIndex T.toTableau y) with hr | hr | hr
   · exact hr
-  · exact absurd (rowIndex_colIndex_injective T.toEquiv (Prod.ext hr hcol)) hxy.ne
+  · exact absurd (rowIndex_colIndex_injective T.toTableau (Prod.ext hr hcol)) hxy.ne
   · exact absurd (lt_of_rowIndex_lt T hcol.symm hr) (asymm hxy)
 
 /-- **Two labels of a standard Young tableau in a common row are ordered as their columns are.** -/
 theorem lt_iff_colIndex_lt (T : StandardYoungTableau μ) {x y : Fin μ.card}
-    (hrow : rowIndex T.toEquiv x = rowIndex T.toEquiv y) :
-    x < y ↔ colIndex T.toEquiv x < colIndex T.toEquiv y := by
+    (hrow : rowIndex T.toTableau x = rowIndex T.toTableau y) :
+    x < y ↔ colIndex T.toTableau x < colIndex T.toTableau y := by
   refine ⟨fun hxy => ?_, lt_of_colIndex_lt T hrow⟩
-  rcases lt_trichotomy (colIndex T.toEquiv x) (colIndex T.toEquiv y) with hc | hc | hc
+  rcases lt_trichotomy (colIndex T.toTableau x) (colIndex T.toTableau y) with hc | hc | hc
   · exact hc
-  · exact absurd (rowIndex_colIndex_injective T.toEquiv (Prod.ext hrow hc)) hxy.ne
+  · exact absurd (rowIndex_colIndex_injective T.toTableau (Prod.ext hrow hc)) hxy.ne
   · exact absurd (lt_of_colIndex_lt T hrow.symm hc) (asymm hxy)
 
 end StandardYoungTableau
@@ -104,31 +104,31 @@ end StandardYoungTableau
 
 /-- **A standard Young tableau is determined by the rows of its labels.** -/
 theorem StandardYoungTableau.rowIndex_injective (μ : YoungDiagram) :
-    Function.Injective fun T : StandardYoungTableau μ => rowIndex T.toEquiv := by
+    Function.Injective fun T : StandardYoungTableau μ => rowIndex T.toTableau := by
   classical
   intro T U h
-  have hrow' : rowIndex T.toEquiv = rowIndex U.toEquiv := h
-  obtain ⟨σ, hrel⟩ := exists_relabel_eq T.toEquiv U.toEquiv
+  have hrow' : rowIndex T.toTableau = rowIndex U.toTableau := h
+  obtain ⟨σ, hrel⟩ := exists_relabel_eq T.toTableau U.toTableau
   -- `σ` carries `T` to `U`, so the row and the column that `U` gives to `σ k` are those that `T`
   -- gives to `k`
-  have hrowU : ∀ k, rowIndex U.toEquiv (σ k) = rowIndex T.toEquiv k := by
+  have hrowU : ∀ k, rowIndex U.toTableau (σ k) = rowIndex T.toTableau k := by
     intro k
     rw [← hrel, rowIndex_relabel]
     simp
-  have hcolU : ∀ k, colIndex U.toEquiv (σ k) = colIndex T.toEquiv k := by
+  have hcolU : ∀ k, colIndex U.toTableau (σ k) = colIndex T.toTableau k := by
     intro k
     rw [← hrel, colIndex_relabel]
     simp
-  have hrow : ∀ k, rowIndex T.toEquiv (σ k) = rowIndex T.toEquiv k := fun k => by
+  have hrow : ∀ k, rowIndex T.toTableau (σ k) = rowIndex T.toTableau k := fun k => by
     rw [congrFun hrow' (σ k), hrowU k]
   -- on each row of `T` the permutation `σ` is increasing, so it is the identity there
   have hσ : σ = 1 := by
     refine Equiv.ext fun x => ?_
     -- `σ` preserves the row of `x`, so it restricts to a permutation of that row
-    have hs : ∀ y, rowIndex T.toEquiv (σ y) = rowIndex T.toEquiv x ↔
-        rowIndex T.toEquiv y = rowIndex T.toEquiv x := fun y => by rw [hrow y]
+    have hs : ∀ y, rowIndex T.toTableau (σ y) = rowIndex T.toTableau x ↔
+        rowIndex T.toTableau y = rowIndex T.toTableau x := fun y => by rw [hrow y]
     have hmono : StrictMono (σ.subtypePerm hs :
-        Equiv.Perm {y // rowIndex T.toEquiv y = rowIndex T.toEquiv x}) := by
+        Equiv.Perm {y // rowIndex T.toTableau y = rowIndex T.toTableau x}) := by
       rintro ⟨y, hy⟩ ⟨y', hy'⟩ hlt
       rw [Equiv.Perm.subtypePerm_apply, Equiv.Perm.subtypePerm_apply, Subtype.mk_lt_mk,
         StandardYoungTableau.lt_iff_colIndex_lt U (by rw [hrowU y, hrowU y', hy, hy']),
@@ -137,8 +137,8 @@ theorem StandardYoungTableau.rowIndex_injective (μ : YoungDiagram) :
     have hfix : σ x = x := by
       simpa using congrArg Subtype.val (StrictMono.apply_eq (x := ⟨x, rfl⟩) hmono)
     simpa using hfix
-  have htu : T.toEquiv = U.toEquiv := by rw [← hrel, hσ, relabel_one]
+  have htu : T.toTableau = U.toTableau := by rw [← hrel, hσ, relabel_one]
   exact StandardYoungTableau.ext fun c => by
-    rw [← StandardYoungTableau.toEquiv_apply, ← StandardYoungTableau.toEquiv_apply, htu]
+    rw [← StandardYoungTableau.toTableau_apply, ← StandardYoungTableau.toTableau_apply, htu]
 
 end TauCeti

--- a/TauCeti/Combinatorics/Young/StandardTableau/Reading.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Reading.lean
@@ -141,7 +141,7 @@ variable {μ : YoungDiagram}
 so on.  This is the tableau at which the classical-groups roadmap fixes the Young symmetrizer
 `c_λ`. -/
 noncomputable def rowSuperstandard (μ : YoungDiagram) : StandardYoungTableau μ where
-  toEquiv :=
+  toTableau :=
     Equiv.ofBijective
       (fun c => ⟨YoungDiagram.readingIndex μ c.1, YoungDiagram.readingIndex_lt_card c.2⟩)
       ((Fintype.bijective_iff_injective_and_card _).mpr

--- a/TauCeti/Combinatorics/Young/Tableau.lean
+++ b/TauCeti/Combinatorics/Young/Tableau.lean
@@ -29,7 +29,7 @@ directly.  As a consequence dot notation on a tableau resolves in the `Equiv` na
 declarations below are to be spelled out, as in `YoungTableau.rowIndex t`.
 
 A `μ`-tableau is not required to be row- or column-increasing.  The strictly row- and
-column-increasing ones are `TauCeti.StandardYoungTableau`, whose `toEquiv` field is a `μ`-tableau
+column-increasing ones are `TauCeti.StandardYoungTableau`, whose `toTableau` field is a `μ`-tableau
 in the present sense; Mathlib's `SemistandardYoungTableau` is a different notion again, a filling
 of `μ` by natural numbers that is weakly increasing along each row and strictly increasing down
 each column (represented as a function `ℕ → ℕ → ℕ` vanishing outside `μ`), with no bijectivity

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
@@ -199,7 +199,7 @@ theorem YoungTableau.toTensorPower_weylRepEquivSymPowerRep (t : YoungTableau μ)
 noncomputable def weylRepOfShapeEquivSymPowerRep (μ : YoungDiagram) (h : μ.colLen 0 ≤ 1) :
     (weylRepOfShape k n μ).Equiv (symPowerRep k n μ.card) :=
   (YoungTableau.weylRepEquivOfShape k n
-      (StandardYoungTableau.rowSuperstandard μ).toEquiv).symm.trans
+      (StandardYoungTableau.rowSuperstandard μ).toTableau).symm.trans
     (YoungTableau.weylRepEquivSymPowerRep k n _ h)
 
 /-- The shape-indexed isomorphism is the tableau-indexed one at the row-superstandard tableau,
@@ -209,9 +209,9 @@ theorem weylRepOfShapeEquivSymPowerRep_apply (μ : YoungDiagram) (h : μ.colLen 
     (x : (weylModuleOfShape k n μ).toSubmodule) :
     weylRepOfShapeEquivSymPowerRep k n μ h x =
       YoungTableau.weylRepEquivSymPowerRep k n
-        (StandardYoungTableau.rowSuperstandard μ).toEquiv h
+        (StandardYoungTableau.rowSuperstandard μ).toTableau h
         ((YoungTableau.weylRepEquivOfShape k n
-          (StandardYoungTableau.rowSuperstandard μ).toEquiv).symm x) :=
+          (StandardYoungTableau.rowSuperstandard μ).toTableau).symm x) :=
   Representation.Equiv.trans_apply _ _ x
 
 end OneRow
@@ -282,7 +282,7 @@ theorem YoungTableau.toTensorPower_weylRepEquivExtPowerRep (t : YoungTableau μ)
 noncomputable def weylRepOfShapeEquivExtPowerRep (μ : YoungDiagram) (h : μ.rowLen 0 ≤ 1) :
     (weylRepOfShape k n μ).Equiv (extPowerRep k n μ.card) :=
   (YoungTableau.weylRepEquivOfShape k n
-      (StandardYoungTableau.rowSuperstandard μ).toEquiv).symm.trans
+      (StandardYoungTableau.rowSuperstandard μ).toTableau).symm.trans
     (YoungTableau.weylRepEquivExtPowerRep k n _ h)
 
 /-- The shape-indexed isomorphism is the tableau-indexed one at the row-superstandard tableau,
@@ -292,9 +292,9 @@ theorem weylRepOfShapeEquivExtPowerRep_apply (μ : YoungDiagram) (h : μ.rowLen 
     (x : (weylModuleOfShape k n μ).toSubmodule) :
     weylRepOfShapeEquivExtPowerRep k n μ h x =
       YoungTableau.weylRepEquivExtPowerRep k n
-        (StandardYoungTableau.rowSuperstandard μ).toEquiv h
+        (StandardYoungTableau.rowSuperstandard μ).toTableau h
         ((YoungTableau.weylRepEquivOfShape k n
-          (StandardYoungTableau.rowSuperstandard μ).toEquiv).symm x) :=
+          (StandardYoungTableau.rowSuperstandard μ).toTableau).symm x) :=
   Representation.Equiv.trans_apply _ _ x
 
 end OneColumn

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -415,13 +415,13 @@ identification is `TauCeti.YoungTableau.weylRepEquivOfShape`.
 This is the object the classical-groups roadmap pins as `schurFunctor n μ`. -/
 noncomputable def weylModuleOfShape (μ : YoungDiagram) :
     Subrepresentation (tensorPowerRep k n μ.card) :=
-  YoungTableau.weylModule k n (StandardYoungTableau.rowSuperstandard μ).toEquiv
+  YoungTableau.weylModule k n (StandardYoungTableau.rowSuperstandard μ).toTableau
 
 /-- The Weyl module of a shape is the Weyl module of its row-superstandard tableau, so the
 tableau-indexed lemmas apply to it. -/
 theorem weylModuleOfShape_def (μ : YoungDiagram) :
     weylModuleOfShape k n μ =
-      YoungTableau.weylModule k n (StandardYoungTableau.rowSuperstandard μ).toEquiv :=
+      YoungTableau.weylModule k n (StandardYoungTableau.rowSuperstandard μ).toTableau :=
   (rfl)
 
 /-- The action of `GL n k` on the Weyl module of a shape. -/
@@ -436,7 +436,7 @@ theorem weylModuleOfShape_toSubmodule (μ : YoungDiagram) :
     (weylModuleOfShape k n μ).toSubmodule =
       LinearMap.range (permTensorActionAlgHom k n μ.card
         (YoungTableau.youngSymmetrizerOver k
-          (StandardYoungTableau.rowSuperstandard μ).toEquiv)) :=
+          (StandardYoungTableau.rowSuperstandard μ).toTableau)) :=
   YoungTableau.weylModule_toSubmodule k n _
 
 /-- The action on the Weyl module of a shape is the restriction of the action on the tensor

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean
@@ -210,39 +210,39 @@ private theorem card_filter_le_of_isLowerSet {α : Type*} [LinearOrder α]
 standard tableau the labels of the first rows are the smallest ones of the column, so moving them
 about inside their columns can only push labels down. -/
 theorem tabloidDominates_relabel_of_mem_colSubgroup (T : StandardYoungTableau μ)
-    {q : Equiv.Perm (Fin μ.card)} (hq : q ∈ colSubgroup T.toEquiv) :
-    TabloidDominates T.toEquiv (relabel q T.toEquiv) := by
+    {q : Equiv.Perm (Fin μ.card)} (hq : q ∈ colSubgroup T.toTableau) :
+    TabloidDominates T.toTableau (relabel q T.toTableau) := by
   classical
-  have hcol : ∀ k, colIndex T.toEquiv (q k) = colIndex T.toEquiv k := mem_colSubgroup.mp hq
+  have hcol : ∀ k, colIndex T.toTableau (q k) = colIndex T.toTableau k := mem_colSubgroup.mp hq
   intro m i
   -- index the labels of the relabelled tableau by their preimages
-  have hreindex : rowCount (relabel q T.toEquiv) m i =
+  have hreindex : rowCount (relabel q T.toTableau) m i =
       (Finset.univ.filter fun x : Fin μ.card =>
-        ((q x : Fin μ.card) : ℕ) < m ∧ rowIndex T.toEquiv x ≤ i).card := by
+        ((q x : Fin μ.card) : ℕ) < m ∧ rowIndex T.toTableau x ≤ i).card := by
     refine Finset.card_equiv (q⁻¹ : Equiv.Perm (Fin μ.card)) fun k => ?_
     simp [rowIndex_relabel]
   -- both counts split over the columns of `T`
   have hmemJ : ∀ x : Fin μ.card,
-      colIndex T.toEquiv x ∈ Finset.image (colIndex T.toEquiv) Finset.univ := fun x =>
+      colIndex T.toTableau x ∈ Finset.image (colIndex T.toTableau) Finset.univ := fun x =>
     Finset.mem_image_of_mem _ (Finset.mem_univ x)
   rw [hreindex, rowCount,
-    Finset.card_eq_sum_card_fiberwise (f := colIndex T.toEquiv)
-      (t := Finset.image (colIndex T.toEquiv) Finset.univ) fun x _ => hmemJ x,
-    Finset.card_eq_sum_card_fiberwise (f := colIndex T.toEquiv)
-      (t := Finset.image (colIndex T.toEquiv) Finset.univ) fun x _ => hmemJ x]
+    Finset.card_eq_sum_card_fiberwise (f := colIndex T.toTableau)
+      (t := Finset.image (colIndex T.toTableau) Finset.univ) fun x _ => hmemJ x,
+    Finset.card_eq_sum_card_fiberwise (f := colIndex T.toTableau)
+      (t := Finset.image (colIndex T.toTableau) Finset.univ) fun x _ => hmemJ x]
   refine Finset.sum_le_sum fun j _ => ?_
   -- the labels of column `j` in the first `i + 1` rows, and their images under `q`
   set A : Finset (Fin μ.card) :=
-    Finset.univ.filter fun x => colIndex T.toEquiv x = j ∧ rowIndex T.toEquiv x ≤ i with hA
+    Finset.univ.filter fun x => colIndex T.toTableau x = j ∧ rowIndex T.toTableau x ≤ i with hA
   have hleft : ((Finset.univ.filter fun x : Fin μ.card =>
-        ((q x : Fin μ.card) : ℕ) < m ∧ rowIndex T.toEquiv x ≤ i).filter
-      fun x => colIndex T.toEquiv x = j) =
+        ((q x : Fin μ.card) : ℕ) < m ∧ rowIndex T.toTableau x ≤ i).filter
+      fun x => colIndex T.toTableau x = j) =
       A.filter fun x => ((q x : Fin μ.card) : ℕ) < m := by
     ext x
     simp only [hA, Finset.mem_filter, Finset.mem_univ, true_and]
     tauto
   have hright : ((Finset.univ.filter fun x : Fin μ.card =>
-        (x : ℕ) < m ∧ rowIndex T.toEquiv x ≤ i).filter fun x => colIndex T.toEquiv x = j) =
+        (x : ℕ) < m ∧ rowIndex T.toTableau x ≤ i).filter fun x => colIndex T.toTableau x = j) =
       A.filter fun x : Fin μ.card => (x : ℕ) < m := by
     ext x
     simp only [hA, Finset.mem_filter, Finset.mem_univ, true_and]
@@ -253,7 +253,7 @@ theorem tabloidDominates_relabel_of_mem_colSubgroup (T : StandardYoungTableau μ
       ((A.image q).filter fun y : Fin μ.card => (y : ℕ) < m).card := by
     rw [Finset.filter_image, Finset.card_image_of_injective _ q.injective]
   rw [himage]
-  refine card_filter_le_of_isLowerSet (S := Finset.univ.filter fun x => colIndex T.toEquiv x = j)
+  refine card_filter_le_of_isLowerSet (S := Finset.univ.filter fun x => colIndex T.toTableau x = j)
     (fun y hy => ?_) (le_of_eq (Finset.card_image_of_injective _ q.injective))
     (fun x hx y hy hlt => ?_) fun _ _ hxy hx => (Fin.lt_def.mp hxy).trans hx
   · obtain ⟨x, hx, rfl⟩ := Finset.mem_image.mp hy
@@ -274,34 +274,34 @@ open YoungTableau
 a nonzero coefficient, one of largest weight has a tabloid that no other standard polytabloid of
 the combination reaches, so its coefficient is read off the combination. -/
 theorem linearIndependent_polytabloid (μ : YoungDiagram) :
-    LinearIndependent ℚ fun T : StandardYoungTableau μ => polytabloid T.toEquiv := by
+    LinearIndependent ℚ fun T : StandardYoungTableau μ => polytabloid T.toTableau := by
   classical
   rw [linearIndependent_iff']
   intro s g hsum T₁ hT₁
   by_contra hg
   obtain ⟨T₀, hT₀, hmax⟩ := Finset.exists_max_image (s.filter fun T => g T ≠ 0)
-    (fun T => rowWeight T.toEquiv) ⟨T₁, Finset.mem_filter.mpr ⟨hT₁, hg⟩⟩
+    (fun T => rowWeight T.toTableau) ⟨T₁, Finset.mem_filter.mpr ⟨hT₁, hg⟩⟩
   obtain ⟨hT₀s, hg₀⟩ := Finset.mem_filter.mp hT₀
   -- no other standard polytabloid of the combination reaches the tabloid of `T₀`
   have hzero : ∀ T ∈ s, T ≠ T₀ →
-      (g T • polytabloid T.toEquiv).coeff (tabloid T₀.toEquiv) = 0 := by
+      (g T • polytabloid T.toTableau).coeff (tabloid T₀.toTableau) = 0 := by
     intro T hTs hTne
     rcases eq_or_ne (g T) 0 with h0 | h0
     · simp [h0]
-    have hvanish : (polytabloid T.toEquiv).coeff (tabloid T₀.toEquiv) = 0 := by
+    have hvanish : (polytabloid T.toTableau).coeff (tabloid T₀.toTableau) = 0 := by
       refine polytabloid_coeff_eq_zero_of_forall_ne _ fun q hq hcontra => hTne ?_
-      have hdom : TabloidDominates T.toEquiv (relabel q T.toEquiv) :=
+      have hdom : TabloidDominates T.toTableau (relabel q T.toTableau) :=
         tabloidDominates_relabel_of_mem_colSubgroup T hq
-      have hrow : rowIndex (relabel q T.toEquiv) = rowIndex T₀.toEquiv := by
+      have hrow : rowIndex (relabel q T.toTableau) = rowIndex T₀.toTableau := by
         rw [← tabloid_eq_iff_rowIndex_eq, tabloid_relabel, hcontra]
-      have hw : rowWeight T.toEquiv ≤ rowWeight (relabel q T.toEquiv) := by
+      have hw : rowWeight T.toTableau ≤ rowWeight (relabel q T.toTableau) := by
         rw [rowWeight_congr hrow]
         exact hmax T (Finset.mem_filter.mpr ⟨hTs, h0⟩)
       exact StandardYoungTableau.rowIndex_injective μ
         ((rowIndex_eq_of_tabloidDominates hdom hw).symm.trans hrow)
     simp [hvanish]
   -- so the coefficient of that tabloid in the combination is the coefficient of `T₀`
-  have hcoeff : (∑ T ∈ s, g T • polytabloid T.toEquiv).coeff (tabloid T₀.toEquiv) = 0 := by
+  have hcoeff : (∑ T ∈ s, g T • polytabloid T.toTableau).coeff (tabloid T₀.toTableau) = 0 := by
     rw [hsum]
     simp
   rw [MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply,
@@ -316,7 +316,7 @@ theorem standardCount_le_finrank_spechtSubrepresentation (μ : YoungDiagram) :
     standardCount μ ≤ Module.finrank ℚ (spechtSubrepresentation μ).toSubmodule := by
   classical
   have hli : LinearIndependent ℚ fun T : StandardYoungTableau μ =>
-      (⟨polytabloid T.toEquiv, polytabloid_mem_spechtSubrepresentation T.toEquiv⟩ :
+      (⟨polytabloid T.toTableau, polytabloid_mem_spechtSubrepresentation T.toTableau⟩ :
         (spechtSubrepresentation μ).toSubmodule) :=
     LinearIndependent.of_comp (spechtSubrepresentation μ).toSubmodule.subtype
       (linearIndependent_polytabloid μ)


### PR DESCRIPTION
This PR makes `StandardYoungTableau.toTableau` use the existing `YoungTableau μ` API instead of spelling the same cell-label equivalence independently as `toEquiv`. It migrates the standard-tableau, Specht, and Weyl-module consumers to the clearer field name.

This is an intentional clean API break: no duplicate `toEquiv` compatibility projection is retained.

Verified with `lake build`, `lake exe axioms`, `lake exe module-system`, and `bash scripts/lint-env.sh`.

:robot: Prepared with OpenAI Codex