### PR TITLE
refactor(ModularForms): use QuotientGroup.eq in Cusps

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Cusps.lean
+++ b/TauCeti/NumberTheory/ModularForms/Cusps.lean
@@ -105,7 +105,7 @@ reference to the group action. -/
 lemma Subgroup.mk_T_pow_eq_iff {n : ℕ} :
     (⟦(mapGL ℝ).rangeRestrict ((ModularGroup.T : SL(2, ℤ)))^n⟧ :
         𝒮ℒ ⧸ (𝒢.subgroupOf 𝒮ℒ)) = ⟦1⟧ ↔ (n : ℝ) ∈ 𝒢.strictPeriods := by
-  rw [Quotient.eq, QuotientGroup.leftRel_apply]
+  rw [QuotientGroup.eq]
   simp only [mul_one, inv_mem_iff, Subgroup.mem_subgroupOf,
     MonoidHom.coe_rangeRestrict, ← map_pow, ModularGroup.mapGL_T_pow_eq_upperRightHom,
     Subgroup.mem_strictPeriods_iff]
@@ -120,7 +120,7 @@ lemma Subgroup.exists_pos_nat_mem_strictPeriods (𝒢 : Subgroup (GL (Fin 2) ℝ
     (Subgroup.FiniteIndex.index_ne_zero (H := (𝒢 : Subgroup (GL (Fin 2) ℝ)).subgroupOf 𝒮ℒ))
     ((mapGL ℝ).rangeRestrict ModularGroup.T)
   refine ⟨n, hn_pos, Subgroup.mk_T_pow_eq_iff.mp ?_⟩
-  rw [Quotient.eq, QuotientGroup.leftRel_apply]
+  rw [QuotientGroup.eq]
   simpa using inv_mem hn_mem
 
 omit [𝒢.IsFiniteRelIndex 𝒮ℒ] in


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke/quotientgroup-eq-sweep"}-->

Refactor of existing code — no new declaration, no statement changed. Two tactic lines.

## The change

`ModularForms/Cusps.lean` reaches coset equality twice via

```lean
rw [Quotient.eq, QuotientGroup.leftRel_apply]
```

`QuotientGroup.eq` **is** that composite — mathlib proves it by `rw [leftRel_apply]` after
`Quotient.eq` — so opening the relation by hand redoes mathlib's own one-line proof. Both sites
become `rw [QuotientGroup.eq]`.

## Why now, and why only these two

#3122 promoted `DoubleCoset.conj_mem_of_mk_eq` and swept the same anti-pattern out of
`ModularForms/NormTrace.lean`, but deliberately stopped there: a `git grep` found twelve
`QuotientGroup.leftRel_apply` sites repo-wide and most are **not** the same edit. That PR said so
explicitly, and this one finishes only the part that is.

Left alone, with reasons:

* `ModularForms/Petersson/Unitary.lean:73,78` — `rw [… ] at hab ⊢`, rewriting a *hypothesis* in
  the relation form, not producing a coset equality;
* `RepresentationTheory/Induction/Character.lean:57` — paired with `rightRel_apply`, a different
  relation;
* `RepresentationTheory/Induction/Mackey/Basic.lean:110,114`,
  `Induction/Permutation.lean:128`, `Induction/ClassFunction.lean:237`,
  `Algebra/Order/Group/ConvexSubgroup.lean:625,627`,
  `HeckeRing/StabConjugation.lean:58`, `HeckeRing/LeftCosetModule/Basic.lean:78` — either inside
  a larger `simp only` set, or consuming the relation rather than establishing an equality, and
  all outside this lane. Mechanical similarity is not licence to sweep them.

## Provenance

No port; this is a local simplification against mathlib's `QuotientGroup.eq`.

Roadmap: ModularForms
