### PR TITLE
feat(ModularForms): the norm's remainder factor is nonzero

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
@@ -28,7 +28,9 @@ translates of `f` times a `1`-periodic remainder analytic at `∞`.
 * `TauCeti.ModularForm.normRest_def`: the remainder as a product of coset factors.
 * `TauCeti.ModularForm.normRest_apply_eq_div`: how to compute the remainder off the zeros of
   the Galois product.
-* `TauCeti.ModularForm.normRest_ne_zero`: the remainder of a nonzero form is nonzero.
+* `TauCeti.ModularForm.normRest_ne_zero_of_norm_ne_zero`, with
+  `TauCeti.ModularForm.normRest_ne_zero` as its modular-form corollary: the remainder of a
+  nonzero form is nonzero.
 
 The remainder and the decomposition itself are algebraic, so they are stated for
 `SlashInvariantForm.norm` under `SlashInvariantFormClass`; only analyticity at the cusp
@@ -269,6 +271,20 @@ public lemma normRest_apply_eq_div {τ : ℍ}
       galoisProd (Subgroup.integerCuspWidth 𝒢) (f : ℍ → ℂ) τ := by
   rw [eq_div_iff h, slashInvariantForm_norm_apply_eq_galoisProd_mul_normRest, mul_comm]
 
+/-- If the norm does not vanish identically then neither does its remainder factor: the
+remainder is a factor of the norm, so a vanishing remainder would kill the whole product.
+
+This is the algebraic content; `normRest_ne_zero` is the modular-form corollary. Order
+arguments over `normRest` need one of the two, since `orderOfVanishingAt_prod` and the rest
+of the vanishing-order API are stated only for factors that are not identically zero. -/
+public lemma normRest_ne_zero_of_norm_ne_zero
+    (hf : (⇑(_root_.SlashInvariantForm.norm 𝒮ℒ f) : ℍ → ℂ) ≠ 0) : normRest f ≠ 0 := by
+  refine right_ne_zero_of_mul (a := galoisProd (Subgroup.integerCuspWidth 𝒢) (⇑f)) ?_
+  have hprod : galoisProd (Subgroup.integerCuspWidth 𝒢) (⇑f) * normRest f
+      = (⇑(_root_.SlashInvariantForm.norm 𝒮ℒ f) : ℍ → ℂ) :=
+    (funext (slashInvariantForm_norm_apply_eq_galoisProd_mul_normRest f)).symm
+  rwa [hprod]
+
 end Algebraic
 
 /-! ### The analytic layer
@@ -304,17 +320,15 @@ public lemma norm_apply_eq_galoisProd_mul_normRest (τ : ℍ) :
     rw [_root_.ModularForm.coe_norm, _root_.SlashInvariantForm.coe_norm]
   rw [hcoe, slashInvariantForm_norm_apply_eq_galoisProd_mul_normRest]
 
-/-- The remainder factor of a nonzero modular form is itself nonzero.
-
-Order arguments over `normRest` need this: `orderOfVanishingAt_prod` and the vanishing-order
-API are stated only for factors that are not identically zero. -/
+/-- The remainder factor of a nonzero modular form is itself nonzero: the modular-form
+corollary of `normRest_ne_zero_of_norm_ne_zero`, discharged by `ModularForm.norm_ne_zero`. -/
 public lemma normRest_ne_zero (hf : (⇑f : ℍ → ℂ) ≠ 0) : normRest f ≠ 0 := by
-  intro h
-  refine _root_.ModularForm.norm_ne_zero 𝒮ℒ hf ?_
-  rw [← DFunLike.coe_injective.eq_iff]
-  ext τ
-  rw [FunLike.coe_zero, Pi.zero_apply, norm_apply_eq_galoisProd_mul_normRest f τ,
-    show normRest f τ = (0 : ℍ → ℂ) τ from congrFun h τ, Pi.zero_apply, mul_zero]
+  refine normRest_ne_zero_of_norm_ne_zero f ?_
+  -- The two norms share an underlying function but not a spelling; both `coe_norm` lemmas
+  -- unfold to the same coset product, which is the bridge.
+  have h : (⇑(_root_.ModularForm.norm 𝒮ℒ f) : ℍ → ℂ) ≠ 0 := fun hz =>
+    _root_.ModularForm.norm_ne_zero 𝒮ℒ hf (DFunLike.coe_injective (by simpa using hz))
+  rwa [_root_.ModularForm.coe_norm, ← _root_.SlashInvariantForm.coe_norm] at h
 
 end Analytic
 

--- a/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
@@ -28,6 +28,7 @@ translates of `f` times a `1`-periodic remainder analytic at `∞`.
 * `TauCeti.ModularForm.normRest_def`: the remainder as a product of coset factors.
 * `TauCeti.ModularForm.normRest_apply_eq_div`: how to compute the remainder off the zeros of
   the Galois product.
+* `TauCeti.ModularForm.normRest_ne_zero`: the remainder of a nonzero form is nonzero.
 
 The remainder and the decomposition itself are algebraic, so they are stated for
 `SlashInvariantForm.norm` under `SlashInvariantFormClass`; only analyticity at the cusp
@@ -302,6 +303,18 @@ public lemma norm_apply_eq_galoisProd_mul_normRest (τ : ℍ) :
   have hcoe : _root_.ModularForm.norm 𝒮ℒ f τ = _root_.SlashInvariantForm.norm 𝒮ℒ f τ := by
     rw [_root_.ModularForm.coe_norm, _root_.SlashInvariantForm.coe_norm]
   rw [hcoe, slashInvariantForm_norm_apply_eq_galoisProd_mul_normRest]
+
+/-- The remainder factor of a nonzero modular form is itself nonzero.
+
+Order arguments over `normRest` need this: `orderOfVanishingAt_prod` and the vanishing-order
+API are stated only for factors that are not identically zero. -/
+public lemma normRest_ne_zero (hf : (⇑f : ℍ → ℂ) ≠ 0) : normRest f ≠ 0 := by
+  intro h
+  refine _root_.ModularForm.norm_ne_zero 𝒮ℒ hf ?_
+  rw [← DFunLike.coe_injective.eq_iff]
+  ext τ
+  rw [FunLike.coe_zero, Pi.zero_apply, norm_apply_eq_galoisProd_mul_normRest f τ,
+    show normRest f τ = (0 : ℍ → ℂ) τ from congrFun h τ, Pi.zero_apply, mul_zero]
 
 end Analytic
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"general-level-order-dictionary"}-->

Advances **`TauCetiRoadmap/ModularForms/README.md`, Layer 1 — "General level — by the coset
norm"**, specifically its order-dictionary milestone. `normRest_ne_zero` is what lets the
nonzero-factor vanishing-order API be applied to the norm decomposition:
`orderOfVanishingAt_prod` (`Order/OfVanishing.lean:166`) requires `∀ i ∈ s, F i ≠ 0`, so the
remainder factor's nonvanishing is a prerequisite for any order bookkeeping over
`ModularForm.norm 𝒮ℒ f`.

### What this does

```lean
public lemma normRest_ne_zero_of_norm_ne_zero
    (hf : (⇑(SlashInvariantForm.norm 𝒮ℒ f) : ℍ → ℂ) ≠ 0) : normRest f ≠ 0   -- algebraic

public lemma normRest_ne_zero (hf : (⇑f : ℍ → ℂ) ≠ 0) : normRest f ≠ 0       -- corollary
```

The algebraic half needs only `SlashInvariantFormClass`: the remainder is a *factor* of the
norm, so `right_ne_zero_of_mul` applied to `funext` of the decomposition gives it directly.
The modular-form half discharges the hypothesis with Mathlib's `ModularForm.norm_ne_zero`,
bridging the two norm spellings through the two `coe_norm` lemmas.

### Why not the product route

The obvious argument — a product of nonzero coset factors is nonzero — is not elementary for
functions: a pointwise product of nonzero functions can vanish, and excluding that needs
zero-isolation and an identity-theorem argument. Going through the decomposition avoids all of
it and needs no new analytic input.

Placement follows the file's existing split: the algebraic statement in the `Algebraic`
section under `SlashInvariantFormClass`, the corollary in `Analytic` where `ModularForm.norm`
is available. Both statements were verified as compiled probes before any file was edited.

Provenance: no external source. This fills a gap in the in-repository `normRest` API added by
#3216 — a genuinely new theorem, hence the roadmap citation above rather than a refactor
attribution.
