### PR TITLE
feat: add nondegenerate smooth two-forms

### DIFF
--- a/TauCeti/Geometry/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Manifold/TwoForm.lean
@@ -179,7 +179,6 @@ def const {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
   isAlt _ v := hB v
 
 /-- The smooth bilinear section of a constant two-form has its defining value in every fiber. -/
-@[simp]
 lemma const_toContMDiffSection_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
     (B : V →L[ℝ] V →L[ℝ] ℝ) (hB : ∀ v, B v v = 0) (x : V) :
     (const B hB).toContMDiffSection x = B :=

--- a/TauCeti/Geometry/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Manifold/TwoForm.lean
@@ -184,13 +184,6 @@ lemma const_toContMDiffSection_apply {V : Type*} [NormedAddCommGroup V] [NormedS
     (const B hB).toContMDiffSection x = B :=
   (rfl)
 
-/-- A constant smooth two-form evaluates to its defining bilinear form. -/
-@[simp]
-lemma const_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
-    (B : V →L[ℝ] V →L[ℝ] ℝ) (hB : ∀ v, B v v = 0) (x v w : V) :
-    const B hB x v w = B v w :=
-  (rfl)
-
 /-- The pointwise bilinear form of a constant smooth two-form is its defining bilinear form with
 continuity forgotten. -/
 @[simp]
@@ -198,7 +191,7 @@ lemma const_bilinFormAt {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
     (B : V →L[ℝ] V →L[ℝ] ℝ) (hB : ∀ v, B v v = 0) (x : V) :
     (const B hB).bilinFormAt x = B.toBilinForm := by
   ext v w
-  exact const_apply B hB x v w
+  rfl
 
 /-- The zero smooth two-form. -/
 protected def zero : SmoothTwoForm I M where

--- a/TauCeti/Geometry/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Manifold/TwoForm.lean
@@ -34,6 +34,7 @@ manifold-valued pseudoholomorphic curves.
 * `TauCeti.SmoothTwoForm`: a smooth alternating bilinear form on tangent fibers.
 * `TauCeti.SmoothTwoForm.bilinFormAt`: the algebraic alternating bilinear form at a point.
 * `TauCeti.SmoothTwoForm.contMDiff_apply`: smooth evaluation on two smooth vector fields.
+* `TauCeti.SmoothTwoForm.const`: the constant smooth two-form on a model vector space.
 
 The definition follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
 Section 2.2.
@@ -138,6 +139,67 @@ lemma contMDiff_apply {n : ℕ∞ω} [ENat.LEInfty n] (form : SmoothTwoForm I M)
   exact hy.2
 
 end Evaluation
+
+/-- A continuous alternating bilinear form defines a constant smooth two-form on its model vector
+space. -/
+def const {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (B : V →L[ℝ] V →L[ℝ] ℝ) (hB : ∀ v, B v v = 0) :
+    SmoothTwoForm (modelWithCornersSelf ℝ V) V where
+  toContMDiffSection :=
+    ⟨fun _ ↦ B, by
+      intro x
+      rw [contMDiffAt_hom_bundle]
+      refine ⟨contMDiffAt_id, ?_⟩
+      let coord := fun y : V =>
+        ContinuousLinearMap.inCoordinates V (TangentSpace 𝓘(ℝ, V)) (V →L[ℝ] ℝ)
+          (fun b : V => TangentSpace 𝓘(ℝ, V) b →L[ℝ] ℝ) x y x y B
+      have hcoord : coord = fun _ => B := by
+        funext y
+        ext v w
+        simp only [ContinuousLinearMap.inCoordinates, TangentBundle.symmL_model_space,
+          ContinuousLinearMap.comp_apply, Trivialization.continuousLinearMapAt_apply, coord]
+        have htan : y ∈ (trivializationAt V (TangentSpace 𝓘(ℝ, V)) x).baseSet := by
+          rw [TangentBundle.trivializationAt_baseSet, chartAt_self_eq]
+          exact Set.mem_univ y
+        have htriv : y ∈ (trivializationAt ℝ (Bundle.Trivial V ℝ) x).baseSet := by
+          simp
+        have hhom : y ∈ (trivializationAt (V →L[ℝ] ℝ)
+            (fun b : V => TangentSpace 𝓘(ℝ, V) b →L[ℝ] ℝ) x).baseSet := by
+          rw [hom_trivializationAt_baseSet]
+          exact ⟨htan, htriv⟩
+        rw [Trivialization.linearMapAt_apply, ite_eq_left hhom, hom_trivializationAt_apply]
+        simp only [ContinuousLinearMap.inCoordinates, Trivial.fiberBundle_trivializationAt',
+          Trivial.continuousLinearMapAt_trivialization, TangentBundle.symmL_model_space,
+          ContinuousLinearMap.id_comp]
+        rfl
+      rw [show (fun y => ContinuousLinearMap.inCoordinates V (TangentSpace 𝓘(ℝ, V))
+        (V →L[ℝ] ℝ) (fun b : V => TangentSpace 𝓘(ℝ, V) b →L[ℝ] ℝ) x y x y B) = coord
+          from rfl, hcoord]
+      exact contMDiffAt_const⟩
+  isAlt _ v := hB v
+
+/-- The smooth bilinear section of a constant two-form has its defining value in every fiber. -/
+@[simp]
+lemma const_toContMDiffSection_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (B : V →L[ℝ] V →L[ℝ] ℝ) (hB : ∀ v, B v v = 0) (x : V) :
+    (const B hB).toContMDiffSection x = B :=
+  (rfl)
+
+/-- A constant smooth two-form evaluates to its defining bilinear form. -/
+@[simp]
+lemma const_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (B : V →L[ℝ] V →L[ℝ] ℝ) (hB : ∀ v, B v v = 0) (x v w : V) :
+    const B hB x v w = B v w :=
+  (rfl)
+
+/-- The pointwise bilinear form of a constant smooth two-form is its defining bilinear form with
+continuity forgotten. -/
+@[simp]
+lemma const_bilinFormAt {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (B : V →L[ℝ] V →L[ℝ] ℝ) (hB : ∀ v, B v v = 0) (x : V) :
+    (const B hB).bilinFormAt x = B.toBilinForm := by
+  ext v w
+  exact const_apply B hB x v w
 
 /-- The zero smooth two-form. -/
 protected def zero : SmoothTwoForm I M where

--- a/TauCeti/Geometry/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Manifold/TwoForm.lean
@@ -150,14 +150,16 @@ def const {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
       intro x
       rw [contMDiffAt_hom_bundle]
       refine ⟨contMDiffAt_id, ?_⟩
-      let coord := fun y : V =>
-        ContinuousLinearMap.inCoordinates V (TangentSpace 𝓘(ℝ, V)) (V →L[ℝ] ℝ)
-          (fun b : V => TangentSpace 𝓘(ℝ, V) b →L[ℝ] ℝ) x y x y B
-      have hcoord : coord = fun _ => B := by
+      -- The base and fiber components of the constant section are the projections of an explicit
+      -- pair, so `dsimp only` reduces the goal to the coordinate expression rewritten below.
+      dsimp only
+      have hcoord : (fun y : V =>
+          ContinuousLinearMap.inCoordinates V (TangentSpace 𝓘(ℝ, V)) (V →L[ℝ] ℝ)
+            (fun b : V => TangentSpace 𝓘(ℝ, V) b →L[ℝ] ℝ) x y x y B) = fun _ => B := by
         funext y
         ext v w
         simp only [ContinuousLinearMap.inCoordinates, TangentBundle.symmL_model_space,
-          ContinuousLinearMap.comp_apply, Trivialization.continuousLinearMapAt_apply, coord]
+          ContinuousLinearMap.comp_apply, Trivialization.continuousLinearMapAt_apply]
         have htan : y ∈ (trivializationAt V (TangentSpace 𝓘(ℝ, V)) x).baseSet := by
           rw [TangentBundle.trivializationAt_baseSet, chartAt_self_eq]
           exact Set.mem_univ y
@@ -172,7 +174,6 @@ def const {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
           Trivial.continuousLinearMapAt_trivialization, TangentBundle.symmL_model_space,
           ContinuousLinearMap.id_comp]
         rfl
-      change ContMDiffAt 𝓘(ℝ, V) 𝓘(ℝ, V →L[ℝ] V →L[ℝ] ℝ) ∞ coord x
       rw [hcoord]
       exact contMDiffAt_const⟩
   isAlt _ v := hB v

--- a/TauCeti/Geometry/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Manifold/TwoForm.lean
@@ -172,13 +172,13 @@ def const {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
           Trivial.continuousLinearMapAt_trivialization, TangentBundle.symmL_model_space,
           ContinuousLinearMap.id_comp]
         rfl
-      rw [show (fun y => ContinuousLinearMap.inCoordinates V (TangentSpace 𝓘(ℝ, V))
-        (V →L[ℝ] ℝ) (fun b : V => TangentSpace 𝓘(ℝ, V) b →L[ℝ] ℝ) x y x y B) = coord
-          from rfl, hcoord]
+      change ContMDiffAt 𝓘(ℝ, V) 𝓘(ℝ, V →L[ℝ] V →L[ℝ] ℝ) ∞ coord x
+      rw [hcoord]
       exact contMDiffAt_const⟩
   isAlt _ v := hB v
 
 /-- The smooth bilinear section of a constant two-form has its defining value in every fiber. -/
+@[simp]
 lemma const_toContMDiffSection_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
     (B : V →L[ℝ] V →L[ℝ] ℝ) (hB : ∀ v, B v v = 0) (x : V) :
     (const B hB).toContMDiffSection x = B :=

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -218,13 +218,6 @@ lemma const_toEndomorphism_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace
     (const Jc hJc).toEndomorphism x = Jc :=
   (rfl)
 
-/-- The constant smooth almost complex structure of `Jc` evaluates to `Jc`. -/
-@[simp]
-lemma const_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
-    (Jc : V →L[ℝ] V) (hJc : ∀ v, Jc (Jc v) = -v) (x v : V) :
-    const Jc hJc x v = Jc v :=
-  (rfl)
-
 end SmoothAlmostComplexStructure
 
 namespace AlmostComplexStructure
@@ -241,7 +234,7 @@ def constSmooth (J : AlmostComplexStructure V) :
 @[simp]
 lemma constSmooth_apply (J : AlmostComplexStructure V) (x v : V) :
     J.constSmooth x v = J v :=
-  SmoothAlmostComplexStructure.const_apply _ _ x v
+  (rfl)
 
 @[simp]
 lemma constSmooth_almostComplexStructureAt (J : AlmostComplexStructure V) (x : V) :
@@ -262,7 +255,7 @@ noncomputable def product (V : Type*) [NormedAddCommGroup V] [NormedSpace ℝ V]
 @[simp]
 lemma product_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] (x v : V × V) :
     product V x v = (-v.2, v.1) :=
-  const_apply _ _ x v
+  (rfl)
 
 @[simp]
 lemma product_almostComplexStructureAt {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -237,13 +237,6 @@ def constSmooth (J : AlmostComplexStructure V) :
   SmoothAlmostComplexStructure.const (LinearMap.toContinuousLinearMap J.toLinearMap)
     J.apply_apply
 
-/-- The endomorphism section of the constant smooth structure has its defining linear value in
-every fiber. -/
-lemma constSmooth_toEndomorphism (J : AlmostComplexStructure V) (x : V) :
-    J.constSmooth.toEndomorphism x = LinearMap.toContinuousLinearMap J.toLinearMap := by
-  rw [constSmooth]
-  exact SmoothAlmostComplexStructure.const_toEndomorphism_apply _ _ x
-
 @[simp]
 lemma constSmooth_apply (J : AlmostComplexStructure V) (x v : V) :
     J.constSmooth x v = J v :=

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -210,6 +210,14 @@ def const {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
       ContinuousLinearMap.coe_id', id_eq]
     exact hJc v
 
+/-- The endomorphism section of a constant smooth almost complex structure has its defining value
+in every fiber. -/
+@[simp]
+lemma const_toEndomorphism_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    (Jc : V →L[ℝ] V) (hJc : ∀ v, Jc (Jc v) = -v) (x : V) :
+    (const Jc hJc).toEndomorphism x = Jc :=
+  (rfl)
+
 /-- The constant smooth almost complex structure of `Jc` evaluates to `Jc`. -/
 @[simp]
 lemma const_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
@@ -229,6 +237,22 @@ def constSmooth (J : AlmostComplexStructure V) :
     SmoothAlmostComplexStructure (modelWithCornersSelf ℝ V) V :=
   SmoothAlmostComplexStructure.const (LinearMap.toContinuousLinearMap J.toLinearMap)
     J.apply_apply
+
+/-- The endomorphism section of the constant smooth structure has its defining linear value in
+every fiber. -/
+@[simp]
+lemma constSmooth_toEndomorphism (J : AlmostComplexStructure V) (x : V) :
+    J.constSmooth.toEndomorphism x = LinearMap.toContinuousLinearMap J.toLinearMap := by
+  rw [constSmooth]
+  exact SmoothAlmostComplexStructure.const_toEndomorphism_apply _ _ x
+
+/-- The endomorphism section of the constant smooth structure acts as the defining linear
+structure. -/
+@[simp]
+lemma constSmooth_toEndomorphism_apply (J : AlmostComplexStructure V) (x v : V) :
+    (J.constSmooth.toEndomorphism x) v = J v := by
+  rw [constSmooth_toEndomorphism]
+  rfl
 
 @[simp]
 lemma constSmooth_apply (J : AlmostComplexStructure V) (x v : V) :

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -212,6 +212,7 @@ def const {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
 
 /-- The endomorphism section of a constant smooth almost complex structure has its defining value
 in every fiber. -/
+@[simp]
 lemma const_toEndomorphism_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
     (Jc : V →L[ℝ] V) (hJc : ∀ v, Jc (Jc v) = -v) (x : V) :
     (const Jc hJc).toEndomorphism x = Jc :=

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -234,7 +234,19 @@ def constSmooth (J : AlmostComplexStructure V) :
 @[simp]
 lemma constSmooth_apply (J : AlmostComplexStructure V) (x v : V) :
     J.constSmooth x v = J v :=
-  (rfl)
+  congrArg (fun A : V →L[ℝ] V ↦ A v)
+    (SmoothAlmostComplexStructure.const_toEndomorphism_apply _ _ x)
+
+/-- Under the canonical identification of a self-model tangent fiber with the model space,
+evaluating a constant smooth almost complex structure is evaluating its defining linear map. -/
+@[simp]
+lemma fromTangentSpace_constSmooth_apply (J : AlmostComplexStructure V) (x : V)
+    (v : TangentSpace 𝓘(ℝ, V) x) :
+    NormedSpace.fromTangentSpace x (J.constSmooth x v) =
+      J (NormedSpace.fromTangentSpace x v) := by
+  exact congrArg
+    (fun A : V →L[ℝ] V ↦ A (NormedSpace.fromTangentSpace x v))
+    (SmoothAlmostComplexStructure.const_toEndomorphism_apply _ _ x)
 
 @[simp]
 lemma constSmooth_almostComplexStructureAt (J : AlmostComplexStructure V) (x : V) :
@@ -255,7 +267,8 @@ noncomputable def product (V : Type*) [NormedAddCommGroup V] [NormedSpace ℝ V]
 @[simp]
 lemma product_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] (x v : V × V) :
     product V x v = (-v.2, v.1) :=
-  (rfl)
+  congrArg (fun A : (V × V) →L[ℝ] (V × V) ↦ A v)
+    (const_toEndomorphism_apply _ _ x)
 
 @[simp]
 lemma product_almostComplexStructureAt {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -212,7 +212,6 @@ def const {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
 
 /-- The endomorphism section of a constant smooth almost complex structure has its defining value
 in every fiber. -/
-@[simp]
 lemma const_toEndomorphism_apply {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
     (Jc : V →L[ℝ] V) (hJc : ∀ v, Jc (Jc v) = -v) (x : V) :
     (const Jc hJc).toEndomorphism x = Jc :=
@@ -240,19 +239,10 @@ def constSmooth (J : AlmostComplexStructure V) :
 
 /-- The endomorphism section of the constant smooth structure has its defining linear value in
 every fiber. -/
-@[simp]
 lemma constSmooth_toEndomorphism (J : AlmostComplexStructure V) (x : V) :
     J.constSmooth.toEndomorphism x = LinearMap.toContinuousLinearMap J.toLinearMap := by
   rw [constSmooth]
   exact SmoothAlmostComplexStructure.const_toEndomorphism_apply _ _ x
-
-/-- The endomorphism section of the constant smooth structure acts as the defining linear
-structure. -/
-@[simp]
-lemma constSmooth_toEndomorphism_apply (J : AlmostComplexStructure V) (x v : V) :
-    (J.constSmooth.toEndomorphism x) v = J v := by
-  rw [constSmooth_toEndomorphism]
-  rfl
 
 @[simp]
 lemma constSmooth_apply (J : AlmostComplexStructure V) (x v : V) :

--- a/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
@@ -160,7 +160,11 @@ def constSmooth (omegaForm : SymplecticForm V) :
 @[simp]
 lemma constSmooth_apply (omegaForm : SymplecticForm V) (x v w : V) :
     omegaForm.constSmooth x v w = omegaForm v w :=
-  SmoothTwoForm.const_apply _ _ x v w
+  by
+    change ((SmoothTwoForm.const omegaForm.toBilinForm.toContinuousBilinearMap
+      omegaForm.isAlt).toContMDiffSection x) v w = omegaForm.toBilinForm v w
+    exact congrArg (fun B : V →L[ℝ] V →L[ℝ] ℝ ↦ B v w)
+      (SmoothTwoForm.const_toContMDiffSection_apply _ _ x)
 
 /-- A constant smooth symplectic form is fiberwise nondegenerate. -/
 @[simp]

--- a/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
@@ -32,6 +32,8 @@ defined here and the separate closedness predicate once that exterior-calculus l
 * `TauCeti.SmoothTwoForm.IsNondegenerate.symplecticFormAt`: the symplectic form on a tangent fiber.
 * `TauCeti.SmoothTwoForm.Tames` and `TauCeti.SmoothTwoForm.Compatible`: the unbundled pointwise
   relations to a smooth almost complex structure.
+* `TauCeti.SmoothTwoForm.IsNondegenerate.tames_iff`, `invariant_iff`, and `compatible_iff`: these
+  relations characterized fiber by fiber through the linear theory.
 * `TauCeti.SymplecticForm.constSmooth`: a symplectic form as a constant smooth two-form.
 
 The definitions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
@@ -120,6 +122,17 @@ structure in both tangent arguments leaves the form unchanged. -/
 def Invariant (form : SmoothTwoForm I M) (J : SmoothAlmostComplexStructure I M) : Prop :=
   ∀ (x : M) (v w : TangentSpace I x), form x (J x v) (J x w) = form x v w
 
+/-- Manifold-level invariance is the pointwise linear invariance condition once nondegeneracy has
+identified each tangent-space form as a `SymplecticForm`. -/
+lemma IsNondegenerate.invariant_iff (h : form.IsNondegenerate) :
+    form.Invariant J ↔ ∀ x, (h.symplecticFormAt x).Invariant (J.almostComplexStructureAt x) := by
+  simp only [SymplecticForm.invariant_iff]
+  constructor <;> intro hinv x v w
+  · simpa only [IsNondegenerate.symplecticFormAt_apply,
+      SmoothAlmostComplexStructure.almostComplexStructureAt_apply] using hinv x v w
+  · simpa only [IsNondegenerate.symplecticFormAt_apply,
+      SmoothAlmostComplexStructure.almostComplexStructureAt_apply] using hinv x v w
+
 /-- Compatibility is the conjunction of invariance and tameness. Neither relation is stored in
 the smooth two-form or almost complex structure. -/
 structure Compatible (form : SmoothTwoForm I M) (J : SmoothAlmostComplexStructure I M) : Prop where
@@ -132,17 +145,22 @@ structure Compatible (form : SmoothTwoForm I M) (J : SmoothAlmostComplexStructur
 lemma Compatible.isNondegenerate (h : form.Compatible J) : form.IsNondegenerate :=
   h.tames.isNondegenerate
 
+/-- Manifold-level compatibility is compatibility of the induced linear pair on every tangent
+space. -/
+lemma IsNondegenerate.compatible_iff (h : form.IsNondegenerate) :
+    form.Compatible J ↔ ∀ x, (h.symplecticFormAt x).Compatible (J.almostComplexStructureAt x) := by
+  simp only [SymplecticForm.compatible_iff, forall_and]
+  constructor
+  · intro hcompat
+    exact ⟨h.invariant_iff.mp hcompat.invariant, h.tames_iff.mp hcompat.tames⟩
+  · rintro ⟨hinv, htame⟩
+    exact ⟨h.invariant_iff.mpr hinv, h.tames_iff.mpr htame⟩
+
 /-- Manifold-level compatibility gives the existing compatible-pair structure on each tangent
 space. -/
 lemma Compatible.compatibleAt (h : form.Compatible J) (x : M) :
     (h.isNondegenerate.symplecticFormAt x).Compatible (J.almostComplexStructureAt x) :=
-  SymplecticForm.Compatible.of_tames
-    ((h.isNondegenerate.symplecticFormAt x).invariant_iff _ |>.mpr fun v w => by
-      simpa only [IsNondegenerate.symplecticFormAt_apply,
-        SmoothAlmostComplexStructure.almostComplexStructureAt_apply] using h.invariant x v w)
-    (fun v hv => by
-      simpa only [IsNondegenerate.symplecticFormAt_apply,
-        SmoothAlmostComplexStructure.almostComplexStructureAt_apply] using h.tames x v hv)
+  h.isNondegenerate.compatible_iff.mp h x
 
 end SmoothTwoForm
 
@@ -159,12 +177,14 @@ def constSmooth (omegaForm : SymplecticForm V) :
 /-- A constant smooth symplectic form evaluates as its defining algebraic form. -/
 @[simp]
 lemma constSmooth_apply (omegaForm : SymplecticForm V) (x v w : V) :
-    omegaForm.constSmooth x v w = omegaForm v w :=
-  by
-    change ((SmoothTwoForm.const omegaForm.toBilinForm.toContinuousBilinearMap
-      omegaForm.isAlt).toContMDiffSection x) v w = omegaForm.toBilinForm v w
-    exact congrArg (fun B : V →L[ℝ] V →L[ℝ] ℝ ↦ B v w)
-      (SmoothTwoForm.const_toContMDiffSection_apply _ _ x)
+    omegaForm.constSmooth x v w = omegaForm v w := by
+  simp only [constSmooth]
+  -- The two sides of `SmoothTwoForm.const_toContMDiffSection_apply` live in the fiber type
+  -- `TangentSpace 𝓘(ℝ, V) x →L[ℝ] _` and in `V →L[ℝ] _`, so `rw` cannot rewrite underneath the
+  -- application; the equality is transported by `congrArg` instead.
+  exact (congrArg (fun B : V →L[ℝ] V →L[ℝ] ℝ ↦ B v w)
+    (SmoothTwoForm.const_toContMDiffSection_apply _ _ x)).trans
+      (LinearMap.toContinuousBilinearMap_apply _ v w)
 
 /-- A constant smooth symplectic form is fiberwise nondegenerate. -/
 @[simp]

--- a/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
@@ -1,0 +1,238 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
+public import TauCeti.Geometry.Manifold.TwoForm
+public import TauCeti.Geometry.Symplectic.Manifold.AlmostComplex
+
+/-!
+# Nondegenerate, tame, and compatible two-forms on manifolds
+
+This file supplies the fiberwise part of a symplectic structure on a smooth manifold. A smooth
+two-form is nondegenerate when its value on every tangent space is a nondegenerate alternating
+bilinear form. Such a value is therefore a `TauCeti.SymplecticForm`, so the pointwise linear theory
+can be reused without restating it.
+
+Tameness and compatibility with a smooth almost complex structure are kept as unbundled
+predicates. They are pointwise exactly `SymplecticForm.Tames` and `SymplecticForm.Compatible`.
+In particular, tameness already forces fiberwise nondegeneracy. The constant construction shows
+that every finite-dimensional symplectic vector space, and especially the standard doubled model,
+gives a non-vacuous manifold-level example.
+
+Closedness is not included: the pinned Mathlib has no exterior derivative of manifold differential
+forms. A symplectic manifold will be a smooth two-form satisfying both the nondegeneracy predicate
+defined here and the separate closedness predicate once that exterior-calculus layer exists.
+
+## Main declarations
+
+* `TauCeti.SmoothTwoForm.IsNondegenerate`: fiberwise nondegeneracy of a smooth two-form.
+* `TauCeti.SmoothTwoForm.IsNondegenerate.symplecticFormAt`: the symplectic form on a tangent fiber.
+* `TauCeti.SmoothTwoForm.Tames` and `TauCeti.SmoothTwoForm.Compatible`: the unbundled pointwise
+  relations to a smooth almost complex structure.
+* `TauCeti.SymplecticForm.constSmooth`: a symplectic form as a constant smooth two-form.
+
+The definitions follow McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*,
+Section 2.2.
+-/
+
+public section
+
+open scoped ContDiff Manifold
+
+noncomputable section
+
+namespace TauCeti
+
+variable {E H M : Type*}
+variable [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+variable [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+
+namespace SmoothTwoForm
+
+variable {form : SmoothTwoForm I M} {J : SmoothAlmostComplexStructure I M}
+
+/-- A smooth two-form is fiberwise nondegenerate when its algebraic bilinear form on every tangent
+space is nondegenerate. Closedness is a separate condition. -/
+def IsNondegenerate (form : SmoothTwoForm I M) : Prop :=
+  ∀ x, (form.bilinFormAt x).Nondegenerate
+
+/-- Fiberwise nondegeneracy in terms of vectors annihilating every vector on the right. For an
+alternating form this one-sided condition implies the corresponding condition on the other side. -/
+lemma isNondegenerate_iff_separatingLeft :
+    form.IsNondegenerate ↔
+      ∀ (x : M) (v : TangentSpace I x),
+        (∀ w, form x v w = 0) → v = 0 := by
+  constructor
+  · intro h x v hv
+    apply (h x).1 v
+    intro w
+    simpa only [bilinFormAt_apply] using hv w
+  · intro h x
+    have hrefl := (form.isAlt_bilinFormAt x).isRefl
+    apply (LinearMap.IsRefl.nondegenerate_iff_separatingLeft hrefl).mpr
+    intro v hv
+    apply h x v
+    intro w
+    simpa only [bilinFormAt_apply] using hv w
+
+/-- A fiberwise nondegenerate smooth two-form gives a symplectic form on each tangent space. -/
+def IsNondegenerate.symplecticFormAt (h : form.IsNondegenerate) (x : M) :
+    SymplecticForm (TangentSpace I x) where
+  toBilinForm := form.bilinFormAt x
+  isAlt := form.isAlt_bilinFormAt x
+  nondegenerate := h x
+
+/-- The tangent-space symplectic form evaluates as the original smooth two-form. -/
+@[simp]
+lemma IsNondegenerate.symplecticFormAt_apply (h : form.IsNondegenerate) (x : M)
+    (v w : TangentSpace I x) :
+    h.symplecticFormAt x v w = form x v w :=
+  form.bilinFormAt_apply x v w
+
+/-- A smooth two-form tames a smooth almost complex structure when
+`form_x(v, J_x v) > 0` for every nonzero tangent vector. -/
+def Tames (form : SmoothTwoForm I M) (J : SmoothAlmostComplexStructure I M) : Prop :=
+  ∀ (x : M) (v : TangentSpace I x), v ≠ 0 → 0 < form x v (J x v)
+
+/-- Manifold-level tameness is the pointwise linear tameness condition once nondegeneracy has
+identified each tangent-space form as a `SymplecticForm`. -/
+lemma IsNondegenerate.tames_iff (h : form.IsNondegenerate) :
+    form.Tames J ↔ ∀ x, (h.symplecticFormAt x).Tames (J.almostComplexStructureAt x) := by
+  constructor <;> intro htame x v hv
+  · simpa only [IsNondegenerate.symplecticFormAt_apply,
+      SmoothAlmostComplexStructure.almostComplexStructureAt_apply] using htame x v hv
+  · simpa only [IsNondegenerate.symplecticFormAt_apply,
+      SmoothAlmostComplexStructure.almostComplexStructureAt_apply] using htame x v hv
+
+/-- A tame smooth two-form is fiberwise nondegenerate. -/
+lemma Tames.isNondegenerate (h : form.Tames J) : form.IsNondegenerate := by
+  rw [isNondegenerate_iff_separatingLeft]
+  intro x v hv
+  by_contra hv0
+  exact (h x v hv0).ne' (hv (J x v))
+
+/-- A smooth two-form is invariant under a smooth almost complex structure when applying the
+structure in both tangent arguments leaves the form unchanged. -/
+def Invariant (form : SmoothTwoForm I M) (J : SmoothAlmostComplexStructure I M) : Prop :=
+  ∀ (x : M) (v w : TangentSpace I x), form x (J x v) (J x w) = form x v w
+
+/-- Compatibility is the conjunction of invariance and tameness. Neither relation is stored in
+the smooth two-form or almost complex structure. -/
+structure Compatible (form : SmoothTwoForm I M) (J : SmoothAlmostComplexStructure I M) : Prop where
+  /-- Applying the almost complex structure in both entries preserves the two-form. -/
+  invariant : form.Invariant J
+  /-- The two-form is positive on every complex line. -/
+  tames : form.Tames J
+
+/-- Compatibility implies fiberwise nondegeneracy. -/
+lemma Compatible.isNondegenerate (h : form.Compatible J) : form.IsNondegenerate :=
+  h.tames.isNondegenerate
+
+/-- Manifold-level compatibility gives the existing compatible-pair structure on each tangent
+space. -/
+lemma Compatible.compatibleAt (h : form.Compatible J) (x : M) :
+    (h.isNondegenerate.symplecticFormAt x).Compatible (J.almostComplexStructureAt x) :=
+  SymplecticForm.Compatible.of_tames
+    ((h.isNondegenerate.symplecticFormAt x).invariant_iff _ |>.mpr fun v w => by
+      simpa only [IsNondegenerate.symplecticFormAt_apply,
+        SmoothAlmostComplexStructure.almostComplexStructureAt_apply] using h.invariant x v w)
+    (fun v hv => by
+      simpa only [IsNondegenerate.symplecticFormAt_apply,
+        SmoothAlmostComplexStructure.almostComplexStructureAt_apply] using h.tames x v hv)
+
+end SmoothTwoForm
+
+namespace SymplecticForm
+
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] [FiniteDimensional ℝ V]
+
+private lemma constSmooth_isAlt (omegaForm : SymplecticForm V) :
+    ∀ v, omegaForm.toBilinForm.toContinuousBilinearMap v v = 0 :=
+  omegaForm.isAlt
+
+/-- A symplectic form on a finite-dimensional normed vector space, regarded as a constant smooth
+two-form on the corresponding model manifold. -/
+def constSmooth (omegaForm : SymplecticForm V) :
+    SmoothTwoForm (modelWithCornersSelf ℝ V) V :=
+  SmoothTwoForm.const omegaForm.toBilinForm.toContinuousBilinearMap
+    (constSmooth_isAlt omegaForm)
+
+/-- The bilinear section of a constant smooth symplectic form has its defining value in every
+fiber. -/
+@[simp]
+lemma constSmooth_toContMDiffSection (omegaForm : SymplecticForm V) (x : V) :
+    omegaForm.constSmooth.toContMDiffSection x =
+      omegaForm.toBilinForm.toContinuousBilinearMap := by
+  rw [constSmooth]
+  exact SmoothTwoForm.const_toContMDiffSection_apply _ _ x
+
+/-- The bilinear section of a constant smooth symplectic form evaluates as the defining form. -/
+@[simp]
+lemma constSmooth_toContMDiffSection_apply (omegaForm : SymplecticForm V) (x v w : V) :
+    omegaForm.constSmooth.toContMDiffSection x v w = omegaForm v w := by
+  rw [constSmooth_toContMDiffSection]
+  rfl
+
+/-- A constant smooth symplectic form evaluates as its defining algebraic form. -/
+@[simp]
+lemma constSmooth_apply (omegaForm : SymplecticForm V) (x v w : V) :
+    omegaForm.constSmooth x v w = omegaForm v w :=
+  SmoothTwoForm.const_apply _ _ x v w
+
+/-- A constant smooth symplectic form is fiberwise nondegenerate. -/
+lemma isNondegenerate_constSmooth (omegaForm : SymplecticForm V) :
+    omegaForm.constSmooth.IsNondegenerate := by
+  rw [SmoothTwoForm.isNondegenerate_iff_separatingLeft]
+  intro x v hv
+  change V at v
+  apply omegaForm.nondegenerate.1 v
+  intro w
+  simpa only [constSmooth_toContMDiffSection_apply] using hv w
+
+/-- Tameness of a pair of constant smooth structures is exactly tameness of the underlying linear
+pair. -/
+lemma tames_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComplexStructure V} :
+    omegaForm.constSmooth.Tames J.constSmooth ↔ omegaForm.Tames J := by
+  constructor
+  · intro h v hv
+    simpa only [constSmooth_toContMDiffSection_apply,
+      AlmostComplexStructure.constSmooth_toEndomorphism_apply] using h 0 v hv
+  · intro h x v hv
+    change V at v
+    simpa only [constSmooth_toContMDiffSection_apply,
+      AlmostComplexStructure.constSmooth_toEndomorphism_apply] using h v hv
+
+/-- Invariance of a pair of constant smooth structures is exactly invariance of the underlying
+linear pair. -/
+lemma invariant_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComplexStructure V} :
+    omegaForm.constSmooth.Invariant J.constSmooth ↔ omegaForm.Invariant J := by
+  rw [SymplecticForm.invariant_iff]
+  constructor
+  · intro h v w
+    simpa only [constSmooth_toContMDiffSection_apply,
+      AlmostComplexStructure.constSmooth_toEndomorphism_apply] using h 0 v w
+  · intro h x v w
+    change V at v w
+    simpa only [constSmooth_toContMDiffSection_apply,
+      AlmostComplexStructure.constSmooth_toEndomorphism_apply] using h v w
+
+/-- Compatibility of a pair of constant smooth structures is exactly compatibility of the
+underlying linear pair. -/
+lemma compatible_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComplexStructure V} :
+    omegaForm.constSmooth.Compatible J.constSmooth ↔ omegaForm.Compatible J := by
+  rw [SymplecticForm.compatible_iff]
+  constructor
+  · intro h
+    exact ⟨invariant_constSmooth_iff.mp h.invariant, tames_constSmooth_iff.mp h.tames⟩
+  · rintro ⟨hinv, htame⟩
+    exact ⟨invariant_constSmooth_iff.mpr hinv, tames_constSmooth_iff.mpr htame⟩
+
+end SymplecticForm
+
+end TauCeti
+
+end

--- a/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
@@ -163,19 +163,11 @@ def constSmooth (omegaForm : SymplecticForm V) :
 
 /-- The bilinear section of a constant smooth symplectic form has its defining value in every
 fiber. -/
-@[simp]
 lemma constSmooth_toContMDiffSection (omegaForm : SymplecticForm V) (x : V) :
     omegaForm.constSmooth.toContMDiffSection x =
       omegaForm.toBilinForm.toContinuousBilinearMap := by
   rw [constSmooth]
   exact SmoothTwoForm.const_toContMDiffSection_apply _ _ x
-
-/-- The bilinear section of a constant smooth symplectic form evaluates as the defining form. -/
-@[simp]
-lemma constSmooth_toContMDiffSection_apply (omegaForm : SymplecticForm V) (x v w : V) :
-    omegaForm.constSmooth.toContMDiffSection x v w = omegaForm v w := by
-  rw [constSmooth_toContMDiffSection]
-  rfl
 
 /-- A constant smooth symplectic form evaluates as its defining algebraic form. -/
 @[simp]
@@ -191,7 +183,7 @@ lemma isNondegenerate_constSmooth (omegaForm : SymplecticForm V) :
   change V at v
   apply omegaForm.nondegenerate.1 v
   intro w
-  simpa only [constSmooth_toContMDiffSection_apply] using hv w
+  simpa only [constSmooth_apply] using hv w
 
 /-- Tameness of a pair of constant smooth structures is exactly tameness of the underlying linear
 pair. -/
@@ -199,12 +191,10 @@ lemma tames_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComplexStr
     omegaForm.constSmooth.Tames J.constSmooth ↔ omegaForm.Tames J := by
   constructor
   · intro h v hv
-    simpa only [constSmooth_toContMDiffSection_apply,
-      AlmostComplexStructure.constSmooth_toEndomorphism_apply] using h 0 v hv
+    simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h 0 v hv
   · intro h x v hv
     change V at v
-    simpa only [constSmooth_toContMDiffSection_apply,
-      AlmostComplexStructure.constSmooth_toEndomorphism_apply] using h v hv
+    simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h v hv
 
 /-- Invariance of a pair of constant smooth structures is exactly invariance of the underlying
 linear pair. -/
@@ -213,12 +203,10 @@ lemma invariant_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComple
   rw [SymplecticForm.invariant_iff]
   constructor
   · intro h v w
-    simpa only [constSmooth_toContMDiffSection_apply,
-      AlmostComplexStructure.constSmooth_toEndomorphism_apply] using h 0 v w
+    simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h 0 v w
   · intro h x v w
     change V at v w
-    simpa only [constSmooth_toContMDiffSection_apply,
-      AlmostComplexStructure.constSmooth_toEndomorphism_apply] using h v w
+    simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h v w
 
 /-- Compatibility of a pair of constant smooth structures is exactly compatibility of the
 underlying linear pair. -/

--- a/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
@@ -163,6 +163,7 @@ lemma constSmooth_apply (omegaForm : SymplecticForm V) (x v w : V) :
   SmoothTwoForm.const_apply _ _ x v w
 
 /-- A constant smooth symplectic form is fiberwise nondegenerate. -/
+@[simp]
 lemma isNondegenerate_constSmooth (omegaForm : SymplecticForm V) :
     omegaForm.constSmooth.IsNondegenerate := fun x => by
   have hx : omegaForm.constSmooth.bilinFormAt x = omegaForm.toBilinForm :=
@@ -172,17 +173,21 @@ lemma isNondegenerate_constSmooth (omegaForm : SymplecticForm V) :
 
 /-- Tameness of a pair of constant smooth structures is exactly tameness of the underlying linear
 pair. -/
+@[simp]
 lemma tames_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComplexStructure V} :
     omegaForm.constSmooth.Tames J.constSmooth ↔ omegaForm.Tames J := by
   constructor
   · intro h v hv
     simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h 0 v hv
   · intro h x v hv
+    -- On the self-model manifold `TangentSpace 𝓘(ℝ, V) x` is definitionally `V`, so there is
+    -- no identification map or transport lemma to rewrite by before using the exposed API.
     change V at v
     simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h v hv
 
 /-- Invariance of a pair of constant smooth structures is exactly invariance of the underlying
 linear pair. -/
+@[simp]
 lemma invariant_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComplexStructure V} :
     omegaForm.constSmooth.Invariant J.constSmooth ↔ omegaForm.Invariant J := by
   rw [SymplecticForm.invariant_iff]
@@ -190,11 +195,13 @@ lemma invariant_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComple
   · intro h v w
     simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h 0 v w
   · intro h x v w
+    -- As above, both tangent vectors are definitionally vectors in the self-model space.
     change V at v w
     simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h v w
 
 /-- Compatibility of a pair of constant smooth structures is exactly compatibility of the
 underlying linear pair. -/
+@[simp]
 lemma compatible_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComplexStructure V} :
     omegaForm.constSmooth.Compatible J.constSmooth ↔ omegaForm.Compatible J := by
   rw [SymplecticForm.compatible_iff]

--- a/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
@@ -186,6 +186,19 @@ lemma constSmooth_apply (omegaForm : SymplecticForm V) (x v w : V) :
     (SmoothTwoForm.const_toContMDiffSection_apply _ _ x)).trans
       (LinearMap.toContinuousBilinearMap_apply _ v w)
 
+/-- Under the canonical identification of a self-model tangent fiber with the model space,
+evaluating a constant smooth symplectic form is evaluating its defining bilinear form. -/
+@[simp]
+lemma fromTangentSpace_constSmooth_apply (omegaForm : SymplecticForm V) (x : V)
+    (v w : TangentSpace 𝓘(ℝ, V) x) :
+    omegaForm.constSmooth x v w =
+      omegaForm (NormedSpace.fromTangentSpace x v) (NormedSpace.fromTangentSpace x w) := by
+  exact (congrArg
+    (fun B : V →L[ℝ] V →L[ℝ] ℝ ↦
+      B (NormedSpace.fromTangentSpace x v) (NormedSpace.fromTangentSpace x w))
+    (SmoothTwoForm.const_toContMDiffSection_apply _ _ x)).trans
+      (LinearMap.toContinuousBilinearMap_apply _ _ _)
+
 /-- A constant smooth symplectic form is fiberwise nondegenerate. -/
 @[simp]
 lemma isNondegenerate_constSmooth (omegaForm : SymplecticForm V) :
@@ -204,10 +217,11 @@ lemma tames_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComplexStr
   · intro h v hv
     simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h 0 v hv
   · intro h x v hv
-    -- On the self-model manifold `TangentSpace 𝓘(ℝ, V) x` is definitionally `V`, so there is
-    -- no identification map or transport lemma to rewrite by before using the exposed API.
-    change V at v
-    simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h v hv
+    -- Use Mathlib's explicit canonical identification of a self-model tangent fiber with `V`.
+    let e : TangentSpace 𝓘(ℝ, V) x ≃L[ℝ] V := NormedSpace.fromTangentSpace x
+    have hev : e v ≠ 0 := fun hev ↦ hv (e.injective (hev.trans e.map_zero.symm))
+    simpa only [e, fromTangentSpace_constSmooth_apply,
+      AlmostComplexStructure.fromTangentSpace_constSmooth_apply] using h (e v) hev
 
 /-- Invariance of a pair of constant smooth structures is exactly invariance of the underlying
 linear pair. -/
@@ -219,9 +233,10 @@ lemma invariant_constSmooth_iff {omegaForm : SymplecticForm V} {J : AlmostComple
   · intro h v w
     simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h 0 v w
   · intro h x v w
-    -- As above, both tangent vectors are definitionally vectors in the self-model space.
-    change V at v w
-    simpa only [constSmooth_apply, AlmostComplexStructure.constSmooth_apply] using h v w
+    -- Use the same canonical identification for both tangent vectors.
+    let e : TangentSpace 𝓘(ℝ, V) x ≃L[ℝ] V := NormedSpace.fromTangentSpace x
+    simpa only [e, fromTangentSpace_constSmooth_apply,
+      AlmostComplexStructure.fromTangentSpace_constSmooth_apply] using h (e v) (e w)
 
 /-- Compatibility of a pair of constant smooth structures is exactly compatibility of the
 underlying linear pair. -/

--- a/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
@@ -150,24 +150,11 @@ namespace SymplecticForm
 
 variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] [FiniteDimensional ℝ V]
 
-private lemma constSmooth_isAlt (omegaForm : SymplecticForm V) :
-    ∀ v, omegaForm.toBilinForm.toContinuousBilinearMap v v = 0 :=
-  omegaForm.isAlt
-
 /-- A symplectic form on a finite-dimensional normed vector space, regarded as a constant smooth
 two-form on the corresponding model manifold. -/
 def constSmooth (omegaForm : SymplecticForm V) :
     SmoothTwoForm (modelWithCornersSelf ℝ V) V :=
-  SmoothTwoForm.const omegaForm.toBilinForm.toContinuousBilinearMap
-    (constSmooth_isAlt omegaForm)
-
-/-- The bilinear section of a constant smooth symplectic form has its defining value in every
-fiber. -/
-lemma constSmooth_toContMDiffSection (omegaForm : SymplecticForm V) (x : V) :
-    omegaForm.constSmooth.toContMDiffSection x =
-      omegaForm.toBilinForm.toContinuousBilinearMap := by
-  rw [constSmooth]
-  exact SmoothTwoForm.const_toContMDiffSection_apply _ _ x
+  SmoothTwoForm.const omegaForm.toBilinForm.toContinuousBilinearMap omegaForm.isAlt
 
 /-- A constant smooth symplectic form evaluates as its defining algebraic form. -/
 @[simp]
@@ -177,13 +164,11 @@ lemma constSmooth_apply (omegaForm : SymplecticForm V) (x v w : V) :
 
 /-- A constant smooth symplectic form is fiberwise nondegenerate. -/
 lemma isNondegenerate_constSmooth (omegaForm : SymplecticForm V) :
-    omegaForm.constSmooth.IsNondegenerate := by
-  rw [SmoothTwoForm.isNondegenerate_iff_separatingLeft]
-  intro x v hv
-  change V at v
-  apply omegaForm.nondegenerate.1 v
-  intro w
-  simpa only [constSmooth_apply] using hv w
+    omegaForm.constSmooth.IsNondegenerate := fun x => by
+  have hx : omegaForm.constSmooth.bilinFormAt x = omegaForm.toBilinForm :=
+    SmoothTwoForm.const_bilinFormAt _ _ x
+  rw [hx]
+  exact omegaForm.nondegenerate
 
 /-- Tameness of a pair of constant smooth structures is exactly tameness of the underlying linear
 pair. -/


### PR DESCRIPTION
This PR adds the fiberwise nondegeneracy, tameness, and compatibility layer for smooth two-forms. It advances the HeegaardFloer Lane F2.1 milestone “Definitions land immediately,” specifically its `tame/compatible J` and `symplectic manifolds` targets.

It extends the existing smooth two-form API with constant forms on model vector spaces, defines `SmoothTwoForm.IsNondegenerate`, `Tames`, `Invariant`, and `Compatible`, and proves that tameness forces nondegeneracy. A compatible smooth pair now specializes to the existing linear compatible-pair structure on every tangent fiber. Constant finite-dimensional symplectic and almost-complex structures recover the underlying linear tameness, invariance, and compatibility conditions exactly.

The mathematics follows McDuff–Salamon, *J-holomorphic Curves and Symplectic Topology*, Section 2.2. The implementation reuses Mathlib’s `LinearMap.BilinForm.Nondegenerate`, alternating-form nondegeneracy criterion, and finite-dimensional conversion from bilinear maps to continuous bilinear maps.

After this PR, Lane F2.1 still needs a manifold exterior derivative and closedness predicate before the symplectic-manifold structure itself can be defined; Darboux/Moser and the later local theory remain after that.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"smooth-two-form-nondegenerate"}-->

🤖 Prepared with Codex
