### PR TITLE
refactor(VectorField): name the two chart-representation steps of mvfderiv_mlieBracket

### DIFF
--- a/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
@@ -177,18 +177,6 @@ private theorem mdifferentiableAt_mvfderiv_apply
   rw [Function.comp_apply, tangentMap_snd, mvfderiv_apply_eq_mfderiv_apply]
   rfl
 
-omit [CompleteSpace E] [IsManifold I (minSmoothness 𝕜 2) M] in
-/-- **The coordinate representation of a function has the same order of smoothness.** Composing
-`f` with the inverse chart gives a map on `Set.range I` that is `ContDiffWithinAt` of the same
-order `n` at the chart image of the point. -/
-private theorem contDiffWithinAt_comp_extChartAt_symm {f : M → F} {x : M}
-    (hf : CMDiffAt n f x) :
-    ContDiffWithinAt 𝕜 n (f ∘ (extChartAt I x).symm) (Set.range I) (extChartAt I x x) := by
-  have hfWithin : ContMDiffWithinAt I 𝓘(𝕜, F) n f Set.univ x := hf
-  have hsymm := contMDiffWithinAt_extChartAt_symm_range_self (I := I) (n := n) x
-  exact contMDiffWithinAt_iff_contDiffWithinAt.mp
-    (ContMDiffWithinAt.comp_of_eq hfWithin hsymm (Set.mapsTo_univ _ _) (extChartAt_to_inv x))
-
 /-- Let `f` have enough derivatives for symmetry of its second derivative at `x`, and let `V` and
 `W` be differentiable vector fields there. Then the differential of `f` on the manifold bracket is
 the commutator of its directional derivatives. This is the manifold counterpart of Mathlib's
@@ -236,7 +224,8 @@ theorem mvfderiv_mlieBracket {f : M → F} {V W : ∀ x : M, TangentSpace I x} {
   rw [← hchain_apply]
   simp only [mfderivWithin_eq_fderivWithin]
   -- Pull the vector fields back and invoke the normed-space bracket identity.
-  have hfcoord := contDiffWithinAt_comp_extChartAt_symm (hf.of_le hn)
+  have hfcoord := contMDiffWithinAt_iff_contDiffWithinAt.mp
+    (contMDiffAt_iff_source.mp (hf.of_le hn))
   have hVcoord : DifferentiableWithinAt 𝕜
       (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (Set.range I))
       (Set.range I) (extChartAt I x x) := by

--- a/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
@@ -177,35 +177,17 @@ private theorem mdifferentiableAt_mvfderiv_apply
   rw [Function.comp_apply, tangentMap_snd, mvfderiv_apply_eq_mfderiv_apply]
   rfl
 
-/-- **A vector field differentiable at a point pulls back to a differentiable coordinate field.**
-The pullback is taken along the inverse chart, so the coordinate field is differentiable within
-`Set.range I` at the chart image of the point. -/
-private theorem differentiableWithinAt_mpullbackWithin_extChartAt_symm
-    {U : ∀ x : M, TangentSpace I x} {x : M}
-    (hU : MDiffAt (fun y ↦ (U y : TangentBundle I M)) x) :
-    DifferentiableWithinAt 𝕜
-      (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm U (Set.range I))
-      (Set.range I) (extChartAt I x x) := by
-  have hU' : MDiffAt[Set.univ] (fun y ↦ (U y : TangentBundle I M)) x :=
-    hU.mdifferentiableWithinAt
-  simpa using hU'.differentiableWithinAt_mpullbackWithin_vectorField
-
 omit [CompleteSpace E] [IsManifold I (minSmoothness 𝕜 2) M] in
-/-- **The coordinate representation of a function keeps its smoothness.** Composing `f` with the
-inverse chart gives a map on `Set.range I` that is `ContDiffWithinAt` of order `minSmoothness 𝕜 2`
-at the chart image of the point. -/
+/-- **The coordinate representation of a function has the same order of smoothness.** Composing
+`f` with the inverse chart gives a map on `Set.range I` that is `ContDiffWithinAt` of the same
+order `n` at the chart image of the point. -/
 private theorem contDiffWithinAt_comp_extChartAt_symm {f : M → F} {x : M}
-    (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n) :
-    ContDiffWithinAt 𝕜 (minSmoothness 𝕜 2) (f ∘ (extChartAt I x).symm)
-      (Set.range I) (extChartAt I x x) := by
-  have hfWithin : ContMDiffWithinAt I 𝓘(𝕜, F) (minSmoothness 𝕜 2) f Set.univ x :=
-    hf.of_le hn
-  have hsymm := contMDiffWithinAt_extChartAt_symm_range_self
-    (I := I) (n := minSmoothness 𝕜 2) x
-  have hcomp := ContMDiffWithinAt.comp_of_eq
-    hfWithin
-    hsymm (Set.mapsTo_univ _ _) (extChartAt_to_inv x)
-  exact contMDiffWithinAt_iff_contDiffWithinAt.mp hcomp
+    (hf : CMDiffAt n f x) :
+    ContDiffWithinAt 𝕜 n (f ∘ (extChartAt I x).symm) (Set.range I) (extChartAt I x x) := by
+  have hfWithin : ContMDiffWithinAt I 𝓘(𝕜, F) n f Set.univ x := hf
+  have hsymm := contMDiffWithinAt_extChartAt_symm_range_self (I := I) (n := n) x
+  exact contMDiffWithinAt_iff_contDiffWithinAt.mp
+    (ContMDiffWithinAt.comp_of_eq hfWithin hsymm (Set.mapsTo_univ _ _) (extChartAt_to_inv x))
 
 /-- Let `f` have enough derivatives for symmetry of its second derivative at `x`, and let `V` and
 `W` be differentiable vector fields there. Then the differential of `f` on the manifold bracket is
@@ -254,9 +236,17 @@ theorem mvfderiv_mlieBracket {f : M → F} {V W : ∀ x : M, TangentSpace I x} {
   rw [← hchain_apply]
   simp only [mfderivWithin_eq_fderivWithin]
   -- Pull the vector fields back and invoke the normed-space bracket identity.
-  have hfcoord := contDiffWithinAt_comp_extChartAt_symm hf hn
-  have hVcoord := differentiableWithinAt_mpullbackWithin_extChartAt_symm hV
-  have hWcoord := differentiableWithinAt_mpullbackWithin_extChartAt_symm hW
+  have hfcoord := contDiffWithinAt_comp_extChartAt_symm (hf.of_le hn)
+  have hVcoord : DifferentiableWithinAt 𝕜
+      (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (Set.range I))
+      (Set.range I) (extChartAt I x x) := by
+    simpa using (hV.mdifferentiableWithinAt (s := Set.univ))
+      |>.differentiableWithinAt_mpullbackWithin_vectorField
+  have hWcoord : DifferentiableWithinAt 𝕜
+      (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm W (Set.range I))
+      (Set.range I) (extChartAt I x x) := by
+    simpa using (hW.mdifferentiableWithinAt (s := Set.univ))
+      |>.differentiableWithinAt_mpullbackWithin_vectorField
   -- Identify chart directional derivatives with their manifold counterparts.
   have hf_chart : MDiffAt f ((extChartAt I x).symm (extChartAt I x x)) := by
     simpa only [extChartAt_to_inv] using hf'

--- a/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
@@ -72,6 +72,16 @@ private theorem fderivWithin_chart_apply_mpullbackWithin
     ((isInvertible_mfderivWithin_extChartAt_symm hz).self_apply_inverse _)
 
 omit [CompleteSpace E] in
+private theorem eventually_mdifferentiableAt_of_contMDiffAt
+    {f : M → F} {x : M} (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n) :
+    ∀ᶠ y in 𝓝 x, MDiffAt f y := by
+  have h2n : (2 : ℕ∞ω) ≤ n :=
+    (le_minSmoothness (𝕜 := 𝕜) (n := (2 : ℕ∞ω))).trans hn
+  filter_upwards [(contMDiffAt_iff_contMDiffAt_nhds (n := 2) (by norm_num)).1
+    (hf.of_le h2n)] with y hy
+  exact hy.mdifferentiableAt (by norm_num)
+
+omit [CompleteSpace E] in
 private theorem eventuallyEq_chart_directionalDerivative
     {f : M → F} {U : ∀ y : M, TangentSpace I y} {x : M}
     (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n) :
@@ -79,13 +89,7 @@ private theorem eventuallyEq_chart_directionalDerivative
       (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm U (Set.range I) z)) =ᶠ[
       𝓝[Set.range I] (extChartAt I x x)]
     (fun y ↦ mvfderiv I f y (U y)) ∘ (extChartAt I x).symm := by
-  have hf_eventually : ∀ᶠ y in 𝓝 x, MDiffAt f y := by
-    have h2n : (2 : ℕ∞ω) ≤ n :=
-      (le_minSmoothness (𝕜 := 𝕜) (n := (2 : ℕ∞ω))).trans hn
-    have hf₂ : CMDiffAt 2 f x := hf.of_le h2n
-    filter_upwards [(contMDiffAt_iff_contMDiffAt_nhds (n := 2) (by norm_num)).1 hf₂]
-      with y hy
-    exact hy.mdifferentiableAt (by norm_num)
+  have hf_eventually := eventually_mdifferentiableAt_of_contMDiffAt hf hn
   have hsymm_tendsto : Tendsto (extChartAt I x).symm
       (𝓝[Set.range I] (extChartAt I x x)) (𝓝 x) := by
     simpa only [extChartAt_to_inv] using
@@ -127,16 +131,6 @@ private theorem exists_open_contMDiffOn_two
     ⟨s, hs, hfs⟩
   exact ⟨interior s, isOpen_interior,
     isOpen_interior.mem_nhds (mem_interior_iff_mem_nhds.mpr hs), hfs.mono interior_subset⟩
-
-omit [CompleteSpace E] in
-private theorem eventually_mdifferentiableAt_of_contMDiffAt
-    {f : M → F} {x : M} (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n) :
-    ∀ᶠ y in 𝓝 x, MDiffAt f y := by
-  have h2n : (2 : ℕ∞ω) ≤ n :=
-    (le_minSmoothness (𝕜 := 𝕜) (n := (2 : ℕ∞ω))).trans hn
-  filter_upwards [(contMDiffAt_iff_contMDiffAt_nhds (n := 2) (by norm_num)).1
-    (hf.of_le h2n)] with y hy
-  exact hy.mdifferentiableAt (by norm_num)
 
 omit [CompleteSpace E] in
 private theorem eventuallyEq_tangentMapWithin_apply

--- a/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
@@ -177,6 +177,36 @@ private theorem mdifferentiableAt_mvfderiv_apply
   rw [Function.comp_apply, tangentMap_snd, mvfderiv_apply_eq_mfderiv_apply]
   rfl
 
+/-- **A vector field differentiable at a point pulls back to a differentiable coordinate field.**
+The pullback is taken along the inverse chart, so the coordinate field is differentiable within
+`Set.range I` at the chart image of the point. -/
+private theorem differentiableWithinAt_mpullbackWithin_extChartAt_symm
+    {U : ∀ x : M, TangentSpace I x} {x : M}
+    (hU : MDiffAt (fun y ↦ (U y : TangentBundle I M)) x) :
+    DifferentiableWithinAt 𝕜
+      (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm U (Set.range I))
+      (Set.range I) (extChartAt I x x) := by
+  have hU' : MDiffAt[Set.univ] (fun y ↦ (U y : TangentBundle I M)) x :=
+    hU.mdifferentiableWithinAt
+  simpa using hU'.differentiableWithinAt_mpullbackWithin_vectorField
+
+omit [CompleteSpace E] [IsManifold I (minSmoothness 𝕜 2) M] in
+/-- **The coordinate representation of a function keeps its smoothness.** Composing `f` with the
+inverse chart gives a map on `Set.range I` that is `ContDiffWithinAt` of order `minSmoothness 𝕜 2`
+at the chart image of the point. -/
+private theorem contDiffWithinAt_comp_extChartAt_symm {f : M → F} {x : M}
+    (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n) :
+    ContDiffWithinAt 𝕜 (minSmoothness 𝕜 2) (f ∘ (extChartAt I x).symm)
+      (Set.range I) (extChartAt I x x) := by
+  have hfWithin : ContMDiffWithinAt I 𝓘(𝕜, F) (minSmoothness 𝕜 2) f Set.univ x :=
+    hf.of_le hn
+  have hsymm := contMDiffWithinAt_extChartAt_symm_range_self
+    (I := I) (n := minSmoothness 𝕜 2) x
+  have hcomp := ContMDiffWithinAt.comp_of_eq
+    hfWithin
+    hsymm (Set.mapsTo_univ _ _) (extChartAt_to_inv x)
+  exact contMDiffWithinAt_iff_contDiffWithinAt.mp hcomp
+
 /-- Let `f` have enough derivatives for symmetry of its second derivative at `x`, and let `V` and
 `W` be differentiable vector fields there. Then the differential of `f` on the manifold bracket is
 the commutator of its directional derivatives. This is the manifold counterpart of Mathlib's
@@ -224,29 +254,9 @@ theorem mvfderiv_mlieBracket {f : M → F} {V W : ∀ x : M, TangentSpace I x} {
   rw [← hchain_apply]
   simp only [mfderivWithin_eq_fderivWithin]
   -- Pull the vector fields back and invoke the normed-space bracket identity.
-  have hfcoord : ContDiffWithinAt 𝕜 (minSmoothness 𝕜 2)
-      (f ∘ (extChartAt I x).symm)
-      (Set.range I) (extChartAt I x x) := by
-    have hfWithin : ContMDiffWithinAt I 𝓘(𝕜, F) (minSmoothness 𝕜 2) f Set.univ x :=
-      hf.of_le hn
-    have hsymm := contMDiffWithinAt_extChartAt_symm_range_self
-      (I := I) (n := minSmoothness 𝕜 2) x
-    have hcomp := ContMDiffWithinAt.comp_of_eq
-      hfWithin
-      hsymm (Set.mapsTo_univ _ _) (extChartAt_to_inv x)
-    exact contMDiffWithinAt_iff_contDiffWithinAt.mp hcomp
-  have hVcoord : DifferentiableWithinAt 𝕜
-      (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (Set.range I))
-      (Set.range I) (extChartAt I x x) := by
-    have hV' : MDiffAt[Set.univ] (fun y ↦ (V y : TangentBundle I M)) x :=
-      hV.mdifferentiableWithinAt
-    simpa using hV'.differentiableWithinAt_mpullbackWithin_vectorField
-  have hWcoord : DifferentiableWithinAt 𝕜
-      (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm W (Set.range I))
-      (Set.range I) (extChartAt I x x) := by
-    have hW' : MDiffAt[Set.univ] (fun y ↦ (W y : TangentBundle I M)) x :=
-      hW.mdifferentiableWithinAt
-    simpa using hW'.differentiableWithinAt_mpullbackWithin_vectorField
+  have hfcoord := contDiffWithinAt_comp_extChartAt_symm hf hn
+  have hVcoord := differentiableWithinAt_mpullbackWithin_extChartAt_symm hV
+  have hWcoord := differentiableWithinAt_mpullbackWithin_extChartAt_symm hW
   -- Identify chart directional derivatives with their manifold counterparts.
   have hf_chart : MDiffAt f ((extChartAt I x).symm (extChartAt I x x)) := by
     simpa only [extChartAt_to_inv] using hf'


### PR DESCRIPTION
`mvfderiv_mlieBracket` opened by passing three objects to the chart, each written out inline. Two
review rounds established that none of it needed a new declaration: both passages are already in
Mathlib, and the PR now just routes to them.

## What it does

**The function's coordinate representation** is `contMDiffAt_iff_source` composed with the
normed-space equivalence, so the call site reads
`contMDiffWithinAt_iff_contDiffWithinAt.mp (contMDiffAt_iff_source.mp (hf.of_le hn))` and the
eleven-line block it replaces is gone.

**The vector fields' coordinate representations** are
`MDifferentiableWithinAt.differentiableWithinAt_mpullbackWithin_vectorField` at `s = Set.univ` —
at that instance the lemma's `(extChartAt I x).symm ⁻¹' s ∩ range I` *is* `range I`. Both call
sites use it directly.

## Two things worth recording

The one-liner form of the vector-field call does not elaborate. With
`have hVcoord := by simpa using …` there is no expected type, so `s` cannot be inferred
(`don't know how to synthesize implicit argument s`), and leaving the set un-normalised makes the
closing `rw` fail with "Did not find an occurrence of the pattern". Both call sites therefore keep
an explicit statement — that ascription is what pins `s := Set.univ` and normalises the set.

Round 2's `reuse` and `generality` findings pointed opposite ways on the same helper — delete it
versus widen its source set to `CMDiffAt[s]`. Deleting settles both, so no contest was needed:
there is no longer a declaration whose source set could be widened.

## Result

The PR adds **no declarations**. `mvfderiv_mlieBracket` goes 94 → 83 lines,
`eventuallyEq_chart_directionalDerivative` 17 → 11, and the file is a net 22 lines shorter.

## Review round 3

A second reviewer model found two things the earlier green board had missed, and both were real.

`attribution` — the description said `Roadmap: none`, but this file's own docstring links
`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`, Deliverable A Layer 1. Corrected above.

`reuse` — `hf_eventually` inside `eventuallyEq_chart_directionalDerivative` restated the private
lemma `eventually_mdifferentiableAt_of_contMDiffAt` verbatim, statement and proof alike. The cause
was ordering: the lemma was declared *below* its would-be caller, so it could not be used and got
re-derived instead. It now sits above the caller and the caller simply applies it, taking that
proof from 17 lines to 11 and leaving one copy of the `contMDiffAt_iff_contMDiffAt_nhds` idiom in
the file instead of two.

Gates re-run on `46e15770`: `lake build` (7806 jobs), `lake exe axioms` (44692 declarations),
`lake exe module-system` (2146 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: RepresentationTheory


