### PR TITLE
feat: make finite Hopf duals functorial

### DIFF
--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Basic.lean
@@ -56,6 +56,12 @@ abbrev ConvolutionDual (k : Type u) (H : Type v) [CommSemiring k] [AddCommMonoid
 
 namespace ConvolutionDual
 
+/-- The convolution dual of a finite-dimensional vector space is finite-dimensional. -/
+noncomputable instance instFiniteDimensional (k : Type u) (H : Type v) [Field k]
+    [AddCommGroup H] [Module k H] [FiniteDimensional k H] :
+    FiniteDimensional k (ConvolutionDual k H) :=
+  LinearEquiv.finiteDimensional (WithConv.linearEquiv k (Module.Dual k H)).symm
+
 section LinearAlgebra
 
 variable (k : Type u) (H : Type v) [Field k] [AddCommGroup H] [Module k H]

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Basic.lean
@@ -58,14 +58,15 @@ namespace ConvolutionDual
 
 /-- The convolution dual of a finite-dimensional vector space is finite-dimensional. -/
 noncomputable instance instFiniteDimensional (k : Type u) (H : Type v) [Field k]
-    [AddCommGroup H] [Module k H] [FiniteDimensional k H] :
-    FiniteDimensional k (ConvolutionDual k H) :=
-  LinearEquiv.finiteDimensional (WithConv.linearEquiv k (Module.Dual k H)).symm
+    [AddCommMonoid H] [Module k H] [Module.Finite k H] :
+    Module.Finite k (ConvolutionDual k H) := by
+  let _ : AddCommGroup H := Module.addCommMonoidToAddCommGroup k
+  exact LinearEquiv.finiteDimensional (WithConv.linearEquiv k (Module.Dual k H)).symm
 
 section LinearAlgebra
 
-variable (k : Type u) (H : Type v) [Field k] [AddCommGroup H] [Module k H]
-  [FiniteDimensional k H]
+variable (k : Type u) (H : Type v) [Field k] [AddCommMonoid H] [Module k H]
+  [Module.Finite k H]
 
 /-- Forget the convolution wrappers on both factors of a tensor of finite-dual elements. -/
 private noncomputable def tensorUnwrap :
@@ -75,21 +76,24 @@ private noncomputable def tensorUnwrap :
 
 /-- A tensor of finite-dual functionals is equivalently a functional on the tensor square. -/
 noncomputable def dualDistribEquiv :
-    ConvolutionDual k H ⊗[k] ConvolutionDual k H ≃ₗ[k] Module.Dual k (H ⊗[k] H) :=
-  (tensorUnwrap k H).trans (TensorProduct.dualDistribEquiv k H H)
+    ConvolutionDual k H ⊗[k] ConvolutionDual k H ≃ₗ[k] Module.Dual k (H ⊗[k] H) := by
+  letI : AddCommGroup H := Module.addCommMonoidToAddCommGroup k
+  exact (tensorUnwrap k H).trans (TensorProduct.dualDistribEquiv k H H)
 
 private theorem dualDistribEquiv_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
     dualDistribEquiv k H w z =
       TensorProduct.dualDistrib k H H ((tensorUnwrap k H) w) z :=
-  rfl
+  by
+    let _ : AddCommGroup H := Module.addCommMonoidToAddCommGroup k
+    rfl
 
 end LinearAlgebra
 
 section Coalgebra
 
-variable (k : Type u) (H : Type v) [Field k] [Ring H] [Algebra k H]
-  [FiniteDimensional k H]
+variable (k : Type u) (H : Type v) [Field k] [Semiring H] [Algebra k H]
+  [Module.Finite k H]
 
 /-- The comultiplication and counit on the finite dual, obtained by transposing multiplication
 and unit on the original algebra. -/
@@ -128,14 +132,17 @@ private theorem counit_apply' (phi : ConvolutionDual k H) :
 /-- Evaluate three finite-dual functionals on a right-associated triple tensor. -/
 private noncomputable def evalTripleEquiv :
     ConvolutionDual k H ⊗[k] (ConvolutionDual k H ⊗[k] ConvolutionDual k H) ≃ₗ[k]
-      Module.Dual k (H ⊗[k] (H ⊗[k] H)) :=
-  (TensorProduct.congr (WithConv.linearEquiv k _) (dualDistribEquiv k H)).trans
-    (TensorProduct.dualDistribEquiv k H (H ⊗[k] H))
+      Module.Dual k (H ⊗[k] (H ⊗[k] H)) := by
+  letI : AddCommGroup H := Module.addCommMonoidToAddCommGroup k
+  exact
+    (TensorProduct.congr (WithConv.linearEquiv k _) (dualDistribEquiv k H)).trans
+      (TensorProduct.dualDistribEquiv k H (H ⊗[k] H))
 
 private theorem evalTripleEquiv_tmul_tmul_apply
     (phi psi chi : ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H (phi ⊗ₜ[k] (psi ⊗ₜ[k] chi)) (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
       phi.ofConv x * (psi.ofConv y * chi.ofConv z) := by
+  let _ : AddCommGroup H := Module.addCommMonoidToAddCommGroup k
   simp [evalTripleEquiv, dualDistribEquiv, tensorUnwrap]
 
 private theorem evalTripleEquiv_tmul_apply
@@ -285,8 +292,8 @@ end Coalgebra
 
 section Bialgebra
 
-variable (k : Type u) (H : Type v) [Field k] [Ring H] [Bialgebra k H]
-  [FiniteDimensional k H]
+variable (k : Type u) (H : Type v) [Field k] [Semiring H] [Bialgebra k H]
+  [Module.Finite k H]
 
 /-- `dualDistribEquiv` packaged in the convolution algebra on functionals on the tensor square. -/
 private noncomputable def evalTensorConv :
@@ -360,8 +367,8 @@ end ConvolutionDual
 
 namespace ConvolutionDual
 
-variable (k : Type u) (H : Type v) [Field k] [CommRing H] [Algebra k H]
-  [FiniteDimensional k H]
+variable (k : Type u) (H : Type v) [Field k] [CommSemiring H] [Algebra k H]
+  [Module.Finite k H]
 
 private theorem dualDistribEquiv_comm_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y : H) :
@@ -401,8 +408,8 @@ namespace ConvolutionDual
 
 section HopfAlgebra
 
-variable (k : Type u) (H : Type v) [Field k] [Ring H] [HopfAlgebra k H]
-  [FiniteDimensional k H]
+variable (k : Type u) (H : Type v) [Field k] [Semiring H] [HopfAlgebra k H]
+  [Module.Finite k H]
 
 /-- The antipode operation on the finite dual, obtained by transposing the antipode of the
 original Hopf algebra. -/

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Basic.lean
@@ -56,17 +56,16 @@ abbrev ConvolutionDual (k : Type u) (H : Type v) [CommSemiring k] [AddCommMonoid
 
 namespace ConvolutionDual
 
-/-- The convolution dual of a finite-dimensional vector space is finite-dimensional. -/
-noncomputable instance instFinite (k : Type u) (H : Type v) [Field k]
-    [AddCommMonoid H] [Module k H] [Module.Finite k H] :
-    Module.Finite k (ConvolutionDual k H) := by
-  let _ : AddCommGroup H := Module.addCommMonoidToAddCommGroup k
-  exact LinearEquiv.finiteDimensional (WithConv.linearEquiv k (Module.Dual k H)).symm
+/-- The convolution wrapper of a finite module is finite. -/
+instance instFinite (k : Type u) (H : Type v) [CommSemiring k]
+    [AddCommMonoid H] [Module k H] [Module.Finite k (Module.Dual k H)] :
+    Module.Finite k (ConvolutionDual k H) :=
+  Module.Finite.equiv (WithConv.linearEquiv k (Module.Dual k H)).symm
 
 section LinearAlgebra
 
-variable (k : Type u) (H : Type v) [Field k] [AddCommMonoid H] [Module k H]
-  [Module.Finite k H]
+variable (k : Type u) (H : Type v) [Field k] [AddCommGroup H] [Module k H]
+  [FiniteDimensional k H]
 
 /-- Forget the convolution wrappers on both factors of a tensor of finite-dual elements. -/
 private noncomputable def tensorUnwrap :
@@ -76,24 +75,52 @@ private noncomputable def tensorUnwrap :
 
 /-- A tensor of finite-dual functionals is equivalently a functional on the tensor square. -/
 noncomputable def dualDistribEquiv :
-    ConvolutionDual k H ⊗[k] ConvolutionDual k H ≃ₗ[k] Module.Dual k (H ⊗[k] H) := by
-  letI : AddCommGroup H := Module.addCommMonoidToAddCommGroup k
-  exact (tensorUnwrap k H).trans (TensorProduct.dualDistribEquiv k H H)
+    ConvolutionDual k H ⊗[k] ConvolutionDual k H ≃ₗ[k] Module.Dual k (H ⊗[k] H) :=
+  (tensorUnwrap k H).trans (TensorProduct.dualDistribEquiv k H H)
 
 private theorem dualDistribEquiv_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
     dualDistribEquiv k H w z =
       TensorProduct.dualDistrib k H H ((tensorUnwrap k H) w) z :=
-  by
-    let _ : AddCommGroup H := Module.addCommMonoidToAddCommGroup k
-    rfl
+  rfl
+
+/-- A pure tensor of finite-dual functionals evaluates componentwise. -/
+@[simp, grind =]
+theorem dualDistribEquiv_tmul_apply (phi psi : ConvolutionDual k H) (x y : H) :
+    dualDistribEquiv k H (phi ⊗ₜ[k] psi) (x ⊗ₜ[k] y) =
+      phi.ofConv x * psi.ofConv y := by
+  simp [dualDistribEquiv, tensorUnwrap]
+
+/-- Precomposition on both dual factors corresponds to applying the original maps on both
+tensor factors. -/
+theorem dualDistribEquiv_map_apply {K : Type*} [AddCommGroup K] [Module k K]
+    [FiniteDimensional k K]
+    (f g : ConvolutionDual k K →ₗ[k] ConvolutionDual k H) (a b : H →ₗ[k] K)
+    (hf : ∀ phi x, (f phi).ofConv x = phi.ofConv (a x))
+    (hg : ∀ phi x, (g phi).ofConv x = phi.ofConv (b x))
+    (w : ConvolutionDual k K ⊗[k] ConvolutionDual k K) (z : H ⊗[k] H) :
+    dualDistribEquiv k H (TensorProduct.map f g w) z =
+      dualDistribEquiv k K w (TensorProduct.map a b z) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (fun x y ↦ x + y) hw₁ hw₂
+  | tmul phi psi =>
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | add z₁ z₂ hz₁ hz₂ =>
+          simpa only [map_add, LinearMap.add_apply] using
+            congrArg₂ (fun x y ↦ x + y) hz₁ hz₂
+      | tmul x y =>
+          rw [TensorProduct.map_tmul, TensorProduct.map_tmul,
+            dualDistribEquiv_tmul_apply, dualDistribEquiv_tmul_apply, hf, hg]
 
 end LinearAlgebra
 
 section Coalgebra
 
-variable (k : Type u) (H : Type v) [Field k] [Semiring H] [Algebra k H]
-  [Module.Finite k H]
+variable (k : Type u) (H : Type v) [Field k] [Ring H] [Algebra k H]
+  [FiniteDimensional k H]
 
 /-- The comultiplication and counit on the finite dual, obtained by transposing multiplication
 and unit on the original algebra. -/
@@ -112,13 +139,6 @@ private theorem dualDistribEquiv_comul' (phi : ConvolutionDual k H) :
   simpa only [psi, LinearMap.dualMap_apply', WithConv.linearEquiv_apply]
     using (dualDistribEquiv k H).apply_symm_apply psi
 
-/-- A pure tensor of finite-dual functionals evaluates componentwise. -/
-@[simp, grind =]
-theorem dualDistribEquiv_tmul_apply (phi psi : ConvolutionDual k H) (x y : H) :
-    dualDistribEquiv k H (phi ⊗ₜ[k] psi) (x ⊗ₜ[k] y) =
-      phi.ofConv x * psi.ofConv y := by
-  simp [dualDistribEquiv, tensorUnwrap]
-
 private theorem dualDistribEquiv_comul_apply' (phi : ConvolutionDual k H) (x y : H) :
     dualDistribEquiv k H (Coalgebra.comul phi) (x ⊗ₜ[k] y) =
       phi.ofConv (x * y) := by
@@ -132,17 +152,14 @@ private theorem counit_apply' (phi : ConvolutionDual k H) :
 /-- Evaluate three finite-dual functionals on a right-associated triple tensor. -/
 private noncomputable def evalTripleEquiv :
     ConvolutionDual k H ⊗[k] (ConvolutionDual k H ⊗[k] ConvolutionDual k H) ≃ₗ[k]
-      Module.Dual k (H ⊗[k] (H ⊗[k] H)) := by
-  letI : AddCommGroup H := Module.addCommMonoidToAddCommGroup k
-  exact
-    (TensorProduct.congr (WithConv.linearEquiv k _) (dualDistribEquiv k H)).trans
-      (TensorProduct.dualDistribEquiv k H (H ⊗[k] H))
+      Module.Dual k (H ⊗[k] (H ⊗[k] H)) :=
+  (TensorProduct.congr (WithConv.linearEquiv k _) (dualDistribEquiv k H)).trans
+    (TensorProduct.dualDistribEquiv k H (H ⊗[k] H))
 
 private theorem evalTripleEquiv_tmul_tmul_apply
     (phi psi chi : ConvolutionDual k H) (x y z : H) :
     evalTripleEquiv k H (phi ⊗ₜ[k] (psi ⊗ₜ[k] chi)) (x ⊗ₜ[k] (y ⊗ₜ[k] z)) =
       phi.ofConv x * (psi.ofConv y * chi.ofConv z) := by
-  let _ : AddCommGroup H := Module.addCommMonoidToAddCommGroup k
   simp [evalTripleEquiv, dualDistribEquiv, tensorUnwrap]
 
 private theorem evalTripleEquiv_tmul_apply
@@ -292,8 +309,8 @@ end Coalgebra
 
 section Bialgebra
 
-variable (k : Type u) (H : Type v) [Field k] [Semiring H] [Bialgebra k H]
-  [Module.Finite k H]
+variable (k : Type u) (H : Type v) [Field k] [Ring H] [Bialgebra k H]
+  [FiniteDimensional k H]
 
 /-- `dualDistribEquiv` packaged in the convolution algebra on functionals on the tensor square. -/
 private noncomputable def evalTensorConv :
@@ -361,14 +378,43 @@ noncomputable instance instBialgebra : Bialgebra k (ConvolutionDual k H) :=
       rw [hmul] at h
       simpa only [WithConv.toConv_ofConv] using h)
 
+/-- Multiplication in the finite dual evaluates by pairing with the original
+comultiplication. -/
+theorem ofConv_mul_apply
+    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
+    (LinearMap.mul' k (ConvolutionDual k H) w).ofConv x =
+      dualDistribEquiv k H w (Coalgebra.comul x) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp
+  | add w₁ w₂ hw₁ hw₂ =>
+      simpa only [map_add, WithConv.ofConv_add, LinearMap.add_apply]
+        using congrArg₂ (fun a b ↦ a + b) hw₁ hw₂
+  | tmul phi psi =>
+      rw [LinearMap.mul'_apply, LinearMap.convMul_apply]
+      generalize Coalgebra.comul (R := k) (A := H) x = z
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | add z₁ z₂ hz₁ hz₂ =>
+          simpa only [map_add, LinearMap.add_apply] using
+            congrArg₂ (fun a b ↦ a + b) hz₁ hz₂
+      | tmul y z =>
+          rw [TensorProduct.map_tmul, LinearMap.mul'_apply, dualDistribEquiv_tmul_apply]
+
+/-- Pointwise form of the characteristic equation for multiplication in the finite dual. -/
+@[grind =]
+theorem convMul_apply (phi psi : ConvolutionDual k H) (x : H) :
+    (phi * psi).ofConv x =
+      dualDistribEquiv k H (phi ⊗ₜ[k] psi) (Coalgebra.comul x) := by
+  simpa only [LinearMap.mul'_apply] using ofConv_mul_apply k H (phi ⊗ₜ[k] psi) x
+
 end Bialgebra
 
 end ConvolutionDual
 
 namespace ConvolutionDual
 
-variable (k : Type u) (H : Type v) [Field k] [CommSemiring H] [Algebra k H]
-  [Module.Finite k H]
+variable (k : Type u) (H : Type v) [Field k] [CommRing H] [Algebra k H]
+  [FiniteDimensional k H]
 
 private theorem dualDistribEquiv_comm_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x y : H) :
@@ -408,8 +454,8 @@ namespace ConvolutionDual
 
 section HopfAlgebra
 
-variable (k : Type u) (H : Type v) [Field k] [Semiring H] [HopfAlgebra k H]
-  [Module.Finite k H]
+variable (k : Type u) (H : Type v) [Field k] [Ring H] [HopfAlgebra k H]
+  [FiniteDimensional k H]
 
 /-- The antipode operation on the finite dual, obtained by transposing the antipode of the
 original Hopf algebra. -/
@@ -424,46 +470,17 @@ private theorem antipode_apply' (phi : ConvolutionDual k H) (x : H) :
       phi.ofConv (HopfAlgebra.antipode k x) := by
   simp [HopfAlgebraStruct.antipode]
 
-private theorem ofConv_mul_apply
-    (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (x : H) :
-    (LinearMap.mul' k (ConvolutionDual k H) w).ofConv x =
-      dualDistribEquiv k H w (Coalgebra.comul x) := by
-  induction w using TensorProduct.induction_on with
-  | zero => simp
-  | add w₁ w₂ hw₁ hw₂ =>
-      simpa only [map_add, WithConv.ofConv_add, LinearMap.add_apply]
-        using congrArg₂ (· + ·) hw₁ hw₂
-  | tmul phi psi =>
-      rw [LinearMap.mul'_apply]
-      rw [LinearMap.convMul_apply]
-      generalize Coalgebra.comul (R := k) (A := H) x = z
-      induction z using TensorProduct.induction_on with
-      | zero => simp
-      | add z₁ z₂ hz₁ hz₂ =>
-          simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
-      | tmul y z =>
-          rw [TensorProduct.map_tmul, LinearMap.mul'_apply, dualDistribEquiv_tmul_apply]
-
 private theorem dualDistribEquiv_map_antipode_left_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
     dualDistribEquiv k H
         (TensorProduct.map (HopfAlgebra.antipode k (A := ConvolutionDual k H))
           LinearMap.id w) z =
       dualDistribEquiv k H w
-        (TensorProduct.map (HopfAlgebra.antipode k (A := H)) LinearMap.id z) := by
-  induction w using TensorProduct.induction_on with
-  | zero => simp
-  | add w₁ w₂ hw₁ hw₂ =>
-      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
-  | tmul phi psi =>
-      induction z using TensorProduct.induction_on with
-      | zero => simp
-      | add z₁ z₂ hz₁ hz₂ =>
-          simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
-      | tmul x y =>
-          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, dualDistribEquiv_tmul_apply,
-            dualDistribEquiv_tmul_apply, antipode_apply']
-          rfl
+        (TensorProduct.map (HopfAlgebra.antipode k (A := H)) LinearMap.id z) :=
+  dualDistribEquiv_map_apply k H
+    (HopfAlgebra.antipode k (A := ConvolutionDual k H)) LinearMap.id
+    (HopfAlgebra.antipode k (A := H)) LinearMap.id
+    (antipode_apply' k H) (fun _ _ ↦ rfl) w z
 
 private theorem dualDistribEquiv_map_antipode_right_apply
     (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) (z : H ⊗[k] H) :
@@ -471,20 +488,10 @@ private theorem dualDistribEquiv_map_antipode_right_apply
         (TensorProduct.map LinearMap.id
           (HopfAlgebra.antipode k (A := ConvolutionDual k H)) w) z =
       dualDistribEquiv k H w
-        (TensorProduct.map LinearMap.id (HopfAlgebra.antipode k (A := H)) z) := by
-  induction w using TensorProduct.induction_on with
-  | zero => simp
-  | add w₁ w₂ hw₁ hw₂ =>
-      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hw₁ hw₂
-  | tmul phi psi =>
-      induction z using TensorProduct.induction_on with
-      | zero => simp
-      | add z₁ z₂ hz₁ hz₂ =>
-          simpa only [map_add, LinearMap.add_apply] using congrArg₂ (· + ·) hz₁ hz₂
-      | tmul x y =>
-          rw [TensorProduct.map_tmul, TensorProduct.map_tmul, dualDistribEquiv_tmul_apply,
-            dualDistribEquiv_tmul_apply, antipode_apply']
-          rfl
+        (TensorProduct.map LinearMap.id (HopfAlgebra.antipode k (A := H)) z) :=
+  dualDistribEquiv_map_apply k H LinearMap.id
+    (HopfAlgebra.antipode k (A := ConvolutionDual k H)) LinearMap.id
+    (HopfAlgebra.antipode k (A := H)) (fun _ _ ↦ rfl) (antipode_apply' k H) w z
 
 /-- The Hopf algebra structure on the finite dual. Its antipode is precomposition with the
 antipode of the original finite-dimensional Hopf algebra. -/

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Basic.lean
@@ -57,7 +57,7 @@ abbrev ConvolutionDual (k : Type u) (H : Type v) [CommSemiring k] [AddCommMonoid
 namespace ConvolutionDual
 
 /-- The convolution dual of a finite-dimensional vector space is finite-dimensional. -/
-noncomputable instance instFiniteDimensional (k : Type u) (H : Type v) [Field k]
+noncomputable instance instFinite (k : Type u) (H : Type v) [Field k]
     [AddCommMonoid H] [Module k H] [Module.Finite k H] :
     Module.Finite k (ConvolutionDual k H) := by
   let _ : AddCommGroup H := Module.addCommMonoidToAddCommGroup k

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
@@ -49,8 +49,8 @@ section Map
 
 variable (k : Type u) [Field k]
 variable {H : Type v} {K : Type w}
-variable [Ring H] [Bialgebra k H]
-variable [Ring K] [Bialgebra k K]
+variable [Semiring H] [Bialgebra k H]
+variable [Semiring K] [Bialgebra k K]
 
 /-- The linear dual of a bialgebra morphism, with convolution wrappers on its source and target. -/
 private noncomputable def mapLinear (f : H →ₐc[k] K) :
@@ -87,7 +87,7 @@ private theorem mapAlgHom_apply_apply (f : H →ₐc[k] K)
     (mapAlgHom k f phi).ofConv x = phi.ofConv (f x) :=
   rfl
 
-variable [FiniteDimensional k H] [FiniteDimensional k K]
+variable [Module.Finite k H] [Module.Finite k K]
 
 private theorem dualDistribEquiv_tensor_map_apply (f : H →ₐc[k] K)
     (z : ConvolutionDual k K ⊗[k] ConvolutionDual k K) (x y : H) :
@@ -141,8 +141,8 @@ theorem map_id :
 
 /-- Dualizing a composite reverses the order of the dual morphisms. -/
 @[simp]
-theorem map_comp {L : Type*} [Ring L] [Bialgebra k L]
-    [FiniteDimensional k L] (g : K →ₐc[k] L) (f : H →ₐc[k] K) :
+theorem map_comp {L : Type*} [Semiring L] [Bialgebra k L]
+    [Module.Finite k L] (g : K →ₐc[k] L) (f : H →ₐc[k] K) :
     map k (g.comp f) = (map k f).comp (map k g) := by
   ext phi x
   simp
@@ -161,23 +161,40 @@ theorem mapEquiv_apply (e : H ≃ₐc[k] K) (phi : ConvolutionDual k K) :
     mapEquiv k e phi = map k e phi :=
   (rfl)
 
+/-- The inverse of the dual equivalence is induced by the inverse bialgebra equivalence. -/
+@[simp]
+theorem mapEquiv_symm (e : H ≃ₐc[k] K) :
+    (mapEquiv k e).symm = mapEquiv k e.symm := by
+  apply BialgEquiv.ext
+  intro phi
+  apply (mapEquiv k e).injective
+  calc
+    mapEquiv k e ((mapEquiv k e).symm phi) = phi := BialgEquiv.apply_symm_apply _ _
+    _ = mapEquiv k e (mapEquiv k e.symm phi) := by
+      ext x
+      simp
+
 end Map
 
 section Evaluation
 
 variable (k : Type u) [Field k]
-variable (H : Type v) [Ring H] [Bialgebra k H] [FiniteDimensional k H]
+variable (H : Type v) [Semiring H] [Bialgebra k H] [Module.Finite k H]
 
 /-- Evaluation into the double convolution dual as a linear equivalence. -/
 private noncomputable def evalLinearEquiv :
-    H ≃ₗ[k] ConvolutionDual k (ConvolutionDual k H) :=
-  (Module.evalEquiv k H).trans
-    ((WithConv.linearEquiv k (Module.Dual k H)).dualMap.trans
-      (WithConv.linearEquiv k (Module.Dual k (ConvolutionDual k H))).symm)
+    H ≃ₗ[k] ConvolutionDual k (ConvolutionDual k H) := by
+  letI : Ring H := Algebra.semiringToRing k
+  exact
+    (Module.evalEquiv k H).trans
+      ((WithConv.linearEquiv k (Module.Dual k H)).dualMap.trans
+        (WithConv.linearEquiv k (Module.Dual k (ConvolutionDual k H))).symm)
 
 private theorem evalLinearEquiv_apply_apply (x : H) (phi : ConvolutionDual k H) :
     (evalLinearEquiv k H x).ofConv phi = phi.ofConv x :=
-  rfl
+  by
+    let _ : Ring H := Algebra.semiringToRing k
+    rfl
 
 /-- Evaluation into the double finite dual as an algebra morphism. -/
 private noncomputable def evalAlgHom :
@@ -215,7 +232,9 @@ private noncomputable def evalAlgHom :
 @[simp]
 private theorem evalAlgHom_apply_apply (x : H) (phi : ConvolutionDual k H) :
     (evalAlgHom k H x).ofConv phi = phi.ofConv x :=
-  rfl
+  by
+    let _ : Ring H := Algebra.semiringToRing k
+    rfl
 
 private theorem convMul_apply_eq_dualDistribEquiv
     (phi psi : ConvolutionDual k H) (x : H) :
@@ -282,20 +301,42 @@ private noncomputable def evalBialgHom :
 The equivalence sends `x` to evaluation at `x`. -/
 noncomputable def evalBialgEquiv :
     H ≃ₐc[k] ConvolutionDual k (ConvolutionDual k H) := by
-  let hbij : Function.Bijective (evalBialgHom k H) := (evalLinearEquiv k H).bijective
-  exact
-    { CoalgEquiv.ofBijective (f := (evalBialgHom k H).toCoalgHom) hbij,
-      (AlgEquiv.ofBijective (evalAlgHom k H) hbij).toMulEquiv with }
+  let bH : Bialgebra k H := inferInstance
+  let bHH : Bialgebra k (ConvolutionDual k (ConvolutionDual k H)) := inferInstance
+  -- `ofBijective` selects coalgebra structures through these bialgebra parent instances.
+  -- Make the definitionally equal structures explicit to avoid the finite-dual instance diamond.
+  change @BialgEquiv k _ H (ConvolutionDual k (ConvolutionDual k H)) _ _
+    bH.toAlgebra bHH.toAlgebra bH.toCoalgebra.toCoalgebraStruct
+      bHH.toCoalgebra.toCoalgebraStruct
+  have hbij : Function.Bijective (evalBialgHom k H) := by
+    change Function.Bijective (evalLinearEquiv k H)
+    exact (evalLinearEquiv k H).bijective
+  exact @BialgEquiv.ofBijective k H (ConvolutionDual k (ConvolutionDual k H)) _ _ _
+    bH bHH (evalBialgHom k H) hbij
+
+private theorem evalBialgEquiv_apply (x : H) :
+    evalBialgEquiv k H x = evalBialgHom k H x := by
+  simp only [evalBialgEquiv, id_eq, BialgEquiv.ofBijective_apply]
 
 /-- The double-dual equivalence evaluates a functional at the original element. -/
 @[simp, grind =]
 theorem evalBialgEquiv_apply_apply (x : H) (phi : ConvolutionDual k H) :
     (evalBialgEquiv k H x).ofConv phi = phi.ofConv x :=
-  evalAlgHom_apply_apply k H x phi
+  by
+    rw [evalBialgEquiv_apply]
+    exact evalAlgHom_apply_apply k H x phi
+
+/-- The inverse double-dual equivalence is characterized by evaluation. -/
+@[simp, grind =]
+theorem evalBialgEquiv_symm_apply_apply
+    (Phi : ConvolutionDual k (ConvolutionDual k H)) (phi : ConvolutionDual k H) :
+    phi.ofConv ((evalBialgEquiv k H).symm Phi) = Phi.ofConv phi := by
+  rw [← evalBialgEquiv_apply_apply]
+  simp
 
 /-- Evaluation into the double dual is natural in finite-dimensional bialgebras. -/
-theorem evalBialgEquiv_naturality {K : Type w} [Ring K] [Bialgebra k K]
-    [FiniteDimensional k K] (f : H →ₐc[k] K) :
+theorem evalBialgEquiv_naturality {K : Type w} [Semiring K] [Bialgebra k K]
+    [Module.Finite k K] (f : H →ₐc[k] K) :
     (evalBialgEquiv k K : K →ₐc[k] ConvolutionDual k (ConvolutionDual k K)).comp f =
       (map k (map k f)).comp (evalBialgEquiv k H) := by
   ext x phi

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
@@ -15,9 +15,9 @@ opposite direction between their convolution duals. Evaluation identifies a fini
 bialgebra with its double convolution dual, compatibly with multiplication, comultiplication,
 unit, and counit.
 
-These are the algebraic functoriality and involutivity statements needed to promote the finite
-Hopf dual constructed in `TauCeti.Algebra.HopfAlgebra.FiniteDual.Basic` to Cartier duality. The
-scheme-level duality, and finite locally free duality over a general base, remain separate steps.
+These are algebraic functoriality and involutivity statements for the finite bialgebra dual
+constructed in `TauCeti.Algebra.HopfAlgebra.FiniteDual.Basic`. The scheme-level Cartier duality
+and its finite locally free general-base form remain separate developments.
 
 ## Main declarations
 
@@ -34,7 +34,8 @@ scheme-level duality, and finite locally free duality over a general base, remai
 * W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
 * J. S. Milne, *Algebraic Groups* (2017), Section 12.e.
 
-This advances Layer 4, "Cartier duality", of the ReductiveGroups roadmap.
+This supports the separate Cartier-duality development identified alongside Layer 4, "Jordan
+decomposition, diagonalizable groups, tori", of the ReductiveGroups roadmap.
 -/
 
 public section
@@ -49,22 +50,25 @@ section Map
 
 variable (k : Type u) [Field k]
 variable {H : Type v} {K : Type w}
-variable [Semiring H] [Bialgebra k H]
-variable [Semiring K] [Bialgebra k K]
 
-/-- The linear dual of a bialgebra morphism, with convolution wrappers on its source and target. -/
-private noncomputable def mapLinear (f : H →ₐc[k] K) :
+section Coalgebra
+
+variable [AddCommGroup H] [Module k H] [Coalgebra k H]
+variable [AddCommGroup K] [Module k K] [Coalgebra k K]
+
+/-- The linear dual of a coalgebra morphism, with convolution wrappers on its source and target. -/
+private noncomputable def mapLinear (f : H →ₗc[k] K) :
     ConvolutionDual k K →ₗ[k] ConvolutionDual k H :=
   (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
     f.toLinearMap.dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap
 
-private theorem mapLinear_apply_apply (f : H →ₐc[k] K)
+private theorem mapLinear_apply (f : H →ₗc[k] K)
     (phi : ConvolutionDual k K) (x : H) :
     (mapLinear k f phi).ofConv x = phi.ofConv (f x) :=
   rfl
 
-/-- Precomposition by a bialgebra morphism as an algebra morphism between convolution duals. -/
-private noncomputable def mapAlgHom (f : H →ₐc[k] K) :
+/-- Precomposition by a coalgebra morphism as an algebra morphism between convolution duals. -/
+private noncomputable def mapAlgHom (f : H →ₗc[k] K) :
     ConvolutionDual k K →ₐ[k] ConvolutionDual k H where
   toFun := mapLinear k f
   map_zero' := map_zero (mapLinear k f)
@@ -72,24 +76,24 @@ private noncomputable def mapAlgHom (f : H →ₐc[k] K) :
   commutes' r := by
     apply WithConv.ofConv_injective
     ext x
-    simp [mapLinear_apply_apply]
+    simp [mapLinear_apply]
   map_one' := by
     apply WithConv.ofConv_injective
     ext x
-    simp [mapLinear_apply_apply, LinearMap.convOne_apply]
+    simp [mapLinear_apply, LinearMap.convOne_apply]
   map_mul' phi psi := by
     apply WithConv.ofConv_injective
-    exact LinearMap.convMul_comp_coalgHom_distrib phi psi f.toCoalgHom
+    exact LinearMap.convMul_comp_coalgHom_distrib phi psi f
 
 @[simp]
-private theorem mapAlgHom_apply_apply (f : H →ₐc[k] K)
+private theorem mapAlgHom_apply (f : H →ₗc[k] K)
     (phi : ConvolutionDual k K) (x : H) :
     (mapAlgHom k f phi).ofConv x = phi.ofConv (f x) :=
-  rfl
+  mapLinear_apply k f phi x
 
-variable [Module.Finite k H] [Module.Finite k K]
+variable [FiniteDimensional k H] [FiniteDimensional k K]
 
-private theorem dualDistribEquiv_tensor_map_apply (f : H →ₐc[k] K)
+private theorem dualDistribEquiv_tensor_map_apply (f : H →ₗc[k] K)
     (z : ConvolutionDual k K ⊗[k] ConvolutionDual k K) (x y : H) :
     dualDistribEquiv k H
         (Algebra.TensorProduct.map (mapAlgHom k f) (mapAlgHom k f) z) (x ⊗ₜ[k] y) =
@@ -97,40 +101,42 @@ private theorem dualDistribEquiv_tensor_map_apply (f : H →ₐc[k] K)
   induction z using TensorProduct.induction_on with
   | zero => simp
   | add z₁ z₂ hz₁ hz₂ =>
-      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (fun a b => a + b) hz₁ hz₂
-  | tmul phi psi => simp
+      simpa only [map_add, LinearMap.add_apply] using
+        congrArg₂ (fun a b ↦ a + b) hz₁ hz₂
+  | tmul phi psi => simp [mapAlgHom_apply]
+
+end Coalgebra
+
+variable [Ring H] [Bialgebra k H]
+variable [Ring K] [Bialgebra k K]
+variable [FiniteDimensional k H] [FiniteDimensional k K]
 
 /-- **The finite dual is contravariantly functorial.** A bialgebra morphism `H → K` induces
 the bialgebra morphism `K* → H*` given by precomposition. -/
 noncomputable def map (f : H →ₐc[k] K) :
     ConvolutionDual k K →ₐc[k] ConvolutionDual k H :=
-  BialgHom.ofAlgHom (mapAlgHom k f)
+  BialgHom.ofAlgHom (mapAlgHom k f.toCoalgHom)
     (by
       ext phi
-      simp [mapAlgHom_apply_apply, counit_apply])
+      rw [AlgHom.comp_apply, counit_apply, mapAlgHom_apply, counit_apply]
+      exact congrArg phi.ofConv f.map_one)
     (by
       ext phi
       apply (dualDistribEquiv k H).injective
-      apply LinearMap.ext
-      intro xy
-      induction xy using TensorProduct.induction_on with
-      | zero => simp
-      | add xy₁ xy₂ hxy₁ hxy₂ =>
-          simpa only [map_add, LinearMap.add_apply] using
-            congrArg₂ (fun a b => a + b) hxy₁ hxy₂
-      | tmul x y =>
-          simp only [AlgHom.comp_apply]
-          simp only [Bialgebra.comulAlgHom, AlgHom.ofLinearMap_apply]
-          rw [dualDistribEquiv_tensor_map_apply,
-            dualDistribEquiv_comul_apply, dualDistribEquiv_comul_apply,
-            mapAlgHom_apply_apply]
-          exact congrArg phi.ofConv (f.map_mul x y).symm)
+      apply TensorProduct.ext'
+      intro x y
+      simp only [AlgHom.comp_apply]
+      simp only [Bialgebra.comulAlgHom, AlgHom.ofLinearMap_apply]
+      rw [dualDistribEquiv_tensor_map_apply k f.toCoalgHom (Coalgebra.comul phi) x y,
+        dualDistribEquiv_comul_apply, dualDistribEquiv_comul_apply,
+        mapAlgHom_apply]
+      exact congrArg phi.ofConv (f.map_mul x y).symm)
 
 /-- The dual morphism evaluates by precomposition. -/
 @[simp, grind =]
-theorem map_apply_apply (f : H →ₐc[k] K) (phi : ConvolutionDual k K) (x : H) :
+theorem map_apply (f : H →ₐc[k] K) (phi : ConvolutionDual k K) (x : H) :
     (map k f phi).ofConv x = phi.ofConv (f x) :=
-  mapAlgHom_apply_apply k f phi x
+  mapAlgHom_apply k f.toCoalgHom phi x
 
 /-- Dualizing the identity bialgebra morphism gives the identity. -/
 @[simp]
@@ -141,8 +147,8 @@ theorem map_id :
 
 /-- Dualizing a composite reverses the order of the dual morphisms. -/
 @[simp]
-theorem map_comp {L : Type*} [Semiring L] [Bialgebra k L]
-    [Module.Finite k L] (g : K →ₐc[k] L) (f : H →ₐc[k] K) :
+theorem map_comp {L : Type*} [Ring L] [Bialgebra k L]
+    [FiniteDimensional k L] (g : K →ₐc[k] L) (f : H →ₐc[k] K) :
     map k (g.comp f) = (map k f).comp (map k g) := by
   ext phi x
   simp
@@ -167,29 +173,46 @@ theorem mapEquiv_symm (e : H ≃ₐc[k] K) :
     (mapEquiv k e).symm = mapEquiv k e.symm := by
   unfold mapEquiv
   rw [BialgEquiv.ofBialgHom_symm]
-  congr 1
+  apply BialgEquiv.ext
+  intro phi
+  rfl
 
 end Map
 
 section Evaluation
 
 variable (k : Type u) [Field k]
-variable (H : Type v) [Semiring H] [Bialgebra k H] [Module.Finite k H]
+variable (H : Type v) [Ring H] [Bialgebra k H] [FiniteDimensional k H]
 
 /-- Evaluation into the double convolution dual as a linear equivalence. -/
 private noncomputable def evalLinearEquiv :
-    H ≃ₗ[k] ConvolutionDual k (ConvolutionDual k H) := by
-  letI : Ring H := Algebra.semiringToRing k
-  exact
-    (Module.evalEquiv k H).trans
-      ((WithConv.linearEquiv k (Module.Dual k H)).dualMap.trans
-        (WithConv.linearEquiv k (Module.Dual k (ConvolutionDual k H))).symm)
+    H ≃ₗ[k] ConvolutionDual k (ConvolutionDual k H) :=
+  (Module.evalEquiv k H).trans
+    ((WithConv.linearEquiv k (Module.Dual k H)).dualMap.trans
+      (WithConv.linearEquiv k (Module.Dual k (ConvolutionDual k H))).symm)
 
-private theorem evalLinearEquiv_apply_apply (x : H) (phi : ConvolutionDual k H) :
+private theorem evalLinearEquiv_apply (x : H) (phi : ConvolutionDual k H) :
     (evalLinearEquiv k H x).ofConv phi = phi.ofConv x :=
-  by
-    let _ : Ring H := Algebra.semiringToRing k
-    rfl
+  rfl
+
+private theorem dualDistribEquiv_tensor_eval_apply
+    (z : H ⊗[k] H) (w : ConvolutionDual k H ⊗[k] ConvolutionDual k H) :
+    dualDistribEquiv k (ConvolutionDual k H)
+        (TensorProduct.map (evalLinearEquiv k H).toLinearMap
+          (evalLinearEquiv k H).toLinearMap z) w =
+      dualDistribEquiv k H w z := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z₁ z₂ hz₁ hz₂ =>
+      simpa only [map_add, LinearMap.add_apply, WithConv.ofConv_add] using
+        congrArg₂ (fun a b ↦ a + b) hz₁ hz₂
+  | tmul x y =>
+      induction w using TensorProduct.induction_on with
+      | zero => simp
+      | add w₁ w₂ hw₁ hw₂ =>
+          simpa only [map_add, LinearMap.add_apply] using
+            congrArg₂ (fun a b ↦ a + b) hw₁ hw₂
+      | tmul phi psi => simp [evalLinearEquiv_apply]
 
 /-- Evaluation into the double finite dual as an algebra morphism. -/
 private noncomputable def evalAlgHom :
@@ -200,139 +223,107 @@ private noncomputable def evalAlgHom :
   commutes' r := by
     apply WithConv.ofConv_injective
     ext phi
-    rw [evalLinearEquiv_apply_apply, Algebra.algebraMap_eq_smul_one, map_smul, smul_eq_mul]
+    rw [evalLinearEquiv_apply, Algebra.algebraMap_eq_smul_one, map_smul, smul_eq_mul]
     simp [Algebra.algebraMap_eq_smul_one, counit_apply]
   map_one' := by
     apply WithConv.ofConv_injective
     ext phi
-    simp [evalLinearEquiv_apply_apply, counit_apply]
+    simp [evalLinearEquiv_apply, counit_apply]
   map_mul' x y := by
     apply WithConv.ofConv_injective
     ext phi
-    rw [evalLinearEquiv_apply_apply]
+    rw [evalLinearEquiv_apply]
     symm
     calc
       ((evalLinearEquiv k H x) * (evalLinearEquiv k H y)).ofConv phi =
-          dualDistribEquiv k H (Coalgebra.comul phi) (x ⊗ₜ[k] y) := by
-        rw [LinearMap.convMul_apply]
-        generalize Coalgebra.comul (R := k) phi = z
-        induction z using TensorProduct.induction_on with
-        | zero => simp
-        | add z₁ z₂ hz₁ hz₂ =>
-            simpa only [map_add, LinearMap.add_apply] using
-              congrArg₂ (fun a b => a + b) hz₁ hz₂
-        | tmul a b => simp [evalLinearEquiv_apply_apply]
+          dualDistribEquiv k (ConvolutionDual k H)
+            (evalLinearEquiv k H x ⊗ₜ[k] evalLinearEquiv k H y)
+              (Coalgebra.comul phi) :=
+        convMul_apply k (ConvolutionDual k H) _ _ phi
+      _ = dualDistribEquiv k H (Coalgebra.comul phi) (x ⊗ₜ[k] y) := by
+        simpa using dualDistribEquiv_tensor_eval_apply k H (x ⊗ₜ[k] y)
+          (Coalgebra.comul phi)
       _ = phi.ofConv (x * y) := dualDistribEquiv_comul_apply k H phi x y
 
 @[simp]
-private theorem evalAlgHom_apply_apply (x : H) (phi : ConvolutionDual k H) :
+private theorem evalAlgHom_apply (x : H) (phi : ConvolutionDual k H) :
     (evalAlgHom k H x).ofConv phi = phi.ofConv x :=
-  by
-    let _ : Ring H := Algebra.semiringToRing k
-    rfl
+  evalLinearEquiv_apply k H x phi
 
-private theorem convMul_apply_eq_dualDistribEquiv
-    (phi psi : ConvolutionDual k H) (x : H) :
-    (phi * psi).ofConv x =
-      dualDistribEquiv k H (phi ⊗ₜ[k] psi) (Coalgebra.comul x) := by
-  rw [LinearMap.convMul_apply]
-  generalize Coalgebra.comul (R := k) x = z
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | add z₁ z₂ hz₁ hz₂ =>
-      simpa only [map_add, LinearMap.add_apply] using
-        congrArg₂ (fun a b => a + b) hz₁ hz₂
-  | tmul a b => simp
+private theorem evalAlgHom_counit_comp :
+    (Bialgebra.counitAlgHom k (ConvolutionDual k (ConvolutionDual k H))).comp
+        (evalAlgHom k H) = Bialgebra.counitAlgHom k H := by
+  ext x
+  simp [counit_apply, evalAlgHom_apply, LinearMap.convOne_apply]
 
-private theorem dualDistribEquiv_tensor_eval_apply
-    (z : H ⊗[k] H) (phi psi : ConvolutionDual k H) :
-    dualDistribEquiv k (ConvolutionDual k H)
-        (TensorProduct.map (evalAlgHom k H).toLinearMap
-          (evalAlgHom k H).toLinearMap z)
-          (phi ⊗ₜ[k] psi) =
-      dualDistribEquiv k H (phi ⊗ₜ[k] psi) z := by
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | add z₁ z₂ hz₁ hz₂ =>
-      simpa only [map_add, LinearMap.add_apply, WithConv.ofConv_add] using
-        congrArg₂ (fun a b => a + b) hz₁ hz₂
-  | tmul x y => simp [evalAlgHom_apply_apply]
-
-/-- Evaluation into the double finite dual as a coalgebra morphism. -/
-private noncomputable def evalCoalgHom :
-    H →ₗc[k] ConvolutionDual k (ConvolutionDual k H) where
-  __ := (evalAlgHom k H).toLinearMap
-  counit_comp := by
-    ext x
-    simp [counit_apply, evalAlgHom_apply_apply, LinearMap.convOne_apply]
-  map_comp_comul := by
-    ext x
-    apply (dualDistribEquiv k (ConvolutionDual k H)).injective
-    apply LinearMap.ext
-    intro phipsi
-    induction phipsi using TensorProduct.induction_on with
-    | zero => simp
-    | add z₁ z₂ hz₁ hz₂ =>
-        simpa only [map_add, LinearMap.add_apply] using
-          congrArg₂ (fun a b => a + b) hz₁ hz₂
-    | tmul phi psi =>
-        simp only [LinearMap.comp_apply]
-        calc
-          _ = dualDistribEquiv k H (phi ⊗ₜ[k] psi) (Coalgebra.comul x) := by
-            exact dualDistribEquiv_tensor_eval_apply k H (Coalgebra.comul x) phi psi
-          _ = (phi * psi).ofConv x :=
-            (convMul_apply_eq_dualDistribEquiv k H phi psi x).symm
-          _ = _ := (evalAlgHom_apply_apply k H x (phi * psi)).symm.trans
-            (dualDistribEquiv_comul_apply
-              k (ConvolutionDual k H) (evalAlgHom k H x) phi psi).symm
+private theorem evalAlgHom_map_comp_comul :
+    (Algebra.TensorProduct.map (evalAlgHom k H) (evalAlgHom k H)).comp
+        (Bialgebra.comulAlgHom k H) =
+      (Bialgebra.comulAlgHom k (ConvolutionDual k (ConvolutionDual k H))).comp
+        (evalAlgHom k H) := by
+  ext x
+  apply (dualDistribEquiv k (ConvolutionDual k H)).injective
+  apply LinearMap.ext
+  intro w
+  simp only [AlgHom.comp_apply, Bialgebra.comulAlgHom, AlgHom.ofLinearMap_apply]
+  calc
+    _ = dualDistribEquiv k H w (Coalgebra.comul x) := by
+      exact dualDistribEquiv_tensor_eval_apply k H (Coalgebra.comul x) w
+    _ = (LinearMap.mul' k (ConvolutionDual k H) w).ofConv x :=
+      (ofConv_mul_apply k H w x).symm
+    _ = _ := by
+      rw [dualDistribEquiv_comul]
+      simp only [LinearMap.comp_apply, evalAlgHom_apply]
 
 /-- Evaluation into the double finite dual as a bialgebra morphism. -/
 private noncomputable def evalBialgHom :
     H →ₐc[k] ConvolutionDual k (ConvolutionDual k H) :=
-  { evalCoalgHom k H, evalAlgHom k H with }
+  BialgHom.ofAlgHom (evalAlgHom k H) (evalAlgHom_counit_comp k H)
+    (evalAlgHom_map_comp_comul k H)
+
+private theorem evalBialgHom_apply (x : H) :
+    evalBialgHom k H x = evalLinearEquiv k H x :=
+  rfl
 
 /-- **A finite-dimensional bialgebra is canonically isomorphic to its double finite dual.**
 
 The equivalence sends `x` to evaluation at `x`. -/
 noncomputable def evalBialgEquiv :
-    H ≃ₐc[k] ConvolutionDual k (ConvolutionDual k H) := by
-  let bH : Bialgebra k H := inferInstance
-  let bHH : Bialgebra k (ConvolutionDual k (ConvolutionDual k H)) := inferInstance
-  -- `ofBijective` selects coalgebra structures through these bialgebra parent instances.
-  -- Make the definitionally equal structures explicit to avoid the finite-dual instance diamond.
-  change @BialgEquiv k _ H (ConvolutionDual k (ConvolutionDual k H)) _ _
-    bH.toAlgebra bHH.toAlgebra bH.toCoalgebra.toCoalgebraStruct
-      bHH.toCoalgebra.toCoalgebraStruct
-  have hbij : Function.Bijective (evalBialgHom k H) := by
-    -- The bundled bialgebra morphism was built with `evalLinearEquiv` as its underlying function.
-    change Function.Bijective (evalLinearEquiv k H)
-    exact (evalLinearEquiv k H).bijective
-  exact @BialgEquiv.ofBijective k H (ConvolutionDual k (ConvolutionDual k H)) _ _ _
-    bH bHH (evalBialgHom k H) hbij
+    H ≃ₐc[k] ConvolutionDual k (ConvolutionDual k H) :=
+  BialgEquiv.ofBijective (evalBialgHom k H) (by
+    constructor
+    · intro x y h
+      apply (evalLinearEquiv k H).injective
+      rw [← evalBialgHom_apply, ← evalBialgHom_apply]
+      exact h
+    · intro y
+      obtain ⟨x, hx⟩ := (evalLinearEquiv k H).surjective y
+      exact ⟨x, by rw [evalBialgHom_apply]; exact hx⟩)
 
-private theorem evalBialgEquiv_apply (x : H) :
+private theorem evalBialgEquiv_eq_evalBialgHom (x : H) :
     evalBialgEquiv k H x = evalBialgHom k H x := by
-  simp only [evalBialgEquiv, id_eq, BialgEquiv.ofBijective_apply]
+  simp only [evalBialgEquiv, BialgEquiv.ofBijective_apply]
 
 /-- The double-dual equivalence evaluates a functional at the original element. -/
 @[simp, grind =]
-theorem evalBialgEquiv_apply_apply (x : H) (phi : ConvolutionDual k H) :
+theorem evalBialgEquiv_apply (x : H) (phi : ConvolutionDual k H) :
     (evalBialgEquiv k H x).ofConv phi = phi.ofConv x :=
   by
-    rw [evalBialgEquiv_apply]
-    exact evalAlgHom_apply_apply k H x phi
+    rw [evalBialgEquiv_eq_evalBialgHom]
+    rw [evalBialgHom_apply]
+    exact evalLinearEquiv_apply k H x phi
 
 /-- The inverse double-dual equivalence is characterized by evaluation. -/
 @[simp, grind =]
-theorem evalBialgEquiv_symm_apply_apply
+theorem apply_evalBialgEquiv_symm_apply
     (Phi : ConvolutionDual k (ConvolutionDual k H)) (phi : ConvolutionDual k H) :
     phi.ofConv ((evalBialgEquiv k H).symm Phi) = Phi.ofConv phi := by
-  rw [← evalBialgEquiv_apply_apply]
+  rw [← evalBialgEquiv_apply]
   simp
 
 /-- Evaluation into the double dual is natural in finite-dimensional bialgebras. -/
-theorem evalBialgEquiv_naturality {K : Type w} [Semiring K] [Bialgebra k K]
-    [Module.Finite k K] (f : H →ₐc[k] K) :
+theorem evalBialgEquiv_naturality {K : Type w} [Ring K] [Bialgebra k K]
+    [FiniteDimensional k K] (f : H →ₐc[k] K) :
     (evalBialgEquiv k K : K →ₐc[k] ConvolutionDual k (ConvolutionDual k K)).comp f =
       (map k (map k f)).comp (evalBialgEquiv k H) := by
   ext x phi

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
@@ -118,7 +118,9 @@ noncomputable def map (f : H →ₐc[k] K) :
   BialgHom.ofAlgHom (mapAlgHom k f.toCoalgHom)
     (by
       ext phi
-      rw [AlgHom.comp_apply, counit_apply, mapAlgHom_apply, counit_apply]
+      change Coalgebra.counit (R := k) (mapAlgHom k f.toCoalgHom phi) =
+        Coalgebra.counit (R := k) phi
+      rw [counit_apply, mapAlgHom_apply, counit_apply]
       exact congrArg phi.ofConv f.map_one)
     (by
       ext phi
@@ -278,7 +280,9 @@ private theorem evalAlgHom_map_comp_comul :
 /-- Evaluation into the double finite dual as a bialgebra morphism. -/
 private noncomputable def evalBialgHom :
     H →ₐc[k] ConvolutionDual k (ConvolutionDual k H) :=
-  BialgHom.ofAlgHom (evalAlgHom k H) (evalAlgHom_counit_comp k H)
+  BialgHom.ofAlgHom (R := k) (A := H)
+    (B := ConvolutionDual k (ConvolutionDual k H))
+    (evalAlgHom k H) (evalAlgHom_counit_comp k H)
     (evalAlgHom_map_comp_comul k H)
 
 private theorem evalBialgHom_apply (x : H) :
@@ -289,20 +293,21 @@ private theorem evalBialgHom_apply (x : H) :
 
 The equivalence sends `x` to evaluation at `x`. -/
 noncomputable def evalBialgEquiv :
-    H ≃ₐc[k] ConvolutionDual k (ConvolutionDual k H) :=
-  BialgEquiv.ofBijective (evalBialgHom k H) (by
-    constructor
-    · intro x y h
-      apply (evalLinearEquiv k H).injective
-      rw [← evalBialgHom_apply, ← evalBialgHom_apply]
-      exact h
-    · intro y
-      obtain ⟨x, hx⟩ := (evalLinearEquiv k H).surjective y
-      exact ⟨x, by rw [evalBialgHom_apply]; exact hx⟩)
+    H ≃ₐc[k] ConvolutionDual k (ConvolutionDual k H) := by
+  let bH : Bialgebra k H := inferInstance
+  let bHH : Bialgebra k (ConvolutionDual k (ConvolutionDual k H)) := inferInstance
+  change @BialgEquiv k _ H (ConvolutionDual k (ConvolutionDual k H)) _ _
+    bH.toAlgebra bHH.toAlgebra bH.toCoalgebra.toCoalgebraStruct
+      bHH.toCoalgebra.toCoalgebraStruct
+  have hbij : Function.Bijective (evalBialgHom k H) := by
+    change Function.Bijective (evalLinearEquiv k H)
+    exact (evalLinearEquiv k H).bijective
+  exact @BialgEquiv.ofBijective k H (ConvolutionDual k (ConvolutionDual k H)) _ _ _
+    bH bHH (evalBialgHom k H) hbij
 
 private theorem evalBialgEquiv_eq_evalBialgHom (x : H) :
     evalBialgEquiv k H x = evalBialgHom k H x := by
-  simp only [evalBialgEquiv, BialgEquiv.ofBijective_apply]
+  simp only [evalBialgEquiv, id_eq, BialgEquiv.ofBijective_apply]
 
 /-- The double-dual equivalence evaluates a functional at the original element. -/
 @[simp, grind =]

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
@@ -165,14 +165,9 @@ theorem mapEquiv_apply (e : H ≃ₐc[k] K) (phi : ConvolutionDual k K) :
 @[simp]
 theorem mapEquiv_symm (e : H ≃ₐc[k] K) :
     (mapEquiv k e).symm = mapEquiv k e.symm := by
-  apply BialgEquiv.ext
-  intro phi
-  apply (mapEquiv k e).injective
-  calc
-    mapEquiv k e ((mapEquiv k e).symm phi) = phi := BialgEquiv.apply_symm_apply _ _
-    _ = mapEquiv k e (mapEquiv k e.symm phi) := by
-      ext x
-      simp
+  unfold mapEquiv
+  rw [BialgEquiv.ofBialgHom_symm]
+  congr 1
 
 end Map
 

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
@@ -309,6 +309,7 @@ noncomputable def evalBialgEquiv :
     bH.toAlgebra bHH.toAlgebra bH.toCoalgebra.toCoalgebraStruct
       bHH.toCoalgebra.toCoalgebraStruct
   have hbij : Function.Bijective (evalBialgHom k H) := by
+    -- The bundled bialgebra morphism was built with `evalLinearEquiv` as its underlying function.
     change Function.Bijective (evalLinearEquiv k H)
     exact (evalLinearEquiv k H).bijective
   exact @BialgEquiv.ofBijective k H (ConvolutionDual k (ConvolutionDual k H)) _ _ _

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Functoriality.lean
@@ -1,0 +1,306 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Bialgebra.Equiv
+public import TauCeti.Algebra.HopfAlgebra.FiniteDual.Basic
+
+/-!
+# Functoriality and reflexivity of the finite Hopf dual
+
+Dualizing a bialgebra morphism between finite-dimensional bialgebras gives a morphism in the
+opposite direction between their convolution duals. Evaluation identifies a finite-dimensional
+bialgebra with its double convolution dual, compatibly with multiplication, comultiplication,
+unit, and counit.
+
+These are the algebraic functoriality and involutivity statements needed to promote the finite
+Hopf dual constructed in `TauCeti.Algebra.HopfAlgebra.FiniteDual.Basic` to Cartier duality. The
+scheme-level duality, and finite locally free duality over a general base, remain separate steps.
+
+## Main declarations
+
+* `TauCeti.ConvolutionDual.map`: the contravariant map on finite-dimensional bialgebras.
+* `TauCeti.ConvolutionDual.map_id` and `TauCeti.ConvolutionDual.map_comp`: its functoriality laws.
+* `TauCeti.ConvolutionDual.mapEquiv`: the contravariant equivalence induced by a bialgebra
+  equivalence.
+* `TauCeti.ConvolutionDual.evalBialgEquiv`: evaluation as a bialgebra equivalence with the double
+  convolution dual.
+* `TauCeti.ConvolutionDual.evalBialgEquiv_naturality`: naturality of evaluation.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+* J. S. Milne, *Algebraic Groups* (2017), Section 12.e.
+
+This advances Layer 4, "Cartier duality", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.ConvolutionDual
+
+universe u v w
+
+section Map
+
+variable (k : Type u) [Field k]
+variable {H : Type v} {K : Type w}
+variable [Ring H] [Bialgebra k H]
+variable [Ring K] [Bialgebra k K]
+
+/-- The linear dual of a bialgebra morphism, with convolution wrappers on its source and target. -/
+private noncomputable def mapLinear (f : H →ₐc[k] K) :
+    ConvolutionDual k K →ₗ[k] ConvolutionDual k H :=
+  (WithConv.linearEquiv k _).symm.toLinearMap ∘ₗ
+    f.toLinearMap.dualMap ∘ₗ (WithConv.linearEquiv k _).toLinearMap
+
+private theorem mapLinear_apply_apply (f : H →ₐc[k] K)
+    (phi : ConvolutionDual k K) (x : H) :
+    (mapLinear k f phi).ofConv x = phi.ofConv (f x) :=
+  rfl
+
+/-- Precomposition by a bialgebra morphism as an algebra morphism between convolution duals. -/
+private noncomputable def mapAlgHom (f : H →ₐc[k] K) :
+    ConvolutionDual k K →ₐ[k] ConvolutionDual k H where
+  toFun := mapLinear k f
+  map_zero' := map_zero (mapLinear k f)
+  map_add' := map_add (mapLinear k f)
+  commutes' r := by
+    apply WithConv.ofConv_injective
+    ext x
+    simp [mapLinear_apply_apply]
+  map_one' := by
+    apply WithConv.ofConv_injective
+    ext x
+    simp [mapLinear_apply_apply, LinearMap.convOne_apply]
+  map_mul' phi psi := by
+    apply WithConv.ofConv_injective
+    exact LinearMap.convMul_comp_coalgHom_distrib phi psi f.toCoalgHom
+
+@[simp]
+private theorem mapAlgHom_apply_apply (f : H →ₐc[k] K)
+    (phi : ConvolutionDual k K) (x : H) :
+    (mapAlgHom k f phi).ofConv x = phi.ofConv (f x) :=
+  rfl
+
+variable [FiniteDimensional k H] [FiniteDimensional k K]
+
+private theorem dualDistribEquiv_tensor_map_apply (f : H →ₐc[k] K)
+    (z : ConvolutionDual k K ⊗[k] ConvolutionDual k K) (x y : H) :
+    dualDistribEquiv k H
+        (Algebra.TensorProduct.map (mapAlgHom k f) (mapAlgHom k f) z) (x ⊗ₜ[k] y) =
+      dualDistribEquiv k K z (f x ⊗ₜ[k] f y) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z₁ z₂ hz₁ hz₂ =>
+      simpa only [map_add, LinearMap.add_apply] using congrArg₂ (fun a b => a + b) hz₁ hz₂
+  | tmul phi psi => simp
+
+/-- **The finite dual is contravariantly functorial.** A bialgebra morphism `H → K` induces
+the bialgebra morphism `K* → H*` given by precomposition. -/
+noncomputable def map (f : H →ₐc[k] K) :
+    ConvolutionDual k K →ₐc[k] ConvolutionDual k H :=
+  BialgHom.ofAlgHom (mapAlgHom k f)
+    (by
+      ext phi
+      simp [mapAlgHom_apply_apply, counit_apply])
+    (by
+      ext phi
+      apply (dualDistribEquiv k H).injective
+      apply LinearMap.ext
+      intro xy
+      induction xy using TensorProduct.induction_on with
+      | zero => simp
+      | add xy₁ xy₂ hxy₁ hxy₂ =>
+          simpa only [map_add, LinearMap.add_apply] using
+            congrArg₂ (fun a b => a + b) hxy₁ hxy₂
+      | tmul x y =>
+          simp only [AlgHom.comp_apply]
+          simp only [Bialgebra.comulAlgHom, AlgHom.ofLinearMap_apply]
+          rw [dualDistribEquiv_tensor_map_apply,
+            dualDistribEquiv_comul_apply, dualDistribEquiv_comul_apply,
+            mapAlgHom_apply_apply]
+          exact congrArg phi.ofConv (f.map_mul x y).symm)
+
+/-- The dual morphism evaluates by precomposition. -/
+@[simp, grind =]
+theorem map_apply_apply (f : H →ₐc[k] K) (phi : ConvolutionDual k K) (x : H) :
+    (map k f phi).ofConv x = phi.ofConv (f x) :=
+  mapAlgHom_apply_apply k f phi x
+
+/-- Dualizing the identity bialgebra morphism gives the identity. -/
+@[simp]
+theorem map_id :
+    map k (BialgHom.id k H) = BialgHom.id k (ConvolutionDual k H) := by
+  ext phi x
+  simp
+
+/-- Dualizing a composite reverses the order of the dual morphisms. -/
+@[simp]
+theorem map_comp {L : Type*} [Ring L] [Bialgebra k L]
+    [FiniteDimensional k L] (g : K →ₐc[k] L) (f : H →ₐc[k] K) :
+    map k (g.comp f) = (map k f).comp (map k g) := by
+  ext phi x
+  simp
+
+/-- A bialgebra equivalence induces a bialgebra equivalence of finite duals in the opposite
+direction. -/
+noncomputable def mapEquiv (e : H ≃ₐc[k] K) :
+    ConvolutionDual k K ≃ₐc[k] ConvolutionDual k H :=
+  BialgEquiv.ofBialgHom (map k e) (map k e.symm)
+    (by rw [← map_comp, BialgEquiv.symm_comp, map_id])
+    (by rw [← map_comp, BialgEquiv.comp_symm, map_id])
+
+/-- The forward map of the dual equivalence is the dual morphism. -/
+@[simp]
+theorem mapEquiv_apply (e : H ≃ₐc[k] K) (phi : ConvolutionDual k K) :
+    mapEquiv k e phi = map k e phi :=
+  (rfl)
+
+end Map
+
+section Evaluation
+
+variable (k : Type u) [Field k]
+variable (H : Type v) [Ring H] [Bialgebra k H] [FiniteDimensional k H]
+
+/-- Evaluation into the double convolution dual as a linear equivalence. -/
+private noncomputable def evalLinearEquiv :
+    H ≃ₗ[k] ConvolutionDual k (ConvolutionDual k H) :=
+  (Module.evalEquiv k H).trans
+    ((WithConv.linearEquiv k (Module.Dual k H)).dualMap.trans
+      (WithConv.linearEquiv k (Module.Dual k (ConvolutionDual k H))).symm)
+
+private theorem evalLinearEquiv_apply_apply (x : H) (phi : ConvolutionDual k H) :
+    (evalLinearEquiv k H x).ofConv phi = phi.ofConv x :=
+  rfl
+
+/-- Evaluation into the double finite dual as an algebra morphism. -/
+private noncomputable def evalAlgHom :
+    H →ₐ[k] ConvolutionDual k (ConvolutionDual k H) where
+  toFun := evalLinearEquiv k H
+  map_zero' := map_zero (evalLinearEquiv k H)
+  map_add' := map_add (evalLinearEquiv k H)
+  commutes' r := by
+    apply WithConv.ofConv_injective
+    ext phi
+    rw [evalLinearEquiv_apply_apply, Algebra.algebraMap_eq_smul_one, map_smul, smul_eq_mul]
+    simp [Algebra.algebraMap_eq_smul_one, counit_apply]
+  map_one' := by
+    apply WithConv.ofConv_injective
+    ext phi
+    simp [evalLinearEquiv_apply_apply, counit_apply]
+  map_mul' x y := by
+    apply WithConv.ofConv_injective
+    ext phi
+    rw [evalLinearEquiv_apply_apply]
+    symm
+    calc
+      ((evalLinearEquiv k H x) * (evalLinearEquiv k H y)).ofConv phi =
+          dualDistribEquiv k H (Coalgebra.comul phi) (x ⊗ₜ[k] y) := by
+        rw [LinearMap.convMul_apply]
+        generalize Coalgebra.comul (R := k) phi = z
+        induction z using TensorProduct.induction_on with
+        | zero => simp
+        | add z₁ z₂ hz₁ hz₂ =>
+            simpa only [map_add, LinearMap.add_apply] using
+              congrArg₂ (fun a b => a + b) hz₁ hz₂
+        | tmul a b => simp [evalLinearEquiv_apply_apply]
+      _ = phi.ofConv (x * y) := dualDistribEquiv_comul_apply k H phi x y
+
+@[simp]
+private theorem evalAlgHom_apply_apply (x : H) (phi : ConvolutionDual k H) :
+    (evalAlgHom k H x).ofConv phi = phi.ofConv x :=
+  rfl
+
+private theorem convMul_apply_eq_dualDistribEquiv
+    (phi psi : ConvolutionDual k H) (x : H) :
+    (phi * psi).ofConv x =
+      dualDistribEquiv k H (phi ⊗ₜ[k] psi) (Coalgebra.comul x) := by
+  rw [LinearMap.convMul_apply]
+  generalize Coalgebra.comul (R := k) x = z
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z₁ z₂ hz₁ hz₂ =>
+      simpa only [map_add, LinearMap.add_apply] using
+        congrArg₂ (fun a b => a + b) hz₁ hz₂
+  | tmul a b => simp
+
+private theorem dualDistribEquiv_tensor_eval_apply
+    (z : H ⊗[k] H) (phi psi : ConvolutionDual k H) :
+    dualDistribEquiv k (ConvolutionDual k H)
+        (TensorProduct.map (evalAlgHom k H).toLinearMap
+          (evalAlgHom k H).toLinearMap z)
+          (phi ⊗ₜ[k] psi) =
+      dualDistribEquiv k H (phi ⊗ₜ[k] psi) z := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z₁ z₂ hz₁ hz₂ =>
+      simpa only [map_add, LinearMap.add_apply, WithConv.ofConv_add] using
+        congrArg₂ (fun a b => a + b) hz₁ hz₂
+  | tmul x y => simp [evalAlgHom_apply_apply]
+
+/-- Evaluation into the double finite dual as a coalgebra morphism. -/
+private noncomputable def evalCoalgHom :
+    H →ₗc[k] ConvolutionDual k (ConvolutionDual k H) where
+  __ := (evalAlgHom k H).toLinearMap
+  counit_comp := by
+    ext x
+    simp [counit_apply, evalAlgHom_apply_apply, LinearMap.convOne_apply]
+  map_comp_comul := by
+    ext x
+    apply (dualDistribEquiv k (ConvolutionDual k H)).injective
+    apply LinearMap.ext
+    intro phipsi
+    induction phipsi using TensorProduct.induction_on with
+    | zero => simp
+    | add z₁ z₂ hz₁ hz₂ =>
+        simpa only [map_add, LinearMap.add_apply] using
+          congrArg₂ (fun a b => a + b) hz₁ hz₂
+    | tmul phi psi =>
+        simp only [LinearMap.comp_apply]
+        calc
+          _ = dualDistribEquiv k H (phi ⊗ₜ[k] psi) (Coalgebra.comul x) := by
+            exact dualDistribEquiv_tensor_eval_apply k H (Coalgebra.comul x) phi psi
+          _ = (phi * psi).ofConv x :=
+            (convMul_apply_eq_dualDistribEquiv k H phi psi x).symm
+          _ = _ := (evalAlgHom_apply_apply k H x (phi * psi)).symm.trans
+            (dualDistribEquiv_comul_apply
+              k (ConvolutionDual k H) (evalAlgHom k H x) phi psi).symm
+
+/-- Evaluation into the double finite dual as a bialgebra morphism. -/
+private noncomputable def evalBialgHom :
+    H →ₐc[k] ConvolutionDual k (ConvolutionDual k H) :=
+  { evalCoalgHom k H, evalAlgHom k H with }
+
+/-- **A finite-dimensional bialgebra is canonically isomorphic to its double finite dual.**
+
+The equivalence sends `x` to evaluation at `x`. -/
+noncomputable def evalBialgEquiv :
+    H ≃ₐc[k] ConvolutionDual k (ConvolutionDual k H) := by
+  let hbij : Function.Bijective (evalBialgHom k H) := (evalLinearEquiv k H).bijective
+  exact
+    { CoalgEquiv.ofBijective (f := (evalBialgHom k H).toCoalgHom) hbij,
+      (AlgEquiv.ofBijective (evalAlgHom k H) hbij).toMulEquiv with }
+
+/-- The double-dual equivalence evaluates a functional at the original element. -/
+@[simp, grind =]
+theorem evalBialgEquiv_apply_apply (x : H) (phi : ConvolutionDual k H) :
+    (evalBialgEquiv k H x).ofConv phi = phi.ofConv x :=
+  evalAlgHom_apply_apply k H x phi
+
+/-- Evaluation into the double dual is natural in finite-dimensional bialgebras. -/
+theorem evalBialgEquiv_naturality {K : Type w} [Ring K] [Bialgebra k K]
+    [FiniteDimensional k K] (f : H →ₐc[k] K) :
+    (evalBialgEquiv k K : K →ₐc[k] ConvolutionDual k (ConvolutionDual k K)).comp f =
+      (map k (map k f)).comp (evalBialgEquiv k H) := by
+  ext x phi
+  simp
+
+end Evaluation
+
+end TauCeti.ConvolutionDual


### PR DESCRIPTION
This PR makes the finite-dimensional Hopf dual contravariantly functorial and identifies every finite-dimensional bialgebra with its double dual by evaluation. It advances the exact target in `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4, “Cartier duality proper is the duality of finite locally free commutative group schemes”: the object-level finite Hopf dual landed in #3021, and this PR supplies the morphism, equivalence, involutivity, and naturality data needed for the algebraic duality.

`ConvolutionDual.map` sends a bialgebra morphism `H → K` to precomposition `K* → H*`, with evaluation, identity, and composition laws. `ConvolutionDual.mapEquiv` upgrades the dual of a bialgebra equivalence to an equivalence in the opposite direction. `ConvolutionDual.evalBialgEquiv` proves that evaluation `H → H**` preserves all bialgebra operations and is bijective, and `evalBialgEquiv_naturality` proves its naturality square. The basic module also exports the finite-dimensionality instance for `ConvolutionDual`, so iterated dualization is available to downstream category constructions.

This is the most effective current step because #3021 supplied only the object construction: without contravariant morphisms and the natural double-dual equivalence there is no duality to transport through the Hopf/affine-group-scheme anti-equivalence. No open PR covers finite-dual functoriality, while the other active ReductiveGroups PRs concern the Kostant form, unipotent groups, tori, or root subgroups.

After this PR, the Layer 4 Cartier-duality milestone still needs the anti-equivalence on finite commutative group schemes (restricting to the commutative/cocommutative Hopf objects), its transport through `Spec`, and the finite-locally-free general-base extension.

The required module organization move is:

| Old module | New module |
| --- | --- |
| `TauCeti.Algebra.HopfAlgebra.FiniteDual` | `TauCeti.Algebra.HopfAlgebra.FiniteDual.Basic` |

The proofs reuse Mathlib’s `LinearMap.dualMap`, `Module.evalEquiv`, convolution composition laws, `BialgHom.ofAlgHom`, `BialgEquiv.ofBialgHom`, and `CoalgEquiv.ofBijective`; no Mathlib code is vendored. The construction follows Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2, and Milne, *Algebraic Groups* (2017), §12.e, both cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-hopf-dual-functoriality"}-->

🤖 Prepared with Codex
