### PR TITLE
feat(ModularForms): the slash sum preserves holomorphy

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Holomorphic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Holomorphic.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Basic
+
+/-!
+# The slash sum preserves holomorphy
+
+`heckeSlashSum` is a finite sum of slashes, so it is holomorphic whenever its argument is. This
+is one of the two conditions separating `SlashInvariantForm` from `ModularForm`; the other,
+boundedness at the cusps, is not addressed here.
+
+The proof is short because both halves are already in mathlib: `MDifferentiable.slash` for a
+single slash, and `MDifferentiable.sum` for the finite sum. The only step particular to this
+development is that `heckeSlashSum` slashes by *rational* matrices, so `ModularForm.rat_slash`
+restates each summand as a slash by the corresponding real matrix before mathlib's lemma applies.
+
+## Main results
+
+* `HeckeRing.GL2.mdiff_heckeSlashSum`: `heckeSlashSum k D f` is holomorphic when `f` is.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.4.
+-/
+
+public section
+
+open Matrix UpperHalfPlane DoubleCoset HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm Manifold
+
+namespace HeckeRing.GL2
+
+variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+
+/-- **The slash sum of a holomorphic function is holomorphic.** Together with slash-invariance
+(`heckeSlashSum_slash_invariant_of_mem_SLnZ`) this supplies one of the two extra conditions a
+`ModularForm` carries over a `SlashInvariantForm`; boundedness at the cusps is separate and is
+not proved here. -/
+lemma mdiff_heckeSlashSum {f : ℍ → ℂ} (hf : MDiff f) : MDiff (heckeSlashSum k D f) := by
+  rw [heckeSlashSum_def]
+  refine MDifferentiable.sum fun i _ ↦ ?_
+  -- each summand slashes by a rational matrix; `rat_slash` restates it at the real image, which
+  -- is the form mathlib's `MDifferentiable.slash` applies to
+  rw [ModularForm.rat_slash]
+  exact hf.slash k _
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Holomorphic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Holomorphic.lean
@@ -14,14 +14,14 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Basic
 is one of the two conditions separating `SlashInvariantForm` from `ModularForm`; the other,
 boundedness at the cusps, is not addressed here.
 
-The proof is short because both halves are already in mathlib: `MDifferentiable.slash` for a
-single slash, and `MDifferentiable.sum` for the finite sum. The only step particular to this
-development is that `heckeSlashSum` slashes by *rational* matrices, so `ModularForm.rat_slash`
-restates each summand as a slash by the corresponding real matrix before mathlib's lemma applies.
+Holomorphy is one of the two conditions a `ModularForm` carries over a `SlashInvariantForm`. A
+consumer building the descent needs this together with boundedness at the cusps; only the former
+is available here, and nothing in this file assumes `f` is slash-invariant, so it applies to any
+holomorphic `f : ℍ → ℂ`.
 
 ## Main results
 
-* `HeckeRing.GL2.mdiff_heckeSlashSum`: `heckeSlashSum k D f` is holomorphic when `f` is.
+* `HeckeRing.GL2.mdifferentiable_heckeSlashSum`: `heckeSlashSum k D f` is holomorphic when `f` is.
 
 ## References
 
@@ -43,11 +43,13 @@ variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
 (`heckeSlashSum_slash_invariant_of_mem_SLnZ`) this supplies one of the two extra conditions a
 `ModularForm` carries over a `SlashInvariantForm`; boundedness at the cusps is separate and is
 not proved here. -/
-lemma mdiff_heckeSlashSum {f : ℍ → ℂ} (hf : MDiff f) : MDiff (heckeSlashSum k D f) := by
+lemma mdifferentiable_heckeSlashSum {f : ℍ → ℂ} (hf : MDiff f) : MDiff (heckeSlashSum k D f) := by
+  -- `heckeSlashSum` is not `@[expose]`, so `heckeSlashSum_def` is what makes the sum visible;
+  -- `MDifferentiable.sum` then reduces to one summand. That summand slashes by a *rational*
+  -- matrix, and `rat_slash` restates it at the real image, which is the form mathlib's
+  -- `MDifferentiable.slash` applies to.
   rw [heckeSlashSum_def]
   refine MDifferentiable.sum fun i _ ↦ ?_
-  -- each summand slashes by a rational matrix; `rat_slash` restates it at the real image, which
-  -- is the form mathlib's `MDifferentiable.slash` applies to
   rw [ModularForm.rat_slash]
   exact hf.slash k _
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke/slash-holomorphic"}-->

## Roadmap target

`TauCetiRoadmap/ModularForms/README.md`, **Layer 2, block (b) "The action on forms"**, which asks
for `Tₙ`/`Tₚ` as endomorphisms of `ModularForm`. #3153 got the double coset acting on
`SlashInvariantForm 𝒮ℒ k`. A `ModularForm` carries exactly two conditions beyond that:

```lean
structure ModularForm extends SlashInvariantForm Γ k where
  holo' : MDiff (toSlashInvariantForm : ℍ → ℂ)
  bdd_at_cusps' {c : OnePoint ℝ} (hc : IsCusp c Γ) : c.IsBoundedAt toFun k
```

This PR supplies the first. The second — boundedness at the cusps — is **not** addressed here and
is the remaining obstruction to the descent.

## What is proved

```lean
lemma mdiff_heckeSlashSum {f : ℍ → ℂ} (hf : MDiff f) : MDiff (heckeSlashSum k D f)
```

## Why it is four lines

Both halves are already in mathlib, and finding that is most of the work:

* `MDifferentiable.slash` (`NumberTheory/ModularForms/Basic.lean`) — the weight-`k` slash of
  `GL(2, ℝ)` preserves holomorphy, for **any** `g`, not just positive determinant;
* `MDifferentiable.sum` (`Geometry/Manifold/MFDeriv/SpecificFunctions.lean`) — `MDiff` is closed
  under finite sums.

The only step particular to this development is that `heckeSlashSum` slashes by *rational*
matrices, so `ModularForm.rat_slash` restates each summand at the corresponding real matrix before
mathlib's lemma applies. `heckeSlashSum_def` (added in #3125) is what makes the sum visible at all,
since `heckeSlashSum` is not `@[expose]`.

No new API is introduced beyond the lemma itself.

## Scope

Deliberately one lemma. The cusp condition is a genuinely different argument — it needs the
behaviour of `f ∣[k] (σᵢδ)ᵀ` as `im τ → ∞` at each cusp, not a pointwise property — and bundling
it here would mix two unrelated proofs in one PR.

## Provenance

No AINTLIB counterpart is ported: AINTLIB reaches `ModularForm` through a different chain
(`Gamma1 N`, `heckeT_n`, `preservesCusps_heckeT_n` in `HeckeRIngs/GL2/AdjointTheory.lean`) rather
than through the level-one `𝒮ℒ` development this file continues. The statement and proof here are
built directly on mathlib's `MDifferentiable.slash` and `MDifferentiable.sum`.

## References

* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
  §3.4.

Roadmap: ModularForms
