### PR TITLE
feat: prove general linear root subgroup relations

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Basic.lean
@@ -27,7 +27,7 @@ group"), in the same spirit as the multiplicative group `𝔾ₘ`.
   `SymmetricAlgebra R M →ₐ[R] A` is the additive monoid `M →ₗ[R] A`.
 * `TauCeti.AdditiveGroup.gaPointsMulEquiv`: the monoid of `A`-valued points of `𝔾ₐ` over `R`
   is the additive monoid of `A`.
-* `TauCeti.AdditiveGroup.gaPointMul`: multiplication of the parameters of two `𝔾ₐ`-points.
+* `TauCeti.AdditiveGroup.gaPointParamMul`: multiplication of the parameters of two `𝔾ₐ`-points.
 * `TauCeti.AdditiveGroup.pointsMulEquiv_mapValue`: the points equivalence is natural in the
   value algebra.
 
@@ -213,8 +213,8 @@ theorem mapValue_gaPointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (a : Multiplic
 `G`.
 
 This is not the convolution multiplication of `𝔾ₐ(A)`: convolution corresponds to addition,
-whereas `gaPointMul F G` records multiplication in the value algebra. -/
-noncomputable def gaPointMul
+whereas `gaPointParamMul F G` records multiplication in the value algebra. -/
+noncomputable def gaPointParamMul
     (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
     WithConv (SymmetricAlgebra R R →ₐ[R] A) :=
   (gaPointsMulEquiv (R := R) (A := A)).symm <|
@@ -222,88 +222,36 @@ noncomputable def gaPointMul
       (Multiplicative.toAdd (gaPointsMulEquiv F) *
         Multiplicative.toAdd (gaPointsMulEquiv G))
 
-/-- Under the points equivalence, `gaPointMul` is multiplication in the value algebra. -/
+/-- Under the points equivalence, `gaPointParamMul` is multiplication in the value algebra. -/
 @[simp]
-theorem gaPointsMulEquiv_gaPointMul
+theorem gaPointsMulEquiv_gaPointParamMul
     (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
-    gaPointsMulEquiv (gaPointMul F G) =
+    gaPointsMulEquiv (gaPointParamMul F G) =
       Multiplicative.ofAdd
         (Multiplicative.toAdd (gaPointsMulEquiv F) *
           Multiplicative.toAdd (gaPointsMulEquiv G)) := by
-  rw [gaPointMul, MulEquiv.apply_symm_apply]
+  rw [gaPointParamMul, MulEquiv.apply_symm_apply]
 
-/-- The value of `gaPointMul F G` on the additive coordinate is the product of the two original
+/-- The value of `gaPointParamMul F G` on the additive coordinate is the product of the two original
 coordinate values. -/
 @[simp]
-theorem gaPointMul_apply_ι (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
-    (gaPointMul F G).ofConv (ι R R 1) =
+theorem gaPointParamMul_apply_ι (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    (gaPointParamMul F G).ofConv (ι R R 1) =
       F.ofConv (ι R R 1) * G.ofConv (ι R R 1) := by
-  rw [← toAdd_gaPointsMulEquiv, gaPointsMulEquiv_gaPointMul, toAdd_ofAdd,
-    toAdd_gaPointsMulEquiv, toAdd_gaPointsMulEquiv]
+  simpa only [toAdd_gaPointsMulEquiv, toAdd_ofAdd] using
+    congrArg Multiplicative.toAdd (gaPointsMulEquiv_gaPointParamMul F G)
 
 /-- Multiplication of `𝔾ₐ`-point parameters is natural in the value algebra. -/
-theorem mapValue_gaPointMul (φ : A →ₐ[R] B)
+theorem mapValue_gaPointParamMul (φ : A →ₐ[R] B)
     (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
-    AlgHom.mapValue (H := SymmetricAlgebra R R) φ (gaPointMul F G) =
-      gaPointMul
+    AlgHom.mapValue (H := SymmetricAlgebra R R) φ (gaPointParamMul F G) =
+      gaPointParamMul
         (AlgHom.mapValue (H := SymmetricAlgebra R R) φ F)
         (AlgHom.mapValue (H := SymmetricAlgebra R R) φ G) := by
-  rw [gaPointMul, mapValue_gaPointsMulEquiv_symm_apply, gaPointMul,
+  rw [gaPointParamMul, mapValue_gaPointsMulEquiv_symm_apply, gaPointParamMul,
     toAdd_gaPointsMulEquiv_mapValue, toAdd_gaPointsMulEquiv_mapValue]
   exact congrArg (gaPointsMulEquiv (R := R) (A := B)).symm
     (congrArg Multiplicative.ofAdd (map_mul φ _ _))
-
-/-- Multiplying the zero parameter on the left gives the zero parameter; the zero point is the
-convolution identity. -/
-@[simp]
-theorem gaPointMul_one_left (F : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
-    gaPointMul 1 F = 1 := by
-  apply (gaPointsMulEquiv (R := R) (A := A)).injective
-  simp
-
-/-- Multiplying the zero parameter on the right gives the zero parameter; the zero point is the
-convolution identity. -/
-@[simp]
-theorem gaPointMul_one_right (F : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
-    gaPointMul F 1 = 1 := by
-  apply (gaPointsMulEquiv (R := R) (A := A)).injective
-  simp
-
-/-- Multiplication of `𝔾ₐ`-point parameters is commutative. -/
-theorem gaPointMul_comm (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
-    gaPointMul F G = gaPointMul G F := by
-  apply (gaPointsMulEquiv (R := R) (A := A)).injective
-  simp only [gaPointsMulEquiv_gaPointMul]
-  exact congrArg Multiplicative.ofAdd (mul_comm _ _)
-
-/-- Multiplication of `𝔾ₐ`-point parameters is associative. -/
-theorem gaPointMul_assoc (F G K : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
-    gaPointMul (gaPointMul F G) K = gaPointMul F (gaPointMul G K) := by
-  apply (gaPointsMulEquiv (R := R) (A := A)).injective
-  simp only [gaPointsMulEquiv_gaPointMul, toAdd_ofAdd]
-  exact congrArg Multiplicative.ofAdd (mul_assoc _ _ _)
-
-/-- Multiplication of `𝔾ₐ`-point parameters distributes over convolution in the left input. -/
-@[simp]
-theorem gaPointMul_mul_left (F G K : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
-    gaPointMul (F * G) K = gaPointMul F K * gaPointMul G K := by
-  apply (gaPointsMulEquiv (R := R) (A := A)).injective
-  simpa only [gaPointsMulEquiv_gaPointMul, map_mul, toAdd_mul, ofAdd_add] using
-    congrArg Multiplicative.ofAdd (add_mul
-      (Multiplicative.toAdd (gaPointsMulEquiv F))
-      (Multiplicative.toAdd (gaPointsMulEquiv G))
-      (Multiplicative.toAdd (gaPointsMulEquiv K)))
-
-/-- Multiplication of `𝔾ₐ`-point parameters distributes over convolution in the right input. -/
-@[simp]
-theorem gaPointMul_mul_right (F G K : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
-    gaPointMul F (G * K) = gaPointMul F G * gaPointMul F K := by
-  apply (gaPointsMulEquiv (R := R) (A := A)).injective
-  simpa only [gaPointsMulEquiv_gaPointMul, map_mul, toAdd_mul, ofAdd_add] using
-    congrArg Multiplicative.ofAdd (mul_add
-      (Multiplicative.toAdd (gaPointsMulEquiv F))
-      (Multiplicative.toAdd (gaPointsMulEquiv G))
-      (Multiplicative.toAdd (gaPointsMulEquiv K)))
 
 end Ga
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Basic.lean
@@ -27,6 +27,7 @@ group"), in the same spirit as the multiplicative group `𝔾ₘ`.
   `SymmetricAlgebra R M →ₐ[R] A` is the additive monoid `M →ₗ[R] A`.
 * `TauCeti.AdditiveGroup.gaPointsMulEquiv`: the monoid of `A`-valued points of `𝔾ₐ` over `R`
   is the additive monoid of `A`.
+* `TauCeti.AdditiveGroup.gaPointMul`: multiplication of the parameters of two `𝔾ₐ`-points.
 * `TauCeti.AdditiveGroup.pointsMulEquiv_mapValue`: the points equivalence is natural in the
   value algebra.
 
@@ -207,6 +208,102 @@ theorem mapValue_gaPointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (a : Multiplic
   rw [(gaPointsMulEquiv (R := R) (A := A)).apply_symm_apply a]
   exact ((gaPointsMulEquiv (R := R) (A := B)).apply_symm_apply
     (Multiplicative.ofAdd (φ (Multiplicative.toAdd a)))).symm
+
+/-- The `A`-valued point of `𝔾ₐ` whose parameter is the product of the parameters of `F` and
+`G`.
+
+This is not the convolution multiplication of `𝔾ₐ(A)`: convolution corresponds to addition,
+whereas `gaPointMul F G` records multiplication in the value algebra. -/
+noncomputable def gaPointMul
+    (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    WithConv (SymmetricAlgebra R R →ₐ[R] A) :=
+  (gaPointsMulEquiv (R := R) (A := A)).symm <|
+    Multiplicative.ofAdd
+      (Multiplicative.toAdd (gaPointsMulEquiv F) *
+        Multiplicative.toAdd (gaPointsMulEquiv G))
+
+/-- Under the points equivalence, `gaPointMul` is multiplication in the value algebra. -/
+@[simp]
+theorem gaPointsMulEquiv_gaPointMul
+    (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    gaPointsMulEquiv (gaPointMul F G) =
+      Multiplicative.ofAdd
+        (Multiplicative.toAdd (gaPointsMulEquiv F) *
+          Multiplicative.toAdd (gaPointsMulEquiv G)) := by
+  rw [gaPointMul, MulEquiv.apply_symm_apply]
+
+/-- The value of `gaPointMul F G` on the additive coordinate is the product of the two original
+coordinate values. -/
+@[simp]
+theorem gaPointMul_apply_ι (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    (gaPointMul F G).ofConv (ι R R 1) =
+      F.ofConv (ι R R 1) * G.ofConv (ι R R 1) := by
+  rw [← toAdd_gaPointsMulEquiv, gaPointsMulEquiv_gaPointMul, toAdd_ofAdd,
+    toAdd_gaPointsMulEquiv, toAdd_gaPointsMulEquiv]
+
+/-- Multiplication of `𝔾ₐ`-point parameters is natural in the value algebra. -/
+theorem mapValue_gaPointMul (φ : A →ₐ[R] B)
+    (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    AlgHom.mapValue (H := SymmetricAlgebra R R) φ (gaPointMul F G) =
+      gaPointMul
+        (AlgHom.mapValue (H := SymmetricAlgebra R R) φ F)
+        (AlgHom.mapValue (H := SymmetricAlgebra R R) φ G) := by
+  rw [gaPointMul, mapValue_gaPointsMulEquiv_symm_apply, gaPointMul,
+    toAdd_gaPointsMulEquiv_mapValue, toAdd_gaPointsMulEquiv_mapValue]
+  exact congrArg (gaPointsMulEquiv (R := R) (A := B)).symm
+    (congrArg Multiplicative.ofAdd (map_mul φ _ _))
+
+/-- Multiplying the zero parameter on the left gives the zero parameter; the zero point is the
+convolution identity. -/
+@[simp]
+theorem gaPointMul_one_left (F : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    gaPointMul 1 F = 1 := by
+  apply (gaPointsMulEquiv (R := R) (A := A)).injective
+  simp
+
+/-- Multiplying the zero parameter on the right gives the zero parameter; the zero point is the
+convolution identity. -/
+@[simp]
+theorem gaPointMul_one_right (F : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    gaPointMul F 1 = 1 := by
+  apply (gaPointsMulEquiv (R := R) (A := A)).injective
+  simp
+
+/-- Multiplication of `𝔾ₐ`-point parameters is commutative. -/
+theorem gaPointMul_comm (F G : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    gaPointMul F G = gaPointMul G F := by
+  apply (gaPointsMulEquiv (R := R) (A := A)).injective
+  simp only [gaPointsMulEquiv_gaPointMul]
+  exact congrArg Multiplicative.ofAdd (mul_comm _ _)
+
+/-- Multiplication of `𝔾ₐ`-point parameters is associative. -/
+theorem gaPointMul_assoc (F G K : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    gaPointMul (gaPointMul F G) K = gaPointMul F (gaPointMul G K) := by
+  apply (gaPointsMulEquiv (R := R) (A := A)).injective
+  simp only [gaPointsMulEquiv_gaPointMul, toAdd_ofAdd]
+  exact congrArg Multiplicative.ofAdd (mul_assoc _ _ _)
+
+/-- Multiplication of `𝔾ₐ`-point parameters distributes over convolution in the left input. -/
+@[simp]
+theorem gaPointMul_mul_left (F G K : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    gaPointMul (F * G) K = gaPointMul F K * gaPointMul G K := by
+  apply (gaPointsMulEquiv (R := R) (A := A)).injective
+  simpa only [gaPointsMulEquiv_gaPointMul, map_mul, toAdd_mul, ofAdd_add] using
+    congrArg Multiplicative.ofAdd (add_mul
+      (Multiplicative.toAdd (gaPointsMulEquiv F))
+      (Multiplicative.toAdd (gaPointsMulEquiv G))
+      (Multiplicative.toAdd (gaPointsMulEquiv K)))
+
+/-- Multiplication of `𝔾ₐ`-point parameters distributes over convolution in the right input. -/
+@[simp]
+theorem gaPointMul_mul_right (F G K : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    gaPointMul F (G * K) = gaPointMul F G * gaPointMul F K := by
+  apply (gaPointsMulEquiv (R := R) (A := A)).injective
+  simpa only [gaPointsMulEquiv_gaPointMul, map_mul, toAdd_mul, ofAdd_add] using
+    congrArg Multiplicative.ofAdd (mul_add
+      (Multiplicative.toAdd (gaPointsMulEquiv F))
+      (Multiplicative.toAdd (gaPointsMulEquiv G))
+      (Multiplicative.toAdd (gaPointsMulEquiv K)))
 
 end Ga
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ChevalleyRelations.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ChevalleyRelations.lean
@@ -27,11 +27,13 @@ For three distinct indices, the chaining relation is
 
 The product `cd` is multiplication in the value algebra, not the convolution product on
 `𝔾ₐ(A)`, which corresponds to addition. The additive-group operation
-`TauCeti.AdditiveGroup.gaPointMul` packages this distinction and is natural in the value algebra.
+`TauCeti.AdditiveGroup.gaPointParamMul` packages this distinction and is natural in the value
+algebra.
 
-These are the root-subgroup equations required by the pinned Chevalley--Demazure interface in
-Layer 9 of the ReductiveGroups roadmap, here verified for the worked example `GLₙ` over an
-arbitrary commutative base ring.
+This file supplies the commutator-relations part of the pinned Chevalley--Demazure interface from
+Layer 9 of the ReductiveGroups roadmap for the worked example `GLₙ` over an arbitrary commutative
+base ring. The pinning equations and the general Chevalley--Demazure construction are not covered
+here.
 
 ## Main declarations
 
@@ -61,13 +63,14 @@ variable {N : ℕ} {i j k l : Fin N}
 
 /-- Root-subgroup values at two non-chaining index pairs commute.
 
-The hypotheses `j ≠ k` and `l ≠ i` say that the corresponding roots do not add to a root;
-the remaining hypotheses ensure that both elementary matrices are root-subgroup values. -/
+The hypotheses `j ≠ k` and `l ≠ i` say that the sum of the corresponding roots is neither a root
+nor zero; the remaining hypotheses ensure that both elementary matrices are root-subgroup
+values. -/
 theorem commute_rootSubgroupPoints (hij : i ≠ j) (hkl : k ≠ l)
     (hjk : j ≠ k) (hli : l ≠ i)
     (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
     Commute (rootSubgroupPoints hij f) (rootSubgroupPoints hkl g) := by
-  rw [Commute]
+  rw [commute_iff_eq]
   apply (pointsMulEquiv (R := R) (A := A) N).injective
   rw [map_mul, map_mul, pointsMulEquiv_rootSubgroupPoints hij f,
     pointsMulEquiv_rootSubgroupPoints hkl g]
@@ -83,19 +86,19 @@ indices,
 ```
 
 The point on the right has parameter `cd` in the value algebra, as recorded by
-`AdditiveGroup.gaPointMul`. -/
+`AdditiveGroup.gaPointParamMul`. -/
 theorem commutatorElement_rootSubgroupPoints (hij : i ≠ j) (hjl : j ≠ l)
     (hil : i ≠ l)
     (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
     ⁅rootSubgroupPoints hij f, rootSubgroupPoints hjl g⁆ =
-      rootSubgroupPoints hil (AdditiveGroup.gaPointMul f g) := by
+      rootSubgroupPoints hil (AdditiveGroup.gaPointParamMul f g) := by
   apply (pointsMulEquiv (R := R) (A := A) N).injective
   rw [map_commutatorElement, pointsMulEquiv_rootSubgroupPoints,
     pointsMulEquiv_rootSubgroupPoints, pointsMulEquiv_rootSubgroupPoints]
   rw [AdditiveGroup.toAdd_gaPointsMulEquiv f,
     AdditiveGroup.toAdd_gaPointsMulEquiv g,
-    AdditiveGroup.toAdd_gaPointsMulEquiv (AdditiveGroup.gaPointMul f g),
-    AdditiveGroup.gaPointMul_apply_ι]
+    AdditiveGroup.toAdd_gaPointsMulEquiv (AdditiveGroup.gaPointParamMul f g),
+    AdditiveGroup.gaPointParamMul_apply_ι]
   exact commutatorElement_transvectionUnit hij hjl hil _ _
 
 end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ChevalleyRelations.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ChevalleyRelations.lean
@@ -1,0 +1,200 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.RootSubgroup
+
+/-!
+# Chevalley relations for the root subgroups of the general linear group
+
+For distinct indices, `TauCeti.GeneralLinear.rootSubgroupPoints` identifies an additive-group
+point of parameter `c` with the elementary matrix
+
+```text
+xᵢⱼ(c) = 1 + c Eᵢⱼ.
+```
+
+This file transports the type-A Chevalley commutator relations from elementary matrices to the
+functor of points of `GLₙ`. If two index pairs do not chain, their root-subgroup values commute.
+For three distinct indices, the chaining relation is
+
+```text
+⁅xᵢⱼ(c), xⱼₗ(d)⁆ = xᵢₗ(cd).
+```
+
+The product `cd` is multiplication in the value algebra, not the convolution product on
+`𝔾ₐ(A)`, which corresponds to addition. The auxiliary point
+`TauCeti.GeneralLinear.rootParameterProduct` packages this distinction and is natural in the
+value algebra.
+
+These are the root-subgroup equations required by the pinned Chevalley--Demazure interface in
+Layer 9 of the ReductiveGroups roadmap, here verified for the worked example `GLₙ` over an
+arbitrary commutative base ring.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.rootParameterProduct`: the additive-group point whose parameter is the
+  product of the parameters of two given points.
+* `TauCeti.GeneralLinear.commute_rootSubgroupPoints`: root subgroups at non-chaining index pairs
+  commute.
+* `TauCeti.GeneralLinear.commutatorElement_rootSubgroupPoints`: the type-A Chevalley commutator
+  relation on algebra-valued points.
+* `TauCeti.GeneralLinear.commutatorElement_rootSubgroupPoints_reverse`: the reverse-chaining
+  relation, with the inverse parameter encoding the structure constant `-1`.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type* (1972), §11.3.
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), §26.3.
+-/
+
+public section
+
+open WithConv
+open scoped commutatorElement
+
+namespace TauCeti.GeneralLinear
+
+universe u w x
+
+variable {R : Type u} [CommRing R]
+variable {A : Type w} [CommRing A] [Algebra R A]
+variable {B : Type x} [CommRing B] [Algebra R B]
+variable {N : ℕ} {i j k l : Fin N}
+
+/-- The `A`-valued point of `𝔾ₐ` whose parameter is the product of the parameters of `f` and
+`g`.
+
+This is not the group multiplication of `𝔾ₐ(A)`: convolution corresponds to addition, whereas
+`rootParameterProduct f g` records multiplication in the value algebra. It is the parameter on
+the right-hand side of the type-A Chevalley commutator relation. -/
+noncomputable def rootParameterProduct
+    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A) :=
+  (AdditiveGroup.gaPointsMulEquiv (R := R) (A := A)).symm <|
+    Multiplicative.ofAdd
+      (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv f) *
+        Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv g))
+
+/-- The value of `rootParameterProduct f g` on the additive coordinate is the product of the two
+original coordinate values. -/
+@[simp]
+theorem rootParameterProduct_apply_ι
+    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    (rootParameterProduct f g).ofConv (SymmetricAlgebra.ι R R 1) =
+      f.ofConv (SymmetricAlgebra.ι R R 1) *
+        g.ofConv (SymmetricAlgebra.ι R R 1) := by
+  rw [← AdditiveGroup.toAdd_gaPointsMulEquiv, rootParameterProduct,
+    MulEquiv.apply_symm_apply]
+  rw [toAdd_ofAdd, AdditiveGroup.toAdd_gaPointsMulEquiv f,
+    AdditiveGroup.toAdd_gaPointsMulEquiv g]
+
+/-- Multiplication of root parameters is natural in the value algebra. -/
+theorem mapValue_rootParameterProduct (phi : A →ₐ[R] B)
+    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi
+        (rootParameterProduct f g) =
+      rootParameterProduct
+        (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f)
+        (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi g) := by
+  apply (AdditiveGroup.gaPointsMulEquiv (R := R) (A := B)).injective
+  have h :
+      Multiplicative.toAdd
+          (AdditiveGroup.gaPointsMulEquiv
+            (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi
+              (rootParameterProduct f g))) =
+        Multiplicative.toAdd
+          (AdditiveGroup.gaPointsMulEquiv
+            (rootParameterProduct
+              (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f)
+              (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi g))) := by
+    calc
+      Multiplicative.toAdd
+          (AdditiveGroup.gaPointsMulEquiv
+            (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi
+              (rootParameterProduct f g))) =
+          phi (Multiplicative.toAdd
+            (AdditiveGroup.gaPointsMulEquiv (rootParameterProduct f g))) :=
+        AdditiveGroup.toAdd_gaPointsMulEquiv_mapValue phi _
+      _ = phi (f.ofConv (SymmetricAlgebra.ι R R 1) *
+          g.ofConv (SymmetricAlgebra.ι R R 1)) := by
+        rw [AdditiveGroup.toAdd_gaPointsMulEquiv, rootParameterProduct_apply_ι]
+      _ = phi (f.ofConv (SymmetricAlgebra.ι R R 1)) *
+          phi (g.ofConv (SymmetricAlgebra.ι R R 1)) := map_mul phi _ _
+      _ = (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f).ofConv
+            (SymmetricAlgebra.ι R R 1) *
+          (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi g).ofConv
+            (SymmetricAlgebra.ι R R 1) := rfl
+      _ = Multiplicative.toAdd
+          (AdditiveGroup.gaPointsMulEquiv
+            (rootParameterProduct
+              (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f)
+              (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi g))) := by
+        rw [AdditiveGroup.toAdd_gaPointsMulEquiv, rootParameterProduct_apply_ι]
+  simpa only [ofAdd_toAdd] using congrArg Multiplicative.ofAdd h
+
+/-- Root-subgroup values at two non-chaining index pairs commute.
+
+The hypotheses `j ≠ k` and `l ≠ i` say that the corresponding roots do not add to a root;
+the remaining hypotheses ensure that both elementary matrices are root-subgroup values. -/
+theorem commute_rootSubgroupPoints (hij : i ≠ j) (hkl : k ≠ l)
+    (hjk : j ≠ k) (hli : l ≠ i)
+    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    Commute (rootSubgroupPoints hij f) (rootSubgroupPoints hkl g) := by
+  rw [Commute]
+  apply (pointsMulEquiv (R := R) (A := A) N).injective
+  rw [map_mul, map_mul, pointsMulEquiv_rootSubgroupPoints hij f,
+    pointsMulEquiv_rootSubgroupPoints hkl g]
+  exact (commute_transvectionUnit hij hkl hjk hli
+    (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv f))
+    (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv g))).eq
+
+/-- **The type-A Chevalley commutator relation on algebra-valued points.** For three distinct
+indices,
+
+```text
+⁅xᵢⱼ(c), xⱼₗ(d)⁆ = xᵢₗ(cd).
+```
+
+The point on the right has parameter `cd` in the value algebra, as recorded by
+`rootParameterProduct`. -/
+theorem commutatorElement_rootSubgroupPoints (hij : i ≠ j) (hjl : j ≠ l)
+    (hil : i ≠ l)
+    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    ⁅rootSubgroupPoints hij f, rootSubgroupPoints hjl g⁆ =
+      rootSubgroupPoints hil (rootParameterProduct f g) := by
+  apply (pointsMulEquiv (R := R) (A := A) N).injective
+  rw [map_commutatorElement, pointsMulEquiv_rootSubgroupPoints,
+    pointsMulEquiv_rootSubgroupPoints, pointsMulEquiv_rootSubgroupPoints]
+  rw [AdditiveGroup.toAdd_gaPointsMulEquiv f,
+    AdditiveGroup.toAdd_gaPointsMulEquiv g,
+    AdditiveGroup.toAdd_gaPointsMulEquiv (rootParameterProduct f g),
+    rootParameterProduct_apply_ι]
+  exact commutatorElement_transvectionUnit hij hjl hil _ _
+
+/-- **The reverse-chaining type-A Chevalley commutator relation.** For three distinct indices,
+
+```text
+⁅xᵢⱼ(c), xₖᵢ(d)⁆ = xₖⱼ(-dc).
+```
+
+The inverse on the right negates the parameter because inversion in `𝔾ₐ(A)` is negation. This is
+the orientation of the type-A relation whose structure constant is `-1`. -/
+theorem commutatorElement_rootSubgroupPoints_reverse (hij : i ≠ j) (hki : k ≠ i)
+    (hkj : k ≠ j)
+    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    ⁅rootSubgroupPoints hij f, rootSubgroupPoints hki g⁆ =
+      rootSubgroupPoints hkj (rootParameterProduct g f)⁻¹ := by
+  calc
+    ⁅rootSubgroupPoints hij f, rootSubgroupPoints hki g⁆ =
+        ⁅rootSubgroupPoints hki g, rootSubgroupPoints hij f⁆⁻¹ :=
+      (commutatorElement_inv _ _).symm
+    _ = (rootSubgroupPoints hkj (rootParameterProduct g f))⁻¹ := by
+      rw [commutatorElement_rootSubgroupPoints hki hij hkj g f]
+    _ = rootSubgroupPoints hkj (rootParameterProduct g f)⁻¹ :=
+      (map_inv (rootSubgroupPoints (R := R) (A := A) hkj) _).symm
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ChevalleyRelations.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ChevalleyRelations.lean
@@ -26,9 +26,8 @@ For three distinct indices, the chaining relation is
 ```
 
 The product `cd` is multiplication in the value algebra, not the convolution product on
-`𝔾ₐ(A)`, which corresponds to addition. The auxiliary point
-`TauCeti.GeneralLinear.rootParameterProduct` packages this distinction and is natural in the
-value algebra.
+`𝔾ₐ(A)`, which corresponds to addition. The additive-group operation
+`TauCeti.AdditiveGroup.gaPointMul` packages this distinction and is natural in the value algebra.
 
 These are the root-subgroup equations required by the pinned Chevalley--Demazure interface in
 Layer 9 of the ReductiveGroups roadmap, here verified for the worked example `GLₙ` over an
@@ -36,8 +35,6 @@ arbitrary commutative base ring.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinear.rootParameterProduct`: the additive-group point whose parameter is the
-  product of the parameters of two given points.
 * `TauCeti.GeneralLinear.commute_rootSubgroupPoints`: root subgroups at non-chaining index pairs
   commute.
 * `TauCeti.GeneralLinear.commutatorElement_rootSubgroupPoints`: the type-A Chevalley commutator
@@ -58,83 +55,11 @@ open scoped commutatorElement
 
 namespace TauCeti.GeneralLinear
 
-universe u w x
+universe u w
 
 variable {R : Type u} [CommRing R]
 variable {A : Type w} [CommRing A] [Algebra R A]
-variable {B : Type x} [CommRing B] [Algebra R B]
 variable {N : ℕ} {i j k l : Fin N}
-
-/-- The `A`-valued point of `𝔾ₐ` whose parameter is the product of the parameters of `f` and
-`g`.
-
-This is not the group multiplication of `𝔾ₐ(A)`: convolution corresponds to addition, whereas
-`rootParameterProduct f g` records multiplication in the value algebra. It is the parameter on
-the right-hand side of the type-A Chevalley commutator relation. -/
-noncomputable def rootParameterProduct
-    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
-    WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A) :=
-  (AdditiveGroup.gaPointsMulEquiv (R := R) (A := A)).symm <|
-    Multiplicative.ofAdd
-      (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv f) *
-        Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv g))
-
-/-- The value of `rootParameterProduct f g` on the additive coordinate is the product of the two
-original coordinate values. -/
-@[simp]
-theorem rootParameterProduct_apply_ι
-    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
-    (rootParameterProduct f g).ofConv (SymmetricAlgebra.ι R R 1) =
-      f.ofConv (SymmetricAlgebra.ι R R 1) *
-        g.ofConv (SymmetricAlgebra.ι R R 1) := by
-  rw [← AdditiveGroup.toAdd_gaPointsMulEquiv, rootParameterProduct,
-    MulEquiv.apply_symm_apply]
-  rw [toAdd_ofAdd, AdditiveGroup.toAdd_gaPointsMulEquiv f,
-    AdditiveGroup.toAdd_gaPointsMulEquiv g]
-
-/-- Multiplication of root parameters is natural in the value algebra. -/
-theorem mapValue_rootParameterProduct (phi : A →ₐ[R] B)
-    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
-    AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi
-        (rootParameterProduct f g) =
-      rootParameterProduct
-        (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f)
-        (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi g) := by
-  apply (AdditiveGroup.gaPointsMulEquiv (R := R) (A := B)).injective
-  have h :
-      Multiplicative.toAdd
-          (AdditiveGroup.gaPointsMulEquiv
-            (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi
-              (rootParameterProduct f g))) =
-        Multiplicative.toAdd
-          (AdditiveGroup.gaPointsMulEquiv
-            (rootParameterProduct
-              (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f)
-              (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi g))) := by
-    calc
-      Multiplicative.toAdd
-          (AdditiveGroup.gaPointsMulEquiv
-            (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi
-              (rootParameterProduct f g))) =
-          phi (Multiplicative.toAdd
-            (AdditiveGroup.gaPointsMulEquiv (rootParameterProduct f g))) :=
-        AdditiveGroup.toAdd_gaPointsMulEquiv_mapValue phi _
-      _ = phi (f.ofConv (SymmetricAlgebra.ι R R 1) *
-          g.ofConv (SymmetricAlgebra.ι R R 1)) := by
-        rw [AdditiveGroup.toAdd_gaPointsMulEquiv, rootParameterProduct_apply_ι]
-      _ = phi (f.ofConv (SymmetricAlgebra.ι R R 1)) *
-          phi (g.ofConv (SymmetricAlgebra.ι R R 1)) := map_mul phi _ _
-      _ = (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f).ofConv
-            (SymmetricAlgebra.ι R R 1) *
-          (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi g).ofConv
-            (SymmetricAlgebra.ι R R 1) := rfl
-      _ = Multiplicative.toAdd
-          (AdditiveGroup.gaPointsMulEquiv
-            (rootParameterProduct
-              (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f)
-              (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi g))) := by
-        rw [AdditiveGroup.toAdd_gaPointsMulEquiv, rootParameterProduct_apply_ι]
-  simpa only [ofAdd_toAdd] using congrArg Multiplicative.ofAdd h
 
 /-- Root-subgroup values at two non-chaining index pairs commute.
 
@@ -160,19 +85,19 @@ indices,
 ```
 
 The point on the right has parameter `cd` in the value algebra, as recorded by
-`rootParameterProduct`. -/
+`AdditiveGroup.gaPointMul`. -/
 theorem commutatorElement_rootSubgroupPoints (hij : i ≠ j) (hjl : j ≠ l)
     (hil : i ≠ l)
     (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
     ⁅rootSubgroupPoints hij f, rootSubgroupPoints hjl g⁆ =
-      rootSubgroupPoints hil (rootParameterProduct f g) := by
+      rootSubgroupPoints hil (AdditiveGroup.gaPointMul f g) := by
   apply (pointsMulEquiv (R := R) (A := A) N).injective
   rw [map_commutatorElement, pointsMulEquiv_rootSubgroupPoints,
     pointsMulEquiv_rootSubgroupPoints, pointsMulEquiv_rootSubgroupPoints]
   rw [AdditiveGroup.toAdd_gaPointsMulEquiv f,
     AdditiveGroup.toAdd_gaPointsMulEquiv g,
-    AdditiveGroup.toAdd_gaPointsMulEquiv (rootParameterProduct f g),
-    rootParameterProduct_apply_ι]
+    AdditiveGroup.toAdd_gaPointsMulEquiv (AdditiveGroup.gaPointMul f g),
+    AdditiveGroup.gaPointMul_apply_ι]
   exact commutatorElement_transvectionUnit hij hjl hil _ _
 
 /-- **The reverse-chaining type-A Chevalley commutator relation.** For three distinct indices,
@@ -187,14 +112,14 @@ theorem commutatorElement_rootSubgroupPoints_reverse (hij : i ≠ j) (hki : k �
     (hkj : k ≠ j)
     (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
     ⁅rootSubgroupPoints hij f, rootSubgroupPoints hki g⁆ =
-      rootSubgroupPoints hkj (rootParameterProduct g f)⁻¹ := by
+      rootSubgroupPoints hkj (AdditiveGroup.gaPointMul g f)⁻¹ := by
   calc
     ⁅rootSubgroupPoints hij f, rootSubgroupPoints hki g⁆ =
         ⁅rootSubgroupPoints hki g, rootSubgroupPoints hij f⁆⁻¹ :=
       (commutatorElement_inv _ _).symm
-    _ = (rootSubgroupPoints hkj (rootParameterProduct g f))⁻¹ := by
+    _ = (rootSubgroupPoints hkj (AdditiveGroup.gaPointMul g f))⁻¹ := by
       rw [commutatorElement_rootSubgroupPoints hki hij hkj g f]
-    _ = rootSubgroupPoints hkj (rootParameterProduct g f)⁻¹ :=
+    _ = rootSubgroupPoints hkj (AdditiveGroup.gaPointMul g f)⁻¹ :=
       (map_inv (rootSubgroupPoints (R := R) (A := A) hkj) _).symm
 
 end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ChevalleyRelations.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ChevalleyRelations.lean
@@ -39,8 +39,6 @@ arbitrary commutative base ring.
   commute.
 * `TauCeti.GeneralLinear.commutatorElement_rootSubgroupPoints`: the type-A Chevalley commutator
   relation on algebra-valued points.
-* `TauCeti.GeneralLinear.commutatorElement_rootSubgroupPoints_reverse`: the reverse-chaining
-  relation, with the inverse parameter encoding the structure constant `-1`.
 
 ## References
 
@@ -99,27 +97,5 @@ theorem commutatorElement_rootSubgroupPoints (hij : i ≠ j) (hjl : j ≠ l)
     AdditiveGroup.toAdd_gaPointsMulEquiv (AdditiveGroup.gaPointMul f g),
     AdditiveGroup.gaPointMul_apply_ι]
   exact commutatorElement_transvectionUnit hij hjl hil _ _
-
-/-- **The reverse-chaining type-A Chevalley commutator relation.** For three distinct indices,
-
-```text
-⁅xᵢⱼ(c), xₖᵢ(d)⁆ = xₖⱼ(-dc).
-```
-
-The inverse on the right negates the parameter because inversion in `𝔾ₐ(A)` is negation. This is
-the orientation of the type-A relation whose structure constant is `-1`. -/
-theorem commutatorElement_rootSubgroupPoints_reverse (hij : i ≠ j) (hki : k ≠ i)
-    (hkj : k ≠ j)
-    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
-    ⁅rootSubgroupPoints hij f, rootSubgroupPoints hki g⁆ =
-      rootSubgroupPoints hkj (AdditiveGroup.gaPointMul g f)⁻¹ := by
-  calc
-    ⁅rootSubgroupPoints hij f, rootSubgroupPoints hki g⁆ =
-        ⁅rootSubgroupPoints hki g, rootSubgroupPoints hij f⁆⁻¹ :=
-      (commutatorElement_inv _ _).symm
-    _ = (rootSubgroupPoints hkj (AdditiveGroup.gaPointMul g f))⁻¹ := by
-      rw [commutatorElement_rootSubgroupPoints hki hij hkj g f]
-    _ = rootSubgroupPoints hkj (AdditiveGroup.gaPointMul g f)⁻¹ :=
-      (map_inv (rootSubgroupPoints (R := R) (A := A) hkj) _).symm
 
 end TauCeti.GeneralLinear


### PR DESCRIPTION
This PR transports the type-A Chevalley commutator equations from elementary matrices to the functor-of-points root subgroup morphisms of `GLₙ`, and packages multiplication of additive-group point parameters naturally in the value algebra. It advances the exact Layer 9 **Root subgroup maps** target in `TauCetiRoadmap/ReductiveGroups/README.md`, where the required pinned Chevalley--Demazure interface includes `x_α : 𝔾ₐ → G` together with the Chevalley commutator relations and pinning equations.

The new API proves that non-chaining root subgroup values commute, proves the forward three-index type-A commutator relation, and proves that the product parameter commutes with change of value algebra. The reverse orientation and its `-1` structure constant follow from the forward relation via the generic commutator-inverse identity, so they are not duplicated as a separate declaration. This is the most direct current step because the `GLₙ` root subgroup morphism and the underlying matrix transvection identities are already merged, while this functor-of-points relation layer was still absent.

After this PR, Layer 9 still needs the general root subgroup and pinning interface for the explicit Chevalley--Demazure construction, its base-change and pinned-isomorphism results, and the special-isogeny analysis.

The proofs reuse the existing Tau Ceti `pointsMulEquiv`, `rootSubgroupPoints`, `commute_transvectionUnit`, and `commutatorElement_transvectionUnit` APIs. No Mathlib infrastructure is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"general-linear-root-subgroup-commutator-relations"}-->

🤖 Prepared with Codex