### PR TITLE
feat: the integer character of a Specht module and the character table of Sₙ

### DIFF
--- a/TauCeti/LinearAlgebra/End/FiniteOrder.lean
+++ b/TauCeti/LinearAlgebra/End/FiniteOrder.lean
@@ -7,11 +7,14 @@ module
 
 public import Mathlib.Algebra.DirectSum.LinearMap
 public import Mathlib.Analysis.Complex.Polynomial.Basic
+public import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
 public import Mathlib.FieldTheory.IsAlgClosed.Spectrum
 public import Mathlib.FieldTheory.Separable
 public import Mathlib.LinearAlgebra.Eigenspace.Charpoly
 public import Mathlib.LinearAlgebra.Eigenspace.Minpoly
 public import Mathlib.LinearAlgebra.Eigenspace.Semisimple
+public import Mathlib.LinearAlgebra.Trace
+public import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
 
 /-!
 # Endomorphisms of finite order
@@ -20,6 +23,13 @@ An endomorphism `f` of a vector space with `f ^ n = 1` is annihilated by `X ^ n 
 consequences are recorded here: every root of its characteristic polynomial is an `n`-th root of
 unity, and if `n` is invertible in the coefficient field then `f` is semisimple, because `X ^ n - 1`
 is then squarefree.
+
+The roots of unity are algebraic integers, so as soon as the characteristic polynomial splits the
+trace, being the sum of those roots, is one too. Splitting is not a real hypothesis: base change to
+an algebraic closure leaves the trace alone beyond transporting it along the field embedding
+(`LinearMap.trace_baseChange`), and an element of the base field whose image is integral over `ℤ`
+was already integral over `ℤ`. So the trace of an endomorphism of finite order is an algebraic
+integer over **any** field.
 
 Over an algebraically closed field semisimplicity is diagonalizability, so the eigenspaces of such
 an `f` decompose the space. Every power of `f` acts on the `μ`-eigenspace as the scalar `μ ^ m`,
@@ -40,6 +50,8 @@ All the results are stated of `Module.End`, so they sit in the `End` namespace u
   an endomorphism of finite order `n` are `n`-th roots of unity.
 * `TauCeti.End.isSemisimple_of_pow_eq_one`: an endomorphism of finite order `n`, with `n`
   invertible in the field, is semisimple.
+* `TauCeti.End.isIntegral_trace_of_pow_eq_one`: over any field, the trace of an endomorphism of
+  finite order is integral over `ℤ`.
 * `TauCeti.End.trace_pow_eq_sum_eigenvalue_pow`: over an algebraically closed field, the trace of
   `f ^ m` is the sum of the `m`-th powers of the eigenvalues of `f`, weighted by the dimensions of
   the eigenspaces.
@@ -72,6 +84,30 @@ theorem pow_eq_one_of_isRoot_charpoly {f : End k V} {n : ℕ} (hf : f ^ n = 1) {
   · have hpow := spectrum.pow_mem_pow f n hspec
     rw [hf, spectrum.one_eq] at hpow
     simpa using hpow
+
+/-- **The trace of an endomorphism of finite order is an algebraic integer**, once its
+characteristic polynomial splits: the trace is then the sum of the roots, and each of those is an
+`n`-th root of unity. -/
+theorem isIntegral_trace_of_pow_eq_one_of_splits {f : End k V} {n : ℕ} (hn : n ≠ 0)
+    (hf : f ^ n = 1) (hsplits : f.charpoly.Splits) : IsIntegral ℤ (LinearMap.trace k V f) := by
+  rw [Module.End.trace_eq_sum_roots_charpoly_of_splits hsplits]
+  refine IsIntegral.multiset_sum fun μ hμ => IsIntegral.of_pow (Nat.pos_of_ne_zero hn) ?_
+  rw [pow_eq_one_of_isRoot_charpoly hf (isRoot_of_mem_roots hμ)]
+  exact isIntegral_one
+
+/-- **The trace of an endomorphism of finite order is an algebraic integer**, over an arbitrary
+field. The splitting hypothesis of `TauCeti.End.isIntegral_trace_of_pow_eq_one_of_splits` is
+removed by base change to an algebraic closure: base change preserves both the order of `f` and,
+up to the field embedding, its trace, and an element of `k` whose image in the closure is integral
+over `ℤ` is itself integral over `ℤ`. -/
+theorem isIntegral_trace_of_pow_eq_one {f : End k V} {n : ℕ} (hn : n ≠ 0) (hf : f ^ n = 1) :
+    IsIntegral ℤ (LinearMap.trace k V f) := by
+  have hbase : f.baseChange (AlgebraicClosure k) ^ n = 1 := by
+    rw [← LinearMap.baseChange_pow, hf, LinearMap.baseChange_one]
+  have hint := isIntegral_trace_of_pow_eq_one_of_splits (k := AlgebraicClosure k) hn hbase
+    (IsAlgClosed.splits _)
+  rw [LinearMap.trace_baseChange] at hint
+  exact hint.tower_bot (algebraMap k (AlgebraicClosure k)).injective
 
 omit [FiniteDimensional k V] in
 /-- An endomorphism `f` with `f ^ n = 1` for some `n` invertible in `k` is semisimple, because it

--- a/TauCeti/LinearAlgebra/End/FiniteOrder.lean
+++ b/TauCeti/LinearAlgebra/End/FiniteOrder.lean
@@ -85,10 +85,11 @@ theorem pow_eq_one_of_isRoot_charpoly {f : End k V} {n : ℕ} (hf : f ^ n = 1) {
     rw [hf, spectrum.one_eq] at hpow
     simpa using hpow
 
-/-- **The trace of an endomorphism of finite order is an algebraic integer**, once its
-characteristic polynomial splits: the trace is then the sum of the roots, and each of those is an
-`n`-th root of unity. -/
-theorem isIntegral_trace_of_pow_eq_one_of_splits {f : End k V} {n : ℕ} (hn : n ≠ 0)
+/-- The trace of an endomorphism of finite order is an algebraic integer once its characteristic
+polynomial splits: the trace is then the sum of the roots, and each of those is an `n`-th root of
+unity. This is the splitting case of `TauCeti.End.isIntegral_trace_of_pow_eq_one`, which subsumes
+it, so it stays private. -/
+private theorem isIntegral_trace_of_pow_eq_one_of_splits {f : End k V} {n : ℕ} (hn : n ≠ 0)
     (hf : f ^ n = 1) (hsplits : f.charpoly.Splits) : IsIntegral ℤ (LinearMap.trace k V f) := by
   rw [Module.End.trace_eq_sum_roots_charpoly_of_splits hsplits]
   refine IsIntegral.multiset_sum fun μ hμ => IsIntegral.of_pow (Nat.pos_of_ne_zero hn) ?_
@@ -96,10 +97,10 @@ theorem isIntegral_trace_of_pow_eq_one_of_splits {f : End k V} {n : ℕ} (hn : n
   exact isIntegral_one
 
 /-- **The trace of an endomorphism of finite order is an algebraic integer**, over an arbitrary
-field. The splitting hypothesis of `TauCeti.End.isIntegral_trace_of_pow_eq_one_of_splits` is
-removed by base change to an algebraic closure: base change preserves both the order of `f` and,
-up to the field embedding, its trace, and an element of `k` whose image in the closure is integral
-over `ℤ` is itself integral over `ℤ`. -/
+field. When the characteristic polynomial splits the trace is a sum of roots of unity; that
+splitting hypothesis is removed by base change to an algebraic closure, which preserves both the
+order of `f` and, up to the field embedding, its trace, and an element of `k` whose image in the
+closure is integral over `ℤ` is itself integral over `ℤ`. -/
 theorem isIntegral_trace_of_pow_eq_one {f : End k V} {n : ℕ} (hn : n ≠ 0) (hf : f ^ n = 1) :
     IsIntegral ℤ (LinearMap.trace k V f) := by
   have hbase : f.baseChange (AlgebraicClosure k) ^ n = 1 := by

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -6,6 +6,7 @@ Authors: Claude
 module
 
 public import TauCeti.LinearAlgebra.End.FiniteOrder
+public import Mathlib.Algebra.GCDMonoid.IntegrallyClosed
 public import Mathlib.RepresentationTheory.Character
 public import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
 
@@ -24,6 +25,13 @@ unity, is bounded in absolute value by the degree `χ(1)`, and is conjugated by 
 element, since conjugation inverts roots of unity. The endomorphism `ρ g` is moreover semisimple as
 soon as `n` is invertible in the coefficient field, since `X ^ n - 1` is then squarefree.
 
+Integrality needs no splitting hypothesis, because base change to an algebraic closure transports
+the character value along the field embedding; that reduction is
+`TauCeti.End.isIntegral_trace_of_pow_eq_one`. Over `ℚ` it gives more than integrality over `ℤ`: a
+rational algebraic integer is an integer, so a rational character is **integer-valued**. That is
+what makes the character table of a group with rational representations, the symmetric group for
+instance, a matrix of integers.
+
 The facts about `ρ g` as a bare endomorphism live in `TauCeti.LinearAlgebra.End.FiniteOrder`.
 
 The conjugation identity `conj (χ g) = χ g⁻¹` also holds for a unitary representation of a
@@ -37,7 +45,12 @@ representation of a group, from the eigenvalues alone, with no invariant inner p
   `(ρ g).charpoly` splits, a character value is a sum of `finrank` many `n`-th roots of unity. The
   variant `TauCeti.Representation.exists_multiset_rootsOfUnity_char_eq_sum` specializes it to an
   algebraically closed field.
-* `TauCeti.FDRep.isIntegral_char`: **character values are algebraic integers**.
+* `TauCeti.Representation.isIntegral_char` and `TauCeti.FDRep.isIntegral_char`: **character values
+  are algebraic integers**, over an arbitrary field.
+* `TauCeti.Representation.exists_intCast_eq_character` and
+  `TauCeti.FDRep.exists_intCast_eq_character`: **a rational character is integer-valued**.
+* `TauCeti.FDRep.intCharacter`: the resulting `ℤ`-valued character of a rational representation of
+  a finite group, a class function taking the degree at the identity.
 * `TauCeti.FDRep.char_mem_adjoin_of_isPrimitiveRoot`: over `ℂ` they lie in `ℤ[ζ_e]`, for `ζ_e`
   a primitive root of unity of order the exponent of the group.
 * `TauCeti.FDRep.norm_char_le_finrank`: over `ℂ`, `‖χ(g)‖ ≤ χ(1)`.
@@ -113,25 +126,30 @@ theorem isSemisimple_of_pow_eq_one (ρ : Representation k G V) {g : G} {n : ℕ}
     (hg : g ^ n = 1) : End.IsSemisimple (ρ g) :=
   End.isSemisimple_of_pow_eq_one hn (by rw [← map_pow, hg, map_one])
 
-/-- **Character values are algebraic integers**: if the characteristic polynomial of `ρ g` splits,
-the value of a character at an element `g` of finite order is integral over `ℤ`, being a sum of
-roots of unity. -/
-theorem isIntegral_char_of_splits (ρ : Representation k G V) {g : G} {n : ℕ}
-    (hsplits : (ρ g).charpoly.Splits) (hn : n ≠ 0) (hg : g ^ n = 1) :
-    IsIntegral ℤ (ρ.character g) := by
-  obtain ⟨s, -, hroot, hsum⟩ := exists_multiset_rootsOfUnity_char_eq_sum_of_splits ρ hsplits hg
-  rw [hsum]
-  refine IsIntegral.multiset_sum fun μ hμ => IsIntegral.of_pow (Nat.pos_of_ne_zero hn) ?_
-  rw [hroot μ hμ]
-  exact isIntegral_one
-
-/-- **Character values are algebraic integers**: over an algebraically closed field, the value of a
-character at an element of finite order is integral over `ℤ`, being a sum of roots of unity. -/
-theorem isIntegral_char [IsAlgClosed k] (ρ : Representation k G V) {g : G} {n : ℕ}
+/-- **Character values are algebraic integers**: over any field, the value of a character at an
+element of finite order is integral over `ℤ`. Once the characteristic polynomial of `ρ g` splits
+this is the statement that a sum of roots of unity is an algebraic integer, and the general case
+follows from that one by base change to an algebraic closure
+(`TauCeti.End.isIntegral_trace_of_pow_eq_one`). -/
+theorem isIntegral_char (ρ : Representation k G V) {g : G} {n : ℕ}
     (hn : n ≠ 0) (hg : g ^ n = 1) : IsIntegral ℤ (ρ.character g) :=
-  isIntegral_char_of_splits ρ (IsAlgClosed.splits _) hn hg
+  End.isIntegral_trace_of_pow_eq_one hn (show ρ g ^ n = 1 by rw [← map_pow, hg, map_one])
 
 end Field
+
+section Rat
+
+variable {G : Type v} {V : Type w} [Monoid G] [AddCommGroup V] [Module ℚ V] [FiniteDimensional ℚ V]
+
+/-- **A rational character value is an integer.** The character of a representation over `ℚ` takes
+at an element of finite order a value that is integral over `ℤ`, and `ℤ` is integrally closed in
+its fraction field `ℚ`, so that value is the cast of an integer. -/
+theorem exists_intCast_eq_character (ρ : Representation ℚ G V) {g : G} {n : ℕ} (hn : n ≠ 0)
+    (hg : g ^ n = 1) : ∃ m : ℤ, (m : ℚ) = ρ.character g := by
+  obtain ⟨m, hm⟩ := IsIntegrallyClosed.isIntegral_iff.1 (isIntegral_char ρ hn hg)
+  exact ⟨m, by simpa using hm⟩
+
+end Rat
 
 section Group
 
@@ -212,6 +230,49 @@ of a finite-dimensional complex representation is integral over `ℤ`. -/
 theorem isIntegral_char (V : FDRep ℂ G) (g : G) : IsIntegral ℤ (V.character g) :=
   Representation.isIntegral_char V.ρ (isOfFinOrder_of_finite g).orderOf_pos.ne'
     (pow_orderOf_eq_one g)
+
+/-- **A rational character is integer-valued.** For a finite group, every value of the character of
+a finite-dimensional representation over `ℚ` is the cast of an integer. -/
+theorem exists_intCast_eq_character (V : FDRep ℚ G) (g : G) : ∃ m : ℤ, (m : ℚ) = V.character g :=
+  Representation.exists_intCast_eq_character V.ρ (isOfFinOrder_of_finite g).orderOf_pos.ne'
+    (pow_orderOf_eq_one g)
+
+/-- **The integer character** of a rational representation of a finite group: the character value
+`V.character g` is the cast of an integer (`TauCeti.FDRep.exists_intCast_eq_character`), and this is
+that integer, extracted as the numerator of the rational value. Read it only through
+`TauCeti.FDRep.intCharacter_cast`, which is what pins it down; the numerator is a way of naming the
+integer, not extra information.
+
+Being in the `TauCeti.FDRep` namespace rather than the root one, it is not available through dot
+notation on an `FDRep ℚ G`, and is written `intCharacter V g` throughout. -/
+noncomputable def intCharacter (V : FDRep ℚ G) (g : G) : ℤ := (V.character g).num
+
+omit [Finite G] in
+theorem intCharacter_def (V : FDRep ℚ G) (g : G) : intCharacter V g = (V.character g).num := (rfl)
+
+/-- **The integer character casts back to the character.** -/
+@[simp]
+theorem intCharacter_cast (V : FDRep ℚ G) (g : G) : (intCharacter V g : ℚ) = V.character g := by
+  obtain ⟨m, hm⟩ := exists_intCast_eq_character V g
+  rw [intCharacter_def, ← hm, Rat.num_intCast]
+
+/-- Representations with the same character have the same integer character. -/
+theorem intCharacter_eq_of_character_eq {V W : FDRep ℚ G} (h : V.character = W.character) :
+    intCharacter V = intCharacter W := by
+  funext g
+  exact Int.cast_injective (α := ℚ) (by rw [intCharacter_cast, intCharacter_cast, h])
+
+/-- **The integer character is a class function.** -/
+theorem intCharacter_conj (V : FDRep ℚ G) (g h : G) :
+    intCharacter V (h * g * h⁻¹) = intCharacter V g :=
+  Int.cast_injective (α := ℚ)
+    (by rw [intCharacter_cast, intCharacter_cast, _root_.FDRep.char_conj])
+
+/-- **The integer character at the identity is the degree.** -/
+@[simp]
+theorem intCharacter_one (V : FDRep ℚ G) : intCharacter V 1 = Module.finrank ℚ V :=
+  Int.cast_injective (α := ℚ)
+    (by rw [intCharacter_cast, _root_.FDRep.char_one]; push_cast; ring)
 
 /-- **Character values are cyclotomic integers.** For a finite group of exponent `e` and a
 primitive `e`-th root of unity `ζ`, every value of a complex character lies in `ℤ[ζ]`. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -6,6 +6,7 @@ Authors: Claude
 module
 
 public import TauCeti.LinearAlgebra.End.FiniteOrder
+public import TauCeti.RepresentationTheory.CharacterTable.ClassFunction
 public import Mathlib.Algebra.GCDMonoid.IntegrallyClosed
 public import Mathlib.RepresentationTheory.Character
 public import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
@@ -47,10 +48,11 @@ representation of a group, from the eigenvalues alone, with no invariant inner p
   algebraically closed field.
 * `TauCeti.Representation.isIntegral_char` and `TauCeti.FDRep.isIntegral_char`: **character values
   are algebraic integers**, over an arbitrary field.
-* `TauCeti.Representation.exists_intCast_eq_character` and
-  `TauCeti.FDRep.exists_intCast_eq_character`: **a rational character is integer-valued**.
+* `TauCeti.Representation.exists_char_eq_intCast` and `TauCeti.FDRep.exists_char_eq_intCast`:
+  **a rational character is integer-valued**.
 * `TauCeti.FDRep.intCharacter`: the resulting `ℤ`-valued character of a rational representation of
-  a finite group, a class function taking the degree at the identity.
+  a finite group, taking the degree at the identity, and `TauCeti.FDRep.intClassFunction`: the same
+  character read as an element of `TauCeti.ClassFunction ℤ G`.
 * `TauCeti.FDRep.char_mem_adjoin_of_isPrimitiveRoot`: over `ℂ` they lie in `ℤ[ζ_e]`, for `ζ_e`
   a primitive root of unity of order the exponent of the group.
 * `TauCeti.FDRep.norm_char_le_finrank`: over `ℂ`, `‖χ(g)‖ ≤ χ(1)`.
@@ -132,8 +134,9 @@ this is the statement that a sum of roots of unity is an algebraic integer, and 
 follows from that one by base change to an algebraic closure
 (`TauCeti.End.isIntegral_trace_of_pow_eq_one`). -/
 theorem isIntegral_char (ρ : Representation k G V) {g : G} {n : ℕ}
-    (hn : n ≠ 0) (hg : g ^ n = 1) : IsIntegral ℤ (ρ.character g) :=
-  End.isIntegral_trace_of_pow_eq_one hn (show ρ g ^ n = 1 by rw [← map_pow, hg, map_one])
+    (hn : n ≠ 0) (hg : g ^ n = 1) : IsIntegral ℤ (ρ.character g) := by
+  have hf : ρ g ^ n = 1 := by rw [← map_pow, hg, map_one]
+  exact End.isIntegral_trace_of_pow_eq_one hn hf
 
 end Field
 
@@ -144,10 +147,10 @@ variable {G : Type v} {V : Type w} [Monoid G] [AddCommGroup V] [Module ℚ V] [F
 /-- **A rational character value is an integer.** The character of a representation over `ℚ` takes
 at an element of finite order a value that is integral over `ℤ`, and `ℤ` is integrally closed in
 its fraction field `ℚ`, so that value is the cast of an integer. -/
-theorem exists_intCast_eq_character (ρ : Representation ℚ G V) {g : G} {n : ℕ} (hn : n ≠ 0)
-    (hg : g ^ n = 1) : ∃ m : ℤ, (m : ℚ) = ρ.character g := by
+theorem exists_char_eq_intCast (ρ : Representation ℚ G V) {g : G} {n : ℕ} (hn : n ≠ 0)
+    (hg : g ^ n = 1) : ∃ m : ℤ, ρ.character g = (m : ℚ) := by
   obtain ⟨m, hm⟩ := IsIntegrallyClosed.isIntegral_iff.1 (isIntegral_char ρ hn hg)
-  exact ⟨m, by simpa using hm⟩
+  exact ⟨m, by simpa using hm.symm⟩
 
 end Rat
 
@@ -226,19 +229,20 @@ namespace FDRep
 variable {G : Type v} [Group G] [Finite G]
 
 /-- **Character values are algebraic integers.** For a finite group, every value of the character
-of a finite-dimensional complex representation is integral over `ℤ`. -/
-theorem isIntegral_char (V : FDRep ℂ G) (g : G) : IsIntegral ℤ (V.character g) :=
+of a finite-dimensional representation over any field is integral over `ℤ`. -/
+theorem isIntegral_char {k : Type u} [Field k] (V : FDRep k G) (g : G) :
+    IsIntegral ℤ (V.character g) :=
   Representation.isIntegral_char V.ρ (isOfFinOrder_of_finite g).orderOf_pos.ne'
     (pow_orderOf_eq_one g)
 
 /-- **A rational character is integer-valued.** For a finite group, every value of the character of
 a finite-dimensional representation over `ℚ` is the cast of an integer. -/
-theorem exists_intCast_eq_character (V : FDRep ℚ G) (g : G) : ∃ m : ℤ, (m : ℚ) = V.character g :=
-  Representation.exists_intCast_eq_character V.ρ (isOfFinOrder_of_finite g).orderOf_pos.ne'
+theorem exists_char_eq_intCast (V : FDRep ℚ G) (g : G) : ∃ m : ℤ, V.character g = (m : ℚ) :=
+  Representation.exists_char_eq_intCast V.ρ (isOfFinOrder_of_finite g).orderOf_pos.ne'
     (pow_orderOf_eq_one g)
 
 /-- **The integer character** of a rational representation of a finite group: the character value
-`V.character g` is the cast of an integer (`TauCeti.FDRep.exists_intCast_eq_character`), and this is
+`V.character g` is the cast of an integer (`TauCeti.FDRep.exists_char_eq_intCast`), and this is
 that integer, extracted as the numerator of the rational value. Read it only through
 `TauCeti.FDRep.intCharacter_cast`, which is what pins it down; the numerator is a way of naming the
 integer, not extra information.
@@ -248,31 +252,45 @@ notation on an `FDRep ℚ G`, and is written `intCharacter V g` throughout. -/
 noncomputable def intCharacter (V : FDRep ℚ G) (g : G) : ℤ := (V.character g).num
 
 omit [Finite G] in
-theorem intCharacter_def (V : FDRep ℚ G) (g : G) : intCharacter V g = (V.character g).num := (rfl)
+private theorem intCharacter_def (V : FDRep ℚ G) (g : G) :
+    intCharacter V g = (V.character g).num := (rfl)
 
 /-- **The integer character casts back to the character.** -/
 @[simp]
 theorem intCharacter_cast (V : FDRep ℚ G) (g : G) : (intCharacter V g : ℚ) = V.character g := by
-  obtain ⟨m, hm⟩ := exists_intCast_eq_character V g
-  rw [intCharacter_def, ← hm, Rat.num_intCast]
+  obtain ⟨m, hm⟩ := exists_char_eq_intCast V g
+  rw [intCharacter_def, hm, Rat.num_intCast]
 
-/-- Representations with the same character have the same integer character. -/
-theorem intCharacter_eq_of_character_eq {V W : FDRep ℚ G} (h : V.character = W.character) :
-    intCharacter V = intCharacter W := by
-  funext g
-  exact Int.cast_injective (α := ℚ) (by rw [intCharacter_cast, intCharacter_cast, h])
+/-- **The integer character carries exactly the information of the rational one**: this is the
+elimination principle for `TauCeti.FDRep.intCharacter`, an integer equation between its values
+being the corresponding equation between character values. -/
+theorem intCharacter_eq_iff {V W : FDRep ℚ G} {g h : G} :
+    intCharacter V g = intCharacter W h ↔ V.character g = W.character h := by
+  rw [← Int.cast_inj (α := ℚ), intCharacter_cast, intCharacter_cast]
 
 /-- **The integer character is a class function.** -/
+@[simp]
 theorem intCharacter_conj (V : FDRep ℚ G) (g h : G) :
     intCharacter V (h * g * h⁻¹) = intCharacter V g :=
-  Int.cast_injective (α := ℚ)
-    (by rw [intCharacter_cast, intCharacter_cast, _root_.FDRep.char_conj])
+  intCharacter_eq_iff.2 (_root_.FDRep.char_conj V g h)
+
+/-- **The integer character of a rational representation, as a class function.** -/
+noncomputable def intClassFunction (V : FDRep ℚ G) : ClassFunction ℤ G :=
+  ⟨intCharacter V, ClassFunction.mem_iff.2 (intCharacter_conj V)⟩
+
+@[simp]
+theorem intClassFunction_apply (V : FDRep ℚ G) (g : G) :
+    (intClassFunction V).1 g = intCharacter V g := (rfl)
+
+/-- Conjugate elements have the same integer character. -/
+theorem intCharacter_eq_of_isConj (V : FDRep ℚ G) {g h : G} (hgh : IsConj g h) :
+    intCharacter V g = intCharacter V h :=
+  ClassFunction.eq_of_isConj (intClassFunction V) hgh
 
 /-- **The integer character at the identity is the degree.** -/
 @[simp]
 theorem intCharacter_one (V : FDRep ℚ G) : intCharacter V 1 = Module.finrank ℚ V :=
-  Int.cast_injective (α := ℚ)
-    (by rw [intCharacter_cast, _root_.FDRep.char_one]; push_cast; ring)
+  Int.cast_injective (α := ℚ) (by simp)
 
 /-- **Character values are cyclotomic integers.** For a finite group of exponent `e` and a
 primitive `e`-th root of unity `ζ`, every value of a complex character lies in `ℤ[ζ]`. -/

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Character.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Character.lean
@@ -32,12 +32,15 @@ column of the identity holds the degrees.
 The general half of the argument is stated for an arbitrary rational representation of a finite
 group, as `TauCeti.FDRep.intCharacter`, and is what this file specializes. Nothing here computes
 an entry of the table: the recursion that does is the Murnaghan--Nakayama rule, which needs rim
-hooks and is not proved here.
+hooks and is not proved here. Neither is `symmetricCharacterTable n` compared with the library's
+general `TauCeti.characterTable k G`, which lives over an algebraically closed field and enumerates
+its rows by `Fin (Nat.card (ConjClasses G))`, nor is any of the table properties that one carries —
+the orthogonality relations, the specification `TauCeti.IsCharacterTableSpec` — proved for it.
 
 ## Main definitions
 
 * `TauCeti.spechtChar`: the `ℤ`-valued character `χ^μ` of the Specht module `S^μ`.
-* `TauCeti.spechtCharClass`: its descent to the conjugacy classes of `Sₙ`.
+* `TauCeti.spechtCharConjClasses`: its descent to the conjugacy classes of `Sₙ`.
 * `TauCeti.spechtCharValue`: its value on the class of cycle type `ν`.
 * `TauCeti.symmetricCharacterTable`: the character table of `Sₙ`, a
   `Matrix (Nat.Partition n) (Nat.Partition n) ℤ`.
@@ -46,10 +49,12 @@ hooks and is not proved here.
 
 * `TauCeti.spechtChar_cast`: the integer character casts to the rational character of `S^μ`.
 * `TauCeti.spechtChar_eq_of_partition_eq`: it depends only on the cycle type.
-* `TauCeti.spechtChar_eq_value`: it is read off the character table.
-* `TauCeti.character_spechtModule_eq_intCast`: conversely the table recovers the rational
+* `TauCeti.spechtChar_one`: the value at the identity is the degree `dim_ℚ S^μ`.
+* `TauCeti.spechtChar_one_pos`: that degree is positive.
+* `TauCeti.spechtChar_eq_value`: the character is read off the character table.
+* `TauCeti.intCast_symmetricCharacterTable_apply`: conversely the table recovers the rational
   character, so no information is lost in passing to `ℤ`.
-* `TauCeti.spechtChar_one`: the value at the identity is the degree `dim_ℚ S^μ`, which is positive.
+* `TauCeti.symmetricCharacterTable_one`: the column of the identity class holds the degrees.
 
 ## References
 
@@ -85,24 +90,16 @@ theorem spechtChar_cast (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
     (spechtChar μ σ : ℚ) = (spechtModule μ).character σ := by
   rw [spechtChar_def, FDRep.intCharacter_cast]
 
-/-- The integer character carries exactly the information of the rational one: two permutations
-share an integer character value precisely when they share the rational one. -/
-theorem spechtChar_eq_iff (μ : n.Partition) (σ τ : Equiv.Perm (Fin n)) :
-    spechtChar μ σ = spechtChar μ τ ↔
-      (spechtModule μ).character σ = (spechtModule μ).character τ := by
-  rw [← spechtChar_cast, ← spechtChar_cast]
-  exact ⟨fun h => by rw [h], fun h => Int.cast_injective h⟩
-
 /-- **The integer character is a class function.** -/
+@[simp]
 theorem spechtChar_conj (μ : n.Partition) (σ τ : Equiv.Perm (Fin n)) :
     spechtChar μ (τ * σ * τ⁻¹) = spechtChar μ σ :=
   FDRep.intCharacter_conj (spechtModule μ) σ τ
 
 /-- Conjugate permutations have the same integer character. -/
 theorem spechtChar_eq_of_isConj (μ : n.Partition) {σ τ : Equiv.Perm (Fin n)} (h : IsConj σ τ) :
-    spechtChar μ σ = spechtChar μ τ := by
-  obtain ⟨c, rfl⟩ := isConj_iff.1 h
-  exact (spechtChar_conj μ σ c).symm
+    spechtChar μ σ = spechtChar μ τ :=
+  FDRep.intCharacter_eq_of_isConj (spechtModule μ) h
 
 /-- **The integer character depends only on the cycle type**, two permutations of `Fin n` being
 conjugate exactly when they have the same partition. -/
@@ -115,42 +112,49 @@ theorem spechtChar_eq_of_partition_eq (μ : n.Partition) {σ τ : Equiv.Perm (Fi
 theorem spechtChar_one (μ : n.Partition) : spechtChar μ 1 = finrank ℚ (spechtModule μ) :=
   FDRep.intCharacter_one (spechtModule μ)
 
-/-- The degree of `S^μ` is positive, so the identity column of the character table has positive
-entries. -/
+/-- **The value at the identity is positive**, the Specht module `S^μ` being nonzero. -/
 theorem spechtChar_one_pos (μ : n.Partition) : 0 < spechtChar μ 1 := by
   rw [spechtChar_one]
   exact_mod_cast finrank_spechtModule_pos μ
 
 /-! ## Descent to the conjugacy classes -/
 
-/-- **The integer character as a function of the conjugacy class.** -/
-noncomputable def spechtCharClass (μ : n.Partition) : ConjClasses (Equiv.Perm (Fin n)) → ℤ :=
-  Quotient.lift (spechtChar μ) fun _ _ h => spechtChar_eq_of_isConj μ h
+/-- **The integer character as a function of the conjugacy class**, the descent
+(`TauCeti.ClassFunction.toConjClasses`) of the class function `TauCeti.FDRep.intClassFunction` of
+`S^μ`. -/
+noncomputable def spechtCharConjClasses (μ : n.Partition) : ConjClasses (Equiv.Perm (Fin n)) → ℤ :=
+  ClassFunction.toConjClasses (FDRep.intClassFunction (spechtModule μ))
+
+theorem spechtCharConjClasses_def (μ : n.Partition) :
+    spechtCharConjClasses μ =
+      ClassFunction.toConjClasses (FDRep.intClassFunction (spechtModule μ)) := (rfl)
 
 @[simp]
-theorem spechtCharClass_mk (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
-    spechtCharClass μ (ConjClasses.mk σ) = spechtChar μ σ := (rfl)
+theorem spechtCharConjClasses_mk (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+    spechtCharConjClasses μ (ConjClasses.mk σ) = spechtChar μ σ := by
+  rw [spechtCharConjClasses_def, ClassFunction.toConjClasses_mk, FDRep.intClassFunction_apply,
+    spechtChar_def]
 
 /-- **The character value of `S^μ` on the class of cycle type `ν`**, the entry `χ^μ(ν)` of the
 character table. -/
 noncomputable def spechtCharValue (μ ν : n.Partition) : ℤ :=
-  spechtCharClass μ (partitionEquivConjClasses n ν)
+  spechtCharConjClasses μ (partitionEquivConjClasses n ν)
 
 theorem spechtCharValue_def (μ ν : n.Partition) :
-    spechtCharValue μ ν = spechtCharClass μ (partitionEquivConjClasses n ν) := (rfl)
+    spechtCharValue μ ν = spechtCharConjClasses μ (partitionEquivConjClasses n ν) := (rfl)
 
 /-- The character value is computed at any permutation representing the class of `ν`. -/
 theorem spechtCharValue_eq_spechtChar (μ ν : n.Partition) {σ : Equiv.Perm (Fin n)}
     (hσ : ConjClasses.mk σ = partitionEquivConjClasses n ν) :
     spechtCharValue μ ν = spechtChar μ σ := by
-  rw [spechtCharValue_def, ← hσ, spechtCharClass_mk]
+  rw [spechtCharValue_def, ← hσ, spechtCharConjClasses_mk]
 
 /-- **The integer character is read off the character table**, at the partition indexing the class
 of the permutation. -/
 theorem spechtChar_eq_value (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
     spechtChar μ σ =
       spechtCharValue μ ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)) := by
-  rw [spechtCharValue_def, Equiv.apply_symm_apply, spechtCharClass_mk]
+  rw [spechtCharValue_def, Equiv.apply_symm_apply, spechtCharConjClasses_mk]
 
 /-! ## The character table -/
 
@@ -158,7 +162,15 @@ theorem spechtChar_eq_value (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
 the value `χ^μ(ν)` of the character of the Specht module `S^μ` on the conjugacy class of cycle
 type `ν`. Both indices are partitions of `n`, which index the irreducible rational representations
 (`TauCeti.partitionEquivSimpleModuleClasses`) and the conjugacy classes
-(`TauCeti.partitionEquivConjClasses`) respectively. -/
+(`TauCeti.partitionEquivConjClasses`) respectively.
+
+Implementation note: this is not the library's general `TauCeti.characterTable k G`, which is
+defined over an algebraically closed field, takes values there, and enumerates its rows by
+`Fin (Nat.card (ConjClasses G))` through an arbitrary choice of ordering of the irreducible
+characters. This matrix is the `ℤ`-valued table of `Sₙ` re-indexed on both sides by the partitions
+of `n`. No comparison with `TauCeti.characterTable ℂ (Equiv.Perm (Fin n))` is proved here, and
+neither are any of the table properties — the orthogonality relations, or the character-table
+specification `TauCeti.IsCharacterTableSpec` — which the general table carries. -/
 noncomputable def symmetricCharacterTable (n : ℕ) : Matrix n.Partition n.Partition ℤ :=
   Matrix.of fun μ ν => spechtCharValue μ ν
 
@@ -168,14 +180,14 @@ theorem symmetricCharacterTable_apply (μ ν : n.Partition) :
 
 /-- **The character table recovers the rational characters of the Specht modules**, so passing from
 `ℚ` to `ℤ` and from permutations to cycle types loses nothing. -/
-theorem character_spechtModule_eq_intCast (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
-    (spechtModule μ).character σ =
-      ((symmetricCharacterTable n μ
-        ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)) : ℤ) : ℚ) := by
+theorem intCast_symmetricCharacterTable_apply (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+    ((symmetricCharacterTable n μ
+        ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)) : ℤ) : ℚ) =
+      (spechtModule μ).character σ := by
   rw [symmetricCharacterTable_apply, ← spechtChar_eq_value, spechtChar_cast]
 
 /-- **The column of the identity holds the degrees** `dim_ℚ S^μ`. -/
-theorem symmetricCharacterTable_apply_one_class (μ : n.Partition) :
+theorem symmetricCharacterTable_one (μ : n.Partition) :
     symmetricCharacterTable n μ ((partitionEquivConjClasses n).symm (ConjClasses.mk 1)) =
       finrank ℚ (spechtModule μ) := by
   rw [symmetricCharacterTable_apply, ← spechtChar_eq_value, spechtChar_one]

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Character.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Character.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.Values
+public import TauCeti.RepresentationTheory.Symmetric.Partitions
+public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
+
+/-!
+# The integer character of a Specht module, and the character table of `Sₙ`
+
+The Specht module `S^μ` is a representation of `Sₙ` over `ℚ`, so its character
+`(spechtModule μ).character` takes values in `ℚ`. Those values are in fact **integers**: a
+character value at an element of finite order is an algebraic integer, and a rational algebraic
+integer is an integer. That refinement is what this file records, as
+`TauCeti.spechtChar μ : Equiv.Perm (Fin n) → ℤ`, together with the cast
+`TauCeti.spechtChar_cast` back to the rational character; integrality is a theorem, not part of
+the definition.
+
+A character is a class function, and the conjugacy classes of `Sₙ` are the partitions of `n`
+(`TauCeti.partitionEquivConjClasses`), so `spechtChar μ` descends to a function of a partition
+`ν`, its **character value** `TauCeti.spechtCharValue μ ν`. Both indices being partitions of `n`,
+these values assemble into a square integer matrix, the **character table of the symmetric group**
+`TauCeti.symmetricCharacterTable n`. Its rows are indexed by the Specht modules, which are
+precisely the irreducible rational representations of `Sₙ`
+(`TauCeti.partitionEquivSimpleModuleClasses`), and its columns by the conjugacy classes; the
+column of the identity holds the degrees.
+
+The general half of the argument is stated for an arbitrary rational representation of a finite
+group, as `TauCeti.FDRep.intCharacter`, and is what this file specializes. Nothing here computes
+an entry of the table: the recursion that does is the Murnaghan--Nakayama rule, which needs rim
+hooks and is not proved here.
+
+## Main definitions
+
+* `TauCeti.spechtChar`: the `ℤ`-valued character `χ^μ` of the Specht module `S^μ`.
+* `TauCeti.spechtCharClass`: its descent to the conjugacy classes of `Sₙ`.
+* `TauCeti.spechtCharValue`: its value on the class of cycle type `ν`.
+* `TauCeti.symmetricCharacterTable`: the character table of `Sₙ`, a
+  `Matrix (Nat.Partition n) (Nat.Partition n) ℤ`.
+
+## Main results
+
+* `TauCeti.spechtChar_cast`: the integer character casts to the rational character of `S^μ`.
+* `TauCeti.spechtChar_eq_of_partition_eq`: it depends only on the cycle type.
+* `TauCeti.spechtChar_eq_value`: it is read off the character table.
+* `TauCeti.character_spechtModule_eq_intCast`: conversely the table recovers the rational
+  character, so no information is lost in passing to `ℤ`.
+* `TauCeti.spechtChar_one`: the value at the identity is the degree `dim_ℚ S^μ`, which is positive.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 6.
+* B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Section 4.10.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 6, "The Specht character".
+-/
+
+public section
+
+namespace TauCeti
+
+open Module
+
+variable {n : ℕ}
+
+/-! ## The integer character -/
+
+/-- **The integer character `χ^μ` of the Specht module** `S^μ`. The character of `S^μ` takes
+rational values, and those values are integers (`TauCeti.FDRep.intCharacter`); this is the
+integer-valued refinement, related to the rational character by `TauCeti.spechtChar_cast`. -/
+noncomputable def spechtChar (μ : n.Partition) : Equiv.Perm (Fin n) → ℤ :=
+  FDRep.intCharacter (spechtModule μ)
+
+theorem spechtChar_def (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+    spechtChar μ σ = FDRep.intCharacter (spechtModule μ) σ := (rfl)
+
+/-- **The integer character of `S^μ` casts to its rational character.** This is the whole content
+of `TauCeti.spechtChar`: the character of a Specht module is integer-valued. -/
+@[simp]
+theorem spechtChar_cast (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+    (spechtChar μ σ : ℚ) = (spechtModule μ).character σ := by
+  rw [spechtChar_def, FDRep.intCharacter_cast]
+
+/-- The integer character carries exactly the information of the rational one: two permutations
+share an integer character value precisely when they share the rational one. -/
+theorem spechtChar_eq_iff (μ : n.Partition) (σ τ : Equiv.Perm (Fin n)) :
+    spechtChar μ σ = spechtChar μ τ ↔
+      (spechtModule μ).character σ = (spechtModule μ).character τ := by
+  rw [← spechtChar_cast, ← spechtChar_cast]
+  exact ⟨fun h => by rw [h], fun h => Int.cast_injective h⟩
+
+/-- **The integer character is a class function.** -/
+theorem spechtChar_conj (μ : n.Partition) (σ τ : Equiv.Perm (Fin n)) :
+    spechtChar μ (τ * σ * τ⁻¹) = spechtChar μ σ :=
+  FDRep.intCharacter_conj (spechtModule μ) σ τ
+
+/-- Conjugate permutations have the same integer character. -/
+theorem spechtChar_eq_of_isConj (μ : n.Partition) {σ τ : Equiv.Perm (Fin n)} (h : IsConj σ τ) :
+    spechtChar μ σ = spechtChar μ τ := by
+  obtain ⟨c, rfl⟩ := isConj_iff.1 h
+  exact (spechtChar_conj μ σ c).symm
+
+/-- **The integer character depends only on the cycle type**, two permutations of `Fin n` being
+conjugate exactly when they have the same partition. -/
+theorem spechtChar_eq_of_partition_eq (μ : n.Partition) {σ τ : Equiv.Perm (Fin n)}
+    (h : σ.partition = τ.partition) : spechtChar μ σ = spechtChar μ τ :=
+  spechtChar_eq_of_isConj μ (Equiv.Perm.partition_eq_of_isConj.mpr h)
+
+/-- **The value at the identity is the degree** `dim_ℚ S^μ`. -/
+@[simp]
+theorem spechtChar_one (μ : n.Partition) : spechtChar μ 1 = finrank ℚ (spechtModule μ) :=
+  FDRep.intCharacter_one (spechtModule μ)
+
+/-- The degree of `S^μ` is positive, so the identity column of the character table has positive
+entries. -/
+theorem spechtChar_one_pos (μ : n.Partition) : 0 < spechtChar μ 1 := by
+  rw [spechtChar_one]
+  exact_mod_cast finrank_spechtModule_pos μ
+
+/-! ## Descent to the conjugacy classes -/
+
+/-- **The integer character as a function of the conjugacy class.** -/
+noncomputable def spechtCharClass (μ : n.Partition) : ConjClasses (Equiv.Perm (Fin n)) → ℤ :=
+  Quotient.lift (spechtChar μ) fun _ _ h => spechtChar_eq_of_isConj μ h
+
+@[simp]
+theorem spechtCharClass_mk (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+    spechtCharClass μ (ConjClasses.mk σ) = spechtChar μ σ := (rfl)
+
+/-- **The character value of `S^μ` on the class of cycle type `ν`**, the entry `χ^μ(ν)` of the
+character table. -/
+noncomputable def spechtCharValue (μ ν : n.Partition) : ℤ :=
+  spechtCharClass μ (partitionEquivConjClasses n ν)
+
+theorem spechtCharValue_def (μ ν : n.Partition) :
+    spechtCharValue μ ν = spechtCharClass μ (partitionEquivConjClasses n ν) := (rfl)
+
+/-- The character value is computed at any permutation representing the class of `ν`. -/
+theorem spechtCharValue_eq_spechtChar (μ ν : n.Partition) {σ : Equiv.Perm (Fin n)}
+    (hσ : ConjClasses.mk σ = partitionEquivConjClasses n ν) :
+    spechtCharValue μ ν = spechtChar μ σ := by
+  rw [spechtCharValue_def, ← hσ, spechtCharClass_mk]
+
+/-- **The integer character is read off the character table**, at the partition indexing the class
+of the permutation. -/
+theorem spechtChar_eq_value (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+    spechtChar μ σ =
+      spechtCharValue μ ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)) := by
+  rw [spechtCharValue_def, Equiv.apply_symm_apply, spechtCharClass_mk]
+
+/-! ## The character table -/
+
+/-- **The character table of the symmetric group `Sₙ`**: the integer matrix whose `(μ, ν)` entry is
+the value `χ^μ(ν)` of the character of the Specht module `S^μ` on the conjugacy class of cycle
+type `ν`. Both indices are partitions of `n`, which index the irreducible rational representations
+(`TauCeti.partitionEquivSimpleModuleClasses`) and the conjugacy classes
+(`TauCeti.partitionEquivConjClasses`) respectively. -/
+noncomputable def symmetricCharacterTable (n : ℕ) : Matrix n.Partition n.Partition ℤ :=
+  Matrix.of fun μ ν => spechtCharValue μ ν
+
+@[simp]
+theorem symmetricCharacterTable_apply (μ ν : n.Partition) :
+    symmetricCharacterTable n μ ν = spechtCharValue μ ν := (rfl)
+
+/-- **The character table recovers the rational characters of the Specht modules**, so passing from
+`ℚ` to `ℤ` and from permutations to cycle types loses nothing. -/
+theorem character_spechtModule_eq_intCast (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+    (spechtModule μ).character σ =
+      ((symmetricCharacterTable n μ
+        ((partitionEquivConjClasses n).symm (ConjClasses.mk σ)) : ℤ) : ℚ) := by
+  rw [symmetricCharacterTable_apply, ← spechtChar_eq_value, spechtChar_cast]
+
+/-- **The column of the identity holds the degrees** `dim_ℚ S^μ`. -/
+theorem symmetricCharacterTable_apply_one_class (μ : n.Partition) :
+    symmetricCharacterTable n μ ((partitionEquivConjClasses n).symm (ConjClasses.mk 1)) =
+      finrank ℚ (spechtModule μ) := by
+  rw [symmetricCharacterTable_apply, ← spechtChar_eq_value, spechtChar_one]
+
+end TauCeti


### PR DESCRIPTION
This PR gives the Specht module `S^μ` an integer-valued character and assembles those values into the character table of `Sₙ`. The character of `S^μ` lands in `ℚ` because the module is built over `ℚ`; that its values are *integers* is a theorem, and it is recorded as a cast (`TauCeti.spechtChar_cast`) rather than baked into the definition. Since a character is a class function and the conjugacy classes of `Sₙ` are the partitions of `n` (`TauCeti.partitionEquivConjClasses`), the integer character descends to `TauCeti.spechtCharValue μ ν`, and both indices being partitions of `n`, these values form the square integer matrix `TauCeti.symmetricCharacterTable n`. `TauCeti.character_spechtModule_eq_intCast` checks that the table loses nothing: it recovers the rational character of every Specht module. The column of the identity class holds the degrees `dim_ℚ S^μ`, which are positive.

This is the "Specht character" bullet of `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 6 ("characters and the Murnaghan-Nakayama rule"), pinned in that roadmap's `Suggested.lean` as `spechtChar`, `spechtChar_cast`, `spechtCharValue`, `spechtChar_eq_value` and `symmetricCharacterTable`. Only the character half of Layer 6 is built: the Murnaghan-Nakayama recursion needs rim hooks and border strips, which do not exist yet, and nothing here computes an entry. The layer's stated dependencies that this bullet actually uses are Layer 0's partition/class dictionary and Layer 3-4's Specht modules with their classification, all of which are in place; the Layer 5 standard basis, still open, is what the *identity-value-is `f^λ`* reading of the degrees would need, and that reading is deliberately not claimed — `TauCeti.spechtChar_one` gives the degree as `finrank ℚ (spechtModule μ)`, not as a count of standard tableaux.

The arithmetic input is general and is proved where it belongs. `TauCeti.End.isIntegral_trace_of_pow_eq_one` says the trace of an endomorphism of finite order is integral over `ℤ` over an *arbitrary* field: when the characteristic polynomial splits the trace is a sum of roots of unity, and the splitting hypothesis is then removed by base change to an algebraic closure, using Mathlib's `LinearMap.trace_baseChange` and `LinearMap.baseChange_pow` together with `IsIntegral.tower_bot`. Consequently `TauCeti.Representation.isIntegral_char` loses its `IsAlgClosed k` hypothesis, and the now strictly weaker `isIntegral_char_of_splits` is removed rather than kept as a duplicate surface; no other module used it. Over `ℚ` integrality plus `ℤ` being integrally closed in `ℚ` gives `TauCeti.Representation.exists_intCast_eq_character` and the `ℤ`-valued class function `TauCeti.FDRep.intCharacter` for any rational representation of a finite group, of which `spechtChar` is the specialization; this keeps the Specht file free of arithmetic and gives the same refinement to every other rational representation. No Mathlib source was vendored.

`lake build`, `lake exe axioms` (allowlist only) and `scripts/lint-env.sh` are green.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"spechtchar"}-->

Roadmap: RepresentationTheory

🤖 Prepared with Claude Code
