### PR TITLE
refactor(Huber): define locSubring as Mathlib's Algebra.adjoin

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
@@ -74,9 +74,7 @@ namespace PairOfDefinition
 /-- The candidate ring of definition `D = A₀[t₁/s, …, tₙ/s]` of `S`. -/
 noncomputable def locSubring (P : PairOfDefinition A) (T : Finset A)
     (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S] : Subring S :=
-  Subring.closure
-    ((algebraMap A S) '' (P.ringOfDefinition : Set A) ∪
-     Set.range (fun t : T ↦ divBy (t : A) s))
+  (Algebra.adjoin ↥P.ringOfDefinition (Set.range fun t : T ↦ divBy (t : A) s)).toSubring
 
 /-- The subring coercion carries the `D`-action on itself to multiplication in `Aₛ`. -/
 private theorem coe_smul_locSubring (P : PairOfDefinition A) (T : Finset A) (s : A)
@@ -93,21 +91,32 @@ theorem locSubring_def (P : PairOfDefinition A) (T : Finset A) (s : A)
     (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S] :
     locSubring P T s S = Subring.closure
       ((algebraMap A S) '' (P.ringOfDefinition : Set A) ∪
-       Set.range (fun t : T ↦ divBy (t : A) s)) := (rfl)
+       Set.range (fun t : T ↦ divBy (t : A) s)) := by
+  rw [locSubring, Algebra.adjoin_eq_ring_closure]
+  congr 1
+  ext x
+  constructor
+  · rintro (⟨⟨a, ha⟩, rfl⟩ | h)
+    · exact Or.inl ⟨a, ha, rfl⟩
+    · exact Or.inr h
+  · rintro (⟨a, ha, rfl⟩ | h)
+    · exact Or.inl ⟨⟨a, ha⟩, rfl⟩
+    · exact Or.inr h
 
 /-- The image of `A₀` under `algebraMap` is contained in `D`. -/
 theorem algebraMap_ringOfDefinition_subset_locSubring (P : PairOfDefinition A)
     (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S] :
     (algebraMap A S) '' (P.ringOfDefinition : Set A) ⊆
-      (locSubring P T s S : Set S) :=
-  Set.subset_union_left.trans Subring.subset_closure
+      (locSubring P T s S : Set S) := by
+  rw [locSubring_def]
+  exact Set.subset_union_left.trans Subring.subset_closure
 
 /-- Each element `t/s` (for `t ∈ T`) belongs to `D`. -/
 theorem divBy_mem_locSubring (P : PairOfDefinition A)
     (T : Finset A) (s : A)
     (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S] {t : A} (ht : t ∈ T) :
     divBy t s ∈ locSubring P T s S :=
-  Subring.subset_closure (Set.mem_union_right _ ⟨⟨t, ht⟩, rfl⟩)
+  Algebra.subset_adjoin ⟨⟨t, ht⟩, rfl⟩
 
 /-- An element of `A₀` maps into `D` under `algebraMap`. -/
 theorem algebraMap_mem_locSubring (P : PairOfDefinition A)


### PR DESCRIPTION
Roadmap: AdicSpaces

Pure refactor of merged code — no roadmap target claimed; CLAUDE.md puts adopting a cleaner idiom
in scope at any time.

A `reuse` BLOCK on a sibling PR (#3221) found that `locSubring` re-derives Mathlib:

```lean
Algebra.adjoin_eq_ring_closure :
    (adjoin R s).toSubring = Subring.closure (Set.range (algebraMap R A) ∪ s)
```

At `R = ↥P.ringOfDefinition`, `Set.range (algebraMap ↥B S) = algebraMap A S '' B`, so that right
side is `locSubring`'s body verbatim. I verified this independently before acting rather than
taking the finding on trust; the sibling PR was then withdrawn entirely, so this is the remaining
route to the fix that finding asked for — *"express `locSubring` directly with that API"*.

## Blast radius: three lemmas, not 104 call sites

Only the **body** of `locSubring` changes, so every consumer is untouched — they go through the
interface. Three lemmas are re-derived:

| lemma | before | after |
|---|---|---|
| `locSubring_def` | `rfl` to the closure form | via `Algebra.adjoin_eq_ring_closure` |
| `divBy_mem_locSubring` | `Subring.subset_closure` | `Algebra.subset_adjoin` |
| `algebraMap_ringOfDefinition_subset_locSubring` | direct | through `locSubring_def` |

`locSubring_le_iff`, `locSubring_empty`, `locSubring_mono` and `locSubring_insert` needed **no
change at all** — they were already routed through `locSubring_def`, which is what made the
interface swappable.

## Signature preservation, checked not assumed

Every interface declaration's instance binders were diffed against `origin/main`:

```
locSubring: unchanged          locSubring_le_iff: unchanged
locSubring_def: unchanged      locSubring_empty: unchanged
divBy_mem_locSubring: unchanged locSubring_mono: unchanged
algebraMap_mem_locSubring: unchanged   locSubring_insert: unchanged
```

This check is here because a sibling PR this week accepted a shorter proof that silently added a
`[ContinuousMul A]` binder to a public theorem, which `generality` correctly called a narrowing.
An adjoin-based definition could plausibly have needed different instances; it does not.

## Follow-up not taken here

`exists_pow_mul_locSubring_mem` opens its induction step by converting `locSubring` into an
`Algebra.adjoin` by hand (twelve lines, ending at `Algebra.adjoin_singleton_eq_range_aeval`). With
`locSubring` now *being* an adjoin, that block is a candidate for collapsing — but the fact needed
is a base-change of adjoin (`adjoin ↥(adjoin R s) {x}` versus `adjoin R (insert x s)`), and
Mathlib's `adjoin_insert_adjoin` is stated over a fixed base, so it is not immediate. Left for its
own PR rather than bundled into a definition change.

## Gates

Build 7849 jobs; `axioms` 45533 declarations, allowlist only; `module-system` 2183 modules;
`LINT-ENV: PASS`.
