### PR TITLE
feat(EllipticCurve): the invariant polynomial of a Weierstrass curve

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
@@ -142,6 +142,7 @@ section BaseChange
 
 variable {S : Type*} [CommRing S] (f : R →+* S)
 
+/-- `invar` commutes with mapping the coefficients along a ring homomorphism. -/
 @[simp]
 lemma map_invar : (W.map f).invar = W.invar.map f := by
   simp [invar]
@@ -149,6 +150,7 @@ lemma map_invar : (W.map f).invar = W.invar.map f := by
 variable [Algebra R S] {A : Type*} [CommRing A] [Algebra R A] [Algebra S A] [IsScalarTower R S A]
   {B : Type*} [CommRing B] [Algebra R B] [Algebra S B] [IsScalarTower R S B] (g : A →ₐ[S] B)
 
+/-- `invar` commutes with base change along an algebra homomorphism between extensions. -/
 lemma baseChange_invar : (W⁄B).invar = (W⁄A).invar.map g := by
   rw [← map_invar, map_baseChange]
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
@@ -10,17 +10,28 @@ public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Invariant
 /-!
 # The invariant polynomial of a Weierstrass curve
 
-The elliptic net `ψ` carries an invariant, in the cross-multiplied sense of
-`IsEllipticNet.invarNum`/`invarDenom` (over a `CommRing` only the cross-multiplied identity holds;
-the reading as the quotient `(ψ(n-1)² ψ(n+2) + ψ(n-2) ψ(n+1)² + ψ₂² ψ(n)³) / (ψ(n+1) ψ(n) ψ(n-1))`,
-independent of `n`, needs nonzero denominators). Modulo the Weierstrass polynomial its value is
+This file defines the polynomial
 
-`WeierstrassCurve.invar = 6 X² + b₂ X + b₄`.
+`WeierstrassCurve.invar = 6 X² + b₂ X + b₄`
 
-This file defines that polynomial and proves the division-polynomial identities that identify it,
-together with the one identity connecting `φ` and `ψ` to `IsEllipticNet.invarDenom`. They are the
-first stage of the `ω` family of division polynomials, which gives the `Y` coordinate of scalar
-multiplication in Jacobian coordinates.
+and proves the division-polynomial identities that pin it down, together with the one identity
+connecting `φ` and `ψ` to `IsEllipticNet.invarDenom`. They are the first stage of the `ω` family of
+division polynomials, which gives the `Y` coordinate of scalar multiplication in Jacobian
+coordinates.
+
+Throughout, `ψ` is Mathlib's division-polynomial sequence `WeierstrassCurve.ψ`, and nothing here
+uses or asserts that it is an elliptic net or an elliptic sequence. `IsEllipticNet.invarNum` and
+`IsEllipticNet.invarDenom` are defined for an **arbitrary** sequence — `invarDenom W s n` is
+`W (n + s) * W n * W (n - s)` — so applying `invarDenom` to `ψ` is the use of a formula, not an
+ellipticity hypothesis; the namespace is where those formulas live, not a claim about `ψ`.
+
+The name `invar` records where the polynomial comes from, and that origin is motivation rather than
+anything established below: for a sequence that *is* an elliptic net, and over a field where the
+relevant denominators are nonzero, `invarNum/invarDenom` is independent of the index — that is the
+cancellation of `IsEllipticNet.invarNum_mul_invarDenom` — and its value modulo the Weierstrass
+polynomial is `6 X² + b₂ X + b₄`. Neither the hypothesis nor that conclusion is proved here, and
+over a `CommRing` the quotient need not exist at all. What this file proves are the polynomial
+identities listed below.
 
 ## Main definitions
 
@@ -38,7 +49,7 @@ multiplication in Jacobian coordinates.
   `WeierstrassCurve.map_invar` and `baseChange_invar`, the naturality the surrounding
   division-polynomial API provides for its other objects.
 * `WeierstrassCurve.φ_mul_ψ`: `φ n * ψ n = X ψ(n)³ - invarDenom ψ 1 n`, which is what connects the
-  division polynomials to the invariant of the elliptic net they form.
+  division polynomials to the invariant denominator formula evaluated at `ψ`.
 
 ## What is deliberately not here
 
@@ -84,9 +95,10 @@ namespace WeierstrassCurve
 
 variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
 
-/-- The invariant polynomial `6 X² + b₂ X + b₄` of a Weierstrass curve: modulo the Weierstrass
-polynomial it is the value of the invariant of the elliptic net `ψ`, the quotient
-`(ψ(n-1)² ψ(n+2) + ψ(n-2) ψ(n+1)² + ψ₂² ψ(n)³) / (ψ(n+1) ψ(n) ψ(n-1))` for any `n`. -/
+/-- The polynomial `6 X² + b₂ X + b₄` of a Weierstrass curve. What ties it to the division
+polynomials is `preΨ₄_add_Ψ₂Sq_sq` below, `preΨ₄ + Ψ₂Sq ^ 2 = invar * Ψ₃`. The name records the
+classical invariant of an elliptic net, whose index-independence is not what is proved here; see
+the module docstring. -/
 noncomputable def invar : R[X] := 6 * X ^ 2 + C W.b₂ * X + C W.b₄
 
 /-- The defining formula for `invar`. The definition body is not exposed, so this equation lemma is
@@ -130,9 +142,10 @@ lemma Affine.CoordinateRing.mk_preΨ₄_add_ψ₂_pow_four :
   rw [preΨ₄_add_ψ₂_pow_four]
   simp
 
-/-- **The division polynomials meet the invariant of their elliptic net**: `φ n * ψ n` is
-`X ψ(n)³` less the invariant's denominator at `s = 1`. This is the step through which the
-elliptic-net identities reach the curve. -/
+/-- **The division polynomials meet the invariant denominator**: `φ n * ψ n` is `X ψ(n)³` less
+`IsEllipticNet.invarDenom ψ 1 n`, which is `ψ(n+1) ψ(n) ψ(n-1)`. That denominator is a formula in an
+arbitrary sequence, so this is an identity between division polynomials and uses no ellipticity of
+`ψ`. It is the step through which the elliptic-net formulas reach the curve. -/
 theorem φ_mul_ψ (n : ℤ) :
     W.φ n * W.ψ n = C X * W.ψ n ^ 3 - IsEllipticNet.invarDenom W.ψ 1 n := by
   rw [WeierstrassCurve.φ, IsEllipticNet.invarDenom_def]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
@@ -10,9 +10,10 @@ public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Invariant
 /-!
 # The invariant polynomial of a Weierstrass curve
 
-The quotient `(ψ(n-1)² ψ(n+2) + ψ(n-2) ψ(n+1)² + ψ₂² ψ(n)³) / (ψ(n+1) ψ(n) ψ(n-1))` is, modulo the
-Weierstrass polynomial, independent of `n` — it is the invariant of the elliptic net `ψ`, and its
-value is the polynomial
+The elliptic net `ψ` carries an invariant, in the cross-multiplied sense of
+`IsEllipticNet.invarNum`/`invarDenom` (over a `CommRing` only the cross-multiplied identity holds;
+the reading as the quotient `(ψ(n-1)² ψ(n+2) + ψ(n-2) ψ(n+1)² + ψ₂² ψ(n)³) / (ψ(n+1) ψ(n) ψ(n-1))`,
+independent of `n`, needs nonzero denominators). Modulo the Weierstrass polynomial its value is
 
 `WeierstrassCurve.invar = 6 X² + b₂ X + b₄`.
 
@@ -31,7 +32,11 @@ multiplication in Jacobian coordinates.
   `invar` down. Its certificate is the `b`-relation `4 b₈ = b₂ b₆ - b₄ ²`.
 * `WeierstrassCurve.preΨ₄_add_ψ₂_pow_four`: the same identity in the bivariate ring, where it
   acquires a multiple of the Weierstrass polynomial.
-* `WeierstrassCurve.C_Ψ₃_eq`: `Ψ₃` through the partial derivatives of the Weierstrass polynomial.
+* `WeierstrassCurve.C_Ψ₃`: `Ψ₃` through the partial derivatives of the Weierstrass polynomial.
+* `WeierstrassCurve.Affine.CoordinateRing.mk_preΨ₄_add_ψ₂_pow_four`: the bivariate identity
+  in the coordinate ring, where the multiple of the Weierstrass polynomial vanishes; with
+  `WeierstrassCurve.map_invar` and `baseChange_invar`, the naturality the surrounding
+  division-polynomial API provides for its other objects.
 * `WeierstrassCurve.φ_mul_ψ`: `φ n * ψ n = X ψ(n)³ - invarDenom ψ 1 n`, which is what connects the
   division polynomials to the invariant of the elliptic net they form.
 
@@ -48,8 +53,9 @@ depends on any of it, so the identities land now and `ω` follows when that gap 
 
 Ported from J. Xu and D. K. Angdinata's `LutzNagell/DivisionPolynomialOmega.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invar`, `C_Ψ₃_eq`,
-`preΨ₄_add_Ψ₂Sq_sq`, `preΨ₄_add_ψ₂_pow_four` and `φ_mul_ψ`. That file's header reads
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invar`, `C_Ψ₃_eq` (here `C_Ψ₃`,
+matching Mathlib's `C_Ψ₂Sq`), `preΨ₄_add_Ψ₂Sq_sq`, `preΨ₄_add_ψ₂_pow_four` and `φ_mul_ψ`. That
+file's header reads
 `Authors: Junyan Xu, David Kurniadi Angdinata`; following this repository's convention for adapted
 material the upstream authorship is credited here rather than in the copyright header.
 
@@ -89,7 +95,7 @@ how a consumer computes with it. Not `@[simp]`: the point of naming the polynomi
 theorem invar_def : W.invar = 6 * X ^ 2 + C W.b₂ * X + C W.b₄ := (rfl)
 
 /-- `Ψ₃` expressed through the partial derivatives of the Weierstrass polynomial. -/
-theorem C_Ψ₃_eq :
+theorem C_Ψ₃ :
     C W.Ψ₃ = (3 * C X + CC W.a₂) * C W.Ψ₂Sq - Affine.polynomialX W ^ 2
       + CC W.a₁ * W.ψ₂ * Affine.polynomialX W - CC W.a₁ ^ 2 * Affine.polynomial W := by
   simp_rw [Ψ₃, Ψ₂Sq, Affine.polynomial, Affine.polynomialX, ψ₂, Affine.polynomialY, b₂, b₄, b₆, b₈,
@@ -105,13 +111,24 @@ theorem preΨ₄_add_Ψ₂Sq_sq : W.preΨ₄ + W.Ψ₂Sq ^ 2 = W.invar * W.Ψ₃
     congr(C $W.b_relation) * (@X R _) ^ 2
 
 /-- The bivariate form of `preΨ₄_add_Ψ₂Sq_sq`. Passing to `R[X][Y]` costs a multiple of the
-Weierstrass polynomial, `ψ₂ ^ 2` and `C Ψ₂Sq` differing by `8` times it. -/
+Weierstrass polynomial: `ψ₂ ^ 2` and `C Ψ₂Sq` differ by `4 * Affine.polynomial W`, and the
+factor `8` here comes from expanding the square of that difference. -/
 theorem preΨ₄_add_ψ₂_pow_four : C W.preΨ₄ + W.ψ₂ ^ 4 =
     C (W.invar * W.Ψ₃) + 8 * Affine.polynomial W * (2 * Affine.polynomial W + C W.Ψ₂Sq) := by
+  -- reassociate the fourth power to expose the `ψ₂ ^ 2` subterm that `ψ₂_sq` rewrites
   simp_rw [show 4 = 2 * 2 by rfl, pow_mul, ψ₂_sq, add_sq, ← add_assoc, ← C_pow, ← C_add,
     preΨ₄_add_Ψ₂Sq_sq]
   simp only [C_mul]
   ring
+
+/-- The bivariate identity in the coordinate ring, where the multiple of the Weierstrass
+polynomial vanishes: consumers working modulo the curve equation read the identity in this
+form. -/
+lemma Affine.CoordinateRing.mk_preΨ₄_add_ψ₂_pow_four :
+    Affine.CoordinateRing.mk W (C W.preΨ₄ + W.ψ₂ ^ 4) =
+      Affine.CoordinateRing.mk W (C (W.invar * W.Ψ₃)) := by
+  rw [preΨ₄_add_ψ₂_pow_four]
+  simp
 
 /-- **The division polynomials meet the invariant of their elliptic net**: `φ n * ψ n` is
 `X ψ(n)³` less the invariant's denominator at `s = 1`. This is the step through which the
@@ -120,5 +137,21 @@ theorem φ_mul_ψ (n : ℤ) :
     W.φ n * W.ψ n = C X * W.ψ n ^ 3 - IsEllipticNet.invarDenom W.ψ 1 n := by
   rw [WeierstrassCurve.φ, IsEllipticNet.invarDenom_def]
   ring
+
+section BaseChange
+
+variable {S : Type*} [CommRing S] (f : R →+* S)
+
+@[simp]
+lemma map_invar : (W.map f).invar = W.invar.map f := by
+  simp [invar]
+
+variable [Algebra R S] {A : Type*} [CommRing A] [Algebra R A] [Algebra S A] [IsScalarTower R S A]
+  {B : Type*} [CommRing B] [Algebra R B] [Algebra S B] [IsScalarTower R S B] (g : A →ₐ[S] B)
+
+lemma baseChange_invar : (W⁄B).invar = (W⁄A).invar.map g := by
+  rw [← map_invar, map_baseChange]
+
+end BaseChange
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Invariant
+
+/-!
+# The invariant polynomial of a Weierstrass curve
+
+The quotient `(ψ(n-1)² ψ(n+2) + ψ(n-2) ψ(n+1)² + ψ₂² ψ(n)³) / (ψ(n+1) ψ(n) ψ(n-1))` is, modulo the
+Weierstrass polynomial, independent of `n` — it is the invariant of the elliptic net `ψ`, and its
+value is the polynomial
+
+`WeierstrassCurve.invar = 6 X² + b₂ X + b₄`.
+
+This file defines that polynomial and proves the division-polynomial identities that identify it,
+together with the one identity connecting `φ` and `ψ` to `IsEllipticNet.invarDenom`. They are the
+first stage of the `ω` family of division polynomials, which gives the `Y` coordinate of scalar
+multiplication in Jacobian coordinates.
+
+## Main definitions
+
+* `WeierstrassCurve.invar`: the invariant polynomial `6 X² + b₂ X + b₄`.
+
+## Main results
+
+* `WeierstrassCurve.preΨ₄_add_Ψ₂Sq_sq`: `preΨ₄ + Ψ₂Sq ^ 2 = invar * Ψ₃`, the identity that pins
+  `invar` down. Its certificate is the `b`-relation `4 b₈ = b₂ b₆ - b₄ ²`.
+* `WeierstrassCurve.preΨ₄_add_ψ₂_pow_four`: the same identity in the bivariate ring, where it
+  acquires a multiple of the Weierstrass polynomial.
+* `WeierstrassCurve.C_Ψ₃_eq`: `Ψ₃` through the partial derivatives of the Weierstrass polynomial.
+* `WeierstrassCurve.φ_mul_ψ`: `φ n * ψ n = X ψ(n)³ - invarDenom ψ 1 n`, which is what connects the
+  division polynomials to the invariant of the elliptic net they form.
+
+## What is deliberately not here
+
+`WeierstrassCurve.ω` itself and its API — `ω_spec`, `two_mul_ω`, `ψc`, `ψc_spec`, `ω_zero`,
+`ω_one`, `ψc_neg`, `map_ω`, `ω_neg` — are **not** in this file. `ω` is defined through
+`redInvarDenom` and `complEDS₂Aux`, and `ω_spec` additionally consumes `redInvar_normEDS`, which
+routes through `normEDS` being an elliptic sequence: a fact the pinned Mathlib records as an open
+TODO and whose proof is the parity-transfer machinery of Mathlib PR #42453. Nothing in this file
+depends on any of it, so the identities land now and `ω` follows when that gap closes.
+
+## Provenance
+
+Ported from J. Xu and D. K. Angdinata's `LutzNagell/DivisionPolynomialOmega.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invar`, `C_Ψ₃_eq`,
+`preΨ₄_add_Ψ₂Sq_sq`, `preΨ₄_add_ψ₂_pow_four` and `φ_mul_ψ`. That file's header reads
+`Authors: Junyan Xu, David Kurniadi Angdinata`; following this repository's convention for adapted
+material the upstream authorship is credited here rather than in the copyright header.
+
+Two adaptations, neither of them a choice:
+
+* the source proves `φ_mul_ψ` by `rw [φ, invarDenom]`, unfolding both definitions. The
+  `invarDenom` half does not port: `EllipticDivisibilitySequence/Invariant.lean` exports that body
+  unexposed, so from this module `rw [invarDenom]` has nothing to rewrite with. It goes through the
+  equation lemma `IsEllipticNet.invarDenom_def` instead. `φ` unfolds as before, being Mathlib's.
+* the source's local `C_simp` macro is written out at its three use sites rather than carried
+  across, a macro being more surface than the one `simp only` call it abbreviates.
+
+The statement of `φ_mul_ψ` was checked against Mathlib's `φ` rather than assumed: Mathlib defines
+`φ n = C X * ψ n ^ 2 - ψ (n + 1) * ψ (n - 1)`, so `φ n * ψ n` is
+`C X * ψ n ^ 3 - ψ (n + 1) * ψ n * ψ (n - 1)`, and that subtrahend is exactly
+`IsEllipticNet.invarDenom ψ 1 n`.
+-/
+
+public section
+
+open Polynomial
+
+open scoped Polynomial.Bivariate
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+
+/-- The invariant polynomial `6 X² + b₂ X + b₄` of a Weierstrass curve: modulo the Weierstrass
+polynomial it is the value of the invariant of the elliptic net `ψ`, the quotient
+`(ψ(n-1)² ψ(n+2) + ψ(n-2) ψ(n+1)² + ψ₂² ψ(n)³) / (ψ(n+1) ψ(n) ψ(n-1))` for any `n`. -/
+noncomputable def invar : R[X] := 6 * X ^ 2 + C W.b₂ * X + C W.b₄
+
+/-- The defining formula for `invar`. The definition body is not exposed, so this equation lemma is
+how a consumer computes with it. Not `@[simp]`: the point of naming the polynomial is that
+`preΨ₄_add_Ψ₂Sq_sq` can be stated over it, which unfolding everywhere would defeat. -/
+theorem invar_def : W.invar = 6 * X ^ 2 + C W.b₂ * X + C W.b₄ := (rfl)
+
+/-- `Ψ₃` expressed through the partial derivatives of the Weierstrass polynomial. -/
+theorem C_Ψ₃_eq :
+    C W.Ψ₃ = (3 * C X + CC W.a₂) * C W.Ψ₂Sq - Affine.polynomialX W ^ 2
+      + CC W.a₁ * W.ψ₂ * Affine.polynomialX W - CC W.a₁ ^ 2 * Affine.polynomial W := by
+  simp_rw [Ψ₃, Ψ₂Sq, Affine.polynomial, Affine.polynomialX, ψ₂, Affine.polynomialY, b₂, b₄, b₆, b₈,
+    CC]
+  simp only [map_ofNat, C_add, C_sub, C_mul, C_pow]
+  ring
+
+/-- **The identity that pins `invar` down**: `preΨ₄ + Ψ₂Sq ^ 2 = invar * Ψ₃`. The certificate is
+the `b`-relation `4 * b₈ = b₂ * b₆ - b₄ ^ 2`. -/
+theorem preΨ₄_add_Ψ₂Sq_sq : W.preΨ₄ + W.Ψ₂Sq ^ 2 = W.invar * W.Ψ₃ := by
+  rw [preΨ₄, Ψ₂Sq, invar, Ψ₃]
+  linear_combination (norm := (simp only [map_ofNat, C_sub, C_mul, C_pow]; ring_nf))
+    congr(C $W.b_relation) * (@X R _) ^ 2
+
+/-- The bivariate form of `preΨ₄_add_Ψ₂Sq_sq`. Passing to `R[X][Y]` costs a multiple of the
+Weierstrass polynomial, `ψ₂ ^ 2` and `C Ψ₂Sq` differing by `8` times it. -/
+theorem preΨ₄_add_ψ₂_pow_four : C W.preΨ₄ + W.ψ₂ ^ 4 =
+    C (W.invar * W.Ψ₃) + 8 * Affine.polynomial W * (2 * Affine.polynomial W + C W.Ψ₂Sq) := by
+  simp_rw [show 4 = 2 * 2 by rfl, pow_mul, ψ₂_sq, add_sq, ← add_assoc, ← C_pow, ← C_add,
+    preΨ₄_add_Ψ₂Sq_sq]
+  simp only [C_mul]
+  ring
+
+/-- **The division polynomials meet the invariant of their elliptic net**: `φ n * ψ n` is
+`X ψ(n)³` less the invariant's denominator at `s = 1`. This is the step through which the
+elliptic-net identities reach the curve. -/
+theorem φ_mul_ψ (n : ℤ) :
+    W.φ n * W.ψ n = C X * W.ψ n ^ 3 - IsEllipticNet.invarDenom W.ψ 1 n := by
+  rw [WeierstrassCurve.φ, IsEllipticNet.invarDenom_def]
+  ring
+
+end WeierstrassCurve


### PR DESCRIPTION
The division-polynomial invariant: the quadratic `invar` whose specialisations tie Mathlib's
division polynomials to the EDS invariant layer, with the multiplication law `φ_mul_ψ` that puts
the file on the Nagell–Lutz route.

```lean
-- TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
noncomputable def invar : R[X]                       -- 6X² + b₂X + b₄
theorem invar_def                                     -- the equation lemma (body unexposed)
theorem C_Ψ₃
theorem preΨ₄_add_Ψ₂Sq_sq : W.preΨ₄ + W.Ψ₂Sq ^ 2 = W.invar * W.Ψ₃
theorem preΨ₄_add_ψ₂_pow_four
lemma Affine.CoordinateRing.mk_preΨ₄_add_ψ₂_pow_four  -- the identity mod the curve equation
theorem φ_mul_ψ : W.φ n * W.ψ n = C X * W.ψ n ^ 3 - invarDenom W.ψ 1 n
@[simp] lemma map_invar / lemma baseChange_invar      -- the family's naturality API
```

## Why now

`TauCetiRoadmap/EllipticCurves/README.md` Layer 6 names Nagell–Lutz as the target; the invariant
layer is the measured prerequisite chain (`ω` and the ZSMul anchor consume it). The blocker,
`invarNum`/`invarDenom`, landed in #2860; every Mathlib prerequisite (`Ψ₂Sq`, `Ψ₃`, `preΨ₄`,
`ψ`, `φ`, `b_relation`) was confirmed present on the pin before writing.

## What is deliberately not here

`ω`, `ω_spec`, `two_mul_ω`, `ψc` and their lemmas: `ω`'s definition consumes `redInvarDenom`
and its specification needs `redInvar_normEDS`, i.e. the normEDS-ellipticity machinery. That
port is authorized and decomposed (slices A–C; slice A is `elliptic/eds-relator-alternating`);
`ω` lands with slice C rather than half-stated here. The module docstring's "What is
deliberately not here" section names the blocked chain declaration by declaration.

The file is named `DivisionPolynomial/Invariant.lean` for what it contains — a file called
`Omega.lean` without `ω` would misdescribe itself.

## Adaptations from the source

Two, neither a choice, both recorded in the provenance paragraph: the source proves `φ_mul_ψ`
by `rw [φ, invarDenom]`, which cannot port — `invarDenom`'s body is exported unexposed from
`EllipticDivisibilitySequence/Invariant.lean` (#2860), so the proof goes through the
`invarDenom_def` equation instead (`φ` unfolds as before, being Mathlib's); and the source's
local `C_simp` macro is written out at its three use sites with per-site-trimmed `simp only`
sets — `linter.unusedSimpArgs` is a hard error here, and each site uses a different subset.
The statement of `φ_mul_ψ` was checked against Mathlib's `φ` definition (not assumed): Mathlib
has `φ n = C X * ψ n ^ 2 - ψ (n + 1) * ψ (n - 1)`, which makes the statement true as written.

## Mathlib absence

All five subjects grepped at 0 hits by name and by shape against the DivisionPolynomial and
EllipticDivisibilitySequence modules (`C_Ψ₃`/`preΨ₄_add`/`φ_mul_ψ`/`invar` and the
`6X² + b₂X + b₄` polynomial all absent); the naming follows Mathlib's own `C_Ψ₂Sq` precedent.
The source file's other declarations are already in Mathlib and are consumed, not restated.

## Duplication and gates

No open PR touches `DivisionPolynomial/` or mentions the target id.

Gates, stated precisely, because the branch was rebased mid-flight. Against the Mathlib pin this
work was written on, the full chain passed: `lake build` clean (7733 jobs), `scripts/lint-env.sh`
LINT-ENV: PASS (70 grandfathered, 0 ratchetable), `lake exe axioms` (43703 declarations, allowlist
only), `lake exe module-system` (2078/2078), and a profiled buzz sweep with no declaration over the
100ms reporting threshold. The branch was then rebased onto current `main` to pick up #3069, which
deleted a local `ContinuousLinearMap.IsFredholm.comp` that the newer Mathlib now declares itself —
without that, the sandboxed build fails on `Analysis/Fredholm/Comp.lean`, a file this PR does not
touch. The rebase left this file byte-identical (`git diff` across it is empty) and moved the pin,
so it was rebuilt against the new one: `lake build` of the module and its dependency closure, 1994
jobs, clean. The full-tree audits at this exact head are CI's sandboxed build, which runs that same
chain.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-divpoly-omega"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
