### PR TITLE
feat(EllipticCurve): the intermediate ring of an isogeny

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.CoordinateRing
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Basic
 
 /-!

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.CoordinateRing
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Basic
+
+/-!
+# The intermediate ring of an isogeny
+
+The integral closure of the target coordinate ring inside the source function field, taken along
+an isogeny's pullback. This is the normalization that `CoordinatePullback.MapsInfinity` names,
+and it receives both coordinate rings: the target's through the pullback, and the source's
+because `mapsInfinity` is precisely the assertion that it lands there.
+
+## Main definitions
+
+* `TauCeti.Isogeny.intermediateRing`: the integral closure of `W₂.CoordinateRing` in
+  `W₁.FunctionField` along `φ.pullback`.
+
+## Main results
+
+* `TauCeti.Isogeny.algebraMap_mem_intermediateRing`: the source coordinate ring lands in it.
+* `TauCeti.Isogeny.pullback_mem_intermediateRing`: so does the target coordinate ring.
+* `TauCeti.Isogeny.id_intermediateRing`: the identity isogeny's intermediate ring is the
+  coordinate ring itself, sitting inside its own fraction field.
+
+## Design
+
+The result is a `Subring W₁.FunctionField`, not a `Subalgebra`. The algebra structure that
+`φ.pullback` induces on `W₁.FunctionField` is deliberately not a global instance — different
+isogenies induce different ones, so registering any would be a diamond, as `Isogeny/Basic.lean`
+explains. A `Subalgebra` would put that structure into the *type*, forcing every statement about
+the object to fix a choice of it; a `Subring` keeps it inside the definition, exactly where
+`MapsInfinity` already keeps it.
+
+Nothing here assumes separability, so purely inseparable isogenies such as Frobenius are covered.
+
+The structural theory of this ring — module-finiteness over `W₂.CoordinateRing`, and its being a
+Dedekind domain — is deliberately not proved here. Every route to it in Mathlib
+(`IsIntegralClosure.finite`, `integralClosure.isDedekindDomain`) carries an
+`Algebra.IsSeparable` hypothesis, so the inseparable case that this roadmap wants is separate
+work rather than a corollary of the definition.
+
+This opens the "points come along" milestone of Layer 1 of
+`TauCetiRoadmap/EllipticCurves/README.md`, which names this object as "the **intermediate ring**
+— the integral closure of `W₂.CoordinateRing` in `W₁.FunctionField`, the normalization
+`mapsInfinity` names", receiving both coordinate rings on the way to `pushClass` and
+`toPointHom`. It follows Silverman, *The Arithmetic of Elliptic Curves*, II.2.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Isogeny
+
+variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
+
+/-- **The intermediate ring of an isogeny**: the integral closure of the target coordinate ring
+inside the source function field, along the isogeny's pullback. -/
+noncomputable def intermediateRing (φ : Isogeny W₁ W₂) : Subring W₁.FunctionField :=
+  letI := φ.pullback.toRingHom.toAlgebra
+  (integralClosure W₂.CoordinateRing W₁.FunctionField).toSubring
+
+/-- Membership in the intermediate ring is integrality over the target coordinate ring acting
+through the pullback. The definition's body is not exposed across the module boundary, so this
+is how downstream modules compute with it. -/
+theorem mem_intermediateRing_iff (φ : Isogeny W₁ W₂) (z : W₁.FunctionField) :
+    z ∈ φ.intermediateRing ↔
+      @IsIntegral W₂.CoordinateRing W₁.FunctionField _ _ φ.pullback.toRingHom.toAlgebra z :=
+  Iff.rfl
+
+/-- **The source coordinate ring lands in the intermediate ring.** This is `mapsInfinity` read
+as a statement about that ring: pointedness of the isogeny says exactly that the source
+coordinates are integral over the pulled-back target coordinate ring. -/
+theorem algebraMap_mem_intermediateRing (φ : Isogeny W₁ W₂) (x : W₁.CoordinateRing) :
+    algebraMap W₁.CoordinateRing W₁.FunctionField x ∈ φ.intermediateRing :=
+  (CoordinatePullback.mapsInfinity_iff φ.pullback).1 φ.mapsInfinity x
+
+/-- **The target coordinate ring lands in the intermediate ring**, through the pullback: each
+element of the image is integral over the ring it is the image of. -/
+theorem pullback_mem_intermediateRing (φ : Isogeny W₁ W₂) (x : W₂.CoordinateRing) :
+    φ.pullback x ∈ φ.intermediateRing :=
+  letI := φ.pullback.toRingHom.toAlgebra
+  isIntegral_algebraMap
+
+/-- **The identity isogeny's intermediate ring is the coordinate ring itself**, embedded in its
+own fraction field: the coordinate ring of an elliptic curve is integrally closed, so nothing in
+the function field beyond it is integral over it. -/
+theorem id_intermediateRing (W : WeierstrassCurve.Affine F) [W.IsElliptic] :
+    (id W).intermediateRing = (algebraMap W.CoordinateRing W.FunctionField).range := by
+  have := WeierstrassCurve.Affine.isIntegrallyClosed_coordinateRing W
+  -- the identity pullback induces the coordinate ring's own algebra structure on the function
+  -- field, so the integral closure below is the ordinary one
+  have halg : (CoordinatePullback.id W).toRingHom.toAlgebra =
+      (inferInstance : Algebra W.CoordinateRing W.FunctionField) := by
+    apply Algebra.algebra_ext
+    intro x
+    rw [RingHom.algebraMap_toAlgebra]
+    exact CoordinatePullback.id_apply W x
+  ext z
+  rw [mem_intermediateRing_iff, RingHom.mem_range, id_pullback, halg]
+  constructor
+  · intro hz
+    have hbot : z ∈ integralClosure W.CoordinateRing W.FunctionField := hz
+    rw [IsIntegrallyClosed.integralClosure_eq_bot] at hbot
+    exact Algebra.mem_bot.1 hbot
+  · rintro ⟨x, rfl⟩
+    exact isIntegral_algebraMap
+
+end Isogeny
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing.lean
@@ -19,12 +19,15 @@ because `mapsInfinity` is precisely the assertion that it lands there.
 
 * `TauCeti.Isogeny.intermediateRing`: the integral closure of `W₂.CoordinateRing` in
   `W₁.FunctionField` along `φ.pullback`.
+* `TauCeti.Isogeny.toIntermediateRing` and `TauCeti.Isogeny.pullbackToIntermediateRing`: the two
+  coordinate rings corestricted into it, along which ideals are extended and the relative norm
+  is taken.
 
 ## Main results
 
 * `TauCeti.Isogeny.algebraMap_mem_intermediateRing`: the source coordinate ring lands in it.
 * `TauCeti.Isogeny.pullback_mem_intermediateRing`: so does the target coordinate ring.
-* `TauCeti.Isogeny.id_intermediateRing`: the identity isogeny's intermediate ring is the
+* `TauCeti.Isogeny.id_intermediateRing`: an identity isogeny's intermediate ring is the
   coordinate ring itself, sitting inside its own fraction field.
 
 ## Design
@@ -36,7 +39,16 @@ explains. A `Subalgebra` would put that structure into the *type*, forcing every
 the object to fix a choice of it; a `Subring` keeps it inside the definition, exactly where
 `MapsInfinity` already keeps it.
 
+The two corestrictions are plain `RingHom`s rather than an `Algebra W₂.CoordinateRing`
+instance on the intermediate ring. An algebra *instance* would reintroduce the diamond the
+`Subring` choice exists to avoid, since the structure it would register is the pullback-induced
+one; a bundled map carries the same information to consumers without registering anything.
+
 Nothing here assumes separability, so purely inseparable isogenies such as Frobenius are covered.
+`id_intermediateRing` is stated for an integrally closed coordinate ring rather than an elliptic
+one, which is all its proof uses; the elliptic case is that hypothesis discharged by
+`WeierstrassCurve.Affine.isIntegrallyClosed_coordinateRing`, and is not given a separate name
+because nothing would consume it.
 
 The structural theory of this ring — module-finiteness over `W₂.CoordinateRing`, and its being a
 Dedekind domain — is deliberately not proved here. Every route to it in Mathlib
@@ -49,6 +61,23 @@ This opens the "points come along" milestone of Layer 1 of
 — the integral closure of `W₂.CoordinateRing` in `W₁.FunctionField`, the normalization
 `mapsInfinity` names", receiving both coordinate rings on the way to `pushClass` and
 `toPointHom`. It follows Silverman, *The Arithmetic of Elliptic Curves*, II.2.
+
+## Provenance
+
+The choice of object is taken from the AINTLIB project (`github.com/CBirkbeck/AINTLIB`, at
+revision `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache 2.0 per the source file's header, by
+Chris Birkbeck): `projects/HasseWeil/HasseWeil/Curves/NormConormIntegralClosure.lean`, which
+introduces `B := integralClosure C₂.CoordinateRing C₁.FunctionField` and carries its structural
+instances `instDedekindB`, `instModuleFiniteB`, `instFractionRingB` and `instTorsionFreeB`, proved
+in `projects/HasseWeil/HasseWeil/Curves/RamificationFinite.lean`.
+
+What is adapted here is the object and the observation that the integral closure over the
+*coordinate* ring — rather than over a localization — is the right home for the norm and
+class-group route to the induced map on points. The structural instances are deliberately **not**
+ported: the source proves them for a fixed extension carrying `[Algebra.IsSeparable K L]`, with
+the algebra structures supplied as instance arguments, whereas this file takes the pullback-induced
+structure locally and assumes no separability. None of the declarations below is a transcription
+of a source declaration.
 
 ## References
 
@@ -71,7 +100,12 @@ noncomputable def intermediateRing (φ : Isogeny W₁ W₂) : Subring W₁.Funct
 
 /-- Membership in the intermediate ring is integrality over the target coordinate ring acting
 through the pullback. The definition's body is not exposed across the module boundary, so this
-is how downstream modules compute with it. -/
+is how downstream modules compute with it.
+
+Deliberately not `@[simp]`: it would rewrite every `z ∈ φ.intermediateRing` into the `IsIntegral`
+form, which is exactly the left-hand side of the two membership lemmas below, so tagging it would
+stop those firing. The simp-normal form of a membership goal is discharge by one of them; this
+lemma is the escape hatch for the goals they do not cover. -/
 theorem mem_intermediateRing_iff (φ : Isogeny W₁ W₂) (z : W₁.FunctionField) :
     z ∈ φ.intermediateRing ↔
       @IsIntegral W₂.CoordinateRing W₁.FunctionField _ _ φ.pullback.toRingHom.toAlgebra z :=
@@ -80,23 +114,48 @@ theorem mem_intermediateRing_iff (φ : Isogeny W₁ W₂) (z : W₁.FunctionFiel
 /-- **The source coordinate ring lands in the intermediate ring.** This is `mapsInfinity` read
 as a statement about that ring: pointedness of the isogeny says exactly that the source
 coordinates are integral over the pulled-back target coordinate ring. -/
+@[simp]
 theorem algebraMap_mem_intermediateRing (φ : Isogeny W₁ W₂) (x : W₁.CoordinateRing) :
     algebraMap W₁.CoordinateRing W₁.FunctionField x ∈ φ.intermediateRing :=
   (CoordinatePullback.mapsInfinity_iff φ.pullback).1 φ.mapsInfinity x
 
 /-- **The target coordinate ring lands in the intermediate ring**, through the pullback: each
 element of the image is integral over the ring it is the image of. -/
+@[simp]
 theorem pullback_mem_intermediateRing (φ : Isogeny W₁ W₂) (x : W₂.CoordinateRing) :
     φ.pullback x ∈ φ.intermediateRing :=
   letI := φ.pullback.toRingHom.toAlgebra
   isIntegral_algebraMap
 
+/-- The source coordinate ring, corestricted into the intermediate ring. Extending an ideal of
+`W₁.CoordinateRing` into the intermediate ring is done along this map. -/
+noncomputable def toIntermediateRing (φ : Isogeny W₁ W₂) :
+    W₁.CoordinateRing →+* φ.intermediateRing :=
+  (algebraMap W₁.CoordinateRing W₁.FunctionField).codRestrict _
+    φ.algebraMap_mem_intermediateRing
+
+@[simp]
+theorem coe_toIntermediateRing (φ : Isogeny W₁ W₂) (x : W₁.CoordinateRing) :
+    (φ.toIntermediateRing x : W₁.FunctionField) =
+      algebraMap W₁.CoordinateRing W₁.FunctionField x := (rfl)
+
+/-- The target coordinate ring, corestricted into the intermediate ring along the pullback. The
+relative ideal norm back down to `W₂.CoordinateRing` is taken over this map. -/
+noncomputable def pullbackToIntermediateRing (φ : Isogeny W₁ W₂) :
+    W₂.CoordinateRing →+* φ.intermediateRing :=
+  φ.pullback.toRingHom.codRestrict _ φ.pullback_mem_intermediateRing
+
+@[simp]
+theorem coe_pullbackToIntermediateRing (φ : Isogeny W₁ W₂) (x : W₂.CoordinateRing) :
+    (φ.pullbackToIntermediateRing x : W₁.FunctionField) = φ.pullback x := (rfl)
+
 /-- **The identity isogeny's intermediate ring is the coordinate ring itself**, embedded in its
-own fraction field: the coordinate ring of an elliptic curve is integrally closed, so nothing in
-the function field beyond it is integral over it. -/
-theorem id_intermediateRing (W : WeierstrassCurve.Affine F) [W.IsElliptic] :
+own fraction field: nothing in the function field beyond an integrally closed coordinate ring is
+integral over it. For an elliptic curve the hypothesis is
+`WeierstrassCurve.Affine.isIntegrallyClosed_coordinateRing`. -/
+@[simp]
+theorem id_intermediateRing (W : WeierstrassCurve.Affine F) [IsIntegrallyClosed W.CoordinateRing] :
     (id W).intermediateRing = (algebraMap W.CoordinateRing W.FunctionField).range := by
-  have := WeierstrassCurve.Affine.isIntegrallyClosed_coordinateRing W
   -- the identity pullback induces the coordinate ring's own algebra structure on the function
   -- field, so the integral closure below is the ordinary one
   have halg : (CoordinatePullback.id W).toRingHom.toAlgebra =


### PR DESCRIPTION
The integral closure of the target coordinate ring inside the source function field, taken along
an isogeny's pullback. One definition and four theorems, in a new file.

```lean
noncomputable def intermediateRing (φ : Isogeny W₁ W₂) : Subring W₁.FunctionField :=
  letI := φ.pullback.toRingHom.toAlgebra
  (integralClosure W₂.CoordinateRing W₁.FunctionField).toSubring
```

## Why it is worth its own PR

Layer 1 of `TauCetiRoadmap/EllipticCurves/README.md` names this object explicitly, under
"Points come along, with the group law for free":

> The **intermediate ring** — the integral closure of `W₂.CoordinateRing` in `W₁.FunctionField`,
> the normalization `mapsInfinity` names — receives *both* coordinate rings […]

and routes the milestone through it: extend an ideal of `W₁.CoordinateRing` into it, take the
relative ideal norm down to `W₂.CoordinateRing` for `pushClass`, then conjugate by `toClassEquiv`
to get `toPointHom : W₁.Point →+ W₂.Point`. This PR is the object itself and the "receives both
coordinate rings" half, which is the part that needs no further theory.

`STATUS.md` for this roadmap independently points here: it records the normality half,
`isIntegrallyClosed_coordinateRing`, as "what the induced map on points of an isogeny needs".
That is the result `id_intermediateRing` below consumes.

## What is deliberately *not* here

Module-finiteness over `W₂.CoordinateRing`, and the intermediate ring being a Dedekind domain.
Those are the next slice, and they are **not** a corollary of this one, for a reason worth
stating so the gap is not mistaken for an oversight:

Every route to them in Mathlib carries a separability hypothesis —
`IsIntegralClosure.finite`, `integralClosure.isDedekindDomain` and
`IsIntegralClosure.isDedekindDomain` all require `[Algebra.IsSeparable K L]`.

But the roadmap wants this ring for *every* isogeny, "inseparable case and Frobenius included",
and `Isogeny.finiteDimensional` in `Isogeny/Degree.lean` is already proved with no separability
hypothesis precisely so that Frobenius is covered. So the inseparable case is genuine new
mathematics rather than a port, and it belongs in its own PR rather than being smuggled in
behind a hypothesis that quietly excludes Frobenius.

Nothing in this PR assumes separability.

## Design: `Subring`, not `Subalgebra`

`Isogeny/Basic.lean` states the constraint:

> The integrality condition installs the algebra structure induced by the chosen pullback only
> locally: different pullbacks generally give different algebra structures on the same function
> field, so registering one globally would create a typeclass diamond.

A `Subalgebra W₂.CoordinateRing W₁.FunctionField` would put that structure into the **type**, so
every statement about the object would have to fix a choice of it, and two isogenies' intermediate
rings would not even be comparable. A `Subring W₁.FunctionField` keeps the induced structure
inside the definition — exactly where `MapsInfinity` already keeps it — at the cost of one
`@IsIntegral` ascription in `mem_intermediateRing_iff`, which is the lemma downstream modules
compute with anyway since the body is not exposed across the module boundary.

## The content

* `algebraMap_mem_intermediateRing` — the **source** coordinate ring lands in it. This is
  `mapsInfinity` itself, read as a statement about this ring; the proof is `φ.mapsInfinity x`.
  That it is one term is the point: the definition is chosen so that pointedness *is* this.
* `pullback_mem_intermediateRing` — the **target** coordinate ring lands in it, through the
  pullback.
* `id_intermediateRing` — the identity isogeny's intermediate ring is the coordinate ring itself,
  inside its own fraction field. This is the one with mathematical content: it consumes
  `isIntegrallyClosed_coordinateRing`, so it is the statement that an elliptic curve's coordinate
  ring has nothing integral over it beyond itself.

## Scope

New mathematics, one definition and four theorems, justified as the Layer-1 target quoted above.
New file `Isogeny/IntermediateRing.lean`, placed beside `Basic`/`FunctionField`/`Degree`; it
imports only what it uses.

## Provenance

The object and its Dedekind/finite/fraction-ring theory appear in
`github.com/CBirkbeck/AINTLIB` @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0 per the
source file's header, in `projects/HasseWeil/HasseWeil/Curves/NormConormIntegralClosure.lean`
(`B`, `instDedekindB`, `instModuleFiniteB`, `instFractionRingB`) with the instances proved in
`projects/HasseWeil/HasseWeil/Curves/RamificationFinite.lean`.

This PR does **not** port those instances, for the separability reason above: the source states
them for a fixed separable extension with the algebra structures supplied as instance arguments,
which is the setting this roadmap explicitly does not want. What is taken from the source is the
choice of object — the integral closure over the *coordinate* ring rather than a localization —
and the observation that it is the right home for the norm/class-group route to `toPointHom`.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"isogeny-intermediate-ring"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
