### PR TITLE
docs(ModularForms): cite the right Shimura proposition for the double-coset action

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
@@ -22,9 +22,10 @@ answer: replacing `σᵢ` by `hσᵢ` for `h ∈ SL₂(ℤ)` multiplies the repr
 slash by `hᵀ` is trivial on that function. Even the identity double coset can therefore send a
 raw `f` to `f ∣[k] h` rather than to `f`.
 
-What repairs it is slash-invariance of `f`, and that is Shimura's Proposition 3.30: for `f`
-invariant under `SL₂(ℤ)` the sum is again invariant, and right multiplication merely permutes
-the representatives. That theorem, and the descent of this sum to a genuine operator on
+What repairs it is slash-invariance of `f`, and that is the proof of Shimura's Proposition
+3.37: for `f` invariant under `SL₂(ℤ)` the sum is again invariant, because right multiplication
+merely permutes the representatives. That theorem, and the descent of this sum to a genuine
+operator on
 `SlashInvariantForm` and `ModularForm`, are deliberately **not** in this file — the reindexing
 argument is substantial and is a different claim. Until then this is an auxiliary sum, named to
 say so, and every consumer must supply the invariance hypothesis itself.
@@ -39,7 +40,11 @@ that is, the `Xᵢ` must represent **right** cosets `HXᵢ`.
 
 Transposition exchanges the two: if `HδH = ⊔ᵢ (σᵢδ)H` then `HδH = ⊔ᵢ H(δᵀσᵢᵀ)`, because
 transposition is an anti-automorphism preserving `SL₂(ℤ)` and fixing every double coset. So the
-representative used here is `(σᵢδ)ᵀ`, which is `transposeRep`. This is Shimura's Prop 3.30.
+representative used here is `(σᵢδ)ᵀ`, which is `transposeRep`.
+
+The transpose is an artefact of which handedness Mathlib's `DecompQuotient` supplies, not of the
+mathematics. Shimura decomposes `Γ₁αΓ₂ = ⊔ᵥ Γ₁aᵥ` — the group on the **left** — so his slash,
+being a right action, permutes those representatives directly and no transpose ever appears.
 
 ⚠ Conventions: `gH` is a left coset and `Hg` a right one, as in Mathlib and in
 `LeftCosetModule/Basic.lean`. AINTLIB's `HeckeAction.lean` uses the opposite labels for the
@@ -81,7 +86,9 @@ against TauCeti's `SLnZ`/`posDetInt` Hecke pair and `transposeGLEquiv` rather th
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
-  §3.4, Proposition 3.30.
+  §3.4 *Action of double cosets on automorphic forms*: equation (3.4.1) defines the operator
+  `f ∣[Γ₁ α Γ₂]ₖ` as the sum below, and Proposition 3.37 is the statement that it maps
+  automorphic forms to automorphic forms — the invariance this file stops short of.
 -/
 
 public section
@@ -127,7 +134,7 @@ lemma det_transposeRep_pos (i : DecompQuotient (SLnZ 2) (SLnZ 2) (D.out : GL (Fi
 
 /-- **The slash sum over a chosen decomposition of a double coset**:
 `∑ᵢ f ∣[k] (σᵢ δ)ᵀ`, over the transposed representatives of the left-coset decomposition of
-`HδH` (Shimura Prop 3.30).
+`HδH` (Shimura's `f ∣[Γ₁ α Γ₂]ₖ`, §3.4 (3.4.1), up to the `det` normalising factor).
 
 ⚠ This depends on the chosen representatives `D.out` and `i.out`, and on a general
 `f : ℍ → ℂ` the value changes with them — see the module docstring. Slash-invariance of `f` is
@@ -139,7 +146,7 @@ noncomputable def heckeSlashSum (f : ℍ → ℂ) : ℍ → ℂ :=
   ∑ i : DecompQuotient (SLnZ 2) (SLnZ 2) (D.out : GL (Fin 2) ℚ), f ∣[k] transposeRep D i
 
 /-- The pointwise value of the slash sum: the sum of the slashed values. This is the equation
-the reindexing proof of Prop 3.30 works from. -/
+the reindexing proof of Prop 3.37 works from. -/
 lemma heckeSlashSum_apply (f : ℍ → ℂ) (τ : ℍ) : heckeSlashSum k D f τ =
     ∑ i : DecompQuotient (SLnZ 2) (SLnZ 2) (D.out : GL (Fin 2) ℚ), (f ∣[k] transposeRep D i) τ :=
   Finset.sum_apply ..

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Reindex.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Reindex.lean
@@ -11,9 +11,9 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Basic
 # Reindexing the slash sum: slashing by any element of a left coset
 
 `heckeSlashSum` sums `f ∣[k] (σᵢ δ)ᵀ` over the left-coset decomposition of `HδH`. To show that
-sum is unchanged by right multiplication — the statement that turns the sum into an operator —
-one needs to know that the summand depends only on the *coset* of `σᵢ`, not on the
-representative chosen, once `f` is slash-invariant.
+sum is unchanged by right multiplication — the statement that turns the sum into an operator,
+and the proof of Shimura's Proposition 3.37 — one needs to know that the summand depends only on
+the *coset* of `σᵢ`, not on the representative chosen, once `f` is slash-invariant.
 
 That is what this file proves. For `h₁, h₂ ∈ H`,
 
@@ -58,12 +58,13 @@ is used only by the invariance block that follows the ported range.
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
-  §3.4.
+  §3.4 *Action of double cosets on automorphic forms*, Proposition 3.37.
 
-This file cites the section rather than a numbered proposition on purpose. The sibling
-`HeckeSlash/Basic.lean` attributes this material to Proposition 3.30; that number has been
-questioned more than once and nobody working on these files has had the book to hand, so it is
-not asserted here. The mathematics is unaffected either way.
+Shimura states the result this file supports inside the proof of Proposition 3.37: "Let `α ∈ Γ₂`.
+Then `{Γ₁ aᵥ α}` coincides with `{Γ₁ aᵥ}` as a whole", from which `g ∣[α]ₖ = g` for
+`g = f ∣[Γ₁ α Γ₂]ₖ`. He needs no transpose, because his decomposition `Γ₁ α Γ₂ = ⊔ᵥ Γ₁ aᵥ` puts
+the group on the left already; the transpose here is an artefact of the handedness Mathlib's
+`DecompQuotient` supplies, not of the mathematics.
 -/
 
 public section
@@ -111,7 +112,7 @@ representative of its own class the absorbed factor is exactly `h₂ᵀ`, so qua
 already reaches every element of `SLnZ 2`. Note also that `hf` is invariance under the *rational*
 slash action, not one routed through the real `𝒮ℒ`.
 
-This is the per-summand step behind Shimura's double-coset Hecke operator (§3.4). The statement
+This is the per-summand step behind Shimura's Proposition 3.37 (§3.4). The statement
 that right multiplication permutes the summands of `heckeSlashSum` without changing the sum is a
 separate argument, which is not formalised here. Mathlib's `SlashInvariantForm.quotientFunc_mk`
 is the single-subgroup analogue, with no double coset and no transpose. -/


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke/shimura-citation"}-->

Documentation only — no Lean declaration, statement or proof is touched.

## The defect

`ModularForms/HeckeSlash/Basic.lean` attributes the double-coset slash sum to **Shimura's
Proposition 3.30**, in five places including its `## References` entry. That is the wrong
proposition.

Checked against the book (Shimura, *Introduction to the Arithmetic Theory of Automorphic
Functions*, Publications of the Mathematical Society of Japan 11, 1971):

> **PROPOSITION 3.30.** *Let the notation be as above. Then the correspondence `Γ'αΓ' ↦ ΓαΓ`,
> with `α ∈ Δ`, defines a homomorphism of `R(Γ', Δ')` into `R(Γ, Δ)`.*  — p. 67, §3.3

That is a statement about Hecke **rings**. It says nothing about automorphic forms, the slash
action, or coset representatives.

## What the correct reference is

§3.4 is titled *"Action of double cosets on automorphic forms"*, and contains exactly this
material:

* **(3.4.1)** defines the operator, `f ∣[Γ₁ α Γ₂]ₖ = det(α)^{k/2−1} · Σᵥ f ∣[aᵥ]ₖ` where
  `Γ₁ α Γ₂ = ⊔ᵥ Γ₁ aᵥ`, followed by the remark *"It is clear that `f ∣[Γ₁αΓ₂]ₖ` is independent of
  the choice of the representatives `aᵥ`."* That is `heckeSlashSum`, up to the normalising factor.
* **Proposition 3.37** states that `[Γ₁ α Γ₂]ₖ` sends `A_k(Γ₁), G_k(Γ₁), S_k(Γ₁)` into
  `A_k(Γ₂), G_k(Γ₂), S_k(Γ₂)`. Its **proof** is the permutation argument these two files exist to
  support: *"Let `α ∈ Γ₂`. Then `{Γ₁ aᵥ α}` coincides with `{Γ₁ aᵥ}` as a whole."*

So the citation moves from 3.30 to §3.4 (3.4.1) and Proposition 3.37.

## A second thing the book settles

Shimura decomposes `Γ₁ α Γ₂ = ⊔ᵥ Γ₁ aᵥ` — the group on the **left** — so his slash, being a right
action, permutes those representatives directly and **no transpose ever appears** in his proof.
The transpose in this development is therefore an artefact of which handedness Mathlib's
`DoubleCoset.DecompQuotient` supplies, not of the mathematics. Both module docstrings now say so;
previously a reader could reasonably have inferred that Shimura's argument needed it.

`Reindex.lean` had deliberately declined to name a proposition at all, recording that nobody
working on the files had the book to hand. That note is now obsolete and is replaced by the
verified citation.

## Not changed

`NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean` also cites Propositions 3.30 and 3.31 — and is
**correct**: it cites them for sending `Γ₀(N) α Γ₀(N)` to `SL₂(ℤ) α SL₂(ℤ)`, which is precisely
the homomorphism 3.30 states (3.31 being the isomorphism refinement). Left untouched.

Roadmap: ModularForms
