### PR TITLE
refactor(ScalarExtension): name the base-change extensionality principles

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Monoidal.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Monoidal.lean
@@ -62,6 +62,48 @@ private theorem scalarExtension_associativity_tmul
               ((TensorProduct.assoc R M N P).toLinearMap.baseChange A)
                 ((1 : A) ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p)))) := rfl
 
+/-- Two maps out of a base-changed module agree as soon as they agree on the pure tensors
+`1 ⊗ₜ m`. -/
+private theorem baseChange_hom_ext {M : Type u} [AddCommMonoid M] [Module R M]
+    {N : SemimoduleCat.{u} A} {f g : SemimoduleCat.of A (A ⊗[R] M) ⟶ N}
+    (h : ∀ m, f (1 ⊗ₜ[R] m) = g (1 ⊗ₜ[R] m)) : f = g := by
+  let _ : Module R N := Module.compHom N (algebraMap R A)
+  let _ : IsScalarTower R A N := IsScalarTower.of_algebraMap_smul fun _ _ ↦ rfl
+  apply SemimoduleCat.hom_ext
+  apply (LinearMap.liftBaseChangeEquiv A).symm.injective
+  apply LinearMap.ext
+  intro m
+  simpa using h m
+
+/-- Two maps out of a base-changed tensor product agree as soon as they agree on the pure
+tensors `1 ⊗ₜ (m ⊗ₜ n)`. -/
+private theorem baseChange_tensor_hom_ext {M N : SemimoduleCat.{u} R} {P : SemimoduleCat.{u} A}
+    {f g : SemimoduleCat.of A (A ⊗[R] (M ⊗[R] N)) ⟶ P}
+    (h : ∀ m n, f (1 ⊗ₜ[R] (m ⊗ₜ[R] n)) = g (1 ⊗ₜ[R] (m ⊗ₜ[R] n))) : f = g := by
+  refine baseChange_hom_ext R A fun x ↦ ?_
+  induction x with
+  | zero => simp
+  | tmul m n => exact h m n
+  | add x y hx hy => rw [TensorProduct.tmul_add, map_add, map_add, hx, hy]
+
+/-- Two maps out of a base-changed triple tensor product agree as soon as they agree on the pure
+tensors `1 ⊗ₜ ((m ⊗ₜ n) ⊗ₜ p)`. -/
+private theorem baseChange_tensor₃_hom_ext {M N P : SemimoduleCat.{u} R}
+    {Q : SemimoduleCat.{u} A}
+    {f g : SemimoduleCat.of A (A ⊗[R] ((M ⊗[R] N) ⊗[R] P)) ⟶ Q}
+    (h : ∀ m n p, f (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p)) =
+      g (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p))) : f = g := by
+  refine baseChange_hom_ext R A fun x ↦ ?_
+  induction x with
+  | zero => simp
+  | tmul y p =>
+    induction y with
+    | zero => simp
+    | tmul m n => exact h m n p
+    | add u v hu hv =>
+      rw [TensorProduct.add_tmul, TensorProduct.tmul_add, map_add, map_add, hu, hv]
+  | add x y hx hy => rw [TensorProduct.tmul_add, map_add, map_add, hx, hy]
+
 /-- Scalar extension from finitely generated comodules to semimodules is strong monoidal. -/
 noncomputable instance instMonoidalScalarExtensionFunctor :
     (scalarExtensionFunctor.{u, v, u, u} R H A).Monoidal := by
@@ -71,51 +113,17 @@ noncomputable instance instMonoidalScalarExtensionFunctor :
       map_id := fun _ ↦ SemimoduleCat.hom_ext LinearMap.baseChange_id
       map_comp := fun f g ↦
         SemimoduleCat.hom_ext (LinearMap.baseChange_comp f.hom.toLinearMap g.hom.toLinearMap) }
-  let baseChangeExt
-      {M : Type u} [AddCommMonoid M] [Module R M] {N : SemimoduleCat.{u} A}
-      {f g : SemimoduleCat.of A (A ⊗[R] M) ⟶ N}
-      (h : ∀ m, f (1 ⊗ₜ[R] m) = g (1 ⊗ₜ[R] m)) : f = g := by
-    let _ : Module R N := Module.compHom N (algebraMap R A)
-    let _ : IsScalarTower R A N := IsScalarTower.of_algebraMap_smul fun _ _ ↦ rfl
-    apply SemimoduleCat.hom_ext
-    apply (LinearMap.liftBaseChangeEquiv A).symm.injective
-    apply LinearMap.ext
-    intro m
-    simpa using h m
-  let baseChangeTensorExt
-      {M N : SemimoduleCat.{u} R} {P : SemimoduleCat.{u} A}
-      {f g : SemimoduleCat.of A (A ⊗[R] (M ⊗[R] N)) ⟶ P}
-      (h : ∀ m n, f (1 ⊗ₜ[R] (m ⊗ₜ[R] n)) = g (1 ⊗ₜ[R] (m ⊗ₜ[R] n))) : f = g := by
-    let _ : Module R P := Module.compHom P (algebraMap R A)
-    let _ : IsScalarTower R A P := IsScalarTower.of_algebraMap_smul fun _ _ ↦ rfl
-    apply SemimoduleCat.hom_ext
-    apply (LinearMap.liftBaseChangeEquiv A).symm.injective
-    apply TensorProduct.ext
-    ext m n
-    simpa only [LinearMap.compr₂ₛₗ_apply, TensorProduct.mk_apply,
-      LinearMap.liftBaseChangeEquiv_symm_apply] using h m n
-  let baseChangeTensorExt₃'
-      {M N P : SemimoduleCat.{u} R} {Q : SemimoduleCat.{u} A}
-      {f g : SemimoduleCat.of A (A ⊗[R] ((M ⊗[R] N) ⊗[R] P)) ⟶ Q}
-      (h : ∀ m n p, f (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p)) =
-        g (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p))) : f = g := by
-    let _ : Module R Q := Module.compHom Q (algebraMap R A)
-    let _ : IsScalarTower R A Q := IsScalarTower.of_algebraMap_smul fun _ _ ↦ rfl
-    apply SemimoduleCat.hom_ext
-    apply (LinearMap.liftBaseChangeEquiv A).symm.injective
-    exact TensorProduct.ext_threefold fun m n p ↦ by
-      simpa only [LinearMap.liftBaseChangeEquiv_symm_apply] using h m n p
   let modelMonoidal : model.Monoidal := Functor.CoreMonoidal.toMonoidal
     (.mk'
       (εIso := (TensorProduct.AlgebraTensorModule.rid R A A).symm.toModuleIsoₛ)
       (μIso := fun M N ↦
         (TensorProduct.AlgebraTensorModule.distribBaseChange R A M N).symm.toModuleIsoₛ)
       (μIso_inv_natural_left := fun {M M'} f N ↦ by
-        apply baseChangeTensorExt
+        apply baseChange_tensor_hom_ext
         intro m n
         rfl)
       (μIso_inv_natural_right := fun {N N'} M f ↦ by
-        apply baseChangeTensorExt
+        apply baseChange_tensor_hom_ext
         intro m n
         rfl)
       (oplax_associativity := fun M N P ↦ by
@@ -135,14 +143,14 @@ noncomputable instance instMonoidalScalarExtensionFunctor :
                   (TensorProduct.AlgebraTensorModule.distribBaseChange R A M (N ⊗ P)).toLinearMap ≫
                 (SemimoduleCat.of A (A ⊗[R] M) ◁ SemimoduleCat.ofHom
                   (TensorProduct.AlgebraTensorModule.distribBaseChange R A N P).toLinearMap)
-        apply baseChangeTensorExt₃'
+        apply baseChange_tensor₃_hom_ext
         intro m n p
         erw [SemimoduleCat.comp_apply, SemimoduleCat.comp_apply,
           SemimoduleCat.comp_apply, SemimoduleCat.comp_apply]
         rw [FGComoduleCat.associator_hom_toLinearMap]
         exact scalarExtension_associativity_tmul R H A M N P m n p)
       (oplax_left_unitality := fun M ↦ by
-        apply baseChangeExt
+        apply baseChange_hom_ext
         intro m
         rw [SemimoduleCat.MonoidalCategory.leftUnitor_inv_apply,
           SemimoduleCat.comp_apply, SemimoduleCat.comp_apply,
@@ -153,7 +161,7 @@ noncomputable instance instMonoidalScalarExtensionFunctor :
           TensorProduct.AlgebraTensorModule.rid_tmul]
         rw [one_smul])
       (oplax_right_unitality := fun M ↦ by
-        apply baseChangeExt
+        apply baseChange_hom_ext
         intro m
         rw [SemimoduleCat.MonoidalCategory.rightUnitor_inv_apply,
           SemimoduleCat.comp_apply, SemimoduleCat.comp_apply,

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Monoidal.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Monoidal.lean
@@ -80,11 +80,14 @@ tensors `1 ⊗ₜ (m ⊗ₜ n)`. -/
 private theorem baseChange_tensor_hom_ext {M N : SemimoduleCat.{u} R} {P : SemimoduleCat.{u} A}
     {f g : SemimoduleCat.of A (A ⊗[R] (M ⊗[R] N)) ⟶ P}
     (h : ∀ m n, f (1 ⊗ₜ[R] (m ⊗ₜ[R] n)) = g (1 ⊗ₜ[R] (m ⊗ₜ[R] n))) : f = g := by
-  refine baseChange_hom_ext R A fun x ↦ ?_
-  induction x with
-  | zero => simp
-  | tmul m n => exact h m n
-  | add x y hx hy => rw [TensorProduct.tmul_add, map_add, map_add, hx, hy]
+  let _ : Module R P := Module.compHom P (algebraMap R A)
+  let _ : IsScalarTower R A P := IsScalarTower.of_algebraMap_smul fun _ _ ↦ rfl
+  apply SemimoduleCat.hom_ext
+  apply (LinearMap.liftBaseChangeEquiv A).symm.injective
+  apply TensorProduct.ext
+  ext m n
+  simpa only [LinearMap.compr₂ₛₗ_apply, TensorProduct.mk_apply,
+    LinearMap.liftBaseChangeEquiv_symm_apply] using h m n
 
 /-- Two maps out of a base-changed triple tensor product agree as soon as they agree on the pure
 tensors `1 ⊗ₜ ((m ⊗ₜ n) ⊗ₜ p)`. -/
@@ -93,16 +96,12 @@ private theorem baseChange_tensor₃_hom_ext {M N P : SemimoduleCat.{u} R}
     {f g : SemimoduleCat.of A (A ⊗[R] ((M ⊗[R] N) ⊗[R] P)) ⟶ Q}
     (h : ∀ m n p, f (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p)) =
       g (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p))) : f = g := by
-  refine baseChange_hom_ext R A fun x ↦ ?_
-  induction x with
-  | zero => simp
-  | tmul y p =>
-    induction y with
-    | zero => simp
-    | tmul m n => exact h m n p
-    | add u v hu hv =>
-      rw [TensorProduct.add_tmul, TensorProduct.tmul_add, map_add, map_add, hu, hv]
-  | add x y hx hy => rw [TensorProduct.tmul_add, map_add, map_add, hx, hy]
+  let _ : Module R Q := Module.compHom Q (algebraMap R A)
+  let _ : IsScalarTower R A Q := IsScalarTower.of_algebraMap_smul fun _ _ ↦ rfl
+  apply SemimoduleCat.hom_ext
+  apply (LinearMap.liftBaseChangeEquiv A).symm.injective
+  exact TensorProduct.ext_threefold fun m n p ↦ by
+    simpa only [LinearMap.liftBaseChangeEquiv_symm_apply] using h m n p
 
 /-- Scalar extension from finitely generated comodules to semimodules is strong monoidal. -/
 noncomputable instance instMonoidalScalarExtensionFunctor :

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Monoidal.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Monoidal.lean
@@ -79,15 +79,12 @@ private theorem baseChange_hom_ext {M : Type u} [AddCommMonoid M] [Module R M]
 tensors `1 ⊗ₜ (m ⊗ₜ n)`. -/
 private theorem baseChange_tensor_hom_ext {M N : SemimoduleCat.{u} R} {P : SemimoduleCat.{u} A}
     {f g : SemimoduleCat.of A (A ⊗[R] (M ⊗[R] N)) ⟶ P}
-    (h : ∀ m n, f (1 ⊗ₜ[R] (m ⊗ₜ[R] n)) = g (1 ⊗ₜ[R] (m ⊗ₜ[R] n))) : f = g := by
-  let _ : Module R P := Module.compHom P (algebraMap R A)
-  let _ : IsScalarTower R A P := IsScalarTower.of_algebraMap_smul fun _ _ ↦ rfl
-  apply SemimoduleCat.hom_ext
-  apply (LinearMap.liftBaseChangeEquiv A).symm.injective
-  apply TensorProduct.ext
-  ext m n
-  simpa only [LinearMap.compr₂ₛₗ_apply, TensorProduct.mk_apply,
-    LinearMap.liftBaseChangeEquiv_symm_apply] using h m n
+    (h : ∀ m n, f (1 ⊗ₜ[R] (m ⊗ₜ[R] n)) = g (1 ⊗ₜ[R] (m ⊗ₜ[R] n))) : f = g :=
+  baseChange_hom_ext R A fun x ↦ by
+    induction x using TensorProduct.induction_on with
+    | zero => simp
+    | tmul m n => exact h m n
+    | add x y hx hy => rw [TensorProduct.tmul_add, map_add, map_add, hx, hy]
 
 /-- Two maps out of a base-changed triple tensor product agree as soon as they agree on the pure
 tensors `1 ⊗ₜ ((m ⊗ₜ n) ⊗ₜ p)`. -/
@@ -95,13 +92,17 @@ private theorem baseChange_tensor₃_hom_ext {M N P : SemimoduleCat.{u} R}
     {Q : SemimoduleCat.{u} A}
     {f g : SemimoduleCat.of A (A ⊗[R] ((M ⊗[R] N) ⊗[R] P)) ⟶ Q}
     (h : ∀ m n p, f (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p)) =
-      g (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p))) : f = g := by
-  let _ : Module R Q := Module.compHom Q (algebraMap R A)
-  let _ : IsScalarTower R A Q := IsScalarTower.of_algebraMap_smul fun _ _ ↦ rfl
-  apply SemimoduleCat.hom_ext
-  apply (LinearMap.liftBaseChangeEquiv A).symm.injective
-  exact TensorProduct.ext_threefold fun m n p ↦ by
-    simpa only [LinearMap.liftBaseChangeEquiv_symm_apply] using h m n p
+      g (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p))) : f = g :=
+  baseChange_hom_ext R A fun x ↦ by
+    induction x using TensorProduct.induction_on with
+    | zero => simp
+    | tmul y p =>
+      induction y using TensorProduct.induction_on with
+      | zero => simp
+      | tmul m n => exact h m n p
+      | add u v hu hv =>
+        rw [TensorProduct.add_tmul, TensorProduct.tmul_add, map_add, map_add, hu, hv]
+    | add x y hx hy => rw [TensorProduct.tmul_add, map_add, map_add, hx, hy]
 
 /-- Scalar extension from finitely generated comodules to semimodules is strong monoidal. -/
 noncomputable instance instMonoidalScalarExtensionFunctor :

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Monoidal.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Monoidal.lean
@@ -79,12 +79,15 @@ private theorem baseChange_hom_ext {M : Type u} [AddCommMonoid M] [Module R M]
 tensors `1 ⊗ₜ (m ⊗ₜ n)`. -/
 private theorem baseChange_tensor_hom_ext {M N : SemimoduleCat.{u} R} {P : SemimoduleCat.{u} A}
     {f g : SemimoduleCat.of A (A ⊗[R] (M ⊗[R] N)) ⟶ P}
-    (h : ∀ m n, f (1 ⊗ₜ[R] (m ⊗ₜ[R] n)) = g (1 ⊗ₜ[R] (m ⊗ₜ[R] n))) : f = g :=
-  baseChange_hom_ext R A fun x ↦ by
-    induction x using TensorProduct.induction_on with
-    | zero => simp
-    | tmul m n => exact h m n
-    | add x y hx hy => rw [TensorProduct.tmul_add, map_add, map_add, hx, hy]
+    (h : ∀ m n, f (1 ⊗ₜ[R] (m ⊗ₜ[R] n)) = g (1 ⊗ₜ[R] (m ⊗ₜ[R] n))) : f = g := by
+  let _ : Module R P := Module.compHom P (algebraMap R A)
+  let _ : IsScalarTower R A P := IsScalarTower.of_algebraMap_smul fun _ _ ↦ rfl
+  apply SemimoduleCat.hom_ext
+  apply (LinearMap.liftBaseChangeEquiv A).symm.injective
+  apply TensorProduct.ext
+  ext m n
+  simpa only [LinearMap.compr₂ₛₗ_apply, TensorProduct.mk_apply,
+    LinearMap.liftBaseChangeEquiv_symm_apply] using h m n
 
 /-- Two maps out of a base-changed triple tensor product agree as soon as they agree on the pure
 tensors `1 ⊗ₜ ((m ⊗ₜ n) ⊗ₜ p)`. -/
@@ -92,17 +95,13 @@ private theorem baseChange_tensor₃_hom_ext {M N P : SemimoduleCat.{u} R}
     {Q : SemimoduleCat.{u} A}
     {f g : SemimoduleCat.of A (A ⊗[R] ((M ⊗[R] N) ⊗[R] P)) ⟶ Q}
     (h : ∀ m n p, f (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p)) =
-      g (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p))) : f = g :=
-  baseChange_hom_ext R A fun x ↦ by
-    induction x using TensorProduct.induction_on with
-    | zero => simp
-    | tmul y p =>
-      induction y using TensorProduct.induction_on with
-      | zero => simp
-      | tmul m n => exact h m n p
-      | add u v hu hv =>
-        rw [TensorProduct.add_tmul, TensorProduct.tmul_add, map_add, map_add, hu, hv]
-    | add x y hx hy => rw [TensorProduct.tmul_add, map_add, map_add, hx, hy]
+      g (1 ⊗ₜ[R] ((m ⊗ₜ[R] n) ⊗ₜ[R] p))) : f = g := by
+  let _ : Module R Q := Module.compHom Q (algebraMap R A)
+  let _ : IsScalarTower R A Q := IsScalarTower.of_algebraMap_smul fun _ _ ↦ rfl
+  apply SemimoduleCat.hom_ext
+  apply (LinearMap.liftBaseChangeEquiv A).symm.injective
+  exact TensorProduct.ext_threefold fun m n p ↦ by
+    simpa only [LinearMap.liftBaseChangeEquiv_symm_apply] using h m n p
 
 /-- Scalar extension from finitely generated comodules to semimodules is strong monoidal. -/
 noncomputable instance instMonoidalScalarExtensionFunctor :


### PR DESCRIPTION
`instMonoidalScalarExtensionFunctor` needed to prove maps out of a base-changed module equal by
checking them on pure tensors, at three arities: `1 ⊗ₜ m`, `1 ⊗ₜ (m ⊗ₜ n)` and
`1 ⊗ₜ ((m ⊗ₜ n) ⊗ₜ p)`. It carried one `let`-bound helper for each, inside the instance body, so
three extensionality principles were stated and proved as construction scaffolding rather than as
facts.

They are now three private lemmas above the instance, with the arity in the name and the pure
tensors they test in the docstring. Each keeps its original proof, so the binary case still goes
through `TensorProduct.ext` and the ternary through `TensorProduct.ext_threefold`.

`instMonoidalScalarExtensionFunctor` drops from 106 lines to 72; the three lemmas are 7, 8 and 6
lines. The file grows by seven lines, the cost of three signatures.

The instance's other two `let`s stay: `model` and `modelMonoidal` are the construction being
transported, not proof scaffolding, and no lemma statement mentions them.

I also tried deriving the two tensor lemmas from the plain one, to write their shared four-line
opening once instead of three times. `reuse` was right to reject that: the derivation replaced
`TensorProduct.ext` and `ext_threefold` with hand-rolled inductions, trading Mathlib API for
repetition of four lines. The opening stays repeated.

Note on scope: at 106 lines this proof was above the 40–50 band I normally target. I raised that
with Chris this tick — the 40–50 band is exhausted, while 56 proofs exceed 50 lines — and the
answer was to widen upward, worst-first. This is the first of those.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all green.

Roadmap: ReductiveGroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
