### PR TITLE
feat(ModularForms): the vanishing order of a slash translate

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
@@ -184,6 +184,7 @@ variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ �
 transports the order from the translated point back to the original one. No invariance is
 needed — the slash factor is analytic and nonvanishing, so only the composition with the
 Möbius action moves the order. -/
+@[simp]
 lemma orderOfVanishingAt_slash (g : ℍ → ℂ) {γ : GL (Fin 2) ℝ} (hdet : 0 < γ.val.det) (z : ℍ) :
     orderOfVanishingAt (g ∣[k] γ) z = orderOfVanishingAt g (γ • z) := by
   have hden_ne : ((γ 1 0 : ℂ) * (z : ℂ) + (γ 1 1 : ℂ)) ≠ 0 := by

--- a/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
@@ -14,9 +14,10 @@ public import TauCeti.Analysis.Complex.UpperHalfPlane.Manifold
 `TauCeti.orderOfVanishingAt f z` is the order of vanishing of `f : ℍ → ℂ` at `z ∈ ℍ`, read
 as the meromorphic order of `f ∘ ofComplex` at `z`. For a nonzero holomorphic function it
 detects vanishing (`orderOfVanishingAt_eq_zero_iff`), and it transports along the slash
-action of any positive-determinant matrix (`orderOfVanishingAt_slash`), so for a
-slash-invariant form it is constant along the group action (`orderOfVanishingAt_smul`,
-a corollary) — the interior half of the order dictionary feeding the valence formula. The order at the cusps (`ℚ`-normalized at
+action of any positive-determinant matrix (`orderOfVanishingAt_slash`); for a
+slash-invariant form it is therefore constant along the group action
+(`orderOfVanishingAt_smul`, a corollary) — the interior half of the order dictionary
+feeding the valence formula. The order at the cusps (`ℚ`-normalized at
 irregular cusps in odd weight) belongs to the general-level layer and is not defined here.
 
 ## Main declarations

--- a/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
@@ -13,9 +13,10 @@ public import TauCeti.Analysis.Complex.UpperHalfPlane.Manifold
 
 `TauCeti.orderOfVanishingAt f z` is the order of vanishing of `f : ℍ → ℂ` at `z ∈ ℍ`, read
 as the meromorphic order of `f ∘ ofComplex` at `z`. For a nonzero holomorphic function it
-detects vanishing (`orderOfVanishingAt_eq_zero_iff`), and for a slash-invariant form it is
-constant along the group action (`orderOfVanishingAt_smul`) — the interior half of the
-order dictionary feeding the valence formula. The order at the cusps (`ℚ`-normalized at
+detects vanishing (`orderOfVanishingAt_eq_zero_iff`), and it transports along the slash
+action of any positive-determinant matrix (`orderOfVanishingAt_slash`), so for a
+slash-invariant form it is constant along the group action (`orderOfVanishingAt_smul`,
+a corollary) — the interior half of the order dictionary feeding the valence formula. The order at the cusps (`ℚ`-normalized at
 irregular cusps in odd weight) belongs to the general-level layer and is not defined here.
 
 ## Main declarations
@@ -27,7 +28,10 @@ irregular cusps in odd weight) belongs to the general-level layer and is not def
   `Finset.prod` and power versions.
 * `TauCeti.orderOfVanishingAt_pos_iff`: for a nonzero holomorphic function, positive
   order characterizes the zeros.
-* `TauCeti.orderOfVanishingAt_smul`: invariance along the action of the group.
+* `TauCeti.orderOfVanishingAt_slash`: the order of a slash translate at `z` is the order at
+  `γ • z`, for any positive-determinant `γ`.
+* `TauCeti.orderOfVanishingAt_smul`: invariance along the action of the group, a corollary
+  of the slash statement.
 * `TauCeti.orderOfVanishingAt_eq_of_coe_eq_add`: invariance under the period translation, for
   a periodic function.
 
@@ -180,28 +184,29 @@ lemma orderOfVanishingAt_pow (hf : MDiff f) (n : ℕ) (z : ℍ) :
 
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 
-/-- The vanishing order of a slash translate: slashing by a matrix of positive determinant
-transports the order from the translated point back to the original one. No invariance is
-needed — the slash factor is analytic and nonvanishing, so only the composition with the
-Möbius action moves the order. -/
+/-- The vanishing order of a slash translate: the order of `g ∣[k] γ` at `z` is the order of
+`g` at `γ • z`. Positive determinant makes the slash's `σ γ` twist trivial and keeps the
+Möbius action on `ℍ`; no invariance of `g` under `γ` is assumed. -/
 @[simp]
-lemma orderOfVanishingAt_slash (g : ℍ → ℂ) {γ : GL (Fin 2) ℝ} (hdet : 0 < γ.val.det) (z : ℍ) :
+lemma orderOfVanishingAt_slash (g : ℍ → ℂ) {γ : GL (Fin 2) ℝ}
+    (hdet : 0 < γ.val.det) (z : ℍ) :
     orderOfVanishingAt (g ∣[k] γ) z = orderOfVanishingAt g (γ • z) := by
-  have hden_ne : ((γ 1 0 : ℂ) * (z : ℂ) + (γ 1 1 : ℂ)) ≠ 0 := by
-    simpa [denom] using denom_ne_zero γ z
+  have hden_ne : denom γ (z : ℂ) ≠ 0 := denom_ne_zero γ z
   have hdet_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ≠ 0 := by
     exact_mod_cast (abs_pos.mpr (γ.det : ℝˣ).ne_zero).ne'
   have hcongr : ((g ∣[k] γ) ∘ ofComplex) =ᶠ[nhds (z : ℂ)]
-      (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1) *
-        ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ (-k)) * (fun w : ℂ ↦ g (γ • ofComplex w)) := by
+      (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1) * denom γ w ^ (-k)) *
+        (fun w : ℂ ↦ g (γ • ofComplex w)) := by
     filter_upwards [isOpen_upperHalfPlaneSet.mem_nhds z.im_pos] with w hw
-    simp [Function.comp_apply, ModularForm.slash_apply, σ, hdet, denom,
-      ofComplex_apply_of_im_pos hw, mul_comm, mul_assoc, mul_left_comm]
+    rw [Function.comp_apply, ModularForm.slash_apply_of_det_pos k hdet g (ofComplex w),
+      Pi.mul_apply, ofComplex_apply_of_im_pos hw]
+    ring
+  -- `denom` is unfolded only here, where `fun_prop` needs to see the linear form in `w`.
   have h_an : AnalyticAt ℂ (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1) *
-      ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ (-k)) (z : ℂ) :=
-    AnalyticAt.mul analyticAt_const (AnalyticAt.zpow (by fun_prop) hden_ne)
-  have h_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1) *
-      ((γ 1 0 : ℂ) * (z : ℂ) + (γ 1 1 : ℂ)) ^ (-k) ≠ 0 :=
+      denom γ w ^ (-k)) (z : ℂ) :=
+    AnalyticAt.mul analyticAt_const
+      (AnalyticAt.zpow (by unfold denom; fun_prop) hden_ne)
+  have h_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1) * denom γ (z : ℂ) ^ (-k) ≠ 0 :=
     mul_ne_zero (zpow_ne_zero _ hdet_ne) (zpow_ne_zero _ hden_ne)
   unfold orderOfVanishingAt
   rw [meromorphicOrderAt_congr (hcongr.filter_mono nhdsWithin_le_nhds),
@@ -215,7 +220,8 @@ positive-determinant element of the group. -/
 lemma orderOfVanishingAt_smul [SlashInvariantFormClass F Γ k] (f : F) {γ}
     (hγ : γ ∈ Γ) (hdet : 0 < γ.val.det) (z : ℍ) :
     orderOfVanishingAt f (γ • z) = orderOfVanishingAt f z := by
-  rw [← orderOfVanishingAt_slash (⇑f) hdet z, SlashInvariantFormClass.slash_action_eq f γ hγ]
+  rw [← orderOfVanishingAt_slash (k := k) (⇑f) hdet z,
+    SlashInvariantFormClass.slash_action_eq f γ hγ]
 
 /-- The meromorphic order of a `c`-periodic function agrees at `z + c` and at `z`. Only a proof
 helper for `orderOfVanishingAt_eq_of_coe_eq_add`: it is a fact about periodic functions on `ℂ`,

--- a/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
@@ -180,6 +180,33 @@ lemma orderOfVanishingAt_pow (hf : MDiff f) (n : ℕ) (z : ℍ) :
 
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 
+/-- The vanishing order of a slash translate: slashing by a matrix of positive determinant
+transports the order from the translated point back to the original one. No invariance is
+needed — the slash factor is analytic and nonvanishing, so only the composition with the
+Möbius action moves the order. -/
+lemma orderOfVanishingAt_slash (g : ℍ → ℂ) {γ : GL (Fin 2) ℝ} (hdet : 0 < γ.val.det) (z : ℍ) :
+    orderOfVanishingAt (g ∣[k] γ) z = orderOfVanishingAt g (γ • z) := by
+  have hden_ne : ((γ 1 0 : ℂ) * (z : ℂ) + (γ 1 1 : ℂ)) ≠ 0 := by
+    simpa [denom] using denom_ne_zero γ z
+  have hdet_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ≠ 0 := by
+    exact_mod_cast (abs_pos.mpr (γ.det : ℝˣ).ne_zero).ne'
+  have hcongr : ((g ∣[k] γ) ∘ ofComplex) =ᶠ[nhds (z : ℂ)]
+      (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1) *
+        ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ (-k)) * (fun w : ℂ ↦ g (γ • ofComplex w)) := by
+    filter_upwards [isOpen_upperHalfPlaneSet.mem_nhds z.im_pos] with w hw
+    simp [Function.comp_apply, ModularForm.slash_apply, σ, hdet, denom,
+      ofComplex_apply_of_im_pos hw, mul_comm, mul_assoc, mul_left_comm]
+  have h_an : AnalyticAt ℂ (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1) *
+      ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ (-k)) (z : ℂ) :=
+    AnalyticAt.mul analyticAt_const (AnalyticAt.zpow (by fun_prop) hden_ne)
+  have h_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1) *
+      ((γ 1 0 : ℂ) * (z : ℂ) + (γ 1 1 : ℂ)) ^ (-k) ≠ 0 :=
+    mul_ne_zero (zpow_ne_zero _ hdet_ne) (zpow_ne_zero _ hden_ne)
+  unfold orderOfVanishingAt
+  rw [meromorphicOrderAt_congr (hcongr.filter_mono nhdsWithin_le_nhds),
+    meromorphicOrderAt_mul_of_ne_zero h_an h_ne, meromorphicOrderAt_comp_smul hdet,
+    Function.comp_def]
+
 /-- The vanishing order of a slash-invariant form is constant along the action of any
 positive-determinant element of the group. -/
 -- Not a `simp` lemma: the subgroup `Γ` occurs only in the hypotheses, so `simpNF` rejects
@@ -187,27 +214,7 @@ positive-determinant element of the group. -/
 lemma orderOfVanishingAt_smul [SlashInvariantFormClass F Γ k] (f : F) {γ}
     (hγ : γ ∈ Γ) (hdet : 0 < γ.val.det) (z : ℍ) :
     orderOfVanishingAt f (γ • z) = orderOfVanishingAt f z := by
-  have hdet_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ≠ 0 := by
-    exact_mod_cast (abs_pos.mpr (γ.det : ℝˣ).ne_zero).ne'
-  have hcongr : (fun w : ℂ ↦ f (γ • ofComplex w)) =ᶠ[nhds (z : ℂ)]
-      (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) *
-        ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) * (⇑f ∘ ofComplex) := by
-    filter_upwards [isOpen_upperHalfPlaneSet.mem_nhds z.im_pos] with w hw
-    rw [Pi.mul_apply, Function.comp_apply, ofComplex_apply_of_im_pos hw]
-    simpa [denom, mul_assoc] using SlashInvariantForm.slash_action_eqn_of_det_pos f hγ hdet ⟨w, hw⟩
-  have h_an : AnalyticAt ℂ (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) *
-      ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) (z : ℂ) := by
-    refine AnalyticAt.mul analyticAt_const (AnalyticAt.zpow (by fun_prop) ?_)
-    simpa [denom] using denom_ne_zero γ z
-  have h_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) *
-      ((γ 1 0 : ℂ) * (z : ℂ) + (γ 1 1 : ℂ)) ^ k ≠ 0 :=
-    mul_ne_zero (zpow_ne_zero _ hdet_ne)
-      (zpow_ne_zero _ (by simpa [denom] using denom_ne_zero γ z))
-  unfold orderOfVanishingAt
-  conv_lhs => rw [Function.comp_def]
-  rw [← meromorphicOrderAt_comp_smul hdet,
-    meromorphicOrderAt_congr (hcongr.filter_mono nhdsWithin_le_nhds),
-    meromorphicOrderAt_mul_of_ne_zero h_an h_ne]
+  rw [← orderOfVanishingAt_slash (⇑f) hdet z, SlashInvariantFormClass.slash_action_eq f γ hγ]
 
 /-- The meromorphic order of a `c`-periodic function agrees at `z + c` and at `z`. Only a proof
 helper for `orderOfVanishingAt_eq_of_coe_eq_add`: it is a fact about periodic functions on `ℂ`,


### PR DESCRIPTION
Roadmap: ModularForms
<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-formula/order-of-slash"}-->

## Summary

The vanishing order under the slash action, for **any** matrix of positive determinant —
no invariance hypothesis:

```
orderOfVanishingAt (g ∣[k] γ) z = orderOfVanishingAt g (γ • z)
```

The slash factor `|det γ|^(k-1) · denom γ z^(-k)` is analytic and nonvanishing at every point
of `ℍ`, so it cannot move the order; only the composition with the Möbius action does, which
is exactly `meromorphicOrderAt_comp_smul`.

This strengthens the file rather than adding to it: the existing
`orderOfVanishingAt_smul` — invariance of the order along elements *of* the group — is now a
two-line corollary (apply the new lemma, then rewrite by slash-invariance), down from about
twenty lines of duplicated analytic bookkeeping.

The motivation is the general-level valence formula (`README.md` § "Layer 1 — General level,
by the coset norm"): the coset factors of `ModularForm.norm` are slash translates by elements
*outside* the subgroup, which the Γ-membership version could not reach. With #3192 (orders
distribute over the norm's coset product) this gives the geometric form the assembly needs —
the order of the norm at a point as a sum of orders of the form at the translated points.

## Provenance

Provenance: none as a port — this is a generalisation of a declaration already in this
repository (`TauCeti.orderOfVanishingAt_smul`), proved from Mathlib's
`meromorphicOrderAt_comp_smul`, `ModularForm.slash_apply` and `σ` (the identity for positive
determinant). AINTLIB's valence development uses the invariance form only, so there is no
upstream statement to credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
