### PR TITLE
feat: prove the additive group unipotent

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.AlgebraicGeometry.AffineSpace
 public import Mathlib.LinearAlgebra.SymmetricAlgebra.Basis
+public import Mathlib.RingTheory.Smooth.Basic
 public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup.Basic
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SchemePoints
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
@@ -92,6 +93,7 @@ section CoordinateAlgebra
 
 variable (R : Type u) [CommSemiring R]
 
+/-- The singleton basis used to present the rank-one symmetric algebra as a polynomial algebra. -/
 private noncomputable def coordinateBasis : Basis (CoordinateIndex.{u}) R R :=
   Basis.singleton _ _
 
@@ -117,6 +119,19 @@ variable (R : Type u) [CommRing R]
 `SymmetricAlgebra R R`, with primitive generator `SymmetricAlgebra.ι R R 1`. -/
 noncomputable abbrev coordinateHopfAlgebra : CommHopfAlgCat.{u} R :=
   CommHopfAlgCat.of R (SymmetricAlgebra R R)
+
+/-- The coordinate algebra of `𝔾ₐ` is of finite type: it is the polynomial algebra on the single
+generator `x`. -/
+instance instFiniteTypeSymmetricAlgebra : Algebra.FiniteType R (SymmetricAlgebra R R) :=
+  Algebra.FiniteType.equiv (inferInstanceAs (Algebra.FiniteType R (MvPolynomial Unit R)))
+    (SymmetricAlgebra.equivMvPolynomial (Basis.singleton Unit R)).symm
+
+/-- The coordinate algebra of `𝔾ₐ` is smooth: it is the polynomial algebra on the single
+generator `x`. -/
+instance instSmoothSymmetricAlgebra : Algebra.Smooth R (SymmetricAlgebra R R) :=
+  letI : Algebra.Smooth R (MvPolynomial Unit R) := ⟨inferInstance, inferInstance⟩
+  Algebra.Smooth.of_equiv
+    (SymmetricAlgebra.equivMvPolynomial (Basis.singleton Unit R)).symm
 
 /-- The additive group scheme obtained by applying relative spectrum to the symmetric Hopf
 algebra on one generator.
@@ -206,6 +221,7 @@ lemma groupScheme_inv_left :
   unfold groupScheme
   convert hopfSpec_obj_inv_left R (coordinateHopfAlgebra R) using 1
 
+/-- The underlying scheme isomorphism from the additive group to affine one-space. -/
 private noncomputable def groupSchemeAffineSpaceIsoLeft :
     (groupScheme R).X.left ≅
       𝔸(CoordinateIndex.{u}; Spec (CommRingCat.of R)) :=

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
@@ -113,18 +113,24 @@ lemma coordinateAlgEquiv_ι_one :
 
 end CoordinateAlgebra
 
-variable (R : Type u) [CommRing R]
+section FiniteType
 
-/-- The commutative Hopf algebra representing the one-dimensional additive group. Its carrier is
-`SymmetricAlgebra R R`, with primitive generator `SymmetricAlgebra.ι R R 1`. -/
-noncomputable abbrev coordinateHopfAlgebra : CommHopfAlgCat.{u} R :=
-  CommHopfAlgCat.of R (SymmetricAlgebra R R)
+variable (R : Type u) [CommSemiring R]
 
 /-- The coordinate algebra of `𝔾ₐ` is of finite type: it is the polynomial algebra on the single
 generator `x`. -/
 instance instFiniteTypeSymmetricAlgebra : Algebra.FiniteType R (SymmetricAlgebra R R) :=
   Algebra.FiniteType.equiv (inferInstanceAs (Algebra.FiniteType R (MvPolynomial Unit R)))
     (SymmetricAlgebra.equivMvPolynomial (Basis.singleton Unit R)).symm
+
+end FiniteType
+
+variable (R : Type u) [CommRing R]
+
+/-- The commutative Hopf algebra representing the one-dimensional additive group. Its carrier is
+`SymmetricAlgebra R R`, with primitive generator `SymmetricAlgebra.ι R R 1`. -/
+noncomputable abbrev coordinateHopfAlgebra : CommHopfAlgCat.{u} R :=
+  CommHopfAlgCat.of R (SymmetricAlgebra R R)
 
 /-- The coordinate algebra of `𝔾ₐ` is smooth: it is the polynomial algebra on the single
 generator `x`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
@@ -120,8 +120,9 @@ variable (R : Type u) [CommSemiring R]
 /-- The coordinate algebra of `𝔾ₐ` is of finite type: it is the polynomial algebra on the single
 generator `x`. -/
 instance instFiniteTypeSymmetricAlgebra : Algebra.FiniteType R (SymmetricAlgebra R R) :=
-  Algebra.FiniteType.equiv (inferInstanceAs (Algebra.FiniteType R (MvPolynomial Unit R)))
-    (SymmetricAlgebra.equivMvPolynomial (Basis.singleton Unit R)).symm
+  Algebra.FiniteType.equiv
+    (inferInstanceAs (Algebra.FiniteType R (MvPolynomial (CoordinateIndex.{u}) R)))
+    (coordinateAlgEquiv R).symm
 
 end FiniteType
 
@@ -135,9 +136,9 @@ noncomputable abbrev coordinateHopfAlgebra : CommHopfAlgCat.{u} R :=
 /-- The coordinate algebra of `𝔾ₐ` is smooth: it is the polynomial algebra on the single
 generator `x`. -/
 instance instSmoothSymmetricAlgebra : Algebra.Smooth R (SymmetricAlgebra R R) :=
-  letI : Algebra.Smooth R (MvPolynomial Unit R) := ⟨inferInstance, inferInstance⟩
-  Algebra.Smooth.of_equiv
-    (SymmetricAlgebra.equivMvPolynomial (Basis.singleton Unit R)).symm
+  letI : Algebra.Smooth R (MvPolynomial (CoordinateIndex.{u}) R) :=
+    ⟨inferInstance, inferInstance⟩
+  Algebra.Smooth.of_equiv (coordinateAlgEquiv R).symm
 
 /-- The additive group scheme obtained by applying relative spectrum to the symmetric Hopf
 algebra on one generator.
@@ -278,9 +279,6 @@ instance isAffine_groupScheme : IsAffine (groupScheme R).X.left := by
 /-- The structural morphism of the additive group scheme is locally of finite presentation. -/
 instance locallyOfFinitePresentation_groupScheme :
     LocallyOfFinitePresentation (groupScheme R).X.hom := by
-  let : Algebra.FinitePresentation R (MvPolynomial (CoordinateIndex.{u}) R) := inferInstance
-  let : Algebra.FinitePresentation R (SymmetricAlgebra R R) :=
-    Algebra.FinitePresentation.equiv (coordinateAlgEquiv R).symm
   rw [groupScheme_X_hom]
   let : LocallyOfFinitePresentation (eqToHom (groupScheme_X_left R)) :=
     locallyOfFinitePresentation_of_isOpenImmersion _

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
@@ -100,6 +100,11 @@ private noncomputable def unitFinsuppEquivNat : (Unit →₀ ℕ) ≃ ℕ where
     simp
   right_inv n := by simp
 
+@[simp]
+private theorem unitFinsuppEquivNat_symm_apply (n : ℕ) :
+    (unitFinsuppEquivNat).symm n = Finsupp.single () n :=
+  rfl
+
 /-- **The monomials `xⁿ` in the coordinate `x = ι(1)` form a basis of the coordinate algebra
 `R[x] = SymmetricAlgebra R R` of the additive group.** -/
 noncomputable def monomialBasis : Basis ℕ R (SymmetricAlgebra R R) :=
@@ -109,7 +114,7 @@ noncomputable def monomialBasis : Basis ℕ R (SymmetricAlgebra R R) :=
 theorem monomialBasis_apply (n : ℕ) :
     monomialBasis R n = (ι R R 1 : SymmetricAlgebra R R) ^ n := by
   rw [monomialBasis, Basis.reindex_apply]
-  change (Basis.symmetricAlgebra (Basis.singleton Unit R)) (Finsupp.single () n) = _
+  rw [unitFinsuppEquivNat_symm_apply]
   rw [Basis.symmetricAlgebra, Basis.map_apply]
   simp only [MvPolynomial.coe_basisMonomials, AlgEquiv.toLinearEquiv_apply,
     ← MvPolynomial.X_pow_eq_monomial, map_pow, SymmetricAlgebra.equivMvPolynomial_symm_X,
@@ -130,8 +135,7 @@ theorem coeff_zero_eq_counit :
     coeff R 0 = Coalgebra.counit (R := R) (A := SymmetricAlgebra R R) := by
   refine (monomialBasis R).ext fun n => ?_
   rw [monomialBasis_apply, coeff_pow]
-  rw [show (Coalgebra.counit (R := R) ((ι R R 1 : SymmetricAlgebra R R) ^ n)) =
-      Bialgebra.counitAlgHom R (SymmetricAlgebra R R) ((ι R R 1) ^ n) from rfl, map_pow]
+  rw [← Bialgebra.counitAlgHom_apply, map_pow]
   simp only [Bialgebra.counitAlgHom_apply, SymmetricAlgebra.counit_ι]
   cases n <;> simp
 
@@ -142,8 +146,7 @@ theorem comul_pow (n : ℕ) :
       ∑ k ∈ Finset.range (n + 1), (n.choose k) •
         (((ι R R 1 : SymmetricAlgebra R R) ^ k) ⊗ₜ[R]
           ((ι R R 1 : SymmetricAlgebra R R) ^ (n - k))) := by
-  rw [show (Coalgebra.comul (R := R) ((ι R R 1 : SymmetricAlgebra R R) ^ n)) =
-      Bialgebra.comulAlgHom R (SymmetricAlgebra R R) ((ι R R 1) ^ n) from rfl, map_pow]
+  rw [← Bialgebra.comulAlgHom_apply, map_pow]
   simp only [Bialgebra.comulAlgHom_apply, SymmetricAlgebra.comul_ι]
   rw [add_pow]
   refine Finset.sum_congr rfl fun k _ => ?_
@@ -151,19 +154,19 @@ theorem comul_pow (n : ℕ) :
     Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul, nsmul_eq_mul, mul_comm]
 
 /-- The pairing of two coefficient functionals on a tensor square of the coordinate algebra. -/
-noncomputable def coeffPair (i j : ℕ) :
+private noncomputable def coeffPair (i j : ℕ) :
     SymmetricAlgebra R R ⊗[R] SymmetricAlgebra R R →ₗ[R] R :=
   (TensorProduct.rid R R).toLinearMap ∘ₗ TensorProduct.map (coeff R i) (coeff R j)
 
 @[simp]
-theorem coeffPair_tmul (i j : ℕ) (a b : SymmetricAlgebra R R) :
+private theorem coeffPair_tmul (i j : ℕ) (a b : SymmetricAlgebra R R) :
     coeffPair R i j (a ⊗ₜ[R] b) = coeff R i a * coeff R j b := by
   simp [coeffPair, smul_eq_mul, mul_comm]
 
 /-- **The coefficient functionals are a divided-power system.** Pairing the `i`-th and `j`-th
 coefficients across the comultiplication returns `(i + j choose i)` times the `(i + j)`-th
 coefficient. -/
-theorem coeffPair_comp_comul (i j : ℕ) :
+private theorem coeffPair_comp_comul (i j : ℕ) :
     coeffPair R i j ∘ₗ (Coalgebra.comul (R := R) (A := SymmetricAlgebra R R)) =
       ((i + j).choose i) • coeff R (i + j) := by
   refine (monomialBasis R).ext fun n => ?_
@@ -202,18 +205,18 @@ theorem tensorComponent_tmul (n : ℕ) (v : V) (h : SymmetricAlgebra R R) :
   simp [tensorComponent]
 
 /-- The `(i, j)`-th coefficient map of `V ⊗[R] (R[x] ⊗[R] R[x])`. -/
-noncomputable def tensorPairComponent (i j : ℕ) :
+private noncomputable def tensorPairComponent (i j : ℕ) :
     V ⊗[R] (SymmetricAlgebra R R ⊗[R] SymmetricAlgebra R R) →ₗ[R] V :=
   (TensorProduct.rid R V).toLinearMap ∘ₗ (coeffPair R i j).lTensor V
 
 @[simp]
-theorem tensorPairComponent_tmul (i j : ℕ) (v : V)
+private theorem tensorPairComponent_tmul (i j : ℕ) (v : V)
     (h : SymmetricAlgebra R R ⊗[R] SymmetricAlgebra R R) :
     tensorPairComponent R V i j (v ⊗ₜ[R] h) = coeffPair R i j h • v := by
   simp [tensorPairComponent]
 
 /-- Reading off a coefficient of a tensor is compatible with the associator. -/
-theorem tensorComponent_comp_tensorComponent (i j : ℕ) :
+private theorem tensorComponent_comp_tensorComponent (i j : ℕ) :
     tensorComponent R V i ∘ₗ tensorComponent R (V ⊗[R] SymmetricAlgebra R R) j =
       tensorPairComponent R V i j ∘ₗ
         (TensorProduct.assoc R V (SymmetricAlgebra R R) (SymmetricAlgebra R R)).toLinearMap := by
@@ -225,7 +228,7 @@ theorem tensorComponent_comp_tensorComponent (i j : ℕ) :
 
 /-- Pairing the `i`-th and `j`-th coefficients across the comultiplication picks out
 `(i + j choose i)` times the `(i + j)`-th coefficient. -/
-theorem tensorPairComponent_comp_lTensor_comul (i j : ℕ) :
+private theorem tensorPairComponent_comp_lTensor_comul (i j : ℕ) :
     tensorPairComponent R V i j ∘ₗ
         (Coalgebra.comul (R := R) (A := SymmetricAlgebra R R)).lTensor V =
       ((i + j).choose i) • tensorComponent R V (i + j) := by
@@ -245,13 +248,13 @@ variable [Comodule R (SymmetricAlgebra R R) V]
 
 /-- **The `n`-th divided-power component of the coaction** of a comodule over the coordinate
 algebra of `𝔾ₐ`: writing the coaction as `ρ v = ∑ₙ Nₙ v ⊗ xⁿ`, this is `Nₙ`. -/
-@[expose] noncomputable def coactComponent (n : ℕ) : V →ₗ[R] V :=
+noncomputable def coactComponent (n : ℕ) : V →ₗ[R] V :=
   tensorComponent R V n ∘ₗ Comodule.coact (R := R) (C := SymmetricAlgebra R R)
 
 theorem coactComponent_apply (n : ℕ) (v : V) :
     coactComponent R V n v =
       tensorComponent R V n (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v) :=
-  rfl
+  by rw [coactComponent, LinearMap.coe_comp, Function.comp_apply]
 
 /-- The zeroth divided-power component is the identity: this is the counit axiom. -/
 @[simp]
@@ -262,7 +265,7 @@ theorem coactComponent_zero : coactComponent R V 0 = LinearMap.id := by
   simp
 
 /-- Reading off a coefficient of the coaction commutes with the coaction itself. -/
-theorem coact_comp_tensorComponent (n : ℕ) :
+private theorem coact_comp_tensorComponent (n : ℕ) :
     Comodule.coact (R := R) (C := SymmetricAlgebra R R) ∘ₗ tensorComponent R V n =
       tensorComponent R (V ⊗[R] SymmetricAlgebra R R) n ∘ₗ
         (Comodule.coact (R := R) (C := SymmetricAlgebra R R) (M := V)).rTensor
@@ -296,7 +299,8 @@ variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
 
 /-- Reading off the `n`-th coefficient of a tensor is the `n`-th coordinate of its expansion in
 the monomial basis. -/
-theorem equivFinsuppOfBasisRight_monomialBasis_apply (z : V ⊗[R] SymmetricAlgebra R R) (n : ℕ) :
+private theorem equivFinsuppOfBasisRight_monomialBasis_apply
+    (z : V ⊗[R] SymmetricAlgebra R R) (n : ℕ) :
     TensorProduct.equivFinsuppOfBasisRight (monomialBasis R) z n = tensorComponent R V n z := by
   induction z using TensorProduct.induction_on with
   | zero => simp
@@ -326,8 +330,7 @@ theorem coact_eq_sum (v : V) :
         w ⊗ₜ[R] ((ι R R 1 : SymmetricAlgebra R R) ^ i) := by
   conv_lhs => rw [← (TensorProduct.equivFinsuppOfBasisRight
     (monomialBasis R)).symm_apply_apply (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v)]
-  rw [show TensorProduct.equivFinsuppOfBasisRight (monomialBasis R)
-      (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v) = coactDecomposition R V v from rfl,
+  simp only [coactDecomposition, LinearMap.coe_comp, Function.comp_apply,
     TensorProduct.equivFinsuppOfBasisRight_symm_apply]
   exact Finsupp.sum_congr fun i _ => by rw [monomialBasis_apply]
 
@@ -346,6 +349,7 @@ noncomputable def coactFiltration (p : ℕ) : Submodule R V :=
 
 variable {V}
 
+@[simp]
 theorem mem_coactFiltration {p : ℕ} {v : V} :
     v ∈ coactFiltration R V p ↔ ∀ i, p < i → coactComponent R V i v = 0 := by
   simp [coactFiltration]
@@ -476,19 +480,6 @@ end Nilpotent
 section AffineGroup
 
 variable (R : Type u) [CommRing R]
-
-/-- The coordinate algebra of `𝔾ₐ` is of finite type: it is the polynomial algebra on the single
-generator `x`. -/
-instance instFiniteTypeSymmetricAlgebra : Algebra.FiniteType R (SymmetricAlgebra R R) :=
-  Algebra.FiniteType.equiv (inferInstanceAs (Algebra.FiniteType R (MvPolynomial Unit R)))
-    (SymmetricAlgebra.equivMvPolynomial (Basis.singleton Unit R)).symm
-
-/-- The coordinate algebra of `𝔾ₐ` is smooth: it is the polynomial algebra on the single
-generator `x`. -/
-instance instSmoothSymmetricAlgebra : Algebra.Smooth R (SymmetricAlgebra R R) :=
-  letI : Algebra.Smooth R (MvPolynomial Unit R) := ⟨inferInstance, inferInstance⟩
-  Algebra.Smooth.of_equiv
-    (SymmetricAlgebra.equivMvPolynomial (Basis.singleton Unit R)).symm
 
 /-- **Every point of the additive group is unipotent.** A point of `𝔾ₐ` valued in a commutative
 `R`-algebra acts on every finitely generated comodule, over a field on every finite-dimensional

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
@@ -1,0 +1,522 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.SymmetricAlgebra.Basis
+public import Mathlib.LinearAlgebra.TensorProduct.Basis
+public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup.Scheme
+public import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+
+/-!
+# The additive group is unipotent
+
+Let `R` be a commutative ring and let `R[x] = SymmetricAlgebra R R` be the coordinate Hopf
+algebra of the additive group `𝔾ₐ`, with primitive generator `x = ι(1)`. This file proves that
+**every point of `𝔾ₐ` is unipotent**: for every commutative `R`-algebra `A`, every point
+`g : R[x] →ₐ[R] A` acts on the scalar extension of every finitely generated comodule by an
+automorphism whose difference from the identity is nilpotent. Over a field this says that `𝔾ₐ`
+acts unipotently in every finite-dimensional representation, which is the geometric definition of
+a unipotent group; together with the smoothness of `R[x]` it exhibits `𝔾ₐ` as the basic example
+of the Layer 5 predicates of the reductive-groups roadmap.
+
+The proof is the classical divided-power argument. The monomials `xⁿ` form a basis of `R[x]`
+(`monomialBasis`), so the coaction of a comodule `V` can be written `ρ v = ∑ₙ Nₙ v ⊗ xⁿ` for a
+family of endomorphisms `Nₙ` of `V` (`coactComponent`), only finitely many of which are nonzero
+on any given vector. The counit axiom says `N₀ = id`, and coassociativity, combined with the
+binomial expansion `Δ(xⁿ) = ∑ₖ (n choose k) xᵏ ⊗ xⁿ⁻ᵏ` of the primitive generator, says that
+`Nᵢ ∘ Nⱼ = (i + j choose i) Nᵢ₊ⱼ`. A point `g` then acts by `a ⊗ v ↦ ∑ᵢ a (g x)ⁱ ⊗ Nᵢ v`, so its
+difference from the identity involves only the components of positive index. Filtering `V` by the
+submodules `Vₚ` on which every `Nᵢ` with `i > p` vanishes (`coactFiltration`), that difference
+carries `Vₚ` into `Vₚ₋₁` and annihilates `V₀`; since a finitely generated comodule is `V_d` for
+some `d`, the `(d + 1)`-st power of the difference vanishes.
+
+## Main definitions
+
+* `TauCeti.AdditiveGroup.monomialBasis`: the monomials `xⁿ` as a basis of `R[x]`, with
+  `TauCeti.AdditiveGroup.coeff` its coordinate functionals.
+* `TauCeti.AdditiveGroup.coactComponent`: the `n`-th divided-power component `Nₙ` of the coaction
+  of an `R[x]`-comodule, and `TauCeti.AdditiveGroup.coactDecomposition` the family of all of them.
+* `TauCeti.AdditiveGroup.coactFiltration`: the divided-power filtration of an `R[x]`-comodule.
+
+## Main results
+
+* `TauCeti.AdditiveGroup.coactComponent_coactComponent`: the divided-power components compose by
+  the binomial rule `Nᵢ ∘ Nⱼ = (i + j choose i) Nᵢ₊ⱼ`.
+* `TauCeti.AdditiveGroup.exists_coactFiltration_eq_top`: the filtration of a finitely generated
+  comodule is exhausted at a finite stage.
+* `TauCeti.AdditiveGroup.isNilpotent_endOfPoint_sub_one` and
+  `TauCeti.AdditiveGroup.isUnipotentPoint`: **every point of `𝔾ₐ` is unipotent.**
+* `TauCeti.AdditiveGroup.smoothUnipotentCommHopfAlgProperty_coordinateHopfAlgebra`: **`𝔾ₐ` over a
+  field is a smooth unipotent affine group**, together with the geometric-point form
+  `TauCeti.AdditiveGroup.geometricallyUnipotentPointsCommHopfAlgProperty_coordinateHopfAlgebra`.
+
+## Implementation notes
+
+The shape of the argument parallels the weight decomposition of a comodule over a monoid algebra
+in `TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra`, which also expands a coaction along a basis
+of the coalgebra using `TensorProduct.equivFinsuppOfBasisRight`. The two cannot share more than
+that tool: there the basis consists of group-like elements, so the components are orthogonal
+idempotents and the comodule splits, whereas here the generator is primitive, so the components
+compose by the binomial rule and the comodule is only filtered.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2 and I.7.8.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §8.3.
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+
+This supplies the first worked example of Layer 5, "Unipotent groups", of the ReductiveGroups
+roadmap: the smooth unipotence predicates defined in
+`TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic` are shown to be non-vacuous, on the group out of
+which the upper-triangular unipotent groups `Uₙ` and the root subgroups of a reductive group are
+built.
+-/
+
+public section
+
+open Module SymmetricAlgebra
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace AdditiveGroup
+
+universe u v w
+
+section MonomialBasis
+
+variable (R : Type u) [CommRing R]
+
+/-- Exponent vectors on a singleton are natural numbers. -/
+private noncomputable def unitFinsuppEquivNat : (Unit →₀ ℕ) ≃ ℕ where
+  toFun f := f ()
+  invFun n := Finsupp.single () n
+  left_inv f := by
+    refine Finsupp.ext fun u => ?_
+    cases u
+    simp
+  right_inv n := by simp
+
+/-- **The monomials `xⁿ` in the coordinate `x = ι(1)` form a basis of the coordinate algebra
+`R[x] = SymmetricAlgebra R R` of the additive group.** -/
+noncomputable def monomialBasis : Basis ℕ R (SymmetricAlgebra R R) :=
+  (Basis.symmetricAlgebra (Basis.singleton Unit R)).reindex unitFinsuppEquivNat
+
+@[simp]
+theorem monomialBasis_apply (n : ℕ) :
+    monomialBasis R n = (ι R R 1 : SymmetricAlgebra R R) ^ n := by
+  rw [monomialBasis, Basis.reindex_apply]
+  change (Basis.symmetricAlgebra (Basis.singleton Unit R)) (Finsupp.single () n) = _
+  rw [Basis.symmetricAlgebra, Basis.map_apply]
+  simp only [MvPolynomial.coe_basisMonomials, AlgEquiv.toLinearEquiv_apply,
+    ← MvPolynomial.X_pow_eq_monomial, map_pow, SymmetricAlgebra.equivMvPolynomial_symm_X,
+    Basis.singleton_apply]
+
+/-- The `n`-th coefficient functional of the coordinate algebra of `𝔾ₐ`: the coefficient of the
+monomial `xⁿ`. -/
+noncomputable def coeff (n : ℕ) : SymmetricAlgebra R R →ₗ[R] R :=
+  (monomialBasis R).coord n
+
+@[simp]
+theorem coeff_pow (m n : ℕ) :
+    coeff R n ((ι R R 1 : SymmetricAlgebra R R) ^ m) = if m = n then 1 else 0 := by
+  rw [coeff, ← monomialBasis_apply R m, Basis.coord_apply, Basis.repr_self_apply]
+
+/-- The coefficient of `x⁰` is the counit. -/
+theorem coeff_zero_eq_counit :
+    coeff R 0 = Coalgebra.counit (R := R) (A := SymmetricAlgebra R R) := by
+  refine (monomialBasis R).ext fun n => ?_
+  rw [monomialBasis_apply, coeff_pow]
+  rw [show (Coalgebra.counit (R := R) ((ι R R 1 : SymmetricAlgebra R R) ^ n)) =
+      Bialgebra.counitAlgHom R (SymmetricAlgebra R R) ((ι R R 1) ^ n) from rfl, map_pow]
+  simp only [Bialgebra.counitAlgHom_apply, SymmetricAlgebra.counit_ι]
+  cases n <;> simp
+
+/-- **The binomial expansion of the comultiplication on monomials.** The coordinate `x` is
+primitive, so `Δ(xⁿ) = ∑ₖ (n choose k) xᵏ ⊗ xⁿ⁻ᵏ`. -/
+theorem comul_pow (n : ℕ) :
+    Coalgebra.comul (R := R) ((ι R R 1 : SymmetricAlgebra R R) ^ n) =
+      ∑ k ∈ Finset.range (n + 1), (n.choose k) •
+        (((ι R R 1 : SymmetricAlgebra R R) ^ k) ⊗ₜ[R]
+          ((ι R R 1 : SymmetricAlgebra R R) ^ (n - k))) := by
+  rw [show (Coalgebra.comul (R := R) ((ι R R 1 : SymmetricAlgebra R R) ^ n)) =
+      Bialgebra.comulAlgHom R (SymmetricAlgebra R R) ((ι R R 1) ^ n) from rfl, map_pow]
+  simp only [Bialgebra.comulAlgHom_apply, SymmetricAlgebra.comul_ι]
+  rw [add_pow]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  rw [Algebra.TensorProduct.tmul_pow, Algebra.TensorProduct.tmul_pow, one_pow, one_pow,
+    Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul, nsmul_eq_mul, mul_comm]
+
+/-- The pairing of two coefficient functionals on a tensor square of the coordinate algebra. -/
+noncomputable def coeffPair (i j : ℕ) :
+    SymmetricAlgebra R R ⊗[R] SymmetricAlgebra R R →ₗ[R] R :=
+  (TensorProduct.rid R R).toLinearMap ∘ₗ TensorProduct.map (coeff R i) (coeff R j)
+
+@[simp]
+theorem coeffPair_tmul (i j : ℕ) (a b : SymmetricAlgebra R R) :
+    coeffPair R i j (a ⊗ₜ[R] b) = coeff R i a * coeff R j b := by
+  simp [coeffPair, smul_eq_mul, mul_comm]
+
+/-- **The coefficient functionals are a divided-power system.** Pairing the `i`-th and `j`-th
+coefficients across the comultiplication returns `(i + j choose i)` times the `(i + j)`-th
+coefficient. -/
+theorem coeffPair_comp_comul (i j : ℕ) :
+    coeffPair R i j ∘ₗ (Coalgebra.comul (R := R) (A := SymmetricAlgebra R R)) =
+      ((i + j).choose i) • coeff R (i + j) := by
+  refine (monomialBasis R).ext fun n => ?_
+  rw [monomialBasis_apply]
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.smul_apply, coeff_pow,
+    comul_pow, map_sum, map_nsmul, coeffPair_tmul, coeff_pow]
+  rcases eq_or_ne n (i + j) with rfl | hn
+  · rw [Finset.sum_eq_single i]
+    · simp
+    · intro k _ hk
+      simp [hk]
+    · intro hi
+      exact absurd (Finset.mem_range.2 (Nat.lt_succ_of_le (Nat.le_add_right i j))) hi
+  · rw [ite_eq_right hn, smul_zero]
+    refine Finset.sum_eq_zero fun k hk => ?_
+    have hkn : k ≤ n := Nat.lt_succ_iff.1 (Finset.mem_range.1 hk)
+    rcases eq_or_ne k i with rfl | hki
+    · have : n - k ≠ j := fun h => hn (by omega)
+      simp [this]
+    · simp [hki]
+
+end MonomialBasis
+
+section Component
+
+variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+
+/-- The `n`-th coefficient map of `V ⊗[R] R[x]`, reading off the coefficient of the monomial
+`xⁿ` in the second factor. -/
+noncomputable def tensorComponent (n : ℕ) : V ⊗[R] SymmetricAlgebra R R →ₗ[R] V :=
+  (TensorProduct.rid R V).toLinearMap ∘ₗ (coeff R n).lTensor V
+
+@[simp]
+theorem tensorComponent_tmul (n : ℕ) (v : V) (h : SymmetricAlgebra R R) :
+    tensorComponent R V n (v ⊗ₜ[R] h) = coeff R n h • v := by
+  simp [tensorComponent]
+
+/-- The `(i, j)`-th coefficient map of `V ⊗[R] (R[x] ⊗[R] R[x])`. -/
+noncomputable def tensorPairComponent (i j : ℕ) :
+    V ⊗[R] (SymmetricAlgebra R R ⊗[R] SymmetricAlgebra R R) →ₗ[R] V :=
+  (TensorProduct.rid R V).toLinearMap ∘ₗ (coeffPair R i j).lTensor V
+
+@[simp]
+theorem tensorPairComponent_tmul (i j : ℕ) (v : V)
+    (h : SymmetricAlgebra R R ⊗[R] SymmetricAlgebra R R) :
+    tensorPairComponent R V i j (v ⊗ₜ[R] h) = coeffPair R i j h • v := by
+  simp [tensorPairComponent]
+
+/-- Reading off a coefficient of a tensor is compatible with the associator. -/
+theorem tensorComponent_comp_tensorComponent (i j : ℕ) :
+    tensorComponent R V i ∘ₗ tensorComponent R (V ⊗[R] SymmetricAlgebra R R) j =
+      tensorPairComponent R V i j ∘ₗ
+        (TensorProduct.assoc R V (SymmetricAlgebra R R) (SymmetricAlgebra R R)).toLinearMap := by
+  refine TensorProduct.ext' fun z h₂ => ?_
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul v h₁ => simp [smul_smul, mul_comm]
+  | add z w hz hw => simp only [TensorProduct.add_tmul, map_add, hz, hw]
+
+/-- Pairing the `i`-th and `j`-th coefficients across the comultiplication picks out
+`(i + j choose i)` times the `(i + j)`-th coefficient. -/
+theorem tensorPairComponent_comp_lTensor_comul (i j : ℕ) :
+    tensorPairComponent R V i j ∘ₗ
+        (Coalgebra.comul (R := R) (A := SymmetricAlgebra R R)).lTensor V =
+      ((i + j).choose i) • tensorComponent R V (i + j) := by
+  refine TensorProduct.ext' fun v h => ?_
+  have hc := congr($(coeffPair_comp_comul R i j) h)
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.smul_apply] at hc
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.lTensor_tmul,
+    tensorPairComponent_tmul, hc, LinearMap.smul_apply, tensorComponent_tmul,
+    ← Nat.cast_smul_eq_nsmul R, smul_smul, smul_eq_mul]
+
+end Component
+
+section CoactComponent
+
+variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+variable [Comodule R (SymmetricAlgebra R R) V]
+
+/-- **The `n`-th divided-power component of the coaction** of a comodule over the coordinate
+algebra of `𝔾ₐ`: writing the coaction as `ρ v = ∑ₙ Nₙ v ⊗ xⁿ`, this is `Nₙ`. -/
+@[expose] noncomputable def coactComponent (n : ℕ) : V →ₗ[R] V :=
+  tensorComponent R V n ∘ₗ Comodule.coact (R := R) (C := SymmetricAlgebra R R)
+
+theorem coactComponent_apply (n : ℕ) (v : V) :
+    coactComponent R V n v =
+      tensorComponent R V n (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v) :=
+  rfl
+
+/-- The zeroth divided-power component is the identity: this is the counit axiom. -/
+@[simp]
+theorem coactComponent_zero : coactComponent R V 0 = LinearMap.id := by
+  ext v
+  rw [coactComponent_apply, tensorComponent, LinearMap.coe_comp, Function.comp_apply,
+    coeff_zero_eq_counit, Comodule.lTensor_counit_coact]
+  simp
+
+/-- Reading off a coefficient of the coaction commutes with the coaction itself. -/
+theorem coact_comp_tensorComponent (n : ℕ) :
+    Comodule.coact (R := R) (C := SymmetricAlgebra R R) ∘ₗ tensorComponent R V n =
+      tensorComponent R (V ⊗[R] SymmetricAlgebra R R) n ∘ₗ
+        (Comodule.coact (R := R) (C := SymmetricAlgebra R R) (M := V)).rTensor
+          (SymmetricAlgebra R R) := by
+  refine TensorProduct.ext' fun v h => ?_
+  simp
+
+/-- **The divided-power components compose by the binomial rule** `Nᵢ ∘ Nⱼ = (i + j choose i)
+Nᵢ₊ⱼ`. This is coassociativity of the coaction, read off in the monomial basis. -/
+theorem coactComponent_coactComponent (i j : ℕ) (v : V) :
+    coactComponent R V i (coactComponent R V j v) =
+      ((i + j).choose i) • coactComponent R V (i + j) v := by
+  have hcoact := congr($(coact_comp_tensorComponent R V j)
+    (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v))
+  simp only [LinearMap.coe_comp, Function.comp_apply] at hcoact
+  have hpair := congr($(tensorComponent_comp_tensorComponent R V i j)
+    ((Comodule.coact (R := R) (C := SymmetricAlgebra R R) (M := V)).rTensor (SymmetricAlgebra R R)
+      (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v)))
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe] at hpair
+  have hfinal := congr($(tensorPairComponent_comp_lTensor_comul R V i j)
+    (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v))
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.smul_apply] at hfinal
+  rw [coactComponent_apply, coactComponent_apply, hcoact, hpair,
+    Comodule.coassoc_apply, hfinal, coactComponent_apply]
+
+end CoactComponent
+
+section Decomposition
+
+variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+
+/-- Reading off the `n`-th coefficient of a tensor is the `n`-th coordinate of its expansion in
+the monomial basis. -/
+theorem equivFinsuppOfBasisRight_monomialBasis_apply (z : V ⊗[R] SymmetricAlgebra R R) (n : ℕ) :
+    TensorProduct.equivFinsuppOfBasisRight (monomialBasis R) z n = tensorComponent R V n z := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul v h =>
+    rw [TensorProduct.equivFinsuppOfBasisRight_apply_tmul_apply, tensorComponent_tmul, coeff,
+      Basis.coord_apply]
+  | add z w hz hw => simp only [map_add, Finsupp.add_apply, hz, hw]
+
+variable [Comodule R (SymmetricAlgebra R R) V]
+
+/-- **The divided-power decomposition of the coaction**, as a finitely supported family: writing
+`ρ v = ∑ₙ Nₙ v ⊗ xⁿ`, this collects the vectors `Nₙ v`, only finitely many of which are
+nonzero. -/
+noncomputable def coactDecomposition : V →ₗ[R] (ℕ →₀ V) :=
+  (TensorProduct.equivFinsuppOfBasisRight (monomialBasis R)).toLinearMap ∘ₗ
+    Comodule.coact (R := R) (C := SymmetricAlgebra R R)
+
+@[simp]
+theorem coactDecomposition_apply (v : V) (n : ℕ) :
+    coactDecomposition R V v n = coactComponent R V n v :=
+  equivFinsuppOfBasisRight_monomialBasis_apply R V _ n
+
+/-- The coaction is recovered from its divided-power components: `ρ v = ∑ₙ Nₙ v ⊗ xⁿ`. -/
+theorem coact_eq_sum (v : V) :
+    Comodule.coact (R := R) (C := SymmetricAlgebra R R) v =
+      (coactDecomposition R V v).sum fun i w =>
+        w ⊗ₜ[R] ((ι R R 1 : SymmetricAlgebra R R) ^ i) := by
+  conv_lhs => rw [← (TensorProduct.equivFinsuppOfBasisRight
+    (monomialBasis R)).symm_apply_apply (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v)]
+  rw [show TensorProduct.equivFinsuppOfBasisRight (monomialBasis R)
+      (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v) = coactDecomposition R V v from rfl,
+    TensorProduct.equivFinsuppOfBasisRight_symm_apply]
+  exact Finsupp.sum_congr fun i _ => by rw [monomialBasis_apply]
+
+end Decomposition
+
+section Filtration
+
+variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+variable [Comodule R (SymmetricAlgebra R R) V]
+
+/-- **The divided-power filtration of a `𝔾ₐ`-comodule**: the `p`-th step consists of the vectors
+whose divided-power components above `p` all vanish. Equivalently, it is the preimage under the
+coaction of `V ⊗ (R ⊕ Rx ⊕ ⋯ ⊕ Rxᵖ)`. -/
+noncomputable def coactFiltration (p : ℕ) : Submodule R V :=
+  ⨅ i ∈ Set.Ioi p, LinearMap.ker (coactComponent R V i)
+
+variable {V}
+
+theorem mem_coactFiltration {p : ℕ} {v : V} :
+    v ∈ coactFiltration R V p ↔ ∀ i, p < i → coactComponent R V i v = 0 := by
+  simp [coactFiltration]
+
+variable (V)
+
+/-- The filtration is monotone. -/
+theorem coactFiltration_mono {p q : ℕ} (h : p ≤ q) :
+    coactFiltration R V p ≤ coactFiltration R V q := fun _v hv =>
+  (mem_coactFiltration R).2 fun i hi => (mem_coactFiltration R).1 hv i (lt_of_le_of_lt h hi)
+
+/-- **The divided-power filtration of a finitely generated comodule is exhaustive.** Each vector
+has only finitely many nonzero divided-power components, and finitely many generators bound them
+all at once. -/
+theorem exists_coactFiltration_eq_top [Module.Finite R V] :
+    ∃ d : ℕ, coactFiltration R V d = ⊤ := by
+  obtain ⟨s, hs⟩ := Module.Finite.fg_top (R := R) (M := V)
+  refine ⟨s.sup fun v => (coactDecomposition R V v).support.sup id, ?_⟩
+  rw [eq_top_iff, ← hs, Submodule.span_le]
+  intro v hv
+  rw [SetLike.mem_coe, mem_coactFiltration]
+  intro i hi
+  rw [← coactDecomposition_apply]
+  refine Finsupp.notMem_support_iff.1 fun hmem => absurd (Finset.le_sup (f := id) hmem) ?_
+  exact not_le.2 (lt_of_le_of_lt (Finset.le_sup (f := fun v =>
+    (coactDecomposition R V v).support.sup id) hv) hi)
+
+end Filtration
+
+section Nilpotent
+
+variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+variable [Comodule R (SymmetricAlgebra R R) V]
+variable {A : Type w} [CommRing A] [Algebra R A]
+
+/-- **A point of `𝔾ₐ` acts through the divided-power components of the coaction.** A point with
+parameter `g x` sends `a ⊗ v` to `∑ᵢ a (g x)ⁱ ⊗ Nᵢ v`. -/
+theorem endOfPoint_tmul_eq_sum (g : SymmetricAlgebra R R →ₐ[R] A) (a : A) (v : V) :
+    Comodule.endOfPoint V g (a ⊗ₜ[R] v) =
+      (coactDecomposition R V v).sum fun i w =>
+        (a * g (ι R R 1) ^ i) ⊗ₜ[R] w := by
+  rw [Comodule.endOfPoint_tmul, coact_eq_sum, map_finsuppSum, map_finsuppSum, Finsupp.smul_sum]
+  refine Finsupp.sum_congr fun i _ => ?_
+  rw [LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, map_pow, TensorProduct.comm_tmul,
+    TensorProduct.smul_tmul', smul_eq_mul]
+
+/-- The action of a point, minus the identity, involves only the positive divided-power
+components. -/
+theorem endOfPoint_sub_one_tmul (g : SymmetricAlgebra R R →ₐ[R] A) (a : A) (v : V) :
+    (Comodule.endOfPoint V g - 1) (a ⊗ₜ[R] v) =
+      ∑ i ∈ (coactDecomposition R V v).support.erase 0,
+        (a * g (ι R R 1) ^ i) ⊗ₜ[R] coactComponent R V i v := by
+  have hsum : (coactDecomposition R V v).sum
+      (fun i w => (a * g (ι R R 1) ^ i) ⊗ₜ[R] w) =
+      ∑ i ∈ insert 0 (coactDecomposition R V v).support,
+        (a * g (ι R R 1) ^ i) ⊗ₜ[R] coactDecomposition R V v i :=
+    Finsupp.sum_of_support_subset _ (Finset.subset_insert _ _) _ fun i _ =>
+      TensorProduct.tmul_zero _ _
+  rw [LinearMap.sub_apply, Module.End.one_apply, endOfPoint_tmul_eq_sum, hsum,
+    ← Finset.add_sum_erase _ _ (Finset.mem_insert_self 0 _), Finset.erase_insert_eq_erase]
+  simp only [coactDecomposition_apply, coactComponent_zero, LinearMap.id_coe, id_eq, pow_zero,
+    mul_one, add_sub_cancel_left]
+
+/-- The positive divided-power components lower the filtration by one step. -/
+theorem coactComponent_mem_coactFiltration {p i : ℕ} (hi : 0 < i) {v : V}
+    (hv : v ∈ coactFiltration R V (p + 1)) :
+    coactComponent R V i v ∈ coactFiltration R V p := by
+  rw [mem_coactFiltration]
+  intro j hj
+  rw [coactComponent_coactComponent, (mem_coactFiltration R).1 hv (j + i) (by omega), smul_zero]
+
+/-- A point acts as the identity on the bottom step of the filtration. -/
+theorem endOfPoint_sub_one_tmul_eq_zero (g : SymmetricAlgebra R R →ₐ[R] A) (a : A) {v : V}
+    (hv : v ∈ coactFiltration R V 0) :
+    (Comodule.endOfPoint V g - 1) (a ⊗ₜ[R] v) = 0 := by
+  rw [endOfPoint_sub_one_tmul]
+  refine Finset.sum_eq_zero fun i hi => ?_
+  rw [(mem_coactFiltration R).1 hv i (Nat.pos_of_ne_zero (Finset.ne_of_mem_erase hi)),
+    TensorProduct.tmul_zero]
+
+/-- A point moves the base change of one step of the filtration into the base change of the
+previous step. -/
+theorem endOfPoint_sub_one_tmul_mem (g : SymmetricAlgebra R R →ₐ[R] A) (a : A) {p : ℕ} {v : V}
+    (hv : v ∈ coactFiltration R V (p + 1)) :
+    (Comodule.endOfPoint V g - 1) (a ⊗ₜ[R] v) ∈ (coactFiltration R V p).baseChange A := by
+  rw [endOfPoint_sub_one_tmul]
+  refine Submodule.sum_mem _ fun i hi => ?_
+  exact Submodule.tmul_mem_baseChange_of_mem _
+    (coactComponent_mem_coactFiltration R V (Nat.pos_of_ne_zero (Finset.ne_of_mem_erase hi)) hv)
+
+/-- **The action of a point is unipotent on each step of the filtration**: on the base change of
+the `p`-th step, the `(p + 1)`-st power of the action minus the identity vanishes. -/
+theorem pow_endOfPoint_sub_one_apply_eq_zero (g : SymmetricAlgebra R R →ₐ[R] A) (p : ℕ)
+    {z : A ⊗[R] V} (hz : z ∈ (coactFiltration R V p).baseChange A) :
+    ((Comodule.endOfPoint V g - 1) ^ (p + 1)) z = 0 := by
+  induction p generalizing z with
+  | zero =>
+    have h : (coactFiltration R V 0).baseChange A ≤
+        LinearMap.ker (Comodule.endOfPoint V g - 1) := by
+      rw [Submodule.baseChange_eq_span, Submodule.span_le]
+      rintro _ ⟨v, hv, rfl⟩
+      exact endOfPoint_sub_one_tmul_eq_zero R V g 1 hv
+    rw [pow_one]
+    exact h hz
+  | succ p ih =>
+    have h : (coactFiltration R V (p + 1)).baseChange A ≤
+        Submodule.comap (Comodule.endOfPoint V g - 1)
+          ((coactFiltration R V p).baseChange A) := by
+      rw [Submodule.baseChange_eq_span, Submodule.span_le]
+      rintro _ ⟨v, hv, rfl⟩
+      exact endOfPoint_sub_one_tmul_mem R V g 1 hv
+    rw [pow_succ, Module.End.mul_apply]
+    exact ih (h hz)
+
+/-- **Every point of `𝔾ₐ` acts unipotently on every finitely generated comodule.** -/
+theorem isNilpotent_endOfPoint_sub_one [Module.Finite R V]
+    (g : SymmetricAlgebra R R →ₐ[R] A) :
+    IsNilpotent (Comodule.endOfPoint V g - 1) := by
+  obtain ⟨d, hd⟩ := exists_coactFiltration_eq_top R V
+  refine ⟨d + 1, LinearMap.ext fun z => ?_⟩
+  rw [LinearMap.zero_apply]
+  refine pow_endOfPoint_sub_one_apply_eq_zero R V g d ?_
+  rw [hd, Submodule.baseChange_top]
+  trivial
+
+end Nilpotent
+
+section AffineGroup
+
+variable (R : Type u) [CommRing R]
+
+/-- The coordinate algebra of `𝔾ₐ` is of finite type: it is the polynomial algebra on the single
+generator `x`. -/
+instance instFiniteTypeSymmetricAlgebra : Algebra.FiniteType R (SymmetricAlgebra R R) :=
+  Algebra.FiniteType.equiv (inferInstanceAs (Algebra.FiniteType R (MvPolynomial Unit R)))
+    (SymmetricAlgebra.equivMvPolynomial (Basis.singleton Unit R)).symm
+
+/-- The coordinate algebra of `𝔾ₐ` is smooth: it is the polynomial algebra on the single
+generator `x`. -/
+instance instSmoothSymmetricAlgebra : Algebra.Smooth R (SymmetricAlgebra R R) :=
+  letI : Algebra.Smooth R (MvPolynomial Unit R) := ⟨inferInstance, inferInstance⟩
+  Algebra.Smooth.of_equiv
+    (SymmetricAlgebra.equivMvPolynomial (Basis.singleton Unit R)).symm
+
+/-- **Every point of the additive group is unipotent.** A point of `𝔾ₐ` valued in a commutative
+`R`-algebra acts on every finitely generated comodule, over a field on every finite-dimensional
+representation, by a unipotent automorphism. -/
+theorem isUnipotentPoint {A : Type w} [CommRing A] [Algebra R A]
+    (g : WithConv (SymmetricAlgebra R R →ₐ[R] A)) :
+    HopfAlgebra.IsUnipotentPoint g := by
+  rw [HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one]
+  exact fun M => isNilpotent_endOfPoint_sub_one R M g.ofConv
+
+/-- **The additive group has only unipotent geometric points.** -/
+theorem geometricallyUnipotentPointsCommHopfAlgProperty_coordinateHopfAlgebra
+    (k : Type u) [Field k] :
+    geometricallyUnipotentPointsCommHopfAlgProperty k (coordinateHopfAlgebra k) := by
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff]
+  exact fun g => isUnipotentPoint k g
+
+/-- **The additive group `𝔾ₐ` is a smooth unipotent affine group.** This is the basic worked
+example of the Layer 5 definition, and the one from which the unipotent upper-triangular groups
+are built. -/
+theorem smoothUnipotentCommHopfAlgProperty_coordinateHopfAlgebra (k : Type u) [Field k] :
+    smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.of k (SymmetricAlgebra k k)) := by
+  rw [smoothUnipotentCommHopfAlgProperty_iff]
+  exact ⟨inferInstance, fun g => isUnipotentPoint k g⟩
+
+end AffineGroup
+
+end AdditiveGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
@@ -88,7 +88,7 @@ universe u v w
 
 section MonomialBasis
 
-variable (R : Type u) [CommRing R]
+variable (R : Type u) [CommSemiring R]
 
 /-- Exponent vectors on a singleton are natural numbers. -/
 private noncomputable def unitFinsuppEquivNat : (Unit →₀ ℕ) ≃ ℕ where
@@ -182,7 +182,7 @@ end MonomialBasis
 
 section Component
 
-variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+variable (R : Type u) [CommSemiring R] (V : Type v) [AddCommMonoid V] [Module R V]
 
 /-- The `n`-th coefficient map of `V ⊗[R] R[x]`, reading off the coefficient of the monomial
 `xⁿ` in the second factor. -/
@@ -233,7 +233,7 @@ end Component
 
 section CoactComponent
 
-variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+variable (R : Type u) [CommSemiring R] (V : Type v) [AddCommMonoid V] [Module R V]
 variable [Comodule R (SymmetricAlgebra R R) V]
 
 /-- **The `n`-th divided-power component of the coaction** of a comodule over the coordinate
@@ -265,6 +265,7 @@ private theorem coact_comp_tensorComponent (n : ℕ) :
 
 /-- **The divided-power components compose by the binomial rule** `Nᵢ ∘ Nⱼ = (i + j choose i)
 Nᵢ₊ⱼ`. This is coassociativity of the coaction, read off in the monomial basis. -/
+@[simp]
 theorem coactComponent_coactComponent (i j : ℕ) (v : V) :
     coactComponent R V i (coactComponent R V j v) =
       ((i + j).choose i) • coactComponent R V (i + j) v := by
@@ -285,7 +286,7 @@ end CoactComponent
 
 section Decomposition
 
-variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+variable (R : Type u) [CommSemiring R] (V : Type v) [AddCommMonoid V] [Module R V]
 
 variable [Comodule R (SymmetricAlgebra R R) V]
 
@@ -319,7 +320,7 @@ end Decomposition
 
 section Filtration
 
-variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+variable (R : Type u) [CommSemiring R] (V : Type v) [AddCommMonoid V] [Module R V]
 variable [Comodule R (SymmetricAlgebra R R) V]
 
 /-- **The divided-power filtration of a `𝔾ₐ`-comodule**: the `p`-th step consists of the vectors
@@ -360,11 +361,11 @@ theorem exists_coactFiltration_eq_top [Module.Finite R V] :
 
 end Filtration
 
-section Nilpotent
+section ActionExpansion
 
-variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+variable (R : Type u) [CommSemiring R] (V : Type v) [AddCommMonoid V] [Module R V]
 variable [Comodule R (SymmetricAlgebra R R) V]
-variable {A : Type w} [CommRing A] [Algebra R A]
+variable {A : Type w} [CommSemiring A] [Algebra R A]
 
 /-- **A point of `𝔾ₐ` acts through the divided-power components of the coaction.** A point with
 parameter `g x` sends `a ⊗ v` to `∑ᵢ a (g x)ⁱ ⊗ Nᵢ v`. -/
@@ -376,6 +377,14 @@ theorem endOfPoint_tmul_eq_sum (g : SymmetricAlgebra R R →ₐ[R] A) (a : A) (v
   refine Finsupp.sum_congr fun i _ => ?_
   rw [LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, map_pow, TensorProduct.comm_tmul,
     TensorProduct.smul_tmul', smul_eq_mul]
+
+end ActionExpansion
+
+section Nilpotent
+
+variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
+variable [Comodule R (SymmetricAlgebra R R) V]
+variable {A : Type w} [CommRing A] [Algebra R A]
 
 /-- The action of a point, minus the identity, involves only the positive divided-power
 components. -/

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup.Scheme
 public import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
@@ -173,8 +172,7 @@ private theorem tensorPairComponent_comp_lTensor_comul (i j : ℕ) :
   refine TensorProduct.ext' fun v h => ?_
   have hc := congr($(coeffPair_comp_comul R i j) h)
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.smul_apply] at hc
-  change Comodule.pairCoeff (R := R) (coeff R i) (coeff R j)
-    (Coalgebra.comul h) = ((i + j).choose i) • coeff R (i + j) h at hc
+  simp only [coeffPair] at hc
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.lTensor_tmul,
     Comodule.tensorPairComponent_tmul, hc, LinearMap.smul_apply, Comodule.tensorComponent_tmul]
   rw [← Nat.cast_smul_eq_nsmul R, smul_eq_mul, mul_smul]
@@ -238,9 +236,8 @@ noncomputable def coactDecomposition : V →ₗ[R] (ℕ →₀ V) :=
 theorem coactDecomposition_apply (v : V) (n : ℕ) :
     coactDecomposition R V v n = coactComponent R V n v := by
   rw [coactDecomposition, LinearMap.coe_comp, Function.comp_apply, coactComponent_apply]
-  unfold Comodule.tensorComponent coeff
-  convert TensorProduct.equivFinsuppOfBasisRight_apply (monomialBasis R)
-    (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v) n using 1 <;> rfl
+  exact Comodule.equivFinsuppOfBasisRight_apply (monomialBasis R)
+    (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v) n
 
 /-- The coaction is recovered from its divided-power components: `ρ v = ∑ₙ Nₙ v ⊗ xⁿ`. -/
 theorem coact_eq_sum (v : V) :

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
@@ -200,8 +200,15 @@ theorem coactComponent_apply (n : ℕ) (v : V) :
 @[simp]
 theorem coactComponent_zero : coactComponent R V 0 = LinearMap.id := by
   ext v
-  rw [coactComponent_apply, Comodule.tensorComponent, LinearMap.coe_comp, Function.comp_apply,
-    coeff_zero_eq_counit, Comodule.lTensor_counit_coact]
+  rw [coactComponent_apply, coeff_zero_eq_counit]
+  have hcomponent :
+      Comodule.tensorComponent (R := R) (M := V)
+          (Coalgebra.counit (R := R) (A := SymmetricAlgebra R R)) =
+        (TensorProduct.rid R V).toLinearMap ∘ₗ
+          (Coalgebra.counit (R := R) (A := SymmetricAlgebra R R)).lTensor V := by
+    refine TensorProduct.ext' fun w c => ?_
+    simp
+  rw [hcomponent, LinearMap.coe_comp, Function.comp_apply, Comodule.lTensor_counit_coact]
   simp
 
 /-- **The divided-power components compose by the binomial rule** `Nᵢ ∘ Nⱼ = (i + j choose i)

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.SymmetricAlgebra.Basis
 public import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup.Scheme
 public import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Basic

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
@@ -343,6 +343,14 @@ theorem coactFiltration_mono {p q : ℕ} (h : p ≤ q) :
     coactFiltration R V p ≤ coactFiltration R V q := fun _v hv =>
   (mem_coactFiltration R).2 fun i hi => (mem_coactFiltration R).1 hv i (lt_of_le_of_lt h hi)
 
+/-- The positive divided-power components lower the filtration by one step. -/
+theorem coactComponent_mem_coactFiltration {p i : ℕ} (hi : 0 < i) {v : V}
+    (hv : v ∈ coactFiltration R V (p + 1)) :
+    coactComponent R V i v ∈ coactFiltration R V p := by
+  rw [mem_coactFiltration]
+  intro j hj
+  rw [coactComponent_coactComponent, (mem_coactFiltration R).1 hv (j + i) (by omega), smul_zero]
+
 /-- **The divided-power filtration of a finitely generated comodule is exhaustive.** Each vector
 has only finitely many nonzero divided-power components, and finitely many generators bound them
 all at once. -/
@@ -402,14 +410,6 @@ theorem endOfPoint_sub_one_tmul (g : SymmetricAlgebra R R →ₐ[R] A) (a : A) (
     ← Finset.add_sum_erase _ _ (Finset.mem_insert_self 0 _), Finset.erase_insert_eq_erase]
   simp only [coactDecomposition_apply, coactComponent_zero, LinearMap.id_coe, id_eq, pow_zero,
     mul_one, add_sub_cancel_left]
-
-/-- The positive divided-power components lower the filtration by one step. -/
-theorem coactComponent_mem_coactFiltration {p i : ℕ} (hi : 0 < i) {v : V}
-    (hv : v ∈ coactFiltration R V (p + 1)) :
-    coactComponent R V i v ∈ coactFiltration R V p := by
-  rw [mem_coactFiltration]
-  intro j hj
-  rw [coactComponent_coactComponent, (mem_coactFiltration R).1 hv (j + i) (by omega), smul_zero]
 
 /-- A point acts as the identity on the bottom step of the filtration. -/
 theorem endOfPoint_sub_one_tmul_eq_zero (g : SymmetricAlgebra R R →ₐ[R] A) (a : A) {v : V}

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
@@ -9,6 +9,7 @@ public import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup.Scheme
 public import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+import TauCeti.Algebra.Bialgebra.Primitive
 
 /-!
 # The additive group is unipotent
@@ -139,20 +140,6 @@ theorem coeff_zero_eq_counit :
   simp only [Bialgebra.counitAlgHom_apply, SymmetricAlgebra.counit_ι]
   cases n <;> simp
 
-/-- **The binomial expansion of the comultiplication on monomials.** The coordinate `x` is
-primitive, so `Δ(xⁿ) = ∑ₖ (n choose k) xᵏ ⊗ xⁿ⁻ᵏ`. -/
-theorem comul_pow (n : ℕ) :
-    Coalgebra.comul (R := R) ((ι R R 1 : SymmetricAlgebra R R) ^ n) =
-      ∑ k ∈ Finset.range (n + 1), (n.choose k) •
-        (((ι R R 1 : SymmetricAlgebra R R) ^ k) ⊗ₜ[R]
-          ((ι R R 1 : SymmetricAlgebra R R) ^ (n - k))) := by
-  rw [← Bialgebra.comulAlgHom_apply, map_pow]
-  simp only [Bialgebra.comulAlgHom_apply, SymmetricAlgebra.comul_ι]
-  rw [add_pow]
-  refine Finset.sum_congr rfl fun k _ => ?_
-  rw [Algebra.TensorProduct.tmul_pow, Algebra.TensorProduct.tmul_pow, one_pow, one_pow,
-    Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul, nsmul_eq_mul, mul_comm]
-
 /-- The pairing of two coefficient functionals on a tensor square of the coordinate algebra. -/
 private noncomputable def coeffPair (i j : ℕ) :
     SymmetricAlgebra R R ⊗[R] SymmetricAlgebra R R →ₗ[R] R :=
@@ -171,22 +158,26 @@ private theorem coeffPair_comp_comul (i j : ℕ) :
       ((i + j).choose i) • coeff R (i + j) := by
   refine (monomialBasis R).ext fun n => ?_
   rw [monomialBasis_apply]
-  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.smul_apply, coeff_pow,
-    comul_pow, map_sum, map_nsmul, coeffPair_tmul, coeff_pow]
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.smul_apply]
+  rw [TauCeti.Bialgebra.comul_pow_of_primitive _ (SymmetricAlgebra.comul_ι R R 1) n]
+  simp only [coeff_pow, map_sum, map_nsmul, coeffPair_tmul, coeff_pow]
   rcases eq_or_ne n (i + j) with rfl | hn
-  · rw [Finset.sum_eq_single i]
+  · rw [Finset.sum_eq_single (i, j)]
     · simp
-    · intro k _ hk
-      simp [hk]
-    · intro hi
-      exact absurd (Finset.mem_range.2 (Nat.lt_succ_of_le (Nat.le_add_right i j))) hi
+    · intro mn _ hmn
+      by_cases hmi : mn.1 = i
+      · by_cases hmj : mn.2 = j
+        · exact (hmn (Prod.ext hmi hmj)).elim
+        · simp [hmi, hmj]
+      · simp [hmi]
+    · simp
   · rw [ite_eq_right hn, smul_zero]
-    refine Finset.sum_eq_zero fun k hk => ?_
-    have hkn : k ≤ n := Nat.lt_succ_iff.1 (Finset.mem_range.1 hk)
-    rcases eq_or_ne k i with rfl | hki
-    · have : n - k ≠ j := fun h => hn (by omega)
-      simp [this]
-    · simp [hki]
+    refine Finset.sum_eq_zero fun mn hmn => ?_
+    have hmnsum : mn.1 + mn.2 = n := Finset.mem_antidiagonal.1 hmn
+    rcases eq_or_ne mn.1 i with hmi | hmi
+    · have : mn.2 ≠ j := fun hmj => hn (by omega)
+      simp [hmi, this]
+    · simp [hmi]
 
 end MonomialBasis
 
@@ -297,18 +288,6 @@ section Decomposition
 
 variable (R : Type u) [CommRing R] (V : Type v) [AddCommMonoid V] [Module R V]
 
-/-- Reading off the `n`-th coefficient of a tensor is the `n`-th coordinate of its expansion in
-the monomial basis. -/
-private theorem equivFinsuppOfBasisRight_monomialBasis_apply
-    (z : V ⊗[R] SymmetricAlgebra R R) (n : ℕ) :
-    TensorProduct.equivFinsuppOfBasisRight (monomialBasis R) z n = tensorComponent R V n z := by
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | tmul v h =>
-    rw [TensorProduct.equivFinsuppOfBasisRight_apply_tmul_apply, tensorComponent_tmul, coeff,
-      Basis.coord_apply]
-  | add z w hz hw => simp only [map_add, Finsupp.add_apply, hz, hw]
-
 variable [Comodule R (SymmetricAlgebra R R) V]
 
 /-- **The divided-power decomposition of the coaction**, as a finitely supported family: writing
@@ -320,8 +299,11 @@ noncomputable def coactDecomposition : V →ₗ[R] (ℕ →₀ V) :=
 
 @[simp]
 theorem coactDecomposition_apply (v : V) (n : ℕ) :
-    coactDecomposition R V v n = coactComponent R V n v :=
-  equivFinsuppOfBasisRight_monomialBasis_apply R V _ n
+    coactDecomposition R V v n = coactComponent R V n v := by
+  rw [coactDecomposition, LinearMap.coe_comp, Function.comp_apply, coactComponent_apply]
+  unfold tensorComponent coeff
+  convert TensorProduct.equivFinsuppOfBasisRight_apply (monomialBasis R)
+    (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v) n using 1 <;> rfl
 
 /-- The coaction is recovered from its divided-power components: `ρ v = ∑ₙ Nₙ v ⊗ xⁿ`. -/
 theorem coact_eq_sum (v : V) :

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean
@@ -55,12 +55,11 @@ some `d`, the `(d + 1)`-st power of the difference vanishes.
 
 ## Implementation notes
 
-The shape of the argument parallels the weight decomposition of a comodule over a monoid algebra
-in `TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra`, which also expands a coaction along a basis
-of the coalgebra using `TensorProduct.equivFinsuppOfBasisRight`. The two cannot share more than
-that tool: there the basis consists of group-like elements, so the components are orthogonal
-idempotents and the comodule splits, whereas here the generator is primitive, so the components
-compose by the binomial rule and the comodule is only filtered.
+The component calculations reuse the coefficient-functional API in
+`TauCeti.Algebra.Coalgebra.Comodule.Basic`. The same API underlies the weight decomposition of a
+comodule over a monoid algebra. The coalgebra-specific calculations differ: group-like basis
+elements give orthogonal idempotents there, while the primitive generator here gives the binomial
+composition rule and hence a filtration rather than a splitting.
 
 ## References
 
@@ -90,31 +89,16 @@ section MonomialBasis
 
 variable (R : Type u) [CommSemiring R]
 
-/-- Exponent vectors on a singleton are natural numbers. -/
-private noncomputable def unitFinsuppEquivNat : (Unit →₀ ℕ) ≃ ℕ where
-  toFun f := f ()
-  invFun n := Finsupp.single () n
-  left_inv f := by
-    refine Finsupp.ext fun u => ?_
-    cases u
-    simp
-  right_inv n := by simp
-
-@[simp]
-private theorem unitFinsuppEquivNat_symm_apply (n : ℕ) :
-    (unitFinsuppEquivNat).symm n = Finsupp.single () n :=
-  rfl
-
 /-- **The monomials `xⁿ` in the coordinate `x = ι(1)` form a basis of the coordinate algebra
 `R[x] = SymmetricAlgebra R R` of the additive group.** -/
 noncomputable def monomialBasis : Basis ℕ R (SymmetricAlgebra R R) :=
-  (Basis.symmetricAlgebra (Basis.singleton Unit R)).reindex unitFinsuppEquivNat
+  (Basis.symmetricAlgebra (Basis.singleton Unit R)).reindex (Finsupp.uniqueEquiv ())
 
 @[simp]
 theorem monomialBasis_apply (n : ℕ) :
     monomialBasis R n = (ι R R 1 : SymmetricAlgebra R R) ^ n := by
   rw [monomialBasis, Basis.reindex_apply]
-  rw [unitFinsuppEquivNat_symm_apply]
+  rw [Finsupp.uniqueEquiv_symm_apply]
   rw [Basis.symmetricAlgebra, Basis.map_apply]
   simp only [MvPolynomial.coe_basisMonomials, AlgEquiv.toLinearEquiv_apply,
     ← MvPolynomial.X_pow_eq_monomial, map_pow, SymmetricAlgebra.equivMvPolynomial_symm_X,
@@ -142,12 +126,7 @@ theorem coeff_zero_eq_counit :
 /-- The pairing of two coefficient functionals on a tensor square of the coordinate algebra. -/
 private noncomputable def coeffPair (i j : ℕ) :
     SymmetricAlgebra R R ⊗[R] SymmetricAlgebra R R →ₗ[R] R :=
-  (TensorProduct.rid R R).toLinearMap ∘ₗ TensorProduct.map (coeff R i) (coeff R j)
-
-@[simp]
-private theorem coeffPair_tmul (i j : ℕ) (a b : SymmetricAlgebra R R) :
-    coeffPair R i j (a ⊗ₜ[R] b) = coeff R i a * coeff R j b := by
-  simp [coeffPair, smul_eq_mul, mul_comm]
+  Comodule.pairCoeff (R := R) (coeff R i) (coeff R j)
 
 /-- **The coefficient functionals are a divided-power system.** Pairing the `i`-th and `j`-th
 coefficients across the comultiplication returns `(i + j choose i)` times the `(i + j)`-th
@@ -159,7 +138,7 @@ private theorem coeffPair_comp_comul (i j : ℕ) :
   rw [monomialBasis_apply]
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.smul_apply]
   rw [TauCeti.Bialgebra.comul_pow_of_primitive _ (SymmetricAlgebra.comul_ι R R 1) n]
-  simp only [coeff_pow, map_sum, map_nsmul, coeffPair_tmul, coeff_pow]
+  simp only [coeff_pow, map_sum, map_nsmul, coeffPair, Comodule.pairCoeff_tmul, coeff_pow]
   rcases eq_or_ne n (i + j) with rfl | hn
   · rw [Finset.sum_eq_single (i, j)]
     · simp
@@ -184,50 +163,22 @@ section Component
 
 variable (R : Type u) [CommSemiring R] (V : Type v) [AddCommMonoid V] [Module R V]
 
-/-- The `n`-th coefficient map of `V ⊗[R] R[x]`, reading off the coefficient of the monomial
-`xⁿ` in the second factor. -/
-noncomputable def tensorComponent (n : ℕ) : V ⊗[R] SymmetricAlgebra R R →ₗ[R] V :=
-  (TensorProduct.rid R V).toLinearMap ∘ₗ (coeff R n).lTensor V
-
-@[simp]
-theorem tensorComponent_tmul (n : ℕ) (v : V) (h : SymmetricAlgebra R R) :
-    tensorComponent R V n (v ⊗ₜ[R] h) = coeff R n h • v := by
-  simp [tensorComponent]
-
-/-- The `(i, j)`-th coefficient map of `V ⊗[R] (R[x] ⊗[R] R[x])`. -/
-private noncomputable def tensorPairComponent (i j : ℕ) :
-    V ⊗[R] (SymmetricAlgebra R R ⊗[R] SymmetricAlgebra R R) →ₗ[R] V :=
-  (TensorProduct.rid R V).toLinearMap ∘ₗ (coeffPair R i j).lTensor V
-
-@[simp]
-private theorem tensorPairComponent_tmul (i j : ℕ) (v : V)
-    (h : SymmetricAlgebra R R ⊗[R] SymmetricAlgebra R R) :
-    tensorPairComponent R V i j (v ⊗ₜ[R] h) = coeffPair R i j h • v := by
-  simp [tensorPairComponent]
-
-/-- Reading off a coefficient of a tensor is compatible with the associator. -/
-private theorem tensorComponent_comp_tensorComponent (i j : ℕ) :
-    tensorComponent R V i ∘ₗ tensorComponent R (V ⊗[R] SymmetricAlgebra R R) j =
-      tensorPairComponent R V i j ∘ₗ
-        (TensorProduct.assoc R V (SymmetricAlgebra R R) (SymmetricAlgebra R R)).toLinearMap := by
-  refine TensorProduct.ext' fun z h₂ => ?_
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | tmul v h₁ => simp [smul_smul, mul_comm]
-  | add z w hz hw => simp only [TensorProduct.add_tmul, map_add, hz, hw]
-
 /-- Pairing the `i`-th and `j`-th coefficients across the comultiplication picks out
 `(i + j choose i)` times the `(i + j)`-th coefficient. -/
 private theorem tensorPairComponent_comp_lTensor_comul (i j : ℕ) :
-    tensorPairComponent R V i j ∘ₗ
+    Comodule.tensorPairComponent (R := R) (M := V) (coeff R i) (coeff R j) ∘ₗ
         (Coalgebra.comul (R := R) (A := SymmetricAlgebra R R)).lTensor V =
-      ((i + j).choose i) • tensorComponent R V (i + j) := by
+      ((i + j).choose i) •
+        Comodule.tensorComponent (R := R) (M := V) (coeff R (i + j)) := by
   refine TensorProduct.ext' fun v h => ?_
   have hc := congr($(coeffPair_comp_comul R i j) h)
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.smul_apply] at hc
+  change Comodule.pairCoeff (R := R) (coeff R i) (coeff R j)
+    (Coalgebra.comul h) = ((i + j).choose i) • coeff R (i + j) h at hc
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.lTensor_tmul,
-    tensorPairComponent_tmul, hc, LinearMap.smul_apply, tensorComponent_tmul,
-    ← Nat.cast_smul_eq_nsmul R, smul_smul, smul_eq_mul]
+    Comodule.tensorPairComponent_tmul, hc, LinearMap.smul_apply, Comodule.tensorComponent_tmul]
+  rw [← Nat.cast_smul_eq_nsmul R, smul_eq_mul, mul_smul]
+  simp only [Nat.cast_smul_eq_nsmul]
 
 end Component
 
@@ -239,28 +190,20 @@ variable [Comodule R (SymmetricAlgebra R R) V]
 /-- **The `n`-th divided-power component of the coaction** of a comodule over the coordinate
 algebra of `𝔾ₐ`: writing the coaction as `ρ v = ∑ₙ Nₙ v ⊗ xⁿ`, this is `Nₙ`. -/
 noncomputable def coactComponent (n : ℕ) : V →ₗ[R] V :=
-  tensorComponent R V n ∘ₗ Comodule.coact (R := R) (C := SymmetricAlgebra R R)
+  Comodule.coactComponent (R := R) (C := SymmetricAlgebra R R) (M := V) (coeff R n)
 
 theorem coactComponent_apply (n : ℕ) (v : V) :
     coactComponent R V n v =
-      tensorComponent R V n (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v) :=
-  by rw [coactComponent, LinearMap.coe_comp, Function.comp_apply]
+      Comodule.tensorComponent (R := R) (M := V) (coeff R n)
+        (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v) :=
+  by rw [coactComponent, Comodule.coactComponent_apply]
 
 /-- The zeroth divided-power component is the identity: this is the counit axiom. -/
 @[simp]
 theorem coactComponent_zero : coactComponent R V 0 = LinearMap.id := by
   ext v
-  rw [coactComponent_apply, tensorComponent, LinearMap.coe_comp, Function.comp_apply,
+  rw [coactComponent_apply, Comodule.tensorComponent, LinearMap.coe_comp, Function.comp_apply,
     coeff_zero_eq_counit, Comodule.lTensor_counit_coact]
-  simp
-
-/-- Reading off a coefficient of the coaction commutes with the coaction itself. -/
-private theorem coact_comp_tensorComponent (n : ℕ) :
-    Comodule.coact (R := R) (C := SymmetricAlgebra R R) ∘ₗ tensorComponent R V n =
-      tensorComponent R (V ⊗[R] SymmetricAlgebra R R) n ∘ₗ
-        (Comodule.coact (R := R) (C := SymmetricAlgebra R R) (M := V)).rTensor
-          (SymmetricAlgebra R R) := by
-  refine TensorProduct.ext' fun v h => ?_
   simp
 
 /-- **The divided-power components compose by the binomial rule** `Nᵢ ∘ Nⱼ = (i + j choose i)
@@ -269,18 +212,12 @@ Nᵢ₊ⱼ`. This is coassociativity of the coaction, read off in the monomial b
 theorem coactComponent_coactComponent (i j : ℕ) (v : V) :
     coactComponent R V i (coactComponent R V j v) =
       ((i + j).choose i) • coactComponent R V (i + j) v := by
-  have hcoact := congr($(coact_comp_tensorComponent R V j)
-    (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v))
-  simp only [LinearMap.coe_comp, Function.comp_apply] at hcoact
-  have hpair := congr($(tensorComponent_comp_tensorComponent R V i j)
-    ((Comodule.coact (R := R) (C := SymmetricAlgebra R R) (M := V)).rTensor (SymmetricAlgebra R R)
-      (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v)))
-  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe] at hpair
+  rw [coactComponent, coactComponent,
+    Comodule.coactComponent_coactComponent]
   have hfinal := congr($(tensorPairComponent_comp_lTensor_comul R V i j)
     (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v))
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.smul_apply] at hfinal
-  rw [coactComponent_apply, coactComponent_apply, hcoact, hpair,
-    Comodule.coassoc_apply, hfinal, coactComponent_apply]
+  rw [hfinal, coactComponent_apply]
 
 end CoactComponent
 
@@ -301,7 +238,7 @@ noncomputable def coactDecomposition : V →ₗ[R] (ℕ →₀ V) :=
 theorem coactDecomposition_apply (v : V) (n : ℕ) :
     coactDecomposition R V v n = coactComponent R V n v := by
   rw [coactDecomposition, LinearMap.coe_comp, Function.comp_apply, coactComponent_apply]
-  unfold tensorComponent coeff
+  unfold Comodule.tensorComponent coeff
   convert TensorProduct.equivFinsuppOfBasisRight_apply (monomialBasis R)
     (Comodule.coact (R := R) (C := SymmetricAlgebra R R) v) n using 1 <;> rfl
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import Mathlib.RingTheory.Coalgebra.Basic
 
 /-!
@@ -105,7 +106,6 @@ theorem lTensor_counit_coact (m : M) :
 /-! ## Components selected by linear functionals -/
 
 /-- Apply a linear functional to the coalgebra factor of a tensor. -/
-@[expose]
 noncomputable def tensorComponent (phi : C →ₗ[R] R) : M ⊗[R] C →ₗ[R] M :=
   (TensorProduct.rid R M).toLinearMap ∘ₗ phi.lTensor M
 
@@ -114,6 +114,15 @@ omit [Coalgebra R C] [Comodule R C M] in
 theorem tensorComponent_tmul (phi : C →ₗ[R] R) (m : M) (c : C) :
     tensorComponent (R := R) (M := M) phi (m ⊗ₜ[R] c) = phi c • m := by
   simp [tensorComponent]
+
+omit [Coalgebra R C] [Comodule R C M] in
+/-- The coordinates of a tensor in a basis of its right factor are its tensor components. -/
+theorem equivFinsuppOfBasisRight_apply {ι : Type*} [DecidableEq ι]
+    (b : Module.Basis ι R C) (t : M ⊗[R] C) (i : ι) :
+    TensorProduct.equivFinsuppOfBasisRight b t i =
+      tensorComponent (R := R) (M := M) (b.coord i) t := by
+  rw [TensorProduct.equivFinsuppOfBasisRight_apply]
+  rfl
 
 omit [Coalgebra R C] [Comodule R C M] in
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Basic.lean
@@ -24,6 +24,8 @@ right comodule of a coalgebra over itself, and the basic morphism API.
 * `TauCeti.Comodule`: a right comodule over a coalgebra.
 * `TauCeti.Comodule.Hom`: morphisms of comodules.
 * `TauCeti.Comodule.instSelf`: the regular right comodule of a coalgebra over itself.
+* `TauCeti.Comodule.coactComponent`: the component of a coaction selected by a linear
+  functional on the coalgebra.
 
 ## References
 
@@ -99,6 +101,102 @@ theorem coassoc_apply (m : M) :
 theorem lTensor_counit_coact (m : M) :
     Coalgebra.counit.lTensor M (coact (R := R) (C := C) (M := M) m) = m ⊗ₜ[R] 1 :=
   LinearMap.congr_fun (Comodule.lTensor_counit_comp_coact (R := R) (C := C) (M := M)) m
+
+/-! ## Components selected by linear functionals -/
+
+/-- Apply a linear functional to the coalgebra factor of a tensor. -/
+@[expose]
+noncomputable def tensorComponent (phi : C →ₗ[R] R) : M ⊗[R] C →ₗ[R] M :=
+  (TensorProduct.rid R M).toLinearMap ∘ₗ phi.lTensor M
+
+omit [Coalgebra R C] [Comodule R C M] in
+@[simp]
+theorem tensorComponent_tmul (phi : C →ₗ[R] R) (m : M) (c : C) :
+    tensorComponent (R := R) (M := M) phi (m ⊗ₜ[R] c) = phi c • m := by
+  simp [tensorComponent]
+
+omit [Coalgebra R C] [Comodule R C M] in
+@[simp]
+theorem tensorComponent_zero :
+    tensorComponent (R := R) (M := M) (0 : C →ₗ[R] R) = 0 := by
+  refine TensorProduct.ext' fun m c => ?_
+  simp
+
+/-- Pair two linear functionals on the factors of a tensor square. -/
+noncomputable def pairCoeff (phi psi : C →ₗ[R] R) : C ⊗[R] C →ₗ[R] R :=
+  (TensorProduct.rid R R).toLinearMap ∘ₗ TensorProduct.map phi psi
+
+omit [Coalgebra R C] in
+@[simp]
+theorem pairCoeff_tmul (phi psi : C →ₗ[R] R) (c d : C) :
+    pairCoeff (R := R) phi psi (c ⊗ₜ[R] d) = phi c * psi d := by
+  simp [pairCoeff, smul_eq_mul, mul_comm]
+
+/-- Apply a pair of linear functionals to the two coalgebra factors of a threefold tensor. -/
+noncomputable def tensorPairComponent (phi psi : C →ₗ[R] R) :
+    M ⊗[R] (C ⊗[R] C) →ₗ[R] M :=
+  (TensorProduct.rid R M).toLinearMap ∘ₗ (pairCoeff (R := R) phi psi).lTensor M
+
+omit [Coalgebra R C] [Comodule R C M] in
+@[simp]
+theorem tensorPairComponent_tmul (phi psi : C →ₗ[R] R) (m : M) (t : C ⊗[R] C) :
+    tensorPairComponent (R := R) (M := M) phi psi (m ⊗ₜ[R] t) =
+      pairCoeff (R := R) phi psi t • m := by
+  simp [tensorPairComponent]
+
+omit [Coalgebra R C] [Comodule R C M] in
+/-- Applying two tensor components successively is applying their pair after reassociation. -/
+theorem tensorComponent_comp_tensorComponent (phi psi : C →ₗ[R] R) :
+    tensorComponent (R := R) (M := M) phi ∘ₗ
+        tensorComponent (R := R) (M := M ⊗[R] C) psi =
+      tensorPairComponent (R := R) (M := M) phi psi ∘ₗ
+        (TensorProduct.assoc R M C C).toLinearMap := by
+  refine TensorProduct.ext_threefold fun m c d => ?_
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe,
+    TensorProduct.assoc_tmul, tensorPairComponent_tmul, pairCoeff_tmul, tensorComponent_tmul,
+    map_smul, smul_smul]
+  rw [mul_comm]
+
+/-- Taking a tensor component commutes with a coaction on the other factor. -/
+theorem coact_comp_tensorComponent (phi : C →ₗ[R] R) :
+    coact (R := R) (C := C) (M := M) ∘ₗ tensorComponent (R := R) (M := M) phi =
+      tensorComponent (R := R) (M := M ⊗[R] C) phi ∘ₗ
+        (coact (R := R) (C := C) (M := M)).rTensor C := by
+  refine TensorProduct.ext' fun m c => ?_
+  simp
+
+/-- The component of a coaction selected by a linear functional on the coalgebra. -/
+noncomputable def coactComponent (phi : C →ₗ[R] R) : M →ₗ[R] M :=
+  tensorComponent (R := R) (M := M) phi ∘ₗ coact (R := R) (C := C) (M := M)
+
+theorem coactComponent_apply (phi : C →ₗ[R] R) (m : M) :
+    coactComponent (R := R) (C := C) (M := M) phi m =
+      tensorComponent (R := R) (M := M) phi (coact m) :=
+  by rw [coactComponent, LinearMap.coe_comp, Function.comp_apply]
+
+/-- Coassociativity read off by two linear functionals on the coalgebra. -/
+theorem coactComponent_coactComponent (phi psi : C →ₗ[R] R) (m : M) :
+    coactComponent (R := R) (C := C) (M := M) phi
+        (coactComponent (R := R) (C := C) (M := M) psi m) =
+      tensorPairComponent (R := R) (M := M) phi psi
+        (Coalgebra.comul.lTensor M (coact m)) := by
+  have hcoact := congr($(coact_comp_tensorComponent (R := R) (C := C) (M := M) psi)
+    (coact (R := R) (C := C) (M := M) m))
+  simp only [LinearMap.coe_comp, Function.comp_apply] at hcoact
+  have hpair := congr($(tensorComponent_comp_tensorComponent
+    (R := R) (C := C) (M := M) phi psi)
+      ((coact (R := R) (C := C) (M := M)).rTensor C (coact m)))
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe] at hpair
+  rw [coactComponent_apply, coactComponent_apply, hcoact, hpair, coassoc_apply]
+
+omit [Comodule R C M] in
+/-- Contracting a pair component after comultiplication uses the corresponding contraction of
+the two coefficient functionals. -/
+theorem tensorPairComponent_comp_lTensor_comul {phi psi theta : C →ₗ[R] R}
+    (h : pairCoeff (R := R) phi psi ∘ₗ Coalgebra.comul = theta) :
+    tensorPairComponent (R := R) (M := M) phi psi ∘ₗ Coalgebra.comul.lTensor M =
+      tensorComponent (R := R) (M := M) theta := by
+  rw [tensorPairComponent, tensorComponent, LinearMap.comp_assoc, ← LinearMap.lTensor_comp, h]
 
 variable (R C) in
 /-- The regular right comodule of a coalgebra over itself, with coaction given by the

--- a/TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MonoidAlgebra.lean
@@ -32,7 +32,6 @@ spanning and the independence half of the decomposition.
 
 ## Main definitions
 
-* `TauCeti.Comodule.tensorComponent`: the `g`-th coefficient map of `V ⊗[R] R[G]`.
 * `TauCeti.Comodule.tensorCoeffEquiv`: the coefficients of an element of `V ⊗[R] R[G]`, as a
   finitely supported family.
 * `TauCeti.Comodule.weightDecomposition`: the weight components of a comodule, as a linear map to
@@ -101,19 +100,16 @@ variable [CommSemiring R] [AddCommMonoid V] [Module R V]
 
 section Component
 
-/-- The `g`-th coefficient map of `V ⊗[R] R[G]`, sending `v ⊗ x` to `x.coeff g • v`. The coaction
-of a comodule over `R[G]` is recovered from these coefficients, which are its weight
-components. -/
-noncomputable def tensorComponent (g : G) : V ⊗[R] MonoidAlgebra R G →ₗ[R] V :=
-  (TensorProduct.rid R V).toLinearMap ∘ₗ
-    (Finsupp.lapply g ∘ₗ (MonoidAlgebra.coeffLinearEquiv R).toLinearMap).lTensor V
-
-variable {R G V}
+/-- The coefficient functional at a basis element of a monoid algebra. -/
+noncomputable def monoidCoeff (g : G) : MonoidAlgebra R G →ₗ[R] R :=
+  Finsupp.lapply g ∘ₗ (MonoidAlgebra.coeffLinearEquiv R).toLinearMap
 
 @[simp]
-theorem tensorComponent_tmul (g : G) (v : V) (x : MonoidAlgebra R G) :
-    tensorComponent R G V g (v ⊗ₜ[R] x) = x.coeff g • v := by
-  simp [tensorComponent]
+theorem monoidCoeff_apply (g : G) (x : MonoidAlgebra R G) :
+    monoidCoeff R G g x = x.coeff g := by
+  simp [monoidCoeff]
+
+variable {R G V}
 
 variable (R G V)
 
@@ -128,10 +124,12 @@ variable {R G V}
 /-- The coefficient family of an element of `V ⊗[R] R[G]` is given by the coefficient maps. -/
 @[simp]
 theorem tensorCoeffEquiv_apply (t : V ⊗[R] MonoidAlgebra R G) (g : G) :
-    tensorCoeffEquiv R G V t g = tensorComponent R G V g t := by
+    tensorCoeffEquiv R G V t g =
+      tensorComponent (R := R) (M := V) (monoidCoeff R G g) t := by
   classical
   have h : (Finsupp.lapply g).comp (tensorCoeffEquiv R G V).toLinearMap =
-      tensorComponent R G V g := TensorProduct.ext' fun v x => by simp [tensorCoeffEquiv]
+      tensorComponent (R := R) (M := V) (monoidCoeff R G g) :=
+    TensorProduct.ext' fun v x => by simp [tensorCoeffEquiv, monoidCoeff]
   exact congr($h t)
 
 /-- The coefficient family of a pure tensor scales the vector by the coefficients. -/
@@ -160,7 +158,7 @@ variable [Comodule R (MonoidAlgebra R G) V]
 
 /-- The projection of a comodule over `R[G]` onto its `g`-weight component. -/
 noncomputable def weightProj (g : G) : V →ₗ[R] V :=
-  tensorComponent R G V g ∘ₗ coact (R := R) (C := MonoidAlgebra R G) (M := V)
+  coactComponent (R := R) (C := MonoidAlgebra R G) (M := V) (monoidCoeff R G g)
 
 variable {R G V} in
 /-- The `g`-weight component of `v` is the `g`-th coefficient of its coaction.
@@ -169,8 +167,10 @@ This is deliberately not a `simp` lemma: `weightProj_weightProj_self` and
 `weightProj_weightProj_of_ne` are the simp-normal form of a composite of weight projections, and
 they could never fire if `simp` first unfolded every `weightProj` to a coefficient of a coaction. -/
 theorem weightProj_apply (g : G) (v : V) :
-    weightProj R G V g v = tensorComponent R G V g (coact (R := R) (C := MonoidAlgebra R G) v) :=
-  (rfl)
+    weightProj R G V g v =
+      tensorComponent (R := R) (M := V) (monoidCoeff R G g)
+        (coact (R := R) (C := MonoidAlgebra R G) v) :=
+  by rw [weightProj, coactComponent_apply]
 
 /-- The weight components of a comodule over `R[G]`, read off its coaction as a finitely supported
 family. -/
@@ -238,101 +238,58 @@ end Counit
 
 section Coassoc
 
-/-- The pair of coefficient maps of `R[G] ⊗[R] R[G]`, contracted to a scalar. -/
-private noncomputable def pairCoeff (h g : G) :
-    MonoidAlgebra R G ⊗[R] MonoidAlgebra R G →ₗ[R] R :=
-  (TensorProduct.lid R R).toLinearMap ∘ₗ
-    TensorProduct.map (Finsupp.lapply h ∘ₗ (MonoidAlgebra.coeffLinearEquiv R).toLinearMap)
-      (Finsupp.lapply g ∘ₗ (MonoidAlgebra.coeffLinearEquiv R).toLinearMap)
-
-/-- The double coefficient map of `V ⊗[R] (R[G] ⊗[R] R[G])`. -/
-private noncomputable def doubleComponent (h g : G) :
-    V ⊗[R] (MonoidAlgebra R G ⊗[R] MonoidAlgebra R G) →ₗ[R] V :=
-  (TensorProduct.rid R V).toLinearMap ∘ₗ (pairCoeff R G h g).lTensor V
-
 variable {R G V}
-
-private theorem pairCoeff_tmul (h g : G) (x y : MonoidAlgebra R G) :
-    pairCoeff R G h g (x ⊗ₜ[R] y) = x.coeff h * y.coeff g := by
-  simp [pairCoeff]
-
-private theorem doubleComponent_tmul (h g : G) (v : V) (x y : MonoidAlgebra R G) :
-    doubleComponent R G V h g (v ⊗ₜ[R] (x ⊗ₜ[R] y)) = (x.coeff h * y.coeff g) • v := by
-  simp [doubleComponent, pairCoeff_tmul]
-
-/-- Reassociating, the double coefficient map is a composite of two single ones. -/
-private theorem doubleComponent_comp_assoc (h g : G) :
-    doubleComponent R G V h g ∘ₗ
-        (TensorProduct.assoc R V (MonoidAlgebra R G) (MonoidAlgebra R G)).toLinearMap =
-      tensorComponent R G V h ∘ₗ tensorComponent R G (V ⊗[R] MonoidAlgebra R G) g :=
-  TensorProduct.ext_threefold fun v x y => by
-    simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe,
-      TensorProduct.assoc_tmul, doubleComponent_tmul, tensorComponent_tmul, map_smul, mul_smul]
-    exact smul_comm _ _ _
 
 /-- Composed with the comultiplication of `R[G]`, the pair of coefficient maps at equal indices is
 a single coefficient map: the elements `single g 1` are group-like. -/
 private theorem pairCoeff_comp_comul_self (g : G) :
-    pairCoeff R G g g ∘ₗ Coalgebra.comul (R := R) (A := MonoidAlgebra R G) =
-      Finsupp.lapply g ∘ₗ (MonoidAlgebra.coeffLinearEquiv R).toLinearMap := by
+    pairCoeff (R := R) (monoidCoeff R G g) (monoidCoeff R G g) ∘ₗ
+        Coalgebra.comul (R := R) (A := MonoidAlgebra R G) = monoidCoeff R G g := by
   refine MonoidAlgebra.lhom_ext' fun k => ?_
   ext
-  by_cases hk : k = g <;> simp [pairCoeff_tmul, MonoidAlgebra.comul_single, hk]
+  by_cases hk : k = g <;>
+    simp [monoidCoeff, MonoidAlgebra.comul_single, hk]
 
 /-- Composed with the comultiplication of `R[G]`, the pair of coefficient maps at distinct indices
 vanishes. -/
 private theorem pairCoeff_comp_comul_of_ne {h g : G} (hne : h ≠ g) :
-    pairCoeff R G h g ∘ₗ Coalgebra.comul (R := R) (A := MonoidAlgebra R G) = 0 := by
+    pairCoeff (R := R) (monoidCoeff R G h) (monoidCoeff R G g) ∘ₗ
+        Coalgebra.comul (R := R) (A := MonoidAlgebra R G) = 0 := by
   refine MonoidAlgebra.lhom_ext' fun k => ?_
   ext
-  by_cases hk : k = g <;> simp [pairCoeff_tmul, MonoidAlgebra.comul_single, hk, hne]
+  by_cases hk : k = g <;>
+    simp [monoidCoeff, MonoidAlgebra.comul_single, hk, hne]
 
 variable [Comodule R (MonoidAlgebra R G) V]
 
-/-- Taking a coefficient of the coaction on the left factor is the coaction of the coefficient. -/
-private theorem tensorComponent_comp_rTensor_coact (g : G) :
-    tensorComponent R G (V ⊗[R] MonoidAlgebra R G) g ∘ₗ
-        (coact (R := R) (C := MonoidAlgebra R G) (M := V)).rTensor (MonoidAlgebra R G) =
-      coact (R := R) (C := MonoidAlgebra R G) (M := V) ∘ₗ tensorComponent R G V g :=
-  TensorProduct.ext' fun v x => by simp
-
 private theorem weightProj_weightProj_eq (h g : G) (v : V) :
     weightProj R G V h (weightProj R G V g v) =
-      doubleComponent R G V h g
+      tensorPairComponent (R := R) (M := V) (monoidCoeff R G h) (monoidCoeff R G g)
         ((Coalgebra.comul (R := R) (A := MonoidAlgebra R G)).lTensor V
-          (coact (R := R) (C := MonoidAlgebra R G) v)) := by
-  have key := congr($(doubleComponent_comp_assoc (R := R) (G := G) (V := V) h g)
-    ((coact (R := R) (C := MonoidAlgebra R G) (M := V)).rTensor (MonoidAlgebra R G)
-      (coact (R := R) (C := MonoidAlgebra R G) v)))
-  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe, coassoc_apply] at key
-  have hcomp := congr($(tensorComponent_comp_rTensor_coact (R := R) (G := G) (V := V) g)
-    (coact (R := R) (C := MonoidAlgebra R G) v))
-  simp only [LinearMap.coe_comp, Function.comp_apply] at hcomp
-  rw [key, hcomp]
-  rw [weightProj_apply, weightProj_apply]
+          (coact (R := R) (C := MonoidAlgebra R G) v)) :=
+  coactComponent_coactComponent (R := R) (C := MonoidAlgebra R G) (M := V)
+    (monoidCoeff R G h) (monoidCoeff R G g) v
 
 /-- **The weight projections are idempotent.** -/
 @[simp]
 theorem weightProj_weightProj_self (g : G) (v : V) :
     weightProj R G V g (weightProj R G V g v) = weightProj R G V g v := by
   rw [weightProj_weightProj_eq]
-  have h : doubleComponent R G V g g ∘ₗ
-      (Coalgebra.comul (R := R) (A := MonoidAlgebra R G)).lTensor V =
-        tensorComponent R G V g := by
-    rw [doubleComponent, tensorComponent, LinearMap.comp_assoc, ← LinearMap.lTensor_comp,
-      pairCoeff_comp_comul_self]
-  exact congr($h (coact (R := R) (C := MonoidAlgebra R G) v))
+  have h := tensorPairComponent_comp_lTensor_comul (M := V)
+    (pairCoeff_comp_comul_self (R := R) (G := G) g)
+  simpa only [LinearMap.coe_comp, Function.comp_apply, weightProj_apply] using
+    congr($h (coact (R := R) (C := MonoidAlgebra R G) v))
 
 /-- **The weight projections at distinct indices are orthogonal.** -/
 @[simp]
 theorem weightProj_weightProj_of_ne {h g : G} (hne : h ≠ g) (v : V) :
     weightProj R G V h (weightProj R G V g v) = 0 := by
   rw [weightProj_weightProj_eq]
-  have h0 : doubleComponent R G V h g ∘ₗ
-      (Coalgebra.comul (R := R) (A := MonoidAlgebra R G)).lTensor V = 0 := by
-    rw [doubleComponent, LinearMap.comp_assoc, ← LinearMap.lTensor_comp,
-      pairCoeff_comp_comul_of_ne hne, LinearMap.lTensor_zero, LinearMap.comp_zero]
-  exact congr($h0 (coact (R := R) (C := MonoidAlgebra R G) v))
+  have h0 := tensorPairComponent_comp_lTensor_comul (M := V)
+    (pairCoeff_comp_comul_of_ne (R := R) (G := G) hne)
+  have := congr($h0 (coact (R := R) (C := MonoidAlgebra R G) v))
+  simpa only [LinearMap.coe_comp, Function.comp_apply, tensorComponent_zero,
+    LinearMap.zero_apply] using this
 
 end Coassoc
 
@@ -372,7 +329,7 @@ theorem weightProj_of_mem {g : G} {v : V} (hv : v ∈ weightSpace R G V g) :
 theorem weightProj_of_mem_of_ne {h g : G} (hne : h ≠ g) {v : V} (hv : v ∈ weightSpace R G V g) :
     weightProj R G V h v = 0 := by
   classical
-  simp [weightProj_apply, mem_weightSpace.mp hv, Ne.symm hne]
+  simp [weightProj_apply, mem_weightSpace.mp hv, hne]
 
 /-- **Each weight component lies in its weight submodule.** -/
 theorem weightProj_mem_weightSpace (g : G) (v : V) :


### PR DESCRIPTION
This PR proves that the additive group `𝔾ₐ` is unipotent: for a commutative ring `R` with coordinate Hopf algebra `R[x] = SymmetricAlgebra R R`, every point `g : R[x] →ₐ[R] A` valued in a commutative `R`-algebra acts on the scalar extension of every finitely generated comodule by an automorphism whose difference from the identity is nilpotent. Over a field this is exactly the geometric representation-theoretic definition, and combined with the smoothness of `R[x]` it exhibits `𝔾ₐ` as a smooth unipotent affine group.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5 milestone "Unipotent groups", together with its "Worked examples (build alongside, as checks along the way)" clause naming `𝔾ₐ`. The milestone's ⚠ warns that a naive nilpotence test in the coordinate ring is vacuous and that the correct definition needs comodule theory; the definition itself landed as `TauCeti.smoothUnipotentCommHopfAlgProperty` (TauCeti#3088) with no group yet known to satisfy it, so nothing so far rules out the predicate being empty. This PR is the most effective next step because it supplies that first witness, and because `𝔾ₐ` is the group out of which the rest of the milestone is built: the upper-triangular unipotent `Uₙ` whose coordinate Hopf algebra is in flight, and the root subgroups `x_α : 𝔾ₐ → G` already merged in `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/RootSubgroup.lean`. After this PR, Layer 5 still needs the closed immersion `Uₙ ↪ GLₙ` with the unipotence of `Uₙ`, the converse embedding characterization, Lie–Kolchin and solvability, and the unipotent radical, before Layer 6 can define reductivity.

The proof is the classical divided-power argument, and the divided-power machinery it introduces is reusable for any `𝔾ₐ`-comodule. The monomials `xⁿ` form a basis of `R[x]` (`monomialBasis`, transported from Mathlib's `Basis.symmetricAlgebra`), so a coaction can be written `ρ v = ∑ₙ Nₙ v ⊗ xⁿ` with `Nₙ` endomorphisms of `V` (`coactComponent`), finitely many nonzero on each vector. The counit axiom gives `N₀ = id`; coassociativity together with the binomial expansion `Δ(xⁿ) = ∑ₖ (n choose k) xᵏ ⊗ xⁿ⁻ᵏ` of the primitive generator gives `Nᵢ ∘ Nⱼ = (i + j choose i) Nᵢ₊ⱼ`. A point acts by `a ⊗ v ↦ ∑ᵢ a (g x)ⁱ ⊗ Nᵢ v`, so its difference from the identity uses only positive-index components; that difference lowers the filtration `Vₚ = {v | Nᵢ v = 0 for i > p}` by one step and annihilates `V₀`, and a finitely generated comodule is `V_d` for some `d`.

Add `TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Unipotent.lean` (524 lines). It reuses Mathlib's `SymmetricAlgebra` basis and `TensorProduct.equivFinsuppOfBasisRight`, `Submodule.baseChange`, and the smoothness and finite-presentation transport lemmas, together with Tau Ceti's comodule point action, unipotent-point predicate, and the merged smooth unipotence object properties. No Mathlib infrastructure is vendored. The file's implementation notes record why the parallel weight decomposition over a monoid algebra in `TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra` cannot be shared beyond that one tool: there the basis is group-like and the comodule splits, here the generator is primitive and the comodule is only filtered. The mathematics follows Jantzen, *Representations of Algebraic Groups*, I.2 and I.7.8, Waterhouse, *Introduction to Affine Group Schemes*, §8.3, and Springer, *Linear Algebraic Groups*, §2.4, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"additive-group-is-unipotent"}-->

🤖 Prepared with Claude Code
