### PR TITLE
feat(EDS): an elliptic sequence is exactly its two doubling recurrences

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Recurrence
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Transfer
 
 /-!
@@ -383,3 +384,24 @@ theorem isEllipticSequence_of_rel (odd : W.Odd) (zero : W 0 = 0) (one : W 1 ∈ 
     (abs_two_mul_emod_two p) (abs_two_mul_emod_two q) (abs_two_mul_emod_two r)
 
 end IsEllipticNet
+
+/-- **Being an elliptic sequence is exactly satisfying the two doubling recurrences.** For a
+sequence that is odd, vanishes at `0` and has `W 1`, `W 2` nonzerodivisors, the whole
+three-index relation is equivalent to the odd recurrence from `m = 2` and the even one from
+`m = 3` — finitely many equations per index rather than a condition on triples.
+
+The forward direction is `IsEllipticSequence.rel_odd` and `rel_even`, which read the two
+recurrences off the relation; the reverse is the descent, which rebuilds the relation from
+them. -/
+theorem isEllipticSequence_iff {R : Type*} [CommRing R] {W : ℤ → R} (odd : W.Odd) (zero : W 0 = 0)
+    (one : W 1 ∈ nonZeroDivisors R) (two : W 2 ∈ nonZeroDivisors R) :
+    IsEllipticSequence W ↔
+      (∀ m : ℤ, 2 ≤ m → W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3)
+        ∧ ∀ m : ℤ, 3 ≤ m → W (2 * m) * W 2 * W 1 ^ 2 =
+            W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) := by
+  refine ⟨fun h ↦ ⟨fun m _ ↦ h.rel_odd m, fun m _ ↦ h.rel_even m⟩, fun ⟨hodd, heven⟩ ↦ ?_⟩
+  refine IsEllipticNet.isEllipticSequence_of_rel odd zero one two (fun m hm ↦ ?_) fun m hm ↦ ?_
+  · rw [IsEllipticNet.rel_odd]
+    linear_combination hodd m hm
+  · rw [IsEllipticNet.rel_even]
+    linear_combination heven m hm

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -8,6 +8,7 @@ public import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 public import Mathlib.NumberTheory.EllipticDivisibilitySequence
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Recurrence
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Transfer
+import TauCeti.NumberTheory.EllipticDivisibilitySequence.SignEquivariance
 
 /-!
 # An elliptic sequence from its two doubling recurrences
@@ -41,18 +42,23 @@ hypotheses that `atom_even`, `atom_odd` and `atomRel_eq` carry.
 * `isEllipticSequence_iff`: the equivalence, and the headline result of the file.
 * `IsEllipticNet.isEllipticSequence_of_rel`: its hard direction, with the recurrences in
   relator form.
-* `IsEllipticNet.atomRelVanishes_of_rel`: the descent itself, at valid quadruples.
 * `IsEllipticNet.atom_mul_atomRel_eq_of_last_eq_fst`, `…_of_last_eq_snd`,
   `IsEllipticNet.atom_mul_atomRel_eq`: the three-term and ten-term expansions that drive it.
-* `IsEllipticNet.atomRel_swap₁₂`, `IsEllipticNet.atomRel_swap₂₃`: antisymmetry of the relator
-  under transpositions of its indices.
 
 ## Implementation notes
 
-The descent's hypothesis is packaged as `AtomRelVanishes`, carrying the parity and ordering
-conditions *inside* the predicate. The induction applies its hypothesis at quadruples whose
-validity is not known in advance, so the recursive call has to be a statement about indices
-alone.
+The descent itself is private. `AtomRelVanishes` and the three lemmas lowering it are shaped by
+this proof rather than by any consumer, and the interface a caller wants is the equivalence and
+its hard direction.
+
+That predicate carries the parity and ordering conditions *inside* it. The induction applies its
+hypothesis at quadruples whose validity is not known in advance, so the recursive call has to be
+a statement about indices alone.
+
+The antisymmetry of `atomRel` under transpositions is **not** proved here: `SignEquivariance.lean`
+already exports `atomRel_swap₁₂`, `atomRel_swap₂₃` and `atomRel_swap₃₄`, together with the general
+`atomRelFin4_perm`. Only the first three indices are ever permuted below, the last being held at
+`0`, so the two adjacent transpositions are all that is used.
 
 Three parts of the source's apparatus are not needed here, each because Mathlib has absorbed
 the layer that made them necessary. Its `rel₄_transf` is `atomRel_avg_sub`; its minimal-index
@@ -66,8 +72,8 @@ Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
 `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`,
 `rel₄_iff_evenRec`, `dMin`, `cMin`, `Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`,
-`rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`, `rel₄_swap₀₁`, `rel₄_swap₁₂`,
-`rel₄_of_oddRec_evenRec` and `IsEllSequence.of_oddRec_evenRec`. That file's header reads
+`rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`, `rel₄_of_oddRec_evenRec` and
+`IsEllSequence.of_oddRec_evenRec`. That file's header reads
 `Authors: Junyan Xu`; following this repository's convention for adapted material the upstream
 authorship is credited here rather than in the copyright header.
 
@@ -78,9 +84,9 @@ renaming. Three of its declarations are deliberately **not** ported. Its `rel₆
 rather than a concept and exists only to shorten four statements, so it would stand a second
 public spelling of `atom _ _ * atomRel _ _ _ _`; the statements below write the product out.
 Its `addMulSub_sq_mul_rel₄_eq₉`, the nine-term expansion, is unused in the source itself — it
-occurs there only at its own declaration — and this descent does not need it. Its four-index
-swap `rel₄_swap₂₃` supports the `Tuple.sort` argument avoided above; with the last index held
-at `0` only the first three are ever permuted, so the two swaps below suffice.
+occurs there only at its own declaration — and this descent does not need it. Its swap family
+`rel₄_swap₀₁`, `rel₄_swap₁₂`, `rel₄_swap₂₃` and the `relFin4_perm` built on them are already in
+this repository as `SignEquivariance.lean`, and are used from there.
 
 `rel₄_iff_evenRec` is the one source declaration carrying `set_option allowUnsafeReducibility
 true` together with `attribute [local reducible] Nat.rawCast`, which #2860 declined to bring
@@ -133,7 +139,7 @@ open scoped nonZeroDivisors
 decreasing. The two hypotheses live inside the predicate rather than outside it because the
 descent applies its induction hypothesis at quadruples whose validity is not known in advance;
 carrying them here means the recursive call is a `Prop` about indices alone. -/
-def AtomRelVanishes (a b c d : ℤ) : Prop :=
+private def AtomRelVanishes (a b c d : ℤ) : Prop :=
   (d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) → NonnegStrictAnti₄ a b c d →
     atomRel W a b c d = 0
 
@@ -166,7 +172,7 @@ private theorem atomRel_triple_eq_zero {a b c c₀ d₀ : ℤ}
 `(a, b, c, d₀)` once `c₀ < c`. Both follow from a three-term expansion trading the relator's
 last index for the pair `c₀, d₀`, after which every summand carries a factor already known to
 vanish. -/
-theorem atomRelVanishes_of_forall_le {a c₀ d₀ : ℤ} (par : c₀ % 2 = d₀ % 2) (le : 0 ≤ d₀)
+private theorem atomRelVanishes_of_forall_le {a c₀ d₀ : ℤ} (par : c₀ % 2 = d₀ % 2) (le : 0 ≤ d₀)
     (lt : d₀ < c₀) (rel : ∀ {a' b : ℤ}, a' ≤ a → AtomRelVanishes W a' b c₀ d₀)
     (mem : atom W c₀ d₀ ∈ R⁰) (b c : ℤ) :
     AtomRelVanishes W a b c c₀ ∧ (c₀ < c → AtomRelVanishes W a b c d₀) := by
@@ -192,7 +198,8 @@ theorem atomRelVanishes_of_forall_le {a c₀ d₀ : ℤ} (par : c₀ % 2 = d₀ 
 the ten-term expansion reaches a quadruple whose last index `d` is merely above `c₀`: each of
 the ten summands carries a relator that either already ends at the fixed pair or is reachable
 from it, and so vanishes. -/
-theorem atomRelVanishes_of_lt {a c₀ d₀ : ℤ} (par : c₀ % 2 = d₀ % 2) (le : 0 ≤ d₀) (lt : d₀ < c₀)
+private theorem atomRelVanishes_of_lt {a c₀ d₀ : ℤ} (par : c₀ % 2 = d₀ % 2) (le : 0 ≤ d₀)
+    (lt : d₀ < c₀)
     (rel : ∀ {a' b : ℤ}, a' ≤ a → AtomRelVanishes W a' b c₀ d₀) (mem : atom W c₀ d₀ ∈ R⁰)
     (b c d : ℤ) (hc : c₀ < d) (par' : d % 2 = d₀ % 2) :
     AtomRelVanishes W a b c d := by
@@ -227,7 +234,7 @@ last two indices are the minimal same-parity pair `(a % 2 + 2, a % 2)`, it vanis
 valid quadruple with first index `a`. The three remaining cases are `d` above the pair, `d` at
 its top, and `d` at its bottom; in the `%2` spelling each is closed by `omega`, where the source
 needed a chain of `Int.negOnePow` lemmas. -/
-theorem atomRelVanishes_of_min {a : ℤ} (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
+private theorem atomRelVanishes_of_min {a : ℤ} (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
     (rel : ∀ {a' b : ℤ}, a' ≤ a → AtomRelVanishes W a' b (a % 2 + 2) (a % 2)) (b c d : ℤ) :
     AtomRelVanishes W a b c d := by
   intro same anti
@@ -247,19 +254,6 @@ theorem atomRelVanishes_of_min {a : ℤ} (one : W 1 ∈ R⁰) (two : W 2 ∈ R�
     rcases (show a % 2 + 2 = c ∨ a % 2 + 2 < c by omega) with heq₂ | hlt₃
     · subst heq₂; exact rel le_rfl same anti
     · exact fix.2 hlt₃ same anti
-
-/-- **The relator is antisymmetric in its first two indices.** -/
-theorem atomRel_swap₁₂ (odd : W.Odd) (a b c d : ℤ) :
-    atomRel W b a c d = -atomRel W a b c d := by
-  rw [atomRel, atomRel, ← neg_atom odd a b]; ring
-
-/-- **The relator is antisymmetric in its middle two indices.** With `atomRel_swap₁₂` these are
-the two transpositions needed here: the last index is held fixed throughout the descent, so only
-the first three are ever permuted, and these two generate that symmetric group. Mathlib supplies
-the `atomRel_same`, `atomRel_neg` and `atomRel_abs` families but neither of these. -/
-theorem atomRel_swap₂₃ (odd : W.Odd) (a b c d : ℤ) :
-    atomRel W a c b d = -atomRel W a b c d := by
-  rw [atomRel, atomRel, ← neg_atom odd b c]; ring
 
 /-- The even base case, as a relator: all four indices are even, so `atomRel_two_mul` applies. -/
 private theorem atomRel_even_eq_rel (m : ℤ) :
@@ -283,7 +277,7 @@ full four-index relation at every valid quadruple. The induction is on the large
 `6` no valid quadruple exists, and above it `atomRelVanishes_of_min` reduces to the minimal
 pair, where either the gap `b + 2 < a` admits the transfer down to a smaller first index, or
 `b + 2 = a` lands on one of the two recurrences according to parity. -/
-theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
+private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
     (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
     (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) :
     ∀ a b c d : ℤ, AtomRelVanishes W a b c d := by
@@ -334,27 +328,27 @@ private theorem atomRel_eq_zero_of_ne (odd : W.Odd)
   rcases lt_trichotomy x y with h₁ | h₁ | h₁
   · rcases lt_trichotomy y z with h₂ | h₂ | h₂
     · have h := sorted pz py px hx h₁ h₂
-      rw [atomRel_swap₁₂ odd y z x 0, atomRel_swap₂₃ odd y x z 0,
-        atomRel_swap₁₂ odd x y z 0] at h
+      rw [atomRel_swap₁₂ odd z y x 0, atomRel_swap₂₃ odd y z x 0,
+        atomRel_swap₁₂ odd y x z 0] at h
       simpa using h
     · exact absurd h₂ hyz
     · rcases lt_trichotomy x z with h₃ | h₃ | h₃
       · have h := sorted py pz px hx h₃ h₂
-        rw [atomRel_swap₂₃ odd y x z 0, atomRel_swap₁₂ odd x y z 0] at h
+        rw [atomRel_swap₂₃ odd y z x 0, atomRel_swap₁₂ odd y x z 0] at h
         simpa using h
       · exact absurd h₃ hxz
       · have h := sorted py px pz hz h₃ h₁
-        rw [atomRel_swap₁₂ odd x y z 0] at h
+        rw [atomRel_swap₁₂ odd y x z 0] at h
         simpa using h
   · exact absurd h₁ hxy
   · rcases lt_trichotomy x z with h₂ | h₂ | h₂
     · have h := sorted pz px py hy h₁ h₂
-      rw [atomRel_swap₁₂ odd x z y 0, atomRel_swap₂₃ odd x y z 0] at h
+      rw [atomRel_swap₁₂ odd z x y 0, atomRel_swap₂₃ odd x z y 0] at h
       simpa using h
     · exact absurd h₂ hxz
     · rcases lt_trichotomy y z with h₃ | h₃ | h₃
       · have h := sorted px pz py hy h₃ h₂
-        rw [atomRel_swap₂₃ odd x y z 0] at h
+        rw [atomRel_swap₂₃ odd x z y 0] at h
         simpa using h
       · exact absurd h₃ hyz
       · exact sorted px py pz hz h₃ h₁

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
-public import Mathlib.NumberTheory.EllipticDivisibilitySequence
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Recurrence
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Transfer
 import TauCeti.NumberTheory.EllipticDivisibilitySequence.SignEquivariance
@@ -251,7 +250,10 @@ private theorem atomRelVanishes_of_min {a : ℤ} (one : W 1 ∈ R⁰) (two : W 2
   · subst heq; exact fix.1 same anti
   · have hdm : d = a % 2 := by omega
     subst hdm
-    rcases (show a % 2 + 2 = c ∨ a % 2 + 2 < c by omega) with heq₂ | hlt₃
+    -- `c` carries the parity of `a` and exceeds `a % 2`, so it is at least `a % 2 + 2`: either
+    -- the quadruple is already the minimal pair, or the previous lemma's second case applies.
+    have hcmin : a % 2 + 2 = c ∨ a % 2 + 2 < c := by omega
+    rcases hcmin with heq₂ | hlt₃
     · subst heq₂; exact rel le_rfl same anti
     · exact fix.2 hlt₃ same anti
 
@@ -295,7 +297,11 @@ private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
     intro same anti
     obtain ⟨h0, h1, h2, h3⟩ := (nonnegStrictAnti₄_iff _ _ _ _).mp anti
     have hpb := same.2.1
-    rcases (show b' + 2 < a' ∨ b' + 2 = a' by omega) with hb | hb
+    -- `b'` and `a'` share a parity and `b' < a'`, so the gap is at least two. A wider gap can be
+    -- transferred down to a smaller first index; a gap of exactly two is where the recurrences
+    -- live, and is the only place the induction bottoms out.
+    have hgap : b' + 2 < a' ∨ b' + 2 = a' := by omega
+    rcases hgap with hb | hb
     · rw [← atomRel_avg_sub W same, ← atomRel_abs₄]
       exact ih _ (by omega) _ _ _ (parity_abs_avg_sub same)
         (nonnegStrictAnti₄_abs_avg_sub h1 (by omega) h2 h3)
@@ -303,13 +309,20 @@ private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
       · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k := ⟨a' / 2, by omega⟩
         have hodd := oddRec (k - 1) (by omega)
         rw [sub_add_cancel] at hodd
-        rw [show (2 * k % 2 : ℤ) = 2 * 0 by omega, show (2 : ℤ) * 0 + 2 = 2 * 1 by norm_num,
-          show b' = 2 * (k - 1) by omega, atomRel_even_eq_rel]
+        -- `atomRel_even_eq_rel` carries every index in `2 * _` form, which is what lets
+        -- `atomRel_two_mul` fire; the goal's indices have to be put in that form first.
+        have hlast : (2 * k % 2 : ℤ) = 2 * 0 := by omega
+        have hthird : (2 : ℤ) * 0 + 2 = 2 * 1 := by norm_num
+        have hsecond : b' = 2 * (k - 1) := by omega
+        rw [hlast, hthird, hsecond, atomRel_even_eq_rel]
         exact hodd
       · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k + 1 := ⟨a' / 2, by omega⟩
-        rw [show ((2 * k + 1) % 2 : ℤ) = 2 * 0 + 1 by omega,
-          show (2 : ℤ) * 0 + 1 + 2 = 2 * 1 + 1 by norm_num,
-          show b' = 2 * (k - 1) + 1 by omega, atomRel_odd_eq_rel]
+        -- Likewise `atomRel_odd_eq_rel` carries its indices in `2 * _ + 1` form, which is what
+        -- lets `atom_odd` reduce each atom without any reasoning about truncated division.
+        have hlast : ((2 * k + 1) % 2 : ℤ) = 2 * 0 + 1 := by omega
+        have hthird : (2 : ℤ) * 0 + 1 + 2 = 2 * 1 + 1 := by norm_num
+        have hsecond : b' = 2 * (k - 1) + 1 := by omega
+        rw [hlast, hthird, hsecond, atomRel_odd_eq_rel]
         exact evenRec k (by omega)
 
 /-- Three distinct positive even indices, in any order, against a last index of `0`. The six

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -10,45 +10,83 @@ public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Recurrence
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Transfer
 
 /-!
-# Expanding a product of an elliptic atom with an elliptic relator
+# An elliptic sequence from its two doubling recurrences
 
-The descent that recovers the full four-index elliptic relation from the two doubling
-recurrences works by rewriting a relator on four unconstrained indices into relators that all
-carry a fixed pair `c, d` of small indices. This file supplies the algebraic identities that
-perform that rewriting; the ordering and parity bookkeeping that makes the resulting induction
-terminate is in `Transfer.lean`.
+`IsEllipticSequence W` is a condition on every triple of integers. This file proves it
+equivalent to two families of equations indexed by a *single* integer — the odd doubling
+recurrence from `m = 2` on and the even one from `m = 3` on — for a sequence that is odd,
+vanishes at `0`, and has `W 1` and `W 2` nonzerodivisors.
 
-All four are polynomial identities in the atoms: `atomRel` is a fixed quadratic expression in
-`atom`, so each statement expands on both sides to a combination of products of two atoms, and
-`ring` closes it. No index arithmetic is involved — the atoms' arguments are carried along
-unchanged — which is why nothing here needs the parity hypotheses that `atom_even`, `atom_odd`
-and `atomRel_eq` require.
+The forward direction is `Recurrence.lean`. The reverse is the descent proved here, by
+induction on the largest index `a`:
+
+* below `6` there is no valid quadruple at all, four nonnegative same-parity indices in strict
+  decrease forcing `6 ≤ a` (`Transfer.lean`);
+* above it, a relator on four unconstrained indices is rewritten into relators carrying a fixed
+  pair of small indices, by the three-term and ten-term expansions below;
+* that reduces to the minimal same-parity pair `(a % 2 + 2, a % 2)`, where either `b + 2 < a`
+  admits the transfer down to a smaller first index, or `b + 2 = a` lands on one of the two
+  recurrences, chosen by the parity of `a`.
+
+Arbitrary indices are then reduced to a valid quadruple: absolute values make them nonnegative,
+coincidences collapse through Mathlib's `atomRel_same` family, and the rest are sorted.
+
+The expansions are polynomial identities in the atoms — `atomRel` is a fixed quadratic
+expression in `atom`, so both sides expand to combinations of products of two atoms and `ring`
+closes them. No index arithmetic is involved, which is why they need none of the parity
+hypotheses that `atom_even`, `atom_odd` and `atomRel_eq` carry.
 
 ## Main results
 
-* `atom_mul_atomRel_eq_of_last_eq_fst`, `atom_mul_atomRel_eq_of_last_eq_snd`: when the relator's
-  last index is already one of the atom's two indices, the product is a three-term combination.
-* `atom_mul_atomRel_eq`: for four unconstrained relator indices, a ten-term combination.
-* `atom_sq_mul_atomRel_eq`: the nine-term combination obtained from the previous two, which is
-  the form the descent actually consumes.
+* `isEllipticSequence_iff`: the equivalence, and the headline result of the file.
+* `IsEllipticNet.isEllipticSequence_of_rel`: its hard direction, with the recurrences in
+  relator form.
+* `IsEllipticNet.atomRelVanishes_of_rel`: the descent itself, at valid quadruples.
+* `IsEllipticNet.atom_mul_atomRel_eq_of_last_eq_fst`, `…_of_last_eq_snd`,
+  `IsEllipticNet.atom_mul_atomRel_eq`: the three-term and ten-term expansions that drive it.
+* `IsEllipticNet.atomRel_swap₁₂`, `IsEllipticNet.atomRel_swap₂₃`: antisymmetry of the relator
+  under transpositions of its indices.
+
+## Implementation notes
+
+The descent's hypothesis is packaged as `AtomRelVanishes`, carrying the parity and ordering
+conditions *inside* the predicate. The induction applies its hypothesis at quadruples whose
+validity is not known in advance, so the recursive call has to be a statement about indices
+alone.
+
+Three parts of the source's apparatus are not needed here, each because Mathlib has absorbed
+the layer that made them necessary. Its `rel₄_transf` is `atomRel_avg_sub`; its minimal-index
+definition `if Even a then 0 else 1`, with five `Int.negOnePow` lemmas about it, is `a % 2`,
+about which everything needed is `omega`; and its `Tuple.sort` argument over four indices
+reduces to six orderings of three, the last index being `0` and so already minimal.
 
 ## Provenance
 
 Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`
-and `addMulSub_sq_mul_rel₄_eq₉`. That file's header reads `Authors: Junyan Xu`; following this
-repository's convention for adapted material the upstream authorship is credited here rather
-than in the copyright header.
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`,
+`rel₄_iff_evenRec`, `dMin`, `cMin`, `Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`,
+`rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`, `rel₄_swap₀₁`, `rel₄_swap₁₂`,
+`rel₄_of_oddRec_evenRec` and `IsEllSequence.of_oddRec_evenRec`. That file's header reads
+`Authors: Junyan Xu`; following this repository's convention for adapted material the upstream
+authorship is credited here rather than in the copyright header.
 
-The source states these against its own `addMulSub` and `rel₄`, which Mathlib now supplies as
-`IsEllipticNet.atom` and `IsEllipticNet.atomRel` with the same definitions, so the statements
-transfer by renaming. The source also carries an abbreviation `rel₆ W k l a b c d` for the
-product `addMulSub W k l * rel₄ W a b c d`, together with a `@[simp]` lemma unfolding it. That
-abbreviation is **not** ported: it names a product rather than a concept, it exists only to
-shorten these four statements, and a wrapper whose sole purpose is to be unfolded again at
-every use site is a second public spelling of `atom _ _ * atomRel _ _ _ _`. The statements below
-therefore write the product out.
+The source states its expansions against its own `addMulSub` and `rel₄`, which Mathlib now
+supplies as `atom` and `atomRel` with the same definitions, so those statements transfer by
+renaming. Three of its declarations are deliberately **not** ported. Its `rel₆` abbreviation for
+`addMulSub W k l * rel₄ W a b c d`, with the `@[simp]` lemma unfolding it, names a product
+rather than a concept and exists only to shorten four statements, so it would stand a second
+public spelling of `atom _ _ * atomRel _ _ _ _`; the statements below write the product out.
+Its `addMulSub_sq_mul_rel₄_eq₉`, the nine-term expansion, is unused in the source itself — it
+occurs there only at its own declaration — and this descent does not need it. Its four-index
+swap `rel₄_swap₂₃` supports the `Tuple.sort` argument avoided above; with the last index held
+at `0` only the first three are ever permuted, so the two swaps below suffice.
+
+`rel₄_iff_evenRec` is the one source declaration carrying `set_option allowUnsafeReducibility
+true` together with `attribute [local reducible] Nat.rawCast`, which #2860 declined to bring
+into this repository. Stating the base cases with indices in `2 * _` and `2 * _ + 1` form lets
+`atomRel_two_mul` and `atom_odd` apply directly, so neither the option nor the attribute
+appears here.
 -/
 
 public section
@@ -87,20 +125,6 @@ theorem atom_mul_atomRel_eq (c d m n r s : ℤ) :
       + atom W n r * atomRel W m s c d - atom W n s * atomRel W m r c d
         + atom W r s * atomRel W m n c d
       - 2 * (atom W m d * atomRel W n r s c) := by
-  simp_rw [atomRel]; ring
-
-/-- **The squared-atom form, in which every relator on the right carries the whole fixed pair.**
-This is the shape the descent consumes: the first two bracketed groups are the right-hand sides
-of `atom_mul_atomRel_eq_of_last_eq_snd` and `…_fst`, and the third is the last group of
-`atom_mul_atomRel_eq`. Squaring the atom is the price of having no index left outside `c, d`. -/
-theorem atom_sq_mul_atomRel_eq (c d m n r s : ℤ) :
-    atom W c d ^ 2 * atomRel W m n r s =
-      atom W m c * (atom W n d * atomRel W r s c d - atom W r d * atomRel W n s c d
-        + atom W s d * atomRel W n r c d)
-      - atom W m d * (atom W n c * atomRel W r s c d - atom W r c * atomRel W n s c d
-        + atom W s c * atomRel W n r c d)
-      + atom W c d * (atom W n r * atomRel W m s c d - atom W n s * atomRel W m r c d
-        + atom W r s * atomRel W m n c d) := by
   simp_rw [atomRel]; ring
 
 open scoped nonZeroDivisors
@@ -229,18 +253,13 @@ theorem atomRel_swap₁₂ (odd : W.Odd) (a b c d : ℤ) :
     atomRel W b a c d = -atomRel W a b c d := by
   rw [atomRel, atomRel, ← neg_atom odd a b]; ring
 
-/-- **The relator is antisymmetric in its middle two indices.** -/
+/-- **The relator is antisymmetric in its middle two indices.** With `atomRel_swap₁₂` these are
+the two transpositions needed here: the last index is held fixed throughout the descent, so only
+the first three are ever permuted, and these two generate that symmetric group. Mathlib supplies
+the `atomRel_same`, `atomRel_neg` and `atomRel_abs` families but neither of these. -/
 theorem atomRel_swap₂₃ (odd : W.Odd) (a b c d : ℤ) :
     atomRel W a c b d = -atomRel W a b c d := by
   rw [atomRel, atomRel, ← neg_atom odd b c]; ring
-
-/-- **The relator is antisymmetric in its last two indices.** Together with `atomRel_swap₁₂` and
-`atomRel_swap₂₃` these are the adjacent transpositions, so the relator is alternating under the
-whole symmetric group on its four indices. Mathlib supplies the `atomRel_same`, `atomRel_neg`
-and `atomRel_abs` families but not these. -/
-theorem atomRel_swap₃₄ (odd : W.Odd) (a b c d : ℤ) :
-    atomRel W a b d c = -atomRel W a b c d := by
-  rw [atomRel, atomRel, ← neg_atom odd c d]; ring
 
 /-- The even base case, as a relator: all four indices are even, so `atomRel_two_mul` applies. -/
 private theorem atomRel_even_eq_rel (m : ℤ) :

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Transfer
 
 /-!
 # Expanding a product of an elliptic atom with an elliptic relator
@@ -99,5 +101,59 @@ theorem atom_sq_mul_atomRel_eq (c d m n r s : ℤ) :
       + atom W c d * (atom W n r * atomRel W m s c d - atom W n s * atomRel W m r c d
         + atom W r s * atomRel W m n c d) := by
   simp_rw [atomRel]; ring
+
+open scoped nonZeroDivisors
+
+/-- **The relator vanishes at a valid quadruple.** "Valid" is: one parity, nonnegative, strictly
+decreasing. The two hypotheses live inside the predicate rather than outside it because the
+descent applies its induction hypothesis at quadruples whose validity is not known in advance;
+carrying them here means the recursive call is a `Prop` about indices alone. -/
+def AtomRelVanishes (a b c d : ℤ) : Prop :=
+  (d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) → NonnegStrictAnti₄ a b c d →
+    atomRel W a b c d = 0
+
+variable {W}
+
+/-- The three relators common to both expansions used by `atomRelVanishes_of_forall_le`. Each
+carries the fixed pair `c₀, d₀` in its last two places and a first index at most `a`, so each is
+in range of the descent hypothesis; the chain `d₀ < c₀ < c < b < a` is what makes all three
+valid quadruples. -/
+private theorem atomRel_triple_eq_zero {a b c c₀ d₀ : ℤ}
+    (rel : ∀ {a' b' : ℤ}, a' ≤ a → AtomRelVanishes W a' b' c₀ d₀)
+    (par : c₀ % 2 = d₀ % 2) (same : d₀ % 2 = a % 2 ∧ d₀ % 2 = b % 2 ∧ d₀ % 2 = c % 2)
+    (le : 0 ≤ d₀) (lt : d₀ < c₀) (hc : c₀ < c) (hcb : c < b) (hba : b < a) :
+    atomRel W b c c₀ d₀ = 0 ∧ atomRel W a c c₀ d₀ = 0 ∧ atomRel W a b c₀ d₀ = 0 := by
+  obtain ⟨ha, hb, hcc⟩ := same
+  refine ⟨rel hba.le ⟨by omega, by omega, by omega⟩ ?_,
+    rel le_rfl ⟨by omega, by omega, by omega⟩ ?_,
+    rel le_rfl ⟨by omega, by omega, by omega⟩ ?_⟩ <;>
+    rw [nonnegStrictAnti₄_iff] <;> omega
+
+/-- **Lowering the last index onto a fixed pair.** Given vanishing at every quadruple
+`(a', b, c₀, d₀)` with `a' ≤ a`, the relator vanishes at `(a, b, c, c₀)` outright, and at
+`(a, b, c, d₀)` once `c₀ < c`. Both follow from a three-term expansion trading the relator's
+last index for the pair `c₀, d₀`, after which every summand carries a factor already known to
+vanish. -/
+theorem atomRelVanishes_of_forall_le {a c₀ d₀ : ℤ} (par : c₀ % 2 = d₀ % 2) (le : 0 ≤ d₀)
+    (lt : d₀ < c₀) (rel : ∀ {a' b : ℤ}, a' ≤ a → AtomRelVanishes W a' b c₀ d₀)
+    (mem : atom W c₀ d₀ ∈ R⁰) (b c : ℤ) :
+    AtomRelVanishes W a b c c₀ ∧ (c₀ < c → AtomRelVanishes W a b c d₀) := by
+  constructor
+  · intro same anti
+    rw [nonnegStrictAnti₄_iff] at anti
+    obtain ⟨-, hc, hcb, hba⟩ := anti
+    obtain ⟨h₁, h₂, h₃⟩ := atomRel_triple_eq_zero rel par
+      ⟨by omega, by omega, by omega⟩ le lt hc hcb hba
+    refine mem.2 _ ?_
+    rw [mul_comm, atom_mul_atomRel_eq_of_last_eq_fst, h₁, h₂, h₃]
+    ring
+  · intro hc same anti
+    rw [nonnegStrictAnti₄_iff] at anti
+    obtain ⟨-, hdc, hcb, hba⟩ := anti
+    obtain ⟨h₁, h₂, h₃⟩ := atomRel_triple_eq_zero rel par
+      ⟨by omega, by omega, by omega⟩ le lt hc hcb hba
+    refine mem.2 _ ?_
+    rw [mul_comm, atom_mul_atomRel_eq_of_last_eq_snd, h₁, h₂, h₃]
+    ring
 
 end IsEllipticNet

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -298,4 +298,88 @@ theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
           show b' = 2 * (k - 1) + 1 by omega, atomRel_odd_eq_rel]
         exact evenRec k (by omega)
 
+/-- Three distinct positive even indices, in any order, against a last index of `0`. The six
+orderings are reached from the decreasing one by the adjacent transpositions; the last index is
+already minimal, so only the first three need sorting and the general `Tuple.sort` argument the
+source uses is not required. -/
+private theorem atomRel_eq_zero_of_ne (odd : W.Odd)
+    (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d) {x y z : ℤ}
+    (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) (px : x % 2 = 0) (py : y % 2 = 0) (pz : z % 2 = 0)
+    (hxy : x ≠ y) (hyz : y ≠ z) (hxz : x ≠ z) :
+    atomRel W x y z 0 = 0 := by
+  have sorted : ∀ {u v w : ℤ}, u % 2 = 0 → v % 2 = 0 → w % 2 = 0 → 0 < w → w < v → v < u →
+      atomRel W u v w 0 = 0 := by
+    intro u v w pu pv pw hw hwv hvu
+    exact descent u v w 0 ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
+  rcases lt_trichotomy x y with h₁ | h₁ | h₁
+  · rcases lt_trichotomy y z with h₂ | h₂ | h₂
+    · have h := sorted pz py px hx h₁ h₂
+      rw [atomRel_swap₁₂ odd y z x 0, atomRel_swap₂₃ odd y x z 0,
+        atomRel_swap₁₂ odd x y z 0] at h
+      simpa using h
+    · exact absurd h₂ hyz
+    · rcases lt_trichotomy x z with h₃ | h₃ | h₃
+      · have h := sorted py pz px hx h₃ h₂
+        rw [atomRel_swap₂₃ odd y x z 0, atomRel_swap₁₂ odd x y z 0] at h
+        simpa using h
+      · exact absurd h₃ hxz
+      · have h := sorted py px pz hz h₃ h₁
+        rw [atomRel_swap₁₂ odd x y z 0] at h
+        simpa using h
+  · exact absurd h₁ hxy
+  · rcases lt_trichotomy x z with h₂ | h₂ | h₂
+    · have h := sorted pz px py hy h₁ h₂
+      rw [atomRel_swap₁₂ odd x z y 0, atomRel_swap₂₃ odd x y z 0] at h
+      simpa using h
+    · exact absurd h₂ hxz
+    · rcases lt_trichotomy y z with h₃ | h₃ | h₃
+      · have h := sorted px pz py hy h₃ h₂
+        rw [atomRel_swap₂₃ odd x y z 0] at h
+        simpa using h
+      · exact absurd h₃ hyz
+      · exact sorted px py pz hz h₃ h₁
+
+/-- Three nonnegative even indices against `0`, with no distinctness assumed: every coincidence
+puts two indices of the relator equal, and each such case is one of Mathlib's `atomRel_same`
+lemmas, whose value carries a factor `W 0`. -/
+private theorem atomRel_eq_zero_of_nonneg (odd : W.Odd) (zero : W 0 = 0)
+    (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d) {x y z : ℤ}
+    (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) (px : x % 2 = 0) (py : y % 2 = 0) (pz : z % 2 = 0) :
+    atomRel W x y z 0 = 0 := by
+  rcases eq_or_lt_of_le hx with rfl | hx'
+  · rw [atomRel_same₁₄ odd]; simp [zero]
+  rcases eq_or_lt_of_le hy with rfl | hy'
+  · rw [atomRel_same₂₄ odd]; simp [zero]
+  rcases eq_or_lt_of_le hz with rfl | hz'
+  · rw [atomRel_same₃₄]; simp [zero]
+  rcases eq_or_ne x y with rfl | hxy
+  · rw [atomRel_same₁₂]; simp [zero]
+  rcases eq_or_ne y z with rfl | hyz
+  · rw [atomRel_same₂₃]; simp [zero]
+  rcases eq_or_ne x z with rfl | hxz
+  · rw [atomRel_same₁₃ odd]; simp [zero]
+  exact atomRel_eq_zero_of_ne odd descent hx' hy' hz' px py pz hxy hyz hxz
+
+/-- `omega` cannot parse `|·|`, so the sign split has to happen before it is called. -/
+private theorem abs_two_mul_emod_two (p : ℤ) : |2 * p| % 2 = 0 := by
+  rcases abs_cases (2 * p) with ⟨h, _⟩ | ⟨h, _⟩ <;> rw [h] <;> omega
+
+/-- **An elliptic sequence from its two doubling recurrences.** A sequence that is odd, vanishes
+at `0`, has `W 1` and `W 2` nonzerodivisors, and satisfies the odd recurrence from `m = 2` and
+the even one from `m = 3`, satisfies the full elliptic-net relation at every triple.
+
+This is the converse direction to `IsEllipticSequence.rel_odd` and `rel_even`: those read the two
+recurrences off the relation, this rebuilds the relation from them. -/
+theorem isEllipticSequence_of_rel (odd : W.Odd) (zero : W 0 = 0) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
+    (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
+    (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) :
+    IsEllipticSequence W := by
+  intro p q r
+  have bridge := atomRel_two_mul W p q r 0
+  norm_num at bridge
+  rw [← bridge, ← atomRel_abs₁ odd, ← atomRel_abs₂ odd, ← atomRel_abs₃ odd]
+  exact atomRel_eq_zero_of_nonneg odd zero
+    (atomRelVanishes_of_rel one two oddRec evenRec) (abs_nonneg _) (abs_nonneg _) (abs_nonneg _)
+    (abs_two_mul_emod_two p) (abs_two_mul_emod_two q) (abs_two_mul_emod_two r)
+
 end IsEllipticNet

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -156,4 +156,38 @@ theorem atomRelVanishes_of_forall_le {a c₀ d₀ : ℤ} (par : c₀ % 2 = d₀ 
     rw [mul_comm, atom_mul_atomRel_eq_of_last_eq_snd, h₁, h₂, h₃]
     ring
 
+/-- **Lowering an unconstrained last index.** With the previous lemma available at every `b, c`,
+the ten-term expansion reaches a quadruple whose last index `d` is merely above `c₀`: each of
+the ten summands carries a relator that either already ends at the fixed pair or is reachable
+from it, and so vanishes. -/
+theorem atomRelVanishes_of_lt {a c₀ d₀ : ℤ} (par : c₀ % 2 = d₀ % 2) (le : 0 ≤ d₀) (lt : d₀ < c₀)
+    (rel : ∀ {a' b : ℤ}, a' ≤ a → AtomRelVanishes W a' b c₀ d₀) (mem : atom W c₀ d₀ ∈ R⁰)
+    (b c d : ℤ) (hc : c₀ < d) (par' : d % 2 = d₀ % 2) :
+    AtomRelVanishes W a b c d := by
+  intro same anti
+  rw [nonnegStrictAnti₄_iff] at anti
+  obtain ⟨hd, hdc, hcb, hba⟩ := anti
+  obtain ⟨hda, hdb, hdc'⟩ := same
+  have fix₁ (b' c' : ℤ) := (atomRelVanishes_of_forall_le par le lt rel mem b' c').1
+  have fix₂ (b' c' : ℤ) := (atomRelVanishes_of_forall_le par le lt rel mem b' c').2
+  have fixb (b' c' : ℤ) :=
+    (atomRelVanishes_of_forall_le par le lt (fun h ↦ rel (h.trans hba.le)) mem b' c').1
+  have e₁ := fix₁ c d ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
+  have e₂ := fix₁ b d ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
+  have e₃ := fix₁ b c ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
+  have e₄ := fix₂ c d hc ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
+  have e₅ := fix₂ b d hc ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
+  have e₆ := fix₂ b c (by omega) ⟨by omega, by omega, by omega⟩
+    (by rw [nonnegStrictAnti₄_iff]; omega)
+  have e₇ := rel (b := d) le_rfl ⟨by omega, by omega, by omega⟩
+    (by rw [nonnegStrictAnti₄_iff]; omega)
+  have e₈ := rel (b := c) le_rfl ⟨by omega, by omega, by omega⟩
+    (by rw [nonnegStrictAnti₄_iff]; omega)
+  have e₉ := rel (b := b) le_rfl ⟨by omega, by omega, by omega⟩
+    (by rw [nonnegStrictAnti₄_iff]; omega)
+  have e₁₀ := fixb c d ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
+  refine mem.2 _ ?_
+  rw [mul_comm, atom_mul_atomRel_eq, e₁, e₂, e₃, e₄, e₅, e₆, e₇, e₈, e₉, e₁₀]
+  ring
+
 end IsEllipticNet

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -223,4 +223,61 @@ theorem atomRelVanishes_of_min {a : ℤ} (one : W 1 ∈ R⁰) (two : W 2 ∈ R�
     · subst heq₂; exact rel le_rfl same anti
     · exact fix.2 hlt₃ same anti
 
+/-- The even base case, as a relator: all four indices are even, so `atomRel_two_mul` applies. -/
+private theorem atomRel_even_eq_rel (m : ℤ) :
+    atomRel W (2 * m) (2 * (m - 1)) (2 * 1) (2 * 0) = rel W m (m - 1) 1 0 := by
+  rw [atomRel_two_mul]
+  norm_num
+
+/-- The odd base case, as a relator. All four indices are odd, so `atom_odd` reduces every atom
+and no reasoning about truncated division survives. The source proves the corresponding
+equivalence under `set_option allowUnsafeReducibility true` together with
+`attribute [local reducible] Nat.rawCast`; putting the indices in `2 * _ + 1` form removes the
+need for either. -/
+private theorem atomRel_odd_eq_rel (m : ℤ) :
+    atomRel W (2 * m + 1) (2 * (m - 1) + 1) (2 * 1 + 1) (2 * 0 + 1)
+      = rel W (m + 1) (m - 1) 1 0 := by
+  simp_rw [atomRel, atom_odd, rel]
+  ring_nf
+
+/-- **The descent.** The two doubling recurrences, holding from `m = 2` and `m = 3` on, force the
+full four-index relation at every valid quadruple. The induction is on the largest index: below
+`6` no valid quadruple exists, and above it `atomRelVanishes_of_min` reduces to the minimal
+pair, where either the gap `b + 2 < a` admits the transfer down to a smaller first index, or
+`b + 2 = a` lands on one of the two recurrences according to parity. -/
+theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
+    (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
+    (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) :
+    ∀ a b c d : ℤ, AtomRelVanishes W a b c d := by
+  intro a
+  induction a using Int.strongRec (m := 6)
+  next a ha =>
+    intro b c d same anti
+    exact absurd ha (not_lt.mpr (six_le_of_parity_of_nonnegStrictAnti₄ same anti))
+  next a h6 ih =>
+    intro b c d
+    refine atomRelVanishes_of_min one two ?_ b c d
+    intro a' b' haa
+    rcases haa.lt_or_eq with hlt | rfl
+    · exact ih a' hlt b' _ _
+    intro same anti
+    obtain ⟨h0, h1, h2, h3⟩ := (nonnegStrictAnti₄_iff _ _ _ _).mp anti
+    have hpb := same.2.1
+    rcases (show b' + 2 < a' ∨ b' + 2 = a' by omega) with hb | hb
+    · rw [← atomRel_avg_sub W same, ← atomRel_abs₄]
+      exact ih _ (by omega) _ _ _ (parity_abs_avg_sub same)
+        (nonnegStrictAnti₄_abs_avg_sub h1 (by omega) h2 h3)
+    · rcases Int.emod_two_eq_zero_or_one a' with hp | hp
+      · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k := ⟨a' / 2, by omega⟩
+        have hodd := oddRec (k - 1) (by omega)
+        rw [sub_add_cancel] at hodd
+        rw [show (2 * k % 2 : ℤ) = 2 * 0 by omega, show (2 : ℤ) * 0 + 2 = 2 * 1 by norm_num,
+          show b' = 2 * (k - 1) by omega, atomRel_even_eq_rel]
+        exact hodd
+      · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k + 1 := ⟨a' / 2, by omega⟩
+        rw [show ((2 * k + 1) % 2 : ℤ) = 2 * 0 + 1 by omega,
+          show (2 : ℤ) * 0 + 1 + 2 = 2 * 1 + 1 by norm_num,
+          show b' = 2 * (k - 1) + 1 by omega, atomRel_odd_eq_rel]
+        exact evenRec k (by omega)
+
 end IsEllipticNet

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -114,6 +114,13 @@ def AtomRelVanishes (a b c d : ℤ) : Prop :=
 
 variable {W}
 
+/-- The minimal same-parity pair above zero, `(a % 2 + 2, a % 2)`, has its atom a nonzerodivisor
+as soon as `W 1` and `W 2` are: the two parities give `W 1 * W 1` and `W 2 * W 1`. -/
+private theorem atom_emod_mem_nonZeroDivisors (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰) (a : ℤ) :
+    atom W (a % 2 + 2) (a % 2) ∈ R⁰ := by
+  rcases Int.emod_two_eq_zero_or_one a with h | h <;> rw [h] <;> norm_num [atom] <;>
+    exact mul_mem ‹_› ‹_›
+
 /-- The three relators common to both expansions used by `atomRelVanishes_of_forall_le`. Each
 carries the fixed pair `c₀, d₀` in its last two places and a first index at most `a`, so each is
 in range of the descent hypothesis; the chain `d₀ < c₀ < c < b < a` is what makes all three
@@ -189,5 +196,31 @@ theorem atomRelVanishes_of_lt {a c₀ d₀ : ℤ} (par : c₀ % 2 = d₀ % 2) (l
   refine mem.2 _ ?_
   rw [mul_comm, atom_mul_atomRel_eq, e₁, e₂, e₃, e₄, e₅, e₆, e₇, e₈, e₉, e₁₀]
   ring
+
+/-- **Only the minimal pair needs checking.** If the relator vanishes at every quadruple whose
+last two indices are the minimal same-parity pair `(a % 2 + 2, a % 2)`, it vanishes at every
+valid quadruple with first index `a`. The three remaining cases are `d` above the pair, `d` at
+its top, and `d` at its bottom; in the `%2` spelling each is closed by `omega`, where the source
+needed a chain of `Int.negOnePow` lemmas. -/
+theorem atomRelVanishes_of_min {a : ℤ} (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
+    (rel : ∀ {a' b : ℤ}, a' ≤ a → AtomRelVanishes W a' b (a % 2 + 2) (a % 2)) (b c d : ℤ) :
+    AtomRelVanishes W a b c d := by
+  intro same anti
+  have par : (a % 2 + 2) % 2 = a % 2 % 2 := by omega
+  have le : (0 : ℤ) ≤ a % 2 := by omega
+  have lt : a % 2 < a % 2 + 2 := by omega
+  have mem := atom_emod_mem_nonZeroDivisors one two (W := W) a
+  have hda := same.1
+  obtain ⟨hd, hdc, hcb, hba⟩ := (nonnegStrictAnti₄_iff a b c d).mp anti
+  rcases lt_or_ge (a % 2 + 2) d with hlt | hge
+  · exact atomRelVanishes_of_lt par le lt rel mem b c d hlt (by omega) same anti
+  have fix := atomRelVanishes_of_forall_le par le lt rel mem b c
+  rcases hge.eq_or_lt with heq | hlt₂
+  · subst heq; exact fix.1 same anti
+  · have hdm : d = a % 2 := by omega
+    subst hdm
+    rcases (show a % 2 + 2 = c ∨ a % 2 + 2 < c by omega) with heq₂ | hlt₃
+    · subst heq₂; exact rel le_rfl same anti
+    · exact fix.2 hlt₃ same anti
 
 end IsEllipticNet

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+
+/-!
+# Expanding a product of an elliptic atom with an elliptic relator
+
+The descent that recovers the full four-index elliptic relation from the two doubling
+recurrences works by rewriting a relator on four unconstrained indices into relators that all
+carry a fixed pair `c, d` of small indices. This file supplies the algebraic identities that
+perform that rewriting; the ordering and parity bookkeeping that makes the resulting induction
+terminate is in `Transfer.lean`.
+
+All four are polynomial identities in the atoms: `atomRel` is a fixed quadratic expression in
+`atom`, so each statement expands on both sides to a combination of products of two atoms, and
+`ring` closes it. No index arithmetic is involved — the atoms' arguments are carried along
+unchanged — which is why nothing here needs the parity hypotheses that `atom_even`, `atom_odd`
+and `atomRel_eq` require.
+
+## Main results
+
+* `atom_mul_atomRel_eq_of_last_eq_fst`, `atom_mul_atomRel_eq_of_last_eq_snd`: when the relator's
+  last index is already one of the atom's two indices, the product is a three-term combination.
+* `atom_mul_atomRel_eq`: for four unconstrained relator indices, a ten-term combination.
+* `atom_sq_mul_atomRel_eq`: the nine-term combination obtained from the previous two, which is
+  the form the descent actually consumes.
+
+## Provenance
+
+Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`
+and `addMulSub_sq_mul_rel₄_eq₉`. That file's header reads `Authors: Junyan Xu`; following this
+repository's convention for adapted material the upstream authorship is credited here rather
+than in the copyright header.
+
+The source states these against its own `addMulSub` and `rel₄`, which Mathlib now supplies as
+`IsEllipticNet.atom` and `IsEllipticNet.atomRel` with the same definitions, so the statements
+transfer by renaming. The source also carries an abbreviation `rel₆ W k l a b c d` for the
+product `addMulSub W k l * rel₄ W a b c d`, together with a `@[simp]` lemma unfolding it. That
+abbreviation is **not** ported: it names a product rather than a concept, it exists only to
+shorten these four statements, and a wrapper whose sole purpose is to be unfolded again at
+every use site is a second public spelling of `atom _ _ * atomRel _ _ _ _`. The statements below
+therefore write the product out.
+-/
+
+public section
+
+namespace IsEllipticNet
+
+variable {R : Type*} [CommRing R] (W : ℤ → R)
+
+/-- **Expanding over a fixed pair, when the relator already ends at the atom's first index.**
+Each relator on the right carries both `c` and `d`, so this trades one occurrence of `c` for
+the pair `c, d`. -/
+theorem atom_mul_atomRel_eq_of_last_eq_fst (c d m n r : ℤ) :
+    atom W c d * atomRel W m n r c =
+      atom W m c * atomRel W n r c d - atom W n c * atomRel W m r c d
+        + atom W r c * atomRel W m n c d := by
+  simp_rw [atomRel]; ring
+
+/-- **Expanding over a fixed pair, when the relator already ends at the atom's second index.**
+The companion of `atom_mul_atomRel_eq_of_last_eq_fst` with the roles of `c` and `d` exchanged
+in the atoms, the relators on the right being the same three. -/
+theorem atom_mul_atomRel_eq_of_last_eq_snd (c d m n r : ℤ) :
+    atom W c d * atomRel W m n r d =
+      atom W m d * atomRel W n r c d - atom W n d * atomRel W m r c d
+        + atom W r d * atomRel W m n c d := by
+  simp_rw [atomRel]; ring
+
+/-- **Expanding over a fixed pair, for four unconstrained relator indices.** Every relator on
+the right has at least one index drawn from the fixed pair `c, d`, which is what lets the
+descent lower the indices it is working on. -/
+theorem atom_mul_atomRel_eq (c d m n r s : ℤ) :
+    atom W c d * atomRel W m n r s =
+      atom W n d * atomRel W m r s c - atom W r d * atomRel W m n s c
+        + atom W s d * atomRel W m n r c
+      + atom W n c * atomRel W m r s d - atom W r c * atomRel W m n s d
+        + atom W s c * atomRel W m n r d
+      + atom W n r * atomRel W m s c d - atom W n s * atomRel W m r c d
+        + atom W r s * atomRel W m n c d
+      - 2 * (atom W m d * atomRel W n r s c) := by
+  simp_rw [atomRel]; ring
+
+/-- **The squared-atom form, in which every relator on the right carries the whole fixed pair.**
+This is the shape the descent consumes: the first two bracketed groups are the right-hand sides
+of `atom_mul_atomRel_eq_of_last_eq_snd` and `…_fst`, and the third is the last group of
+`atom_mul_atomRel_eq`. Squaring the atom is the price of having no index left outside `c, d`. -/
+theorem atom_sq_mul_atomRel_eq (c d m n r s : ℤ) :
+    atom W c d ^ 2 * atomRel W m n r s =
+      atom W m c * (atom W n d * atomRel W r s c d - atom W r d * atomRel W n s c d
+        + atom W s d * atomRel W n r c d)
+      - atom W m d * (atom W n c * atomRel W r s c d - atom W r c * atomRel W n s c d
+        + atom W s c * atomRel W n r c d)
+      + atom W c d * (atom W n r * atomRel W m s c d - atom W n s * atomRel W m r c d
+        + atom W r s * atomRel W m n c d) := by
+  simp_rw [atomRel]; ring
+
+end IsEllipticNet

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -223,6 +223,24 @@ theorem atomRelVanishes_of_min {a : ℤ} (one : W 1 ∈ R⁰) (two : W 2 ∈ R�
     · subst heq₂; exact rel le_rfl same anti
     · exact fix.2 hlt₃ same anti
 
+/-- **The relator is antisymmetric in its first two indices.** -/
+theorem atomRel_swap₁₂ (odd : W.Odd) (a b c d : ℤ) :
+    atomRel W b a c d = -atomRel W a b c d := by
+  rw [atomRel, atomRel, ← neg_atom odd a b]; ring
+
+/-- **The relator is antisymmetric in its middle two indices.** -/
+theorem atomRel_swap₂₃ (odd : W.Odd) (a b c d : ℤ) :
+    atomRel W a c b d = -atomRel W a b c d := by
+  rw [atomRel, atomRel, ← neg_atom odd b c]; ring
+
+/-- **The relator is antisymmetric in its last two indices.** Together with `atomRel_swap₁₂` and
+`atomRel_swap₂₃` these are the adjacent transpositions, so the relator is alternating under the
+whole symmetric group on its four indices. Mathlib supplies the `atomRel_same`, `atomRel_neg`
+and `atomRel_abs` families but not these. -/
+theorem atomRel_swap₃₄ (odd : W.Odd) (a b c d : ℤ) :
+    atomRel W a b d c = -atomRel W a b c d := by
+  rw [atomRel, atomRel, ← neg_atom odd c d]; ring
+
 /-- The even base case, as a relator: all four indices are even, so `atomRel_two_mul` applies. -/
 private theorem atomRel_even_eq_rel (m : ℤ) :
     atomRel W (2 * m) (2 * (m - 1)) (2 * 1) (2 * 0) = rel W m (m - 1) 1 0 := by

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
@@ -67,7 +67,6 @@ namespace IsEllipticSequence
 variable {R : Type*} [CommRing R] {W : ℤ → R}
 
 /-- **The odd doubling relation of an elliptic sequence.** -/
-@[grind]
 theorem rel_odd (h : IsEllipticSequence W) (m : ℤ) :
     W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3 := by
   have hm := h (m + 1) m 1
@@ -75,7 +74,6 @@ theorem rel_odd (h : IsEllipticSequence W) (m : ℤ) :
   linear_combination hm
 
 /-- **The even doubling relation of an elliptic sequence.** -/
-@[grind]
 theorem rel_even (h : IsEllipticSequence W) (m : ℤ) :
     W (2 * m) * W 2 * W 1 ^ 2 =
       W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) := by

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
@@ -7,57 +7,59 @@ module
 public import Mathlib.NumberTheory.EllipticDivisibilitySequence
 
 /-!
-# The odd and even recurrences of an elliptic sequence
+# The doubling relations of an elliptic sequence, solved for the doubled term
 
-An elliptic sequence satisfies `IsEllipticNet.rel W p q r 0 = 0` for all `p, q, r` — that is
-Mathlib's `IsEllipticSequence`. Two particular cases of that relation are the recurrences that
-compute the sequence term by term, doubling the index:
+`IsEllipticSequence W` says that `IsEllipticNet.rel W p q r 0` vanishes for all `p, q, r`.
+Mathlib's `IsEllipticNet.rel_odd` and `rel_even` evaluate that relator at the two instances
+relating a doubled index to its neighbours, but they give the relator's *value* rather than what
+its vanishing says.
 
-* at `(m + 1, m, 1)` the relation says how `W (2 * m + 1)` is determined by lower terms;
-* at `(m + 1, m - 1, 1)` it says the same for `W (2 * m)`.
-
-This file names those two right-hand sides, `OddRec` and `EvenRec`, and proves that each is
-equivalent to the corresponding instance of Mathlib's relator. Naming them is what lets the
-division-polynomial development state the doubling step without carrying the four-index relator
-through every use site.
-
-## Main definitions
-
-* `IsEllipticNet.OddRec`: the recurrence for `W (2 * m + 1)`.
-* `IsEllipticNet.EvenRec`: the recurrence for `W (2 * m)`.
+This file supplies that second step: at each of those instances, the relator vanishes exactly when
+the doubled-index term stands in a named relation to the neighbouring terms. That is the form the
+division-polynomial development consumes, since the hypothesis in hand there is
+`IsEllipticSequence`, which supplies vanishing rather than a value.
 
 ## Main results
 
-* `IsEllipticNet.rel_iff_oddRec`: the relator at `(m + 1, m, 1, 0)` vanishes iff `OddRec` holds.
-* `IsEllipticNet.rel_iff_evenRec`: the relator at `(m + 1, m - 1, 1, 0)` vanishes iff `EvenRec`
-  holds.
+* `IsEllipticNet.rel_odd_eq_zero_iff`: `rel W (m + 1) m 1 0 = 0` iff
+  `W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3`.
+* `IsEllipticNet.rel_even_eq_zero_iff`: `rel W (m + 1) (m - 1) 1 0 = 0` iff
+  `W (2 * m) * W 2 * W 1 ^ 2 = W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2)`.
 
 ## Implementation notes
 
-The recurrences are stated over Mathlib's `IsEllipticNet.rel` at `s = 0`, which is exactly the
-shape `IsEllipticSequence` quantifies over — `IsEllipticSequence W ↔ ∀ p q r, rel W p q r 0 = 0`
-holds by definition. The source states them over a three-index predicate of its own; taking
-Mathlib's four-index relator with `s = 0` instead means a consumer that has `IsEllipticSequence`
-can apply these directly, and no second relation stands beside Mathlib's.
+These are equations about the doubled-index term, not new predicates. An earlier draft followed
+the source in introducing `OddRec` and `EvenRec` as `Prop` definitions; that stood a second
+recurrence interface beside Mathlib's `rel_odd` / `rel_even`, which already name these two
+instances. Deriving the vanishing form from those lemmas leaves one API rather than two, and makes
+each proof a rewrite followed by a rearrangement.
+
+The equations **relate** the doubled-index term to its neighbours; they do not on their own
+determine it. Nothing here inverts `W 1` or `W 2 * W 1 ^ 2`, and over an arbitrary `CommRing`
+neither need be a unit, so solving for `W (2 * m + 1)` or `W (2 * m)` requires a hypothesis this
+file does not carry.
 
 ## Provenance
 
-Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `OddRec`, `EvenRec`,
-`rel₃_iff_oddRec` and `rel₃_iff_evenRec`. That file's header reads `Authors: Junyan Xu`; following
-this repository's convention for adapted material the upstream authorship is credited here rather
-than in the copyright header.
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `OddRec`, `EvenRec`, `rel₃_iff_oddRec`
+and `rel₃_iff_evenRec`. That file's header reads `Authors: Junyan Xu`; following this repository's
+convention for adapted material the upstream authorship is credited here rather than in the
+copyright header.
 
-The source states both equivalences against its own `Rel₃`, a three-index predicate defined as the
-`d = 0` case of its four-index relation. Mathlib supplies that case as `rel W p q r 0`, so `Rel₃`
-is not ported: the equivalences are stated against Mathlib's relator directly.
+The adaptation is substantial, because Mathlib has since absorbed most of what the source had to
+build for itself. The source states its equivalences against `Rel₃`, a three-index relation of its
+own, and carries `OddRec` / `EvenRec` as `Prop` definitions naming the right-hand sides. Mathlib
+supplies `Rel₃` as `rel W p q r 0` — the shape `IsEllipticSequence` quantifies over — and supplies
+`rel_odd` / `rel_even` as the evaluations at these two instances. What remains to port is the
+passage from value to vanishing, which is what the two lemmas here do.
 
 The source's `rel₄_iff_evenRec`, a third equivalence against the four-index relator at
-`(2 * m + 1, 2 * m - 1, 3, 1)`, is **not** ported here. It is the one declaration in this group
-carrying `set_option allowUnsafeReducibility true` together with a `Nat.rawCast` reducibility
-attribute, which this repository does not take on unexamined; it belongs with the descent layer
-that consumes it rather than with the definitions.
+`(2 * m + 1, 2 * m - 1, 3, 1)`, is not ported. It is the one declaration in this group carrying
+`set_option allowUnsafeReducibility true` together with an `attribute [local reducible]
+Nat.rawCast`, which this repository has previously declined to take on, and it belongs with the
+descent layer that consumes it.
 -/
 
 public section
@@ -66,24 +68,19 @@ namespace IsEllipticNet
 
 variable {R : Type*} [CommRing R] (W : ℤ → R) (m : ℤ)
 
-/-- The recurrence determining the odd-index term `W (2 * m + 1)` of an elliptic sequence. -/
-def OddRec : Prop :=
-  W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3
-
-/-- The recurrence determining the even-index term `W (2 * m)` of an elliptic sequence. -/
-def EvenRec : Prop :=
-  W (2 * m) * W 2 * W 1 ^ 2 = W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2)
-
-/-- **The odd recurrence is the relator at `(m + 1, m, 1, 0)`.** -/
-theorem rel_iff_oddRec : rel W (m + 1) m 1 0 = 0 ↔ OddRec W m := by
-  rw [rel, OddRec]
-  ring_nf
+/-- **The odd doubling relation, in vanishing form.** The relator at `(m + 1, m, 1, 0)` vanishes
+exactly when `W (2 * m + 1)` stands in this relation to its neighbours. -/
+theorem rel_odd_eq_zero_iff : rel W (m + 1) m 1 0 = 0 ↔
+    W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3 := by
+  rw [rel_odd]
   constructor <;> intro h <;> linear_combination h
 
-/-- **The even recurrence is the relator at `(m + 1, m - 1, 1, 0)`.** -/
-theorem rel_iff_evenRec : rel W (m + 1) (m - 1) 1 0 = 0 ↔ EvenRec W m := by
-  rw [rel, EvenRec]
-  ring_nf
+/-- **The even doubling relation, in vanishing form.** The relator at `(m + 1, m - 1, 1, 0)`
+vanishes exactly when `W (2 * m)` stands in this relation to its neighbours. -/
+theorem rel_even_eq_zero_iff : rel W (m + 1) (m - 1) 1 0 = 0 ↔
+    W (2 * m) * W 2 * W 1 ^ 2 =
+      W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) := by
+  rw [rel_even]
   constructor <;> intro h <;> linear_combination h
 
 end IsEllipticNet

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
@@ -7,24 +7,26 @@ module
 public import Mathlib.NumberTheory.EllipticDivisibilitySequence
 
 /-!
-# The doubling relations of an elliptic sequence, solved for the doubled term
+# The doubling relations of an elliptic sequence
 
 `IsEllipticSequence W` says that `IsEllipticNet.rel W p q r 0` vanishes for all `p, q, r`.
 Mathlib's `IsEllipticNet.rel_odd` and `rel_even` evaluate that relator at the two instances
 relating a doubled index to its neighbours, but they give the relator's *value* rather than what
 its vanishing says.
 
-This file supplies that second step: at each of those instances, the relator vanishes exactly when
-the doubled-index term stands in a named relation to the neighbouring terms. That is the form the
-division-polynomial development consumes, since the hypothesis in hand there is
-`IsEllipticSequence`, which supplies vanishing rather than a value.
+This file carries that through to the consumer. The two `_eq_zero_iff` lemmas say what vanishing
+means at those instances, and the two `IsEllipticSequence` lemmas hand the resulting relation
+straight to someone holding that hypothesis — which is how the division-polynomial development
+meets these, with `IsEllipticSequence` in hand rather than a relator value.
 
 ## Main results
 
-* `IsEllipticNet.rel_odd_eq_zero_iff`: `rel W (m + 1) m 1 0 = 0` iff
+* `IsEllipticSequence.rel_odd`: from `IsEllipticSequence W`, the relation
   `W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3`.
-* `IsEllipticNet.rel_even_eq_zero_iff`: `rel W (m + 1) (m - 1) 1 0 = 0` iff
+* `IsEllipticSequence.rel_even`: from `IsEllipticSequence W`, the relation
   `W (2 * m) * W 2 * W 1 ^ 2 = W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2)`.
+* `IsEllipticNet.rel_odd_eq_zero_iff` / `rel_even_eq_zero_iff`: the vanishing form at each
+  instance, which is what the two lemmas above are read off.
 
 ## Implementation notes
 
@@ -84,3 +86,20 @@ theorem rel_even_eq_zero_iff : rel W (m + 1) (m - 1) 1 0 = 0 ↔
   constructor <;> intro h <;> linear_combination h
 
 end IsEllipticNet
+
+namespace IsEllipticSequence
+
+variable {R : Type*} [CommRing R] {W : ℤ → R}
+
+/-- **The odd doubling relation of an elliptic sequence.** -/
+theorem rel_odd (h : IsEllipticSequence W) (m : ℤ) :
+    W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3 :=
+  (IsEllipticNet.rel_odd_eq_zero_iff W m).1 (h (m + 1) m 1)
+
+/-- **The even doubling relation of an elliptic sequence.** -/
+theorem rel_even (h : IsEllipticSequence W) (m : ℤ) :
+    W (2 * m) * W 2 * W 1 ^ 2 =
+      W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) :=
+  (IsEllipticNet.rel_even_eq_zero_iff W m).1 (h (m + 1) (m - 1) 1)
+
+end IsEllipticSequence

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
@@ -11,35 +11,31 @@ public import Mathlib.NumberTheory.EllipticDivisibilitySequence
 
 `IsEllipticSequence W` says that `IsEllipticNet.rel W p q r 0` vanishes for all `p, q, r`.
 Mathlib's `IsEllipticNet.rel_odd` and `rel_even` evaluate that relator at the two instances
-relating a doubled index to its neighbours, but they give the relator's *value* rather than what
-its vanishing says.
+relating a doubled index to its neighbours, but they give the relator's *value* rather than the
+relation that follows from its vanishing.
 
-This file carries that through to the consumer. The two `_eq_zero_iff` lemmas say what vanishing
-means at those instances, and the two `IsEllipticSequence` lemmas hand the resulting relation
-straight to someone holding that hypothesis — which is how the division-polynomial development
-meets these, with `IsEllipticSequence` in hand rather than a relator value.
+This file draws that consequence: from `IsEllipticSequence W`, the doubled-index term stands in a
+fixed relation to its neighbours, at both parities. This is the intended interface for the
+division-polynomial development, which will meet the doubling step holding `IsEllipticSequence`
+rather than a relator value; no file consumes it yet.
 
 ## Main results
 
-* `IsEllipticSequence.rel_odd`: from `IsEllipticSequence W`, the relation
+* `IsEllipticSequence.rel_odd`: from `IsEllipticSequence W`,
   `W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3`.
-* `IsEllipticSequence.rel_even`: from `IsEllipticSequence W`, the relation
+* `IsEllipticSequence.rel_even`: from `IsEllipticSequence W`,
   `W (2 * m) * W 2 * W 1 ^ 2 = W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2)`.
-* `IsEllipticNet.rel_odd_eq_zero_iff` / `rel_even_eq_zero_iff`: the vanishing form at each
-  instance, which is what the two lemmas above are read off.
 
 ## Implementation notes
 
-These are equations about the doubled-index term, not new predicates. An earlier draft followed
-the source in introducing `OddRec` and `EvenRec` as `Prop` definitions; that stood a second
-recurrence interface beside Mathlib's `rel_odd` / `rel_even`, which already name these two
-instances. Deriving the vanishing form from those lemmas leaves one API rather than two, and makes
-each proof a rewrite followed by a rearrangement.
+Each proof specialises the hypothesis at the relevant instance, rewrites with Mathlib's evaluation
+of the relator there, and rearranges. Nothing intermediate is named: an earlier draft exported the
+two vanishing-form equivalences as well, but their only consumers were the two lemmas below, so
+they were a second public spelling of `rel_odd` / `rel_even` rather than API.
 
-The equations **relate** the doubled-index term to its neighbours; they do not on their own
-determine it. Nothing here inverts `W 1` or `W 2 * W 1 ^ 2`, and over an arbitrary `CommRing`
-neither need be a unit, so solving for `W (2 * m + 1)` or `W (2 * m)` requires a hypothesis this
-file does not carry.
+The equations **relate** the doubled-index term to its neighbours; they do not determine it.
+Nothing here inverts `W 1` or `W 2 * W 1 ^ 2`, and over an arbitrary `CommRing` neither need be a
+unit, so solving for `W (2 * m + 1)` or `W (2 * m)` requires a hypothesis this file does not carry.
 
 ## Provenance
 
@@ -54,8 +50,8 @@ The adaptation is substantial, because Mathlib has since absorbed most of what t
 build for itself. The source states its equivalences against `Rel₃`, a three-index relation of its
 own, and carries `OddRec` / `EvenRec` as `Prop` definitions naming the right-hand sides. Mathlib
 supplies `Rel₃` as `rel W p q r 0` — the shape `IsEllipticSequence` quantifies over — and supplies
-`rel_odd` / `rel_even` as the evaluations at these two instances. What remains to port is the
-passage from value to vanishing, which is what the two lemmas here do.
+`rel_odd` / `rel_even` as the evaluations at these two instances. What remains is the consequence
+drawn here, and none of the source's four declarations survives as such.
 
 The source's `rel₄_iff_evenRec`, a third equivalence against the four-index relator at
 `(2 * m + 1, 2 * m - 1, 3, 1)`, is not ported. It is the one declaration in this group carrying
@@ -66,40 +62,25 @@ descent layer that consumes it.
 
 public section
 
-namespace IsEllipticNet
-
-variable {R : Type*} [CommRing R] (W : ℤ → R) (m : ℤ)
-
-/-- **The odd doubling relation, in vanishing form.** The relator at `(m + 1, m, 1, 0)` vanishes
-exactly when `W (2 * m + 1)` stands in this relation to its neighbours. -/
-theorem rel_odd_eq_zero_iff : rel W (m + 1) m 1 0 = 0 ↔
-    W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3 := by
-  rw [rel_odd]
-  constructor <;> intro h <;> linear_combination h
-
-/-- **The even doubling relation, in vanishing form.** The relator at `(m + 1, m - 1, 1, 0)`
-vanishes exactly when `W (2 * m)` stands in this relation to its neighbours. -/
-theorem rel_even_eq_zero_iff : rel W (m + 1) (m - 1) 1 0 = 0 ↔
-    W (2 * m) * W 2 * W 1 ^ 2 =
-      W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) := by
-  rw [rel_even]
-  constructor <;> intro h <;> linear_combination h
-
-end IsEllipticNet
-
 namespace IsEllipticSequence
 
 variable {R : Type*} [CommRing R] {W : ℤ → R}
 
 /-- **The odd doubling relation of an elliptic sequence.** -/
+@[grind]
 theorem rel_odd (h : IsEllipticSequence W) (m : ℤ) :
-    W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3 :=
-  (IsEllipticNet.rel_odd_eq_zero_iff W m).1 (h (m + 1) m 1)
+    W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3 := by
+  have hm := h (m + 1) m 1
+  rw [IsEllipticNet.rel_odd] at hm
+  linear_combination hm
 
 /-- **The even doubling relation of an elliptic sequence.** -/
+@[grind]
 theorem rel_even (h : IsEllipticSequence W) (m : ℤ) :
     W (2 * m) * W 2 * W 1 ^ 2 =
-      W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) :=
-  (IsEllipticNet.rel_even_eq_zero_iff W m).1 (h (m + 1) (m - 1) 1)
+      W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) := by
+  have hm := h (m + 1) (m - 1) 1
+  rw [IsEllipticNet.rel_even] at hm
+  linear_combination hm
 
 end IsEllipticSequence

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+
+/-!
+# The odd and even recurrences of an elliptic sequence
+
+An elliptic sequence satisfies `IsEllipticNet.rel W p q r 0 = 0` for all `p, q, r` — that is
+Mathlib's `IsEllipticSequence`. Two particular cases of that relation are the recurrences that
+compute the sequence term by term, doubling the index:
+
+* at `(m + 1, m, 1)` the relation says how `W (2 * m + 1)` is determined by lower terms;
+* at `(m + 1, m - 1, 1)` it says the same for `W (2 * m)`.
+
+This file names those two right-hand sides, `OddRec` and `EvenRec`, and proves that each is
+equivalent to the corresponding instance of Mathlib's relator. Naming them is what lets the
+division-polynomial development state the doubling step without carrying the four-index relator
+through every use site.
+
+## Main definitions
+
+* `IsEllipticNet.OddRec`: the recurrence for `W (2 * m + 1)`.
+* `IsEllipticNet.EvenRec`: the recurrence for `W (2 * m)`.
+
+## Main results
+
+* `IsEllipticNet.rel_iff_oddRec`: the relator at `(m + 1, m, 1, 0)` vanishes iff `OddRec` holds.
+* `IsEllipticNet.rel_iff_evenRec`: the relator at `(m + 1, m - 1, 1, 0)` vanishes iff `EvenRec`
+  holds.
+
+## Implementation notes
+
+The recurrences are stated over Mathlib's `IsEllipticNet.rel` at `s = 0`, which is exactly the
+shape `IsEllipticSequence` quantifies over — `IsEllipticSequence W ↔ ∀ p q r, rel W p q r 0 = 0`
+holds by definition. The source states them over a three-index predicate of its own; taking
+Mathlib's four-index relator with `s = 0` instead means a consumer that has `IsEllipticSequence`
+can apply these directly, and no second relation stands beside Mathlib's.
+
+## Provenance
+
+Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `OddRec`, `EvenRec`,
+`rel₃_iff_oddRec` and `rel₃_iff_evenRec`. That file's header reads `Authors: Junyan Xu`; following
+this repository's convention for adapted material the upstream authorship is credited here rather
+than in the copyright header.
+
+The source states both equivalences against its own `Rel₃`, a three-index predicate defined as the
+`d = 0` case of its four-index relation. Mathlib supplies that case as `rel W p q r 0`, so `Rel₃`
+is not ported: the equivalences are stated against Mathlib's relator directly.
+
+The source's `rel₄_iff_evenRec`, a third equivalence against the four-index relator at
+`(2 * m + 1, 2 * m - 1, 3, 1)`, is **not** ported here. It is the one declaration in this group
+carrying `set_option allowUnsafeReducibility true` together with a `Nat.rawCast` reducibility
+attribute, which this repository does not take on unexamined; it belongs with the descent layer
+that consumes it rather than with the definitions.
+-/
+
+public section
+
+namespace IsEllipticNet
+
+variable {R : Type*} [CommRing R] (W : ℤ → R) (m : ℤ)
+
+/-- The recurrence determining the odd-index term `W (2 * m + 1)` of an elliptic sequence. -/
+def OddRec : Prop :=
+  W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3
+
+/-- The recurrence determining the even-index term `W (2 * m)` of an elliptic sequence. -/
+def EvenRec : Prop :=
+  W (2 * m) * W 2 * W 1 ^ 2 = W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2)
+
+/-- **The odd recurrence is the relator at `(m + 1, m, 1, 0)`.** -/
+theorem rel_iff_oddRec : rel W (m + 1) m 1 0 = 0 ↔ OddRec W m := by
+  rw [rel, OddRec]
+  ring_nf
+  constructor <;> intro h <;> linear_combination h
+
+/-- **The even recurrence is the relator at `(m + 1, m - 1, 1, 0)`.** -/
+theorem rel_iff_evenRec : rel W (m + 1) (m - 1) 1 0 = 0 ↔ EvenRec W m := by
+  rw [rel, EvenRec]
+  ring_nf
+  constructor <;> intro h <;> linear_combination h
+
+end IsEllipticNet


### PR DESCRIPTION
Being an elliptic sequence is exactly satisfying the two doubling recurrences — the equivalence,
and the descent that proves the hard direction.

```lean
theorem isEllipticSequence_iff (odd : W.Odd) (zero : W 0 = 0)
    (one : W 1 ∈ nonZeroDivisors R) (two : W 2 ∈ nonZeroDivisors R) :
    IsEllipticSequence W ↔
      (∀ m : ℤ, 2 ≤ m → W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3)
        ∧ ∀ m : ℤ, 3 ≤ m → W (2 * m) * W 2 * W 1 ^ 2 =
            W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2)
```

`IsEllipticSequence W` is a condition on every *triple* of integers. This says it is equivalent to
two families of equations indexed by a single integer — one recurrence per parity, from `m = 2`
and `m = 3` on. That is what makes the predicate checkable, and it is the step Mathlib's own file
stops short of: `EllipticDivisibilitySequence.lean:70` records "prove that `normEDS` satisfies
`IsEllipticDvdSequence`" as an open TODO, and this equivalence is what that proof needs.

## The two directions

**Forward** is `Recurrence.lean`: `IsEllipticSequence.rel_odd` and `rel_even` read the two
recurrences off the relation, one rewrite and one rearrangement each.

**Reverse** is the descent, and is the substance of this PR. Induction on the largest index `a`:

* below `6` no valid quadruple exists at all, since four nonnegative same-parity indices in
  strict decrease force `6 ≤ a`;
* above it, the relator on four unconstrained indices is rewritten into relators carrying a
  fixed pair of small indices, by a three-term and a ten-term expansion;
* that reduces every case to the minimal same-parity pair, where either the gap `b + 2 < a`
  admits a transfer down to a smaller first index, or `b + 2 = a` lands exactly on one of the
  two recurrences, chosen by the parity of `a`.

Then arbitrary indices are reduced to that valid case: absolute values make them nonnegative,
coincidences collapse through Mathlib's `atomRel_same` family (each value carries a factor
`W 0`), and the rest are sorted.

## What is smaller than the source, and why

Three parts of the source's apparatus turned out to be unnecessary here, each because Mathlib
has since absorbed the layer it was compensating for.

* **No `set_option allowUnsafeReducibility true`.** The source proves its odd base case under
  that option together with `attribute [local reducible] Nat.rawCast`, which #2860 already
  declined to bring into this repository. Stating the base cases with indices in `2 * _` and
  `2 * _ + 1` form makes Mathlib's `atomRel_two_mul` and `atom_odd` apply directly, and neither
  the option nor the attribute is needed anywhere in this PR.
* **No `dMin` / `cMin` layer.** The source defines the minimal same-parity index as
  `if Even a then 0 else 1` and carries five `Int.negOnePow` lemmas about it. In Mathlib's `% 2`
  spelling that is `a % 2`, and all five become `omega` — as does the three-case split in
  `atomRelVanishes_of_min`, where the source needs `add_two_le_iff_lt_of_even_sub` and
  `negOnePow_eq_iff`.
* **No general permutation machinery.** The source sorts four indices with `Tuple.sort`,
  needing `relFin4`, `relFin4_perm`, `relFin4_perm'` and a four-index swap family. Here the
  last index is `0`, which is already minimal, so only the first three need sorting: six
  orderings reached from the decreasing one by two adjacent transpositions.

## Mathlib overlap, stated rather than glossed

Most of what the source built for itself is now upstream, and this PR consumes it rather than
restating it: `atom` and `atomRel` are its `addMulSub` and `rel₄`; `atomRel_avg_sub` is its
`rel₄_transf`, proved there with `grind` and no reducibility surgery; `atomRel_eq` is its
`rel₄_eq_net`; `atomRel_two_mul`, `atom_odd`, and the `atomRel_same`, `atomRel_neg` and
`atomRel_abs` families are all used as given.

What Mathlib does **not** have, checked by a loogle type-pattern search for
`atom _ _ _ * atomRel _ _ _ _ _` (empty) and by reading the file to its two closing TODOs: the
expansions and the descent itself. The antisymmetry under index transpositions is absent from
Mathlib but **present in this repository** already, in `SignEquivariance.lean`, and is taken
from there rather than restated.

The public surface added is five declarations: the three expansions and the two consumer-facing
results. The descent predicate and the lemmas lowering it are private — they are shaped by this
proof, not by any caller.

## Deliberately not ported

* The source's `rel₆` abbreviation for `addMulSub W k l * rel₄ W a b c d`, with its `@[simp]`
  unfolding lemma. It names a product rather than a concept and exists only to shorten four
  statements, so it would be a second public spelling of `atom _ _ * atomRel _ _ _ _`.
* `addMulSub_sq_mul_rel₄_eq₉`, the nine-term expansion. It is **unused in the source too** —
  it occurs only at its own declaration there — and this descent does not need it.
* The source's swap family `rel₄_swap₀₁`, `rel₄_swap₁₂`, `rel₄_swap₂₃` and the `relFin4_perm`
  built on them. These are **already in this repository**, as `SignEquivariance.lean`, which
  exports `atomRel_swap₁₂`, `atomRel_swap₂₃`, `atomRel_swap₃₄` and the general
  `atomRelFin4_perm`; this PR imports and uses them. Only the first three indices are ever
  permuted here, the last being held at `0`, so the two adjacent transpositions suffice.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, the **Layer 6** torsion/Nagell–Lutz strand, whose
stated route to `lutz_nagell` runs through the division polynomials. The blocking fact on that
chain is identifying `normEDS` as an elliptic sequence, which is Mathlib's open TODO; this
equivalence is the tool that discharges it, since `normEDS` satisfies both recurrences by
`normEDS_odd` and `normEDS_even`.

## Provenance

Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `OddRec`, `EvenRec`, `rel₃_iff_oddRec`,
`rel₃_iff_evenRec`, `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`, `rel₄_iff_evenRec`, `dMin`, `cMin`,
`Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`, `rel₄_of_min₂`,
`rel₄_of_anti_oddRec_evenRec`, `rel₄_swap₀₁`, `rel₄_swap₁₂`, `rel₄_of_oddRec_evenRec` and
`IsEllSequence.of_oddRec_evenRec`. That file's header reads `Authors: Junyan Xu`; following this
repository's convention for adapted material the upstream authorship is credited in the module
docstrings rather than in the copyright header.

## Gates

`lake build` PASS on a worktree verified clean beforehand, at Mathlib pin byte-identical to
`origin/main`'s, with the branch rebased onto current `main`. No `sorry`; `#print axioms
isEllipticSequence_iff` reports exactly `[propext, Classical.choice, Quot.sound]`.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-recurrence"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
