### PR TITLE
refactor(EllipticCurve): name the nontrivial-cocycle branch of the twist classification

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -710,25 +710,19 @@ private theorem exists_smul_eq_quadraticTwist_of_map_eq_negVariableChange_mul
     (hρ : ρ • E'.baseChange L = E.baseChange L) {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1)
     (hρmap : ρ.map (σ : L →+* L) = (E.baseChange L).negVariableChange * ρ) :
     ∃ C : VariableChange K, C • E' = E.quadraticTwist L := by
-  -- composing `ρ` with the inverse trace-norm change of variables cancels the cocycle, so the
-  -- composite descends to `K`
-  obtain ⟨θ, hθ⟩ := Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L
-  have hinj := FaithfulSMul.algebraMap_injective K L
-  set C₁ := E.quadraticTwistOfTraceNormVariableChange hθ hσ with hC₁
-  have hcoc := E.map_quadraticTwistOfTraceNormVariableChange hθ hσ
-  have hχiso : (C₁⁻¹ * ρ) • E'.baseChange L
-      = (E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)).baseChange L := by
-    rw [mul_smul, hρ, hC₁, E.inv_quadraticTwistOfTraceNormVariableChange_smul hθ hσ]
-  have hχinv : (C₁⁻¹ * ρ).map (σ : L →+* L) = C₁⁻¹ * ρ := by
-    rw [VariableChange.map_mul, VariableChange.map_inv, hcoc, hρmap, mul_inv_rev,
-      (E.baseChange L).negVariableChange_inv, mul_assoc,
+  -- the twist's own change of variables carries the opposite cocycle, so `T · ρ` is
+  -- `σ`-invariant and descends to `K`
+  have hχiso : (E.quadraticTwistVariableChange L * ρ) • E'.baseChange L
+      = (E.quadraticTwist L).baseChange L := by
+    rw [mul_smul, hρ, E.quadraticTwistVariableChange_smul L]
+  have hχinv : (E.quadraticTwistVariableChange L * ρ).map (σ : L →+* L)
+      = E.quadraticTwistVariableChange L * ρ := by
+    rw [VariableChange.map_mul, E.map_quadraticTwistVariableChange L hσ, hρmap, mul_assoc,
       ← mul_assoc (E.baseChange L).negVariableChange,
       (E.baseChange L).negVariableChange_mul_self, one_mul]
   obtain ⟨χK, hχK⟩ := VariableChange.exists_baseChange_eq_of_map_eq L hσ hχinv
-  have hE'T : χK • E' = E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ) :=
-    smul_eq_of_baseChange_smul_eq L hinj χK (by rw [hχK]; exact hχiso)
-  obtain ⟨C₀, hC₀⟩ := E.exists_smul_quadraticTwist_eq hθ
-  exact ⟨C₀⁻¹ * χK, by rw [mul_smul, hE'T, ← hC₀, inv_smul_smul]⟩
+  exact ⟨χK, smul_eq_of_baseChange_smul_eq L (FaithfulSMul.algebraMap_injective K L) χK
+    (by rw [hχK]; exact hχiso)⟩
 
 variable (L) in
 /-- **Classification of the forms of `E` split by `L/K`, for `j(E) ∉ {0, 1728}`.** A curve over `K`

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -703,19 +703,16 @@ theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : 
   exact mul_right_cancel (((mul_left_cancel hchain).trans (one_mul C₁).symm))
 
 omit [E.IsElliptic] in
-/-- **The nontrivial cocycle gives the twist.** If an `L`-isomorphism `ρ : E'ᴸ ≅ Eᴸ` has Galois
-cocycle `[-1]` — that is, `σρ = [-1]·ρ` — then `E'` is `K`-isomorphic to the quadratic twist of
-`E`. Composing `ρ` with the inverse of the trace–norm change of variables cancels that cocycle, so
-the composite descends to `K`.
-
-The `j`-hypotheses are not needed: this is the branch *after* the automorphism dichotomy has been
-applied, and it uses only the shape of the cocycle it produced. -/
+/-- **An `L`-isomorphism `E'ᴸ ≅ Eᴸ` whose Galois conjugate differs from it by `[-1]` makes `E'`
+`K`-isomorphic to the quadratic twist of `E`.** -/
 private theorem exists_smul_eq_quadraticTwist_of_map_eq_negVariableChange_mul
     {E' : WeierstrassCurve K} {ρ : VariableChange L}
-    (hρ : ρ • E'.baseChange L = E.baseChange L) {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {θ : L}
-    (hθ : θ ∉ Set.range (algebraMap K L))
+    (hρ : ρ • E'.baseChange L = E.baseChange L) {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1)
     (hρmap : ρ.map (σ : L →+* L) = (E.baseChange L).negVariableChange * ρ) :
     ∃ C : VariableChange K, C • E' = E.quadraticTwist L := by
+  -- composing `ρ` with the inverse trace-norm change of variables cancels the cocycle, so the
+  -- composite descends to `K`
+  obtain ⟨θ, hθ⟩ := Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L
   have hinj := FaithfulSMul.algebraMap_injective K L
   set C₁ := E.quadraticTwistOfTraceNormVariableChange hθ hσ with hC₁
   have hcoc := E.map_quadraticTwistOfTraceNormVariableChange hθ hσ
@@ -749,7 +746,6 @@ theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj�
       ∃ C : VariableChange K, C • E' = E.quadraticTwist L := by
   obtain ⟨ρ, hρ⟩ := h
   obtain ⟨σ, hσ⟩ := Algebra.IsQuadraticExtension.exists_algEquiv_ne_one K L
-  obtain ⟨θ, hθ⟩ := Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L
   have hinj := FaithfulSMul.algebraMap_injective K L
   -- the Galois conjugate of `ρ` is again an isomorphism `E'ᴸ ≅ Eᴸ`, so `σρ · ρ⁻¹` fixes `Eᴸ`
   have hσρ : (ρ.map (σ : L →+* L)) • E'.baseChange L = E.baseChange L :=
@@ -765,7 +761,7 @@ theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj�
       VariableChange.exists_baseChange_eq_of_map_eq L hσ (mul_inv_eq_one.mp hbcase)
     exact ⟨ρK, smul_eq_of_baseChange_smul_eq L hinj ρK (by rw [hρK]; exact hρ)⟩
   · -- nontrivial cocycle: `E'` is the twist
-    exact .inr (E.exists_smul_eq_quadraticTwist_of_map_eq_negVariableChange_mul hρ hσ hθ
+    exact .inr (E.exists_smul_eq_quadraticTwist_of_map_eq_negVariableChange_mul hρ hσ
       (mul_inv_eq_iff_eq_mul.mp hbcase))
 
 end Classification

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -702,6 +702,37 @@ theorem not_exists_smul_quadraticTwist_eq (hj₀ : E.j ≠ 0) (hj₁₇₂₈ : 
       _ = a * C₁ := haC.symm
   exact mul_right_cancel (((mul_left_cancel hchain).trans (one_mul C₁).symm))
 
+omit [E.IsElliptic] in
+/-- **The nontrivial cocycle gives the twist.** If an `L`-isomorphism `ρ : E'ᴸ ≅ Eᴸ` has Galois
+cocycle `[-1]` — that is, `σρ = [-1]·ρ` — then `E'` is `K`-isomorphic to the quadratic twist of
+`E`. Composing `ρ` with the inverse of the trace–norm change of variables cancels that cocycle, so
+the composite descends to `K`.
+
+The `j`-hypotheses are not needed: this is the branch *after* the automorphism dichotomy has been
+applied, and it uses only the shape of the cocycle it produced. -/
+private theorem exists_smul_eq_quadraticTwist_of_map_eq_negVariableChange_mul
+    {E' : WeierstrassCurve K} {ρ : VariableChange L}
+    (hρ : ρ • E'.baseChange L = E.baseChange L) {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {θ : L}
+    (hθ : θ ∉ Set.range (algebraMap K L))
+    (hρmap : ρ.map (σ : L →+* L) = (E.baseChange L).negVariableChange * ρ) :
+    ∃ C : VariableChange K, C • E' = E.quadraticTwist L := by
+  have hinj := FaithfulSMul.algebraMap_injective K L
+  set C₁ := E.quadraticTwistOfTraceNormVariableChange hθ hσ with hC₁
+  have hcoc := E.map_quadraticTwistOfTraceNormVariableChange hθ hσ
+  have hχiso : (C₁⁻¹ * ρ) • E'.baseChange L
+      = (E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)).baseChange L := by
+    rw [mul_smul, hρ, hC₁, E.inv_quadraticTwistOfTraceNormVariableChange_smul hθ hσ]
+  have hχinv : (C₁⁻¹ * ρ).map (σ : L →+* L) = C₁⁻¹ * ρ := by
+    rw [VariableChange.map_mul, VariableChange.map_inv, hcoc, hρmap, mul_inv_rev,
+      (E.baseChange L).negVariableChange_inv, mul_assoc,
+      ← mul_assoc (E.baseChange L).negVariableChange,
+      (E.baseChange L).negVariableChange_mul_self, one_mul]
+  obtain ⟨χK, hχK⟩ := VariableChange.exists_baseChange_eq_of_map_eq L hσ hχinv
+  have hE'T : χK • E' = E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ) :=
+    smul_eq_of_baseChange_smul_eq L hinj χK (by rw [hχK]; exact hχiso)
+  obtain ⟨C₀, hC₀⟩ := E.exists_smul_quadraticTwist_eq hθ
+  exact ⟨C₀⁻¹ * χK, by rw [mul_smul, hE'T, ← hC₀, inv_smul_smul]⟩
+
 variable (L) in
 /-- **Classification of the forms of `E` split by `L/K`, for `j(E) ∉ {0, 1728}`.** A curve over `K`
 that becomes isomorphic to `E` over `L` is isomorphic over `K` either to `E` or to its quadratic
@@ -719,8 +750,6 @@ theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj�
   obtain ⟨ρ, hρ⟩ := h
   obtain ⟨σ, hσ⟩ := Algebra.IsQuadraticExtension.exists_algEquiv_ne_one K L
   obtain ⟨θ, hθ⟩ := Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap K L
-  set C₁ := E.quadraticTwistOfTraceNormVariableChange hθ hσ with hC₁
-  have hcoc := E.map_quadraticTwistOfTraceNormVariableChange hθ hσ
   have hinj := FaithfulSMul.algebraMap_injective K L
   -- the Galois conjugate of `ρ` is again an isomorphism `E'ᴸ ≅ Eᴸ`, so `σρ · ρ⁻¹` fixes `Eᴸ`
   have hσρ : (ρ.map (σ : L →+* L)) • E'.baseChange L = E.baseChange L :=
@@ -735,23 +764,9 @@ theorem exists_smul_eq_or_exists_smul_eq_quadraticTwist (hj₀ : E.j ≠ 0) (hj�
     obtain ⟨ρK, hρK⟩ :=
       VariableChange.exists_baseChange_eq_of_map_eq L hσ (mul_inv_eq_one.mp hbcase)
     exact ⟨ρK, smul_eq_of_baseChange_smul_eq L hinj ρK (by rw [hρK]; exact hρ)⟩
-  · -- nontrivial cocycle: `C₁⁻¹ · ρ` is `σ`-invariant, its cocycle cancelling that of `C₁`
-    right
-    have hρmap : ρ.map (σ : L →+* L) = (E.baseChange L).negVariableChange * ρ :=
-      mul_inv_eq_iff_eq_mul.mp hbcase
-    have hχiso : (C₁⁻¹ * ρ) • E'.baseChange L
-        = (E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ)).baseChange L := by
-      rw [mul_smul, hρ, hC₁, E.inv_quadraticTwistOfTraceNormVariableChange_smul hθ hσ]
-    have hχinv : (C₁⁻¹ * ρ).map (σ : L →+* L) = C₁⁻¹ * ρ := by
-      rw [VariableChange.map_mul, VariableChange.map_inv, hcoc, hρmap, mul_inv_rev,
-        (E.baseChange L).negVariableChange_inv, mul_assoc,
-        ← mul_assoc (E.baseChange L).negVariableChange,
-        (E.baseChange L).negVariableChange_mul_self, one_mul]
-    obtain ⟨χK, hχK⟩ := VariableChange.exists_baseChange_eq_of_map_eq L hσ hχinv
-    have hE'T : χK • E' = E.quadraticTwistOf (Algebra.trace K L θ) (Algebra.norm K θ) :=
-      smul_eq_of_baseChange_smul_eq L hinj χK (by rw [hχK]; exact hχiso)
-    obtain ⟨C₀, hC₀⟩ := E.exists_smul_quadraticTwist_eq hθ
-    exact ⟨C₀⁻¹ * χK, by rw [mul_smul, hE'T, ← hC₀, inv_smul_smul]⟩
+  · -- nontrivial cocycle: `E'` is the twist
+    exact .inr (E.exists_smul_eq_quadraticTwist_of_map_eq_negVariableChange_mul hρ hσ hθ
+      (mul_inv_eq_iff_eq_mul.mp hbcase))
 
 end Classification
 


### PR DESCRIPTION
`exists_smul_eq_or_exists_smul_eq_quadraticTwist` carried a 48-line proof that ends in a two-way
case split on the Galois cocycle. The trivial branch is four lines; the nontrivial one is eighteen
and is a self-contained statement. Name it. No statement changes; no new public declaration.

## The split

After the automorphism dichotomy fires, `σρ · ρ⁻¹` is either `1` or `[-1]`:

* **trivial cocycle** — `ρ` is `σ`-invariant, descends to `K`, and `E' ≅ E`. Four lines; stays
  inline, since naming it would be longer than it is.
* **nontrivial cocycle** — `σρ = [-1]·ρ`. Composing `ρ` with the inverse of the trace–norm change
  of variables cancels that cocycle, so the composite descends and `E'` is the twist. Eighteen
  lines, and it never looks at the case split again.

The second is now — and, following review, proved a different way than the code it replaces:

```lean
omit [E.IsElliptic] in
private theorem exists_smul_eq_quadraticTwist_of_map_eq_negVariableChange_mul
    {E' : WeierstrassCurve K} {ρ : VariableChange L}
    (hρ : ρ • E'.baseChange L = E.baseChange L) {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1)
    (hρmap : ρ.map (σ : L →+* L) = (E.baseChange L).negVariableChange * ρ) :
    ∃ C : VariableChange K, C • E' = E.quadraticTwist L
```

## What the extraction exposes

**It needs no `j`-hypotheses and no ellipticity.** It is the branch *after* the dichotomy has been
applied, and it consumes only the shape of the cocycle that dichotomy produced — `hρmap` — not the
reason the dichotomy held. The `omit [E.IsElliptic]` is the compiler confirming that: with the
branch inline there was no way to see it, since the enclosing theorem needs both hypotheses for the
dichotomy itself.

## Lengths

| Declaration | Before | After |
|---|---|---|
| `exists_smul_eq_or_exists_smul_eq_quadraticTwist` | 48 | 31 |
| `exists_smul_eq_quadraticTwist_of_map_eq_negVariableChange_mul` | — | 20 |

The parent is still one line over the 30-line threshold, and I am not claiming otherwise: what
remains is the `σρ · ρ⁻¹` cocycle computation plus the two branches, and splitting *that* further
would fragment a single argument. The 50-line cap is comfortably met.

The branch is **not** carried over unchanged: see the review note below. The trivial branch and the
surrounding cocycle computation are.

## A `/simplify` pass, before opening rather than after

Extracting the branch left `set C₁ := … with hC₁` and `have hcoc := …` dead in the parent — the
helper derives both for itself. Both are deleted here. That is the same dead-scaffolding pattern
`proof-quality` caught on #3201 after the fact; running the check first this time cost nothing and
saved a round.

## Scope

Improvement work on existing code: no statement changes, the new declaration is `private`, and no
new mathematics — it is the existing proof's own branch. The file goes from 991 to 975 lines,
against the 1500-line limit for an existing file. This is the follow-up named in #3201, which
shared the automorphism dichotomy between the two classification theorems and left the cocycle case
split for a separate topic.

## Review

One private round, two findings, both taken:

* `generality` — the helper took the quadratic generator `θ` as a parameter, but neither `hρmap`
  nor the conclusion mentions it. Quantified inside the proof instead, which also let the parent
  drop its own generator extraction.
* `documentation` — the docstring explained the extraction and the proof; restated as the result
  alone, with the cocycle-cancellation note demoted to an ordinary comment.

The posted round then found two more, and together theychange the branch's proof rather than its
placement:

* `reuse` — the branch reconstructed the generator, the trace–norm change of variables and a bridge
  back to `quadraticTwist`, all of which `quadraticTwistVariableChange` already packages:
  `quadraticTwistVariableChange_smul` says it carries `Eᴸ` to the twist, and
  `map_quadraticTwistVariableChange` says its Galois cocycle is exactly `[-1]`. So `T · ρ` is
  `σ`-invariant in three rewrites and descends straight to the twist — no `θ`, no trace–norm, no
  `C₀` bridge.
* `proof-quality` — `hχinv` was a ten-lemma `rw` chain. On the new route it is five, of which two
  are the cocycle-specific `map_quadraticTwistVariableChange` and `hρmap`.

That took the helper from 26 lines to 20 and removed the last use of `θ` from this branch.
`inv_quadraticTwistOfTraceNormVariableChange_smul` stays: the sibling
`not_exists_smul_quadraticTwist_eq` still uses it.

## Gates

`lake build` whole project clean; `scripts/lint-env.sh` **PASS**, no new violations; `lake exe
axioms` all within `[propext, Classical.choice, Quot.sound]`; `lake exe module-system` all modules
opt in. No line exceeds 100 codepoints.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"quadtwist-cocycle-branches"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
