### PR TITLE
feat: add integral lattice Gram determinants

### DIFF
--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -35,8 +35,11 @@ The form restricts to a canonical `ℤ`-bilinear form on the carrier.  Conversel
   integrality proof.
 * `TauCeti.IntegralLattice.ofBasis`: the lattice spanned by a basis on which a given form is
   integral.
+* `TauCeti.IntegralLattice.ofBasis.basis`: the canonical carrier basis induced by a rational basis.
 * `TauCeti.IntegralLattice.ofGramMatrix`: the lattice and form determined by an integral
   symmetric Gram matrix.
+* `TauCeti.IntegralLattice.ofGramMatrix.basis`: the canonical carrier basis induced by a rational
+  basis.
 -/
 
 public section
@@ -214,6 +217,24 @@ theorem ofBasis.coe_basisElem (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ 
   unfold ofBasis.basisElem
   rfl
 
+/-- The canonical carrier basis of `ofBasis b B hB hint` induced by `b`. -/
+noncomputable def ofBasis.basis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
+    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) :
+    Basis ι ℤ (ofBasis b B hB hint) :=
+  b.restrictScalars ℤ
+
+@[simp]
+theorem ofBasis.basis_apply (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
+    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) (i : ι) :
+    ofBasis.basis b B hB hint i = ofBasis.basisElem b B hB hint i :=
+  Subtype.ext (b.restrictScalars_apply ℤ i)
+
+@[simp]
+theorem ofBasis.coe_basis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
+    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) (i : ι) :
+    (ofBasis.basis b B hB hint i : V) = b i :=
+  b.restrictScalars_apply ℤ i
+
 end Basis
 
 section GramMatrix
@@ -254,6 +275,24 @@ theorem ofGramMatrix.coe_basisElem (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (
     (i : ι) : (ofGramMatrix.basisElem b G hG i : V) = b i := by
   unfold ofGramMatrix.basisElem
   rfl
+
+open Classical in
+/-- The canonical carrier basis of `ofGramMatrix b G hG` induced by `b`. -/
+noncomputable def ofGramMatrix.basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
+    Basis ι ℤ (ofGramMatrix b G hG) :=
+  b.restrictScalars ℤ
+
+open Classical in
+@[simp]
+theorem ofGramMatrix.basis_apply (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) (i : ι) :
+    ofGramMatrix.basis b G hG i = ofGramMatrix.basisElem b G hG i :=
+  Subtype.ext (b.restrictScalars_apply ℤ i)
+
+open Classical in
+@[simp]
+theorem ofGramMatrix.coe_basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) (i : ι) :
+    (ofGramMatrix.basis b G hG i : V) = b i :=
+  b.restrictScalars_apply ℤ i
 
 open Classical in
 /-- Evaluating the induced integral form of `ofGramMatrix` on embedded basis vectors recovers

--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -229,7 +229,6 @@ theorem ofBasis.basis_apply (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V)
     ofBasis.basis b B hB hint i = ofBasis.basisElem b B hB hint i :=
   Subtype.ext (b.restrictScalars_apply ℤ i)
 
-@[simp]
 theorem ofBasis.coe_basis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
     (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) (i : ι) :
     (ofBasis.basis b B hB hint i : V) = b i :=
@@ -289,7 +288,6 @@ theorem ofGramMatrix.basis_apply (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG
   Subtype.ext (b.restrictScalars_apply ℤ i)
 
 open Classical in
-@[simp]
 theorem ofGramMatrix.coe_basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) (i : ι) :
     (ofGramMatrix.basis b G hG i : V) = b i :=
   b.restrictScalars_apply ℤ i

--- a/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Basic.lean
@@ -204,19 +204,6 @@ theorem ofBasis_form (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : 
     (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) :
     (ofBasis b B hB hint).form = B := (rfl)
 
-/-- The canonical embedding of the basis vector `b i` into the carrier of `ofBasis b B hB hint`. -/
-noncomputable def ofBasis.basisElem (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
-    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) (i : ι) :
-    ofBasis b B hB hint :=
-  ⟨b i, by rw [ofBasis_carrier]; exact Submodule.subset_span (Set.mem_range_self i)⟩
-
-@[simp]
-theorem ofBasis.coe_basisElem (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
-    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) (i : ι) :
-    (ofBasis.basisElem b B hB hint i : V) = b i := by
-  unfold ofBasis.basisElem
-  rfl
-
 /-- The canonical carrier basis of `ofBasis b B hB hint` induced by `b`. -/
 noncomputable def ofBasis.basis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
     (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) :
@@ -224,11 +211,6 @@ noncomputable def ofBasis.basis (b : Basis ι ℚ V) (B : LinearMap.BilinForm �
   b.restrictScalars ℤ
 
 @[simp]
-theorem ofBasis.basis_apply (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
-    (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) (i : ι) :
-    ofBasis.basis b B hB hint i = ofBasis.basisElem b B hB hint i :=
-  Subtype.ext (b.restrictScalars_apply ℤ i)
-
 theorem ofBasis.coe_basis (b : Basis ι ℚ V) (B : LinearMap.BilinForm ℚ V) (hB : B.IsSymm)
     (hint : ∀ i j, B (b i) (b j) ∈ (1 : Submodule ℤ ℚ)) (i : ι) :
     (ofBasis.basis b B hB hint i : V) = b i :=
@@ -262,20 +244,6 @@ theorem ofGramMatrix_form (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.Is
     (ofGramMatrix b G hG).form = Matrix.toBilin b (G.map (algebraMap ℤ ℚ)) := (rfl)
 
 open Classical in
-/-- The canonical embedding of the basis vector `b i` into the carrier of
-`ofGramMatrix b G hG`. -/
-noncomputable def ofGramMatrix.basisElem (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
-    (i : ι) : ofGramMatrix b G hG :=
-  ⟨b i, by rw [ofGramMatrix_carrier]; exact Submodule.subset_span (Set.mem_range_self i)⟩
-
-open Classical in
-@[simp]
-theorem ofGramMatrix.coe_basisElem (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
-    (i : ι) : (ofGramMatrix.basisElem b G hG i : V) = b i := by
-  unfold ofGramMatrix.basisElem
-  rfl
-
-open Classical in
 /-- The canonical carrier basis of `ofGramMatrix b G hG` induced by `b`. -/
 noncomputable def ofGramMatrix.basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
     Basis ι ℤ (ofGramMatrix b G hG) :=
@@ -283,11 +251,6 @@ noncomputable def ofGramMatrix.basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ)
 
 open Classical in
 @[simp]
-theorem ofGramMatrix.basis_apply (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) (i : ι) :
-    ofGramMatrix.basis b G hG i = ofGramMatrix.basisElem b G hG i :=
-  Subtype.ext (b.restrictScalars_apply ℤ i)
-
-open Classical in
 theorem ofGramMatrix.coe_basis (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) (i : ι) :
     (ofGramMatrix.basis b G hG i : V) = b i :=
   b.restrictScalars_apply ℤ i
@@ -298,11 +261,11 @@ the corresponding entry of the Gram matrix. -/
 @[simp]
 theorem integralForm_ofGramMatrix_apply (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm)
     (i j : ι) :
-    (ofGramMatrix b G hG).integralForm (ofGramMatrix.basisElem b G hG i)
-      (ofGramMatrix.basisElem b G hG j) = G i j := by
+    (ofGramMatrix b G hG).integralForm (ofGramMatrix.basis b G hG i)
+      (ofGramMatrix.basis b G hG j) = G i j := by
   apply Int.cast_injective (α := ℚ)
-  rw [integralForm_cast, ofGramMatrix_form, ofGramMatrix.coe_basisElem,
-    ofGramMatrix.coe_basisElem, ← LinearMap.BilinForm.toMatrix_apply (b := b),
+  rw [integralForm_cast, ofGramMatrix_form, ofGramMatrix.coe_basis,
+    ofGramMatrix.coe_basis, ← LinearMap.BilinForm.toMatrix_apply (b := b),
     LinearMap.BilinForm.toMatrix_toBilin, Matrix.map_apply]
   rfl
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
@@ -56,15 +56,15 @@ section GramMatrix
 variable (L : IntegralLattice V)
 
 /-- The integral Gram matrix of a carrier basis. -/
-noncomputable def gramMatrix {ι : Type v} [Fintype ι] (e : Basis ι ℤ L) : Matrix ι ι ℤ :=
+@[expose]
+noncomputable def gramMatrix {ι : Type v} (e : Basis ι ℤ L) : Matrix ι ι ℤ :=
   fun i j ↦ L.integralForm (e i) (e j)
 
-open Classical in
 /-- A Gram-matrix entry is the value of the integral form on the corresponding basis vectors. -/
 @[simp]
-theorem gramMatrix_apply {ι : Type v} [Fintype ι] (e : Basis ι ℤ L) (i j : ι) :
+theorem gramMatrix_apply {ι : Type v} (e : Basis ι ℤ L) (i j : ι) :
     L.gramMatrix e i j = L.integralForm (e i) (e j) :=
-  (rfl)
+  rfl
 
 /-- The Gram matrix is Mathlib's matrix of the restricted integral bilinear form. -/
 theorem gramMatrix_eq_toMatrix {ι : Type v} [Fintype ι] [DecidableEq ι]
@@ -73,18 +73,16 @@ theorem gramMatrix_eq_toMatrix {ι : Type v} [Fintype ι] [DecidableEq ι]
   ext i j
   rw [gramMatrix_apply, LinearMap.BilinForm.toMatrix_apply]
 
-open Classical in
 /-- Casting a Gram-matrix entry to `ℚ` recovers the ambient rational form. -/
-theorem intCast_gramMatrix_apply {ι : Type v} [Fintype ι] (e : Basis ι ℤ L) (i j : ι) :
+theorem intCast_gramMatrix_apply {ι : Type v} (e : Basis ι ℤ L) (i j : ι) :
     (L.gramMatrix e i j : ℚ) = L.form (e i : V) (e j : V) := by
   rw [gramMatrix_apply, integralForm_cast]
 
-open Classical in
 /-- The Gram matrix of a symmetric integral lattice is symmetric. -/
-theorem gramMatrix_isSymm {ι : Type v} [Fintype ι] (e : Basis ι ℤ L) :
+theorem gramMatrix_isSymm {ι : Type v} (e : Basis ι ℤ L) :
     (L.gramMatrix e).IsSymm := by
-  rw [gramMatrix_eq_toMatrix, LinearMap.BilinForm.isSymm_toMatrix_iff_isSymm]
-  exact L.isSymm_integralForm
+  ext i j
+  rw [Matrix.transpose_apply, gramMatrix_apply, gramMatrix_apply, L.isSymm_integralForm.eq]
 
 /-- Extending the carrier basis and the entries of its Gram matrix to `ℚ` gives the matrix of the
 ambient rational form. -/
@@ -114,12 +112,10 @@ theorem intCast_gramDet {ι : Type v} [Fintype ι] [DecidableEq ι]
   rw [gramDet, Int.cast_det]
   exact congrArg Matrix.det (map_gramMatrix L e)
 
-open Classical in
 /-- Reindexing a carrier basis simultaneously reindexes the rows and columns of its Gram matrix. -/
-theorem gramMatrix_reindex {ι : Type v} {κ : Type w} [Fintype ι] [Fintype κ]
+theorem gramMatrix_reindex {ι : Type v} {κ : Type w}
     (e : Basis ι ℤ L) (σ : ι ≃ κ) :
     L.gramMatrix (e.reindex σ) = (L.gramMatrix e).submatrix σ.symm σ.symm := by
-  classical
   ext i j
   simp only [gramMatrix_apply, Basis.reindex_apply, Matrix.submatrix_apply]
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
@@ -182,8 +182,7 @@ theorem gramMatrix_ofGramMatrix {ι : Type v} [Fintype ι]
     (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
     (ofGramMatrix b G hG).gramMatrix (ofGramMatrix.basis b G hG) = G := by
   ext i j
-  rw [gramMatrix_apply, ofGramMatrix.basis_apply, ofGramMatrix.basis_apply,
-    integralForm_ofGramMatrix_apply]
+  rw [gramMatrix_apply, integralForm_ofGramMatrix_apply]
 
 /-- The signed Gram determinant of `ofGramMatrix b G hG` in its canonical carrier basis is the
 determinant of `G`. -/

--- a/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
@@ -56,22 +56,20 @@ section GramMatrix
 variable (L : IntegralLattice V)
 
 /-- The integral Gram matrix of a carrier basis. -/
-@[expose]
 noncomputable def gramMatrix {ι : Type v} (e : Basis ι ℤ L) : Matrix ι ι ℤ :=
-  fun i j ↦ L.integralForm (e i) (e j)
+  LinearMap.BilinForm.toMatrixAux e L.integralForm
 
 /-- A Gram-matrix entry is the value of the integral form on the corresponding basis vectors. -/
 @[simp]
 theorem gramMatrix_apply {ι : Type v} (e : Basis ι ℤ L) (i j : ι) :
     L.gramMatrix e i j = L.integralForm (e i) (e j) :=
-  rfl
+  LinearMap.BilinForm.toMatrixAux_apply L.integralForm e i j
 
 /-- The Gram matrix is Mathlib's matrix of the restricted integral bilinear form. -/
 theorem gramMatrix_eq_toMatrix {ι : Type v} [Fintype ι] [DecidableEq ι]
     (e : Basis ι ℤ L) :
-    L.gramMatrix e = LinearMap.BilinForm.toMatrix e L.integralForm := by
-  ext i j
-  rw [gramMatrix_apply, LinearMap.BilinForm.toMatrix_apply]
+    L.gramMatrix e = LinearMap.BilinForm.toMatrix e L.integralForm :=
+  LinearMap.BilinForm.toMatrixAux_eq e L.integralForm
 
 /-- Casting a Gram-matrix entry to `ℚ` recovers the ambient rational form. -/
 theorem intCast_gramMatrix_apply {ι : Type v} (e : Basis ι ℤ L) (i j : ι) :
@@ -79,7 +77,7 @@ theorem intCast_gramMatrix_apply {ι : Type v} (e : Basis ι ℤ L) (i j : ι) :
   rw [gramMatrix_apply, integralForm_cast]
 
 /-- The Gram matrix of a symmetric integral lattice is symmetric. -/
-theorem gramMatrix_isSymm {ι : Type v} (e : Basis ι ℤ L) :
+theorem isSymm_gramMatrix {ι : Type v} (e : Basis ι ℤ L) :
     (L.gramMatrix e).IsSymm := by
   ext i j
   rw [Matrix.transpose_apply, gramMatrix_apply, gramMatrix_apply, L.isSymm_integralForm.eq]
@@ -99,9 +97,17 @@ theorem map_gramMatrix {ι : Type v} [Fintype ι] [DecidableEq ι] (e : Basis ι
     Basis.extendOfIsLattice_apply]
 
 /-- The signed determinant of the Gram matrix in a carrier basis. -/
+@[expose]
 noncomputable def gramDet {ι : Type v} [Fintype ι] [DecidableEq ι]
     (e : Basis ι ℤ L) : ℤ :=
   Matrix.det (L.gramMatrix e)
+
+/-- Unfolding the signed Gram determinant to the matrix determinant. -/
+@[simp]
+theorem gramDet_def {ι : Type v} [Fintype ι] [DecidableEq ι]
+    (e : Basis ι ℤ L) :
+    L.gramDet e = Matrix.det (L.gramMatrix e) :=
+  rfl
 
 /-- Casting the signed Gram determinant to `ℚ` gives the determinant of the ambient rational form
 in the extended basis. -/
@@ -109,7 +115,7 @@ theorem intCast_gramDet {ι : Type v} [Fintype ι] [DecidableEq ι]
     (e : Basis ι ℤ L) :
     (L.gramDet e : ℚ) =
       Matrix.det (LinearMap.BilinForm.toMatrix (e.extendOfIsLattice ℚ) L.form) := by
-  rw [gramDet, Int.cast_det]
+  rw [gramDet_def, Int.cast_det]
   exact congrArg Matrix.det (map_gramMatrix L e)
 
 /-- Reindexing a carrier basis simultaneously reindexes the rows and columns of its Gram matrix. -/
@@ -123,7 +129,7 @@ theorem gramMatrix_reindex {ι : Type v} {κ : Type w}
 theorem gramDet_reindex {ι : Type v} {κ : Type w} [Fintype ι] [Fintype κ]
     [DecidableEq ι] [DecidableEq κ] (e : Basis ι ℤ L) (σ : ι ≃ κ) :
     L.gramDet (e.reindex σ) = L.gramDet e := by
-  rw [gramDet, gramMatrix_reindex, Matrix.det_submatrix_equiv_self, gramDet]
+  rw [gramDet_def, gramMatrix_reindex, Matrix.det_submatrix_equiv_self, ← gramDet_def]
 
 /-- Two carrier bases with the same index type give the same signed Gram determinant. -/
 private theorem gramDet_eq_gramDet_sameIndex {ι : Type v} [Fintype ι] [DecidableEq ι]
@@ -134,7 +140,7 @@ private theorem gramDet_eq_gramDet_sameIndex {ι : Type v} [Fintype ι] [Decidab
       (f.toMatrix e).transpose * LinearMap.BilinForm.toMatrix f L.integralForm * f.toMatrix e =
         LinearMap.BilinForm.toMatrix e L.integralForm :=
     LinearMap.BilinForm.toMatrix_mul_basis_toMatrix (b := f) e L.integralForm
-  rw [gramDet, gramDet, gramMatrix_eq_toMatrix, gramMatrix_eq_toMatrix]
+  rw [gramDet_def, gramDet_def, gramMatrix_eq_toMatrix, gramMatrix_eq_toMatrix]
   calc
     Matrix.det (LinearMap.BilinForm.toMatrix e L.integralForm) =
         Matrix.det ((f.toMatrix e).transpose *

--- a/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
@@ -34,6 +34,12 @@ discriminant group.
 * `TauCeti.IntegralLattice.gramDet_eq_gramDet`: Gram determinants agree in any two bases.
 * `TauCeti.IntegralLattice.gramDet_ne_zero_iff`: a Gram determinant is nonzero exactly when the
   ambient form is nondegenerate.
+* `TauCeti.IntegralLattice.gramMatrix_ofGramMatrix`: the Gram matrix of `ofGramMatrix` in its
+  canonical basis is `G`.
+* `TauCeti.IntegralLattice.determinant_ofGramMatrix`: the signed determinant of `ofGramMatrix` is
+  the determinant of `G`.
+* `TauCeti.IntegralLattice.discriminant_ofGramMatrix`: the discriminant of `ofGramMatrix` is the
+  absolute determinant of `G`.
 
 ## References
 
@@ -170,6 +176,23 @@ theorem gramDet_ne_zero_iff {ι : Type v} [Fintype ι] [DecidableEq ι]
     ← intCast_gramDet]
   exact (Int.cast_ne_zero (α := ℚ) (n := L.gramDet e)).symm
 
+/-- The Gram matrix of `ofGramMatrix b G hG` in its canonical carrier basis is `G`. -/
+@[simp]
+theorem gramMatrix_ofGramMatrix {ι : Type v} [Fintype ι]
+    (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
+    (ofGramMatrix b G hG).gramMatrix (ofGramMatrix.basis b G hG) = G := by
+  ext i j
+  rw [gramMatrix_apply, ofGramMatrix.basis_apply, ofGramMatrix.basis_apply,
+    integralForm_ofGramMatrix_apply]
+
+/-- The signed Gram determinant of `ofGramMatrix b G hG` in its canonical carrier basis is the
+determinant of `G`. -/
+@[simp]
+theorem gramDet_ofGramMatrix {ι : Type v} [Fintype ι] [DecidableEq ι]
+    (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
+    (ofGramMatrix b G hG).gramDet (ofGramMatrix.basis b G hG) = G.det := by
+  rw [gramDet_def, gramMatrix_ofGramMatrix]
+
 end GramMatrix
 
 section Invariants
@@ -184,6 +207,13 @@ theorem determinant_eq_gramDet (L : IntegralLattice V) {ι : Type v} [Fintype ι
     L.determinant = L.gramDet e := by
   classical
   exact L.gramDet_eq_gramDet _ _
+
+/-- The basis-independent signed determinant of `ofGramMatrix b G hG` is the determinant of `G`. -/
+@[simp]
+theorem determinant_ofGramMatrix {ι : Type v} [Fintype ι] [DecidableEq ι]
+    (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
+    (ofGramMatrix b G hG).determinant = G.det := by
+  rw [determinant_eq_gramDet _ (ofGramMatrix.basis b G hG), gramDet_ofGramMatrix]
 
 /-- The basis-independent determinant is nonzero exactly when the ambient rational form is
 nondegenerate. -/
@@ -209,6 +239,13 @@ theorem discriminant_eq_natAbs_gramDet (L : IntegralLattice V) {ι : Type v} [Fi
     L.discriminant = (L.gramDet e).natAbs := by
   classical
   rw [discriminant_def, L.determinant_eq_gramDet e]
+
+/-- The discriminant of `ofGramMatrix b G hG` is the absolute value of the determinant of `G`. -/
+@[simp]
+theorem discriminant_ofGramMatrix {ι : Type v} [Fintype ι] [DecidableEq ι]
+    (b : Basis ι ℚ V) (G : Matrix ι ι ℤ) (hG : G.IsSymm) :
+    (ofGramMatrix b G hG).discriminant = G.det.natAbs := by
+  rw [discriminant_def, determinant_ofGramMatrix]
 
 /-- The discriminant is positive exactly when the ambient rational form is nondegenerate. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
@@ -102,7 +102,6 @@ noncomputable def gramDet {ι : Type v} [Fintype ι] [DecidableEq ι]
   Matrix.det (L.gramMatrix e)
 
 /-- Unfolding the signed Gram determinant to the matrix determinant. -/
-@[simp]
 theorem gramDet_def {ι : Type v} [Fintype ι] [DecidableEq ι]
     (e : Basis ι ℤ L) :
     L.gramDet e = Matrix.det (L.gramMatrix e) :=
@@ -200,7 +199,6 @@ noncomputable def discriminant (L : IntegralLattice V) : ℕ :=
   L.determinant.natAbs
 
 /-- Unfolding the discriminant to the absolute value of the signed determinant. -/
-@[simp]
 theorem discriminant_def (L : IntegralLattice V) :
     L.discriminant = L.determinant.natAbs :=
   (rfl)

--- a/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.IntegralLattice.Basic
+import Mathlib.LinearAlgebra.Determinant
+
+/-!
+# Gram determinants of integral lattices
+
+This file attaches an integral Gram matrix to every basis of an integral lattice. Its determinant
+is independent of the carrier basis: an integral change-of-basis matrix has determinant `1` or
+`-1`, and the Gram matrix changes by multiplication by that matrix and its transpose. The resulting
+basis-free signed determinant and its absolute value are the determinant and discriminant of the
+lattice.
+
+The rational scalar extension of a Gram matrix is the matrix of the ambient rational bilinear form
+in the extended basis. Consequently the signed determinant is nonzero exactly when that form is
+nondegenerate. This is the determinant criterion needed before constructing the finite
+discriminant group.
+
+## Main definitions
+
+* `TauCeti.IntegralLattice.gramMatrix`: the integral matrix of the restricted form in a carrier
+  basis.
+* `TauCeti.IntegralLattice.gramDet`: its signed determinant.
+* `TauCeti.IntegralLattice.determinant`: the basis-independent signed determinant.
+* `TauCeti.IntegralLattice.discriminant`: the nonnegative absolute determinant.
+
+## Main results
+
+* `TauCeti.IntegralLattice.gramDet_eq_gramDet`: Gram determinants agree in any two bases.
+* `TauCeti.IntegralLattice.gramDet_ne_zero_iff`: a Gram determinant is nonzero exactly when the
+  ambient form is nondegenerate.
+
+## References
+
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+* `TauCetiRoadmap/IntegralLattices/README.md`, Layer 1.
+-/
+
+public section
+
+open Module
+
+namespace TauCeti.IntegralLattice
+
+universe u v w
+
+variable {V : Type u} [AddCommGroup V] [Module ℚ V]
+
+section GramMatrix
+
+variable (L : IntegralLattice V)
+
+/-- The integral Gram matrix of a carrier basis. -/
+noncomputable def gramMatrix {ι : Type v} [Fintype ι] (e : Basis ι ℤ L) : Matrix ι ι ℤ :=
+  fun i j ↦ L.integralForm (e i) (e j)
+
+open Classical in
+/-- A Gram-matrix entry is the value of the integral form on the corresponding basis vectors. -/
+@[simp]
+theorem gramMatrix_apply {ι : Type v} [Fintype ι] (e : Basis ι ℤ L) (i j : ι) :
+    L.gramMatrix e i j = L.integralForm (e i) (e j) :=
+  (rfl)
+
+/-- The Gram matrix is Mathlib's matrix of the restricted integral bilinear form. -/
+theorem gramMatrix_eq_toMatrix {ι : Type v} [Fintype ι] [DecidableEq ι]
+    (e : Basis ι ℤ L) :
+    L.gramMatrix e = LinearMap.BilinForm.toMatrix e L.integralForm := by
+  ext i j
+  rw [gramMatrix_apply, LinearMap.BilinForm.toMatrix_apply]
+
+open Classical in
+/-- Casting a Gram-matrix entry to `ℚ` recovers the ambient rational form. -/
+theorem intCast_gramMatrix_apply {ι : Type v} [Fintype ι] (e : Basis ι ℤ L) (i j : ι) :
+    (L.gramMatrix e i j : ℚ) = L.form (e i : V) (e j : V) := by
+  rw [gramMatrix_apply, integralForm_cast]
+
+open Classical in
+/-- The Gram matrix of a symmetric integral lattice is symmetric. -/
+theorem gramMatrix_isSymm {ι : Type v} [Fintype ι] (e : Basis ι ℤ L) :
+    (L.gramMatrix e).IsSymm := by
+  rw [gramMatrix_eq_toMatrix, LinearMap.BilinForm.isSymm_toMatrix_iff_isSymm]
+  exact L.isSymm_integralForm
+
+/-- Extending the carrier basis and the entries of its Gram matrix to `ℚ` gives the matrix of the
+ambient rational form. -/
+theorem map_gramMatrix {ι : Type v} [Fintype ι] [DecidableEq ι] (e : Basis ι ℤ L) :
+    (L.gramMatrix e).map (algebraMap ℤ ℚ) =
+      LinearMap.BilinForm.toMatrix (e.extendOfIsLattice ℚ) L.form := by
+  ext i j
+  simp only [Matrix.map_apply]
+  -- `Matrix.map` displays the integer cast as `algebraMap`; the entry lemma uses cast notation.
+  change (L.gramMatrix e i j : ℚ) =
+    LinearMap.BilinForm.toMatrix (e.extendOfIsLattice ℚ) L.form i j
+  rw [intCast_gramMatrix_apply,
+    LinearMap.BilinForm.toMatrix_apply, Basis.extendOfIsLattice_apply,
+    Basis.extendOfIsLattice_apply]
+
+/-- The signed determinant of the Gram matrix in a carrier basis. -/
+noncomputable def gramDet {ι : Type v} [Fintype ι] [DecidableEq ι]
+    (e : Basis ι ℤ L) : ℤ :=
+  Matrix.det (L.gramMatrix e)
+
+/-- Casting the signed Gram determinant to `ℚ` gives the determinant of the ambient rational form
+in the extended basis. -/
+theorem intCast_gramDet {ι : Type v} [Fintype ι] [DecidableEq ι]
+    (e : Basis ι ℤ L) :
+    (L.gramDet e : ℚ) =
+      Matrix.det (LinearMap.BilinForm.toMatrix (e.extendOfIsLattice ℚ) L.form) := by
+  rw [gramDet, Int.cast_det]
+  exact congrArg Matrix.det (map_gramMatrix L e)
+
+open Classical in
+/-- Reindexing a carrier basis simultaneously reindexes the rows and columns of its Gram matrix. -/
+theorem gramMatrix_reindex {ι : Type v} {κ : Type w} [Fintype ι] [Fintype κ]
+    (e : Basis ι ℤ L) (σ : ι ≃ κ) :
+    L.gramMatrix (e.reindex σ) = (L.gramMatrix e).submatrix σ.symm σ.symm := by
+  classical
+  ext i j
+  simp only [gramMatrix_apply, Basis.reindex_apply, Matrix.submatrix_apply]
+
+/-- Reindexing a carrier basis does not change its signed Gram determinant. -/
+theorem gramDet_reindex {ι : Type v} {κ : Type w} [Fintype ι] [Fintype κ]
+    [DecidableEq ι] [DecidableEq κ] (e : Basis ι ℤ L) (σ : ι ≃ κ) :
+    L.gramDet (e.reindex σ) = L.gramDet e := by
+  rw [gramDet, gramMatrix_reindex, Matrix.det_submatrix_equiv_self, gramDet]
+
+/-- Two carrier bases with the same index type give the same signed Gram determinant. -/
+private theorem gramDet_eq_gramDet_sameIndex {ι : Type v} [Fintype ι] [DecidableEq ι]
+    (e f : Basis ι ℤ L) : L.gramDet e = L.gramDet f := by
+  have hchange : IsUnit (f.toMatrix e).det := f.isUnit_det e
+  rw [Int.isUnit_iff, ← sq_eq_one_iff] at hchange
+  have hmatrix :
+      (f.toMatrix e).transpose * LinearMap.BilinForm.toMatrix f L.integralForm * f.toMatrix e =
+        LinearMap.BilinForm.toMatrix e L.integralForm :=
+    LinearMap.BilinForm.toMatrix_mul_basis_toMatrix (b := f) e L.integralForm
+  rw [gramDet, gramDet, gramMatrix_eq_toMatrix, gramMatrix_eq_toMatrix]
+  calc
+    Matrix.det (LinearMap.BilinForm.toMatrix e L.integralForm) =
+        Matrix.det ((f.toMatrix e).transpose *
+          LinearMap.BilinForm.toMatrix f L.integralForm * f.toMatrix e) :=
+      congrArg Matrix.det hmatrix.symm
+    _ = (f.toMatrix e).det ^ 2 *
+        Matrix.det (LinearMap.BilinForm.toMatrix f L.integralForm) := by
+      rw [Matrix.det_mul, Matrix.det_mul, Matrix.det_transpose]
+      ring
+    _ = Matrix.det (LinearMap.BilinForm.toMatrix f L.integralForm) := by
+      rw [hchange, one_mul]
+
+/-- **The signed Gram determinant is independent of the carrier basis.** This permits both the
+index type and the basis to change. -/
+theorem gramDet_eq_gramDet {ι : Type v} {κ : Type w} [Fintype ι] [Fintype κ]
+    [DecidableEq ι] [DecidableEq κ] (e : Basis ι ℤ L) (f : Basis κ ℤ L) :
+    L.gramDet e = L.gramDet f := by
+  let σ : ι ≃ κ := e.indexEquiv f
+  calc
+    L.gramDet e = L.gramDet (e.reindex σ) := (gramDet_reindex L e σ).symm
+    _ = L.gramDet f := gramDet_eq_gramDet_sameIndex L _ _
+
+/-- A Gram determinant is nonzero exactly when the ambient rational form is nondegenerate. -/
+theorem gramDet_ne_zero_iff {ι : Type v} [Fintype ι] [DecidableEq ι]
+    (e : Basis ι ℤ L) :
+    L.gramDet e ≠ 0 ↔ L.form.Nondegenerate := by
+  rw [LinearMap.BilinForm.nondegenerate_iff_det_ne_zero (e.extendOfIsLattice ℚ),
+    ← intCast_gramDet]
+  exact (Int.cast_ne_zero (α := ℚ) (n := L.gramDet e)).symm
+
+end GramMatrix
+
+section Invariants
+
+/-- The basis-independent signed determinant of an integral lattice. -/
+noncomputable def determinant (L : IntegralLattice V) : ℤ :=
+  L.gramDet (Module.Free.chooseBasis ℤ L)
+
+/-- The signed determinant agrees with the determinant of the Gram matrix in every carrier basis. -/
+theorem determinant_eq_gramDet (L : IntegralLattice V) {ι : Type v} [Fintype ι]
+    [DecidableEq ι] (e : Basis ι ℤ L) :
+    L.determinant = L.gramDet e := by
+  classical
+  exact L.gramDet_eq_gramDet _ _
+
+/-- The basis-independent determinant is nonzero exactly when the ambient rational form is
+nondegenerate. -/
+theorem determinant_ne_zero_iff (L : IntegralLattice V) :
+    L.determinant ≠ 0 ↔ L.form.Nondegenerate := by
+  classical
+  rw [determinant, gramDet_ne_zero_iff]
+
+/-- The nonnegative discriminant of an integral lattice is the absolute value of its signed
+determinant. -/
+noncomputable def discriminant (L : IntegralLattice V) : ℕ :=
+  L.determinant.natAbs
+
+/-- The discriminant is the absolute value of the Gram determinant in every carrier basis. -/
+theorem discriminant_eq_natAbs_gramDet (L : IntegralLattice V) {ι : Type v} [Fintype ι]
+    [DecidableEq ι] (e : Basis ι ℤ L) :
+    L.discriminant = (L.gramDet e).natAbs := by
+  classical
+  rw [discriminant, L.determinant_eq_gramDet e]
+
+/-- The discriminant is positive exactly when the ambient rational form is nondegenerate. -/
+theorem discriminant_pos_iff (L : IntegralLattice V) :
+    0 < L.discriminant ↔ L.form.Nondegenerate := by
+  classical
+  rw [discriminant, Int.natAbs_pos, determinant_ne_zero_iff]
+
+end Invariants
+
+end TauCeti.IntegralLattice

--- a/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Gram.lean
@@ -97,7 +97,6 @@ theorem map_gramMatrix {ι : Type v} [Fintype ι] [DecidableEq ι] (e : Basis ι
     Basis.extendOfIsLattice_apply]
 
 /-- The signed determinant of the Gram matrix in a carrier basis. -/
-@[expose]
 noncomputable def gramDet {ι : Type v} [Fintype ι] [DecidableEq ι]
     (e : Basis ι ℤ L) : ℤ :=
   Matrix.det (L.gramMatrix e)
@@ -107,7 +106,7 @@ noncomputable def gramDet {ι : Type v} [Fintype ι] [DecidableEq ι]
 theorem gramDet_def {ι : Type v} [Fintype ι] [DecidableEq ι]
     (e : Basis ι ℤ L) :
     L.gramDet e = Matrix.det (L.gramMatrix e) :=
-  rfl
+  (rfl)
 
 /-- Casting the signed Gram determinant to `ℚ` gives the determinant of the ambient rational form
 in the extended basis. -/
@@ -164,6 +163,7 @@ theorem gramDet_eq_gramDet {ι : Type v} {κ : Type w} [Fintype ι] [Fintype κ]
     _ = L.gramDet f := gramDet_eq_gramDet_sameIndex L _ _
 
 /-- A Gram determinant is nonzero exactly when the ambient rational form is nondegenerate. -/
+@[simp]
 theorem gramDet_ne_zero_iff {ι : Type v} [Fintype ι] [DecidableEq ι]
     (e : Basis ι ℤ L) :
     L.gramDet e ≠ 0 ↔ L.form.Nondegenerate := by
@@ -188,6 +188,7 @@ theorem determinant_eq_gramDet (L : IntegralLattice V) {ι : Type v} [Fintype ι
 
 /-- The basis-independent determinant is nonzero exactly when the ambient rational form is
 nondegenerate. -/
+@[simp]
 theorem determinant_ne_zero_iff (L : IntegralLattice V) :
     L.determinant ≠ 0 ↔ L.form.Nondegenerate := by
   classical
@@ -198,18 +199,25 @@ determinant. -/
 noncomputable def discriminant (L : IntegralLattice V) : ℕ :=
   L.determinant.natAbs
 
+/-- Unfolding the discriminant to the absolute value of the signed determinant. -/
+@[simp]
+theorem discriminant_def (L : IntegralLattice V) :
+    L.discriminant = L.determinant.natAbs :=
+  (rfl)
+
 /-- The discriminant is the absolute value of the Gram determinant in every carrier basis. -/
 theorem discriminant_eq_natAbs_gramDet (L : IntegralLattice V) {ι : Type v} [Fintype ι]
     [DecidableEq ι] (e : Basis ι ℤ L) :
     L.discriminant = (L.gramDet e).natAbs := by
   classical
-  rw [discriminant, L.determinant_eq_gramDet e]
+  rw [discriminant_def, L.determinant_eq_gramDet e]
 
 /-- The discriminant is positive exactly when the ambient rational form is nondegenerate. -/
+@[simp]
 theorem discriminant_pos_iff (L : IntegralLattice V) :
     0 < L.discriminant ↔ L.form.Nondegenerate := by
   classical
-  rw [discriminant, Int.natAbs_pos, determinant_ne_zero_iff]
+  rw [discriminant_def, Int.natAbs_pos, determinant_ne_zero_iff]
 
 end Invariants
 


### PR DESCRIPTION
This PR adds the IntegralLattices Layer 1 Gram-invariant API: define the integral Gram matrix of every carrier basis, identify its rational extension with the ambient form matrix, prove that its signed determinant is unchanged under arbitrary changes of basis, and expose basis-free signed determinant and nonnegative discriminant invariants. It also proves the roadmap's exact nondegeneracy criterion, namely that a carrier Gram determinant is nonzero exactly when the ambient rational bilinear form is nondegenerate.

The preferred `CFSGStatement` roadmap has no coherent unclaimed sorry-free next step at present: its direct zero-case statement is already in flight, while its remaining Lie-type layers are explicitly blocked on RootSystems Layer 6 and ReductiveGroups Layer 9 work that is itself already substantially claimed or in flight. The next viable unclaimed critical-path step is therefore the IntegralLattices Layer 1 target: “For every carrier basis, define the integral Gram matrix … [and] define the signed determinant and its nonnegative absolute value [with] change-of-basis invariance.”

This closes that Gram-matrix and basis-free determinant target within the Layer 1 “lattices with forms” milestone. After this PR, Layer 1 still needs the Gram-matrix constructor's nondegeneracy instance, isometry invariance, and the remaining form operations and lattice examples; Layer 2 will then relate this discriminant to the finite dual quotient.

The proofs reuse Mathlib's `LinearMap.BilinForm.toMatrix_mul_basis_toMatrix`, `Basis.isUnit_det`, `Matrix.det_submatrix_equiv_self`, `LinearMap.BilinForm.nondegenerate_iff_det_ne_zero`, and integral determinant-cast infrastructure. No Mathlib implementation is vendored.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"gram-matrix-determinant"}-->

🤖 Prepared with Codex
