### PR TITLE
refactor(EllipticCurve): split the trace and norm halves of the integrality argument

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -366,60 +366,71 @@ private noncomputable def conjFunctionField :
     W.FunctionField ≃ₐ[F[X]] W.FunctionField :=
   IsFractionRing.algEquivOfAlgEquiv (CoordinateRing.conj W)
 
-/-- **The trace and the norm of an integral quotient are divisible by the denominator.** For
-`w = b / d` with `b` in the coordinate ring and `d` in `F[X]`, writing `b = p + q Y` in the basis,
-`d` divides the trace `2p - q(a₁X + a₃)` of `b`, and `d²` divides its norm
-`p² - pq(a₁X + a₃) - q²(X³ + a₂X² + a₄X + a₆)`.
+/-- The structure map into the function field factors through the coordinate ring. -/
+private theorem algebraMap_functionField_eq (r : F[X]) :
+    algebraMap F[X] W.FunctionField r =
+      algebraMap W.CoordinateRing W.FunctionField (algebraMap F[X] W.CoordinateRing r) :=
+  IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField r
 
-Ellipticity of `W` is not needed for this computation, and is not assumed. It enters only in the
-divisibility argument that consumes these two facts. -/
-private theorem dvd_trace_and_sq_dvd_norm {b : W.CoordinateRing} {d p q : F[X]}
+/-- Conjugation moves only the numerator of `b / d`, because it fixes `F[X]`. -/
+private theorem conjFunctionField_apply_div (b : W.CoordinateRing) (d : F[X]) :
+    conjFunctionField W (algebraMap W.CoordinateRing W.FunctionField b /
+        algebraMap F[X] W.FunctionField d) =
+      algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.conj W b) /
+        algebraMap F[X] W.FunctionField d := by
+  rw [map_div₀, conjFunctionField, IsFractionRing.algEquivOfAlgEquiv_algebraMap, AlgEquiv.commutes]
+
+/-- **The trace of an integral quotient is divisible by the denominator.** For `w = b / d` with `b`
+in the coordinate ring and `d` in `F[X]`, writing `b = p + q Y` in the basis, `d` divides the trace
+`2p - q(a₁X + a₃)` of `b`, because that trace is `w + σw` and both summands are integral.
+
+Ellipticity of `W` is not needed here, and is not assumed. -/
+private theorem dvd_trace_of_isIntegral_div {b : W.CoordinateRing} {d p q : F[X]}
     (hd0 : d ≠ 0) (hpq : p • (1 : W.CoordinateRing) + q • mk W Y = b)
     (hz : IsIntegral F[X] (algebraMap W.CoordinateRing W.FunctionField b /
       algebraMap F[X] W.FunctionField d)) :
-    d ∣ 2 * p - q * (C W.a₁ * X + C W.a₃) ∧
-      d ^ 2 ∣ p ^ 2 - p * q * (C W.a₁ * X + C W.a₃) -
-        q ^ 2 * (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆) := by
-  set σ := conjFunctionField W with hσ
-  have hmap : ∀ r : F[X], algebraMap F[X] W.FunctionField r =
-      algebraMap W.CoordinateRing W.FunctionField (algebraMap F[X] W.CoordinateRing r) := fun r =>
-    IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField r
-  have hσz : σ (algebraMap W.CoordinateRing W.FunctionField b /
-      algebraMap F[X] W.FunctionField d) =
-      algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.conj W b) /
-        algebraMap F[X] W.FunctionField d := by
-    rw [map_div₀, hσ, conjFunctionField, IsFractionRing.algEquivOfAlgEquiv_algebraMap,
-      AlgEquiv.commutes]
-  have hσzi : IsIntegral F[X] (σ (algebraMap W.CoordinateRing W.FunctionField b /
-      algebraMap F[X] W.FunctionField d)) := hz.map (σ : W.FunctionField →ₐ[F[X]] W.FunctionField)
-  refine ⟨dvd_of_isIntegral_div (L := W.FunctionField) hd0 ?_,
-    dvd_of_isIntegral_div (L := W.FunctionField) (pow_ne_zero 2 hd0) ?_⟩
-  · have hadd : p • (1 : W.CoordinateRing) + q • mk W Y +
-        CoordinateRing.conj W (p • 1 + q • mk W Y) =
-        algebraMap F[X] W.CoordinateRing (2 * p - q * (C W.a₁ * X + C W.a₃)) := by
-      simpa only [AdjoinRoot.mk_X, map_add, map_smul, map_one, CoordinateRing.conj_mk_Y,
-        AdjoinRoot.smul_mk] using CoordinateRing.add_negPolynomial_smul_basis W p q
-    have : algebraMap F[X] W.FunctionField (2 * p - q * (C W.a₁ * X + C W.a₃)) /
-        algebraMap F[X] W.FunctionField d =
-        algebraMap W.CoordinateRing W.FunctionField b / algebraMap F[X] W.FunctionField d +
-          σ (algebraMap W.CoordinateRing W.FunctionField b /
-            algebraMap F[X] W.FunctionField d) := by
-      rw [hσz, ← add_div, ← map_add, hmap, ← hpq, hadd]
-    rw [this]
-    exact hz.add hσzi
-  · have hnorm : Algebra.norm F[X] b = p ^ 2 - p * q * (C W.a₁ * X + C W.a₃) -
-        q ^ 2 * (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆) := by
-      rw [← hpq, norm_smul_basis]
-    have : algebraMap F[X] W.FunctionField (p ^ 2 - p * q * (C W.a₁ * X + C W.a₃) -
-        q ^ 2 * (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)) /
-        algebraMap F[X] W.FunctionField (d ^ 2) =
-        (algebraMap W.CoordinateRing W.FunctionField b / algebraMap F[X] W.FunctionField d) *
-          σ (algebraMap W.CoordinateRing W.FunctionField b /
-            algebraMap F[X] W.FunctionField d) := by
-      rw [hσz, div_mul_div_comm, ← map_mul, ← hnorm, CoordinateRing.mul_conj, ← hmap,
-        map_pow, pow_two]
-    rw [this]
-    exact hz.mul hσzi
+    d ∣ 2 * p - q * (C W.a₁ * X + C W.a₃) := by
+  refine dvd_of_isIntegral_div (L := W.FunctionField) hd0 ?_
+  have hadd : p • (1 : W.CoordinateRing) + q • mk W Y +
+      CoordinateRing.conj W (p • 1 + q • mk W Y) =
+      algebraMap F[X] W.CoordinateRing (2 * p - q * (C W.a₁ * X + C W.a₃)) := by
+    simpa only [AdjoinRoot.mk_X, map_add, map_smul, map_one, CoordinateRing.conj_mk_Y,
+      AdjoinRoot.smul_mk] using CoordinateRing.add_negPolynomial_smul_basis W p q
+  have hsum : algebraMap F[X] W.FunctionField (2 * p - q * (C W.a₁ * X + C W.a₃)) /
+      algebraMap F[X] W.FunctionField d =
+      algebraMap W.CoordinateRing W.FunctionField b / algebraMap F[X] W.FunctionField d +
+        conjFunctionField W (algebraMap W.CoordinateRing W.FunctionField b /
+          algebraMap F[X] W.FunctionField d) := by
+    rw [conjFunctionField_apply_div, ← add_div, ← map_add, algebraMap_functionField_eq, ← hpq,
+      hadd]
+  rw [hsum]
+  exact hz.add (hz.map (conjFunctionField W : W.FunctionField →ₐ[F[X]] W.FunctionField))
+
+/-- **The norm of an integral quotient is divisible by the square of the denominator.** The
+companion of `dvd_trace_of_isIntegral_div`: the norm is `w · σw`, so `d²` divides
+`p² - pq(a₁X + a₃) - q²(X³ + a₂X² + a₄X + a₆)`.
+
+Ellipticity of `W` is not needed here either. -/
+private theorem sq_dvd_norm_of_isIntegral_div {b : W.CoordinateRing} {d p q : F[X]}
+    (hd0 : d ≠ 0) (hpq : p • (1 : W.CoordinateRing) + q • mk W Y = b)
+    (hz : IsIntegral F[X] (algebraMap W.CoordinateRing W.FunctionField b /
+      algebraMap F[X] W.FunctionField d)) :
+    d ^ 2 ∣ p ^ 2 - p * q * (C W.a₁ * X + C W.a₃) -
+      q ^ 2 * (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆) := by
+  refine dvd_of_isIntegral_div (L := W.FunctionField) (pow_ne_zero 2 hd0) ?_
+  have hnorm : Algebra.norm F[X] b = p ^ 2 - p * q * (C W.a₁ * X + C W.a₃) -
+      q ^ 2 * (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆) := by
+    rw [← hpq, norm_smul_basis]
+  have hprod : algebraMap F[X] W.FunctionField (p ^ 2 - p * q * (C W.a₁ * X + C W.a₃) -
+      q ^ 2 * (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆)) /
+      algebraMap F[X] W.FunctionField (d ^ 2) =
+      (algebraMap W.CoordinateRing W.FunctionField b / algebraMap F[X] W.FunctionField d) *
+        conjFunctionField W (algebraMap W.CoordinateRing W.FunctionField b /
+          algebraMap F[X] W.FunctionField d) := by
+    rw [conjFunctionField_apply_div, div_mul_div_comm, ← map_mul, ← hnorm,
+      CoordinateRing.mul_conj, ← algebraMap_functionField_eq, map_pow, pow_two]
+  rw [hprod]
+  exact hz.mul (hz.map (conjFunctionField W : W.FunctionField →ₐ[F[X]] W.FunctionField))
 
 /-- Every element of the function field of an elliptic curve that is integral over `F[X]` already
 lies in the coordinate ring. -/
@@ -438,9 +449,6 @@ private theorem exists_algebraMap_eq [W.IsElliptic] {z : W.FunctionField}
   have hd0 : d ≠ 0 := fun h => (mul_ne_zero hb₂0 hcb₂0) (by rw [← hdB, h, map_zero])
   have hinjB : Function.Injective (algebraMap W.CoordinateRing W.FunctionField) :=
     FaithfulSMul.algebraMap_injective _ _
-  have hmap : ∀ r : F[X], algebraMap F[X] W.FunctionField r =
-      algebraMap W.CoordinateRing W.FunctionField (algebraMap F[X] W.CoordinateRing r) := fun r =>
-    IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField r
   have hinjK : Function.Injective (algebraMap F[X] W.FunctionField) := by
     rw [IsScalarTower.algebraMap_eq F[X] W.CoordinateRing W.FunctionField]
     exact hinjB.comp (FaithfulSMul.algebraMap_injective _ _)
@@ -451,17 +459,18 @@ private theorem exists_algebraMap_eq [W.IsElliptic] {z : W.FunctionField}
   have hzeq : algebraMap W.CoordinateRing W.FunctionField b₁ /
       algebraMap W.CoordinateRing W.FunctionField b₂ =
       algebraMap W.CoordinateRing W.FunctionField b / algebraMap F[X] W.FunctionField d := by
-    rw [hmap, hdB, hb, map_mul, map_mul, mul_div_mul_right _ _ hcb₂K]
+    rw [algebraMap_functionField_eq, hdB, hb, map_mul, map_mul, mul_div_mul_right _ _ hcb₂K]
   rw [hzeq] at hz ⊢
   -- the trace and the norm of `z`
   obtain ⟨p, q, hpq⟩ := exists_smul_basis_eq b
-  obtain ⟨htr, hnm⟩ := dvd_trace_and_sq_dvd_norm W hd0 hpq hz
+  have htr := dvd_trace_of_isIntegral_div W hd0 hpq hz
+  have hnm := sq_dvd_norm_of_isIntegral_div W hd0 hpq hz
   -- conclude
   obtain ⟨hdp, hdq⟩ := dvd_and_dvd W d p q hd0 htr hnm
   obtain ⟨p', rfl⟩ := hdp
   obtain ⟨q', rfl⟩ := hdq
   refine ⟨p' • 1 + q' • mk W Y, ?_⟩
-  rw [eq_div_iff hdK, hmap, ← map_mul, ← hpq]
+  rw [eq_div_iff hdK, algebraMap_functionField_eq, ← map_mul, ← hpq]
   congr 1
   simp only [smul, ← CoordinateRing.mk_C_eq_algebraMap, map_mul]
   ring1

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -366,12 +366,6 @@ private noncomputable def conjFunctionField :
     W.FunctionField ≃ₐ[F[X]] W.FunctionField :=
   IsFractionRing.algEquivOfAlgEquiv (CoordinateRing.conj W)
 
-/-- The structure map into the function field factors through the coordinate ring. -/
-private theorem algebraMap_functionField_eq (r : F[X]) :
-    algebraMap F[X] W.FunctionField r =
-      algebraMap W.CoordinateRing W.FunctionField (algebraMap F[X] W.CoordinateRing r) :=
-  IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField r
-
 /-- Conjugation moves only the numerator of `b / d`, because it fixes `F[X]`. -/
 private theorem conjFunctionField_apply_div (b : W.CoordinateRing) (d : F[X]) :
     conjFunctionField W (algebraMap W.CoordinateRing W.FunctionField b /
@@ -381,8 +375,9 @@ private theorem conjFunctionField_apply_div (b : W.CoordinateRing) (d : F[X]) :
   rw [map_div₀, conjFunctionField, IsFractionRing.algEquivOfAlgEquiv_algebraMap, AlgEquiv.commutes]
 
 /-- **The trace of an integral quotient is divisible by the denominator.** For `w = b / d` with `b`
-in the coordinate ring and `d` in `F[X]`, writing `b = p + q Y` in the basis, `d` divides the trace
-`2p - q(a₁X + a₃)` of `b`, because that trace is `w + σw` and both summands are integral.
+in the coordinate ring and `d` in `F[X]`, writing `b = p + q Y` in the basis, the trace of `w` is
+`w + σw = (2p - q(a₁X + a₃)) / d`, whose numerator is the trace of `b`. Both summands are integral
+over `F[X]`, hence so is the quotient, and that forces `d ∣ 2p - q(a₁X + a₃)`.
 
 Ellipticity of `W` is not needed here, and is not assumed. -/
 private theorem dvd_trace_of_isIntegral_div {b : W.CoordinateRing} {d p q : F[X]}
@@ -401,14 +396,15 @@ private theorem dvd_trace_of_isIntegral_div {b : W.CoordinateRing} {d p q : F[X]
       algebraMap W.CoordinateRing W.FunctionField b / algebraMap F[X] W.FunctionField d +
         conjFunctionField W (algebraMap W.CoordinateRing W.FunctionField b /
           algebraMap F[X] W.FunctionField d) := by
-    rw [conjFunctionField_apply_div, ← add_div, ← map_add, algebraMap_functionField_eq, ← hpq,
-      hadd]
+    rw [conjFunctionField_apply_div, ← add_div, ← map_add,
+      IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, ← hpq, hadd]
   rw [hsum]
   exact hz.add (hz.map (conjFunctionField W : W.FunctionField →ₐ[F[X]] W.FunctionField))
 
 /-- **The norm of an integral quotient is divisible by the square of the denominator.** The
-companion of `dvd_trace_of_isIntegral_div`: the norm is `w · σw`, so `d²` divides
-`p² - pq(a₁X + a₃) - q²(X³ + a₂X² + a₄X + a₆)`.
+companion of `dvd_trace_of_isIntegral_div`: the norm of `w = b / d` is
+`w · σw = Norm(b) / d²`, and `Norm(b)` is `p² - pq(a₁X + a₃) - q²(X³ + a₂X² + a₄X + a₆)` in the
+basis. Integrality of that product forces `d² ∣ Norm(b)`.
 
 Ellipticity of `W` is not needed here either. -/
 private theorem sq_dvd_norm_of_isIntegral_div {b : W.CoordinateRing} {d p q : F[X]}
@@ -428,7 +424,8 @@ private theorem sq_dvd_norm_of_isIntegral_div {b : W.CoordinateRing} {d p q : F[
         conjFunctionField W (algebraMap W.CoordinateRing W.FunctionField b /
           algebraMap F[X] W.FunctionField d) := by
     rw [conjFunctionField_apply_div, div_mul_div_comm, ← map_mul, ← hnorm,
-      CoordinateRing.mul_conj, ← algebraMap_functionField_eq, map_pow, pow_two]
+      CoordinateRing.mul_conj,
+      ← IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, map_pow, pow_two]
   rw [hprod]
   exact hz.mul (hz.map (conjFunctionField W : W.FunctionField →ₐ[F[X]] W.FunctionField))
 
@@ -459,7 +456,8 @@ private theorem exists_algebraMap_eq [W.IsElliptic] {z : W.FunctionField}
   have hzeq : algebraMap W.CoordinateRing W.FunctionField b₁ /
       algebraMap W.CoordinateRing W.FunctionField b₂ =
       algebraMap W.CoordinateRing W.FunctionField b / algebraMap F[X] W.FunctionField d := by
-    rw [algebraMap_functionField_eq, hdB, hb, map_mul, map_mul, mul_div_mul_right _ _ hcb₂K]
+    rw [IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, hdB, hb, map_mul,
+      map_mul, mul_div_mul_right _ _ hcb₂K]
   rw [hzeq] at hz ⊢
   -- the trace and the norm of `z`
   obtain ⟨p, q, hpq⟩ := exists_smul_basis_eq b
@@ -470,7 +468,8 @@ private theorem exists_algebraMap_eq [W.IsElliptic] {z : W.FunctionField}
   obtain ⟨p', rfl⟩ := hdp
   obtain ⟨q', rfl⟩ := hdq
   refine ⟨p' • 1 + q' • mk W Y, ?_⟩
-  rw [eq_div_iff hdK, algebraMap_functionField_eq, ← map_mul, ← hpq]
+  rw [eq_div_iff hdK, IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField,
+    ← map_mul, ← hpq]
   congr 1
   simp only [smul, ← CoordinateRing.mk_C_eq_algebraMap, map_mul]
   ring1


### PR DESCRIPTION
`dvd_trace_and_sq_dvd_norm` proved a conjunction in 47 lines: ten lines of shared setup, then two
visibly parallel halves — the trace and the norm. This splits it, and shares the two facts both
halves needed. No statement changes to any surviving declaration; no new public declaration.

## The shape it had

```lean
private theorem dvd_trace_and_sq_dvd_norm … : d ∣ 2p - q(a₁X + a₃) ∧ d² ∣ p² - pq(a₁X + a₃) - q²c
  set σ := conjFunctionField W with hσ
  have hmap  : ∀ r : F[X], algebraMap F[X] W.FunctionField r = …   -- (also written out verbatim
  have hσz   : σ (b / d) = conj b / d                              --  in exists_algebraMap_eq)
  have hσzi  : IsIntegral F[X] (σ (b / d))
  refine ⟨dvd_of_isIntegral_div hd0 ?_, dvd_of_isIntegral_div (pow_ne_zero 2 hd0) ?_⟩
  · …13 lines… exact hz.add hσzi     -- the trace half
  · …13 lines… exact hz.mul hσzi     -- the norm half
```

`/decompose-proof`'s "split `∧`" applies literally: the two bullets share nothing but the setup,
and each ends in the one-line fact that makes it work — `hz.add hσzi` for the trace, `hz.mul hσzi`
for the norm.

## What comes out

Two named halves, and one shared fact:

```lean
private theorem dvd_trace_of_isIntegral_div … : d ∣ 2 * p - q * (C W.a₁ * X + C W.a₃)
private theorem sq_dvd_norm_of_isIntegral_div … :
    d ^ 2 ∣ p ^ 2 - p * q * (C W.a₁ * X + C W.a₃) - q ^ 2 * (X ^ 3 + …)

/-- Conjugation moves only the numerator of `b / d`, because it fixes `F[X]`. -/
private theorem conjFunctionField_apply_div (b : W.CoordinateRing) (d : F[X]) :
    conjFunctionField W (algebraMap W.CoordinateRing W.FunctionField b /
        algebraMap F[X] W.FunctionField d)
      = algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.conj W b) /
        algebraMap F[X] W.FunctionField d
```

`dvd_trace_and_sq_dvd_norm` itself is **deleted** rather than kept as a wrapper around the two
halves — the repository does not carry a compatibility surface, and its single call site,
`exists_algebraMap_eq`, now makes two calls instead of destructuring one.

## A duplicated `have` goes too, against Mathlib rather than a new wrapper

This is the part worth more than the line count. A three-line
`have hmap : ∀ r : F[X], algebraMap F[X] W.FunctionField r = …` was written out **twice** — once in
`dvd_trace_and_sq_dvd_norm` and again, character for character, in `exists_algebraMap_eq` below it.
Both copies are gone: it is exactly `IsScalarTower.algebraMap_apply F[X] W.CoordinateRing
W.FunctionField`, so the call sites now name Mathlib's lemma directly. So a proof this PR is not
otherwise restructuring gets shorter too.

`hσzi` is deliberately *not* extracted: it is `hz.map σ`, a single application, and naming it would
buy nothing.

## Lengths

| Declaration | Before | After |
|---|---|---|
| `dvd_trace_and_sq_dvd_norm` | 47 | deleted |
| `dvd_trace_of_isIntegral_div` | — | 21 |
| `sq_dvd_norm_of_isIntegral_div` | — | 20 |
| `exists_algebraMap_eq` | 43 | 41 |
| `conjFunctionField_apply_div` | — | 7 |

Both halves land under the 30-line threshold. `exists_algebraMap_eq` is only two lines shorter and
remains above it; decomposing *that* proof is a separate topic and not attempted here.

Every tactic line is carried over unchanged apart from the plumbing the split requires: `set σ …
with hσ` disappears (the conjugation is now named at the two places it is applied), and the
rewrites that went through `hσz` now name `conjFunctionField_apply_div`, and the ones that went
through `hmap` name `IsScalarTower.algebraMap_apply` directly.

## Scope

Improvement work on existing code. Every declaration involved is `private`; nothing public is
added, renamed or removed; no new mathematics. The file goes from 489 to 497 lines, against the
1500-line limit for an existing file.

## Review

One private round, two findings, both taken:

* `reuse` (**block**) — a first draft named the repeated `hmap` as a private
  `algebraMap_functionField_eq`, which is precisely `IsScalarTower.algebraMap_apply` specialised.
  Deleted; the call sites use Mathlib's lemma.
* `documentation` — both new docstrings conflated the trace/norm of the numerator `b` with those of
  the quotient `w = b / d`. Corrected: the trace of `w` is `(2p - q(a₁X + a₃)) / d` and its norm is
  `Norm(b) / d²`.

## Gates

`lake build` whole project clean; `scripts/lint-env.sh` **PASS**, no new violations;
`lake exe axioms` all within `[propext, Classical.choice, Quot.sound]`; `lake exe module-system`
all modules opt in. No line exceeds 100 codepoints.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"coordring-split-trace-norm"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
