### PR TITLE
refactor(HeckeRing): promote conj_mem_of_mk_eq and stop re-deriving QuotientGroup.eq

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -133,13 +133,8 @@ theorem multiplicity_mul_left {γ : G} (hγ : γ ∈ Γ₁) (g h d : G)
   have h1 : QuotientGroup.mk (γ'⁻¹ * i.out) = γ'⁻¹ • i := by
     rw [← smul_eq_mul]
     exact MulAction.Quotient.mk_smul_out _ γ'⁻¹ i
-  have hk : (γ'⁻¹ * i.out)⁻¹ * (γ'⁻¹ • i).out ∈
-      (ConjAct.toConjAct g • Γ₂).subgroupOf Γ₁ :=
-    QuotientGroup.eq.mp (h1.trans (QuotientGroup.out_eq' _).symm)
-  have hβ : g⁻¹ * ((((γ'⁻¹ * i.out)⁻¹ * (γ'⁻¹ • i).out : Γ₁) : G)) * g ∈ Γ₂ := by
-    have hmem := Subgroup.mem_subgroupOf.mp hk
-    rwa [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv,
-      ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv] at hmem
+  have hβ : g⁻¹ * ((((γ'⁻¹ * i.out)⁻¹ * (γ'⁻¹ • i).out : Γ₁) : G)) * g ∈ Γ₂ :=
+    conj_mem_of_mk_eq g (h1.trans (QuotientGroup.out_eq' _).symm)
   have hy : ((γ'⁻¹ • i).out : G) =
       γ⁻¹ * (i.out : G) * (((γ'⁻¹ * i.out)⁻¹ * (γ'⁻¹ • i).out : Γ₁) : G) := by
     -- `γ' = ⟨γ, hγ⟩` by the `set` above, so the two sides of the `show` are definitionally

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -185,24 +185,27 @@ lemma mk_out_mul_injective (Γ₁ Γ₂ : Subgroup G) (g : G) :
 open scoped Pointwise in
 /-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`: an
 element of the stabilizer conjugates into `H` under `g`. -/
-lemma conj_mem_of_stabilizer {H : Subgroup G} (g : G)
-    (n : (ConjAct.toConjAct g • H).subgroupOf H) : g⁻¹ * (n : G) * g ∈ H := by
+lemma conj_mem_of_stabilizer {H₁ H₂ : Subgroup G} (g : G)
+    (n : (ConjAct.toConjAct g • H₂).subgroupOf H₁) : g⁻¹ * (n : G) * g ∈ H₂ := by
   have hn := n.2
   rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
     ConjAct.smul_def] at hn
   simpa [ConjAct.ofConjAct_toConjAct] using hn
 
-/-- Equality of classes in `DecompQuotient H H g` gives the conjugation relation between their
+/-- Equality of classes in `DecompQuotient H₁ H₂ g` gives the conjugation relation between their
 representatives: `u₁⁻¹ u₂` lies in the stabilizer indexing the decomposition, so conjugating it
-by `g` lands back in `H`.
+by `g` lands in `H₂`.
+
+Note the two subgroups play different roles: the representatives live in `H₁`, which indexes the
+quotient, while the conclusion lands in `H₂`, which is the one being conjugated. They coincide in
+the common case `DecompQuotient H H g`.
 
 This is the form to reach for when a class equality `⟦u₁⟧ = ⟦u₂⟧` has to be turned into a
-membership. `QuotientGroup.eq` supplies the stabilizer membership and
-`conj_mem_of_stabilizer` does the conjugation; unfolding `QuotientGroup.leftRel` by hand
-duplicates both. -/
-lemma conj_mem_of_mk_eq {H : Subgroup G} (g : G) {u₁ u₂ : H}
-    (h : (QuotientGroup.mk u₁ : DecompQuotient H H g) = QuotientGroup.mk u₂) :
-    g⁻¹ * ((u₁ : G)⁻¹ * u₂) * g ∈ H :=
+membership. `QuotientGroup.eq` supplies the stabilizer membership and `conj_mem_of_stabilizer`
+does the conjugation; unfolding `QuotientGroup.leftRel` by hand duplicates both. -/
+lemma conj_mem_of_mk_eq {H₁ H₂ : Subgroup G} (g : G) {u₁ u₂ : H₁}
+    (h : (QuotientGroup.mk u₁ : DecompQuotient H₁ H₂ g) = QuotientGroup.mk u₂) :
+    g⁻¹ * ((u₁ : G)⁻¹ * u₂) * g ∈ H₂ :=
   conj_mem_of_stabilizer g ⟨_, QuotientGroup.eq.mp h⟩
 
 end DoubleCoset

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -183,8 +183,8 @@ lemma mk_out_mul_injective (Γ₁ Γ₂ : Subgroup G) (g : G) :
   simpa [mul_assoc] using hij
 
 open scoped Pointwise in
-/-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`: an
-element of the stabilizer conjugates into `H` under `g`. -/
+/-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`: an element
+of `(ConjAct.toConjAct g • H₂).subgroupOf H₁` conjugates by `g` into `H₂`. -/
 lemma conj_mem_of_stabilizer {H₁ H₂ : Subgroup G} (g : G)
     (n : (ConjAct.toConjAct g • H₂).subgroupOf H₁) : g⁻¹ * (n : G) * g ∈ H₂ := by
   have hn := n.2
@@ -198,11 +198,10 @@ by `g` lands in `H₂`.
 
 Note the two subgroups play different roles: the representatives live in `H₁`, which indexes the
 quotient, while the conclusion lands in `H₂`, which is the one being conjugated. They coincide in
-the common case `DecompQuotient H H g`.
-
-This is the form to reach for when a class equality `⟦u₁⟧ = ⟦u₂⟧` has to be turned into a
-membership. `QuotientGroup.eq` supplies the stabilizer membership and `conj_mem_of_stabilizer`
-does the conjugation; unfolding `QuotientGroup.leftRel` by hand duplicates both. -/
+the common case `DecompQuotient H H g`. -/
+-- Reach for this whenever a class equality `⟦u₁⟧ = ⟦u₂⟧` has to become a membership:
+-- `QuotientGroup.eq` supplies the stabilizer membership and `conj_mem_of_stabilizer` does the
+-- conjugation, so unfolding `QuotientGroup.leftRel` by hand duplicates both.
 lemma conj_mem_of_mk_eq {H₁ H₂ : Subgroup G} (g : G) {u₁ u₂ : H₁}
     (h : (QuotientGroup.mk u₁ : DecompQuotient H₁ H₂ g) = QuotientGroup.mk u₂) :
     g⁻¹ * ((u₁ : G)⁻¹ * u₂) * g ∈ H₂ :=

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -192,6 +192,19 @@ lemma conj_mem_of_stabilizer {H : Subgroup G} (g : G)
     ConjAct.smul_def] at hn
   simpa [ConjAct.ofConjAct_toConjAct] using hn
 
+/-- Equality of classes in `DecompQuotient H H g` gives the conjugation relation between their
+representatives: `u₁⁻¹ u₂` lies in the stabilizer indexing the decomposition, so conjugating it
+by `g` lands back in `H`.
+
+This is the form to reach for when a class equality `⟦u₁⟧ = ⟦u₂⟧` has to be turned into a
+membership. `QuotientGroup.eq` supplies the stabilizer membership and
+`conj_mem_of_stabilizer` does the conjugation; unfolding `QuotientGroup.leftRel` by hand
+duplicates both. -/
+lemma conj_mem_of_mk_eq {H : Subgroup G} (g : G) {u₁ u₂ : H}
+    (h : (QuotientGroup.mk u₁ : DecompQuotient H H g) = QuotientGroup.mk u₂) :
+    g⁻¹ * ((u₁ : G)⁻¹ * u₂) * g ∈ H :=
+  conj_mem_of_stabilizer g ⟨_, QuotientGroup.eq.mp h⟩
+
 end DoubleCoset
 
 namespace IsHeckeTriple

--- a/TauCeti/NumberTheory/HeckeRing/Commutativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Commutativity.lean
@@ -187,16 +187,6 @@ private lemma exists_bar_eq [IsHeckeTriple Δ H H]
   rw [doubleCoset_eq_of_mem (ι.bar_mem_doubleCoset_self h_fix g)] at hbar
   exact mem_doubleCoset.mp hbar
 
-/-- Equality of classes in `DecompQuotient H H g` yields the conjugation relation of their
-representatives. -/
-private lemma conj_mem_of_mk_eq (g : G) {u₁ u₂ : H}
-    (h : (QuotientGroup.mk u₁ : DecompQuotient H H g) = QuotientGroup.mk u₂) :
-    g⁻¹ * ((u₁ : G)⁻¹ * u₂) * g ∈ H := by
-  have hk := QuotientGroup.eq.mp h
-  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
-    ← ConjAct.toConjAct_inv, ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv] at hk
-  simpa [mul_assoc] using hk
-
 /-- Membership in the one-sided count set is invariant under replacing a representative of
 a class in `DecompQuotient H H g₂` by the canonical `out`. -/
 private lemma out_mul_inv_mul_mem {g₁ g₂ d : G} {u : G} (hu : u ∈ H)

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Reindex.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Reindex.lean
@@ -120,9 +120,9 @@ lemma slash_transposeRep_of_mem_SLnZ {h₁ h₂ : GL (Fin 2) ℚ} (hh₁ : h₁ 
     f ∣[k] (transposeGLEquiv 2 (h₁ * ↑D.out * h₂)).unop = f ∣[k] transposeRep D ⟦⟨h₁, hh₁⟩⟧ := by
   rw [transposeGLEquiv_eq_mul_transposeRep D ⟦⟨h₁, hh₁⟩⟧ h₁ h₂]
   -- The leftover factor lies in `H`: `Quotient.out_eq` says the chosen representative of `⟦h₁⟧`
-  -- is in `h₁`'s own class, so `QuotientGroup.eq` puts `σ⁻¹ h₁` in the stabilizer indexing the
-  -- decomposition, and `conj_mem_of_stabilizer` conjugates that by `δ` back into `H`.
+  -- is in `h₁`'s own class, and `conj_mem_of_mk_eq` turns that class equality into the
+  -- conjugated membership in one step.
   exact slash_transpose_mul_of_mem_SLnZ k
-    (mul_mem (conj_mem_of_stabilizer _ ⟨_, QuotientGroup.eq.mp (Quotient.out_eq _)⟩) hh₂) _ f hf
+    (mul_mem (conj_mem_of_mk_eq _ (Quotient.out_eq _)) hh₂) _ f hf
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Reindex.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Reindex.lean
@@ -45,8 +45,8 @@ commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), 
 Restated against TauCeti's `SLnZ` / `posDetInt` Hecke pair, `DoubleCoset.DecompQuotient`,
 `transposeGLEquiv` and `transposeRep`, rather than AINTLIB's `GL_pair`, `decompQuot`,
 `GL_transposeEquiv` and `tRep`. AINTLIB's `h_coset_mem_H` is not reproduced as a declaration: this
-repository already owns its two steps, as `QuotientGroup.eq` and
-`DoubleCoset.conj_mem_of_stabilizer`, so it is inlined at its one use site.
+repository already owns exactly that statement as `DoubleCoset.conj_mem_of_mk_eq`, which is what
+the proof below calls.
 
 One deliberate deviation: the slash-invariance hypothesis is carried at `SLnZ 2` under the
 rational slash action, rather than routed through the real `𝒮ℒ`. AINTLIB's

--- a/TauCeti/NumberTheory/ModularForms/NormTrace.lean
+++ b/TauCeti/NumberTheory/ModularForms/NormTrace.lean
@@ -107,18 +107,19 @@ private lemma smul_mem_tPowCosets [DecidableEq (𝒮ℒ ⧸ (𝒢.subgroupOf �
     obtain ⟨j, -, hj⟩ := Finset.mem_image.mp hq
     -- The action lemma below produces the `QuotientGroup.mk` spelling of the coset, while the
     -- image members are spelled `⟦·⟧`; the two are definitionally but not syntactically equal,
-    -- so this bridge is proved by `Quotient.sound` rather than reached by rewriting.
+    -- so this bridge is proved rather than reached by rewriting. `QuotientGroup.eq` is the
+    -- membership criterion for that equality — its own proof is `rw [leftRel_apply]`, so
+    -- opening `Quotient.exact`/`leftRel_apply` by hand only redoes it.
     have hmk : ((t * x : 𝒮ℒ) : 𝒮ℒ ⧸ (𝒢.subgroupOf 𝒮ℒ)) =
         ⟦(mapGL ℝ).rangeRestrict ((ModularGroup.T : SL(2, ℤ))^((j : ℕ) + 1))⟧ :=
-      Quotient.sound (QuotientGroup.leftRel_apply.mpr (by
+      QuotientGroup.eq.mpr (by
         rw [pow_succ', map_mul, ← ht_def]
-        convert inv_mem (QuotientGroup.leftRel_apply.mp (Quotient.exact hj)) using 1
-        group))
+        convert inv_mem (QuotientGroup.eq.mp hj) using 1
+        group)
     rw [MulAction.Quotient.smul_mk, smul_eq_mul, Finset.mem_image, hmk]
     by_cases hj1 : (j : ℕ) + 1 < Subgroup.integerCuspWidth 𝒢
     · exact ⟨⟨(j : ℕ) + 1, hj1⟩, Finset.mem_univ _, rfl⟩
-    · refine ⟨⟨0, Subgroup.integerCuspWidth_pos⟩, Finset.mem_univ _,
-        Quotient.sound (QuotientGroup.leftRel_apply.mpr ?_)⟩
+    · refine ⟨⟨0, Subgroup.integerCuspWidth_pos⟩, Finset.mem_univ _, QuotientGroup.eq.mpr ?_⟩
       have hw : (j : ℕ) + 1 = Subgroup.integerCuspWidth 𝒢 := by lia
       rw [hw]
       simp only [pow_zero, map_one, inv_one, one_mul, Subgroup.mem_subgroupOf, map_pow]


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke/coset-dedup"}-->

Refactor of existing code — no new mathematics, no roadmap target claimed. Three files, one
declaration promoted and one proof chain deduplicated twice.

## The duplication

`DoubleCoset.conj_mem_of_stabilizer` (`HeckeRing/Basic.lean`) already turns an element of the
stabilizer indexing `DecompQuotient` into a membership `g⁻¹ n g ∈ H`. But the *class-equality*
form of the same fact — given `⟦u₁⟧ = ⟦u₂⟧` in `DecompQuotient H H g`, conclude
`g⁻¹ (u₁⁻¹ u₂) g ∈ H` — was sitting **private** in `HeckeRing/Commutativity.lean`, re-deriving
the whole chain by hand:

```lean
  have hk := QuotientGroup.eq.mp h
  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
    ← ConjAct.toConjAct_inv, ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv] at hk
  simpa [mul_assoc] using hk
```

Being `private`, it could not be reused, so the same reasoning got open-coded again downstream —
most recently in `HeckeSlash/Reindex.lean`, where it had to be written out inline.

## The change

`conj_mem_of_mk_eq` moves into the `DoubleCoset` namespace in `HeckeRing/Basic.lean`, beside
`conj_mem_of_stabilizer`, becomes public, and is reproved **as a corollary of its neighbour**
rather than from the primitives:

```lean
lemma conj_mem_of_mk_eq {H₁ H₂ : Subgroup G} (g : G) {u₁ u₂ : H₁}
    (h : (QuotientGroup.mk u₁ : DecompQuotient H₁ H₂ g) = QuotientGroup.mk u₂) :
    g⁻¹ * ((u₁ : G)⁻¹ * u₂) * g ∈ H₂ :=
  conj_mem_of_stabilizer g ⟨_, QuotientGroup.eq.mp h⟩
```

Four rewrite steps and a `simpa` become one term. `Commutativity.lean`'s call site is unchanged —
it now resolves to the public lemma.

**Stated at two subgroups** (round 1 `api-design`/`generality`): `DecompQuotient H₁ H₂ g` is
`↥H₁ ⧸ (ConjAct.toConjAct g • H₂).subgroupOf H₁`, so the representatives live in `H₁` while the
conclusion lands in `H₂`; restricting to `H₁ = H₂` would have excluded the general object the
lemma characterizes. `conj_mem_of_stabilizer` is generalized the same way so the corollary proof
survives. Every existing caller infers `H₁ = H₂` and is unchanged — verified by building
`Commutativity`, `LeftCosetModule.Basic`, `LeftCosetModule.Action` and `HeckeSlash.Reindex`.

**Third use site converted** (round 1 `reuse`): `HeckeSlash/Reindex.lean` was composing
`conj_mem_of_stabilizer _ ⟨_, QuotientGroup.eq.mp _⟩` inline — precisely what the promoted lemma
now encapsulates — and becomes `conj_mem_of_mk_eq _ (Quotient.out_eq _)`.

## Second: the `leftRel_apply` anti-pattern

`ModularForms/NormTrace.lean` reached class equality through
`Quotient.sound (QuotientGroup.leftRel_apply.mpr _)` and
`QuotientGroup.leftRel_apply.mp (Quotient.exact hj)`. `QuotientGroup.eq` **is** that criterion —
mathlib proves it by `rw [leftRel_apply]` — so unfolding the relation by hand only redoes
mathlib's own one-line proof. Three sites become `QuotientGroup.eq.mpr` / `.mp`, and the
surrounding comment now explains the criterion rather than the hand-unfolding.

## Deliberately narrow

`git grep QuotientGroup.leftRel_apply` finds nine further sites across `Algebra/Order/Group`,
`RepresentationTheory/Induction/*`, `HeckeRing/StabConjugation.lean`, `ModularForms/Cusps.lean`
and `LeftCosetModule/Basic.lean`. Those are **not** touched here: several are `rw`-ing the
relation as part of a larger `simp only` set, or are about `rightRel`, where the substitution is
not the same edit. One topic per PR; this one is the coset-membership chain the Hecke files use.

Roadmap: ModularForms
