### PR TITLE
refactor(UniversalCover): name the two endpoints of the initial-segment family

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Covering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Covering.lean
@@ -113,6 +113,39 @@ instance pathConnectedSpace (x₀ : X) :
   obtain ⟨α₂, rfl⟩ := surjective_ofBasedPath x₀ z₂
   exact (joined_basepoint_ofBasedPath α₁).symm.trans (joined_basepoint_ofBasedPath α₂)
 
+/-- At time `0` the family of initial segments of `γ` appended to `α` is the class of `α`
+itself. -/
+private theorem ofBasedPath_append_initialSegmentFamily_zero {α : BasedPath x₀} {y : X}
+    (γ : Path (BasedPath.endpoint α) y) :
+    ofBasedPath x₀ (BasedPath.append α (Path.initialSegmentFamily γ 0)) = ofBasedPath x₀ α := by
+  have h0_hom :
+      Path.Homotopic
+        ((α.toPath.trans (Path.initialSegmentFamily γ 0)).cast rfl
+          (by simp))
+        α.toPath := by
+    rw [Path.initialSegmentFamily_zero]
+    simpa using! Path.Homotopic.trans_refl α.toPath
+  have h0_end : BasedPath.endpoint (BasedPath.append α (Path.initialSegmentFamily γ 0)) =
+      BasedPath.endpoint α := by
+    rw [BasedPath.endpoint_append]
+    simp
+  exact ofBasedPath_eq_of_homotopic_toPath (x₀ := x₀) h0_end h0_hom
+
+/-- At time `1` the family of initial segments of `γ` appended to `α` is the class of
+`α.append γ`. -/
+private theorem ofBasedPath_append_initialSegmentFamily_one {α : BasedPath x₀} {y : X}
+    (γ : Path (BasedPath.endpoint α) y) :
+    ofBasedPath x₀ (BasedPath.append α (Path.initialSegmentFamily γ 1)) =
+      ofBasedPath x₀ (BasedPath.append α γ) := by
+  rw [Path.initialSegmentFamily_one]
+  apply congrArg (ofBasedPath x₀)
+  apply BasedPath.ext
+  intro t
+  -- `BasedPath.append` inserts endpoint casts definitionally; expose the underlying paths.
+  change (α.toPath.trans (γ.cast _ _)) t = (α.toPath.trans γ) t
+  rw [Path.trans_apply, Path.trans_apply]
+  split_ifs <;> simp only [Path.cast_coe]
+
 /-- The lift through `proj` of a path `γ` starting at the class of `α` ends at the class of
 the concatenated based path `α.append γ`. -/
 theorem liftPath_apply_one_eq_ofBasedPath_append
@@ -132,19 +165,8 @@ theorem liftPath_apply_one_eq_ofBasedPath_append
     rw [Function.comp_apply, show Γ t =
       ofBasedPath x₀ (BasedPath.append α (Path.initialSegmentFamily γ t)) from rfl,
       proj_ofBasedPath, BasedPath.endpoint_append]
-  have hΓ_zero : Γ 0 = ofBasedPath x₀ α := by
-    have h0_hom :
-        Path.Homotopic
-          ((α.toPath.trans (Path.initialSegmentFamily γ 0)).cast rfl
-            (by simp))
-          α.toPath := by
-      rw [Path.initialSegmentFamily_zero]
-      simpa using! Path.Homotopic.trans_refl α.toPath
-    have h0_end : BasedPath.endpoint (BasedPath.append α (Path.initialSegmentFamily γ 0)) =
-        BasedPath.endpoint α := by
-      rw [BasedPath.endpoint_append]
-      simp
-    exact ofBasedPath_eq_of_homotopic_toPath (x₀ := x₀) h0_end h0_hom
+  have hΓ_zero : Γ 0 = ofBasedPath x₀ α :=
+    ofBasedPath_append_initialSegmentFamily_zero γ
   have hΓ_eq_lift :
       Γ = (isCoveringMap x₀).liftPath γ (ofBasedPath x₀ α)
         (by simp) :=
@@ -156,14 +178,7 @@ theorem liftPath_apply_one_eq_ofBasedPath_append
   -- Both sides are values of the local lift wrapper; unfolding exposes the appended paths.
   change ofBasedPath x₀ (BasedPath.append α (Path.initialSegmentFamily γ 1)) =
     ofBasedPath x₀ (BasedPath.append α γ)
-  rw [Path.initialSegmentFamily_one]
-  apply congrArg (ofBasedPath x₀)
-  apply BasedPath.ext
-  intro t
-  -- `BasedPath.append` inserts endpoint casts definitionally; expose the underlying paths.
-  change (α.toPath.trans (γ.cast _ _)) t = (α.toPath.trans γ) t
-  rw [Path.trans_apply, Path.trans_apply]
-  split_ifs <;> simp only [Path.cast_coe]
+  exact ofBasedPath_append_initialSegmentFamily_one γ
 
 /-- The universal cover is simply connected. -/
 instance simplyConnectedSpace [LocallyPathConnectedSpace X] [PathConnectedSpace X]


### PR DESCRIPTION
`liftPath_apply_one_eq_ofBasedPath_append` carried a 43-line proof. It builds a candidate lift
`Γ`, shows `Γ` agrees with `ofBasedPath` at each end of the interval, and feeds the pair to
`eq_liftPath_iff'`. The two endpoint computations are facts about based paths alone. Name them.
No statement changes; no new public declaration.

## The extracted helpers

```lean
private theorem ofBasedPath_append_initialSegmentFamily_zero {α : BasedPath x₀} {y : X}
    (γ : Path (BasedPath.endpoint α) y) :
    ofBasedPath x₀ (BasedPath.append α (Path.initialSegmentFamily γ 0)) = ofBasedPath x₀ α

private theorem ofBasedPath_append_initialSegmentFamily_one {α : BasedPath x₀} {y : X}
    (γ : Path (BasedPath.endpoint α) y) :
    ofBasedPath x₀ (BasedPath.append α (Path.initialSegmentFamily γ 1)) =
      ofBasedPath x₀ (BasedPath.append α γ)
```

**Neither needs a covering-space hypothesis.** The enclosing theorem carries
`[LocallyPathConnectedSpace X]`, `[PathConnectedSpace X]` and
`[SemilocallySimplyConnectedSpace X]`; those three exist only so that `isCoveringMap x₀` is
available, and no covering map occurs in either endpoint identity. Dropping them is what makes
the pair readable as what they are — the two ends of `Path.initialSegmentFamily`.

They also come as a matched pair, which is the whole content of the lifting argument: `Γ 0` is
the class you started from, `Γ 1` is the class of the appended path, and `eq_liftPath_iff'`
turns that into the statement about `liftPath`.

## Result

| | before | after |
|---|---|---|
| `liftPath_apply_one_eq_ofBasedPath_append` | 43 | 25 |
| `ofBasedPath_append_initialSegmentFamily_zero` | — | 12 |
| `ofBasedPath_append_initialSegmentFamily_one` | — | 8 |

The blocks move verbatim; the parent keeps its `let Γ` wrapper and the `change` that exposes
the appended paths.

Gates run on `c1a02941`: `lake build` (7785 jobs), `lake exe axioms` (44317 declarations),
`lake exe module-system` (2125 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: none