### PR TITLE
feat: add the Lipschitz Clifford norm

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -48,20 +48,26 @@ universe u v
 namespace CliffordAlgebra
 
 variable {K : Type u} {V : Type v} [Field K]
-  [AddCommGroup V] [Module K V] (Q : QuadraticForm K V) [Invertible (2 : K)]
+  [AddCommGroup V] [Module K V] (Q : QuadraticForm K V)
 
 /-- The Lipschitz action is onto the orthogonal group of a finite-dimensional nondegenerate
 quadratic space over a field of characteristic other than two. -/
 theorem lipschitzToOrthogonal_surjective
-    [FiniteDimensional K V] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
-    Function.Surjective (lipschitzToOrthogonal Q) :=
-  MonoidHom.range_eq_top.mp <|
+    [NeZero (2 : K)] [FiniteDimensional K V]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    Function.Surjective
+      (@lipschitzToOrthogonal K V _ _ _ Q
+        (invertibleOfNonzero (NeZero.ne (2 : K)))) := by
+  let _ : Invertible (2 : K) := invertibleOfNonzero (NeZero.ne (2 : K))
+  exact MonoidHom.range_eq_top.mp <|
     QuadraticMap.subgroup_eq_top_of_reflection_mem
       Q hQ (lipschitzToOrthogonal Q).range
       fun v _ ↦ by
         rw [MonoidHom.mem_range]
         exact ⟨⟨unitι Q v, unitι_mem_lipschitzGroup v⟩,
           lipschitzToOrthogonal_unitι Q v⟩
+
+variable [Invertible (2 : K)]
 
 section IsSepClosed
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -9,7 +9,10 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.ReflectionLift
 public import TauCeti.LinearAlgebra.QuadraticForm.CartanDieudonne
 
 /-!
-# Pin corrections over fixed subspaces
+# Cartan--Dieudonné for Lipschitz and Pin actions
+
+Over a field of characteristic other than two, Cartan--Dieudonné and the action of a generating
+vector show that the Lipschitz action is onto the orthogonal group.
 
 Let `g` be an orthogonal automorphism fixing a subspace `W`, and let `x` be an anisotropic vector
 orthogonal to `W`. The generic fixed-subspace correction in the quadratic-form layer uses one or
@@ -19,6 +22,8 @@ element lies in the range of `pinToOrthogonal`.
 
 ## Main results
 
+* `TauCeti.CliffordAlgebra.lipschitzToOrthogonal_surjective`: the Lipschitz action is onto for a
+  finite-dimensional nondegenerate quadratic space.
 * `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton`: a
   Pin-range correction extends a fixed subspace by one orthogonal anisotropic vector.
 * `TauCeti.CliffordAlgebra.pinToOrthogonal_surjective`: over a separably closed field of
@@ -44,6 +49,19 @@ namespace CliffordAlgebra
 
 variable {K : Type u} {V : Type v} [Field K]
   [AddCommGroup V] [Module K V] (Q : QuadraticForm K V) [Invertible (2 : K)]
+
+/-- The Lipschitz action is onto the orthogonal group of a finite-dimensional nondegenerate
+quadratic space over a field of characteristic other than two. -/
+theorem lipschitzToOrthogonal_surjective
+    [FiniteDimensional K V] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
+    Function.Surjective (lipschitzToOrthogonal Q) :=
+  MonoidHom.range_eq_top.mp <|
+    QuadraticMap.subgroup_eq_top_of_reflection_mem
+      Q hQ (lipschitzToOrthogonal Q).range
+      fun v _ ↦ by
+        rw [MonoidHom.mem_range]
+        exact ⟨⟨unitι Q v, unitι_mem_lipschitzGroup v⟩,
+          lipschitzToOrthogonal_unitι Q v⟩
 
 section IsSepClosed
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
@@ -10,7 +10,7 @@ import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 /-!
 # The norm of the Lipschitz group
 
-The Clifford norm `star x * x` of a Lipschitz element is a nonzero scalar. This defines a
+The Clifford norm `star x * x` of a Lipschitz element is a unit scalar. This defines a
 homomorphism from the Lipschitz group to the units of the base ring. Generating vectors have norm
 the negative of their quadratic norm.
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
@@ -20,6 +20,8 @@ norm: the Clifford norm descends modulo squares through the kernel of that actio
 ## Main results
 
 * `TauCeti.CliffordAlgebra.lipschitzNorm`: the unit-valued Clifford norm.
+* `TauCeti.CliffordAlgebra.self_mul_star_eq_algebraMap_lipschitzNorm`: its second
+  characteristic Clifford-product equation.
 * `TauCeti.CliffordAlgebra.lipschitzNorm_unitι`: its value on a generating vector.
 
 ## References
@@ -141,6 +143,15 @@ theorem star_mul_self_eq_algebraMap_lipschitzNorm
         ((x : (CliffordAlgebra Q)ˣ) : CliffordAlgebra Q) =
       algebraMap R (CliffordAlgebra Q) (lipschitzNorm Q x : R) :=
   star_mul_self_eq_lipschitzNormUnit Q x
+
+/-- The product of a Lipschitz element with its Clifford conjugate is its scalar norm. -/
+@[simp]
+theorem self_mul_star_eq_algebraMap_lipschitzNorm
+    (Q : QuadraticForm R V) (x : lipschitzGroup Q) :
+    ((x : (CliffordAlgebra Q)ˣ) : CliffordAlgebra Q) *
+        star ((x : (CliffordAlgebra Q)ˣ) : CliffordAlgebra Q) =
+      algebraMap R (CliffordAlgebra Q) (lipschitzNorm Q x : R) :=
+  (Classical.choose_spec (exists_lipschitzNormUnit Q x x.2)).2
 
 /-- A generating vector has Clifford norm equal to the negative of its quadratic norm. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Pin.Action
+import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
+
+/-!
+# The norm of the Lipschitz group
+
+The Clifford norm `star x * x` of a Lipschitz element is a nonzero scalar. This defines a
+homomorphism from the Lipschitz group to the units of the base ring. Generating vectors have norm
+the negative of their quadratic norm.
+
+Together with the orthogonal action, this homomorphism is the input for the general-field spinor
+norm: the Clifford norm descends modulo squares through the kernel of that action.
+
+## Main results
+
+* `TauCeti.CliffordAlgebra.lipschitzNorm`: the unit-valued Clifford norm.
+* `TauCeti.CliffordAlgebra.lipschitzNorm_unitι`: its value on a generating vector.
+
+## References
+
+See H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+-/
+
+public section
+
+open CliffordAlgebra QuadraticMap
+
+namespace TauCeti.CliffordAlgebra
+
+universe u v
+
+variable {R : Type u} {V : Type v} [CommRing R] [AddCommGroup V] [Module R V]
+  [Invertible (2 : R)]
+
+private theorem exists_lipschitzNormUnit (Q : QuadraticForm R V)
+    (x : (CliffordAlgebra Q)ˣ) (hx : x ∈ lipschitzGroup Q) :
+    ∃ r : Rˣ,
+      star (x : CliffordAlgebra Q) * (x : CliffordAlgebra Q) =
+        algebraMap R (CliffordAlgebra Q) (r : R) ∧
+      (x : CliffordAlgebra Q) * star (x : CliffordAlgebra Q) =
+        algebraMap R (CliffordAlgebra Q) (r : R) := by
+  induction hx using Subgroup.closure_induction with
+  | mem x hgen =>
+      obtain ⟨v, hv⟩ := hgen
+      let _ := x.invertible
+      let _ : Invertible (ι Q v) := by rw [hv]; infer_instance
+      let _ : Invertible (Q v) := invertibleOfInvertibleι Q v
+      refine ⟨-(unitOfInvertible (Q v)), ?_, ?_⟩
+      · rw [← hv, star_ι, neg_mul, ι_sq_scalar]
+        -- Expose the scalar value of the canonical negative unit.
+        change -(algebraMap R (CliffordAlgebra Q)) (Q v) =
+          (algebraMap R (CliffordAlgebra Q)) (-Q v)
+        exact (map_neg _ _).symm
+      · rw [← hv, star_ι, mul_neg, ι_sq_scalar]
+        -- Expose the scalar value of the canonical negative unit.
+        change -(algebraMap R (CliffordAlgebra Q)) (Q v) =
+          (algebraMap R (CliffordAlgebra Q)) (-Q v)
+        exact (map_neg _ _).symm
+  | inv x hx ih =>
+      obtain ⟨r, hr, hr'⟩ := ih
+      refine ⟨r⁻¹, ?_, ?_⟩
+      · have hunit : x * star x = Units.map (algebraMap R (CliffordAlgebra Q)) r := by
+          apply Units.ext
+          simpa using hr'
+        have hinv := congrArg Inv.inv hunit
+        have hval := congrArg Units.val hinv
+        simpa [star_inv, map_inv] using hval
+      · have hunit : star x * x = Units.map (algebraMap R (CliffordAlgebra Q)) r := by
+          apply Units.ext
+          simpa using hr
+        have hinv := congrArg Inv.inv hunit
+        have hval := congrArg Units.val hinv
+        simpa [star_inv, map_inv] using hval
+  | one =>
+      exact ⟨1, by simp, by simp⟩
+  | mul x y hx hy ihx ihy =>
+      obtain ⟨r, hr, hr'⟩ := ihx
+      obtain ⟨s, hs, hs'⟩ := ihy
+      refine ⟨r * s, ?_, ?_⟩
+      · simp only [Units.val_mul, star_mul]
+        rw [mul_assoc (star (y : CliffordAlgebra Q))]
+        rw [← mul_assoc (star (x : CliffordAlgebra Q))]
+        rw [hr, Algebra.commutes]
+        rw [← mul_assoc, hs, ← map_mul, mul_comm]
+      · simp only [Units.val_mul, star_mul]
+        rw [mul_assoc (x : CliffordAlgebra Q)]
+        rw [← mul_assoc (y : CliffordAlgebra Q)]
+        rw [hs', Algebra.commutes]
+        rw [← mul_assoc, hr', ← map_mul]
+
+private noncomputable def lipschitzNormUnit (Q : QuadraticForm R V)
+    (x : lipschitzGroup Q) : Rˣ :=
+  Classical.choose (exists_lipschitzNormUnit Q x x.2)
+
+private theorem star_mul_self_eq_lipschitzNormUnit (Q : QuadraticForm R V)
+    (x : lipschitzGroup Q) :
+    star ((x : (CliffordAlgebra Q)ˣ) : CliffordAlgebra Q) *
+        ((x : (CliffordAlgebra Q)ˣ) : CliffordAlgebra Q) =
+      algebraMap R (CliffordAlgebra Q) (lipschitzNormUnit Q x : R) :=
+  (Classical.choose_spec (exists_lipschitzNormUnit Q x x.2)).1
+
+/-- The unit-valued Clifford norm on the Lipschitz group. -/
+noncomputable def lipschitzNorm (Q : QuadraticForm R V) : lipschitzGroup Q →* Rˣ where
+  toFun := lipschitzNormUnit Q
+  map_one' := by
+    apply Units.ext
+    apply algebraMap_injective Q
+    -- Compare the chosen unit through the faithful Clifford scalar map.
+    change algebraMap R (CliffordAlgebra Q) (lipschitzNormUnit Q 1 : R) =
+      algebraMap R (CliffordAlgebra Q) 1
+    simpa using (star_mul_self_eq_lipschitzNormUnit Q 1).symm
+  map_mul' x y := by
+    apply Units.ext
+    apply algebraMap_injective Q
+    have hxy := star_mul_self_eq_lipschitzNormUnit Q (x * y)
+    have hx := star_mul_self_eq_lipschitzNormUnit Q x
+    have hy := star_mul_self_eq_lipschitzNormUnit Q y
+    simp only [Units.val_mul]
+    rw [map_mul]
+    -- Compare the chosen units through the faithful Clifford scalar map.
+    change algebraMap R (CliffordAlgebra Q) (lipschitzNormUnit Q (x * y) : R) =
+      algebraMap R (CliffordAlgebra Q) (lipschitzNormUnit Q x : R) *
+        algebraMap R (CliffordAlgebra Q) (lipschitzNormUnit Q y : R)
+    rw [← hx, ← hy, ← hxy]
+    simp only [Subgroup.coe_mul, Units.val_mul, star_mul]
+    rw [mul_assoc (star ((y : (CliffordAlgebra Q)ˣ) : CliffordAlgebra Q)),
+      ← mul_assoc (star ((x : (CliffordAlgebra Q)ˣ) : CliffordAlgebra Q)),
+      hx, Algebra.commutes, ← mul_assoc, Algebra.commutes]
+
+/-- The product of the Clifford conjugate of a Lipschitz element with itself is its scalar norm. -/
+@[simp]
+theorem star_mul_self_eq_algebraMap_lipschitzNorm
+    (Q : QuadraticForm R V) (x : lipschitzGroup Q) :
+    star ((x : (CliffordAlgebra Q)ˣ) : CliffordAlgebra Q) *
+        ((x : (CliffordAlgebra Q)ˣ) : CliffordAlgebra Q) =
+      algebraMap R (CliffordAlgebra Q) (lipschitzNorm Q x : R) :=
+  star_mul_self_eq_lipschitzNormUnit Q x
+
+/-- A generating vector has Clifford norm equal to the negative of its quadratic norm. -/
+@[simp]
+theorem lipschitzNorm_unitι (Q : QuadraticForm R V) (v : V) [Invertible (Q v)] :
+    lipschitzNorm Q ⟨unitι Q v, unitι_mem_lipschitzGroup v⟩ =
+      -(unitOfInvertible (Q v)) := by
+  apply Units.ext
+  apply algebraMap_injective Q
+  have h := star_mul_self_eq_algebraMap_lipschitzNorm Q
+    ⟨unitι Q v, unitι_mem_lipschitzGroup v⟩
+  simp only [coe_unitι] at h
+  rw [star_ι, neg_mul, ι_sq_scalar] at h
+  -- Read the unit equality through its scalar value.
+  change algebraMap R (CliffordAlgebra Q) (lipschitzNorm Q
+      ⟨unitι Q v, unitι_mem_lipschitzGroup v⟩ : R) =
+    algebraMap R (CliffordAlgebra Q) (-Q v)
+  exact h.symm.trans (map_neg _ _).symm
+
+/-- The Clifford norm of a Pin element is one. -/
+@[simp]
+theorem lipschitzNorm_pinToLipschitz (Q : QuadraticForm R V) (p : pinGroup Q) :
+    lipschitzNorm Q (pinToLipschitz Q p) = 1 := by
+  apply Units.ext
+  apply algebraMap_injective Q
+  rw [← star_mul_self_eq_algebraMap_lipschitzNorm]
+  simpa only [coe_pinToLipschitz_apply, Units.val_one, map_one] using
+    pinGroup.coe_star_mul_self p
+
+end TauCeti.CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Action.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Action.lean
@@ -245,8 +245,8 @@ theorem ι_lipschitzVectorAction_apply (x : lipschitzGroup Q) (m : M) :
   rw [lipschitzVectorAction_apply, ι_vectorMap_apply Q x.2, twistedConj_apply]
 
 /-- **A vector acts by the reflection in its orthogonal hyperplane.** These are the generators of
-the Lipschitz group, so this identification is what an eventual Cartan-Dieudonné theorem would turn
-into surjectivity of `pinToOrthogonal`. -/
+the Lipschitz group, so this identification is what Cartan--Dieudonné turns into surjectivity of
+`lipschitzToOrthogonal`. -/
 @[simp]
 theorem lipschitzVectorAction_unitι (v : M) [Invertible (Q v)] :
     lipschitzVectorAction Q ⟨unitι Q v, unitι_mem_lipschitzGroup v⟩ =
@@ -281,6 +281,17 @@ theorem coe_lipschitzToOrthogonal_apply (x : lipschitzGroup Q) (m : M) :
       lipschitzVectorAction Q x m := by
   rw [lipschitzToOrthogonal]
   rfl
+
+/-- A generating vector acts by its bundled orthogonal reflection. -/
+@[simp]
+theorem lipschitzToOrthogonal_unitι (v : M) [Invertible (Q v)] :
+    lipschitzToOrthogonal Q ⟨unitι Q v, unitι_mem_lipschitzGroup v⟩ =
+      QuadraticMap.reflectionOrthogonal Q v := by
+  apply Subtype.ext
+  rw [QuadraticMap.coe_reflectionOrthogonal]
+  apply LinearEquiv.ext
+  intro m
+  rw [coe_lipschitzToOrthogonal_apply, lipschitzVectorAction_unitι]
 
 /-! ### The Pin and spin groups -/
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -159,15 +159,6 @@ theorem reflection_mem_range_pinToOrthogonal_of_isSquare (v : V) [Invertible (Q 
   rw [MonoidHom.mem_range]
   exact ⟨pinReflectionLift Q v hv, pinToOrthogonal_pinReflectionLift Q v hv⟩
 
-private theorem lipschitzToOrthogonal_unitι_eq (v : V) [Invertible (Q v)] :
-    lipschitzToOrthogonal Q ⟨unitι Q v, unitι_mem_lipschitzGroup v⟩ =
-      QuadraticMap.reflectionOrthogonal Q v := by
-  apply Subtype.ext
-  rw [QuadraticMap.coe_reflectionOrthogonal]
-  apply LinearEquiv.ext
-  intro m
-  rw [coe_lipschitzToOrthogonal_apply, lipschitzVectorAction_unitι]
-
 /-- If the product of the required normalization scalars is a square, the product of the
 reflections in `v` and `w` lifts through the Spin action. -/
 theorem reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare
@@ -200,8 +191,7 @@ theorem reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare
             ⟨unitι Q w, unitι_mem_lipschitzGroup _⟩ := by
       apply Subtype.ext
       simp only [Subgroup.coe_mul]
-    rw [hmul,
-      map_mul, lipschitzToOrthogonal_unitι_eq, lipschitzToOrthogonal_unitι_eq]
+    rw [hmul, map_mul, lipschitzToOrthogonal_unitι, lipschitzToOrthogonal_unitι]
     apply Subtype.ext
     simp only [Subgroup.coe_mul, QuadraticMap.coe_reflectionOrthogonal]
     exact congrArg (fun x : V ≃ₗ[K] V => x * QuadraticMap.reflection Q w)


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the Clifford norm and orthogonal-action inputs for the general-field spinor norm.

- Computes scalar, vector-generator, and Pin norm equations.
- Bundles the generator reflection and proves the Lipschitz action is onto.

## Roadmap target

Supplies the Layer 2 general-field spinor-norm prerequisite:
https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-2-the-pin-and-spin-groups-and-the-double-covers

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/README.md#lipschitzNorm"}-->

## Verification

Full gates, consumers, golf, and fresh aggregate `2+1` pass at `ac605fbe13924e6db742f0b012a4f597ef1c514f`.

## Scale and generality

Changes four files by +223/−15. The norm uses a commutative ring with invertible `2`; surjectivity adds finite dimension, nondegeneracy, and a field.

## Scope

- **Consumes:** Lipschitz action, Clifford scalars, and Cartan–Dieudonné.
- **Provides:** Lipschitz norm/equations, bundled reflection, and action surjectivity.
- **Fits:** supplies both inputs for square-class descent on the orthogonal group.
- **Boundary:** kernel descent, spinor norm, and the Spin-image theorem remain downstream.

<sub>🤖 GPT-5.6 Sol high · [rubrics](https://github.com/TauCetiProject/TauCetiReview/commit/16f11e6798240ed324cecb2400aef7c90ebd70d5) · [2+1](https://github.com/utensil/formal-land/commit/8429746) fixed: API 3, attribution 1, docs 3, generality 1, naming 1, placement 3, proof 1, reuse 1</sub>