### PR TITLE
feat(ModularForms): expose normRest's holomorphy and boundedness

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
@@ -21,7 +21,9 @@ translates of `f` times a `1`-periodic remainder analytic at `∞`.
 
 * `TauCeti.SlashInvariantForm.mdifferentiable_quotientFunc`.
 * `TauCeti.SlashInvariantForm.isBoundedAtImInfty_quotientFunc`.
-* `TauCeti.ModularForm.normRest`, `TauCeti.ModularForm.periodic_normRest` and
+* `TauCeti.ModularForm.normRest`, with `TauCeti.ModularForm.periodic_normRest`,
+  `TauCeti.ModularForm.mdifferentiable_normRest`,
+  `TauCeti.ModularForm.isBoundedAtImInfty_normRest` and
   `TauCeti.ModularForm.analyticAt_cuspFunction_normRest`.
 * `TauCeti.ModularForm.slashInvariantForm_norm_apply_eq_galoisProd_mul_normRest`, with
   `TauCeti.ModularForm.norm_apply_eq_galoisProd_mul_normRest` as its modular-form corollary.
@@ -295,16 +297,25 @@ section Analytic
 
 variable [ModularFormClass F 𝒢 k]
 
-/-- The cusp function of `normRest` is analytic at `0`. -/
-public lemma analyticAt_cuspFunction_normRest :
-    AnalyticAt ℂ (cuspFunction 1 (normRest f)) 0 := by
+/-- `normRest` is holomorphic: it is a product of coset factors, each of which is. -/
+public lemma mdifferentiable_normRest : MDiff (normRest f) := by
   classical
   let _ : Fintype (𝒮ℒ ⧸ (𝒢.subgroupOf 𝒮ℒ)) := Fintype.ofFinite _
-  exact analyticAt_cuspFunction_zero one_pos (periodic_normRest f)
-    (normRest_eq_prod_tPowCosets f ▸ MDifferentiable.prod fun q _ ↦
-      SlashInvariantForm.mdifferentiable_quotientFunc f q)
-    (normRest_eq_prod_tPowCosets f ▸ Filter.BoundedAtFilter.prod _ fun q _ ↦
-      SlashInvariantForm.isBoundedAtImInfty_quotientFunc f q)
+  exact normRest_eq_prod_tPowCosets f ▸ MDifferentiable.prod fun q _ ↦
+    SlashInvariantForm.mdifferentiable_quotientFunc f q
+
+/-- `normRest` is bounded at `∞`: it is a product of coset factors, each of which is. -/
+public lemma isBoundedAtImInfty_normRest : IsBoundedAtImInfty (normRest f) := by
+  classical
+  let _ : Fintype (𝒮ℒ ⧸ (𝒢.subgroupOf 𝒮ℒ)) := Fintype.ofFinite _
+  exact normRest_eq_prod_tPowCosets f ▸ Filter.BoundedAtFilter.prod _ fun q _ ↦
+    SlashInvariantForm.isBoundedAtImInfty_quotientFunc f q
+
+/-- The cusp function of `normRest` is analytic at `0`. -/
+public lemma analyticAt_cuspFunction_normRest :
+    AnalyticAt ℂ (cuspFunction 1 (normRest f)) 0 :=
+  analyticAt_cuspFunction_zero one_pos (periodic_normRest f)
+    (mdifferentiable_normRest f) (isBoundedAtImInfty_normRest f)
 
 /-- **Decomposition of the norm at the cusp** for a modular form: the norm of `f` from `𝒢`
 down to `𝒮ℒ` is the Galois product of the first `Subgroup.integerCuspWidth 𝒢` integer


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"general-level-order-dictionary"}-->

Advances **`TauCetiRoadmap/ModularForms/README.md`, Layer 1 — "General level — by the coset
norm"**, order-dictionary milestone.

### What this does

```lean
public lemma mdifferentiable_normRest      : MDiff (normRest f)
public lemma isBoundedAtImInfty_normRest   : IsBoundedAtImInfty (normRest f)
```

`analyticAt_cuspFunction_normRest` proved both facts inline and then discarded them, so a
caller needing either one separately could not reach it. This names them, and that lemma now
composes them rather than repeating them — it drops to a term proof.

### Why they are needed

They are precisely the hypotheses of Mathlib's `qExpansion_eq_zero_iff`
(`QExpansion.lean:525`), which is the route from `normRest f ≠ 0` (#3252) to
`(qExpansion 1 (normRest f)).order ≠ ⊤`. That finiteness is what the order bookkeeping over
the norm decomposition needs, so these two facts have to be nameable rather than buried.

Pure extraction — no new mathematics. Both statements were verified as compiled probes before
the file was edited.

### Note for reviewers

`Norm/Trace.lean` is also touched by #3232 (which adds the cusp-order identity) and by #3236
(which changes its import line to follow a file move). The three regions are disjoint;
whichever lands later takes a mechanical merge. The order agreed with the other worker is
#3232 first, then #3236 rebases.

Provenance: no external source. This exposes facts already proven in-repository by #3216, so
it needs no fresh roadmap target beyond the Layer 1 milestone cited above.
