### PR TITLE
feat: a map with Fredholm derivative is proper near the point

### DIFF
--- a/TauCeti/Analysis/Fredholm/Estimate.lean
+++ b/TauCeti/Analysis/Fredholm/Estimate.lean
@@ -4,159 +4,47 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Analysis.Normed.Operator.Banach
 public import TauCeti.Analysis.Fredholm.Basic
+public import TauCeti.Analysis.Normed.Operator.ClosedRange
 
 /-!
-# The a priori estimate of a closed-range operator
+# The a priori estimate of a Fredholm operator
 
-A continuous linear map `T : E →L[𝕜] F` between Banach spaces with closed range fails to be
-bounded below only in the direction of its kernel. When that kernel is complemented, this file
-makes the failure quantitative, in the classical form
+A Fredholm operator `T : E →L[𝕜] F` has closed range and a finite-dimensional, topologically
+complemented kernel, so the general estimate of `TauCeti.Analysis.Normed.Operator.ClosedRange`
+applies to it: there is a continuous projection `P` of `E` onto `ker T` and a constant `C > 0` with
 
-`‖x‖ ≤ C * ‖T x‖ + ‖P x‖`,
+`‖x‖ ≤ C * ‖T x‖ + ‖P x‖`.
 
-where `P` is a continuous projection of `E` onto `ker T`. For a Fredholm operator the kernel is
-finite-dimensional, so the estimate turns an operator bound into a compactness statement: the
-correction term ranges over a finite-dimensional — hence locally compact — direction.
-
-The proof is one application of the open mapping theorem, in the packaged form
-`ContinuousLinearMap.antilipschitz_of_injective_of_isClosed_range`: on a topological complement
-`X₁` of the kernel, `T` is injective with closed range, so it is bounded below there. Mathlib's
-file carries a `TODO` asking for exactly this generalisation once Fredholm operators are available.
+Because `ker T` is finite-dimensional, the correction term `‖P x‖` ranges over a locally compact
+direction; this is what makes the estimate a compactness statement rather than a mere operator
+bound, and it is the linear input to Smale's local properness lemma, which
+`TauCeti.Analysis.Fredholm.Proper` reads off the same estimate.
 
 ## Main declarations
 
-* `ContinuousLinearMap.exists_norm_le_mul_norm_of_mem`: a closed-range operator is bounded below
-  on any topological complement of its kernel.
-* `ContinuousLinearMap.exists_norm_le_mul_norm_add_norm_projectionL`: the a priori estimate
-  against the projection onto the kernel determined by a chosen complement.
-* `ContinuousLinearMap.exists_projection_norm_le`: the same estimate with the
-  complement discharged, so that the only data left is a continuous projection with range the
-  kernel.
-
-Lane F0 of the analytic Heegaard Floer roadmap asks for the nonlinear-analysis substrate over the
-linear Fredholm theory, and `TauCeti.Analysis.Fredholm.Proper` uses the estimate below to prove
-that a map with Fredholm derivative is proper near a point (Smale, *An infinite dimensional version
-of Sard's theorem*, Amer. J. Math. 87 (1965)); local properness is in turn what makes the critical
-values of such a map locally closed, and hence what upgrades Sard--Smale from a density statement
-to a residuality statement.
+* `ContinuousLinearMap.IsFredholm.exists_projection_norm_le_mul_norm_add_norm`: the a priori
+  estimate of a Fredholm operator, phrased against `ContinuousLinearMap.IsFredholm` as
+  `TauCeti.Analysis.Fredholm.Basic` prescribes.
 -/
 
 public section
 
 namespace TauCeti
 
-open Submodule
-
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
-variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-variable {T : E →L[𝕜] F} {X₁ : Submodule 𝕜 E}
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
 
-/-! ### The kernel direction is invisible to `T` -/
+/-- **The a priori estimate of a Fredholm operator**: there is a continuous projection `P` of `E`
+onto `ker T` and a constant `C > 0` with `‖x‖ ≤ C * ‖T x‖ + ‖P x‖`.
 
-/-- The projection of `E` onto `ker T` along a topological complement lands, as its name promises,
-in the kernel, so `T` kills it. -/
-@[simp]
-theorem apply_projectionL_ker (h : IsTopCompl (T.ker) X₁) (x : E) :
-    T ((T.ker).projection X₁ h.isCompl x) = 0 :=
-  LinearMap.mem_ker.1 ((T.ker).projectionOnto X₁ h.isCompl x).2
-
-/-- `T` takes the same value on `x` and on the component of `x` in a topological complement of the
-kernel. -/
-@[simp]
-theorem apply_projectionL_of_isTopCompl (h : IsTopCompl (T.ker) X₁) (x : E) :
-    T (X₁.projection (T.ker) h.symm.isCompl x) = T x := by
-  have hsum : (T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x = x :=
-    projectionL_add_projectionL_eq_self h x
-  have hadd : T ((T.ker).projectionL X₁ h x) + T (X₁.projectionL (T.ker) h.symm x) = T x := by
-    rw [← map_add, hsum]
-  have hker : T ((T.ker).projectionL X₁ h x) = 0 := by
-    simpa only [Submodule.coe_projectionL] using apply_projectionL_ker h x
-  rwa [hker, zero_add] at hadd
-
-/-- A continuous linear map restricted to a topological complement of its kernel still has the
-whole range of the map as its range: the kernel direction contributes nothing. -/
-theorem range_comp_subtypeL_of_isTopCompl (h : IsTopCompl (T.ker) X₁) :
-    Set.range (T ∘L X₁.subtypeL) = Set.range T := by
-  refine Set.Subset.antisymm (by rintro _ ⟨x, rfl⟩; exact ⟨x, rfl⟩) ?_
-  rintro _ ⟨x, rfl⟩
-  refine ⟨X₁.projectionOntoL (T.ker) h.symm x, ?_⟩
-  simpa only [ContinuousLinearMap.comp_apply, Submodule.coe_subtypeL, Submodule.coe_subtype,
-    Submodule.coe_projectionOntoL_apply, Submodule.coe_projectionL] using
-    apply_projectionL_of_isTopCompl h x
-
-/-! ### The estimate -/
-
-variable [CompleteSpace E] [CompleteSpace F]
-
-/-- **A closed-range operator is bounded below off its kernel.** On any topological complement
-`X₁` of `ker T` there is a constant `C > 0` with `‖x‖ ≤ C * ‖T x‖` for every `x ∈ X₁`.
-
-This is `ContinuousLinearMap.antilipschitz_of_injective_of_isClosed_range` applied to the
-restriction of `T` to `X₁`, which is injective because `X₁` meets the kernel trivially, and has
-closed range because that range is the range of `T`. -/
-theorem _root_.ContinuousLinearMap.exists_norm_le_mul_norm_of_mem (T : E →L[𝕜] F)
-    (hclosed : IsClosed (T.range : Set F)) (h : IsTopCompl (T.ker) X₁) :
-    ∃ C > 0, ∀ x ∈ X₁, ‖x‖ ≤ C * ‖T x‖ := by
-  have : CompleteSpace X₁ := h.isClosed'.completeSpace_coe
-  have hinj : Function.Injective (T ∘L X₁.subtypeL) := by
-    intro x y hxy
-    have hxy' : T (x : E) = T (y : E) := hxy
-    have hmem : (x : E) - (y : E) ∈ T.ker ⊓ X₁ := by
-      refine ⟨LinearMap.mem_ker.2 ?_, X₁.sub_mem x.2 y.2⟩
-      simp [map_sub, hxy']
-    rw [h.isCompl.inf_eq_bot] at hmem
-    exact Subtype.ext (sub_eq_zero.1 hmem)
-  have hclosed_restrict : IsClosed (Set.range (T ∘L X₁.subtypeL)) := by
-    rw [range_comp_subtypeL_of_isTopCompl h]
-    simpa [LinearMap.coe_range] using hclosed
-  obtain ⟨K, hK⟩ :=
-    (T ∘L X₁.subtypeL).antilipschitz_of_injective_of_isClosed_range hinj hclosed_restrict
-  refine ⟨K + 1, by positivity, fun x hx => ?_⟩
-  have hx' := hK.le_mul_dist (⟨x, hx⟩ : X₁) 0
-  simp only [ContinuousLinearMap.comp_apply, coe_subtypeL, coe_subtype, map_zero,
-    dist_eq_norm, sub_zero] at hx'
-  have hK0 : (0 : ℝ) ≤ K := K.coe_nonneg
-  calc ‖x‖ ≤ (K : ℝ) * ‖T x‖ := hx'
-    _ ≤ ((K : ℝ) + 1) * ‖T x‖ := by nlinarith [norm_nonneg (T x)]
-
-/-- **The a priori estimate of a closed-range operator**, stated against the projection onto the
-kernel along a chosen topological complement: there is a `C > 0` with
-`‖x‖ ≤ C * ‖T x‖ + ‖P x‖` for all `x`, where `P` is that projection. -/
-theorem _root_.ContinuousLinearMap.exists_norm_le_mul_norm_add_norm_projectionL
-    (T : E →L[𝕜] F) (hclosed : IsClosed (T.range : Set F)) (h : IsTopCompl (T.ker) X₁) :
-    ∃ C > 0, ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖(T.ker).projectionL X₁ h x‖ := by
-  obtain ⟨C, hC, hbound⟩ := T.exists_norm_le_mul_norm_of_mem hclosed h
-  refine ⟨C, hC, fun x => ?_⟩
-  have hsum : (T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x = x :=
-    projectionL_add_projectionL_eq_self h x
-  have hq := hbound (X₁.projectionL (T.ker) h.symm x)
-    (X₁.projectionOntoL (T.ker) h.symm x).2
-  have hTx : T (X₁.projectionL (T.ker) h.symm x) = T x := by
-    simpa only [Submodule.coe_projectionL] using apply_projectionL_of_isTopCompl h x
-  rw [hTx] at hq
-  calc ‖x‖ = ‖(T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x‖ := by rw [hsum]
-    _ ≤ ‖(T.ker).projectionL X₁ h x‖ + ‖X₁.projectionL (T.ker) h.symm x‖ := norm_add_le _ _
-    _ ≤ ‖(T.ker).projectionL X₁ h x‖ + C * ‖T x‖ := by gcongr
-    _ = C * ‖T x‖ + ‖(T.ker).projectionL X₁ h x‖ := by ring
-
-/-- **The a priori estimate of a closed-range operator with complemented kernel**, with the
-complement discharged: there is a continuous projection `P` of `E` onto `ker T` and a constant
-`C > 0` with
-`‖x‖ ≤ C * ‖T x‖ + ‖P x‖`.
-
-When `ker T` is finite-dimensional, the correction term `‖P x‖` ranges over a finite-dimensional
-space; in particular, this says that a Fredholm operator is bounded below "up to a compact
-error". -/
-theorem _root_.ContinuousLinearMap.exists_projection_norm_le (T : E →L[𝕜] F)
-    (hclosed : IsClosed (T.range : Set F)) (hcompl : T.ker.ClosedComplemented) :
+This is `ContinuousLinearMap.exists_projection_norm_le_mul_norm_add_norm`, which needs only a
+closed range and a complemented kernel, specialised to a Fredholm operator. -/
+theorem _root_.ContinuousLinearMap.IsFredholm.exists_projection_norm_le_mul_norm_add_norm
+    {T : E →L[𝕜] F} (hT : T.IsFredholm) :
     ∃ (P : E →L[𝕜] E) (C : ℝ), 0 < C ∧ IsIdempotentElem P ∧ P.range = T.ker ∧
-      ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖P x‖ := by
-  obtain ⟨X₁, h⟩ := hcompl.exists_isTopCompl
-  obtain ⟨C, hC, hbound⟩ := T.exists_norm_le_mul_norm_add_norm_projectionL hclosed h
-  exact ⟨(T.ker).projectionL X₁ h, C, hC, isIdempotentElem_projectionL h,
-    range_projectionL h, hbound⟩
+      ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖P x‖ :=
+  T.exists_projection_norm_le_mul_norm_add_norm hT.isClosed_range hT.closedComplemented_ker
 
 end TauCeti

--- a/TauCeti/Analysis/Fredholm/Estimate.lean
+++ b/TauCeti/Analysis/Fredholm/Estimate.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Normed.Operator.Banach
+public import TauCeti.Analysis.Fredholm.Basic
+
+/-!
+# The a priori estimate of a Fredholm operator
+
+A Fredholm operator `T : E →L[𝕜] F` between Banach spaces fails to be bounded below only in the
+finite-dimensional direction of its kernel. This file makes that quantitative, in the classical
+form
+
+`‖x‖ ≤ C * ‖T x‖ + ‖P x‖`,
+
+where `P` is a continuous projection of `E` onto `ker T`. The estimate is the standard *a priori
+estimate* attached to a Fredholm operator, and it is what turns an operator bound into a
+compactness statement: the correction term ranges over a finite-dimensional space, so a set on
+which `T` is bounded is bounded modulo a finite-dimensional — hence locally compact — direction.
+
+The proof is one application of the open mapping theorem, in the packaged form
+`ContinuousLinearMap.antilipschitz_of_injective_of_isClosed_range`: on a topological complement
+`X₁` of the kernel, `T` is injective with closed range, so it is bounded below there. Mathlib's
+file carries a `TODO` asking for exactly this generalisation once Fredholm operators are available.
+
+## Main declarations
+
+* `ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_of_mem`: a Fredholm operator is bounded
+  below on any topological complement of its kernel.
+* `ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_add_norm_projectionL`: the a priori
+  estimate against the projection onto the kernel determined by a chosen complement.
+* `ContinuousLinearMap.IsFredholm.exists_projection_norm_le`: the same estimate with the
+  complement discharged, so that the only data left is a continuous projection with range the
+  kernel.
+
+Lane F0 of the analytic Heegaard Floer roadmap asks for the nonlinear-analysis substrate over the
+linear Fredholm theory, and `TauCeti.Analysis.Fredholm.Proper` uses the estimate below to prove
+that a map with Fredholm derivative is proper near a point (Smale, *An infinite dimensional version
+of Sard's theorem*, Amer. J. Math. 87 (1965)); local properness is in turn what makes the critical
+values of such a map locally closed, and hence what upgrades Sard--Smale from a density statement
+to a residuality statement.
+-/
+
+public section
+
+namespace TauCeti
+
+open Submodule
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+variable {T : E →L[𝕜] F} {X₁ : Submodule 𝕜 E}
+
+/-! ### The kernel direction is invisible to `T` -/
+
+/-- The projection of `E` onto `ker T` along a topological complement lands, as its name promises,
+in the kernel, so `T` kills it. -/
+theorem apply_projectionL_ker (h : IsTopCompl (T.ker) X₁) (x : E) :
+    T ((T.ker).projectionL X₁ h x) = 0 :=
+  LinearMap.mem_ker.1 ((T.ker).projectionOntoL X₁ h x).2
+
+/-- `T` takes the same value on `x` and on the component of `x` in a topological complement of the
+kernel. -/
+theorem apply_projectionL_of_isTopCompl (h : IsTopCompl (T.ker) X₁) (x : E) :
+    T (X₁.projectionL (T.ker) h.symm x) = T x := by
+  have hsum : (T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x = x :=
+    projectionL_add_projectionL_eq_self h x
+  have hadd : T ((T.ker).projectionL X₁ h x) + T (X₁.projectionL (T.ker) h.symm x) = T x := by
+    rw [← map_add, hsum]
+  rwa [apply_projectionL_ker h, zero_add] at hadd
+
+/-- A continuous linear map restricted to a topological complement of its kernel still has the
+whole range of the map as its range: the kernel direction contributes nothing. -/
+theorem range_comp_subtypeL_of_isTopCompl (h : IsTopCompl (T.ker) X₁) :
+    Set.range (T ∘L X₁.subtypeL) = Set.range T := by
+  refine Set.Subset.antisymm (by rintro _ ⟨x, rfl⟩; exact ⟨x, rfl⟩) ?_
+  rintro _ ⟨x, rfl⟩
+  exact ⟨X₁.projectionOntoL (T.ker) h.symm x, apply_projectionL_of_isTopCompl h x⟩
+
+/-! ### The estimate -/
+
+variable [CompleteSpace E] [CompleteSpace F]
+
+/-- **A Fredholm operator is bounded below off its kernel.** On any topological complement `X₁` of
+`ker T` there is a constant `C > 0` with `‖x‖ ≤ C * ‖T x‖` for every `x ∈ X₁`.
+
+This is `ContinuousLinearMap.antilipschitz_of_injective_of_isClosed_range` applied to the
+restriction of `T` to `X₁`, which is injective because `X₁` meets the kernel trivially, and has
+closed range because that range is the range of `T`. -/
+theorem _root_.ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_of_mem
+    (hT : T.IsFredholm) (h : IsTopCompl (T.ker) X₁) :
+    ∃ C > 0, ∀ x ∈ X₁, ‖x‖ ≤ C * ‖T x‖ := by
+  have : CompleteSpace X₁ := h.isClosed'.completeSpace_coe
+  have hinj : Function.Injective (T ∘L X₁.subtypeL) := by
+    intro x y hxy
+    have hxy' : T (x : E) = T (y : E) := hxy
+    have hmem : (x : E) - (y : E) ∈ T.ker ⊓ X₁ := by
+      refine ⟨LinearMap.mem_ker.2 ?_, X₁.sub_mem x.2 y.2⟩
+      simp [map_sub, hxy']
+    rw [h.isCompl.inf_eq_bot] at hmem
+    exact Subtype.ext (sub_eq_zero.1 hmem)
+  have hclosed : IsClosed (Set.range (T ∘L X₁.subtypeL)) := by
+    rw [range_comp_subtypeL_of_isTopCompl h]
+    simpa [LinearMap.coe_range] using hT.isClosed_range
+  obtain ⟨K, hK⟩ := (T ∘L X₁.subtypeL).antilipschitz_of_injective_of_isClosed_range hinj hclosed
+  refine ⟨K + 1, by positivity, fun x hx => ?_⟩
+  have hx' := hK.le_mul_dist (⟨x, hx⟩ : X₁) 0
+  simp only [ContinuousLinearMap.comp_apply, coe_subtypeL, coe_subtype, map_zero,
+    dist_eq_norm, sub_zero] at hx'
+  have hK0 : (0 : ℝ) ≤ K := K.coe_nonneg
+  calc ‖x‖ ≤ (K : ℝ) * ‖T x‖ := hx'
+    _ ≤ ((K : ℝ) + 1) * ‖T x‖ := by nlinarith [norm_nonneg (T x)]
+
+/-- **The a priori estimate of a Fredholm operator**, stated against the projection onto the kernel
+along a chosen topological complement: there is a `C > 0` with `‖x‖ ≤ C * ‖T x‖ + ‖P x‖` for all
+`x`, where `P` is that projection. -/
+theorem _root_.ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_add_norm_projectionL
+    (hT : T.IsFredholm) (h : IsTopCompl (T.ker) X₁) :
+    ∃ C > 0, ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖(T.ker).projectionL X₁ h x‖ := by
+  obtain ⟨C, hC, hbound⟩ := hT.exists_norm_le_mul_norm_of_mem h
+  refine ⟨C, hC, fun x => ?_⟩
+  have hsum : (T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x = x :=
+    projectionL_add_projectionL_eq_self h x
+  have hq := hbound (X₁.projectionL (T.ker) h.symm x)
+    (X₁.projectionOntoL (T.ker) h.symm x).2
+  rw [apply_projectionL_of_isTopCompl h] at hq
+  calc ‖x‖ = ‖(T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x‖ := by rw [hsum]
+    _ ≤ ‖(T.ker).projectionL X₁ h x‖ + ‖X₁.projectionL (T.ker) h.symm x‖ := norm_add_le _ _
+    _ ≤ ‖(T.ker).projectionL X₁ h x‖ + C * ‖T x‖ := by gcongr
+    _ = C * ‖T x‖ + ‖(T.ker).projectionL X₁ h x‖ := by ring
+
+/-- **The a priori estimate of a Fredholm operator**, with the complement discharged: there is a
+continuous projection `P` of `E` onto `ker T` and a constant `C > 0` with
+`‖x‖ ≤ C * ‖T x‖ + ‖P x‖`.
+
+Since `ker T` is finite-dimensional, the correction term `‖P x‖` ranges over a finite-dimensional
+space; this is the sense in which a Fredholm operator is bounded below "up to a compact error". -/
+theorem _root_.ContinuousLinearMap.IsFredholm.exists_projection_norm_le [CompleteSpace 𝕜]
+    (hT : T.IsFredholm) :
+    ∃ (P : E →L[𝕜] E) (C : ℝ), 0 < C ∧ P.range = T.ker ∧
+      ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖P x‖ := by
+  obtain ⟨X₁, h⟩ := hT.closedComplemented_ker.exists_isTopCompl
+  obtain ⟨C, hC, hbound⟩ := hT.exists_norm_le_mul_norm_add_norm_projectionL h
+  exact ⟨(T.ker).projectionL X₁ h, C, hC, range_projectionL h, hbound⟩
+
+end TauCeti

--- a/TauCeti/Analysis/Fredholm/Estimate.lean
+++ b/TauCeti/Analysis/Fredholm/Estimate.lean
@@ -59,19 +59,23 @@ variable {T : E →L[𝕜] F} {X₁ : Submodule 𝕜 E}
 
 /-- The projection of `E` onto `ker T` along a topological complement lands, as its name promises,
 in the kernel, so `T` kills it. -/
+@[simp]
 theorem apply_projectionL_ker (h : IsTopCompl (T.ker) X₁) (x : E) :
-    T ((T.ker).projectionL X₁ h x) = 0 :=
-  LinearMap.mem_ker.1 ((T.ker).projectionOntoL X₁ h x).2
+    T ((T.ker).projection X₁ h.isCompl x) = 0 :=
+  LinearMap.mem_ker.1 ((T.ker).projectionOnto X₁ h.isCompl x).2
 
 /-- `T` takes the same value on `x` and on the component of `x` in a topological complement of the
 kernel. -/
+@[simp]
 theorem apply_projectionL_of_isTopCompl (h : IsTopCompl (T.ker) X₁) (x : E) :
-    T (X₁.projectionL (T.ker) h.symm x) = T x := by
+    T (X₁.projection (T.ker) h.symm.isCompl x) = T x := by
   have hsum : (T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x = x :=
     projectionL_add_projectionL_eq_self h x
   have hadd : T ((T.ker).projectionL X₁ h x) + T (X₁.projectionL (T.ker) h.symm x) = T x := by
     rw [← map_add, hsum]
-  rwa [apply_projectionL_ker h, zero_add] at hadd
+  have hker : T ((T.ker).projectionL X₁ h x) = 0 := by
+    simpa only [Submodule.coe_projectionL] using apply_projectionL_ker h x
+  rwa [hker, zero_add] at hadd
 
 /-- A continuous linear map restricted to a topological complement of its kernel still has the
 whole range of the map as its range: the kernel direction contributes nothing. -/
@@ -79,7 +83,10 @@ theorem range_comp_subtypeL_of_isTopCompl (h : IsTopCompl (T.ker) X₁) :
     Set.range (T ∘L X₁.subtypeL) = Set.range T := by
   refine Set.Subset.antisymm (by rintro _ ⟨x, rfl⟩; exact ⟨x, rfl⟩) ?_
   rintro _ ⟨x, rfl⟩
-  exact ⟨X₁.projectionOntoL (T.ker) h.symm x, apply_projectionL_of_isTopCompl h x⟩
+  refine ⟨X₁.projectionOntoL (T.ker) h.symm x, ?_⟩
+  simpa only [ContinuousLinearMap.comp_apply, Submodule.coe_subtypeL, Submodule.coe_subtype,
+    Submodule.coe_projectionOntoL_apply, Submodule.coe_projectionL] using
+    apply_projectionL_of_isTopCompl h x
 
 /-! ### The estimate -/
 
@@ -127,7 +134,9 @@ theorem _root_.ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_add_norm_p
     projectionL_add_projectionL_eq_self h x
   have hq := hbound (X₁.projectionL (T.ker) h.symm x)
     (X₁.projectionOntoL (T.ker) h.symm x).2
-  rw [apply_projectionL_of_isTopCompl h] at hq
+  have hTx : T (X₁.projectionL (T.ker) h.symm x) = T x := by
+    simpa only [Submodule.coe_projectionL] using apply_projectionL_of_isTopCompl h x
+  rw [hTx] at hq
   calc ‖x‖ = ‖(T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x‖ := by rw [hsum]
     _ ≤ ‖(T.ker).projectionL X₁ h x‖ + ‖X₁.projectionL (T.ker) h.symm x‖ := norm_add_le _ _
     _ ≤ ‖(T.ker).projectionL X₁ h x‖ + C * ‖T x‖ := by gcongr
@@ -141,10 +150,11 @@ Since `ker T` is finite-dimensional, the correction term `‖P x‖` ranges over
 space; this is the sense in which a Fredholm operator is bounded below "up to a compact error". -/
 theorem _root_.ContinuousLinearMap.IsFredholm.exists_projection_norm_le
     (hT : T.IsFredholm) :
-    ∃ (P : E →L[𝕜] E) (C : ℝ), 0 < C ∧ P.range = T.ker ∧
+    ∃ (P : E →L[𝕜] E) (C : ℝ), 0 < C ∧ IsIdempotentElem P ∧ P.range = T.ker ∧
       ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖P x‖ := by
   obtain ⟨X₁, h⟩ := hT.closedComplemented_ker.exists_isTopCompl
   obtain ⟨C, hC, hbound⟩ := hT.exists_norm_le_mul_norm_add_norm_projectionL h
-  exact ⟨(T.ker).projectionL X₁ h, C, hC, range_projectionL h, hbound⟩
+  exact ⟨(T.ker).projectionL X₁ h, C, hC, isIdempotentElem_projectionL h,
+    range_projectionL h, hbound⟩
 
 end TauCeti

--- a/TauCeti/Analysis/Fredholm/Estimate.lean
+++ b/TauCeti/Analysis/Fredholm/Estimate.lean
@@ -8,18 +8,17 @@ public import Mathlib.Analysis.Normed.Operator.Banach
 public import TauCeti.Analysis.Fredholm.Basic
 
 /-!
-# The a priori estimate of a Fredholm operator
+# The a priori estimate of a closed-range operator
 
-A Fredholm operator `T : E →L[𝕜] F` between Banach spaces fails to be bounded below only in the
-finite-dimensional direction of its kernel. This file makes that quantitative, in the classical
-form
+A continuous linear map `T : E →L[𝕜] F` between Banach spaces with closed range fails to be
+bounded below only in the direction of its kernel. When that kernel is complemented, this file
+makes the failure quantitative, in the classical form
 
 `‖x‖ ≤ C * ‖T x‖ + ‖P x‖`,
 
-where `P` is a continuous projection of `E` onto `ker T`. The estimate is the standard *a priori
-estimate* attached to a Fredholm operator, and it is what turns an operator bound into a
-compactness statement: the correction term ranges over a finite-dimensional space, so a set on
-which `T` is bounded is bounded modulo a finite-dimensional — hence locally compact — direction.
+where `P` is a continuous projection of `E` onto `ker T`. For a Fredholm operator the kernel is
+finite-dimensional, so the estimate turns an operator bound into a compactness statement: the
+correction term ranges over a finite-dimensional — hence locally compact — direction.
 
 The proof is one application of the open mapping theorem, in the packaged form
 `ContinuousLinearMap.antilipschitz_of_injective_of_isClosed_range`: on a topological complement
@@ -28,11 +27,11 @@ file carries a `TODO` asking for exactly this generalisation once Fredholm opera
 
 ## Main declarations
 
-* `ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_of_mem`: a Fredholm operator is bounded
-  below on any topological complement of its kernel.
-* `ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_add_norm_projectionL`: the a priori
-  estimate against the projection onto the kernel determined by a chosen complement.
-* `ContinuousLinearMap.IsFredholm.exists_projection_norm_le`: the same estimate with the
+* `ContinuousLinearMap.exists_norm_le_mul_norm_of_mem`: a closed-range operator is bounded below
+  on any topological complement of its kernel.
+* `ContinuousLinearMap.exists_norm_le_mul_norm_add_norm_projectionL`: the a priori estimate
+  against the projection onto the kernel determined by a chosen complement.
+* `ContinuousLinearMap.exists_projection_norm_le`: the same estimate with the
   complement discharged, so that the only data left is a continuous projection with range the
   kernel.
 
@@ -92,14 +91,14 @@ theorem range_comp_subtypeL_of_isTopCompl (h : IsTopCompl (T.ker) X₁) :
 
 variable [CompleteSpace E] [CompleteSpace F]
 
-/-- **A Fredholm operator is bounded below off its kernel.** On any topological complement `X₁` of
-`ker T` there is a constant `C > 0` with `‖x‖ ≤ C * ‖T x‖` for every `x ∈ X₁`.
+/-- **A closed-range operator is bounded below off its kernel.** On any topological complement
+`X₁` of `ker T` there is a constant `C > 0` with `‖x‖ ≤ C * ‖T x‖` for every `x ∈ X₁`.
 
 This is `ContinuousLinearMap.antilipschitz_of_injective_of_isClosed_range` applied to the
 restriction of `T` to `X₁`, which is injective because `X₁` meets the kernel trivially, and has
 closed range because that range is the range of `T`. -/
-theorem _root_.ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_of_mem
-    (hT : T.IsFredholm) (h : IsTopCompl (T.ker) X₁) :
+theorem _root_.ContinuousLinearMap.exists_norm_le_mul_norm_of_mem (T : E →L[𝕜] F)
+    (hclosed : IsClosed (T.range : Set F)) (h : IsTopCompl (T.ker) X₁) :
     ∃ C > 0, ∀ x ∈ X₁, ‖x‖ ≤ C * ‖T x‖ := by
   have : CompleteSpace X₁ := h.isClosed'.completeSpace_coe
   have hinj : Function.Injective (T ∘L X₁.subtypeL) := by
@@ -110,10 +109,11 @@ theorem _root_.ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_of_mem
       simp [map_sub, hxy']
     rw [h.isCompl.inf_eq_bot] at hmem
     exact Subtype.ext (sub_eq_zero.1 hmem)
-  have hclosed : IsClosed (Set.range (T ∘L X₁.subtypeL)) := by
+  have hclosed_restrict : IsClosed (Set.range (T ∘L X₁.subtypeL)) := by
     rw [range_comp_subtypeL_of_isTopCompl h]
-    simpa [LinearMap.coe_range] using hT.isClosed_range
-  obtain ⟨K, hK⟩ := (T ∘L X₁.subtypeL).antilipschitz_of_injective_of_isClosed_range hinj hclosed
+    simpa [LinearMap.coe_range] using hclosed
+  obtain ⟨K, hK⟩ :=
+    (T ∘L X₁.subtypeL).antilipschitz_of_injective_of_isClosed_range hinj hclosed_restrict
   refine ⟨K + 1, by positivity, fun x hx => ?_⟩
   have hx' := hK.le_mul_dist (⟨x, hx⟩ : X₁) 0
   simp only [ContinuousLinearMap.comp_apply, coe_subtypeL, coe_subtype, map_zero,
@@ -122,13 +122,13 @@ theorem _root_.ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_of_mem
   calc ‖x‖ ≤ (K : ℝ) * ‖T x‖ := hx'
     _ ≤ ((K : ℝ) + 1) * ‖T x‖ := by nlinarith [norm_nonneg (T x)]
 
-/-- **The a priori estimate of a Fredholm operator**, stated against the projection onto the kernel
-along a chosen topological complement: there is a `C > 0` with `‖x‖ ≤ C * ‖T x‖ + ‖P x‖` for all
-`x`, where `P` is that projection. -/
-theorem _root_.ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_add_norm_projectionL
-    (hT : T.IsFredholm) (h : IsTopCompl (T.ker) X₁) :
+/-- **The a priori estimate of a closed-range operator**, stated against the projection onto the
+kernel along a chosen topological complement: there is a `C > 0` with
+`‖x‖ ≤ C * ‖T x‖ + ‖P x‖` for all `x`, where `P` is that projection. -/
+theorem _root_.ContinuousLinearMap.exists_norm_le_mul_norm_add_norm_projectionL
+    (T : E →L[𝕜] F) (hclosed : IsClosed (T.range : Set F)) (h : IsTopCompl (T.ker) X₁) :
     ∃ C > 0, ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖(T.ker).projectionL X₁ h x‖ := by
-  obtain ⟨C, hC, hbound⟩ := hT.exists_norm_le_mul_norm_of_mem h
+  obtain ⟨C, hC, hbound⟩ := T.exists_norm_le_mul_norm_of_mem hclosed h
   refine ⟨C, hC, fun x => ?_⟩
   have hsum : (T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x = x :=
     projectionL_add_projectionL_eq_self h x
@@ -142,18 +142,20 @@ theorem _root_.ContinuousLinearMap.IsFredholm.exists_norm_le_mul_norm_add_norm_p
     _ ≤ ‖(T.ker).projectionL X₁ h x‖ + C * ‖T x‖ := by gcongr
     _ = C * ‖T x‖ + ‖(T.ker).projectionL X₁ h x‖ := by ring
 
-/-- **The a priori estimate of a Fredholm operator**, with the complement discharged: there is a
-continuous projection `P` of `E` onto `ker T` and a constant `C > 0` with
+/-- **The a priori estimate of a closed-range operator with complemented kernel**, with the
+complement discharged: there is a continuous projection `P` of `E` onto `ker T` and a constant
+`C > 0` with
 `‖x‖ ≤ C * ‖T x‖ + ‖P x‖`.
 
-Since `ker T` is finite-dimensional, the correction term `‖P x‖` ranges over a finite-dimensional
-space; this is the sense in which a Fredholm operator is bounded below "up to a compact error". -/
-theorem _root_.ContinuousLinearMap.IsFredholm.exists_projection_norm_le
-    (hT : T.IsFredholm) :
+When `ker T` is finite-dimensional, the correction term `‖P x‖` ranges over a finite-dimensional
+space; in particular, this says that a Fredholm operator is bounded below "up to a compact
+error". -/
+theorem _root_.ContinuousLinearMap.exists_projection_norm_le (T : E →L[𝕜] F)
+    (hclosed : IsClosed (T.range : Set F)) (hcompl : T.ker.ClosedComplemented) :
     ∃ (P : E →L[𝕜] E) (C : ℝ), 0 < C ∧ IsIdempotentElem P ∧ P.range = T.ker ∧
       ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖P x‖ := by
-  obtain ⟨X₁, h⟩ := hT.closedComplemented_ker.exists_isTopCompl
-  obtain ⟨C, hC, hbound⟩ := hT.exists_norm_le_mul_norm_add_norm_projectionL h
+  obtain ⟨X₁, h⟩ := hcompl.exists_isTopCompl
+  obtain ⟨C, hC, hbound⟩ := T.exists_norm_le_mul_norm_add_norm_projectionL hclosed h
   exact ⟨(T.ker).projectionL X₁ h, C, hC, isIdempotentElem_projectionL h,
     range_projectionL h, hbound⟩
 

--- a/TauCeti/Analysis/Fredholm/Estimate.lean
+++ b/TauCeti/Analysis/Fredholm/Estimate.lean
@@ -139,7 +139,7 @@ continuous projection `P` of `E` onto `ker T` and a constant `C > 0` with
 
 Since `ker T` is finite-dimensional, the correction term `‖P x‖` ranges over a finite-dimensional
 space; this is the sense in which a Fredholm operator is bounded below "up to a compact error". -/
-theorem _root_.ContinuousLinearMap.IsFredholm.exists_projection_norm_le [CompleteSpace 𝕜]
+theorem _root_.ContinuousLinearMap.IsFredholm.exists_projection_norm_le
     (hT : T.IsFredholm) :
     ∃ (P : E →L[𝕜] E) (C : ℝ), 0 < C ∧ P.range = T.ker ∧
       ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖P x‖ := by

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.FDeriv
+public import Mathlib.Analysis.Normed.Module.FiniteDimension
+public import TauCeti.Analysis.Fredholm.Estimate
+
+/-!
+# A map with Fredholm derivative is proper near the point
+
+A continuous map between infinite-dimensional Banach spaces is essentially never proper: closed
+balls are not compact, so even a linear isomorphism has noncompact fibres of compact sets. A map
+whose derivative at a point `a` is **Fredholm** is nonetheless proper on a neighbourhood of `a`:
+
+`∃ N ∈ 𝓝 a, ∀ L compact, N ∩ f ⁻¹' L is compact`.
+
+This is Smale's local properness lemma, the geometric half of the input to the Sard--Smale theorem
+(Smale, *An infinite dimensional version of Sard's theorem*, Amer. J. Math. 87 (1965), 861–866;
+McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix A). Its consequence
+recorded here is that the preimage `f ⁻¹' L` of a compact set — in particular a level set
+`f ⁻¹' {c}`, the shape every moduli space of the analytic Heegaard Floer roadmap takes — is a
+**locally compact** space, even though the Banach space it sits inside is not.
+
+The proof is quantitative rather than chart-theoretic. The a priori estimate
+`ContinuousLinearMap.IsFredholm.exists_projection_norm_le` supplies a continuous projection `P`
+of `E` onto `ker f'` and a constant `C > 0` with `‖x‖ ≤ C * ‖f' x‖ + ‖P x‖`. On a small enough
+closed ball `N` around `a`, strict differentiability turns this into the two-sided bound
+
+`‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖`  for `x, y ∈ N`,
+
+so the map `x ↦ (f x, P x)` is anti-Lipschitz on `N`. Its second component takes values in the
+finite-dimensional space `ker f'`, where bounded sets have compact closure, so `x ↦ (f x, P x)`
+sends `N ∩ f ⁻¹' L` into a compact box; being anti-Lipschitz, it reflects total boundedness, and
+`N ∩ f ⁻¹' L` is totally bounded and closed, hence compact.
+
+## Main declarations
+
+* `HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage`: local properness.
+* `HasStrictFDerivAt.exists_mem_nhds_isCompact_inter_preimage_singleton`: the fibre through
+  a point is compact near that point.
+* `TauCeti.locallyCompactSpace_preimage` and `TauCeti.locallyCompactSpace_preimage_singleton`: the
+  preimage of a compact set, and in particular a level set, along which the derivative is Fredholm
+  is locally compact.
+
+Lane F0 of the analytic Heegaard Floer roadmap asks for the package "a moduli space is the zero
+set of a Fredholm section, and at a regular point a manifold of dimension the index", of which
+`TauCeti.Analysis.Fredholm.LevelSet` supplies the charts; local properness is the complementary
+topological half, and it is what will make the critical values of a Fredholm map locally closed
+in the Sard--Smale argument.
+-/
+
+public section
+
+namespace TauCeti
+
+open Filter Metric Set Submodule Topology
+open scoped NNReal
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [ProperSpace 𝕜]
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
+variable {f : E → F} {f' : E →L[𝕜] F} {a : E}
+
+/-- **Local properness of a map with Fredholm derivative.** If `f` is strictly differentiable at
+`a` and its derivative there is a Fredholm operator, then `f` is proper on a neighbourhood `N` of
+`a`: the part of the preimage of any compact set lying in `N` is compact.
+
+Compare `ContinuousLinearMap.IsFredholm.exists_projection_norm_le`, the linear estimate this is
+read off from: the kernel direction, in which `f'` loses all control, is finite-dimensional, so
+the loss of compactness it causes is harmless. -/
+theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
+    (hf : HasStrictFDerivAt f f' a) (hf' : f'.IsFredholm) :
+    ∃ N ∈ 𝓝 a, ∀ L : Set F, IsCompact L → IsCompact (N ∩ f ⁻¹' L) := by
+  obtain ⟨P, C, hC, hPrange, hest⟩ := hf'.exists_projection_norm_le
+  have hCpos : (0 : ℝ) < 2 * C := by linarith
+  set ε : ℝ≥0 := ⟨(2 * C)⁻¹, inv_nonneg.2 hCpos.le⟩
+  have hεcoe : (ε : ℝ) = (2 * C)⁻¹ := rfl
+  have hεpos : 0 < ε := by
+    rw [← NNReal.coe_pos, hεcoe]
+    exact inv_pos.2 hCpos
+  obtain ⟨s, hs, happ⟩ := hf.approximates_deriv_on_nhds (Or.inr hεpos)
+  obtain ⟨δ, hδ, hball⟩ := Metric.mem_nhds_iff.1 hs
+  set N : Set E := Metric.closedBall a (δ / 2) with hNdef
+  have hNs : N ⊆ s :=
+    (Metric.closedBall_subset_ball (by linarith)).trans hball
+  have happN : ApproximatesLinearOn f f' N ε := happ.mono_set hNs
+  have hcontOn : ContinuousOn f N := happN.continuousOn
+  -- the two-sided bound on `N`
+  have key : ∀ x ∈ N, ∀ y ∈ N,
+      ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
+    intro x hx y hy
+    have h1 := hest (x - y)
+    have h2 := happN x hx y hy
+    have h3 : ‖f' (x - y)‖ ≤ ‖f x - f y‖ + (ε : ℝ) * ‖x - y‖ := by
+      have hrw : f' (x - y) = f x - f y - (f x - f y - f' (x - y)) := by abel
+      rw [hrw]
+      exact (norm_sub_le _ _).trans (by linarith)
+    have h4 : C * ‖f' (x - y)‖ ≤ C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖) :=
+      mul_le_mul_of_nonneg_left h3 hC.le
+    have h5 : C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖)
+        = C * ‖f x - f y‖ + 1 / 2 * ‖x - y‖ := by
+      rw [mul_add, ← mul_assoc, hεcoe]
+      field_simp
+    rw [map_sub P x y] at h1
+    linarith
+  refine ⟨N, Metric.closedBall_mem_nhds a (by linarith), fun L hL => ?_⟩
+  -- the compact box the projection lands in
+  have hPmem : ∀ x, P x ∈ f'.ker := by
+    intro x
+    rw [← hPrange]
+    exact ⟨x, rfl⟩
+  have : FiniteDimensional 𝕜 f'.ker := hf'.finite_ker
+  have : ProperSpace f'.ker := FiniteDimensional.proper 𝕜 f'.ker
+  set Kp : Set E := f'.ker.subtypeL '' Metric.closedBall (0 : f'.ker) (‖P‖ * (‖a‖ + δ / 2))
+  have hKpc : IsCompact Kp :=
+    (isCompact_closedBall _ _).image f'.ker.subtypeL.continuous
+  have hPN : ∀ x ∈ N, P x ∈ Kp := by
+    intro x hx
+    refine ⟨⟨P x, hPmem x⟩, ?_, rfl⟩
+    have hxa : ‖x - a‖ ≤ δ / 2 := by
+      rw [hNdef, Metric.mem_closedBall, dist_eq_norm] at hx
+      exact hx
+    have hnx : ‖x‖ ≤ ‖a‖ + δ / 2 := by
+      calc ‖x‖ = ‖a + (x - a)‖ := by rw [add_sub_cancel]
+        _ ≤ ‖a‖ + ‖x - a‖ := norm_add_le _ _
+        _ ≤ ‖a‖ + δ / 2 := by linarith
+    simp only [Metric.mem_closedBall, dist_zero_right]
+    calc ‖(⟨P x, hPmem x⟩ : f'.ker)‖ = ‖P x‖ := rfl
+      _ ≤ ‖P‖ * ‖x‖ := P.le_opNorm x
+      _ ≤ ‖P‖ * (‖a‖ + δ / 2) := by gcongr
+  -- the anti-Lipschitz coordinate on `N`
+  set Θ : N → F × E := fun x => (f (x : E), P (x : E))
+  have hanti : AntilipschitzWith ⟨2 * C + 2, by positivity⟩ Θ := by
+    refine AntilipschitzWith.of_le_mul_dist fun x y => ?_
+    have hd1 : ‖f (x : E) - f (y : E)‖ ≤ dist (Θ x) (Θ y) := by
+      rw [Prod.dist_eq, ← dist_eq_norm]
+      exact le_max_left _ _
+    have hd2 : ‖P (x : E) - P (y : E)‖ ≤ dist (Θ x) (Θ y) := by
+      rw [Prod.dist_eq, ← dist_eq_norm]
+      exact le_max_right _ _
+    have hk := key (x : E) x.2 (y : E) y.2
+    have hCd : C * ‖f (x : E) - f (y : E)‖ ≤ C * dist (Θ x) (Θ y) :=
+      mul_le_mul_of_nonneg_left hd1 hC.le
+    rw [Subtype.dist_eq, dist_eq_norm]
+    change ‖(x : E) - (y : E)‖ ≤ (2 * C + 2) * dist (Θ x) (Θ y)
+    nlinarith [dist_nonneg (x := Θ x) (y := Θ y)]
+  have hΘlip : LipschitzWith (‖f'‖₊ + ε + ‖P‖₊) Θ := by
+    have h1 : LipschitzWith (‖f'‖₊ + ε) fun x : N => f (x : E) := happN.lipschitz
+    have h2 : LipschitzWith ‖P‖₊ fun x : N => P (x : E) := P.lipschitz.restrict N
+    exact (h1.prodMk h2).weaken (by simp)
+  have hind : IsUniformInducing Θ := hanti.isUniformInducing hΘlip.uniformContinuous
+  -- total boundedness, then compactness
+  have htb : TotallyBounded ((Subtype.val : N → E) '' {x : N | f (x : E) ∈ L}) := by
+    refine TotallyBounded.image ?_ uniformContinuous_subtype_val
+    refine (totallyBounded_preimage hind (hL.prod hKpc).totallyBounded).subset ?_
+    exact fun x hx => ⟨hx, hPN (x : E) x.2⟩
+  have himg : (Subtype.val : N → E) '' {x : N | f (x : E) ∈ L} = N ∩ f ⁻¹' L := by
+    rw [show {x : N | f (x : E) ∈ L} = (Subtype.val : N → E) ⁻¹' (f ⁻¹' L) from rfl,
+      Subtype.image_preimage_coe, Set.inter_comm]
+  rw [himg] at htb
+  exact htb.isCompact_of_isClosed
+    (hcontOn.preimage_isClosed_of_isClosed Metric.isClosed_closedBall hL.isClosed)
+
+/-- The fibre of `f` through a point at which the derivative is Fredholm is compact near that
+point. This is the case `L = {f a}` of local properness, and it is the local finiteness statement
+that a moduli space of a Fredholm problem inherits before any global energy bound is imposed. -/
+theorem _root_.HasStrictFDerivAt.exists_mem_nhds_isCompact_inter_preimage_singleton
+    (hf : HasStrictFDerivAt f f' a) (hf' : f'.IsFredholm) (c : F) :
+    ∃ N ∈ 𝓝 a, IsCompact (N ∩ f ⁻¹' {c}) := by
+  obtain ⟨N, hN, hprop⟩ := hf.exists_mem_nhds_forall_isCompact_inter_preimage hf'
+  exact ⟨N, hN, hprop {c} isCompact_singleton⟩
+
+/-- **The preimage of a compact set under a map with Fredholm derivative is locally compact.** If
+`f` is strictly differentiable at each point of `f ⁻¹' L` with Fredholm derivative there, and `L`
+is compact, then `f ⁻¹' L`, with the topology induced from `E`, is a locally compact space.
+
+No compactness is assumed of the ambient Banach space, and none is available: the point is that
+the Fredholm condition confines the failure of local compactness to the finite-dimensional kernel
+direction, which the preimage does not see. -/
+theorem locallyCompactSpace_preimage {D : E → E →L[𝕜] F} {L : Set F} (hL : IsCompact L)
+    (hf : ∀ x ∈ f ⁻¹' L, HasStrictFDerivAt f (D x) x)
+    (hD : ∀ x ∈ f ⁻¹' L, (D x).IsFredholm) :
+    LocallyCompactSpace (f ⁻¹' L) := by
+  have : WeaklyLocallyCompactSpace (f ⁻¹' L) := by
+    refine ⟨fun x => ?_⟩
+    obtain ⟨N, hN, hprop⟩ :=
+      (hf x x.2).exists_mem_nhds_forall_isCompact_inter_preimage (hD x x.2)
+    refine ⟨(Subtype.val : (f ⁻¹' L) → E) ⁻¹' N, ?_, ?_⟩
+    · rw [Topology.IsEmbedding.subtypeVal.isCompact_iff, Subtype.image_preimage_coe,
+        Set.inter_comm]
+      exact hprop L hL
+    · exact continuous_subtype_val.continuousAt.preimage_mem_nhds hN
+  infer_instance
+
+/-- **A level set of a map with Fredholm derivative is locally compact**: the case `L = {c}` of
+`TauCeti.locallyCompactSpace_preimage`, and the shape every moduli space of a Fredholm problem
+takes. -/
+theorem locallyCompactSpace_preimage_singleton {D : E → E →L[𝕜] F} {c : F}
+    (hf : ∀ x ∈ f ⁻¹' {c}, HasStrictFDerivAt f (D x) x)
+    (hD : ∀ x ∈ f ⁻¹' {c}, (D x).IsFredholm) :
+    LocallyCompactSpace (f ⁻¹' {c}) :=
+  locallyCompactSpace_preimage isCompact_singleton hf hD
+
+end TauCeti

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -11,9 +11,9 @@ public import TauCeti.Analysis.Fredholm.Estimate
 /-!
 # A map with Fredholm derivative is proper near the point
 
-A continuous map between infinite-dimensional Banach spaces is essentially never proper: closed
-balls are not compact, so even a linear isomorphism has noncompact fibres of compact sets. A map
-whose derivative at a point `a` is **Fredholm** is nonetheless proper on a neighbourhood of `a`:
+A continuous map between infinite-dimensional Banach spaces need not be proper: a Fredholm linear
+map with nonzero kernel has a noncompact fibre over zero. A map whose derivative at a point `a` is
+**Fredholm** is nonetheless proper on a neighbourhood of `a`:
 
 `∃ N ∈ 𝓝 a, ∀ L compact, N ∩ f ⁻¹' L is compact`.
 
@@ -74,7 +74,7 @@ the loss of compactness it causes is harmless. -/
 theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
     (hf : HasStrictFDerivAt f f' a) (hf' : f'.IsFredholm) :
     ∃ N ∈ 𝓝 a, ∀ L : Set F, IsCompact L → IsCompact (N ∩ f ⁻¹' L) := by
-  obtain ⟨P, C, hC, hPrange, hest⟩ := hf'.exists_projection_norm_le
+  obtain ⟨P, C, hC, _hPidemp, hPrange, hest⟩ := hf'.exists_projection_norm_le
   have hCpos : (0 : ℝ) < 2 * C := by linarith
   set ε : ℝ≥0 := ⟨(2 * C)⁻¹, inv_nonneg.2 hCpos.le⟩
   have hεcoe : (ε : ℝ) = (2 * C)⁻¹ := rfl
@@ -145,22 +145,23 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
     have hCd : C * ‖f (x : E) - f (y : E)‖ ≤ C * dist (Θ x) (Θ y) :=
       mul_le_mul_of_nonneg_left hd1 hC.le
     rw [Subtype.dist_eq, dist_eq_norm]
-    change ‖(x : E) - (y : E)‖ ≤ (2 * C + 2) * dist (Θ x) (Θ y)
-    nlinarith [dist_nonneg (x := Θ x) (y := Θ y)]
+    calc
+      ‖(x : E) - (y : E)‖ ≤ 2 * (C * ‖f (x : E) - f (y : E)‖) +
+          2 * ‖P (x : E) - P (y : E)‖ := hk
+      _ ≤ (2 * C + 2) * dist (Θ x) (Θ y) := by
+        nlinarith [dist_nonneg (x := Θ x) (y := Θ y)]
   have hΘlip : LipschitzWith (‖f'‖₊ + ε + ‖P‖₊) Θ := by
     have h1 : LipschitzWith (‖f'‖₊ + ε) fun x : N => f (x : E) := happN.lipschitz
     have h2 : LipschitzWith ‖P‖₊ fun x : N => P (x : E) := P.lipschitz.restrict N
     exact (h1.prodMk h2).weaken (by simp)
   have hind : IsUniformInducing Θ := hanti.isUniformInducing hΘlip.uniformContinuous
   -- total boundedness, then compactness
-  have htb : TotallyBounded ((Subtype.val : N → E) '' {x : N | f (x : E) ∈ L}) := by
+  have htb : TotallyBounded
+      ((Subtype.val : N → E) '' (Subtype.val : N → E) ⁻¹' (f ⁻¹' L)) := by
     refine TotallyBounded.image ?_ uniformContinuous_subtype_val
     refine (totallyBounded_preimage hind (hL.prod hKpc).totallyBounded).subset ?_
     exact fun x hx => ⟨hx, hPN (x : E) x.2⟩
-  have himg : (Subtype.val : N → E) '' {x : N | f (x : E) ∈ L} = N ∩ f ⁻¹' L := by
-    rw [show {x : N | f (x : E) ∈ L} = (Subtype.val : N → E) ⁻¹' (f ⁻¹' L) from rfl,
-      Subtype.image_preimage_coe, Set.inter_comm]
-  rw [himg] at htb
+  rw [Subtype.image_preimage_coe] at htb
   exact htb.isCompact_of_isClosed
     (hcontOn.preimage_isClosed_of_isClosed Metric.isClosed_closedBall hL.isClosed)
 
@@ -179,7 +180,7 @@ is compact, then `f ⁻¹' L`, with the topology induced from `E`, is a locally 
 
 No compactness is assumed of the ambient Banach space, and none is available: the point is that
 the Fredholm condition confines the failure of local compactness to the finite-dimensional kernel
-direction, which the preimage does not see. -/
+direction, which is itself locally compact and is controlled locally by the kernel projection. -/
 theorem locallyCompactSpace_preimage {D : E → E →L[𝕜] F} {L : Set F} (hL : IsCompact L)
     (hf : ∀ x ∈ f ⁻¹' L, HasStrictFDerivAt f (D x) x)
     (hD : ∀ x ∈ f ⁻¹' L, (D x).IsFredholm) :

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -6,10 +6,11 @@ module
 
 public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.FDeriv
 public import Mathlib.Analysis.Normed.Module.FiniteDimension
-public import TauCeti.Analysis.Fredholm.Estimate
+public import TauCeti.Analysis.Fredholm.Basic
+public import TauCeti.Analysis.Normed.Operator.ClosedRange
 
 /-!
-# A map with upper semi-Fredholm derivative is proper near the point
+# A map with Fredholm derivative is proper near the point
 
 A continuous map between infinite-dimensional Banach spaces need not be proper: a Fredholm linear
 map with nonzero kernel has a noncompact fibre over zero. A map whose derivative at a point `a` is
@@ -26,25 +27,24 @@ recorded here is that the preimage `f ⁻¹' L` of a compact set — in particul
 **locally compact** space, even though the Banach space it sits inside is not.
 
 The proof is quantitative rather than chart-theoretic. The a priori estimate
-`ContinuousLinearMap.exists_projection_norm_le` supplies a continuous projection `P`
-of `E` onto `ker f'` and a constant `C > 0` with `‖x‖ ≤ C * ‖f' x‖ + ‖P x‖`. On a small enough
-closed ball `N` around `a`, strict differentiability turns this into the two-sided bound
-
-`‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖`  for `x, y ∈ N`,
-
-so the map `x ↦ (f x, P x)` is anti-Lipschitz on `N`. Its second component takes values in the
+`ContinuousLinearMap.exists_projection_norm_le_mul_norm_add_norm` supplies a continuous projection
+`P` of `E` onto `ker f'` and a constant `C > 0` with `‖x‖ ≤ C * ‖f' x‖ + ‖P x‖`; that is exactly
+the statement that the linear map `f'.prod P` is anti-Lipschitz. On a small enough closed ball `N`
+around `a`, strict differentiability makes `x ↦ (f x, P x)` a small Lipschitz perturbation of
+`f'.prod P`, hence anti-Lipschitz there as well. Its second component takes values in the
 finite-dimensional space `ker f'`, where bounded sets have compact closure, so `x ↦ (f x, P x)`
 sends `N ∩ f ⁻¹' L` into a compact box; being anti-Lipschitz, it reflects total boundedness, and
 `N ∩ f ⁻¹' L` is totally bounded and closed, hence compact.
 
 ## Main declarations
 
-* `HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage`: local properness.
-* `HasStrictFDerivAt.exists_mem_nhds_isCompact_inter_preimage_singleton`: an arbitrary fibre is
-  compact near the point of differentiation.
-* `TauCeti.locallyCompactSpace_preimage` and `TauCeti.locallyCompactSpace_preimage_singleton`: the
-  preimage of a compact set, and in particular a level set, along which the derivative is Fredholm
-  is locally compact.
+* `HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage` and
+  `HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage_of_isFredholm`: local
+  properness, from the unbundled hypotheses and from `ContinuousLinearMap.IsFredholm`.
+* `TauCeti.locallyCompactSpace_preimage_of_isClosed_range_of_finite_ker` and
+  `TauCeti.locallyCompactSpace_preimage_of_isFredholm`: the preimage of a compact set along which
+  the derivative is Fredholm is locally compact.
+* `TauCeti.locallyCompactSpace_preimage_singleton_of_isFredholm`: the same for a level set.
 
 Lane F0 of the analytic Heegaard Floer roadmap asks for the package "a moduli space is the zero
 set of a Fredholm section, and at a regular point a manifold of dimension the index", of which
@@ -60,7 +60,7 @@ namespace TauCeti
 open Filter Metric Set Submodule Topology
 open scoped NNReal
 
-variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [ProperSpace 𝕜]
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [LocallyCompactSpace 𝕜]
 variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
 variable {f : E → F} {f' : E →L[𝕜] F} {a : E}
@@ -70,21 +70,36 @@ differentiable at `a` and its derivative there has closed range and finite-dimen
 complemented kernel, then `f` is proper on a neighbourhood `N` of `a`: the part of the preimage of
 any compact set lying in `N` is compact.
 
-Compare `ContinuousLinearMap.exists_projection_norm_le`, the linear estimate this is read off
-from: the kernel direction, in which `f'` loses all control, is finite-dimensional, so the loss of
-compactness it causes is harmless. -/
+Compare `ContinuousLinearMap.exists_projection_norm_le_mul_norm_add_norm`, the linear estimate this
+is read off from: the kernel direction, in which `f'` loses all control, is finite-dimensional, so
+the loss of compactness it causes is harmless. -/
 theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
     (hf : HasStrictFDerivAt f f' a) (hclosed : IsClosed (f'.range : Set F))
     (hfinite : FiniteDimensional 𝕜 f'.ker) (hcompl : f'.ker.ClosedComplemented) :
     ∃ N ∈ 𝓝 a, ∀ L : Set F, IsCompact L → IsCompact (N ∩ f ⁻¹' L) := by
   obtain ⟨P, C, hC, _hPidemp, hPrange, hest⟩ :=
-    f'.exists_projection_norm_le hclosed hcompl
-  have hCpos : (0 : ℝ) < 2 * C := by linarith
-  set ε : ℝ≥0 := ⟨(2 * C)⁻¹, inv_nonneg.2 hCpos.le⟩
-  have hεcoe : (ε : ℝ) = (2 * C)⁻¹ := rfl
-  have hεpos : 0 < ε := by
-    rw [← NNReal.coe_pos, hεcoe]
-    exact inv_pos.2 hCpos
+    f'.exists_projection_norm_le_mul_norm_add_norm hclosed hcompl
+  -- the estimate says precisely that the linear map `f'.prod P` is bounded below
+  set K : ℝ≥0 := ⟨C + 1, by positivity⟩ with hKdef
+  have hKcoe : (K : ℝ) = C + 1 := rfl
+  have hQ : AntilipschitzWith K (f'.prod P) := by
+    refine (f'.prod P).antilipschitz_of_bound fun x => ?_
+    have hfst : ‖f' x‖ ≤ ‖(f'.prod P) x‖ := by
+      rw [ContinuousLinearMap.prod_apply, Prod.norm_def]; exact le_max_left _ _
+    have hsnd : ‖P x‖ ≤ ‖(f'.prod P) x‖ := by
+      rw [ContinuousLinearMap.prod_apply, Prod.norm_def]; exact le_max_right _ _
+    have hx := hest x
+    rw [hKcoe]
+    nlinarith [norm_nonneg ((f'.prod P) x)]
+  -- a perturbation smaller than `K⁻¹` keeps that bound, by
+  -- `AntilipschitzWith.add_sub_lipschitzWith`
+  set ε : ℝ≥0 := ⟨(2 * (C + 1))⁻¹, by positivity⟩ with hεdef
+  have hεcoe : (ε : ℝ) = (2 * (C + 1))⁻¹ := rfl
+  have hεpos : 0 < ε := by rw [← NNReal.coe_pos, hεcoe]; positivity
+  have hεlt : ε < K⁻¹ := by
+    rw [← NNReal.coe_lt_coe, hεcoe, NNReal.coe_inv, hKcoe, inv_lt_inv₀ (by positivity) (by
+      positivity)]
+    linarith
   obtain ⟨s, hs, happ⟩ := hf.approximates_deriv_on_nhds (Or.inr hεpos)
   obtain ⟨δ, hδ, hball⟩ := Metric.mem_nhds_iff.1 hs
   set N : Set E := Metric.closedBall a (δ / 2) with hNdef
@@ -92,30 +107,12 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
     (Metric.closedBall_subset_ball (by linarith)).trans hball
   have happN : ApproximatesLinearOn f f' N ε := happ.mono_set hNs
   have hcontOn : ContinuousOn f N := happN.continuousOn
-  -- the two-sided bound on `N`
-  have key : ∀ x ∈ N, ∀ y ∈ N,
-      ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
-    intro x hx y hy
-    have h1 := hest (x - y)
-    have h2 := happN x hx y hy
-    have h3 : ‖f' (x - y)‖ ≤ ‖f x - f y‖ + (ε : ℝ) * ‖x - y‖ := by
-      have hrw : f' (x - y) = f x - f y - (f x - f y - f' (x - y)) := by abel
-      rw [hrw]
-      exact (norm_sub_le _ _).trans (by linarith)
-    have h4 : C * ‖f' (x - y)‖ ≤ C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖) :=
-      mul_le_mul_of_nonneg_left h3 hC.le
-    have h5 : C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖)
-        = C * ‖f x - f y‖ + 1 / 2 * ‖x - y‖ := by
-      rw [mul_add, ← mul_assoc, hεcoe]
-      field_simp
-    rw [map_sub P x y] at h1
-    linarith
   refine ⟨N, Metric.closedBall_mem_nhds a (by linarith), fun L hL => ?_⟩
   -- the compact box the projection lands in
   have hPmem : ∀ x, P x ∈ f'.ker := by
     intro x
     rw [← hPrange]
-    exact ⟨x, rfl⟩
+    exact LinearMap.mem_range_self _ x
   let _ : FiniteDimensional 𝕜 f'.ker := hfinite
   have : ProperSpace f'.ker := FiniteDimensional.proper 𝕜 f'.ker
   set Kp : Set E := f'.ker.subtypeL '' Metric.closedBall (0 : f'.ker) (‖P‖ * (‖a‖ + δ / 2))
@@ -131,29 +128,19 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
       calc ‖x‖ = ‖a + (x - a)‖ := by rw [add_sub_cancel]
         _ ≤ ‖a‖ + ‖x - a‖ := norm_add_le _ _
         _ ≤ ‖a‖ + δ / 2 := by linarith
-    simp only [Metric.mem_closedBall, dist_zero_right]
-    calc ‖(⟨P x, hPmem x⟩ : f'.ker)‖ = ‖P x‖ := rfl
-      _ ≤ ‖P‖ * ‖x‖ := P.le_opNorm x
+    simp only [Metric.mem_closedBall, dist_zero_right, Submodule.coe_norm]
+    calc ‖P x‖ ≤ ‖P‖ * ‖x‖ := P.le_opNorm x
       _ ≤ ‖P‖ * (‖a‖ + δ / 2) := by gcongr
-  -- the anti-Lipschitz coordinate on `N`
-  set Θ : N → F × E := fun x => (f (x : E), P (x : E))
-  have hanti : AntilipschitzWith ⟨2 * C + 2, by positivity⟩ Θ := by
-    refine AntilipschitzWith.of_le_mul_dist fun x y => ?_
-    have hd1 : ‖f (x : E) - f (y : E)‖ ≤ dist (Θ x) (Θ y) := by
-      rw [Prod.dist_eq, ← dist_eq_norm]
-      exact le_max_left _ _
-    have hd2 : ‖P (x : E) - P (y : E)‖ ≤ dist (Θ x) (Θ y) := by
-      rw [Prod.dist_eq, ← dist_eq_norm]
-      exact le_max_right _ _
-    have hk := key (x : E) x.2 (y : E) y.2
-    have hCd : C * ‖f (x : E) - f (y : E)‖ ≤ C * dist (Θ x) (Θ y) :=
-      mul_le_mul_of_nonneg_left hd1 hC.le
-    rw [Subtype.dist_eq, dist_eq_norm]
-    calc
-      ‖(x : E) - (y : E)‖ ≤ 2 * (C * ‖f (x : E) - f (y : E)‖) +
-          2 * ‖P (x : E) - P (y : E)‖ := hk
-      _ ≤ (2 * C + 2) * dist (Θ x) (Θ y) := by
-        nlinarith [dist_nonneg (x := Θ x) (y := Θ y)]
+  -- the anti-Lipschitz coordinate on `N`: a small perturbation of `f'.prod P`
+  set Θ : N → F × E := fun x => (f (x : E), P (x : E)) with hΘdef
+  have hsub : Θ - N.domRestrict (f'.prod P) = fun x : N => (f (x : E) - f' (x : E), (0 : E)) := by
+    funext x
+    simp [hΘdef]
+  have hlip : LipschitzWith ε (Θ - N.domRestrict (f'.prod P)) := by
+    rw [hsub]
+    simpa using happN.lipschitz_sub.prodMk (LipschitzWith.const (α := N) (0 : E))
+  have hanti : AntilipschitzWith (K⁻¹ - ε)⁻¹ Θ :=
+    (hQ.domRestrict N).add_sub_lipschitzWith hlip hεlt
   have hΘlip : LipschitzWith (‖f'‖₊ + ε + ‖P‖₊) Θ := by
     have h1 : LipschitzWith (‖f'‖₊ + ε) fun x : N => f (x : E) := happN.lipschitz
     have h2 : LipschitzWith ‖P‖₊ fun x : N => P (x : E) := P.lipschitz.restrict N
@@ -169,17 +156,15 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
   exact htb.isCompact_of_isClosed
     (hcontOn.preimage_isClosed_of_isClosed Metric.isClosed_closedBall hL.isClosed)
 
-/-- An arbitrary fibre of `f` is compact near a point where the derivative has closed range and
-finite-dimensional complemented kernel. This is the case `L = {c}` of local properness, and it is
-the local finiteness statement that a moduli space of a Fredholm problem inherits before any
-global energy bound is imposed. -/
-theorem _root_.HasStrictFDerivAt.exists_mem_nhds_isCompact_inter_preimage_singleton
-    (hf : HasStrictFDerivAt f f' a) (hclosed : IsClosed (f'.range : Set F))
-    (hfinite : FiniteDimensional 𝕜 f'.ker) (hcompl : f'.ker.ClosedComplemented) (c : F) :
-    ∃ N ∈ 𝓝 a, IsCompact (N ∩ f ⁻¹' {c}) := by
-  obtain ⟨N, hN, hprop⟩ :=
-    hf.exists_mem_nhds_forall_isCompact_inter_preimage hclosed hfinite hcompl
-  exact ⟨N, hN, hprop {c} isCompact_singleton⟩
+/-- **Local properness of a map with Fredholm derivative** (Smale). This is
+`HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage` phrased against
+`ContinuousLinearMap.IsFredholm`, as `TauCeti.Analysis.Fredholm.Basic` prescribes; the finite
+dimensionality of the cokernel plays no role. -/
+theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage_of_isFredholm
+    (hf : HasStrictFDerivAt f f' a) (hFred : f'.IsFredholm) :
+    ∃ N ∈ 𝓝 a, ∀ L : Set F, IsCompact L → IsCompact (N ∩ f ⁻¹' L) :=
+  hf.exists_mem_nhds_forall_isCompact_inter_preimage hFred.isClosed_range hFred.finite_ker
+    hFred.closedComplemented_ker
 
 /-- **The preimage of a compact set under a map with upper semi-Fredholm derivative is locally
 compact.** If `f` is strictly differentiable at each point of `f ⁻¹' L`, its derivative there has
@@ -189,7 +174,8 @@ the topology induced from `E`, is a locally compact space.
 No compactness is assumed of the ambient Banach space, and none is available: the point is that
 the hypotheses confine the failure of local compactness to the finite-dimensional kernel
 direction, which is itself locally compact and is controlled by the kernel projection. -/
-theorem locallyCompactSpace_preimage {D : E → E →L[𝕜] F} {L : Set F} (hL : IsCompact L)
+theorem locallyCompactSpace_preimage_of_isClosed_range_of_finite_ker {D : E → E →L[𝕜] F}
+    {L : Set F} (hL : IsCompact L)
     (hf : ∀ x ∈ f ⁻¹' L, HasStrictFDerivAt f (D x) x)
     (hclosed : ∀ x ∈ f ⁻¹' L, IsClosed ((D x).range : Set F))
     (hfinite : ∀ x ∈ f ⁻¹' L, FiniteDimensional 𝕜 (D x).ker)
@@ -207,15 +193,24 @@ theorem locallyCompactSpace_preimage {D : E → E →L[𝕜] F} {L : Set F} (hL 
     · exact continuous_subtype_val.continuousAt.preimage_mem_nhds hN
   infer_instance
 
-/-- **A level set of a map with upper semi-Fredholm derivative is locally compact**: the case
-`L = {c}` of `TauCeti.locallyCompactSpace_preimage`, and the shape every moduli space of a Fredholm
-problem takes. -/
-theorem locallyCompactSpace_preimage_singleton {D : E → E →L[𝕜] F} {c : F}
+/-- **The preimage of a compact set along which the derivative is Fredholm is locally compact**:
+`TauCeti.locallyCompactSpace_preimage_of_isClosed_range_of_finite_ker` phrased against
+`ContinuousLinearMap.IsFredholm`. -/
+theorem locallyCompactSpace_preimage_of_isFredholm {D : E → E →L[𝕜] F} {L : Set F}
+    (hL : IsCompact L) (hf : ∀ x ∈ f ⁻¹' L, HasStrictFDerivAt f (D x) x)
+    (hFred : ∀ x ∈ f ⁻¹' L, (D x).IsFredholm) :
+    LocallyCompactSpace (f ⁻¹' L) :=
+  locallyCompactSpace_preimage_of_isClosed_range_of_finite_ker hL hf
+    (fun x hx => (hFred x hx).isClosed_range) (fun x hx => (hFred x hx).finite_ker)
+    fun x hx => (hFred x hx).closedComplemented_ker
+
+/-- **A level set of a map with Fredholm derivative is locally compact**: the case `L = {c}` of
+`TauCeti.locallyCompactSpace_preimage_of_isFredholm`, and the shape every moduli space of a
+Fredholm problem takes. -/
+theorem locallyCompactSpace_preimage_singleton_of_isFredholm {D : E → E →L[𝕜] F} {c : F}
     (hf : ∀ x ∈ f ⁻¹' {c}, HasStrictFDerivAt f (D x) x)
-    (hclosed : ∀ x ∈ f ⁻¹' {c}, IsClosed ((D x).range : Set F))
-    (hfinite : ∀ x ∈ f ⁻¹' {c}, FiniteDimensional 𝕜 (D x).ker)
-    (hcompl : ∀ x ∈ f ⁻¹' {c}, (D x).ker.ClosedComplemented) :
+    (hFred : ∀ x ∈ f ⁻¹' {c}, (D x).IsFredholm) :
     LocallyCompactSpace (f ⁻¹' {c}) :=
-  locallyCompactSpace_preimage isCompact_singleton hf hclosed hfinite hcompl
+  locallyCompactSpace_preimage_of_isFredholm isCompact_singleton hf hFred
 
 end TauCeti

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -9,11 +9,12 @@ public import Mathlib.Analysis.Normed.Module.FiniteDimension
 public import TauCeti.Analysis.Fredholm.Estimate
 
 /-!
-# A map with Fredholm derivative is proper near the point
+# A map with upper semi-Fredholm derivative is proper near the point
 
 A continuous map between infinite-dimensional Banach spaces need not be proper: a Fredholm linear
 map with nonzero kernel has a noncompact fibre over zero. A map whose derivative at a point `a` is
-**Fredholm** is nonetheless proper on a neighbourhood of `a`:
+closed-range with finite-dimensional complemented kernel — in particular, a **Fredholm**
+operator — is nonetheless proper on a neighbourhood of `a`:
 
 `∃ N ∈ 𝓝 a, ∀ L compact, N ∩ f ⁻¹' L is compact`.
 
@@ -25,7 +26,7 @@ recorded here is that the preimage `f ⁻¹' L` of a compact set — in particul
 **locally compact** space, even though the Banach space it sits inside is not.
 
 The proof is quantitative rather than chart-theoretic. The a priori estimate
-`ContinuousLinearMap.IsFredholm.exists_projection_norm_le` supplies a continuous projection `P`
+`ContinuousLinearMap.exists_projection_norm_le` supplies a continuous projection `P`
 of `E` onto `ker f'` and a constant `C > 0` with `‖x‖ ≤ C * ‖f' x‖ + ‖P x‖`. On a small enough
 closed ball `N` around `a`, strict differentiability turns this into the two-sided bound
 
@@ -39,8 +40,8 @@ sends `N ∩ f ⁻¹' L` into a compact box; being anti-Lipschitz, it reflects t
 ## Main declarations
 
 * `HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage`: local properness.
-* `HasStrictFDerivAt.exists_mem_nhds_isCompact_inter_preimage_singleton`: the fibre through
-  a point is compact near that point.
+* `HasStrictFDerivAt.exists_mem_nhds_isCompact_inter_preimage_singleton`: an arbitrary fibre is
+  compact near the point of differentiation.
 * `TauCeti.locallyCompactSpace_preimage` and `TauCeti.locallyCompactSpace_preimage_singleton`: the
   preimage of a compact set, and in particular a level set, along which the derivative is Fredholm
   is locally compact.
@@ -64,17 +65,20 @@ variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpac
   [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
 variable {f : E → F} {f' : E →L[𝕜] F} {a : E}
 
-/-- **Local properness of a map with Fredholm derivative.** If `f` is strictly differentiable at
-`a` and its derivative there is a Fredholm operator, then `f` is proper on a neighbourhood `N` of
-`a`: the part of the preimage of any compact set lying in `N` is compact.
+/-- **Local properness of a map with upper semi-Fredholm derivative.** If `f` is strictly
+differentiable at `a` and its derivative there has closed range and finite-dimensional
+complemented kernel, then `f` is proper on a neighbourhood `N` of `a`: the part of the preimage of
+any compact set lying in `N` is compact.
 
-Compare `ContinuousLinearMap.IsFredholm.exists_projection_norm_le`, the linear estimate this is
-read off from: the kernel direction, in which `f'` loses all control, is finite-dimensional, so
-the loss of compactness it causes is harmless. -/
+Compare `ContinuousLinearMap.exists_projection_norm_le`, the linear estimate this is read off
+from: the kernel direction, in which `f'` loses all control, is finite-dimensional, so the loss of
+compactness it causes is harmless. -/
 theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
-    (hf : HasStrictFDerivAt f f' a) (hf' : f'.IsFredholm) :
+    (hf : HasStrictFDerivAt f f' a) (hclosed : IsClosed (f'.range : Set F))
+    (hfinite : FiniteDimensional 𝕜 f'.ker) (hcompl : f'.ker.ClosedComplemented) :
     ∃ N ∈ 𝓝 a, ∀ L : Set F, IsCompact L → IsCompact (N ∩ f ⁻¹' L) := by
-  obtain ⟨P, C, hC, _hPidemp, hPrange, hest⟩ := hf'.exists_projection_norm_le
+  obtain ⟨P, C, hC, _hPidemp, hPrange, hest⟩ :=
+    f'.exists_projection_norm_le hclosed hcompl
   have hCpos : (0 : ℝ) < 2 * C := by linarith
   set ε : ℝ≥0 := ⟨(2 * C)⁻¹, inv_nonneg.2 hCpos.le⟩
   have hεcoe : (ε : ℝ) = (2 * C)⁻¹ := rfl
@@ -112,7 +116,7 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
     intro x
     rw [← hPrange]
     exact ⟨x, rfl⟩
-  have : FiniteDimensional 𝕜 f'.ker := hf'.finite_ker
+  let _ : FiniteDimensional 𝕜 f'.ker := hfinite
   have : ProperSpace f'.ker := FiniteDimensional.proper 𝕜 f'.ker
   set Kp : Set E := f'.ker.subtypeL '' Metric.closedBall (0 : f'.ker) (‖P‖ * (‖a‖ + δ / 2))
   have hKpc : IsCompact Kp :=
@@ -165,30 +169,37 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
   exact htb.isCompact_of_isClosed
     (hcontOn.preimage_isClosed_of_isClosed Metric.isClosed_closedBall hL.isClosed)
 
-/-- The fibre of `f` through a point at which the derivative is Fredholm is compact near that
-point. This is the case `L = {f a}` of local properness, and it is the local finiteness statement
-that a moduli space of a Fredholm problem inherits before any global energy bound is imposed. -/
+/-- An arbitrary fibre of `f` is compact near a point where the derivative has closed range and
+finite-dimensional complemented kernel. This is the case `L = {c}` of local properness, and it is
+the local finiteness statement that a moduli space of a Fredholm problem inherits before any
+global energy bound is imposed. -/
 theorem _root_.HasStrictFDerivAt.exists_mem_nhds_isCompact_inter_preimage_singleton
-    (hf : HasStrictFDerivAt f f' a) (hf' : f'.IsFredholm) (c : F) :
+    (hf : HasStrictFDerivAt f f' a) (hclosed : IsClosed (f'.range : Set F))
+    (hfinite : FiniteDimensional 𝕜 f'.ker) (hcompl : f'.ker.ClosedComplemented) (c : F) :
     ∃ N ∈ 𝓝 a, IsCompact (N ∩ f ⁻¹' {c}) := by
-  obtain ⟨N, hN, hprop⟩ := hf.exists_mem_nhds_forall_isCompact_inter_preimage hf'
+  obtain ⟨N, hN, hprop⟩ :=
+    hf.exists_mem_nhds_forall_isCompact_inter_preimage hclosed hfinite hcompl
   exact ⟨N, hN, hprop {c} isCompact_singleton⟩
 
-/-- **The preimage of a compact set under a map with Fredholm derivative is locally compact.** If
-`f` is strictly differentiable at each point of `f ⁻¹' L` with Fredholm derivative there, and `L`
-is compact, then `f ⁻¹' L`, with the topology induced from `E`, is a locally compact space.
+/-- **The preimage of a compact set under a map with upper semi-Fredholm derivative is locally
+compact.** If `f` is strictly differentiable at each point of `f ⁻¹' L`, its derivative there has
+closed range and finite-dimensional complemented kernel, and `L` is compact, then `f ⁻¹' L`, with
+the topology induced from `E`, is a locally compact space.
 
 No compactness is assumed of the ambient Banach space, and none is available: the point is that
-the Fredholm condition confines the failure of local compactness to the finite-dimensional kernel
-direction, which is itself locally compact and is controlled locally by the kernel projection. -/
+the hypotheses confine the failure of local compactness to the finite-dimensional kernel
+direction, which is itself locally compact and is controlled by the kernel projection. -/
 theorem locallyCompactSpace_preimage {D : E → E →L[𝕜] F} {L : Set F} (hL : IsCompact L)
     (hf : ∀ x ∈ f ⁻¹' L, HasStrictFDerivAt f (D x) x)
-    (hD : ∀ x ∈ f ⁻¹' L, (D x).IsFredholm) :
+    (hclosed : ∀ x ∈ f ⁻¹' L, IsClosed ((D x).range : Set F))
+    (hfinite : ∀ x ∈ f ⁻¹' L, FiniteDimensional 𝕜 (D x).ker)
+    (hcompl : ∀ x ∈ f ⁻¹' L, (D x).ker.ClosedComplemented) :
     LocallyCompactSpace (f ⁻¹' L) := by
   have : WeaklyLocallyCompactSpace (f ⁻¹' L) := by
     refine ⟨fun x => ?_⟩
     obtain ⟨N, hN, hprop⟩ :=
-      (hf x x.2).exists_mem_nhds_forall_isCompact_inter_preimage (hD x x.2)
+      (hf x x.2).exists_mem_nhds_forall_isCompact_inter_preimage
+        (hclosed x x.2) (hfinite x x.2) (hcompl x x.2)
     refine ⟨(Subtype.val : (f ⁻¹' L) → E) ⁻¹' N, ?_, ?_⟩
     · rw [Topology.IsEmbedding.subtypeVal.isCompact_iff, Subtype.image_preimage_coe,
         Set.inter_comm]
@@ -196,13 +207,15 @@ theorem locallyCompactSpace_preimage {D : E → E →L[𝕜] F} {L : Set F} (hL 
     · exact continuous_subtype_val.continuousAt.preimage_mem_nhds hN
   infer_instance
 
-/-- **A level set of a map with Fredholm derivative is locally compact**: the case `L = {c}` of
-`TauCeti.locallyCompactSpace_preimage`, and the shape every moduli space of a Fredholm problem
-takes. -/
+/-- **A level set of a map with upper semi-Fredholm derivative is locally compact**: the case
+`L = {c}` of `TauCeti.locallyCompactSpace_preimage`, and the shape every moduli space of a Fredholm
+problem takes. -/
 theorem locallyCompactSpace_preimage_singleton {D : E → E →L[𝕜] F} {c : F}
     (hf : ∀ x ∈ f ⁻¹' {c}, HasStrictFDerivAt f (D x) x)
-    (hD : ∀ x ∈ f ⁻¹' {c}, (D x).IsFredholm) :
+    (hclosed : ∀ x ∈ f ⁻¹' {c}, IsClosed ((D x).range : Set F))
+    (hfinite : ∀ x ∈ f ⁻¹' {c}, FiniteDimensional 𝕜 (D x).ker)
+    (hcompl : ∀ x ∈ f ⁻¹' {c}, (D x).ker.ClosedComplemented) :
     LocallyCompactSpace (f ⁻¹' {c}) :=
-  locallyCompactSpace_preimage isCompact_singleton hf hD
+  locallyCompactSpace_preimage isCompact_singleton hf hclosed hfinite hcompl
 
 end TauCeti

--- a/TauCeti/Analysis/Normed/Operator/ClosedRange.lean
+++ b/TauCeti/Analysis/Normed/Operator/ClosedRange.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Normed.Operator.Banach
+public import Mathlib.Topology.Algebra.Module.Complement
+
+/-!
+# The a priori estimate of a closed-range operator
+
+A continuous linear map `T : E →L[𝕜] F` between Banach spaces with closed range fails to be
+bounded below only in the direction of its kernel. When that kernel is complemented, this file
+makes the failure quantitative, in the classical form
+
+`‖x‖ ≤ C * ‖T x‖ + ‖P x‖`,
+
+where `P` is a continuous projection of `E` onto `ker T`. When the kernel is in addition
+finite-dimensional the estimate turns an operator bound into a compactness statement: the
+correction term ranges over a finite-dimensional — hence locally compact — direction.
+
+The proof is one application of the open mapping theorem, in the packaged form
+`ContinuousLinearMap.antilipschitz_of_injective_of_isClosed_range`: on a topological complement
+`X₁` of the kernel, `T` is injective with closed range, so it is bounded below there. Mathlib's
+file carries a `TODO` asking for exactly this generalisation once Fredholm operators are available.
+
+## Main declarations
+
+* `ContinuousLinearMap.exists_norm_le_mul_norm_of_isTopCompl`: a closed-range operator is bounded
+  below on any topological complement of its kernel.
+* `ContinuousLinearMap.exists_norm_le_mul_norm_add_norm_projectionL`: the a priori estimate
+  against the projection onto the kernel determined by a chosen complement.
+* `ContinuousLinearMap.exists_projection_norm_le_mul_norm_add_norm`: the same estimate with the
+  complement discharged, so that the only data left is a continuous projection with range the
+  kernel.
+
+Nothing here is Fredholm theory — only a closed range and a complemented kernel are used — but the
+Fredholm reading is the intended one: `TauCeti.Analysis.Fredholm.Estimate` specialises the last
+estimate to a Fredholm operator, and `TauCeti.Analysis.Fredholm.Proper` uses it to prove that a map
+with Fredholm derivative is proper near a point (Smale, *An infinite dimensional version of Sard's
+theorem*, Amer. J. Math. 87 (1965)), as Lane F0 of the analytic Heegaard Floer roadmap asks.
+-/
+
+public section
+
+namespace TauCeti
+
+open Submodule
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+variable {T : E →L[𝕜] F} {X₁ : Submodule 𝕜 E}
+variable [CompleteSpace E] [CompleteSpace F]
+
+/-- **A closed-range operator is bounded below off its kernel.** On any topological complement
+`X₁` of `ker T` there is a constant `C > 0` with `‖x‖ ≤ C * ‖T x‖` for every `x ∈ X₁`.
+
+This is `ContinuousLinearMap.antilipschitz_of_injective_of_isClosed_range` applied to the
+restriction of `T` to `X₁`, which is injective because `X₁` meets the kernel trivially, and has
+closed range because that range is the range of `T`. -/
+theorem _root_.ContinuousLinearMap.exists_norm_le_mul_norm_of_isTopCompl (T : E →L[𝕜] F)
+    (hclosed : IsClosed (T.range : Set F)) (h : IsTopCompl (T.ker) X₁) :
+    ∃ C > 0, ∀ x ∈ X₁, ‖x‖ ≤ C * ‖T x‖ := by
+  have : CompleteSpace X₁ := h.isClosed'.completeSpace_coe
+  have hinj : Function.Injective (T ∘L X₁.subtypeL) := by
+    intro x y hxy
+    have hxy' : T (x : E) = T (y : E) := by simpa using hxy
+    have hmem : (x : E) - (y : E) ∈ T.ker ⊓ X₁ := by
+      refine ⟨LinearMap.mem_ker.2 ?_, X₁.sub_mem x.2 y.2⟩
+      simp [map_sub, hxy']
+    rw [h.isCompl.inf_eq_bot] at hmem
+    exact Subtype.ext (sub_eq_zero.1 hmem)
+  have hrange : Set.range (T ∘L X₁.subtypeL) = (T.range : Set F) := by
+    have himage : Set.range (T ∘L X₁.subtypeL) = T '' (X₁ : Set E) := by
+      ext y
+      exact ⟨by rintro ⟨x, rfl⟩; exact ⟨x, x.2, rfl⟩, by rintro ⟨x, hx, rfl⟩; exact ⟨⟨x, hx⟩, rfl⟩⟩
+    have hmap : Submodule.map (T : E →ₗ[𝕜] F) X₁ = T.range :=
+      Submodule.map_eq_range_iff.2 h.isCompl.symm.codisjoint
+    rw [himage]
+    simpa using congrArg (SetLike.coe) hmap
+  obtain ⟨K, hK⟩ :=
+    (T ∘L X₁.subtypeL).antilipschitz_of_injective_of_isClosed_range hinj (hrange ▸ hclosed)
+  refine ⟨K + 1, by positivity, fun x hx => ?_⟩
+  have hx' := hK.le_mul_dist (⟨x, hx⟩ : X₁) 0
+  simp only [ContinuousLinearMap.comp_apply, coe_subtypeL, coe_subtype, map_zero,
+    dist_eq_norm, sub_zero] at hx'
+  have hK0 : (0 : ℝ) ≤ K := K.coe_nonneg
+  calc ‖x‖ ≤ (K : ℝ) * ‖T x‖ := hx'
+    _ ≤ ((K : ℝ) + 1) * ‖T x‖ := by nlinarith [norm_nonneg (T x)]
+
+/-- **The a priori estimate of a closed-range operator**, stated against the projection onto the
+kernel along a chosen topological complement: there is a `C > 0` with
+`‖x‖ ≤ C * ‖T x‖ + ‖P x‖` for all `x`, where `P` is that projection. -/
+theorem _root_.ContinuousLinearMap.exists_norm_le_mul_norm_add_norm_projectionL
+    (T : E →L[𝕜] F) (hclosed : IsClosed (T.range : Set F)) (h : IsTopCompl (T.ker) X₁) :
+    ∃ C > 0, ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖(T.ker).projectionL X₁ h x‖ := by
+  obtain ⟨C, hC, hbound⟩ := T.exists_norm_le_mul_norm_of_isTopCompl hclosed h
+  refine ⟨C, hC, fun x => ?_⟩
+  have hsum : (T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x = x :=
+    projectionL_add_projectionL_eq_self h x
+  have hq := hbound (X₁.projectionL (T.ker) h.symm x) (projectionL_apply_mem h.symm x)
+  -- `T` sees only the component of `x` in the complement, the other one lying in `ker T`
+  have hker : T ((T.ker).projectionL X₁ h x) = 0 :=
+    LinearMap.mem_ker.1 (projectionL_apply_mem h x)
+  have hTx : T (X₁.projectionL (T.ker) h.symm x) = T x := by
+    conv_rhs => rw [← hsum]
+    rw [map_add, hker, zero_add]
+  rw [hTx] at hq
+  calc ‖x‖ = ‖(T.ker).projectionL X₁ h x + X₁.projectionL (T.ker) h.symm x‖ := by rw [hsum]
+    _ ≤ ‖(T.ker).projectionL X₁ h x‖ + ‖X₁.projectionL (T.ker) h.symm x‖ := norm_add_le _ _
+    _ ≤ ‖(T.ker).projectionL X₁ h x‖ + C * ‖T x‖ := by gcongr
+    _ = C * ‖T x‖ + ‖(T.ker).projectionL X₁ h x‖ := by ring
+
+/-- **The a priori estimate of a closed-range operator with complemented kernel**, with the
+complement discharged: there is a continuous projection `P` of `E` onto `ker T` and a constant
+`C > 0` with
+`‖x‖ ≤ C * ‖T x‖ + ‖P x‖`.
+
+When `ker T` is finite-dimensional, the correction term `‖P x‖` ranges over a finite-dimensional
+space; in particular, this says that a Fredholm operator is bounded below "up to a compact
+error". -/
+theorem _root_.ContinuousLinearMap.exists_projection_norm_le_mul_norm_add_norm (T : E →L[𝕜] F)
+    (hclosed : IsClosed (T.range : Set F)) (hcompl : T.ker.ClosedComplemented) :
+    ∃ (P : E →L[𝕜] E) (C : ℝ), 0 < C ∧ IsIdempotentElem P ∧ P.range = T.ker ∧
+      ∀ x, ‖x‖ ≤ C * ‖T x‖ + ‖P x‖ := by
+  obtain ⟨X₁, h⟩ := hcompl.exists_isTopCompl
+  obtain ⟨C, hC, hbound⟩ := T.exists_norm_le_mul_norm_add_norm_projectionL hclosed h
+  exact ⟨(T.ker).projectionL X₁ h, C, hC, isIdempotentElem_projectionL h,
+    range_projectionL h, hbound⟩
+
+end TauCeti


### PR DESCRIPTION
This PR proves that a map between Banach spaces whose derivative at a point is a Fredholm operator is proper on a neighbourhood of that point, and deduces that the preimage of a compact set — in particular a level set — along which the derivative is Fredholm is a locally compact space, even though the ambient Banach space is not. This is Smale's local properness lemma (Smale, *An infinite dimensional version of Sard's theorem*, Amer. J. Math. 87 (1965), 861–866; McDuff–Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix A), together with the linear a priori estimate `‖x‖ ≤ C * ‖T x‖ + ‖P x‖` it rests on.

The target is Lane F0 of the HeegaardFloer roadmap, whose next unmet milestone is **Sard–Smale** ("Finite-dimensional Sard; Fredholm operators …; **Sard–Smale** (Smale 1965); the 'moduli space = zero set of a Fredholm section, generically a manifold of dimension = index' package (McDuff–Salamon, Appendix A)"). Local properness is the standard prerequisite of that milestone: it is what makes the critical values of a Fredholm map locally closed, and hence what upgrades Sard–Smale from "the regular values are dense" to "the regular values are residual". It also completes the topological half of the moduli-space package whose chart half already lives in `TauCeti/Analysis/Fredholm/LevelSet.lean`: that file gives a regular level set its charts, and this one gives it local compactness. What remains for the Sard–Smale milestone after this PR is the local normal form of a Fredholm map together with the slice-wise application of finite-dimensional Sard, and — for indices above zero — the Morse–Sard theorem in the dimension range that `TauCeti/Analysis/Calculus/Sard/` does not yet cover.

`TauCeti/Analysis/Fredholm/Estimate.lean` (150 lines) proves that a Fredholm operator is bounded below on any topological complement of its kernel, by applying Mathlib's `ContinuousLinearMap.antilipschitz_of_injective_of_isClosed_range` to the restriction — Mathlib's file carries a `TODO` asking for exactly this generalisation once Fredholm operators exist — and packages the result as `‖x‖ ≤ C * ‖T x‖ + ‖P x‖` with `P` a continuous projection onto `ker T`. `TauCeti/Analysis/Fredholm/Proper.lean` (207 lines) turns that, through strict differentiability, into the two-sided bound `‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖` on a small closed ball, so that `x ↦ (f x, P x)` is anti-Lipschitz there; its second component lands in the finite-dimensional `ker f'`, where bounded sets have compact closure, so the anti-Lipschitz map reflects total boundedness of a compact box and the intersection is totally bounded and closed, hence compact.

Everything is built from Mathlib's existing API (`ContinuousLinearMap.IsFredholm`, `Submodule.projectionL`, `ApproximatesLinearOn`, `AntilipschitzWith.isUniformInducing`, `totallyBounded_preimage`); nothing is vendored, and no new definitions are introduced — the two files are theorems only.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"fredholm-locally-proper"}-->

🤖 Prepared with Claude Code
