### PR TITLE
feat(DeFinetti): re-export the L² route from the public facade

### DIFF
--- a/TauCeti/Probability/DeFinetti.lean
+++ b/TauCeti/Probability/DeFinetti.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.Probability.Exchangeability
 public import TauCeti.Probability.DeFinetti.Representation
+public import TauCeti.Probability.DeFinetti.ViaL2.Theorem
 public import TauCeti.Probability.DeFinetti.CountableIndex
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Unique
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.PathDisintegration
@@ -29,6 +30,10 @@ This module declares nothing of its own; it is a curated re-export, and it build
 * `conditionallyIID_of_contractable` — the summit: contractable implies conditionally i.i.d.;
 * `conditionallyIID_of_exchangeable` and `deFinetti` — de Finetti's theorem in conditional form;
 * `deFinetti_equivalence`, `deFinetti_RyllNardzewski_equivalence` — the equivalence forms;
+* `deFinetti_viaL2`, `conditionallyIID_of_contractable_viaL2` and
+  `deFinetti_RyllNardzewski_equivalence_viaL2` — the same summits proved by the `L²` averaging
+  route rather than the martingale one. The unsuffixed names above are the martingale route;
+  the suffixed ones name the route explicitly, and are what Layer 7 of the roadmap advertises;
 * `deFinetti_mixture` — the unique mixture representation;
 * `mixedIID_mixingLaw_unique` — uniqueness of the mixing *law*;
 * `conditionallyIID_ae_unique` — a.e. uniqueness of the directing *measure*;


### PR DESCRIPTION
Layer 7 advertises `deFinetti_viaL2` among the names its public facade exposes, but
`TauCeti/Probability/DeFinetti.lean` had no import path to `ViaL2/Theorem.lean` — so the name did
not resolve from the facade alone, despite the theorem having been on `main` for some time.

Re-exporting that module closes the gap and brings its two companion wrappers
(`conditionallyIID_of_contractable_viaL2`, `deFinetti_RyllNardzewski_equivalence_viaL2`) with it.
The docstring entry says plainly which route each name is: the unsuffixed summits are the
martingale route, the suffixed ones name their route.

## How the gap was found, and what else it showed

Elaborating every name Layer 7 lists against an import of the facade *only*:

```lean
import TauCeti.Probability.DeFinetti
open TauCeti.Probability
#check @deFinetti  -- … and each of the others
```

Before this change, five of six existing names resolved and `deFinetti_viaL2` did not. After it,
all eight do.

That test also turns up a factual error in the roadmap's own notes, which I am not fixing here
since roadmap changes need a human: `Exchangeability/STATUS.md:29` says Layer 7 *"exports every name
on its list except `deFinetti_viaL2`, `deFinetti_viaKoopman`, `deFinetti_empiricalMeasure`, and
`exchangeable_extreme_iff_iid`"*. But `exchangeable_extreme_iff_iid` **does** export, via the
`PathSpace.Law.Extreme` import the facade already has. The STATUS line overstates the gap by one
name.

`deFinetti_viaKoopman` remains unexported because it is still in review (#3170); the facade entry
for it belongs in that stack, not here. `deFinetti_empiricalMeasure` does not exist and is blocked
on a roadmap well-posedness decision recorded at `STATUS.md:39`.

Roadmap: Exchangeability

Advances `TauCetiRoadmap/Exchangeability/README.md`, **Layer 7** (public API and examples), whose
exposed-name list this brings the facade into line with.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
