### PR TITLE
feat(EllipticCurve): right cancellation for isogeny composition

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
@@ -251,6 +251,18 @@ theorem comp_assoc {W₄ : WeierstrassCurve.Affine F} (χ : Isogeny W₃ W₄) (
     (φ : Isogeny W₁ W₂) : (χ.comp ψ).comp φ = χ.comp (ψ.comp φ) :=
   Isogeny.ext <| AlgHom.ext fun x ↦ by simp
 
+/-- **Right cancellation**: precomposition with a fixed isogeny is injective.
+
+An isogeny is determined by its coordinate pullback, and the composite's pullback is
+`φ.fieldPullback ∘ ψ.pullback`. Since `φ.fieldPullback` is a ring homomorphism out of a field it
+is injective, so the two pullbacks agree and the isogenies are equal. Silverman proves the
+corresponding statement by subtracting the two isogenies; at the pullback level no group
+structure on isogenies is needed. -/
+theorem comp_right_cancel {φ : Isogeny W₁ W₂} {ψ₁ ψ₂ : Isogeny W₂ W₃}
+    (h : ψ₁.comp φ = ψ₂.comp φ) : ψ₁ = ψ₂ :=
+  Isogeny.ext <| AlgHom.ext fun x ↦ φ.fieldPullback.toRingHom.injective <| by
+    simpa using congrArg (fun χ : Isogeny W₁ W₃ ↦ χ.pullback x) h
+
 end Isogeny
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
@@ -36,6 +36,17 @@ field. `TauCeti.Isogeny.comp` therefore lives here rather than beside `TauCeti.I
   its function-field law and `TauCeti.Isogeny.id_comp`, `TauCeti.Isogeny.comp_id`,
   `TauCeti.Isogeny.comp_assoc` the unit and associativity laws. The pointedness obligation is
   discharged privately when `comp` is defined.
+* `TauCeti.Isogeny.comp_right_injective` and `TauCeti.Isogeny.comp_right_cancel`: precomposition
+  by a fixed isogeny is injective. This is the uniqueness half of the dual isogeny
+  (Silverman III.6.2), reached without the group structure on `Hom` that Silverman's subtraction
+  argument uses.
+
+Adapted from the AINTLIB project (`github.com/CBirkbeck/AINTLIB`, at revision
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache 2.0 per the source file's header, by Chris
+Birkbeck): `projects/HasseWeil/HasseWeil/EC/IsogenyAG/CanonicalDual.lean`, declaration
+`Isogeny.compose_right_cancel`. The source states it for an isogeny structure that carries the
+point map as an independent field, so its proof passes through `ext_toCurveMap`; here an isogeny
+is determined by its pullback, so pullback extensionality suffices.
 
 The degree of an isogeny — the dimension of `W₁.FunctionField` over the image of `fieldPullback`
 — is `TauCeti.Isogeny.degree`, in `Isogeny/Degree.lean`; it is stated there rather than here
@@ -251,17 +262,18 @@ theorem comp_assoc {W₄ : WeierstrassCurve.Affine F} (χ : Isogeny W₃ W₄) (
     (φ : Isogeny W₁ W₂) : (χ.comp ψ).comp φ = χ.comp (ψ.comp φ) :=
   Isogeny.ext <| AlgHom.ext fun x ↦ by simp
 
-/-- **Right cancellation**: precomposition with a fixed isogeny is injective.
+/-- Precomposition by a fixed isogeny is injective. -/
+theorem comp_right_injective (φ : Isogeny W₁ W₂) :
+    Function.Injective fun ψ : Isogeny W₂ W₃ ↦ ψ.comp φ := fun _ _ h ↦
+  -- the composite's pullback is `φ.fieldPullback ∘ ψ.pullback`, and an embedding of function
+  -- fields cancels on the left
+  Isogeny.ext <| (AlgHom.cancel_left φ.fieldPullback.toRingHom.injective).mp <| by
+    simpa using congrArg Isogeny.pullback h
 
-An isogeny is determined by its coordinate pullback, and the composite's pullback is
-`φ.fieldPullback ∘ ψ.pullback`. Since `φ.fieldPullback` is a ring homomorphism out of a field it
-is injective, so the two pullbacks agree and the isogenies are equal. Silverman proves the
-corresponding statement by subtracting the two isogenies; at the pullback level no group
-structure on isogenies is needed. -/
-theorem comp_right_cancel {φ : Isogeny W₁ W₂} {ψ₁ ψ₂ : Isogeny W₂ W₃}
-    (h : ψ₁.comp φ = ψ₂.comp φ) : ψ₁ = ψ₂ :=
-  Isogeny.ext <| AlgHom.ext fun x ↦ φ.fieldPullback.toRingHom.injective <| by
-    simpa using congrArg (fun χ : Isogeny W₁ W₃ ↦ χ.pullback x) h
+/-- Two isogenies agree exactly when they agree after precomposition by a fixed isogeny. -/
+theorem comp_right_cancel {φ : Isogeny W₁ W₂} {ψ₁ ψ₂ : Isogeny W₂ W₃} :
+    ψ₁.comp φ = ψ₂.comp φ ↔ ψ₁ = ψ₂ :=
+  (comp_right_injective φ).eq_iff
 
 end Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
@@ -36,10 +36,10 @@ field. `TauCeti.Isogeny.comp` therefore lives here rather than beside `TauCeti.I
   its function-field law and `TauCeti.Isogeny.id_comp`, `TauCeti.Isogeny.comp_id`,
   `TauCeti.Isogeny.comp_assoc` the unit and associativity laws. The pointedness obligation is
   discharged privately when `comp` is defined.
-* `TauCeti.Isogeny.comp_right_injective` and `TauCeti.Isogeny.comp_right_cancel`: precomposition
-  by a fixed isogeny is injective. This is the uniqueness half of the dual isogeny
-  (Silverman III.6.2), reached without the group structure on `Hom` that Silverman's subtraction
-  argument uses.
+* `TauCeti.Isogeny.comp_right_injective` and `TauCeti.Isogeny.comp_right_inj`: precomposition
+  by a fixed isogeny is injective. Equivalently, a factorisation `ψ = λ.comp φ` through a fixed
+  `φ` determines its factor `λ` uniquely — the uniqueness half of factoring an isogeny, reached
+  without the group structure on `Hom` that Silverman's subtraction argument uses.
 
 Adapted from the AINTLIB project (`github.com/CBirkbeck/AINTLIB`, at revision
 `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache 2.0 per the source file's header, by Chris
@@ -270,9 +270,10 @@ theorem comp_right_injective (φ : Isogeny W₁ W₂) :
   Isogeny.ext <| (AlgHom.cancel_left φ.fieldPullback.toRingHom.injective).mp <| by
     simpa using congrArg Isogeny.pullback h
 
-/-- Two isogenies agree exactly when they agree after precomposition by a fixed isogeny. -/
+/-- Two isogenies agree exactly when they agree after precomposition by a fixed isogeny. So a
+factorisation through a fixed `φ` determines its factor uniquely. -/
 @[simp]
-theorem comp_right_cancel {φ : Isogeny W₁ W₂} {ψ₁ ψ₂ : Isogeny W₂ W₃} :
+theorem comp_right_inj {φ : Isogeny W₁ W₂} {ψ₁ ψ₂ : Isogeny W₂ W₃} :
     ψ₁.comp φ = ψ₂.comp φ ↔ ψ₁ = ψ₂ :=
   (comp_right_injective φ).eq_iff
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
@@ -271,6 +271,7 @@ theorem comp_right_injective (φ : Isogeny W₁ W₂) :
     simpa using congrArg Isogeny.pullback h
 
 /-- Two isogenies agree exactly when they agree after precomposition by a fixed isogeny. -/
+@[simp]
 theorem comp_right_cancel {φ : Isogeny W₁ W₂} {ψ₁ ψ₂ : Isogeny W₂ W₃} :
     ψ₁.comp φ = ψ₂.comp φ ↔ ψ₁ = ψ₂ :=
   (comp_right_injective φ).eq_iff


### PR DESCRIPTION
Precomposition by a fixed isogeny is injective. Two declarations, no new definitions and no new
imports.

```lean
theorem comp_right_injective (φ : Isogeny W₁ W₂) :
    Function.Injective fun ψ : Isogeny W₂ W₃ ↦ ψ.comp φ := fun _ _ h ↦
  Isogeny.ext <| (AlgHom.cancel_left φ.fieldPullback.toRingHom.injective).mp <| by
    simpa using congrArg Isogeny.pullback h

theorem comp_right_inj {φ : Isogeny W₁ W₂} {ψ₁ ψ₂ : Isogeny W₂ W₃} :
    ψ₁.comp φ = ψ₂.comp φ ↔ ψ₁ = ψ₂ :=
  (comp_right_injective φ).eq_iff
```

## Why it is worth its own PR

This is the **uniqueness half of the factorisation theorem**, which Layer 1 of
`TauCetiRoadmap/EllipticCurves/README.md` makes "a milestone in its own right, because it is what
the dual is built from and it is easy to state wrongly". That milestone reads: for isogenies
`φ : W₁ → W₂` and `ψ : W₁ → W₃`, `ψ` factors as `ψ = λ ∘ φ` for a **unique** isogeny `λ` iff
`ψ^*K(W₃) ⊆ φ^*K(W₂)`. Uniqueness of `λ` *is* right-cancellation, and unlike the existence half
it needs none of the subfield criterion — so it lands on its own, ahead of the milestone rather
than buried inside it.

The dual is a later stage that consumes this milestone, not this PR's justification: it is built
by factoring `[deg φ]` through `φ`, which additionally needs `[n]` and the Frobenius machinery.

It is also the cheap proof. Silverman gets uniqueness by *subtracting* the two isogenies, which
needs the group structure on `Hom(E₁, E₂)` — itself a substantial Layer-1 target
(`AddCommGroup` on `Hom`, "the layer's real content"). At the pullback level none of that is
required: the composite's pullback is `φ.fieldPullback ∘ ψᵢ.pullback`, and `φ.fieldPullback` is a
ring homomorphism out of a field, hence injective. So the two pullbacks agree, and an isogeny is
determined by its pullback.

## The adaptation is shorter than the source, for a structural reason

TauCeti's `Isogeny` is **pullback-only**: one data field (`pullback`) and one `Prop`
(`mapsInfinity`), with `@[ext]`. Equal pullbacks therefore *give* equal isogenies.

The source's `Isogeny` instead carries a point map alongside the pullback, so its proof has to go
through `Isogeny.ext_toCurveMap` and `CurveMap.ext`, and its dual development is forced into a
witness-parametric API because the two components cannot both be pinned by the defining
equations. TauCeti does not have that problem: `mapsInfinity` is the integrality condition, and
the point map is a *consequence* of it rather than independent data — as this file's own
`Isogeny` docstring says, "consequences of this condition rather than additional structure
fields".

So this is adaptation, not transcription, and the difference is load-bearing for what comes next.

## Scope

New mathematics, one theorem, justified as a Layer-1 prerequisite above. No new definitions, no
new imports, no existing statement changed. Placed in `Isogeny/FunctionField.lean` beside `comp`,
`comp_assoc` and `pullback_injective`, all of which it uses or sits with.

## Provenance

Adapted from `github.com/CBirkbeck/AINTLIB` @
`2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0 **per the source file's header**
(the repository has no top-level `LICENSE` file; the header reads
`Copyright (c) 2026 Chris Birkbeck … Released under Apache 2.0 license … Authors: Chris Birkbeck`).
File `projects/HasseWeil/HasseWeil/EC/IsogenyAG/CanonicalDual.lean`, declaration
`Isogeny.compose_right_cancel`.

Two provenance details checked rather than assumed, because both were easy to get wrong:

* A second checkout of the same material exists at `CBirkbeck/Hasse-Weil` @ `94f6d72eeea3`, and
  its copy of `CanonicalDual.lean` **differs** from AINTLIB's. The lemma above was read from
  AINTLIB, so AINTLIB is what is cited.
* `compose_right_cancel` is present in the file at the cited revision (last touched by
  `8dc9fa14`), so this is committed source, not a working-tree edit.

## Review

Three private rounds and one posted round; every finding taken, none contested.

Posted round 1 (this commit's parent):

* **naming** — `comp_right_cancel` is a bidirectional injectivity lemma, so Mathlib's structural
  convention prescribes the `_inj` suffix. Renamed to `comp_right_inj`.
* **scope** — the justification targeted the dual-isogeny stage, whose prerequisites are absent,
  when the result's direct consumer is the earlier factorisation milestone. Restated above, and
  the module docstring's bullet with it.

Private rounds, four findings, all four taken:

* **generality** — only the forward implication was exported. `comp_right_injective` is now the
  primary statement, with the `↔` derived from it, which is the shape the factorisation's
  uniqueness will consume and the Mathlib-idiomatic one.
* **reuse** — the proof hand-rolled left-cancellation of an algebra-hom composite pointwise.
  Mathlib has `AlgHom.cancel_left` with exactly that signature; the proof calls it.
* **attribution** — the source was named in this description but not in the code. TauCeti's
  convention is that ported material records its provenance in the module docstring, so repo,
  revision, licence, author, file and declaration now live in the file itself.
* **documentation** — the docstrings narrated the proof and compared with Silverman. They state
  the results; the comparison moved to the module doc.

## Gates

`lake build` whole project clean; `scripts/lint-env.sh` **PASS**, no new violations; `lake exe
axioms` all within `[propext, Classical.choice, Quot.sound]`; `lake exe module-system` all modules
opt in. No line exceeds 100 codepoints.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"isogeny-comp-right-cancel"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
