### PR TITLE
feat(ModularForms): the remainder's q-expansion is a nonzero power series

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
@@ -35,7 +35,7 @@ translates of `f` times a `1`-periodic remainder analytic at `∞`.
   nonzero form is nonzero.
 * `TauCeti.ModularForm.qExpansion_one_norm_order_eq`: the `q`-expansion order of the norm at
   `∞` splits as the order of `f` plus the order of the remainder.
-* `TauCeti.ModularForm.qExpansion_normRest_ne_zero`: the remainder's `q`-expansion is a
+* `TauCeti.ModularForm.qExpansion_one_normRest_ne_zero`: the remainder's `q`-expansion is a
   nonzero power series.
 
 The remainder and the decomposition itself are algebraic, so they are stated for
@@ -385,7 +385,8 @@ public lemma qExpansion_one_norm_order_eq :
 
 This is what makes the order at `∞` of `normRest f` finite, so that it can appear as a
 summand in a cusp-order count. -/
-public lemma qExpansion_normRest_ne_zero (hf : (⇑f : ℍ → ℂ) ≠ 0) : qExpansion 1 (normRest f) ≠ 0 :=
+public lemma qExpansion_one_normRest_ne_zero (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    qExpansion 1 (normRest f) ≠ 0 :=
   mt (qExpansion_eq_zero_iff one_pos (periodic_normRest f) (mdifferentiable_normRest f)
     (isBoundedAtImInfty_normRest f)).mp (normRest_ne_zero f hf)
 

--- a/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
@@ -35,6 +35,8 @@ translates of `f` times a `1`-periodic remainder analytic at `∞`.
   nonzero form is nonzero.
 * `TauCeti.ModularForm.qExpansion_one_norm_order_eq`: the `q`-expansion order of the norm at
   `∞` splits as the order of `f` plus the order of the remainder.
+* `TauCeti.ModularForm.qExpansion_normRest_ne_zero`: the remainder's `q`-expansion is a
+  nonzero power series.
 
 The remainder and the decomposition itself are algebraic, so they are stated for
 `SlashInvariantForm.norm` under `SlashInvariantFormClass`; only analyticity at the cusp
@@ -378,6 +380,14 @@ public lemma qExpansion_one_norm_order_eq :
       (isBoundedAtImInfty_galoisProd hf_bdd)) (analyticAt_cuspFunction_normRest f)
   rw [h_qexp, PowerSeries.order_mul,
     qExpansion_one_galoisProd_order_eq hn_pos hf_n_per hf_bdd (ModularFormClass.holo f)]
+
+/-- The `q`-expansion of `normRest f` is a nonzero power series whenever `f` is nonzero.
+
+This is what makes the order at `∞` of `normRest f` finite, so that it can appear as a
+summand in a cusp-order count. -/
+public lemma qExpansion_normRest_ne_zero (hf : (⇑f : ℍ → ℂ) ≠ 0) : qExpansion 1 (normRest f) ≠ 0 :=
+  mt (qExpansion_eq_zero_iff one_pos (periodic_normRest f) (mdifferentiable_normRest f)
+    (isBoundedAtImInfty_normRest f)).mp (normRest_ne_zero f hf)
 
 end Analytic
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"general-level-order-dictionary"}-->

Advances **`TauCetiRoadmap/ModularForms/README.md`, Layer 1 — "General level — by the coset
norm"**, order-dictionary milestone. This is the step the previous two PRs were assembled for.

### What this does

```lean
public lemma qExpansion_one_normRest_ne_zero (hf : (⇑f : ℍ → ℂ) ≠ 0) :
    qExpansion 1 (normRest f) ≠ 0
```

### Why it is the next step

The order at `∞` is read off the `q`-expansion, and `PowerSeries.order` is `⊤` exactly when
the series is zero. So this nonvanishing is what makes the cusp order of `normRest f` a
finite number, and hence able to appear as a summand in a cusp-order count over the norm
decomposition.

It is a three-line composition of facts that have just landed, which is why it is its own PR
rather than part of either:

* `normRest_ne_zero` (#3252) — the remainder factor of a nonzero form is nonzero;
* `mdifferentiable_normRest` and `isBoundedAtImInfty_normRest` (#3262) — named precisely
  because they are two of the four hypotheses of Mathlib's `qExpansion_eq_zero_iff`
  (`QExpansion.lean:525`);
* `periodic_normRest` — the remaining hypothesis, already in the file.

`qExpansion_eq_zero_iff` turns "the `q`-expansion vanishes" into "the function vanishes", and
`normRest_ne_zero` contradicts that.

### A route that does not work, recorded so it is not retried

The tempting shortcut is to get the order additively from `qExpansionOrderAtCusp_mul`
(`AtCusp.lean:103`) applied to the decomposition `norm = galoisProd * normRest`. That lemma
needs nonvanishing on the *punctured disc*, not just nonvanishing of the function, and the
decomposition does not supply it. Going through `qExpansion_eq_zero_iff` avoids the punctured-
disc hypothesis entirely.

### Scope

Only the `≠ 0` form is added. The `(qExpansion 1 (normRest f)).order ≠ ⊤` form is one
`PowerSeries.order_eq_top` step from this one, so it would be a single-use composition helper
rather than an assertion of its own; consumers can take that step where they need it.

No new mathematics beyond the composition — the statement was verified as a compiled `example`
before the file was edited, and both it and its proof went in unchanged.

### Relation to the source library

Provenance: `github.com/CBirkbeck/AINTLIB` @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`, as
published in that repo — searched, **not** ported.

AINTLIB carries the closest analogue at
`projects/LeanModularForms/LeanModularForms/ForMathlib/ValenceFormula/PVChain/Seg5CuspIntegral.lean:67`:

```lean
private lemma qExpFMS_ne_zero (hf : f ≠ 0) :
    UpperHalfPlane.qExpansionFormalMultilinearSeries 1 f ≠ 0
```

It is a different statement — the *formal multilinear series* rather than the `PowerSeries`,
for a bundled `ModularForm (Gamma 1) k` at level one rather than the raw function
`normRest f` at general level — and it is `private`. It is also proved from scratch in ~15
lines, going through `HasFPowerSeriesOnBall` and
`eqOn_zero_of_preconnected_of_eventuallyEq_zero`. That derivation is no longer necessary:
Mathlib's `qExpansion_eq_zero_iff` now supplies the same content directly, which is why the
lemma here is two lines. Nothing was copied.

Searched with three vocabularies — `normRest` (absent from AINTLIB entirely),
`qExpansion … ≠ 0` / `qExpansion … ne_zero`, and `qExpansion … order`. No `PowerSeries`-level
nonvanishing statement exists there.

The composed ingredients (#3216, #3252, #3262) are already in-repository, so this needs no
fresh roadmap target beyond the Layer 1 milestone cited above.
