### PR TITLE
feat(NumberTheory): the elliptic relator is sign-equivariant in its four indices

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Alternating.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Alternating.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Module.Basic
 public import Mathlib.GroupTheory.Perm.Sign
 public import Mathlib.NumberTheory.EllipticDivisibilitySequence
-public import Mathlib.Tactic.FinCases
+import Mathlib.Algebra.Module.Basic
+import Mathlib.Tactic.FinCases
 
 /-!
 # The elliptic relator is alternating in its four indices

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Alternating.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Alternating.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Module.Basic
+public import Mathlib.GroupTheory.Perm.Sign
+public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+public import Mathlib.Tactic.FinCases
+
+/-!
+# The elliptic relator is alternating in its four indices
+
+For an odd sequence `W : ℤ → R`, Mathlib's `IsEllipticNet.atomRel W a b c d` changes sign under a
+transposition of its four arguments. This file proves that for the three adjacent transpositions
+and then, by inducting over the generators of `Equiv.Perm (Fin 4)`, for an arbitrary permutation:
+`atomRelFin4` is alternating.
+
+The point is the descent that identifies elliptic sequences. Deducing the four-index relation from
+the one-index odd and even recurrences works by ordering the four indices and shrinking the largest,
+which is only available once the relation may be reordered freely — and, since three of the six
+`atomRel_same` shapes then collapse to zero, once repeated indices can be discharged.
+
+## Main definitions
+
+* `IsEllipticNet.atomRelFin4`: `atomRel` with its four indices packaged as a `Fin 4`-tuple, the
+  form an arbitrary permutation acts on.
+
+## Main results
+
+* `IsEllipticNet.atomRel_swap₁₂`, `atomRel_swap₂₃`, `atomRel_swap₃₄`: the three adjacent
+  transpositions each negate `atomRel`.
+* `IsEllipticNet.atomRelFin4_perm`: `atomRelFin4 W (t ∘ σ) = sign σ • atomRelFin4 W t` for every
+  `σ : Equiv.Perm (Fin 4)`, and `atomRelFin4_perm'` in the form that cancels the sign.
+
+## Implementation notes
+
+The three transpositions are the generators `Mathlib`'s `Equiv.Perm.mclosure_swap_castSucc_succ`
+gives for `Perm (Fin 4)`, which is what makes the induction in `atomRelFin4_perm` go through with
+exactly these three lemmas as its base cases.
+
+Each transposition rests on `IsEllipticNet.neg_atom`, `-atom W a b = atom W b a`, which is where the
+oddness of `W` enters; nothing else here needs a hypothesis on `W`.
+
+## Provenance
+
+Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₄_swap₀₁`, `rel₄_swap₁₂`,
+`rel₄_swap₂₃`, `relFin4`, `relFin4_perm` and `relFin4_perm'`. That file's header reads
+`Authors: Junyan Xu`; following this repository's convention for adapted material the upstream
+authorship is credited here rather than in the copyright header.
+
+Restated over Mathlib's names for this API: the source's `rel₄` is `IsEllipticNet.atomRel` and its
+`addMulSub` is `IsEllipticNet.atom`, and the source's standing `neg : ∀ k, W (-k) = -W k` hypothesis
+is Mathlib's `W.Odd`. The transpositions are numbered from one, as Mathlib numbers its
+`atomRel_same₁₂ … atomRel_same₃₄` family, rather than from zero as the source does.
+-/
+
+public section
+
+open Equiv
+
+namespace IsEllipticNet
+
+variable {R : Type*} [CommRing R] {W : ℤ → R}
+
+/-- Transposing the first two indices negates the relator. -/
+theorem atomRel_swap₁₂ (odd : W.Odd) (a b c d : ℤ) :
+    atomRel W a b c d = -atomRel W b a c d := by
+  simp_rw [atomRel, ← neg_atom odd a b]
+  ring
+
+/-- Transposing the middle two indices negates the relator. -/
+theorem atomRel_swap₂₃ (odd : W.Odd) (a b c d : ℤ) :
+    atomRel W a b c d = -atomRel W a c b d := by
+  simp_rw [atomRel, ← neg_atom odd b c]
+  ring
+
+/-- Transposing the last two indices negates the relator. -/
+theorem atomRel_swap₃₄ (odd : W.Odd) (a b c d : ℤ) :
+    atomRel W a b c d = -atomRel W a b d c := by
+  simp_rw [atomRel, ← neg_atom odd c d]
+  ring
+
+variable (W) in
+/-- The relator with its four indices packaged as a tuple, the form a permutation acts on. -/
+def atomRelFin4 (t : Fin 4 → ℤ) : R := atomRel W (t 0) (t 1) (t 2) (t 3)
+
+/-- The defining formula for `atomRelFin4`. The definition body is not exposed, so this equation
+lemma is how a consumer computes with it. -/
+theorem atomRelFin4_def (t : Fin 4 → ℤ) :
+    atomRelFin4 W t = atomRel W (t 0) (t 1) (t 2) (t 3) := (rfl)
+
+/-- **The relator is alternating**: permuting the four indices multiplies it by the sign of the
+permutation. -/
+theorem atomRelFin4_perm (odd : W.Odd) (σ : Perm (Fin 4)) :
+    ∀ t : Fin 4 → ℤ, atomRelFin4 W (t ∘ σ) = Perm.sign σ • atomRelFin4 W t := by
+  have hmem := (Perm.mclosure_swap_castSucc_succ 3).symm ▸ Submonoid.mem_top σ
+  refine Submonoid.closure_induction
+    (motive := fun (σ : Perm (Fin 4)) _ ↦
+      ∀ t, atomRelFin4 W (t ∘ σ) = Perm.sign σ • atomRelFin4 W t)
+    ?_ (fun t ↦ by simp) (fun σ τ _ _ hσ hτ t ↦ ?_) hmem
+  on_goal 2 => rw [Perm.coe_mul, ← Function.comp_assoc, hτ, hσ, map_mul, mul_comm, mul_smul]
+  rintro _ ⟨i, rfl⟩ t
+  fin_cases i <;> rw [Perm.sign_swap Fin.castSucc_lt_succ.ne, Units.neg_smul, one_smul]
+  exacts [atomRel_swap₁₂ odd _ _ _ _, atomRel_swap₂₃ odd _ _ _ _, atomRel_swap₃₄ odd _ _ _ _]
+
+/-- `atomRelFin4_perm` in the form that cancels the sign. -/
+theorem atomRelFin4_perm' (odd : W.Odd) (σ : Perm (Fin 4)) (t : Fin 4 → ℤ) :
+    Perm.sign σ • atomRelFin4 W (t ∘ σ) = atomRelFin4 W t := by
+  rw [atomRelFin4_perm odd, ← mul_smul, Int.units_mul_self, one_smul]
+
+end IsEllipticNet

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Alternating.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Alternating.lean
@@ -89,7 +89,9 @@ variable (W) in
 def atomRelFin4 (t : Fin 4 → ℤ) : R := atomRel W (t 0) (t 1) (t 2) (t 3)
 
 /-- The defining formula for `atomRelFin4`. The definition body is not exposed, so this equation
-lemma is how a consumer computes with it. -/
+lemma is how a consumer computes with it. `@[simp]`, as the `_def` equations of this API are:
+the tuple packaging carries no content of its own, so unfolding it is always progress. -/
+@[simp]
 theorem atomRelFin4_def (t : Fin 4 → ℤ) :
     atomRelFin4 W t = atomRel W (t 0) (t 1) (t 2) (t 3) := (rfl)
 
@@ -101,11 +103,15 @@ theorem atomRelFin4_perm (odd : W.Odd) (σ : Perm (Fin 4)) :
   refine Submonoid.closure_induction
     (motive := fun (σ : Perm (Fin 4)) _ ↦
       ∀ t, atomRelFin4 W (t ∘ σ) = Perm.sign σ • atomRelFin4 W t)
-    ?_ (fun t ↦ by simp) (fun σ τ _ _ hσ hτ t ↦ ?_) hmem
-  on_goal 2 => rw [Perm.coe_mul, ← Function.comp_assoc, hτ, hσ, map_mul, mul_comm, mul_smul]
-  rintro _ ⟨i, rfl⟩ t
-  fin_cases i <;> rw [Perm.sign_swap Fin.castSucc_lt_succ.ne, Units.neg_smul, one_smul]
-  exacts [atomRel_swap₁₂ odd _ _ _ _, atomRel_swap₂₃ odd _ _ _ _, atomRel_swap₃₄ odd _ _ _ _]
+    (fun _ hgen t ↦ ?generator)
+    (fun t ↦ by simp)
+    (fun σ τ _ _ hσ hτ t ↦ by
+      rw [Perm.coe_mul, ← Function.comp_assoc, hτ, hσ, map_mul, mul_comm, mul_smul])
+    hmem
+  case generator =>
+    obtain ⟨i, rfl⟩ := hgen
+    fin_cases i <;> rw [Perm.sign_swap Fin.castSucc_lt_succ.ne, Units.neg_smul, one_smul]
+    exacts [atomRel_swap₁₂ odd _ _ _ _, atomRel_swap₂₃ odd _ _ _ _, atomRel_swap₃₄ odd _ _ _ _]
 
 /-- `atomRelFin4_perm` in the form that cancels the sign. -/
 theorem atomRelFin4_perm' (odd : W.Odd) (σ : Perm (Fin 4)) (t : Fin 4 → ℤ) :

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
@@ -58,7 +58,9 @@ oddness of `W` enters; nothing else here needs a hypothesis on `W`.
 Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
 `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₄_swap₀₁`, `rel₄_swap₁₂`,
-`rel₄_swap₂₃`, `relFin4`, `relFin4_perm` and `relFin4_perm'`. That file's header reads
+`rel₄_swap₂₃`, `relFin4` and `relFin4_perm`. The source's `relFin4_perm'` — the sign-cancelled
+orientation — was **considered and not ported**: it has no consumer until the descent slice, and
+lands there beside `rel₄_of_oddRec_evenRec`, the proof that uses it. That file's header reads
 `Authors: Junyan Xu`; following this repository's convention for adapted material the upstream
 authorship is credited here rather than in the copyright header.
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
@@ -39,8 +39,8 @@ discharged — Mathlib's `atomRel_same` family with `W 0 = 0`.
 * `IsEllipticNet.atomRel_swap₁₂`, `atomRel_swap₂₃`, `atomRel_swap₃₄`: the three adjacent
   transpositions each negate `atomRel`.
 * `IsEllipticNet.atomRelFin4_perm`: `atomRelFin4 W (t ∘ σ) = sign σ • atomRelFin4 W t` for every
-  `σ : Equiv.Perm (Fin 4)`, and `atomRelFin4_perm'` in the form that cancels the sign. Note this is
-  sign-equivariance, not alternation — see the header.
+  `σ : Equiv.Perm (Fin 4)`, and `IsEllipticNet.sign_smul_atomRelFin4_perm` with the sign moved
+  left, where it cancels. Note this is sign-equivariance, not alternation — see the header.
 
 ## Implementation notes
 
@@ -96,9 +96,10 @@ variable (W) in
 /-- The relator with its four indices packaged as a tuple, the form a permutation acts on. -/
 def atomRelFin4 (t : Fin 4 → ℤ) : R := atomRel W (t 0) (t 1) (t 2) (t 3)
 
-/-- The defining formula for `atomRelFin4`. The definition body is not exposed, so this equation
-lemma is how a consumer computes with it. `@[simp]`, as the `_def` equations of this API are:
-the tuple packaging carries no content of its own, so unfolding it is always progress. -/
+/-- The `@[simp]` unfolding equation for `atomRelFin4`, and the supported way to compute with it:
+the tuple packaging carries no content of its own, so unfolding is always progress. The body is
+exported unexposed — a plain `public section`, no `@[expose]` — so an importing module cannot
+unfold it directly and reaches the formula through this lemma. -/
 @[simp]
 theorem atomRelFin4_def (t : Fin 4 → ℤ) :
     atomRelFin4 W t = atomRel W (t 0) (t 1) (t 2) (t 3) := (rfl)
@@ -120,11 +121,13 @@ theorem atomRelFin4_perm (odd : W.Odd) (σ : Perm (Fin 4)) :
     hmem
   case generator =>
     obtain ⟨i, rfl⟩ := hgen
-    fin_cases i <;> rw [Perm.sign_swap Fin.castSucc_lt_succ.ne, Units.neg_smul, one_smul]
+    fin_cases i <;>
+      simp only [Perm.sign_swap Fin.castSucc_lt_succ.ne, Units.neg_smul, one_smul, atomRelFin4_def,
+        Function.comp_apply, Fin.isValue]
     exacts [atomRel_swap₁₂ odd _ _ _ _, atomRel_swap₂₃ odd _ _ _ _, atomRel_swap₃₄ odd _ _ _ _]
 
-/-- `atomRelFin4_perm` in the form that cancels the sign. -/
-theorem atomRelFin4_perm' (odd : W.Odd) (σ : Perm (Fin 4)) (t : Fin 4 → ℤ) :
+/-- `atomRelFin4_perm` with the sign moved to the left, where it cancels. -/
+theorem sign_smul_atomRelFin4_perm (odd : W.Odd) (σ : Perm (Fin 4)) (t : Fin 4 → ℤ) :
     Perm.sign σ • atomRelFin4 W (t ∘ σ) = atomRelFin4 W t := by
   rw [atomRelFin4_perm odd, ← mul_smul, Int.units_mul_self, one_smul]
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
@@ -10,17 +10,24 @@ import Mathlib.Algebra.Module.Basic
 import Mathlib.Tactic.FinCases
 
 /-!
-# The elliptic relator is alternating in its four indices
+# The elliptic relator is sign-equivariant in its four indices
 
 For an odd sequence `W : ℤ → R`, Mathlib's `IsEllipticNet.atomRel W a b c d` changes sign under a
 transposition of its four arguments. This file proves that for the three adjacent transpositions
 and then, by inducting over the generators of `Equiv.Perm (Fin 4)`, for an arbitrary permutation:
-`atomRelFin4` is alternating.
+`atomRelFin4 W (t ∘ σ) = sign σ • atomRelFin4 W t`.
 
-The point is the descent that identifies elliptic sequences. Deducing the four-index relation from
-the one-index odd and even recurrences works by ordering the four indices and shrinking the largest,
-which is only available once the relation may be reordered freely — and, since three of the six
-`atomRel_same` shapes then collapse to zero, once repeated indices can be discharged.
+This is **skew-symmetry, not alternation**, and the distinction is not pedantic here. `R` is an
+arbitrary commutative ring, so `2` may be a zero divisor or vanish; the usual implication from
+`f = -f` to `f = 0` is unavailable, and nothing below forces the relator to vanish when two indices
+coincide. That vanishing is a separate fact, and it is Mathlib's: given `W 0 = 0`, each of the six
+`IsEllipticNet.atomRel_same` lemmas has the shape `_ * W 0 * _`, hence is zero. The descent uses
+both, from their two sources.
+
+The point is that descent. Deducing the four-index relation from the one-index odd and even
+recurrences works by ordering the four indices and shrinking the largest, which is only available
+once the relation may be reordered freely — this file — and once repeated indices can be
+discharged — Mathlib's `atomRel_same` family with `W 0 = 0`.
 
 ## Main definitions
 
@@ -32,7 +39,8 @@ which is only available once the relation may be reordered freely — and, since
 * `IsEllipticNet.atomRel_swap₁₂`, `atomRel_swap₂₃`, `atomRel_swap₃₄`: the three adjacent
   transpositions each negate `atomRel`.
 * `IsEllipticNet.atomRelFin4_perm`: `atomRelFin4 W (t ∘ σ) = sign σ • atomRelFin4 W t` for every
-  `σ : Equiv.Perm (Fin 4)`, and `atomRelFin4_perm'` in the form that cancels the sign.
+  `σ : Equiv.Perm (Fin 4)`, and `atomRelFin4_perm'` in the form that cancels the sign. Note this is
+  sign-equivariance, not alternation — see the header.
 
 ## Implementation notes
 
@@ -95,8 +103,10 @@ the tuple packaging carries no content of its own, so unfolding it is always pro
 theorem atomRelFin4_def (t : Fin 4 → ℤ) :
     atomRelFin4 W t = atomRel W (t 0) (t 1) (t 2) (t 3) := (rfl)
 
-/-- **The relator is alternating**: permuting the four indices multiplies it by the sign of the
-permutation. -/
+/-- **The relator is sign-equivariant**: permuting the four indices multiplies it by the sign of
+the permutation. This is skew-symmetry; it does *not* say the relator vanishes at repeated indices,
+which over a ring with `2` a zero divisor does not follow, and which Mathlib's `atomRel_same`
+family supplies separately from `W 0 = 0`. -/
 theorem atomRelFin4_perm (odd : W.Odd) (σ : Perm (Fin 4)) :
     ∀ t : Fin 4 → ℤ, atomRelFin4 W (t ∘ σ) = Perm.sign σ • atomRelFin4 W t := by
   have hmem := (Perm.mclosure_swap_castSucc_succ 3).symm ▸ Submonoid.mem_top σ

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
@@ -39,8 +39,10 @@ discharged — Mathlib's `atomRel_same` family with `W 0 = 0`.
 * `IsEllipticNet.atomRel_swap₁₂`, `atomRel_swap₂₃`, `atomRel_swap₃₄`: the three adjacent
   transpositions each negate `atomRel`.
 * `IsEllipticNet.atomRelFin4_perm`: `atomRelFin4 W (t ∘ σ) = sign σ • atomRelFin4 W t` for every
-  `σ : Equiv.Perm (Fin 4)`, and `IsEllipticNet.sign_smul_atomRelFin4_perm` with the sign moved
-  left, where it cancels. Note this is sign-equivariance, not alternation — see the header.
+  `σ : Equiv.Perm (Fin 4)`. Note this is sign-equivariance, not alternation — see the header. The
+  sign-cancelled orientation is one `rw [atomRelFin4_perm odd, ← mul_smul, Int.units_mul_self,
+  one_smul]` away and is not stated here: it has no consumer until the descent slice, which is
+  where it will land, next to the proof that uses it.
 
 ## Implementation notes
 
@@ -125,10 +127,5 @@ theorem atomRelFin4_perm (odd : W.Odd) (σ : Perm (Fin 4)) :
       simp only [Perm.sign_swap Fin.castSucc_lt_succ.ne, Units.neg_smul, one_smul, atomRelFin4_def,
         Function.comp_apply, Fin.isValue]
     exacts [atomRel_swap₁₂ odd _ _ _ _, atomRel_swap₂₃ odd _ _ _ _, atomRel_swap₃₄ odd _ _ _ _]
-
-/-- `atomRelFin4_perm` with the sign moved to the left, where it cancels. -/
-theorem sign_smul_atomRelFin4_perm (odd : W.Odd) (σ : Perm (Fin 4)) (t : Fin 4 → ℤ) :
-    Perm.sign σ • atomRelFin4 W (t ∘ σ) = atomRelFin4 W t := by
-  rw [atomRelFin4_perm odd, ← mul_smul, Int.units_mul_self, one_smul]
 
 end IsEllipticNet


### PR DESCRIPTION
The elliptic relator is sign-equivariant in its four indices — the first slice of the `normEDS`
ellipticity chain, and the piece that makes the descent to elliptic sequences available.

```lean
-- TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
namespace IsEllipticNet

theorem atomRel_swap₁₂ (odd : W.Odd) (a b c d : ℤ) : atomRel W a b c d = -atomRel W b a c d
theorem atomRel_swap₂₃ (odd : W.Odd) (a b c d : ℤ) : atomRel W a b c d = -atomRel W a c b d
theorem atomRel_swap₃₄ (odd : W.Odd) (a b c d : ℤ) : atomRel W a b c d = -atomRel W a b d c

def atomRelFin4 (t : Fin 4 → ℤ) : R := atomRel W (t 0) (t 1) (t 2) (t 3)

theorem atomRelFin4_perm (odd : W.Odd) (σ : Perm (Fin 4)) :
    ∀ t, atomRelFin4 W (t ∘ σ) = Perm.sign σ • atomRelFin4 W t
```

**What it says.** For an odd sequence `W`, Mathlib's `IsEllipticNet.atomRel` changes sign under each
of the three adjacent transpositions of its arguments, and hence — inducting over the generators
`Equiv.Perm.mclosure_swap_castSucc_succ` gives for `Perm (Fin 4)` — under an arbitrary permutation.

**Skew-symmetry, not alternation.** An earlier draft of this file said "alternating", which
overstates it: `R` is an arbitrary commutative ring, so `2` may be a zero divisor and `f = -f` does
not give `f = 0`. Nothing here forces the relator to vanish at repeated indices. That vanishing is
Mathlib's — with `W 0 = 0`, each of the six `atomRel_same` lemmas has the shape `_ * W 0 * _` — and
the descent draws on the two facts from their two sources. The file, its title and its docstrings
now say sign-equivariance throughout.

**Why it is wanted.** Deducing the four-index relation from the one-index odd and even recurrences
proceeds by ordering the four indices and shrinking the largest. That needs the relation to be
reorderable, and needs repeated indices dischargeable through Mathlib's `atomRel_same` family. This
file supplies the first half; the descent itself is the next slice.

Each transposition is a single rewrite with Mathlib's `neg_atom`, which is where oddness enters —
only one `atom` term differs between the two sides. Nothing else here constrains `W`.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, the **Layer 6** torsion/Nagell–Lutz strand: the targets
`lutz_nagell` and `lutz_nagell_integrality_general` (README.md:821-837), whose stated route is the
division polynomials. This is a measured prerequisite of that route, not a speculative one. The
chain is `redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS ←
IsEllipticSequence.normEDS`, and `normEDS` ellipticity in turn needs the descent, which needs this
file. The pinned Mathlib records that ellipticity as an open TODO
(`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean`), so it is built here per the roadmap's
own policy for material in flight upstream (README.md:232-236): "build them here when a layer needs
them, and swap in the upstream version — deleting the duplication — the moment it lands."

## Mathlib absence

Absent from the pinned Mathlib. Mathlib carries the surrounding `atom`/`atomRel` layer in full —
`atom_same`, `atom_mul_atom`, `neg_atom`, the four `atomRel_neg`, the four `atomRel_abs`, the six
`atomRel_same`, `atomRel_avg_sub`, `atomRel_eq`, `rel_eq`, `rel_neg`, and the `map_*` naturality —
but nothing about antisymmetry or permutation of the four indices: greps for `atomRel_swap`,
antisymmetry, `Perm` and `sign` over that module return nothing.

## Provenance

Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₄_swap₀₁`, `rel₄_swap₁₂`,
`rel₄_swap₂₃`, `relFin4` and `relFin4_perm`. The source's `relFin4_perm'` was **considered and not
ported** — it has no consumer until the descent slice and lands there, beside the proof that uses
it; `reuse` asked for exactly that on this PR. That file's header reads
`Authors: Junyan Xu`; following this repository's convention for adapted material the upstream
authorship is credited in the module docstring rather than in the copyright header.

**Adaptations.** Restated over Mathlib's names for this API — the source's `rel₄` is
`IsEllipticNet.atomRel`, its `addMulSub` is `IsEllipticNet.atom`, and its standing
`neg : ∀ k, W (-k) = -W k` hypothesis is Mathlib's `W.Odd`. The transpositions are numbered from
one, matching Mathlib's own `atomRel_same₁₂ … atomRel_same₃₄` family, rather than from zero as the
source does. The source's `rel₄_abs` and the three `rel₄_same` lemmas are **not** ported: Mathlib's
`atomRel_abs₁…₄` already give the first, and its `atomRel_same₁₂`/`₂₃`/`₃₄` give the others once
`W 0 = 0`.

## Gates

Two measurements against two different pins, kept distinct on purpose.

**The full four-gate chain, at Mathlib `f5809ef6`** (the pin this branch was authored against), on a
worktree verified clean by `git status --short` beforehand and on file content identical to what is
here now: `lake build` PASS (7754 jobs) · `scripts/lint-env.sh` PASS · `lake exe axioms` — 44008
declarations audited, all within `[propext, Classical.choice, Quot.sound]` · `lake exe module-system`
— 2099 modules, all opted in.

**Then the branch was rebased**, because its old base broke against current `main`. Mathlib now
declares `ContinuousLinearMap.IsFredholm.comp` itself, and `main` removed TauCeti's local copy in
`052dec58e` (#3069, 2026-08-13 20:16:45Z). The sandboxed build takes the *trusted base's* pins but
overlays the *PR head's* whole `TauCeti/`, so any head predating that commit carries the old
duplicate into the new Mathlib and fails on a file its own diff never touches — which is what
happened here. The rebase onto `189d7ab98` replayed all 7 commits cleanly, left the diff at exactly
one file, and moved the Mathlib pin `f5809ef6` → `f4fd7f7e`.

**At the new pin `f4fd7f7e`, a targeted build:** `lake build
TauCeti.NumberTheory.EllipticDivisibilitySequence.SignEquivariance` PASS (1003 jobs; the module
itself 46s). The full-tree re-audit was **not** re-run locally, and that is a deliberate,
disclosed choice rather than an omission: this machine was thrashing — roughly 596 `lean` workers
across eight worktrees at load ~20 on 16 cores, with zero `.olean` files completing in thirty
minutes — so a full local chain was making no progress at all. The new information the rebase
raises is confined to the one changed module, which imports only Mathlib; the rest of the tree is
`main`'s, already proved green at `189d7ab98`. The full chain at this head is precisely what CI's
sandboxed build runs on a clean runner. Old-pin numbers are not restated as if measured at the new
head.

`lint-env` reports **PASS** with 69 grandfathered and **1 ratchetable**. That one is not from this
branch: it is the stale baseline line `simpNF Polynomial.derivative_hermite_succ`, flagged because a
merge elsewhere fixed the underlying Hermite-polynomial violation, and `lint-env` asks for the
baseline line to be deleted in a follow-up. Deleting it would mean editing `scripts/lint-baseline.txt`,
which is human-owned, and would cost this PR its `TauCeti/`-only auto-merge — so it is left alone
and surfaced instead.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"relator-alternating"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
