### PR TITLE
feat: add Fredholm local normal form

### DIFF
--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Fredholm.Basic
-public import Mathlib.Analysis.Calculus.Implicit
-import Mathlib.Analysis.Calculus.FDeriv.OfCompLeft
+public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.FDeriv
+import Mathlib.Analysis.Calculus.FDeriv.Prod
 
 /-!
 # Local normal form of a Fredholm map
@@ -15,20 +15,22 @@ This file gives the Lyapunov--Schmidt finite-dimensional reduction of a nonlinea
 where its derivative is Fredholm. A Fredholm package splits the domain and codomain into
 essential parts, on which the derivative is invertible, and finite-dimensional inessential
 parts. Projecting the nonlinear map to the essential codomain and retaining the inessential
-domain coordinate gives a local homeomorphism. In those coordinates the original map has the
-form
+domain coordinate gives a local homeomorphism. This is the first-order, topological part of the
+finite-dimensional reduction; applying Sard additionally requires neighborhood `C^k` regularity
+of the chart and obstruction under corresponding hypotheses on the original map. In these
+coordinates the original map has the form
 
 `(r, k) ↦ r + q(r, k)`,
 
 where `q` takes values in the finite-dimensional codomain complement. Thus all failure of
 surjectivity is confined to the finite-dimensional codomain complement; after fixing `r`, the
-remaining variable `k` also ranges over a finite-dimensional space. This is the local reduction
-used in the proof of Sard--Smale in Lane F0 of the analytic Heegaard Floer roadmap.
+remaining variable `k` also ranges over a finite-dimensional space. This is the normal-form
+ingredient of the Sard--Smale argument in Lane F0 of the analytic Heegaard Floer roadmap.
 
 The construction follows S. Smale, *An infinite dimensional version of Sard's theorem*,
 Amer. J. Math. 87 (1965), 861--866, and McDuff--Salamon, *J-holomorphic Curves and Symplectic
 Topology*, Appendix A. The local chart is Mathlib's
-`ImplicitFunctionData.toOpenPartialHomeomorph`; the linear splittings are Mathlib's
+`HasStrictFDerivAt.toOpenPartialHomeomorph`; the linear splittings are Mathlib's
 `ContinuousLinearMap.FredholmPackage`.
 
 ## Main declarations
@@ -36,8 +38,6 @@ Topology*, Appendix A. The local chart is Mathlib's
 * `ContinuousLinearMap.FredholmPackage.normalFormEquivL`: the linear coordinate change
   determined by a Fredholm package.
 * `ContinuousLinearMap.FredholmPackage.normalFormMap`: the nonlinear coordinate map.
-* `ContinuousLinearMap.FredholmPackage.normalFormImplicitFunctionData`: the corresponding data
-  for Mathlib's implicit function theorem.
 * `ContinuousLinearMap.FredholmPackage.normalFormOpenPartialHomeomorph`: the local homeomorphism
   defined by that map.
 * `ContinuousLinearMap.FredholmPackage.obstructionMap`: the remainder valued in the
@@ -56,15 +56,10 @@ open Set
 
 namespace ContinuousLinearMap.FredholmPackage
 
-variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
   [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
-  [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
   {T : E →L[𝕜] F} (pkg : ContinuousLinearMap.FredholmPackage T)
-
-local instance : FiniteDimensional 𝕜 pkg.decDom.X₀ := pkg.decDom.finite_X₀
-local instance : CompleteSpace pkg.decDom.X₀ := FiniteDimensional.complete 𝕜 _
-local instance : CompleteSpace pkg.decCodom.X₁ :=
-  pkg.decCodom.isTopCompl.isClosed.completeSpace_coe
 
 /-! ### Linear and nonlinear coordinates -/
 
@@ -76,7 +71,7 @@ def normalFormEquivL :
   (Submodule.prodEquivOfIsTopCompl _ _ pkg.decDom.isTopCompl).symm.trans
     (pkg.equiv.prodCongr (ContinuousLinearEquiv.refl 𝕜 pkg.decDom.X₀))
 
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+omit [CompleteSpace E] in
 /-- The essential coordinate of the linear normal form is the projection of `T x` to the
 essential codomain summand. -/
 @[simp]
@@ -84,7 +79,7 @@ theorem normalFormEquivL_fst (x : E) :
     (pkg.normalFormEquivL x).1 = pkg.decCodom.proj (T x) := by
   simp [normalFormEquivL, pkg.eq_equiv]
 
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+omit [CompleteSpace E] in
 /-- The inessential coordinate of the linear normal form is the projection of `x` to the
 finite-dimensional kernel summand. -/
 @[simp]
@@ -93,7 +88,7 @@ theorem normalFormEquivL_snd (x : E) :
       pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm x := by
   simp [normalFormEquivL]
 
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+omit [CompleteSpace E] in
 /-- The inverse linear normal-form coordinates reassemble the essential and inessential domain
 components. -/
 @[simp]
@@ -109,7 +104,7 @@ def normalFormMap (f : E → F) (a : E) (x : E) :
   (pkg.decCodom.proj (f x),
     pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm (x - a))
 
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+omit [CompleteSpace E] in
 /-- The two components of the nonlinear normal-form coordinate map. -/
 @[simp]
 theorem normalFormMap_apply (f : E → F) (a x : E) :
@@ -119,13 +114,13 @@ theorem normalFormMap_apply (f : E → F) (a x : E) :
   unfold normalFormMap
   rfl
 
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+omit [CompleteSpace E] in
 /-- The normal-form coordinate map evaluated at its base point. -/
 theorem normalFormMap_self (f : E → F) (a : E) :
     pkg.normalFormMap f a a = (pkg.decCodom.proj (f a), 0) := by
   simp [normalFormMap]
 
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+omit [CompleteSpace E] in
 /-- The derivative of the nonlinear normal-form coordinate map at any point is the product of the
 projected derivative of `f` and the fixed projection onto the inessential domain summand. -/
 theorem hasStrictFDerivAt_normalFormMap_of {f : E → F} {a x : E} {T' : E →L[𝕜] F}
@@ -142,7 +137,7 @@ theorem hasStrictFDerivAt_normalFormMap_of {f : E → F} {a x : E} {T' : E →L[
     simpa only [map_sub] using P.hasStrictFDerivAt.sub_const (P a)
   exact hfst.prodMk hsnd
 
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+omit [CompleteSpace E] in
 /-- The product of the two linear normal-form projections agrees with the explicit linear
 coordinate equivalence supplied by the Fredholm package. -/
 private theorem prod_projection_eq_normalFormEquivL :
@@ -153,7 +148,7 @@ private theorem prod_projection_eq_normalFormEquivL :
   · exact congrArg Subtype.val (pkg.normalFormEquivL_fst x).symm
   · exact congrArg Subtype.val (pkg.normalFormEquivL_snd x).symm
 
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+omit [CompleteSpace E] in
 /-- The derivative of the nonlinear normal-form coordinate map at its base point is precisely the
 linear coordinate equivalence associated to the Fredholm package. -/
 theorem hasStrictFDerivAt_normalFormMap {f : E → F} {a : E}
@@ -163,62 +158,34 @@ theorem hasStrictFDerivAt_normalFormMap {f : E → F} {a : E}
   (pkg.hasStrictFDerivAt_normalFormMap_of hf).congr_fderiv
     pkg.prod_projection_eq_normalFormEquivL
 
-/-- The implicit-function-theorem data underlying the Fredholm normal-form chart. -/
-def normalFormImplicitFunctionData {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
-    ImplicitFunctionData 𝕜 E pkg.decCodom.X₁ pkg.decDom.X₀ := by
-  let P := pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm
-  have hleft : pkg.decCodom.proj.comp T =
-      (pkg.equiv : pkg.decDom.X₁ →L[𝕜] pkg.decCodom.X₁).comp pkg.decDom.proj := by
-    ext x
-    simp [pkg.eq_equiv]
-  exact {
-    leftFun := fun x ↦ pkg.decCodom.proj (f x)
-    leftDeriv := pkg.decCodom.proj.comp T
-    rightFun := fun x ↦ P (x - a)
-    rightDeriv := P
-    pt := a
-    hasStrictFDerivAt_leftFun := pkg.decCodom.proj.hasStrictFDerivAt.comp a hf
-    hasStrictFDerivAt_rightFun := by
-      simpa only [map_sub] using P.hasStrictFDerivAt.sub_const (P a)
-    range_leftDeriv := by rw [hleft]; simp [LinearMap.range_comp]
-    range_rightDeriv := Submodule.range_projectionOntoL _
-    isCompl_ker := by
-      rw [hleft, show ((pkg.equiv : pkg.decDom.X₁ →L[𝕜] pkg.decCodom.X₁).comp
-          pkg.decDom.proj).ker = pkg.decDom.X₀ by simp [LinearMap.ker_comp],
-        Submodule.ker_projectionOntoL]
-      exact pkg.decDom.isTopCompl.isCompl.symm }
-
 /-- The local homeomorphism putting a map into Fredholm normal-form coordinates near a point where
 its derivative is represented by `pkg`. -/
 def normalFormOpenPartialHomeomorph {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
     OpenPartialHomeomorph E (pkg.decCodom.X₁ × pkg.decDom.X₀) :=
-  (pkg.normalFormImplicitFunctionData hf).toOpenPartialHomeomorph
+  (pkg.hasStrictFDerivAt_normalFormMap hf).toOpenPartialHomeomorph _
 
 /-- The Fredholm normal-form homeomorphism agrees with the normal-form coordinate map everywhere;
 its source only controls where the inverse laws apply. -/
 @[simp]
 theorem normalFormOpenPartialHomeomorph_apply {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) (x : E) :
-    pkg.normalFormOpenPartialHomeomorph hf x = pkg.normalFormMap f a x := by
-  rw [normalFormOpenPartialHomeomorph,
-    ImplicitFunctionData.toOpenPartialHomeomorph_apply]
-  unfold normalFormImplicitFunctionData normalFormMap
-  rfl
+    pkg.normalFormOpenPartialHomeomorph hf x = pkg.normalFormMap f a x :=
+  congrFun (HasStrictFDerivAt.toOpenPartialHomeomorph_coe _) x
 
 /-- The base point belongs to the source of the Fredholm normal-form homeomorphism. -/
 theorem mem_normalFormOpenPartialHomeomorph_source {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
     a ∈ (pkg.normalFormOpenPartialHomeomorph hf).source :=
-  (pkg.normalFormImplicitFunctionData hf).pt_mem_toOpenPartialHomeomorph_source
+  (pkg.hasStrictFDerivAt_normalFormMap hf).mem_toOpenPartialHomeomorph_source
 
 /-- The normal-form coordinate of the base point belongs to the target of the local
 homeomorphism. -/
 theorem normalFormOpenPartialHomeomorph_self_mem_target {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
     (pkg.decCodom.proj (f a), 0) ∈ (pkg.normalFormOpenPartialHomeomorph hf).target := by
-  rw [normalFormOpenPartialHomeomorph]
-  simpa only [normalFormImplicitFunctionData, map_sub, sub_self, map_zero] using
-    (pkg.normalFormImplicitFunctionData hf).map_pt_mem_toOpenPartialHomeomorph_target
+  rw [← pkg.normalFormMap_self f a, ← pkg.normalFormOpenPartialHomeomorph_apply hf]
+  exact (pkg.normalFormOpenPartialHomeomorph hf).map_source
+    (pkg.mem_normalFormOpenPartialHomeomorph_source hf)
 
 /-- Applying the inverse normal-form coordinate map to the coordinate of the base point returns
 the base point. -/
@@ -238,14 +205,25 @@ theorem normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
 
 /-- The inessential-codomain component of `f` in Fredholm normal-form coordinates. Its codomain is
 finite dimensional by `pkg.decCodom.finite_X₀`; fixing the first coordinate restricts it to a map
-between the finite-dimensional spaces `pkg.decDom.X₀` and `pkg.decCodom.X₀`, and that slice is
-what Sard's theorem is applied to in Sard--Smale. Values outside the target of
-`pkg.normalFormOpenPartialHomeomorph hf` are irrelevant, as for any `OpenPartialHomeomorph`
-inverse. -/
+between the finite-dimensional spaces `pkg.decDom.X₀` and `pkg.decCodom.X₀`. Applying Sard to
+that slice additionally requires suitable neighborhood regularity. Values outside the target of
+`pkg.normalFormOpenPartialHomeomorph hf` are irrelevant, as for any
+`OpenPartialHomeomorph` inverse. -/
 def obstructionMap {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
     (y : pkg.decCodom.X₁ × pkg.decDom.X₀) : pkg.decCodom.X₀ :=
   pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm
     (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y))
+
+/-- The obstruction map is the complementary-codomain projection of `f` after applying the
+inverse normal-form coordinates. -/
+@[simp]
+theorem obstructionMap_apply {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
+    (y : pkg.decCodom.X₁ × pkg.decDom.X₀) :
+    pkg.obstructionMap hf y =
+      pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm
+        (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y)) := by
+  unfold obstructionMap
+  rfl
 
 /-- In normal-form coordinates, the essential component of `f` is the first coordinate. -/
 theorem proj_apply_normalFormOpenPartialHomeomorph_symm {f : E → F} {a : E}
@@ -280,43 +258,14 @@ theorem hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self {f : E → F
       (pkg.normalFormEquivL.symm :
         (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)
       (pkg.decCodom.proj (f a), 0) := by
-  let φ := pkg.normalFormImplicitFunctionData hf
-  have hequiv :
-      φ.leftDeriv.equivProdOfSurjectiveOfIsCompl φ.rightDeriv φ.range_leftDeriv
-          φ.range_rightDeriv φ.isCompl_ker = pkg.normalFormEquivL := by
-    apply ContinuousLinearEquiv.ext
-    funext x
-    rw [ContinuousLinearMap.equivProdOfSurjectiveOfIsCompl_apply]
-    apply Prod.ext
-    · exact pkg.normalFormEquivL_fst x |>.symm
-    · exact pkg.normalFormEquivL_snd x |>.symm
-  have hinv := φ.hasStrictFDerivAt.to_localInverse
-  have hderiv :
-      ((φ.leftDeriv.equivProdOfSurjectiveOfIsCompl φ.rightDeriv φ.range_leftDeriv
-          φ.range_rightDeriv φ.isCompl_ker).symm :
-        (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E) =
-      (pkg.normalFormEquivL.symm : (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E) := by
-    rw [hequiv]
-  have hfun : HasStrictFDerivAt.localInverse φ.prodFun
-      (φ.leftDeriv.equivProdOfSurjectiveOfIsCompl φ.rightDeriv φ.range_leftDeriv
-        φ.range_rightDeriv φ.isCompl_ker) φ.pt φ.hasStrictFDerivAt =
-      φ.toOpenPartialHomeomorph.symm := by
-    funext y
-    rw [HasStrictFDerivAt.localInverse_def]
-    calc
-      _ = φ.implicitFunction y.1 y.2 := by
-        exact (congrFun (congrFun φ.implicitFunction_def y.1) y.2).symm
-      _ = _ := φ.implicitFunction_apply
-  have hpt : φ.prodFun φ.pt = (pkg.decCodom.proj (f a), 0) := by
-    rw [φ.prodFun_apply]
-    simp only [φ, normalFormImplicitFunctionData, map_sub, sub_self]
-  rw [hfun, hpt] at hinv
-  exact hinv.congr_fderiv hderiv
+  have hinv := (pkg.hasStrictFDerivAt_normalFormMap hf).to_localInverse
+  rw [HasStrictFDerivAt.localInverse_def] at hinv
+  simpa only [normalFormOpenPartialHomeomorph, normalFormMap_self] using hinv
 
-omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+omit [CompleteSpace E] in
 /-- The projection onto the inessential codomain summand vanishes on the image of the Fredholm
 operator. -/
-theorem projectionOntoL_X₀_apply_T (x : E) :
+theorem projectionOntoL_apply_eq_zero (x : E) :
     pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm (T x) = 0 :=
   Submodule.projectionOntoL_apply_eq_zero_of_mem_right _ (by
     rw [← pkg.range_eq]
@@ -346,11 +295,10 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
       (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)) = 0 := by
     apply ContinuousLinearMap.ext
     intro y
-    exact pkg.projectionOntoL_X₀_apply_T _
-  change HasStrictFDerivAt
-    (fun y ↦ P (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y))) 0
-      (pkg.decCodom.proj (f a), 0)
-  exact hcomp.congr_fderiv hzero
+    exact pkg.projectionOntoL_apply_eq_zero _
+  apply (hcomp.congr_fderiv hzero).congr_of_eventuallyEq
+  filter_upwards [] with y
+  exact (pkg.obstructionMap_apply hf y).symm
 
 end ContinuousLinearMap.FredholmPackage
 

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -262,15 +262,6 @@ theorem hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self {f : E → F
   rw [HasStrictFDerivAt.localInverse_def] at hinv
   simpa only [normalFormOpenPartialHomeomorph, normalFormMap_self] using hinv
 
-omit [CompleteSpace E] in
-/-- The projection onto the inessential codomain summand vanishes on the image of the Fredholm
-operator. -/
-theorem projectionOntoL_apply_eq_zero (x : E) :
-    pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm (T x) = 0 :=
-  Submodule.projectionOntoL_apply_eq_zero_of_mem_right _ (by
-    rw [← pkg.range_eq]
-    exact LinearMap.mem_range_self (T : E →ₗ[𝕜] F) x)
-
 /-- The finite-dimensional obstruction has zero derivative at the coordinate of the base point.
 This is the differential statement that the chosen essential coordinate absorbs the entire
 linear part of `f`. -/
@@ -295,7 +286,9 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
       (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)) = 0 := by
     apply ContinuousLinearMap.ext
     intro y
-    exact pkg.projectionOntoL_apply_eq_zero _
+    change P (T (pkg.normalFormEquivL.symm y)) = 0
+    apply Submodule.projectionOntoL_apply_eq_zero_of_mem_right
+    exact pkg.range_eq.le (LinearMap.mem_range_self (T : E →ₗ[𝕜] F) _)
   apply (hcomp.congr_fderiv hzero).congr_of_eventuallyEq
   filter_upwards [] with y
   exact (pkg.obstructionMap_apply hf y).symm

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -5,8 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Fredholm.Basic
-public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.FDeriv
-import Mathlib.Analysis.Calculus.FDeriv.Prod
+public import Mathlib.Analysis.Calculus.Implicit
 
 /-!
 # Local normal form of a Fredholm map
@@ -30,7 +29,7 @@ ingredient of the Sard--Smale argument in Lane F0 of the analytic Heegaard Floer
 The construction follows S. Smale, *An infinite dimensional version of Sard's theorem*,
 Amer. J. Math. 87 (1965), 861--866, and McDuff--Salamon, *J-holomorphic Curves and Symplectic
 Topology*, Appendix A. The local chart is Mathlib's
-`HasStrictFDerivAt.toOpenPartialHomeomorph`; the linear splittings are Mathlib's
+`ImplicitFunctionData.toOpenPartialHomeomorph`; the linear splittings are Mathlib's
 `ContinuousLinearMap.FredholmPackage`.
 
 ## Main declarations
@@ -38,6 +37,8 @@ Topology*, Appendix A. The local chart is Mathlib's
 * `ContinuousLinearMap.FredholmPackage.normalFormEquivL`: the linear coordinate change
   determined by a Fredholm package.
 * `ContinuousLinearMap.FredholmPackage.normalFormMap`: the nonlinear coordinate map.
+* `ContinuousLinearMap.FredholmPackage.normalFormImplicitFunctionData`: the data feeding that map
+  into Mathlib's implicit function theorem.
 * `ContinuousLinearMap.FredholmPackage.normalFormOpenPartialHomeomorph`: the local homeomorphism
   defined by that map.
 * `ContinuousLinearMap.FredholmPackage.obstructionMap`: the remainder valued in the
@@ -57,7 +58,7 @@ open Set
 namespace ContinuousLinearMap.FredholmPackage
 
 variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
-  [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F]
   {T : E →L[𝕜] F} (pkg : ContinuousLinearMap.FredholmPackage T)
 
@@ -71,7 +72,6 @@ def normalFormEquivL :
   (Submodule.prodEquivOfIsTopCompl _ _ pkg.decDom.isTopCompl).symm.trans
     (pkg.equiv.prodCongr (ContinuousLinearEquiv.refl 𝕜 pkg.decDom.X₀))
 
-omit [CompleteSpace E] in
 /-- The essential coordinate of the linear normal form is the projection of `T x` to the
 essential codomain summand. -/
 @[simp]
@@ -79,7 +79,6 @@ theorem normalFormEquivL_fst (x : E) :
     (pkg.normalFormEquivL x).1 = pkg.decCodom.proj (T x) := by
   simp [normalFormEquivL, pkg.eq_equiv]
 
-omit [CompleteSpace E] in
 /-- The inessential coordinate of the linear normal form is the projection of `x` to the
 finite-dimensional kernel summand. -/
 @[simp]
@@ -88,7 +87,6 @@ theorem normalFormEquivL_snd (x : E) :
       pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm x := by
   simp [normalFormEquivL]
 
-omit [CompleteSpace E] in
 /-- The inverse linear normal-form coordinates reassemble the essential and inessential domain
 components. -/
 @[simp]
@@ -104,7 +102,6 @@ def normalFormMap (f : E → F) (a : E) (x : E) :
   (pkg.decCodom.proj (f x),
     pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm (x - a))
 
-omit [CompleteSpace E] in
 /-- The two components of the nonlinear normal-form coordinate map. -/
 @[simp]
 theorem normalFormMap_apply (f : E → F) (a x : E) :
@@ -114,13 +111,12 @@ theorem normalFormMap_apply (f : E → F) (a x : E) :
   unfold normalFormMap
   rfl
 
-omit [CompleteSpace E] in
-/-- The normal-form coordinate map evaluated at its base point. -/
+/-- The normal-form coordinate map evaluated at its base point. Not a `simp` lemma: the general
+`normalFormMap_apply` already rewrites the left-hand side. -/
 theorem normalFormMap_self (f : E → F) (a : E) :
     pkg.normalFormMap f a a = (pkg.decCodom.proj (f a), 0) := by
   simp [normalFormMap]
 
-omit [CompleteSpace E] in
 /-- The derivative of the nonlinear normal-form coordinate map at any point is the product of the
 projected derivative of `f` and the fixed projection onto the inessential domain summand. -/
 theorem hasStrictFDerivAt_normalFormMap_of {f : E → F} {a x : E} {T' : E →L[𝕜] F}
@@ -137,7 +133,6 @@ theorem hasStrictFDerivAt_normalFormMap_of {f : E → F} {a x : E} {T' : E →L[
     simpa only [map_sub] using P.hasStrictFDerivAt.sub_const (P a)
   exact hfst.prodMk hsnd
 
-omit [CompleteSpace E] in
 /-- The product of the two linear normal-form projections agrees with the explicit linear
 coordinate equivalence supplied by the Fredholm package. -/
 private theorem prod_projection_eq_normalFormEquivL :
@@ -148,7 +143,6 @@ private theorem prod_projection_eq_normalFormEquivL :
   · exact congrArg Subtype.val (pkg.normalFormEquivL_fst x).symm
   · exact congrArg Subtype.val (pkg.normalFormEquivL_snd x).symm
 
-omit [CompleteSpace E] in
 /-- The derivative of the nonlinear normal-form coordinate map at its base point is precisely the
 linear coordinate equivalence associated to the Fredholm package. -/
 theorem hasStrictFDerivAt_normalFormMap {f : E → F} {a : E}
@@ -158,11 +152,59 @@ theorem hasStrictFDerivAt_normalFormMap {f : E → F} {a : E}
   (pkg.hasStrictFDerivAt_normalFormMap_of hf).congr_fderiv
     pkg.prod_projection_eq_normalFormEquivL
 
+/-- The essential component of the Fredholm operator factors through the package equivalence. -/
+private theorem proj_comp_eq :
+    pkg.decCodom.proj.comp T =
+      (pkg.equiv : pkg.decDom.X₁ →L[𝕜] pkg.decCodom.X₁).comp pkg.decDom.proj := by
+  ext x
+  simp [pkg.eq_equiv]
+
+/-! ### The normal-form chart -/
+
+section Chart
+
+variable [CompleteSpace E]
+
+/-- The inessential domain summand is closed in the complete space `E`. -/
+local instance : CompleteSpace pkg.decDom.X₀ :=
+  pkg.decDom.isTopCompl.isClosed'.completeSpace_coe
+
+/-- The essential codomain summand is linearly homeomorphic to a closed subspace of the complete
+space `E`. -/
+local instance : CompleteSpace pkg.decCodom.X₁ :=
+  haveI : CompleteSpace pkg.decDom.X₁ := pkg.decDom.isTopCompl.isClosed.completeSpace_coe
+  (pkg.equiv.isUniformEmbedding.completeSpace_congr pkg.equiv.surjective).mp inferInstance
+
+/-- The data feeding the Fredholm normal-form coordinates into Mathlib's implicit function
+theorem: the essential component of `f` on the left, the inessential coordinate of `x - a` on the
+right. Its `ImplicitFunctionData.prodFun` is `pkg.normalFormMap f a`. -/
+def normalFormImplicitFunctionData {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
+    ImplicitFunctionData 𝕜 E pkg.decCodom.X₁ pkg.decDom.X₀ where
+  leftFun x := pkg.decCodom.proj (f x)
+  leftDeriv := pkg.decCodom.proj.comp T
+  rightFun x := pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm (x - a)
+  rightDeriv := pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm
+  pt := a
+  hasStrictFDerivAt_leftFun := pkg.decCodom.proj.hasStrictFDerivAt.comp a hf
+  hasStrictFDerivAt_rightFun := by
+    simpa only [map_sub] using (pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁
+      pkg.decDom.isTopCompl.symm).hasStrictFDerivAt.sub_const
+      (pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm a)
+  range_leftDeriv := by
+    rw [pkg.proj_comp_eq]
+    simp [LinearMap.range_comp]
+  range_rightDeriv := Submodule.range_projectionOntoL _
+  isCompl_ker := by
+    rw [pkg.proj_comp_eq, show ((pkg.equiv : pkg.decDom.X₁ →L[𝕜] pkg.decCodom.X₁).comp
+        pkg.decDom.proj).ker = pkg.decDom.X₀ by simp [LinearMap.ker_comp],
+      Submodule.ker_projectionOntoL]
+    exact pkg.decDom.isTopCompl.isCompl.symm
+
 /-- The local homeomorphism putting a map into Fredholm normal-form coordinates near a point where
 its derivative is represented by `pkg`. -/
 def normalFormOpenPartialHomeomorph {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
     OpenPartialHomeomorph E (pkg.decCodom.X₁ × pkg.decDom.X₀) :=
-  (pkg.hasStrictFDerivAt_normalFormMap hf).toOpenPartialHomeomorph _
+  (pkg.normalFormImplicitFunctionData hf).toOpenPartialHomeomorph
 
 /-- The Fredholm normal-form homeomorphism agrees with the normal-form coordinate map everywhere;
 its source only controls where the inverse laws apply. -/
@@ -170,22 +212,21 @@ its source only controls where the inverse laws apply. -/
 theorem normalFormOpenPartialHomeomorph_apply {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) (x : E) :
     pkg.normalFormOpenPartialHomeomorph hf x = pkg.normalFormMap f a x :=
-  congrFun (HasStrictFDerivAt.toOpenPartialHomeomorph_coe _) x
+  (pkg.normalFormImplicitFunctionData hf).toOpenPartialHomeomorph_apply x
 
 /-- The base point belongs to the source of the Fredholm normal-form homeomorphism. -/
 theorem mem_normalFormOpenPartialHomeomorph_source {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
     a ∈ (pkg.normalFormOpenPartialHomeomorph hf).source :=
-  (pkg.hasStrictFDerivAt_normalFormMap hf).mem_toOpenPartialHomeomorph_source
+  (pkg.normalFormImplicitFunctionData hf).pt_mem_toOpenPartialHomeomorph_source
 
 /-- The normal-form coordinate of the base point belongs to the target of the local
 homeomorphism. -/
 theorem normalFormOpenPartialHomeomorph_self_mem_target {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
     (pkg.decCodom.proj (f a), 0) ∈ (pkg.normalFormOpenPartialHomeomorph hf).target := by
-  rw [← pkg.normalFormMap_self f a, ← pkg.normalFormOpenPartialHomeomorph_apply hf]
-  exact (pkg.normalFormOpenPartialHomeomorph hf).map_source
-    (pkg.mem_normalFormOpenPartialHomeomorph_source hf)
+  rw [← pkg.normalFormMap_self f a]
+  exact (pkg.normalFormImplicitFunctionData hf).map_pt_mem_toOpenPartialHomeomorph_target
 
 /-- Applying the inverse normal-form coordinate map to the coordinate of the base point returns
 the base point. -/
@@ -225,6 +266,15 @@ theorem obstructionMap_apply {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a
   unfold obstructionMap
   rfl
 
+/-- At the coordinate of the base point the obstruction is the inessential-codomain component
+of `f a`. Not a `simp` lemma: `obstructionMap_apply` and
+`normalFormOpenPartialHomeomorph_symm_self` already rewrite the left-hand side. -/
+theorem obstructionMap_self {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
+    pkg.obstructionMap hf (pkg.decCodom.proj (f a), 0) =
+      pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm (f a) := by
+  rw [pkg.obstructionMap_apply hf, Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
+    pkg.normalFormOpenPartialHomeomorph_symm_self hf]
+
 /-- In normal-form coordinates, the essential component of `f` is the first coordinate. -/
 theorem proj_apply_normalFormOpenPartialHomeomorph_symm {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a)
@@ -250,6 +300,30 @@ theorem apply_normalFormOpenPartialHomeomorph_symm {f : E → F} {a : E}
     pkg.proj_apply_normalFormOpenPartialHomeomorph_symm hf hy] at hsplit
   simpa [e, obstructionMap, Submodule.prodEquivOfIsTopCompl_apply] using hsplit.symm
 
+/-- The linear equivalence produced by the implicit-function data is the linear normal-form
+coordinate change. -/
+private theorem equivProd_normalFormImplicitFunctionData {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    (pkg.normalFormImplicitFunctionData hf).leftDeriv.equivProdOfSurjectiveOfIsCompl
+        (pkg.normalFormImplicitFunctionData hf).rightDeriv
+        (pkg.normalFormImplicitFunctionData hf).range_leftDeriv
+        (pkg.normalFormImplicitFunctionData hf).range_rightDeriv
+        (pkg.normalFormImplicitFunctionData hf).isCompl_ker =
+      pkg.normalFormEquivL :=
+  ContinuousLinearEquiv.coe_injective pkg.prod_projection_eq_normalFormEquivL
+
+/-- Mathlib reaches the inverse of the implicit-function chart through
+`ImplicitFunctionData.implicitFunction`, so the two spellings of that inverse are identified
+pointwise. -/
+private theorem coe_symm_normalFormOpenPartialHomeomorph {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    ⇑(pkg.normalFormOpenPartialHomeomorph hf).symm =
+      ⇑((pkg.normalFormImplicitFunctionData hf).hasStrictFDerivAt.toOpenPartialHomeomorph
+        (pkg.normalFormImplicitFunctionData hf).prodFun).symm := by
+  funext y
+  exact ((pkg.normalFormImplicitFunctionData hf).implicitFunction_apply).symm.trans
+    (congrFun (congrFun (pkg.normalFormImplicitFunctionData hf).implicitFunction_def y.1) y.2)
+
 /-- The inverse normal-form coordinates have derivative inverse to the linear normal-form
 equivalence at the coordinate of the base point. -/
 theorem hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
@@ -258,9 +332,14 @@ theorem hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self {f : E → F
       (pkg.normalFormEquivL.symm :
         (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)
       (pkg.decCodom.proj (f a), 0) := by
-  have hinv := (pkg.hasStrictFDerivAt_normalFormMap hf).to_localInverse
+  have hpt : (pkg.normalFormImplicitFunctionData hf).prodFun
+      (pkg.normalFormImplicitFunctionData hf).pt = (pkg.decCodom.proj (f a), 0) := by
+    simp [normalFormImplicitFunctionData]
+  have hinv := (pkg.normalFormImplicitFunctionData hf).hasStrictFDerivAt.to_localInverse
   rw [HasStrictFDerivAt.localInverse_def] at hinv
-  simpa only [normalFormOpenPartialHomeomorph, normalFormMap_self] using hinv
+  rw [pkg.coe_symm_normalFormOpenPartialHomeomorph hf,
+    ← pkg.equivProd_normalFormImplicitFunctionData hf, ← hpt]
+  exact hinv
 
 /-- The finite-dimensional obstruction has zero derivative at the coordinate of the base point.
 This is the differential statement that the chosen essential coordinate absorbs the entire
@@ -286,12 +365,14 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
       (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)) = 0 := by
     apply ContinuousLinearMap.ext
     intro y
-    change P (T (pkg.normalFormEquivL.symm y)) = 0
+    simp only [ContinuousLinearMap.comp_apply, _root_.zero_apply, P]
     apply Submodule.projectionOntoL_apply_eq_zero_of_mem_right
     exact pkg.range_eq.le (LinearMap.mem_range_self (T : E →ₗ[𝕜] F) _)
   apply (hcomp.congr_fderiv hzero).congr_of_eventuallyEq
   filter_upwards [] with y
   exact (pkg.obstructionMap_apply hf y).symm
+
+end Chart
 
 end ContinuousLinearMap.FredholmPackage
 

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -37,8 +37,6 @@ Topology*, Appendix A. The local chart is Mathlib's
 * `ContinuousLinearMap.FredholmPackage.normalFormEquivL`: the linear coordinate change
   determined by a Fredholm package.
 * `ContinuousLinearMap.FredholmPackage.normalFormMap`: the nonlinear coordinate map.
-* `ContinuousLinearMap.FredholmPackage.normalFormImplicitFunctionData`: the data feeding that map
-  into Mathlib's implicit function theorem.
 * `ContinuousLinearMap.FredholmPackage.normalFormOpenPartialHomeomorph`: the local homeomorphism
   defined by that map.
 * `ContinuousLinearMap.FredholmPackage.obstructionMap`: the remainder valued in the
@@ -119,7 +117,8 @@ theorem normalFormMap_self (f : E → F) (a : E) :
 
 /-- The derivative of the nonlinear normal-form coordinate map at any point is the product of the
 projected derivative of `f` and the fixed projection onto the inessential domain summand. -/
-theorem hasStrictFDerivAt_normalFormMap_of {f : E → F} {a x : E} {T' : E →L[𝕜] F}
+theorem hasStrictFDerivAt_normalFormMap_of_hasStrictFDerivAt
+    {f : E → F} {a x : E} {T' : E →L[𝕜] F}
     (hf : HasStrictFDerivAt f T' x) :
     HasStrictFDerivAt (pkg.normalFormMap f a)
       ((pkg.decCodom.proj.comp T').prod
@@ -149,7 +148,7 @@ theorem hasStrictFDerivAt_normalFormMap {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
     HasStrictFDerivAt (pkg.normalFormMap f a)
       (pkg.normalFormEquivL : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀) a :=
-  (pkg.hasStrictFDerivAt_normalFormMap_of hf).congr_fderiv
+  (pkg.hasStrictFDerivAt_normalFormMap_of_hasStrictFDerivAt hf).congr_fderiv
     pkg.prod_projection_eq_normalFormEquivL
 
 /-- The essential component of the Fredholm operator factors through the package equivalence. -/
@@ -178,7 +177,7 @@ local instance : CompleteSpace pkg.decCodom.X₁ :=
 /-- The data feeding the Fredholm normal-form coordinates into Mathlib's implicit function
 theorem: the essential component of `f` on the left, the inessential coordinate of `x - a` on the
 right. Its `ImplicitFunctionData.prodFun` is `pkg.normalFormMap f a`. -/
-def normalFormImplicitFunctionData {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
+private def normalFormImplicitFunctionData {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
     ImplicitFunctionData 𝕜 E pkg.decCodom.X₁ pkg.decDom.X₀ where
   leftFun x := pkg.decCodom.proj (f x)
   leftDeriv := pkg.decCodom.proj.comp T
@@ -195,9 +194,10 @@ def normalFormImplicitFunctionData {f : E → F} {a : E} (hf : HasStrictFDerivAt
     simp [LinearMap.range_comp]
   range_rightDeriv := Submodule.range_projectionOntoL _
   isCompl_ker := by
-    rw [pkg.proj_comp_eq, show ((pkg.equiv : pkg.decDom.X₁ →L[𝕜] pkg.decCodom.X₁).comp
-        pkg.decDom.proj).ker = pkg.decDom.X₀ by simp [LinearMap.ker_comp],
-      Submodule.ker_projectionOntoL]
+    have hker : ((pkg.equiv : pkg.decDom.X₁ →L[𝕜] pkg.decCodom.X₁).comp
+        pkg.decDom.proj).ker = pkg.decDom.X₀ := by
+      simp [LinearMap.ker_comp]
+    rw [pkg.proj_comp_eq, hker, Submodule.ker_projectionOntoL]
     exact pkg.decDom.isTopCompl.isCompl.symm
 
 /-- The local homeomorphism putting a map into Fredholm normal-form coordinates near a point where

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -5,8 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Fredholm.Basic
-public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.FDeriv
-import Mathlib.Analysis.Calculus.FDeriv.Prod
+public import Mathlib.Analysis.Calculus.Implicit
 import Mathlib.Analysis.Calculus.FDeriv.OfCompLeft
 
 /-!
@@ -28,20 +27,23 @@ used in the proof of Sard--Smale in Lane F0 of the analytic Heegaard Floer roadm
 
 The construction follows S. Smale, *An infinite dimensional version of Sard's theorem*,
 Amer. J. Math. 87 (1965), 861--866, and McDuff--Salamon, *J-holomorphic Curves and Symplectic
-Topology*, Appendix A. The inverse-function step is Mathlib's
-`HasStrictFDerivAt.toOpenPartialHomeomorph`; the linear splittings are Mathlib's
+Topology*, Appendix A. The local chart is Mathlib's
+`ImplicitFunctionData.toOpenPartialHomeomorph`; the linear splittings are Mathlib's
 `ContinuousLinearMap.FredholmPackage`.
 
 ## Main declarations
 
-* `ContinuousLinearMap.FredholmPackage.normalFormLinearEquiv`: the linear coordinate change
+* `ContinuousLinearMap.FredholmPackage.normalFormEquivL`: the linear coordinate change
   determined by a Fredholm package.
 * `ContinuousLinearMap.FredholmPackage.normalFormMap`: the nonlinear coordinate map.
-* `ContinuousLinearMap.FredholmPackage.normalForm`: the local homeomorphism defined by that map.
-* `ContinuousLinearMap.FredholmPackage.obstructionMap`: the finite-dimensional remainder in the
-  complementary codomain direction.
-* `ContinuousLinearMap.FredholmPackage.apply_normalForm_symm`: reconstruction of the original map
-  from its essential coordinate and obstruction map.
+* `ContinuousLinearMap.FredholmPackage.normalFormImplicitFunctionData`: the corresponding data
+  for Mathlib's implicit function theorem.
+* `ContinuousLinearMap.FredholmPackage.normalFormOpenPartialHomeomorph`: the local homeomorphism
+  defined by that map.
+* `ContinuousLinearMap.FredholmPackage.obstructionMap`: the remainder valued in the
+  finite-dimensional complementary codomain direction.
+* `ContinuousLinearMap.FredholmPackage.apply_normalFormOpenPartialHomeomorph_symm`:
+  reconstruction of the original map from its essential coordinate and obstruction map.
 * `ContinuousLinearMap.FredholmPackage.hasStrictFDerivAt_obstructionMap_self`: the obstruction has
   zero derivative at the base point.
 -/
@@ -59,12 +61,17 @@ variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
   {T : E →L[𝕜] F} (pkg : ContinuousLinearMap.FredholmPackage T)
 
+local instance : FiniteDimensional 𝕜 pkg.decDom.X₀ := pkg.decDom.finite_X₀
+local instance : CompleteSpace pkg.decDom.X₀ := FiniteDimensional.complete 𝕜 _
+local instance : CompleteSpace pkg.decCodom.X₁ :=
+  pkg.decCodom.isTopCompl.isClosed.completeSpace_coe
+
 /-! ### Linear and nonlinear coordinates -/
 
 /-- The linear coordinate change associated to a Fredholm package. It first splits the domain as
 the essential summand and the finite-dimensional kernel summand, then uses the package's
 equivalence on the essential coordinate. -/
-def normalFormLinearEquiv :
+def normalFormEquivL :
     E ≃L[𝕜] (pkg.decCodom.X₁ × pkg.decDom.X₀) :=
   (Submodule.prodEquivOfIsTopCompl _ _ pkg.decDom.isTopCompl).symm.trans
     (pkg.equiv.prodCongr (ContinuousLinearEquiv.refl 𝕜 pkg.decDom.X₀))
@@ -73,18 +80,26 @@ omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The essential coordinate of the linear normal form is the projection of `T x` to the
 essential codomain summand. -/
 @[simp]
-theorem normalFormLinearEquiv_fst (x : E) :
-    (pkg.normalFormLinearEquiv x).1 = pkg.decCodom.proj (T x) := by
-  simp [normalFormLinearEquiv, pkg.eq_equiv]
+theorem normalFormEquivL_fst (x : E) :
+    (pkg.normalFormEquivL x).1 = pkg.decCodom.proj (T x) := by
+  simp [normalFormEquivL, pkg.eq_equiv]
 
 omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The inessential coordinate of the linear normal form is the projection of `x` to the
 finite-dimensional kernel summand. -/
 @[simp]
-theorem normalFormLinearEquiv_snd (x : E) :
-    (pkg.normalFormLinearEquiv x).2 =
+theorem normalFormEquivL_snd (x : E) :
+    (pkg.normalFormEquivL x).2 =
       pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm x := by
-  simp [normalFormLinearEquiv]
+  simp [normalFormEquivL]
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The inverse linear normal-form coordinates reassemble the essential and inessential domain
+components. -/
+@[simp]
+theorem normalFormEquivL_symm_apply (y : pkg.decCodom.X₁ × pkg.decDom.X₀) :
+    pkg.normalFormEquivL.symm y = (pkg.equiv.symm y.1 : E) + (y.2 : E) := by
+  simp [normalFormEquivL]
 
 /-- The nonlinear normal-form coordinate map at `a`. Its first coordinate is the projection of
 `f x` to the essential codomain summand; its second remembers the finite-dimensional kernel
@@ -92,8 +107,7 @@ coordinate of `x - a`. -/
 def normalFormMap (f : E → F) (a : E) (x : E) :
     pkg.decCodom.X₁ × pkg.decDom.X₀ :=
   (pkg.decCodom.proj (f x),
-    ((ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
-      (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀)) (x - a))
+    pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm (x - a))
 
 omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The two components of the nonlinear normal-form coordinate map. -/
@@ -101,8 +115,7 @@ omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 theorem normalFormMap_apply (f : E → F) (a x : E) :
     pkg.normalFormMap f a x =
       (pkg.decCodom.proj (f x),
-        ((ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
-          (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀)) (x - a)) := by
+        pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm (x - a)) := by
   unfold normalFormMap
   rfl
 
@@ -113,141 +126,198 @@ theorem normalFormMap_self (f : E → F) (a : E) :
   simp [normalFormMap]
 
 omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The derivative of the nonlinear normal-form coordinate map at any point is the product of the
+projected derivative of `f` and the fixed projection onto the inessential domain summand. -/
+theorem hasStrictFDerivAt_normalFormMap_of {f : E → F} {a x : E} {T' : E →L[𝕜] F}
+    (hf : HasStrictFDerivAt f T' x) :
+    HasStrictFDerivAt (pkg.normalFormMap f a)
+      ((pkg.decCodom.proj.comp T').prod
+        (pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm)) x := by
+  have hfst : HasStrictFDerivAt (fun x ↦ pkg.decCodom.proj (f x))
+      (pkg.decCodom.proj.comp T') x :=
+    pkg.decCodom.proj.hasStrictFDerivAt.comp x hf
+  let P := pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm
+  have hsnd : HasStrictFDerivAt
+      (fun x ↦ P (x - a)) P x := by
+    simpa only [map_sub] using P.hasStrictFDerivAt.sub_const (P a)
+  exact hfst.prodMk hsnd
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The product of the two linear normal-form projections agrees with the explicit linear
+coordinate equivalence supplied by the Fredholm package. -/
+private theorem prod_projection_eq_normalFormEquivL :
+    (pkg.decCodom.proj.comp T).prod
+        (pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm) =
+      (pkg.normalFormEquivL : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀) := by
+  ext x
+  · exact congrArg Subtype.val (pkg.normalFormEquivL_fst x).symm
+  · exact congrArg Subtype.val (pkg.normalFormEquivL_snd x).symm
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The derivative of the nonlinear normal-form coordinate map at its base point is precisely the
 linear coordinate equivalence associated to the Fredholm package. -/
 theorem hasStrictFDerivAt_normalFormMap {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
     HasStrictFDerivAt (pkg.normalFormMap f a)
-      (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀) a := by
-  have hfst : HasStrictFDerivAt (fun x ↦ pkg.decCodom.proj (f x))
-      (pkg.decCodom.proj.comp T) a :=
-    pkg.decCodom.proj.hasStrictFDerivAt.comp a hf
-  have hsnd : HasStrictFDerivAt
-      (fun x ↦ ((ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
-        (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀)) (x - a))
-      ((ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
-        (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀)) a := by
-    let L := (ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
-      (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀)
-    simpa only [L, map_sub] using
-      L.hasStrictFDerivAt.sub_const (L a)
-  have hprod := hfst.prodMk hsnd
-  have hmap : HasStrictFDerivAt (pkg.normalFormMap f a)
-      ((pkg.decCodom.proj.comp T).prod
-        ((ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
-          (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀))) a := by
-    apply hprod.congr_of_eventuallyEq
-    filter_upwards [] with x
-    exact (pkg.normalFormMap_apply f a x).symm
-  apply hmap.congr_fderiv
-  ext x
-  · exact congrArg Subtype.val (pkg.normalFormLinearEquiv_fst x).symm
-  · rfl
+      (pkg.normalFormEquivL : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀) a :=
+  (pkg.hasStrictFDerivAt_normalFormMap_of hf).congr_fderiv
+    pkg.prod_projection_eq_normalFormEquivL
+
+/-- The implicit-function-theorem data underlying the Fredholm normal-form chart. -/
+def normalFormImplicitFunctionData {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
+    ImplicitFunctionData 𝕜 E pkg.decCodom.X₁ pkg.decDom.X₀ := by
+  let P := pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm
+  have hleft : pkg.decCodom.proj.comp T =
+      (pkg.equiv : pkg.decDom.X₁ →L[𝕜] pkg.decCodom.X₁).comp pkg.decDom.proj := by
+    ext x
+    simp [pkg.eq_equiv]
+  exact {
+    leftFun := fun x ↦ pkg.decCodom.proj (f x)
+    leftDeriv := pkg.decCodom.proj.comp T
+    rightFun := fun x ↦ P (x - a)
+    rightDeriv := P
+    pt := a
+    hasStrictFDerivAt_leftFun := pkg.decCodom.proj.hasStrictFDerivAt.comp a hf
+    hasStrictFDerivAt_rightFun := by
+      simpa only [map_sub] using P.hasStrictFDerivAt.sub_const (P a)
+    range_leftDeriv := by rw [hleft]; simp [LinearMap.range_comp]
+    range_rightDeriv := Submodule.range_projectionOntoL _
+    isCompl_ker := by
+      rw [hleft, show ((pkg.equiv : pkg.decDom.X₁ →L[𝕜] pkg.decCodom.X₁).comp
+          pkg.decDom.proj).ker = pkg.decDom.X₀ by simp [LinearMap.ker_comp],
+        Submodule.ker_projectionOntoL]
+      exact pkg.decDom.isTopCompl.isCompl.symm }
 
 /-- The local homeomorphism putting a map into Fredholm normal-form coordinates near a point where
 its derivative is represented by `pkg`. -/
-def normalForm {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
+def normalFormOpenPartialHomeomorph {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
     OpenPartialHomeomorph E (pkg.decCodom.X₁ × pkg.decDom.X₀) :=
-  (pkg.hasStrictFDerivAt_normalFormMap hf).toOpenPartialHomeomorph _
+  (pkg.normalFormImplicitFunctionData hf).toOpenPartialHomeomorph
 
-omit [CompleteSpace 𝕜] [CompleteSpace F] in
 /-- The Fredholm normal-form homeomorphism agrees with the normal-form coordinate map everywhere;
 its source only controls where the inverse laws apply. -/
 @[simp]
-theorem normalForm_apply {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) (x : E) :
-    pkg.normalForm hf x = pkg.normalFormMap f a x :=
-  congrFun (HasStrictFDerivAt.toOpenPartialHomeomorph_coe _) x
+theorem normalFormOpenPartialHomeomorph_apply {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) (x : E) :
+    pkg.normalFormOpenPartialHomeomorph hf x = pkg.normalFormMap f a x := by
+  rw [normalFormOpenPartialHomeomorph,
+    ImplicitFunctionData.toOpenPartialHomeomorph_apply]
+  unfold normalFormImplicitFunctionData normalFormMap
+  rfl
 
-omit [CompleteSpace 𝕜] [CompleteSpace F] in
 /-- The base point belongs to the source of the Fredholm normal-form homeomorphism. -/
-theorem mem_normalForm_source {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
-    a ∈ (pkg.normalForm hf).source :=
-  (pkg.hasStrictFDerivAt_normalFormMap hf).mem_toOpenPartialHomeomorph_source
+theorem mem_normalFormOpenPartialHomeomorph_source {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    a ∈ (pkg.normalFormOpenPartialHomeomorph hf).source :=
+  (pkg.normalFormImplicitFunctionData hf).pt_mem_toOpenPartialHomeomorph_source
 
-omit [CompleteSpace 𝕜] [CompleteSpace F] in
 /-- The normal-form coordinate of the base point belongs to the target of the local
 homeomorphism. -/
-theorem normalForm_self_mem_target {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
-    (pkg.decCodom.proj (f a), 0) ∈ (pkg.normalForm hf).target := by
-  rw [← pkg.normalFormMap_self f a, ← pkg.normalForm_apply hf]
-  exact (pkg.normalForm hf).map_source (pkg.mem_normalForm_source hf)
+theorem normalFormOpenPartialHomeomorph_self_mem_target {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    (pkg.decCodom.proj (f a), 0) ∈ (pkg.normalFormOpenPartialHomeomorph hf).target := by
+  rw [normalFormOpenPartialHomeomorph]
+  simpa only [normalFormImplicitFunctionData, map_sub, sub_self, map_zero] using
+    (pkg.normalFormImplicitFunctionData hf).map_pt_mem_toOpenPartialHomeomorph_target
 
-omit [CompleteSpace 𝕜] [CompleteSpace F] in
 /-- Applying the inverse normal-form coordinate map to the coordinate of the base point returns
 the base point. -/
 @[simp]
-theorem normalForm_symm_self {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
-    (pkg.normalForm hf).symm
-      (pkg.decCodom.X₁.projectionOnto pkg.decCodom.X₀ pkg.decCodom.isTopCompl.isCompl (f a), 0) =
-        a := by
-  change (pkg.normalForm hf).symm (pkg.decCodom.proj (f a), 0) = a
-  rw [← pkg.normalFormMap_self f a, ← pkg.normalForm_apply hf]
-  exact (pkg.normalForm hf).left_inv (pkg.mem_normalForm_source hf)
+theorem normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    (pkg.normalFormOpenPartialHomeomorph hf).symm (pkg.decCodom.proj (f a), 0) = a := by
+  rw [← pkg.normalFormMap_self f a, ← pkg.normalFormOpenPartialHomeomorph_apply hf]
+  exact (pkg.normalFormOpenPartialHomeomorph hf).left_inv
+    (pkg.mem_normalFormOpenPartialHomeomorph_source hf)
 
 /-! ### The finite-dimensional obstruction map -/
 
 /-- The inessential-codomain component of `f` in Fredholm normal-form coordinates. Its codomain is
-finite dimensional by `pkg.decCodom.finite_X₀`; this is the finite-dimensional map to which Sard's
-theorem is applied in the proof of Sard--Smale. Values outside the target of `pkg.normalForm hf`
-are irrelevant, as for any `OpenPartialHomeomorph` inverse. -/
+finite dimensional by `pkg.decCodom.finite_X₀`; fixing the first coordinate restricts it to a map
+between the finite-dimensional spaces `pkg.decDom.X₀` and `pkg.decCodom.X₀`, and that slice is
+what Sard's theorem is applied to in Sard--Smale. Values outside the target of
+`pkg.normalFormOpenPartialHomeomorph hf` are irrelevant, as for any `OpenPartialHomeomorph`
+inverse. -/
 def obstructionMap {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
     (y : pkg.decCodom.X₁ × pkg.decDom.X₀) : pkg.decCodom.X₀ :=
   pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm
-    (f ((pkg.normalForm hf).symm y))
+    (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y))
 
-omit [CompleteSpace 𝕜] [CompleteSpace F] in
-/-- The obstruction map is the complementary-codomain projection of `f` after applying the
-inverse normal-form coordinates. -/
-@[simp]
-theorem obstructionMap_apply {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
-    (y : pkg.decCodom.X₁ × pkg.decDom.X₀) :
-    pkg.obstructionMap hf y =
-      pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm
-        (f ((pkg.normalForm hf).symm y)) := by
-  unfold obstructionMap
-  rfl
-
-omit [CompleteSpace 𝕜] [CompleteSpace F] in
 /-- In normal-form coordinates, the essential component of `f` is the first coordinate. -/
-theorem proj_apply_normalForm_symm {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
-    {y : pkg.decCodom.X₁ × pkg.decDom.X₀} (hy : y ∈ (pkg.normalForm hf).target) :
-    pkg.decCodom.proj (f ((pkg.normalForm hf).symm y)) = y.1 := by
-  have hright := (pkg.normalForm hf).right_inv hy
-  rw [pkg.normalForm_apply hf] at hright
+theorem proj_apply_normalFormOpenPartialHomeomorph_symm {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a)
+    {y : pkg.decCodom.X₁ × pkg.decDom.X₀}
+    (hy : y ∈ (pkg.normalFormOpenPartialHomeomorph hf).target) :
+    pkg.decCodom.proj (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y)) = y.1 := by
+  have hright := (pkg.normalFormOpenPartialHomeomorph hf).right_inv hy
+  rw [pkg.normalFormOpenPartialHomeomorph_apply hf] at hright
   exact congrArg Prod.fst hright
 
-omit [CompleteSpace 𝕜] [CompleteSpace F] in
 /-- **Fredholm local normal form.** On the target of the normal-form chart, the original map is
 the sum of its essential coordinate and the finite-dimensional obstruction. -/
-theorem apply_normalForm_symm {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
-    {y : pkg.decCodom.X₁ × pkg.decDom.X₀} (hy : y ∈ (pkg.normalForm hf).target) :
-    f ((pkg.normalForm hf).symm y) =
+theorem apply_normalFormOpenPartialHomeomorph_symm {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a)
+    {y : pkg.decCodom.X₁ × pkg.decDom.X₀}
+    (hy : y ∈ (pkg.normalFormOpenPartialHomeomorph hf).target) :
+    f ((pkg.normalFormOpenPartialHomeomorph hf).symm y) =
       (y.1 : F) + (pkg.obstructionMap hf y : F) := by
   let e : (pkg.decCodom.X₁ × pkg.decCodom.X₀) ≃L[𝕜] F :=
     Submodule.prodEquivOfIsTopCompl _ _ pkg.decCodom.isTopCompl
-  have hsplit := e.apply_symm_apply (f ((pkg.normalForm hf).symm y))
+  have hsplit := e.apply_symm_apply (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y))
   rw [Submodule.prodEquivOfIsTopCompl_symm_apply,
-    pkg.proj_apply_normalForm_symm hf hy] at hsplit
+    pkg.proj_apply_normalFormOpenPartialHomeomorph_symm hf hy] at hsplit
   simpa [e, obstructionMap, Submodule.prodEquivOfIsTopCompl_apply] using hsplit.symm
 
-omit [CompleteSpace 𝕜] [CompleteSpace F] in
 /-- The inverse normal-form coordinates have derivative inverse to the linear normal-form
 equivalence at the coordinate of the base point. -/
-theorem hasStrictFDerivAt_normalForm_symm_self {f : E → F} {a : E}
+theorem hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
-    HasStrictFDerivAt (pkg.normalForm hf).symm
-      (pkg.normalFormLinearEquiv.symm :
+    HasStrictFDerivAt (pkg.normalFormOpenPartialHomeomorph hf).symm
+      (pkg.normalFormEquivL.symm :
         (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)
       (pkg.decCodom.proj (f a), 0) := by
-  refine OpenPartialHomeomorph.hasStrictFDerivAt_symm (pkg.normalForm hf)
-    (pkg.normalForm_self_mem_target hf) ?_
-  simp only [Submodule.coe_projectionOntoL]
-  rw [pkg.normalForm_symm_self hf]
-  apply (pkg.hasStrictFDerivAt_normalFormMap hf).congr_of_eventuallyEq
-  filter_upwards [] with x
-  exact (pkg.normalForm_apply hf x).symm
+  let φ := pkg.normalFormImplicitFunctionData hf
+  have hequiv :
+      φ.leftDeriv.equivProdOfSurjectiveOfIsCompl φ.rightDeriv φ.range_leftDeriv
+          φ.range_rightDeriv φ.isCompl_ker = pkg.normalFormEquivL := by
+    apply ContinuousLinearEquiv.ext
+    funext x
+    rw [ContinuousLinearMap.equivProdOfSurjectiveOfIsCompl_apply]
+    apply Prod.ext
+    · exact pkg.normalFormEquivL_fst x |>.symm
+    · exact pkg.normalFormEquivL_snd x |>.symm
+  have hinv := φ.hasStrictFDerivAt.to_localInverse
+  have hderiv :
+      ((φ.leftDeriv.equivProdOfSurjectiveOfIsCompl φ.rightDeriv φ.range_leftDeriv
+          φ.range_rightDeriv φ.isCompl_ker).symm :
+        (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E) =
+      (pkg.normalFormEquivL.symm : (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E) := by
+    rw [hequiv]
+  have hfun : HasStrictFDerivAt.localInverse φ.prodFun
+      (φ.leftDeriv.equivProdOfSurjectiveOfIsCompl φ.rightDeriv φ.range_leftDeriv
+        φ.range_rightDeriv φ.isCompl_ker) φ.pt φ.hasStrictFDerivAt =
+      φ.toOpenPartialHomeomorph.symm := by
+    funext y
+    rw [HasStrictFDerivAt.localInverse_def]
+    calc
+      _ = φ.implicitFunction y.1 y.2 := by
+        exact (congrFun (congrFun φ.implicitFunction_def y.1) y.2).symm
+      _ = _ := φ.implicitFunction_apply
+  have hpt : φ.prodFun φ.pt = (pkg.decCodom.proj (f a), 0) := by
+    rw [φ.prodFun_apply]
+    simp only [φ, normalFormImplicitFunctionData, map_sub, sub_self]
+  rw [hfun, hpt] at hinv
+  exact hinv.congr_fderiv hderiv
 
-omit [CompleteSpace 𝕜] [CompleteSpace F] in
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The projection onto the inessential codomain summand vanishes on the image of the Fredholm
+operator. -/
+theorem projectionOntoL_X₀_apply_T (x : E) :
+    pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm (T x) = 0 :=
+  Submodule.projectionOntoL_apply_eq_zero_of_mem_right _ (by
+    rw [← pkg.range_eq]
+    exact LinearMap.mem_range_self (T : E →ₗ[𝕜] F) x)
+
 /-- The finite-dimensional obstruction has zero derivative at the coordinate of the base point.
 This is the differential statement that the chosen essential coordinate absorbs the entire
 linear part of `f`. -/
@@ -257,25 +327,25 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
       (0 : (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] pkg.decCodom.X₀)
       (pkg.decCodom.proj (f a), 0) := by
   let P := pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm
-  have hinv := pkg.hasStrictFDerivAt_normalForm_symm_self hf
+  have hinv := pkg.hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self hf
   have hf' : HasStrictFDerivAt f T
-      ((pkg.normalForm hf).symm (pkg.decCodom.proj (f a), 0)) := by
-    simpa only [Submodule.coe_projectionOntoL, pkg.normalForm_symm_self hf] using hf
+      ((pkg.normalFormOpenPartialHomeomorph hf).symm (pkg.decCodom.proj (f a), 0)) := by
+    simpa only [pkg.normalFormOpenPartialHomeomorph_symm_self hf] using hf
   have hcomp : HasStrictFDerivAt
-      (fun y ↦ P (f ((pkg.normalForm hf).symm y)))
-      (P.comp (T.comp (pkg.normalFormLinearEquiv.symm :
+      (fun y ↦ P (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y)))
+      (P.comp (T.comp (pkg.normalFormEquivL.symm :
         (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)))
       (pkg.decCodom.proj (f a), 0) :=
     P.hasStrictFDerivAt.comp _ (hf'.comp _ hinv)
-  have hzero : P.comp (T.comp (pkg.normalFormLinearEquiv.symm :
+  have hzero : P.comp (T.comp (pkg.normalFormEquivL.symm :
       (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)) = 0 := by
     apply ContinuousLinearMap.ext
     intro y
-    apply Subtype.ext
-    simp [P, pkg.eq_equiv]
-  apply (hcomp.congr_fderiv hzero).congr_of_eventuallyEq
-  filter_upwards [] with y
-  exact (pkg.obstructionMap_apply hf y).symm
+    exact pkg.projectionOntoL_X₀_apply_T _
+  change HasStrictFDerivAt
+    (fun y ↦ P (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y))) 0
+      (pkg.decCodom.proj (f a), 0)
+  exact hcomp.congr_fderiv hzero
 
 end ContinuousLinearMap.FredholmPackage
 

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -225,8 +225,12 @@ the base point. -/
 @[simp]
 theorem normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
-    (pkg.normalFormOpenPartialHomeomorph hf).symm (pkg.decCodom.proj (f a), 0) = a := by
-  rw [← pkg.normalFormMap_self f a, ← pkg.normalFormOpenPartialHomeomorph_apply hf]
+    (pkg.normalFormOpenPartialHomeomorph hf).symm
+      (pkg.decCodom.X₁.projectionOnto pkg.decCodom.X₀ pkg.decCodom.isTopCompl.isCompl (f a), 0) =
+        a := by
+  rw [← Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
+    ← pkg.normalFormMap_self f a,
+    ← pkg.normalFormOpenPartialHomeomorph_apply hf]
   exact (pkg.normalFormOpenPartialHomeomorph hf).left_inv
     (pkg.mem_normalFormOpenPartialHomeomorph_source hf)
 
@@ -330,7 +334,8 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
   have hinv := pkg.hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self hf
   have hf' : HasStrictFDerivAt f T
       ((pkg.normalFormOpenPartialHomeomorph hf).symm (pkg.decCodom.proj (f a), 0)) := by
-    simpa only [pkg.normalFormOpenPartialHomeomorph_symm_self hf] using hf
+    simpa only [Submodule.coe_projectionOntoL,
+      pkg.normalFormOpenPartialHomeomorph_symm_self hf] using hf
   have hcomp : HasStrictFDerivAt
       (fun y ↦ P (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y)))
       (P.comp (T.comp (pkg.normalFormEquivL.symm :

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -108,7 +108,6 @@ theorem normalFormMap_apply (f : E → F) (a x : E) :
 
 omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- The normal-form coordinate map evaluated at its base point. -/
-@[simp]
 theorem normalFormMap_self (f : E → F) (a : E) :
     pkg.normalFormMap f a a = (pkg.decCodom.proj (f a), 0) := by
   simp [normalFormMap]
@@ -178,7 +177,10 @@ omit [CompleteSpace 𝕜] [CompleteSpace F] in
 the base point. -/
 @[simp]
 theorem normalForm_symm_self {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
-    (pkg.normalForm hf).symm (pkg.decCodom.proj (f a), 0) = a := by
+    (pkg.normalForm hf).symm
+      (pkg.decCodom.X₁.projectionOnto pkg.decCodom.X₀ pkg.decCodom.isTopCompl.isCompl (f a), 0) =
+        a := by
+  change (pkg.normalForm hf).symm (pkg.decCodom.proj (f a), 0) = a
   rw [← pkg.normalFormMap_self f a, ← pkg.normalForm_apply hf]
   exact (pkg.normalForm hf).left_inv (pkg.mem_normalForm_source hf)
 
@@ -239,6 +241,7 @@ theorem hasStrictFDerivAt_normalForm_symm_self {f : E → F} {a : E}
       (pkg.decCodom.proj (f a), 0) := by
   refine OpenPartialHomeomorph.hasStrictFDerivAt_symm (pkg.normalForm hf)
     (pkg.normalForm_self_mem_target hf) ?_
+  simp only [Submodule.coe_projectionOntoL]
   rw [pkg.normalForm_symm_self hf]
   apply (pkg.hasStrictFDerivAt_normalFormMap hf).congr_of_eventuallyEq
   filter_upwards [] with x
@@ -257,7 +260,7 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
   have hinv := pkg.hasStrictFDerivAt_normalForm_symm_self hf
   have hf' : HasStrictFDerivAt f T
       ((pkg.normalForm hf).symm (pkg.decCodom.proj (f a), 0)) := by
-    simpa only [pkg.normalForm_symm_self hf] using hf
+    simpa only [Submodule.coe_projectionOntoL, pkg.normalForm_symm_self hf] using hf
   have hcomp : HasStrictFDerivAt
       (fun y ↦ P (f ((pkg.normalForm hf).symm y)))
       (P.comp (T.comp (pkg.normalFormLinearEquiv.symm :

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -1,0 +1,279 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Fredholm.Basic
+public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.FDeriv
+import Mathlib.Analysis.Calculus.FDeriv.Prod
+import Mathlib.Analysis.Calculus.FDeriv.OfCompLeft
+
+/-!
+# Local normal form of a Fredholm map
+
+This file gives the Lyapunov--Schmidt finite-dimensional reduction of a nonlinear map at a point
+where its derivative is Fredholm. A Fredholm package splits the domain and codomain into
+essential parts, on which the derivative is invertible, and finite-dimensional inessential
+parts. Projecting the nonlinear map to the essential codomain and retaining the inessential
+domain coordinate gives a local homeomorphism. In those coordinates the original map has the
+form
+
+`(r, k) ↦ r + q(r, k)`,
+
+where `q` takes values in the finite-dimensional codomain complement. Thus all failure of
+surjectivity is confined to the finite-dimensional codomain complement; after fixing `r`, the
+remaining variable `k` also ranges over a finite-dimensional space. This is the local reduction
+used in the proof of Sard--Smale in Lane F0 of the analytic Heegaard Floer roadmap.
+
+The construction follows S. Smale, *An infinite dimensional version of Sard's theorem*,
+Amer. J. Math. 87 (1965), 861--866, and McDuff--Salamon, *J-holomorphic Curves and Symplectic
+Topology*, Appendix A. The inverse-function step is Mathlib's
+`HasStrictFDerivAt.toOpenPartialHomeomorph`; the linear splittings are Mathlib's
+`ContinuousLinearMap.FredholmPackage`.
+
+## Main declarations
+
+* `ContinuousLinearMap.FredholmPackage.normalFormLinearEquiv`: the linear coordinate change
+  determined by a Fredholm package.
+* `ContinuousLinearMap.FredholmPackage.normalFormMap`: the nonlinear coordinate map.
+* `ContinuousLinearMap.FredholmPackage.normalForm`: the local homeomorphism defined by that map.
+* `ContinuousLinearMap.FredholmPackage.obstructionMap`: the finite-dimensional remainder in the
+  complementary codomain direction.
+* `ContinuousLinearMap.FredholmPackage.apply_normalForm_symm`: reconstruction of the original map
+  from its essential coordinate and obstruction map.
+* `ContinuousLinearMap.FredholmPackage.hasStrictFDerivAt_obstructionMap_self`: the obstruction has
+  zero derivative at the base point.
+-/
+
+public section
+
+noncomputable section
+
+open Set
+
+namespace ContinuousLinearMap.FredholmPackage
+
+variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
+  {T : E →L[𝕜] F} (pkg : ContinuousLinearMap.FredholmPackage T)
+
+/-! ### Linear and nonlinear coordinates -/
+
+/-- The linear coordinate change associated to a Fredholm package. It first splits the domain as
+the essential summand and the finite-dimensional kernel summand, then uses the package's
+equivalence on the essential coordinate. -/
+def normalFormLinearEquiv :
+    E ≃L[𝕜] (pkg.decCodom.X₁ × pkg.decDom.X₀) :=
+  (Submodule.prodEquivOfIsTopCompl _ _ pkg.decDom.isTopCompl).symm.trans
+    (pkg.equiv.prodCongr (ContinuousLinearEquiv.refl 𝕜 pkg.decDom.X₀))
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The essential coordinate of the linear normal form is the projection of `T x` to the
+essential codomain summand. -/
+@[simp]
+theorem normalFormLinearEquiv_fst (x : E) :
+    (pkg.normalFormLinearEquiv x).1 = pkg.decCodom.proj (T x) := by
+  simp [normalFormLinearEquiv, pkg.eq_equiv]
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The inessential coordinate of the linear normal form is the projection of `x` to the
+finite-dimensional kernel summand. -/
+@[simp]
+theorem normalFormLinearEquiv_snd (x : E) :
+    (pkg.normalFormLinearEquiv x).2 =
+      pkg.decDom.X₀.projectionOntoL pkg.decDom.X₁ pkg.decDom.isTopCompl.symm x := by
+  simp [normalFormLinearEquiv]
+
+/-- The nonlinear normal-form coordinate map at `a`. Its first coordinate is the projection of
+`f x` to the essential codomain summand; its second remembers the finite-dimensional kernel
+coordinate of `x - a`. -/
+def normalFormMap (f : E → F) (a : E) (x : E) :
+    pkg.decCodom.X₁ × pkg.decDom.X₀ :=
+  (pkg.decCodom.proj (f x),
+    ((ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
+      (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀)) (x - a))
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The two components of the nonlinear normal-form coordinate map. -/
+@[simp]
+theorem normalFormMap_apply (f : E → F) (a x : E) :
+    pkg.normalFormMap f a x =
+      (pkg.decCodom.proj (f x),
+        ((ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
+          (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀)) (x - a)) := by
+  unfold normalFormMap
+  rfl
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The normal-form coordinate map evaluated at its base point. -/
+@[simp]
+theorem normalFormMap_self (f : E → F) (a : E) :
+    pkg.normalFormMap f a a = (pkg.decCodom.proj (f a), 0) := by
+  simp [normalFormMap]
+
+omit [CompleteSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- The derivative of the nonlinear normal-form coordinate map at its base point is precisely the
+linear coordinate equivalence associated to the Fredholm package. -/
+theorem hasStrictFDerivAt_normalFormMap {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    HasStrictFDerivAt (pkg.normalFormMap f a)
+      (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀) a := by
+  have hfst : HasStrictFDerivAt (fun x ↦ pkg.decCodom.proj (f x))
+      (pkg.decCodom.proj.comp T) a :=
+    pkg.decCodom.proj.hasStrictFDerivAt.comp a hf
+  have hsnd : HasStrictFDerivAt
+      (fun x ↦ ((ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
+        (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀)) (x - a))
+      ((ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
+        (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀)) a := by
+    let L := (ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
+      (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀)
+    simpa only [L, map_sub] using
+      L.hasStrictFDerivAt.sub_const (L a)
+  have hprod := hfst.prodMk hsnd
+  have hmap : HasStrictFDerivAt (pkg.normalFormMap f a)
+      ((pkg.decCodom.proj.comp T).prod
+        ((ContinuousLinearMap.snd 𝕜 pkg.decCodom.X₁ pkg.decDom.X₀).comp
+          (pkg.normalFormLinearEquiv : E →L[𝕜] pkg.decCodom.X₁ × pkg.decDom.X₀))) a := by
+    apply hprod.congr_of_eventuallyEq
+    filter_upwards [] with x
+    exact (pkg.normalFormMap_apply f a x).symm
+  apply hmap.congr_fderiv
+  ext x
+  · exact congrArg Subtype.val (pkg.normalFormLinearEquiv_fst x).symm
+  · rfl
+
+/-- The local homeomorphism putting a map into Fredholm normal-form coordinates near a point where
+its derivative is represented by `pkg`. -/
+def normalForm {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
+    OpenPartialHomeomorph E (pkg.decCodom.X₁ × pkg.decDom.X₀) :=
+  (pkg.hasStrictFDerivAt_normalFormMap hf).toOpenPartialHomeomorph _
+
+omit [CompleteSpace 𝕜] [CompleteSpace F] in
+/-- The Fredholm normal-form homeomorphism agrees with the normal-form coordinate map everywhere;
+its source only controls where the inverse laws apply. -/
+@[simp]
+theorem normalForm_apply {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) (x : E) :
+    pkg.normalForm hf x = pkg.normalFormMap f a x :=
+  congrFun (HasStrictFDerivAt.toOpenPartialHomeomorph_coe _) x
+
+omit [CompleteSpace 𝕜] [CompleteSpace F] in
+/-- The base point belongs to the source of the Fredholm normal-form homeomorphism. -/
+theorem mem_normalForm_source {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
+    a ∈ (pkg.normalForm hf).source :=
+  (pkg.hasStrictFDerivAt_normalFormMap hf).mem_toOpenPartialHomeomorph_source
+
+omit [CompleteSpace 𝕜] [CompleteSpace F] in
+/-- The normal-form coordinate of the base point belongs to the target of the local
+homeomorphism. -/
+theorem normalForm_self_mem_target {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
+    (pkg.decCodom.proj (f a), 0) ∈ (pkg.normalForm hf).target := by
+  rw [← pkg.normalFormMap_self f a, ← pkg.normalForm_apply hf]
+  exact (pkg.normalForm hf).map_source (pkg.mem_normalForm_source hf)
+
+omit [CompleteSpace 𝕜] [CompleteSpace F] in
+/-- Applying the inverse normal-form coordinate map to the coordinate of the base point returns
+the base point. -/
+@[simp]
+theorem normalForm_symm_self {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
+    (pkg.normalForm hf).symm (pkg.decCodom.proj (f a), 0) = a := by
+  rw [← pkg.normalFormMap_self f a, ← pkg.normalForm_apply hf]
+  exact (pkg.normalForm hf).left_inv (pkg.mem_normalForm_source hf)
+
+/-! ### The finite-dimensional obstruction map -/
+
+/-- The inessential-codomain component of `f` in Fredholm normal-form coordinates. Its codomain is
+finite dimensional by `pkg.decCodom.finite_X₀`; this is the finite-dimensional map to which Sard's
+theorem is applied in the proof of Sard--Smale. Values outside the target of `pkg.normalForm hf`
+are irrelevant, as for any `OpenPartialHomeomorph` inverse. -/
+def obstructionMap {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
+    (y : pkg.decCodom.X₁ × pkg.decDom.X₀) : pkg.decCodom.X₀ :=
+  pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm
+    (f ((pkg.normalForm hf).symm y))
+
+omit [CompleteSpace 𝕜] [CompleteSpace F] in
+/-- The obstruction map is the complementary-codomain projection of `f` after applying the
+inverse normal-form coordinates. -/
+@[simp]
+theorem obstructionMap_apply {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
+    (y : pkg.decCodom.X₁ × pkg.decDom.X₀) :
+    pkg.obstructionMap hf y =
+      pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm
+        (f ((pkg.normalForm hf).symm y)) := by
+  unfold obstructionMap
+  rfl
+
+omit [CompleteSpace 𝕜] [CompleteSpace F] in
+/-- In normal-form coordinates, the essential component of `f` is the first coordinate. -/
+theorem proj_apply_normalForm_symm {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
+    {y : pkg.decCodom.X₁ × pkg.decDom.X₀} (hy : y ∈ (pkg.normalForm hf).target) :
+    pkg.decCodom.proj (f ((pkg.normalForm hf).symm y)) = y.1 := by
+  have hright := (pkg.normalForm hf).right_inv hy
+  rw [pkg.normalForm_apply hf] at hright
+  exact congrArg Prod.fst hright
+
+omit [CompleteSpace 𝕜] [CompleteSpace F] in
+/-- **Fredholm local normal form.** On the target of the normal-form chart, the original map is
+the sum of its essential coordinate and the finite-dimensional obstruction. -/
+theorem apply_normalForm_symm {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
+    {y : pkg.decCodom.X₁ × pkg.decDom.X₀} (hy : y ∈ (pkg.normalForm hf).target) :
+    f ((pkg.normalForm hf).symm y) =
+      (y.1 : F) + (pkg.obstructionMap hf y : F) := by
+  let e : (pkg.decCodom.X₁ × pkg.decCodom.X₀) ≃L[𝕜] F :=
+    Submodule.prodEquivOfIsTopCompl _ _ pkg.decCodom.isTopCompl
+  have hsplit := e.apply_symm_apply (f ((pkg.normalForm hf).symm y))
+  rw [Submodule.prodEquivOfIsTopCompl_symm_apply,
+    pkg.proj_apply_normalForm_symm hf hy] at hsplit
+  simpa [e, obstructionMap, Submodule.prodEquivOfIsTopCompl_apply] using hsplit.symm
+
+omit [CompleteSpace 𝕜] [CompleteSpace F] in
+/-- The inverse normal-form coordinates have derivative inverse to the linear normal-form
+equivalence at the coordinate of the base point. -/
+theorem hasStrictFDerivAt_normalForm_symm_self {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    HasStrictFDerivAt (pkg.normalForm hf).symm
+      (pkg.normalFormLinearEquiv.symm :
+        (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)
+      (pkg.decCodom.proj (f a), 0) := by
+  refine OpenPartialHomeomorph.hasStrictFDerivAt_symm (pkg.normalForm hf)
+    (pkg.normalForm_self_mem_target hf) ?_
+  rw [pkg.normalForm_symm_self hf]
+  apply (pkg.hasStrictFDerivAt_normalFormMap hf).congr_of_eventuallyEq
+  filter_upwards [] with x
+  exact (pkg.normalForm_apply hf x).symm
+
+omit [CompleteSpace 𝕜] [CompleteSpace F] in
+/-- The finite-dimensional obstruction has zero derivative at the coordinate of the base point.
+This is the differential statement that the chosen essential coordinate absorbs the entire
+linear part of `f`. -/
+theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    HasStrictFDerivAt (pkg.obstructionMap hf)
+      (0 : (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] pkg.decCodom.X₀)
+      (pkg.decCodom.proj (f a), 0) := by
+  let P := pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm
+  have hinv := pkg.hasStrictFDerivAt_normalForm_symm_self hf
+  have hf' : HasStrictFDerivAt f T
+      ((pkg.normalForm hf).symm (pkg.decCodom.proj (f a), 0)) := by
+    simpa only [pkg.normalForm_symm_self hf] using hf
+  have hcomp : HasStrictFDerivAt
+      (fun y ↦ P (f ((pkg.normalForm hf).symm y)))
+      (P.comp (T.comp (pkg.normalFormLinearEquiv.symm :
+        (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)))
+      (pkg.decCodom.proj (f a), 0) :=
+    P.hasStrictFDerivAt.comp _ (hf'.comp _ hinv)
+  have hzero : P.comp (T.comp (pkg.normalFormLinearEquiv.symm :
+      (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[𝕜] E)) = 0 := by
+    apply ContinuousLinearMap.ext
+    intro y
+    apply Subtype.ext
+    simp [P, pkg.eq_equiv]
+  apply (hcomp.congr_fderiv hzero).congr_of_eventuallyEq
+  filter_upwards [] with y
+  exact (pkg.obstructionMap_apply hf y).symm
+
+end ContinuousLinearMap.FredholmPackage
+
+end


### PR DESCRIPTION
This PR adds the Lyapunov--Schmidt local normal form of a nonlinear map at a point with Fredholm derivative. Given Mathlib's `ContinuousLinearMap.FredholmPackage`, define the coordinate map whose essential component is the projection of `f x` to the range summand and whose inessential component is the kernel coordinate of `x - a`; prove its derivative is the package's continuous linear equivalence, and use Mathlib's inverse function theorem to obtain a local homeomorphism.

The exact roadmap target is `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F0, “Sard--Smale (Smale 1965).” This PR supplies its local finite-dimensional-reduction prerequisite: in the new coordinates, prove that `f` is the sum of the essential coordinate and an obstruction valued in the finite-dimensional codomain complement, and prove that obstruction has zero derivative at the base point. Fixing the essential coordinate leaves precisely the finite-dimensional kernel-to-cokernel slice to which Sard is applied. After this PR, the Sard--Smale milestone still needs the slice-wise Sard argument and its residual-set assembly; positive Fredholm index additionally needs the source-dimension-larger Morse--Sard theorem not yet present in `TauCeti/Analysis/Calculus/Sard/`.

The construction follows S. Smale, “An infinite dimensional version of Sard's theorem,” Amer. J. Math. 87 (1965), 861--866, and McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix A, both cited in the module docstring. Add `TauCeti/Analysis/Fredholm/NormalForm.lean` (279 lines). No formalization is vendored: the implementation directly reuses Mathlib's `ContinuousLinearMap.FredholmPackage`, `Submodule.prodEquivOfIsTopCompl`, `HasStrictFDerivAt.toOpenPartialHomeomorph`, and the inverse derivative API.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"fredholm-local-normal-form"}-->

🤖 Prepared with Codex
