### PR TITLE
chore: give Algebra, Analysis, RepresentationTheory and LinearAlgebra a conforming Authors line

### DIFF
--- a/TauCeti/Algebra/Algebra/Hom.lean
+++ b/TauCeti/Algebra/Algebra/Hom.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Algebra/Subalgebra/Lattice.lean
+++ b/TauCeti/Algebra/Algebra/Subalgebra/Lattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Algebra/Subalgebra/MaximalCommutative.lean
+++ b/TauCeti/Algebra/Algebra/Subalgebra/MaximalCommutative.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/Kernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/ReducedPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/ReducedPoints.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Frobenius.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Frobenius.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Tangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/BaseChange/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/BaseChange/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/BaseChange/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/BaseChange/Naturality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Cocharacter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/CharacterLattice/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/CharacterLattice/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/CharacterLattice/Continuous.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/CharacterLattice/Continuous.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/CharacterLattice/Functoriality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/CharacterLattice/Functoriality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/AlgebraicallyClosed.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/AlgebraicallyClosed.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/GroupScheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/GroupScheme.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/IdentityComponent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/IdentityComponent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Normal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/ConstantGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/ConstantGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/CharacterLattice.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/CharacterLattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/EssentialImage.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/EssentialImage.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Functoriality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Functoriality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/PowerEndomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/PowerEndomorphism.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/ClosedImmersion.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/ClosedImmersion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Points.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Points.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Semisimple.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Semisimple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/SmoothConnected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/SmoothConnected.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Weight.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/FaithfullyFlatDescent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FaithfullyFlatDescent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteType/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteType/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteType/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteType/CommHopfAlgCat.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteType/ConnectedComponents.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteType/ConnectedComponents.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteType/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteType/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Projection.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Projection.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Torsor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Torsor.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/FrobeniusPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FrobeniusPoints.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ChevalleyRelations.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ChevalleyRelations.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/Bialgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/Bialgebra.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/HopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/HopfAlgebra.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Determinant.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Determinant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/RootSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/RootSubgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ScalarExtension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ScalarExtension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Tangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeometricallyReduced/CommHopfAlgCat.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/NotReduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/NotReduced.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Torsion.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Torsion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Conjugation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/KernelPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/KernelPoints.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Order.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Order.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Tangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Order.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Order.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Presheaf.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Presheaf.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Classification.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Classification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Semisimple.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Semisimple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Tangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/CharacterLattice.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/CharacterLattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Cocharacter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/GaloisModule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/GaloisModule.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Dual.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Dual.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Morphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Morphism.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Trivial.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Coordinate.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Coordinate.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Faithful.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Faithful.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/GeometricSemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/GeometricSemisimplePoint.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ScalarExtension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/GlobalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/GlobalFunctional.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/LocalFunctional.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Multiplication.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/PointFaithful.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/PointFaithful.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Reconstruction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Reconstruction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/SemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/SemisimplePoint.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Unit.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Character.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Character.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Faithful.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Faithful.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Naturality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/NoCharacters.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/NoCharacters.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UpperUnitriangular.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UpperUnitriangular.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Inclusion.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Inclusion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Kernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Scheme.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/CommHopfAlgCat.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Borel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Extension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Extension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/ChevalleyRelations.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/ChevalleyRelations.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Antigravity
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/RootSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/RootSubgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Scheme.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Tangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/CharacterLattice.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/CharacterLattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Cocharacter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Scheme.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Adjoint.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Cotangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Equivariance.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Equivariance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/FiniteType.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint/Cotangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Cotangent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Representation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Representation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Scheme.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/CharacterLattice/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/CharacterLattice/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/CharacterLattice/Functoriality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/CharacterLattice/Functoriality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Characterization.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Characterization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Cocharacter/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Cocharacter/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Cocharacter/Functoriality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Cocharacter/Functoriality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/SmoothConnected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/SmoothConnected.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Trivial.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Extension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Extension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Semisimple.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Semisimple.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Nilpotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Nilpotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Bialgebra/Augmentation.lean
+++ b/TauCeti/Algebra/Bialgebra/Augmentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Bialgebra/GroupLike/Evaluation.lean
+++ b/TauCeti/Algebra/Bialgebra/GroupLike/Evaluation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Bialgebra/GroupLike/Map.lean
+++ b/TauCeti/Algebra/Bialgebra/GroupLike/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Bialgebra/GroupLike/ScalarAut.lean
+++ b/TauCeti/Algebra/Bialgebra/GroupLike/ScalarAut.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/BaseChange.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/Product.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Bialgebra/Primitive.lean
+++ b/TauCeti/Algebra/Bialgebra/Primitive.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Bialgebra/Quotient.lean
+++ b/TauCeti/Algebra/Bialgebra/Quotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Bialgebra/TensorProduct.lean
+++ b/TauCeti/Algebra/Bialgebra/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/BrauerGroup/BaseChange.lean
+++ b/TauCeti/Algebra/BrauerGroup/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/BrauerGroup/Basic.lean
+++ b/TauCeti/Algebra/BrauerGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/BrauerGroup/Group.lean
+++ b/TauCeti/Algebra/BrauerGroup/Group.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/BrauerGroup/Quaternion.lean
+++ b/TauCeti/Algebra/BrauerGroup/Quaternion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/BrauerGroup/Splitting.lean
+++ b/TauCeti/Algebra/BrauerGroup/Splitting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/BrauerGroup/Trivial.lean
+++ b/TauCeti/Algebra/BrauerGroup/Trivial.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Category/CommAlgCat/Fppf.lean
+++ b/TauCeti/Algebra/Category/CommAlgCat/Fppf.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Category/CommAlgCat/RestrictScalars.lean
+++ b/TauCeti/Algebra/Category/CommAlgCat/RestrictScalars.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Category/CommGrpCat/FiniteGeneration.lean
+++ b/TauCeti/Algebra/Category/CommGrpCat/FiniteGeneration.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Category/ModuleCat/DirectedUnion.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/DirectedUnion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/FinitePresentation.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/FinitePresentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/Basic.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/FinitePresentation.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/FinitePresentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/LocalTriviality.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/LocalTriviality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Central/BaseChange.lean
+++ b/TauCeti/Algebra/Central/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Central/Matrix.lean
+++ b/TauCeti/Algebra/Central/Matrix.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Central/Quaternion.lean
+++ b/TauCeti/Algebra/Central/Quaternion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Central/TensorProduct.lean
+++ b/TauCeti/Algebra/Central/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/BaseChange.lean
+++ b/TauCeti/Algebra/CentralSimple/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/Bimodule.lean
+++ b/TauCeti/Algebra/CentralSimple/Bimodule.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/Centralizer.lean
+++ b/TauCeti/Algebra/CentralSimple/Centralizer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/Degree.lean
+++ b/TauCeti/Algebra/CentralSimple/Degree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/End.lean
+++ b/TauCeti/Algebra/CentralSimple/End.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/MaximalSubfield.lean
+++ b/TauCeti/Algebra/CentralSimple/MaximalSubfield.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/Opposite.lean
+++ b/TauCeti/Algebra/CentralSimple/Opposite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/Quaternion.lean
+++ b/TauCeti/Algebra/CentralSimple/Quaternion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
+++ b/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/Splitting.lean
+++ b/TauCeti/Algebra/CentralSimple/Splitting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/Subfield.lean
+++ b/TauCeti/Algebra/CentralSimple/Subfield.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/TensorProduct.lean
+++ b/TauCeti/Algebra/CentralSimple/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CentralSimple/Wedderburn.lean
+++ b/TauCeti/Algebra/CentralSimple/Wedderburn.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Cat.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Cat.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Cofree.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Cofree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Corestrict.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Dual.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Dual.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Evaluation.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Evaluation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Cofree.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Cofree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Corestrict.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Dual.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Dual.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Preadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Preadditive.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Product.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Rigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Rigid.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Monoidal.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/ScalarExtension/Monoidal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Symmetric.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Symmetric.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Flag/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Flag/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Flag/Extension.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Flag/Extension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Adjoin.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Adjoin.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Comul.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Comul.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Dual.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Dual.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Finite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/FiniteType.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/FiniteType.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Matrix.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Matrix.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Morphism.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Morphism.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/PointAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/PointAction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Product.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Regular.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Regular.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Subcoalgebra.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Subcoalgebra.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Transport.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Transport.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Trivial.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Trivial.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra/Semisimple.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra/Semisimple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointSeparation.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointSeparation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Preadditive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Preadditive.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Product.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Regular.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Regular.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/ScalarExtension.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/ScalarExtension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Transport.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Transport.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Trivial.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Trivial.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Zero.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Convolution.lean
+++ b/TauCeti/Algebra/Coalgebra/Convolution.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/GroupLike/Map.lean
+++ b/TauCeti/Algebra/Coalgebra/GroupLike/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra/Finite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra/GroupLike.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra/GroupLike.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra/Lattice.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra/Lattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra/Map.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra/RegularSubcomodule.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra/RegularSubcomodule.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Comap.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Comap.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/DirectedUnion.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/DirectedUnion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Induced.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Multiplication.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Quotient.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Quotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/CubicDiscriminant.lean
+++ b/TauCeti/Algebra/CubicDiscriminant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/ConjFinite.lean
+++ b/TauCeti/Algebra/Group/ConjFinite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/Coprime.lean
+++ b/TauCeti/Algebra/Group/Coprime.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient/Basic.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient/Cyclic.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient/Cyclic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient/FreeModule.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient/FreeModule.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient/Prod.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient/Prod.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
+++ b/TauCeti/Algebra/Group/FreeAbelianCharacter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/NormalizerQuotient/Basic.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotient/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/NormalizerQuotient/Conjugation.lean
+++ b/TauCeti/Algebra/Group/NormalizerQuotient/Conjugation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/PowMonoidHom.lean
+++ b/TauCeti/Algebra/Group/PowMonoidHom.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/SquareRoot.lean
+++ b/TauCeti/Algebra/Group/SquareRoot.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/Subgroup/Centralizer.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Centralizer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/Subgroup/Map.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/Subgroup/Normalizer.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Normalizer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/Subgroup/Pointwise.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Pointwise.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Group/ZMultiples.lean
+++ b/TauCeti/Algebra/Group/ZMultiples.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
+++ b/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/GroupAction/FixingSubgroup.lean
+++ b/TauCeti/Algebra/GroupAction/FixingSubgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
+++ b/TauCeti/Algebra/GroupAction/OrbitRelQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
+++ b/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/Antipode.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Antipode.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Augmentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/CartierDuality.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/CartierDuality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/GroupLike/FiniteGeneration.lean
+++ b/TauCeti/Algebra/HopfAlgebra/GroupLike/FiniteGeneration.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Map.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/SymmetricAlgebra.lean
+++ b/TauCeti/Algebra/HopfAlgebra/SymmetricAlgebra.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/SymmetricAlgebra/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/SymmetricAlgebra/Augmentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/HopfAlgebra/SymmetricAlgebra/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/SymmetricAlgebra/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/Basic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Borel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/DiagonalCartan.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/DiagonalCartan.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/RootSpace.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/RootSpace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/TraceForm.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/TraceForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/HighestWeight/Basic.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/HighestWeight/Existence.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Existence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/HighestWeight/Module.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Module.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/InnerAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/InnerAutomorphism.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Presentation/Basic.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Presentation/Serre/Automorphism.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre/Automorphism.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/SkewAdjoint.lean
+++ b/TauCeti/Algebra/Lie/SkewAdjoint.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/Associative.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Associative.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/Basic.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/Casimir.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Casimir.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/Classification.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Classification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
+++ b/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/Decomposition.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Decomposition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/IntegralLattice.lean
+++ b/TauCeti/Algebra/Lie/Sl2/IntegralLattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/KostantSpan.lean
+++ b/TauCeti/Algebra/Lie/Sl2/KostantSpan.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/Spectrum.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Spectrum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/Standard.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Standard.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/Straightening.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Straightening.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/WeightMultiplicity.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeightMultiplicity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/WeightString.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeightString.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Subalgebra/Rationalization.lean
+++ b/TauCeti/Algebra/Lie/Subalgebra/Rationalization.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Subalgebra/Top.lean
+++ b/TauCeti/Algebra/Lie/Subalgebra/Top.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Submodule/Atom.lean
+++ b/TauCeti/Algebra/Lie/Submodule/Atom.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Antipode.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Antipode.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Basic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Bialgebra.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Bialgebra.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Commutation.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Commutation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Functoriality.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Functoriality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/HopfAlgebra.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/HopfAlgebra.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Antipode.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Antipode.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/BaseChangeAction.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/BaseChangeAction.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Comultiplication.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Comultiplication.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Exponential.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Exponential.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Form.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Form.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/HopfAlgebra.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/HopfAlgebra.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/LatticeAction.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/LatticeAction.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Orbit.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Orbit.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Basic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/ChevalleyRelations.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/ChevalleyRelations.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Commutator.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Commutator.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Coordinate.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Coordinate.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Elementary.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Elementary.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/PointRepresentation.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/PointRepresentation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Basic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Relations.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Relations.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Serre.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Serre.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/WeightDecomposition.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/WeightDecomposition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/PBW/Basic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/PBW/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/PBW/Functoriality.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/PBW/Functoriality.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/PBW/LeadingTerm.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/PBW/LeadingTerm.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/PBW/Ordered.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/PBW/Ordered.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Borel.lean
+++ b/TauCeti/Algebra/Lie/Weights/Borel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Central.lean
+++ b/TauCeti/Algebra/Lie/Weights/Central.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/ChevalleySystem.lean
+++ b/TauCeti/Algebra/Lie/Weights/ChevalleySystem.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Diagonalizable.lean
+++ b/TauCeti/Algebra/Lie/Weights/Diagonalizable.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Integrality.lean
+++ b/TauCeti/Algebra/Lie/Weights/Integrality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Killing.lean
+++ b/TauCeti/Algebra/Lie/Weights/Killing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Reflection.lean
+++ b/TauCeti/Algebra/Lie/Weights/Reflection.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Root/CorootSpan.lean
+++ b/TauCeti/Algebra/Lie/Weights/Root/CorootSpan.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Root/IntegralLattice.lean
+++ b/TauCeti/Algebra/Lie/Weights/Root/IntegralLattice.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Root/Rationalization.lean
+++ b/TauCeti/Algebra/Lie/Weights/Root/Rationalization.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Root/String.lean
+++ b/TauCeti/Algebra/Lie/Weights/Root/String.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Sl2System.lean
+++ b/TauCeti/Algebra/Lie/Weights/Sl2System.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/Span.lean
+++ b/TauCeti/Algebra/Lie/Weights/Span.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/StructureConstant/Basic.lean
+++ b/TauCeti/Algebra/Lie/Weights/StructureConstant/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/StructureConstant/Normalization.lean
+++ b/TauCeti/Algebra/Lie/Weights/StructureConstant/Normalization.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/StructureConstant/Symmetry.lean
+++ b/TauCeti/Algebra/Lie/Weights/StructureConstant/Symmetry.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Lie/Weights/WeylInvariance.lean
+++ b/TauCeti/Algebra/Lie/Weights/WeylInvariance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Matrix/BaseChange.lean
+++ b/TauCeti/Algebra/Matrix/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Matrix/Pi.lean
+++ b/TauCeti/Algebra/Matrix/Pi.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Module/Equiv/Basic.lean
+++ b/TauCeti/Algebra/Module/Equiv/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Module/GradedModule/Internal.lean
+++ b/TauCeti/Algebra/Module/GradedModule/Internal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Module/Lattice.lean
+++ b/TauCeti/Algebra/Module/Lattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Module/LinearMap/Index.lean
+++ b/TauCeti/Algebra/Module/LinearMap/Index.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Module/ProjectiveCover.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Module/Rat.lean
+++ b/TauCeti/Algebra/Module/Rat.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Module/Submodule/Superfluous.lean
+++ b/TauCeti/Algebra/Module/Submodule/Superfluous.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/MonoidAlgebra/Basis.lean
+++ b/TauCeti/Algebra/MonoidAlgebra/Basis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/MonoidAlgebra/Exactness.lean
+++ b/TauCeti/Algebra/MonoidAlgebra/Exactness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/MonoidAlgebra/Trace.lean
+++ b/TauCeti/Algebra/MonoidAlgebra/Trace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/MonoidAlgebra/Twisted.lean
+++ b/TauCeti/Algebra/MonoidAlgebra/Twisted.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Octonion.lean
+++ b/TauCeti/Algebra/Octonion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Order/BigOperators/ProdSubProd.lean
+++ b/TauCeti/Algebra/Order/BigOperators/ProdSubProd.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Order/Ring/Units.lean
+++ b/TauCeti/Algebra/Order/Ring/Units.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Polynomial/Card/BoundedCoeff.lean
+++ b/TauCeti/Algebra/Polynomial/Card/BoundedCoeff.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Polynomial/Card/RootSetUnion.lean
+++ b/TauCeti/Algebra/Polynomial/Card/RootSetUnion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Polynomial/CoeffList.lean
+++ b/TauCeti/Algebra/Polynomial/CoeffList.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/Polynomial/QuadraticDiscriminant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Polynomial/Semiconj.lean
+++ b/TauCeti/Algebra/Polynomial/Semiconj.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Polynomial/Sequence.lean
+++ b/TauCeti/Algebra/Polynomial/Sequence.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Polynomial/Smeval.lean
+++ b/TauCeti/Algebra/Polynomial/Smeval.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/QuadraticDiscriminant.lean
+++ b/TauCeti/Algebra/QuadraticDiscriminant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Ring/Commutator.lean
+++ b/TauCeti/Algebra/Ring/Commutator.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Ring/Subgroup.lean
+++ b/TauCeti/Algebra/Ring/Subgroup.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Ring/Units.lean
+++ b/TauCeti/Algebra/Ring/Units.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Squarefree.lean
+++ b/TauCeti/Algebra/Squarefree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/Subalgebra/Center.lean
+++ b/TauCeti/Algebra/Subalgebra/Center.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/TensorProduct/BaseChange.lean
+++ b/TauCeti/Algebra/TensorProduct/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/TensorProduct/CommonOverfield.lean
+++ b/TauCeti/Algebra/TensorProduct/CommonOverfield.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/TensorProduct/Subring.lean
+++ b/TauCeti/Algebra/TensorProduct/Subring.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Algebra/WordFiltration.lean
+++ b/TauCeti/Algebra/WordFiltration.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Analytic/Order.lean
+++ b/TauCeti/Analysis/Analytic/Order.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Bochner/BochnerTheorem.lean
+++ b/TauCeti/Analysis/Bochner/BochnerTheorem.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Bochner/CharFun/PosDef.lean
+++ b/TauCeti/Analysis/Bochner/CharFun/PosDef.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Bochner/CharFun/PositiveDefinite.lean
+++ b/TauCeti/Analysis/Bochner/CharFun/PositiveDefinite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Bochner/Fourier/Convention.lean
+++ b/TauCeti/Analysis/Bochner/Fourier/Convention.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Bochner/Fourier/Nonneg.lean
+++ b/TauCeti/Analysis/Bochner/Fourier/Nonneg.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Bochner/Gaussian/Basic.lean
+++ b/TauCeti/Analysis/Bochner/Gaussian/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Bochner/Gaussian/Regularization.lean
+++ b/TauCeti/Analysis/Bochner/Gaussian/Regularization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/Bilinear.lean
+++ b/TauCeti/Analysis/Calculus/Bilinear.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/TauCeti/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/ContinuousLinearMapInverse.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousLinearMapInverse.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/DSlope/Basic.lean
+++ b/TauCeti/Analysis/Calculus/DSlope/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/DensityLength.lean
+++ b/TauCeti/Analysis/Calculus/DensityLength.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/DerivativeTest.lean
+++ b/TauCeti/Analysis/Calculus/DerivativeTest.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/ExponentialSlope.lean
+++ b/TauCeti/Analysis/Calculus/ExponentialSlope.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/HalfLinePrimitive.lean
+++ b/TauCeti/Analysis/Calculus/HalfLinePrimitive.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/Morse.lean
+++ b/TauCeti/Analysis/Calculus/Morse.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/ParametricFDeriv.lean
+++ b/TauCeti/Analysis/Calculus/ParametricFDeriv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/ParametricIntegral.lean
+++ b/TauCeti/Analysis/Calculus/ParametricIntegral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/ParametricPullback.lean
+++ b/TauCeti/Analysis/Calculus/ParametricPullback.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/PeriodicDeriv.lean
+++ b/TauCeti/Analysis/Calculus/PeriodicDeriv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/RescaledDerivative.lean
+++ b/TauCeti/Analysis/Calculus/RescaledDerivative.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/Sard/FlatStratum.lean
+++ b/TauCeti/Analysis/Calculus/Sard/FlatStratum.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/Sard/LowDimension.lean
+++ b/TauCeti/Analysis/Calculus/Sard/LowDimension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Calculus/SecondDerivative.lean
+++ b/TauCeti/Analysis/Calculus/SecondDerivative.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Integral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Measures.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Theorem.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Theorem.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Tightness.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Tightness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Closure.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Closure.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteMixture.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteMixture.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Laplace/Kernel.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Laplace/Kernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/OpenClosure.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/OpenClosure.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Power.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Power.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Reciprocal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/CompletelyMonotone/Reparametrization.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Reparametrization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/BranchLogRoot.lean
+++ b/TauCeti/Analysis/Complex/BranchLogRoot.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Continuation/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/ClosedForm.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/ClosedForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Density.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Density.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Distance.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Distance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Triangle.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Triangle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/ImageSimplyConnected.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ImageSimplyConnected.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
+++ b/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Koebe.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Koebe.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Moebius.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Moebius.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Monodromy.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Monodromy.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/NormalFamilies.lean
+++ b/TauCeti/Analysis/Complex/Conformal/NormalFamilies.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Betweenness.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Betweenness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Geodesic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Geodesic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Isometry/Equiv.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Isometry/Equiv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/MetricSpace.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/MetricSpace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Topology.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Topology.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/PseudoHyperbolic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/PseudoHyperbolic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Arc.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Arc.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Circle.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Circle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Circle/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Circle/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Circle/Conjugate.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Circle/Conjugate.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Circle/Principle.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Circle/Principle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Injective.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Injective.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Line.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Line.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Principle.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Principle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Removability.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Removability.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Removability/Arc.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Removability/Arc.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Removability/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Removability/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Removability/Circle.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Removability/Circle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Conformal.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Conformal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Equivalence.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Equivalence.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Existence.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Existence.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Normalization.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Normalization.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Uniqueness.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Uniqueness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/Schwarz.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Schwarz.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/AutomorphismIsometry.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/AutomorphismIsometry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Derivative.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Derivative.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Isometry.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Isometry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Classification.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Classification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Group.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Group.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Parametrization.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Parametrization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Rotation.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Rotation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Conformal/UnitDisc/Homeomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDisc/Homeomorph.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/Periodic.lean
+++ b/TauCeti/Analysis/Complex/Periodic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/SlitPlane.lean
+++ b/TauCeti/Analysis/Complex/SlitPlane.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/UnitDisc/Basic.lean
+++ b/TauCeti/Analysis/Complex/UnitDisc/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Manifold.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Manifold.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Complex/UpperLogContinuity.lean
+++ b/TauCeti/Analysis/Complex/UpperLogContinuity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Concat.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Concat.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Chord/Direction.lean
+++ b/TauCeti/Analysis/Contour/Chord/Direction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Crossing/LipschitzRegularity.lean
+++ b/TauCeti/Analysis/Contour/Crossing/LipschitzRegularity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Cycle/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Cycle/HomologyCauchy.lean
+++ b/TauCeti/Analysis/Contour/Cycle/HomologyCauchy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Cycle/Winding.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Winding.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/JordanLemma.lean
+++ b/TauCeti/Analysis/Contour/JordanLemma.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/ModelSector/Closed.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/Closed.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Tau Ceti contributors
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/ModelSector/Corner.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/Corner.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Tau Ceti contributors
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Residue/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Residue/Cycle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Residue/Quotient.lean
+++ b/TauCeti/Analysis/Contour/Residue/Quotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/BoundedIntegrand.lean
+++ b/TauCeti/Analysis/Contour/Winding/BoundedIntegrand.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/Continuity.lean
+++ b/TauCeti/Analysis/Contour/Winding/Continuity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/Integer.lean
+++ b/TauCeti/Analysis/Contour/Winding/Integer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/LipschitzBoundedIntegrand.lean
+++ b/TauCeti/Analysis/Contour/Winding/LipschitzBoundedIntegrand.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Tau Ceti contributors
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/Number/Segment.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Segment.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/PrincipalValueRealIntegral.lean
+++ b/TauCeti/Analysis/Contour/Winding/PrincipalValueRealIntegral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/Proximity.lean
+++ b/TauCeti/Analysis/Contour/Winding/Proximity.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Tau Ceti contributors
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral/OnCurve.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral/OnCurve.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/SegmentSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/SegmentSum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/Winding/UnboundedComponent.lean
+++ b/TauCeti/Analysis/Contour/Winding/UnboundedComponent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Basic.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Dirichlet.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/Dirichlet.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/HalfResidue.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/HalfResidue.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/SineIntegral.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/HalfDisc/SineIntegral.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Tau Ceti contributors
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fourier/Continuous.lean
+++ b/TauCeti/Analysis/Fourier/Continuous.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/Adjoint.lean
+++ b/TauCeti/Analysis/Fredholm/Adjoint.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/Basic.lean
+++ b/TauCeti/Analysis/Fredholm/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/ClosedRange.lean
+++ b/TauCeti/Analysis/Fredholm/ClosedRange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/Comp.lean
+++ b/TauCeti/Analysis/Fredholm/Comp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
+++ b/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
+++ b/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/Criteria.lean
+++ b/TauCeti/Analysis/Fredholm/Criteria.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/Estimate.lean
+++ b/TauCeti/Analysis/Fredholm/Estimate.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/FiniteRank.lean
+++ b/TauCeti/Analysis/Fredholm/FiniteRank.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/Index.lean
+++ b/TauCeti/Analysis/Fredholm/Index.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/LevelSet.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/Prod.lean
+++ b/TauCeti/Analysis/Fredholm/Prod.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/Restriction.lean
+++ b/TauCeti/Analysis/Fredholm/Restriction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/SelfAdjoint.lean
+++ b/TauCeti/Analysis/Fredholm/SelfAdjoint.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/SmallPerturbation.lean
+++ b/TauCeti/Analysis/Fredholm/SmallPerturbation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Fredholm/Zero.lean
+++ b/TauCeti/Analysis/Fredholm/Zero.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Conjugation.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Conjugation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Harmonic/Ball.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Harmonic/Ball.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Harmonic/Dilation.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Harmonic/Dilation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Harmonic/Isometry.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Harmonic/Isometry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/L2/Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Product.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/BarrierMaximizer.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/BarrierMaximizer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/Basic.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/Comparison.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/Comparison.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/LocalExtr.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/LocalExtr.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/MaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/MaximumPrinciple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/SignCondition.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/SignCondition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/WeakMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/WeakMaximumPrinciple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/ZerothOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/ZerothOrderMaximumPrinciple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/LaxMilgram.lean
+++ b/TauCeti/Analysis/InnerProductSpace/LaxMilgram.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/NormPow.lean
+++ b/TauCeti/Analysis/InnerProductSpace/NormPow.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/Parseval.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Parseval.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/PolynomialCompleteness.lean
+++ b/TauCeti/Analysis/InnerProductSpace/PolynomialCompleteness.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/PositiveDefinite.lean
+++ b/TauCeti/Analysis/InnerProductSpace/PositiveDefinite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/TensorProduct.lean
+++ b/TauCeti/Analysis/InnerProductSpace/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/InnerProductSpace/WeightedOrthogonalBasis.lean
+++ b/TauCeti/Analysis/InnerProductSpace/WeightedOrthogonalBasis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Matrix/PosSemidef.lean
+++ b/TauCeti/Analysis/Matrix/PosSemidef.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Matrix/UnitaryGroup.lean
+++ b/TauCeti/Analysis/Matrix/UnitaryGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Algebra/Basic.lean
+++ b/TauCeti/Analysis/Normed/Algebra/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Algebra/OneSubExpNegDivSelf/Basic.lean
+++ b/TauCeti/Analysis/Normed/Algebra/OneSubExpNegDivSelf/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Algebra/OneSubExpNegDivSelf/Integral.lean
+++ b/TauCeti/Analysis/Normed/Algebra/OneSubExpNegDivSelf/Integral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Module/Ball.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Module/Trace.lean
+++ b/TauCeti/Analysis/Normed/Module/Trace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Operator/Compact/Basic.lean
+++ b/TauCeti/Analysis/Normed/Operator/Compact/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Operator/Compact/Eigenspace.lean
+++ b/TauCeti/Analysis/Normed/Operator/Compact/Eigenspace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean
+++ b/TauCeti/Analysis/Normed/Operator/Compact/RieszTheory.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Operator/Dense.lean
+++ b/TauCeti/Analysis/Normed/Operator/Dense.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Operator/Exponential.lean
+++ b/TauCeti/Analysis/Normed/Operator/Exponential.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Operator/LinearPMap/Shift.lean
+++ b/TauCeti/Analysis/Normed/Operator/LinearPMap/Shift.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Shift.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Shift.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/Unbounded.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/ODE/SmoothParameter.lean
+++ b/TauCeti/Analysis/ODE/SmoothParameter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/Ellipticity/Basic.lean
+++ b/TauCeti/Analysis/PDE/Ellipticity/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/Ellipticity/Energy.lean
+++ b/TauCeti/Analysis/PDE/Ellipticity/Energy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/EnergyForm/Basic.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/EnergyForm/Continuity.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Continuity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/EnergyForm/Integrability.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Integrability.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/EnergyForm/Integrated/Basic.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Integrated/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/EnergyForm/Integrated/Symmetry.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Integrated/Symmetry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/EnergyForm/Linearity.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Linearity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/EnergyForm/Measurability.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Measurability.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/EnergyLowerBounds.lean
+++ b/TauCeti/Analysis/PDE/EnergyLowerBounds.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Gradient.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Gradient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Planar.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Planar.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/Harnack/Planar.lean
+++ b/TauCeti/Analysis/PDE/Harnack/Planar.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/Harnack/StrongPrinciple.lean
+++ b/TauCeti/Analysis/PDE/Harnack/StrongPrinciple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/ShiftedLaplacianEnergy.lean
+++ b/TauCeti/Analysis/PDE/ShiftedLaplacianEnergy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Polynomial/SymmetricPower.lean
+++ b/TauCeti/Analysis/Polynomial/SymmetricPower.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Continuity.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Continuity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/FourierAtom.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FourierAtom.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Function/Closure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Function/Closure.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Function/Kernel.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Function/Kernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Kernel/Bounds.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel/Bounds.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Kernel/Finsupp.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel/Finsupp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Kernel/Kolmogorov.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel/Kolmogorov.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Kernel/Radical.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel/Radical.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Limits.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Limits.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Normalize.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Normalize.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/Pullback.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Pullback.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Bounds.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Bounds.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/PositiveDefinite.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/PositiveDefinite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Transform.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Transform.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Uniqueness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Normalize.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Normalize.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Product.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Pullback.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Pullback.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Axis.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Axis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Slice.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Slice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/BoundedGenerator.lean
+++ b/TauCeti/Analysis/Semigroups/BoundedGenerator.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/BoundedGenerator/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/BoundedGenerator/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/BoundedGenerator/Perturbation.lean
+++ b/TauCeti/Analysis/Semigroups/BoundedGenerator/Perturbation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/BoundedGenerator/Resolvent.lean
+++ b/TauCeti/Analysis/Semigroups/BoundedGenerator/Resolvent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/CauchyProblem.lean
+++ b/TauCeti/Analysis/Semigroups/CauchyProblem.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Defs.lean
+++ b/TauCeti/Analysis/Semigroups/Defs.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Dissipative/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Dissipative/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Dissipative/Hilbert.lean
+++ b/TauCeti/Analysis/Semigroups/Dissipative/Hilbert.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Approximation.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Approximation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Convergence.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Convergence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Limit.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Limit.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Shift.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Shift.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generation/LimitSemigroup.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/LimitSemigroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generation/LumerPhillips.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/LumerPhillips.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generation/Yosida/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/Yosida/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generation/Yosida/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/Yosida/Generator.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Generator.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generator/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generator/Closed.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Closed.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generator/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/ExponentialShift.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generator/Invariance.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Invariance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Generator/Uniqueness.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Uniqueness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/GrowthBound.lean
+++ b/TauCeti/Analysis/Semigroups/GrowthBound.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Identity.lean
+++ b/TauCeti/Analysis/Semigroups/Identity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Resolvent/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Resolvent/Deriv.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Deriv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Resolvent/Identity.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Identity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Semigroups/UniformlyContinuous.lean
+++ b/TauCeti/Analysis/Semigroups/UniformlyContinuous.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Sobolev/Dilation.lean
+++ b/TauCeti/Analysis/Sobolev/Dilation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Sobolev/Poincare/WholeSpace.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/WholeSpace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Sobolev/W1p.lean
+++ b/TauCeti/Analysis/Sobolev/W1p.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/Sobolev/WeakDeriv.lean
+++ b/TauCeti/Analysis/Sobolev/WeakDeriv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Artanh.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Artanh.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Basic.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Fourier/Basic.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Fourier/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Fourier/HilbertBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Fourier/HilbertBasis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/HilbertBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/HilbertBasis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Ladder.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Ladder.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/MemLp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/MemLp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Operator.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Operator.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Antigravity
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Oscillator.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Oscillator.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Basis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Basis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Parseval.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Schwartz.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Schwartz.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Orthogonality.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Orthogonality.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Hyperbolic.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hyperbolic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/JordanIntegral.lean
+++ b/TauCeti/Analysis/SpecialFunctions/JordanIntegral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Arccos.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Arccos.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Cosine/HilbertBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Cosine/HilbertBasis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Cosine/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Cosine/Parseval.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Antigravity
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Cosine/Transfer.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Cosine/Transfer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/HilbertBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/HilbertBasis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Parseval.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/WeightIsometry.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/WeightIsometry.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Orthogonality.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Orthogonality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
+++ b/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/BilinearForm/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Basic.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/BilinearForm/DualLattice.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/DualLattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/BilinearForm/ExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/ExteriorSquare.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry/Basic.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Multilinear.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Multilinear.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Squares.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Squares.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti Project. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Tau Ceti Project
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Action.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Action.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/DoubleCover.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Kernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Subalgebra.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Subalgebra.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SignSwitch.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SignSwitch.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti Project. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Tau Ceti Project
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Action.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Action.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Surjectivity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Surjectivity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/StandardBivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/StandardBivector.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Vectors.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Vectors.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Complex/Finrank.lean
+++ b/TauCeti/LinearAlgebra/Complex/Finrank.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Complex/LinearPart.lean
+++ b/TauCeti/LinearAlgebra/Complex/LinearPart.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Determinant.lean
+++ b/TauCeti/LinearAlgebra/Determinant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Dimension/DirectSum.lean
+++ b/TauCeti/LinearAlgebra/Dimension/DirectSum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
+++ b/TauCeti/LinearAlgebra/Dimension/IsQuadraticExtension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Eigenspace/Binomial.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Binomial.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Eigenspace/DiagonalBasis.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/DiagonalBasis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Eigenspace/Separation.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Separation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/End/FiniteOrder.lean
+++ b/TauCeti/LinearAlgebra/End/FiniteOrder.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/End/Prod.lean
+++ b/TauCeti/LinearAlgebra/End/Prod.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/End/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/End/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Dimension.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Dimension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/End.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/End.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/ExteriorPower.lean
+++ b/TauCeti/LinearAlgebra/ExteriorPower.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/TauCeti/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Prod.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Prod.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Graded/LinearMap.lean
+++ b/TauCeti/LinearAlgebra/Graded/LinearMap.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Graded/Multilinear.lean
+++ b/TauCeti/LinearAlgebra/Graded/Multilinear.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Bilinear.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Bilinear.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Cardinality.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Cardinality.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Group.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Group.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Quadratic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Dual/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Dual/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Dual/Finiteness.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Dual/Finiteness.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Even.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Even.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Examples.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Examples.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Isometry.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Isometry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Norm.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Norm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/RadicalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RadicalQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Signature.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Signature.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Unimodular.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Unimodular.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/JordanChevalley/Prod.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Prod.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/CharpolyFinTwo.lean
+++ b/TauCeti/LinearAlgebra/Matrix/CharpolyFinTwo.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/Commute.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Commute.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/Dual.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Dual.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/Echelon/KernelBasis.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Echelon/KernelBasis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/Echelon/RowReduce.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Echelon/RowReduce.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/EigenvalueSearch.lean
+++ b/TauCeti/LinearAlgebra/Matrix/EigenvalueSearch.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Borel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Centralizer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/ConjugacyClasses.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/ConjugacyClasses.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/LeftMulMatrix.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/LeftMulMatrix.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/NonSplitTorus.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/NonSplitTorus.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/PolynomialFunctions.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/PolynomialFunctions.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/ScalarUnipotent.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/ScalarUnipotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Transvection.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Transvection.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Unipotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/UpperUnitriangular/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/UpperUnitriangular/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/UpperUnitriangular/Nilpotent.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/UpperUnitriangular/Nilpotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/Gram.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Gram.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/JointEigenvalueSearch.lean
+++ b/TauCeti/LinearAlgebra/Matrix/JointEigenvalueSearch.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/PosDef.lean
+++ b/TauCeti/LinearAlgebra/Matrix/PosDef.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/PosSemidef.lean
+++ b/TauCeti/LinearAlgebra/Matrix/PosSemidef.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/QuadraticFormCongruence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/QuadraticFormCongruence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/RationalCanonicalFormFinTwo.lean
+++ b/TauCeti/LinearAlgebra/Matrix/RationalCanonicalFormFinTwo.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/Submatrix.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Submatrix.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/SymplecticMultiplier.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SymplecticMultiplier.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Matrix/ToLin.lean
+++ b/TauCeti/LinearAlgebra/Matrix/ToLin.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Multilinear/Polarization.lean
+++ b/TauCeti/LinearAlgebra/Multilinear/Polarization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/OrthogonalGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Projection.lean
+++ b/TauCeti/LinearAlgebra/Projection.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/CartanDieudonne.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Reflection.lean
+++ b/TauCeti/LinearAlgebra/Reflection.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/AdjoinPendant.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/AdjoinPendant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Chain.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Chain.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Classification.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Classification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Coxeter/DynkinType.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Coxeter/DynkinType.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Coxeter/Matrix.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Coxeter/Matrix.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/DiagramPermutations.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/DiagramPermutations.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Duality.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Duality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/DynkinType.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/DynkinType.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/E8Coordinates.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/E8Coordinates.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/AffineD.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/AffineD.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classical.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classification.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Diagram.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Diagram.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Classification.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Classification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/NoBranch.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/NoBranch.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Reindex.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Reindex.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/ForkedDoubleEdge.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/ForkedDoubleEdge.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/Classification.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/Classification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/Components.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/Components.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/Reindex.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/Reindex.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/TripleEdge.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/TripleEdge.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/TwoDoubleEdges.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/TwoDoubleEdges.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/TypeA.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/TypeA.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Flip.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Flip.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/FundamentalDomain.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FundamentalDomain.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Height.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Height.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/InvariantForm/RootString.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/InvariantForm/RootString.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/DominantChamber.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/DominantChamber.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Length.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Length.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/StrongExchange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/StrongExchange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Subword.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Subword.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Isomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Isomorphism.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/KostantPartition.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/KostantPartition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/LongestElement.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/LongestElement.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Lowering.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Lowering.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/NumberOfRoots.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/NumberOfRoots.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Opposition.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Opposition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Positive.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Positive.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/RankTwo.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/RankTwo.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/RootLength.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/RootLength.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Model.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Model.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/Datum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/Lattice.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/Lattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E8/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E8/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E8/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E8/Datum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E8/Lattice.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E8/Lattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/F4.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/F4.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/G2.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/G2.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Chamber.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Chamber.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Dihedral.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Dihedral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Group.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Group.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Orbit.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Orbit.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Vector.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Vector.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Semisimple.lean
+++ b/TauCeti/LinearAlgebra/Semisimple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Submodule/DirectedUnion.lean
+++ b/TauCeti/LinearAlgebra/Submodule/DirectedUnion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/SymmetricPower/Basic.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/SymmetricPower/Basis.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower/Basis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/SymmetricPower/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower/Coordinates.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/SymmetricPower/Lift.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower/Lift.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/TensorProduct/Basis.lean
+++ b/TauCeti/LinearAlgebra/TensorProduct/Basis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/TensorSquare.lean
+++ b/TauCeti/LinearAlgebra/TensorSquare.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/TotallyReal/Basic.lean
+++ b/TauCeti/LinearAlgebra/TotallyReal/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/TotallyReal/Finrank.lean
+++ b/TauCeti/LinearAlgebra/TotallyReal/Finrank.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Trace/Idempotent.lean
+++ b/TauCeti/LinearAlgebra/Trace/Idempotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Trace/Pi.lean
+++ b/TauCeti/LinearAlgebra/Trace/Pi.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/Trace/Prod.lean
+++ b/TauCeti/LinearAlgebra/Trace/Prod.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LinearAlgebra/UnitaryGroup.lean
+++ b/TauCeti/LinearAlgebra/UnitaryGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/AsModule.lean
+++ b/TauCeti/RepresentationTheory/AsModule.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Augmentation.lean
+++ b/TauCeti/RepresentationTheory/Augmentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/BlockRepresentation.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/BlockRepresentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/CentralCharacter.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/CentralCharacter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/CentralIdempotent.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/CentralIdempotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basis.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Integral.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Integral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/MultiplicationMatrix.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/MultiplicationMatrix.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Representation.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Representation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Completeness.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Completeness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/ClassData/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/ClassData/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/ClassData/Dihedral.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/ClassData/Dihedral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/ClassData/EigenvectorSearch.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/ClassData/EigenvectorSearch.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Dihedral.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Dihedral.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Lift.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Lift.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Prime.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Prime.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Structure.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Structure.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Eigenrow.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Eigenrow.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/FiniteField.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/FiniteField.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/InvolutionCount.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/InvolutionCount.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/Trichotomy.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/Trichotomy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/IdempotentDecomposition.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/IdempotentDecomposition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Independence.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Independence.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/IrreducibleClassification.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/IrreducibleClassification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Pairing.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Pairing.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/RealClasses.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/RealClasses.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Recovery.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Recovery.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/SimpleModuleCount.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/SimpleModuleCount.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Specification.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Specification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Table.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Table.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/VirtualCharacter.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/VirtualCharacter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/BrauerGenerators.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/BrauerGenerators.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Decomposition.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Decomposition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Diagonal.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Diagonal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/DominantWeight.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/DominantWeight.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExtremeShape.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Basic.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Shift.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Shift.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Tableau.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Tableau.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Orthogonal.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Orthogonal.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Rational.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Rational.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Restriction.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Restriction.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Standard.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Standard.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Symplectic.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Symplectic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Torus.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Torus.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Volume.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Volume.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylDimension.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylDimension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
+++ b/TauCeti/RepresentationTheory/Compact/ApproximateIdentity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/Averaging.lean
+++ b/TauCeti/RepresentationTheory/Compact/Averaging.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/Character/Basic.lean
+++ b/TauCeti/RepresentationTheory/Compact/Character/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
+++ b/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/Character/Projection.lean
+++ b/TauCeti/RepresentationTheory/Compact/Character/Projection.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/ClassFunctionLp.lean
+++ b/TauCeti/RepresentationTheory/Compact/ClassFunctionLp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/Convolution.lean
+++ b/TauCeti/RepresentationTheory/Compact/Convolution.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/EigenspaceRepresentation.lean
+++ b/TauCeti/RepresentationTheory/Compact/EigenspaceRepresentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/Haar.lean
+++ b/TauCeti/RepresentationTheory/Compact/Haar.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/Integrated.lean
+++ b/TauCeti/RepresentationTheory/Compact/Integrated.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/Intertwiner.lean
+++ b/TauCeti/RepresentationTheory/Compact/Intertwiner.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Compact/MatrixCoefficient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/Orthonormal.lean
+++ b/TauCeti/RepresentationTheory/Compact/Orthonormal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/PeterWeyl.lean
+++ b/TauCeti/RepresentationTheory/Compact/PeterWeyl.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/RegularRepresentation.lean
+++ b/TauCeti/RepresentationTheory/Compact/RegularRepresentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/RepresentativeDensity.lean
+++ b/TauCeti/RepresentationTheory/Compact/RepresentativeDensity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
+++ b/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/Unitarizable.lean
+++ b/TauCeti/RepresentationTheory/Compact/Unitarizable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Compact/UnitaryModel.lean
+++ b/TauCeti/RepresentationTheory/Compact/UnitaryModel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/Character.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Character.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/Conjugate.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Conjugate.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/InvariantComplement.lean
+++ b/TauCeti/RepresentationTheory/Continuous/InvariantComplement.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
+++ b/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/Representative.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Representative.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/Subrepresentation.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Subrepresentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/TensorProduct.lean
+++ b/TauCeti/RepresentationTheory/Continuous/TensorProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/Transport.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Transport.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/Unitary/Basic.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Unitary/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Continuous/Unitary/Equivalence.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Unitary/Equivalence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Dual.lean
+++ b/TauCeti/RepresentationTheory/Dual.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ExteriorPower.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/GaloisLattice/Basic.lean
+++ b/TauCeti/RepresentationTheory/GaloisLattice/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/GaloisLattice/Dual.lean
+++ b/TauCeti/RepresentationTheory/GaloisLattice/Dual.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/GaloisLattice/FiniteQuotient.lean
+++ b/TauCeti/RepresentationTheory/GaloisLattice/FiniteQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Artin.lean
+++ b/TauCeti/RepresentationTheory/Induction/Artin.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Character.lean
+++ b/TauCeti/RepresentationTheory/Induction/Character.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/ClassFunction.lean
+++ b/TauCeti/RepresentationTheory/Induction/ClassFunction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Basic.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Orbit.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Orbit.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Conjugate.lean
+++ b/TauCeti/RepresentationTheory/Induction/Conjugate.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex, Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/DoubleCosetPairing.lean
+++ b/TauCeti/RepresentationTheory/Induction/DoubleCosetPairing.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
+++ b/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Ideal.lean
+++ b/TauCeti/RepresentationTheory/Induction/Ideal.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Inertia.lean
+++ b/TauCeti/RepresentationTheory/Induction/Inertia.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Mackey/Basic.lean
+++ b/TauCeti/RepresentationTheory/Induction/Mackey/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Mackey/Intertwining.lean
+++ b/TauCeti/RepresentationTheory/Induction/Mackey/Intertwining.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Mackey/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Induction/Mackey/Irreducible.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Mackey/Subgroup.lean
+++ b/TauCeti/RepresentationTheory/Induction/Mackey/Subgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Permutation.lean
+++ b/TauCeti/RepresentationTheory/Induction/Permutation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Projection.lean
+++ b/TauCeti/RepresentationTheory/Induction/Projection.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Induction/Restriction.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Spanning.lean
+++ b/TauCeti/RepresentationTheory/Induction/Spanning.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean
+++ b/TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Induction/VirtualCharacter.lean
+++ b/TauCeti/RepresentationTheory/Induction/VirtualCharacter.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Intertwining.lean
+++ b/TauCeti/RepresentationTheory/Intertwining.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/InvariantForm.lean
+++ b/TauCeti/RepresentationTheory/InvariantForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/MatrixCoefficients.lean
+++ b/TauCeti/RepresentationTheory/MatrixCoefficients.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/OfModule.lean
+++ b/TauCeti/RepresentationTheory/OfModule.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/PermutationForm.lean
+++ b/TauCeti/RepresentationTheory/PermutationForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ProjectiveRepresentation/Basic.lean
+++ b/TauCeti/RepresentationTheory/ProjectiveRepresentation/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ProjectiveRepresentation/Extension.lean
+++ b/TauCeti/RepresentationTheory/ProjectiveRepresentation/Extension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean
+++ b/TauCeti/RepresentationTheory/ProjectiveRepresentation/SchurMultiplier.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/PathAlgebra.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/PathAlgebra.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/AdmissibleIdeal.lean
+++ b/TauCeti/RepresentationTheory/Quiver/AdmissibleIdeal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/EulerForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/FirstArrow.lean
+++ b/TauCeti/RepresentationTheory/Quiver/FirstArrow.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/EulerForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/PathAlgebra.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/PathAlgebra.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/UpperTriangular.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/UpperTriangular.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/LastArrow.lean
+++ b/TauCeti/RepresentationTheory/Quiver/LastArrow.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/ModuleDecomposition.lean
+++ b/TauCeti/RepresentationTheory/Quiver/ModuleDecomposition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/OneLoop.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/OneLoop.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/PrimitiveIdempotent.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PrimitiveIdempotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Radical.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Radical.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Acyclic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Acyclic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Admissible.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Admissible.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/DimensionVector.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/DimensionVector.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/EulerForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/FullyFaithful.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/FullyFaithful.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Indecomposable.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Indecomposable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Iterate.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Iterate.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Representation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Representation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Comparison.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Comparison.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/DimensionVector.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Indecomposable.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Indecomposable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Injective/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Injective/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Injective/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Injective/EulerForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Acyclic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Acyclic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Projective/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Projective/EulerForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Simple.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Simple.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Subrepresentation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Subrepresentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Quiver/SemisimpleQuotient.lean
+++ b/TauCeti/RepresentationTheory/Quiver/SemisimpleQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Rep/OfMulAction.lean
+++ b/TauCeti/RepresentationTheory/Rep/OfMulAction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SU2/Basic.lean
+++ b/TauCeti/RepresentationTheory/SU2/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SU2/Character.lean
+++ b/TauCeti/RepresentationTheory/SU2/Character.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SU2/ConjugacyClasses.lean
+++ b/TauCeti/RepresentationTheory/SU2/ConjugacyClasses.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SU2/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/SU2/Irreducible.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SU2/TorusConjugacy.lean
+++ b/TauCeti/RepresentationTheory/SU2/TorusConjugacy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SU2/Weight.lean
+++ b/TauCeti/RepresentationTheory/SU2/Weight.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SU2/Weyl/Basic.lean
+++ b/TauCeti/RepresentationTheory/SU2/Weyl/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SU2/Weyl/Character.lean
+++ b/TauCeti/RepresentationTheory/SU2/Weyl/Character.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SU2/Weyl/Orthogonality.lean
+++ b/TauCeti/RepresentationTheory/SU2/Weyl/Orthogonality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Spin/HalfSpin.lean
+++ b/TauCeti/RepresentationTheory/Spin/HalfSpin.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Exists.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Exists.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Spin/Representation.lean
+++ b/TauCeti/RepresentationTheory/Spin/Representation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Subrepresentation.lean
+++ b/TauCeti/RepresentationTheory/Subrepresentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/ClassSize.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Factorization.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Factorization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Partitions.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/PermutationModule/Basic.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/PermutationModule/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/PermutationModule/Extremes.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/PermutationModule/Extremes.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/PermutationModule/Form.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/PermutationModule/Form.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Relabel.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Relabel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/RowColumnSubgroup.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/RowColumnSubgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/AbsoluteIrreducibility.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/AbsoluteIrreducibility.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Character.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Character.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Comparison.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Comparison.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Distinctness.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Distinctness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Dominance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Ideal/Basic.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Ideal/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Ideal/Extremes.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Ideal/Extremes.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Ideal/Idempotent.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Ideal/Idempotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Ideal/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Ideal/Irreducible.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Module.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Module.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/Basic.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/Faithful.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/Faithful.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/Invariants.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/Invariants.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/Vanishing.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Vanishing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Symmetric/YoungSubgroup.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/YoungSubgroup.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SymmetricPower.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Tensor/PermRange.lean
+++ b/TauCeti/RepresentationTheory/Tensor/PermRange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Tensor/Power.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Power.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 


### PR DESCRIPTION
This PR makes every file in `TauCeti/Algebra`, `TauCeti/Analysis`, `TauCeti/RepresentationTheory` and `TauCeti/LinearAlgebra` carry a copyright header that satisfies Mathlib's `linter.style.header`.

Part 1 of 2. Regenerated on current `main` after the original branch fell 268 commits behind; the change is fully scripted, so regenerating was more reliable than resolving 1863 conflicts by hand, and it picks up files added since. Split by directory because the whole-tree change is now 2094 files and 2108 insertions, over CI's 2000 guard on both counts.

The header state had drifted a long way: most files had no `Authors:` line at all, and those that did used a dozen spellings, including `Claude`, `Codex`, `Cadence`, and four variations on the project's own name.

- Files with no `Authors:` line gain `Authors: The Tau Ceti contributors`.
- Files naming an AI assistant, or a variant project spelling, are normalised to the same line.
- Files crediting a named human (Chris Birkbeck, Kim Morrison, Joseph Tooby-Smith, including mixed lines) are left exactly as they are. Erasing a named person's credit is not something a formatting pass should do, and the linter does not ask for it.

I verified the result by replicating the linter's own checks over the whole tree: `/-` and `-/` alone on their lines, the copyright line starting `Copyright (c) 20` and ending `. All rights reserved.`, the exact license line, and an `Authors: ` line that is non-empty, has no double space, no `" and "`, and no trailing period. Zero files fail.

One case worth noting, because it caught a bug in my first pass: `AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean` mentions "Authors: Chris Birkbeck" inside a docstring at line 71 as a provenance note. A whole-file search for `^Authors:` matched that, took the file for human-credited, and left its header without an authors line. The check is now scoped to the header block.

No Lean code changes; the build is unaffected.

Roadmap: none

🤖 Prepared with Claude Code