### PR TITLE
feat(ModularForms): the norm's vanishing order dominates the form's

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Norm/Order.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Order.lean
@@ -66,30 +66,18 @@ public lemma orderOfVanishingAt_norm (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0) (
     (fun q _ ↦ SlashInvariantForm.mdifferentiable_quotientFunc f q)
     (fun q _ ↦ SlashInvariantForm.quotientFunc_ne_zero hf q) p
 
-/-- The norm vanishes at a point to at least the order the form itself does: the form is the
-identity-coset factor of the product, and the other factors contribute non-negative orders.
-
-This is the "the zeros of the norm dominate the zeros of the form" step, which transports
-finiteness of the zero set down from the level-one norm to the original form. -/
-public lemma orderOfVanishingAt_le_orderOfVanishingAt_norm (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0)
-    (p : ℍ) : orderOfVanishingAt (⇑f) p ≤
-      orderOfVanishingAt (⇑(_root_.ModularForm.norm ℋ f)) p := by
-  rw [orderOfVanishingAt_norm f hf p]
+/-- The norm vanishes at a point to at least the order the form itself does: the zeros of the
+norm dominate the zeros of the form. -/
+public lemma orderOfVanishingAt_le_orderOfVanishingAt_norm (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0) (p : ℍ) :
+    orderOfVanishingAt (⇑f) p ≤ orderOfVanishingAt (⇑(_root_.ModularForm.norm ℋ f)) p := by
   let _ : Fintype (ℋ ⧸ 𝒢.subgroupOf ℋ) := Fintype.ofFinite _
-  rw [finsum_eq_sum_of_fintype]
-  -- The coset space is not a group — `𝒢.subgroupOf ℋ` need not be normal — so the identity
+  rw [orderOfVanishingAt_norm f hf p, finsum_eq_sum_of_fintype]
+  -- The form is the identity-coset factor of the product and the other factors have non-negative
+  -- order. The coset space is not a group — `𝒢.subgroupOf ℋ` need not be normal — so the identity
   -- coset is spelled `⟦1⟧` rather than `1`.
-  have h1 : _root_.SlashInvariantForm.quotientFunc f (⟦1⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) = ⇑f := by
-    rw [_root_.SlashInvariantForm.quotientFunc_mk]
-    simp
-  calc orderOfVanishingAt (⇑f) p
-      = orderOfVanishingAt
-          (_root_.SlashInvariantForm.quotientFunc f (⟦1⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ)) p := by rw [h1]
-    _ ≤ ∑ q, orderOfVanishingAt (_root_.SlashInvariantForm.quotientFunc f q) p :=
-        Finset.single_le_sum
-          (fun q _ ↦ orderOfVanishingAt_nonneg
-            (SlashInvariantForm.mdifferentiable_quotientFunc f q) p)
-          (Finset.mem_univ _)
+  simpa using Finset.single_le_sum
+    (fun q _ ↦ orderOfVanishingAt_nonneg (SlashInvariantForm.mdifferentiable_quotientFunc f q) p)
+    (Finset.mem_univ (⟦1⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ))
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/Norm/Order.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Order.lean
@@ -24,6 +24,8 @@ order of the norm is the sum of the orders of the factors.
   form is nonzero.
 * `TauCeti.ModularForm.orderOfVanishingAt_norm`: the vanishing order of the norm at a point
   is the sum, over the coset space, of the vanishing orders of the coset factors.
+* `TauCeti.ModularForm.orderOfVanishingAt_le_orderOfVanishingAt_norm`: the norm vanishes to
+  at least the order the form does, so the zeros of the norm dominate those of the form.
 -/
 
 open UpperHalfPlane
@@ -63,6 +65,31 @@ public lemma orderOfVanishingAt_norm (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0) (
   exact orderOfVanishingAt_prod
     (fun q _ ↦ SlashInvariantForm.mdifferentiable_quotientFunc f q)
     (fun q _ ↦ SlashInvariantForm.quotientFunc_ne_zero hf q) p
+
+/-- The norm vanishes at a point to at least the order the form itself does: the form is the
+identity-coset factor of the product, and the other factors contribute non-negative orders.
+
+This is the "the zeros of the norm dominate the zeros of the form" step, which transports
+finiteness of the zero set down from the level-one norm to the original form. -/
+public lemma orderOfVanishingAt_le_orderOfVanishingAt_norm (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0)
+    (p : ℍ) : orderOfVanishingAt (⇑f) p ≤
+      orderOfVanishingAt (⇑(_root_.ModularForm.norm ℋ f)) p := by
+  rw [orderOfVanishingAt_norm f hf p]
+  let _ : Fintype (ℋ ⧸ 𝒢.subgroupOf ℋ) := Fintype.ofFinite _
+  rw [finsum_eq_sum_of_fintype]
+  -- The coset space is not a group — `𝒢.subgroupOf ℋ` need not be normal — so the identity
+  -- coset is spelled `⟦1⟧` rather than `1`.
+  have h1 : _root_.SlashInvariantForm.quotientFunc f (⟦1⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) = ⇑f := by
+    rw [_root_.SlashInvariantForm.quotientFunc_mk]
+    simp
+  calc orderOfVanishingAt (⇑f) p
+      = orderOfVanishingAt
+          (_root_.SlashInvariantForm.quotientFunc f (⟦1⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ)) p := by rw [h1]
+    _ ≤ ∑ q, orderOfVanishingAt (_root_.SlashInvariantForm.quotientFunc f q) p :=
+        Finset.single_le_sum
+          (fun q _ ↦ orderOfVanishingAt_nonneg
+            (SlashInvariantForm.mdifferentiable_quotientFunc f q) p)
+          (Finset.mem_univ _)
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/Norm/Order.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Order.lean
@@ -68,16 +68,20 @@ public lemma orderOfVanishingAt_norm (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0) (
 
 /-- The norm vanishes at a point to at least the order the form itself does: the zeros of the
 norm dominate the zeros of the form. -/
-public lemma orderOfVanishingAt_le_orderOfVanishingAt_norm (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0) (p : ℍ) :
+public lemma orderOfVanishingAt_le_orderOfVanishingAt_norm (f : F) (p : ℍ) :
     orderOfVanishingAt (⇑f) p ≤ orderOfVanishingAt (⇑(_root_.ModularForm.norm ℋ f)) p := by
-  let _ : Fintype (ℋ ⧸ 𝒢.subgroupOf ℋ) := Fintype.ofFinite _
-  rw [orderOfVanishingAt_norm f hf p, finsum_eq_sum_of_fintype]
-  -- The form is the identity-coset factor of the product and the other factors have non-negative
-  -- order. The coset space is not a group — `𝒢.subgroupOf ℋ` need not be normal — so the identity
-  -- coset is spelled `⟦1⟧` rather than `1`.
-  simpa using Finset.single_le_sum
-    (fun q _ ↦ orderOfVanishingAt_nonneg (SlashInvariantForm.mdifferentiable_quotientFunc f q) p)
-    (Finset.mem_univ (⟦1⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ))
+  rcases eq_or_ne (⇑f : ℍ → ℂ) 0 with hf | hf
+  · -- The norm of the zero form is zero, so both sides are the order of the same function.
+    rw [hf, (_root_.ModularForm.norm_eq_zero_iff ℋ f).mpr hf]
+    simp
+  · let _ : Fintype (ℋ ⧸ 𝒢.subgroupOf ℋ) := Fintype.ofFinite _
+    rw [orderOfVanishingAt_norm f hf p, finsum_eq_sum_of_fintype]
+    -- The form is the identity-coset factor of the product and the other factors have
+    -- non-negative order. The coset space is not a group — `𝒢.subgroupOf ℋ` need not be normal
+    -- — so the identity coset is spelled `⟦1⟧` rather than `1`.
+    simpa using Finset.single_le_sum
+      (fun q _ ↦ orderOfVanishingAt_nonneg (SlashInvariantForm.mdifferentiable_quotientFunc f q) p)
+      (Finset.mem_univ (⟦1⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ))
 
 end ModularForm
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"general-level-order-dictionary"}-->

Advances **`TauCetiRoadmap/ModularForms/README.md`, Layer 1 — "General level — by the coset
norm"**, order-dictionary milestone. That milestone names three things, the last of which is
"finite support of the order divisor of a nonzero form — proved **here**, from the norm map and
the level-one finite-zeros statement (*the zeros of `Nm(f)` dominate those of `f`*)". This PR is
that parenthesis, in order form.

### What this does

```lean
public lemma orderOfVanishingAt_le_orderOfVanishingAt_norm (f : F) (p : ℍ) :
    orderOfVanishingAt (⇑f) p ≤ orderOfVanishingAt (⇑(ModularForm.norm ℋ f)) p
```

It holds for **every** form, with no nonvanishing hypothesis: when `f = 0` the norm is zero
too (`ModularForm.norm_eq_zero_iff`), so both sides are the order of the same function.

### Why

`orderOfVanishingAt_norm` (the lemma directly above it) expands the norm's order at an interior
point as the sum over the coset space of the orders of the coset factors. The form itself is one
of those factors — the identity coset — and every order is non-negative, so the sum dominates
that single term.

That is exactly what transports finiteness of the zero set *downwards*: `Nm(f)` is a level-one
form, so `finite_zeros_in_fd` applies to it, and any zero of `f` is a zero of `Nm(f)` of at
least the same order. Keeping this step here is what lets Layer 1 establish finite support of
the order divisor without reaching for the Layer-10 compactification.

One spelling note recorded in the proof, because it is not obvious and cost a probe:
`ℋ ⧸ 𝒢.subgroupOf ℋ` is a coset **space**, not a group — `subgroupOf` need not be normal — so
there is no `1 : ℋ ⧸ 𝒢.subgroupOf ℋ` and the identity coset must be written `⟦1⟧`. Writing `1`
fails with `failed to synthesize OfNat`.

### Relation to the source library

Provenance: `github.com/CBirkbeck/AINTLIB` @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`, as
published in that repo — searched, **not** ported.

The nearest AINTLIB development is
`projects/LeanModularForms/LeanModularForms/Modularforms/DimGenCongLevels/NormTransfer.lean`,
whose subject is *"Transfer of `q`-coefficient vanishing under norm"*: it proves the **cusp**
statement (`valueAtInfty_norm_eq_zero_of_valueAtInfty_eq_zero` and the `cuspFunction`/BigO
lemmas around it), that vanishing of the first `N` `q`-coefficients of `f` at `∞` transfers to
the norm.

This PR is the **interior** counterpart — a statement about `orderOfVanishingAt` at a point of
`ℍ`, proved through the coset-product expansion rather than through BigO estimates on the cusp
function. AINTLIB's `DimGenCongLevels` chain is aimed at finite-dimensionality and the Sturm
bound, both of which live at the cusp, so it has no interior-divisor statement to port. Searched
three vocabularies: `orderOfVanishingAt_le` / `orderOfVanishingAt_norm` / "dominate";
`orderAtCusp'`-with-norm and `Nm`-with-`ord`; and zero-set/divisor spellings. Nothing to reuse.

Duplication: no open PR by any author touches `Norm/Order.lean` or `Order/OfVanishing.lean`, and
none declares an `orderOfVanishingAt_le…` lemma.
