### PR TITLE
refactor(Contour): drop the empty-crossings case split at both PV summits

### DIFF
--- a/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
+++ b/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
@@ -154,32 +154,27 @@ theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {
       h_imm.isPiecewiseC1On.intervalIntegrable_deriv hε
   have h_plain := fun l u =>
     plain_piece_integral_eq (s := s) h_imm hab hk c (l := l) (u := u)
-  rcases T.eq_empty_or_nonempty with hT_empty | -
-  · refine hasCauchyPVAt_of_perWindow_boundary_tendsto_of_interiorDisjoint
-      (Φ := fun z => c * (-(↑(k - 1) : ℂ)⁻¹ * ((z - s) ^ (k - 1))⁻¹))
-      hab.le T ?_ ?_ ?_ ?_ h_int_tr h_plain ?_
-      (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => 1)
-        fun t _ => one_pos)
-    all_goals simp [hT_empty]
-  · -- The same uniform radius as in `InvSubCPVExistence`; the constant bound `1` is inert here,
-    -- and the strict margins it returns are what removes the halving this used to need.
-    obtain ⟨ρ, hρ_pos, h_endpts, h_pair, -⟩ :=
-      exists_common_window_radius_le h_Ioo (fun _ => 1) fun _ _ => one_pos
-    refine hasCauchyPVAt_of_perWindow_boundary_tendsto_of_interiorDisjoint
-      (Φ := fun z => c * (-(↑(k - 1) : ℂ)⁻¹ * ((z - s) ^ (k - 1))⁻¹))
-      hab.le T (fun _ => hρ_pos.le)
-      (fun t ht => by linarith [(h_endpts t ht).1])
-      (fun t ht => by linarith [(h_endpts t ht).2])
-      (fun t ht t' ht' hne => (h_pair t ht t' ht' hne).le)
-      h_int_tr h_plain
-      (fun t₀ ht₀ => perWindow_boundary_tendsto_of_interior h_imm hab (h_Ioo t₀ ht₀)
-        (hT_mem.mp ht₀).2 hk hkn (h_flat t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2)
-        (h_B t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2) c p.countable_toSet hp hρ_pos
-        (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
-        fun t ht h_eq => eq_of_mem_window_of_eq_of_lt_of_two_mul_lt (h_endpts t₀ ht₀)
-          (h_pair t₀ ht₀) h_complete ht h_eq)
-      (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
-        fun t _ => hρ_pos)
+  -- The same uniform radius as in `InvSubCPVExistence`; the constant bound `1` is inert here,
+  -- and the strict margins it returns are what removes the halving this used to need.
+  -- No case split on `T` is needed: `exists_common_window_radius_le` supplies a radius when
+  -- there are no crossings, and every window hypothesis below is a `∀` over `T`.
+  obtain ⟨ρ, hρ_pos, h_endpts, h_pair, -⟩ :=
+    exists_common_window_radius_le h_Ioo (fun _ => 1) fun _ _ => one_pos
+  exact hasCauchyPVAt_of_perWindow_boundary_tendsto_of_interiorDisjoint
+    (Φ := fun z => c * (-(↑(k - 1) : ℂ)⁻¹ * ((z - s) ^ (k - 1))⁻¹))
+    hab.le T (fun _ => hρ_pos.le)
+    (fun t ht => by linarith [(h_endpts t ht).1])
+    (fun t ht => by linarith [(h_endpts t ht).2])
+    (fun t ht t' ht' hne => (h_pair t ht t' ht' hne).le)
+    h_int_tr h_plain
+    (fun t₀ ht₀ => perWindow_boundary_tendsto_of_interior h_imm hab (h_Ioo t₀ ht₀)
+      (hT_mem.mp ht₀).2 hk hkn (h_flat t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2)
+      (h_B t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2) c p.countable_toSet hp hρ_pos
+      (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
+      fun t ht h_eq => eq_of_mem_window_of_eq_of_lt_of_two_mul_lt (h_endpts t₀ ht₀)
+        (h_pair t₀ ht₀) h_complete ht h_eq)
+    (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
+      fun t _ => hρ_pos)
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -152,28 +152,25 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
       MeasureTheory.volume a b :=
     fun _ hε => intervalIntegrable_inv_sub_truncated h_imm.continuousOn
       h_imm.isPiecewiseC1On.intervalIntegrable_deriv hε
-  rcases T.eq_empty_or_nonempty with hT_empty | -
-  · refine cauchyPVExistsAt_of_perWindow_tendsto_of_interiorDisjoint hab.le T ?_ ?_ ?_ ?_ h_int_tr
-      ?_ (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => 1)
-        fun t _ => one_pos)
-    all_goals simp [hT_empty]
-  · choose! R hR_pos _ _ _ _ _ _ h_spec using
-      fun t₀ (ht₀ : t₀ ∈ T) =>
-        exists_radius_perWindow_tendsto_log_norm_add_arg h_imm hab (h_Ioo t₀ ht₀) (hT_mem.mp ht₀).2
-    -- one radius serving every crossing at once, below each per-crossing radius `R t`
-    obtain ⟨ρ, hρ_pos, h_endpts, h_pair, hρ_le_R⟩ :=
-      exists_common_window_radius_le h_Ioo R hR_pos
-    refine cauchyPVExistsAt_of_perWindow_tendsto_of_interiorDisjoint hab.le T (fun _ => hρ_pos.le)
-      (fun t ht => by linarith [(h_endpts t ht).1])
-      (fun t ht => by linarith [(h_endpts t ht).2])
-      (fun t ht t' ht' hne => (h_pair t ht t' ht' hne).le)
-      h_int_tr
-      (fun t₀ ht₀ => ⟨_, h_spec t₀ ht₀ ρ hρ_pos (hρ_le_R t₀ ht₀)
-        (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
-        fun t ht h_eq => eq_of_mem_window_of_eq_of_lt_of_two_mul_lt (h_endpts t₀ ht₀)
-          (h_pair t₀ ht₀) h_complete ht h_eq⟩)
-      (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
-        fun t _ => hρ_pos)
+  choose! R hR_pos _ _ _ _ _ _ h_spec using
+    fun t₀ (ht₀ : t₀ ∈ T) =>
+      exists_radius_perWindow_tendsto_log_norm_add_arg h_imm hab (h_Ioo t₀ ht₀) (hT_mem.mp ht₀).2
+  -- one radius serving every crossing at once, below each per-crossing radius `R t`; no case
+  -- split on `T` is needed, since this supplies a radius when there are no crossings and every
+  -- window hypothesis below is a `∀` over `T`
+  obtain ⟨ρ, hρ_pos, h_endpts, h_pair, hρ_le_R⟩ :=
+    exists_common_window_radius_le h_Ioo R hR_pos
+  exact cauchyPVExistsAt_of_perWindow_tendsto_of_interiorDisjoint hab.le T (fun _ => hρ_pos.le)
+    (fun t ht => by linarith [(h_endpts t ht).1])
+    (fun t ht => by linarith [(h_endpts t ht).2])
+    (fun t ht t' ht' hne => (h_pair t ht t' ht' hne).le)
+    h_int_tr
+    (fun t₀ ht₀ => ⟨_, h_spec t₀ ht₀ ρ hρ_pos (hρ_le_R t₀ ht₀)
+      (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
+      fun t ht h_eq => eq_of_mem_window_of_eq_of_lt_of_two_mul_lt (h_endpts t₀ ht₀)
+        (h_pair t₀ ht₀) h_complete ht h_eq⟩)
+    (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
+      fun t _ => hρ_pos)
 
 end TauCeti.Contour
 


### PR DESCRIPTION
Both principal-value summits opened with `rcases T.eq_empty_or_nonempty`, and the empty branch
reassembled the same aggregation call with window radius `1` and every hypothesis discharged by
`simp [hT_empty]`. The split is redundant, twice over.

## Why it is redundant

1. **`exists_common_window_radius_le` already handles an empty crossing set.** Its own first
   line is `rcases crossings.eq_empty_or_nonempty with rfl | h_nonempty` and it returns
   `⟨1, one_pos, by simp, by simp, by simp⟩` (`Crossing/Windows.lean:167-168`) — the same
   radius `1` the deleted branches were supplying by hand.
2. **Every window hypothesis of the aggregation lemma is a `∀` over the crossing set**
   (`hr_nonneg` is even guarded by `crossings.Nonempty`), so with `T` empty they hold
   vacuously — which is exactly what the `simp [hT_empty]` in the deleted branch was proving.

So calling the radius lemma unconditionally covers both cases with the branch that was already
written for the nonempty one. Nothing is added to make this work: the deleted code is strictly
a re-derivation.

`Winding/RealIntegral/OnCurve.lean:323` is the precedent already on main — it consumes the same
radius lemma with no case split at all.

## Result

| | before | after |
|---|---|---|
| `IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv` | 44 | 39 |
| `IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub` | 37 | 34 |

No declaration is added, removed, renamed or restated; both statements are untouched. Two files
change because the same redundancy sits at both summits and fixing one and not the other would
leave the two out of step.

Gates run on `a2437a43`: `lake build` (7771 jobs), `lake exe axioms` (44194 declarations),
`lake exe module-system` (2115 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: ContourIntegration