### PR TITLE
feat: add Spin and Pin representations

### DIFF
--- a/TauCeti/RepresentationTheory/Spin/Representation.lean
+++ b/TauCeti/RepresentationTheory/Spin/Representation.lean
@@ -13,14 +13,16 @@ import TauCeti.LinearAlgebra.ExteriorAlgebra.End
 /-!
 # The Spin-group representation on the exterior model
 
-This file restricts the Fock action of a Clifford algebra to its Spin group and proves that the
-underlying Clifford action generates every endomorphism of the exterior model.
+This file restricts the Fock action of a Clifford algebra to its Spin group and proves, when the
+first isotropic summand is finite free, that the underlying Clifford action generates every
+endomorphism of the exterior model.
 
 ## Main definitions and results
 
 * `TauCeti.spinRep` and `TauCeti.pinRep` are the representations of `spinGroup Q` and `pinGroup Q`
   on the exterior model.
-* `TauCeti.spinAction_surjective` identifies the Fock action as onto the full endomorphism algebra.
+* `TauCeti.spinAction_surjective` identifies the Fock action as onto the full endomorphism algebra
+  when the first isotropic summand is finite free.
 
 ## References
 
@@ -62,8 +64,8 @@ theorem pinRep_apply (Q : QuadraticForm K V) (P : SpinPolarizationData Q) (g : p
     pinRep Q P g = spinAction Q P g := by
   simp [pinRep]
 
-/-- The Fock action of a Clifford algebra on its exterior model is onto the full endomorphism
-algebra. -/
+/-- When the first isotropic summand is finite free, the Fock action of a Clifford algebra on its
+exterior model is onto the full endomorphism algebra. -/
 theorem spinAction_surjective {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
     [Module.Free K P.W] [Module.Finite K P.W] :
     Function.Surjective (spinAction Q P) := by

--- a/TauCeti/RepresentationTheory/Spin/Representation.lean
+++ b/TauCeti/RepresentationTheory/Spin/Representation.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Spin.Polarization.CliffordAction
+public import Mathlib.LinearAlgebra.CliffordAlgebra.SpinGroup
+public import Mathlib.RepresentationTheory.Basic
+
+import TauCeti.LinearAlgebra.ExteriorAlgebra.End
+
+/-!
+# The Spin-group representation on the exterior model
+
+This file restricts the Fock action of a Clifford algebra to its Spin group and proves that the
+underlying Clifford action generates every endomorphism of the exterior model.
+
+## Main definitions and results
+
+* `TauCeti.spinRep` and `TauCeti.pinRep` are the representations of `spinGroup Q` and `pinGroup Q`
+  on the exterior model.
+* `TauCeti.spinAction_surjective` identifies the Fock action as onto the full endomorphism algebra.
+
+## References
+
+* [Spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md)
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v
+
+variable {K : Type u} [CommRing K]
+variable {V : Type v} [AddCommGroup V] [Module K V]
+
+/-- The representation of the Spin group obtained by restricting its Clifford-algebra action on
+the exterior algebra of the first isotropic summand. -/
+noncomputable def spinRep (Q : QuadraticForm K V) (P : SpinPolarizationData Q) :
+    Representation K (spinGroup Q) (ExteriorAlgebra K P.W) :=
+  (spinAction Q P).toRingHom.toMonoidHom.comp
+    ((Units.coeHom (CliffordAlgebra Q)).comp spinGroup.toUnits)
+
+/-- A Spin-group element acts through its underlying Clifford-algebra element. -/
+@[simp]
+theorem spinRep_apply (Q : QuadraticForm K V) (P : SpinPolarizationData Q) (g : spinGroup Q) :
+    spinRep Q P g = spinAction Q P g := by
+  simp [spinRep]
+
+/-- The representation of the Pin group obtained by restricting its Clifford-algebra action on
+the exterior algebra of the first isotropic summand. -/
+noncomputable def pinRep (Q : QuadraticForm K V) (P : SpinPolarizationData Q) :
+    Representation K (pinGroup Q) (ExteriorAlgebra K P.W) :=
+  (spinAction Q P).toRingHom.toMonoidHom.comp
+    ((Units.coeHom (CliffordAlgebra Q)).comp pinGroup.toUnits)
+
+/-- A Pin-group element acts through its underlying Clifford-algebra element. -/
+@[simp]
+theorem pinRep_apply (Q : QuadraticForm K V) (P : SpinPolarizationData Q) (g : pinGroup Q) :
+    pinRep Q P g = spinAction Q P g := by
+  simp [pinRep]
+
+/-- The Fock action of a Clifford algebra on its exterior model is onto the full endomorphism
+algebra. -/
+theorem spinAction_surjective {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
+    [Module.Free K P.W] [Module.Finite K P.W] :
+    Function.Surjective (spinAction Q P) := by
+  rw [← AlgHom.range_eq_top]
+  apply top_unique
+  rw [← ExteriorAlgebra.creation_contraction_adjoin_eq_top (K := K) (W := P.W)]
+  apply Algebra.adjoin_le
+  rintro f (⟨x, rfl⟩ | ⟨d, rfl⟩)
+  · apply (spinAction Q P).mem_range.mpr
+    refine ⟨CliffordAlgebra.ι Q (x : V), ?_⟩
+    apply LinearMap.ext
+    intro s
+    exact spinAction_ι_wedge P x s
+  · obtain ⟨y, rfl⟩ := P.pairingEquiv.surjective d
+    apply (spinAction Q P).mem_range.mpr
+    refine ⟨CliffordAlgebra.ι Q (y : V), ?_⟩
+    apply LinearMap.ext
+    intro s
+    exact spinAction_ι_contract P y s
+
+end TauCeti


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Packages the Spin and Pin representations on the exterior model.

- Restricts the merged Clifford action through the canonical group embeddings.
- Exposes the Spin and Pin action equations.
- Proves the Clifford action is onto the full endomorphism algebra.

## Roadmap target

Advances Layer 4's group-representation boundary:
https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-4-the-spin-module

## Verification

Full gates, consumers, golf, and local `2+1` review pass at `d88a07861c6ada0d9aa6e474fcc4d4ce7f58d58c`.

## Scale and generality

Adds one 87-line file over a commutative ring. Surjectivity additionally assumes the first isotropic summand is finite free.

## Scope

- **Consumes:** the merged Clifford action and creation/contraction generation theorem.
- **Provides:** `spinRep`, `pinRep`, their action equations, and `spinAction_surjective`.
- **Fits:** supplies the Layer 4 group-action boundary used by later structure theory.
- **Boundary:** half-spin summands and irreducibility remain downstream.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [0a98539](https://github.com/TauCetiProject/TauCetiReview/commit/0a98539e2c435ce4035a266d4c3654f56e805ac5) · local 2+1 review @ [3c27326](https://github.com/utensil/formal-land/commit/3c273267907632175365cc835cf767d0a1aec5af) fixed: none</sub>
