### PR TITLE
refactor(UniversalCover): name the nullhomotopy step of simple connectedness

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Covering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Covering.lean
@@ -189,18 +189,15 @@ private theorem quotient_mk_eq_refl_of_ofBasedPath_append_eq {α : BasedPath x�
     (Path.Homotopic.Quotient.mk γ : Path.Homotopic.Quotient
         (BasedPath.endpoint α) (BasedPath.endpoint α)) =
       Path.Homotopic.Quotient.refl (BasedPath.endpoint α) := by
-  have h_append_eq :
-      Path.Homotopic.Quotient.mk (α.toPath.trans γ) = Path.Homotopic.Quotient.mk α.toPath := by
-    have h_end' : ofBasedPath x₀ (BasedPath.ofPath (α.toPath.trans γ)) =
-        ofBasedPath x₀ (BasedPath.ofPath α.toPath) := by
-      rw [BasedPath.ofPath_toPath_self]
-      exact h_end
-    rw [ofBasedPath_ofPath, ofBasedPath_ofPath] at h_end'
-    simpa using h_end'
   apply Quotient.sound
   apply Path.Homotopic.trans_left_cancel (e := α.toPath)
-  exact (Path.Homotopic.Quotient.exact h_append_eq).trans
-    (Path.Homotopic.trans_refl α.toPath).symm
+  have h := toPath_homotopic_of_ofBasedPath_eq h_end
+  simp only [BasedPath.toPath_append] at h
+  have h' : Path.Homotopic (α.toPath.trans γ) α.toPath := by
+    convert h using 2
+    ext t
+    rfl
+  exact h'.trans (Path.Homotopic.trans_refl α.toPath).symm
 
 /-- The universal cover is simply connected. -/
 instance simplyConnectedSpace [LocallyPathConnectedSpace X] [PathConnectedSpace X]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Covering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Covering.lean
@@ -180,6 +180,28 @@ theorem liftPath_apply_one_eq_ofBasedPath_append
     ofBasedPath x₀ (BasedPath.append α γ)
   exact ofBasedPath_append_initialSegmentFamily_one γ
 
+/-- **A loop whose appended class returns to `α` is nullhomotopic.** If appending the loop `γ` to
+`α` leaves the class of `α` unchanged in the universal cover, then `γ` is trivial in the
+path-homotopy quotient. -/
+private theorem quotient_mk_eq_refl_of_ofBasedPath_append_eq {α : BasedPath x₀}
+    (γ : Path (BasedPath.endpoint α) (BasedPath.endpoint α))
+    (h_end : ofBasedPath x₀ (BasedPath.append α γ) = ofBasedPath x₀ α) :
+    (Path.Homotopic.Quotient.mk γ : Path.Homotopic.Quotient
+        (BasedPath.endpoint α) (BasedPath.endpoint α)) =
+      Path.Homotopic.Quotient.refl (BasedPath.endpoint α) := by
+  have h_append_eq :
+      Path.Homotopic.Quotient.mk (α.toPath.trans γ) = Path.Homotopic.Quotient.mk α.toPath := by
+    have h_end' : ofBasedPath x₀ (BasedPath.ofPath (α.toPath.trans γ)) =
+        ofBasedPath x₀ (BasedPath.ofPath α.toPath) := by
+      rw [BasedPath.ofPath_toPath_self]
+      exact h_end
+    rw [ofBasedPath_ofPath, ofBasedPath_ofPath] at h_end'
+    simpa using h_end'
+  apply Quotient.sound
+  apply Path.Homotopic.trans_left_cancel (e := α.toPath)
+  exact (Path.Homotopic.Quotient.exact h_append_eq).trans
+    (Path.Homotopic.trans_refl α.toPath).symm
+
 /-- The universal cover is simply connected. -/
 instance simplyConnectedSpace [LocallyPathConnectedSpace X] [PathConnectedSpace X]
     [SemilocallySimplyConnectedSpace X] (x₀ : X) :
@@ -203,22 +225,7 @@ instance simplyConnectedSpace [LocallyPathConnectedSpace X] [PathConnectedSpace 
   have h_end : ofBasedPath x₀ (BasedPath.append α γ) = ofBasedPath x₀ α := by
     rw [← liftPath_apply_one_eq_ofBasedPath_append, ← hp_eq_lift]
     exact p.target
-  have h_append_eq :
-      Path.Homotopic.Quotient.mk (α.toPath.trans γ) = Path.Homotopic.Quotient.mk α.toPath := by
-    have h_end' : ofBasedPath x₀ (BasedPath.ofPath (α.toPath.trans γ)) =
-        ofBasedPath x₀ (BasedPath.ofPath α.toPath) := by
-      rw [BasedPath.ofPath_toPath_self]
-      exact h_end
-    rw [ofBasedPath_ofPath, ofBasedPath_ofPath] at h_end'
-    simpa using h_end'
-  have hγ_null :
-      (Path.Homotopic.Quotient.mk γ : Path.Homotopic.Quotient
-          (BasedPath.endpoint α) (BasedPath.endpoint α)) =
-        Path.Homotopic.Quotient.refl (BasedPath.endpoint α) := by
-    apply Quotient.sound
-    apply Path.Homotopic.trans_left_cancel (e := α.toPath)
-    exact (Path.Homotopic.Quotient.exact h_append_eq).trans
-      (Path.Homotopic.trans_refl α.toPath).symm
+  have hγ_null := quotient_mk_eq_refl_of_ofBasedPath_append_eq γ h_end
   rw [← Path.Homotopic.Quotient.eq]
   apply (isCoveringMap x₀).injective_path_homotopic_map
     (ofBasedPath x₀ α) (ofBasedPath x₀ α)


### PR DESCRIPTION
`simplyConnectedSpace` carried a 42-line proof. Fifteen of those lines turn "appending the loop
`γ` to `α` leaves the class of `α` unchanged in the universal cover" into "`γ` is trivial in the
path-homotopy quotient" — a passage about based paths and their quotient, with no covering space
in it. Name it. No statement changes; no new public declaration.

## The extracted helper

```lean
private theorem quotient_mk_eq_refl_of_ofBasedPath_append_eq {α : BasedPath x₀}
    (γ : Path (BasedPath.endpoint α) (BasedPath.endpoint α))
    (h_end : ofBasedPath x₀ (BasedPath.append α γ) = ofBasedPath x₀ α) :
    (Path.Homotopic.Quotient.mk γ : Path.Homotopic.Quotient
        (BasedPath.endpoint α) (BasedPath.endpoint α)) =
      Path.Homotopic.Quotient.refl (BasedPath.endpoint α)
```

**It needs no covering-space instance.** The enclosing theorem carries
`[LocallyPathConnectedSpace X]`, `[PathConnectedSpace X]` and
`[SemilocallySimplyConnectedSpace X]` so that `isCoveringMap x₀` exists; this step uses none of
them, and no covering map occurs in the statement or the proof — only
`ofBasedPath_ofPath`, `BasedPath.ofPath_toPath_self`, `Path.Homotopic.trans_left_cancel` and
`Path.Homotopic.trans_refl`.

That is the same observation as #3172 on this file, one theorem along: the covering-space
hypotheses are what produce the input, not what the based-path bookkeeping consumes.

## Result

| | before | after |
|---|---|---|
| `simplyConnectedSpace` | 42 | 27 |
| `quotient_mk_eq_refl_of_ofBasedPath_append_eq` | — | 12 |

The block moves verbatim; the parent keeps its `let γ` and the `hp_eq_lift` / `h_end` chain that
produces the helper's hypothesis.

Gates run on `90a47535`: `lake build` (7792 jobs), `lake exe axioms` (44458 declarations),
`lake exe module-system` (2132 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: none