### PR TITLE
refactor(Complex): decompose the disc-isometry classification

### DIFF
--- a/TauCeti/Analysis/Complex/Isometry.lean
+++ b/TauCeti/Analysis/Complex/Isometry.lean
@@ -132,7 +132,7 @@ variable {r : ℝ} {g : ℂ → ℂ}
 orthonormal frame.** There are orthogonal unit vectors `e`, `f` for which `⟪e, g z⟫_ℝ` and
 `⟪f, g z⟫_ℝ` are the real and imaginary parts of `z`, for every `z` of the disc. The one frame
 serves every point; that is what later fixes a single `u` in the classification. -/
-private theorem exists_norm_eq_one_real_inner_map_eq_of_dist_map_eq (hr : 0 < r) (h0 : g 0 = 0)
+private theorem exists_orthonormal_pair_real_inner_map_eq_of_dist_map_eq (hr : 0 < r) (h0 : g 0 = 0)
     (hg : ∀ z ∈ ball (0 : ℂ) r, ∀ w ∈ ball (0 : ℂ) r, dist (g z) (g w) = dist z w) :
     ∃ e f : ℂ, ‖e‖ = 1 ∧ ‖f‖ = 1 ∧ ⟪e, f⟫ = 0 ∧
       (∀ z ∈ ball (0 : ℂ) r, ⟪e, g z⟫ = z.re) ∧ ∀ z ∈ ball (0 : ℂ) r, ⟪f, g z⟫ = z.im := by
@@ -174,7 +174,7 @@ theorem exists_norm_eq_one_eqOn_ball_const_mul_or_const_mul_conj_of_dist_map_eq 
       (EqOn g (fun z => u * z) (ball (0 : ℂ) r) ∨
         EqOn g (fun z => u * conj z) (ball (0 : ℂ) r)) := by
   obtain ⟨e, f, hne, hnf, horth, hre, him⟩ :=
-    exists_norm_eq_one_real_inner_map_eq_of_dist_map_eq hr h0 hg
+    exists_orthonormal_pair_real_inner_map_eq_of_dist_map_eq hr h0 hg
   refine ⟨e, hne, ?_⟩
   rcases eq_mul_I_or_eq_neg_mul_I_of_real_inner_eq_zero hne hnf horth with hcase | hcase
   · -- The frame is positively oriented: `g` is the rotation by `e`.

--- a/TauCeti/Analysis/Complex/Isometry.lean
+++ b/TauCeti/Analysis/Complex/Isometry.lean
@@ -28,13 +28,12 @@ The proof is the classical orthonormal-frame argument. `TauCeti/Analysis/InnerPr
 Isometry.lean` turns the distance hypothesis into preservation of the real inner product that `ℂ`
 carries (`Complex.inner : ⟪w, z⟫_ℝ = (z * conj w).re`). The two probe points `r / 2` and `I * r / 2`
 of the disc then have images whose doublings-by-`2 / r` are an orthonormal pair `e`, `f`, and
-`⟪e, g z⟫_ℝ`, `⟪f, g z⟫_ℝ` read off the real and imaginary parts of `z` — the second through
-Mathlib's two-dimensional orientation API, whose area form `Complex.areaForm` is `(conj x * y).im`
-and whose quarter turn `Complex.rightAngleRotation` is multiplication by `I`. Orthogonality of two
-unit complex numbers means a quarter turn, `f = e * I` or `f = -(e * I)`
-(`TauCeti.eq_mul_I_or_eq_neg_mul_I_of_real_inner_eq_zero`), and the two cases give
-`conj e * g z = z` and `conj e * g z = conj z` respectively — the alternative being fixed once, by
-`f`, and not per point.
+`⟪e, g z⟫_ℝ`, `⟪f, g z⟫_ℝ` read off the real and imaginary parts of `z`. Orthogonality of two unit
+complex numbers means a quarter turn, `f = e * I` or `f = -(e * I)`
+(`TauCeti.eq_mul_I_or_eq_neg_mul_I_of_real_inner_eq_zero`, where Mathlib's two-dimensional
+orientation API enters, its quarter turn `Complex.rightAngleRotation` being multiplication by
+`I`), and pairing `g z` against `e` and against `e * I` recovers `g z` as `e * z` in the first case
+and as `e * conj z` in the second — the alternative being fixed once, by `f`, and not per point.
 
 That argument is adapted from the proof of
 `TauCeti.exists_norm_eq_one_eqOn_ball_const_mul_or_const_mul_conj` and its `private` scaffolding
@@ -105,9 +104,61 @@ theorem eq_mul_I_or_eq_neg_mul_I_of_real_inner_eq_zero {z w : ℂ} (hz : ‖z‖
   · exact Or.inl (one_smul _ _)
   · exact Or.inr (by rw [neg_smul, one_smul])
 
+/-- **A unit vector and its quarter turn recover a point of the plane from two inner products.**
+If `⟪e, w⟫_ℝ` is the real part of `v` and `⟪e * I, w⟫_ℝ` is its imaginary part, for a unit `e`,
+then `w = e * v`.
+
+Read at `v` and at `conj v`, this is what turns the two orientations of the frame `e`, `e * I`
+into the two alternatives of the classification below. -/
+private theorem eq_mul_of_real_inner_eq_re_of_real_inner_mul_I_eq_im {e w v : ℂ} (he : ‖e‖ = 1)
+    (hre : ⟪e, w⟫ = v.re) (him : ⟪e * I, w⟫ = v.im) : w = e * v := by
+  -- pairing `w` against `e` and against `e * I` reads off the two parts of `w * conj e`
+  have him' : (w * conj e).im = ⟪e * I, w⟫ := by
+    simp only [_root_.Complex.inner, map_mul, _root_.Complex.conj_I, _root_.Complex.mul_re,
+      _root_.Complex.mul_im, _root_.Complex.neg_re, _root_.Complex.neg_im, _root_.Complex.I_re,
+      _root_.Complex.I_im]
+    ring
+  have hmul : e * conj e = 1 := by rw [_root_.Complex.mul_conj', he]; norm_num
+  have hv : w * conj e = v :=
+    _root_.Complex.ext (by rw [← _root_.Complex.inner]; exact hre) (by rw [him']; exact him)
+  calc w = e * (w * conj e) := by rw [← mul_assoc, mul_comm e w, mul_assoc, hmul, mul_one]
+    _ = e * v := by rw [hv]
+
 /-! ### The classification -/
 
 variable {r : ℝ} {g : ℂ → ℂ}
+
+/-- **The values on a disc of a distance-preserving map fixing its centre are read by a single
+orthonormal frame.** There are orthogonal unit vectors `e`, `f` for which `⟪e, g z⟫_ℝ` and
+`⟪f, g z⟫_ℝ` are the real and imaginary parts of `z`, for every `z` of the disc. The one frame
+serves every point; that is what later fixes a single `u` in the classification. -/
+private theorem exists_norm_eq_one_real_inner_map_eq_of_dist_map_eq (hr : 0 < r) (h0 : g 0 = 0)
+    (hg : ∀ z ∈ ball (0 : ℂ) r, ∀ w ∈ ball (0 : ℂ) r, dist (g z) (g w) = dist z w) :
+    ∃ e f : ℂ, ‖e‖ = 1 ∧ ‖f‖ = 1 ∧ ⟪e, f⟫ = 0 ∧
+      (∀ z ∈ ball (0 : ℂ) r, ⟪e, g z⟫ = z.re) ∧ ∀ z ∈ ball (0 : ℂ) r, ⟪f, g z⟫ = z.im := by
+  have hzero : (0 : ℂ) ∈ ball (0 : ℂ) r := mem_ball_self hr
+  -- the probe point in a unit direction `a`, at half the radius
+  have hnorm : ∀ a : ℂ, ‖a‖ = 1 → ‖((r / 2 : ℝ) • a : ℂ)‖ = r / 2 := fun a ha => by
+    rw [norm_smul, Real.norm_eq_abs, abs_of_pos (by linarith), ha, mul_one]
+  have hmem : ∀ a : ℂ, ‖a‖ = 1 → ((r / 2 : ℝ) • a : ℂ) ∈ ball (0 : ℂ) r := fun a ha => by
+    rw [mem_ball_zero_iff, hnorm a ha]
+    linarith
+  -- its image, doubled by `2 / r`, is a unit vector pairing as `a` itself does
+  have key : ∀ a : ℂ, ‖a‖ = 1 → ‖(2 / r : ℝ) • g ((r / 2 : ℝ) • a)‖ = 1 ∧
+      ∀ z ∈ ball (0 : ℂ) r, ⟪(2 / r : ℝ) • g ((r / 2 : ℝ) • a), g z⟫ = ⟪a, z⟫ := fun a ha => by
+    refine ⟨?_, fun z hz => ?_⟩
+    · rw [norm_smul, Real.norm_eq_abs, abs_of_pos (div_pos two_pos hr),
+        norm_map_of_dist_map_eq hzero h0 hg (hmem a ha), hnorm a ha]
+      field_simp
+    · rw [real_inner_smul_left, real_inner_map_map_of_dist_map_eq hzero h0 hg (hmem a ha) hz,
+        real_inner_smul_left]
+      field_simp
+  obtain ⟨hne, hre⟩ := key 1 norm_one
+  obtain ⟨hnf, him⟩ := key I _root_.Complex.norm_I
+  refine ⟨_, _, hne, hnf, ?_, fun z hz => by simpa using hre z hz,
+    fun z hz => by simpa using him z hz⟩
+  rw [real_inner_smul_right, hre _ (hmem I _root_.Complex.norm_I)]
+  simp
 
 /-- **Distance-preserving self-maps of a disc fixing its centre are rotations and rotated
 conjugations.** A map of `ball 0 r` that fixes `0` and preserves the distance between any two of
@@ -122,100 +173,18 @@ theorem exists_norm_eq_one_eqOn_ball_const_mul_or_const_mul_conj_of_dist_map_eq 
     ∃ u : ℂ, ‖u‖ = 1 ∧
       (EqOn g (fun z => u * z) (ball (0 : ℂ) r) ∨
         EqOn g (fun z => u * conj z) (ball (0 : ℂ) r)) := by
-  have hzero : (0 : ℂ) ∈ ball (0 : ℂ) r := mem_ball_self hr
-  have hip : ∀ z ∈ ball (0 : ℂ) r, ∀ w ∈ ball (0 : ℂ) r, ⟪g z, g w⟫ = ⟪z, w⟫ :=
-    fun _ hz _ hw => real_inner_map_map_of_dist_map_eq hzero h0 hg hz hw
-  -- The two probe points, at half the radius along the two axes.
-  set p : ℂ := ((r / 2 : ℝ) : ℂ) with hp_def
-  set q : ℂ := I * p with hq_def
-  -- They are the real multiples `r / 2` of the two axes `1` and `I`, and pairing a point of the
-  -- plane against those two axes reads off its two real coordinates (`Complex.inner`).
-  have hp_smul : p = (r / 2 : ℝ) • (1 : ℂ) := by rw [hp_def, _root_.Complex.real_smul, mul_one]
-  have hq_smul : q = (r / 2 : ℝ) • I := by
-    rw [hq_def, hp_def, _root_.Complex.real_smul]
-    exact mul_comm _ _
-  have hone : ∀ z : ℂ, ⟪(1 : ℂ), z⟫ = z.re := fun z => by
-    rw [_root_.Complex.inner, map_one, mul_one]
-  have hI : ∀ z : ℂ, ⟪I, z⟫ = z.im := fun z => by
-    rw [_root_.Complex.inner, _root_.Complex.conj_I, _root_.Complex.mul_re, _root_.Complex.neg_re,
-      _root_.Complex.neg_im, _root_.Complex.I_re, _root_.Complex.I_im]
-    ring
-  have hnp : ‖p‖ = r / 2 := by
-    rw [hp_def, _root_.Complex.norm_real, Real.norm_eq_abs, abs_of_pos (by linarith)]
-  have hnq : ‖q‖ = r / 2 := by rw [hq_def, norm_mul, _root_.Complex.norm_I, one_mul, hnp]
-  have hpm : p ∈ ball (0 : ℂ) r := by
-    rw [mem_ball_zero_iff, hnp]
-    linarith
-  have hqm : q ∈ ball (0 : ℂ) r := by
-    rw [mem_ball_zero_iff, hnq]
-    linarith
-  -- Their images, rescaled to unit length, are an orthonormal frame.
-  set c : ℝ := 2 / r with hc_def
-  have hcp : 0 < c := by
-    rw [hc_def]
-    positivity
-  set e : ℂ := c • g p with he_def
-  set f : ℂ := c • g q with hf_def
-  have hne : ‖e‖ = 1 := by
-    rw [he_def, norm_smul, Real.norm_eq_abs, abs_of_pos hcp,
-      norm_map_of_dist_map_eq hzero h0 hg hpm, hnp, hc_def]
-    field_simp
-  have hnf : ‖f‖ = 1 := by
-    rw [hf_def, norm_smul, Real.norm_eq_abs, abs_of_pos hcp,
-      norm_map_of_dist_map_eq hzero h0 hg hqm, hnq, hc_def]
-    field_simp
-  -- The frame is orthogonal, and reads off the coordinates of every point of the disc.
-  have hpq : ⟪p, q⟫ = 0 := by
-    rw [hp_smul, hq_smul, real_inner_smul_left, real_inner_smul_right, hone I,
-      _root_.Complex.I_re]
-    ring
-  have horth : ⟪e, f⟫ = 0 := by
-    rw [he_def, hf_def, real_inner_smul_left, real_inner_smul_right, hip p hpm q hqm, hpq]
-    ring
-  have hre : ∀ z ∈ ball (0 : ℂ) r, ⟪e, g z⟫ = z.re := fun z hz => by
-    rw [he_def, real_inner_smul_left, hip p hpm z hz, hp_smul, real_inner_smul_left, hone z,
-      hc_def]
-    field_simp
-  have him : ∀ z ∈ ball (0 : ℂ) r, ⟪f, g z⟫ = z.im := fun z hz => by
-    rw [hf_def, real_inner_smul_left, hip q hqm z hz, hq_smul, real_inner_smul_left, hI z,
-      hc_def]
-    field_simp
-  -- `e * conj e = 1` lets the frame reading be undone.
-  have hmul : e * conj e = 1 := by
-    rw [_root_.Complex.mul_conj', hne]
-    norm_num
-  have hcoordre : ∀ z ∈ ball (0 : ℂ) r, (conj e * g z).re = z.re := fun z hz => by
-    -- The real part of `conj e * g z` is `⟪e, g z⟫_ℝ` (`Complex.inner`, up to `mul_comm`).
-    rw [mul_comm, ← _root_.Complex.inner]
-    exact hre z hz
+  obtain ⟨e, f, hne, hnf, horth, hre, him⟩ :=
+    exists_norm_eq_one_real_inner_map_eq_of_dist_map_eq hr h0 hg
   refine ⟨e, hne, ?_⟩
   rcases eq_mul_I_or_eq_neg_mul_I_of_real_inner_eq_zero hne hnf horth with hcase | hcase
   · -- The frame is positively oriented: `g` is the rotation by `e`.
-    refine Or.inl fun z hz => ?_
-    have hcoordim : (conj e * g z).im = z.im := by
-      -- The imaginary part of `conj e * g z` is the area form, which pairs the quarter turn
-      -- `e * I = f` against `g z`.
-      rw [← _root_.Complex.areaForm, ← Orientation.inner_rightAngleRotation_left,
-        _root_.Complex.rightAngleRotation, mul_comm, ← hcase]
-      exact him z hz
-    have hxi : conj e * g z = z := _root_.Complex.ext (hcoordre z hz) hcoordim
-    calc g z = e * (conj e * g z) := by rw [← mul_assoc, hmul, one_mul]
-      _ = e * z := by rw [hxi]
+    exact Or.inl fun z hz => eq_mul_of_real_inner_eq_re_of_real_inner_mul_I_eq_im hne (hre z hz)
+      (by rw [← hcase]; exact him z hz)
   · -- The frame is negatively oriented: `g` is that rotation composed with the conjugation.
-    refine Or.inr fun z hz => ?_
-    have hcoordim : (conj e * g z).im = -z.im := by
-      -- Same reading of the imaginary part, with `f = -(e * I)` now contributing the sign.
-      rw [← _root_.Complex.areaForm, ← Orientation.inner_rightAngleRotation_left,
-        _root_.Complex.rightAngleRotation, mul_comm, ← neg_neg (e * I), ← hcase, inner_neg_left]
-      exact congrArg Neg.neg (him z hz)
-    have hxi : conj e * g z = conj z := by
-      refine _root_.Complex.ext ?_ ?_
-      · rw [_root_.Complex.conj_re]
-        exact hcoordre z hz
-      · rw [_root_.Complex.conj_im]
-        exact hcoordim
-    calc g z = e * (conj e * g z) := by rw [← mul_assoc, hmul, one_mul]
-      _ = e * conj z := by rw [hxi]
+    refine Or.inr fun z hz => eq_mul_of_real_inner_eq_re_of_real_inner_mul_I_eq_im (v := conj z)
+      hne (by rw [_root_.Complex.conj_re]; exact hre z hz) ?_
+    rw [_root_.Complex.conj_im, ← neg_eq_iff_eq_neg, ← inner_neg_left, ← hcase]
+    exact him z hz
 
 /-- **The distance-preserving self-maps of a disc fixing its centre are exactly the rotations and
 the rotated conjugations.** The converse half is immediate — multiplication by a unit and


### PR DESCRIPTION
`exists_norm_eq_one_eqOn_ball_const_mul_or_const_mul_conj_of_dist_map_eq` — the
classification of distance-preserving self-maps of a disc fixing its centre — carried a
94-line proof, the longest in the file. This splits it into two private helpers and a
12-line consumer. No statement changes; no new public declaration.

## What moved

**`eq_mul_of_real_inner_eq_re_of_real_inner_mul_I_eq_im`** (11 lines) recovers a point of
the plane from its two inner products against a unit vector `e` and its quarter turn
`e * I`: if `⟪e, w⟫_ℝ = v.re` and `⟪e * I, w⟫_ℝ = v.im` then `w = e * v`.

The two branches of the case split previously ran near-duplicate coordinate computations
to the same end. They are the *same* statement: the second branch is the first read at
`conj v`, since `conj v` has real part `v.re` and imaginary part `-v.im`. One lemma now
serves both, and the duplication is gone rather than merely factored.

**`exists_orthonormal_pair_real_inner_map_eq_of_dist_map_eq`** (23 lines) produces the
orthonormal frame `e`, `f` whose pairings against `g z` are the real and imaginary parts
of `z`. The old proof built the two probe points `r / 2` and `I * r / 2` and their images
separately, in parallel blocks; the helper does that work once for a general unit
direction `a` and applies it at `1` and at `I`. Its name is the terminology the module
docstring already uses for the corresponding scaffolding in the file this argument was
adapted from.

## What was deleted rather than moved

* `⟪1, z⟫_ℝ = z.re` and `⟪I, z⟫_ℝ = z.im` were re-derived by hand (2 and 5 lines).
  `Complex.inner` is `@[simp]` in Mathlib, so `simp` closes both; the `have`s are gone.
* The imaginary part was read through `Complex.areaForm` and
  `Orientation.inner_rightAngleRotation_left`. It is now read directly, and `areaForm` is
  no longer referenced anywhere in the repository. Mathlib's two-dimensional orientation
  API is confined to `eq_mul_I_or_eq_neg_mul_I_of_real_inner_eq_zero`, which is what
  actually needs it — the import and the `finrank_real_complex_fact` local instance are
  still required there.
* `hr0 : r ≠ 0` was threaded to `field_simp`, which does not need it (confirmed by
  compiling without it).

## Hypotheses

Both helpers were given their minimal hypotheses rather than the parent's context.
`eq_mul_of_...` needs no `r`, no `g` and no disc — it is a fact about the plane, and sits
in the plane section beside the quarter-turn lemma it pairs with.
`exists_orthonormal_pair_...` takes exactly `0 < r`, `g 0 = 0` and the distance
hypothesis, all three used: `0 < r` is what puts the probe points inside a nonempty disc,
so it cannot be weakened to `0 ≤ r`.

## Result

| | before | after |
|---|---|---|
| `..._of_dist_map_eq` | 94 | 12 |
| longest proof in file | 94 | 23 |
| file | 243 | 212 |

Gates run on `d77bdbb1`: `lake build` (7767 jobs), `lake exe axioms` (44178 declarations),
`lake exe module-system` (2111 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

The sole consumer, `Analysis/Complex/Conformal/Poincare/Isometry/Classification.lean`, is
untouched — it calls the classification, whose statement is unchanged.

Roadmap: ConformalMapping