### PR TITLE
feat: package the Pin double cover

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/DoubleCover.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.GroupTheory.GroupExtension.Of.Surjective
+public import TauCeti.LinearAlgebra.CliffordAlgebra.CartanDieudonne
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Pin.Kernel
+
+/-!
+# The Pin double cover as a group extension
+
+For a positive-dimensional finite nondegenerate quadratic space over a field in which `2` is
+invertible, the kernel equivalence from `Pin.Kernel` and any proof that the action is surjective
+package the Pin double cover as a `GroupExtension`; in particular, the action is surjective over a
+separably closed field.
+
+## Main definitions and results
+
+* `TauCeti.CliffordAlgebra.pinDoubleCoverOfSurjective` packages any surjective Pin action as a
+  group extension.
+* `TauCeti.CliffordAlgebra.pinDoubleCover` packages
+  `1 → ZMod 2 → Pin(Q) → O(Q) → 1` as a group extension.
+* `TauCeti.CliffordAlgebra.pinDoubleCoverOfSurjective_inl_ofAdd_one` and
+  `TauCeti.CliffordAlgebra.pinDoubleCoverOfSurjective_rightHom` characterize the generic
+  extension.
+* `TauCeti.CliffordAlgebra.pinDoubleCover_inl_ofAdd_one` and
+  `TauCeti.CliffordAlgebra.pinDoubleCover_rightHom` characterize the separably closed case.
+
+## References
+
+This supplies the Pin short exact sequence of Layer 2 over a separably closed field. See
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. H. B. Lawson and
+M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+-/
+
+public section
+
+open CliffordAlgebra
+
+namespace TauCeti.CliffordAlgebra
+
+universe u v
+
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V] [Nontrivial V]
+  [FiniteDimensional K V] [Invertible (2 : K)]
+
+/-- A surjective Pin action on a positive-dimensional nondegenerate quadratic space over a field
+in which `2` is invertible is the group extension `1 → ZMod 2 → Pin(Q) → O(Q) → 1`. -/
+noncomputable def pinDoubleCoverOfSurjective
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (hsurj : Function.Surjective (pinToOrthogonal Q)) :
+    GroupExtension (Multiplicative (ZMod 2)) (pinGroup Q)
+      (QuadraticMap.orthogonalGroup Q) :=
+  GroupExtension.ofMulEquivKer hsurj (zmodTwoMulEquivKerPinToOrthogonal Q hQ)
+
+/-- The inclusion in a Pin double cover built from a surjectivity proof sends the generator to
+the scalar `-1`. -/
+@[simp]
+theorem pinDoubleCoverOfSurjective_inl_ofAdd_one
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (hsurj : Function.Surjective (pinToOrthogonal Q)) :
+    (pinDoubleCoverOfSurjective Q hQ hsurj).inl (Multiplicative.ofAdd 1) =
+      spinToPin Q (spinGroup.negOne Q hQ.ne_zero) := by
+  rw [pinDoubleCoverOfSurjective, GroupExtension.ofMulEquivKer_inl,
+    MonoidHom.comp_apply]
+  exact congrArg Subtype.val (zmodTwoMulEquivKerPinToOrthogonal_apply_ofAdd_one Q hQ)
+
+/-- The projection in a Pin double cover built from a surjectivity proof is the Pin action. -/
+@[simp]
+theorem pinDoubleCoverOfSurjective_rightHom
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (hsurj : Function.Surjective (pinToOrthogonal Q)) :
+    (pinDoubleCoverOfSurjective Q hQ hsurj).rightHom = pinToOrthogonal Q :=
+  GroupExtension.ofMulEquivKer_rightHom _ _
+
+/-- For a positive-dimensional nondegenerate quadratic space over a separably closed field in
+which `2` is invertible, the Pin action is the group extension
+`1 → ZMod 2 → Pin(Q) → O(Q) → 1`. -/
+noncomputable def pinDoubleCover [IsSepClosed K]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    GroupExtension (Multiplicative (ZMod 2)) (pinGroup Q)
+      (QuadraticMap.orthogonalGroup Q) :=
+  pinDoubleCoverOfSurjective Q hQ (pinToOrthogonal_surjective Q hQ)
+
+/-- The separably closed Pin double cover is the generic construction applied to canonical
+surjectivity. -/
+theorem pinDoubleCover_def [IsSepClosed K]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    pinDoubleCover Q hQ =
+      pinDoubleCoverOfSurjective Q hQ (pinToOrthogonal_surjective Q hQ) :=
+  (rfl)
+
+/-- The inclusion in the separably closed Pin double cover sends the generator to the scalar
+`-1`. -/
+@[simp]
+theorem pinDoubleCover_inl_ofAdd_one [IsSepClosed K]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    (pinDoubleCover Q hQ).inl (Multiplicative.ofAdd 1) =
+      spinToPin Q (spinGroup.negOne Q hQ.ne_zero) := by
+  rw [pinDoubleCover_def, pinDoubleCoverOfSurjective_inl_ofAdd_one]
+
+/-- The projection in the separably closed Pin double cover is the Pin action. -/
+@[simp]
+theorem pinDoubleCover_rightHom [IsSepClosed K]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    (pinDoubleCover Q hQ).rightHom = pinToOrthogonal Q := by
+  rw [pinDoubleCover_def, pinDoubleCoverOfSurjective_rightHom]
+
+end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/DoubleCover.lean
@@ -32,7 +32,8 @@ separably closed field.
 
 This supplies the Pin short exact sequence of Layer 2 over a separably closed field. See
 `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. H. B. Lawson and
-M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2. The API and proof structure are adapted
+from `TauCeti.LinearAlgebra.CliffordAlgebra.Spin.DoubleCover`.
 -/
 
 public section


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Packages the algebraic Pin double cover as a group extension.

- Builds the extension from any proof that the Pin action is surjective.
- Specializes it to finite-dimensional nondegenerate forms over separably closed fields.
- Exposes the generator and projection equations for both constructions.

## Roadmap target

Completes the Pin half of the Layer 2 double-cover boundary:
https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-2-the-pin-and-spin-groups-and-the-double-covers

## Verification

Focused and full builds, `--iofail`, audits, lint, opaque consumers, collision checks, structural golf, and fresh aggregate `2+1` review pass at `0ed8a6a5bd32afcdfe89f1fbac3566adf3abcb80`.

## Scale and generality

Adds one 112-line file. The generic construction accepts any surjective Pin action; the canonical extension assumes a finite-dimensional nondegenerate quadratic space over a separably closed field with invertible `2`.

## Scope

- **Consumes:** the merged Pin-kernel equivalence, Pin surjectivity, and generic kernel-to-extension constructor.
- **Provides:** generic and canonical Pin group extensions with generator and projection equations.
- **Fits:** completes the algebraic Pin short exact sequence alongside the merged Spin double cover.
- **Boundary:** general-field spinor norm, topology, and the differential of the cover remain downstream.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [2c299e1](https://github.com/TauCetiProject/TauCetiReview/commit/2c299e1d1950d731786005ef33209486b2fa7f9d) · local 2+1 review @ [3c27326](https://github.com/utensil/formal-land/commit/3c273267907632175365cc835cf767d0a1aec5af) fixed: attribution (1)</sub>
