### PR TITLE
Define complete monotonicity on arbitrary sets

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -40,19 +40,23 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
 
 * `TauCeti.CompletelyMonotoneOn`: complete monotonicity on an arbitrary set, defined by reflecting
   Mathlib's `AbsolutelyMonotoneOn` predicate.
+* `TauCeti.CompletelyMonotoneOn.iff_neg_one_pow_mul_iteratedDerivWithin_nonneg`: on a
+  `UniqueDiffOn` set, equivalence with smoothness and alternating signs.
 * `TauCeti.CompletelyMonotoneOn.of_contDiff`: a globally smooth function whose ordinary iterated
   derivatives have alternating signs on a set is completely monotone there.
 * `TauCeti.CompletelyMonotoneOn.add`, `TauCeti.CompletelyMonotoneOn.smul`: closure under addition
   and nonnegative scalar multiplication.
 * `TauCeti.IsCompletelyMonotone`: the predicate that `f` is smooth and sign-alternating on
   `[0, ∞)`.
+* `TauCeti.isCompletelyMonotone_iff_completelyMonotoneOn`: `IsCompletelyMonotone` is the
+  `Ici 0` specialization of `CompletelyMonotoneOn`.
 * `TauCeti.IsCompletelyMonotone.congr`: complete monotonicity only depends on the values of the
   function on `[0, ∞)`.
 * `TauCeti.IsCompletelyMonotone.nonneg`, `TauCeti.IsCompletelyMonotone.derivWithin_nonpos`,
   `TauCeti.IsCompletelyMonotone.antitoneOn`: a completely monotone function is nonnegative
   and nonincreasing on `[0, ∞)`.
-* `TauCeti.IsCompletelyMonotoneOnIci.exists_nonneg_tendsto_atTop`,
-  `TauCeti.IsCompletelyMonotoneOnIci.le_of_tendsto_atTop`: order-limit consequences of
+* `TauCeti.IsContinuousCompletelyMonotoneOnIoi.exists_nonneg_tendsto_atTop`,
+  `TauCeti.IsContinuousCompletelyMonotoneOnIoi.le_of_tendsto_atTop`: order-limit consequences of
   nonnegativity and monotonicity on `[0, ∞)`.
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_iteratedDeriv_nonneg`: on the open half-line,
   the sign condition also holds for ordinary iterated derivatives.
@@ -61,7 +65,7 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
   scalar multiples.
 * `TauCeti.IsCompletelyMonotoneOnIoi`: the open-half-line analogue, using ordinary iterated
   derivatives on `(0, ∞)`.
-* `TauCeti.IsCompletelyMonotoneOnIci`: the closed-half-line predicate used by the
+* `TauCeti.IsContinuousCompletelyMonotoneOnIoi`: the closed-half-line predicate used by the
   finite-measure Hausdorff--Bernstein--Widder theorem: continuity on `[0, ∞)` plus complete
   monotonicity on `(0, ∞)`.
 * `TauCeti.isCompletelyMonotone_const`: a nonnegative constant is completely monotone.
@@ -83,10 +87,17 @@ namespace TauCeti
 /-- A function `f : ℝ → ℝ` is **completely monotone on a set `s`** if its reflection
 `u ↦ f (-u)` is absolutely monotone on the reflected set `-s`. Mathlib's
 `AbsolutelyMonotoneOn` uses a Taylor-series witness, so this definition remains meaningful even
-when `s` is not uniquely differentiable. Under `UniqueDiffOn ℝ s`, it is equivalent to the
-expected alternating-sign condition on `iteratedDerivWithin`. -/
+when `s` is not uniquely differentiable. Under `UniqueDiffOn ℝ s`, it is equivalent to
+smoothness on `s` together with the alternating-sign condition on `iteratedDerivWithin`; see
+`CompletelyMonotoneOn.iff_neg_one_pow_mul_iteratedDerivWithin_nonneg`. -/
 def CompletelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop :=
   AbsolutelyMonotoneOn (fun u => f (-u)) (-s)
+
+/-- Complete monotonicity on `s` unfolds to absolute monotonicity of the reflected function on
+the reflected set. -/
+theorem completelyMonotoneOn_iff_absolutelyMonotoneOn_comp_neg {f : ℝ → ℝ} {s : Set ℝ} :
+    CompletelyMonotoneOn f s ↔ AbsolutelyMonotoneOn (fun u => f (-u)) (-s) :=
+  Iff.rfl
 
 namespace CompletelyMonotoneOn
 
@@ -96,15 +107,20 @@ private theorem uniqueDiffOn_neg (hs : UniqueDiffOn ℝ s) : UniqueDiffOn ℝ (-
   rw [← Set.image_neg_eq_neg]
   exact (ContinuousLinearEquiv.neg ℝ).uniqueDiffOn_image hs
 
-/-- A completely monotone function on `s` is smooth on `s`. -/
-theorem contDiffOn (hf : CompletelyMonotoneOn f s) : ContDiffOn ℝ ∞ f s := by
-  have hneg := AbsolutelyMonotoneOn.contDiffOn hf
-  have hpre : ((-ContinuousLinearMap.id ℝ ℝ) ⁻¹' (-s)) = s := by
+private theorem contDiffOn_comp_neg_iff :
+    ContDiffOn ℝ ∞ (fun u => f (-u)) (-s) ↔ ContDiffOn ℝ ∞ f s := by
+  have hpre : (ContinuousLinearEquiv.neg ℝ) ⁻¹' s = -s := by
     ext x
     simp
   rw [← hpre]
   simpa [Function.comp_def] using
-    hneg.comp_continuousLinearMap (-ContinuousLinearMap.id ℝ ℝ)
+    (ContinuousLinearEquiv.neg ℝ).contDiffOn_comp_iff (f := f) (s := s) (n := ∞)
+
+/-- A completely monotone function on `s` is smooth on `s`. -/
+@[grind →]
+theorem contDiffOn (hf : CompletelyMonotoneOn f s) : ContDiffOn ℝ ∞ f s := by
+  exact contDiffOn_comp_neg_iff.mp
+    (completelyMonotoneOn_iff_absolutelyMonotoneOn_comp_neg.mp hf).contDiffOn
 
 /-- A globally `C^∞` function whose iterated derivatives have alternating signs on `s` is
 completely monotone on `s`. The set `s` need *not* satisfy `UniqueDiffOn`. -/
@@ -118,6 +134,7 @@ theorem of_contDiff (hf : ContDiff ℝ ∞ f)
 
 /-- On a uniquely differentiable set, the iterated derivatives of a completely monotone function
 have the expected alternating signs. -/
+@[grind =>]
 theorem neg_one_pow_mul_iteratedDerivWithin_nonneg (hf : CompletelyMonotoneOn f s)
     (hs : UniqueDiffOn ℝ s) (n : ℕ) {x : ℝ} (hx : x ∈ s) :
     0 ≤ (-1) ^ n * iteratedDerivWithin n f s x := by
@@ -129,7 +146,7 @@ theorem neg_one_pow_mul_iteratedDerivWithin_nonneg (hf : CompletelyMonotoneOn f 
 
 /-- On a uniquely differentiable set, complete monotonicity is equivalent to smoothness together
 with the usual alternating-sign condition on iterated derivatives within the set. -/
-theorem iff_iteratedDerivWithin_nonneg (hs : UniqueDiffOn ℝ s) :
+theorem iff_neg_one_pow_mul_iteratedDerivWithin_nonneg (hs : UniqueDiffOn ℝ s) :
     CompletelyMonotoneOn f s ↔
       ContDiffOn ℝ ∞ f s ∧
         ∀ n : ℕ, ∀ x ∈ s, 0 ≤ (-1) ^ n * iteratedDerivWithin n f s x := by
@@ -137,15 +154,10 @@ theorem iff_iteratedDerivWithin_nonneg (hs : UniqueDiffOn ℝ s) :
     fun n _ hx => hf.neg_one_pow_mul_iteratedDerivWithin_nonneg hs n hx⟩, ?_⟩
   rintro ⟨hcont, hsign⟩
   have hsneg := uniqueDiffOn_neg hs
-  rw [CompletelyMonotoneOn,
+  rw [completelyMonotoneOn_iff_absolutelyMonotoneOn_comp_neg,
     AbsolutelyMonotoneOn.iff_iteratedDerivWithin_nonneg hsneg]
   refine ⟨?_, fun n x hx => ?_⟩
-  · have hpre : ((-ContinuousLinearMap.id ℝ ℝ) ⁻¹' s) = -s := by
-      ext x
-      simp
-    rw [← hpre]
-    simpa [Function.comp_def] using
-      hcont.comp_continuousLinearMap (-ContinuousLinearMap.id ℝ ℝ)
+  · exact contDiffOn_comp_neg_iff.mpr hcont
   · rw [iteratedDerivWithin_comp_neg]
     simpa [smul_eq_mul] using hsign n (-x) (by simpa using hx)
 
@@ -154,7 +166,7 @@ theorem iff_iteratedDerivWithin_nonneg (hs : UniqueDiffOn ℝ s) :
 /-- The sum of two completely monotone functions is completely monotone. -/
 theorem add {g : ℝ → ℝ} (hf : CompletelyMonotoneOn f s) (hg : CompletelyMonotoneOn g s) :
     CompletelyMonotoneOn (f + g) s := by
-  rw [CompletelyMonotoneOn]
+  rw [completelyMonotoneOn_iff_absolutelyMonotoneOn_comp_neg] at hf hg ⊢
   convert AbsolutelyMonotoneOn.add hf hg using 1
   ext u
   rfl
@@ -162,7 +174,7 @@ theorem add {g : ℝ → ℝ} (hf : CompletelyMonotoneOn f s) (hg : CompletelyMo
 /-- A nonnegative scalar multiple of a completely monotone function is completely monotone. -/
 theorem smul {c : ℝ} (hf : CompletelyMonotoneOn f s) (hc : 0 ≤ c) :
     CompletelyMonotoneOn (c • f) s := by
-  rw [CompletelyMonotoneOn]
+  rw [completelyMonotoneOn_iff_absolutelyMonotoneOn_comp_neg] at hf ⊢
   convert AbsolutelyMonotoneOn.smul hf hc using 1
   ext u
   rfl
@@ -188,19 +200,9 @@ lemma isCompletelyMonotone_iff {f : ℝ → ℝ} :
 /-- The closed-half-line predicate is the specialization of complete monotonicity on a set. -/
 lemma isCompletelyMonotone_iff_completelyMonotoneOn {f : ℝ → ℝ} :
     IsCompletelyMonotone f ↔ CompletelyMonotoneOn f (Ici 0) := by
-  rw [isCompletelyMonotone_iff, CompletelyMonotoneOn.iff_iteratedDerivWithin_nonneg
-    (uniqueDiffOn_Ici 0)]
+  rw [isCompletelyMonotone_iff,
+    CompletelyMonotoneOn.iff_neg_one_pow_mul_iteratedDerivWithin_nonneg (uniqueDiffOn_Ici 0)]
   simp only [mem_Ici]
-
-/-- Completely monotone functions are exactly absolutely monotone functions after reflecting the
-closed half-line through zero. -/
-lemma isCompletelyMonotone_iff_absolutelyMonotoneOn_comp_neg {f : ℝ → ℝ} :
-    IsCompletelyMonotone f ↔ AbsolutelyMonotoneOn (fun u => f (-u)) (Iic 0) := by
-  rw [isCompletelyMonotone_iff_completelyMonotoneOn, CompletelyMonotoneOn]
-  have hset : (-(Ici (0 : ℝ)) : Set ℝ) = Iic 0 := by
-    ext x
-    simp
-  rw [hset]
 
 namespace IsCompletelyMonotone
 
@@ -309,17 +311,12 @@ derivative is `(-x)ⁿ e^{-x t}`, so `(-1)ⁿ` times it is `xⁿ e^{-x t} ≥ 0`
 lemma isCompletelyMonotone_exp_neg_mul {x : ℝ} (hx : 0 ≤ x) :
     IsCompletelyMonotone (fun t => Real.exp (-x * t)) := by
   have hcd : ContDiff ℝ ∞ (fun t : ℝ => Real.exp (-x * t)) := by fun_prop
-  refine ⟨hcd.contDiffOn, fun n t ht => ?_⟩
-  have hcat : ContDiffAt ℝ (n : WithTop ℕ∞) (fun t : ℝ => Real.exp (-x * t)) t :=
-    hcd.contDiffAt.of_le (by exact_mod_cast le_top)
-  have hval : iteratedDerivWithin n (fun t : ℝ => Real.exp (-x * t)) (Ici 0) t
-      = (-x) ^ n * Real.exp (-x * t) := by
-    rw [iteratedDerivWithin_eq_iteratedDeriv (uniqueDiffOn_Ici 0) hcat (mem_Ici.mpr ht),
-      iteratedDeriv_exp_const_mul]
+  rw [isCompletelyMonotone_iff_completelyMonotoneOn]
+  refine CompletelyMonotoneOn.of_contDiff hcd fun n t _ => ?_
   have hpow : (0 : ℝ) ≤ (-1) ^ n * (-x) ^ n := by
     rw [← mul_pow, neg_one_mul, neg_neg]
     exact pow_nonneg hx n
-  rw [hval, ← mul_assoc]
+  rw [iteratedDeriv_exp_const_mul, ← mul_assoc]
   exact mul_nonneg hpow (Real.exp_nonneg _)
 
 /-- Complete monotonicity on the open half-line `(0, ∞)`: the function is `C^∞` there and its
@@ -328,6 +325,22 @@ Bernstein functions, whose right derivatives need not be finite at `0`. -/
 @[expose] def IsCompletelyMonotoneOnIoi (f : ℝ → ℝ) : Prop :=
   ContDiffOn ℝ ∞ f (Ioi 0) ∧
     ∀ n : ℕ, ∀ t : ℝ, 0 < t → 0 ≤ (-1) ^ n * iteratedDeriv n f t
+
+/-- Complete monotonicity on `(0, ∞)` is the open-half-line specialization of complete
+monotonicity on a set. -/
+lemma isCompletelyMonotoneOnIoi_iff_completelyMonotoneOn {f : ℝ → ℝ} :
+    IsCompletelyMonotoneOnIoi f ↔ CompletelyMonotoneOn f (Ioi 0) := by
+  rw [IsCompletelyMonotoneOnIoi,
+    CompletelyMonotoneOn.iff_neg_one_pow_mul_iteratedDerivWithin_nonneg (uniqueDiffOn_Ioi 0)]
+  constructor
+  · rintro ⟨hcont, hsign⟩
+    exact ⟨hcont, fun n x hx => by
+      rw [iteratedDerivWithin_of_isOpen isOpen_Ioi hx]
+      exact hsign n x hx⟩
+  · rintro ⟨hcont, hsign⟩
+    exact ⟨hcont, fun n x hx => by
+      rw [← iteratedDerivWithin_of_isOpen isOpen_Ioi hx]
+      exact hsign n x hx⟩
 
 namespace IsCompletelyMonotoneOnIoi
 
@@ -377,20 +390,14 @@ lemma congr (hf : IsCompletelyMonotoneOnIoi f) (h : Set.EqOn g f (Ioi 0)) :
 /-- Complete monotonicity on `(0, ∞)` is closed under addition. -/
 lemma add (hf : IsCompletelyMonotoneOnIoi f) (hg : IsCompletelyMonotoneOnIoi g) :
     IsCompletelyMonotoneOnIoi (f + g) := by
-  refine ⟨hf.contDiffOn.add hg.contDiffOn, fun n t ht => ?_⟩
-  rw [iteratedDeriv_add
-    ((hf.contDiffOn.contDiffAt (isOpen_Ioi.mem_nhds ht)).of_le (by exact_mod_cast le_top))
-    ((hg.contDiffOn.contDiffAt (isOpen_Ioi.mem_nhds ht)).of_le (by exact_mod_cast le_top))]
-  simpa [mul_add] using add_nonneg (hf.neg_one_pow_mul_iteratedDeriv_nonneg n ht)
-    (hg.neg_one_pow_mul_iteratedDeriv_nonneg n ht)
+  rw [isCompletelyMonotoneOnIoi_iff_completelyMonotoneOn] at hf hg ⊢
+  exact hf.add hg
 
 /-- Complete monotonicity on `(0, ∞)` is closed under multiplication by a nonnegative constant. -/
 lemma smul (hf : IsCompletelyMonotoneOnIoi f) {c : ℝ} (hc : 0 ≤ c) :
     IsCompletelyMonotoneOnIoi (c • f) := by
-  refine ⟨hf.contDiffOn.const_smul c, fun n t ht => ?_⟩
-  rw [iteratedDeriv_const_smul_field]
-  simpa [smul_eq_mul, mul_assoc, mul_left_comm, mul_comm] using
-    mul_nonneg hc (hf.neg_one_pow_mul_iteratedDeriv_nonneg n ht)
+  rw [isCompletelyMonotoneOnIoi_iff_completelyMonotoneOn] at hf ⊢
+  exact hf.smul hc
 
 /-- The closed-half-line Tau Ceti predicate restricts to complete monotonicity on `(0, ∞)`. -/
 lemma _root_.TauCeti.IsCompletelyMonotone.isCompletelyMonotoneOnIoi
@@ -429,44 +436,45 @@ end IsCompletelyMonotoneOnIoi
 This is the classical finite-measure hypothesis: the function is continuous on `[0, ∞)` and
 completely monotone on the open half-line `(0, ∞)`. It is weaker at the endpoint than the existing
 `IsCompletelyMonotone`, which requires all derivatives within `[0, ∞)` to exist at `0`. -/
-def IsCompletelyMonotoneOnIci (f : ℝ → ℝ) : Prop :=
+def IsContinuousCompletelyMonotoneOnIoi (f : ℝ → ℝ) : Prop :=
   ContinuousOn f (Ici 0) ∧ IsCompletelyMonotoneOnIoi f
 
-/-- `IsCompletelyMonotoneOnIci f` unfolds to continuity on `[0, ∞)` and complete monotonicity on
-the open half-line. -/
-lemma isCompletelyMonotoneOnIci_iff {f : ℝ → ℝ} :
-    IsCompletelyMonotoneOnIci f ↔
+/-- `IsContinuousCompletelyMonotoneOnIoi f` unfolds to continuity on `[0, ∞)` and complete
+monotonicity on the open half-line. -/
+lemma isContinuousCompletelyMonotoneOnIoi_iff {f : ℝ → ℝ} :
+    IsContinuousCompletelyMonotoneOnIoi f ↔
       ContinuousOn f (Ici 0) ∧ IsCompletelyMonotoneOnIoi f :=
   Iff.rfl
 
-namespace IsCompletelyMonotoneOnIci
+namespace IsContinuousCompletelyMonotoneOnIoi
 
 variable {f g : ℝ → ℝ}
 
 /-- A closed-half-line completely monotone function is continuous on `[0, ∞)`. -/
 @[grind →]
-lemma continuousOn (hf : IsCompletelyMonotoneOnIci f) : ContinuousOn f (Ici 0) := hf.1
+lemma continuousOn (hf : IsContinuousCompletelyMonotoneOnIoi f) : ContinuousOn f (Ici 0) := hf.1
 
 /-- A closed-half-line completely monotone function is completely monotone on `(0, ∞)`. -/
 @[grind =>]
-lemma isCompletelyMonotoneOnIoi (hf : IsCompletelyMonotoneOnIci f) :
+lemma isCompletelyMonotoneOnIoi (hf : IsContinuousCompletelyMonotoneOnIoi f) :
     IsCompletelyMonotoneOnIoi f := hf.2
 
 /-- The existing strong Tau Ceti predicate implies the roadmap-level closed-half-line predicate. -/
 lemma of_isCompletelyMonotone (hf : IsCompletelyMonotone f) :
-    IsCompletelyMonotoneOnIci f :=
+    IsContinuousCompletelyMonotoneOnIoi f :=
   ⟨hf.contDiffOn.continuousOn, hf.isCompletelyMonotoneOnIoi⟩
 
 /-- Closed-half-line complete monotonicity is closed under addition. -/
-lemma add (hf : IsCompletelyMonotoneOnIci f) (hg : IsCompletelyMonotoneOnIci g) :
-    IsCompletelyMonotoneOnIci (f + g) :=
+lemma add (hf : IsContinuousCompletelyMonotoneOnIoi f)
+    (hg : IsContinuousCompletelyMonotoneOnIoi g) :
+    IsContinuousCompletelyMonotoneOnIoi (f + g) :=
   ⟨hf.continuousOn.add hg.continuousOn,
     hf.isCompletelyMonotoneOnIoi.add hg.isCompletelyMonotoneOnIoi⟩
 
 /-- Closed-half-line complete monotonicity is closed under multiplication by a nonnegative
 constant. -/
-lemma smul (hf : IsCompletelyMonotoneOnIci f) {c : ℝ} (hc : 0 ≤ c) :
-    IsCompletelyMonotoneOnIci (c • f) :=
+lemma smul (hf : IsContinuousCompletelyMonotoneOnIoi f) {c : ℝ} (hc : 0 ≤ c) :
+    IsContinuousCompletelyMonotoneOnIoi (c • f) :=
   ⟨hf.continuousOn.const_smul c, hf.isCompletelyMonotoneOnIoi.smul hc⟩
 
 
@@ -474,7 +482,7 @@ lemma smul (hf : IsCompletelyMonotoneOnIci f) {c : ℝ} (hc : 0 ≤ c) :
 /-- A closed-half-line completely monotone function is nonincreasing on `[0, ∞)`: the
 derivative is nonpositive on the interior and continuity extends the monotonicity to the
 endpoint. -/
-lemma antitoneOn (hf : IsCompletelyMonotoneOnIci f) : AntitoneOn f (Ici 0) := by
+lemma antitoneOn (hf : IsContinuousCompletelyMonotoneOnIoi f) : AntitoneOn f (Ici 0) := by
   refine antitoneOn_of_deriv_nonpos (convex_Ici 0) hf.continuousOn
     (by
       simpa [interior_Ici] using
@@ -486,36 +494,36 @@ lemma antitoneOn (hf : IsCompletelyMonotoneOnIci f) : AntitoneOn f (Ici 0) := by
 /-- A closed-half-line completely monotone function is nonnegative on `[0, ∞)`:
 nonnegativity on the open half-line passes to `0` by continuity. -/
 @[grind =>]
-lemma nonneg (hf : IsCompletelyMonotoneOnIci f) {t : ℝ} (ht : 0 ≤ t) : 0 ≤ f t :=
+lemma nonneg (hf : IsContinuousCompletelyMonotoneOnIoi f) {t : ℝ} (ht : 0 ≤ t) : 0 ≤ f t :=
   hf.isCompletelyMonotoneOnIoi.nonneg_of_continuousWithinAt
     (hf.continuousOn.continuousWithinAt (by simp)) ht
 
 /-- A closed-half-line completely monotone function is nonnegative at `0`. -/
-lemma nonneg_zero (hf : IsCompletelyMonotoneOnIci f) : 0 ≤ f 0 :=
+lemma nonneg_zero (hf : IsContinuousCompletelyMonotoneOnIoi f) : 0 ≤ f 0 :=
   hf.nonneg le_rfl
 
 /-- A closed-half-line completely monotone function lies below its value at `0` on `[0, ∞)`. -/
-lemma le_apply_zero (hf : IsCompletelyMonotoneOnIci f) {t : ℝ} (ht : 0 ≤ t) : f t ≤ f 0 :=
+lemma le_apply_zero (hf : IsContinuousCompletelyMonotoneOnIoi f) {t : ℝ} (ht : 0 ≤ t) : f t ≤ f 0 :=
   hf.antitoneOn (mem_Ici.mpr le_rfl) (mem_Ici.mpr ht) ht
 
 
 /-- Closed-half-line complete monotonicity is determined by values on `[0, ∞)`. -/
-lemma congr (hf : IsCompletelyMonotoneOnIci f) (h : EqOn g f (Ici 0)) :
-    IsCompletelyMonotoneOnIci g := by
+lemma congr (hf : IsContinuousCompletelyMonotoneOnIoi f) (h : EqOn g f (Ici 0)) :
+    IsContinuousCompletelyMonotoneOnIoi g := by
   refine ⟨hf.continuousOn.congr fun x hx => h hx, ?_⟩
   exact hf.isCompletelyMonotoneOnIoi.congr fun x hx => h (Ioi_subset_Ici_self hx)
 
 /-- Closed-half-line complete monotonicity is closed under finite sums. -/
 protected lemma sum {ι : Type*} {s : Finset ι} {F : ι → ℝ → ℝ}
-    (hF : ∀ i ∈ s, IsCompletelyMonotoneOnIci (F i)) :
-    IsCompletelyMonotoneOnIci (fun t => ∑ i ∈ s, F i t) := by
-  have h := Finset.sum_induction F IsCompletelyMonotoneOnIci
-    (fun _ _ => IsCompletelyMonotoneOnIci.add)
+    (hF : ∀ i ∈ s, IsContinuousCompletelyMonotoneOnIoi (F i)) :
+    IsContinuousCompletelyMonotoneOnIoi (fun t => ∑ i ∈ s, F i t) := by
+  have h := Finset.sum_induction F IsContinuousCompletelyMonotoneOnIoi
+    (fun _ _ => IsContinuousCompletelyMonotoneOnIoi.add)
     (of_isCompletelyMonotone (isCompletelyMonotone_const le_rfl)) hF
   have heq : (∑ i ∈ s, F i) = fun t => ∑ i ∈ s, F i t := funext fun t => Finset.sum_apply t s F
   rwa [heq] at h
 
-end IsCompletelyMonotoneOnIci
+end IsContinuousCompletelyMonotoneOnIoi
 
 /-- The `max`-truncation of a function antitone on a closed half-line is antitone everywhere:
 the shared totalization step of the half-line limit lemmas below. -/
@@ -545,13 +553,13 @@ private lemma le_of_tendsto_atTop_of_antitoneOn_Ici {f : ℝ → ℝ} {a : ℝ} 
     (hL.congr' (eventually_atTop.mpr ⟨a, fun t ht => by simp [hg₀, max_eq_left ht]⟩)) T
   simpa [hg₀, max_eq_left hT] using this
 
-namespace IsCompletelyMonotoneOnIci
+namespace IsContinuousCompletelyMonotoneOnIoi
 
 variable {f : ℝ → ℝ}
 
 /-- A closed-half-line completely monotone function has a limit `L ≥ 0` at infinity: it is
 antitone on `[0, ∞)` and bounded below by `0`. -/
-lemma exists_nonneg_tendsto_atTop (hf : IsCompletelyMonotoneOnIci f) :
+lemma exists_nonneg_tendsto_atTop (hf : IsContinuousCompletelyMonotoneOnIoi f) :
     ∃ L, Tendsto f atTop (𝓝 L) ∧ 0 ≤ L := by
   obtain ⟨L, hL⟩ := exists_tendsto_atTop_of_antitoneOn_Ici hf.antitoneOn
     ⟨0, by rintro y ⟨x, hx, rfl⟩; exact hf.nonneg hx⟩
@@ -559,11 +567,11 @@ lemma exists_nonneg_tendsto_atTop (hf : IsCompletelyMonotoneOnIci f) :
 
 /-- A closed-half-line completely monotone function lies above its limit at infinity on
 `[0, ∞)`. -/
-lemma le_of_tendsto_atTop (hcm : IsCompletelyMonotoneOnIci f) {L : ℝ}
+lemma le_of_tendsto_atTop (hcm : IsContinuousCompletelyMonotoneOnIoi f) {L : ℝ}
     (hL : Tendsto f atTop (𝓝 L)) {T : ℝ} (hT : 0 ≤ T) : L ≤ f T :=
   le_of_tendsto_atTop_of_antitoneOn_Ici hcm.antitoneOn hL hT
 
-end IsCompletelyMonotoneOnIci
+end IsContinuousCompletelyMonotoneOnIoi
 
 namespace IsCompletelyMonotone
 
@@ -572,7 +580,7 @@ variable {f : ℝ → ℝ}
 /-- A completely monotone function is nonincreasing on `[0, ∞)`: the strong predicate
 implies the closed-half-line one, whose monotonicity applies. -/
 lemma antitoneOn (hf : IsCompletelyMonotone f) : AntitoneOn f (Ici 0) :=
-  (IsCompletelyMonotoneOnIci.of_isCompletelyMonotone hf).antitoneOn
+  (IsContinuousCompletelyMonotoneOnIoi.of_isCompletelyMonotone hf).antitoneOn
 
 end IsCompletelyMonotone
 

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -13,8 +13,9 @@ public import TauCeti.Analysis.Calculus.IteratedDerivWithin
 /-!
 # Completely monotone functions
 
-A function `f : ℝ → ℝ` is *completely monotone* if it is smooth on the closed half-line
-`[0, ∞)` and its iterated derivatives there alternate in sign:
+A function `f : ℝ → ℝ` is *completely monotone on a set* if it is smooth there and its iterated
+derivatives alternate in sign. The principal specialization in this development uses the closed
+half-line `[0, ∞)`:
 `(-1)ⁿ f⁽ⁿ⁾(t) ≥ 0` for every `n` and every `t ≥ 0`. Equivalently `f` is nonnegative,
 nonincreasing, convex, and so on through every order. Bernstein's theorem identifies the
 completely monotone functions on the *open* half-line `(0, ∞)` with the Laplace transforms of
@@ -34,6 +35,8 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
 
 ## Main declarations
 
+* `TauCeti.CompletelyMonotoneOn`: complete monotonicity on an arbitrary set, formulated through a
+  Taylor-series witness in parallel with Mathlib's `AbsolutelyMonotoneOn`.
 * `TauCeti.IsCompletelyMonotone`: the predicate that `f` is smooth and sign-alternating on
   `[0, ∞)`.
 * `TauCeti.IsCompletelyMonotone.congr`: complete monotonicity only depends on the values of the
@@ -70,6 +73,49 @@ open scoped ContDiff Topology
 
 namespace TauCeti
 
+/-- A function `f : ℝ → ℝ` is **completely monotone on a set `s`** if it admits a Taylor series on
+`s` whose `n`th coefficient has sign `(-1)ⁿ`. As in Mathlib's `AbsolutelyMonotoneOn`, the Taylor
+witness makes the definition meaningful even when `s` is not uniquely differentiable. Under
+`UniqueDiffOn ℝ s`, this is equivalent to the expected condition on `iteratedDerivWithin`. -/
+def CompletelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop :=
+  ∃ p : ℝ → FormalMultilinearSeries ℝ ℝ ℝ,
+    HasFTaylorSeriesUpToOn ∞ f p s ∧
+      ∀ (n : ℕ) ⦃x : ℝ⦄, x ∈ s → 0 ≤ (-1) ^ n * p x n fun _ ↦ (1 : ℝ)
+
+namespace CompletelyMonotoneOn
+
+variable {f : ℝ → ℝ} {s : Set ℝ}
+
+/-- A completely monotone function on `s` is smooth on `s`. -/
+theorem contDiffOn (hf : CompletelyMonotoneOn f s) : ContDiffOn ℝ ∞ f s := by
+  obtain ⟨_, hp, _⟩ := hf
+  exact hp.contDiffOn
+
+/-- On a uniquely differentiable set, the iterated derivatives of a completely monotone function
+have the expected alternating signs. -/
+theorem neg_one_pow_mul_iteratedDerivWithin_nonneg (hf : CompletelyMonotoneOn f s)
+    (hs : UniqueDiffOn ℝ s) (n : ℕ) {x : ℝ} (hx : x ∈ s) :
+    0 ≤ (-1) ^ n * iteratedDerivWithin n f s x := by
+  obtain ⟨p, hp, hp_nonneg⟩ := hf
+  have heq : p x n = iteratedFDerivWithin ℝ n f s x :=
+    hp.eq_iteratedFDerivWithin_of_uniqueDiffOn (mod_cast le_top) hs hx
+  rw [iteratedDerivWithin_eq_iteratedFDerivWithin, ← heq]
+  exact hp_nonneg n hx
+
+/-- On a uniquely differentiable set, complete monotonicity is equivalent to smoothness together
+with the usual alternating-sign condition on iterated derivatives within the set. -/
+theorem iff_iteratedDerivWithin_nonneg (hs : UniqueDiffOn ℝ s) :
+    CompletelyMonotoneOn f s ↔
+      ContDiffOn ℝ ∞ f s ∧
+        ∀ n : ℕ, ∀ x ∈ s, 0 ≤ (-1) ^ n * iteratedDerivWithin n f s x := by
+  refine ⟨fun hf => ⟨hf.contDiffOn,
+    fun n _ hx => hf.neg_one_pow_mul_iteratedDerivWithin_nonneg hs n hx⟩, ?_⟩
+  rintro ⟨hcont, hsign⟩
+  refine ⟨ftaylorSeriesWithin ℝ f s, hcont.ftaylorSeriesWithin hs, fun n x hx => ?_⟩
+  exact iteratedDerivWithin_eq_iteratedFDerivWithin (𝕜 := ℝ) (f := f) (s := s) ▸ hsign n x hx
+
+end CompletelyMonotoneOn
+
 /-- A function `f : ℝ → ℝ` is **completely monotone** if it is `C^∞` on the closed half-line
 `[0, ∞)` and its iterated derivatives within `[0, ∞)` alternate in sign:
 `0 ≤ (-1)ⁿ f⁽ⁿ⁾(t)` for every `n` and every `t ≥ 0`. The smoothness clause prevents the sign
@@ -85,6 +131,13 @@ lemma isCompletelyMonotone_iff {f : ℝ → ℝ} :
       ContDiffOn ℝ ∞ f (Ici 0) ∧
         ∀ n : ℕ, ∀ t : ℝ, 0 ≤ t → 0 ≤ (-1) ^ n * iteratedDerivWithin n f (Ici 0) t :=
   Iff.rfl
+
+/-- The closed-half-line predicate is the specialization of complete monotonicity on a set. -/
+lemma isCompletelyMonotone_iff_completelyMonotoneOn {f : ℝ → ℝ} :
+    IsCompletelyMonotone f ↔ CompletelyMonotoneOn f (Ici 0) := by
+  rw [isCompletelyMonotone_iff, CompletelyMonotoneOn.iff_iteratedDerivWithin_nonneg
+    (uniqueDiffOn_Ici 0)]
+  simp only [mem_Ici]
 
 /-- Completely monotone functions are exactly absolutely monotone functions after reflecting the
 closed half-line through zero. -/

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -271,19 +271,14 @@ lemma hasDerivAt_iteratedDerivWithin_succ
 /-- Completely monotone functions are closed under addition. -/
 lemma add (hf : IsCompletelyMonotone f) (hg : IsCompletelyMonotone g) :
     IsCompletelyMonotone (f + g) := by
-  rw [isCompletelyMonotone_iff_absolutelyMonotoneOn_comp_neg]
-  convert (isCompletelyMonotone_iff_absolutelyMonotoneOn_comp_neg.mp hf).add
-    (isCompletelyMonotone_iff_absolutelyMonotoneOn_comp_neg.mp hg) using 1
-  ext u
-  simp [Pi.add_apply]
+  rw [isCompletelyMonotone_iff_completelyMonotoneOn] at hf hg ⊢
+  exact hf.add hg
 
 /-- Completely monotone functions are closed under multiplication by a nonnegative constant. -/
 lemma smul (hf : IsCompletelyMonotone f) {c : ℝ} (hc : 0 ≤ c) :
     IsCompletelyMonotone (c • f) := by
-  rw [isCompletelyMonotone_iff_absolutelyMonotoneOn_comp_neg]
-  convert (isCompletelyMonotone_iff_absolutelyMonotoneOn_comp_neg.mp hf).smul hc using 1
-  ext u
-  simp [Pi.smul_apply, smul_eq_mul]
+  rw [isCompletelyMonotone_iff_completelyMonotoneOn] at hf ⊢
+  exact hf.smul hc
 
 end IsCompletelyMonotone
 

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -13,11 +13,12 @@ public import TauCeti.Analysis.Calculus.IteratedDerivWithin
 /-!
 # Completely monotone functions
 
-A function `f : ℝ → ℝ` is *completely monotone on a set* if it admits a Taylor-series witness
-whose coefficients alternate in sign. This formulation remains meaningful on sets that are not
-uniquely differentiable. On a `UniqueDiffOn` set it is equivalent to smoothness together with
-alternating signs for the iterated derivatives within the set. The principal specialization in
-this development uses the closed half-line `[0, ∞)`:
+A function `f : ℝ → ℝ` is *completely monotone on a set* if its reflection `u ↦ f (-u)` is
+absolutely monotone on the reflected set. Mathlib formulates absolute monotonicity through a
+Taylor-series witness, so this remains meaningful on sets that are not uniquely differentiable.
+On a `UniqueDiffOn` set it is equivalent to smoothness together with alternating signs for the
+iterated derivatives within the set. The principal specialization in this development uses the
+closed half-line `[0, ∞)`:
 `(-1)ⁿ f⁽ⁿ⁾(t) ≥ 0` for every `n` and every `t ≥ 0`. Equivalently `f` is nonnegative,
 nonincreasing, convex, and so on through every order. Bernstein's theorem identifies the
 completely monotone functions on the *open* half-line `(0, ∞)` with the Laplace transforms of
@@ -37,8 +38,8 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
 
 ## Main declarations
 
-* `TauCeti.CompletelyMonotoneOn`: complete monotonicity on an arbitrary set, formulated through a
-  Taylor-series witness in parallel with Mathlib's `AbsolutelyMonotoneOn`.
+* `TauCeti.CompletelyMonotoneOn`: complete monotonicity on an arbitrary set, defined by reflecting
+  Mathlib's `AbsolutelyMonotoneOn` predicate.
 * `TauCeti.CompletelyMonotoneOn.of_contDiff`: a globally smooth function whose ordinary iterated
   derivatives have alternating signs on a set is completely monotone there.
 * `TauCeti.CompletelyMonotoneOn.add`, `TauCeti.CompletelyMonotoneOn.smul`: closure under addition
@@ -79,42 +80,52 @@ open scoped ContDiff Topology
 
 namespace TauCeti
 
-/-- A function `f : ℝ → ℝ` is **completely monotone on a set `s`** if it admits a Taylor series on
-`s` whose `n`th coefficient has sign `(-1)ⁿ`. As in Mathlib's `AbsolutelyMonotoneOn`, the Taylor
-witness makes the definition meaningful even when `s` is not uniquely differentiable. Under
-`UniqueDiffOn ℝ s`, this is equivalent to the expected condition on `iteratedDerivWithin`. -/
+/-- A function `f : ℝ → ℝ` is **completely monotone on a set `s`** if its reflection
+`u ↦ f (-u)` is absolutely monotone on the reflected set `-s`. Mathlib's
+`AbsolutelyMonotoneOn` uses a Taylor-series witness, so this definition remains meaningful even
+when `s` is not uniquely differentiable. Under `UniqueDiffOn ℝ s`, it is equivalent to the
+expected alternating-sign condition on `iteratedDerivWithin`. -/
 def CompletelyMonotoneOn (f : ℝ → ℝ) (s : Set ℝ) : Prop :=
-  ∃ p : ℝ → FormalMultilinearSeries ℝ ℝ ℝ,
-    HasFTaylorSeriesUpToOn ∞ f p s ∧
-      ∀ (n : ℕ) ⦃x : ℝ⦄, x ∈ s → 0 ≤ (-1) ^ n * p x n fun _ ↦ (1 : ℝ)
+  AbsolutelyMonotoneOn (fun u => f (-u)) (-s)
 
 namespace CompletelyMonotoneOn
 
 variable {f : ℝ → ℝ} {s : Set ℝ}
 
+private theorem uniqueDiffOn_neg (hs : UniqueDiffOn ℝ s) : UniqueDiffOn ℝ (-s) := by
+  rw [← Set.image_neg_eq_neg]
+  exact (ContinuousLinearEquiv.neg ℝ).uniqueDiffOn_image hs
+
 /-- A completely monotone function on `s` is smooth on `s`. -/
 theorem contDiffOn (hf : CompletelyMonotoneOn f s) : ContDiffOn ℝ ∞ f s := by
-  obtain ⟨_, hp, _⟩ := hf
-  exact hp.contDiffOn
+  have hneg := AbsolutelyMonotoneOn.contDiffOn hf
+  have hpre : ((-ContinuousLinearMap.id ℝ ℝ) ⁻¹' (-s)) = s := by
+    ext x
+    simp
+  rw [← hpre]
+  simpa [Function.comp_def] using
+    hneg.comp_continuousLinearMap (-ContinuousLinearMap.id ℝ ℝ)
 
 /-- A globally `C^∞` function whose iterated derivatives have alternating signs on `s` is
 completely monotone on `s`. The set `s` need *not* satisfy `UniqueDiffOn`. -/
 theorem of_contDiff (hf : ContDiff ℝ ∞ f)
     (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ (-1) ^ n * iteratedDeriv n f x) :
     CompletelyMonotoneOn f s := by
-  refine ⟨ftaylorSeries ℝ f, (hf.ftaylorSeries).hasFTaylorSeriesUpToOn s, fun n x hx => ?_⟩
-  exact iteratedDeriv_eq_iteratedFDeriv (𝕜 := ℝ) (f := f) ▸ h n x hx
+  refine AbsolutelyMonotoneOn.of_contDiff (hf.comp contDiff_neg) ?_
+  intro n x hx
+  rw [iteratedDeriv_comp_neg]
+  simpa [smul_eq_mul] using h n (-x) (by simpa using hx)
 
 /-- On a uniquely differentiable set, the iterated derivatives of a completely monotone function
 have the expected alternating signs. -/
 theorem neg_one_pow_mul_iteratedDerivWithin_nonneg (hf : CompletelyMonotoneOn f s)
     (hs : UniqueDiffOn ℝ s) (n : ℕ) {x : ℝ} (hx : x ∈ s) :
     0 ≤ (-1) ^ n * iteratedDerivWithin n f s x := by
-  obtain ⟨p, hp, hp_nonneg⟩ := hf
-  have heq : p x n = iteratedFDerivWithin ℝ n f s x :=
-    hp.eq_iteratedFDerivWithin_of_uniqueDiffOn (mod_cast le_top) hs hx
-  rw [iteratedDerivWithin_eq_iteratedFDerivWithin, ← heq]
-  exact hp_nonneg n hx
+  have hsneg := uniqueDiffOn_neg hs
+  have h := AbsolutelyMonotoneOn.iteratedDerivWithin_nonneg hf hsneg n
+    (x := -x) (by simpa using hx)
+  rw [iteratedDerivWithin_comp_neg] at h
+  simpa [smul_eq_mul] using h
 
 /-- On a uniquely differentiable set, complete monotonicity is equivalent to smoothness together
 with the usual alternating-sign condition on iterated derivatives within the set. -/
@@ -125,30 +136,36 @@ theorem iff_iteratedDerivWithin_nonneg (hs : UniqueDiffOn ℝ s) :
   refine ⟨fun hf => ⟨hf.contDiffOn,
     fun n _ hx => hf.neg_one_pow_mul_iteratedDerivWithin_nonneg hs n hx⟩, ?_⟩
   rintro ⟨hcont, hsign⟩
-  refine ⟨ftaylorSeriesWithin ℝ f s, hcont.ftaylorSeriesWithin hs, fun n x hx => ?_⟩
-  exact iteratedDerivWithin_eq_iteratedFDerivWithin (𝕜 := ℝ) (f := f) (s := s) ▸ hsign n x hx
+  have hsneg := uniqueDiffOn_neg hs
+  rw [CompletelyMonotoneOn,
+    AbsolutelyMonotoneOn.iff_iteratedDerivWithin_nonneg hsneg]
+  refine ⟨?_, fun n x hx => ?_⟩
+  · have hpre : ((-ContinuousLinearMap.id ℝ ℝ) ⁻¹' s) = -s := by
+      ext x
+      simp
+    rw [← hpre]
+    simpa [Function.comp_def] using
+      hcont.comp_continuousLinearMap (-ContinuousLinearMap.id ℝ ℝ)
+  · rw [iteratedDerivWithin_comp_neg]
+    simpa [smul_eq_mul] using hsign n (-x) (by simpa using hx)
 
 /-! ### Closure properties -/
 
 /-- The sum of two completely monotone functions is completely monotone. -/
 theorem add {g : ℝ → ℝ} (hf : CompletelyMonotoneOn f s) (hg : CompletelyMonotoneOn g s) :
     CompletelyMonotoneOn (f + g) s := by
-  obtain ⟨p, hp, hp_nonneg⟩ := hf
-  obtain ⟨q, hq, hq_nonneg⟩ := hg
-  refine ⟨p + q, hp.add hq, fun n x hx => ?_⟩
-  simp only [Pi.add_apply, FormalMultilinearSeries.add_apply, add_apply, mul_add]
-  exact add_nonneg (hp_nonneg n hx) (hq_nonneg n hx)
+  rw [CompletelyMonotoneOn]
+  convert AbsolutelyMonotoneOn.add hf hg using 1
+  ext u
+  rfl
 
 /-- A nonnegative scalar multiple of a completely monotone function is completely monotone. -/
 theorem smul {c : ℝ} (hf : CompletelyMonotoneOn f s) (hc : 0 ≤ c) :
     CompletelyMonotoneOn (c • f) s := by
-  obtain ⟨p, hp, hp_nonneg⟩ := hf
-  set T : ℝ →L[ℝ] ℝ := c • ContinuousLinearMap.id ℝ ℝ with hT
-  have hcomp : (T ∘ f) = c • f := by ext x; simp [hT, smul_eq_mul]
-  refine ⟨_, hcomp ▸ hp.continuousLinearMap_comp T, fun n x hx => ?_⟩
-  simp only [ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply, hT,
-    smul_apply, ContinuousLinearMap.id_apply, smul_eq_mul]
-  simpa only [mul_assoc, mul_left_comm, mul_comm] using mul_nonneg hc (hp_nonneg n hx)
+  rw [CompletelyMonotoneOn]
+  convert AbsolutelyMonotoneOn.smul hf hc using 1
+  ext u
+  rfl
 
 end CompletelyMonotoneOn
 
@@ -179,40 +196,11 @@ lemma isCompletelyMonotone_iff_completelyMonotoneOn {f : ℝ → ℝ} :
 closed half-line through zero. -/
 lemma isCompletelyMonotone_iff_absolutelyMonotoneOn_comp_neg {f : ℝ → ℝ} :
     IsCompletelyMonotone f ↔ AbsolutelyMonotoneOn (fun u => f (-u)) (Iic 0) := by
-  rw [isCompletelyMonotone_iff,
-    AbsolutelyMonotoneOn.iff_iteratedDerivWithin_nonneg (uniqueDiffOn_Iic 0)]
-  constructor
-  -- Reflect smoothness and the alternating-sign condition from `[0, ∞)` to `(-∞, 0]`.
-  · rintro ⟨hcont, hsign⟩
-    refine ⟨?_, fun n u hu => ?_⟩
-    · have hpre : ((-ContinuousLinearMap.id ℝ ℝ) ⁻¹' Ici 0) = Iic 0 := by
-        ext x
-        simp
-      rw [← hpre]
-      simpa [Function.comp_def] using
-        hcont.comp_continuousLinearMap (-ContinuousLinearMap.id ℝ ℝ)
-    · rw [iteratedDerivWithin_comp_neg (n := n) (f := f) (s := Iic 0) u]
-      have hset : (-Iic (0 : ℝ) : Set ℝ) = Ici 0 := by
-        ext x
-        simp
-      rw [hset]
-      simpa [smul_eq_mul] using hsign n (-u) (neg_nonneg.mpr hu)
-  -- Reflect the absolutely-monotone data back to the original closed half-line.
-  · rintro ⟨hcont, hsign⟩
-    refine ⟨?_, fun n t ht => ?_⟩
-    · have hpre : ((-ContinuousLinearMap.id ℝ ℝ) ⁻¹' Iic 0) = Ici 0 := by
-        ext x
-        simp
-      rw [← hpre]
-      simpa [Function.comp_def] using
-        hcont.comp_continuousLinearMap (-ContinuousLinearMap.id ℝ ℝ)
-    · have hsign' := hsign n (-t) (mem_Iic.mpr (neg_nonpos.mpr ht))
-      rw [iteratedDerivWithin_comp_neg (n := n) (f := f) (s := Iic 0) (-t)] at hsign'
-      have hset : (-Iic (0 : ℝ) : Set ℝ) = Ici 0 := by
-        ext x
-        simp
-      rw [hset] at hsign'
-      simpa [smul_eq_mul] using hsign'
+  rw [isCompletelyMonotone_iff_completelyMonotoneOn, CompletelyMonotoneOn]
+  have hset : (-(Ici (0 : ℝ)) : Set ℝ) = Iic 0 := by
+    ext x
+    simp
+  rw [hset]
 
 namespace IsCompletelyMonotone
 

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -13,9 +13,11 @@ public import TauCeti.Analysis.Calculus.IteratedDerivWithin
 /-!
 # Completely monotone functions
 
-A function `f : ℝ → ℝ` is *completely monotone on a set* if it is smooth there and its iterated
-derivatives alternate in sign. The principal specialization in this development uses the closed
-half-line `[0, ∞)`:
+A function `f : ℝ → ℝ` is *completely monotone on a set* if it admits a Taylor-series witness
+whose coefficients alternate in sign. This formulation remains meaningful on sets that are not
+uniquely differentiable. On a `UniqueDiffOn` set it is equivalent to smoothness together with
+alternating signs for the iterated derivatives within the set. The principal specialization in
+this development uses the closed half-line `[0, ∞)`:
 `(-1)ⁿ f⁽ⁿ⁾(t) ≥ 0` for every `n` and every `t ≥ 0`. Equivalently `f` is nonnegative,
 nonincreasing, convex, and so on through every order. Bernstein's theorem identifies the
 completely monotone functions on the *open* half-line `(0, ∞)` with the Laplace transforms of
@@ -37,6 +39,10 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
 
 * `TauCeti.CompletelyMonotoneOn`: complete monotonicity on an arbitrary set, formulated through a
   Taylor-series witness in parallel with Mathlib's `AbsolutelyMonotoneOn`.
+* `TauCeti.CompletelyMonotoneOn.of_contDiff`: a globally smooth function whose ordinary iterated
+  derivatives have alternating signs on a set is completely monotone there.
+* `TauCeti.CompletelyMonotoneOn.add`, `TauCeti.CompletelyMonotoneOn.smul`: closure under addition
+  and nonnegative scalar multiplication.
 * `TauCeti.IsCompletelyMonotone`: the predicate that `f` is smooth and sign-alternating on
   `[0, ∞)`.
 * `TauCeti.IsCompletelyMonotone.congr`: complete monotonicity only depends on the values of the
@@ -91,6 +97,14 @@ theorem contDiffOn (hf : CompletelyMonotoneOn f s) : ContDiffOn ℝ ∞ f s := b
   obtain ⟨_, hp, _⟩ := hf
   exact hp.contDiffOn
 
+/-- A globally `C^∞` function whose iterated derivatives have alternating signs on `s` is
+completely monotone on `s`. The set `s` need *not* satisfy `UniqueDiffOn`. -/
+theorem of_contDiff (hf : ContDiff ℝ ∞ f)
+    (h : ∀ n : ℕ, ∀ x ∈ s, 0 ≤ (-1) ^ n * iteratedDeriv n f x) :
+    CompletelyMonotoneOn f s := by
+  refine ⟨ftaylorSeries ℝ f, (hf.ftaylorSeries).hasFTaylorSeriesUpToOn s, fun n x hx => ?_⟩
+  exact iteratedDeriv_eq_iteratedFDeriv (𝕜 := ℝ) (f := f) ▸ h n x hx
+
 /-- On a uniquely differentiable set, the iterated derivatives of a completely monotone function
 have the expected alternating signs. -/
 theorem neg_one_pow_mul_iteratedDerivWithin_nonneg (hf : CompletelyMonotoneOn f s)
@@ -113,6 +127,28 @@ theorem iff_iteratedDerivWithin_nonneg (hs : UniqueDiffOn ℝ s) :
   rintro ⟨hcont, hsign⟩
   refine ⟨ftaylorSeriesWithin ℝ f s, hcont.ftaylorSeriesWithin hs, fun n x hx => ?_⟩
   exact iteratedDerivWithin_eq_iteratedFDerivWithin (𝕜 := ℝ) (f := f) (s := s) ▸ hsign n x hx
+
+/-! ### Closure properties -/
+
+/-- The sum of two completely monotone functions is completely monotone. -/
+theorem add {g : ℝ → ℝ} (hf : CompletelyMonotoneOn f s) (hg : CompletelyMonotoneOn g s) :
+    CompletelyMonotoneOn (f + g) s := by
+  obtain ⟨p, hp, hp_nonneg⟩ := hf
+  obtain ⟨q, hq, hq_nonneg⟩ := hg
+  refine ⟨p + q, hp.add hq, fun n x hx => ?_⟩
+  simp only [Pi.add_apply, FormalMultilinearSeries.add_apply, add_apply, mul_add]
+  exact add_nonneg (hp_nonneg n hx) (hq_nonneg n hx)
+
+/-- A nonnegative scalar multiple of a completely monotone function is completely monotone. -/
+theorem smul {c : ℝ} (hf : CompletelyMonotoneOn f s) (hc : 0 ≤ c) :
+    CompletelyMonotoneOn (c • f) s := by
+  obtain ⟨p, hp, hp_nonneg⟩ := hf
+  set T : ℝ →L[ℝ] ℝ := c • ContinuousLinearMap.id ℝ ℝ with hT
+  have hcomp : (T ∘ f) = c • f := by ext x; simp [hT, smul_eq_mul]
+  refine ⟨_, hcomp ▸ hp.continuousLinearMap_comp T, fun n x hx => ?_⟩
+  simp only [ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply, hT,
+    smul_apply, ContinuousLinearMap.id_apply, smul_eq_mul]
+  simpa only [mul_assoc, mul_left_comm, mul_comm] using mul_nonneg hc (hp_nonneg n hx)
 
 end CompletelyMonotoneOn
 

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
@@ -29,7 +29,7 @@ uniqueness both live in `Laplace/Representation.lean`.
 
 ## Main declarations
 
-* `TauCeti.exists_representsLaplace_of_isCompletelyMonotoneOnIci`
+* `TauCeti.exists_representsLaplace_of_isContinuousCompletelyMonotoneOnIoi`
 * `TauCeti.hausdorff_bernstein_widder`, `TauCeti.hausdorff_bernstein_widder_existsUnique`
 
 ## References
@@ -288,7 +288,7 @@ private lemma isTightMeasureSet_range_of_representsLaplace_shift
 /-- The representing measure of the positive shift `t ↦ f (t + δ)` has total mass
 `f δ ≤ f 0`. -/
 private lemma measure_univ_le_of_representsLaplace_shift
-    {f : ℝ → ℝ} (hf : IsCompletelyMonotoneOnIci f) {δ : ℝ} (hδ : 0 ≤ δ)
+    {f : ℝ → ℝ} (hf : IsContinuousCompletelyMonotoneOnIoi f) {δ : ℝ} (hδ : 0 ≤ δ)
     {μ : Measure ℝ≥0} (hμ : RepresentsLaplace μ (fun t : ℝ => f (t + δ))) :
     μ univ ≤ ENNReal.ofReal (f 0) := by
   have := hμ.isFiniteMeasure
@@ -302,8 +302,8 @@ private lemma measure_univ_le_of_representsLaplace_shift
 /-- **Existence half of the Hausdorff--Bernstein--Widder theorem**: a function continuous on
 `[0, ∞)` and completely monotone on `(0, ∞)` is the Laplace transform of a finite positive
 measure on `ℝ≥0`. -/
-theorem exists_representsLaplace_of_isCompletelyMonotoneOnIci
-    {f : ℝ → ℝ} (hf : IsCompletelyMonotoneOnIci f) :
+theorem exists_representsLaplace_of_isContinuousCompletelyMonotoneOnIoi
+    {f : ℝ → ℝ} (hf : IsContinuousCompletelyMonotoneOnIoi f) :
     ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := by
   classical
   -- Stage 1: the positive null sequence of shifts `aₙ = 1/(n+1)`.
@@ -353,15 +353,15 @@ theorem exists_representsLaplace_of_isCompletelyMonotoneOnIci
 A function is continuous on `[0, ∞)` and completely monotone on `(0, ∞)` if and only if it is
 the Laplace transform of a finite positive measure on `ℝ≥0`. -/
 theorem hausdorff_bernstein_widder (f : ℝ → ℝ) :
-    IsCompletelyMonotoneOnIci f ↔ ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := by
+    IsContinuousCompletelyMonotoneOnIoi f ↔ ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := by
   constructor
-  · exact exists_representsLaplace_of_isCompletelyMonotoneOnIci
+  · exact exists_representsLaplace_of_isContinuousCompletelyMonotoneOnIoi
   · rintro ⟨μ, hμ⟩
-    exact hμ.isCompletelyMonotoneOnIci
+    exact hμ.isContinuousCompletelyMonotoneOnIoi
 
 /-- Unique-existence form of the Hausdorff--Bernstein--Widder theorem. -/
 theorem hausdorff_bernstein_widder_existsUnique (f : ℝ → ℝ) :
-    IsCompletelyMonotoneOnIci f ↔ ∃! μ : Measure ℝ≥0, RepresentsLaplace μ f := by
+    IsContinuousCompletelyMonotoneOnIoi f ↔ ∃! μ : Measure ℝ≥0, RepresentsLaplace μ f := by
   rw [hausdorff_bernstein_widder]
   exact ⟨fun ⟨μ, hμ⟩ => ⟨μ, hμ, fun ν hν => hν.unique hμ⟩,
     fun ⟨μ, hμ, _⟩ => ⟨μ, hμ⟩⟩

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
@@ -624,7 +624,7 @@ private lemma integral_chafaiDensity_le_tendsto_sub (f : ℝ → ℝ)
     (hL : Tendsto f atTop (nhds L)) (T : ℝ) (hT : 0 < T) :
     ∫ t in (0 : ℝ)..T, chafaiDensity f n t ≤ f 0 - L := by
   linarith [integral_chafaiDensity_le_sub f hcm n hn T hT,
-    (IsCompletelyMonotoneOnIci.of_isCompletelyMonotone hcm).le_of_tendsto_atTop hL hT.le]
+    (IsContinuousCompletelyMonotoneOnIoi.of_isCompletelyMonotone hcm).le_of_tendsto_atTop hL hT.le]
 
 private lemma chafaiDensity_integrableOn_Ioi_of_tendsto (f : ℝ → ℝ)
     (hcm : IsCompletelyMonotone f) (n : ℕ) (hn : 1 ≤ n) (L : ℝ) (hL : Tendsto f atTop (nhds L)) :
@@ -699,7 +699,7 @@ lemma chafaiMeasure_finite_mass (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f)
         IsFiniteMeasure (chafaiMeasure f n) ∧
         (chafaiMeasure f n) univ ≤ ENNReal.ofReal (f 0 - L) := by
   obtain ⟨L, hL, hL_nn⟩ :=
-    (IsCompletelyMonotoneOnIci.of_isCompletelyMonotone hcm).exists_nonneg_tendsto_atTop
+    (IsContinuousCompletelyMonotoneOnIoi.of_isCompletelyMonotone hcm).exists_nonneg_tendsto_atTop
   exact ⟨L, hL, hL_nn, fun n => chafaiMeasure_finite_mass_of_tendsto f hcm n L hL⟩
 
 /-- **Natural rescaled total mass bound**: for a completely monotone `f`, the rescaled
@@ -757,7 +757,7 @@ lemma chafaiRescaled_prokhorov_mass_bound (f : ℝ → ℝ) (hcm : IsCompletelyM
         (chafaiRescaled f n) univ ≤ (C : ENNReal) := by
   obtain ⟨L, hL, hL_nn, hfinite⟩ := chafaiRescaled_finite_mass f hcm
   have hL_le : L ≤ f 0 :=
-    (IsCompletelyMonotoneOnIci.of_isCompletelyMonotone hcm).le_of_tendsto_atTop hL le_rfl
+    (IsContinuousCompletelyMonotoneOnIoi.of_isCompletelyMonotone hcm).le_of_tendsto_atTop hL le_rfl
   let C : ℝ≥0 := ⟨f 0 - L, sub_nonneg.mpr hL_le⟩
   refine ⟨L, C, hL, hL_nn, rfl, fun n => ?_⟩
   refine ⟨(hfinite n).1, ?_⟩
@@ -1023,7 +1023,7 @@ private lemma tendsto_sub_pow_mul_normalized_iteratedDerivWithin (f : ℝ → �
       atTop (nhds 0) := by
   -- complete monotonicity already supplies the limit at infinity that integrability needs
   obtain ⟨L, hL, -⟩ :=
-    (IsCompletelyMonotoneOnIci.of_isCompletelyMonotone hcm).exists_nonneg_tendsto_atTop
+    (IsContinuousCompletelyMonotoneOnIoi.of_isCompletelyMonotone hcm).exists_nonneg_tendsto_atTop
   set h := fun T => (-1 : ℝ) ^ k * iteratedDerivWithin k f (Ici 0) T
   have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk
   obtain ⟨h_nonneg₀, h_antitone₀⟩ :=

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Theorem.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Theorem.lean
@@ -25,7 +25,7 @@ on `ℝ≥0`.
 This is the **existence** half of the Bernstein milestone in
 `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B. Uniqueness of the representing measure
 is `TauCeti.RepresentsLaplace.unique`, the converse direction is
-`TauCeti.isCompletelyMonotoneOnIci_laplaceTransform`, and all three combine in
+`TauCeti.isContinuousCompletelyMonotoneOnIoi_laplaceTransform`, and all three combine in
 `Bernstein/HausdorffBernsteinWidder.lean` as `TauCeti.hausdorff_bernstein_widder` and
 `TauCeti.hausdorff_bernstein_widder_existsUnique`.
 

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -144,7 +144,7 @@ taken within the closed half-line `[0, ∞)`. -/
 lemma IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn (hcm : IsCompletelyMonotone f) :
     IntegrableOn (fun t => -iteratedDerivWithin 1 f (Ici 0) t) (Ioi 0) := by
   obtain ⟨L, hL, -⟩ :=
-    (IsCompletelyMonotoneOnIci.of_isCompletelyMonotone hcm).exists_nonneg_tendsto_atTop
+    (IsContinuousCompletelyMonotoneOnIoi.of_isCompletelyMonotone hcm).exists_nonneg_tendsto_atTop
   have hcont : ContinuousWithinAt f (Ici 0) 0 :=
     hcm.contDiffOn.continuousOn.continuousWithinAt self_mem_Ici
   have hderiv : ∀ t ∈ Ioi 0,

--- a/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
@@ -28,7 +28,7 @@ transforms and the predicate that a finite measure represents a function by its 
   API and the bridge `TauCeti.laplaceTransform_eq_mgf` to Mathlib's moment-generating function.
 * `TauCeti.RepresentsLaplace`: the predicate that a finite measure represents a function by its
   Laplace transform on `[0, ∞)`, with `congr`/`add`/`smul`/`unique` API.
-* `TauCeti.isCompletelyMonotoneOnIci_laplaceTransform`,
+* `TauCeti.isContinuousCompletelyMonotoneOnIoi_laplaceTransform`,
   `TauCeti.isCompletelyMonotone_laplaceTransform_of_moments`: the easy direction of the
   representation theorem, in the closed-half-line and all-moments forms.
 * `TauCeti.Measure.ext_of_forall_laplaceTransform_natCast_eq`: finite measures are determined
@@ -414,10 +414,10 @@ theorem isCompletelyMonotoneOnIoi_laplaceTransform
 
 /-- The Laplace transform of a finite measure is completely monotone in the closed-half-line
 roadmap sense. -/
-theorem isCompletelyMonotoneOnIci_laplaceTransform
+theorem isContinuousCompletelyMonotoneOnIoi_laplaceTransform
     (μ : Measure ℝ≥0) [hμ : IsFiniteMeasure μ] :
-    IsCompletelyMonotoneOnIci (laplaceTransform μ) :=
-  isCompletelyMonotoneOnIci_iff.mpr
+    IsContinuousCompletelyMonotoneOnIoi (laplaceTransform μ) :=
+  isContinuousCompletelyMonotoneOnIoi_iff.mpr
     ⟨continuousOn_Ici_laplaceTransform μ,
       isCompletelyMonotoneOnIoi_laplaceTransform μ fun _ ht => integrable_exp_neg_mul μ ht.le⟩
 
@@ -468,9 +468,10 @@ lemma apply_zero (h : RepresentsLaplace μ f) : f 0 = μ.real univ := by
 
 /-- A represented function is continuous on `[0, ∞)` and completely monotone on `(0, ∞)`:
 the easy direction of the Hausdorff--Bernstein--Widder theorem, through the representation. -/
-lemma isCompletelyMonotoneOnIci (h : RepresentsLaplace μ f) : IsCompletelyMonotoneOnIci f := by
+lemma isContinuousCompletelyMonotoneOnIoi (h : RepresentsLaplace μ f) :
+    IsContinuousCompletelyMonotoneOnIoi f := by
   have := h.isFiniteMeasure
-  exact (isCompletelyMonotoneOnIci_laplaceTransform μ).congr fun t ht =>
+  exact (isContinuousCompletelyMonotoneOnIoi_laplaceTransform μ).congr fun t ht =>
     h.eq_laplaceTransform ht
 
 /-- A representation transports along agreement on the nonnegative half-line: the predicate

--- a/TauCeti/Analysis/CompletelyMonotone/OpenClosure.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/OpenClosure.lean
@@ -14,7 +14,7 @@ This file extends the API for `TauCeti.IsCompletelyMonotoneOnIoi`, the ordinary-
 version of complete monotonicity on `(0, ∞)`, with the multiplicative and differential closure
 properties needed by the Bernstein-function part of the one-parameter-semigroups roadmap, and
 derives the corresponding multiplicative closure for the closed-half-line predicate
-`TauCeti.IsCompletelyMonotoneOnIci`.
+`TauCeti.IsContinuousCompletelyMonotoneOnIoi`.
 
 The closed-half-line predicate `TauCeti.IsCompletelyMonotone` already has product and
 negated-derivative closure in `TauCeti.Analysis.CompletelyMonotone.Closure`. The open version is
@@ -31,9 +31,10 @@ derivative at `0`, so their derivative is naturally completely monotone only on 
   there.
 * `TauCeti.IsCompletelyMonotoneOnIoi.neg_deriv`: the negated ordinary derivative of a completely
   monotone function on `(0, ∞)` is completely monotone there.
-* `TauCeti.IsCompletelyMonotoneOnIci.mul`, `TauCeti.IsCompletelyMonotoneOnIci.prod`,
-  `TauCeti.IsCompletelyMonotoneOnIci.pow`: the closed-half-line predicate is closed under
-  pointwise multiplication, finite products, and natural powers.
+* `TauCeti.IsContinuousCompletelyMonotoneOnIoi.mul`,
+  `TauCeti.IsContinuousCompletelyMonotoneOnIoi.prod`,
+  `TauCeti.IsContinuousCompletelyMonotoneOnIoi.pow`: the closed-half-line predicate is closed
+  under pointwise multiplication, finite products, and natural powers.
 
 ## References
 
@@ -129,32 +130,33 @@ theorem neg_deriv (hf : IsCompletelyMonotoneOnIoi f) :
 
 end IsCompletelyMonotoneOnIoi
 
-namespace IsCompletelyMonotoneOnIci
+namespace IsContinuousCompletelyMonotoneOnIoi
 
 variable {f g : ℝ → ℝ}
 
 /-- Closed-half-line complete monotonicity is closed under pointwise multiplication. -/
-protected lemma mul (hf : IsCompletelyMonotoneOnIci f) (hg : IsCompletelyMonotoneOnIci g) :
-    IsCompletelyMonotoneOnIci (f * g) :=
-  isCompletelyMonotoneOnIci_iff.mpr ⟨hf.continuousOn.mul hg.continuousOn,
+protected lemma mul (hf : IsContinuousCompletelyMonotoneOnIoi f)
+    (hg : IsContinuousCompletelyMonotoneOnIoi g) :
+    IsContinuousCompletelyMonotoneOnIoi (f * g) :=
+  isContinuousCompletelyMonotoneOnIoi_iff.mpr ⟨hf.continuousOn.mul hg.continuousOn,
     hf.isCompletelyMonotoneOnIoi.mul hg.isCompletelyMonotoneOnIoi⟩
 
 /-- Closed-half-line complete monotonicity is closed under finite products. -/
 protected lemma prod {ι : Type*} {s : Finset ι} {F : ι → ℝ → ℝ}
-    (hF : ∀ i ∈ s, IsCompletelyMonotoneOnIci (F i)) :
-    IsCompletelyMonotoneOnIci (fun t => ∏ i ∈ s, F i t) := by
-  have h := Finset.prod_induction F IsCompletelyMonotoneOnIci
-    (fun _ _ => IsCompletelyMonotoneOnIci.mul)
+    (hF : ∀ i ∈ s, IsContinuousCompletelyMonotoneOnIoi (F i)) :
+    IsContinuousCompletelyMonotoneOnIoi (fun t => ∏ i ∈ s, F i t) := by
+  have h := Finset.prod_induction F IsContinuousCompletelyMonotoneOnIoi
+    (fun _ _ => IsContinuousCompletelyMonotoneOnIoi.mul)
     (of_isCompletelyMonotone (isCompletelyMonotone_const zero_le_one)) hF
   have heq : (∏ i ∈ s, F i) = fun t => ∏ i ∈ s, F i t := funext fun t => Finset.prod_apply t s F
   rwa [heq] at h
 
 /-- Closed-half-line complete monotonicity is closed under natural powers. -/
-protected lemma pow (hf : IsCompletelyMonotoneOnIci f) (k : ℕ) :
-    IsCompletelyMonotoneOnIci (f ^ k) :=
-  isCompletelyMonotoneOnIci_iff.mpr
+protected lemma pow (hf : IsContinuousCompletelyMonotoneOnIoi f) (k : ℕ) :
+    IsContinuousCompletelyMonotoneOnIoi (f ^ k) :=
+  isContinuousCompletelyMonotoneOnIoi_iff.mpr
     ⟨hf.continuousOn.pow k, hf.isCompletelyMonotoneOnIoi.pow k⟩
 
-end IsCompletelyMonotoneOnIci
+end IsContinuousCompletelyMonotoneOnIoi
 
 end TauCeti


### PR DESCRIPTION
This PR introduces `CompletelyMonotoneOn f s`, the set-parametric formulation parallel to Mathlib's `AbsolutelyMonotoneOn`. It uses a Taylor-series witness, so the definition remains meaningful on sets that are not uniquely differentiable, and proves the expected `iteratedDerivWithin` characterization under `UniqueDiffOn`.

The existing closed-half-line predicate is connected by `isCompletelyMonotone_iff_completelyMonotoneOn`; its downstream API remains focused on `[0, ∞)`.

Roadmap: OneParameterSemigroups

Verified with `lake build`, `lake exe axioms`, `lake exe module-system`, and `bash scripts/lint-env.sh`.

:robot: Prepared with OpenAI Codex