### PR TITLE
refactor(EllipticCurve): name the unit cancellation in variableChange_nodePolynomial

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -143,6 +143,17 @@ lemma discrim_map_nodePolynomial (φ : A →+* B) (W : WeierstrassCurve A) :
   simp only [discrim, map_add, map_sub, map_mul, map_neg, map_pow, map_ofNat] at h ⊢
   linear_combination h
 
+/-- A power of the constant `u⁻¹` absorbs any smaller power of the constant `u`. This is the one
+piece of arithmetic `ring` cannot do for `variableChange_nodePolynomial` below: it treats `↑u` and
+`↑u⁻¹` as unrelated constants, so their cancellation has to be supplied to `linear_combination`
+as a hypothesis. -/
+private lemma C_inv_pow_mul_C_pow (u : Aˣ) (m n : ℕ) :
+    Polynomial.C (↑u⁻¹ : A) ^ (m + n) * Polynomial.C (↑u : A) ^ n
+      = Polynomial.C (↑u⁻¹ : A) ^ m := by
+  have h : (↑u⁻¹ : A) ^ (m + n) * (↑u : A) ^ n = (↑u⁻¹ : A) ^ m := by
+    rw [pow_add, mul_assoc, ← mul_pow, u.inv_mul, one_pow, mul_one]
+  simp only [← Polynomial.C_pow, ← Polynomial.C_mul, h]
+
 /-- Under a change of variables `C = (u, r, s, t)`, the node polynomial transforms by the affine
 substitution `T ↦ u T + s` and the unit scalar `u⁻⁶` — reflecting that the tangent slopes `λ`
 transform as `λ ↦ (λ - s)/u`. Over a field this makes splitting invariant; see
@@ -150,33 +161,23 @@ transform as `λ ↦ (λ - s)/u`. Over a field this makes splitting invariant; s
 lemma variableChange_nodePolynomial (W : WeierstrassCurve A) (C : VariableChange A) :
     (C • W).nodePolynomial = .C ((↑C.u⁻¹ : A) ^ 6)
       * W.nodePolynomial.comp (.C (↑C.u : A) * .X + .C C.s) := by
-  -- `ring` cannot see that `u⁻¹` inverts `u`, so the two cancellations it needs are supplied as
-  -- hypotheses and fed to `linear_combination`: `e2` corrects the `X²` coefficient, where the
-  -- scalar `u⁻⁶` meets the `u²` from `(uX + s)²`, and `e1` the `X` coefficient, where it meets a
-  -- single `u`.
-  have hu : (↑C.u⁻¹ : A) * (↑C.u : A) = 1 := C.u.inv_mul
-  have e2 : (↑C.u⁻¹ : A) ^ 6 * (↑C.u : A) ^ 2 = (↑C.u⁻¹ : A) ^ 4 := by
-    linear_combination ((↑C.u⁻¹ : A) ^ 4 * ((↑C.u⁻¹ : A) * (↑C.u : A) + 1)) * hu
-  have e1 : (↑C.u⁻¹ : A) ^ 6 * (↑C.u : A) = (↑C.u⁻¹ : A) ^ 5 := by
-    linear_combination ((↑C.u⁻¹ : A) ^ 5) * hu
+  -- the two cancellations `linear_combination` needs: `e2` corrects the `X²` coefficient, where
+  -- the scalar `u⁻⁶` meets the `u²` from `(uX + s)²`, and `e1` the `X` coefficient, where it
+  -- meets a single `u`.
+  have e2 := C_inv_pow_mul_C_pow C.u 4 2
+  have e1 := C_inv_pow_mul_C_pow C.u 5 1
   have hc₄ : Polynomial.C W.c₄ = Polynomial.C W.b₂ ^ 2 - 24 * Polynomial.C W.b₄ := by
     rw [c₄]
     simp only [Polynomial.C_sub, Polynomial.C_mul, Polynomial.C_pow, map_ofNat]
-  have e2p : (Polynomial.C (↑C.u⁻¹ : A)) ^ 6 * (Polynomial.C (↑C.u : A)) ^ 2
-      = (Polynomial.C (↑C.u⁻¹ : A)) ^ 4 := by
-    rw [← Polynomial.C_pow, ← Polynomial.C_pow, ← Polynomial.C_mul, e2, Polynomial.C_pow]
-  have e1p : (Polynomial.C (↑C.u⁻¹ : A)) ^ 6 * Polynomial.C (↑C.u : A)
-      = (Polynomial.C (↑C.u⁻¹ : A)) ^ 5 := by
-    rw [← Polynomial.C_pow, ← Polynomial.C_mul, e1, Polynomial.C_pow]
   simp only [nodePolynomial, variableChange_a₁, variableChange_a₂, variableChange_c₄,
     variableChange_b₂, variableChange_b₄, variableChange_b₆, Polynomial.mul_comp,
     Polynomial.add_comp, Polynomial.sub_comp, Polynomial.C_comp, Polynomial.X_comp, pow_two,
     mul_add, add_mul, mul_sub, sub_mul, Polynomial.C_mul, Polynomial.C_add, Polynomial.C_sub,
     Polynomial.C_pow, map_ofNat, Polynomial.ofNat_comp]
   -- the `r`-shift contributes `c₄` through `variableChange_a₂`, in expanded form
-  linear_combination (-Polynomial.C W.c₄ * Polynomial.X ^ 2) * e2p
+  linear_combination (-Polynomial.C W.c₄ * Polynomial.X ^ 2) * e2
     + (-(2 * Polynomial.C W.c₄ * Polynomial.C C.s + Polynomial.C W.a₁ * Polynomial.C W.c₄)
-        * Polynomial.X) * e1p
+        * Polynomial.X) * e1
     + (-3 * Polynomial.C (↑C.u⁻¹ : A) ^ 6 * Polynomial.C C.r) * hc₄
 
 /-- **Invariance of the node polynomial's splitting under change of variables.** Since a change of

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -143,16 +143,14 @@ lemma discrim_map_nodePolynomial (φ : A →+* B) (W : WeierstrassCurve A) :
   simp only [discrim, map_add, map_sub, map_mul, map_neg, map_pow, map_ofNat] at h ⊢
   linear_combination h
 
-/-- A power of the constant `u⁻¹` absorbs any smaller power of the constant `u`. This is the one
-piece of arithmetic `ring` cannot do for `variableChange_nodePolynomial` below: it treats `↑u` and
-`↑u⁻¹` as unrelated constants, so their cancellation has to be supplied to `linear_combination`
-as a hypothesis. -/
+/-- A power of the constant polynomial `u⁻¹` absorbs any smaller power of the constant
+polynomial `u`. -/
 private lemma C_inv_pow_mul_C_pow (u : Aˣ) (m n : ℕ) :
     Polynomial.C (↑u⁻¹ : A) ^ (m + n) * Polynomial.C (↑u : A) ^ n
       = Polynomial.C (↑u⁻¹ : A) ^ m := by
-  have h : (↑u⁻¹ : A) ^ (m + n) * (↑u : A) ^ n = (↑u⁻¹ : A) ^ m := by
-    rw [pow_add, mul_assoc, ← mul_pow, u.inv_mul, one_pow, mul_one]
-  simp only [← Polynomial.C_pow, ← Polynomial.C_mul, h]
+  have hCu : Polynomial.C (↑u⁻¹ : A) * Polynomial.C (↑u : A) = 1 := by
+    rw [← Polynomial.C_mul, u.inv_mul, Polynomial.C_1]
+  rw [pow_add, mul_assoc, pow_mul_pow_eq_one n hCu, mul_one]
 
 /-- Under a change of variables `C = (u, r, s, t)`, the node polynomial transforms by the affine
 substitution `T ↦ u T + s` and the unit scalar `u⁻⁶` — reflecting that the tangent slopes `λ`
@@ -161,9 +159,9 @@ transform as `λ ↦ (λ - s)/u`. Over a field this makes splitting invariant; s
 lemma variableChange_nodePolynomial (W : WeierstrassCurve A) (C : VariableChange A) :
     (C • W).nodePolynomial = .C ((↑C.u⁻¹ : A) ^ 6)
       * W.nodePolynomial.comp (.C (↑C.u : A) * .X + .C C.s) := by
-  -- the two cancellations `linear_combination` needs: `e2` corrects the `X²` coefficient, where
-  -- the scalar `u⁻⁶` meets the `u²` from `(uX + s)²`, and `e1` the `X` coefficient, where it
-  -- meets a single `u`.
+  -- `ring` treats `↑u` and `↑u⁻¹` as unrelated constants, so the two cancellations it needs are
+  -- supplied to `linear_combination`: `e2` corrects the `X²` coefficient, where the scalar `u⁻⁶`
+  -- meets the `u²` from `(uX + s)²`, and `e1` the `X` coefficient, where it meets a single `u`.
   have e2 := C_inv_pow_mul_C_pow C.u 4 2
   have e1 := C_inv_pow_mul_C_pow C.u 5 1
   have hc₄ : Polynomial.C W.c₄ = Polynomial.C W.b₂ ^ 2 - 24 * Polynomial.C W.b₄ := by


### PR DESCRIPTION
`variableChange_nodePolynomial` proved the same two unit cancellations **twice** — once over `A`
and again over `A[X]` — using four hand-guessed `linear_combination` coefficients. Both are
instances of one fact. Name it, apply it twice, and the proof drops from 30 lines to 23. No
statement changes.

## The duplication

The proof needs `ring` to know that `u⁻¹` inverts `u`, in two places: the `X²` coefficient, where
the scalar `u⁻⁶` meets the `u²` coming from `(uX + s)²`, and the `X` coefficient, where it meets a
single `u`. It supplied that as five `have`s:

| | statement | proved by |
|---|---|---|
| `hu` | `u⁻¹ * u = 1` | `C.u.inv_mul` |
| `e2` | `u⁻¹⁶ * u² = u⁻¹⁴` | `linear_combination (u⁻¹⁴ * (u⁻¹ * u + 1)) * hu` |
| `e1` | `u⁻¹⁶ * u = u⁻¹⁵` | `linear_combination u⁻¹⁵ * hu` |
| `e2p` | the same as `e2`, under `C` | `rw [← C_pow, ← C_pow, ← C_mul, e2, C_pow]` |
| `e1p` | the same as `e1`, under `C` | `rw [← C_pow, ← C_mul, e1, C_pow]` |

Only `e2p` and `e1p` are ever used; `hu`, `e2` and `e1` exist solely to get there. And `e2p`/`e1p`
differ only in the exponents `(6, 2, 4)` versus `(6, 1, 5)`.

## One lemma instead

```lean
private lemma C_inv_pow_mul_C_pow (u : Aˣ) (m n : ℕ) :
    Polynomial.C (↑u⁻¹ : A) ^ (m + n) * Polynomial.C (↑u : A) ^ n
      = Polynomial.C (↑u⁻¹ : A) ^ m
```

Its proof is three lines: transport `u.inv_mul` under `C`, then
`rw [pow_add, mul_assoc, pow_mul_pow_eq_one n hCu, mul_one]` — the cancellation itself is Mathlib's
`pow_mul_pow_eq_one`, not a fresh one. So the two hand-guessed `linear_combination` coefficients
disappear along with the two hand-written `rw` chains. The call sites become

```lean
  have e2 := C_inv_pow_mul_C_pow C.u 4 2
  have e1 := C_inv_pow_mul_C_pow C.u 5 1
```

and the `linear_combination` that does the actual work is carried over **unchanged** — only the two
hypothesis names in it move from `e2p`/`e1p` to `e2`/`e1`. That is what makes the diff verifiable
by inspection: the mathematics of the transformation law is untouched.

## Why the helper is private and lives here

It is used once, by the lemma directly below it. Nothing else in the repository does this
cancellation under `Polynomial.C`: the only other `u.inv_mul` in the elliptic tree,
`QuadraticTwist.lean:340`, is a scalar relation handed to `grobner`, not a `C`-power identity. So
there is no shared helper to reuse and none to create — a general `Units` lemma in
`TauCeti/Algebra/` would have exactly one caller. `NodePolynomial.lean`'s neighbour
`XYIdealMaximal.lean` carries five private helpers on the same principle: name the single step,
next to the proof that needs it.

## Lengths

| Declaration | Before | After |
|---|---|---|
| `variableChange_nodePolynomial` | 30 | 23 |
| `C_inv_pow_mul_C_pow` | — | 8 |

The file goes from 246 to 247 lines, against the 1500-line limit for an existing file. The point is
not the line count — it is that two facts are now proved once each instead of twice each, and the
parent is under the 30-line threshold.

## Scope

Improvement work on existing code: no statement changes, the new declaration is `private`, and no
new mathematics. No open PR touches this file.

## Review

Two private rounds. Round 1 raised two findings, both taken:

* **reuse** — the helper hand-rolled a cancellation Mathlib already has. Correct: its proof now
  calls `pow_mul_pow_eq_one`. The thread also suggested deleting the helper and inlining the two
  hypotheses at the call site; I kept the helper, because inlining restores the very duplication
  this PR removes — two near-identical three-line blocks differing only in the exponents — and
  puts the parent back at 27 lines. Mathlib supplies the *cancellation* (`a^n * b^n = 1`); it has
  no lemma of this shape (`a^(m+n) * b^n = a^m`), which loogle confirms, so the helper composes
  the Mathlib lemma rather than restating it.
* **documentation** — the docstring explained what `ring` needs instead of stating the result. It
  now states the result; the tactic rationale moved to the proof comment on the parent, where it
  belongs.

## Gates

`lake build` whole project **7843 jobs** clean; `scripts/lint-env.sh` **PASS**, no new violations;
`lake exe axioms` **45309** declarations all within `[propext, Classical.choice, Quot.sound]`;
`lake exe module-system` **2178/2178**. No line exceeds 100 codepoints.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"nodepoly-unit-cancellation"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
