### PR TITLE
feat: generate exterior endomorphisms

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -7,7 +7,7 @@ module
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Even
-import Mathlib.LinearAlgebra.ExteriorAlgebra.Basis
+import TauCeti.LinearAlgebra.ExteriorAlgebra.Contraction
 import Mathlib.LinearAlgebra.BilinearForm.Properties
 import Mathlib.Tactic.NoncommRing
 
@@ -78,36 +78,6 @@ private theorem contractLeft_associated_eq_zero_of_commute_of_mem_even
 
 section Exterior
 
-private theorem contractLeft_ιMulti_eq_zero {n : ℕ}
-    (d : Module.Dual R M) (v : Fin n → M) (h : ∀ i, d (v i) = 0) :
-    contractLeft (Q := (0 : QuadraticForm R M)) d (ExteriorAlgebra.ιMulti R n v) = 0 := by
-  induction n with
-  | zero =>
-      rw [ExteriorAlgebra.ιMulti_zero_apply]
-      exact contractLeft_one (Q := (0 : QuadraticForm R M)) d
-  | succ n ih =>
-      rw [ExteriorAlgebra.ιMulti_succ_apply, contractLeft_ι_mul, h 0, zero_smul,
-        ih (Matrix.vecTail v) (fun i => h i.succ), mul_zero, sub_zero]
-
-private theorem contractLeft_basis_eq_zero_of_not_mem {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
-    contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) = 0 := by
-  rw [ExteriorAlgebra.basis_apply]
-  apply contractLeft_ιMulti_eq_zero
-  intro j
-  simp only [Function.comp_apply, Module.Basis.coord_apply,
-    Module.Basis.repr_self, Finsupp.single_apply]
-  split_ifs with h
-  · exfalso
-    apply hi
-    rw [← h]
-    have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
-      (Set.powersetCard.prodEquiv.symm s).2
-      (Set.powersetCard.ofFinEmbEquiv.symm (Set.powersetCard.prodEquiv.symm s).2 j)).mp
-      ⟨j, rfl⟩
-    exact hj
-  · rfl
-
 private noncomputable def exteriorCoordProj {n : ℕ}
     (b : Module.Basis (Fin n) R M) (i : Fin n) :
     ExteriorAlgebra R M →ₗ[R] ExteriorAlgebra R M :=
@@ -118,52 +88,15 @@ private theorem exteriorCoordProj_basis_of_not_mem {n : ℕ}
     (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
     exteriorCoordProj b i (b.ExteriorAlgebra s) = 0 := by
   rw [exteriorCoordProj, LinearMap.comp_apply, LinearMap.mulLeft_apply,
-    contractLeft_basis_eq_zero_of_not_mem b i s hi, mul_zero]
-
-private theorem basis_exteriorAlgebra_singleton_eq_ι {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) :
-    b.ExteriorAlgebra {i} = ExteriorAlgebra.ι R (b i) := by
-  let a : Set.powersetCard (Fin n) 1 :=
-    Set.powersetCard.ofCard (s := {i}) (Finset.card_singleton i)
-  rw [ExteriorAlgebra.basis_apply_ofCard b (Finset.card_singleton i)]
-  rw [ExteriorAlgebra.ιMulti_family]
-  rw [ExteriorAlgebra.ιMulti_succ_apply, ExteriorAlgebra.ιMulti_zero_apply, mul_one]
-  have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
-    a (Set.powersetCard.ofFinEmbEquiv.symm a 0)).mp ⟨0, rfl⟩
-  have hj' : Set.powersetCard.ofFinEmbEquiv.symm a 0 ∈ ({i} : Finset (Fin n)) := hj
-  have heq : Set.powersetCard.ofFinEmbEquiv.symm a 0 = i := Finset.eq_of_mem_singleton hj'
-  exact congrArg (fun j ↦ ExteriorAlgebra.ι R (b j)) heq
+    TauCeti.ExteriorAlgebra.ι_mul_contractLeft_coord_basis]
+  simp only [hi, ↓reduceIte]
 
 private theorem exteriorCoordProj_basis_of_mem {n : ℕ}
     (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∈ s) :
     exteriorCoordProj b i (b.ExteriorAlgebra s) = b.ExteriorAlgebra s := by
-  let a : Set.powersetCard (Fin n) 1 := ⟨{i}, Finset.card_singleton i⟩
-  let t : Set.powersetCard (Fin n) (s.erase i).card := ⟨s.erase i, rfl⟩
-  have hdisj : Disjoint a.val t.val := by simp [a, t]
-  have hunion : Set.powersetCard.disjUnion hdisj =
-      (Set.powersetCard.ofCard (s := s) (by
-        rw [Finset.card_erase_of_mem hi]
-        have : 0 < s.card := Finset.card_pos.mpr ⟨i, hi⟩
-        omega) : Set.powersetCard (Fin n) (1 + (s.erase i).card)) := by
-    apply Subtype.ext
-    simp [Set.powersetCard.disjUnion, a, t, hi]
-  have hprod := ExteriorAlgebra.basis_mul_of_disjoint b a t hdisj
-  rw [hunion] at hprod
-  simp only [a, t, Set.powersetCard.val_ofCard] at hprod
-  have hfixed : exteriorCoordProj b i
-      (b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i)) =
-      b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i) := by
-    rw [exteriorCoordProj, LinearMap.comp_apply, LinearMap.mulLeft_apply,
-      basis_exteriorAlgebra_singleton_eq_ι]
-    rw [contractLeft_ι_mul]
-    simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
-    rw [contractLeft_basis_eq_zero_of_not_mem b i (s.erase i) (by simp),
-      mul_zero, sub_zero]
-    simp
-  rw [hprod] at hfixed
-  rcases Int.units_eq_one_or (Equiv.Perm.sign
-    (Set.powersetCard.permOfDisjoint hdisj)) with hsign | hsign <;>
-    rw [hsign] at hfixed <;> simpa using hfixed
+  rw [exteriorCoordProj, LinearMap.comp_apply, LinearMap.mulLeft_apply,
+    TauCeti.ExteriorAlgebra.ι_mul_contractLeft_coord_basis]
+  simp only [hi, ↓reduceIte]
 
 private theorem exteriorCoordProj_repr_of_mem {n : ℕ}
     (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∈ s)

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
@@ -22,7 +22,7 @@ open CliffordAlgebra
 
 namespace TauCeti.ExteriorAlgebra
 
-universe u v
+universe u v w
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 
@@ -37,8 +37,8 @@ private theorem contractLeft_ιMulti_eq_zero {n : ℕ}
       rw [ExteriorAlgebra.ιMulti_succ_apply, contractLeft_ι_mul, h 0, zero_smul,
         ih (Matrix.vecTail v) (fun i ↦ h i.succ), mul_zero, sub_zero]
 
-private theorem contractLeft_basis_eq_zero_of_not_mem {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
+private theorem contractLeft_basis_eq_zero_of_not_mem {I : Type w} [LinearOrder I]
+    (b : Module.Basis I R M) (i : I) (s : Finset I) (hi : i ∉ s) :
     contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) = 0 := by
   rw [ExteriorAlgebra.basis_apply]
   apply contractLeft_ιMulti_eq_zero
@@ -56,37 +56,37 @@ private theorem contractLeft_basis_eq_zero_of_not_mem {n : ℕ}
     exact hj
   · rfl
 
-private theorem basis_exteriorAlgebra_singleton_eq_ι {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) :
+private theorem basis_exteriorAlgebra_singleton_eq_ι {I : Type w} [LinearOrder I]
+    (b : Module.Basis I R M) (i : I) :
     b.ExteriorAlgebra {i} = ExteriorAlgebra.ι R (b i) := by
-  let a : Set.powersetCard (Fin n) 1 :=
+  let a : Set.powersetCard I 1 :=
     Set.powersetCard.ofCard (s := {i}) (Finset.card_singleton i)
   rw [ExteriorAlgebra.basis_apply_ofCard b (Finset.card_singleton i)]
   rw [ExteriorAlgebra.ιMulti_family]
   rw [ExteriorAlgebra.ιMulti_succ_apply, ExteriorAlgebra.ιMulti_zero_apply, mul_one]
   have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
     a (Set.powersetCard.ofFinEmbEquiv.symm a 0)).mp ⟨0, rfl⟩
-  have hj' : Set.powersetCard.ofFinEmbEquiv.symm a 0 ∈ ({i} : Finset (Fin n)) := hj
+  have hj' : Set.powersetCard.ofFinEmbEquiv.symm a 0 ∈ ({i} : Finset I) := hj
   have heq : Set.powersetCard.ofFinEmbEquiv.symm a 0 = i := Finset.eq_of_mem_singleton hj'
   exact congrArg (fun j ↦ ExteriorAlgebra.ι R (b j)) heq
 
 /-- Creation after contraction by a basis coordinate is the projection onto exterior basis
 vectors containing that coordinate. -/
 @[simp]
-theorem ι_mul_contractLeft_coord_basis {n : ℕ}
-    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) :
+theorem ι_mul_contractLeft_coord_basis {I : Type w} [LinearOrder I]
+    (b : Module.Basis I R M) (i : I) (s : Finset I) :
     ExteriorAlgebra.ι R (b i) *
         contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) =
       if i ∈ s then b.ExteriorAlgebra s else 0 := by
   split_ifs with hi
-  · let a : Set.powersetCard (Fin n) 1 := ⟨{i}, Finset.card_singleton i⟩
-    let t : Set.powersetCard (Fin n) (s.erase i).card := ⟨s.erase i, rfl⟩
+  · let a : Set.powersetCard I 1 := ⟨{i}, Finset.card_singleton i⟩
+    let t : Set.powersetCard I (s.erase i).card := ⟨s.erase i, rfl⟩
     have hdisj : Disjoint a.val t.val := by simp [a, t]
     have hunion : Set.powersetCard.disjUnion hdisj =
         (Set.powersetCard.ofCard (s := s) (by
           rw [Finset.card_erase_of_mem hi]
           have : 0 < s.card := Finset.card_pos.mpr ⟨i, hi⟩
-          omega) : Set.powersetCard (Fin n) (1 + (s.erase i).card)) := by
+          omega) : Set.powersetCard I (1 + (s.erase i).card)) := by
       apply Subtype.ext
       simp [Set.powersetCard.disjUnion, a, t, hi]
     have hprod := ExteriorAlgebra.basis_mul_of_disjoint b a t hdisj

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
+public import Mathlib.LinearAlgebra.ExteriorAlgebra.Basis
+
+/-!
+# Coordinate projections on an exterior algebra
+
+Left multiplication by a basis vector after contraction by its dual coordinate is the projection
+onto the exterior basis vectors containing that coordinate. This is the occupation-number
+projection used by both scalar detection in Clifford algebras and the matrix-unit construction
+from creation and annihilation operators.
+-/
+
+public section
+
+open CliffordAlgebra
+
+namespace TauCeti.ExteriorAlgebra
+
+universe u v
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+private theorem contractLeft_ιMulti_eq_zero {n : ℕ}
+    (d : Module.Dual R M) (v : Fin n → M) (h : ∀ i, d (v i) = 0) :
+    contractLeft (Q := (0 : QuadraticForm R M)) d (ExteriorAlgebra.ιMulti R n v) = 0 := by
+  induction n with
+  | zero =>
+      rw [ExteriorAlgebra.ιMulti_zero_apply]
+      exact contractLeft_one (Q := (0 : QuadraticForm R M)) d
+  | succ n ih =>
+      rw [ExteriorAlgebra.ιMulti_succ_apply, contractLeft_ι_mul, h 0, zero_smul,
+        ih (Matrix.vecTail v) (fun i ↦ h i.succ), mul_zero, sub_zero]
+
+private theorem contractLeft_basis_eq_zero_of_not_mem {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
+    contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) = 0 := by
+  rw [ExteriorAlgebra.basis_apply]
+  apply contractLeft_ιMulti_eq_zero
+  intro j
+  simp only [Function.comp_apply, Module.Basis.coord_apply,
+    Module.Basis.repr_self, Finsupp.single_apply]
+  split_ifs with h
+  · exfalso
+    apply hi
+    rw [← h]
+    have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
+      (Set.powersetCard.prodEquiv.symm s).2
+      (Set.powersetCard.ofFinEmbEquiv.symm (Set.powersetCard.prodEquiv.symm s).2 j)).mp
+      ⟨j, rfl⟩
+    exact hj
+  · rfl
+
+private theorem basis_exteriorAlgebra_singleton_eq_ι {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) :
+    b.ExteriorAlgebra {i} = ExteriorAlgebra.ι R (b i) := by
+  let a : Set.powersetCard (Fin n) 1 :=
+    Set.powersetCard.ofCard (s := {i}) (Finset.card_singleton i)
+  rw [ExteriorAlgebra.basis_apply_ofCard b (Finset.card_singleton i)]
+  rw [ExteriorAlgebra.ιMulti_family]
+  rw [ExteriorAlgebra.ιMulti_succ_apply, ExteriorAlgebra.ιMulti_zero_apply, mul_one]
+  have hj := (Set.powersetCard.mem_range_ofFinEmbEquiv_symm_iff_mem
+    a (Set.powersetCard.ofFinEmbEquiv.symm a 0)).mp ⟨0, rfl⟩
+  have hj' : Set.powersetCard.ofFinEmbEquiv.symm a 0 ∈ ({i} : Finset (Fin n)) := hj
+  have heq : Set.powersetCard.ofFinEmbEquiv.symm a 0 = i := Finset.eq_of_mem_singleton hj'
+  exact congrArg (fun j ↦ ExteriorAlgebra.ι R (b j)) heq
+
+/-- Creation after contraction by a basis coordinate is the projection onto exterior basis
+vectors containing that coordinate. -/
+@[simp]
+theorem ι_mul_contractLeft_coord_basis {n : ℕ}
+    (b : Module.Basis (Fin n) R M) (i : Fin n) (s : Finset (Fin n)) :
+    ExteriorAlgebra.ι R (b i) *
+        contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) =
+      if i ∈ s then b.ExteriorAlgebra s else 0 := by
+  split_ifs with hi
+  · let a : Set.powersetCard (Fin n) 1 := ⟨{i}, Finset.card_singleton i⟩
+    let t : Set.powersetCard (Fin n) (s.erase i).card := ⟨s.erase i, rfl⟩
+    have hdisj : Disjoint a.val t.val := by simp [a, t]
+    have hunion : Set.powersetCard.disjUnion hdisj =
+        (Set.powersetCard.ofCard (s := s) (by
+          rw [Finset.card_erase_of_mem hi]
+          have : 0 < s.card := Finset.card_pos.mpr ⟨i, hi⟩
+          omega) : Set.powersetCard (Fin n) (1 + (s.erase i).card)) := by
+      apply Subtype.ext
+      simp [Set.powersetCard.disjUnion, a, t, hi]
+    have hprod := ExteriorAlgebra.basis_mul_of_disjoint b a t hdisj
+    rw [hunion] at hprod
+    simp only [a, t, Set.powersetCard.val_ofCard] at hprod
+    have hfixed : ExteriorAlgebra.ι R (b i) *
+        contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i)
+          (b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i)) =
+        b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i) := by
+      rw [basis_exteriorAlgebra_singleton_eq_ι]
+      rw [contractLeft_ι_mul]
+      simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
+      rw [contractLeft_basis_eq_zero_of_not_mem b i (s.erase i) (by simp),
+        mul_zero, sub_zero]
+      simp
+    rw [hprod] at hfixed
+    rcases Int.units_eq_one_or (Equiv.Perm.sign
+      (Set.powersetCard.permOfDisjoint hdisj)) with hsign | hsign <;>
+      rw [hsign] at hfixed <;> simpa using hfixed
+  · rw [contractLeft_basis_eq_zero_of_not_mem b i s hi, mul_zero]
+
+end TauCeti.ExteriorAlgebra

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/End.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/End.lean
@@ -79,28 +79,13 @@ private theorem basisProjection_mem_actionRange {n : ℕ} (b : Module.Basis (Fin
   · exact occupationProjection_mem_actionRange b i
   · exact vacancyProjection_mem_actionRange b i
 
-private theorem occupationProjection_basis_of_not_mem {n : ℕ}
-    (b : Module.Basis (Fin n) K W) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
-    occupationProjection b i (b.ExteriorAlgebra s) = 0 := by
-  rw [occupationProjection, LinearMap.comp_apply, LinearMap.mulLeft_apply,
-    ι_mul_contractLeft_coord_basis]
-  simp only [hi, ↓reduceIte]
-
-private theorem occupationProjection_basis_of_mem {n : ℕ}
-    (b : Module.Basis (Fin n) K W) (i : Fin n) (s : Finset (Fin n)) (hi : i ∈ s) :
-    occupationProjection b i (b.ExteriorAlgebra s) = b.ExteriorAlgebra s := by
-  rw [occupationProjection, LinearMap.comp_apply, LinearMap.mulLeft_apply,
-    ι_mul_contractLeft_coord_basis]
-  simp only [hi, ↓reduceIte]
-
 private theorem vacancyProjection_basis {n : ℕ}
     (b : Module.Basis (Fin n) K W) (i : Fin n) (s : Finset (Fin n)) :
     vacancyProjection b i (b.ExteriorAlgebra s) =
       if i ∈ s then 0 else b.ExteriorAlgebra s := by
-  rw [vacancyProjection, LinearMap.sub_apply, LinearMap.id_apply]
-  split_ifs with hi
-  · rw [occupationProjection_basis_of_mem b i s hi, sub_self]
-  · rw [occupationProjection_basis_of_not_mem b i s hi, sub_zero]
+  rw [vacancyProjection, LinearMap.sub_apply, LinearMap.id_apply, occupationProjection,
+    LinearMap.comp_apply, LinearMap.mulLeft_apply, ι_mul_contractLeft_coord_basis]
+  split_ifs <;> simp
 
 private theorem basisFactor_apply {n : ℕ}
     (b : Module.Basis (Fin n) K W) (s t : Finset (Fin n)) (i : Fin n) :
@@ -108,8 +93,8 @@ private theorem basisFactor_apply {n : ℕ}
         (b.ExteriorAlgebra t) =
       (if (i ∈ s ↔ i ∈ t) then 1 else 0) • b.ExteriorAlgebra t := by
   by_cases his : i ∈ s <;> by_cases hit : i ∈ t <;>
-    simp [his, hit, occupationProjection_basis_of_mem,
-      occupationProjection_basis_of_not_mem, vacancyProjection_basis]
+    simp [his, hit, occupationProjection, ι_mul_contractLeft_coord_basis,
+      vacancyProjection_basis]
 
 private theorem listProd_basisFactor_apply {n : ℕ}
     (b : Module.Basis (Fin n) K W) (s t : Finset (Fin n)) (l : List (Fin n)) :

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/End.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/End.lean
@@ -1,0 +1,355 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.ExteriorAlgebra.Contraction
+
+/-!
+# Exterior creation and contraction generate all endomorphisms
+
+For a finite free module, left exterior multiplication and contraction by dual vectors generate
+the full endomorphism algebra of its exterior algebra.
+
+## Main result
+
+* `TauCeti.ExteriorAlgebra.creation_contraction_adjoin_eq_top`: creation and contraction generate
+  every endomorphism.
+
+## References
+
+* [Spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md)
+-/
+
+public section
+
+open Module CliffordAlgebra
+
+namespace TauCeti.ExteriorAlgebra
+
+universe u v
+
+variable {K : Type u} [CommRing K] {W : Type v} [AddCommGroup W] [Module K W]
+
+private noncomputable def occupationProjection {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (i : Fin n) : Module.End K (ExteriorAlgebra K W) :=
+  (LinearMap.mulLeft K ((ExteriorAlgebra.ι K) (b i))).comp
+    (CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm K W)) (b.coord i))
+
+private noncomputable def vacancyProjection {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (i : Fin n) : Module.End K (ExteriorAlgebra K W) :=
+  LinearMap.id - occupationProjection b i
+
+private noncomputable def basisProjection {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s : Finset (Fin n)) : Module.End K (ExteriorAlgebra K W) :=
+  List.prod ((List.ofFn fun i : Fin n ↦ i).map fun i ↦
+    if i ∈ s then occupationProjection b i else vacancyProjection b i)
+
+private noncomputable def actionRange {n : ℕ} (b : Module.Basis (Fin n) K W) :
+    Subalgebra K (Module.End K (ExteriorAlgebra K W)) :=
+  Algebra.adjoin K
+    (Set.range fun i : Fin n ↦
+      (LinearMap.mulLeft K ((ExteriorAlgebra.ι K) (b i)) : Module.End K _) ) ⊔
+  Algebra.adjoin K
+    (Set.range fun i : Fin n ↦
+      (CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm K W)) (b.coord i) : Module.End K _))
+
+private theorem occupationProjection_mem_actionRange {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (i : Fin n) : occupationProjection b i ∈ actionRange b := by
+  apply (actionRange b).mul_mem
+  -- View each generator algebra through its inclusion into `actionRange`.
+  · exact (show Algebra.adjoin K _ ≤ actionRange b from le_sup_left)
+      (Algebra.subset_adjoin (Set.mem_range_self i))
+  · exact (show Algebra.adjoin K _ ≤ actionRange b from le_sup_right)
+      (Algebra.subset_adjoin (Set.mem_range_self i))
+
+private theorem vacancyProjection_mem_actionRange {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (i : Fin n) : vacancyProjection b i ∈ actionRange b := by
+  exact (actionRange b).sub_mem (actionRange b).one_mem
+    (occupationProjection_mem_actionRange b i)
+
+private theorem basisProjection_mem_actionRange {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s : Finset (Fin n)) : basisProjection b s ∈ actionRange b := by
+  rw [basisProjection]
+  apply Submonoid.list_prod_mem
+  intro f hf
+  obtain ⟨i, hi, rfl⟩ := List.mem_map.mp hf
+  split_ifs
+  · exact occupationProjection_mem_actionRange b i
+  · exact vacancyProjection_mem_actionRange b i
+
+private theorem occupationProjection_basis_of_not_mem {n : ℕ}
+    (b : Module.Basis (Fin n) K W) (i : Fin n) (s : Finset (Fin n)) (hi : i ∉ s) :
+    occupationProjection b i (b.ExteriorAlgebra s) = 0 := by
+  rw [occupationProjection, LinearMap.comp_apply, LinearMap.mulLeft_apply,
+    ι_mul_contractLeft_coord_basis]
+  simp only [hi, ↓reduceIte]
+
+private theorem occupationProjection_basis_of_mem {n : ℕ}
+    (b : Module.Basis (Fin n) K W) (i : Fin n) (s : Finset (Fin n)) (hi : i ∈ s) :
+    occupationProjection b i (b.ExteriorAlgebra s) = b.ExteriorAlgebra s := by
+  rw [occupationProjection, LinearMap.comp_apply, LinearMap.mulLeft_apply,
+    ι_mul_contractLeft_coord_basis]
+  simp only [hi, ↓reduceIte]
+
+private theorem vacancyProjection_basis {n : ℕ}
+    (b : Module.Basis (Fin n) K W) (i : Fin n) (s : Finset (Fin n)) :
+    vacancyProjection b i (b.ExteriorAlgebra s) =
+      if i ∈ s then 0 else b.ExteriorAlgebra s := by
+  rw [vacancyProjection, LinearMap.sub_apply, LinearMap.id_apply]
+  split_ifs with hi
+  · rw [occupationProjection_basis_of_mem b i s hi, sub_self]
+  · rw [occupationProjection_basis_of_not_mem b i s hi, sub_zero]
+
+private theorem basisFactor_apply {n : ℕ}
+    (b : Module.Basis (Fin n) K W) (s t : Finset (Fin n)) (i : Fin n) :
+    (if i ∈ s then occupationProjection b i else vacancyProjection b i)
+        (b.ExteriorAlgebra t) =
+      (if (i ∈ s ↔ i ∈ t) then 1 else 0) • b.ExteriorAlgebra t := by
+  by_cases his : i ∈ s <;> by_cases hit : i ∈ t <;>
+    simp [his, hit, occupationProjection_basis_of_mem,
+      occupationProjection_basis_of_not_mem, vacancyProjection_basis]
+
+private theorem listProd_basisFactor_apply {n : ℕ}
+    (b : Module.Basis (Fin n) K W) (s t : Finset (Fin n)) (l : List (Fin n)) :
+    (l.map (fun i ↦ if i ∈ s then occupationProjection b i else vacancyProjection b i)).prod
+        (b.ExteriorAlgebra t) =
+      (List.prod (l.map (fun i ↦ (if (i ∈ s ↔ i ∈ t) then 1 else 0 : K))) •
+        b.ExteriorAlgebra t) := by
+  induction l with
+  | nil => simp
+  | cons i l ih =>
+      rw [List.map_cons, List.prod_cons, Module.End.mul_apply, ih, map_smul,
+        basisFactor_apply]
+      simp
+
+private theorem basisProjection_basis {n : ℕ}
+    (b : Module.Basis (Fin n) K W) (s t : Finset (Fin n)) :
+    basisProjection b s (b.ExteriorAlgebra t) =
+      if s = t then b.ExteriorAlgebra t else 0 := by
+  rw [basisProjection, listProd_basisFactor_apply]
+  by_cases hst : s = t
+  · subst t
+    simp only [iff_self, ite_true]
+    have hall : (List.ofFn fun i : Fin n ↦ i).map (fun _ ↦ (1 : K)) =
+        List.replicate n 1 := by
+      apply List.eq_replicate_iff.mpr
+      simp
+    rw [hall, List.prod_replicate, one_pow, one_smul]
+  · have hdiff : ∃ i : Fin n, ¬ (i ∈ s ↔ i ∈ t) := by
+      contrapose! hst
+      exact Finset.ext hst
+    obtain ⟨i, hi⟩ := hdiff
+    have hzero : (0 : K) ∈
+        (List.ofFn fun i : Fin n ↦ i).map
+          (fun i ↦ (if (i ∈ s ↔ i ∈ t) then 1 else 0 : K)) := by
+      apply List.mem_map.mpr
+      exact ⟨i, List.mem_ofFn.mpr ⟨i, rfl⟩, by simp [hi]⟩
+    rw [ite_eq_right hst]
+    rw [List.prod_eq_zero hzero, zero_smul]
+
+private noncomputable def create {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s : Finset (Fin n)) : Module.End K (ExteriorAlgebra K W) :=
+  List.prod ((List.ofFn fun j : Fin s.card ↦
+    Set.powersetCard.ofFinEmbEquiv.symm (Set.powersetCard.prodEquiv.symm s).2 j).map
+      fun i ↦ (LinearMap.mulLeft K ((ExteriorAlgebra.ι K) (b i)) : Module.End K _))
+
+private noncomputable def annihilate {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s : Finset (Fin n)) : Module.End K (ExteriorAlgebra K W) :=
+  List.prod (((List.ofFn fun j : Fin s.card ↦
+    Set.powersetCard.ofFinEmbEquiv.symm (Set.powersetCard.prodEquiv.symm s).2 j).map
+      fun i ↦ (CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm K W))
+        (b.coord i) : Module.End K _)).reverse)
+
+private theorem create_mem_actionRange {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s : Finset (Fin n)) : create b s ∈ actionRange b := by
+  rw [create]
+  apply Submonoid.list_prod_mem
+  intro f hf
+  obtain ⟨i, -, rfl⟩ := List.mem_map.mp hf
+  -- View the creation algebra through its inclusion into `actionRange`.
+  exact (show Algebra.adjoin K _ ≤ actionRange b from le_sup_left)
+    (Algebra.subset_adjoin (Set.mem_range_self i))
+
+private theorem annihilate_mem_actionRange {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s : Finset (Fin n)) : annihilate b s ∈ actionRange b := by
+  rw [annihilate]
+  apply Submonoid.list_prod_mem
+  intro f hf
+  have hf' : f ∈ (List.ofFn fun j : Fin s.card ↦
+      Set.powersetCard.ofFinEmbEquiv.symm
+        (Set.powersetCard.prodEquiv.symm s).2 j).map
+        fun i ↦ (CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm K W))
+          (b.coord i) : Module.End K _) := by simpa using hf
+  obtain ⟨i, -, rfl⟩ := List.mem_map.mp hf'
+  -- View the contraction algebra through its inclusion into `actionRange`.
+  exact (show Algebra.adjoin K _ ≤ actionRange b from le_sup_right)
+    (Algebra.subset_adjoin (Set.mem_range_self i))
+
+private noncomputable def matrixUnit {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s t : Finset (Fin n)) : Module.End K (ExteriorAlgebra K W) :=
+  create b s * annihilate b t * basisProjection b t
+
+private theorem matrixUnit_mem_actionRange {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s t : Finset (Fin n)) : matrixUnit b s t ∈ actionRange b :=
+  (actionRange b).mul_mem
+    ((actionRange b).mul_mem (create_mem_actionRange b s) (annihilate_mem_actionRange b t))
+    (basisProjection_mem_actionRange b t)
+
+private theorem create_basis_empty {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s : Finset (Fin n)) :
+    create b s (b.ExteriorAlgebra ∅) = b.ExteriorAlgebra s := by
+  have hEmpty : b.ExteriorAlgebra (∅ : Finset (Fin n)) = 1 := by
+    rw [ExteriorAlgebra.basis_apply]
+    simp
+  rw [create, hEmpty, ExteriorAlgebra.basis_apply]
+  have hmap (xs : List (Fin n)) :
+      (xs.map (fun i ↦ LinearMap.mulLeft K (ExteriorAlgebra.ι K (b i)))).prod 1 =
+        (xs.map fun i ↦ ExteriorAlgebra.ι K (b i)).prod := by
+    induction xs with
+    | nil => simp
+    | cons i xs ih => simp [ih, Module.End.mul_apply]
+  rw [hmap]
+  -- Expose the `ιMulti` family underlying the exterior basis vector.
+  change _ = ExteriorAlgebra.ιMulti K s.card
+    (b ∘ Set.powersetCard.ofFinEmbEquiv.symm
+      (Set.powersetCard.prodEquiv.symm s).2)
+  rw [ExteriorAlgebra.ιMulti_apply]
+  rw [List.map_ofFn]
+  apply congrArg List.prod
+  apply List.ofFn_inj.mpr
+  rfl
+
+private theorem contractLeft_listProd_eq_zero_of_not_mem {n : ℕ}
+    (b : Module.Basis (Fin n) K W) (i : Fin n) (xs : List (Fin n)) (hi : i ∉ xs) :
+    CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm K W)) (b.coord i)
+      (xs.map fun j ↦ ExteriorAlgebra.ι K (b j)).prod = 0 := by
+  induction xs with
+  | nil => exact CliffordAlgebra.contractLeft_one (Q := (0 : QuadraticForm K W)) (b.coord i)
+  | cons j xs ih =>
+      rw [List.map_cons, List.prod_cons, CliffordAlgebra.contractLeft_ι_mul]
+      have hij : i ≠ j := by
+        intro h
+        exact hi (by simp [h])
+      have hit : i ∉ xs := by
+        intro h
+        exact hi (by simp [h])
+      simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
+      simp only [ite_eq_right hij.symm]
+      rw [zero_smul, ih hit, mul_zero, sub_zero]
+
+private theorem annihilate_listProd_self {n : ℕ}
+    (b : Module.Basis (Fin n) K W) (xs : List (Fin n)) (hxs : xs.Nodup) :
+    (xs.map fun i ↦ (CliffordAlgebra.contractLeft
+      (Q := (0 : QuadraticForm K W)) (b.coord i) : Module.End K _)).reverse.prod
+      (xs.map fun i ↦ ExteriorAlgebra.ι K (b i)).prod = 1 := by
+  induction xs with
+  | nil => simp
+  | cons i xs ih =>
+      simp only [List.map_cons, List.reverse_cons, List.prod_append, List.prod_cons,
+        Module.End.mul_apply]
+      -- Expose application of the bundled endomorphism product.
+      change (xs.map fun i ↦ (CliffordAlgebra.contractLeft
+        (Q := (0 : QuadraticForm K W)) (b.coord i) : Module.End K _)).reverse.prod
+          ((CliffordAlgebra.contractLeft
+            (Q := (0 : QuadraticForm K W)) (b.coord i))
+              (ExteriorAlgebra.ι K (b i) *
+                (xs.map fun j ↦ ExteriorAlgebra.ι K (b j)).prod)) = 1
+      rw [CliffordAlgebra.contractLeft_ι_mul]
+      simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
+      rw [contractLeft_listProd_eq_zero_of_not_mem b i xs hxs.notMem, mul_zero, sub_zero]
+      simp only [ite_true, one_smul]
+      rw [ih hxs.tail]
+
+private theorem annihilate_basis_self {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s : Finset (Fin n)) :
+    annihilate b s (b.ExteriorAlgebra s) = b.ExteriorAlgebra ∅ := by
+  have hEmpty : b.ExteriorAlgebra (∅ : Finset (Fin n)) = 1 := by
+    rw [ExteriorAlgebra.basis_apply]
+    simp
+  rw [annihilate, ExteriorAlgebra.basis_apply, hEmpty]
+  -- Expose `annihilate` as its reversed product of contraction maps.
+  change ((List.map (fun i ↦ (CliffordAlgebra.contractLeft
+      (Q := (0 : QuadraticForm K W)) (b.coord i) : Module.End K _))
+      (List.ofFn fun j : Fin s.card ↦
+        Set.powersetCard.ofFinEmbEquiv.symm
+          (Set.powersetCard.prodEquiv.symm s).2 j)).reverse.prod)
+    (ExteriorAlgebra.ιMulti K s.card
+    (b ∘ Set.powersetCard.ofFinEmbEquiv.symm
+      (Set.powersetCard.prodEquiv.symm s).2)) = 1
+  rw [ExteriorAlgebra.ιMulti_apply]
+  -- Put the contraction and exterior products in the same list representation.
+  change ((List.ofFn fun j : Fin s.card ↦
+      Set.powersetCard.ofFinEmbEquiv.symm
+        (Set.powersetCard.prodEquiv.symm s).2 j).map fun i ↦
+          (CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm K W))
+            (b.coord i) : Module.End K _)).reverse.prod
+    ((List.ofFn fun j : Fin s.card ↦
+      ExteriorAlgebra.ι K (b (Set.powersetCard.ofFinEmbEquiv.symm
+        (Set.powersetCard.prodEquiv.symm s).2 j))).prod) = 1
+  let xs := List.ofFn fun j : Fin s.card ↦ Set.powersetCard.ofFinEmbEquiv.symm
+    (Set.powersetCard.prodEquiv.symm s).2 j
+  have hxmap : xs.map (fun i ↦ ExteriorAlgebra.ι K (b i)) =
+      List.ofFn (fun j : Fin s.card ↦ ExteriorAlgebra.ι K
+        (b (Set.powersetCard.ofFinEmbEquiv.symm
+          (Set.powersetCard.prodEquiv.symm s).2 j))) := by
+    dsimp only [xs]
+    rw [List.map_ofFn]
+    congr 1
+  rw [← hxmap]
+  apply annihilate_listProd_self b xs
+  exact List.nodup_ofFn.mpr
+    (Set.powersetCard.ofFinEmbEquiv.symm
+      (Set.powersetCard.prodEquiv.symm s).2).injective
+
+private theorem matrixUnit_basis {n : ℕ} (b : Module.Basis (Fin n) K W)
+    (s t u : Finset (Fin n)) :
+    matrixUnit b s t (b.ExteriorAlgebra u) =
+      if t = u then b.ExteriorAlgebra s else 0 := by
+  rw [matrixUnit, Module.End.mul_apply, Module.End.mul_apply, basisProjection_basis]
+  split_ifs with h
+  · subst u
+    rw [annihilate_basis_self, create_basis_empty]
+  · rw [map_zero, map_zero]
+
+private theorem actionRange_eq_top {n : ℕ} (b : Module.Basis (Fin n) K W) :
+    actionRange b = ⊤ := by
+  apply top_unique
+  intro f _
+  rw [← b.ExteriorAlgebra.end.sum_repr f]
+  apply Submodule.sum_mem (p := (actionRange b).toSubmodule)
+  intro st _
+  -- Replace the basis matrix by the pointwise-equal constructed matrix unit.
+  rw [show b.ExteriorAlgebra.end.repr f st • b.ExteriorAlgebra.end st =
+      b.ExteriorAlgebra.end.repr f st • matrixUnit b st.1 st.2 by
+    apply b.ExteriorAlgebra.ext
+    intro u
+    simp only [LinearMap.smul_apply]
+    rw [Module.Basis.end_apply_apply]
+    rw [matrixUnit_basis]]
+  exact (actionRange b).smul_mem (matrixUnit_mem_actionRange b st.1 st.2) _
+
+/-- Exterior creation and contraction generate every endomorphism of a finite free module's
+exterior algebra. -/
+theorem creation_contraction_adjoin_eq_top [Module.Free K W] [Module.Finite K W] :
+    Algebra.adjoin K
+      (Set.range (fun x : W ↦
+        (LinearMap.mulLeft K (ExteriorAlgebra.ι K x) : Module.End K (ExteriorAlgebra K W))) ∪
+       Set.range (fun d : Module.Dual K W ↦
+        (CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm K W)) d :
+          Module.End K (ExteriorAlgebra K W)))) = ⊤ := by
+  let _ := Fintype.ofFinite (Module.Free.ChooseBasisIndex K W)
+  let b : Module.Basis (Fin (Fintype.card (Module.Free.ChooseBasisIndex K W))) K W :=
+    (Module.Free.chooseBasis K W).reindex (Fintype.equivFin _)
+  apply top_unique
+  rw [← actionRange_eq_top b]
+  apply sup_le
+  · apply Algebra.adjoin_le
+    rintro _ ⟨i, rfl⟩
+    exact Algebra.subset_adjoin (Or.inl ⟨b i, rfl⟩)
+  · apply Algebra.adjoin_le
+    rintro _ ⟨i, rfl⟩
+    exact Algebra.subset_adjoin (Or.inr ⟨b.coord i, rfl⟩)
+
+end TauCeti.ExteriorAlgebra


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Proves that exterior creation and contraction operators generate every endomorphism of a finite free exterior algebra.

- Extracts the shared basis-coordinate projection used by Clifford scalar detection.
- Builds occupation projections and matrix units from creation and contraction.
- Identifies their generated subalgebra with the full endomorphism algebra.

## Roadmap target

Supplies the matrix-unit prerequisite for Layer 4 `spinAction` surjectivity:
https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#the-clifford-module-s--bigwedge-w

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/README.md#spinAction-surjective"}-->

## Verification

Current-main focused/full builds, axioms, module audit, lint, exact `spinAction` consumer, bare-`simp` probes, structural golf, and fresh paired review pass at `c978e95b310c0594d73daea9a159af26968f2c38`.

## Scale and generality

Changes three files by +472/−73. The public results work over any commutative ring and finite free module; no field, nondegeneracy, or characteristic assumption is added.

## Scope

- **Consumes:** Mathlib exterior-basis and contraction APIs, plus the merged Spin-action component equations.
- **Provides:** a shared coordinate projection equation and the creation/contraction generation theorem.
- **Fits:** supplies the exact lower-layer theorem used to prove `spinAction` surjective.
- **Boundary:** Spin-action surjectivity and representation classification remain downstream consumers.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [a66b04d](https://github.com/TauCetiProject/TauCetiReview/commit/a66b04d97721565b13c8abe07f750fb1d2959ad5) · local 2+1 review @ [8429746](https://github.com/utensil/formal-land/commit/84297461ff318491bfc26ad7c1b8402a56c03e8e) fixed: api-design (1), attribution (1), placement (1), proof-quality (1), reuse (1)</sub>
