### PR TITLE
feat: classify branchless double-edge diagrams

### DIFF
--- a/TauCeti/Combinatorics/SimpleGraph/PathGraph.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/PathGraph.lean
@@ -33,6 +33,9 @@ of `p`. The subgraph spanned by `p` is therefore all of `G`, and Mathlib's
 
 * `TauCeti.IsTree.nonempty_iso_pathGraph_of_degree_le_two`: a finite tree of maximum degree two is
   isomorphic to the path graph on its vertices.
+* `TauCeti.adj_iff_of_iso_pathGraph`: adjacency read through such a numbering is consecutiveness of
+  the numbers.
+* `TauCeti.pathGraphRevIso`: the reversal automorphism of a path graph, which reverses a numbering.
 
 ## References
 
@@ -45,6 +48,27 @@ namespace TauCeti
 open SimpleGraph
 
 variable {V : Type*} {G : SimpleGraph V}
+
+/-! ## Numbering a graph as a path -/
+
+/-- **Adjacency read through a numbering of a graph as a path**: two vertices are adjacent exactly
+when their numbers are consecutive. -/
+theorem adj_iff_of_iso_pathGraph {n : ℕ} (f : G ≃g pathGraph n) (i j : V) :
+    G.Adj i j ↔ (f i : ℕ) + 1 = (f j : ℕ) ∨ (f j : ℕ) + 1 = (f i : ℕ) := by
+  simpa only [pathGraph_adj] using f.map_adj_iff.symm
+
+/-- **Reversal is an automorphism of a path graph.** Composing with it reverses a numbering of a
+graph as a path. -/
+@[expose] def pathGraphRevIso (n : ℕ) : pathGraph n ≃g pathGraph n where
+  toEquiv := Fin.revPerm
+  map_rel_iff' := by
+    intro i j
+    simp only [pathGraph_adj, Fin.revPerm_apply, Fin.rev]
+    omega
+
+@[simp] theorem pathGraphRevIso_apply {n : ℕ} (i : Fin n) : pathGraphRevIso n i = i.rev := rfl
+
+/-! ## A finite tree of maximum degree two -/
 
 /-- **A neighbour of the first vertex of a longest path lies on that path**: otherwise it could be
 prepended, and the path was not longest. -/

--- a/TauCeti/Combinatorics/SimpleGraph/PathGraph.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/PathGraph.lean
@@ -58,15 +58,16 @@ theorem adj_iff_of_iso_pathGraph {n : ℕ} (f : G ≃g pathGraph n) (i j : V) :
   simpa only [pathGraph_adj] using f.map_adj_iff.symm
 
 /-- **Reversal is an automorphism of a path graph.** Composing with it reverses a numbering of a
-graph as a path. -/
-@[expose] def pathGraphRevIso (n : ℕ) : pathGraph n ≃g pathGraph n where
+graph as a path. The body is exported unexposed, so `pathGraphRevIso_apply` is the interface an
+importing module computes with. -/
+def pathGraphRevIso (n : ℕ) : pathGraph n ≃g pathGraph n where
   toEquiv := Fin.revPerm
   map_rel_iff' := by
     intro i j
     simp only [pathGraph_adj, Fin.revPerm_apply, Fin.rev]
     omega
 
-@[simp] theorem pathGraphRevIso_apply {n : ℕ} (i : Fin n) : pathGraphRevIso n i = i.rev := rfl
+@[simp] theorem pathGraphRevIso_apply {n : ℕ} (i : Fin n) : pathGraphRevIso n i = i.rev := (rfl)
 
 /-! ## A finite tree of maximum degree two -/
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
@@ -6,7 +6,7 @@ module
 
 import TauCeti.Combinatorics.SimpleGraph.PathGraph
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Diagram
-public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Classification
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Basic
 import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Reindex
 import TauCeti.LinearAlgebra.RootSystem.FiniteType.TwoDoubleEdges
 
@@ -29,11 +29,10 @@ double-edge branch.
 
 ## Main results
 
-* `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two`: a
-  connected finite-type diagram of maximum degree two containing an oriented double edge is a
-  double-edge model with two nonempty arms.
-* `TauCeti.IsFiniteType.exists_doubleEdgeCartanMatrix_shape_of_degree_le_two`: the resulting arms
-  have exactly one of the `B`, `C`, and `F_4` shapes.
+* `IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_eq_one_or_eq_one_or_eq_two_two`
+  (in the `TauCeti` namespace, the full name being too long for one line): a preconnected
+  finite-type diagram of maximum degree two containing an oriented double edge is a double-edge
+  model whose two nonempty arms have one of the `B`, `C`, and `F_4` shapes.
 
 ## References
 
@@ -48,22 +47,21 @@ namespace TauCeti
 
 open SimpleGraph
 
-variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
+variable {B : Type*} [Fintype B] {A : Matrix B B ℤ} {n : ℕ}
 
 /-! ## A path has at most one multiple edge -/
 
 /-- Starting from a multiple edge at position `a` in a path numbering, every later edge is
 single. -/
-private theorem apply_mul_apply_eq_one_of_pathEquiv_of_lt (h : IsFiniteType A)
-    (k : B ≃ Fin n)
-    (hk : ∀ i j, (diagramGraph A).Adj i j ↔
-      (k i : ℕ) + 1 = (k j : ℕ) ∨ (k j : ℕ) + 1 = (k i : ℕ))
+private theorem apply_mul_apply_eq_one_of_isoPathGraph_of_lt (h : IsFiniteType A)
+    (k : diagramGraph A ≃g pathGraph n)
     {a : ℕ} (ha : a + 1 < n)
     (hfirst : 2 ≤ A (k.symm ⟨a, by omega⟩) (k.symm ⟨a + 1, ha⟩) *
       A (k.symm ⟨a + 1, ha⟩) (k.symm ⟨a, by omega⟩))
     {r : ℕ} (hr : r + 1 < n) (har : a < r) :
     A (k.symm ⟨r, by omega⟩) (k.symm ⟨r + 1, hr⟩) *
       A (k.symm ⟨r + 1, hr⟩) (k.symm ⟨r, by omega⟩) = 1 := by
+  have hk := adj_iff_of_iso_pathGraph k
   -- Strong induction on the distance from `a`: the intervening edges are single by induction.
   -- Thus the two-multiple-edge exclusion applies to the subpath from `a` through `r + 1`.
   induction r using Nat.strong_induction_on with
@@ -75,6 +73,12 @@ private theorem apply_mul_apply_eq_one_of_pathEquiv_of_lt (h : IsFiniteType A)
         if hs : a + s < n then k.symm ⟨a + s, hs⟩ else k.symm ⟨0, hn⟩
       have hv_apply {s : ℕ} (hs : s < m + 3) : k (v s) = ⟨a + s, by omega⟩ := by
         simp [v, show a + s < n by omega]
+      -- The same fact read backwards, naming the vertex of the interval at each position.
+      have hv_eq {s : ℕ} (hs : s < m + 3) {t : ℕ} (ht : t < n) (hst : a + s = t) :
+          v s = k.symm ⟨t, ht⟩ := by
+        apply k.injective
+        rw [hv_apply hs, k.apply_symm_apply]
+        exact Fin.ext hst
       have hv : Set.InjOn v (Set.Iio (m + 3)) := by
         intro s hs t ht hst
         have hks : (k (v s) : ℕ) = a + s := by
@@ -103,36 +107,16 @@ private theorem apply_mul_apply_eq_one_of_pathEquiv_of_lt (h : IsFiniteType A)
       have hsimple : ∀ s, 0 < s → s < m + 1 →
           A (v s) (v (s + 1)) * A (v (s + 1)) (v s) = 1 := by
         intro s hs hsm
-        have hvs : v s = k.symm ⟨a + s, by omega⟩ := by
-          apply k.injective
-          rw [hv_apply (by omega), k.apply_symm_apply]
-        have hvss : v (s + 1) = k.symm ⟨a + s + 1, by omega⟩ := by
-          apply k.injective
-          rw [hv_apply (by omega), k.apply_symm_apply]
-          rfl
-        rw [hvs, hvss]
+        rw [hv_eq (t := a + s) (by omega) (by omega) rfl,
+          hv_eq (t := a + s + 1) (by omega) (by omega) (by omega)]
         exact ih (a + s) (by omega) (by omega) (by omega)
       -- The two-multiple-edge exclusion applied to this interval makes its last edge single.
       have hle := h.apply_mul_apply_le_one_of_chain_of_two_le hv hzero hsimple (m := m) (by
-        have hv0 : v 0 = k.symm ⟨a, by omega⟩ := by
-          apply k.injective
-          rw [hv_apply (by omega), k.apply_symm_apply]
-          rfl
-        have hv1 : v 1 = k.symm ⟨a + 1, ha⟩ := by
-          apply k.injective
-          rw [hv_apply (by omega), k.apply_symm_apply]
-        simpa [hv0, hv1] using hfirst)
-      have hvm1 : v (m + 1) = k.symm ⟨r, by omega⟩ := by
-        apply k.injective
-        rw [hv_apply (by omega), k.apply_symm_apply]
-        congr 1
-        omega
-      have hvm2 : v (m + 2) = k.symm ⟨r + 1, hr⟩ := by
-        apply k.injective
-        rw [hv_apply (by omega), k.apply_symm_apply]
-        congr 1
-        omega
-      rw [hvm1, hvm2] at hle
+        rw [hv_eq (t := a) (by omega) (by omega) (by omega),
+          hv_eq (t := a + 1) (by omega) ha rfl]
+        exact hfirst)
+      rw [hv_eq (t := r) (by omega) (by omega) (by omega),
+        hv_eq (t := r + 1) (by omega) hr (by omega)] at hle
       have hne : A (k.symm ⟨r, by omega⟩) (k.symm ⟨r + 1, hr⟩) ≠ 0 := by
         apply (h.diagramGraph_adj_iff.mp ?_).2
         rw [hk, k.apply_symm_apply, k.apply_symm_apply]
@@ -140,23 +124,19 @@ private theorem apply_mul_apply_eq_one_of_pathEquiv_of_lt (h : IsFiniteType A)
       have hone := h.one_le_apply_mul_apply hne
       omega
 
-/-- In a path numbering, every edge other than a fixed multiple edge has Cartan product one. -/
-private theorem apply_mul_apply_eq_one_of_pathEquiv (h : IsFiniteType A) (k : B ≃ Fin n)
-    (hk : ∀ i j, (diagramGraph A).Adj i j ↔
-      (k i : ℕ) + 1 = (k j : ℕ) ∨ (k j : ℕ) + 1 = (k i : ℕ))
-    {u v : B} (huv : (k u : ℕ) + 1 = (k v : ℕ))
-    (hfirst : 2 ≤ A u v * A v u) {i j : B} (hij : (diagramGraph A).Adj i j)
-    (hne : ¬ ((i = u ∧ j = v) ∨ (i = v ∧ j = u))) : A i j * A j i = 1 := by
-  have hpath := (hk i j).mp hij
+/-- In a path numbering, an edge lying strictly beyond a fixed multiple edge has Cartan product
+one. -/
+private theorem apply_mul_apply_eq_one_of_isoPathGraph_of_lt_min (h : IsFiniteType A)
+    (k : diagramGraph A ≃g pathGraph n) {u v : B} (huv : (k u : ℕ) + 1 = (k v : ℕ))
+    (hfirst : 2 ≤ A u v * A v u) {i j : B}
+    (hpath : (k i : ℕ) + 1 = (k j : ℕ) ∨ (k j : ℕ) + 1 = (k i : ℕ))
+    (hlt : (k u : ℕ) < min (k i : ℕ) (k j : ℕ)) : A i j * A j i = 1 := by
   let a := (k u : ℕ)
   let r := min (k i : ℕ) (k j : ℕ)
+  have har : a < r := hlt
   have ha : a + 1 < n := by rw [huv]; exact (k v).isLt
-  have hr : r + 1 < n := by
-    rcases hpath with hp | hp
-    · simp only [r]
-      omega
-    · simp only [r]
-      omega
+  have hr : r + 1 < n := by rcases hpath with hp | hp <;> simp only [r] <;> omega
+  -- The multiple edge is the edge from position `a` to position `a + 1`.
   have hbase : 2 ≤ A (k.symm ⟨a, by omega⟩) (k.symm ⟨a + 1, ha⟩) *
       A (k.symm ⟨a + 1, ha⟩) (k.symm ⟨a, by omega⟩) := by
     have hku : k.symm ⟨a, by omega⟩ = u := by
@@ -165,91 +145,80 @@ private theorem apply_mul_apply_eq_one_of_pathEquiv (h : IsFiniteType A) (k : B 
     have hkv : k.symm ⟨a + 1, ha⟩ = v := by
       apply k.injective
       rw [k.apply_symm_apply]
-      apply Fin.ext
-      exact huv
+      exact Fin.ext huv
     simpa only [hku, hkv] using hfirst
-  rcases lt_trichotomy a r with har | har | har
-  · have hone := apply_mul_apply_eq_one_of_pathEquiv_of_lt h k hk ha hbase hr har
-    rcases hpath with hp | hp
-    · have hki : k i = ⟨r, by omega⟩ := by apply Fin.ext; simp only [r]; omega
-      have hkj : k j = ⟨r + 1, hr⟩ := by apply Fin.ext; simp only [r]; omega
-      have hi : k.symm ⟨r, by omega⟩ = i := by rw [← hki, k.symm_apply_apply]
-      have hj : k.symm ⟨r + 1, hr⟩ = j := by rw [← hkj, k.symm_apply_apply]
-      simpa only [hi, hj] using hone
-    · have hkj : k j = ⟨r, by omega⟩ := by apply Fin.ext; simp only [r]; omega
-      have hki : k i = ⟨r + 1, hr⟩ := by apply Fin.ext; simp only [r]; omega
-      have hj : k.symm ⟨r, by omega⟩ = j := by rw [← hkj, k.symm_apply_apply]
-      have hi : k.symm ⟨r + 1, hr⟩ = i := by rw [← hki, k.symm_apply_apply]
-      simpa only [hi, hj, mul_comm] using hone
+  -- The target edge is the edge from position `r` to position `r + 1`, in one of the two
+  -- orientations.
+  have hone := apply_mul_apply_eq_one_of_isoPathGraph_of_lt h k ha hbase hr har
+  rcases hpath with hp | hp
+  · have hi : k.symm ⟨r, by omega⟩ = i := by
+      rw [show (⟨r, by omega⟩ : Fin n) = k i from Fin.ext (by simp only [r]; omega),
+        k.symm_apply_apply]
+    have hj : k.symm ⟨r + 1, hr⟩ = j := by
+      rw [show (⟨r + 1, hr⟩ : Fin n) = k j from Fin.ext (by simp only [r]; omega),
+        k.symm_apply_apply]
+    simpa only [hi, hj] using hone
+  · have hj : k.symm ⟨r, by omega⟩ = j := by
+      rw [show (⟨r, by omega⟩ : Fin n) = k j from Fin.ext (by simp only [r]; omega),
+        k.symm_apply_apply]
+    have hi : k.symm ⟨r + 1, hr⟩ = i := by
+      rw [show (⟨r + 1, hr⟩ : Fin n) = k i from Fin.ext (by simp only [r]; omega),
+        k.symm_apply_apply]
+    simpa only [hi, hj, mul_comm] using hone
+
+/-- In a path numbering, every edge other than a fixed multiple edge has Cartan product one. -/
+private theorem apply_mul_apply_eq_one_of_isoPathGraph (h : IsFiniteType A)
+    (k : diagramGraph A ≃g pathGraph n) {u v : B} (huv : (k u : ℕ) + 1 = (k v : ℕ))
+    (hfirst : 2 ≤ A u v * A v u) {i j : B} (hij : (diagramGraph A).Adj i j)
+    (hne : ¬ ((i = u ∧ j = v) ∨ (i = v ∧ j = u))) : A i j * A j i = 1 := by
+  -- The multiple edge occupies the positions `k u` and `k u + 1`, and the edge `i -- j` the
+  -- positions `min (k i) (k j)` and `min (k i) (k j) + 1`. Trichotomy on the two positions: the
+  -- previous lemma settles the edges beyond the multiple edge, the reversed numbering turns the
+  -- edges before it into that case, and the remaining case is the excluded coincidence.
+  have hpath := (adj_iff_of_iso_pathGraph k i j).mp hij
+  rcases lt_trichotomy (k u : ℕ) (min (k i : ℕ) (k j : ℕ)) with hlt | heq | hgt
+  · exact apply_mul_apply_eq_one_of_isoPathGraph_of_lt_min h k huv hfirst hpath hlt
   · exfalso
     rcases hpath with hp | hp
-    · have hiu : i = u := k.injective (Fin.ext (by simp only [a, r] at har; omega))
-      have hjv : j = v := k.injective (Fin.ext (by simp only [a, r] at har; omega))
-      exact hne (Or.inl ⟨hiu, hjv⟩)
-    · have hiv : i = v := k.injective (Fin.ext (by simp only [a, r] at har; omega))
-      have hju : j = u := k.injective (Fin.ext (by simp only [a, r] at har; omega))
-      exact hne (Or.inr ⟨hiv, hju⟩)
-  · let k' : B ≃ Fin n := k.trans Fin.revPerm
-    have hk' : ∀ x y, (diagramGraph A).Adj x y ↔
-        (k' x : ℕ) + 1 = (k' y : ℕ) ∨ (k' y : ℕ) + 1 = (k' x : ℕ) := by
-      intro x y
-      rw [hk]
-      simp only [k', Equiv.trans_apply, Fin.revPerm_apply, Fin.val_rev]
+    · exact hne (Or.inl ⟨k.injective (Fin.ext (by omega)), k.injective (Fin.ext (by omega))⟩)
+    · exact hne (Or.inr ⟨k.injective (Fin.ext (by omega)), k.injective (Fin.ext (by omega))⟩)
+  · let k' : diagramGraph A ≃g pathGraph n := k.trans (pathGraphRevIso n)
+    have hk' : ∀ x : B, (k' x : ℕ) = n - 1 - (k x : ℕ) := fun x => by
+      simp only [k', RelIso.trans_apply, pathGraphRevIso_apply, Fin.val_rev]
       omega
+    -- Reversing the numbering exchanges the two endpoints of the multiple edge and reverses the
+    -- order of the positions, so the edge `i -- j` now lies beyond it.
     have huv' : (k' v : ℕ) + 1 = (k' u : ℕ) := by
-      simp only [k', Equiv.trans_apply, Fin.revPerm_apply, Fin.val_rev]
+      simp only [hk']
+      have := (k v).isLt
       omega
-    let a' := (k' v : ℕ)
-    let r' := min (k' i : ℕ) (k' j : ℕ)
-    have ha' : a' + 1 < n := by rw [huv']; exact (k' u).isLt
-    have hpath' := (hk' i j).mp hij
-    have hr' : r' + 1 < n := by
-      rcases hpath' with hp | hp <;> simp only [r'] <;> omega
-    have har' : a' < r' := by
-      rcases hpath with hp | hp <;>
-        simp only [a, r, a', r', k', Equiv.trans_apply, Fin.revPerm_apply, Fin.val_rev] at har ⊢ <;>
-        omega
-    have hbase' : 2 ≤ A (k'.symm ⟨a', by omega⟩) (k'.symm ⟨a' + 1, ha'⟩) *
-        A (k'.symm ⟨a' + 1, ha'⟩) (k'.symm ⟨a', by omega⟩) := by
-      have hkv : k'.symm ⟨a', by omega⟩ = v := by
-        apply k'.injective
-        rw [k'.apply_symm_apply]
-      have hku : k'.symm ⟨a' + 1, ha'⟩ = u := by
-        apply k'.injective
-        rw [k'.apply_symm_apply]
-        apply Fin.ext
-        exact huv'
-      simpa only [hkv, hku, mul_comm] using hfirst
-    have hone := apply_mul_apply_eq_one_of_pathEquiv_of_lt h k' hk' ha' hbase' hr' har'
-    rcases hpath' with hp | hp
-    · have hki : k' i = ⟨r', by omega⟩ := by apply Fin.ext; simp only [r']; omega
-      have hkj : k' j = ⟨r' + 1, hr'⟩ := by apply Fin.ext; simp only [r']; omega
-      have hi : k'.symm ⟨r', by omega⟩ = i := by rw [← hki, k'.symm_apply_apply]
-      have hj : k'.symm ⟨r' + 1, hr'⟩ = j := by rw [← hkj, k'.symm_apply_apply]
-      simpa only [hi, hj] using hone
-    · have hkj : k' j = ⟨r', by omega⟩ := by apply Fin.ext; simp only [r']; omega
-      have hki : k' i = ⟨r' + 1, hr'⟩ := by apply Fin.ext; simp only [r']; omega
-      have hj : k'.symm ⟨r', by omega⟩ = j := by rw [← hkj, k'.symm_apply_apply]
-      have hi : k'.symm ⟨r' + 1, hr'⟩ = i := by rw [← hki, k'.symm_apply_apply]
-      simpa only [hi, hj, mul_comm] using hone
+    have hlt' : (k' v : ℕ) < min (k' i : ℕ) (k' j : ℕ) := by
+      simp only [hk']
+      have := (k i).isLt
+      have := (k j).isLt
+      omega
+    refine apply_mul_apply_eq_one_of_isoPathGraph_of_lt_min h k' huv' ?_
+      ((adj_iff_of_iso_pathGraph k' i j).mp hij) hlt'
+    rw [mul_comm]
+    exact hfirst
 
 /-! ## Reindexing and classification -/
 
-/-- **The branchless double-edge case is a double-edge model.** A connected finite-type diagram
-of maximum degree two that contains the oriented double edge `A v u = -2` reindexes to two
-nonempty chains joined by that edge.
+/-- A preconnected finite-type diagram of maximum degree two that contains the oriented double edge
+`A v u = -2` reindexes to two nonempty chains joined by that edge.
 
-Unlike `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix`, this theorem does not
-assume that every other off-diagonal entry is `-1`. The preceding path argument proves that the
-chosen edge is the only multiple edge, and the finite-type sign conditions then determine every
-remaining nonzero entry. -/
-theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two
-    (h : IsFiniteType A) (hconn : (diagramGraph A).Connected)
-    (hdeg : ∀ i, ((diagramGraph A).neighborSet i).ncard ≤ 2)
+Unlike `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix`, this does not assume
+that every other off-diagonal entry is `-1`. The preceding path argument proves that the chosen
+edge is the only multiple edge, and the finite-type sign conditions then determine every remaining
+nonzero entry. -/
+private theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two
+    [DecidableEq B] (h : IsFiniteType A) (hconn : (diagramGraph A).Preconnected)
+    (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2)
     {u v : B} (hvu : A v u = -2) :
     ∃ p q : ℕ, 0 < p ∧ 0 < q ∧ ∃ e : B ≃ Fin p ⊕ Fin q,
       ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
-  classical
+  have : Nonempty B := ⟨u⟩
+  have hconn' : (diagramGraph A).Connected := ⟨hconn⟩
   have hvu_ne : v ≠ u := by
     rintro rfl
     rw [h.apply_self] at hvu
@@ -260,31 +229,24 @@ theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_
     omega
   have hadj : (diagramGraph A).Adj u v :=
     h.diagramGraph_adj_iff.mpr ⟨hvu_ne.symm, hAuv⟩
+  -- The Cartan product of the double edge is `2`, so its other entry is `-1`.
   have hAuv_eq : A u v = -1 := by
     have hmem := h.apply_mul_apply_mem_of_ne hvu_ne.symm
-    have hnonpos := h.apply_le_zero_of_ne hvu_ne.symm
     rw [hvu] at hmem
     simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
-    rcases hmem with hzero | hone | htwo | hthree <;> ring_nf at * <;> omega
+    rcases hmem with hc | hc | hc | hc <;> omega
   have hprod : A u v * A v u = 2 := by rw [hAuv_eq, hvu]; norm_num
-  have hdeg' : ∀ i, (diagramGraph A).degree i ≤ 2 := by
-    intro i
-    rw [← card_neighborSet_eq_degree, Set.fintypeCard_eq_ncard]
-    exact hdeg i
   obtain ⟨k⟩ := IsTree.nonempty_iso_pathGraph_of_degree_le_two
-    (h.isTree_diagramGraph hconn) hdeg'
-  have hk : ∀ i j, (diagramGraph A).Adj i j ↔
-      (k i : ℕ) + 1 = (k j : ℕ) ∨ (k j : ℕ) + 1 = (k i : ℕ) :=
-    fun i j => by simpa only [pathGraph_adj] using k.map_adj_iff.symm
-  have hpath := (hk u v).mp hadj
+    (h.isTree_diagramGraph hconn') hdeg
+  have hpath := (adj_iff_of_iso_pathGraph k u v).mp hadj
   have hsingle : ∀ {i j : B}, (diagramGraph A).Adj i j →
       ¬ ((i = u ∧ j = v) ∨ (i = v ∧ j = u)) → A i j * A j i = 1 := by
     intro i j hij hne
     rcases hpath with huv | huv
-    · exact apply_mul_apply_eq_one_of_pathEquiv h k.toEquiv hk huv (by omega) hij hne
-    · exact apply_mul_apply_eq_one_of_pathEquiv h k.toEquiv hk huv
+    · exact apply_mul_apply_eq_one_of_isoPathGraph h k huv (by omega) hij hne
+    · exact apply_mul_apply_eq_one_of_isoPathGraph h k huv
         (by simpa only [mul_comm] using (show 2 ≤ A u v * A v u by omega)) hij (by tauto)
-  refine h.exists_equiv_forall_eq_doubleEdgeCartanMatrix hconn hdeg' hvu ?_
+  refine h.exists_equiv_forall_eq_doubleEdgeCartanMatrix hconn' hdeg hvu ?_
   intro i j hij hAij
   by_cases hforward : i = v ∧ j = u
   · exact Or.inl hforward
@@ -299,19 +261,21 @@ theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_
   · exact absurd hpos.1 (by omega)
   · exact hneg.1
 
-/-- **The admissible shapes in the branchless double-edge case.** Under the same hypotheses as
-`TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two`, the two
-nonempty arms have one of the three shapes in the Cartan--Killing list: the second arm is a
-singleton (type `C`), the first arm is a singleton (type `B`), or both have two vertices (type
-`F_4`). -/
-theorem IsFiniteType.exists_doubleEdgeCartanMatrix_shape_of_degree_le_two
-    (h : IsFiniteType A) (hconn : (diagramGraph A).Connected)
-    (hdeg : ∀ i, ((diagramGraph A).neighborSet i).ncard ≤ 2)
+/-- **The branchless double-edge case is a double-edge model of one of the admissible shapes.** A
+preconnected finite-type diagram of maximum degree two that contains the oriented double edge
+`A v u = -2` reindexes to two nonempty chains joined by that edge, and those chains have one of the
+three shapes in the Cartan--Killing list: the second is a singleton (type `C`), the first is a
+singleton (type `B`), or both have two vertices (type `F_4`).
+
+Unlike `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix`, this does not assume
+that the chosen double edge is the only multiple edge; the path argument of this file proves it. -/
+theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_eq_one_or_eq_one_or_eq_two_two
+    [DecidableEq B] (h : IsFiniteType A) (hconn : (diagramGraph A).Preconnected)
+    (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2)
     {u v : B} (hvu : A v u = -2) :
     ∃ p q : ℕ, 0 < p ∧ 0 < q ∧ (q = 1 ∨ p = 1 ∨ (p = 2 ∧ q = 2)) ∧
       ∃ e : B ≃ Fin p ⊕ Fin q,
         ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
-  classical
   obtain ⟨p, q, hp, hq, e, he⟩ :=
     h.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two hconn hdeg hvu
   have hmatrix : doubleEdgeCartanMatrix p q = A.submatrix e.symm e.symm := by

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
@@ -52,11 +52,8 @@ variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
 
 /-! ## A path has at most one multiple edge -/
 
-/-- Starting from a multiple edge at position `a` in a path numbering, every later edge is single.
-
-The proof is strong induction on the distance from `a`. For the edge at `r`, the intervening edges
-are single by induction, so `TauCeti.IsFiniteType.apply_mul_apply_le_one_of_chain_of_two_le`
-applies to the subpath from `a` through `r + 1`. -/
+/-- Starting from a multiple edge at position `a` in a path numbering, every later edge is
+single. -/
 private theorem apply_mul_apply_eq_one_of_pathEquiv_of_lt (h : IsFiniteType A)
     (k : B ≃ Fin n)
     (hk : ∀ i j, (diagramGraph A).Adj i j ↔
@@ -67,6 +64,8 @@ private theorem apply_mul_apply_eq_one_of_pathEquiv_of_lt (h : IsFiniteType A)
     {r : ℕ} (hr : r + 1 < n) (har : a < r) :
     A (k.symm ⟨r, by omega⟩) (k.symm ⟨r + 1, hr⟩) *
       A (k.symm ⟨r + 1, hr⟩) (k.symm ⟨r, by omega⟩) = 1 := by
+  -- Strong induction on the distance from `a`: the intervening edges are single by induction.
+  -- Thus the two-multiple-edge exclusion applies to the subpath from `a` through `r + 1`.
   induction r using Nat.strong_induction_on with
   | h r ih =>
       let m := r - a - 1
@@ -245,10 +244,12 @@ assume that every other off-diagonal entry is `-1`. The preceding path argument 
 chosen edge is the only multiple edge, and the finite-type sign conditions then determine every
 remaining nonzero entry. -/
 theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two
-    [DecidableEq B] (h : IsFiniteType A) (hconn : (diagramGraph A).Connected)
-    (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2) {u v : B} (hvu : A v u = -2) :
+    (h : IsFiniteType A) (hconn : (diagramGraph A).Connected)
+    (hdeg : ∀ i, ((diagramGraph A).neighborSet i).ncard ≤ 2)
+    {u v : B} (hvu : A v u = -2) :
     ∃ p q : ℕ, 0 < p ∧ 0 < q ∧ ∃ e : B ≃ Fin p ⊕ Fin q,
       ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
+  classical
   have hvu_ne : v ≠ u := by
     rintro rfl
     rw [h.apply_self] at hvu
@@ -266,8 +267,12 @@ theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_
     simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
     rcases hmem with hzero | hone | htwo | hthree <;> ring_nf at * <;> omega
   have hprod : A u v * A v u = 2 := by rw [hAuv_eq, hvu]; norm_num
+  have hdeg' : ∀ i, (diagramGraph A).degree i ≤ 2 := by
+    intro i
+    rw [← card_neighborSet_eq_degree, Set.fintypeCard_eq_ncard]
+    exact hdeg i
   obtain ⟨k⟩ := IsTree.nonempty_iso_pathGraph_of_degree_le_two
-    (h.isTree_diagramGraph hconn) hdeg
+    (h.isTree_diagramGraph hconn) hdeg'
   have hk : ∀ i j, (diagramGraph A).Adj i j ↔
       (k i : ℕ) + 1 = (k j : ℕ) ∨ (k j : ℕ) + 1 = (k i : ℕ) :=
     fun i j => by simpa only [pathGraph_adj] using k.map_adj_iff.symm
@@ -279,7 +284,7 @@ theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_
     · exact apply_mul_apply_eq_one_of_pathEquiv h k.toEquiv hk huv (by omega) hij hne
     · exact apply_mul_apply_eq_one_of_pathEquiv h k.toEquiv hk huv
         (by simpa only [mul_comm] using (show 2 ≤ A u v * A v u by omega)) hij (by tauto)
-  refine h.exists_equiv_forall_eq_doubleEdgeCartanMatrix hconn hdeg hvu ?_
+  refine h.exists_equiv_forall_eq_doubleEdgeCartanMatrix hconn hdeg' hvu ?_
   intro i j hij hAij
   by_cases hforward : i = v ∧ j = u
   · exact Or.inl hforward
@@ -299,12 +304,14 @@ theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_
 nonempty arms have one of the three shapes in the Cartan--Killing list: the second arm is a
 singleton (type `C`), the first arm is a singleton (type `B`), or both have two vertices (type
 `F_4`). -/
-theorem IsFiniteType.exists_doubleEdgeCartanMatrix_shape_of_degree_le_two [DecidableEq B]
+theorem IsFiniteType.exists_doubleEdgeCartanMatrix_shape_of_degree_le_two
     (h : IsFiniteType A) (hconn : (diagramGraph A).Connected)
-    (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2) {u v : B} (hvu : A v u = -2) :
+    (hdeg : ∀ i, ((diagramGraph A).neighborSet i).ncard ≤ 2)
+    {u v : B} (hvu : A v u = -2) :
     ∃ p q : ℕ, 0 < p ∧ 0 < q ∧ (q = 1 ∨ p = 1 ∨ (p = 2 ∧ q = 2)) ∧
       ∃ e : B ≃ Fin p ⊕ Fin q,
         ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
+  classical
   obtain ⟨p, q, hp, hq, e, he⟩ :=
     h.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two hconn hdeg hvu
   have hmatrix : doubleEdgeCartanMatrix p q = A.submatrix e.symm e.symm := by

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
@@ -57,6 +57,8 @@ in the Cartan--Killing list: the second is a singleton (type `C`), the first is 
 
 The double edge is given by the orientation-free hypothesis `A u v * A v u = 2`; the two
 orientations of the edge give the two transposed models, both of which the disjunction covers. -/
+-- `degree` needs finite neighbour sets while the theorem type is elaborated, so this decidability
+-- instance cannot be confined to the proof.
 theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_eq_one_or_eq_one_or_eq_two_two
     [DecidableEq B] (h : IsFiniteType A) (hconn : (diagramGraph A).Preconnected)
     (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2)

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-import TauCeti.Combinatorics.SimpleGraph.PathGraph
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Diagram
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Basic
 import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Reindex
@@ -15,24 +14,25 @@ public section
 /-!
 # The branchless double-edge case of the finite-type classification
 
-A connected finite-type Cartan diagram of maximum degree two is a path. If one edge of that path
-is double, the affine-diagram exclusion in
-`TauCeti.IsFiniteType.apply_mul_apply_le_one_of_chain_of_two_le` forces every other edge to be
-single. The path can therefore be reindexed onto `TauCeti.doubleEdgeCartanMatrix p q`, and the
-double-edge bound leaves precisely the families `B_n`, `C_n`, and the exceptional type `F_4`.
+A connected finite-type Cartan diagram of maximum degree two is a path. If one edge of that path is
+double, `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix` reindexes the diagram
+onto `TauCeti.doubleEdgeCartanMatrix p q`, and the double-edge bound
+`TauCeti.eq_one_or_eq_one_or_eq_two_two_of_isFiniteType_doubleEdge` leaves precisely the families
+`B_n`, `C_n`, and the exceptional type `F_4`.
 
-This file discharges the uniqueness hypothesis of
-`TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix`: the caller need only exhibit
-one double edge. Excluding a branch vertex from a connected finite-type diagram containing a
-double edge remains the final extraction step before this result applies to the unrestricted
-double-edge branch.
+The double edge is taken here in the orientation-free form `A u v * A v u = 2`, which is what the
+sign conditions of a finite-type matrix produce at a multiple edge. Its two orientations reindex to
+the two transposed models, and the alternatives below are stated so as to cover both.
+
+Excluding a branch vertex from a connected finite-type diagram containing a double edge remains the
+final extraction step before this result applies to the unrestricted double-edge branch.
 
 ## Main results
 
 * `IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_eq_one_or_eq_one_or_eq_two_two`
   (in the `TauCeti` namespace, the full name being too long for one line): a preconnected
-  finite-type diagram of maximum degree two containing an oriented double edge is a double-edge
-  model whose two nonempty arms have one of the `B`, `C`, and `F_4` shapes.
+  finite-type diagram of maximum degree two containing a double edge is a double-edge model whose
+  two nonempty arms have one of the `B`, `C`, and `F_4` shapes.
 
 ## References
 
@@ -47,249 +47,47 @@ namespace TauCeti
 
 open SimpleGraph
 
-variable {B : Type*} [Fintype B] {A : Matrix B B ℤ} {n : ℕ}
-
-/-! ## A path has at most one multiple edge -/
-
-/-- Starting from a multiple edge at position `a` in a path numbering, every later edge is
-single. -/
-private theorem apply_mul_apply_eq_one_of_isoPathGraph_of_lt (h : IsFiniteType A)
-    (k : diagramGraph A ≃g pathGraph n)
-    {a : ℕ} (ha : a + 1 < n)
-    (hfirst : 2 ≤ A (k.symm ⟨a, by omega⟩) (k.symm ⟨a + 1, ha⟩) *
-      A (k.symm ⟨a + 1, ha⟩) (k.symm ⟨a, by omega⟩))
-    {r : ℕ} (hr : r + 1 < n) (har : a < r) :
-    A (k.symm ⟨r, by omega⟩) (k.symm ⟨r + 1, hr⟩) *
-      A (k.symm ⟨r + 1, hr⟩) (k.symm ⟨r, by omega⟩) = 1 := by
-  have hk := adj_iff_of_iso_pathGraph k
-  -- Strong induction on the distance from `a`: the intervening edges are single by induction.
-  -- Thus the two-multiple-edge exclusion applies to the subpath from `a` through `r + 1`.
-  induction r using Nat.strong_induction_on with
-  | h r ih =>
-      let m := r - a - 1
-      have hn : 0 < n := by omega
-      -- Read the interval from vertex `a` through vertex `r + 1` as a chain of length `m + 3`.
-      let v : ℕ → B := fun s =>
-        if hs : a + s < n then k.symm ⟨a + s, hs⟩ else k.symm ⟨0, hn⟩
-      have hv_apply {s : ℕ} (hs : s < m + 3) : k (v s) = ⟨a + s, by omega⟩ := by
-        have hs' : a + s < n := by omega
-        simp [v, hs']
-      -- The same fact read backwards, naming the vertex of the interval at each position.
-      have hv_eq {s : ℕ} (hs : s < m + 3) {t : ℕ} (ht : t < n) (hst : a + s = t) :
-          v s = k.symm ⟨t, ht⟩ := by
-        apply k.injective
-        rw [hv_apply hs, k.apply_symm_apply]
-        exact Fin.ext hst
-      have hv : Set.InjOn v (Set.Iio (m + 3)) := by
-        intro s hs t ht hst
-        have hks : (k (v s) : ℕ) = a + s := by
-          simpa using congrArg Fin.val (hv_apply (Set.mem_Iio.mp hs))
-        have hkt : (k (v t) : ℕ) = a + t := by
-          simpa using congrArg Fin.val (hv_apply (Set.mem_Iio.mp ht))
-        have := congrArg (fun x : B => (k x : ℕ)) hst
-        rw [hks, hkt] at this
-        omega
-      -- Nonconsecutive vertices of the interval are not adjacent in the path.
-      have hzero : ∀ s t, s + 1 < t → t < m + 3 → A (v s) (v t) = 0 := by
-        intro s t hst ht
-        by_contra hne
-        have hvs : (k (v s) : ℕ) = a + s := by
-          simpa using congrArg Fin.val (hv_apply (s := s) (by omega))
-        have hvt : (k (v t) : ℕ) = a + t := by
-          simpa using congrArg Fin.val (hv_apply (s := t) ht)
-        have hvne : v s ≠ v t := fun heq => by
-          have := congrArg (fun x : B => (k x : ℕ)) heq
-          rw [hvs, hvt] at this
-          omega
-        have hadj := h.diagramGraph_adj_iff.mpr ⟨hvne, hne⟩
-        rw [hk, hvs, hvt] at hadj
-        omega
-      -- Every interior edge is closer to `a` than the target edge, hence single by induction.
-      have hsimple : ∀ s, 0 < s → s < m + 1 →
-          A (v s) (v (s + 1)) * A (v (s + 1)) (v s) = 1 := by
-        intro s hs hsm
-        rw [hv_eq (t := a + s) (by omega) (by omega) rfl,
-          hv_eq (t := a + s + 1) (by omega) (by omega) (by omega)]
-        exact ih (a + s) (by omega) (by omega) (by omega)
-      -- The two-multiple-edge exclusion applied to this interval makes its last edge single.
-      have hle := h.apply_mul_apply_le_one_of_chain_of_two_le hv hzero hsimple (m := m) (by
-        rw [hv_eq (t := a) (by omega) (by omega) (by omega),
-          hv_eq (t := a + 1) (by omega) ha rfl]
-        exact hfirst)
-      rw [hv_eq (t := r) (by omega) (by omega) (by omega),
-        hv_eq (t := r + 1) (by omega) hr (by omega)] at hle
-      have hne : A (k.symm ⟨r, by omega⟩) (k.symm ⟨r + 1, hr⟩) ≠ 0 := by
-        apply (h.diagramGraph_adj_iff.mp ?_).2
-        rw [hk, k.apply_symm_apply, k.apply_symm_apply]
-        exact Or.inl rfl
-      have hone := h.one_le_apply_mul_apply hne
-      omega
-
-/-- In a path numbering, an edge lying strictly beyond a fixed multiple edge has Cartan product
-one. -/
-private theorem apply_mul_apply_eq_one_of_isoPathGraph_of_lt_min (h : IsFiniteType A)
-    (k : diagramGraph A ≃g pathGraph n) {u v : B} (huv : (k u : ℕ) + 1 = (k v : ℕ))
-    (hfirst : 2 ≤ A u v * A v u) {i j : B}
-    (hpath : (k i : ℕ) + 1 = (k j : ℕ) ∨ (k j : ℕ) + 1 = (k i : ℕ))
-    (hlt : (k u : ℕ) < min (k i : ℕ) (k j : ℕ)) : A i j * A j i = 1 := by
-  let a := (k u : ℕ)
-  let r := min (k i : ℕ) (k j : ℕ)
-  have har : a < r := hlt
-  have ha : a + 1 < n := by rw [huv]; exact (k v).isLt
-  have hr : r + 1 < n := by rcases hpath with hp | hp <;> simp only [r] <;> omega
-  -- The multiple edge is the edge from position `a` to position `a + 1`.
-  have hbase : 2 ≤ A (k.symm ⟨a, by omega⟩) (k.symm ⟨a + 1, ha⟩) *
-      A (k.symm ⟨a + 1, ha⟩) (k.symm ⟨a, by omega⟩) := by
-    have hku : k.symm ⟨a, by omega⟩ = u := by
-      apply k.injective
-      rw [k.apply_symm_apply]
-    have hkv : k.symm ⟨a + 1, ha⟩ = v := by
-      apply k.injective
-      rw [k.apply_symm_apply]
-      exact Fin.ext huv
-    simpa only [hku, hkv] using hfirst
-  -- The target edge is the edge from position `r` to position `r + 1`, in one of the two
-  -- orientations.
-  have hone := apply_mul_apply_eq_one_of_isoPathGraph_of_lt h k ha hbase hr har
-  rcases hpath with hp | hp
-  · have hi : k.symm ⟨r, by omega⟩ = i := by
-      apply k.injective
-      rw [k.apply_symm_apply]
-      exact Fin.ext (by simp only [r]; omega)
-    have hj : k.symm ⟨r + 1, hr⟩ = j := by
-      apply k.injective
-      rw [k.apply_symm_apply]
-      exact Fin.ext (by simp only [r]; omega)
-    simpa only [hi, hj] using hone
-  · have hj : k.symm ⟨r, by omega⟩ = j := by
-      apply k.injective
-      rw [k.apply_symm_apply]
-      exact Fin.ext (by simp only [r]; omega)
-    have hi : k.symm ⟨r + 1, hr⟩ = i := by
-      apply k.injective
-      rw [k.apply_symm_apply]
-      exact Fin.ext (by simp only [r]; omega)
-    simpa only [hi, hj, mul_comm] using hone
-
-/-- In a path numbering, every edge other than a fixed multiple edge has Cartan product one. -/
-private theorem apply_mul_apply_eq_one_of_isoPathGraph (h : IsFiniteType A)
-    (k : diagramGraph A ≃g pathGraph n) {u v : B} (huv : (k u : ℕ) + 1 = (k v : ℕ))
-    (hfirst : 2 ≤ A u v * A v u) {i j : B} (hij : (diagramGraph A).Adj i j)
-    (hne : ¬ ((i = u ∧ j = v) ∨ (i = v ∧ j = u))) : A i j * A j i = 1 := by
-  -- The multiple edge occupies the positions `k u` and `k u + 1`, and the edge `i -- j` the
-  -- positions `min (k i) (k j)` and `min (k i) (k j) + 1`. Trichotomy on the two positions: the
-  -- previous lemma settles the edges beyond the multiple edge, the reversed numbering turns the
-  -- edges before it into that case, and the remaining case is the excluded coincidence.
-  have hpath := (adj_iff_of_iso_pathGraph k i j).mp hij
-  rcases lt_trichotomy (k u : ℕ) (min (k i : ℕ) (k j : ℕ)) with hlt | heq | hgt
-  · exact apply_mul_apply_eq_one_of_isoPathGraph_of_lt_min h k huv hfirst hpath hlt
-  · exfalso
-    rcases hpath with hp | hp
-    · exact hne (Or.inl ⟨k.injective (Fin.ext (by omega)), k.injective (Fin.ext (by omega))⟩)
-    · exact hne (Or.inr ⟨k.injective (Fin.ext (by omega)), k.injective (Fin.ext (by omega))⟩)
-  · let k' : diagramGraph A ≃g pathGraph n := k.trans (pathGraphRevIso n)
-    have hk' : ∀ x : B, (k' x : ℕ) = n - 1 - (k x : ℕ) := fun x => by
-      simp only [k', RelIso.trans_apply, pathGraphRevIso_apply, Fin.val_rev]
-      omega
-    -- Reversing the numbering exchanges the two endpoints of the multiple edge and reverses the
-    -- order of the positions, so the edge `i -- j` now lies beyond it.
-    have huv' : (k' v : ℕ) + 1 = (k' u : ℕ) := by
-      simp only [hk']
-      have := (k v).isLt
-      omega
-    have hlt' : (k' v : ℕ) < min (k' i : ℕ) (k' j : ℕ) := by
-      simp only [hk']
-      have := (k i).isLt
-      have := (k j).isLt
-      omega
-    refine apply_mul_apply_eq_one_of_isoPathGraph_of_lt_min h k' huv' ?_
-      ((adj_iff_of_iso_pathGraph k' i j).mp hij) hlt'
-    rw [mul_comm]
-    exact hfirst
-
-/-! ## Reindexing and classification -/
-
-/-- A preconnected finite-type diagram of maximum degree two that contains the oriented double edge
-`A v u = -2` reindexes to two nonempty chains joined by that edge.
-
-Unlike `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix`, this does not assume
-that every other off-diagonal entry is `-1`. The preceding path argument proves that the chosen
-edge is the only multiple edge, and the finite-type sign conditions then determine every remaining
-nonzero entry. -/
-private theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two
-    [DecidableEq B] (h : IsFiniteType A) (hconn : (diagramGraph A).Preconnected)
-    (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2)
-    {u v : B} (hvu : A v u = -2) :
-    ∃ p q : ℕ, 0 < p ∧ 0 < q ∧ ∃ e : B ≃ Fin p ⊕ Fin q,
-      ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
-  have : Nonempty B := ⟨u⟩
-  have hconn' : (diagramGraph A).Connected := ⟨hconn⟩
-  have hvu_ne : v ≠ u := by
-    rintro rfl
-    rw [h.apply_self] at hvu
-    omega
-  have hAuv : A u v ≠ 0 := fun hz => by
-    have := h.apply_eq_zero_symm hz
-    rw [hvu] at this
-    omega
-  have hadj : (diagramGraph A).Adj u v :=
-    h.diagramGraph_adj_iff.mpr ⟨hvu_ne.symm, hAuv⟩
-  -- The Cartan product of the double edge is `2`, so its other entry is `-1`.
-  have hAuv_eq : A u v = -1 := by
-    have hmem := h.apply_mul_apply_mem_of_ne hvu_ne.symm
-    rw [hvu] at hmem
-    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
-    rcases hmem with hc | hc | hc | hc <;> omega
-  have hprod : A u v * A v u = 2 := by rw [hAuv_eq, hvu]; norm_num
-  have hprod' : A v u * A u v = 2 := by rw [mul_comm]; exact hprod
-  obtain ⟨k⟩ := IsTree.nonempty_iso_pathGraph_of_degree_le_two
-    (h.isTree_diagramGraph hconn') hdeg
-  have hpath := (adj_iff_of_iso_pathGraph k u v).mp hadj
-  have hsingle : ∀ {i j : B}, (diagramGraph A).Adj i j →
-      ¬ ((i = u ∧ j = v) ∨ (i = v ∧ j = u)) → A i j * A j i = 1 := by
-    intro i j hij hne
-    rcases hpath with huv | huv
-    · exact apply_mul_apply_eq_one_of_isoPathGraph h k huv (by omega) hij hne
-    · exact apply_mul_apply_eq_one_of_isoPathGraph h k huv (by omega) hij (by tauto)
-  refine h.exists_equiv_forall_eq_doubleEdgeCartanMatrix hconn' hdeg hvu ?_
-  intro i j hij hAij
-  by_cases hforward : i = v ∧ j = u
-  · exact Or.inl hforward
-  right
-  by_cases hreverse : i = u ∧ j = v
-  · rcases hreverse with ⟨rfl, rfl⟩
-    exact hAuv_eq
-  have hadj' := h.diagramGraph_adj_iff.mpr ⟨hij, hAij⟩
-  have hone := hsingle hadj' (by tauto)
-  have hnonpos := h.apply_le_zero_of_ne hij
-  rcases Int.eq_one_or_neg_one_of_mul_eq_one' hone with hpos | hneg
-  · exact absurd hpos.1 (by omega)
-  · exact hneg.1
+variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
 
 /-- **The branchless double-edge case is a double-edge model of one of the admissible shapes.** A
-preconnected finite-type diagram of maximum degree two that contains the oriented double edge
-`A v u = -2` reindexes to two nonempty chains joined by that edge, and those chains have one of the
-three shapes in the Cartan--Killing list: the second is a singleton (type `C`), the first is a
-singleton (type `B`), or both have two vertices (type `F_4`).
+preconnected finite-type diagram of maximum degree two in which the edge `u -- v` is double
+reindexes to two nonempty chains joined by that edge, and those chains have one of the three shapes
+in the Cartan--Killing list: the second is a singleton (type `C`), the first is a singleton (type
+`B`), or both have two vertices (type `F_4`).
 
-Unlike `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix`, this does not assume
-that the chosen double edge is the only multiple edge; the path argument of this file proves it. -/
+The double edge is given by the orientation-free hypothesis `A u v * A v u = 2`; the two
+orientations of the edge give the two transposed models, both of which the disjunction covers. -/
 theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_eq_one_or_eq_one_or_eq_two_two
     [DecidableEq B] (h : IsFiniteType A) (hconn : (diagramGraph A).Preconnected)
     (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2)
-    {u v : B} (hvu : A v u = -2) :
+    {u v : B} (huv : A u v * A v u = 2) :
     ∃ p q : ℕ, 0 < p ∧ 0 < q ∧ (q = 1 ∨ p = 1 ∨ (p = 2 ∧ q = 2)) ∧
       ∃ e : B ≃ Fin p ⊕ Fin q,
         ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
-  obtain ⟨p, q, hp, hq, e, he⟩ :=
-    h.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two hconn hdeg hvu
-  have hmatrix : doubleEdgeCartanMatrix p q = A.submatrix e.symm e.symm := by
-    ext i j
-    simpa only [Matrix.submatrix_apply, e.apply_symm_apply] using (he (e.symm i) (e.symm j)).symm
-  have hmodel : IsFiniteType (doubleEdgeCartanMatrix p q) := by
-    rw [hmatrix]
-    exact h.submatrix e.symm.injective
-  exact ⟨p, q, hp, hq, eq_one_or_eq_one_or_eq_two_two_of_isFiniteType_doubleEdge hp hq hmodel,
-    e, he⟩
+  -- Either orientation of the double edge reindexes; the model classification then applies to the
+  -- resulting model, which finite type inherits as a principal submatrix.
+  have key : ∀ {x y : B}, A y x = -2 →
+      ∃ p q : ℕ, 0 < p ∧ 0 < q ∧ (q = 1 ∨ p = 1 ∨ (p = 2 ∧ q = 2)) ∧
+        ∃ e : B ≃ Fin p ⊕ Fin q,
+          ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
+    intro x y hyx
+    obtain ⟨p, q, hp, hq, e, he⟩ := h.exists_equiv_forall_eq_doubleEdgeCartanMatrix hconn hdeg hyx
+    have hmatrix : doubleEdgeCartanMatrix p q = A.submatrix e.symm e.symm := by
+      ext i j
+      simpa only [Matrix.submatrix_apply, e.apply_symm_apply] using (he (e.symm i) (e.symm j)).symm
+    have hmodel : IsFiniteType (doubleEdgeCartanMatrix p q) := by
+      rw [hmatrix]
+      exact h.submatrix e.symm.injective
+    exact ⟨p, q, hp, hq, eq_one_or_eq_one_or_eq_two_two_of_isFiniteType_doubleEdge hp hq hmodel,
+      e, he⟩
+  -- A double edge has entries `-1` and `-2`, in one order or the other.
+  have hne : u ≠ v := by
+    rintro rfl
+    rw [h.apply_self] at huv
+    norm_num at huv
+  rcases eq_neg_one_and_eq_neg_two_or_of_mul_eq_two (h.apply_le_zero_of_ne hne) huv with
+    ⟨-, hvu⟩ | ⟨huv', -⟩
+  · exact key hvu
+  · exact key huv'
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
@@ -72,7 +72,8 @@ private theorem apply_mul_apply_eq_one_of_isoPathGraph_of_lt (h : IsFiniteType A
       let v : ℕ → B := fun s =>
         if hs : a + s < n then k.symm ⟨a + s, hs⟩ else k.symm ⟨0, hn⟩
       have hv_apply {s : ℕ} (hs : s < m + 3) : k (v s) = ⟨a + s, by omega⟩ := by
-        simp [v, show a + s < n by omega]
+        have hs' : a + s < n := by omega
+        simp [v, hs']
       -- The same fact read backwards, naming the vertex of the interval at each position.
       have hv_eq {s : ℕ} (hs : s < m + 3) {t : ℕ} (ht : t < n) (hst : a + s = t) :
           v s = k.symm ⟨t, ht⟩ := by
@@ -152,18 +153,22 @@ private theorem apply_mul_apply_eq_one_of_isoPathGraph_of_lt_min (h : IsFiniteTy
   have hone := apply_mul_apply_eq_one_of_isoPathGraph_of_lt h k ha hbase hr har
   rcases hpath with hp | hp
   · have hi : k.symm ⟨r, by omega⟩ = i := by
-      rw [show (⟨r, by omega⟩ : Fin n) = k i from Fin.ext (by simp only [r]; omega),
-        k.symm_apply_apply]
+      apply k.injective
+      rw [k.apply_symm_apply]
+      exact Fin.ext (by simp only [r]; omega)
     have hj : k.symm ⟨r + 1, hr⟩ = j := by
-      rw [show (⟨r + 1, hr⟩ : Fin n) = k j from Fin.ext (by simp only [r]; omega),
-        k.symm_apply_apply]
+      apply k.injective
+      rw [k.apply_symm_apply]
+      exact Fin.ext (by simp only [r]; omega)
     simpa only [hi, hj] using hone
   · have hj : k.symm ⟨r, by omega⟩ = j := by
-      rw [show (⟨r, by omega⟩ : Fin n) = k j from Fin.ext (by simp only [r]; omega),
-        k.symm_apply_apply]
+      apply k.injective
+      rw [k.apply_symm_apply]
+      exact Fin.ext (by simp only [r]; omega)
     have hi : k.symm ⟨r + 1, hr⟩ = i := by
-      rw [show (⟨r + 1, hr⟩ : Fin n) = k i from Fin.ext (by simp only [r]; omega),
-        k.symm_apply_apply]
+      apply k.injective
+      rw [k.apply_symm_apply]
+      exact Fin.ext (by simp only [r]; omega)
     simpa only [hi, hj, mul_comm] using hone
 
 /-- In a path numbering, every edge other than a fixed multiple edge has Cartan product one. -/
@@ -236,6 +241,7 @@ private theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_de
     simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
     rcases hmem with hc | hc | hc | hc <;> omega
   have hprod : A u v * A v u = 2 := by rw [hAuv_eq, hvu]; norm_num
+  have hprod' : A v u * A u v = 2 := by rw [mul_comm]; exact hprod
   obtain ⟨k⟩ := IsTree.nonempty_iso_pathGraph_of_degree_le_two
     (h.isTree_diagramGraph hconn') hdeg
   have hpath := (adj_iff_of_iso_pathGraph k u v).mp hadj
@@ -244,8 +250,7 @@ private theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_de
     intro i j hij hne
     rcases hpath with huv | huv
     · exact apply_mul_apply_eq_one_of_isoPathGraph h k huv (by omega) hij hne
-    · exact apply_mul_apply_eq_one_of_isoPathGraph h k huv
-        (by simpa only [mul_comm] using (show 2 ≤ A u v * A v u by omega)) hij (by tauto)
+    · exact apply_mul_apply_eq_one_of_isoPathGraph h k huv (by omega) hij (by tauto)
   refine h.exists_equiv_forall_eq_doubleEdgeCartanMatrix hconn' hdeg hvu ?_
   intro i j hij hAij
   by_cases hforward : i = v ∧ j = u

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean
@@ -1,0 +1,319 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+import TauCeti.Combinatorics.SimpleGraph.PathGraph
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Diagram
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Classification
+import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Reindex
+import TauCeti.LinearAlgebra.RootSystem.FiniteType.TwoDoubleEdges
+
+public section
+
+/-!
+# The branchless double-edge case of the finite-type classification
+
+A connected finite-type Cartan diagram of maximum degree two is a path. If one edge of that path
+is double, the affine-diagram exclusion in
+`TauCeti.IsFiniteType.apply_mul_apply_le_one_of_chain_of_two_le` forces every other edge to be
+single. The path can therefore be reindexed onto `TauCeti.doubleEdgeCartanMatrix p q`, and the
+double-edge bound leaves precisely the families `B_n`, `C_n`, and the exceptional type `F_4`.
+
+This file discharges the uniqueness hypothesis of
+`TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix`: the caller need only exhibit
+one double edge. Excluding a branch vertex from a connected finite-type diagram containing a
+double edge remains the final extraction step before this result applies to the unrestricted
+double-edge branch.
+
+## Main results
+
+* `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two`: a
+  connected finite-type diagram of maximum degree two containing an oriented double edge is a
+  double-edge model with two nonempty arms.
+* `TauCeti.IsFiniteType.exists_doubleEdgeCartanMatrix_shape_of_degree_le_two`: the resulting arms
+  have exactly one of the `B`, `C`, and `F_4` shapes.
+
+## References
+
+This is the branchless double-edge case of the "classification of finite-type Cartan matrices" in
+Layer 5 of `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`. The exclusion of two
+multiple edges is the affine-diagram argument in N. Bourbaki, *Lie Groups and Lie Algebras,
+Chapters 4--6*, Chapter VI, section 4, and J. E. Humphreys, *Introduction to Lie Algebras and
+Representation Theory*, section 11.4.
+-/
+
+namespace TauCeti
+
+open SimpleGraph
+
+variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
+
+/-! ## A path has at most one multiple edge -/
+
+/-- Starting from a multiple edge at position `a` in a path numbering, every later edge is single.
+
+The proof is strong induction on the distance from `a`. For the edge at `r`, the intervening edges
+are single by induction, so `TauCeti.IsFiniteType.apply_mul_apply_le_one_of_chain_of_two_le`
+applies to the subpath from `a` through `r + 1`. -/
+private theorem apply_mul_apply_eq_one_of_pathEquiv_of_lt (h : IsFiniteType A)
+    (k : B ≃ Fin n)
+    (hk : ∀ i j, (diagramGraph A).Adj i j ↔
+      (k i : ℕ) + 1 = (k j : ℕ) ∨ (k j : ℕ) + 1 = (k i : ℕ))
+    {a : ℕ} (ha : a + 1 < n)
+    (hfirst : 2 ≤ A (k.symm ⟨a, by omega⟩) (k.symm ⟨a + 1, ha⟩) *
+      A (k.symm ⟨a + 1, ha⟩) (k.symm ⟨a, by omega⟩))
+    {r : ℕ} (hr : r + 1 < n) (har : a < r) :
+    A (k.symm ⟨r, by omega⟩) (k.symm ⟨r + 1, hr⟩) *
+      A (k.symm ⟨r + 1, hr⟩) (k.symm ⟨r, by omega⟩) = 1 := by
+  induction r using Nat.strong_induction_on with
+  | h r ih =>
+      let m := r - a - 1
+      have hn : 0 < n := by omega
+      -- Read the interval from vertex `a` through vertex `r + 1` as a chain of length `m + 3`.
+      let v : ℕ → B := fun s =>
+        if hs : a + s < n then k.symm ⟨a + s, hs⟩ else k.symm ⟨0, hn⟩
+      have hv_apply {s : ℕ} (hs : s < m + 3) : k (v s) = ⟨a + s, by omega⟩ := by
+        simp [v, show a + s < n by omega]
+      have hv : Set.InjOn v (Set.Iio (m + 3)) := by
+        intro s hs t ht hst
+        have hks : (k (v s) : ℕ) = a + s := by
+          simpa using congrArg Fin.val (hv_apply (Set.mem_Iio.mp hs))
+        have hkt : (k (v t) : ℕ) = a + t := by
+          simpa using congrArg Fin.val (hv_apply (Set.mem_Iio.mp ht))
+        have := congrArg (fun x : B => (k x : ℕ)) hst
+        rw [hks, hkt] at this
+        omega
+      -- Nonconsecutive vertices of the interval are not adjacent in the path.
+      have hzero : ∀ s t, s + 1 < t → t < m + 3 → A (v s) (v t) = 0 := by
+        intro s t hst ht
+        by_contra hne
+        have hvs : (k (v s) : ℕ) = a + s := by
+          simpa using congrArg Fin.val (hv_apply (s := s) (by omega))
+        have hvt : (k (v t) : ℕ) = a + t := by
+          simpa using congrArg Fin.val (hv_apply (s := t) ht)
+        have hvne : v s ≠ v t := fun heq => by
+          have := congrArg (fun x : B => (k x : ℕ)) heq
+          rw [hvs, hvt] at this
+          omega
+        have hadj := h.diagramGraph_adj_iff.mpr ⟨hvne, hne⟩
+        rw [hk, hvs, hvt] at hadj
+        omega
+      -- Every interior edge is closer to `a` than the target edge, hence single by induction.
+      have hsimple : ∀ s, 0 < s → s < m + 1 →
+          A (v s) (v (s + 1)) * A (v (s + 1)) (v s) = 1 := by
+        intro s hs hsm
+        have hvs : v s = k.symm ⟨a + s, by omega⟩ := by
+          apply k.injective
+          rw [hv_apply (by omega), k.apply_symm_apply]
+        have hvss : v (s + 1) = k.symm ⟨a + s + 1, by omega⟩ := by
+          apply k.injective
+          rw [hv_apply (by omega), k.apply_symm_apply]
+          rfl
+        rw [hvs, hvss]
+        exact ih (a + s) (by omega) (by omega) (by omega)
+      -- The two-multiple-edge exclusion applied to this interval makes its last edge single.
+      have hle := h.apply_mul_apply_le_one_of_chain_of_two_le hv hzero hsimple (m := m) (by
+        have hv0 : v 0 = k.symm ⟨a, by omega⟩ := by
+          apply k.injective
+          rw [hv_apply (by omega), k.apply_symm_apply]
+          rfl
+        have hv1 : v 1 = k.symm ⟨a + 1, ha⟩ := by
+          apply k.injective
+          rw [hv_apply (by omega), k.apply_symm_apply]
+        simpa [hv0, hv1] using hfirst)
+      have hvm1 : v (m + 1) = k.symm ⟨r, by omega⟩ := by
+        apply k.injective
+        rw [hv_apply (by omega), k.apply_symm_apply]
+        congr 1
+        omega
+      have hvm2 : v (m + 2) = k.symm ⟨r + 1, hr⟩ := by
+        apply k.injective
+        rw [hv_apply (by omega), k.apply_symm_apply]
+        congr 1
+        omega
+      rw [hvm1, hvm2] at hle
+      have hne : A (k.symm ⟨r, by omega⟩) (k.symm ⟨r + 1, hr⟩) ≠ 0 := by
+        apply (h.diagramGraph_adj_iff.mp ?_).2
+        rw [hk, k.apply_symm_apply, k.apply_symm_apply]
+        exact Or.inl rfl
+      have hone := h.one_le_apply_mul_apply hne
+      omega
+
+/-- In a path numbering, every edge other than a fixed multiple edge has Cartan product one. -/
+private theorem apply_mul_apply_eq_one_of_pathEquiv (h : IsFiniteType A) (k : B ≃ Fin n)
+    (hk : ∀ i j, (diagramGraph A).Adj i j ↔
+      (k i : ℕ) + 1 = (k j : ℕ) ∨ (k j : ℕ) + 1 = (k i : ℕ))
+    {u v : B} (huv : (k u : ℕ) + 1 = (k v : ℕ))
+    (hfirst : 2 ≤ A u v * A v u) {i j : B} (hij : (diagramGraph A).Adj i j)
+    (hne : ¬ ((i = u ∧ j = v) ∨ (i = v ∧ j = u))) : A i j * A j i = 1 := by
+  have hpath := (hk i j).mp hij
+  let a := (k u : ℕ)
+  let r := min (k i : ℕ) (k j : ℕ)
+  have ha : a + 1 < n := by rw [huv]; exact (k v).isLt
+  have hr : r + 1 < n := by
+    rcases hpath with hp | hp
+    · simp only [r]
+      omega
+    · simp only [r]
+      omega
+  have hbase : 2 ≤ A (k.symm ⟨a, by omega⟩) (k.symm ⟨a + 1, ha⟩) *
+      A (k.symm ⟨a + 1, ha⟩) (k.symm ⟨a, by omega⟩) := by
+    have hku : k.symm ⟨a, by omega⟩ = u := by
+      apply k.injective
+      rw [k.apply_symm_apply]
+    have hkv : k.symm ⟨a + 1, ha⟩ = v := by
+      apply k.injective
+      rw [k.apply_symm_apply]
+      apply Fin.ext
+      exact huv
+    simpa only [hku, hkv] using hfirst
+  rcases lt_trichotomy a r with har | har | har
+  · have hone := apply_mul_apply_eq_one_of_pathEquiv_of_lt h k hk ha hbase hr har
+    rcases hpath with hp | hp
+    · have hki : k i = ⟨r, by omega⟩ := by apply Fin.ext; simp only [r]; omega
+      have hkj : k j = ⟨r + 1, hr⟩ := by apply Fin.ext; simp only [r]; omega
+      have hi : k.symm ⟨r, by omega⟩ = i := by rw [← hki, k.symm_apply_apply]
+      have hj : k.symm ⟨r + 1, hr⟩ = j := by rw [← hkj, k.symm_apply_apply]
+      simpa only [hi, hj] using hone
+    · have hkj : k j = ⟨r, by omega⟩ := by apply Fin.ext; simp only [r]; omega
+      have hki : k i = ⟨r + 1, hr⟩ := by apply Fin.ext; simp only [r]; omega
+      have hj : k.symm ⟨r, by omega⟩ = j := by rw [← hkj, k.symm_apply_apply]
+      have hi : k.symm ⟨r + 1, hr⟩ = i := by rw [← hki, k.symm_apply_apply]
+      simpa only [hi, hj, mul_comm] using hone
+  · exfalso
+    rcases hpath with hp | hp
+    · have hiu : i = u := k.injective (Fin.ext (by simp only [a, r] at har; omega))
+      have hjv : j = v := k.injective (Fin.ext (by simp only [a, r] at har; omega))
+      exact hne (Or.inl ⟨hiu, hjv⟩)
+    · have hiv : i = v := k.injective (Fin.ext (by simp only [a, r] at har; omega))
+      have hju : j = u := k.injective (Fin.ext (by simp only [a, r] at har; omega))
+      exact hne (Or.inr ⟨hiv, hju⟩)
+  · let k' : B ≃ Fin n := k.trans Fin.revPerm
+    have hk' : ∀ x y, (diagramGraph A).Adj x y ↔
+        (k' x : ℕ) + 1 = (k' y : ℕ) ∨ (k' y : ℕ) + 1 = (k' x : ℕ) := by
+      intro x y
+      rw [hk]
+      simp only [k', Equiv.trans_apply, Fin.revPerm_apply, Fin.val_rev]
+      omega
+    have huv' : (k' v : ℕ) + 1 = (k' u : ℕ) := by
+      simp only [k', Equiv.trans_apply, Fin.revPerm_apply, Fin.val_rev]
+      omega
+    let a' := (k' v : ℕ)
+    let r' := min (k' i : ℕ) (k' j : ℕ)
+    have ha' : a' + 1 < n := by rw [huv']; exact (k' u).isLt
+    have hpath' := (hk' i j).mp hij
+    have hr' : r' + 1 < n := by
+      rcases hpath' with hp | hp <;> simp only [r'] <;> omega
+    have har' : a' < r' := by
+      rcases hpath with hp | hp <;>
+        simp only [a, r, a', r', k', Equiv.trans_apply, Fin.revPerm_apply, Fin.val_rev] at har ⊢ <;>
+        omega
+    have hbase' : 2 ≤ A (k'.symm ⟨a', by omega⟩) (k'.symm ⟨a' + 1, ha'⟩) *
+        A (k'.symm ⟨a' + 1, ha'⟩) (k'.symm ⟨a', by omega⟩) := by
+      have hkv : k'.symm ⟨a', by omega⟩ = v := by
+        apply k'.injective
+        rw [k'.apply_symm_apply]
+      have hku : k'.symm ⟨a' + 1, ha'⟩ = u := by
+        apply k'.injective
+        rw [k'.apply_symm_apply]
+        apply Fin.ext
+        exact huv'
+      simpa only [hkv, hku, mul_comm] using hfirst
+    have hone := apply_mul_apply_eq_one_of_pathEquiv_of_lt h k' hk' ha' hbase' hr' har'
+    rcases hpath' with hp | hp
+    · have hki : k' i = ⟨r', by omega⟩ := by apply Fin.ext; simp only [r']; omega
+      have hkj : k' j = ⟨r' + 1, hr'⟩ := by apply Fin.ext; simp only [r']; omega
+      have hi : k'.symm ⟨r', by omega⟩ = i := by rw [← hki, k'.symm_apply_apply]
+      have hj : k'.symm ⟨r' + 1, hr'⟩ = j := by rw [← hkj, k'.symm_apply_apply]
+      simpa only [hi, hj] using hone
+    · have hkj : k' j = ⟨r', by omega⟩ := by apply Fin.ext; simp only [r']; omega
+      have hki : k' i = ⟨r' + 1, hr'⟩ := by apply Fin.ext; simp only [r']; omega
+      have hj : k'.symm ⟨r', by omega⟩ = j := by rw [← hkj, k'.symm_apply_apply]
+      have hi : k'.symm ⟨r' + 1, hr'⟩ = i := by rw [← hki, k'.symm_apply_apply]
+      simpa only [hi, hj, mul_comm] using hone
+
+/-! ## Reindexing and classification -/
+
+/-- **The branchless double-edge case is a double-edge model.** A connected finite-type diagram
+of maximum degree two that contains the oriented double edge `A v u = -2` reindexes to two
+nonempty chains joined by that edge.
+
+Unlike `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix`, this theorem does not
+assume that every other off-diagonal entry is `-1`. The preceding path argument proves that the
+chosen edge is the only multiple edge, and the finite-type sign conditions then determine every
+remaining nonzero entry. -/
+theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two
+    [DecidableEq B] (h : IsFiniteType A) (hconn : (diagramGraph A).Connected)
+    (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2) {u v : B} (hvu : A v u = -2) :
+    ∃ p q : ℕ, 0 < p ∧ 0 < q ∧ ∃ e : B ≃ Fin p ⊕ Fin q,
+      ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
+  have hvu_ne : v ≠ u := by
+    rintro rfl
+    rw [h.apply_self] at hvu
+    omega
+  have hAuv : A u v ≠ 0 := fun hz => by
+    have := h.apply_eq_zero_symm hz
+    rw [hvu] at this
+    omega
+  have hadj : (diagramGraph A).Adj u v :=
+    h.diagramGraph_adj_iff.mpr ⟨hvu_ne.symm, hAuv⟩
+  have hAuv_eq : A u v = -1 := by
+    have hmem := h.apply_mul_apply_mem_of_ne hvu_ne.symm
+    have hnonpos := h.apply_le_zero_of_ne hvu_ne.symm
+    rw [hvu] at hmem
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
+    rcases hmem with hzero | hone | htwo | hthree <;> ring_nf at * <;> omega
+  have hprod : A u v * A v u = 2 := by rw [hAuv_eq, hvu]; norm_num
+  obtain ⟨k⟩ := IsTree.nonempty_iso_pathGraph_of_degree_le_two
+    (h.isTree_diagramGraph hconn) hdeg
+  have hk : ∀ i j, (diagramGraph A).Adj i j ↔
+      (k i : ℕ) + 1 = (k j : ℕ) ∨ (k j : ℕ) + 1 = (k i : ℕ) :=
+    fun i j => by simpa only [pathGraph_adj] using k.map_adj_iff.symm
+  have hpath := (hk u v).mp hadj
+  have hsingle : ∀ {i j : B}, (diagramGraph A).Adj i j →
+      ¬ ((i = u ∧ j = v) ∨ (i = v ∧ j = u)) → A i j * A j i = 1 := by
+    intro i j hij hne
+    rcases hpath with huv | huv
+    · exact apply_mul_apply_eq_one_of_pathEquiv h k.toEquiv hk huv (by omega) hij hne
+    · exact apply_mul_apply_eq_one_of_pathEquiv h k.toEquiv hk huv
+        (by simpa only [mul_comm] using (show 2 ≤ A u v * A v u by omega)) hij (by tauto)
+  refine h.exists_equiv_forall_eq_doubleEdgeCartanMatrix hconn hdeg hvu ?_
+  intro i j hij hAij
+  by_cases hforward : i = v ∧ j = u
+  · exact Or.inl hforward
+  right
+  by_cases hreverse : i = u ∧ j = v
+  · rcases hreverse with ⟨rfl, rfl⟩
+    exact hAuv_eq
+  have hadj' := h.diagramGraph_adj_iff.mpr ⟨hij, hAij⟩
+  have hone := hsingle hadj' (by tauto)
+  have hnonpos := h.apply_le_zero_of_ne hij
+  rcases Int.eq_one_or_neg_one_of_mul_eq_one' hone with hpos | hneg
+  · exact absurd hpos.1 (by omega)
+  · exact hneg.1
+
+/-- **The admissible shapes in the branchless double-edge case.** Under the same hypotheses as
+`TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two`, the two
+nonempty arms have one of the three shapes in the Cartan--Killing list: the second arm is a
+singleton (type `C`), the first arm is a singleton (type `B`), or both have two vertices (type
+`F_4`). -/
+theorem IsFiniteType.exists_doubleEdgeCartanMatrix_shape_of_degree_le_two [DecidableEq B]
+    (h : IsFiniteType A) (hconn : (diagramGraph A).Connected)
+    (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2) {u v : B} (hvu : A v u = -2) :
+    ∃ p q : ℕ, 0 < p ∧ 0 < q ∧ (q = 1 ∨ p = 1 ∨ (p = 2 ∧ q = 2)) ∧
+      ∃ e : B ≃ Fin p ⊕ Fin q,
+        ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
+  obtain ⟨p, q, hp, hq, e, he⟩ :=
+    h.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_degree_le_two hconn hdeg hvu
+  have hmatrix : doubleEdgeCartanMatrix p q = A.submatrix e.symm e.symm := by
+    ext i j
+    simpa only [Matrix.submatrix_apply, e.apply_symm_apply] using (he (e.symm i) (e.symm j)).symm
+  have hmodel : IsFiniteType (doubleEdgeCartanMatrix p q) := by
+    rw [hmatrix]
+    exact h.submatrix e.symm.injective
+  exact ⟨p, q, hp, hq, eq_one_or_eq_one_or_eq_two_two_of_isFiniteType_doubleEdge hp hq hmodel,
+    e, he⟩
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Reindex.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Reindex.lean
@@ -336,6 +336,8 @@ relabelling under which `A` is `TauCeti.doubleEdgeCartanMatrix p q`.
 Nothing is assumed about the other edges: the path argument above proves that the chosen edge is
 the only multiple edge, and the finite-type sign conditions then determine every remaining nonzero
 entry. -/
+-- `degree` needs finite neighbour sets while the theorem type is elaborated, so this decidability
+-- instance cannot be confined to the proof.
 theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix [DecidableEq B]
     (h : IsFiniteType A)
     (hconn : (diagramGraph A).Preconnected) (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2)

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Reindex.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Reindex.lean
@@ -61,17 +61,6 @@ private def doubleEdgePathEquiv (p q n : ℕ) (hpq : p + q = n) :
   simp [doubleEdgePathEquiv, Fin.rev]
   omega
 
-/-- Reversal is an automorphism of a finite path graph. -/
-private def pathGraphRevIso (n : ℕ) : pathGraph n ≃g pathGraph n where
-  toEquiv := Fin.revPerm
-  map_rel_iff' := by
-    intro i j
-    simp only [pathGraph_adj, Fin.revPerm_apply, Fin.rev]
-    omega
-
-@[simp] private lemma pathGraphRevIso_apply {n : ℕ} (i : Fin n) :
-    pathGraphRevIso n i = i.rev := rfl
-
 /-- The entries of a double-edge model, read along its underlying path. The only oriented
 exception to the value `-1` on adjacent vertices is the `-2` half of the double edge. -/
 private lemma doubleEdgeCartanMatrix_apply_eq_path (p q n : ℕ) (hp : 0 < p) (hq : 0 < q)
@@ -185,21 +174,15 @@ theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix [DecidableEq 
       ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
   obtain ⟨iso⟩ := IsTree.nonempty_iso_pathGraph_of_degree_le_two
     (h.isTree_diagramGraph hconn) hdeg
-  -- Adjacency read through any numbering of the diagram as a path.
-  have hnum : ∀ (m : ℕ) (f : diagramGraph A ≃g pathGraph m) (i j : B),
-      (diagramGraph A).Adj i j ↔ (f i : ℕ) + 1 = (f j : ℕ) ∨ (f j : ℕ) + 1 = (f i : ℕ) :=
-    fun _ f i j ↦ by simpa only [pathGraph_adj] using f.map_adj_iff.symm
   have hvu_ne : v ≠ u := by
     rintro rfl
     rw [h.apply_self] at hvu
     omega
   have hadj : (diagramGraph A).Adj u v :=
     (h.diagramGraph_adj_iff.mpr ⟨hvu_ne, by simp [hvu]⟩).symm
-  have hpath : (iso u : ℕ) + 1 = (iso v : ℕ) ∨ (iso v : ℕ) + 1 = (iso u : ℕ) := by
-    rwa [← iso.map_adj_iff, pathGraph_adj] at hadj
-  rcases hpath with horder | horder
+  rcases (adj_iff_of_iso_pathGraph iso u v).mp hadj with horder | horder
   · exact exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_pathEquiv h iso.toEquiv
-      (hnum _ iso) horder hvu hsimple
+      (adj_iff_of_iso_pathGraph iso) horder hvu hsimple
   · let iso' : diagramGraph A ≃g pathGraph (Fintype.card B) :=
       iso.trans (pathGraphRevIso (Fintype.card B))
     have horder' : (iso' u : ℕ) + 1 = (iso' v : ℕ) := by
@@ -208,6 +191,6 @@ theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix [DecidableEq 
       have hv := (iso v).isLt
       omega
     exact exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_pathEquiv h iso'.toEquiv
-      (hnum _ iso') horder' hvu hsimple
+      (adj_iff_of_iso_pathGraph iso') horder' hvu hsimple
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Reindex.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Reindex.lean
@@ -7,6 +7,7 @@ module
 import TauCeti.Combinatorics.SimpleGraph.PathGraph
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Diagram
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Basic
+import TauCeti.LinearAlgebra.RootSystem.FiniteType.TwoDoubleEdges
 
 public section
 
@@ -18,31 +19,34 @@ when both chains are nonempty, finite type leaves precisely the families `B_n`, 
 exceptional type `F_4`. To apply that result to an arbitrary Cartan matrix, its diagram must first
 be reindexed onto the model.
 
-This file performs that reindexing for the branchless case. A connected finite-type diagram in
+This file performs that reindexing for the branchless case. A preconnected finite-type diagram in
 which every vertex has degree at most two is a path. After orienting the path so that a chosen
-double edge points from `-1` to `-2`, cutting at that edge gives two nonempty chains. If this is the
-only double edge, every other edge is simple, so the matrix itself -- not merely its underlying
-graph -- is `TauCeti.doubleEdgeCartanMatrix p q` after one simultaneous relabelling.
+double edge points from `-1` to `-2`, cutting at that edge gives two nonempty chains. No other edge
+of the path is multiple: applying the affine-diagram exclusion
+`TauCeti.IsFiniteType.apply_mul_apply_le_one_of_chain_of_two_le` inductively along the path rules
+out a second one. Hence every other edge is simple, and the matrix itself -- not merely its
+underlying graph -- is `TauCeti.doubleEdgeCartanMatrix p q` after one simultaneous relabelling.
 
 ## Main result
 
-* `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix`: a connected finite-type
-  matrix of maximum degree two, with a unique chosen double edge, reindexes to a nonempty
+* `TauCeti.IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix`: a preconnected finite-type
+  matrix of maximum degree two containing one oriented double edge reindexes to a nonempty
   `TauCeti.doubleEdgeCartanMatrix p q`.
 
 This is the reindexing bridge in the double-edge branch of the classification of finite-type
 Cartan matrices, Layer 5 of `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`. The
 remaining global assembly must prove that a connected diagram containing a double edge has no
-branch vertex and has no second double edge. See J. E. Humphreys, *Introduction to Lie Algebras
-and Representation Theory*, section 11.4, and Bourbaki, *Lie Groups and Lie Algebras, Chapters
-4--6*, Chapter VI, section 4.
+branch vertex. See J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*,
+section 11.4, and Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Chapter VI, section 4.
 -/
 
 namespace TauCeti
 
 open SimpleGraph
 
-variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
+variable {B : Type*} [Fintype B] {A : Matrix B B ℤ} {n : ℕ}
+
+/-! ## The double-edge model read along its path -/
 
 /-- The path ordering of two chains joined at their last vertices. The first chain is read from
 its outside vertex toward the double edge, and the second from the double edge toward its outside
@@ -94,6 +98,8 @@ private lemma doubleEdgeCartanMatrix_apply_eq_path (p q n : ℕ) (hp : 0 < p) (h
     have hyle : (y : ℕ) ≤ q - 1 := by omega
     rw [chainEntry_def]
     split_ifs <;> omega
+
+/-! ## Reindexing a path-shaped diagram -/
 
 /-- The reindexing theorem with an already oriented path numbering. -/
 private theorem exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_pathEquiv
@@ -155,18 +161,12 @@ private theorem exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_pathEquiv
     by_contra hne
     exact ha (h.diagramGraph_adj_iff.mpr ⟨hij, hne⟩)
 
-/-- **A path-shaped finite-type matrix with one oriented double edge is a double-edge model.**
-Suppose the diagram is connected, every vertex has degree at most two, the edge `u -- v` carries
-`A v u = -2`, and that entry is the only nonzero off-diagonal entry that is not `-1`. Then there
-are nonempty chains of lengths `p` and `q` and a simultaneous relabelling under which `A` is
-`TauCeti.doubleEdgeCartanMatrix p q`.
-
-The hypothesis on off-diagonal entries is the matrix form of saying that the chosen edge is the
-only multiple edge; in particular it already forces the opposite entry `A u v` to be `-1`. The
-global classification supplies it by excluding two multiple edges along a chain; this theorem
-performs the subsequent reindexing. -/
-theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix [DecidableEq B]
-    (h : IsFiniteType A)
+/-- The reindexing theorem with the uniqueness of the multiple edge assumed. The hypothesis
+`hsimple` on off-diagonal entries is the matrix form of saying that the chosen edge is the only
+multiple edge; in particular it already forces the opposite entry `A u v` to be `-1`. The path
+argument below discharges it. -/
+private theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_simple
+    [DecidableEq B] (h : IsFiniteType A)
     (hconn : (diagramGraph A).Connected) (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2)
     {u v : B} (hvu : A v u = -2)
     (hsimple : ∀ {i j}, i ≠ j → A i j ≠ 0 → (i = v ∧ j = u) ∨ A i j = -1) :
@@ -192,5 +192,199 @@ theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix [DecidableEq 
       omega
     exact exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_pathEquiv h iso'.toEquiv
       (adj_iff_of_iso_pathGraph iso') horder' hvu hsimple
+
+/-! ## A path carries at most one multiple edge -/
+
+/-- Starting from a multiple edge at position `a` in a path numbering, every later edge is
+single. -/
+private theorem apply_mul_apply_eq_one_of_isoPathGraph_of_lt (h : IsFiniteType A)
+    (k : diagramGraph A ≃g pathGraph n)
+    {a : ℕ} (ha : a + 1 < n)
+    (hfirst : 2 ≤ A (k.symm ⟨a, by omega⟩) (k.symm ⟨a + 1, ha⟩) *
+      A (k.symm ⟨a + 1, ha⟩) (k.symm ⟨a, by omega⟩))
+    {r : ℕ} (hr : r + 1 < n) (har : a < r) :
+    A (k.symm ⟨r, by omega⟩) (k.symm ⟨r + 1, hr⟩) *
+      A (k.symm ⟨r + 1, hr⟩) (k.symm ⟨r, by omega⟩) = 1 := by
+  have hk := adj_iff_of_iso_pathGraph k
+  -- Strong induction on the distance from `a`: the intervening edges are single by induction.
+  -- Thus the two-multiple-edge exclusion applies to the subpath from `a` through `r + 1`.
+  induction r using Nat.strong_induction_on with
+  | h r ih =>
+      let m := r - a - 1
+      have hn : 0 < n := by omega
+      -- Read the interval from vertex `a` through vertex `r + 1` as a chain of length `m + 3`.
+      let v : ℕ → B := fun s =>
+        if hs : a + s < n then k.symm ⟨a + s, hs⟩ else k.symm ⟨0, hn⟩
+      have hv_apply {s : ℕ} (hs : s < m + 3) : k (v s) = ⟨a + s, by omega⟩ := by
+        have hs' : a + s < n := by omega
+        simp [v, hs']
+      have hv_val (s : ℕ) (hs : s < m + 3) : (k (v s) : ℕ) = a + s := by
+        simpa using congrArg Fin.val (hv_apply hs)
+      -- The same fact read backwards, naming the vertex of the interval at each position.
+      have hv_eq {s : ℕ} (hs : s < m + 3) {t : ℕ} (ht : t < n) (hst : a + s = t) :
+          v s = k.symm ⟨t, ht⟩ := by
+        apply k.injective
+        rw [hv_apply hs, k.apply_symm_apply]
+        exact Fin.ext hst
+      have hv : Set.InjOn v (Set.Iio (m + 3)) := by
+        intro s hs t ht hst
+        have := congrArg (fun x : B => (k x : ℕ)) hst
+        rw [hv_val s (Set.mem_Iio.mp hs), hv_val t (Set.mem_Iio.mp ht)] at this
+        omega
+      -- Nonconsecutive vertices of the interval are not adjacent in the path.
+      have hzero : ∀ s t, s + 1 < t → t < m + 3 → A (v s) (v t) = 0 := by
+        intro s t hst ht
+        by_contra hne
+        have hvne : v s ≠ v t := fun heq => by
+          have := congrArg (fun x : B => (k x : ℕ)) heq
+          rw [hv_val s (by omega), hv_val t ht] at this
+          omega
+        have hadj := h.diagramGraph_adj_iff.mpr ⟨hvne, hne⟩
+        rw [hk, hv_val s (by omega), hv_val t ht] at hadj
+        omega
+      -- Every interior edge is closer to `a` than the target edge, hence single by induction.
+      have hsimple : ∀ s, 0 < s → s < m + 1 →
+          A (v s) (v (s + 1)) * A (v (s + 1)) (v s) = 1 := by
+        intro s hs hsm
+        rw [hv_eq (t := a + s) (by omega) (by omega) rfl,
+          hv_eq (t := a + s + 1) (by omega) (by omega) (by omega)]
+        exact ih (a + s) (by omega) (by omega) (by omega)
+      -- The two-multiple-edge exclusion applied to this interval makes its last edge single.
+      have hle := h.apply_mul_apply_le_one_of_chain_of_two_le hv hzero hsimple (m := m) (by
+        rw [hv_eq (t := a) (by omega) (by omega) (by omega),
+          hv_eq (t := a + 1) (by omega) ha rfl]
+        exact hfirst)
+      rw [hv_eq (t := r) (by omega) (by omega) (by omega),
+        hv_eq (t := r + 1) (by omega) hr (by omega)] at hle
+      have hne : A (k.symm ⟨r, by omega⟩) (k.symm ⟨r + 1, hr⟩) ≠ 0 := by
+        apply (h.diagramGraph_adj_iff.mp ?_).2
+        rw [hk, k.apply_symm_apply, k.apply_symm_apply]
+        exact Or.inl rfl
+      have hone := h.one_le_apply_mul_apply hne
+      omega
+
+/-- In a path numbering, an edge lying strictly beyond a fixed multiple edge has Cartan product
+one. -/
+private theorem apply_mul_apply_eq_one_of_isoPathGraph_of_lt_min (h : IsFiniteType A)
+    (k : diagramGraph A ≃g pathGraph n) {u v : B} (huv : (k u : ℕ) + 1 = (k v : ℕ))
+    (hfirst : 2 ≤ A u v * A v u) {i j : B}
+    (hpath : (k i : ℕ) + 1 = (k j : ℕ) ∨ (k j : ℕ) + 1 = (k i : ℕ))
+    (hlt : (k u : ℕ) < min (k i : ℕ) (k j : ℕ)) : A i j * A j i = 1 := by
+  let a := (k u : ℕ)
+  let r := min (k i : ℕ) (k j : ℕ)
+  have har : a < r := hlt
+  have ha : a + 1 < n := by rw [huv]; exact (k v).isLt
+  have hr : r + 1 < n := by rcases hpath with hp | hp <;> simp only [r] <;> omega
+  -- The multiple edge is the edge from position `a` to position `a + 1`.
+  have hbase : 2 ≤ A (k.symm ⟨a, by omega⟩) (k.symm ⟨a + 1, ha⟩) *
+      A (k.symm ⟨a + 1, ha⟩) (k.symm ⟨a, by omega⟩) := by
+    have hku : k.symm ⟨a, by omega⟩ = u := k.symm_apply_eq.mpr (Fin.ext (by simp only [a]))
+    have hkv : k.symm ⟨a + 1, ha⟩ = v := k.symm_apply_eq.mpr (Fin.ext (by simp only [a]; omega))
+    simpa only [hku, hkv] using hfirst
+  -- The target edge is the edge from position `r` to position `r + 1`, in one of the two
+  -- orientations.
+  have hone := apply_mul_apply_eq_one_of_isoPathGraph_of_lt h k ha hbase hr har
+  rcases hpath with hp | hp
+  · have hi : k.symm ⟨r, by omega⟩ = i := k.symm_apply_eq.mpr (Fin.ext (by simp only [r]; omega))
+    have hj : k.symm ⟨r + 1, hr⟩ = j := k.symm_apply_eq.mpr (Fin.ext (by simp only [r]; omega))
+    simpa only [hi, hj] using hone
+  · have hj : k.symm ⟨r, by omega⟩ = j := k.symm_apply_eq.mpr (Fin.ext (by simp only [r]; omega))
+    have hi : k.symm ⟨r + 1, hr⟩ = i := k.symm_apply_eq.mpr (Fin.ext (by simp only [r]; omega))
+    simpa only [hi, hj, mul_comm] using hone
+
+/-- In a path numbering, every edge other than a fixed multiple edge has Cartan product one. -/
+private theorem apply_mul_apply_eq_one_of_isoPathGraph (h : IsFiniteType A)
+    (k : diagramGraph A ≃g pathGraph n) {u v : B} (huv : (k u : ℕ) + 1 = (k v : ℕ))
+    (hfirst : 2 ≤ A u v * A v u) {i j : B} (hij : (diagramGraph A).Adj i j)
+    (hne : ¬ ((i = u ∧ j = v) ∨ (i = v ∧ j = u))) : A i j * A j i = 1 := by
+  -- The multiple edge occupies the positions `k u` and `k u + 1`, and the edge `i -- j` the
+  -- positions `min (k i) (k j)` and `min (k i) (k j) + 1`. Trichotomy on the two positions: the
+  -- previous lemma settles the edges beyond the multiple edge, the reversed numbering turns the
+  -- edges before it into that case, and the remaining case is the excluded coincidence.
+  have hpath := (adj_iff_of_iso_pathGraph k i j).mp hij
+  rcases lt_trichotomy (k u : ℕ) (min (k i : ℕ) (k j : ℕ)) with hlt | heq | hgt
+  · exact apply_mul_apply_eq_one_of_isoPathGraph_of_lt_min h k huv hfirst hpath hlt
+  · exfalso
+    rcases hpath with hp | hp
+    · exact hne (Or.inl ⟨k.injective (Fin.ext (by omega)), k.injective (Fin.ext (by omega))⟩)
+    · exact hne (Or.inr ⟨k.injective (Fin.ext (by omega)), k.injective (Fin.ext (by omega))⟩)
+  · let k' : diagramGraph A ≃g pathGraph n := k.trans (pathGraphRevIso n)
+    have hk' : ∀ x : B, (k' x : ℕ) = n - 1 - (k x : ℕ) := fun x => by
+      simp only [k', RelIso.trans_apply, pathGraphRevIso_apply, Fin.val_rev]
+      omega
+    -- Reversing the numbering exchanges the two endpoints of the multiple edge and reverses the
+    -- order of the positions, so the edge `i -- j` now lies beyond it.
+    have huv' : (k' v : ℕ) + 1 = (k' u : ℕ) := by
+      simp only [hk']
+      have := (k v).isLt
+      omega
+    have hlt' : (k' v : ℕ) < min (k' i : ℕ) (k' j : ℕ) := by
+      simp only [hk']
+      have := (k i).isLt
+      have := (k j).isLt
+      omega
+    refine apply_mul_apply_eq_one_of_isoPathGraph_of_lt_min h k' huv' ?_
+      ((adj_iff_of_iso_pathGraph k' i j).mp hij) hlt'
+    rw [mul_comm]
+    exact hfirst
+
+/-- **A path-shaped finite-type matrix containing an oriented double edge is a double-edge model.**
+Suppose the diagram is preconnected, every vertex has degree at most two, and the edge `u -- v`
+carries `A v u = -2`. Then there are nonempty chains of lengths `p` and `q` and a simultaneous
+relabelling under which `A` is `TauCeti.doubleEdgeCartanMatrix p q`.
+
+Nothing is assumed about the other edges: the path argument above proves that the chosen edge is
+the only multiple edge, and the finite-type sign conditions then determine every remaining nonzero
+entry. -/
+theorem IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix [DecidableEq B]
+    (h : IsFiniteType A)
+    (hconn : (diagramGraph A).Preconnected) (hdeg : ∀ i, (diagramGraph A).degree i ≤ 2)
+    {u v : B} (hvu : A v u = -2) :
+    ∃ p q : ℕ, 0 < p ∧ 0 < q ∧ ∃ e : B ≃ Fin p ⊕ Fin q,
+      ∀ i j, A i j = doubleEdgeCartanMatrix p q (e i) (e j) := by
+  have : Nonempty B := ⟨u⟩
+  have hconn' : (diagramGraph A).Connected := ⟨hconn⟩
+  have hvu_ne : v ≠ u := by
+    rintro rfl
+    rw [h.apply_self] at hvu
+    omega
+  have hAuv : A u v ≠ 0 := fun hz => by
+    have := h.apply_eq_zero_symm hz
+    rw [hvu] at this
+    omega
+  have hadj : (diagramGraph A).Adj u v :=
+    h.diagramGraph_adj_iff.mpr ⟨hvu_ne.symm, hAuv⟩
+  -- The Cartan product of the double edge is `2`, so its other entry is `-1`.
+  have hAuv_eq : A u v = -1 := by
+    have hmem := h.apply_mul_apply_mem_of_ne hvu_ne.symm
+    rw [hvu] at hmem
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
+    rcases hmem with hc | hc | hc | hc <;> omega
+  have hprod : A u v * A v u = 2 := by rw [hAuv_eq, hvu]; norm_num
+  have hprod' : A v u * A u v = 2 := by rw [mul_comm]; exact hprod
+  obtain ⟨k⟩ := IsTree.nonempty_iso_pathGraph_of_degree_le_two
+    (h.isTree_diagramGraph hconn') hdeg
+  have hpath := (adj_iff_of_iso_pathGraph k u v).mp hadj
+  -- Every edge other than `u -- v` is single.
+  have hsingle : ∀ {i j : B}, (diagramGraph A).Adj i j →
+      ¬ ((i = u ∧ j = v) ∨ (i = v ∧ j = u)) → A i j * A j i = 1 := by
+    intro i j hij hne
+    rcases hpath with huv | huv
+    · exact apply_mul_apply_eq_one_of_isoPathGraph h k huv (by omega) hij hne
+    · exact apply_mul_apply_eq_one_of_isoPathGraph h k huv (by omega) hij (by tauto)
+  refine h.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_simple hconn' hdeg hvu ?_
+  intro i j hij hAij
+  by_cases hforward : i = v ∧ j = u
+  · exact Or.inl hforward
+  right
+  by_cases hreverse : i = u ∧ j = v
+  · rcases hreverse with ⟨rfl, rfl⟩
+    exact hAuv_eq
+  have hadj' := h.diagramGraph_adj_iff.mpr ⟨hij, hAij⟩
+  have hone := hsingle hadj' (by tauto)
+  have hnonpos := h.apply_le_zero_of_ne hij
+  rcases Int.eq_one_or_neg_one_of_mul_eq_one' hone with hpos | hneg
+  · exact absurd hpos.1 (by omega)
+  · exact hneg.1
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/TwoDoubleEdges.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/TwoDoubleEdges.lean
@@ -308,9 +308,9 @@ section Chain
 
 variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
 
-/-- Two nonpositive integers whose product is `2` are `-1` and `-2`, in one order or the other:
-the two entries of a double edge. -/
-private lemma eq_neg_one_and_eq_neg_two_or_of_mul_eq_two {x y : ℤ} (hx : x ≤ 0)
+/-- **Two nonpositive integers whose product is `2` are `-1` and `-2`**, in one order or the other:
+the two entries of a double edge, whose orientation this splits into its two cases. -/
+lemma eq_neg_one_and_eq_neg_two_or_of_mul_eq_two {x y : ℤ} (hx : x ≤ 0)
     (hxy : x * y = 2) : (x = -1 ∧ y = -2) ∨ (x = -2 ∧ y = -1) := by
   have hdvd : (-x) ∣ 2 := ⟨-y, by rw [neg_mul_neg, hxy]⟩
   have hle : -x ≤ 2 := Int.le_of_dvd (by norm_num) hdvd

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/TypeA.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/TypeA.lean
@@ -78,14 +78,14 @@ theorem exists_equiv_forall_eq_cartanMatrix_A_of_isTree_of_isSimplyLaced_of_degr
     by_cases hA : A i j = 0
     · -- Distinct nonadjacent indices: the entry vanishes and the vertices are not consecutive.
       have hnot : ¬ (diagramGraph A).Adj i j := fun hc ↦ (diagramGraph_adj.mp hc).2.1 hA
-      rw [← iso.map_adj_iff, pathGraph_adj] at hnot
+      rw [adj_iff_of_iso_pathGraph iso] at hnot
       push Not at hnot
       have hne : (iso i : ℕ) ≠ (iso j : ℕ) := fun hc ↦ hij (iso.toEquiv.injective (Fin.ext hc))
       rw [hA, chainEntry_eq_zero hne (fun hc ↦ hnot.2 hc.symm) fun hc ↦ hnot.1 hc.symm]
     · -- Adjacent indices: the entry is `-1` and the vertices are consecutive.
       have hadj : (diagramGraph A).Adj i j := diagramGraph_adj.mpr
         ⟨hij, hA, fun hji ↦ hA ((hzero i j).mpr hji)⟩
-      rw [← iso.map_adj_iff, pathGraph_adj] at hadj
+      rw [adj_iff_of_iso_pathGraph iso] at hadj
       rw [(hsl hij).resolve_left hA]
       rcases hadj with hc | hc
       · rw [← hc, chainEntry_succ_right]


### PR DESCRIPTION
This PR proves the branchless double-edge case of the finite-type Cartan classification. Given a connected finite-type diagram of maximum degree two and one oriented double edge, show that every other edge is single, reindex the matrix as `doubleEdgeCartanMatrix p q`, and derive the sharp alternatives `q = 1`, `p = 1`, or `p = q = 2`, corresponding to the `C`, `B`, and `F₄` shapes.

The exact roadmap target is `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, Layer 5 milestone “classification of finite-type Cartan matrices,” specifically the non-simply-laced double-edge branch needed for `existsUnique_dynkinType`. This is the next critical step after the merged path reindexing and double-edge model classification: it discharges the previously external uniqueness-of-the-multiple-edge hypothesis by applying the affine two-double-edge exclusion inductively along the path. After this PR, the milestone still needs the extraction proving that a connected finite-type diagram containing a double edge has no degree-three vertex, followed by the final global case split; the simply-laced branch extraction is in flight in #3224.

Add `TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Branchless.lean`. The proof reuses Mathlib's finite-tree/path graph isomorphism and `Fin.revPerm`, together with Tau Ceti's `IsFiniteType.apply_mul_apply_le_one_of_chain_of_two_le`, path reindexing theorem, and double-edge model bound; no Mathlib or external formalization is vendored. Review asked for the shared path-numbering plumbing to be factored rather than re-derived, so `TauCeti/Combinatorics/SimpleGraph/PathGraph.lean` gains `adj_iff_of_iso_pathGraph` and `pathGraphRevIso`, and `DoubleEdge/Reindex.lean` and `FiniteType/TypeA.lean` now use them in place of their private copies and inline rewrites. Review then asked for the reindexing API not to advertise hypotheses this PR proves redundant, so the path argument now lives in `DoubleEdge/Reindex.lean`: its public `IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix` no longer assumes that the chosen edge is the only multiple one and takes `Preconnected` rather than `Connected`, the hypothesis form remaining as its private engine. `Branchless.lean` accordingly exports one theorem, `IsFiniteType.exists_equiv_forall_eq_doubleEdgeCartanMatrix_eq_one_or_eq_one_or_eq_two_two`, stated with the orientation-free `A u v * A v u = 2` and splitting the two orientations with `eq_neg_one_and_eq_neg_two_or_of_mul_eq_two`, which `FiniteType/TwoDoubleEdges.lean` now exports instead of keeping private. The mathematical argument follows Bourbaki, *Lie Groups and Lie Algebras*, Chapter VI §4, and Humphreys, *Introduction to Lie Algebras and Representation Theory*, §11.4, both credited in the module documentation.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"double-edge-branch-classification"}-->

🤖 Prepared with Codex


