### PR TITLE
feat: Parseval and expansions for the multidimensional Hermite bases

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
@@ -377,6 +377,7 @@ theorem piHilbertBasis_apply {κ : ι → Type*}
 
 /-- The coordinate of a tensor in a product Hilbert basis is the product of its coordinatewise
 coordinates. -/
+@[simp]
 theorem piHilbertBasis_repr_L2piMul {κ : ι → Type*}
     (b : ∀ i, HilbertBasis (κ i) 𝕜 (Lp 𝕜 2 (μ i))) (F : ∀ i, Lp 𝕜 2 (μ i))
     (k : ∀ i, κ i) :

--- a/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
@@ -44,6 +44,7 @@ orthonormality half is short. The completeness half runs in three moves:
 ## Main statements
 
 * `TauCeti.memLp_pi_prod` — the pointwise product of `L²` functions is `L²` for the product measure.
+* `TauCeti.integrable_L2piMul_mul` — a product of `L²` factors times an `L²` function is integrable.
 * `TauCeti.inner_L2piMul` — the inner product of two tensors factors coordinatewise.
 * `TauCeti.orthonormal_L2piMul` — coordinatewise orthonormal families multiply to an orthonormal
   family.
@@ -101,6 +102,12 @@ noncomputable def L2piMul (F : ∀ i, Lp 𝕜 2 (μ i)) : Lp 𝕜 2 (Measure.pi 
 theorem coeFn_L2piMul (F : ∀ i, Lp 𝕜 2 (μ i)) :
     ⇑(L2piMul F) =ᵐ[Measure.pi μ] fun x : ∀ i, α i => ∏ i, F i (x i) :=
   MemLp.coeFn_toLp _
+
+/-- A pointwise product of coordinatewise `L²` functions times an `L²` function on the product
+space is integrable. -/
+theorem integrable_L2piMul_mul (F : ∀ i, Lp 𝕜 2 (μ i)) (f : Lp 𝕜 2 (Measure.pi μ)) :
+    Integrable (fun x : ∀ i, α i => (∏ i, F i (x i)) * f x) (Measure.pi μ) :=
+  (memLp_pi_prod fun i => Lp.memLp (F i)).integrable_mul (Lp.memLp f)
 
 end NormedCommRing
 
@@ -367,6 +374,15 @@ theorem piHilbertBasis_apply {κ : ι → Type*}
     (b : ∀ i, HilbertBasis (κ i) 𝕜 (Lp 𝕜 2 (μ i))) (k : ∀ i, κ i) :
     piHilbertBasis b k = L2piMul fun i => b i (k i) := by
   rw [piHilbertBasis, HilbertBasis.coe_mkOfOrthogonalEqBot]
+
+/-- The coordinate of a tensor in a product Hilbert basis is the product of its coordinatewise
+coordinates. -/
+theorem piHilbertBasis_repr_L2piMul {κ : ι → Type*}
+    (b : ∀ i, HilbertBasis (κ i) 𝕜 (Lp 𝕜 2 (μ i))) (F : ∀ i, Lp 𝕜 2 (μ i))
+    (k : ∀ i, κ i) :
+    (piHilbertBasis b).repr (L2piMul F) k = ∏ i, (b i).repr (F i) (k i) := by
+  rw [HilbertBasis.repr_apply_apply, piHilbertBasis_apply, inner_L2piMul]
+  exact Finset.prod_congr rfl fun i _ => (HilbertBasis.repr_apply_apply (b i) (F i) (k i)).symm
 
 /-- The `k`-th vector of `piHilbertBasis` is a.e. the pointwise product `∏ i, b i (k i)`. -/
 theorem coeFn_piHilbertBasis {κ : ι → Type*}

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Basis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Basis.lean
@@ -22,6 +22,8 @@ factor — here `TauCeti.hermiteHilbertBasis` — so this file only performs the
 ## Main statements
 
 * `TauCeti.hermiteFunctionPiBasis` — the multi-index basis.
+* `TauCeti.hermiteFunctionPiBasis_apply` — the `a`-th vector is the tensor `TauCeti.L2piMul` of the
+  one-dimensional Hermite vectors, as an equality of `L²` vectors.
 * `TauCeti.coeFn_hermiteFunctionPiBasis` — the anti-vacuity pin: the `a`-th vector really is the
   product `∏ᵢ ψ_{aᵢ}(xᵢ)`.
 -/
@@ -39,6 +41,16 @@ Hermite-function basis in every coordinate — the eigenbasis of the `ℝ^ι` ha
 noncomputable def hermiteFunctionPiBasis :
     HilbertBasis (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi fun _ : ι => (volume : Measure ℝ))) :=
   piHilbertBasis fun _ => hermiteHilbertBasis 𝕜
+
+/-- **The `a`-th basis vector is the tensor of the one-dimensional Hermite vectors.** This is the
+identification `TauCeti.coeFn_hermiteFunctionPiBasis` below refines to a pointwise product; stated
+between `L²` vectors it is what the expansion API rewrites with, since the inner product against a
+tensor factors coordinatewise (`TauCeti.inner_L2piMul`). -/
+@[simp]
+theorem hermiteFunctionPiBasis_apply (a : ι → ℕ) :
+    hermiteFunctionPiBasis 𝕜 ι a = L2piMul fun i => hermiteFunctionLp 𝕜 (a i) := by
+  rw [hermiteFunctionPiBasis, piHilbertBasis_apply]
+  simp only [coe_hermiteHilbertBasis]
 
 /-- **The basis vectors are the multi-index Hermite-function products.** Without this the
 construction would only exhibit *some* Hilbert basis of `L²(volume^ι)`. The coordinatewise

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Parseval.lean
@@ -19,10 +19,9 @@ that a consumer never has to unfold `hermiteFunctionPiBasis` to expand a functio
 variables in Hermite functions. It is the `Fintype`-indexed analogue of
 `TauCeti.tsum_norm_sq_inner_hermiteFunctionLp` and its neighbours.
 
-Beyond the transported one-dimensional statements there is one genuinely multidimensional lemma,
-`TauCeti.hermiteFunctionPiBasis_repr_L2piMul`: on a function that is itself a product, the
-multi-index coordinates are the products of the one-dimensional Hermite coordinates. It is the
-coordinate form of the tensor inner-product identity `TauCeti.inner_L2piMul`.
+At this arity the file additionally gives the coordinate as an integral, proves that its integrand
+is integrable, and specializes `TauCeti.piHilbertBasis_repr_L2piMul` to show that the coordinates
+of a product are the products of the one-dimensional Hermite coordinates.
 
 ## Main statements
 
@@ -65,10 +64,10 @@ theorem integrable_prod_hermiteFunction_mul
     (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (volume : Measure ℝ))) (a : ι → ℕ) :
     Integrable (fun x : ι → ℝ => (∏ i, (algebraMap ℝ 𝕜) (hermiteFunction (a i) (x i))) * f x)
       (Measure.pi fun _ : ι => (volume : Measure ℝ)) := by
-  refine (MeasureTheory.L2.integrable_inner (𝕜 := 𝕜) (hermiteFunctionPiBasis 𝕜 ι a) f).congr ?_
-  filter_upwards [coeFn_hermiteFunctionPiBasis 𝕜 ι a] with x hx
-  rw [hx]
-  simp [RCLike.algebraMap_eq_ofReal, map_prod, mul_comm]
+  refine (integrable_L2piMul_mul (fun i => hermiteFunctionLp 𝕜 (a i)) f).congr ?_
+  filter_upwards [coeFn_L2piMul (fun i => hermiteFunctionLp 𝕜 (a i)),
+    coeFn_hermiteFunctionPiBasis 𝕜 ι a] with x hprod hexplicit
+  rw [← hprod, ← hermiteFunctionPiBasis_apply, hexplicit]
 
 /-- The `a`-th multi-index Hermite coordinate of `f`, as an integral of `f` against the product
 `∏ᵢ ψ_{aᵢ}(xᵢ)`. The Hermite functions are real, so no complex conjugate survives. -/
@@ -91,7 +90,16 @@ theorem hermiteFunctionPiBasis_repr_L2piMul
     (F : ι → Lp 𝕜 2 (volume : Measure ℝ)) (a : ι → ℕ) :
     (hermiteFunctionPiBasis 𝕜 ι).repr (L2piMul F) a
       = ∏ i, inner 𝕜 (hermiteFunctionLp 𝕜 (a i)) (F i) := by
-  rw [hermiteFunctionPiBasis_repr_apply, inner_L2piMul]
+  rw [HilbertBasis.repr_apply_apply, hermiteFunctionPiBasis_apply]
+  calc
+    inner 𝕜 (L2piMul fun i => hermiteFunctionLp 𝕜 (a i)) (L2piMul F)
+        = ∏ i, (hermiteHilbertBasis 𝕜).repr (F i) (a i) := by
+          simpa only [HilbertBasis.repr_apply_apply, piHilbertBasis_apply,
+            coe_hermiteHilbertBasis] using
+              piHilbertBasis_repr_L2piMul (fun _ : ι => hermiteHilbertBasis 𝕜) F a
+    _ = ∏ i, inner 𝕜 (hermiteFunctionLp 𝕜 (a i)) (F i) :=
+      Finset.prod_congr rfl fun i _ => by
+        rw [HilbertBasis.repr_apply_apply, coe_hermiteHilbertBasis]
 
 /-- **Parseval's identity for the multi-index Hermite basis** (polarized form): the multi-index
 Hermite coordinates of `f` and `g` pair to their inner product. -/

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Parseval.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Parseval
+public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Pi.Basis
+
+/-!
+# Parseval and expansions for the multi-index Hermite-function basis
+
+`TauCeti.hermiteFunctionPiBasis` exhibits the multi-index Hermite functions
+`Ψ_a(x) = ∏ᵢ ψ_{aᵢ}(xᵢ)` as a Hilbert basis of `L²(ℝ^ι)`. This file states the expansion
+identities that basis was built for, phrased in the explicit tensors
+`TauCeti.L2piMul fun i => TauCeti.hermiteFunctionLp 𝕜 (a i)` rather than the bundled basis, so
+that a consumer never has to unfold `hermiteFunctionPiBasis` to expand a function of several
+variables in Hermite functions. It is the `Fintype`-indexed analogue of
+`TauCeti.tsum_norm_sq_inner_hermiteFunctionLp` and its neighbours.
+
+Beyond the transported one-dimensional statements there is one genuinely multidimensional lemma,
+`TauCeti.hermiteFunctionPiBasis_repr_L2piMul`: on a function that is itself a product, the
+multi-index coordinates are the products of the one-dimensional Hermite coordinates. It is the
+coordinate form of the tensor inner-product identity `TauCeti.inner_L2piMul`.
+
+## Main statements
+
+* `TauCeti.hermiteFunctionPiBasis_repr_apply` — the `a`-th coordinate of `f` is `⟪Ψ_a, f⟫`.
+* `TauCeti.hermiteFunctionPiBasis_repr_eq_integral` — the same coordinate as an integral against
+  `∏ᵢ ψ_{aᵢ}(xᵢ)`, whose integrand is integrable by
+  `TauCeti.integrable_prod_hermiteFunction_mul`.
+* `TauCeti.hermiteFunctionPiBasis_repr_L2piMul` — the coordinates of a product function are the
+  products of the one-dimensional coordinates.
+* `TauCeti.tsum_inner_mul_inner_L2piMul_hermiteFunctionLp` — Parseval in polarized form.
+* `TauCeti.tsum_norm_sq_inner_L2piMul_hermiteFunctionLp` — Parseval in norm-square form,
+  `∑' a, ‖⟪Ψ_a, f⟫‖² = ‖f‖²`.
+* `TauCeti.hasSum_L2piMul_hermiteFunctionLp_expansion` — the multi-index Hermite expansion
+  `∑' a, ⟪Ψ_a, f⟫ • Ψ_a = f`.
+
+Every statement holds for an arbitrary `RCLike` scalar field, so `𝕜 = ℝ` and `𝕜 = ℂ` are the same
+theorem.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory
+
+variable {𝕜 : Type*} [RCLike 𝕜] {ι : Type*} [Fintype ι]
+
+/-- The coordinates of `f` in the multi-index Hermite-function basis are its inner products
+against the tensors `Ψ_a = ∏ᵢ ψ_{aᵢ}`. -/
+@[simp]
+theorem hermiteFunctionPiBasis_repr_apply
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (volume : Measure ℝ))) (a : ι → ℕ) :
+    (hermiteFunctionPiBasis 𝕜 ι).repr f a
+      = inner 𝕜 (L2piMul fun i => hermiteFunctionLp 𝕜 (a i)) f := by
+  simpa using (hermiteFunctionPiBasis 𝕜 ι).repr_apply_apply f a
+
+/-- The integrand of the coordinate integral below is integrable: it is the pointwise inner product
+of two `L²` functions. -/
+theorem integrable_prod_hermiteFunction_mul
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (volume : Measure ℝ))) (a : ι → ℕ) :
+    Integrable (fun x : ι → ℝ => (∏ i, (algebraMap ℝ 𝕜) (hermiteFunction (a i) (x i))) * f x)
+      (Measure.pi fun _ : ι => (volume : Measure ℝ)) := by
+  refine (MeasureTheory.L2.integrable_inner (𝕜 := 𝕜) (hermiteFunctionPiBasis 𝕜 ι a) f).congr ?_
+  filter_upwards [coeFn_hermiteFunctionPiBasis 𝕜 ι a] with x hx
+  rw [hx]
+  simp [RCLike.algebraMap_eq_ofReal, map_prod, mul_comm]
+
+/-- The `a`-th multi-index Hermite coordinate of `f`, as an integral of `f` against the product
+`∏ᵢ ψ_{aᵢ}(xᵢ)`. The Hermite functions are real, so no complex conjugate survives. -/
+theorem hermiteFunctionPiBasis_repr_eq_integral
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (volume : Measure ℝ))) (a : ι → ℕ) :
+    (hermiteFunctionPiBasis 𝕜 ι).repr f a
+      = ∫ x : ι → ℝ, (∏ i, (algebraMap ℝ 𝕜) (hermiteFunction (a i) (x i))) * f x
+          ∂(Measure.pi fun _ : ι => (volume : Measure ℝ)) := by
+  rw [(hermiteFunctionPiBasis 𝕜 ι).repr_apply_apply, MeasureTheory.L2.inner_def]
+  refine integral_congr_ae ?_
+  filter_upwards [coeFn_hermiteFunctionPiBasis 𝕜 ι a] with x hx
+  rw [hx]
+  simp [RCLike.algebraMap_eq_ofReal, map_prod, mul_comm]
+
+/-- **The multi-index coordinates of a product function factor.** If `f(x) = ∏ᵢ Fᵢ(xᵢ)` then its
+`a`-th multi-index Hermite coordinate is the product of the `aᵢ`-th one-dimensional Hermite
+coordinates of the factors — the statement that makes a multidimensional Hermite expansion of a
+product function computable from one-dimensional ones. -/
+theorem hermiteFunctionPiBasis_repr_L2piMul
+    (F : ι → Lp 𝕜 2 (volume : Measure ℝ)) (a : ι → ℕ) :
+    (hermiteFunctionPiBasis 𝕜 ι).repr (L2piMul F) a
+      = ∏ i, inner 𝕜 (hermiteFunctionLp 𝕜 (a i)) (F i) := by
+  rw [hermiteFunctionPiBasis_repr_apply, inner_L2piMul]
+
+/-- **Parseval's identity for the multi-index Hermite basis** (polarized form): the multi-index
+Hermite coordinates of `f` and `g` pair to their inner product. -/
+theorem tsum_inner_mul_inner_L2piMul_hermiteFunctionLp
+    (f g : Lp 𝕜 2 (Measure.pi fun _ : ι => (volume : Measure ℝ))) :
+    ∑' a : ι → ℕ, inner 𝕜 f (L2piMul fun i => hermiteFunctionLp 𝕜 (a i))
+        * inner 𝕜 (L2piMul fun i => hermiteFunctionLp 𝕜 (a i)) g = inner 𝕜 f g := by
+  simpa using (hermiteFunctionPiBasis 𝕜 ι).tsum_inner_mul_inner f g
+
+/-- **Parseval's identity for the multi-index Hermite basis** (norm-square form): the squared
+multi-index Hermite coordinates of `f` sum to `‖f‖²`. -/
+theorem tsum_norm_sq_inner_L2piMul_hermiteFunctionLp
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (volume : Measure ℝ))) :
+    ∑' a : ι → ℕ, ‖inner 𝕜 (L2piMul fun i => hermiteFunctionLp 𝕜 (a i)) f‖ ^ 2 = ‖f‖ ^ 2 := by
+  simpa using (hermiteFunctionPiBasis 𝕜 ι).tsum_norm_sq_inner f
+
+/-- The squared multi-index Hermite coordinate family of an `L²(ℝ^ι)` function is summable. -/
+theorem summable_norm_sq_inner_L2piMul_hermiteFunctionLp
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (volume : Measure ℝ))) :
+    Summable fun a : ι → ℕ => ‖inner 𝕜 (L2piMul fun i => hermiteFunctionLp 𝕜 (a i)) f‖ ^ 2 := by
+  simpa using (hermiteFunctionPiBasis 𝕜 ι).summable_norm_sq_inner f
+
+/-- **The multi-index Hermite expansion.** Every `f ∈ L²(ℝ^ι)` is the sum of its multi-index
+Hermite series, summed over multi-indices `a : ι → ℕ` in the unordered sense. -/
+theorem hasSum_L2piMul_hermiteFunctionLp_expansion
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (volume : Measure ℝ))) :
+    HasSum (fun a : ι → ℕ => inner 𝕜 (L2piMul fun i => hermiteFunctionLp 𝕜 (a i)) f
+      • L2piMul fun i => hermiteFunctionLp 𝕜 (a i)) f := by
+  simpa using (hermiteFunctionPiBasis 𝕜 ι).hasSum_repr f
+
+end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Pi/Parseval.lean
@@ -85,7 +85,12 @@ theorem hermiteFunctionPiBasis_repr_eq_integral
 /-- **The multi-index coordinates of a product function factor.** If `f(x) = ∏ᵢ Fᵢ(xᵢ)` then its
 `a`-th multi-index Hermite coordinate is the product of the `aᵢ`-th one-dimensional Hermite
 coordinates of the factors — the statement that makes a multidimensional Hermite expansion of a
-product function computable from one-dimensional ones. -/
+product function computable from one-dimensional ones.
+
+Unlike its generic source `TauCeti.piHilbertBasis_repr_L2piMul` and its Gaussian sibling
+`TauCeti.gaussianHermitePiBasis_repr_L2piMul`, this is not a `simp` lemma: `simp` already
+factors this coordinate, through `TauCeti.hermiteFunctionPiBasis_repr_apply` and
+`TauCeti.inner_L2piMul`. -/
 theorem hermiteFunctionPiBasis_repr_L2piMul
     (F : ι → Lp 𝕜 2 (volume : Measure ℝ)) (a : ι → ℕ) :
     (hermiteFunctionPiBasis 𝕜 ι).repr (L2piMul F) a

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Basis.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Basis.lean
@@ -31,6 +31,8 @@ exactly the statement the roadmap asks for.
 ## Main statements
 
 * `TauCeti.gaussianHermitePiBasis` — the multi-index basis.
+* `TauCeti.gaussianHermitePiBasis_apply` — the `a`-th vector is the tensor `TauCeti.L2piMul` of the
+  one-dimensional Gaussian Hermite vectors, as an equality of `L²` vectors.
 * `TauCeti.coeFn_gaussianHermitePiBasis` — the anti-vacuity pin: the `a`-th vector really is the
   product `∏ᵢ H_{aᵢ}(xᵢ)/√(aᵢ!)`.
 * `TauCeti.sqrt_prod_gaussianPDFReal_smul_gaussianHermitePiBasis`: scaling the `a`-th vector by
@@ -52,6 +54,15 @@ Hermite basis in every coordinate. -/
 noncomputable def gaussianHermitePiBasis :
     HilbertBasis (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) :=
   piHilbertBasis fun _ => gaussianHermiteHilbertBasis 𝕜
+
+/-- **The `a`-th basis vector is the tensor of the one-dimensional Gaussian Hermite vectors.**
+Stated between `L²` vectors, this is what the expansion API rewrites with, since the inner product
+against a tensor factors coordinatewise (`TauCeti.inner_L2piMul`);
+`TauCeti.coeFn_gaussianHermitePiBasis` below refines it to a pointwise product of polynomials. -/
+@[simp]
+theorem gaussianHermitePiBasis_apply (a : ι → ℕ) :
+    gaussianHermitePiBasis 𝕜 ι a = L2piMul fun i => gaussianHermiteHilbertBasis 𝕜 (a i) := by
+  rw [gaussianHermitePiBasis, piHilbertBasis_apply]
 
 /-- **The basis vectors are the multi-index Hermite products.** Without this the construction would
 only exhibit *some* Hilbert basis of `L²(γ^ι)`. The coordinatewise identification transfers to the

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Parseval.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Parseval.lean
@@ -82,6 +82,7 @@ theorem gaussianHermitePiBasis_repr_apply
 one-dimensional `L²(N(0, 1))` factors `Fᵢ`, its `a`-th multivariate Hermite coordinate is the
 product of the `aᵢ`-th one-dimensional Hermite coordinates of the factors: a multivariate chaos
 expansion of a product of independent variables is computable from one-dimensional ones. -/
+@[simp]
 theorem gaussianHermitePiBasis_repr_L2piMul
     (F : ι → Lp 𝕜 2 (gaussianReal 0 1)) (a : ι → ℕ) :
     (gaussianHermitePiBasis 𝕜 ι).repr (L2piMul F) a

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Parseval.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Parseval.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Probability.Distributions.Gaussian.Hermite.Parseval
+public import TauCeti.Probability.Distributions.Gaussian.Hermite.Pi.Basis
+
+/-!
+# Parseval and expansions for the multivariate Gaussian Hermite basis
+
+`TauCeti.gaussianHermitePiBasis` exhibits the multi-index Hermite products
+`Ψ_a(x) = ∏ᵢ H_{aᵢ}(xᵢ)/√(aᵢ!)` as a Hilbert basis of `L²(γ^ι)`, `γ = N(0, 1)`. This file supplies
+the coefficient, Parseval, and reconstruction API for that basis: the expansion of an `L²` function
+of `ι` independent standard Gaussians into multivariate Hermite polynomials, the finite-dimensional
+form of a chaos expansion. It is the `Fintype`-indexed analogue of
+`TauCeti.hasSum_gaussianHermite_expansion` and its neighbours.
+
+As in one dimension the coefficient has no name of its own: it is spelled out as the integral
+against `∏ᵢ H_{aᵢ}/√(aᵢ!)`, and the Parseval-side lemmas are named after that integral.
+
+Two lemmas are genuinely multidimensional rather than transported. The coordinate theorem
+`TauCeti.gaussianHermitePiBasis_repr_apply` writes the abstract `HilbertBasis.repr` coordinate as
+an integral over `ℝ^ι`, and `TauCeti.gaussianHermitePiBasis_repr_L2piMul` factors the coordinates
+of a product function into the one-dimensional coordinates of its factors — the coordinate form of
+the tensor inner-product identity `TauCeti.inner_L2piMul`.
+
+## Main statements
+
+* `TauCeti.gaussianHermitePiBasis_repr_apply` identifies each coordinate with its integral, whose
+  integrand is integrable by `TauCeti.integrable_prod_hermite_div_sqrt_factorial_mul`.
+* `TauCeti.gaussianHermitePiBasis_repr_L2piMul` factors the coordinates of a product function.
+* `TauCeti.tsum_norm_sq_integral_prod_hermite_mul_pi_gaussianReal` is Parseval's identity for those
+  coefficients.
+* `TauCeti.summable_norm_sq_integral_prod_hermite_mul_pi_gaussianReal` gives square-summability of
+  the coefficients.
+* `TauCeti.hasSum_gaussianHermitePi_expansion` reconstructs every `L²(γ^ι)` vector from its
+  multivariate Hermite series.
+
+All statements hold for an arbitrary `RCLike` scalar field, simultaneously covering real and
+complex-valued `L²` functions.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Polynomial ProbabilityTheory
+
+variable {𝕜 : Type*} [RCLike 𝕜] {ι : Type*} [Fintype ι]
+
+/-- The integrand of the coordinate integral below is integrable: it is the pointwise inner product
+of two `L²` functions. -/
+theorem integrable_prod_hermite_div_sqrt_factorial_mul
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) (a : ι → ℕ) :
+    Integrable (fun x : ι → ℝ => (∏ i, (algebraMap ℝ 𝕜)
+      (aeval (x i) (hermite (a i)) / Real.sqrt ((a i).factorial : ℝ))) * f x)
+        (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ)) := by
+  refine (MeasureTheory.L2.integrable_inner (𝕜 := 𝕜) (gaussianHermitePiBasis 𝕜 ι a) f).congr ?_
+  filter_upwards [coeFn_gaussianHermitePiBasis 𝕜 ι a] with x hx
+  rw [hx]
+  simp [RCLike.algebraMap_eq_ofReal, map_prod, mul_comm]
+
+/-- The `a`-th multivariate Gaussian Hermite coordinate of `f` is the integral of `f` against the
+normalized multi-index Hermite product `∏ᵢ H_{aᵢ}(xᵢ)/√(aᵢ!)`. The polynomials are real, so no
+complex conjugate survives. -/
+@[simp]
+theorem gaussianHermitePiBasis_repr_apply
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) (a : ι → ℕ) :
+    (gaussianHermitePiBasis 𝕜 ι).repr f a
+      = ∫ x : ι → ℝ, (∏ i, (algebraMap ℝ 𝕜)
+          (aeval (x i) (hermite (a i)) / Real.sqrt ((a i).factorial : ℝ))) * f x
+            ∂(Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ)) := by
+  rw [(gaussianHermitePiBasis 𝕜 ι).repr_apply_apply, MeasureTheory.L2.inner_def]
+  refine integral_congr_ae ?_
+  filter_upwards [coeFn_gaussianHermitePiBasis 𝕜 ι a] with x hx
+  rw [hx]
+  simp [RCLike.algebraMap_eq_ofReal, map_prod, mul_comm]
+
+/-- **The multi-index coordinates of a product function factor.** If `f(x) = ∏ᵢ Fᵢ(xᵢ)` for
+one-dimensional `L²(N(0, 1))` factors `Fᵢ`, its `a`-th multivariate Hermite coordinate is the
+product of the `aᵢ`-th one-dimensional Hermite coordinates of the factors: a multivariate chaos
+expansion of a product of independent variables is computable from one-dimensional ones. -/
+theorem gaussianHermitePiBasis_repr_L2piMul
+    (F : ι → Lp 𝕜 2 (gaussianReal 0 1)) (a : ι → ℕ) :
+    (gaussianHermitePiBasis 𝕜 ι).repr (L2piMul F) a
+      = ∏ i, ∫ x : ℝ, (algebraMap ℝ 𝕜)
+          (aeval x (hermite (a i)) / Real.sqrt ((a i).factorial : ℝ)) * F i x
+            ∂(gaussianReal 0 1) := by
+  rw [(gaussianHermitePiBasis 𝕜 ι).repr_apply_apply, gaussianHermitePiBasis_apply, inner_L2piMul]
+  exact Finset.prod_congr rfl fun i _ => by
+    rw [← HilbertBasis.repr_apply_apply, gaussianHermiteHilbertBasis_repr_apply]
+
+/-- **Parseval's identity for the multivariate Gaussian Hermite basis.** The squared coefficients
+of `f` against the multi-index Hermite products sum to `‖f‖²`. -/
+theorem tsum_norm_sq_integral_prod_hermite_mul_pi_gaussianReal
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) :
+    ∑' a : ι → ℕ, ‖∫ x : ι → ℝ, (∏ i, (algebraMap ℝ 𝕜)
+      (aeval (x i) (hermite (a i)) / Real.sqrt ((a i).factorial : ℝ))) * f x
+        ∂(Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))‖ ^ 2 = ‖f‖ ^ 2 := by
+  simpa only [← HilbertBasis.repr_apply_apply, gaussianHermitePiBasis_repr_apply] using
+    (gaussianHermitePiBasis 𝕜 ι).tsum_norm_sq_inner f
+
+/-- The squared multivariate Gaussian Hermite coefficients of an `L²(γ^ι)` function are
+summable. -/
+theorem summable_norm_sq_integral_prod_hermite_mul_pi_gaussianReal
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) :
+    Summable fun a : ι → ℕ => ‖∫ x : ι → ℝ, (∏ i, (algebraMap ℝ 𝕜)
+      (aeval (x i) (hermite (a i)) / Real.sqrt ((a i).factorial : ℝ))) * f x
+        ∂(Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))‖ ^ 2 := by
+  simpa only [← HilbertBasis.repr_apply_apply, gaussianHermitePiBasis_repr_apply] using
+    (gaussianHermitePiBasis 𝕜 ι).summable_norm_sq_inner f
+
+/-- **The multivariate Gaussian Hermite expansion.** Every `f ∈ L²(γ^ι; 𝕜)` is the sum of its
+multi-index Hermite series, summed over multi-indices `a : ι → ℕ` in the unordered sense. -/
+theorem hasSum_gaussianHermitePi_expansion
+    (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) :
+    HasSum (fun a : ι → ℕ =>
+      (∫ x : ι → ℝ, (∏ i, (algebraMap ℝ 𝕜)
+        (aeval (x i) (hermite (a i)) / Real.sqrt ((a i).factorial : ℝ))) * f x
+          ∂(Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) •
+            gaussianHermitePiBasis 𝕜 ι a) f := by
+  simpa only [gaussianHermitePiBasis_repr_apply] using (gaussianHermitePiBasis 𝕜 ι).hasSum_repr f
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Parseval.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Parseval.lean
@@ -21,16 +21,15 @@ form of a chaos expansion. It is the `Fintype`-indexed analogue of
 As in one dimension the coefficient has no name of its own: it is spelled out as the integral
 against `∏ᵢ H_{aᵢ}/√(aᵢ!)`, and the Parseval-side lemmas are named after that integral.
 
-Two lemmas are genuinely multidimensional rather than transported. The coordinate theorem
-`TauCeti.gaussianHermitePiBasis_repr_apply` writes the abstract `HilbertBasis.repr` coordinate as
-an integral over `ℝ^ι`, and `TauCeti.gaussianHermitePiBasis_repr_L2piMul` factors the coordinates
-of a product function into the one-dimensional coordinates of its factors — the coordinate form of
-the tensor inner-product identity `TauCeti.inner_L2piMul`.
+At this arity the file additionally gives the coordinate as an integral, proves that its integrand
+is integrable, and specializes `TauCeti.piHilbertBasis_repr_L2piMul` to factor the coordinates of a
+product function into the one-dimensional coordinates of its factors.
 
 ## Main statements
 
 * `TauCeti.gaussianHermitePiBasis_repr_apply` identifies each coordinate with its integral, whose
-  integrand is integrable by `TauCeti.integrable_prod_hermite_div_sqrt_factorial_mul`.
+  integrand is integrable by
+  `TauCeti.integrable_prod_hermite_div_sqrt_factorial_mul_pi_gaussianReal`.
 * `TauCeti.gaussianHermitePiBasis_repr_L2piMul` factors the coordinates of a product function.
 * `TauCeti.tsum_norm_sq_integral_prod_hermite_mul_pi_gaussianReal` is Parseval's identity for those
   coefficients.
@@ -53,20 +52,19 @@ variable {𝕜 : Type*} [RCLike 𝕜] {ι : Type*} [Fintype ι]
 
 /-- The integrand of the coordinate integral below is integrable: it is the pointwise inner product
 of two `L²` functions. -/
-theorem integrable_prod_hermite_div_sqrt_factorial_mul
+theorem integrable_prod_hermite_div_sqrt_factorial_mul_pi_gaussianReal
     (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) (a : ι → ℕ) :
     Integrable (fun x : ι → ℝ => (∏ i, (algebraMap ℝ 𝕜)
       (aeval (x i) (hermite (a i)) / Real.sqrt ((a i).factorial : ℝ))) * f x)
         (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ)) := by
-  refine (MeasureTheory.L2.integrable_inner (𝕜 := 𝕜) (gaussianHermitePiBasis 𝕜 ι a) f).congr ?_
-  filter_upwards [coeFn_gaussianHermitePiBasis 𝕜 ι a] with x hx
-  rw [hx]
-  simp [RCLike.algebraMap_eq_ofReal, map_prod, mul_comm]
+  refine (integrable_L2piMul_mul (fun i => gaussianHermiteHilbertBasis 𝕜 (a i)) f).congr ?_
+  filter_upwards [coeFn_L2piMul (fun i => gaussianHermiteHilbertBasis 𝕜 (a i)),
+    coeFn_gaussianHermitePiBasis 𝕜 ι a] with x hprod hexplicit
+  rw [← hprod, ← gaussianHermitePiBasis_apply, hexplicit]
 
 /-- The `a`-th multivariate Gaussian Hermite coordinate of `f` is the integral of `f` against the
 normalized multi-index Hermite product `∏ᵢ H_{aᵢ}(xᵢ)/√(aᵢ!)`. The polynomials are real, so no
 complex conjugate survives. -/
-@[simp]
 theorem gaussianHermitePiBasis_repr_apply
     (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) (a : ι → ℕ) :
     (gaussianHermitePiBasis 𝕜 ι).repr f a
@@ -89,9 +87,14 @@ theorem gaussianHermitePiBasis_repr_L2piMul
       = ∏ i, ∫ x : ℝ, (algebraMap ℝ 𝕜)
           (aeval x (hermite (a i)) / Real.sqrt ((a i).factorial : ℝ)) * F i x
             ∂(gaussianReal 0 1) := by
-  rw [(gaussianHermitePiBasis 𝕜 ι).repr_apply_apply, gaussianHermitePiBasis_apply, inner_L2piMul]
-  exact Finset.prod_congr rfl fun i _ => by
-    rw [← HilbertBasis.repr_apply_apply, gaussianHermiteHilbertBasis_repr_apply]
+  rw [HilbertBasis.repr_apply_apply, gaussianHermitePiBasis_apply]
+  calc
+    inner 𝕜 (L2piMul fun i => gaussianHermiteHilbertBasis 𝕜 (a i)) (L2piMul F)
+        = ∏ i, (gaussianHermiteHilbertBasis 𝕜).repr (F i) (a i) := by
+          simpa only [HilbertBasis.repr_apply_apply, piHilbertBasis_apply] using
+            piHilbertBasis_repr_L2piMul (fun _ : ι => gaussianHermiteHilbertBasis 𝕜) F a
+    _ = _ := Finset.prod_congr rfl fun i _ => by
+      rw [gaussianHermiteHilbertBasis_repr_apply]
 
 /-- **Parseval's identity for the multivariate Gaussian Hermite basis.** The squared coefficients
 of `f` against the multi-index Hermite products sum to `‖f‖²`. -/
@@ -119,9 +122,10 @@ theorem hasSum_gaussianHermitePi_expansion
     (f : Lp 𝕜 2 (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) :
     HasSum (fun a : ι → ℕ =>
       (∫ x : ι → ℝ, (∏ i, (algebraMap ℝ 𝕜)
-        (aeval (x i) (hermite (a i)) / Real.sqrt ((a i).factorial : ℝ))) * f x
+          (aeval (x i) (hermite (a i)) / Real.sqrt ((a i).factorial : ℝ))) * f x
           ∂(Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) •
-            gaussianHermitePiBasis 𝕜 ι a) f := by
-  simpa only [gaussianHermitePiBasis_repr_apply] using (gaussianHermitePiBasis 𝕜 ι).hasSum_repr f
+            L2piMul fun i => gaussianHermiteHilbertBasis 𝕜 (a i)) f := by
+  simpa only [gaussianHermitePiBasis_repr_apply, gaussianHermitePiBasis_apply] using
+    (gaussianHermitePiBasis 𝕜 ι).hasSum_repr f
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Parseval.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Parseval.lean
@@ -31,6 +31,7 @@ product function into the one-dimensional coordinates of its factors.
   integrand is integrable by
   `TauCeti.integrable_prod_hermite_div_sqrt_factorial_mul_pi_gaussianReal`.
 * `TauCeti.gaussianHermitePiBasis_repr_L2piMul` factors the coordinates of a product function.
+* `TauCeti.tsum_inner_mul_inner_L2piMul_gaussianHermiteHilbertBasis` is Parseval in polarized form.
 * `TauCeti.tsum_norm_sq_integral_prod_hermite_mul_pi_gaussianReal` is Parseval's identity for those
   coefficients.
 * `TauCeti.summable_norm_sq_integral_prod_hermite_mul_pi_gaussianReal` gives square-summability of
@@ -95,6 +96,15 @@ theorem gaussianHermitePiBasis_repr_L2piMul
             piHilbertBasis_repr_L2piMul (fun _ : ι => gaussianHermiteHilbertBasis 𝕜) F a
     _ = _ := Finset.prod_congr rfl fun i _ => by
       rw [gaussianHermiteHilbertBasis_repr_apply]
+
+/-- **Parseval's identity for the multivariate Gaussian Hermite basis** (polarized form): the
+multi-index Gaussian Hermite coordinates of `f` and `g` pair to their inner product. -/
+theorem tsum_inner_mul_inner_L2piMul_gaussianHermiteHilbertBasis
+    (f g : Lp 𝕜 2 (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))) :
+    ∑' a : ι → ℕ, inner 𝕜 f (L2piMul fun i => gaussianHermiteHilbertBasis 𝕜 (a i))
+        * inner 𝕜 (L2piMul fun i => gaussianHermiteHilbertBasis 𝕜 (a i)) g = inner 𝕜 f g := by
+  simpa only [gaussianHermitePiBasis_apply] using
+    (gaussianHermitePiBasis 𝕜 ι).tsum_inner_mul_inner f g
 
 /-- **Parseval's identity for the multivariate Gaussian Hermite basis.** The squared coefficients
 of `f` against the multi-index Hermite products sum to `‖f‖²`. -/


### PR DESCRIPTION
This PR gives the two multidimensional Hermite Hilbert bases the coefficient, Parseval, summability and reconstruction API that every one-dimensional basis on this roadmap already has. The milestone served is Part D of `OrthogonalL2Bases`, whose targets `hermiteFunctionPiBasis` (`HilbertBasis (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi fun _ => volume))`, the `B3 ∘ A` instantiation) and `gaussianHermitePiBasis` (`HilbertBasis (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi fun _ => gaussianReal 0 1))`, "the standard basis for multivariate Gaussian L² / chaos expansions") landed as bundled bases with their `coe_*` pins, but with no way to expand a function against them: Part A3 has `hasSum_hermiteFunctionLp_expansion`, A3′ has `hasSum_gaussianHermite_expansion` and Part C has its Chebyshev counterpart, while the `Π i, ℕ`-indexed bases Part D calls for had none. After this PR the multi-index bases are usable exactly like the one-dimensional ones; what remains in this corner of the roadmap is the same packaging for the multi-index Chebyshev basis, whose construction is already in flight in TauCeti#2185.

Two lemmas here are genuinely multidimensional rather than transported. Each basis first gets an `L²`-vector-level pin, `hermiteFunctionPiBasis_apply` and `gaussianHermitePiBasis_apply`, identifying its `a`-th vector with the tensor `L2piMul` of the one-dimensional vectors — the existing `coeFn_*` pins are a.e. statements about representatives and cannot be rewritten with inside an inner product. Through them the coordinates factor: `hermiteFunctionPiBasis_repr_L2piMul` and `gaussianHermitePiBasis_repr_L2piMul` say that on a function which is itself a product `∏ᵢ Fᵢ(xᵢ)`, the multi-index coordinate at `a` is the product of the `aᵢ`-th one-dimensional coordinates of the factors, which is the coordinate form of the existing tensor identity `inner_L2piMul` and the step that makes a multivariate expansion computable from one-dimensional ones. The remaining statements are the coordinate integrals over `ℝ^ι` (with the integrability of their integrands, so the `∫` is not a junk value), Parseval in polarized and norm-square form, square-summability of the coefficients, and the expansions themselves, summed over multi-indices in the unordered `HasSum` sense; all of them hold for an arbitrary `RCLike` scalar field, so `ℝ` and `ℂ` are one theorem, as the roadmap's generality bar requires.

Adding a `Pi*.lean` sibling to each existing `PiBasis.lean` triggers the repository's directory rule, so both modules move as they gain one; only imports and module headers change, and no declaration is renamed:

| old module | new module |
| --- | --- |
| `TauCeti.Analysis.SpecialFunctions.Hermite.Function.PiBasis` | `TauCeti.Analysis.SpecialFunctions.Hermite.Function.Pi.Basis` |
| `TauCeti.Probability.Distributions.Gaussian.Hermite.PiBasis` | `TauCeti.Probability.Distributions.Gaussian.Hermite.Pi.Basis` |

Nothing in the repository imported either module, so the moves need no other edits. No Mathlib infrastructure was vendored; the proofs go through Mathlib's `HilbertBasis.repr_apply_apply`, `MeasureTheory.L2.inner_def` and `MeasureTheory.L2.integrable_inner`, and through this repository's `inner_L2piMul`, `HilbertBasis.tsum_norm_sq_inner` and the one-dimensional coordinate lemmas.

Roadmap: OrthogonalL2Bases

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"hermite-pi-basis-expansion"}-->

🤖 Prepared with Claude Code
