### PR TITLE
feat: transport Cartier duality to group schemes

### DIFF
--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/Equivalence.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/Equivalence.lean
@@ -22,8 +22,8 @@ general base are separate steps.
 
 ## Main declarations
 
-* `TauCeti.FiniteBicommutativeHopfAlgCat`: finite-dimensional commutative, cocommutative Hopf
-  algebras over a field.
+* `TauCeti.FiniteBicommutativeHopfAlgCat`: module-finite commutative, cocommutative Hopf
+  algebras over a commutative ring.
 * `TauCeti.FiniteBicommutativeHopfAlgCat.dualFunctor`: contravariant finite dualization.
 * `TauCeti.FiniteBicommutativeHopfAlgCat.evalIso`: the objectwise double-dual evaluation
   isomorphism, natural in morphisms by `evalIso_hom_naturality`.
@@ -45,86 +45,88 @@ namespace TauCeti
 
 universe u
 
-/-- The object property selecting finite-dimensional bicommutative Hopf algebras over a field.
+/-- The object property selecting module-finite bicommutative Hopf algebras over a commutative ring.
 
 The ambient `CommHopfAlgCat` supplies commutativity of multiplication; the second conjunct is
 cocommutativity of comultiplication. -/
-def finiteBicommutativeHopfAlgProperty (k : Type u) [Field k] :
-    ObjectProperty (_root_.CommHopfAlgCat.{u} k) :=
-  fun H => Module.Finite k H ∧ Coalgebra.IsCocomm k H
+def finiteBicommutativeHopfAlgProperty (R : Type u) [CommRing R] :
+    ObjectProperty (_root_.CommHopfAlgCat.{u} R) :=
+  fun H => Module.Finite R H ∧ Coalgebra.IsCocomm R H
 
-/-- Membership in `finiteBicommutativeHopfAlgProperty` is finite-dimensionality together with
+/-- Membership in `finiteBicommutativeHopfAlgProperty` is module-finiteness together with
 cocommutativity. -/
 @[simp]
-theorem finiteBicommutativeHopfAlgProperty_iff (k : Type u) [Field k]
-    (H : _root_.CommHopfAlgCat.{u} k) :
-    finiteBicommutativeHopfAlgProperty k H ↔
-      Module.Finite k H ∧ Coalgebra.IsCocomm k H :=
+theorem finiteBicommutativeHopfAlgProperty_iff (R : Type u) [CommRing R]
+    (H : _root_.CommHopfAlgCat.{u} R) :
+    finiteBicommutativeHopfAlgProperty R H ↔
+      Module.Finite R H ∧ Coalgebra.IsCocomm R H :=
   Iff.rfl
 
-/-- The category of finite-dimensional bicommutative Hopf algebras over a field. -/
-abbrev FiniteBicommutativeHopfAlgCat (k : Type u) [Field k] :=
-  (finiteBicommutativeHopfAlgProperty (k := k)).FullSubcategory
+/-- The category of module-finite bicommutative Hopf algebras over a commutative ring. -/
+abbrev FiniteBicommutativeHopfAlgCat (R : Type u) [CommRing R] :=
+  (finiteBicommutativeHopfAlgProperty (R := R)).FullSubcategory
 
 namespace FiniteBicommutativeHopfAlgCat
 
-variable {k : Type u} [Field k]
+variable {R : Type u} [CommRing R]
 
-instance : CoeSort (FiniteBicommutativeHopfAlgCat.{u} k) (Type u) :=
+instance : CoeSort (FiniteBicommutativeHopfAlgCat.{u} R) (Type u) :=
   ⟨fun H => H.obj⟩
 
-instance commRing (H : FiniteBicommutativeHopfAlgCat.{u} k) : CommRing H :=
+instance commRing (H : FiniteBicommutativeHopfAlgCat.{u} R) : CommRing H :=
   inferInstanceAs (CommRing H.obj)
 
-instance hopfAlgebra (H : FiniteBicommutativeHopfAlgCat.{u} k) :
-    HopfAlgebra k H :=
-  inferInstanceAs (HopfAlgebra k H.obj)
+instance hopfAlgebra (H : FiniteBicommutativeHopfAlgCat.{u} R) :
+    HopfAlgebra R H :=
+  inferInstanceAs (HopfAlgebra R H.obj)
 
-instance finite (H : FiniteBicommutativeHopfAlgCat.{u} k) : Module.Finite k H :=
+instance finite (H : FiniteBicommutativeHopfAlgCat.{u} R) : Module.Finite R H :=
   H.property.1
 
-instance isCocomm (H : FiniteBicommutativeHopfAlgCat.{u} k) :
-    Coalgebra.IsCocomm k H :=
+instance isCocomm (H : FiniteBicommutativeHopfAlgCat.{u} R) :
+    Coalgebra.IsCocomm R H :=
   H.property.2
 
-variable (k) in
-/-- Bundle a finite-dimensional bicommutative Hopf algebra as an object of
+variable (R) in
+/-- Bundle a module-finite bicommutative Hopf algebra as an object of
 `FiniteBicommutativeHopfAlgCat`. -/
-abbrev of (H : Type u) [CommRing H] [HopfAlgebra k H] [Module.Finite k H]
-    [Coalgebra.IsCocomm k H] : FiniteBicommutativeHopfAlgCat.{u} k :=
-  ⟨_root_.CommHopfAlgCat.of k H,
-    (finiteBicommutativeHopfAlgProperty_iff k _).2 ⟨inferInstance, inferInstance⟩⟩
+abbrev of (H : Type u) [CommRing H] [HopfAlgebra R H] [Module.Finite R H]
+    [Coalgebra.IsCocomm R H] : FiniteBicommutativeHopfAlgCat.{u} R :=
+  ⟨_root_.CommHopfAlgCat.of R H,
+    (finiteBicommutativeHopfAlgProperty_iff R _).2 ⟨inferInstance, inferInstance⟩⟩
 
 /-- The bialgebra morphism underlying a morphism of finite bicommutative Hopf algebras. -/
-abbrev toBialgHom {H K : FiniteBicommutativeHopfAlgCat.{u} k} (f : H ⟶ K) :
-    H →ₐc[k] K :=
+abbrev toBialgHom {H K : FiniteBicommutativeHopfAlgCat.{u} R} (f : H ⟶ K) :
+    H →ₐc[R] K :=
   f.hom.hom
 
-/-- Bundle a bialgebra morphism between finite-dimensional bicommutative Hopf algebras. -/
-abbrev ofHom {H K : Type u} [CommRing H] [CommRing K] [HopfAlgebra k H]
-    [HopfAlgebra k K] [Module.Finite k H] [Module.Finite k K]
-    [Coalgebra.IsCocomm k H] [Coalgebra.IsCocomm k K] (f : H →ₐc[k] K) :
-    of k H ⟶ of k K :=
+/-- Bundle a bialgebra morphism between module-finite bicommutative Hopf algebras. -/
+abbrev ofHom {H K : Type u} [CommRing H] [CommRing K] [HopfAlgebra R H]
+    [HopfAlgebra R K] [Module.Finite R H] [Module.Finite R K]
+    [Coalgebra.IsCocomm R H] [Coalgebra.IsCocomm R K] (f : H →ₐc[R] K) :
+    of R H ⟶ of R K :=
   ObjectProperty.homMk (_root_.CommHopfAlgCat.ofHom f)
 
 /-- Morphisms of finite bicommutative Hopf algebras are determined by their underlying
 bialgebra morphisms. -/
 @[ext]
-theorem hom_ext {H K : FiniteBicommutativeHopfAlgCat.{u} k} {f g : H ⟶ K}
+theorem hom_ext {H K : FiniteBicommutativeHopfAlgCat.{u} R} {f g : H ⟶ K}
     (h : toBialgHom f = toBialgHom g) : f = g :=
-  ObjectProperty.hom_ext (P := finiteBicommutativeHopfAlgProperty k)
+  ObjectProperty.hom_ext (P := finiteBicommutativeHopfAlgProperty R)
     (_root_.CommHopfAlgCat.hom_ext h)
 
 @[simp]
-theorem toBialgHom_id {H : FiniteBicommutativeHopfAlgCat.{u} k} :
-    toBialgHom (𝟙 H : H ⟶ H) = BialgHom.id k H :=
+theorem toBialgHom_id {H : FiniteBicommutativeHopfAlgCat.{u} R} :
+    toBialgHom (𝟙 H : H ⟶ H) = BialgHom.id R H :=
   rfl
 
 @[simp]
-theorem toBialgHom_comp {H K L : FiniteBicommutativeHopfAlgCat.{u} k}
+theorem toBialgHom_comp {H K L : FiniteBicommutativeHopfAlgCat.{u} R}
     (f : H ⟶ K) (g : K ⟶ L) :
     toBialgHom (f ≫ g) = (toBialgHom g).comp (toBialgHom f) :=
   rfl
+
+variable {k : Type u} [Field k]
 
 /-- The finite dual of a finite-dimensional bicommutative Hopf algebra. -/
 noncomputable abbrev dual (H : FiniteBicommutativeHopfAlgCat.{u} k) :

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean
@@ -95,38 +95,38 @@ instance (S : CommRingCat.{u}) :
     · exact isCommMonObj_of_grp_iso
         ((affineGroupSchemeProperty S).ι.mapIso e) hG.2
 
-/-- Under the affine Hopf/group-scheme anti-equivalence, finite-dimensionality and
+/-- Under the affine Hopf/group-scheme anti-equivalence, module-finiteness and
 cocommutativity of the coordinate Hopf algebra correspond to finiteness and commutativity of the
 affine group scheme. -/
 theorem finiteCommAffineGroupSchemeProperty_inverseImage
-    (k : Type u) [Field k] :
-    (finiteCommAffineGroupSchemeProperty (CommRingCat.of k)).inverseImage
-        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor =
-      (finiteBicommutativeHopfAlgProperty k).op := by
+    (R : Type u) [CommRing R] :
+    (finiteCommAffineGroupSchemeProperty (CommRingCat.of R)).inverseImage
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of R)).functor =
+      (finiteBicommutativeHopfAlgProperty R).op := by
   ext H
-  let G : AffineGroupSchemeCat (CommRingCat.of k) :=
-    ⟨(hopfSpec (CommRingCat.of k)).obj H, by
+  let G : AffineGroupSchemeCat (CommRingCat.of R) :=
+    ⟨(hopfSpec (CommRingCat.of R)).obj H, by
       apply (affineGroupSchemeProperty_iff _).mpr
       rw [← essImage_hopfSpec]
       exact ⟨H, ⟨Iso.refl _⟩⟩⟩
   let e : (commHopfAlgCatOpEquivAffineGroupSchemeCat
-      (CommRingCat.of k)).functor.obj H ≅ G :=
-    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      (CommRingCat.of R)).functor.obj H ≅ G :=
+    (affineGroupSchemeProperty (CommRingCat.of R)).ι.preimageIso
       ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-        (CommRingCat.of k)).app H)
+        (CommRingCat.of R)).app H)
   rw [ObjectProperty.prop_inverseImage_iff,
     finiteCommAffineGroupSchemeProperty_iff, ObjectProperty.op_iff,
     finiteBicommutativeHopfAlgProperty_iff]
   constructor
   · intro h
-    have hG : finiteCommAffineGroupSchemeProperty (CommRingCat.of k) G :=
-      (finiteCommAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso e h
-    exact ⟨(moduleFinite_iff_isFinite_hopfSpec k H.unop).mpr hG.1,
-      (isCocomm_iff_isCommMonObj_hopfSpec k H.unop).mpr hG.2⟩
+    have hG : finiteCommAffineGroupSchemeProperty (CommRingCat.of R) G :=
+      (finiteCommAffineGroupSchemeProperty (CommRingCat.of R)).prop_of_iso e h
+    exact ⟨(moduleFinite_iff_isFinite_hopfSpec R H.unop).mpr hG.1,
+      (isCocomm_iff_isCommMonObj_hopfSpec R H.unop).mpr hG.2⟩
   · intro h
-    apply (finiteCommAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso e.symm
-    exact ⟨(moduleFinite_iff_isFinite_hopfSpec k H.unop).mp h.1,
-      (isCocomm_iff_isCommMonObj_hopfSpec k H.unop).mp h.2⟩
+    apply (finiteCommAffineGroupSchemeProperty (CommRingCat.of R)).prop_of_iso e.symm
+    exact ⟨(moduleFinite_iff_isFinite_hopfSpec R H.unop).mp h.1,
+      (isCocomm_iff_isCommMonObj_hopfSpec R H.unop).mp h.2⟩
 
 /-- The category of finite commutative affine group schemes over a base ring. -/
 abbrev FiniteCommAffineGroupSchemeCat (S : CommRingCat.{u}) :=
@@ -140,28 +140,28 @@ instance {S : CommRingCat.{u}} (G : FiniteCommAffineGroupSchemeCat S) :
     IsCommMonObj G.obj.obj.X :=
   G.property.2
 
-/-- `Spec` as an anti-equivalence from finite-dimensional bicommutative Hopf algebras to finite
-commutative affine group schemes over a field. -/
+/-- `Spec` as an anti-equivalence from module-finite bicommutative Hopf algebras to finite
+commutative affine group schemes over a commutative ring. -/
 noncomputable def finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat
-    (k : Type u) [Field k] :
-    (FiniteBicommutativeHopfAlgCat.{u} k)ᵒᵖ ≌
-      FiniteCommAffineGroupSchemeCat (CommRingCat.of k) :=
-  (ObjectProperty.opEquivalence (finiteBicommutativeHopfAlgProperty k)).symm.trans <|
+    (R : Type u) [CommRing R] :
+    (FiniteBicommutativeHopfAlgCat.{u} R)ᵒᵖ ≌
+      FiniteCommAffineGroupSchemeCat (CommRingCat.of R) :=
+  (ObjectProperty.opEquivalence (finiteBicommutativeHopfAlgProperty R)).symm.trans <|
     (commHopfAlgCatOpEquivAffineGroupSchemeCat
-      (CommRingCat.of k)).congrFullSubcategory
-        (finiteCommAffineGroupSchemeProperty_inverseImage k)
+      (CommRingCat.of R)).congrFullSubcategory
+        (finiteCommAffineGroupSchemeProperty_inverseImage R)
 
 /-- The restricted equivalence followed by the finite-commutative inclusion is definitionally
 the unrestricted equivalence applied after forgetting the finiteness and cocommutativity proofs.
 This private isomorphism isolates the implementation of the object-property restrictions. -/
 private noncomputable def
     finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCatFunctorCompιIso
-    (k : Type u) [Field k] :
-    (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k).functor ⋙
-        (finiteCommAffineGroupSchemeProperty (CommRingCat.of k)).ι ≅
-      (forget₂ (FiniteBicommutativeHopfAlgCat.{u} k)
-          (CommHopfAlgCat.{u} k)).op ⋙
-        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor :=
+    (R : Type u) [CommRing R] :
+    (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat R).functor ⋙
+        (finiteCommAffineGroupSchemeProperty (CommRingCat.of R)).ι ≅
+      (forget₂ (FiniteBicommutativeHopfAlgCat.{u} R)
+          (CommHopfAlgCat.{u} R)).op ⋙
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of R)).functor :=
   Iso.refl _
 
 /-- The forward restricted anti-equivalence, followed by the inclusions into affine group schemes
@@ -169,21 +169,21 @@ and all group schemes, is `hopfSpec` applied after forgetting the finiteness and
 proofs. This is the computation interface for the restricted equivalence. -/
 noncomputable def
     finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat.functorCompιIso
-    (k : Type u) [Field k] :
-    (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k).functor ⋙
-          (finiteCommAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
-        (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
-      (forget₂ (FiniteBicommutativeHopfAlgCat.{u} k)
-          (CommHopfAlgCat.{u} k)).op ⋙ hopfSpec (CommRingCat.of k) :=
+    (R : Type u) [CommRing R] :
+    (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat R).functor ⋙
+          (finiteCommAffineGroupSchemeProperty (CommRingCat.of R)).ι ⋙
+        (affineGroupSchemeProperty (CommRingCat.of R)).ι ≅
+      (forget₂ (FiniteBicommutativeHopfAlgCat.{u} R)
+          (CommHopfAlgCat.{u} R)).op ⋙ hopfSpec (CommRingCat.of R) :=
   Functor.isoWhiskerRight
-      (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCatFunctorCompιIso k)
-      (affineGroupSchemeProperty (CommRingCat.of k)).ι ≪≫
+      (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCatFunctorCompιIso R)
+      (affineGroupSchemeProperty (CommRingCat.of R)).ι ≪≫
     Functor.associator _ _ _ ≪≫
     Functor.isoWhiskerLeft
-      (forget₂ (FiniteBicommutativeHopfAlgCat.{u} k)
-        (CommHopfAlgCat.{u} k)).op
+      (forget₂ (FiniteBicommutativeHopfAlgCat.{u} R)
+        (CommHopfAlgCat.{u} R)).op
       (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-        (CommRingCat.of k))
+        (CommRingCat.of R))
 
 namespace FiniteCommAffineGroupSchemeCat
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean
@@ -25,6 +25,8 @@ Hopf algebra is cocommutative.
   Hopf--`Spec` anti-equivalence.
 * `TauCeti.finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat.functorCompιIso`:
   after both inclusions, the restricted equivalence is Mathlib's `hopfSpec`.
+* `TauCeti.finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat.inverseCompιIso`:
+  after inclusion, the restricted inverse is the unrestricted inverse.
 * `TauCeti.FiniteCommAffineGroupSchemeCat.cartierDuality`: Cartier duality transported to finite
   commutative affine group schemes over a field.
 * `TauCeti.FiniteCommAffineGroupSchemeCat.cartierDuality_functor`: its computation as transported
@@ -48,19 +50,6 @@ open scoped CategoryTheory.MonObj
 namespace TauCeti
 
 universe u
-
-private instance finite_respectsIso :
-    MorphismProperty.RespectsIso (@IsFinite) where
-  toRespectsLeft :=
-    { precomp := fun i hi f hf => by
-        let _ := hi
-        let _ := hf
-        infer_instance }
-  toRespectsRight :=
-    { postcomp := fun i hi f hf => by
-        let _ := hi
-        let _ := hf
-        infer_instance }
 
 /-- The object property selecting finite commutative affine group schemes over a base ring. -/
 def finiteCommAffineGroupSchemeProperty (S : CommRingCat.{u}) :
@@ -185,6 +174,35 @@ noncomputable def
       (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
         (CommRingCat.of R))
 
+/-- The inverse restricted anti-equivalence, followed by the inclusion into commutative Hopf
+algebras, is the unrestricted inverse applied after including finite commutative affine group
+schemes into affine group schemes. -/
+noncomputable def
+    finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat.inverseCompιIso
+    (R : Type u) [CommRing R] :
+    (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat R).inverse ⋙
+        (forget₂ (FiniteBicommutativeHopfAlgCat.{u} R)
+          (CommHopfAlgCat.{u} R)).op ≅
+      (finiteCommAffineGroupSchemeProperty (CommRingCat.of R)).ι ⋙
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of R)).inverse :=
+  Iso.refl _
+
+/-- The `rightOp` inverse used in scheme-level Cartier duality computes, after forgetting
+module-finiteness and cocommutativity, as the opposite of the unrestricted coordinate Hopf-algebra
+functor. -/
+noncomputable def
+    finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat.rightOpInverseCompιIso
+    (R : Type u) [CommRing R] :
+    (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat R).rightOp.inverse ⋙
+        forget₂ (FiniteBicommutativeHopfAlgCat.{u} R) (CommHopfAlgCat.{u} R) ≅
+      ((finiteCommAffineGroupSchemeProperty (CommRingCat.of R)).ι ⋙
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of R)).inverse).leftOp := by
+  let e :=
+    finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat.inverseCompιIso R
+  exact
+    { hom := e.inv.leftOp
+      inv := e.hom.leftOp }
+
 namespace FiniteCommAffineGroupSchemeCat
 
 /-- **Cartier duality for finite commutative affine group schemes over a field.** -/
@@ -197,7 +215,9 @@ noncomputable def cartierDuality
       (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k)
 
 /-- The forward functor of scheme-level Cartier duality is finite dualization transported through
-the restricted Hopf--`Spec` equivalence. -/
+the restricted Hopf--`Spec` equivalence. Together with `rightOpInverseCompιIso` and
+`functorCompιIso`, this describes both coordinate-algebra extraction and reconstruction without
+unfolding the restricted equivalence. -/
 @[simp]
 theorem cartierDuality_functor (k : Type u) [Field k] :
     (cartierDuality k).functor =

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean
@@ -77,6 +77,9 @@ private theorem isCommMonObj_of_grp_iso
 instance (S : CommRingCat.{u}) :
     (finiteCommAffineGroupSchemeProperty S).IsClosedUnderIsomorphisms where
   of_iso e hG := by
+    let _ : MorphismProperty.RespectsIso (@IsFinite : MorphismProperty Scheme) :=
+      MorphismProperty.respectsIso_of_isStableUnderComposition
+        (fun _ _ f (_ : IsIso f) ↦ inferInstance)
     constructor
     · exact (MorphismProperty.over_iso_iff (@IsFinite)
         ((Grp.forget _).mapIso

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean
@@ -1,0 +1,264 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Morphisms.Finite
+public import Mathlib.CategoryTheory.ObjectProperty.Opposite
+public import TauCeti.Algebra.HopfAlgebra.FiniteDual.Equivalence
+public import TauCeti.Algebra.Coalgebra.Convolution
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+
+/-!
+# Cartier duality for finite commutative affine group schemes
+
+This file transports finite-dimensional Cartier duality from coordinate Hopf algebras to affine
+group schemes over a field. A Hopf spectrum is finite over the base precisely when its coordinate
+algebra is finite-dimensional, and it is a commutative group object precisely when its coordinate
+Hopf algebra is cocommutative.
+
+## Main declarations
+
+* `TauCeti.finiteCommAffineGroupSchemeProperty`: the object property selecting finite
+  commutative affine group schemes over a field.
+* `TauCeti.finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat`: the restricted
+  Hopf--`Spec` anti-equivalence.
+* `TauCeti.finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat.functorCompιIso`:
+  after both inclusions, the restricted equivalence is Mathlib's `hopfSpec`.
+* `TauCeti.finiteCommAffineGroupSchemeCartierDuality`: Cartier duality transported to finite
+  commutative affine group schemes.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+* J. S. Milne, *Algebraic Groups* (2017), Section 12.e.
+
+This completes the field-level scheme transport in Layer 4, "Cartier duality", of the
+ReductiveGroups roadmap. Extension to finite locally free group schemes over a general base is a
+separate step.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry Opposite WithConv
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti
+
+universe u
+
+private instance finite_respectsIso :
+    MorphismProperty.RespectsIso (@IsFinite) where
+  toRespectsLeft :=
+    { precomp := fun i hi f hf => by
+        let _ := hi
+        let _ := hf
+        infer_instance }
+  toRespectsRight :=
+    { postcomp := fun i hi f hf => by
+        let _ := hi
+        let _ := hf
+        infer_instance }
+
+/-- A Hopf spectrum is a commutative group object exactly when its coordinate Hopf algebra is
+cocommutative. -/
+theorem isCocomm_iff_isCommMonObj_hopfSpec
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    Coalgebra.IsCocomm k H ↔
+      IsCommMonObj
+        (((hopfSpec (CommRingCat.of k)).obj (op H)).X) := by
+  constructor
+  · intro h
+    let _ := h
+    rw [hopfSpec_obj_eq_asOver]
+    infer_instance
+  · intro h
+    rw [hopfSpec_obj_eq_asOver] at h
+    let _ := h
+    constructor
+    let leftPoint : WithConv (H →ₐ[k] TensorProduct k H H) :=
+      toConv (Bialgebra.TensorProduct.includeLeft
+        (R := k) (H₁ := H) (H₂ := H)).toAlgHom
+    let rightPoint : WithConv (H →ₐ[k] TensorProduct k H H) :=
+      toConv (Bialgebra.TensorProduct.includeRight
+        (R := k) (H₁ := H) (H₂ := H)).toAlgHom
+    have hcomm : leftPoint * rightPoint = rightPoint * leftPoint := by
+      apply (AlgebraicGeometry.Spec.mapMulEquiv
+        (R := k) (S := H) (T := TensorProduct k H H)).injective
+      simpa only [map_mul] using mul_comm
+        ((AlgebraicGeometry.Spec.mapMulEquiv
+          (R := k) (S := H) (T := TensorProduct k H H)) leftPoint)
+        ((AlgebraicGeometry.Spec.mapMulEquiv
+          (R := k) (S := H) (T := TensorProduct k H H)) rightPoint)
+    have hswap :
+        toConv ((Algebra.TensorProduct.comm k H H).toAlgHom.comp
+          (Bialgebra.comulAlgHom k H)) = rightPoint * leftPoint := by
+      rw [Bialgebra.toConv_comp_comulAlgHom]
+      simp only [leftPoint, rightPoint,
+        Bialgebra.TensorProduct.includeLeft_toAlgHom,
+        Bialgebra.TensorProduct.includeRight_toAlgHom,
+        Algebra.TensorProduct.comm_comp_includeLeft,
+        Algebra.TensorProduct.comm_comp_includeRight]
+    have hcomul :
+        toConv ((Algebra.TensorProduct.comm k H H).toAlgHom.comp
+          (Bialgebra.comulAlgHom k H)) =
+            toConv (Bialgebra.comulAlgHom k H) := by
+      rw [hswap, ← hcomm]
+      exact Bialgebra.comulPoint_eq_include_mul.symm
+    have hlinear := congrArg
+      (fun f : WithConv (H →ₐ[k] TensorProduct k H H) => f.ofConv.toLinearMap) hcomul
+    simp only [AlgHom.comp_toLinearMap, Bialgebra.toLinearMap_comulAlgHom] at hlinear
+    apply LinearMap.ext
+    intro x
+    exact LinearMap.congr_fun hlinear x
+
+/-- A Hopf spectrum is finite over its base exactly when its coordinate algebra is
+finite-dimensional. -/
+theorem moduleFinite_iff_isFinite_hopfSpec
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    Module.Finite k H ↔
+      IsFinite (((hopfSpec (CommRingCat.of k)).obj (op H)).X.hom) := by
+  rw [hopfSpec_obj_X_hom]
+  rw [MorphismProperty.cancel_left_of_respectsIso
+    (P := @IsFinite) (eqToHom (hopfSpec_obj_X_left k H))]
+  rw [IsFinite.SpecMap_iff]
+  -- `SpecMap_iff` leaves the algebra map behind the `CommRingCat.ofHom` projection.
+  change Module.Finite k H ↔ (algebraMap k H).Finite
+  exact RingHom.finite_algebraMap.symm
+
+/-- The object property selecting finite commutative affine group schemes over a field. -/
+def finiteCommAffineGroupSchemeProperty (k : Type u) [Field k] :
+    ObjectProperty (AffineGroupSchemeCat (CommRingCat.of k)) :=
+  fun G => IsFinite G.obj.X.hom ∧ IsCommMonObj G.obj.X
+
+/-- Membership in the finite-commutative affine-group-scheme property. -/
+@[simp]
+theorem finiteCommAffineGroupSchemeProperty_iff
+    (k : Type u) [Field k] (G : AffineGroupSchemeCat (CommRingCat.of k)) :
+    finiteCommAffineGroupSchemeProperty k G ↔
+      IsFinite G.obj.X.hom ∧ IsCommMonObj G.obj.X :=
+  Iff.rfl
+
+private theorem isCommMonObj_of_grp_iso
+    {C : Type u} [Category C] [CartesianMonoidalCategory C] [BraidedCategory C]
+    {G H : Grp C} (e : G ≅ H) (hG : IsCommMonObj G.X) : IsCommMonObj H.X := by
+  let _ := hG
+  constructor
+  apply (cancel_mono e.inv.hom.hom).1
+  simp only [Category.assoc, IsMonHom.mul_hom]
+  rw [← Category.assoc, ← BraidedCategory.braiding_naturality]
+  simp only [Category.assoc, IsCommMonObj.mul_comm]
+
+instance (k : Type u) [Field k] :
+    (finiteCommAffineGroupSchemeProperty k).IsClosedUnderIsomorphisms where
+  of_iso e hG := by
+    constructor
+    · exact (MorphismProperty.over_iso_iff (@IsFinite)
+        ((Grp.forget _).mapIso
+          ((affineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso e))).mp hG.1
+    · exact isCommMonObj_of_grp_iso
+        ((affineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso e) hG.2
+
+/-- Under the affine Hopf/group-scheme anti-equivalence, finite-dimensionality and
+cocommutativity of the coordinate Hopf algebra correspond to finiteness and commutativity of the
+affine group scheme. -/
+theorem finiteCommAffineGroupSchemeProperty_inverseImage
+    (k : Type u) [Field k] :
+    (finiteCommAffineGroupSchemeProperty k).inverseImage
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor =
+      (finiteBicommutativeHopfAlgProperty k).op := by
+  ext H
+  let G : AffineGroupSchemeCat (CommRingCat.of k) :=
+    ⟨(hopfSpec (CommRingCat.of k)).obj H, by
+      apply (affineGroupSchemeProperty_iff _).mpr
+      rw [← essImage_hopfSpec]
+      exact ⟨H, ⟨Iso.refl _⟩⟩⟩
+  let e : (commHopfAlgCatOpEquivAffineGroupSchemeCat
+      (CommRingCat.of k)).functor.obj H ≅ G :=
+    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+        (CommRingCat.of k)).app H)
+  rw [ObjectProperty.prop_inverseImage_iff,
+    finiteCommAffineGroupSchemeProperty_iff, ObjectProperty.op_iff,
+    finiteBicommutativeHopfAlgProperty_iff]
+  constructor
+  · intro h
+    have hG : finiteCommAffineGroupSchemeProperty k G :=
+      (finiteCommAffineGroupSchemeProperty k).prop_of_iso e h
+    exact ⟨(moduleFinite_iff_isFinite_hopfSpec k H.unop).mpr hG.1,
+      (isCocomm_iff_isCommMonObj_hopfSpec k H.unop).mpr hG.2⟩
+  · intro h
+    apply (finiteCommAffineGroupSchemeProperty k).prop_of_iso e.symm
+    exact ⟨(moduleFinite_iff_isFinite_hopfSpec k H.unop).mp h.1,
+      (isCocomm_iff_isCommMonObj_hopfSpec k H.unop).mp h.2⟩
+
+/-- The category of finite commutative affine group schemes over a field. -/
+abbrev FiniteCommAffineGroupSchemeCat (k : Type u) [Field k] :=
+  (finiteCommAffineGroupSchemeProperty k).FullSubcategory
+
+instance {k : Type u} [Field k] (G : FiniteCommAffineGroupSchemeCat.{u} k) :
+    IsFinite G.obj.obj.X.hom :=
+  G.property.1
+
+instance {k : Type u} [Field k] (G : FiniteCommAffineGroupSchemeCat.{u} k) :
+    IsCommMonObj G.obj.obj.X :=
+  G.property.2
+
+/-- `Spec` as an anti-equivalence from finite-dimensional bicommutative Hopf algebras to finite
+commutative affine group schemes over a field. -/
+noncomputable def finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat
+    (k : Type u) [Field k] :
+    (FiniteBicommutativeHopfAlgCat.{u} k)ᵒᵖ ≌
+      FiniteCommAffineGroupSchemeCat k :=
+  (ObjectProperty.opEquivalence (finiteBicommutativeHopfAlgProperty k)).symm.trans <|
+    (commHopfAlgCatOpEquivAffineGroupSchemeCat
+      (CommRingCat.of k)).congrFullSubcategory
+        (finiteCommAffineGroupSchemeProperty_inverseImage k)
+
+/-- The restricted equivalence followed by the finite-commutative inclusion is definitionally
+the unrestricted equivalence applied after forgetting the finiteness and cocommutativity proofs.
+This private isomorphism isolates the implementation of the object-property restrictions. -/
+private noncomputable def
+    finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCatFunctorCompιIso
+    (k : Type u) [Field k] :
+    (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k).functor ⋙
+        (finiteCommAffineGroupSchemeProperty k).ι ≅
+      (forget₂ (FiniteBicommutativeHopfAlgCat.{u} k)
+          (CommHopfAlgCat.{u} k)).op ⋙
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor :=
+  Iso.refl _
+
+/-- The forward restricted anti-equivalence, followed by the inclusions into affine group schemes
+and all group schemes, is `hopfSpec` applied after forgetting the finiteness and cocommutativity
+proofs. This is the computation interface for the restricted equivalence. -/
+noncomputable def
+    finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat.functorCompιIso
+    (k : Type u) [Field k] :
+    (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k).functor ⋙
+          (finiteCommAffineGroupSchemeProperty k).ι ⋙
+        (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
+      (forget₂ (FiniteBicommutativeHopfAlgCat.{u} k)
+          (CommHopfAlgCat.{u} k)).op ⋙ hopfSpec (CommRingCat.of k) :=
+  Functor.isoWhiskerRight
+      (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCatFunctorCompιIso k)
+      (affineGroupSchemeProperty (CommRingCat.of k)).ι ≪≫
+    Functor.associator _ _ _ ≪≫
+    Functor.isoWhiskerLeft
+      (forget₂ (FiniteBicommutativeHopfAlgCat.{u} k)
+        (CommHopfAlgCat.{u} k)).op
+      (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+        (CommRingCat.of k))
+
+/-- **Cartier duality for finite commutative affine group schemes over a field.** On coordinate
+Hopf algebras this is finite linear dualization. -/
+noncomputable def finiteCommAffineGroupSchemeCartierDuality
+    (k : Type u) [Field k] :
+    (FiniteCommAffineGroupSchemeCat k)ᵒᵖ ≌
+      FiniteCommAffineGroupSchemeCat k :=
+  ((finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k).rightOp).symm.trans <|
+    (FiniteBicommutativeHopfAlgCat.cartierDuality (k := k)).symm |>.trans
+      (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k)
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean
@@ -4,10 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.AlgebraicGeometry.Morphisms.Finite
 public import Mathlib.CategoryTheory.ObjectProperty.Opposite
 public import TauCeti.Algebra.HopfAlgebra.FiniteDual.Equivalence
-public import TauCeti.Algebra.Coalgebra.Convolution
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
 
@@ -22,13 +20,15 @@ Hopf algebra is cocommutative.
 ## Main declarations
 
 * `TauCeti.finiteCommAffineGroupSchemeProperty`: the object property selecting finite
-  commutative affine group schemes over a field.
+  commutative affine group schemes over a base ring.
 * `TauCeti.finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat`: the restricted
   Hopf--`Spec` anti-equivalence.
 * `TauCeti.finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat.functorCompιIso`:
   after both inclusions, the restricted equivalence is Mathlib's `hopfSpec`.
-* `TauCeti.finiteCommAffineGroupSchemeCartierDuality`: Cartier duality transported to finite
-  commutative affine group schemes.
+* `TauCeti.FiniteCommAffineGroupSchemeCat.cartierDuality`: Cartier duality transported to finite
+  commutative affine group schemes over a field.
+* `TauCeti.FiniteCommAffineGroupSchemeCat.cartierDuality_functor`: its computation as transported
+  finite dualization.
 
 ## References
 
@@ -42,7 +42,7 @@ separate step.
 
 public section
 
-open CategoryTheory AlgebraicGeometry Opposite WithConv
+open CategoryTheory AlgebraicGeometry Opposite
 open scoped CategoryTheory.MonObj
 
 namespace TauCeti
@@ -62,82 +62,16 @@ private instance finite_respectsIso :
         let _ := hf
         infer_instance }
 
-/-- A Hopf spectrum is a commutative group object exactly when its coordinate Hopf algebra is
-cocommutative. -/
-theorem isCocomm_iff_isCommMonObj_hopfSpec
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
-    Coalgebra.IsCocomm k H ↔
-      IsCommMonObj
-        (((hopfSpec (CommRingCat.of k)).obj (op H)).X) := by
-  constructor
-  · intro h
-    let _ := h
-    rw [hopfSpec_obj_eq_asOver]
-    infer_instance
-  · intro h
-    rw [hopfSpec_obj_eq_asOver] at h
-    let _ := h
-    constructor
-    let leftPoint : WithConv (H →ₐ[k] TensorProduct k H H) :=
-      toConv (Bialgebra.TensorProduct.includeLeft
-        (R := k) (H₁ := H) (H₂ := H)).toAlgHom
-    let rightPoint : WithConv (H →ₐ[k] TensorProduct k H H) :=
-      toConv (Bialgebra.TensorProduct.includeRight
-        (R := k) (H₁ := H) (H₂ := H)).toAlgHom
-    have hcomm : leftPoint * rightPoint = rightPoint * leftPoint := by
-      apply (AlgebraicGeometry.Spec.mapMulEquiv
-        (R := k) (S := H) (T := TensorProduct k H H)).injective
-      simpa only [map_mul] using mul_comm
-        ((AlgebraicGeometry.Spec.mapMulEquiv
-          (R := k) (S := H) (T := TensorProduct k H H)) leftPoint)
-        ((AlgebraicGeometry.Spec.mapMulEquiv
-          (R := k) (S := H) (T := TensorProduct k H H)) rightPoint)
-    have hswap :
-        toConv ((Algebra.TensorProduct.comm k H H).toAlgHom.comp
-          (Bialgebra.comulAlgHom k H)) = rightPoint * leftPoint := by
-      rw [Bialgebra.toConv_comp_comulAlgHom]
-      simp only [leftPoint, rightPoint,
-        Bialgebra.TensorProduct.includeLeft_toAlgHom,
-        Bialgebra.TensorProduct.includeRight_toAlgHom,
-        Algebra.TensorProduct.comm_comp_includeLeft,
-        Algebra.TensorProduct.comm_comp_includeRight]
-    have hcomul :
-        toConv ((Algebra.TensorProduct.comm k H H).toAlgHom.comp
-          (Bialgebra.comulAlgHom k H)) =
-            toConv (Bialgebra.comulAlgHom k H) := by
-      rw [hswap, ← hcomm]
-      exact Bialgebra.comulPoint_eq_include_mul.symm
-    have hlinear := congrArg
-      (fun f : WithConv (H →ₐ[k] TensorProduct k H H) => f.ofConv.toLinearMap) hcomul
-    simp only [AlgHom.comp_toLinearMap, Bialgebra.toLinearMap_comulAlgHom] at hlinear
-    apply LinearMap.ext
-    intro x
-    exact LinearMap.congr_fun hlinear x
-
-/-- A Hopf spectrum is finite over its base exactly when its coordinate algebra is
-finite-dimensional. -/
-theorem moduleFinite_iff_isFinite_hopfSpec
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
-    Module.Finite k H ↔
-      IsFinite (((hopfSpec (CommRingCat.of k)).obj (op H)).X.hom) := by
-  rw [hopfSpec_obj_X_hom]
-  rw [MorphismProperty.cancel_left_of_respectsIso
-    (P := @IsFinite) (eqToHom (hopfSpec_obj_X_left k H))]
-  rw [IsFinite.SpecMap_iff]
-  -- `SpecMap_iff` leaves the algebra map behind the `CommRingCat.ofHom` projection.
-  change Module.Finite k H ↔ (algebraMap k H).Finite
-  exact RingHom.finite_algebraMap.symm
-
-/-- The object property selecting finite commutative affine group schemes over a field. -/
-def finiteCommAffineGroupSchemeProperty (k : Type u) [Field k] :
-    ObjectProperty (AffineGroupSchemeCat (CommRingCat.of k)) :=
+/-- The object property selecting finite commutative affine group schemes over a base ring. -/
+def finiteCommAffineGroupSchemeProperty (S : CommRingCat.{u}) :
+    ObjectProperty (AffineGroupSchemeCat S) :=
   fun G => IsFinite G.obj.X.hom ∧ IsCommMonObj G.obj.X
 
 /-- Membership in the finite-commutative affine-group-scheme property. -/
 @[simp]
 theorem finiteCommAffineGroupSchemeProperty_iff
-    (k : Type u) [Field k] (G : AffineGroupSchemeCat (CommRingCat.of k)) :
-    finiteCommAffineGroupSchemeProperty k G ↔
+    (S : CommRingCat.{u}) (G : AffineGroupSchemeCat S) :
+    finiteCommAffineGroupSchemeProperty S G ↔
       IsFinite G.obj.X.hom ∧ IsCommMonObj G.obj.X :=
   Iff.rfl
 
@@ -151,22 +85,22 @@ private theorem isCommMonObj_of_grp_iso
   rw [← Category.assoc, ← BraidedCategory.braiding_naturality]
   simp only [Category.assoc, IsCommMonObj.mul_comm]
 
-instance (k : Type u) [Field k] :
-    (finiteCommAffineGroupSchemeProperty k).IsClosedUnderIsomorphisms where
+instance (S : CommRingCat.{u}) :
+    (finiteCommAffineGroupSchemeProperty S).IsClosedUnderIsomorphisms where
   of_iso e hG := by
     constructor
     · exact (MorphismProperty.over_iso_iff (@IsFinite)
         ((Grp.forget _).mapIso
-          ((affineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso e))).mp hG.1
+          ((affineGroupSchemeProperty S).ι.mapIso e))).mp hG.1
     · exact isCommMonObj_of_grp_iso
-        ((affineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso e) hG.2
+        ((affineGroupSchemeProperty S).ι.mapIso e) hG.2
 
 /-- Under the affine Hopf/group-scheme anti-equivalence, finite-dimensionality and
 cocommutativity of the coordinate Hopf algebra correspond to finiteness and commutativity of the
 affine group scheme. -/
 theorem finiteCommAffineGroupSchemeProperty_inverseImage
     (k : Type u) [Field k] :
-    (finiteCommAffineGroupSchemeProperty k).inverseImage
+    (finiteCommAffineGroupSchemeProperty (CommRingCat.of k)).inverseImage
         (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor =
       (finiteBicommutativeHopfAlgProperty k).op := by
   ext H
@@ -185,24 +119,24 @@ theorem finiteCommAffineGroupSchemeProperty_inverseImage
     finiteBicommutativeHopfAlgProperty_iff]
   constructor
   · intro h
-    have hG : finiteCommAffineGroupSchemeProperty k G :=
-      (finiteCommAffineGroupSchemeProperty k).prop_of_iso e h
+    have hG : finiteCommAffineGroupSchemeProperty (CommRingCat.of k) G :=
+      (finiteCommAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso e h
     exact ⟨(moduleFinite_iff_isFinite_hopfSpec k H.unop).mpr hG.1,
       (isCocomm_iff_isCommMonObj_hopfSpec k H.unop).mpr hG.2⟩
   · intro h
-    apply (finiteCommAffineGroupSchemeProperty k).prop_of_iso e.symm
+    apply (finiteCommAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso e.symm
     exact ⟨(moduleFinite_iff_isFinite_hopfSpec k H.unop).mp h.1,
       (isCocomm_iff_isCommMonObj_hopfSpec k H.unop).mp h.2⟩
 
-/-- The category of finite commutative affine group schemes over a field. -/
-abbrev FiniteCommAffineGroupSchemeCat (k : Type u) [Field k] :=
-  (finiteCommAffineGroupSchemeProperty k).FullSubcategory
+/-- The category of finite commutative affine group schemes over a base ring. -/
+abbrev FiniteCommAffineGroupSchemeCat (S : CommRingCat.{u}) :=
+  (finiteCommAffineGroupSchemeProperty S).FullSubcategory
 
-instance {k : Type u} [Field k] (G : FiniteCommAffineGroupSchemeCat.{u} k) :
+instance {S : CommRingCat.{u}} (G : FiniteCommAffineGroupSchemeCat S) :
     IsFinite G.obj.obj.X.hom :=
   G.property.1
 
-instance {k : Type u} [Field k] (G : FiniteCommAffineGroupSchemeCat.{u} k) :
+instance {S : CommRingCat.{u}} (G : FiniteCommAffineGroupSchemeCat S) :
     IsCommMonObj G.obj.obj.X :=
   G.property.2
 
@@ -211,7 +145,7 @@ commutative affine group schemes over a field. -/
 noncomputable def finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat
     (k : Type u) [Field k] :
     (FiniteBicommutativeHopfAlgCat.{u} k)ᵒᵖ ≌
-      FiniteCommAffineGroupSchemeCat k :=
+      FiniteCommAffineGroupSchemeCat (CommRingCat.of k) :=
   (ObjectProperty.opEquivalence (finiteBicommutativeHopfAlgProperty k)).symm.trans <|
     (commHopfAlgCatOpEquivAffineGroupSchemeCat
       (CommRingCat.of k)).congrFullSubcategory
@@ -224,7 +158,7 @@ private noncomputable def
     finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCatFunctorCompιIso
     (k : Type u) [Field k] :
     (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k).functor ⋙
-        (finiteCommAffineGroupSchemeProperty k).ι ≅
+        (finiteCommAffineGroupSchemeProperty (CommRingCat.of k)).ι ≅
       (forget₂ (FiniteBicommutativeHopfAlgCat.{u} k)
           (CommHopfAlgCat.{u} k)).op ⋙
         (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor :=
@@ -237,7 +171,7 @@ noncomputable def
     finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat.functorCompιIso
     (k : Type u) [Field k] :
     (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k).functor ⋙
-          (finiteCommAffineGroupSchemeProperty k).ι ⋙
+          (finiteCommAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
         (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
       (forget₂ (FiniteBicommutativeHopfAlgCat.{u} k)
           (CommHopfAlgCat.{u} k)).op ⋙ hopfSpec (CommRingCat.of k) :=
@@ -251,14 +185,27 @@ noncomputable def
       (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
         (CommRingCat.of k))
 
-/-- **Cartier duality for finite commutative affine group schemes over a field.** On coordinate
-Hopf algebras this is finite linear dualization. -/
-noncomputable def finiteCommAffineGroupSchemeCartierDuality
+namespace FiniteCommAffineGroupSchemeCat
+
+/-- **Cartier duality for finite commutative affine group schemes over a field.** -/
+noncomputable def cartierDuality
     (k : Type u) [Field k] :
-    (FiniteCommAffineGroupSchemeCat k)ᵒᵖ ≌
-      FiniteCommAffineGroupSchemeCat k :=
+    (FiniteCommAffineGroupSchemeCat (CommRingCat.of k))ᵒᵖ ≌
+      FiniteCommAffineGroupSchemeCat (CommRingCat.of k) :=
   ((finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k).rightOp).symm.trans <|
-    (FiniteBicommutativeHopfAlgCat.cartierDuality (k := k)).symm |>.trans
+    ((FiniteBicommutativeHopfAlgCat.dualFunctor (k := k)).rightOp).asEquivalence |>.trans
       (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k)
+
+/-- The forward functor of scheme-level Cartier duality is finite dualization transported through
+the restricted Hopf--`Spec` equivalence. -/
+@[simp]
+theorem cartierDuality_functor (k : Type u) [Field k] :
+    (cartierDuality k).functor =
+      (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k).rightOp.inverse ⋙
+        (FiniteBicommutativeHopfAlgCat.dualFunctor (k := k)).rightOp ⋙
+        (finiteBicommutativeHopfAlgCatOpEquivFiniteCommAffineGroupSchemeCat k).functor :=
+  by simp [cartierDuality]
+
+end FiniteCommAffineGroupSchemeCat
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.Group.Affine
+public import Mathlib.AlgebraicGeometry.Morphisms.Finite
+public import TauCeti.Algebra.Coalgebra.Convolution
 
 /-!
 # Projections of Hopf spectra
@@ -28,11 +30,16 @@ same-universe restriction is inherited from Mathlib's current `hopfSpec` constru
 * `TauCeti.algSpec_map_left_ofAlgHom`: the underlying spectrum map of an algebra morphism.
 * `TauCeti.hopfSpec_obj_one_left`, `TauCeti.hopfSpec_obj_mul_left`, and
   `TauCeti.hopfSpec_obj_inv_left`: its three group operations.
+* `TauCeti.isCocomm_iff_isCommMonObj_hopfSpec`: cocommutativity corresponds to a commutative
+  group object.
+* `TauCeti.moduleFinite_iff_isFinite_hopfSpec`: module-finiteness corresponds to a finite
+  structural morphism.
 -/
 
 public section
 
-open CategoryTheory
+open CategoryTheory Opposite WithConv
+open scoped CategoryTheory.MonObj
 
 namespace TauCeti
 
@@ -41,6 +48,19 @@ open AlgebraicGeometry MonObj MonoidalCategory
 universe u
 
 variable (R : Type u) [CommRing R]
+
+private instance finite_respectsIso :
+    MorphismProperty.RespectsIso (@IsFinite) where
+  toRespectsLeft :=
+    { precomp := fun i hi f hf => by
+        let _ := hi
+        let _ := hf
+        infer_instance }
+  toRespectsRight :=
+    { postcomp := fun i hi f hf => by
+        let _ := hi
+        let _ := hf
+        infer_instance }
 
 /-- The scheme underlying the Hopf spectrum of `H` is its ordinary spectrum. -/
 @[simp↓]
@@ -162,5 +182,71 @@ lemma hopfSpec_obj_inv_left (H : CommHopfAlgCat.{u} R) :
   rw [hopfSpec_obj_eq_asOver]
   exact heq_of_eq (algSpec_map_left_ofAlgHom R
     (HopfAlgebra.antipodeAlgHom R H))
+
+/-- A Hopf spectrum is a commutative group object exactly when its coordinate Hopf algebra is
+cocommutative. -/
+theorem isCocomm_iff_isCommMonObj_hopfSpec
+    (R : Type u) [CommRing R] (H : CommHopfAlgCat.{u} R) :
+    Coalgebra.IsCocomm R H ↔
+      IsCommMonObj
+        (((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (op H)).X) := by
+  constructor
+  · intro h
+    let _ := h
+    rw [hopfSpec_obj_eq_asOver]
+    infer_instance
+  · intro h
+    rw [hopfSpec_obj_eq_asOver] at h
+    let _ := h
+    constructor
+    let leftPoint : WithConv (H →ₐ[R] TensorProduct R H H) :=
+      toConv (Bialgebra.TensorProduct.includeLeft
+        (R := R) (H₁ := H) (H₂ := H)).toAlgHom
+    let rightPoint : WithConv (H →ₐ[R] TensorProduct R H H) :=
+      toConv (Bialgebra.TensorProduct.includeRight
+        (R := R) (H₁ := H) (H₂ := H)).toAlgHom
+    have hcomm : leftPoint * rightPoint = rightPoint * leftPoint := by
+      apply (AlgebraicGeometry.Spec.mapMulEquiv
+        (R := R) (S := H) (T := TensorProduct R H H)).injective
+      simpa only [map_mul] using mul_comm
+        ((AlgebraicGeometry.Spec.mapMulEquiv
+          (R := R) (S := H) (T := TensorProduct R H H)) leftPoint)
+        ((AlgebraicGeometry.Spec.mapMulEquiv
+          (R := R) (S := H) (T := TensorProduct R H H)) rightPoint)
+    have hswap :
+        toConv ((Algebra.TensorProduct.comm R H H).toAlgHom.comp
+          (Bialgebra.comulAlgHom R H)) = rightPoint * leftPoint := by
+      rw [Bialgebra.toConv_comp_comulAlgHom]
+      simp only [leftPoint, rightPoint,
+        Bialgebra.TensorProduct.includeLeft_toAlgHom,
+        Bialgebra.TensorProduct.includeRight_toAlgHom,
+        Algebra.TensorProduct.comm_comp_includeLeft,
+        Algebra.TensorProduct.comm_comp_includeRight]
+    have hcomul :
+        toConv ((Algebra.TensorProduct.comm R H H).toAlgHom.comp
+          (Bialgebra.comulAlgHom R H)) =
+            toConv (Bialgebra.comulAlgHom R H) := by
+      rw [hswap, ← hcomm]
+      exact Bialgebra.comulPoint_eq_include_mul.symm
+    have hlinear := congrArg
+      (fun f : WithConv (H →ₐ[R] TensorProduct R H H) => f.ofConv.toLinearMap) hcomul
+    simp only [AlgHom.comp_toLinearMap, Bialgebra.toLinearMap_comulAlgHom] at hlinear
+    apply LinearMap.ext
+    intro x
+    exact LinearMap.congr_fun hlinear x
+
+/-- A Hopf spectrum is finite over its base exactly when its coordinate algebra is
+module-finite. -/
+theorem moduleFinite_iff_isFinite_hopfSpec
+    (R : Type u) [CommRing R] (H : CommHopfAlgCat.{u} R) :
+    Module.Finite R H ↔
+      IsFinite (((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (op H)).X.hom) := by
+  rw [hopfSpec_obj_X_hom]
+  rw [MorphismProperty.cancel_left_of_respectsIso
+    (P := @IsFinite) (eqToHom (hopfSpec_obj_X_left R H))]
+  rw [IsFinite.SpecMap_iff]
+  -- `SpecMap_iff` leaves the algebra map behind the `CommRingCat.ofHom` projection.
+  change Module.Finite R H ↔ (algebraMap R H).Finite
+  exact RingHom.finite_algebraMap.symm
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
@@ -49,20 +49,6 @@ universe u
 
 variable (R : Type u) [CommRing R]
 
-/-- Finite morphisms of schemes are invariant under isomorphisms. -/
-instance finite_respectsIso :
-    MorphismProperty.RespectsIso (@IsFinite) where
-  toRespectsLeft :=
-    { precomp := fun i hi f hf => by
-        let _ := hi
-        let _ := hf
-        infer_instance }
-  toRespectsRight :=
-    { postcomp := fun i hi f hf => by
-        let _ := hi
-        let _ := hf
-        infer_instance }
-
 /-- The scheme underlying the Hopf spectrum of `H` is its ordinary spectrum. -/
 @[simp↓]
 lemma hopfSpec_obj_X_left (H : CommHopfAlgCat.{u} R) :
@@ -242,6 +228,9 @@ theorem moduleFinite_iff_isFinite_hopfSpec
     (R : Type u) [CommRing R] (H : CommHopfAlgCat.{u} R) :
     Module.Finite R H ↔
       IsFinite (((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (op H)).X.hom) := by
+  let _ : MorphismProperty.RespectsIso (@IsFinite : MorphismProperty Scheme) :=
+    MorphismProperty.respectsIso_of_isStableUnderComposition
+      (fun _ _ f (_ : IsIso f) ↦ inferInstance)
   rw [hopfSpec_obj_X_hom]
   rw [MorphismProperty.cancel_left_of_respectsIso
     (P := @IsFinite) (eqToHom (hopfSpec_obj_X_left R H))]

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
@@ -49,7 +49,8 @@ universe u
 
 variable (R : Type u) [CommRing R]
 
-private instance finite_respectsIso :
+/-- Finite morphisms of schemes are invariant under isomorphisms. -/
+instance finite_respectsIso :
     MorphismProperty.RespectsIso (@IsFinite) where
   toRespectsLeft :=
     { precomp := fun i hi f hf => by


### PR DESCRIPTION
This PR transports finite-dimensional Cartier duality through the affine Hopf/`Spec` anti-equivalence to finite commutative affine group schemes over a field. It proves both predicate comparisons needed for the restriction: finite-dimensional coordinate algebras correspond to finite structural morphisms, while cocommutative coordinate Hopf algebras correspond exactly to commutative group objects. It then packages restricted `Spec` and Cartier-duality equivalences and exposes the restricted `Spec` computation isomorphism.

The exact ReductiveGroups target is Layer 4, “Cartier duality”: “Cartier duality proper is the duality of finite locally free commutative group schemes.” The milestone served is the field-level scheme transport, directly consuming the finite-dimensional Hopf-algebra Cartier duality added in #3290. This is the most effective next step because the algebraic core is now present and transport through `Spec` is the next explicit dependency on the milestone's critical path. After this PR, the milestone still needs the extension from fields and finite-dimensional algebras to finite locally free Hopf algebras and group schemes over a general base.

The proof reuses Mathlib's `AlgebraicGeometry.Spec.mapMulEquiv`, `IsFinite.SpecMap_iff`, and object-property restriction machinery, together with Tau Ceti's convolution-dual equivalence; no external infrastructure is vendored. The mathematical formulation follows Waterhouse, Chapter 2, and Milne, §12.e, as recorded in the module documentation.

The new module is `TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean` (264 lines).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-commutative-group-scheme-cartier-duality"}-->

🤖 Prepared with Codex
