### PR TITLE
feat(EDS): index bookkeeping for the descent on the elliptic relator

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Data.Fin.VecNotation
 public import Mathlib.NumberTheory.EllipticDivisibilitySequence
 import Mathlib.Data.Int.ModEq
 import Mathlib.Order.Fin.Tuple
@@ -35,6 +36,8 @@ terminate.
   `atomRel_avg_sub` produces it.
 * `IsEllipticNet.parity_abs_avg_sub`: the same after `atomRel_abs₄` absorbs the sign on the last
   index — the shape the descent consumes.
+* `IsEllipticNet.nonnegStrictAnti₄_def` / `nonnegStrictAnti₄_iff`: the predicate's defining body,
+  and its adjacent-inequality normal form.
 * `IsEllipticNet.nonnegStrictAnti₄_avg_sub`: nonnegativity and strict decrease survive it.
 * `IsEllipticNet.six_le_of_parity_of_nonnegStrictAnti₄`: a strictly decreasing quadruple
   of one parity with `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three
@@ -84,9 +87,14 @@ the descent needs it wherever it needs the ordering; the decreasing half is Math
 `StrictAnti` on the tuple. -/
 def NonnegStrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ StrictAnti ![a, b, c, d]
 
+/-- The defining body of `NonnegStrictAnti₄`, for a consumer that wants the tuple form and
+Mathlib's `StrictAnti` API directly rather than the adjacent inequalities. -/
+theorem nonnegStrictAnti₄_def (a b c d : ℤ) :
+    NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ StrictAnti ![a, b, c, d] := Iff.rfl
+
 /-- `NonnegStrictAnti₄` unfolded to its adjacent inequalities. Not a restatement of the
-defining body — that is `0 ≤ d ∧ StrictAnti ![a, b, c, d]` — but the equivalent form consumers
-want, and the normal form `simp` rewrites to. -/
+defining body — that is `nonnegStrictAnti₄_def` — but the equivalent form the descent consumes,
+and the normal form `simp` rewrites to. -/
 @[simp]
 theorem nonnegStrictAnti₄_iff (a b c d : ℤ) :
     NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := by

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -35,7 +35,8 @@ terminate.
 
 * `IsEllipticNet.parity_abs_avg_sub`: same parity survives the transfer, with the witness taken
   relative to the entry `atomRel_abs₄` leaves under an absolute value.
-* `IsEllipticNet.nonnegStrictAnti₄_iff`: the predicate as its four adjacent inequalities.
+* `IsEllipticNet.nonnegStrictAnti₄_def` / `nonnegStrictAnti₄_iff`: the predicate in its defining
+  tuple form, and as its four adjacent inequalities.
 * `IsEllipticNet.nonnegStrictAnti₄_abs_avg_sub`: nonnegativity and strict decrease survive it.
 * `IsEllipticNet.six_le_of_parity_of_nonnegStrictAnti₄`: a strictly decreasing quadruple
   of one parity with `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three
@@ -104,6 +105,11 @@ namespace IsEllipticNet
 the descent needs it wherever it needs the ordering; the decreasing half is Mathlib's
 `StrictAnti` on the tuple. -/
 def NonnegStrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ StrictAnti ![a, b, c, d]
+
+/-- `NonnegStrictAnti₄` in its defining tuple form, for a consumer that wants Mathlib's
+`StrictAnti` API on the tuple. Not `@[simp]`: `nonnegStrictAnti₄_iff` is the normal form. -/
+theorem nonnegStrictAnti₄_def (a b c d : ℤ) :
+    NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ StrictAnti ![a, b, c, d] := Iff.rfl
 
 /-- `NonnegStrictAnti₄` as its four adjacent inequalities. -/
 @[simp]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -35,7 +35,8 @@ terminate.
 
 * `IsEllipticNet.parity_abs_avg_sub`: same parity survives the transfer, with the witness taken
   relative to the entry `atomRel_abs₄` leaves under an absolute value.
-* `IsEllipticNet.nonnegStrictAnti₄_iff`: the predicate as its four adjacent inequalities.
+* `IsEllipticNet.nonnegStrictAnti₄_iff`: the predicate as the lower bound `0 ≤ d` together
+  with the three adjacent inequalities.
 * `IsEllipticNet.nonnegStrictAnti₄_abs_avg_sub`: nonnegativity and strict decrease survive it.
 * `IsEllipticNet.six_le_of_parity_of_nonnegStrictAnti₄`: a strictly decreasing quadruple
   of one parity with `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three
@@ -106,7 +107,7 @@ the descent needs it wherever it needs the ordering; the decreasing half is Math
 `StrictAnti` on the tuple. -/
 def NonnegStrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ StrictAnti ![a, b, c, d]
 
-/-- `NonnegStrictAnti₄` as its four adjacent inequalities. -/
+/-- `NonnegStrictAnti₄` as the lower bound and the three adjacent inequalities. -/
 @[simp]
 theorem nonnegStrictAnti₄_iff (a b c d : ℤ) :
     NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := by

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -33,14 +33,10 @@ terminate.
 
 ## Main results
 
-* `IsEllipticNet.parity_abs_avg_sub`: same parity survives the transfer, in the form the descent
-  consumes — after `atomRel_abs₄` has absorbed the sign. The raw-index form that `atomRel_avg_sub`
-  produces is a private step inside its proof rather than a second public spelling.
-* `IsEllipticNet.nonnegStrictAnti₄_def` / `nonnegStrictAnti₄_iff`: the predicate's defining body,
-  and its adjacent-inequality normal form.
-* `IsEllipticNet.nonnegStrictAnti₄_abs_avg_sub`: nonnegativity and strict decrease survive it,
-  under the gap `d + 2 ≤ c` rather than parity — parity is what the descent has, but only the gap
-  is what the proof uses.
+* `IsEllipticNet.parity_abs_avg_sub`: same parity survives the transfer, with the witness taken
+  relative to the entry `atomRel_abs₄` leaves under an absolute value.
+* `IsEllipticNet.nonnegStrictAnti₄_iff`: the predicate as its four adjacent inequalities.
+* `IsEllipticNet.nonnegStrictAnti₄_abs_avg_sub`: nonnegativity and strict decrease survive it.
 * `IsEllipticNet.six_le_of_parity_of_nonnegStrictAnti₄`: a strictly decreasing quadruple
   of one parity with `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three
   times over.
@@ -62,10 +58,16 @@ normal form once for downstream use.
 **On the imports.** The rule here is: **public** for what the public *statements* mention,
 **private** for what only the proofs need. So `Mathlib.Algebra.Order.Group.Int` and
 `…Group.Unbundled.Abs` are public — the statements use ℤ arithmetic and `|…|` — as is
-`Mathlib.Order.Fin.Tuple`, since `nonnegStrictAnti₄_def` mentions `StrictAnti ![…]` and that
+`Mathlib.Order.Fin.Tuple`, since `NonnegStrictAnti₄` is defined by `StrictAnti ![…]` and that
 module supplies the vector notation too. `Mathlib.Data.Int.ModEq` and `Mathlib.Algebra.Order.Group
 .Abs` are private, each used only inside a proof — the latter for `abs_cases`, which is
 `to_additive`-generated from `mabs_cases` and so appears under no literal definition of its own.
+
+**On the hypotheses.** `nonnegStrictAnti₄_abs_avg_sub` takes the four inequalities separately
+rather than a bundled `NonnegStrictAnti₄` plus a gap: the descent supplies parity, from which
+`d + 2 ≤ c` follows by `omega`, and bundling would have carried `d < c` alongside the strictly
+stronger gap. Only `parity_abs_avg_sub` and `six_le_of_parity_of_nonnegStrictAnti₄` genuinely need
+parity as parity.
 
 This file does **not** import `Mathlib.NumberTheory.EllipticDivisibilitySequence`. No declaration
 here mentions `atom`, `atomRel` or `rel`: the statements are about ℤ arithmetic, order and parity,
@@ -103,14 +105,7 @@ the descent needs it wherever it needs the ordering; the decreasing half is Math
 `StrictAnti` on the tuple. -/
 def NonnegStrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ StrictAnti ![a, b, c, d]
 
-/-- The defining body of `NonnegStrictAnti₄`, for a consumer that wants the tuple form and
-Mathlib's `StrictAnti` API directly rather than the adjacent inequalities. -/
-theorem nonnegStrictAnti₄_def (a b c d : ℤ) :
-    NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ StrictAnti ![a, b, c, d] := Iff.rfl
-
-/-- `NonnegStrictAnti₄` unfolded to its adjacent inequalities. Not a restatement of the
-defining body — that is `nonnegStrictAnti₄_def` — but the equivalent form the descent consumes,
-and the normal form `simp` rewrites to. -/
+/-- `NonnegStrictAnti₄` as its four adjacent inequalities. -/
 @[simp]
 theorem nonnegStrictAnti₄_iff (a b c d : ℤ) :
     NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := by
@@ -119,9 +114,7 @@ theorem nonnegStrictAnti₄_iff (a b c d : ℤ) :
   omega
 
 /-- **Same parity survives the transfer**, for the transferred quadruple exactly as
-`atomRel_avg_sub` produces it, with the last index raw. Private: it is the step through which
-`parity_abs_avg_sub` is proved, and that absolute-value form is the shape every consumer wants,
-so exporting both would put two spellings of one fact on the public surface. -/
+`atomRel_avg_sub` produces it, with the last index raw. -/
 private theorem parity_avg_sub {a b c d : ℤ}
     (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
     ((a + b + c + d) / 2 - a) % 2 = ((a + b + c + d) / 2 - d) % 2 ∧
@@ -130,10 +123,8 @@ private theorem parity_avg_sub {a b c d : ℤ}
   obtain ⟨h₁, h₂, h₃⟩ := parity
   omega
 
-/-- **Same parity survives the transfer**, in the form the descent consumes: the parity witness is
-written relative to `|(a + b + c + d) / 2 - a|`, the entry `atomRel_abs₄` leaves under an absolute
-value. This is the only public parity statement here; the raw-index step it goes through is
-private. -/
+/-- **Same parity survives the transfer**, with the parity witness written relative to
+`|(a + b + c + d) / 2 - a|`, the entry `atomRel_abs₄` leaves under an absolute value. -/
 theorem parity_abs_avg_sub {a b c d : ℤ}
     (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
     |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - d) % 2 ∧
@@ -145,18 +136,12 @@ theorem parity_abs_avg_sub {a b c d : ℤ}
   exact ⟨habs.trans h₁, habs.trans h₂, habs.trans h₃⟩
 
 /-- **Nonnegativity and strict decrease survive the transfer.** The last index needs its absolute
-value: `m - a` is the one difference that can be negative, `a` being the largest index.
-
-The hypothesis is the **gap** `d + 2 ≤ c`, not parity. The descent supplies parity, and
-`d % 2 = c % 2` together with `d < c` gives the gap — but only the gap is used, so demanding
-parity here would state the lemma at a narrower level than it holds. A caller that has parity
-closes the difference by `omega`. -/
-theorem nonnegStrictAnti₄_abs_avg_sub {a b c d : ℤ} (hcd : d + 2 ≤ c)
-    (anti : NonnegStrictAnti₄ a b c d) :
+value: `m - a` is the one difference that can be negative, `a` being the largest index. -/
+theorem nonnegStrictAnti₄_abs_avg_sub {a b c d : ℤ}
+    (hd : 0 ≤ d) (hcd : d + 2 ≤ c) (hcb : c < b) (hba : b < a) :
     NonnegStrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
       ((a + b + c + d) / 2 - b) |(a + b + c + d) / 2 - a| := by
-  rw [nonnegStrictAnti₄_iff] at anti ⊢
-  obtain ⟨hd, hdc, hcb, hba⟩ := anti
+  rw [nonnegStrictAnti₄_iff]
   refine ⟨abs_nonneg _, ?_, by omega, by omega⟩
   rcases abs_cases ((a + b + c + d) / 2 - a) with ⟨h, _⟩ | ⟨h, _⟩ <;> rw [h] <;> omega
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -57,6 +57,15 @@ chain of three inequalities. `Mathlib/Order/Fin/Tuple.lean` states that API thro
 into the adjacent comparisons the descent consumes, and `nonnegStrictAnti₄_iff` records that
 normal form once for downstream use.
 
+**On the imports.** No *declaration* here mentions `atomRel`; the EDS import is nevertheless kept
+public rather than replaced by narrow modules. Replacing it was tried and costs more than it saves:
+dropping it loses `abs`, then `AddGroup ℤ`, then `abs_cases`, each surfacing only at the next build,
+because that one import transitively carries the ℤ ordered-algebra stack these proofs run on. The
+file also lives in `EllipticDivisibilitySequence/`, declares into `IsEllipticNet`, and exists to
+feed `atomRel_avg_sub` and `atomRel_abs₄`, so a consumer of this module wants EDS in scope anyway.
+`Mathlib.Data.Fin.VecNotation` is public because `nonnegStrictAnti₄_def` mentions `![…]` in its
+statement; `Mathlib.Data.Int.ModEq` stays private, being used only inside a proof.
+
 ## Provenance
 
 Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
@@ -126,12 +135,10 @@ theorem parity_abs_avg_sub {a b c d : ℤ}
 
 /-- **Nonnegativity and strict decrease survive the transfer.** The last index needs its absolute
 value: `m - a` is the one difference that can be negative, `a` being the largest index. -/
-theorem nonnegStrictAnti₄_avg_sub {a b c d : ℤ}
-    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2)
+theorem nonnegStrictAnti₄_avg_sub {a b c d : ℤ} (parity : d % 2 = c % 2)
     (anti : NonnegStrictAnti₄ a b c d) :
     NonnegStrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
       ((a + b + c + d) / 2 - b) |(a + b + c + d) / 2 - a| := by
-  obtain ⟨h₁, h₂, h₃⟩ := parity
   rw [nonnegStrictAnti₄_iff] at anti ⊢
   obtain ⟨hd, hdc, hcb, hba⟩ := anti
   refine ⟨abs_nonneg _, ?_, by omega, by omega⟩

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -7,8 +7,8 @@ module
 public import Mathlib.Algebra.Order.Group.Int
 public import Mathlib.Algebra.Order.Group.Unbundled.Abs
 public import Mathlib.Order.Fin.Tuple
+import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Data.Int.ModEq
-import Mathlib.NumberTheory.EllipticDivisibilitySequence
 
 /-!
 # Index bookkeeping for the descent on the elliptic relator
@@ -61,9 +61,15 @@ normal form once for downstream use.
 **private** for what only the proofs need. So `Mathlib.Algebra.Order.Group.Int` and
 `…Group.Unbundled.Abs` are public — the statements use ℤ arithmetic and `|…|` — as is
 `Mathlib.Order.Fin.Tuple`, since `nonnegStrictAnti₄_def` mentions `StrictAnti ![…]` and that
-module supplies the vector notation too. `Mathlib.Data.Int.ModEq` is private, used only inside a
-proof. The EDS import is **private** as well: no declaration here mentions `atomRel`, so none of
-that API belongs in this module's public surface, but the proofs still draw instances from it.
+module supplies the vector notation too. `Mathlib.Data.Int.ModEq` and `Mathlib.Algebra.Order.Group
+.Abs` are private, each used only inside a proof — the latter for `abs_cases`, which is
+`to_additive`-generated from `mabs_cases` and so appears under no literal definition of its own.
+
+This file does **not** import `Mathlib.NumberTheory.EllipticDivisibilitySequence`. No declaration
+here mentions `atom`, `atomRel` or `rel`: the statements are about ℤ arithmetic, order and parity,
+and the EDS lemmas they are *for* — `atomRel_avg_sub`, `atomRel_abs₄`, `atomRel_eq` — are named in
+the prose because that is what fixes the index shapes, not because anything here needs their API.
+Importing the EDS module only to reach `abs_cases` through it cost 279 build jobs.
 
 ## Provenance
 
@@ -122,9 +128,10 @@ private theorem parity_avg_sub {a b c d : ℤ}
   obtain ⟨h₁, h₂, h₃⟩ := parity
   omega
 
-/-- **Same parity survives the transfer**, in the form the descent consumes: the first index
-carries the absolute value that `atomRel_abs₄` leaves behind. This is the only public parity
-statement here; the raw-index step it goes through is private. -/
+/-- **Same parity survives the transfer**, in the form the descent consumes: the parity witness is
+written relative to `|(a + b + c + d) / 2 - a|`, the entry `atomRel_abs₄` leaves under an absolute
+value. This is the only public parity statement here; the raw-index step it goes through is
+private. -/
 theorem parity_abs_avg_sub {a b c d : ℤ}
     (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
     |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - d) % 2 ∧

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+import Mathlib.Data.Int.ModEq
 import Mathlib.Order.Fin.Tuple
 
 /-!
@@ -109,8 +110,10 @@ theorem parity_abs_avg_sub {a b c d : ℤ}
     |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - d) % 2 ∧
       |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - c) % 2 ∧
         |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - b) % 2 := by
-  obtain ⟨h₁, h₂, h₃⟩ := parity
-  rcases abs_cases ((a + b + c + d) / 2 - a) with ⟨h, _⟩ | ⟨h, _⟩ <;> rw [h] <;> omega
+  have habs : |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - a) % 2 :=
+    Int.abs_modEq_two
+  obtain ⟨h₁, h₂, h₃⟩ := parity_avg_sub parity
+  exact ⟨habs.trans h₁, habs.trans h₂, habs.trans h₃⟩
 
 /-- **Nonnegativity and strict decrease survive the transfer.** The last index needs its absolute
 value: `m - a` is the one difference that can be negative, `a` being the largest index. -/

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -35,8 +35,7 @@ terminate.
 
 * `IsEllipticNet.parity_abs_avg_sub`: same parity survives the transfer, with the witness taken
   relative to the entry `atomRel_abs₄` leaves under an absolute value.
-* `IsEllipticNet.nonnegStrictAnti₄_def` / `nonnegStrictAnti₄_iff`: the predicate in its defining
-  tuple form, and as its four adjacent inequalities.
+* `IsEllipticNet.nonnegStrictAnti₄_iff`: the predicate as its four adjacent inequalities.
 * `IsEllipticNet.nonnegStrictAnti₄_abs_avg_sub`: nonnegativity and strict decrease survive it.
 * `IsEllipticNet.six_le_of_parity_of_nonnegStrictAnti₄`: a strictly decreasing quadruple
   of one parity with `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three
@@ -64,10 +63,11 @@ module supplies the vector notation too. `Mathlib.Data.Int.ModEq` and `Mathlib.A
 .Abs` are private, each used only inside a proof — the latter for `abs_cases`, which is
 `to_additive`-generated from `mabs_cases` and so appears under no literal definition of its own.
 
-**On the hypotheses.** `nonnegStrictAnti₄_abs_avg_sub` takes the four inequalities separately
-rather than a bundled `NonnegStrictAnti₄` plus a gap: the descent supplies parity, from which
-`d + 2 ≤ c` follows by `omega`, and bundling would have carried `d < c` alongside the strictly
-stronger gap. Only `parity_abs_avg_sub` and `six_le_of_parity_of_nonnegStrictAnti₄` genuinely need
+**On the hypotheses.** `nonnegStrictAnti₄_abs_avg_sub` takes `d < c`, `2 ≤ c + d`, `c < b` and
+`b < a` separately, rather than a bundled `NonnegStrictAnti₄`. Those are what the transferred
+ordering actually needs: the descent supplies parity, and a same-parity gap is strictly stronger
+than this — `(a, b, c, d) = (4, 3, 2, 1)` satisfies these and the conclusion while failing
+`d + 2 ≤ c`. Only `parity_abs_avg_sub` and `six_le_of_parity_of_nonnegStrictAnti₄` genuinely need
 parity as parity.
 
 This file does **not** import `Mathlib.NumberTheory.EllipticDivisibilitySequence`. No declaration
@@ -106,11 +106,6 @@ the descent needs it wherever it needs the ordering; the decreasing half is Math
 `StrictAnti` on the tuple. -/
 def NonnegStrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ StrictAnti ![a, b, c, d]
 
-/-- `NonnegStrictAnti₄` in its defining tuple form, for a consumer that wants Mathlib's
-`StrictAnti` API on the tuple. Not `@[simp]`: `nonnegStrictAnti₄_iff` is the normal form. -/
-theorem nonnegStrictAnti₄_def (a b c d : ℤ) :
-    NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ StrictAnti ![a, b, c, d] := Iff.rfl
-
 /-- `NonnegStrictAnti₄` as its four adjacent inequalities. -/
 @[simp]
 theorem nonnegStrictAnti₄_iff (a b c d : ℤ) :
@@ -144,7 +139,7 @@ theorem parity_abs_avg_sub {a b c d : ℤ}
 /-- **Nonnegativity and strict decrease survive the transfer.** The last index needs its absolute
 value: `m - a` is the one difference that can be negative, `a` being the largest index. -/
 theorem nonnegStrictAnti₄_abs_avg_sub {a b c d : ℤ}
-    (hd : 0 ≤ d) (hcd : d + 2 ≤ c) (hcb : c < b) (hba : b < a) :
+    (hdc : d < c) (hcd : 2 ≤ c + d) (hcb : c < b) (hba : b < a) :
     NonnegStrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
       ((a + b + c + d) / 2 - b) |(a + b + c + d) / 2 - a| := by
   rw [nonnegStrictAnti₄_iff]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -38,7 +38,9 @@ terminate.
   produces is a private step inside its proof rather than a second public spelling.
 * `IsEllipticNet.nonnegStrictAnti₄_def` / `nonnegStrictAnti₄_iff`: the predicate's defining body,
   and its adjacent-inequality normal form.
-* `IsEllipticNet.nonnegStrictAnti₄_abs_avg_sub`: nonnegativity and strict decrease survive it.
+* `IsEllipticNet.nonnegStrictAnti₄_abs_avg_sub`: nonnegativity and strict decrease survive it,
+  under the gap `d + 2 ≤ c` rather than parity — parity is what the descent has, but only the gap
+  is what the proof uses.
 * `IsEllipticNet.six_le_of_parity_of_nonnegStrictAnti₄`: a strictly decreasing quadruple
   of one parity with `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three
   times over.
@@ -143,8 +145,13 @@ theorem parity_abs_avg_sub {a b c d : ℤ}
   exact ⟨habs.trans h₁, habs.trans h₂, habs.trans h₃⟩
 
 /-- **Nonnegativity and strict decrease survive the transfer.** The last index needs its absolute
-value: `m - a` is the one difference that can be negative, `a` being the largest index. -/
-theorem nonnegStrictAnti₄_abs_avg_sub {a b c d : ℤ} (parity : d % 2 = c % 2)
+value: `m - a` is the one difference that can be negative, `a` being the largest index.
+
+The hypothesis is the **gap** `d + 2 ≤ c`, not parity. The descent supplies parity, and
+`d % 2 = c % 2` together with `d < c` gives the gap — but only the gap is used, so demanding
+parity here would state the lemma at a narrower level than it holds. A caller that has parity
+closes the difference by `omega`. -/
+theorem nonnegStrictAnti₄_abs_avg_sub {a b c d : ℤ} (hcd : d + 2 ≤ c)
     (anti : NonnegStrictAnti₄ a b c d) :
     NonnegStrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
       ((a + b + c + d) / 2 - b) |(a + b + c + d) / 2 - a| := by

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -33,10 +33,9 @@ terminate.
 
 ## Main results
 
-* `IsEllipticNet.parity_avg_sub`: same parity survives the transfer, for the tuple exactly as
-  `atomRel_avg_sub` produces it.
-* `IsEllipticNet.parity_abs_avg_sub`: the same after `atomRel_abs₄` absorbs the sign on the last
-  index — the shape the descent consumes.
+* `IsEllipticNet.parity_abs_avg_sub`: same parity survives the transfer, in the form the descent
+  consumes — after `atomRel_abs₄` has absorbed the sign. The raw-index form that `atomRel_avg_sub`
+  produces is a private step inside its proof rather than a second public spelling.
 * `IsEllipticNet.nonnegStrictAnti₄_def` / `nonnegStrictAnti₄_iff`: the predicate's defining body,
   and its adjacent-inequality normal form.
 * `IsEllipticNet.nonnegStrictAnti₄_abs_avg_sub`: nonnegativity and strict decrease survive it.
@@ -111,9 +110,11 @@ theorem nonnegStrictAnti₄_iff (a b c d : ℤ) :
   simp
   omega
 
-/-- **Same parity survives the transfer.** Stated for the transferred quadruple exactly as
-`atomRel_avg_sub` produces it, with the last index raw. -/
-theorem parity_avg_sub {a b c d : ℤ}
+/-- **Same parity survives the transfer**, for the transferred quadruple exactly as
+`atomRel_avg_sub` produces it, with the last index raw. Private: it is the step through which
+`parity_abs_avg_sub` is proved, and that absolute-value form is the shape every consumer wants,
+so exporting both would put two spellings of one fact on the public surface. -/
+private theorem parity_avg_sub {a b c d : ℤ}
     (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
     ((a + b + c + d) / 2 - a) % 2 = ((a + b + c + d) / 2 - d) % 2 ∧
       ((a + b + c + d) / 2 - a) % 2 = ((a + b + c + d) / 2 - c) % 2 ∧
@@ -121,8 +122,9 @@ theorem parity_avg_sub {a b c d : ℤ}
   obtain ⟨h₁, h₂, h₃⟩ := parity
   omega
 
-/-- The absolute-value form of `parity_avg_sub`, for the last index after `atomRel_abs₄` has
-absorbed the sign. This is the shape the descent consumes. -/
+/-- **Same parity survives the transfer**, in the form the descent consumes: the first index
+carries the absolute value that `atomRel_abs₄` leaves behind. This is the only public parity
+statement here; the raw-index step it goes through is private. -/
 theorem parity_abs_avg_sub {a b c d : ℤ}
     (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
     |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - d) % 2 ∧

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -4,10 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Data.Fin.VecNotation
-public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+public import Mathlib.Algebra.Order.Group.Int
+public import Mathlib.Algebra.Order.Group.Unbundled.Abs
+public import Mathlib.Order.Fin.Tuple
 import Mathlib.Data.Int.ModEq
-import Mathlib.Order.Fin.Tuple
+import Mathlib.NumberTheory.EllipticDivisibilitySequence
 
 /-!
 # Index bookkeeping for the descent on the elliptic relator
@@ -38,7 +39,7 @@ terminate.
   index — the shape the descent consumes.
 * `IsEllipticNet.nonnegStrictAnti₄_def` / `nonnegStrictAnti₄_iff`: the predicate's defining body,
   and its adjacent-inequality normal form.
-* `IsEllipticNet.nonnegStrictAnti₄_avg_sub`: nonnegativity and strict decrease survive it.
+* `IsEllipticNet.nonnegStrictAnti₄_abs_avg_sub`: nonnegativity and strict decrease survive it.
 * `IsEllipticNet.six_le_of_parity_of_nonnegStrictAnti₄`: a strictly decreasing quadruple
   of one parity with `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three
   times over.
@@ -57,14 +58,13 @@ chain of three inequalities. `Mathlib/Order/Fin/Tuple.lean` states that API thro
 into the adjacent comparisons the descent consumes, and `nonnegStrictAnti₄_iff` records that
 normal form once for downstream use.
 
-**On the imports.** No *declaration* here mentions `atomRel`; the EDS import is nevertheless kept
-public rather than replaced by narrow modules. Replacing it was tried and costs more than it saves:
-dropping it loses `abs`, then `AddGroup ℤ`, then `abs_cases`, each surfacing only at the next build,
-because that one import transitively carries the ℤ ordered-algebra stack these proofs run on. The
-file also lives in `EllipticDivisibilitySequence/`, declares into `IsEllipticNet`, and exists to
-feed `atomRel_avg_sub` and `atomRel_abs₄`, so a consumer of this module wants EDS in scope anyway.
-`Mathlib.Data.Fin.VecNotation` is public because `nonnegStrictAnti₄_def` mentions `![…]` in its
-statement; `Mathlib.Data.Int.ModEq` stays private, being used only inside a proof.
+**On the imports.** The rule here is: **public** for what the public *statements* mention,
+**private** for what only the proofs need. So `Mathlib.Algebra.Order.Group.Int` and
+`…Group.Unbundled.Abs` are public — the statements use ℤ arithmetic and `|…|` — as is
+`Mathlib.Order.Fin.Tuple`, since `nonnegStrictAnti₄_def` mentions `StrictAnti ![…]` and that
+module supplies the vector notation too. `Mathlib.Data.Int.ModEq` is private, used only inside a
+proof. The EDS import is **private** as well: no declaration here mentions `atomRel`, so none of
+that API belongs in this module's public surface, but the proofs still draw instances from it.
 
 ## Provenance
 
@@ -135,7 +135,7 @@ theorem parity_abs_avg_sub {a b c d : ℤ}
 
 /-- **Nonnegativity and strict decrease survive the transfer.** The last index needs its absolute
 value: `m - a` is the one difference that can be negative, `a` being the largest index. -/
-theorem nonnegStrictAnti₄_avg_sub {a b c d : ℤ} (parity : d % 2 = c % 2)
+theorem nonnegStrictAnti₄_abs_avg_sub {a b c d : ℤ} (parity : d % 2 = c % 2)
     (anti : NonnegStrictAnti₄ a b c d) :
     NonnegStrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
       ((a + b + c + d) / 2 - b) |(a + b + c + d) / 2 - a| := by

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -51,7 +51,7 @@ conversion at the use sites, and avoids standing a second parity predicate next 
 The ordering half reuses Mathlib's tuple API: it is `StrictAnti ![a, b, c, d]`, not a hand-rolled
 chain of three inequalities. `Mathlib/Order/Fin/Tuple.lean` states that API through `vecCons` —
 `strictAnti_vecCons` and `strictAnti_vecEmpty`, both `@[simp]` — so `simp` unfolds the tuple form
-into the adjacent comparisons the descent consumes, and `nonnegStrictAnti₄_def` records that
+into the adjacent comparisons the descent consumes, and `nonnegStrictAnti₄_iff` records that
 normal form once for downstream use.
 
 ## Provenance
@@ -84,10 +84,11 @@ the descent needs it wherever it needs the ordering; the decreasing half is Math
 `StrictAnti` on the tuple. -/
 def NonnegStrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ StrictAnti ![a, b, c, d]
 
-/-- The adjacent-inequality form of `NonnegStrictAnti₄`. The definition body is not exposed,
-so this equation lemma is how a consumer computes with it, and it is the normal form `simp` uses. -/
+/-- `NonnegStrictAnti₄` unfolded to its adjacent inequalities. Not a restatement of the
+defining body — that is `0 ≤ d ∧ StrictAnti ![a, b, c, d]` — but the equivalent form consumers
+want, and the normal form `simp` rewrites to. -/
 @[simp]
-theorem nonnegStrictAnti₄_def (a b c d : ℤ) :
+theorem nonnegStrictAnti₄_iff (a b c d : ℤ) :
     NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := by
   unfold NonnegStrictAnti₄
   simp
@@ -123,7 +124,7 @@ theorem nonnegStrictAnti₄_avg_sub {a b c d : ℤ}
     NonnegStrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
       ((a + b + c + d) / 2 - b) |(a + b + c + d) / 2 - a| := by
   obtain ⟨h₁, h₂, h₃⟩ := parity
-  rw [nonnegStrictAnti₄_def] at anti ⊢
+  rw [nonnegStrictAnti₄_iff] at anti ⊢
   obtain ⟨hd, hdc, hcb, hba⟩ := anti
   refine ⟨abs_nonneg _, ?_, by omega, by omega⟩
   rcases abs_cases ((a + b + c + d) / 2 - a) with ⟨h, _⟩ | ⟨h, _⟩ <;> rw [h] <;> omega
@@ -135,7 +136,7 @@ theorem six_le_of_parity_of_nonnegStrictAnti₄ {a b c d : ℤ}
     (anti : NonnegStrictAnti₄ a b c d) :
     6 ≤ a := by
   obtain ⟨h₁, h₂, h₃⟩ := parity
-  rw [nonnegStrictAnti₄_def] at anti
+  rw [nonnegStrictAnti₄_iff] at anti
   obtain ⟨hd, hdc, hcb, hba⟩ := anti
   omega
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+import Mathlib.Order.Fin.Tuple
 
 /-!
 # Index bookkeeping for the descent on the elliptic relator
@@ -47,12 +48,11 @@ Parity is spelled as Mathlib spells it for this API — the unbundled conjunctio
 predicate over `Int.negOnePow`. Matching the upstream shape means those two lemmas apply with no
 conversion at the use sites, and avoids standing a second parity predicate next to Mathlib's.
 
-The ordering half is likewise a plain conjunction of the three adjacent inequalities rather than
-`StrictAnti ![a, b, c, d]`. Mathlib's `StrictAnti` is a predicate on order-preserving *functions*,
-and it is nowhere applied to a `Matrix.cons` tuple in Mathlib itself; the descent, meanwhile,
-consumes exactly the three adjacent comparisons at every site, so bundling them into a function on
-`Fin 4` and unbundling them again at each use would add a layer without adding a fact.
-`Fin.strictAnti_iff_succ_lt` is the bridge if a caller ever wants the bundled form.
+The ordering half reuses Mathlib's tuple API: it is `StrictAnti ![a, b, c, d]`, not a hand-rolled
+chain of three inequalities. `Mathlib/Order/Fin/Tuple.lean` states that API through `vecCons` —
+`strictAnti_vecCons` and `strictAnti_vecEmpty`, both `@[simp]` — so `simp` unfolds the tuple form
+into the adjacent comparisons the descent consumes, and `nonnegStrictDecreasing₄_def` records that
+normal form once for downstream use.
 
 ## Provenance
 
@@ -80,14 +80,18 @@ public section
 namespace IsEllipticNet
 
 /-- The four indices are nonnegative and strictly decreasing. Nonnegativity is bundled in because
-the descent needs it wherever it needs the ordering. -/
-def NonnegStrictDecreasing₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ d < c ∧ c < b ∧ b < a
+the descent needs it wherever it needs the ordering; the decreasing half is Mathlib's
+`StrictAnti` on the tuple. -/
+def NonnegStrictDecreasing₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ StrictAnti ![a, b, c, d]
 
-/-- The defining formula for `NonnegStrictDecreasing₄`. The definition body is not exposed, so this
-equation lemma is how a consumer computes with it, and it is the normal form `simp` uses. -/
+/-- The adjacent-inequality form of `NonnegStrictDecreasing₄`. The definition body is not exposed,
+so this equation lemma is how a consumer computes with it, and it is the normal form `simp` uses. -/
 @[simp]
 theorem nonnegStrictDecreasing₄_def (a b c d : ℤ) :
-    NonnegStrictDecreasing₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := Iff.rfl
+    NonnegStrictDecreasing₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := by
+  unfold NonnegStrictDecreasing₄
+  simp
+  omega
 
 /-- **Same parity survives the transfer.** Stated for the transferred quadruple exactly as
 `atomRel_avg_sub` produces it, with the last index raw. -/
@@ -117,6 +121,7 @@ theorem nonnegStrictDecreasing₄_avg_sub {a b c d : ℤ}
     NonnegStrictDecreasing₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
       ((a + b + c + d) / 2 - b) |(a + b + c + d) / 2 - a| := by
   obtain ⟨h₁, h₂, h₃⟩ := parity
+  rw [nonnegStrictDecreasing₄_def] at anti ⊢
   obtain ⟨hd, hdc, hcb, hba⟩ := anti
   refine ⟨abs_nonneg _, ?_, by omega, by omega⟩
   rcases abs_cases ((a + b + c + d) / 2 - a) with ⟨h, _⟩ | ⟨h, _⟩ <;> rw [h] <;> omega
@@ -128,6 +133,7 @@ theorem six_le_of_parity_of_nonnegStrictDecreasing₄ {a b c d : ℤ}
     (anti : NonnegStrictDecreasing₄ a b c d) :
     6 ≤ a := by
   obtain ⟨h₁, h₂, h₃⟩ := parity
+  rw [nonnegStrictDecreasing₄_def] at anti
   obtain ⟨hd, hdc, hcb, hba⟩ := anti
   omega
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -30,7 +30,10 @@ terminate.
 
 ## Main results
 
-* `IsEllipticNet.parity_avg_sub`: same parity survives the transfer.
+* `IsEllipticNet.parity_avg_sub`: same parity survives the transfer, for the tuple exactly as
+  `atomRel_avg_sub` produces it.
+* `IsEllipticNet.parity_abs_avg_sub`: the same after `atomRel_abs₄` absorbs the sign on the last
+  index — the shape the descent consumes.
 * `IsEllipticNet.nonnegStrictDecreasing₄_avg_sub`: nonnegativity and strict decrease survive it.
 * `IsEllipticNet.six_le_of_parity_of_nonnegStrictDecreasing₄`: a strictly decreasing quadruple
   of one parity with `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three
@@ -43,6 +46,13 @@ Parity is spelled as Mathlib spells it for this API — the unbundled conjunctio
 `IsEllipticNet.atomRel_eq` and `atomRel_avg_sub` take it — rather than as the source's bundled
 predicate over `Int.negOnePow`. Matching the upstream shape means those two lemmas apply with no
 conversion at the use sites, and avoids standing a second parity predicate next to Mathlib's.
+
+The ordering half is likewise a plain conjunction of the three adjacent inequalities rather than
+`StrictAnti ![a, b, c, d]`. Mathlib's `StrictAnti` is a predicate on order-preserving *functions*,
+and it is nowhere applied to a `Matrix.cons` tuple in Mathlib itself; the descent, meanwhile,
+consumes exactly the three adjacent comparisons at every site, so bundling them into a function on
+`Fin 4` and unbundling them again at each use would add a layer without adding a fact.
+`Fin.strictAnti_iff_succ_lt` is the bridge if a caller ever wants the bundled form.
 
 ## Provenance
 
@@ -79,10 +89,19 @@ equation lemma is how a consumer computes with it, and it is the normal form `si
 theorem nonnegStrictDecreasing₄_def (a b c d : ℤ) :
     NonnegStrictDecreasing₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := Iff.rfl
 
-/-- **Same parity survives the transfer.** Stated for the transferred quadruple in the order
-`atomRel_avg_sub` produces it, and with the absolute value on the last index that
-`atomRel_abs₄` absorbs. -/
+/-- **Same parity survives the transfer.** Stated for the transferred quadruple exactly as
+`atomRel_avg_sub` produces it, with the last index raw. -/
 theorem parity_avg_sub {a b c d : ℤ}
+    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
+    ((a + b + c + d) / 2 - a) % 2 = ((a + b + c + d) / 2 - d) % 2 ∧
+      ((a + b + c + d) / 2 - a) % 2 = ((a + b + c + d) / 2 - c) % 2 ∧
+        ((a + b + c + d) / 2 - a) % 2 = ((a + b + c + d) / 2 - b) % 2 := by
+  obtain ⟨h₁, h₂, h₃⟩ := parity
+  omega
+
+/-- The absolute-value form of `parity_avg_sub`, for the last index after `atomRel_abs₄` has
+absorbed the sign. This is the shape the descent consumes. -/
+theorem parity_abs_avg_sub {a b c d : ℤ}
     (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
     |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - d) % 2 ∧
       |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - c) % 2 ∧

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -23,16 +23,18 @@ terminate.
 
 ## Main definitions
 
-* `IsEllipticNet.NonnegStrictAnti₄`: the four indices are nonnegative and strictly decreasing. The
-  nonnegativity is bundled in because every use needs it alongside the ordering, and the name says
-  so: Mathlib's `StrictAnti` is the order-reversing property alone.
+* `IsEllipticNet.NonnegStrictDecreasing₄`: the four indices are nonnegative and strictly
+  decreasing. The nonnegativity is bundled in because every use needs it alongside the ordering,
+  and the name carries both halves — `StrictAnti` is Mathlib's name for an antitone *function*,
+  not for a chain of four integers.
 
 ## Main results
 
 * `IsEllipticNet.parity_avg_sub`: same parity survives the transfer.
-* `IsEllipticNet.nonnegStrictAnti₄_avg_sub`: nonnegativity and strict decrease survive it.
-* `IsEllipticNet.six_le_of_nonnegStrictAnti₄`: a strictly decreasing quadruple of one parity with
-  `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three times over.
+* `IsEllipticNet.nonnegStrictDecreasing₄_avg_sub`: nonnegativity and strict decrease survive it.
+* `IsEllipticNet.six_le_of_parity_of_nonnegStrictDecreasing₄`: a strictly decreasing quadruple
+  of one parity with `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three
+  times over.
 
 ## Implementation notes
 
@@ -49,10 +51,11 @@ Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `StrictAnti₄`, `HaveSameParity₄.transf`,
 `HaveSameParity₄.strictAnti₄_transf` and `HaveSameParity₄.six_le_of_strictAnti₄`. That file's
 header reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
-upstream authorship is credited here rather than in the copyright header. The source's `StrictAnti₄`
-is renamed `NonnegStrictAnti₄` here, since the predicate also carries the lower bound `0 ≤ d` and
-Mathlib already uses `StrictAnti` for the order-reversing property alone; the three dependent names
-follow it.
+upstream authorship is credited here rather than in the copyright header. The source's
+`StrictAnti₄` is renamed `NonnegStrictDecreasing₄` here: the predicate also carries the lower
+bound `0 ≤ d`, and `StrictAnti` is Mathlib's name for an antitone function rather than for a
+chain of four integers. The dependent names follow it, and `six_le_of_parity_of_…` names the
+parity hypothesis that its statement genuinely needs.
 
 The source's surrounding transfer machinery is **not** ported, being already upstream: its
 `rel₄_transf` is Mathlib's `atomRel_avg_sub`, its `rel₄_eq_net` is Mathlib's `atomRel_eq`, and its
@@ -68,13 +71,13 @@ namespace IsEllipticNet
 
 /-- The four indices are nonnegative and strictly decreasing. Nonnegativity is bundled in because
 the descent needs it wherever it needs the ordering. -/
-def NonnegStrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ d < c ∧ c < b ∧ b < a
+def NonnegStrictDecreasing₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ d < c ∧ c < b ∧ b < a
 
-/-- The defining formula for `NonnegStrictAnti₄`. The definition body is not exposed, so this
+/-- The defining formula for `NonnegStrictDecreasing₄`. The definition body is not exposed, so this
 equation lemma is how a consumer computes with it, and it is the normal form `simp` uses. -/
 @[simp]
-theorem nonnegStrictAnti₄_def (a b c d : ℤ) :
-    NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := Iff.rfl
+theorem nonnegStrictDecreasing₄_def (a b c d : ℤ) :
+    NonnegStrictDecreasing₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := Iff.rfl
 
 /-- **Same parity survives the transfer.** Stated for the transferred quadruple in the order
 `atomRel_avg_sub` produces it, and with the absolute value on the last index that
@@ -89,9 +92,10 @@ theorem parity_avg_sub {a b c d : ℤ}
 
 /-- **Nonnegativity and strict decrease survive the transfer.** The last index needs its absolute
 value: `m - a` is the one difference that can be negative, `a` being the largest index. -/
-theorem nonnegStrictAnti₄_avg_sub {a b c d : ℤ}
-    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) (anti : NonnegStrictAnti₄ a b c d) :
-    NonnegStrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
+theorem nonnegStrictDecreasing₄_avg_sub {a b c d : ℤ}
+    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2)
+    (anti : NonnegStrictDecreasing₄ a b c d) :
+    NonnegStrictDecreasing₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
       ((a + b + c + d) / 2 - b) |(a + b + c + d) / 2 - a| := by
   obtain ⟨h₁, h₂, h₃⟩ := parity
   obtain ⟨hd, hdc, hcb, hba⟩ := anti
@@ -100,8 +104,9 @@ theorem nonnegStrictAnti₄_avg_sub {a b c d : ℤ}
 
 /-- A strictly decreasing quadruple of one parity, bounded below by zero, has `6 ≤ a`: each of the
 three consecutive gaps is at least two. This is what makes the descent terminate. -/
-theorem six_le_of_nonnegStrictAnti₄ {a b c d : ℤ}
-    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) (anti : NonnegStrictAnti₄ a b c d) :
+theorem six_le_of_parity_of_nonnegStrictDecreasing₄ {a b c d : ℤ}
+    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2)
+    (anti : NonnegStrictDecreasing₄ a b c d) :
     6 ≤ a := by
   obtain ⟨h₁, h₂, h₃⟩ := parity
   obtain ⟨hd, hdc, hcb, hba⟩ := anti

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -24,10 +24,9 @@ terminate.
 
 ## Main definitions
 
-* `IsEllipticNet.NonnegStrictDecreasing₄`: the four indices are nonnegative and strictly
-  decreasing. The nonnegativity is bundled in because every use needs it alongside the ordering,
-  and the name carries both halves — `StrictAnti` is Mathlib's name for an antitone *function*,
-  not for a chain of four integers.
+* `IsEllipticNet.NonnegStrictAnti₄`: the four indices are nonnegative and strictly decreasing.
+  The name carries both halves of the definition — Mathlib's `StrictAnti` on the tuple, and the
+  lower bound bundled alongside it because every use needs the two together.
 
 ## Main results
 
@@ -35,8 +34,8 @@ terminate.
   `atomRel_avg_sub` produces it.
 * `IsEllipticNet.parity_abs_avg_sub`: the same after `atomRel_abs₄` absorbs the sign on the last
   index — the shape the descent consumes.
-* `IsEllipticNet.nonnegStrictDecreasing₄_avg_sub`: nonnegativity and strict decrease survive it.
-* `IsEllipticNet.six_le_of_parity_of_nonnegStrictDecreasing₄`: a strictly decreasing quadruple
+* `IsEllipticNet.nonnegStrictAnti₄_avg_sub`: nonnegativity and strict decrease survive it.
+* `IsEllipticNet.six_le_of_parity_of_nonnegStrictAnti₄`: a strictly decreasing quadruple
   of one parity with `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three
   times over.
 
@@ -51,7 +50,7 @@ conversion at the use sites, and avoids standing a second parity predicate next 
 The ordering half reuses Mathlib's tuple API: it is `StrictAnti ![a, b, c, d]`, not a hand-rolled
 chain of three inequalities. `Mathlib/Order/Fin/Tuple.lean` states that API through `vecCons` —
 `strictAnti_vecCons` and `strictAnti_vecEmpty`, both `@[simp]` — so `simp` unfolds the tuple form
-into the adjacent comparisons the descent consumes, and `nonnegStrictDecreasing₄_def` records that
+into the adjacent comparisons the descent consumes, and `nonnegStrictAnti₄_def` records that
 normal form once for downstream use.
 
 ## Provenance
@@ -62,9 +61,9 @@ Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 `HaveSameParity₄.strictAnti₄_transf` and `HaveSameParity₄.six_le_of_strictAnti₄`. That file's
 header reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
 upstream authorship is credited here rather than in the copyright header. The source's
-`StrictAnti₄` is renamed `NonnegStrictDecreasing₄` here: the predicate also carries the lower
-bound `0 ≤ d`, and `StrictAnti` is Mathlib's name for an antitone function rather than for a
-chain of four integers. The dependent names follow it, and `six_le_of_parity_of_…` names the
+`StrictAnti₄` gains a `Nonneg` prefix here, because the predicate bundles the lower bound `0 ≤ d`
+that the source's name left unsaid; the `StrictAnti` half is kept, the definition being Mathlib's
+`StrictAnti` on the tuple. The dependent names follow it, and `six_le_of_parity_of_…` names the
 parity hypothesis that its statement genuinely needs.
 
 The source's surrounding transfer machinery is **not** ported, being already upstream: its
@@ -82,14 +81,14 @@ namespace IsEllipticNet
 /-- The four indices are nonnegative and strictly decreasing. Nonnegativity is bundled in because
 the descent needs it wherever it needs the ordering; the decreasing half is Mathlib's
 `StrictAnti` on the tuple. -/
-def NonnegStrictDecreasing₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ StrictAnti ![a, b, c, d]
+def NonnegStrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ StrictAnti ![a, b, c, d]
 
-/-- The adjacent-inequality form of `NonnegStrictDecreasing₄`. The definition body is not exposed,
+/-- The adjacent-inequality form of `NonnegStrictAnti₄`. The definition body is not exposed,
 so this equation lemma is how a consumer computes with it, and it is the normal form `simp` uses. -/
 @[simp]
-theorem nonnegStrictDecreasing₄_def (a b c d : ℤ) :
-    NonnegStrictDecreasing₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := by
-  unfold NonnegStrictDecreasing₄
+theorem nonnegStrictAnti₄_def (a b c d : ℤ) :
+    NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := by
+  unfold NonnegStrictAnti₄
   simp
   omega
 
@@ -115,25 +114,25 @@ theorem parity_abs_avg_sub {a b c d : ℤ}
 
 /-- **Nonnegativity and strict decrease survive the transfer.** The last index needs its absolute
 value: `m - a` is the one difference that can be negative, `a` being the largest index. -/
-theorem nonnegStrictDecreasing₄_avg_sub {a b c d : ℤ}
+theorem nonnegStrictAnti₄_avg_sub {a b c d : ℤ}
     (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2)
-    (anti : NonnegStrictDecreasing₄ a b c d) :
-    NonnegStrictDecreasing₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
+    (anti : NonnegStrictAnti₄ a b c d) :
+    NonnegStrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
       ((a + b + c + d) / 2 - b) |(a + b + c + d) / 2 - a| := by
   obtain ⟨h₁, h₂, h₃⟩ := parity
-  rw [nonnegStrictDecreasing₄_def] at anti ⊢
+  rw [nonnegStrictAnti₄_def] at anti ⊢
   obtain ⟨hd, hdc, hcb, hba⟩ := anti
   refine ⟨abs_nonneg _, ?_, by omega, by omega⟩
   rcases abs_cases ((a + b + c + d) / 2 - a) with ⟨h, _⟩ | ⟨h, _⟩ <;> rw [h] <;> omega
 
 /-- A strictly decreasing quadruple of one parity, bounded below by zero, has `6 ≤ a`: each of the
 three consecutive gaps is at least two. This is what makes the descent terminate. -/
-theorem six_le_of_parity_of_nonnegStrictDecreasing₄ {a b c d : ℤ}
+theorem six_le_of_parity_of_nonnegStrictAnti₄ {a b c d : ℤ}
     (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2)
-    (anti : NonnegStrictDecreasing₄ a b c d) :
+    (anti : NonnegStrictAnti₄ a b c d) :
     6 ≤ a := by
   obtain ⟨h₁, h₂, h₃⟩ := parity
-  rw [nonnegStrictDecreasing₄_def] at anti
+  rw [nonnegStrictAnti₄_def] at anti
   obtain ⟨hd, hdc, hcb, hba⟩ := anti
   omega
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+
+/-!
+# Index bookkeeping for the descent on the elliptic relator
+
+Mathlib's `IsEllipticNet.atomRel_avg_sub` transfers the four-index relator from a quadruple
+`a, b, c, d` to the quadruple obtained by subtracting each index from the average
+`m = (a + b + c + d) / 2`, in reverse order:
+
+`atomRel W (m - d) (m - c) (m - b) (m - a) = atomRel W a b c d`.
+
+The descent that identifies elliptic sequences runs on that transfer, and needs to know that its
+two side conditions survive it: the four indices stay of one parity, and — after taking the
+absolute value of the last, which `IsEllipticNet.atomRel_abs₄` absorbs — they stay nonnegative and
+strictly decreasing. This file proves both, together with the bound `6 ≤ a` that makes the descent
+terminate.
+
+## Main definitions
+
+* `IsEllipticNet.StrictAnti₄`: the four indices are nonnegative and strictly decreasing. The
+  nonnegativity is bundled in because every use needs it alongside the ordering.
+
+## Main results
+
+* `IsEllipticNet.parity_avg_sub`: same parity survives the transfer.
+* `IsEllipticNet.strictAnti₄_avg_sub`: nonnegativity and strict decrease survive it.
+* `IsEllipticNet.six_le_of_strictAnti₄`: a strictly decreasing quadruple of one parity with
+  `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three times over.
+
+## Implementation notes
+
+Parity is spelled as Mathlib spells it for this API — the unbundled conjunction
+`d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2`, relative to the last index, as
+`IsEllipticNet.atomRel_eq` and `atomRel_avg_sub` take it — rather than as the source's bundled
+predicate over `Int.negOnePow`. Matching the upstream shape means those two lemmas apply with no
+conversion at the use sites, and avoids standing a second parity predicate next to Mathlib's.
+
+That choice also shortens the proofs: `omega` reasons about `%` and `/` by the literal `2`
+natively, so the parity bookkeeping the source carries out through `negOnePow_sub`,
+`negOnePow_abs` and `add_two_le_iff_lt_of_even_sub` is discharged directly here.
+
+## Provenance
+
+Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `StrictAnti₄`, `HaveSameParity₄.transf`,
+`HaveSameParity₄.strictAnti₄_transf` and `HaveSameParity₄.six_le_of_strictAnti₄`. That file's
+header reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
+upstream authorship is credited here rather than in the copyright header.
+
+The source's surrounding transfer machinery is **not** ported, being already upstream: its
+`rel₄_transf` is Mathlib's `atomRel_avg_sub`, its `rel₄_eq_net` is Mathlib's `atomRel_eq`, and its
+`avg₄` is inlined there as `(a + b + c + d) / 2`. With `rel₄_transf` unneeded, so are the four
+declarations existing only to prove it — `addMulSub₄`, `addMulSub₄_mul_addMulSub₄`,
+`addMulSub_transf` and `avg₄_add_avg₄`. That is also why no `set_option allowUnsafeReducibility`
+appears here: the one source lemma carrying it is among those not needed.
+-/
+
+public section
+
+namespace IsEllipticNet
+
+/-- The four indices are nonnegative and strictly decreasing. Nonnegativity is bundled in because
+the descent needs it wherever it needs the ordering. -/
+def StrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ d < c ∧ c < b ∧ b < a
+
+/-- The defining formula for `StrictAnti₄`. The definition body is not exposed, so this equation
+lemma is how a consumer computes with it. -/
+theorem strictAnti₄_def (a b c d : ℤ) :
+    StrictAnti₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := Iff.rfl
+
+/-- **Same parity survives the transfer.** Stated for the transferred quadruple in the order
+`atomRel_avg_sub` produces it, and with the absolute value on the last index that
+`atomRel_abs₄` absorbs. -/
+theorem parity_avg_sub {a b c d : ℤ}
+    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
+    |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - d) % 2 ∧
+      |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - c) % 2 ∧
+        |(a + b + c + d) / 2 - a| % 2 = ((a + b + c + d) / 2 - b) % 2 := by
+  obtain ⟨h₁, h₂, h₃⟩ := parity
+  rcases abs_cases ((a + b + c + d) / 2 - a) with ⟨h, _⟩ | ⟨h, _⟩ <;> rw [h] <;> omega
+
+/-- **Nonnegativity and strict decrease survive the transfer.** The last index needs its absolute
+value: `m - a` is the one difference that can be negative, `a` being the largest index. -/
+theorem strictAnti₄_avg_sub {a b c d : ℤ}
+    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) (anti : StrictAnti₄ a b c d) :
+    StrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c) ((a + b + c + d) / 2 - b)
+      |(a + b + c + d) / 2 - a| := by
+  obtain ⟨h₁, h₂, h₃⟩ := parity
+  obtain ⟨hd, hdc, hcb, hba⟩ := anti
+  refine ⟨abs_nonneg _, ?_, by omega, by omega⟩
+  rcases abs_cases ((a + b + c + d) / 2 - a) with ⟨h, _⟩ | ⟨h, _⟩ <;> rw [h] <;> omega
+
+/-- A strictly decreasing quadruple of one parity, bounded below by zero, has `6 ≤ a`: each of the
+three consecutive gaps is at least two. This is what makes the descent terminate. -/
+theorem six_le_of_strictAnti₄ {a b c d : ℤ}
+    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) (anti : StrictAnti₄ a b c d) :
+    6 ≤ a := by
+  obtain ⟨h₁, h₂, h₃⟩ := parity
+  obtain ⟨hd, hdc, hcb, hba⟩ := anti
+  omega
+
+end IsEllipticNet

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -23,14 +23,15 @@ terminate.
 
 ## Main definitions
 
-* `IsEllipticNet.StrictAnti₄`: the four indices are nonnegative and strictly decreasing. The
-  nonnegativity is bundled in because every use needs it alongside the ordering.
+* `IsEllipticNet.NonnegStrictAnti₄`: the four indices are nonnegative and strictly decreasing. The
+  nonnegativity is bundled in because every use needs it alongside the ordering, and the name says
+  so: Mathlib's `StrictAnti` is the order-reversing property alone.
 
 ## Main results
 
 * `IsEllipticNet.parity_avg_sub`: same parity survives the transfer.
-* `IsEllipticNet.strictAnti₄_avg_sub`: nonnegativity and strict decrease survive it.
-* `IsEllipticNet.six_le_of_strictAnti₄`: a strictly decreasing quadruple of one parity with
+* `IsEllipticNet.nonnegStrictAnti₄_avg_sub`: nonnegativity and strict decrease survive it.
+* `IsEllipticNet.six_le_of_nonnegStrictAnti₄`: a strictly decreasing quadruple of one parity with
   `0 ≤ d` has `6 ≤ a` — consecutive indices differ by at least two, three times over.
 
 ## Implementation notes
@@ -41,10 +42,6 @@ Parity is spelled as Mathlib spells it for this API — the unbundled conjunctio
 predicate over `Int.negOnePow`. Matching the upstream shape means those two lemmas apply with no
 conversion at the use sites, and avoids standing a second parity predicate next to Mathlib's.
 
-That choice also shortens the proofs: `omega` reasons about `%` and `/` by the literal `2`
-natively, so the parity bookkeeping the source carries out through `negOnePow_sub`,
-`negOnePow_abs` and `add_two_le_iff_lt_of_even_sub` is discharged directly here.
-
 ## Provenance
 
 Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
@@ -52,7 +49,10 @@ Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `StrictAnti₄`, `HaveSameParity₄.transf`,
 `HaveSameParity₄.strictAnti₄_transf` and `HaveSameParity₄.six_le_of_strictAnti₄`. That file's
 header reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
-upstream authorship is credited here rather than in the copyright header.
+upstream authorship is credited here rather than in the copyright header. The source's `StrictAnti₄`
+is renamed `NonnegStrictAnti₄` here, since the predicate also carries the lower bound `0 ≤ d` and
+Mathlib already uses `StrictAnti` for the order-reversing property alone; the three dependent names
+follow it.
 
 The source's surrounding transfer machinery is **not** ported, being already upstream: its
 `rel₄_transf` is Mathlib's `atomRel_avg_sub`, its `rel₄_eq_net` is Mathlib's `atomRel_eq`, and its
@@ -68,12 +68,13 @@ namespace IsEllipticNet
 
 /-- The four indices are nonnegative and strictly decreasing. Nonnegativity is bundled in because
 the descent needs it wherever it needs the ordering. -/
-def StrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ d < c ∧ c < b ∧ b < a
+def NonnegStrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ d < c ∧ c < b ∧ b < a
 
-/-- The defining formula for `StrictAnti₄`. The definition body is not exposed, so this equation
-lemma is how a consumer computes with it. -/
-theorem strictAnti₄_def (a b c d : ℤ) :
-    StrictAnti₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := Iff.rfl
+/-- The defining formula for `NonnegStrictAnti₄`. The definition body is not exposed, so this
+equation lemma is how a consumer computes with it, and it is the normal form `simp` uses. -/
+@[simp]
+theorem nonnegStrictAnti₄_def (a b c d : ℤ) :
+    NonnegStrictAnti₄ a b c d ↔ 0 ≤ d ∧ d < c ∧ c < b ∧ b < a := Iff.rfl
 
 /-- **Same parity survives the transfer.** Stated for the transferred quadruple in the order
 `atomRel_avg_sub` produces it, and with the absolute value on the last index that
@@ -88,10 +89,10 @@ theorem parity_avg_sub {a b c d : ℤ}
 
 /-- **Nonnegativity and strict decrease survive the transfer.** The last index needs its absolute
 value: `m - a` is the one difference that can be negative, `a` being the largest index. -/
-theorem strictAnti₄_avg_sub {a b c d : ℤ}
-    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) (anti : StrictAnti₄ a b c d) :
-    StrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c) ((a + b + c + d) / 2 - b)
-      |(a + b + c + d) / 2 - a| := by
+theorem nonnegStrictAnti₄_avg_sub {a b c d : ℤ}
+    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) (anti : NonnegStrictAnti₄ a b c d) :
+    NonnegStrictAnti₄ ((a + b + c + d) / 2 - d) ((a + b + c + d) / 2 - c)
+      ((a + b + c + d) / 2 - b) |(a + b + c + d) / 2 - a| := by
   obtain ⟨h₁, h₂, h₃⟩ := parity
   obtain ⟨hd, hdc, hcb, hba⟩ := anti
   refine ⟨abs_nonneg _, ?_, by omega, by omega⟩
@@ -99,8 +100,8 @@ theorem strictAnti₄_avg_sub {a b c d : ℤ}
 
 /-- A strictly decreasing quadruple of one parity, bounded below by zero, has `6 ≤ a`: each of the
 three consecutive gaps is at least two. This is what makes the descent terminate. -/
-theorem six_le_of_strictAnti₄ {a b c d : ℤ}
-    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) (anti : StrictAnti₄ a b c d) :
+theorem six_le_of_nonnegStrictAnti₄ {a b c d : ℤ}
+    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) (anti : NonnegStrictAnti₄ a b c d) :
     6 ≤ a := by
   obtain ⟨h₁, h₂, h₃⟩ := parity
   obtain ⟨hd, hdc, hcb, hba⟩ := anti


### PR DESCRIPTION
Index bookkeeping for the descent on the elliptic relator — the second slice of the `normEDS`
ellipticity chain, and the one that makes the descent terminate.

```lean
-- TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
namespace IsEllipticNet

def NonnegStrictAnti₄ (a b c d : ℤ) : Prop := 0 ≤ d ∧ StrictAnti ![a, b, c, d]

@[simp] theorem nonnegStrictAnti₄_iff  -- lower bound + three adjacent inequalities

theorem parity_abs_avg_sub  -- same parity survives the transfer, in the consumed form
theorem nonnegStrictAnti₄_abs_avg_sub (hdc : d < c) (hcd : 2 ≤ c + d) (hcb) (hba)
theorem six_le_of_parity_of_nonnegStrictAnti₄ (parity) (anti) : 6 ≤ a
```

**What it says.** Mathlib's `IsEllipticNet.atomRel_avg_sub` transfers the four-index relator from a
quadruple `a, b, c, d` to the one obtained by subtracting each index from the average
`m = (a+b+c+d)/2`, in reverse order. The descent that identifies elliptic sequences runs on that
transfer and needs its two side conditions to survive it: the indices stay of one parity, and —
after the absolute value on the last, which `atomRel_abs₄` absorbs — they stay nonnegative and
strictly decreasing. `six_le_of_parity_of_nonnegStrictAnti₄` is what makes the descent terminate: three consecutive
same-parity gaps are each at least two, so `6 ≤ a`.

The predicate is named for **both** halves of what it asserts: the Mathlib-supplied strict
antitonicity of the tuple, and the lower bound `0 ≤ d` that the descent needs alongside it — which
a bare `StrictAnti₄` would have left unsaid. `six_le_of_parity_of_…`
likewise names the parity hypothesis its statement needs — the bound is false without it, since
`3 > 2 > 1 > 0` is nonneg and strictly decreasing with `a = 3`.
Its characteristic lemma `nonnegStrictAnti₄_iff` is `@[simp]`, so the unexposed body stays unexposed
while `simp` can still unpack and discharge `NonnegStrictAnti₄` goals without a manual rewrite.

**The parity transfer is proved in two steps but exported once.** `atomRel_avg_sub` produces the
transferred quadruple with its **last index raw**, and that raw form closes with a bare `omega` —
the absolute value having been the only thing that forced a case split. It is therefore worth
having as a step, and it is `private`: `parity_abs_avg_sub` derives from it the form the descent
actually consumes, once `atomRel_abs₄` has absorbed the sign, and that is the only parity statement
on the public surface. Exporting both would put two spellings of one fact in the API for the sake
of an intermediate.

**The ordering half reuses Mathlib's tuple API.** It is `StrictAnti ![a, b, c, d]`, not a
hand-rolled chain. `Mathlib/Order/Fin/Tuple.lean` states that API through `vecCons` —
`strictAnti_vecCons` (:126) and `strictAnti_vecEmpty` (:135), both `@[simp]` — so `simp` reduces
the tuple form to the adjacent comparisons the descent consumes, and `nonnegStrictAnti₄_iff`
records that normal form once. It is therefore no longer `Iff.rfl`, but `unfold`, `simp`, `omega`.

**The order-transfer lemma takes four inequalities, not parity and not a bundle.**
`nonnegStrictAnti₄_abs_avg_sub` assumes `0 ≤ d`, `d + 2 ≤ c`, `c < b`, `b < a`. Parity is what the
descent has, and `d % 2 = c % 2` with `d < c` yields the gap in one `omega` step — but only the gap
is used, so stating it over parity pinned the lemma to a narrower hypothesis than it needs; and
taking `NonnegStrictAnti₄` alongside the gap would have carried `d < c` next to the strictly
stronger `d + 2 ≤ c`. Parity survives as a hypothesis only where it is genuinely parity that is
needed: `parity_abs_avg_sub` and `six_le_of_parity_of_nonnegStrictAnti₄`.

**On `nonnegStrictAnti₄_def`, where two rubrics disagreed — and how it was settled.** `reuse`
asked twice for this lemma to be deleted as a second public spelling of the definition body;
between those, `api-design` asked for it to be added, on the grounds that a consumer otherwise
cannot reach the tuple form. Both argued from the same premise, so it was measured rather than
guessed: from a module that only *imports* this one, both `unfold NonnegStrictAnti₄` and `Iff.rfl`
reach `0 ≤ d ∧ StrictAnti ![a, b, c, d]`. The body is not opaque across the module boundary, so
nothing is blocked without the lemma and `reuse` is right on the merits; `api-design`'s stated
reason does not hold. The lemma is therefore absent, and `nonnegStrictAnti₄_iff` is the single
named form — the one the descent consumes and the `simp` normal form.

## Two things worth the reviewer's attention

**Parity is spelled as Mathlib spells it.** The unbundled conjunction
`d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2`, relative to the last index, exactly as
`IsEllipticNet.atomRel_eq` and `atomRel_avg_sub` take it — rather than the source's bundled
predicate over `Int.negOnePow`. That means those two lemmas apply at the use sites with no
conversion, and no second parity predicate stands beside Mathlib's. It also shortens the proofs
measurably: `omega` reasons about `%` and `/` by the literal `2` natively, so
`six_le_of_parity_of_nonnegStrictAnti₄` is `omega` once the predicate is rewritten to its
adjacent-inequality form, where the source needs `add_two_le_iff_lt_of_even_sub` plus `linarith`;
and the parity transfer is `rcases abs_cases … <;> omega` against the source's `negOnePow_sub` /
`negOnePow_abs` manipulation.

**Most of the source's transfer layer is deliberately not ported, because Mathlib already has it.**
`rel₄_transf` **is** `atomRel_avg_sub`; `rel₄_eq_net` **is** `atomRel_eq`; `avg₄` is inlined
upstream as `(a+b+c+d)/2`. With `rel₄_transf` unneeded, so are the four declarations existing only
to prove it — `addMulSub₄`, `addMulSub₄_mul_addMulSub₄`, `addMulSub_transf`, `avg₄_add_avg₄`. One
consequence is worth stating: `addMulSub_transf` is the source lemma carrying
`set_option allowUnsafeReducibility true` together with a `Nat.rawCast` reducibility attribute, and
since it is not needed, that setting does not appear here — discharged rather than worked around.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, the **Layer 6** torsion/Nagell–Lutz strand
(README.md:821-837), whose stated route to `lutz_nagell` and `lutz_nagell_integrality_general` is
the division polynomials. A measured prerequisite on that route: the chain is
`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS ← IsEllipticSequence.normEDS`, and
that last fact needs the descent, which needs this file. The pinned Mathlib records it as an open
TODO, so it is built here per the roadmap's policy for material in flight upstream
(README.md:232-236).

## Mathlib absence

Absent from the pinned Mathlib: greps over `Mathlib/NumberTheory/EllipticDivisibilitySequence.lean`
for `oddRec`, `evenRec`, `Valid`, `Perm`, `SameParity` and `StrictAnti` return nothing. What
Mathlib does carry — the whole `atom`/`atomRel` layer including `atomRel_avg_sub` and `atomRel_eq` —
is consumed here rather than restated, as above.

## Provenance

Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `StrictAnti₄`,
`HaveSameParity₄.transf`, `HaveSameParity₄.strictAnti₄_transf` and
`HaveSameParity₄.six_le_of_strictAnti₄` — the source's own names, unchanged here. That file's
header reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
upstream authorship is credited in the module docstring rather than in the copyright header.

**Renamed on the way in.** The source's `StrictAnti₄` becomes `NonnegStrictAnti₄`, and its
dependants follow. The predicate bundles `0 ≤ d` alongside the strict antitonicity, and the
source's name mentioned only the ordering — so the rename is about the halved promise, not about
the `StrictAnti` term itself, which this file now takes from Mathlib directly.

## Cleanup

An **inline author pass** — file-level style, naming, line packing, docstrings, the equation lemma
for the unexposed definition, and the negative results recorded in the module docstring. The
per-declaration Phase-4 fan-out and the `/simplify` and `/buzz` hand-offs are **deferred to review
rounds** rather than run before this PR. Stated plainly rather than claimed as a full 11-phase run.

**The EDS module is deliberately not imported.** No declaration here mentions `atom`, `atomRel` or
`rel` — the statements are ℤ arithmetic, order and parity, and the Mathlib lemmas they exist to
serve are named in prose because they fix the index shapes, not because their API is used. The one
thing the proofs did reach for through that import was `abs_cases`, which is `to_additive`-generated
from `mabs_cases` in `Mathlib/Algebra/Order/Group/Abs.lean` and so matches no literal definition of
its own; importing that module directly is both narrower and honest, and drops the module's build
from 954 jobs to 675.

## Gates

**The full four-gate chain, at Mathlib `f5809ef6`** — the pin this branch was first authored
against — on a worktree verified clean by `git status --short` beforehand: `lake build` PASS
(7754 jobs) · `scripts/lint-env.sh` PASS (69 grandfathered, 1 ratchetable, that one a pre-existing
baseline line from another branch) · `lake exe axioms` — 44008 declarations, all within
`[propext, Classical.choice, Quot.sound]` · `lake exe module-system` — 2099 modules, all opted in.

**The branch has since been rebased onto `fb56272d0`**, current `main`. It had drifted 57 commits
behind, and while the specific hazard did not apply here — the Mathlib pin is byte-identical to
`main`'s at `f4fd7f7e`, and the base already contained the bump cleanup in `052dec58e` (#3069) —
a stale base is worth removing as a variable before opening a PR rather than after. The rebase
replayed cleanly and left the diff at one file.

**At that base, a targeted build:** `lake build
TauCeti.NumberTheory.EllipticDivisibilitySequence.Transfer` PASS — **675 jobs**, down from 954
before the EDS import was dropped. The full-tree audits are not restated as if measured at this
head: the numbers above were taken at the earlier pin, and the full chain at this head is exactly
what CI's sandboxed build runs on a clean runner.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-transfer"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
