### PR TITLE
refactor(RootSystem): name the two branch-end facts of the double-fork embedding

### DIFF
--- a/TauCeti/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Acyclic.lean
@@ -17,9 +17,10 @@ This file records reusable consequences of acyclicity for paths in simple graphs
 
 * `SimpleGraph.IsAcyclic.not_adj_getVert_of_add_one_lt`: nonconsecutive vertices of a path
   in an acyclic graph are not adjacent.
-* `SimpleGraph.IsAcyclic.ne_of_adj_start_of_adj_end`: the outer ends of the two branches at the
-  ends of a path are distinct.
-* `SimpleGraph.IsAcyclic.not_adj_of_adj_start_of_adj_end`: those two outer ends are not adjacent.
+* `SimpleGraph.IsAcyclic.ne_of_adj_start_of_adj_end`: an off-path neighbour of a path's start
+  differs from every neighbour of its end.
+* `SimpleGraph.IsAcyclic.not_adj_of_adj_start_of_adj_end`: when both lie off the path, such a
+  neighbour of the start and a neighbour of the end are not adjacent.
 -/
 
 namespace TauCeti
@@ -40,9 +41,9 @@ theorem _root_.SimpleGraph.IsAcyclic.not_adj_getVert_of_add_one_lt {V : Type*}
   have := hp.getVert_injOn (by omega : i + 1 ≤ p.length) hj heq.symm
   omega
 
-/-- **The outer ends of the two branches at the ends of a path are distinct.** In an acyclic
-graph, a vertex adjacent to the start of a path with distinct endpoints and off that path differs
-from every vertex adjacent to the path's end. -/
+/-- **An off-path neighbour of a path's start differs from every neighbour of its end.** In an
+acyclic graph, for a path with distinct endpoints. Only the start-side vertex is required to lie
+off the path; the end-side one is unconstrained. -/
 theorem _root_.SimpleGraph.IsAcyclic.ne_of_adj_start_of_adj_end {V : Type*} {G : SimpleGraph V}
     {u v : V} (hG : G.IsAcyclic) (huv : u ≠ v) {q : G.Walk u v} (hq : q.IsPath)
     {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) : a ≠ b := fun hab ↦
@@ -52,9 +53,9 @@ theorem _root_.SimpleGraph.IsAcyclic.ne_of_adj_start_of_adj_end {V : Type*} {G :
     (hG.eq_snd_of_adj_start (hq.cons ha' (h := ha.symm)) (hab ▸ hb).symm
       (SimpleGraph.Walk.end_mem_support _)).symm
 
-/-- **The outer ends of the two branches at the ends of a path are not adjacent.** In an acyclic
-graph, no edge joins a vertex adjacent to the start of a path to a vertex adjacent to its end, when
-both lie off the path. -/
+/-- **Neighbours of a path's two ends, both lying off the path, are not adjacent.** In an acyclic
+graph, no edge joins a vertex adjacent to the start of a path to one adjacent to its end. Here
+both are required to lie off the path, unlike in `ne_of_adj_start_of_adj_end`. -/
 theorem _root_.SimpleGraph.IsAcyclic.not_adj_of_adj_start_of_adj_end {V : Type*}
     {G : SimpleGraph V} {u v : V} (hG : G.IsAcyclic) {q : G.Walk u v} (hq : q.IsPath)
     {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) (hb' : b ∉ q.support) :

--- a/TauCeti/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Acyclic.lean
@@ -17,6 +17,9 @@ This file records reusable consequences of acyclicity for paths in simple graphs
 
 * `SimpleGraph.IsAcyclic.not_adj_getVert_of_add_one_lt`: nonconsecutive vertices of a path
   in an acyclic graph are not adjacent.
+* `SimpleGraph.IsAcyclic.ne_of_adj_start_of_adj_end`: the outer ends of the two branches at the
+  ends of a path are distinct.
+* `SimpleGraph.IsAcyclic.not_adj_of_adj_start_of_adj_end`: those two outer ends are not adjacent.
 -/
 
 namespace TauCeti
@@ -36,5 +39,31 @@ theorem _root_.SimpleGraph.IsAcyclic.not_adj_getVert_of_add_one_lt {V : Type*}
   rw [hsnd] at heq
   have := hp.getVert_injOn (by omega : i + 1 ≤ p.length) hj heq.symm
   omega
+
+/-- **The outer ends of the two branches at the ends of a path are distinct.** In an acyclic
+graph, a vertex adjacent to the start of a path with distinct endpoints and off that path differs
+from every vertex adjacent to the path's end. -/
+theorem _root_.SimpleGraph.IsAcyclic.ne_of_adj_start_of_adj_end {V : Type*} {G : SimpleGraph V}
+    {u v : V} (hG : G.IsAcyclic) (huv : u ≠ v) {q : G.Walk u v} (hq : q.IsPath)
+    {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) : a ≠ b := fun hab ↦
+  -- `a = b` makes `a` adjacent to the far end `v` of the path `a — u — … — v`, so acyclicity
+  -- forces `v` to be that path's second vertex, which is `u`.
+  huv <| (SimpleGraph.Walk.snd_cons q ha.symm).symm.trans
+    (hG.eq_snd_of_adj_start (hq.cons ha' (h := ha.symm)) (hab ▸ hb).symm
+      (SimpleGraph.Walk.end_mem_support _)).symm
+
+/-- **The outer ends of the two branches at the ends of a path are not adjacent.** In an acyclic
+graph, no edge joins a vertex adjacent to the start of a path to a vertex adjacent to its end, when
+both lie off the path. -/
+theorem _root_.SimpleGraph.IsAcyclic.not_adj_of_adj_start_of_adj_end {V : Type*}
+    {G : SimpleGraph V} {u v : V} (hG : G.IsAcyclic) {q : G.Walk u v} (hq : q.IsPath)
+    {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) (hb' : b ∉ q.support) :
+    ¬G.Adj a b := by
+  intro hadj
+  -- The paths `a — u — … — v` and `a — b` leave `a` with adjacent far ends, and `v` misses the
+  -- edge `a — b`, so acyclicity puts `b` on the first path; but `b` is neither `a` nor on `q`.
+  have hmem := hG.mem_support_of_ne_mem_support_of_adj_of_isPath (hq.cons ha' (h := ha.symm))
+    hadj.isPath_toWalk hb (by simp [hb.ne, ne_of_mem_of_not_mem q.end_mem_support ha'])
+  simp [hadj.ne', hb'] at hmem
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
@@ -257,42 +257,29 @@ private lemma submatrix_doubleForkEmbedding_eq (h : IsFiniteType A)
       exact (h.diagramGraph_adj_iff.mp hadj).2 hzero'
 
 /-- **The outer ends of the two branches at the ends of a path are distinct.** In an acyclic
-graph, a vertex adjacent to the start of a nontrivial path and off that path differs from every
-vertex adjacent to the path's end. -/
+graph, a vertex adjacent to the start of a path with distinct endpoints and off that path differs
+from every vertex adjacent to the path's end. -/
 private theorem ne_of_adj_first_of_adj_last {V : Type*} {G : SimpleGraph V}
     (hG : G.IsAcyclic) {u v : V} (huv : u ≠ v) {q : G.Walk u v} (hq : q.IsPath)
-    {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) : a ≠ b := by
-  intro hab
-  -- `a — u — … — v` and the single edge `a — v` are two paths with the same ends, so equal;
-  -- but the first is longer, since `u ≠ v` keeps `q` from being nil.
-  have hlen : q.length ≠ 0 := fun h => huv (SimpleGraph.Walk.eq_of_length_eq_zero h)
-  have heq := (hG.subsingleton_path a v).elim
-    (⟨q.cons ha.symm, hq.cons ha'⟩ : G.Path a v)
-    (SimpleGraph.Path.singleton (hab ▸ hb).symm)
-  have h := congrArg (fun r : G.Path a v ↦ r.val.length) heq
-  simp only [SimpleGraph.Walk.length_cons, SimpleGraph.Path.singleton_coe,
-    (hab ▸ hb).symm.length_toWalk] at h
-  omega
+    {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) : a ≠ b := fun hab ↦
+  -- `a = b` makes `a` adjacent to the far end `v` of the path `a — u — … — v`, so acyclicity
+  -- forces `v` to be that path's second vertex, which is `u`.
+  huv <| (SimpleGraph.Walk.snd_cons q ha.symm).symm.trans
+    (hG.eq_snd_of_adj_start (hq.cons ha' (h := ha.symm)) (hab ▸ hb).symm
+      (SimpleGraph.Walk.end_mem_support _)).symm
 
 /-- **The outer ends of the two branches at the ends of a path are not adjacent.** In an acyclic
 graph, no edge joins a vertex adjacent to the start of a path to a vertex adjacent to its end, when
 both lie off the path. -/
 private theorem not_adj_of_adj_first_of_adj_last {V : Type*} {G : SimpleGraph V}
-    (hG : G.IsAcyclic) {u v : V} {q : G.Walk u v} (hq : q.IsPath)
-    {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) (hb' : b ∉ q.support) :
-    ¬G.Adj a b := by
+    (hG : G.IsAcyclic) {u v : V} {q : G.Walk u v} (hq : q.IsPath) {a b : V} (ha : G.Adj u a)
+    (ha' : a ∉ q.support) (hb : G.Adj v b) (hb' : b ∉ q.support) : ¬G.Adj a b := by
   intro hadj
-  -- `a — u — … — v — b` and the single edge `a — b` are two paths with the same ends.
-  have hb'' : b ∉ (q.cons ha.symm).support := by
-    simp only [SimpleGraph.Walk.support_cons, List.mem_cons, not_or]
-    exact ⟨hadj.ne', hb'⟩
-  have heq := (hG.subsingleton_path a b).elim
-    (⟨(q.cons ha.symm).concat hb, (hq.cons ha').concat hb'' hb⟩ : G.Path a b)
-    (SimpleGraph.Path.singleton hadj)
-  have h := congrArg (fun r : G.Path a b ↦ r.val.length) heq
-  simp only [SimpleGraph.Walk.length_concat, SimpleGraph.Walk.length_cons,
-    SimpleGraph.Path.singleton_coe, hadj.length_toWalk] at h
-  omega
+  -- The paths `a — u — … — v` and `a — b` leave `a` with adjacent far ends, and `v` misses the
+  -- edge `a — b`, so acyclicity puts `b` on the first path; but `b` is neither `a` nor on `q`.
+  have hmem := hG.mem_support_of_ne_mem_support_of_adj_of_isPath (hq.cons ha' (h := ha.symm))
+    hadj.isPath_toWalk hb (by simp [hb.ne, ne_of_mem_of_not_mem q.end_mem_support ha'])
+  simp [hadj.ne', hb'] at hmem
 
 /-- **Two distinct branch vertices in one simply-laced finite-type component contain an affine
 `D` principal submatrix.** The middle `Fin (n + 2)` is the path between the branch vertices, and

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
@@ -256,31 +256,6 @@ private lemma submatrix_doubleForkEmbedding_eq (h : IsFiniteType A)
         (h.diagramGraph_adj_iff.mp (hright_adj j)).2
       exact (h.diagramGraph_adj_iff.mp hadj).2 hzero'
 
-/-- **The outer ends of the two branches at the ends of a path are distinct.** In an acyclic
-graph, a vertex adjacent to the start of a path with distinct endpoints and off that path differs
-from every vertex adjacent to the path's end. -/
-private theorem ne_of_adj_first_of_adj_last {V : Type*} {G : SimpleGraph V}
-    (hG : G.IsAcyclic) {u v : V} (huv : u ≠ v) {q : G.Walk u v} (hq : q.IsPath)
-    {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) : a ≠ b := fun hab ↦
-  -- `a = b` makes `a` adjacent to the far end `v` of the path `a — u — … — v`, so acyclicity
-  -- forces `v` to be that path's second vertex, which is `u`.
-  huv <| (SimpleGraph.Walk.snd_cons q ha.symm).symm.trans
-    (hG.eq_snd_of_adj_start (hq.cons ha' (h := ha.symm)) (hab ▸ hb).symm
-      (SimpleGraph.Walk.end_mem_support _)).symm
-
-/-- **The outer ends of the two branches at the ends of a path are not adjacent.** In an acyclic
-graph, no edge joins a vertex adjacent to the start of a path to a vertex adjacent to its end, when
-both lie off the path. -/
-private theorem not_adj_of_adj_first_of_adj_last {V : Type*} {G : SimpleGraph V}
-    (hG : G.IsAcyclic) {u v : V} {q : G.Walk u v} (hq : q.IsPath) {a b : V} (ha : G.Adj u a)
-    (ha' : a ∉ q.support) (hb : G.Adj v b) (hb' : b ∉ q.support) : ¬G.Adj a b := by
-  intro hadj
-  -- The paths `a — u — … — v` and `a — b` leave `a` with adjacent far ends, and `v` misses the
-  -- edge `a — b`, so acyclicity puts `b` on the first path; but `b` is neither `a` nor on `q`.
-  have hmem := hG.mem_support_of_ne_mem_support_of_adj_of_isPath (hq.cons ha' (h := ha.symm))
-    hadj.isPath_toWalk hb (by simp [hb.ne, ne_of_mem_of_not_mem q.end_mem_support ha'])
-  simp [hadj.ne', hb'] at hmem
-
 /-- **Two distinct branch vertices in one simply-laced finite-type component contain an affine
 `D` principal submatrix.** The middle `Fin (n + 2)` is the path between the branch vertices, and
 the two outer copies of `Fin 2` enumerate the unused neighbours at either end.
@@ -341,10 +316,10 @@ theorem exists_doubleFork_submatrix (h : IsFiniteType A) {u v : B}
     hright_ne_penultimate i
       (h.isAcyclic_diagramGraph.eq_penultimate_of_adj_end hq (hright_adj i) hi)
   have hleft_right_ne (i j : Fin 2) : leftVertex i ≠ rightVertex j :=
-    ne_of_adj_first_of_adj_last h.isAcyclic_diagramGraph huv_ne hq
+    h.isAcyclic_diagramGraph.ne_of_adj_start_of_adj_end huv_ne hq
       (hleft_adj i) (hleft_not_mem i) (hright_adj j)
   have hleft_right_not_adj (i j : Fin 2) : ¬G.Adj (leftVertex i) (rightVertex j) :=
-    not_adj_of_adj_first_of_adj_last h.isAcyclic_diagramGraph hq
+    h.isAcyclic_diagramGraph.not_adj_of_adj_start_of_adj_end hq
       (hleft_adj i) (hleft_not_mem i) (hright_adj j) (hright_not_mem j)
   have he' := doubleForkEmbedding_injective hq hn leftVertex rightVertex hleft_inj hright_inj
     hleft_not_mem hright_not_mem hleft_right_ne

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
@@ -260,11 +260,12 @@ private lemma submatrix_doubleForkEmbedding_eq (h : IsFiniteType A)
 graph, a vertex adjacent to the start of a nontrivial path and off that path differs from every
 vertex adjacent to the path's end. -/
 private theorem ne_of_adj_first_of_adj_last {V : Type*} {G : SimpleGraph V}
-    (hG : G.IsAcyclic) {u v : V} {q : G.Walk u v} (hq : q.IsPath) (hlen : q.length ≠ 0)
+    (hG : G.IsAcyclic) {u v : V} (huv : u ≠ v) {q : G.Walk u v} (hq : q.IsPath)
     {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) : a ≠ b := by
   intro hab
   -- `a — u — … — v` and the single edge `a — v` are two paths with the same ends, so equal;
-  -- but the first is longer, since `q` is not nil.
+  -- but the first is longer, since `u ≠ v` keeps `q` from being nil.
+  have hlen : q.length ≠ 0 := fun h => huv (SimpleGraph.Walk.eq_of_length_eq_zero h)
   have heq := (hG.subsingleton_path a v).elim
     (⟨q.cons ha.symm, hq.cons ha'⟩ : G.Path a v)
     (SimpleGraph.Path.singleton (hab ▸ hb).symm)
@@ -353,7 +354,7 @@ theorem exists_doubleFork_submatrix (h : IsFiniteType A) {u v : B}
     hright_ne_penultimate i
       (h.isAcyclic_diagramGraph.eq_penultimate_of_adj_end hq (hright_adj i) hi)
   have hleft_right_ne (i j : Fin 2) : leftVertex i ≠ rightVertex j :=
-    ne_of_adj_first_of_adj_last h.isAcyclic_diagramGraph hq (by omega)
+    ne_of_adj_first_of_adj_last h.isAcyclic_diagramGraph huv_ne hq
       (hleft_adj i) (hleft_not_mem i) (hright_adj j)
   have hleft_right_not_adj (i j : Fin 2) : ¬G.Adj (leftVertex i) (rightVertex j) :=
     not_adj_of_adj_first_of_adj_last h.isAcyclic_diagramGraph hq

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
@@ -256,6 +256,43 @@ private lemma submatrix_doubleForkEmbedding_eq (h : IsFiniteType A)
         (h.diagramGraph_adj_iff.mp (hright_adj j)).2
       exact (h.diagramGraph_adj_iff.mp hadj).2 hzero'
 
+/-- **The outer ends of the two branches at the ends of a path are distinct.** In an acyclic
+graph, a vertex adjacent to the start of a nontrivial path and off that path differs from every
+vertex adjacent to the path's end. -/
+private theorem ne_of_adj_first_of_adj_last {V : Type*} {G : SimpleGraph V}
+    (hG : G.IsAcyclic) {u v : V} {q : G.Walk u v} (hq : q.IsPath) (hlen : q.length ≠ 0)
+    {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) : a ≠ b := by
+  intro hab
+  -- `a — u — … — v` and the single edge `a — v` are two paths with the same ends, so equal;
+  -- but the first is longer, since `q` is not nil.
+  have heq := (hG.subsingleton_path a v).elim
+    (⟨q.cons ha.symm, hq.cons ha'⟩ : G.Path a v)
+    (SimpleGraph.Path.singleton (hab ▸ hb).symm)
+  have h := congrArg (fun r : G.Path a v ↦ r.val.length) heq
+  simp only [SimpleGraph.Walk.length_cons, SimpleGraph.Path.singleton_coe,
+    (hab ▸ hb).symm.length_toWalk] at h
+  omega
+
+/-- **The outer ends of the two branches at the ends of a path are not adjacent.** In an acyclic
+graph, no edge joins a vertex adjacent to the start of a path to a distinct vertex adjacent to its
+end, when both lie off the path. -/
+private theorem not_adj_of_adj_first_of_adj_last {V : Type*} {G : SimpleGraph V}
+    (hG : G.IsAcyclic) {u v : V} {q : G.Walk u v} (hq : q.IsPath)
+    {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) (hb' : b ∉ q.support)
+    (hab : a ≠ b) : ¬G.Adj a b := by
+  intro hadj
+  -- `a — u — … — v — b` and the single edge `a — b` are two paths with the same ends.
+  have hb'' : b ∉ (q.cons ha.symm).support := by
+    simp only [SimpleGraph.Walk.support_cons, List.mem_cons, not_or]
+    exact ⟨hab.symm, hb'⟩
+  have heq := (hG.subsingleton_path a b).elim
+    (⟨(q.cons ha.symm).concat hb, (hq.cons ha').concat hb'' hb⟩ : G.Path a b)
+    (SimpleGraph.Path.singleton hadj)
+  have h := congrArg (fun r : G.Path a b ↦ r.val.length) heq
+  simp only [SimpleGraph.Walk.length_concat, SimpleGraph.Walk.length_cons,
+    SimpleGraph.Path.singleton_coe, hadj.length_toWalk] at h
+  omega
+
 /-- **Two distinct branch vertices in one simply-laced finite-type component contain an affine
 `D` principal submatrix.** The middle `Fin (n + 2)` is the path between the branch vertices, and
 the two outer copies of `Fin 2` enumerate the unused neighbours at either end.
@@ -315,33 +352,12 @@ theorem exists_doubleFork_submatrix (h : IsFiniteType A) {u v : B}
   have hright_not_mem (i : Fin 2) : rightVertex i ∉ q.support := fun hi ↦
     hright_ne_penultimate i
       (h.isAcyclic_diagramGraph.eq_penultimate_of_adj_end hq (hright_adj i) hi)
-  have hleft_right_ne (i j : Fin 2) : leftVertex i ≠ rightVertex j := by
-    intro hij
-    have hp' : (q.cons (hleft_adj i).symm).IsPath := hq.cons (hleft_not_mem i)
-    have heq := h.isAcyclic_diagramGraph.subsingleton_path (leftVertex i) v |>.elim
-      (⟨q.cons (hleft_adj i).symm, hp'⟩ : G.Path (leftVertex i) v)
-      (SimpleGraph.Path.singleton (hij ▸ hright_adj j).symm)
-    have hlen := congrArg (fun r : G.Path (leftVertex i) v ↦ r.val.length) heq
-    simp only [SimpleGraph.Walk.length_cons, SimpleGraph.Path.singleton_coe,
-      (hij ▸ hright_adj j).symm.length_toWalk, hn] at hlen
-    omega
-  have hleft_right_not_adj (i j : Fin 2) : ¬G.Adj (leftVertex i) (rightVertex j) := by
-    have hp' : (q.cons (hleft_adj i).symm).IsPath := hq.cons (hleft_not_mem i)
-    have hright_not_mem' : rightVertex j ∉ (q.cons (hleft_adj i).symm).support := by
-      simp only [SimpleGraph.Walk.support_cons, List.mem_cons, not_or]
-      exact ⟨(hleft_right_ne i j).symm, hright_not_mem j⟩
-    have hp'' := hp'.concat hright_not_mem' (hright_adj j)
-    intro hadj
-    have heq := h.isAcyclic_diagramGraph.subsingleton_path
-      (leftVertex i) (rightVertex j) |>.elim
-        (⟨(q.cons (hleft_adj i).symm).concat (hright_adj j), hp''⟩ :
-          G.Path (leftVertex i) (rightVertex j))
-        (SimpleGraph.Path.singleton hadj)
-    have hlen := congrArg
-      (fun r : G.Path (leftVertex i) (rightVertex j) ↦ r.val.length) heq
-    simp only [SimpleGraph.Walk.length_concat, SimpleGraph.Walk.length_cons,
-      SimpleGraph.Path.singleton_coe, hadj.length_toWalk, hn] at hlen
-    omega
+  have hleft_right_ne (i j : Fin 2) : leftVertex i ≠ rightVertex j :=
+    ne_of_adj_first_of_adj_last h.isAcyclic_diagramGraph hq (by omega)
+      (hleft_adj i) (hleft_not_mem i) (hright_adj j)
+  have hleft_right_not_adj (i j : Fin 2) : ¬G.Adj (leftVertex i) (rightVertex j) :=
+    not_adj_of_adj_first_of_adj_last h.isAcyclic_diagramGraph hq
+      (hleft_adj i) (hleft_not_mem i) (hright_adj j) (hright_not_mem j) (hleft_right_ne i j)
   have he' := doubleForkEmbedding_injective hq hn leftVertex rightVertex hleft_inj hright_inj
     hleft_not_mem hright_not_mem hleft_right_ne
   -- Every vertex of the double fork lies in the component of `u`, so `hsl` applies to it.

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/UniqueBranch.lean
@@ -275,17 +275,17 @@ private theorem ne_of_adj_first_of_adj_last {V : Type*} {G : SimpleGraph V}
   omega
 
 /-- **The outer ends of the two branches at the ends of a path are not adjacent.** In an acyclic
-graph, no edge joins a vertex adjacent to the start of a path to a distinct vertex adjacent to its
-end, when both lie off the path. -/
+graph, no edge joins a vertex adjacent to the start of a path to a vertex adjacent to its end, when
+both lie off the path. -/
 private theorem not_adj_of_adj_first_of_adj_last {V : Type*} {G : SimpleGraph V}
     (hG : G.IsAcyclic) {u v : V} {q : G.Walk u v} (hq : q.IsPath)
-    {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) (hb' : b ∉ q.support)
-    (hab : a ≠ b) : ¬G.Adj a b := by
+    {a b : V} (ha : G.Adj u a) (ha' : a ∉ q.support) (hb : G.Adj v b) (hb' : b ∉ q.support) :
+    ¬G.Adj a b := by
   intro hadj
   -- `a — u — … — v — b` and the single edge `a — b` are two paths with the same ends.
   have hb'' : b ∉ (q.cons ha.symm).support := by
     simp only [SimpleGraph.Walk.support_cons, List.mem_cons, not_or]
-    exact ⟨hab.symm, hb'⟩
+    exact ⟨hadj.ne', hb'⟩
   have heq := (hG.subsingleton_path a b).elim
     (⟨(q.cons ha.symm).concat hb, (hq.cons ha').concat hb'' hb⟩ : G.Path a b)
     (SimpleGraph.Path.singleton hadj)
@@ -358,7 +358,7 @@ theorem exists_doubleFork_submatrix (h : IsFiniteType A) {u v : B}
       (hleft_adj i) (hleft_not_mem i) (hright_adj j)
   have hleft_right_not_adj (i j : Fin 2) : ¬G.Adj (leftVertex i) (rightVertex j) :=
     not_adj_of_adj_first_of_adj_last h.isAcyclic_diagramGraph hq
-      (hleft_adj i) (hleft_not_mem i) (hright_adj j) (hright_not_mem j) (hleft_right_ne i j)
+      (hleft_adj i) (hleft_not_mem i) (hright_adj j) (hright_not_mem j)
   have he' := doubleForkEmbedding_injective hq hn leftVertex rightVertex hleft_inj hright_inj
     hleft_not_mem hright_not_mem hleft_right_ne
   -- Every vertex of the double fork lies in the component of `u`, so `hsl` applies to it.


### PR DESCRIPTION
`exists_doubleFork_submatrix` — the proof that two branch vertices in a simply-laced finite-type
component contain an affine `D` submatrix — ran to 91 lines. Two of its phases were statements
about acyclic graphs, with no root-system content at all.

## The two extractions

**`ne_of_adj_first_of_adj_last`** — in an acyclic graph, a vertex adjacent to the start of a path
with distinct endpoints and off that path differs from every vertex adjacent to the path's end.

**`not_adj_of_adj_first_of_adj_last`** — no edge joins such a vertex to one adjacent to the path's
end, when both lie off the path.

## What the required passes changed

Both lemmas went through `/mathlibable` and `/cleanup`, and each pass found something.

**Hypotheses were wrong, not merely redundant.** The first lemma originally took
`q.length ≠ 0`. That is not the condition the mathematics needs: with `hq` dropped, a backtracking
walk of positive length breaks the conclusion, so the correct hypothesis is `u ≠ v` — which the
caller already had in scope, so the call site got shorter. The second lemma took `a ≠ b`; it never
needed it, since `hadj.ne'` recovers it from irreflexivity after `intro hadj`. Deriving the second
from the first was considered and rejected: the first needs `u ≠ v` and the second needs no
nontriviality hypothesis at all, so routing through it would *add* a hypothesis. All of this was
compile-verified, including the degenerate `q = nil` case.

**Both proofs were re-deriving mathlib.** `/cleanup` replaced the hand-rolled two-paths arguments
with `IsAcyclic.eq_snd_of_adj_start` and
`IsAcyclic.mem_support_of_ne_mem_support_of_adj_of_isPath`. The first lemma is now a term proof
with no `by` at all.

That also disposed of the obvious refactor. The two proofs had shared a visible skeleton — build a
`Path`, compare with `Path.singleton` under `subsingleton_path`, take lengths, `omega` — which
looked like a candidate for a shared helper. It was a symptom: the skeleton was the part being
re-derived, and it vanished once both routed to the existing API. What a factored helper would
have asserted (*in an acyclic graph a path between adjacent vertices is the single edge*) is a
general statement about `SimpleGraph.IsAcyclic`, i.e. new mathematics whose home is upstream, not
a private helper in a root-system file.

## Result

| | before | after |
|---|---|---|
| `exists_doubleFork_submatrix` | 91 | 70 |
| `ne_of_adj_first_of_adj_last` | — | 3 (term proof) |
| `not_adj_of_adj_first_of_adj_last` | — | 4 |

Neither lemma is in mathlib: the `IsAcyclic` namespace was enumerated, `Acyclic.lean` and
`Walk/Chord.lean` read in full, plus Loogle queries and compiled `exact?` probes that fail.

Gates run on `344558b2`: `lake build` (7817 jobs), `lake exe axioms` (44799 declarations),
`lake exe module-system` (2157 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`).

Roadmap: RepresentationTheory
