### PR TITLE
refactor(Crosscut): share the length-area witness between the two crosscut consumers

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
@@ -136,13 +136,14 @@ image boundary.** For `f` holomorphic and injective on `ball c r` with
 radius `ρ < R` at which the image of `ball c r ∩ sphere ζ ρ` has diameter at most `ε` and the
 closed image crosscut meets `frontier (f '' ball c r)` in two points at distance at most `ε`.
 
-The radius comes from the limiting form `TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top`
-of Wolff's lemma, which makes `TauCeti.circleImageLength f (ball c r) ζ ρ` smaller than
-`ENNReal.ofReal ε` — in particular finite, which is what
+The radius comes from
+`TauCeti.exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top`, the length--area
+selection of `Conformal/ShortCrosscut.lean`: below any prescribed bound it produces a radius at
+which `TauCeti.circleImageLength f (ball c r) ζ ρ` is finite — which is what
 `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair` needs, so the ends are two
-points; `TauCeti.diam_image_ball_inter_sphere_le` turns the same bound into the diameter bound, and
-`TauCeti.diam_frontier_inter_closure_image_inter_sphere_le` passes it on to the two ends, which lie
-in the boundary piece and so are no further apart than the image crosscut is wide.
+points — and at which the image crosscut is no wider than `ε`. That width is passed on to the two
+ends by `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le`: they lie in the boundary piece
+and so are no further apart than the image crosscut is wide.
 
 Only `0 < r` is asked of the disc, and only `0 < R` of the prescribed bound: the radius is searched
 for below `min R (2 * r)` instead of below `R`, which is what makes `ball c r ∩ sphere ζ ρ` a
@@ -154,21 +155,15 @@ theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le
     ∃ ρ ∈ Ioo 0 R, ∃ u v,
       frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v} ∧
         dist u v ≤ ε ∧ diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε := by
-  obtain ⟨ρ, hρmem, hlen⟩ :=
-    exists_circleImageLength_lt_of_lintegral_ne_top (s := ball c r) f measurableSet_ball ζ hfin
-      (ENNReal.ofReal_pos.mpr hε).ne' (R := min R (2 * r)) (lt_min hR (by linarith))
-  have hfin' : circleImageLength f (ball c r) ζ ρ ≠ ⊤ :=
-    (hlen.trans ENNReal.ofReal_lt_top).ne
-  have hdiam : diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε :=
-    diam_image_ball_inter_sphere_le hf hε.le hlen.le
+  obtain ⟨ρ, hρmem, hfin', hdiam, hb⟩ :=
+    exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top (ζ := ζ) hf hfin hε
+      (lt_min hR (by linarith : (0 : ℝ) < 2 * r))
   obtain ⟨u, v, hpair⟩ := exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair hζ hρmem.1
     (hρmem.2.trans_le (min_le_right _ _)) hf hinj hfin'
   have hu : u ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
     rw [hpair]; exact mem_insert _ _
   have hv : v ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
     rw [hpair]; exact mem_insert_of_mem _ rfl
-  have hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) :=
-    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hf hfin'
   exact ⟨ρ, ⟨hρmem.1, hρmem.2.trans_le (min_le_left _ _)⟩, u, v, hpair,
     (dist_le_diam_of_mem (hb.closure.subset inter_subset_right) hu hv).trans
       ((diam_frontier_inter_closure_image_inter_sphere_le hb).trans hdiam), hdiam⟩

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
@@ -65,34 +65,6 @@ open Bornology Complex MeasureTheory Metric Set
 
 variable {f : ℂ → ℂ} {c ζ : ℂ} {r : ℝ}
 
-/-- **Below every radius bound there is a radius whose circular image piece is as small as
-prescribed.** For `f` holomorphic on `ball c r` with finite Dirichlet integral, and any `κ > 0`,
-some `ρ` below the bound and below `2 * r` has `diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ κ`, with
-that image bounded and its circle-image length finite. Nothing is claimed here about `ρ` giving a
-genuine crosscut; that is settled downstream.
-
-Neither injectivity of `f` nor any hypothesis on the frontier of the image is involved: this is
-the length--area input to the theorem below, separated from the Jordan-curve geometry.
-
-This strengthens `TauCeti.exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top`, which
-selects the same radius but discards the finite circle-image length that produced the bound. The
-theorem below needs that witness twice over -- both closing theorems take it -- so it cannot be
-derived from the weaker form. -/
-private theorem exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top (hr : 0 < r)
-    (hf : DifferentiableOn ℂ f (ball c r))
-    (hdir : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {κ R : ℝ} (hκ : 0 < κ) (hR : 0 < R) :
-    ∃ ρ ∈ Ioo 0 R, ρ < 2 * r ∧ circleImageLength f (ball c r) ζ ρ ≠ ⊤ ∧
-      diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ κ ∧
-      IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
-  obtain ⟨ρ, hρ, hlen⟩ :=
-    exists_circleImageLength_lt_of_lintegral_ne_top f measurableSet_ball ζ hdir
-      (ENNReal.ofReal_pos.mpr hκ).ne' (R := min R (2 * r)) (lt_min hR (by linarith))
-  have hlenFin : circleImageLength f (ball c r) ζ ρ ≠ ⊤ :=
-    (hlen.trans ENNReal.ofReal_lt_top).ne
-  exact ⟨ρ, ⟨hρ.1, hρ.2.trans_le (min_le_left _ _)⟩, hρ.2.trans_le (min_le_right _ _), hlenFin,
-    diam_image_ball_inter_sphere_le hf hκ.le hlen.le,
-    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hf hlenFin⟩
-
 /-- **A short image crosscut lies on a small Jordan curve.** Let `f` be holomorphic and injective
 on `ball c r`, with finite Dirichlet integral and Jordan-curve frontier. For every `ε > 0`, every
 boundary point `ζ` of the disc, and every radius bound `R > 0`, there is a genuine circular
@@ -125,8 +97,11 @@ theorem exists_isJordanCurve_superset_closure_image_ball_inter_sphere_diam_le
   obtain ⟨κ, hκ, hκε, hκδ⟩ : ∃ κ : ℝ, 0 < κ ∧ κ ≤ ε / 2 ∧ κ < δ :=
     ⟨min (ε / 2) (δ / 2), lt_min (by positivity) (by positivity), min_le_left _ _,
       (min_le_right _ _).trans_lt (by linarith)⟩
-  obtain ⟨ρ, hρ, hρr, hlenFin, hcross, hcrossBounded⟩ :=
-    exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top (ζ := ζ) hr hf hdir hκ hR
+  obtain ⟨ρ, hρmem, hlenFin, hcross, hcrossBounded⟩ :=
+    exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top (ζ := ζ) hf hdir hκ
+      (lt_min hR (by linarith : (0 : ℝ) < 2 * r))
+  have hρ : ρ ∈ Ioo 0 R := ⟨hρmem.1, hρmem.2.trans_le (min_le_left _ _)⟩
+  have hρr : ρ < 2 * r := hρmem.2.trans_le (min_le_right _ _)
   have hcrossSub : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ closure (f '' ball c r) :=
     closure_mono (image_mono inter_subset_left)
   by_cases hends :

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
@@ -72,8 +72,13 @@ that image bounded and its circle-image length finite. Nothing is claimed here a
 genuine crosscut; that is settled downstream.
 
 Neither injectivity of `f` nor any hypothesis on the frontier of the image is involved: this is
-the length--area input to the theorem below, separated from the Jordan-curve geometry. -/
-private theorem exists_radius_diam_image_ball_inter_sphere_le (hr : 0 < r)
+the length--area input to the theorem below, separated from the Jordan-curve geometry.
+
+This strengthens `TauCeti.exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top`, which
+selects the same radius but discards the finite circle-image length that produced the bound. The
+theorem below needs that witness twice over -- both closing theorems take it -- so it cannot be
+derived from the weaker form. -/
+private theorem exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top (hr : 0 < r)
     (hf : DifferentiableOn ℂ f (ball c r))
     (hdir : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {κ R : ℝ} (hκ : 0 < κ) (hR : 0 < R) :
     ∃ ρ ∈ Ioo 0 R, ρ < 2 * r ∧ circleImageLength f (ball c r) ζ ρ ≠ ⊤ ∧
@@ -115,13 +120,13 @@ theorem exists_isJordanCurve_superset_closure_image_ball_inter_sphere_diam_le
         J ⊆ closure (f '' ball c r) ∧ diam J ≤ ε := by
   obtain ⟨δ, hδ, hpath⟩ :=
     hfrontier.exists_pos_forall_exists_path_injective_diam_le (by positivity : (0 : ℝ) < ε / 2)
-  -- one radius `κ` serves both roles below: it caps the crosscut at half the tolerance and
-  -- keeps its two ends within the distance `δ` the path-joining theorem needs
+  -- one scale `κ` serves both roles below: it caps the crosscut diameter at half the tolerance
+  -- and keeps its two ends within the distance `δ` the path-joining theorem needs
   obtain ⟨κ, hκ, hκε, hκδ⟩ : ∃ κ : ℝ, 0 < κ ∧ κ ≤ ε / 2 ∧ κ < δ :=
     ⟨min (ε / 2) (δ / 2), lt_min (by positivity) (by positivity), min_le_left _ _,
       (min_le_right _ _).trans_lt (by linarith)⟩
   obtain ⟨ρ, hρ, hρr, hlenFin, hcross, hcrossBounded⟩ :=
-    exists_radius_diam_image_ball_inter_sphere_le (ζ := ζ) hr hf hdir hκ hR
+    exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top (ζ := ζ) hr hf hdir hκ hR
   have hcrossSub : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ closure (f '' ball c r) :=
     closure_mono (image_mono inter_subset_left)
   by_cases hends :

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean
@@ -65,6 +65,29 @@ open Bornology Complex MeasureTheory Metric Set
 
 variable {f : ℂ → ℂ} {c ζ : ℂ} {r : ℝ}
 
+/-- **Below every radius bound there is a radius whose circular image piece is as small as
+prescribed.** For `f` holomorphic on `ball c r` with finite Dirichlet integral, and any `κ > 0`,
+some `ρ` below the bound and below `2 * r` has `diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ κ`, with
+that image bounded and its circle-image length finite. Nothing is claimed here about `ρ` giving a
+genuine crosscut; that is settled downstream.
+
+Neither injectivity of `f` nor any hypothesis on the frontier of the image is involved: this is
+the length--area input to the theorem below, separated from the Jordan-curve geometry. -/
+private theorem exists_radius_diam_image_ball_inter_sphere_le (hr : 0 < r)
+    (hf : DifferentiableOn ℂ f (ball c r))
+    (hdir : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {κ R : ℝ} (hκ : 0 < κ) (hR : 0 < R) :
+    ∃ ρ ∈ Ioo 0 R, ρ < 2 * r ∧ circleImageLength f (ball c r) ζ ρ ≠ ⊤ ∧
+      diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ κ ∧
+      IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
+  obtain ⟨ρ, hρ, hlen⟩ :=
+    exists_circleImageLength_lt_of_lintegral_ne_top f measurableSet_ball ζ hdir
+      (ENNReal.ofReal_pos.mpr hκ).ne' (R := min R (2 * r)) (lt_min hR (by linarith))
+  have hlenFin : circleImageLength f (ball c r) ζ ρ ≠ ⊤ :=
+    (hlen.trans ENNReal.ofReal_lt_top).ne
+  exact ⟨ρ, ⟨hρ.1, hρ.2.trans_le (min_le_left _ _)⟩, hρ.2.trans_le (min_le_right _ _), hlenFin,
+    diam_image_ball_inter_sphere_le hf hκ.le hlen.le,
+    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hf hlenFin⟩
+
 /-- **A short image crosscut lies on a small Jordan curve.** Let `f` be holomorphic and injective
 on `ball c r`, with finite Dirichlet integral and Jordan-curve frontier. For every `ε > 0`, every
 boundary point `ζ` of the disc, and every radius bound `R > 0`, there is a genuine circular
@@ -90,66 +113,50 @@ theorem exists_isJordanCurve_superset_closure_image_ball_inter_sphere_diam_le
         closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ J ∧
         J ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r) ∧
         J ⊆ closure (f '' ball c r) ∧ diam J ≤ ε := by
-  have hhalf : 0 < ε / 2 := by positivity
   obtain ⟨δ, hδ, hpath⟩ :=
-    hfrontier.exists_pos_forall_exists_path_injective_diam_le hhalf
-  let κ := min (ε / 2) (δ / 2)
-  have hκ : 0 < κ := lt_min hhalf (by positivity)
-  obtain ⟨ρ, hρ, hlen⟩ :=
-    exists_circleImageLength_lt_of_lintegral_ne_top f measurableSet_ball ζ hdir
-      (ENNReal.ofReal_pos.mpr hκ).ne' (R := min R (2 * r)) (lt_min hR (by linarith))
-  have hρR : ρ < R := hρ.2.trans_le (min_le_left _ _)
-  have hρr : ρ < 2 * r := hρ.2.trans_le (min_le_right _ _)
-  have hlenFin : circleImageLength f (ball c r) ζ ρ ≠ ⊤ :=
-    (hlen.trans ENNReal.ofReal_lt_top).ne
-  have hcross : diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ κ :=
-    diam_image_ball_inter_sphere_le hf hκ.le hlen.le
-  have hcrossBounded : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) :=
-    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hf hlenFin
+    hfrontier.exists_pos_forall_exists_path_injective_diam_le (by positivity : (0 : ℝ) < ε / 2)
+  -- one radius `κ` serves both roles below: it caps the crosscut at half the tolerance and
+  -- keeps its two ends within the distance `δ` the path-joining theorem needs
+  obtain ⟨κ, hκ, hκε, hκδ⟩ : ∃ κ : ℝ, 0 < κ ∧ κ ≤ ε / 2 ∧ κ < δ :=
+    ⟨min (ε / 2) (δ / 2), lt_min (by positivity) (by positivity), min_le_left _ _,
+      (min_le_right _ _).trans_lt (by linarith)⟩
+  obtain ⟨ρ, hρ, hρr, hlenFin, hcross, hcrossBounded⟩ :=
+    exists_radius_diam_image_ball_inter_sphere_le (ζ := ζ) hr hf hdir hκ hR
   have hcrossSub : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ closure (f '' ball c r) :=
     closure_mono (image_mono inter_subset_left)
   by_cases hends :
       (frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))).Subsingleton
-  · refine ⟨ρ, ⟨hρ.1, hρR⟩, hρr, closure (f '' (ball c r ∩ sphere ζ ρ)), ?_,
+  · refine ⟨ρ, hρ, hρr, closure (f '' (ball c r ∩ sphere ζ ρ)), ?_,
       subset_rfl, subset_union_left, hcrossSub, ?_⟩
     · exact isJordanCurve_closure_image_ball_inter_sphere_of_subsingleton hζ hρ.1 hρr
         hf hinj hlenFin hends
     · rw [diam_closure]
-      exact hcross.trans (by dsimp [κ]; linarith [min_le_left (ε / 2) (δ / 2)])
+      linarith
   · obtain ⟨u, v, huv, hpair, hclose⟩ :=
       exists_forall_isJordanCurve_closure_image_ball_inter_sphere_union_range_of_not_subsingleton
         hζ hρ.1 hρr hf hinj hlenFin hends
-    have hu : u ∈ frontier (f '' ball c r) ∩
-        closure (f '' (ball c r ∩ sphere ζ ρ)) := by
-      rw [hpair]
-      exact mem_insert u {v}
-    have hv : v ∈ frontier (f '' ball c r) ∩
-        closure (f '' (ball c r ∩ sphere ζ ρ)) := by
-      rw [hpair]
-      exact mem_insert_of_mem u (mem_singleton v)
-    have hκδ : κ < δ := by
-      dsimp [κ]
-      linarith [min_le_right (ε / 2) (δ / 2)]
+    have hu : u ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) :=
+      hpair ▸ mem_insert u {v}
+    have hv : v ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) :=
+      hpair ▸ mem_insert_of_mem u (mem_singleton v)
     have huvδ : dist u v < δ := by
       refine (dist_le_diam_of_mem hcrossBounded.closure hu.2 hv.2).trans_lt ?_
       rw [diam_closure]
       exact hcross.trans_lt hκδ
     obtain ⟨γ, hγinj, hγsub, hγdiam⟩ := hpath hu.1 hv.1 huv huvδ
-    refine ⟨ρ, ⟨hρ.1, hρR⟩, hρr,
-      closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ range γ,
-      hclose γ hγinj hγsub, subset_union_left, union_subset_union subset_rfl hγsub, ?_, ?_⟩
-    · exact union_subset hcrossSub (hγsub.trans frontier_subset_closure)
-    · have hinter :
-          (closure (f '' (ball c r ∩ sphere ζ ρ)) ∩ range γ).Nonempty :=
-        ⟨u, hu.2, ⟨0, γ.source⟩⟩
-      calc
-        diam (closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ range γ)
-            ≤ diam (closure (f '' (ball c r ∩ sphere ζ ρ))) + diam (range γ) :=
-          diam_union' hinter
-        _ = diam (f '' (ball c r ∩ sphere ζ ρ)) + diam (range γ) := by
-          rw [diam_closure]
-        _ ≤ κ + ε / 2 := add_le_add hcross hγdiam
-        _ ≤ ε := by dsimp [κ]; linarith [min_le_left (ε / 2) (δ / 2)]
+    refine ⟨ρ, hρ, hρr, closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ range γ,
+      hclose γ hγinj hγsub, subset_union_left, union_subset_union subset_rfl hγsub,
+      union_subset hcrossSub (hγsub.trans frontier_subset_closure), ?_⟩
+    have hinter : (closure (f '' (ball c r ∩ sphere ζ ρ)) ∩ range γ).Nonempty :=
+      ⟨u, hu.2, ⟨0, γ.source⟩⟩
+    calc
+      diam (closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ range γ)
+          ≤ diam (closure (f '' (ball c r ∩ sphere ζ ρ))) + diam (range γ) :=
+        diam_union' hinter
+      _ = diam (f '' (ball c r ∩ sphere ζ ρ)) + diam (range γ) := by
+        rw [diam_closure]
+      _ ≤ κ + ε / 2 := add_le_add hcross hγdiam
+      _ ≤ ε := by linarith
 
 /-- **The bounded-image form of the small-Jordan-curve theorem.** A holomorphic injection of a
 disc onto a bounded domain has finite Dirichlet integral by the conformal area formula, so for

--- a/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
@@ -63,6 +63,9 @@ needed for the estimates themselves, whose statements cover every centre and rad
   Wolff's lemma: a holomorphic map of a disc with finite Dirichlet integral has, at every centre
   `ζ` and below every positive radius, a radius `ρ` at which `f '' (ball c r ∩ sphere ζ ρ)` has
   diameter at most `ε`.
+* `TauCeti.exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top` — the same
+  selection returning also the finite circle-image length and the boundedness that follows from
+  it, which is the form the crosscut theorems downstream consume.
 * `TauCeti.exists_diam_image_ball_inter_sphere_le` — its corollary for an injective map with
   bounded image, the case a Riemann map falls under.
 
@@ -182,6 +185,30 @@ theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top
 /-! ## Circle intersections with a short image -/
 
 /-- **A holomorphic map of finite Dirichlet integral has short images of small circle
+intersections, together with the length witness that produced the bound.** For `f` holomorphic on
+`ball c r` with finite Dirichlet integral and an arbitrary `ζ`, every tolerance `ε > 0` and every
+bound `R > 0` admit a radius `ρ < R` at which `circleImageLength f (ball c r) ζ ρ` is finite, the
+image of `ball c r ∩ sphere ζ ρ` has diameter at most `ε`, and that image is bounded.
+
+`TauCeti.exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top` is the diameter conjunct
+alone. Callers that go on to talk about the crosscut itself need the finite length as well --
+the endpoint-limit and Jordan-closing theorems both take it -- and boundedness follows from it,
+so all three are returned here rather than reconstructed at each call site. A caller wanting a
+genuine circular crosscut applies this at `dist ζ c = r` with `R := min R (2 * r)`. -/
+theorem exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top
+    (hf : DifferentiableOn ℂ f (ball c r))
+    (hfin : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R) :
+    ∃ ρ ∈ Ioo 0 R, circleImageLength f (ball c r) ζ ρ ≠ ⊤ ∧
+      diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε ∧
+      IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
+  obtain ⟨ρ, hρmem, hlen⟩ :=
+    exists_circleImageLength_lt_of_lintegral_ne_top (s := ball c r) f measurableSet_ball ζ hfin
+      (ENNReal.ofReal_pos.mpr hε).ne' hR
+  have hfin' : circleImageLength f (ball c r) ζ ρ ≠ ⊤ := (hlen.trans ENNReal.ofReal_lt_top).ne
+  exact ⟨ρ, hρmem, hfin', diam_image_ball_inter_sphere_le hf hε.le hlen.le,
+    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hf hfin'⟩
+
+/-- **A holomorphic map of finite Dirichlet integral has short images of small circle
 intersections.** For `f` holomorphic on `ball c r` with `∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤`
 and an arbitrary `ζ`, every tolerance `ε > 0` and every bound `R > 0` admit a radius `ρ < R` at
 which the image of `ball c r ∩ sphere ζ ρ` has diameter at most `ε`. The case the Carathéodory
@@ -209,10 +236,9 @@ theorem exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top
     (hf : DifferentiableOn ℂ f (ball c r))
     (hfin : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R) :
     ∃ ρ ∈ Ioo 0 R, diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε := by
-  obtain ⟨ρ, hρmem, hlen⟩ :=
-    exists_circleImageLength_lt_of_lintegral_ne_top (s := ball c r) f measurableSet_ball ζ hfin
-      (ENNReal.ofReal_pos.mpr hε).ne' hR
-  exact ⟨ρ, hρmem, diam_image_ball_inter_sphere_le hf hε.le hlen.le⟩
+  obtain ⟨ρ, hρmem, -, hdiam, -⟩ :=
+    exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top (ζ := ζ) hf hfin hε hR
+  exact ⟨ρ, hρmem, hdiam⟩
 
 /-- **A conformal map of a disc has arbitrarily small images of the circle intersections
 `ball c r ∩ sphere ζ ρ` at every centre `ζ`.** This is the case of


### PR DESCRIPTION
`exists_isJordanCurve_superset_closure_image_ball_inter_sphere_diam_le` carried a 60-line
proof whose first eleven lines pick a crosscut radius and read off four facts about it. That
block turned out not to be new: `Crosscut/BoundaryEnds.lean` was already performing the same
radius selection and the same three derivations. So rather than naming a private copy, this
factors the shared witness into `Conformal/ShortCrosscut.lean` and routes both consumers
through it.

## The shared lemma

```lean
theorem exists_diam_image_ball_inter_sphere_le_and_circleImageLength_ne_top
    (hf : DifferentiableOn ℂ f (ball c r))
    (hfin : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R) :
    ∃ ρ ∈ Ioo 0 R, circleImageLength f (ball c r) ζ ρ ≠ ⊤ ∧
      diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε ∧
      IsBounded (f '' (ball c r ∩ sphere ζ ρ))
```

It sits in `ShortCrosscut.lean` beside `diam_image_ball_inter_sphere_le` and
`isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top`, the two lemmas it is built
from, and is stated at the **general** bound `ρ ∈ Ioo 0 R`. Both callers instantiate it at
`R := min R (2 * r)`, which is what makes `ball c r ∩ sphere ζ ρ` a genuine circular crosscut
rather than the empty set — that restriction belongs at the call sites, since away from the
boundary circle it is neither needed nor true.

**It uses none of the crosscut hypotheses.** No `dist ζ c = r`, no `InjOn f`, no Jordan
frontier: the choice of radius is pure length--area, and the geometry enters only afterwards.

## What this deletes

`exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top` is now the diameter conjunct of
the new lemma rather than a second call, so **`exists_circleImageLength_lt_of_lintegral_ne_top`
is invoked from exactly one place in the repository, down from three.**

| | before | after |
|---|---|---|
| `exists_isJordanCurve_superset_..._diam_le` | 60 | 47 |
| `exists_frontier_inter_..._eq_pair_dist_le` | 25 | 12 |
| new shared lemma | — | 6 |

`SmallJordanCurve.lean` is 13 lines shorter than before this PR despite the proof carrying the
`min` instantiation itself.

## Also in this PR

The scale `κ` in the Jordan-curve proof was `let κ := min (ε / 2) (δ / 2)`, unfolded by
`dsimp [κ]` at three separate points to recover the only two facts wanted from it. It is now
obtained with exactly those two properties, so the unfoldings and their `min_le_*` hints are
gone and the two arithmetic steps close by bare `linarith`.

Prose kept in step: `BoundaryEnds.lean` described the length--area call it no longer makes
directly, and `ShortCrosscut.lean`'s `## Main results` inventory gains the new theorem.

Gates run on `6d3fee97`: `lake build` (7767 jobs), `lake exe axioms` (44176 declarations),
`lake exe module-system` (2111 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: ConformalMapping