### PR TITLE
feat(EllipticCurve): the affine point-place dictionary

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
@@ -66,12 +66,17 @@ theorem algHom_mk_eq_evalEval (f : W.CoordinateRing →ₐ[R] R) (p : R[X][Y]) :
       p.evalEval
         (f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W (C X)))
         (f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W Y)) := by
+  -- `f` precomposed with the quotient map, as an `R`-algebra map on bivariate polynomials
   let g : R[X][Y] →ₐ[R] R :=
     f.comp ((AdjoinRoot.mkₐ W.polynomial).restrictScalars R)
-  have hg := (aevalAevalEquiv R R).apply_symm_apply g
-  change g p = p.evalEval (g (C X)) (g Y)
-  exact (DFunLike.congr_fun hg.symm p).trans
-    (congrFun (coe_aevalAeval_eq_evalEval (g (C X)) (g Y)) p)
+  have hg (q : R[X][Y]) : g q = f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W q) := by
+    simp only [g, AlgHom.comp_apply, AlgHom.restrictScalars_apply, AdjoinRoot.coe_mkₐ]
+  -- `g` is in the image of `aevalAevalEquiv`, hence is evaluation at the images of `X` and `Y`
+  have key : ⇑g = evalEval (g (C X)) (g Y) := by
+    conv_lhs => rw [← (aevalAevalEquiv R R).apply_symm_apply g, aevalAevalEquiv_symm_apply,
+      aevalAevalEquiv_apply, coe_aevalAeval_eq_evalEval]
+  rw [← hg]
+  exact congrFun key p
 
 /-- The images of the coordinate functions under an algebra homomorphism from the coordinate ring
 to the base ring satisfy the Weierstrass equation. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
@@ -20,8 +20,6 @@ itself, not a global `WeierstrassCurve R`.
 
 * `TauCeti.WeierstrassCurve.evalEval_eq_of_mk_eq`: bivariate polynomials that are equal in the
   coordinate ring evaluate equally at a point of the curve.
-* `TauCeti.WeierstrassCurve.ringHom_eq_evalEvalRingHom`: a ring homomorphism on bivariate
-  polynomials that fixes constants is evaluation at the images of the variables.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.algHom_mk_eq_evalEval`: an algebra homomorphism
   from the coordinate ring is evaluation at the images of the coordinate functions, and
   `TauCeti.WeierstrassCurve.Affine.CoordinateRing.equation_of_algHom` says that those images
@@ -57,17 +55,6 @@ theorem evalEval_eq_of_mk_eq (h : W.Equation x y) {p q : R[X][Y]}
   have hev := AdjoinRoot.evalEval_mk (p := W.polynomial) h
   exact hev p ▸ hev q ▸ congrArg _ hpq
 
-/-- A ring homomorphism from bivariate polynomials that fixes the constant coefficients is
-evaluation at the images of the two variables. -/
-theorem ringHom_eq_evalEvalRingHom (g : R[X][Y] →+* R)
-    (hg : ∀ c : R, g (C (C c)) = c) :
-    g = evalEvalRingHom (g (C X)) (g Y) := by
-  refine Polynomial.ringHom_ext' (Polynomial.ringHom_ext' ?_ ?_) ?_
-  · ext c
-    simp only [RingHom.comp_apply, hg, coe_evalRingHom, eval_C]
-  · simp
-  · simp
-
 namespace Affine.CoordinateRing
 
 variable {W : _root_.WeierstrassCurve.Affine R}
@@ -79,19 +66,12 @@ theorem algHom_mk_eq_evalEval (f : W.CoordinateRing →ₐ[R] R) (p : R[X][Y]) :
       p.evalEval
         (f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W (C X)))
         (f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W Y)) := by
-  have hconstants : ∀ c : R,
-      (f.toRingHom.comp (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W)) (C (C c)) = c :=
-    fun c ↦ by
-    rw [RingHom.comp_apply]
-    have hCC : _root_.WeierstrassCurve.Affine.CoordinateRing.mk W (C (C c)) =
-        algebraMap R W.CoordinateRing c := by
-      rw [IsScalarTower.algebraMap_apply R R[X] W.CoordinateRing, AdjoinRoot.algebraMap_eq]
-      simp
-    rw [hCC]
-    exact f.commutes c
-  exact DFunLike.congr_fun
-    (ringHom_eq_evalEvalRingHom
-      (f.toRingHom.comp (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W)) hconstants) p
+  let g : R[X][Y] →ₐ[R] R :=
+    f.comp ((AdjoinRoot.mkₐ W.polynomial).restrictScalars R)
+  have hg := (aevalAevalEquiv R R).apply_symm_apply g
+  change g p = p.evalEval (g (C X)) (g Y)
+  exact (DFunLike.congr_fun hg.symm p).trans
+    (congrFun (coe_aevalAeval_eq_evalEval (g (C X)) (g Y)) p)
 
 /-- The images of the coordinate functions under an algebra homomorphism from the coordinate ring
 to the base ring satisfy the Weierstrass equation. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
@@ -71,12 +71,19 @@ theorem algHom_mk_eq_evalEval (f : W.CoordinateRing →ₐ[R] R) (p : R[X][Y]) :
     f.comp ((AdjoinRoot.mkₐ W.polynomial).restrictScalars R)
   have hg (q : R[X][Y]) : g q = f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W q) := by
     simp only [g, AlgHom.comp_apply, AlgHom.restrictScalars_apply, AdjoinRoot.coe_mkₐ]
-  -- `g` is in the image of `aevalAevalEquiv`, hence is evaluation at the images of `X` and `Y`
-  have key : ⇑g = evalEval (g (C X)) (g Y) := by
-    conv_lhs => rw [← (aevalAevalEquiv R R).apply_symm_apply g, aevalAevalEquiv_symm_apply,
-      aevalAevalEquiv_apply, coe_aevalAeval_eq_evalEval]
+  have key : g.toRingHom = evalEvalRingHom (g (C X)) (g Y) := by
+    apply Polynomial.ringHom_ext'
+    · apply Polynomial.ringHom_ext'
+      · ext r
+        simp only [RingHom.comp_apply, coe_evalRingHom, eval_C]
+        have hCC : (C (C r) : R[X][Y]) = algebraMap R R[X][Y] r :=
+          (congrFun coe_algebraMap_eq_CC r).symm
+        rw [hCC]
+        exact g.commutes r
+      · simp
+    · simp
   rw [← hg]
-  exact congrFun key p
+  exact RingHom.congr_fun key p
 
 /-- The images of the coordinate functions under an algebra homomorphism from the coordinate ring
 to the base ring satisfy the Weierstrass equation. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
@@ -11,22 +11,30 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
 
 The coordinate ring `R[W]` of an affine Weierstrass curve `W` is `AdjoinRoot W.polynomial`, so at a
 point `(x, y)` satisfying the Weierstrass equation the evaluation map `Polynomial.evalEval x y`
-factors through it, by Mathlib's `AdjoinRoot.evalEval`. The statement below is about the affine
-model `WeierstrassCurve.Affine R` itself, not about a global `WeierstrassCurve R`. This file
-records the one consequence that factorisation is wanted for: an identity between bivariate
-polynomials that holds only in `R[W]` may be evaluated at any point of `W`.
+factors through it, by Mathlib's `AdjoinRoot.evalEval`. Conversely, every `R`-algebra homomorphism
+from `R[W]` to `R` is evaluation at the images of the coordinate functions, and those images
+satisfy the equation. These statements concern the affine model `WeierstrassCurve.Affine R`
+itself, not a global `WeierstrassCurve R`.
 
 ## Main results
 
 * `TauCeti.WeierstrassCurve.evalEval_eq_of_mk_eq`: bivariate polynomials that are equal in the
   coordinate ring evaluate equally at a point of the curve.
+* `TauCeti.WeierstrassCurve.ringHom_eq_evalEvalRingHom`: a ring homomorphism on bivariate
+  polynomials that fixes constants is evaluation at the images of the variables.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.algHom_mk_eq_evalEval`: an algebra homomorphism
+  from the coordinate ring is evaluation at the images of the coordinate functions, and
+  `TauCeti.WeierstrassCurve.Affine.CoordinateRing.equation_of_algHom` says that those images
+  satisfy the Weierstrass equation.
 
 Stated over an arbitrary commutative ring; the curve need not be elliptic, and `R` need not be a
 domain, since the statement is exactly the factorisation and nothing more.
 
 This supports the Nagell–Lutz route of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item
 "The torsion subgroup and Nagell–Lutz", whose division-polynomial identities Mathlib states in the
-coordinate ring but which are consumed at points of the curve.
+coordinate ring but which are consumed at points of the curve. The converse evaluation statements
+also support Layer 0's point–place dictionary by recovering an equation solution from a residue
+degree-one ideal.
 -/
 
 public section
@@ -48,6 +56,53 @@ theorem evalEval_eq_of_mk_eq (h : W.Equation x y) {p q : R[X][Y]}
     p.evalEval x y = q.evalEval x y := by
   have hev := AdjoinRoot.evalEval_mk (p := W.polynomial) h
   exact hev p ▸ hev q ▸ congrArg _ hpq
+
+/-- A ring homomorphism from bivariate polynomials that fixes the constant coefficients is
+evaluation at the images of the two variables. -/
+theorem ringHom_eq_evalEvalRingHom (g : R[X][Y] →+* R)
+    (hg : ∀ c : R, g (C (C c)) = c) :
+    g = evalEvalRingHom (g (C X)) (g Y) := by
+  refine Polynomial.ringHom_ext' (Polynomial.ringHom_ext' ?_ ?_) ?_
+  · ext c
+    simp only [RingHom.comp_apply, hg, coe_evalRingHom, eval_C]
+  · simp
+  · simp
+
+namespace Affine.CoordinateRing
+
+variable {W : _root_.WeierstrassCurve.Affine R}
+
+/-- An algebra homomorphism from the coordinate ring to the base ring is evaluation at the images
+of the two coordinate functions. -/
+theorem algHom_mk_eq_evalEval (f : W.CoordinateRing →ₐ[R] R) (p : R[X][Y]) :
+    f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W p) =
+      p.evalEval
+        (f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W (C X)))
+        (f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W Y)) := by
+  have hconstants : ∀ c : R,
+      (f.toRingHom.comp (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W)) (C (C c)) = c :=
+    fun c ↦ by
+    rw [RingHom.comp_apply]
+    have hCC : _root_.WeierstrassCurve.Affine.CoordinateRing.mk W (C (C c)) =
+        algebraMap R W.CoordinateRing c := by
+      rw [IsScalarTower.algebraMap_apply R R[X] W.CoordinateRing, AdjoinRoot.algebraMap_eq]
+      simp
+    rw [hCC]
+    exact f.commutes c
+  exact DFunLike.congr_fun
+    (ringHom_eq_evalEvalRingHom
+      (f.toRingHom.comp (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W)) hconstants) p
+
+/-- The images of the coordinate functions under an algebra homomorphism from the coordinate ring
+to the base ring satisfy the Weierstrass equation. -/
+theorem equation_of_algHom (f : W.CoordinateRing →ₐ[R] R) :
+    W.Equation
+      (f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W (C X)))
+      (f (_root_.WeierstrassCurve.Affine.CoordinateRing.mk W Y)) := by
+  rw [_root_.WeierstrassCurve.Affine.Equation, ← algHom_mk_eq_evalEval f W.polynomial,
+    AdjoinRoot.mk_self, map_zero]
+
+end Affine.CoordinateRing
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
@@ -145,7 +145,7 @@ lands in the *degree-one* places. -/
 theorem pointPlace.finrank_residueField_eq_one {y : F} (h : W.Equation x y) :
     Module.finrank F (W.CoordinateRing ⧸ (pointPlace h).asIdeal) = 1 := by
   rw [pointPlace_asIdeal]
-  exact finrank_quotient_XYIdeal h
+  rw [(CoordinateRing.quotientXYIdealEquiv h).toLinearEquiv.finrank_eq, Module.finrank_self]
 
 /-- **Every degree-one place is the place of a point**, the converse of
 `pointPlace.finrank_residueField_eq_one`. -/
@@ -157,7 +157,7 @@ theorem exists_pointPlace_eq {v : HeightOneSpectrum W.CoordinateRing}
 
 variable (W) in
 /-- Send a solution of `W.Equation` to its degree-one place. -/
-noncomputable def equationToDegreeOnePlace
+private noncomputable def equationToDegreeOnePlace
     (p : {xy : F × F // W.Equation xy.1 xy.2}) :
     {v : HeightOneSpectrum W.CoordinateRing //
       Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1} :=
@@ -165,7 +165,8 @@ noncomputable def equationToDegreeOnePlace
 
 variable (W) in
 /-- Sending an equation solution to its degree-one place is bijective. -/
-theorem equationToDegreeOnePlace_bijective : Function.Bijective (equationToDegreeOnePlace W) :=
+private theorem equationToDegreeOnePlace_bijective :
+    Function.Bijective (equationToDegreeOnePlace W) :=
   ⟨fun p q h ↦ Subtype.ext <| Prod.ext_iff.mpr <|
       (pointPlace_eq_iff p.2 q.2).mp (Subtype.ext_iff.mp h),
     fun v ↦ by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
@@ -9,12 +9,12 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.XYIdealMaximal
 public import Mathlib.RingTheory.DedekindDomain.AdicValuation
 
 /-!
-# The affine points of an elliptic curve are its degree-one affine places
+# Solutions of a Weierstrass equation are its degree-one affine places
 
-For an elliptic curve `W` over a field, the coordinate ring is a Dedekind domain and the ideal
-`⟨X - x, Y - y⟩ = XYIdeal W x (C y)` of a point `(x, y)` of the curve is maximal and nonzero. It is
-therefore a point of `IsDedekindDomain.HeightOneSpectrum W.CoordinateRing`, which is Mathlib's
-type of nonzero primes and carries the adic valuation on the function field.
+For an affine Weierstrass curve `W` over a field whose coordinate ring is a Dedekind domain, the
+ideal `⟨X - x, Y - y⟩ = XYIdeal W x (C y)` of a solution `(x, y)` of `W.Equation` is maximal and
+nonzero. It is therefore a point of `IsDedekindDomain.HeightOneSpectrum W.CoordinateRing`, which
+is Mathlib's type of nonzero primes and carries the adic valuation on the function field.
 
 This file builds that place and identifies which places arise: exactly those of **degree one**, the
 degree of a place being the rank of its residue field over the base field. A point has degree one
@@ -27,14 +27,17 @@ a residue field of degree `d` over `F` and is the place of no rational point at 
 over an algebraically closed base that every place has degree one, so that points correspond to
 *all* nonzero primes.
 
+When `W` is elliptic, Mathlib's `Affine.equation_iff_nonsingular` identifies the solutions of
+`W.Equation` with the affine points in `W.toAffine.Point`, namely the points other than `0`.
+
 ## Main definitions
 
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace`: the place — the height-one prime of
   the coordinate ring — attached to a point of the curve, built with Mathlib's
   `IsDedekindDomain.HeightOneSpectrum.ofPrime`.
-* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.equationEquivPointPlace`: **the affine
-  point–place dictionary** — `pointPlace` as an equivalence between the points of the curve and
-  the degree-one places.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.equationEquivDegreeOnePlace`: **the affine
+  point–place dictionary** — `pointPlace` as an equivalence between solutions of `W.Equation`
+  and the degree-one places.
 
 ## Main results
 
@@ -44,7 +47,7 @@ over an algebraically closed base that every place has degree one, so that point
   two points have the same place exactly when they have the same coordinates.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace.finrank_residueField_eq_one`: the
   place of a point has degree one.
-* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.exists_pointPlace_eq`: consequently every
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.exists_pointPlace_eq`: conversely, every
   degree-one place is the place of a point.
 
 `(pointPlace h).valuation W.FunctionField` is then the associated multiplicative adic valuation on
@@ -60,7 +63,8 @@ whose §Places asks for the affine places as the maximal ideals of the coordinat
 an API of `ord_v` and uniformisers, and for the point–place dictionary: "for elliptic `W`,
 `W.toAffine.Point` is in bijection with the degree-`1` places: `O ↦ infinityPlace`, and an affine
 nonsingular `(x₀, y₀) ↦` the maximal ideal `(X − x₀, Y − y₀)`". This is the affine half of that
-dictionary, in both directions. The place at infinity
+dictionary at the level of equation solutions; for elliptic `W`, `equation_iff_nonsingular`
+identifies its domain with the nonzero affine points. The place at infinity
 (`TauCeti.WeierstrassCurve.Affine.infinityPlace`) is a valuation on the function field rather than
 a prime of the coordinate ring, so the two are not yet terms of one type of places, although they
 are already known to be distinct places
@@ -88,6 +92,14 @@ inverses, powers, uniformisers. None of that is reproduced: once the point is pr
 `HeightOneSpectrum`, those are Mathlib's `Valuation.map_mul`, `Valuation.map_add`,
 `Valuation.zero_iff`, `Valuation.map_inv`, `Valuation.map_add_of_distinct_val` and
 `IsDedekindDomain.HeightOneSpectrum.valuation_exists_uniformizer`.
+
+The packaged equivalence corresponds to AINTLIB's `smoothPointEquivHeightOneSpectrum` in
+`projects/HasseWeil/HasseWeil/Foundation/Curves/Valuation/SmoothPointPrime.lean`
+(`github.com/CBirkbeck/AINTLIB @ 1c1c74664e40`, Apache-2.0; Authors: Chris Birkbeck). That version
+uses `SmoothPlaneCurve` and `SmoothPoint` wrappers, assumes a maximal-ideal hypothesis and
+`[IsAlgClosed F]`, and reaches all height-one primes. Here the domain is the equation-solution
+subtype and the codomain is the degree-one places over an arbitrary field. The preceding
+"not a port" statement concerns only the `ord_P` valuation API.
 -/
 
 public section
@@ -102,8 +114,8 @@ variable {F : Type*} [Field F] {W : _root_.WeierstrassCurve.Affine F} {x : F}
 
 variable [IsDedekindDomain W.CoordinateRing]
 
-/-- **The place of an affine point of an elliptic curve**: the ideal `⟨X - x, Y - y⟩` as a nonzero
-prime of the coordinate ring, for a point `(x, y)` of the curve. The Dedekind hypothesis is an
+/-- **The place of a solution of a Weierstrass equation**: the ideal `⟨X - x, Y - y⟩` as a nonzero
+prime of the coordinate ring, for a solution `(x, y)` of `W.Equation`. The Dedekind hypothesis is an
 instance argument; for an elliptic curve it is
 `TauCeti.WeierstrassCurve.Affine.isDedekindDomain_coordinateRing`. -/
 noncomputable def pointPlace {y : F} (h : W.Equation x y) :
@@ -132,45 +144,60 @@ lands in the *degree-one* places. -/
 @[simp]
 theorem pointPlace.finrank_residueField_eq_one {y : F} (h : W.Equation x y) :
     Module.finrank F (W.CoordinateRing ⧸ (pointPlace h).asIdeal) = 1 := by
-  rw [(Ideal.quotientEquivAlgOfEq F (pointPlace_asIdeal h)).toLinearEquiv.finrank_eq,
-    (CoordinateRing.quotientXYIdealEquiv h).toLinearEquiv.finrank_eq, Module.finrank_self]
+  rw [pointPlace_asIdeal]
+  exact finrank_quotient_XYIdeal h
 
 /-- **Every degree-one place is the place of a point**, the converse of
 `pointPlace.finrank_residueField_eq_one`. -/
 theorem exists_pointPlace_eq {v : HeightOneSpectrum W.CoordinateRing}
     (hv : Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1) :
     ∃ (x y : F) (h : W.Equation x y), pointPlace h = v := by
-  obtain ⟨x, y, h, hI⟩ := exists_equation_and_eq_XYIdeal hv
+  obtain ⟨x, y, h, hI⟩ := finrank_quotient_eq_one_iff.mp hv
   exact ⟨x, y, h, by rw [HeightOneSpectrum.ext_iff, pointPlace_asIdeal, hI]⟩
 
 variable (W) in
-/-- **The affine point–place dictionary**: the points of the curve correspond to the degree-one
-places of its coordinate ring, a point going to the prime `⟨X - x, Y - y⟩`. Injectivity is
-`pointPlace_eq_iff` and surjectivity is `exists_pointPlace_eq`. -/
-noncomputable def equationEquivPointPlace :
+/-- Send a solution of `W.Equation` to its degree-one place. -/
+noncomputable def equationToDegreeOnePlace
+    (p : {xy : F × F // W.Equation xy.1 xy.2}) :
+    {v : HeightOneSpectrum W.CoordinateRing //
+      Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1} :=
+  ⟨pointPlace p.2, pointPlace.finrank_residueField_eq_one p.2⟩
+
+variable (W) in
+/-- Sending an equation solution to its degree-one place is bijective. -/
+theorem equationToDegreeOnePlace_bijective : Function.Bijective (equationToDegreeOnePlace W) :=
+  ⟨fun p q h ↦ Subtype.ext <| Prod.ext_iff.mpr <|
+      (pointPlace_eq_iff p.2 q.2).mp (Subtype.ext_iff.mp h),
+    fun v ↦ by
+      obtain ⟨x, y, h, hv⟩ := exists_pointPlace_eq v.2
+      exact ⟨⟨(x, y), h⟩, Subtype.ext hv⟩⟩
+
+variable (W) in
+/-- **The affine point–place dictionary**: the solutions of `W.Equation` correspond to the
+degree-one places of its coordinate ring, a solution going to the prime `⟨X - x, Y - y⟩`.
+For elliptic `W`, these solutions are the nonzero affine points by `equation_iff_nonsingular`.
+Injectivity is `pointPlace_eq_iff` and surjectivity is `exists_pointPlace_eq`. -/
+noncomputable def equationEquivDegreeOnePlace :
     {xy : F × F // W.Equation xy.1 xy.2} ≃
       {v : HeightOneSpectrum W.CoordinateRing //
         Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1} :=
-  Equiv.ofBijective (fun p ↦ ⟨pointPlace p.2, pointPlace.finrank_residueField_eq_one p.2⟩)
-    ⟨fun p q h ↦ Subtype.ext <| Prod.ext_iff.mpr <|
-        (pointPlace_eq_iff p.2 q.2).mp (Subtype.ext_iff.mp h),
-      fun v ↦ by
-        obtain ⟨x, y, h, hv⟩ := exists_pointPlace_eq v.2
-        exact ⟨⟨(x, y), h⟩, Subtype.ext hv⟩⟩
+  Equiv.ofBijective (equationToDegreeOnePlace W) (equationToDegreeOnePlace_bijective W)
 
 /-- The dictionary sends a point to its place. -/
 @[simp]
-theorem coe_equationEquivPointPlace (p : {xy : F × F // W.Equation xy.1 xy.2}) :
-    (equationEquivPointPlace W p : HeightOneSpectrum W.CoordinateRing) = pointPlace p.2 := (rfl)
+theorem equationEquivDegreeOnePlace_apply_coe (p : {xy : F × F // W.Equation xy.1 xy.2}) :
+    (equationEquivDegreeOnePlace W p : HeightOneSpectrum W.CoordinateRing) = pointPlace p.2 := by
+  rw [equationEquivDegreeOnePlace, Equiv.ofBijective_apply]
+  rfl
 
 /-- Reading the dictionary backwards and then taking the place recovers the original place. -/
 @[simp]
-theorem pointPlace_equationEquivPointPlace_symm
+theorem pointPlace_equationEquivDegreeOnePlace_symm_apply
     (v : {v : HeightOneSpectrum W.CoordinateRing //
       Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1}) :
-    pointPlace ((equationEquivPointPlace W).symm v).2 = v.1 := by
-  rw [← coe_equationEquivPointPlace]
-  exact congrArg Subtype.val ((equationEquivPointPlace W).apply_symm_apply v)
+    pointPlace ((equationEquivDegreeOnePlace W).symm v).2 = v.1 := by
+  rw [← equationEquivDegreeOnePlace_apply_coe]
+  exact congrArg Subtype.val ((equationEquivDegreeOnePlace W).apply_symm_apply v)
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
@@ -9,18 +9,43 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.XYIdealMaximal
 public import Mathlib.RingTheory.DedekindDomain.AdicValuation
 
 /-!
-# The place of an affine point of an elliptic curve
+# The affine points of an elliptic curve are its degree-one affine places
 
 For an elliptic curve `W` over a field, the coordinate ring is a Dedekind domain and the ideal
 `⟨X - x, Y - y⟩ = XYIdeal W x (C y)` of a point `(x, y)` of the curve is maximal and nonzero. It is
 therefore a point of `IsDedekindDomain.HeightOneSpectrum W.CoordinateRing`, which is Mathlib's
 type of nonzero primes and carries the adic valuation on the function field.
 
+This file builds that place and identifies which places arise: exactly those of **degree one**, the
+degree of a place being the rank of its residue field over the base field. A point has degree one
+because the quotient by its ideal is the base field, by Mathlib's `quotientXYIdealEquiv`.
+Conversely a proper ideal `I` of `F[W]` whose quotient has rank one is the ideal of a point. The
+rank hypothesis makes `algebraMap F (F[W] ⧸ I)` bijective, so composing the quotient map with its
+inverse gives a ring homomorphism `ρ : F[W] → F` fixing the constants; being a ring homomorphism
+out of `F[X][Y]/⟨W(X, Y)⟩`, it is evaluation at the pair `(ρ x, ρ y)`, which therefore satisfies
+the Weierstrass equation. The maximal ideal `⟨X - ρ x, Y - ρ y⟩` is contained in the proper ideal
+`I`, hence equal to it.
+
+Neither direction needs ellipticity or a Dedekind hypothesis: both are statements about an ideal
+of the coordinate ring. Those hypotheses enter only in the packaging, where the places and the
+point group are named.
+
+The degree hypothesis is part of the statement, not a convenience: a place of degree `d > 1` has
+a residue field of degree `d` over `F` and is the place of no rational point at all. It is only
+over an algebraically closed base that every place has degree one, so that points correspond to
+*all* nonzero primes.
+
 ## Main definitions
 
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace`: the place — the height-one prime of
   the coordinate ring — attached to a point of the curve, built with Mathlib's
   `IsDedekindDomain.HeightOneSpectrum.ofPrime`.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.equationEquivPointPlace`: **the affine
+  point–place dictionary** — `pointPlace` as an equivalence between the points of the curve and
+  the degree-one places.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointEquivPointPlace`: the same dictionary read
+  on the point group of an elliptic curve, whose extra element — the point at infinity — is the
+  `WithZero` adjoined to the degree-one places.
 
 ## Main results
 
@@ -28,9 +53,14 @@ type of nonzero primes and carries the adic valuation on the function field.
   identifying its underlying ideal as `XYIdeal W x (C y)`.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace_eq_iff`: `pointPlace` is injective —
   two points have the same place exactly when they have the same coordinates.
-* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace.finrank_residueField_eq_one`:
-  consequently the
-  place of a point has degree one: its residue field is one-dimensional over the base field.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.finrank_quotient_XYIdeal` and
+  `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace.finrank_residueField_eq_one`:
+  the place of a point has degree one.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.exists_equation_and_eq_XYIdeal`: **the
+  classification** — a proper ideal whose quotient has rank one over the base field is the ideal
+  of a point of the curve.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.exists_pointPlace_eq`: consequently every
+  degree-one place is the place of a point.
 
 `(pointPlace h).valuation W.FunctionField` is then the associated multiplicative adic valuation on
 the function field, taking values in `ℤᵐ⁰` and normalised so that a uniformiser has value
@@ -42,9 +72,18 @@ uniformiser — comes with it.
 
 `TauCetiRoadmap/EllipticCurves/README.md`, **Layer 0** (the function field, places, and divisors),
 whose §Places asks for the affine places as the maximal ideals of the coordinate ring together with
-an API of `ord_v` and uniformisers, and for the point–place dictionary. This is the direction that
-sends a point to a place. The layer seeds no declaration this competes with, and records that the
-design is coordinated with D. Angdinata's in-flight upstream `CoordinateRing` work.
+an API of `ord_v` and uniformisers, and for the point–place dictionary: "for elliptic `W`,
+`W.toAffine.Point` is in bijection with the degree-`1` places: `O ↦ infinityPlace`, and an affine
+nonsingular `(x₀, y₀) ↦` the maximal ideal `(X − x₀, Y − y₀)`". This is the affine half of that
+dictionary, in both directions. The place at infinity
+(`TauCeti.WeierstrassCurve.Affine.infinityPlace`) is a valuation on the function field rather than
+a prime of the coordinate ring, so the two are not yet terms of one type of places, although they
+are already known to be distinct places
+(`TauCeti.WeierstrassCurve.Affine.infinityPlace_ne_heightOneSpectrum_valuation`). Until Layer 0
+fixes that type, the point at infinity is the adjoined element of `pointEquivPointPlace`, and
+identifying that element with the place at infinity is what remains. The layer seeds no declaration
+this competes with, and records that the design is coordinated with D. Angdinata's in-flight
+upstream `CoordinateRing` work.
 
 ## Provenance
 
@@ -55,6 +94,20 @@ The degree-one result corresponds to AINTLIB's `HasseWeil/Curves/ResidueFieldAtS
 degree additionally assumes an algebraically closed base; here the wrappers are dropped, the
 hypothesis is the curve equation, no closure is needed, and the content is Mathlib's
 `quotientXYIdealEquiv` rather than a fresh construction.
+
+The classification has a counterpart in the same project, in
+`projects/HasseWeil/HasseWeil/Foundation/Curves/Valuation/NormValuation.lean` at
+`github.com/CBirkbeck/AINTLIB @ 1c1c74664e40` (Apache-2.0 per that file's header;
+Authors: Chris Birkbeck): `exists_coordinates_of_isMaximal_of_surjective`,
+`equation_of_coordinates_of_field` and `exists_smoothPoint_of_isMaximal_of_surjective`, packaged
+in `Valuation/SmoothPointPrime.lean` as `smoothPointEquivHeightOneSpectrum`. That statement is
+about a *maximal* ideal of the coordinate ring of a `SmoothPlaneCurve`, hypothesises surjectivity
+of `algebraMap F (F[C] ⧸ M)`, assumes ellipticity throughout, and its packaged bijection is onto
+all height-one primes under `[IsAlgClosed F]`. The development below is written directly against
+Mathlib's `XYIdeal`: the ideal is only assumed proper, the hypothesis is the residue degree, no
+ellipticity is used until the point group is named, and the bijection is with the degree-one
+places over an arbitrary field, which is the roadmap's statement and the one that survives without
+a closure hypothesis.
 
 The place itself is not a port. AINTLIB's `HasseWeil/Curves/Valuation.lean` builds an `ord_P` for
 its own
@@ -68,13 +121,70 @@ inverses, powers, uniformisers. None of that is reproduced: once the point is pr
 public section
 
 open Polynomial WeierstrassCurve WeierstrassCurve.Affine IsDedekindDomain
+open scoped Polynomial.Bivariate
 
 namespace TauCeti
 
 namespace WeierstrassCurve.Affine.CoordinateRing
 
-variable {F : Type*} [Field F] {W : _root_.WeierstrassCurve.Affine F}
-  [IsDedekindDomain W.CoordinateRing] {x : F}
+variable {F : Type*} [Field F] {W : _root_.WeierstrassCurve.Affine F} {x : F}
+
+/-- **The ideal of a point has residue degree one**: the quotient of the coordinate ring by
+`⟨X - x, Y - y⟩` is one-dimensional over the base field, being the base field itself by Mathlib's
+`quotientXYIdealEquiv`. -/
+theorem finrank_quotient_XYIdeal {y : F} (h : W.Equation x y) :
+    Module.finrank F (W.CoordinateRing ⧸ CoordinateRing.XYIdeal W x (C y)) = 1 := by
+  rw [(CoordinateRing.quotientXYIdealEquiv h).toLinearEquiv.finrank_eq, Module.finrank_self]
+
+/-- **A proper ideal of residue degree one is the ideal of a point.** The quotient map, followed by
+the inverse of the bijection `algebraMap F (F[W] ⧸ I)`, is a ring homomorphism `F[W] → F`; it is
+evaluation at the images `(x, y)` of the two coordinates, so that pair satisfies the Weierstrass
+equation, and the maximal ideal it cuts out is contained in `I`, hence equal to it.
+
+No ellipticity or Dedekind hypothesis is involved; this is the converse of
+`finrank_quotient_XYIdeal`. -/
+theorem exists_equation_and_eq_XYIdeal {I : Ideal W.CoordinateRing} (hI : I ≠ ⊤)
+    (hdeg : Module.finrank F (W.CoordinateRing ⧸ I) = 1) :
+    ∃ (x y : F) (_ : W.Equation x y), I = CoordinateRing.XYIdeal W x (C y) := by
+  have hnt : Nontrivial (W.CoordinateRing ⧸ I) := Ideal.Quotient.nontrivial_iff.mpr hI
+  have hbij : Function.Bijective (algebraMap F (W.CoordinateRing ⧸ I)) :=
+    Algebra.finrank_eq_one_iff_bijective_algebraMap.mp hdeg
+  set e : (W.CoordinateRing ⧸ I) ≃+* F := (RingEquiv.ofBijective _ hbij).symm with he
+  set ρ : W.CoordinateRing →+* F := (e : (W.CoordinateRing ⧸ I) →+* F).comp (Ideal.Quotient.mk I)
+    with hρ
+  have hρmem : ∀ a, ρ a = 0 ↔ a ∈ I := fun a ↦ by
+    rw [hρ, RingHom.comp_apply, RingEquiv.coe_toRingHom, map_eq_zero_iff e e.injective,
+      Ideal.Quotient.eq_zero_iff_mem]
+  have hρalg : ∀ c : F, ρ (algebraMap F W.CoordinateRing c) = c := fun c ↦ by
+    rw [hρ, RingHom.comp_apply, RingEquiv.coe_toRingHom, he, ← Ideal.Quotient.algebraMap_eq,
+      ← IsScalarTower.algebraMap_apply F W.CoordinateRing (W.CoordinateRing ⧸ I) c]
+    exact (RingEquiv.ofBijective _ hbij).symm_apply_apply c
+  set x₀ := ρ (CoordinateRing.mk W (C X)) with hx₀
+  set y₀ := ρ (CoordinateRing.mk W Y) with hy₀
+  -- a ring homomorphism out of the coordinate ring is evaluation at the images of the coordinates
+  have hcomp : ∀ p : F[X][Y], ρ (CoordinateRing.mk W p) = p.evalEval x₀ y₀ := by
+    have h : ρ.comp (CoordinateRing.mk W) = evalEvalRingHom x₀ y₀ := by
+      refine Polynomial.ringHom_ext' (Polynomial.ringHom_ext' ?_ ?_) ?_
+      · ext c
+        have hCC : CoordinateRing.mk W (C (C c)) = algebraMap F W.CoordinateRing c := by
+          rw [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing, AdjoinRoot.algebraMap_eq]
+          simp
+        simp only [RingHom.comp_apply, hCC, hρalg, coe_evalRingHom, eval_C]
+      · simpa using hx₀.symm
+      · simpa using hy₀.symm
+    exact fun p ↦ congrArg (fun f ↦ f p) h
+  have heq : W.Equation x₀ y₀ := by
+    have h0 : ρ (CoordinateRing.mk W W.polynomial) = 0 := by rw [AdjoinRoot.mk_self, map_zero]
+    rwa [hcomp] at h0
+  refine ⟨x₀, y₀, heq, ((XYIdeal_isMaximal_of_equation heq).eq_of_le hI ?_).symm⟩
+  rw [CoordinateRing.XYIdeal, Ideal.span_le, Set.pair_subset_iff]
+  refine ⟨?_, ?_⟩
+  · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.XClass, hcomp]
+    simp [evalEval_C]
+  · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.YClass, hcomp]
+    simp
+
+variable [IsDedekindDomain W.CoordinateRing]
 
 /-- **The place of an affine point of an elliptic curve**: the ideal `⟨X - x, Y - y⟩` as a nonzero
 prime of the coordinate ring, for a point `(x, y)` of the curve. The Dedekind hypothesis is an
@@ -92,8 +202,7 @@ theorem pointPlace_asIdeal {y : F} (h : W.Equation x y) :
   simp [pointPlace]
 
 /-- **`pointPlace` is injective**: two points of the curve have the same place exactly when they
-have the same coordinates. Whether every place arises from a point is a separate statement, not
-proved here. -/
+have the same coordinates. -/
 @[simp]
 theorem pointPlace_eq_iff {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) (h₂ : W.Equation x₂ y₂) :
     pointPlace h₁ = pointPlace h₂ ↔ x₁ = x₂ ∧ y₁ = y₂ := by
@@ -101,19 +210,62 @@ theorem pointPlace_eq_iff {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁
   rw [HeightOneSpectrum.ext_iff, pointPlace_asIdeal, pointPlace_asIdeal]
   exact XYIdeal_eq_iff h₁
 
-
 /-- **The place of a point has degree one.** The degree of a place is the rank of its residue field
 over the base, and here that rank is one — which is the sense in which the point–place dictionary
-lands in the *degree-one* places. (The identification of the residue field with `F` itself is
-Mathlib's `quotientXYIdealEquiv`, used in the proof; only the rank is stated.) -/
+lands in the *degree-one* places. -/
 @[simp]
 theorem pointPlace.finrank_residueField_eq_one {y : F} (h : W.Equation x y) :
     Module.finrank F (W.CoordinateRing ⧸ (pointPlace h).asIdeal) = 1 := by
-  -- the `XYIdeal`-level form is not exported: it would be a one-line wrapper around
-  -- `quotientXYIdealEquiv`, so the rewrite happens here
-  rw [(Ideal.quotientEquivAlgOfEq F (pointPlace_asIdeal h)).toLinearEquiv.finrank_eq,
-    (_root_.WeierstrassCurve.Affine.CoordinateRing.quotientXYIdealEquiv h).toLinearEquiv.finrank_eq,
-    Module.finrank_self]
+  rw [(Ideal.quotientEquivAlgOfEq F (pointPlace_asIdeal h)).toLinearEquiv.finrank_eq]
+  exact finrank_quotient_XYIdeal h
+
+/-- **Every degree-one place is the place of a point**, the converse of
+`pointPlace.finrank_residueField_eq_one`. -/
+theorem exists_pointPlace_eq {v : HeightOneSpectrum W.CoordinateRing}
+    (hv : Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1) :
+    ∃ (x y : F) (h : W.Equation x y), pointPlace h = v := by
+  obtain ⟨x, y, h, hI⟩ := exists_equation_and_eq_XYIdeal v.isPrime.ne_top hv
+  exact ⟨x, y, h, by rw [HeightOneSpectrum.ext_iff, pointPlace_asIdeal, hI]⟩
+
+variable (W) in
+/-- **The affine point–place dictionary**: the points of the curve correspond to the degree-one
+places of its coordinate ring, a point going to the prime `⟨X - x, Y - y⟩`. Injectivity is
+`pointPlace_eq_iff` and surjectivity is `exists_pointPlace_eq`. -/
+noncomputable def equationEquivPointPlace :
+    {xy : F × F // W.Equation xy.1 xy.2} ≃
+      {v : HeightOneSpectrum W.CoordinateRing //
+        Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1} :=
+  Equiv.ofBijective (fun p ↦ ⟨pointPlace p.2, pointPlace.finrank_residueField_eq_one p.2⟩)
+    ⟨fun p q h ↦ Subtype.ext <| Prod.ext_iff.mpr <|
+        (pointPlace_eq_iff p.2 q.2).mp (Subtype.ext_iff.mp h),
+      fun v ↦ by
+        obtain ⟨x, y, h, hv⟩ := exists_pointPlace_eq v.2
+        exact ⟨⟨(x, y), h⟩, Subtype.ext hv⟩⟩
+
+/-- The dictionary sends a point to its place. -/
+@[simp]
+theorem coe_equationEquivPointPlace (p : {xy : F × F // W.Equation xy.1 xy.2}) :
+    (equationEquivPointPlace W p : HeightOneSpectrum W.CoordinateRing) = pointPlace p.2 := (rfl)
+
+variable (W) in
+/-- **The point–place dictionary on the point group** of an elliptic curve: the affine points are
+the degree-one places of the coordinate ring, and the point at infinity is the one further place —
+here the element `WithZero` adjoins, since the place at infinity lives on the function field and
+is not a prime of the coordinate ring. -/
+noncomputable def pointEquivPointPlace [W.IsElliptic] :
+    W.Point ≃ WithZero {v : HeightOneSpectrum W.CoordinateRing //
+      Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1} :=
+  (pointEquiv W).trans (equationEquivPointPlace W).optionCongr
+
+/-- The dictionary sends the point at infinity to the adjoined element. -/
+@[simp]
+theorem pointEquivPointPlace_zero [W.IsElliptic] : pointEquivPointPlace W .zero = none := (rfl)
+
+/-- The dictionary sends an affine point to its place. -/
+@[simp]
+theorem pointEquivPointPlace_mk [W.IsElliptic] {y : F} (h : W.Equation x y) :
+    pointEquivPointPlace W (.mk h) =
+      .some ⟨pointPlace h, pointPlace.finrank_residueField_eq_one h⟩ := (rfl)
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
@@ -27,8 +27,8 @@ the Weierstrass equation. The maximal ideal `⟨X - ρ x, Y - ρ y⟩` is contai
 `I`, hence equal to it.
 
 Neither direction needs ellipticity or a Dedekind hypothesis: both are statements about an ideal
-of the coordinate ring. Those hypotheses enter only in the packaging, where the places and the
-point group are named.
+of the coordinate ring. The Dedekind hypothesis enters only in the packaging, where the places are
+named.
 
 The degree hypothesis is part of the statement, not a convenience: a place of degree `d > 1` has
 a residue field of degree `d` over `F` and is the place of no rational point at all. It is only
@@ -43,9 +43,6 @@ over an algebraically closed base that every place has degree one, so that point
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.equationEquivPointPlace`: **the affine
   point–place dictionary** — `pointPlace` as an equivalence between the points of the curve and
   the degree-one places.
-* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointEquivPointPlace`: the same dictionary read
-  on the point group of an elliptic curve, whose extra element — the point at infinity — is the
-  `WithZero` adjoined to the degree-one places.
 
 ## Main results
 
@@ -79,11 +76,12 @@ dictionary, in both directions. The place at infinity
 (`TauCeti.WeierstrassCurve.Affine.infinityPlace`) is a valuation on the function field rather than
 a prime of the coordinate ring, so the two are not yet terms of one type of places, although they
 are already known to be distinct places
-(`TauCeti.WeierstrassCurve.Affine.infinityPlace_ne_heightOneSpectrum_valuation`). Until Layer 0
-fixes that type, the point at infinity is the adjoined element of `pointEquivPointPlace`, and
-identifying that element with the place at infinity is what remains. The layer seeds no declaration
-this competes with, and records that the design is coordinated with D. Angdinata's in-flight
-upstream `CoordinateRing` work.
+(`TauCeti.WeierstrassCurve.Affine.infinityPlace_ne_heightOneSpectrum_valuation`). The point at
+infinity therefore stays out of the dictionary here: reading it on the whole point group `W.Point`
+has to wait for Layer 0 to fix one type of places holding both `infinityPlace` and the affine ones,
+and is what remains of the milestone. The layer seeds no declaration this competes with, and
+records that the design is coordinated with D. Angdinata's in-flight upstream `CoordinateRing`
+work.
 
 ## Provenance
 
@@ -105,9 +103,8 @@ about a *maximal* ideal of the coordinate ring of a `SmoothPlaneCurve`, hypothes
 of `algebraMap F (F[C] ⧸ M)`, assumes ellipticity throughout, and its packaged bijection is onto
 all height-one primes under `[IsAlgClosed F]`. The development below is written directly against
 Mathlib's `XYIdeal`: the ideal is only assumed proper, the hypothesis is the residue degree, no
-ellipticity is used until the point group is named, and the bijection is with the degree-one
-places over an arbitrary field, which is the roadmap's statement and the one that survives without
-a closure hypothesis.
+ellipticity is used at all, and the bijection is with the degree-one places over an arbitrary
+field, which is the roadmap's statement and the one that survives without a closure hypothesis.
 
 The place itself is not a port. AINTLIB's `HasseWeil/Curves/Valuation.lean` builds an `ord_P` for
 its own
@@ -246,26 +243,6 @@ noncomputable def equationEquivPointPlace :
 @[simp]
 theorem coe_equationEquivPointPlace (p : {xy : F × F // W.Equation xy.1 xy.2}) :
     (equationEquivPointPlace W p : HeightOneSpectrum W.CoordinateRing) = pointPlace p.2 := (rfl)
-
-variable (W) in
-/-- **The point–place dictionary on the point group** of an elliptic curve: the affine points are
-the degree-one places of the coordinate ring, and the point at infinity is the one further place —
-here the element `WithZero` adjoins, since the place at infinity lives on the function field and
-is not a prime of the coordinate ring. -/
-noncomputable def pointEquivPointPlace [W.IsElliptic] :
-    W.Point ≃ WithZero {v : HeightOneSpectrum W.CoordinateRing //
-      Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1} :=
-  (pointEquiv W).trans (equationEquivPointPlace W).optionCongr
-
-/-- The dictionary sends the point at infinity to the adjoined element. -/
-@[simp]
-theorem pointEquivPointPlace_zero [W.IsElliptic] : pointEquivPointPlace W .zero = none := (rfl)
-
-/-- The dictionary sends an affine point to its place. -/
-@[simp]
-theorem pointEquivPointPlace_mk [W.IsElliptic] {y : F} (h : W.Equation x y) :
-    pointEquivPointPlace W (.mk h) =
-      .some ⟨pointPlace h, pointPlace.finrank_residueField_eq_one h⟩ := (rfl)
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
@@ -18,17 +18,9 @@ type of nonzero primes and carries the adic valuation on the function field.
 
 This file builds that place and identifies which places arise: exactly those of **degree one**, the
 degree of a place being the rank of its residue field over the base field. A point has degree one
-because the quotient by its ideal is the base field, by Mathlib's `quotientXYIdealEquiv`.
-Conversely a proper ideal `I` of `F[W]` whose quotient has rank one is the ideal of a point. The
-rank hypothesis makes `algebraMap F (F[W] ⧸ I)` bijective, so composing the quotient map with its
-inverse gives a ring homomorphism `ρ : F[W] → F` fixing the constants; being a ring homomorphism
-out of `F[X][Y]/⟨W(X, Y)⟩`, it is evaluation at the pair `(ρ x, ρ y)`, which therefore satisfies
-the Weierstrass equation. The maximal ideal `⟨X - ρ x, Y - ρ y⟩` is contained in the proper ideal
-`I`, hence equal to it.
-
-Neither direction needs ellipticity or a Dedekind hypothesis: both are statements about an ideal
-of the coordinate ring. The Dedekind hypothesis enters only in the packaging, where the places are
-named.
+because the quotient by its ideal is the base field, by Mathlib's `quotientXYIdealEquiv`; the
+converse ideal-level classification is in `XYIdealMaximal.lean`. The Dedekind hypothesis enters
+only in the packaging, where the places are named.
 
 The degree hypothesis is part of the statement, not a convenience: a place of degree `d > 1` has
 a residue field of degree `d` over `F` and is the place of no rational point at all. It is only
@@ -47,15 +39,11 @@ over an algebraically closed base that every place has degree one, so that point
 ## Main results
 
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace_asIdeal`: a `@[simp]` lemma
-  identifying its underlying ideal as `XYIdeal W x (C y)`.
+  identifying the ideal underlying `pointPlace` as `XYIdeal W x (C y)`.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace_eq_iff`: `pointPlace` is injective —
   two points have the same place exactly when they have the same coordinates.
-* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.finrank_quotient_XYIdeal` and
-  `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace.finrank_residueField_eq_one`:
-  the place of a point has degree one.
-* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.exists_equation_and_eq_XYIdeal`: **the
-  classification** — a proper ideal whose quotient has rank one over the base field is the ideal
-  of a point of the curve.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace.finrank_residueField_eq_one`: the
+  place of a point has degree one.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.exists_pointPlace_eq`: consequently every
   degree-one place is the place of a point.
 
@@ -93,19 +81,6 @@ degree additionally assumes an algebraically closed base; here the wrappers are 
 hypothesis is the curve equation, no closure is needed, and the content is Mathlib's
 `quotientXYIdealEquiv` rather than a fresh construction.
 
-The classification has a counterpart in the same project, in
-`projects/HasseWeil/HasseWeil/Foundation/Curves/Valuation/NormValuation.lean` at
-`github.com/CBirkbeck/AINTLIB @ 1c1c74664e40` (Apache-2.0 per that file's header;
-Authors: Chris Birkbeck): `exists_coordinates_of_isMaximal_of_surjective`,
-`equation_of_coordinates_of_field` and `exists_smoothPoint_of_isMaximal_of_surjective`, packaged
-in `Valuation/SmoothPointPrime.lean` as `smoothPointEquivHeightOneSpectrum`. That statement is
-about a *maximal* ideal of the coordinate ring of a `SmoothPlaneCurve`, hypothesises surjectivity
-of `algebraMap F (F[C] ⧸ M)`, assumes ellipticity throughout, and its packaged bijection is onto
-all height-one primes under `[IsAlgClosed F]`. The development below is written directly against
-Mathlib's `XYIdeal`: the ideal is only assumed proper, the hypothesis is the residue degree, no
-ellipticity is used at all, and the bijection is with the degree-one places over an arbitrary
-field, which is the roadmap's statement and the one that survives without a closure hypothesis.
-
 The place itself is not a port. AINTLIB's `HasseWeil/Curves/Valuation.lean` builds an `ord_P` for
 its own
 `SmoothPlaneCurve` wrapper with about twenty lemmas — multiplicativity, the ultrametric bound,
@@ -118,68 +93,12 @@ inverses, powers, uniformisers. None of that is reproduced: once the point is pr
 public section
 
 open Polynomial WeierstrassCurve WeierstrassCurve.Affine IsDedekindDomain
-open scoped Polynomial.Bivariate
 
 namespace TauCeti
 
 namespace WeierstrassCurve.Affine.CoordinateRing
 
 variable {F : Type*} [Field F] {W : _root_.WeierstrassCurve.Affine F} {x : F}
-
-/-- **The ideal of a point has residue degree one**: the quotient of the coordinate ring by
-`⟨X - x, Y - y⟩` is one-dimensional over the base field, being the base field itself by Mathlib's
-`quotientXYIdealEquiv`. -/
-theorem finrank_quotient_XYIdeal {y : F} (h : W.Equation x y) :
-    Module.finrank F (W.CoordinateRing ⧸ CoordinateRing.XYIdeal W x (C y)) = 1 := by
-  rw [(CoordinateRing.quotientXYIdealEquiv h).toLinearEquiv.finrank_eq, Module.finrank_self]
-
-/-- **A proper ideal of residue degree one is the ideal of a point.** The quotient map, followed by
-the inverse of the bijection `algebraMap F (F[W] ⧸ I)`, is a ring homomorphism `F[W] → F`; it is
-evaluation at the images `(x, y)` of the two coordinates, so that pair satisfies the Weierstrass
-equation, and the maximal ideal it cuts out is contained in `I`, hence equal to it.
-
-No ellipticity or Dedekind hypothesis is involved; this is the converse of
-`finrank_quotient_XYIdeal`. -/
-theorem exists_equation_and_eq_XYIdeal {I : Ideal W.CoordinateRing} (hI : I ≠ ⊤)
-    (hdeg : Module.finrank F (W.CoordinateRing ⧸ I) = 1) :
-    ∃ (x y : F) (_ : W.Equation x y), I = CoordinateRing.XYIdeal W x (C y) := by
-  have hnt : Nontrivial (W.CoordinateRing ⧸ I) := Ideal.Quotient.nontrivial_iff.mpr hI
-  have hbij : Function.Bijective (algebraMap F (W.CoordinateRing ⧸ I)) :=
-    Algebra.finrank_eq_one_iff_bijective_algebraMap.mp hdeg
-  set e : (W.CoordinateRing ⧸ I) ≃+* F := (RingEquiv.ofBijective _ hbij).symm with he
-  set ρ : W.CoordinateRing →+* F := (e : (W.CoordinateRing ⧸ I) →+* F).comp (Ideal.Quotient.mk I)
-    with hρ
-  have hρmem : ∀ a, ρ a = 0 ↔ a ∈ I := fun a ↦ by
-    rw [hρ, RingHom.comp_apply, RingEquiv.coe_toRingHom, map_eq_zero_iff e e.injective,
-      Ideal.Quotient.eq_zero_iff_mem]
-  have hρalg : ∀ c : F, ρ (algebraMap F W.CoordinateRing c) = c := fun c ↦ by
-    rw [hρ, RingHom.comp_apply, RingEquiv.coe_toRingHom, he, ← Ideal.Quotient.algebraMap_eq,
-      ← IsScalarTower.algebraMap_apply F W.CoordinateRing (W.CoordinateRing ⧸ I) c]
-    exact (RingEquiv.ofBijective _ hbij).symm_apply_apply c
-  set x₀ := ρ (CoordinateRing.mk W (C X)) with hx₀
-  set y₀ := ρ (CoordinateRing.mk W Y) with hy₀
-  -- a ring homomorphism out of the coordinate ring is evaluation at the images of the coordinates
-  have hcomp : ∀ p : F[X][Y], ρ (CoordinateRing.mk W p) = p.evalEval x₀ y₀ := by
-    have h : ρ.comp (CoordinateRing.mk W) = evalEvalRingHom x₀ y₀ := by
-      refine Polynomial.ringHom_ext' (Polynomial.ringHom_ext' ?_ ?_) ?_
-      · ext c
-        have hCC : CoordinateRing.mk W (C (C c)) = algebraMap F W.CoordinateRing c := by
-          rw [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing, AdjoinRoot.algebraMap_eq]
-          simp
-        simp only [RingHom.comp_apply, hCC, hρalg, coe_evalRingHom, eval_C]
-      · simpa using hx₀.symm
-      · simpa using hy₀.symm
-    exact fun p ↦ congrArg (fun f ↦ f p) h
-  have heq : W.Equation x₀ y₀ := by
-    have h0 : ρ (CoordinateRing.mk W W.polynomial) = 0 := by rw [AdjoinRoot.mk_self, map_zero]
-    rwa [hcomp] at h0
-  refine ⟨x₀, y₀, heq, ((XYIdeal_isMaximal_of_equation heq).eq_of_le hI ?_).symm⟩
-  rw [CoordinateRing.XYIdeal, Ideal.span_le, Set.pair_subset_iff]
-  refine ⟨?_, ?_⟩
-  · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.XClass, hcomp]
-    simp [evalEval_C]
-  · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.YClass, hcomp]
-    simp
 
 variable [IsDedekindDomain W.CoordinateRing]
 
@@ -213,15 +132,15 @@ lands in the *degree-one* places. -/
 @[simp]
 theorem pointPlace.finrank_residueField_eq_one {y : F} (h : W.Equation x y) :
     Module.finrank F (W.CoordinateRing ⧸ (pointPlace h).asIdeal) = 1 := by
-  rw [(Ideal.quotientEquivAlgOfEq F (pointPlace_asIdeal h)).toLinearEquiv.finrank_eq]
-  exact finrank_quotient_XYIdeal h
+  rw [(Ideal.quotientEquivAlgOfEq F (pointPlace_asIdeal h)).toLinearEquiv.finrank_eq,
+    (CoordinateRing.quotientXYIdealEquiv h).toLinearEquiv.finrank_eq, Module.finrank_self]
 
 /-- **Every degree-one place is the place of a point**, the converse of
 `pointPlace.finrank_residueField_eq_one`. -/
 theorem exists_pointPlace_eq {v : HeightOneSpectrum W.CoordinateRing}
     (hv : Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1) :
     ∃ (x y : F) (h : W.Equation x y), pointPlace h = v := by
-  obtain ⟨x, y, h, hI⟩ := exists_equation_and_eq_XYIdeal v.isPrime.ne_top hv
+  obtain ⟨x, y, h, hI⟩ := exists_equation_and_eq_XYIdeal hv
   exact ⟨x, y, h, by rw [HeightOneSpectrum.ext_iff, pointPlace_asIdeal, hI]⟩
 
 variable (W) in
@@ -243,6 +162,15 @@ noncomputable def equationEquivPointPlace :
 @[simp]
 theorem coe_equationEquivPointPlace (p : {xy : F × F // W.Equation xy.1 xy.2}) :
     (equationEquivPointPlace W p : HeightOneSpectrum W.CoordinateRing) = pointPlace p.2 := (rfl)
+
+/-- Reading the dictionary backwards and then taking the place recovers the original place. -/
+@[simp]
+theorem pointPlace_equationEquivPointPlace_symm
+    (v : {v : HeightOneSpectrum W.CoordinateRing //
+      Module.finrank F (W.CoordinateRing ⧸ v.asIdeal) = 1}) :
+    pointPlace ((equationEquivPointPlace W).symm v).2 = v.1 := by
+  rw [← coe_equationEquivPointPlace]
+  exact congrArg Subtype.val ((equationEquivPointPlace W).apply_symm_apply v)
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean
@@ -5,15 +5,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+public import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
 
 /-!
-# The ideal of a point of a Weierstrass curve is maximal, and determines its coordinates
+# Ideals of points of a Weierstrass curve
 
 For a point `(x, y)` on an affine Weierstrass curve `W` over a field, Mathlib's
 `CoordinateRing.XYIdeal W x (C y)` is the ideal `⟨X - x, Y - y⟩` of the coordinate ring, and
 `CoordinateRing.quotientXYIdealEquiv` identifies the quotient by it with the base field. This file
 records the consequences: that ideal is maximal, it is nonzero, and it determines the coordinates
-it was built from.
+it was built from. Conversely, every ideal whose quotient has rank one over the base field is the
+ideal of a point.
 
 ## Main results
 
@@ -29,6 +31,8 @@ it was built from.
   `y₁.eval x₁ = y₂.eval x₂`, as soon as the first is proper.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.XYIdeal_eq_iff`: the constant-polynomial point
   case, where the conclusion is equality of the coordinates and properness comes from maximality.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.exists_equation_and_eq_XYIdeal`: an ideal whose
+  quotient has rank one over the base field is `XYIdeal W x (C y)` for a point `(x, y)` of `W`.
 
 Mathlib has the quotient isomorphism but records nothing about the ideal itself; the many `XYIdeal`
 lemmas it does state (`XYIdeal_eq₁`, `XYIdeal_eq₂`, `XYIdeal_mul_XYIdeal`, `XYIdeal_neg_mul`) are
@@ -41,8 +45,8 @@ Only the curve equation is needed, not nonsingularity: the quotient is the base 
 This supports `TauCetiRoadmap/EllipticCurves/README.md`, Layer 0, whose point–place dictionary
 identifies the affine places of `W` with the maximal ideals of its coordinate ring — "the affine
 places are the maximal ideals of the coordinate ring". Maximality of `XYIdeal` is the direction
-that sends a point to a place, and `XYIdeal_eq_iff` says that map is injective. Classifying *all*
-maximal ideals as coming from points is a separate statement, not proved here.
+that sends a point to a place, `XYIdeal_eq_iff` says that map is injective, and
+`exists_equation_and_eq_XYIdeal` classifies the ideals with residue degree one.
 
 The roadmap's §"What Mathlib already has (consume)" lists `Affine.CoordinateRing` as consumed
 infrastructure that "is load-bearing API here, not an
@@ -59,11 +63,23 @@ Changes from the source. There the ideal is reached through a `SmoothPlaneCurve`
 nonsingularity proof; the surrounding wrappers are not ported, and the statement is made directly
 about Mathlib's `XYIdeal`. The hypothesis is correspondingly weakened from nonsingularity to the
 curve equation, which is all the quotient isomorphism consumes.
+
+The classification has a counterpart in the same project, in
+`projects/HasseWeil/HasseWeil/Foundation/Curves/Valuation/NormValuation.lean` at
+`github.com/CBirkbeck/AINTLIB @ 1c1c74664e40` (Apache-2.0 per that file's header;
+Authors: Chris Birkbeck): `exists_coordinates_of_isMaximal_of_surjective`,
+`equation_of_coordinates_of_field` and `exists_smoothPoint_of_isMaximal_of_surjective`, packaged
+in `Valuation/SmoothPointPrime.lean` as `smoothPointEquivHeightOneSpectrum`. That statement is
+about a *maximal* ideal of the coordinate ring of a `SmoothPlaneCurve`, hypothesises surjectivity
+of `algebraMap F (F[C] ⧸ M)`, and assumes ellipticity throughout. The classification below is
+written directly against Mathlib's `XYIdeal`: its hypothesis is the residue degree and it uses no
+ellipticity or Dedekind assumption.
 -/
 
 public section
 
 open Polynomial WeierstrassCurve WeierstrassCurve.Affine
+open scoped Polynomial.Bivariate
 
 namespace TauCeti
 
@@ -200,6 +216,69 @@ theorem XYIdeal_eq_iff {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) :
       x₁ = x₂ ∧ y₁ = y₂ := by
   simpa only [eval_C] using XYIdeal_eq_iff_of_ne_top (x₂ := x₂) (y₂ := C y₂)
     (XYIdeal_isMaximal_of_equation h₁).ne_top
+
+/-- A ring homomorphism from the coordinate ring that fixes the base field is evaluation at the
+images of the two coordinate functions. -/
+theorem ringHom_comp_mk_eq_evalEvalRingHom (f : W.CoordinateRing →+* F)
+    (hf : ∀ c : F, f (algebraMap F W.CoordinateRing c) = c) :
+    f.comp (CoordinateRing.mk W) =
+      evalEvalRingHom (f (CoordinateRing.mk W (C X))) (f (CoordinateRing.mk W Y)) := by
+  refine Polynomial.ringHom_ext' (Polynomial.ringHom_ext' ?_ ?_) ?_
+  · ext c
+    have hCC : CoordinateRing.mk W (C (C c)) = algebraMap F W.CoordinateRing c := by
+      rw [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing, AdjoinRoot.algebraMap_eq]
+      simp
+    simp only [RingHom.comp_apply, hCC, hf, coe_evalRingHom, eval_C]
+  · simp
+  · simp
+
+/-- The images of the coordinate functions under a base-field-preserving ring homomorphism from
+the coordinate ring satisfy the Weierstrass equation. -/
+theorem equation_of_ringHom (f : W.CoordinateRing →+* F)
+    (hf : ∀ c : F, f (algebraMap F W.CoordinateRing c) = c) :
+    W.Equation (f (CoordinateRing.mk W (C X))) (f (CoordinateRing.mk W Y)) := by
+  have hcomp := congrArg (fun g : F[X][Y] →+* F ↦ g W.polynomial)
+    (ringHom_comp_mk_eq_evalEvalRingHom f hf)
+  have hzero : f (CoordinateRing.mk W W.polynomial) = 0 := by
+    rw [AdjoinRoot.mk_self, map_zero]
+  rw [← RingHom.comp_apply] at hzero
+  rw [hcomp] at hzero
+  exact hzero
+
+/-- **An ideal of residue degree one is the ideal of a point.** Every ideal `I` for which
+`F[W] ⧸ I` has finrank one over `F` is `XYIdeal W x (C y)` for some solution `(x, y)` of the
+Weierstrass equation. No ellipticity or Dedekind hypothesis is involved. -/
+theorem exists_equation_and_eq_XYIdeal {I : Ideal W.CoordinateRing}
+    (hdeg : Module.finrank F (W.CoordinateRing ⧸ I) = 1) :
+    ∃ (x y : F) (_ : W.Equation x y), I = CoordinateRing.XYIdeal W x (C y) := by
+  have hI : I ≠ ⊤ := Ideal.Quotient.nontrivial_iff.mp <|
+    Module.nontrivial_of_finrank_pos (R := F) (by rw [hdeg]; norm_num)
+  have hbij : Function.Bijective (algebraMap F (W.CoordinateRing ⧸ I)) :=
+    Algebra.finrank_eq_one_iff_bijective_algebraMap.mp hdeg
+  let e : (W.CoordinateRing ⧸ I) ≃ₐ[F] F :=
+    (AlgEquiv.ofBijective (Algebra.ofId F _) hbij).symm
+  let ρ : W.CoordinateRing →ₐ[F] F := e.toAlgHom.comp (Ideal.Quotient.mkₐ F I)
+  have hρmem : ∀ a, ρ a = 0 ↔ a ∈ I := fun a ↦ by
+    simp only [ρ, AlgHom.comp_apply, Ideal.Quotient.mkₐ_eq_mk]
+    constructor
+    · intro h
+      apply Ideal.Quotient.eq_zero_iff_mem.mp
+      exact e.injective (by simpa using h)
+    · intro h
+      rw [Ideal.Quotient.eq_zero_iff_mem.mpr h, map_zero]
+  let x₀ := ρ (CoordinateRing.mk W (C X))
+  let y₀ := ρ (CoordinateRing.mk W Y)
+  have hcomp : ∀ p : F[X][Y], ρ (CoordinateRing.mk W p) = p.evalEval x₀ y₀ := fun p ↦
+    congrArg (fun g : F[X][Y] →+* F ↦ g p)
+      (ringHom_comp_mk_eq_evalEvalRingHom ρ.toRingHom ρ.commutes)
+  have heq : W.Equation x₀ y₀ := equation_of_ringHom ρ.toRingHom ρ.commutes
+  refine ⟨x₀, y₀, heq, ((XYIdeal_isMaximal_of_equation heq).eq_of_le hI ?_).symm⟩
+  rw [CoordinateRing.XYIdeal, Ideal.span_le, Set.pair_subset_iff]
+  refine ⟨?_, ?_⟩
+  · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.XClass, hcomp]
+    simp [evalEval_C]
+  · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.YClass, hcomp]
+    simp
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean
@@ -24,8 +24,6 @@ ideal of a point.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.XYIdeal_isMaximal`: `XYIdeal W x y` is maximal
   for any `y : F[X]` solving the Weierstrass equation at `x`, matching the generality of
   `XYIdeal` and `quotientXYIdealEquiv` themselves.
-* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.finrank_quotient_XYIdeal`: the quotient by such
-  an ideal has rank one over the base field.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.XYIdeal_isMaximal_of_equation`: the point case,
   `XYIdeal W x (C y)` for `(x, y)` on `W`.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.XYIdeal_eq_iff_of_ne_top`: two such ideals are
@@ -111,12 +109,6 @@ theorem XYIdeal_isMaximal {y : F[X]} (h : (W.polynomial.eval y).eval x = 0) :
     (CoordinateRing.XYIdeal W x y).IsMaximal :=
   Ideal.Quotient.maximal_of_isField _
     ((CoordinateRing.quotientXYIdealEquiv h).toRingEquiv.isField (Field.toIsField F))
-
-/-- **The quotient by the ideal of a point has rank one over the base field.** This is stated for
-polynomial `y`, matching `XYIdeal`, `quotientXYIdealEquiv`, and `XYIdeal_isMaximal`. -/
-theorem finrank_quotient_XYIdeal {y : F[X]} (h : (W.polynomial.eval y).eval x = 0) :
-    Module.finrank F (W.CoordinateRing ⧸ CoordinateRing.XYIdeal W x y) = 1 := by
-  rw [(CoordinateRing.quotientXYIdealEquiv h).toLinearEquiv.finrank_eq, Module.finrank_self]
 
 /-- **The ideal of a point of a Weierstrass curve is maximal**, the constant-polynomial case of
 `XYIdeal_isMaximal`. -/
@@ -258,7 +250,7 @@ theorem finrank_quotient_eq_one_iff {I : Ideal W.CoordinateRing} :
     · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.YClass, hcomp]
       simp
   · rintro ⟨x, y, h, rfl⟩
-    exact finrank_quotient_XYIdeal h
+    rw [(CoordinateRing.quotientXYIdealEquiv h).toLinearEquiv.finrank_eq, Module.finrank_self]
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.Eval
 public import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
 
 /-!
@@ -24,6 +24,8 @@ ideal of a point.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.XYIdeal_isMaximal`: `XYIdeal W x y` is maximal
   for any `y : F[X]` solving the Weierstrass equation at `x`, matching the generality of
   `XYIdeal` and `quotientXYIdealEquiv` themselves.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.finrank_quotient_XYIdeal`: the quotient by such
+  an ideal has rank one over the base field.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.XYIdeal_isMaximal_of_equation`: the point case,
   `XYIdeal W x (C y)` for `(x, y)` on `W`.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.XYIdeal_eq_iff_of_ne_top`: two such ideals are
@@ -31,13 +33,9 @@ ideal of a point.
   `y₁.eval x₁ = y₂.eval x₂`, as soon as the first is proper.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.XYIdeal_eq_iff`: the constant-polynomial point
   case, where the conclusion is equality of the coordinates and properness comes from maximality.
-* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.ringHom_comp_mk_eq_evalEvalRingHom`: a ring
-  homomorphism from the coordinate ring to the base field that fixes the base field is evaluation
-  at the images of the two coordinate functions, and
-  `TauCeti.WeierstrassCurve.Affine.CoordinateRing.equation_of_ringHom`: that pair of images is
-  therefore a point of the curve.
-* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.exists_equation_and_eq_XYIdeal`: an ideal whose
-  quotient has rank one over the base field is `XYIdeal W x (C y)` for a point `(x, y)` of `W`.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.finrank_quotient_eq_one_iff`: an ideal has a
+  rank-one quotient exactly when it is `XYIdeal W x (C y)` for a solution `(x, y)` of the
+  Weierstrass equation.
 
 Mathlib has the quotient isomorphism but records nothing about the ideal itself; the many `XYIdeal`
 lemmas it does state (`XYIdeal_eq₁`, `XYIdeal_eq₂`, `XYIdeal_mul_XYIdeal`, `XYIdeal_neg_mul`) are
@@ -51,7 +49,7 @@ This supports `TauCetiRoadmap/EllipticCurves/README.md`, Layer 0, whose point–
 identifies the affine places of `W` with the maximal ideals of its coordinate ring — "the affine
 places are the maximal ideals of the coordinate ring". Maximality of `XYIdeal` is the direction
 that sends a point to a place, `XYIdeal_eq_iff` says that map is injective, and
-`exists_equation_and_eq_XYIdeal` classifies the ideals with residue degree one.
+`finrank_quotient_eq_one_iff` classifies the ideals with residue degree one.
 
 The roadmap's §"What Mathlib already has (consume)" lists `Affine.CoordinateRing` as consumed
 infrastructure that "is load-bearing API here, not an
@@ -113,6 +111,12 @@ theorem XYIdeal_isMaximal {y : F[X]} (h : (W.polynomial.eval y).eval x = 0) :
     (CoordinateRing.XYIdeal W x y).IsMaximal :=
   Ideal.Quotient.maximal_of_isField _
     ((CoordinateRing.quotientXYIdealEquiv h).toRingEquiv.isField (Field.toIsField F))
+
+/-- **The quotient by the ideal of a point has rank one over the base field.** This is stated for
+polynomial `y`, matching `XYIdeal`, `quotientXYIdealEquiv`, and `XYIdeal_isMaximal`. -/
+theorem finrank_quotient_XYIdeal {y : F[X]} (h : (W.polynomial.eval y).eval x = 0) :
+    Module.finrank F (W.CoordinateRing ⧸ CoordinateRing.XYIdeal W x y) = 1 := by
+  rw [(CoordinateRing.quotientXYIdealEquiv h).toLinearEquiv.finrank_eq, Module.finrank_self]
 
 /-- **The ideal of a point of a Weierstrass curve is maximal**, the constant-polynomial case of
 `XYIdeal_isMaximal`. -/
@@ -222,63 +226,39 @@ theorem XYIdeal_eq_iff {x₁ x₂ y₁ y₂ : F} (h₁ : W.Equation x₁ y₁) :
   simpa only [eval_C] using XYIdeal_eq_iff_of_ne_top (x₂ := x₂) (y₂ := C y₂)
     (XYIdeal_isMaximal_of_equation h₁).ne_top
 
-/-- A ring homomorphism from the coordinate ring that fixes the base field is evaluation at the
-images of the two coordinate functions. -/
-theorem ringHom_comp_mk_eq_evalEvalRingHom (f : W.CoordinateRing →+* F)
-    (hf : ∀ c : F, f (algebraMap F W.CoordinateRing c) = c) :
-    f.comp (CoordinateRing.mk W) =
-      evalEvalRingHom (f (CoordinateRing.mk W (C X))) (f (CoordinateRing.mk W Y)) := by
-  refine Polynomial.ringHom_ext' (Polynomial.ringHom_ext' ?_ ?_) ?_
-  · ext c
-    have hCC : CoordinateRing.mk W (C (C c)) = algebraMap F W.CoordinateRing c := by
-      rw [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing, AdjoinRoot.algebraMap_eq]
+/-- **The ideals of residue degree one are exactly the ideals of points.** An ideal `I` has a
+rank-one quotient over `F` if and only if it is `XYIdeal W x (C y)` for some solution `(x, y)` of
+the Weierstrass equation. No ellipticity or Dedekind hypothesis is involved. -/
+theorem finrank_quotient_eq_one_iff {I : Ideal W.CoordinateRing} :
+    Module.finrank F (W.CoordinateRing ⧸ I) = 1 ↔
+      ∃ x y : F, W.Equation x y ∧ I = CoordinateRing.XYIdeal W x (C y) := by
+  constructor
+  · intro hdeg
+    have hI : I ≠ ⊤ := Ideal.Quotient.nontrivial_iff.mp <|
+      Module.nontrivial_of_finrank_pos (R := F) (by rw [hdeg]; norm_num)
+    have hbij : Function.Bijective (algebraMap F (W.CoordinateRing ⧸ I)) :=
+      Algebra.finrank_eq_one_iff_bijective_algebraMap.mp hdeg
+    let e : (W.CoordinateRing ⧸ I) ≃ₐ[F] F :=
+      (AlgEquiv.ofBijective (Algebra.ofId F _) hbij).symm
+    let ρ : W.CoordinateRing →ₐ[F] F := e.toAlgHom.comp (Ideal.Quotient.mkₐ F I)
+    have hρmem : ∀ a, ρ a = 0 ↔ a ∈ I := fun a ↦ by
+      simp only [ρ, AlgHom.comp_apply, AlgEquiv.coe_toAlgHom, Ideal.Quotient.mkₐ_eq_mk]
+      rw [map_eq_zero_iff _ e.injective, Ideal.Quotient.eq_zero_iff_mem]
+    let x₀ := ρ (CoordinateRing.mk W (C X))
+    let y₀ := ρ (CoordinateRing.mk W Y)
+    have hcomp : ∀ p : F[X][Y], ρ (CoordinateRing.mk W p) = p.evalEval x₀ y₀ := fun p ↦ by
+      simpa only [x₀, y₀] using algHom_mk_eq_evalEval ρ p
+    have heq : W.Equation x₀ y₀ := by
+      simpa only [x₀, y₀] using equation_of_algHom ρ
+    refine ⟨x₀, y₀, heq, ((XYIdeal_isMaximal_of_equation heq).eq_of_le hI ?_).symm⟩
+    rw [CoordinateRing.XYIdeal, Ideal.span_le, Set.pair_subset_iff]
+    refine ⟨?_, ?_⟩
+    · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.XClass, hcomp]
+      simp [evalEval_C]
+    · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.YClass, hcomp]
       simp
-    simp only [RingHom.comp_apply, hCC, hf, coe_evalRingHom, eval_C]
-  · simp
-  · simp
-
-/-- The images of the coordinate functions under a base-field-preserving ring homomorphism from
-the coordinate ring satisfy the Weierstrass equation. -/
-theorem equation_of_ringHom (f : W.CoordinateRing →+* F)
-    (hf : ∀ c : F, f (algebraMap F W.CoordinateRing c) = c) :
-    W.Equation (f (CoordinateRing.mk W (C X))) (f (CoordinateRing.mk W Y)) := by
-  have hcomp := congrArg (fun g : F[X][Y] →+* F ↦ g W.polynomial)
-    (ringHom_comp_mk_eq_evalEvalRingHom f hf)
-  have hzero : f (CoordinateRing.mk W W.polynomial) = 0 := by
-    rw [AdjoinRoot.mk_self, map_zero]
-  rw [← RingHom.comp_apply] at hzero
-  rw [hcomp] at hzero
-  exact hzero
-
-/-- **An ideal of residue degree one is the ideal of a point.** Every ideal `I` for which
-`F[W] ⧸ I` has finrank one over `F` is `XYIdeal W x (C y)` for some solution `(x, y)` of the
-Weierstrass equation. No ellipticity or Dedekind hypothesis is involved. -/
-theorem exists_equation_and_eq_XYIdeal {I : Ideal W.CoordinateRing}
-    (hdeg : Module.finrank F (W.CoordinateRing ⧸ I) = 1) :
-    ∃ (x y : F) (_ : W.Equation x y), I = CoordinateRing.XYIdeal W x (C y) := by
-  have hI : I ≠ ⊤ := Ideal.Quotient.nontrivial_iff.mp <|
-    Module.nontrivial_of_finrank_pos (R := F) (by rw [hdeg]; norm_num)
-  have hbij : Function.Bijective (algebraMap F (W.CoordinateRing ⧸ I)) :=
-    Algebra.finrank_eq_one_iff_bijective_algebraMap.mp hdeg
-  let e : (W.CoordinateRing ⧸ I) ≃ₐ[F] F :=
-    (AlgEquiv.ofBijective (Algebra.ofId F _) hbij).symm
-  let ρ : W.CoordinateRing →ₐ[F] F := e.toAlgHom.comp (Ideal.Quotient.mkₐ F I)
-  have hρmem : ∀ a, ρ a = 0 ↔ a ∈ I := fun a ↦ by
-    rw [show ρ a = e (Ideal.Quotient.mk I a) from rfl, map_eq_zero_iff _ e.injective,
-      Ideal.Quotient.eq_zero_iff_mem]
-  let x₀ := ρ (CoordinateRing.mk W (C X))
-  let y₀ := ρ (CoordinateRing.mk W Y)
-  have hcomp : ∀ p : F[X][Y], ρ (CoordinateRing.mk W p) = p.evalEval x₀ y₀ := fun p ↦
-    congrArg (fun g : F[X][Y] →+* F ↦ g p)
-      (ringHom_comp_mk_eq_evalEvalRingHom ρ.toRingHom ρ.commutes)
-  have heq : W.Equation x₀ y₀ := equation_of_ringHom ρ.toRingHom ρ.commutes
-  refine ⟨x₀, y₀, heq, ((XYIdeal_isMaximal_of_equation heq).eq_of_le hI ?_).symm⟩
-  rw [CoordinateRing.XYIdeal, Ideal.span_le, Set.pair_subset_iff]
-  refine ⟨?_, ?_⟩
-  · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.XClass, hcomp]
-    simp [evalEval_C]
-  · rw [SetLike.mem_coe, ← hρmem, CoordinateRing.YClass, hcomp]
-    simp
+  · rintro ⟨x, y, h, rfl⟩
+    exact finrank_quotient_XYIdeal h
 
 end WeierstrassCurve.Affine.CoordinateRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean
@@ -31,6 +31,11 @@ ideal of a point.
   `y₁.eval x₁ = y₂.eval x₂`, as soon as the first is proper.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.XYIdeal_eq_iff`: the constant-polynomial point
   case, where the conclusion is equality of the coordinates and properness comes from maximality.
+* `TauCeti.WeierstrassCurve.Affine.CoordinateRing.ringHom_comp_mk_eq_evalEvalRingHom`: a ring
+  homomorphism from the coordinate ring to the base field that fixes the base field is evaluation
+  at the images of the two coordinate functions, and
+  `TauCeti.WeierstrassCurve.Affine.CoordinateRing.equation_of_ringHom`: that pair of images is
+  therefore a point of the curve.
 * `TauCeti.WeierstrassCurve.Affine.CoordinateRing.exists_equation_and_eq_XYIdeal`: an ideal whose
   quotient has rank one over the base field is `XYIdeal W x (C y)` for a point `(x, y)` of `W`.
 
@@ -259,13 +264,8 @@ theorem exists_equation_and_eq_XYIdeal {I : Ideal W.CoordinateRing}
     (AlgEquiv.ofBijective (Algebra.ofId F _) hbij).symm
   let ρ : W.CoordinateRing →ₐ[F] F := e.toAlgHom.comp (Ideal.Quotient.mkₐ F I)
   have hρmem : ∀ a, ρ a = 0 ↔ a ∈ I := fun a ↦ by
-    simp only [ρ, AlgHom.comp_apply, Ideal.Quotient.mkₐ_eq_mk]
-    constructor
-    · intro h
-      apply Ideal.Quotient.eq_zero_iff_mem.mp
-      exact e.injective (by simpa using h)
-    · intro h
-      rw [Ideal.Quotient.eq_zero_iff_mem.mpr h, map_zero]
+    rw [show ρ a = e (Ideal.Quotient.mk I a) from rfl, map_eq_zero_iff _ e.injective,
+      Ideal.Quotient.eq_zero_iff_mem]
   let x₀ := ρ (CoordinateRing.mk W (C X))
   let y₀ := ρ (CoordinateRing.mk W Y)
   have hcomp : ∀ p : F[X][Y], ρ (CoordinateRing.mk W p) = p.evalEval x₀ y₀ := fun p ↦


### PR DESCRIPTION
This PR classifies the ideals of the coordinate ring of a Weierstrass curve whose quotient has rank one over the base field: a proper ideal `I` of `F[W]` with `Module.finrank F (F[W] ⧸ I) = 1` is `⟨X - x, Y - y⟩` for a point `(x, y)` of the curve (`exists_equation_and_eq_XYIdeal`). Together with the converse — the quotient by the ideal of a point *is* the base field, Mathlib's `quotientXYIdealEquiv` — this makes the existing `pointPlace` a bijection between the points of the curve and the **degree-one** places of the coordinate ring, packaged as `equationEquivPointPlace`.

The milestone is Layer 0's **point–place dictionary** in `TauCetiRoadmap/EllipticCurves/README.md`: "for elliptic `W`, `W.toAffine.Point` is in bijection with the degree-`1` places: `O ↦ infinityPlace`, and an affine nonsingular `(x₀, y₀) ↦` the maximal ideal `(X − x₀, Y − y₀)`", of which the layer says "every later layer passes through this dictionary". The direction that sends a point to a place, its injectivity, and its degree-one property already landed (#2583, #2782); this is the missing converse and the affine bijection itself. What remains of the milestone after this PR is the point at infinity: `TauCeti.WeierstrassCurve.Affine.infinityPlace` is a valuation on the function field rather than a prime of the coordinate ring — the two are already known to be distinct places (#2790) — so reading the dictionary on the whole point group `W.Point` has to wait for Layer 0 to fix one type of places holding both, and this PR stops at the affine half rather than standing a sentinel in for the missing place at infinity.

The proof needs nothing new. The rank hypothesis makes `algebraMap F (F[W] ⧸ I)` bijective (`Algebra.finrank_eq_one_iff_bijective_algebraMap`), so the quotient map followed by its inverse is a ring homomorphism `ρ : F[W] → F` fixing the constants; `Polynomial.ringHom_ext'`, applied twice, identifies `ρ ∘ mk` with evaluation at `(ρ x, ρ y)`, so that pair satisfies the Weierstrass equation because `mk` kills `W.polynomial`; and `⟨X - ρ x, Y - ρ y⟩`, maximal by this repository's `XYIdeal_isMaximal_of_equation` and contained in the proper ideal `I`, is `I`. Neither this nor the rank-one lemma it inverts uses ellipticity or a Dedekind hypothesis — they are statements about an ideal — so both live in the ideal-level file `Affine/XYIdealMaximal.lean` alongside the rest of the `XYIdeal_*` API, and the place file consumes them. The evaluation step is factored out as two reusable lemmas there, `ringHom_comp_mk_eq_evalEvalRingHom` and `equation_of_ringHom`.

The degree hypothesis is load-bearing rather than convenient: a place of degree `d > 1` has a residue field of degree `d` over `F` and is the place of no rational point, so it is only over an algebraically closed base that the points exhaust the height-one primes. This is why the equivalence is stated against the subtype of degree-one places over an arbitrary field.

Nothing is vendored from Mathlib. Provenance, recorded in the module docstring: the same classification exists in AINTLIB's HasseWeil project (`github.com/CBirkbeck/AINTLIB @ 1c1c74664e40`, Apache-2.0 per the file header, Authors: Chris Birkbeck), in `projects/HasseWeil/HasseWeil/Foundation/Curves/Valuation/NormValuation.lean` (`exists_coordinates_of_isMaximal_of_surjective`, `equation_of_coordinates_of_field`, `exists_smoothPoint_of_isMaximal_of_surjective`) and `Valuation/SmoothPointPrime.lean` (`smoothPointEquivHeightOneSpectrum`). That development is phrased for a maximal ideal of a `SmoothPlaneCurve`, hypothesises surjectivity of the residue map, assumes ellipticity throughout, and its packaged bijection is onto all height-one primes under `[IsAlgClosed F]`; the version here is written directly against Mathlib's `XYIdeal`, assumes only that the ideal is proper, takes the residue degree as the hypothesis, and gives the degree-one bijection over an arbitrary field.

Two files changed. `TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean` gains the ideal-level classification and the two ring-hom lemmas it rests on, which is where the rest of the `XYIdeal_*` API lives and where nothing about places or Dedekind domains is needed; `TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean` gains the affine equivalence and its two characterisation lemmas, joining `pointPlace` and the point-to-place direction. `lake build`, `lake exe axioms` (all within `[propext, Classical.choice, Quot.sound]`), `lake exe module-system` and `scripts/lint-env.sh` (PASS, no new violations) are all clean.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"point-place-dictionary"}-->

🤖 Prepared with Claude Code

