### PR TITLE
refactor(Analysis/PDE): remove remaining redundant symmetry wrappers

### DIFF
--- a/TauCeti/Analysis/PDE/EnergyForm/Integrated/Symmetry.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Integrated/Symmetry.lean
@@ -33,8 +33,6 @@ integrand.
 * `TauCeti.PDE.energyFormIntegral_coefficientSymmetricPart_zero_drift_apply`: the
   symmetric-part zero-drift form is the average of the original form and its transpose, under the
   natural integrability hypotheses.
-* `TauCeti.PDE.energyFormIntegral_one_zero_mass_swap_eq`: bundled symmetry of the
-  shifted-Laplacian model form.
 -/
 
 public section
@@ -96,32 +94,6 @@ lemma energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae (ha : ∀ᵐ x ∂μ, (
   funext U V
   exact energyFormIntegral_zero_drift_comm_of_isSymm_ae (a := a) (c := c) (U := V) (V := U) ha
 
-/-- Symmetry on a domain when the measure is a.e. supported there and the principal
-coefficients are pointwise symmetric on that domain. -/
-lemma energyFormIntegral_zero_drift_comm_on {Ω : Set X}
-    (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) :
-    energyFormIntegral μ a (fun _ => 0) c U V =
-      energyFormIntegral μ a (fun _ => 0) c V U :=
-  energyFormIntegral_zero_drift_comm_of_isSymm_ae
-    (hΩ.mono fun _ hx => ha hx)
-
-/-- Bundled-map symmetry on a domain when the measure is a.e. supported there and the
-principal coefficients are pointwise symmetric on that domain. -/
-lemma energyFormIntegral_zero_drift_swap_eq_on {Ω : Set X}
-    (hΩ : ∀ᵐ x ∂μ, x ∈ Ω) (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) :
-    Function.swap (energyFormIntegral μ a (fun _ => 0) c) =
-      energyFormIntegral μ a (fun _ => 0) c := by
-  funext U V
-  exact energyFormIntegral_zero_drift_comm_on
-    (a := a) (c := c) (U := V) (V := U) hΩ ha
-
-/-- The symmetric-part zero-drift integrated energy form is symmetric. -/
-lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_comm :
-    energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c U V =
-      energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c V U :=
-  energyFormIntegral_zero_drift_comm_of_isSymm_ae
-    (Filter.Eventually.of_forall fun _ => coefficientSymmetricPart_isSymm _)
-
 /-- Bundled-map symmetry for the symmetric-part zero-drift integrated energy form. -/
 @[simp]
 lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_swap_eq :
@@ -130,20 +102,6 @@ lemma energyFormIntegral_coefficientSymmetricPart_zero_drift_swap_eq :
       energyFormIntegral μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c :=
   energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae
     (Filter.Eventually.of_forall fun _ => coefficientSymmetricPart_isSymm _)
-
-/-- The shifted-Laplacian model integrated form `-Δ + c` is symmetric. -/
-lemma energyFormIntegral_one_zero_mass_comm :
-    energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c U V =
-      energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c V U :=
-  energyFormIntegral_zero_drift_comm_of_isSymm_ae
-    (Filter.Eventually.of_forall fun _ => isSymm_one)
-
-/-- Bundled symmetry of the shifted-Laplacian model integrated form `-Δ + c`. -/
-lemma energyFormIntegral_one_zero_mass_swap_eq :
-    Function.swap (energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c) =
-      energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) c :=
-  energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae
-    (Filter.Eventually.of_forall fun _ => isSymm_one)
 
 /-- Replacing the principal coefficient by its symmetric part does not change the diagonal
 integrated energy.  The drift and mass coefficients are arbitrary, since the diagonal

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -38,10 +38,6 @@ separate conjunction API.
   part has zero-drift jet form equal to the average of the original form and its transpose.
 * `TauCeti.PDE.energyIntegrand_coefficientSymmetricPart_self`: the diagonal energy density
   is unchanged by replacing the principal coefficient by its symmetric part.
-* `TauCeti.PDE.energyIntegrand_zero_drift_comm_on`: a pointwise symmetric coefficient field
-  gives symmetric zero-drift jet forms at every point of the domain.
-* `TauCeti.PDE.energyIntegrand_one_zero_mass_flip_eq`: bundled symmetry of the shifted
-  Laplacian jet form.
 -/
 
 public section
@@ -52,7 +48,7 @@ namespace PDE
 
 open Matrix
 
-variable {X n : Type*} [Fintype n]
+variable {n : Type*} [Fintype n]
 
 /-- Local classical decidable equality for finite coordinate indices in symmetry proofs. -/
 noncomputable local instance symmetricEnergyDecidableEq : DecidableEq n := Classical.decEq n
@@ -114,27 +110,6 @@ lemma energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq (A : Matrix n 
     (energyIntegrand (coefficientSymmetricPart A) 0 c).flip =
       energyIntegrand (coefficientSymmetricPart A) 0 c :=
   energyIntegrand_zero_drift_flip_eq_of_isSymm (coefficientSymmetricPart_isSymm A) c
-
-/-- A pointwise symmetric coefficient field gives symmetric zero-drift jet forms at every
-point of the domain. -/
-lemma energyIntegrand_zero_drift_comm_on {Ω : Set X} {a : X → Matrix n n ℝ}
-    (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) {x : X} (hx : x ∈ Ω) (c : X → ℝ)
-    (U V : ℝ × EuclideanSpace ℝ n) :
-    energyIntegrand (a x) 0 (c x) U V = energyIntegrand (a x) 0 (c x) V U :=
-  energyIntegrand_zero_drift_comm_of_isSymm (ha hx) (c x) U V
-
-/-- A pointwise symmetric coefficient field gives a bundled symmetric zero-drift jet form at
-each point of the domain. -/
-lemma energyIntegrand_zero_drift_flip_eq_on {Ω : Set X} {a : X → Matrix n n ℝ}
-    (ha : ∀ ⦃x⦄, x ∈ Ω → (a x).IsSymm) {x : X} (hx : x ∈ Ω) (c : X → ℝ) :
-    (energyIntegrand (a x) 0 (c x)).flip = energyIntegrand (a x) 0 (c x) :=
-  energyIntegrand_zero_drift_flip_eq_of_isSymm (ha hx) (c x)
-
-/-- Bundled symmetry of the shifted Laplacian jet form. -/
-lemma energyIntegrand_one_zero_mass_flip_eq (c : ℝ) :
-    (energyIntegrand (1 : Matrix n n ℝ) 0 c).flip =
-      energyIntegrand (1 : Matrix n n ℝ) 0 c :=
-  energyIntegrand_zero_drift_flip_eq_of_isSymm isSymm_one c
 
 end PDE
 


### PR DESCRIPTION
## Summary
- Remove eight consumer-free redundant symmetry wrappers left deferred after earlier #793 cleanup.
- Keep the two `@[simp]` specialization APIs that remain useful: `energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq` and `energyFormIntegral_coefficientSymmetricPart_zero_drift_swap_eq`.
- Doc-only Main-declaration cleanup for removed names; cores and retained simp lemmas untouched in proof.

## What (8 deletions)
Pointwise (`TauCeti/Analysis/PDE/SymmetricEnergy.lean`):
- `energyIntegrand_zero_drift_comm_on`
- `energyIntegrand_zero_drift_flip_eq_on`
- `energyIntegrand_one_zero_mass_flip_eq`

Integrated (`TauCeti/Analysis/PDE/EnergyForm/Integrated/Symmetry.lean`):
- `energyFormIntegral_zero_drift_comm_on`
- `energyFormIntegral_zero_drift_swap_eq_on`
- `energyFormIntegral_coefficientSymmetricPart_zero_drift_comm`
- `energyFormIntegral_one_zero_mass_comm`
- `energyFormIntegral_one_zero_mass_swap_eq`

## Why
- Consumer audit on current `main` (`9e45c55978e9fdedfeea495c93478e326fbdf1f2`): each deleted name is definition-only (plus own-module docs / sibling wrappers also deleted). Zero external Lean consumers.
- AGENTS.md: Tau Ceti does not preserve backwards compatibility. When declarations are deleted, do not retain anything whose only purpose is compatibility (aliases, wrapper declarations, deprecated shims).
- Retain the two `@[simp]` APIs above; all core transpose / `of_isSymm` / a.e. / `coefficientSymmetricPart_*` theorems remain.

## Scope
- Two files only; deletion + Main-doc cleanup.
- No aliases, deprecations, new decls, Basic.lean edits, or proof rewrites of retained theorems.
- Cores untouched.

**Follow-up to #793**

Roadmap: PDE

This does not close #793. Of the original deferred set of 10, 8 are deleted here; the deferred list reduces to the 2 retained simp APIs.

## Verification
Local (Windows):
- `git rev-parse HEAD` before edit: `9e45c55978e9fdedfeea495c93478e326fbdf1f2` (main advanced past memo tip `d1c21376...`; re-audited on new tip).
- `git diff --check`: clean (no output).
- Post-edit `rg` for the 8 deleted names: zero matches.
- Retains + core `energyFormIntegral_zero_drift_comm_of_isSymm_ae` still present.
- `lake env lean` / full gates (`cache get`, `lake build`, axioms, module-system, `lint-env`): **not run locally** — disk full; toolchain extract failed with `There is not enough space on the disk. (os error 112)`. Rely on CI.

## Test plan
- [ ] CI build green on this branch
- [ ] Confirm CI lint-env / axioms / module-system pass
- [ ] Spot-check that the two `@[simp]` retains still typecheck in CI logs
