### PR TITLE
refactor(Huber): give the weighted convolution the helpers the unweighted one has

### DIFF
--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
@@ -591,23 +591,19 @@ theorem IsWeightedRestricted.finite_coeff_notMem {T : Fin k → Set A}
 /-- One open additive subgroup absorbing exceptional coefficients of two series at once: `Z` sends
 `coeff α f * z` into `Tα · U` for every `α ∈ F`, and `coeff β g * z` into `Tβ · U` for every
 `β ∈ G`. -/
-private theorem exists_openAddSubgroup_forall_two_sided_weightMul_mem [NonarchimedeanRing A]
+private theorem exists_openAddSubgroup_forall_pair_weightMul_mem [NonarchimedeanRing A]
     {T : Fin k → Set A} (hT : IsWeightFamily T) (U : OpenAddSubgroup A)
     (F G : Finset (Fin k →₀ ℕ)) (f g : MvPowerSeries (Fin k) A) :
     ∃ Z : OpenAddSubgroup A,
       (∀ α ∈ F, ∀ z ∈ Z, MvPowerSeries.coeff α f * z ∈ weightMul T α U.toAddSubgroup) ∧
         ∀ β ∈ G, ∀ z ∈ Z, MvPowerSeries.coeff β g * z ∈ weightMul T β U.toAddSubgroup := by
   have hU : (U : Set A) ∈ nhds (0 : A) := U.isOpen.mem_nhds U.zero_mem
-  obtain ⟨Zf, hZf⟩ := NonarchimedeanRing.exists_openAddSubgroup_forall_mul_subset F
-    (fun α ↦ MvPowerSeries.coeff α f) (fun α ↦ weightMul T α U.toAddSubgroup)
-    (fun α _ ↦ hT.weightMul_mem_nhds α hU)
-  obtain ⟨Zg, hZg⟩ := NonarchimedeanRing.exists_openAddSubgroup_forall_mul_subset G
-    (fun β ↦ MvPowerSeries.coeff β g) (fun β ↦ weightMul T β U.toAddSubgroup)
-    (fun β _ ↦ hT.weightMul_mem_nhds β hU)
-  have hZf_le : Zf ⊓ Zg ≤ Zf := inf_le_left
-  have hZg_le : Zf ⊓ Zg ≤ Zg := inf_le_right
-  exact ⟨Zf ⊓ Zg, fun α hα z hz ↦ hZf α hα z (hZf_le hz),
-    fun β hβ z hz ↦ hZg β hβ z (hZg_le hz)⟩
+  obtain ⟨Z, hZ⟩ := NonarchimedeanRing.exists_openAddSubgroup_forall_mul_subset (F.disjSum G)
+    (Sum.elim (fun α ↦ MvPowerSeries.coeff α f) fun β ↦ MvPowerSeries.coeff β g)
+    (Sum.elim (fun α ↦ weightMul T α U.toAddSubgroup) fun β ↦ weightMul T β U.toAddSubgroup)
+    (by rintro (α | β) _ <;> exact hT.weightMul_mem_nhds _ hU)
+  exact ⟨Z, fun α hα z hz ↦ hZ (Sum.inl α) (Finset.inl_mem_disjSum.mpr hα) z hz,
+    fun β hβ z hz ↦ hZ (Sum.inr β) (Finset.inr_mem_disjSum.mpr hβ) z hz⟩
 
 /-- **`A⟨X⟩_T` is closed under multiplication** (Wedhorn 5.48, the point he flags as "not
 entirely clear").
@@ -630,7 +626,7 @@ theorem IsWeightedRestricted.mul [NonarchimedeanRing A] {T : Fin k → Set A}
   obtain ⟨W, hWU⟩ := NonarchimedeanRing.mul_subset U
   have hF := hf.finite_coeff_notMem W
   have hG := hg.finite_coeff_notMem W
-  obtain ⟨Z, hZf, hZg⟩ := exists_openAddSubgroup_forall_two_sided_weightMul_mem hT U
+  obtain ⟨Z, hZf, hZg⟩ := exists_openAddSubgroup_forall_pair_weightMul_mem hT U
     hF.toFinset hG.toFinset f g
   have hFZ := hf.finite_coeff_notMem Z
   have hGZ := hg.finite_coeff_notMem Z

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
@@ -62,7 +62,7 @@ counterexample in `IsWeightFamily`'s docstring shows the hypothesis is not autom
 * `TauCeti.Huber.IsWeightedRestricted.mul`: `A⟨X⟩_T` is closed under multiplication, the point
   Wedhorn flags as not entirely clear; with the additive closure lemmas this gives the subring.
   `TauCeti.Huber.IsWeightedRestricted.finite_coeff_notMem` restates the predicate as finiteness of
-  the exceptional set of coefficients, which is the form that argument consumes.
+  the exceptional set of coefficients.
 * `TauCeti.Huber.weightedNhd_subgroups_basis`: the `U⟨X⟩` are a fundamental system of
   neighbourhoods of zero for a ring topology, with its contract
   (`hasBasis_nhds_zero_weightedTopology`, `isTopologicalRing_weightedTopology`,
@@ -582,7 +582,7 @@ theorem IsWeightedRestricted.add {T : Fin k → Set A} {f g : MvPowerSeries (Fin
   simpa using (weightMul T ν U.toAddSubgroup).add_mem hfν hgν
 
 /-- Weighted restrictedness, restated: for every open additive subgroup `U`, only finitely many
-coefficients fail to lie in `Tν · U`. This is the form the convolution argument consumes. -/
+coefficients fail to lie in `Tν · U`. -/
 theorem IsWeightedRestricted.finite_coeff_notMem {T : Fin k → Set A}
     {f : MvPowerSeries (Fin k) A} (hf : IsWeightedRestricted T f) (U : OpenAddSubgroup A) :
     {ν | MvPowerSeries.coeff ν f ∉ weightMul T ν U.toAddSubgroup}.Finite :=

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
@@ -61,6 +61,8 @@ counterexample in `IsWeightFamily`'s docstring shows the hypothesis is not autom
   multiplication by an element of `Tᵢ` an open *map*, not merely of open image.
 * `TauCeti.Huber.IsWeightedRestricted.mul`: `A⟨X⟩_T` is closed under multiplication, the point
   Wedhorn flags as not entirely clear; with the additive closure lemmas this gives the subring.
+  `TauCeti.Huber.IsWeightedRestricted.finite_coeff_notMem` restates the predicate as finiteness of
+  the exceptional set of coefficients, which is the form that argument consumes.
 * `TauCeti.Huber.weightedNhd_subgroups_basis`: the `U⟨X⟩` are a fundamental system of
   neighbourhoods of zero for a ring topology, with its contract
   (`hasBasis_nhds_zero_weightedTopology`, `isTopologicalRing_weightedTopology`,
@@ -579,6 +581,34 @@ theorem IsWeightedRestricted.add {T : Fin k → Set A} {f g : MvPowerSeries (Fin
   filter_upwards [hf U, hg U] with ν hfν hgν
   simpa using (weightMul T ν U.toAddSubgroup).add_mem hfν hgν
 
+/-- Weighted restrictedness, restated: for every open additive subgroup `U`, only finitely many
+coefficients fail to lie in `Tν · U`. This is the form the convolution argument consumes. -/
+theorem IsWeightedRestricted.finite_coeff_notMem {T : Fin k → Set A}
+    {f : MvPowerSeries (Fin k) A} (hf : IsWeightedRestricted T f) (U : OpenAddSubgroup A) :
+    {ν | MvPowerSeries.coeff ν f ∉ weightMul T ν U.toAddSubgroup}.Finite :=
+  Filter.eventually_cofinite.mp (hf U)
+
+/-- One open additive subgroup absorbing exceptional coefficients of two series at once: `Z` sends
+`coeff α f * z` into `Tα · U` for every `α ∈ F`, and `coeff β g * z` into `Tβ · U` for every
+`β ∈ G`. -/
+private theorem exists_openAddSubgroup_forall_two_sided_weightMul_mem [NonarchimedeanRing A]
+    {T : Fin k → Set A} (hT : IsWeightFamily T) (U : OpenAddSubgroup A)
+    (F G : Finset (Fin k →₀ ℕ)) (f g : MvPowerSeries (Fin k) A) :
+    ∃ Z : OpenAddSubgroup A,
+      (∀ α ∈ F, ∀ z ∈ Z, MvPowerSeries.coeff α f * z ∈ weightMul T α U.toAddSubgroup) ∧
+        ∀ β ∈ G, ∀ z ∈ Z, MvPowerSeries.coeff β g * z ∈ weightMul T β U.toAddSubgroup := by
+  have hU : (U : Set A) ∈ nhds (0 : A) := U.isOpen.mem_nhds U.zero_mem
+  obtain ⟨Zf, hZf⟩ := NonarchimedeanRing.exists_openAddSubgroup_forall_mul_subset F
+    (fun α ↦ MvPowerSeries.coeff α f) (fun α ↦ weightMul T α U.toAddSubgroup)
+    (fun α _ ↦ hT.weightMul_mem_nhds α hU)
+  obtain ⟨Zg, hZg⟩ := NonarchimedeanRing.exists_openAddSubgroup_forall_mul_subset G
+    (fun β ↦ MvPowerSeries.coeff β g) (fun β ↦ weightMul T β U.toAddSubgroup)
+    (fun β _ ↦ hT.weightMul_mem_nhds β hU)
+  have hZf_le : Zf ⊓ Zg ≤ Zf := inf_le_left
+  have hZg_le : Zf ⊓ Zg ≤ Zg := inf_le_right
+  exact ⟨Zf ⊓ Zg, fun α hα z hz ↦ hZf α hα z (hZf_le hz),
+    fun β hβ z hz ↦ hZg β hβ z (hZg_le hz)⟩
+
 /-- **`A⟨X⟩_T` is closed under multiplication** (Wedhorn 5.48, the point he flags as "not
 entirely clear").
 
@@ -597,25 +627,13 @@ theorem IsWeightedRestricted.mul [NonarchimedeanRing A] {T : Fin k → Set A}
   -- `α + β = ν` has `α` bad, `β` bad, or neither, and each case lands in `Tν · U`.
   classical
   intro U
-  have hUnhds : (U : Set A) ∈ nhds (0 : A) := U.isOpen.mem_nhds U.zero_mem
   obtain ⟨W, hWU⟩ := NonarchimedeanRing.mul_subset U
-  have hF : {α | MvPowerSeries.coeff α f ∉ weightMul T α W.toAddSubgroup}.Finite :=
-    Filter.eventually_cofinite.mp (hf W)
-  have hG : {β | MvPowerSeries.coeff β g ∉ weightMul T β W.toAddSubgroup}.Finite :=
-    Filter.eventually_cofinite.mp (hg W)
-  obtain ⟨Zf, hZf⟩ := NonarchimedeanRing.exists_openAddSubgroup_forall_mul_subset hF.toFinset
-    (fun α ↦ MvPowerSeries.coeff α f) (fun α ↦ weightMul T α U.toAddSubgroup)
-    (fun α _ ↦ hT.weightMul_mem_nhds α hUnhds)
-  obtain ⟨Zg, hZg⟩ := NonarchimedeanRing.exists_openAddSubgroup_forall_mul_subset hG.toFinset
-    (fun β ↦ MvPowerSeries.coeff β g) (fun β ↦ weightMul T β U.toAddSubgroup)
-    (fun β _ ↦ hT.weightMul_mem_nhds β hUnhds)
-  set Z : OpenAddSubgroup A := Zf ⊓ Zg
-  have hZle_f : Z ≤ Zf := inf_le_left
-  have hZle_g : Z ≤ Zg := inf_le_right
-  have hFZ : {α | MvPowerSeries.coeff α f ∉ weightMul T α Z.toAddSubgroup}.Finite :=
-    Filter.eventually_cofinite.mp (hf Z)
-  have hGZ : {β | MvPowerSeries.coeff β g ∉ weightMul T β Z.toAddSubgroup}.Finite :=
-    Filter.eventually_cofinite.mp (hg Z)
+  have hF := hf.finite_coeff_notMem W
+  have hG := hg.finite_coeff_notMem W
+  obtain ⟨Z, hZf, hZg⟩ := exists_openAddSubgroup_forall_two_sided_weightMul_mem hT U
+    hF.toFinset hG.toFinset f g
+  have hFZ := hf.finite_coeff_notMem Z
+  have hGZ := hg.finite_coeff_notMem Z
   rw [Filter.eventually_cofinite]
   refine Set.Finite.subset ((hF.add hGZ).union (hFZ.add hG)) ?_
   intro ν hν
@@ -634,14 +652,14 @@ theorem IsWeightedRestricted.mul [NonarchimedeanRing A] {T : Fin k → Set A}
         exact hνE (Or.inr ⟨p.1, hbad, p.2, hp2, hsum⟩)
       rw [mul_comm, ← hsum, add_comm]
       exact mul_mem_weightMul_of_forall_mul_mem
-        (fun z hz ↦ hZg p.2 (hG.mem_toFinset.mpr hp2) z (hZle_g hz)) hgood
+        (fun z hz ↦ hZg p.2 (hG.mem_toFinset.mpr hp2) z hz) hgood
   · -- `p.1` is bad: absorb it
     have hgood : MvPowerSeries.coeff p.2 g ∈ weightMul T p.2 Z.toAddSubgroup := by
       by_contra hbad
       exact hνE (Or.inl ⟨p.1, hp1, p.2, hbad, hsum⟩)
     rw [← hsum]
     exact mul_mem_weightMul_of_forall_mul_mem
-      (fun z hz ↦ hZf p.1 (hF.mem_toFinset.mpr hp1) z (hZle_f hz)) hgood
+      (fun z hz ↦ hZf p.1 (hF.mem_toFinset.mpr hp1) z hz) hgood
 
 /-- The negation of a `T`-restricted series is `T`-restricted. -/
 theorem IsWeightedRestricted.neg {T : Fin k → Set A} {f : MvPowerSeries (Fin k) A}
@@ -778,8 +796,7 @@ theorem exists_weightedNhd_mul_mem [NonarchimedeanRing A] {T : Fin k → Set A}
   have hUnhds : (U : Set A) ∈ nhds (0 : A) := U.isOpen.mem_nhds U.zero_mem
   obtain ⟨W, hWU⟩ := NonarchimedeanRing.mul_subset U
   have hx : IsWeightedRestricted T (x : MvPowerSeries (Fin k) A) := x.2
-  have hF : {α | MvPowerSeries.coeff α (x : MvPowerSeries (Fin k) A)
-      ∉ weightMul T α W.toAddSubgroup}.Finite := Filter.eventually_cofinite.mp (hx W)
+  have hF := hx.finite_coeff_notMem W
   obtain ⟨Zx, hZx⟩ := NonarchimedeanRing.exists_openAddSubgroup_forall_mul_subset hF.toFinset
     (fun α ↦ MvPowerSeries.coeff α (x : MvPowerSeries (Fin k) A))
     (fun α ↦ weightMul T α U.toAddSubgroup) (fun α _ ↦ hT.weightMul_mem_nhds α hUnhds)
@@ -898,8 +915,7 @@ theorem exists_mvPolynomial_forall_coeff_sub_mem {T : Fin k → Set A}
     ∃ p : MvPolynomial (Fin k) A, ∀ ν, MvPowerSeries.coeff ν (f - (p : MvPowerSeries (Fin k) A))
       ∈ weightMul T ν U.toAddSubgroup := by
   classical
-  have hbad : {ν | MvPowerSeries.coeff ν f ∉ weightMul T ν U.toAddSubgroup}.Finite :=
-    Filter.eventually_cofinite.mp (hf U)
+  have hbad := hf.finite_coeff_notMem U
   refine ⟨MvPowerSeries.truncFinset A hbad.toFinset f, fun ν ↦ ?_⟩
   rw [map_sub, MvPolynomial.coeff_coe, MvPowerSeries.coeff_truncFinset]
   by_cases hν : ν ∈ hbad.toFinset


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"weighted-convolution-helpers"}-->

Pure refactor of merged code; CLAUDE.md puts proof simplification in scope at any time. No
statement changes, no new mathematics.

`IsWeightedRestricted.mul` — Wedhorn 5.48, the step he flags as "not entirely clear" — was
**59 lines**, over the 50-line cap. It is now **45**. The change is to give the weighted file the
two helpers its unweighted sibling already has.

## First helper: restrictedness as finiteness

`RestrictedPowerSeries.lean` states this once, as public API:

```lean
theorem IsRestricted.finite_coeff_notMem (hf : IsRestricted f) (W : OpenAddSubgroup A) :
    {s | MvPowerSeries.coeff s f ∉ (W : Set A)}.Finite
```

The weighted file had no analogue and instead open-coded `Filter.eventually_cofinite.mp (h U)`
with the set spelled out **six times** — four in `IsWeightedRestricted.mul`, one in
`exists_weightedNhd_mul_mem`, one in `exists_mvPolynomial_forall_coeff_sub_mem`. All six now read

```lean
theorem IsWeightedRestricted.finite_coeff_notMem (hf : IsWeightedRestricted T f)
    (U : OpenAddSubgroup A) :
    {ν | MvPowerSeries.coeff ν f ∉ weightMul T ν U.toAddSubgroup}.Finite :=
  Filter.eventually_cofinite.mp (hf U)
```

It is a one-line unfolding, and that is the point: the *statement* is what earns the name. Each
of the six sites had to re-derive the set expression and each took two lines to do it.

## Second helper: one subgroup absorbing both factors

```lean
private theorem exists_openAddSubgroup_forall_pair_weightMul_mem
    (hT : IsWeightFamily T) (U : OpenAddSubgroup A)
    (F G : Finset (Fin k →₀ ℕ)) (f g : MvPowerSeries (Fin k) A) :
    ∃ Z : OpenAddSubgroup A,
      (∀ α ∈ F, ∀ z ∈ Z, MvPowerSeries.coeff α f * z ∈ weightMul T α U.toAddSubgroup) ∧
        ∀ β ∈ G, ∀ z ∈ Z, MvPowerSeries.coeff β g * z ∈ weightMul T β U.toAddSubgroup
```

This is `NonarchimedeanRing.exists_openAddSubgroup_forall_mul_subset` applied **once**, to
`F.disjSum G`, with `Sum.elim` supplying both the coefficient function and the target family.
Inline, the same step cost nine lines — two three-line applications of that lemma, the
`set Z := Zf ⊓ Zg`, and the two `Z ≤ Zf`, `Z ≤ Zg` inclusions, which then had to be threaded
through both branches of the case split. Named, the convolution argument obtains one subgroup and
uses it directly.

It plays the role that `exists_mem_nhds_zero_two_sided_mul_subset` plays in `IsRestricted.mul`
(#3255), but it is not its mirror image: that file's `A` is a bare `Ring`, so its statement is
genuinely two-*sided*, while here `A` is a `CommRing` and both conjuncts multiply on the same
side — hence `pair`, not `two_sided`. The two PRs are independent: different files, different
statements, no shared code, and neither depends on the other.

## Not changed

`IsWeightedRestricted.mul`'s statement, and the mathematics of the convolution bound: the
exceptional set `E = (F + G_Z) ∪ (F_Z + G)`, the three-case split on a splitting `α + β = ν`, and
the standing `IsWeightFamily` hypothesis are all untouched. Only the neighbourhood construction
and the finiteness bookkeeping moved.

## Checked against Mathlib and the file's imports

* `Filter.eventually_cofinite` is the general lemma; `finite_coeff_notMem` is a named
  specialisation at this predicate, matching the sibling file's API, not a reproof.
* `NonarchimedeanRing.exists_openAddSubgroup_forall_mul_subset`
  (`TauCeti/Topology/Algebra/Nonarchimedean/Absorption.lean`) already gives the *one-sided*
  statement for an arbitrary finite family; the helper here is that lemma used twice, not a new
  induction.
* Grepped `TauCeti/` for `finite_coeff_notMem` and for a two-sided absorbing subgroup before
  writing either: the only hit was the unweighted sibling.

`WeightedRestrictedSeries/Basic.lean` is 1330 lines, up 16 net. It was already past the point
where `/split-file` would be worth considering; splitting it is a separate PR and is not
attempted here.

## Review round 2

Both findings implemented, neither contested.

* `reuse` — the helper applied the finite-family absorption lemma twice and intersected the
  results by hand. It now applies it once to the disjoint sum, as the finding prescribed; the
  conjuncts come back through `Finset.inl_mem_disjSum` / `inr_mem_disjSum`. Four lines shorter,
  and the API is used rather than re-derived. The finding's conditional second half — remove the
  wrapper if it stays single-use — is declined for a stated reason: inlining its seven lines puts
  `IsWeightedRestricted.mul` back at the 50-line cap, which is what this PR exists to get under.
* `naming` — `two_sided` was wrong and I had carried it over from the unweighted file, where `A`
  is a bare `Ring` and the two conjuncts really are `a * y` and `x * b`. Here `A` is a `CommRing`,
  both conjuncts multiply on the same side, and the helper absorbs a *pair of families*. Renamed
  to `exists_openAddSubgroup_forall_pair_weightMul_mem`.

## Gates

Build GATE_BUILD jobs; `axioms` GATE_AXIOMS declarations, allowlist only; `module-system`
GATE_MODULES modules; `LINT-ENV: PASS`. Widths, the module-docstring name-resolution check, and
the mathlib-absence greps run over the changed file; no proof in it is over the 50-line cap.
