### PR TITLE
feat: the weight decomposition of the symmetric powers of SU(2)

### DIFF
--- a/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
+++ b/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.GroupWithZero.Units.Basic
+
+/-!
+# Merging a power of a unit with a power of its inverse
+
+A product `a ^ i * a⁻¹ ^ (n - i)`, in which the two exponents are natural numbers adding up to
+`n`, is the integer power `a ^ (2 * i - n)`.  Such a product is what a diagonal matrix
+`diag(a, a⁻¹)` contributes to a monomial of degree `n`, so the identity is the exponent
+bookkeeping behind a weight computation.
+
+Mathlib splits an integer power as a quotient (`zpow_sub₀`, `zpow_natCast_sub_natCast₀`) and
+subtracts natural-number exponents (`pow_sub₀`, `inv_pow_sub₀`); this is the corresponding
+statement for the exponents `i` and `n - i` of `a` and `a⁻¹`.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- **A power of `a` times a power of `a⁻¹` is an integer power of `a`**: for `i ≤ n`, the
+exponents `i` and `n - i` combine to `i - (n - i) = 2 * i - n`. -/
+theorem pow_mul_inv_pow_eq_zpow₀ {G₀ : Type*} [GroupWithZero G₀] {a : G₀} (ha : a ≠ 0) {i n : ℕ}
+    (hi : i ≤ n) : a ^ i * a⁻¹ ^ (n - i) = a ^ (2 * (i : ℤ) - n) := by
+  -- the exponent `2 * i - n` is the exponent of `a` minus the exponent of `a⁻¹`
+  have hexp : 2 * (i : ℤ) - n = (i : ℤ) - ((n - i : ℕ) : ℤ) := by omega
+  rw [hexp, zpow_sub₀ ha, zpow_natCast, zpow_natCast, inv_pow, div_eq_mul_inv]
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Eigenspace/DiagonalBasis.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/DiagonalBasis.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Basis.Basic
+
+/-!
+# Invariant subspaces of an endomorphism diagonal in a basis
+
+An endomorphism `f` of a module that is diagonal in a basis `b`, so `f (b i) = a i • b i`, scales
+the `i`-th coordinate of every vector by the eigenvalue `a i`.  When the eigenvalues are pairwise
+distinct, that is when `a` is injective, this pins down the invariant subspaces: an `f`-invariant
+subspace contains every basis vector occurring in one of its elements, hence is spanned by the
+basis vectors it contains, and a nonzero eigenvector of `f` is a multiple of a single basis
+vector.  Neither is automatic for an operator with repeated eigenvalues.
+
+The mechanism is that a coordinate of a vector `w` can be cleared without disturbing the others:
+`f w - a j • w` again lies in any invariant subspace containing `w`, and its `k`-th coordinate is
+`(a k - a j) * b.repr w k`, which vanishes at `k = j` and, by injectivity of `a`, at no other
+index where `w` had a nonzero coordinate.  An induction on the number of nonzero coordinates then
+strips a vector down to a single basis vector.
+
+Mathlib records the neighbouring facts in eigenspace language: eigenspaces for distinct
+eigenvalues are independent (`Module.End.eigenspaces_iSupIndep`), and eigenvectors for distinct
+eigenvalues are linearly independent (`Module.End.eigenvectors_linearIndependent'`); neither says
+what an invariant subspace looks like.  `TauCeti.iSup_inf_iInf_eigenspace_of_invariant` does cut
+an invariant submodule out by eigenspaces, but for a commuting family over an algebraically
+closed field, in finite dimension, and with semisimple restrictions.  A diagonalizing basis
+carries all of that for free and in coordinates, which is the form used here: no finiteness, no
+algebraic closedness, and the answer names the basis vectors involved.
+
+## Main results
+
+* `Module.Basis.repr_apply_of_apply_basis`: the coordinates of `f w` are those of `w` scaled by
+  the eigenvalues.
+* `Module.Basis.self_mem_of_repr_ne_zero` and `Module.Basis.eq_span_self_mem`: an invariant
+  subspace contains every basis vector occurring in one of its elements, and is spanned by the
+  basis vectors it contains.
+* `Module.Basis.exists_eq_and_mem_span_singleton`: a nonzero eigenvector of `f` is a multiple of
+  a single basis vector, whose eigenvalue is its eigenvalue.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {ι K V : Type*}
+
+/-! ### The coordinates are scaled by the eigenvalues -/
+
+section CommSemiring
+
+variable [CommSemiring K] [AddCommMonoid V] [Module K V] {f : V →ₗ[K] V} {a : ι → K}
+
+/-- **An endomorphism diagonal in a basis scales the coordinates**: if `f (b i) = a i • b i` for
+every `i`, then `f` multiplies the `i`-th coordinate of every vector by `a i`. -/
+theorem _root_.Module.Basis.repr_apply_of_apply_basis (b : Module.Basis ι K V)
+    (hf : ∀ i, f (b i) = a i • b i) (w : V) (i : ι) :
+    b.repr (f w) i = a i * b.repr w i := by
+  have key : (Finsupp.lapply i).comp ((b.repr : V →ₗ[K] ι →₀ K).comp f)
+      = (a i • Finsupp.lapply i).comp (b.repr : V →ₗ[K] ι →₀ K) := by
+    refine b.ext fun j => ?_
+    rcases eq_or_ne j i with rfl | hj
+    · simp [hf j]
+    · simp [hf j, hj]
+  simpa using LinearMap.congr_fun key w
+
+/-- A vector whose only possibly nonzero coordinate is the `i`-th one is that coordinate times
+the `i`-th basis vector. -/
+private theorem eq_smul_of_support_subset_singleton {b : Module.Basis ι K V} {w : V} {i : ι}
+    (h : (b.repr w).support ⊆ {i}) : w = b.repr w i • b i :=
+  calc w = b.repr.symm (b.repr w) := (b.repr.symm_apply_apply w).symm
+    _ = b.repr.symm (Finsupp.single i (b.repr w i)) :=
+        congrArg _ (Finsupp.support_subset_singleton.1 h)
+    _ = b.repr w i • b i := b.repr_symm_single i _
+
+end CommSemiring
+
+/-! ### Invariant subspaces are spanned by basis vectors -/
+
+section Field
+
+variable [Field K] [AddCommGroup V] [Module K V] {f : V →ₗ[K] V} {a : ι → K}
+  {W : Submodule K V}
+
+/-- **Clearing a coordinate**: subtracting from `f w` the multiple `a j • w` kills the `j`-th
+coordinate and multiplies the `k`-th one by `a k - a j`. -/
+private theorem repr_sub_smul_apply (b : Module.Basis ι K V) (hf : ∀ i, f (b i) = a i • b i)
+    (w : V) (j k : ι) :
+    b.repr (f w - a j • w) k = (a k - a j) * b.repr w k := by
+  rw [map_sub, map_smul, Finsupp.sub_apply, Finsupp.smul_apply,
+    b.repr_apply_of_apply_basis hf, smul_eq_mul, sub_mul]
+
+/-- The cleared vector has strictly smaller support: it loses the `j`-th coordinate and gains
+none. -/
+private theorem support_repr_sub_smul_subset [DecidableEq ι] (b : Module.Basis ι K V)
+    (hf : ∀ i, f (b i) = a i • b i) (w : V) (j : ι) :
+    (b.repr (f w - a j • w)).support ⊆ (b.repr w).support.erase j := by
+  intro k hk
+  have hk0 : b.repr (f w - a j • w) k ≠ 0 := Finsupp.mem_support_iff.1 hk
+  rw [repr_sub_smul_apply b hf w j k] at hk0
+  refine Finset.mem_erase.2 ⟨?_, Finsupp.mem_support_iff.2 (right_ne_zero_of_mul hk0)⟩
+  rintro rfl
+  exact hk0 (by rw [sub_self, zero_mul])
+
+private theorem self_mem_aux (b : Module.Basis ι K V) (hf : ∀ i, f (b i) = a i • b i)
+    (ha : Function.Injective a) (hW : ∀ v ∈ W, f v ∈ W) :
+    ∀ (n : ℕ) (w : V), w ∈ W → (b.repr w).support.card ≤ n →
+      ∀ i : ι, b.repr w i ≠ 0 → b i ∈ W := by
+  classical
+  intro n
+  induction n with
+  | zero =>
+    intro w _ hcard i hi
+    have hsupp : (b.repr w).support = ∅ := Finset.card_eq_zero.1 (Nat.le_zero.1 hcard)
+    exact absurd (Finsupp.notMem_support_iff.1 (by rw [hsupp]; exact Finset.notMem_empty i)) hi
+  | succ n ih =>
+    intro w hw hcard i hi
+    by_cases hsub : (b.repr w).support ⊆ {i}
+    · -- the `i`-th coordinate is the only nonzero one, so `b i` is a multiple of `w`;
+      -- naming that coordinate keeps it from being rewritten along with `w` below
+      set c := b.repr w i
+      have hmem : c⁻¹ • w ∈ W := W.smul_mem _ hw
+      rwa [eq_smul_of_support_subset_singleton hsub, smul_smul, inv_mul_cancel₀ hi,
+        one_smul] at hmem
+    · -- otherwise some other coordinate `j` is nonzero, and can be cleared
+      obtain ⟨j, hjs, hji⟩ := Finset.not_subset.1 hsub
+      have hjne : j ≠ i := fun h => hji (Finset.mem_singleton.2 h)
+      have hmem : f w - a j • w ∈ W := W.sub_mem (hW w hw) (W.smul_mem _ hw)
+      have hcard' : (b.repr (f w - a j • w)).support.card ≤ n := by
+        have hle := Finset.card_le_card (support_repr_sub_smul_subset b hf w j)
+        rw [Finset.card_erase_of_mem hjs] at hle
+        have hpos : 0 < (b.repr w).support.card := Finset.card_pos.2 ⟨j, hjs⟩
+        omega
+      refine ih _ hmem hcard' i ?_
+      rw [repr_sub_smul_apply b hf w j i]
+      exact mul_ne_zero (sub_ne_zero.2 fun h => hjne (ha h).symm) hi
+
+/-- **An invariant subspace contains every basis vector occurring in one of its elements**, when
+the endomorphism is diagonal in the basis with pairwise distinct eigenvalues: the coordinates of
+an element can then be separated by repeatedly clearing one of them. -/
+theorem _root_.Module.Basis.self_mem_of_repr_ne_zero (b : Module.Basis ι K V)
+    (hf : ∀ i, f (b i) = a i • b i) (ha : Function.Injective a) (hW : ∀ v ∈ W, f v ∈ W) {w : V}
+    (hw : w ∈ W) {i : ι} (hi : b.repr w i ≠ 0) : b i ∈ W :=
+  self_mem_aux b hf ha hW _ w hw le_rfl i hi
+
+/-- **An invariant subspace is spanned by the basis vectors it contains**, when the endomorphism
+is diagonal in the basis with pairwise distinct eigenvalues. -/
+theorem _root_.Module.Basis.eq_span_self_mem (b : Module.Basis ι K V)
+    (hf : ∀ i, f (b i) = a i • b i) (ha : Function.Injective a) (hW : ∀ v ∈ W, f v ∈ W) :
+    W = Submodule.span K {v | ∃ i : ι, b i = v ∧ v ∈ W} := by
+  refine le_antisymm (fun w hw => ?_) (Submodule.span_le.2 ?_)
+  · rw [← b.linearCombination_repr w, Finsupp.linearCombination_apply, Finsupp.sum]
+    refine Submodule.sum_mem _ fun k hk => ?_
+    exact Submodule.smul_mem _ _ (Submodule.subset_span
+      ⟨k, rfl, b.self_mem_of_repr_ne_zero hf ha hW hw (Finsupp.mem_support_iff.1 hk)⟩)
+  · rintro v ⟨-, -, hv⟩
+    exact hv
+
+/-- **A nonzero eigenvector is a multiple of a single basis vector**, when the endomorphism is
+diagonal in the basis with pairwise distinct eigenvalues, and its eigenvalue is the eigenvalue of
+that basis vector. -/
+theorem _root_.Module.Basis.exists_eq_and_mem_span_singleton (b : Module.Basis ι K V)
+    (hf : ∀ i, f (b i) = a i • b i) (ha : Function.Injective a) {w : V} (hw : w ≠ 0) {c : K}
+    (hfw : f w = c • w) : ∃ i : ι, a i = c ∧ w ∈ Submodule.span K {b i} := by
+  classical
+  have hcoord : ∀ k : ι, a k * b.repr w k = c * b.repr w k := by
+    intro k
+    rw [← b.repr_apply_of_apply_basis hf, hfw, map_smul, Finsupp.smul_apply, smul_eq_mul]
+  have hrne : b.repr w ≠ 0 := fun h => hw (b.repr.map_eq_zero_iff.1 h)
+  obtain ⟨i, hi⟩ := Finsupp.ne_iff.1 hrne
+  rw [Finsupp.coe_zero, Pi.zero_apply] at hi
+  have hci : a i = c := mul_right_cancel₀ hi (hcoord i)
+  refine ⟨i, hci, ?_⟩
+  have hsupp : (b.repr w).support ⊆ {i} := fun k hk =>
+    Finset.mem_singleton.2
+      (ha ((mul_right_cancel₀ (Finsupp.mem_support_iff.1 hk) (hcoord k)).trans hci.symm))
+  rw [eq_smul_of_support_subset_singleton hsupp]
+  exact Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _)
+
+end Field
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Eigenspace/DiagonalBasis.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/DiagonalBasis.lean
@@ -38,8 +38,8 @@ algebraic closedness, and the answer names the basis vectors involved.
 * `Module.Basis.self_mem_of_repr_ne_zero` and `Module.Basis.eq_span_self_mem`: an invariant
   subspace contains every basis vector occurring in one of its elements, and is spanned by the
   basis vectors it contains.
-* `Module.Basis.exists_eq_and_mem_span_singleton`: a nonzero eigenvector of `f` is a multiple of
-  a single basis vector, whose eigenvalue is its eigenvalue.
+* `Module.Basis.exists_apply_eq_and_mem_span_singleton`: a nonzero eigenvector of `f` is a
+  multiple of a single basis vector, whose eigenvalue is its eigenvalue.
 -/
 
 public section
@@ -162,7 +162,7 @@ theorem _root_.Module.Basis.eq_span_self_mem (b : Module.Basis ι K V)
 /-- **A nonzero eigenvector is a multiple of a single basis vector**, when the endomorphism is
 diagonal in the basis with pairwise distinct eigenvalues, and its eigenvalue is the eigenvalue of
 that basis vector. -/
-theorem _root_.Module.Basis.exists_eq_and_mem_span_singleton (b : Module.Basis ι K V)
+theorem _root_.Module.Basis.exists_apply_eq_and_mem_span_singleton (b : Module.Basis ι K V)
     (hf : ∀ i, f (b i) = a i • b i) (ha : Function.Injective a) {w : V} (hw : w ≠ 0) {c : K}
     (hfw : f w = c • w) : ∃ i : ι, a i = c ∧ w ∈ Submodule.span K {b i} := by
   classical

--- a/TauCeti/LinearAlgebra/SymmetricPower/Basis.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower/Basis.lean
@@ -33,7 +33,7 @@ orderings of an unordered tuple differ by a permutation.
 
 ## Main results
 
-* `SymmetricPower.map_symmetricPower_of_apply_basis`: an endomorphism diagonal in a basis is
+* `SymmetricPower.map_basis_symmetricPower_of_apply_basis`: an endomorphism diagonal in a basis is
   diagonal in the induced basis of the symmetric power, with eigenvalue the product of the
   eigenvalues listed by the index.
 * `SymmetricPower.finrank_eq`: the rank of `Sym[R]^n M` is `Nat.multichoose (finrank R M) n`.
@@ -178,7 +178,7 @@ theorem _root_.Module.Basis.symmetricPower_apply (s : Sym κ n) :
 power**: the basis vector indexed by `s` is an eigenvector, with eigenvalue the product of the
 eigenvalues listed by `s`.  Summing these eigenvalues gives the trace,
 `SymmetricPower.trace_map_of_apply_basis`. -/
-theorem map_symmetricPower_of_apply_basis (f : M →ₗ[R] M) (a : κ → R)
+theorem map_basis_symmetricPower_of_apply_basis (f : M →ₗ[R] M) (a : κ → R)
     (hf : ∀ i, f (b i) = a i • b i) (s : Sym κ n) :
     map (ι := Fin n) f (b.symmetricPower n s) =
       ((s : Multiset κ).map a).prod • b.symmetricPower n s := by
@@ -223,7 +223,8 @@ theorem trace_map_of_apply_basis [Fintype κ] [DecidableEq κ] (b : Basis κ R M
   classical
   rw [LinearMap.trace_eq_matrix_trace R (b.symmetricPower n), Matrix.trace]
   refine Finset.sum_congr rfl fun s _ => ?_
-  rw [Matrix.diag_apply, LinearMap.toMatrix_apply, map_symmetricPower_of_apply_basis b f a hf s,
+  rw [Matrix.diag_apply, LinearMap.toMatrix_apply,
+    map_basis_symmetricPower_of_apply_basis b f a hf s,
     map_smul, Finsupp.smul_apply, Basis.repr_self, Finsupp.single_eq_same, smul_eq_mul, mul_one]
 
 end CommRing

--- a/TauCeti/LinearAlgebra/SymmetricPower/Basis.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower/Basis.lean
@@ -33,6 +33,9 @@ orderings of an unordered tuple differ by a permutation.
 
 ## Main results
 
+* `SymmetricPower.map_symmetricPower_of_apply_basis`: an endomorphism diagonal in a basis is
+  diagonal in the induced basis of the symmetric power, with eigenvalue the product of the
+  eigenvalues listed by the index.
 * `SymmetricPower.finrank_eq`: the rank of `Sym[R]^n M` is `Nat.multichoose (finrank R M) n`.
 * `SymmetricPower.trace_map_of_apply_basis`: the trace on `Sym[R]^n M` of an endomorphism that is
   diagonal in a basis is the sum, over the unordered `n`-tuples of basis indices, of the product
@@ -171,6 +174,23 @@ theorem _root_.Module.Basis.symmetricPower_apply (s : Sym κ n) :
     b.symmetricPower n s = tprodOfSym R b s :=
   linearEquivFinsupp_symm_single b s
 
+/-- **An endomorphism diagonal in a basis is diagonal in the induced basis of the symmetric
+power**: the basis vector indexed by `s` is an eigenvector, with eigenvalue the product of the
+eigenvalues listed by `s`.  Summing these eigenvalues gives the trace,
+`SymmetricPower.trace_map_of_apply_basis`. -/
+theorem map_symmetricPower_of_apply_basis (f : M →ₗ[R] M) (a : κ → R)
+    (hf : ∀ i, f (b i) = a i • b i) (s : Sym κ n) :
+    map (ι := Fin n) f (b.symmetricPower n s) =
+      ((s : Multiset κ).map a).prod • b.symmetricPower n s := by
+  have hfb : (fun i => f (b (orderOfSym s i))) =
+      fun i => a (orderOfSym s i) • b (orderOfSym s i) := funext fun i => hf _
+  conv_lhs => rw [Basis.symmetricPower_apply, tprodOfSym, map_tprod]
+  rw [hfb, (tprod R).map_smul_univ, Basis.symmetricPower_apply, tprodOfSym]
+  congr 1
+  conv_rhs => rw [← ofFn_orderOfSym s]
+  rw [TauCeti.Sym.coe_ofFn, Multiset.map_coe, List.map_ofFn, Multiset.prod_coe,
+    List.prod_ofFn, Function.comp_def]
+
 /-! ### Freeness and rank -/
 
 /-- A symmetric power of a free module is free, on the unordered tuples of basis indices. -/
@@ -201,21 +221,10 @@ theorem trace_map_of_apply_basis [Fintype κ] [DecidableEq κ] (b : Basis κ R M
     LinearMap.trace R (Sym[R]^n M) (map (ι := Fin n) f) =
       ∑ s : Sym κ n, ((s : Multiset κ).map a).prod := by
   classical
-  have hdiag : ∀ s : Sym κ n, map (ι := Fin n) f (b.symmetricPower n s) =
-      ((s : Multiset κ).map a).prod • b.symmetricPower n s := by
-    intro s
-    have hfb : (fun i => f (b (orderOfSym s i))) =
-        fun i => a (orderOfSym s i) • b (orderOfSym s i) := funext fun i => hf _
-    conv_lhs => rw [Basis.symmetricPower_apply, tprodOfSym, map_tprod]
-    rw [hfb, (tprod R).map_smul_univ, Basis.symmetricPower_apply, tprodOfSym]
-    congr 1
-    conv_rhs => rw [← ofFn_orderOfSym s]
-    rw [TauCeti.Sym.coe_ofFn, Multiset.map_coe, List.map_ofFn, Multiset.prod_coe,
-      List.prod_ofFn, Function.comp_def]
   rw [LinearMap.trace_eq_matrix_trace R (b.symmetricPower n), Matrix.trace]
   refine Finset.sum_congr rfl fun s _ => ?_
-  rw [Matrix.diag_apply, LinearMap.toMatrix_apply, hdiag s, map_smul, Finsupp.smul_apply,
-    Basis.repr_self, Finsupp.single_eq_same, smul_eq_mul, mul_one]
+  rw [Matrix.diag_apply, LinearMap.toMatrix_apply, map_symmetricPower_of_apply_basis b f a hf s,
+    map_smul, Finsupp.smul_apply, Basis.repr_self, Finsupp.single_eq_same, smul_eq_mul, mul_one]
 
 end CommRing
 

--- a/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.RepresentationTheory.ClassicalGroups.SymmetricPower
 public import TauCeti.RepresentationTheory.SU2.Basic
+import TauCeti.Algebra.GroupWithZero.Units.Basic
 import TauCeti.RingTheory.MvPolynomial.Symmetric.Complete
 
 /-!
@@ -116,23 +117,14 @@ theorem character_symPower_torusHom (z : Circle) :
   refine sum_congr rfl fun i _ => ?_
   simp
 
-/-- **The weight of a monomial as an exponent**: the diagonal entries `z` and `z⁻¹` of a torus
-element contribute `i` and `n - i` factors to the monomial with `i` factors of the first basis
-vector, and the resulting scalar is the `2i - n`-th power of `z`. -/
-theorem coe_pow_mul_coe_inv_pow (z : Circle) {i n : ℕ} (hi : i ≤ n) :
-    (z : ℂ) ^ i * ((z : ℂ)⁻¹) ^ (n - i) = (z : ℂ) ^ (2 * (i : ℤ) - n) := by
-  -- the weight `2i - n` is the exponent of `z` minus the exponent of `z⁻¹`
-  have hexp : 2 * (i : ℤ) - n = (i : ℤ) - ((n - i : ℕ) : ℤ) := by omega
-  rw [hexp, zpow_sub₀ (Circle.coe_ne_zero z), zpow_natCast, zpow_natCast, inv_pow,
-    div_eq_mul_inv]
-
 /-- The weight string with the weights displayed as integer exponents `2i - d`. -/
 theorem character_symPower_torusHom_zpow (z : Circle) :
     (symPower d).character (torusHom z)
       = ∑ i ∈ range (d + 1), (z : ℂ) ^ (2 * (i : ℤ) - d) := by
   rw [character_symPower_torusHom]
+  -- the diagonal entries `z` and `z⁻¹` contribute `i` and `d - i` factors to the `i`-th monomial
   exact sum_congr rfl fun i hi =>
-    coe_pow_mul_coe_inv_pow z (Nat.lt_succ_iff.mp (mem_range.mp hi))
+    pow_mul_inv_pow_eq_zpow₀ (Circle.coe_ne_zero z) (Nat.lt_succ_iff.mp (mem_range.mp hi))
 
 /-- **The weight string in exponential coordinates.**  Writing the torus element as
 `diag(e^{iθ}, e^{-iθ})`, the character of `Symᵈ(ℂ²)` is `∑ᵢ e^{i(2i-d)θ}`: the classical

--- a/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
@@ -116,17 +116,23 @@ theorem character_symPower_torusHom (z : Circle) :
   refine sum_congr rfl fun i _ => ?_
   simp
 
+/-- **The weight of a monomial as an exponent**: the diagonal entries `z` and `z⁻¹` of a torus
+element contribute `i` and `n - i` factors to the monomial with `i` factors of the first basis
+vector, and the resulting scalar is the `2i - n`-th power of `z`. -/
+theorem coe_pow_mul_coe_inv_pow (z : Circle) {i n : ℕ} (hi : i ≤ n) :
+    (z : ℂ) ^ i * ((z : ℂ)⁻¹) ^ (n - i) = (z : ℂ) ^ (2 * (i : ℤ) - n) := by
+  -- the weight `2i - n` is the exponent of `z` minus the exponent of `z⁻¹`
+  have hexp : 2 * (i : ℤ) - n = (i : ℤ) - ((n - i : ℕ) : ℤ) := by omega
+  rw [hexp, zpow_sub₀ (Circle.coe_ne_zero z), zpow_natCast, zpow_natCast, inv_pow,
+    div_eq_mul_inv]
+
 /-- The weight string with the weights displayed as integer exponents `2i - d`. -/
 theorem character_symPower_torusHom_zpow (z : Circle) :
     (symPower d).character (torusHom z)
       = ∑ i ∈ range (d + 1), (z : ℂ) ^ (2 * (i : ℤ) - d) := by
   rw [character_symPower_torusHom]
-  refine sum_congr rfl fun i hi => ?_
-  have hi' : (i : ℕ) ≤ d := Nat.lt_succ_iff.mp (mem_range.mp hi)
-  -- the weight `2i - d` is the exponent of `z` minus the exponent of `z⁻¹`
-  have hexp : 2 * (i : ℤ) - d = (i : ℤ) - ((d - i : ℕ) : ℤ) := by omega
-  rw [hexp, zpow_sub₀ (Circle.coe_ne_zero z), zpow_natCast, zpow_natCast, inv_pow,
-    div_eq_mul_inv]
+  exact sum_congr rfl fun i hi =>
+    coe_pow_mul_coe_inv_pow z (Nat.lt_succ_iff.mp (mem_range.mp hi))
 
 /-- **The weight string in exponential coordinates.**  Writing the torus element as
 `diag(e^{iθ}, e^{-iθ})`, the character of `Symᵈ(ℂ²)` is `∑ᵢ e^{i(2i-d)θ}`: the classical

--- a/TauCeti/RepresentationTheory/SU2/Weight.lean
+++ b/TauCeti/RepresentationTheory/SU2/Weight.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.RepresentationTheory.SU2.SymmetricPower
 import Mathlib.Analysis.Real.Pi.Irrational
+import TauCeti.Algebra.GroupWithZero.Units.Basic
 import TauCeti.LinearAlgebra.Eigenspace.DiagonalBasis
 
 /-!
@@ -131,7 +132,7 @@ theorem symPower_torusHom_weightBasis (z : Circle) (i : Fin (d + 1)) :
       (stdRep_diagGL_apply_basisFun _)]
   congr 1
   -- the eigenvalue is `z` on the `i` factors of index `0` and `z⁻¹` on the `d - i` of index `1`
-  rw [weight_def, ← coe_pow_mul_coe_inv_pow z hi]
+  rw [weight_def, ← pow_mul_inv_pow_eq_zpow₀ (Circle.coe_ne_zero z) hi]
   simp [coe_symFinTwoEquiv_symm_apply]
 
 /-- The coordinates of a vector in the weight basis are scaled by the weights: the torus is
@@ -204,7 +205,7 @@ vector, and `m` is that vector's weight, one of the `d + 1` integers `2i - d`. -
 theorem exists_weight_eq_of_forall_torusHom_smul {w : Sym[ℂ]^d(Fin 2 → ℂ)} (hw : w ≠ 0) {m : ℤ}
     (hsmul : ∀ z : Circle, symPower d (torusHom z) w = ((z : ℂ) ^ m) • w) :
     ∃ i : Fin (d + 1), weight d i = m ∧ w ∈ Submodule.span ℂ {weightBasis d i} := by
-  obtain ⟨i, hi, hspan⟩ := (weightBasis d).exists_eq_and_mem_span_singleton
+  obtain ⟨i, hi, hspan⟩ := (weightBasis d).exists_apply_eq_and_mem_span_singleton
     (symPower_torusHom_weightBasis d genericTorus) (coe_genericTorus_zpow_weight_injective d) hw
     (hsmul genericTorus)
   exact ⟨i, coe_genericTorus_zpow_injective hi, hspan⟩

--- a/TauCeti/RepresentationTheory/SU2/Weight.lean
+++ b/TauCeti/RepresentationTheory/SU2/Weight.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.RepresentationTheory.SU2.SymmetricPower
 import Mathlib.Analysis.Real.Pi.Irrational
+import TauCeti.LinearAlgebra.Eigenspace.DiagonalBasis
 
 /-!
 # The weight decomposition of `Symᵈ(ℂ²)` under the maximal torus of `SU(2)`
@@ -24,12 +25,11 @@ occurs with multiplicity exactly one, and the character above,
 Two consequences make this the form the highest-weight classification uses.
 
 * **A torus-stable subspace is spanned by weight vectors.**  Nothing forces this for a single
-  operator with repeated eigenvalues; here the eigenvalues are distinct, and the proof is the
-  usual one: subtracting an eigenvalue multiple of a vector from its image under a fixed
-  generic torus element kills one coordinate and keeps the others, so an induction on the number
-  of nonzero coordinates strips a vector down to a single weight vector.  The generic element is
-  `exp(i)`, whose powers are pairwise distinct because `π` is irrational; it is a device of the
-  proof, and stays private to this file.
+  operator with repeated eigenvalues; here the eigenvalues are distinct, which is exactly the
+  hypothesis of the general coordinate argument
+  `TauCeti/LinearAlgebra/Eigenspace/DiagonalBasis.lean`.  Feeding it a torus element whose
+  integer powers are pairwise distinct — `exp(i)`, by the irrationality of `π` — separates the
+  `d + 1` weights at once.  That element is a device of the proof and stays private to this file.
 * **The weight spaces are lines.**  A nonzero vector on which the whole torus acts through a
   single character `z ↦ z^m` is a multiple of one basis vector, and `m` is one of the `d + 1`
   weights.
@@ -43,11 +43,12 @@ Two consequences make this the form the highest-weight classification uses.
 
 * `TauCeti.SU2.symPower_torusHom_weightBasis`: `diag(z, z⁻¹)` acts on the `i`-th weight vector by
   `z^{2i - d}`, and `TauCeti.SU2.weight_injective`: the weights are pairwise distinct.
-* `TauCeti.SU2.weightBasis_mem_of_repr_ne_zero` and `TauCeti.SU2.eq_span_weightBasis`: a
+* `TauCeti.SU2.weightBasis_mem_of_repr_ne_zero` and `TauCeti.SU2.eq_span_weightBasis_mem`: a
   torus-stable subspace contains every weight vector occurring in one of its elements, and is
   spanned by the weight vectors it contains.
 * `TauCeti.SU2.exists_weight_eq_of_forall_torusHom_smul`: a nonzero vector on which the torus acts
-  through a single character `z ↦ z^m` spans a weight line, and `m` is one of the weights.
+  through a single character `z ↦ z^m` is a multiple of a single weight vector, and `m` is that
+  vector's weight.
 
 ## References
 
@@ -107,8 +108,9 @@ theorem weight_last : weight d (Fin.last d) = (d : ℤ) := by
   rw [weight_def, Fin.val_last]
   ring
 
-/-- **The weights are pairwise distinct**: every weight of `Symᵈ(ℂ²)` occurs with multiplicity
-one. -/
+/-- **The `d + 1` weights `2i - d` are pairwise distinct.**  Together with
+`TauCeti.SU2.symPower_torusHom_weightBasis` this is what makes each weight of `Symᵈ(ℂ²)` occur
+with multiplicity one, in the form `TauCeti.SU2.exists_weight_eq_of_forall_torusHom_smul`. -/
 theorem weight_injective : Function.Injective (weight d) := by
   intro i j hij
   rw [weight_def, weight_def] at hij
@@ -121,37 +123,24 @@ weight vector by `z^{2i - d}`.  This is the weight decomposition of `Symᵈ(ℂ�
 character `TauCeti.SU2.character_symPower_torusHom` is the trace. -/
 theorem symPower_torusHom_weightBasis (z : Circle) (i : Fin (d + 1)) :
     symPower d (torusHom z) (weightBasis d i) = (z : ℂ) ^ weight d i • weightBasis d i := by
-  have hz : (z : ℂ) ≠ 0 := z.coe_ne_zero
   have hi : (i : ℕ) ≤ d := Nat.lt_succ_iff.mp i.isLt
   rw [weightBasis_apply, symPower_apply, toGL_torusHom,
     Representation.symmetricPower_apply,
-    SymmetricPower.map_symmetricPower_of_apply_basis (Pi.basisFun ℂ (Fin 2)) _
+    SymmetricPower.map_basis_symmetricPower_of_apply_basis (Pi.basisFun ℂ (Fin 2)) _
       (fun j => ((![Circle.toUnits z, (Circle.toUnits z)⁻¹] j : ℂˣ) : ℂ))
       (stdRep_diagGL_apply_basisFun _)]
   congr 1
-  rw [coe_symFinTwoEquiv_symm_apply, Multiset.map_add, Multiset.map_replicate,
-    Multiset.map_replicate, Multiset.prod_add, Multiset.prod_replicate, Multiset.prod_replicate]
   -- the eigenvalue is `z` on the `i` factors of index `0` and `z⁻¹` on the `d - i` of index `1`
-  have h0 : ((![Circle.toUnits z, (Circle.toUnits z)⁻¹] 0 : ℂˣ) : ℂ) = (z : ℂ) := by simp
-  have h1 : ((![Circle.toUnits z, (Circle.toUnits z)⁻¹] 1 : ℂˣ) : ℂ) = (z : ℂ)⁻¹ := by simp
-  have hexp : weight d i = (i : ℕ) - ((d - (i : ℕ) : ℕ) : ℤ) := by
-    rw [weight_def]
-    omega
-  rw [h0, h1, hexp, zpow_sub₀ hz, zpow_natCast, zpow_natCast, inv_pow, div_eq_mul_inv]
+  rw [weight_def, ← coe_pow_mul_coe_inv_pow z hi]
+  simp [coe_symFinTwoEquiv_symm_apply]
 
 /-- The coordinates of a vector in the weight basis are scaled by the weights: the torus is
 diagonal, so it multiplies the `i`-th coordinate by `z^{2i - d}`. -/
-theorem repr_symPower_torusHom (z : Circle) (w : Sym[ℂ]^d(Fin 2 → ℂ)) (i : Fin (d + 1)) :
+theorem weightBasis_repr_symPower_torusHom (z : Circle) (w : Sym[ℂ]^d(Fin 2 → ℂ))
+    (i : Fin (d + 1)) :
     (weightBasis d).repr (symPower d (torusHom z) w) i
-      = (z : ℂ) ^ weight d i * (weightBasis d).repr w i := by
-  have key : symPower d (torusHom z) w
-      = ∑ k, ((z : ℂ) ^ weight d k * (weightBasis d).repr w k) • weightBasis d k := by
-    conv_lhs => rw [← (weightBasis d).sum_repr w]
-    rw [map_sum]
-    refine Finset.sum_congr rfl fun k _ => ?_
-    rw [map_smul, symPower_torusHom_weightBasis, smul_smul, mul_comm]
-  rw [key]
-  exact congrFun ((weightBasis d).repr_sum_self _) i
+      = (z : ℂ) ^ weight d i * (weightBasis d).repr w i :=
+  (weightBasis d).repr_apply_of_apply_basis (symPower_torusHom_weightBasis d z) w i
 
 /-! ### A torus element with pairwise distinct powers -/
 
@@ -190,125 +179,35 @@ private theorem coe_genericTorus_zpow_weight_injective :
 
 variable {d}
 
-private theorem weightBasis_mem_aux {W : Submodule ℂ (Sym[ℂ]^d(Fin 2 → ℂ))}
-    (hW : ∀ (z : Circle) (v : Sym[ℂ]^d(Fin 2 → ℂ)), v ∈ W → symPower d (torusHom z) v ∈ W) :
-    ∀ (n : ℕ) (w : Sym[ℂ]^d(Fin 2 → ℂ)), w ∈ W →
-      ((weightBasis d).repr w).support.card ≤ n →
-        ∀ i : Fin (d + 1), (weightBasis d).repr w i ≠ 0 → weightBasis d i ∈ W := by
-  classical
-  intro n
-  induction n with
-  | zero =>
-    intro w _ hcard i hi
-    have hsupp : ((weightBasis d).repr w).support = ∅ :=
-      Finset.card_eq_zero.1 (Nat.le_zero.1 hcard)
-    exact absurd (Finsupp.notMem_support_iff.1 (by rw [hsupp]; exact Finset.notMem_empty i)) hi
-  | succ n ih =>
-    intro w hw hcard i hi
-    by_cases hsub : ((weightBasis d).repr w).support ⊆ {i}
-    · -- the only nonzero coordinate is the `i`-th, so `w` is already a multiple of `b i`
-      have hsum : ∑ k, (weightBasis d).repr w k • weightBasis d k
-          = (weightBasis d).repr w i • weightBasis d i := by
-        refine Finset.sum_eq_single i (fun k _ hk => ?_) fun h => absurd (Finset.mem_univ i) h
-        rw [Finsupp.notMem_support_iff.1 fun hks => hk (Finset.mem_singleton.1 (hsub hks)),
-          zero_smul]
-      obtain ⟨c, hc0, hcw⟩ : ∃ c : ℂ, c ≠ 0 ∧ w = c • weightBasis d i :=
-        ⟨(weightBasis d).repr w i, hi, by rw [← hsum, (weightBasis d).sum_repr]⟩
-      have hbi : weightBasis d i = c⁻¹ • w := by
-        rw [hcw, smul_smul, inv_mul_cancel₀ hc0, one_smul]
-      rw [hbi]
-      exact W.smul_mem _ hw
-    · -- otherwise some other coordinate `j` is nonzero, and can be cleared
-      obtain ⟨j, hjs, hji⟩ := Finset.not_subset.1 hsub
-      have hjne : j ≠ i := fun h => hji (Finset.mem_singleton.2 h)
-      set w' := symPower d (torusHom genericTorus) w
-        - ((genericTorus : ℂ) ^ weight d j) • w with hw'def
-      have hw'W : w' ∈ W := W.sub_mem (hW _ _ hw) (W.smul_mem _ hw)
-      have hrepr : ∀ k : Fin (d + 1), (weightBasis d).repr w' k
-          = ((genericTorus : ℂ) ^ weight d k - (genericTorus : ℂ) ^ weight d j)
-              * (weightBasis d).repr w k := by
-        intro k
-        rw [hw'def, map_sub, map_smul, Finsupp.sub_apply, Finsupp.smul_apply,
-          repr_symPower_torusHom, smul_eq_mul, sub_mul]
-      have hsupp' : ((weightBasis d).repr w').support ⊆
-          ((weightBasis d).repr w).support.erase j := by
-        intro k hk
-        have hk0 : (weightBasis d).repr w' k ≠ 0 := Finsupp.mem_support_iff.1 hk
-        rw [hrepr k] at hk0
-        refine Finset.mem_erase.2 ⟨?_, Finsupp.mem_support_iff.2 (right_ne_zero_of_mul hk0)⟩
-        rintro rfl
-        exact hk0 (by rw [sub_self, zero_mul])
-      have hcard' : ((weightBasis d).repr w').support.card ≤ n := by
-        have hle := Finset.card_le_card hsupp'
-        rw [Finset.card_erase_of_mem hjs] at hle
-        have hpos : 0 < ((weightBasis d).repr w).support.card := Finset.card_pos.2 ⟨j, hjs⟩
-        omega
-      refine ih w' hw'W hcard' i ?_
-      rw [hrepr i]
-      refine mul_ne_zero (sub_ne_zero.2 fun h => ?_) hi
-      exact hjne (coe_genericTorus_zpow_weight_injective d h).symm
-
 /-- **A torus-stable subspace contains every weight vector that occurs in one of its elements.**
-The weights of `Symᵈ(ℂ²)` are pairwise distinct, so the coordinates of a vector in the weight
-basis can be separated by repeatedly clearing one of them with the generic torus element. -/
+The torus is diagonal in the weight basis and the weights `weight d i` are pairwise distinct, so
+a single torus element already separates the coordinates of a vector. -/
 theorem weightBasis_mem_of_repr_ne_zero {W : Submodule ℂ (Sym[ℂ]^d(Fin 2 → ℂ))}
     (hW : ∀ (z : Circle) (v : Sym[ℂ]^d(Fin 2 → ℂ)), v ∈ W → symPower d (torusHom z) v ∈ W)
     {w : Sym[ℂ]^d(Fin 2 → ℂ)} (hw : w ∈ W) {i : Fin (d + 1)}
     (hi : (weightBasis d).repr w i ≠ 0) : weightBasis d i ∈ W :=
-  weightBasis_mem_aux hW _ w hw le_rfl i hi
+  (weightBasis d).self_mem_of_repr_ne_zero (symPower_torusHom_weightBasis d genericTorus)
+    (coe_genericTorus_zpow_weight_injective d) (hW genericTorus) hw hi
 
 /-- **A torus-stable subspace of `Symᵈ(ℂ²)` is spanned by the weight vectors it contains.** -/
-theorem eq_span_weightBasis {W : Submodule ℂ (Sym[ℂ]^d(Fin 2 → ℂ))}
+theorem eq_span_weightBasis_mem {W : Submodule ℂ (Sym[ℂ]^d(Fin 2 → ℂ))}
     (hW : ∀ (z : Circle) (v : Sym[ℂ]^d(Fin 2 → ℂ)), v ∈ W → symPower d (torusHom z) v ∈ W) :
-    W = Submodule.span ℂ {v | ∃ i : Fin (d + 1), weightBasis d i = v ∧ v ∈ W} := by
-  classical
-  refine le_antisymm (fun w hw => ?_) (Submodule.span_le.2 ?_)
-  · rw [← (weightBasis d).sum_repr w]
-    refine Submodule.sum_mem _ fun k _ => ?_
-    by_cases hk : (weightBasis d).repr w k = 0
-    · rw [hk, zero_smul]
-      exact Submodule.zero_mem _
-    · exact Submodule.smul_mem _ _
-        (Submodule.subset_span ⟨k, rfl, weightBasis_mem_of_repr_ne_zero hW hw hk⟩)
-  · rintro v ⟨-, -, hv⟩
-    exact hv
+    W = Submodule.span ℂ {v | ∃ i : Fin (d + 1), weightBasis d i = v ∧ v ∈ W} :=
+  (weightBasis d).eq_span_self_mem (symPower_torusHom_weightBasis d genericTorus)
+    (coe_genericTorus_zpow_weight_injective d) (hW genericTorus)
 
 /-! ### The weight spaces are lines -/
 
-/-- **The weight spaces of `Symᵈ(ℂ²)` are one-dimensional, and the weights are the `2i - d`.**  A
-nonzero vector on which the whole maximal torus acts through the single character `z ↦ z^m` is a
-multiple of a single weight vector, whose weight is `m`. -/
+/-- **A vector transforming under a single character of the torus is a weight vector.**  A nonzero
+`w` on which the whole maximal torus acts through `z ↦ z^m` is a multiple of a single weight
+vector, and `m` is that vector's weight, one of the `d + 1` integers `2i - d`. -/
 theorem exists_weight_eq_of_forall_torusHom_smul {w : Sym[ℂ]^d(Fin 2 → ℂ)} (hw : w ≠ 0) {m : ℤ}
     (hsmul : ∀ z : Circle, symPower d (torusHom z) w = ((z : ℂ) ^ m) • w) :
     ∃ i : Fin (d + 1), weight d i = m ∧ w ∈ Submodule.span ℂ {weightBasis d i} := by
-  classical
-  have hcoord : ∀ k : Fin (d + 1),
-      (genericTorus : ℂ) ^ weight d k * (weightBasis d).repr w k
-        = (genericTorus : ℂ) ^ m * (weightBasis d).repr w k := by
-    intro k
-    rw [← repr_symPower_torusHom d genericTorus w k, hsmul genericTorus, map_smul,
-      Finsupp.smul_apply, smul_eq_mul]
-  have hrne : (weightBasis d).repr w ≠ 0 := fun h =>
-    hw ((weightBasis d).repr.map_eq_zero_iff.1 h)
-  obtain ⟨i, hi⟩ := Finsupp.ne_iff.1 hrne
-  rw [Finsupp.coe_zero, Pi.zero_apply] at hi
-  have hwi : weight d i = m := coe_genericTorus_zpow_injective (mul_right_cancel₀ hi (hcoord i))
-  refine ⟨i, hwi, ?_⟩
-  have hzero : ∀ k : Fin (d + 1), k ≠ i → (weightBasis d).repr w k = 0 := by
-    intro k hk
-    by_contra hk0
-    have hpow : (genericTorus : ℂ) ^ weight d k = (genericTorus : ℂ) ^ weight d i := by
-      rw [hwi]
-      exact mul_right_cancel₀ hk0 (hcoord k)
-    exact hk (coe_genericTorus_zpow_weight_injective d hpow)
-  have hsum : ∑ k, (weightBasis d).repr w k • weightBasis d k
-      = (weightBasis d).repr w i • weightBasis d i := by
-    refine Finset.sum_eq_single i (fun k _ hk => ?_) fun h => absurd (Finset.mem_univ i) h
-    rw [hzero k hk, zero_smul]
-  have hwe : w = (weightBasis d).repr w i • weightBasis d i := by
-    rw [← hsum, (weightBasis d).sum_repr]
-  rw [hwe]
-  exact Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _)
+  obtain ⟨i, hi, hspan⟩ := (weightBasis d).exists_eq_and_mem_span_singleton
+    (symPower_torusHom_weightBasis d genericTorus) (coe_genericTorus_zpow_weight_injective d) hw
+    (hsmul genericTorus)
+  exact ⟨i, coe_genericTorus_zpow_injective hi, hspan⟩
 
 end SU2
 

--- a/TauCeti/RepresentationTheory/SU2/Weight.lean
+++ b/TauCeti/RepresentationTheory/SU2/Weight.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.SU2.SymmetricPower
+import Mathlib.Analysis.Real.Pi.Irrational
+
+/-!
+# The weight decomposition of `Symᵈ(ℂ²)` under the maximal torus of `SU(2)`
+
+`TauCeti/RepresentationTheory/SU2/SymmetricPower.lean` computes the *character* of the symmetric
+power `Symᵈ(ℂ²)` of the standard representation of `SU(2)` on the maximal torus as the weight
+string `z^{-d} + z^{2-d} + ⋯ + z^d`.  A character is a trace, so it records the weights only with
+multiplicity; this file builds the decomposition behind it.
+
+The monomial basis of `Symᵈ(ℂ²)`, reindexed by `Fin (d + 1)` through
+`TauCeti.symFinTwoEquiv`, is a basis of **weight vectors**: `diag(z, z⁻¹)` acts on the `i`-th one
+by the scalar `z^{2i - d}`.  The `d + 1` weights `2i - d` are pairwise distinct, so each weight
+occurs with multiplicity exactly one, and the character above is their sum.
+
+Two consequences make this the form the highest-weight classification uses.
+
+* **A torus-stable subspace is spanned by weight vectors.**  Nothing forces this for a single
+  operator with repeated eigenvalues; here the eigenvalues are distinct, and the proof is the
+  usual one: subtracting an eigenvalue multiple of a vector from its image under a fixed
+  generic torus element kills one coordinate and keeps the others, so an induction on the number
+  of nonzero coordinates strips a vector down to a single weight vector.  The generic element is
+  `TauCeti.SU2.genericTorus = exp(i)`, whose powers are pairwise distinct because `π` is
+  irrational.
+* **The weight spaces are lines.**  A nonzero vector on which the whole torus acts through a
+  single character `z ↦ z^m` is a multiple of one basis vector, and `m` is one of the `d + 1`
+  weights.
+
+## Main definitions
+
+* `TauCeti.SU2.weightBasis`: the weight basis of `Symᵈ(ℂ²)`, indexed by `Fin (d + 1)`.
+* `TauCeti.SU2.weight`: the weight `2i - d` of the `i`-th weight vector.
+* `TauCeti.SU2.genericTorus`: a torus element whose integer powers are pairwise distinct.
+
+## Main results
+
+* `TauCeti.SU2.symPower_torusHom_weightBasis`: `diag(z, z⁻¹)` acts on the `i`-th weight vector by
+  `z^{2i - d}`, and `TauCeti.SU2.weight_injective`: the weights are pairwise distinct.
+* `TauCeti.SU2.character_symPower_torusHom_eq_sum_weight`: the character on the torus is the sum
+  of the weights, which is the weight string of
+  `TauCeti.SU2.character_symPower_torusHom_zpow` reindexed.
+* `TauCeti.SU2.weightBasis_mem_of_repr_ne_zero` and `TauCeti.SU2.eq_span_weightBasis`: a
+  torus-stable subspace contains every weight vector occurring in one of its elements, and is
+  spanned by the weight vectors it contains.
+* `TauCeti.SU2.exists_weight_eq_of_forall_torusHom_smul`: a nonzero vector on which the torus acts
+  through a single character `z ↦ z^m` spans a weight line, and `m` is one of the weights.
+
+## References
+
+This is the "weight/string decomposition" milestone of the `SU(2)` engine case of
+`TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`, which asks for the weights
+`{d, d-2, …, -d}` of `Symᵈ(ℂ²)` "each with multiplicity one, computed from the diagonal action",
+as the input to the highest-weight argument.
+
+* D. Bump, *Lie Groups*, 2nd ed., Springer GTM 225 (2013), Chapter 3.
+* T. Bröcker, T. tom Dieck, *Representations of Compact Lie Groups*, Springer GTM 98 (1985),
+  Chapter II, §5.
+-/
+
+public section
+
+open Finset Matrix
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace SU2
+
+variable (d : ℕ)
+
+/-! ### The weight basis and the weights -/
+
+/-- **The weight basis of `Symᵈ(ℂ²)`**: the monomial basis of the symmetric power, whose index
+`i : Fin (d + 1)` counts the factors equal to the first standard basis vector of `ℂ²`.  Its
+elements are eigenvectors of the maximal torus, by
+`TauCeti.SU2.symPower_torusHom_weightBasis`. -/
+noncomputable def weightBasis : Module.Basis (Fin (d + 1)) ℂ (Sym[ℂ]^d(Fin 2 → ℂ)) :=
+  ((Pi.basisFun ℂ (Fin 2)).symmetricPower d).reindex (symFinTwoEquiv d)
+
+/-- The `i`-th weight vector is the monomial basis vector of `Symᵈ(ℂ²)` with `i` factors equal to
+the first standard basis vector of `ℂ²` and `d - i` equal to the second. -/
+theorem weightBasis_apply (i : Fin (d + 1)) :
+    weightBasis d i =
+      (Pi.basisFun ℂ (Fin 2)).symmetricPower d ((symFinTwoEquiv d).symm i) :=
+  Module.Basis.reindex_apply _ _ _
+
+/-- **The weight** of the `i`-th weight vector: the torus element `diag(z, z⁻¹)` acts on it by
+`z^{2i - d}`.  As `i` runs over `Fin (d + 1)` these are the `d + 1` integers
+`-d, 2 - d, …, d - 2, d`. -/
+def weight (i : Fin (d + 1)) : ℤ := 2 * (i : ℕ) - (d : ℤ)
+
+/-- The weight of the `i`-th weight vector, unfolded. -/
+theorem weight_def (i : Fin (d + 1)) : weight d i = 2 * (i : ℕ) - (d : ℤ) := (rfl)
+
+/-- The lowest weight of `Symᵈ(ℂ²)` is `-d`, on the monomial with no factor of the first basis
+vector. -/
+@[simp]
+theorem weight_zero : weight d 0 = -(d : ℤ) := by simp [weight_def]
+
+/-- The highest weight of `Symᵈ(ℂ²)` is `d`, on the `d`-th power of the first basis vector. -/
+@[simp]
+theorem weight_last : weight d (Fin.last d) = (d : ℤ) := by
+  rw [weight_def, Fin.val_last]
+  ring
+
+/-- **The weights are pairwise distinct**: every weight of `Symᵈ(ℂ²)` occurs with multiplicity
+one. -/
+theorem weight_injective : Function.Injective (weight d) := by
+  intro i j hij
+  rw [weight_def, weight_def] at hij
+  exact Fin.ext (by omega)
+
+/-! ### The torus acts diagonally in the weight basis -/
+
+/-- **The maximal torus is diagonal in the weight basis**: `diag(z, z⁻¹)` multiplies the `i`-th
+weight vector by `z^{2i - d}`.  This is the weight decomposition of `Symᵈ(ℂ²)`, of which the
+character `TauCeti.SU2.character_symPower_torusHom` is the trace. -/
+theorem symPower_torusHom_weightBasis (z : Circle) (i : Fin (d + 1)) :
+    symPower d (torusHom z) (weightBasis d i) = (z : ℂ) ^ weight d i • weightBasis d i := by
+  have hz : (z : ℂ) ≠ 0 := z.coe_ne_zero
+  have hi : (i : ℕ) ≤ d := Nat.lt_succ_iff.mp i.isLt
+  rw [weightBasis_apply, symPower_apply, toGL_torusHom,
+    Representation.symmetricPower_apply,
+    SymmetricPower.map_symmetricPower_of_apply_basis (Pi.basisFun ℂ (Fin 2)) _
+      (fun j => ((![Circle.toUnits z, (Circle.toUnits z)⁻¹] j : ℂˣ) : ℂ))
+      (stdRep_diagGL_apply_basisFun _)]
+  congr 1
+  rw [coe_symFinTwoEquiv_symm_apply, Multiset.map_add, Multiset.map_replicate,
+    Multiset.map_replicate, Multiset.prod_add, Multiset.prod_replicate, Multiset.prod_replicate]
+  -- the eigenvalue is `z` on the `i` factors of index `0` and `z⁻¹` on the `d - i` of index `1`
+  have h0 : ((![Circle.toUnits z, (Circle.toUnits z)⁻¹] 0 : ℂˣ) : ℂ) = (z : ℂ) := by simp
+  have h1 : ((![Circle.toUnits z, (Circle.toUnits z)⁻¹] 1 : ℂˣ) : ℂ) = (z : ℂ)⁻¹ := by simp
+  have hexp : weight d i = (i : ℕ) - ((d - (i : ℕ) : ℕ) : ℤ) := by
+    rw [weight_def]
+    omega
+  rw [h0, h1, hexp, zpow_sub₀ hz, zpow_natCast, zpow_natCast, inv_pow, div_eq_mul_inv]
+
+/-- **The character is the sum of the weights.**  This is the weight string
+`TauCeti.SU2.character_symPower_torusHom_zpow` written over the index set of the weight basis. -/
+theorem character_symPower_torusHom_eq_sum_weight (z : Circle) :
+    (symPower d).character (torusHom z) = ∑ i : Fin (d + 1), (z : ℂ) ^ weight d i := by
+  rw [character_symPower_torusHom_zpow]
+  exact (Fin.sum_univ_eq_sum_range
+    (fun j : ℕ => (z : ℂ) ^ (2 * (j : ℤ) - (d : ℤ))) (d + 1)).symm
+
+/-- The coordinates of a vector in the weight basis are scaled by the weights: the torus is
+diagonal, so it multiplies the `i`-th coordinate by `z^{2i - d}`. -/
+theorem repr_symPower_torusHom (z : Circle) (w : Sym[ℂ]^d(Fin 2 → ℂ)) (i : Fin (d + 1)) :
+    (weightBasis d).repr (symPower d (torusHom z) w) i
+      = (z : ℂ) ^ weight d i * (weightBasis d).repr w i := by
+  have key : symPower d (torusHom z) w
+      = ∑ k, ((z : ℂ) ^ weight d k * (weightBasis d).repr w k) • weightBasis d k := by
+    conv_lhs => rw [← (weightBasis d).sum_repr w]
+    rw [map_sum]
+    refine Finset.sum_congr rfl fun k _ => ?_
+    rw [map_smul, symPower_torusHom_weightBasis, smul_smul, mul_comm]
+  rw [key]
+  exact congrFun ((weightBasis d).repr_sum_self _) i
+
+/-! ### A torus element with pairwise distinct powers -/
+
+/-- **A generic element of the maximal torus**: `exp(i)`, an element of infinite order.  Its
+integer powers are pairwise distinct (`TauCeti.SU2.coe_genericTorus_zpow_injective`) because `π`
+is irrational, so it already separates the `d + 1` weights of `Symᵈ(ℂ²)` for every `d` at once. -/
+noncomputable def genericTorus : Circle := Circle.exp 1
+
+/-- **The powers of `TauCeti.SU2.genericTorus` are pairwise distinct.**  An equality
+`exp(i)^m = exp(i)^n` says `m - n` is an integer multiple of `2π`, which forces `m = n` since `π`
+is irrational. -/
+theorem coe_genericTorus_zpow_injective :
+    Function.Injective fun m : ℤ => (genericTorus : ℂ) ^ m := by
+  intro m n hmn
+  have h : (genericTorus ^ m : Circle) = genericTorus ^ n :=
+    Subtype.ext (by simpa only [Circle.coe_zpow] using hmn)
+  rw [genericTorus, ← Circle.exp_intCast_mul, ← Circle.exp_intCast_mul, mul_one, mul_one] at h
+  obtain ⟨k, hk⟩ := Circle.exp_eq_exp.1 h
+  rcases eq_or_ne k 0 with rfl | hk0
+  · have hmn' : (m : ℝ) = (n : ℝ) := by simpa using hk
+    exact_mod_cast hmn'
+  · refine absurd ?_ ((irrational_pi.intCast_mul (m := 2 * k) (by omega)).ne_int (m - n))
+    push_cast
+    linear_combination -hk
+
+/-- The generic torus element separates the weights of `Symᵈ(ℂ²)`: it acts on the `d + 1` weight
+vectors by `d + 1` pairwise distinct scalars. -/
+theorem coe_genericTorus_zpow_weight_injective :
+    Function.Injective fun i : Fin (d + 1) => (genericTorus : ℂ) ^ weight d i :=
+  fun _ _ h => weight_injective d (coe_genericTorus_zpow_injective h)
+
+/-! ### Torus-stable subspaces are spanned by weight vectors -/
+
+variable {d}
+
+private theorem weightBasis_mem_aux {W : Submodule ℂ (Sym[ℂ]^d(Fin 2 → ℂ))}
+    (hW : ∀ (z : Circle) (v : Sym[ℂ]^d(Fin 2 → ℂ)), v ∈ W → symPower d (torusHom z) v ∈ W) :
+    ∀ (n : ℕ) (w : Sym[ℂ]^d(Fin 2 → ℂ)), w ∈ W →
+      ((weightBasis d).repr w).support.card ≤ n →
+        ∀ i : Fin (d + 1), (weightBasis d).repr w i ≠ 0 → weightBasis d i ∈ W := by
+  classical
+  intro n
+  induction n with
+  | zero =>
+    intro w _ hcard i hi
+    have hsupp : ((weightBasis d).repr w).support = ∅ :=
+      Finset.card_eq_zero.1 (Nat.le_zero.1 hcard)
+    exact absurd (Finsupp.notMem_support_iff.1 (by rw [hsupp]; exact Finset.notMem_empty i)) hi
+  | succ n ih =>
+    intro w hw hcard i hi
+    by_cases hsub : ((weightBasis d).repr w).support ⊆ {i}
+    · -- the only nonzero coordinate is the `i`-th, so `w` is already a multiple of `b i`
+      have hsum : ∑ k, (weightBasis d).repr w k • weightBasis d k
+          = (weightBasis d).repr w i • weightBasis d i := by
+        refine Finset.sum_eq_single i (fun k _ hk => ?_) fun h => absurd (Finset.mem_univ i) h
+        rw [Finsupp.notMem_support_iff.1 fun hks => hk (Finset.mem_singleton.1 (hsub hks)),
+          zero_smul]
+      obtain ⟨c, hc0, hcw⟩ : ∃ c : ℂ, c ≠ 0 ∧ w = c • weightBasis d i :=
+        ⟨(weightBasis d).repr w i, hi, by rw [← hsum, (weightBasis d).sum_repr]⟩
+      have hbi : weightBasis d i = c⁻¹ • w := by
+        rw [hcw, smul_smul, inv_mul_cancel₀ hc0, one_smul]
+      rw [hbi]
+      exact W.smul_mem _ hw
+    · -- otherwise some other coordinate `j` is nonzero, and can be cleared
+      obtain ⟨j, hjs, hji⟩ := Finset.not_subset.1 hsub
+      have hjne : j ≠ i := fun h => hji (Finset.mem_singleton.2 h)
+      set w' := symPower d (torusHom genericTorus) w
+        - ((genericTorus : ℂ) ^ weight d j) • w with hw'def
+      have hw'W : w' ∈ W := W.sub_mem (hW _ _ hw) (W.smul_mem _ hw)
+      have hrepr : ∀ k : Fin (d + 1), (weightBasis d).repr w' k
+          = ((genericTorus : ℂ) ^ weight d k - (genericTorus : ℂ) ^ weight d j)
+              * (weightBasis d).repr w k := by
+        intro k
+        rw [hw'def, map_sub, map_smul, Finsupp.sub_apply, Finsupp.smul_apply,
+          repr_symPower_torusHom, smul_eq_mul, sub_mul]
+      have hsupp' : ((weightBasis d).repr w').support ⊆
+          ((weightBasis d).repr w).support.erase j := by
+        intro k hk
+        have hk0 : (weightBasis d).repr w' k ≠ 0 := Finsupp.mem_support_iff.1 hk
+        rw [hrepr k] at hk0
+        refine Finset.mem_erase.2 ⟨?_, Finsupp.mem_support_iff.2 (right_ne_zero_of_mul hk0)⟩
+        rintro rfl
+        exact hk0 (by rw [sub_self, zero_mul])
+      have hcard' : ((weightBasis d).repr w').support.card ≤ n := by
+        have hle := Finset.card_le_card hsupp'
+        rw [Finset.card_erase_of_mem hjs] at hle
+        have hpos : 0 < ((weightBasis d).repr w).support.card := Finset.card_pos.2 ⟨j, hjs⟩
+        omega
+      refine ih w' hw'W hcard' i ?_
+      rw [hrepr i]
+      refine mul_ne_zero (sub_ne_zero.2 fun h => ?_) hi
+      exact hjne (coe_genericTorus_zpow_weight_injective d h).symm
+
+/-- **A torus-stable subspace contains every weight vector that occurs in one of its elements.**
+The weights of `Symᵈ(ℂ²)` are pairwise distinct, so the coordinates of a vector in the weight
+basis can be separated by repeatedly clearing one of them with the generic torus element. -/
+theorem weightBasis_mem_of_repr_ne_zero {W : Submodule ℂ (Sym[ℂ]^d(Fin 2 → ℂ))}
+    (hW : ∀ (z : Circle) (v : Sym[ℂ]^d(Fin 2 → ℂ)), v ∈ W → symPower d (torusHom z) v ∈ W)
+    {w : Sym[ℂ]^d(Fin 2 → ℂ)} (hw : w ∈ W) {i : Fin (d + 1)}
+    (hi : (weightBasis d).repr w i ≠ 0) : weightBasis d i ∈ W :=
+  weightBasis_mem_aux hW _ w hw le_rfl i hi
+
+/-- **A torus-stable subspace of `Symᵈ(ℂ²)` is spanned by the weight vectors it contains.** -/
+theorem eq_span_weightBasis {W : Submodule ℂ (Sym[ℂ]^d(Fin 2 → ℂ))}
+    (hW : ∀ (z : Circle) (v : Sym[ℂ]^d(Fin 2 → ℂ)), v ∈ W → symPower d (torusHom z) v ∈ W) :
+    W = Submodule.span ℂ {v | ∃ i : Fin (d + 1), weightBasis d i = v ∧ v ∈ W} := by
+  classical
+  refine le_antisymm (fun w hw => ?_) (Submodule.span_le.2 ?_)
+  · rw [← (weightBasis d).sum_repr w]
+    refine Submodule.sum_mem _ fun k _ => ?_
+    by_cases hk : (weightBasis d).repr w k = 0
+    · rw [hk, zero_smul]
+      exact Submodule.zero_mem _
+    · exact Submodule.smul_mem _ _
+        (Submodule.subset_span ⟨k, rfl, weightBasis_mem_of_repr_ne_zero hW hw hk⟩)
+  · rintro v ⟨-, -, hv⟩
+    exact hv
+
+/-! ### The weight spaces are lines -/
+
+/-- **The weight spaces of `Symᵈ(ℂ²)` are one-dimensional, and the weights are the `2i - d`.**  A
+nonzero vector on which the whole maximal torus acts through the single character `z ↦ z^m` is a
+multiple of a single weight vector, whose weight is `m`. -/
+theorem exists_weight_eq_of_forall_torusHom_smul {w : Sym[ℂ]^d(Fin 2 → ℂ)} (hw : w ≠ 0) {m : ℤ}
+    (hsmul : ∀ z : Circle, symPower d (torusHom z) w = ((z : ℂ) ^ m) • w) :
+    ∃ i : Fin (d + 1), weight d i = m ∧ w ∈ Submodule.span ℂ {weightBasis d i} := by
+  classical
+  have hcoord : ∀ k : Fin (d + 1),
+      (genericTorus : ℂ) ^ weight d k * (weightBasis d).repr w k
+        = (genericTorus : ℂ) ^ m * (weightBasis d).repr w k := by
+    intro k
+    rw [← repr_symPower_torusHom d genericTorus w k, hsmul genericTorus, map_smul,
+      Finsupp.smul_apply, smul_eq_mul]
+  have hrne : (weightBasis d).repr w ≠ 0 := fun h =>
+    hw ((weightBasis d).repr.map_eq_zero_iff.1 h)
+  obtain ⟨i, hi⟩ := Finsupp.ne_iff.1 hrne
+  rw [Finsupp.coe_zero, Pi.zero_apply] at hi
+  have hwi : weight d i = m := coe_genericTorus_zpow_injective (mul_right_cancel₀ hi (hcoord i))
+  refine ⟨i, hwi, ?_⟩
+  have hzero : ∀ k : Fin (d + 1), k ≠ i → (weightBasis d).repr w k = 0 := by
+    intro k hk
+    by_contra hk0
+    refine hk (coe_genericTorus_zpow_weight_injective d ?_)
+    change (genericTorus : ℂ) ^ weight d k = (genericTorus : ℂ) ^ weight d i
+    rw [hwi]
+    exact mul_right_cancel₀ hk0 (hcoord k)
+  have hsum : ∑ k, (weightBasis d).repr w k • weightBasis d k
+      = (weightBasis d).repr w i • weightBasis d i := by
+    refine Finset.sum_eq_single i (fun k _ hk => ?_) fun h => absurd (Finset.mem_univ i) h
+    rw [hzero k hk, zero_smul]
+  have hwe : w = (weightBasis d).repr w i • weightBasis d i := by
+    rw [← hsum, (weightBasis d).sum_repr]
+  rw [hwe]
+  exact Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _)
+
+end SU2
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/SU2/Weight.lean
+++ b/TauCeti/RepresentationTheory/SU2/Weight.lean
@@ -18,7 +18,8 @@ multiplicity; this file builds the decomposition behind it.
 The monomial basis of `Symᵈ(ℂ²)`, reindexed by `Fin (d + 1)` through
 `TauCeti.symFinTwoEquiv`, is a basis of **weight vectors**: `diag(z, z⁻¹)` acts on the `i`-th one
 by the scalar `z^{2i - d}`.  The `d + 1` weights `2i - d` are pairwise distinct, so each weight
-occurs with multiplicity exactly one, and the character above is their sum.
+occurs with multiplicity exactly one, and the character above,
+`TauCeti.SU2.character_symPower_torusHom_zpow`, is their sum.
 
 Two consequences make this the form the highest-weight classification uses.
 
@@ -43,9 +44,6 @@ Two consequences make this the form the highest-weight classification uses.
 
 * `TauCeti.SU2.symPower_torusHom_weightBasis`: `diag(z, z⁻¹)` acts on the `i`-th weight vector by
   `z^{2i - d}`, and `TauCeti.SU2.weight_injective`: the weights are pairwise distinct.
-* `TauCeti.SU2.character_symPower_torusHom_eq_sum_weight`: the character on the torus is the sum
-  of the weights, which is the weight string of
-  `TauCeti.SU2.character_symPower_torusHom_zpow` reindexed.
 * `TauCeti.SU2.weightBasis_mem_of_repr_ne_zero` and `TauCeti.SU2.eq_span_weightBasis`: a
   torus-stable subspace contains every weight vector occurring in one of its elements, and is
   spanned by the weight vectors it contains.
@@ -141,14 +139,6 @@ theorem symPower_torusHom_weightBasis (z : Circle) (i : Fin (d + 1)) :
     rw [weight_def]
     omega
   rw [h0, h1, hexp, zpow_sub₀ hz, zpow_natCast, zpow_natCast, inv_pow, div_eq_mul_inv]
-
-/-- **The character is the sum of the weights.**  This is the weight string
-`TauCeti.SU2.character_symPower_torusHom_zpow` written over the index set of the weight basis. -/
-theorem character_symPower_torusHom_eq_sum_weight (z : Circle) :
-    (symPower d).character (torusHom z) = ∑ i : Fin (d + 1), (z : ℂ) ^ weight d i := by
-  rw [character_symPower_torusHom_zpow]
-  exact (Fin.sum_univ_eq_sum_range
-    (fun j : ℕ => (z : ℂ) ^ (2 * (j : ℤ) - (d : ℤ))) (d + 1)).symm
 
 /-- The coordinates of a vector in the weight basis are scaled by the weights: the torus is
 diagonal, so it multiplies the `i`-th coordinate by `z^{2i - d}`. -/

--- a/TauCeti/RepresentationTheory/SU2/Weight.lean
+++ b/TauCeti/RepresentationTheory/SU2/Weight.lean
@@ -28,8 +28,8 @@ Two consequences make this the form the highest-weight classification uses.
   usual one: subtracting an eigenvalue multiple of a vector from its image under a fixed
   generic torus element kills one coordinate and keeps the others, so an induction on the number
   of nonzero coordinates strips a vector down to a single weight vector.  The generic element is
-  `TauCeti.SU2.genericTorus = exp(i)`, whose powers are pairwise distinct because `π` is
-  irrational.
+  `exp(i)`, whose powers are pairwise distinct because `π` is irrational; it is a device of the
+  proof, and stays private to this file.
 * **The weight spaces are lines.**  A nonzero vector on which the whole torus acts through a
   single character `z ↦ z^m` is a multiple of one basis vector, and `m` is one of the `d + 1`
   weights.
@@ -38,7 +38,6 @@ Two consequences make this the form the highest-weight classification uses.
 
 * `TauCeti.SU2.weightBasis`: the weight basis of `Symᵈ(ℂ²)`, indexed by `Fin (d + 1)`.
 * `TauCeti.SU2.weight`: the weight `2i - d` of the `i`-th weight vector.
-* `TauCeti.SU2.genericTorus`: a torus element whose integer powers are pairwise distinct.
 
 ## Main results
 
@@ -157,14 +156,17 @@ theorem repr_symPower_torusHom (z : Circle) (w : Sym[ℂ]^d(Fin 2 → ℂ)) (i :
 /-! ### A torus element with pairwise distinct powers -/
 
 /-- **A generic element of the maximal torus**: `exp(i)`, an element of infinite order.  Its
-integer powers are pairwise distinct (`TauCeti.SU2.coe_genericTorus_zpow_injective`) because `π`
-is irrational, so it already separates the `d + 1` weights of `Symᵈ(ℂ²)` for every `d` at once. -/
-noncomputable def genericTorus : Circle := Circle.exp 1
+integer powers are pairwise distinct (`coe_genericTorus_zpow_injective`) because `π` is
+irrational, so it already separates the `d + 1` weights of `Symᵈ(ℂ²)` for every `d` at once.
 
-/-- **The powers of `TauCeti.SU2.genericTorus` are pairwise distinct.**  An equality
+This is the separating element the proofs below run on, not part of the interface: the results
+they prove are stated for the whole torus. -/
+private noncomputable def genericTorus : Circle := Circle.exp 1
+
+/-- **The powers of `genericTorus` are pairwise distinct.**  An equality
 `exp(i)^m = exp(i)^n` says `m - n` is an integer multiple of `2π`, which forces `m = n` since `π`
 is irrational. -/
-theorem coe_genericTorus_zpow_injective :
+private theorem coe_genericTorus_zpow_injective :
     Function.Injective fun m : ℤ => (genericTorus : ℂ) ^ m := by
   intro m n hmn
   have h : (genericTorus ^ m : Circle) = genericTorus ^ n :=
@@ -180,7 +182,7 @@ theorem coe_genericTorus_zpow_injective :
 
 /-- The generic torus element separates the weights of `Symᵈ(ℂ²)`: it acts on the `d + 1` weight
 vectors by `d + 1` pairwise distinct scalars. -/
-theorem coe_genericTorus_zpow_weight_injective :
+private theorem coe_genericTorus_zpow_weight_injective :
     Function.Injective fun i : Fin (d + 1) => (genericTorus : ℂ) ^ weight d i :=
   fun _ _ h => weight_injective d (coe_genericTorus_zpow_injective h)
 
@@ -295,10 +297,10 @@ theorem exists_weight_eq_of_forall_torusHom_smul {w : Sym[ℂ]^d(Fin 2 → ℂ)}
   have hzero : ∀ k : Fin (d + 1), k ≠ i → (weightBasis d).repr w k = 0 := by
     intro k hk
     by_contra hk0
-    refine hk (coe_genericTorus_zpow_weight_injective d ?_)
-    change (genericTorus : ℂ) ^ weight d k = (genericTorus : ℂ) ^ weight d i
-    rw [hwi]
-    exact mul_right_cancel₀ hk0 (hcoord k)
+    have hpow : (genericTorus : ℂ) ^ weight d k = (genericTorus : ℂ) ^ weight d i := by
+      rw [hwi]
+      exact mul_right_cancel₀ hk0 (hcoord k)
+    exact hk (coe_genericTorus_zpow_weight_injective d hpow)
   have hsum : ∑ k, (weightBasis d).repr w k • weightBasis d k
       = (weightBasis d).repr w i • weightBasis d i := by
     refine Finset.sum_eq_single i (fun k _ hk => ?_) fun h => absurd (Finset.mem_univ i) h


### PR DESCRIPTION
This PR builds the weight decomposition of the symmetric powers `Symᵈ(ℂ²)` of the standard representation of `SU(2)` under its maximal torus, the "weight/string decomposition" milestone (`su2Irrep_character_torus`) of the `SU(2)` engine case in `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`, which asks for the weights `{d, d-2, …, -d}` "each with multiplicity one, computed from the diagonal action" as the input to the highest-weight argument. `TauCeti/RepresentationTheory/SU2/SymmetricPower.lean` already has the character on the torus, but a character is a trace and records the weights only with multiplicity; the decomposition behind it was missing.

`TauCeti.SU2.weightBasis` is the monomial basis of `Symᵈ(ℂ²)` reindexed by `Fin (d + 1)` through `TauCeti.symFinTwoEquiv`, and `TauCeti.SU2.symPower_torusHom_weightBasis` computes the diagonal action: `diag(z, z⁻¹)` multiplies the `i`-th basis vector by `z^{2i-d}`. The weights `TauCeti.SU2.weight d i = 2i - d` are pairwise distinct (`TauCeti.SU2.weight_injective`), so every weight occurs exactly once, which is the decomposition behind the existing character formula `TauCeti.SU2.character_symPower_torusHom_zpow` (that character is left as it is: a `Fin (d + 1)`-indexed restatement of it was dropped in 95dcd8b as a duplicate).

Two consequences are what the classification consumes. `TauCeti.SU2.weightBasis_mem_of_repr_ne_zero` and `TauCeti.SU2.eq_span_weightBasis_mem`: a torus-stable subspace contains every weight vector occurring in one of its elements, hence is spanned by the weight vectors it contains. And `TauCeti.SU2.exists_weight_eq_of_forall_torusHom_smul`: a nonzero vector on which the whole torus acts through a single character `z ↦ z^m` is a multiple of one of the `d + 1` weight vectors, and `m` is its weight — the multiplicity-one statement.

Neither is automatic for an operator with repeated eigenvalues, and neither uses anything about `Sym`, `ℂ²` or `SU(2)`. The linear algebra is therefore stated where it belongs, in the new `TauCeti/LinearAlgebra/Eigenspace/DiagonalBasis.lean`: for an endomorphism diagonal in a basis with an injective eigenvalue function, `Module.Basis.self_mem_of_repr_ne_zero`, `Module.Basis.eq_span_self_mem` and `Module.Basis.exists_eq_and_mem_span_singleton` (with `Module.Basis.repr_apply_of_apply_basis`, the coordinate form, over a commutative semiring). The proof clears one coordinate at a time — `f w - a j • w` stays in the subspace and loses its `j`-th coordinate — and inducts on the number of nonzero ones. The `SU(2)` results are instantiations of these at a fixed generic torus element `exp(i)`, whose integer powers are pairwise distinct because `π` is irrational; that element is private to the `SU(2)` file and the statements there are for the whole torus.

One prerequisite is factored out of existing code rather than duplicated: the computation that an endomorphism diagonal in a basis is diagonal in the induced basis of a symmetric power was a `have` inside `TauCeti.SymmetricPower.trace_map_of_apply_basis`, and is now the public `TauCeti.SymmetricPower.map_basis_symmetricPower_of_apply_basis` in `TauCeti/LinearAlgebra/SymmetricPower/Basis.lean`, with the trace lemma reusing it. Likewise the exponent computation `a^i * (a⁻¹)^{n-i} = a^{2i-n}`, shared by the character proof and the weight-basis proof, is now `TauCeti.pow_mul_inv_pow_eq_zpow₀` in `TauCeti/Algebra/GroupWithZero/Units/Basic.lean`, stated for a `GroupWithZero` alongside Mathlib's `pow_sub₀`/`zpow_natCast_sub_natCast₀`. No declaration is removed.

No Mathlib source is vendored; the files consume Mathlib's `Circle` API (`Circle.exp_eq_exp`, `Circle.exp_intCast_mul`), `irrational_pi`, and `Module.Basis`/`Finsupp` coordinates directly.

`lake build`, `lake exe axioms` and `scripts/lint-env.sh` are green on the branch.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"su2irrep-character-torus"}-->

🤖 Prepared with Claude Code

