### PR TITLE
refactor(DividedPowers): share the scaled raising step of the straightening recursion

### DIFF
--- a/TauCeti/Algebra/Lie/Sl2/Straightening.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Straightening.lean
@@ -317,25 +317,6 @@ private theorem eq_of_succ_nsmul_eq (m : ℕ) {x y : A}
   have hm : ((m + 1 : ℕ) : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
   exact smul_right_injective A hm h
 
-section Semiring
-
-variable {A : Type u} [Semiring A] [Algebra ℚ A]
-
-/-- **Raising the left divided power, scaled.** Multiplying by `E` on the left turns the product
-`E^[m] · F^[n]` into `(m + 1)` copies of `E^[m+1] · F^[n]`. -/
-private theorem succ_nsmul_dividedPower_succ_mul (m n : ℕ) (E F : A) :
-    (m + 1) • (dividedPower (m + 1) E * dividedPower n F) =
-      E * (dividedPower m E * dividedPower n F) := by
-  calc
-    (m + 1) • (dividedPower (m + 1) E * dividedPower n F) =
-        ((m + 1) • dividedPower (m + 1) E) * dividedPower n F := by
-          simp only [nsmul_eq_mul]
-          rw [mul_assoc]
-    _ = (E * dividedPower m E) * dividedPower n F := by rw [self_mul_dividedPower]
-    _ = E * (dividedPower m E * dividedPower n F) := mul_assoc _ _ _
-
-end Semiring
-
 private theorem straightening_step {H E F : A}
     (hef : E * F - F * E = H) (hhe : H * E - E * H = 2 • E)
     (hhf : H * F - F * H = -(2 • F)) (m n : ℕ)

--- a/TauCeti/Algebra/Lie/Sl2/Straightening.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Straightening.lean
@@ -317,6 +317,10 @@ private theorem eq_of_succ_nsmul_eq (m : ℕ) {x y : A}
   have hm : ((m + 1 : ℕ) : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
   exact smul_right_injective A hm h
 
+section Semiring
+
+variable {A : Type u} [Semiring A] [Algebra ℚ A]
+
 /-- **Raising the left divided power, scaled.** Multiplying by `E` on the left turns the product
 `E^[m] · F^[n]` into `(m + 1)` copies of `E^[m+1] · F^[n]`. -/
 private theorem succ_nsmul_dividedPower_succ_mul (m n : ℕ) (E F : A) :
@@ -329,6 +333,8 @@ private theorem succ_nsmul_dividedPower_succ_mul (m n : ℕ) (E F : A) :
           rw [mul_assoc]
     _ = (E * dividedPower m E) * dividedPower n F := by rw [self_mul_dividedPower]
     _ = E * (dividedPower m E * dividedPower n F) := mul_assoc _ _ _
+
+end Semiring
 
 private theorem straightening_step {H E F : A}
     (hef : E * F - F * E = H) (hhe : H * E - E * H = 2 • E)

--- a/TauCeti/Algebra/Lie/Sl2/Straightening.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Straightening.lean
@@ -317,6 +317,19 @@ private theorem eq_of_succ_nsmul_eq (m : ℕ) {x y : A}
   have hm : ((m + 1 : ℕ) : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
   exact smul_right_injective A hm h
 
+/-- **Raising the left divided power, scaled.** Multiplying by `E` on the left turns the product
+`E^[m] · F^[n]` into `(m + 1)` copies of `E^[m+1] · F^[n]`. -/
+private theorem succ_nsmul_dividedPower_succ_mul (m n : ℕ) (E F : A) :
+    (m + 1) • (dividedPower (m + 1) E * dividedPower n F) =
+      E * (dividedPower m E * dividedPower n F) := by
+  calc
+    (m + 1) • (dividedPower (m + 1) E * dividedPower n F) =
+        ((m + 1) • dividedPower (m + 1) E) * dividedPower n F := by
+          simp only [nsmul_eq_mul]
+          rw [mul_assoc]
+    _ = (E * dividedPower m E) * dividedPower n F := by rw [self_mul_dividedPower]
+    _ = E * (dividedPower m E * dividedPower n F) := mul_assoc _ _ _
+
 private theorem straightening_step {H E F : A}
     (hef : E * F - F * E = H) (hhe : H * E - E * H = 2 • E)
     (hhf : H * F - F * H = -(2 • F)) (m n : ℕ)
@@ -328,23 +341,15 @@ private theorem straightening_step {H E F : A}
   have hleft :
       (m + 1) • (dividedPower (m + 1) E * dividedPower n F) =
         E * ∑ k ∈ range (min m n + 1), straighteningSummand H E F m n k := by
-    calc
-      (m + 1) • (dividedPower (m + 1) E * dividedPower n F) =
-          ((m + 1) • dividedPower (m + 1) E) * dividedPower n F := by
-            simp only [nsmul_eq_mul]
-            rw [mul_assoc]
-      _ = (E * dividedPower m E) * dividedPower n F := by rw [self_mul_dividedPower]
-      _ = E * (dividedPower m E * dividedPower n F) := by rw [mul_assoc]
-      _ = E * ∑ k ∈ range (min m n + 1),
-          straighteningSummand H E F m n k := by rw [ih]
+    rw [succ_nsmul_dividedPower_succ_mul, ih]
   rw [hleft, mul_sum]
+  let K := keptStraighteningSummand H E F m n
+  let R := raisedStraighteningSummand H E F m n
+  let T := fun k ↦ (m + 1) • straighteningSummand H E F (m + 1) n k
   by_cases hmn : m < n
   · have hmin : min m n = m := min_eq_left (Nat.le_of_lt hmn)
     have hminSucc : min (m + 1) n = m + 1 := min_eq_left hmn
     rw [hmin, hminSucc]
-    let K := keptStraighteningSummand H E F m n
-    let R := raisedStraighteningSummand H E F m n
-    let T := fun k ↦ (m + 1) • straighteningSummand H E F (m + 1) n k
     have hcombine :
         ∑ j ∈ range (m + 2), T j = ∑ k ∈ range (m + 1), (K k + R k) := by
       apply sum_range_adjacent_with_zero K R T m
@@ -364,9 +369,6 @@ private theorem straightening_step {H E F : A}
     have hmin : min m n = n := min_eq_right hnm
     have hminSucc : min (m + 1) n = n := min_eq_right (by omega)
     rw [hmin, hminSucc]
-    let K := keptStraighteningSummand H E F m n
-    let R := raisedStraighteningSummand H E F m n
-    let T := fun k ↦ (m + 1) • straighteningSummand H E F (m + 1) n k
     have hcombine :
         ∑ j ∈ range (n + 1), T j = (∑ k ∈ range n, (K k + R k)) + K n := by
       apply sum_range_adjacent_capped K R T n

--- a/TauCeti/RingTheory/DividedPowers/Associative.lean
+++ b/TauCeti/RingTheory/DividedPowers/Associative.lean
@@ -141,6 +141,19 @@ theorem self_mul_dividedPower (n : ℕ) (x : A) :
     x * dividedPower n x = (n + 1) • dividedPower (n + 1) x := by
   simpa [add_comm 1 n] using mul_dividedPower 1 n x
 
+/-- **Raising the left divided power, scaled.** Multiplying by `x` on the left turns
+`x^[m] · y^[n]` into `m + 1` copies of `x^[m+1] · y^[n]`. -/
+theorem succ_nsmul_dividedPower_succ_mul (m n : ℕ) (x y : A) :
+    (m + 1) • (dividedPower (m + 1) x * dividedPower n y) =
+      x * (dividedPower m x * dividedPower n y) := by
+  calc
+    (m + 1) • (dividedPower (m + 1) x * dividedPower n y) =
+        ((m + 1) • dividedPower (m + 1) x) * dividedPower n y := by
+          simp only [nsmul_eq_mul]
+          rw [mul_assoc]
+    _ = (x * dividedPower m x) * dividedPower n y := by rw [self_mul_dividedPower]
+    _ = x * (dividedPower m x * dividedPower n y) := mul_assoc _ _ _
+
 /-- The first-order recurrence solved for the successor divided power. -/
 theorem dividedPower_succ (n : ℕ) (x : A) :
     dividedPower (n + 1) x = ((n + 1 : ℕ) : ℚ)⁻¹ • (dividedPower n x * x) := by

--- a/TauCeti/RingTheory/DividedPowers/Associative.lean
+++ b/TauCeti/RingTheory/DividedPowers/Associative.lean
@@ -141,18 +141,16 @@ theorem self_mul_dividedPower (n : ℕ) (x : A) :
     x * dividedPower n x = (n + 1) • dividedPower (n + 1) x := by
   simpa [add_comm 1 n] using mul_dividedPower 1 n x
 
-/-- **Raising the left divided power, scaled.** Multiplying by `x` on the left turns
-`x^[m] · y^[n]` into `m + 1` copies of `x^[m+1] · y^[n]`. -/
-theorem succ_nsmul_dividedPower_succ_mul (m n : ℕ) (x y : A) :
-    (m + 1) • (dividedPower (m + 1) x * dividedPower n y) =
-      x * (dividedPower m x * dividedPower n y) := by
+/-- **Raising the left divided power, scaled.** Multiplying by `x` on the left turns `x^[m] · z`
+into `m + 1` copies of `x^[m+1] · z`, for any `z`. -/
+theorem succ_nsmul_dividedPower_succ_mul (m : ℕ) (x z : A) :
+    (m + 1) • (dividedPower (m + 1) x * z) = x * (dividedPower m x * z) := by
   calc
-    (m + 1) • (dividedPower (m + 1) x * dividedPower n y) =
-        ((m + 1) • dividedPower (m + 1) x) * dividedPower n y := by
-          simp only [nsmul_eq_mul]
-          rw [mul_assoc]
-    _ = (x * dividedPower m x) * dividedPower n y := by rw [self_mul_dividedPower]
-    _ = x * (dividedPower m x * dividedPower n y) := mul_assoc _ _ _
+    (m + 1) • (dividedPower (m + 1) x * z) = ((m + 1) • dividedPower (m + 1) x) * z := by
+      simp only [nsmul_eq_mul]
+      rw [mul_assoc]
+    _ = (x * dividedPower m x) * z := by rw [self_mul_dividedPower]
+    _ = x * (dividedPower m x * z) := mul_assoc _ _ _
 
 /-- The first-order recurrence solved for the successor divided power. -/
 theorem dividedPower_succ (n : ℕ) (x : A) :

--- a/TauCeti/RingTheory/DividedPowers/NormalOrdering.lean
+++ b/TauCeti/RingTheory/DividedPowers/NormalOrdering.lean
@@ -225,7 +225,7 @@ theorem dividedPower_mul_dividedPower_of_commutator_eq {x y z : A}
               (dividedPower (m + 1) x * dividedPower n y) =
             x * (dividedPower m x * dividedPower n y) := by
         rw [Nat.cast_smul_eq_nsmul]
-        exact succ_nsmul_dividedPower_succ_mul m n x y
+        exact succ_nsmul_dividedPower_succ_mul m x (dividedPower n y)
       rw [← inv_smul_smul₀ hm (dividedPower (m + 1) x * dividedPower n y),
         ← inv_smul_smul₀ hm
           (∑ k ∈ range (min (m + 1) n + 1),

--- a/TauCeti/RingTheory/DividedPowers/NormalOrdering.lean
+++ b/TauCeti/RingTheory/DividedPowers/NormalOrdering.lean
@@ -224,8 +224,8 @@ theorem dividedPower_mul_dividedPower_of_commutator_eq {x y z : A}
           ((m + 1 : ℕ) : ℚ) •
               (dividedPower (m + 1) x * dividedPower n y) =
             x * (dividedPower m x * dividedPower n y) := by
-        rw [← smul_mul_assoc, Nat.cast_smul_eq_nsmul,
-          ← self_mul_dividedPower, mul_assoc]
+        rw [Nat.cast_smul_eq_nsmul]
+        exact succ_nsmul_dividedPower_succ_mul m n x y
       rw [← inv_smul_smul₀ hm (dividedPower (m + 1) x * dividedPower n y),
         ← inv_smul_smul₀ hm
           (∑ k ∈ range (min (m + 1) n + 1),


### PR DESCRIPTION
`straightening_step` carried a 58-line proof — the longest in the file #3118 has just landed.
Its opening twelve-line `calc` does one thing: move a factor of `E` across a divided power.
Name it. No statement changes.

## Where the lemma ended up

It is **not** new. `RingTheory/DividedPowers/NormalOrdering.lean` already had it inline: the
`have hscaled` inside `dividedPower_mul_dividedPower_of_commutator_eq` states the same identity
in its `ℚ`-smul form and bridges to the `ℕ`-smul one with `Nat.cast_smul_eq_nsmul` in its own
proof. So rather than adding a private copy in `Sl2/Straightening.lean`, the lemma goes to
`RingTheory/DividedPowers/Associative.lean`, beside `self_mul_dividedPower` and
`mul_dividedPower` that it is built from:

```lean
theorem succ_nsmul_dividedPower_succ_mul (m : ℕ) (x z : A) :
    (m + 1) • (dividedPower (m + 1) x * z) = x * (dividedPower m x * z)
```

Both `Straightening.lean` and `NormalOrdering.lean` now call it; the inline `hscaled` derivation
is gone.

## How the statement got to that form

Review pared it twice, and both were right:

* **not a ring identity.** It has no subtraction. `Associative.lean` already sits at
  `[Semiring A] [Algebra ℚ A]` (line 58), which is where it now lives — so the weaker typeclass
  and the correct home turn out to be the same move.
* **not about divided powers on the right.** The right factor was never unfolded, so it is an
  arbitrary `z : A`. Both call sites instantiate `z` at a divided power.

What remains uses none of the `sl₂` data the enclosing theorem assumes — not the commutator
relations, not the induction hypothesis, which is applied at the call site.

## Also in this PR

The three `let`s naming the kept, raised and scaled summand families were written out verbatim
in *both* branches of the `by_cases m < n`, although none depends on the split. They are hoisted
above it.

## Result

| | before | after |
|---|---|---|
| `straightening_step` | 58 | 47 |
| `succ_nsmul_dividedPower_succ_mul` (shared) | — | 7 |
| inline `hscaled` in `NormalOrdering` | 2-line derivation | call |

Gates run on `89385e80`: `lake build` (7792 jobs), `lake exe axioms` (44458 declarations),
`lake exe module-system` (2132 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: ReductiveGroups