### PR TITLE
feat: package Quillen exact structures

### DIFF
--- a/TauCeti/CategoryTheory/Exact/ExactStructure.lean
+++ b/TauCeti/CategoryTheory/Exact/ExactStructure.lean
@@ -6,8 +6,7 @@ Authors: Codex
 module
 
 public import TauCeti.CategoryTheory.Exact.KernelCokernelPair
-public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.IsPullback.Defs
-public import Mathlib.CategoryTheory.MorphismProperty.Composition
+public import Mathlib.CategoryTheory.MorphismProperty.Limits
 public import Mathlib.CategoryTheory.ObjectProperty.ClosedUnderIsomorphisms
 
 /-!
@@ -40,15 +39,11 @@ under isomorphisms in Mathlib's sense, and the inflations and the deflations are
 conflations makes the inflations and the deflations
 `CategoryTheory.MorphismProperty.RespectsIso`, and E0/E0op and E1/E1op are recorded as
 `CategoryTheory.MorphismProperty.ContainsIdentities` and
-`CategoryTheory.MorphismProperty.IsStableUnderComposition` instances.
-
-E2 and E2op cannot be phrased through Mathlib's
-`CategoryTheory.MorphismProperty.IsStableUnderCobaseChange` and its dual: those classes assume
-a square is already known to be a pushout, whereas Quillen's axioms *assert the existence* of
-the pushout of an inflation along an arbitrary morphism, in a category with no pushouts to
-speak of otherwise. They are therefore existential fields, as
-`CategoryTheory.Pretriangulated.distinguished_cocone_triangle` is. Deducing stability under
-cobase change from E2 belongs to the inflation--deflation calculus built on this file.
+`CategoryTheory.MorphismProperty.IsStableUnderComposition` instances. E2/E2op are recorded by
+the corresponding property-specific `HasPushouts`/`HasPullbacks` and
+`IsStableUnderCobaseChange`/`IsStableUnderBaseChange` classes. These assert existence only for
+pushouts of inflations and pullbacks of deflations, without requiring arbitrary pushouts or
+pullbacks in the ambient category.
 
 ## References
 
@@ -59,7 +54,7 @@ cobase change from E2 belongs to the inflation--deflation calculus built on this
   formalization, fixes the design followed here: the `ConflationClass`/`ExactStructure`
   split, the E0/E0op, E1/E1op, E2/E2op fields, and the derived inflation and deflation
   predicates are its. This file replaces its bespoke `PushoutWitness` and `PullbackWitness`
-  by `CategoryTheory.IsPushout` and `CategoryTheory.IsPullback`, and its pair of composable
+  by Mathlib's property-specific pushout and pullback classes, and its pair of composable
   morphisms by a `CategoryTheory.ShortComplex`.
 -/
 
@@ -182,7 +177,8 @@ end ConflationClass
 /-- A Quillen exact structure on an additive category, in the self-dual E0/E1/E2
 presentation.
 
-The E2 fields provide genuine universal squares. No ambient pushouts or pullbacks are assumed. -/
+The E2 fields provide genuine universal squares through Mathlib's pushout and pullback APIs. No
+ambient pushouts or pullbacks are assumed. -/
 structure ExactStructure (C : Type u) [Category.{v} C] [Preadditive C] [HasZeroObject C]
     [HasBinaryBiproducts C] extends ConflationClass C where
   /-- E0: identity morphisms are inflations. -/
@@ -197,16 +193,15 @@ structure ExactStructure (C : Type u) [Category.{v} C] [Preadditive C] [HasZeroO
   isDeflation_comp : ∀ {X Y Z : C} (p : X ⟶ Y) (q : Y ⟶ Z),
     toConflationClass.IsDeflation p → toConflationClass.IsDeflation q →
       toConflationClass.IsDeflation (p ≫ q)
-  /-- E2: the pushout of an inflation along any morphism exists, and its other leg is an
-  inflation. -/
-  pushout_isInflation : ∀ {X Y : C} (i : X ⟶ Y), toConflationClass.IsInflation i →
-    ∀ {X' : C} (f : X ⟶ X'), ∃ (Y' : C) (g : Y ⟶ Y') (i' : X' ⟶ Y'),
-      IsPushout i f g i' ∧ toConflationClass.IsInflation i'
-  /-- E2op: the pullback of a deflation along any morphism exists, and its other leg is a
-  deflation. -/
-  pullback_isDeflation : ∀ {X Y : C} (p : X ⟶ Y), toConflationClass.IsDeflation p →
-    ∀ {Y' : C} (f : Y' ⟶ Y), ∃ (X' : C) (p' : X' ⟶ Y') (g : X' ⟶ X),
-      IsPullback p' g f p ∧ toConflationClass.IsDeflation p'
+  /-- E2 existence: pushouts of inflations along arbitrary morphisms exist. -/
+  hasPushouts_inflations : toConflationClass.inflations.HasPushouts
+  /-- E2 stability: every cobase change of an inflation is an inflation. -/
+  isStableUnderCobaseChange_inflations :
+    toConflationClass.inflations.IsStableUnderCobaseChange
+  /-- E2op existence: pullbacks of deflations along arbitrary morphisms exist. -/
+  hasPullbacks_deflations : toConflationClass.deflations.HasPullbacks
+  /-- E2op stability: every base change of a deflation is a deflation. -/
+  isStableUnderBaseChange_deflations : toConflationClass.deflations.IsStableUnderBaseChange
 
 namespace ExactStructure
 
@@ -244,6 +239,20 @@ instance (E : ExactStructure C) : E.inflations.IsStableUnderComposition where
 /-- E1op, as the statement that the deflations are stable under composition. -/
 instance (E : ExactStructure C) : E.deflations.IsStableUnderComposition where
   comp_mem := E.isDeflation_comp
+
+/-- E2 existence, as property-specific availability of pushouts. -/
+instance (E : ExactStructure C) : E.inflations.HasPushouts := E.hasPushouts_inflations
+
+/-- E2 stability, as stability of inflations under cobase change. -/
+instance (E : ExactStructure C) : E.inflations.IsStableUnderCobaseChange :=
+  E.isStableUnderCobaseChange_inflations
+
+/-- E2op existence, as property-specific availability of pullbacks. -/
+instance (E : ExactStructure C) : E.deflations.HasPullbacks := E.hasPullbacks_deflations
+
+/-- E2op stability, as stability of deflations under base change. -/
+instance (E : ExactStructure C) : E.deflations.IsStableUnderBaseChange :=
+  E.isStableUnderBaseChange_deflations
 
 end ExactStructure
 

--- a/TauCeti/CategoryTheory/Exact/ExactStructure.lean
+++ b/TauCeti/CategoryTheory/Exact/ExactStructure.lean
@@ -7,6 +7,8 @@ module
 
 public import TauCeti.CategoryTheory.Exact.KernelCokernelPair
 public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.IsPullback.Defs
+public import Mathlib.CategoryTheory.MorphismProperty.Composition
+public import Mathlib.CategoryTheory.ObjectProperty.ClosedUnderIsomorphisms
 
 /-!
 # Exact structures
@@ -24,15 +26,39 @@ constructed separately.
 ## Main definitions
 
 * `TauCeti.ConflationClass` is an isomorphism-closed class of kernel--cokernel pairs.
-* `TauCeti.ConflationClass.IsInflation` and `TauCeti.ConflationClass.IsDeflation` say that a
-  morphism occurs as the first or second map of a conflation.
+* `TauCeti.ConflationClass.inflations` and `TauCeti.ConflationClass.deflations` are the
+  `CategoryTheory.MorphismProperty` of morphisms occurring as the first, resp. second, map of a
+  conflation. `TauCeti.ConflationClass.IsInflation` and `TauCeti.ConflationClass.IsDeflation`
+  are the corresponding predicates on a single morphism.
 * `TauCeti.ExactStructure` equips a conflation class with E0/E0op, E1/E1op, and E2/E2op.
+
+## Implementation notes
+
+The conflations are a `CategoryTheory.ObjectProperty (CategoryTheory.ShortComplex C)` closed
+under isomorphisms in Mathlib's sense, and the inflations and the deflations are each a
+`CategoryTheory.MorphismProperty`, so that the generic API applies: E0/E0op and E1/E1op are
+recorded as `CategoryTheory.MorphismProperty.ContainsIdentities` and
+`CategoryTheory.MorphismProperty.IsStableUnderComposition` instances.
+
+E2 and E2op cannot be phrased through Mathlib's
+`CategoryTheory.MorphismProperty.IsStableUnderCobaseChange` and its dual: those classes assume
+a square is already known to be a pushout, whereas Quillen's axioms *assert the existence* of
+the pushout of an inflation along an arbitrary morphism, in a category with no pushouts to
+speak of otherwise. They are therefore existential fields, as
+`CategoryTheory.Pretriangulated.distinguished_cocone_triangle` is. Deducing stability under
+cobase change from E2 belongs to the inflation--deflation calculus built on this file.
 
 ## References
 
 * Theo Bühler, *Exact categories*, Expositiones Mathematicae **28** (2010), 1--69,
   <https://arxiv.org/abs/0811.1480>. Definition 2.1 and Remarks 2.2--2.8 give the axioms used
   here.
+* `TauCetiRoadmap/GrothendieckEulerForms/Suggested.lean`, the human-authored roadmap
+  formalization, fixes the design followed here: the `ConflationClass`/`ExactStructure`
+  split, the E0/E0op, E1/E1op, E2/E2op fields, and the derived inflation and deflation
+  predicates are its. This file replaces its bespoke `PushoutWitness` and `PullbackWitness`
+  by `CategoryTheory.IsPushout` and `CategoryTheory.IsPullback`, and its pair of composable
+  morphisms by a `CategoryTheory.ShortComplex`.
 -/
 
 public section
@@ -50,11 +76,13 @@ variable {C : Type u} [Category.{v} C] [Preadditive C]
 This is the relation underlying an exact structure, before imposing the Quillen axioms. -/
 structure ConflationClass (C : Type u) [Category.{v} C] [Preadditive C] where
   /-- The distinguished short complexes. -/
-  Conflation : ShortComplex C → Prop
+  Conflation : ObjectProperty (ShortComplex C)
   /-- Every conflation is a kernel--cokernel pair. -/
   isKernelCokernelPair : ∀ S, Conflation S → IsKernelCokernelPair S
   /-- The class of conflations is closed under isomorphisms of short complexes. -/
-  conflation_iff_of_iso : ∀ {S T : ShortComplex C}, (S ≅ T) → (Conflation S ↔ Conflation T)
+  isClosedUnderIsomorphisms : Conflation.IsClosedUnderIsomorphisms
+
+attribute [instance] ConflationClass.isClosedUnderIsomorphisms
 
 namespace ConflationClass
 
@@ -67,13 +95,31 @@ theorem ext (E F : ConflationClass C) (h : ∀ S, E.Conflation S ↔ F.Conflatio
   funext S
   exact propext (h S)
 
+/-- The inflations: the morphisms occurring as the first map of a conflation. -/
+def inflations (E : ConflationClass C) : MorphismProperty C :=
+  fun _ Y i => ∃ (Z : C) (p : Y ⟶ Z) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero)
+
+/-- The deflations: the morphisms occurring as the second map of a conflation. -/
+def deflations (E : ConflationClass C) : MorphismProperty C :=
+  fun Y _ p => ∃ (X : C) (i : X ⟶ Y) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero)
+
 /-- A morphism is an inflation when it is the first map of a conflation. -/
-def IsInflation (E : ConflationClass C) {X Y : C} (i : X ⟶ Y) : Prop :=
-  ∃ (Z : C) (p : Y ⟶ Z) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero)
+abbrev IsInflation (E : ConflationClass C) {X Y : C} (i : X ⟶ Y) : Prop := E.inflations i
 
 /-- A morphism is a deflation when it is the second map of a conflation. -/
-def IsDeflation (E : ConflationClass C) {Y Z : C} (p : Y ⟶ Z) : Prop :=
-  ∃ (X : C) (i : X ⟶ Y) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero)
+abbrev IsDeflation (E : ConflationClass C) {Y Z : C} (p : Y ⟶ Z) : Prop := E.deflations p
+
+/-- A morphism is an inflation exactly when it is the first map of a conflation. -/
+theorem isInflation_iff (E : ConflationClass C) {X Y : C} (i : X ⟶ Y) :
+    E.IsInflation i ↔
+      ∃ (Z : C) (p : Y ⟶ Z) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero) :=
+  Iff.rfl
+
+/-- A morphism is a deflation exactly when it is the second map of a conflation. -/
+theorem isDeflation_iff (E : ConflationClass C) {Y Z : C} (p : Y ⟶ Z) :
+    E.IsDeflation p ↔
+      ∃ (X : C) (i : X ⟶ Y) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero) :=
+  Iff.rfl
 
 /-- A conflation's first map is an inflation. -/
 theorem isInflation_f (E : ConflationClass C) {S : ShortComplex C} (hS : E.Conflation S) :
@@ -100,7 +146,12 @@ theorem IsDeflation.epi {E : ConflationClass C} {Y Z : C} {p : Y ⟶ Z}
 /-- An isomorphism of short complexes transports the property of being a conflation. -/
 theorem conflation_of_iso (E : ConflationClass C) {S T : ShortComplex C} (e : S ≅ T)
     (hS : E.Conflation S) : E.Conflation T :=
-  (E.conflation_iff_of_iso e).mp hS
+  E.Conflation.prop_of_iso e hS
+
+/-- Isomorphic short complexes are conflations together. -/
+theorem conflation_iff_of_iso (E : ConflationClass C) {S T : ShortComplex C} (e : S ≅ T) :
+    E.Conflation S ↔ E.Conflation T :=
+  E.Conflation.prop_iff_of_iso e
 
 end ConflationClass
 
@@ -153,6 +204,36 @@ abbrev IsInflation (E : ExactStructure C) {X Y : C} (i : X ⟶ Y) : Prop :=
 /-- The predicate that a morphism is the second map of a distinguished conflation. -/
 abbrev IsDeflation (E : ExactStructure C) {Y Z : C} (p : Y ⟶ Z) : Prop :=
   E.toConflationClass.IsDeflation p
+
+/-- E0, as the statement that the inflations contain the identities. -/
+instance (E : ExactStructure C) : E.inflations.ContainsIdentities where
+  id_mem := E.id_isInflation
+
+/-- E0op, as the statement that the deflations contain the identities. -/
+instance (E : ExactStructure C) : E.deflations.ContainsIdentities where
+  id_mem := E.id_isDeflation
+
+/-- E1, as the statement that the inflations are stable under composition. -/
+instance (E : ExactStructure C) : E.inflations.IsStableUnderComposition where
+  comp_mem := E.comp_isInflation
+
+/-- E1op, as the statement that the deflations are stable under composition. -/
+instance (E : ExactStructure C) : E.deflations.IsStableUnderComposition where
+  comp_mem := E.comp_isDeflation
+
+/-- A morphism is an inflation exactly when it is the first map of a distinguished
+conflation. -/
+theorem isInflation_iff (E : ExactStructure C) {X Y : C} (i : X ⟶ Y) :
+    E.IsInflation i ↔
+      ∃ (Z : C) (p : Y ⟶ Z) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero) :=
+  E.toConflationClass.isInflation_iff i
+
+/-- A morphism is a deflation exactly when it is the second map of a distinguished
+conflation. -/
+theorem isDeflation_iff (E : ExactStructure C) {Y Z : C} (p : Y ⟶ Z) :
+    E.IsDeflation p ↔
+      ∃ (X : C) (i : X ⟶ Y) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero) :=
+  E.toConflationClass.isDeflation_iff p
 
 /-- A conflation's first map is an inflation. -/
 theorem isInflation_f (E : ExactStructure C) {S : ShortComplex C} (hS : E.Conflation S) :

--- a/TauCeti/CategoryTheory/Exact/ExactStructure.lean
+++ b/TauCeti/CategoryTheory/Exact/ExactStructure.lean
@@ -36,8 +36,10 @@ constructed separately.
 
 The conflations are a `CategoryTheory.ObjectProperty (CategoryTheory.ShortComplex C)` closed
 under isomorphisms in Mathlib's sense, and the inflations and the deflations are each a
-`CategoryTheory.MorphismProperty`, so that the generic API applies: E0/E0op and E1/E1op are
-recorded as `CategoryTheory.MorphismProperty.ContainsIdentities` and
+`CategoryTheory.MorphismProperty`, so that the generic API applies: isomorphism-closure of the
+conflations makes the inflations and the deflations
+`CategoryTheory.MorphismProperty.RespectsIso`, and E0/E0op and E1/E1op are recorded as
+`CategoryTheory.MorphismProperty.ContainsIdentities` and
 `CategoryTheory.MorphismProperty.IsStableUnderComposition` instances.
 
 E2 and E2op cannot be phrased through Mathlib's
@@ -153,6 +155,28 @@ theorem conflation_iff_of_iso (E : ConflationClass C) {S T : ShortComplex C} (e 
     E.Conflation S ↔ E.Conflation T :=
   E.Conflation.prop_iff_of_iso e
 
+/-- Being an inflation is invariant under composing with isomorphisms on either side: the
+witnessing conflation transports along the isomorphism. -/
+instance (E : ConflationClass C) : E.inflations.RespectsIso := by
+  apply MorphismProperty.RespectsIso.mk
+  · rintro X Y Z e i ⟨W, p, zero, hS⟩
+    refine ⟨W, p, by simp [zero], E.conflation_of_iso (S := ShortComplex.mk i p zero)
+      (ShortComplex.isoMk e.symm (Iso.refl _) (Iso.refl _) (by simp) (by simp)) hS⟩
+  · rintro X Y Z e i ⟨W, p, zero, hS⟩
+    refine ⟨W, e.inv ≫ p, by simp [zero], E.conflation_of_iso (S := ShortComplex.mk i p zero)
+      (ShortComplex.isoMk (Iso.refl _) e (Iso.refl _) (by simp) (by simp)) hS⟩
+
+/-- Being a deflation is invariant under composing with isomorphisms on either side: the
+witnessing conflation transports along the isomorphism. -/
+instance (E : ConflationClass C) : E.deflations.RespectsIso := by
+  apply MorphismProperty.RespectsIso.mk
+  · rintro X Y Z e p ⟨W, i, zero, hS⟩
+    refine ⟨W, i ≫ e.inv, by simp [zero], E.conflation_of_iso (S := ShortComplex.mk i p zero)
+      (ShortComplex.isoMk (Iso.refl _) e.symm (Iso.refl _) (by simp) (by simp)) hS⟩
+  · rintro X Y Z e p ⟨W, i, zero, hS⟩
+    refine ⟨W, i, by simp [reassoc_of% zero], E.conflation_of_iso (S := ShortComplex.mk i p zero)
+      (ShortComplex.isoMk (Iso.refl _) (Iso.refl _) e (by simp) (by simp)) hS⟩
+
 end ConflationClass
 
 /-- A Quillen exact structure on an additive category, in the self-dual E0/E1/E2
@@ -162,15 +186,15 @@ The E2 fields provide genuine universal squares. No ambient pushouts or pullback
 structure ExactStructure (C : Type u) [Category.{v} C] [Preadditive C] [HasZeroObject C]
     [HasBinaryBiproducts C] extends ConflationClass C where
   /-- E0: identity morphisms are inflations. -/
-  id_isInflation : ∀ X : C, toConflationClass.IsInflation (𝟙 X)
+  isInflation_id : ∀ X : C, toConflationClass.IsInflation (𝟙 X)
   /-- E0op: identity morphisms are deflations. -/
-  id_isDeflation : ∀ X : C, toConflationClass.IsDeflation (𝟙 X)
+  isDeflation_id : ∀ X : C, toConflationClass.IsDeflation (𝟙 X)
   /-- E1: a composite of inflations is an inflation. -/
-  comp_isInflation : ∀ {X Y Z : C} (i : X ⟶ Y) (j : Y ⟶ Z),
+  isInflation_comp : ∀ {X Y Z : C} (i : X ⟶ Y) (j : Y ⟶ Z),
     toConflationClass.IsInflation i → toConflationClass.IsInflation j →
       toConflationClass.IsInflation (i ≫ j)
   /-- E1op: a composite of deflations is a deflation. -/
-  comp_isDeflation : ∀ {X Y Z : C} (p : X ⟶ Y) (q : Y ⟶ Z),
+  isDeflation_comp : ∀ {X Y Z : C} (p : X ⟶ Y) (q : Y ⟶ Z),
     toConflationClass.IsDeflation p → toConflationClass.IsDeflation q →
       toConflationClass.IsDeflation (p ≫ q)
   /-- E2: the pushout of an inflation along any morphism exists, and its other leg is an
@@ -207,58 +231,19 @@ abbrev IsDeflation (E : ExactStructure C) {Y Z : C} (p : Y ⟶ Z) : Prop :=
 
 /-- E0, as the statement that the inflations contain the identities. -/
 instance (E : ExactStructure C) : E.inflations.ContainsIdentities where
-  id_mem := E.id_isInflation
+  id_mem := E.isInflation_id
 
 /-- E0op, as the statement that the deflations contain the identities. -/
 instance (E : ExactStructure C) : E.deflations.ContainsIdentities where
-  id_mem := E.id_isDeflation
+  id_mem := E.isDeflation_id
 
 /-- E1, as the statement that the inflations are stable under composition. -/
 instance (E : ExactStructure C) : E.inflations.IsStableUnderComposition where
-  comp_mem := E.comp_isInflation
+  comp_mem := E.isInflation_comp
 
 /-- E1op, as the statement that the deflations are stable under composition. -/
 instance (E : ExactStructure C) : E.deflations.IsStableUnderComposition where
-  comp_mem := E.comp_isDeflation
-
-/-- A morphism is an inflation exactly when it is the first map of a distinguished
-conflation. -/
-theorem isInflation_iff (E : ExactStructure C) {X Y : C} (i : X ⟶ Y) :
-    E.IsInflation i ↔
-      ∃ (Z : C) (p : Y ⟶ Z) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero) :=
-  E.toConflationClass.isInflation_iff i
-
-/-- A morphism is a deflation exactly when it is the second map of a distinguished
-conflation. -/
-theorem isDeflation_iff (E : ExactStructure C) {Y Z : C} (p : Y ⟶ Z) :
-    E.IsDeflation p ↔
-      ∃ (X : C) (i : X ⟶ Y) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero) :=
-  E.toConflationClass.isDeflation_iff p
-
-/-- A conflation's first map is an inflation. -/
-theorem isInflation_f (E : ExactStructure C) {S : ShortComplex C} (hS : E.Conflation S) :
-    E.IsInflation S.f :=
-  E.toConflationClass.isInflation_f hS
-
-/-- A conflation's second map is a deflation. -/
-theorem isDeflation_g (E : ExactStructure C) {S : ShortComplex C} (hS : E.Conflation S) :
-    E.IsDeflation S.g :=
-  E.toConflationClass.isDeflation_g hS
-
-/-- Every inflation in an exact structure is a monomorphism. -/
-theorem IsInflation.mono {E : ExactStructure C} {X Y : C} {i : X ⟶ Y}
-    (hi : E.IsInflation i) : Mono i :=
-  ConflationClass.IsInflation.mono hi
-
-/-- Every deflation in an exact structure is an epimorphism. -/
-theorem IsDeflation.epi {E : ExactStructure C} {Y Z : C} {p : Y ⟶ Z}
-    (hp : E.IsDeflation p) : Epi p :=
-  ConflationClass.IsDeflation.epi hp
-
-/-- An isomorphism of short complexes transports distinguished conflations. -/
-theorem conflation_of_iso (E : ExactStructure C) {S T : ShortComplex C} (e : S ≅ T)
-    (hS : E.Conflation S) : E.Conflation T :=
-  E.toConflationClass.conflation_of_iso e hS
+  comp_mem := E.isDeflation_comp
 
 end ExactStructure
 

--- a/TauCeti/CategoryTheory/Exact/ExactStructure.lean
+++ b/TauCeti/CategoryTheory/Exact/ExactStructure.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.CategoryTheory.Exact.KernelCokernelPair
+public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.IsPullback.Defs
+
+/-!
+# Exact structures
+
+An exact structure on an additive category is an isomorphism-closed class of kernel--cokernel
+pairs satisfying Quillen's axioms. This file packages those axioms in their self-dual
+E0/E1/E2 form. In particular, the E2 axioms return actual pushout and pullback squares; they do
+not assume that the ambient category has arbitrary pushouts or pullbacks.
+
+The distinguished short complexes are called *conflations*. Their first maps are
+*inflations*, and their second maps are *deflations*. The structures here contain only this
+intrinsic data and the six Quillen axioms. The split and canonical abelian exact structures are
+constructed separately.
+
+## Main definitions
+
+* `TauCeti.ConflationClass` is an isomorphism-closed class of kernel--cokernel pairs.
+* `TauCeti.ConflationClass.IsInflation` and `TauCeti.ConflationClass.IsDeflation` say that a
+  morphism occurs as the first or second map of a conflation.
+* `TauCeti.ExactStructure` equips a conflation class with E0/E0op, E1/E1op, and E2/E2op.
+
+## References
+
+* Theo Bühler, *Exact categories*, Expositiones Mathematicae **28** (2010), 1--69,
+  <https://arxiv.org/abs/0811.1480>. Definition 2.1 and Remarks 2.2--2.8 give the axioms used
+  here.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe v u
+
+variable {C : Type u} [Category.{v} C] [Preadditive C]
+
+/-- An isomorphism-closed class of kernel--cokernel pairs in a preadditive category.
+
+This is the relation underlying an exact structure, before imposing the Quillen axioms. -/
+structure ConflationClass (C : Type u) [Category.{v} C] [Preadditive C] where
+  /-- The distinguished short complexes. -/
+  Conflation : ShortComplex C → Prop
+  /-- Every conflation is a kernel--cokernel pair. -/
+  isKernelCokernelPair : ∀ S, Conflation S → IsKernelCokernelPair S
+  /-- The class of conflations is closed under isomorphisms of short complexes. -/
+  conflation_iff_of_iso : ∀ {S T : ShortComplex C}, (S ≅ T) → (Conflation S ↔ Conflation T)
+
+namespace ConflationClass
+
+/-- Two conflation classes are equal when they distinguish the same short complexes. -/
+@[ext]
+theorem ext (E F : ConflationClass C) (h : ∀ S, E.Conflation S ↔ F.Conflation S) : E = F := by
+  cases E
+  cases F
+  simp only [mk.injEq]
+  funext S
+  exact propext (h S)
+
+/-- A morphism is an inflation when it is the first map of a conflation. -/
+def IsInflation (E : ConflationClass C) {X Y : C} (i : X ⟶ Y) : Prop :=
+  ∃ (Z : C) (p : Y ⟶ Z) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero)
+
+/-- A morphism is a deflation when it is the second map of a conflation. -/
+def IsDeflation (E : ConflationClass C) {Y Z : C} (p : Y ⟶ Z) : Prop :=
+  ∃ (X : C) (i : X ⟶ Y) (zero : i ≫ p = 0), E.Conflation (ShortComplex.mk i p zero)
+
+/-- A conflation's first map is an inflation. -/
+theorem isInflation_f (E : ConflationClass C) {S : ShortComplex C} (hS : E.Conflation S) :
+    E.IsInflation S.f := by
+  exact ⟨S.X₃, S.g, S.zero, hS⟩
+
+/-- A conflation's second map is a deflation. -/
+theorem isDeflation_g (E : ConflationClass C) {S : ShortComplex C} (hS : E.Conflation S) :
+    E.IsDeflation S.g := by
+  exact ⟨S.X₁, S.f, S.zero, hS⟩
+
+/-- Every inflation is a monomorphism. -/
+theorem IsInflation.mono {E : ConflationClass C} {X Y : C} {i : X ⟶ Y}
+    (hi : E.IsInflation i) : Mono i := by
+  obtain ⟨Z, p, zero, hS⟩ := hi
+  exact (E.isKernelCokernelPair (ShortComplex.mk i p zero) hS).mono_f
+
+/-- Every deflation is an epimorphism. -/
+theorem IsDeflation.epi {E : ConflationClass C} {Y Z : C} {p : Y ⟶ Z}
+    (hp : E.IsDeflation p) : Epi p := by
+  obtain ⟨X, i, zero, hS⟩ := hp
+  exact (E.isKernelCokernelPair (ShortComplex.mk i p zero) hS).epi_g
+
+/-- An isomorphism of short complexes transports the property of being a conflation. -/
+theorem conflation_of_iso (E : ConflationClass C) {S T : ShortComplex C} (e : S ≅ T)
+    (hS : E.Conflation S) : E.Conflation T :=
+  (E.conflation_iff_of_iso e).mp hS
+
+end ConflationClass
+
+/-- A Quillen exact structure on an additive category, in the self-dual E0/E1/E2
+presentation.
+
+The E2 fields provide genuine universal squares. No ambient pushouts or pullbacks are assumed. -/
+structure ExactStructure (C : Type u) [Category.{v} C] [Preadditive C] [HasZeroObject C]
+    [HasBinaryBiproducts C] extends ConflationClass C where
+  /-- E0: identity morphisms are inflations. -/
+  id_isInflation : ∀ X : C, toConflationClass.IsInflation (𝟙 X)
+  /-- E0op: identity morphisms are deflations. -/
+  id_isDeflation : ∀ X : C, toConflationClass.IsDeflation (𝟙 X)
+  /-- E1: a composite of inflations is an inflation. -/
+  comp_isInflation : ∀ {X Y Z : C} (i : X ⟶ Y) (j : Y ⟶ Z),
+    toConflationClass.IsInflation i → toConflationClass.IsInflation j →
+      toConflationClass.IsInflation (i ≫ j)
+  /-- E1op: a composite of deflations is a deflation. -/
+  comp_isDeflation : ∀ {X Y Z : C} (p : X ⟶ Y) (q : Y ⟶ Z),
+    toConflationClass.IsDeflation p → toConflationClass.IsDeflation q →
+      toConflationClass.IsDeflation (p ≫ q)
+  /-- E2: the pushout of an inflation along any morphism exists, and its other leg is an
+  inflation. -/
+  pushout_isInflation : ∀ {X Y : C} (i : X ⟶ Y), toConflationClass.IsInflation i →
+    ∀ {X' : C} (f : X ⟶ X'), ∃ (Y' : C) (g : Y ⟶ Y') (i' : X' ⟶ Y'),
+      IsPushout i f g i' ∧ toConflationClass.IsInflation i'
+  /-- E2op: the pullback of a deflation along any morphism exists, and its other leg is a
+  deflation. -/
+  pullback_isDeflation : ∀ {X Y : C} (p : X ⟶ Y), toConflationClass.IsDeflation p →
+    ∀ {Y' : C} (f : Y' ⟶ Y), ∃ (X' : C) (p' : X' ⟶ Y') (g : X' ⟶ X),
+      IsPullback p' g f p ∧ toConflationClass.IsDeflation p'
+
+namespace ExactStructure
+
+variable [HasZeroObject C] [HasBinaryBiproducts C]
+
+/-- Two exact structures are equal when they have the same conflations. -/
+@[ext]
+theorem ext (E F : ExactStructure C) (h : ∀ S, E.Conflation S ↔ F.Conflation S) : E = F := by
+  cases E
+  cases F
+  simp only [mk.injEq]
+  apply ConflationClass.ext
+  exact h
+
+/-- The predicate that a morphism is the first map of a distinguished conflation. -/
+abbrev IsInflation (E : ExactStructure C) {X Y : C} (i : X ⟶ Y) : Prop :=
+  E.toConflationClass.IsInflation i
+
+/-- The predicate that a morphism is the second map of a distinguished conflation. -/
+abbrev IsDeflation (E : ExactStructure C) {Y Z : C} (p : Y ⟶ Z) : Prop :=
+  E.toConflationClass.IsDeflation p
+
+/-- A conflation's first map is an inflation. -/
+theorem isInflation_f (E : ExactStructure C) {S : ShortComplex C} (hS : E.Conflation S) :
+    E.IsInflation S.f :=
+  E.toConflationClass.isInflation_f hS
+
+/-- A conflation's second map is a deflation. -/
+theorem isDeflation_g (E : ExactStructure C) {S : ShortComplex C} (hS : E.Conflation S) :
+    E.IsDeflation S.g :=
+  E.toConflationClass.isDeflation_g hS
+
+/-- Every inflation in an exact structure is a monomorphism. -/
+theorem IsInflation.mono {E : ExactStructure C} {X Y : C} {i : X ⟶ Y}
+    (hi : E.IsInflation i) : Mono i :=
+  ConflationClass.IsInflation.mono hi
+
+/-- Every deflation in an exact structure is an epimorphism. -/
+theorem IsDeflation.epi {E : ExactStructure C} {Y Z : C} {p : Y ⟶ Z}
+    (hp : E.IsDeflation p) : Epi p :=
+  ConflationClass.IsDeflation.epi hp
+
+/-- An isomorphism of short complexes transports distinguished conflations. -/
+theorem conflation_of_iso (E : ExactStructure C) {S T : ShortComplex C} (e : S ≅ T)
+    (hS : E.Conflation S) : E.Conflation T :=
+  E.toConflationClass.conflation_of_iso e hS
+
+end ExactStructure
+
+end TauCeti


### PR DESCRIPTION
This PR packages Quillen exact structures in their intrinsic self-dual E0/E1/E2 presentation. Define an isomorphism-closed `ConflationClass` of kernel--cokernel pairs, define inflations and deflations by occurrence in a conflation, and define `ExactStructure` with identity and composition axioms together with pushout and pullback axioms that return genuine universal squares. Prove extensionality for both structures, transport of conflations along short-complex isomorphisms, and the fundamental facts that every inflation is mono and every deflation is epi.

The exact roadmap target is `TauCetiRoadmap/GrothendieckEulerForms/README.md`, Layer 0, “Exact structures”: an `ExactStructure C` is an isomorphism-closed class of kernel--cokernel pairs with E0/E0op, E1/E1op, and E2/E2op, where E2 and E2op construct actual universal squares. This is the next unmet critical-path step after the merged kernel--cokernel-pair package and supplies the datum consumed by every later exact K₀, resolution, Cartan-map, and Ext-Euler construction.

After this PR, Layer 0 still needs the standard inflation/deflation calculus and bicartesian consequences, the opposite structure and functoriality, the split and canonical abelian structures, induced extension-closed structures, and conflation-exact functors.

Add `TauCeti/CategoryTheory/Exact/ExactStructure.lean` (184 lines). Reuse Mathlib's `CategoryTheory.Limits.IsPushout` and `IsPullback` universal-square API and Tau Ceti's merged `IsKernelCokernelPair`; no Mathlib infrastructure is vendored. The axiom package follows Bühler, *Exact Categories*, Definition 2.1 and Remarks 2.2--2.8, as credited in the module documentation.

Roadmap: GrothendieckEulerForms

<!--tauceti-target:v1 {"focus":"GrothendieckEulerForms","id":"exact-structure-axioms"}-->

🤖 Prepared with Codex
