### PR TITLE
refactor(EllipticCurve): drop two dead private norm-degree lemmas

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Norm.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Norm.lean
@@ -98,9 +98,7 @@ private theorem norm_algebraMap_polynomial' (d : F[X]) :
 
 /-- **The degree of the norm of `u / d`**: the polynomial norm's degree, less twice that of the
 denominator. Stated for an arbitrary numerator `u` in the coordinate ring, so it carries no
-hypothesis on the basis coefficients — they may vanish. This is the form downstream proofs should
-use; a private specialisation below reads off the weighted `max` for `u = a • 1 + b • y`, which does
-need `a` and `b` nonzero. -/
+hypothesis on the basis coefficients — they may vanish. -/
 theorem intDegree_norm_of_mul_eq {f : W.FunctionField} (hf : f ≠ 0) {u : W.CoordinateRing}
     {d : F[X]} (hd : d ≠ 0)
     (h : f * algebraMap F[X] W.FunctionField d = algebraMap W.CoordinateRing W.FunctionField u) :
@@ -116,26 +114,6 @@ theorem intDegree_norm_of_mul_eq {f : W.FunctionField} (hf : f ≠ 0) {u : W.Coo
   have := congrArg RatFunc.intDegree hnorm
   rw [RatFunc.intDegree_mul hNf (pow_ne_zero _ hdR), ← map_pow,
     RatFunc.intDegree_polynomial, RatFunc.intDegree_polynomial, natDegree_pow] at this
-  omega
-
-/-- natDegree form of Mathlib's `degree_norm_smul_basis` (recovered from `be8adaca`). -/
-private theorem natDegree_norm_smul_basis {a b : F[X]} (ha : a ≠ 0) (hb : b ≠ 0) :
-    (Algebra.norm F[X] (a • (1 : W.CoordinateRing) + b • CoordinateRing.mk W Y)).natDegree =
-      max (2 * a.natDegree) (2 * b.natDegree + 3) := by
-  refine natDegree_eq_of_degree_eq_some ?_
-  rw [CoordinateRing.degree_norm_smul_basis, degree_eq_natDegree ha, degree_eq_natDegree hb]
-  norm_cast
-
-/-- **The degree of the norm, in the `(a + b y)/p` normal form.** -/
-private theorem intDegree_norm_eq_max {f : W.FunctionField} (hf : f ≠ 0) {a b p : F[X]}
-    (ha : a ≠ 0) (hb : b ≠ 0) (hp : p ≠ 0)
-    (h : f * algebraMap F[X] W.FunctionField p =
-      algebraMap W.CoordinateRing W.FunctionField (a • 1 + b • CoordinateRing.mk W Y)) :
-    (Algebra.norm (RatFunc F) f).intDegree
-      = max (2 * (a.natDegree : ℤ) - 2 * p.natDegree)
-            (2 * (b.natDegree : ℤ) + 3 - 2 * p.natDegree) := by
-  rw [intDegree_norm_of_mul_eq W hf hp h, natDegree_norm_smul_basis W ha hb]
-  push_cast
   omega
 
 end WeierstrassCurve.Affine


### PR DESCRIPTION
Delete two `private` theorems from the function-field norm file that nothing consumes, and the
sentence of a neighbouring docstring that pointed at them.

```lean
-- TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Norm.lean
private theorem natDegree_norm_smul_basis   -- deleted
private theorem intDegree_norm_eq_max       -- deleted
```

## Why they are dead, not merely unused-looking

Both are `private`, so no declaration outside this module can name them, and inside the module the
call graph terminates:

* `intDegree_norm_eq_max` has **no** call sites at all.
* `natDegree_norm_smul_basis` has exactly one, inside `intDegree_norm_eq_max`.

So the pair is only reachable from itself: deleting `intDegree_norm_eq_max` makes the other dead by
construction. `grep -rn 'natDegree_norm_smul_basis\|intDegree_norm_eq_max' TauCeti/` returns three
hits, all three inside this file and all shown above. The file was born this way — the pair has
never had a consumer.

## Why deleting is the right call rather than exporting

The surviving general form is strictly better placed for the work that actually uses it.
`intDegree_norm_of_mul_eq` states the same degree computation for an *arbitrary* numerator in the
coordinate ring, so it carries no `a ≠ 0`/`b ≠ 0` hypotheses; the deleted specialisation only
reads that off in the `a • 1 + b • y` basis, and needs both coefficients nonzero to do it. A
consumer that ever wants the weighted `max` form can derive it in two lines from what remains
(`CoordinateRing.degree_norm_smul_basis` is Mathlib's), and would then state it where it is used,
with the hypotheses that site actually has. Keeping a private, hypothesis-heavy specialisation
alive on the chance that someone later wants it is exactly the speculative surface this repository
does not carry.

The docstring of `intDegree_norm_of_mul_eq` ended with "a private specialisation below reads off
the weighted `max` …", which would otherwise become a dangling reference; that sentence goes with
the code it describes. Nothing else in the file or its module docstring mentions the pair — the
"Main results" section lists only the two public theorems, both untouched.

## Scope

Improvement work on existing code: no declaration is added, no statement changed, and nothing
public is touched, so no roadmap target is claimed. The `Roadmap:` line below is attribution to the
area the file belongs to. The deletion was found by the `/simplify` pass while cleaning
`FunctionField/InfinityPlace.lean` (#3100) and deliberately deferred to its own PR rather than
smuggled into an unrelated diff.

## Gates

Stated exactly. The branch is based on current `main` (so it carries #3069's Fredholm deletion and
builds against the current pin), and the deletion was verified by building the changed module
together with its only downstream consumer: `lake build` of
`Affine.FunctionField.Norm` and `Affine.FunctionField.InfinityPlace`, 2512 jobs, clean. That is the
whole blast radius — `InfinityPlace` is the only module in the repository that imports `Norm`.

The full-tree audits at this head are CI's sandboxed build, which runs `lake build`,
`scripts/lint-env.sh`, `lake exe axioms` and `lake exe module-system`. They were not re-run locally
for this diff: the machine is currently running six concurrent worktree builds and a full local
pass makes no progress, and for a diff that only *removes* two private theorems those audits cannot
change — a deletion introduces no axiom, no linter violation and no module, and the surviving
declarations are byte-identical apart from one docstring sentence.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"norm-drop-dead-pair"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
