### PR TITLE
refactor(CongruenceSubgroups): name the Chinese-remainder lift

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -519,6 +519,29 @@ private lemma mem_Gamma_and_inv_mul_mem_Gamma_of_map_eq {a b : ℕ}
     rw [hβ_b]
     exact inv_mul_cancel _
 
+/-- **The Chinese remainder theorem lifts a matrix of `Γ(gcd a b)` simultaneously.** For
+`γ ∈ Γ(gcd a b)` there is an integer matrix congruent to the identity modulo `a` and to `γ`
+modulo `b`. -/
+private lemma exists_matrix_modEq_one_modEq_of_mem_Gamma_gcd {a b : ℕ} {γ : SL(2, ℤ)}
+    (hγ : γ ∈ Gamma (Nat.gcd a b)) :
+    ∃ M : Matrix (Fin 2) (Fin 2) ℤ,
+      (∀ i j, M i j ≡ ((1 : SL(2, ℤ)) i j : ℤ) [ZMOD (a : ℤ)]) ∧
+        ∀ i j, M i j ≡ (γ i j : ℤ) [ZMOD (b : ℤ)] := by
+  have hcompat : ∀ i j : Fin 2,
+      ((1 : SL(2, ℤ)) i j : ℤ) ≡ (γ i j : ℤ) [ZMOD ↑(Int.gcd (a : ℤ) (b : ℤ))] := by
+    -- `Int.gcd` of two casts is the `Nat.gcd` of the naturals; the two spellings of the
+    -- modulus are equal but not syntactically interchangeable.
+    have hgcd : (↑(Int.gcd (a : ℤ) (b : ℤ)) : ℤ) = ↑(Nat.gcd a b) := by simp [Int.gcd]
+    rw [hgcd]
+    exact intCast_apply_modEq_one_of_mem_Gamma _ γ hγ
+  obtain ⟨z00, hz00a, hz00b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 0 0)
+  obtain ⟨z01, hz01a, hz01b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 0 1)
+  obtain ⟨z10, hz10a, hz10b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 1 0)
+  obtain ⟨z11, hz11a, hz11b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 1 1)
+  refine ⟨!![z00, z01; z10, z11], ?_, ?_⟩ <;>
+    · intro i j
+      fin_cases i <;> fin_cases j <;> assumption
+
 /-- **Shimura, Lemma 3.28.** `Γ(gcd a b) = Γ(a) ⊔ Γ(b)`: the join of two principal congruence
 subgroups is the principal congruence subgroup of the gcd.
 
@@ -541,24 +564,7 @@ theorem Gamma_gcd_eq_sup (a b : ℕ) : Gamma (Nat.gcd a b) = Gamma a ⊔ Gamma b
   have : (Gamma a).Normal := Gamma_normal a
   intro γ hγ
   rw [Subgroup.mem_sup_of_normal_left]
-  have hcompat : ∀ i j : Fin 2,
-      ((1 : SL(2, ℤ)) i j : ℤ) ≡ (γ i j : ℤ) [ZMOD ↑(Int.gcd (a : ℤ) (b : ℤ))] := by
-    -- `Int.gcd` of two casts is the `Nat.gcd` of the naturals; the two spellings of the
-    -- modulus are equal but not syntactically interchangeable.
-    have hgcd : (↑(Int.gcd (a : ℤ) (b : ℤ)) : ℤ) = ↑(Nat.gcd a b) := by simp [Int.gcd]
-    rw [hgcd]
-    exact intCast_apply_modEq_one_of_mem_Gamma _ γ hγ
-  obtain ⟨z00, hz00a, hz00b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 0 0)
-  obtain ⟨z01, hz01a, hz01b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 0 1)
-  obtain ⟨z10, hz10a, hz10b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 1 0)
-  obtain ⟨z11, hz11a, hz11b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 1 1)
-  set M : Matrix (Fin 2) (Fin 2) ℤ := !![z00, z01; z10, z11]
-  have hMa : ∀ i j, M i j ≡ ((1 : SL(2, ℤ)) i j : ℤ) [ZMOD (a : ℤ)] := by
-    intro i j
-    fin_cases i <;> fin_cases j <;> assumption
-  have hMb : ∀ i j, M i j ≡ (γ i j : ℤ) [ZMOD (b : ℤ)] := by
-    intro i j
-    fin_cases i <;> fin_cases j <;> assumption
+  obtain ⟨M, hMa, hMb⟩ := exists_matrix_modEq_one_modEq_of_mem_Gamma_gcd hγ
   have hM_det : (M.map (Int.castRingHom (ZMod (Nat.lcm a b)))).det = 1 := by
     simp only [Matrix.det_fin_two, Matrix.map_apply, Int.coe_castRingHom]
     have h := (ZMod.intCast_eq_intCast_iff _ _ _).mpr (det_fin_two_modEq_one_lcm hMa hMb)

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -534,13 +534,8 @@ private lemma exists_matrix_modEq_one_modEq_of_mem_Gamma_gcd {a b : ℕ} {γ : S
     have hgcd : (↑(Int.gcd (a : ℤ) (b : ℤ)) : ℤ) = ↑(Nat.gcd a b) := by simp [Int.gcd]
     rw [hgcd]
     exact intCast_apply_modEq_one_of_mem_Gamma _ γ hγ
-  obtain ⟨z00, hz00a, hz00b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 0 0)
-  obtain ⟨z01, hz01a, hz01b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 0 1)
-  obtain ⟨z10, hz10a, hz10b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 1 0)
-  obtain ⟨z11, hz11a, hz11b⟩ := exists_int_modEq_of_modEq_gcd (hcompat 1 1)
-  refine ⟨!![z00, z01; z10, z11], ?_, ?_⟩ <;>
-    · intro i j
-      fin_cases i <;> fin_cases j <;> assumption
+  choose z hza hzb using fun i j => exists_int_modEq_of_modEq_gcd (hcompat i j)
+  exact ⟨Matrix.of z, hza, hzb⟩
 
 /-- **Shimura, Lemma 3.28.** `Γ(gcd a b) = Γ(a) ⊔ Γ(b)`: the join of two principal congruence
 subgroups is the principal congruence subgroup of the gcd.


### PR DESCRIPTION
#3171 took `Gamma_gcd_eq_sup` (Shimura Lemma 3.28) from 71 lines to 41 by naming its determinant
and splitting steps. What remained as the bulk of the proof is its opening: turning
`γ ∈ Γ(gcd a b)` into an integer matrix congruent to the identity modulo `a` and to `γ` modulo
`b`. That is the Chinese remainder theorem applied entrywise. Name it. No statement changes; no
new public declaration.

## The extracted helper

```lean
private lemma exists_matrix_modEq_one_modEq_of_mem_Gamma_gcd {a b : ℕ} {γ : SL(2, ℤ)}
    (hγ : γ ∈ Gamma (Nat.gcd a b)) :
    ∃ M : Matrix (Fin 2) (Fin 2) ℤ,
      (∀ i j, M i j ≡ ((1 : SL(2, ℤ)) i j : ℤ) [ZMOD (a : ℤ)]) ∧
        ∀ i j, M i j ≡ (γ i j : ℤ) [ZMOD (b : ℤ)]
```

**Its only hypothesis is `hγ`.** The enclosing theorem first disposes of `a = 0` and `b = 0`,
installs `NeZero a`, `NeZero b`, `NeZero (Nat.lcm a b)`, and invokes the normality of `Γ(a)`
before it can proceed; the lift needs none of that. It is in fact *more* general than the
context it came from — at a zero level `[ZMOD 0]` is equality and the statement still holds,
whereas the theorem genuinely needs the level positive.

It is also the only part of the proof that mentions `Gamma`: everything downstream is about
matrices and their reductions.

## The lift is pointwise

The first draft called `exists_int_modEq_of_modEq_gcd` at each of the four entries and
reassembled them with `fin_cases`. Review pointed out that this is what `choose` does uniformly:

```lean
choose z hza hzb using fun i j => exists_int_modEq_of_modEq_gcd (hcompat i j)
exact ⟨Matrix.of z, hza, hzb⟩
```

Nothing is specialised to four entries any more, and the helper is 9 lines rather than 14.

The parent consequently no longer needs the `set` that named the matrix — it `obtain`s it.

## Result

| | before | after |
|---|---|---|
| `Gamma_gcd_eq_sup` | 41 | 24 |
| `exists_matrix_modEq_one_modEq_of_mem_Gamma_gcd` | — | 9 |

Together with #3171 the theorem goes 71 → 24, with three named steps: the CRT lift, the
determinant congruence, and the splitting of `γ`.

Gates run on `a8f02fd6`: `lake build` (7798 jobs), `lake exe axioms` (44576 declarations),
`lake exe module-system` (2138 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: ModularForms