### PR TITLE
refactor(RootSystem): name the two estimates inside the cyclic-diagram proof

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
@@ -353,6 +353,62 @@ theorem apply_mul_apply_mem_of_ne (h : IsFiniteType A) {i j : B} (hij : i ≠ j)
   simp only [Set.mem_insert_iff, Set.mem_singleton_iff]
   omega
 
+/-- **On a cycle of length at least three an index and its two cyclic neighbours are pairwise
+distinct.** Successor and predecessor are the cyclic ones, taken in the additive group `Fin m`.
+Three is the exact threshold: on `Fin 2` an index has a single neighbour, `i + 1 = i - 1`. -/
+private theorem cyclic_neighbors_pairwise_ne {m : ℕ} [NeZero m] (hm : 3 ≤ m) (i : Fin m) :
+    i + 1 ≠ i ∧ i - 1 ≠ i ∧ i + 1 ≠ i - 1 := by
+  have hval1 : ((1 : Fin m) : ℕ) = 1 := by
+    rw [Fin.val_one', Nat.mod_eq_of_lt (by omega)]
+  have hone : (1 : Fin m) ≠ 0 := fun hc ↦ by
+    have hval := congrArg Fin.val hc
+    rw [hval1, Fin.val_zero] at hval
+    omega
+  have htwo : (1 : Fin m) + 1 ≠ 0 := fun hc ↦ by
+    have hval2 : (((1 : Fin m) + 1 : Fin m) : ℕ) = 2 := by
+      rw [Fin.val_add, hval1, Nat.mod_eq_of_lt (by omega)]
+    have hval := congrArg Fin.val hc
+    rw [hval2, Fin.val_zero] at hval
+    omega
+  have hsucc : i + 1 ≠ i := fun hc ↦ hone (add_left_cancel (hc.trans (add_zero i).symm))
+  refine ⟨hsucc, fun hc ↦ ?_, fun hc ↦ ?_⟩
+  · have h1 : i - 1 + 1 = i + 1 := by rw [hc]
+    rw [sub_add_cancel] at h1
+    exact hsucc h1.symm
+  · refine htwo (add_left_cancel (a := i) ?_)
+    rw [← add_assoc, hc, sub_add_cancel, add_zero]
+
+/-- **A symmetric cycle form with the given diagonal and edge bounds has rows summing to a
+difference of reciprocals.** For `f` symmetric with `f i i = 2 / dᵢ`, nonpositive off the diagonal
+and at most `-1/dᵢ` along each cycle edge, the `i`th row sums to at most `1/dᵢ - 1/dᵢ₋₁`. Summing
+this over the cycle makes the right-hand side telescope to zero. -/
+private theorem sum_le_inv_sub_inv {m : ℕ} [NeZero m] (hm : 3 ≤ m)
+    {d : Fin m → ℚ} {f : Fin m → Fin m → ℚ} (hfsymm : ∀ i j, f i j = f j i)
+    (hdiag : ∀ i, f i i = 2 / d i) (hnonpos : ∀ i j : Fin m, j ≠ i → f i j ≤ 0)
+    (hedge : ∀ i : Fin m, f i (i + 1) ≤ -(d i)⁻¹) (i : Fin m) :
+    ∑ j, f i j ≤ (d i)⁻¹ - (d (i - 1))⁻¹ := by
+  obtain ⟨hsucc, hpred, hsp⟩ := cyclic_neighbors_pairwise_ne hm i
+  rw [← Finset.sum_sdiff (Finset.subset_univ ({i, i + 1, i - 1} : Finset (Fin m)))]
+  have hrest : ∑ j ∈ Finset.univ \ ({i, i + 1, i - 1} : Finset (Fin m)), f i j ≤ 0 := by
+    refine Finset.sum_nonpos fun j hj ↦ hnonpos i j ?_
+    simp only [Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton, not_or] at hj
+    tauto
+  have hthree : ∑ j ∈ ({i, i + 1, i - 1} : Finset (Fin m)), f i j
+      = f i i + f i (i + 1) + f i (i - 1) := by
+    rw [Finset.sum_insert (by
+        simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+        exact ⟨hsucc.symm, hpred.symm⟩),
+      Finset.sum_insert (by simpa using hsp), Finset.sum_singleton, add_assoc]
+  have hlast : f i (i - 1) ≤ -(d (i - 1))⁻¹ := by
+    have hshift := hedge (i - 1)
+    rwa [sub_add_cancel, hfsymm] at hshift
+  have hhalf : (2 : ℚ) / d i = (d i)⁻¹ + (d i)⁻¹ := by
+    rw [div_eq_mul_inv]; ring
+  have hii := hdiag i
+  have hnext := hedge i
+  rw [hthree]
+  linarith
+
 /-- **A cyclic diagram is not of finite type.** On an index type of size at least three, no
 finite-type matrix joins every index to its cyclic successor: some `Tₖ,ₖ₊₁` vanishes.
 
@@ -377,30 +433,6 @@ private theorem exists_apply_succ_eq_zero_fin {m : ℕ} [NeZero m] (hm : 3 ≤ m
   push Not at hcon
   obtain ⟨d, hd, hpd⟩ := h.exists_symmetrizer
   have hsymm := symmetrization_apply_comm hpd
-  -- An index, its successor and its predecessor are pairwise distinct, the cycle being long enough.
-  have hval1 : ((1 : Fin m) : ℕ) = 1 := by
-    rw [Fin.val_one', Nat.mod_eq_of_lt (by omega)]
-  have hone : (1 : Fin m) ≠ 0 := fun hc ↦ by
-    have hval := congrArg Fin.val hc
-    rw [hval1, Fin.val_zero] at hval
-    omega
-  have htwo : (1 : Fin m) + 1 ≠ 0 := fun hc ↦ by
-    have hval2 : (((1 : Fin m) + 1 : Fin m) : ℕ) = 2 := by
-      rw [Fin.val_add, hval1, Nat.mod_eq_of_lt (by omega)]
-    have hval := congrArg Fin.val hc
-    rw [hval2, Fin.val_zero] at hval
-    omega
-  have hsucc : ∀ i : Fin m, i + 1 ≠ i := fun i hc ↦
-    hone (add_left_cancel (hc.trans (add_zero i).symm))
-  have hpred : ∀ i : Fin m, i - 1 ≠ i := by
-    intro i hc
-    have h1 : i - 1 + 1 = i + 1 := by rw [hc]
-    rw [sub_add_cancel] at h1
-    exact hsucc i h1.symm
-  have hsp : ∀ i : Fin m, i + 1 ≠ i - 1 := by
-    intro i hc
-    refine htwo (add_left_cancel (a := i) ?_)
-    rw [← add_assoc, hc, sub_add_cancel, add_zero]
   -- `f i j` is the contribution of the pair `(i, j)` to the form at the test vector; it is
   -- symmetric, and nonpositive off the diagonal.
   obtain ⟨f, hf⟩ : ∃ f : Fin m → Fin m → ℚ, ∀ i j, f i j = (T i j : ℚ) / d j := ⟨_, fun _ _ ↦ rfl⟩
@@ -422,7 +454,7 @@ private theorem exists_apply_succ_eq_zero_fin {m : ℕ} [NeZero m] (hm : 3 ≤ m
     intro i
     have h0 : T (i + 1) i ≠ 0 := fun hc ↦ hcon i (h.apply_eq_zero_symm hc)
     have hle : T (i + 1) i ≤ -1 := by
-      have := h.apply_le_zero_of_ne (hsucc i)
+      have := h.apply_le_zero_of_ne (cyclic_neighbors_pairwise_ne hm i).1
       omega
     have hcast : ((T (i + 1) i : ℤ) : ℚ) ≤ -1 := by exact_mod_cast hle
     calc f i (i + 1) = (T (i + 1) i : ℚ) * (d i)⁻¹ := by rw [hfsymm, hf, div_eq_mul_inv]
@@ -441,28 +473,8 @@ private theorem exists_apply_succ_eq_zero_fin {m : ℕ} [NeZero m] (hm : 3 ≤ m
     rw [hf, inv_mul_cancel_left₀ (hd i).ne', div_eq_mul_inv]
   -- Each index contributes at most `1/dᵢ - 1/dᵢ₋₁`, and those differences telescope around the
   -- cycle to `0`.
-  have hbound : ∀ i : Fin m, ∑ j, f i j ≤ (d i)⁻¹ - (d (i - 1))⁻¹ := by
-    intro i
-    rw [← Finset.sum_sdiff (Finset.subset_univ ({i, i + 1, i - 1} : Finset (Fin m)))]
-    have hrest : ∑ j ∈ Finset.univ \ ({i, i + 1, i - 1} : Finset (Fin m)), f i j ≤ 0 := by
-      refine Finset.sum_nonpos fun j hj ↦ hnonpos i j ?_
-      simp only [Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton, not_or] at hj
-      tauto
-    have hthree : ∑ j ∈ ({i, i + 1, i - 1} : Finset (Fin m)), f i j
-        = f i i + f i (i + 1) + f i (i - 1) := by
-      rw [Finset.sum_insert (by
-          simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
-          exact ⟨(hsucc i).symm, (hpred i).symm⟩),
-        Finset.sum_insert (by simpa using hsp i), Finset.sum_singleton, add_assoc]
-    have hlast : f i (i - 1) ≤ -(d (i - 1))⁻¹ := by
-      have hshift := hedge (i - 1)
-      rwa [sub_add_cancel, hfsymm] at hshift
-    have hhalf : (2 : ℚ) / d i = (d i)⁻¹ + (d i)⁻¹ := by
-      rw [div_eq_mul_inv]; ring
-    have hii := hdiag i
-    have hnext := hedge i
-    rw [hthree]
-    linarith
+  have hbound : ∀ i : Fin m, ∑ j, f i j ≤ (d i)⁻¹ - (d (i - 1))⁻¹ :=
+    sum_le_inv_sub_inv hm hfsymm hdiag hnonpos hedge
   have hshift : ∑ i : Fin m, (d (i - 1))⁻¹ = ∑ i : Fin m, (d i)⁻¹ :=
     Fintype.sum_equiv (Equiv.subRight (1 : Fin m)) _ _ fun _ ↦ rfl
   have hle := Finset.sum_le_sum fun i (_ : i ∈ (Finset.univ : Finset (Fin m))) ↦ hbound i


### PR DESCRIPTION
`exists_apply_succ_eq_zero_fin` — the proof that a cyclic diagram is not of finite type — ran to 95
lines, and two of its phases were self-contained statements rather than steps.

## The two extractions

**`cyclic_neighbors_pairwise_ne`** (19 lines). The proof opened with 23 lines of `Fin` arithmetic
establishing that `i`, `i + 1` and `i - 1` are pairwise distinct. That is a fact about `Fin m`
alone: it mentions neither the matrix nor finite type, and three is the exact threshold — on
`Fin 2` a single neighbour serves as both, `i + 1 = i - 1`.

`[NeZero m]` is kept in the signature despite following from `3 ≤ m`. It is load-bearing in the
*statement*, not the proof: without it `(1 : Fin m)` has no `OfNat` instance and the type does not
elaborate. Deriving it inside the proof was tried and fails at that point.

**`sum_le_inv_sub_inv`** (21 lines). The row estimate — that a symmetric `f` with `f i i = 2 / dᵢ`,
nonpositive off the diagonal and at most `-1/dᵢ` along each cycle edge has `∑ⱼ f i j ≤ 1/dᵢ -
1/dᵢ₋₁` — is the substance of the positive-definiteness contradiction, and holds for any such `f`
and `d`. It needs no positivity of `d`, and the parent's `hd` is deliberately not threaded through.
It takes `3 ≤ m` and calls the first helper itself rather than accepting three distinctness
hypotheses.

With the distinctness moved inside, the parent's `hpred` and `hsp` became dead and `hsucc` had a
single remaining use, so all three are gone.

## Result

| | before | after |
|---|---|---|
| `exists_apply_succ_eq_zero_fin` | 95 | 51 |
| `cyclic_neighbors_pairwise_ne` | — | 19 |
| `sum_le_inv_sub_inv` | — | 21 |

Searched Mathlib for the distinctness facts before extracting — `Fin.one_ne_zero`, `succ_ne_self`
(it is `Nat.succ_ne_self`, not the cyclic `Fin` one), `add_right_eq_self`, and the `Data/Fin` tree.
The cyclic-neighbour package is not there.

Gates run on `6cc7d416`: `lake build` (7805 jobs), `lake exe axioms` (44695 declarations),
`lake exe module-system` (2145 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: none
