### PR TITLE
feat: the degree of an isogeny is finite, positive and multiplicative

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Finrank.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Finrank.lean
@@ -8,6 +8,7 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
 public import Mathlib.LinearAlgebra.Dimension.Localization
 public import Mathlib.FieldTheory.IntermediateField.Adjoin.Defs
 public import Mathlib.FieldTheory.RatFunc.Basic
+import TauCeti.FieldTheory.IntermediateField.FieldRange
 
 /-!
 # The function field of a Weierstrass curve has degree two over `R(x)`
@@ -45,8 +46,8 @@ rational function field that sits *inside* `R(W)` as an intermediate field.
 * `WeierstrassCurve.Affine.finrank_ratFuncRange`: `[F(W) : F(x)] = 2` for that copy. This is the
   degree above a subfield of `F(W)` rather than above an abstract `L`, which is what any argument
   comparing two subfields of `F(W)` — a tower, or a relative degree — needs; the two are related
-  by transporting along `AlgHom.equivFieldRange`, since the copy and `RatFunc F` are isomorphic as
-  fields acting on `F(W)`.
+  by `TauCeti.AlgHom.finrank_fieldRange`, since the copy and `RatFunc F` are isomorphic as fields
+  acting on `F(W)`.
 
 Exporting the algebra instance is safe here for the reason Mathlib withholds it in general: the
 collision is with the identity structure on `FractionRing R[X]`, and `R(W)` is a *quadratic*
@@ -180,22 +181,12 @@ theorem mem_ratFuncRange {z : W.FunctionField} :
   AlgHom.mem_fieldRange
 
 /-- **`[F(W) : F(x)] = 2`**, for the copy of the rational function field inside `F(W)`: the
-`L = RatFunc F` case of `finrank_functionField`, transported along the embedding. -/
+`L = RatFunc F` case of `finrank_functionField`, transported along the embedding by
+`TauCeti.AlgHom.finrank_fieldRange`. -/
 @[simp]
-theorem finrank_ratFuncRange : Module.finrank (ratFuncRange W) W.FunctionField = 2 := by
-  have hsquare : (algebraMap (ratFuncRange W) W.FunctionField).comp
-      (IsScalarTower.toAlgHom F (RatFunc F) W.FunctionField).equivFieldRange.toRingEquiv.toRingHom =
-      (RingEquiv.refl W.FunctionField).toRingHom.comp
-        (algebraMap (RatFunc F) W.FunctionField) := by
-    -- both sides send `r` to its image in `F(W)`; `equivFieldRange` is the range restriction
-    ext x
-    exact AlgHom.equivFieldRange_apply_coe
-      (IsScalarTower.toAlgHom F (RatFunc F) W.FunctionField) x
-  have h := Algebra.finrank_eq_of_equiv_equiv
-    (IsScalarTower.toAlgHom F (RatFunc F) W.FunctionField).equivFieldRange.toRingEquiv
-    (RingEquiv.refl W.FunctionField) hsquare
-  rw [finrank_functionField W (RatFunc F)] at h
-  exact h.symm
+theorem finrank_ratFuncRange : Module.finrank (ratFuncRange W) W.FunctionField = 2 :=
+  (TauCeti.AlgHom.finrank_fieldRange (IsScalarTower.toAlgHom F (RatFunc F) W.FunctionField)
+    fun _ ↦ rfl).trans (finrank_functionField W (RatFunc F))
 
 end Field
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Finrank.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Finrank.lean
@@ -186,7 +186,8 @@ theorem mem_ratFuncRange {z : W.FunctionField} :
 @[simp]
 theorem finrank_ratFuncRange : Module.finrank (ratFuncRange W) W.FunctionField = 2 :=
   (TauCeti.AlgHom.finrank_fieldRange (IsScalarTower.toAlgHom F (RatFunc F) W.FunctionField)
-    fun _ ↦ rfl).trans (finrank_functionField W (RatFunc F))
+    fun z ↦ (IsScalarTower.toAlgHom_apply F (RatFunc F) W.FunctionField z).symm).trans
+      (finrank_functionField W (RatFunc F))
 
 end Field
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Finrank
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.FunctionField
 import Mathlib.NumberTheory.FunctionField
+import TauCeti.FieldTheory.IntermediateField.FieldRange
 
 /-!
 # The degree of an isogeny
@@ -21,8 +22,8 @@ of an infinite extension reads `0`. Finiteness holds for every isogeny, and this
 it: the pullback of the affine coordinate is transcendental over `F`
 (`TauCeti.Isogeny.transcendental_pullback_X`), so the pulled-back function field already
 contains a transcendental element `t`, and `F(W₁)` is finite over `F(t)` because it is finite
-over the rational function field. Positivity of the degree follows at once, and so does the
-converse reading of degree one: an isogeny of degree one is an isomorphism on function fields.
+over the rational function field. Positivity of the degree follows at once, and degree one reads
+as an isomorphism on function fields.
 
 Multiplicativity under composition is the `finrank` tower formula, applied to
 `F(W₃) → F(W₂) → F(W₁)`. The pulled-back copies of `F(W₂)` and `F(W₃)` are subfields of
@@ -36,22 +37,27 @@ degree off any algebra structure whose structure map is the pullback.
 
 ## Main results
 
-* `TauCeti.Isogeny.exists_transcendental_mem_fieldRange`: the pulled-back function field is not
-  contained in the constants.
 * `TauCeti.Isogeny.finiteDimensional`: **automatic finiteness** — the extension a degree
   measures is finite, the inseparable case included.
 * `TauCeti.Isogeny.degree_eq_finrank`: the degree read off an arbitrary algebra structure
   induced by the pullback.
-* `TauCeti.Isogeny.degree_pos`: an isogeny has positive degree; `TauCeti.Isogeny.degree_id`
-  computes the identity's, and is the `@[simp]` normal form of a degree.
+* `TauCeti.Isogeny.degree_pos`: an isogeny has positive degree.
+* `TauCeti.Isogeny.degree_eq_one_iff`: degree one means the function-field pullback is onto;
+  `TauCeti.Isogeny.degree_id` is the identity's case, and is the `@[simp]` normal form of a
+  degree.
 * `TauCeti.Isogeny.degree_comp`: **the tower formula** `deg (ψ ∘ φ) = deg ψ * deg φ`.
-* `TauCeti.Isogeny.degree_eq_one_iff`: degree one means the function-field pullback is onto.
 
 These are the `Isogeny.finiteDimensional` and `degree_pos` seeds of
 `TauCetiRoadmap/EllipticCurves/Suggested.lean` together with the degree multiplicativity named
-in `README.md` §Layer 1; the proofs are original. The mathematics is Silverman, *The Arithmetic
-of Elliptic Curves*, II.2.4(a) and II.2.4(c) — where finiteness of the extension is exactly what
-makes a nonconstant map of curves finite.
+in `README.md` §Layer 1. The mathematics is Silverman, *The Arithmetic of Elliptic Curves*,
+II.2.4(a) and II.2.4(c) — where finiteness of the extension is exactly what makes a nonconstant
+map of curves finite.
+
+`degree` is the coordinate-ring form of D. Angdinata's function-field definition, as the
+`Isogeny` structure itself is, and `finiteDimensional` is ⚠ mathlib-track material: it is proved
+in that shared upstream development, in its function-field form, ahead of the mathlib PRs
+(`TauCetiRoadmap/EllipticCurves/README.md` §Provenance). It is built here until those land; the
+proofs below are written against the coordinate-ring form rather than ported.
 
 ## References
 
@@ -85,36 +91,29 @@ left-hand side, so tagging both fails `simpNF`. -/
 theorem degree_def (φ : Isogeny W₁ W₂) :
     φ.degree = Module.finrank φ.fieldPullback.fieldRange W₁.FunctionField := (rfl)
 
-/-- **The pulled-back function field contains a transcendental element**: the pullback of the
-affine coordinate `x` of the target, which `transcendental_pullback_X` places outside the
-constants. This is the input to finiteness, and it is where the isogeny hypotheses are spent —
-a merely arbitrary subfield of `W₁.FunctionField` need not sit under a finite extension. -/
-theorem exists_transcendental_mem_fieldRange (φ : Isogeny W₁ W₂) :
-    ∃ t ∈ φ.fieldPullback.fieldRange, Transcendental F t :=
-  ⟨φ.pullback (algebraMap F[X] W₂.CoordinateRing X),
-    ⟨algebraMap W₂.CoordinateRing W₂.FunctionField (algebraMap F[X] W₂.CoordinateRing X), by
-      simp⟩,
-    φ.transcendental_pullback_X⟩
-
+-- `RatFunc` is opened for the duration of this declaration alone: the algebra structure of
+-- `W₁.FunctionField` over the rational function field is a scoped instance upstream, because it
+-- is a diamond when the two coincide.
 open scoped RatFunc in
 /-- **An isogeny has finite degree** (Silverman II.2.4(a)): the extension of `W₁.FunctionField`
 over the pulled-back copy of `W₂.FunctionField` is finite, with no separability hypothesis —
 purely inseparable isogenies such as Frobenius are covered.
 
-The pulled-back copy contains an element `t` transcendental over `F`, and `W₁.FunctionField` is
-finite over `F(t)`, because it is a function field over `F`: finite over the rational function
-field, by `WeierstrassCurve.Affine.finiteDimensional_functionField`. Enlarging the base field
-from `F(t)` to the whole pulled-back copy keeps it finite.
-
-`RatFunc` is opened for the duration of this declaration alone: the algebra structure of
-`W₁.FunctionField` over the rational function field is a scoped instance upstream, because it
-is a diamond when the two coincide. -/
+The pulled-back copy contains the pullback `t` of the target's affine coordinate, transcendental
+over `F` by `transcendental_pullback_X`, and `W₁.FunctionField` is finite over `F(t)`, because it
+is a function field over `F`: finite over the rational function field, by
+`WeierstrassCurve.Affine.finiteDimensional_functionField`. Enlarging the base field from `F(t)`
+to the whole pulled-back copy keeps it finite. This is where the isogeny hypotheses are spent — a
+merely arbitrary subfield of `W₁.FunctionField` need not sit under a finite extension. -/
 instance finiteDimensional (φ : Isogeny W₁ W₂) :
     FiniteDimensional φ.fieldPullback.fieldRange W₁.FunctionField := by
-  obtain ⟨t, htmem, ht⟩ := φ.exists_transcendental_mem_fieldRange
-  have hle : F⟮t⟯ ≤ φ.fieldPullback.fieldRange := adjoin_simple_le_iff.2 htmem
+  set t := φ.pullback (algebraMap F[X] W₂.CoordinateRing X) with ht_def
+  have hle : F⟮t⟯ ≤ φ.fieldPullback.fieldRange :=
+    adjoin_simple_le_iff.2
+      ⟨algebraMap W₂.CoordinateRing W₂.FunctionField (algebraMap F[X] W₂.CoordinateRing X), by
+        simp [ht_def]⟩
   have : FiniteDimensional F⟮t⟯ W₁.FunctionField :=
-    FunctionField.finiteDimensional_of_adjoin_transcendental ht
+    FunctionField.finiteDimensional_of_adjoin_transcendental φ.transcendental_pullback_X
   let _ := (IntermediateField.inclusion hle).toRingHom.toAlgebra
   have : IsScalarTower F⟮t⟯ φ.fieldPullback.fieldRange W₁.FunctionField :=
     IsScalarTower.of_algebraMap_eq fun _ ↦ rfl
@@ -127,15 +126,8 @@ structure map is the pullback, rather than for one fixed choice: registering suc
 globally would create a diamond, since different isogenies induce different ones. -/
 theorem degree_eq_finrank (φ : Isogeny W₁ W₂) [Algebra W₂.FunctionField W₁.FunctionField]
     (h : ∀ z, algebraMap W₂.FunctionField W₁.FunctionField z = φ.fieldPullback z) :
-    φ.degree = Module.finrank W₂.FunctionField W₁.FunctionField := by
-  have hsquare : (algebraMap φ.fieldPullback.fieldRange W₁.FunctionField).comp
-      φ.fieldPullback.equivFieldRange.toRingEquiv.toRingHom =
-      (RingEquiv.refl W₁.FunctionField).toRingHom.comp
-        (algebraMap W₂.FunctionField W₁.FunctionField) := by
-    ext z
-    exact (AlgHom.equivFieldRange_apply_coe φ.fieldPullback z).trans (h z).symm
-  exact (Algebra.finrank_eq_of_equiv_equiv φ.fieldPullback.equivFieldRange.toRingEquiv
-    (RingEquiv.refl W₁.FunctionField) hsquare).symm
+    φ.degree = Module.finrank W₂.FunctionField W₁.FunctionField :=
+  φ.degree_def.trans (AlgHom.finrank_fieldRange φ.fieldPullback h)
 
 /-- **The degree of an isogeny is positive.** The extension is finite and the source function
 field is nontrivial. -/
@@ -147,18 +139,22 @@ theorem degree_pos (φ : Isogeny W₁ W₂) : 0 < φ.degree :=
 theorem degree_ne_zero (φ : Isogeny W₁ W₂) : φ.degree ≠ 0 :=
   φ.degree_pos.ne'
 
+/-- **Degree one means an isomorphism of function fields.** The degree measures
+`W₁.FunctionField` over the image of `fieldPullback`, so it is one exactly when that image is
+everything. -/
+theorem degree_eq_one_iff (φ : Isogeny W₁ W₂) :
+    φ.degree = 1 ↔ Function.Surjective φ.fieldPullback := by
+  rw [degree_def, IntermediateField.finrank_eq_one_iff_eq_top, AlgHom.fieldRange_eq_top]
+
 /-- The identity isogeny has degree one: its function-field pullback is the identity, so the
 extension it measures is trivial. -/
 @[simp]
-theorem degree_id (W : WeierstrassCurve.Affine F) : (id W).degree = 1 := by
-  have hrange : (id W).fieldPullback.fieldRange = ⊤ := by
-    rw [id_fieldPullback]
-    exact AlgHom.fieldRange_eq_top.mpr Function.surjective_id
-  rw [degree_def, hrange]
-  exact IntermediateField.finrank_top
+theorem degree_id (W : WeierstrassCurve.Affine F) : (id W).degree = 1 :=
+  (degree_eq_one_iff _).2 <| by rw [id_fieldPullback]; exact Function.surjective_id
 
 /-- **The degree is multiplicative under composition** (Silverman II.2.4(c)): the tower formula
 for `F(W₃) ⊆ F(W₂) ⊆ F(W₁)`, the inclusions being the pullbacks. -/
+@[simp]
 theorem degree_comp (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂) :
     (ψ.comp φ).degree = ψ.degree * φ.degree := by
   let _ := φ.fieldPullback.toRingHom.toAlgebra
@@ -166,24 +162,10 @@ theorem degree_comp (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂) :
   let _ := (ψ.comp φ).fieldPullback.toRingHom.toAlgebra
   have htower : IsScalarTower W₃.FunctionField W₂.FunctionField W₁.FunctionField :=
     IsScalarTower.of_algebraMap_eq fun z ↦ by
-      change (ψ.comp φ).fieldPullback z = φ.fieldPullback (ψ.fieldPullback z)
-      rw [comp_fieldPullback]
-      rfl
+      simp [RingHom.algebraMap_toAlgebra, comp_fieldPullback]
   rw [φ.degree_eq_finrank fun _ ↦ rfl, ψ.degree_eq_finrank fun _ ↦ rfl,
     (ψ.comp φ).degree_eq_finrank fun _ ↦ rfl]
   exact (Module.finrank_mul_finrank W₃.FunctionField W₂.FunctionField W₁.FunctionField).symm
-
-/-- **Degree one means an isomorphism of function fields.** The degree measures
-`W₁.FunctionField` over the image of `fieldPullback`, so it is one exactly when that image is
-everything — the finiteness of the extension being what rules out the degenerate reading of
-`finrank`. -/
-theorem degree_eq_one_iff (φ : Isogeny W₁ W₂) :
-    φ.degree = 1 ↔ Function.Surjective φ.fieldPullback := by
-  rw [← AlgHom.fieldRange_eq_top]
-  refine ⟨fun h ↦ IntermediateField.eq_of_le_of_finrank_eq' le_top ?_, fun h ↦ ?_⟩
-  · rw [IntermediateField.finrank_top, ← degree_def, h]
-  · rw [degree_def, h]
-    exact IntermediateField.finrank_top
 
 end Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Finrank
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.FunctionField
+import Mathlib.NumberTheory.FunctionField
+
+/-!
+# The degree of an isogeny
+
+The degree of an isogeny `φ : W₁ → W₂` of affine Weierstrass curves over a field `F` is the
+dimension of `W₁.FunctionField` over the image of the function-field pullback `φ.fieldPullback`
+— the pulled-back copy of `W₂.FunctionField`, which that pullback embeds isomorphically. No
+properness, smoothness or separability input is involved: the degree is field theory.
+
+That reading is only honest once the extension is known to be finite, since `Module.finrank`
+of an infinite extension reads `0`. Finiteness holds for every isogeny, and this file proves
+it: the pullback of the affine coordinate is transcendental over `F`
+(`TauCeti.Isogeny.transcendental_pullback_X`), so the pulled-back function field already
+contains a transcendental element `t`, and `F(W₁)` is finite over `F(t)` because it is finite
+over the rational function field. Positivity of the degree follows at once, and so does the
+converse reading of degree one: an isogeny of degree one is an isomorphism on function fields.
+
+Multiplicativity under composition is the `finrank` tower formula, applied to
+`F(W₃) → F(W₂) → F(W₁)`. The pulled-back copies of `F(W₂)` and `F(W₃)` are subfields of
+`F(W₁)`, so the tower is stated through `TauCeti.Isogeny.degree_eq_finrank`, which reads a
+degree off any algebra structure whose structure map is the pullback.
+
+## Main definitions
+
+* `TauCeti.Isogeny.degree`: the degree of an isogeny, with `TauCeti.Isogeny.degree_def` the
+  equation lemma the module boundary makes necessary.
+
+## Main results
+
+* `TauCeti.Isogeny.exists_transcendental_mem_fieldRange`: the pulled-back function field is not
+  contained in the constants.
+* `TauCeti.Isogeny.finiteDimensional`: **automatic finiteness** — the extension a degree
+  measures is finite, the inseparable case included.
+* `TauCeti.Isogeny.degree_eq_finrank`: the degree read off an arbitrary algebra structure
+  induced by the pullback.
+* `TauCeti.Isogeny.degree_pos`: an isogeny has positive degree; `TauCeti.Isogeny.degree_id`
+  computes the identity's, and is the `@[simp]` normal form of a degree.
+* `TauCeti.Isogeny.degree_comp`: **the tower formula** `deg (ψ ∘ φ) = deg ψ * deg φ`.
+* `TauCeti.Isogeny.degree_eq_one_iff`: degree one means the function-field pullback is onto.
+
+These are the `Isogeny.finiteDimensional` and `degree_pos` seeds of
+`TauCetiRoadmap/EllipticCurves/Suggested.lean` together with the degree multiplicativity named
+in `README.md` §Layer 1; the proofs are original. The mathematics is Silverman, *The Arithmetic
+of Elliptic Curves*, II.2.4(a) and II.2.4(c) — where finiteness of the extension is exactly what
+makes a nonconstant map of curves finite.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.
+-/
+
+public section
+
+namespace TauCeti
+
+open IntermediateField Polynomial
+
+namespace Isogeny
+
+variable {F : Type*} [Field F] {W₁ W₂ W₃ : WeierstrassCurve.Affine F}
+
+/-- **The degree of an isogeny**: the dimension of the source function field `W₁.FunctionField`
+over the image of `fieldPullback` — the pulled-back copy of the target's function field
+`W₂.FunctionField`, which `fieldPullback` embeds isomorphically.
+
+This is Silverman, *The Arithmetic of Elliptic Curves*, II.2.4(a). The extension is finite
+(`finiteDimensional` below), so the dimension is honest and positive. -/
+noncomputable def degree (φ : Isogeny W₁ W₂) : ℕ :=
+  Module.finrank φ.fieldPullback.fieldRange W₁.FunctionField
+
+/-- The defining formula for `degree`. The definition's body is not exposed across the module
+boundary, so this is how downstream modules compute with it.
+
+Not `@[simp]`: `degree_id` is the simp-normal form of a degree, and this lemma rewrites its
+left-hand side, so tagging both fails `simpNF`. -/
+theorem degree_def (φ : Isogeny W₁ W₂) :
+    φ.degree = Module.finrank φ.fieldPullback.fieldRange W₁.FunctionField := (rfl)
+
+/-- **The pulled-back function field contains a transcendental element**: the pullback of the
+affine coordinate `x` of the target, which `transcendental_pullback_X` places outside the
+constants. This is the input to finiteness, and it is where the isogeny hypotheses are spent —
+a merely arbitrary subfield of `W₁.FunctionField` need not sit under a finite extension. -/
+theorem exists_transcendental_mem_fieldRange (φ : Isogeny W₁ W₂) :
+    ∃ t ∈ φ.fieldPullback.fieldRange, Transcendental F t :=
+  ⟨φ.pullback (algebraMap F[X] W₂.CoordinateRing X),
+    ⟨algebraMap W₂.CoordinateRing W₂.FunctionField (algebraMap F[X] W₂.CoordinateRing X), by
+      simp⟩,
+    φ.transcendental_pullback_X⟩
+
+open scoped RatFunc in
+/-- **An isogeny has finite degree** (Silverman II.2.4(a)): the extension of `W₁.FunctionField`
+over the pulled-back copy of `W₂.FunctionField` is finite, with no separability hypothesis —
+purely inseparable isogenies such as Frobenius are covered.
+
+The pulled-back copy contains an element `t` transcendental over `F`, and `W₁.FunctionField` is
+finite over `F(t)`, because it is a function field over `F`: finite over the rational function
+field, by `WeierstrassCurve.Affine.finiteDimensional_functionField`. Enlarging the base field
+from `F(t)` to the whole pulled-back copy keeps it finite.
+
+`RatFunc` is opened for the duration of this declaration alone: the algebra structure of
+`W₁.FunctionField` over the rational function field is a scoped instance upstream, because it
+is a diamond when the two coincide. -/
+instance finiteDimensional (φ : Isogeny W₁ W₂) :
+    FiniteDimensional φ.fieldPullback.fieldRange W₁.FunctionField := by
+  obtain ⟨t, htmem, ht⟩ := φ.exists_transcendental_mem_fieldRange
+  have hle : F⟮t⟯ ≤ φ.fieldPullback.fieldRange := adjoin_simple_le_iff.2 htmem
+  have : FiniteDimensional F⟮t⟯ W₁.FunctionField :=
+    FunctionField.finiteDimensional_of_adjoin_transcendental ht
+  let _ := (IntermediateField.inclusion hle).toRingHom.toAlgebra
+  have : IsScalarTower F⟮t⟯ φ.fieldPullback.fieldRange W₁.FunctionField :=
+    IsScalarTower.of_algebraMap_eq fun _ ↦ rfl
+  exact Module.Finite.of_restrictScalars_finite F⟮t⟯ _ _
+
+/-- **The degree read off any algebra structure induced by the pullback.** The function-field
+pullback identifies `W₂.FunctionField` with the subfield of `W₁.FunctionField` that `degree`
+measures against, so the two dimensions agree. Stated for an arbitrary algebra structure whose
+structure map is the pullback, rather than for one fixed choice: registering such a structure
+globally would create a diamond, since different isogenies induce different ones. -/
+theorem degree_eq_finrank (φ : Isogeny W₁ W₂) [Algebra W₂.FunctionField W₁.FunctionField]
+    (h : ∀ z, algebraMap W₂.FunctionField W₁.FunctionField z = φ.fieldPullback z) :
+    φ.degree = Module.finrank W₂.FunctionField W₁.FunctionField := by
+  have hsquare : (algebraMap φ.fieldPullback.fieldRange W₁.FunctionField).comp
+      φ.fieldPullback.equivFieldRange.toRingEquiv.toRingHom =
+      (RingEquiv.refl W₁.FunctionField).toRingHom.comp
+        (algebraMap W₂.FunctionField W₁.FunctionField) := by
+    ext z
+    exact (AlgHom.equivFieldRange_apply_coe φ.fieldPullback z).trans (h z).symm
+  exact (Algebra.finrank_eq_of_equiv_equiv φ.fieldPullback.equivFieldRange.toRingEquiv
+    (RingEquiv.refl W₁.FunctionField) hsquare).symm
+
+/-- **The degree of an isogeny is positive.** The extension is finite and the source function
+field is nontrivial. -/
+theorem degree_pos (φ : Isogeny W₁ W₂) : 0 < φ.degree :=
+  Module.finrank_pos
+
+/-- The degree of an isogeny is nonzero, the `≠` form of `degree_pos`. -/
+@[simp]
+theorem degree_ne_zero (φ : Isogeny W₁ W₂) : φ.degree ≠ 0 :=
+  φ.degree_pos.ne'
+
+/-- The identity isogeny has degree one: its function-field pullback is the identity, so the
+extension it measures is trivial. -/
+@[simp]
+theorem degree_id (W : WeierstrassCurve.Affine F) : (id W).degree = 1 := by
+  have hrange : (id W).fieldPullback.fieldRange = ⊤ := by
+    rw [id_fieldPullback]
+    exact AlgHom.fieldRange_eq_top.mpr Function.surjective_id
+  rw [degree_def, hrange]
+  exact IntermediateField.finrank_top
+
+/-- **The degree is multiplicative under composition** (Silverman II.2.4(c)): the tower formula
+for `F(W₃) ⊆ F(W₂) ⊆ F(W₁)`, the inclusions being the pullbacks. -/
+theorem degree_comp (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂) :
+    (ψ.comp φ).degree = ψ.degree * φ.degree := by
+  let _ := φ.fieldPullback.toRingHom.toAlgebra
+  let _ := ψ.fieldPullback.toRingHom.toAlgebra
+  let _ := (ψ.comp φ).fieldPullback.toRingHom.toAlgebra
+  have htower : IsScalarTower W₃.FunctionField W₂.FunctionField W₁.FunctionField :=
+    IsScalarTower.of_algebraMap_eq fun z ↦ by
+      change (ψ.comp φ).fieldPullback z = φ.fieldPullback (ψ.fieldPullback z)
+      rw [comp_fieldPullback]
+      rfl
+  rw [φ.degree_eq_finrank fun _ ↦ rfl, ψ.degree_eq_finrank fun _ ↦ rfl,
+    (ψ.comp φ).degree_eq_finrank fun _ ↦ rfl]
+  exact (Module.finrank_mul_finrank W₃.FunctionField W₂.FunctionField W₁.FunctionField).symm
+
+/-- **Degree one means an isomorphism of function fields.** The degree measures
+`W₁.FunctionField` over the image of `fieldPullback`, so it is one exactly when that image is
+everything — the finiteness of the extension being what rules out the degenerate reading of
+`finrank`. -/
+theorem degree_eq_one_iff (φ : Isogeny W₁ W₂) :
+    φ.degree = 1 ↔ Function.Surjective φ.fieldPullback := by
+  rw [← AlgHom.fieldRange_eq_top]
+  refine ⟨fun h ↦ IntermediateField.eq_of_le_of_finrank_eq' le_top ?_, fun h ↦ ?_⟩
+  · rw [IntermediateField.finrank_top, ← degree_def, h]
+  · rw [degree_def, h]
+    exact IntermediateField.finrank_top
+
+end Isogeny
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
@@ -116,7 +116,9 @@ instance finiteDimensional (φ : Isogeny W₁ W₂) :
     FunctionField.finiteDimensional_of_adjoin_transcendental φ.transcendental_pullback_X
   let _ := (IntermediateField.inclusion hle).toRingHom.toAlgebra
   have : IsScalarTower F⟮t⟯ φ.fieldPullback.fieldRange W₁.FunctionField :=
-    IsScalarTower.of_algebraMap_eq fun _ ↦ rfl
+    IsScalarTower.of_algebraMap_eq fun z ↦ by
+      rw [RingHom.algebraMap_toAlgebra]
+      exact (IntermediateField.coe_inclusion hle z).symm
   exact Module.Finite.of_restrictScalars_finite F⟮t⟯ _ _
 
 /-- **The degree read off any algebra structure induced by the pullback.** The function-field
@@ -163,8 +165,15 @@ theorem degree_comp (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂) :
   have htower : IsScalarTower W₃.FunctionField W₂.FunctionField W₁.FunctionField :=
     IsScalarTower.of_algebraMap_eq fun z ↦ by
       simp [RingHom.algebraMap_toAlgebra, comp_fieldPullback]
-  rw [φ.degree_eq_finrank fun _ ↦ rfl, ψ.degree_eq_finrank fun _ ↦ rfl,
-    (ψ.comp φ).degree_eq_finrank fun _ ↦ rfl]
+  rw [φ.degree_eq_finrank fun z ↦ by
+      rw [RingHom.algebraMap_toAlgebra]
+      exact congrFun (AlgHom.coe_toRingHom φ.fieldPullback) z,
+    ψ.degree_eq_finrank fun z ↦ by
+      rw [RingHom.algebraMap_toAlgebra]
+      exact congrFun (AlgHom.coe_toRingHom ψ.fieldPullback) z,
+    (ψ.comp φ).degree_eq_finrank fun z ↦ by
+      rw [RingHom.algebraMap_toAlgebra]
+      exact congrFun (AlgHom.coe_toRingHom (ψ.comp φ).fieldPullback) z]
   exact (Module.finrank_mul_finrank W₃.FunctionField W₂.FunctionField W₁.FunctionField).symm
 
 end Isogeny

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
@@ -133,8 +133,9 @@ theorem degree_eq_finrank (φ : Isogeny W₁ W₂) [Algebra W₂.FunctionField W
 
 /-- **The degree of an isogeny is positive.** The extension is finite and the source function
 field is nontrivial. -/
-theorem degree_pos (φ : Isogeny W₁ W₂) : 0 < φ.degree :=
-  Module.finrank_pos
+theorem degree_pos (φ : Isogeny W₁ W₂) : 0 < φ.degree := by
+  rw [degree_def]
+  exact Module.finrank_pos
 
 /-- The degree of an isogeny is nonzero, the `≠` form of `degree_pos`. -/
 @[simp]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FrobeniusTower
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.FunctionField
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
 public import Mathlib.FieldTheory.Finite.Basic
 
 /-!

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
@@ -13,9 +13,11 @@ import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Finrank
 # Function-field pullbacks of isogenies
 
 This file proves that the coordinate pullback of an isogeny is injective and extends it uniquely
-to the function fields. Injectivity is the algebraic form of nonconstancy: a nonzero element in the
-kernel would make the pulled-back target coordinate algebraic over the base field. Pointedness
-would then make the source coordinate algebraic as well, contradicting its transcendence.
+to the function fields. Both rest on one nonconstancy statement: the pulled-back target
+coordinate is transcendental over the base field, since otherwise pointedness would make the
+source coordinate algebraic as well, against its transcendence. Injectivity is then the
+observation that a nonzero element of the kernel has a nonzero norm over the target's polynomial
+subring, and that norm is a polynomial relation killing the pulled-back coordinate.
 
 That extension is what lets isogenies be composed: a coordinate pullback lands in a *function*
 field, so composing two of them needs the outer one extended across the inner one's fraction
@@ -24,6 +26,9 @@ field. `TauCeti.Isogeny.comp` therefore lives here rather than beside `TauCeti.I
 
 ## Main results
 
+* `TauCeti.Isogeny.transcendental_pullback_X`: the pullback of the affine coordinate `x` is
+  transcendental over the base field. This is the nonconstancy step, and the source of a
+  transcendental element inside the pulled-back function field.
 * `TauCeti.Isogeny.pullback_injective`: a coordinate pullback satisfying `MapsInfinity` is
   injective.
 * `TauCeti.Isogeny.fieldPullback`: the induced embedding of function fields.
@@ -31,12 +36,11 @@ field. `TauCeti.Isogeny.comp` therefore lives here rather than beside `TauCeti.I
   its function-field law and `TauCeti.Isogeny.id_comp`, `TauCeti.Isogeny.comp_id`,
   `TauCeti.Isogeny.comp_assoc` the unit and associativity laws. The pointedness obligation is
   discharged privately when `comp` is defined.
-* `TauCeti.Isogeny.degree`: the degree of an isogeny, the dimension of the source function field
-  over the image of `fieldPullback`, with `TauCeti.Isogeny.degree_def` the equation lemma the
-  module boundary makes necessary; `TauCeti.Isogeny.degree_id` computes it for the identity and is
-  the `@[simp]` normal form.
-  Finiteness of that extension — which is what makes the degree honest, since `finrank` of an
-  infinite extension reads `0` — is not proved here, so nothing below asserts positivity.
+
+The degree of an isogeny — the dimension of `W₁.FunctionField` over the image of `fieldPullback`
+— is `TauCeti.Isogeny.degree`, in `Isogeny/Degree.lean`; it is stated there rather than here
+because the finiteness that makes it honest is proved from `transcendental_pullback_X` together
+with the degree of the function field over the rational function field.
 
 The construction is the coordinate-ring form of D. Angdinata's function-field definition of an
 isogeny and follows the nonconstancy argument described in the elliptic-curves roadmap. The
@@ -98,8 +102,41 @@ private theorem isIntegral_pullback_of_isIntegral_X (φ : Isogeny W₁ W₂)
       (Polynomial.hom_eval₂ P (algebraMap F[X] W₂.CoordinateRing)
         φ.pullback.toRingHom a).symm.trans (by rw [hPa, map_zero])
 
+/-- **The pullback of the affine coordinate is transcendental.** If `φ^*x₂` were algebraic over
+`F`, then every pullback would be integral over `F`, because the target coordinate ring is
+integral over `F[x₂]`; pointedness would carry that to the source coordinate `x₁`, which is
+transcendental.
+
+This is the nonconstancy of an isogeny, in the form later files consume: it exhibits a
+transcendental element of the pulled-back function field, which is what makes the extension it
+sits under finite. -/
+theorem transcendental_pullback_X (φ : Isogeny W₁ W₂) :
+    Transcendental F (φ.pullback (algebraMap F[X] W₂.CoordinateRing X)) := by
+  intro ht_algebraic
+  have himage : ∀ a : W₂.CoordinateRing, IsIntegral F (φ.pullback a) :=
+    isIntegral_pullback_of_isIntegral_X φ ht_algebraic.isIntegral
+  let x₁ : W₁.FunctionField :=
+    algebraMap W₁.CoordinateRing W₁.FunctionField
+      (algebraMap F[X] W₁.CoordinateRing X)
+  have hx₁_over_target :
+      @IsIntegral W₂.CoordinateRing W₁.FunctionField _ _
+        φ.pullback.toRingHom.toAlgebra x₁ :=
+    (CoordinatePullback.mapsInfinity_iff φ.pullback).1 φ.mapsInfinity
+      (algebraMap F[X] W₁.CoordinateRing X)
+  have hx₁ : IsIntegral F x₁ :=
+    isIntegral_of_isIntegral_map φ.pullback.toRingHom himage hx₁_over_target
+  have hx₁_transcendental : Transcendental F x₁ := by
+    have hx₁_eq : x₁ = algebraMap F[X] W₁.FunctionField X :=
+      (IsScalarTower.algebraMap_apply F[X] W₁.CoordinateRing W₁.FunctionField X).symm
+    rw [hx₁_eq]
+    exact (transcendental_algebraMap_iff
+      (FaithfulSMul.algebraMap_injective F[X] W₁.FunctionField)).2
+        (Polynomial.transcendental_X F)
+  exact hx₁_transcendental hx₁.isAlgebraic
+
 /-- The coordinate pullback of any isogeny of affine Weierstrass curves over a field is
-injective. -/
+injective. A nonzero element of the kernel has nonzero norm over `F[x₂]`, and that norm is a
+polynomial relation killing `φ^*x₂` — which `transcendental_pullback_X` forbids. -/
 theorem pullback_injective (φ : Isogeny W₁ W₂) : Function.Injective φ.pullback := by
   apply (injective_iff_map_eq_zero φ.pullback).2
   intro z hz
@@ -124,28 +161,7 @@ theorem pullback_injective (φ : Isogeny W₁ W₂) : Function.Injective φ.pull
         simp [t, x₂]
       exact AlgHom.congr_fun hhom N
     rw [heval, hnorm, map_mul, hz, zero_mul]
-  have ht_algebraic : IsAlgebraic F t := ⟨N, hN₀, hN⟩
-  have ht : IsIntegral F t := ht_algebraic.isIntegral
-  have himage : ∀ a : W₂.CoordinateRing, IsIntegral F (φ.pullback a) :=
-    isIntegral_pullback_of_isIntegral_X φ ht
-  let x₁ : W₁.FunctionField :=
-    algebraMap W₁.CoordinateRing W₁.FunctionField
-      (algebraMap F[X] W₁.CoordinateRing X)
-  have hx₁_over_target :
-      @IsIntegral W₂.CoordinateRing W₁.FunctionField _ _
-        φ.pullback.toRingHom.toAlgebra x₁ :=
-    (CoordinatePullback.mapsInfinity_iff φ.pullback).1 φ.mapsInfinity
-      (algebraMap F[X] W₁.CoordinateRing X)
-  have hx₁ : IsIntegral F x₁ :=
-    isIntegral_of_isIntegral_map φ.pullback.toRingHom himage hx₁_over_target
-  have hx₁_transcendental : Transcendental F x₁ := by
-    have hx₁_eq : x₁ = algebraMap F[X] W₁.FunctionField X :=
-      (IsScalarTower.algebraMap_apply F[X] W₁.CoordinateRing W₁.FunctionField X).symm
-    rw [hx₁_eq]
-    exact (transcendental_algebraMap_iff
-      (FaithfulSMul.algebraMap_injective F[X] W₁.FunctionField)).2
-        (Polynomial.transcendental_X F)
-  exact hx₁_transcendental hx₁.isAlgebraic
+  exact φ.transcendental_pullback_X ⟨N, hN₀, hN⟩
 
 /-- The function-field pullback induced by an isogeny. It is the unique extension of the
 coordinate pullback across the target fraction field. -/
@@ -234,37 +250,6 @@ as for `CategoryTheory.Category.assoc`. -/
 theorem comp_assoc {W₄ : WeierstrassCurve.Affine F} (χ : Isogeny W₃ W₄) (ψ : Isogeny W₂ W₃)
     (φ : Isogeny W₁ W₂) : (χ.comp ψ).comp φ = χ.comp (ψ.comp φ) :=
   Isogeny.ext <| AlgHom.ext fun x ↦ by simp
-
-/-- **The degree of an isogeny**: the dimension of the source function field `W₁.FunctionField`
-over the image of `fieldPullback` — the pulled-back copy of the target's function field
-`W₂.FunctionField`, which `fieldPullback` embeds isomorphically.
-
-This is the shape of Silverman, *The Arithmetic of Elliptic Curves*, II.2.4(a). Two things it
-does **not** yet carry. The extension is finite for a nonconstant map of one-variable function
-fields, but that is not proved here, and `Module.finrank` of an infinite extension reads `0`, so
-`degree` is only known to be the honest dimension once finiteness is available. Consequently
-positivity is unavailable too: `degree_id` below is computed from the extension being trivial,
-not from any general bound. -/
-noncomputable def degree (φ : Isogeny W₁ W₂) : ℕ :=
-  Module.finrank φ.fieldPullback.fieldRange W₁.FunctionField
-
-/-- The defining formula for `degree`. The definition's body is not exposed across the module
-boundary, so this is how downstream modules compute with it.
-
-Not `@[simp]`: `degree_id` is the simp-normal form of a degree, and this lemma rewrites its
-left-hand side, so tagging both fails `simpNF`. -/
-theorem degree_def (φ : Isogeny W₁ W₂) :
-    φ.degree = Module.finrank φ.fieldPullback.fieldRange W₁.FunctionField := (rfl)
-
-/-- The identity isogeny has degree one: its function-field pullback is the identity, so the
-extension it measures is trivial. -/
-@[simp]
-theorem degree_id (W : WeierstrassCurve.Affine F) : (id W).degree = 1 := by
-  have hrange : (id W).fieldPullback.fieldRange = ⊤ := by
-    rw [id_fieldPullback]
-    exact AlgHom.fieldRange_eq_top.mpr Function.surjective_id
-  rw [degree_def, hrange]
-  exact IntermediateField.finrank_top
 
 end Isogeny
 

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.FieldTheory.IntermediateField.Basic
+public import Mathlib.LinearAlgebra.Dimension.Finrank
+
+/-!
+# The degree above the range of a field embedding
+
+An `F`-algebra map `f : K →ₐ[F] L` of fields is injective, so it identifies `K` with the
+intermediate field `f.fieldRange`. This file records that the two therefore support the same
+degree: `[L : f.fieldRange] = [L : K]`, whenever `L` is a `K`-algebra through `f`.
+
+Both dimensions are needed in practice. A degree over `K` is what an abstract extension
+supplies, while a degree over `f.fieldRange` is what any argument comparing two subfields of
+`L` — a tower, or a relative degree — must work with, since those subfields are intermediate
+fields of one extension rather than separate types.
+
+The `K`-algebra structure on `L` is a hypothesis rather than `f.toRingHom.toAlgebra`, because
+the structure the caller already has need only agree with `f`, and for a fixed pair `K`, `L`
+different embeddings `f` induce different structures, so none can be registered globally.
+
+## Main results
+
+* `TauCeti.AlgHom.finrank_fieldRange`: `[L : f.fieldRange] = [L : K]`.
+-/
+
+public section
+
+namespace TauCeti.AlgHom
+
+variable {F K L : Type*} [Field F] [Field K] [Field L] [Algebra F K] [Algebra F L]
+
+/-- **The degree above the range of a field embedding equals the degree above its source.**
+Stated for an arbitrary `K`-algebra structure on `L` whose structure map is `f`, rather than for
+`f.toRingHom.toAlgebra`, so that it applies to a structure the caller already has. -/
+theorem finrank_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
+    Module.finrank f.fieldRange L = Module.finrank K L := by
+  -- transport along `f.equivFieldRange`, the range restriction of `f`, which is the identity
+  -- on `L`; both squares commute because `h` says the structure map is `f`
+  have hsquare : (algebraMap f.fieldRange L).comp f.equivFieldRange.toRingEquiv.toRingHom =
+      (RingEquiv.refl L).toRingHom.comp (algebraMap K L) := by
+    ext z
+    exact (_root_.AlgHom.equivFieldRange_apply_coe f z).trans (h z).symm
+  exact (Algebra.finrank_eq_of_equiv_equiv f.equivFieldRange.toRingEquiv (RingEquiv.refl L)
+    hsquare).symm
+
+end TauCeti.AlgHom


### PR DESCRIPTION
This PR proves that the field extension an isogeny's degree measures is finite, hence that the degree is an honest positive number, and that it is multiplicative under composition. It closes the `Isogeny.finiteDimensional` and `Isogeny.degree_pos` seeds of `TauCetiRoadmap/EllipticCurves/Suggested.lean`, together with the `deg (ψ ∘ φ) = deg ψ · deg φ` clause of the milestone that carries them: the opening isogeny bullet of §Layer 1 of `TauCetiRoadmap/EllipticCurves/README.md`, "automatic injectivity and **finiteness** (`Isogeny.finiteDimensional`, seeded — a nonconstant map of one-variable function fields is finite, the inseparable case included), `deg φ ≥ 1` (seeded), the separable and inseparable degrees, identity and composition with `deg (ψ ∘ φ) = deg ψ · deg φ` — the tower formula". `STATUS.md` names exactly this as the frontier: "Nothing is computed on the isogeny type yet: `deg φ` as a finrank over the pulled-back function field, finiteness, positivity, composition, `π_q`" — the type, `comp`, the bare `degree` and `π_q` landed since, and finiteness with its consequences is what was still missing under them.

Finiteness is where the isogeny hypotheses are spent. `W₁.FunctionField` is not finite over an arbitrary subfield, so the proof exhibits a transcendental element inside the pulled-back copy of `W₂.FunctionField`: the pullback of the target's affine coordinate. That element is transcendental for the reason `pullback_injective` already used — if it were algebraic over `F`, every pullback would be integral over `F`, and `mapsInfinity` would carry that to the source coordinate `x₁`, which is transcendental. So this PR factors that step out of the injectivity proof as `Isogeny.transcendental_pullback_X` and rebuilds `pullback_injective` on it; the two now share one argument rather than the second re-deriving it. With `t` in hand, `W₁.FunctionField` is finite over `F(t)` because it is a function field over `F` — finite over the rational function field, which is `WeierstrassCurve.Affine.finiteDimensional_functionField`, already in the repository — and enlarging the base from `F(t)` to the whole pulled-back copy keeps it finite.

Positivity is then `Module.finrank_pos`, and degree one gets its converse reading: `Isogeny.degree_eq_one_iff` says the degree is one exactly when the function-field pullback is surjective. That one is pure field theory — Mathlib's `IntermediateField.finrank_eq_one_iff_eq_top` composed with `AlgHom.fieldRange_eq_top`, with no finiteness input — but it is only worth stating once the degree is known to be honest. Multiplicativity is the `finrank` tower formula for `F(W₃) → F(W₂) → F(W₁)`. Since the pulled-back copies are subfields of `F(W₁)` rather than the function fields themselves, the tower is reached through `Isogeny.degree_eq_finrank`, which reads a degree off *any* algebra structure whose structure map is the pullback; no such structure is registered globally, because different isogenies would induce different ones on the same pair of fields.

The new declarations are `Isogeny.transcendental_pullback_X` (in `Isogeny/FunctionField.lean`), `AlgHom.finrank_fieldRange` (in the new `FieldTheory/IntermediateField/FieldRange.lean`: an `F`-algebra map of fields identifies its source with its `fieldRange`, so `[L : f.fieldRange] = [L : K]` — the transport step `Affine.finrank_ratFuncRange` already performed by hand, now shared with `degree_eq_finrank` rather than repeated), and, in the new `Isogeny/Degree.lean`, `Isogeny.finiteDimensional`, `Isogeny.degree_eq_finrank`, `Isogeny.degree_pos`, `Isogeny.degree_ne_zero`, `Isogeny.degree_comp` and `Isogeny.degree_eq_one_iff`. Three existing declarations move, unchanged in statement and proof, into the new file, since the caveats their docstrings carried ("finiteness ... is not proved here, so nothing below asserts positivity") are exactly what this PR removes:

| old | new |
| --- | --- |
| `TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean`: `Isogeny.degree` | `TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean` |
| `.../Isogeny/FunctionField.lean`: `Isogeny.degree_def` | `.../Isogeny/Degree.lean` |
| `.../Isogeny/FunctionField.lean`: `Isogeny.degree_id` | `.../Isogeny/Degree.lean` |

No declaration is renamed, so the only other change is `Isogeny/Frobenius.lean` importing `Isogeny.Degree` in place of `Isogeny.FunctionField`, which it now reaches transitively.

Nothing is vendored. The proof consumes Mathlib's `FunctionField.finiteDimensional_of_adjoin_transcendental` (`Mathlib/NumberTheory/FunctionField.lean`), which is precisely "a function field is finite over `F(t)` for any transcendental `t`", together with `Module.finrank_mul_finrank`, `Algebra.finrank_eq_of_equiv_equiv` and `IntermediateField.finrank_eq_one_iff_eq_top`; `RatFunc.liftAlgebra` is a scoped instance upstream (it is a diamond when the two fields coincide), so it is opened for one declaration only rather than exported. `Mathlib.NumberTheory.FunctionField` is a private import: only proofs use it.

What remains on this milestone after this PR is the separable and inseparable degrees of an isogeny — Mathlib has `Field.finSepDegree` and the two tower laws, but transporting a separable degree along the base-field identification `W₂.FunctionField ≃ φ^*W₂.FunctionField` has no ready-made lemma, so it is a piece of work of its own rather than a corollary of what is here — after which §Layer 1 moves on to `[n]`, relative Frobenius, the hom-group and the dual.

Verified at this head: `lake build` (7769 jobs, green), `lake exe axioms` (44162 declarations, allowlist only), `lake exe module-system` (2111 modules), and `scripts/lint-env.sh` (PASS, no new violations; its one ratchet note names `Polynomial.derivative_hermite_succ`, untouched by this diff).

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"isogeny-finitedimensional"}-->

🤖 Prepared with Claude Code

