### PR TITLE
refactor(EllipticCurve): name the two derivative transformation laws of the change of variables

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/VariableChange.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/VariableChange.lean
@@ -151,11 +151,12 @@ change of variables scales the Weierstrass polynomial by `u⁶`, and `u` is a un
       - (C.u : R) ^ 3 * y * u_pow_mul_variableChange_a₃ W C
       + (C.u : R) ^ 2 * x * u_pow_mul_variableChange_a₄ W C + u_pow_mul_variableChange_a₆ W C
 
-/-- **The `Y`-partial derivative under the change of variables**, scaling by `u³`. Both sides are
-`polynomialY` evaluated at a point, written in the expanded form that `evalEval_polynomialY` and
-`nonsingular_iff'` produce; this is the second row of the matrix in `variableChange_nonsingular`
+/-- **The `Y`-partial derivative under the change of variables**, scaling by `u³`. The left-hand
+side is `W.polynomialY` at the image point, the right-hand side `u³` times `(C • W).polynomialY`
+at the source, both written in the expanded form that `evalEval_polynomialY` and
+`nonsingular_iff'` produce. This is the second row of the matrix in `variableChange_nonsingular`
 below. -/
-private lemma variableChange_polynomialY_eval (x y : R) :
+private lemma variableChange_evalEval_polynomialY (x y : R) :
     2 * ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
         + W.a₁ * ((C.u : R) ^ 2 * x + C.r) + W.a₃
       = (C.u : R) ^ 3 * (2 * y + (C • W).a₁ * x + (C • W).a₃) := by
@@ -163,10 +164,13 @@ private lemma variableChange_polynomialY_eval (x y : R) :
     - u_pow_mul_variableChange_a₃ W C
 
 /-- **The `X`-partial derivative under the change of variables**, scaling by `u⁴` and shearing by
-an `s`-multiple of the `Y`-partial. Both sides are `polynomialX` evaluated at a point, in the same
-expanded form as `variableChange_polynomialY_eval`; this is the first row of the matrix in
-`variableChange_nonsingular` below, and the only place the shear `s` enters a derivative. -/
-private lemma variableChange_polynomialX_eval (x y : R) :
+an `s`-multiple of the `Y`-partial. The left-hand side is `W.polynomialX` at the image point. The
+right-hand side is *not* a `polynomialX` alone: it is `u⁴` times `(C • W).polynomialX` at the
+source, minus `s` times `u³` times `(C • W).polynomialY` there — the shear is what makes this the
+first row `(u⁴, -su³)` of the matrix in `variableChange_nonsingular` below, and this is the only
+identity in the file in which `s` enters a derivative. Everything is in the expanded form that
+`evalEval_polynomialX`, `evalEval_polynomialY` and `nonsingular_iff'` produce. -/
+private lemma variableChange_evalEval_polynomialX (x y : R) :
     W.a₁ * ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
         - (3 * ((C.u : R) ^ 2 * x + C.r) ^ 2 + 2 * W.a₂ * ((C.u : R) ^ 2 * x + C.r) + W.a₄)
       = (C.u : R) ^ 4 * ((C • W).a₁ * y - (3 * x ^ 2 + 2 * (C • W).a₂ * x + (C • W).a₄))
@@ -189,7 +193,7 @@ curve, whereas carrying a point to a point needs no such hypothesis. -/
       ↔ (C • W).toAffine.Nonsingular x y := by
   rw [nonsingular_iff', nonsingular_iff', variableChange_equation]
   refine and_congr_right fun _ ↦ ?_
-  rw [variableChange_polynomialX_eval W C x y, variableChange_polynomialY_eval W C x y,
+  rw [variableChange_evalEval_polynomialX W C x y, variableChange_evalEval_polynomialY W C x y,
     ← not_and_or, ← not_and_or]
   refine not_congr ⟨fun ⟨h1, h2⟩ ↦ ?_, fun ⟨h1, h2⟩ ↦ ?_⟩
   · have hB := (C.u.isUnit.pow 3).mul_right_eq_zero.mp h2

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/VariableChange.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/VariableChange.lean
@@ -151,9 +151,34 @@ change of variables scales the Weierstrass polynomial by `u⁶`, and `u` is a un
       - (C.u : R) ^ 3 * y * u_pow_mul_variableChange_a₃ W C
       + (C.u : R) ^ 2 * x * u_pow_mul_variableChange_a₄ W C + u_pow_mul_variableChange_a₆ W C
 
+/-- **The `Y`-partial derivative under the change of variables**, scaling by `u³`. Both sides are
+`polynomialY` evaluated at a point, written in the expanded form that `evalEval_polynomialY` and
+`nonsingular_iff'` produce; this is the second row of the matrix in `variableChange_nonsingular`
+below. -/
+private lemma variableChange_polynomialY_eval (x y : R) :
+    2 * ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
+        + W.a₁ * ((C.u : R) ^ 2 * x + C.r) + W.a₃
+      = (C.u : R) ^ 3 * (2 * y + (C • W).a₁ * x + (C • W).a₃) := by
+  linear_combination (-(C.u : R) ^ 2 * x) * u_mul_variableChange_a₁ W C
+    - u_pow_mul_variableChange_a₃ W C
+
+/-- **The `X`-partial derivative under the change of variables**, scaling by `u⁴` and shearing by
+an `s`-multiple of the `Y`-partial. Both sides are `polynomialX` evaluated at a point, in the same
+expanded form as `variableChange_polynomialY_eval`; this is the first row of the matrix in
+`variableChange_nonsingular` below, and the only place the shear `s` enters a derivative. -/
+private lemma variableChange_polynomialX_eval (x y : R) :
+    W.a₁ * ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
+        - (3 * ((C.u : R) ^ 2 * x + C.r) ^ 2 + 2 * W.a₂ * ((C.u : R) ^ 2 * x + C.r) + W.a₄)
+      = (C.u : R) ^ 4 * ((C • W).a₁ * y - (3 * x ^ 2 + 2 * (C • W).a₂ * x + (C • W).a₄))
+        - C.s * ((C.u : R) ^ 3 * (2 * y + (C • W).a₁ * x + (C • W).a₃)) := by
+  linear_combination (-(C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x) * u_mul_variableChange_a₁ W C
+    + (2 * (C.u : R) ^ 2 * x) * u_pow_mul_variableChange_a₂ W C
+    + C.s * u_pow_mul_variableChange_a₃ W C + u_pow_mul_variableChange_a₄ W C
+
 /-- **Nonsingularity transfers across the change of variables.** The two partial derivatives
-transform by the matrix `![![u⁴, -su³], ![0, u³]]`, which is invertible because `u` is, so
-`W_X ≠ 0 ∨ W_Y ≠ 0` holds at the image exactly when it holds at the source.
+transform by the matrix `![![u⁴, -su³], ![0, u³]]` — the two lemmas just above — which is
+invertible because `u` is, so `W_X ≠ 0 ∨ W_Y ≠ 0` holds at the image exactly when it holds at the
+source.
 
 This is what lets the point map of `Affine/Point/VariableChange.lean` avoid `[W.IsElliptic]`:
 `equation_iff_nonsingular` would supply nonsingularity from the equation, but only for an elliptic
@@ -162,23 +187,10 @@ curve, whereas carrying a point to a point needs no such hypothesis. -/
     W.toAffine.Nonsingular ((C.u : R) ^ 2 * x + C.r)
         ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
       ↔ (C • W).toAffine.Nonsingular x y := by
-  -- `W_Y` scales by `u³`
-  have hY : 2 * ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
-        + W.a₁ * ((C.u : R) ^ 2 * x + C.r) + W.a₃
-      = (C.u : R) ^ 3 * (2 * y + (C • W).a₁ * x + (C • W).a₃) := by
-    linear_combination (-(C.u : R) ^ 2 * x) * u_mul_variableChange_a₁ W C
-      - u_pow_mul_variableChange_a₃ W C
-  -- `W_X` scales by `u⁴`, shifted by an `s`-multiple of `W_Y`
-  have hX : W.a₁ * ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
-        - (3 * ((C.u : R) ^ 2 * x + C.r) ^ 2 + 2 * W.a₂ * ((C.u : R) ^ 2 * x + C.r) + W.a₄)
-      = (C.u : R) ^ 4 * ((C • W).a₁ * y - (3 * x ^ 2 + 2 * (C • W).a₂ * x + (C • W).a₄))
-        - C.s * ((C.u : R) ^ 3 * (2 * y + (C • W).a₁ * x + (C • W).a₃)) := by
-    linear_combination (-(C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x) * u_mul_variableChange_a₁ W C
-      + (2 * (C.u : R) ^ 2 * x) * u_pow_mul_variableChange_a₂ W C
-      + C.s * u_pow_mul_variableChange_a₃ W C + u_pow_mul_variableChange_a₄ W C
   rw [nonsingular_iff', nonsingular_iff', variableChange_equation]
   refine and_congr_right fun _ ↦ ?_
-  rw [hX, hY, ← not_and_or, ← not_and_or]
+  rw [variableChange_polynomialX_eval W C x y, variableChange_polynomialY_eval W C x y,
+    ← not_and_or, ← not_and_or]
   refine not_congr ⟨fun ⟨h1, h2⟩ ↦ ?_, fun ⟨h1, h2⟩ ↦ ?_⟩
   · have hB := (C.u.isUnit.pow 3).mul_right_eq_zero.mp h2
     rw [hB, mul_zero, mul_zero, sub_zero] at h1

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/VariableChange.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/VariableChange.lean
@@ -12,13 +12,18 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Formula
 An admissible change of variables `C : VariableChange R` carries a point `(x, y)` of `C • W` to
 the point `(u²x + r, u³y + u²sx + t)` of `W`. This file records what that substitution does to
 each formula Mathlib's `Affine/Formula.lean` defines — `negY`, `addX`, `negAddY`, `addY` and
-`slope` — and to the two predicates `Equation` and `Nonsingular` that cut the curve out.
+`slope` — to the two partial derivatives `polynomialX` and `polynomialY`, and to the two
+predicates `Equation` and `Nonsingular` that cut the curve out.
 
 ## Main statements
 
 * `WeierstrassCurve.Affine.variableChange_negY`, `_addX`, `_negAddY`, `_addY`: each formula
   transforms by an explicit power of `u`, together with the shear and translation the change of
   variables applies to the coordinate concerned.
+* `WeierstrassCurve.Affine.variableChange_evalEval_polynomialX`, `_polynomialY`: the two partial
+  derivatives transform by the matrix `![![u⁴, -su³], ![0, u³]]` — the `Y`-partial simply scales
+  by `u³`, while the `X`-partial scales by `u⁴` and is sheared by an `s`-multiple of the
+  `Y`-partial. Invertibility of that matrix is what `variableChange_nonsingular` runs on.
 * `WeierstrassCurve.Affine.variableChange_equation`, `_nonsingular`: `(x, y)` lies on `C • W`,
   respectively is a smooth point of it, exactly when its image lies on `W`. Both are `@[simp]`.
   These are what make the change of variables carry points to points.
@@ -151,30 +156,29 @@ change of variables scales the Weierstrass polynomial by `u⁶`, and `u` is a un
       - (C.u : R) ^ 3 * y * u_pow_mul_variableChange_a₃ W C
       + (C.u : R) ^ 2 * x * u_pow_mul_variableChange_a₄ W C + u_pow_mul_variableChange_a₆ W C
 
-/-- **The `Y`-partial derivative under the change of variables**, scaling by `u³`. The left-hand
-side is `W.polynomialY` at the image point, the right-hand side `u³` times `(C • W).polynomialY`
-at the source, both written in the expanded form that `evalEval_polynomialY` and
-`nonsingular_iff'` produce. This is the second row of the matrix in `variableChange_nonsingular`
-below. -/
-private lemma variableChange_evalEval_polynomialY (x y : R) :
-    2 * ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
-        + W.a₁ * ((C.u : R) ^ 2 * x + C.r) + W.a₃
-      = (C.u : R) ^ 3 * (2 * y + (C • W).a₁ * x + (C • W).a₃) := by
+/-- **`polynomialY` under the change of variables**, scaling by `u³`. The `Y`-partial derivative
+of the Weierstrass polynomial, evaluated at the image point, is `u³` times the corresponding
+derivative of `C • W` evaluated at the source point. This is the second row `(0, u³)` of the
+matrix in `variableChange_nonsingular` below. -/
+lemma variableChange_evalEval_polynomialY (x y : R) :
+    W.toAffine.polynomialY.evalEval ((C.u : R) ^ 2 * x + C.r)
+        ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
+      = (C.u : R) ^ 3 * (C • W).toAffine.polynomialY.evalEval x y := by
+  simp only [evalEval_polynomialY]
   linear_combination (-(C.u : R) ^ 2 * x) * u_mul_variableChange_a₁ W C
     - u_pow_mul_variableChange_a₃ W C
 
-/-- **The `X`-partial derivative under the change of variables**, scaling by `u⁴` and shearing by
-an `s`-multiple of the `Y`-partial. The left-hand side is `W.polynomialX` at the image point. The
-right-hand side is *not* a `polynomialX` alone: it is `u⁴` times `(C • W).polynomialX` at the
-source, minus `s` times `u³` times `(C • W).polynomialY` there — the shear is what makes this the
-first row `(u⁴, -su³)` of the matrix in `variableChange_nonsingular` below, and this is the only
-identity in the file in which `s` enters a derivative. Everything is in the expanded form that
-`evalEval_polynomialX`, `evalEval_polynomialY` and `nonsingular_iff'` produce. -/
-private lemma variableChange_evalEval_polynomialX (x y : R) :
-    W.a₁ * ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
-        - (3 * ((C.u : R) ^ 2 * x + C.r) ^ 2 + 2 * W.a₂ * ((C.u : R) ^ 2 * x + C.r) + W.a₄)
-      = (C.u : R) ^ 4 * ((C • W).a₁ * y - (3 * x ^ 2 + 2 * (C • W).a₂ * x + (C • W).a₄))
-        - C.s * ((C.u : R) ^ 3 * (2 * y + (C • W).a₁ * x + (C • W).a₃)) := by
+/-- **`polynomialX` under the change of variables**, scaling by `u⁴` and picking up a shear. The
+`X`-partial derivative, evaluated at the image point, is `u⁴` times the corresponding derivative
+of `C • W` at the source point, *minus* `s` times the `u³`-scaled `Y`-partial there. That extra
+shear term is the one asymmetry between the two derivative laws, and it makes this the first row
+`(u⁴, -su³)` of the matrix in `variableChange_nonsingular` below. -/
+lemma variableChange_evalEval_polynomialX (x y : R) :
+    W.toAffine.polynomialX.evalEval ((C.u : R) ^ 2 * x + C.r)
+        ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
+      = (C.u : R) ^ 4 * (C • W).toAffine.polynomialX.evalEval x y
+        - C.s * ((C.u : R) ^ 3 * (C • W).toAffine.polynomialY.evalEval x y) := by
+  simp only [evalEval_polynomialX, evalEval_polynomialY]
   linear_combination (-(C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x) * u_mul_variableChange_a₁ W C
     + (2 * (C.u : R) ^ 2 * x) * u_pow_mul_variableChange_a₂ W C
     + C.s * u_pow_mul_variableChange_a₃ W C + u_pow_mul_variableChange_a₄ W C
@@ -191,7 +195,7 @@ curve, whereas carrying a point to a point needs no such hypothesis. -/
     W.toAffine.Nonsingular ((C.u : R) ^ 2 * x + C.r)
         ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
       ↔ (C • W).toAffine.Nonsingular x y := by
-  rw [nonsingular_iff', nonsingular_iff', variableChange_equation]
+  rw [Nonsingular, Nonsingular, variableChange_equation]
   refine and_congr_right fun _ ↦ ?_
   rw [variableChange_evalEval_polynomialX W C x y, variableChange_evalEval_polynomialY W C x y,
     ← not_and_or, ← not_and_or]


### PR DESCRIPTION
`variableChange_nonsingular` carried a 38-line proof whose first two thirds were two
named-only-by-comment algebraic identities: how each partial derivative of the Weierstrass
polynomial transforms under the change of variables. This names them, as the two transformation
laws the file was otherwise missing. No statement changes to any existing declaration.

## The file already had the idiom, and these two were the gap in it

`Affine/Formula/VariableChange.lean` exists to record what the substitution
`(x, y) ↦ (u²x + r, u³y + u²sx + t)` does to each formula, one named lemma per formula —
`variableChange_negY`, `_addX`, `_negAddY`, `_addY`, `_equation`, `_slope` — each a one-line
`linear_combination` of the five private `u_pow_mul_variableChange_aᵢ` lemmas that clear Mathlib's
`u⁻¹` factors.

The two partial derivatives were the exception. They were transformed inline, inside
`variableChange_nonsingular`, as

```lean
  -- `W_Y` scales by `u³`
  have hY : … := by linear_combination …
  -- `W_X` scales by `u⁴`, shifted by an `s`-multiple of `W_Y`
  have hX : … := by linear_combination …
```

— the same kind of statement, with the same kind of proof, as every named lemma in the file, just
anonymous. And the docstring of `variableChange_nonsingular` already asserted what they say:
*"The two partial derivatives transform by the matrix `![![u⁴, -su³], ![0, u³]]`."* Nothing in the
file let a reader check that claim.

## The two laws

```lean
lemma variableChange_evalEval_polynomialY (x y : R) :
    W.toAffine.polynomialY.evalEval ((C.u : R) ^ 2 * x + C.r)
        ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
      = (C.u : R) ^ 3 * (C • W).toAffine.polynomialY.evalEval x y

lemma variableChange_evalEval_polynomialX (x y : R) :
    W.toAffine.polynomialX.evalEval ((C.u : R) ^ 2 * x + C.r)
        ((C.u : R) ^ 3 * y + (C.u : R) ^ 2 * C.s * x + C.t)
      = (C.u : R) ^ 4 * (C • W).toAffine.polynomialX.evalEval x y
        - C.s * ((C.u : R) ^ 3 * (C • W).toAffine.polynomialY.evalEval x y)
```

They are literally the matrix the docstring names: the `X` law is its first row `(u⁴, -su³)`, the
`Y` law its second row `(0, u³)`. The two are not symmetric — only the `X` law carries the shear
term — and each docstring says which one it is.

They are stated with `polynomialX.evalEval` / `polynomialY.evalEval`, Mathlib's own spelling for
evaluating a bivariate Weierstrass polynomial, so they sit beside `evalEval_polynomialX` and
`evalEval_polynomialY` rather than in a hand-expanded form. The call site correspondingly opens
with `rw [Nonsingular, Nonsingular, …]` in place of `nonsingular_iff'` — which is exactly how
Mathlib proves `nonsingular_iff'` itself (`Affine/Basic.lean:216`), and what puts the goal in
`evalEval` form for these two lemmas to rewrite.

## On these being public

They are new public declarations, and that is deliberate rather than incidental: they are
formula-level transformation laws, the same category as `variableChange_negY` and
`variableChange_equation` beside them, and the module docstring's description of what the file
covers now lists them. No new mathematics enters the repository — both identities were already
proved, inline, in the proof directly below them; what changes is that they are named, stated in
Mathlib's vocabulary, and reusable.

I first wrote them `private`, on the reasoning that a smaller public surface is the safer default
for a refactor. The `generality` rubric disagreed with that shape, and it is right: a private
lemma stated only in call-site-expanded form is under-scoped for a file whose whole purpose is
these laws.

## What is left

`variableChange_nonsingular` keeps its statement byte-for-byte and is now just the argument its
docstring describes: rewrite through the two transformation laws, then use invertibility of `u` to
move the disjunction across.

| Declaration | Before | After |
|---|---|---|
| `variableChange_nonsingular` | 38 | 25 |
| `variableChange_evalEval_polynomialY` | — | 8 |
| `variableChange_evalEval_polynomialX` | — | 10 |

Both `linear_combination` certificates are carried over unchanged, character for character; the
only edits to a tactic block are the opening `rw` and the two rewrites now naming lemmas instead
of local hypotheses. The file goes from 235 to 256 lines.

## Scope

Improvement work on existing code. No existing declaration changes its statement, nothing is
renamed or removed, and no new mathematics is added — the two new lemmas are an existing proof's
own steps, lifted out. The one downstream module, `Affine/Point/VariableChange.lean`, is untouched
and rebuilt clean. The `Roadmap:` line is attribution to the area the file belongs to, not a fresh
roadmap claim.

## Review

Three private rounds before this PR opened. Two produced findings, both taken rather than contested; the third came back all-ten-green with no findings.

* Round 1 — `naming`: the helpers carried a generic `_eval` suffix where Mathlib spells this
  operation `evalEval`. `documentation`: the `X` docstring called both sides `polynomialX`
  evaluations, understating the sheared `polynomialY` term on the right.
* Round 2 — `generality`: private, hand-expanded helpers are under-scoped for this file; state
  them as public `evalEval` laws parallel to the existing ones. `documentation`: the `X` docstring
  claimed to be the only identity in which `s` enters a derivative, but `s` appears in the image
  `y`-coordinate on both sides; what is unique to `X` is the extra `-su³·W_Y` shear term.

## Gates

Run in full at this head:

* `lake build` — the whole project, **7794 jobs**, clean, no warnings. The lakefile sets
  `warningAsError = true` with the Mathlib linter set, so this is also the lint gate.
* `scripts/lint-env.sh` — **LINT-ENV: PASS**, no new violations (68 grandfathered, 2 ratchetable,
  both pre-existing and unrelated; clearing them means editing the human-owned
  `scripts/lint-baseline.txt`, so they are left alone).
* `lake exe axioms` — **44562** declarations, all within `[propext, Classical.choice, Quot.sound]`.
* `lake exe module-system` — **2134/2134** modules opt in.

The file is 256 lines against the 1500-line limit for an existing file, and no line exceeds 100
codepoints (the maximum is 98).

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"varchange-name-derivative-scaling"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
