### PR TITLE
Define isotopies by embedding time slices

### DIFF
--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/ContinuousAmbientIsotopy/Basic.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/ContinuousAmbientIsotopy/Basic.lean
@@ -75,7 +75,7 @@ namespace ContinuousAmbientIsotopic
 the two bundled smooth embeddings. -/
 theorem of_ambientIsotopy (Φ : TauCeti.AmbientIsotopy N)
     (hΦ : Φ.final.comp f.toContinuousMap = g.toContinuousMap) : ContinuousAmbientIsotopic f g :=
-  ⟨Φ, hΦ⟩
+  continuousAmbientIsotopic_def.mpr ⟨Φ, hΦ⟩
 
 /-- A symmetric form of `SmoothEmbedding.ContinuousAmbientIsotopic.of_ambientIsotopy`, useful when
 the endpoint equation is oriented as `g = Φ.final ∘ f`. -/

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/ContinuousAmbientIsotopy/Basic.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/ContinuousAmbientIsotopy/Basic.lean
@@ -31,8 +31,8 @@ underlying maps.
 * `TauCeti.SmoothEmbedding.ContinuousAmbientIsotopic.setoid`: continuous ambient isotopy as a
   setoid on bundled smooth embeddings.
 
-The source for the topological notion is Burde--Zieschang, *Knots*, Chapter 1, Definitions 1.1
-and 1.2, via the existing `TauCeti.Topology.Homotopy.Isotopy.Basic` and
+The source for the topological ambient-isotopy notion is Burde--Zieschang, *Knots*, Chapter 1,
+Definition 1.2, via the existing `TauCeti.Topology.Homotopy.Isotopy.Basic` and
 `TauCeti.Topology.Homotopy.AmbientIsotopic.Basic` files.
 -/
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopic/Basic.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic/Basic.lean
@@ -54,7 +54,7 @@ carries `f` to `g`, that is, its final homeomorphism postcomposes `f` to `g`. Th
 continuous topological ambient-isotopy relation intended to underlie later knot-equivalence
 specialisations (ambient isotopy of smooth embeddings `S¹ ↪ M`); it does not itself encode the
 smooth or PL structure those specialisations add. -/
-@[expose] def AmbientIsotopic (f g : C(X, Y)) : Prop :=
+def AmbientIsotopic (f g : C(X, Y)) : Prop :=
   ∃ Φ : AmbientIsotopy Y, Φ.final.comp f = g
 
 /-- `f` and `g` are ambient isotopic exactly when some ambient isotopy's final homeomorphism

--- a/TauCeti/Topology/Homotopy/AmbientIsotopic/Basic.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic/Basic.lean
@@ -23,10 +23,9 @@ operations on ambient isotopies themselves, which live beside the `AmbientIsotop
 `TauCeti.Topology.Homotopy.Isotopy.Basic`: the constant ambient isotopy `AmbientIsotopy.refl`, the
 pointwise composition `AmbientIsotopy.trans`, and the pointwise inverse `AmbientIsotopy.symm`.
 Because each of their total maps is a composition or inverse of homeomorphisms, none of the
-closure operations needs the closed-cover gluing that `Isotopy.trans` requires. This is a
-continuous topological generalization of the point-set ambient-isotopy condition in
-Burde--Zieschang, *Knots*, Chapter 1, intended for later specialization to embeddings such as
-knots.
+closure operations needs a separate gluing argument. This is a continuous topological
+generalization of the point-set ambient-isotopy condition in Burde--Zieschang, *Knots*, Chapter 1,
+Definition 1.2, intended for later specialization to embeddings such as knots.
 
 ## Main definitions
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean
@@ -113,7 +113,8 @@ variable {f g : C(X, Y)}
 their ranges (the embedded images, for embeddings) are homeomorphic. -/
 theorem nonempty_rangeHomeomorph (hfg : AmbientIsotopic f g) :
     Nonempty (Set.range f ≃ₜ Set.range g) := by
-  obtain ⟨Φ, rfl⟩ := hfg
+  obtain ⟨Φ, hΦ⟩ := ambientIsotopic_def.mp hfg
+  subst g
   exact ⟨Φ.rangeHomeomorph f⟩
 
 /-- **Ambient isotopy preserves complements up to homeomorphism.** If `f` and `g` are ambient
@@ -122,7 +123,8 @@ isotopic, the complements `(range f)ᶜ` and `(range g)ᶜ` are homeomorphic. Fo
 ambient isotopy rather than on the naive isotopy relation. -/
 theorem nonempty_complementHomeomorph (hfg : AmbientIsotopic f g) :
     Nonempty (↥(Set.range f)ᶜ ≃ₜ ↥(Set.range g)ᶜ) := by
-  obtain ⟨Φ, rfl⟩ := hfg
+  obtain ⟨Φ, hΦ⟩ := ambientIsotopic_def.mp hfg
+  subst g
   exact ⟨Φ.complementHomeomorph f⟩
 
 end AmbientIsotopic

--- a/TauCeti/Topology/Homotopy/AmbientIsotopic/Naturality.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic/Naturality.lean
@@ -45,8 +45,8 @@ variable {f g : C(X, Y)}
 of `Y` carries `f` to `g`, the same ambient isotopy carries `f ∘ e` to `g ∘ e`. -/
 theorem precomp (hfg : AmbientIsotopic f g) (e : C(W, X)) :
     AmbientIsotopic (f.comp e) (g.comp e) := by
-  obtain ⟨Φ, hΦ⟩ := hfg
-  refine ⟨Φ, ?_⟩
+  obtain ⟨Φ, hΦ⟩ := ambientIsotopic_def.mp hfg
+  refine ambientIsotopic_def.mpr ⟨Φ, ?_⟩
   ext w
   exact congr_fun (congrArg DFunLike.coe hΦ) (e w)
 
@@ -54,8 +54,8 @@ theorem precomp (hfg : AmbientIsotopic f g) (e : C(W, X)) :
 ambient isotopy is obtained by transporting the original one across the homeomorphism. -/
 theorem postcomp_homeomorph (hfg : AmbientIsotopic f g) (h : Y ≃ₜ Z) :
     AmbientIsotopic ((h : C(Y, Z)).comp f) ((h : C(Y, Z)).comp g) := by
-  obtain ⟨Φ, hΦ⟩ := hfg
-  refine ⟨Φ.transport h, ?_⟩
+  obtain ⟨Φ, hΦ⟩ := ambientIsotopic_def.mp hfg
+  refine ambientIsotopic_def.mpr ⟨Φ.transport h, ?_⟩
   ext x
   have hx : Φ.final (f x) = g x := congr_fun (congrArg DFunLike.coe hΦ) x
   simpa [AmbientIsotopy.final_transport] using congrArg h hx

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyConj.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyConj.lean
@@ -68,7 +68,7 @@ pre- and post-composed with the product homeomorphisms `id ×ₜ h⁻¹` and `id
           ⇑((Homeomorph.refl I).prodCongr h.symm) := by
       funext p
       obtain ⟨t, z⟩ := p
-      simp [Homeomorph.coe_prodCongr, Function.comp_def, totalMap]
+      simp [Homeomorph.coe_prodCongr, Function.comp_def]
     rw [heq]
     exact (((Homeomorph.refl I).prodCongr h).isHomeomorph.comp Φ.isHomeomorph_total).comp
       ((Homeomorph.refl I).prodCongr h.symm).isHomeomorph
@@ -79,9 +79,10 @@ pre- and post-composed with the product homeomorphisms `id ×ₜ h⁻¹` and `id
 theorem transport_apply (h : Y ≃ₜ Z) (p : I × Z) :
     (Φ.transport h).toContinuousMap p = h (Φ.toContinuousMap (p.1, h.symm p.2)) := rfl
 
-@[simp]
+@[simp 1100]
 theorem final_transport (h : Y ≃ₜ Z) (z : Z) :
-    (Φ.transport h).final z = h (Φ.final (h.symm z)) := rfl
+    (Φ.transport h).final z = h (Φ.final (h.symm z)) := by
+  rw [final_apply, transport_apply, final_apply]
 
 /-- Every time slice of a transported ambient isotopy is the corresponding slice of `Φ` read in
 the coordinates supplied by `h`:
@@ -98,7 +99,8 @@ read in the coordinates supplied by `h`:
 @[simp]
 theorem finalHomeomorph_transport (h : Y ≃ₜ Z) :
     (Φ.transport h).finalHomeomorph = (h.symm.trans Φ.finalHomeomorph).trans h := by
-  rw [finalHomeomorph, finalHomeomorph, homeomorph_transport]
+  ext z
+  simp only [finalHomeomorph_apply, final_transport, Homeomorph.trans_apply]
 
 /-- **Conjugation of an ambient isotopy** by a self-homeomorphism `h`: the special case of
 `AmbientIsotopy.transport` in which the change of coordinates fixes the ambient space, so the
@@ -110,8 +112,9 @@ endpoint slices conjugate inside the group `Y ≃ₜ Y`. The total map is
 theorem conj_apply (h : Y ≃ₜ Y) (p : I × Y) :
     (Φ.conj h).toContinuousMap p = h (Φ.toContinuousMap (p.1, h.symm p.2)) := rfl
 
-@[simp]
-theorem final_conj (h : Y ≃ₜ Y) (y : Y) : (Φ.conj h).final y = h (Φ.final (h.symm y)) := rfl
+@[simp 1100]
+theorem final_conj (h : Y ≃ₜ Y) (y : Y) : (Φ.conj h).final y = h (Φ.final (h.symm y)) := by
+  rw [final_apply, conj_apply, final_apply]
 
 /-- Every time slice of a conjugated ambient isotopy is the conjugate of the corresponding time
 slice: `(Φ.conj h).homeomorph t = h * Φ.homeomorph t * h⁻¹`. -/
@@ -126,7 +129,8 @@ homeomorphism: `(Φ.conj h).finalHomeomorph = h * Φ.finalHomeomorph * h⁻¹`. 
 @[simp]
 theorem finalHomeomorph_conj (h : Y ≃ₜ Y) :
     (Φ.conj h).finalHomeomorph = h * Φ.finalHomeomorph * h⁻¹ := by
-  rw [finalHomeomorph, finalHomeomorph, homeomorph_conj]
+  ext y
+  simp only [finalHomeomorph_apply, final_conj, Homeomorph.mul_apply, Homeomorph.inv_apply]
 
 end AmbientIsotopy
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyConj.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyConj.lean
@@ -60,7 +60,7 @@ variable (Φ : AmbientIsotopy Y)
 at each time `t` run the homeomorphism `Φ t` in the coordinates supplied by `h`, giving
 `z ↦ h (Φ (t, h⁻¹ z))`. The total map is a homeomorphism because it is `Φ`'s total homeomorphism
 pre- and post-composed with the product homeomorphisms `id ×ₜ h⁻¹` and `id ×ₜ h`. -/
-@[expose] noncomputable def transport (h : Y ≃ₜ Z) : AmbientIsotopy Z where
+noncomputable def transport (h : Y ≃ₜ Z) : AmbientIsotopy Z where
   toContinuousMap := ⟨fun p => h (Φ.toContinuousMap (p.1, h.symm p.2)), by fun_prop⟩
   isHomeomorph_total' := by
     have heq : (fun p : I × Z => (p.1, h (Φ.toContinuousMap (p.1, h.symm p.2))))
@@ -77,7 +77,7 @@ pre- and post-composed with the product homeomorphisms `id ×ₜ h⁻¹` and `id
 
 @[simp]
 theorem transport_apply (h : Y ≃ₜ Z) (p : I × Z) :
-    (Φ.transport h).toContinuousMap p = h (Φ.toContinuousMap (p.1, h.symm p.2)) := rfl
+    (Φ.transport h).toContinuousMap p = h (Φ.toContinuousMap (p.1, h.symm p.2)) := (rfl)
 
 @[simp 1100]
 theorem final_transport (h : Y ≃ₜ Z) (z : Z) :
@@ -106,11 +106,11 @@ theorem finalHomeomorph_transport (h : Y ≃ₜ Z) :
 `AmbientIsotopy.transport` in which the change of coordinates fixes the ambient space, so the
 endpoint slices conjugate inside the group `Y ≃ₜ Y`. The total map is
 `(t, y) ↦ (t, h (Φ (t, h⁻¹ y)))`. -/
-@[expose] noncomputable def conj (h : Y ≃ₜ Y) : AmbientIsotopy Y := Φ.transport h
+noncomputable def conj (h : Y ≃ₜ Y) : AmbientIsotopy Y := Φ.transport h
 
 @[simp]
 theorem conj_apply (h : Y ≃ₜ Y) (p : I × Y) :
-    (Φ.conj h).toContinuousMap p = h (Φ.toContinuousMap (p.1, h.symm p.2)) := rfl
+    (Φ.conj h).toContinuousMap p = h (Φ.toContinuousMap (p.1, h.symm p.2)) := (rfl)
 
 @[simp 1100]
 theorem final_conj (h : Y ≃ₜ Y) (y : Y) : (Φ.conj h).final y = h (Φ.final (h.symm y)) := by

--- a/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
@@ -70,12 +70,6 @@ open unitInterval ContinuousMap Topology
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
-private theorem isEmbedding_const_prod (t : I) : IsEmbedding fun x : X => (t, x) :=
-  IsEmbedding.of_comp (by fun_prop) continuous_snd (by
-    convert (IsEmbedding.id : IsEmbedding (id : X → X)) using 1
-    ext x
-    rfl)
-
 /-- An **isotopy** between `f₀ f₁ : C(X, Y)` is a homotopy for which every time slice
 `x ↦ F(t, x)` is a topological embedding.
 
@@ -97,14 +91,6 @@ instance instFunLike : FunLike (Isotopy f₀ f₁) (I × X) Y where
     obtain ⟨G, _⟩ := G
     congr
     exact DFunLike.coe_injective h
-
-/-- The level-preserving total map of an isotopy. -/
-@[expose] def totalMap (F : Isotopy f₀ f₁) : C(I × X, I × Y) :=
-  ⟨fun p => (p.1, F.toHomotopy p), by fun_prop⟩
-
-@[simp]
-theorem totalMap_apply (F : Isotopy f₀ f₁) (p : I × X) :
-    F.totalMap p = (p.1, F.toHomotopy p) := rfl
 
 @[simp]
 theorem apply_zero (F : Isotopy f₀ f₁) (x : X) : F (0, x) = f₀ x :=
@@ -229,7 +215,7 @@ theorem isHomeomorph_apply (t : I) : IsHomeomorph fun y => Φ.toContinuousMap (t
   · let k : Y → I × Y := fun y => (t, y)
     have hk_cont : Continuous k := by fun_prop
     have hcomp : IsEmbedding (k ∘ fun y => Φ.toContinuousMap (t, y)) := by
-      convert Φ.isHomeomorph_total.isEmbedding.comp (isEmbedding_const_prod (X := Y) t) using 1
+      convert Φ.isHomeomorph_total.isEmbedding.comp (isEmbedding_prodMkRight t) using 1
       ext y <;> rfl
     exact IsEmbedding.of_comp (by fun_prop) hk_cont hcomp
   · intro y
@@ -295,7 +281,7 @@ instance : Inhabited (AmbientIsotopy Y) := ⟨refl Y⟩
 
 /-- An ambient isotopy carries any embedding `f` to the embedding `Φ.final ∘ f` through an
 explicit isotopy: at time `t` the embedding is the homeomorphism `Φ t` postcomposed with `f`. -/
-@[expose] def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) where
+def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) where
   toHomotopyWith :=
     { toFun := fun p => Φ.toContinuousMap (p.1, f p.2)
       continuous_toFun := by fun_prop
@@ -306,7 +292,7 @@ explicit isotopy: at time `t` the embedding is the homeomorphism `Φ t` postcomp
 @[simp]
 theorem isotopy_apply {f : C(X, Y)} (hf : IsEmbedding f) (t : I) (x : X) :
     Φ.isotopy hf (t, x) = Φ.toContinuousMap (t, f x) :=
-  rfl
+  (rfl)
 
 /-- **Ambient isotopy implies isotopy**: an ambient isotopy of `Y` carries any embedding `f`
 into `Y` to the isotopic embedding `Φ.final ∘ f`. -/

--- a/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
@@ -95,6 +95,11 @@ instance instFunLike : FunLike (Isotopy f₀ f₁) (I × X) Y where
     congr
     exact DFunLike.coe_injective h
 
+/-- Two isotopies are equal when they agree at every time and point. -/
+@[ext]
+theorem ext {F G : Isotopy f₀ f₁} (h : ∀ x, F x = G x) : F = G :=
+  DFunLike.ext F G h
+
 @[simp]
 theorem apply_zero (F : Isotopy f₀ f₁) (x : X) : F (0, x) = f₀ x :=
   F.map_zero_left x
@@ -105,7 +110,7 @@ theorem apply_one (F : Isotopy f₀ f₁) (x : X) : F (1, x) = f₁ x :=
 
 /-- Every time-slice of an isotopy is a topological embedding. -/
 theorem isEmbedding_apply (F : Isotopy f₀ f₁) (t : I) :
-    IsEmbedding fun x => F.toHomotopy (t, x) :=
+    IsEmbedding fun x => F (t, x) :=
   F.prop' t
 
 /-- The map an isotopy starts at is a topological embedding. -/
@@ -124,6 +129,7 @@ noncomputable def trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f�
 
 /-- The value of a concatenated isotopy is given by the first isotopy on `[0, 1 / 2]`
 and by the second isotopy on `[1 / 2, 1]`, with the time parameter rescaled linearly. -/
+@[simp]
 theorem trans_apply {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) (x : I × X) :
     (F.trans G) x =
       if h : (x.1 : ℝ) ≤ 1 / 2 then
@@ -144,8 +150,11 @@ end Isotopy
 
 Warning: for classical knot theory this non-ambient relation is too coarse: it need not preserve
 knot complements, so knot invariants must be built on `AmbientIsotopic`, not on `Isotopic`. -/
-@[expose] def Isotopic (f₀ f₁ : C(X, Y)) : Prop :=
+def Isotopic (f₀ f₁ : C(X, Y)) : Prop :=
   Nonempty (Isotopy f₀ f₁)
+
+/-- Two maps are isotopic exactly when there is an isotopy between them. -/
+theorem isotopic_def {f₀ f₁ : C(X, Y)} : Isotopic f₀ f₁ ↔ Nonempty (Isotopy f₀ f₁) := Iff.rfl
 
 namespace Isotopic
 
@@ -200,12 +209,21 @@ namespace AmbientIsotopy
 
 variable (Φ : AmbientIsotopy Y)
 
+/-- Two ambient isotopies are equal when their underlying continuous maps agree pointwise. -/
+@[ext]
+theorem ext {Φ Ψ : AmbientIsotopy Y}
+    (h : ∀ p, Φ.toContinuousMap p = Ψ.toContinuousMap p) : Φ = Ψ := by
+  cases Φ
+  cases Ψ
+  simp only [AmbientIsotopy.mk.injEq]
+  exact ContinuousMap.ext h
+
 /-- The level-preserving total map of an ambient isotopy. -/
-@[expose] def totalMap : C(I × Y, I × Y) :=
+def totalMap : C(I × Y, I × Y) :=
   ⟨fun p => (p.1, Φ.toContinuousMap p), by fun_prop⟩
 
 @[simp]
-theorem totalMap_apply (p : I × Y) : Φ.totalMap p = (p.1, Φ.toContinuousMap p) := rfl
+theorem totalMap_apply (p : I × Y) : Φ.totalMap p = (p.1, Φ.toContinuousMap p) := (rfl)
 
 /-- The level-preserving total map of an ambient isotopy is a homeomorphism. -/
 theorem isHomeomorph_total : IsHomeomorph Φ.totalMap :=
@@ -234,39 +252,39 @@ theorem map_zero_left (y : Y) : Φ.toContinuousMap (0, y) = y :=
   Φ.map_zero_left' y
 
 /-- The time-`1` homeomorphism produced by an ambient isotopy, as a continuous map. -/
-@[expose] def final : C(Y, Y) := ⟨fun y => Φ.toContinuousMap (1, y), by fun_prop⟩
+def final : C(Y, Y) := ⟨fun y => Φ.toContinuousMap (1, y), by fun_prop⟩
 
-@[simp]
-theorem final_apply (y : Y) : Φ.final y = Φ.toContinuousMap (1, y) := rfl
+theorem final_apply (y : Y) : Φ.final y = Φ.toContinuousMap (1, y) := (rfl)
 
 /-- The final map produced by an ambient isotopy is a homeomorphism. -/
 theorem isHomeomorph_final : IsHomeomorph Φ.final :=
   Φ.isHomeomorph_apply 1
 
 /-- The time-`t` self-homeomorphism bundled as a `Homeomorph`. -/
-@[expose] noncomputable def homeomorph (t : I) : Y ≃ₜ Y :=
+noncomputable def homeomorph (t : I) : Y ≃ₜ Y :=
   IsHomeomorph.homeomorph (fun y => Φ.toContinuousMap (t, y)) (Φ.isHomeomorph_apply t)
 
 @[simp]
 theorem homeomorph_apply (t : I) (y : Y) : Φ.homeomorph t y = Φ.toContinuousMap (t, y) :=
-  rfl
+  (rfl)
 
 /-- The time-`1` homeomorphism produced by an ambient isotopy. -/
-@[expose] noncomputable def finalHomeomorph : Y ≃ₜ Y :=
+noncomputable def finalHomeomorph : Y ≃ₜ Y :=
   Φ.homeomorph 1
 
 @[simp]
 theorem finalHomeomorph_apply (y : Y) : Φ.finalHomeomorph y = Φ.final y :=
-  rfl
+  (rfl)
 
 /-- The constant ambient isotopy at the identity. -/
-@[expose] def refl (Y : Type*) [TopologicalSpace Y] : AmbientIsotopy Y where
+def refl (Y : Type*) [TopologicalSpace Y] : AmbientIsotopy Y where
   toContinuousMap := ⟨fun p => p.2, by fun_prop⟩
   isHomeomorph_total' := .id
   map_zero_left' _ := rfl
 
 /-- The final map of the constant ambient isotopy is the identity. -/
-theorem final_refl (y : Y) : (refl Y).final y = y := rfl
+@[simp 1100]
+theorem final_refl (y : Y) : (refl Y).final y = y := (rfl)
 
 /-- Every time slice of the constant ambient isotopy is the identity homeomorphism. -/
 @[simp]
@@ -304,21 +322,22 @@ theorem isotopic {f : C(X, Y)} (hf : IsEmbedding f) : Isotopic f (Φ.final.comp 
 
 /-- The level-preserving total map of an ambient isotopy, bundled as a self-homeomorphism of
 `I × Y`. -/
-@[expose] noncomputable def totalHomeomorph : (I × Y) ≃ₜ (I × Y) :=
+noncomputable def totalHomeomorph : (I × Y) ≃ₜ (I × Y) :=
   IsHomeomorph.homeomorph Φ.totalMap Φ.isHomeomorph_total
 
 @[simp]
 theorem totalHomeomorph_apply (p : I × Y) :
-    Φ.totalHomeomorph p = (p.1, Φ.toContinuousMap p) := rfl
+    Φ.totalHomeomorph p = (p.1, Φ.toContinuousMap p) := (rfl)
 
 /-- The inverse total homeomorphism preserves the time coordinate. -/
+@[simp]
 theorem totalHomeomorph_symm_fst (p : I × Y) : (Φ.totalHomeomorph.symm p).1 = p.1 := by
   have h := Φ.totalHomeomorph.apply_symm_apply p
   rw [totalHomeomorph_apply] at h
   exact (Prod.ext_iff.mp h).1
 
 /-- **Composition of ambient isotopies**: follow `Φ_t` then `Ψ_t` at each time `t`. -/
-@[expose] def trans (Ψ : AmbientIsotopy Y) : AmbientIsotopy Y where
+def trans (Ψ : AmbientIsotopy Y) : AmbientIsotopy Y where
   toContinuousMap := ⟨fun p => Ψ.toContinuousMap (p.1, Φ.toContinuousMap p), by fun_prop⟩
   isHomeomorph_total' := by
     have heq : (fun p : I × Y => (p.1, Ψ.toContinuousMap (p.1, Φ.toContinuousMap p)))
@@ -333,13 +352,14 @@ theorem totalHomeomorph_symm_fst (p : I × Y) : (Φ.totalHomeomorph.symm p).1 = 
 
 @[simp]
 theorem trans_apply (Ψ : AmbientIsotopy Y) (p : I × Y) :
-    (Φ.trans Ψ).toContinuousMap p = Ψ.toContinuousMap (p.1, Φ.toContinuousMap p) := rfl
+    (Φ.trans Ψ).toContinuousMap p = Ψ.toContinuousMap (p.1, Φ.toContinuousMap p) := (rfl)
 
 /-- The final map of the composite ambient isotopy `Φ.trans Ψ` is the composition of the final
 maps of `Φ` and `Ψ`: at the endpoint it is `Ψ.final ∘ Φ.final`. -/
-@[simp]
+@[simp 1100]
 theorem final_trans (Ψ : AmbientIsotopy Y) (y : Y) :
-    (Φ.trans Ψ).final y = Ψ.final (Φ.final y) := rfl
+    (Φ.trans Ψ).final y = Ψ.final (Φ.final y) := by
+  rw [final_apply, trans_apply, final_apply, final_apply]
 
 /-- Every time slice of a composite ambient isotopy is the composite of the corresponding
 time slices. -/
@@ -357,7 +377,7 @@ theorem finalHomeomorph_trans (Ψ : AmbientIsotopy Y) :
   rw [finalHomeomorph, finalHomeomorph, finalHomeomorph, homeomorph_trans]
 
 /-- **Inverse of an ambient isotopy**: undo `Φ_t` at each time `t`. -/
-@[expose] noncomputable def symm : AmbientIsotopy Y where
+noncomputable def symm : AmbientIsotopy Y where
   toContinuousMap := ⟨fun p => (Φ.totalHomeomorph.symm p).2,
     continuous_snd.comp Φ.totalHomeomorph.symm.continuous⟩
   isHomeomorph_total' := by
@@ -376,10 +396,11 @@ theorem finalHomeomorph_trans (Ψ : AmbientIsotopy Y) :
 
 @[simp]
 theorem symm_apply (p : I × Y) :
-    Φ.symm.toContinuousMap p = (Φ.totalHomeomorph.symm p).2 := rfl
+    Φ.symm.toContinuousMap p = (Φ.totalHomeomorph.symm p).2 := (rfl)
 
 /-- The inverse ambient isotopy undoes the original: its final map is a left inverse of the
 original final map. -/
+@[simp 1100]
 theorem symm_final_final (y : Y) : Φ.symm.final (Φ.final y) = y := by
   have h1 : Φ.totalHomeomorph (1, y) = (1, Φ.toContinuousMap (1, y)) := by
     rw [totalHomeomorph_apply]
@@ -388,6 +409,7 @@ theorem symm_final_final (y : Y) : Φ.symm.final (Φ.final y) = y := by
 
 /-- The original ambient isotopy undoes its inverse: the original final map is a left inverse of
 the inverse final map. -/
+@[simp 1100]
 theorem final_symm_final (y : Y) : Φ.final (Φ.symm.final y) = y := by
   have hfst : (Φ.totalHomeomorph.symm (1, y)).1 = 1 := Φ.totalHomeomorph_symm_fst (1, y)
   have happ := Φ.totalHomeomorph.apply_symm_apply (1, y)

--- a/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
@@ -16,12 +16,15 @@ embedding, and an *ambient isotopy* of a space `Y` is a
 homotopy from the identity of `Y` whose level-preserving total map `I × Y → I × Y` is a
 homeomorphism. These are the point-set foundations that the geometric-topology roadmap
 (`TauCetiRoadmap/GeometricTopology`) asks for once, in full generality, before specialising.
-The definitions follow Burde--Zieschang, *Knots*, Chapter 1, Definitions 1.1 and 1.2,
-generalized to this continuous topological setting. The non-ambient relation is the general
-point-set notion of isotopy; later knot-equivalence foundations should use ambient isotopy,
-specialized as needed to smooth embeddings `S¹ ↪ M`. Later geometric-topology foundations
-specialize these isotopy and ambient-isotopy notions as appropriate for locally flat isotopy,
-diffeotopies, and concordance.
+`Isotopy` deliberately uses the slice-wise, homotopy-through-embeddings convention.
+Burde--Zieschang, *Knots*, Chapter 1, Definition 1.1 instead requires the associated
+level-preserving map `I × X → I × Y` to be an embedding. The two conditions agree when `X` is
+compact and `Y` is Hausdorff, but the slice-wise condition is weaker for the arbitrary spaces
+allowed here. `AmbientIsotopy` follows their Definition 1.2, generalized to this continuous
+topological setting. The non-ambient relation is a general point-set notion of isotopy; later
+knot-equivalence foundations should use ambient isotopy, specialized as needed to smooth
+embeddings `S¹ ↪ M`. Later geometric-topology foundations specialize these notions as appropriate
+for locally flat isotopy, diffeotopies, and concordance.
 
 ## A warning: non-ambient isotopy is degenerate for knots
 
@@ -32,7 +35,7 @@ knot-theoretic content: an ambient isotopy induces a homeomorphism of complement
 invariants must be built on `AmbientIsotopy` and the `AmbientIsotopic` equivalence from
 `TauCeti.Topology.Homotopy.AmbientIsotopic.Basic`, not on `Isotopy`/`Isotopic`. See
 Burde--Zieschang, *Knots*, Chapter 1 §A, where ambient isotopy (Definition 1.2) is introduced
-after the naive isotopy of Definition 1.1.
+after their stronger level-preserving notion of non-ambient isotopy (Definition 1.1).
 
 ## Main definitions
 
@@ -76,7 +79,7 @@ variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 As an equivalence this non-ambient relation is too coarse for classical knot theory: it need not
 extend to a motion of the ambient space and therefore need not preserve knot complements. Use
 `AmbientIsotopy`/`AmbientIsotopic` for knot equivalence; see the module docstring and the
-Burde--Zieschang reference. -/
+comparison with the Burde--Zieschang definition there. -/
 structure Isotopy (f₀ f₁ : C(X, Y)) extends
     HomotopyWith f₀ f₁ fun g : C(X, Y) => IsEmbedding g
 

--- a/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
@@ -52,10 +52,6 @@ after their stronger level-preserving notion of non-ambient isotopy (Definition 
 
 * `TauCeti.Isotopy.isEmbedding_left` / `isEmbedding_right`: the endpoints of an isotopy are
   embeddings.
-* `TauCeti.Isotopy.toHomotopyWith`: an isotopy is, in particular, a Mathlib homotopy through
-  embeddings.
-* `TauCeti.Isotopy.refl` / `TauCeti.Isotopy.symm` / `TauCeti.Isotopy.trans`: bundled
-  constructors for constant, reversed, and concatenated isotopies.
 * `TauCeti.Isotopic.refl` / `TauCeti.Isotopic.symm` / `TauCeti.Isotopic.trans`: isotopy is
   reflexive on embeddings, symmetric, and transitive.
 * `TauCeti.Isotopic.homotopic`: isotopic maps are homotopic.
@@ -82,33 +78,12 @@ As an equivalence this non-ambient relation is too coarse for classical knot the
 extend to a motion of the ambient space and therefore need not preserve knot complements. Use
 `AmbientIsotopy`/`AmbientIsotopic` for knot equivalence; see the module docstring and the
 comparison with the Burde--Zieschang definition there. -/
-structure Isotopy (f₀ f₁ : C(X, Y)) extends
-    HomotopyWith f₀ f₁ fun g : C(X, Y) => IsEmbedding g
+abbrev Isotopy (f₀ f₁ : C(X, Y)) :=
+  HomotopyWith f₀ f₁ fun g : C(X, Y) => IsEmbedding g
 
 namespace Isotopy
 
 variable {f₀ f₁ : C(X, Y)}
-
-instance instFunLike : FunLike (Isotopy f₀ f₁) (I × X) Y where
-  coe F := F.toHomotopyWith
-  coe_injective F G h := by
-    obtain ⟨F, _⟩ := F
-    obtain ⟨G, _⟩ := G
-    congr
-    exact DFunLike.coe_injective h
-
-/-- Two isotopies are equal when they agree at every time and point. -/
-@[ext]
-theorem ext {F G : Isotopy f₀ f₁} (h : ∀ x, F x = G x) : F = G :=
-  DFunLike.ext F G h
-
-@[simp]
-theorem apply_zero (F : Isotopy f₀ f₁) (x : X) : F (0, x) = f₀ x :=
-  F.map_zero_left x
-
-@[simp]
-theorem apply_one (F : Isotopy f₀ f₁) (x : X) : F (1, x) = f₁ x :=
-  F.map_one_left x
 
 /-- Every time-slice of an isotopy is a topological embedding. -/
 theorem isEmbedding_apply (F : Isotopy f₀ f₁) (t : I) :
@@ -122,37 +97,6 @@ theorem isEmbedding_left (F : Isotopy f₀ f₁) : IsEmbedding f₀ := by
 /-- The map an isotopy ends at is a topological embedding. -/
 theorem isEmbedding_right (F : Isotopy f₀ f₁) : IsEmbedding f₁ := by
   simpa using F.isEmbedding_apply 1
-
-/-- The constant homotopy at an embedding is an isotopy. -/
-def refl (f : C(X, Y)) (hf : IsEmbedding f) : Isotopy f f where
-  toHomotopyWith := HomotopyWith.refl f hf
-
-/-- Reverse an isotopy by reversing its time parameter. -/
-def symm (F : Isotopy f₀ f₁) : Isotopy f₁ f₀ where
-  toHomotopyWith := F.toHomotopyWith.symm
-
-/-- Concatenate two isotopies: the result follows `F` on `[0, 1 / 2]` and `G` on `[1 / 2, 1]`,
-with the time parameter rescaled linearly. -/
-noncomputable def trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
-    Isotopy f₀ f₂ where
-  toHomotopyWith := F.toHomotopyWith.trans G.toHomotopyWith
-
-/-- The value of a concatenated isotopy is given by the first isotopy on `[0, 1 / 2]`
-and by the second isotopy on `[1 / 2, 1]`, with the time parameter rescaled linearly. -/
-@[simp]
-theorem trans_apply {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) (x : I × X) :
-    (F.trans G) x =
-      if h : (x.1 : ℝ) ≤ 1 / 2 then
-        F (⟨2 * x.1, (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨x.1.2.1, h⟩⟩, x.2)
-      else
-        G (⟨2 * x.1 - 1,
-          unitInterval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, x.1.2.2⟩⟩, x.2) :=
-  Homotopy.trans_apply F.toHomotopy G.toHomotopy x
-
-instance instHomotopyLike : HomotopyLike (Isotopy f₀ f₁) f₀ f₁ where
-  map_continuous F := F.continuous_toFun
-  map_zero_left F := F.map_zero_left
-  map_one_left F := F.map_one_left
 
 end Isotopy
 
@@ -175,7 +119,7 @@ theorem of_isotopy (F : Isotopy f₀ f₁) : Isotopic f₀ f₁ := ⟨F⟩
 
 /-- Isotopy is reflexive on embeddings. -/
 theorem refl (f : C(X, Y)) (hf : IsEmbedding f) : Isotopic f f :=
-  ⟨Isotopy.refl f hf⟩
+  ⟨HomotopyWith.refl f hf⟩
 
 /-- Isotopy is symmetric. -/
 @[symm]
@@ -202,7 +146,7 @@ theorem homotopic (h : Isotopic f₀ f₁) : Homotopic f₀ f₁ :=
 /-- Isotopic maps are homotopic through embeddings in Mathlib's generic API. -/
 theorem homotopicWith (h : Isotopic f₀ f₁) :
     HomotopicWith f₀ f₁ fun g : C(X, Y) => IsEmbedding g :=
-  ⟨h.some.toHomotopyWith⟩
+  h
 
 end Isotopic
 
@@ -313,12 +257,11 @@ instance : Inhabited (AmbientIsotopy Y) := ⟨refl Y⟩
 /-- An ambient isotopy carries any embedding `f` to the embedding `Φ.final ∘ f` through an
 explicit isotopy: at time `t` the embedding is the homeomorphism `Φ t` postcomposed with `f`. -/
 def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) where
-  toHomotopyWith :=
-    { toFun := fun p => Φ.toContinuousMap (p.1, f p.2)
-      continuous_toFun := by fun_prop
-      map_zero_left := fun x => Φ.map_zero_left (f x)
-      map_one_left := fun _ => rfl
-      prop' := fun t => (Φ.isHomeomorph_apply t).isEmbedding.comp hf }
+  toFun := fun p => Φ.toContinuousMap (p.1, f p.2)
+  continuous_toFun := by fun_prop
+  map_zero_left := fun x => Φ.map_zero_left (f x)
+  map_one_left := fun _ => rfl
+  prop' := fun t => (Φ.isHomeomorph_apply t).isEmbedding.comp hf
 
 @[simp]
 theorem isotopy_apply {f : C(X, Y)} (hf : IsEmbedding f) (t : I) (x : X) :

--- a/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
@@ -54,6 +54,8 @@ after their stronger level-preserving notion of non-ambient isotopy (Definition 
   embeddings.
 * `TauCeti.Isotopy.toHomotopyWith`: an isotopy is, in particular, a Mathlib homotopy through
   embeddings.
+* `TauCeti.Isotopy.refl` / `TauCeti.Isotopy.symm` / `TauCeti.Isotopy.trans`: bundled
+  constructors for constant, reversed, and concatenated isotopies.
 * `TauCeti.Isotopic.refl` / `TauCeti.Isotopic.symm` / `TauCeti.Isotopic.trans`: isotopy is
   reflexive on embeddings, symmetric, and transitive.
 * `TauCeti.Isotopic.homotopic`: isotopic maps are homotopic.
@@ -121,6 +123,14 @@ theorem isEmbedding_left (F : Isotopy f₀ f₁) : IsEmbedding f₀ := by
 theorem isEmbedding_right (F : Isotopy f₀ f₁) : IsEmbedding f₁ := by
   simpa using F.isEmbedding_apply 1
 
+/-- The constant homotopy at an embedding is an isotopy. -/
+def refl (f : C(X, Y)) (hf : IsEmbedding f) : Isotopy f f where
+  toHomotopyWith := HomotopyWith.refl f hf
+
+/-- Reverse an isotopy by reversing its time parameter. -/
+def symm (F : Isotopy f₀ f₁) : Isotopy f₁ f₀ where
+  toHomotopyWith := F.toHomotopyWith.symm
+
 /-- Concatenate two isotopies: the result follows `F` on `[0, 1 / 2]` and `G` on `[1 / 2, 1]`,
 with the time parameter rescaled linearly. -/
 noncomputable def trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
@@ -165,12 +175,12 @@ theorem of_isotopy (F : Isotopy f₀ f₁) : Isotopic f₀ f₁ := ⟨F⟩
 
 /-- Isotopy is reflexive on embeddings. -/
 theorem refl (f : C(X, Y)) (hf : IsEmbedding f) : Isotopic f f :=
-  ⟨{ toHomotopyWith := HomotopyWith.refl f hf }⟩
+  ⟨Isotopy.refl f hf⟩
 
 /-- Isotopy is symmetric. -/
 @[symm]
 theorem symm (h : Isotopic f₀ f₁) : Isotopic f₁ f₀ :=
-  ⟨{ toHomotopyWith := h.some.toHomotopyWith.symm }⟩
+  ⟨h.some.symm⟩
 
 /-- Isotopy is transitive. -/
 @[trans]

--- a/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
@@ -11,8 +11,8 @@ public import Mathlib.Topology.Maps.Basic
 /-!
 # Isotopy and ambient isotopy
 
-An *isotopy* between two continuous maps is a homotopy whose level-preserving total map
-`I × X → I × Y` is a topological embedding, and an *ambient isotopy* of a space `Y` is a
+An *isotopy* between two continuous maps is a homotopy whose every time slice is a topological
+embedding, and an *ambient isotopy* of a space `Y` is a
 homotopy from the identity of `Y` whose level-preserving total map `I × Y → I × Y` is a
 homeomorphism. These are the point-set foundations that the geometric-topology roadmap
 (`TauCetiRoadmap/GeometricTopology`) asks for once, in full generality, before specialising.
@@ -36,8 +36,7 @@ after the naive isotopy of Definition 1.1.
 
 ## Main definitions
 
-* `TauCeti.Isotopy f₀ f₁`: a homotopy from `f₀` to `f₁` whose total level-preserving map is a
-  topological embedding.
+* `TauCeti.Isotopy f₀ f₁`: a homotopy from `f₀` to `f₁` through topological embeddings.
 * `TauCeti.Isotopic f₀ f₁`: the proposition that such an isotopy exists. This is the reusable
   general non-ambient relation; knot-equivalence layers should instead use `AmbientIsotopic` from
   `TauCeti.Topology.Homotopy.AmbientIsotopic.Basic`.
@@ -77,84 +76,22 @@ private theorem isEmbedding_const_prod (t : I) : IsEmbedding fun x : X => (t, x)
     ext x
     rfl)
 
-/-- A map is inducing if its restrictions to the preimages of a closed cover of the codomain are
-inducing. (The closedness of the cover in the *codomain* is what makes the gluing work, even
-though the analogous statement for an arbitrary closed cover of the domain fails.) -/
-private theorem isInducing_of_isClosed_cover {Z W : Type*} [TopologicalSpace Z]
-    [TopologicalSpace W] {f : Z → W} (hf : Continuous f) {D₁ D₂ : Set W}
-    (h₁ : IsClosed D₁) (h₂ : IsClosed D₂) (hcov : D₁ ∪ D₂ = Set.univ)
-    (hi₁ : IsInducing ((f ⁻¹' D₁).domRestrict f)) (hi₂ : IsInducing ((f ⁻¹' D₂).domRestrict f)) :
-    IsInducing f := by
-  rw [isInducing_iff_nhds]
-  intro z
-  refine le_antisymm ((hf.tendsto z).le_comap) ?_
-  rw [Filter.le_def]
-  intro U hU
-  rw [Filter.mem_comap]
-  have extract : ∀ D : Set W, IsInducing ((f ⁻¹' D).domRestrict f) → f z ∈ D →
-      ∃ V ∈ 𝓝 (f z), f ⁻¹' V ∩ f ⁻¹' D ⊆ U := by
-    intro D hi hzD
-    rw [isInducing_iff_nhds] at hi
-    have hUsub : Subtype.val ⁻¹' U ∈ 𝓝 (⟨z, hzD⟩ : f ⁻¹' D) :=
-      continuous_subtype_val.continuousAt.preimage_mem_nhds hU
-    rw [hi ⟨z, hzD⟩, Filter.mem_comap] at hUsub
-    obtain ⟨V, hV, hVsub⟩ := hUsub
-    refine ⟨V, hV, ?_⟩
-    rintro y ⟨hyV, hyD⟩
-    -- The restricted map applies definitionally to `f y`, so this `show` only changes
-    -- `hyV : f y ∈ V` into the preimage-membership type expected by `hVsub`.
-    exact hVsub (show ((f ⁻¹' D).domRestrict f) ⟨y, hyD⟩ ∈ V from hyV)
-  have wstep : ∀ D : Set W, IsClosed D → IsInducing ((f ⁻¹' D).domRestrict f) →
-      ∃ V ∈ 𝓝 (f z), f ⁻¹' V ∩ f ⁻¹' D ⊆ U := by
-    intro D hD hi
-    by_cases hzD : f z ∈ D
-    · exact extract D hi hzD
-    · exact ⟨Dᶜ, hD.isOpen_compl.mem_nhds hzD, by rintro y ⟨hyc, hyd⟩; exact absurd hyd hyc⟩
-  obtain ⟨V₁, hV₁, hs₁⟩ := wstep D₁ h₁ hi₁
-  obtain ⟨V₂, hV₂, hs₂⟩ := wstep D₂ h₂ hi₂
-  refine ⟨V₁ ∩ V₂, Filter.inter_mem hV₁ hV₂, ?_⟩
-  rw [Set.preimage_inter]
-  intro y hy
-  have hycov : y ∈ f ⁻¹' D₁ ∪ f ⁻¹' D₂ := by
-    rw [← Set.preimage_union, hcov]; exact Set.mem_univ y
-  rcases hycov with h | h
-  · exact hs₁ ⟨hy.1, h⟩
-  · exact hs₂ ⟨hy.2, h⟩
-
-/-- If `e` is an embedding parametrising the preimage `f ⁻¹' D` and `f ∘ e` is inducing, then the
-restriction of `f` to `f ⁻¹' D` is inducing. -/
-private theorem isInducing_restrict_of_embedding {Z W A : Type*} [TopologicalSpace Z]
-    [TopologicalSpace W] [TopologicalSpace A] {f : Z → W} {D : Set W} {e : A → Z}
-    (he : IsEmbedding e) (hrange : Set.range e = f ⁻¹' D) (hfe : IsInducing (f ∘ e)) :
-    IsInducing ((f ⁻¹' D).domRestrict f) := by
-  let φ : A ≃ₜ (f ⁻¹' D) := he.toHomeomorph.trans (Homeomorph.setCongr hrange)
-  have hφ_apply (a : A) : (φ a : Z) = e a := by
-    simp only [φ, Homeomorph.trans_apply]
-    simp [Homeomorph.setCongr]
-  have hcomp : (f ⁻¹' D).domRestrict f ∘ φ = f ∘ e := by
-    funext a
-    exact congrArg f (hφ_apply a)
-  have h0 : IsInducing ((f ⁻¹' D).domRestrict f ∘ φ) := hcomp ▸ hfe
-  have h2 := h0.comp φ.symm.isInducing
-  rwa [Function.comp_assoc, Homeomorph.self_comp_symm, Function.comp_id] at h2
-
-/-- An **isotopy** between `f₀ f₁ : C(X, Y)` is a homotopy whose level-preserving total map
-`I × X → I × Y` is a topological embedding.
+/-- An **isotopy** between `f₀ f₁ : C(X, Y)` is a homotopy for which every time slice
+`x ↦ F(t, x)` is a topological embedding.
 
 As an equivalence this non-ambient relation is too coarse for classical knot theory: it need not
 extend to a motion of the ambient space and therefore need not preserve knot complements. Use
 `AmbientIsotopy`/`AmbientIsotopic` for knot equivalence; see the module docstring and the
 Burde--Zieschang reference. -/
-structure Isotopy (f₀ f₁ : C(X, Y)) extends Homotopy f₀ f₁ where
-  /-- the level-preserving total map of an isotopy is a topological embedding -/
-  isEmbedding_total' : IsEmbedding fun p : I × X => (p.1, toFun p)
+structure Isotopy (f₀ f₁ : C(X, Y)) extends
+    HomotopyWith f₀ f₁ fun g : C(X, Y) => IsEmbedding g
 
 namespace Isotopy
 
 variable {f₀ f₁ : C(X, Y)}
 
 instance instFunLike : FunLike (Isotopy f₀ f₁) (I × X) Y where
-  coe F := F.toFun
+  coe F := F.toHomotopyWith
   coe_injective F G h := by
     obtain ⟨F, _⟩ := F
     obtain ⟨G, _⟩ := G
@@ -177,25 +114,10 @@ theorem apply_zero (F : Isotopy f₀ f₁) (x : X) : F (0, x) = f₀ x :=
 theorem apply_one (F : Isotopy f₀ f₁) (x : X) : F (1, x) = f₁ x :=
   F.map_one_left x
 
-/-- The level-preserving total map of an isotopy is a topological embedding. -/
-theorem isEmbedding_total (F : Isotopy f₀ f₁) : IsEmbedding F.totalMap :=
-  F.isEmbedding_total'
-
 /-- Every time-slice of an isotopy is a topological embedding. -/
 theorem isEmbedding_apply (F : Isotopy f₀ f₁) (t : I) :
-    IsEmbedding fun x => F.toHomotopy (t, x) := by
-  let k : Y → I × Y := fun y => (t, y)
-  have hk_cont : Continuous k := by fun_prop
-  have hcomp : IsEmbedding (k ∘ fun x => F.toHomotopy (t, x)) := by
-    convert F.isEmbedding_total.comp (isEmbedding_const_prod (X := X) t) using 1
-    ext x <;> rfl
-  exact IsEmbedding.of_comp (by fun_prop) hk_cont hcomp
-
-/-- An isotopy is, in particular, a `HomotopyWith` whose slices are embeddings. -/
-def toHomotopyWith (F : Isotopy f₀ f₁) :
-    HomotopyWith f₀ f₁ fun g : C(X, Y) => IsEmbedding g where
-  toHomotopy := F.toHomotopy
-  prop' := F.isEmbedding_apply
+    IsEmbedding fun x => F.toHomotopy (t, x) :=
+  F.prop' t
 
 /-- The map an isotopy starts at is a topological embedding. -/
 theorem isEmbedding_left (F : Isotopy f₀ f₁) : IsEmbedding f₀ := by
@@ -205,160 +127,11 @@ theorem isEmbedding_left (F : Isotopy f₀ f₁) : IsEmbedding f₀ := by
 theorem isEmbedding_right (F : Isotopy f₀ f₁) : IsEmbedding f₁ := by
   simpa using F.isEmbedding_apply 1
 
-/-- Value of the concatenated homotopy on the first half `[0, 1 / 2]`, with the time parameter
-rescaled to `2 * t`. -/
-private theorem trans_toHomotopy_apply_of_le (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) {t : I} (x : X)
-    (h : (t : ℝ) ≤ 1 / 2) : (F.toHomotopy.trans G.toHomotopy) (t, x)
-      = F.toHomotopy (⟨2 * t, (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨t.2.1, h⟩⟩, x) := by
-  rw [Homotopy.trans_apply, dite_eq_left h]
-
-/-- Value of the concatenated homotopy on the second half `[1 / 2, 1]`, with the time parameter
-rescaled to `2 * t - 1`. -/
-private theorem trans_toHomotopy_apply_of_not_le (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) {t : I}
-    (x : X) (h : ¬ (t : ℝ) ≤ 1 / 2) : (F.toHomotopy.trans G.toHomotopy) (t, x)
-      = G.toHomotopy
-          (⟨2 * t - 1, unitInterval.two_mul_sub_one_mem_iff.2 ⟨(not_le.1 h).le, t.2.2⟩⟩, x) := by
-  rw [Homotopy.trans_apply, dite_eq_right h]
-
-/-- Halving reparametrisation `s ↦ s / 2 : I → I`, with image the left half `[0, 1 / 2]`. -/
-private noncomputable def half (s : I) : I :=
-  ⟨(s : ℝ) / 2, by constructor <;> [linarith [s.2.1]; linarith [s.2.2]]⟩
-
-/-- Right-half reparametrisation `s ↦ s / 2 + 1 / 2 : I → I`, with image `[1 / 2, 1]`. -/
-private noncomputable def halfRight (s : I) : I :=
-  ⟨(s : ℝ) / 2 + 1 / 2, by constructor <;> [linarith [s.2.1]; linarith [s.2.2]]⟩
-
-private theorem coe_half (s : I) : (half s : ℝ) = (s : ℝ) / 2 := rfl
-private theorem coe_halfRight (s : I) : (halfRight s : ℝ) = (s : ℝ) / 2 + 1 / 2 := rfl
-
-private theorem injective_half : Function.Injective half := fun a b hab =>
-  Subtype.ext (by have := congrArg Subtype.val hab; simp only [coe_half] at this; linarith)
-
-private theorem injective_halfRight : Function.Injective halfRight := fun a b hab =>
-  Subtype.ext (by have := congrArg Subtype.val hab; simp only [coe_halfRight] at this; linarith)
-
-private theorem half_left_inv (t : I) (ht : (t : ℝ) ≤ 1 / 2) :
-    half (⟨2 * t, ⟨by linarith [t.2.1], by linarith [ht]⟩⟩ : I) = t := by
-  apply Subtype.ext
-  simp only [coe_half]
-  ring
-
-private theorem halfRight_right_inv (t : I) (ht : 1 / 2 ≤ (t : ℝ)) :
-    halfRight (⟨2 * t - 1, ⟨by linarith [ht], by linarith [t.2.2]⟩⟩ : I) = t := by
-  apply Subtype.ext
-  simp only [coe_halfRight]
-  ring
-
-private theorem isEmbedding_half : IsEmbedding half :=
-  ((Continuous.subtype_mk (by fun_prop) _).isClosedEmbedding injective_half).isEmbedding
-
-private theorem isEmbedding_halfRight : IsEmbedding halfRight :=
-  ((Continuous.subtype_mk (by fun_prop) _).isClosedEmbedding injective_halfRight).isEmbedding
-
-private theorem range_half : Set.range half = {t : I | (t : ℝ) ≤ 1 / 2} := by
-  ext t
-  simp only [Set.mem_range, Set.mem_ofPred_eq]
-  refine ⟨?_, fun ht => ⟨⟨2 * t, ⟨by linarith [t.2.1], by linarith⟩⟩, ?_⟩⟩
-  · rintro ⟨s, rfl⟩; rw [coe_half]; linarith [s.2.2]
-  · exact half_left_inv t ht
-
-private theorem range_halfRight : Set.range halfRight = {t : I | 1 / 2 ≤ (t : ℝ)} := by
-  ext t
-  simp only [Set.mem_range, Set.mem_ofPred_eq]
-  refine ⟨?_, fun ht => ⟨⟨2 * t - 1, ⟨by linarith, by linarith [t.2.2]⟩⟩, ?_⟩⟩
-  · rintro ⟨s, rfl⟩; rw [coe_halfRight]; linarith [s.2.1]
-  · exact halfRight_right_inv t ht
-
-private theorem trans_half (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) (s : I) (x : X) :
-    (F.toHomotopy.trans G.toHomotopy) (half s, x) = F.toHomotopy (s, x) := by
-  have h : ((half s : I) : ℝ) ≤ 1 / 2 := by rw [coe_half]; linarith [s.2.2]
-  rw [trans_toHomotopy_apply_of_le _ _ _ h]
-  congr 2
-  apply Subtype.ext
-  simp only [coe_half]; ring
-
-private theorem trans_halfRight (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) (s : I) (x : X) :
-    (F.toHomotopy.trans G.toHomotopy) (halfRight s, x) = G.toHomotopy (s, x) := by
-  by_cases h : ((halfRight s : I) : ℝ) ≤ 1 / 2
-  · have hs0 : (s : ℝ) = 0 := le_antisymm (by rw [coe_halfRight] at h; linarith) s.2.1
-    have hs : s = (0 : I) := Subtype.ext (by rw [hs0]; rfl)
-    subst hs
-    rw [trans_toHomotopy_apply_of_le _ _ _ h]
-    have key : (⟨2 * ((halfRight (0 : I)) : ℝ), by simp only [coe_halfRight]; norm_num⟩ : I) = 1 :=
-      Subtype.ext (by simp only [coe_halfRight]; norm_num)
-    rw [key]
-    simp
-  · rw [trans_toHomotopy_apply_of_not_le _ _ _ h]
-    congr 2
-    apply Subtype.ext
-    simp only [coe_halfRight]; ring
-
-/-- One half of a concatenation. Where the cylinder is parametrised by the embedding `e`, the
-concatenated total map `T` is `e × id` composed with the factor's total map, so it is inducing
-there. This is used at `e = half` with the first isotopy and at `e = halfRight` with the second. -/
-private theorem isInducing_domRestrict_of_isEmbedding_prodMap (H : Isotopy f₀ f₁) {e : I → I}
-    (he : IsEmbedding e) {T : I × X → I × Y} {D : Set (I × Y)}
-    (hrange : Set.range (Prod.map e (id : X → X)) = T ⁻¹' D)
-    (hTe : T ∘ (Prod.map e (id : X → X)) = (Prod.map e (id : Y → Y)) ∘ H.totalMap) :
-    IsInducing ((T ⁻¹' D).domRestrict T) :=
-  isInducing_restrict_of_embedding (he.prodMap IsEmbedding.id) hrange
-    (hTe ▸ (he.prodMap IsEmbedding.id).isInducing.comp H.isEmbedding_total.isInducing)
-
-/-- The total map of a concatenation is inducing: it is inducing on each closed half of the
-cylinder, where it is a reparametrisation of a factor's total map, and the two halves cover. -/
-private theorem isInducing_totalMap_trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
-    IsInducing fun p : I × X => (p.1, (F.toHomotopy.trans G.toHomotopy) p) := by
-  set T : I × X → I × Y := fun p => (p.1, (F.toHomotopy.trans G.toHomotopy) p) with hT
-  have hfst : Continuous fun q : I × Y => (q.1 : ℝ) := by fun_prop
-  set D₁ : Set (I × Y) := {q | (q.1 : ℝ) ≤ 1 / 2} with hD₁def
-  set D₂ : Set (I × Y) := {q | 1 / 2 ≤ (q.1 : ℝ)} with hD₂def
-  have hcov : D₁ ∪ D₂ = Set.univ := by
-    ext q
-    simp only [hD₁def, hD₂def, Set.mem_union, Set.mem_ofPred_eq, Set.mem_univ, iff_true]
-    exact le_total _ _
-  have hrange₁ : Set.range (Prod.map half (id : X → X)) = T ⁻¹' D₁ := by
-    rw [Set.range_prodMap, Set.range_id, range_half]; ext ⟨t, x⟩; simp [hT, hD₁def]
-  have hTe₁ : T ∘ (Prod.map half (id : X → X))
-      = (Prod.map half (id : Y → Y)) ∘ F.totalMap := by
-    funext p; obtain ⟨s, x⟩ := p
-    simp only [Function.comp_apply, Prod.map_apply, id_eq, hT, totalMap_apply]
-    rw [trans_half]
-  have hrange₂ : Set.range (Prod.map halfRight (id : X → X)) = T ⁻¹' D₂ := by
-    rw [Set.range_prodMap, Set.range_id, range_halfRight]; ext ⟨t, x⟩; simp [hT, hD₂def]
-  have hTe₂ : T ∘ (Prod.map halfRight (id : X → X))
-      = (Prod.map halfRight (id : Y → Y)) ∘ G.totalMap := by
-    funext p; obtain ⟨s, x⟩ := p
-    simp only [Function.comp_apply, Prod.map_apply, id_eq, hT, totalMap_apply]
-    rw [trans_halfRight]
-  exact isInducing_of_isClosed_cover (by fun_prop) (isClosed_le hfst continuous_const)
-    (isClosed_le continuous_const hfst) hcov
-    (isInducing_domRestrict_of_isEmbedding_prodMap F isEmbedding_half hrange₁ hTe₁)
-    (isInducing_domRestrict_of_isEmbedding_prodMap G isEmbedding_halfRight hrange₂ hTe₂)
-
-/-- The total map of a concatenation is injective: on each half it agrees with the corresponding
-factor's total map, which is injective, and the time coordinate is preserved. -/
-private theorem totalMap_trans_injective {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
-    Function.Injective fun p : I × X => (p.1, (F.toHomotopy.trans G.toHomotopy) p) := by
-  rintro ⟨t, x⟩ ⟨t', x'⟩ hpp
-  have ht : t = t' := congrArg Prod.fst hpp
-  subst ht
-  have hH : (F.toHomotopy.trans G.toHomotopy) (t, x)
-      = (F.toHomotopy.trans G.toHomotopy) (t, x') := congrArg Prod.snd hpp
-  by_cases h : (t : ℝ) ≤ 1 / 2
-  · rw [trans_toHomotopy_apply_of_le _ _ _ h, trans_toHomotopy_apply_of_le _ _ _ h] at hH
-    exact Prod.ext rfl ((F.isEmbedding_apply _).injective hH)
-  · rw [trans_toHomotopy_apply_of_not_le _ _ _ h,
-      trans_toHomotopy_apply_of_not_le _ _ _ h] at hH
-    exact Prod.ext rfl ((G.isEmbedding_apply _).injective hH)
-
 /-- Concatenate two isotopies: the result follows `F` on `[0, 1 / 2]` and `G` on `[1 / 2, 1]`,
-with the time parameter rescaled linearly. The concatenated total map is an embedding because it
-is one on each closed half (where it is `F`'s or `G`'s total embedding, reparametrised), and these
-glue along the closed cover `{(t, y) | t ≤ 1 / 2}`, `{(t, y) | 1 / 2 ≤ t}` of the codomain. -/
+with the time parameter rescaled linearly. -/
 noncomputable def trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
     Isotopy f₀ f₂ where
-  toHomotopy := F.toHomotopy.trans G.toHomotopy
-  isEmbedding_total' := ⟨isInducing_totalMap_trans F G, totalMap_trans_injective F G⟩
+  toHomotopyWith := F.toHomotopyWith.trans G.toHomotopyWith
 
 /-- The value of a concatenated isotopy is given by the first isotopy on `[0, 1 / 2]`
 and by the second isotopy on `[1 / 2, 1]`, with the time parameter rescaled linearly. -/
@@ -394,22 +167,12 @@ theorem of_isotopy (F : Isotopy f₀ f₁) : Isotopic f₀ f₁ := ⟨F⟩
 
 /-- Isotopy is reflexive on embeddings. -/
 theorem refl (f : C(X, Y)) (hf : IsEmbedding f) : Isotopic f f :=
-  ⟨{ toHomotopy := Homotopy.refl f,
-      isEmbedding_total' := IsEmbedding.id.prodMap hf }⟩
+  ⟨{ toHomotopyWith := HomotopyWith.refl f hf }⟩
 
 /-- Isotopy is symmetric. -/
 @[symm]
 theorem symm (h : Isotopic f₀ f₁) : Isotopic f₁ f₀ :=
-  ⟨{ toHomotopy := h.some.toHomotopy.symm,
-      isEmbedding_total' := by
-        let e : I × X ≃ₜ I × X :=
-          unitInterval.symmHomeomorph.prodCongr (Homeomorph.refl X)
-        let e' : I × Y ≃ₜ I × Y :=
-          unitInterval.symmHomeomorph.prodCongr (Homeomorph.refl Y)
-        convert e'.isEmbedding.comp (h.some.isEmbedding_total.comp e.isEmbedding) using 1
-        ext p
-        · simp [Function.comp_def, Isotopy.totalMap, e, e', unitInterval.symm_symm]
-        · exact congrArg h.some.toHomotopy (by ext <;> simp [e]) }⟩
+  ⟨{ toHomotopyWith := h.some.toHomotopyWith.symm }⟩
 
 /-- Isotopy is transitive. -/
 @[trans]
@@ -530,22 +293,15 @@ theorem finalHomeomorph_refl : (refl Y).finalHomeomorph = Homeomorph.refl Y := b
 
 instance : Inhabited (AmbientIsotopy Y) := ⟨refl Y⟩
 
-private theorem isotopy_totalMap_eq {f : C(X, Y)} :
-    (fun p : I × X => (p.1, Φ.toContinuousMap (p.1, f p.2))) =
-      Φ.totalMap ∘ Prod.map id f :=
-  rfl
-
 /-- An ambient isotopy carries any embedding `f` to the embedding `Φ.final ∘ f` through an
 explicit isotopy: at time `t` the embedding is the homeomorphism `Φ t` postcomposed with `f`. -/
 @[expose] def isotopy {f : C(X, Y)} (hf : IsEmbedding f) : Isotopy f (Φ.final.comp f) where
-  toHomotopy :=
+  toHomotopyWith :=
     { toFun := fun p => Φ.toContinuousMap (p.1, f p.2)
       continuous_toFun := by fun_prop
       map_zero_left := fun x => Φ.map_zero_left (f x)
-      map_one_left := fun _ => rfl }
-  isEmbedding_total' := by
-    rw [isotopy_totalMap_eq]
-    exact Φ.isHomeomorph_total.isEmbedding.comp (IsEmbedding.id.prodMap hf)
+      map_one_left := fun _ => rfl
+      prop' := fun t => (Φ.isHomeomorph_apply t).isEmbedding.comp hf }
 
 @[simp]
 theorem isotopy_apply {f : C(X, Y)} (hf : IsEmbedding f) (t : I) (x : X) :

--- a/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
@@ -208,6 +208,7 @@ theorem map_zero_left (y : Y) : Φ.toContinuousMap (0, y) = y :=
 /-- The time-`1` homeomorphism produced by an ambient isotopy, as a continuous map. -/
 def final : C(Y, Y) := ⟨fun y => Φ.toContinuousMap (1, y), by fun_prop⟩
 
+@[simp]
 theorem final_apply (y : Y) : Φ.final y = Φ.toContinuousMap (1, y) := (rfl)
 
 /-- The final map produced by an ambient isotopy is a homeomorphism. -/
@@ -353,7 +354,7 @@ theorem symm_apply (p : I × Y) :
 
 /-- The inverse ambient isotopy undoes the original: its final map is a left inverse of the
 original final map. -/
-@[simp 1100]
+@[simp↓ 1100]
 theorem symm_final_final (y : Y) : Φ.symm.final (Φ.final y) = y := by
   have h1 : Φ.totalHomeomorph (1, y) = (1, Φ.toContinuousMap (1, y)) := by
     rw [totalHomeomorph_apply]
@@ -362,7 +363,7 @@ theorem symm_final_final (y : Y) : Φ.symm.final (Φ.final y) = y := by
 
 /-- The original ambient isotopy undoes its inverse: the original final map is a left inverse of
 the inverse final map. -/
-@[simp 1100]
+@[simp↓ 1100]
 theorem final_symm_final (y : Y) : Φ.final (Φ.symm.final y) = y := by
   have hfst : (Φ.totalHomeomorph.symm (1, y)).1 = 1 := Φ.totalHomeomorph_symm_fst (1, y)
   have happ := Φ.totalHomeomorph.apply_symm_apply (1, y)

--- a/TauCeti/Topology/Homotopy/Isotopy/Comp.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Comp.lean
@@ -59,9 +59,8 @@ variable {f₀ f₁ : C(X, Y)}
 isotopy `g ∘ f₀ ≈ g ∘ f₁`. -/
 def postcomp (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
     Isotopy (g.comp f₀) (g.comp f₁) where
-  toHomotopyWith :=
-    { toHomotopy := (Homotopy.refl g).comp F.toHomotopy
-      prop' := fun t => hg.comp (F.isEmbedding_apply t) }
+  toHomotopy := (Homotopy.refl g).comp F.toHomotopy
+  prop' := fun t => hg.comp (F.isEmbedding_apply t)
 
 @[simp]
 theorem postcomp_apply (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) (p : I × X) :
@@ -71,9 +70,8 @@ theorem postcomp_apply (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g
 isotopy `f₀ ∘ e ≈ f₁ ∘ e`. -/
 def precomp (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
     Isotopy (f₀.comp e) (f₁.comp e) where
-  toHomotopyWith :=
-    { toHomotopy := F.toHomotopy.compContinuousMap e
-      prop' := fun t => (F.isEmbedding_apply t).comp he }
+  toHomotopy := F.toHomotopy.compContinuousMap e
+  prop' := fun t => (F.isEmbedding_apply t).comp he
 
 @[simp]
 theorem precomp_apply (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) (p : I × W) :
@@ -89,13 +87,13 @@ variable {f₀ f₁ : C(X, Y)}
 embedding, then `g ∘ f₀ ≈ g ∘ f₁`. -/
 theorem postcomp (h : Isotopic f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
     Isotopic (g.comp f₀) (g.comp f₁) :=
-  isotopic_def.mpr ⟨(isotopic_def.mp h).some.postcomp g hg⟩
+  of_isotopy ((isotopic_def.mp h).some.postcomp g hg)
 
 /-- Precompose an isotopy relation with a topological embedding: if `f₀ ≈ f₁` and `e` is an
 embedding, then `f₀ ∘ e ≈ f₁ ∘ e`. -/
 theorem precomp (h : Isotopic f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
     Isotopic (f₀.comp e) (f₁.comp e) :=
-  isotopic_def.mpr ⟨(isotopic_def.mp h).some.precomp e he⟩
+  of_isotopy ((isotopic_def.mp h).some.precomp e he)
 
 /-- The two-sided form: an isotopy relation survives composing with an embedding on each
 side. -/

--- a/TauCeti/Topology/Homotopy/Isotopy/Comp.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Comp.lean
@@ -57,7 +57,7 @@ variable {f₀ f₁ : C(X, Y)}
 
 /-- Postcompose an isotopy `f₀ ≈ f₁` with a topological embedding `g : Y ↪ Z` to get an
 isotopy `g ∘ f₀ ≈ g ∘ f₁`. -/
-@[expose] def postcomp (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
+def postcomp (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
     Isotopy (g.comp f₀) (g.comp f₁) where
   toHomotopyWith :=
     { toHomotopy := (Homotopy.refl g).comp F.toHomotopy
@@ -65,11 +65,11 @@ isotopy `g ∘ f₀ ≈ g ∘ f₁`. -/
 
 @[simp]
 theorem postcomp_apply (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) (p : I × X) :
-    F.postcomp g hg p = g (F p) := rfl
+    F.postcomp g hg p = g (F p) := (rfl)
 
 /-- Precompose an isotopy `f₀ ≈ f₁` with a topological embedding `e : W ↪ X` to get an
 isotopy `f₀ ∘ e ≈ f₁ ∘ e`. -/
-@[expose] def precomp (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
+def precomp (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
     Isotopy (f₀.comp e) (f₁.comp e) where
   toHomotopyWith :=
     { toHomotopy := F.toHomotopy.compContinuousMap e
@@ -77,7 +77,7 @@ isotopy `f₀ ∘ e ≈ f₁ ∘ e`. -/
 
 @[simp]
 theorem precomp_apply (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) (p : I × W) :
-    F.precomp e he p = F (p.1, e p.2) := rfl
+    F.precomp e he p = F (p.1, e p.2) := (rfl)
 
 end Isotopy
 

--- a/TauCeti/Topology/Homotopy/Isotopy/Comp.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Comp.lean
@@ -89,13 +89,13 @@ variable {f₀ f₁ : C(X, Y)}
 embedding, then `g ∘ f₀ ≈ g ∘ f₁`. -/
 theorem postcomp (h : Isotopic f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
     Isotopic (g.comp f₀) (g.comp f₁) :=
-  ⟨h.some.postcomp g hg⟩
+  isotopic_def.mpr ⟨(isotopic_def.mp h).some.postcomp g hg⟩
 
 /-- Precompose an isotopy relation with a topological embedding: if `f₀ ≈ f₁` and `e` is an
 embedding, then `f₀ ∘ e ≈ f₁ ∘ e`. -/
 theorem precomp (h : Isotopic f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
     Isotopic (f₀.comp e) (f₁.comp e) :=
-  ⟨h.some.precomp e he⟩
+  isotopic_def.mpr ⟨(isotopic_def.mp h).some.precomp e he⟩
 
 /-- The two-sided form: an isotopy relation survives composing with an embedding on each
 side. -/

--- a/TauCeti/Topology/Homotopy/Isotopy/Comp.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Comp.lean
@@ -9,8 +9,8 @@ public import TauCeti.Topology.Homotopy.Isotopy.Basic
 /-!
 # Naturality of isotopy under composition with embeddings
 
-An isotopy is a homotopy whose level-preserving total map is a topological embedding. This
-file records that the isotopy relation is *natural*: composing on either side with a
+An isotopy is a homotopy through topological embeddings. This file records that the isotopy
+relation is *natural*: composing on either side with a
 topological embedding carries an isotopy to an isotopy, and so an isotopy relation to an
 isotopy relation. These are the closure properties the geometric-topology roadmap
 (`TauCetiRoadmap/GeometricTopology/README.md`) asks the general isotopy notion to carry
@@ -59,9 +59,9 @@ variable {f₀ f₁ : C(X, Y)}
 isotopy `g ∘ f₀ ≈ g ∘ f₁`. -/
 @[expose] def postcomp (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) :
     Isotopy (g.comp f₀) (g.comp f₁) where
-  toHomotopy := (Homotopy.refl g).comp F.toHomotopy
-  isEmbedding_total' :=
-    (IsEmbedding.id.prodMap hg).comp F.isEmbedding_total'
+  toHomotopyWith :=
+    { toHomotopy := (Homotopy.refl g).comp F.toHomotopy
+      prop' := fun t => hg.comp (F.isEmbedding_apply t) }
 
 @[simp]
 theorem postcomp_apply (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g) (p : I × X) :
@@ -71,9 +71,9 @@ theorem postcomp_apply (F : Isotopy f₀ f₁) (g : C(Y, Z)) (hg : IsEmbedding g
 isotopy `f₀ ∘ e ≈ f₁ ∘ e`. -/
 @[expose] def precomp (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) :
     Isotopy (f₀.comp e) (f₁.comp e) where
-  toHomotopy := F.toHomotopy.compContinuousMap e
-  isEmbedding_total' :=
-    F.isEmbedding_total'.comp (IsEmbedding.id.prodMap he)
+  toHomotopyWith :=
+    { toHomotopy := F.toHomotopy.compContinuousMap e
+      prop' := fun t => (F.isEmbedding_apply t).comp he }
 
 @[simp]
 theorem precomp_apply (F : Isotopy f₀ f₁) (e : C(W, X)) (he : IsEmbedding e) (p : I × W) :

--- a/TauCeti/Topology/Homotopy/Isotopy/Prod.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Prod.lean
@@ -60,8 +60,8 @@ private theorem isEmbedding_dupTime :
   rw [this]
   exact IsEmbedding.id
 
-/-- The core embedding lemma shared by the isotopy and ambient-isotopy products. If `u` and `v` are
-embeddings of `I × X → I × Y` and `I × X' → I × Y'` that preserve the time coordinate, then the
+/-- The core embedding lemma used by the ambient-isotopy product. If `u` and `v` are embeddings of
+`I × X → I × Y` and `I × X' → I × Y'` that preserve the time coordinate, then the
 *merged* total map `(t, (x, x')) ↦ (t, ((u (t, x)).2, (v (t, x')).2))` reading both at the same
 time `t` is an embedding. It factors as the time-duplicating embedding, then `u × v`, then the
 projection identifying the two (equal) time coordinates. -/
@@ -92,7 +92,7 @@ variable {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(X', Y')}
 isotopy `g₀ ≈ g₁` build an isotopy `f₀.prodMap g₀ ≈ f₁.prodMap g₁` whose value at `(t, (x, x'))` is
 `(F (t, x), G (t, x'))`. The underlying homotopy is Mathlib's `ContinuousMap.Homotopy.prodMap`,
 and each slice is a product of embeddings. -/
-@[expose] def prodMap (F : Isotopy f₀ f₁) (G : Isotopy g₀ g₁) :
+def prodMap (F : Isotopy f₀ f₁) (G : Isotopy g₀ g₁) :
     Isotopy (f₀.prodMap g₀) (f₁.prodMap g₁) where
   toHomotopyWith :=
     { toHomotopy := F.toHomotopy.prodMap G.toHomotopy
@@ -100,7 +100,7 @@ and each slice is a product of embeddings. -/
 
 @[simp]
 theorem prodMap_apply (F : Isotopy f₀ f₁) (G : Isotopy g₀ g₁) (p : I × (X × X')) :
-    F.prodMap G p = (F (p.1, p.2.1), G (p.1, p.2.2)) := rfl
+    F.prodMap G p = (F (p.1, p.2.1), G (p.1, p.2.2)) := (rfl)
 
 end Isotopy
 

--- a/TauCeti/Topology/Homotopy/Isotopy/Prod.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Prod.lean
@@ -9,8 +9,8 @@ public import TauCeti.Topology.Homotopy.AmbientIsotopic.Basic
 /-!
 # Products of isotopies and ambient isotopies
 
-An isotopy is a homotopy whose level-preserving total map is a topological embedding, and an
-ambient isotopy is a homotopy from the identity whose total map is a homeomorphism. This file
+An isotopy is a homotopy through topological embeddings, and an ambient isotopy is a homotopy
+from the identity whose total map is a homeomorphism. This file
 records that both notions are closed under taking products: an isotopy `f₀ ≈ f₁` and an isotopy
 `g₀ ≈ g₁` combine, *along the shared time parameter*, into an isotopy `f₀ × g₀ ≈ f₁ × g₁` of the
 product maps, and likewise for ambient isotopies of a product space.
@@ -21,11 +21,9 @@ ambient isotopy are defined once before being specialised to locally flat isotop
 and knot equivalence. It is also the isotopy analogue of the product closure lemmas that the
 roadmap's later local-flatness product API is expected to mirror. For `TauCeti.Isotopy`, the
 construction follows Mathlib's product lemmas for embeddings (`Topology.IsEmbedding.prodMap`) and
-homotopy (`ContinuousMap.Homotopy.prodMap`), the latter of which supplies the underlying homotopy
-here. The single subtlety past the homotopy case is that the two factors share one time coordinate,
-so the level-preserving total map of the product is *not* literally the product of the two total
-maps (which would carry two independent times); the embedding/homeomorphism statements are
-recovered through the time-duplicating embedding `(t, x, x') ↦ ((t, x), (t, x'))`.
+homotopy (`ContinuousMap.Homotopy.prodMap`). For ambient isotopies, the two factors share one time
+coordinate, so the homeomorphism statement uses the time-duplicating embedding
+`(t, x, x') ↦ ((t, x), (t, x'))`.
 
 ## Main definitions
 
@@ -92,13 +90,13 @@ variable {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(X', Y')}
 
 /-- The **product of two isotopies**, sharing the time parameter: from an isotopy `f₀ ≈ f₁` and an
 isotopy `g₀ ≈ g₁` build an isotopy `f₀.prodMap g₀ ≈ f₁.prodMap g₁` whose value at `(t, (x, x'))` is
-`(F (t, x), G (t, x'))`. The underlying homotopy is Mathlib's `ContinuousMap.Homotopy.prodMap`; the
-total map is an embedding by `isEmbedding_mergeTotal`. -/
+`(F (t, x), G (t, x'))`. The underlying homotopy is Mathlib's `ContinuousMap.Homotopy.prodMap`,
+and each slice is a product of embeddings. -/
 @[expose] def prodMap (F : Isotopy f₀ f₁) (G : Isotopy g₀ g₁) :
     Isotopy (f₀.prodMap g₀) (f₁.prodMap g₁) where
-  toHomotopy := F.toHomotopy.prodMap G.toHomotopy
-  isEmbedding_total' :=
-    isEmbedding_mergeTotal F.isEmbedding_total G.isEmbedding_total (fun _ => rfl) (fun _ => rfl)
+  toHomotopyWith :=
+    { toHomotopy := F.toHomotopy.prodMap G.toHomotopy
+      prop' := fun t => (F.isEmbedding_apply t).prodMap (G.isEmbedding_apply t) }
 
 @[simp]
 theorem prodMap_apply (F : Isotopy f₀ f₁) (G : Isotopy g₀ g₁) (p : I × (X × X')) :

--- a/TauCeti/Topology/Homotopy/Isotopy/Prod.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Prod.lean
@@ -112,7 +112,7 @@ variable {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(X', Y')}
 `f₀.prodMap g₀ ≈ f₁.prodMap g₁`. -/
 theorem prodMap (h : Isotopic f₀ f₁) (h' : Isotopic g₀ g₁) :
     Isotopic (f₀.prodMap g₀) (f₁.prodMap g₁) :=
-  ⟨h.some.prodMap h'.some⟩
+  isotopic_def.mpr ⟨(isotopic_def.mp h).some.prodMap (isotopic_def.mp h').some⟩
 
 end Isotopic
 
@@ -123,14 +123,15 @@ namespace AmbientIsotopy
 is `(Φ (t, y), Ψ (t, y'))`. Its total map is a homeomorphism, being an embedding (by
 `isEmbedding_mergeTotal`) and surjective (each factor is surjective at every time, by
 `AmbientIsotopy.isHomeomorph_apply`). -/
-@[expose]
 def prodCongr (Φ : AmbientIsotopy Y) (Ψ : AmbientIsotopy Y') : AmbientIsotopy (Y × Y') where
   toContinuousMap :=
     ⟨fun p => (Φ.toContinuousMap (p.1, p.2.1), Ψ.toContinuousMap (p.1, p.2.2)), by fun_prop⟩
   isHomeomorph_total' := by
     rw [isHomeomorph_iff_isEmbedding_surjective]
-    refine ⟨isEmbedding_mergeTotal Φ.isHomeomorph_total.isEmbedding Ψ.isHomeomorph_total.isEmbedding
-      (fun _ => rfl) (fun _ => rfl), ?_⟩
+    refine ⟨?_, ?_⟩
+    · simpa only [totalMap_apply] using
+        isEmbedding_mergeTotal Φ.isHomeomorph_total.isEmbedding
+          Ψ.isHomeomorph_total.isEmbedding (fun p => by simp) (fun p => by simp)
     rintro ⟨t, z, z'⟩
     obtain ⟨y, hy⟩ := (Φ.isHomeomorph_apply t).surjective z
     obtain ⟨y', hy'⟩ := (Ψ.isHomeomorph_apply t).surjective z'
@@ -140,12 +141,13 @@ def prodCongr (Φ : AmbientIsotopy Y) (Ψ : AmbientIsotopy Y') : AmbientIsotopy 
 @[simp]
 theorem prodCongr_apply (Φ : AmbientIsotopy Y) (Ψ : AmbientIsotopy Y') (p : I × (Y × Y')) :
     (Φ.prodCongr Ψ).toContinuousMap p =
-      (Φ.toContinuousMap (p.1, p.2.1), Ψ.toContinuousMap (p.1, p.2.2)) := rfl
+      (Φ.toContinuousMap (p.1, p.2.1), Ψ.toContinuousMap (p.1, p.2.2)) := (rfl)
 
 /-- The final map of a product ambient isotopy is the product of the two final maps. -/
-@[simp]
+@[simp 1100]
 theorem final_prodCongr (Φ : AmbientIsotopy Y) (Ψ : AmbientIsotopy Y') (y : Y × Y') :
-    (Φ.prodCongr Ψ).final y = (Φ.final y.1, Ψ.final y.2) := rfl
+    (Φ.prodCongr Ψ).final y = (Φ.final y.1, Ψ.final y.2) := by
+  rw [final_apply, prodCongr_apply, final_apply, final_apply]
 
 end AmbientIsotopy
 
@@ -158,9 +160,11 @@ variable {f f' : C(X, Y)} {g g' : C(X', Y')}
 isotopic in `Y × Y'`, via the product ambient isotopy. -/
 theorem prodMap (h : AmbientIsotopic f f') (h' : AmbientIsotopic g g') :
     AmbientIsotopic (f.prodMap g) (f'.prodMap g') := by
-  obtain ⟨Φ, rfl⟩ := h
-  obtain ⟨Ψ, rfl⟩ := h'
-  refine ⟨Φ.prodCongr Ψ, ContinuousMap.ext fun p => ?_⟩
+  obtain ⟨Φ, hΦ⟩ := ambientIsotopic_def.mp h
+  obtain ⟨Ψ, hΨ⟩ := ambientIsotopic_def.mp h'
+  subst f'
+  subst g'
+  refine ambientIsotopic_def.mpr ⟨Φ.prodCongr Ψ, ContinuousMap.ext fun p => ?_⟩
   exact AmbientIsotopy.final_prodCongr Φ Ψ ((f.prodMap g) p)
 
 end AmbientIsotopic

--- a/TauCeti/Topology/Homotopy/Isotopy/Prod.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Prod.lean
@@ -94,9 +94,8 @@ isotopy `g₀ ≈ g₁` build an isotopy `f₀.prodMap g₀ ≈ f₁.prodMap g�
 and each slice is a product of embeddings. -/
 def prodMap (F : Isotopy f₀ f₁) (G : Isotopy g₀ g₁) :
     Isotopy (f₀.prodMap g₀) (f₁.prodMap g₁) where
-  toHomotopyWith :=
-    { toHomotopy := F.toHomotopy.prodMap G.toHomotopy
-      prop' := fun t => (F.isEmbedding_apply t).prodMap (G.isEmbedding_apply t) }
+  toHomotopy := F.toHomotopy.prodMap G.toHomotopy
+  prop' := fun t => (F.isEmbedding_apply t).prodMap (G.isEmbedding_apply t)
 
 @[simp]
 theorem prodMap_apply (F : Isotopy f₀ f₁) (G : Isotopy g₀ g₁) (p : I × (X × X')) :
@@ -112,7 +111,7 @@ variable {f₀ f₁ : C(X, Y)} {g₀ g₁ : C(X', Y')}
 `f₀.prodMap g₀ ≈ f₁.prodMap g₁`. -/
 theorem prodMap (h : Isotopic f₀ f₁) (h' : Isotopic g₀ g₁) :
     Isotopic (f₀.prodMap g₀) (f₁.prodMap g₁) :=
-  isotopic_def.mpr ⟨(isotopic_def.mp h).some.prodMap (isotopic_def.mp h').some⟩
+  of_isotopy ((isotopic_def.mp h).some.prodMap (isotopic_def.mp h').some)
 
 end Isotopic
 


### PR DESCRIPTION
This PR changes `Isotopy` to the slice-wise formulation: a homotopy for which every time slice is a topological embedding. It extends Mathlib's `HomotopyWith` directly and migrates composition, products, the isotopy relation, and the ambient-isotopy bridge.

This convention is deliberately weaker, for arbitrary topological spaces, than Burde--Zieschang's Definition 1.1, which requires the associated level-preserving total map to be an embedding. The conditions agree when the source is compact and the target is Hausdorff. `AmbientIsotopy` retains its total-homeomorphism requirement and follows their Definition 1.2.

The previous stronger requirement that the level-preserving total map be an embedding is removed. This also deletes the bespoke closed-cover gluing proof used only to preserve that condition under concatenation (281 net lines removed). Ambient isotopies retain their total-homeomorphism requirement.

Verified with `lake build`, `lake exe axioms`, `lake exe module-system`, and `bash scripts/lint-env.sh`.

Roadmap: GeometricTopology

:robot: Prepared with OpenAI Codex