### PR TITLE
refactor: give the SemistandardYoungTableau API dot notation

### DIFF
--- a/TauCeti/Combinatorics/Young/Interlacing.lean
+++ b/TauCeti/Combinatorics/Young/Interlacing.lean
@@ -119,17 +119,6 @@ theorem mem_interlacingShapes {n : ℕ} :
 
 end YoungDiagram
 
-namespace SemistandardYoungTableau
-
-variable {μ : _root_.YoungDiagram}
-
-/-- The entries of a semistandard Young tableau increase weakly to the right and downwards. -/
-theorem entry_le_of_le (T : _root_.SemistandardYoungTableau μ) {i₁ i₂ j₁ j₂ : ℕ} (hi : i₁ ≤ i₂)
-    (hj : j₁ ≤ j₂) (hc : ((i₂, j₂) : ℕ × ℕ) ∈ μ) : T i₁ j₁ ≤ T i₂ j₂ :=
-  (T.row_weak_of_le hj (μ.up_left_mem hi le_rfl hc)).trans (T.col_weak hi hc)
-
-end SemistandardYoungTableau
-
 namespace TauCeti
 
 namespace BoundedSSYT

--- a/TauCeti/Combinatorics/Young/Interlacing.lean
+++ b/TauCeti/Combinatorics/Young/Interlacing.lean
@@ -119,8 +119,6 @@ theorem mem_interlacingShapes {n : ℕ} :
 
 end YoungDiagram
 
-namespace TauCeti
-
 namespace SemistandardYoungTableau
 
 variable {μ : _root_.YoungDiagram}
@@ -131,6 +129,8 @@ theorem entry_le_of_le (T : _root_.SemistandardYoungTableau μ) {i₁ i₂ j₁ 
   (T.row_weak_of_le hj (μ.up_left_mem hi le_rfl hc)).trans (T.col_weak hi hc)
 
 end SemistandardYoungTableau
+
+namespace TauCeti
 
 namespace BoundedSSYT
 

--- a/TauCeti/Combinatorics/Young/Kostka.lean
+++ b/TauCeti/Combinatorics/Young/Kostka.lean
@@ -21,7 +21,7 @@ the tableau of shape `μ` whose `i`-th row consists of `i`s is the only one of c
 `∑_{i < k} w i` to be at most the corresponding partial sum of the row lengths of `μ` (so, for
 partitions, `K_{μ ν} = 0` unless `μ` dominates `ν`).
 
-The mechanism behind both is a single observation, `TauCeti.SemistandardYoungTableau.le_entry`: the
+The mechanism behind both is a single observation, `SemistandardYoungTableau.le_entry`: the
 entries of a semistandard tableau strictly increase down each column, so the entry in row `i` is at
 least `i`, and therefore the cells carrying an entry smaller than `k` all lie in the first `k`
 rows.
@@ -32,7 +32,7 @@ highest-weight tableau `SemistandardYoungTableau.highestWeight μ` is `μ.rowLen
 
 ## Main definitions
 
-* `TauCeti.SemistandardYoungTableau.content`: the content (or weight) of a semistandard Young
+* `SemistandardYoungTableau.content`: the content (or weight) of a semistandard Young
   tableau, `content T i` being the number of cells filled with `i`.
 * `TauCeti.BoundedSSYT`: the semistandard Young tableaux of a given shape whose entries lie below
   a given bound, that is, those written in a finite alphabet.
@@ -43,11 +43,11 @@ highest-weight tableau `SemistandardYoungTableau.highestWeight μ` is `μ.rowLen
 
 ## Main results
 
-* `TauCeti.SemistandardYoungTableau.sum_content_le_sum_take_rowLens`: the partial sums of the
+* `SemistandardYoungTableau.sum_content_le_sum_take_rowLens`: the partial sums of the
   content of a tableau of shape `μ` are bounded by those of the row lengths of `μ`.
-* `TauCeti.SemistandardYoungTableau.eq_highestWeight_of_content_eq_rowLen`: a tableau of shape `μ`
+* `SemistandardYoungTableau.eq_highestWeight_of_content_eq_rowLen`: a tableau of shape `μ`
   and content `μ.rowLen` is the highest-weight tableau.
-* `TauCeti.SemistandardYoungTableau.finite_content_eq`: the tableaux of a fixed shape and content
+* `SemistandardYoungTableau.finite_content_eq`: the tableaux of a fixed shape and content
   are finite, so the Kostka number counts them faithfully.
 * `TauCeti.finite_boundedSSYT`: likewise the tableaux of a fixed shape written in a finite alphabet,
   `TauCeti.BoundedSSYT`, are finite.
@@ -63,8 +63,6 @@ highest-weight tableau `SemistandardYoungTableau.highestWeight μ` is `μ.rowLen
 -/
 
 public section
-
-namespace TauCeti
 
 namespace SemistandardYoungTableau
 
@@ -196,6 +194,8 @@ instance finite_content_eq (μ : YoungDiagram) (w : ℕ → ℕ) :
   · rw [T.1.zeros hij, T'.1.zeros hij]
 
 end SemistandardYoungTableau
+
+namespace TauCeti
 
 /-- The semistandard Young tableaux of shape `μ` written in the alphabet `{0, …, n - 1}`, that
 is, those all of whose entries are smaller than `n`.  Mathlib's `SemistandardYoungTableau μ`

--- a/TauCeti/Combinatorics/Young/Kostka.lean
+++ b/TauCeti/Combinatorics/Young/Kostka.lean
@@ -193,6 +193,11 @@ instance finite_content_eq (μ : YoungDiagram) (w : ℕ → ℕ) :
   · exact congrArg Subtype.val (congrFun hTT' ⟨(i, j), hij⟩)
   · rw [T.1.zeros hij, T'.1.zeros hij]
 
+/-- The entries of a semistandard Young tableau increase weakly to the right and downwards. -/
+theorem entry_le_of_le (T : _root_.SemistandardYoungTableau μ) {i₁ i₂ j₁ j₂ : ℕ} (hi : i₁ ≤ i₂)
+    (hj : j₁ ≤ j₂) (hc : ((i₂, j₂) : ℕ × ℕ) ∈ μ) : T i₁ j₁ ≤ T i₂ j₂ :=
+  (T.row_weak_of_le hj (μ.up_left_mem hi le_rfl hc)).trans (T.col_weak hi hc)
+
 end SemistandardYoungTableau
 
 namespace TauCeti

--- a/TauCeti/Combinatorics/Young/Kostka.lean
+++ b/TauCeti/Combinatorics/Young/Kostka.lean
@@ -8,6 +8,7 @@ public import Mathlib.Combinatorics.Young.SemistandardTableau
 public import Mathlib.Data.Finsupp.Multiset
 public import Mathlib.SetTheory.Cardinal.Finite
 public import TauCeti.Combinatorics.Enumerative.Partition.Conjugate
+public import TauCeti.Combinatorics.Young.SemistandardTableau
 
 /-!
 # Kostka numbers
@@ -192,11 +193,6 @@ instance finite_content_eq (μ : YoungDiagram) (w : ℕ → ℕ) :
   by_cases hij : (i, j) ∈ μ
   · exact congrArg Subtype.val (congrFun hTT' ⟨(i, j), hij⟩)
   · rw [T.1.zeros hij, T'.1.zeros hij]
-
-/-- The entries of a semistandard Young tableau increase weakly to the right and downwards. -/
-theorem entry_le_of_le (T : _root_.SemistandardYoungTableau μ) {i₁ i₂ j₁ j₂ : ℕ} (hi : i₁ ≤ i₂)
-    (hj : j₁ ≤ j₂) (hc : ((i₂, j₂) : ℕ × ℕ) ∈ μ) : T i₁ j₁ ≤ T i₂ j₂ :=
-  (T.row_weak_of_le hj (μ.up_left_mem hi le_rfl hc)).trans (T.col_weak hi hc)
 
 end SemistandardYoungTableau
 

--- a/TauCeti/Combinatorics/Young/SemistandardTableau.lean
+++ b/TauCeti/Combinatorics/Young/SemistandardTableau.lean
@@ -10,9 +10,9 @@ public import Mathlib.Combinatorics.Young.SemistandardTableau
 # Order properties of semistandard Young tableaux
 
 Mathlib's `SemistandardYoungTableau` records that entries increase weakly along each row and
-strictly down each column, as two separate one-step conditions. This file combines them into the
-two-dimensional monotonicity statement that consumers actually reach for: an entry is bounded by
-any entry weakly below and to the right of it.
+strictly down each column, each within a single row or column. This file combines the two into the
+two-dimensional statement that consumers actually reach for, comparing entries that differ in both
+coordinates at once: an entry is bounded by any entry weakly below and to the right of it.
 
 The material is deliberately kept in its own module, upstream of the contents and Kostka-number
 theory, so that a basic order fact about tableaux does not oblige a consumer to import that

--- a/TauCeti/Combinatorics/Young/SemistandardTableau.lean
+++ b/TauCeti/Combinatorics/Young/SemistandardTableau.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Combinatorics.Young.SemistandardTableau
+
+/-!
+# Order properties of semistandard Young tableaux
+
+Mathlib's `SemistandardYoungTableau` records that entries increase weakly along each row and
+strictly down each column, as two separate one-step conditions. This file combines them into the
+two-dimensional monotonicity statement that consumers actually reach for: an entry is bounded by
+any entry weakly below and to the right of it.
+
+The material is deliberately kept in its own module, upstream of the contents and Kostka-number
+theory, so that a basic order fact about tableaux does not oblige a consumer to import that
+theory.
+
+## Main declarations
+
+* `SemistandardYoungTableau.entry_le_of_le`: entries increase weakly to the right and downwards.
+-/
+
+public section
+
+namespace SemistandardYoungTableau
+
+variable {μ : YoungDiagram}
+
+/-- The entries of a semistandard Young tableau increase weakly to the right and downwards. -/
+theorem entry_le_of_le (T : SemistandardYoungTableau μ) {i₁ i₂ j₁ j₂ : ℕ} (hi : i₁ ≤ i₂)
+    (hj : j₁ ≤ j₂) (hc : ((i₂, j₂) : ℕ × ℕ) ∈ μ) : T i₁ j₁ ≤ T i₂ j₂ :=
+  (T.row_weak_of_le hj (μ.up_left_mem hi le_rfl hc)).trans (T.col_weak hi hc)
+
+end SemistandardYoungTableau

--- a/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Tableau.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Tableau.lean
@@ -48,8 +48,8 @@ regime is there a tableau to speak of.
 
 * `TauCeti.GTPattern.tableauEntry` and `TauCeti.GTPattern.toTableau`: the tableau entry `T i c`
   read off a pattern, and the semistandard Young tableau it assembles.
-* `TauCeti.SemistandardYoungTableau.patternEntry` and
-  `TauCeti.SemistandardYoungTableau.toGTPattern`: the pattern read off a tableau.
+* `SemistandardYoungTableau.patternEntry` and
+  `SemistandardYoungTableau.toGTPattern`: the pattern read off a tableau.
 * `TauCeti.gtPatternEquivSSYT`: **the bijection**, between the patterns with `n` rows and top row
   the shape `μ` and the semistandard Young tableaux of shape `μ` with entries below `n`, that is,
   `TauCeti.BoundedSSYT n μ`.
@@ -57,7 +57,7 @@ regime is there a tableau to speak of.
 ## Main results
 
 * `TauCeti.GTPattern.lt_tableauEntry_iff` and
-  `TauCeti.SemistandardYoungTableau.lt_card_filter_rowLen_iff`: the two counting maps are decided
+  `SemistandardYoungTableau.lt_card_filter_rowLen_iff`: the two counting maps are decided
   by the pattern entries, respectively by the tableau entries.  Everything else is read off these
   two comparisons.
 * `TauCeti.card_gtPattern_topRow_eq_card_ssyt`: the patterns with a given top row are as many as
@@ -82,9 +82,9 @@ nonempty the two readings agree, since a nonempty shape forces `n ≠ 0`.
 
 public section
 
-namespace TauCeti
-
 open Finset
+
+namespace TauCeti
 
 variable {n : ℕ} {μ : YoungDiagram}
 
@@ -257,7 +257,11 @@ end GTPattern
 
 /-! ### From a tableau to a pattern -/
 
+end TauCeti
+
 namespace SemistandardYoungTableau
+
+variable {n : ℕ} {μ : YoungDiagram}
 
 /-- The `(i, j)` entry of the pattern attached to a semistandard Young tableau, as a pattern with
 `n` rows: for `j ≤ n` it is the number of cells of row `i` of `μ` whose entry is below `j`, that
@@ -268,7 +272,7 @@ def patternEntry (T : SemistandardYoungTableau μ) (n i j : ℕ) : ℤ :=
 
 /-- The pattern entry of a tableau, unfolded: `0` past the top row, and otherwise the count of the
 cells of row `i` of `μ` carrying an entry below `j`.  The body of
-`TauCeti.SemistandardYoungTableau.patternEntry` is not exposed, so this is how the count is
+`SemistandardYoungTableau.patternEntry` is not exposed, so this is how the count is
 reached. -/
 @[simp]
 theorem patternEntry_def (T : SemistandardYoungTableau μ) (n i j : ℕ) :
@@ -281,14 +285,14 @@ increase weakly, so the condition is downward closed in `c`. -/
 @[simp]
 theorem lt_card_filter_rowLen_iff (T : SemistandardYoungTableau μ) {i j c : ℕ} :
     c < #{c' ∈ range (μ.rowLen i) | T i c' < j} ↔ c < μ.rowLen i ∧ T i c < j :=
-  lt_card_filter_range_iff fun _ _ hxy hx hpx =>
+  TauCeti.lt_card_filter_range_iff fun _ _ hxy hx hpx =>
     (T.row_weak_of_le hxy (YoungDiagram.mem_iff_lt_rowLen.mpr hx)).trans_lt hpx
 
 /-- **The Gelfand-Tsetlin pattern of a semistandard Young tableau**, with `n` rows: row `j` is
 the row-length sequence of the shape filled by the entries `< j`.  No bound on the entries is
 needed to build the pattern; a bound is what makes its top row the whole of `μ`
-(`TauCeti.SemistandardYoungTableau.topRow_toGTPattern`). -/
-def toGTPattern (T : SemistandardYoungTableau μ) (n : ℕ) : GTPattern n where
+(`SemistandardYoungTableau.topRow_toGTPattern`). -/
+def toGTPattern (T : SemistandardYoungTableau μ) (n : ℕ) : TauCeti.GTPattern n where
   entry := patternEntry T n
   zeros' {i j} h := by
     simp only [patternEntry_def]
@@ -336,7 +340,7 @@ theorem topRow_toGTPattern (T : SemistandardYoungTableau μ) (n : ℕ)
   have hfil : {c ∈ range (μ.rowLen (i : ℕ)) | T (i : ℕ) c < n} = range (μ.rowLen (i : ℕ)) :=
     filter_true_of_mem fun c hc =>
       hT _ _ (YoungDiagram.mem_iff_lt_rowLen.mpr (mem_range.mp hc))
-  rw [GTPattern.topRow_apply, toGTPattern_apply]
+  rw [TauCeti.GTPattern.topRow_apply, toGTPattern_apply]
   simp only [patternEntry_def]
   rw [ite_eq_right (lt_irrefl n), hfil, card_range]
 
@@ -353,6 +357,8 @@ theorem toGTPattern_succ_le_iff (T : SemistandardYoungTableau μ) (n : ℕ) {i c
   omega
 
 end SemistandardYoungTableau
+
+namespace TauCeti
 
 /-! ### The bijection -/
 
@@ -433,7 +439,7 @@ theorem gtPatternEquivSSYT_apply_coe (n : ℕ) (μ : YoungDiagram) (hμ : μ.col
   (rfl)
 
 /-- The inverse bijection sends a tableau to the pattern
-`TauCeti.SemistandardYoungTableau.toGTPattern` it names. -/
+`SemistandardYoungTableau.toGTPattern` it names. -/
 @[simp]
 theorem gtPatternEquivSSYT_symm_apply_coe (n : ℕ) (μ : YoungDiagram) (hμ : μ.colLen 0 ≤ n)
     (T : BoundedSSYT n μ) :

--- a/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Basic.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Basic.lean
@@ -23,7 +23,7 @@ definition alone gives, and transports it to the partition-indexed Schur polynom
 The tableaux summed over are the bounded ones, `TauCeti.BoundedSSYT`: Mathlib's
 `SemistandardYoungTableau μ` fills cells with arbitrary natural numbers, and it is the bound that
 makes the sum finite. The alphabet is `0, 1, …, N - 1` rather than the classical `1, …, N`,
-matching `TauCeti.SemistandardYoungTableau.content`.
+matching `SemistandardYoungTableau.content`.
 
 The load-bearing statement is `TauCeti.coeff_diagramSchurPoly`: the coefficient of a monomial
 `x^d` in `s_μ` is the image in the coefficient semiring of the Kostka number `K_{μ d}`, the number


### PR DESCRIPTION
This PR moves the declarations extending Mathlib's `SemistandardYoungTableau` out of the enclosing `namespace TauCeti`, so that `T.entry_le_of_le` and the rest elaborate as dot notation.

`SemistandardYoungTableau` is Mathlib's, from `Mathlib/Combinatorics/Young/SemistandardTableau.lean`. This is the follow-up promised in the api-design thread on #3096, which correctly caught that I had left this type behind while moving `YoungDiagram`, and had wrongly described it as Tau Ceti's own.

**Stacked on #3096**, and targets that branch rather than `main`. The dependency is real rather than bookkeeping: the block in `Young/Kostka.lean` calls `sum_take_rowLens_eq_card_filter_fst` and `sum_range_rowLen_eq_card_filter_fst`, which #3096 moves from `TauCeti.YoungDiagram` to `YoungDiagram`. Based on `main` instead, those calls would need qualifying with `TauCeti.` and then unqualifying again the moment #3096 landed.

Three blocks move, and the third is why this was not folded into #3096. `GelfandTsetlin/Tableau.lean` needed two things beyond the namespace change: its `#{c ∈ range ...}` `Finset.card` notation depends on an `open Finset` that lived inside the enclosing `TauCeti` namespace, so that is hoisted to file scope; and the block's proofs call `GTPattern.topRow_apply` and `lt_card_filter_range_iff`, both of which stay in `TauCeti` and are now referenced by their full names. The shared `variable {n : ℕ} {μ : YoungDiagram}` binder is restated inside the moved block for the same reason.

No declaration is renamed and no proof changes.

Roadmap: none

🤖 Prepared with Claude Code