### PR TITLE
chore(ViaKoopman): drop a dead classical from the block induction

### DIFF
--- a/TauCeti/Probability/DeFinetti/ViaKoopman/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/BlockFactorization.lean
@@ -94,7 +94,6 @@ theorem setIntegral_weight_mul_blockIndicatorProd_prefix_eq_prod_condExp
   | zero => intro B _ w _ _; simp
   | succ r ih =>
     intro B hB w hw hw_bdd
-    classical
     set E : (ℕ → α) → ℝ :=
       ρ[fun y : ℕ → α => (B (Fin.last r)).indicator (fun _ => (1 : ℝ)) (y r) |
         MeasurableSpace.invariants (shift α)] with hEdef


### PR DESCRIPTION
`classical` in `setIntegral_weight_mul_blockIndicatorProd_prefix_eq_prod_condExp` is unused — the
induction needs no decidability, and the module builds without it. Verified by removing it and
rebuilding.

Found while auditing the Koopman files against the categories review has repeatedly flagged; the
same dead-scaffolding finding was raised on #3152 and #3168. It is split out here rather than
carried in #3170, whose topic is `deFinetti_viaKoopman`.

Roadmap: none

Dead-code removal in an existing proof; no mathematical content changes.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
