### PR TITLE
refactor(EllipticCurve): name the tangent and chord halves of variableChange_slope

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/VariableChange.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/VariableChange.lean
@@ -216,6 +216,43 @@ variable {F : Type*} [Field F] (W : WeierstrassCurve F) (C : VariableChange F)
 The slope of the chord or tangent is a quotient, so this is the first statement that needs to
 divide, and the only one here that asks for a field. -/
 
+/-- **The tangent case of `variableChange_slope`**: at a single point that is not its own
+negation, the tangent slope scales by `u` and translates by `s`. The curve equations are not
+needed — they are what `variableChange_slope` uses to reach this case. -/
+private lemma variableChange_slope_of_Y_ne [DecidableEq F] {x y : F}
+    (hy : y ≠ (C • W).toAffine.negY x y) :
+    W.toAffine.slope ((C.u : F) ^ 2 * x + C.r) ((C.u : F) ^ 2 * x + C.r)
+        ((C.u : F) ^ 3 * y + (C.u : F) ^ 2 * C.s * x + C.t)
+        ((C.u : F) ^ 3 * y + (C.u : F) ^ 2 * C.s * x + C.t)
+      = (C.u : F) * (C • W).toAffine.slope x x y y + C.s := by
+  have hu : (C.u : F) ≠ 0 := C.u.ne_zero
+  have hΦy : (C.u : F) ^ 3 * y + (C.u : F) ^ 2 * C.s * x + C.t
+      ≠ W.toAffine.negY ((C.u : F) ^ 2 * x + C.r)
+          ((C.u : F) ^ 3 * y + (C.u : F) ^ 2 * C.s * x + C.t) := by
+    rw [variableChange_negY]
+    exact fun h ↦ hy (mul_left_cancel₀ (pow_ne_zero 3 hu) (by linear_combination h))
+  rw [W.toAffine.slope_of_Y_ne rfl hΦy, (C • W).toAffine.slope_of_Y_ne rfl hy,
+    ← mul_div_assoc, div_add' _ _ _ (sub_ne_zero.mpr hy),
+    div_eq_div_iff (sub_ne_zero.mpr hΦy) (sub_ne_zero.mpr hy)]
+  simp [negY, variableChange_a₁, variableChange_a₂, variableChange_a₃, variableChange_a₄]
+  field
+
+/-- **The chord case of `variableChange_slope`**: through two points with distinct
+`x`-coordinates, which stay distinct after the change of variables because `u` is a unit. The
+curve equations are not needed here either. -/
+private lemma variableChange_slope_of_X_ne [DecidableEq F] {x₁ x₂ y₁ y₂ : F} (hx : x₁ ≠ x₂) :
+    W.toAffine.slope ((C.u : F) ^ 2 * x₁ + C.r) ((C.u : F) ^ 2 * x₂ + C.r)
+        ((C.u : F) ^ 3 * y₁ + (C.u : F) ^ 2 * C.s * x₁ + C.t)
+        ((C.u : F) ^ 3 * y₂ + (C.u : F) ^ 2 * C.s * x₂ + C.t)
+      = (C.u : F) * (C • W).toAffine.slope x₁ x₂ y₁ y₂ + C.s := by
+  have hu : (C.u : F) ≠ 0 := C.u.ne_zero
+  have hΦx : (C.u : F) ^ 2 * x₁ + C.r ≠ (C.u : F) ^ 2 * x₂ + C.r := by
+    simpa [mul_right_inj' (pow_ne_zero 2 hu)] using hx
+  rw [W.toAffine.slope_of_X_ne hΦx, (C • W).toAffine.slope_of_X_ne hx]
+  have h1 := sub_ne_zero.mpr hΦx
+  have h2 := sub_ne_zero.mpr hx
+  field
+
 /-- **The slope under the change of variables**, scaling by `u` and translating by `s` — the law
 the change of variables applies to a slope, as `y` scales by `u³` and `x` by `u²`. Stated for two
 points of `C • W` on the curve, excluding the degenerate case `x₁ = x₂ ∧ y₁ = negY x₂ y₂` —
@@ -227,26 +264,11 @@ lemma variableChange_slope [DecidableEq F] {x₁ x₂ y₁ y₂ : F}
         ((C.u : F) ^ 3 * y₁ + (C.u : F) ^ 2 * C.s * x₁ + C.t)
         ((C.u : F) ^ 3 * y₂ + (C.u : F) ^ 2 * C.s * x₂ + C.t)
       = (C.u : F) * (C • W).toAffine.slope x₁ x₂ y₁ y₂ + C.s := by
-  have hu : (C.u : F) ≠ 0 := C.u.ne_zero
   rcases eq_or_ne x₁ x₂ with rfl | hx
   · have hy : y₁ ≠ (C • W).toAffine.negY x₁ y₂ := fun h ↦ hxy ⟨rfl, h⟩
     obtain rfl := Y_eq_of_Y_ne h₁ h₂ rfl hy
-    have hΦy : (C.u : F) ^ 3 * y₁ + (C.u : F) ^ 2 * C.s * x₁ + C.t
-        ≠ W.toAffine.negY ((C.u : F) ^ 2 * x₁ + C.r)
-            ((C.u : F) ^ 3 * y₁ + (C.u : F) ^ 2 * C.s * x₁ + C.t) := by
-      rw [variableChange_negY]
-      exact fun h ↦ hy (mul_left_cancel₀ (pow_ne_zero 3 hu) (by linear_combination h))
-    rw [W.toAffine.slope_of_Y_ne rfl hΦy, (C • W).toAffine.slope_of_Y_ne rfl hy,
-      ← mul_div_assoc, div_add' _ _ _ (sub_ne_zero.mpr hy),
-      div_eq_div_iff (sub_ne_zero.mpr hΦy) (sub_ne_zero.mpr hy)]
-    simp [negY, variableChange_a₁, variableChange_a₂, variableChange_a₃, variableChange_a₄]
-    field
-  · have hΦx : (C.u : F) ^ 2 * x₁ + C.r ≠ (C.u : F) ^ 2 * x₂ + C.r := by
-      simpa [mul_right_inj' (pow_ne_zero 2 hu)] using hx
-    rw [W.toAffine.slope_of_X_ne hΦx, (C • W).toAffine.slope_of_X_ne hx]
-    have h1 := sub_ne_zero.mpr hΦx
-    have h2 := sub_ne_zero.mpr hx
-    field
+    exact variableChange_slope_of_Y_ne W C hy
+  · exact variableChange_slope_of_X_ne W C hx
 
 end Field
 


### PR DESCRIPTION
`variableChange_slope` carried a 33-line proof that is one `rcases` over two unrelated cases: the
tangent at a single point, and the chord through two points with distinct `x`. Name them. No
statement changes; no new public declaration.

## The split

The proof was

```lean
  rcases eq_or_ne x₁ x₂ with rfl | hx
  · …13 lines…   -- tangent: slope_of_Y_ne on both sides
  · …6 lines…    -- chord:   slope_of_X_ne on both sides
```

with nothing shared between the branches but `have hu : (C.u : F) ≠ 0`. The two are now
`variableChange_slope_of_Y_ne` and `variableChange_slope_of_X_ne`, named after the Mathlib lemmas
each one runs on (`Affine.slope_of_Y_ne`, `Affine.slope_of_X_ne`), and `variableChange_slope`
becomes the case split alone:

```lean
  rcases eq_or_ne x₁ x₂ with rfl | hx
  · have hy : y₁ ≠ (C • W).toAffine.negY x₁ y₂ := fun h ↦ hxy ⟨rfl, h⟩
    obtain rfl := Y_eq_of_Y_ne h₁ h₂ rfl hy
    exact variableChange_slope_of_Y_ne W C hy
  · exact variableChange_slope_of_X_ne W C hx
```

## Neither half needs the curve

This is what the split exposes. `variableChange_slope` takes the two equations `h₁`, `h₂` and the
non-degeneracy `hxy`, but neither branch uses the equations directly:

* the **chord** half needs only `x₁ ≠ x₂`;
* the **tangent** half needs only `y ≠ negY x y` at the one point.

The equations are used in exactly one place — `Y_eq_of_Y_ne h₁ h₂ rfl hy`, which is how the
`x₁ = x₂` branch learns that `y₂ = y₁` and so collapses to a single point. That step now stands
alone in the parent proof, and the two halves are pure slope algebra. Each helper's docstring says
so.

## Lengths

| Declaration | Before | After |
|---|---|---|
| `variableChange_slope` | 33 | 18 |
| `variableChange_slope_of_Y_ne` | — | 18 |
| `variableChange_slope_of_X_ne` | — | 13 |

All three are under the 30-line threshold; the largest branch was 13 lines, which
`/decompose-proof` flags for extraction. Every tactic line is carried over unchanged apart from
`have hu : (C.u : F) ≠ 0`, which each half now derives for itself since the parent no longer needs
it.

## Scope

Improvement work on existing code: no statement changes, both new declarations are `private`, and
no new mathematics. The file goes from 256 to 278 lines, against the 1500-line limit for an
existing file. The one downstream module, `Affine/Point/VariableChange.lean`, is untouched and
rebuilt clean.

## Gates

`lake build` whole project **7810 jobs** clean, no warnings; `scripts/lint-env.sh` **PASS**, no new
violations; `lake exe axioms` **44769** declarations all within `[propext, Classical.choice,
Quot.sound]`; `lake exe module-system` **2153/2153**. No line exceeds 100 codepoints.

The private review round came back all ten green with no findings.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"varchange-slope-tangent"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
