### PR TITLE
feat: add divided-power lattice bases

### DIFF
--- a/TauCeti/RingTheory/DividedPowers/Basis.lean
+++ b/TauCeti/RingTheory/DividedPowers/Basis.lean
@@ -24,7 +24,8 @@ polynomials `(X choose n)`.
 
 ## Main declarations
 
-* `TauCeti.Associative.span_dividedPower_eq_span_pow`: divided and ordinary powers have the same
+* `TauCeti.Associative.dividedPowerSpan`: the rational submodule spanned by divided powers.
+* `TauCeti.Associative.dividedPowerSpan_eq_span_pow`: divided and ordinary powers have the same
   rational span.
 * `TauCeti.Associative.linearIndependent_dividedPower_iff`: divided powers are rationally
   independent exactly when ordinary powers are.
@@ -33,6 +34,8 @@ polynomials `(X choose n)`.
 * `TauCeti.Associative.dividedPowerLatticeBasis`: its canonical `ℤ`-basis.
 * `TauCeti.Associative.mem_dividedPowerLattice_iff`: membership as a finite integral linear
   combination.
+* `TauCeti.Associative.mem_dividedPowerLattice_iff_existsUnique_sum_dividedPower_eq`: unique finite
+  expansion in divided powers for elements of the integral lattice.
 
 ## References
 
@@ -52,28 +55,48 @@ section Semiring
 
 variable {A : Type u} [Semiring A] [Algebra ℚ A]
 
+/-- The rational submodule spanned by the divided powers of `x`. -/
+noncomputable def dividedPowerSpan (x : A) : Submodule ℚ A :=
+  span ℚ (range fun n : ℕ => dividedPower n x)
+
+/-- The defining equation of `dividedPowerSpan`. -/
+theorem dividedPowerSpan_def (x : A) :
+    dividedPowerSpan x = span ℚ (range fun n : ℕ => dividedPower n x) := by
+  unfold dividedPowerSpan
+  rfl
+
+/-- Every divided power of `x` belongs to `dividedPowerSpan x`. -/
+@[simp]
+theorem dividedPower_mem_dividedPowerSpan (x : A) (n : ℕ) :
+    dividedPower n x ∈ dividedPowerSpan x :=
+  subset_span (mem_range_self n)
+
+/-- Containment characterization for `dividedPowerSpan x`. -/
+@[simp]
+theorem dividedPowerSpan_le_iff {x : A} {p : Submodule ℚ A} :
+    dividedPowerSpan x ≤ p ↔ ∀ n : ℕ, dividedPower n x ∈ p := by
+  rw [dividedPowerSpan_def, span_le, Set.range_subset_iff]
+  rfl
+
 /-- The divided powers of an element and its ordinary powers span the same rational submodule. -/
-theorem span_dividedPower_eq_span_pow (x : A) :
-    span ℚ (range fun n : ℕ => dividedPower n x) = span ℚ (range fun n : ℕ => x ^ n) := by
+theorem dividedPowerSpan_eq_span_pow (x : A) :
+    dividedPowerSpan x = span ℚ (range fun n : ℕ => x ^ n) := by
   apply le_antisymm
-  · rw [span_le]
-    rintro _ ⟨n, rfl⟩
-    change dividedPower n x ∈ span ℚ (range fun n : ℕ => x ^ n)
+  · rw [dividedPowerSpan_le_iff]
+    intro n
     rw [dividedPower_def]
     exact smul_mem _ _ (subset_span (mem_range_self n))
-  · rw [span_le]
-    rintro _ ⟨n, rfl⟩
-    change x ^ n ∈ span ℚ (range fun n : ℕ => dividedPower n x)
+  · rw [span_le, range_subset_iff]
+    intro n
     rw [← factorial_smul_dividedPower_eq_pow]
-    exact smul_mem _ _ (subset_span (mem_range_self n))
+    exact smul_mem _ _ (dividedPower_mem_dividedPowerSpan x n)
 
 private noncomputable def invFactorialUnit (n : ℕ) : ℚˣ :=
   Units.mk0 (n.factorial : ℚ)⁻¹ <| inv_ne_zero <| by exact_mod_cast n.factorial_ne_zero
 
 private theorem invFactorialUnit_smul_pow (x : A) (n : ℕ) :
     invFactorialUnit n • x ^ n = dividedPower n x := by
-  change (n.factorial : ℚ)⁻¹ • x ^ n = dividedPower n x
-  exact (dividedPower_def n x).symm
+  rw [Units.smul_def, invFactorialUnit, Units.val_mk0, dividedPower_def]
 
 /-- Divided powers are linearly independent over `ℚ` exactly when the ordinary powers are. -/
 theorem linearIndependent_dividedPower_iff (x : A) :
@@ -88,10 +111,6 @@ theorem linearIndependent_dividedPower {x : A}
     (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
     LinearIndependent ℚ (fun n : ℕ => dividedPower n x) :=
   (linearIndependent_dividedPower_iff x).2 h
-
-/-- The rational submodule spanned by the divided powers of `x`. -/
-noncomputable def dividedPowerSpan (x : A) : Submodule ℚ A :=
-  span ℚ (range fun n : ℕ => dividedPower n x)
 
 /-- When the powers of `x` are linearly independent, the divided powers form a basis of their
 rational span. -/
@@ -116,6 +135,25 @@ variable {A : Type u} [Ring A] [Algebra ℚ A]
 /-- The integral lattice spanned by the divided powers of `x`. -/
 noncomputable def dividedPowerLattice (x : A) : Submodule ℤ A :=
   span ℤ (range fun n : ℕ => dividedPower n x)
+
+/-- The defining equation of `dividedPowerLattice`. -/
+theorem dividedPowerLattice_def (x : A) :
+    dividedPowerLattice x = span ℤ (range fun n : ℕ => dividedPower n x) := by
+  unfold dividedPowerLattice
+  rfl
+
+/-- Every divided power of `x` belongs to `dividedPowerLattice x`. -/
+@[simp]
+theorem dividedPower_mem_dividedPowerLattice (x : A) (n : ℕ) :
+    dividedPower n x ∈ dividedPowerLattice x :=
+  subset_span (mem_range_self n)
+
+/-- Containment characterization for `dividedPowerLattice x`. -/
+@[simp]
+theorem dividedPowerLattice_le_iff {x : A} {p : Submodule ℤ A} :
+    dividedPowerLattice x ≤ p ↔ ∀ n : ℕ, dividedPower n x ∈ p := by
+  rw [dividedPowerLattice_def, span_le, Set.range_subset_iff]
+  rfl
 
 /-- Membership in the divided-power lattice means being a finite integral linear combination of
 divided powers. -/
@@ -147,7 +185,7 @@ theorem coe_dividedPowerLatticeBasis_apply (x : A)
 
 /-- Under rational independence of the powers, every element of the divided-power lattice has a
 unique finite expansion in divided powers. -/
-theorem existsUnique_sum_dividedPower_eq {x y : A}
+theorem mem_dividedPowerLattice_iff_existsUnique_sum_dividedPower_eq {x y : A}
     (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
     y ∈ dividedPowerLattice x ↔
       ∃! c : ℕ →₀ ℤ, c.sum (fun n a => a • dividedPower n x) = y := by

--- a/TauCeti/RingTheory/DividedPowers/Basis.lean
+++ b/TauCeti/RingTheory/DividedPowers/Basis.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.RingTheory.DividedPowers.Associative
+public import Mathlib.LinearAlgebra.Basis.Submodule
+
+/-!
+# Bases of divided powers
+
+In an associative rational algebra, the divided powers of an element differ from its ordinary
+powers by the nonzero scalars `1 / n!`. Consequently the two families span the same rational
+submodule and one is linearly independent exactly when the other is. When they are independent,
+the divided powers also give a canonical integral basis of their `ℤ`-span.
+
+This isolates the root-vector factor in the integral PBW argument for the Kostant form. For a
+Chevalley root vector, rational PBW supplies independence of the ordinary powers; the results here
+then turn its divided powers into the integral basis used in the Chevalley--Demazure construction
+of Layer 9 of the ReductiveGroups roadmap. The Cartan factor is instead built from the binomial
+polynomials `(X choose n)`.
+
+## Main declarations
+
+* `TauCeti.Associative.span_dividedPower_eq_span_pow`: divided and ordinary powers have the same
+  rational span.
+* `TauCeti.Associative.linearIndependent_dividedPower_iff`: divided powers are rationally
+  independent exactly when ordinary powers are.
+* `TauCeti.Associative.dividedPowerSpanBasis`: the resulting basis of the rational span.
+* `TauCeti.Associative.dividedPowerLattice`: the integral span of the divided powers.
+* `TauCeti.Associative.dividedPowerLatticeBasis`: its canonical `ℤ`-basis.
+* `TauCeti.Associative.mem_dividedPowerLattice_iff`: membership as a finite integral linear
+  combination.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, Section 26.
+* J. C. Jantzen, *Representations of Algebraic Groups*, 2nd ed., II.1.
+-/
+
+public section
+
+namespace TauCeti.Associative
+
+open Set Submodule
+
+universe u
+
+section Semiring
+
+variable {A : Type u} [Semiring A] [Algebra ℚ A]
+
+/-- The divided powers of an element and its ordinary powers span the same rational submodule. -/
+theorem span_dividedPower_eq_span_pow (x : A) :
+    span ℚ (range fun n : ℕ => dividedPower n x) = span ℚ (range fun n : ℕ => x ^ n) := by
+  apply le_antisymm
+  · rw [span_le]
+    rintro _ ⟨n, rfl⟩
+    change dividedPower n x ∈ span ℚ (range fun n : ℕ => x ^ n)
+    rw [dividedPower_def]
+    exact smul_mem _ _ (subset_span (mem_range_self n))
+  · rw [span_le]
+    rintro _ ⟨n, rfl⟩
+    change x ^ n ∈ span ℚ (range fun n : ℕ => dividedPower n x)
+    rw [← factorial_smul_dividedPower_eq_pow]
+    exact smul_mem _ _ (subset_span (mem_range_self n))
+
+private noncomputable def invFactorialUnit (n : ℕ) : ℚˣ :=
+  Units.mk0 (n.factorial : ℚ)⁻¹ <| inv_ne_zero <| by exact_mod_cast n.factorial_ne_zero
+
+private theorem invFactorialUnit_smul_pow (x : A) (n : ℕ) :
+    invFactorialUnit n • x ^ n = dividedPower n x := by
+  change (n.factorial : ℚ)⁻¹ • x ^ n = dividedPower n x
+  exact (dividedPower_def n x).symm
+
+/-- Divided powers are linearly independent over `ℚ` exactly when the ordinary powers are. -/
+theorem linearIndependent_dividedPower_iff (x : A) :
+    LinearIndependent ℚ (fun n : ℕ => dividedPower n x) ↔
+      LinearIndependent ℚ (fun n : ℕ => x ^ n) := by
+  rw [← LinearIndependent.units_smul_iff (fun n : ℕ => x ^ n) invFactorialUnit]
+  convert Iff.rfl using 2
+  exact funext (invFactorialUnit_smul_pow x)
+
+/-- Divided powers are linearly independent whenever the ordinary powers are. -/
+theorem linearIndependent_dividedPower {x : A}
+    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
+    LinearIndependent ℚ (fun n : ℕ => dividedPower n x) :=
+  (linearIndependent_dividedPower_iff x).2 h
+
+/-- The rational submodule spanned by the divided powers of `x`. -/
+noncomputable def dividedPowerSpan (x : A) : Submodule ℚ A :=
+  span ℚ (range fun n : ℕ => dividedPower n x)
+
+/-- When the powers of `x` are linearly independent, the divided powers form a basis of their
+rational span. -/
+noncomputable def dividedPowerSpanBasis (x : A)
+    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
+    Module.Basis ℕ ℚ (dividedPowerSpan x) :=
+  Module.Basis.span (linearIndependent_dividedPower h)
+
+/-- The rational-span basis evaluates to the corresponding divided power in the ambient algebra. -/
+@[simp]
+theorem coe_dividedPowerSpanBasis_apply (x : A)
+    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) (n : ℕ) :
+    (dividedPowerSpanBasis x h n : A) = dividedPower n x := by
+  exact Module.Basis.coe_span_apply (linearIndependent_dividedPower h) n
+
+end Semiring
+
+section Ring
+
+variable {A : Type u} [Ring A] [Algebra ℚ A]
+
+/-- The integral lattice spanned by the divided powers of `x`. -/
+noncomputable def dividedPowerLattice (x : A) : Submodule ℤ A :=
+  span ℤ (range fun n : ℕ => dividedPower n x)
+
+/-- Membership in the divided-power lattice means being a finite integral linear combination of
+divided powers. -/
+theorem mem_dividedPowerLattice_iff {x y : A} :
+    y ∈ dividedPowerLattice x ↔
+      ∃ c : ℕ →₀ ℤ, c.sum (fun n a => a • dividedPower n x) = y := by
+  exact Finsupp.mem_span_range_iff_exists_finsupp
+
+/-- Rational independence of the ordinary powers makes the divided powers integrally independent. -/
+theorem linearIndependent_dividedPower_int {x : A}
+    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
+    LinearIndependent ℤ (fun n : ℕ => dividedPower n x) :=
+  (linearIndependent_dividedPower h).restrict_scalars (smul_left_injective ℤ one_ne_zero)
+
+/-- When the powers of `x` are rationally independent, the divided powers form a `ℤ`-basis of
+their integral lattice. -/
+noncomputable def dividedPowerLatticeBasis (x : A)
+    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
+    Module.Basis ℕ ℤ (dividedPowerLattice x) :=
+  Module.Basis.span (linearIndependent_dividedPower_int h)
+
+/-- The integral-lattice basis evaluates to the corresponding divided power in the ambient
+algebra. -/
+@[simp]
+theorem coe_dividedPowerLatticeBasis_apply (x : A)
+    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) (n : ℕ) :
+    (dividedPowerLatticeBasis x h n : A) = dividedPower n x := by
+  exact Module.Basis.coe_span_apply (linearIndependent_dividedPower_int h) n
+
+/-- Under rational independence of the powers, every element of the divided-power lattice has a
+unique finite expansion in divided powers. -/
+theorem existsUnique_sum_dividedPower_eq {x y : A}
+    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
+    y ∈ dividedPowerLattice x ↔
+      ∃! c : ℕ →₀ ℤ, c.sum (fun n a => a • dividedPower n x) = y := by
+  rw [mem_dividedPowerLattice_iff]
+  constructor
+  · rintro ⟨c, hc⟩
+    refine ⟨c, hc, fun d hd => ?_⟩
+    apply linearIndependent_dividedPower_int h
+    simpa only [Finsupp.linearCombination_apply] using hd.trans hc.symm
+  · exact ExistsUnique.exists
+
+end Ring
+
+end TauCeti.Associative

--- a/TauCeti/RingTheory/DividedPowers/Basis.lean
+++ b/TauCeti/RingTheory/DividedPowers/Basis.lean
@@ -168,34 +168,50 @@ theorem linearIndependent_dividedPower_int {x : A}
     LinearIndependent ℤ (fun n : ℕ => dividedPower n x) :=
   (linearIndependent_dividedPower h).restrict_scalars (smul_left_injective ℤ one_ne_zero)
 
-/-- When the powers of `x` are rationally independent, the divided powers form a `ℤ`-basis of
-their integral lattice. -/
+/-- When the divided powers of `x` are integrally independent, they form a `ℤ`-basis of their
+integral lattice. -/
 noncomputable def dividedPowerLatticeBasis (x : A)
-    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
+    (h : LinearIndependent ℤ (fun n : ℕ => dividedPower n x)) :
     Module.Basis ℕ ℤ (dividedPowerLattice x) :=
-  Module.Basis.span (linearIndependent_dividedPower_int h)
+  Module.Basis.span h
 
 /-- The integral-lattice basis evaluates to the corresponding divided power in the ambient
 algebra. -/
 @[simp]
 theorem coe_dividedPowerLatticeBasis_apply (x : A)
-    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) (n : ℕ) :
+    (h : LinearIndependent ℤ (fun n : ℕ => dividedPower n x)) (n : ℕ) :
     (dividedPowerLatticeBasis x h n : A) = dividedPower n x := by
-  exact Module.Basis.coe_span_apply (linearIndependent_dividedPower_int h) n
+  exact Module.Basis.coe_span_apply h n
 
-/-- Under rational independence of the powers, every element of the divided-power lattice has a
-unique finite expansion in divided powers. -/
+/-- Under integral independence of the divided powers, every element of the divided-power lattice
+has a unique finite expansion in divided powers. -/
 theorem mem_dividedPowerLattice_iff_existsUnique_sum_dividedPower_eq {x y : A}
-    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
+    (h : LinearIndependent ℤ (fun n : ℕ => dividedPower n x)) :
     y ∈ dividedPowerLattice x ↔
       ∃! c : ℕ →₀ ℤ, c.sum (fun n a => a • dividedPower n x) = y := by
   rw [mem_dividedPowerLattice_iff]
   constructor
   · rintro ⟨c, hc⟩
     refine ⟨c, hc, fun d hd => ?_⟩
-    apply linearIndependent_dividedPower_int h
+    apply h
     simpa only [Finsupp.linearCombination_apply] using hd.trans hc.symm
   · exact ExistsUnique.exists
+
+/-- Rational independence of the powers gives the canonical `ℤ`-basis of the integral
+divided-power lattice. -/
+noncomputable def dividedPowerLatticeBasisOfPow (x : A)
+    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
+    Module.Basis ℕ ℤ (dividedPowerLattice x) :=
+  dividedPowerLatticeBasis x (linearIndependent_dividedPower_int h)
+
+/-- Under rational independence of the powers, every element of the divided-power lattice has a
+unique finite expansion in divided powers. -/
+theorem mem_dividedPowerLattice_iff_existsUnique_sum_dividedPower_eq_of_pow {x y : A}
+    (h : LinearIndependent ℚ (fun n : ℕ => x ^ n)) :
+    y ∈ dividedPowerLattice x ↔
+      ∃! c : ℕ →₀ ℤ, c.sum (fun n a => a • dividedPower n x) = y :=
+  mem_dividedPowerLattice_iff_existsUnique_sum_dividedPower_eq
+    (linearIndependent_dividedPower_int h)
 
 end Ring
 


### PR DESCRIPTION
This PR adds the root-vector divided-power basis needed by the integral PBW input to the Chevalley--Demazure construction. It proves that the divided powers `xⁿ / n!` and ordinary powers of an element in a rational associative algebra have the same rational span and are linearly independent simultaneously, then packages the divided powers as canonical bases of their rational span and integral `ℤ`-lattice, with an exact unique-coordinate characterization.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, “The Chevalley–Demazure construction,” which constructs each explicit pinned split reductive group scheme over `ℤ` via a Chevalley basis and the Kostant `ℤ`-form of its enveloping algebra. The milestone served is the integral PBW basis of that Kostant form: this PR closes the root-vector factor by converting rational independence of ordinary PBW powers into integral independence and unique finite coordinates for their divided powers.

The preferred `CFSGStatement` roadmap has no viable unclaimed direct step on current `main`: I0, the numbered conventions, the fixed-point/central-quotient infrastructure, and the complete sporadic lane are merged; `classificationStatement_of_zero` is in flight in #3058; and L0–L3 explicitly wait on RootSystems Layer 6 and ReductiveGroups Layer 9. The root-data dispatcher is blocked by the in-flight E7 datum in #2809, while the Layer 9 Cartan-binomial, Chevalley-system, integral-lattice, and associated-graded rungs are already in flight. This independent root-vector basis factor is therefore the next coherent unclaimed prerequisite.

Consumer roadmap: CFSGStatement

The dependency edge is `CFSGStatement` milestone L0, “pinned ambient groups,” → ReductiveGroups Layer 9, “pinned Chevalley--Demazure group schemes over ℤ”: `ValidLieTypeIndex.AmbientGroup` consumes algebraic-closure-valued points of the explicit group scheme, whose construction consumes the Kostant integral PBW basis; the basis in turn uses this PR for each root-vector divided-power factor.

After this PR, the milestone still needs rational PBW independence of ordered ordinary monomials, assembly of the root-vector factors with the Cartan-binomial factor into the full integral Kostant basis, and then the explicit group scheme, pinning, base change, root subgroups, pinned isomorphism theorem, and special isogenies.

Add `TauCeti/RingTheory/DividedPowers/Basis.lean` (164 lines). The implementation reuses Mathlib’s `LinearIndependent.units_smul_iff`, scalar restriction of linear independence, `Module.Basis.span`, and `Finsupp.mem_span_range_iff_exists_finsupp`; no Mathlib infrastructure is vendored. The mathematical construction follows Humphreys, *Introduction to Lie Algebras and Representation Theory*, §26, and Jantzen, *Representations of Algebraic Groups*, II.1, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"divided-power-basis"}-->

🤖 Prepared with Codex
