### PR TITLE
refactor(FundamentalDomainBoundary): drop the redundant nonvanishing hypothesis

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -123,15 +123,20 @@ private theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 
         (((ρ : ℂ) - w) / ((ρ : ℂ) + 1 - w)).arg +
         ((-1 / 2 + H * Complex.I - w) / ((ρ : ℂ) - w)).arg +
         ((1 / 2 + H * Complex.I - w) / (-1 / 2 + H * Complex.I - w)).arg := by
-    simpa [Complex.log_im] using congrArg Complex.im
-      ((inv_mul_eq_iff_eq_mul₀ Complex.two_pi_I_ne_zero).mp (hsum.symm.trans hn)).symm
+    -- clear the `(2πI)⁻¹`, then read off the imaginary part: each `log`'s is its argument
+    have hmul := (inv_mul_eq_iff_eq_mul₀ Complex.two_pi_I_ne_zero).mp (hsum.symm.trans hn)
+    have hIm' := congrArg Complex.im hmul.symm
+    simpa [Complex.log_im, Complex.add_im, Complex.mul_im] using hIm'
   have hb₁ := Complex.neg_pi_lt_arg (((ρ : ℂ) + 1 - w) / (1 / 2 + H * Complex.I - w))
   have hb₂ := Complex.neg_pi_lt_arg (((ρ : ℂ) - w) / ((ρ : ℂ) + 1 - w))
   have hb₃ := Complex.neg_pi_lt_arg ((-1 / 2 + H * Complex.I - w) / ((ρ : ℂ) - w))
   have hb₄ := Complex.neg_pi_lt_arg ((1 / 2 + H * Complex.I - w) / (-1 / 2 + H * Complex.I - w))
-  have hn2 : (-2 : ℤ) < n := by exact_mod_cast (show (-2 : ℝ) < (n : ℝ) by nlinarith)
-  have hn0 : n < 0 := by exact_mod_cast (show (n : ℝ) < 0 by nlinarith)
-  rw [hn, show n = -1 by lia]
+  have hn2R : (-2 : ℝ) < (n : ℝ) := by nlinarith
+  have hn0R : (n : ℝ) < 0 := by nlinarith
+  have hn2 : (-2 : ℤ) < n := by exact_mod_cast hn2R
+  have hn0 : n < 0 := by exact_mod_cast hn0R
+  have hneg : n = -1 := by lia
+  rw [hn, hneg]
   norm_num
 
 /-- Points of the lifted segment and of the strip box satisfy the interior avoidance

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -74,8 +74,10 @@ theorem fdBoundary_ne_of_abs_re_lt_half_of_one_lt_norm_of_im_lt (hre : |w.re| < 
 
 /-- The endpoint ratio of a piece has negative argument when its junction chord turns
 clockwise as seen from `w`; the four instances below feed the pinning argument. -/
-private lemma arg_div_neg {z₁ z₂ : ℂ} (hz₁ : z₁ ≠ 0)
-    (hnum : z₂.im * z₁.re - z₂.re * z₁.im < 0) : (z₂ / z₁).arg < 0 := by
+private lemma arg_div_neg {z₁ z₂ : ℂ} (hnum : z₂.im * z₁.re - z₂.re * z₁.im < 0) :
+    (z₂ / z₁).arg < 0 := by
+  -- a vanishing denominator would make the chord determinant `0`, contradicting `hnum`
+  have hz₁ : z₁ ≠ 0 := by rintro rfl; simp at hnum
   rw [Complex.arg_neg_iff, Complex.div_im, div_sub_div_same]
   exact div_neg_of_neg_of_pos hnum (Complex.normSq_pos.mpr hz₁)
 
@@ -85,37 +87,17 @@ private theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 
     (hy1 : 1 < w.im) (hyH : w.im < H) : windingNumber (fdBoundary H) 0 5 w = -1 := by
   obtain ⟨hx₁, hx₂⟩ := abs_lt.mp hx
   have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_lt_one.le
-  have hnorm : 1 < ‖w‖ :=
-    hy1.trans_le ((le_abs_self _).trans (Complex.abs_im_le_norm w))
+  have hnorm : 1 < ‖w‖ := hy1.trans_le ((le_abs_self _).trans (Complex.abs_im_le_norm w))
   have hw := fdBoundary_ne_of_abs_re_lt_half_of_one_lt_norm_of_im_lt hx hnorm hyH
-  -- the four endpoint differences, their coordinates, and their nonvanishing
-  have hz₀ : (1 / 2 + H * Complex.I - w).re = 1 / 2 - w.re ∧
-      (1 / 2 + H * Complex.I - w).im = H - w.im := by constructor <;> simp
-  have hz₁ : ((ρ : ℂ) + 1 - w).re = 1 / 2 - w.re ∧
-      ((ρ : ℂ) + 1 - w).im = Real.sqrt 3 / 2 - w.im := by
-    constructor <;> simp [ρ]; norm_num
-  have hz₃ : ((ρ : ℂ) - w).re = -(1 / 2) - w.re ∧
-      ((ρ : ℂ) - w).im = Real.sqrt 3 / 2 - w.im := by
-    constructor <;> simp [ρ]; norm_num
-  have hz₄ : (-1 / 2 + H * Complex.I - w).re = -(1 / 2) - w.re ∧
-      (-1 / 2 + H * Complex.I - w).im = H - w.im := by constructor <;> simp; norm_num
-  have hne₀ : (1 / 2 + H * Complex.I - w) ≠ 0 := fun h0 => by
-    have := congrArg Complex.re h0; rw [hz₀.1] at this; simp at this; linarith
-  have hne₁ : ((ρ : ℂ) + 1 - w) ≠ 0 := fun h0 => by
-    have := congrArg Complex.re h0; rw [hz₁.1] at this; simp at this; linarith
-  have hne₃ : ((ρ : ℂ) - w) ≠ 0 := fun h0 => by
-    have := congrArg Complex.re h0; rw [hz₃.1] at this; simp at this; linarith
-  have hne₄ : (-1 / 2 + H * Complex.I - w) ≠ 0 := fun h0 => by
-    have := congrArg Complex.re h0; rw [hz₄.1] at this; simp at this; linarith
-  -- the four piece arguments are strictly negative
-  have ha₁ : ((((ρ : ℂ) + 1 - w)) / (1 / 2 + H * Complex.I - w)).arg < 0 :=
-    arg_div_neg hne₀ (by rw [hz₀.1, hz₀.2, hz₁.1, hz₁.2]; nlinarith)
-  have ha₂ : ((((ρ : ℂ) - w)) / ((ρ : ℂ) + 1 - w)).arg < 0 :=
-    arg_div_neg hne₁ (by rw [hz₁.1, hz₁.2, hz₃.1, hz₃.2]; nlinarith)
-  have ha₃ : (((-1 / 2 + H * Complex.I - w)) / ((ρ : ℂ) - w)).arg < 0 :=
-    arg_div_neg hne₃ (by rw [hz₃.1, hz₃.2, hz₄.1, hz₄.2]; nlinarith)
-  have ha₄ : (((1 / 2 + H * Complex.I - w)) / (-1 / 2 + H * Complex.I - w)).arg < 0 :=
-    arg_div_neg hne₄ (by rw [hz₄.1, hz₄.2, hz₀.1, hz₀.2]; nlinarith)
+  -- the four endpoint differences turn clockwise: the piece arguments are strictly negative
+  have ha₁ : (((ρ : ℂ) + 1 - w) / (1 / 2 + H * Complex.I - w)).arg < 0 :=
+    arg_div_neg <| by norm_num [ρ]; nlinarith
+  have ha₂ : (((ρ : ℂ) - w) / ((ρ : ℂ) + 1 - w)).arg < 0 :=
+    arg_div_neg <| by norm_num [ρ]; nlinarith
+  have ha₃ : ((-1 / 2 + H * Complex.I - w) / ((ρ : ℂ) - w)).arg < 0 :=
+    arg_div_neg <| by norm_num [ρ]; nlinarith
+  have ha₄ : ((1 / 2 + H * Complex.I - w) / (-1 / 2 + H * Complex.I - w)).arg < 0 :=
+    arg_div_neg <| by norm_num [ρ]; nlinarith
   -- the winding number is the normalized sum of the four principal logarithms
   have hsum : windingNumber (fdBoundary H) 0 5 w =
       (2 * (Real.pi : ℂ) * Complex.I)⁻¹ *
@@ -124,10 +106,8 @@ private theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 
           Complex.log ((-1 / 2 + H * Complex.I - w) / ((ρ : ℂ) - w)) +
           Complex.log ((1 / 2 + H * Complex.I - w) / (-1 / 2 + H * Complex.I - w))) := by
     rw [windingNumber_fdBoundary_eq_sum_pieces hw,
-      windingNumber_fdBoundarySegment1_eq_log hx₂,
-      windingNumber_fdBoundary_arc_eq_log hy1,
-      windingNumber_fdBoundarySegment4_eq_log hx₁,
-      windingNumber_fdBoundarySegment5_eq_log hyH]
+      windingNumber_fdBoundarySegment1_eq_log hx₂, windingNumber_fdBoundary_arc_eq_log hy1,
+      windingNumber_fdBoundarySegment4_eq_log hx₁, windingNumber_fdBoundarySegment5_eq_log hyH]
     ring
   -- integrality
   obtain ⟨P, hP, hdiff⟩ := (isPiecewiseC1On_fdBoundary H).exists_countable_differentiableAt
@@ -138,28 +118,20 @@ private theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 
       (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])
       (isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv)
   -- extract the argument sum and pin the integer
-  have hπ : (0 : ℝ) < Real.pi := Real.pi_pos
   have hIm : 2 * Real.pi * (n : ℝ) =
       (((ρ : ℂ) + 1 - w) / (1 / 2 + H * Complex.I - w)).arg +
-        ((((ρ : ℂ) - w)) / ((ρ : ℂ) + 1 - w)).arg +
-        (((-1 / 2 + H * Complex.I - w)) / ((ρ : ℂ) - w)).arg +
-        (((1 / 2 + H * Complex.I - w)) / (-1 / 2 + H * Complex.I - w)).arg := by
-    have := hsum.symm.trans hn
-    rw [inv_mul_eq_iff_eq_mul₀ Complex.two_pi_I_ne_zero] at this
-    have hIm' := congrArg Complex.im this.symm
-    simpa [Complex.log_im, Complex.add_im, Complex.mul_im] using hIm'
+        (((ρ : ℂ) - w) / ((ρ : ℂ) + 1 - w)).arg +
+        ((-1 / 2 + H * Complex.I - w) / ((ρ : ℂ) - w)).arg +
+        ((1 / 2 + H * Complex.I - w) / (-1 / 2 + H * Complex.I - w)).arg := by
+    simpa [Complex.log_im] using congrArg Complex.im
+      ((inv_mul_eq_iff_eq_mul₀ Complex.two_pi_I_ne_zero).mp (hsum.symm.trans hn)).symm
   have hb₁ := Complex.neg_pi_lt_arg (((ρ : ℂ) + 1 - w) / (1 / 2 + H * Complex.I - w))
-  have hb₂ := Complex.neg_pi_lt_arg ((((ρ : ℂ) - w)) / ((ρ : ℂ) + 1 - w))
-  have hb₃ := Complex.neg_pi_lt_arg (((-1 / 2 + H * Complex.I - w)) / ((ρ : ℂ) - w))
-  have hb₄ := Complex.neg_pi_lt_arg (((1 / 2 + H * Complex.I - w)) / (-1 / 2 + H * Complex.I - w))
-  have hn2 : (-2 : ℤ) < n := by
-    have : (-2 : ℝ) < (n : ℝ) := by nlinarith
-    exact_mod_cast this
-  have hn0 : n < 0 := by
-    have : ((n : ℝ)) < 0 := by nlinarith
-    exact_mod_cast this
-  have : n = -1 := by omega
-  rw [hn, this]
+  have hb₂ := Complex.neg_pi_lt_arg (((ρ : ℂ) - w) / ((ρ : ℂ) + 1 - w))
+  have hb₃ := Complex.neg_pi_lt_arg ((-1 / 2 + H * Complex.I - w) / ((ρ : ℂ) - w))
+  have hb₄ := Complex.neg_pi_lt_arg ((1 / 2 + H * Complex.I - w) / (-1 / 2 + H * Complex.I - w))
+  have hn2 : (-2 : ℤ) < n := by exact_mod_cast (show (-2 : ℝ) < (n : ℝ) by nlinarith)
+  have hn0 : n < 0 := by exact_mod_cast (show (n : ℝ) < 0 by nlinarith)
+  rw [hn, show n = -1 by lia]
   norm_num
 
 /-- Points of the lifted segment and of the strip box satisfy the interior avoidance


### PR DESCRIPTION
A `/cleanup` pass over `windingNumber_fdBoundary_eq_neg_one_of_one_lt_im`, whose body ran to 78
lines and was almost entirely consecutive `have`s — twelve in a row at its worst.

## The one observation that carries it

`arg_div_neg` asked its callers for `(hz₁ : z₁ ≠ 0)`. That hypothesis is redundant: its other
hypothesis is `z₂.im * z₁.re - z₂.re * z₁.im < 0`, and at `z₁ = 0` the chord determinant is
literally `0`, so the strict inequality is already false. The lemma now derives it in one line
(`rintro rfl; simp at hnum`) and is strictly more general.

Everything else follows. The four hand-rolled `hne₀ … hne₄` derivations existed only to discharge
that argument, and the four `hz₀ … hz₄` coordinate conjunctions existed only to feed those — all
eight blocks are gone, and the four determinant goals are discharged directly by `norm_num [ρ]`
at the point of use.

## Also in this pass

* Seven non-terminal bare `simp` calls removed (they were inside the deleted blocks).
* `hπ : 0 < Real.pi` was unused — `hb₁` and `ha₁` already pin it linearly. Dropped, drop-test
  verified against the build.
* Four single-use inner `have`s inlined; `omega` → `lia`; `f (by …)` → `f <| by …`; seven
  redundant double-paren groups removed, which makes the four ratios in `ha`/`hb`/`hIm`
  textually identical.

`grind` and `aesop` were both tried on the whole proof and on the determinant subgoals; both
fail, and `linear_combination` degenerates to the `ring` already there. Mathlib has no
`windingNumber` at all, so there is nothing upstream to route to.

## Result

| | before | after |
|---|---|---|
| `windingNumber_fdBoundary_eq_neg_one_of_one_lt_im` | 78 | 53 |
| `arg_div_neg` | 4 | 6 |
| file | 251 | 228 |

The theorem's statement is byte-identical; the `arg_div_neg` signature change is the deliberate
weakening described above. Longest consecutive-`have` run in the proof: 12 → 6.

## Review round 1

`proof-quality` flagged two over-golfed steps and both are fixed. The imaginary-part step is
staged again — `hmul`, then `hIm'`, then the `simpa` — with `Complex.add_im` and `Complex.mul_im`
named rather than left to the ambient simp set, and the three `show` ascriptions in the pinning
step are typed `have` facts (`hn2R`, `hn0R`, `hneg`).

The finding suggested `simpa only`. That does not close the goal: `simpa only [Complex.log_im,
Complex.add_im, Complex.mul_im] using hIm'` fails with `Type mismatch: After simplification, term
…` at that line, because the ambient set performs normalisation beyond the three named lemmas. The
form kept is `simpa [Complex.log_im, Complex.add_im, Complex.mul_im]` — an explicit list including
both imaginary-part lemmas the finding asks for, which is the same list the pre-cleanup proof used.

Gates re-run on `5a69bc77`: `lake build` (7809 jobs), `lake exe axioms` (44721 declarations),
`lake exe module-system` (2149 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: ModularForms

