### PR TITLE
refactor(Probability): name the two measure-theoretic steps of the conditional strong law

### DIFF
--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/StrongLaw.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/StrongLaw.lean
@@ -100,6 +100,46 @@ variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] [MeasurableSpace E]
   [BorelSpace E] [SecondCountableTopology E]
 
+omit [CompleteSpace E] in
+/-- The set of pairs `(Q, x)` for which the averages of `f` along the path `x` converge to the
+integral of `f` against `Q` is measurable. -/
+private theorem measurableSet_tendsto_average_integral {f : α → E} (hf : Measurable f) :
+    MeasurableSet {z : ProbabilityMeasure α × (ℕ → α) |
+      Tendsto (fun n : ℕ => (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, f (z.2 i)) atTop
+        (𝓝 (∫ y, f y ∂(z.1 : Measure α)))} :=
+  MeasureTheory.measurableSet_tendsto_fun
+    (fun _n => (Finset.measurable_sum _ fun i _ =>
+      hf.comp ((measurable_pi_apply i).comp measurable_snd)).const_smul _)
+    -- `Q ↦ ∫ f dQ` is measurable: it is the integral against the coercion kernel
+    -- `ProbabilityMeasure α → Measure α`.
+    ((hf.stronglyMeasurable.integral_kernel
+      (κ := ⟨((↑) : ProbabilityMeasure α → Measure α), measurable_subtype_coe⟩)).measurable.comp
+        measurable_fst)
+
+/-- **On each fibre of the mixture the averages converge almost surely.** For a bounded measurable
+`f` and a probability measure `Q`, the pairing of `Q` with an i.i.d. `Q`-path lands almost surely
+in the set where the averages of `f` converge to `∫ f dQ`.
+
+This is the classical strong law, read on the fibre `(δ_Q, Q^{⊗ℕ})`; nothing about the directing
+measure or the process is involved. -/
+private theorem measure_compl_tendsto_average_integral_eq_zero {f : α → E} (hf : Measurable f)
+    {C : ℝ} (hbdd : ∀ x, ‖f x‖ ≤ C) (Q : ProbabilityMeasure α) :
+    ((Measure.dirac Q).prod (Measure.infinitePi fun _ : ℕ => (Q : Measure α)))
+      {z : ProbabilityMeasure α × (ℕ → α) |
+        Tendsto (fun n : ℕ => (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, f (z.2 i)) atTop
+          (𝓝 (∫ y, f y ∂(z.1 : Measure α)))}ᶜ = 0 := by
+  have hint : Integrable f (Q : Measure α) :=
+    Integrable.of_bound hf.aestronglyMeasurable C (.of_forall hbdd)
+  have hsl : ∀ᵐ x ∂(Measure.infinitePi fun _ : ℕ => (Q : Measure α)),
+      (Q, x) ∈ {z : ProbabilityMeasure α × (ℕ → α) |
+        Tendsto (fun n : ℕ => (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, f (z.2 i)) atTop
+          (𝓝 (∫ y, f y ∂(z.1 : Measure α)))} := by
+    filter_upwards [strong_law_ae_infinitePi (Q : Measure α) hf hint] with x hx
+    simpa only [Set.mem_ofPred_eq] using hx
+  rw [Measure.dirac_prod, Measure.map_apply measurable_prodMk_left
+    (measurableSet_tendsto_average_integral hf).compl]
+  exact ae_iff.mp hsl
+
 /-- **The conditional strong law of large numbers.** For a conditionally i.i.d. process and a
 bounded measurable observable `f` valued in a Banach space, the averages of `f` along the process
 converge almost surely to the integral of `f` against the directing measure.
@@ -119,26 +159,12 @@ theorem ConditionallyIIDWith.tendsto_average_ae [IsFiniteMeasure μ]
       (𝓝 (∫ y, f y ∂(z.1 : Measure α)))} with hG
   have hGmeas : MeasurableSet G := by
     rw [hG]
-    exact MeasureTheory.measurableSet_tendsto_fun
-      (fun n => (Finset.measurable_sum _ fun i _ =>
-        hf.comp ((measurable_pi_apply i).comp measurable_snd)).const_smul _)
-      -- `Q ↦ ∫ f dQ` is measurable: it is the integral against the coercion kernel
-      -- `ProbabilityMeasure α → Measure α`.
-      ((hf.stronglyMeasurable.integral_kernel
-        (κ := ⟨((↑) : ProbabilityMeasure α → Measure α), measurable_subtype_coe⟩)).measurable.comp
-          measurable_fst)
+    exact measurableSet_tendsto_average_integral hf
   -- Every fibre of the mixture is an i.i.d. law, where the strong law applies.
   have hfibre : ∀ Q : ProbabilityMeasure α,
       ((Measure.dirac Q).prod (Measure.infinitePi fun _ : ℕ => (Q : Measure α))) Gᶜ = 0 := by
-    intro Q
-    have hint : Integrable f (Q : Measure α) :=
-      Integrable.of_bound hf.aestronglyMeasurable C (.of_forall hbdd)
-    have hsl : ∀ᵐ x ∂(Measure.infinitePi fun _ : ℕ => (Q : Measure α)), (Q, x) ∈ G := by
-      filter_upwards [strong_law_ae_infinitePi (Q : Measure α) hf hint] with x hx
-      rw [hG]
-      simpa only [Set.mem_ofPred_eq] using hx
-    rw [Measure.dirac_prod, Measure.map_apply measurable_prodMk_left hGmeas.compl]
-    exact ae_iff.mp hsl
+    rw [hG]
+    exact fun Q => measure_compl_tendsto_average_integral_eq_zero hf hbdd Q
   have hker : Measurable fun Q : ProbabilityMeasure α =>
       (Measure.dirac Q).prod (Measure.infinitePi fun _ : ℕ => (Q : Measure α)) :=
     TauCeti.MeasureTheory.measurable_dirac_prod_infinitePi_const

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/StrongLaw.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/StrongLaw.lean
@@ -116,20 +116,18 @@ private theorem measurableSet_tendsto_average_integral {f : α → E} (hf : Meas
       (κ := ⟨((↑) : ProbabilityMeasure α → Measure α), measurable_subtype_coe⟩)).measurable.comp
         measurable_fst)
 
-/-- **On each fibre of the mixture the averages converge almost surely.** For a bounded measurable
-`f` and a probability measure `Q`, the pairing of `Q` with an i.i.d. `Q`-path lands almost surely
-in the set where the averages of `f` converge to `∫ f dQ`.
+/-- **On each fibre of the mixture the averages converge almost surely.** For `f` measurable and
+integrable against a probability measure `Q`, the pairing of `Q` with an i.i.d. `Q`-path lands
+almost surely in the set where the averages of `f` converge to `∫ f dQ`.
 
 This is the classical strong law, read on the fibre `(δ_Q, Q^{⊗ℕ})`; nothing about the directing
 measure or the process is involved. -/
 private theorem measure_compl_tendsto_average_integral_eq_zero {f : α → E} (hf : Measurable f)
-    {C : ℝ} (hbdd : ∀ x, ‖f x‖ ≤ C) (Q : ProbabilityMeasure α) :
+    (Q : ProbabilityMeasure α) (hint : Integrable f (Q : Measure α)) :
     ((Measure.dirac Q).prod (Measure.infinitePi fun _ : ℕ => (Q : Measure α)))
       {z : ProbabilityMeasure α × (ℕ → α) |
         Tendsto (fun n : ℕ => (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, f (z.2 i)) atTop
           (𝓝 (∫ y, f y ∂(z.1 : Measure α)))}ᶜ = 0 := by
-  have hint : Integrable f (Q : Measure α) :=
-    Integrable.of_bound hf.aestronglyMeasurable C (.of_forall hbdd)
   have hsl : ∀ᵐ x ∂(Measure.infinitePi fun _ : ℕ => (Q : Measure α)),
       (Q, x) ∈ {z : ProbabilityMeasure α × (ℕ → α) |
         Tendsto (fun n : ℕ => (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, f (z.2 i)) atTop
@@ -164,7 +162,8 @@ theorem ConditionallyIIDWith.tendsto_average_ae [IsFiniteMeasure μ]
   have hfibre : ∀ Q : ProbabilityMeasure α,
       ((Measure.dirac Q).prod (Measure.infinitePi fun _ : ℕ => (Q : Measure α))) Gᶜ = 0 := by
     rw [hG]
-    exact fun Q => measure_compl_tendsto_average_integral_eq_zero hf hbdd Q
+    exact fun Q => measure_compl_tendsto_average_integral_eq_zero hf Q
+      (Integrable.of_bound hf.aestronglyMeasurable C (.of_forall hbdd))
   have hker : Measurable fun Q : ProbabilityMeasure α =>
       (Measure.dirac Q).prod (Measure.infinitePi fun _ : ℕ => (Q : Measure α)) :=
     TauCeti.MeasureTheory.measurable_dirac_prod_infinitePi_const


### PR DESCRIPTION
`ConditionallyIIDWith.tendsto_average_ae` carried a 45-line proof. Its first two blocks say
nothing about conditional independence: one shows the convergence event is measurable, the
other that each fibre of the mixture gives that event full measure. Name them. No statement
changes; no new public declaration.

## The extracted helpers

```lean
omit [CompleteSpace E] in
private theorem measurableSet_tendsto_average_integral {f : α → E} (hf : Measurable f) :
    MeasurableSet {z : ProbabilityMeasure α × (ℕ → α) |
      Tendsto (fun n : ℕ => (n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, f (z.2 i)) atTop
        (𝓝 (∫ y, f y ∂(z.1 : Measure α)))}

private theorem measure_compl_tendsto_average_integral_eq_zero {f : α → E} (hf : Measurable f)
    (Q : ProbabilityMeasure α) (hint : Integrable f (Q : Measure α)) :
    ((Measure.dirac Q).prod (Measure.infinitePi fun _ : ℕ => (Q : Measure α))) {…}ᶜ = 0
```

**Neither mentions the process.** The enclosing theorem assumes a conditionally i.i.d. `X` with
directing measure `ν`, an ambient `μ`, `IsFiniteMeasure μ`, and a.e.-measurability of every
`X i`. The first helper uses only `Measurable f`; the second only `Measurable f` and
integrability against a single `Q`. That is the content of the split: the
conditional-independence hypothesis is needed nowhere until the fibres are glued.

**The fibre lemma takes integrability, not the uniform bound.** The enclosing theorem has
`‖f x‖ ≤ C` because it needs one bound to serve every `Q` at once; on a fixed fibre the proof
consumes only `Integrable f (Q : Measure α)`, which is strictly weaker — a global bound gives it
under any probability measure, but plenty of integrable `f` are unbounded. The conversion
happens at the call site.

**The split also found a redundant instance.** With the measurability step standing alone, the
`unusedSectionVars` linter reports that it does not use `[CompleteSpace E]` — completeness is
needed for the Bochner integral in the *statement* of the theorem, not for measurability of the
convergence set. It is now `omit`ted, following the convention already used in
`Topology/JordanCurve/Path.lean:71`.

## Result

| | before | after |
|---|---|---|
| `ConditionallyIIDWith.tendsto_average_ae` | 45 | 31 |
| `measurableSet_tendsto_average_integral` | — | 13 |
| `measure_compl_tendsto_average_integral_eq_zero` | — | 10 |

The two blocks move essentially verbatim; the parent keeps its `set G … with hG` abbreviation
and bridges to the spelled-out statements with the `rw [hG]` it already had.

Gates run on `17b49c27`: `lake build` (7776 jobs), `lake exe axioms` (44234 declarations),
`lake exe module-system` (2118 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: Exchangeability