### PR TITLE
refactor(CongruenceSubgroups): name the two steps of the CRT decomposition

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -463,6 +463,59 @@ private lemma map_apply_of_dvd_lcm {a b : ℕ} [NeZero (Nat.lcm a b)]
   simpa only [Matrix.SpecialLinearGroup.map_apply_coe, RingHom.mapMatrix_apply, Matrix.map_apply,
     Int.coe_castRingHom, map_intCast] using this
 
+/-- **A `2 × 2` integer matrix congruent to the identity modulo `a` and to a matrix of
+`SL(2, ℤ)` modulo `b` has determinant congruent to `1` modulo `lcm a b`.** -/
+private lemma det_fin_two_modEq_one_lcm {a b : ℕ} {M : Matrix (Fin 2) (Fin 2) ℤ} {γ : SL(2, ℤ)}
+    (hMa : ∀ i j, M i j ≡ ((1 : SL(2, ℤ)) i j : ℤ) [ZMOD (a : ℤ)])
+    (hMb : ∀ i j, M i j ≡ (γ i j : ℤ) [ZMOD (b : ℤ)]) :
+    M 0 0 * M 1 1 - M 0 1 * M 1 0 ≡ 1 [ZMOD ↑(Nat.lcm a b)] := by
+  -- `Int.modEq_and_modEq_iff_modEq_lcm` is stated for `Int.lcm`, so the `Nat.lcm` modulus
+  -- has to be renamed before it applies.
+  have hlcm : (↑(Nat.lcm a b) : ℤ) = ↑(Int.lcm (a : ℤ) (b : ℤ)) := by simp [Int.lcm, Nat.lcm]
+  rw [hlcm, ← Int.modEq_and_modEq_iff_modEq_lcm]
+  refine ⟨?_, ?_⟩
+  · have h : M 0 0 * M 1 1 - M 0 1 * M 1 0 ≡ 1 * 1 - 0 * 0 [ZMOD (a : ℤ)] :=
+      ((hMa 0 0).mul (hMa 1 1)).sub ((hMa 0 1).mul (hMa 1 0))
+    simpa using h
+  · have hdetγ : (γ 0 0 : ℤ) * γ 1 1 - γ 0 1 * γ 1 0 = 1 := by
+      have h := γ.prop
+      rw [Matrix.det_fin_two] at h
+      exact_mod_cast h
+    have h : M 0 0 * M 1 1 - M 0 1 * M 1 0 ≡
+        (γ 0 0 : ℤ) * γ 1 1 - (γ 0 1 : ℤ) * γ 1 0 [ZMOD (b : ℤ)] :=
+      ((hMb 0 0).mul (hMb 1 1)).sub ((hMb 0 1).mul (hMb 1 0))
+    rwa [hdetγ] at h
+
+/-- **A lift realising `M` modulo `lcm a b` splits `γ` across the two levels.** If `β` reduces
+to `M` modulo `lcm a b`, and `M` is congruent to the identity modulo `a` and to `γ` modulo `b`,
+then `β ∈ Γ(a)` and `β⁻¹γ ∈ Γ(b)`. -/
+private lemma mem_Gamma_and_inv_mul_mem_Gamma_of_map_eq {a b : ℕ} [NeZero (Nat.lcm a b)]
+    {M : Matrix (Fin 2) (Fin 2) ℤ} {β γ : SL(2, ℤ)}
+    (hβ : (↑(Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod (Nat.lcm a b))) β) :
+        Matrix (Fin 2) (Fin 2) (ZMod (Nat.lcm a b))) =
+      M.map (Int.castRingHom (ZMod (Nat.lcm a b))))
+    (hMa : ∀ i j, M i j ≡ ((1 : SL(2, ℤ)) i j : ℤ) [ZMOD (a : ℤ)])
+    (hMb : ∀ i j, M i j ≡ (γ i j : ℤ) [ZMOD (b : ℤ)]) :
+    β ∈ Gamma a ∧ β⁻¹ * γ ∈ Gamma b := by
+  have hzM : ∀ i j : Fin 2,
+      (M i j : ZMod a) = ((1 : SL(2, ℤ)) i j : ZMod a) ∧
+      (M i j : ZMod b) = (γ i j : ZMod b) := fun i j =>
+    ⟨(ZMod.intCast_eq_intCast_iff _ _ _).mpr (hMa i j),
+      (ZMod.intCast_eq_intCast_iff _ _ _).mpr (hMb i j)⟩
+  refine ⟨?_, ?_⟩
+  · rw [Gamma_mem']
+    ext i j
+    rw [map_apply_of_dvd_lcm M β hβ (Nat.dvd_lcm_left a b) i j, (hzM i j).1]
+    simp [Matrix.one_apply]
+  · rw [Gamma_mem', map_mul, map_inv]
+    have hβ_b : Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod b)) β =
+        Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod b)) γ := by
+      ext i j
+      rw [map_apply_of_dvd_lcm M β hβ (Nat.dvd_lcm_right a b) i j, (hzM i j).2]
+      simp
+    rw [hβ_b]
+    exact inv_mul_cancel _
+
 /-- **Shimura, Lemma 3.28.** `Γ(gcd a b) = Γ(a) ⊔ Γ(b)`: the join of two principal congruence
 subgroups is the principal congruence subgroup of the gcd.
 
@@ -496,52 +549,22 @@ theorem Gamma_gcd_eq_sup (a b : ℕ) : Gamma (Nat.gcd a b) = Gamma a ⊔ Gamma b
   obtain ⟨z01, hz01a, hz01b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 0 1)
   obtain ⟨z10, hz10a, hz10b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 1 0)
   obtain ⟨z11, hz11a, hz11b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 1 1)
-  have hdet_lcm : z00 * z11 - z01 * z10 ≡ 1 [ZMOD ↑(Nat.lcm a b)] := by
-    -- `Int.modEq_and_modEq_iff_modEq_lcm` is stated for `Int.lcm`, so the `Nat.lcm` modulus
-    -- has to be renamed before it applies.
-    have hlcm : (↑(Nat.lcm a b) : ℤ) = ↑(Int.lcm (a : ℤ) (b : ℤ)) := by simp [Int.lcm, Nat.lcm]
-    rw [hlcm, ← Int.modEq_and_modEq_iff_modEq_lcm]
-    refine ⟨?_, ?_⟩
-    · have h : z00 * z11 - z01 * z10 ≡ 1 * 1 - 0 * 0 [ZMOD (a : ℤ)] :=
-        (hz00a.mul hz11a).sub (hz01a.mul hz10a)
-      simpa using h
-    · have hdetγ : (γ 0 0 : ℤ) * γ 1 1 - γ 0 1 * γ 1 0 = 1 := by
-        have h := γ.prop
-        rw [Matrix.det_fin_two] at h
-        exact_mod_cast h
-      have h : z00 * z11 - z01 * z10 ≡
-          (γ 0 0 : ℤ) * γ 1 1 - (γ 0 1 : ℤ) * γ 1 0 [ZMOD (b : ℤ)] :=
-        (hz00b.mul hz11b).sub (hz01b.mul hz10b)
-      rwa [hdetγ] at h
-  set M : Matrix (Fin 2) (Fin 2) ℤ := !![z00, z01; z10, z11] with hM
+  set M : Matrix (Fin 2) (Fin 2) ℤ := !![z00, z01; z10, z11]
+  have hMa : ∀ i j, M i j ≡ ((1 : SL(2, ℤ)) i j : ℤ) [ZMOD (a : ℤ)] := by
+    intro i j
+    fin_cases i <;> fin_cases j <;> assumption
+  have hMb : ∀ i j, M i j ≡ (γ i j : ℤ) [ZMOD (b : ℤ)] := by
+    intro i j
+    fin_cases i <;> fin_cases j <;> assumption
   have hM_det : (M.map (Int.castRingHom (ZMod (Nat.lcm a b)))).det = 1 := by
-    simp only [Matrix.det_fin_two, hM, Matrix.map_apply, Int.coe_castRingHom]
-    have h := (ZMod.intCast_eq_intCast_iff _ _ _).mpr hdet_lcm
+    simp only [Matrix.det_fin_two, Matrix.map_apply, Int.coe_castRingHom]
+    have h := (ZMod.intCast_eq_intCast_iff _ _ _).mpr (det_fin_two_modEq_one_lcm hMa hMb)
     push_cast at h ⊢
     exact_mod_cast h
   obtain ⟨β, hβ⟩ := Matrix.SpecialLinearGroup.map_intCast_zmod_surjective
     ⟨M.map (Int.castRingHom (ZMod (Nat.lcm a b))), hM_det⟩
-  have hβ_mat := congr_arg Subtype.val hβ
-  have hzM : ∀ i j : Fin 2,
-      (M i j : ZMod a) = ((1 : SL(2, ℤ)) i j : ZMod a) ∧
-      (M i j : ZMod b) = (γ i j : ZMod b) := by
-    intro i j
-    fin_cases i <;> fin_cases j <;>
-      exact ⟨(ZMod.intCast_eq_intCast_iff _ _ _).mpr ‹_›,
-        (ZMod.intCast_eq_intCast_iff _ _ _).mpr ‹_›⟩
-  have hβ_a : β ∈ Gamma a := by
-    rw [Gamma_mem']
-    ext i j
-    rw [map_apply_of_dvd_lcm M β hβ_mat (Nat.dvd_lcm_left a b) i j, (hzM i j).1]
-    simp [Matrix.one_apply]
-  refine ⟨β, hβ_a, β⁻¹ * γ, ?_, by group⟩
-  rw [Gamma_mem', map_mul, map_inv]
-  have hβ_b : Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod b)) β =
-      Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod b)) γ := by
-    ext i j
-    rw [map_apply_of_dvd_lcm M β hβ_mat (Nat.dvd_lcm_right a b) i j, (hzM i j).2]
-    simp
-  rw [hβ_b]
-  exact inv_mul_cancel _
+  obtain ⟨hβ_a, hβ_b⟩ :=
+    mem_Gamma_and_inv_mul_mem_Gamma_of_map_eq (congr_arg Subtype.val hβ) hMa hMb
+  exact ⟨β, hβ_a, β⁻¹ * γ, hβ_b, by group⟩
 
 end CongruenceSubgroup

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -446,7 +446,7 @@ private lemma intCast_apply_modEq_one_of_mem_Gamma (N : ℕ) (γ : SL(2, ℤ))
   simpa [Matrix.one_apply] using h.symm
 
 /-- A lift chosen modulo `lcm a b` reduces correctly modulo any divisor of it. -/
-private lemma map_apply_of_dvd_lcm {a b : ℕ} [NeZero (Nat.lcm a b)]
+private lemma map_apply_of_dvd_lcm {a b : ℕ}
     (M : Matrix (Fin 2) (Fin 2) ℤ) (β : SL(2, ℤ))
     (hβ : (↑(Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod (Nat.lcm a b))) β) :
         Matrix (Fin 2) (Fin 2) (ZMod (Nat.lcm a b))) =
@@ -469,27 +469,30 @@ private lemma det_fin_two_modEq_one_lcm {a b : ℕ} {M : Matrix (Fin 2) (Fin 2) 
     (hMa : ∀ i j, M i j ≡ ((1 : SL(2, ℤ)) i j : ℤ) [ZMOD (a : ℤ)])
     (hMb : ∀ i j, M i j ≡ (γ i j : ℤ) [ZMOD (b : ℤ)]) :
     M 0 0 * M 1 1 - M 0 1 * M 1 0 ≡ 1 [ZMOD ↑(Nat.lcm a b)] := by
+  -- reduction is a ring map, so it carries determinants to determinants (`RingHom.map_det`),
+  -- and every matrix of `SL(2, ℤ)` has determinant `1`; the two moduli then differ only in
+  -- which matrix `M` is compared against
+  have key : ∀ (n : ℕ) (g : SL(2, ℤ)), (∀ i j, M i j ≡ (g i j : ℤ) [ZMOD (n : ℤ)]) →
+      M 0 0 * M 1 1 - M 0 1 * M 1 0 ≡ 1 [ZMOD (n : ℤ)] := by
+    intro n g hM
+    have hmap : (Int.castRingHom (ZMod n)).mapMatrix M =
+        (Int.castRingHom (ZMod n)).mapMatrix (g : Matrix (Fin 2) (Fin 2) ℤ) := by
+      ext i j
+      exact (ZMod.intCast_eq_intCast_iff _ _ _).mpr (hM i j)
+    have hdet := congr_arg Matrix.det hmap
+    rw [← RingHom.map_det, ← RingHom.map_det, g.prop] at hdet
+    rw [← ZMod.intCast_eq_intCast_iff, ← Matrix.det_fin_two]
+    simpa using hdet
   -- `Int.modEq_and_modEq_iff_modEq_lcm` is stated for `Int.lcm`, so the `Nat.lcm` modulus
   -- has to be renamed before it applies.
   have hlcm : (↑(Nat.lcm a b) : ℤ) = ↑(Int.lcm (a : ℤ) (b : ℤ)) := by simp [Int.lcm, Nat.lcm]
   rw [hlcm, ← Int.modEq_and_modEq_iff_modEq_lcm]
-  refine ⟨?_, ?_⟩
-  · have h : M 0 0 * M 1 1 - M 0 1 * M 1 0 ≡ 1 * 1 - 0 * 0 [ZMOD (a : ℤ)] :=
-      ((hMa 0 0).mul (hMa 1 1)).sub ((hMa 0 1).mul (hMa 1 0))
-    simpa using h
-  · have hdetγ : (γ 0 0 : ℤ) * γ 1 1 - γ 0 1 * γ 1 0 = 1 := by
-      have h := γ.prop
-      rw [Matrix.det_fin_two] at h
-      exact_mod_cast h
-    have h : M 0 0 * M 1 1 - M 0 1 * M 1 0 ≡
-        (γ 0 0 : ℤ) * γ 1 1 - (γ 0 1 : ℤ) * γ 1 0 [ZMOD (b : ℤ)] :=
-      ((hMb 0 0).mul (hMb 1 1)).sub ((hMb 0 1).mul (hMb 1 0))
-    rwa [hdetγ] at h
+  exact ⟨key a 1 hMa, key b γ hMb⟩
 
 /-- **A lift realising `M` modulo `lcm a b` splits `γ` across the two levels.** If `β` reduces
 to `M` modulo `lcm a b`, and `M` is congruent to the identity modulo `a` and to `γ` modulo `b`,
 then `β ∈ Γ(a)` and `β⁻¹γ ∈ Γ(b)`. -/
-private lemma mem_Gamma_and_inv_mul_mem_Gamma_of_map_eq {a b : ℕ} [NeZero (Nat.lcm a b)]
+private lemma mem_Gamma_and_inv_mul_mem_Gamma_of_map_eq {a b : ℕ}
     {M : Matrix (Fin 2) (Fin 2) ℤ} {β γ : SL(2, ℤ)}
     (hβ : (↑(Matrix.SpecialLinearGroup.map (Int.castRingHom (ZMod (Nat.lcm a b))) β) :
         Matrix (Fin 2) (Fin 2) (ZMod (Nat.lcm a b))) =


### PR DESCRIPTION
`Gamma_gcd_eq_sup` (Shimura Lemma 3.28, `Γ(gcd a b) = Γ(a) ⊔ Γ(b)`) ran to 71 lines — the
longest proof left in the repository outside the contended Hecke files. Two of its blocks are
self-contained facts that neither mention congruence subgroups nor need the theorem's context.
Name them. No statement changes; no new public declaration.

## The extracted helpers

```lean
private lemma det_fin_two_modEq_one_lcm {a b : ℕ} {M : Matrix (Fin 2) (Fin 2) ℤ} {γ : SL(2, ℤ)}
    (hMa : ∀ i j, M i j ≡ ((1 : SL(2, ℤ)) i j : ℤ) [ZMOD (a : ℤ)])
    (hMb : ∀ i j, M i j ≡ (γ i j : ℤ) [ZMOD (b : ℤ)]) :
    M 0 0 * M 1 1 - M 0 1 * M 1 0 ≡ 1 [ZMOD ↑(Nat.lcm a b)]

private lemma mem_Gamma_and_inv_mul_mem_Gamma_of_map_eq {a b : ℕ}
    {M : Matrix (Fin 2) (Fin 2) ℤ} {β γ : SL(2, ℤ)}
    (hβ : … β reduces to M mod lcm a b …) (hMa : …) (hMb : …) :
    β ∈ Gamma a ∧ β⁻¹ * γ ∈ Gamma b
```

Both take their congruences as two `∀ i j` hypotheses rather than the eight loose ones the
proof had accumulated from four separate Bézout lifts.

**Neither needs any `NeZero`.** The enclosing theorem installs `NeZero a`, `NeZero b` and
`NeZero (Nat.lcm a b)` before it can proceed. Review pointed out that the splitting lemma
inherits the last of these only through `map_apply_of_dvd_lcm`, and that neither needs it —
both compile without, and the statements are meaningful at a zero lcm. That removal is
independently corroborated: `scripts/lint-baseline.txt` already carried
`unusedArguments CongruenceSubgroup.map_apply_of_dvd_lcm` as a grandfathered violation, and
`lint-env` now reports that entry as no longer violating.

**The determinant goes through `RingHom.map_det`.** The first draft expanded the 2×2
determinant and transported all four entries by hand. Reduction is a ring map, so it carries
determinants to determinants; every matrix of `SL(2, ℤ)` has determinant `1` by `g.prop`. The
two moduli then differ only in which matrix `M` is compared against, so what were two parallel
branches collapse into one inner `key`.

## What that also cleaned up

Packaging the four lifts as `hMa`/`hMb` immediately after they are obtained removes the
`fin_cases`-plus-anonymous-hypothesis (`‹_›`) lookup that used to build `hzM`, which now falls
out of `ZMod.intCast_eq_intCast_iff` directly. It also leaves the `set`-bound equation `hM`
unused, so that is gone too.

## Result

| | before | after |
|---|---|---|
| `Gamma_gcd_eq_sup` | 71 | 41 |
| `det_fin_two_modEq_one_lcm` | — | 19 |
| `mem_Gamma_and_inv_mul_mem_Gamma_of_map_eq` | — | 18 |

Gates run on `a76e109d`: `lake build` (7784 jobs), `lake exe axioms` (44316 declarations),
`lake exe module-system` (2124 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: ModularForms