### PR TITLE
feat: add the rational basis of the adic spectrum

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -61,6 +61,8 @@ layer deferred above.
   among the numerators.
 * `TauCeti.ValuationSpectrum.rationalSubset_singleton_one` : the whole spectrum is the
   rational subset `R({1}/1)` — Wedhorn's "`Spa (A, A⁺)` itself is rational".
+* `TauCeti.ValuationSpectrum.val_preimage_rationalSubset` : on the subtype `spa A⁺`, a
+  rational subset is just the trace of its ambient basic open.
 * `TauCeti.ValuationSpectrum.isOpen_val_preimage_rationalSubset` : a rational subset is
   relatively open in the subspace `spa A⁺`.
 * `TauCeti.ValuationSpectrum.rationalSubset_inter` : the intersection identity above — the
@@ -133,11 +135,20 @@ theorem rationalSubset_singleton_one (Aplus : Subring A) :
   exact ⟨fun t ht => by simp [Finset.mem_singleton.mp ht],
     v.toValuativeRel.not_vle_one_zero⟩
 
+/-- On the subtype `spa A⁺`, the preimage of `R(T/s)` is the preimage of the ambient basic
+open `Spv(A)(T/s)`: the `spa A⁺` condition is automatic from the subtype. This is the form used
+to compare the rational bases of `Spa(A,A⁺)` and `Spv(A,I)`. -/
+@[simp]
+theorem val_preimage_rationalSubset (Aplus : Subring A) (T : Finset A) (s : A) :
+    (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)) =
+      Subtype.val ⁻¹' basicOpenFinset T s := by
+  rw [rationalSubset_def, Set.preimage_inter, Subtype.coe_preimage_self, Set.univ_inter]
+
 /-- The preimage of `R(T/s)` under the coercion of the subtype `spa A⁺` is open: a rational
 subset is relatively open in the adic spectrum. -/
 theorem isOpen_val_preimage_rationalSubset (Aplus : Subring A) (T : Finset A) (s : A) :
     IsOpen (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)) := by
-  rw [rationalSubset_def, Set.preimage_inter, Subtype.coe_preimage_self, Set.univ_inter]
+  rw [val_preimage_rationalSubset]
   exact (isOpen_basicOpenFinset T s).preimage continuous_subtype_val
 
 open scoped Classical Pointwise in

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -23,9 +23,9 @@ R(T/s) = {v ∈ Spa(A,A⁺) : v(t) ≤ v(s) ≠ 0 for every t ∈ T}
 
 for which the ideal `T · A` is open form a basis of quasi-compact opens of `Spa(A,A⁺)`.
 The proof compares them with the rational basis of `Spv(A,IA)`. By Wedhorn Lemma 6.6,
-openness of `T · A` is exactly admissibility for `IA`; conversely, an admissible pair `(T,s)`
-becomes open after inserting `s` among the numerators, which does not change its rational
-subset. This comparison also transports closure under intersections and quasi-compactness.
+openness of `T · A` implies admissibility for `IA`; conversely, an admissible pair `(T,s)`
+has open numerator ideal after inserting `s` among the numerators, which does not change its
+rational subset. This comparison also transports closure under intersections and quasi-compactness.
 
 The plus ring is arbitrary here. The additional condition that it be a ring of integral
 elements is part of calling the resulting space the adic spectrum of a Huber pair, but none of
@@ -106,8 +106,9 @@ theorem mem_spaRationalFamily_iff {Aplus : Subring A} {U : Set (spa Aplus)} :
 theorem univ_mem_spaRationalFamily (Aplus : Subring A) :
     Set.univ ∈ spaRationalFamily Aplus := by
   refine ⟨{1}, 1, ?_, ?_⟩
-  · rw [show Ideal.span (({1} : Finset A) : Set A) = ⊤ by
-      exact (Ideal.eq_top_iff_one _).mpr (Ideal.subset_span (by simp))]
+  · have hspan : Ideal.span (({1} : Finset A) : Set A) = ⊤ :=
+      (Ideal.eq_top_iff_one _).mpr (Ideal.subset_span (by simp))
+    rw [hspan]
     exact isOpen_univ
   · rw [rationalSubset_singleton_one]
     exact (Subtype.coe_preimage_self (spa Aplus)).symm
@@ -120,7 +121,8 @@ open Classical in
 /-- If two numerator ideals are open, then so is the ideal spanned by the product of the
 numerator sets after adjoining their respective denominators. This is the admissibility half of
 the intersection formula for rational subsets. -/
-theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A) {T₁ T₂ : Finset A} {s₁ s₂ : A}
+private theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A)
+    {T₁ T₂ : Finset A} {s₁ s₂ : A}
     (hT₁ : IsOpen (Ideal.span (T₁ : Set A) : Set A))
     (hT₂ : IsOpen (Ideal.span (T₂ : Set A) : Set A)) :
     IsOpen (Ideal.span ((insert s₁ T₁ * insert s₂ T₂ : Finset A) : Set A) : Set A) := by
@@ -187,12 +189,12 @@ theorem isTopologicalBasis_spaRationalFamily_of_pairOfDefinition
     have hW : W ∈ spaRationalFamily Aplus :=
       mem_spaRationalFamily_iff.mpr ⟨insert s T, s, hOpen, rfl⟩
     refine ⟨W, hW, ?_, ?_⟩
-    · rw [show W = Subtype.val ⁻¹' rationalSubset Aplus (insert s T) s from rfl,
-        rationalSubset_insert_self, val_preimage_rationalSubset]
+    · simp only [W]
+      rw [rationalSubset_insert_self, val_preimage_rationalSubset]
       exact hxV
     · intro y hy
-      rw [show W = Subtype.val ⁻¹' rationalSubset Aplus (insert s T) s from rfl,
-        rationalSubset_insert_self, val_preimage_rationalSubset] at hy
+      simp only [W] at hy
+      rw [rationalSubset_insert_self, val_preimage_rationalSubset] at hy
       let yI : spvOfIdeal P.extendedIdealOfDefinition hfg :=
         ⟨y, spa_subset_spvOfIdeal P Aplus y.property⟩
       exact hVO (a := yI) hy
@@ -228,11 +230,17 @@ theorem isCompact_of_mem_spaRationalFamily_of_pairOfDefinition
   let e : S ≃ₜ spa Aplus := Topology.IsEmbedding.subtypeVal.homeomorphOfSubsetRange
     (fun x hx ↦ ⟨⟨x, spa_subset_spvOfIdeal P Aplus hx⟩, rfl⟩)
   apply e.isCompact_preimage.mp
+  have heval (x : S) : ((e x : spa Aplus) : Spv A) =
+      ((x : spvOfIdeal P.extendedIdealOfDefinition hfg) : Spv A) := by
+    simpa only [e] using
+      (Topology.IsEmbedding.homeomorphOfSubsetRange_apply_coe
+        Topology.IsEmbedding.subtypeVal
+        (fun x hx ↦ ⟨⟨x, spa_subset_spvOfIdeal P Aplus hx⟩, rfl⟩) x)
   have hpre : e ⁻¹' (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)) =
       Subtype.val ⁻¹' V := by
     ext x
-    simp only [Set.mem_preimage, val_preimage_rationalSubset]
-    rfl
+    simp only [Set.mem_preimage, val_preimage_rationalSubset, V]
+    rw [heval]
   rw [hpre]
   exact hS.isSpectralMap_subtypeVal.isCompact_preimage_of_isOpen hVopen hVcompact
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -1,0 +1,250 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Bases
+public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.RationalSubset.Basic
+public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Spectral
+import TauCeti.RingTheory.Huber.OpenIdeal
+
+/-!
+# The rational basis of the adic spectrum
+
+**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Definition 7.29, Remark 7.30(5),
+and Theorem 7.35.**
+
+Let `P = (A₀,I)` be a pair of definition of a Huber ring. The rational subsets
+
+```text
+R(T/s) = {v ∈ Spa(A,A⁺) : v(t) ≤ v(s) ≠ 0 for every t ∈ T}
+```
+
+for which the ideal `T · A` is open form a basis of quasi-compact opens of `Spa(A,A⁺)`.
+The proof compares them with the rational basis of `Spv(A,IA)`. By Wedhorn Lemma 6.6,
+openness of `T · A` is exactly admissibility for `IA`; conversely, an admissible pair `(T,s)`
+becomes open after inserting `s` among the numerators, which does not change its rational
+subset. This comparison also transports closure under intersections and quasi-compactness.
+
+The plus ring is arbitrary here. The additional condition that it be a ring of integral
+elements is part of calling the resulting space the adic spectrum of a Huber pair, but none of
+the basis arguments uses it.
+
+## Main definitions
+
+* `TauCeti.ValuationSpectrum.spaRationalFamily`: the family of rational subsets with open
+  numerator ideal, viewed as subsets of `spa Aplus`.
+
+## Main results
+
+* `TauCeti.ValuationSpectrum.inter_mem_spaRationalFamily`: the family is closed under binary
+  intersections, completing Wedhorn Remark 7.30(5).
+* `TauCeti.ValuationSpectrum.isTopologicalBasis_spaRationalFamily`: the family is a basis for
+  the topology of `spa Aplus`.
+* `TauCeti.ValuationSpectrum.isCompact_of_mem_spaRationalFamily`: every member of the family is
+  quasi-compact. Each result also has an `_of_pairOfDefinition` form for use with a specified
+  pair of definition.
+
+## References
+
+* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.29, Remark 7.30, Theorem 7.35,
+  and Lemma 6.6.
+-/
+
+public section
+
+namespace TauCeti.ValuationSpectrum
+
+open Set Topology TopologicalSpace TauCeti TauCeti.Huber
+open scoped Pointwise
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A]
+
+/-! ### Open numerator ideals and admissibility -/
+
+section TopologicalRing
+
+variable [IsTopologicalRing A]
+
+/-- An open numerator ideal is admissible for the extended ideal of every pair of definition.
+This is Wedhorn Lemma 6.6 applied to the inclusion of the numerator span into the span obtained
+after adjoining the denominator. -/
+theorem isAdmissible_extendedIdealOfDefinition_of_isOpen_span (P : PairOfDefinition A)
+    {T : Finset A} {s : A} (hT : IsOpen (Ideal.span (T : Set A) : Set A)) :
+    IsAdmissible P.extendedIdealOfDefinition T s := by
+  rw [isAdmissible_iff]
+  refine (P.isOpen_iff_le_radical _).mp hT |>.trans (Ideal.radical_mono ?_)
+  exact Ideal.span_mono (Set.subset_insert s (T : Set A))
+
+/-- An admissible numerator set becomes an open numerator ideal after adjoining its denominator.
+The rational subset itself is unchanged by this operation. -/
+theorem isOpen_span_insert_of_isAdmissible_extendedIdealOfDefinition (P : PairOfDefinition A)
+    {T : Finset A} {s : A} (hT : IsAdmissible P.extendedIdealOfDefinition T s) :
+    IsOpen (Ideal.span (insert s (T : Set A)) : Set A) := by
+  rw [P.isOpen_iff_le_radical]
+  exact isAdmissible_iff.mp hT
+
+end TopologicalRing
+
+/-! ### The rational family -/
+
+/-- The rational family of `Spa(A,A⁺)`: rational subsets `R(T/s)` whose numerator ideal
+`T · A` is open, viewed as subsets of the subtype `spa Aplus`. -/
+def spaRationalFamily (Aplus : Subring A) : Set (Set (spa Aplus)) :=
+  {U | ∃ (T : Finset A) (s : A), IsOpen (Ideal.span (T : Set A) : Set A) ∧
+    U = Subtype.val ⁻¹' rationalSubset Aplus T s}
+
+/-- Membership in the rational family is a presentation as `R(T/s)` with open numerator ideal. -/
+@[simp]
+theorem mem_spaRationalFamily_iff {Aplus : Subring A} {U : Set (spa Aplus)} :
+    U ∈ spaRationalFamily Aplus ↔
+      ∃ (T : Finset A) (s : A), IsOpen (Ideal.span (T : Set A) : Set A) ∧
+        U = Subtype.val ⁻¹' rationalSubset Aplus T s := Iff.rfl
+
+/-- The whole adic spectrum belongs to its rational family, presented as `R({1}/1)`. -/
+theorem univ_mem_spaRationalFamily (Aplus : Subring A) :
+    Set.univ ∈ spaRationalFamily Aplus := by
+  refine ⟨{1}, 1, ?_, ?_⟩
+  · rw [show Ideal.span (({1} : Finset A) : Set A) = ⊤ by
+      exact (Ideal.eq_top_iff_one _).mpr (Ideal.subset_span (by simp))]
+    exact isOpen_univ
+  · rw [rationalSubset_singleton_one]
+    exact (Subtype.coe_preimage_self (spa Aplus)).symm
+
+section TopologicalRing
+
+variable [IsTopologicalRing A]
+
+open Classical in
+/-- If two numerator ideals are open, then so is the ideal spanned by the product of the
+numerator sets after adjoining their respective denominators. This is the admissibility half of
+the intersection formula for rational subsets. -/
+theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A) {T₁ T₂ : Finset A} {s₁ s₂ : A}
+    (hT₁ : IsOpen (Ideal.span (T₁ : Set A) : Set A))
+    (hT₂ : IsOpen (Ideal.span (T₂ : Set A) : Set A)) :
+    IsOpen (Ideal.span ((insert s₁ T₁ * insert s₂ T₂ : Finset A) : Set A) : Set A) := by
+  classical
+  rw [P.isOpen_iff_le_radical]
+  have hmul :=
+    (isAdmissible_extendedIdealOfDefinition_of_isOpen_span (s := s₁) P hT₁).mul
+      (isAdmissible_extendedIdealOfDefinition_of_isOpen_span (s := s₂) P hT₂)
+  rw [isAdmissible_iff] at hmul
+  have hs : s₁ * s₂ ∈ insert s₁ T₁ * insert s₂ T₂ :=
+    Finset.mul_mem_mul (Finset.mem_insert_self _ _) (Finset.mem_insert_self _ _)
+  rwa [Set.insert_eq_self.mpr (Finset.mem_coe.mpr hs)] at hmul
+
+/-- **Wedhorn Remark 7.30(5).** Rational subsets with open numerator ideal are closed under
+intersection. The set identity is `rationalSubset_inter`; admissibility is multiplicative in
+`Spv(A,IA)`, and adjoining the product denominator turns it back into openness. -/
+theorem inter_mem_spaRationalFamily_of_pairOfDefinition (P : PairOfDefinition A)
+    {Aplus : Subring A}
+    {U V : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus)
+    (hV : V ∈ spaRationalFamily Aplus) : U ∩ V ∈ spaRationalFamily Aplus := by
+  classical
+  obtain ⟨T₁, s₁, hT₁, rfl⟩ := hU
+  obtain ⟨T₂, s₂, hT₂, rfl⟩ := hV
+  refine ⟨insert s₁ T₁ * insert s₂ T₂, s₁ * s₂,
+    isOpen_span_insert_mul_insert P hT₁ hT₂, ?_⟩
+  rw [← Set.preimage_inter, rationalSubset_inter]
+
+/-- **Wedhorn Remark 7.30(5).** Over a Huber ring, the rational family is closed under binary
+intersection, without choosing a pair of definition. -/
+theorem inter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A}
+    {U V : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus)
+    (hV : V ∈ spaRationalFamily Aplus) : U ∩ V ∈ spaRationalFamily Aplus :=
+  (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
+    fun P ↦ inter_mem_spaRationalFamily_of_pairOfDefinition P hU hV
+
+/-! ### Basis and quasi-compactness -/
+
+/-- **Rational subsets form a basis of `Spa(A,A⁺)`.** The statement is made from an explicit
+pair of definition. Every rational neighbourhood in the basis of `Spv(A,IA)` becomes a member
+of `spaRationalFamily` after adjoining its denominator. -/
+theorem isTopologicalBasis_spaRationalFamily_of_pairOfDefinition
+    (P : PairOfDefinition A) (Aplus : Subring A) :
+    IsTopologicalBasis (spaRationalFamily Aplus) := by
+  classical
+  apply isTopologicalBasis_of_isOpen_of_nhds
+  · rintro U ⟨T, s, -, rfl⟩
+    exact isOpen_val_preimage_rationalSubset Aplus T s
+  · intro x U hx hU
+    obtain ⟨O, hO, rfl⟩ := Topology.IsEmbedding.subtypeVal.isInducing.isOpen_iff.mp hU
+    let hfg : ∃ J : Ideal A, J.FG ∧ P.extendedIdealOfDefinition.radical = J.radical :=
+      ⟨P.extendedIdealOfDefinition, P.fg_extendedIdealOfDefinition, rfl⟩
+    let xI : spvOfIdeal P.extendedIdealOfDefinition hfg :=
+      ⟨x, spa_subset_spvOfIdeal P Aplus x.property⟩
+    have hxO : xI ∈ Subtype.val ⁻¹' O := hx
+    have hOI : IsOpen (Subtype.val ⁻¹' O : Set (spvOfIdeal P.extendedIdealOfDefinition hfg)) :=
+      hO.preimage continuous_subtype_val
+    obtain ⟨V, hVr, hxV, hVO⟩ :=
+      (isTopologicalBasis_rationalFamily P.extendedIdealOfDefinition hfg).isOpen_iff.mp hOI xI hxO
+    obtain ⟨T, s, hadm, rfl⟩ := mem_rationalFamily_iff.mp hVr
+    let W : Set (spa Aplus) := Subtype.val ⁻¹' rationalSubset Aplus (insert s T) s
+    have hOpen : IsOpen (Ideal.span ((insert s T : Finset A) : Set A) : Set A) := by
+      simpa only [Finset.coe_insert] using
+        isOpen_span_insert_of_isAdmissible_extendedIdealOfDefinition P hadm
+    have hW : W ∈ spaRationalFamily Aplus :=
+      mem_spaRationalFamily_iff.mpr ⟨insert s T, s, hOpen, rfl⟩
+    refine ⟨W, hW, ?_, ?_⟩
+    · rw [show W = Subtype.val ⁻¹' rationalSubset Aplus (insert s T) s from rfl,
+        rationalSubset_insert_self, val_preimage_rationalSubset]
+      exact hxV
+    · intro y hy
+      rw [show W = Subtype.val ⁻¹' rationalSubset Aplus (insert s T) s from rfl,
+        rationalSubset_insert_self, val_preimage_rationalSubset] at hy
+      let yI : spvOfIdeal P.extendedIdealOfDefinition hfg :=
+        ⟨y, spa_subset_spvOfIdeal P Aplus y.property⟩
+      exact hVO (a := yI) hy
+
+/-- **Rational subsets form a basis of `Spa(A,A⁺)`**, without choosing a pair of definition
+of the Huber ring. -/
+theorem isTopologicalBasis_spaRationalFamily [IsHuberRing A] (Aplus : Subring A) :
+    IsTopologicalBasis (spaRationalFamily Aplus) :=
+  (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
+    fun P ↦ isTopologicalBasis_spaRationalFamily_of_pairOfDefinition P Aplus
+
+/-- Every member of the rational family of `Spa(A,A⁺)` is quasi-compact. Its counterpart in
+`Spv(A,IA)` is a quasi-compact open, and its intersection with the pro-constructible trace of
+`spa Aplus` stays quasi-compact. -/
+theorem isCompact_of_mem_spaRationalFamily_of_pairOfDefinition
+    (P : PairOfDefinition A) {Aplus : Subring A}
+    {U : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus) : IsCompact U := by
+  obtain ⟨T, s, hT, rfl⟩ := hU
+  let hfg : ∃ J : Ideal A, J.FG ∧ P.extendedIdealOfDefinition.radical = J.radical :=
+    ⟨P.extendedIdealOfDefinition, P.fg_extendedIdealOfDefinition, rfl⟩
+  let S : Set (spvOfIdeal P.extendedIdealOfDefinition hfg) :=
+    Subtype.val ⁻¹' spa Aplus
+  let V : Set (spvOfIdeal P.extendedIdealOfDefinition hfg) :=
+    Subtype.val ⁻¹' basicOpenFinset T s
+  have := spectralSpace_spvOfIdeal P.extendedIdealOfDefinition hfg
+  have hS : IsProConstructible S := isProConstructible_val_preimage_spa P Aplus
+  have hVopen : IsOpen V := (isOpen_basicOpenFinset T s).preimage continuous_subtype_val
+  have hVmem : V ∈ rationalFamily P.extendedIdealOfDefinition hfg :=
+    mem_rationalFamily_iff.mpr
+      ⟨T, s, isAdmissible_extendedIdealOfDefinition_of_isOpen_span P hT, rfl⟩
+  have hVcompact : IsCompact V :=
+    isCompact_of_mem_rationalFamily P.extendedIdealOfDefinition hfg hVmem
+  let e : S ≃ₜ spa Aplus := Topology.IsEmbedding.subtypeVal.homeomorphOfSubsetRange
+    (fun x hx ↦ ⟨⟨x, spa_subset_spvOfIdeal P Aplus hx⟩, rfl⟩)
+  apply e.isCompact_preimage.mp
+  have hpre : e ⁻¹' (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)) =
+      Subtype.val ⁻¹' V := by
+    ext x
+    simp only [Set.mem_preimage, val_preimage_rationalSubset]
+    rfl
+  rw [hpre]
+  exact hS.isSpectralMap_subtypeVal.isCompact_preimage_of_isOpen hVopen hVcompact
+
+/-- Every rational subset with open numerator ideal in the adic spectrum of a Huber ring is
+quasi-compact, without choosing a pair of definition. -/
+theorem isCompact_of_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A}
+    {U : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus) : IsCompact U :=
+  (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
+    fun P ↦ isCompact_of_mem_spaRationalFamily_of_pairOfDefinition P hU
+
+end TopologicalRing
+
+end TauCeti.ValuationSpectrum
+
+end


### PR DESCRIPTION
This PR equips `Spa(A,A⁺)` with its rational basis: define the family of `R(T/s)` whose numerator ideal `T · A` is open, prove it is stable under intersections, prove it is a topological basis, and prove every member is quasi-compact.

This is the exact target in `TauCetiRoadmap/AdicSpaces/README.md`, Layer 2.2, **“Rational subsets”**: “Prove that rational subsets form a basis of quasi-compact opens and are closed under finite intersections.” It is the most effective current step toward that milestone because `Spv(A,I)` already has its quasi-compact rational basis and `Spa(A,A⁺)` is already spectral, while Layer 3’s rational localisation and structure presheaf need precisely this basis interface. After this PR, Layer 2.2 still needs perturbation invariance (Proposition 7.34), the remaining standard-cover/unit-criterion and rational-refinement results (Corollary 7.53 and Lemma 7.54), and rational-in-rational transitivity (Proposition 8.2(2)).

The mathematical comparison follows Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.29, Remark 7.30(5), Theorem 7.35, and Lemma 6.6, as credited in the new module. Lemma 6.6 turns openness of `T · A` into admissibility in `Spv(A,IA)`; inserting the denominator gives the converse presentation without changing the rational subset; and pro-constructibility of `Spa(A,A⁺)` transfers quasi-compactness from the `Spv(A,IA)` basis. No Mathlib infrastructure or external formalisation is vendored.

`TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean` is a new 250-line module. The existing basic module gains the 12-line characteristic lemma `val_preimage_rationalSubset`, which identifies a rational subset’s trace on the `spa` subtype and is consumed by the basis proof.

The directory-layout rule requires this module move; no forwarding import remains:

| Old module | New module |
|---|---|
| `TauCeti.AlgebraicGeometry.AdicSpace.Spa.RationalSubset` | `TauCeti.AlgebraicGeometry.AdicSpace.Spa.RationalSubset.Basic` |

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"rational-subsets-basis-quasi-compact-opens"}-->

🤖 Prepared with Codex
