### PR TITLE
docs(EDS): correct the source header quotation and credit both authors

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
@@ -59,10 +59,10 @@ Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in 
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `compl₂EDSAux`, `compl₂EDSAux_two`, `compl₂EDSAux_mul_b` and `map_compl₂EDSAux`. That
 file's header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
-adapted material the upstream authorship is credited here rather than in the copyright header. That
-file is part of the joint LutzNagell development with J. Xu, who authors the neighbouring
-`Universal.lean` and co-authors `DivisionPolynomialOmega.lean`; both are credited for what this
-repository takes from it.
+adapted material the upstream authorship is credited here rather than in the copyright header. J.
+Xu is acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
+co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
+an author of the declarations above.
 
 The same declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), the upstreaming
 of that AINTLIB file, so they are portable under this project's rule and deduplicate when it lands.

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
@@ -55,12 +55,14 @@ factors move.
 
 ## Provenance
 
-Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `compl₂EDSAux`, `compl₂EDSAux_two`, `compl₂EDSAux_mul_b` and `map_compl₂EDSAux`. That
 file's header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
-adapted material the upstream authorship is credited here to both rather than in the copyright
-header.
+adapted material the upstream authorship is credited here rather than in the copyright header. That
+file is part of the joint LutzNagell development with J. Xu, who authors the neighbouring
+`Universal.lean` and co-authors `DivisionPolynomialOmega.lean`; both are credited for what this
+repository takes from it.
 
 The same declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), the upstreaming
 of that AINTLIB file, so they are portable under this project's rule and deduplicate when it lands.

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
@@ -55,12 +55,12 @@ factors move.
 
 ## Provenance
 
-Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `compl₂EDSAux`, `compl₂EDSAux_two`,
-`compl₂EDSAux_mul_b` and `map_compl₂EDSAux`. That file's header reads `Authors: Junyan Xu`;
-following this repository's convention for adapted material the upstream authorship is credited
-here rather than in the copyright header.
+Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `compl₂EDSAux`, `compl₂EDSAux_two`, `compl₂EDSAux_mul_b` and `map_compl₂EDSAux`. That
+file's header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
+adapted material the upstream authorship is credited here to both rather than in the copyright
+header.
 
 The same declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), the upstreaming
 of that AINTLIB file, so they are portable under this project's rule and deduplicate when it lands.

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -67,14 +67,13 @@ reduces to six orderings of three, the last index being `0` and so already minim
 
 ## Provenance
 
-Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`,
-`rel₄_iff_evenRec`, `dMin`, `cMin`, `Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`,
-`rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`, `rel₄_of_oddRec_evenRec` and
-`IsEllSequence.of_oddRec_evenRec`. That file's header reads
-`Authors: Junyan Xu`; following this repository's convention for adapted material the upstream
-authorship is credited here rather than in the copyright header.
+Adapted from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`, `rel₄_iff_evenRec`, `dMin`, `cMin`,
+`Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`, `rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`,
+`rel₄_of_oddRec_evenRec` and `IsEllSequence.of_oddRec_evenRec`. That file's header reads `Authors:
+David Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
+authorship is credited here to both rather than in the copyright header.
 
 The source states its expansions against its own `addMulSub` and `rel₄`, which Mathlib now
 supplies as `atom` and `atomRel` with the same definitions, so those statements transfer by

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -67,13 +67,15 @@ reduces to six orderings of three, the last index being `0` and so already minim
 
 ## Provenance
 
-Adapted from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`, `rel₄_iff_evenRec`, `dMin`, `cMin`,
 `Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`, `rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`,
 `rel₄_of_oddRec_evenRec` and `IsEllSequence.of_oddRec_evenRec`. That file's header reads `Authors:
 David Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
-authorship is credited here to both rather than in the copyright header.
+authorship is credited here rather than in the copyright header. That file is part of the joint
+LutzNagell development with J. Xu, who authors the neighbouring `Universal.lean` and co-authors
+`DivisionPolynomialOmega.lean`; both are credited for what this repository takes from it.
 
 The source states its expansions against its own `addMulSub` and `rel₄`, which Mathlib now
 supplies as `atom` and `atomRel` with the same definitions, so those statements transfer by

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -73,9 +73,10 @@ declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`, `rel₄_iff_eve
 `Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`, `rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`,
 `rel₄_of_oddRec_evenRec` and `IsEllSequence.of_oddRec_evenRec`. That file's header reads `Authors:
 David Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
-authorship is credited here rather than in the copyright header. That file is part of the joint
-LutzNagell development with J. Xu, who authors the neighbouring `Universal.lean` and co-authors
-`DivisionPolynomialOmega.lean`; both are credited for what this repository takes from it.
+authorship is credited here rather than in the copyright header. J. Xu is acknowledged for the
+surrounding LutzNagell development — he authors `Universal.lean` and co-authors
+`DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as an author of
+the declarations above.
 
 The source states its expansions against its own `addMulSub` and `rel₄`, which Mathlib now
 supplies as `atom` and `atomRel` with the same definitions, so those statements transfer by

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Invariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Invariant.lean
@@ -58,11 +58,13 @@ where one cannot divide through.
 
 ## Provenance
 
-Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `invarNum`, `invarDenom` and `invar_of_net`. That file's header reads `Authors: David
 Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
-authorship is credited here to both rather than in the copyright header.
+authorship is credited here rather than in the copyright header. That file is part of the joint
+LutzNagell development with J. Xu, who authors the neighbouring `Universal.lean` and co-authors
+`DivisionPolynomialOmega.lean`; both are credited for what this repository takes from it.
 
 The same three declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), which is
 the upstreaming of that AINTLIB file; this port uses that PR's naming

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Invariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Invariant.lean
@@ -58,12 +58,11 @@ where one cannot divide through.
 
 ## Provenance
 
-Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invarNum`, `invarDenom` and
-`invar_of_net`. That file's header reads `Authors: Junyan Xu`; following this repository's
-convention for adapted material the upstream authorship is credited here rather than in the
-copyright header.
+Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `invarNum`, `invarDenom` and `invar_of_net`. That file's header reads `Authors: David
+Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
+authorship is credited here to both rather than in the copyright header.
 
 The same three declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), which is
 the upstreaming of that AINTLIB file; this port uses that PR's naming

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Invariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Invariant.lean
@@ -62,9 +62,10 @@ Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in 
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `invarNum`, `invarDenom` and `invar_of_net`. That file's header reads `Authors: David
 Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
-authorship is credited here rather than in the copyright header. That file is part of the joint
-LutzNagell development with J. Xu, who authors the neighbouring `Universal.lean` and co-authors
-`DivisionPolynomialOmega.lean`; both are credited for what this repository takes from it.
+authorship is credited here rather than in the copyright header. J. Xu is acknowledged for the
+surrounding LutzNagell development — he authors `Universal.lean` and co-authors
+`DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as an author of
+the declarations above.
 
 The same three declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), which is
 the upstreaming of that AINTLIB file; this port uses that PR's naming

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -42,12 +42,12 @@ waiting on, not the slice that lands them.
 
 ## Provenance
 
-Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations
-`IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That file's header
-reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
-upstream authorship is credited here rather than in the copyright header.
+Adapted from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That
+file's header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
+adapted material the upstream authorship is credited here to both rather than in the copyright
+header.
 
 The source proves the hypothesis-carrying version from its own descent development; here that
 step is `isEllipticSequence_iff`, so the helper is six lines rather than a file. The universal

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -42,12 +42,14 @@ waiting on, not the slice that lands them.
 
 ## Provenance
 
-Adapted from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That
 file's header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
-adapted material the upstream authorship is credited here to both rather than in the copyright
-header.
+adapted material the upstream authorship is credited here rather than in the copyright header. That
+file is part of the joint LutzNagell development with J. Xu, who authors the neighbouring
+`Universal.lean` and co-authors `DivisionPolynomialOmega.lean`; both are credited for what this
+repository takes from it.
 
 The source proves the hypothesis-carrying version from its own descent development; here that
 step is `isEllipticSequence_iff`, so the helper is six lines rather than a file. The universal

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -46,10 +46,10 @@ Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That
 file's header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
-adapted material the upstream authorship is credited here rather than in the copyright header. That
-file is part of the joint LutzNagell development with J. Xu, who authors the neighbouring
-`Universal.lean` and co-authors `DivisionPolynomialOmega.lean`; both are credited for what this
-repository takes from it.
+adapted material the upstream authorship is credited here rather than in the copyright header. J.
+Xu is acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
+co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
+an author of the declarations above.
 
 The source proves the hypothesis-carrying version from its own descent development; here that
 step is `isEllipticSequence_iff`, so the helper is six lines rather than a file. The universal

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
@@ -43,10 +43,10 @@ Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `OddRec`, `EvenRec`, `rel₃_iff_oddRec` and `rel₃_iff_evenRec`. That file's header
 reads `Authors: David Kurniadi Angdinata`; following this repository's convention for adapted
-material the upstream authorship is credited here rather than in the copyright header. That file is
-part of the joint LutzNagell development with J. Xu, who authors the neighbouring `Universal.lean`
-and co-authors `DivisionPolynomialOmega.lean`; both are credited for what this repository takes
-from it.
+material the upstream authorship is credited here rather than in the copyright header. J. Xu is
+acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
+co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
+an author of the declarations above.
 
 The adaptation is substantial, because Mathlib has since absorbed most of what the source had to
 build for itself. The source states its equivalences against `Rel₃`, a three-index relation of its

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
@@ -39,11 +39,14 @@ unit, so solving for `W (2 * m + 1)` or `W (2 * m)` requires a hypothesis this f
 
 ## Provenance
 
-Adapted from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `OddRec`, `EvenRec`, `rel₃_iff_oddRec` and `rel₃_iff_evenRec`. That file's header
 reads `Authors: David Kurniadi Angdinata`; following this repository's convention for adapted
-material the upstream authorship is credited here to both rather than in the copyright header.
+material the upstream authorship is credited here rather than in the copyright header. That file is
+part of the joint LutzNagell development with J. Xu, who authors the neighbouring `Universal.lean`
+and co-authors `DivisionPolynomialOmega.lean`; both are credited for what this repository takes
+from it.
 
 The adaptation is substantial, because Mathlib has since absorbed most of what the source had to
 build for itself. The source states its equivalences against `Rel₃`, a three-index relation of its

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
@@ -39,12 +39,11 @@ unit, so solving for `W (2 * m + 1)` or `W (2 * m)` requires a hypothesis this f
 
 ## Provenance
 
-Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `OddRec`, `EvenRec`, `rel₃_iff_oddRec`
-and `rel₃_iff_evenRec`. That file's header reads `Authors: Junyan Xu`; following this repository's
-convention for adapted material the upstream authorship is credited here rather than in the
-copyright header.
+Adapted from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `OddRec`, `EvenRec`, `rel₃_iff_oddRec` and `rel₃_iff_evenRec`. That file's header
+reads `Authors: David Kurniadi Angdinata`; following this repository's convention for adapted
+material the upstream authorship is credited here to both rather than in the copyright header.
 
 The adaptation is substantial, because Mathlib has since absorbed most of what the source had to
 build for itself. The source states its equivalences against `Rel₃`, a three-index relation of its

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -60,13 +60,15 @@ ellipticity variables over exactly this block.
 
 ## Provenance
 
-Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `invarNum_normEDS`, `redInvarNum`, `compl₂EDS_eq_redInvarNum_sub` and
 `invarNum_eq_redInvarNum_mul` — the source's own names, which this file respells with `reduced`
 written out. That file's header reads `Authors: David Kurniadi Angdinata`; following this
-repository's convention for adapted material the upstream authorship is credited here to both
-rather than in the copyright header.
+repository's convention for adapted material the upstream authorship is credited here rather than
+in the copyright header. That file is part of the joint LutzNagell development with J. Xu, who
+authors the neighbouring `Universal.lean` and co-authors `DivisionPolynomialOmega.lean`; both are
+credited for what this repository takes from it.
 
 The same declarations sit in **Mathlib PR #13057**, the upstreaming of that AINTLIB file, so they
 are portable under this project's rule and deduplicate if and when it lands.

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -66,9 +66,9 @@ declarations `invarNum_normEDS`, `redInvarNum`, `compl₂EDS_eq_redInvarNum_sub`
 `invarNum_eq_redInvarNum_mul` — the source's own names, which this file respells with `reduced`
 written out. That file's header reads `Authors: David Kurniadi Angdinata`; following this
 repository's convention for adapted material the upstream authorship is credited here rather than
-in the copyright header. That file is part of the joint LutzNagell development with J. Xu, who
-authors the neighbouring `Universal.lean` and co-authors `DivisionPolynomialOmega.lean`; both are
-credited for what this repository takes from it.
+in the copyright header. J. Xu is acknowledged for the surrounding LutzNagell development — he
+authors `Universal.lean` and co-authors `DivisionPolynomialOmega.lean` at the same revision — as
+context for this port, not as an author of the declarations above.
 
 The same declarations sit in **Mathlib PR #13057**, the upstreaming of that AINTLIB file, so they
 are portable under this project's rule and deduplicate if and when it lands.

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -60,13 +60,13 @@ ellipticity variables over exactly this block.
 
 ## Provenance
 
-Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `invarNum_normEDS`, `redInvarNum`,
-`compl₂EDS_eq_redInvarNum_sub` and `invarNum_eq_redInvarNum_mul` — the source's own names, which
-this file respells with `reduced` written out. That file's header reads `Authors: Junyan Xu`;
-following this repository's convention for adapted material the upstream authorship is credited
-here rather than in the copyright header.
+Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `invarNum_normEDS`, `redInvarNum`, `compl₂EDS_eq_redInvarNum_sub` and
+`invarNum_eq_redInvarNum_mul` — the source's own names, which this file respells with `reduced`
+written out. That file's header reads `Authors: David Kurniadi Angdinata`; following this
+repository's convention for adapted material the upstream authorship is credited here to both
+rather than in the copyright header.
 
 The same declarations sit in **Mathlib PR #13057**, the upstreaming of that AINTLIB file, so they
 are portable under this project's rule and deduplicate if and when it lands.

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
@@ -55,14 +55,16 @@ oddness of `W` enters; nothing else here needs a hypothesis on `W`.
 
 ## Provenance
 
-Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `rel₄_swap₀₁`, `rel₄_swap₁₂`, `rel₄_swap₂₃`, `relFin4` and `relFin4_perm`. The
 source's `relFin4_perm'` — the sign-cancelled orientation — was **considered and not ported**: it
 has no consumer until the descent slice, and lands there beside `rel₄_of_oddRec_evenRec`, the proof
 that uses it. That file's header reads `Authors: David Kurniadi Angdinata`; following this
-repository's convention for adapted material the upstream authorship is credited here to both
-rather than in the copyright header.
+repository's convention for adapted material the upstream authorship is credited here rather than
+in the copyright header. That file is part of the joint LutzNagell development with J. Xu, who
+authors the neighbouring `Universal.lean` and co-authors `DivisionPolynomialOmega.lean`; both are
+credited for what this repository takes from it.
 
 Restated over Mathlib's names for this API: the source's `rel₄` is `IsEllipticNet.atomRel` and its
 `addMulSub` is `IsEllipticNet.atom`, and the source's standing `neg : ∀ k, W (-k) = -W k` hypothesis

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
@@ -55,14 +55,14 @@ oddness of `W` enters; nothing else here needs a hypothesis on `W`.
 
 ## Provenance
 
-Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₄_swap₀₁`, `rel₄_swap₁₂`,
-`rel₄_swap₂₃`, `relFin4` and `relFin4_perm`. The source's `relFin4_perm'` — the sign-cancelled
-orientation — was **considered and not ported**: it has no consumer until the descent slice, and
-lands there beside `rel₄_of_oddRec_evenRec`, the proof that uses it. That file's header reads
-`Authors: Junyan Xu`; following this repository's convention for adapted material the upstream
-authorship is credited here rather than in the copyright header.
+Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `rel₄_swap₀₁`, `rel₄_swap₁₂`, `rel₄_swap₂₃`, `relFin4` and `relFin4_perm`. The
+source's `relFin4_perm'` — the sign-cancelled orientation — was **considered and not ported**: it
+has no consumer until the descent slice, and lands there beside `rel₄_of_oddRec_evenRec`, the proof
+that uses it. That file's header reads `Authors: David Kurniadi Angdinata`; following this
+repository's convention for adapted material the upstream authorship is credited here to both
+rather than in the copyright header.
 
 Restated over Mathlib's names for this API: the source's `rel₄` is `IsEllipticNet.atomRel` and its
 `addMulSub` is `IsEllipticNet.atom`, and the source's standing `neg : ∀ k, W (-k) = -W k` hypothesis

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
@@ -62,9 +62,9 @@ source's `relFin4_perm'` — the sign-cancelled orientation — was **considered
 has no consumer until the descent slice, and lands there beside `rel₄_of_oddRec_evenRec`, the proof
 that uses it. That file's header reads `Authors: David Kurniadi Angdinata`; following this
 repository's convention for adapted material the upstream authorship is credited here rather than
-in the copyright header. That file is part of the joint LutzNagell development with J. Xu, who
-authors the neighbouring `Universal.lean` and co-authors `DivisionPolynomialOmega.lean`; both are
-credited for what this repository takes from it.
+in the copyright header. J. Xu is acknowledged for the surrounding LutzNagell development — he
+authors `Universal.lean` and co-authors `DivisionPolynomialOmega.lean` at the same revision — as
+context for this port, not as an author of the declarations above.
 
 Restated over Mathlib's names for this API: the source's `rel₄` is `IsEllipticNet.atomRel` and its
 `addMulSub` is `IsEllipticNet.atom`, and the source's standing `neg : ∀ k, W (-k) = -W k` hypothesis

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Six.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Six.lean
@@ -18,12 +18,14 @@ expressed through the fifth rather than expanded. The fifth term does have a clo
 `normEDS b c d 5 = d * b ^ 4 - c ^ 3`, but the factored shape above is the one the divisibility
 arguments downstream consume, so the statement keeps `normEDS _ 5` rather than substituting it.
 
-Adapted from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`,
 path `projects/NagellLutz/LutzNagell/EllipticDivisibilitySequence.lean`), declaration
 `normEDS_six`. That file's header reads `Authors: David Kurniadi Angdinata`; following this
-repository's convention for adapted material, the upstream authorship is credited here to both
-rather than in the copyright header.
+repository's convention for adapted material, the upstream authorship is credited here rather than
+in the copyright header. That file is part of the joint LutzNagell development with J. Xu, who
+authors the neighbouring `Universal.lean` and co-authors `DivisionPolynomialOmega.lean`; both are
+credited for what this repository takes from it.
 
 **Adaptations:** converted to this repository's module system, and restated for Mathlib's current
 names — the source predates the rename of `compl₂EDS` to `complEDS₂` and of

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Six.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Six.lean
@@ -23,9 +23,9 @@ Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in
 path `projects/NagellLutz/LutzNagell/EllipticDivisibilitySequence.lean`), declaration
 `normEDS_six`. That file's header reads `Authors: David Kurniadi Angdinata`; following this
 repository's convention for adapted material, the upstream authorship is credited here rather than
-in the copyright header. That file is part of the joint LutzNagell development with J. Xu, who
-authors the neighbouring `Universal.lean` and co-authors `DivisionPolynomialOmega.lean`; both are
-credited for what this repository takes from it.
+in the copyright header. J. Xu is acknowledged for the surrounding LutzNagell development — he
+authors `Universal.lean` and co-authors `DivisionPolynomialOmega.lean` at the same revision — as
+context for this port, not as an author of the declarations above.
 
 **Adaptations:** converted to this repository's module system, and restated for Mathlib's current
 names — the source predates the rename of `compl₂EDS` to `complEDS₂` and of

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Six.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Six.lean
@@ -18,13 +18,12 @@ expressed through the fifth rather than expanded. The fifth term does have a clo
 `normEDS b c d 5 = d * b ^ 4 - c ^ 3`, but the factored shape above is the one the divisibility
 arguments downstream consume, so the statement keeps `normEDS _ 5` rather than substituting it.
 
-Adapted from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`, path
-`projects/NagellLutz/LutzNagell/EllipticDivisibilitySequence.lean`), declaration
-`normEDS_six`. That file's header reads `Authors: Junyan Xu`; following this repository's
-convention for adapted material, the upstream authorship is credited here rather than in the
-copyright header.
+Adapted from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`,
+path `projects/NagellLutz/LutzNagell/EllipticDivisibilitySequence.lean`), declaration
+`normEDS_six`. That file's header reads `Authors: David Kurniadi Angdinata`; following this
+repository's convention for adapted material, the upstream authorship is credited here to both
+rather than in the copyright header.
 
 **Adaptations:** converted to this repository's module system, and restated for Mathlib's current
 names — the source predates the rename of `compl₂EDS` to `complEDS₂` and of

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -84,9 +84,9 @@ Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in 
 declarations `StrictAnti₄`, `HaveSameParity₄.transf`, `HaveSameParity₄.strictAnti₄_transf` and
 `HaveSameParity₄.six_le_of_strictAnti₄`. That file's header reads `Authors: David Kurniadi
 Angdinata`; following this repository's convention for adapted material the upstream authorship is
-credited here rather than in the copyright header. That file is part of the joint LutzNagell
-development with J. Xu, who authors the neighbouring `Universal.lean` and co-authors
-`DivisionPolynomialOmega.lean`; both are credited for what this repository takes from it. The
+credited here rather than in the copyright header. J. Xu is acknowledged for the surrounding
+LutzNagell development — he authors `Universal.lean` and co-authors `DivisionPolynomialOmega.lean`
+at the same revision — as context for this port, not as an author of the declarations above. The
 source's `StrictAnti₄` gains a `Nonneg` prefix here, because the predicate bundles the lower bound
 `0 ≤ d` that the source's name left unsaid; the `StrictAnti` half is kept, the definition being
 Mathlib's `StrictAnti` on the tuple. The dependent names follow it, and `six_le_of_parity_of_…`

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -79,16 +79,18 @@ Importing the EDS module only to reach `abs_cases` through it cost 279 build job
 
 ## Provenance
 
-Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `StrictAnti₄`, `HaveSameParity₄.transf`, `HaveSameParity₄.strictAnti₄_transf` and
 `HaveSameParity₄.six_le_of_strictAnti₄`. That file's header reads `Authors: David Kurniadi
 Angdinata`; following this repository's convention for adapted material the upstream authorship is
-credited here to both rather than in the copyright header. The source's `StrictAnti₄` gains a
-`Nonneg` prefix here, because the predicate bundles the lower bound `0 ≤ d` that the source's name
-left unsaid; the `StrictAnti` half is kept, the definition being Mathlib's `StrictAnti` on the
-tuple. The dependent names follow it, and `six_le_of_parity_of_…` names the parity hypothesis that
-its statement genuinely needs.
+credited here rather than in the copyright header. That file is part of the joint LutzNagell
+development with J. Xu, who authors the neighbouring `Universal.lean` and co-authors
+`DivisionPolynomialOmega.lean`; both are credited for what this repository takes from it. The
+source's `StrictAnti₄` gains a `Nonneg` prefix here, because the predicate bundles the lower bound
+`0 ≤ d` that the source's name left unsaid; the `StrictAnti` half is kept, the definition being
+Mathlib's `StrictAnti` on the tuple. The dependent names follow it, and `six_le_of_parity_of_…`
+names the parity hypothesis that its statement genuinely needs.
 
 The source's surrounding transfer machinery is **not** ported, being already upstream: its
 `rel₄_transf` is Mathlib's `atomRel_avg_sub`, its `rel₄_eq_net` is Mathlib's `atomRel_eq`, and its

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -79,16 +79,16 @@ Importing the EDS module only to reach `abs_cases` through it cost 279 build job
 
 ## Provenance
 
-Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `StrictAnti₄`, `HaveSameParity₄.transf`,
-`HaveSameParity₄.strictAnti₄_transf` and `HaveSameParity₄.six_le_of_strictAnti₄`. That file's
-header reads `Authors: Junyan Xu`; following this repository's convention for adapted material the
-upstream authorship is credited here rather than in the copyright header. The source's
-`StrictAnti₄` gains a `Nonneg` prefix here, because the predicate bundles the lower bound `0 ≤ d`
-that the source's name left unsaid; the `StrictAnti` half is kept, the definition being Mathlib's
-`StrictAnti` on the tuple. The dependent names follow it, and `six_le_of_parity_of_…` names the
-parity hypothesis that its statement genuinely needs.
+Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `StrictAnti₄`, `HaveSameParity₄.transf`, `HaveSameParity₄.strictAnti₄_transf` and
+`HaveSameParity₄.six_le_of_strictAnti₄`. That file's header reads `Authors: David Kurniadi
+Angdinata`; following this repository's convention for adapted material the upstream authorship is
+credited here to both rather than in the copyright header. The source's `StrictAnti₄` gains a
+`Nonneg` prefix here, because the predicate bundles the lower bound `0 ≤ d` that the source's name
+left unsaid; the `StrictAnti` half is kept, the definition being Mathlib's `StrictAnti` on the
+tuple. The dependent names follow it, and `six_le_of_parity_of_…` names the parity hypothesis that
+its statement genuinely needs.
 
 The source's surrounding transfer machinery is **not** ported, being already upstream: its
 `rel₄_transf` is Mathlib's `atomRel_avg_sub`, its `rel₄_eq_net` is Mathlib's `atomRel_eq`, and its

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
@@ -62,15 +62,14 @@ instance otherwise.
 
 ## Provenance
 
-Ported from J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `Param`, `universalNormEDS`,
-`normEDS_eq_aeval`, `compl₂EDS_eq_aeval` and `complEDS_eq_aeval`. **`Param` is spelt
-`NormEDSParam` here** — a root-level `Param` says nothing about elliptic divisibility sequences and
-makes its namespace equally generic; that rename is an adaptation made in this repository, not
-upstream's name. That file's header reads
-`Authors: Junyan Xu`; following this repository's convention for adapted material the upstream
-authorship is credited here rather than in the copyright header.
+Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `Param`, `universalNormEDS`, `normEDS_eq_aeval`, `compl₂EDS_eq_aeval` and
+`complEDS_eq_aeval`. **`Param` is spelt `NormEDSParam` here** — a root-level `Param` says nothing
+about elliptic divisibility sequences and makes its namespace equally generic; that rename is an
+adaptation made in this repository, not upstream's name. That file's header reads `Authors: David
+Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
+authorship is credited here to both rather than in the copyright header.
 
 The same declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), the
 upstreaming of that AINTLIB file, so they are portable under this project's rule and deduplicate

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
@@ -62,14 +62,16 @@ instance otherwise.
 
 ## Provenance
 
-Ported from D. K. Angdinata and J. Xu's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `Param`, `universalNormEDS`, `normEDS_eq_aeval`, `compl₂EDS_eq_aeval` and
 `complEDS_eq_aeval`. **`Param` is spelt `NormEDSParam` here** — a root-level `Param` says nothing
 about elliptic divisibility sequences and makes its namespace equally generic; that rename is an
 adaptation made in this repository, not upstream's name. That file's header reads `Authors: David
 Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
-authorship is credited here to both rather than in the copyright header.
+authorship is credited here rather than in the copyright header. That file is part of the joint
+LutzNagell development with J. Xu, who authors the neighbouring `Universal.lean` and co-authors
+`DivisionPolynomialOmega.lean`; both are credited for what this repository takes from it.
 
 The same declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), the
 upstreaming of that AINTLIB file, so they are portable under this project's rule and deduplicate

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
@@ -69,9 +69,10 @@ declarations `Param`, `universalNormEDS`, `normEDS_eq_aeval`, `compl₂EDS_eq_ae
 about elliptic divisibility sequences and makes its namespace equally generic; that rename is an
 adaptation made in this repository, not upstream's name. That file's header reads `Authors: David
 Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
-authorship is credited here rather than in the copyright header. That file is part of the joint
-LutzNagell development with J. Xu, who authors the neighbouring `Universal.lean` and co-authors
-`DivisionPolynomialOmega.lean`; both are credited for what this repository takes from it.
+authorship is credited here rather than in the copyright header. J. Xu is acknowledged for the
+surrounding LutzNagell development — he authors `Universal.lean` and co-authors
+`DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as an author of
+the declarations above.
 
 The same declarations sit in **Mathlib PR #13057** (open, last updated 2024-07-31), the
 upstreaming of that AINTLIB file, so they are portable under this project's rule and deduplicate


### PR DESCRIPTION
Ten files in `EllipticDivisibilitySequence/` credit their AINTLIB source to J. Xu alone and
quote its header as `Authors: Junyan Xu`. That header reads something else.

```
projects/NagellLutz/LutzNagell/EllipticDivisibilitySequence.lean
  Copyright (c) 2024 David Kurniadi Angdinata
  Authors: David Kurniadi Angdinata
```

identical at AINTLIB `1c1c74664e40071c2c2165bc55ca2616a67ccd6b` (the revision every one of the
ten cites) and at that checkout's current `2baa76f7`; `grep -i "junyan\|xu"` over the whole file
returns nothing at either. So the quoted header line was false in all ten.

This PR quotes that header as it actually reads and credits both people, **without** claiming Xu
authored the cited file. Angdinata is named as its author; Xu is credited distinctly as co-author
of the surrounding LutzNagell development — he authors the neighbouring `Universal.lean` and
co-authors `DivisionPolynomialOmega.lean`, both checked at the cited revision.

A first draft wrote "D. K. Angdinata and J. Xu's `EllipticDivisibilitySequence.lean`", which the
`documentation` rubric rejected in local review: a block cannot quote a header naming one author
and call the same work joint in the same breath. Splitting the two claims fixes that — the header
quotation is now exact, and Xu's contribution is described where it is verifiable rather than
asserted of a file he did not write.

## Scope: exactly the files citing that one source

The error is confined to citations of `EllipticDivisibilitySequence.lean`. Two other files credit
Xu and are **correct**, because they cite different sources:

| file | cites | that file's header |
|---|---|---|
| `EllipticCurve/Universal.lean` | `LutzNagell/Universal.lean` | `Authors: Junyan Xu` ✓ |
| `DivisionPolynomial/Invariant.lean` | `LutzNagell/DivisionPolynomialOmega.lean` | `Authors: Junyan Xu, David Kurniadi Angdinata` ✓ |

Both are untouched. A blanket replace on the string `Junyan Xu` would have corrupted them, and
would also have reached ~22 further occurrences in `Topology/` and `AlgebraicTopology/` belonging
to another lane. The change is keyed on *which source each file cites*, verified per file.

## How it happened, since it was not carelessness

Xu genuinely authored neighbouring files in the same AINTLIB directory — `Universal.lean` is his,
`DivisionPolynomialOmega.lean` is his and Angdinata's. "Xu" was therefore a locally plausible
name to carry across, and once one file's provenance block said it, later files inherited the
sentence from their predecessors rather than from the source. The blocks also cite Mathlib PR
#13057 as the upstreaming of the same declarations, which is a second plausible route to the
name.

Crediting both is the resolution: the material reaches this repository through work by both
people, and the header quotation is now accurate rather than invented.

## Files

`ComplAux`, `Descent`, `Invariant`, `NormEDS`, `Recurrence`, `ReducedInvariant`,
`SignEquivariance`, `Six`, `Transfer`, `Universal` — all in
`TauCeti/NumberTheory/EllipticDivisibilitySequence/`.

No declaration, signature, proof or import changes; the diff is module-docstring prose, and the
provenance paragraphs are re-wrapped where the longer attribution changed the line breaks.

## Gates

`lake build` PASS at 7874 jobs, branch cut from current `main` (`973cce1b1`). No line over 100
codepoints, measured in codepoints rather than bytes — these files are dense in `₂`, `←` and `ω`,
so a byte count both over- and under-reports. Docstrings are parsed, so the build is a real gate
here even though no declaration changed.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-attribution-both"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
