### PR TITLE
feat: add barycentric subdivisions

### DIFF
--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Basic.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Basic.lean
@@ -17,8 +17,8 @@ public section
 
 namespace AbstractSimplicialComplex
 
-/-- A face of an abstract simplicial complex, bundled with its membership proof. -/
-abbrev Face {ι : Type*} (K : AbstractSimplicialComplex ι) := {σ : Finset ι // σ ∈ K}
+/-- A face of a set-like collection of finite sets, bundled with its membership proof. -/
+abbrev Face {ι S : Type*} [SetLike S (Finset ι)] (K : S) := {σ : Finset ι // σ ∈ K}
 
 /-- A finite set is a face of the underlying precomplex exactly when it is a face of the abstract
 simplicial complex itself. This is the single place where the two `SetLike` instances are
@@ -30,3 +30,17 @@ theorem mem_toPreAbstractSimplicialComplex {ι : Type*} {K : AbstractSimplicialC
 
 end AbstractSimplicialComplex
 
+namespace TauCeti.AbstractSimplicialComplex
+
+/-- The order on bundled faces is inclusion of their underlying finite sets. -/
+theorem face_le_iff {ι S : Type*} [SetLike S (Finset ι)] {K : S}
+    {σ τ : _root_.AbstractSimplicialComplex.Face K} :
+    σ ≤ τ ↔ (σ : Finset ι) ⊆ τ :=
+  Iff.rfl
+
+/-- A finite set belongs to the full abstract simplicial complex exactly when it is nonempty. -/
+theorem mem_top_iff {ι : Type*} {σ : Finset ι} :
+    σ ∈ (⊤ : _root_.AbstractSimplicialComplex ι) ↔ σ.Nonempty :=
+  Iff.rfl
+
+end TauCeti.AbstractSimplicialComplex

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Basic.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Basic.lean
@@ -11,14 +11,27 @@ public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
 
 This file contains general-purpose lemmas supplementing Mathlib's basic abstract simplicial
 complex API.
+
+Faces are bundled by `TauCeti.SetLike.Face`, stated for an arbitrary set-like collection of
+finite sets so that the same type describes the faces of an `AbstractSimplicialComplex` and of a
+`PreAbstractSimplicialComplex`; hence its neutral namespace.
 -/
 
 public section
 
-namespace AbstractSimplicialComplex
+namespace TauCeti.SetLike
 
 /-- A face of a set-like collection of finite sets, bundled with its membership proof. -/
-abbrev Face {ι S : Type*} [SetLike S (Finset ι)] (K : S) := {σ : Finset ι // σ ∈ K}
+abbrev Face {ι S : Type*} [_root_.SetLike S (Finset ι)] (K : S) := {σ : Finset ι // σ ∈ K}
+
+/-- The order on bundled faces is inclusion of their underlying finite sets. -/
+theorem face_le_iff {ι S : Type*} [_root_.SetLike S (Finset ι)] {K : S} {σ τ : Face K} :
+    σ ≤ τ ↔ (σ : Finset ι) ⊆ τ :=
+  Iff.rfl
+
+end TauCeti.SetLike
+
+namespace AbstractSimplicialComplex
 
 /-- A finite set is a face of the underlying precomplex exactly when it is a face of the abstract
 simplicial complex itself. This is the single place where the two `SetLike` instances are
@@ -31,12 +44,6 @@ theorem mem_toPreAbstractSimplicialComplex {ι : Type*} {K : AbstractSimplicialC
 end AbstractSimplicialComplex
 
 namespace TauCeti.AbstractSimplicialComplex
-
-/-- The order on bundled faces is inclusion of their underlying finite sets. -/
-theorem face_le_iff {ι S : Type*} [SetLike S (Finset ι)] {K : S}
-    {σ τ : _root_.AbstractSimplicialComplex.Face K} :
-    σ ≤ τ ↔ (σ : Finset ι) ⊆ τ :=
-  Iff.rfl
 
 /-- A finite set belongs to the full abstract simplicial complex exactly when it is nonempty. -/
 theorem mem_top_iff {ι : Type*} {σ : Finset ι} :

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
@@ -181,21 +181,21 @@ variable {M : _root_.PreAbstractSimplicialComplex γ}
 -/
 def faceOrderHom [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
-    _root_.AbstractSimplicialComplex.Face K →o _root_.AbstractSimplicialComplex.Face L where
+    SetLike.Face K →o SetLike.Face L where
   toFun σ := ⟨σ.1.image f, f.map_face σ.2⟩
   monotone' _ _ h := Finset.image_mono f h
 
 @[simp]
 theorem coe_faceOrderHom_apply [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
-    (σ : _root_.AbstractSimplicialComplex.Face K) :
+    (σ : SetLike.Face K) :
     (faceOrderHom f σ : Finset β) = σ.1.image f :=
   (rfl)
 
 private theorem faceOrderHom_comp_apply [DecidableEq β] [DecidableEq γ]
     (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
-    (σ : _root_.AbstractSimplicialComplex.Face K) :
+    (σ : SetLike.Face K) :
     faceOrderHom (g.comp f) σ = faceOrderHom g (faceOrderHom f σ) := by
   apply Subtype.ext
   rw [coe_faceOrderHom_apply, coe_faceOrderHom_apply, coe_faceOrderHom_apply]

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.AlgebraicTopology.SimplicialComplex.Basic
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Basic
 
 /-!
 # Maps of abstract simplicial complexes
@@ -170,3 +170,57 @@ end SimplicialMap
 
 end PreAbstractSimplicialComplex
 
+namespace TauCeti.PreAbstractSimplicialComplex.SimplicialMap
+
+variable {α β γ : Type*}
+variable {K : _root_.PreAbstractSimplicialComplex α}
+variable {L : _root_.PreAbstractSimplicialComplex β}
+variable {M : _root_.PreAbstractSimplicialComplex γ}
+
+/-- A simplicial map induces a monotone map between face posets by taking the image of every face.
+-/
+def faceOrderHom [DecidableEq β]
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
+    _root_.AbstractSimplicialComplex.Face K →o _root_.AbstractSimplicialComplex.Face L where
+  toFun σ := ⟨σ.1.image f, f.map_face σ.2⟩
+  monotone' _ _ h := Finset.image_mono f h
+
+@[simp]
+theorem coe_faceOrderHom_apply [DecidableEq β]
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
+    (σ : _root_.AbstractSimplicialComplex.Face K) :
+    (faceOrderHom f σ : Finset β) = σ.1.image f :=
+  (rfl)
+
+private theorem faceOrderHom_comp_apply [DecidableEq β] [DecidableEq γ]
+    (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
+    (σ : _root_.AbstractSimplicialComplex.Face K) :
+    faceOrderHom (g.comp f) σ = faceOrderHom g (faceOrderHom f σ) := by
+  apply Subtype.ext
+  rw [coe_faceOrderHom_apply, coe_faceOrderHom_apply, coe_faceOrderHom_apply]
+  rw [← Finset.image_comp]
+  exact congrArg (fun h : α → γ => σ.1.image h)
+    (_root_.PreAbstractSimplicialComplex.SimplicialMap.coe_comp g f)
+
+/-- Mapping face posets along the identity is the identity order homomorphism. -/
+@[simp]
+theorem faceOrderHom_id [DecidableEq α] :
+    faceOrderHom (_root_.PreAbstractSimplicialComplex.SimplicialMap.id K) = OrderHom.id := by
+  apply OrderHom.ext
+  funext σ
+  apply Subtype.ext
+  rw [coe_faceOrderHom_apply]
+  simp
+
+/-- Mapping face posets along a composite is composition of the face-poset maps. -/
+@[simp]
+theorem faceOrderHom_comp [DecidableEq β] [DecidableEq γ]
+    (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
+    faceOrderHom (g.comp f) = (faceOrderHom g).comp (faceOrderHom f) := by
+  apply OrderHom.ext
+  funext σ
+  exact faceOrderHom_comp_apply g f σ
+
+end TauCeti.PreAbstractSimplicialComplex.SimplicialMap

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
@@ -34,7 +34,7 @@ Chapter 2.
   chains.
 * `TauCeti.AbstractSimplicialComplex.pair_mem_orderComplex_iff`: two vertices span an edge exactly
   when they are comparable.
-* `TauCeti.AbstractSimplicialComplex.orderComplex_eq_top`: the order complex of a linear order is
+* `TauCeti.AbstractSimplicialComplex.orderComplex_eq_top`: the order complex of a total preorder is
   the full simplicial complex.
 * `TauCeti.AbstractSimplicialComplex.orderComplexMap_id` and
   `TauCeti.AbstractSimplicialComplex.orderComplexMap_comp`: functoriality laws.
@@ -98,10 +98,11 @@ theorem comparable_of_mem_orderComplex {σ : Finset P} (hσ : σ ∈ orderComple
   · exact Or.inl hpq.le
   · exact (mem_orderComplex_iff.mp hσ).2 (by exact_mod_cast hp) (by exact_mod_cast hq) hpq
 
-/-- If the order on `P` is linear, every nonempty finite set is a chain, so its order complex is
+/-- If the preorder on `P` is total, every nonempty finite set is a chain, so its order complex is
 the full abstract simplicial complex. -/
 @[simp]
-theorem orderComplex_eq_top (P : Type*) [LinearOrder P] :
+theorem orderComplex_eq_top (P : Type*) [Preorder P]
+    [Std.Total ((· ≤ ·) : P → P → Prop)] :
     orderComplex P = (⊤ : AbstractSimplicialComplex P) := by
   apply le_antisymm le_top
   intro σ hσ
@@ -109,7 +110,7 @@ theorem orderComplex_eq_top (P : Type*) [LinearOrder P] :
   change σ ∈ (orderComplex P).faces
   rw [orderComplex]
   change σ.Nonempty at hσ
-  exact ⟨hσ, isChain_of_trichotomous _⟩
+  exact ⟨hσ, fun p _ q _ _ => total_of (· ≤ ·) p q⟩
 
 /-- A monotone map induces a simplicial map between order complexes. -/
 def orderComplexMap [DecidableEq Q] (f : P →o Q) :

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Order.Preorder.Chain
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Basic
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Maps
+
+/-!
+# Order complexes
+
+The order complex of a partially ordered type has the elements of the type as vertices and the
+nonempty finite chains as faces. This is the general construction underlying barycentric
+subdivision: applying it to the face poset of a simplicial complex gives its first barycentric
+subdivision.
+
+This file also records functoriality. A monotone map sends a chain to a chain, and hence induces a
+simplicial map of order complexes. The construction and its functoriality follow the description
+of derived subdivisions in Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*,
+Chapter 2.
+
+## Main definitions
+
+* `TauCeti.AbstractSimplicialComplex.orderComplex`: the simplicial complex of nonempty finite
+  chains.
+* `TauCeti.AbstractSimplicialComplex.orderComplexMap`: the simplicial map induced by a monotone
+  map.
+
+## Main results
+
+* `TauCeti.AbstractSimplicialComplex.mem_orderComplex_iff`: faces are exactly the nonempty finite
+  chains.
+* `TauCeti.AbstractSimplicialComplex.pair_mem_orderComplex_iff`: two vertices span an edge exactly
+  when they are comparable.
+* `TauCeti.AbstractSimplicialComplex.orderComplex_eq_top`: the order complex of a linear order is
+  the full simplicial complex.
+* `TauCeti.AbstractSimplicialComplex.orderComplexMap_id` and
+  `TauCeti.AbstractSimplicialComplex.orderComplexMap_comp`: functoriality laws.
+-/
+
+public section
+
+open Finset Set
+
+namespace TauCeti
+
+namespace AbstractSimplicialComplex
+
+variable {P Q R : Type*} [PartialOrder P] [PartialOrder Q] [PartialOrder R]
+
+/-- The **order complex** of a partially ordered type `P`. Its vertices are the elements of `P`,
+and a nonempty finite set of vertices is a face exactly when its elements are pairwise comparable.
+-/
+noncomputable def orderComplex (P : Type*) [PartialOrder P] : AbstractSimplicialComplex P where
+  faces := {σ | σ.Nonempty ∧ IsChain (· ≤ ·) (↑σ : Set P)}
+  isRelLowerSet_faces := fun {_} hσ =>
+    ⟨hσ.1, fun _ hsub hne =>
+      ⟨hne, hσ.2.mono (by exact_mod_cast hsub)⟩⟩
+  singleton_mem p := by
+    classical
+    exact ⟨singleton_nonempty p, by simp⟩
+
+/-- A finite set is a face of the order complex exactly when it is nonempty and is a chain. -/
+@[simp]
+theorem mem_orderComplex_iff {σ : Finset P} :
+    σ ∈ orderComplex P ↔ σ.Nonempty ∧ IsChain (· ≤ ·) (↑σ : Set P) :=
+  by
+    -- `SetLike` membership hides the defining predicate behind the structure's `faces` projection.
+    change σ ∈ (orderComplex P).faces ↔ _
+    rw [orderComplex]
+    rfl
+
+/-- Two elements span an edge of the order complex exactly when they are comparable. This also
+covers the degenerate case `p = q`, when the pair is a singleton face. -/
+@[simp]
+theorem pair_mem_orderComplex_iff [DecidableEq P] (p q : P) :
+    {p, q} ∈ orderComplex P ↔ p ≤ q ∨ q ≤ p := by
+  rw [mem_orderComplex_iff]
+  constructor
+  · intro h
+    by_cases hpq : p = q
+    · exact Or.inl hpq.le
+    · exact h.2 (by simp) (by simp) hpq
+  · intro hpq
+    refine ⟨⟨p, by simp⟩, ?_⟩
+    rcases hpq with hpq | hqp
+    · simpa only [Finset.coe_insert, Finset.coe_singleton] using IsChain.pair hpq
+    · simpa only [Finset.pair_comm, Finset.coe_insert, Finset.coe_singleton] using
+        IsChain.pair hqp
+
+/-- In a face of an order complex, every two vertices are comparable. -/
+theorem comparable_of_mem_orderComplex {σ : Finset P} (hσ : σ ∈ orderComplex P)
+    {p q : P} (hp : p ∈ σ) (hq : q ∈ σ) : p ≤ q ∨ q ≤ p := by
+  by_cases hpq : p = q
+  · exact Or.inl hpq.le
+  · exact (mem_orderComplex_iff.mp hσ).2 (by exact_mod_cast hp) (by exact_mod_cast hq) hpq
+
+/-- If the order on `P` is linear, every nonempty finite set is a chain, so its order complex is
+the full abstract simplicial complex. -/
+@[simp]
+theorem orderComplex_eq_top (P : Type*) [LinearOrder P] :
+    orderComplex P = (⊤ : AbstractSimplicialComplex P) := by
+  apply le_antisymm le_top
+  intro σ hσ
+  -- Expose the two `faces` projections before unfolding the order complex and the lattice top.
+  change σ ∈ (orderComplex P).faces
+  rw [orderComplex]
+  change σ.Nonempty at hσ
+  exact ⟨hσ, isChain_of_trichotomous _⟩
+
+/-- A monotone map induces a simplicial map between order complexes. -/
+def orderComplexMap [DecidableEq Q] (f : P →o Q) :
+    PreAbstractSimplicialComplex.SimplicialMap
+      (orderComplex P).toPreAbstractSimplicialComplex
+      (orderComplex Q).toPreAbstractSimplicialComplex where
+  toFun := f
+  map_face' := by
+    intro σ hσ
+    rw [_root_.AbstractSimplicialComplex.mem_toPreAbstractSimplicialComplex,
+      mem_orderComplex_iff]
+    rw [_root_.AbstractSimplicialComplex.mem_toPreAbstractSimplicialComplex,
+      mem_orderComplex_iff] at hσ
+    refine ⟨image_nonempty.mpr hσ.1, ?_⟩
+    simpa only [coe_image] using f.monotone.isChain_image hσ.2
+
+@[simp]
+theorem coe_orderComplexMap [DecidableEq Q] (f : P →o Q) :
+    ⇑(orderComplexMap f) = f :=
+  (rfl)
+
+@[simp]
+theorem orderComplexMap_apply [DecidableEq Q] (f : P →o Q) (p : P) :
+    orderComplexMap f p = f p :=
+  (rfl)
+
+/-- The simplicial map of order complexes induced by the identity is the identity simplicial map.
+-/
+@[simp]
+theorem orderComplexMap_id [DecidableEq P] :
+  orderComplexMap OrderHom.id =
+      PreAbstractSimplicialComplex.SimplicialMap.id
+        (orderComplex P).toPreAbstractSimplicialComplex := by
+  ext p
+  -- `SimplicialMap.ext` leaves `toFun` projections; recover applications to use the public API.
+  change orderComplexMap OrderHom.id p =
+    PreAbstractSimplicialComplex.SimplicialMap.id
+      (orderComplex P).toPreAbstractSimplicialComplex p
+  rw [orderComplexMap_apply, PreAbstractSimplicialComplex.SimplicialMap.id_apply]
+  rfl
+
+/-- The simplicial map of order complexes induced by a composite is the composite of the induced
+simplicial maps. -/
+@[simp]
+theorem orderComplexMap_comp [DecidableEq Q] [DecidableEq R] (g : Q →o R) (f : P →o Q) :
+    orderComplexMap (g.comp f) =
+      (orderComplexMap g).comp (orderComplexMap f) := by
+  ext p
+  -- `SimplicialMap.ext` leaves `toFun` projections; recover applications to use the public API.
+  change orderComplexMap (g.comp f) p = (orderComplexMap g).comp (orderComplexMap f) p
+  rw [orderComplexMap_apply, PreAbstractSimplicialComplex.SimplicialMap.comp_apply,
+    orderComplexMap_apply, orderComplexMap_apply]
+  rfl
+
+end AbstractSimplicialComplex
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
@@ -11,7 +11,7 @@ public import TauCeti.AlgebraicTopology.SimplicialComplex.Maps
 /-!
 # Order complexes
 
-The order complex of a partially ordered type has the elements of the type as vertices and the
+The order complex of a preordered type has the elements of the type as vertices and the
 nonempty finite chains as faces. This is the general construction underlying barycentric
 subdivision: applying it to the face poset of a simplicial complex gives its first barycentric
 subdivision.
@@ -48,12 +48,12 @@ namespace TauCeti
 
 namespace AbstractSimplicialComplex
 
-variable {P Q R : Type*} [PartialOrder P] [PartialOrder Q] [PartialOrder R]
+variable {P Q R : Type*} [Preorder P] [Preorder Q] [Preorder R]
 
-/-- The **order complex** of a partially ordered type `P`. Its vertices are the elements of `P`,
+/-- The **order complex** of a preordered type `P`. Its vertices are the elements of `P`,
 and a nonempty finite set of vertices is a face exactly when its elements are pairwise comparable.
 -/
-noncomputable def orderComplex (P : Type*) [PartialOrder P] : AbstractSimplicialComplex P where
+noncomputable def orderComplex (P : Type*) [Preorder P] : AbstractSimplicialComplex P where
   faces := {σ | σ.Nonempty ∧ IsChain (· ≤ ·) (↑σ : Set P)}
   isRelLowerSet_faces := fun {_} hσ =>
     ⟨hσ.1, fun _ hsub hne =>

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Order.Preorder.Chain
-public import TauCeti.AlgebraicTopology.SimplicialComplex.Basic
 public import TauCeti.AlgebraicTopology.SimplicialComplex.Maps
 
 /-!
@@ -17,9 +16,10 @@ subdivision: applying it to the face poset of a simplicial complex gives its fir
 subdivision.
 
 This file also records functoriality. A monotone map sends a chain to a chain, and hence induces a
-simplicial map of order complexes. The construction and its functoriality follow the description
-of derived subdivisions in Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*,
-Chapter 2.
+simplicial map of order complexes. The barycentric-subdivision specialization in the next module
+models the derived subdivision described by Rourke--Sanderson, *Introduction to Piecewise-Linear
+Topology*, Chapter 2; the generic order-complex formulation and its functoriality are not taken
+from that source.
 
 ## Main definitions
 
@@ -66,11 +66,23 @@ noncomputable def orderComplex (P : Type*) [Preorder P] : AbstractSimplicialComp
 @[simp]
 theorem mem_orderComplex_iff {σ : Finset P} :
     σ ∈ orderComplex P ↔ σ.Nonempty ∧ IsChain (· ≤ ·) (↑σ : Set P) :=
-  by
-    -- `SetLike` membership hides the defining predicate behind the structure's `faces` projection.
-    change σ ∈ (orderComplex P).faces ↔ _
-    rw [orderComplex]
-    rfl
+  Iff.rfl
+
+/-- A finite set is a face of the order complex exactly when it is nonempty and every two of its
+elements are comparable. -/
+theorem mem_orderComplex_iff' {σ : Finset P} :
+    σ ∈ orderComplex P ↔
+      σ.Nonempty ∧ ∀ p ∈ σ, ∀ q ∈ σ, p ≤ q ∨ q ≤ p := by
+  rw [mem_orderComplex_iff]
+  refine and_congr_right fun _ => ⟨fun h p hp q hq => ?_, fun h => ?_⟩
+  · exact h.total (by exact_mod_cast hp) (by exact_mod_cast hq)
+  · intro p hp q hq _
+    exact h p (by exact_mod_cast hp) q (by exact_mod_cast hq)
+
+/-- In a face of an order complex, every two vertices are comparable. -/
+theorem le_or_le_of_mem_orderComplex {σ : Finset P} (hσ : σ ∈ orderComplex P)
+    {p q : P} (hp : p ∈ σ) (hq : q ∈ σ) : p ≤ q ∨ q ≤ p :=
+  (mem_orderComplex_iff.mp hσ).2.total (by exact_mod_cast hp) (by exact_mod_cast hq)
 
 /-- Two elements span an edge of the order complex exactly when they are comparable. This also
 covers the degenerate case `p = q`, when the pair is a singleton face.
@@ -78,25 +90,15 @@ covers the degenerate case `p = q`, when the pair is a singleton face.
 This is not a `simp` lemma: `mem_orderComplex_iff` already rewrites the left-hand side. -/
 theorem pair_mem_orderComplex_iff [DecidableEq P] (p q : P) :
     {p, q} ∈ orderComplex P ↔ p ≤ q ∨ q ≤ p := by
-  rw [mem_orderComplex_iff]
   constructor
   · intro h
-    by_cases hpq : p = q
-    · exact Or.inl hpq.le
-    · exact h.2 (by simp) (by simp) hpq
+    exact le_or_le_of_mem_orderComplex h (by simp) (by simp)
   · intro hpq
+    rw [mem_orderComplex_iff]
     refine ⟨⟨p, by simp⟩, ?_⟩
     rcases hpq with hpq | hqp
-    · simpa only [Finset.coe_insert, Finset.coe_singleton] using IsChain.pair hpq
-    · simpa only [Finset.pair_comm, Finset.coe_insert, Finset.coe_singleton] using
-        IsChain.pair hqp
-
-/-- In a face of an order complex, every two vertices are comparable. -/
-theorem comparable_of_mem_orderComplex {σ : Finset P} (hσ : σ ∈ orderComplex P)
-    {p q : P} (hp : p ∈ σ) (hq : q ∈ σ) : p ≤ q ∨ q ≤ p := by
-  by_cases hpq : p = q
-  · exact Or.inl hpq.le
-  · exact (mem_orderComplex_iff.mp hσ).2 (by exact_mod_cast hp) (by exact_mod_cast hq) hpq
+    · simpa only [Finset.coe_pair] using IsChain.pair hpq
+    · simpa only [Finset.pair_comm, Finset.coe_pair] using IsChain.pair hqp
 
 /-- If the preorder on `P` is total, every nonempty finite set is a chain, so its order complex is
 the full abstract simplicial complex. -/
@@ -106,11 +108,8 @@ theorem orderComplex_eq_top (P : Type*) [Preorder P]
     orderComplex P = (⊤ : AbstractSimplicialComplex P) := by
   apply le_antisymm le_top
   intro σ hσ
-  -- Expose the two `faces` projections before unfolding the order complex and the lattice top.
-  change σ ∈ (orderComplex P).faces
-  rw [orderComplex]
-  change σ.Nonempty at hσ
-  exact ⟨hσ, fun p _ q _ _ => total_of (· ≤ ·) p q⟩
+  exact mem_orderComplex_iff.mpr
+    ⟨mem_top_iff.mp hσ, fun p _ q _ _ => total_of (· ≤ ·) p q⟩
 
 /-- A monotone map induces a simplicial map between order complexes. -/
 def orderComplexMap [DecidableEq Q] (f : P →o Q) :
@@ -144,12 +143,8 @@ theorem orderComplexMap_id [DecidableEq P] :
   orderComplexMap OrderHom.id =
       PreAbstractSimplicialComplex.SimplicialMap.id
         (orderComplex P).toPreAbstractSimplicialComplex := by
-  ext p
-  -- `SimplicialMap.ext` leaves `toFun` projections; recover applications to use the public API.
-  change orderComplexMap OrderHom.id p =
-    PreAbstractSimplicialComplex.SimplicialMap.id
-      (orderComplex P).toPreAbstractSimplicialComplex p
-  rw [orderComplexMap_apply, PreAbstractSimplicialComplex.SimplicialMap.id_apply]
+  apply DFunLike.coe_injective
+  rw [coe_orderComplexMap, PreAbstractSimplicialComplex.SimplicialMap.coe_id]
   rfl
 
 /-- The simplicial map of order complexes induced by a composite is the composite of the induced
@@ -158,11 +153,9 @@ simplicial maps. -/
 theorem orderComplexMap_comp [DecidableEq Q] [DecidableEq R] (g : Q →o R) (f : P →o Q) :
     orderComplexMap (g.comp f) =
       (orderComplexMap g).comp (orderComplexMap f) := by
-  ext p
-  -- `SimplicialMap.ext` leaves `toFun` projections; recover applications to use the public API.
-  change orderComplexMap (g.comp f) p = (orderComplexMap g).comp (orderComplexMap f) p
-  rw [orderComplexMap_apply, PreAbstractSimplicialComplex.SimplicialMap.comp_apply,
-    orderComplexMap_apply, orderComplexMap_apply]
+  apply DFunLike.coe_injective
+  rw [coe_orderComplexMap, PreAbstractSimplicialComplex.SimplicialMap.coe_comp,
+    coe_orderComplexMap, coe_orderComplexMap]
   rfl
 
 end AbstractSimplicialComplex

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
@@ -73,8 +73,9 @@ theorem mem_orderComplex_iff {σ : Finset P} :
     rfl
 
 /-- Two elements span an edge of the order complex exactly when they are comparable. This also
-covers the degenerate case `p = q`, when the pair is a singleton face. -/
-@[simp]
+covers the degenerate case `p = q`, when the pair is a singleton face.
+
+This is not a `simp` lemma: `mem_orderComplex_iff` already rewrites the left-hand side. -/
 theorem pair_mem_orderComplex_iff [DecidableEq P] (p q : P) :
     {p, q} ∈ orderComplex P ↔ p ≤ q ∨ q ≤ p := by
   rw [mem_orderComplex_iff]

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Realization.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Realization.lean
@@ -43,7 +43,7 @@ public section
 
 noncomputable section
 
-open Set
+open Set TauCeti.SetLike
 
 namespace AbstractSimplicialComplex
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex/Realization.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex/Realization.lean
@@ -39,7 +39,7 @@ public section
 
 noncomputable section
 
-open Metric Set
+open Metric Set TauCeti.SetLike
 
 namespace AbstractSimplicialComplex
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
@@ -145,8 +145,7 @@ theorem barycentricMap_apply_coe [DecidableEq β]
   by
     rw [← faceOrderHom_apply_coe, ← coe_barycentricMap]
 
-/-- Mapping face posets along a composite agrees pointwise with composing the face-poset maps. -/
-theorem faceOrderHom_comp_apply [DecidableEq β] [DecidableEq γ]
+private theorem faceOrderHom_comp_apply [DecidableEq β] [DecidableEq γ]
     (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
     (σ : BarycentricVertex K) :
@@ -156,6 +155,26 @@ theorem faceOrderHom_comp_apply [DecidableEq β] [DecidableEq γ]
   rw [← Finset.image_comp]
   exact congrArg (fun h : α → γ => σ.1.image h)
     (_root_.PreAbstractSimplicialComplex.SimplicialMap.coe_comp g f)
+
+/-- Mapping face posets along the identity is the identity order homomorphism. -/
+@[simp]
+theorem faceOrderHom_id [DecidableEq α] :
+    faceOrderHom (_root_.PreAbstractSimplicialComplex.SimplicialMap.id K) = OrderHom.id := by
+  apply OrderHom.ext
+  funext σ
+  apply Subtype.ext
+  rw [faceOrderHom_apply_coe]
+  simp
+
+/-- Mapping face posets along a composite is composition of the face-poset maps. -/
+@[simp]
+theorem faceOrderHom_comp [DecidableEq β] [DecidableEq γ]
+    (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
+    faceOrderHom (g.comp f) = (faceOrderHom g).comp (faceOrderHom f) := by
+  apply OrderHom.ext
+  funext σ
+  exact faceOrderHom_comp_apply g f σ
 
 /-- Barycentric subdivision sends the identity simplicial map to the identity simplicial map. -/
 @[simp]

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
@@ -18,24 +18,24 @@ The construction is made for `PreAbstractSimplicialComplex`, since links, deleti
 subcomplexes need not contain every ambient singleton. Its result is an
 `AbstractSimplicialComplex`: every face of the original complex is genuinely a vertex of the
 subdivision. Simplicial maps act on face posets by taking vertexwise images, yielding the
-functorial map `barycentricMap`.
+functorial map `barycentricSubdivisionMap`.
 
 This supplies the subdivision primitive required by Layer 11 of the GeometricTopology roadmap
 before combinatorial spheres and balls can be defined up to subdivision. The definition follows
 Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2, "Derived
 Subdivisions". Identifying the realizations of a complex and its subdivision is separate geometric
-realization work.
+realization work. The functoriality here is only at the level of abstract complexes: the canonical
+identification of a subdivision's realization with the original realization is not natural in
+arbitrary simplicial maps.
 
 ## Main definitions
 
-* `TauCeti.PreAbstractSimplicialComplex.BarycentricVertex`: a nonempty face of the original
-  complex, regarded as a vertex of its subdivision.
 * `TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision`: the order complex of the face
   poset.
 * `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.faceOrderHom`: the monotone map on face
   posets induced by a simplicial map.
-* `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.barycentricMap`: the induced simplicial map
-  between barycentric subdivisions.
+* `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.barycentricSubdivisionMap`: the induced
+  simplicial map between barycentric subdivisions.
 
 ## Main results
 
@@ -43,8 +43,9 @@ realization work.
   criterion.
 * `TauCeti.PreAbstractSimplicialComplex.pair_mem_barycentricSubdivision_iff`: two original faces
   span an edge exactly when one contains the other.
-* `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.barycentricMap_id` and
-  `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.barycentricMap_comp`: functoriality laws.
+* `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.barycentricSubdivisionMap_id` and
+  `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.barycentricSubdivisionMap_comp`:
+  functoriality laws.
 -/
 
 public section
@@ -57,142 +58,121 @@ namespace PreAbstractSimplicialComplex
 
 variable {α β γ : Type*}
 
-/-- A vertex of the barycentric subdivision of `K` is a face of `K`. Faces of a pre-abstract
-simplicial complex are nonempty by definition. -/
-abbrev BarycentricVertex (K : PreAbstractSimplicialComplex α) := {σ : Finset α // σ ∈ K}
-
 /-- The first **barycentric subdivision** of `K`: its vertices are the faces of `K`, and its faces
 are the nonempty finite chains of faces under inclusion. -/
-noncomputable def barycentricSubdivision (K : PreAbstractSimplicialComplex α) :
-    AbstractSimplicialComplex (BarycentricVertex K) :=
-  AbstractSimplicialComplex.orderComplex (BarycentricVertex K)
+@[expose] noncomputable def barycentricSubdivision (K : PreAbstractSimplicialComplex α) :
+    AbstractSimplicialComplex (_root_.AbstractSimplicialComplex.Face K) :=
+  AbstractSimplicialComplex.orderComplex (_root_.AbstractSimplicialComplex.Face K)
+
+/-- Barycentric subdivision is the order complex of the face poset. -/
+@[simp]
+theorem barycentricSubdivision_eq_orderComplex (K : PreAbstractSimplicialComplex α) :
+    barycentricSubdivision K =
+      AbstractSimplicialComplex.orderComplex (_root_.AbstractSimplicialComplex.Face K) :=
+  rfl
 
 variable {K : PreAbstractSimplicialComplex α}
 
 /-- A collection of faces of `K` is a face of its barycentric subdivision exactly when it is
 nonempty and totally ordered by inclusion. -/
 @[simp]
-theorem mem_barycentricSubdivision_iff {τ : Finset (BarycentricVertex K)} :
+theorem mem_barycentricSubdivision_iff
+    {τ : Finset (_root_.AbstractSimplicialComplex.Face K)} :
     τ ∈ barycentricSubdivision K ↔
-      τ.Nonempty ∧ IsChain (· ≤ ·) (↑τ : Set (BarycentricVertex K)) :=
-  AbstractSimplicialComplex.mem_orderComplex_iff
+      τ.Nonempty ∧
+        IsChain (· ≤ ·) (↑τ : Set (_root_.AbstractSimplicialComplex.Face K)) := by
+  rw [barycentricSubdivision_eq_orderComplex,
+    AbstractSimplicialComplex.mem_orderComplex_iff]
+
+/-- A collection is a face of the barycentric subdivision exactly when it is nonempty and every
+two original faces in the collection are nested. -/
+theorem mem_barycentricSubdivision_iff'
+    {ρ : Finset (_root_.AbstractSimplicialComplex.Face K)} :
+    ρ ∈ barycentricSubdivision K ↔
+      ρ.Nonempty ∧ ∀ σ ∈ ρ, ∀ τ ∈ ρ,
+        (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ := by
+  rw [barycentricSubdivision_eq_orderComplex,
+    AbstractSimplicialComplex.mem_orderComplex_iff']
+  simp only [TauCeti.AbstractSimplicialComplex.face_le_iff]
 
 /-- Two faces of `K` span an edge in its barycentric subdivision exactly when one is contained in
 the other.
 
 This is not a `simp` lemma: `mem_barycentricSubdivision_iff` already rewrites the left-hand
 side. -/
-theorem pair_mem_barycentricSubdivision_iff [DecidableEq α] (σ τ : BarycentricVertex K) :
-    {σ, τ} ∈ barycentricSubdivision K ↔ (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ :=
-  AbstractSimplicialComplex.pair_mem_orderComplex_iff σ τ
+theorem pair_mem_barycentricSubdivision_iff [DecidableEq α]
+    (σ τ : _root_.AbstractSimplicialComplex.Face K) :
+    {σ, τ} ∈ barycentricSubdivision K ↔
+      (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ := by
+  rw [barycentricSubdivision_eq_orderComplex,
+    AbstractSimplicialComplex.pair_mem_orderComplex_iff]
+  simp only [TauCeti.AbstractSimplicialComplex.face_le_iff]
 
 /-- Every two original faces occurring in one face of the barycentric subdivision are nested. -/
-theorem comparable_of_mem_barycentricSubdivision {ρ : Finset (BarycentricVertex K)}
-    (hρ : ρ ∈ barycentricSubdivision K) {σ τ : BarycentricVertex K}
-    (hσ : σ ∈ ρ) (hτ : τ ∈ ρ) : (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ :=
-  AbstractSimplicialComplex.comparable_of_mem_orderComplex hρ hσ hτ
+theorem subset_or_subset_of_mem_barycentricSubdivision
+    {ρ : Finset (_root_.AbstractSimplicialComplex.Face K)}
+    (hρ : ρ ∈ barycentricSubdivision K)
+    {σ τ : _root_.AbstractSimplicialComplex.Face K}
+    (hσ : σ ∈ ρ) (hτ : τ ∈ ρ) :
+    (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ := by
+  rw [barycentricSubdivision_eq_orderComplex] at hρ
+  simpa only [TauCeti.AbstractSimplicialComplex.face_le_iff] using
+    AbstractSimplicialComplex.le_or_le_of_mem_orderComplex hρ hσ hτ
 
 namespace SimplicialMap
 
 variable {K : PreAbstractSimplicialComplex α} {L : PreAbstractSimplicialComplex β}
   {M : PreAbstractSimplicialComplex γ}
 
-/-- A simplicial map induces a monotone map between face posets by taking the image of every face.
--/
-def faceOrderHom [DecidableEq β]
-    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
-    BarycentricVertex K →o BarycentricVertex L where
-  toFun σ := ⟨σ.1.image f, f.map_face σ.2⟩
-  monotone' _ _ h := Finset.image_mono f h
-
--- Not a `simp` lemma: its right-hand side is a lambda building a subtype, so
--- `faceOrderHom_apply_coe` is the pointwise `simp`-normal form.
-theorem coe_faceOrderHom [DecidableEq β]
-    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
-    ⇑(faceOrderHom f) = fun σ => ⟨σ.1.image f, f.map_face σ.2⟩ :=
-  (rfl)
-
-@[simp]
-theorem faceOrderHom_apply_coe [DecidableEq β]
-    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
-    (σ : BarycentricVertex K) :
-    (faceOrderHom f σ : Finset β) = σ.1.image f :=
-  (rfl)
-
 /-- A simplicial map induces a simplicial map between barycentric subdivisions by mapping every
 face-vertex to its vertexwise image. -/
-def barycentricMap [DecidableEq β]
+@[expose] def barycentricSubdivisionMap [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
     _root_.PreAbstractSimplicialComplex.SimplicialMap
       (barycentricSubdivision K).toPreAbstractSimplicialComplex
       (barycentricSubdivision L).toPreAbstractSimplicialComplex :=
   AbstractSimplicialComplex.orderComplexMap (faceOrderHom f)
 
--- Not a `simp` lemma: it would reduce `barycentricMap_apply_coe`, the pointwise
--- `simp`-normal form, to a duplicate.
-theorem coe_barycentricMap [DecidableEq β]
+/-- The subdivision map is the order-complex map induced by the map on face posets. -/
+theorem barycentricSubdivisionMap_eq_orderComplexMap [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
-    ⇑(barycentricMap f) = faceOrderHom f :=
-  by
-    rw [barycentricMap]
-    exact AbstractSimplicialComplex.coe_orderComplexMap (faceOrderHom f)
+    barycentricSubdivisionMap f = AbstractSimplicialComplex.orderComplexMap (faceOrderHom f) :=
+  rfl
 
-@[simp]
-theorem barycentricMap_apply_coe [DecidableEq β]
-    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
-    (σ : BarycentricVertex K) :
-    (barycentricMap f σ : Finset β) = σ.1.image f :=
-  by
-    rw [← faceOrderHom_apply_coe, ← coe_barycentricMap]
-
-private theorem faceOrderHom_comp_apply [DecidableEq β] [DecidableEq γ]
-    (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
-    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
-    (σ : BarycentricVertex K) :
-    faceOrderHom (g.comp f) σ = faceOrderHom g (faceOrderHom f σ) := by
-  apply Subtype.ext
-  rw [faceOrderHom_apply_coe, faceOrderHom_apply_coe, faceOrderHom_apply_coe]
-  rw [← Finset.image_comp]
-  exact congrArg (fun h : α → γ => σ.1.image h)
-    (_root_.PreAbstractSimplicialComplex.SimplicialMap.coe_comp g f)
-
-/-- Mapping face posets along the identity is the identity order homomorphism. -/
-@[simp]
-theorem faceOrderHom_id [DecidableEq α] :
-    faceOrderHom (_root_.PreAbstractSimplicialComplex.SimplicialMap.id K) = OrderHom.id := by
-  apply OrderHom.ext
-  funext σ
-  apply Subtype.ext
-  rw [faceOrderHom_apply_coe]
-  simp
-
-/-- Mapping face posets along a composite is composition of the face-poset maps. -/
-@[simp]
-theorem faceOrderHom_comp [DecidableEq β] [DecidableEq γ]
-    (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
+theorem coe_barycentricSubdivisionMap [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
-    faceOrderHom (g.comp f) = (faceOrderHom g).comp (faceOrderHom f) := by
-  apply OrderHom.ext
-  funext σ
-  exact faceOrderHom_comp_apply g f σ
+    ⇑(barycentricSubdivisionMap f) = faceOrderHom f := by
+  rw [barycentricSubdivisionMap_eq_orderComplexMap]
+  exact AbstractSimplicialComplex.coe_orderComplexMap (faceOrderHom f)
+
+@[simp]
+theorem coe_barycentricSubdivisionMap_apply [DecidableEq β]
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
+    (σ : _root_.AbstractSimplicialComplex.Face K) :
+    (barycentricSubdivisionMap f σ : Finset β) = σ.1.image f := by
+  rw [← coe_faceOrderHom_apply, ← coe_barycentricSubdivisionMap]
 
 /-- Barycentric subdivision sends the identity simplicial map to the identity simplicial map. -/
 @[simp]
-theorem barycentricMap_id [DecidableEq α] :
-    barycentricMap (_root_.PreAbstractSimplicialComplex.SimplicialMap.id K) =
+theorem barycentricSubdivisionMap_id [DecidableEq α] :
+    barycentricSubdivisionMap (_root_.PreAbstractSimplicialComplex.SimplicialMap.id K) =
       _root_.PreAbstractSimplicialComplex.SimplicialMap.id
         (barycentricSubdivision K).toPreAbstractSimplicialComplex := by
-  rw [barycentricMap, faceOrderHom_id, AbstractSimplicialComplex.orderComplexMap_id]
+  rw [barycentricSubdivisionMap_eq_orderComplexMap, faceOrderHom_id,
+    AbstractSimplicialComplex.orderComplexMap_id]
   rfl
 
 /-- Barycentric subdivision sends a composite of simplicial maps to the composite of their
 induced maps. -/
 @[simp]
-theorem barycentricMap_comp [DecidableEq β] [DecidableEq γ]
+theorem barycentricSubdivisionMap_comp [DecidableEq β] [DecidableEq γ]
     (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
-    barycentricMap (g.comp f) = (barycentricMap g).comp (barycentricMap f) := by
-  rw [barycentricMap, faceOrderHom_comp, AbstractSimplicialComplex.orderComplexMap_comp]
+    barycentricSubdivisionMap (g.comp f) =
+      (barycentricSubdivisionMap g).comp (barycentricSubdivisionMap f) := by
+  rw [barycentricSubdivisionMap_eq_orderComplexMap, faceOrderHom_comp,
+    AbstractSimplicialComplex.orderComplexMap_comp,
+    barycentricSubdivisionMap_eq_orderComplexMap, barycentricSubdivisionMap_eq_orderComplexMap]
   rfl
 
 end SimplicialMap

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.SimplicialComplex.OrderComplex
+
+/-!
+# Barycentric subdivision of abstract simplicial complexes
+
+The vertices of the first barycentric subdivision of a simplicial complex `K` are the nonempty
+faces of `K`. A collection of these new vertices spans a face exactly when the corresponding faces
+of `K` form a chain under inclusion. Equivalently, the barycentric subdivision is the order
+complex of the face poset.
+
+The construction is made for `PreAbstractSimplicialComplex`, since links, deletions, and collapse
+subcomplexes need not contain every ambient singleton. Its result is an
+`AbstractSimplicialComplex`: every face of the original complex is genuinely a vertex of the
+subdivision. Simplicial maps act on face posets by taking vertexwise images, yielding the
+functorial map `barycentricMap`.
+
+This supplies the subdivision primitive required by Layer 11 of the GeometricTopology roadmap
+before combinatorial spheres and balls can be defined up to subdivision. The definition follows
+Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2, "Derived
+Subdivisions". Identifying the realizations of a complex and its subdivision is separate geometric
+realization work.
+
+## Main definitions
+
+* `TauCeti.PreAbstractSimplicialComplex.BarycentricVertex`: a nonempty face of the original
+  complex, regarded as a vertex of its subdivision.
+* `TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision`: the order complex of the face
+  poset.
+* `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.faceOrderHom`: the monotone map on face
+  posets induced by a simplicial map.
+* `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.barycentricMap`: the induced simplicial map
+  between barycentric subdivisions.
+
+## Main results
+
+* `TauCeti.PreAbstractSimplicialComplex.mem_barycentricSubdivision_iff`: the characteristic face
+  criterion.
+* `TauCeti.PreAbstractSimplicialComplex.pair_mem_barycentricSubdivision_iff`: two original faces
+  span an edge exactly when one contains the other.
+* `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.barycentricMap_id` and
+  `TauCeti.PreAbstractSimplicialComplex.SimplicialMap.barycentricMap_comp`: functoriality laws.
+-/
+
+public section
+
+open Finset Set
+
+namespace TauCeti
+
+namespace PreAbstractSimplicialComplex
+
+variable {α β γ : Type*}
+
+/-- A vertex of the barycentric subdivision of `K` is a face of `K`. Faces of a pre-abstract
+simplicial complex are nonempty by definition. -/
+abbrev BarycentricVertex (K : PreAbstractSimplicialComplex α) := {σ : Finset α // σ ∈ K}
+
+/-- The first **barycentric subdivision** of `K`: its vertices are the faces of `K`, and its faces
+are the nonempty finite chains of faces under inclusion. -/
+noncomputable def barycentricSubdivision (K : PreAbstractSimplicialComplex α) :
+    AbstractSimplicialComplex (BarycentricVertex K) :=
+  AbstractSimplicialComplex.orderComplex (BarycentricVertex K)
+
+variable {K : PreAbstractSimplicialComplex α}
+
+/-- A collection of faces of `K` is a face of its barycentric subdivision exactly when it is
+nonempty and totally ordered by inclusion. -/
+@[simp]
+theorem mem_barycentricSubdivision_iff {τ : Finset (BarycentricVertex K)} :
+    τ ∈ barycentricSubdivision K ↔
+      τ.Nonempty ∧ IsChain (· ≤ ·) (↑τ : Set (BarycentricVertex K)) :=
+  AbstractSimplicialComplex.mem_orderComplex_iff
+
+/-- Two faces of `K` span an edge in its barycentric subdivision exactly when one is contained in
+the other. -/
+@[simp]
+theorem pair_mem_barycentricSubdivision_iff [DecidableEq α] (σ τ : BarycentricVertex K) :
+    {σ, τ} ∈ barycentricSubdivision K ↔ (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ :=
+  AbstractSimplicialComplex.pair_mem_orderComplex_iff σ τ
+
+/-- Every two original faces occurring in one face of the barycentric subdivision are nested. -/
+theorem comparable_of_mem_barycentricSubdivision {ρ : Finset (BarycentricVertex K)}
+    (hρ : ρ ∈ barycentricSubdivision K) {σ τ : BarycentricVertex K}
+    (hσ : σ ∈ ρ) (hτ : τ ∈ ρ) : (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ :=
+  AbstractSimplicialComplex.comparable_of_mem_orderComplex hρ hσ hτ
+
+namespace SimplicialMap
+
+variable {K : PreAbstractSimplicialComplex α} {L : PreAbstractSimplicialComplex β}
+  {M : PreAbstractSimplicialComplex γ}
+
+/-- A simplicial map induces a monotone map between face posets by taking the image of every face.
+-/
+def faceOrderHom [DecidableEq β]
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
+    BarycentricVertex K →o BarycentricVertex L where
+  toFun σ := ⟨σ.1.image f, f.map_face σ.2⟩
+  monotone' _ _ h := Finset.image_mono f h
+
+@[simp]
+theorem coe_faceOrderHom [DecidableEq β]
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
+    ⇑(faceOrderHom f) = fun σ => ⟨σ.1.image f, f.map_face σ.2⟩ :=
+  (rfl)
+
+@[simp]
+theorem faceOrderHom_apply_coe [DecidableEq β]
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
+    (σ : BarycentricVertex K) :
+    (faceOrderHom f σ : Finset β) = σ.1.image f :=
+  (rfl)
+
+/-- A simplicial map induces a simplicial map between barycentric subdivisions by mapping every
+face-vertex to its vertexwise image. -/
+def barycentricMap [DecidableEq β]
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
+    _root_.PreAbstractSimplicialComplex.SimplicialMap
+      (barycentricSubdivision K).toPreAbstractSimplicialComplex
+      (barycentricSubdivision L).toPreAbstractSimplicialComplex :=
+  AbstractSimplicialComplex.orderComplexMap (faceOrderHom f)
+
+@[simp]
+theorem coe_barycentricMap [DecidableEq β]
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
+    ⇑(barycentricMap f) = faceOrderHom f :=
+  by
+    rw [barycentricMap]
+    exact AbstractSimplicialComplex.coe_orderComplexMap (faceOrderHom f)
+
+@[simp]
+theorem barycentricMap_apply_coe [DecidableEq β]
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
+    (σ : BarycentricVertex K) :
+    (barycentricMap f σ : Finset β) = σ.1.image f :=
+  by
+    rw [← faceOrderHom_apply_coe, ← coe_barycentricMap]
+
+/-- Mapping face posets along a composite agrees pointwise with composing the face-poset maps. -/
+theorem faceOrderHom_comp_apply [DecidableEq β] [DecidableEq γ]
+    (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
+    (σ : BarycentricVertex K) :
+    faceOrderHom (g.comp f) σ = faceOrderHom g (faceOrderHom f σ) := by
+  apply Subtype.ext
+  rw [faceOrderHom_apply_coe, faceOrderHom_apply_coe, faceOrderHom_apply_coe]
+  rw [← Finset.image_comp]
+  exact congrArg (fun h : α → γ => σ.1.image h)
+    (_root_.PreAbstractSimplicialComplex.SimplicialMap.coe_comp g f)
+
+/-- Barycentric subdivision sends the identity simplicial map to the identity simplicial map. -/
+@[simp]
+theorem barycentricMap_id [DecidableEq α] :
+    barycentricMap (_root_.PreAbstractSimplicialComplex.SimplicialMap.id K) =
+      _root_.PreAbstractSimplicialComplex.SimplicialMap.id
+        (barycentricSubdivision K).toPreAbstractSimplicialComplex := by
+  apply DFunLike.coe_injective
+  funext σ
+  apply Subtype.ext
+  rw [barycentricMap_apply_coe]
+  simp
+
+/-- Barycentric subdivision sends a composite of simplicial maps to the composite of their
+induced maps. -/
+@[simp]
+theorem barycentricMap_comp [DecidableEq β] [DecidableEq γ]
+    (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
+    (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
+    barycentricMap (g.comp f) = (barycentricMap g).comp (barycentricMap f) := by
+  apply DFunLike.coe_injective
+  funext σ
+  rw [coe_barycentricMap,
+    _root_.PreAbstractSimplicialComplex.SimplicialMap.coe_comp,
+    coe_barycentricMap, coe_barycentricMap]
+  exact faceOrderHom_comp_apply g f σ
+
+end SimplicialMap
+
+end PreAbstractSimplicialComplex
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
@@ -78,8 +78,10 @@ theorem mem_barycentricSubdivision_iff {τ : Finset (BarycentricVertex K)} :
   AbstractSimplicialComplex.mem_orderComplex_iff
 
 /-- Two faces of `K` span an edge in its barycentric subdivision exactly when one is contained in
-the other. -/
-@[simp]
+the other.
+
+This is not a `simp` lemma: `mem_barycentricSubdivision_iff` already rewrites the left-hand
+side. -/
 theorem pair_mem_barycentricSubdivision_iff [DecidableEq α] (σ τ : BarycentricVertex K) :
     {σ, τ} ∈ barycentricSubdivision K ↔ (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ :=
   AbstractSimplicialComplex.pair_mem_orderComplex_iff σ τ
@@ -103,7 +105,8 @@ def faceOrderHom [DecidableEq β]
   toFun σ := ⟨σ.1.image f, f.map_face σ.2⟩
   monotone' _ _ h := Finset.image_mono f h
 
-@[simp]
+-- Not a `simp` lemma: its right-hand side is a lambda building a subtype, so
+-- `faceOrderHom_apply_coe` is the pointwise `simp`-normal form.
 theorem coe_faceOrderHom [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
     ⇑(faceOrderHom f) = fun σ => ⟨σ.1.image f, f.map_face σ.2⟩ :=
@@ -125,7 +128,8 @@ def barycentricMap [DecidableEq β]
       (barycentricSubdivision L).toPreAbstractSimplicialComplex :=
   AbstractSimplicialComplex.orderComplexMap (faceOrderHom f)
 
-@[simp]
+-- Not a `simp` lemma: it would reduce `barycentricMap_apply_coe`, the pointwise
+-- `simp`-normal form, to a duplicate.
 theorem coe_barycentricMap [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
     ⇑(barycentricMap f) = faceOrderHom f :=

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
@@ -182,11 +182,8 @@ theorem barycentricMap_id [DecidableEq α] :
     barycentricMap (_root_.PreAbstractSimplicialComplex.SimplicialMap.id K) =
       _root_.PreAbstractSimplicialComplex.SimplicialMap.id
         (barycentricSubdivision K).toPreAbstractSimplicialComplex := by
-  apply DFunLike.coe_injective
-  funext σ
-  apply Subtype.ext
-  rw [barycentricMap_apply_coe]
-  simp
+  rw [barycentricMap, faceOrderHom_id, AbstractSimplicialComplex.orderComplexMap_id]
+  rfl
 
 /-- Barycentric subdivision sends a composite of simplicial maps to the composite of their
 induced maps. -/
@@ -195,12 +192,8 @@ theorem barycentricMap_comp [DecidableEq β] [DecidableEq γ]
     (g : _root_.PreAbstractSimplicialComplex.SimplicialMap L M)
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
     barycentricMap (g.comp f) = (barycentricMap g).comp (barycentricMap f) := by
-  apply DFunLike.coe_injective
-  funext σ
-  rw [coe_barycentricMap,
-    _root_.PreAbstractSimplicialComplex.SimplicialMap.coe_comp,
-    coe_barycentricMap, coe_barycentricMap]
-  exact faceOrderHom_comp_apply g f σ
+  rw [barycentricMap, faceOrderHom_comp, AbstractSimplicialComplex.orderComplexMap_comp]
+  rfl
 
 end SimplicialMap
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
@@ -9,10 +9,11 @@ public import TauCeti.AlgebraicTopology.SimplicialComplex.OrderComplex
 /-!
 # Barycentric subdivision of abstract simplicial complexes
 
-The vertices of the first barycentric subdivision of a simplicial complex `K` are its faces. For a
-precomplex, these may include the empty face. A collection of these new vertices spans a face
-exactly when the corresponding faces of `K` form a chain under inclusion. Equivalently, the
-barycentric subdivision is the order complex of the face poset.
+The vertices of the first barycentric subdivision of a simplicial complex `K` are its faces, which
+are always nonempty: `PreAbstractSimplicialComplex` requires its face collection to be a lower set
+relative to `Finset.Nonempty`, so the empty face never occurs. A collection of these new vertices
+spans a face exactly when the corresponding faces of `K` form a chain under inclusion.
+Equivalently, the barycentric subdivision is the order complex of the face poset.
 
 The construction is made for `PreAbstractSimplicialComplex`, since links, deletions, and collapse
 subcomplexes need not contain every ambient singleton. Its result is an

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
@@ -9,10 +9,10 @@ public import TauCeti.AlgebraicTopology.SimplicialComplex.OrderComplex
 /-!
 # Barycentric subdivision of abstract simplicial complexes
 
-The vertices of the first barycentric subdivision of a simplicial complex `K` are the nonempty
-faces of `K`. A collection of these new vertices spans a face exactly when the corresponding faces
-of `K` form a chain under inclusion. Equivalently, the barycentric subdivision is the order
-complex of the face poset.
+The vertices of the first barycentric subdivision of a simplicial complex `K` are its faces. For a
+precomplex, these may include the empty face. A collection of these new vertices spans a face
+exactly when the corresponding faces of `K` form a chain under inclusion. Equivalently, the
+barycentric subdivision is the order complex of the face poset.
 
 The construction is made for `PreAbstractSimplicialComplex`, since links, deletions, and collapse
 subcomplexes need not contain every ambient singleton. Its result is an

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
@@ -65,7 +65,6 @@ are the nonempty finite chains of faces under inclusion. -/
   AbstractSimplicialComplex.orderComplex (_root_.AbstractSimplicialComplex.Face K)
 
 /-- Barycentric subdivision is the order complex of the face poset. -/
-@[simp]
 theorem barycentricSubdivision_eq_orderComplex (K : PreAbstractSimplicialComplex α) :
     barycentricSubdivision K =
       AbstractSimplicialComplex.orderComplex (_root_.AbstractSimplicialComplex.Face K) :=

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
@@ -125,7 +125,7 @@ variable {K : PreAbstractSimplicialComplex α} {L : PreAbstractSimplicialComplex
 
 /-- A simplicial map induces a simplicial map between barycentric subdivisions by mapping every
 face-vertex to its vertexwise image. -/
-@[expose] def barycentricSubdivisionMap [DecidableEq β]
+def barycentricSubdivisionMap [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
     _root_.PreAbstractSimplicialComplex.SimplicialMap
       (barycentricSubdivision K).toPreAbstractSimplicialComplex
@@ -136,7 +136,7 @@ face-vertex to its vertexwise image. -/
 theorem barycentricSubdivisionMap_eq_orderComplexMap [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :
     barycentricSubdivisionMap f = AbstractSimplicialComplex.orderComplexMap (faceOrderHom f) :=
-  rfl
+  (rfl)
 
 theorem coe_barycentricSubdivisionMap [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L) :

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean
@@ -61,13 +61,13 @@ variable {α β γ : Type*}
 /-- The first **barycentric subdivision** of `K`: its vertices are the faces of `K`, and its faces
 are the nonempty finite chains of faces under inclusion. -/
 @[expose] noncomputable def barycentricSubdivision (K : PreAbstractSimplicialComplex α) :
-    AbstractSimplicialComplex (_root_.AbstractSimplicialComplex.Face K) :=
-  AbstractSimplicialComplex.orderComplex (_root_.AbstractSimplicialComplex.Face K)
+    AbstractSimplicialComplex (SetLike.Face K) :=
+  AbstractSimplicialComplex.orderComplex (SetLike.Face K)
 
 /-- Barycentric subdivision is the order complex of the face poset. -/
 theorem barycentricSubdivision_eq_orderComplex (K : PreAbstractSimplicialComplex α) :
     barycentricSubdivision K =
-      AbstractSimplicialComplex.orderComplex (_root_.AbstractSimplicialComplex.Face K) :=
+      AbstractSimplicialComplex.orderComplex (SetLike.Face K) :=
   rfl
 
 variable {K : PreAbstractSimplicialComplex α}
@@ -75,47 +75,44 @@ variable {K : PreAbstractSimplicialComplex α}
 /-- A collection of faces of `K` is a face of its barycentric subdivision exactly when it is
 nonempty and totally ordered by inclusion. -/
 @[simp]
-theorem mem_barycentricSubdivision_iff
-    {τ : Finset (_root_.AbstractSimplicialComplex.Face K)} :
+theorem mem_barycentricSubdivision_iff {τ : Finset (SetLike.Face K)} :
     τ ∈ barycentricSubdivision K ↔
       τ.Nonempty ∧
-        IsChain (· ≤ ·) (↑τ : Set (_root_.AbstractSimplicialComplex.Face K)) := by
+        IsChain (· ≤ ·) (↑τ : Set (SetLike.Face K)) := by
   rw [barycentricSubdivision_eq_orderComplex,
     AbstractSimplicialComplex.mem_orderComplex_iff]
 
 /-- A collection is a face of the barycentric subdivision exactly when it is nonempty and every
 two original faces in the collection are nested. -/
-theorem mem_barycentricSubdivision_iff'
-    {ρ : Finset (_root_.AbstractSimplicialComplex.Face K)} :
+theorem mem_barycentricSubdivision_iff' {ρ : Finset (SetLike.Face K)} :
     ρ ∈ barycentricSubdivision K ↔
       ρ.Nonempty ∧ ∀ σ ∈ ρ, ∀ τ ∈ ρ,
         (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ := by
   rw [barycentricSubdivision_eq_orderComplex,
     AbstractSimplicialComplex.mem_orderComplex_iff']
-  simp only [TauCeti.AbstractSimplicialComplex.face_le_iff]
+  simp only [SetLike.face_le_iff]
 
 /-- Two faces of `K` span an edge in its barycentric subdivision exactly when one is contained in
 the other.
 
 This is not a `simp` lemma: `mem_barycentricSubdivision_iff` already rewrites the left-hand
 side. -/
-theorem pair_mem_barycentricSubdivision_iff [DecidableEq α]
-    (σ τ : _root_.AbstractSimplicialComplex.Face K) :
+theorem pair_mem_barycentricSubdivision_iff [DecidableEq α] (σ τ : SetLike.Face K) :
     {σ, τ} ∈ barycentricSubdivision K ↔
       (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ := by
   rw [barycentricSubdivision_eq_orderComplex,
     AbstractSimplicialComplex.pair_mem_orderComplex_iff]
-  simp only [TauCeti.AbstractSimplicialComplex.face_le_iff]
+  simp only [SetLike.face_le_iff]
 
 /-- Every two original faces occurring in one face of the barycentric subdivision are nested. -/
 theorem subset_or_subset_of_mem_barycentricSubdivision
-    {ρ : Finset (_root_.AbstractSimplicialComplex.Face K)}
+    {ρ : Finset (SetLike.Face K)}
     (hρ : ρ ∈ barycentricSubdivision K)
-    {σ τ : _root_.AbstractSimplicialComplex.Face K}
+    {σ τ : SetLike.Face K}
     (hσ : σ ∈ ρ) (hτ : τ ∈ ρ) :
     (σ : Finset α) ⊆ τ ∨ (τ : Finset α) ⊆ σ := by
   rw [barycentricSubdivision_eq_orderComplex] at hρ
-  simpa only [TauCeti.AbstractSimplicialComplex.face_le_iff] using
+  simpa only [SetLike.face_le_iff] using
     AbstractSimplicialComplex.le_or_le_of_mem_orderComplex hρ hσ hτ
 
 namespace SimplicialMap
@@ -147,7 +144,7 @@ theorem coe_barycentricSubdivisionMap [DecidableEq β]
 @[simp]
 theorem coe_barycentricSubdivisionMap_apply [DecidableEq β]
     (f : _root_.PreAbstractSimplicialComplex.SimplicialMap K L)
-    (σ : _root_.AbstractSimplicialComplex.Face K) :
+    (σ : SetLike.Face K) :
     (barycentricSubdivisionMap f σ : Finset β) = σ.1.image f := by
   rw [← coe_faceOrderHom_apply, ← coe_barycentricSubdivisionMap]
 


### PR DESCRIPTION
This PR defines order complexes and uses the face poset of a pre-abstract simplicial complex to construct its first barycentric subdivision. It characterizes subdivision faces as nonempty finite chains, proves that two face-vertices span an edge exactly when they are nested, and makes the construction functorial on simplicial maps with identity and composition laws.

The exact roadmap target is `TauCetiRoadmap/GeometricTopology/README.md`, Layer 11 milestone **“Combinatorial manifolds via the link condition”**, specifically the required subdivision primitive before combinatorial spheres and balls can be defined as complexes PL-homeomorphic after subdivision to standard simplex boundaries and simplices. This is the next effective step because geometric realization, simplex boundaries, links, dimension, products, and collapse are already on `main`, while neither Tau Ceti nor the pinned Mathlib contains an abstract simplicial subdivision construction.

After this PR, the milestone still needs the realization homeomorphism between a complex and its barycentric subdivision, an iteration/subdivision relation, the recursive combinatorial sphere and ball predicates, and then the vertex-link definition of combinatorial manifolds.

`TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean` supplies the reusable order-complex construction and the simplicial map induced by an `OrderHom`. `TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision.lean` specializes it to face posets and proves functoriality. The implementation reuses Mathlib's `AbstractSimplicialComplex`, `Set.IsChain`, and `OrderHom`, together with Tau Ceti's existing `PreAbstractSimplicialComplex.SimplicialMap`; no Mathlib infrastructure or external formalization is vendored.

The mathematical construction follows Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2, “Derived Subdivisions,” as credited in both module docstrings.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"barycentric-subdivision"}-->

🤖 Prepared with Codex
