### PR TITLE
feat(ModularForms): q-coefficient vanishing versus cusp-function growth

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/QExpansion/BigO.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/BigO.lean
@@ -10,20 +10,23 @@ public import Mathlib.NumberTheory.ModularForms.QExpansion
 /-!
 # `q`-coefficient vanishing and cusp-function growth
 
-The dictionary between vanishing of the first `N` `q`-coefficients of a modular form and
-`O(‖q‖^N)` growth of its cusp function at `0`, in both directions, together with the limit
-of the form's values along `Im τ → ∞`. These are the analytic inputs of the norm step of
-the general-level valence reduction: transporting coefficient vanishing through the norm
-map to level one goes via the growth bound, which is multiplicative.
+The dictionary between vanishing of the first `N` `q`-coefficients of a periodic function
+on `ℍ` and `O(‖q‖^N)` growth of its cusp function at `0`, in both directions, together with
+the limit of the function's values along `Im τ → ∞`. The general layer asks only for
+analyticity of the cusp function at `0` (with periodicity for the limit); the corollaries
+specialize to modular forms. These are the analytic inputs of the norm step of the
+general-level valence reduction: growth bounds are multiplicative, so they transport
+coefficient vanishing through the norm map to level one.
 
 ## Main declarations
 
-* `TauCeti.ModularForm.modularForm_tendsto_valueAtInfty`: values of a modular form tend to
-  `valueAtInfty` along `atImInfty`.
-* `TauCeti.ModularForm.cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero`: if the first
-  `N` `q`-coefficients vanish, the cusp function is `O(‖q‖^N)` near `0`.
-* `TauCeti.ModularForm.qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow`: conversely,
-  an `O(‖q‖^N)` bound kills the `n`-th coefficient for every `n < N`.
+* `TauCeti.UpperHalfPlane.cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero` and
+  `TauCeti.UpperHalfPlane.qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow`: the two
+  directions of the dictionary, for any function whose cusp function is analytic at `0`.
+* `TauCeti.UpperHalfPlane.tendsto_valueAtInfty`: an `h`-periodic function with cusp
+  function analytic at `0` tends to `valueAtInfty` along `atImInfty`.
+* The `TauCeti.ModularFormClass` corollaries of all three, for a modular form on a
+  subgroup with `h` in its strict period set.
 
 ## References
 
@@ -31,69 +34,56 @@ Ported from AINTLIB's `LeanModularForms` project
 ([github.com/CBirkbeck/AINTLIB](https://github.com/CBirkbeck/AINTLIB), commit `2baa76f742`,
 Apache 2.0, the file
 `projects/LeanModularForms/LeanModularForms/Modularforms/DimGenCongLevels/Auxiliary.lean`),
-with the converse direction reproved through Mathlib's power-series uniqueness machinery
-instead of the source's circle-integral bounds.
+generalized to the function level and reproved through Mathlib's power-series uniqueness
+machinery instead of the source's circle-integral bounds.
 -/
 
-namespace TauCeti.ModularForm
-
-open scoped Topology Real
 open UpperHalfPlane Filter
+
+open scoped Topology
+
+namespace TauCeti.UpperHalfPlane
 
 noncomputable section
 
-variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {h : ℝ} {F : Type*} [FunLike F ℍ ℂ]
+variable {h : ℝ} {F : Type*} [FunLike F ℍ ℂ] {f : F}
 
-/-- Values of a modular form tend to `valueAtInfty` along `atImInfty`. -/
-public lemma modularForm_tendsto_valueAtInfty [ModularFormClass F Γ k]
-    (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) :
+/-- A function on `ℍ` that is `h`-periodic with cusp function analytic at `0` tends to
+`valueAtInfty` along `atImInfty`. -/
+public lemma tendsto_valueAtInfty (hh : 0 < h) (hper : Function.Periodic (⇑f ∘ ofComplex) h)
+    (hfanalytic : AnalyticAt ℂ (cuspFunction h f) 0) :
     Tendsto (fun τ : ℍ ↦ f τ) atImInfty (𝓝 (valueAtInfty f)) := by
-  have hAn := ModularFormClass.analyticAt_cuspFunction_zero (f := f) hh hΓ
-  have hper := SlashInvariantFormClass.periodic_comp_ofComplex f hΓ
   have ht : Tendsto (fun τ : ℍ ↦ f τ) atImInfty (𝓝 (cuspFunction h f 0)) := by
     refine Filter.Tendsto.congr (fun τ ↦ ?_)
-      ((hAn.continuousAt.tendsto).comp (UpperHalfPlane.qParam_tendsto_atImInfty hh))
-    simpa using (SlashInvariantFormClass.eq_cuspFunction (f := f) (h := h) τ hΓ hh.ne')
-  simpa [UpperHalfPlane.cuspFunction_apply_zero hh hAn hper] using ht
+      ((hfanalytic.continuousAt.tendsto).comp (qParam_tendsto_atImInfty hh))
+    simpa using eq_cuspFunction τ hh.ne' hper
+  simpa [cuspFunction_apply_zero hh hfanalytic hper] using ht
+
+/-- The power series of the cusp function at `0` is the `q`-expansion. -/
+private lemma hasFPowerSeriesAt_cuspFunction (hfanalytic : AnalyticAt ℂ (cuspFunction h f) 0) :
+    HasFPowerSeriesAt (cuspFunction h f) (qExpansionFormalMultilinearSeries h f) 0 := by
+  simpa [qExpansionFormalMultilinearSeries, qExpansion_coeff, div_eq_mul_inv, mul_comm]
+    using hfanalytic.hasFPowerSeriesAt
 
 /-- If the first `N` `q`-coefficients vanish, then the cusp function is `O(‖q‖^N)` near
 `0`. -/
 public lemma cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero
-    [ModularFormClass F Γ k]
-    (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (N : ℕ)
+    (hfanalytic : AnalyticAt ℂ (cuspFunction h f) 0) (N : ℕ)
     (hcoeff : ∀ n < N, (qExpansion h f).coeff n = 0) :
     cuspFunction h f =O[𝓝 (0 : ℂ)] (fun q : ℂ ↦ ‖q‖ ^ N) := by
-  have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
-  have hper := SlashInvariantFormClass.periodic_comp_ofComplex f hΓ
-  have hAn := ModularFormClass.analyticAt_cuspFunction_zero (f := f) hh hΓ
-  have hhol := ModularFormClass.holo f
-  have hbdd := ModularFormClass.bdd_at_infty f
-  have hFPS : HasFPowerSeriesAt (cuspFunction h f)
-      (qExpansionFormalMultilinearSeries (F := F) h f) 0 :=
-    (hasFPowerSeries_cuspFunction (F := F) f hh hAn
-      (fun τ ↦ hasSum_qExpansion hh hper hhol hbdd τ)).hasFPowerSeriesAt
-  have hps : (qExpansionFormalMultilinearSeries (F := F) h f).partialSum N = 0 := by
+  have hps : (qExpansionFormalMultilinearSeries h f).partialSum N = 0 := by
     ext q
     exact Finset.sum_eq_zero fun n hn ↦ by
       simp [hcoeff n (by simpa [Finset.mem_range] using hn)]
-  simpa [zero_add, hps] using hFPS.isBigO_sub_partialSum_pow N
+  simpa [zero_add, hps] using
+    (hasFPowerSeriesAt_cuspFunction hfanalytic).isBigO_sub_partialSum_pow N
 
 /-- If `cuspFunction h f = O(‖q‖^N)` near `0`, then the `n`-th `q`-coefficient vanishes for
-`n < N`: by strong induction the partial sum of order `n + 1` reduces to the `n`-th
-homogeneous term, which is then dominated by `‖q‖ ^ (n + 1)` and must vanish. -/
+`n < N`. -/
 public lemma qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow
-    [ModularFormClass F Γ k]
-    (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) {N n : ℕ} (hn : n < N)
+    (hfanalytic : AnalyticAt ℂ (cuspFunction h f) 0) {N n : ℕ} (hn : n < N)
     (hO : cuspFunction h f =O[𝓝 (0 : ℂ)] (fun q : ℂ ↦ ‖q‖ ^ N)) :
     (qExpansion h f).coeff n = 0 := by
-  have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
-  have hper := SlashInvariantFormClass.periodic_comp_ofComplex f hΓ
-  have hFPS : HasFPowerSeriesAt (cuspFunction h f)
-      (qExpansionFormalMultilinearSeries (F := F) h f) 0 :=
-    (hasFPowerSeries_cuspFunction (F := F) f hh
-      (ModularFormClass.analyticAt_cuspFunction_zero (f := f) hh hΓ)
-      (fun τ ↦ hasSum_qExpansion hh hper (ModularFormClass.holo f)
-        (ModularFormClass.bdd_at_infty f) τ)).hasFPowerSeriesAt
   induction n using Nat.strong_induction_on with
   | _ n ih =>
   have hON : cuspFunction h f =O[𝓝 (0 : ℂ)] fun q : ℂ ↦ ‖q‖ ^ (n + 1) := by
@@ -102,7 +92,7 @@ public lemma qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow
     simpa [abs_of_nonneg (norm_nonneg q)] using
       pow_le_pow_of_le_one (norm_nonneg q) (mem_ball_zero_iff.mp hq).le hn
   have hps : ∀ y : ℂ,
-      (qExpansionFormalMultilinearSeries (F := F) h f).partialSum (n + 1) y =
+      (qExpansionFormalMultilinearSeries h f).partialSum (n + 1) y =
         y ^ n • (qExpansion h f).coeff n := by
     intro y
     rw [FormalMultilinearSeries.partialSum, Finset.sum_range_succ, Finset.sum_eq_zero
@@ -110,9 +100,9 @@ public lemma qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow
         simp [ih m (Finset.mem_range.mp hm) ((Finset.mem_range.mp hm).trans hn)]),
       zero_add, FormalMultilinearSeries.apply_eq_pow_smul_coeff,
       qExpansionFormalMultilinearSeries_coeff]
-  have hhom : (fun y : ℂ ↦ qExpansionFormalMultilinearSeries (F := F) h f n fun _ ↦ y)
+  have hhom : (fun y : ℂ ↦ qExpansionFormalMultilinearSeries h f n fun _ ↦ y)
       =O[𝓝 (0 : ℂ)] fun y : ℂ ↦ ‖y‖ ^ (n + 1) := by
-    have hsub := hFPS.isBigO_sub_partialSum_pow (n + 1)
+    have hsub := (hasFPowerSeriesAt_cuspFunction hfanalytic).isBigO_sub_partialSum_pow (n + 1)
     simp only [zero_add] at hsub
     refine (hON.sub hsub).congr_left fun y ↦ ?_
     rw [hps, FormalMultilinearSeries.apply_eq_pow_smul_coeff,
@@ -124,4 +114,38 @@ public lemma qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow
 
 end
 
-end TauCeti.ModularForm
+end TauCeti.UpperHalfPlane
+
+namespace TauCeti.ModularFormClass
+
+variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {h : ℝ} {F : Type*} [FunLike F ℍ ℂ]
+
+/-- Values of a modular form tend to `valueAtInfty` along `atImInfty`. -/
+public lemma tendsto_valueAtInfty [ModularFormClass F Γ k] (f : F) (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) :
+    Tendsto (fun τ : ℍ ↦ f τ) atImInfty (𝓝 (valueAtInfty f)) :=
+  TauCeti.UpperHalfPlane.tendsto_valueAtInfty hh
+    (SlashInvariantFormClass.periodic_comp_ofComplex (k := k) f hΓ)
+    (_root_.ModularFormClass.analyticAt_cuspFunction_zero (F := F) (k := k) (f := f) hh hΓ)
+
+/-- If the first `N` `q`-coefficients of a modular form vanish, then its cusp function is
+`O(‖q‖^N)` near `0`. -/
+public lemma cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero [ModularFormClass F Γ k]
+    (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (N : ℕ)
+    (hcoeff : ∀ n < N, (qExpansion h f).coeff n = 0) :
+    cuspFunction h f =O[𝓝 (0 : ℂ)] (fun q : ℂ ↦ ‖q‖ ^ N) :=
+  TauCeti.UpperHalfPlane.cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero
+    (_root_.ModularFormClass.analyticAt_cuspFunction_zero (F := F) (k := k) (f := f) hh hΓ)
+    N hcoeff
+
+/-- If the cusp function of a modular form is `O(‖q‖^N)` near `0`, then its `n`-th
+`q`-coefficient vanishes for `n < N`. -/
+public lemma qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow [ModularFormClass F Γ k]
+    (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) {N n : ℕ} (hn : n < N)
+    (hO : cuspFunction h f =O[𝓝 (0 : ℂ)] (fun q : ℂ ↦ ‖q‖ ^ N)) :
+    (qExpansion h f).coeff n = 0 :=
+  TauCeti.UpperHalfPlane.qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow
+    (_root_.ModularFormClass.analyticAt_cuspFunction_zero (F := F) (k := k) (f := f) hh hΓ)
+    hn hO
+
+end TauCeti.ModularFormClass

--- a/TauCeti/NumberTheory/ModularForms/QExpansion/BigO.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/BigO.lean
@@ -12,9 +12,10 @@ public import Mathlib.NumberTheory.ModularForms.QExpansion
 
 The dictionary between vanishing of the first `N` `q`-coefficients of a periodic function
 on `ℍ` and `O(‖q‖^N)` growth of its cusp function at `0`, in both directions, together with
-the limit of the function's values along `Im τ → ∞`. The general layer asks only for
-analyticity of the cusp function at `0` (with periodicity for the limit); the corollaries
-specialize to modular forms. These are the analytic inputs of the norm step of the
+the limit of the function's values along `Im τ → ∞`. The general layer asks only what each
+statement needs: analyticity of the cusp function at `0` for the two dictionary directions,
+and mere continuity there — with periodicity — for the limit. The corollaries specialize to
+modular forms. These are the analytic inputs of the norm step of the
 general-level valence reduction: growth bounds are multiplicative, so they transport
 coefficient vanishing through the norm map to level one.
 
@@ -23,8 +24,8 @@ coefficient vanishing through the norm map to level one.
 * `TauCeti.UpperHalfPlane.cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero` and
   `TauCeti.UpperHalfPlane.qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow`: the two
   directions of the dictionary, for any function whose cusp function is analytic at `0`.
-* `TauCeti.UpperHalfPlane.tendsto_valueAtInfty`: an `h`-periodic function with cusp
-  function analytic at `0` tends to `valueAtInfty` along `atImInfty`.
+* `TauCeti.UpperHalfPlane.tendsto_valueAtInfty`: an `h`-periodic function whose cusp
+  function is merely continuous at `0` tends to `valueAtInfty` along `atImInfty`.
 * The `TauCeti.ModularFormClass` corollaries of all three, for a modular form on a
   subgroup with `h` in its strict period set.
 
@@ -48,8 +49,8 @@ noncomputable section
 
 variable {h : ℝ} {f : ℍ → ℂ}
 
-/-- A function on `ℍ` that is `h`-periodic with cusp function analytic at `0` tends to
-`valueAtInfty` along `atImInfty`. -/
+/-- A function on `ℍ` that is `h`-periodic and whose cusp function is continuous at `0`
+tends to `valueAtInfty` along `atImInfty`. -/
 public lemma tendsto_valueAtInfty (hh : 0 < h) (hper : Function.Periodic (f ∘ ofComplex) h)
     (hcont : ContinuousAt (cuspFunction h f) 0) :
     Tendsto f atImInfty (𝓝 (valueAtInfty f)) := by

--- a/TauCeti/NumberTheory/ModularForms/QExpansion/BigO.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/BigO.lean
@@ -46,18 +46,21 @@ namespace TauCeti.UpperHalfPlane
 
 noncomputable section
 
-variable {h : ℝ} {F : Type*} [FunLike F ℍ ℂ] {f : F}
+variable {h : ℝ} {f : ℍ → ℂ}
 
 /-- A function on `ℍ` that is `h`-periodic with cusp function analytic at `0` tends to
 `valueAtInfty` along `atImInfty`. -/
-public lemma tendsto_valueAtInfty (hh : 0 < h) (hper : Function.Periodic (⇑f ∘ ofComplex) h)
-    (hfanalytic : AnalyticAt ℂ (cuspFunction h f) 0) :
-    Tendsto (fun τ : ℍ ↦ f τ) atImInfty (𝓝 (valueAtInfty f)) := by
-  have ht : Tendsto (fun τ : ℍ ↦ f τ) atImInfty (𝓝 (cuspFunction h f 0)) := by
-    refine Filter.Tendsto.congr (fun τ ↦ ?_)
-      ((hfanalytic.continuousAt.tendsto).comp (qParam_tendsto_atImInfty hh))
+public lemma tendsto_valueAtInfty (hh : 0 < h) (hper : Function.Periodic (f ∘ ofComplex) h)
+    (hcont : ContinuousAt (cuspFunction h f) 0) :
+    Tendsto f atImInfty (𝓝 (valueAtInfty f)) := by
+  have ht : Tendsto f atImInfty (𝓝 (cuspFunction h f 0)) := by
+    refine Filter.Tendsto.congr (fun τ ↦ ?_) (hcont.tendsto.comp (qParam_tendsto_atImInfty hh))
     simpa using eq_cuspFunction τ hh.ne' hper
-  simpa [cuspFunction_apply_zero hh hfanalytic hper] using ht
+  simpa [valueAtInfty, ht.limUnder_eq] using ht
+
+section PowerSeries
+
+variable {F : Type*} [FunLike F ℍ ℂ] {f : F}
 
 /-- The power series of the cusp function at `0` is the `q`-expansion. -/
 private lemma hasFPowerSeriesAt_cuspFunction (hfanalytic : AnalyticAt ℂ (cuspFunction h f) 0) :
@@ -112,6 +115,8 @@ public lemma qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow
     qExpansionFormalMultilinearSeries_coeff] using
     hhom.continuousMultilinearMap_apply_eq_zero 1
 
+end PowerSeries
+
 end
 
 end TauCeti.UpperHalfPlane
@@ -126,7 +131,8 @@ public lemma tendsto_valueAtInfty [ModularFormClass F Γ k] (f : F) (hh : 0 < h)
     Tendsto (fun τ : ℍ ↦ f τ) atImInfty (𝓝 (valueAtInfty f)) :=
   TauCeti.UpperHalfPlane.tendsto_valueAtInfty hh
     (SlashInvariantFormClass.periodic_comp_ofComplex (k := k) f hΓ)
-    (_root_.ModularFormClass.analyticAt_cuspFunction_zero (F := F) (k := k) (f := f) hh hΓ)
+    (_root_.ModularFormClass.analyticAt_cuspFunction_zero (F := F) (k := k) (f := f)
+      hh hΓ).continuousAt
 
 /-- If the first `N` `q`-coefficients of a modular form vanish, then its cusp function is
 `O(‖q‖^N)` near `0`. -/

--- a/TauCeti/NumberTheory/ModularForms/QExpansion/BigO.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/BigO.lean
@@ -27,9 +27,12 @@ map to level one goes via the growth bound, which is multiplicative.
 
 ## References
 
-Ported from AINTLIB's `SpherePacking.ModularForms` auxiliary layer
+Ported from AINTLIB's `LeanModularForms` project
 ([github.com/CBirkbeck/AINTLIB](https://github.com/CBirkbeck/AINTLIB), commit `2baa76f742`,
-Apache 2.0, `Modularforms/DimGenCongLevels/Auxiliary.lean`).
+Apache 2.0, the file
+`projects/LeanModularForms/LeanModularForms/Modularforms/DimGenCongLevels/Auxiliary.lean`),
+with the converse direction reproved through Mathlib's power-series uniqueness machinery
+instead of the source's circle-integral bounds.
 -/
 
 namespace TauCeti.ModularForm
@@ -75,82 +78,49 @@ public lemma cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero
       simp [hcoeff n (by simpa [Finset.mem_range] using hn)]
   simpa [zero_add, hps] using hFPS.isBigO_sub_partialSum_pow N
 
-private lemma norm_cuspFunction_div_pow_le_of_ball_bound
-    (f : F) {C' δ : ℝ} {N n : ℕ} (hn : n < N) (hC' : 0 ≤ C')
-    (hδ : Metric.ball (0 : ℂ) δ ⊆ {z | ‖cuspFunction h f z‖ ≤ C' * ‖z‖ ^ N})
-    {R : ℝ} (hR0 : 0 < R) (hRltδ : R < δ) (hRlt1 : R < 1) {z : ℂ}
-    (hz : z ∈ Metric.sphere (0 : ℂ) R) :
-    ‖cuspFunction h f z / z ^ (n + 1)‖ ≤ C' := by
-  have hzR : ‖z‖ = R := by simpa [mem_sphere_zero_iff_norm] using hz
-  have hcz : ‖cuspFunction h f z‖ ≤ C' * ‖z‖ ^ N :=
-    hδ (by simpa [Metric.mem_ball, dist_zero_right, hzR] using hRltδ)
-  have hpow_le : ‖z‖ ^ N ≤ ‖z‖ ^ (n + 1) :=
-    pow_le_pow_of_le_one (norm_nonneg _) (by simpa [hzR] using hRlt1.le)
-      (Nat.succ_le_of_lt hn)
-  calc
-    ‖cuspFunction h f z / z ^ (n + 1)‖
-        = ‖cuspFunction h f z‖ / ‖z‖ ^ (n + 1) := by simp only [norm_div, norm_pow]
-    _ ≤ (C' * ‖z‖ ^ (n + 1)) / ‖z‖ ^ (n + 1) := by
-      gcongr
-      exact hcz.trans (by gcongr)
-    _ = C' := by
-      have hz_norm_ne : (‖z‖ : ℝ) ≠ 0 := by simpa [hzR] using hR0.ne'
-      field_simp
-
-private lemma norm_circleIntegral_cuspFunction_div_pow_le
-    (f : F) {C' δ : ℝ} {N n : ℕ} (hn : n < N) (hC' : 0 ≤ C')
-    (hδ : Metric.ball (0 : ℂ) δ ⊆ {z | ‖cuspFunction h f z‖ ≤ C' * ‖z‖ ^ N})
-    {R : ℝ} (hR0 : 0 < R) (hRltδ : R < δ) (hRlt1 : R < 1) :
-    ‖∮ (z : ℂ) in C(0, R), cuspFunction h f z / z ^ (n + 1)‖ ≤ 2 * π * R * C' :=
-  circleIntegral.norm_integral_le_of_norm_le_const hR0.le fun _ hz ↦
-    norm_cuspFunction_div_pow_le_of_ball_bound (f := f) hn hC' hδ hR0 hRltδ hRlt1 hz
-
 /-- If `cuspFunction h f = O(‖q‖^N)` near `0`, then the `n`-th `q`-coefficient vanishes for
-`n < N`. -/
+`n < N`: by strong induction the partial sum of order `n + 1` reduces to the `n`-th
+homogeneous term, which is then dominated by `‖q‖ ^ (n + 1)` and must vanish. -/
 public lemma qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow
     [ModularFormClass F Γ k]
     (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) {N n : ℕ} (hn : n < N)
     (hO : cuspFunction h f =O[𝓝 (0 : ℂ)] (fun q : ℂ ↦ ‖q‖ ^ N)) :
     (qExpansion h f).coeff n = 0 := by
-  rcases Asymptotics.isBigO_iff.1 hO with ⟨C, hC⟩
-  set C' : ℝ := max C 1
-  have hC'pos : 0 < C' :=
-    lt_of_lt_of_le (by norm_num : (0 : ℝ) < 1) (le_max_right _ _)
-  have hC' : ∀ᶠ q : ℂ in 𝓝 (0 : ℂ), ‖cuspFunction h f q‖ ≤ C' * ‖q‖ ^ N := by
-    filter_upwards [hC] with q hq
-    refine (by simpa using hq : ‖cuspFunction h f q‖ ≤ C * ‖q‖ ^ N).trans ?_
-    gcongr
-    exact le_max_left _ _
-  rcases Metric.mem_nhds_iff.1 hC' with ⟨δ, hδ0, hδ⟩
-  by_contra hne
-  set ε : ℝ := ‖(qExpansion h f).coeff n‖ / 2
-  have hε : 0 < ε := half_pos (norm_pos_iff.2 hne)
-  set K : ℝ := ‖((2 * π * Complex.I : ℂ)⁻¹)‖ * (2 * π * C')
-  have hKpos : 0 < K :=
-    mul_pos (by simp [Real.pi_ne_zero]) (by positivity)
-  set R : ℝ := min (δ / 2) (min (1 / 2) (ε / (2 * K)))
-  have hR0 : 0 < R :=
-    lt_min (by linarith) (lt_min (by norm_num) (div_pos hε (by positivity)))
-  have hRltδ : R < δ := (min_le_left _ _).trans_lt (by linarith)
-  have hRlt1 : R < 1 := ((min_le_right _ _).trans (min_le_left _ _)).trans_lt (by norm_num)
-  have hRle : R ≤ ε / (2 * K) := (min_le_right _ _).trans (min_le_right _ _)
-  have hbound_int :
-      ‖∮ (z : ℂ) in C(0, R), cuspFunction h f z / z ^ (n + 1)‖ ≤ 2 * π * R * C' :=
-    norm_circleIntegral_cuspFunction_div_pow_le (f := f) hn hC'pos.le hδ hR0 hRltδ hRlt1
   have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
   have hper := SlashInvariantFormClass.periodic_comp_ofComplex f hΓ
-  have hcoeff_le : ‖(qExpansion h f).coeff n‖ ≤ K * R := by
-    rw [qExpansion_coeff_eq_circleIntegral (f := (f : ℍ → ℂ)) hh hper
-      (ModularFormClass.holo f) (ModularFormClass.bdd_at_infty f) n hR0 hRlt1]
-    have := mul_le_mul_of_nonneg_left hbound_int (norm_nonneg ((2 * π * Complex.I : ℂ)⁻¹))
-    simpa [norm_mul, K, mul_assoc, mul_left_comm, mul_comm] using this
-  have hRlt : R < ε / K :=
-    hRle.trans_lt (div_lt_div_of_pos_left hε hKpos (by nlinarith [hKpos]))
-  have hKRlt : K * R < ε := by
-    have h := mul_lt_mul_of_pos_left hRlt hKpos
-    rwa [mul_div_cancel₀ _ hKpos.ne'] at h
-  have : ‖(qExpansion h f).coeff n‖ < ‖(qExpansion h f).coeff n‖ / 2 := hcoeff_le.trans_lt hKRlt
-  linarith [norm_nonneg ((qExpansion h f).coeff n)]
+  have hFPS : HasFPowerSeriesAt (cuspFunction h f)
+      (qExpansionFormalMultilinearSeries (F := F) h f) 0 :=
+    (hasFPowerSeries_cuspFunction (F := F) f hh
+      (ModularFormClass.analyticAt_cuspFunction_zero (f := f) hh hΓ)
+      (fun τ ↦ hasSum_qExpansion hh hper (ModularFormClass.holo f)
+        (ModularFormClass.bdd_at_infty f) τ)).hasFPowerSeriesAt
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+  have hON : cuspFunction h f =O[𝓝 (0 : ℂ)] fun q : ℂ ↦ ‖q‖ ^ (n + 1) := by
+    refine hO.trans (Asymptotics.isBigO_iff.mpr ⟨1, ?_⟩)
+    filter_upwards [Metric.ball_mem_nhds (0 : ℂ) one_pos] with q hq
+    simpa [abs_of_nonneg (norm_nonneg q)] using
+      pow_le_pow_of_le_one (norm_nonneg q) (mem_ball_zero_iff.mp hq).le hn
+  have hps : ∀ y : ℂ,
+      (qExpansionFormalMultilinearSeries (F := F) h f).partialSum (n + 1) y =
+        y ^ n • (qExpansion h f).coeff n := by
+    intro y
+    rw [FormalMultilinearSeries.partialSum, Finset.sum_range_succ, Finset.sum_eq_zero
+      (fun m hm ↦ by
+        simp [ih m (Finset.mem_range.mp hm) ((Finset.mem_range.mp hm).trans hn)]),
+      zero_add, FormalMultilinearSeries.apply_eq_pow_smul_coeff,
+      qExpansionFormalMultilinearSeries_coeff]
+  have hhom : (fun y : ℂ ↦ qExpansionFormalMultilinearSeries (F := F) h f n fun _ ↦ y)
+      =O[𝓝 (0 : ℂ)] fun y : ℂ ↦ ‖y‖ ^ (n + 1) := by
+    have hsub := hFPS.isBigO_sub_partialSum_pow (n + 1)
+    simp only [zero_add] at hsub
+    refine (hON.sub hsub).congr_left fun y ↦ ?_
+    rw [hps, FormalMultilinearSeries.apply_eq_pow_smul_coeff,
+      qExpansionFormalMultilinearSeries_coeff]
+    ring
+  simpa [FormalMultilinearSeries.apply_eq_pow_smul_coeff,
+    qExpansionFormalMultilinearSeries_coeff] using
+    hhom.continuousMultilinearMap_apply_eq_zero 1
 
 end
 

--- a/TauCeti/NumberTheory/ModularForms/QExpansionBigO.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansionBigO.lean
@@ -42,8 +42,8 @@ noncomputable section
 variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {h : ℝ} {F : Type*} [FunLike F ℍ ℂ]
 
 /-- Values of a modular form tend to `valueAtInfty` along `atImInfty`. -/
-public lemma modularForm_tendsto_valueAtInfty [ModularFormClass F Γ k] [Γ.HasDetPlusMinusOne]
-    [DiscreteTopology Γ] (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) :
+public lemma modularForm_tendsto_valueAtInfty [ModularFormClass F Γ k]
+    (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) :
     Tendsto (fun τ : ℍ ↦ f τ) atImInfty (𝓝 (valueAtInfty f)) := by
   have hAn := ModularFormClass.analyticAt_cuspFunction_zero (f := f) hh hΓ
   have hper := SlashInvariantFormClass.periodic_comp_ofComplex f hΓ
@@ -56,7 +56,7 @@ public lemma modularForm_tendsto_valueAtInfty [ModularFormClass F Γ k] [Γ.HasD
 /-- If the first `N` `q`-coefficients vanish, then the cusp function is `O(‖q‖^N)` near
 `0`. -/
 public lemma cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero
-    [ModularFormClass F Γ k] [Γ.HasDetPlusMinusOne] [DiscreteTopology Γ]
+    [ModularFormClass F Γ k]
     (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (N : ℕ)
     (hcoeff : ∀ n < N, (qExpansion h f).coeff n = 0) :
     cuspFunction h f =O[𝓝 (0 : ℂ)] (fun q : ℂ ↦ ‖q‖ ^ N) := by
@@ -76,7 +76,6 @@ public lemma cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero
   simpa [zero_add, hps] using hFPS.isBigO_sub_partialSum_pow N
 
 private lemma norm_cuspFunction_div_pow_le_of_ball_bound
-    [ModularFormClass F Γ k] [Γ.HasDetPlusMinusOne] [DiscreteTopology Γ]
     (f : F) {C' δ : ℝ} {N n : ℕ} (hn : n < N) (hC' : 0 ≤ C')
     (hδ : Metric.ball (0 : ℂ) δ ⊆ {z | ‖cuspFunction h f z‖ ≤ C' * ‖z‖ ^ N})
     {R : ℝ} (hR0 : 0 < R) (hRltδ : R < δ) (hRlt1 : R < 1) {z : ℂ}
@@ -99,7 +98,6 @@ private lemma norm_cuspFunction_div_pow_le_of_ball_bound
       field_simp
 
 private lemma norm_circleIntegral_cuspFunction_div_pow_le
-    [ModularFormClass F Γ k] [Γ.HasDetPlusMinusOne] [DiscreteTopology Γ]
     (f : F) {C' δ : ℝ} {N n : ℕ} (hn : n < N) (hC' : 0 ≤ C')
     (hδ : Metric.ball (0 : ℂ) δ ⊆ {z | ‖cuspFunction h f z‖ ≤ C' * ‖z‖ ^ N})
     {R : ℝ} (hR0 : 0 < R) (hRltδ : R < δ) (hRlt1 : R < 1) :

--- a/TauCeti/NumberTheory/ModularForms/QExpansionBigO.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansionBigO.lean
@@ -108,7 +108,7 @@ private lemma norm_circleIntegral_cuspFunction_div_pow_le
 /-- If `cuspFunction h f = O(‖q‖^N)` near `0`, then the `n`-th `q`-coefficient vanishes for
 `n < N`. -/
 public lemma qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow
-    [ModularFormClass F Γ k] [Γ.HasDetPlusMinusOne] [DiscreteTopology Γ]
+    [ModularFormClass F Γ k]
     (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) {N n : ℕ} (hn : n < N)
     (hO : cuspFunction h f =O[𝓝 (0 : ℂ)] (fun q : ℂ ↦ ‖q‖ ^ N)) :
     (qExpansion h f).coeff n = 0 := by

--- a/TauCeti/NumberTheory/ModularForms/QExpansionBigO.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansionBigO.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.ModularForms.QExpansion
+
+/-!
+# `q`-coefficient vanishing and cusp-function growth
+
+The dictionary between vanishing of the first `N` `q`-coefficients of a modular form and
+`O(‖q‖^N)` growth of its cusp function at `0`, in both directions, together with the limit
+of the form's values along `Im τ → ∞`. These are the analytic inputs of the norm step of
+the general-level valence reduction: transporting coefficient vanishing through the norm
+map to level one goes via the growth bound, which is multiplicative.
+
+## Main declarations
+
+* `TauCeti.ModularForm.modularForm_tendsto_valueAtInfty`: values of a modular form tend to
+  `valueAtInfty` along `atImInfty`.
+* `TauCeti.ModularForm.cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero`: if the first
+  `N` `q`-coefficients vanish, the cusp function is `O(‖q‖^N)` near `0`.
+* `TauCeti.ModularForm.qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow`: conversely,
+  an `O(‖q‖^N)` bound kills the `n`-th coefficient for every `n < N`.
+
+## References
+
+Ported from AINTLIB's `SpherePacking.ModularForms` auxiliary layer
+([github.com/CBirkbeck/AINTLIB](https://github.com/CBirkbeck/AINTLIB), commit `2baa76f742`,
+Apache 2.0, `Modularforms/DimGenCongLevels/Auxiliary.lean`).
+-/
+
+namespace TauCeti.ModularForm
+
+open scoped Topology Real
+open UpperHalfPlane Filter
+
+noncomputable section
+
+variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {h : ℝ} {F : Type*} [FunLike F ℍ ℂ]
+
+/-- Values of a modular form tend to `valueAtInfty` along `atImInfty`. -/
+public lemma modularForm_tendsto_valueAtInfty [ModularFormClass F Γ k] [Γ.HasDetPlusMinusOne]
+    [DiscreteTopology Γ] (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) :
+    Tendsto (fun τ : ℍ ↦ f τ) atImInfty (𝓝 (valueAtInfty f)) := by
+  have hAn := ModularFormClass.analyticAt_cuspFunction_zero (f := f) hh hΓ
+  have hper := SlashInvariantFormClass.periodic_comp_ofComplex f hΓ
+  have ht : Tendsto (fun τ : ℍ ↦ f τ) atImInfty (𝓝 (cuspFunction h f 0)) := by
+    refine Filter.Tendsto.congr (fun τ ↦ ?_)
+      ((hAn.continuousAt.tendsto).comp (UpperHalfPlane.qParam_tendsto_atImInfty hh))
+    simpa using (SlashInvariantFormClass.eq_cuspFunction (f := f) (h := h) τ hΓ hh.ne')
+  simpa [UpperHalfPlane.cuspFunction_apply_zero hh hAn hper] using ht
+
+/-- If the first `N` `q`-coefficients vanish, then the cusp function is `O(‖q‖^N)` near
+`0`. -/
+public lemma cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero
+    [ModularFormClass F Γ k] [Γ.HasDetPlusMinusOne] [DiscreteTopology Γ]
+    (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (N : ℕ)
+    (hcoeff : ∀ n < N, (qExpansion h f).coeff n = 0) :
+    cuspFunction h f =O[𝓝 (0 : ℂ)] (fun q : ℂ ↦ ‖q‖ ^ N) := by
+  have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
+  have hper := SlashInvariantFormClass.periodic_comp_ofComplex f hΓ
+  have hAn := ModularFormClass.analyticAt_cuspFunction_zero (f := f) hh hΓ
+  have hhol := ModularFormClass.holo f
+  have hbdd := ModularFormClass.bdd_at_infty f
+  have hFPS : HasFPowerSeriesAt (cuspFunction h f)
+      (qExpansionFormalMultilinearSeries (F := F) h f) 0 :=
+    (hasFPowerSeries_cuspFunction (F := F) f hh hAn
+      (fun τ ↦ hasSum_qExpansion hh hper hhol hbdd τ)).hasFPowerSeriesAt
+  have hps : (qExpansionFormalMultilinearSeries (F := F) h f).partialSum N = 0 := by
+    ext q
+    exact Finset.sum_eq_zero fun n hn ↦ by
+      simp [hcoeff n (by simpa [Finset.mem_range] using hn)]
+  simpa [zero_add, hps] using hFPS.isBigO_sub_partialSum_pow N
+
+private lemma norm_cuspFunction_div_pow_le_of_ball_bound
+    [ModularFormClass F Γ k] [Γ.HasDetPlusMinusOne] [DiscreteTopology Γ]
+    (f : F) {C' δ : ℝ} {N n : ℕ} (hn : n < N) (hC' : 0 ≤ C')
+    (hδ : Metric.ball (0 : ℂ) δ ⊆ {z | ‖cuspFunction h f z‖ ≤ C' * ‖z‖ ^ N})
+    {R : ℝ} (hR0 : 0 < R) (hRltδ : R < δ) (hRlt1 : R < 1) {z : ℂ}
+    (hz : z ∈ Metric.sphere (0 : ℂ) R) :
+    ‖cuspFunction h f z / z ^ (n + 1)‖ ≤ C' := by
+  have hzR : ‖z‖ = R := by simpa [mem_sphere_zero_iff_norm] using hz
+  have hcz : ‖cuspFunction h f z‖ ≤ C' * ‖z‖ ^ N :=
+    hδ (by simpa [Metric.mem_ball, dist_zero_right, hzR] using hRltδ)
+  have hpow_le : ‖z‖ ^ N ≤ ‖z‖ ^ (n + 1) :=
+    pow_le_pow_of_le_one (norm_nonneg _) (by simpa [hzR] using hRlt1.le)
+      (Nat.succ_le_of_lt hn)
+  calc
+    ‖cuspFunction h f z / z ^ (n + 1)‖
+        = ‖cuspFunction h f z‖ / ‖z‖ ^ (n + 1) := by simp only [norm_div, norm_pow]
+    _ ≤ (C' * ‖z‖ ^ (n + 1)) / ‖z‖ ^ (n + 1) := by
+      gcongr
+      exact hcz.trans (by gcongr)
+    _ = C' := by
+      have hz_norm_ne : (‖z‖ : ℝ) ≠ 0 := by simpa [hzR] using hR0.ne'
+      field_simp
+
+private lemma norm_circleIntegral_cuspFunction_div_pow_le
+    [ModularFormClass F Γ k] [Γ.HasDetPlusMinusOne] [DiscreteTopology Γ]
+    (f : F) {C' δ : ℝ} {N n : ℕ} (hn : n < N) (hC' : 0 ≤ C')
+    (hδ : Metric.ball (0 : ℂ) δ ⊆ {z | ‖cuspFunction h f z‖ ≤ C' * ‖z‖ ^ N})
+    {R : ℝ} (hR0 : 0 < R) (hRltδ : R < δ) (hRlt1 : R < 1) :
+    ‖∮ (z : ℂ) in C(0, R), cuspFunction h f z / z ^ (n + 1)‖ ≤ 2 * π * R * C' :=
+  circleIntegral.norm_integral_le_of_norm_le_const hR0.le fun _ hz ↦
+    norm_cuspFunction_div_pow_le_of_ball_bound (f := f) hn hC' hδ hR0 hRltδ hRlt1 hz
+
+/-- If `cuspFunction h f = O(‖q‖^N)` near `0`, then the `n`-th `q`-coefficient vanishes for
+`n < N`. -/
+public lemma qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow
+    [ModularFormClass F Γ k] [Γ.HasDetPlusMinusOne] [DiscreteTopology Γ]
+    (f : F) (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) {N n : ℕ} (hn : n < N)
+    (hO : cuspFunction h f =O[𝓝 (0 : ℂ)] (fun q : ℂ ↦ ‖q‖ ^ N)) :
+    (qExpansion h f).coeff n = 0 := by
+  rcases Asymptotics.isBigO_iff.1 hO with ⟨C, hC⟩
+  set C' : ℝ := max C 1
+  have hC'pos : 0 < C' :=
+    lt_of_lt_of_le (by norm_num : (0 : ℝ) < 1) (le_max_right _ _)
+  have hC' : ∀ᶠ q : ℂ in 𝓝 (0 : ℂ), ‖cuspFunction h f q‖ ≤ C' * ‖q‖ ^ N := by
+    filter_upwards [hC] with q hq
+    refine (by simpa using hq : ‖cuspFunction h f q‖ ≤ C * ‖q‖ ^ N).trans ?_
+    gcongr
+    exact le_max_left _ _
+  rcases Metric.mem_nhds_iff.1 hC' with ⟨δ, hδ0, hδ⟩
+  by_contra hne
+  set ε : ℝ := ‖(qExpansion h f).coeff n‖ / 2
+  have hε : 0 < ε := half_pos (norm_pos_iff.2 hne)
+  set K : ℝ := ‖((2 * π * Complex.I : ℂ)⁻¹)‖ * (2 * π * C')
+  have hKpos : 0 < K :=
+    mul_pos (by simp [Real.pi_ne_zero]) (by positivity)
+  set R : ℝ := min (δ / 2) (min (1 / 2) (ε / (2 * K)))
+  have hR0 : 0 < R :=
+    lt_min (by linarith) (lt_min (by norm_num) (div_pos hε (by positivity)))
+  have hRltδ : R < δ := (min_le_left _ _).trans_lt (by linarith)
+  have hRlt1 : R < 1 := ((min_le_right _ _).trans (min_le_left _ _)).trans_lt (by norm_num)
+  have hRle : R ≤ ε / (2 * K) := (min_le_right _ _).trans (min_le_right _ _)
+  have hbound_int :
+      ‖∮ (z : ℂ) in C(0, R), cuspFunction h f z / z ^ (n + 1)‖ ≤ 2 * π * R * C' :=
+    norm_circleIntegral_cuspFunction_div_pow_le (f := f) hn hC'pos.le hδ hR0 hRltδ hRlt1
+  have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
+  have hper := SlashInvariantFormClass.periodic_comp_ofComplex f hΓ
+  have hcoeff_le : ‖(qExpansion h f).coeff n‖ ≤ K * R := by
+    rw [qExpansion_coeff_eq_circleIntegral (f := (f : ℍ → ℂ)) hh hper
+      (ModularFormClass.holo f) (ModularFormClass.bdd_at_infty f) n hR0 hRlt1]
+    have := mul_le_mul_of_nonneg_left hbound_int (norm_nonneg ((2 * π * Complex.I : ℂ)⁻¹))
+    simpa [norm_mul, K, mul_assoc, mul_left_comm, mul_comm] using this
+  have hRlt : R < ε / K :=
+    hRle.trans_lt (div_lt_div_of_pos_left hε hKpos (by nlinarith [hKpos]))
+  have hKRlt : K * R < ε := by
+    have h := mul_lt_mul_of_pos_left hRlt hKpos
+    rwa [mul_div_cancel₀ _ hKpos.ne'] at h
+  have : ‖(qExpansion h f).coeff n‖ < ‖(qExpansion h f).coeff n‖ / 2 := hcoeff_le.trans_lt hKRlt
+  linarith [norm_nonneg ((qExpansion h f).coeff n)]
+
+end
+
+end TauCeti.ModularForm


### PR DESCRIPTION
Roadmap: ModularForms
<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-formula/general-level-qexpansion-bigo"}-->

## Summary

The analytic half of the norm step in the ModularForms roadmap's Layer 1 (the general-level
valence reduction, `README.md` § "Layer 1"): the dictionary between vanishing of the first
`N` `q`-coefficients of a modular form and `O(‖q‖^N)` growth of its cusp function at `0`.
One new file, `NumberTheory/ModularForms/QExpansion/BigO.lean`:

Two layers. The general one, in `TauCeti.UpperHalfPlane`, asks only that the cusp function
be analytic at `0` (plus periodicity for the limit):

- `tendsto_valueAtInfty` — an `h`-periodic function tends to `valueAtInfty` along
  `Im τ → ∞`;
- `cuspFunction_isBigO_pow_of_qExpansion_coeff_eq_zero` — coefficient vanishing gives the
  growth bound, via the `q`-expansion power series;
- `qExpansion_coeff_eq_zero_of_cuspFunction_isBigO_pow` — conversely the growth bound kills
  each earlier coefficient, by strong induction through Mathlib's power-series uniqueness
  lemma `Asymptotics.IsBigO.continuousMultilinearMap_apply_eq_zero`.

The `TauCeti.ModularFormClass` corollaries then specialize all three to a modular form on a
subgroup with `h` in its strict period set, discharging analyticity and periodicity from
`analyticAt_cuspFunction_zero` and `periodic_comp_ofComplex`.

Independent of #3179 (no shared files); the follow-up transfer PR consumes both: growth
bounds are multiplicative, so they transport coefficient vanishing through the norm map.

## Provenance

Provenance: github.com/CBirkbeck/AINTLIB @ 2baa76f742bdb4fb8ee323fabba41203bd390e08,
Apache 2.0, `projects/LeanModularForms/LeanModularForms/Modularforms/DimGenCongLevels/Auxiliary.lean`
(ported in full; the source file is fully proven, zero sorries). Consumes Mathlib's
`QExpansion` API (`qExpansion_coeff_eq_circleIntegral`, `hasFPowerSeries_cuspFunction`,
`qExpansionFormalMultilinearSeries`); the dictionary itself is absent at the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


