### PR TITLE
fix: do not re-invite organization members every hour

### DIFF
--- a/scripts/claims_access.py
+++ b/scripts/claims_access.py
@@ -93,9 +93,13 @@ def merged_pr_authors():
 
 
 def already_admitted():
-    """Logins that already have access, or have been asked. Collaborators cover org members who
-    inherit it; invitations cover people who have not clicked yet (workers accept their own
-    invitation, but an operator who has not started one since the grant still has it pending)."""
+    """Logins that already have access, or have been asked: direct collaborators plus people who have
+    not clicked yet (workers accept their own invitation, but an operator who has not started one
+    since the grant still has it pending).
+
+    This does NOT see people whose access comes from the organization. The collaborators endpoint
+    resolves those only for a caller that can read org membership, and this App is installed on one
+    repository and has no organization permissions at all, by design. `has_access` covers them."""
     collaborators = gh_lines(
         ["api", "--paginate", f"/repos/{CLAIMS_REPO}/collaborators?per_page=100", "--jq", ".[].login"],
         CLAIMS_TOKEN,
@@ -107,29 +111,47 @@ def already_admitted():
     return set(collaborators) | set(invitations)
 
 
+def has_access(login):
+    """Can this login already push, however they got it? Asked per candidate rather than read off the
+    collaborator list, because that list omits organization members (see `already_admitted`), and
+    without this an org member is a candidate on every single run, forever."""
+    p = gh(
+        ["api", f"/repos/{CLAIMS_REPO}/collaborators/{login}/permission", "--jq", ".permission"],
+        CLAIMS_TOKEN,
+        check=False,
+    )
+    return p.returncode == 0 and p.stdout.strip() in ("write", "maintain", "admin")
+
+
 def grant():
     """Invite every author who is not in yet. A failure on one login does not stop the others, but
     the job still ends red so somebody looks (an org that forbids outside collaborators, or requires
     2FA of them, fails exactly here)."""
-    missing = sorted(merged_pr_authors() - already_admitted())
-    if not missing:
-        print("grant: every merged-PR author already has the claim namespace")
-        return 0
+    candidates = sorted(merged_pr_authors() - already_admitted())
+    invited = 0
     failures = 0
-    for login in missing:
+    for login in candidates:
+        if has_access(login):
+            continue  # an organization member; nothing to grant and nothing to report
         if DRY_RUN:
             print(f"grant: would invite {login}")
+            invited += 1
             continue
         p = gh(
             ["api", "-X", "PUT", f"/repos/{CLAIMS_REPO}/collaborators/{login}", "-f", "permission=push"],
             CLAIMS_TOKEN,
             check=False,
         )
-        if p.returncode == 0:
-            print(f"grant: invited {login} to {CLAIMS_REPO}")
-        else:
+        if p.returncode != 0:
             failures += 1
             print(f"grant: FAILED to invite {login}: {(p.stderr or p.stdout).strip()}", file=sys.stderr)
+            continue
+        # 201 answers with the invitation; 204 (empty) means they could already push after all, so
+        # say what happened rather than claiming an invitation that was never sent.
+        print(f"grant: invited {login} to {CLAIMS_REPO}" if p.stdout.strip() else f"grant: {login} already had access")
+        invited += 1
+    if not invited:
+        print("grant: every merged-PR author already has the claim namespace")
     return failures
 
 

--- a/scripts/test_claims_access.py
+++ b/scripts/test_claims_access.py
@@ -5,6 +5,8 @@ Run with: python3 scripts/test_claims_access.py
 
 import json
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 import claims_access as ca
 
@@ -31,6 +33,29 @@ class HumanAuthors(unittest.TestCase):
     def test_no_merged_prs_admits_nobody(self):
         self.assertEqual(ca.human_authors([]), set())
         self.assertEqual(ca.human_authors(None), set())
+
+
+class HasAccess(unittest.TestCase):
+    """Access inherited from the organization is invisible to the collaborator list this App can see,
+    so without an explicit check every org member is a candidate to invite on every single run."""
+
+    def answer(self, returncode, stdout):
+        return lambda args, token, check=True: SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+    def test_anyone_who_can_already_push_is_left_alone(self):
+        for permission in ("admin", "maintain", "write"):
+            with self.subTest(permission=permission), mock.patch.object(ca, "gh", self.answer(0, permission + "\n")):
+                self.assertTrue(ca.has_access("an-org-member"))
+
+    def test_read_only_or_no_access_still_needs_an_invitation(self):
+        for permission in ("read", "none", ""):
+            with self.subTest(permission=permission), mock.patch.object(ca, "gh", self.answer(0, permission + "\n")):
+                self.assertFalse(ca.has_access("a-contributor"))
+
+    def test_an_unreadable_answer_falls_towards_inviting(self):
+        # A redundant invitation is a no-op; a missed one is a fleet that never coordinates.
+        with mock.patch.object(ca, "gh", self.answer(1, "")):
+            self.assertFalse(ca.has_access("a-contributor"))
 
 
 class Sweepable(unittest.TestCase):


### PR DESCRIPTION
This PR stops the claims reconciler treating organization members as people who still need inviting. The collaborator list the App can read omits anyone whose access comes from the organization, because resolving that needs organization membership read and this App is installed on one repository with no organization permissions at all, by design. The first dry run therefore proposed inviting five org members, and every run after it would have proposed the same five.

It now asks for each candidate's effective permission, and only for the few who are neither direct collaborators nor already invited, so the cost is a handful of calls per run. It also distinguishes the two answers a grant can give: 201 carries an invitation, 204 means the account could already push, and reporting the second as "invited" describes an invitation that was never sent.

Verified by dry run against the live repositories: `grant: every merged-PR author already has the claim namespace`, where before this change the same run proposed five redundant invitations.

🤖 Prepared with Claude Code