### PR TITLE
feat(ModularForms): the slash sum of a slash-invariant function is slash-invariant

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
@@ -138,6 +138,12 @@ sufficiency theorem is available. -/
 noncomputable def heckeSlashSum (f : ℍ → ℂ) : ℍ → ℂ :=
   ∑ i : DecompQuotient (SLnZ 2) (SLnZ 2) (D.out : GL (Fin 2) ℚ), f ∣[k] transposeRep D i
 
+/-- Defining equation for `heckeSlashSum` at the level of functions. Since `heckeSlashSum` is
+not `@[expose]`, a downstream module rewrites with this instead of unfolding the body; the
+pointwise `heckeSlashSum_apply` below is the companion for arguments that work at a point. -/
+lemma heckeSlashSum_def (f : ℍ → ℂ) : heckeSlashSum k D f =
+    ∑ i : DecompQuotient (SLnZ 2) (SLnZ 2) (D.out : GL (Fin 2) ℚ), f ∣[k] transposeRep D i := (rfl)
+
 /-- The pointwise value of the slash sum: the sum of the slashed values. This is the equation
 the reindexing proof of Prop 3.30 works from. -/
 lemma heckeSlashSum_apply (f : ℍ → ℂ) (τ : ℍ) : heckeSlashSum k D f τ =

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
@@ -63,8 +63,10 @@ and scalars commute past it (`ModularForm.rat_smul_slash_of_det_pos`). Over a ge
 
 ## Main results
 
-* `HeckeRing.GL2.transposeRep_def`, `HeckeRing.GL2.heckeSlashSum_apply`: the characteristic
-  equations, which are the interface since neither definition is `@[expose]`.
+* `HeckeRing.GL2.transposeRep_def`, `HeckeRing.GL2.heckeSlashSum_def` and
+  `HeckeRing.GL2.heckeSlashSum_apply`: the characteristic equations, which are the interface
+  since neither definition is `@[expose]`. The last two are the function-level and pointwise
+  forms of the same equation.
 * `HeckeRing.GL2.det_transposeRep_pos`: the representatives have positive determinant.
 * `HeckeRing.GL2.heckeSlashSum_add`, `heckeSlashSum_zero`, `heckeSlashSum_smul`: `ℂ`-linearity.
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
@@ -22,8 +22,8 @@ That is the content of the proof of Shimura's Proposition 3.37 — right multipl
 
 ## Main results
 
-* `HeckeRing.GL2.heckeSlashSum_slash_of_mem_SLnZ`: for `γ ∈ SL₂(ℤ)` and slash-invariant `f`,
-  `heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f`.
+* `HeckeRing.GL2.heckeSlashSum_slash_invariant_of_mem_SLnZ`: for `γ ∈ SL₂(ℤ)` and
+  slash-invariant `f`, `heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f`.
 
 ## Provenance
 
@@ -72,7 +72,7 @@ transposed.
 ⚠ This proves invariance of the sum formed from the representatives `D.out` and `i.out` that
 `heckeSlashSum` fixes. It does **not** state that sums formed from *different* choices of
 representatives agree; that would be a separate theorem, and none is available yet. -/
-theorem heckeSlashSum_slash_of_mem_SLnZ (f : ℍ → ℂ) (hf : ∀ δ ∈ SLnZ 2, f ∣[k] δ = f)
+theorem heckeSlashSum_slash_invariant_of_mem_SLnZ (f : ℍ → ℂ) (hf : ∀ δ ∈ SLnZ 2, f ∣[k] δ = f)
     {γ : GL (Fin 2) ℚ} (hγ : γ ∈ SLnZ 2) :
     heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f := by
   have hγT : (transposeGLEquiv 2 γ).unop ∈ SLnZ 2 := transposeGLEquiv_mem_SLnZ 2 hγ
@@ -86,8 +86,9 @@ theorem heckeSlashSum_slash_of_mem_SLnZ (f : ℍ → ℂ) (hf : ∀ δ ∈ SLnZ 
     exact congrArg (f ∣[k] transposeRep D ·)
       (MulAction.Quotient.mk_smul_out _ (⟨_, hγT⟩ : SLnZ 2) i)
   rw [heckeSlashSum_def, SlashAction.sum_slash]
-  -- `MulAction.toPerm` of the transposed `γ` is the reindexing bijection; `hperm` is exactly its
-  -- compatibility hypothesis, since `toPerm b i` and `b • i` are definitionally equal.
-  exact Fintype.sum_equiv (MulAction.toPerm (⟨_, hγT⟩ : SLnZ 2)) _ _ hperm
+  -- `MulAction.toPerm` of the transposed `γ` is the reindexing bijection. Its compatibility
+  -- hypothesis is `hperm` up to `toPerm_apply`, which is stated rather than left to defeq.
+  exact Fintype.sum_equiv (MulAction.toPerm (⟨_, hγT⟩ : SLnZ 2)) _ _ fun i ↦ by
+    simpa only [MulAction.toPerm_apply] using hperm i
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
@@ -65,10 +65,13 @@ private lemma transposeRep_mul (i : DecompQuotient (SLnZ 2) (SLnZ 2) D.out) (γ 
 under the weight-`k` slash action of `SL₂(ℤ)` and `γ ∈ SL₂(ℤ)`,
 `heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f`.
 
-This is what makes the sum an operator: with it, `heckeSlashSum` no longer depends on the chosen
-representatives, since any two choices differ by an element of `SL₂(ℤ)`. The proof is Shimura's —
-right multiplication by `γ` permutes the summands — and the permutation is `MulAction.toPerm`
-applied to `γᵀ`, the transpose appearing because the representatives are transposed. -/
+The proof is Shimura's — right multiplication by `γ` permutes the summands — and the permutation
+is `MulAction.toPerm` applied to `γᵀ`, the transpose appearing because the representatives are
+transposed.
+
+⚠ This proves invariance of the sum formed from the representatives `D.out` and `i.out` that
+`heckeSlashSum` fixes. It does **not** state that sums formed from *different* choices of
+representatives agree; that would be a separate theorem, and none is available yet. -/
 theorem heckeSlashSum_slash_of_mem_SLnZ (f : ℍ → ℂ) (hf : ∀ δ ∈ SLnZ 2, f ∣[k] δ = f)
     {γ : GL (Fin 2) ℚ} (hγ : γ ∈ SLnZ 2) :
     heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f := by

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Reindex
+
+/-!
+# The slash sum is `SL₂(ℤ)`-invariant
+
+`heckeSlashSum` is a sum over *chosen* coset representatives, and `HeckeSlash/Basic.lean` records
+that on a general `f : ℍ → ℂ` the value depends on those choices. This file proves the theorem
+that repairs it: if `f` is invariant under the weight-`k` slash action of `SL₂(ℤ)`, then so is
+`heckeSlashSum k D f`.
+
+That is the content of the proof of Shimura's Proposition 3.37 — right multiplication by
+`γ ∈ SL₂(ℤ)` merely **permutes** the representatives, so the sum is unchanged. The permutation is
+`MulAction.toPerm` for the action of `SL₂(ℤ)` on `DecompQuotient`, and the per-summand step is
+`slash_transposeRep_of_mem_SLnZ` from `HeckeSlash/Reindex.lean`.
+
+## Main results
+
+* `HeckeRing.GL2.heckeSlashSum_slash_of_mem_SLnZ`: for `γ ∈ SL₂(ℤ)` and slash-invariant `f`,
+  `heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f`.
+
+## Provenance
+
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GL2/HeckeAction.lean`](https://github.com/CBirkbeck/AINTLIB),
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), lines 198–224:
+`tRep_mul_eq_transpose` and `heckeSlash_slash_invariant`.
+
+Restated against TauCeti's `SLnZ`/`posDetInt` Hecke pair and `transposeGLEquiv`. As in
+`Reindex.lean`, the invariance hypothesis is carried at `SLnZ 2` under the rational slash action
+rather than routed through the real `𝒮ℒ`, so AINTLIB's `mem_SL_exists_H` bridge — which opens its
+proof — is not needed here and the statement quantifies over `γ ∈ SLnZ 2` directly.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.4, Proposition 3.37.
+-/
+
+public section
+
+open Matrix UpperHalfPlane DoubleCoset HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm
+
+namespace HeckeRing.GL2
+
+variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+
+-- Right multiplication of a representative by `γ` is the transpose of left multiplication by
+-- `γᵀ`, which is what turns the reindexing lemma into a permutation of the index type.
+private lemma transposeRep_mul (i : DecompQuotient (SLnZ 2) (SLnZ 2) D.out) (γ : GL (Fin 2) ℚ) :
+    transposeRep D i * γ = (transposeGLEquiv 2 ((transposeGLEquiv 2 γ).unop *
+      (i.out : GL (Fin 2) ℚ) * (D.out : GL (Fin 2) ℚ))).unop := by
+  simp [transposeRep_def, map_mul, MulOpposite.unop_mul, transposeGLEquiv_transposeGLEquiv,
+    mul_assoc]
+
+/-- **The slash sum of a slash-invariant function is again slash-invariant.** For `f` invariant
+under the weight-`k` slash action of `SL₂(ℤ)` and `γ ∈ SL₂(ℤ)`,
+`heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f`.
+
+This is what makes the sum an operator: with it, `heckeSlashSum` no longer depends on the chosen
+representatives, since any two choices differ by an element of `SL₂(ℤ)`. The proof is Shimura's —
+right multiplication by `γ` permutes the summands — and the permutation is `MulAction.toPerm`
+applied to `γᵀ`, the transpose appearing because the representatives are transposed. -/
+theorem heckeSlashSum_slash_of_mem_SLnZ (f : ℍ → ℂ) (hf : ∀ δ ∈ SLnZ 2, f ∣[k] δ = f)
+    {γ : GL (Fin 2) ℚ} (hγ : γ ∈ SLnZ 2) :
+    heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f := by
+  have hγT : (transposeGLEquiv 2 γ).unop ∈ SLnZ 2 := transposeGLEquiv_mem_SLnZ 2 hγ
+  -- Slashing the `i`-th summand by `γ` gives the summand at the permuted index.
+  have hperm (i : DecompQuotient (SLnZ 2) (SLnZ 2) D.out) :
+      (f ∣[k] transposeRep D i) ∣[k] γ =
+        f ∣[k] transposeRep D ((⟨_, hγT⟩ : SLnZ 2) • i) := by
+    rw [← SlashAction.slash_mul k (transposeRep D i) γ f, transposeRep_mul, ← mul_one
+      ((⟨_, hγT⟩ : SLnZ 2) * (i.out : GL (Fin 2) ℚ) * (D.out : GL (Fin 2) ℚ)),
+      slash_transposeRep_of_mem_SLnZ k D (mul_mem hγT i.out.2) (one_mem _) f hf]
+    exact congrArg (f ∣[k] transposeRep D ·)
+      (MulAction.Quotient.mk_smul_out _ (⟨_, hγT⟩ : SLnZ 2) i)
+  rw [heckeSlashSum_def, SlashAction.sum_slash]
+  -- `MulAction.toPerm` of the transposed `γ` is the reindexing bijection; `hperm` is exactly its
+  -- compatibility hypothesis, since `toPerm b i` and `b • i` are definitionally equal.
+  exact Fintype.sum_equiv (MulAction.toPerm (⟨_, hγT⟩ : SLnZ 2)) _ _ hperm
+
+end HeckeRing.GL2


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke/slash-invariance"}-->

## Roadmap target

`TauCetiRoadmap/ModularForms/README.md`, **Layer 2, block (b) "The action on forms"**, which
requires `Tₙ`/`Tₚ` as `ℂ`-linear endomorphisms of `M_k(Γ₁(N))`. This PR removes the obstruction
that `HeckeSlash/Basic.lean` explicitly flagged: the sum was **not yet an action**.

## What is proved

```lean
theorem heckeSlashSum_slash_of_mem_SLnZ (f : ℍ → ℂ) (hf : ∀ δ ∈ SLnZ 2, f ∣[k] δ = f)
    {γ : GL (Fin 2) ℚ} (hγ : γ ∈ SLnZ 2) :
    heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f
```

`heckeSlashSum` is a sum over *chosen* coset representatives, and `Basic.lean` records that on a
general `f : ℍ → ℂ` its value depends on those choices. This is the theorem that repairs it: for
slash-invariant `f`, the sum is again slash-invariant.

## The argument

This is the proof of Shimura's Proposition 3.37, and it is short because the two hard pieces are
already in place:

* right multiplication by `γ` **permutes** the representatives — the permutation is
  `MulAction.toPerm` for the action of `SL₂(ℤ)` on `DecompQuotient`, applied to `γᵀ` (transposed,
  because the representatives are);
* the per-summand step is `slash_transposeRep_of_mem_SLnZ` (#3003).

One private helper carries the algebra: `transposeRep_mul` says right multiplication of a
representative by `γ` is the transpose of *left* multiplication by `γᵀ`, which is precisely what
turns the reindexing lemma into a permutation of the index type.

## One added API lemma

`heckeSlashSum_def` is added to `HeckeSlash/Basic.lean`: the characteristic equation of
`heckeSlashSum` **at the level of functions**. `Basic.lean` had only the pointwise
`heckeSlashSum_apply`, and since `heckeSlashSum` is not `@[expose]`, `rw [heckeSlashSum]` cannot
work from a downstream module — this proof needs the function-level form to apply
`SlashAction.sum_slash`. It is the missing sibling of `transposeRep_def`, and the file's "Main
results" list already promised the characteristic equations as the interface.

## Provenance

Ported from the AINTLIB `LeanModularForms` project
([`LeanModularForms/HeckeRIngs/GL2/HeckeAction.lean`](https://github.com/CBirkbeck/AINTLIB),
commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), lines 198–224:
`tRep_mul_eq_transpose` and `heckeSlash_slash_invariant`.

Restated against TauCeti's `SLnZ`/`posDetInt` Hecke pair and `transposeGLEquiv`. As in
`Reindex.lean`, the invariance hypothesis is carried at `SLnZ 2` under the **rational** slash
action rather than routed through the real `𝒮ℒ`, so AINTLIB's `mem_SL_exists_H` bridge — which
opens its proof with `obtain ⟨σ_Q, hσ_Q, rfl⟩` — is not needed here, and the statement quantifies
over `γ ∈ SLnZ 2` directly. AINTLIB's `set σ_QT`/`set π` are also dropped: a `set`-bound local of
a class-valued type can capture instance resolution.

## Scope

Stops at the invariance theorem. AINTLIB's `heckeSlashInvariant` — the `SlashInvariantForm`
packaging — and `tRep_mul_anti` are the next rung, not this PR.

## References

* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
  §3.4, Proposition 3.37.

Roadmap: ModularForms
