### PR TITLE
refactor(ModularForms): deduplicate the unit-circle S-action facts into Modular/Orbits

### DIFF
--- a/TauCeti/NumberTheory/Modular/Orbits.lean
+++ b/TauCeti/NumberTheory/Modular/Orbits.lean
@@ -161,7 +161,7 @@ lemma S_smul_mem_fd_of_norm_eq_one {p : ℍ} (hre : |p.re| ≤ 1 / 2) (hnorm : �
 /-- The inversion is an involution of `ℍ`. -/
 @[simp]
 lemma S_smul_S_smul (p : ℍ) : _root_.ModularGroup.S • (_root_.ModularGroup.S • p) = p := by
-  rw [← SL_neg_smul, ← _root_.ModularGroup.S_inv, inv_smul_smul]
+  rw [← _root_.ModularGroup.SL_neg_smul, ← _root_.ModularGroup.S_inv, inv_smul_smul]
 
 /-- A point of the closed fundamental domain lying in the `SL(2, ℤ)`-orbit of `i` is `i`
 itself: the boundary identifications of `𝒟` fix `i`. -/

--- a/TauCeti/NumberTheory/Modular/Orbits.lean
+++ b/TauCeti/NumberTheory/Modular/Orbits.lean
@@ -147,20 +147,21 @@ lemma re_S_smul_of_norm_eq_one {p : ℍ} (hp : ‖(p : ℂ)‖ = 1) :
     (_root_.ModularGroup.S • p).re = -p.re := by
   rw [re_S_smul, Complex.normSq_eq_norm_sq, hp, one_pow, div_one]
 
-/-- On the unit circle the inversion preserves the closed fundamental domain: the norm stays
-at `1`, and the real-part bound is symmetric under the sign flip. -/
-lemma S_smul_mem_fd {p : ℍ} (hp : p ∈ 𝒟) (hnorm : ‖(p : ℂ)‖ = 1) :
+/-- On the unit circle a point with the fundamental domain's real-part bound is carried into
+the closed fundamental domain by the inversion: the norm stays at `1`, and the real-part
+bound is symmetric under the sign flip. -/
+lemma S_smul_mem_fd_of_norm_eq_one {p : ℍ} (hre : |p.re| ≤ 1 / 2) (hnorm : ‖(p : ℂ)‖ = 1) :
     _root_.ModularGroup.S • p ∈ 𝒟 := by
   refine ⟨?_, ?_⟩
   · rw [Complex.normSq_eq_norm_sq, norm_coe_S_smul_of_norm_eq_one hnorm]
     norm_num
   · rw [re_S_smul_of_norm_eq_one hnorm, abs_neg]
-    exact hp.2
+    exact hre
 
 /-- The inversion is an involution of `ℍ`. -/
-lemma S_smul_S_smul (p : ℍ) : _root_.ModularGroup.S • (_root_.ModularGroup.S • p) = p :=
-  UpperHalfPlane.ext <| by
-    rw [modular_S_smul, modular_S_smul, coe_mk, coe_mk, neg_inv, neg_neg, inv_inv]
+@[simp]
+lemma S_smul_S_smul (p : ℍ) : _root_.ModularGroup.S • (_root_.ModularGroup.S • p) = p := by
+  rw [← SL_neg_smul, ← _root_.ModularGroup.S_inv, inv_smul_smul]
 
 /-- A point of the closed fundamental domain lying in the `SL(2, ℤ)`-orbit of `i` is `i`
 itself: the boundary identifications of `𝒟` fix `i`. -/

--- a/TauCeti/NumberTheory/Modular/Orbits.lean
+++ b/TauCeti/NumberTheory/Modular/Orbits.lean
@@ -158,8 +158,10 @@ lemma S_smul_mem_fd_of_norm_eq_one {p : ℍ} (hre : |p.re| ≤ 1 / 2) (hnorm : �
   · rw [re_S_smul_of_norm_eq_one hnorm, abs_neg]
     exact hre
 
+-- Not `@[simp]`: the simpNF linter rewrites the stated LHS through the unconditional simp
+-- lemma `ModularGroup.sl_moeb` to the `GL (Fin 2) ℝ`-lifted double action, the same reason
+-- `norm_coe_S_smul` and `re_S_smul` above are not tagged.
 /-- The inversion is an involution of `ℍ`. -/
-@[simp]
 lemma S_smul_S_smul (p : ℍ) : _root_.ModularGroup.S • (_root_.ModularGroup.S • p) = p := by
   rw [← _root_.ModularGroup.SL_neg_smul, ← _root_.ModularGroup.S_inv, inv_smul_smul]
 

--- a/TauCeti/NumberTheory/Modular/Orbits.lean
+++ b/TauCeti/NumberTheory/Modular/Orbits.lean
@@ -147,6 +147,21 @@ lemma re_S_smul_of_norm_eq_one {p : ℍ} (hp : ‖(p : ℂ)‖ = 1) :
     (_root_.ModularGroup.S • p).re = -p.re := by
   rw [re_S_smul, Complex.normSq_eq_norm_sq, hp, one_pow, div_one]
 
+/-- On the unit circle the inversion preserves the closed fundamental domain: the norm stays
+at `1`, and the real-part bound is symmetric under the sign flip. -/
+lemma S_smul_mem_fd {p : ℍ} (hp : p ∈ 𝒟) (hnorm : ‖(p : ℂ)‖ = 1) :
+    _root_.ModularGroup.S • p ∈ 𝒟 := by
+  refine ⟨?_, ?_⟩
+  · rw [Complex.normSq_eq_norm_sq, norm_coe_S_smul_of_norm_eq_one hnorm]
+    norm_num
+  · rw [re_S_smul_of_norm_eq_one hnorm, abs_neg]
+    exact hp.2
+
+/-- The inversion is an involution of `ℍ`. -/
+lemma S_smul_S_smul (p : ℍ) : _root_.ModularGroup.S • (_root_.ModularGroup.S • p) = p :=
+  UpperHalfPlane.ext <| by
+    rw [modular_S_smul, modular_S_smul, coe_mk, coe_mk, neg_inv, neg_neg, inv_inv]
+
 /-- A point of the closed fundamental domain lying in the `SL(2, ℤ)`-orbit of `i` is `i`
 itself: the boundary identifications of `𝒟` fix `i`. -/
 @[simp]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/BoundaryPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/BoundaryPairing.lean
@@ -145,7 +145,7 @@ private lemma S_smul_mem_of_norm_eq_one (hS : ∀ q ∈ S, orderOfVanishingAt g 
     (hnorm : ‖(p : ℂ)‖ = 1) (hne : orderOfVanishingAt g p ≠ 0) :
     ModularGroup.S • p ∈ S ∧ ‖((ModularGroup.S • p : ℍ) : ℂ)‖ = 1 ∧
       ((ModularGroup.S • p : ℍ) : ℂ).re = -(p : ℂ).re :=
-  ⟨hcomp _ (ModularGroup.S_smul_mem_fd (hS p hp hne) hnorm) (hord ▸ hne),
+  ⟨hcomp _ (ModularGroup.S_smul_mem_fd_of_norm_eq_one (hS p hp hne).2 hnorm) (hord ▸ hne),
     ModularGroup.norm_coe_S_smul_of_norm_eq_one hnorm,
     by rw [coe_re, ModularGroup.re_S_smul_of_norm_eq_one hnorm, coe_re]⟩
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/BoundaryPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/BoundaryPairing.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.NumberTheory.Modular
 public import TauCeti.Analysis.Complex.UpperHalfPlane.Rho
 public import TauCeti.NumberTheory.ModularForms.Order.OfVanishing
+import TauCeti.NumberTheory.Modular.Orbits
 
 /-!
 # Pairing the boundary divisor points of the fundamental domain
@@ -126,25 +127,6 @@ section Arc
 
 variable {g : ℍ → ℂ} {p : ℍ}
 
-private lemma coe_S_smul (p : ℍ) : ((ModularGroup.S • p : ℍ) : ℂ) = (-(p : ℂ))⁻¹ := by
-  rw [modular_S_smul]
-
-private lemma norm_coe_S_smul (hp : ‖(p : ℂ)‖ = 1) : ‖((ModularGroup.S • p : ℍ) : ℂ)‖ = 1 := by
-  rw [coe_S_smul, norm_inv, norm_neg, hp, inv_one]
-
--- On the unit arc the inversion is `z ↦ -conj z`, so it flips the real part.
-private lemma re_coe_S_smul (hp : ‖(p : ℂ)‖ = 1) :
-    ((ModularGroup.S • p : ℍ) : ℂ).re = -(p : ℂ).re := by
-  rw [coe_S_smul, inv_re, normSq_neg, Complex.normSq_eq_norm_sq, hp, one_pow, neg_re, div_one]
-
-private lemma S_smul_mem_fd (hp : p ∈ 𝒟) (hnorm : ‖(p : ℂ)‖ = 1) : ModularGroup.S • p ∈ 𝒟 :=
-  ⟨Complex.one_le_normSq_iff.mpr (norm_coe_S_smul hnorm).ge,
-    by simpa only [← coe_re, re_coe_S_smul hnorm, abs_neg] using hp.2⟩
-
-/-- The inversion is an involution of `ℍ`. -/
-private lemma S_smul_S_smul (p : ℍ) : ModularGroup.S • (ModularGroup.S • p) = p :=
-  UpperHalfPlane.ext (by rw [coe_S_smul, coe_S_smul, neg_inv, neg_neg, inv_inv])
-
 /-- Slash-invariance carries the vanishing order along the inversion. -/
 private lemma orderOfVanishingAt_S_smul [SlashInvariantFormClass F Γ k] (f : F)
     (hSmem : ModularGroup.S ∈ Γ) (p : ℍ) :
@@ -163,8 +145,9 @@ private lemma S_smul_mem_of_norm_eq_one (hS : ∀ q ∈ S, orderOfVanishingAt g 
     (hnorm : ‖(p : ℂ)‖ = 1) (hne : orderOfVanishingAt g p ≠ 0) :
     ModularGroup.S • p ∈ S ∧ ‖((ModularGroup.S • p : ℍ) : ℂ)‖ = 1 ∧
       ((ModularGroup.S • p : ℍ) : ℂ).re = -(p : ℂ).re :=
-  ⟨hcomp _ (S_smul_mem_fd (hS p hp hne) hnorm) (hord ▸ hne), norm_coe_S_smul hnorm,
-    re_coe_S_smul hnorm⟩
+  ⟨hcomp _ (ModularGroup.S_smul_mem_fd (hS p hp hne) hnorm) (hord ▸ hne),
+    ModularGroup.norm_coe_S_smul_of_norm_eq_one hnorm,
+    by rw [coe_re, ModularGroup.re_S_smul_of_norm_eq_one hnorm, coe_re]⟩
 
 end Arc
 
@@ -182,7 +165,8 @@ theorem sum_orderOfVanishingAt_rightArc_eq_leftArc [SlashInvariantFormClass F Γ
   rw [← Finset.sum_filter_ne_zero, ← Finset.sum_filter_ne_zero
     (s := S.filter (fun p : ℍ ↦ ‖(p : ℂ)‖ = 1 ∧ (p : ℂ).re < 0))]
   refine Finset.sum_nbij' (ModularGroup.S • ·) (ModularGroup.S • ·) (fun q hq ↦ ?_)
-    (fun q hq ↦ ?_) (fun q _ ↦ S_smul_S_smul q) (fun q _ ↦ S_smul_S_smul q)
+    (fun q hq ↦ ?_) (fun q _ ↦ ModularGroup.S_smul_S_smul q)
+    (fun q _ ↦ ModularGroup.S_smul_S_smul q)
     (fun q _ ↦ (hord q).symm)
   -- the two halves of the arc are interchanged by the same argument, `re` flipping sign
   all_goals

--- a/TauCeti/NumberTheory/ModularForms/Order/OrbitReduction.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OrbitReduction.lean
@@ -189,7 +189,7 @@ private lemma exists_of_norm_eq_one_of_re_pos [ModularFormClass F 𝒮ℒ k] {f 
   have hne : ((ModularGroup.S • p₀ : ℍ) : ℂ) ≠ (ρ : ℂ) := fun h ↦
     hqρ (horb ▸ congrArg Quotient.mk'' (UpperHalfPlane.coe_injective h))
   refine ⟨ModularGroup.S • p₀, mem_canonicalReps.mpr ⟨mem_fdZeros.mpr
-    ⟨ModularGroup.S_smul_mem_fd hfd hnorm, hord'⟩,
+    ⟨ModularGroup.S_smul_mem_fd_of_norm_eq_one hfd.2 hnorm, hord'⟩,
       Or.inr (Or.inr ⟨hne, ModularGroup.norm_coe_S_smul_of_norm_eq_one hnorm, ?_⟩)⟩, horb⟩
   rw [coe_re, ModularGroup.re_S_smul_of_norm_eq_one hnorm]
   exact neg_lt_zero.mpr (coe_re p₀ ▸ hpos)

--- a/TauCeti/NumberTheory/ModularForms/Order/OrbitReduction.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OrbitReduction.lean
@@ -140,14 +140,6 @@ theorem orbit_mk_injOn_canonicalReps [ModularFormClass F 𝒮ℒ k] {f : F}
     · norm_num [hnorm] at hgt
     · exact coe_re p ▸ hre
 
-private lemma S_smul_mem_fd {p : ℍ} (hp : p ∈ 𝒟) (hnorm : ‖(p : ℂ)‖ = 1) :
-    ModularGroup.S • p ∈ 𝒟 := by
-  refine ⟨?_, ?_⟩
-  · rw [Complex.normSq_eq_norm_sq, ModularGroup.norm_coe_S_smul_of_norm_eq_one hnorm]
-    norm_num
-  · rw [ModularGroup.re_S_smul_of_norm_eq_one hnorm, abs_neg]
-    exact hp.2
-
 private lemma normSq_coe_vadd_neg_one {p : ℍ} (hre : (p : ℂ).re = 1 / 2) :
     Complex.normSq (((-1 : ℝ) +ᵥ p : ℍ) : ℂ) = Complex.normSq (p : ℂ) := by
   rw [coe_re] at hre
@@ -197,7 +189,7 @@ private lemma exists_of_norm_eq_one_of_re_pos [ModularFormClass F 𝒮ℒ k] {f 
   have hne : ((ModularGroup.S • p₀ : ℍ) : ℂ) ≠ (ρ : ℂ) := fun h ↦
     hqρ (horb ▸ congrArg Quotient.mk'' (UpperHalfPlane.coe_injective h))
   refine ⟨ModularGroup.S • p₀, mem_canonicalReps.mpr ⟨mem_fdZeros.mpr
-    ⟨S_smul_mem_fd hfd hnorm, hord'⟩,
+    ⟨ModularGroup.S_smul_mem_fd hfd hnorm, hord'⟩,
       Or.inr (Or.inr ⟨hne, ModularGroup.norm_coe_S_smul_of_norm_eq_one hnorm, ?_⟩)⟩, horb⟩
   rw [coe_re, ModularGroup.re_S_smul_of_norm_eq_one hnorm]
   exact neg_lt_zero.mpr (coe_re p₀ ▸ hpos)


### PR DESCRIPTION
Roadmap: ModularForms
<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-formula/s-smul-dedup"}-->

## Summary

Deduplicates the unit-circle `S`-action facts that accumulated three copies as the valence
chain landed. A refactor of existing declarations; no new mathematics — the ModularForms
roadmap names the motivating development.

- `Modular/Orbits.lean` gains two public lemmas beside the existing unit-circle pair
  (`norm_coe_S_smul_of_norm_eq_one`, `re_S_smul_of_norm_eq_one`):
  `S_smul_mem_fd` — on the unit circle the inversion preserves the closed fundamental
  domain — and `S_smul_S_smul` — the inversion is an involution of `ℍ`.
- `FundamentalDomainBoundary/BoundaryPairing.lean` deletes its five private copies
  (`coe_S_smul`, `norm_coe_S_smul`, `re_coe_S_smul`, `S_smul_mem_fd`, `S_smul_S_smul`) and
  consumes the `Modular/Orbits` API through a proof-only import.
- `Order/OrbitReduction.lean` deletes its private duplicate of `S_smul_mem_fd`.

Net −9 lines across 3 files; no statement or name visible to consumers changes except the
two promotions.

## Provenance

Provenance: none — a relocation/dedup of declarations already in the repository (introduced
across #2944, #2963, #2857); no external source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
