### PR TITLE
feat(HeckeRing): the matrix of an upper-triangular coset representative

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CosetDecomposition.lean
@@ -141,6 +141,16 @@ work from `diag(a) · U(B)` without unfolding `upperTriGL`. -/
 lemma upperTriGL_def {a : Fin n → ℕ} (B : UpperTriEntries n a) :
     upperTriGL B = natDiagGL n a * (mapGL ℚ (unitriSL B)) := (rfl)
 
+/-- **The matrix of the representative**: `diag(a) · U(B)` entrywise over `ℚ`. `upperTriGL` is
+built from `natDiagGL` and `mapGL`, so consumers that need the literal matrix — for instance to
+recognise the classical `T_p` representatives `!![1, b; 0, p]` at `n = 2`, `a = ![1, p]` — would
+otherwise unfold three definitions to get it. -/
+@[simp] lemma upperTriGL_coe {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (B : UpperTriEntries n a) :
+    (↑(upperTriGL B) : Matrix (Fin n) (Fin n) ℚ) =
+      Matrix.diagonal (fun i ↦ (a i : ℚ)) * (unitriMat B).map (Int.cast) := by
+  rw [upperTriGL_def, Units.val_mul, natDiagGL_coe n a ha]
+  simp [Matrix.SpecialLinearGroup.mapGL_coe_matrix]
+
 /-- Each upper-triangular representative lies in the double coset of `diag(a)`. -/
 lemma upperTriGL_mem_doubleCoset {a : Fin n → ℕ} (B : UpperTriEntries n a) :
     upperTriGL B ∈ doubleCoset (natDiagGL n a) (SLnZ n) (SLnZ n) :=


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke/upper-tri-coe"}-->

One lemma. No new object, no statement of existing API changed.

## What is added

```lean
@[simp] lemma upperTriGL_coe {a : Fin n → ℕ} (ha : ∀ i, 0 < a i) (B : UpperTriEntries n a) :
    (↑(upperTriGL B) : Matrix (Fin n) (Fin n) ℚ) =
      Matrix.diagonal (fun i ↦ (a i : ℚ)) * (unitriMat B).map (Int.cast)
```

the matrix of the upper-triangular coset representative. It sits beside `upperTriGL_def` and
mirrors `natDiagGL_coe`, which already exists and has six call sites — so the file now gives the
matrix form of **both** factors it builds representatives from, rather than one.

## Why it is needed

`upperTriGL B` is defined as `natDiagGL n a * mapGL ℚ (unitriSL B)`. A consumer that needs the
literal matrix — and the classical Hecke material is written entirely in literal matrices —
currently has to unfold three definitions inline.

Concretely, this is the adapter for porting the level-`N` Hecke operators. AINTLIB's
`HeckeRIngs/GL2/HeckeT_p.lean` opens with

```lean
noncomputable def T_p_upper (p : ℕ) (hp : 0 < p) (b : ℕ) : GL (Fin 2) ℚ :=
  GeneralLinearGroup.mkOfDetNeZero !![1, (b : ℚ); 0, (p : ℚ)] …
```

and this repository already owns that element: it is `upperTriGL` at `n = 2`, `a = ![1, p]`,
since `diag(1, p) · U(b) = !![1, b; 0, p]`. With `upperTriGL_coe` that identification is a `simp`;
without it the port would restate the matrix and duplicate `upperTriGL` — which is exactly what
the `reuse` rubric blocked on #2924, when a ported `tpUpper` restated the same object.

## Generality

Stated at general `n`, not at `n = 2`. The classical `!![1, b; 0, p]` form is the `n = 2`
instance and follows by `simp` at the call site; a specialised lemma would have reintroduced the
duplication one layer up.

## Provenance

No port. This is a characteristic lemma for an existing TauCeti definition
(`HeckeRing/GLn/CosetDecomposition.lean`), added to support the forthcoming port of AINTLIB's
`HeckeRIngs/GL2/HeckeT_p.lean` (commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`), whose
representatives are the `n = 2` instances of it.

Roadmap: ModularForms
