### PR TITLE
feat: rule out characters of unipotent groups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/NoCharacters.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/NoCharacters.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Character
+public import TauCeti.RingTheory.FiniteType.PointSeparation
+
+/-!
+# Characters of a unipotent affine group
+
+Let `H` be the reduced finite-type coordinate Hopf algebra of an affine group over a field `k`,
+and let `K` be an algebraically closed extension of `k`. If every `K`-valued point of the group is
+unipotent, then every group-like element of `H` is one. In geometric language, every algebraic
+character of the group is trivial.
+
+The argument combines two independent inputs. A unipotent point evaluates every group-like
+element at one, by the rank-one representation attached to that element. Algebraically closed
+points separate elements of a reduced finite-type algebra, so an element evaluated as one by all
+points is itself one. The conclusion does not require connectedness: the pointwise unipotence
+hypothesis is already strong enough.
+
+## Main results
+
+* `TauCeti.GroupLike.eq_one_of_forall_algHom_apply_eq_one`: a group-like element evaluated as one
+  at every algebraically closed point is one.
+* `TauCeti.groupLike_eq_one_of_forall_isUnipotentPoint`: every algebraic character is trivial when
+  all algebraically closed points are unipotent.
+* `TauCeti.subsingleton_groupLike_of_forall_isUnipotentPoint`: the character group is
+  subsingleton under the same hypotheses.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, Section 2.4.
+
+This completes the "no nontrivial characters" consequence in Layer 5, "Unipotent groups", of
+`TauCetiRoadmap/ReductiveGroups/README.md`.
+-/
+
+public section
+
+open WithConv
+
+namespace TauCeti
+
+namespace GroupLike
+
+universe u v w
+
+variable {k : Type u} {H : Type v} {K : Type w}
+  [Field k] [CommRing H] [Bialgebra k H] [Algebra.FiniteType k H]
+  [IsReduced H] [Field K] [Algebra k K] [IsAlgClosed K]
+
+/-- A group-like element of a reduced finite-type algebra is one if every algebraically closed
+point evaluates it as one.
+
+This is the coordinate-algebra form of the fact that an algebraic character is determined by its
+values on geometric points. -/
+theorem eq_one_of_forall_algHom_apply_eq_one (x : GroupLike k H)
+    (h : ∀ f : H →ₐ[k] K, f x = 1) : x = 1 := by
+  apply _root_.GroupLike.val_injective
+  apply TauCeti.eq_of_forall_algHom_apply_eq (k := k) (K := K)
+  intro f
+  simpa using h f
+
+end GroupLike
+
+universe u v w
+
+variable {k : Type u} {H : Type v} {K : Type w}
+  [Field k] [CommRing H] [HopfAlgebra k H] [Algebra.FiniteType k H]
+  [IsReduced H] [Field K] [Algebra k K] [IsAlgClosed K]
+
+/-- **A reduced finite-type affine group whose algebraically closed points are all unipotent has
+no nontrivial algebraic characters.** Every group-like element of its coordinate Hopf algebra is
+one. -/
+theorem groupLike_eq_one_of_forall_isUnipotentPoint
+    (hH : ∀ g : WithConv (H →ₐ[k] K), HopfAlgebra.IsUnipotentPoint g)
+    (x : GroupLike k H) : x = 1 := by
+  apply GroupLike.eq_one_of_forall_algHom_apply_eq_one (K := K) x
+  intro g
+  exact (hH (toConv g)).apply_groupLike_eq_one x
+
+/-- The algebraic character group of a reduced finite-type affine group is subsingleton when all
+of its algebraically closed points are unipotent. -/
+theorem subsingleton_groupLike_of_forall_isUnipotentPoint
+    (hH : ∀ g : WithConv (H →ₐ[k] K), HopfAlgebra.IsUnipotentPoint g) :
+    Subsingleton (GroupLike k H) :=
+  ⟨fun x y ↦
+    (groupLike_eq_one_of_forall_isUnipotentPoint hH x).trans
+      (groupLike_eq_one_of_forall_isUnipotentPoint hH y).symm⟩
+
+end TauCeti


### PR DESCRIPTION
This PR proves that a reduced finite-type affine group whose algebraically closed points are all unipotent has no nontrivial algebraic characters. Apply the merged rank-one result `HopfAlgebra.IsUnipotentPoint.apply_groupLike_eq_one` to every geometric point, then use the merged affine Nullstellensatz principle `eq_of_forall_algHom_apply_eq` to conclude that each group-like coordinate is itself one; package the result both elementwise and as `Subsingleton (GroupLike k H)`.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5 milestone **“Unipotent groups”**, specifically its stated consequence that a connected unipotent group has no nontrivial characters. The theorem is naturally slightly stronger: connectedness is not needed once all geometric points are assumed unipotent, while reducedness and finite type are exactly the hypotheses required for geometric points to separate coordinate functions. This is the most effective current step because #3091 supplied the pointwise rank-one calculation and the open group-level definition in #3088 explicitly leaves this deduction outstanding, so the present PR completes that consequence without overlapping the definition.

After this PR, Layer 5 still needs the upper-unitriangular coordinate Hopf algebra and closed subgroup scheme, Lie–Kolchin, the upper-unitriangular embedding characterization, and the unipotent radical.

Add `TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/NoCharacters.lean` (95 lines). Reuse Tau Ceti's `eq_of_forall_algHom_apply_eq` and `HopfAlgebra.IsUnipotentPoint.apply_groupLike_eq_one`; no Mathlib infrastructure or external formalization is vendored. The mathematical argument follows J. C. Jantzen, *Representations of Algebraic Groups*, I.2, and T. A. Springer, *Linear Algebraic Groups*, §2.4, both credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"unipotent-groups-have-no-characters"}-->

🤖 Prepared with Codex
