### PR TITLE
refactor(EllipticCurve): share the Aut(E) dichotomy between the twist classification theorems

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Aut.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Aut.lean
@@ -20,8 +20,8 @@ proves the classical fact (Silverman, *The Arithmetic of Elliptic Curves*, III.1
 
 * `WeierstrassCurve.eq_one_or_eq_negVariableChange_of_smul_eq`: if `j(E) ∉ {0, 1728}` then any
   `C : VariableChange K` with `C • E = E` equals `1` or `negVariableChange E`.
-* `WeierstrassCurve.eq_one_or_eq_negVariableChange_baseChange`: the same dichotomy for the base
-  change of `E` along an injection, with the `j`-hypotheses still read on `E` itself.
+* `WeierstrassCurve.eq_one_or_eq_negVariableChange_map`: the same dichotomy for the image of `E`
+  under any injective ring map, with the `j`-hypotheses still read on `E` itself.
 * `WeierstrassCurve.autGroup E`: the automorphism group of `E`, as the stabiliser of `E` under
   the action of `VariableChange K`. It is an `abbrev`, so Mathlib's `MulAction.stabilizer` API
   applies to it unchanged.
@@ -181,20 +181,20 @@ theorem eq_one_or_eq_negVariableChange_of_smul_eq [E.IsElliptic] (hj₀ : E.j �
     (E.j_eq_zero_iff.not.mp hj₀) (E.j_eq_1728_iff.not.mp hj₁₇₂₈) hC
 
 omit [IsDomain A] in
-variable {B : Type*} [CommRing B] [IsDomain B] [Algebra A B] in
-/-- **`Aut(E ⊗ B) = {±1}` when `j(E) ∉ {0, 1728}`**: the dichotomy survives base change along an
-injection. The hypotheses stay on `E` over the base ring, since `j` of the base change is the
-image of `j` (`map_j`), so an injective `algebraMap` carries both away from `0` and `1728`. Only
-the target has to be a domain; the base needs no more than a commutative ring. -/
-theorem eq_one_or_eq_negVariableChange_baseChange [E.IsElliptic]
-    (hinj : Function.Injective (algebraMap A B)) (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
-    {D : VariableChange B} (hD : D • E.baseChange B = E.baseChange B) :
-    D = 1 ∨ D = (E.baseChange B).negVariableChange := by
-  have : (E.baseChange B).IsElliptic := inferInstanceAs ((E.map (algebraMap A B)).IsElliptic)
-  have hj : (E.baseChange B).j = algebraMap A B E.j := by simp only [baseChange, map_j]
-  refine (E.baseChange B).eq_one_or_eq_negVariableChange_of_smul_eq ?_ ?_ hD
-  · rw [hj]; exact fun h ↦ hj₀ (hinj (by rw [h, map_zero]))
-  · rw [hj]; exact fun h ↦ hj₁₇₂₈ (hinj (by rw [h, map_ofNat]))
+variable {B : Type*} [CommRing B] [IsDomain B] in
+/-- **`Aut(E.map f) = {±1}` when `j(E) ∉ {0, 1728}`**: the dichotomy survives any injective change
+of base ring. The hypotheses stay on `E` over the source ring, since `j` of the image is the image
+of `j` (`map_j`), so an injective `f` carries both away from `0` and from `1728`. Only the target
+has to be a domain; the source needs no more than a commutative ring. Applies to a base change
+through `E.baseChange B = E.map (algebraMap A B)`. -/
+theorem eq_one_or_eq_negVariableChange_map [E.IsElliptic] {f : A →+* B}
+    (hf : Function.Injective f) (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
+    {D : VariableChange B} (hD : D • E.map f = E.map f) :
+    D = 1 ∨ D = (E.map f).negVariableChange := by
+  have hj : (E.map f).j = f E.j := E.map_j f
+  refine (E.map f).eq_one_or_eq_negVariableChange_of_smul_eq ?_ ?_ hD
+  · rw [hj]; exact fun h ↦ hj₀ (hf (by rw [h, map_zero]))
+  · rw [hj]; exact fun h ↦ hj₁₇₂₈ (hf (by rw [h, map_ofNat]))
 
 /-! ### The automorphism group -/
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Aut.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Aut.lean
@@ -20,6 +20,8 @@ proves the classical fact (Silverman, *The Arithmetic of Elliptic Curves*, III.1
 
 * `WeierstrassCurve.eq_one_or_eq_negVariableChange_of_smul_eq`: if `j(E) ∉ {0, 1728}` then any
   `C : VariableChange K` with `C • E = E` equals `1` or `negVariableChange E`.
+* `WeierstrassCurve.eq_one_or_eq_negVariableChange_baseChange`: the same dichotomy for the base
+  change of `E` along an injection, with the `j`-hypotheses still read on `E` itself.
 * `WeierstrassCurve.autGroup E`: the automorphism group of `E`, as the stabiliser of `E` under
   the action of `VariableChange K`. It is an `abbrev`, so Mathlib's `MulAction.stabilizer` API
   applies to it unchanged.
@@ -177,6 +179,22 @@ theorem eq_one_or_eq_negVariableChange_of_smul_eq [E.IsElliptic] (hj₀ : E.j �
     C = 1 ∨ C = E.negVariableChange :=
   E.eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq
     (E.j_eq_zero_iff.not.mp hj₀) (E.j_eq_1728_iff.not.mp hj₁₇₂₈) hC
+
+omit [IsDomain A] in
+variable {B : Type*} [CommRing B] [IsDomain B] [Algebra A B] in
+/-- **`Aut(E ⊗ B) = {±1}` when `j(E) ∉ {0, 1728}`**: the dichotomy survives base change along an
+injection. The hypotheses stay on `E` over the base ring, since `j` of the base change is the
+image of `j` (`map_j`), so an injective `algebraMap` carries both away from `0` and `1728`. Only
+the target has to be a domain; the base needs no more than a commutative ring. -/
+theorem eq_one_or_eq_negVariableChange_baseChange [E.IsElliptic]
+    (hinj : Function.Injective (algebraMap A B)) (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
+    {D : VariableChange B} (hD : D • E.baseChange B = E.baseChange B) :
+    D = 1 ∨ D = (E.baseChange B).negVariableChange := by
+  have : (E.baseChange B).IsElliptic := inferInstanceAs ((E.map (algebraMap A B)).IsElliptic)
+  have hj : (E.baseChange B).j = algebraMap A B E.j := by simp only [baseChange, map_j]
+  refine (E.baseChange B).eq_one_or_eq_negVariableChange_of_smul_eq ?_ ?_ hD
+  · rw [hj]; exact fun h ↦ hj₀ (hinj (by rw [h, map_zero]))
+  · rw [hj]; exact fun h ↦ hj₁₇₂₈ (hinj (by rw [h, map_ofNat]))
 
 /-! ### The automorphism group -/
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -710,7 +710,7 @@ twist by `L` — and, by `not_exists_smul_quadraticTwist_eq`, those two alternat
 There are exactly two alternatives because such forms are classified by
 `H¹(Gal(L/K), Aut Eᴸ) = Hom(ℤ/2, {±1})`, a group of order two. The `j`-hypotheses are what give
 `Aut Eᴸ = {±1}` (`eq_one_or_eq_negVariableChange_map`); for the excluded `j` the
-automorphism group is larger and there can be more forms. -/
+automorphism group can be larger and there can be more forms. -/
 theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
     (E' : WeierstrassCurve K)
     (h : ∃ C : VariableChange L, C • E'.baseChange L = E.baseChange L) :

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -644,6 +644,34 @@ section Classification
 
 variable [E.IsElliptic]
 
+omit [Algebra.IsSeparable K L] in
+/-- **`Aut(Eᴸ) = {±1}` when `j(E) ∉ {0, 1728}`**: an `L`-change of variables fixing `Eᴸ` is either
+the identity or `[-1]`.
+
+This is the only place either classification theorem below uses its two `j`-hypotheses, which is
+what their docstrings claim; naming the step is what makes that claim checkable. The hypotheses
+enter through `c₄ ≠ 0` and `c₆ ≠ 0` for the base change, which are exactly `j ≠ 0` and
+`j ≠ 1728`. At those two values the automorphism group can be strictly larger. -/
+private theorem eq_one_or_eq_negVariableChange_baseChange (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
+    {D : VariableChange L} (hD : D • E.baseChange L = E.baseChange L) :
+    D = 1 ∨ D = (E.baseChange L).negVariableChange := by
+  have hinj := FaithfulSMul.algebraMap_injective K L
+  -- `baseChange` is `map (algebraMap K L)`, whose `IsElliptic` instance Mathlib registers
+  have : (E.baseChange L).IsElliptic := inferInstanceAs ((E.map (algebraMap K L)).IsElliptic)
+  exact (E.baseChange L).eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq
+    (E.baseChange_c₄_ne_zero hinj (E.j_eq_zero_iff.not.mp hj₀))
+    (E.baseChange_c₆_ne_zero hinj (E.j_eq_1728_iff.not.mp hj₁₇₂₈)) hD
+
+omit [E.IsElliptic] in
+/-- The inverse of the trace–norm change of variables carries `Eᴸ` back to the base change of the
+twist by `θ`. Both classification theorems need this reading of
+`quadraticTwistOfTraceNormVariableChange_smul_baseChange`. Ellipticity is not needed. -/
+private theorem inv_quadraticTwistOfTraceNormVariableChange_smul {θ : L}
+    (hθ : θ ∉ Set.range (algebraMap K L)) {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) :
+    (E.quadraticTwistOfTraceNormVariableChange hθ hσ)⁻¹ • E.baseChange L
+      = (E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)).baseChange L := by
+  rw [← E.quadraticTwistOfTraceNormVariableChange_smul_baseChange hθ hσ, inv_smul_smul]
+
 variable (L) in
 /-- **The quadratic twist is not isomorphic to `E` over `K`**, when `j(E) ∉ {0, 1728}`. Twisting is
 a genuinely nontrivial operation: this is what `map_quadraticTwistOfTraceNormVariableChange`
@@ -664,8 +692,7 @@ theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : 
   have hiso := E.quadraticTwistOfTraceNormVariableChange_smul_baseChange hθ hσ
   have hcoc := E.map_quadraticTwistOfTraceNormVariableChange hθ hσ
   obtain ⟨C₀, hC₀⟩ := E.exists_smul_quadraticTwist_eq hθ
-  have hinj := FaithfulSMul.algebraMap_injective K L
-  -- `baseChange` is `map (algebraMap K L)`, whose `IsElliptic` instance Mathlib registers
+  -- needed by `negVariableChange_ne_one` at the end; the `Aut(Eᴸ) = {±1}` step supplies its own
   have : (E.baseChange L).IsElliptic := inferInstanceAs ((E.map (algebraMap K L)).IsElliptic)
   -- transfer the hypothetical `K`-isomorphism to the twist by `θ`
   have hDK : (CK * C₀⁻¹) • E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ) = E := by
@@ -676,20 +703,13 @@ theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : 
       = E.baseChange L := by rw [hψ, baseChange_smul_baseChange, hDK]
   have hψinv : ψ.map (σ : L →+* L) = ψ :=
     VariableChange.map_baseChange (C := CK * C₀⁻¹) (σ : L →ₐ[K] L)
-  have hc4L : (E.baseChange L).c₄ ≠ 0 :=
-    E.baseChange_c₄_ne_zero hinj (E.j_eq_zero_iff.not.mp hj₀)
-  have hc6L : (E.baseChange L).c₆ ≠ 0 :=
-    E.baseChange_c₆_ne_zero hinj (E.j_eq_1728_iff.not.mp hj₁₇₂₈)
   -- `a := ψ · C₁⁻¹` fixes `Eᴸ`, so it is `1` or `[-1]`; either way it is `σ`-invariant
   set a := ψ * C₁⁻¹ with ha
-  have hC1inv : C₁⁻¹ • E.baseChange L
-      = (E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)).baseChange L := by
-    rw [← hiso, inv_smul_smul]
-  have haut : a • E.baseChange L = E.baseChange L := by rw [ha, mul_smul, hC1inv, hψiso]
+  have haut : a • E.baseChange L = E.baseChange L := by
+    rw [ha, mul_smul, hC₁, E.inv_quadraticTwistOfTraceNormVariableChange_smul hθ hσ, hψiso]
   have haC : a * C₁ = ψ := by rw [ha, mul_assoc, inv_mul_cancel, mul_one]
   have hamap : a.map (σ : L →+* L) = a := by
-    rcases (E.baseChange L).eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq
-      hc4L hc6L haut with hcase | hcase
+    rcases E.eq_one_or_eq_negVariableChange_baseChange hj₀ hj₁₇₂₈ haut with hcase | hcase
     · rw [hcase]; exact VariableChange.map_one _
     · rw [hcase]; exact E.negVariableChange_baseChange_map L (σ : L →ₐ[K] L)
   -- applying `σ` to `ψ = a · C₁` forces `[-1] = 1`
@@ -724,20 +744,13 @@ theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj�
   have hiso := E.quadraticTwistOfTraceNormVariableChange_smul_baseChange hθ hσ
   have hcoc := E.map_quadraticTwistOfTraceNormVariableChange hθ hσ
   have hinj := FaithfulSMul.algebraMap_injective K L
-  -- `baseChange` is `map (algebraMap K L)`, whose `IsElliptic` instance Mathlib registers
-  have : (E.baseChange L).IsElliptic := inferInstanceAs ((E.map (algebraMap K L)).IsElliptic)
-  have hc4L : (E.baseChange L).c₄ ≠ 0 :=
-    E.baseChange_c₄_ne_zero hinj (E.j_eq_zero_iff.not.mp hj₀)
-  have hc6L : (E.baseChange L).c₆ ≠ 0 :=
-    E.baseChange_c₆_ne_zero hinj (E.j_eq_1728_iff.not.mp hj₁₇₂₈)
   -- the Galois conjugate of `ρ` is again an isomorphism `E'ᴸ ≅ Eᴸ`, so `σρ · ρ⁻¹` fixes `Eᴸ`
   have hσρ : (ρ.map (σ : L →+* L)) • E'.baseChange L = E.baseChange L :=
     map_smul_baseChange_eq L (σ : L →ₐ[K] L) hρ
   have hρinv : ρ⁻¹ • E.baseChange L = E'.baseChange L := by rw [← hρ, inv_smul_smul]
   have hb : (ρ.map (σ : L →+* L) * ρ⁻¹) • E.baseChange L = E.baseChange L := by
     rw [mul_smul, hρinv, hσρ]
-  rcases (E.baseChange L).eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq
-    hc4L hc6L hb with hbcase | hbcase
+  rcases E.eq_one_or_eq_negVariableChange_baseChange hj₀ hj₁₇₂₈ hb with hbcase | hbcase
   · -- trivial cocycle: `ρ` is `σ`-invariant, so it descends and `E' ≅ E` over `K`
     left
     obtain ⟨ρK, hρK⟩ :=
@@ -747,12 +760,9 @@ theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj�
     right
     have hρmap : ρ.map (σ : L →+* L) = (E.baseChange L).negVariableChange * ρ :=
       mul_inv_eq_iff_eq_mul.mp hbcase
-    have hC1inv : C₁⁻¹ • E.baseChange L
-        = (E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)).baseChange L := by
-      rw [← hiso, inv_smul_smul]
     have hχiso : (C₁⁻¹ * ρ) • E'.baseChange L
         = (E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)).baseChange L := by
-      rw [mul_smul, hρ, hC1inv]
+      rw [mul_smul, hρ, hC₁, E.inv_quadraticTwistOfTraceNormVariableChange_smul hθ hσ]
     have hχinv : (C₁⁻¹ * ρ).map (σ : L →+* L) = C₁⁻¹ * ρ := by
       rw [VariableChange.map_mul, VariableChange.map_inv, hcoc, hρmap, mul_inv_rev,
         (E.baseChange L).negVariableChange_inv, mul_assoc,

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -658,12 +658,9 @@ variable (L) in
 a genuinely nontrivial operation: this is what `map_quadraticTwistOfTraceNormVariableChange`
 deliberately stopped short of claiming, and the `j`-hypotheses are exactly what it lacked.
 
-Where the hypotheses enter: the only use of them is to get `Aut(Eᴸ) = {±1}`, via
-`eq_one_or_eq_negVariableChange_baseChange`, which carries `j ≠ 0` and `j ≠ 1728` along the base
-change and hands them to `eq_one_or_eq_negVariableChange_of_smul_eq`. At those two values the
-automorphism group can be strictly larger and the argument has nothing to run on. That is a
-statement about *this proof*; whether the theorem itself fails without them is not settled here,
-and no counterexample is asserted. -/
+What the `j`-hypotheses buy is `Aut(Eᴸ) = {±1}`
+(`eq_one_or_eq_negVariableChange_baseChange`). At `j ∈ {0, 1728}` the automorphism group can be
+strictly larger, and the statement is not claimed there; nor is a counterexample asserted. -/
 theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728) :
     ¬∃ C : VariableChange K, C • E.quadraticTwist L = E := by
   rintro ⟨CK, hCK⟩
@@ -709,10 +706,10 @@ variable (L) in
 that becomes isomorphic to `E` over `L` is isomorphic over `K` either to `E` or to its quadratic
 twist by `L` — and, by `not_exists_smul_quadraticTwist_eq`, those two alternatives are distinct.
 
-The mechanism: such forms are classified by `H¹(Gal(L/K), Aut Eᴸ) = Hom(ℤ/2, {±1})`, of order two,
-and the two cases below are the two cocycles. `Aut Eᴸ = {±1}` is where `j ∉ {0, 1728}` enters
-(`eq_one_or_eq_negVariableChange_baseChange`); for the excluded `j` the automorphism group is
-larger and there can be more forms. -/
+There are exactly two alternatives because such forms are classified by
+`H¹(Gal(L/K), Aut Eᴸ) = Hom(ℤ/2, {±1})`, a group of order two. The `j`-hypotheses are what give
+`Aut Eᴸ = {±1}` (`eq_one_or_eq_negVariableChange_baseChange`); for the excluded `j` the
+automorphism group is larger and there can be more forms. -/
 theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
     (E' : WeierstrassCurve K)
     (h : ∃ C : VariableChange L, C • E'.baseChange L = E.baseChange L) :

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -659,7 +659,7 @@ a genuinely nontrivial operation: this is what `map_quadraticTwistOfTraceNormVar
 deliberately stopped short of claiming, and the `j`-hypotheses are exactly what it lacked.
 
 What the `j`-hypotheses buy is `Aut(Eᴸ) = {±1}`
-(`eq_one_or_eq_negVariableChange_baseChange`). At `j ∈ {0, 1728}` the automorphism group can be
+(`eq_one_or_eq_negVariableChange_map`). At `j ∈ {0, 1728}` the automorphism group can be
 strictly larger, and the statement is not claimed there; nor is a counterexample asserted. -/
 theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728) :
     ¬∃ C : VariableChange K, C • E.quadraticTwist L = E := by
@@ -687,7 +687,8 @@ theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : 
     rw [ha, mul_smul, hC₁, E.inv_quadraticTwistOfTraceNormVariableChange_smul hθ hσ, hψiso]
   have haC : a * C₁ = ψ := by rw [ha, mul_assoc, inv_mul_cancel, mul_one]
   have hamap : a.map (σ : L →+* L) = a := by
-    rcases E.eq_one_or_eq_negVariableChange_baseChange hinj hj₀ hj₁₇₂₈ haut with hcase | hcase
+    rcases E.eq_one_or_eq_negVariableChange_map (f := algebraMap K L) hinj hj₀ hj₁₇₂₈ haut with
+      hcase | hcase
     · rw [hcase]; exact VariableChange.map_one _
     · rw [hcase]; exact E.negVariableChange_baseChange_map L (σ : L →ₐ[K] L)
   -- applying `σ` to `ψ = a · C₁` forces `[-1] = 1`
@@ -708,7 +709,7 @@ twist by `L` — and, by `not_exists_smul_quadraticTwist_eq`, those two alternat
 
 There are exactly two alternatives because such forms are classified by
 `H¹(Gal(L/K), Aut Eᴸ) = Hom(ℤ/2, {±1})`, a group of order two. The `j`-hypotheses are what give
-`Aut Eᴸ = {±1}` (`eq_one_or_eq_negVariableChange_baseChange`); for the excluded `j` the
+`Aut Eᴸ = {±1}` (`eq_one_or_eq_negVariableChange_map`); for the excluded `j` the
 automorphism group is larger and there can be more forms. -/
 theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
     (E' : WeierstrassCurve K)
@@ -727,7 +728,8 @@ theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj�
   have hρinv : ρ⁻¹ • E.baseChange L = E'.baseChange L := by rw [← hρ, inv_smul_smul]
   have hb : (ρ.map (σ : L →+* L) * ρ⁻¹) • E.baseChange L = E.baseChange L := by
     rw [mul_smul, hρinv, hσρ]
-  rcases E.eq_one_or_eq_negVariableChange_baseChange hinj hj₀ hj₁₇₂₈ hb with hbcase | hbcase
+  rcases E.eq_one_or_eq_negVariableChange_map (f := algebraMap K L) hinj hj₀ hj₁₇₂₈ hb with
+    hbcase | hbcase
   · -- trivial cocycle: `ρ` is `σ`-invariant, so it descends and `E' ≅ E` over `K`
     left
     obtain ⟨ρK, hρK⟩ :=

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -644,20 +644,6 @@ section Classification
 
 variable [E.IsElliptic]
 
-omit [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L] in
-/-- **`Aut(Eᴸ) = {±1}` when `j(E) ∉ {0, 1728}`**: an `L`-change of variables fixing the base
-change `Eᴸ` is either the identity or `[-1]`. -/
-private theorem eq_one_or_eq_negVariableChange_baseChange (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
-    {D : VariableChange L} (hD : D • E.baseChange L = E.baseChange L) :
-    D = 1 ∨ D = (E.baseChange L).negVariableChange := by
-  have hinj := FaithfulSMul.algebraMap_injective K L
-  -- `baseChange` is `map (algebraMap K L)`, whose `IsElliptic` instance Mathlib registers
-  have : (E.baseChange L).IsElliptic := inferInstanceAs ((E.map (algebraMap K L)).IsElliptic)
-  have hj : (E.baseChange L).j = algebraMap K L E.j := by simp only [baseChange, map_j]
-  refine (E.baseChange L).eq_one_or_eq_negVariableChange_of_smul_eq ?_ ?_ hD
-  · rw [hj]; exact fun h ↦ hj₀ (hinj (by rw [h, map_zero]))
-  · rw [hj]; exact fun h ↦ hj₁₇₂₈ (hinj (by rw [h, map_ofNat]))
-
 omit [E.IsElliptic] in
 /-- The inverse of the trace–norm change of variables carries `Eᴸ` back to the base change of the
 quadratic twist by `θ`. -/
@@ -673,11 +659,11 @@ a genuinely nontrivial operation: this is what `map_quadraticTwistOfTraceNormVar
 deliberately stopped short of claiming, and the `j`-hypotheses are exactly what it lacked.
 
 Where the hypotheses enter: the only use of them is to get `Aut(Eᴸ) = {±1}`, via
-`eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq`, whose hypotheses `c₄ ≠ 0`
-and `c₆ ≠ 0` are exactly `j ≠ 0` and `j ≠ 1728`. At those two values the automorphism group can be
-strictly larger and the argument has nothing to run on. That is a statement about *this proof*;
-whether the theorem itself fails without them is not settled here, and no counterexample is
-asserted. -/
+`eq_one_or_eq_negVariableChange_baseChange`, which carries `j ≠ 0` and `j ≠ 1728` along the base
+change and hands them to `eq_one_or_eq_negVariableChange_of_smul_eq`. At those two values the
+automorphism group can be strictly larger and the argument has nothing to run on. That is a
+statement about *this proof*; whether the theorem itself fails without them is not settled here,
+and no counterexample is asserted. -/
 theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728) :
     ¬∃ C : VariableChange K, C • E.quadraticTwist L = E := by
   rintro ⟨CK, hCK⟩
@@ -686,6 +672,7 @@ theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : 
   set C₁ := E.quadraticTwistOfTraceNormVariableChange hθ hσ with hC₁
   have hcoc := E.map_quadraticTwistOfTraceNormVariableChange hθ hσ
   obtain ⟨C₀, hC₀⟩ := E.exists_smul_quadraticTwist_eq hθ
+  have hinj := FaithfulSMul.algebraMap_injective K L
   -- needed by `negVariableChange_ne_one` at the end; the `Aut(Eᴸ) = {±1}` step supplies its own
   have : (E.baseChange L).IsElliptic := inferInstanceAs ((E.map (algebraMap K L)).IsElliptic)
   -- transfer the hypothetical `K`-isomorphism to the twist by `θ`
@@ -703,7 +690,7 @@ theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : 
     rw [ha, mul_smul, hC₁, E.inv_quadraticTwistOfTraceNormVariableChange_smul hθ hσ, hψiso]
   have haC : a * C₁ = ψ := by rw [ha, mul_assoc, inv_mul_cancel, mul_one]
   have hamap : a.map (σ : L →+* L) = a := by
-    rcases E.eq_one_or_eq_negVariableChange_baseChange hj₀ hj₁₇₂₈ haut with hcase | hcase
+    rcases E.eq_one_or_eq_negVariableChange_baseChange hinj hj₀ hj₁₇₂₈ haut with hcase | hcase
     · rw [hcase]; exact VariableChange.map_one _
     · rw [hcase]; exact E.negVariableChange_baseChange_map L (σ : L →ₐ[K] L)
   -- applying `σ` to `ψ = a · C₁` forces `[-1] = 1`
@@ -724,8 +711,8 @@ twist by `L` — and, by `not_exists_smul_quadraticTwist_eq`, those two alternat
 
 The mechanism: such forms are classified by `H¹(Gal(L/K), Aut Eᴸ) = Hom(ℤ/2, {±1})`, of order two,
 and the two cases below are the two cocycles. `Aut Eᴸ = {±1}` is where `j ∉ {0, 1728}` enters
-(`eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq`); for the excluded `j`
-the automorphism group is larger and there can be more forms. -/
+(`eq_one_or_eq_negVariableChange_baseChange`); for the excluded `j` the automorphism group is
+larger and there can be more forms. -/
 theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
     (E' : WeierstrassCurve K)
     (h : ∃ C : VariableChange L, C • E'.baseChange L = E.baseChange L) :
@@ -743,7 +730,7 @@ theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj�
   have hρinv : ρ⁻¹ • E.baseChange L = E'.baseChange L := by rw [← hρ, inv_smul_smul]
   have hb : (ρ.map (σ : L →+* L) * ρ⁻¹) • E.baseChange L = E.baseChange L := by
     rw [mul_smul, hρinv, hσρ]
-  rcases E.eq_one_or_eq_negVariableChange_baseChange hj₀ hj₁₇₂₈ hb with hbcase | hbcase
+  rcases E.eq_one_or_eq_negVariableChange_baseChange hinj hj₀ hj₁₇₂₈ hb with hbcase | hbcase
   · -- trivial cocycle: `ρ` is `σ`-invariant, so it descends and `E' ≅ E` over `K`
     left
     obtain ⟨ρK, hρK⟩ :=

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -644,28 +644,23 @@ section Classification
 
 variable [E.IsElliptic]
 
-omit [Algebra.IsSeparable K L] in
-/-- **`Aut(Eᴸ) = {±1}` when `j(E) ∉ {0, 1728}`**: an `L`-change of variables fixing `Eᴸ` is either
-the identity or `[-1]`.
-
-This is the only place either classification theorem below uses its two `j`-hypotheses, which is
-what their docstrings claim; naming the step is what makes that claim checkable. The hypotheses
-enter through `c₄ ≠ 0` and `c₆ ≠ 0` for the base change, which are exactly `j ≠ 0` and
-`j ≠ 1728`. At those two values the automorphism group can be strictly larger. -/
+omit [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L] in
+/-- **`Aut(Eᴸ) = {±1}` when `j(E) ∉ {0, 1728}`**: an `L`-change of variables fixing the base
+change `Eᴸ` is either the identity or `[-1]`. -/
 private theorem eq_one_or_eq_negVariableChange_baseChange (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
     {D : VariableChange L} (hD : D • E.baseChange L = E.baseChange L) :
     D = 1 ∨ D = (E.baseChange L).negVariableChange := by
   have hinj := FaithfulSMul.algebraMap_injective K L
   -- `baseChange` is `map (algebraMap K L)`, whose `IsElliptic` instance Mathlib registers
   have : (E.baseChange L).IsElliptic := inferInstanceAs ((E.map (algebraMap K L)).IsElliptic)
-  exact (E.baseChange L).eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq
-    (E.baseChange_c₄_ne_zero hinj (E.j_eq_zero_iff.not.mp hj₀))
-    (E.baseChange_c₆_ne_zero hinj (E.j_eq_1728_iff.not.mp hj₁₇₂₈)) hD
+  have hj : (E.baseChange L).j = algebraMap K L E.j := by simp only [baseChange, map_j]
+  refine (E.baseChange L).eq_one_or_eq_negVariableChange_of_smul_eq ?_ ?_ hD
+  · rw [hj]; exact fun h ↦ hj₀ (hinj (by rw [h, map_zero]))
+  · rw [hj]; exact fun h ↦ hj₁₇₂₈ (hinj (by rw [h, map_ofNat]))
 
 omit [E.IsElliptic] in
 /-- The inverse of the trace–norm change of variables carries `Eᴸ` back to the base change of the
-twist by `θ`. Both classification theorems need this reading of
-`quadraticTwistOfTraceNormVariableChange_smul_baseChange`. Ellipticity is not needed. -/
+quadratic twist by `θ`. -/
 private theorem inv_quadraticTwistOfTraceNormVariableChange_smul {θ : L}
     (hθ : θ ∉ Set.range (algebraMap K L)) {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) :
     (E.quadraticTwistOfTraceNormVariableChange hθ hσ)⁻¹ • E.baseChange L
@@ -689,7 +684,6 @@ theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : 
   obtain ⟨σ, hσ⟩ := Algebra.IsQuadraticExtension.exists_algEquiv_ne_one K L
   obtain ⟨θ, hθ⟩ := Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L
   set C₁ := E.quadraticTwistOfTraceNormVariableChange hθ hσ with hC₁
-  have hiso := E.quadraticTwistOfTraceNormVariableChange_smul_baseChange hθ hσ
   have hcoc := E.map_quadraticTwistOfTraceNormVariableChange hθ hσ
   obtain ⟨C₀, hC₀⟩ := E.exists_smul_quadraticTwist_eq hθ
   -- needed by `negVariableChange_ne_one` at the end; the `Aut(Eᴸ) = {±1}` step supplies its own
@@ -741,7 +735,6 @@ theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj�
   obtain ⟨σ, hσ⟩ := Algebra.IsQuadraticExtension.exists_algEquiv_ne_one K L
   obtain ⟨θ, hθ⟩ := Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L
   set C₁ := E.quadraticTwistOfTraceNormVariableChange hθ hσ with hC₁
-  have hiso := E.quadraticTwistOfTraceNormVariableChange_smul_baseChange hθ hσ
   have hcoc := E.map_quadraticTwistOfTraceNormVariableChange hθ hσ
   have hinj := FaithfulSMul.algebraMap_injective K L
   -- the Galois conjugate of `ρ` is again an isomorphism `E'ᴸ ≅ Eᴸ`, so `σρ · ρ⁻¹` fixes `Eᴸ`


### PR DESCRIPTION
The two classification theorems in `QuadraticTwist.lean` opened with the same ten lines of setup,
character for character — down to the same inline comment — and both then re-derived the same
`Aut(Eᴸ) = {±1}` dichotomy by hand. This shares that step, as a base-change lemma in the `Aut`
layer where it belongs. No statement changes to any existing declaration.

## The duplication

`not_exists_smul_quadraticTwist_eq` (49 lines) and `exists_smul_eq_or_exists_smul_eq_quadraticTwist`
(58 lines) each began:

```lean
  obtain ⟨σ, hσ⟩ := Algebra.IsQuadraticExtension.exists_algEquiv_ne_one K L
  obtain ⟨θ, hθ⟩ := Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L
  set C₁ := E.quadraticTwistOfTraceNormVariableChange hθ hσ with hC₁
  have hiso := …; have hcoc := …; have hinj := FaithfulSMul.algebraMap_injective K L
  -- `baseChange` is `map (algebraMap K L)`, whose `IsElliptic` instance Mathlib registers
  have : (E.baseChange L).IsElliptic := inferInstanceAs ((E.map (algebraMap K L)).IsElliptic)
  have hc4L : (E.baseChange L).c₄ ≠ 0 := E.baseChange_c₄_ne_zero hinj (E.j_eq_zero_iff.not.mp hj₀)
  have hc6L : (E.baseChange L).c₆ ≠ 0 := E.baseChange_c₆_ne_zero hinj (…hj₁₇₂₈)
```

and each later wrote out the same `hC1inv` block and the same
`eq_one_or_eq_negVariableChange_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq hc4L hc6L _` call.

## The shared step, in `Aut.lean`

```lean
omit [IsDomain A] in
variable {B : Type*} [CommRing B] [IsDomain B] in
theorem eq_one_or_eq_negVariableChange_map [E.IsElliptic] {f : A →+* B}
    (hf : Function.Injective f) (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : E.j ≠ 1728)
    {D : VariableChange B} (hD : D • E.map f = E.map f) :
    D = 1 ∨ D = (E.map f).negVariableChange
```

It sits next to `eq_one_or_eq_negVariableChange_of_smul_eq`, whose base-change form it is, and it
is proved *from* that theorem: `j` of a base change is the image of `j` (Mathlib's `map_j`), so an
injective `algebraMap` carries both `≠ 0` and `≠ 1728` across. The original code instead went
around through `c₄`/`c₆`; going through the `j`-level lemma is shorter and is the API that already
existed.

Three hypotheses turn out not to be needed, and the signature records it: the source ring needs no
`IsDomain` (only the target does); nothing quadratic or separable is involved — which is precisely
why this does not belong in `QuadraticTwist.lean`; and it is not about base change along an
algebra at all, but about the image under any injective ring map, `E.baseChange B` being
`E.map (algebraMap A B)`.

`QuadraticTwist.lean` keeps one genuinely local helper, the inverse-twist rewrite both proofs
used:

```lean
private theorem inv_quadraticTwistOfTraceNormVariableChange_smul {θ : L}
    (hθ : θ ∉ Set.range (algebraMap K L)) {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) :
    (E.quadraticTwistOfTraceNormVariableChange hθ hσ)⁻¹ • E.baseChange L
      = (E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)).baseChange L
```

## It makes an existing claim checkable

Both theorems' docstrings already asserted that the `j`-hypotheses are used for exactly one thing —
`not_exists_smul_quadraticTwist_eq` says:

> Where the hypotheses enter: the only use of them is to get `Aut(Eᴸ) = {±1}` …

Nothing in the file let a reader verify that. Now `hj₀` and `hj₁₇₂₈` are each consumed at exactly
one place per proof — the call to `eq_one_or_eq_negVariableChange_map` — and the claim is
read off the code. Both docstrings are updated to name the lemma actually used, since the route
they described (`…_of_c₄_ne_zero_of_c₆_ne_zero_of_smul_eq`) is no longer the one taken.

One instance deliberately **stays** in `not_exists_smul_quadraticTwist_eq`: it still needs
`(E.baseChange L).IsElliptic` for its closing `negVariableChange_ne_one`, a different consumer from
the `Aut` step. That now carries a comment saying so, rather than one `have` silently serving two
unrelated purposes.

## Lengths

| Declaration | Before | After |
|---|---|---|
| `exists_smul_eq_or_exists_smul_eq_quadraticTwist` | 58 | 47 |
| `not_exists_smul_quadraticTwist_eq` | 49 | 41 |
| `eq_one_or_eq_negVariableChange_map` (new, `Aut.lean`) | — | 15 |
| `inv_quadraticTwistOfTraceNormVariableChange_smul` (new, private) | — | 7 |

Both classification theorems come under the repository's 50-line cap; the 58-line one was over it.
Both remain above the 30-line threshold that flags decomposition, and finishing that is a separate
topic: each still contains a two-branch cocycle case split that would be the natural next
extraction. Doing it here would mix a decomposition into a de-duplication.

The extraction also made `have hiso := E.quadraticTwistOfTraceNormVariableChange_smul_baseChange hθ hσ`
dead in **both** proofs, so both are deleted. Otherwise every surviving tactic line is carried over
unchanged.

## Scope

Improvement work on existing code: no existing declaration changes its statement, nothing is
renamed or removed, and no new mathematics — the base-change dichotomy was already being proved
inline, twice. It adds one public declaration to `Aut.lean`, listed in that file's Main statements;
that is where the reviewer's placement rubric put it, and it is the base-change form of the theorem
immediately above it. `#2850` also touches `QuadraticTwist.lean`, but only line 365 — nowhere near
this diff.

## Review

Four private rounds before this PR opened, ten findings, all taken rather than contested:

* Round 1 — `reuse` (**block**): the helper re-derived the `c₄`/`c₆` path when `Aut.lean` already
  exposes `eq_one_or_eq_negVariableChange_of_smul_eq` at the `j` level. `generality`: it also
  inherited `[Algebra.IsQuadraticExtension K L]` without needing it. `documentation`: both new
  docstrings carried proof-organisation commentary. `proof-quality`: two now-dead `hiso` bindings.
* Round 2 — `placement`: the helper is generic `Aut` API, not quadratic-twist material, so it moved
  to `Aut.lean`. `api-design` and `documentation`: after the proof route changed, both public
  docstrings still named the old `c₄`/`c₆` lemma — stale, and now corrected.
* Round 3 — `documentation`: the two classification docstrings described proof mechanics ("the only
  use", "this proof", "the two cases below"); reframed at result level.
* Round 4 — `generality`: the new lemma was stated for an algebra base change though the argument
  is about any injective ring map; restated as `…_map` over `{f : A →+* B}`.

## Gates

* `lake build` — whole project, **7805 jobs**, clean, no warnings (the lakefile sets
  `warningAsError = true` with the Mathlib linter set, so this is the lint gate too).
* `scripts/lint-env.sh` — **LINT-ENV: PASS**, no new violations.
* `lake exe axioms` — **44677** declarations, all within `[propext, Classical.choice, Quot.sound]`.
* `lake exe module-system` — **2145/2145** modules opt in.

`Aut.lean` is 250 lines and `QuadraticTwist.lean` 971, both against the 1500-line limit for an
existing file; no line exceeds 100 codepoints.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"quadtwist-share-aut-step"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
