### PR TITLE
feat(EDS): a normalised EDS is an elliptic sequence

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Descent
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Universal
+
+/-!
+# A normalised EDS is an elliptic sequence
+
+`normEDS b c d` is defined by the doubling recursion, so it satisfies that recursion by
+construction. This file draws the consequence: it satisfies the full three-index elliptic
+relation, for arbitrary `b`, `c`, `d` in any commutative ring.
+
+This is the first half of the TODO Mathlib records at
+`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean:70`, "prove that `normEDS` satisfies
+`IsEllipticDvdSequence`". That predicate is `IsEllipticSequence ∧ IsDvdSequence`; the second
+conjunct needs a general `normEDS_mul_complEDS`, of which Mathlib has only the `k = 2` case, and
+is left to its own slice.
+
+## Main results
+
+* `isEllipticSequence_normEDS`: `IsEllipticSequence (normEDS b c d)`, with no hypothesis on the
+  parameters.
+
+## Implementation notes
+
+The direct argument needs `normEDS b c d 2 = b` to be a nonzerodivisor, which is a genuine
+constraint on `b`. It is avoided by proving the statement over `ℤ[B, C, D]` first, where the
+second term is the indeterminate `X B` and is a nonzerodivisor because a polynomial ring over a
+domain is a domain, and then transporting along `aeval`. Every `normEDS b c d` is such a
+specialisation of `universalNormEDS`, which is what `normEDS_eq_aeval` says, so the hypothesis
+survives only in the private helper, applied once at the indeterminates.
+
+`Universal.lean` records `universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors`
+as belonging with "whichever slice ports" the fact proved here. They are still not ported: they
+rest on `normEDS 2 3 2 = id`, which additionally needs an extensionality principle for elliptic
+sequences that this repository does not yet have. This file is the prerequisite they were
+waiting on, not the slice that lands them.
+
+## Provenance
+
+Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations
+`IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That file's header
+reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
+upstream authorship is credited here rather than in the copyright header.
+
+The source proves the hypothesis-carrying version from its own descent development; here that
+step is `isEllipticSequence_iff`, so the helper is six lines rather than a file. The universal
+transport is the source's argument, with `normEDS_eq_aeval` in place of its inline rewriting.
+-/
+
+public section
+
+open scoped nonZeroDivisors
+open MvPolynomial NormEDSParam
+
+variable {R : Type*} [CommRing R] {b c d : R}
+
+/-- **A normalised EDS is an elliptic sequence, given that `b` is a nonzerodivisor.** Superseded
+by `isEllipticSequence_normEDS`, which carries no hypothesis; this is the form that transports. -/
+private theorem isEllipticSequence_normEDS_of_mem (hb : b ∈ R⁰) :
+    IsEllipticSequence (normEDS b c d) := by
+  refine (isEllipticSequence_iff (fun k ↦ normEDS_neg b c d k) (normEDS_zero b c d)
+    (by simp [normEDS_one]) (by simpa [normEDS_two] using hb)).mpr ⟨fun m _ ↦ ?_, fun m _ ↦ ?_⟩
+  · simpa [normEDS_one] using normEDS_odd b c d m
+  -- `linear_combination` needs `normEDS _ _ _ 2` and `… 1` as `b` and `1` before it can match.
+  · simp only [normEDS_one, normEDS_two, one_pow, mul_one]
+    linear_combination normEDS_even b c d m
+
+/-- **A normalised EDS is an elliptic sequence.** No hypothesis on `b`, `c`, `d`. -/
+theorem isEllipticSequence_normEDS (b c d : R) : IsEllipticSequence (normEDS b c d) := by
+  -- Supply the defining equation rather than leaving it to `isDefEq`: `universalNormEDS`'s body
+  -- is not exposed, so unification cannot cheaply see it as `normEDS (X B) (X C) (X D)`.
+  have huniv : IsEllipticSequence (universalNormEDS : ℤ → MvPolynomial NormEDSParam ℤ) := by
+    have hfun : (universalNormEDS : ℤ → MvPolynomial NormEDSParam ℤ)
+        = normEDS (X B) (X C) (X D) := funext universalNormEDS_apply
+    rw [hfun]
+    exact isEllipticSequence_normEDS_of_mem (mem_nonZeroDivisors_of_ne_zero (X_ne_zero B))
+  intro p q r
+  -- `map_rel` is stated for `f ∘ W`, `normEDS_eq_aeval` for the eta-expanded lambda.
+  rw [normEDS_eq_aeval (b := b) (c := c) (d := d), ← Function.comp_def,
+    ← IsEllipticNet.map_rel, huniv, map_zero]


### PR DESCRIPTION
A normalised elliptic divisibility sequence really is an elliptic sequence — with no hypothesis
on its parameters.

```lean
-- TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
theorem isEllipticSequence_normEDS (b c d : R) : IsEllipticSequence (normEDS b c d)
```

This is the elliptic half of the first TODO Mathlib leaves open in
`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean:70`:

> TODO: prove that `normEDS` satisfies `IsEllipticDvdSequence`.

`IsEllipticDvdSequence` is `IsEllipticSequence ∧ IsDvdSequence`. This PR settles the first
conjunct; the second needs `normEDS_mul_complEDS`, of which Mathlib has only the `k = 2` case
(`normEDS_dvd_normEDS_two_mul`), and is left for its own slice.

## Why there is no hypothesis on `b`

The direct argument needs `normEDS b c d 2 = b` to be a nonzerodivisor, which is a real
constraint on `b`. The universal route avoids it: prove the statement over
`ℤ[B, C, D] = MvPolynomial NormEDSParam ℤ`, where the second term is the indeterminate `X B` and
is a nonzerodivisor because a polynomial ring over a domain is a domain, then transport along
`aeval` to an arbitrary `CommRing`. Every specialisation `normEDS b c d` is the image of
`universalNormEDS` under such an `aeval`, which is exactly what `Universal.lean`'s
`normEDS_eq_aeval` says.

So the hypothesis-carrying version survives only as a private helper, used once, at the
indeterminates.

## What this consumes

* `isEllipticSequence_iff` — the equivalence between `IsEllipticSequence` and the two doubling
  recurrences. Each of its four hypotheses is discharged by an existing Mathlib lemma
  (`normEDS_neg`, `normEDS_zero`, `normEDS_one`, `normEDS_two`), and its two recurrence
  obligations by `normEDS_odd` and `normEDS_even`.
* `Universal.lean`'s `normEDS_eq_aeval`, for the transport.
* Mathlib's `IsEllipticNet.map_rel`, for the ring-hom compatibility of the relator.

## A note on what this unblocks

`Universal.lean` records two declarations as deliberately not ported, with the reason:

> Deliberately **not** ported here: `universalNormEDS_ne_zero` and
> `universalNormEDS_mem_nonZeroDivisors`. They rest on `normEDS 2 3 2 = id`, whose proof needs
> `normEDS` to be known an elliptic sequence — which the pinned Mathlib does not know … They
> belong with whichever slice ports that.

This is that slice, and the fact is now available. Those two are still **not** included here,
because `normEDS 2 3 2 = id` additionally needs an extensionality principle for elliptic
sequences (AINTLIB's `IsEllSequence.ext`) that this repository does not yet have. They land with
that principle, which is the next slice; this PR is the prerequisite it was waiting on.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, the **Layer 6** torsion/Nagell–Lutz strand. The route
to `lutz_nagell` runs through the division polynomials, and every step past the recurrences needs
`normEDS` known to be elliptic — it is the hypothesis of the invariant and denominator arguments
that follow.

## Provenance

Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations
`IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That file's header
reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
upstream authorship is credited in the module docstring rather than in the copyright header.

The source proves the hypothesis-carrying version from its own descent; here that step is
`isEllipticSequence_iff`, so the helper is six lines rather than a development. The universal
transport is the source's argument, with `normEDS_eq_aeval` standing in for its inline `aeval`
rewriting.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-normeds-elliptic"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
