### PR TITLE
feat: the isometry group of a bilinear form

### DIFF
--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -10,21 +10,22 @@ public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
 public import Mathlib.LinearAlgebra.BilinearForm.TensorProduct
 public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.LinearAlgebra.Matrix.BilinearForm
+public import TauCeti.LinearAlgebra.GeneralLinearGroup.Congr
 
 /-!
 # The isometry group of a bilinear form
 
 An endomorphism `f` of a module `M` is an *isometry* of a bilinear form `B` when
-`B (f x) (f y) = B x y`. This file introduces that predicate, `TauCeti.IsFormIsometry`, and the
-group it cuts out inside the linear automorphisms of `M`, `TauCeti.formIsometryGroup B`, together
-with the API a consumer of the group needs: a Gram-matrix criterion, the resulting constraint
-`(det f) ^ 2 = 1`, functoriality in the module and in the base ring, and stability of orthogonal
-complements.
+`B (f x) (f y) = B x y`. This file introduces that predicate, `TauCeti.BilinForm.IsIsometry`, and
+the group it cuts out inside the linear automorphisms of `M`, `TauCeti.BilinForm.isometryGroup B`,
+together with the API a consumer of the group needs: a Gram-matrix criterion, the resulting
+constraint `(det f) ^ 2 = 1`, functoriality in the module and in the base ring, and stability of
+orthogonal complements.
 
 Mathlib bundles the same notion twice — as a map, `B₁ →bᵢ B₂`, and as an equivalence,
 `LinearMap.BilinForm.IsometryEquiv B₁ B₂` — and both bridges are recorded here
-(`TauCeti.IsFormIsometry.toIsometry`, `TauCeti.isFormIsometry_toLinearMap`, and
-`TauCeti.formIsometryGroupEquivIsometryEquiv`, the last an equivalence of *types* between the
+(`TauCeti.BilinForm.IsIsometry.toIsometry`, `TauCeti.BilinForm.isIsometry_toLinearMap`, and
+`TauCeti.BilinForm.isometryGroupEquivIsometryEquiv`, the last an equivalence of *types* between the
 subgroup and `B.IsometryEquiv B`). What is new is the unbundled predicate, which is what lets
 "preserves `B`" be a side condition on an endomorphism one already has — the hypothesis of the
 automatic-invertibility theorem below, and the membership condition of a subgroup — and the group
@@ -34,33 +35,64 @@ action, none of which a bare type of bundled equivalences provides.
 Two statements are worth singling out.
 
 * Over an integral domain, isometries of a nondegenerate form on a finite free module are
-  *automatically* invertible (`TauCeti.IsFormIsometry.bijective`): preserving `B` forces
-  `(det f) ^ 2 = 1`, so `det f` is a unit. For a `ℤ`-lattice this says that a form-preserving
-  endomorphism of the lattice already lies in the arithmetic group `Aut(V, Q)`, which is how such
-  an automorphism usually presents itself — as an integer matrix satisfying `Aᵀ * G * A = G`.
+  *automatically* invertible, so they already form elements of the group
+  (`TauCeti.BilinForm.IsIsometry.toIsometryGroup`, `TauCeti.BilinForm.IsIsometry.bijective`):
+  preserving `B` forces `(det f) ^ 2 = 1`, so `det f` is a unit. For a `ℤ`-lattice this says that a
+  form-preserving endomorphism of the lattice already lies in the arithmetic group `Aut(V, Q)`,
+  which is how such an automorphism usually presents itself — as an integer matrix satisfying
+  `Aᵀ * G * A = G`.
 * Base change along an algebra `R → A` is a group homomorphism
-  `Aut(M, B) →* Aut(A ⊗[R] M, B_A)` (`TauCeti.formIsometryGroupBaseChange`). For `R = ℤ` and
+  `Aut(M, B) →* Aut(A ⊗[R] M, B_A)` (`TauCeti.BilinForm.isometryGroupBaseChange`). For `R = ℤ` and
   `A = ℂ` this is the action of `Aut(V, Q)` on the complexification of the lattice, through which
   the monodromy of a variation of Hodge structure acts.
 
 ## Main definitions
 
-* `TauCeti.IsFormIsometry`: an endomorphism preserves a bilinear form.
-* `TauCeti.formIsometryGroup`: the isometry group `Aut(M, B) ≤ M ≃ₗ[R] M`.
-* `TauCeti.IsFormIsometry.toLinearEquiv`: an isometry with invertible Gram determinant, as a
-  linear automorphism.
-* `TauCeti.formIsometryGroupBaseChange`: base change of isometries, as a group homomorphism.
-* `TauCeti.formIsometryGroupCongr`: transport of the isometry group along a linear equivalence.
+* `TauCeti.BilinForm.IsIsometry`: an endomorphism preserves a bilinear form.
+* `TauCeti.BilinForm.isometryGroup`: the isometry group `Aut(M, B) ≤ M ≃ₗ[R] M`.
+* `TauCeti.BilinForm.IsIsometry.toIsometryGroup`: an isometry of a nondegenerate form on a finite
+  free module over an integral domain, as an element of the isometry group.
+* `TauCeti.BilinForm.isometryGroupBaseChange`: base change of isometries, as a group homomorphism.
+* `TauCeti.BilinForm.isometryGroupCongr`: transport of the isometry group along a linear
+  equivalence.
 
 ## Main results
 
-* `TauCeti.isFormIsometry_iff_toMatrix`: the Gram-matrix criterion `Aᵀ * G * A = G`.
-* `TauCeti.IsFormIsometry.det_sq_eq_one`: `(det f) ^ 2 = 1` for an isometry of a form whose Gram
-  determinant is a non-zero-divisor.
-* `TauCeti.IsFormIsometry.bijective`: over an integral domain, an isometry of a nondegenerate form
-  on a finite free module is bijective.
-* `TauCeti.IsFormIsometry.map_orthogonal`: a surjective isometry carries `B`-orthogonal complements
-  to `B`-orthogonal complements.
+* `TauCeti.BilinForm.isIsometry_iff_toMatrix`: the Gram-matrix criterion `Aᵀ * G * A = G`.
+* `TauCeti.BilinForm.IsIsometry.det_sq_eq_one`: `(det f) ^ 2 = 1` for an isometry of a form whose
+  Gram determinant is a non-zero-divisor.
+* `TauCeti.BilinForm.IsIsometry.bijective`: over an integral domain, an isometry of a nondegenerate
+  form on a finite free module is bijective.
+* `TauCeti.BilinForm.IsIsometry.map_orthogonal`: a surjective isometry carries `B`-orthogonal
+  complements to `B`-orthogonal complements.
+
+## Implementation notes
+
+The file is laid out by hypothesis strength: the predicate, the group, the bridges to Mathlib's
+bundled isometries, the transport along a linear equivalence, the Gram-matrix criterion and base
+change need only a `CommSemiring` and additive monoids, which is where every Mathlib ingredient
+they consume is stated; injectivity needs subtraction in `M`; the determinant results need `M` to
+be an additive group over a `CommRing`; the automatic invertibility of an isometry of a
+nondegenerate form needs an integral domain and a finite free module.
+
+This is the bilinear-form counterpart of `TauCeti.QuadraticMap.orthogonalGroup` in
+`TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean`, whose API it follows; for a quadratic
+form `Q` over a ring in which `2` is a regular scalar the orthogonal group of `Q` is the isometry
+group of `Q.polarBilin`, `TauCeti.QuadraticMap.orthogonalGroup_eq_isometryGroup_polarBilin`.
+
+The roadmap names the predicate `IsLatticeIsometry Qint`, on a lattice automorphism `e : V ≃ₗ[ℤ] V`.
+Preserving a bilinear form is not lattice-specific, so it is stated here for an endomorphism of a
+module over an arbitrary commutative ring, with the roadmap's integral case `R = ℤ` the intended
+specialisation and the automatic invertibility of an isometry of a nondegenerate integral form
+(`TauCeti.BilinForm.IsIsometry.toIsometryGroup`) recovering the automorphism form; the declaration
+is named after the general statement rather than after the lattice. For the same reason the file
+sits with the repository's other bilinear-form material rather than under `TauCeti/Geometry/Hodge/`.
+
+## References
+
+* [Hodge structures, polarizations and period domains roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HodgeStructures/README.md),
+  Layer 3, "Period-domain points; the symmetry group": `IsLatticeIsometry Qint` cutting out
+  `Aut(V, Qint)`, and its companion "the `Subgroup`/`Group` packaging of `Aut(V, Qint)`".
 -/
 
 public section
@@ -71,119 +103,159 @@ open Module
 open LinearMap (BilinForm)
 open scoped Matrix TensorProduct
 
-variable {R M M' : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup M']
+namespace BilinForm
+
+section CommSemiring
+
+variable {R M M' : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid M']
   [Module R M']
 
 /-- An endomorphism `f` of `M` is an *isometry* of the bilinear form `B` when it preserves `B`,
 that is, when `B (f x) (f y) = B x y` for all `x` and `y`.
 
-Specialised to a finite free `ℤ`-module `V` and an integral form `Q`, the isometries form the
-arithmetic group `Aut(V, Q)`; see `TauCeti.formIsometryGroup`. -/
-@[expose] def IsFormIsometry (B : BilinForm R M) (f : M →ₗ[R] M) : Prop :=
+Isometric endomorphisms form a monoid, not a group: for the zero form on `ℤ ^ 2` every endomorphism
+is one. For a finite free `ℤ`-module `V` and a *nondegenerate* integral form `Q` an isometric
+endomorphism is automatically invertible (`TauCeti.BilinForm.IsIsometry.toIsometryGroup`), and the
+resulting automorphisms are the arithmetic group `Aut(V, Q)`; see
+`TauCeti.BilinForm.isometryGroup`. -/
+@[expose] def IsIsometry (B : BilinForm R M) (f : M →ₗ[R] M) : Prop :=
   ∀ x y, B (f x) (f y) = B x y
 
 variable {B : BilinForm R M} {f g : M →ₗ[R] M}
 
-theorem isFormIsometry_iff_comp : IsFormIsometry B f ↔ B.comp f f = B :=
+/-- An endomorphism is an isometry of `B` exactly when precomposing `B` with it on both sides
+returns `B`. -/
+theorem isIsometry_iff_comp : IsIsometry B f ↔ B.comp f f = B :=
   ⟨fun h => LinearMap.BilinForm.ext fun x y => h x y, fun h x y =>
     LinearMap.BilinForm.congr_fun h x y⟩
 
-theorem isFormIsometry_toLinearMap (φ : B →bᵢ B) : IsFormIsometry B φ.toLinearMap := φ.map_app
+/-- The underlying map of one of Mathlib's isometric maps `B →bᵢ B` is an isometry. -/
+theorem isIsometry_toLinearMap (φ : B →bᵢ B) : IsIsometry B φ.toLinearMap := φ.map_app
 
-namespace IsFormIsometry
+namespace IsIsometry
 
-/-- An isometry, bundled as one of Mathlib's isometric maps `B →bᵢ B`. -/
-@[expose] def toIsometry (hf : IsFormIsometry B f) : B →bᵢ B := ⟨f, hf⟩
+/-- An isometry, bundled as one of Mathlib's isometric maps `B →bᵢ B`. The body is exposed so that
+the two evaluation lemmas below hold by `rfl` downstream. -/
+@[expose] def toIsometry (hf : IsIsometry B f) : B →bᵢ B := ⟨f, hf⟩
 
 @[simp]
-theorem toIsometry_apply (hf : IsFormIsometry B f) (x : M) : hf.toIsometry x = f x := rfl
+theorem toIsometry_apply (hf : IsIsometry B f) (x : M) : hf.toIsometry x = f x := rfl
 
-protected theorem id : IsFormIsometry B LinearMap.id := fun _ _ => rfl
+@[simp]
+theorem toIsometry_toLinearMap (hf : IsIsometry B f) : hf.toIsometry.toLinearMap = f := rfl
 
-protected theorem comp (hf : IsFormIsometry B f) (hg : IsFormIsometry B g) :
-    IsFormIsometry B (f ∘ₗ g) := fun x y => (hf (g x) (g y)).trans (hg x y)
+protected theorem id : IsIsometry B LinearMap.id := fun _ _ => rfl
 
-/-- An isometry of a left-separating form is injective: it cannot collapse a vector that pairs
-nontrivially with something. -/
-theorem injective (hB : B.SeparatingLeft) (hf : IsFormIsometry B f) : Function.Injective f := by
-  rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
-  intro x hx
-  refine hB x fun y => ?_
-  rw [← hf x y, LinearMap.mem_ker.mp hx, LinearMap.map_zero₂]
+protected theorem comp (hf : IsIsometry B f) (hg : IsIsometry B g) : IsIsometry B (f ∘ₗ g) :=
+  fun x y => (hf (g x) (g y)).trans (hg x y)
 
 /-- An isometry preserving a submodule restricts to an isometry of the restricted form. -/
-theorem restrict {N : Submodule R M} (hf : IsFormIsometry B f) (hN : ∀ x ∈ N, f x ∈ N) :
-    IsFormIsometry (B.restrict N) (f.restrict hN) := fun x y => hf x y
+theorem restrict {N : Submodule R M} (hf : IsIsometry B f) (hN : ∀ x ∈ N, f x ∈ N) :
+    IsIsometry (B.restrict N) (f.restrict hN) := fun x y => by
+  simp only [LinearMap.BilinForm.restrict_apply, LinearMap.coe_restrict_apply]
+  exact hf x y
 
 /-- An isometry maps the `B`-orthogonal complement of `N` into the `B`-orthogonal complement of
 the image of `N`. -/
-theorem map_orthogonal_le (hf : IsFormIsometry B f) (N : Submodule R M) :
+theorem map_orthogonal_le (hf : IsIsometry B f) (N : Submodule R M) :
     (B.orthogonal N).map f ≤ B.orthogonal (N.map f) := by
   rintro - ⟨x, hx, rfl⟩
   rw [LinearMap.BilinForm.mem_orthogonal_iff]
   rintro - ⟨n, hn, rfl⟩
-  show B (f n) (f x) = 0
   rw [hf n x]
   exact (LinearMap.BilinForm.mem_orthogonal_iff.mp hx) n hn
 
 /-- A surjective isometry carries `B`-orthogonal complements to `B`-orthogonal complements. -/
-theorem map_orthogonal (hf : IsFormIsometry B f) (hsurj : Function.Surjective f)
-    (N : Submodule R M) : (B.orthogonal N).map f = B.orthogonal (N.map f) := by
+theorem map_orthogonal (hf : IsIsometry B f) (hsurj : Function.Surjective f) (N : Submodule R M) :
+    (B.orthogonal N).map f = B.orthogonal (N.map f) := by
   refine le_antisymm (hf.map_orthogonal_le N) fun x hx => ?_
   obtain ⟨z, rfl⟩ := hsurj x
   refine Submodule.mem_map_of_mem ?_
   rw [LinearMap.BilinForm.mem_orthogonal_iff]
   intro n hn
-  show B n z = 0
   rw [← hf n z]
   exact (LinearMap.BilinForm.mem_orthogonal_iff.mp hx) _ ⟨n, hn, rfl⟩
 
-end IsFormIsometry
+end IsIsometry
 
 /-- The isometry group `Aut(M, B)` of a bilinear form `B` on `M`: the linear automorphisms of `M`
 that preserve `B`.
 
 For a finite free `ℤ`-module `V` carrying an integral form `Q` this is the arithmetic group
 `Aut(V, Q)`; a variation of Hodge structure has its monodromy representation land in it, acting on
-the complexification through `TauCeti.formIsometryGroupBaseChange`. -/
-def formIsometryGroup (B : BilinForm R M) : Subgroup (M ≃ₗ[R] M) where
-  carrier := {e | IsFormIsometry B (e : M →ₗ[R] M)}
+the complexification through `TauCeti.BilinForm.isometryGroupBaseChange`. -/
+def isometryGroup (B : BilinForm R M) : Subgroup (M ≃ₗ[R] M) where
+  carrier := {e | IsIsometry B (e : M →ₗ[R] M)}
   one_mem' := fun _ _ => rfl
   mul_mem' := fun {a b} ha hb x y => (ha (b x) (b y)).trans (hb x y)
   inv_mem' := fun {a} ha x y => by
     simpa using (ha (a.symm x) (a.symm y)).symm
 
-@[simp]
-theorem mem_formIsometryGroup_iff {e : M ≃ₗ[R] M} :
-    e ∈ formIsometryGroup B ↔ ∀ x y, B (e x) (e y) = B x y := Iff.rfl
+/-- Membership in the isometry group is the isometry predicate. -/
+theorem mem_isometryGroup {e : M ≃ₗ[R] M} :
+    e ∈ isometryGroup B ↔ IsIsometry B (e : M →ₗ[R] M) := Iff.rfl
 
-/-- An element of the isometry group carries `B`-orthogonal complements to `B`-orthogonal
-complements. -/
-theorem map_orthogonal_of_mem_formIsometryGroup {e : M ≃ₗ[R] M} (he : e ∈ formIsometryGroup B)
-    (N : Submodule R M) :
-    (B.orthogonal N).map (e : M →ₗ[R] M) = B.orthogonal (N.map (e : M →ₗ[R] M)) :=
-  IsFormIsometry.map_orthogonal he e.surjective N
+@[simp]
+theorem mem_isometryGroup_iff {e : M ≃ₗ[R] M} :
+    e ∈ isometryGroup B ↔ ∀ x y, B (e x) (e y) = B x y := Iff.rfl
 
 /-- Membership in `Aut(M, B)` is exactly Mathlib's notion of a self-isometry of `B`: the subgroup
-`TauCeti.formIsometryGroup B` and the type `LinearMap.BilinForm.IsometryEquiv B B` carry the same
-data, the subgroup adding the group structure. -/
-def formIsometryGroupEquivIsometryEquiv (B : BilinForm R M) :
-    formIsometryGroup B ≃ B.IsometryEquiv B where
-  toFun e := ⟨e.1, fun x y => e.2 x y⟩
-  invFun e := ⟨e.toLinearEquiv, fun x y => e.map_app y x⟩
+`TauCeti.BilinForm.isometryGroup B` and the type `LinearMap.BilinForm.IsometryEquiv B B` carry the
+same data, the subgroup adding the group structure. -/
+@[expose] def isometryGroupEquivIsometryEquiv (B : BilinForm R M) :
+    isometryGroup B ≃ B.IsometryEquiv B where
+  toFun e := ⟨e.1, fun x y => mem_isometryGroup.mp e.2 x y⟩
+  invFun e := ⟨e.toLinearEquiv, mem_isometryGroup.mpr fun x y => e.map_app y x⟩
   left_inv _ := rfl
   right_inv _ := rfl
 
-/-- Transporting a bilinear form along a linear equivalence transports its isometry group. -/
-def formIsometryGroupCongr (B : BilinForm R M) (e : M ≃ₗ[R] M') :
-    formIsometryGroup B ≃* formIsometryGroup (LinearMap.BilinForm.congr e B) where
-  toFun a := ⟨e.symm ≪≫ₗ (a : M ≃ₗ[R] M) ≪≫ₗ e, fun x y => by
-    simpa using a.2 (e.symm x) (e.symm y)⟩
-  invFun a := ⟨e ≪≫ₗ (a : M' ≃ₗ[R] M') ≪≫ₗ e.symm, fun x y => by
-    simpa using a.2 (e x) (e y)⟩
-  left_inv a := Subtype.ext (by ext x; simp)
-  right_inv a := Subtype.ext (by ext x; simp)
-  map_mul' a b := Subtype.ext (by ext x; simp)
+@[simp]
+theorem coe_isometryGroupEquivIsometryEquiv (B : BilinForm R M) (e : isometryGroup B) :
+    ⇑(isometryGroupEquivIsometryEquiv B e) = ⇑(e : M ≃ₗ[R] M) := rfl
+
+@[simp]
+theorem coe_isometryGroupEquivIsometryEquiv_symm (B : BilinForm R M) (e : B.IsometryEquiv B) :
+    (((isometryGroupEquivIsometryEquiv B).symm e : M ≃ₗ[R] M) : M → M) = ⇑e := rfl
+
+section Congr
+
+/-- Conjugation by `e` carries `Aut(M, B)` onto `Aut(M', B ∘ e⁻¹)`. -/
+private theorem map_isometryGroup (B : BilinForm R M) (e : M ≃ₗ[R] M') :
+    (isometryGroup B).map (LinearEquiv.congrAut e : _ →* _)
+      = isometryGroup (LinearMap.BilinForm.congr e B) := by
+  ext g
+  simp only [Subgroup.mem_map, MonoidHom.coe_coe, mem_isometryGroup_iff]
+  constructor
+  · rintro ⟨a, ha, rfl⟩ x y
+    simp only [LinearEquiv.congrAut_apply, LinearMap.BilinForm.congr_apply,
+      LinearEquiv.symm_apply_apply]
+    exact ha _ _
+  · refine fun hg => ⟨(LinearEquiv.congrAut e).symm g, fun x y => ?_,
+      (LinearEquiv.congrAut e).apply_symm_apply g⟩
+    have := hg (e x) (e y)
+    simpa only [LinearEquiv.congrAut_symm_apply, LinearMap.BilinForm.congr_apply,
+      LinearEquiv.symm_apply_apply] using this
+
+/-- Transporting a bilinear form along a linear equivalence transports its isometry group:
+conjugation by `e : M ≃ₗ[R] M'` carries `Aut(M, B)` onto `Aut(M', B ∘ e⁻¹)`. -/
+def isometryGroupCongr (B : BilinForm R M) (e : M ≃ₗ[R] M') :
+    isometryGroup B ≃* isometryGroup (LinearMap.BilinForm.congr e B) :=
+  ((LinearEquiv.congrAut e).subgroupMap _).trans
+    (MulEquiv.subgroupCongr (map_isometryGroup B e))
+
+@[simp]
+theorem coe_isometryGroupCongr_apply (B : BilinForm R M) (e : M ≃ₗ[R] M') (a : isometryGroup B)
+    (x : M') : (isometryGroupCongr B e a : M' ≃ₗ[R] M') x = e ((a : M ≃ₗ[R] M) (e.symm x)) := by
+  simp [isometryGroupCongr]
+
+@[simp]
+theorem coe_isometryGroupCongr_symm_apply (B : BilinForm R M) (e : M ≃ₗ[R] M')
+    (a : isometryGroup (LinearMap.BilinForm.congr e B)) (x : M) :
+    ((isometryGroupCongr B e).symm a : M ≃ₗ[R] M) x
+      = e.symm ((a : M' ≃ₗ[R] M') (e x)) := by
+  simp [isometryGroupCongr]
+
+end Congr
 
 /-! ### The Gram-matrix criterion -/
 
@@ -193,77 +265,12 @@ variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
 /-- An endomorphism is an isometry of `B` exactly when its matrix `A` in a basis `b` satisfies
 `Aᵀ * G * A = G` for the Gram matrix `G` of `B` in `b`. -/
-theorem isFormIsometry_iff_toMatrix (b : Basis ι R M) :
-    IsFormIsometry B f ↔
+theorem isIsometry_iff_toMatrix (b : Basis ι R M) :
+    IsIsometry B f ↔
       (LinearMap.toMatrix b b f)ᵀ * LinearMap.BilinForm.toMatrix b B * LinearMap.toMatrix b b f
         = LinearMap.BilinForm.toMatrix b B := by
-  rw [isFormIsometry_iff_comp, ← (LinearMap.BilinForm.toMatrix b).injective.eq_iff,
+  rw [isIsometry_iff_comp, ← (LinearMap.BilinForm.toMatrix b).injective.eq_iff,
     LinearMap.BilinForm.toMatrix_comp b b B f f]
-
-namespace IsFormIsometry
-
-/-- An isometry scales the Gram determinant by the square of its determinant — and hence, the form
-being preserved, not at all. -/
-theorem det_sq_mul_det_toMatrix (b : Basis ι R M) (hf : IsFormIsometry B f) :
-    LinearMap.det f ^ 2 * (LinearMap.BilinForm.toMatrix b B).det =
-      (LinearMap.BilinForm.toMatrix b B).det := by
-  have h := congrArg Matrix.det ((isFormIsometry_iff_toMatrix b).mp hf)
-  rw [Matrix.det_mul, Matrix.det_mul, Matrix.det_transpose, LinearMap.det_toMatrix] at h
-  rw [show LinearMap.det f ^ 2 * (LinearMap.BilinForm.toMatrix b B).det
-      = LinearMap.det f * (LinearMap.BilinForm.toMatrix b B).det * LinearMap.det f from by ring]
-  exact h
-
-/-- An isometry of a bilinear form whose Gram determinant is a non-zero-divisor has determinant
-squaring to `1`; over `ℤ` this says its determinant is `±1`. -/
-theorem det_sq_eq_one (b : Basis ι R M)
-    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
-    (hf : IsFormIsometry B f) : LinearMap.det f ^ 2 = 1 := by
-  have h : (LinearMap.det f ^ 2 - 1) * (LinearMap.BilinForm.toMatrix b B).det = 0 := by
-    rw [sub_mul, one_mul, hf.det_sq_mul_det_toMatrix b, sub_self]
-  exact sub_eq_zero.mp ((mem_nonZeroDivisors_iff.mp hG).2 _ h)
-
-theorem isUnit_det (b : Basis ι R M)
-    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
-    (hf : IsFormIsometry B f) : IsUnit (LinearMap.det f) :=
-  IsUnit.of_mul_eq_one _ (by rw [← sq]; exact hf.det_sq_eq_one b hG)
-
-/-- An isometry of a bilinear form whose Gram determinant is a non-zero-divisor is a linear
-automorphism. This is how an element of `Aut(V, Q)` usually presents itself: as an endomorphism
-of the lattice `V` preserving `Q`, with invertibility a consequence rather than a hypothesis. -/
-noncomputable def toLinearEquiv (b : Basis ι R M)
-    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
-    (hf : IsFormIsometry B f) : M ≃ₗ[R] M :=
-  LinearEquiv.ofIsUnitDet (v := b) (v' := b)
-    (by rw [LinearMap.det_toMatrix]; exact hf.isUnit_det b hG)
-
-@[simp]
-theorem coe_toLinearEquiv (b : Basis ι R M)
-    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
-    (hf : IsFormIsometry B f) : (toLinearEquiv b hG hf : M →ₗ[R] M) = f :=
-  LinearEquiv.coe_ofIsUnitDet _
-
-@[simp]
-theorem toLinearEquiv_apply (b : Basis ι R M)
-    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
-    (hf : IsFormIsometry B f) (x : M) : toLinearEquiv b hG hf x = f x :=
-  congrArg (fun l : M →ₗ[R] M => l x) (coe_toLinearEquiv b hG hf)
-
-theorem toLinearEquiv_mem_formIsometryGroup (b : Basis ι R M)
-    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
-    (hf : IsFormIsometry B f) : toLinearEquiv b hG hf ∈ formIsometryGroup B := fun x y => by
-  simpa using hf x y
-
-/-- Over an integral domain, an endomorphism of a finite free module preserving a nondegenerate
-bilinear form is automatically bijective. -/
-theorem bijective [IsDomain R] [Module.Free R M] [Module.Finite R M] (hB : B.Nondegenerate)
-    (hf : IsFormIsometry B f) : Function.Bijective f := by
-  set b := Module.Free.chooseBasis R M
-  have hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R :=
-    mem_nonZeroDivisors_of_ne_zero ((LinearMap.BilinForm.nondegenerate_iff_det_ne_zero b).mp hB)
-  have h := (toLinearEquiv b hG hf).bijective
-  rwa [show ⇑(toLinearEquiv b hG hf) = ⇑f from funext (toLinearEquiv_apply b hG hf)] at h
-
-end IsFormIsometry
 
 end Matrix
 
@@ -271,10 +278,12 @@ end Matrix
 
 section BaseChange
 
-variable (A : Type*) [CommRing A] [Algebra R A]
+variable (A : Type*) [CommSemiring A] [Algebra R A]
 
-theorem IsFormIsometry.baseChange (hf : IsFormIsometry B f) :
-    IsFormIsometry (LinearMap.BilinForm.baseChange A B) (f.baseChange A) := by
+/-- Base change along an `R`-algebra `A` carries an isometry of `B` to an isometry of the
+base-changed form. -/
+theorem IsIsometry.baseChange (hf : IsIsometry B f) :
+    IsIsometry (LinearMap.BilinForm.baseChange A B) (f.baseChange A) := by
   intro x y
   induction x using TensorProduct.induction_on with
   | zero => simp
@@ -288,13 +297,129 @@ theorem IsFormIsometry.baseChange (hf : IsFormIsometry B f) :
 /-- Base change along an `R`-algebra `A` is a group homomorphism
 `Aut(M, B) →* Aut(A ⊗[R] M, B_A)`. For `R = ℤ` and `A = ℂ` this is the action of the arithmetic
 group `Aut(V, Q)` on the complexification of the lattice. -/
-def formIsometryGroupBaseChange (B : BilinForm R M) :
-    formIsometryGroup B →* formIsometryGroup (LinearMap.BilinForm.baseChange A B) where
+@[expose] def isometryGroupBaseChange (B : BilinForm R M) :
+    isometryGroup B →* isometryGroup (LinearMap.BilinForm.baseChange A B) where
   toFun e := ⟨LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M),
-    fun x y => IsFormIsometry.baseChange A e.2 x y⟩
+    mem_isometryGroup.mpr (IsIsometry.baseChange A (mem_isometryGroup.mp e.2))⟩
   map_one' := Subtype.ext (by simp)
-  map_mul' a b := Subtype.ext (by simp [LinearEquiv.baseChange_mul])
+  map_mul' a b := Subtype.ext (by simp [_root_.LinearEquiv.baseChange_mul])
+
+@[simp]
+theorem coe_isometryGroupBaseChange (B : BilinForm R M) (e : isometryGroup B) :
+    (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M)
+      = LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M) := rfl
+
+@[simp]
+theorem isometryGroupBaseChange_tmul (B : BilinForm R M) (e : isometryGroup B) (a : A) (m : M) :
+    (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M) (a ⊗ₜ m)
+      = a ⊗ₜ (e : M ≃ₗ[R] M) m := rfl
 
 end BaseChange
+
+end CommSemiring
+
+/-! ### Determinants -/
+
+section CommRing
+
+variable {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M] {B : BilinForm R M}
+  {f : M →ₗ[R] M}
+
+/-- An isometry of a left-separating form is injective: it cannot collapse a vector that pairs
+nontrivially with something. -/
+theorem IsIsometry.injective (hB : B.SeparatingLeft) (hf : IsIsometry B f) :
+    Function.Injective f := by
+  rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
+  intro x hx
+  refine hB x fun y => ?_
+  rw [← hf x y, LinearMap.mem_ker.mp hx, LinearMap.map_zero₂]
+
+section Matrix
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+namespace IsIsometry
+
+/-- An isometry scales the Gram determinant by the square of its determinant — and hence, the form
+being preserved, not at all. -/
+theorem det_sq_mul_det_toMatrix_self (b : Basis ι R M) (hf : IsIsometry B f) :
+    LinearMap.det f ^ 2 * (LinearMap.BilinForm.toMatrix b B).det =
+      (LinearMap.BilinForm.toMatrix b B).det := by
+  have h := congrArg Matrix.det ((isIsometry_iff_toMatrix b).mp hf)
+  rw [Matrix.det_mul, Matrix.det_mul, Matrix.det_transpose, LinearMap.det_toMatrix] at h
+  calc LinearMap.det f ^ 2 * (LinearMap.BilinForm.toMatrix b B).det
+      = LinearMap.det f * (LinearMap.BilinForm.toMatrix b B).det * LinearMap.det f := by ring
+    _ = (LinearMap.BilinForm.toMatrix b B).det := h
+
+/-- An isometry of a bilinear form whose Gram determinant is a non-zero-divisor has determinant
+squaring to `1`; over `ℤ` this says its determinant is `±1`. -/
+theorem det_sq_eq_one (b : Basis ι R M)
+    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
+    (hf : IsIsometry B f) : LinearMap.det f ^ 2 = 1 := by
+  have h : (LinearMap.det f ^ 2 - 1) * (LinearMap.BilinForm.toMatrix b B).det = 0 := by
+    rw [sub_mul, one_mul, hf.det_sq_mul_det_toMatrix_self b, sub_self]
+  exact sub_eq_zero.mp ((mem_nonZeroDivisors_iff.mp hG).2 _ h)
+
+/-- An isometry of a bilinear form whose Gram determinant is a non-zero-divisor has unit
+determinant, its square being `1`. -/
+theorem isUnit_det (b : Basis ι R M)
+    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
+    (hf : IsIsometry B f) : IsUnit (LinearMap.det f) :=
+  IsUnit.of_mul_eq_one _ (by rw [← sq]; exact hf.det_sq_eq_one b hG)
+
+end IsIsometry
+
+/-- Over an integral domain, the Gram determinant of a nondegenerate form is a non-zero-divisor. -/
+theorem det_toMatrix_mem_nonZeroDivisors [IsDomain R] (b : Basis ι R M) (hB : B.Nondegenerate) :
+    (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R :=
+  mem_nonZeroDivisors_of_ne_zero ((LinearMap.BilinForm.nondegenerate_iff_det_ne_zero b).mp hB)
+
+end Matrix
+
+section Nondegenerate
+
+variable [IsDomain R] [Module.Free R M] [Module.Finite R M]
+
+namespace IsIsometry
+
+/-- An isometry of a nondegenerate form on a finite free module over an integral domain has unit
+determinant. -/
+theorem isUnit_det_of_nondegenerate (hB : B.Nondegenerate) (hf : IsIsometry B f) :
+    IsUnit (LinearMap.det f) :=
+  hf.isUnit_det (Module.Free.chooseBasis R M)
+    (det_toMatrix_mem_nonZeroDivisors (Module.Free.chooseBasis R M) hB)
+
+/-- Over an integral domain, an endomorphism of a finite free module preserving a nondegenerate
+bilinear form is automatically invertible, hence an element of the isometry group. This is how an
+element of `Aut(V, Q)` usually presents itself: as an endomorphism of the lattice `V` preserving
+`Q`, with invertibility a consequence rather than a hypothesis. -/
+@[expose] noncomputable def toIsometryGroup (hB : B.Nondegenerate) (hf : IsIsometry B f) :
+    isometryGroup B :=
+  ⟨LinearMap.equivOfIsUnitDet (hf.isUnit_det_of_nondegenerate hB),
+    mem_isometryGroup.mpr fun x y => by simpa using hf x y⟩
+
+@[simp]
+theorem coe_toIsometryGroup (hB : B.Nondegenerate) (hf : IsIsometry B f) :
+    ((hf.toIsometryGroup hB : isometryGroup B) : M →ₗ[R] M) = f :=
+  LinearMap.coe_equivOfIsUnitDet (hf.isUnit_det_of_nondegenerate hB)
+
+@[simp]
+theorem toIsometryGroup_apply (hB : B.Nondegenerate) (hf : IsIsometry B f) (x : M) :
+    (hf.toIsometryGroup hB : M ≃ₗ[R] M) x = f x :=
+  LinearMap.equivOfIsUnitDet_apply (hf.isUnit_det_of_nondegenerate hB) x
+
+/-- Over an integral domain, an endomorphism of a finite free module preserving a nondegenerate
+bilinear form is automatically bijective. -/
+theorem bijective (hB : B.Nondegenerate) (hf : IsIsometry B f) : Function.Bijective f := by
+  have h : ⇑(hf.toIsometryGroup hB : M ≃ₗ[R] M) = ⇑f := funext (toIsometryGroup_apply hB hf)
+  exact h ▸ (hf.toIsometryGroup hB : M ≃ₗ[R] M).bijective
+
+end IsIsometry
+
+end Nondegenerate
+
+end CommRing
+
+end BilinForm
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -280,13 +280,6 @@ theorem coe_isometryGroupBaseChange (B : BilinForm R M) (e : isometryGroup B) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M)
       = LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M) := (rfl)
 
-@[simp]
-theorem isometryGroupBaseChange_tmul (B : BilinForm R M) (e : isometryGroup B) (a : A) (m : M) :
-    (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M) (a ⊗ₜ m)
-      = a ⊗ₜ (e : M ≃ₗ[R] M) m := by
-  rw [coe_isometryGroupBaseChange]
-  exact LinearEquiv.baseChange_tmul R A M M a m
-
 end BaseChange
 
 end CommSemiring

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -138,6 +138,7 @@ theorem isIsometry_toLinearMap (φ : B →bᵢ B) : IsIsometry B φ.toLinearMap 
 namespace IsIsometry
 
 /-- An isometry takes the same value under `B` after applying the endomorphism to both inputs. -/
+@[grind =]
 protected theorem apply (hf : IsIsometry B f) (x y : M) : B (f x) (f y) = B x y :=
   isIsometry_iff.mp hf x y
 
@@ -316,9 +317,12 @@ theorem coe_isometryGroupBaseChange (B : BilinForm R M) (e : isometryGroup B) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M)
       = LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M) := (rfl)
 
+@[simp]
 theorem isometryGroupBaseChange_tmul (B : BilinForm R M) (e : isometryGroup B) (a : A) (m : M) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M) (a ⊗ₜ m)
-      = a ⊗ₜ (e : M ≃ₗ[R] M) m := (rfl)
+      = a ⊗ₜ (e : M ≃ₗ[R] M) m := by
+  rw [coe_isometryGroupBaseChange]
+  exact LinearEquiv.baseChange_tmul R A M M a m
 
 end BaseChange
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -10,14 +10,16 @@ public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
 public import Mathlib.LinearAlgebra.BilinearForm.TensorProduct
 public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.LinearAlgebra.Matrix.BilinearForm
+public import TauCeti.LinearAlgebra.BilinearForm.Isometry.Basic
 public import TauCeti.LinearAlgebra.GeneralLinearGroup.Congr
 
 /-!
 # The isometry group of a bilinear form
 
 An endomorphism `f` of a module `M` is an *isometry* of a bilinear form `B` when
-`B (f x) (f y) = B x y`. This file introduces that predicate, `TauCeti.BilinForm.IsIsometry`, and
-the group it cuts out inside the linear automorphisms of `M`, `TauCeti.BilinForm.isometryGroup B`,
+`B (f x) (f y) = B x y`. Starting from the predicate `TauCeti.BilinForm.IsIsometry` defined in the
+dependency-light module `TauCeti.LinearAlgebra.BilinearForm.Isometry.Basic`, this file builds the
+group it cuts out inside the linear automorphisms of `M`, `TauCeti.BilinForm.isometryGroup B`,
 together with the API a consumer of the group needs: a Gram-matrix criterion, the resulting
 constraint `(det f) ^ 2 = 1`, functoriality in the module and in the base ring, and stability of
 orthogonal complements.
@@ -34,7 +36,7 @@ action, none of which a bare type of bundled equivalences provides.
 
 Two statements are worth singling out.
 
-* Over an integral domain, isometries of a nondegenerate form on a finite free module are
+* Over an integral domain, isometries of a left-separating form on a finite free module are
   *automatically* invertible, so they already form elements of the group
   (`TauCeti.BilinForm.IsIsometry.toIsometryGroup`, `TauCeti.BilinForm.IsIsometry.bijective`):
   preserving `B` forces `(det f) ^ 2 = 1`, so `det f` is a unit. For a `ℤ`-lattice this says that a
@@ -50,7 +52,7 @@ Two statements are worth singling out.
 
 * `TauCeti.BilinForm.IsIsometry`: an endomorphism preserves a bilinear form.
 * `TauCeti.BilinForm.isometryGroup`: the isometry group `Aut(M, B) ≤ M ≃ₗ[R] M`.
-* `TauCeti.BilinForm.IsIsometry.toIsometryGroup`: an isometry of a nondegenerate form on a finite
+* `TauCeti.BilinForm.IsIsometry.toIsometryGroup`: an isometry of a left-separating form on a finite
   free module over an integral domain, as an element of the isometry group.
 * `TauCeti.BilinForm.isometryGroupBaseChange`: base change of isometries, as a group homomorphism.
 * `TauCeti.BilinForm.isometryGroupCongr`: transport of the isometry group along a linear
@@ -61,19 +63,19 @@ Two statements are worth singling out.
 * `TauCeti.BilinForm.isIsometry_iff_toMatrix`: the Gram-matrix criterion `Aᵀ * G * A = G`.
 * `TauCeti.BilinForm.IsIsometry.det_sq_eq_one`: `(det f) ^ 2 = 1` for an isometry of a form whose
   Gram determinant is a non-zero-divisor.
-* `TauCeti.BilinForm.IsIsometry.bijective`: over an integral domain, an isometry of a nondegenerate
-  form on a finite free module is bijective.
+* `TauCeti.BilinForm.IsIsometry.bijective`: over an integral domain, an isometry of a
+  left-separating form on a finite free module is bijective.
 * `TauCeti.BilinForm.IsIsometry.map_orthogonal`: a surjective isometry carries `B`-orthogonal
   complements to `B`-orthogonal complements.
 
 ## Implementation notes
 
-The file is laid out by hypothesis strength: the predicate, the group, the bridges to Mathlib's
-bundled isometries, the transport along a linear equivalence, the Gram-matrix criterion and base
+The API is laid out by hypothesis strength: the imported predicate and elementary bridge to
+Mathlib, the group, transport along a linear equivalence, the Gram-matrix criterion, and base
 change need only a `CommSemiring` and additive monoids, which is where every Mathlib ingredient
 they consume is stated; injectivity needs subtraction in `M`; the determinant results need `M` to
 be an additive group over a `CommRing`; the automatic invertibility of an isometry of a
-nondegenerate form needs an integral domain and a finite free module.
+left-separating form needs an integral domain and a finite free module.
 
 This is the bilinear-form counterpart of `TauCeti.QuadraticMap.orthogonalGroup` in
 `TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean`, whose API it follows; for a quadratic
@@ -83,7 +85,7 @@ group of `Q.polarBilin`, `TauCeti.QuadraticMap.orthogonalGroup_eq_isometryGroup_
 The roadmap names the predicate `IsLatticeIsometry Qint`, on a lattice automorphism `e : V ≃ₗ[ℤ] V`.
 Preserving a bilinear form is not lattice-specific, so it is stated here for an endomorphism of a
 module over an arbitrary commutative ring, with the roadmap's integral case `R = ℤ` the intended
-specialisation and the automatic invertibility of an isometry of a nondegenerate integral form
+specialisation and the automatic invertibility of an isometry of a left-separating integral form
 (`TauCeti.BilinForm.IsIsometry.toIsometryGroup`) recovering the automorphism form; the declaration
 is named after the general statement rather than after the lattice. For the same reason the file
 sits with the repository's other bilinear-form material rather than under `TauCeti/Geometry/Hodge/`.
@@ -110,57 +112,15 @@ section CommSemiring
 variable {R M M' : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid M']
   [Module R M']
 
-/-- An endomorphism `f` of `M` is an *isometry* of the bilinear form `B` when it preserves `B`,
-that is, when `B (f x) (f y) = B x y` for all `x` and `y`.
-
-Isometric endomorphisms form a monoid, not a group: for the zero form on `ℤ ^ 2` every endomorphism
-is one. For a finite free `ℤ`-module `V` and a *nondegenerate* integral form `Q` an isometric
-endomorphism is automatically invertible (`TauCeti.BilinForm.IsIsometry.toIsometryGroup`), and the
-resulting automorphisms are the arithmetic group `Aut(V, Q)`; see
-`TauCeti.BilinForm.isometryGroup`. -/
-def IsIsometry (B : BilinForm R M) (f : M →ₗ[R] M) : Prop :=
-  ∀ x y, B (f x) (f y) = B x y
-
 variable {B : BilinForm R M} {f g : M →ₗ[R] M}
-
-/-- An endomorphism is an isometry of `B` exactly when it preserves `B` pointwise. -/
-theorem isIsometry_iff : IsIsometry B f ↔ ∀ x y, B (f x) (f y) = B x y := (Iff.rfl)
-
-/-- An endomorphism is an isometry of `B` exactly when precomposing `B` with it on both sides
-returns `B`. -/
-theorem isIsometry_iff_comp : IsIsometry B f ↔ B.comp f f = B :=
-  ⟨fun h => LinearMap.BilinForm.ext fun x y => h x y, fun h x y =>
-    LinearMap.BilinForm.congr_fun h x y⟩
-
-/-- The underlying map of one of Mathlib's isometric maps `B →bᵢ B` is an isometry. -/
-theorem isIsometry_toLinearMap (φ : B →bᵢ B) : IsIsometry B φ.toLinearMap := φ.map_app
 
 namespace IsIsometry
 
-/-- An isometry takes the same value under `B` after applying the endomorphism to both inputs. -/
-@[grind =]
-protected theorem apply (hf : IsIsometry B f) (x y : M) : B (f x) (f y) = B x y :=
-  isIsometry_iff.mp hf x y
-
-/-- An isometry, bundled as one of Mathlib's isometric maps `B →bᵢ B`. -/
-def toIsometry (hf : IsIsometry B f) : B →bᵢ B := ⟨f, hf⟩
-
-@[simp]
-theorem toIsometry_apply (hf : IsIsometry B f) (x : M) : hf.toIsometry x = f x := (rfl)
-
-@[simp]
-theorem toIsometry_toLinearMap (hf : IsIsometry B f) : hf.toIsometry.toLinearMap = f := (rfl)
-
-protected theorem id : IsIsometry B LinearMap.id := fun _ _ => rfl
-
-protected theorem comp (hf : IsIsometry B f) (hg : IsIsometry B g) : IsIsometry B (f ∘ₗ g) :=
-  fun x y => (hf (g x) (g y)).trans (hg x y)
-
 /-- An isometry preserving a submodule restricts to an isometry of the restricted form. -/
 theorem restrict {N : Submodule R M} (hf : IsIsometry B f) (hN : ∀ x ∈ N, f x ∈ N) :
-    IsIsometry (B.restrict N) (f.restrict hN) := fun x y => by
+    IsIsometry (B.restrict N) (f.restrict hN) := isIsometry_iff.mpr fun x y => by
   simp only [LinearMap.BilinForm.restrict_apply, LinearMap.coe_restrict_apply]
-  exact hf x y
+  exact hf.apply x y
 
 /-- An isometry maps the `B`-orthogonal complement of `N` into the `B`-orthogonal complement of
 the image of `N`. -/
@@ -169,7 +129,7 @@ theorem map_orthogonal_le (hf : IsIsometry B f) (N : Submodule R M) :
   rintro - ⟨x, hx, rfl⟩
   rw [LinearMap.BilinForm.mem_orthogonal_iff]
   rintro - ⟨n, hn, rfl⟩
-  rw [hf n x]
+  rw [hf.apply n x]
   exact (LinearMap.BilinForm.mem_orthogonal_iff.mp hx) n hn
 
 /-- A surjective isometry carries `B`-orthogonal complements to `B`-orthogonal complements. -/
@@ -180,7 +140,7 @@ theorem map_orthogonal (hf : IsIsometry B f) (hsurj : Function.Surjective f) (N 
   refine Submodule.mem_map_of_mem ?_
   rw [LinearMap.BilinForm.mem_orthogonal_iff]
   intro n hn
-  rw [← hf n z]
+  rw [← hf.apply n z]
   exact (LinearMap.BilinForm.mem_orthogonal_iff.mp hx) _ ⟨n, hn, rfl⟩
 
 end IsIsometry
@@ -193,10 +153,11 @@ For a finite free `ℤ`-module `V` carrying an integral form `Q` this is the ari
 the complexification through `TauCeti.BilinForm.isometryGroupBaseChange`. -/
 def isometryGroup (B : BilinForm R M) : Subgroup (M ≃ₗ[R] M) where
   carrier := {e | IsIsometry B (e : M →ₗ[R] M)}
-  one_mem' := fun _ _ => rfl
-  mul_mem' := fun {a b} ha hb x y => (ha (b x) (b y)).trans (hb x y)
-  inv_mem' := fun {a} ha x y => by
-    simpa using (ha (a.symm x) (a.symm y)).symm
+  one_mem' := isIsometry_iff.mpr fun _ _ => rfl
+  mul_mem' := fun {a b} ha hb => isIsometry_iff.mpr fun x y =>
+    (ha.apply (b x) (b y)).trans (hb.apply x y)
+  inv_mem' := fun {a} ha => isIsometry_iff.mpr fun x y => by
+    simpa using (ha.apply (a.symm x) (a.symm y)).symm
 
 /-- Membership in the isometry group is the isometry predicate. -/
 theorem mem_isometryGroup {e : M ≃ₗ[R] M} :
@@ -212,8 +173,9 @@ theorem mem_isometryGroup_iff {e : M ≃ₗ[R] M} :
 same data, the subgroup adding the group structure. -/
 def isometryGroupEquivIsometryEquiv (B : BilinForm R M) :
     isometryGroup B ≃ B.IsometryEquiv B where
-  toFun e := ⟨e.1, fun x y => mem_isometryGroup.mp e.2 x y⟩
-  invFun e := ⟨e.toLinearEquiv, mem_isometryGroup.mpr fun x y => e.map_app y x⟩
+  toFun e := ⟨e.1, fun x y => (mem_isometryGroup.mp e.2).apply x y⟩
+  invFun e := ⟨e.toLinearEquiv,
+    mem_isometryGroup.mpr (isIsometry_iff.mpr fun x y => e.map_app y x)⟩
   left_inv _ := rfl
   right_inv _ := rfl
 
@@ -292,6 +254,7 @@ variable (A : Type*) [CommSemiring A] [Algebra R A]
 base-changed form. -/
 theorem IsIsometry.baseChange (hf : IsIsometry B f) :
     IsIsometry (LinearMap.BilinForm.baseChange A B) (f.baseChange A) := by
+  rw [isIsometry_iff]
   intro x y
   induction x using TensorProduct.induction_on with
   | zero => simp
@@ -300,7 +263,7 @@ theorem IsIsometry.baseChange (hf : IsIsometry B f) :
       induction y using TensorProduct.induction_on with
       | zero => simp
       | add y₁ y₂ h₁ h₂ => simp only [map_add, h₁, h₂]
-      | tmul a' m' => simp [hf m m']
+      | tmul a' m' => simp [hf.apply m m']
 
 /-- Base change along an `R`-algebra `A` is a group homomorphism
 `Aut(M, B) →* Aut(A ⊗[R] M, B_A)`. For `R = ℤ` and `A = ℂ` this is the action of the arithmetic
@@ -317,6 +280,7 @@ theorem coe_isometryGroupBaseChange (B : BilinForm R M) (e : isometryGroup B) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M)
       = LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M) := (rfl)
 
+@[simp]
 theorem isometryGroupBaseChange_tmul (B : BilinForm R M) (e : isometryGroup B) (a : A) (m : M) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M) (a ⊗ₜ m)
       = a ⊗ₜ (e : M ≃ₗ[R] M) m := by
@@ -339,7 +303,7 @@ theorem IsIsometry.injective (hB : B.SeparatingLeft) (hf : IsIsometry B f) :
   intro x y hxy
   rw [← sub_eq_zero]
   refine hB (x - y) fun z => ?_
-  rw [← hf (x - y) z, map_sub, hxy, sub_self, LinearMap.map_zero₂]
+  rw [← hf.apply (x - y) z, map_sub, hxy, sub_self, LinearMap.map_zero₂]
 
 end AddCommGroup
 
@@ -385,10 +349,12 @@ theorem isUnit_det (b : Basis ι R M)
 
 end IsIsometry
 
-/-- Over an integral domain, the Gram determinant of a nondegenerate form is a non-zero-divisor. -/
-theorem det_toMatrix_mem_nonZeroDivisors [IsDomain R] (b : Basis ι R M) (hB : B.Nondegenerate) :
+/-- Over an integral domain, the Gram determinant of a left-separating form is a
+non-zero-divisor. -/
+theorem det_toMatrix_mem_nonZeroDivisors [IsDomain R] (b : Basis ι R M)
+    (hB : B.SeparatingLeft) :
     (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R :=
-  mem_nonZeroDivisors_of_ne_zero ((LinearMap.BilinForm.nondegenerate_iff_det_ne_zero b).mp hB)
+  mem_nonZeroDivisors_of_ne_zero ((LinearMap.separatingLeft_iff_det_ne_zero b).mp hB)
 
 end Matrix
 
@@ -403,7 +369,7 @@ group. -/
 noncomputable def toIsometryGroupOfIsUnitDet (hf : IsIsometry B f)
     (hdet : IsUnit (LinearMap.det f)) : isometryGroup B :=
   ⟨LinearMap.equivOfIsUnitDet hdet,
-    mem_isometryGroup.mpr fun x y => by simpa using hf.apply x y⟩
+    mem_isometryGroup.mpr (isIsometry_iff.mpr fun x y => by simpa using hf.apply x y)⟩
 
 @[simp]
 theorem coe_toIsometryGroupOfIsUnitDet (hf : IsIsometry B f)
@@ -421,46 +387,46 @@ end IsIsometry
 
 end UnitDeterminant
 
-section Nondegenerate
+section SeparatingLeft
 
 variable [IsDomain R] [Module.Free R M] [Module.Finite R M]
 
 namespace IsIsometry
 
-/-- An isometry of a nondegenerate form on a finite free module over an integral domain has unit
+/-- An isometry of a left-separating form on a finite free module over an integral domain has unit
 determinant. -/
-theorem isUnit_det_of_nondegenerate (hB : B.Nondegenerate) (hf : IsIsometry B f) :
+theorem isUnit_det_of_separatingLeft (hB : B.SeparatingLeft) (hf : IsIsometry B f) :
     IsUnit (LinearMap.det f) :=
   hf.isUnit_det (Module.Free.chooseBasis R M)
     (det_toMatrix_mem_nonZeroDivisors (Module.Free.chooseBasis R M) hB)
 
-/-- Over an integral domain, an endomorphism of a finite free module preserving a nondegenerate
+/-- Over an integral domain, an endomorphism of a finite free module preserving a left-separating
 bilinear form is automatically invertible, hence an element of the isometry group. This is how an
 element of `Aut(V, Q)` usually presents itself: as an endomorphism of the lattice `V` preserving
 `Q`, with invertibility a consequence rather than a hypothesis. -/
-noncomputable def toIsometryGroup (hB : B.Nondegenerate) (hf : IsIsometry B f) :
+noncomputable def toIsometryGroup (hB : B.SeparatingLeft) (hf : IsIsometry B f) :
     isometryGroup B :=
-  hf.toIsometryGroupOfIsUnitDet (hf.isUnit_det_of_nondegenerate hB)
+  hf.toIsometryGroupOfIsUnitDet (hf.isUnit_det_of_separatingLeft hB)
 
 @[simp]
-theorem coe_toIsometryGroup (hB : B.Nondegenerate) (hf : IsIsometry B f) :
+theorem coe_toIsometryGroup (hB : B.SeparatingLeft) (hf : IsIsometry B f) :
     ((hf.toIsometryGroup hB : isometryGroup B) : M →ₗ[R] M) = f :=
-  LinearMap.coe_equivOfIsUnitDet (hf.isUnit_det_of_nondegenerate hB)
+  LinearMap.coe_equivOfIsUnitDet (hf.isUnit_det_of_separatingLeft hB)
 
 @[simp]
-theorem toIsometryGroup_apply (hB : B.Nondegenerate) (hf : IsIsometry B f) (x : M) :
+theorem toIsometryGroup_apply (hB : B.SeparatingLeft) (hf : IsIsometry B f) (x : M) :
     (hf.toIsometryGroup hB : M ≃ₗ[R] M) x = f x :=
-  LinearMap.equivOfIsUnitDet_apply (hf.isUnit_det_of_nondegenerate hB) x
+  LinearMap.equivOfIsUnitDet_apply (hf.isUnit_det_of_separatingLeft hB) x
 
-/-- Over an integral domain, an endomorphism of a finite free module preserving a nondegenerate
+/-- Over an integral domain, an endomorphism of a finite free module preserving a left-separating
 bilinear form is automatically bijective. -/
-theorem bijective (hB : B.Nondegenerate) (hf : IsIsometry B f) : Function.Bijective f :=
+theorem bijective (hB : B.SeparatingLeft) (hf : IsIsometry B f) : Function.Bijective f :=
   (Module.End.isUnit_iff f).mp
-    ((LinearMap.isUnit_iff_isUnit_det f).mpr (hf.isUnit_det_of_nondegenerate hB))
+    ((LinearMap.isUnit_iff_isUnit_det f).mpr (hf.isUnit_det_of_separatingLeft hB))
 
 end IsIsometry
 
-end Nondegenerate
+end SeparatingLeft
 
 end CommRing
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -316,7 +316,6 @@ theorem coe_isometryGroupBaseChange (B : BilinForm R M) (e : isometryGroup B) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M)
       = LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M) := (rfl)
 
-@[simp]
 theorem isometryGroupBaseChange_tmul (B : BilinForm R M) (e : isometryGroup B) (a : A) (m : M) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M) (a ⊗ₜ m)
       = a ⊗ₜ (e : M ≃ₗ[R] M) m := (rfl)

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -317,7 +317,6 @@ theorem coe_isometryGroupBaseChange (B : BilinForm R M) (e : isometryGroup B) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M)
       = LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M) := (rfl)
 
-@[simp]
 theorem isometryGroupBaseChange_tmul (B : BilinForm R M) (e : isometryGroup B) (a : A) (m : M) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M) (a ⊗ₜ m)
       = a ⊗ₜ (e : M ≃ₗ[R] M) m := by

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -327,21 +327,28 @@ end BaseChange
 
 end CommSemiring
 
+section AddCommGroup
+
+variable {R M : Type*} [CommSemiring R] [AddCommGroup M] [Module R M]
+  {B : BilinForm R M} {f : M →ₗ[R] M}
+
+/-- An isometry of a left-separating form is injective: it cannot collapse a vector that pairs
+nontrivially with something. -/
+theorem IsIsometry.injective (hB : B.SeparatingLeft) (hf : IsIsometry B f) :
+    Function.Injective f := by
+  intro x y hxy
+  rw [← sub_eq_zero]
+  refine hB (x - y) fun z => ?_
+  rw [← hf (x - y) z, map_sub, hxy, sub_self, LinearMap.map_zero₂]
+
+end AddCommGroup
+
 /-! ### Determinants -/
 
 section CommRing
 
 variable {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M] {B : BilinForm R M}
   {f : M →ₗ[R] M}
-
-/-- An isometry of a left-separating form is injective: it cannot collapse a vector that pairs
-nontrivially with something. -/
-theorem IsIsometry.injective (hB : B.SeparatingLeft) (hf : IsIsometry B f) :
-    Function.Injective f := by
-  rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
-  intro x hx
-  refine hB x fun y => ?_
-  rw [← hf x y, LinearMap.mem_ker.mp hx, LinearMap.map_zero₂]
 
 section Matrix
 
@@ -410,13 +417,6 @@ theorem toIsometryGroupOfIsUnitDet_apply (hf : IsIsometry B f)
     (hf.toIsometryGroupOfIsUnitDet hdet : M ≃ₗ[R] M) x = f x :=
   LinearMap.equivOfIsUnitDet_apply hdet x
 
-/-- An endomorphism of a finite free module with unit determinant is bijective. -/
-theorem bijective_of_isUnit_det (hf : IsIsometry B f) (hdet : IsUnit (LinearMap.det f)) :
-    Function.Bijective f := by
-  have h : ⇑(hf.toIsometryGroupOfIsUnitDet hdet : M ≃ₗ[R] M) = ⇑f :=
-    funext (hf.toIsometryGroupOfIsUnitDet_apply hdet)
-  exact h ▸ (hf.toIsometryGroupOfIsUnitDet hdet : M ≃ₗ[R] M).bijective
-
 end IsIsometry
 
 end UnitDeterminant
@@ -454,8 +454,9 @@ theorem toIsometryGroup_apply (hB : B.Nondegenerate) (hf : IsIsometry B f) (x : 
 
 /-- Over an integral domain, an endomorphism of a finite free module preserving a nondegenerate
 bilinear form is automatically bijective. -/
-theorem bijective (hB : B.Nondegenerate) (hf : IsIsometry B f) : Function.Bijective f := by
-  exact hf.bijective_of_isUnit_det (hf.isUnit_det_of_nondegenerate hB)
+theorem bijective (hB : B.Nondegenerate) (hf : IsIsometry B f) : Function.Bijective f :=
+  (Module.End.isUnit_iff f).mp
+    ((LinearMap.isUnit_iff_isUnit_det f).mpr (hf.isUnit_det_of_nondegenerate hB))
 
 end IsIsometry
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -118,10 +118,13 @@ is one. For a finite free `ℤ`-module `V` and a *nondegenerate* integral form `
 endomorphism is automatically invertible (`TauCeti.BilinForm.IsIsometry.toIsometryGroup`), and the
 resulting automorphisms are the arithmetic group `Aut(V, Q)`; see
 `TauCeti.BilinForm.isometryGroup`. -/
-@[expose] def IsIsometry (B : BilinForm R M) (f : M →ₗ[R] M) : Prop :=
+def IsIsometry (B : BilinForm R M) (f : M →ₗ[R] M) : Prop :=
   ∀ x y, B (f x) (f y) = B x y
 
 variable {B : BilinForm R M} {f g : M →ₗ[R] M}
+
+/-- An endomorphism is an isometry of `B` exactly when it preserves `B` pointwise. -/
+theorem isIsometry_iff : IsIsometry B f ↔ ∀ x y, B (f x) (f y) = B x y := (Iff.rfl)
 
 /-- An endomorphism is an isometry of `B` exactly when precomposing `B` with it on both sides
 returns `B`. -/
@@ -134,15 +137,18 @@ theorem isIsometry_toLinearMap (φ : B →bᵢ B) : IsIsometry B φ.toLinearMap 
 
 namespace IsIsometry
 
-/-- An isometry, bundled as one of Mathlib's isometric maps `B →bᵢ B`. The body is exposed so that
-the two evaluation lemmas below hold by `rfl` downstream. -/
-@[expose] def toIsometry (hf : IsIsometry B f) : B →bᵢ B := ⟨f, hf⟩
+/-- An isometry takes the same value under `B` after applying the endomorphism to both inputs. -/
+protected theorem apply (hf : IsIsometry B f) (x y : M) : B (f x) (f y) = B x y :=
+  isIsometry_iff.mp hf x y
+
+/-- An isometry, bundled as one of Mathlib's isometric maps `B →bᵢ B`. -/
+def toIsometry (hf : IsIsometry B f) : B →bᵢ B := ⟨f, hf⟩
 
 @[simp]
-theorem toIsometry_apply (hf : IsIsometry B f) (x : M) : hf.toIsometry x = f x := rfl
+theorem toIsometry_apply (hf : IsIsometry B f) (x : M) : hf.toIsometry x = f x := (rfl)
 
 @[simp]
-theorem toIsometry_toLinearMap (hf : IsIsometry B f) : hf.toIsometry.toLinearMap = f := rfl
+theorem toIsometry_toLinearMap (hf : IsIsometry B f) : hf.toIsometry.toLinearMap = f := (rfl)
 
 protected theorem id : IsIsometry B LinearMap.id := fun _ _ => rfl
 
@@ -197,12 +203,13 @@ theorem mem_isometryGroup {e : M ≃ₗ[R] M} :
 
 @[simp]
 theorem mem_isometryGroup_iff {e : M ≃ₗ[R] M} :
-    e ∈ isometryGroup B ↔ ∀ x y, B (e x) (e y) = B x y := Iff.rfl
+    e ∈ isometryGroup B ↔ ∀ x y, B (e x) (e y) = B x y :=
+  mem_isometryGroup.trans isIsometry_iff
 
 /-- Membership in `Aut(M, B)` is exactly Mathlib's notion of a self-isometry of `B`: the subgroup
 `TauCeti.BilinForm.isometryGroup B` and the type `LinearMap.BilinForm.IsometryEquiv B B` carry the
 same data, the subgroup adding the group structure. -/
-@[expose] def isometryGroupEquivIsometryEquiv (B : BilinForm R M) :
+def isometryGroupEquivIsometryEquiv (B : BilinForm R M) :
     isometryGroup B ≃ B.IsometryEquiv B where
   toFun e := ⟨e.1, fun x y => mem_isometryGroup.mp e.2 x y⟩
   invFun e := ⟨e.toLinearEquiv, mem_isometryGroup.mpr fun x y => e.map_app y x⟩
@@ -211,11 +218,11 @@ same data, the subgroup adding the group structure. -/
 
 @[simp]
 theorem coe_isometryGroupEquivIsometryEquiv (B : BilinForm R M) (e : isometryGroup B) :
-    ⇑(isometryGroupEquivIsometryEquiv B e) = ⇑(e : M ≃ₗ[R] M) := rfl
+    ⇑(isometryGroupEquivIsometryEquiv B e) = ⇑(e : M ≃ₗ[R] M) := (rfl)
 
 @[simp]
 theorem coe_isometryGroupEquivIsometryEquiv_symm (B : BilinForm R M) (e : B.IsometryEquiv B) :
-    (((isometryGroupEquivIsometryEquiv B).symm e : M ≃ₗ[R] M) : M → M) = ⇑e := rfl
+    (((isometryGroupEquivIsometryEquiv B).symm e : M ≃ₗ[R] M) : M → M) = ⇑e := (rfl)
 
 section Congr
 
@@ -297,7 +304,7 @@ theorem IsIsometry.baseChange (hf : IsIsometry B f) :
 /-- Base change along an `R`-algebra `A` is a group homomorphism
 `Aut(M, B) →* Aut(A ⊗[R] M, B_A)`. For `R = ℤ` and `A = ℂ` this is the action of the arithmetic
 group `Aut(V, Q)` on the complexification of the lattice. -/
-@[expose] def isometryGroupBaseChange (B : BilinForm R M) :
+def isometryGroupBaseChange (B : BilinForm R M) :
     isometryGroup B →* isometryGroup (LinearMap.BilinForm.baseChange A B) where
   toFun e := ⟨LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M),
     mem_isometryGroup.mpr (IsIsometry.baseChange A (mem_isometryGroup.mp e.2))⟩
@@ -307,12 +314,12 @@ group `Aut(V, Q)` on the complexification of the lattice. -/
 @[simp]
 theorem coe_isometryGroupBaseChange (B : BilinForm R M) (e : isometryGroup B) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M)
-      = LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M) := rfl
+      = LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M) := (rfl)
 
 @[simp]
 theorem isometryGroupBaseChange_tmul (B : BilinForm R M) (e : isometryGroup B) (a : A) (m : M) :
     (isometryGroupBaseChange A B e : A ⊗[R] M ≃ₗ[A] A ⊗[R] M) (a ⊗ₜ m)
-      = a ⊗ₜ (e : M ≃ₗ[R] M) m := rfl
+      = a ⊗ₜ (e : M ≃ₗ[R] M) m := (rfl)
 
 end BaseChange
 
@@ -376,6 +383,42 @@ theorem det_toMatrix_mem_nonZeroDivisors [IsDomain R] (b : Basis ι R M) (hB : B
 
 end Matrix
 
+section UnitDeterminant
+
+variable [Module.Free R M] [Module.Finite R M]
+
+namespace IsIsometry
+
+/-- An isometry whose underlying endomorphism has unit determinant, as an element of the isometry
+group. -/
+noncomputable def toIsometryGroupOfIsUnitDet (hf : IsIsometry B f)
+    (hdet : IsUnit (LinearMap.det f)) : isometryGroup B :=
+  ⟨LinearMap.equivOfIsUnitDet hdet,
+    mem_isometryGroup.mpr fun x y => by simpa using hf.apply x y⟩
+
+@[simp]
+theorem coe_toIsometryGroupOfIsUnitDet (hf : IsIsometry B f)
+    (hdet : IsUnit (LinearMap.det f)) :
+    ((hf.toIsometryGroupOfIsUnitDet hdet : isometryGroup B) : M →ₗ[R] M) = f :=
+  LinearMap.coe_equivOfIsUnitDet hdet
+
+@[simp]
+theorem toIsometryGroupOfIsUnitDet_apply (hf : IsIsometry B f)
+    (hdet : IsUnit (LinearMap.det f)) (x : M) :
+    (hf.toIsometryGroupOfIsUnitDet hdet : M ≃ₗ[R] M) x = f x :=
+  LinearMap.equivOfIsUnitDet_apply hdet x
+
+/-- An endomorphism of a finite free module with unit determinant is bijective. -/
+theorem bijective_of_isUnit_det (hf : IsIsometry B f) (hdet : IsUnit (LinearMap.det f)) :
+    Function.Bijective f := by
+  have h : ⇑(hf.toIsometryGroupOfIsUnitDet hdet : M ≃ₗ[R] M) = ⇑f :=
+    funext (hf.toIsometryGroupOfIsUnitDet_apply hdet)
+  exact h ▸ (hf.toIsometryGroupOfIsUnitDet hdet : M ≃ₗ[R] M).bijective
+
+end IsIsometry
+
+end UnitDeterminant
+
 section Nondegenerate
 
 variable [IsDomain R] [Module.Free R M] [Module.Finite R M]
@@ -393,10 +436,9 @@ theorem isUnit_det_of_nondegenerate (hB : B.Nondegenerate) (hf : IsIsometry B f)
 bilinear form is automatically invertible, hence an element of the isometry group. This is how an
 element of `Aut(V, Q)` usually presents itself: as an endomorphism of the lattice `V` preserving
 `Q`, with invertibility a consequence rather than a hypothesis. -/
-@[expose] noncomputable def toIsometryGroup (hB : B.Nondegenerate) (hf : IsIsometry B f) :
+noncomputable def toIsometryGroup (hB : B.Nondegenerate) (hf : IsIsometry B f) :
     isometryGroup B :=
-  ⟨LinearMap.equivOfIsUnitDet (hf.isUnit_det_of_nondegenerate hB),
-    mem_isometryGroup.mpr fun x y => by simpa using hf x y⟩
+  hf.toIsometryGroupOfIsUnitDet (hf.isUnit_det_of_nondegenerate hB)
 
 @[simp]
 theorem coe_toIsometryGroup (hB : B.Nondegenerate) (hf : IsIsometry B f) :
@@ -411,8 +453,7 @@ theorem toIsometryGroup_apply (hB : B.Nondegenerate) (hf : IsIsometry B f) (x : 
 /-- Over an integral domain, an endomorphism of a finite free module preserving a nondegenerate
 bilinear form is automatically bijective. -/
 theorem bijective (hB : B.Nondegenerate) (hf : IsIsometry B f) : Function.Bijective f := by
-  have h : ⇑(hf.toIsometryGroup hB : M ≃ₗ[R] M) = ⇑f := funext (toIsometryGroup_apply hB hf)
-  exact h ▸ (hf.toIsometryGroup hB : M ≃ₗ[R] M).bijective
+  exact hf.bijective_of_isUnit_det (hf.isUnit_det_of_nondegenerate hB)
 
 end IsIsometry
 

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -1,0 +1,300 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
+public import Mathlib.LinearAlgebra.BilinearForm.IsometryEquiv
+public import Mathlib.LinearAlgebra.BilinearForm.Orthogonal
+public import Mathlib.LinearAlgebra.BilinearForm.TensorProduct
+public import Mathlib.LinearAlgebra.Determinant
+public import Mathlib.LinearAlgebra.Matrix.BilinearForm
+
+/-!
+# The isometry group of a bilinear form
+
+An endomorphism `f` of a module `M` is an *isometry* of a bilinear form `B` when
+`B (f x) (f y) = B x y`. This file introduces that predicate, `TauCeti.IsFormIsometry`, and the
+group it cuts out inside the linear automorphisms of `M`, `TauCeti.formIsometryGroup B`, together
+with the API a consumer of the group needs: a Gram-matrix criterion, the resulting constraint
+`(det f) ^ 2 = 1`, functoriality in the module and in the base ring, and stability of orthogonal
+complements.
+
+Mathlib bundles the same notion twice — as a map, `B₁ →bᵢ B₂`, and as an equivalence,
+`LinearMap.BilinForm.IsometryEquiv B₁ B₂` — and both bridges are recorded here
+(`TauCeti.IsFormIsometry.toIsometry`, `TauCeti.isFormIsometry_toLinearMap`, and
+`TauCeti.formIsometryGroupEquivIsometryEquiv`, the last an equivalence of *types* between the
+subgroup and `B.IsometryEquiv B`). What is new is the unbundled predicate, which is what lets
+"preserves `B`" be a side condition on an endomorphism one already has — the hypothesis of the
+automatic-invertibility theorem below, and the membership condition of a subgroup — and the group
+structure, needed as soon as one wants subgroups of it, group homomorphisms into it, or a group
+action, none of which a bare type of bundled equivalences provides.
+
+Two statements are worth singling out.
+
+* Over an integral domain, isometries of a nondegenerate form on a finite free module are
+  *automatically* invertible (`TauCeti.IsFormIsometry.bijective`): preserving `B` forces
+  `(det f) ^ 2 = 1`, so `det f` is a unit. For a `ℤ`-lattice this says that a form-preserving
+  endomorphism of the lattice already lies in the arithmetic group `Aut(V, Q)`, which is how such
+  an automorphism usually presents itself — as an integer matrix satisfying `Aᵀ * G * A = G`.
+* Base change along an algebra `R → A` is a group homomorphism
+  `Aut(M, B) →* Aut(A ⊗[R] M, B_A)` (`TauCeti.formIsometryGroupBaseChange`). For `R = ℤ` and
+  `A = ℂ` this is the action of `Aut(V, Q)` on the complexification of the lattice, through which
+  the monodromy of a variation of Hodge structure acts.
+
+## Main definitions
+
+* `TauCeti.IsFormIsometry`: an endomorphism preserves a bilinear form.
+* `TauCeti.formIsometryGroup`: the isometry group `Aut(M, B) ≤ M ≃ₗ[R] M`.
+* `TauCeti.IsFormIsometry.toLinearEquiv`: an isometry with invertible Gram determinant, as a
+  linear automorphism.
+* `TauCeti.formIsometryGroupBaseChange`: base change of isometries, as a group homomorphism.
+* `TauCeti.formIsometryGroupCongr`: transport of the isometry group along a linear equivalence.
+
+## Main results
+
+* `TauCeti.isFormIsometry_iff_toMatrix`: the Gram-matrix criterion `Aᵀ * G * A = G`.
+* `TauCeti.IsFormIsometry.det_sq_eq_one`: `(det f) ^ 2 = 1` for an isometry of a form whose Gram
+  determinant is a non-zero-divisor.
+* `TauCeti.IsFormIsometry.bijective`: over an integral domain, an isometry of a nondegenerate form
+  on a finite free module is bijective.
+* `TauCeti.IsFormIsometry.map_orthogonal`: a surjective isometry carries `B`-orthogonal complements
+  to `B`-orthogonal complements.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module
+open LinearMap (BilinForm)
+open scoped Matrix TensorProduct
+
+variable {R M M' : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup M']
+  [Module R M']
+
+/-- An endomorphism `f` of `M` is an *isometry* of the bilinear form `B` when it preserves `B`,
+that is, when `B (f x) (f y) = B x y` for all `x` and `y`.
+
+Specialised to a finite free `ℤ`-module `V` and an integral form `Q`, the isometries form the
+arithmetic group `Aut(V, Q)`; see `TauCeti.formIsometryGroup`. -/
+@[expose] def IsFormIsometry (B : BilinForm R M) (f : M →ₗ[R] M) : Prop :=
+  ∀ x y, B (f x) (f y) = B x y
+
+variable {B : BilinForm R M} {f g : M →ₗ[R] M}
+
+theorem isFormIsometry_iff_comp : IsFormIsometry B f ↔ B.comp f f = B :=
+  ⟨fun h => LinearMap.BilinForm.ext fun x y => h x y, fun h x y =>
+    LinearMap.BilinForm.congr_fun h x y⟩
+
+theorem isFormIsometry_toLinearMap (φ : B →bᵢ B) : IsFormIsometry B φ.toLinearMap := φ.map_app
+
+namespace IsFormIsometry
+
+/-- An isometry, bundled as one of Mathlib's isometric maps `B →bᵢ B`. -/
+@[expose] def toIsometry (hf : IsFormIsometry B f) : B →bᵢ B := ⟨f, hf⟩
+
+@[simp]
+theorem toIsometry_apply (hf : IsFormIsometry B f) (x : M) : hf.toIsometry x = f x := rfl
+
+protected theorem id : IsFormIsometry B LinearMap.id := fun _ _ => rfl
+
+protected theorem comp (hf : IsFormIsometry B f) (hg : IsFormIsometry B g) :
+    IsFormIsometry B (f ∘ₗ g) := fun x y => (hf (g x) (g y)).trans (hg x y)
+
+/-- An isometry of a left-separating form is injective: it cannot collapse a vector that pairs
+nontrivially with something. -/
+theorem injective (hB : B.SeparatingLeft) (hf : IsFormIsometry B f) : Function.Injective f := by
+  rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
+  intro x hx
+  refine hB x fun y => ?_
+  rw [← hf x y, LinearMap.mem_ker.mp hx, LinearMap.map_zero₂]
+
+/-- An isometry preserving a submodule restricts to an isometry of the restricted form. -/
+theorem restrict {N : Submodule R M} (hf : IsFormIsometry B f) (hN : ∀ x ∈ N, f x ∈ N) :
+    IsFormIsometry (B.restrict N) (f.restrict hN) := fun x y => hf x y
+
+/-- An isometry maps the `B`-orthogonal complement of `N` into the `B`-orthogonal complement of
+the image of `N`. -/
+theorem map_orthogonal_le (hf : IsFormIsometry B f) (N : Submodule R M) :
+    (B.orthogonal N).map f ≤ B.orthogonal (N.map f) := by
+  rintro - ⟨x, hx, rfl⟩
+  rw [LinearMap.BilinForm.mem_orthogonal_iff]
+  rintro - ⟨n, hn, rfl⟩
+  show B (f n) (f x) = 0
+  rw [hf n x]
+  exact (LinearMap.BilinForm.mem_orthogonal_iff.mp hx) n hn
+
+/-- A surjective isometry carries `B`-orthogonal complements to `B`-orthogonal complements. -/
+theorem map_orthogonal (hf : IsFormIsometry B f) (hsurj : Function.Surjective f)
+    (N : Submodule R M) : (B.orthogonal N).map f = B.orthogonal (N.map f) := by
+  refine le_antisymm (hf.map_orthogonal_le N) fun x hx => ?_
+  obtain ⟨z, rfl⟩ := hsurj x
+  refine Submodule.mem_map_of_mem ?_
+  rw [LinearMap.BilinForm.mem_orthogonal_iff]
+  intro n hn
+  show B n z = 0
+  rw [← hf n z]
+  exact (LinearMap.BilinForm.mem_orthogonal_iff.mp hx) _ ⟨n, hn, rfl⟩
+
+end IsFormIsometry
+
+/-- The isometry group `Aut(M, B)` of a bilinear form `B` on `M`: the linear automorphisms of `M`
+that preserve `B`.
+
+For a finite free `ℤ`-module `V` carrying an integral form `Q` this is the arithmetic group
+`Aut(V, Q)`; a variation of Hodge structure has its monodromy representation land in it, acting on
+the complexification through `TauCeti.formIsometryGroupBaseChange`. -/
+def formIsometryGroup (B : BilinForm R M) : Subgroup (M ≃ₗ[R] M) where
+  carrier := {e | IsFormIsometry B (e : M →ₗ[R] M)}
+  one_mem' := fun _ _ => rfl
+  mul_mem' := fun {a b} ha hb x y => (ha (b x) (b y)).trans (hb x y)
+  inv_mem' := fun {a} ha x y => by
+    simpa using (ha (a.symm x) (a.symm y)).symm
+
+@[simp]
+theorem mem_formIsometryGroup_iff {e : M ≃ₗ[R] M} :
+    e ∈ formIsometryGroup B ↔ ∀ x y, B (e x) (e y) = B x y := Iff.rfl
+
+/-- An element of the isometry group carries `B`-orthogonal complements to `B`-orthogonal
+complements. -/
+theorem map_orthogonal_of_mem_formIsometryGroup {e : M ≃ₗ[R] M} (he : e ∈ formIsometryGroup B)
+    (N : Submodule R M) :
+    (B.orthogonal N).map (e : M →ₗ[R] M) = B.orthogonal (N.map (e : M →ₗ[R] M)) :=
+  IsFormIsometry.map_orthogonal he e.surjective N
+
+/-- Membership in `Aut(M, B)` is exactly Mathlib's notion of a self-isometry of `B`: the subgroup
+`TauCeti.formIsometryGroup B` and the type `LinearMap.BilinForm.IsometryEquiv B B` carry the same
+data, the subgroup adding the group structure. -/
+def formIsometryGroupEquivIsometryEquiv (B : BilinForm R M) :
+    formIsometryGroup B ≃ B.IsometryEquiv B where
+  toFun e := ⟨e.1, fun x y => e.2 x y⟩
+  invFun e := ⟨e.toLinearEquiv, fun x y => e.map_app y x⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- Transporting a bilinear form along a linear equivalence transports its isometry group. -/
+def formIsometryGroupCongr (B : BilinForm R M) (e : M ≃ₗ[R] M') :
+    formIsometryGroup B ≃* formIsometryGroup (LinearMap.BilinForm.congr e B) where
+  toFun a := ⟨e.symm ≪≫ₗ (a : M ≃ₗ[R] M) ≪≫ₗ e, fun x y => by
+    simpa using a.2 (e.symm x) (e.symm y)⟩
+  invFun a := ⟨e ≪≫ₗ (a : M' ≃ₗ[R] M') ≪≫ₗ e.symm, fun x y => by
+    simpa using a.2 (e x) (e y)⟩
+  left_inv a := Subtype.ext (by ext x; simp)
+  right_inv a := Subtype.ext (by ext x; simp)
+  map_mul' a b := Subtype.ext (by ext x; simp)
+
+/-! ### The Gram-matrix criterion -/
+
+section Matrix
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+/-- An endomorphism is an isometry of `B` exactly when its matrix `A` in a basis `b` satisfies
+`Aᵀ * G * A = G` for the Gram matrix `G` of `B` in `b`. -/
+theorem isFormIsometry_iff_toMatrix (b : Basis ι R M) :
+    IsFormIsometry B f ↔
+      (LinearMap.toMatrix b b f)ᵀ * LinearMap.BilinForm.toMatrix b B * LinearMap.toMatrix b b f
+        = LinearMap.BilinForm.toMatrix b B := by
+  rw [isFormIsometry_iff_comp, ← (LinearMap.BilinForm.toMatrix b).injective.eq_iff,
+    LinearMap.BilinForm.toMatrix_comp b b B f f]
+
+namespace IsFormIsometry
+
+/-- An isometry scales the Gram determinant by the square of its determinant — and hence, the form
+being preserved, not at all. -/
+theorem det_sq_mul_det_toMatrix (b : Basis ι R M) (hf : IsFormIsometry B f) :
+    LinearMap.det f ^ 2 * (LinearMap.BilinForm.toMatrix b B).det =
+      (LinearMap.BilinForm.toMatrix b B).det := by
+  have h := congrArg Matrix.det ((isFormIsometry_iff_toMatrix b).mp hf)
+  rw [Matrix.det_mul, Matrix.det_mul, Matrix.det_transpose, LinearMap.det_toMatrix] at h
+  rw [show LinearMap.det f ^ 2 * (LinearMap.BilinForm.toMatrix b B).det
+      = LinearMap.det f * (LinearMap.BilinForm.toMatrix b B).det * LinearMap.det f from by ring]
+  exact h
+
+/-- An isometry of a bilinear form whose Gram determinant is a non-zero-divisor has determinant
+squaring to `1`; over `ℤ` this says its determinant is `±1`. -/
+theorem det_sq_eq_one (b : Basis ι R M)
+    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
+    (hf : IsFormIsometry B f) : LinearMap.det f ^ 2 = 1 := by
+  have h : (LinearMap.det f ^ 2 - 1) * (LinearMap.BilinForm.toMatrix b B).det = 0 := by
+    rw [sub_mul, one_mul, hf.det_sq_mul_det_toMatrix b, sub_self]
+  exact sub_eq_zero.mp ((mem_nonZeroDivisors_iff.mp hG).2 _ h)
+
+theorem isUnit_det (b : Basis ι R M)
+    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
+    (hf : IsFormIsometry B f) : IsUnit (LinearMap.det f) :=
+  IsUnit.of_mul_eq_one _ (by rw [← sq]; exact hf.det_sq_eq_one b hG)
+
+/-- An isometry of a bilinear form whose Gram determinant is a non-zero-divisor is a linear
+automorphism. This is how an element of `Aut(V, Q)` usually presents itself: as an endomorphism
+of the lattice `V` preserving `Q`, with invertibility a consequence rather than a hypothesis. -/
+noncomputable def toLinearEquiv (b : Basis ι R M)
+    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
+    (hf : IsFormIsometry B f) : M ≃ₗ[R] M :=
+  LinearEquiv.ofIsUnitDet (v := b) (v' := b)
+    (by rw [LinearMap.det_toMatrix]; exact hf.isUnit_det b hG)
+
+@[simp]
+theorem coe_toLinearEquiv (b : Basis ι R M)
+    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
+    (hf : IsFormIsometry B f) : (toLinearEquiv b hG hf : M →ₗ[R] M) = f :=
+  LinearEquiv.coe_ofIsUnitDet _
+
+@[simp]
+theorem toLinearEquiv_apply (b : Basis ι R M)
+    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
+    (hf : IsFormIsometry B f) (x : M) : toLinearEquiv b hG hf x = f x :=
+  congrArg (fun l : M →ₗ[R] M => l x) (coe_toLinearEquiv b hG hf)
+
+theorem toLinearEquiv_mem_formIsometryGroup (b : Basis ι R M)
+    (hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R)
+    (hf : IsFormIsometry B f) : toLinearEquiv b hG hf ∈ formIsometryGroup B := fun x y => by
+  simpa using hf x y
+
+/-- Over an integral domain, an endomorphism of a finite free module preserving a nondegenerate
+bilinear form is automatically bijective. -/
+theorem bijective [IsDomain R] [Module.Free R M] [Module.Finite R M] (hB : B.Nondegenerate)
+    (hf : IsFormIsometry B f) : Function.Bijective f := by
+  set b := Module.Free.chooseBasis R M
+  have hG : (LinearMap.BilinForm.toMatrix b B).det ∈ nonZeroDivisors R :=
+    mem_nonZeroDivisors_of_ne_zero ((LinearMap.BilinForm.nondegenerate_iff_det_ne_zero b).mp hB)
+  have h := (toLinearEquiv b hG hf).bijective
+  rwa [show ⇑(toLinearEquiv b hG hf) = ⇑f from funext (toLinearEquiv_apply b hG hf)] at h
+
+end IsFormIsometry
+
+end Matrix
+
+/-! ### Base change -/
+
+section BaseChange
+
+variable (A : Type*) [CommRing A] [Algebra R A]
+
+theorem IsFormIsometry.baseChange (hf : IsFormIsometry B f) :
+    IsFormIsometry (LinearMap.BilinForm.baseChange A B) (f.baseChange A) := by
+  intro x y
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | add x₁ x₂ h₁ h₂ => simp only [map_add, LinearMap.add_apply, h₁, h₂]
+  | tmul a m =>
+      induction y using TensorProduct.induction_on with
+      | zero => simp
+      | add y₁ y₂ h₁ h₂ => simp only [map_add, h₁, h₂]
+      | tmul a' m' => simp [hf m m']
+
+/-- Base change along an `R`-algebra `A` is a group homomorphism
+`Aut(M, B) →* Aut(A ⊗[R] M, B_A)`. For `R = ℤ` and `A = ℂ` this is the action of the arithmetic
+group `Aut(V, Q)` on the complexification of the lattice. -/
+def formIsometryGroupBaseChange (B : BilinForm R M) :
+    formIsometryGroup B →* formIsometryGroup (LinearMap.BilinForm.baseChange A B) where
+  toFun e := ⟨LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M),
+    fun x y => IsFormIsometry.baseChange A e.2 x y⟩
+  map_one' := Subtype.ext (by simp)
+  map_mul' a b := Subtype.ext (by simp [LinearEquiv.baseChange_mul])
+
+end BaseChange
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry.lean
@@ -45,8 +45,8 @@ Two statements are worth singling out.
   `Aᵀ * G * A = G`.
 * Base change along an algebra `R → A` is a group homomorphism
   `Aut(M, B) →* Aut(A ⊗[R] M, B_A)` (`TauCeti.BilinForm.isometryGroupBaseChange`). For `R = ℤ` and
-  `A = ℂ` this is the action of `Aut(V, Q)` on the complexification of the lattice, through which
-  the monodromy of a variation of Hodge structure acts.
+  `A = ℂ` this is the action of `Aut(V, Q)` on the complexification of the lattice. When `Q` is
+  preserved by monodromy, the monodromy of a variation of Hodge structure acts through this map.
 
 ## Main definitions
 
@@ -149,8 +149,9 @@ end IsIsometry
 that preserve `B`.
 
 For a finite free `ℤ`-module `V` carrying an integral form `Q` this is the arithmetic group
-`Aut(V, Q)`; a variation of Hodge structure has its monodromy representation land in it, acting on
-the complexification through `TauCeti.BilinForm.isometryGroupBaseChange`. -/
+`Aut(V, Q)`; when `Q` is preserved by monodromy, a variation of Hodge structure has its monodromy
+representation land in this group and act on the complexification through
+`TauCeti.BilinForm.isometryGroupBaseChange`. -/
 def isometryGroup (B : BilinForm R M) : Subgroup (M ≃ₗ[R] M) where
   carrier := {e | IsIsometry B (e : M →ₗ[R] M)}
   one_mem' := isIsometry_iff.mpr fun _ _ => rfl
@@ -267,7 +268,8 @@ theorem IsIsometry.baseChange (hf : IsIsometry B f) :
 
 /-- Base change along an `R`-algebra `A` is a group homomorphism
 `Aut(M, B) →* Aut(A ⊗[R] M, B_A)`. For `R = ℤ` and `A = ℂ` this is the action of the arithmetic
-group `Aut(V, Q)` on the complexification of the lattice. -/
+group `Aut(V, Q)` on the complexification of the lattice, through which monodromy acts when it
+preserves `Q`. -/
 def isometryGroupBaseChange (B : BilinForm R M) :
     isometryGroup B →* isometryGroup (LinearMap.BilinForm.baseChange A B) where
   toFun e := ⟨LinearEquiv.baseChange R A M M (e : M ≃ₗ[R] M),

--- a/TauCeti/LinearAlgebra/BilinearForm/Isometry/Basic.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/Isometry/Basic.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.BilinearForm.Hom
+public import Mathlib.LinearAlgebra.BilinearForm.Isometry
+
+/-!
+# Isometric endomorphisms of a bilinear form
+
+This file defines the predicate that an endomorphism preserves a bilinear form and provides its
+elementary API, including the bridge to Mathlib's bundled isometric maps. The isometry group and
+the determinant, base-change, and orthogonal-complement API are developed in
+`TauCeti.LinearAlgebra.BilinearForm.Isometry`.
+-/
+
+public section
+
+namespace TauCeti
+
+open LinearMap (BilinForm)
+
+namespace BilinForm
+
+section CommSemiring
+
+variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
+
+/-- An endomorphism `f` of `M` is an *isometry* of the bilinear form `B` when it preserves `B`,
+that is, when `B (f x) (f y) = B x y` for all `x` and `y`.
+
+Isometric endomorphisms form a monoid, not a group: for the zero form on `ℤ ^ 2` every endomorphism
+is one. For a finite free `ℤ`-module `V` and a left-separating integral form `Q` an isometric
+endomorphism is automatically invertible (`TauCeti.BilinForm.IsIsometry.toIsometryGroup`), and the
+resulting automorphisms are the arithmetic group `Aut(V, Q)`; see
+`TauCeti.BilinForm.isometryGroup`. -/
+def IsIsometry (B : BilinForm R M) (f : M →ₗ[R] M) : Prop :=
+  ∀ x y, B (f x) (f y) = B x y
+
+variable {B : BilinForm R M} {f g : M →ₗ[R] M}
+
+/-- An endomorphism is an isometry of `B` exactly when it preserves `B` pointwise. -/
+theorem isIsometry_iff : IsIsometry B f ↔ ∀ x y, B (f x) (f y) = B x y := (Iff.rfl)
+
+/-- An endomorphism is an isometry of `B` exactly when precomposing `B` with it on both sides
+returns `B`. -/
+theorem isIsometry_iff_comp : IsIsometry B f ↔ B.comp f f = B :=
+  ⟨fun h => LinearMap.BilinForm.ext fun x y => h x y, fun h x y =>
+    LinearMap.BilinForm.congr_fun h x y⟩
+
+/-- The underlying map of one of Mathlib's isometric maps `B →bᵢ B` is an isometry. -/
+theorem isIsometry_toLinearMap (φ : B →bᵢ B) : IsIsometry B φ.toLinearMap := φ.map_app
+
+namespace IsIsometry
+
+/-- An isometry takes the same value under `B` after applying the endomorphism to both inputs. -/
+@[grind =]
+protected theorem apply (hf : IsIsometry B f) (x y : M) : B (f x) (f y) = B x y :=
+  isIsometry_iff.mp hf x y
+
+/-- An isometry, bundled as one of Mathlib's isometric maps `B →bᵢ B`. -/
+def toIsometry (hf : IsIsometry B f) : B →bᵢ B := ⟨f, hf⟩
+
+@[simp]
+theorem toIsometry_apply (hf : IsIsometry B f) (x : M) : hf.toIsometry x = f x := (rfl)
+
+@[simp]
+theorem toIsometry_toLinearMap (hf : IsIsometry B f) : hf.toIsometry.toLinearMap = f := (rfl)
+
+protected theorem id : IsIsometry B LinearMap.id := fun _ _ => rfl
+
+protected theorem comp (hf : IsIsometry B f) (hg : IsIsometry B g) : IsIsometry B (f ∘ₗ g) :=
+  fun x y => (hf (g x) (g y)).trans (hg x y)
+
+end IsIsometry
+
+end CommSemiring
+
+end BilinForm
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
+
+/-!
+# Conjugating automorphism groups along a linear equivalence
+
+Mathlib conjugates general linear groups with
+`LinearMap.GeneralLinearGroup.congrLinearEquiv : GL R M₁ ≃* GL R M₂`, and identifies `GL R M` with
+the automorphisms `M ≃ₗ[R] M` through `LinearMap.GeneralLinearGroup.generalLinearEquiv`. Groups of
+linear automorphisms cut out by a structure they preserve — an orthogonal group, an isometry
+group — are subgroups of `M ≃ₗ[R] M` rather than of `GL R M`, so what they need is the composite of
+those two, which this file records as `TauCeti.LinearEquiv.congrAut`.
+
+## Main definitions
+
+* `TauCeti.LinearEquiv.congrAut`: conjugation by `e : M₁ ≃ₗ[R] M₂`, as an isomorphism
+  `(M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ[R] M₂)`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace LinearEquiv
+
+open LinearMap.GeneralLinearGroup
+
+variable {R M₁ M₂ : Type*} [CommSemiring R] [AddCommMonoid M₁] [Module R M₁] [AddCommMonoid M₂]
+  [Module R M₂]
+
+/-- Conjugation by a linear equivalence `e : M₁ ≃ₗ[R] M₂`, as an isomorphism of automorphism
+groups: Mathlib's `LinearMap.GeneralLinearGroup.congrLinearEquiv` read through
+`LinearMap.GeneralLinearGroup.generalLinearEquiv`.
+
+The body is exposed so that the two evaluation lemmas below hold by `rfl` downstream. -/
+@[expose] def congrAut (e : M₁ ≃ₗ[R] M₂) : (M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ[R] M₂) :=
+  ((generalLinearEquiv R M₁).symm.trans (congrLinearEquiv e)).trans (generalLinearEquiv R M₂)
+
+@[simp]
+theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : M₂) :
+    congrAut e f m = e (f (e.symm m)) := rfl
+
+@[simp]
+theorem congrAut_symm_apply (e : M₁ ≃ₗ[R] M₂) (g : M₂ ≃ₗ[R] M₂) (m : M₁) :
+    (congrAut e).symm g m = e.symm (g (e m)) := rfl
+
+end LinearEquiv
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -44,8 +44,7 @@ def congrAut (e : M₁ ≃ₗ[R] M₂) : (M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ
 @[simp]
 theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : M₂) :
     congrAut e f m = e (f (e.symm m)) := by
-  change (generalLinearEquiv R M₂
-    (congrLinearEquiv e ((generalLinearEquiv R M₁).symm f))) m = _
+  rw [congrAut, MulEquiv.trans_apply, MulEquiv.trans_apply]
   simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
     LinearEquiv.trans_apply]
   apply congrArg e
@@ -59,11 +58,9 @@ theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : 
 @[simp]
 theorem congrAut_symm_apply (e : M₁ ≃ₗ[R] M₂) (g : M₂ ≃ₗ[R] M₂) (m : M₁) :
     (congrAut e).symm g m = e.symm (g (e m)) := by
-  change (generalLinearEquiv R M₁
-    ((congrLinearEquiv e).symm ((generalLinearEquiv R M₂).symm g))) m = _
+  rw [congrAut, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply]
   rw [congrLinearEquiv_symm]
-  simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
-    LinearEquiv.trans_apply, LinearEquiv.symm_symm]
+  simp only [congrLinearEquiv_apply, LinearEquiv.symm_symm]
   apply congrArg e.symm
   calc
     ((generalLinearEquiv R M₂).symm g).toLinearEquiv (e m) =

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -30,7 +30,7 @@ namespace LinearEquiv
 
 open LinearMap.GeneralLinearGroup
 
-variable {R M₁ M₂ : Type*} [CommSemiring R] [AddCommMonoid M₁] [Module R M₁] [AddCommMonoid M₂]
+variable {R M₁ M₂ : Type*} [Semiring R] [AddCommMonoid M₁] [Module R M₁] [AddCommMonoid M₂]
   [Module R M₂]
 
 /-- Conjugation by a linear equivalence `e : M₁ ≃ₗ[R] M₂`, as an isomorphism of automorphism
@@ -44,25 +44,33 @@ def congrAut (e : M₁ ≃ₗ[R] M₂) : (M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ
 @[simp]
 theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : M₂) :
     congrAut e f m = e (f (e.symm m)) := by
-  -- Expose the composite once so named evaluation lemmas, rather than reduction, drive the proof.
   change (generalLinearEquiv R M₂
     (congrLinearEquiv e ((generalLinearEquiv R M₁).symm f))) m = _
   simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
     LinearEquiv.trans_apply]
-  rw [show ((generalLinearEquiv R M₁).symm f).toLinearEquiv = f from
-    (generalLinearEquiv R M₁).apply_symm_apply f]
+  apply congrArg e
+  calc
+    ((generalLinearEquiv R M₁).symm f).toLinearEquiv (e.symm m) =
+        generalLinearEquiv R M₁ ((generalLinearEquiv R M₁).symm f) (e.symm m) := by
+      exact (LinearMap.congr_fun
+        (generalLinearEquiv_to_linearMap ((generalLinearEquiv R M₁).symm f)) (e.symm m)).symm
+    _ = f (e.symm m) := by rw [(generalLinearEquiv R M₁).apply_symm_apply]
 
 @[simp]
 theorem congrAut_symm_apply (e : M₁ ≃ₗ[R] M₂) (g : M₂ ≃ₗ[R] M₂) (m : M₁) :
     (congrAut e).symm g m = e.symm (g (e m)) := by
-  -- Expose the composite once so named evaluation lemmas, rather than reduction, drive the proof.
   change (generalLinearEquiv R M₁
     ((congrLinearEquiv e).symm ((generalLinearEquiv R M₂).symm g))) m = _
   rw [congrLinearEquiv_symm]
   simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
     LinearEquiv.trans_apply, LinearEquiv.symm_symm]
-  rw [show ((generalLinearEquiv R M₂).symm g).toLinearEquiv = g from
-    (generalLinearEquiv R M₂).apply_symm_apply g]
+  apply congrArg e.symm
+  calc
+    ((generalLinearEquiv R M₂).symm g).toLinearEquiv (e m) =
+        generalLinearEquiv R M₂ ((generalLinearEquiv R M₂).symm g) (e m) := by
+      exact (LinearMap.congr_fun
+        (generalLinearEquiv_to_linearMap ((generalLinearEquiv R M₂).symm g)) (e m)).symm
+    _ = g (e m) := by rw [(generalLinearEquiv R M₂).apply_symm_apply]
 
 end LinearEquiv
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -30,8 +30,20 @@ namespace LinearEquiv
 
 open LinearMap.GeneralLinearGroup
 
-variable {R M₁ M₂ : Type*} [Semiring R] [AddCommMonoid M₁] [Module R M₁] [AddCommMonoid M₂]
-  [Module R M₂]
+variable {R M M₁ M₂ : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid M₁]
+  [Module R M₁] [AddCommMonoid M₂] [Module R M₂]
+
+/-- The linear automorphism underlying the general linear group element
+`(generalLinearEquiv R M).symm f` is `f` itself.
+
+Mathlib records how `generalLinearEquiv` computes on coercions (`coeFn_generalLinearEquiv`,
+`coe_toLinearEquiv`) rather than at the level of `M ≃ₗ[R] M`, so both evaluation lemmas for
+`congrAut` below need this bridge; it is stated once here. -/
+private theorem toLinearEquiv_generalLinearEquiv_symm (f : M ≃ₗ[R] M) :
+    ((generalLinearEquiv R M).symm f).toLinearEquiv = f := by
+  ext m
+  rw [coe_toLinearEquiv, ← coeFn_generalLinearEquiv]
+  exact DFunLike.congr_fun ((generalLinearEquiv R M).apply_symm_apply f) m
 
 /-- Conjugation by a linear equivalence `e : M₁ ≃ₗ[R] M₂`, as an isomorphism of automorphism
 groups: Mathlib's `LinearMap.GeneralLinearGroup.congrLinearEquiv` read through
@@ -47,29 +59,16 @@ theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : 
     congrAut e f m = e (f (e.symm m)) := by
   rw [congrAut, MulEquiv.trans_apply, MulEquiv.trans_apply]
   simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
-    LinearEquiv.trans_apply]
-  apply congrArg e
-  calc
-    ((generalLinearEquiv R M₁).symm f).toLinearEquiv (e.symm m) =
-        generalLinearEquiv R M₁ ((generalLinearEquiv R M₁).symm f) (e.symm m) := by
-      exact (LinearMap.congr_fun
-        (generalLinearEquiv_to_linearMap ((generalLinearEquiv R M₁).symm f)) (e.symm m)).symm
-    _ = f (e.symm m) := by rw [(generalLinearEquiv R M₁).apply_symm_apply]
+    LinearEquiv.trans_apply, toLinearEquiv_generalLinearEquiv_symm]
 
 /-- Inverse conjugation by `e` sends `m` to `e.symm (g (e m))`. -/
 @[simp]
 theorem congrAut_symm_apply (e : M₁ ≃ₗ[R] M₂) (g : M₂ ≃ₗ[R] M₂) (m : M₁) :
     (congrAut e).symm g m = e.symm (g (e m)) := by
-  rw [congrAut, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply]
-  rw [congrLinearEquiv_symm]
-  simp only [congrLinearEquiv_apply, LinearEquiv.symm_symm]
-  apply congrArg e.symm
-  calc
-    ((generalLinearEquiv R M₂).symm g).toLinearEquiv (e m) =
-        generalLinearEquiv R M₂ ((generalLinearEquiv R M₂).symm g) (e m) := by
-      exact (LinearMap.congr_fun
-        (generalLinearEquiv_to_linearMap ((generalLinearEquiv R M₂).symm g)) (e m)).symm
-    _ = g (e m) := by rw [(generalLinearEquiv R M₂).apply_symm_apply]
+  rw [congrAut, MulEquiv.symm_trans_apply, MulEquiv.symm_trans_apply, congrLinearEquiv_symm]
+  simp only [congrLinearEquiv_apply, MulEquiv.symm_symm, coeFn_generalLinearEquiv,
+    coe_ofLinearEquiv, LinearEquiv.symm_symm, LinearEquiv.trans_apply,
+    toLinearEquiv_generalLinearEquiv_symm]
 
 end LinearEquiv
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -43,11 +43,24 @@ def congrAut (e : M₁ ≃ₗ[R] M₂) : (M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ
 
 @[simp]
 theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : M₂) :
-    congrAut e f m = e (f (e.symm m)) := (rfl)
+    congrAut e f m = e (f (e.symm m)) := by
+  change (generalLinearEquiv R M₂
+    (congrLinearEquiv e ((generalLinearEquiv R M₁).symm f))) m = _
+  simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
+    LinearEquiv.trans_apply]
+  rw [show ((generalLinearEquiv R M₁).symm f).toLinearEquiv = f from
+    (generalLinearEquiv R M₁).apply_symm_apply f]
 
 @[simp]
 theorem congrAut_symm_apply (e : M₁ ≃ₗ[R] M₂) (g : M₂ ≃ₗ[R] M₂) (m : M₁) :
-    (congrAut e).symm g m = e.symm (g (e m)) := (rfl)
+    (congrAut e).symm g m = e.symm (g (e m)) := by
+  change (generalLinearEquiv R M₁
+    ((congrLinearEquiv e).symm ((generalLinearEquiv R M₂).symm g))) m = _
+  rw [congrLinearEquiv_symm]
+  simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
+    LinearEquiv.trans_apply, LinearEquiv.symm_symm]
+  rw [show ((generalLinearEquiv R M₂).symm g).toLinearEquiv = g from
+    (generalLinearEquiv R M₂).apply_symm_apply g]
 
 end LinearEquiv
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -37,17 +37,17 @@ variable {R M₁ M₂ : Type*} [CommSemiring R] [AddCommMonoid M₁] [Module R M
 groups: Mathlib's `LinearMap.GeneralLinearGroup.congrLinearEquiv` read through
 `LinearMap.GeneralLinearGroup.generalLinearEquiv`.
 
-The body is exposed so that the two evaluation lemmas below hold by `rfl` downstream. -/
-@[expose] def congrAut (e : M₁ ≃ₗ[R] M₂) : (M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ[R] M₂) :=
+The two evaluation lemmas below are its characteristic API. -/
+def congrAut (e : M₁ ≃ₗ[R] M₂) : (M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ[R] M₂) :=
   ((generalLinearEquiv R M₁).symm.trans (congrLinearEquiv e)).trans (generalLinearEquiv R M₂)
 
 @[simp]
 theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : M₂) :
-    congrAut e f m = e (f (e.symm m)) := rfl
+    congrAut e f m = e (f (e.symm m)) := (rfl)
 
 @[simp]
 theorem congrAut_symm_apply (e : M₁ ≃ₗ[R] M₂) (g : M₂ ≃ₗ[R] M₂) (m : M₁) :
-    (congrAut e).symm g m = e.symm (g (e m)) := rfl
+    (congrAut e).symm g m = e.symm (g (e m)) := (rfl)
 
 end LinearEquiv
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -44,6 +44,7 @@ def congrAut (e : M₁ ≃ₗ[R] M₂) : (M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ
 @[simp]
 theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : M₂) :
     congrAut e f m = e (f (e.symm m)) := by
+  -- Expose the composite once so named evaluation lemmas, rather than reduction, drive the proof.
   change (generalLinearEquiv R M₂
     (congrLinearEquiv e ((generalLinearEquiv R M₁).symm f))) m = _
   simp only [congrLinearEquiv_apply, coeFn_generalLinearEquiv, coe_ofLinearEquiv,
@@ -54,6 +55,7 @@ theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : 
 @[simp]
 theorem congrAut_symm_apply (e : M₁ ≃ₗ[R] M₂) (g : M₂ ≃ₗ[R] M₂) (m : M₁) :
     (congrAut e).symm g m = e.symm (g (e m)) := by
+  -- Expose the composite once so named evaluation lemmas, rather than reduction, drive the proof.
   change (generalLinearEquiv R M₁
     ((congrLinearEquiv e).symm ((generalLinearEquiv R M₂).symm g))) m = _
   rw [congrLinearEquiv_symm]

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Congr.lean
@@ -41,6 +41,7 @@ The two evaluation lemmas below are its characteristic API. -/
 def congrAut (e : M₁ ≃ₗ[R] M₂) : (M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ[R] M₂) :=
   ((generalLinearEquiv R M₁).symm.trans (congrLinearEquiv e)).trans (generalLinearEquiv R M₂)
 
+/-- Conjugating `f` by `e` sends `m` to `e (f (e.symm m))`. -/
 @[simp]
 theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : M₂) :
     congrAut e f m = e (f (e.symm m)) := by
@@ -55,6 +56,7 @@ theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : 
         (generalLinearEquiv_to_linearMap ((generalLinearEquiv R M₁).symm f)) (e.symm m)).symm
     _ = f (e.symm m) := by rw [(generalLinearEquiv R M₁).apply_symm_apply]
 
+/-- Inverse conjugation by `e` sends `m` to `e.symm (g (e m))`. -/
 @[simp]
 theorem congrAut_symm_apply (e : M₁ ≃ₗ[R] M₂) (g : M₂ ≃ₗ[R] M₂) (m : M₁) :
     (congrAut e).symm g m = e.symm (g (e m)) := by

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
+public import TauCeti.LinearAlgebra.BilinearForm.Isometry
+public import TauCeti.LinearAlgebra.GeneralLinearGroup.Congr
 public import TauCeti.LinearAlgebra.Reflection
 
 /-!
@@ -51,7 +52,9 @@ negating it and is a transvection rather than a reflection in `v ^ ⊥`.
   (`isOrtho_iff_of_mem_orthogonalGroup`). As soon as `2` acts injectively on the target the
   converse holds, `TauCeti.QuadraticMap.mem_orthogonalGroup_iff_polar`, which is the usual
   identification of the isometries of a quadratic form with the isometries of its polar bilinear
-  form.
+  form. At the level of groups this is
+  `TauCeti.QuadraticMap.orthogonalGroup_eq_isometryGroup_polarBilin`: `O(Q)` is the isometry group
+  `TauCeti.BilinForm.isometryGroup` of `Q.polarBilin`, so the bilinear-form API applies to it.
 * `TauCeti.QuadraticMap.orthogonalGroupEquivIsometryEquiv`: the underlying set of the orthogonal
   group is Mathlib's type of self-isometries `Q.IsometryEquiv Q`. This is the compatibility with the
   Mathlib vocabulary; the point of `orthogonalGroup` is the group structure, which
@@ -170,22 +173,10 @@ section Congr
 variable {M₁ : Type*} {M₂ : Type*} [AddCommMonoid M₁] [Module R M₁] [AddCommMonoid M₂] [Module R M₂]
   {Q₁ : QuadraticMap R M₁ N} {Q₂ : QuadraticMap R M₂ N}
 
-open LinearMap.GeneralLinearGroup in
-/-- Conjugation by a linear equivalence `e : M₁ ≃ₗ[R] M₂`, as an isomorphism of automorphism
-groups: Mathlib's `LinearMap.GeneralLinearGroup.congrLinearEquiv` read through
-`LinearMap.GeneralLinearGroup.generalLinearEquiv`. -/
-private def congrAut (e : M₁ ≃ₗ[R] M₂) : (M₁ ≃ₗ[R] M₁) ≃* (M₂ ≃ₗ[R] M₂) :=
-  ((generalLinearEquiv R M₁).symm.trans (congrLinearEquiv e)).trans (generalLinearEquiv R M₂)
-
-private theorem congrAut_apply (e : M₁ ≃ₗ[R] M₂) (f : M₁ ≃ₗ[R] M₁) (m : M₂) :
-    congrAut e f m = e (f (e.symm m)) := rfl
-
-private theorem congrAut_symm_apply (e : M₁ ≃ₗ[R] M₂) (g : M₂ ≃ₗ[R] M₂) (m : M₁) :
-    (congrAut e).symm g m = e.symm (g (e m)) := rfl
-
 /-- Conjugation by an isometric equivalence carries `O(Q₁)` onto `O(Q₂)`. -/
 private theorem map_orthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
-    (orthogonalGroup Q₁).map (congrAut e.toLinearEquiv : _ →* _) = orthogonalGroup Q₂ := by
+    (orthogonalGroup Q₁).map (LinearEquiv.congrAut e.toLinearEquiv : _ →* _)
+      = orthogonalGroup Q₂ := by
   have key : ∀ x : M₁, Q₂ (e.toLinearEquiv x) = Q₁ x := e.map_app
   have key' : ∀ x : M₂, Q₁ (e.toLinearEquiv.symm x) = Q₂ x := fun x => by
     rw [← key (e.toLinearEquiv.symm x), e.toLinearEquiv.apply_symm_apply]
@@ -193,10 +184,10 @@ private theorem map_orthogonalGroup (e : Q₁.IsometryEquiv Q₂) :
   simp only [Subgroup.mem_map, MonoidHom.coe_coe, mem_orthogonalGroup_iff]
   constructor
   · rintro ⟨f, hf, rfl⟩ m
-    rw [congrAut_apply, key, hf, key']
-  · refine fun hg => ⟨(congrAut e.toLinearEquiv).symm g, fun m => ?_,
-      (congrAut e.toLinearEquiv).apply_symm_apply g⟩
-    rw [congrAut_symm_apply, key', hg, key]
+    rw [LinearEquiv.congrAut_apply, key, hf, key']
+  · refine fun hg => ⟨(LinearEquiv.congrAut e.toLinearEquiv).symm g, fun m => ?_,
+      (LinearEquiv.congrAut e.toLinearEquiv).apply_symm_apply g⟩
+    rw [LinearEquiv.congrAut_symm_apply, key', hg, key]
 
 /-- Isometric quadratic maps have isomorphic orthogonal groups: conjugation by an isometric
 equivalence `e : Q₁ ≃qᵢ Q₂` carries `O(Q₁)` onto `O(Q₂)`.
@@ -205,19 +196,20 @@ Over an algebraically closed field every nondegenerate quadratic form of a given
 to every other, so this is what makes `O(Q)` depend on the rank alone. -/
 def orthogonalGroupCongr (e : Q₁.IsometryEquiv Q₂) :
     orthogonalGroup Q₁ ≃* orthogonalGroup Q₂ :=
-  ((congrAut e.toLinearEquiv).subgroupMap _).trans (MulEquiv.subgroupCongr (map_orthogonalGroup e))
+  ((LinearEquiv.congrAut e.toLinearEquiv).subgroupMap _).trans
+    (MulEquiv.subgroupCongr (map_orthogonalGroup e))
 
 @[simp]
 theorem coe_orthogonalGroupCongr_apply (e : Q₁.IsometryEquiv Q₂) (f : orthogonalGroup Q₁) (m : M₂) :
     (orthogonalGroupCongr e f : M₂ ≃ₗ[R] M₂) m
       = e.toLinearEquiv ((f : M₁ ≃ₗ[R] M₁) (e.toLinearEquiv.symm m)) := by
-  simp [orthogonalGroupCongr, congrAut_apply]
+  simp [orthogonalGroupCongr, LinearEquiv.congrAut_apply]
 
 @[simp]
 theorem coe_orthogonalGroupCongr_symm_apply (e : Q₁.IsometryEquiv Q₂) (g : orthogonalGroup Q₂)
     (m : M₁) : ((orthogonalGroupCongr e).symm g : M₁ ≃ₗ[R] M₁) m
       = e.toLinearEquiv.symm ((g : M₂ ≃ₗ[R] M₂) (e.toLinearEquiv m)) := by
-  simp [orthogonalGroupCongr, congrAut_symm_apply]
+  simp [orthogonalGroupCongr, LinearEquiv.congrAut_symm_apply]
 
 end Congr
 
@@ -256,6 +248,23 @@ theorem mem_orthogonalGroup_iff_polar (h2 : IsSMulRegular N (2 : R)) {f : M ≃�
   exact h2 ((key (f m)).trans ((h m m).trans (key m).symm))
 
 end Polar
+
+section PolarBilin
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+/-- The orthogonal group of a quadratic form is the isometry group of its polar bilinear form, as
+soon as `2` is a regular scalar: `orthogonalGroup Q` and `TauCeti.BilinForm.isometryGroup
+Q.polarBilin` are then two names for the same subgroup of `M ≃ₗ[R] M`, and the bilinear-form API —
+the Gram-matrix criterion, `det ^ 2 = 1`, base change — applies to `O(Q)` through it. Some such
+hypothesis is needed: in characteristic two the polarization forgets `Q` on the diagonal. -/
+theorem orthogonalGroup_eq_isometryGroup_polarBilin (h2 : IsSMulRegular R (2 : R))
+    (Q : QuadraticForm R M) : orthogonalGroup Q = BilinForm.isometryGroup Q.polarBilin := by
+  ext f
+  simp only [mem_orthogonalGroup_iff_polar h2, BilinForm.mem_isometryGroup_iff,
+    QuadraticMap.polarBilin_apply_apply]
+
+end PolarBilin
 
 section Det
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -6,7 +6,6 @@ module
 
 public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
 public import TauCeti.LinearAlgebra.BilinearForm.Isometry
-public import TauCeti.LinearAlgebra.GeneralLinearGroup.Congr
 public import TauCeti.LinearAlgebra.Reflection
 
 /-!

--- a/TauCeti/RepresentationTheory/InvariantForm.lean
+++ b/TauCeti/RepresentationTheory/InvariantForm.lean
@@ -7,7 +7,7 @@ module
 public import Mathlib.RepresentationTheory.Invariants
 public import Mathlib.RepresentationTheory.Irreducible
 public import TauCeti.LinearAlgebra.BilinearForm.Basic
-public import TauCeti.LinearAlgebra.BilinearForm.Isometry
+public import TauCeti.LinearAlgebra.BilinearForm.Isometry.Basic
 
 /-!
 # Invariant bilinear forms on a representation

--- a/TauCeti/RepresentationTheory/InvariantForm.lean
+++ b/TauCeti/RepresentationTheory/InvariantForm.lean
@@ -77,10 +77,13 @@ representation, is what makes `G` a group.
 `TauCeti.Representation.IsInvariantForm` is the statement that every `ρ g` is an isometry of the
 form, `TauCeti.BilinForm.IsIsometry B (ρ g)`, so that the invariant forms of a representation and
 the isometry group of a form are the same notion read two ways.  Its body is not exposed:
-`TauCeti.Representation.isInvariantForm_iff` introduces it and
-`TauCeti.Representation.IsInvariantForm.apply` eliminates it, so nothing outside this file has to
-unfold the definition.  The `iff` is deliberately not a `simp` lemma: unfolding invariance into its
-quantified equation would take `TauCeti.Representation.isInvariantForm_zero` and
+`TauCeti.Representation.isInvariantForm_iff_isIsometry` and
+`TauCeti.Representation.isInvariantForm_iff` introduce its isometry and pointwise forms, while
+`TauCeti.Representation.IsInvariantForm.isIsometry` and
+`TauCeti.Representation.IsInvariantForm.apply` eliminate them, so nothing outside this file has to
+unfold the definition.  The pointwise `iff` is deliberately not a `simp` lemma: unfolding
+invariance into its quantified equation would take
+`TauCeti.Representation.isInvariantForm_zero` and
 `TauCeti.Representation.mem_invariantForms` out of simp-normal form, which the `simpNF` linter
 rejects.  What the file adds around that pair is the two rewritings that are *not*
 immediate -- moving a single `ρ g` across the form at the cost of an inverse
@@ -142,6 +145,15 @@ def IsInvariantForm (ρ : Representation k G V) (B : BilinForm k V) : Prop :=
   ∀ g : G, BilinForm.IsIsometry B (ρ g)
 
 variable {ρ : Representation k G V} {B C : BilinForm k V}
+
+/-- A form is invariant for `ρ` exactly when every `ρ g` is an isometry of the form. -/
+theorem isInvariantForm_iff_isIsometry :
+    IsInvariantForm ρ B ↔ ∀ g : G, BilinForm.IsIsometry B (ρ g) := Iff.rfl
+
+/-- Every element of a representation is an isometry of an invariant form. -/
+theorem IsInvariantForm.isIsometry (hB : IsInvariantForm ρ B) (g : G) :
+    BilinForm.IsIsometry B (ρ g) :=
+  isInvariantForm_iff_isIsometry.mp hB g
 
 /-- A form is invariant for `ρ` exactly when it satisfies the pointwise equation
 `B (ρ g x) (ρ g y) = B x y`. -/

--- a/TauCeti/RepresentationTheory/InvariantForm.lean
+++ b/TauCeti/RepresentationTheory/InvariantForm.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.RepresentationTheory.Invariants
 public import Mathlib.RepresentationTheory.Irreducible
 public import TauCeti.LinearAlgebra.BilinearForm.Basic
+public import TauCeti.LinearAlgebra.BilinearForm.Isometry
 
 /-!
 # Invariant bilinear forms on a representation
@@ -73,7 +74,9 @@ representation, is what makes `G` a group.
 
 ## Implementation notes
 
-`TauCeti.Representation.IsInvariantForm` is a plain `∀`-statement, but its body is not exposed:
+`TauCeti.Representation.IsInvariantForm` is the statement that every `ρ g` is an isometry of the
+form, `TauCeti.BilinForm.IsIsometry B (ρ g)`, so that the invariant forms of a representation and
+the isometry group of a form are the same notion read two ways.  Its body is not exposed:
 `TauCeti.Representation.isInvariantForm_iff` introduces it and
 `TauCeti.Representation.IsInvariantForm.apply` eliminates it, so nothing outside this file has to
 unfold the definition.  The `iff` is deliberately not a `simp` lemma: unfolding invariance into its
@@ -134,9 +137,9 @@ section Monoid
 variable {k G V : Type*} [CommSemiring k] [Monoid G] [AddCommMonoid V] [Module k V]
 
 /-- A bilinear form `B` is **invariant** for a representation `ρ` when every `ρ g` preserves it:
-`B (ρ g x) (ρ g y) = B x y`. -/
+`B (ρ g x) (ρ g y) = B x y`; that is, when every `ρ g` is an isometry of `B`. -/
 def IsInvariantForm (ρ : Representation k G V) (B : BilinForm k V) : Prop :=
-  ∀ (g : G) (x y : V), B (ρ g x) (ρ g y) = B x y
+  ∀ g : G, BilinForm.IsIsometry B (ρ g)
 
 variable {ρ : Representation k G V} {B C : BilinForm k V}
 

--- a/TauCeti/RepresentationTheory/InvariantForm.lean
+++ b/TauCeti/RepresentationTheory/InvariantForm.lean
@@ -146,19 +146,23 @@ variable {ρ : Representation k G V} {B C : BilinForm k V}
 /-- A form is invariant for `ρ` exactly when it satisfies the pointwise equation
 `B (ρ g x) (ρ g y) = B x y`. -/
 theorem isInvariantForm_iff :
-    IsInvariantForm ρ B ↔ ∀ (g : G) (x y : V), B (ρ g x) (ρ g y) = B x y := Iff.rfl
+    IsInvariantForm ρ B ↔ ∀ (g : G) (x y : V), B (ρ g x) (ρ g y) = B x y :=
+  ⟨fun h g => BilinForm.isIsometry_iff.mp (h g),
+    fun h g => BilinForm.isIsometry_iff.mpr (h g)⟩
 
 /-- An invariant form takes the same value on `ρ g x` and `ρ g y` as it does on `x` and `y`. -/
 @[grind =]
 theorem IsInvariantForm.apply (hB : IsInvariantForm ρ B) (g : G) (x y : V) :
-    B (ρ g x) (ρ g y) = B x y := hB g x y
+    B (ρ g x) (ρ g y) = B x y := (hB g).apply x y
 
 /-- The invariant bilinear forms of `ρ`, as a submodule of all bilinear forms on `V`. -/
 def invariantForms (ρ : Representation k G V) : Submodule k (BilinForm k V) where
   carrier := {B | IsInvariantForm ρ B}
-  add_mem' hB hC g x y := by simp only [LinearMap.add_apply, hB g x y, hC g x y]
-  zero_mem' _ _ _ := rfl
-  smul_mem' c _ hB g x y := by simp only [LinearMap.smul_apply, hB g x y]
+  add_mem' hB hC g := BilinForm.isIsometry_iff.mpr fun x y => by
+    simp only [LinearMap.add_apply, hB.apply g x y, hC.apply g x y]
+  zero_mem' _ := BilinForm.isIsometry_iff.mpr fun _ _ => rfl
+  smul_mem' c _ hB g := BilinForm.isIsometry_iff.mpr fun x y => by
+    simp only [LinearMap.smul_apply, hB.apply g x y]
 
 /-- Membership in `TauCeti.Representation.invariantForms` is invariance. -/
 @[simp]
@@ -166,7 +170,8 @@ theorem mem_invariantForms : B ∈ invariantForms ρ ↔ IsInvariantForm ρ B :=
 
 /-- The zero form is invariant. -/
 @[simp]
-theorem isInvariantForm_zero : IsInvariantForm ρ (0 : BilinForm k V) := fun _ _ _ => rfl
+theorem isInvariantForm_zero : IsInvariantForm ρ (0 : BilinForm k V) :=
+  fun _ => BilinForm.isIsometry_iff.mpr fun _ _ => rfl
 
 /-- A sum of invariant forms is invariant. -/
 theorem IsInvariantForm.add (hB : IsInvariantForm ρ B) (hC : IsInvariantForm ρ C) :
@@ -179,13 +184,13 @@ theorem IsInvariantForm.smul (c : k) (hB : IsInvariantForm ρ B) : IsInvariantFo
 
 /-- Exchanging the two arguments of an invariant form leaves it invariant. -/
 theorem IsInvariantForm.flip (hB : IsInvariantForm ρ B) : IsInvariantForm ρ B.flip :=
-  fun g x y => hB.apply g y x
+  fun g => BilinForm.isIsometry_iff.mpr fun x y => hB.apply g y x
 
 /-- Every bilinear form is invariant for the trivial representation, which acts by the identity. -/
 @[simp]
 theorem isInvariantForm_trivial (B : BilinForm k V) :
     IsInvariantForm (Representation.trivial k G V) B :=
-  fun _ _ _ => rfl
+  fun _ => BilinForm.isIsometry_iff.mpr fun _ _ => rfl
 
 end Monoid
 
@@ -274,7 +279,8 @@ theorem isInvariantForm_iff_isIntertwiningMap (ρ : Representation k G V) (B : B
   · refine fun hB => ⟨fun g v => ?_⟩
     ext w
     simpa [Module.Dual.transpose_apply] using hB.apply_left g v w
-  · intro hB g x y
+  · intro hB g
+    refine BilinForm.isIsometry_iff.mpr fun x y => ?_
     have h := DFunLike.congr_fun (hB.isIntertwining g x) (ρ g y)
     simpa [Module.Dual.transpose_apply] using h
 


### PR DESCRIPTION
This PR builds the symmetry group that the `HodgeStructures` roadmap exposes for its consumers. The roadmap's *Generality bar* pins it — "**The symmetry group is exposed.** `IsLatticeIsometry Qint` cuts out `Aut(V, Qint)` (integral automorphisms preserving the form) — the target of a variation's monodromy, provided here so the successor roadmap consumes it rather than redefining it" — and L3 repeats it under *Companions to build*: "the `Subgroup`/`Group` packaging of `Aut(V, Qint)` from `IsLatticeIsometry` (the successor's monodromy target)". The milestone served is **L3 — Period-domain points; the symmetry group**, whose seeded goal is `∑ᶠ p, h p = dim_ℂ V_ℂ`. That numerical goal, and L3's other definitions `HodgeType` and `PeriodDomain.Point`, all read off L0's `DirectSum.IsInternal hs.piece`, which is still in flight (#3136), so this PR takes the one L3 component that is independent of the pure-Hodge definitions and can land now. After this PR, L3 still needs `HodgeType`, `PeriodDomain.Point`, and the Hodge-number dimension count, each of which sits on top of L0.

`TauCeti.IsFormIsometry B f` says that an endomorphism `f` preserves a bilinear form `B`, and `TauCeti.formIsometryGroup B` is the subgroup of `M ≃ₗ[R] M` it cuts out. Around them the file develops what a consumer of the group actually needs: the Gram-matrix criterion `Aᵀ * G * A = G` in a basis; the consequence that an isometry has `(det f) ^ 2 = 1` whenever the Gram determinant is a non-zero-divisor, hence `IsUnit (det f)`; the resulting promotion `IsFormIsometry.toLinearEquiv` of an isometry to a linear automorphism, so that over an integral domain a form-preserving endomorphism of a finite free module carrying a nondegenerate form is *automatically* bijective (`IsFormIsometry.bijective`) — which is how an element of `Aut(V, Q)` usually arrives, as an integer matrix satisfying `Aᵀ G A = G` rather than as an invertible map; stability of `B`-orthogonal complements under a surjective isometry and of the restricted form on an invariant submodule; transport of the whole group along a linear equivalence (`formIsometryGroupCongr`); and base change as a group homomorphism `Aut(M, B) →* Aut(A ⊗[R] M, B_A)` (`formIsometryGroupBaseChange`), which at `R = ℤ`, `A = ℂ` is exactly the action on the complexified lattice through which a variation's monodromy acts.

Two deliberate departures from the roadmap text, both stated in the module docstring. First, generality: preserving a bilinear form is not a lattice-specific notion, so everything is stated over an arbitrary commutative ring `R`, with the roadmap's integral case `R = ℤ` a specialisation and the `IsDomain`/`Module.Free`/`Module.Finite` hypotheses appearing only where they are used; the declaration is therefore named `IsFormIsometry` rather than the roadmap's provisional `IsLatticeIsometry`. Second, placement: nothing here is Hodge-specific, so the file joins the repository's existing bilinear-form material at `TauCeti/LinearAlgebra/BilinearForm/Isometry.lean` rather than `TauCeti/Geometry/Hodge/`; the roadmap association is attribution, not directory.

On reuse: Mathlib already bundles this notion twice, as maps `B₁ →bᵢ B₂` (`LinearMap.BilinForm.Isometry`) and as equivalences `LinearMap.BilinForm.IsometryEquiv B₁ B₂`, and it has no group packaging for either. Both bridges are supplied here — `IsFormIsometry.toIsometry` and `isFormIsometry_toLinearMap` for the map version, and `formIsometryGroupEquivIsometryEquiv`, an equivalence of types between the subgroup and `B.IsometryEquiv B`, for the equivalence version — so the unbundled predicate and the subgroup sit alongside Mathlib's bundled types rather than duplicating them. What is genuinely new is the predicate (a side condition on an endomorphism one already has, which is what the automatic-invertibility statement and subgroup membership both need) and the group structure. No Mathlib infrastructure was vendored or copied; the proofs consume `LinearMap.BilinForm.toMatrix_comp`, `LinearMap.BilinForm.nondegenerate_iff_det_ne_zero`, `LinearEquiv.ofIsUnitDet`, and the `LinearEquiv.baseChange` monoid lemmas as they stand.

One new file, `TauCeti/LinearAlgebra/BilinearForm/Isometry.lean` (300 lines).

Roadmap: HodgeStructures

<!--tauceti-target:v1 {"focus":"HodgeStructures","id":"islatticeisometry"}-->

🤖 Prepared with Claude Code
