### PR TITLE
refactor(EllipticCurve): get the polynomial denominator from IsLocalization.surj

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -439,11 +439,9 @@ private theorem exists_div_algebraMap_eq (z : W.FunctionField) :
   obtain ⟨⟨b, m, hm⟩, hbm⟩ :=
     IsLocalization.surj (Algebra.algebraMapSubmonoid W.CoordinateRing (nonZeroDivisors F[X])) z
   obtain ⟨d, hd, rfl⟩ := hm
-  have hd0 : algebraMap F[X] W.FunctionField d ≠ 0 := by
-    rw [IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField]
-    exact (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective W.CoordinateRing
-      W.FunctionField)).mpr ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective F[X]
-      W.CoordinateRing)).mpr (mem_nonZeroDivisors_iff_ne_zero.mp hd))
+  have hd0 : algebraMap F[X] W.FunctionField d ≠ 0 :=
+    (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective F[X] W.FunctionField)).mpr
+      (mem_nonZeroDivisors_iff_ne_zero.mp hd)
   refine ⟨b, d, mem_nonZeroDivisors_iff_ne_zero.mp hd, ?_⟩
   rw [eq_comm, eq_div_iff hd0,
     IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, hbm]
@@ -455,11 +453,8 @@ private theorem exists_algebraMap_eq [W.IsElliptic] {z : W.FunctionField}
     ∃ b : W.CoordinateRing, algebraMap W.CoordinateRing W.FunctionField b = z := by
   -- write `z = b / d` with `b` in the coordinate ring and `d` in `F[X]`
   obtain ⟨b, d, hd0, rfl⟩ := exists_div_algebraMap_eq W z
-  have hinjK : Function.Injective (algebraMap F[X] W.FunctionField) := by
-    rw [IsScalarTower.algebraMap_eq F[X] W.CoordinateRing W.FunctionField]
-    exact (FaithfulSMul.algebraMap_injective _ _).comp (FaithfulSMul.algebraMap_injective _ _)
-  have hdK : algebraMap F[X] W.FunctionField d ≠ 0 := fun h =>
-    hd0 (hinjK (h.trans (map_zero _).symm))
+  have hdK : algebraMap F[X] W.FunctionField d ≠ 0 :=
+    (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective F[X] W.FunctionField)).mpr hd0
   -- the trace and the norm of `z`
   obtain ⟨p, q, hpq⟩ := exists_smul_basis_eq b
   have htr := dvd_trace_of_isIntegral_div W hd0 hpq hz

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -429,36 +429,40 @@ private theorem sq_dvd_norm_of_isIntegral_div {b : W.CoordinateRing} {d p q : F[
   rw [hprod]
   exact hz.mul (hz.map (conjFunctionField W : W.FunctionField →ₐ[F[X]] W.FunctionField))
 
+/-- **Every element of the function field has a polynomial denominator.** Writing `z = b₁ / b₂`
+with both in the coordinate ring, multiply through by `conj b₂`: the denominator becomes
+`b₂ * conj b₂`, which is the norm of `b₂` and so already lies in `F[X]`.
+
+Ellipticity of `W` is not needed. -/
+private theorem exists_div_algebraMap_eq (z : W.FunctionField) :
+    ∃ (b : W.CoordinateRing) (d : F[X]), d ≠ 0 ∧
+      algebraMap W.CoordinateRing W.FunctionField b /
+        algebraMap F[X] W.FunctionField d = z := by
+  obtain ⟨b₁, b₂, hb₂, rfl⟩ := IsFractionRing.div_surjective (A := W.CoordinateRing) z
+  have hb₂0 : b₂ ≠ 0 := mem_nonZeroDivisors_iff_ne_zero.mp hb₂
+  have hcb₂0 : CoordinateRing.conj W b₂ ≠ 0 := fun h =>
+    hb₂0 <| (CoordinateRing.conj W).injective (by rw [h, map_zero])
+  have hdB : algebraMap F[X] W.CoordinateRing (Algebra.norm F[X] b₂) =
+      b₂ * CoordinateRing.conj W b₂ := (CoordinateRing.mul_conj W b₂).symm
+  have hcb₂K : algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.conj W b₂) ≠ 0 :=
+    fun h => hcb₂0 ((FaithfulSMul.algebraMap_injective _ _) (h.trans (map_zero _).symm))
+  refine ⟨b₁ * CoordinateRing.conj W b₂, Algebra.norm F[X] b₂,
+    fun h => (mul_ne_zero hb₂0 hcb₂0) (by rw [← hdB, h, map_zero]), ?_⟩
+  rw [IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, hdB, map_mul, map_mul,
+    mul_div_mul_right _ _ hcb₂K]
+
 /-- Every element of the function field of an elliptic curve that is integral over `F[X]` already
 lies in the coordinate ring. -/
 private theorem exists_algebraMap_eq [W.IsElliptic] {z : W.FunctionField}
     (hz : IsIntegral F[X] z) :
     ∃ b : W.CoordinateRing, algebraMap W.CoordinateRing W.FunctionField b = z := by
   -- write `z = b / d` with `b` in the coordinate ring and `d` in `F[X]`
-  obtain ⟨b₁, b₂, hb₂, rfl⟩ := IsFractionRing.div_surjective (A := W.CoordinateRing) z
-  have hb₂0 : b₂ ≠ 0 := mem_nonZeroDivisors_iff_ne_zero.mp hb₂
-  have hcb₂0 : CoordinateRing.conj W b₂ ≠ 0 := fun h =>
-    hb₂0 <| (CoordinateRing.conj W).injective (by rw [h, map_zero])
-  set b : W.CoordinateRing := b₁ * CoordinateRing.conj W b₂ with hb
-  set d : F[X] := Algebra.norm F[X] b₂
-  have hdB : algebraMap F[X] W.CoordinateRing d = b₂ * CoordinateRing.conj W b₂ :=
-    (CoordinateRing.mul_conj W b₂).symm
-  have hd0 : d ≠ 0 := fun h => (mul_ne_zero hb₂0 hcb₂0) (by rw [← hdB, h, map_zero])
-  have hinjB : Function.Injective (algebraMap W.CoordinateRing W.FunctionField) :=
-    FaithfulSMul.algebraMap_injective _ _
+  obtain ⟨b, d, hd0, rfl⟩ := exists_div_algebraMap_eq W z
   have hinjK : Function.Injective (algebraMap F[X] W.FunctionField) := by
     rw [IsScalarTower.algebraMap_eq F[X] W.CoordinateRing W.FunctionField]
-    exact hinjB.comp (FaithfulSMul.algebraMap_injective _ _)
+    exact (FaithfulSMul.algebraMap_injective _ _).comp (FaithfulSMul.algebraMap_injective _ _)
   have hdK : algebraMap F[X] W.FunctionField d ≠ 0 := fun h =>
     hd0 (hinjK (h.trans (map_zero _).symm))
-  have hcb₂K : algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.conj W b₂) ≠ 0 :=
-    fun h => hcb₂0 (hinjB (h.trans (map_zero _).symm))
-  have hzeq : algebraMap W.CoordinateRing W.FunctionField b₁ /
-      algebraMap W.CoordinateRing W.FunctionField b₂ =
-      algebraMap W.CoordinateRing W.FunctionField b / algebraMap F[X] W.FunctionField d := by
-    rw [IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, hdB, hb, map_mul,
-      map_mul, mul_div_mul_right _ _ hcb₂K]
-  rw [hzeq] at hz ⊢
   -- the trace and the norm of `z`
   obtain ⟨p, q, hpq⟩ := exists_smul_basis_eq b
   have htr := dvd_trace_of_isIntegral_div W hd0 hpq hz

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -429,27 +429,24 @@ private theorem sq_dvd_norm_of_isIntegral_div {b : W.CoordinateRing} {d p q : F[
   rw [hprod]
   exact hz.mul (hz.map (conjFunctionField W : W.FunctionField →ₐ[F[X]] W.FunctionField))
 
-/-- **Every element of the function field has a polynomial denominator.** Writing `z = b₁ / b₂`
-with both in the coordinate ring, multiply through by `conj b₂`: the denominator becomes
-`b₂ * conj b₂`, which is the norm of `b₂` and so already lies in `F[X]`.
-
+/-- **Every element of the function field is a coordinate-ring element over a nonzero
+polynomial**: the denominator can be taken in `F[X]`, not merely in the coordinate ring.
 Ellipticity of `W` is not needed. -/
 private theorem exists_div_algebraMap_eq (z : W.FunctionField) :
     ∃ (b : W.CoordinateRing) (d : F[X]), d ≠ 0 ∧
       algebraMap W.CoordinateRing W.FunctionField b /
         algebraMap F[X] W.FunctionField d = z := by
-  obtain ⟨b₁, b₂, hb₂, rfl⟩ := IsFractionRing.div_surjective (A := W.CoordinateRing) z
-  have hb₂0 : b₂ ≠ 0 := mem_nonZeroDivisors_iff_ne_zero.mp hb₂
-  have hcb₂0 : CoordinateRing.conj W b₂ ≠ 0 := fun h =>
-    hb₂0 <| (CoordinateRing.conj W).injective (by rw [h, map_zero])
-  have hdB : algebraMap F[X] W.CoordinateRing (Algebra.norm F[X] b₂) =
-      b₂ * CoordinateRing.conj W b₂ := (CoordinateRing.mul_conj W b₂).symm
-  have hcb₂K : algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.conj W b₂) ≠ 0 :=
-    fun h => hcb₂0 ((FaithfulSMul.algebraMap_injective _ _) (h.trans (map_zero _).symm))
-  refine ⟨b₁ * CoordinateRing.conj W b₂, Algebra.norm F[X] b₂,
-    fun h => (mul_ne_zero hb₂0 hcb₂0) (by rw [← hdB, h, map_zero]), ?_⟩
-  rw [IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, hdB, map_mul, map_mul,
-    mul_div_mul_right _ _ hcb₂K]
+  obtain ⟨⟨b, m, hm⟩, hbm⟩ :=
+    IsLocalization.surj (Algebra.algebraMapSubmonoid W.CoordinateRing (nonZeroDivisors F[X])) z
+  obtain ⟨d, hd, rfl⟩ := hm
+  have hd0 : algebraMap F[X] W.FunctionField d ≠ 0 := by
+    rw [IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField]
+    exact (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective W.CoordinateRing
+      W.FunctionField)).mpr ((map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective F[X]
+      W.CoordinateRing)).mpr (mem_nonZeroDivisors_iff_ne_zero.mp hd))
+  refine ⟨b, d, mem_nonZeroDivisors_iff_ne_zero.mp hd, ?_⟩
+  rw [eq_comm, eq_div_iff hd0,
+    IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, hbm]
 
 /-- Every element of the function field of an elliptic curve that is integral over `F[X]` already
 lies in the coordinate ring. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -429,32 +429,23 @@ private theorem sq_dvd_norm_of_isIntegral_div {b : W.CoordinateRing} {d p q : F[
   rw [hprod]
   exact hz.mul (hz.map (conjFunctionField W : W.FunctionField →ₐ[F[X]] W.FunctionField))
 
-/-- **Every element of the function field is a coordinate-ring element over a nonzero
-polynomial**: the denominator can be taken in `F[X]`, not merely in the coordinate ring.
-Ellipticity of `W` is not needed. -/
-private theorem exists_div_algebraMap_eq (z : W.FunctionField) :
-    ∃ (b : W.CoordinateRing) (d : F[X]), d ≠ 0 ∧
-      algebraMap W.CoordinateRing W.FunctionField b /
-        algebraMap F[X] W.FunctionField d = z := by
-  obtain ⟨⟨b, m, hm⟩, hbm⟩ :=
-    IsLocalization.surj (Algebra.algebraMapSubmonoid W.CoordinateRing (nonZeroDivisors F[X])) z
-  obtain ⟨d, hd, rfl⟩ := hm
-  have hd0 : algebraMap F[X] W.FunctionField d ≠ 0 :=
-    (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective F[X] W.FunctionField)).mpr
-      (mem_nonZeroDivisors_iff_ne_zero.mp hd)
-  refine ⟨b, d, mem_nonZeroDivisors_iff_ne_zero.mp hd, ?_⟩
-  rw [eq_comm, eq_div_iff hd0,
-    IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, hbm]
-
 /-- Every element of the function field of an elliptic curve that is integral over `F[X]` already
 lies in the coordinate ring. -/
 private theorem exists_algebraMap_eq [W.IsElliptic] {z : W.FunctionField}
     (hz : IsIntegral F[X] z) :
     ∃ b : W.CoordinateRing, algebraMap W.CoordinateRing W.FunctionField b = z := by
-  -- write `z = b / d` with `b` in the coordinate ring and `d` in `F[X]`
-  obtain ⟨b, d, hd0, rfl⟩ := exists_div_algebraMap_eq W z
+  -- write `z = b / d` with `b` in the coordinate ring and `d` in `F[X]`; the function field is
+  -- the localisation at the image of `nonZeroDivisors F[X]`, so the denominator is a polynomial
+  obtain ⟨⟨b, m, hm⟩, hbm⟩ :=
+    IsLocalization.surj (Algebra.algebraMapSubmonoid W.CoordinateRing (nonZeroDivisors F[X])) z
+  obtain ⟨d, hd, rfl⟩ := hm
+  have hd0 : d ≠ 0 := mem_nonZeroDivisors_iff_ne_zero.mp hd
   have hdK : algebraMap F[X] W.FunctionField d ≠ 0 :=
     (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective F[X] W.FunctionField)).mpr hd0
+  obtain rfl : algebraMap W.CoordinateRing W.FunctionField b /
+      algebraMap F[X] W.FunctionField d = z := by
+    rw [eq_comm, eq_div_iff hdK,
+      IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, hbm]
   -- the trace and the norm of `z`
   obtain ⟨p, q, hpq⟩ := exists_smul_basis_eq b
   have htr := dvd_trace_of_isIntegral_div W hd0 hpq hz


### PR DESCRIPTION
`exists_algebraMap_eq` spent the first 22 of its 43 lines hand-building a *polynomial* denominator
for an element of the function field, by multiplying through by a conjugate so that
`b₂ · conj b₂ = Norm b₂`. Mathlib gives that directly: the function field is the localisation of
the coordinate ring at the image of `nonZeroDivisors F[X]`, so `IsLocalization.surj` hands over a
denominator already in `F[X]`. No statement changes; no new declaration; the file gets shorter.

## What it was doing

```lean
  obtain ⟨b₁, b₂, hb₂, rfl⟩ := IsFractionRing.div_surjective z   -- z = b₁ / b₂, both in F[W]
  …22 lines: b₂ ≠ 0, conj b₂ ≠ 0, hdB : algebraMap (Norm b₂) = b₂ * conj b₂,
             injectivity of both structure maps, and finally
             hzeq : b₁ / b₂ = (b₁ * conj b₂) / algebraMap (Norm b₂)…
  rw [hzeq] at hz ⊢
  …the divisibility argument…
```

`IsFractionRing.div_surjective` only promises a denominator in the **coordinate ring**, and the
divisibility argument downstream needs one in `F[X]` — hence the conjugation detour.

## What it does now

```lean
  obtain ⟨⟨b, m, hm⟩, hbm⟩ :=
    IsLocalization.surj (Algebra.algebraMapSubmonoid W.CoordinateRing (nonZeroDivisors F[X])) z
  obtain ⟨d, hd, rfl⟩ := hm
```

The submonoid is exactly "denominators coming from `F[X]`", so unpacking its witness gives `d` in
`F[X]` with no further work. The conjugation argument, the two injectivity derivations and the
`hzeq` rewrite all go.

`CoordinateRing.mul_conj` — the lemma the old code leaned on — is untouched and still used by the
trace and norm computations above; only this denominator step stops needing it.

## Lengths

| Declaration | Before | After |
|---|---|---|
| `exists_algebraMap_eq` | 43 | 30 |

The file goes from 499 to **485** lines: this removes code rather than moving it. Nothing is
extracted, so there is no new declaration to name, document or place.

Everything below the denominator step is carried over unchanged.

## Scope

Improvement work on existing code: no statement changes, nothing public added, renamed or removed,
no new mathematics. This is the follow-up named in #3210, which split the trace and norm halves of
the divisibility input and left this proof for a separate topic.

## Review

Three rounds, all findings implemented rather than contested — and the PR is not the one I opened.
It began as a decomposition, extracting the denominator step as a private
`exists_div_algebraMap_eq`, and review turned it into a deletion:

* Round 1 (private) — `reuse`: the extracted step lifted the conjugation argument verbatim, which
  rebuilds by hand what `IsLocalization.surj` gives for the `F[X]`-denominator submonoid. Reproved
  through that API. `documentation`: the docstring narrated the proof; restated at result level.
* A `/simplify` pass then caught what no rubric had: the extracted lemma and its caller were each
  separately deriving `algebraMap F[X] W.FunctionField d ≠ 0`, one via a scalar-tower rewrite and
  the other via a hand-composed injectivity. `FaithfulSMul.algebraMap_injective` resolves for that
  map directly, collapsing both to a one-line `map_ne_zero_iff`.
* Round 2 (posted) — `reuse` again: with the conjugation gone, the extracted lemma was a one-use
  wrapper around `IsLocalization.surj`. Deleted, and the localisation call inlined.

The net effect is better than the original plan: instead of naming a 22-line detour, the detour is
gone.

## Gates

`lake build` whole project clean; `scripts/lint-env.sh` **PASS**, no new violations; `lake exe
axioms` all within `[propext, Classical.choice, Quot.sound]`; `lake exe module-system` all modules
opt in. No line exceeds 100 codepoints.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"coordring-exists-algebramap"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
