### PR TITLE
refactor(ODE): name the invertibility and proximity steps of the Picard germ

### DIFF
--- a/TauCeti/Analysis/ODE/SmoothParameter.lean
+++ b/TauCeti/Analysis/ODE/SmoothParameter.lean
@@ -78,7 +78,7 @@ private theorem picardResidual_apply (f : C(E × F, F)) (x₀ : F)
       ContinuousMap.unitIntervalIntegral (f.comp (parameterizedPath p)) := by
   rfl
 
-/-- A smooth vector field gives a smooth Picard residual. -/
+/-- A vector field of class `Cⁿ` gives a Picard residual of class `Cⁿ`. -/
 private theorem contDiff_picardResidual (n : ℕ) (f : C(E × F, F))
     (hf : ContDiff ℝ n f) (x₀ : F) :
     ContDiff ℝ n (picardResidual f x₀) := by
@@ -136,7 +136,8 @@ private theorem hasDerivWithinAt_Icc_of_forall_eq_picard
   · exact ht
 
 /-- **The path-derivative of the Picard residual at the constant base solution is invertible.**
-For a smooth field vanishing near `x₀` at the base parameter `p₀`, the restriction of
+For a continuously differentiable field vanishing near `x₀` at the base parameter `p₀`, the
+restriction of
 `fderiv ℝ (picardResidual gc x₀)` to the path direction is invertible at `(p₀, const x₀)`. -/
 private theorem isInvertible_fderiv_picardResidual_comp_inr
     (gc : C(E × F, F)) (hg : ContDiff ℝ 1 gc) (p₀ : E) (x₀ : F)

--- a/TauCeti/Analysis/ODE/SmoothParameter.lean
+++ b/TauCeti/Analysis/ODE/SmoothParameter.lean
@@ -135,6 +135,61 @@ private theorem hasDerivWithinAt_Icc_of_forall_eq_picard
     exact hq ⟨s, hs⟩
   · exact ht
 
+/-- **The path-derivative of the Picard residual at the constant base solution is invertible.**
+For a smooth field vanishing near `x₀` at the base parameter `p₀`, the restriction of
+`fderiv ℝ (picardResidual gc x₀)` to the path direction is invertible at `(p₀, const x₀)`. -/
+private theorem isInvertible_fderiv_picardResidual_comp_inr {n : ℕ}
+    (gc : C(E × F, F)) (hg : ContDiff ℝ (n + 1) gc) (p₀ : E) (x₀ : F)
+    (hgzero : ∀ᶠ y in nhds x₀, gc (p₀, y) = 0) :
+    (fderiv ℝ (picardResidual gc x₀)
+          (p₀, (ContinuousMap.const _ x₀ : C(Set.Icc (0 : ℝ) 1, F))) ∘L
+        ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)).IsInvertible := by
+  have hR : ContDiffAt ℝ (n + 1) (picardResidual gc x₀)
+      (p₀, (ContinuousMap.const _ x₀ : C(Set.Icc (0 : ℝ) 1, F))) :=
+    (contDiff_picardResidual (n + 1) gc hg x₀).contDiffAt
+  have hpartial := hasStrictFDerivAt_picardResidual_path gc p₀ x₀ hgzero
+  have hdiff := hR.differentiableAt (by norm_num)
+  have hinnerRaw := hasFDerivAt_const (𝕜 := ℝ) p₀
+    (ContinuousMap.const (Set.Icc (0 : ℝ) 1) x₀) |>.prodMk
+    (hasFDerivAt_id (𝕜 := ℝ) (ContinuousMap.const (Set.Icc (0 : ℝ) 1) x₀))
+  have hinner := hinnerRaw.congr_fderiv (g' :=
+    ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)) (by
+      apply ContinuousLinearMap.ext
+      intro z
+      simp [ContinuousLinearMap.inr_apply])
+  have hpartialEq :=
+    (hdiff.hasFDerivAt.comp (ContinuousMap.const (Set.Icc (0 : ℝ) 1) x₀) hinner).unique
+      hpartial.hasFDerivAt
+  rw [hpartialEq]
+  exact ⟨ContinuousLinearEquiv.refl ℝ _, rfl⟩
+
+/-- **A parameter-to-path germ continuous at the base parameter keeps its whole path near the
+base point.** If `γ` is continuous at `p₀` and `γ p₀` is the constant path at `x₀`, then for `p`
+near `p₀` the parameterized path `(p, γ p)` stays within any prescribed distance of the constant
+path at `(p₀, x₀)`. -/
+private theorem eventually_dist_parameterizedPath_lt {γ : E → C(Set.Icc (0 : ℝ) 1, F)} {p₀ : E}
+    {x₀ : F} (hγcont : ContinuousAt γ p₀)
+    (hγbase : γ p₀ = ContinuousMap.const _ x₀) {ε : ℝ} (hε : 0 < ε) :
+    ∀ᶠ p in nhds p₀,
+      dist (parameterizedPath (p, γ p))
+        (ContinuousMap.const (Set.Icc (0 : ℝ) 1) (p₀, x₀)) < ε := by
+  have hpath := parameterizedPath.continuous.continuousAt.comp
+    (continuousAt_id.prodMk hγcont)
+  have hpathBase : parameterizedPath (p₀, γ p₀) =
+      ContinuousMap.const _ (p₀, x₀) := by
+    rw [hγbase]
+    apply ContinuousMap.ext
+    intro t
+    rw [parameterizedPath_apply, ContinuousMap.const_apply]
+    rw [ContinuousMap.const_apply]
+  filter_upwards [hpath (Metric.ball_mem_nhds (parameterizedPath (p₀, γ p₀)) hε)] with p hp
+  have hpBall : parameterizedPath (p, γ p) ∈
+      Metric.ball (parameterizedPath (p₀, γ p₀)) ε := Set.mem_preimage.mp hp
+  have hp' : dist (parameterizedPath (p, γ p))
+      (parameterizedPath (p₀, γ p₀)) < ε := by
+    simpa only [Metric.mem_ball] using hpBall
+  simpa only [hpathBase] using hp'
+
 /-- A smooth parameterized autonomous vector field which vanishes at the base parameter admits a
 locally smooth family of solutions through a fixed initial state. The result is stated at every
 finite order; this is the form needed to assemble smoothness of a germ. Each nearby path satisfies
@@ -180,22 +235,10 @@ theorem exists_contDiffAt_picard_solution
     exact hy.trans hyzero
   -- At the constant base solution the path derivative of the residual is the identity, so the
   -- implicit function theorem produces a smooth parameter-to-path germ.
-  have hpartial := hasStrictFDerivAt_picardResidual_path gc p₀ x₀ hgzero
-  have hdiff := hR.differentiableAt (by norm_num)
-  have hinnerRaw := hasFDerivAt_const (𝕜 := ℝ) p₀ basePath |>.prodMk
-    (hasFDerivAt_id (𝕜 := ℝ) basePath)
-  have hinner := hinnerRaw.congr_fderiv (g' :=
-    ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)) (by
-      apply ContinuousLinearMap.ext
-      intro z
-      simp [ContinuousLinearMap.inr_apply])
-  have hpartialFromR := hdiff.hasFDerivAt.comp basePath hinner
-  have hpartialEq := hpartialFromR.unique hpartial.hasFDerivAt
   have hinvertible :
       (fderiv ℝ R u ∘L
-        ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)).IsInvertible := by
-    rw [hpartialEq]
-    exact ⟨ContinuousLinearEquiv.refl ℝ _, rfl⟩
+        ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)).IsInvertible :=
+    isInvertible_fderiv_picardResidual_comp_inr gc hg p₀ x₀ hgzero
   let γ : E → C(Set.Icc (0 : ℝ) 1, F) :=
     hR.implicitFunction (by norm_num) hinvertible
   have hγsmooth : ContDiffAt ℝ (n + 1) γ p₀ :=
@@ -212,28 +255,10 @@ theorem exists_contDiffAt_picard_solution
   have hγeq : ∀ᶠ p in nhds p₀, R (p, γ p) = 0 := by
     filter_upwards [hR.eventually_apply_implicitFunction (by norm_num) hinvertible] with p hp
     rw [hp, hRbase]
-  have hpath := parameterizedPath.continuous.continuousAt.comp
-    (continuousAt_id.prodMk hγsmooth.continuousAt)
-  have hpathBase : parameterizedPath (p₀, γ p₀) =
-      ContinuousMap.const _ (p₀, x₀) := by
-    rw [hγbase]
-    apply ContinuousMap.ext
-    intro t
-    rw [parameterizedPath_apply, ContinuousMap.const_apply]
-    rw [ContinuousMap.const_apply]
   have hgfSet : {z : E × F | g z = f z} ∈ nhds (p₀, x₀) := hgf
   obtain ⟨ε, hε, hεgf⟩ := Metric.mem_nhds_iff.mp hgfSet
-  have hpathsNear : ∀ᶠ p in nhds p₀,
-      dist (parameterizedPath (p, γ p)) (ContinuousMap.const _ (p₀, x₀)) < ε := by
-    have hnear := hpath (Metric.ball_mem_nhds
-      (parameterizedPath (p₀, γ p₀)) hε)
-    filter_upwards [hnear] with p hp
-    have hpBall : parameterizedPath (p, γ p) ∈
-        Metric.ball (parameterizedPath (p₀, γ p₀)) ε := Set.mem_preimage.mp hp
-    have hp' : dist (parameterizedPath (p, γ p))
-        (parameterizedPath (p₀, γ p₀)) < ε := by
-      simpa only [Metric.mem_ball] using hpBall
-    simpa only [hpathBase] using hp'
+  have hpathsNear := eventually_dist_parameterizedPath_lt (γ := γ)
+    hγsmooth.continuousAt (by simpa only [basePath] using hγbase) hε
   -- Restrict to parameters whose whole Picard path remains where the cutoff field agrees with
   -- the original field; then transfer the integral equation and its derivative consequences.
   refine ⟨γ, hγsmooth, by simpa only [basePath] using hγbase, ?_⟩

--- a/TauCeti/Analysis/ODE/SmoothParameter.lean
+++ b/TauCeti/Analysis/ODE/SmoothParameter.lean
@@ -138,28 +138,21 @@ private theorem hasDerivWithinAt_Icc_of_forall_eq_picard
 /-- **The path-derivative of the Picard residual at the constant base solution is invertible.**
 For a smooth field vanishing near `x₀` at the base parameter `p₀`, the restriction of
 `fderiv ℝ (picardResidual gc x₀)` to the path direction is invertible at `(p₀, const x₀)`. -/
-private theorem isInvertible_fderiv_picardResidual_comp_inr {n : ℕ}
-    (gc : C(E × F, F)) (hg : ContDiff ℝ (n + 1) gc) (p₀ : E) (x₀ : F)
+private theorem isInvertible_fderiv_picardResidual_comp_inr
+    (gc : C(E × F, F)) (hg : ContDiff ℝ 1 gc) (p₀ : E) (x₀ : F)
     (hgzero : ∀ᶠ y in nhds x₀, gc (p₀, y) = 0) :
     (fderiv ℝ (picardResidual gc x₀)
           (p₀, (ContinuousMap.const _ x₀ : C(Set.Icc (0 : ℝ) 1, F))) ∘L
         ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)).IsInvertible := by
-  have hR : ContDiffAt ℝ (n + 1) (picardResidual gc x₀)
+  have hR : ContDiffAt ℝ 1 (picardResidual gc x₀)
       (p₀, (ContinuousMap.const _ x₀ : C(Set.Icc (0 : ℝ) 1, F))) :=
-    (contDiff_picardResidual (n + 1) gc hg x₀).contDiffAt
+    (contDiff_picardResidual 1 gc hg x₀).contDiffAt
   have hpartial := hasStrictFDerivAt_picardResidual_path gc p₀ x₀ hgzero
   have hdiff := hR.differentiableAt (by norm_num)
-  have hinnerRaw := hasFDerivAt_const (𝕜 := ℝ) p₀
-    (ContinuousMap.const (Set.Icc (0 : ℝ) 1) x₀) |>.prodMk
-    (hasFDerivAt_id (𝕜 := ℝ) (ContinuousMap.const (Set.Icc (0 : ℝ) 1) x₀))
-  have hinner := hinnerRaw.congr_fderiv (g' :=
-    ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)) (by
-      apply ContinuousLinearMap.ext
-      intro z
-      simp [ContinuousLinearMap.inr_apply])
   have hpartialEq :=
-    (hdiff.hasFDerivAt.comp (ContinuousMap.const (Set.Icc (0 : ℝ) 1) x₀) hinner).unique
-      hpartial.hasFDerivAt
+    (hdiff.hasFDerivAt.comp (ContinuousMap.const (Set.Icc (0 : ℝ) 1) x₀)
+      (hasFDerivAt_prodMk_right (𝕜 := ℝ) p₀
+        (ContinuousMap.const (Set.Icc (0 : ℝ) 1) x₀))).unique hpartial.hasFDerivAt
   rw [hpartialEq]
   exact ⟨ContinuousLinearEquiv.refl ℝ _, rfl⟩
 
@@ -167,12 +160,11 @@ private theorem isInvertible_fderiv_picardResidual_comp_inr {n : ℕ}
 base point.** If `γ` is continuous at `p₀` and `γ p₀` is the constant path at `x₀`, then for `p`
 near `p₀` the parameterized path `(p, γ p)` stays within any prescribed distance of the constant
 path at `(p₀, x₀)`. -/
-private theorem eventually_dist_parameterizedPath_lt {γ : E → C(Set.Icc (0 : ℝ) 1, F)} {p₀ : E}
+private theorem eventually_dist_parameterizedPath_lt {γ : E → C(K, F)} {p₀ : E}
     {x₀ : F} (hγcont : ContinuousAt γ p₀)
     (hγbase : γ p₀ = ContinuousMap.const _ x₀) {ε : ℝ} (hε : 0 < ε) :
     ∀ᶠ p in nhds p₀,
-      dist (parameterizedPath (p, γ p))
-        (ContinuousMap.const (Set.Icc (0 : ℝ) 1) (p₀, x₀)) < ε := by
+      dist (parameterizedPath (p, γ p)) (ContinuousMap.const K (p₀, x₀)) < ε := by
   have hpath := parameterizedPath.continuous.continuousAt.comp
     (continuousAt_id.prodMk hγcont)
   have hpathBase : parameterizedPath (p₀, γ p₀) =
@@ -182,13 +174,8 @@ private theorem eventually_dist_parameterizedPath_lt {γ : E → C(Set.Icc (0 : 
     intro t
     rw [parameterizedPath_apply, ContinuousMap.const_apply]
     rw [ContinuousMap.const_apply]
-  filter_upwards [hpath (Metric.ball_mem_nhds (parameterizedPath (p₀, γ p₀)) hε)] with p hp
-  have hpBall : parameterizedPath (p, γ p) ∈
-      Metric.ball (parameterizedPath (p₀, γ p₀)) ε := Set.mem_preimage.mp hp
-  have hp' : dist (parameterizedPath (p, γ p))
-      (parameterizedPath (p₀, γ p₀)) < ε := by
-    simpa only [Metric.mem_ball] using hpBall
-  simpa only [hpathBase] using hp'
+  simpa only [hpathBase, Function.comp_apply, id_eq] using
+    (Metric.continuousAt_iff'.mp hpath ε hε)
 
 /-- A smooth parameterized autonomous vector field which vanishes at the base parameter admits a
 locally smooth family of solutions through a fixed initial state. The result is stated at every
@@ -238,7 +225,7 @@ theorem exists_contDiffAt_picard_solution
   have hinvertible :
       (fderiv ℝ R u ∘L
         ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)).IsInvertible :=
-    isInvertible_fderiv_picardResidual_comp_inr gc hg p₀ x₀ hgzero
+    isInvertible_fderiv_picardResidual_comp_inr gc (hg.of_le (by norm_num)) p₀ x₀ hgzero
   let γ : E → C(Set.Icc (0 : ℝ) 1, F) :=
     hR.implicitFunction (by norm_num) hinvertible
   have hγsmooth : ContDiffAt ℝ (n + 1) γ p₀ :=


### PR DESCRIPTION
`exists_contDiffAt_picard_solution` carried a 132-line proof — the longest uncontended body in
the repository. Two of its blocks stand alone. Name them. No statement changes; no new public
declaration.

## The extracted helpers

```lean
private theorem isInvertible_fderiv_picardResidual_comp_inr
    (gc : C(E × F, F)) (hg : ContDiff ℝ 1 gc) (p₀ : E) (x₀ : F)
    (hgzero : ∀ᶠ y in nhds x₀, gc (p₀, y) = 0) :
    (fderiv ℝ (picardResidual gc x₀) (p₀, ContinuousMap.const _ x₀) ∘L
      ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)).IsInvertible

private theorem eventually_dist_parameterizedPath_lt {γ : E → C(K, F)} {p₀ : E} {x₀ : F}
    (hγcont : ContinuousAt γ p₀) (hγbase : γ p₀ = ContinuousMap.const _ x₀)
    {ε : ℝ} (hε : 0 < ε) :
    ∀ᶠ p in nhds p₀,
      dist (parameterizedPath (p, γ p)) (ContinuousMap.const K (p₀, x₀)) < ε
```

**The first is the hypothesis the implicit function theorem needs**, isolated. The enclosing
theorem carries the original field `f`, its smoothness `hf`, the vanishing hypothesis `hzero`,
`[FiniteDimensional ℝ E]` and `[FiniteDimensional ℝ F]`; the invertibility statement uses none of
them. Review pared it twice more: it needs no `[CompleteSpace F]` (`lint-env`'s `unusedArguments`
caught that), and no `n` — only `ContDiff ℝ 1`, since all that is used is differentiability of
the residual.

**The second is not about ODEs.** It needs only continuity at the base parameter, where the
caller has `ContDiffAt ℝ (n+1) γ p₀`, and nothing about the vector field appears. Review also
pointed out it was needlessly fixed to `Set.Icc 0 1` when `parameterizedPath` is defined for the
file's arbitrary compact `K`, so it is now stated there and specialised at the call site.

Two hand-rolled steps were replaced by their library forms, both named by review: the derivative
of `fun γ ↦ (p₀, γ)` is `hasFDerivAt_prodMk_right`, and the eventual metric bound is
`Metric.continuousAt_iff'` rather than a ball preimage.

## Result

| | before | after |
|---|---|---|
| `exists_contDiffAt_picard_solution` | 132 | 102 |
| `isInvertible_fderiv_picardResidual_comp_inr` | — | 11 |
| `eventually_dist_parameterizedPath_lt` | — | 11 |

This is a first pass: the remaining 102 lines still hold the residual-transfer phase (the Picard
integral equation and its two derivative consequences), which can be named separately.

Weakening the invertibility helper to `ContDiff ℝ 1` left its docstring promising a *smooth*
field, which review caught. Both are now stated at the order actually assumed — the helper, and
`contDiff_picardResidual` next to it, whose hypothesis is `ContDiff ℝ n` for an arbitrary finite
`n` and which carried the same overstatement.

Gates run on `4616c0ed`: `lake build` (7805 jobs), `lake exe axioms` (44677 declarations),
`lake exe module-system` (2145 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: none
