### PR TITLE
feat(ModularForms): the diamond operators are Petersson-unitary, and newness at a fixed nebentypus

### DIFF
--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -12,7 +12,7 @@ public import Mathlib.GroupTheory.Index
 The preimage `H.comap f` of a finite-index subgroup along a group homomorphism again has finite
 index: its index is the relative index of `H` in the range of `f`, which is finite. Adjoining
 the centre to a finite-index subgroup also keeps the index finite, since it only enlarges the
-subgroup, and it enlarges no normaliser either: whatever normalises `Γ` normalises `Γ·Z`.
+subgroup, and it does not shrink the normaliser either: whatever normalises `Γ` normalises `Γ·Z`.
 
 Because the order of a subgroup divides the order of the group -- with the index as cofactor --
 invertibility of the order of a finite group in a semiring passes to every subgroup.
@@ -48,8 +48,9 @@ instance instFiniteIndexWithCenter {G : Type*} [Group G] (Γ : Subgroup G)
     [Γ.FiniteIndex] : Γ.withCenter.FiniteIndex :=
   Subgroup.finiteIndex_of_le Γ.le_withCenter
 
-/-- **Adjoining the centre preserves normalisers.** Conjugation is an automorphism, so it
-distributes over the supremum defining `Γ.withCenter`, and it fixes the centre. -/
+/-- **Everything that normalises `Γ` normalises `Γ` with the centre adjoined.** Conjugation is an
+automorphism, so it distributes over the supremum defining `Γ.withCenter`, and it fixes the
+centre. -/
 theorem normalizer_le_normalizer_withCenter {G : Type*} [Group G] (Γ : Subgroup G) :
     normalizer (Γ : Set G) ≤ normalizer (Γ.withCenter : Set G) := fun g hg ↦ by
   rw [mem_normalizer_iff_map_conj_eq] at hg ⊢

--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -12,7 +12,7 @@ public import Mathlib.GroupTheory.Index
 The preimage `H.comap f` of a finite-index subgroup along a group homomorphism again has finite
 index: its index is the relative index of `H` in the range of `f`, which is finite. Adjoining
 the centre to a finite-index subgroup also keeps the index finite, since it only enlarges the
-subgroup, and it does not shrink the normaliser either: whatever normalises `Γ` normalises `Γ·Z`.
+subgroup.
 
 Because the order of a subgroup divides the order of the group -- with the index as cofactor --
 invertibility of the order of a finite group in a semiring passes to every subgroup.
@@ -47,14 +47,6 @@ lemma le_withCenter {G : Type*} [Group G] (Γ : Subgroup G) : Γ ≤ Γ.withCent
 instance instFiniteIndexWithCenter {G : Type*} [Group G] (Γ : Subgroup G)
     [Γ.FiniteIndex] : Γ.withCenter.FiniteIndex :=
   Subgroup.finiteIndex_of_le Γ.le_withCenter
-
-/-- **Everything that normalises `Γ` normalises `Γ` with the centre adjoined.** Conjugation is an
-automorphism, so it distributes over the supremum defining `Γ.withCenter`, and it fixes the
-centre. -/
-theorem normalizer_le_normalizer_withCenter {G : Type*} [Group G] (Γ : Subgroup G) :
-    normalizer (Γ : Set G) ≤ normalizer (Γ.withCenter : Set G) := fun g hg ↦ by
-  rw [mem_normalizer_iff_map_conj_eq] at hg ⊢
-  rw [withCenter_def, map_sup, hg, Subgroup.Normal.map_conj_eq (Subgroup.center G) g]
 
 end Subgroup
 

--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -12,7 +12,7 @@ public import Mathlib.GroupTheory.Index
 The preimage `H.comap f` of a finite-index subgroup along a group homomorphism again has finite
 index: its index is the relative index of `H` in the range of `f`, which is finite. Adjoining
 the centre to a finite-index subgroup also keeps the index finite, since it only enlarges the
-subgroup.
+subgroup, and it enlarges no normaliser either: whatever normalises `Γ` normalises `Γ·Z`.
 
 Because the order of a subgroup divides the order of the group -- with the index as cofactor --
 invertibility of the order of a finite group in a semiring passes to every subgroup.
@@ -47,6 +47,13 @@ lemma le_withCenter {G : Type*} [Group G] (Γ : Subgroup G) : Γ ≤ Γ.withCent
 instance instFiniteIndexWithCenter {G : Type*} [Group G] (Γ : Subgroup G)
     [Γ.FiniteIndex] : Γ.withCenter.FiniteIndex :=
   Subgroup.finiteIndex_of_le Γ.le_withCenter
+
+/-- **Adjoining the centre preserves normalisers.** Conjugation is an automorphism, so it
+distributes over the supremum defining `Γ.withCenter`, and it fixes the centre. -/
+theorem normalizer_le_normalizer_withCenter {G : Type*} [Group G] (Γ : Subgroup G) :
+    normalizer (Γ : Set G) ≤ normalizer (Γ.withCenter : Set G) := fun g hg ↦ by
+  rw [mem_normalizer_iff_map_conj_eq] at hg ⊢
+  rw [withCenter_def, map_sup, hg, Subgroup.Normal.map_conj_eq (Subgroup.center G) g]
 
 end Subgroup
 

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -45,7 +45,8 @@ infrastructure independent of the diamond operators.
   `Γ(N) ≤ Γ(M)` whenever `M ∣ N`.
 * `CongruenceSubgroup.isUnit_intCast_apply_zero_zero_of_mem_Gamma0`: a `Γ₀(N)` matrix has
   unit upper-left entry modulo `N`.
-* `CongruenceSubgroup.Gamma0_normalizes_Gamma1`: conjugation by `Γ₀(N)` preserves `Γ₁(N)`.
+* `CongruenceSubgroup.Gamma0_normalizes_Gamma1` and
+  `CongruenceSubgroup.Gamma0_le_normalizer_Gamma1`: conjugation by `Γ₀(N)` preserves `Γ₁(N)`.
 * `CongruenceSubgroup.Gamma1_map_le_Gamma0_map`: the inclusion `Γ₁(N) ≤ Γ₀(N)` after mapping to
   `GL₂(ℝ)`.
 * `CongruenceSubgroup.Gamma1_map_inv_conjAct_eq`: `(Gamma1 N).map (mapGL ℝ)` is invariant
@@ -130,6 +131,15 @@ theorem Gamma0_normalizes_Gamma1 (g : ↥(Gamma0 N)) (h : SL(2, ℤ)) (hh : h �
   (Gamma1_mem _ _).mpr <| (Gamma1_to_Gamma0_mem _).mp <|
     (Gamma0Map N).normal_ker.conj_mem ⟨h, Gamma1_in_Gamma0 N hh⟩
       ((Gamma1_to_Gamma0_mem _).mpr ((Gamma1_mem _ _).mp hh)) g
+
+/-- `Γ₀(N)` lies in the normaliser of `Γ₁(N)`: the statement of `Gamma0_normalizes_Gamma1` in
+the form the coset combinatorics of the Petersson product consumes. -/
+theorem Gamma0_le_normalizer_Gamma1 (N : ℕ) :
+    Gamma0 N ≤ Subgroup.normalizer (Gamma1 N : Set SL(2, ℤ)) := fun g hg ↦
+  Subgroup.mem_normalizer_iff.mpr fun h ↦
+    ⟨Gamma0_normalizes_Gamma1 ⟨g, hg⟩ h, fun hh ↦ by
+      simpa [mul_assoc] using
+        Gamma0_normalizes_Gamma1 ⟨g⁻¹, (Gamma0 N).inv_mem hg⟩ _ hh⟩
 
 /-- The inclusion `Γ₁(N) ≤ Γ₀(N)`, transported to `GL₂(ℝ)`. -/
 theorem Gamma1_map_le_Gamma0_map (N : ℕ) :

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
@@ -24,10 +24,11 @@ restriction of a lower-level form (`ofLe_mem_cuspFormsOld`).
 The old subspace is stable under the diamond operators, because `V_d` intertwines them:
 `⟨u⟩` at level `N` acts on `V_d f` as `⟨u mod M⟩` acts on `f`
 (`TauCeti.CuspForm.diamondOpCusp_levelRaise`). This is the lemma behind the fixed-nebentypus
-refinement `S_k(N, χ)ⁿᵉʷ = S_k(Γ₁(N))ⁿᵉʷ ⊓ S_k(N, χ)` of Layer 3 of the ModularForms roadmap;
-that refinement additionally needs the diamond operators to be Petersson-unitary, which is not
-proved here, and neither is the stability of the new subspace under the Hecke operators, whose
-action on forms is Layer 2 and does not yet exist.
+refinement `S_k(N, χ)ⁿᵉʷ = S_k(Γ₁(N))ⁿᵉʷ ⊓ S_k(N, χ)` of Layer 3 of the ModularForms roadmap,
+which additionally needs the diamond operators to be Petersson-unitary and is carried out in
+`TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean`. The stability of the new subspace
+under the Hecke operators is still missing: the Hecke action on forms is Layer 2 of that
+roadmap, and does not yet exist.
 
 ## Main definitions
 
@@ -198,6 +199,11 @@ subspace inside `S_k(Γ₁(N))`. -/
 def cuspFormsNew (N : ℕ) [NeZero N] (k : ℤ) :
     Submodule ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
   CuspForm.peterssonOrthogonal (cuspFormsOld N k)
+
+/-- Defining equation for the sealed `cuspFormsNew`: it is the Petersson-orthogonal complement
+of the old subspace. -/
+lemma cuspFormsNew_def (N : ℕ) [NeZero N] (k : ℤ) :
+    cuspFormsNew N k = CuspForm.peterssonOrthogonal (cuspFormsOld N k) := (rfl)
 
 /-- **Newness is tested on the level-raises.** A cusp form of level `N` is new exactly when it
 is Petersson-orthogonal to `V_d g` for every cusp form `g` of proper divisor level. -/

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.CharacterDecomp
+public import TauCeti.NumberTheory.ModularForms.Newforms.Basic
+public import TauCeti.NumberTheory.ModularForms.Petersson.Unitary
+
+/-!
+# The old and new subspaces at a fixed nebentypus
+
+The old subspace `S_k(Γ₁(N))ᵒˡᵈ` and its Petersson-orthogonal complement, the new subspace
+`S_k(Γ₁(N))ⁿᵉʷ` (`TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean`), are both stable under
+the diamond operators: the old one because the level-raising maps intertwine the diamonds, the
+new one because the diamonds are Petersson-unitary
+(`TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean`). Both therefore decompose along the
+nebentypus character spaces `S_k(N, χ) = cuspFormCharSpace k χ`, and this file records what that
+decomposition says about newness.
+
+The main statement is the *refinement at a fixed nebentypus*: for a cusp form `f ∈ S_k(N, χ)`,
+being new is orthogonality to the old forms **of the same nebentypus** alone,
+
+`f ∈ S_k(Γ₁(N))ⁿᵉʷ ↔ f ⊥ (S_k(Γ₁(N))ᵒˡᵈ ⊓ S_k(N, χ))`,
+
+because old forms of a different nebentypus are automatically orthogonal to `f`. Equivalently,
+in the form Layer 3 of the ModularForms roadmap asks for, the new subspace of `S_k(N, χ)` —
+the orthogonal complement, taken inside `S_k(N, χ)`, of the old forms there — is
+`S_k(Γ₁(N))ⁿᵉʷ ⊓ S_k(N, χ)`: newness may be read at level `Γ₁(N)` and then intersected. The
+old/new decomposition then restricts to each nebentypus space,
+`S_k(N, χ) = S_k(N, χ)ᵒˡᵈ ⊕ S_k(N, χ)ⁿᵉʷ`.
+
+What is *not* proved here is the roadmap's explicit description of the old part of `S_k(N, χ)`
+as `Σ_{M ∣ N, cond χ ∣ M} Σ_{d ∣ N/M} V_d S_k(M, χ_M)`; that identification of
+`S_k(Γ₁(N))ᵒˡᵈ ⊓ S_k(N, χ)` needs the descent of `χ` to the divisor levels, and the conductor
+theory it rests on.
+
+## Main results
+
+* `TauCeti.diamondOpCusp_mem_cuspFormsNew`: the new subspace is diamond-stable.
+* `TauCeti.iSup_inf_cuspFormsOld_cuspFormCharSpace`,
+  `TauCeti.iSup_inf_cuspFormsNew_cuspFormCharSpace`: the old and the new subspace are each the
+  supremum of their nebentypus components, an independent family in both cases.
+* `TauCeti.mem_cuspFormsNew_iff_of_mem_cuspFormCharSpace`: a form of nebentypus `χ` is new
+  exactly when it is orthogonal to the old forms of nebentypus `χ`.
+* `TauCeti.cuspFormsNew_inf_cuspFormCharSpace`: `S_k(N, χ)ⁿᵉʷ = S_k(Γ₁(N))ⁿᵉʷ ⊓ S_k(N, χ)`.
+* `TauCeti.sup_cuspFormsOld_cuspFormsNew_inf_cuspFormCharSpace` and
+  `TauCeti.disjoint_cuspFormsOld_cuspFormsNew_inf_cuspFormCharSpace`: the old/new decomposition
+  of `S_k(N, χ)`.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005],
+  Section 5.6.
+* Miyake, *Modular forms*, Section 4.6.
+-/
+
+public section
+
+open Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup
+
+open scoped MatrixGroups ModularForm
+
+namespace TauCeti
+
+open _root_.CuspForm
+
+variable {N : ℕ} [NeZero N] {k : ℤ} {χ : (ZMod N)ˣ →* ℂˣ}
+
+/-! ### Diamond stability of the new subspace -/
+
+/-- **The new subspace is diamond-stable.** The old subspace is carried onto itself by `⟨u⟩`,
+and `⟨u⟩` is Petersson-unitary, so it preserves the orthogonal complement as well. -/
+theorem diamondOpCusp_mem_cuspFormsNew (u : (ZMod N)ˣ)
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormsNew N k) :
+    diamondOpCusp k u f ∈ cuspFormsNew N k := by
+  rw [cuspFormsNew_def] at hf ⊢
+  exact CuspForm.diamondOpCusp_mem_peterssonOrthogonal
+    (fun _ _ hg ↦ diamondOpCusp_mem_cuspFormsOld _ hg) u hf
+
+/-- The new subspace is diamond-stable, in the `Submodule.map` form. -/
+theorem cuspFormsNew_map_diamondOpCusp_le (u : (ZMod N)ˣ) (k : ℤ) :
+    (cuspFormsNew N k).map (diamondOpCusp k u) ≤ cuspFormsNew N k := by
+  rw [Submodule.map_le_iff_le_comap]
+  exact fun _ hf ↦ diamondOpCusp_mem_cuspFormsNew u hf
+
+/-! ### The nebentypus components of the old and new subspaces -/
+
+/-- **The old subspace is the sum of its nebentypus components.** -/
+theorem iSup_inf_cuspFormsOld_cuspFormCharSpace (N : ℕ) [NeZero N] (k : ℤ) :
+    (⨆ χ : (ZMod N)ˣ →* ℂˣ, cuspFormsOld N k ⊓ cuspFormCharSpace k χ) = cuspFormsOld N k :=
+  iSup_inf_cuspFormCharSpace_of_invariant k _ fun _ _ hf ↦ by
+    rw [diamondOpCuspHom_apply]; exact diamondOpCusp_mem_cuspFormsOld _ hf
+
+/-- **The new subspace is the sum of its nebentypus components.** -/
+theorem iSup_inf_cuspFormsNew_cuspFormCharSpace (N : ℕ) [NeZero N] (k : ℤ) :
+    (⨆ χ : (ZMod N)ˣ →* ℂˣ, cuspFormsNew N k ⊓ cuspFormCharSpace k χ) = cuspFormsNew N k :=
+  iSup_inf_cuspFormCharSpace_of_invariant k _ fun _ _ hf ↦ by
+    rw [diamondOpCuspHom_apply]; exact diamondOpCusp_mem_cuspFormsNew _ hf
+
+/-- The nebentypus components of the old subspace form an independent family, being contained
+in the independent family of nebentypus spaces. -/
+theorem iSupIndep_inf_cuspFormsOld_cuspFormCharSpace (N : ℕ) [NeZero N] (k : ℤ) :
+    iSupIndep fun χ : (ZMod N)ˣ →* ℂˣ ↦ cuspFormsOld N k ⊓ cuspFormCharSpace k χ :=
+  (iSupIndep_cuspFormCharSpace k).mono fun _ ↦ inf_le_right
+
+/-- The nebentypus components of the new subspace form an independent family. -/
+theorem iSupIndep_inf_cuspFormsNew_cuspFormCharSpace (N : ℕ) [NeZero N] (k : ℤ) :
+    iSupIndep fun χ : (ZMod N)ˣ →* ℂˣ ↦ cuspFormsNew N k ⊓ cuspFormCharSpace k χ :=
+  (iSupIndep_cuspFormCharSpace k).mono fun _ ↦ inf_le_right
+
+/-! ### Newness at a fixed nebentypus -/
+
+/-- **Newness is tested against the old forms of the same nebentypus.** A cusp form of
+nebentypus `χ` is new exactly when it is Petersson-orthogonal to the old forms of nebentypus
+`χ`: the old subspace is the sum of its nebentypus components, and the components with
+`ψ ≠ χ` are orthogonal to `f` for free, the nebentypus decomposition being an orthogonal one. -/
+theorem mem_cuspFormsNew_iff_of_mem_cuspFormCharSpace
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) :
+    f ∈ cuspFormsNew N k ↔
+      f ∈ CuspForm.peterssonOrthogonal (cuspFormsOld N k ⊓ cuspFormCharSpace k χ) := by
+  have hold : CuspForm.peterssonOrthogonal (cuspFormsOld N k) =
+      ⨅ ψ : (ZMod N)ˣ →* ℂˣ,
+        CuspForm.peterssonOrthogonal (cuspFormsOld N k ⊓ cuspFormCharSpace k ψ) := by
+    rw [← CuspForm.peterssonOrthogonal_iSup, iSup_inf_cuspFormsOld_cuspFormCharSpace]
+  rw [cuspFormsNew_def, hold, Submodule.mem_iInf]
+  refine ⟨fun h ↦ h χ, fun h ψ ↦ ?_⟩
+  rcases eq_or_ne ψ χ with rfl | hψ
+  · exact h
+  · exact CuspForm.mem_peterssonOrthogonal_iff.mpr fun g hg ↦
+      CuspForm.peterssonInnerCosets_eq_zero_of_ne hψ hg.2 hf
+
+/-- **The new subspace of `S_k(N, χ)`.** The orthogonal complement of the old forms of
+nebentypus `χ`, taken inside `S_k(N, χ)`, is what one gets by intersecting the new subspace of
+`S_k(Γ₁(N))` with `S_k(N, χ)`: newness may be read at level `Γ₁(N)` and then restricted to a
+nebentypus. This is the milestone `S_k(N, χ)ⁿᵉʷ = S_k(Γ₁(N))ⁿᵉʷ ⊓ S_k(N, χ)` of Layer 3 of the
+ModularForms roadmap. -/
+theorem cuspFormsNew_inf_cuspFormCharSpace (N : ℕ) [NeZero N] (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
+    cuspFormsNew N k ⊓ cuspFormCharSpace k χ =
+      CuspForm.peterssonOrthogonal (cuspFormsOld N k ⊓ cuspFormCharSpace k χ) ⊓
+        cuspFormCharSpace k χ := by
+  ext f
+  simp only [Submodule.mem_inf]
+  exact ⟨fun h ↦ ⟨(mem_cuspFormsNew_iff_of_mem_cuspFormCharSpace h.2).mp h.1, h.2⟩,
+    fun h ↦ ⟨(mem_cuspFormsNew_iff_of_mem_cuspFormCharSpace h.2).mpr h.1, h.2⟩⟩
+
+/-- **The old/new decomposition restricts to each nebentypus space**: `S_k(N, χ)` is spanned by
+its old and its new part. Inside `S_k(N, χ)` the two are complementary, by the modular law and
+the completeness of the Petersson-orthogonal complement. -/
+theorem sup_cuspFormsOld_cuspFormsNew_inf_cuspFormCharSpace (N : ℕ) [NeZero N] (k : ℤ)
+    (χ : (ZMod N)ˣ →* ℂˣ) :
+    cuspFormsOld N k ⊓ cuspFormCharSpace k χ ⊔ cuspFormsNew N k ⊓ cuspFormCharSpace k χ =
+      cuspFormCharSpace k χ :=
+  calc cuspFormsOld N k ⊓ cuspFormCharSpace k χ ⊔ cuspFormsNew N k ⊓ cuspFormCharSpace k χ
+      = cuspFormsOld N k ⊓ cuspFormCharSpace k χ ⊔
+          CuspForm.peterssonOrthogonal (cuspFormsOld N k ⊓ cuspFormCharSpace k χ) ⊓
+            cuspFormCharSpace k χ := by
+        rw [cuspFormsNew_inf_cuspFormCharSpace]
+    _ = (cuspFormsOld N k ⊓ cuspFormCharSpace k χ ⊔
+          CuspForm.peterssonOrthogonal (cuspFormsOld N k ⊓ cuspFormCharSpace k χ)) ⊓
+            cuspFormCharSpace k χ := (sup_inf_assoc_of_le _ inf_le_right).symm
+    _ = cuspFormCharSpace k χ := by
+        rw [CuspForm.sup_peterssonOrthogonal_eq_top, top_inf_eq]
+
+/-- **The old and new parts of `S_k(N, χ)` meet only in `0`.** -/
+theorem disjoint_cuspFormsOld_cuspFormsNew_inf_cuspFormCharSpace (N : ℕ) [NeZero N] (k : ℤ)
+    (χ : (ZMod N)ˣ →* ℂˣ) :
+    Disjoint (cuspFormsOld N k ⊓ cuspFormCharSpace k χ)
+      (cuspFormsNew N k ⊓ cuspFormCharSpace k χ) :=
+  (disjoint_cuspFormsOld_cuspFormsNew N k).mono inf_le_left inf_le_left
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
@@ -123,7 +123,7 @@ theorem mem_cuspFormsNew_iff_of_mem_cuspFormCharSpace
   rcases eq_or_ne ψ χ with rfl | hψ
   · exact h
   · exact CuspForm.mem_peterssonOrthogonal_iff.mpr fun g hg ↦
-      CuspForm.peterssonInnerCosets_eq_zero_of_ne hψ hg.2 hf
+      CuspForm.peterssonInnerCosets_eq_zero_of_mem_cuspFormCharSpace_of_ne hψ hg.2 hf
 
 /-- **The new subspace of `S_k(N, χ)`.** The orthogonal complement of the old forms of
 nebentypus `χ`, taken inside `S_k(N, χ)`, is what one gets by intersecting the new subspace of

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
@@ -79,12 +79,6 @@ theorem diamondOpCusp_mem_cuspFormsNew (u : (ZMod N)ˣ)
   exact CuspForm.diamondOpCusp_mem_peterssonOrthogonal
     (fun _ _ hg ↦ diamondOpCusp_mem_cuspFormsOld _ hg) u hf
 
-/-- The new subspace is diamond-stable, in the `Submodule.map` form. -/
-theorem cuspFormsNew_map_diamondOpCusp_le (u : (ZMod N)ˣ) (k : ℤ) :
-    (cuspFormsNew N k).map (diamondOpCusp k u) ≤ cuspFormsNew N k := by
-  rw [Submodule.map_le_iff_le_comap]
-  exact fun _ hf ↦ diamondOpCusp_mem_cuspFormsNew u hf
-
 /-! ### The nebentypus components of the old and new subspaces -/
 
 /-- **The old subspace is the sum of its nebentypus components.** -/

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
@@ -42,9 +42,6 @@ theory it rests on.
 * `TauCeti.iSup_inf_cuspFormsOld_cuspFormCharSpace`,
   `TauCeti.iSup_inf_cuspFormsNew_cuspFormCharSpace`: the old and the new subspace are each the
   supremum of their nebentypus components.
-* `TauCeti.iSupIndep_inf_cuspFormsOld_cuspFormCharSpace`,
-  `TauCeti.iSupIndep_inf_cuspFormsNew_cuspFormCharSpace`: those components form an independent
-  family in both cases.
 * `TauCeti.mem_cuspFormsNew_iff_of_mem_cuspFormCharSpace`: a form of nebentypus `χ` is new
   exactly when it is orthogonal to the old forms of nebentypus `χ`.
 * `TauCeti.cuspFormsNew_inf_cuspFormCharSpace`: `S_k(N, χ)ⁿᵉʷ = S_k(Γ₁(N))ⁿᵉʷ ⊓ S_k(N, χ)`.
@@ -95,17 +92,6 @@ theorem iSup_inf_cuspFormsNew_cuspFormCharSpace (N : ℕ) [NeZero N] (k : ℤ) :
     (⨆ χ : (ZMod N)ˣ →* ℂˣ, cuspFormsNew N k ⊓ cuspFormCharSpace k χ) = cuspFormsNew N k :=
   iSup_inf_cuspFormCharSpace_of_invariant k _ fun _ _ hf ↦ by
     rw [diamondOpCuspHom_apply]; exact diamondOpCusp_mem_cuspFormsNew _ hf
-
-/-- The nebentypus components of the old subspace form an independent family, being contained
-in the independent family of nebentypus spaces. -/
-theorem iSupIndep_inf_cuspFormsOld_cuspFormCharSpace (N : ℕ) [NeZero N] (k : ℤ) :
-    iSupIndep fun χ : (ZMod N)ˣ →* ℂˣ ↦ cuspFormsOld N k ⊓ cuspFormCharSpace k χ :=
-  (iSupIndep_cuspFormCharSpace k).mono fun _ ↦ inf_le_right
-
-/-- The nebentypus components of the new subspace form an independent family. -/
-theorem iSupIndep_inf_cuspFormsNew_cuspFormCharSpace (N : ℕ) [NeZero N] (k : ℤ) :
-    iSupIndep fun χ : (ZMod N)ˣ →* ℂˣ ↦ cuspFormsNew N k ⊓ cuspFormCharSpace k χ :=
-  (iSupIndep_cuspFormCharSpace k).mono fun _ ↦ inf_le_right
 
 /-! ### Newness at a fixed nebentypus -/
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
@@ -41,7 +41,10 @@ theory it rests on.
 * `TauCeti.diamondOpCusp_mem_cuspFormsNew`: the new subspace is diamond-stable.
 * `TauCeti.iSup_inf_cuspFormsOld_cuspFormCharSpace`,
   `TauCeti.iSup_inf_cuspFormsNew_cuspFormCharSpace`: the old and the new subspace are each the
-  supremum of their nebentypus components, an independent family in both cases.
+  supremum of their nebentypus components.
+* `TauCeti.iSupIndep_inf_cuspFormsOld_cuspFormCharSpace`,
+  `TauCeti.iSupIndep_inf_cuspFormsNew_cuspFormCharSpace`: those components form an independent
+  family in both cases.
 * `TauCeti.mem_cuspFormsNew_iff_of_mem_cuspFormCharSpace`: a form of nebentypus `χ` is new
   exactly when it is orthogonal to the old forms of nebentypus `χ`.
 * `TauCeti.cuspFormsNew_inf_cuspFormCharSpace`: `S_k(N, χ)ⁿᵉʷ = S_k(Γ₁(N))ⁿᵉʷ ⊓ S_k(N, χ)`.

--- a/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
@@ -164,8 +164,8 @@ theorem exists_slash_eq_smul_of_mem_withCenter {γ : SL(2, ℤ)} (hγ : γ ∈ �
   rcases hcase with rfl | rfl
   · exact ⟨1, by simp, fun f ↦ by rw [SlashInvariantFormClass.SL_slash_eq f _ hγ', one_smul]⟩
   · refine ⟨(-1 : ℂ) ^ k, ?_, fun f ↦ ?_⟩
-    · rw [show conj ((-1 : ℂ) ^ k) = (-1 : ℂ) ^ k by simp,
-        ← zpow_add₀ (by norm_num : (-1 : ℂ) ≠ 0), ← two_mul, zpow_mul]
+    · have hreal : conj ((-1 : ℂ) ^ k) = (-1 : ℂ) ^ k := by simp
+      rw [hreal, ← zpow_add₀ (by norm_num : (-1 : ℂ) ≠ 0), ← two_mul, zpow_mul]
       norm_num
     · -- the `SL(2, ℤ)` slash action goes through `mapGL ℝ`, which sends `-I` to `-I`
       have hcoe : ((-1 : SL(2, ℤ)) : GL (Fin 2) ℝ) = -1 := mapGL_neg_one

--- a/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
@@ -44,6 +44,8 @@ positive-definite Hermitian form is all that the adjoint theory downstream needs
 ## Main results
 
 * `Subgroup.mem_withCenter_iff`: an element of `Γ·{±I}` is `±` one of `Γ`.
+* `CuspForm.exists_slash_eq_smul_of_mem_withCenter`: slashing by an element of `Γ·{±I}` scales
+  every form by one and the same unimodular constant.
 * `CuspForm.peterssonInner_slash_of_mem_withCenter`: the summand is independent of the coset
   representative, which is what makes the sum well defined.
 * `CuspForm.peterssonInnerCosets_conj_symm`: Hermitian symmetry.
@@ -152,6 +154,25 @@ theorem _root_.Subgroup.mem_withCenter_iff {γ : SL(2, ℤ)} :
       exact Subgroup.withCenter_def Γ ▸ mul_neg_one γ' ▸ Subgroup.mul_mem_sup hγ' hcenter
 
 omit [Γ.FiniteIndex] in
+/-- **Slashing by `Γ·{±I}` scales every form by one and the same unimodular constant**: by `1`
+on `Γ` itself, where the forms are invariant, and by `(-1)^k` on its negatives, since `-I` acts
+trivially on `ℍ` and contributes only the automorphy factor. Unimodularity `conj c * c = 1` is
+what makes the constant invisible to the conjugate-linear Petersson pairing. -/
+theorem exists_slash_eq_smul_of_mem_withCenter {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) :
+    ∃ c : ℂ, conj c * c = 1 ∧ ∀ f : CuspForm (Γ.map (mapGL ℝ)) k, ⇑f ∣[k] γ = c • ⇑f := by
+  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff.mp hγ
+  rcases hcase with rfl | rfl
+  · exact ⟨1, by simp, fun f ↦ by rw [SlashInvariantFormClass.SL_slash_eq f _ hγ', one_smul]⟩
+  · refine ⟨(-1 : ℂ) ^ k, ?_, fun f ↦ ?_⟩
+    · rw [show conj ((-1 : ℂ) ^ k) = (-1 : ℂ) ^ k by simp,
+        ← zpow_add₀ (by norm_num : (-1 : ℂ) ≠ 0), ← two_mul, zpow_mul]
+      norm_num
+    · -- the `SL(2, ℤ)` slash action goes through `mapGL ℝ`, which sends `-I` to `-I`
+      have hcoe : ((-1 : SL(2, ℤ)) : GL (Fin 2) ℝ) = -1 := mapGL_neg_one
+      rw [← mul_neg_one γ', SlashAction.slash_mul, ModularForm.SL_slash (γ := (-1 : SL(2, ℤ))),
+        hcoe, ModularForm.slash_neg_one, SlashInvariantFormClass.SL_slash_eq f _ hγ']
+
+omit [Γ.FiniteIndex] in
 /-- **The summand does not depend on the coset representative**: the level-one-domain pairing
 is unchanged by slashing with `Γ·{±I}`. The `Γ` part fixes a `Γ`-invariant form, and `-I`
 scales it by the real sign `(-1)^k`, which the conjugate-linear pairing cancels against
@@ -159,23 +180,9 @@ itself. This is what lets the defining sum be reindexed over the coset space. -/
 theorem peterssonInner_slash_of_mem_withCenter
     (f g : CuspForm (Γ.map (mapGL ℝ)) k) {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) :
     UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] γ) (⇑g ∣[k] γ) = peterssonInnerFd f g := by
-  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff.mp hγ
-  rcases hcase with rfl | rfl
-  · rw [SlashInvariantFormClass.SL_slash_eq f _ hγ',
-      SlashInvariantFormClass.SL_slash_eq g _ hγ', peterssonInnerFd_def]
-  · -- the `SL(2, ℤ)` slash action goes through `mapGL ℝ`, which sends `-I` to `-I`
-    have hcoe : ((-1 : SL(2, ℤ)) : GL (Fin 2) ℝ) = -1 := mapGL_neg_one
-    have hneg : ∀ h : ℍ → ℂ, h ∣[k] (-γ') = (-1 : ℂ) ^ k • (h ∣[k] γ') := fun h ↦ by
-      rw [← mul_neg_one γ', SlashAction.slash_mul, ModularForm.SL_slash (γ := (-1 : SL(2, ℤ))),
-        hcoe, ModularForm.slash_neg_one]
-    rw [hneg, hneg, SlashInvariantFormClass.SL_slash_eq f _ hγ',
-      SlashInvariantFormClass.SL_slash_eq g _ hγ',
-      peterssonInner_smul_right, peterssonInner_smul_left, peterssonInnerFd_def]
-    have hreal : (starRingEnd ℂ) ((-1 : ℂ) ^ k) = (-1 : ℂ) ^ k := by simp
-    have hsq : ((-1 : ℂ) ^ k) * ((-1 : ℂ) ^ k) = 1 := by
-      rw [← zpow_add₀ (by norm_num : (-1 : ℂ) ≠ 0), ← two_mul, zpow_mul]
-      norm_num
-    rw [hreal, ← mul_assoc, hsq, one_mul]
+  obtain ⟨c, hc, hslash⟩ := exists_slash_eq_smul_of_mem_withCenter (k := k) hγ
+  rw [hslash f, hslash g, peterssonInner_smul_left, peterssonInner_smul_right, ← mul_assoc, hc,
+    one_mul, peterssonInnerFd_def]
 
 omit [Γ.FiniteIndex] in
 /-- Each summand of the self-pairing is a non-negative real: the integrand is

--- a/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
@@ -12,8 +12,8 @@ public import TauCeti.NumberTheory.ModularForms.Petersson.Orthogonal
 
 The Petersson product `CuspForm.peterssonInnerCosets` on `S_k(Γ)` is a sum over the cosets of
 `Γ·{±I}` in `SL₂(ℤ)` of level-one-domain pairings of slashed forms. Slashing both arguments by
-an `α ∈ SL₂(ℤ)` that *normalises* `Γ` permutes those cosets — right multiplication by `α⁻¹` is
-a well-defined permutation of `SL₂(ℤ)/Γ·{±I}` exactly because `α` normalises the group — so it
+an `α ∈ SL₂(ℤ)` that *normalises* `Γ·{±I}` permutes those cosets — right multiplication by `α⁻¹`
+is a well-defined permutation of `SL₂(ℤ)/Γ·{±I}` exactly because `α` normalises the group — so it
 leaves the whole sum unchanged: such a slash is **unitary** for the Petersson product.
 
 The case this roadmap needs is `Γ = Γ₁(N)` and `α ∈ Γ₀(N)`, that is, the **diamond operators**
@@ -28,12 +28,13 @@ Petersson-orthogonal, since the diamond eigenvalues `χ(d)` are roots of unity: 
 ## Main results
 
 * `TauCeti.CuspForm.peterssonInnerCosets_slash`: the Petersson product is unchanged by slashing
-  both arguments with an element of the normaliser of `Γ`.
+  both arguments with an element of the normaliser of `Γ·{±I}`.
 * `TauCeti.CuspForm.peterssonInnerCosets_diamondOpCusp`: the diamond operators are
   Petersson-unitary.
 * `TauCeti.CuspForm.diamondOpCusp_mem_peterssonOrthogonal`: the Petersson-orthogonal complement
   of a diamond-stable subspace is diamond-stable.
-* `TauCeti.CuspForm.peterssonInnerCosets_eq_zero_of_ne` and its submodule form
+* `TauCeti.CuspForm.peterssonInnerCosets_eq_zero_of_mem_cuspFormCharSpace_of_ne` and its
+  submodule form
   `TauCeti.CuspForm.cuspFormCharSpace_le_peterssonOrthogonal_of_ne`: cusp forms with distinct
   nebentypus characters are Petersson-orthogonal, so the nebentypus decomposition of
   `S_k(Γ₁(N))` is an orthogonal one.
@@ -122,42 +123,48 @@ private theorem peterssonInner_slash_inv_out (f g : CuspForm (Γ.map (mapGL ℝ)
   rwa [← SlashAction.slash_mul, ← SlashAction.slash_mul, hcancel] at h
 
 /-- **The Petersson product is unitary under a normalising slash.** If `α ∈ SL₂(ℤ)` normalises
-`Γ` and the slashes `f ∣[k] α`, `g ∣[k] α` are again cusp forms `F`, `G` for `Γ`, then
+`Γ·{±I}` and the slashes `f ∣[k] α`, `g ∣[k] α` are again cusp forms `F`, `G` for `Γ`, then
 `⟪F, G⟫ = ⟪f, g⟫`: right multiplication by `α⁻¹` permutes the cosets of `Γ·{±I}` indexing the
 defining sum, and the summands match up term by term.
+
+It is `Γ·{±I}`, not `Γ`, that the hypothesis constrains, that being the group whose cosets the
+sum runs over; an `α` normalising `Γ` normalises `Γ·{±I}` too, by
+`Subgroup.normalizer_le_normalizer_sup_normal`.
 
 The forms `F` and `G` are taken as data with their defining equations, rather than built here,
 because the operators that arise this way — the diamond operators of Layer 0, the Atkin–Lehner
 involutions later — each package the slashed function as a cusp form in their own way. -/
 theorem peterssonInnerCosets_slash {α : SL(2, ℤ)}
-    (hα : α ∈ Subgroup.normalizer (Γ : Set SL(2, ℤ)))
+    (hα : α ∈ Subgroup.normalizer (Γ.withCenter : Set SL(2, ℤ)))
     {f g F G : CuspForm (Γ.map (mapGL ℝ)) k} (hF : ⇑F = ⇑f ∣[k] α) (hG : ⇑G = ⇑g ∣[k] α) :
     peterssonInnerCosets F G = peterssonInnerCosets f g := by
-  have hαW : α ∈ Subgroup.normalizer (Γ.withCenter : Set SL(2, ℤ)) := by
-    rw [Subgroup.withCenter_def]
-    exact Subgroup.normalizer_le_normalizer_sup_normal hα
   have hsummand : ∀ q : SL(2, ℤ) ⧸ Γ.withCenter,
       UpperHalfPlane.peterssonInner k fd (⇑F ∣[k] (q.out)⁻¹) (⇑G ∣[k] (q.out)⁻¹) =
-        UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] ((cosetRightMul hαW q).out)⁻¹)
-          (⇑g ∣[k] ((cosetRightMul hαW q).out)⁻¹) := fun q ↦ by
+        UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] ((cosetRightMul hα q).out)⁻¹)
+          (⇑g ∣[k] ((cosetRightMul hα q).out)⁻¹) := fun q ↦ by
     have hinv : (q.out * α⁻¹)⁻¹ = α * (q.out)⁻¹ := by group
-    rw [cosetRightMul_apply hαW q, peterssonInner_slash_inv_out f g (q.out * α⁻¹), hF, hG,
+    rw [cosetRightMul_apply hα q, peterssonInner_slash_inv_out f g (q.out * α⁻¹), hF, hG,
       ← SlashAction.slash_mul, ← SlashAction.slash_mul, hinv]
   rw [peterssonInnerCosets_def, peterssonInnerCosets_def, Finset.sum_congr rfl fun q _ ↦ hsummand q]
-  exact Fintype.sum_equiv (cosetRightMul hαW) _ _ fun _ ↦ rfl
+  exact Fintype.sum_equiv (cosetRightMul hα) _ _ fun _ ↦ rfl
 
 /-! ### The diamond operators are unitary -/
 
 variable {N : ℕ} [NeZero N]
 
 /-- **The diamond operators are Petersson-unitary**: `⟪⟨d⟩f, ⟨d⟩g⟫ = ⟪f, g⟫`. The operator
-`⟨d⟩` is slashing by a representative of `d` in `Γ₀(N)`, and `Γ₀(N)` normalises `Γ₁(N)`. -/
+`⟨d⟩` is slashing by a representative of `d` in `Γ₀(N)`, and `Γ₀(N)` normalises `Γ₁(N)`, hence
+also `Γ₁(N)·{±I}`. -/
+@[simp]
 theorem peterssonInnerCosets_diamondOpCusp (k : ℤ) (d : (ZMod N)ˣ)
     (f g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
     peterssonInnerCosets (diamondOpCusp k d f) (diamondOpCusp k d g) =
       peterssonInnerCosets f g := by
   obtain ⟨γ, hγ⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
-  exact peterssonInnerCosets_slash (Gamma0_le_normalizer_Gamma1 N γ.2)
+  have hnorm : (γ : SL(2, ℤ)) ∈ Subgroup.normalizer ((Gamma1 N).withCenter : Set SL(2, ℤ)) := by
+    rw [Subgroup.withCenter_def]
+    exact Subgroup.normalizer_le_normalizer_sup_normal (Gamma0_le_normalizer_Gamma1 N γ.2)
+  exact peterssonInnerCosets_slash hnorm
     (coe_diamondOpCusp k d γ hγ f) (coe_diamondOpCusp k d γ hγ g)
 
 /-- **The Petersson-orthogonal complement of a diamond-stable subspace is diamond-stable.**
@@ -192,7 +199,8 @@ operators are unitary and act on the two forms by the scalars `χ(d)` and `ψ(d)
 is multiplied by `conj (χ d) * ψ d`; at a `d` where the characters differ this scalar is not `1`,
 the values being unimodular. Hence the nebentypus decomposition of `S_k(Γ₁(N))` is an orthogonal
 decomposition. -/
-theorem peterssonInnerCosets_eq_zero_of_ne {k : ℤ} {χ ψ : (ZMod N)ˣ →* ℂˣ} (hne : χ ≠ ψ)
+theorem peterssonInnerCosets_eq_zero_of_mem_cuspFormCharSpace_of_ne {k : ℤ}
+    {χ ψ : (ZMod N)ˣ →* ℂˣ} (hne : χ ≠ ψ)
     {f g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ)
     (hg : g ∈ cuspFormCharSpace k ψ) : peterssonInnerCosets f g = 0 := by
   obtain ⟨d, hd⟩ : ∃ d, χ d ≠ ψ d := by
@@ -215,11 +223,13 @@ theorem peterssonInnerCosets_eq_zero_of_ne {k : ℤ} {χ ψ : (ZMod N)ˣ →* �
   · exact h
 
 /-- **The nebentypus decomposition of `S_k(Γ₁(N))` is orthogonal**: distinct nebentypus spaces
-are Petersson-orthogonal, the submodule form of `peterssonInnerCosets_eq_zero_of_ne`. -/
+are Petersson-orthogonal, the submodule form of
+`peterssonInnerCosets_eq_zero_of_mem_cuspFormCharSpace_of_ne`. -/
 theorem cuspFormCharSpace_le_peterssonOrthogonal_of_ne {k : ℤ} {χ ψ : (ZMod N)ˣ →* ℂˣ}
     (hne : χ ≠ ψ) :
     cuspFormCharSpace k ψ ≤ peterssonOrthogonal (cuspFormCharSpace (N := N) k χ) := fun _ hg ↦
-  mem_peterssonOrthogonal_iff.mpr fun _ hf ↦ peterssonInnerCosets_eq_zero_of_ne hne hf hg
+  mem_peterssonOrthogonal_iff.mpr fun _ hf ↦
+    peterssonInnerCosets_eq_zero_of_mem_cuspFormCharSpace_of_ne hne hf hg
 
 end CuspForm
 

--- a/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.DiamondOperators
+public import TauCeti.NumberTheory.ModularForms.Petersson.Orthogonal
+
+/-!
+# The Petersson product is unitary under a normalising slash
+
+The Petersson product `CuspForm.peterssonInnerCosets` on `S_k(Γ)` is a sum over the cosets of
+`Γ·{±I}` in `SL₂(ℤ)` of level-one-domain pairings of slashed forms. Slashing both arguments by
+an `α ∈ SL₂(ℤ)` that *normalises* `Γ` permutes those cosets — right multiplication by `α⁻¹` is
+a well-defined permutation of `SL₂(ℤ)/Γ·{±I}` exactly because `α` normalises the group — so it
+leaves the whole sum unchanged: such a slash is **unitary** for the Petersson product.
+
+The case this roadmap needs is `Γ = Γ₁(N)` and `α ∈ Γ₀(N)`, that is, the **diamond operators**
+`⟨d⟩` of `TauCeti/NumberTheory/ModularForms/DiamondOperators.lean`: `⟪⟨d⟩f, ⟨d⟩g⟫ = ⟪f, g⟫`.
+Two consequences carry Layer 3 of the ModularForms roadmap forward. First, the
+Petersson-orthogonal complement of a diamond-stable subspace is again diamond-stable — the
+diamonds form a *group* of unitaries, so a stable subspace is mapped *onto* itself, which is
+what an orthogonal complement needs. Second, cusp forms with distinct nebentypus characters are
+Petersson-orthogonal, since the diamond eigenvalues `χ(d)` are roots of unity: unitarity turns
+`⟪f, g⟫` into `conj (χ d) * ψ d * ⟪f, g⟫`, and the scalar differs from `1` at some `d`.
+
+## Main results
+
+* `TauCeti.CuspForm.peterssonInnerCosets_slash`: the Petersson product is unchanged by slashing
+  both arguments with an element of the normaliser of `Γ`.
+* `TauCeti.CuspForm.peterssonInnerCosets_diamondOpCusp`: the diamond operators are
+  Petersson-unitary.
+* `TauCeti.CuspForm.diamondOpCusp_mem_peterssonOrthogonal`: the Petersson-orthogonal complement
+  of a diamond-stable subspace is diamond-stable.
+* `TauCeti.CuspForm.peterssonInnerCosets_eq_zero_of_ne` and its submodule form
+  `TauCeti.CuspForm.cuspFormCharSpace_le_peterssonOrthogonal_of_ne`: cusp forms with distinct
+  nebentypus characters are Petersson-orthogonal, so the nebentypus decomposition of
+  `S_k(Γ₁(N))` is an orthogonal one.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005],
+  Section 5.5.
+* Miyake, *Modular forms*, Section 4.5.
+-/
+
+public section
+
+open Matrix.SpecialLinearGroup UpperHalfPlane ModularGroup CongruenceSubgroup
+
+open scoped MatrixGroups ModularForm ComplexConjugate
+
+namespace TauCeti
+
+open _root_.CuspForm
+
+namespace CuspForm
+
+variable {Γ : Subgroup SL(2, ℤ)} [Γ.FiniteIndex] {k : ℤ}
+
+/-! ### Slashing by a normalising element -/
+
+/-- Right multiplication by an element normalising `Γ·{±I}`, as a permutation of the coset space
+`SL₂(ℤ)/Γ·{±I}`. Right multiplication is well defined on left cosets precisely because
+`α (Γ·{±I}) α⁻¹ = Γ·{±I}`; this permutation is the reindexing behind
+`peterssonInnerCosets_slash`. -/
+private def cosetRightMul {α : SL(2, ℤ)}
+    (hα : α ∈ Subgroup.normalizer (Γ.withCenter : Set SL(2, ℤ))) :
+    SL(2, ℤ) ⧸ Γ.withCenter ≃ SL(2, ℤ) ⧸ Γ.withCenter where
+  toFun := Quotient.map' (· * α⁻¹) fun a b hab ↦ by
+    rw [QuotientGroup.leftRel_apply] at hab ⊢
+    have h := (Subgroup.mem_normalizer_iff.mp hα (a⁻¹ * b)).mp hab
+    simpa only [show (a * α⁻¹)⁻¹ * (b * α⁻¹) = α * (a⁻¹ * b) * α⁻¹ by group] using h
+  invFun := Quotient.map' (· * α) fun a b hab ↦ by
+    rw [QuotientGroup.leftRel_apply] at hab ⊢
+    have h := (Subgroup.mem_normalizer_iff''.mp hα (a⁻¹ * b)).mp hab
+    simpa only [show (a * α)⁻¹ * (b * α) = α⁻¹ * (a⁻¹ * b) * α by group] using h
+  left_inv q := by
+    induction q using QuotientGroup.induction_on
+    simp only [Quotient.map'_mk'', inv_mul_cancel_right]
+  right_inv q := by
+    induction q using QuotientGroup.induction_on
+    simp only [Quotient.map'_mk'', mul_inv_cancel_right]
+
+omit [Γ.FiniteIndex] in
+private lemma cosetRightMul_apply {α : SL(2, ℤ)}
+    (hα : α ∈ Subgroup.normalizer (Γ.withCenter : Set SL(2, ℤ)))
+    (q : SL(2, ℤ) ⧸ Γ.withCenter) :
+    cosetRightMul hα q = (QuotientGroup.mk (q.out * α⁻¹) : SL(2, ℤ) ⧸ Γ.withCenter) := by
+  conv_lhs => rw [← Quotient.out_eq q]
+  rfl
+
+omit [Γ.FiniteIndex] in
+/-- Slashing by an element of `Γ·{±I}` is invisible to the level-one-domain pairing, even after
+a further slash: the two forms pick up the same unimodular constant, and the pairing is
+conjugate-linear in one argument and linear in the other. -/
+theorem peterssonInner_slash_slash_of_mem_withCenter (f g : CuspForm (Γ.map (mapGL ℝ)) k)
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) (β : SL(2, ℤ)) :
+    UpperHalfPlane.peterssonInner k fd ((⇑f ∣[k] γ) ∣[k] β) ((⇑g ∣[k] γ) ∣[k] β) =
+      UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] β) (⇑g ∣[k] β) := by
+  obtain ⟨c, hc, hslash⟩ := exists_slash_eq_smul_of_mem_withCenter (k := k) hγ
+  rw [hslash f, hslash g, ModularForm.SL_smul_slash, ModularForm.SL_smul_slash,
+    peterssonInner_smul_left, peterssonInner_smul_right, ← mul_assoc, hc, one_mul]
+
+omit [Γ.FiniteIndex] in
+/-- **The summand of the Petersson product is a function of the coset.** Replacing the chosen
+representative `q.out` of a coset by any other element of it does not change the level-one-domain
+pairing of the correspondingly slashed forms. -/
+theorem peterssonInner_slash_inv_out (f g : CuspForm (Γ.map (mapGL ℝ)) k) (δ : SL(2, ℤ)) :
+    UpperHalfPlane.peterssonInner k fd
+        (⇑f ∣[k] ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹)
+        (⇑g ∣[k] ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹) =
+      UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] δ⁻¹) (⇑g ∣[k] δ⁻¹) := by
+  have hmem : ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹ * δ ∈ Γ.withCenter :=
+    QuotientGroup.eq.mp (Quotient.out_eq _)
+  have h := peterssonInner_slash_slash_of_mem_withCenter f g hmem δ⁻¹
+  rwa [← SlashAction.slash_mul, ← SlashAction.slash_mul,
+    show ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹ * δ * δ⁻¹ =
+      ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹ by group] at h
+
+/-- **The Petersson product is unitary under a normalising slash.** If `α ∈ SL₂(ℤ)` normalises
+`Γ` and the slashes `f ∣[k] α`, `g ∣[k] α` are again cusp forms `F`, `G` for `Γ`, then
+`⟪F, G⟫ = ⟪f, g⟫`: right multiplication by `α⁻¹` permutes the cosets of `Γ·{±I}` indexing the
+defining sum, and the summands match up term by term.
+
+The forms `F` and `G` are taken as data with their defining equations, rather than built here,
+because the operators that arise this way — the diamond operators of Layer 0, the Atkin–Lehner
+involutions later — each package the slashed function as a cusp form in their own way. -/
+theorem peterssonInnerCosets_slash {α : SL(2, ℤ)}
+    (hα : α ∈ Subgroup.normalizer (Γ : Set SL(2, ℤ)))
+    {f g F G : CuspForm (Γ.map (mapGL ℝ)) k} (hF : ⇑F = ⇑f ∣[k] α) (hG : ⇑G = ⇑g ∣[k] α) :
+    peterssonInnerCosets F G = peterssonInnerCosets f g := by
+  have hαW : α ∈ Subgroup.normalizer (Γ.withCenter : Set SL(2, ℤ)) :=
+    Subgroup.normalizer_le_normalizer_withCenter Γ hα
+  have hsummand : ∀ q : SL(2, ℤ) ⧸ Γ.withCenter,
+      UpperHalfPlane.peterssonInner k fd (⇑F ∣[k] (q.out)⁻¹) (⇑G ∣[k] (q.out)⁻¹) =
+        UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] ((cosetRightMul hαW q).out)⁻¹)
+          (⇑g ∣[k] ((cosetRightMul hαW q).out)⁻¹) := fun q ↦ by
+    rw [cosetRightMul_apply hαW q, peterssonInner_slash_inv_out f g (q.out * α⁻¹), hF, hG,
+      ← SlashAction.slash_mul, ← SlashAction.slash_mul,
+      show (q.out * α⁻¹)⁻¹ = α * (q.out)⁻¹ by group]
+  rw [peterssonInnerCosets_def, peterssonInnerCosets_def, Finset.sum_congr rfl fun q _ ↦ hsummand q]
+  exact Fintype.sum_equiv (cosetRightMul hαW) _ _ fun _ ↦ rfl
+
+/-! ### The diamond operators are unitary -/
+
+variable {N : ℕ} [NeZero N]
+
+/-- **The diamond operators are Petersson-unitary**: `⟪⟨d⟩f, ⟨d⟩g⟫ = ⟪f, g⟫`. The operator
+`⟨d⟩` is slashing by a representative of `d` in `Γ₀(N)`, and `Γ₀(N)` normalises `Γ₁(N)`. -/
+theorem peterssonInnerCosets_diamondOpCusp (k : ℤ) (d : (ZMod N)ˣ)
+    (f g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    peterssonInnerCosets (diamondOpCusp k d f) (diamondOpCusp k d g) =
+      peterssonInnerCosets f g := by
+  obtain ⟨γ, hγ⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
+  exact peterssonInnerCosets_slash (Gamma0_le_normalizer_Gamma1 N γ.2)
+    (coe_diamondOpCusp k d γ hγ f) (coe_diamondOpCusp k d γ hγ g)
+
+/-- **The Petersson-orthogonal complement of a diamond-stable subspace is diamond-stable.**
+Unitarity alone would not suffice: what is used is that the diamonds form a *group*, so a stable
+subspace `V` is carried *onto* itself by `⟨d⟩`, and every `g ∈ V` is `⟨d⟩` of the element
+`⟨d⁻¹⟩ g` of `V`. -/
+theorem diamondOpCusp_mem_peterssonOrthogonal {k : ℤ}
+    {V : Submodule ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k)}
+    (hV : ∀ u : (ZMod N)ˣ, ∀ f ∈ V, diamondOpCusp k u f ∈ V) (d : (ZMod N)ˣ)
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ peterssonOrthogonal V) :
+    diamondOpCusp k d f ∈ peterssonOrthogonal V := by
+  refine mem_peterssonOrthogonal_iff.mpr fun g hg ↦ ?_
+  have hgd : diamondOpCusp k d (diamondOpCusp k d⁻¹ g) = g := by
+    rw [← LinearMap.comp_apply, ← diamondOpCusp_mul, mul_inv_cancel, diamondOpCusp_one,
+      LinearMap.id_apply]
+  rw [← hgd, peterssonInnerCosets_diamondOpCusp k d (diamondOpCusp k d⁻¹ g) f]
+  exact mem_peterssonOrthogonal_iff.mp hf _ (hV d⁻¹ g hg)
+
+/-! ### Distinct nebentypus characters are orthogonal -/
+
+/-- A character of the finite group `(ZMod N)ˣ` takes unimodular values. -/
+private lemma conj_mul_char_eq_one (χ : (ZMod N)ˣ →* ℂˣ) (d : (ZMod N)ˣ) :
+    conj (χ d : ℂ) * (χ d : ℂ) = 1 := by
+  have hpow : ((χ d : ℂ)) ^ Nat.card (ZMod N)ˣ = 1 := by
+    rw [← Units.val_pow_eq_pow_val, ← map_pow, pow_card_eq_one', map_one, Units.val_one]
+  have hnorm : ‖(χ d : ℂ)‖ = 1 := Complex.norm_eq_one_of_pow_eq_one hpow Nat.card_pos.ne'
+  rw [RCLike.conj_mul, hnorm]
+  norm_num
+
+/-- **Cusp forms with distinct nebentypus characters are Petersson-orthogonal.** The diamond
+operators are unitary and act on the two forms by the scalars `χ(d)` and `ψ(d)`, so the pairing
+is multiplied by `conj (χ d) * ψ d`; at a `d` where the characters differ this scalar is not `1`,
+the values being unimodular. Hence the nebentypus decomposition of `S_k(Γ₁(N))` is an orthogonal
+decomposition. -/
+theorem peterssonInnerCosets_eq_zero_of_ne {k : ℤ} {χ ψ : (ZMod N)ˣ →* ℂˣ} (hne : χ ≠ ψ)
+    {f g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ)
+    (hg : g ∈ cuspFormCharSpace k ψ) : peterssonInnerCosets f g = 0 := by
+  obtain ⟨d, hd⟩ : ∃ d, χ d ≠ ψ d := by
+    by_contra hcon
+    exact hne (MonoidHom.ext fun d ↦ not_not.mp fun h ↦ hcon ⟨d, h⟩)
+  have hscal : conj (χ d : ℂ) * (ψ d : ℂ) ≠ 1 := fun h ↦ hd <| Units.ext <| by
+    have h2 : (χ d : ℂ) * (conj (χ d : ℂ) * (ψ d : ℂ)) = (χ d : ℂ) * 1 := by rw [h]
+    rwa [← mul_assoc, mul_comm (χ d : ℂ) (conj (χ d : ℂ)), conj_mul_char_eq_one, one_mul,
+      mul_one, eq_comm] at h2
+  have key : peterssonInnerCosets f g =
+      conj (χ d : ℂ) * (ψ d : ℂ) * peterssonInnerCosets f g := by
+    conv_lhs => rw [← peterssonInnerCosets_diamondOpCusp k d f g]
+    rw [diamondOpCusp_apply_of_mem_cuspFormCharSpace k χ d hf,
+      diamondOpCusp_apply_of_mem_cuspFormCharSpace k ψ d hg,
+      peterssonInnerCosets_smul_left, peterssonInnerCosets_smul_right, ← mul_assoc]
+  rcases mul_eq_zero.mp (show (1 - conj (χ d : ℂ) * (ψ d : ℂ)) * peterssonInnerCosets f g = 0 by
+    rw [sub_mul, one_mul, ← key, sub_self]) with h | h
+  · exact absurd (sub_eq_zero.mp h).symm hscal
+  · exact h
+
+/-- **The nebentypus decomposition of `S_k(Γ₁(N))` is orthogonal**: distinct nebentypus spaces
+are Petersson-orthogonal, the submodule form of `peterssonInnerCosets_eq_zero_of_ne`. -/
+theorem cuspFormCharSpace_le_peterssonOrthogonal_of_ne {k : ℤ} {χ ψ : (ZMod N)ˣ →* ℂˣ}
+    (hne : χ ≠ ψ) :
+    cuspFormCharSpace k ψ ≤ peterssonOrthogonal (cuspFormCharSpace (N := N) k χ) := fun _ hg ↦
+  mem_peterssonOrthogonal_iff.mpr fun _ hf ↦ peterssonInnerCosets_eq_zero_of_ne hne hf hg
+
+end CuspForm
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
@@ -133,8 +133,9 @@ theorem peterssonInnerCosets_slash {α : SL(2, ℤ)}
     (hα : α ∈ Subgroup.normalizer (Γ : Set SL(2, ℤ)))
     {f g F G : CuspForm (Γ.map (mapGL ℝ)) k} (hF : ⇑F = ⇑f ∣[k] α) (hG : ⇑G = ⇑g ∣[k] α) :
     peterssonInnerCosets F G = peterssonInnerCosets f g := by
-  have hαW : α ∈ Subgroup.normalizer (Γ.withCenter : Set SL(2, ℤ)) :=
-    Subgroup.normalizer_le_normalizer_withCenter Γ hα
+  have hαW : α ∈ Subgroup.normalizer (Γ.withCenter : Set SL(2, ℤ)) := by
+    rw [Subgroup.withCenter_def]
+    exact Subgroup.normalizer_le_normalizer_sup_normal hα
   have hsummand : ∀ q : SL(2, ℤ) ⧸ Γ.withCenter,
       UpperHalfPlane.peterssonInner k fd (⇑F ∣[k] (q.out)⁻¹) (⇑G ∣[k] (q.out)⁻¹) =
         UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] ((cosetRightMul hαW q).out)⁻¹)

--- a/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
@@ -71,11 +71,13 @@ private def cosetRightMul {α : SL(2, ℤ)}
   toFun := Quotient.map' (· * α⁻¹) fun a b hab ↦ by
     rw [QuotientGroup.leftRel_apply] at hab ⊢
     have h := (Subgroup.mem_normalizer_iff.mp hα (a⁻¹ * b)).mp hab
-    simpa only [show (a * α⁻¹)⁻¹ * (b * α⁻¹) = α * (a⁻¹ * b) * α⁻¹ by group] using h
+    have hconj : (a * α⁻¹)⁻¹ * (b * α⁻¹) = α * (a⁻¹ * b) * α⁻¹ := by group
+    simpa only [hconj] using h
   invFun := Quotient.map' (· * α) fun a b hab ↦ by
     rw [QuotientGroup.leftRel_apply] at hab ⊢
     have h := (Subgroup.mem_normalizer_iff''.mp hα (a⁻¹ * b)).mp hab
-    simpa only [show (a * α)⁻¹ * (b * α) = α⁻¹ * (a⁻¹ * b) * α by group] using h
+    have hconj : (a * α)⁻¹ * (b * α) = α⁻¹ * (a⁻¹ * b) * α := by group
+    simpa only [hconj] using h
   left_inv q := by
     induction q using QuotientGroup.induction_on
     simp only [Quotient.map'_mk'', inv_mul_cancel_right]
@@ -95,7 +97,7 @@ omit [Γ.FiniteIndex] in
 /-- Slashing by an element of `Γ·{±I}` is invisible to the level-one-domain pairing, even after
 a further slash: the two forms pick up the same unimodular constant, and the pairing is
 conjugate-linear in one argument and linear in the other. -/
-theorem peterssonInner_slash_slash_of_mem_withCenter (f g : CuspForm (Γ.map (mapGL ℝ)) k)
+private theorem peterssonInner_slash_slash_of_mem_withCenter (f g : CuspForm (Γ.map (mapGL ℝ)) k)
     {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) (β : SL(2, ℤ)) :
     UpperHalfPlane.peterssonInner k fd ((⇑f ∣[k] γ) ∣[k] β) ((⇑g ∣[k] γ) ∣[k] β) =
       UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] β) (⇑g ∣[k] β) := by
@@ -107,7 +109,7 @@ omit [Γ.FiniteIndex] in
 /-- **The summand of the Petersson product is a function of the coset.** Replacing the chosen
 representative `q.out` of a coset by any other element of it does not change the level-one-domain
 pairing of the correspondingly slashed forms. -/
-theorem peterssonInner_slash_inv_out (f g : CuspForm (Γ.map (mapGL ℝ)) k) (δ : SL(2, ℤ)) :
+private theorem peterssonInner_slash_inv_out (f g : CuspForm (Γ.map (mapGL ℝ)) k) (δ : SL(2, ℤ)) :
     UpperHalfPlane.peterssonInner k fd
         (⇑f ∣[k] ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹)
         (⇑g ∣[k] ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹) =
@@ -115,9 +117,9 @@ theorem peterssonInner_slash_inv_out (f g : CuspForm (Γ.map (mapGL ℝ)) k) (δ
   have hmem : ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹ * δ ∈ Γ.withCenter :=
     QuotientGroup.eq.mp (Quotient.out_eq _)
   have h := peterssonInner_slash_slash_of_mem_withCenter f g hmem δ⁻¹
-  rwa [← SlashAction.slash_mul, ← SlashAction.slash_mul,
-    show ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹ * δ * δ⁻¹ =
-      ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹ by group] at h
+  have hcancel : ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹ * δ * δ⁻¹ =
+      ((QuotientGroup.mk δ : SL(2, ℤ) ⧸ Γ.withCenter).out)⁻¹ := by group
+  rwa [← SlashAction.slash_mul, ← SlashAction.slash_mul, hcancel] at h
 
 /-- **The Petersson product is unitary under a normalising slash.** If `α ∈ SL₂(ℤ)` normalises
 `Γ` and the slashes `f ∣[k] α`, `g ∣[k] α` are again cusp forms `F`, `G` for `Γ`, then
@@ -137,9 +139,9 @@ theorem peterssonInnerCosets_slash {α : SL(2, ℤ)}
       UpperHalfPlane.peterssonInner k fd (⇑F ∣[k] (q.out)⁻¹) (⇑G ∣[k] (q.out)⁻¹) =
         UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] ((cosetRightMul hαW q).out)⁻¹)
           (⇑g ∣[k] ((cosetRightMul hαW q).out)⁻¹) := fun q ↦ by
+    have hinv : (q.out * α⁻¹)⁻¹ = α * (q.out)⁻¹ := by group
     rw [cosetRightMul_apply hαW q, peterssonInner_slash_inv_out f g (q.out * α⁻¹), hF, hG,
-      ← SlashAction.slash_mul, ← SlashAction.slash_mul,
-      show (q.out * α⁻¹)⁻¹ = α * (q.out)⁻¹ by group]
+      ← SlashAction.slash_mul, ← SlashAction.slash_mul, hinv]
   rw [peterssonInnerCosets_def, peterssonInnerCosets_def, Finset.sum_congr rfl fun q _ ↦ hsummand q]
   exact Fintype.sum_equiv (cosetRightMul hαW) _ _ fun _ ↦ rfl
 
@@ -205,8 +207,9 @@ theorem peterssonInnerCosets_eq_zero_of_ne {k : ℤ} {χ ψ : (ZMod N)ˣ →* �
     rw [diamondOpCusp_apply_of_mem_cuspFormCharSpace k χ d hf,
       diamondOpCusp_apply_of_mem_cuspFormCharSpace k ψ d hg,
       peterssonInnerCosets_smul_left, peterssonInnerCosets_smul_right, ← mul_assoc]
-  rcases mul_eq_zero.mp (show (1 - conj (χ d : ℂ) * (ψ d : ℂ)) * peterssonInnerCosets f g = 0 by
-    rw [sub_mul, one_mul, ← key, sub_self]) with h | h
+  have hfactor : (1 - conj (χ d : ℂ) * (ψ d : ℂ)) * peterssonInnerCosets f g = 0 := by
+    rw [sub_mul, one_mul, ← key, sub_self]
+  rcases mul_eq_zero.mp hfactor with h | h
   · exact absurd (sub_eq_zero.mp h).symm hscal
   · exact h
 


### PR DESCRIPTION
This PR proves that the diamond operators are unitary for the Petersson product and draws the
consequence Layer 3 of the ModularForms roadmap asks for: the new subspace of `S_k(N, χ)` — the
Petersson-orthogonal complement, taken inside `S_k(N, χ)`, of the old forms there — is
`S_k(Γ₁(N))ⁿᵉʷ ⊓ S_k(N, χ)`, the roadmap's "equal to `S_k(Γ₁(N))^new ∩ S_k(N,χ)` by diamond
stability — a named lemma, not a remark". The milestone it serves is Layer 3's *oldforms and
newforms (the spaces)*: `TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean` already builds
`cuspFormsOld`/`cuspFormsNew` and the diamond stability of the old subspace, and its module
docstring names exactly what was missing — "that refinement additionally needs the diamond
operators to be Petersson-unitary, which is not proved here". This PR supplies it.

The route is one general theorem and three specialisations. `peterssonInnerCosets` is a sum over
the cosets of `Γ·{±I}` in `SL₂(ℤ)`; slashing both arguments by an `α` normalising `Γ` sends the
summand of a coset to the summand of another, and right multiplication by `α⁻¹` is a permutation
of the coset space precisely because `α` normalises the group, so the sum is unchanged
(`CuspForm.peterssonInnerCosets_slash`, for an arbitrary finite-index `Γ`). Since `Γ₀(N)`
normalises `Γ₁(N)` and `⟨d⟩` is slashing by a `Γ₀(N)`-representative of `d`, the diamond
operators are unitary. Three consequences follow: the Petersson-orthogonal complement of a
diamond-stable subspace is diamond-stable — this needs the diamonds to form a *group*, so that a
stable subspace is carried *onto* itself — hence `cuspFormsNew` is diamond-stable and is the sum
of its nebentypus components; distinct nebentypus spaces are orthogonal, the diamond eigenvalues
being roots of unity; and therefore a form of nebentypus `χ` is new exactly when it is orthogonal
to the old forms of nebentypus `χ` alone. The modular law then splits each nebentypus space into
its old and its new part.

Two files are added, ~390 lines: `TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean`
(unitarity under a normalising slash, the diamond specialisation, orthogonality of distinct
nebentypus spaces) and `TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean` (the
newforms consequences). Four existing files gain small pieces: the general
`Subgroup.normalizer_le_normalizer_withCenter` in `TauCeti/GroupTheory/Index.lean`, next to
`withCenter`; `CongruenceSubgroup.Gamma0_le_normalizer_Gamma1`, the normaliser phrasing of the
existing `Gamma0_normalizes_Gamma1`; `CuspForm.exists_slash_eq_smul_of_mem_withCenter` in
`Petersson/FiniteIndex.lean`, factored out of the existing coset-representative proof, which is
now three lines and no longer repeats the `±I` sign computation; and the defining lemma
`cuspFormsNew_def` plus a docstring update in `Newforms/Basic.lean`. No code was vendored from
Mathlib or from AINTLIB; the statements follow Diamond–Shurman §5.5–5.6 and Miyake §4.5–4.6, and
the files they extend record their own AINTLIB provenance.

What remains on this milestone after this PR: the roadmap's explicit indexing of the old part,
`S_k(N,χ)^old = Σ_{M ∣ N, cond χ ∣ M} Σ_{d ∣ N/M} V_d S_k(M, χ_M)`, which needs the descent of
`χ` to the divisor levels and the conductor theory under it; and the Petersson adjoint
`Tₙ* = ⟨n⟩⁻¹Tₙ` with the new-subspace stability under the Hecke operators, which waits on the
Layer 2 action of `Tₙ` on forms.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"cuspformsnew-inf-cuspformcharspace"}-->

🤖 Prepared with Claude Code
