### PR TITLE
refactor(Contour): name the polar-form step of the argument lift

### DIFF
--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -368,13 +368,12 @@ private theorem exists_monotone_partition_mesh_lt {a b δ : ℝ} (hab : a ≤ b)
     linarith
 
 /-- **The polar form at a point, from the partition data alone.** For a monotone `s` with
-`s 0 = a`, no node sent to `w`, and every segment ratio in the slit plane, any `t` between `s 0`
+`s 0 = a` and no node sent to `w`, any `t` between `s 0`
 and `s N` satisfies `γ t - w = ‖γ t - w‖ · exp (I · θ t)`, where
 `θ t = arg (γ a - w) + ∑_{j < N} (log (segRatio γ w (s j) (s (j+1)) t)).im`. -/
 private theorem polar_form_of_partition {γ : ℝ → ℂ} {w : ℂ} {a : ℝ} {N : ℕ} {s : ℕ → ℝ}
     (hN_pos : 0 < N) (hs_zero : s 0 = a) (hs_mono : Monotone s)
     (hs_avoid : ∀ j ≤ N, γ (s j) - w ≠ 0) {t : ℝ}
-    (h_ratio_ne : ∀ j < N, segRatio γ w (s j) (s (j + 1)) t ≠ 0)
     (h_cov_lo : s 0 ≤ t) (h_cov_hi : t ≤ s N) :
     γ t - w = (‖γ t - w‖ : ℂ) * Complex.exp (Complex.I *
       ((Complex.arg (γ a - w) +
@@ -387,8 +386,14 @@ private theorem polar_form_of_partition {γ : ℝ → ℂ} {w : ℂ} {a : ℝ} {
   have h_prod_eq : (γ a - w) *
       ∏ j ∈ Finset.range N, segRatio γ w (s j) (s (j + 1)) t = γ t - w := by
     rw [h_telescope, mul_div_cancel₀ _ h_avoid_a]
+  rcases eq_or_ne (γ t - w) 0 with h0 | h0
+  · simp [h0]
+  -- the product is the nonzero `γ t - w` up to the nonzero factor `γ a - w`, so no factor vanishes
+  have hprod_ne : (γ a - w) *
+      ∏ j ∈ Finset.range N, segRatio γ w (s j) (s (j + 1)) t ≠ 0 := by
+    rw [h_prod_eq]; exact h0
   exact polar_form_of_prod (zs := fun j ↦ segRatio γ w (s j) (s (j + 1)) t)
-    h_avoid_a (fun j hj ↦ h_ratio_ne j (Finset.mem_range.mp hj)) h_prod_eq
+    h_avoid_a (Finset.prod_ne_zero_iff.mp (right_ne_zero_of_mul hprod_ne)) h_prod_eq
 
 /-! ### Main theorem: argument lift on `[a, b]` -/
 
@@ -440,7 +445,6 @@ theorem exists_continuousOn_arg_lift_with_partition {γ : ℝ → ℂ} {w : ℂ}
       (hs_le j) (hs_mesh j)
   -- Lift property
   · exact fun t ht => polar_form_of_partition hN_pos hs_zero hs_mono hs_avoid
-      (fun j hj ↦ Complex.slitPlane_ne_zero (h_seg j hj t))
       (by rw [hs_zero]; exact ht.1) (by rw [hs_N]; exact ht.2)
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -367,29 +367,34 @@ private theorem exists_monotone_partition_mesh_lt {a b δ : ℝ} (hab : a ≤ b)
     rw [abs_of_nonneg (by linarith)] at hbd
     linarith
 
-/-- **The polar form at a point, from the partition data alone.** For a monotone `s` with
-`s 0 = a` and no node sent to `w`, any `t` between `s 0`
-and `s N` satisfies `γ t - w = ‖γ t - w‖ · exp (I · θ t)`, where
-`θ t = arg (γ a - w) + ∑_{j < N} (log (segRatio γ w (s j) (s (j+1)) t)).im`. -/
-private theorem polar_form_of_partition {γ : ℝ → ℂ} {w : ℂ} {a : ℝ} {N : ℕ} {s : ℕ → ℝ}
-    (hN_pos : 0 < N) (hs_zero : s 0 = a) (hs_mono : Monotone s)
-    (hs_avoid : ∀ j < N, γ (s j) - w ≠ 0) {t : ℝ}
+/-- **The polar form at a point, from the partition data alone.** For a monotone `s` sending no
+node `s j` with `j < N` to `w`, any `t` between `s 0` and `s N` satisfies
+`γ t - w = ‖γ t - w‖ · exp (I · θ t)`, where
+`θ t = arg (γ (s 0) - w) + ∑_{j < N} (log (segRatio γ w (s j) (s (j+1)) t)).im`.
+
+For `N = 0` this is the ordinary polar identity at `s 0`, with no hypothesis at all. -/
+private theorem polar_form_of_partition {γ : ℝ → ℂ} {w : ℂ} {N : ℕ} {s : ℕ → ℝ}
+    (hs_mono : Monotone s) (hs_avoid : ∀ j < N, γ (s j) - w ≠ 0) {t : ℝ}
     (h_cov_lo : s 0 ≤ t) (h_cov_hi : t ≤ s N) :
     γ t - w = (‖γ t - w‖ : ℂ) * Complex.exp (Complex.I *
-      ((Complex.arg (γ a - w) +
+      ((Complex.arg (γ (s 0) - w) +
         ∑ j ∈ Finset.range N,
           (Complex.log (segRatio γ w (s j) (s (j + 1)) t)).im : ℝ) : ℂ)) := by
-  have h_avoid_a : γ a - w ≠ 0 := hs_zero ▸ hs_avoid 0 hN_pos
+  rcases Nat.eq_zero_or_pos N with rfl | hN_pos
+  · -- no segments: `t` is pinned to `s 0` and the sum is empty
+    rw [le_antisymm h_cov_hi h_cov_lo]
+    simpa [mul_comm] using (Complex.norm_mul_exp_arg_mul_I (γ (s 0) - w)).symm
+  have h_avoid_a : γ (s 0) - w ≠ 0 := hs_avoid 0 hN_pos
   obtain ⟨k, hk_lt, hk_lo, hk_hi⟩ := exists_covering_segment hN_pos hs_mono h_cov_lo h_cov_hi
   have h_telescope := prod_segRatio_telescope hs_mono hs_avoid hk_lt hk_lo hk_hi
-  rw [hs_zero] at h_telescope
-  have h_prod_eq : (γ a - w) *
+  have h_prod_eq : (γ (s 0) - w) *
       ∏ j ∈ Finset.range N, segRatio γ w (s j) (s (j + 1)) t = γ t - w := by
     rw [h_telescope, mul_div_cancel₀ _ h_avoid_a]
   rcases eq_or_ne (γ t - w) 0 with h0 | h0
   · simp [h0]
-  -- the product is the nonzero `γ t - w` up to the nonzero factor `γ a - w`, so no factor vanishes
-  have hprod_ne : (γ a - w) *
+  -- the product is the nonzero `γ t - w` up to the nonzero factor `γ (s 0) - w`, so no factor
+  -- vanishes
+  have hprod_ne : (γ (s 0) - w) *
       ∏ j ∈ Finset.range N, segRatio γ w (s j) (s (j + 1)) t ≠ 0 := by
     rw [h_prod_eq]; exact h0
   exact polar_form_of_prod (zs := fun j ↦ segRatio γ w (s j) (s (j + 1)) t)
@@ -440,9 +445,9 @@ theorem exists_continuousOn_arg_lift_with_partition {γ : ℝ → ℂ} {w : ℂ}
       (hs_in j (Finset.mem_range.mp hj).le) (hs_in (j + 1) (Finset.mem_range.mp hj))
       (hs_le j) (hs_mesh j)
   -- Lift property
-  · exact fun t ht => polar_form_of_partition hN_pos hs_zero hs_mono
-      (fun j hj ↦ hs_avoid j hj.le)
-      (by rw [hs_zero]; exact ht.1) (by rw [hs_N]; exact ht.2)
+  · exact fun t ht => by
+      simpa [hs_zero] using polar_form_of_partition hs_mono (fun j hj ↦ hs_avoid j hj.le)
+        (by rw [hs_zero]; exact ht.1) (by rw [hs_N]; exact ht.2)
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -367,6 +367,35 @@ private theorem exists_monotone_partition_mesh_lt {a b δ : ℝ} (hab : a ≤ b)
     rw [abs_of_nonneg (by linarith)] at hbd
     linarith
 
+/-- **The polar form at a point, from the partition data alone.** For a monotone `s` with
+`s 0 = a`, no node sent to `w`, and every segment ratio in the slit plane, any `t` between `s 0`
+and `s N` satisfies `γ t - w = ‖γ t - w‖ · exp (I · θ t)`, where
+`θ t = arg (γ a - w) + ∑_{j < N} (log (segRatio γ w (s j) (s (j+1)) t)).im`.
+
+None of the analytic data behind the partition -- continuity of `γ`, the distance lower bound,
+the uniform modulus, the mesh bound -- takes part. -/
+private theorem polar_form_of_partition {γ : ℝ → ℂ} {w : ℂ} {a : ℝ} {N : ℕ} {s : ℕ → ℝ}
+    (hN_pos : 0 < N) (hs_zero : s 0 = a) (hs_mono : Monotone s)
+    (hs_avoid : ∀ j ≤ N, γ (s j) - w ≠ 0)
+    (h_seg : ∀ j, j < N → ∀ t, segRatio γ w (s j) (s (j + 1)) t ∈ Complex.slitPlane)
+    {t : ℝ} (h_cov_lo : s 0 ≤ t) (h_cov_hi : t ≤ s N) :
+    γ t - w = (‖γ t - w‖ : ℂ) * Complex.exp (Complex.I *
+      ((Complex.arg (γ a - w) +
+        ∑ j ∈ Finset.range N,
+          (Complex.log (segRatio γ w (s j) (s (j + 1)) t)).im : ℝ) : ℂ)) := by
+  have h_avoid_a : γ a - w ≠ 0 := hs_zero ▸ hs_avoid 0 (Nat.zero_le N)
+  obtain ⟨k, hk_lt, hk_lo, hk_hi⟩ := exists_covering_segment hN_pos hs_mono h_cov_lo h_cov_hi
+  have h_telescope := prod_segRatio_telescope hs_mono hs_avoid hk_lt hk_lo hk_hi
+  rw [hs_zero] at h_telescope
+  have h_ratio_ne : ∀ j ∈ Finset.range N,
+      segRatio γ w (s j) (s (j + 1)) t ≠ 0 := fun j hj ↦
+    Complex.slitPlane_ne_zero (h_seg j (Finset.mem_range.mp hj) t)
+  have h_prod_eq : (γ a - w) *
+      ∏ j ∈ Finset.range N, segRatio γ w (s j) (s (j + 1)) t = γ t - w := by
+    rw [h_telescope, mul_div_cancel₀ _ h_avoid_a]
+  exact polar_form_of_prod (zs := fun j ↦ segRatio γ w (s j) (s (j + 1)) t)
+    h_avoid_a h_ratio_ne h_prod_eq
+
 /-! ### Main theorem: argument lift on `[a, b]` -/
 
 /-- **Argument lift on `[a, b]`, with a partition.** For `γ` continuous on `[a, b]` (`a ≤ b`) and
@@ -397,12 +426,16 @@ theorem exists_continuousOn_arg_lift_with_partition {γ : ℝ → ℂ} {w : ℂ}
   have hs_avoid : ∀ j ≤ N, γ (s j) - w ≠ 0 := fun j hj ↦
     sub_ne_zero.mpr (h_avoid (s j) (hs_in j hj))
   have hs_le : ∀ j, s j ≤ s (j + 1) := fun j ↦ hs_mono (Nat.le_succ _)
+  -- both the `slitPlane` conclusion and the nonvanishing the telescoping product needs read
+  -- off this one fact
+  have h_seg : ∀ j, j < N → ∀ t, segRatio γ w (s j) (s (j + 1)) t ∈ Complex.slitPlane :=
+    fun j hj ↦ segRatio_mem_slitPlane hρ_pos h_dist_lb h_unif
+      (hs_in j hj.le) (hs_in (j + 1) hj) (hs_le j) (hs_mesh j)
   have h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
       (γ t - w) / (γ (s j) - w) ∈ Complex.slitPlane := by
     intro j hj t ht
     rw [← segRatio_eq_div_of_mem_Icc ht]
-    exact segRatio_mem_slitPlane hρ_pos h_dist_lb h_unif
-      (hs_in j hj.le) (hs_in (j + 1) hj) (hs_le j) (hs_mesh j) t
+    exact h_seg j hj t
   refine ⟨N, s, hN_pos, hs_zero, hs_N, hs_mono, hs_in, hs_avoid, h_slit, ?_, ?_⟩
   -- Continuity of θ
   · refine ContinuousOn.add continuousOn_const ?_
@@ -412,26 +445,8 @@ theorem exists_continuousOn_arg_lift_with_partition {γ : ℝ → ℂ} {w : ℂ}
       (hs_in j (Finset.mem_range.mp hj).le) (hs_in (j + 1) (Finset.mem_range.mp hj))
       (hs_le j) (hs_mesh j)
   -- Lift property
-  · intro t ht
-    have h_avoid_a : γ a - w ≠ 0 :=
-      sub_ne_zero.mpr (h_avoid a ⟨le_rfl, hab⟩)
-    have h_cov_lo : s 0 ≤ t := by rw [hs_zero]; exact ht.1
-    have h_cov_hi : t ≤ s N := by rw [hs_N]; exact ht.2
-    obtain ⟨k, hk_lt, hk_lo, hk_hi⟩ := exists_covering_segment hN_pos hs_mono h_cov_lo h_cov_hi
-    have h_telescope := prod_segRatio_telescope hs_mono hs_avoid hk_lt hk_lo hk_hi
-    rw [hs_zero] at h_telescope
-    have h_ratio_ne : ∀ j ∈ Finset.range N,
-        segRatio γ w (s j) (s (j + 1)) t ≠ 0 := fun j hj ↦
-      Complex.slitPlane_ne_zero
-        (segRatio_mem_slitPlane hρ_pos h_dist_lb h_unif
-          (hs_in j (Finset.mem_range.mp hj).le)
-          (hs_in (j + 1) (Finset.mem_range.mp hj))
-          (hs_le j) (hs_mesh j) t)
-    have h_prod_eq : (γ a - w) *
-        ∏ j ∈ Finset.range N, segRatio γ w (s j) (s (j + 1)) t = γ t - w := by
-      rw [h_telescope, mul_div_cancel₀ _ h_avoid_a]
-    exact polar_form_of_prod (zs := fun j ↦ segRatio γ w (s j) (s (j + 1)) t)
-      h_avoid_a h_ratio_ne h_prod_eq
+  · exact fun t ht => polar_form_of_partition hN_pos hs_zero hs_mono hs_avoid h_seg
+      (by rw [hs_zero]; exact ht.1) (by rw [hs_N]; exact ht.2)
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -370,15 +370,12 @@ private theorem exists_monotone_partition_mesh_lt {a b δ : ℝ} (hab : a ≤ b)
 /-- **The polar form at a point, from the partition data alone.** For a monotone `s` with
 `s 0 = a`, no node sent to `w`, and every segment ratio in the slit plane, any `t` between `s 0`
 and `s N` satisfies `γ t - w = ‖γ t - w‖ · exp (I · θ t)`, where
-`θ t = arg (γ a - w) + ∑_{j < N} (log (segRatio γ w (s j) (s (j+1)) t)).im`.
-
-None of the analytic data behind the partition -- continuity of `γ`, the distance lower bound,
-the uniform modulus, the mesh bound -- takes part. -/
+`θ t = arg (γ a - w) + ∑_{j < N} (log (segRatio γ w (s j) (s (j+1)) t)).im`. -/
 private theorem polar_form_of_partition {γ : ℝ → ℂ} {w : ℂ} {a : ℝ} {N : ℕ} {s : ℕ → ℝ}
     (hN_pos : 0 < N) (hs_zero : s 0 = a) (hs_mono : Monotone s)
-    (hs_avoid : ∀ j ≤ N, γ (s j) - w ≠ 0)
-    (h_seg : ∀ j, j < N → ∀ t, segRatio γ w (s j) (s (j + 1)) t ∈ Complex.slitPlane)
-    {t : ℝ} (h_cov_lo : s 0 ≤ t) (h_cov_hi : t ≤ s N) :
+    (hs_avoid : ∀ j ≤ N, γ (s j) - w ≠ 0) {t : ℝ}
+    (h_ratio_ne : ∀ j < N, segRatio γ w (s j) (s (j + 1)) t ≠ 0)
+    (h_cov_lo : s 0 ≤ t) (h_cov_hi : t ≤ s N) :
     γ t - w = (‖γ t - w‖ : ℂ) * Complex.exp (Complex.I *
       ((Complex.arg (γ a - w) +
         ∑ j ∈ Finset.range N,
@@ -387,14 +384,11 @@ private theorem polar_form_of_partition {γ : ℝ → ℂ} {w : ℂ} {a : ℝ} {
   obtain ⟨k, hk_lt, hk_lo, hk_hi⟩ := exists_covering_segment hN_pos hs_mono h_cov_lo h_cov_hi
   have h_telescope := prod_segRatio_telescope hs_mono hs_avoid hk_lt hk_lo hk_hi
   rw [hs_zero] at h_telescope
-  have h_ratio_ne : ∀ j ∈ Finset.range N,
-      segRatio γ w (s j) (s (j + 1)) t ≠ 0 := fun j hj ↦
-    Complex.slitPlane_ne_zero (h_seg j (Finset.mem_range.mp hj) t)
   have h_prod_eq : (γ a - w) *
       ∏ j ∈ Finset.range N, segRatio γ w (s j) (s (j + 1)) t = γ t - w := by
     rw [h_telescope, mul_div_cancel₀ _ h_avoid_a]
   exact polar_form_of_prod (zs := fun j ↦ segRatio γ w (s j) (s (j + 1)) t)
-    h_avoid_a h_ratio_ne h_prod_eq
+    h_avoid_a (fun j hj ↦ h_ratio_ne j (Finset.mem_range.mp hj)) h_prod_eq
 
 /-! ### Main theorem: argument lift on `[a, b]` -/
 
@@ -445,7 +439,8 @@ theorem exists_continuousOn_arg_lift_with_partition {γ : ℝ → ℂ} {w : ℂ}
       (hs_in j (Finset.mem_range.mp hj).le) (hs_in (j + 1) (Finset.mem_range.mp hj))
       (hs_le j) (hs_mesh j)
   -- Lift property
-  · exact fun t ht => polar_form_of_partition hN_pos hs_zero hs_mono hs_avoid h_seg
+  · exact fun t ht => polar_form_of_partition hN_pos hs_zero hs_mono hs_avoid
+      (fun j hj ↦ Complex.slitPlane_ne_zero (h_seg j hj t))
       (by rw [hs_zero]; exact ht.1) (by rw [hs_N]; exact ht.2)
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -215,7 +215,7 @@ private lemma prod_range_div_complex (a : ℕ → ℂ) (k : ℕ) (ha : ∀ j ≤
     hu 0 (Nat.zero_le k)]
 
 /-- Telescoping product: for `t ∈ [s_k, s_{k+1}]` along a monotone partition
-`s : ℕ → ℝ` with `γ(s_j) ≠ w` for `0 ≤ j ≤ N`, the product
+`s : ℕ → ℝ` with `γ(s_j) ≠ w` for `j < N`, the product
 `∏_{j < N} segRatio γ w (s j) (s (j+1)) t` collapses to `(γ t - w) / (γ (s 0) - w)`.
 
 This is the key identity making `Im(log)` of each `segRatio` add up to a

--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -372,7 +372,9 @@ node `s j` with `j < N` to `w`, any `t` between `s 0` and `s N` satisfies
 `γ t - w = ‖γ t - w‖ · exp (I · θ t)`, where
 `θ t = arg (γ (s 0) - w) + ∑_{j < N} (log (segRatio γ w (s j) (s (j+1)) t)).im`.
 
-For `N = 0` this is the ordinary polar identity at `s 0`, with no hypothesis at all. -/
+For `N = 0` the avoidance hypothesis is vacuous and monotonicity goes unused; the coverage
+bounds still do the work, pinning `t = s 0`, where the conclusion is the ordinary polar
+identity. -/
 private theorem polar_form_of_partition {γ : ℝ → ℂ} {w : ℂ} {N : ℕ} {s : ℕ → ℝ}
     (hs_mono : Monotone s) (hs_avoid : ∀ j < N, γ (s j) - w ≠ 0) {t : ℝ}
     (h_cov_lo : s 0 ≤ t) (h_cov_hi : t ≤ s N) :

--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -221,7 +221,7 @@ private lemma prod_range_div_complex (a : ℕ → ℂ) (k : ℕ) (ha : ∀ j ≤
 This is the key identity making `Im(log)` of each `segRatio` add up to a
 continuous argument lift of `t ↦ γ t - w`. -/
 private theorem prod_segRatio_telescope {γ : ℝ → ℂ} {w : ℂ} {N : ℕ} {s : ℕ → ℝ}
-    (hs_mono : Monotone s) (h_avoid : ∀ j ≤ N, γ (s j) - w ≠ 0)
+    (hs_mono : Monotone s) (h_avoid : ∀ j < N, γ (s j) - w ≠ 0)
     {t : ℝ} {k : ℕ} (hk : k < N) (hk_lo : s k ≤ t) (hk_hi : t ≤ s (k + 1)) :
     ∏ j ∈ Finset.range N, segRatio γ w (s j) (s (j + 1)) t = (γ t - w) / (γ (s 0) - w) := by
   -- Split range N = range (k+1) ∪ Ico (k+1) N
@@ -232,7 +232,7 @@ private theorem prod_segRatio_telescope {γ : ℝ → ℂ} {w : ℂ} {N : ℕ} {
       segRatio γ w (s j) (s (j + 1)) t = 1 := by
     intro j hj
     rw [Finset.mem_Ico] at hj
-    refine segRatio_eq_one_of_le ?_ (h_avoid j hj.2.le)
+    refine segRatio_eq_one_of_le ?_ (h_avoid j hj.2)
     exact hk_hi.trans (hs_mono hj.1)
   rw [Finset.prod_congr rfl h_ico_eq_one, Finset.prod_const_one, mul_one]
   -- Peel off middle term j = k from range (k+1)
@@ -249,10 +249,10 @@ private theorem prod_segRatio_telescope {γ : ℝ → ℂ} {w : ℂ} {N : ℕ} {
   rw [segRatio_eq_div_of_mem_Icc ⟨hk_lo, hk_hi⟩]
   -- Apply telescoping lemma to range k product
   rw [prod_range_div_complex (fun j ↦ γ (s j) - w) k
-        (fun j hj ↦ h_avoid j (hj.trans hk.le))]
+        (fun j hj ↦ h_avoid j (lt_of_le_of_lt hj hk))]
   -- Cancel γ s_k - w
   rw [div_mul_div_comm, mul_comm (γ (s k) - w) (γ t - w),
-      mul_div_mul_right _ _ (h_avoid k hk.le)]
+      mul_div_mul_right _ _ (h_avoid k hk)]
 
 /-! ### Continuous arg-lift summand (continued) -/
 
@@ -373,13 +373,13 @@ and `s N` satisfies `γ t - w = ‖γ t - w‖ · exp (I · θ t)`, where
 `θ t = arg (γ a - w) + ∑_{j < N} (log (segRatio γ w (s j) (s (j+1)) t)).im`. -/
 private theorem polar_form_of_partition {γ : ℝ → ℂ} {w : ℂ} {a : ℝ} {N : ℕ} {s : ℕ → ℝ}
     (hN_pos : 0 < N) (hs_zero : s 0 = a) (hs_mono : Monotone s)
-    (hs_avoid : ∀ j ≤ N, γ (s j) - w ≠ 0) {t : ℝ}
+    (hs_avoid : ∀ j < N, γ (s j) - w ≠ 0) {t : ℝ}
     (h_cov_lo : s 0 ≤ t) (h_cov_hi : t ≤ s N) :
     γ t - w = (‖γ t - w‖ : ℂ) * Complex.exp (Complex.I *
       ((Complex.arg (γ a - w) +
         ∑ j ∈ Finset.range N,
           (Complex.log (segRatio γ w (s j) (s (j + 1)) t)).im : ℝ) : ℂ)) := by
-  have h_avoid_a : γ a - w ≠ 0 := hs_zero ▸ hs_avoid 0 (Nat.zero_le N)
+  have h_avoid_a : γ a - w ≠ 0 := hs_zero ▸ hs_avoid 0 hN_pos
   obtain ⟨k, hk_lt, hk_lo, hk_hi⟩ := exists_covering_segment hN_pos hs_mono h_cov_lo h_cov_hi
   have h_telescope := prod_segRatio_telescope hs_mono hs_avoid hk_lt hk_lo hk_hi
   rw [hs_zero] at h_telescope
@@ -425,16 +425,12 @@ theorem exists_continuousOn_arg_lift_with_partition {γ : ℝ → ℂ} {w : ℂ}
   have hs_avoid : ∀ j ≤ N, γ (s j) - w ≠ 0 := fun j hj ↦
     sub_ne_zero.mpr (h_avoid (s j) (hs_in j hj))
   have hs_le : ∀ j, s j ≤ s (j + 1) := fun j ↦ hs_mono (Nat.le_succ _)
-  -- both the `slitPlane` conclusion and the nonvanishing the telescoping product needs read
-  -- off this one fact
-  have h_seg : ∀ j, j < N → ∀ t, segRatio γ w (s j) (s (j + 1)) t ∈ Complex.slitPlane :=
-    fun j hj ↦ segRatio_mem_slitPlane hρ_pos h_dist_lb h_unif
-      (hs_in j hj.le) (hs_in (j + 1) hj) (hs_le j) (hs_mesh j)
   have h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
       (γ t - w) / (γ (s j) - w) ∈ Complex.slitPlane := by
     intro j hj t ht
     rw [← segRatio_eq_div_of_mem_Icc ht]
-    exact h_seg j hj t
+    exact segRatio_mem_slitPlane hρ_pos h_dist_lb h_unif
+      (hs_in j hj.le) (hs_in (j + 1) hj) (hs_le j) (hs_mesh j) t
   refine ⟨N, s, hN_pos, hs_zero, hs_N, hs_mono, hs_in, hs_avoid, h_slit, ?_, ?_⟩
   -- Continuity of θ
   · refine ContinuousOn.add continuousOn_const ?_
@@ -444,7 +440,8 @@ theorem exists_continuousOn_arg_lift_with_partition {γ : ℝ → ℂ} {w : ℂ}
       (hs_in j (Finset.mem_range.mp hj).le) (hs_in (j + 1) (Finset.mem_range.mp hj))
       (hs_le j) (hs_mesh j)
   -- Lift property
-  · exact fun t ht => polar_form_of_partition hN_pos hs_zero hs_mono hs_avoid
+  · exact fun t ht => polar_form_of_partition hN_pos hs_zero hs_mono
+      (fun j hj ↦ hs_avoid j hj.le)
       (by rw [hs_zero]; exact ht.1) (by rw [hs_N]; exact ht.2)
 
 end TauCeti.Contour


### PR DESCRIPTION
`exists_continuousOn_arg_lift_with_partition` carried a 43-line proof. Its last sixteen lines
derive the polar form at a point from the partition just built — a step that uses none of the
analytic input the theorem assumes. Name it. No statement changes; no new public declaration.

## The extracted helper

```lean
private theorem polar_form_of_partition {γ : ℝ → ℂ} {w : ℂ} {N : ℕ} {s : ℕ → ℝ}
    (hs_mono : Monotone s) (hs_avoid : ∀ j < N, γ (s j) - w ≠ 0) {t : ℝ}
    (h_cov_lo : s 0 ≤ t) (h_cov_hi : t ≤ s N) :
    γ t - w = (‖γ t - w‖ : ℂ) * Complex.exp (Complex.I *
      ((Complex.arg (γ (s 0) - w) + ∑ j ∈ Finset.range N, …) : ℂ))
```

The caller supplies `ContinuousOn γ (Icc a b)`, the distance lower bound `ρ ≤ ‖γ t - w‖`, the
uniform modulus, the mesh bound `s (j+1) - s j < δ'`, `a ≤ b`, and `∀ t ∈ Icc a b, γ t ≠ w`.
The helper takes none of them, and successive review rounds pared it back six times:

* `γ a - w ≠ 0` — it is `hs_avoid 0`.
* slit-plane membership of the segment ratios — only their nonvanishing was ever used.
* the nonvanishing itself — where `γ t = w` the conclusion is `0 = 0`, and elsewhere the
  telescoping identity exhibits the product as the nonzero `γ t - w` over the nonzero first
  factor, so no factor can vanish.
* avoidance at the right endpoint — `segRatio` puts only its first index in a denominator and
  the product runs over `Finset.range N`, so `γ (s N) ≠ w` is never needed. (This also weakens
  `prod_segRatio_telescope`, private with this proof as its only consumer.)
* the basepoint `a` and `hs_zero : s 0 = a` — `a` occurred only inside `arg (γ a - w)`, so the
  statement is about `γ (s 0) - w` and the caller rewrites once.
* `0 < N` — with `N = 0` the coverage hypotheses pin `t = s 0` and the sum is empty, leaving
  `Complex.norm_mul_exp_arg_mul_I`, which holds at `0` too. The degenerate partition needs no
  hypothesis at all.

What survives is: `s` monotone, no node `s j` with `j < N` sent to `w`, and `t` between `s 0`
and `s N`.

## Result

| | before | after |
|---|---|---|
| `exists_continuousOn_arg_lift_with_partition` | 43 | 25 |
| `polar_form_of_partition` | — | 19 |

Gates run on `c844060e`: `lake build` (7782 jobs), `lake exe axioms` (44278 declarations),
`lake exe module-system` (2122 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: ContourIntegration