### PR TITLE
refactor(Covering): name the equal-or-disjoint property of the sheets

### DIFF
--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -79,7 +79,7 @@ private theorem image_smul_eq_image_smul_of_inter_nonempty
   obtain ⟨⟨h, hh⟩, hhu'⟩ := horbit.mp hww'.symm
   -- `H` acts through the coercion to `G` — `MulAction.subgroup_smul_def` — so the orbit witness is
   -- an element of `G` fixing `qH`, and `hhu'` retypes to the ambient action.
-  have hhu : h • (g' • u') = g • u := hhu'
+  have hhu : h • (g' • u') = g • u := by simpa only [MulAction.subgroup_smul_def] using hhu'
   have hmap : ∀ e : E, qH (h • e) = qH e := fun e =>
     horbit.mpr ⟨⟨h, hh⟩, MulAction.subgroup_smul_def ⟨h, hh⟩ e⟩
   have hgg' : g = h * g' := eq_of_inv_mul_eq_one <| by

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -74,19 +74,15 @@ private theorem image_smul_eq_image_smul_of_inter_nonempty
     (hdisj : ∀ g : G, (g • U ∩ U).Nonempty → g = 1) {g g' : G}
     (hmeet : (qH '' (g • U) ∩ qH '' (g' • U)).Nonempty) :
     qH '' (g • U) = qH '' (g' • U) := by
-  obtain ⟨z, ⟨w, hw, rfl⟩, w', hw', hww'⟩ := hmeet
-  obtain ⟨u, hu, rfl⟩ := Set.mem_smul_set.mp hw
-  obtain ⟨u', hu', rfl⟩ := Set.mem_smul_set.mp hw'
+  -- A point common to the two images is `qH (g • u) = qH (g' • u')` for some `u, u' ∈ U`.
+  obtain ⟨_, ⟨_, ⟨u, hu, rfl⟩, rfl⟩, _, ⟨u', hu', rfl⟩, hww'⟩ := hmeet
   obtain ⟨⟨h, hh⟩, hhu'⟩ := horbit.mp hww'.symm
   -- `H` acts on `E` through `G`, so the orbit witness is an element of `G` fixing `qH`.
-  have hhu : h • (g' • u') = g • u := hhu'
   have hmap : ∀ e : E, qH (h • e) = qH e := fun _ => horbit.mpr ⟨⟨h, hh⟩, rfl⟩
-  have hone : g⁻¹ * h * g' = 1 := by
+  have hgg' : g = h * g' := eq_of_inv_mul_eq_one <| by
     refine hdisj _ ⟨u, Set.mem_smul_set.mpr ⟨u', hu', ?_⟩, hu⟩
-    rw [mul_smul, mul_smul, hhu, inv_smul_smul]
-  have hgg' : g = h * g' := eq_of_inv_mul_eq_one (by simpa [mul_assoc] using hone)
-  rw [hgg', mul_smul]
-  simp only [← Set.image_smul, Set.image_image, hmap]
+    rw [mul_smul, mul_smul, show h • (g' • u') = g • u from hhu', inv_smul_smul]
+  simp [hgg', mul_smul, ← Set.image_smul, Set.image_image, hmap]
 
 /-- The evenly covered neighbourhood of `q e` cut out by a set `U` around `e` whose `G`-translates
 are pairwise disjoint. Its sheets are the images in `Y` of the translates `g • U`. -/

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -65,6 +65,31 @@ variable {E X Y : Type*} [TopologicalSpace E] [TopologicalSpace X] [TopologicalS
 
 namespace IsQuotientCoveringMap
 
+/-- **Translates of `U` whose images in `Y` meet have the same image.** When the `G`-translates of
+`U` are pairwise disjoint, the sets `qH '' (g • U)` are therefore pairwise equal or disjoint. -/
+private theorem image_smul_eq_image_smul_of_inter_nonempty
+    (hqH : IsQuotientCoveringMap qH H) {U : Set E}
+    (hdisj : ∀ g : G, (g • U ∩ U).Nonempty → g = 1) {g g' : G}
+    (hmeet : (qH '' (g • U) ∩ qH '' (g' • U)).Nonempty) :
+    qH '' (g • U) = qH '' (g' • U) := by
+  obtain ⟨z, ⟨w, hw, rfl⟩, w', hw', hww'⟩ := hmeet
+  obtain ⟨u, hu, rfl⟩ := Set.mem_smul_set.mp hw
+  obtain ⟨u', hu', rfl⟩ := Set.mem_smul_set.mp hw'
+  obtain ⟨⟨h, hh⟩, hhu'⟩ := hqH.apply_eq_iff_mem_orbit.mp hww'.symm
+  -- `H` acts on `E` through `G`, so the orbit witness is an element of `G` fixing `qH`.
+  have hhu : h • (g' • u') = g • u := hhu'
+  have hmap : ∀ e : E, qH (h • e) = qH e := fun _ => hqH.map_smul ⟨h, hh⟩
+  have hone : g⁻¹ * h * g' = 1 := by
+    refine hdisj _ ⟨u, Set.mem_smul_set.mpr ⟨u', hu', ?_⟩, hu⟩
+    rw [mul_smul, mul_smul, hhu, inv_smul_smul]
+  have hgg' : g = h * g' := by
+    have h2 : g * (g⁻¹ * h * g') = h * g' := by
+      rw [← mul_assoc, mul_inv_cancel_left]
+    rw [hone, mul_one] at h2
+    exact h2
+  rw [hgg', mul_smul]
+  simp only [← Set.image_smul, Set.image_image, hmap]
+
 /-- The evenly covered neighbourhood of `q e` cut out by a set `U` around `e` whose `G`-translates
 are pairwise disjoint. Its sheets are the images in `Y` of the translates `g • U`. -/
 private theorem isEvenlyCovered_of_smul_disjoint (hq : IsQuotientCoveringMap q G)
@@ -79,27 +104,6 @@ private theorem isEvenlyCovered_of_smul_disjoint (hq : IsQuotientCoveringMap q G
   have hsheet_open : ∀ g : G, IsOpen (qH '' (g • U)) := fun g =>
     hqH.isOpenQuotientMap.isOpenMap _ (hUo.smul g)
   have hVo : IsOpen (q '' U) := hq.isOpenQuotientMap.isOpenMap _ hUo
-  -- Two translates of `U` whose images in `Y` meet differ by an element of `H`, so their images
-  -- coincide.
-  have hsheet_eq : ∀ g g' : G, (qH '' (g • U) ∩ qH '' (g' • U)).Nonempty →
-      qH '' (g • U) = qH '' (g' • U) := by
-    rintro g g' ⟨z, ⟨w, hw, rfl⟩, w', hw', hww'⟩
-    obtain ⟨u, hu, rfl⟩ := Set.mem_smul_set.mp hw
-    obtain ⟨u', hu', rfl⟩ := Set.mem_smul_set.mp hw'
-    obtain ⟨⟨h, hh⟩, hhu'⟩ := hqH.apply_eq_iff_mem_orbit.mp hww'.symm
-    -- `H` acts on `E` through `G`, so the orbit witness is an element of `G` fixing `qH`.
-    have hhu : h • (g' • u') = g • u := hhu'
-    have hmap : ∀ e : E, qH (h • e) = qH e := fun _ => hqH.map_smul ⟨h, hh⟩
-    have hone : g⁻¹ * h * g' = 1 := by
-      refine hdisj _ ⟨u, Set.mem_smul_set.mpr ⟨u', hu', ?_⟩, hu⟩
-      rw [mul_smul, mul_smul, hhu, inv_smul_smul]
-    have hgg' : g = h * g' := by
-      have h2 : g * (g⁻¹ * h * g') = h * g' := by
-        rw [← mul_assoc, mul_inv_cancel_left]
-      rw [hone, mul_one] at h2
-      exact h2
-    rw [hgg', mul_smul]
-    simp only [← Set.image_smul, Set.image_image, hmap]
   let : TopologicalSpace {S : Set Y // ∃ g : G, S = qH '' (g • U)} := ⊥
   have : DiscreteTopology {S : Set Y // ∃ g : G, S = qH '' (g • U)} := ⟨rfl⟩
   have : Nonempty {S : Set Y // ∃ g : G, S = qH '' (g • U)} :=
@@ -154,7 +158,8 @@ private theorem isEvenlyCovered_of_smul_disjoint (hq : IsQuotientCoveringMap q G
     rintro ⟨S, g, rfl⟩ ⟨S', g', rfl⟩ hne
     simp only [Function.onFun, Set.disjoint_iff_inter_eq_empty]
     by_contra hcon
-    exact hne (Subtype.ext (hsheet_eq g g' (Set.nonempty_iff_ne_empty.mpr hcon)))
+    exact hne (Subtype.ext (image_smul_eq_image_smul_of_inter_nonempty hqH hdisj
+      (Set.nonempty_iff_ne_empty.mpr hcon)))
   · -- The sheets exhaust the preimage of the base set.
     intro z hz
     obtain ⟨w, rfl⟩ := hqH.surjective z

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -66,9 +66,9 @@ variable {E X Y : Type*} [TopologicalSpace E] [TopologicalSpace X] [TopologicalS
 namespace IsQuotientCoveringMap
 
 omit [TopologicalSpace E] [TopologicalSpace Y] in
-/-- **Translates of `U` whose images in `Y` meet have the same image.** When the `G`-translates of
-`U` are pairwise disjoint, the sets `qH '' (g • U)` are therefore pairwise equal or disjoint. This
-is a statement about the fibres of `qH` alone: no topology enters. -/
+/-- **When the `G`-translates of `U` are pairwise disjoint, two translates whose images in `Y` meet
+have the same image.** So the sets `qH '' (g • U)` are pairwise equal or disjoint. This is a
+statement about the fibres of `qH` alone: no topology enters. -/
 private theorem image_smul_eq_image_smul_of_inter_nonempty
     (horbit : ∀ {e₁ e₂ : E}, qH e₁ = qH e₂ ↔ e₁ ∈ MulAction.orbit H e₂) {U : Set E}
     (hdisj : ∀ g : G, (g • U ∩ U).Nonempty → g = 1) {g g' : G}

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -65,20 +65,22 @@ variable {E X Y : Type*} [TopologicalSpace E] [TopologicalSpace X] [TopologicalS
 
 namespace IsQuotientCoveringMap
 
+omit [TopologicalSpace E] [TopologicalSpace Y] in
 /-- **Translates of `U` whose images in `Y` meet have the same image.** When the `G`-translates of
-`U` are pairwise disjoint, the sets `qH '' (g • U)` are therefore pairwise equal or disjoint. -/
+`U` are pairwise disjoint, the sets `qH '' (g • U)` are therefore pairwise equal or disjoint. This
+is a statement about the fibres of `qH` alone: no topology enters. -/
 private theorem image_smul_eq_image_smul_of_inter_nonempty
-    (hqH : IsQuotientCoveringMap qH H) {U : Set E}
+    (horbit : ∀ {e₁ e₂ : E}, qH e₁ = qH e₂ ↔ e₁ ∈ MulAction.orbit H e₂) {U : Set E}
     (hdisj : ∀ g : G, (g • U ∩ U).Nonempty → g = 1) {g g' : G}
     (hmeet : (qH '' (g • U) ∩ qH '' (g' • U)).Nonempty) :
     qH '' (g • U) = qH '' (g' • U) := by
   obtain ⟨z, ⟨w, hw, rfl⟩, w', hw', hww'⟩ := hmeet
   obtain ⟨u, hu, rfl⟩ := Set.mem_smul_set.mp hw
   obtain ⟨u', hu', rfl⟩ := Set.mem_smul_set.mp hw'
-  obtain ⟨⟨h, hh⟩, hhu'⟩ := hqH.apply_eq_iff_mem_orbit.mp hww'.symm
+  obtain ⟨⟨h, hh⟩, hhu'⟩ := horbit.mp hww'.symm
   -- `H` acts on `E` through `G`, so the orbit witness is an element of `G` fixing `qH`.
   have hhu : h • (g' • u') = g • u := hhu'
-  have hmap : ∀ e : E, qH (h • e) = qH e := fun _ => hqH.map_smul ⟨h, hh⟩
+  have hmap : ∀ e : E, qH (h • e) = qH e := fun _ => horbit.mpr ⟨⟨h, hh⟩, rfl⟩
   have hone : g⁻¹ * h * g' = 1 := by
     refine hdisj _ ⟨u, Set.mem_smul_set.mpr ⟨u', hu', ?_⟩, hu⟩
     rw [mul_smul, mul_smul, hhu, inv_smul_smul]
@@ -158,7 +160,8 @@ private theorem isEvenlyCovered_of_smul_disjoint (hq : IsQuotientCoveringMap q G
     rintro ⟨S, g, rfl⟩ ⟨S', g', rfl⟩ hne
     simp only [Function.onFun, Set.disjoint_iff_inter_eq_empty]
     by_contra hcon
-    exact hne (Subtype.ext (image_smul_eq_image_smul_of_inter_nonempty hqH hdisj
+    exact hne (Subtype.ext (image_smul_eq_image_smul_of_inter_nonempty
+      hqH.apply_eq_iff_mem_orbit hdisj
       (Set.nonempty_iff_ne_empty.mpr hcon)))
   · -- The sheets exhaust the preimage of the base set.
     intro z hz

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -84,11 +84,7 @@ private theorem image_smul_eq_image_smul_of_inter_nonempty
   have hone : g⁻¹ * h * g' = 1 := by
     refine hdisj _ ⟨u, Set.mem_smul_set.mpr ⟨u', hu', ?_⟩, hu⟩
     rw [mul_smul, mul_smul, hhu, inv_smul_smul]
-  have hgg' : g = h * g' := by
-    have h2 : g * (g⁻¹ * h * g') = h * g' := by
-      rw [← mul_assoc, mul_inv_cancel_left]
-    rw [hone, mul_one] at h2
-    exact h2
+  have hgg' : g = h * g' := eq_of_inv_mul_eq_one (by simpa [mul_assoc] using hone)
   rw [hgg', mul_smul]
   simp only [← Set.image_smul, Set.image_image, hmap]
 
@@ -158,11 +154,10 @@ private theorem isEvenlyCovered_of_smul_disjoint (hq : IsQuotientCoveringMap q G
     exact ⟨qH (g • u), ⟨g • u, Set.smul_mem_smul_set hu, rfl⟩, by rw [hrqH, hq.map_smul]⟩
   · -- Distinct sheets are disjoint.
     rintro ⟨S, g, rfl⟩ ⟨S', g', rfl⟩ hne
-    simp only [Function.onFun, Set.disjoint_iff_inter_eq_empty]
     by_contra hcon
     exact hne (Subtype.ext (image_smul_eq_image_smul_of_inter_nonempty
       hqH.apply_eq_iff_mem_orbit hdisj
-      (Set.nonempty_iff_ne_empty.mpr hcon)))
+      (Set.not_disjoint_iff_nonempty_inter.mp hcon)))
   · -- The sheets exhaust the preimage of the base set.
     intro z hz
     obtain ⟨w, rfl⟩ := hqH.surjective z

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -77,11 +77,14 @@ private theorem image_smul_eq_image_smul_of_inter_nonempty
   -- A point common to the two images is `qH (g • u) = qH (g' • u')` for some `u, u' ∈ U`.
   obtain ⟨_, ⟨_, ⟨u, hu, rfl⟩, rfl⟩, _, ⟨u', hu', rfl⟩, hww'⟩ := hmeet
   obtain ⟨⟨h, hh⟩, hhu'⟩ := horbit.mp hww'.symm
-  -- `H` acts on `E` through `G`, so the orbit witness is an element of `G` fixing `qH`.
-  have hmap : ∀ e : E, qH (h • e) = qH e := fun _ => horbit.mpr ⟨⟨h, hh⟩, rfl⟩
+  -- `H` acts through the coercion to `G` — `MulAction.subgroup_smul_def` — so the orbit witness is
+  -- an element of `G` fixing `qH`, and `hhu'` retypes to the ambient action.
+  have hhu : h • (g' • u') = g • u := hhu'
+  have hmap : ∀ e : E, qH (h • e) = qH e := fun e =>
+    horbit.mpr ⟨⟨h, hh⟩, MulAction.subgroup_smul_def ⟨h, hh⟩ e⟩
   have hgg' : g = h * g' := eq_of_inv_mul_eq_one <| by
     refine hdisj _ ⟨u, Set.mem_smul_set.mpr ⟨u', hu', ?_⟩, hu⟩
-    rw [mul_smul, mul_smul, show h • (g' • u') = g • u from hhu', inv_smul_smul]
+    rw [mul_smul, mul_smul, hhu, inv_smul_smul]
   simp [hgg', mul_smul, ← Set.image_smul, Set.image_image, hmap]
 
 /-- The evenly covered neighbourhood of `q e` cut out by a set `U` around `e` whose `G`-translates


### PR DESCRIPTION
`isEvenlyCovered_of_smul_disjoint` ran to 92 lines. Its middle phase was a statement in its own
right rather than a step.

## The extraction

**`image_smul_eq_image_smul_of_inter_nonempty`** (17 lines). Two translates of `U` whose images in
`Y` meet have the same image — so the sets `qH '' (g • U)` are pairwise equal or disjoint, which
is exactly the hypothesis `IsOpen.trivializationDiscrete` consumes.

The point of naming it is what it does *not* need. Inline, it sat in scope with the ambient
quotient map `q`, the factorisation `hr : r ∘ qH = q`, openness of `U`, the basepoint `e`, and the
derived `ContinuousConstSMul G E` instance, and it uses none of them.

Review round 1 pushed this further, correctly: it took `IsQuotientCoveringMap qH H` whole while
using only that lemma's fibres-are-orbits property. It now takes that property directly, as
`horbit : ∀ {e₁ e₂}, qH e₁ = qH e₂ ↔ e₁ ∈ MulAction.orbit H e₂` — which also supplies the
`H`-invariance of `qH`, via `horbit.mpr ⟨⟨h, hh⟩, rfl⟩`, that the covering-map field was being
carried for. The caller passes `hqH.apply_eq_iff_mem_orbit`.

The statement is now purely algebraic, and the compiler says so rather than the prose: with the
weaker hypothesis the `unusedSectionVars` linter reports `[TopologicalSpace E]` and
`[TopologicalSpace Y]` as unused, and both are omitted. No topology enters a lemma that lives in
`Topology/Covering/`.

Dropping it into place also let the parent's `hsheet_eq` binding go entirely; the single consumer,
the disjointness obligation of the trivialization, now calls the lemma directly.

## Result

| | before | after |
|---|---|---|
| `isEvenlyCovered_of_smul_disjoint` | 92 | 72 |
| `image_smul_eq_image_smul_of_inter_nonempty` | — | 9 |

Vacuous at the degenerate end: for `U = ∅` every translate image is empty, so the meeting
hypothesis is unsatisfiable and the statement holds trivially.

## Review round 2, plus the standing skill passes

`reuse` was right that the `hgg'` step hand-derived group cancellation; `eq_of_inv_mul_eq_one`
does it directly.

Both required passes then ran on the lemma. `/mathlibable` returned **not in mathlib** — verified
by Loogle, an untruncated grep over twelve term families, and a compiled `exact?` probe, for both
this form and the `MulAction.IsBlock` form. The block API provably cannot reach it: `IsBlock`
describes `{g • B}`, indexed by *left* cosets `gH`, whereas this family is the `H`-saturations
`(Hg) • U`, indexed by *right* cosets; the two agree only when `H ⊴ G`, which is not assumed — so
`G` does not act on `Y` at all. It also confirmed `horbit` is the right hypothesis shape (mathlib
states the identical standalone hypothesis at `Mathlib/Topology/Covering/Quotient.lean:166`),
that both directions of the iff are used, and that the placement should stay.

`/cleanup` then took the body from 13 lines to 9. The substantive change is a strategy one:
stating the disjointness witness as `g⁻¹ * (h * g')` rather than `g⁻¹ * h * g'` makes
`eq_of_inv_mul_eq_one` apply directly, which deletes both the `hone` intermediate and the
`simpa [mul_assoc]` bridge that reconciled the association. The three destructuring `obtain`s
collapse into one nested pattern — the idiom the upstream file itself uses at
`Mathlib/Topology/Covering/Quotient.lean:259`.

Gates re-run on `a90647e9`: `lake build` (7815 jobs), `lake exe axioms` (44789 declarations),
`lake exe module-system` (2155 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: none


