### PR TITLE
feat(Huber): boundedness transfers from A to its completion

### DIFF
--- a/TauCeti/RingTheory/Huber/Completion.lean
+++ b/TauCeti/RingTheory/Huber/Completion.lean
@@ -38,9 +38,10 @@ converge because `Â` is complete, and their sums exhibit the element as a combi
 
 ## Main results
 
-* `TauCeti.Huber.PairOfDefinition.isBounded_image_completion_coe_of_isBounded` and
-  `TauCeti.Huber.PairOfDefinition.isPowerBounded_completion_coe_of_isPowerBounded`: boundedness and
-  power-boundedness transfer from `A` to its completion along the canonical map.
+* `TauCeti.Huber.isBounded_image_completion_coe_of_isBounded` and
+  `TauCeti.Huber.isPowerBounded_completion_coe_of_isPowerBounded`: boundedness and
+  power-boundedness transfer from `A` to its completion along the canonical map. Both are stated
+  for a Huber ring, with no pair of definition in the signature.
 * `TauCeti.Huber.PairOfDefinition.hasBasis_nhds_zero_completion`: the closures of the images of
   the powers `Iⁿ` are a neighbourhood basis of zero in `Â`.
 * `TauCeti.Huber.PairOfDefinition.completionIdeal_pow`: `Îⁿ` is the closure of the image of `Iⁿ`.
@@ -442,13 +443,19 @@ theorem mem_completion_idealOfDefinition (P : PairOfDefinition A)
       (⟨x, by rw [← completion_ringOfDefinition P]; exact x.2⟩ :
         P.completionRingOfDefinition) ∈ P.completionIdeal := (Iff.rfl)
 
-/-- The image of a bounded subset of `A` is bounded in the completion.
+end PairOfDefinition
+
+/-- **The image of a bounded subset of `A` is bounded in `Â`.**
+
+Stated for a Huber ring rather than for a chosen pair of definition: the conclusion does not
+mention one, so the choice is internal to the proof.
 
 The closure argument follows AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, branch
 `dev/adic-spaces` at `37bbdaeb9`), `projects/AdicSpaces/Adic spaces/LocalizationTopology.lean:545`,
 where it is stated for the rational-localisation completion. No proof was copied. -/
-theorem isBounded_image_completion_coe_of_isBounded (P : PairOfDefinition A) {X : Set A}
+theorem isBounded_image_completion_coe_of_isBounded [IsHuberRing A] {X : Set A}
     (hX : IsBounded X) : IsBounded (((↑) : A → Completion A) '' X) := by
+  refine (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim fun P ↦ ?_
   rw [isBounded_iff]
   intro U hU
   obtain ⟨n, -, hnU⟩ := (P.hasBasis_nhds_zero_completion).mem_iff.mp hU
@@ -462,35 +469,27 @@ theorem isBounded_image_completion_coe_of_isBounded (P : PairOfDefinition A) {X 
   -- the closure of the first into the closure of the second.
   have hcont : Continuous (fun u : Completion A ↦ u * (x : Completion A)) :=
     continuous_id.mul continuous_const
-  have hmaps : ∀ z ∈ ((↑) : A → Completion A) '' (P.idealImage m : Set A),
-      z * (x : Completion A)
-        ∈ closure (((↑) : A → Completion A) '' (P.idealImage n : Set A)) := by
+  have hmaps : ((↑) : A → Completion A) '' (P.idealImage m : Set A)
+      ⊆ (fun u : Completion A ↦ u * (x : Completion A)) ⁻¹'
+        closure (((↑) : A → Completion A) '' (P.idealImage n : Set A)) := by
     rintro _ ⟨a, ha, rfl⟩
-    rw [← Completion.coe_mul]
+    rw [Set.mem_preimage, ← Completion.coe_mul]
     exact subset_closure ⟨a * x, hXW (Set.mul_mem_mul (hmW ha) hxX), rfl⟩
-  have himg : (fun u : Completion A ↦ u * (x : Completion A)) ''
-      (((↑) : A → Completion A) '' (P.idealImage m : Set A))
-      ⊆ closure (((↑) : A → Completion A) '' (P.idealImage n : Set A)) := by
-    rintro _ ⟨z, hz, rfl⟩
-    exact hmaps z hz
-  exact closure_minimal himg isClosed_closure
+  exact closure_minimal (Set.image_subset_iff.mpr hmaps) isClosed_closure
     (image_closure_subset_closure_image hcont ⟨y, hy, rfl⟩)
 
 /-- **A power-bounded element of `A` stays power-bounded in `Â`.** -/
-theorem isPowerBounded_completion_coe_of_isPowerBounded (P : PairOfDefinition A) {a : A}
+theorem isPowerBounded_completion_coe_of_isPowerBounded [IsHuberRing A] {a : A}
     (ha : IsPowerBounded a) : IsPowerBounded ((a : Completion A)) := by
+  -- the coercion is `⇑Completion.coeRingHom`, so it commutes with powers; stated once here
+  have hcoe : ∀ k : ℕ, ((a : Completion A)) ^ k = ((a ^ k : A) : Completion A) :=
+    fun k ↦ (map_pow Completion.coeRingHom a k).symm
   have h : Set.range (((a : Completion A)) ^ · : ℕ → Completion A)
       = ((↑) : A → Completion A) '' Set.range (a ^ · : ℕ → A) := by
-    ext y
-    constructor
-    · rintro ⟨k, rfl⟩
-      exact ⟨a ^ k, ⟨k, rfl⟩, map_pow Completion.coeRingHom a k⟩
-    · rintro ⟨_, ⟨k, rfl⟩, rfl⟩
-      exact ⟨k, (map_pow Completion.coeRingHom a k).symm⟩
+    simpa only [hcoe] using Set.range_comp' (((↑) : A → Completion A)) (a ^ · : ℕ → A)
   rw [isPowerBounded_iff, h]
-  exact P.isBounded_image_completion_coe_of_isBounded (isPowerBounded_iff.mp ha)
+  exact isBounded_image_completion_coe_of_isBounded (isPowerBounded_iff.mp ha)
 
-end PairOfDefinition
 
 /-- Wedhorn Remark 6.8: the completion of a Huber ring is a Huber ring. -/
 instance IsHuberRing.completion [IsHuberRing A] : IsHuberRing (Completion A) :=

--- a/TauCeti/RingTheory/Huber/Completion.lean
+++ b/TauCeti/RingTheory/Huber/Completion.lean
@@ -38,8 +38,8 @@ converge because `Â` is complete, and their sums exhibit the element as a combi
 
 ## Main results
 
-* `TauCeti.Huber.PairOfDefinition.isBounded_image_coe_of_isBounded` and
-  `TauCeti.Huber.PairOfDefinition.isPowerBounded_coe_of_isPowerBounded`: boundedness and
+* `TauCeti.Huber.PairOfDefinition.isBounded_image_completion_coe_of_isBounded` and
+  `TauCeti.Huber.PairOfDefinition.isPowerBounded_completion_coe_of_isPowerBounded`: boundedness and
   power-boundedness transfer from `A` to its completion along the canonical map.
 * `TauCeti.Huber.PairOfDefinition.hasBasis_nhds_zero_completion`: the closures of the images of
   the powers `Iⁿ` are a neighbourhood basis of zero in `Â`.
@@ -442,8 +442,12 @@ theorem mem_completion_idealOfDefinition (P : PairOfDefinition A)
       (⟨x, by rw [← completion_ringOfDefinition P]; exact x.2⟩ :
         P.completionRingOfDefinition) ∈ P.completionIdeal := (Iff.rfl)
 
-/-- The image of a bounded subset of `A` is bounded in the completion. -/
-theorem isBounded_image_coe_of_isBounded (P : PairOfDefinition A) {X : Set A}
+/-- The image of a bounded subset of `A` is bounded in the completion.
+
+The closure argument follows AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, branch
+`dev/adic-spaces` at `37bbdaeb9`), `projects/AdicSpaces/Adic spaces/LocalizationTopology.lean:545`,
+where it is stated for the rational-localisation completion. No proof was copied. -/
+theorem isBounded_image_completion_coe_of_isBounded (P : PairOfDefinition A) {X : Set A}
     (hX : IsBounded X) : IsBounded (((↑) : A → Completion A) '' X) := by
   rw [isBounded_iff]
   intro U hU
@@ -473,7 +477,7 @@ theorem isBounded_image_coe_of_isBounded (P : PairOfDefinition A) {X : Set A}
     (image_closure_subset_closure_image hcont ⟨y, hy, rfl⟩)
 
 /-- **A power-bounded element of `A` stays power-bounded in `Â`.** -/
-theorem isPowerBounded_coe_of_isPowerBounded (P : PairOfDefinition A) {a : A}
+theorem isPowerBounded_completion_coe_of_isPowerBounded (P : PairOfDefinition A) {a : A}
     (ha : IsPowerBounded a) : IsPowerBounded ((a : Completion A)) := by
   have h : Set.range (((a : Completion A)) ^ · : ℕ → Completion A)
       = ((↑) : A → Completion A) '' Set.range (a ^ · : ℕ → A) := by
@@ -484,7 +488,7 @@ theorem isPowerBounded_coe_of_isPowerBounded (P : PairOfDefinition A) {a : A}
     · rintro ⟨_, ⟨k, rfl⟩, rfl⟩
       exact ⟨k, (map_pow Completion.coeRingHom a k).symm⟩
   rw [isPowerBounded_iff, h]
-  exact P.isBounded_image_coe_of_isBounded (isPowerBounded_iff.mp ha)
+  exact P.isBounded_image_completion_coe_of_isBounded (isPowerBounded_iff.mp ha)
 
 end PairOfDefinition
 

--- a/TauCeti/RingTheory/Huber/Completion.lean
+++ b/TauCeti/RingTheory/Huber/Completion.lean
@@ -38,6 +38,9 @@ converge because `Â` is complete, and their sums exhibit the element as a combi
 
 ## Main results
 
+* `TauCeti.Huber.PairOfDefinition.isBounded_image_coe_of_isBounded` and
+  `TauCeti.Huber.PairOfDefinition.isPowerBounded_coe_of_isPowerBounded`: boundedness and
+  power-boundedness transfer from `A` to its completion along the canonical map.
 * `TauCeti.Huber.PairOfDefinition.hasBasis_nhds_zero_completion`: the closures of the images of
   the powers `Iⁿ` are a neighbourhood basis of zero in `Â`.
 * `TauCeti.Huber.PairOfDefinition.completionIdeal_pow`: `Îⁿ` is the closure of the image of `Iⁿ`.
@@ -438,6 +441,50 @@ theorem mem_completion_idealOfDefinition (P : PairOfDefinition A)
     x ∈ P.completion.idealOfDefinition ↔
       (⟨x, by rw [← completion_ringOfDefinition P]; exact x.2⟩ :
         P.completionRingOfDefinition) ∈ P.completionIdeal := (Iff.rfl)
+
+/-- The image of a bounded subset of `A` is bounded in the completion. -/
+theorem isBounded_image_coe_of_isBounded (P : PairOfDefinition A) {X : Set A}
+    (hX : IsBounded X) : IsBounded (((↑) : A → Completion A) '' X) := by
+  rw [isBounded_iff]
+  intro U hU
+  obtain ⟨n, -, hnU⟩ := (P.hasBasis_nhds_zero_completion).mem_iff.mp hU
+  obtain ⟨W, hW, hXW⟩ := isBounded_iff.mp hX (P.idealImage n)
+    ((P.isOpen_idealImage n).mem_nhds (P.idealImage n).zero_mem)
+  obtain ⟨m, -, hmW⟩ := P.hasBasis_nhds_zero.mem_iff.mp hW
+  refine ⟨_, (P.hasBasis_nhds_zero_completion).mem_of_mem (i := m) trivial,
+    Set.Subset.trans ?_ hnU⟩
+  rintro _ ⟨y, hy, _, ⟨x, hxX, rfl⟩, rfl⟩
+  -- `· * ↑x` is continuous and carries the image of `Iᵐ` into the image of `Iⁿ`, so it carries
+  -- the closure of the first into the closure of the second.
+  have hcont : Continuous (fun u : Completion A ↦ u * (x : Completion A)) :=
+    continuous_id.mul continuous_const
+  have hmaps : ∀ z ∈ ((↑) : A → Completion A) '' (P.idealImage m : Set A),
+      z * (x : Completion A)
+        ∈ closure (((↑) : A → Completion A) '' (P.idealImage n : Set A)) := by
+    rintro _ ⟨a, ha, rfl⟩
+    rw [← Completion.coe_mul]
+    exact subset_closure ⟨a * x, hXW (Set.mul_mem_mul (hmW ha) hxX), rfl⟩
+  have himg : (fun u : Completion A ↦ u * (x : Completion A)) ''
+      (((↑) : A → Completion A) '' (P.idealImage m : Set A))
+      ⊆ closure (((↑) : A → Completion A) '' (P.idealImage n : Set A)) := by
+    rintro _ ⟨z, hz, rfl⟩
+    exact hmaps z hz
+  exact closure_minimal himg isClosed_closure
+    (image_closure_subset_closure_image hcont ⟨y, hy, rfl⟩)
+
+/-- **A power-bounded element of `A` stays power-bounded in `Â`.** -/
+theorem isPowerBounded_coe_of_isPowerBounded (P : PairOfDefinition A) {a : A}
+    (ha : IsPowerBounded a) : IsPowerBounded ((a : Completion A)) := by
+  have h : Set.range (((a : Completion A)) ^ · : ℕ → Completion A)
+      = ((↑) : A → Completion A) '' Set.range (a ^ · : ℕ → A) := by
+    ext y
+    constructor
+    · rintro ⟨k, rfl⟩
+      exact ⟨a ^ k, ⟨k, rfl⟩, map_pow Completion.coeRingHom a k⟩
+    · rintro ⟨_, ⟨k, rfl⟩, rfl⟩
+      exact ⟨k, (map_pow Completion.coeRingHom a k).symm⟩
+  rw [isPowerBounded_iff, h]
+  exact P.isBounded_image_coe_of_isBounded (isPowerBounded_iff.mp ha)
 
 end PairOfDefinition
 


### PR DESCRIPTION
**Boundedness transfers from `A` to its completion `Â`.**

Two theorems in `Huber/Completion.lean`:

* `isBounded_image_coe_of_isBounded` — a bounded subset of `A` has bounded image in `Â`;
* `isPowerBounded_coe_of_isPowerBounded` — hence a power-bounded element stays power-bounded.

## Why

`Huber/Completion.lean` currently mentions neither `IsBounded` nor `IsPowerBounded`: it builds the
completion's ring of definition and its zero-basis, but says nothing about which subsets stay
bounded. Roadmap Layer 3.1 needs exactly that. `A_U⁺` is defined as an integral closure inside
`A⟨T/s⟩` of the *image* of `A⁺[T/s]`, and showing that image power-bounded — the substance of the
Huber-pair property for `(A_U, A_U⁺)` — is a statement about the completion map, not about the
localisation.

This is the completion half. The localisation half, transfer along `A → Aₛ`, is #3272; the two are
independent and neither uses the other.

## Proof

The completion's zero-basis is the closures of the images of the `Iⁿ`
(`hasBasis_nhds_zero_completion`). Given `U` and its index `n`, boundedness of `X` supplies
`W ∈ 𝓝 0` with `W * X ⊆ image(Iⁿ)`, and `Iᵐ ⊆ W` for some `m`. Multiplication by a fixed `↑x` is
continuous and carries `image(Iᵐ)` into `image(Iⁿ)`, so it carries the closure of the first into
the closure of the second — `image_closure_subset_closure_image` then `closure_minimal`.

## Three things worth recording, each of which cost a cycle

* **Match the destination file's `variable` line before writing.** This file uses
  `[UniformSpace A] [IsUniformAddGroup A] [IsTopologicalRing A]`; opening with
  `[TopologicalSpace A] [NonarchimedeanRing A]` fails to synthesize `UniformSpace A` *and* draws
  `linter.overlappingInstances`.
* **The `show` linter rejects a beta-reducing restatement.** `rintro _ ⟨_, ⟨a, ha, rfl⟩, rfl⟩`
  leaves `(fun u ↦ u * ↑x) ↑a`, and `show` used to beta-reduce it is flagged as changing the goal
  rather than restating it. The image inclusion is now proved directly, where `exact` closes the
  redex up to defeq without a tactic that announces it.
* **`image_closure_subset_closure_image` is a root-namespace lemma.** There is no
  `Continuous.image_closure_subset_closure_image`, and dot-notation fails with an invalid-field
  error that reads as though the hypothesis is wrong.

## Gates

`lake build` (0 warnings), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
(`LINT-ENV: PASS`) — all exit 0, each run separately, on this head atop current `main`.

## Provenance

AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `dev/adic-spaces` at `37bbdaeb9`),
`LocalizationTopology.lean:545` has the same closure argument for the rational-localisation
completion. This is stated for the completion of `A` itself, against TauCeti's
`completionIdealImage` API; no proof was copied.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-3.1-completion-transfer"}-->

Part of TauCetiProject/TauCetiRoadmap#174.
