### PR TITLE
feat(ModularForms): vanishing and boundedness at a cusp are closed under finite sums

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.ModularForms.BoundedAtCusp
+
+/-!
+# Vanishing and boundedness at a cusp are closed under finite sums
+
+Mathlib's `OnePoint.IsZeroAt` and `OnePoint.IsBoundedAt` are closed under binary sums
+(`OnePoint.IsZeroAt.add`, `OnePoint.IsBoundedAt.add`), but the zero function and a
+`Finset.sum` are not recorded. This file adds them.
+
+The gap matters for the Hecke operators, which are finite sums of slashes: a proof that such
+an operator preserves vanishing at the cusps is an induction over the summands, and without
+`OnePoint.IsZeroAt.sum` each call site has to rerun that induction by hand.
+
+## Main declarations
+
+* `OnePoint.IsZeroAt.zero`, `OnePoint.IsBoundedAt.zero`: the zero function vanishes, and is
+  bounded, at every point of `OnePoint ℝ`.
+* `OnePoint.IsZeroAt.sum`, `OnePoint.IsBoundedAt.sum`: a finite sum of functions vanishing
+  (resp. bounded) at `c` vanishes (resp. is bounded) at `c`.
+-/
+
+public section
+
+open UpperHalfPlane
+
+open scoped ModularForm
+
+namespace OnePoint
+
+variable {c : OnePoint ℝ} {k : ℤ} {ι : Type*} {s : Finset ι} {F : ι → ℍ → ℂ}
+
+/-- The zero function vanishes at every point of `OnePoint ℝ`. -/
+@[simp]
+lemma IsZeroAt.zero : IsZeroAt c (0 : ℍ → ℂ) k := fun _ _ ↦ by
+  rw [SlashAction.zero_slash, isZeroAtImInfty_iff]
+  exact fun ε hε ↦ ⟨0, fun _ _ ↦ by simpa using hε.le⟩
+
+/-- The zero function is bounded at every point of `OnePoint ℝ`. -/
+@[simp]
+lemma IsBoundedAt.zero : IsBoundedAt c (0 : ℍ → ℂ) k := fun _ _ ↦ by
+  simpa only [SlashAction.zero_slash] using zero_form_isBoundedAtImInfty
+
+/-- A finite sum of functions vanishing at `c` vanishes at `c`. -/
+lemma IsZeroAt.sum (h : ∀ i ∈ s, IsZeroAt c (F i) k) : IsZeroAt c (∑ i ∈ s, F i) k :=
+  Finset.sum_induction F (fun g ↦ IsZeroAt c g k) (fun _ _ ↦ IsZeroAt.add) IsZeroAt.zero h
+
+/-- A finite sum of functions bounded at `c` is bounded at `c`. -/
+lemma IsBoundedAt.sum (h : ∀ i ∈ s, IsBoundedAt c (F i) k) : IsBoundedAt c (∑ i ∈ s, F i) k :=
+  Finset.sum_induction F (fun g ↦ IsBoundedAt c g k) (fun _ _ ↦ IsBoundedAt.add)
+    IsBoundedAt.zero h
+
+end OnePoint
+
+end

--- a/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
@@ -23,6 +23,17 @@ an operator preserves vanishing at the cusps is an induction over the summands, 
   bounded, at every point of `OnePoint ℝ`.
 * `OnePoint.IsZeroAt.sum`, `OnePoint.IsBoundedAt.sum`: a finite sum of functions vanishing
   (resp. bounded) at `c` vanishes (resp. is bounded) at `c`.
+
+## Provenance
+
+No code is transcribed here, but the gap these lemmas fill was identified from the AINTLIB
+`LeanModularForms` project (Chris Birkbeck, Apache-2.0):
+`LeanModularForms/HeckeRIngs/GL2/AdjointTheory.lean` lines 62-71, at commit
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`. Its `heckeT_p_ut_zero_at_cusps` open-codes this
+induction with `Finset.sum_induction`, and obtains the base case by constructing a zero
+`CuspForm` purely to invoke `zero_at_cusps'` — because `IsZeroAt c 0 k` is not stated anywhere.
+The statements below are about Mathlib's `OnePoint.IsZeroAt`/`IsBoundedAt` and are given at
+arbitrary `c`, `k` and index type.
 -/
 
 public section

--- a/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
@@ -19,6 +19,8 @@ an operator preserves vanishing at the cusps is an induction over the summands, 
 
 ## Main declarations
 
+* `UpperHalfPlane.isZeroAtImInfty_zero`: the zero analogue of Mathlib's
+  `zero_form_isBoundedAtImInfty`, which is absent upstream.
 * `OnePoint.IsZeroAt.zero`, `OnePoint.IsBoundedAt.zero`: the zero function vanishes, and is
   bounded, at every point of `OnePoint ℝ`.
 * `OnePoint.IsZeroAt.sum`, `OnePoint.IsBoundedAt.sum`: a finite sum of functions vanishing
@@ -42,6 +44,21 @@ open UpperHalfPlane
 
 open scoped ModularForm
 
+namespace UpperHalfPlane
+
+/-- **The zero function is zero at `im → ∞`.** Mathlib provides the bounded analogue,
+`zero_form_isBoundedAtImInfty`, but not this one, so every consumer has to reach past
+`IsZeroAtImInfty` to `Filter.zero_zeroAtFilter` itself. The unfolding is done once, here.
+
+`IsZeroAtImInfty` is a non-`@[expose]` wrapper for `ZeroAtFilter atImInfty`, so the `!` is
+required: plain `simpa using` cannot cross that boundary. This is the proof Mathlib gives for
+the same goal in `CuspForm.instZero`. -/
+@[simp]
+lemma isZeroAtImInfty_zero : IsZeroAtImInfty (0 : ℍ → ℂ) := by
+  simpa using! Filter.zero_zeroAtFilter _
+
+end UpperHalfPlane
+
 namespace OnePoint
 
 variable {c : OnePoint ℝ} {k : ℤ} {ι : Type*} {s : Finset ι} {F : ι → ℍ → ℂ}
@@ -50,10 +67,7 @@ variable {c : OnePoint ℝ} {k : ℤ} {ι : Type*} {s : Finset ι} {F : ι → �
 @[simp]
 lemma IsZeroAt.zero : IsZeroAt c (0 : ℍ → ℂ) k := fun _ _ ↦ by
   rw [SlashAction.zero_slash]
-  -- `IsZeroAtImInfty` is a non-`@[expose]` wrapper for `ZeroAtFilter atImInfty`, so the `!` is
-  -- required: plain `simpa using` cannot cross that boundary. This is the same proof Mathlib
-  -- gives for the same goal in `CuspForm.instZero` (`NumberTheory/ModularForms/Basic.lean`).
-  simpa using! Filter.zero_zeroAtFilter _
+  exact isZeroAtImInfty_zero
 
 /-- The zero function is bounded at every point of `OnePoint ℝ`. -/
 @[simp]

--- a/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
@@ -50,6 +50,9 @@ variable {c : OnePoint ℝ} {k : ℤ} {ι : Type*} {s : Finset ι} {F : ι → �
 @[simp]
 lemma IsZeroAt.zero : IsZeroAt c (0 : ℍ → ℂ) k := fun _ _ ↦ by
   rw [SlashAction.zero_slash]
+  -- `IsZeroAtImInfty` is a non-`@[expose]` wrapper for `ZeroAtFilter atImInfty`, so the `!` is
+  -- required: plain `simpa using` cannot cross that boundary. This is the same proof Mathlib
+  -- gives for the same goal in `CuspForm.instZero` (`NumberTheory/ModularForms/Basic.lean`).
   simpa using! Filter.zero_zeroAtFilter _
 
 /-- The zero function is bounded at every point of `OnePoint ℝ`. -/

--- a/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
@@ -49,8 +49,8 @@ variable {c : OnePoint ℝ} {k : ℤ} {ι : Type*} {s : Finset ι} {F : ι → �
 /-- The zero function vanishes at every point of `OnePoint ℝ`. -/
 @[simp]
 lemma IsZeroAt.zero : IsZeroAt c (0 : ℍ → ℂ) k := fun _ _ ↦ by
-  rw [SlashAction.zero_slash, isZeroAtImInfty_iff]
-  exact fun ε hε ↦ ⟨0, fun _ _ ↦ by simpa using hε.le⟩
+  rw [SlashAction.zero_slash]
+  simpa using! Filter.zero_zeroAtFilter _
 
 /-- The zero function is bounded at every point of `OnePoint ℝ`. -/
 @[simp]

--- a/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
@@ -46,15 +46,13 @@ open scoped ModularForm
 
 namespace UpperHalfPlane
 
-/-- **The zero function is zero at `im → ∞`.** Mathlib provides the bounded analogue,
-`zero_form_isBoundedAtImInfty`, but not this one, so every consumer has to reach past
-`IsZeroAtImInfty` to `Filter.zero_zeroAtFilter` itself. The unfolding is done once, here.
-
-`IsZeroAtImInfty` is a non-`@[expose]` wrapper for `ZeroAtFilter atImInfty`, so the `!` is
-required: plain `simpa using` cannot cross that boundary. This is the proof Mathlib gives for
-the same goal in `CuspForm.instZero`. -/
+/-- **The zero function is zero at `im → ∞`.** This is the missing analogue of Mathlib's
+`zero_form_isBoundedAtImInfty`, which covers only the bounded predicate. -/
 @[simp]
-lemma isZeroAtImInfty_zero : IsZeroAtImInfty (0 : ℍ → ℂ) := by
+lemma isZeroAtImInfty_zero {α : Type*} [Zero α] [TopologicalSpace α] :
+    IsZeroAtImInfty (0 : ℍ → α) := by
+  -- `IsZeroAtImInfty` is a non-`@[expose]` wrapper for `ZeroAtFilter atImInfty`; plain
+  -- `simpa using` cannot cross that boundary, as `CuspForm.instZero` also finds.
   simpa using! Filter.zero_zeroAtFilter _
 
 end UpperHalfPlane


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke/zero-at-cusp-sum"}-->

## Roadmap target

`TauCetiRoadmap/ModularForms/README.md`, **Layer 2, block (b) "The action on forms"** — `Tₙ`, `Tₚ`
as `ℂ`-linear endomorphisms "preserving `M_k(N,χ)` and `S_k(N,χ)`", with the warning at line 435:

> ⚠ The action must preserve cuspidality and the nebentypus; prove that, don't assume it.

This is a prerequisite for that proof, not the proof itself.

## What is added

```lean
@[simp] lemma OnePoint.IsZeroAt.zero    : IsZeroAt c (0 : ℍ → ℂ) k
@[simp] lemma OnePoint.IsBoundedAt.zero : IsBoundedAt c (0 : ℍ → ℂ) k

lemma OnePoint.IsZeroAt.sum    (h : ∀ i ∈ s, IsZeroAt c (F i) k)    : IsZeroAt c (∑ i ∈ s, F i) k
lemma OnePoint.IsBoundedAt.sum (h : ∀ i ∈ s, IsBoundedAt c (F i) k) : IsBoundedAt c (∑ i ∈ s, F i) k
```

## Why

Mathlib's `Mathlib/NumberTheory/ModularForms/BoundedAtCusp.lean` gives these predicates closure
under **binary** sums — `OnePoint.IsZeroAt.add`, `OnePoint.IsBoundedAt.add` — and nothing for the
zero function or a `Finset.sum`. Every Hecke operator is a finite sum of slashes, so "this
operator preserves vanishing at the cusps" is an induction over the summands, and without these
each call site reruns that induction by hand.

That is exactly what the source does. AINTLIB's cusp base case reads:

```lean
apply Finset.sum_induction _ (fun g ↦ c.IsZeroAt g k) (fun _ _ ha hb ↦ ha.add hb)
  ((0 : CuspForm ((Gamma1 N).map (mapGL ℝ)) k).zero_at_cusps' hc)
```

— it constructs a zero **cusp form** purely to obtain `IsZeroAt c 0 k`, because the direct
statement does not exist. With `IsZeroAt.sum` that whole block becomes one application.

## Scope, and what deliberately is *not* here

Only the four closure lemmas. In particular this PR does **not** port AINTLIB's
`PreservesCusps` layer, because reading it against the current pin shows most of it should not
be ported at all:

* `PreservesCusps` and its `one`/`mul`/`sub`/`smul` closure lemmas are subsumed by Mathlib's
  `ModularForm.cuspFormSubmodule` and `IsCuspForm`, whose `isCuspForm_iff` is literally the same
  condition; re-stating them would rebuild a submodule by hand.
* AINTLIB's `CuspForm.toModularForm'` duplicates Mathlib's `CuspForm.toModularFormₗ`, which is
  moreover a `ℂ`-linear map rather than a bare function.
* `preservesCusps_heckeT_p_all`, `_heckeT_ppow` and `_heckeT_n` all rest on `heckeT_p`, which
  this repository does not have yet.

The genuinely missing, genuinely reusable piece was the sum closure, so that is what this is.

## Note on the proof

`IsZeroAtImInfty` is not `@[expose]`, so its body is opaque here: `ZeroAtFilter atImInfty 0`
does not unify with `IsZeroAtImInfty 0`, and `(zeroAtImInftySubmodule ℂ).zero_mem` fails for the
same reason. The proof therefore goes through Mathlib's own wrapper `isZeroAtImInfty_iff`.

## Provenance

No code is transcribed. The gap was identified from the AINTLIB `LeanModularForms` project
([`LeanModularForms/HeckeRIngs/GL2/AdjointTheory.lean`](https://github.com/CBirkbeck/AINTLIB)
lines 62–71, commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck),
whose `heckeT_p_ut_zero_at_cusps` open-codes this induction. The statements here are about
Mathlib's `OnePoint.IsZeroAt`/`IsBoundedAt` and are stated at general `c`, `k` and index type.

Roadmap: ModularForms
