### PR TITLE
feat(AdicSpace): Cont A is closed in Spv (A, IA) — Wedhorn Corollary 7.12

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Cont/OfIdeal.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Cont/OfIdeal.lean
@@ -12,15 +12,16 @@ import TauCeti.RingTheory.Huber.Continuous.OfCofinal
 import TauCeti.RingTheory.Valuation.Continuous.TopologicallyNilpotent
 
 /-!
-# Continuous points in `Spv (A, I)`: Wedhorn's Theorem 7.10
+# Continuous points in `Spv (A, I)`: Wedhorn's Theorem 7.10 and Corollary 7.12
 
-**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Theorem 7.10.**
+**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Theorem 7.10 and Corollary 7.12.**
 
 Theorem 7.10 identifies `Cont A` inside `Spv (A, IA)` for a pair of definition `(A₀, I)`, as the
 locus where additionally `v(a) < 1` for every `a ∈ I`. This file proves the two conjuncts of the
 inclusion — a continuous point lies in `Spv (A, IA)`, and it is sub-unit on the ideal of
 definition — then the converse, and assembles the identification
-`cont_eq_spvOfIdeal_inter_setOfPred_forall_vlt_one`.
+`cont_eq_spvOfIdeal_inter_setOfPred_forall_vlt_one`. Corollary 7.12 follows: the sub-unit
+condition is closed in `Spv A`, so `Cont A` is a closed subset of the subspace `Spv (A, IA)`.
 
 For the inclusion, the argument needs no estimate and no pair of definition either. Membership in
 `Spv (A, I)` is `cΓ_v(I) = Γ_v`, which by Lemma 7.4 follows from cofinality of `v` at every
@@ -51,10 +52,12 @@ nilpotent — the nilpotence is a property of the generators, not of the ideal t
   `TauCeti.Huber.PairOfDefinition.isContinuous_of_forall_cofinalValue`.
 * `TauCeti.ValuationSpectrum.cont_eq_spvOfIdeal_inter_setOfPred_forall_vlt_one` : **Theorem 7.10**,
   the resulting identification of `Cont A` inside `Spv (A, IA)`.
+* `TauCeti.ValuationSpectrum.isClosed_val_preimage_cont` : **Corollary 7.12**, `Cont A` is a
+  closed subset of `Spv (A, IA)`.
 
 ## References
 
-* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Theorem 7.10 and Lemma 7.4.
+* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Theorem 7.10, Corollary 7.12, and Lemma 7.4.
 -/
 
 public section
@@ -164,6 +167,23 @@ theorem cont_eq_spvOfIdeal_inter_setOfPred_forall_vlt_one (P : PairOfDefinition 
       not_vle_one_of_isContinuous_of_mem_idealOfDefinition P ((mem_cont_iff v).mp hv) ha⟩
   · rintro ⟨hmem, h1⟩
     exact (mem_cont_iff v).mpr (isContinuous_of_mem_spvOfIdeal_of_forall_vlt_one P hmem h1)
+
+/-- **Wedhorn Corollary 7.12.** `Cont A` is a closed subset of `Spv (A, IA)`: by Theorem 7.10
+its trace on the subspace is the sub-unit locus of the ideal of definition, which is closed
+already in `Spv A`. -/
+theorem isClosed_val_preimage_cont (P : PairOfDefinition A) :
+    IsClosed (Subtype.val ⁻¹' cont A : Set (spvOfIdeal P.extendedIdealOfDefinition
+      ⟨P.extendedIdealOfDefinition, P.fg_extendedIdealOfDefinition, rfl⟩)) := by
+  rw [cont_eq_spvOfIdeal_inter_setOfPred_forall_vlt_one P, Set.preimage_inter,
+    Subtype.coe_preimage_self, Set.univ_inter]
+  have h : {v : Spv A | ∀ a ∈ P.idealOfDefinition,
+      v.toValuativeRel.vlt ((a : P.ringOfDefinition) : A) 1}
+      = {v : Spv A | ∀ b ∈ ((↑) : P.ringOfDefinition → A) ''
+          (P.idealOfDefinition : Set P.ringOfDefinition), v.toValuativeRel.vlt b 1} := by
+    ext v
+    simp
+  rw [h]
+  exact (isClosed_setOfPred_forall_vlt_one _).preimage continuous_subtype_val
 
 end TauCeti.ValuationSpectrum
 


### PR DESCRIPTION
**Wedhorn Corollary 7.12: `Cont A` is a closed subset of `Spv (A, IA)` — Layer 1.5's last
item.**

```lean
theorem isClosed_val_preimage_cont (P : PairOfDefinition A) :
    IsClosed (Subtype.val ⁻¹' cont A : Set (spvOfIdeal P.extendedIdealOfDefinition
      ⟨P.extendedIdealOfDefinition, P.fg_extendedIdealOfDefinition, rfl⟩))
```

The proof composes the two pieces merged this week: Theorem 7.10's identification
`cont_eq_spvOfIdeal_inter_setOfPred_forall_vlt_one` (#3066) rewrites the trace of `Cont A` on
the subspace into the sub-unit locus of the ideal of definition, and #2987's
`isClosed_setOfPred_forall_vlt_one` closes that locus already in `Spv A`; pull back along the
continuous subtype inclusion. The statement shape (`Subtype.val ⁻¹' … : Set (spvOfIdeal …)`)
and name follow `isOpen_val_preimage_rationalSubset`. The module docstring, Main results, and
References gain the 7.12 entries in the same diff.

With this, roadmap Layer 1.5 (`Cont A`, Theorem 7.10, Corollary 7.12) is complete; Theorem
7.35 (Layer 2.1) consumes this closedness together with the pro-constructibility machinery.

## Gates

`lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
(`LINT-ENV: PASS`) — all exit 0, each run separately, on this head atop current `main`.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-1.5-cor-7.12"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
