### PR TITLE
docs(EDS): remove the parity-transfer claim the repo has since disproved

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
@@ -56,9 +56,11 @@ identities listed below.
 `WeierstrassCurve.ω` itself and its API — `ω_spec`, `two_mul_ω`, `ψc`, `ψc_spec`, `ω_zero`,
 `ω_one`, `ψc_neg`, `map_ω`, `ω_neg` — are **not** in this file. `ω` is defined through
 `redInvarDenom` and `complEDS₂Aux`, and `ω_spec` additionally consumes `redInvar_normEDS`, which
-routes through `normEDS` being an elliptic sequence: a fact the pinned Mathlib records as an open
-TODO and whose proof is the parity-transfer machinery of Mathlib PR #42453. Nothing in this file
-depends on any of it, so the identities land now and `ω` follows when that gap closes.
+routes through `normEDS` being an elliptic sequence — that is `isEllipticSequence_normEDS` in
+`NormEDS.lean`, which the pinned Mathlib still records as an open TODO. What is missing for `ω`
+is `redInvarDenom` itself together with the chain
+`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`. Nothing in this file depends
+on any of it, so the identities land now and `ω` follows when that gap closes.
 
 ## Provenance
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -47,13 +47,16 @@ Both route through the fact that `normEDS` is an elliptic sequence, along
 
 for the first, and `invarDenom_eq_redInvarDenom_mul ← normEDS_mul_complEDS_div ←
 normEDS_mul_complEDS ← normEDS_mul_complEDS_of_mem ← IsEllipticSequence.normEDS` for the second.
-That fact is not in the pinned Mathlib, which records it as an open TODO
+That fact is `isEllipticSequence_normEDS` in `NormEDS.lean`, proved here through the descent of
+`Descent.lean`; the pinned Mathlib still records it as an open TODO
 (`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean`: "prove that `normEDS` satisfies
-`IsEllipticDvdSequence`"), and proving it needs the parity-transfer machinery of Mathlib PR #42453.
-Carrying the bare definition across now would add a formula that no consumer can state anything
-about, so it waits for the layer that gives it meaning. Everything below is independent of that
-fact: nothing carries an ellipticity hypothesis, and the source discharges the ellipticity
-variables over exactly this block.
+`IsEllipticDvdSequence`"). What the denominator side still lacks is the rest of each chain above:
+`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS` for the first, and
+`normEDS_mul_complEDS_div ← normEDS_mul_complEDS ← normEDS_mul_complEDS_of_mem` for the second.
+Carrying the bare definition across before them would add a formula that no consumer can state
+anything about, so it waits for the layer that gives it meaning. Everything below is independent
+of that fact: nothing carries an ellipticity hypothesis, and the source discharges the
+ellipticity variables over exactly this block.
 
 ## Provenance
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
@@ -85,11 +85,12 @@ one-line proof and consumers reaching for the pre-normalised sequence would othe
 redo it.
 
 Deliberately **not** ported here: `universalNormEDS_ne_zero` and
-`universalNormEDS_mem_nonZeroDivisors`. They rest on `normEDS 2 3 2 = id`, which needs two
-things: `normEDS` known to be an elliptic sequence, which is now `isEllipticSequence_normEDS` in
-`NormEDS.lean`, and an extensionality principle for elliptic sequences — two such sequences
-agreeing at the indices that determine them are equal — which this repository does not have.
-They belong with whichever slice ports that principle.
+`universalNormEDS_mem_nonZeroDivisors`. They rest on `normEDS 2 3 2 = id`, the source's
+`normEDS_two_three_two`, which needs two things: `normEDS` known to be an elliptic sequence,
+which is now `isEllipticSequence_normEDS` in `NormEDS.lean`, and an extensionality principle for
+elliptic sequences — the source's `IsEllSequence.ext`, that two elliptic sequences agreeing at
+the indices which determine them are equal — which this repository does not have. They belong
+with whichever slice ports that principle.
 -/
 
 public section

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
@@ -85,9 +85,11 @@ one-line proof and consumers reaching for the pre-normalised sequence would othe
 redo it.
 
 Deliberately **not** ported here: `universalNormEDS_ne_zero` and
-`universalNormEDS_mem_nonZeroDivisors`. They rest on `normEDS 2 3 2 = id`, whose proof needs
-`normEDS` to be known an elliptic sequence — which the pinned Mathlib does not know, and which is
-the content of the separate open Mathlib PR #42453. They belong with whichever slice ports that.
+`universalNormEDS_mem_nonZeroDivisors`. They rest on `normEDS 2 3 2 = id`, which needs two
+things: `normEDS` known to be an elliptic sequence, which is now `isEllipticSequence_normEDS` in
+`NormEDS.lean`, and an extensionality principle for elliptic sequences — two such sequences
+agreeing at the indices that determine them are equal — which this repository does not have.
+They belong with whichever slice ports that principle.
 -/
 
 public section


### PR DESCRIPTION
Three files state that proving `normEDS` an elliptic sequence requires the parity-transfer
machinery of Mathlib PR #42453. That is no longer true, and it has not been since #3270.

| file | said | now says |
|---|---|---|
| `ReducedInvariant.lean` | blocked on PR #42453 | the fact is `isEllipticSequence_normEDS`; names the chains still missing |
| `Universal.lean` | blocked on PR #42453 | blocked on an extensionality principle — see below |
| `DivisionPolynomial/Invariant.lean` | blocked on PR #42453 | the fact is available; `redInvarDenom` and its chain are what `ω` still waits on |

No declaration changes. The diff is module-docstring prose in three files.

## Why the claim is false

#3226 proved `isEllipticSequence_iff` — being an elliptic sequence is exactly satisfying the two
doubling recurrences — by the descent in `Descent.lean`. #3270 then proved
`isEllipticSequence_normEDS` from it, transporting along `aeval` from the universal polynomial
ring. Neither step uses parity transfer. The route the three docstrings describe as necessary was
not the route taken, and the fact they describe as unavailable has been in the repository since
#3270 merged.

The pinned Mathlib does still record it as an open TODO, and each replacement says so. What
changed is the repository, not Mathlib.

## A gap this turned up, which is not a wording fix

`Universal.lean` was not merely stale — it was wrong about its own blocker. It records
`universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors` as waiting on `normEDS`
being known elliptic. They are not. That fact is now available and those two are still not
provable here, because `normEDS 2 3 2 = id` additionally needs an **extensionality principle for
elliptic sequences** — two such sequences agreeing at the indices that determine them are equal
(AINTLIB's `IsEllSequence.ext`). The repository does not have it, and nothing else in the
repository currently wants it.

So the honest statement of the blocker is one this repository had never written down. It is
recorded here rather than acted on: whether that principle should be built is a roadmap question
for a human, not something to add off the back of a documentation PR.

## Why prose, and why now

A reader who trusted these blocks would go and build parity-transfer machinery that nothing
needs, or conclude that the invariant and denominator layers are further away than they are. Each
replacement therefore states what is true now and names the surviving gap explicitly, rather than
narrating the correction:

* invariant side — `redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`
* denominator side — `normEDS_mul_complEDS_div ← normEDS_mul_complEDS ← normEDS_mul_complEDS_of_mem`
* `ω` additionally needs `redInvarDenom` itself

All eight of those names are absent from the repository, checked by full-name grep across
`TauCeti/` at this head; `invarDenom` (`Invariant.lean`) and `isEllipticSequence_normEDS`
(`NormEDS.lean`) are present. After this PR no file in `TauCeti/` mentions PR #42453.

## Gates

`lake build` PASS at 7866 jobs, branch cut from current `main` (`ef5729d9c`). No line over 100
codepoints — measured in codepoints, not bytes, since these files are full of `₂`, `←` and `ω`
and a byte count both over- and under-reports. Docstrings are parsed, so the build is a real gate
here even though no declaration changed.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-stale-parity-claim"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
