### PR TITLE
feat: define integral symmetric lattices

### DIFF
--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -27,6 +27,7 @@ The form restricts to a canonical `ℤ`-bilinear form on the carrier.  Conversel
 ## Main definitions
 
 * `TauCeti.IntegralLattice`: an integral symmetric lattice in a rational vector space.
+* `TauCeti.IntegralLattice.form_mem_one`: the rational form takes integer values on lattice vectors.
 * `TauCeti.IntegralLattice.rationalBasis`: the ambient `ℚ`-basis extending a chosen `ℤ`-basis of
   the carrier.
 * `TauCeti.IntegralLattice.integralForm`: the induced `ℤ`-bilinear form on the carrier.
@@ -80,6 +81,11 @@ instance : CoeFun (IntegralLattice V) fun _ ↦ V → V → ℚ :=
 
 @[simp]
 theorem coe_form_apply (L : IntegralLattice V) (x y : V) : L x y = L.form x y := rfl
+
+/-- The value of the rational form on lattice vectors is integral. -/
+theorem form_mem_one (L : IntegralLattice V) (x y : L) :
+    L.form x y ∈ (1 : Submodule ℤ ℚ) :=
+  L.le_dual x.2 (y : V) y.2
 
 /-- The chosen `ℤ`-basis of an integral lattice extends to a `ℚ`-basis of the ambient space. -/
 noncomputable def rationalBasis (L : IntegralLattice V) :
@@ -201,20 +207,18 @@ noncomputable def ofBasis.basisElem (b : Basis ι ℚ V) (B : LinearMap.BilinFor
     ofBasis b B hB hint :=
   ⟨b i, by rw [ofBasis_carrier]; exact Submodule.subset_span (Set.mem_range_self i)⟩
 
+@[simp]
+theorem ofBasis.coe_basisElem (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
+    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) (i : ι) :
+    (ofBasis.basisElem b B hB hint i : V) = b i := by
+  unfold ofBasis.basisElem
+  rfl
+
 end Basis
 
 section GramMatrix
 
 variable {ι : Type*} [Fintype ι]
-
-open Classical in
-/-- Evaluating the rational bilinear form associated with a matrix on basis vectors recovers
-the matrix entry. -/
-theorem toBilin_map_apply_basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (i j : ι) :
-    Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) (b i) (b j) = (G i j : ℚ) := by
-  rw [← LinearMap.BilinForm.toMatrix_apply (b := b), LinearMap.BilinForm.toMatrix_toBilin,
-    Matrix.map_apply]
-  rfl
 
 open Classical in
 /-- Construct an integral lattice from a finite rational basis and an integral symmetric Gram
@@ -223,7 +227,8 @@ noncomputable def ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG :
     IntegralLattice V :=
   ofBasis b (Matrix.toBilin b (G.map (algebraMap ℤ ℚ)))
     ((Matrix.isSymm_toBilin_iff_isSymm (b := b)).mpr (hG.map _)) fun i j ↦ by
-      rw [toBilin_map_apply_basis]
+      rw [← LinearMap.BilinForm.toMatrix_apply (b := b), LinearMap.BilinForm.toMatrix_toBilin,
+        Matrix.map_apply]
       exact Submodule.mem_one.mpr ⟨G i j, rfl⟩
 
 open Classical in
@@ -244,6 +249,13 @@ noncomputable def ofGramMatrix.basisElem (b : Basis ι ℚ V) (G : Matrix ι ι 
   ⟨b i, by rw [ofGramMatrix_carrier]; exact Submodule.subset_span (Set.mem_range_self i)⟩
 
 open Classical in
+@[simp]
+theorem ofGramMatrix.coe_basisElem (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
+    (i : ι) : (ofGramMatrix.basisElem b G hG i : V) = b i := by
+  unfold ofGramMatrix.basisElem
+  rfl
+
+open Classical in
 /-- Evaluating the induced integral form of `ofGramMatrix` on embedded basis vectors recovers
 the corresponding entry of the Gram matrix. -/
 @[simp]
@@ -252,8 +264,10 @@ theorem integralForm_ofGramMatrix_apply (b : Basis ι ℚ V) (G : Matrix ι ι �
     (ofGramMatrix b G hG).integralForm (ofGramMatrix.basisElem b G hG i)
       (ofGramMatrix.basisElem b G hG j) = G i j := by
   apply Int.cast_injective (α := ℚ)
-  rw [integralForm_cast, ofGramMatrix_form]
-  exact toBilin_map_apply_basis b G i j
+  rw [integralForm_cast, ofGramMatrix_form, ofGramMatrix.coe_basisElem,
+    ofGramMatrix.coe_basisElem, ← LinearMap.BilinForm.toMatrix_apply (b := b),
+    LinearMap.BilinForm.toMatrix_toBilin, Matrix.map_apply]
+  rfl
 
 end GramMatrix
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -19,9 +19,18 @@ integers.  The integrality condition is expressed using Mathlib's
 The form restricts to a canonical `ℤ`-bilinear form on the carrier.  Conversely, a finite
 `ℚ`-basis and an integral symmetric Gram matrix construct an integral lattice.
 
+## References
+
+* `TauCetiRoadmap/IntegralLattices/README.md`
+* `TauCetiRoadmap/IntegralLattices/Suggested.lean`
+
 ## Main definitions
 
 * `TauCeti.IntegralLattice`: an integral symmetric lattice in a rational vector space.
+* `TauCeti.IntegralLattice.ofSubmodule`: constructor from an existing full submodule with an
+  integral symmetric form.
+* `TauCeti.IntegralLattice.basis`: a chosen `ℤ`-basis of the carrier.
+* `TauCeti.IntegralLattice.rationalBasis`: the ambient `ℚ`-basis extending the carrier basis.
 * `TauCeti.IntegralLattice.integralForm`: the induced `ℤ`-bilinear form on the carrier.
 * `TauCeti.IntegralLattice.ofBasis`: the lattice spanned by a basis on which a given form is
   integral.
@@ -29,7 +38,7 @@ The form restricts to a canonical `ℤ`-bilinear form on the carrier.  Conversel
   symmetric Gram matrix.
 -/
 
-@[expose] public section
+public section
 
 open Module
 
@@ -59,11 +68,63 @@ namespace IntegralLattice
 
 variable {V}
 
+/-- Construct an integral symmetric lattice from a full submodule and a symmetric rational form
+that is integral on the submodule. -/
+def ofSubmodule (M : Submodule ℤ V) (B : LinearMap.BilinForm ℚ V) (hM : M.IsLattice ℚ)
+    (hB : B.IsSymm) (hle : M ≤ B.dualSubmodule M) : IntegralLattice V where
+  carrier := M
+  form := B
+  isLattice := hM
+  isSymm := hB
+  le_dual := hle
+
+@[simp]
+theorem carrier_ofSubmodule (M : Submodule ℤ V) (B : LinearMap.BilinForm ℚ V) (hM : M.IsLattice ℚ)
+    (hB : B.IsSymm) (hle : M ≤ B.dualSubmodule M) :
+    (ofSubmodule M B hM hB hle).carrier = M := (rfl)
+
+@[simp]
+theorem form_ofSubmodule (M : Submodule ℤ V) (B : LinearMap.BilinForm ℚ V) (hM : M.IsLattice ℚ)
+    (hB : B.IsSymm) (hle : M ≤ B.dualSubmodule M) :
+    (ofSubmodule M B hM hB hle).form = B := (rfl)
+
 /-- The carrier of an integral lattice is a Mathlib lattice. -/
 instance (L : IntegralLattice V) : L.carrier.IsLattice ℚ := L.isLattice
 
 /-- An integral lattice coerces to the type of its vectors. -/
 instance : CoeSort (IntegralLattice V) (Type u) := ⟨fun L ↦ L.carrier⟩
+
+/-- The carrier of an integral lattice is a free `ℤ`-module. -/
+instance (L : IntegralLattice V) : Module.Free ℤ L := inferInstance
+
+/-- The carrier of an integral lattice is a finitely generated `ℤ`-module. -/
+instance (L : IntegralLattice V) : Module.Finite ℤ L := inferInstance
+
+/-- A chosen `ℤ`-basis of the carrier of an integral lattice. -/
+noncomputable def basis (L : IntegralLattice V) :
+    Basis (Module.Free.ChooseBasisIndex ℤ L) ℤ L :=
+  Module.Free.chooseBasis ℤ L
+
+/-- The chosen `ℤ`-basis of an integral lattice extends to a `ℚ`-basis of the ambient space. -/
+noncomputable def rationalBasis (L : IntegralLattice V) :
+    Basis (Module.Free.ChooseBasisIndex ℤ L) ℚ V :=
+  L.basis.extendOfIsLattice ℚ
+
+@[simp]
+theorem rationalBasis_apply (L : IntegralLattice V) (i : Module.Free.ChooseBasisIndex ℤ L) :
+    L.rationalBasis i = (L.basis i : V) :=
+  Basis.extendOfIsLattice_apply ℚ L.basis i
+
+/-- The `ℤ`-rank of the carrier of an integral lattice equals the `ℚ`-rank of the ambient space. -/
+theorem rank_carrier (L : IntegralLattice V) :
+    Module.rank ℤ L = Module.rank ℚ V :=
+  Submodule.IsLattice.rank' ℚ L.carrier
+
+/-- The `ℤ`-finrank of the carrier of an integral lattice equals the `ℚ`-finrank of the ambient
+space. -/
+theorem finrank_carrier (L : IntegralLattice V) :
+    Module.finrank ℤ L = Module.finrank ℚ V :=
+  congr_arg Cardinal.toNat L.rank_carrier
 
 /-- Two integral lattices are equal if their carriers and rational forms are equal. -/
 @[ext]
@@ -98,6 +159,11 @@ theorem integralForm_isSymm (L : IntegralLattice V) : L.integralForm.IsSymm := b
   intro x y
   exact Int.cast_injective (by rw [L.integralForm_cast, L.integralForm_cast, L.form_comm])
 
+/-- The symmetry equation for the induced integral form of an integral lattice. -/
+theorem integralForm_comm (L : IntegralLattice V) (x y : L) :
+    L.integralForm x y = L.integralForm y x :=
+  L.integralForm_isSymm.eq x y
+
 section Basis
 
 variable {ι : Type*} [Finite ι]
@@ -121,22 +187,37 @@ noncomputable def ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (
   isSymm := hB
   le_dual := by
     rw [Submodule.span_le]
-    rintro x ⟨i, rfl⟩
-    change Submodule.span ℤ (Set.range b) ≤
-      Submodule.comap ((B (b i)).restrictScalars ℤ) (1 : Submodule ℤ ℚ)
-    rw [Submodule.span_le]
-    rintro _ ⟨j, rfl⟩
-    exact hint i j
+    rintro _ ⟨i, rfl⟩
+    change b i ∈ B.dualSubmodule (Submodule.span ℤ (Set.range b))
+    rw [LinearMap.BilinForm.mem_dualSubmodule]
+    intro y hy
+    induction hy using Submodule.span_induction with
+    | mem z hz =>
+      obtain ⟨j, rfl⟩ := hz
+      exact hint i j
+    | zero =>
+      simp only [map_zero, Submodule.zero_mem]
+    | add u v _ _ hu_mem hv_mem =>
+      simp only [map_add, Submodule.add_mem _ hu_mem hv_mem]
+    | smul c u _ hu_mem =>
+      rw [map_zsmul]
+      exact Submodule.smul_mem _ c hu_mem
 
 @[simp]
 theorem carrier_ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
     (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) :
-    (ofBasis b B hB hint).carrier = Submodule.span ℤ (Set.range b) := rfl
+    (ofBasis b B hB hint).carrier = Submodule.span ℤ (Set.range b) := (rfl)
 
 @[simp]
 theorem form_ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
     (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) :
-    (ofBasis b B hB hint).form = B := rfl
+    (ofBasis b B hB hint).form = B := (rfl)
+
+/-- The canonical embedding of the basis vector `b i` into the carrier of `ofBasis b B hB hint`. -/
+noncomputable def ofBasis.basisElem (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
+    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) (i : ι) :
+    ofBasis b B hB hint :=
+  ⟨b i, by rw [carrier_ofBasis]; exact Submodule.subset_span (Set.mem_range_self i)⟩
 
 section GramMatrix
 
@@ -156,11 +237,41 @@ noncomputable def ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG :
 
 @[simp]
 theorem carrier_ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
-    (ofGramMatrix b G hG).carrier = Submodule.span ℤ (Set.range b) := rfl
+    (ofGramMatrix b G hG).carrier = Submodule.span ℤ (Set.range b) := (rfl)
 
 @[simp]
 theorem form_ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
-    (ofGramMatrix b G hG).form = Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) := rfl
+    (ofGramMatrix b G hG).form = Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) := (rfl)
+
+/-- The canonical embedding of the basis vector `b i` into the carrier of `ofGramMatrix b G hG`. -/
+noncomputable def ofGramMatrix.basisElem (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
+    (i : ι) : ofGramMatrix b G hG :=
+  ⟨b i, by rw [carrier_ofGramMatrix]; exact Submodule.subset_span (Set.mem_range_self i)⟩
+
+/-- Evaluating the induced integral form of `ofGramMatrix` on embedded basis vectors recovers
+the corresponding entry of the Gram matrix. -/
+@[simp]
+theorem integralForm_ofGramMatrix_apply (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
+    (i j : ι) (hi : b i ∈ (ofGramMatrix b G hG).carrier)
+    (hj : b j ∈ (ofGramMatrix b G hG).carrier) :
+    (ofGramMatrix b G hG).integralForm ⟨b i, hi⟩ ⟨b j, hj⟩ = G i j := by
+  apply Int.cast_injective (α := ℚ)
+  rw [integralForm_cast]
+  have hform : (ofGramMatrix b G hG).form = Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) :=
+    form_ofGramMatrix b G hG
+  rw [hform]
+  have h := congr_fun (congr_fun
+    (LinearMap.BilinForm.toMatrix_toBilin (b := b) (G.map (algebraMap ℤ ℚ))) i) j
+  rw [LinearMap.BilinForm.toMatrix_apply] at h
+  rw [h]
+  simp
+
+@[simp]
+theorem integralForm_ofGramMatrix_basisElem (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
+    (i j : ι) :
+    (ofGramMatrix b G hG).integralForm (ofGramMatrix.basisElem b G hG i)
+      (ofGramMatrix.basisElem b G hG j) = G i j :=
+  integralForm_ofGramMatrix_apply b G hG i j _ _
 
 end GramMatrix
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -186,7 +186,6 @@ variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
 /-- Evaluating the rational bilinear form associated with a matrix on basis vectors recovers
 the matrix entry. -/
-@[simp]
 theorem toBilin_map_apply_basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (i j : ι) :
     Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) (b i) (b j) = (G i j : ℚ) := by
   rw [← LinearMap.BilinForm.toMatrix_apply (b := b), LinearMap.BilinForm.toMatrix_toBilin,

--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -27,10 +27,8 @@ The form restricts to a canonical `ℤ`-bilinear form on the carrier.  Conversel
 ## Main definitions
 
 * `TauCeti.IntegralLattice`: an integral symmetric lattice in a rational vector space.
-* `TauCeti.IntegralLattice.ofSubmodule`: constructor from an existing full submodule with an
-  integral symmetric form.
-* `TauCeti.IntegralLattice.basis`: a chosen `ℤ`-basis of the carrier.
-* `TauCeti.IntegralLattice.rationalBasis`: the ambient `ℚ`-basis extending the carrier basis.
+* `TauCeti.IntegralLattice.rationalBasis`: the ambient `ℚ`-basis extending a chosen `ℤ`-basis of
+  the carrier.
 * `TauCeti.IntegralLattice.integralForm`: the induced `ℤ`-bilinear form on the carrier.
 * `TauCeti.IntegralLattice.ofBasis`: the lattice spanned by a basis on which a given form is
   integral.
@@ -68,26 +66,6 @@ namespace IntegralLattice
 
 variable {V}
 
-/-- Construct an integral symmetric lattice from a full submodule and a symmetric rational form
-that is integral on the submodule. -/
-def ofSubmodule (M : Submodule ℤ V) (B : LinearMap.BilinForm ℚ V) (hM : M.IsLattice ℚ)
-    (hB : B.IsSymm) (hle : M ≤ B.dualSubmodule M) : IntegralLattice V where
-  carrier := M
-  form := B
-  isLattice := hM
-  isSymm := hB
-  le_dual := hle
-
-@[simp]
-theorem carrier_ofSubmodule (M : Submodule ℤ V) (B : LinearMap.BilinForm ℚ V) (hM : M.IsLattice ℚ)
-    (hB : B.IsSymm) (hle : M ≤ B.dualSubmodule M) :
-    (ofSubmodule M B hM hB hle).carrier = M := (rfl)
-
-@[simp]
-theorem form_ofSubmodule (M : Submodule ℤ V) (B : LinearMap.BilinForm ℚ V) (hM : M.IsLattice ℚ)
-    (hB : B.IsSymm) (hle : M ≤ B.dualSubmodule M) :
-    (ofSubmodule M B hM hB hle).form = B := (rfl)
-
 /-- The carrier of an integral lattice is a Mathlib lattice. -/
 instance (L : IntegralLattice V) : L.carrier.IsLattice ℚ := L.isLattice
 
@@ -101,37 +79,21 @@ instance : CoeFun (IntegralLattice V) fun _ ↦ V → V → ℚ :=
 @[simp]
 theorem coeFun_apply (L : IntegralLattice V) (x y : V) : L x y = L.form x y := rfl
 
-/-- The carrier of an integral lattice is a free `ℤ`-module. -/
-instance (L : IntegralLattice V) : Module.Free ℤ L := inferInstance
-
-/-- The carrier of an integral lattice is a finitely generated `ℤ`-module. -/
-instance (L : IntegralLattice V) : Module.Finite ℤ L := inferInstance
-
-/-- A chosen `ℤ`-basis of the carrier of an integral lattice. -/
-noncomputable def basis (L : IntegralLattice V) :
-    Basis (Module.Free.ChooseBasisIndex ℤ L) ℤ L :=
-  Module.Free.chooseBasis ℤ L
-
 /-- The chosen `ℤ`-basis of an integral lattice extends to a `ℚ`-basis of the ambient space. -/
 noncomputable def rationalBasis (L : IntegralLattice V) :
     Basis (Module.Free.ChooseBasisIndex ℤ L) ℚ V :=
-  L.basis.extendOfIsLattice ℚ
+  (Module.Free.chooseBasis ℤ L).extendOfIsLattice ℚ
 
 @[simp]
 theorem rationalBasis_apply (L : IntegralLattice V) (i : Module.Free.ChooseBasisIndex ℤ L) :
-    L.rationalBasis i = (L.basis i : V) :=
-  Basis.extendOfIsLattice_apply ℚ L.basis i
-
-/-- The `ℤ`-rank of the carrier of an integral lattice equals the `ℚ`-rank of the ambient space. -/
-theorem rank_carrier (L : IntegralLattice V) :
-    Module.rank ℤ L = Module.rank ℚ V :=
-  Submodule.IsLattice.rank' ℚ L.carrier
+    L.rationalBasis i = (Module.Free.chooseBasis ℤ L i : V) :=
+  Basis.extendOfIsLattice_apply ℚ (Module.Free.chooseBasis ℤ L) i
 
 /-- The `ℤ`-finrank of the carrier of an integral lattice equals the `ℚ`-finrank of the ambient
 space. -/
 theorem finrank_carrier (L : IntegralLattice V) :
     Module.finrank ℤ L = Module.finrank ℚ V :=
-  congr_arg Cardinal.toNat L.rank_carrier
+  congr_arg Cardinal.toNat (Submodule.IsLattice.rank' ℚ L.carrier)
 
 /-- Two integral lattices are equal if their carriers and rational forms are equal. -/
 @[ext]
@@ -142,10 +104,6 @@ theorem ext {L M : IntegralLattice V} (hcarrier : L.carrier = M.carrier)
   cases hcarrier
   cases hform
   rfl
-
-/-- The symmetry equation for the rational form of an integral lattice. -/
-theorem form_comm (L : IntegralLattice V) (x y : V) : L.form x y = L.form y x :=
-  L.isSymm.eq x y
 
 /-- The integral bilinear form induced on the carrier.
 
@@ -164,12 +122,7 @@ theorem integralForm_cast (L : IntegralLattice V) (x y : L) :
 theorem integralForm_isSymm (L : IntegralLattice V) : L.integralForm.IsSymm := by
   constructor
   intro x y
-  exact Int.cast_injective (by rw [L.integralForm_cast, L.integralForm_cast, L.form_comm])
-
-/-- The symmetry equation for the induced integral form of an integral lattice. -/
-theorem integralForm_comm (L : IntegralLattice V) (x y : L) :
-    L.integralForm x y = L.integralForm y x :=
-  L.integralForm_isSymm.eq x y
+  exact Int.cast_injective (by rw [L.integralForm_cast, L.integralForm_cast, L.isSymm.eq])
 
 section Basis
 
@@ -225,9 +178,20 @@ noncomputable def ofBasis.basisElem (b : Basis ι ℚ V) (B : LinearMap.BilinFor
     ofBasis b B hB hint :=
   ⟨b i, by rw [carrier_ofBasis]; exact Submodule.subset_span (Set.mem_range_self i)⟩
 
+end Basis
+
 section GramMatrix
 
-variable [Fintype ι] [DecidableEq ι]
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+/-- Evaluating the rational bilinear form associated with a matrix on basis vectors recovers
+the matrix entry. -/
+@[simp]
+theorem toBilin_map_apply_basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (i j : ι) :
+    Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) (b i) (b j) = (G i j : ℚ) := by
+  rw [← LinearMap.BilinForm.toMatrix_apply (b := b), LinearMap.BilinForm.toMatrix_toBilin,
+    Matrix.map_apply]
+  rfl
 
 /-- Construct an integral lattice from a finite rational basis and an integral symmetric Gram
 matrix. -/
@@ -235,11 +199,8 @@ noncomputable def ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG :
   IntegralLattice V :=
   ofBasis b (Matrix.toBilin b (G.map (algebraMap ℤ ℚ)))
     ((Matrix.isSymm_toBilin_iff_isSymm (b := b)).mpr (hG.map _)) fun i j ↦ by
-      apply Submodule.mem_one.mpr
-      refine ⟨G i j, ?_⟩
-      simpa only [LinearMap.BilinForm.toMatrix_apply, Matrix.map_apply] using
-        congr_fun (congr_fun
-          (LinearMap.BilinForm.toMatrix_toBilin (b := b) (G.map (algebraMap ℤ ℚ))) i) j |>.symm
+      rw [toBilin_map_apply_basis]
+      exact Submodule.mem_one.mpr ⟨G i j, rfl⟩
 
 @[simp]
 theorem carrier_ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
@@ -249,11 +210,6 @@ theorem carrier_ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G
 theorem form_ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
     (ofGramMatrix b G hG).form = Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) := (rfl)
 
-/-- The canonical embedding of the basis vector `b i` into the carrier of `ofGramMatrix b G hG`. -/
-noncomputable def ofGramMatrix.basisElem (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
-    (i : ι) : ofGramMatrix b G hG :=
-  ⟨b i, by rw [carrier_ofGramMatrix]; exact Submodule.subset_span (Set.mem_range_self i)⟩
-
 /-- Evaluating the induced integral form of `ofGramMatrix` on embedded basis vectors recovers
 the corresponding entry of the Gram matrix. -/
 @[simp]
@@ -262,26 +218,9 @@ theorem integralForm_ofGramMatrix_apply (b : Basis ι ℚ V) (G : Matrix ι ι �
     (hj : b j ∈ (ofGramMatrix b G hG).carrier) :
     (ofGramMatrix b G hG).integralForm ⟨b i, hi⟩ ⟨b j, hj⟩ = G i j := by
   apply Int.cast_injective (α := ℚ)
-  rw [integralForm_cast]
-  have hform : (ofGramMatrix b G hG).form = Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) :=
-    form_ofGramMatrix b G hG
-  rw [hform]
-  have h := congr_fun (congr_fun
-    (LinearMap.BilinForm.toMatrix_toBilin (b := b) (G.map (algebraMap ℤ ℚ))) i) j
-  rw [LinearMap.BilinForm.toMatrix_apply] at h
-  rw [h]
-  simp
-
-@[simp]
-theorem integralForm_ofGramMatrix_basisElem (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
-    (i j : ι) :
-    (ofGramMatrix b G hG).integralForm (ofGramMatrix.basisElem b G hG i)
-      (ofGramMatrix.basisElem b G hG j) = G i j :=
-  integralForm_ofGramMatrix_apply b G hG i j _ _
+  rw [integralForm_cast, form_ofGramMatrix, toBilin_map_apply_basis]
 
 end GramMatrix
-
-end Basis
 
 end IntegralLattice
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -94,6 +94,13 @@ instance (L : IntegralLattice V) : L.carrier.IsLattice ℚ := L.isLattice
 /-- An integral lattice coerces to the type of its vectors. -/
 instance : CoeSort (IntegralLattice V) (Type u) := ⟨fun L ↦ L.carrier⟩
 
+/-- An integral lattice coerces to its rational bilinear form. -/
+instance : CoeFun (IntegralLattice V) fun _ ↦ V → V → ℚ :=
+  ⟨fun L x y ↦ L.form x y⟩
+
+@[simp]
+theorem coeFun_apply (L : IntegralLattice V) (x y : V) : L x y = L.form x y := rfl
+
 /-- The carrier of an integral lattice is a free `ℤ`-module. -/
 instance (L : IntegralLattice V) : Module.Free ℤ L := inferInstance
 
@@ -188,8 +195,7 @@ noncomputable def ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (
   le_dual := by
     rw [Submodule.span_le]
     rintro _ ⟨i, rfl⟩
-    change b i ∈ B.dualSubmodule (Submodule.span ℤ (Set.range b))
-    rw [LinearMap.BilinForm.mem_dualSubmodule]
+    rw [SetLike.mem_coe, LinearMap.BilinForm.mem_dualSubmodule]
     intro y hy
     induction hy using Submodule.span_induction with
     | mem z hz =>

--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -65,19 +65,6 @@ instance (L : IntegralLattice V) : L.carrier.IsLattice ℚ := L.isLattice
 /-- An integral lattice coerces to the type of its vectors. -/
 instance : CoeSort (IntegralLattice V) (Type u) := ⟨fun L ↦ L.carrier⟩
 
-/-- Membership in an integral lattice means membership in its carrier. -/
-instance : Membership V (IntegralLattice V) := ⟨fun L x ↦ x ∈ L.carrier⟩
-
-/-- An integral lattice coerces to its rational bilinear form. -/
-instance : CoeFun (IntegralLattice V) fun _ ↦ V → V → ℚ :=
-  ⟨fun L x y ↦ L.form x y⟩
-
-@[simp]
-theorem mem_carrier {L : IntegralLattice V} {x : V} : x ∈ L.carrier ↔ x ∈ L := Iff.rfl
-
-@[simp]
-theorem coeFun_apply (L : IntegralLattice V) (x y : V) : L x y = L.form x y := rfl
-
 /-- Two integral lattices are equal if their carriers and rational forms are equal. -/
 @[ext]
 theorem ext {L M : IntegralLattice V} (hcarrier : L.carrier = M.carrier)
@@ -92,50 +79,24 @@ theorem ext {L M : IntegralLattice V} (hcarrier : L.carrier = M.carrier)
 theorem form_comm (L : IntegralLattice V) (x y : V) : L.form x y = L.form y x :=
   L.isSymm.eq x y
 
-/-- The inclusion of the carrier into its dual submodule. -/
-def toDualSubmodule (L : IntegralLattice V) :
-    L.carrier →ₗ[ℤ] L.form.dualSubmodule L.carrier :=
-  L.carrier.subtype.codRestrict (L.form.dualSubmodule L.carrier) fun x ↦ L.le_dual x.property
-
-@[simp]
-theorem coe_toDualSubmodule (L : IntegralLattice V) (x : L) :
-    (L.toDualSubmodule x : V) = x := rfl
-
-/-- The inclusion of an integral lattice into its dual submodule is injective. -/
-theorem toDualSubmodule_injective (L : IntegralLattice V) :
-    Function.Injective L.toDualSubmodule := by
-  intro x y hxy
-  apply Subtype.ext
-  exact congr_arg (fun z : L.form.dualSubmodule L.carrier ↦ (z : V)) hxy
-
 /-- The integral bilinear form induced on the carrier.
 
 This is the integral-valued restriction of `L.form`, obtained from Mathlib's canonical pairing
 between a submodule and its dual submodule. -/
 noncomputable def integralForm (L : IntegralLattice V) : LinearMap.BilinForm ℤ L :=
-  (L.form.dualSubmoduleToDual L.carrier).comp L.toDualSubmodule
+  (L.form.dualSubmoduleToDual L.carrier).comp (Submodule.inclusion L.le_dual)
 
 /-- The integral form recovers the rational form after coercion to `ℚ`. -/
 @[simp]
 theorem integralForm_cast (L : IntegralLattice V) (x y : L) :
     (L.integralForm x y : ℚ) = L.form x y := by
-  exact L.form.dualSubmoduleParing_spec (L.toDualSubmodule x) y
+  exact L.form.dualSubmoduleParing_spec (Submodule.inclusion L.le_dual x) y
 
 /-- The induced integral form is symmetric. -/
 theorem integralForm_isSymm (L : IntegralLattice V) : L.integralForm.IsSymm := by
   constructor
   intro x y
   exact Int.cast_injective (by rw [L.integralForm_cast, L.integralForm_cast, L.form_comm])
-
-/-- The rational form takes an integer value on every pair of lattice vectors. -/
-theorem exists_int_eq_form (L : IntegralLattice V) (x y : L) :
-    ∃ z : ℤ, (z : ℚ) = L.form x y :=
-  Submodule.mem_one.mp (L.le_dual x.property y y.property)
-
-/-- The rank of the carrier equals the rational rank of the ambient space. -/
-theorem rank_carrier (L : IntegralLattice V) :
-    Module.rank ℤ L.carrier = Module.rank ℚ V :=
-  Submodule.IsLattice.rank' ℚ L.carrier
 
 section Basis
 
@@ -160,16 +121,12 @@ noncomputable def ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (
   isSymm := hB
   le_dual := by
     rw [Submodule.span_le]
-    rintro x ⟨i, rfl⟩ y hy
-    induction hy using Submodule.span_induction with
-    | mem y hy =>
-        obtain ⟨j, rfl⟩ := hy
-        exact hint i j
-    | zero => simp
-    | add x y _ _ hx hy =>
-        simpa using (1 : Submodule ℤ ℚ).add_mem hx hy
-    | smul z x _ hx =>
-        simpa using (1 : Submodule ℤ ℚ).smul_mem z hx
+    rintro x ⟨i, rfl⟩
+    change Submodule.span ℤ (Set.range b) ≤
+      Submodule.comap ((B (b i)).restrictScalars ℤ) (1 : Submodule ℤ ℚ)
+    rw [Submodule.span_le]
+    rintro _ ⟨j, rfl⟩
+    exact hint i j
 
 @[simp]
 theorem carrier_ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)

--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Module.Lattice
+public import Mathlib.LinearAlgebra.BilinearForm.DualLattice
+public import Mathlib.LinearAlgebra.Matrix.BilinearForm
+
+/-!
+# Integral symmetric lattices
+
+An integral symmetric lattice in a rational vector space consists of a full finitely generated
+`ℤ`-submodule together with a symmetric `ℚ`-bilinear form whose values on the lattice are
+integers.  The integrality condition is expressed using Mathlib's
+`LinearMap.BilinForm.dualSubmodule`: the carrier is contained in its dual submodule.
+
+The form restricts to a canonical `ℤ`-bilinear form on the carrier.  Conversely, a finite
+`ℚ`-basis and an integral symmetric Gram matrix construct an integral lattice.
+
+## Main definitions
+
+* `TauCeti.IntegralLattice`: an integral symmetric lattice in a rational vector space.
+* `TauCeti.IntegralLattice.integralForm`: the induced `ℤ`-bilinear form on the carrier.
+* `TauCeti.IntegralLattice.ofBasis`: the lattice spanned by a basis on which a given form is
+  integral.
+* `TauCeti.IntegralLattice.ofGramMatrix`: the lattice and form determined by an integral
+  symmetric Gram matrix.
+-/
+
+@[expose] public section
+
+open Module
+
+namespace TauCeti
+
+universe u
+
+variable (V : Type u) [AddCommGroup V] [Module ℚ V]
+
+/-- An integral symmetric lattice in a rational vector space.
+
+The field `le_dual` says exactly that the form takes integer values on pairs of vectors in
+`carrier`. -/
+structure IntegralLattice where
+  /-- The full `ℤ`-submodule underlying the lattice. -/
+  carrier : Submodule ℤ V
+  /-- The rational symmetric bilinear form on the ambient vector space. -/
+  form : LinearMap.BilinForm ℚ V
+  /-- The carrier is finitely generated and spans the ambient rational vector space. -/
+  isLattice : carrier.IsLattice ℚ
+  /-- The rational bilinear form is symmetric. -/
+  isSymm : form.IsSymm
+  /-- Every vector of the carrier lies in its dual submodule. -/
+  le_dual : carrier ≤ form.dualSubmodule carrier
+
+namespace IntegralLattice
+
+variable {V}
+
+/-- The carrier of an integral lattice is a Mathlib lattice. -/
+instance (L : IntegralLattice V) : L.carrier.IsLattice ℚ := L.isLattice
+
+/-- An integral lattice coerces to the type of its vectors. -/
+instance : CoeSort (IntegralLattice V) (Type u) := ⟨fun L ↦ L.carrier⟩
+
+/-- Membership in an integral lattice means membership in its carrier. -/
+instance : Membership V (IntegralLattice V) := ⟨fun L x ↦ x ∈ L.carrier⟩
+
+/-- An integral lattice coerces to its rational bilinear form. -/
+instance : CoeFun (IntegralLattice V) fun _ ↦ V → V → ℚ :=
+  ⟨fun L x y ↦ L.form x y⟩
+
+@[simp]
+theorem mem_carrier {L : IntegralLattice V} {x : V} : x ∈ L.carrier ↔ x ∈ L := Iff.rfl
+
+@[simp]
+theorem coeFun_apply (L : IntegralLattice V) (x y : V) : L x y = L.form x y := rfl
+
+/-- Two integral lattices are equal if their carriers and rational forms are equal. -/
+@[ext]
+theorem ext {L M : IntegralLattice V} (hcarrier : L.carrier = M.carrier)
+    (hform : L.form = M.form) : L = M := by
+  cases L
+  cases M
+  cases hcarrier
+  cases hform
+  rfl
+
+/-- The symmetry equation for the rational form of an integral lattice. -/
+theorem form_comm (L : IntegralLattice V) (x y : V) : L.form x y = L.form y x :=
+  L.isSymm.eq x y
+
+/-- The inclusion of the carrier into its dual submodule. -/
+def toDualSubmodule (L : IntegralLattice V) :
+    L.carrier →ₗ[ℤ] L.form.dualSubmodule L.carrier :=
+  L.carrier.subtype.codRestrict (L.form.dualSubmodule L.carrier) fun x ↦ L.le_dual x.property
+
+@[simp]
+theorem coe_toDualSubmodule (L : IntegralLattice V) (x : L) :
+    (L.toDualSubmodule x : V) = x := rfl
+
+/-- The inclusion of an integral lattice into its dual submodule is injective. -/
+theorem toDualSubmodule_injective (L : IntegralLattice V) :
+    Function.Injective L.toDualSubmodule := by
+  intro x y hxy
+  apply Subtype.ext
+  exact congr_arg (fun z : L.form.dualSubmodule L.carrier ↦ (z : V)) hxy
+
+/-- The integral bilinear form induced on the carrier.
+
+This is the integral-valued restriction of `L.form`, obtained from Mathlib's canonical pairing
+between a submodule and its dual submodule. -/
+noncomputable def integralForm (L : IntegralLattice V) : LinearMap.BilinForm ℤ L :=
+  (L.form.dualSubmoduleToDual L.carrier).comp L.toDualSubmodule
+
+/-- The integral form recovers the rational form after coercion to `ℚ`. -/
+@[simp]
+theorem integralForm_cast (L : IntegralLattice V) (x y : L) :
+    (L.integralForm x y : ℚ) = L.form x y := by
+  exact L.form.dualSubmoduleParing_spec (L.toDualSubmodule x) y
+
+/-- The induced integral form is symmetric. -/
+theorem integralForm_isSymm (L : IntegralLattice V) : L.integralForm.IsSymm := by
+  constructor
+  intro x y
+  exact Int.cast_injective (by rw [L.integralForm_cast, L.integralForm_cast, L.form_comm])
+
+/-- The rational form takes an integer value on every pair of lattice vectors. -/
+theorem exists_int_eq_form (L : IntegralLattice V) (x y : L) :
+    ∃ z : ℤ, (z : ℚ) = L.form x y :=
+  Submodule.mem_one.mp (L.le_dual x.property y y.property)
+
+/-- The rank of the carrier equals the rational rank of the ambient space. -/
+theorem rank_carrier (L : IntegralLattice V) :
+    Module.rank ℤ L.carrier = Module.rank ℚ V :=
+  Submodule.IsLattice.rank' ℚ L.carrier
+
+section Basis
+
+variable {ι : Type*} [Finite ι]
+
+/-- The `ℤ`-span of a finite rational basis is a Mathlib lattice. -/
+theorem isLattice_span_basis (b : Basis ι ℚ V) :
+    (Submodule.span ℤ (Set.range b)).IsLattice ℚ := by
+  constructor
+  · exact Submodule.fg_span (Set.finite_range b)
+  · simp [Submodule.span_span_of_tower]
+
+/-- A symmetric rational form that is integral on basis vectors defines an integral lattice.
+
+The carrier is the `ℤ`-span of the basis.  Bilinearity propagates the integral-value hypothesis
+from basis vectors to their integral span. -/
+noncomputable def ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
+    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) : IntegralLattice V where
+  carrier := Submodule.span ℤ (Set.range b)
+  form := B
+  isLattice := isLattice_span_basis b
+  isSymm := hB
+  le_dual := by
+    rw [Submodule.span_le]
+    rintro x ⟨i, rfl⟩ y hy
+    induction hy using Submodule.span_induction with
+    | mem y hy =>
+        obtain ⟨j, rfl⟩ := hy
+        exact hint i j
+    | zero => simp
+    | add x y _ _ hx hy =>
+        simpa using (1 : Submodule ℤ ℚ).add_mem hx hy
+    | smul z x _ hx =>
+        simpa using (1 : Submodule ℤ ℚ).smul_mem z hx
+
+@[simp]
+theorem carrier_ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
+    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) :
+    (ofBasis b B hB hint).carrier = Submodule.span ℤ (Set.range b) := rfl
+
+@[simp]
+theorem form_ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
+    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) :
+    (ofBasis b B hB hint).form = B := rfl
+
+section GramMatrix
+
+variable [Fintype ι] [DecidableEq ι]
+
+/-- Construct an integral lattice from a finite rational basis and an integral symmetric Gram
+matrix. -/
+noncomputable def ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
+  IntegralLattice V :=
+  ofBasis b (Matrix.toBilin b (G.map (algebraMap ℤ ℚ)))
+    ((Matrix.isSymm_toBilin_iff_isSymm (b := b)).mpr (hG.map _)) fun i j ↦ by
+      apply Submodule.mem_one.mpr
+      refine ⟨G i j, ?_⟩
+      simpa only [LinearMap.BilinForm.toMatrix_apply, Matrix.map_apply] using
+        congr_fun (congr_fun
+          (LinearMap.BilinForm.toMatrix_toBilin (b := b) (G.map (algebraMap ℤ ℚ))) i) j |>.symm
+
+@[simp]
+theorem carrier_ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
+    (ofGramMatrix b G hG).carrier = Submodule.span ℤ (Set.range b) := rfl
+
+@[simp]
+theorem form_ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
+    (ofGramMatrix b G hG).form = Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) := rfl
+
+end GramMatrix
+
+end Basis
+
+end IntegralLattice
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -30,6 +30,8 @@ The form restricts to a canonical `ℤ`-bilinear form on the carrier.  Conversel
 * `TauCeti.IntegralLattice.rationalBasis`: the ambient `ℚ`-basis extending a chosen `ℤ`-basis of
   the carrier.
 * `TauCeti.IntegralLattice.integralForm`: the induced `ℤ`-bilinear form on the carrier.
+* `TauCeti.IntegralLattice.ofSubmodule`: constructor from a full submodule, symmetric form, and
+  integrality proof.
 * `TauCeti.IntegralLattice.ofBasis`: the lattice spanned by a basis on which a given form is
   integral.
 * `TauCeti.IntegralLattice.ofGramMatrix`: the lattice and form determined by an integral
@@ -77,7 +79,7 @@ instance : CoeFun (IntegralLattice V) fun _ ↦ V → V → ℚ :=
   ⟨fun L x y ↦ L.form x y⟩
 
 @[simp]
-theorem coeFun_apply (L : IntegralLattice V) (x y : V) : L x y = L.form x y := rfl
+theorem coe_form_apply (L : IntegralLattice V) (x y : V) : L x y = L.form x y := rfl
 
 /-- The chosen `ℤ`-basis of an integral lattice extends to a `ℚ`-basis of the ambient space. -/
 noncomputable def rationalBasis (L : IntegralLattice V) :
@@ -116,13 +118,34 @@ noncomputable def integralForm (L : IntegralLattice V) : LinearMap.BilinForm ℤ
 @[simp]
 theorem integralForm_cast (L : IntegralLattice V) (x y : L) :
     (L.integralForm x y : ℚ) = L.form x y := by
+  rw [integralForm, LinearMap.comp_apply, LinearMap.BilinForm.dualSubmoduleToDual_apply_apply]
   exact L.form.dualSubmoduleParing_spec (Submodule.inclusion L.le_dual x) y
 
 /-- The induced integral form is symmetric. -/
-theorem integralForm_isSymm (L : IntegralLattice V) : L.integralForm.IsSymm := by
+theorem isSymm_integralForm (L : IntegralLattice V) : L.integralForm.IsSymm := by
   constructor
   intro x y
   exact Int.cast_injective (by rw [L.integralForm_cast, L.integralForm_cast, L.isSymm.eq])
+
+/-- Construct an integral lattice from a full submodule, a symmetric rational bilinear form, and
+an integrality proof. -/
+def ofSubmodule (S : Submodule ℤ V) [hS : S.IsLattice ℚ] (B : LinearMap.BilinForm ℚ V)
+    (hB : B.IsSymm) (hle : S ≤ B.dualSubmodule S) : IntegralLattice V where
+  carrier := S
+  form := B
+  isLattice := hS
+  isSymm := hB
+  le_dual := hle
+
+@[simp]
+theorem ofSubmodule_carrier (S : Submodule ℤ V) [hS : S.IsLattice ℚ] (B : LinearMap.BilinForm ℚ V)
+    (hB : B.IsSymm) (hle : S ≤ B.dualSubmodule S) :
+    (ofSubmodule S B hB hle).carrier = S := (rfl)
+
+@[simp]
+theorem ofSubmodule_form (S : Submodule ℤ V) [hS : S.IsLattice ℚ] (B : LinearMap.BilinForm ℚ V)
+    (hB : B.IsSymm) (hle : S ≤ B.dualSubmodule S) :
+    (ofSubmodule S B hB hle).form = B := (rfl)
 
 section Basis
 
@@ -163,12 +186,12 @@ noncomputable def ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (
       exact Submodule.smul_mem _ c hu_mem
 
 @[simp]
-theorem carrier_ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
+theorem ofBasis_carrier (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
     (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) :
     (ofBasis b B hB hint).carrier = Submodule.span ℤ (Set.range b) := (rfl)
 
 @[simp]
-theorem form_ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
+theorem ofBasis_form (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
     (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) :
     (ofBasis b B hB hint).form = B := (rfl)
 
@@ -176,14 +199,15 @@ theorem form_ofBasis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : 
 noncomputable def ofBasis.basisElem (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
     (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) (i : ι) :
     ofBasis b B hB hint :=
-  ⟨b i, by rw [carrier_ofBasis]; exact Submodule.subset_span (Set.mem_range_self i)⟩
+  ⟨b i, by rw [ofBasis_carrier]; exact Submodule.subset_span (Set.mem_range_self i)⟩
 
 end Basis
 
 section GramMatrix
 
-variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+variable {ι : Type*} [Fintype ι]
 
+open Classical in
 /-- Evaluating the rational bilinear form associated with a matrix on basis vectors recovers
 the matrix entry. -/
 theorem toBilin_map_apply_basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (i j : ι) :
@@ -192,32 +216,44 @@ theorem toBilin_map_apply_basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (i j
     Matrix.map_apply]
   rfl
 
+open Classical in
 /-- Construct an integral lattice from a finite rational basis and an integral symmetric Gram
 matrix. -/
 noncomputable def ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
-  IntegralLattice V :=
+    IntegralLattice V :=
   ofBasis b (Matrix.toBilin b (G.map (algebraMap ℤ ℚ)))
     ((Matrix.isSymm_toBilin_iff_isSymm (b := b)).mpr (hG.map _)) fun i j ↦ by
       rw [toBilin_map_apply_basis]
       exact Submodule.mem_one.mpr ⟨G i j, rfl⟩
 
+open Classical in
 @[simp]
-theorem carrier_ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
+theorem ofGramMatrix_carrier (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
     (ofGramMatrix b G hG).carrier = Submodule.span ℤ (Set.range b) := (rfl)
 
+open Classical in
 @[simp]
-theorem form_ofGramMatrix (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
+theorem ofGramMatrix_form (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
     (ofGramMatrix b G hG).form = Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) := (rfl)
 
+open Classical in
+/-- The canonical embedding of the basis vector `b i` into the carrier of
+`ofGramMatrix b G hG`. -/
+noncomputable def ofGramMatrix.basisElem (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
+    (i : ι) : ofGramMatrix b G hG :=
+  ⟨b i, by rw [ofGramMatrix_carrier]; exact Submodule.subset_span (Set.mem_range_self i)⟩
+
+open Classical in
 /-- Evaluating the induced integral form of `ofGramMatrix` on embedded basis vectors recovers
 the corresponding entry of the Gram matrix. -/
 @[simp]
 theorem integralForm_ofGramMatrix_apply (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
-    (i j : ι) (hi : b i ∈ (ofGramMatrix b G hG).carrier)
-    (hj : b j ∈ (ofGramMatrix b G hG).carrier) :
-    (ofGramMatrix b G hG).integralForm ⟨b i, hi⟩ ⟨b j, hj⟩ = G i j := by
+    (i j : ι) :
+    (ofGramMatrix b G hG).integralForm (ofGramMatrix.basisElem b G hG i)
+      (ofGramMatrix.basisElem b G hG j) = G i j := by
   apply Int.cast_injective (α := ℚ)
-  rw [integralForm_cast, form_ofGramMatrix, toBilin_map_apply_basis]
+  rw [integralForm_cast, ofGramMatrix_form]
+  exact toBilin_map_apply_basis b G i j
 
 end GramMatrix
 


### PR DESCRIPTION
This PR defines integral symmetric lattices in rational vector spaces, exposes their carrier and form APIs, restricts the rational pairing to a canonical symmetric `ℤ`-bilinear form, and constructs examples from integral basis pairings or a symmetric integral Gram matrix.

It advances the `IntegralLattices` roadmap's Layer 1 milestone, “Core definitions: integral symmetric lattices,” specifically the target defining a full finitely generated `ℤ`-submodule with an integer-valued symmetric `ℚ`-bilinear form and its basic constructors. After this PR, Layer 1 still needs dual lattices, discriminants, even/unimodular predicates, orthogonal sums and scaling, and the stated duality laws.

The preferred `CFSGStatement` roadmap has no viable unclaimed direct step at present: I0 and S0/S1 are complete, A0's universe transport is already in flight, and L0–L3 explicitly wait on open RootSystems and ReductiveGroups dependencies. This makes the first foundational `IntegralLattices` target the most effective available critical-path step without overlapping active work.

The implementation reuses Mathlib's `Submodule.IsLattice`, `LinearMap.BilinForm.dualSubmodule`, `LinearMap.BilinForm.dualSubmoduleToDual`, and matrix/bilinear-form equivalence; no Mathlib code is vendored.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"integral-symmetric-lattice"}-->

🤖 Prepared with Codex
