### PR TITLE
review(proof-quality): bridge the subgroup action with simpa only

### DIFF
--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -79,7 +79,7 @@ private theorem image_smul_eq_image_smul_of_inter_nonempty
   obtain ⟨⟨h, hh⟩, hhu'⟩ := horbit.mp hww'.symm
   -- `H` acts through the coercion to `G` — `MulAction.subgroup_smul_def` — so the orbit witness is
   -- an element of `G` fixing `qH`, and `hhu'` retypes to the ambient action.
-  have hhu : h • (g' • u') = g • u := hhu'
+  have hhu : h • (g' • u') = g • u := by simpa only [MulAction.subgroup_smul_def] using hhu'
   have hmap : ∀ e : E, qH (h • e) = qH e := fun e =>
     horbit.mpr ⟨⟨h, hh⟩, MulAction.subgroup_smul_def ⟨h, hh⟩ e⟩
   have hgg' : g = h * g' := eq_of_inv_mul_eq_one <| by


### PR DESCRIPTION
A one-line follow-up to #3219, which merged while this fix was in flight.

`proof-quality` flagged that `have hhu : h • (g' • u') = g • u := hhu'` silently retypes the
subgroup action as the ambient `G`-action through definitional equality, making the proof depend
on which instance path the action arrives by. The fix is a named bridge:

```lean
have hhu : h • (g' • u') = g • u := by simpa only [MulAction.subgroup_smul_def] using hhu'
```

## Why `simpa only` and not `rw`

Worth recording, because the obvious form does not work and the reason is not obvious.

`rw [MulAction.subgroup_smul_def] at hhu'` fails with `Tactic 'rewrite' failed: Did not find an
occurrence of the pattern`. That is an instance-path mismatch rather than a missing lemma:
`MulAction.instMulAction (H : Subgroup G) := inferInstanceAs (MulAction H.toSubmonoid α)`
(`Mathlib/GroupTheory/GroupAction/Defs.lean:247`), so the `•` in `hhu'` elaborates through the
*submonoid* instance while `subgroup_smul_def`'s left-hand side elaborates through the *subgroup*
one. The two are definitionally equal — the lemma is literally `rfl` — but not syntactically
equal, so `rw` cannot match. `simp only` matches up to reducible instance defeq and closes it.

Both facts are compile-checked: the `rw` form fails, the `simpa only` form builds.

The lemma already carries its `/mathlibable` and `/cleanup` passes from #3219; this changes one
tactic inside a proof body and touches no statement.

Gates run on `c879096b`: `lake build` (7847 jobs), `lake exe axioms` (45456 declarations),
`lake exe module-system` (2181 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: none
