### PR TITLE
refactor(EDS): name the base case and sorted case of the descent

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -279,6 +279,28 @@ private theorem atomRel_odd_eq_rel (k : ℤ) :
   simp_rw [atomRel, atom_odd, rel]
   ring_nf
 
+/-- **At a gap of exactly two the relator vanishes at the minimal pair.** This is where the
+induction bottoms out: the odd recurrence supplies the even first index and the even recurrence
+the odd one. -/
+private theorem atomRel_eq_zero_of_gap_two
+    (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
+    (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) {a b : ℤ} (h6 : 6 ≤ a)
+    (hb : b + 2 = a) :
+    atomRel W a b (a % 2 + 2) (a % 2) = 0 := by
+  rcases Int.emod_two_eq_zero_or_one a with hp | hp
+  · obtain ⟨k, rfl⟩ : ∃ k, a = 2 * k := ⟨a / 2, by omega⟩
+    -- `atomRel_even_eq_rel` is stated with its second index in `2 * _` form, which is what lets
+    -- `atomRel_two_mul` reduce every atom; put `b` in that form before rewriting.
+    obtain rfl : b = 2 * (k - 1) := by omega
+    rw [atomRel_even_eq_rel]
+    simpa using oddRec (k - 1) (by omega)
+  · obtain ⟨k, rfl⟩ : ∃ k, a = 2 * k + 1 := ⟨a / 2, by omega⟩
+    -- Likewise `atomRel_odd_eq_rel` wants `2 * _ + 1`, which is what lets `atom_odd` reduce each
+    -- atom without any reasoning about truncated division.
+    obtain rfl : b = 2 * (k - 1) + 1 := by omega
+    rw [atomRel_odd_eq_rel]
+    exact evenRec k (by omega)
+
 /-- **The descent.** The two doubling recurrences, holding from `m = 2` and `m = 3` on, force the
 full four-index relation at every valid quadruple. The induction is on the largest index: below
 `6` no valid quadruple exists, and above it `atomRelVanishes_of_min` reduces to the minimal
@@ -310,13 +332,7 @@ private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
     · rw [← atomRel_avg_sub W same, ← atomRel_abs₄]
       exact ih _ (by omega) _ _ _ (parity_abs_avg_sub same)
         (nonnegStrictAnti₄_abs_avg_sub h1 (by omega) h2 h3)
-    · rcases Int.emod_two_eq_zero_or_one a' with hp | hp
-      · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k := ⟨a' / 2, by omega⟩
-        rw [show b' = 2 * (k - 1) by omega, atomRel_even_eq_rel]
-        simpa using oddRec (k - 1) (by omega)
-      · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k + 1 := ⟨a' / 2, by omega⟩
-        rw [show b' = 2 * (k - 1) + 1 by omega, atomRel_odd_eq_rel]
-        exact evenRec k (by omega)
+    · exact atomRel_eq_zero_of_gap_two oddRec evenRec (by omega) hb
 
 /-- The relator vanishes at three even indices in strict decrease above `0`, against a last
 index of `0`: the descent's hypothesis at exactly the shape the sorting step below produces. -/

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -274,11 +274,39 @@ private theorem atomRel_odd_eq_rel (m : ℤ) :
   simp_rw [atomRel, atom_odd, rel]
   ring_nf
 
+/-- **The even base case**: first index `2 * k`, second two below it, at the minimal pair
+`(2, 0)`. This is where the odd recurrence is consumed. -/
+private theorem atomRelVanishes_base_even
+    (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0) {k b : ℤ} (hk : 3 ≤ k)
+    (hb : b = 2 * (k - 1)) :
+    atomRel W (2 * k) b (2 * k % 2 + 2) (2 * k % 2) = 0 := by
+  have hodd := oddRec (k - 1) (by omega)
+  rw [sub_add_cancel] at hodd
+  -- `atomRel_even_eq_rel` carries every index in `2 * _` form, which is what lets
+  -- `atomRel_two_mul` fire; the goal's indices have to be put in that form first.
+  have hlast : (2 * k % 2 : ℤ) = 2 * 0 := by omega
+  have hthird : (2 : ℤ) * 0 + 2 = 2 * 1 := by norm_num
+  rw [hlast, hthird, hb, atomRel_even_eq_rel]
+  exact hodd
+
+/-- **The odd base case**: first index `2 * k + 1`, second two below it, at the minimal pair
+`(3, 1)`. This is where the even recurrence is consumed. -/
+private theorem atomRelVanishes_base_odd
+    (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) {k b : ℤ} (hk : 3 ≤ k)
+    (hb : b = 2 * (k - 1) + 1) :
+    atomRel W (2 * k + 1) b ((2 * k + 1) % 2 + 2) ((2 * k + 1) % 2) = 0 := by
+  -- Likewise `atomRel_odd_eq_rel` carries its indices in `2 * _ + 1` form, which is what lets
+  -- `atom_odd` reduce each atom without any reasoning about truncated division.
+  have hlast : ((2 * k + 1) % 2 : ℤ) = 2 * 0 + 1 := by omega
+  have hthird : (2 : ℤ) * 0 + 1 + 2 = 2 * 1 + 1 := by norm_num
+  rw [hlast, hthird, hb, atomRel_odd_eq_rel]
+  exact evenRec k (by omega)
+
 /-- **The descent.** The two doubling recurrences, holding from `m = 2` and `m = 3` on, force the
 full four-index relation at every valid quadruple. The induction is on the largest index: below
 `6` no valid quadruple exists, and above it `atomRelVanishes_of_min` reduces to the minimal
 pair, where either the gap `b + 2 < a` admits the transfer down to a smaller first index, or
-`b + 2 = a` lands on one of the two recurrences according to parity. -/
+`b + 2 = a` lands on one of the two base cases according to parity. -/
 private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
     (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
     (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) :
@@ -307,23 +335,17 @@ private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
         (nonnegStrictAnti₄_abs_avg_sub h1 (by omega) h2 h3)
     · rcases Int.emod_two_eq_zero_or_one a' with hp | hp
       · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k := ⟨a' / 2, by omega⟩
-        have hodd := oddRec (k - 1) (by omega)
-        rw [sub_add_cancel] at hodd
-        -- `atomRel_even_eq_rel` carries every index in `2 * _` form, which is what lets
-        -- `atomRel_two_mul` fire; the goal's indices have to be put in that form first.
-        have hlast : (2 * k % 2 : ℤ) = 2 * 0 := by omega
-        have hthird : (2 : ℤ) * 0 + 2 = 2 * 1 := by norm_num
-        have hsecond : b' = 2 * (k - 1) := by omega
-        rw [hlast, hthird, hsecond, atomRel_even_eq_rel]
-        exact hodd
+        exact atomRelVanishes_base_even oddRec (by omega) (by omega)
       · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k + 1 := ⟨a' / 2, by omega⟩
-        -- Likewise `atomRel_odd_eq_rel` carries its indices in `2 * _ + 1` form, which is what
-        -- lets `atom_odd` reduce each atom without any reasoning about truncated division.
-        have hlast : ((2 * k + 1) % 2 : ℤ) = 2 * 0 + 1 := by omega
-        have hthird : (2 : ℤ) * 0 + 1 + 2 = 2 * 1 + 1 := by norm_num
-        have hsecond : b' = 2 * (k - 1) + 1 := by omega
-        rw [hlast, hthird, hsecond, atomRel_odd_eq_rel]
-        exact evenRec k (by omega)
+        exact atomRelVanishes_base_odd evenRec (by omega) (by omega)
+
+/-- The relator vanishes at three even indices in strict decrease above `0`, against a last
+index of `0`: the descent's hypothesis at exactly the shape the sorting step below produces. -/
+private theorem atomRel_eq_zero_of_sorted (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d)
+    {u v w : ℤ} (pu : u % 2 = 0) (pv : v % 2 = 0) (pw : w % 2 = 0)
+    (hw : 0 < w) (hwv : w < v) (hvu : v < u) :
+    atomRel W u v w 0 = 0 :=
+  descent u v w 0 ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
 
 /-- Three distinct positive even indices, in any order, against a last index of `0`. The six
 orderings are reached from the decreasing one by the adjacent transpositions; the last index is
@@ -334,10 +356,7 @@ private theorem atomRel_eq_zero_of_ne (odd : W.Odd)
     (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) (px : x % 2 = 0) (py : y % 2 = 0) (pz : z % 2 = 0)
     (hxy : x ≠ y) (hyz : y ≠ z) (hxz : x ≠ z) :
     atomRel W x y z 0 = 0 := by
-  have sorted : ∀ {u v w : ℤ}, u % 2 = 0 → v % 2 = 0 → w % 2 = 0 → 0 < w → w < v → v < u →
-      atomRel W u v w 0 = 0 := by
-    intro u v w pu pv pw hw hwv hvu
-    exact descent u v w 0 ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
+  have sorted {u v w : ℤ} := atomRel_eq_zero_of_sorted (W := W) descent (u := u) (v := v) (w := w)
   rcases lt_trichotomy x y with h₁ | h₁ | h₁
   · rcases lt_trichotomy y z with h₂ | h₂ | h₂
     · have h := sorted pz py px hx h₁ h₂

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -274,14 +274,11 @@ private theorem atomRel_odd_eq_rel (m : ℤ) :
   simp_rw [atomRel, atom_odd, rel]
   ring_nf
 
-/-- **The even base case**: first index `2 * k`, second two below it, at the minimal pair
-`(2, 0)`. This is where the odd recurrence is consumed. -/
-private theorem atomRelVanishes_base_even
-    (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0) {k b : ℤ} (hk : 3 ≤ k)
+/-- **The relator vanishes at an even first index** whose two lower indices sit at the minimal
+pair `(2, 0)`, given the odd recurrence at that one place. -/
+private theorem atomRel_even_eq_zero_of_oddRec {k b : ℤ} (hodd : rel W k (k - 1) 1 0 = 0)
     (hb : b = 2 * (k - 1)) :
     atomRel W (2 * k) b (2 * k % 2 + 2) (2 * k % 2) = 0 := by
-  have hodd := oddRec (k - 1) (by omega)
-  rw [sub_add_cancel] at hodd
   -- `atomRel_even_eq_rel` carries every index in `2 * _` form, which is what lets
   -- `atomRel_two_mul` fire; the goal's indices have to be put in that form first.
   have hlast : (2 * k % 2 : ℤ) = 2 * 0 := by omega
@@ -289,18 +286,17 @@ private theorem atomRelVanishes_base_even
   rw [hlast, hthird, hb, atomRel_even_eq_rel]
   exact hodd
 
-/-- **The odd base case**: first index `2 * k + 1`, second two below it, at the minimal pair
-`(3, 1)`. This is where the even recurrence is consumed. -/
-private theorem atomRelVanishes_base_odd
-    (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) {k b : ℤ} (hk : 3 ≤ k)
-    (hb : b = 2 * (k - 1) + 1) :
+/-- **The relator vanishes at an odd first index** whose two lower indices sit at the minimal
+pair `(3, 1)`, given the even recurrence at that one place. -/
+private theorem atomRel_odd_eq_zero_of_evenRec {k b : ℤ}
+    (heven : rel W (k + 1) (k - 1) 1 0 = 0) (hb : b = 2 * (k - 1) + 1) :
     atomRel W (2 * k + 1) b ((2 * k + 1) % 2 + 2) ((2 * k + 1) % 2) = 0 := by
   -- Likewise `atomRel_odd_eq_rel` carries its indices in `2 * _ + 1` form, which is what lets
   -- `atom_odd` reduce each atom without any reasoning about truncated division.
   have hlast : ((2 * k + 1) % 2 : ℤ) = 2 * 0 + 1 := by omega
   have hthird : (2 : ℤ) * 0 + 1 + 2 = 2 * 1 + 1 := by norm_num
   rw [hlast, hthird, hb, atomRel_odd_eq_rel]
-  exact evenRec k (by omega)
+  exact heven
 
 /-- **The descent.** The two doubling recurrences, holding from `m = 2` and `m = 3` on, force the
 full four-index relation at every valid quadruple. The induction is on the largest index: below
@@ -335,17 +331,17 @@ private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
         (nonnegStrictAnti₄_abs_avg_sub h1 (by omega) h2 h3)
     · rcases Int.emod_two_eq_zero_or_one a' with hp | hp
       · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k := ⟨a' / 2, by omega⟩
-        exact atomRelVanishes_base_even oddRec (by omega) (by omega)
+        exact atomRel_even_eq_zero_of_oddRec (by simpa using oddRec (k - 1) (by omega)) (by omega)
       · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k + 1 := ⟨a' / 2, by omega⟩
-        exact atomRelVanishes_base_odd evenRec (by omega) (by omega)
+        exact atomRel_odd_eq_zero_of_evenRec (evenRec k (by omega)) (by omega)
 
 /-- The relator vanishes at three even indices in strict decrease above `0`, against a last
 index of `0`: the descent's hypothesis at exactly the shape the sorting step below produces. -/
-private theorem atomRel_eq_zero_of_sorted (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d)
-    {u v w : ℤ} (pu : u % 2 = 0) (pv : v % 2 = 0) (pw : w % 2 = 0)
+private theorem atomRel_eq_zero_of_sorted {u v w : ℤ} (h : AtomRelVanishes W u v w 0)
+    (pu : u % 2 = 0) (pv : v % 2 = 0) (pw : w % 2 = 0)
     (hw : 0 < w) (hwv : w < v) (hvu : v < u) :
     atomRel W u v w 0 = 0 :=
-  descent u v w 0 ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
+  h ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
 
 /-- Three distinct positive even indices, in any order, against a last index of `0`. The six
 orderings are reached from the decreasing one by the adjacent transpositions; the last index is
@@ -356,7 +352,7 @@ private theorem atomRel_eq_zero_of_ne (odd : W.Odd)
     (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) (px : x % 2 = 0) (py : y % 2 = 0) (pz : z % 2 = 0)
     (hxy : x ≠ y) (hyz : y ≠ z) (hxz : x ≠ z) :
     atomRel W x y z 0 = 0 := by
-  have sorted {u v w : ℤ} := atomRel_eq_zero_of_sorted (W := W) descent (u := u) (v := v) (w := w)
+  have sorted {u v w : ℤ} := atomRel_eq_zero_of_sorted (W := W) (descent u v w 0)
   rcases lt_trichotomy x y with h₁ | h₁ | h₁
   · rcases lt_trichotomy y z with h₂ | h₂ | h₂
     · have h := sorted pz py px hx h₁ h₂

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -334,24 +334,19 @@ private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
         (nonnegStrictAnti₄_abs_avg_sub h1 (by omega) h2 h3)
     · exact atomRel_eq_zero_of_gap_two oddRec evenRec (by omega) hb
 
-/-- The relator vanishes at three even indices in strict decrease above `0`, against a last
-index of `0`: the descent's hypothesis at exactly the shape the sorting step below produces. -/
-private theorem atomRel_eq_zero_of_sorted {u v w : ℤ} (h : AtomRelVanishes W u v w 0)
-    (pu : u % 2 = 0) (pv : v % 2 = 0) (pw : w % 2 = 0)
-    (hw : 0 < w) (hwv : w < v) (hvu : v < u) :
-    atomRel W u v w 0 = 0 :=
-  h ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
-
 /-- Three distinct positive even indices, in any order, against a last index of `0`. The six
 orderings are reached from the decreasing one by the adjacent transpositions; the last index is
 already minimal, so only the first three need sorting and the general `Tuple.sort` argument the
-source uses is not required. -/
+source uses is not required. The local `sorted` is the descent specialised to that decreasing
+shape, which is the only shape the six branches ever need. -/
 private theorem atomRel_eq_zero_of_ne (odd : W.Odd)
     (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d) {x y z : ℤ}
     (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) (px : x % 2 = 0) (py : y % 2 = 0) (pz : z % 2 = 0)
     (hxy : x ≠ y) (hyz : y ≠ z) (hxz : x ≠ z) :
     atomRel W x y z 0 = 0 := by
-  have sorted {u v w : ℤ} := atomRel_eq_zero_of_sorted (W := W) (descent u v w 0)
+  have sorted {u v w : ℤ} (pu : u % 2 = 0) (pv : v % 2 = 0) (pw : w % 2 = 0)
+      (hw : 0 < w) (hwv : w < v) (hvu : v < u) : atomRel W u v w 0 = 0 :=
+    descent u v w 0 ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
   rcases lt_trichotomy x y with h₁ | h₁ | h₁
   · rcases lt_trichotomy y z with h₂ | h₂ | h₂
     · have h := sorted pz py px hx h₁ h₂

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -258,9 +258,11 @@ private theorem atomRelVanishes_of_min {a : ℤ} (one : W 1 ∈ R⁰) (two : W 2
     · exact fix.2 hlt₃ same anti
 
 /-- The even base case, as a relator: all four indices are even, so `atomRel_two_mul` applies. -/
-private theorem atomRel_even_eq_rel (m : ℤ) :
-    atomRel W (2 * m) (2 * (m - 1)) (2 * 1) (2 * 0) = rel W m (m - 1) 1 0 := by
-  rw [atomRel_two_mul]
+private theorem atomRel_even_eq_rel (k : ℤ) :
+    atomRel W (2 * k) (2 * (k - 1)) (2 * k % 2 + 2) (2 * k % 2) = rel W k (k - 1) 1 0 := by
+  have hlast : (2 * k % 2 : ℤ) = 2 * 0 := by omega
+  have hthird : (2 : ℤ) * 0 + 2 = 2 * 1 := by norm_num
+  rw [hlast, hthird, atomRel_two_mul]
   norm_num
 
 /-- The odd base case, as a relator. All four indices are odd, so `atom_odd` reduces every atom
@@ -268,35 +270,14 @@ and no reasoning about truncated division survives. The source proves the corres
 equivalence under `set_option allowUnsafeReducibility true` together with
 `attribute [local reducible] Nat.rawCast`; putting the indices in `2 * _ + 1` form removes the
 need for either. -/
-private theorem atomRel_odd_eq_rel (m : ℤ) :
-    atomRel W (2 * m + 1) (2 * (m - 1) + 1) (2 * 1 + 1) (2 * 0 + 1)
-      = rel W (m + 1) (m - 1) 1 0 := by
-  simp_rw [atomRel, atom_odd, rel]
-  ring_nf
-
-/-- **The relator vanishes at an even first index** whose two lower indices sit at the minimal
-pair `(2, 0)`, given the odd recurrence at that one place. -/
-private theorem atomRel_even_eq_zero_of_oddRec {k b : ℤ} (hodd : rel W k (k - 1) 1 0 = 0)
-    (hb : b = 2 * (k - 1)) :
-    atomRel W (2 * k) b (2 * k % 2 + 2) (2 * k % 2) = 0 := by
-  -- `atomRel_even_eq_rel` carries every index in `2 * _` form, which is what lets
-  -- `atomRel_two_mul` fire; the goal's indices have to be put in that form first.
-  have hlast : (2 * k % 2 : ℤ) = 2 * 0 := by omega
-  have hthird : (2 : ℤ) * 0 + 2 = 2 * 1 := by norm_num
-  rw [hlast, hthird, hb, atomRel_even_eq_rel]
-  exact hodd
-
-/-- **The relator vanishes at an odd first index** whose two lower indices sit at the minimal
-pair `(3, 1)`, given the even recurrence at that one place. -/
-private theorem atomRel_odd_eq_zero_of_evenRec {k b : ℤ}
-    (heven : rel W (k + 1) (k - 1) 1 0 = 0) (hb : b = 2 * (k - 1) + 1) :
-    atomRel W (2 * k + 1) b ((2 * k + 1) % 2 + 2) ((2 * k + 1) % 2) = 0 := by
-  -- Likewise `atomRel_odd_eq_rel` carries its indices in `2 * _ + 1` form, which is what lets
-  -- `atom_odd` reduce each atom without any reasoning about truncated division.
+private theorem atomRel_odd_eq_rel (k : ℤ) :
+    atomRel W (2 * k + 1) (2 * (k - 1) + 1) ((2 * k + 1) % 2 + 2) ((2 * k + 1) % 2)
+      = rel W (k + 1) (k - 1) 1 0 := by
   have hlast : ((2 * k + 1) % 2 : ℤ) = 2 * 0 + 1 := by omega
   have hthird : (2 : ℤ) * 0 + 1 + 2 = 2 * 1 + 1 := by norm_num
-  rw [hlast, hthird, hb, atomRel_odd_eq_rel]
-  exact heven
+  rw [hlast, hthird]
+  simp_rw [atomRel, atom_odd, rel]
+  ring_nf
 
 /-- **The descent.** The two doubling recurrences, holding from `m = 2` and `m = 3` on, force the
 full four-index relation at every valid quadruple. The induction is on the largest index: below
@@ -331,9 +312,11 @@ private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
         (nonnegStrictAnti₄_abs_avg_sub h1 (by omega) h2 h3)
     · rcases Int.emod_two_eq_zero_or_one a' with hp | hp
       · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k := ⟨a' / 2, by omega⟩
-        exact atomRel_even_eq_zero_of_oddRec (by simpa using oddRec (k - 1) (by omega)) (by omega)
+        rw [show b' = 2 * (k - 1) by omega, atomRel_even_eq_rel]
+        simpa using oddRec (k - 1) (by omega)
       · obtain ⟨k, rfl⟩ : ∃ k, a' = 2 * k + 1 := ⟨a' / 2, by omega⟩
-        exact atomRel_odd_eq_zero_of_evenRec (evenRec k (by omega)) (by omega)
+        rw [show b' = 2 * (k - 1) + 1 by omega, atomRel_odd_eq_rel]
+        exact evenRec k (by omega)
 
 /-- The relator vanishes at three even indices in strict decrease above `0`, against a last
 index of `0`: the descent's hypothesis at exactly the shape the sorting step below produces. -/


### PR DESCRIPTION
Two proofs in `Descent.lean` sit above the 30-line decomposition threshold. This names the
pieces they were hiding.

| declaration | before | after |
|---|---|---|
| `atomRelVanishes_of_rel` | 41 | **23** |
| `atomRel_eq_zero_of_ne` | 31 | **30** |

Counted as source lines of the proof body. Counting only non-blank, non-comment lines the same
two go 34 → 20 and 31 → 30; no declaration in the file is over the threshold on either count.
No statement of a public declaration changes; the public surface is byte-identical and every new
or altered declaration is `private`.

## What changed, and why these cuts

**`atomRel_eq_zero_of_gap_two`** is extracted: the point where the induction bottoms out, when
the gap between the first two indices is exactly two. It carries both parities together, because
that is where the choice between the two doubling recurrences is actually made — the odd
recurrence discharges an even first index and the even one discharges an odd first index. In the
original this was a bare `rcases` on `a % 2` inside the descent, so the correspondence was
visible only by reading the index arithmetic.

**`atomRel_even_eq_rel` and `atomRel_odd_eq_rel` are restated, not duplicated.** Both already
existed as index-normalisation bridges stated in `2 * _` and `2 * _ + 1` form. The descent needs
them at the `% 2` shape its minimal pair produces, so an earlier draft of this PR added two
wrapper lemmas doing that normalisation on top. `reuse` was right that those wrappers were a
thin second layer over existing private lemmas, each used once. Rather than delete them and
inline the normalisation back into the descent — which would have pushed the proof over the
threshold again, undoing this PR — the two bridges are now **stated directly at the shape their
one caller needs**. One layer instead of two, and the parity branches are three lines each.

**The sorted case stays a local `have`, not a private lemma.** The six-way sorting proof needs
the descent at one shape only — three even indices in strict decrease above `0`, against a last
index of `0` — and every branch reaches that shape by transpositions. An earlier draft named it
as a private theorem; `reuse` was right that a private declaration applied at exactly one site is
a wrapper rather than a reusable piece. It is now a `have` with a full type ascription inside the
one proof that uses it, which keeps the fact named and stated while adding no second declaration
to the file. Its role is documented on the enclosing theorem rather than in an inline comment, so
the explanation does not consume proof-body budget.

## Why the proofs were over the threshold

Worth recording, because it is a general interaction rather than an accident of this file.

Both were **under** the threshold when written. They went over during #3226's `proof-quality`
round, which asked for the inline `show … by omega` goal-shaping terms to be replaced by named
facts carrying the reason each shape is required. That is the right change and the file is better
for it, but it adds roughly a line and a half per site, and three proofs crossed 30 as a result.

So `proof-quality` compliance and the decomposition threshold pull against each other: satisfying
the first can silently violate the second, and nothing warns you, because the rubric goes green on
the very shape that breaks the line budget. The remedy is to re-measure declaration lengths at the
head you actually push, after the last review round rather than before it.

Two measurement notes in the same spirit. A naive script that counts from one declaration's start
to the next over-counts, because a docstring's interior lines do not begin with a comment marker
and so survive a naive filter; measured with comment-stripping, the two offenders were 41 and 31,
not the 46 and 35 a naive count reports, and a third apparent offender was never over at all. And
a comment-stripping counter still has to decide whether a blanked comment line inside a proof
counts as a line: it does for the reviewer reading the file, which is why the table above uses
source lines and reports the stricter count alongside.

## Gates

`lake build` PASS at 1021 jobs, on a worktree verified clean beforehand, branch cut from current
`main` (`f5c4afcb1`, the merge of #3226). No `sorry`; no line over 100 codepoints; zero LSP
diagnostics. The public surface is byte-identical, so nothing downstream can break.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-descent-decompose"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
