### PR TITLE
refactor(EllipticCurve): name the three steps of the coordinate-ring divisibility core

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -179,9 +179,111 @@ end CoordinateRing
 
 /-! ## The divisibility core -/
 
+section CommRing
+
+variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve.Affine R)
+
+/-- **The `X`-derivative vanishes as well.** Write `H = g² - gs - c` for the Weierstrass polynomial
+read at `Y = -g`. A square divisor of `H` divides its derivative, and that derivative splits as
+`H' = g'(2g - s) - (a₁g + c')`, so a divisor of `2g - s` is left dividing `a₁g + c'`. Modulo `π`
+this says `W_X` vanishes at the point once `W_Y` does.
+
+Neither primality of `π` nor any field structure is used: this is the chain rule and
+`Polynomial.pow_sub_one_dvd_derivative_of_pow_dvd`. -/
+private theorem dvd_a₁_mul_add_of_sq_dvd {π g : R[X]}
+    (hs : π ∣ 2 * g - (C W.a₁ * X + C W.a₃))
+    (hsq : π ^ 2 ∣ g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
+      (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)) :
+    π ∣ C W.a₁ * g + (3 * X ^ 2 + 2 * C W.a₂ * X + C W.a₄) := by
+  have hd : derivative (g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
+      (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)) =
+      derivative g * (2 * g - (C W.a₁ * X + C W.a₃)) -
+        (C W.a₁ * g + (3 * X ^ 2 + 2 * C W.a₂ * X + C W.a₄)) := by
+    simp only [derivative_sub, derivative_mul, derivative_pow, derivative_add, derivative_C,
+      derivative_X, map_ofNat, Nat.cast_ofNat]
+    ring1
+  have hd' : π ∣ derivative g * (2 * g - (C W.a₁ * X + C W.a₃)) -
+      (C W.a₁ * g + (3 * X ^ 2 + 2 * C W.a₂ * X + C W.a₄)) := by
+    rw [← hd]
+    simpa using Polynomial.pow_sub_one_dvd_derivative_of_pow_dvd hsq
+  simpa using dvd_sub (hs.mul_left (derivative g)) hd'
+
+end CommRing
+
 section Field
 
 variable {F : Type*} [Field F] (W : _root_.WeierstrassCurve.Affine F)
+
+/-- **No prime square divides `H = g² - gs - c` once the prime divides `2g - s`.** This is where
+the curve enters, and it is the one step that uses ellipticity. In the residue field
+`k = F[X]/(π)` the three divisibilities say that `(x₀, β)` lies on `W` over `k`, with `x₀` the
+image of `X` and `β` that of `-g`, and that both partial derivatives vanish there:
+
+* `π ∣ H` gives the equation of `W`;
+* `π ∣ 2g - s` gives `W_Y(x₀, β) = 2β + a₁x₀ + a₃ = 0`;
+* `π ∣ a₁g + c'` — `dvd_a₁_mul_add_of_sq_dvd` — gives `W_X(x₀, β) = a₁β - (3x₀² + 2a₂x₀ + a₄) = 0`.
+
+That is a singular point of an elliptic curve. The argument is uniform in the characteristic,
+unlike the route through `Squarefree (4X³ + b₂X² + 2b₄X + b₆)`. -/
+private theorem not_sq_dvd_of_dvd_two_mul_sub [W.IsElliptic] {π g : F[X]} (hπ : Prime π)
+    (hs : π ∣ 2 * g - (C W.a₁ * X + C W.a₃)) :
+    ¬π ^ 2 ∣ g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
+      (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆) := by
+  intro hsq
+  have : Fact (Irreducible π) := ⟨hπ.irreducible⟩
+  have hev : ∀ r : F[X], π ∣ r → aeval (AdjoinRoot.root π) r = 0 := fun r hr => by
+    rw [AdjoinRoot.aeval_eq]; exact AdjoinRoot.mk_eq_zero.mpr hr
+  have h₁ := hev _ ((dvd_pow_self π two_ne_zero).trans hsq)
+  have h₂ := hev _ hs
+  have h₃ := hev _ (dvd_a₁_mul_add_of_sq_dvd W hs hsq)
+  simp only [map_sub, map_add, map_mul, map_pow, map_ofNat, aeval_C, aeval_X] at h₁ h₂ h₃
+  have key : (W.map (algebraMap F (AdjoinRoot π))).Nonsingular (AdjoinRoot.root π)
+      (-aeval (AdjoinRoot.root π) g) := equation_iff_nonsingular.mp <| by
+    rw [equation_iff']
+    simp only [_root_.WeierstrassCurve.map_a₁, _root_.WeierstrassCurve.map_a₂,
+      _root_.WeierstrassCurve.map_a₃, _root_.WeierstrassCurve.map_a₄,
+      _root_.WeierstrassCurve.map_a₆]
+    linear_combination h₁
+  rw [nonsingular_iff'] at key
+  refine key.2.elim (fun h => h ?_) fun h => h ?_
+  · simp only [_root_.WeierstrassCurve.map_a₁, _root_.WeierstrassCurve.map_a₂,
+      _root_.WeierstrassCurve.map_a₄]
+    linear_combination -h₃
+  · simp only [_root_.WeierstrassCurve.map_a₁, _root_.WeierstrassCurve.map_a₃]
+    linear_combination -h₂
+
+/-- **Away from `q`, the pair `(p, q)` collapses to a single `g`.** A prime not dividing `q` is
+invertible in the residue field, so `p ≡ gq` modulo `π` for some `g`; substituting that into the
+trace and norm divisibilities and cancelling the factors of `q` — legitimate since `π` is prime
+and misses `q` — leaves the same two divisibilities for the pair `(g, 1)`.
+
+This step is pure divisibility bookkeeping: the curve is not used, and `W` need not be
+elliptic. -/
+private theorem exists_dvd_two_mul_sub_and_sq_dvd_of_not_dvd {π p q : F[X]} (hπ : Prime π)
+    (hq : ¬π ∣ q) (ht : π ∣ 2 * p - q * (C W.a₁ * X + C W.a₃))
+    (hn : π ^ 2 ∣ p ^ 2 - p * q * (C W.a₁ * X + C W.a₃) -
+      q ^ 2 * (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)) :
+    ∃ g : F[X], π ∣ 2 * g - (C W.a₁ * X + C W.a₃) ∧
+      π ^ 2 ∣ g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
+        (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆) := by
+  have : Fact (Irreducible π) := ⟨hπ.irreducible⟩
+  have hqk : AdjoinRoot.mk π q ≠ 0 := fun h => hq (AdjoinRoot.mk_eq_zero.mp h)
+  -- choose `g` with `p ≡ g * q` modulo `π`
+  obtain ⟨g, hg⟩ := AdjoinRoot.mk_surjective (AdjoinRoot.mk π p / AdjoinRoot.mk π q)
+  obtain ⟨p₁, hp₁⟩ : π ∣ p - g * q := AdjoinRoot.mk_eq_zero.mp <| by
+    rw [map_sub, map_mul, hg, div_mul_cancel₀ _ hqk, sub_self]
+  -- transport the two divisibilities to `g`
+  obtain ⟨f, hf⟩ : π ∣ 2 * g - (C W.a₁ * X + C W.a₃) := by
+    have hprod : π ∣ q * (2 * g - (C W.a₁ * X + C W.a₃)) := by
+      obtain ⟨t₁, ht₁⟩ := ht
+      exact ⟨t₁ - 2 * p₁, by linear_combination ht₁ - 2 * hp₁⟩
+    exact (hπ.dvd_or_dvd hprod).resolve_left hq
+  refine ⟨g, ⟨f, hf⟩, ?_⟩
+  refine hπ.pow_dvd_of_dvd_mul_left (a := q ^ 2) 2 (fun h => hq (hπ.dvd_of_dvd_pow h)) ?_
+  obtain ⟨n₁, hn₁⟩ := hn
+  exact ⟨n₁ - p₁ * q * f - p₁ ^ 2, by
+    linear_combination hn₁ -
+      (p + g * q + π * p₁ - q * (C W.a₁ * X + C W.a₃)) * hp₁ - π * p₁ * q * hf⟩
 
 /-- Over a field, a prime dividing the trace `2p - qs` and whose square divides the norm
 `p² - pqs - q²c` divides both `p` and `q`. This is where the curve enters: the alternative is a
@@ -193,62 +295,8 @@ private theorem dvd_and_dvd_of_prime [W.IsElliptic] {π p q : F[X]} (hπ : Prime
     π ∣ p ∧ π ∣ q := by
   have hq : π ∣ q := by
     by_contra hq
-    have : Fact (Irreducible π) := ⟨hπ.irreducible⟩
-    have hqk : AdjoinRoot.mk π q ≠ 0 := fun h => hq (AdjoinRoot.mk_eq_zero.mp h)
-    -- choose `g` with `p ≡ g * q` modulo `π`
-    obtain ⟨g, hg⟩ := AdjoinRoot.mk_surjective (AdjoinRoot.mk π p / AdjoinRoot.mk π q)
-    obtain ⟨p₁, hp₁⟩ : π ∣ p - g * q := AdjoinRoot.mk_eq_zero.mp <| by
-      rw [map_sub, map_mul, hg, div_mul_cancel₀ _ hqk, sub_self]
-    -- transport the two divisibilities to `g`
-    obtain ⟨f, hf⟩ : π ∣ 2 * g - (C W.a₁ * X + C W.a₃) := by
-      have hprod : π ∣ q * (2 * g - (C W.a₁ * X + C W.a₃)) := by
-        obtain ⟨t₁, ht₁⟩ := ht
-        exact ⟨t₁ - 2 * p₁, by linear_combination ht₁ - 2 * hp₁⟩
-      refine (hπ.dvd_or_dvd hprod).resolve_left hq
-    have hm : π ^ 2 ∣ g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
-        (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆) := by
-      refine hπ.pow_dvd_of_dvd_mul_left (a := q ^ 2) 2 (fun h => hq (hπ.dvd_of_dvd_pow h)) ?_
-      obtain ⟨n₁, hn₁⟩ := hn
-      exact ⟨n₁ - p₁ * q * f - p₁ ^ 2, by
-        linear_combination hn₁ -
-          (p + g * q + π * p₁ - q * (C W.a₁ * X + C W.a₃)) * hp₁ - π * p₁ * q * hf⟩
-    -- `π ∣ H` and `π ∣ H'`, the latter read through `H' = g'(2g - s) - (a₁g + c')`
-    have hH₁ : π ∣ C W.a₁ * g + (3 * X ^ 2 + 2 * C W.a₂ * X + C W.a₄) := by
-      have hd : derivative (g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
-          (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)) =
-          derivative g * (2 * g - (C W.a₁ * X + C W.a₃)) -
-            (C W.a₁ * g + (3 * X ^ 2 + 2 * C W.a₂ * X + C W.a₄)) := by
-        simp only [derivative_sub, derivative_mul, derivative_pow, derivative_add, derivative_C,
-          derivative_X, map_ofNat, Nat.cast_ofNat]
-        ring1
-      have hd' : π ∣ derivative g * (2 * g - (C W.a₁ * X + C W.a₃)) -
-          (C W.a₁ * g + (3 * X ^ 2 + 2 * C W.a₂ * X + C W.a₄)) := by
-        rw [← hd]
-        simpa using Polynomial.pow_sub_one_dvd_derivative_of_pow_dvd hm
-      simpa using dvd_sub (Dvd.dvd.mul_left ⟨f, hf⟩ (derivative g)) hd'
-    -- the three vanishings, read in the residue field
-    have hev : ∀ r : F[X], π ∣ r → aeval (AdjoinRoot.root π) r = 0 := fun r hr => by
-      rw [AdjoinRoot.aeval_eq]; exact AdjoinRoot.mk_eq_zero.mpr hr
-    have h₁ := hev (g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
-      (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆))
-        ((dvd_pow_self π two_ne_zero).trans hm)
-    have h₂ := hev (2 * g - (C W.a₁ * X + C W.a₃)) ⟨f, hf⟩
-    have h₃ := hev _ hH₁
-    simp only [map_sub, map_add, map_mul, map_pow, map_ofNat, aeval_C, aeval_X] at h₁ h₂ h₃
-    have key : (W.map (algebraMap F (AdjoinRoot π))).Nonsingular (AdjoinRoot.root π)
-        (-aeval (AdjoinRoot.root π) g) := equation_iff_nonsingular.mp <| by
-      rw [equation_iff']
-      simp only [_root_.WeierstrassCurve.map_a₁, _root_.WeierstrassCurve.map_a₂,
-        _root_.WeierstrassCurve.map_a₃, _root_.WeierstrassCurve.map_a₄,
-        _root_.WeierstrassCurve.map_a₆]
-      linear_combination h₁
-    rw [nonsingular_iff'] at key
-    refine key.2.elim (fun h => h ?_) fun h => h ?_
-    · simp only [_root_.WeierstrassCurve.map_a₁, _root_.WeierstrassCurve.map_a₂,
-        _root_.WeierstrassCurve.map_a₄]
-      linear_combination -h₃
-    · simp only [_root_.WeierstrassCurve.map_a₁, _root_.WeierstrassCurve.map_a₃]
-      linear_combination -h₂
+    obtain ⟨g, hs, hsq⟩ := exists_dvd_two_mul_sub_and_sq_dvd_of_not_dvd W hπ hq ht hn
+    exact not_sq_dvd_of_dvd_two_mul_sub W hπ hs hsq
   refine ⟨?_, hq⟩
   obtain ⟨q₁, rfl⟩ := hq
   refine hπ.dvd_of_dvd_pow (n := 2) ?_

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -190,7 +190,7 @@ this says `W_X` vanishes at the point once `W_Y` does.
 
 Neither primality of `π` nor any field structure is used: this is the chain rule and
 `Polynomial.pow_sub_one_dvd_derivative_of_pow_dvd`. -/
-private theorem dvd_a₁_mul_add_of_sq_dvd {π g : R[X]}
+private theorem dvd_a₁_mul_add_of_dvd_two_mul_sub_of_sq_dvd {π g : R[X]}
     (hs : π ∣ 2 * g - (C W.a₁ * X + C W.a₃))
     (hsq : π ^ 2 ∣ g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
       (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)) :
@@ -221,7 +221,8 @@ image of `X` and `β` that of `-g`, and that both partial derivatives vanish the
 
 * `π ∣ H` gives the equation of `W`;
 * `π ∣ 2g - s` gives `W_Y(x₀, β) = 2β + a₁x₀ + a₃ = 0`;
-* `π ∣ a₁g + c'` — `dvd_a₁_mul_add_of_sq_dvd` — gives `W_X(x₀, β) = a₁β - (3x₀² + 2a₂x₀ + a₄) = 0`.
+* `π ∣ a₁g + c'` gives `W_X(x₀, β) = a₁β - (3x₀² + 2a₂x₀ + a₄) = 0`; this is the third divisibility
+  and it comes from the other two, by `dvd_a₁_mul_add_of_dvd_two_mul_sub_of_sq_dvd`.
 
 That is a singular point of an elliptic curve. The argument is uniform in the characteristic,
 unlike the route through `Squarefree (4X³ + b₂X² + 2b₄X + b₆)`. -/
@@ -235,7 +236,7 @@ private theorem not_sq_dvd_of_dvd_two_mul_sub [W.IsElliptic] {π g : F[X]} (hπ 
     rw [AdjoinRoot.aeval_eq]; exact AdjoinRoot.mk_eq_zero.mpr hr
   have h₁ := hev _ ((dvd_pow_self π two_ne_zero).trans hsq)
   have h₂ := hev _ hs
-  have h₃ := hev _ (dvd_a₁_mul_add_of_sq_dvd W hs hsq)
+  have h₃ := hev _ (dvd_a₁_mul_add_of_dvd_two_mul_sub_of_sq_dvd W hs hsq)
   simp only [map_sub, map_add, map_mul, map_pow, map_ofNat, aeval_C, aeval_X] at h₁ h₂ h₃
   have key : (W.map (algebraMap F (AdjoinRoot π))).Nonsingular (AdjoinRoot.root π)
       (-aeval (AdjoinRoot.root π) g) := equation_iff_nonsingular.mp <| by


### PR DESCRIPTION
`dvd_and_dvd_of_prime` in `Affine/CoordinateRing.lean` carried a **69-line** proof — the longest
declaration in the elliptic tree, and past this repository's 50-line cap. The file's own module
docstring already sets that argument out as three steps. The proof named none of them. This names
them. No statement changes, no new public declaration, no change to what is proved.

## The docstring was already the decomposition

The module docstring describes the argument in full, and its three bullets are exactly the three
lemmas extracted here:

> * `(x₀, β)` lies on `W` over `k`, where `x₀` is the image of `X` and `β` the image of `-g`;
> * `W_Y(x₀, β) = 2β + a₁x₀ + a₃ = 0`, which is `π ∣ 2g - s`;
> * `W_X(x₀, β) = a₁β - (3x₀² + 2a₂x₀ + a₄) = 0`, which is `π ∣ a₁g + c'`.
>
> That is a singular point of an elliptic curve, which is absurd.

A reader could follow the mathematics from the docstring but had to re-derive the correspondence
with the proof by hand, because nothing in the 69 lines was labelled.

## The three helpers

```lean
-- the chain rule; no primality, no field structure, no ellipticity
private theorem dvd_a₁_mul_add_of_dvd_two_mul_sub_of_sq_dvd {π g : R[X]}
    (hs : π ∣ 2 * g - (C W.a₁ * X + C W.a₃))
    (hsq : π ^ 2 ∣ g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
      (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)) :
    π ∣ C W.a₁ * g + (3 * X ^ 2 + 2 * C W.a₂ * X + C W.a₄)

-- the singular point: the one step that uses `[W.IsElliptic]`
private theorem not_sq_dvd_of_dvd_two_mul_sub [W.IsElliptic] {π g : F[X]} (hπ : Prime π)
    (hs : π ∣ 2 * g - (C W.a₁ * X + C W.a₃)) :
    ¬π ^ 2 ∣ g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
      (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)

-- the collapse of the pair `(p, q)` to a single `g`; pure divisibility
private theorem exists_dvd_two_mul_sub_and_sq_dvd_of_not_dvd {π p q : F[X]} (hπ : Prime π)
    (hq : ¬π ∣ q) (ht : π ∣ 2 * p - q * (C W.a₁ * X + C W.a₃))
    (hn : π ^ 2 ∣ p ^ 2 - p * q * (C W.a₁ * X + C W.a₃) -
      q ^ 2 * (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)) :
    ∃ g : F[X], π ∣ 2 * g - (C W.a₁ * X + C W.a₃) ∧
      π ^ 2 ∣ g ^ 2 - g * (C W.a₁ * X + C W.a₃) -
        (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)
```

What is left in `dvd_and_dvd_of_prime` is its own content and nothing else: `π ∣ q` by
contradiction through the two field-level helpers, then `π ∣ p` read off from it.

## The split records two hypotheses that were being carried too far

This is the part that is worth more than the line count.

* **`dvd_a₁_mul_add_of_dvd_two_mul_sub_of_sq_dvd` needs no field and no prime.** It is the chain
  rule together with `Polynomial.pow_sub_one_dvd_derivative_of_pow_dvd`: a square divisor of `H = g² - gs - c`
  divides `H'`, and `H' = g'(2g - s) - (a₁g + c')` splits that into the `Y`-part and the `X`-part.
  Nothing there is about `π` being prime, or about `F[X]` being a polynomial ring over a field, so
  it is stated over a `CommRing` in a new `section CommRing` above the existing `section Field`.
* **`exists_dvd_two_mul_sub_and_sq_dvd_of_not_dvd` needs no ellipticity.** It divides through by
  `q` in the residue field and cancels; the curve appears only as the coefficients being carried
  along.

So after this change `[W.IsElliptic]` appears on exactly one of the four declarations — the
singular-point step, which is the only place it is genuinely used. Previously it sat on the whole
69-line block, where a reader could not tell which part consumed it.

## Lengths

| Declaration | Before | After |
|---|---|---|
| `dvd_and_dvd_of_prime` | 69 | 15 |
| `dvd_a₁_mul_add_of_dvd_two_mul_sub_of_sq_dvd` | — | 24 |
| `not_sq_dvd_of_dvd_two_mul_sub` | — | 27 |
| `exists_dvd_two_mul_sub_and_sq_dvd_of_not_dvd` | — | 26 |

Every piece is now under the 30-line threshold, not merely under the 50-line cap. The file goes
from 439 to 490 lines, all of the growth being the three new signatures and their docstrings.

## The proof steps themselves are unchanged

Every tactic block is moved, not rewritten: the same `linear_combination` certificates, the same
`simp only` sets, the same `equation_iff_nonsingular` / `nonsingular_iff'` route. Two incidental
tidies come with the move and are the only edits to a tactic:

* `refine (hπ.dvd_or_dvd hprod).resolve_left hq` closes its goal, so it becomes `exact`.
* `Dvd.dvd.mul_left ⟨f, hf⟩ (derivative g)` becomes `hs.mul_left (derivative g)`, since the
  divisibility that was destructured into `⟨f, hf⟩` is now a named hypothesis of the helper.

The witness `f` is still destructured inside
`exists_dvd_two_mul_sub_and_sq_dvd_of_not_dvd`, because the `linear_combination` certificate for
the norm divisibility mentions it.

## Scope

Improvement work on existing code: no declaration changes its statement, nothing public is added,
renamed or removed, and no new mathematics enters the repository. All four declarations are
`private`, and the only consumer — `dvd_and_dvd`, immediately below — is untouched. The `Roadmap:`
line is attribution to the area the file belongs to, not a fresh roadmap claim.

## Gates

Run in full at `488d207dd`, against the merge-base pin. The head since then differs only by the
`naming` rename below — one `private` declaration renamed, its single call site updated and one
docstring bullet rewrapped — for which the changed module and all three of its importers were
rebuilt clean (2508 jobs); the whole-tree numbers are unaffected by a rename of a private symbol
with no cross-module uses.

* `lake build` — the whole project, **7786 jobs**, clean, and with no warnings. The lakefile sets
  `warningAsError = true` with the Mathlib linter set, so this is also the lint gate.
* `scripts/lint-env.sh` — **LINT-ENV: PASS**, no new violations (68 grandfathered, 2 ratchetable).
  Both ratchetable entries are pre-existing and unrelated to this diff
  (`simpNF Polynomial.derivative_hermite_succ` and
  `unusedArguments TauCeti.ModularForm.orderOfVanishingAt_corner_eq_zero`); clearing them means
  editing `scripts/lint-baseline.txt`, which is human-owned, so they are left alone.
* `lake exe axioms` — **44368** declarations audited, all within
  `[propext, Classical.choice, Quot.sound]`.
* `lake exe module-system` — **2126/2126** modules opt in.
* `lake lean … -Dprofiler=true -Dprofiler.threshold=400` on the changed module — whole-file
  elaboration **330 ms**, nothing over the threshold, so no declaration is near the 1 s budget.

The file is 490 lines against the 1500-line limit for an existing file, and no line exceeds 100
codepoints (the maximum is exactly 100).

## Review

Round 1 requested one change, in `naming`: the helper was first called
`dvd_a₁_mul_add_of_sq_dvd`, naming only the square-divisibility hypothesis, but the conclusion
needs `hs : π ∣ 2g - s` just as essentially — without it, `π² ∣ H` gives only
`π ∣ g'(2g - s) - (a₁g + c')`. Renamed to `dvd_a₁_mul_add_of_dvd_two_mul_sub_of_sq_dvd`, listing
both hypotheses in argument order.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"coordring-decompose-core"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
