### PR TITLE
feat: embed the Kostant tensor square

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Comultiplication.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Comultiplication.lean
@@ -110,7 +110,6 @@ noncomputable abbrev kostantTensorForm (e : ι → L) (h : κ → L) : Subring (
 
 /-- Membership in the integral tensor form is equivalent to having an integral tensor
 representative under the canonical tensor map. -/
-@[simp]
 theorem mem_kostantTensorForm_iff (e : ι → L) (h : κ → L) (z : U ⊗[ℚ] U) :
     z ∈ kostantTensorForm e h ↔
       ∃ t : kostantForm e h ⊗[ℤ] kostantForm e h, kostantTensorMap e h t = z := by
@@ -228,15 +227,19 @@ theorem kostantFormComul_unique (e : ι → L) (h : κ → L)
 @[simp]
 theorem kostantFormComul_dividedPower (e : ι → L) (h : κ → L) (i : ι) (n : ℕ) :
     kostantFormComul e h
-        ⟨Associative.dividedPower n (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)),
-          dividedPower_mem_kostantForm e h i n⟩ =
+        ⟨Associative.dividedPower n
+            ((UniversalEnvelopingAlgebra.mkAlgHom ℚ L) ((TensorAlgebra.ι ℚ) (e i))),
+          by simpa only [UniversalEnvelopingAlgebra.ι_apply] using
+            dividedPower_mem_kostantForm e h i n⟩ =
       ∑ ij ∈ Finset.antidiagonal n,
         (⟨Associative.dividedPower ij.1 (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)),
             dividedPower_mem_kostantForm e h i ij.1⟩ : kostantForm e h) ⊗ₜ[ℤ]
           (⟨Associative.dividedPower ij.2 (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)),
             dividedPower_mem_kostantForm e h i ij.2⟩ : kostantForm e h) := by
   apply kostantTensorMap_injective e h
-  rw [kostantTensorMap_kostantFormComul_apply, comul_ι_dividedPower]
+  rw [kostantTensorMap_kostantFormComul_apply]
+  simp only [← UniversalEnvelopingAlgebra.ι_apply]
+  rw [comul_ι_dividedPower]
   simp only [map_sum, kostantTensorMap_tmul]
 
 /-- The integral coproduct of a generalized Cartan binomial is the coefficient-one antidiagonal
@@ -244,15 +247,19 @@ sum. -/
 @[simp]
 theorem kostantFormComul_ringChoose (e : ι → L) (h : κ → L) (j : κ) (n : ℕ) :
     kostantFormComul e h
-        ⟨Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) n,
-          ringChoose_mem_kostantForm e h j n⟩ =
+        ⟨Ring.choose
+            ((UniversalEnvelopingAlgebra.mkAlgHom ℚ L) ((TensorAlgebra.ι ℚ) (h j))) n,
+          by simpa only [UniversalEnvelopingAlgebra.ι_apply] using
+            ringChoose_mem_kostantForm e h j n⟩ =
       ∑ ij ∈ Finset.antidiagonal n,
         (⟨Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) ij.1,
             ringChoose_mem_kostantForm e h j ij.1⟩ : kostantForm e h) ⊗ₜ[ℤ]
           (⟨Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) ij.2,
             ringChoose_mem_kostantForm e h j ij.2⟩ : kostantForm e h) := by
   apply kostantTensorMap_injective e h
-  rw [kostantTensorMap_kostantFormComul_apply, comul_ι_choose]
+  rw [kostantTensorMap_kostantFormComul_apply]
+  simp only [← UniversalEnvelopingAlgebra.ι_apply]
+  rw [comul_ι_choose]
   simp only [map_sum, kostantTensorMap_tmul]
 
 /-! ## The integral counit -/

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Comultiplication.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Comultiplication.lean
@@ -110,6 +110,7 @@ noncomputable def kostantTensorForm (e : ι → L) (h : κ → L) : Subring (U �
 
 /-- Membership in the integral tensor form is equivalent to having an integral tensor
 representative under the canonical tensor map. -/
+@[simp]
 theorem mem_kostantTensorForm_iff (e : ι → L) (h : κ → L) (z : U ⊗[ℚ] U) :
     z ∈ kostantTensorForm e h ↔
       ∃ t : kostantForm e h ⊗[ℤ] kostantForm e h, kostantTensorMap e h t = z := by

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Comultiplication.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Comultiplication.lean
@@ -105,7 +105,7 @@ from `kostantForm e h ⊗[ℤ] kostantForm e h`.
 
 This range is the codomain of the rational restriction; `kostantTensorEquiv` below identifies it
 with the integral tensor square. -/
-noncomputable abbrev kostantTensorForm (e : ι → L) (h : κ → L) : Subring (U ⊗[ℚ] U) :=
+noncomputable def kostantTensorForm (e : ι → L) (h : κ → L) : Subring (U ⊗[ℚ] U) :=
   TauCeti.Subring.tensorSquareRange ℚ (kostantForm e h)
 
 /-- Membership in the integral tensor form is equivalent to having an integral tensor
@@ -189,8 +189,7 @@ noncomputable def kostantTensorEquiv (e : ι → L) (h : κ → L) :
 theorem coe_kostantTensorEquiv_apply (e : ι → L) (h : κ → L)
     (t : kostantForm e h ⊗[ℤ] kostantForm e h) :
     (kostantTensorEquiv e h t : U ⊗[ℚ] U) = kostantTensorMap e h t := by
-  simp only [kostantTensorEquiv, TauCeti.Subring.coe_tensorSquareEquivRange_apply,
-    kostantTensorMap]
+  exact TauCeti.Subring.coe_tensorSquareEquivRange_apply (kostantForm e h) t
 
 /-- The integral comultiplication of a Kostant form. It is the unique algebra homomorphism whose
 composition with `kostantTensorMap` is the rational enveloping-algebra comultiplication. -/
@@ -205,13 +204,17 @@ theorem kostantTensorMap_kostantFormComul_apply (e : ι → L) (h : κ → L)
     (a : kostantForm e h) :
     kostantTensorMap e h (kostantFormComul e h a) =
       Coalgebra.comul (R := ℚ) (a : U) := by
-  rw [kostantFormComul, AlgHom.comp_apply, ← coe_kostantTensorEquiv_apply]
-  change
-    (kostantTensorEquiv e h
-      ((kostantTensorEquiv e h).symm (kostantFormComulRange e h a)) :
-        U ⊗[ℚ] U) = _
-  rw [(kostantTensorEquiv e h).apply_symm_apply]
-  exact coe_kostantFormComulRange_apply e h a
+  rw [kostantFormComul, AlgHom.comp_apply]
+  calc
+    kostantTensorMap e h
+        ((kostantTensorEquiv e h).symm (kostantFormComulRange e h a)) =
+        (kostantTensorEquiv e h
+          ((kostantTensorEquiv e h).symm (kostantFormComulRange e h a)) : U ⊗[ℚ] U) :=
+      (coe_kostantTensorEquiv_apply e h _).symm
+    _ = (kostantFormComulRange e h a : U ⊗[ℚ] U) :=
+      congrArg Subtype.val
+        ((kostantTensorEquiv e h).apply_symm_apply (kostantFormComulRange e h a))
+    _ = _ := coe_kostantFormComulRange_apply e h a
 
 /-- The integral comultiplication is uniquely determined by its agreement with the rational
 enveloping-algebra comultiplication. -/

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Comultiplication.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/Comultiplication.lean
@@ -24,16 +24,16 @@ The canonical map
 kostantForm e h ⊗[ℤ] kostantForm e h → U(L) ⊗[ℚ] U(L)
 ```
 
-sends a pure tensor to the pure tensor of its two underlying elements. Its range is
-`kostantTensorForm e h`. The coefficient-one coproduct formulas for divided powers and generalized
-binomial coefficients show that the rational comultiplication of every element of the Kostant form
-lies in this range. The restriction is packaged as `kostantFormComul`.
+sends a pure tensor to the pure tensor of its two underlying elements. It is injective because a
+subring of a rational algebra is torsion-free, hence flat over `ℤ`; this is the general theorem
+`TauCeti.Subring.tensorSquareMap_injective`. Its range is `kostantTensorForm e h`, so it gives the
+equivalence `kostantTensorEquiv` between the integral tensor square and that range.
 
-Using the range rather than identifying it with the integral tensor product is deliberate. That
-identification requires injectivity of the canonical map, which is part of the integral PBW and
-base-change work still in progress. The range statement proved here is exactly the integrality
-statement independent of that injectivity: every rational coproduct has an integral tensor
-representative, and no representative is chosen.
+The coefficient-one coproduct formulas for divided powers and generalized binomial coefficients
+show that the rational comultiplication of every element of the Kostant form lies in this range.
+Transporting the range-valued restriction back through `kostantTensorEquiv` gives the canonical
+integral coproduct `kostantFormComul : U_ℤ →ₐ[ℤ] U_ℤ ⊗[ℤ] U_ℤ`. Thus integrality now means an
+actual algebra homomorphism, rather than only the existence of an integral tensor representative.
 
 The counit has no such issue. It sends every positive generator to zero and hence the entire form
 to the integer-cast subring of `ℚ`. The map `kostantFormCounit` is its canonical restriction to
@@ -43,13 +43,19 @@ to the integer-cast subring of `ℚ`. The map `kostantFormCounit` is its canonic
 
 * `TauCeti.UniversalEnvelopingAlgebra.kostantTensorMap`: the canonical map from the integral
   tensor square to the rational tensor square.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantTensorMap_injective`: the canonical tensor map is
+  injective.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantTensorForm`: the range of that map.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantTensorEquiv`: the equivalence from the integral tensor
+  square onto that range.
 * `TauCeti.UniversalEnvelopingAlgebra.comul_mem_kostantTensorForm`: the rational coproduct of an
   element of the Kostant form has an integral tensor representative.
 * `TauCeti.UniversalEnvelopingAlgebra.counit_mem_bot_of_mem_kostantForm`: the rational counit of an
   element of the Kostant form is an integer.
-* `TauCeti.UniversalEnvelopingAlgebra.kostantFormComul`: the rational comultiplication restricted
-  to the integral tensor form.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantFormComul`: the canonical integral comultiplication.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantFormComul_dividedPower` and
+  `TauCeti.UniversalEnvelopingAlgebra.kostantFormComul_ringChoose`: its formulas on the
+  generators of the Kostant form.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantFormCounit`: the counit of the Kostant form, valued
   in `ℤ`.
 
@@ -97,9 +103,9 @@ theorem kostantTensorMap_tmul (e : ι → L) (h : κ → L) (x y : kostantForm e
 /-- The integral tensor form inside the rational tensor square: the range of the canonical map
 from `kostantForm e h ⊗[ℤ] kostantForm e h`.
 
-This range formulation records existence of an integral tensor representative without assuming
-injectivity of the canonical map. -/
-noncomputable def kostantTensorForm (e : ι → L) (h : κ → L) : Subring (U ⊗[ℚ] U) :=
+This range is the codomain of the rational restriction; `kostantTensorEquiv` below identifies it
+with the integral tensor square. -/
+noncomputable abbrev kostantTensorForm (e : ι → L) (h : κ → L) : Subring (U ⊗[ℚ] U) :=
   TauCeti.Subring.tensorSquareRange ℚ (kostantForm e h)
 
 /-- Membership in the integral tensor form is equivalent to having an integral tensor
@@ -146,29 +152,108 @@ theorem comul_mem_kostantTensorForm (e : ι → L) (h : κ → L) {a : U}
           tmul_mem_kostantTensorForm e h (ringChoose_mem_kostantForm e h j ij.1)
             (ringChoose_mem_kostantForm e h j ij.2)⟩ ha
 
--- The rational comultiplication restricted to the integral tensor form.
+-- The rational comultiplication restricted to the range of the integral tensor square.
 private noncomputable def kostantFormComulRingHom (e : ι → L) (h : κ → L) :
     kostantForm e h →+* kostantTensorForm e h :=
   (Bialgebra.comulAlgHom ℚ U).toRingHom.restrict (kostantForm e h) (kostantTensorForm e h)
     fun _ ha => comul_mem_kostantTensorForm e h ha
 
-/-- The comultiplication of the Kostant form, with codomain restricted to the integral tensor form
-inside the rational tensor square. -/
-noncomputable def kostantFormComul (e : ι → L) (h : κ → L) :
+private noncomputable def kostantFormComulRange (e : ι → L) (h : κ → L) :
     kostantForm e h →ₐ[ℤ] kostantTensorForm e h :=
   (kostantFormComulRingHom e h).toIntAlgHom
 
-/-- The restricted comultiplication agrees with the rational bialgebra comultiplication on
-underlying elements. -/
-@[simp]
-theorem coe_kostantFormComul_apply (e : ι → L) (h : κ → L) (a : kostantForm e h) :
-    (kostantFormComul e h a : U ⊗[ℚ] U) = Coalgebra.comul (R := ℚ) (a : U) := by
-  rw [kostantFormComul, RingHom.toIntAlgHom_apply, kostantFormComulRingHom]
+private theorem coe_kostantFormComulRange_apply (e : ι → L) (h : κ → L)
+    (a : kostantForm e h) :
+    (kostantFormComulRange e h a : U ⊗[ℚ] U) = Coalgebra.comul (R := ℚ) (a : U) := by
+  rw [kostantFormComulRange, RingHom.toIntAlgHom_apply, kostantFormComulRingHom]
   simpa only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe,
     Bialgebra.comulAlgHom_apply] using
     RingHom.coe_restrict_apply (Bialgebra.comulAlgHom ℚ U).toRingHom
       (kostantForm e h) (kostantTensorForm e h)
       (fun _ ha => comul_mem_kostantTensorForm e h ha) a
+
+/-- The canonical map from the integral tensor square of a Kostant form to the rational tensor
+square of its enveloping algebra is injective. -/
+theorem kostantTensorMap_injective (e : ι → L) (h : κ → L) :
+    Function.Injective (kostantTensorMap e h) := by
+  simpa only [kostantTensorMap] using
+    TauCeti.Subring.tensorSquareMap_injective (kostantForm e h)
+
+/-- The canonical equivalence from the integral tensor square of a Kostant form onto its image in
+the rational tensor square. -/
+noncomputable def kostantTensorEquiv (e : ι → L) (h : κ → L) :
+    kostantForm e h ⊗[ℤ] kostantForm e h ≃ₐ[ℤ] kostantTensorForm e h :=
+  TauCeti.Subring.tensorSquareEquivRange (kostantForm e h)
+
+/-- The tensor equivalence acts by the canonical map into the rational tensor square. -/
+@[simp]
+theorem coe_kostantTensorEquiv_apply (e : ι → L) (h : κ → L)
+    (t : kostantForm e h ⊗[ℤ] kostantForm e h) :
+    (kostantTensorEquiv e h t : U ⊗[ℚ] U) = kostantTensorMap e h t := by
+  simp only [kostantTensorEquiv, TauCeti.Subring.coe_tensorSquareEquivRange_apply,
+    kostantTensorMap]
+
+/-- The integral comultiplication of a Kostant form. It is the unique algebra homomorphism whose
+composition with `kostantTensorMap` is the rational enveloping-algebra comultiplication. -/
+noncomputable def kostantFormComul (e : ι → L) (h : κ → L) :
+    kostantForm e h →ₐ[ℤ] kostantForm e h ⊗[ℤ] kostantForm e h :=
+  (kostantTensorEquiv e h).symm.toAlgHom.comp (kostantFormComulRange e h)
+
+/-- The integral comultiplication becomes the rational enveloping-algebra comultiplication under
+the canonical tensor embedding. -/
+@[simp]
+theorem kostantTensorMap_kostantFormComul_apply (e : ι → L) (h : κ → L)
+    (a : kostantForm e h) :
+    kostantTensorMap e h (kostantFormComul e h a) =
+      Coalgebra.comul (R := ℚ) (a : U) := by
+  rw [kostantFormComul, AlgHom.comp_apply, ← coe_kostantTensorEquiv_apply]
+  change
+    (kostantTensorEquiv e h
+      ((kostantTensorEquiv e h).symm (kostantFormComulRange e h a)) :
+        U ⊗[ℚ] U) = _
+  rw [(kostantTensorEquiv e h).apply_symm_apply]
+  exact coe_kostantFormComulRange_apply e h a
+
+/-- The integral comultiplication is uniquely determined by its agreement with the rational
+enveloping-algebra comultiplication. -/
+theorem kostantFormComul_unique (e : ι → L) (h : κ → L)
+    (f : kostantForm e h →ₐ[ℤ] kostantForm e h ⊗[ℤ] kostantForm e h)
+    (hf : ∀ a, kostantTensorMap e h (f a) = Coalgebra.comul (R := ℚ) (a : U)) :
+    f = kostantFormComul e h := by
+  ext a
+  apply kostantTensorMap_injective e h
+  rw [hf, kostantTensorMap_kostantFormComul_apply]
+
+/-- The integral coproduct of a divided power is the coefficient-one antidiagonal sum. -/
+@[simp]
+theorem kostantFormComul_dividedPower (e : ι → L) (h : κ → L) (i : ι) (n : ℕ) :
+    kostantFormComul e h
+        ⟨Associative.dividedPower n (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)),
+          dividedPower_mem_kostantForm e h i n⟩ =
+      ∑ ij ∈ Finset.antidiagonal n,
+        (⟨Associative.dividedPower ij.1 (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)),
+            dividedPower_mem_kostantForm e h i ij.1⟩ : kostantForm e h) ⊗ₜ[ℤ]
+          (⟨Associative.dividedPower ij.2 (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)),
+            dividedPower_mem_kostantForm e h i ij.2⟩ : kostantForm e h) := by
+  apply kostantTensorMap_injective e h
+  rw [kostantTensorMap_kostantFormComul_apply, comul_ι_dividedPower]
+  simp only [map_sum, kostantTensorMap_tmul]
+
+/-- The integral coproduct of a generalized Cartan binomial is the coefficient-one antidiagonal
+sum. -/
+@[simp]
+theorem kostantFormComul_ringChoose (e : ι → L) (h : κ → L) (j : κ) (n : ℕ) :
+    kostantFormComul e h
+        ⟨Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) n,
+          ringChoose_mem_kostantForm e h j n⟩ =
+      ∑ ij ∈ Finset.antidiagonal n,
+        (⟨Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) ij.1,
+            ringChoose_mem_kostantForm e h j ij.1⟩ : kostantForm e h) ⊗ₜ[ℤ]
+          (⟨Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) ij.2,
+            ringChoose_mem_kostantForm e h j ij.2⟩ : kostantForm e h) := by
+  apply kostantTensorMap_injective e h
+  rw [kostantTensorMap_kostantFormComul_apply, comul_ι_choose]
+  simp only [map_sum, kostantTensorMap_tmul]
 
 /-! ## The integral counit -/
 

--- a/TauCeti/Algebra/TensorProduct/Subring.lean
+++ b/TauCeti/Algebra/TensorProduct/Subring.lean
@@ -107,9 +107,9 @@ theorem tensorSquareMap_injective (S : Subring A) :
     apply (intTensorToRatTensor (A := A)).injective
     rw [tensorSquareMap_eq_intTensorToRatTensor] at hxy
     exact hxy
-  change TensorProduct.AlgebraTensorModule.map f f x =
-    TensorProduct.AlgebraTensorModule.map f f y at hmap
-  rw [TensorProduct.AlgebraTensorModule.map_eq] at hmap
+  rw [← AlgHom.toLinearMap_apply, ← AlgHom.toLinearMap_apply,
+      Algebra.TensorProduct.toLinearMap_map,
+      TensorProduct.AlgebraTensorModule.map_eq] at hmap
   exact hmap
 
 end Rational

--- a/TauCeti/Algebra/TensorProduct/Subring.lean
+++ b/TauCeti/Algebra/TensorProduct/Subring.lean
@@ -114,7 +114,6 @@ noncomputable abbrev tensorSquareRange (S : Subring A) : Subring (A ⊗[R] A) :=
   (tensorSquareMap R S).toRingHom.range
 
 /-- Membership in the tensor-square range is equivalent to having an integral tensor preimage. -/
-@[simp]
 theorem mem_tensorSquareRange_iff (S : Subring A) (z : A ⊗[R] A) :
     z ∈ tensorSquareRange R S ↔ ∃ t : S ⊗[ℤ] S, tensorSquareMap R S t = z := by
   rfl

--- a/TauCeti/Algebra/TensorProduct/Subring.lean
+++ b/TauCeti/Algebra/TensorProduct/Subring.lean
@@ -70,7 +70,9 @@ private noncomputable def intTensorToRatTensor : A ⊗[ℤ] A ≃ₐ[ℚ] A ⊗[
 @[simp]
 private theorem intTensorToRatTensor_tmul (x y : A) :
     intTensorToRatTensor (A := A) (x ⊗ₜ[ℤ] y) = x ⊗ₜ[ℚ] y := by
-  rfl
+  rw [intTensorToRatTensor, AlgEquiv.symm_apply_eq]
+  exact (Algebra.TensorProduct.mapOfCompatibleSMul_tmul
+    (R := ℤ) (S := ℚ) (T := ℚ) (A := A) (B := A) x y).symm
 
 private theorem tensorSquareMap_eq_intTensorToRatTensor (S : Subring A) :
     tensorSquareMap ℚ S =
@@ -79,23 +81,12 @@ private theorem tensorSquareMap_eq_intTensorToRatTensor (S : Subring A) :
           S.subtype.toIntAlgHom S.subtype.toIntAlgHom) := by
   ext x <;> simp
 
-omit [Algebra ℚ A] in
-private theorem tensorProductMap_apply_eq_algebraTensorProductMap_apply (S : Subring A)
-    (t : S ⊗[ℤ] S) :
-    TensorProduct.map S.subtype.toIntAlgHom.toLinearMap S.subtype.toIntAlgHom.toLinearMap t =
-      Algebra.TensorProduct.map (R := ℤ) (S := ℤ)
-        S.subtype.toIntAlgHom S.subtype.toIntAlgHom t := by
-  induction t using TensorProduct.induction_on with
-  | zero => simp
-  | add x y hx hy => simp [hx, hy]
-  | tmul x y => rfl
-
 /-- The canonical map from the integer tensor square of a subring of a rational algebra to the
-rational tensor square of the ambient algebra is injective.
-
-The subring is torsion-free as an abelian group because it embeds in a rational vector space, hence
-flat over `ℤ`. Therefore tensoring its inclusion with itself is injective. The target of that map is
-initially `A ⊗[ℤ] A`; the canonical equivalence `A ⊗[ℤ] A ≃ A ⊗[ℚ] A` then gives the stated map. -/
+rational tensor square of the ambient algebra is injective. -/
+-- The subring is torsion-free as an abelian group because it embeds in a rational vector space,
+-- hence flat over `ℤ`. Therefore tensoring its inclusion with itself is injective. The target
+-- of that map is initially `A ⊗[ℤ] A`; the canonical equivalence `A ⊗[ℤ] A ≃ A ⊗[ℚ] A` then
+-- gives the stated map.
 theorem tensorSquareMap_injective (S : Subring A) :
     Function.Injective (tensorSquareMap ℚ S) := by
   let : IsAddTorsionFree A := .of_module_rat A
@@ -116,7 +107,10 @@ theorem tensorSquareMap_injective (S : Subring A) :
     apply (intTensorToRatTensor (A := A)).injective
     rw [tensorSquareMap_eq_intTensorToRatTensor] at hxy
     exact hxy
-  simpa only [f, tensorProductMap_apply_eq_algebraTensorProductMap_apply] using hmap
+  change TensorProduct.AlgebraTensorModule.map f f x =
+    TensorProduct.AlgebraTensorModule.map f f y at hmap
+  rw [TensorProduct.AlgebraTensorModule.map_eq] at hmap
+  exact hmap
 
 end Rational
 
@@ -126,6 +120,7 @@ noncomputable def tensorSquareRange (S : Subring A) : Subring (A ⊗[R] A) :=
   (tensorSquareMap R S).toRingHom.range
 
 /-- Membership in the tensor-square range is equivalent to having an integral tensor preimage. -/
+@[simp]
 theorem mem_tensorSquareRange_iff (S : Subring A) (z : A ⊗[R] A) :
     z ∈ tensorSquareRange R S ↔ ∃ t : S ⊗[ℤ] S, tensorSquareMap R S t = z := by
   rfl
@@ -149,8 +144,8 @@ noncomputable def tensorSquareEquivRange (S : Subring A) :
 /-- The equivalence onto the tensor-square range acts by the canonical tensor-square map. -/
 @[simp]
 theorem coe_tensorSquareEquivRange_apply (S : Subring A) (t : S ⊗[ℤ] S) :
-    (tensorSquareEquivRange S t : A ⊗[ℚ] A) = tensorSquareMap ℚ S t := by
-  rfl
+    (tensorSquareEquivRange S t : A ⊗[ℚ] A) = tensorSquareMap ℚ S t :=
+  AlgEquiv.ofInjective_apply (tensorSquareMap ℚ S) (tensorSquareMap_injective S) t
 
 end RationalRange
 

--- a/TauCeti/Algebra/TensorProduct/Subring.lean
+++ b/TauCeti/Algebra/TensorProduct/Subring.lean
@@ -5,6 +5,8 @@ Authors: Codex
 -/
 module
 
+public import Mathlib.RingTheory.Flat.Domain
+public import Mathlib.RingTheory.Flat.TorsionFree
 public import Mathlib.RingTheory.TensorProduct.Maps
 
 /-!
@@ -16,7 +18,11 @@ to the tensor square of the ambient algebra, together with its range and basic m
 ## Main definitions and results
 
 * `TauCeti.Subring.tensorSquareMap`: the canonical map from the integral tensor square.
+* `TauCeti.Subring.tensorSquareMap_injective`: over a rational algebra, the canonical map is
+  injective.
 * `TauCeti.Subring.tensorSquareRange`: the range of the canonical map.
+* `TauCeti.Subring.tensorSquareEquivRange`: over a rational algebra, the canonical equivalence
+  onto that range.
 * `TauCeti.Subring.mem_tensorSquareRange_iff`: membership in the range in terms of a preimage.
 * `TauCeti.Subring.tmul_mem_tensorSquareRange`: pure tensors of subring elements lie in the range.
 -/
@@ -50,9 +56,61 @@ theorem tensorSquareMap_tmul (S : Subring A) (x y : S) :
     tensorSquareMap R S (x ⊗ₜ[ℤ] y) = (x : A) ⊗ₜ[R] (y : A) := by
   simp [tensorSquareMap]
 
+section Rational
+
+variable {A : Type v} [Ring A] [Algebra ℚ A]
+
+-- Since the two factors are rational vector spaces, imposing rational balancing on their integer
+-- tensor product adds no relations. Mathlib proves this as the compatibility of the two scalar
+-- actions; naming the resulting equivalence keeps that implementation out of the injectivity
+-- argument below.
+private noncomputable def intTensorToRatTensor : A ⊗[ℤ] A ≃ₐ[ℚ] A ⊗[ℚ] A :=
+  (Algebra.TensorProduct.equivOfCompatibleSMul ℤ ℚ ℚ A A).symm
+
+@[simp]
+private theorem intTensorToRatTensor_tmul (x y : A) :
+    intTensorToRatTensor (A := A) (x ⊗ₜ[ℤ] y) = x ⊗ₜ[ℚ] y := by
+  rfl
+
+private theorem tensorSquareMap_eq_intTensorToRatTensor (S : Subring A) :
+    tensorSquareMap ℚ S =
+      ((intTensorToRatTensor (A := A)).toAlgHom.restrictScalars ℤ).comp
+        (Algebra.TensorProduct.map (R := ℤ) (S := ℤ)
+          S.subtype.toIntAlgHom S.subtype.toIntAlgHom) := by
+  ext x <;> simp
+
+/-- The canonical map from the integer tensor square of a subring of a rational algebra to the
+rational tensor square of the ambient algebra is injective.
+
+The subring is torsion-free as an abelian group because it embeds in a rational vector space, hence
+flat over `ℤ`. Therefore tensoring its inclusion with itself is injective. The target of that map is
+initially `A ⊗[ℤ] A`; the canonical equivalence `A ⊗[ℤ] A ≃ A ⊗[ℚ] A` then gives the stated map. -/
+theorem tensorSquareMap_injective (S : Subring A) :
+    Function.Injective (tensorSquareMap ℚ S) := by
+  let : IsAddTorsionFree A := .of_module_rat A
+  let : IsAddTorsionFree S :=
+    Function.Injective.isAddTorsionFree S.subtype.toAddMonoidHom S.subtype_injective
+  let : Module.Flat ℤ S := inferInstance
+  let f : S →ₗ[ℤ] A := S.subtype.toIntAlgHom.toLinearMap
+  have hinjective : Function.Injective (TensorProduct.map f f) :=
+    TensorProduct.map_injective_of_flat_flat_of_isDomain
+      (R := ℤ) f f S.subtype_injective S.subtype_injective
+  intro x y hxy
+  apply hinjective
+  change
+    Algebra.TensorProduct.map (R := ℤ) (S := ℤ)
+        S.subtype.toIntAlgHom S.subtype.toIntAlgHom x =
+      Algebra.TensorProduct.map (R := ℤ) (S := ℤ)
+        S.subtype.toIntAlgHom S.subtype.toIntAlgHom y
+  apply (intTensorToRatTensor (A := A)).injective
+  rw [tensorSquareMap_eq_intTensorToRatTensor] at hxy
+  exact hxy
+
+end Rational
+
 /-- The range of the canonical map from the integral tensor square of a subring to the tensor
 square of the ambient algebra. -/
-noncomputable def tensorSquareRange (S : Subring A) : Subring (A ⊗[R] A) :=
+noncomputable abbrev tensorSquareRange (S : Subring A) : Subring (A ⊗[R] A) :=
   (tensorSquareMap R S).toRingHom.range
 
 /-- Membership in the tensor-square range is equivalent to having an integral tensor preimage. -/
@@ -66,5 +124,23 @@ theorem tmul_mem_tensorSquareRange (S : Subring A) {x y : A} (hx : x ∈ S) (hy 
     x ⊗ₜ[R] y ∈ tensorSquareRange R S := by
   rw [mem_tensorSquareRange_iff]
   exact ⟨(⟨x, hx⟩ : S) ⊗ₜ[ℤ] (⟨y, hy⟩ : S), tensorSquareMap_tmul R S _ _⟩
+
+section RationalRange
+
+variable {A : Type v} [Ring A] [Algebra ℚ A]
+
+/-- The canonical equivalence from the integer tensor square of a subring of a rational algebra
+onto its range in the rational tensor square. -/
+noncomputable def tensorSquareEquivRange (S : Subring A) :
+    S ⊗[ℤ] S ≃ₐ[ℤ] tensorSquareRange ℚ S :=
+  AlgEquiv.ofInjective (tensorSquareMap ℚ S) (tensorSquareMap_injective S)
+
+/-- The equivalence onto the tensor-square range acts by the canonical tensor-square map. -/
+@[simp]
+theorem coe_tensorSquareEquivRange_apply (S : Subring A) (t : S ⊗[ℤ] S) :
+    (tensorSquareEquivRange S t : A ⊗[ℚ] A) = tensorSquareMap ℚ S t := by
+  rfl
+
+end RationalRange
 
 end TauCeti.Subring

--- a/TauCeti/Algebra/TensorProduct/Subring.lean
+++ b/TauCeti/Algebra/TensorProduct/Subring.lean
@@ -79,6 +79,17 @@ private theorem tensorSquareMap_eq_intTensorToRatTensor (S : Subring A) :
           S.subtype.toIntAlgHom S.subtype.toIntAlgHom) := by
   ext x <;> simp
 
+omit [Algebra ℚ A] in
+private theorem tensorProductMap_apply_eq_algebraTensorProductMap_apply (S : Subring A)
+    (t : S ⊗[ℤ] S) :
+    TensorProduct.map S.subtype.toIntAlgHom.toLinearMap S.subtype.toIntAlgHom.toLinearMap t =
+      Algebra.TensorProduct.map (R := ℤ) (S := ℤ)
+        S.subtype.toIntAlgHom S.subtype.toIntAlgHom t := by
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp [hx, hy]
+  | tmul x y => rfl
+
 /-- The canonical map from the integer tensor square of a subring of a rational algebra to the
 rational tensor square of the ambient algebra is injective.
 
@@ -97,20 +108,21 @@ theorem tensorSquareMap_injective (S : Subring A) :
       (R := ℤ) f f S.subtype_injective S.subtype_injective
   intro x y hxy
   apply hinjective
-  change
-    Algebra.TensorProduct.map (R := ℤ) (S := ℤ)
+  have hmap :
+      Algebra.TensorProduct.map (R := ℤ) (S := ℤ)
         S.subtype.toIntAlgHom S.subtype.toIntAlgHom x =
       Algebra.TensorProduct.map (R := ℤ) (S := ℤ)
-        S.subtype.toIntAlgHom S.subtype.toIntAlgHom y
-  apply (intTensorToRatTensor (A := A)).injective
-  rw [tensorSquareMap_eq_intTensorToRatTensor] at hxy
-  exact hxy
+        S.subtype.toIntAlgHom S.subtype.toIntAlgHom y := by
+    apply (intTensorToRatTensor (A := A)).injective
+    rw [tensorSquareMap_eq_intTensorToRatTensor] at hxy
+    exact hxy
+  simpa only [f, tensorProductMap_apply_eq_algebraTensorProductMap_apply] using hmap
 
 end Rational
 
 /-- The range of the canonical map from the integral tensor square of a subring to the tensor
 square of the ambient algebra. -/
-noncomputable abbrev tensorSquareRange (S : Subring A) : Subring (A ⊗[R] A) :=
+noncomputable def tensorSquareRange (S : Subring A) : Subring (A ⊗[R] A) :=
   (tensorSquareMap R S).toRingHom.range
 
 /-- Membership in the tensor-square range is equivalent to having an integral tensor preimage. -/


### PR DESCRIPTION
This PR makes the Kostant integral form's coproduct land in its actual tensor square over `ℤ`, advancing the ReductiveGroups Layer 9 target “The Chevalley–Demazure construction … via a Chevalley basis and the Kostant `ℤ`-form of the enveloping algebra.” It proves that the canonical map from the integer tensor square of any subring of a rational algebra into the ambient rational tensor square is injective, identifies that tensor square with its range, and transports the existing range-valued coproduct across the equivalence. It also records uniqueness and the coefficient-one coproduct formulas for divided powers and generalized Cartan binomials.

The preferred CFSGStatement roadmap has no viable direct unclaimed step: its independent index, convention, and sporadic work has landed, its universe-transport work is in flight, and L0 explicitly waits on ReductiveGroups Layer 9. The dependency edge is CFSGStatement L0 “explicit pinned Chevalley--Demazure groups” → ReductiveGroups Layer 9 “pinned Chevalley–Demazure group schemes over `ℤ`” → the Kostant integral Hopf order used by the explicit construction; this PR supplies the canonical integral comultiplication part of that order.

Reuse Mathlib's `Algebra.TensorProduct.equivOfCompatibleSMul`, `TensorProduct.map_injective_of_flat_flat_of_isDomain`, the torsion-free-to-flat instance over `ℤ`, and `AlgEquiv.ofInjective`; no Mathlib code is vendored.

After this PR, Layer 9 still needs the remaining Hopf-order laws and antipode packaging, integral PBW/freeness and the Chevalley basis, then the group-scheme construction, base change, pinnings, points, root subgroups, pinned isomorphism theorem, and special isogenies consumed by CFSGStatement L0–L2.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"kostant-tensor-map-injective"}-->

🤖 Prepared with Codex
