### PR TITLE
feat(EDS): the reduced invariant numerator of a normalised EDS

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -111,7 +111,14 @@ namespace IsEllipticNet
 
 /-- **The cancellation `reducedInvarNum` is named for**: the invariant numerator of a normalised EDS
 at `s = 1` is `reducedInvarNum` times `b`. The factor of `b` is constant in `m`, which is what makes
-the reduced form the one the division-polynomial identities are stated over. -/
+the reduced form the one the division-polynomial identities are stated over.
+
+The **priority is load-bearing**, not decoration. `invarNum_def` is itself `@[simp]`, and at equal
+priority it wins on this term: with a plain `@[simp]` here, `simp` still rewrites
+`invarNum (normEDS b c d) 1 m` to the fully expanded formula and this lemma never fires. At `high`
+it fires first, and because `reducedInvarNum_def` is deliberately *not* `@[simp]` the result then
+stays folded at `reducedInvarNum b c d m * b`, which is the normal form this file exists to name. -/
+@[simp high]
 theorem invarNum_normEDS_one_eq_reducedInvarNum_mul :
     invarNum (normEDS b c d) 1 m = reducedInvarNum b c d m * b := by
   simp_rw [reducedInvarNum_def, right_distrib, complEDS₂_mul_b, mul_assoc 2 _ b,

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.ComplAux
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Invariant
+
+/-!
+# The reduced invariant of a normalised EDS
+
+For a normalised EDS `normEDS b c d`, the invariant of `IsEllipticNet` at `s = 1` carries factors
+that are constant in the index: `IsEllipticNet.invarNum` is divisible by `b = W 2`, and
+`IsEllipticNet.invarDenom` by `b * c = W 2 * W 3`. This file names the two quotients — `redInvarNum`
+and `redInvarDenom` — and proves the cancellation for the numerator.
+
+The numerator's reduced form is a sum rather than a quotient: `redInvarNum` is defined outright as
+
+`redInvarNum b c d m = complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m`,
+
+and `invarNum_eq_redInvarNum_mul` is what identifies it as the cancellation, `invarNum` being
+`redInvarNum * b`. Reading it the other way, `complEDS₂_eq_redInvarNum_sub` expresses the second
+complement through the invariant — the step by which the elliptic-net identities reach the division
+polynomials in the Lutz–Nagell development.
+
+## Main definitions
+
+* `redInvarNum`: the invariant numerator of a normalised EDS with one factor of `b` cancelled.
+* `redInvarDenom`: the corresponding denominator, `W (m + 1) * W m * W (m - 1)` with `W 3 * W 2`
+  cancelled. Its definition splits on `m % 6`, because which of the three consecutive terms the
+  complement sequences divide depends on that residue.
+
+## Main results
+
+* `IsEllipticNet.invarNum_eq_redInvarNum_mul`: `invarNum (normEDS b c d) 1 m` is
+  `redInvarNum b c d m * b` — the cancellation the reduced numerator is named for.
+* `complEDS₂_eq_redInvarNum_sub`: the second complement read off the reduced numerator.
+* `IsEllipticNet.invarNum_normEDS`: the invariant numerator of a normalised EDS at `s = 1`, with
+  `W 1 = 1` and `W 2 = b` substituted. This is a measured prerequisite of
+  `invarNum_eq_redInvarNum_mul` rather than an addition: that proof cancels `b` against the
+  substituted `W 2`, so the substituted form has to exist first. The source names it for the same
+  reason, and the blocked layer's `invarNum_normEDS_two` and `invarDenom_normEDS_two` are the same
+  shape at a fixed index.
+
+## What is deliberately not here
+
+The two results that would connect `redInvarNum` and `redInvarDenom` to each other —
+`redInvar_normEDS` (`redInvarNum b c d m = redInvarDenom b c d m * (d + b ^ 4)`) and
+`invarDenom_eq_redInvarDenom_mul` — are **not** in this file, and are not an oversight. Both route
+through the fact that `normEDS` is an elliptic sequence, along
+
+`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS ← IsEllipticSequence.normEDS`
+
+for the first, and `invarDenom_eq_redInvarDenom_mul ← normEDS_mul_complEDS_div ←
+normEDS_mul_complEDS ← normEDS_mul_complEDS_of_mem ← IsEllipticSequence.normEDS` for the second.
+That fact is not in the pinned Mathlib, which records it as an open TODO
+(`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean`: "prove that `normEDS` satisfies
+`IsEllipticDvdSequence`"), and proving it needs the parity-transfer machinery of Mathlib PR #42453.
+Everything in this file is independent of it: nothing below carries an ellipticity hypothesis, and
+the source discharges the ellipticity variables over exactly this block.
+
+## Provenance
+
+Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invarNum_normEDS`, `redInvarNum`,
+`compl₂EDS_eq_redInvarNum_sub`, `invarNum_eq_redInvarNum_mul` and `redInvarDenom`. That file's
+header reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
+upstream authorship is credited here rather than in the copyright header.
+
+The same declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), the upstreaming
+of that AINTLIB file, so they are portable under this project's rule and deduplicate when it lands.
+They are spelt with Mathlib's later names (`compl₂EDS → complEDS₂`, `IsEllSequence →
+IsEllipticSequence`), which #13057 predates, and follow `ComplAux.lean` in keeping the
+`normEDS`-family declarations in the **root** namespace where Mathlib keeps `normEDS`, `complEDS`
+and `complEDS₂`; the two results about `IsEllipticNet.invarNum` stay in that namespace, after their
+left-hand sides.
+
+One adaptation is forced rather than chosen: the source proves `invarNum_normEDS` by
+`simp [invarNum]`, unfolding the definition. That does not port, because `Invariant.lean` exports
+`invarNum`'s body unexposed — from an importing module `simp [invarNum]` is rejected outright — so
+the proof goes through the `@[simp]` equation lemma `IsEllipticNet.invarNum_def` instead.
+-/
+
+public section
+
+variable {R : Type*} [CommRing R] (b c d : R) (m : ℤ)
+
+namespace IsEllipticNet
+
+/-- The invariant numerator of a normalised EDS at `s = 1`, with `W 1 = 1` and `W 2 = b`
+substituted. -/
+theorem invarNum_normEDS (n : ℤ) :
+    invarNum (normEDS b c d) 1 n =
+      normEDS b c d (n + 2) * normEDS b c d (n - 1) ^ 2
+        + normEDS b c d (n + 1) ^ 2 * normEDS b c d (n - 2)
+        + normEDS b c d n ^ 3 * b ^ 2 := by
+  simp [invarNum_def]
+
+end IsEllipticNet
+
+/-- The invariant numerator of a normalised EDS with one factor of `b` cancelled. Stated as the sum
+it reduces to rather than as a quotient; `IsEllipticNet.invarNum_eq_redInvarNum_mul` is what
+identifies it as the cancellation. -/
+def redInvarNum : R :=
+  complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m
+
+/-- The defining formula for `redInvarNum`. The definition body is not exposed, so this equation
+lemma is how a consumer computes with it. It is deliberately **not** `@[simp]`, for the reason
+`complEDS₂Aux_def` is not: tagging it would have `simp` unfold `redInvarNum` everywhere and defeat
+the point of naming the term. -/
+theorem redInvarNum_def : redInvarNum b c d m =
+    complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m := (rfl)
+
+/-- **The second complement read off the reduced numerator.** This is the direction the Lutz–Nagell
+development uses: it expresses `complEDS₂` through the invariant of the elliptic net, rather than
+through its own defining difference. -/
+theorem complEDS₂_eq_redInvarNum_sub :
+    complEDS₂ b c d m =
+      redInvarNum b c d m - normEDS b c d m ^ 3 * b - 2 * complEDS₂Aux b c d m := by
+  rw [redInvarNum_def]; ring
+
+namespace IsEllipticNet
+
+/-- **The cancellation `redInvarNum` is named for**: the invariant numerator of a normalised EDS at
+`s = 1` is `redInvarNum` times `b`. The factor of `b` is constant in `m`, which is what makes the
+reduced form the one the division-polynomial identities are stated over. -/
+theorem invarNum_eq_redInvarNum_mul :
+    invarNum (normEDS b c d) 1 m = redInvarNum b c d m * b := by
+  simp_rw [redInvarNum_def, right_distrib, complEDS₂_mul_b, mul_assoc 2 _ b, complEDS₂Aux_mul_b,
+    invarNum_normEDS]
+  ring
+
+end IsEllipticNet
+
+/-- The denominator `W (m + 1) * W m * W (m - 1)` of the invariant of a normalised EDS, with the
+constant factor `W 3 * W 2 = c * b` cancelled.
+
+The definition splits on `m % 6`. Among any three consecutive indices `m - 1, m, m + 1` exactly
+which are divisible by `2` and by `3` depends on the residue, and the complement sequences
+`complEDS b c d 2` and `complEDS b c d 3` are what carry off those factors; the residues `0`, `1`
+and `5` take the sixth complement instead, with `r₆ = W 6 / (W 3 * W 2)` written as
+`normEDS b c d 5 - d ^ 2`. -/
+def redInvarDenom : R :=
+  let C := complEDS b c d
+  let W := normEDS b c d
+  let r₆ := normEDS b c d 5 - d ^ 2
+  if m % 6 = 0 then r₆ * C 6 (m / 6) * W (m + 1) * W (m - 1) else
+  if m % 6 = 1 then r₆ * C 6 ((m - 1) / 6) * W (m + 1) * W m else
+  if m % 6 = 5 then r₆ * C 6 ((m + 1) / 6) * W m * W (m - 1) else
+  if m % 6 = 2 then C 3 ((m + 1) / 3) * C 2 (m / 2) * W (m - 1) else
+  if m % 6 = 4 then C 3 ((m - 1) / 3) * C 2 (m / 2) * W (m + 1) else
+  if m % 6 = 3 then C 3 (m / 3) * C 2 ((m - 1) / 2) * W (m + 1) else 0

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -32,6 +32,8 @@ by which the elliptic-net identities reach the division polynomials in the Lutz�
 * `IsEllipticNet.invarNum_normEDS_one_eq_reducedInvarNum_mul`: `invarNum (normEDS b c d) 1 m` is
   `reducedInvarNum b c d m * b` — the cancellation the reduced numerator is named for.
 * `complEDS₂_eq_reducedInvarNum_sub`: the second complement read off the reduced numerator.
+* `map_reducedInvarNum`: it is natural in the coefficient ring, so a specialisation or base change
+  may be pushed through it rather than around the unexposed body.
 
 ## What is deliberately not here
 
@@ -79,7 +81,7 @@ the proof goes through the `@[simp]` equation lemma `IsEllipticNet.invarNum_def`
 
 public section
 
-variable {R : Type*} [CommRing R] (b c d : R) (m : ℤ)
+variable {R S : Type*} [CommRing R] [CommRing S] (b c d : R) (m : ℤ)
 
 /-- The invariant numerator of a normalised EDS with one factor of `b` cancelled. Stated as the sum
 it reduces to rather than as a quotient;
@@ -116,3 +118,11 @@ theorem invarNum_normEDS_one_eq_reducedInvarNum_mul :
   ring
 
 end IsEllipticNet
+
+variable {F : Type*} [FunLike F R S] [RingHomClass F R S] (f : F)
+
+/-- The reduced numerator is natural in the coefficient ring. -/
+@[simp]
+theorem map_reducedInvarNum :
+    f (reducedInvarNum b c d m) = reducedInvarNum (f b) (f c) (f d) m := by
+  simp [reducedInvarNum_def, map_ofNat]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -70,8 +70,10 @@ are portable under this project's rule and deduplicate if and when it lands.
 They are spelt with Mathlib's later names (`compl₂EDS → complEDS₂`, `IsEllSequence →
 IsEllipticSequence`), which #13057 predates, and follow `ComplAux.lean` in keeping the
 `normEDS`-family declarations in the **root** namespace where Mathlib keeps `normEDS`, `complEDS`
-and `complEDS₂`; the two results about `IsEllipticNet.invarNum` stay in that namespace, after their
-left-hand sides.
+and `complEDS₂`. Placement follows each left-hand side, so `reducedInvarNum`,
+`reducedInvarNum_def`, `complEDS₂_eq_reducedInvarNum_sub` and `map_reducedInvarNum` all sit at
+root, and only `invarNum_normEDS_one_eq_reducedInvarNum_mul`, whose left-hand side is an
+`IsEllipticNet` term, sits in that namespace.
 
 One adaptation is forced rather than chosen: the source proves `invarNum_normEDS` by
 `simp [invarNum]`, unfolding the definition. That does not port, because `Invariant.lean` exports

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -12,14 +12,16 @@ public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Invariant
 
 For a normalised EDS `normEDS b c d`, the invariant of `IsEllipticNet` at `s = 1` carries factors
 that are constant in the index: `IsEllipticNet.invarNum` is divisible by `b = W 2`, and
-`IsEllipticNet.invarDenom` by `b * c = W 2 * W 3`. This file names the two quotients — `redInvarNum`
-and `redInvarDenom` — and proves the cancellation for the numerator.
+`IsEllipticNet.invarDenom` is expected to be divisible by `b * c = W 2 * W 3`. This file names
+`redInvarNum` and **proves** its cancellation; `redInvarDenom` is only the candidate piecewise
+expression for the reduced denominator, since the theorem identifying it as the quotient is not
+available here (see below).
 
 The numerator's reduced form is a sum rather than a quotient: `redInvarNum` is defined outright as
 
 `redInvarNum b c d m = complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m`,
 
-and `invarNum_eq_redInvarNum_mul` is what identifies it as the cancellation, `invarNum` being
+and `invarNum_one_eq_redInvarNum_mul` is what identifies it as the cancellation, `invarNum` being
 `redInvarNum * b`. Reading it the other way, `complEDS₂_eq_redInvarNum_sub` expresses the second
 complement through the invariant — the step by which the elliptic-net identities reach the division
 polynomials in the Lutz–Nagell development.
@@ -33,15 +35,15 @@ polynomials in the Lutz–Nagell development.
 
 ## Main results
 
-* `IsEllipticNet.invarNum_eq_redInvarNum_mul`: `invarNum (normEDS b c d) 1 m` is
+* `IsEllipticNet.invarNum_one_eq_redInvarNum_mul`: `invarNum (normEDS b c d) 1 m` is
   `redInvarNum b c d m * b` — the cancellation the reduced numerator is named for.
 * `complEDS₂_eq_redInvarNum_sub`: the second complement read off the reduced numerator.
-* `IsEllipticNet.invarNum_normEDS`: the invariant numerator of a normalised EDS at `s = 1`, with
+* `IsEllipticNet.invarNum_one_normEDS`: the invariant numerator of a normalised EDS at `s = 1`, with
   `W 1 = 1` and `W 2 = b` substituted. This is a measured prerequisite of
-  `invarNum_eq_redInvarNum_mul` rather than an addition: that proof cancels `b` against the
+  `invarNum_one_eq_redInvarNum_mul` rather than an addition: that proof cancels `b` against the
   substituted `W 2`, so the substituted form has to exist first. The source names it for the same
-  reason, and the blocked layer's `invarNum_normEDS_two` and `invarDenom_normEDS_two` are the same
-  shape at a fixed index.
+  reason, and the blocked layer's `invarNum_one_normEDS_two` and `invarDenom_normEDS_two` are the
+  same shape at a fixed index.
 
 ## What is deliberately not here
 
@@ -64,8 +66,8 @@ the source discharges the ellipticity variables over exactly this block.
 
 Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invarNum_normEDS`, `redInvarNum`,
-`compl₂EDS_eq_redInvarNum_sub`, `invarNum_eq_redInvarNum_mul` and `redInvarDenom`. That file's
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invarNum_one_normEDS`, `redInvarNum`,
+`compl₂EDS_eq_redInvarNum_sub`, `invarNum_one_eq_redInvarNum_mul` and `redInvarDenom`. That file's
 header reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
 upstream authorship is credited here rather than in the copyright header.
 
@@ -77,7 +79,7 @@ IsEllipticSequence`), which #13057 predates, and follow `ComplAux.lean` in keepi
 and `complEDS₂`; the two results about `IsEllipticNet.invarNum` stay in that namespace, after their
 left-hand sides.
 
-One adaptation is forced rather than chosen: the source proves `invarNum_normEDS` by
+One adaptation is forced rather than chosen: the source proves `invarNum_one_normEDS` by
 `simp [invarNum]`, unfolding the definition. That does not port, because `Invariant.lean` exports
 `invarNum`'s body unexposed — from an importing module `simp [invarNum]` is rejected outright — so
 the proof goes through the `@[simp]` equation lemma `IsEllipticNet.invarNum_def` instead.
@@ -91,7 +93,7 @@ namespace IsEllipticNet
 
 /-- The invariant numerator of a normalised EDS at `s = 1`, with `W 1 = 1` and `W 2 = b`
 substituted. -/
-theorem invarNum_normEDS (n : ℤ) :
+theorem invarNum_one_normEDS (n : ℤ) :
     invarNum (normEDS b c d) 1 n =
       normEDS b c d (n + 2) * normEDS b c d (n - 1) ^ 2
         + normEDS b c d (n + 1) ^ 2 * normEDS b c d (n - 2)
@@ -101,7 +103,7 @@ theorem invarNum_normEDS (n : ℤ) :
 end IsEllipticNet
 
 /-- The invariant numerator of a normalised EDS with one factor of `b` cancelled. Stated as the sum
-it reduces to rather than as a quotient; `IsEllipticNet.invarNum_eq_redInvarNum_mul` is what
+it reduces to rather than as a quotient; `IsEllipticNet.invarNum_one_eq_redInvarNum_mul` is what
 identifies it as the cancellation. -/
 def redInvarNum : R :=
   complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m
@@ -126,16 +128,18 @@ namespace IsEllipticNet
 /-- **The cancellation `redInvarNum` is named for**: the invariant numerator of a normalised EDS at
 `s = 1` is `redInvarNum` times `b`. The factor of `b` is constant in `m`, which is what makes the
 reduced form the one the division-polynomial identities are stated over. -/
-theorem invarNum_eq_redInvarNum_mul :
+theorem invarNum_one_eq_redInvarNum_mul :
     invarNum (normEDS b c d) 1 m = redInvarNum b c d m * b := by
   simp_rw [redInvarNum_def, right_distrib, complEDS₂_mul_b, mul_assoc 2 _ b, complEDS₂Aux_mul_b,
-    invarNum_normEDS]
+    invarNum_one_normEDS]
   ring
 
 end IsEllipticNet
 
-/-- The denominator `W (m + 1) * W m * W (m - 1)` of the invariant of a normalised EDS, with the
-constant factor `W 3 * W 2 = c * b` cancelled.
+/-- The **candidate** reduced denominator: the piecewise expression intended to be
+`W (m + 1) * W m * W (m - 1)` with the constant factor `W 3 * W 2 = c * b` cancelled. That
+identification is `invarDenom_eq_redInvarDenom_mul`, which is *not* proved here — it routes through
+`IsEllipticSequence.normEDS` — so this definition stands on its formula alone for now.
 
 The definition splits on `m % 6`. Among any three consecutive indices `m - 1, m, m + 1` exactly
 which are divisible by `2` and by `3` depends on the residue, and the complement sequences
@@ -152,3 +156,20 @@ def redInvarDenom : R :=
   if m % 6 = 2 then C 3 ((m + 1) / 3) * C 2 (m / 2) * W (m - 1) else
   if m % 6 = 4 then C 3 ((m - 1) / 3) * C 2 (m / 2) * W (m + 1) else
   if m % 6 = 3 then C 3 (m / 3) * C 2 ((m - 1) / 2) * W (m + 1) else 0
+
+/-- The defining formula for `redInvarDenom`, residue by residue. The definition body is not
+exposed, so this equation lemma is how a consumer computes with it. -/
+theorem redInvarDenom_def :
+    redInvarDenom b c d m =
+      if m % 6 = 0 then (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (m / 6) *
+        normEDS b c d (m + 1) * normEDS b c d (m - 1) else
+      if m % 6 = 1 then (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 ((m - 1) / 6) *
+        normEDS b c d (m + 1) * normEDS b c d m else
+      if m % 6 = 5 then (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 ((m + 1) / 6) *
+        normEDS b c d m * normEDS b c d (m - 1) else
+      if m % 6 = 2 then complEDS b c d 3 ((m + 1) / 3) * complEDS b c d 2 (m / 2) *
+        normEDS b c d (m - 1) else
+      if m % 6 = 4 then complEDS b c d 3 ((m - 1) / 3) * complEDS b c d 2 (m / 2) *
+        normEDS b c d (m + 1) else
+      if m % 6 = 3 then complEDS b c d 3 (m / 3) * complEDS b c d 2 ((m - 1) / 2) *
+        normEDS b c d (m + 1) else 0 := (rfl)

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -21,7 +21,8 @@ The numerator's reduced form is a sum rather than a quotient: `redInvarNum` is d
 
 `redInvarNum b c d m = complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m`,
 
-and `invarNum_one_eq_redInvarNum_mul` is what identifies it as the cancellation, `invarNum` being
+and `invarNum_normEDS_one_eq_redInvarNum_mul` is what identifies it as the cancellation,
+`invarNum` being
 `redInvarNum * b`. Reading it the other way, `complEDS₂_eq_redInvarNum_sub` expresses the second
 complement through the invariant — the step by which the elliptic-net identities reach the division
 polynomials in the Lutz–Nagell development.
@@ -35,15 +36,9 @@ polynomials in the Lutz–Nagell development.
 
 ## Main results
 
-* `IsEllipticNet.invarNum_one_eq_redInvarNum_mul`: `invarNum (normEDS b c d) 1 m` is
+* `IsEllipticNet.invarNum_normEDS_one_eq_redInvarNum_mul`: `invarNum (normEDS b c d) 1 m` is
   `redInvarNum b c d m * b` — the cancellation the reduced numerator is named for.
 * `complEDS₂_eq_redInvarNum_sub`: the second complement read off the reduced numerator.
-* `IsEllipticNet.invarNum_one_normEDS`: the invariant numerator of a normalised EDS at `s = 1`, with
-  `W 1 = 1` and `W 2 = b` substituted. This is a measured prerequisite of
-  `invarNum_one_eq_redInvarNum_mul` rather than an addition: that proof cancels `b` against the
-  substituted `W 2`, so the substituted form has to exist first. The source names it for the same
-  reason, and the blocked layer's `invarNum_one_normEDS_two` and `invarDenom_normEDS_two` are the
-  same shape at a fixed index.
 
 ## What is deliberately not here
 
@@ -66,8 +61,9 @@ the source discharges the ellipticity variables over exactly this block.
 
 Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invarNum_one_normEDS`, `redInvarNum`,
-`compl₂EDS_eq_redInvarNum_sub`, `invarNum_one_eq_redInvarNum_mul` and `redInvarDenom`. That file's
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invarNum_normEDS`, `redInvarNum`,
+`compl₂EDS_eq_redInvarNum_sub`, `invarNum_eq_redInvarNum_mul` and `redInvarDenom` — the
+source's own names. That file's
 header reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
 upstream authorship is credited here rather than in the copyright header.
 
@@ -79,7 +75,7 @@ IsEllipticSequence`), which #13057 predates, and follow `ComplAux.lean` in keepi
 and `complEDS₂`; the two results about `IsEllipticNet.invarNum` stay in that namespace, after their
 left-hand sides.
 
-One adaptation is forced rather than chosen: the source proves `invarNum_one_normEDS` by
+One adaptation is forced rather than chosen: the source proves `invarNum_normEDS` by
 `simp [invarNum]`, unfolding the definition. That does not port, because `Invariant.lean` exports
 `invarNum`'s body unexposed — from an importing module `simp [invarNum]` is rejected outright — so
 the proof goes through the `@[simp]` equation lemma `IsEllipticNet.invarNum_def` instead.
@@ -91,19 +87,11 @@ variable {R : Type*} [CommRing R] (b c d : R) (m : ℤ)
 
 namespace IsEllipticNet
 
-/-- The invariant numerator of a normalised EDS at `s = 1`, with `W 1 = 1` and `W 2 = b`
-substituted. -/
-theorem invarNum_one_normEDS (n : ℤ) :
-    invarNum (normEDS b c d) 1 n =
-      normEDS b c d (n + 2) * normEDS b c d (n - 1) ^ 2
-        + normEDS b c d (n + 1) ^ 2 * normEDS b c d (n - 2)
-        + normEDS b c d n ^ 3 * b ^ 2 := by
-  simp [invarNum_def]
-
 end IsEllipticNet
 
 /-- The invariant numerator of a normalised EDS with one factor of `b` cancelled. Stated as the sum
-it reduces to rather than as a quotient; `IsEllipticNet.invarNum_one_eq_redInvarNum_mul` is what
+it reduces to rather than as a quotient;
+`IsEllipticNet.invarNum_normEDS_one_eq_redInvarNum_mul` is what
 identifies it as the cancellation. -/
 def redInvarNum : R :=
   complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m
@@ -128,10 +116,10 @@ namespace IsEllipticNet
 /-- **The cancellation `redInvarNum` is named for**: the invariant numerator of a normalised EDS at
 `s = 1` is `redInvarNum` times `b`. The factor of `b` is constant in `m`, which is what makes the
 reduced form the one the division-polynomial identities are stated over. -/
-theorem invarNum_one_eq_redInvarNum_mul :
+theorem invarNum_normEDS_one_eq_redInvarNum_mul :
     invarNum (normEDS b c d) 1 m = redInvarNum b c d m * b := by
-  simp_rw [redInvarNum_def, right_distrib, complEDS₂_mul_b, mul_assoc 2 _ b, complEDS₂Aux_mul_b,
-    invarNum_one_normEDS]
+  simp_rw [redInvarNum_def, right_distrib, complEDS₂_mul_b, mul_assoc 2 _ b, complEDS₂Aux_mul_b]
+  simp [invarNum_def]
   ring
 
 end IsEllipticNet
@@ -146,7 +134,7 @@ which are divisible by `2` and by `3` depends on the residue, and the complement
 `complEDS b c d 2` and `complEDS b c d 3` are what carry off those factors; the residues `0`, `1`
 and `5` take the sixth complement instead, with `r₆ = W 6 / (W 3 * W 2)` written as
 `normEDS b c d 5 - d ^ 2`. -/
-def redInvarDenom : R :=
+private def redInvarDenom : R :=
   let C := complEDS b c d
   let W := normEDS b c d
   let r₆ := normEDS b c d 5 - d ^ 2
@@ -159,7 +147,7 @@ def redInvarDenom : R :=
 
 /-- The defining formula for `redInvarDenom`, residue by residue. The definition body is not
 exposed, so this equation lemma is how a consumer computes with it. -/
-theorem redInvarDenom_def :
+private theorem redInvarDenom_def :
     redInvarDenom b c d m =
       if m % 6 = 0 then (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (m / 6) *
         normEDS b c d (m + 1) * normEDS b c d (m - 1) else

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -65,8 +65,8 @@ this file respells with `reduced` written out. That file's header reads `Authors
 following this repository's convention for adapted material the upstream authorship is credited
 here rather than in the copyright header.
 
-The same declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), the upstreaming
-of that AINTLIB file, so they are portable under this project's rule and deduplicate when it lands.
+The same declarations sit in **Mathlib PR #13057**, the upstreaming of that AINTLIB file, so they
+are portable under this project's rule and deduplicate if and when it lands.
 They are spelt with Mathlib's later names (`compl₂EDS → complEDS₂`, `IsEllSequence →
 IsEllipticSequence`), which #13057 predates, and follow `ComplAux.lean` in keeping the
 `normEDS`-family declarations in the **root** namespace where Mathlib keeps `normEDS`, `complEDS`

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -10,42 +10,36 @@ public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Invariant
 /-!
 # The reduced invariant of a normalised EDS
 
-For a normalised EDS `normEDS b c d`, the invariant of `IsEllipticNet` at `s = 1` carries factors
-that are constant in the index: `IsEllipticNet.invarNum` is divisible by `b = W 2`, and
-`IsEllipticNet.invarDenom` is expected to be divisible by `b * c = W 2 * W 3`. This file names
-`redInvarNum` and **proves** its cancellation; `redInvarDenom` is only the candidate piecewise
-expression for the reduced denominator, since the theorem identifying it as the quotient is not
-available here (see below).
+For a normalised EDS `normEDS b c d`, the invariant of `IsEllipticNet` at `s = 1` carries a factor
+that is constant in the index: `IsEllipticNet.invarNum` is divisible by `b = W 2`. This file names
+the quotient `reducedInvarNum` and **proves** that cancellation.
 
-The numerator's reduced form is a sum rather than a quotient: `redInvarNum` is defined outright as
+The reduced numerator is a sum rather than a quotient: `reducedInvarNum` is defined outright as
 
-`redInvarNum b c d m = complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m`,
+`reducedInvarNum b c d m = complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m`,
 
-and `invarNum_normEDS_one_eq_redInvarNum_mul` is what identifies it as the cancellation,
-`invarNum` being
-`redInvarNum * b`. Reading it the other way, `complEDS₂_eq_redInvarNum_sub` expresses the second
-complement through the invariant — the step by which the elliptic-net identities reach the division
-polynomials in the Lutz–Nagell development.
+and `invarNum_normEDS_one_eq_reducedInvarNum_mul` is what identifies it as the cancellation,
+`invarNum` being `reducedInvarNum * b`. Read the other way,
+`complEDS₂_eq_reducedInvarNum_sub` expresses the second complement through the invariant — the step
+by which the elliptic-net identities reach the division polynomials in the Lutz–Nagell development.
 
 ## Main definitions
 
-* `redInvarNum`: the invariant numerator of a normalised EDS with one factor of `b` cancelled.
-* `redInvarDenom`: the corresponding denominator, `W (m + 1) * W m * W (m - 1)` with `W 3 * W 2`
-  cancelled. Its definition splits on `m % 6`, because which of the three consecutive terms the
-  complement sequences divide depends on that residue.
+* `reducedInvarNum`: the invariant numerator of a normalised EDS with one factor of `b` cancelled.
 
 ## Main results
 
-* `IsEllipticNet.invarNum_normEDS_one_eq_redInvarNum_mul`: `invarNum (normEDS b c d) 1 m` is
-  `redInvarNum b c d m * b` — the cancellation the reduced numerator is named for.
-* `complEDS₂_eq_redInvarNum_sub`: the second complement read off the reduced numerator.
+* `IsEllipticNet.invarNum_normEDS_one_eq_reducedInvarNum_mul`: `invarNum (normEDS b c d) 1 m` is
+  `reducedInvarNum b c d m * b` — the cancellation the reduced numerator is named for.
+* `complEDS₂_eq_reducedInvarNum_sub`: the second complement read off the reduced numerator.
 
 ## What is deliberately not here
 
-The two results that would connect `redInvarNum` and `redInvarDenom` to each other —
-`redInvar_normEDS` (`redInvarNum b c d m = redInvarDenom b c d m * (d + b ^ 4)`) and
-`invarDenom_eq_redInvarDenom_mul` — are **not** in this file, and are not an oversight. Both route
-through the fact that `normEDS` is an elliptic sequence, along
+The **denominator** side of the reduction is absent, by measurement rather than oversight. The
+source's `redInvarDenom` — a piecewise expression for `W (m + 1) * W m * W (m - 1)` with the
+constant factor `W 3 * W 2` cancelled — is worth having only together with the results identifying
+it as that quotient, `redInvar_normEDS` and `invarDenom_eq_redInvarDenom_mul` (the source's names).
+Both route through the fact that `normEDS` is an elliptic sequence, along
 
 `redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS ← IsEllipticSequence.normEDS`
 
@@ -54,18 +48,20 @@ normEDS_mul_complEDS ← normEDS_mul_complEDS_of_mem ← IsEllipticSequence.norm
 That fact is not in the pinned Mathlib, which records it as an open TODO
 (`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean`: "prove that `normEDS` satisfies
 `IsEllipticDvdSequence`"), and proving it needs the parity-transfer machinery of Mathlib PR #42453.
-Everything in this file is independent of it: nothing below carries an ellipticity hypothesis, and
-the source discharges the ellipticity variables over exactly this block.
+Carrying the bare definition across now would add a formula that no consumer can state anything
+about, so it waits for the layer that gives it meaning. Everything below is independent of that
+fact: nothing carries an ellipticity hypothesis, and the source discharges the ellipticity
+variables over exactly this block.
 
 ## Provenance
 
 Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
 `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invarNum_normEDS`, `redInvarNum`,
-`compl₂EDS_eq_redInvarNum_sub`, `invarNum_eq_redInvarNum_mul` and `redInvarDenom` — the
-source's own names. That file's
-header reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
-upstream authorship is credited here rather than in the copyright header.
+`compl₂EDS_eq_redInvarNum_sub` and `invarNum_eq_redInvarNum_mul` — the source's own names, which
+this file respells with `reduced` written out. That file's header reads `Authors: Junyan Xu`;
+following this repository's convention for adapted material the upstream authorship is credited
+here rather than in the copyright header.
 
 The same declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), the upstreaming
 of that AINTLIB file, so they are portable under this project's rule and deduplicate when it lands.
@@ -85,79 +81,38 @@ public section
 
 variable {R : Type*} [CommRing R] (b c d : R) (m : ℤ)
 
-namespace IsEllipticNet
-
-end IsEllipticNet
-
 /-- The invariant numerator of a normalised EDS with one factor of `b` cancelled. Stated as the sum
 it reduces to rather than as a quotient;
-`IsEllipticNet.invarNum_normEDS_one_eq_redInvarNum_mul` is what
+`IsEllipticNet.invarNum_normEDS_one_eq_reducedInvarNum_mul` is what
 identifies it as the cancellation. -/
-def redInvarNum : R :=
+def reducedInvarNum : R :=
   complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m
 
-/-- The defining formula for `redInvarNum`. The definition body is not exposed, so this equation
+/-- The defining formula for `reducedInvarNum`. The definition body is not exposed, so this equation
 lemma is how a consumer computes with it. It is deliberately **not** `@[simp]`, for the reason
-`complEDS₂Aux_def` is not: tagging it would have `simp` unfold `redInvarNum` everywhere and defeat
-the point of naming the term. -/
-theorem redInvarNum_def : redInvarNum b c d m =
+`complEDS₂Aux_def` is not: tagging it would have `simp` unfold `reducedInvarNum` everywhere and
+defeat the point of naming the term. -/
+theorem reducedInvarNum_def : reducedInvarNum b c d m =
     complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m := (rfl)
 
 /-- **The second complement read off the reduced numerator.** This is the direction the Lutz–Nagell
 development uses: it expresses `complEDS₂` through the invariant of the elliptic net, rather than
 through its own defining difference. -/
-theorem complEDS₂_eq_redInvarNum_sub :
+theorem complEDS₂_eq_reducedInvarNum_sub :
     complEDS₂ b c d m =
-      redInvarNum b c d m - normEDS b c d m ^ 3 * b - 2 * complEDS₂Aux b c d m := by
-  rw [redInvarNum_def]; ring
+      reducedInvarNum b c d m - normEDS b c d m ^ 3 * b - 2 * complEDS₂Aux b c d m := by
+  rw [reducedInvarNum_def]; ring
 
 namespace IsEllipticNet
 
-/-- **The cancellation `redInvarNum` is named for**: the invariant numerator of a normalised EDS at
-`s = 1` is `redInvarNum` times `b`. The factor of `b` is constant in `m`, which is what makes the
-reduced form the one the division-polynomial identities are stated over. -/
-theorem invarNum_normEDS_one_eq_redInvarNum_mul :
-    invarNum (normEDS b c d) 1 m = redInvarNum b c d m * b := by
-  simp_rw [redInvarNum_def, right_distrib, complEDS₂_mul_b, mul_assoc 2 _ b, complEDS₂Aux_mul_b]
+/-- **The cancellation `reducedInvarNum` is named for**: the invariant numerator of a normalised EDS
+at `s = 1` is `reducedInvarNum` times `b`. The factor of `b` is constant in `m`, which is what makes
+the reduced form the one the division-polynomial identities are stated over. -/
+theorem invarNum_normEDS_one_eq_reducedInvarNum_mul :
+    invarNum (normEDS b c d) 1 m = reducedInvarNum b c d m * b := by
+  simp_rw [reducedInvarNum_def, right_distrib, complEDS₂_mul_b, mul_assoc 2 _ b,
+    complEDS₂Aux_mul_b]
   simp [invarNum_def]
   ring
 
 end IsEllipticNet
-
-/-- The **candidate** reduced denominator: the piecewise expression intended to be
-`W (m + 1) * W m * W (m - 1)` with the constant factor `W 3 * W 2 = c * b` cancelled. That
-identification is `invarDenom_eq_redInvarDenom_mul`, which is *not* proved here — it routes through
-`IsEllipticSequence.normEDS` — so this definition stands on its formula alone for now.
-
-The definition splits on `m % 6`. Among any three consecutive indices `m - 1, m, m + 1` exactly
-which are divisible by `2` and by `3` depends on the residue, and the complement sequences
-`complEDS b c d 2` and `complEDS b c d 3` are what carry off those factors; the residues `0`, `1`
-and `5` take the sixth complement instead, with `r₆ = W 6 / (W 3 * W 2)` written as
-`normEDS b c d 5 - d ^ 2`. -/
-private def redInvarDenom : R :=
-  let C := complEDS b c d
-  let W := normEDS b c d
-  let r₆ := normEDS b c d 5 - d ^ 2
-  if m % 6 = 0 then r₆ * C 6 (m / 6) * W (m + 1) * W (m - 1) else
-  if m % 6 = 1 then r₆ * C 6 ((m - 1) / 6) * W (m + 1) * W m else
-  if m % 6 = 5 then r₆ * C 6 ((m + 1) / 6) * W m * W (m - 1) else
-  if m % 6 = 2 then C 3 ((m + 1) / 3) * C 2 (m / 2) * W (m - 1) else
-  if m % 6 = 4 then C 3 ((m - 1) / 3) * C 2 (m / 2) * W (m + 1) else
-  if m % 6 = 3 then C 3 (m / 3) * C 2 ((m - 1) / 2) * W (m + 1) else 0
-
-/-- The defining formula for `redInvarDenom`, residue by residue. The definition body is not
-exposed, so this equation lemma is how a consumer computes with it. -/
-private theorem redInvarDenom_def :
-    redInvarDenom b c d m =
-      if m % 6 = 0 then (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (m / 6) *
-        normEDS b c d (m + 1) * normEDS b c d (m - 1) else
-      if m % 6 = 1 then (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 ((m - 1) / 6) *
-        normEDS b c d (m + 1) * normEDS b c d m else
-      if m % 6 = 5 then (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 ((m + 1) / 6) *
-        normEDS b c d m * normEDS b c d (m - 1) else
-      if m % 6 = 2 then complEDS b c d 3 ((m + 1) / 3) * complEDS b c d 2 (m / 2) *
-        normEDS b c d (m - 1) else
-      if m % 6 = 4 then complEDS b c d 3 ((m - 1) / 3) * complEDS b c d 2 (m / 2) *
-        normEDS b c d (m + 1) else
-      if m % 6 = 3 then complEDS b c d 3 (m / 3) * complEDS b c d 2 ((m - 1) / 2) *
-        normEDS b c d (m + 1) else 0 := (rfl)


### PR DESCRIPTION
The reduced invariant of a normalised EDS — the cancellation that puts the invariant of an elliptic
net into the form the division-polynomial identities are stated over.

```lean
-- TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
def reducedInvarNum (b c d : R) (m : ℤ) : R :=
  complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m

theorem reducedInvarNum_def       -- the defining formula; the body is unexposed

theorem complEDS₂_eq_reducedInvarNum_sub :
    complEDS₂ b c d m =
      reducedInvarNum b c d m - normEDS b c d m ^ 3 * b - 2 * complEDS₂Aux b c d m

namespace IsEllipticNet
theorem invarNum_normEDS_one_eq_reducedInvarNum_mul :
    invarNum (normEDS b c d) 1 m = reducedInvarNum b c d m * b
end IsEllipticNet

@[simp] theorem map_reducedInvarNum :
    f (reducedInvarNum b c d m) = reducedInvarNum (f b) (f c) (f d) m
```

**What it says.** For a normalised EDS, the invariant numerator of `IsEllipticNet` at `s = 1`
carries a factor constant in the index — it is divisible by `b = W 2`. `reducedInvarNum` names the
quotient, and `invarNum_normEDS_one_eq_reducedInvarNum_mul` is what identifies it as the
cancellation rather than merely a definition of the right shape. Read the other way,
`complEDS₂_eq_reducedInvarNum_sub` expresses the second complement through the invariant — the step
by which the elliptic-net identities reach the division polynomials.

The reduced numerator is stated as the **sum it reduces to**, not as a quotient, so it needs no
divisibility side condition and no `CommRing`-to-`Field` strengthening. `reducedInvarNum_def` is
the equation lemma a consumer computes with, since the definition body is unexposed; it is
deliberately not `@[simp]`, matching `complEDS₂Aux_def` — tagging it would have `simp` unfold the
definition everywhere and defeat the point of naming the term.

`map_reducedInvarNum` completes that API in the other direction: because the body is unexposed, a
specialisation or base change would otherwise have to route around it. It follows the sibling
`ComplAux.lean` exactly — same late `variable` placement, same `@[simp]` — and rests on Mathlib's
`map_complEDS₂` and `map_normEDS` together with this file's `map_complEDS₂Aux`.

## What is deliberately not here

**The denominator side of the reduction.** The source also carries `redInvarDenom`, a piecewise
expression (splitting on `m % 6`) for `W (m + 1) * W m * W (m - 1)` with the constant factor
`W 3 * W 2` cancelled. It is **not** ported here, and that is a measurement rather than an omission:
the definition is worth having only alongside the two results that identify it as that quotient,
`redInvar_normEDS` and `invarDenom_eq_redInvarDenom_mul` (the source's names), and both route
through `normEDS` being an elliptic sequence:

```
redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS ← IsEllipticSequence.normEDS
invarDenom_eq_redInvarDenom_mul ← normEDS_mul_complEDS_div ← normEDS_mul_complEDS
                                ← normEDS_mul_complEDS_of_mem ← IsEllipticSequence.normEDS
```

The pinned Mathlib records that ellipticity as an open TODO
(`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean`) and its proof needs the parity-transfer
machinery. Carrying the bare formula across now would add a definition about which no consumer
could state anything, so it waits for the layer that gives it meaning and lands with it. The
numerator side has no such dependency — nothing here carries an ellipticity hypothesis — which is
why it ships on its own. The module docstring names both chains so a reader can check the claim
rather than take it.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, the **Layer 6** torsion/Nagell–Lutz strand
(README.md:821-837), whose stated route to `lutz_nagell` and `lutz_nagell_integrality_general` is
the division polynomials. This is a prerequisite on that route.

## Provenance

Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invarNum_normEDS`, `redInvarNum`,
`compl₂EDS_eq_redInvarNum_sub` and `invarNum_eq_redInvarNum_mul` — the source's own names. That
file's header reads `Authors: Junyan Xu`; following this repository's convention for adapted
material the upstream authorship is credited in the module docstring rather than in the copyright
header.

**Renamed on the way in.** The source abbreviates *reduced* to `red`; this file writes it out, so
`redInvarNum` becomes `reducedInvarNum` and its dependants follow. That matches the file's own name
and the surrounding EDS API, which spells terms out. The source's `redInvarDenom` keeps its own
spelling in the prose above because it names a declaration that exists only upstream.

**One adaptation is forced rather than chosen.** The source proves `invarNum_normEDS` by
`simp [invarNum]`, unfolding the definition. That does not port:
`EllipticDivisibilitySequence/Invariant.lean` exports `invarNum`'s body unexposed, so from an
importing module `simp [invarNum]` is rejected outright — "Expected a definition with an exposed
body". The proof goes through the `@[simp]` equation lemma `IsEllipticNet.invarNum_def` instead.
Everything else is the rename table applied verbatim (`compl₂EDS → complEDS₂`,
`IsEllSequence → IsEllipticSequence`).

The source's `invarNum_normEDS` is **not** carried across as a separate declaration. It is
`invarNum_def` specialised to `normEDS` at `s = 1`, and `invarNum_def` is already public on `main`,
so the one place that needed it expands the equation lemma inline instead.

Namespacing follows each left-hand side: the `invarNum` fact sits in `IsEllipticNet`, the
`normEDS`-family declarations in the root namespace where Mathlib keeps `normEDS`, `complEDS` and
`complEDS₂` — the same call `ComplAux.lean` made.

## Cleanup

An **inline author pass** (file-level style, naming, line packing verified by codepoint count,
docstrings, equation lemmas for unexposed bodies, negative results recorded in the docstring). The
per-declaration Phase-4 fan-out and the `/simplify` and `/buzz` hand-offs are **deferred to review
rounds** rather than run before this PR. Three private review rounds were run instead and every
finding complied with; the substantive ones are recorded above — the deleted duplicate of
`invarNum_def`, the dropped denominator, and the `red` → `reduced` respelling. Stated plainly
rather than claimed as a full 11-phase run.

## Gates

Two measurements, kept distinct rather than blurred.

**The full four-gate chain, at Mathlib `f5809ef6`** — the pin this branch was authored against —
on a worktree verified clean by `git status --short` beforehand: `lake build`, `scripts/lint-env.sh`
(PASS, 0 ratchetable), `lake exe axioms` and `lake exe module-system` all pass.

**Then the branch was rebased onto `4df85e7ab`.** Its old base predated `052dec58e` (#3069), which
removed TauCeti's local `ContinuousLinearMap.IsFredholm.comp` now that Mathlib declares it; the
sandboxed build overlays the PR head's whole `TauCeti/` onto the trusted base's pins, so any older
head red-builds on a file its own diff never touches. The rebase replayed cleanly, left the diff at
one file, and moved the Mathlib pin to `f4fd7f7e`.

**At the new pin, a targeted build:** `lake build
TauCeti.NumberTheory.EllipticDivisibilitySequence.ReducedInvariant` PASS — 942 jobs, the module
10s, with its dependencies `ComplAux` and `Invariant` rebuilt from main. The full-tree audits at
this head are what CI's sandboxed build runs on a clean runner; the old-pin numbers above are not
restated as if they had been measured at the new head.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-redinvariant"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
