### PR TITLE
feat: prove the root-string Killing-form ratio

### DIFF
--- a/TauCeti/Algebra/Lie/Weights/RootString.lean
+++ b/TauCeti/Algebra/Lie/Weights/RootString.lean
@@ -257,10 +257,10 @@ private noncomputable def rootInvariantForm : (rootSystem H).InvariantForm where
       root_apply_cartanEquivDual_symm_ne_zero (H.isNonZero_coe_root i)
     have hai := (dualKillingForm_symm (H := H)).eq a i.1
     have hbi := (dualKillingForm_symm (H := H)).eq b i.1
-    -- Definitional equality: `(rootSystem H).reflection i` expands to reflection along `i.1`.
-    change dualKillingForm (a - a (coroot i.1) • (i.1 : Module.Dual K H))
-      (b - b (coroot i.1) • (i.1 : Module.Dual K H)) = dualKillingForm a b
-    simp only [map_sub, LinearMap.sub_apply, map_smul, map_nsmul, LinearMap.smul_apply,
+    rw [RootPairing.reflection_apply, RootPairing.reflection_apply]
+    simp only [rootSystem_root_apply, rootSystem_coroot_apply, RootPairing.coroot',
+      LinearMap.flip_apply, rootSystem_toLinearMap_apply,
+      map_sub, LinearMap.sub_apply, map_smul, map_nsmul, LinearMap.smul_apply,
       dualKillingForm_apply, smul_eq_mul, nsmul_eq_mul, Nat.cast_ofNat, coroot]
     simp only [dualKillingForm_apply] at hai hbi
     rw [hai, hbi]
@@ -295,12 +295,11 @@ private lemma rootSystem_chainCoeffs_eq {a b : Weight K H L}
       let c : Weight K H L := ⟨n • (a : H → K) + b, h⟩
       have hc : c.IsNonZero := by
         intro hc₀
-        -- Definitional equality: `c.IsNonZero` is `(c : H → K) ≠ 0`, so `hc₀` means `c.1 = 0`.
-        change n • (a : H → K) + b = 0 at hc₀
+        have hc₀' : n • (a : H → K) + b = 0 := hc₀.eq
         have hrel : (n : K) • (a : Module.Dual K H) +
             (1 : K) • (b : Module.Dual K H) = 0 := by
           ext z
-          simpa [Weight.toLinear_apply] using congrFun hc₀ z
+          simpa [Weight.toLinear_apply] using congrFun hc₀' z
         exact one_ne_zero (hab.eq_zero_of_pair hrel).2
       refine ⟨⟨c, by simpa [LieSubalgebra.root] using hc⟩, ?_⟩
       ext z
@@ -368,14 +367,9 @@ theorem chainTopCoeff_mul_killingForm_root_neg_eq
       (P := P) (rootInvariantForm (H := H)) hk
   have hβkill := hx.killingForm_root_neg_eq β hβ
   have hγkill := hx.killingForm_root_neg_eq γ hγ
-  simp only [rootInvariantForm, dualKillingForm_apply] at hlength
+  simp only [rootInvariantForm, dualKillingForm_apply, P, k, j, rootSystem_root_apply,
+    Weight.toLinear_apply] at hlength
   rw [hcoeff.1, hcoeff.2] at hlength
-  -- Definitional equality: `P.root k` reduces to `γ` and `P.root j` to `β`.
-  change (chainTopCoeff α β : K) *
-      (γ : Module.Dual K H) ((cartanEquivDual H).symm (γ : Module.Dual K H)) =
-    (chainBotCoeff α β + 1 : ℕ) *
-      (β : Module.Dual K H) ((cartanEquivDual H).symm (β : Module.Dual K H)) at hlength
-  simp only [Weight.toLinear_apply] at hlength
   rw [hβkill, hγkill]
   have hβne := root_apply_cartanEquivDual_symm_ne_zero hβ
   have hγne := root_apply_cartanEquivDual_symm_ne_zero hγ

--- a/TauCeti/Algebra/Lie/Weights/RootString.lean
+++ b/TauCeti/Algebra/Lie/Weights/RootString.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Algebra.Lie.Weights.RootSystem
+public import TauCeti.Algebra.Lie.Weights.Sl2System
+public import TauCeti.LinearAlgebra.RootSystem.InvariantForm.RootString
 
 public section
 
@@ -40,6 +42,8 @@ relations among the constants.
   pair of root vectors exists and is non-zero.
 * `TauCeti.mul_eq_of_lie_eq_smul`: the two structure constants of a root string multiply to
   `q * (p + 1)`.
+* `TauCeti.IsSl2System.chainTopCoeff_mul_killingForm_root_neg_eq`: normalized Killing pairings at
+  consecutive roots have the reciprocal root-length ratio.
 
 ## Implementation notes
 
@@ -64,7 +68,7 @@ Chevalley basis are the numbers `N` above. The product constraint `N * N' = q * 
 with a coherent normalization of root vectors and additional symmetry relations, leads to the
 integral normalization `N = ±(p + 1)`.
 
-* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §25.1.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §25.1--25.2.
 * R. W. Carter, *Simple Groups of Lie Type*, §4.1.
 -/
 
@@ -219,5 +223,161 @@ theorem mul_eq_of_lie_eq_smul {α β : Weight K H L} (hα : α.IsNonZero) (hβ :
   have hsub := sub_eq_zero.mpr hmain
   rw [← sub_smul, smul_eq_zero] at hsub
   exact sub_eq_zero.mp (hsub.resolve_right hy₀)
+
+/-! ### The root-length ratio -/
+
+private noncomputable def dualKillingForm : LinearMap.BilinForm K (Module.Dual K H) :=
+  (LinearMap.id : Module.Dual K H →ₗ[K] Module.Dual K H).compl₂
+    (cartanEquivDual H).symm.toLinearMap
+
+omit [CharZero K] [IsTriangularizable K H L] in
+@[simp]
+private lemma dualKillingForm_apply (a b : Module.Dual K H) :
+    dualKillingForm (H := H) a b = a ((cartanEquivDual H).symm b) :=
+  rfl
+
+omit [CharZero K] [IsTriangularizable K H L] in
+private lemma dualKillingForm_symm :
+    (dualKillingForm (H := H)).IsSymm := by
+  constructor
+  intro a b
+  have h := (LieModule.traceForm_isSymm K H L).eq
+    ((cartanEquivDual H).symm a) ((cartanEquivDual H).symm b)
+  simpa only [dualKillingForm_apply, cartanEquivDual,
+    LinearMap.BilinForm.apply_toDual_symm_apply, RingHom.id_apply] using h
+
+private noncomputable def rootInvariantForm : (rootSystem H).InvariantForm where
+  form := dualKillingForm
+  symm := LinearMap.BilinForm.isSymm_iff.mp dualKillingForm_symm
+  ne_zero i := by
+    simpa only [dualKillingForm_apply, rootSystem_root_apply, Weight.toLinear_apply] using
+      root_apply_cartanEquivDual_symm_ne_zero (H.isNonZero_coe_root i)
+  isOrthogonal_reflection i := by
+    intro a b
+    have hd : i.1 ((cartanEquivDual H).symm i.1) ≠ 0 :=
+      root_apply_cartanEquivDual_symm_ne_zero (H.isNonZero_coe_root i)
+    have hai := (dualKillingForm_symm (H := H)).eq a i.1
+    have hbi := (dualKillingForm_symm (H := H)).eq b i.1
+    change dualKillingForm (a - a (coroot i.1) • (i.1 : Module.Dual K H))
+      (b - b (coroot i.1) • (i.1 : Module.Dual K H)) = dualKillingForm a b
+    simp only [map_sub, LinearMap.sub_apply, map_smul, map_nsmul, LinearMap.smul_apply,
+      dualKillingForm_apply, smul_eq_mul, nsmul_eq_mul, Nat.cast_ofNat, coroot]
+    simp only [dualKillingForm_apply] at hai hbi
+    rw [hai, hbi]
+    simp only [Weight.toLinear_apply]
+    field_simp
+    ring
+
+private lemma rootSystem_chainCoeffs_eq {a b : Weight K H L}
+    (ha : a.IsNonZero) (hb : b.IsNonZero)
+    (hab : LinearIndependent K ![(a : Module.Dual K H), (b : Module.Dual K H)]) :
+    (rootSystem H).chainTopCoeff ⟨a, by simpa [LieSubalgebra.root] using ha⟩
+        ⟨b, by simpa [LieSubalgebra.root] using hb⟩ = chainTopCoeff a b ∧
+      (rootSystem H).chainBotCoeff ⟨a, by simpa [LieSubalgebra.root] using ha⟩
+        ⟨b, by simpa [LieSubalgebra.root] using hb⟩ = chainBotCoeff a b := by
+  let P := rootSystem H
+  let ia : H.root := ⟨a, by simpa [LieSubalgebra.root] using ha⟩
+  let ib : H.root := ⟨b, by simpa [LieSubalgebra.root] using hb⟩
+  have hlin : LinearIndependent K ![P.root ia, P.root ib] := by
+    simpa only [P, rootSystem_root_apply, ia, ib] using hab
+  have hmem (n : ℤ) :
+      P.root ib + n • P.root ia ∈ Set.range P.root ↔ rootSpace H (n • a + b) ≠ ⊥ := by
+    constructor
+    · rintro ⟨c, hc⟩
+      have hc' : (c.1 : H → K) = n • (a : H → K) + b := by
+        ext z
+        simpa only [P, rootSystem_root_apply, ia, ib, Weight.toLinear_apply,
+          LinearMap.add_apply, LinearMap.smul_apply, Pi.add_apply, Pi.smul_apply,
+          smul_eq_mul, add_comm] using DFunLike.congr_fun hc z
+      simpa only [hc'] using c.1.genWeightSpace_ne_bot
+    · intro h
+      let c : Weight K H L := ⟨n • (a : H → K) + b, h⟩
+      have hc : c.IsNonZero := by
+        intro hc₀
+        change n • (a : H → K) + b = 0 at hc₀
+        have hrel : (n : K) • (a : Module.Dual K H) +
+            (1 : K) • (b : Module.Dual K H) = 0 := by
+          ext z
+          simpa [Weight.toLinear_apply] using congrFun hc₀ z
+        exact one_ne_zero (hab.eq_zero_of_pair hrel).2
+      refine ⟨⟨c, by simpa [LieSubalgebra.root] using hc⟩, ?_⟩
+      ext z
+      simp [P, ia, ib, c, Weight.toLinear_apply, add_comm]
+  constructor
+  · apply le_antisymm
+    · have hz := (rootSpace_zsmul_add_ne_bot_iff a b ha
+          (P.chainTopCoeff ia ib)).1 <| (hmem _).1 <| by
+          simpa [Nat.cast_smul_eq_nsmul] using
+            (P.root_add_nsmul_mem_range_iff_le_chainTopCoeff hlin).2 le_rfl
+      exact_mod_cast hz.1
+    · rw [← P.root_add_nsmul_mem_range_iff_le_chainTopCoeff hlin]
+      have := (hmem (chainTopCoeff a b)).2 <| by
+        simpa [Nat.cast_smul_eq_nsmul] using
+          genWeightSpace_nsmul_add_ne_bot_of_le a b (le_refl (chainTopCoeff a b))
+      simpa [Nat.cast_smul_eq_nsmul] using this
+  · apply le_antisymm
+    · have hroot := (P.root_sub_nsmul_mem_range_iff_le_chainBotCoeff hlin).2 le_rfl
+      have := (hmem (-(P.chainBotCoeff ia ib : ℤ))).1 (by
+        simpa [Nat.cast_smul_eq_nsmul, sub_eq_add_neg, neg_smul] using hroot)
+      have hz := (rootSpace_zsmul_add_ne_bot_iff a b ha _).1 this |>.2
+      simp only [neg_neg] at hz
+      exact_mod_cast hz
+    · rw [← P.root_sub_nsmul_mem_range_iff_le_chainBotCoeff hlin]
+      have hroot := (rootSpace_zsmul_add_ne_bot_iff a b ha
+        (-(chainBotCoeff a b : ℤ))).2 (by simp)
+      have := (hmem (-(chainBotCoeff a b : ℤ))).2 hroot
+      simpa [Nat.cast_smul_eq_nsmul, sub_eq_add_neg, neg_smul] using this
+
+namespace IsSl2System
+
+variable {x : Weight K H L → L} (hx : IsSl2System x)
+
+include hx
+
+/-- **Root-string ratio for normalized Killing pairings.** If `γ = α + β`, then
+
+```text
+q B(x β, x (-β)) = (p + 1) B(x γ, x (-γ)),
+```
+
+where `p = chainBotCoeff α β` and `q = chainTopCoeff α β`. This reciprocal form of the
+invariant root-length identity supplies the cancellation used to normalize Chevalley structure
+constants. -/
+theorem chainTopCoeff_mul_killingForm_root_neg_eq
+    (α β γ : Weight K H L) (hα : α.IsNonZero) (hβ : β.IsNonZero) (hγ : γ.IsNonZero)
+    (hαβ : (γ : H → K) = (α : H → K) + β) :
+    (chainTopCoeff α β : K) * killingForm K L (x β) (x (-β)) =
+      (chainBotCoeff α β + 1 : ℕ) * killingForm K L (x γ) (x (-γ)) := by
+  let P := rootSystem H
+  let i : H.root := ⟨α, by simpa [LieSubalgebra.root] using hα⟩
+  let j : H.root := ⟨β, by simpa [LieSubalgebra.root] using hβ⟩
+  let k : H.root := ⟨γ, by simpa [LieSubalgebra.root] using hγ⟩
+  have hk : P.root k = P.root i + P.root j := by
+    ext z
+    simpa only [P, rootSystem_root_apply, i, j, k, Weight.toLinear_apply,
+      LinearMap.add_apply, Pi.add_apply] using congrFun hαβ z
+  have hlin := P.linearIndependent_of_add_mem_range_root' ⟨k, hk⟩
+  have hcoeff := rootSystem_chainCoeffs_eq hα hβ (by
+    simpa only [P, rootSystem_root_apply, i, j] using hlin)
+  have hlength :=
+    TauCeti.RootPairing.InvariantForm.chainTopCoeff_mul_apply_add_self_eq
+      (P := P) (rootInvariantForm (H := H)) hk
+  have hβkill := hx.killingForm_root_neg_eq β hβ
+  have hγkill := hx.killingForm_root_neg_eq γ hγ
+  simp only [rootInvariantForm, dualKillingForm_apply] at hlength
+  rw [hcoeff.1, hcoeff.2] at hlength
+  change (chainTopCoeff α β : K) *
+      (γ : Module.Dual K H) ((cartanEquivDual H).symm (γ : Module.Dual K H)) =
+    (chainBotCoeff α β + 1 : ℕ) *
+      (β : Module.Dual K H) ((cartanEquivDual H).symm (β : Module.Dual K H)) at hlength
+  simp only [Weight.toLinear_apply] at hlength
+  rw [hβkill, hγkill]
+  have hβne := root_apply_cartanEquivDual_symm_ne_zero hβ
+  have hγne := root_apply_cartanEquivDual_symm_ne_zero hγ
+  field_simp
+  rw [hlength]
+  ring
+
+end IsSl2System
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/Weights/RootString.lean
+++ b/TauCeti/Algebra/Lie/Weights/RootString.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Lie.Weights.RootSystem
 public import TauCeti.Algebra.Lie.Weights.Sl2System
 public import TauCeti.LinearAlgebra.RootSystem.InvariantForm.RootString
 
@@ -258,6 +257,7 @@ private noncomputable def rootInvariantForm : (rootSystem H).InvariantForm where
       root_apply_cartanEquivDual_symm_ne_zero (H.isNonZero_coe_root i)
     have hai := (dualKillingForm_symm (H := H)).eq a i.1
     have hbi := (dualKillingForm_symm (H := H)).eq b i.1
+    -- Definitional equality: `(rootSystem H).reflection i` expands to reflection along `i.1`.
     change dualKillingForm (a - a (coroot i.1) • (i.1 : Module.Dual K H))
       (b - b (coroot i.1) • (i.1 : Module.Dual K H)) = dualKillingForm a b
     simp only [map_sub, LinearMap.sub_apply, map_smul, map_nsmul, LinearMap.smul_apply,
@@ -280,6 +280,7 @@ private lemma rootSystem_chainCoeffs_eq {a b : Weight K H L}
   let ib : H.root := ⟨b, by simpa [LieSubalgebra.root] using hb⟩
   have hlin : LinearIndependent K ![P.root ia, P.root ib] := by
     simpa only [P, rootSystem_root_apply, ia, ib] using hab
+  -- Step 1: Equivalence between range membership in `P.root` and Lie weight space non-triviality.
   have hmem (n : ℤ) :
       P.root ib + n • P.root ia ∈ Set.range P.root ↔ rootSpace H (n • a + b) ≠ ⊥ := by
     constructor
@@ -294,6 +295,7 @@ private lemma rootSystem_chainCoeffs_eq {a b : Weight K H L}
       let c : Weight K H L := ⟨n • (a : H → K) + b, h⟩
       have hc : c.IsNonZero := by
         intro hc₀
+        -- Definitional equality: `c.IsNonZero` is `(c : H → K) ≠ 0`, so `hc₀` means `c.1 = 0`.
         change n • (a : H → K) + b = 0 at hc₀
         have hrel : (n : K) • (a : Module.Dual K H) +
             (1 : K) • (b : Module.Dual K H) = 0 := by
@@ -303,6 +305,7 @@ private lemma rootSystem_chainCoeffs_eq {a b : Weight K H L}
       refine ⟨⟨c, by simpa [LieSubalgebra.root] using hc⟩, ?_⟩
       ext z
       simp [P, ia, ib, c, Weight.toLinear_apply, add_comm]
+  -- Step 2: Compare `chainTopCoeff` via characterization by maximal non-vanishing.
   constructor
   · apply le_antisymm
     · have hz := (rootSpace_zsmul_add_ne_bot_iff a b ha
@@ -315,6 +318,7 @@ private lemma rootSystem_chainCoeffs_eq {a b : Weight K H L}
         simpa [Nat.cast_smul_eq_nsmul] using
           genWeightSpace_nsmul_add_ne_bot_of_le a b (le_refl (chainTopCoeff a b))
       simpa [Nat.cast_smul_eq_nsmul] using this
+  -- Step 3: Compare `chainBotCoeff` via characterization by minimal non-vanishing.
   · apply le_antisymm
     · have hroot := (P.root_sub_nsmul_mem_range_iff_le_chainBotCoeff hlin).2 le_rfl
       have := (hmem (-(P.chainBotCoeff ia ib : ℤ))).1 (by
@@ -360,12 +364,13 @@ theorem chainTopCoeff_mul_killingForm_root_neg_eq
   have hcoeff := rootSystem_chainCoeffs_eq hα hβ (by
     simpa only [P, rootSystem_root_apply, i, j] using hlin)
   have hlength :=
-    TauCeti.RootPairing.InvariantForm.chainTopCoeff_mul_apply_add_self_eq
+    TauCeti.RootPairing.InvariantForm.chainTopCoeff_mul_apply_root_self_eq
       (P := P) (rootInvariantForm (H := H)) hk
   have hβkill := hx.killingForm_root_neg_eq β hβ
   have hγkill := hx.killingForm_root_neg_eq γ hγ
   simp only [rootInvariantForm, dualKillingForm_apply] at hlength
   rw [hcoeff.1, hcoeff.2] at hlength
+  -- Definitional equality: `P.root k` reduces to `γ` and `P.root j` to `β`.
   change (chainTopCoeff α β : K) *
       (γ : Module.Dual K H) ((cartanEquivDual H).symm (γ : Module.Dual K H)) =
     (chainBotCoeff α β + 1 : ℕ) *

--- a/TauCeti/LinearAlgebra/RootSystem/InvariantForm/RootString.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/InvariantForm/RootString.lean
@@ -6,7 +6,6 @@ Authors: Codex
 module
 
 public import Mathlib.LinearAlgebra.RootSystem.Chain
-public import Mathlib.LinearAlgebra.RootSystem.RootPositive
 
 /-!
 # Invariant forms along root strings
@@ -77,9 +76,10 @@ namespace InvariantForm
 
 /-- Two orthogonal roots whose sum is a root have the same squared length in every invariant
 form. -/
-theorem apply_self_eq_of_pairing_eq_zero_of_root_add (B : P.InvariantForm) {i j k : I}
+theorem apply_root_self_eq_of_root_add_of_pairing_eq_zero (B : P.InvariantForm) {i j k : I}
     (hk : P.root k = P.root i + P.root j) (hij₀ : P.pairing i j = 0) :
     B.form (P.root i) (P.root i) = B.form (P.root j) (P.root j) := by
+  -- Step 1: Establish orthogonality and compute pairings with the sum root k.
   have hadd : P.root i + P.root j ∈ range P.root := ⟨k, hk⟩
   have hlin := P.linearIndependent_of_add_mem_range_root' hadd
   have hji₀ : P.pairing j i = 0 := (P.pairing_eq_zero_iff' (i := i) (j := j)).mp hij₀
@@ -89,6 +89,7 @@ theorem apply_self_eq_of_pairing_eq_zero_of_root_add (B : P.InvariantForm) {i j 
   have hkj : P.pairing k j = 2 := by
     rw [← P.root_coroot'_eq_pairing, hk, map_add, P.root_coroot'_eq_pairing,
       P.root_coroot'_eq_pairing, hij₀, P.pairing_same, zero_add]
+  -- Step 2: Verify that i and j are distinct from ±k to apply the pairing classification.
   have hik : P.root i ≠ P.root k := by
     intro h
     have hj₀ : P.root j = 0 := by
@@ -115,6 +116,7 @@ theorem apply_self_eq_of_pairing_eq_zero_of_root_add (B : P.InvariantForm) {i j 
     have hrel : (1 : R) • P.root i + (2 : R) • P.root j = 0 := by
       rw [one_smul, two_smul, ← add_assoc, ← hk, h, add_neg_cancel]
     exact one_ne_zero (hlin.eq_zero_of_pair hrel).1
+  -- Step 3: Classify integer pairings `⟨i, k⟩` and `⟨j, k⟩` using `P.pairingIn_pairingIn_mem_set`.
   have hkiℤ : P.pairingIn ℤ k i = 2 := by
     apply FaithfulSMul.algebraMap_injective ℤ R
     simpa only [P.algebraMap_pairingIn, map_ofNat] using hki
@@ -136,6 +138,7 @@ theorem apply_self_eq_of_pairing_eq_zero_of_root_add (B : P.InvariantForm) {i j 
     rw [← P.algebraMap_pairingIn ℤ]
     rw [this]
     norm_num
+  -- Step 4: Combine the invariant-form swap identities `B(i, i) ⟨k, i⟩ = B(k, k) ⟨i, k⟩`.
   have hi := B.pairing_mul_eq_pairing_mul_swap i k
   have hj := B.pairing_mul_eq_pairing_mul_swap j k
   rw [hki, hik₁] at hi
@@ -152,10 +155,11 @@ q (γ, γ) = (p + 1) (β, β),
 ```
 
 where `p = chainBotCoeff α β` and `q = chainTopCoeff α β`. -/
-theorem chainTopCoeff_mul_apply_add_self_eq (B : P.InvariantForm) {i j k : I}
+theorem chainTopCoeff_mul_apply_root_self_eq (B : P.InvariantForm) {i j k : I}
     (hk : P.root k = P.root i + P.root j) :
     (P.chainTopCoeff i j : R) * B.form (P.root k) (P.root k) =
       (P.chainBotCoeff i j + 1 : ℕ) * B.form (P.root j) (P.root j) := by
+  -- Step 1: Linear independence and string endpoint bounds.
   have hadd : P.root i + P.root j ∈ range P.root := ⟨k, hk⟩
   have hij := P.linearIndependent_of_add_mem_range_root' hadd
   have hji := P.linearIndependent_of_add_mem_range_root' (i := j) (j := i)
@@ -168,6 +172,7 @@ theorem chainTopCoeff_mul_apply_add_self_eq (B : P.InvariantForm) {i j k : I}
   have hlen' := P.chainBotCoeff_add_chainTopCoeff_le_three (i := j) (j := i)
   have hpq := P.chainBotCoeff_sub_chainTopCoeff hij
   have hpq' := P.chainBotCoeff_sub_chainTopCoeff hji
+  -- Step 2: Distinctness of roots `i` and `±j` from linear independence.
   have hne : i ≠ j := by
     intro h
     subst j
@@ -177,6 +182,7 @@ theorem chainTopCoeff_mul_apply_add_self_eq (B : P.InvariantForm) {i j k : I}
     exact one_ne_zero (hij.eq_zero_of_pair' (s := 1) (t := -1) (by simpa using h)).1
   have hpair := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed' i j
     (fun h ↦ hne (P.root.injective h)) hne'
+  -- Step 3: Bilinear expansion of `B(k, k) = B(i + j, i + j)` and invariant-form swap relation.
   have hsym : B.form (P.root j) (P.root i) = B.form (P.root i) (P.root j) := by
     simpa only [RingHom.id_apply] using B.symm.eq (P.root j) (P.root i)
   have hform :
@@ -206,6 +212,7 @@ theorem chainTopCoeff_mul_apply_add_self_eq (B : P.InvariantForm) {i j k : I}
   rw [hpqR, hpqR', ← hbot] at hlength
   rw [hform, hcross, hpqR]
   simp only [mem_insert_iff, mem_singleton_iff, Prod.mk.injEq] at hpair
+  -- Step 4: Case analysis on the root-pairing possibilities from the rank-2 classification.
   have hcases :
       P.chainTopCoeff i j = P.chainBotCoeff i j + 1 ∨
       (P.chainBotCoeff i j = 0 ∧ P.chainTopCoeff i j = 2 ∧
@@ -233,7 +240,7 @@ theorem chainTopCoeff_mul_apply_add_self_eq (B : P.InvariantForm) {i j k : I}
       rw [hpqR', ← hbot, hp, hq']
       norm_num
     have heq :=
-      TauCeti.RootPairing.InvariantForm.apply_self_eq_of_pairing_eq_zero_of_root_add
+      TauCeti.RootPairing.InvariantForm.apply_root_self_eq_of_root_add_of_pairing_eq_zero
         (P := P) B hk hij₀
     norm_num [hp, hq] at heq ⊢
     linear_combination heq

--- a/TauCeti/LinearAlgebra/RootSystem/InvariantForm/RootString.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/InvariantForm/RootString.lean
@@ -1,0 +1,248 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.LinearAlgebra.RootSystem.Chain
+public import Mathlib.LinearAlgebra.RootSystem.RootPositive
+
+/-!
+# Invariant forms along root strings
+
+This file records how an invariant bilinear form changes between consecutive roots in a root
+string.  The results are the root-system calculation behind the integrality of Chevalley structure
+constants.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §25.2.
+* R. W. Carter, *Simple Groups of Lie Type*, §4.1.
+
+This advances the Chevalley-basis input to the explicit Chevalley--Demazure construction in Layer
+9 of `TauCetiRoadmap/ReductiveGroups/README.md`, consumed by milestone L0 of the
+`CFSGStatement` roadmap.
+-/
+
+public section
+
+noncomputable section
+
+open Function Set
+
+namespace TauCeti
+
+namespace RootPairing
+
+variable {I R M N : Type*} [Finite I] [CommRing R] [CharZero R] [IsDomain R]
+  [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  {P : RootPairing I R M N} [P.IsCrystallographic] [P.IsReduced]
+
+/-- The lower endpoint of the root string through two roots is symmetric when their sum is a
+root. -/
+theorem chainBotCoeff_comm_of_root_add_mem {i j : I}
+    (hadd : P.root i + P.root j ∈ range P.root) :
+    P.chainBotCoeff i j = P.chainBotCoeff j i := by
+  have hij := P.linearIndependent_of_add_mem_range_root' hadd
+  have hji := P.linearIndependent_of_add_mem_range_root' (i := j) (j := i)
+    (by simpa [add_comm] using hadd)
+  have htop := P.one_le_chainTopCoeff_of_root_add_mem hadd
+  have htop' := P.one_le_chainTopCoeff_of_root_add_mem (i := j) (j := i)
+    (by simpa [add_comm] using hadd)
+  have hlen := P.chainBotCoeff_add_chainTopCoeff_le_three (i := i) (j := j)
+  have hlen' := P.chainBotCoeff_add_chainTopCoeff_le_three (i := j) (j := i)
+  have hbot_le : P.chainBotCoeff i j ≤ 2 := by omega
+  have htop_le : P.chainTopCoeff i j ≤ 3 := by omega
+  have htop'_le : P.chainTopCoeff j i ≤ 3 := by omega
+  have hbot : 1 ≤ P.chainBotCoeff i j ↔ 1 ≤ P.chainBotCoeff j i := by
+    rw [← P.root_sub_nsmul_mem_range_iff_le_chainBotCoeff hij,
+      ← P.root_sub_nsmul_mem_range_iff_le_chainBotCoeff hji]
+    simp only [one_smul]
+    constructor
+    · intro h
+      have hn := (P.neg_mem_range_root_iff (x := P.root j - P.root i)).2 h
+      simpa only [neg_sub] using hn
+    · intro h
+      have hn := (P.neg_mem_range_root_iff (x := P.root i - P.root j)).2 h
+      simpa only [neg_sub] using hn
+  have hpair := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed i j
+  have hpq := P.chainBotCoeff_sub_chainTopCoeff hij
+  have hpq' := P.chainBotCoeff_sub_chainTopCoeff hji
+  simp only [mem_insert_iff, mem_singleton_iff, Prod.mk.injEq] at hpair
+  rcases hpair with h | h | h | h | h | h | h | h | h | h | h | h | h <;>
+    rcases h with ⟨h, h'⟩ <;> omega
+
+namespace InvariantForm
+
+/-- Two orthogonal roots whose sum is a root have the same squared length in every invariant
+form. -/
+theorem apply_self_eq_of_pairing_eq_zero_of_root_add (B : P.InvariantForm) {i j k : I}
+    (hk : P.root k = P.root i + P.root j) (hij₀ : P.pairing i j = 0) :
+    B.form (P.root i) (P.root i) = B.form (P.root j) (P.root j) := by
+  have hadd : P.root i + P.root j ∈ range P.root := ⟨k, hk⟩
+  have hlin := P.linearIndependent_of_add_mem_range_root' hadd
+  have hji₀ : P.pairing j i = 0 := (P.pairing_eq_zero_iff' (i := i) (j := j)).mp hij₀
+  have hki : P.pairing k i = 2 := by
+    rw [← P.root_coroot'_eq_pairing, hk, map_add, P.root_coroot'_eq_pairing,
+      P.root_coroot'_eq_pairing, hji₀, P.pairing_same, add_zero]
+  have hkj : P.pairing k j = 2 := by
+    rw [← P.root_coroot'_eq_pairing, hk, map_add, P.root_coroot'_eq_pairing,
+      P.root_coroot'_eq_pairing, hij₀, P.pairing_same, zero_add]
+  have hik : P.root i ≠ P.root k := by
+    intro h
+    have hj₀ : P.root j = 0 := by
+      calc
+        P.root j = (P.root i + P.root j) - P.root i := by abel
+        _ = P.root k - P.root i := by rw [hk]
+        _ = 0 := sub_eq_zero.mpr h.symm
+    exact P.ne_zero j hj₀
+  have hjk : P.root j ≠ P.root k := by
+    intro h
+    have hi₀ : P.root i = 0 := by
+      calc
+        P.root i = (P.root i + P.root j) - P.root j := by abel
+        _ = P.root k - P.root j := by rw [hk]
+        _ = 0 := sub_eq_zero.mpr h.symm
+    exact P.ne_zero i hi₀
+  have hik' : P.root i ≠ -P.root k := by
+    intro h
+    have hrel : (2 : R) • P.root i + (1 : R) • P.root j = 0 := by
+      rw [one_smul, two_smul, add_assoc, ← hk, h, neg_add_cancel]
+    exact one_ne_zero (hlin.eq_zero_of_pair hrel).2
+  have hjk' : P.root j ≠ -P.root k := by
+    intro h
+    have hrel : (1 : R) • P.root i + (2 : R) • P.root j = 0 := by
+      rw [one_smul, two_smul, ← add_assoc, ← hk, h, add_neg_cancel]
+    exact one_ne_zero (hlin.eq_zero_of_pair hrel).1
+  have hkiℤ : P.pairingIn ℤ k i = 2 := by
+    apply FaithfulSMul.algebraMap_injective ℤ R
+    simpa only [P.algebraMap_pairingIn, map_ofNat] using hki
+  have hkjℤ : P.pairingIn ℤ k j = 2 := by
+    apply FaithfulSMul.algebraMap_injective ℤ R
+    simpa only [P.algebraMap_pairingIn, map_ofNat] using hkj
+  have hpik := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed' i k
+    hik hik'
+  have hpjk := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed' j k
+    hjk hjk'
+  simp only [mem_insert_iff, mem_singleton_iff, Prod.mk.injEq] at hpik hpjk
+  have hik₁ : P.pairing i k = 1 := by
+    have : P.pairingIn ℤ i k = 1 := by omega
+    rw [← P.algebraMap_pairingIn ℤ]
+    rw [this]
+    norm_num
+  have hjk₁ : P.pairing j k = 1 := by
+    have : P.pairingIn ℤ j k = 1 := by omega
+    rw [← P.algebraMap_pairingIn ℤ]
+    rw [this]
+    norm_num
+  have hi := B.pairing_mul_eq_pairing_mul_swap i k
+  have hj := B.pairing_mul_eq_pairing_mul_swap j k
+  rw [hki, hik₁] at hi
+  rw [hkj, hjk₁] at hj
+  have htwo : (2 : R) ≠ 0 := by norm_num
+  apply mul_left_cancel₀ htwo
+  linear_combination hi - hj
+
+/-- Along a root string, the squared lengths of two consecutive roots have the ratio of the
+corresponding raising coefficients.  If `γ = α + β`, then
+
+```text
+q (γ, γ) = (p + 1) (β, β),
+```
+
+where `p = chainBotCoeff α β` and `q = chainTopCoeff α β`. -/
+theorem chainTopCoeff_mul_apply_add_self_eq (B : P.InvariantForm) {i j k : I}
+    (hk : P.root k = P.root i + P.root j) :
+    (P.chainTopCoeff i j : R) * B.form (P.root k) (P.root k) =
+      (P.chainBotCoeff i j + 1 : ℕ) * B.form (P.root j) (P.root j) := by
+  have hadd : P.root i + P.root j ∈ range P.root := ⟨k, hk⟩
+  have hij := P.linearIndependent_of_add_mem_range_root' hadd
+  have hji := P.linearIndependent_of_add_mem_range_root' (i := j) (j := i)
+    (by simpa [add_comm] using hadd)
+  have hbot := chainBotCoeff_comm_of_root_add_mem (P := P) hadd
+  have htop := P.one_le_chainTopCoeff_of_root_add_mem hadd
+  have htop' := P.one_le_chainTopCoeff_of_root_add_mem (i := j) (j := i)
+    (by simpa [add_comm] using hadd)
+  have hlen := P.chainBotCoeff_add_chainTopCoeff_le_three (i := i) (j := j)
+  have hlen' := P.chainBotCoeff_add_chainTopCoeff_le_three (i := j) (j := i)
+  have hpq := P.chainBotCoeff_sub_chainTopCoeff hij
+  have hpq' := P.chainBotCoeff_sub_chainTopCoeff hji
+  have hne : i ≠ j := by
+    intro h
+    subst j
+    exact one_ne_zero (hij.eq_zero_of_pair' (s := 1) (t := 1) rfl).1
+  have hne' : P.root i ≠ -P.root j := by
+    intro h
+    exact one_ne_zero (hij.eq_zero_of_pair' (s := 1) (t := -1) (by simpa using h)).1
+  have hpair := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed' i j
+    (fun h ↦ hne (P.root.injective h)) hne'
+  have hsym : B.form (P.root j) (P.root i) = B.form (P.root i) (P.root j) := by
+    simpa only [RingHom.id_apply] using B.symm.eq (P.root j) (P.root i)
+  have hform :
+      B.form (P.root k) (P.root k) =
+        B.form (P.root i) (P.root i) + 2 * B.form (P.root i) (P.root j) +
+          B.form (P.root j) (P.root j) := by
+    rw [hk]
+    simp only [map_add, LinearMap.add_apply]
+    rw [hsym]
+    ring
+  have hcross :
+      2 * B.form (P.root i) (P.root j) =
+        P.pairing j i * B.form (P.root i) (P.root i) := by
+    rw [← hsym]
+    exact B.two_mul_apply_root_root j i
+  have hpqR : P.pairing j i =
+      (P.chainBotCoeff i j : R) - P.chainTopCoeff i j := by
+    rw [← P.algebraMap_pairingIn ℤ, ← hpq]
+    push_cast
+    rfl
+  have hpqR' : P.pairing i j =
+      (P.chainBotCoeff j i : R) - P.chainTopCoeff j i := by
+    rw [← P.algebraMap_pairingIn ℤ, ← hpq']
+    push_cast
+    rfl
+  have hlength := B.pairing_mul_eq_pairing_mul_swap i j
+  rw [hpqR, hpqR', ← hbot] at hlength
+  rw [hform, hcross, hpqR]
+  simp only [mem_insert_iff, mem_singleton_iff, Prod.mk.injEq] at hpair
+  have hcases :
+      P.chainTopCoeff i j = P.chainBotCoeff i j + 1 ∨
+      (P.chainBotCoeff i j = 0 ∧ P.chainTopCoeff i j = 2 ∧
+        P.chainTopCoeff j i = 1) ∨
+      (P.chainBotCoeff i j = 0 ∧ P.chainTopCoeff i j = 3 ∧
+        P.chainTopCoeff j i = 1) ∨
+      (P.chainBotCoeff i j = 1 ∧ P.chainTopCoeff i j = 1 ∧
+        P.chainTopCoeff j i = 1) ∨
+      (P.chainBotCoeff i j = 2 ∧ P.chainTopCoeff i j = 1 ∧
+        P.chainTopCoeff j i = 1) := by
+    rcases hpair with h | h | h | h | h | h | h | h | h | h | h <;>
+      rcases h with ⟨h, h'⟩ <;> omega
+  rcases hcases with h | ⟨hp, hq, hq'⟩ | ⟨hp, hq, hq'⟩ |
+      ⟨hp, hq, hq'⟩ | ⟨hp, hq, hq'⟩
+  · rw [h]
+    push_cast
+    ring
+  · norm_num [hp, hq, hq', hbot] at hlength ⊢
+    rw [← hlength]
+    ring
+  · norm_num [hp, hq, hq', hbot] at hlength ⊢
+    rw [← hlength]
+    ring
+  · have hij₀ : P.pairing i j = 0 := by
+      rw [hpqR', ← hbot, hp, hq']
+      norm_num
+    have heq :=
+      TauCeti.RootPairing.InvariantForm.apply_self_eq_of_pairing_eq_zero_of_root_add
+        (P := P) B hk hij₀
+    norm_num [hp, hq] at heq ⊢
+    linear_combination heq
+  · norm_num [hp, hq, hq', hbot] at hlength ⊢
+    rw [hlength]
+    ring
+
+end InvariantForm
+
+end RootPairing
+
+end TauCeti


### PR DESCRIPTION
This PR proves the invariant-form root-string ratio and specializes it to normalized Killing pairings: when `γ = α + β`, establish `q B(x β, x (-β)) = (p + 1) B(x γ, x (-γ))`. Compare Mathlib's abstract root-pairing string endpoints with its Lie-weight string endpoints, construct the inverse restricted-Killing invariant form, and discharge the exact root-length hypothesis exposed by the in-flight Chevalley structure-constant normalization in #3206.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, item “The Chevalley–Demazure construction,” specifically construction from a Chevalley basis and the Kostant `ℤ`-form of the enveloping algebra. This PR completes the invariant-form root-length calculation needed by the local normalization step. After this PR, that rung still needs the global coherent choice of a Chevalley-involution-compatible root-vector system and assembly of the resulting normalized constants into an integral Chevalley basis; Layer 9 then continues through integral PBW/freeness, the Hopf order, and the pinned group scheme.

The preferred `CFSGStatement` roadmap has no viable direct unclaimed step on current `main`: I0 and the sporadic lane are complete, the universe-transport part of A0 is in flight in #3058, and L0 explicitly waits on RootSystems Layer 6 and ReductiveGroups Layer 9. The RootSystems dispatcher is blocked by the active `E₇` and `E₈` datum PRs #2809 and #2893, so this PR follows the other explicit dependency into the missing Chevalley-basis root-length calculation.

Dependency edge: `CFSGStatement` milestone L0 “pinned ambient groups” consumes the explicit pinned Chevalley–Demazure group scheme from ReductiveGroups Layer 9; that construction consumes an integral Chevalley basis, and #3206's normalization theorem consumes the Killing-pairing ratio proved here.

Add `TauCeti/LinearAlgebra/RootSystem/InvariantForm/RootString.lean` (248 lines) and extend `TauCeti/Algebra/Lie/Weights/RootString.lean` by 161 lines. Reuse Mathlib's `RootPairing.InvariantForm`, root-chain endpoint characterizations, reduced crystallographic pairing classification, `cartanEquivDual`, and restricted Killing-form API; no Mathlib infrastructure or external formalization is vendored. The calculation follows Humphreys, *Introduction to Lie Algebras and Representation Theory*, §25.2, and Carter, *Simple Groups of Lie Type*, §4.1, as credited in the module documentation.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"root-string-killing-form-ratio"}-->

🤖 Prepared with Codex
