### PR TITLE
refactor(Huber): split LocalizationTopology into a directory

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
@@ -7,15 +7,20 @@ module
 public import TauCeti.RingTheory.Localization.Away
 public import Mathlib.Topology.Algebra.Nonarchimedean.Bases
 public import Mathlib.RingTheory.Adjoin.Polynomial.Basic
-public import TauCeti.RingTheory.Huber.Completion
+public import TauCeti.RingTheory.Huber.Basic
 
 /-!
-# Localization Topology for Huber Rings
+# The localisation topology: construction
 
-We construct the non-archimedean ring topology on a localisation `S` of `A` away from an
-element `s`, following Proposition and Definition 5.51, §5.6, of Wedhorn's *Adic Spaces*. The
-carrier is an arbitrary `IsLocalization.Away s S` rather than the concrete `Localization.Away s`,
-so a consumer holding `A[1/s]` in another presentation can use the topology directly.
+We construct the non-archimedean ring topology on a localisation `S` of `A` away from an element
+`s`, following Proposition and Definition 5.51, §5.6, of Wedhorn's *Adic Spaces*, and show that
+`Aₛ` under it is a Huber ring. The carrier is an arbitrary `IsLocalization.Away s S` rather than
+the concrete `Localization.Away s`, so a consumer holding `A[1/s]` in another presentation can use
+the topology directly.
+
+The material about *maps out of* `Aₛ` is in the sibling modules: the continuity criterion and the
+universal property in `LocalizationTopology.UniversalProperty`, the completion `A⟨T/s⟩` in
+`LocalizationTopology.Completion`.
 
 ## Main definitions
 
@@ -23,95 +28,31 @@ so a consumer holding `A[1/s]` in another presentation can use the topology dire
 * `HasDenominatorPower P T s S` : the standing hypothesis the construction runs under — some power
   of `I` has all of its fractions `b/s` already in `D`.
 * `locIdeal P T s S` : the candidate ideal of definition `J = I · D` in `D`.
-* `locIdealImage P T s S n` : The `n`-th neighborhood `image(Jⁿ)` in `Aₛ`.
-* `locUniformSpace P T s S` : the uniformity `locTopology` determines, packaged so that
-  `UniformSpace.Completion S` — Wedhorn's `A⟨T/s⟩` — can be written down.
-* `toCompletionLoc P T s S` : the structure map `A → A⟨T/s⟩`.
-* `localizationUniform P T s S` : the pair `localization`, transported to the topology
-  `locUniformSpace` induces, so that no statement about `A⟨T/s⟩` carries the transport. Its
-  `localizationUniform_ringOfDefinition` and `mem_localizationUniform_idealOfDefinition` reduce it
-  to the concrete `D` and `J`, so the completed pair's characteristic lemmas do too.
-* `completionLocalization P T s S` : the pair of definition `A⟨T/s⟩` carries, characterised by
-  `completionLocalization_ringOfDefinition` and
-  `mem_completionLocalization_idealOfDefinition`.
+* `locIdealImage P T s S n` : the `n`-th neighborhood `image(Jⁿ)` in `Aₛ`.
+* `locBasis` and `locTopology` : the neighbourhoods form a `RingSubgroupsBasis`, hence a ring
+  topology on `Aₛ`.
+* `localization P T s S` : the pair of definition `Aₛ` carries under that topology.
 
 ## Main results
 
-* `hasDenominatorPower_of_pow_le_span`: the standing hypothesis holds whenever some power of `I`
-  lies in `s · A₀`.
-* `locSubring_le_iff`, with `locSubring_empty` and `locSubring_mono`: the universal property of
-  `D` and the two consequences of it this file needs.
-* `locIdeal_pow`, `locIdeal_pow_eq_span`, `toLocSubring_mem_locIdeal_pow` and
-  `algebraMap_mem_locIdealImage`: the characteristic lemmas for the powers of `J` and their images,
-  which stand in for unfolding `locIdeal` (whose body is not exported).
-* `locIdealImage_antitone`: Neighborhoods are antitone.
-* `locIdealImage_preimage_eq_locIdeal_pow`: the image and preimage along the subtype embedding are
-  inverse on `Jⁿ`. This is what identifies the subspace topology on `D` with its `J`-adic
-  topology, in `hasBasis_nhds_zero_locSubring` and `isAdic_locIdeal` below.
-* `locIdealImage_mul_subset_add`: the basis is graded,
-  `locIdealImage i * locIdealImage j ⊆ locIdealImage (i + j)`; `locIdealImage_mul_subset` and
-  `locIdealImage_mul_locSubring_subset` are its diagonal and zeroth cases.
-* `locIdealImage_leftMul`: the remaining multiplicative compatibility the subgroup basis needs.
-* `locBasis`: The neighborhoods form a `RingSubgroupsBasis`, so they are the zero-neighbourhood
-  basis of a ring topology on `Aₛ`, namely `locTopology`.
 * `hasBasis_nhds_zero_locTopology`, `isTopologicalRing_locTopology` and
-  `nonarchimedeanRing_locTopology`: the contract of `locTopology`, to be used in place of unfolding
-  the construction.
-* `continuous_algebraMap_locTopology`: the structure map `A → Aₛ` is continuous.
-* `isOpen_locIdealImage`, and `isOpen_locSubring` with `isBounded_locSubring`: every basic
-  neighbourhood is open, and `D` is open and bounded.
-* `hasBasis_nhds_zero_locSubring` and `isAdic_locIdeal`: the powers of `J` are a neighbourhood
-  basis of zero in `D`, so the subspace topology on `D` is the `J`-adic one. With `fg_locIdeal`
-  this completes every condition `TauCeti.Huber.PairOfDefinition` asks of the pair `(D, J)`.
-* `localization` and `isHuberRing_locTopology`: those conditions assembled, so `Aₛ` under
-  `locTopology` is a Huber ring. `localization_ringOfDefinition` and
-  `mem_localization_idealOfDefinition` are its contract, since the body of `localization` is not
-  exposed.
-* `isPowerBounded_of_mem_locSubring` and `isPowerBounded_divBy`: every element of `D` — in
-  particular each fraction `t/s` — is power-bounded, the fact a converse to the continuity
-  criterion needs.
-* `continuous_of_continuous_algebraMap_of_isPowerBounded`: a sufficient criterion
-  for a ring homomorphism out of `Aₛ` to be continuous — its restriction along `algebraMap` is
-  continuous and the fractions `t/s` go to power-bounded elements. The converse is not proved
-  here.
-* `existsUnique_continuous_ringHom_locTopology`: Wedhorn 5.51's universal property — a continuous
-  `φ : A →+* B` inverting `s` and sending each `t/s` to a power-bounded element extends to `Aₛ` in
-  exactly one continuous way.
-* `isUniformAddGroup_locUniformSpace` and `isTopologicalRing_locUniformSpace`: the two companions
-  of `locUniformSpace`. Since `locTopology` is not an instance, a statement about `A⟨T/s⟩` has to
-  name its structures; these three declarations are what it names, and `toCompletionLoc_apply`
-  computes the structure map.
-* `locUniformSpace_toTopologicalSpace`: the topology `locUniformSpace` induces is `locTopology`.
-  This is what a proof rewrites against, so no body in this file needs exposing.
-* `continuous_toCompletionLoc`: the structure map `A → A⟨T/s⟩` is continuous.
-* `isHuberRing_completion_locTopology` and
-  `existsUnique_continuous_ringHom_completion_locTopology`: the separated completion `A⟨T/s⟩` is
-  Huber — witnessed by `completionLocalization`, exactly as `localization` witnesses
-  `isHuberRing_locTopology` — and the same universal property holds across it for complete
-  Hausdorff targets.
+  `nonarchimedeanRing_locTopology`: the contract of `locTopology`, to be used in place of
+  unfolding the construction.
+* `isHuberRing_locTopology`: `Aₛ` under `locTopology` is a Huber ring.
 
 ## Provenance
 
-This is a port of AINTLIB's `LocalizationTopology.lean`, at commit `d9f2fbbb`. The main
-changes are:
-- Adapted `PairOfDefinition` field names to TauCeti conventions
-  (`A₀`→`ringOfDefinition`, `I`→`ideal`, etc.)
-- Uses TauCeti's module system and namespace structure
-- Uses characteristic lemmas instead of destructuring definitions
-- Removed unused hypotheses to satisfy `#lint` checks
-- Stated over an arbitrary localisation `S` away from `s`, rather than the concrete model
-  `Localization.Away s` the source uses
+This is a port of AINTLIB's `LocalizationTopology.lean`, at commit `d9f2fbbb`. The main changes
+are: adapted `PairOfDefinition` field names to TauCeti conventions (`A₀`→`ringOfDefinition`,
+`I`→`ideal`, etc.); uses characteristic lemmas instead of destructuring definitions; removed
+unused hypotheses to satisfy `#lint` checks; stated over an arbitrary localisation `S` away from
+`s`, rather than the concrete model `Localization.Away s` the source uses.
 
 ## References
 
 * [T. Wedhorn, *Adic Spaces*][wedhorn_adic], Proposition and Definition 5.51, §5.6
 * [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
   commit `d9f2fbbb`, `projects/AdicSpaces/Adic spaces/LocalizationTopology.lean`
-* `Mathlib.Topology.Algebra.Valued.ValuationTopology`, `Valued.mk'` — the model for the
-  instance setup in the completion results below. It layers
-  `IsTopologicalAddGroup.rightUniformSpace` and `isUniformAddGroup_of_addCommGroup` on a topology
-  built from a `RingSubgroupsBasis`, passing that topology positionally because it is not an
-  instance; `locTopology` is in the same position here.
 -/
 
 open Pointwise Topology
@@ -743,422 +684,6 @@ theorem isHuberRing_locTopology [IsTopologicalRing A] (P : PairOfDefinition A) (
   letI := locTopology P T s S hden
   letI := isTopologicalRing_locTopology P T s S hden
   ⟨⟨localization P T s S hden⟩⟩
-
-/-! ### A sufficient criterion for continuity -/
-
-/-- Along `algebraMap`, some power of the ideal of definition multiplies the image of `A₀` into
-any prescribed open subgroup of `B`. This is the `A₀`-level base case of
-`exists_pow_mul_locSubring_mem`. -/
-private theorem exists_pow_mul_algebraMap_mem {B : Type*} [Ring B] [TopologicalSpace B]
-    (P : PairOfDefinition A)
-    (S : Type*) [Ring S] [Algebra A S] (f : S →+* B)
-    (hf : Continuous (f.comp (algebraMap A S))) (G : OpenAddSubgroup B) :
-    ∃ m : ℕ, ∀ x ∈ P.ringOfDefinition.map (algebraMap A S),
-      ∀ b ∈ P.idealOfDefinition ^ m,
-        f (x * algebraMap A S (b : A)) ∈ (G : Set B) := by
-  obtain ⟨m, hm⟩ : ∃ m : ℕ, ∀ b ∈ P.idealOfDefinition ^ m,
-      f (algebraMap A S (b : A)) ∈ (G : Set B) := by
-    have hcont : Filter.Tendsto (f.comp (algebraMap A S)) (𝓝 0) (𝓝 0) := by
-      rw [← map_zero (f.comp (algebraMap A S))]
-      exact hf.continuousAt
-    obtain ⟨n, -, hn⟩ := P.hasBasis_nhds_zero.mem_iff.mp (hcont (G.isOpen.mem_nhds G.zero_mem))
-    exact ⟨n, fun b hb ↦ hn ((P.mem_idealImage n).mpr ⟨b, hb, rfl⟩)⟩
-  refine ⟨m, ?_⟩
-  rintro _ ⟨a₀, ha₀, rfl⟩ b hb
-  rw [← map_mul (algebraMap A S)]
-  exact hm ⟨(a₀ : A) * (b : A), P.ringOfDefinition.mul_mem ha₀ b.property⟩
-    (Ideal.mul_mem_left _ ⟨a₀, ha₀⟩ hb)
-
-/-- The same statement with `A₀` replaced by all of `D = A₀[t₁/s, …, tₙ/s]`. This is where
-power-boundedness of the fractions enters: the induction adjoins one `t/s` at a time and writes an
-element of the larger ring as a polynomial in it, whose powers a bounded set absorbs.
-
-Stated over an arbitrary `U : Finset A` rather than the `T` of the theorem that uses it, because
-that is what the `Finset.induction` needs. -/
-private theorem exists_pow_mul_locSubring_mem {B : Type*} [Ring B] [TopologicalSpace B]
-    [NonarchimedeanRing B] (P : PairOfDefinition A) (s : A)
-    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (f : S →+* B)
-    (hf : Continuous (f.comp (algebraMap A S))) (U : Finset A) :
-    (∀ t ∈ U, IsPowerBounded (f (divBy t s))) →
-      ∀ G : OpenAddSubgroup B, ∃ m : ℕ, ∀ x ∈ locSubring P U s S,
-        ∀ b ∈ P.idealOfDefinition ^ m,
-          f (x * algebraMap A S (b : A)) ∈ (G : Set B) := by
-  classical
-  induction U using Finset.induction with
-  | empty =>
-    intro _ G
-    obtain ⟨m, hm⟩ := exists_pow_mul_algebraMap_mem P S f hf G
-    exact ⟨m, fun x hx b hb ↦ hm x (locSubring_empty P s S ▸ hx) b hb⟩
-  | insert t U' ht ih =>
-    intro hpowU G
-    have hinsert_le : locSubring P (insert t U') s S ≤
-        Subring.closure ((locSubring P U' s S : Set S) ∪ {divBy t s}) :=
-      (locSubring_le_iff P _ s S).mpr
-        ⟨fun _ ha ↦ Subring.subset_closure (.inl (algebraMap_mem_locSubring P U' s S ha)),
-         fun t' ht' ↦ by
-           rcases Finset.mem_insert.mp ht' with rfl | ht'U
-           · exact Subring.subset_closure (.inr rfl)
-           · exact Subring.subset_closure (.inl (divBy_mem_locSubring P U' s S ht'U))⟩
-    obtain ⟨V, hV, hzV⟩ := isBounded_iff.mp (isPowerBounded_iff.mp
-      (hpowU t (Finset.mem_insert_self t U'))) (G : Set B) (G.isOpen.mem_nhds G.zero_mem)
-    obtain ⟨W, hWV⟩ := NonarchimedeanAddGroup.is_nonarchimedean V hV
-    obtain ⟨m, hm⟩ := ih (fun t' ht' ↦ hpowU t' (Finset.mem_insert_of_mem ht')) W
-    refine ⟨m, fun x hx b hb ↦ ?_⟩
-    -- Write `x` as a polynomial in `t/s` with coefficients in the smaller subring.
-    have hx_adj : x ∈ Algebra.adjoin (locSubring P U' s S)
-        ({divBy t s} : Set S) := by
-      have h_le : Subring.closure
-          ((locSubring P U' s S : Set S) ∪ {divBy t s}) ≤
-            (Algebra.adjoin (locSubring P U' s S)
-              ({divBy t s} : Set S)).toSubring := by
-        rw [Subring.closure_le]
-        rintro w (hw | rfl)
-        · exact Subalgebra.algebraMap_mem _ (⟨w, hw⟩ : locSubring P U' s S)
-        · exact Algebra.subset_adjoin rfl
-      exact h_le (hinsert_le hx)
-    rw [Algebra.adjoin_singleton_eq_range_aeval, AlgHom.mem_range] at hx_adj
-    obtain ⟨p, hp⟩ := hx_adj
-    rw [← hp, Polynomial.aeval_eq_sum_range, Finset.sum_mul, map_sum]
-    refine G.toAddSubgroup.sum_mem fun i _ ↦ ?_
-    rw [Algebra.smul_def, Algebra.algebraMap_ofSubsemiring_apply, mul_right_comm,
-      map_mul, map_pow]
-    exact hzV (Set.mul_mem_mul (hWV (hm _ (p.coeff i).property b hb)) ⟨i, rfl⟩)
-
-/-- A ring homomorphism out of `Aₛ` is continuous for the localisation topology as soon as its
-restriction along `algebraMap` is continuous and the fractions `t/s` are sent to power-bounded
-elements. This is a sufficient criterion only; no converse is proved here.
-
-The second hypothesis does real work rather than following from the first: `D` is generated over
-`A₀` by exactly those fractions, so continuity of `f ∘ algebraMap` alone says nothing about the
-image of `D`. -/
-theorem continuous_of_continuous_algebraMap_of_isPowerBounded {B : Type*}
-    [Ring B] [TopologicalSpace B] [NonarchimedeanRing B] [IsTopologicalRing A]
-    (P : PairOfDefinition A) (T : Finset A) (s : A)
-    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S)
-    (f : S →+* B)
-    (hf : Continuous (f.comp (algebraMap A S)))
-    (hpow : ∀ t ∈ T, IsPowerBounded (f (divBy t s))) :
-    @Continuous _ _ (locTopology P T s S hden) _ f := by
-  have hfull := exists_pow_mul_locSubring_mem P s S f hf T hpow
-  let _ : TopologicalSpace S := locTopology P T s S hden
-  have : IsTopologicalRing S := isTopologicalRing_locTopology P T s S hden
-  refine continuous_of_continuousAt_zero f ?_
-  rw [ContinuousAt, map_zero, Filter.tendsto_def]
-  intro V hV
-  obtain ⟨W, hWV⟩ := NonarchimedeanAddGroup.is_nonarchimedean V hV
-  obtain ⟨m, hm⟩ := hfull W
-  refine Filter.mem_of_superset
-    ((hasBasis_nhds_zero_locTopology P T s S hden).mem_iff.mpr ⟨m, trivial, le_refl _⟩) ?_
-  intro x hx
-  obtain ⟨d, hd, rfl⟩ := (mem_locIdealImage_iff P T s S m).mp hx
-  refine hWV ?_
-  rw [locIdeal_pow_eq_span] at hd
-  suffices h : ∀ r : locSubring P T s S,
-      f ((locSubring P T s S).subtype (r * d)) ∈ (W : Set B) by
-    simpa using h 1
-  refine Submodule.span_induction (p := fun d _ ↦ ∀ r : locSubring P T s S,
-    f ((locSubring P T s S).subtype (r * d)) ∈ (W : Set B)) ?_ ?_ ?_ ?_ hd
-  · rintro _ ⟨b, hb, rfl⟩ r
-    rw [Subring.coe_subtype, MulMemClass.coe_mul, toLocSubring_apply]
-    exact hm r.val r.property b hb
-  · intro r
-    simp
-  · intro d₁ d₂ _ _ h₁ h₂ r
-    rw [mul_add, map_add, map_add]
-    exact W.toAddSubgroup.add_mem (h₁ r) (h₂ r)
-  · intro c d _ hd r
-    rw [smul_eq_mul, ← mul_assoc]
-    exact hd (r * c)
-
-
-/-! ### The universal property -/
-
-/-- **Wedhorn 5.51, the universal property of `Aₛ` under `locTopology`.** A ring homomorphism
-`φ : A →+* B` into a nonarchimedean ring extends to `Aₛ` in exactly one continuous way, provided
-`φ` is continuous, `φ s` is a unit, and each fraction `φ t / φ s` is power-bounded.
-
-The condition on the fractions is stated as sufficient, and only that. It is *not* forced by
-continuity: a continuous ring homomorphism need not carry power-bounded elements to power-bounded
-elements — `IsBounded.image` in `Huber/Bounded.lean` is stated for the image under a map, and
-`IsBounded.image_of_isOpenMap` needs openness on top, precisely because continuity alone does not
-suffice. Whether some weaker condition is also necessary is not addressed here.
-
-The map itself is Mathlib's `IsLocalization.Away.lift`, which is purely algebraic and needs no
-topology; the topology's contribution is that this lift is *continuous*, supplied by
-`continuous_of_continuous_algebraMap_of_isPowerBounded`. Uniqueness is
-`IsLocalization.ringHom_ext` and is algebraic too: a homomorphism out of a localisation is already
-determined by its restriction along `algebraMap`, so nothing topological enters there. -/
-theorem existsUnique_continuous_ringHom_locTopology {B : Type*} [CommRing B] [TopologicalSpace B]
-    [NonarchimedeanRing B] [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A) (s : A)
-    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) {φ : A →+* B} (hφ : ContinuousAt φ 0) (hs : IsUnit (φ s))
-    (hpow : ∀ t ∈ T, IsPowerBounded (φ t * ↑hs.unit⁻¹)) :
-    letI := locTopology P T s S hden
-    ∃! f : S →+* B, Continuous f ∧ f.comp (algebraMap A S) = φ := by
-  let _ := locTopology P T s S hden
-  refine ⟨IsLocalization.Away.lift s hs, ⟨?_, IsLocalization.Away.lift_comp s hs⟩, ?_⟩
-  · refine continuous_of_continuous_algebraMap_of_isPowerBounded P T s S hden _ ?_ ?_
-    · rw [IsLocalization.Away.lift_comp s hs]; exact continuous_of_continuousAt_zero φ hφ
-    · intro t ht
-      have : IsLocalization.Away.lift s hs ((divBy t s : S)) = φ t * ↑hs.unit⁻¹ := by
-        rw [divBy_def, IsLocalization.Away.lift, IsLocalization.lift_mk']
-        congr 2
-      rw [this]; exact hpow t ht
-  · rintro g ⟨-, hg⟩
-    exact IsLocalization.ringHom_ext (Submonoid.powers s)
-      (hg.trans (IsLocalization.Away.lift_comp s hs).symm)
-
-/-! ### The completion `A⟨T/s⟩` -/
-
-/-- **The canonical uniformity on `Aₛ`**, the one its topology determines.
-
-`locTopology` is not an instance, so a consumer of the completion has to name the uniform structure
-explicitly. This packages the construction, and it takes **three** declarations to state anything
-about `A⟨T/s⟩`: `locUniformSpace` makes `UniformSpace.Completion S` well-formed,
-`isUniformAddGroup_locUniformSpace` makes the completion an additive group, and
-`isTopologicalRing_locUniformSpace` is what its ring structure is inferred from. The first two
-alone do not suffice.
-
-`locUniformSpace_toTopologicalSpace` is the characteristic property — the topology it induces is
-`locTopology` — so the body is not exposed and a proof rewrites against that lemma instead.
-
-It is *the* uniformity, not merely one compatible with the topology:
-`IsUniformAddGroup.rightUniformSpace_eq` identifies it with any uniformity making `Aₛ` a uniform
-additive group, so a consumer arriving with its own such structure rewrites rather than
-transports. -/
-@[instance_reducible]
-noncomputable def locUniformSpace (P : PairOfDefinition A) (T : Finset A) (s : A) (S : Type*)
-    [CommRing S] [Algebra A S] [IsLocalization.Away s S] (hden : HasDenominatorPower P T s S)
-    [IsTopologicalRing A] : UniformSpace S :=
-  letI tS := locTopology P T s S hden
-  letI := isTopologicalRing_locTopology P T s S hden
-  @IsTopologicalAddGroup.rightUniformSpace S _ tS _
-
-/-- The topology `locUniformSpace` induces is `locTopology`. This is the characteristic property
-of the packaged uniformity: it lets a statement made at one be rewritten to the other. -/
-@[simp]
-theorem locUniformSpace_toTopologicalSpace [IsTopologicalRing A] (P : PairOfDefinition A)
-    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    (locUniformSpace P T s S hden).toTopologicalSpace = locTopology P T s S hden := (rfl)
-
-/-- `Aₛ` is a uniform additive group for `locUniformSpace`. The companion of `locUniformSpace`:
-the two together are what `UniformSpace.Completion S` needs. -/
-theorem isUniformAddGroup_locUniformSpace [IsTopologicalRing A] (P : PairOfDefinition A)
-    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    @IsUniformAddGroup S (locUniformSpace P T s S hden) _ :=
-  @isUniformAddGroup_of_addCommGroup _ _ (locTopology P T s S hden) _
-
-/-- `Aₛ` is a topological ring for the topology `locUniformSpace` induces. Stated at that
-topology rather than at `locTopology`, so that it applies where the packaged uniformity is in
-scope. -/
-theorem isTopologicalRing_locUniformSpace [IsTopologicalRing A] (P : PairOfDefinition A)
-    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    letI := locUniformSpace P T s S hden
-    IsTopologicalRing S :=
-  isTopologicalRing_locTopology P T s S hden
-
-/-- **The structure map `A → A⟨T/s⟩`**, the localisation map followed by the completion map. This
-is the canonical ring homomorphism the universal property extends. -/
-noncomputable def toCompletionLoc [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A)
-    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    A →+* UniformSpace.Completion S :=
-  letI := locUniformSpace P T s S hden
-  letI := isUniformAddGroup_locUniformSpace P T s S hden
-  letI := isTopologicalRing_locUniformSpace P T s S hden
-  (UniformSpace.Completion.coeRingHom).comp (algebraMap A S)
-
-/-- The structure map is the localisation map followed by the completion map. The body of
-`toCompletionLoc` is not exported, so this is how a consumer computes with it. -/
-@[simp]
-theorem toCompletionLoc_apply [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A) (s : A)
-    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) (a : A) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    toCompletionLoc P T s S hden a = (algebraMap A S a : UniformSpace.Completion S) := (rfl)
-
-
-/-- The localisation pair `localization`, transported along `locUniformSpace_toTopologicalSpace`
-to the topology the packaged uniformity induces.
-
-`localization` is stated at `locTopology` and the completion is taken at `locUniformSpace`. The
-two topologies are equal, but not syntactically, so the transport has to be named: naming it here
-keeps the cast out of every statement about `A⟨T/s⟩` below. -/
-noncomputable def localizationUniform [IsTopologicalRing A] (P : PairOfDefinition A)
-    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    letI := locUniformSpace P T s S hden
-    PairOfDefinition S :=
-  (locUniformSpace_toTopologicalSpace P T s S hden).symm ▸ localization P T s S hden
-
-/-- The ring of definition of `localizationUniform` is `D`, as for `localization`: the transport
-is along an equality of topologies and `ringOfDefinition` is a `Subring S`, which does not depend
-on one. This is what makes the completed pair's API reduce to the concrete data. -/
-@[simp]
-theorem localizationUniform_ringOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A)
-    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    letI := locUniformSpace P T s S hden
-    (localizationUniform P T s S hden).ringOfDefinition = locSubring P T s S := (rfl)
-
-/-- Membership in the ideal of definition of `localizationUniform` is membership in `J`, as for
-`localization`. With `localizationUniform_ringOfDefinition` this reduces the completed pair's
-characteristic lemmas to the concrete `D` and `J`. -/
-@[simp]
-theorem mem_localizationUniform_idealOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A)
-    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S)
-    {x : letI := locUniformSpace P T s S hden;
-      (localizationUniform P T s S hden).ringOfDefinition} :
-    letI := locUniformSpace P T s S hden
-    x ∈ (localizationUniform P T s S hden).idealOfDefinition ↔
-      (⟨x, by rw [← localizationUniform_ringOfDefinition P T s S hden]; exact x.2⟩ :
-        locSubring P T s S) ∈ locIdeal P T s S := (Iff.rfl)
-
-/-- **The pair of definition on `A⟨T/s⟩`**, the completion of the pair `localization` carries on
-`Aₛ`. This is the completed counterpart of `localization`, and it is what makes `A⟨T/s⟩` Huber.
-
-Its ring of definition and ideal of definition are characterised by
-`completionLocalization_ringOfDefinition` and `mem_completionLocalization_idealOfDefinition`,
-which are how a consumer computes with it — the body is not exposed. -/
-noncomputable def completionLocalization [IsTopologicalRing A] (P : PairOfDefinition A)
-    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    PairOfDefinition (UniformSpace.Completion S) :=
-  letI := locUniformSpace P T s S hden
-  letI := isUniformAddGroup_locUniformSpace P T s S hden
-  letI := isTopologicalRing_locUniformSpace P T s S hden
-  (localizationUniform P T s S hden).completion
-
-/-- The ring of definition of `completionLocalization` is the one `PairOfDefinition.completion`
-supplies for the localisation pair: the closure of the image of `D`. -/
-@[simp]
-theorem completionLocalization_ringOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A)
-    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    (completionLocalization P T s S hden).ringOfDefinition =
-      (localizationUniform P T s S hden).completionRingOfDefinition := by
-  let _ := locUniformSpace P T s S hden
-  have _ := isUniformAddGroup_locUniformSpace P T s S hden
-  have _ := isTopologicalRing_locUniformSpace P T s S hden
-  exact PairOfDefinition.completion_ringOfDefinition _
-
-/-- Membership in the ideal of definition of `A⟨T/s⟩` is membership in `J · D̂`.
-
-Stated as a membership characterisation rather than an equation because the type of
-`idealOfDefinition` depends on `ringOfDefinition`, which the opaque body of `completionLocalization`
-does not expose — the same shape as `PairOfDefinition.mem_completion_idealOfDefinition`, which
-this delegates to. -/
-@[simp]
-theorem mem_completionLocalization_idealOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A)
-    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    ∀ {x : (completionLocalization P T s S hden).ringOfDefinition},
-      x ∈ (completionLocalization P T s S hden).idealOfDefinition ↔
-        (⟨x, by
-            rw [← completionLocalization_ringOfDefinition P T s S hden]; exact x.2⟩ :
-          (localizationUniform P T s S hden).completionRingOfDefinition)
-            ∈ (localizationUniform P T s S hden).completionIdeal := by
-  let _ := locUniformSpace P T s S hden
-  have _ := isUniformAddGroup_locUniformSpace P T s S hden
-  have _ := isTopologicalRing_locUniformSpace P T s S hden
-  intro x
-  exact PairOfDefinition.mem_completion_idealOfDefinition (localizationUniform P T s S hden)
-
-/-- **The structure map `A → A⟨T/s⟩` is continuous**: it is the continuous localisation map
-followed by the completion map. -/
-theorem continuous_toCompletionLoc [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A)
-    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    Continuous (toCompletionLoc P T s S hden) := by
-  let _ := locUniformSpace P T s S hden
-  have _ := isUniformAddGroup_locUniformSpace P T s S hden
-  have _ := isTopologicalRing_locUniformSpace P T s S hden
-  have h : Continuous fun a : A ↦ ((algebraMap A S a : S) : UniformSpace.Completion S) :=
-    (UniformSpace.Completion.continuous_coe (α := S)).comp
-      (continuous_algebraMap_locTopology P T s S hden)
-  exact h.congr fun a ↦ (toCompletionLoc_apply P T s S hden a).symm
-
-/-- **`A⟨T/s⟩` is a Huber ring**: the separated completion of `Aₛ` under `locTopology` —
-Wedhorn's `A⟨T/s⟩` — carries a pair of definition.
-
-The statement introduces `locUniformSpace`, `isUniformAddGroup_locUniformSpace` and
-`isTopologicalRing_locUniformSpace`, because `locTopology` is not an instance and
-`UniformSpace.Completion S` is not well-formed without them. -/
-theorem isHuberRing_completion_locTopology [IsTopologicalRing A] (P : PairOfDefinition A)
-    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    IsHuberRing (UniformSpace.Completion S) :=
-  letI := locUniformSpace P T s S hden
-  letI := isUniformAddGroup_locUniformSpace P T s S hden
-  letI := isTopologicalRing_locUniformSpace P T s S hden
-  ⟨⟨completionLocalization P T s S hden⟩⟩
-
-/-- **The universal property of `A⟨T/s⟩`**, for complete Hausdorff targets: a ring homomorphism
-`φ : A →+* B` continuous at zero, with `φ s` a unit and each fraction `φ t / φ s` power-bounded,
-extends to the completion in exactly one continuous way.
-
-The hypotheses are those of `existsUnique_continuous_ringHom_locTopology` together with `B`
-complete and separated, which is what an extension across the completion requires. As there, the
-condition on the fractions is sufficient and is not claimed to be necessary. -/
-theorem existsUnique_continuous_ringHom_completion_locTopology {B : Type*} [CommRing B]
-    [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B] [T0Space B]
-    [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A) (s : A) (S : Type*) [CommRing S]
-    [Algebra A S] [IsLocalization.Away s S] (hden : HasDenominatorPower P T s S) {φ : A →+* B}
-    (hφ : ContinuousAt φ 0) (hs : IsUnit (φ s))
-    (hpow : ∀ t ∈ T, IsPowerBounded (φ t * ↑hs.unit⁻¹)) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    ∃! g : UniformSpace.Completion S →+* B,
-      Continuous g ∧ g.comp (toCompletionLoc P T s S hden) = φ := by
-  let _ := locUniformSpace P T s S hden
-  have _ := isUniformAddGroup_locUniformSpace P T s S hden
-  have _ := isTopologicalRing_locUniformSpace P T s S hden
-  obtain ⟨f, ⟨hfc, hfe⟩, huniq⟩ :=
-    existsUnique_continuous_ringHom_locTopology P T s S hden hφ hs hpow
-  refine ⟨UniformSpace.Completion.extensionHom f hfc,
-    ⟨UniformSpace.Completion.continuous_extension, ?_⟩, ?_⟩
-  · ext a
-    simpa [UniformSpace.Completion.extensionHom_coe, UniformSpace.Completion.coeRingHom] using
-      congrArg (fun h => h a) hfe
-  · rintro g ⟨hgc, hge⟩
-    have hcomp : (g.comp UniformSpace.Completion.coeRingHom).comp (algebraMap A S) = φ := by
-      refine RingHom.ext fun a ↦ ?_
-      have h := congrArg (fun h ↦ h a) hge
-      simp only [RingHom.comp_apply, toCompletionLoc_apply] at h
-      simpa [UniformSpace.Completion.coeRingHom] using h
-    have hcoe : g.comp UniformSpace.Completion.coeRingHom = f :=
-      huniq _ ⟨hgc.comp UniformSpace.Completion.continuous_coeRingHom, hcomp⟩
-    refine RingHom.coe_inj (UniformSpace.Completion.extension_unique
-      (uniformContinuous_addMonoidHom_of_continuous hfc)
-      (uniformContinuous_addMonoidHom_of_continuous hgc) fun x ↦ ?_).symm
-    simpa [UniformSpace.Completion.coeRingHom] using (congrArg (fun h ↦ h x) hcoe).symm
 
 end PairOfDefinition
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
@@ -6,7 +6,6 @@ module
 
 public import TauCeti.RingTheory.Localization.Away
 public import Mathlib.Topology.Algebra.Nonarchimedean.Bases
-public import Mathlib.RingTheory.Adjoin.Polynomial.Basic
 public import TauCeti.RingTheory.Huber.Basic
 
 /-!

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
@@ -38,6 +38,12 @@ complete Hausdorff targets.
   `existsUnique_continuous_ringHom_completion_locTopology`: `A⟨T/s⟩` is Huber, and the universal
   property holds across it for complete Hausdorff targets.
 
+## Provenance
+
+`A⟨T/s⟩` and its universal property are this repository's own, built on the localisation topology
+of `LocalizationTopology.Basic`, which is the AINTLIB port — see that module's Provenance section
+for the source file and commit.
+
 ## References
 
 * [T. Wedhorn, *Adic Spaces*][wedhorn_adic], Proposition and Definition 5.51, §5.6

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
@@ -1,0 +1,319 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RingTheory.Huber.LocalizationTopology.UniversalProperty
+public import TauCeti.RingTheory.Huber.Completion
+
+/-!
+# The completion `A⟨T/s⟩`
+
+The separated completion of `Aₛ` under `locTopology` is Wedhorn's `A⟨T/s⟩`. It is a Huber ring,
+and the universal property of `LocalizationTopology.UniversalProperty` extends across it for
+complete Hausdorff targets.
+
+## Main definitions
+
+* `locUniformSpace P T s S` : the uniformity `locTopology` determines, packaged so that
+  `UniformSpace.Completion S` can be written down.
+* `toCompletionLoc P T s S` : the structure map `A → A⟨T/s⟩`.
+* `localizationUniform P T s S` : the pair `localization`, transported to the topology
+  `locUniformSpace` induces, so that no statement about `A⟨T/s⟩` carries the transport.
+* `completionLocalization P T s S` : the pair of definition `A⟨T/s⟩` carries.
+
+## Main results
+
+* `locUniformSpace_toTopologicalSpace`: the topology `locUniformSpace` induces is `locTopology`.
+  This is what a proof rewrites against, so no body in this file needs exposing.
+* `isUniformAddGroup_locUniformSpace` and `isTopologicalRing_locUniformSpace`: the two companions
+  of `locUniformSpace`. Since `locTopology` is not an instance, a statement about `A⟨T/s⟩` has to
+  name its structures; these three declarations are what it names.
+* `localizationUniform_ringOfDefinition` and `mem_localizationUniform_idealOfDefinition`, with
+  `completionLocalization_ringOfDefinition` and `mem_completionLocalization_idealOfDefinition`:
+  the completed pair's API, reducing to the concrete `D` and `J`.
+* `continuous_toCompletionLoc`: the structure map `A → A⟨T/s⟩` is continuous.
+* `isHuberRing_completion_locTopology` and
+  `existsUnique_continuous_ringHom_completion_locTopology`: `A⟨T/s⟩` is Huber, and the universal
+  property holds across it for complete Hausdorff targets.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic], Proposition and Definition 5.51, §5.6
+* `Mathlib.Topology.Algebra.Valued.ValuationTopology`, `Valued.mk'` — the model for the instance
+  setup here. It layers `IsTopologicalAddGroup.rightUniformSpace` and
+  `isUniformAddGroup_of_addCommGroup` on a topology built from a `RingSubgroupsBasis`, passing
+  that topology positionally because it is not an instance; `locTopology` is in the same position.
+-/
+
+open Pointwise Topology
+
+namespace TauCeti.Huber
+
+open TauCeti.Localization
+
+public section
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A]
+
+namespace PairOfDefinition
+
+/-! ### The completion `A⟨T/s⟩` -/
+
+/-- **The canonical uniformity on `Aₛ`**, the one its topology determines.
+
+`locTopology` is not an instance, so a consumer of the completion has to name the uniform structure
+explicitly. This packages the construction, and it takes **three** declarations to state anything
+about `A⟨T/s⟩`: `locUniformSpace` makes `UniformSpace.Completion S` well-formed,
+`isUniformAddGroup_locUniformSpace` makes the completion an additive group, and
+`isTopologicalRing_locUniformSpace` is what its ring structure is inferred from. The first two
+alone do not suffice.
+
+`locUniformSpace_toTopologicalSpace` is the characteristic property — the topology it induces is
+`locTopology` — so the body is not exposed and a proof rewrites against that lemma instead.
+
+It is *the* uniformity, not merely one compatible with the topology:
+`IsUniformAddGroup.rightUniformSpace_eq` identifies it with any uniformity making `Aₛ` a uniform
+additive group, so a consumer arriving with its own such structure rewrites rather than
+transports. -/
+@[instance_reducible]
+noncomputable def locUniformSpace (P : PairOfDefinition A) (T : Finset A) (s : A) (S : Type*)
+    [CommRing S] [Algebra A S] [IsLocalization.Away s S] (hden : HasDenominatorPower P T s S)
+    [IsTopologicalRing A] : UniformSpace S :=
+  letI tS := locTopology P T s S hden
+  letI := isTopologicalRing_locTopology P T s S hden
+  @IsTopologicalAddGroup.rightUniformSpace S _ tS _
+
+/-- The topology `locUniformSpace` induces is `locTopology`. This is the characteristic property
+of the packaged uniformity: it lets a statement made at one be rewritten to the other. -/
+@[simp]
+theorem locUniformSpace_toTopologicalSpace [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    (locUniformSpace P T s S hden).toTopologicalSpace = locTopology P T s S hden := (rfl)
+
+/-- `Aₛ` is a uniform additive group for `locUniformSpace`. The companion of `locUniformSpace`:
+the two together are what `UniformSpace.Completion S` needs. -/
+theorem isUniformAddGroup_locUniformSpace [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    @IsUniformAddGroup S (locUniformSpace P T s S hden) _ :=
+  letI := isTopologicalRing_locTopology P T s S hden
+  @isUniformAddGroup_of_addCommGroup _ _ (locTopology P T s S hden) _
+
+/-- `Aₛ` is a topological ring for the topology `locUniformSpace` induces. Stated at that
+topology rather than at `locTopology`, so that it applies where the packaged uniformity is in
+scope. -/
+theorem isTopologicalRing_locUniformSpace [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    IsTopologicalRing S :=
+  isTopologicalRing_locTopology P T s S hden
+
+/-- **The structure map `A → A⟨T/s⟩`**, the localisation map followed by the completion map. This
+is the canonical ring homomorphism the universal property extends. -/
+noncomputable def toCompletionLoc [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A)
+    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    A →+* UniformSpace.Completion S :=
+  letI := locUniformSpace P T s S hden
+  letI := isUniformAddGroup_locUniformSpace P T s S hden
+  letI := isTopologicalRing_locUniformSpace P T s S hden
+  (UniformSpace.Completion.coeRingHom).comp (algebraMap A S)
+
+/-- The structure map is the localisation map followed by the completion map. The body of
+`toCompletionLoc` is not exported, so this is how a consumer computes with it. -/
+@[simp]
+theorem toCompletionLoc_apply [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) (a : A) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    toCompletionLoc P T s S hden a = (algebraMap A S a : UniformSpace.Completion S) := (rfl)
+
+
+/-- The localisation pair `localization`, transported along `locUniformSpace_toTopologicalSpace`
+to the topology the packaged uniformity induces.
+
+`localization` is stated at `locTopology` and the completion is taken at `locUniformSpace`. The
+two topologies are equal, but not syntactically, so the transport has to be named: naming it here
+keeps the cast out of every statement about `A⟨T/s⟩` below. -/
+noncomputable def localizationUniform [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    PairOfDefinition S :=
+  (locUniformSpace_toTopologicalSpace P T s S hden).symm ▸ localization P T s S hden
+
+/-- The ring of definition of `localizationUniform` is `D`, as for `localization`: the transport
+is along an equality of topologies and `ringOfDefinition` is a `Subring S`, which does not depend
+on one. This is what makes the completed pair's API reduce to the concrete data. -/
+@[simp]
+theorem localizationUniform_ringOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    (localizationUniform P T s S hden).ringOfDefinition = locSubring P T s S :=
+  localization_ringOfDefinition P T s S hden
+
+/-- Membership in the ideal of definition of `localizationUniform` is membership in `J`, as for
+`localization`. With `localizationUniform_ringOfDefinition` this reduces the completed pair's
+characteristic lemmas to the concrete `D` and `J`. -/
+@[simp]
+theorem mem_localizationUniform_idealOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    {x : letI := locUniformSpace P T s S hden;
+      (localizationUniform P T s S hden).ringOfDefinition} :
+    letI := locUniformSpace P T s S hden
+    x ∈ (localizationUniform P T s S hden).idealOfDefinition ↔
+      (⟨x, by rw [← localizationUniform_ringOfDefinition P T s S hden]; exact x.2⟩ :
+        locSubring P T s S) ∈ locIdeal P T s S :=
+  mem_localization_idealOfDefinition P T s S hden
+
+/-- **The pair of definition on `A⟨T/s⟩`**, the completion of the pair `localization` carries on
+`Aₛ`. This is the completed counterpart of `localization`, and it is what makes `A⟨T/s⟩` Huber.
+
+Its ring of definition and ideal of definition are characterised by
+`completionLocalization_ringOfDefinition` and `mem_completionLocalization_idealOfDefinition`,
+which are how a consumer computes with it — the body is not exposed. -/
+noncomputable def completionLocalization [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    PairOfDefinition (UniformSpace.Completion S) :=
+  letI := locUniformSpace P T s S hden
+  letI := isUniformAddGroup_locUniformSpace P T s S hden
+  letI := isTopologicalRing_locUniformSpace P T s S hden
+  (localizationUniform P T s S hden).completion
+
+/-- The ring of definition of `completionLocalization` is the one `PairOfDefinition.completion`
+supplies for the localisation pair: the closure of the image of `D`. -/
+@[simp]
+theorem completionLocalization_ringOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    (completionLocalization P T s S hden).ringOfDefinition =
+      (localizationUniform P T s S hden).completionRingOfDefinition := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  exact PairOfDefinition.completion_ringOfDefinition _
+
+/-- Membership in the ideal of definition of `A⟨T/s⟩` is membership in `J · D̂`.
+
+Stated as a membership characterisation rather than an equation because the type of
+`idealOfDefinition` depends on `ringOfDefinition`, which the opaque body of `completionLocalization`
+does not expose — the same shape as `PairOfDefinition.mem_completion_idealOfDefinition`, which
+this delegates to. -/
+@[simp]
+theorem mem_completionLocalization_idealOfDefinition [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    ∀ {x : (completionLocalization P T s S hden).ringOfDefinition},
+      x ∈ (completionLocalization P T s S hden).idealOfDefinition ↔
+        (⟨x, by
+            rw [← completionLocalization_ringOfDefinition P T s S hden]; exact x.2⟩ :
+          (localizationUniform P T s S hden).completionRingOfDefinition)
+            ∈ (localizationUniform P T s S hden).completionIdeal := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  intro x
+  exact PairOfDefinition.mem_completion_idealOfDefinition (localizationUniform P T s S hden)
+
+/-- **The structure map `A → A⟨T/s⟩` is continuous**: it is the continuous localisation map
+followed by the completion map. -/
+theorem continuous_toCompletionLoc [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A)
+    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    Continuous (toCompletionLoc P T s S hden) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have h : Continuous fun a : A ↦ ((algebraMap A S a : S) : UniformSpace.Completion S) :=
+    (UniformSpace.Completion.continuous_coe (α := S)).comp
+      (continuous_algebraMap_locTopology P T s S hden)
+  exact h.congr fun a ↦ (toCompletionLoc_apply P T s S hden a).symm
+
+/-- **`A⟨T/s⟩` is a Huber ring**: the separated completion of `Aₛ` under `locTopology` —
+Wedhorn's `A⟨T/s⟩` — carries a pair of definition.
+
+The statement introduces `locUniformSpace`, `isUniformAddGroup_locUniformSpace` and
+`isTopologicalRing_locUniformSpace`, because `locTopology` is not an instance and
+`UniformSpace.Completion S` is not well-formed without them. -/
+theorem isHuberRing_completion_locTopology [IsTopologicalRing A] (P : PairOfDefinition A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    IsHuberRing (UniformSpace.Completion S) :=
+  letI := locUniformSpace P T s S hden
+  letI := isUniformAddGroup_locUniformSpace P T s S hden
+  letI := isTopologicalRing_locUniformSpace P T s S hden
+  ⟨⟨completionLocalization P T s S hden⟩⟩
+
+/-- **The universal property of `A⟨T/s⟩`**, for complete Hausdorff targets: a ring homomorphism
+`φ : A →+* B` continuous at zero, with `φ s` a unit and each fraction `φ t / φ s` power-bounded,
+extends to the completion in exactly one continuous way.
+
+The hypotheses are those of `existsUnique_continuous_ringHom_locTopology` together with `B`
+complete and separated, which is what an extension across the completion requires. As there, the
+condition on the fractions is sufficient and is not claimed to be necessary. -/
+theorem existsUnique_continuous_ringHom_completion_locTopology {B : Type*} [CommRing B]
+    [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B] [T0Space B]
+    [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A) (s : A) (S : Type*) [CommRing S]
+    [Algebra A S] [IsLocalization.Away s S] (hden : HasDenominatorPower P T s S) {φ : A →+* B}
+    (hφ : ContinuousAt φ 0) (hs : IsUnit (φ s))
+    (hpow : ∀ t ∈ T, IsPowerBounded (φ t * ↑hs.unit⁻¹)) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    ∃! g : UniformSpace.Completion S →+* B,
+      Continuous g ∧ g.comp (toCompletionLoc P T s S hden) = φ := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  obtain ⟨f, ⟨hfc, hfe⟩, huniq⟩ :=
+    existsUnique_continuous_ringHom_locTopology P T s S hden hφ hs hpow
+  refine ⟨UniformSpace.Completion.extensionHom f hfc,
+    ⟨UniformSpace.Completion.continuous_extension, ?_⟩, ?_⟩
+  · ext a
+    simpa [UniformSpace.Completion.extensionHom_coe, UniformSpace.Completion.coeRingHom] using
+      congrArg (fun h => h a) hfe
+  · rintro g ⟨hgc, hge⟩
+    have hcomp : (g.comp UniformSpace.Completion.coeRingHom).comp (algebraMap A S) = φ := by
+      refine RingHom.ext fun a ↦ ?_
+      have h := congrArg (fun h ↦ h a) hge
+      simp only [RingHom.comp_apply, toCompletionLoc_apply] at h
+      simpa [UniformSpace.Completion.coeRingHom] using h
+    have hcoe : g.comp UniformSpace.Completion.coeRingHom = f :=
+      huniq _ ⟨hgc.comp UniformSpace.Completion.continuous_coeRingHom, hcomp⟩
+    refine RingHom.coe_inj (UniformSpace.Completion.extension_unique
+      (uniformContinuous_addMonoidHom_of_continuous hfc)
+      (uniformContinuous_addMonoidHom_of_continuous hgc) fun x ↦ ?_).symm
+    simpa [UniformSpace.Completion.coeRingHom] using (congrArg (fun h ↦ h x) hcoe).symm
+
+end PairOfDefinition
+
+end
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/UniversalProperty.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/UniversalProperty.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RingTheory.Huber.LocalizationTopology.Basic
+
+/-!
+# The localisation topology: the universal property
+
+A ring homomorphism out of `Aₛ` is continuous as soon as its restriction along `algebraMap` is and
+the fractions `t/s` go to power-bounded elements; and `Aₛ` is the universal such target. This is
+the second half of Wedhorn's Proposition and Definition 5.51.
+
+The construction of the topology is in `LocalizationTopology.Basic`, and the completion `A⟨T/s⟩`
+in `LocalizationTopology.Completion`.
+
+## Main results
+
+* `isPowerBounded_of_mem_locSubring` and `isPowerBounded_divBy`: every element of `D` — in
+  particular each fraction `t/s` — is power-bounded.
+* `continuous_of_continuous_algebraMap_of_isPowerBounded`: a sufficient criterion for a ring
+  homomorphism out of `Aₛ` to be continuous. The converse is not proved here.
+* `existsUnique_continuous_ringHom_locTopology`: the universal property — a continuous
+  `φ : A →+* B` inverting `s` and sending each `t/s` to a power-bounded element extends to `Aₛ` in
+  exactly one continuous way.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic], Proposition and Definition 5.51, §5.6
+-/
+
+open Pointwise Topology
+
+namespace TauCeti.Huber
+
+open TauCeti.Localization
+
+public section
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A]
+
+namespace PairOfDefinition
+
+/-! ### A sufficient criterion for continuity -/
+
+/-- Along `algebraMap`, some power of the ideal of definition multiplies the image of `A₀` into
+any prescribed open subgroup of `B`. This is the `A₀`-level base case of
+`exists_pow_mul_locSubring_mem`. -/
+private theorem exists_pow_mul_algebraMap_mem {B : Type*} [Ring B] [TopologicalSpace B]
+    (P : PairOfDefinition A)
+    (S : Type*) [Ring S] [Algebra A S] (f : S →+* B)
+    (hf : Continuous (f.comp (algebraMap A S))) (G : OpenAddSubgroup B) :
+    ∃ m : ℕ, ∀ x ∈ P.ringOfDefinition.map (algebraMap A S),
+      ∀ b ∈ P.idealOfDefinition ^ m,
+        f (x * algebraMap A S (b : A)) ∈ (G : Set B) := by
+  obtain ⟨m, hm⟩ : ∃ m : ℕ, ∀ b ∈ P.idealOfDefinition ^ m,
+      f (algebraMap A S (b : A)) ∈ (G : Set B) := by
+    have hcont : Filter.Tendsto (f.comp (algebraMap A S)) (𝓝 0) (𝓝 0) := by
+      rw [← map_zero (f.comp (algebraMap A S))]
+      exact hf.continuousAt
+    obtain ⟨n, -, hn⟩ := P.hasBasis_nhds_zero.mem_iff.mp (hcont (G.isOpen.mem_nhds G.zero_mem))
+    exact ⟨n, fun b hb ↦ hn ((P.mem_idealImage n).mpr ⟨b, hb, rfl⟩)⟩
+  refine ⟨m, ?_⟩
+  rintro _ ⟨a₀, ha₀, rfl⟩ b hb
+  rw [← map_mul (algebraMap A S)]
+  exact hm ⟨(a₀ : A) * (b : A), P.ringOfDefinition.mul_mem ha₀ b.property⟩
+    (Ideal.mul_mem_left _ ⟨a₀, ha₀⟩ hb)
+
+/-- The same statement with `A₀` replaced by all of `D = A₀[t₁/s, …, tₙ/s]`. This is where
+power-boundedness of the fractions enters: the induction adjoins one `t/s` at a time and writes an
+element of the larger ring as a polynomial in it, whose powers a bounded set absorbs.
+
+Stated over an arbitrary `U : Finset A` rather than the `T` of the theorem that uses it, because
+that is what the `Finset.induction` needs. -/
+private theorem exists_pow_mul_locSubring_mem {B : Type*} [Ring B] [TopologicalSpace B]
+    [NonarchimedeanRing B] (P : PairOfDefinition A) (s : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (f : S →+* B)
+    (hf : Continuous (f.comp (algebraMap A S))) (U : Finset A) :
+    (∀ t ∈ U, IsPowerBounded (f (divBy t s))) →
+      ∀ G : OpenAddSubgroup B, ∃ m : ℕ, ∀ x ∈ locSubring P U s S,
+        ∀ b ∈ P.idealOfDefinition ^ m,
+          f (x * algebraMap A S (b : A)) ∈ (G : Set B) := by
+  classical
+  induction U using Finset.induction with
+  | empty =>
+    intro _ G
+    obtain ⟨m, hm⟩ := exists_pow_mul_algebraMap_mem P S f hf G
+    exact ⟨m, fun x hx b hb ↦ hm x (locSubring_empty P s S ▸ hx) b hb⟩
+  | insert t U' ht ih =>
+    intro hpowU G
+    have hinsert_le : locSubring P (insert t U') s S ≤
+        Subring.closure ((locSubring P U' s S : Set S) ∪ {divBy t s}) :=
+      (locSubring_le_iff P _ s S).mpr
+        ⟨fun _ ha ↦ Subring.subset_closure (.inl (algebraMap_mem_locSubring P U' s S ha)),
+         fun t' ht' ↦ by
+           rcases Finset.mem_insert.mp ht' with rfl | ht'U
+           · exact Subring.subset_closure (.inr rfl)
+           · exact Subring.subset_closure (.inl (divBy_mem_locSubring P U' s S ht'U))⟩
+    obtain ⟨V, hV, hzV⟩ := isBounded_iff.mp (isPowerBounded_iff.mp
+      (hpowU t (Finset.mem_insert_self t U'))) (G : Set B) (G.isOpen.mem_nhds G.zero_mem)
+    obtain ⟨W, hWV⟩ := NonarchimedeanAddGroup.is_nonarchimedean V hV
+    obtain ⟨m, hm⟩ := ih (fun t' ht' ↦ hpowU t' (Finset.mem_insert_of_mem ht')) W
+    refine ⟨m, fun x hx b hb ↦ ?_⟩
+    -- Write `x` as a polynomial in `t/s` with coefficients in the smaller subring.
+    have hx_adj : x ∈ Algebra.adjoin (locSubring P U' s S)
+        ({divBy t s} : Set S) := by
+      have h_le : Subring.closure
+          ((locSubring P U' s S : Set S) ∪ {divBy t s}) ≤
+            (Algebra.adjoin (locSubring P U' s S)
+              ({divBy t s} : Set S)).toSubring := by
+        rw [Subring.closure_le]
+        rintro w (hw | rfl)
+        · exact Subalgebra.algebraMap_mem _ (⟨w, hw⟩ : locSubring P U' s S)
+        · exact Algebra.subset_adjoin rfl
+      exact h_le (hinsert_le hx)
+    rw [Algebra.adjoin_singleton_eq_range_aeval, AlgHom.mem_range] at hx_adj
+    obtain ⟨p, hp⟩ := hx_adj
+    rw [← hp, Polynomial.aeval_eq_sum_range, Finset.sum_mul, map_sum]
+    refine G.toAddSubgroup.sum_mem fun i _ ↦ ?_
+    rw [Algebra.smul_def, Algebra.algebraMap_ofSubsemiring_apply, mul_right_comm,
+      map_mul, map_pow]
+    exact hzV (Set.mul_mem_mul (hWV (hm _ (p.coeff i).property b hb)) ⟨i, rfl⟩)
+
+/-- A ring homomorphism out of `Aₛ` is continuous for the localisation topology as soon as its
+restriction along `algebraMap` is continuous and the fractions `t/s` are sent to power-bounded
+elements. This is a sufficient criterion only; no converse is proved here.
+
+The second hypothesis does real work rather than following from the first: `D` is generated over
+`A₀` by exactly those fractions, so continuity of `f ∘ algebraMap` alone says nothing about the
+image of `D`. -/
+theorem continuous_of_continuous_algebraMap_of_isPowerBounded {B : Type*}
+    [Ring B] [TopologicalSpace B] [NonarchimedeanRing B] [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (f : S →+* B)
+    (hf : Continuous (f.comp (algebraMap A S)))
+    (hpow : ∀ t ∈ T, IsPowerBounded (f (divBy t s))) :
+    @Continuous _ _ (locTopology P T s S hden) _ f := by
+  have hfull := exists_pow_mul_locSubring_mem P s S f hf T hpow
+  let _ : TopologicalSpace S := locTopology P T s S hden
+  have : IsTopologicalRing S := isTopologicalRing_locTopology P T s S hden
+  refine continuous_of_continuousAt_zero f ?_
+  rw [ContinuousAt, map_zero, Filter.tendsto_def]
+  intro V hV
+  obtain ⟨W, hWV⟩ := NonarchimedeanAddGroup.is_nonarchimedean V hV
+  obtain ⟨m, hm⟩ := hfull W
+  refine Filter.mem_of_superset
+    ((hasBasis_nhds_zero_locTopology P T s S hden).mem_iff.mpr ⟨m, trivial, le_refl _⟩) ?_
+  intro x hx
+  obtain ⟨d, hd, rfl⟩ := (mem_locIdealImage_iff P T s S m).mp hx
+  refine hWV ?_
+  rw [locIdeal_pow_eq_span] at hd
+  suffices h : ∀ r : locSubring P T s S,
+      f ((locSubring P T s S).subtype (r * d)) ∈ (W : Set B) by
+    simpa using h 1
+  refine Submodule.span_induction (p := fun d _ ↦ ∀ r : locSubring P T s S,
+    f ((locSubring P T s S).subtype (r * d)) ∈ (W : Set B)) ?_ ?_ ?_ ?_ hd
+  · rintro _ ⟨b, hb, rfl⟩ r
+    rw [Subring.coe_subtype, MulMemClass.coe_mul, toLocSubring_apply]
+    exact hm r.val r.property b hb
+  · intro r
+    simp
+  · intro d₁ d₂ _ _ h₁ h₂ r
+    rw [mul_add, map_add, map_add]
+    exact W.toAddSubgroup.add_mem (h₁ r) (h₂ r)
+  · intro c d _ hd r
+    rw [smul_eq_mul, ← mul_assoc]
+    exact hd (r * c)
+
+
+/-! ### The universal property -/
+
+/-- **Wedhorn 5.51, the universal property of `Aₛ` under `locTopology`.** A ring homomorphism
+`φ : A →+* B` into a nonarchimedean ring extends to `Aₛ` in exactly one continuous way, provided
+`φ` is continuous, `φ s` is a unit, and each fraction `φ t / φ s` is power-bounded.
+
+The condition on the fractions is stated as sufficient, and only that. It is *not* forced by
+continuity: a continuous ring homomorphism need not carry power-bounded elements to power-bounded
+elements — `IsBounded.image` in `Huber/Bounded.lean` is stated for the image under a map, and
+`IsBounded.image_of_isOpenMap` needs openness on top, precisely because continuity alone does not
+suffice. Whether some weaker condition is also necessary is not addressed here.
+
+The map itself is Mathlib's `IsLocalization.Away.lift`, which is purely algebraic and needs no
+topology; the topology's contribution is that this lift is *continuous*, supplied by
+`continuous_of_continuous_algebraMap_of_isPowerBounded`. Uniqueness is
+`IsLocalization.ringHom_ext` and is algebraic too: a homomorphism out of a localisation is already
+determined by its restriction along `algebraMap`, so nothing topological enters there. -/
+theorem existsUnique_continuous_ringHom_locTopology {B : Type*} [CommRing B] [TopologicalSpace B]
+    [NonarchimedeanRing B] [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) {φ : A →+* B} (hφ : ContinuousAt φ 0) (hs : IsUnit (φ s))
+    (hpow : ∀ t ∈ T, IsPowerBounded (φ t * ↑hs.unit⁻¹)) :
+    letI := locTopology P T s S hden
+    ∃! f : S →+* B, Continuous f ∧ f.comp (algebraMap A S) = φ := by
+  let _ := locTopology P T s S hden
+  refine ⟨IsLocalization.Away.lift s hs, ⟨?_, IsLocalization.Away.lift_comp s hs⟩, ?_⟩
+  · refine continuous_of_continuous_algebraMap_of_isPowerBounded P T s S hden _ ?_ ?_
+    · rw [IsLocalization.Away.lift_comp s hs]; exact continuous_of_continuousAt_zero φ hφ
+    · intro t ht
+      have : IsLocalization.Away.lift s hs ((divBy t s : S)) = φ t * ↑hs.unit⁻¹ := by
+        rw [divBy_def, IsLocalization.Away.lift, IsLocalization.lift_mk']
+        congr 2
+      rw [this]; exact hpow t ht
+  · rintro g ⟨-, hg⟩
+    exact IsLocalization.ringHom_ext (Submonoid.powers s)
+      (hg.trans (IsLocalization.Away.lift_comp s hs).symm)
+
+end PairOfDefinition
+
+end
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/UniversalProperty.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/UniversalProperty.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.RingTheory.Huber.LocalizationTopology.Basic
+public import Mathlib.RingTheory.Adjoin.Polynomial.Basic
 
 /-!
 # The localisation topology: the universal property
@@ -16,15 +17,23 @@ the second half of Wedhorn's Proposition and Definition 5.51.
 The construction of the topology is in `LocalizationTopology.Basic`, and the completion `A⟨T/s⟩`
 in `LocalizationTopology.Completion`.
 
+The power-boundedness prerequisites this needs — `isPowerBounded_of_mem_locSubring` and
+`isPowerBounded_divBy`, which say every element of `D`, in particular each fraction `t/s`, is
+power-bounded — are in `LocalizationTopology.Basic` and imported from there.
+
 ## Main results
 
-* `isPowerBounded_of_mem_locSubring` and `isPowerBounded_divBy`: every element of `D` — in
-  particular each fraction `t/s` — is power-bounded.
 * `continuous_of_continuous_algebraMap_of_isPowerBounded`: a sufficient criterion for a ring
   homomorphism out of `Aₛ` to be continuous. The converse is not proved here.
 * `existsUnique_continuous_ringHom_locTopology`: the universal property — a continuous
   `φ : A →+* B` inverting `s` and sending each `t/s` to a power-bounded element extends to `Aₛ` in
   exactly one continuous way.
+
+## Provenance
+
+The declarations here are relocated from the AINTLIB port recorded in
+`LocalizationTopology.Basic`; see that module's Provenance section for the source file and
+commit. This module adds no new mathematics.
 
 ## References
 

--- a/TauCeti/RingTheory/Localization/Away.lean
+++ b/TauCeti/RingTheory/Localization/Away.lean
@@ -43,7 +43,7 @@ Huber namespace, alongside `TauCeti/RingTheory/Localization/DenIdeal.lean`.
 inside the Huber development. They are generalised here to an arbitrary `IsLocalization.Away`
 over a commutative semiring, linked to Mathlib's `IsLocalization.Away.invSelf`, and moved out of
 the Huber namespace because nothing about them is topological. The topological part of that port
-is `TauCeti/RingTheory/Huber/LocalizationTopology.lean`, which records the same provenance.
+is `TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean`, which records the same provenance.
 
 ## References
 


### PR DESCRIPTION
Roadmap: AdicSpaces

Pure refactor of merged code, so no roadmap target is claimed — CLAUDE.md puts relocation and
file organisation in scope at any time. The roadmap named for attribution is the one the file
serves.

`TauCeti/RingTheory/Huber/LocalizationTopology.lean` reached **1167 lines** after #3062. It
becomes three modules, cut at existing `/-! ###` section boundaries:

| module | lines | contents |
|---|---|---|
| `LocalizationTopology/Basic.lean` | 692 | `D`, the standing hypothesis, `J`, the neighbourhood basis, `locTopology`, `Aₛ` as a Huber ring |
| `LocalizationTopology/UniversalProperty.lean` | 216 | power-boundedness, the continuity criterion, Wedhorn 5.51's universal property |
| `LocalizationTopology/Completion.lean` | 319 | the uniformity, `A⟨T/s⟩`, its pair of definition, the completed universal property |

**All 69 declarations are preserved** — I counted them on both sides rather than trusting the
move. The diff is that move plus three proof changes, and nothing else.

## The three proof changes, which are the reason this is not a pure `git mv`

A theorem body elaborates at full transparency and can unfold an **unexposed** definition inside
its own module — but not across a module boundary. Three proofs were relying on that, and the
first attempt at this split failed on exactly them:

* `localizationUniform_ringOfDefinition` and `mem_localizationUniform_idealOfDefinition` were
  `rfl` and `Iff.rfl`, reaching through `localization`'s unexposed body. They now apply the
  public `localization_ringOfDefinition` and `mem_localization_idealOfDefinition`. That is what
  those lemmas exist for, and it is the same "go through the API, not around it" the
  `proof-quality` rubric asked for elsewhere in this file.
* `isUniformAddGroup_locUniformSpace` needed `isTopologicalRing_locTopology` supplied via `letI`:
  it is a theorem rather than an instance, and was previously found only because it sat in the
  same module.

No `@[expose]` was added. The alternative — exposing `localization` so the `rfl`s keep working —
would undo what #3062's `api-design` round removed.

## Why now

**Nothing imports the old module.** The only repository reference was a docstring path in
`RingTheory/Localization/Away.lean`, updated here. So this is the cheapest possible moment to
split: zero downstream churn, and the file only grows from here as Layer 4.1 lands. No forwarding
module is left behind, per the no-compatibility-surface rule.

## Gates

Build 7788 jobs; `axioms` 44365 declarations, allowlist only; `module-system` 2128 modules;
`LINT-ENV: PASS`. The two ratchetable baseline entries it reports
(`Polynomial.derivative_hermite_succ`, a `ModularForm` one) are unrelated drift from `main` — the
baseline never referenced this file.
