### PR TITLE
feat(EDS): normEDS is an elliptic net, and the four-index equivalence

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -353,8 +353,8 @@ private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
 
 /-- **Four pairwise distinct nonnegative indices of one parity, in any order.** The tuple is
 sorted by `Tuple.sort` and the relator read off the sorted order, `atomRelFin4_perm` supplying the
-sign. Unlike the three-index case below, no index is pinned at `0`, so there is no distinguished
-minimum and the general permutation argument is what the sorting needs. -/
+sign. No index is pinned at `0` here, so there is no distinguished minimum and the sorting needs
+the general permutation argument rather than the six orderings of three free indices. -/
 private theorem atomRelFin4_eq_zero_of_injective (odd : W.Odd)
     (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d) {t : Fin 4 → ℤ}
     (nonneg : ∀ i, 0 ≤ t i) (par : ∀ i j, t i % 2 = t j % 2) (inj : Function.Injective t) :

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -13,12 +13,12 @@ import Mathlib.Tactic.FinCases
 import TauCeti.NumberTheory.EllipticDivisibilitySequence.SignEquivariance
 
 /-!
-# An elliptic sequence from its two doubling recurrences
+# An elliptic net from its two doubling recurrences
 
-`IsEllipticSequence W` is a condition on every triple of integers. This file proves it
-equivalent to two families of equations indexed by a *single* integer — the odd doubling
-recurrence from `m = 2` on and the even one from `m = 3` on — for a sequence that is odd,
-vanishes at `0`, and has `W 1` and `W 2` nonzerodivisors.
+`IsEllipticNet W` is a condition on every quadruple of integers, `IsEllipticSequence W` on every
+triple. This file proves both equivalent to two families of equations indexed by a *single*
+integer — the odd doubling recurrence from `m = 2` on and the even one from `m = 3` on — for a
+sequence that is odd, vanishes at `0`, and has `W 1` and `W 2` nonzerodivisors.
 
 The forward direction is `Recurrence.lean`. The reverse is the descent proved here, by
 induction on the largest index `a`:
@@ -41,11 +41,11 @@ hypotheses that `atom_even`, `atom_odd` and `atomRel_eq` carry.
 
 ## Main results
 
-* `isEllipticSequence_iff`: the equivalence, and the headline result of the file.
-* `IsEllipticNet.isEllipticNet_of_rel`: the same two recurrences give the **four**-index
-  relation at every quadruple, not only the three-index one.
-* `IsEllipticNet.isEllipticSequence_of_rel`: its hard direction, with the recurrences in
-  relator form — now the `s = 0` case of the net.
+* `isEllipticNet_iff`: the equivalence at **four** indices, and the headline result of the file.
+* `isEllipticSequence_iff`: its `s = 0` case, the three-index equivalence.
+* `IsEllipticNet.isEllipticNet_of_rel`: the hard direction of the first, with the recurrences in
+  relator form.
+* `IsEllipticNet.isEllipticSequence_of_rel`: the `s = 0` case of that.
 * `IsEllipticNet.atom_mul_atomRel_eq_of_last_eq_fst`, `…_of_last_eq_snd`,
   `IsEllipticNet.atom_mul_atomRel_eq`: the three-term and ten-term expansions that drive it.
 
@@ -431,23 +431,46 @@ theorem isEllipticSequence_of_rel (odd : W.Odd) (zero : W 0 = 0) (one : W 1 ∈ 
 
 end IsEllipticNet
 
+/-- **Being an elliptic net is exactly satisfying the two doubling recurrences.** For a sequence
+that is odd, vanishes at `0` and has `W 1`, `W 2` nonzerodivisors, the **four**-index relation at
+every quadruple is equivalent to the odd recurrence from `m = 2` and the even one from `m = 3` —
+finitely many equations per index rather than a condition on quadruples.
+
+The forward direction reads the two recurrences off the net through its `s = 0` sequence; the
+reverse is the descent, which rebuilds the whole net from them.
+
+So under these hypotheses being an elliptic net and being an elliptic sequence are the same
+condition, which is what makes `isEllipticSequence_iff` below a corollary. They are not the same
+condition in general: `normEDS b c d` at arbitrary parameters need not have `W 2 = b` a
+nonzerodivisor, and `NormEDS.lean` reaches the net there by transporting from the universal ring
+rather than through this equivalence. -/
+theorem isEllipticNet_iff {R : Type*} [CommRing R] {W : ℤ → R} (odd : W.Odd) (zero : W 0 = 0)
+    (one : W 1 ∈ nonZeroDivisors R) (two : W 2 ∈ nonZeroDivisors R) :
+    IsEllipticNet W ↔
+      (∀ m : ℤ, 2 ≤ m → W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3)
+        ∧ ∀ m : ℤ, 3 ≤ m → W (2 * m) * W 2 * W 1 ^ 2 =
+            W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) := by
+  refine ⟨fun h ↦ ⟨fun m _ ↦ h.isEllipticSequence.rel_odd m,
+    fun m _ ↦ h.isEllipticSequence.rel_even m⟩, fun ⟨hodd, heven⟩ ↦ ?_⟩
+  refine IsEllipticNet.isEllipticNet_of_rel odd zero one two (fun m hm ↦ ?_) fun m hm ↦ ?_
+  · rw [IsEllipticNet.rel_odd]
+    linear_combination hodd m hm
+  · rw [IsEllipticNet.rel_even]
+    linear_combination heven m hm
+
 /-- **Being an elliptic sequence is exactly satisfying the two doubling recurrences.** For a
 sequence that is odd, vanishes at `0` and has `W 1`, `W 2` nonzerodivisors, the whole
 three-index relation is equivalent to the odd recurrence from `m = 2` and the even one from
 `m = 3` — finitely many equations per index rather than a condition on triples.
 
 The forward direction is `IsEllipticSequence.rel_odd` and `rel_even`, which read the two
-recurrences off the relation; the reverse is the descent, which rebuilds the relation from
-them. -/
+recurrences off the relation; the reverse is `isEllipticNet_iff` at `s = 0`, the descent having
+rebuilt the entire net from the same two recurrences. -/
 theorem isEllipticSequence_iff {R : Type*} [CommRing R] {W : ℤ → R} (odd : W.Odd) (zero : W 0 = 0)
     (one : W 1 ∈ nonZeroDivisors R) (two : W 2 ∈ nonZeroDivisors R) :
     IsEllipticSequence W ↔
       (∀ m : ℤ, 2 ≤ m → W (2 * m + 1) * W 1 ^ 3 = W (m + 2) * W m ^ 3 - W (m - 1) * W (m + 1) ^ 3)
         ∧ ∀ m : ℤ, 3 ≤ m → W (2 * m) * W 2 * W 1 ^ 2 =
-            W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) := by
-  refine ⟨fun h ↦ ⟨fun m _ ↦ h.rel_odd m, fun m _ ↦ h.rel_even m⟩, fun ⟨hodd, heven⟩ ↦ ?_⟩
-  refine IsEllipticNet.isEllipticSequence_of_rel odd zero one two (fun m hm ↦ ?_) fun m hm ↦ ?_
-  · rw [IsEllipticNet.rel_odd]
-    linear_combination hodd m hm
-  · rw [IsEllipticNet.rel_even]
-    linear_combination heven m hm
+            W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) :=
+  ⟨fun h ↦ ⟨fun m _ ↦ h.rel_odd m, fun m _ ↦ h.rel_even m⟩,
+    fun h ↦ ((isEllipticNet_iff odd zero one two).mpr h).isEllipticSequence⟩

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -74,17 +74,18 @@ needed, and is used.
 ## Provenance
 
 Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`,
-`rel₄_iff_evenRec`, `dMin`, `cMin`, `Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`,
-`rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`, `rel₄_of_oddRec_evenRec` and
-`IsEllSequence.of_oddRec_evenRec`, and — for the four-index sorting and the net entry point —
-`IsEllSequence.rel₄` and `IsEllSequence.net`. That file's header reads
-`Authors: David Kurniadi Angdinata`; following this repository's convention for adapted material
-the upstream authorship is credited here rather than in the copyright header. J. Xu is
-acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
-co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
-an author of the declarations above.
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`, `rel₄_iff_evenRec`, `dMin`, `cMin`,
+`Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`, `rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`,
+`rel₄_of_oddRec_evenRec` and `IsEllSequence.of_oddRec_evenRec`. That file's header reads `Authors:
+David Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
+authorship is credited here rather than in the copyright header. J. Xu is acknowledged for the
+surrounding LutzNagell development — he authors `Universal.lean` and co-authors
+`DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as an author of
+the declarations above.
+
+The four-index sorting and the net entry point adapt two further declarations of that same file,
+`IsEllSequence.rel₄` and `IsEllSequence.net`.
 
 The source states its expansions against its own `addMulSub` and `rel₄`, which Mathlib now
 supplies as `atom` and `atomRel` with the same definitions, so those statements transfer by

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -41,8 +41,10 @@ hypotheses that `atom_even`, `atom_odd` and `atomRel_eq` carry.
 ## Main results
 
 * `isEllipticSequence_iff`: the equivalence, and the headline result of the file.
+* `IsEllipticNet.isEllipticNet_of_rel`: the same two recurrences give the **four**-index
+  relation at every quadruple, not only the three-index one.
 * `IsEllipticNet.isEllipticSequence_of_rel`: its hard direction, with the recurrences in
-  relator form.
+  relator form — now the `s = 0` case of the net.
 * `IsEllipticNet.atom_mul_atomRel_eq_of_last_eq_fst`, `…_of_last_eq_snd`,
   `IsEllipticNet.atom_mul_atomRel_eq`: the three-term and ten-term expansions that drive it.
 
@@ -58,14 +60,15 @@ a statement about indices alone.
 
 The antisymmetry of `atomRel` under transpositions is **not** proved here: `SignEquivariance.lean`
 already exports `atomRel_swap₁₂`, `atomRel_swap₂₃` and `atomRel_swap₃₄`, together with the general
-`atomRelFin4_perm`. Only the first three indices are ever permuted below, the last being held at
-`0`, so the two adjacent transpositions are all that is used.
+`atomRelFin4_perm`. It is that general form the sorting uses. The net has no distinguished index —
+`rel_eq` produces the quadruple `(2p + s, 2q + s, 2r + s, s)`, in which `s` is free — so all four
+are sorted, by `Tuple.sort` composed with the reversal, rather than three against a fixed `0`.
 
-Three parts of the source's apparatus are not needed here, each because Mathlib has absorbed
-the layer that made them necessary. Its `rel₄_transf` is `atomRel_avg_sub`; its minimal-index
+Two parts of the source's apparatus are not needed here, each because Mathlib has absorbed the
+layer that made them necessary. Its `rel₄_transf` is `atomRel_avg_sub`; and its minimal-index
 definition `if Even a then 0 else 1`, with five `Int.negOnePow` lemmas about it, is `a % 2`,
-about which everything needed is `omega`; and its `Tuple.sort` argument over four indices
-reduces to six orderings of three, the last index being `0` and so already minimal.
+about which everything needed is `omega`. Its `Tuple.sort` argument over four indices **is**
+needed, and is used.
 
 ## Provenance
 
@@ -338,47 +341,6 @@ private theorem atomRelVanishes_of_rel (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
         (nonnegStrictAnti₄_abs_avg_sub h1 (by omega) h2 h3)
     · exact atomRel_eq_zero_of_gap_two oddRec evenRec (by omega) hb
 
-/-- Three distinct positive even indices, in any order, against a last index of `0`. The six
-orderings are reached from the decreasing one by the adjacent transpositions; the last index is
-already minimal, so only the first three need sorting and the general `Tuple.sort` argument the
-source uses is not required. The local `sorted` is the descent specialised to that decreasing
-shape, which is the only shape the six branches ever need. -/
-private theorem atomRel_eq_zero_of_ne (odd : W.Odd)
-    (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d) {x y z : ℤ}
-    (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) (px : x % 2 = 0) (py : y % 2 = 0) (pz : z % 2 = 0)
-    (hxy : x ≠ y) (hyz : y ≠ z) (hxz : x ≠ z) :
-    atomRel W x y z 0 = 0 := by
-  have sorted {u v w : ℤ} (pu : u % 2 = 0) (pv : v % 2 = 0) (pw : w % 2 = 0)
-      (hw : 0 < w) (hwv : w < v) (hvu : v < u) : atomRel W u v w 0 = 0 :=
-    descent u v w 0 ⟨by omega, by omega, by omega⟩ (by rw [nonnegStrictAnti₄_iff]; omega)
-  rcases lt_trichotomy x y with h₁ | h₁ | h₁
-  · rcases lt_trichotomy y z with h₂ | h₂ | h₂
-    · have h := sorted pz py px hx h₁ h₂
-      rw [atomRel_swap₁₂ odd z y x 0, atomRel_swap₂₃ odd y z x 0,
-        atomRel_swap₁₂ odd y x z 0] at h
-      simpa using h
-    · exact absurd h₂ hyz
-    · rcases lt_trichotomy x z with h₃ | h₃ | h₃
-      · have h := sorted py pz px hx h₃ h₂
-        rw [atomRel_swap₂₃ odd y z x 0, atomRel_swap₁₂ odd y x z 0] at h
-        simpa using h
-      · exact absurd h₃ hxz
-      · have h := sorted py px pz hz h₃ h₁
-        rw [atomRel_swap₁₂ odd y x z 0] at h
-        simpa using h
-  · exact absurd h₁ hxy
-  · rcases lt_trichotomy x z with h₂ | h₂ | h₂
-    · have h := sorted pz px py hy h₁ h₂
-      rw [atomRel_swap₁₂ odd z x y 0, atomRel_swap₂₃ odd x z y 0] at h
-      simpa using h
-    · exact absurd h₂ hxz
-    · rcases lt_trichotomy y z with h₃ | h₃ | h₃
-      · have h := sorted px pz py hy h₃ h₂
-        rw [atomRel_swap₂₃ odd x z y 0] at h
-        simpa using h
-      · exact absurd h₃ hyz
-      · exact sorted px py pz hz h₃ h₁
-
 /-- **Four pairwise distinct nonnegative indices of one parity, in any order.** The tuple is
 sorted by `Tuple.sort` and the relator read off the sorted order, `atomRelFin4_perm` supplying the
 sign. Unlike the three-index case below, no index is pinned at `0`, so there is no distinguished
@@ -415,7 +377,8 @@ private theorem abs_emod_two (x : ℤ) : |x| % 2 = x % 2 := by
 /-- **The relator vanishes at any quadruple of one parity.** All four indices are made
 nonnegative by sign equivariance, a coincidence between any two is one of Mathlib's
 `atomRel_same` lemmas, and the remaining pairwise-distinct case is sorted. This is the net
-statement; `atomRel_eq_zero_of_nonneg` below is its `d = 0` specialisation. -/
+statement, and the only reduction the file needs: the sequence case is `isEllipticSequence_of_rel`
+applying it at `d = 0`. -/
 private theorem atomRel_eq_zero_of_parity (odd : W.Odd) (zero : W 0 = 0)
     (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d) {a b c d : ℤ}
     (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
@@ -445,48 +408,31 @@ private theorem atomRel_eq_zero_of_parity (odd : W.Odd) (zero : W 0 = 0)
   simpa using atomRelFin4_eq_zero_of_injective odd descent
     (t := ![|a|, |b|, |c|, |d|]) (fun i ↦ by fin_cases i <;> simp [abs_nonneg]) hpar hinj
 
-/-- Three nonnegative even indices against `0`, with no distinctness assumed: every coincidence
-puts two indices of the relator equal, and each such case is one of Mathlib's `atomRel_same`
-lemmas, whose value carries a factor `W 0`. -/
-private theorem atomRel_eq_zero_of_nonneg (odd : W.Odd) (zero : W 0 = 0)
-    (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d) {x y z : ℤ}
-    (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) (px : x % 2 = 0) (py : y % 2 = 0) (pz : z % 2 = 0) :
-    atomRel W x y z 0 = 0 := by
-  rcases eq_or_lt_of_le hx with rfl | hx'
-  · rw [atomRel_same₁₄ odd]; simp [zero]
-  rcases eq_or_lt_of_le hy with rfl | hy'
-  · rw [atomRel_same₂₄ odd]; simp [zero]
-  rcases eq_or_lt_of_le hz with rfl | hz'
-  · rw [atomRel_same₃₄]; simp [zero]
-  rcases eq_or_ne x y with rfl | hxy
-  · rw [atomRel_same₁₂]; simp [zero]
-  rcases eq_or_ne y z with rfl | hyz
-  · rw [atomRel_same₂₃]; simp [zero]
-  rcases eq_or_ne x z with rfl | hxz
-  · rw [atomRel_same₁₃ odd]; simp [zero]
-  exact atomRel_eq_zero_of_ne odd descent hx' hy' hz' px py pz hxy hyz hxz
+/-- **An elliptic net from the two doubling recurrences.** A sequence that is odd, vanishes at
+`0`, has `W 1` and `W 2` nonzerodivisors, and satisfies the odd recurrence from `m = 2` and the
+even one from `m = 3`, satisfies the full four-index relation at *every* quadruple.
 
-/-- `omega` cannot parse `|·|`, so the sign split has to happen before it is called. -/
-private theorem abs_two_mul_emod_two (p : ℤ) : |2 * p| % 2 = 0 := by
-  rcases abs_cases (2 * p) with ⟨h, _⟩ | ⟨h, _⟩ <;> rw [h] <;> omega
+`rel_eq` writes `rel W p q r s` as the relator at `(2p + s, 2q + s, 2r + s, s)`, whose four
+indices are all congruent to `s`, so this is exactly `atomRel_eq_zero_of_parity` at that
+quadruple. -/
+theorem isEllipticNet_of_rel (odd : W.Odd) (zero : W 0 = 0) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
+    (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
+    (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) :
+    IsEllipticNet W := by
+  intro p q r s
+  rw [rel_eq]
+  exact atomRel_eq_zero_of_parity odd zero (atomRelVanishes_of_rel one two oddRec evenRec)
+    ⟨by omega, by omega, by omega⟩
 
-/-- **An elliptic sequence from its two doubling recurrences.** A sequence that is odd, vanishes
-at `0`, has `W 1` and `W 2` nonzerodivisors, and satisfies the odd recurrence from `m = 2` and
-the even one from `m = 3`, satisfies the full elliptic-net relation at every triple.
+/-- **An elliptic sequence from its two doubling recurrences**, the last index held at `0`.
 
 This is the converse direction to `IsEllipticSequence.rel_odd` and `rel_even`: those read the two
 recurrences off the relation, this rebuilds the relation from them. -/
 theorem isEllipticSequence_of_rel (odd : W.Odd) (zero : W 0 = 0) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
     (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
     (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) :
-    IsEllipticSequence W := by
-  intro p q r
-  have bridge := atomRel_two_mul W p q r 0
-  norm_num at bridge
-  rw [← bridge, ← atomRel_abs₁ odd, ← atomRel_abs₂ odd, ← atomRel_abs₃ odd]
-  exact atomRel_eq_zero_of_nonneg odd zero
-    (atomRelVanishes_of_rel one two oddRec evenRec) (abs_nonneg _) (abs_nonneg _) (abs_nonneg _)
-    (abs_two_mul_emod_two p) (abs_two_mul_emod_two q) (abs_two_mul_emod_two r)
+    IsEllipticSequence W :=
+  fun p q r ↦ isEllipticNet_of_rel odd zero one two oddRec evenRec p q r 0
 
 end IsEllipticNet
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -8,6 +8,7 @@ public import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Recurrence
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Transfer
 import Mathlib.Data.Fin.Tuple.Sort
+import Mathlib.Data.Int.ModEq
 import Mathlib.Tactic.FinCases
 import TauCeti.NumberTheory.EllipticDivisibilitySequence.SignEquivariance
 
@@ -73,15 +74,17 @@ needed, and is used.
 ## Provenance
 
 Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
-declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`, `rel₄_iff_evenRec`, `dMin`, `cMin`,
-`Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`, `rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`,
-`rel₄_of_oddRec_evenRec` and `IsEllSequence.of_oddRec_evenRec`. That file's header reads `Authors:
-David Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
-authorship is credited here rather than in the copyright header. J. Xu is acknowledged for the
-surrounding LutzNagell development — he authors `Universal.lean` and co-authors
-`DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as an author of
-the declarations above.
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `rel₆_eq₃`, `rel₆_eq₃'`, `rel₆_eq₁₀`,
+`rel₄_iff_evenRec`, `dMin`, `cMin`, `Rel₄OfValid`, `rel₄_fix₁_of_fix₂`, `rel₄_of_fix₂`,
+`rel₄_of_min₂`, `rel₄_of_anti_oddRec_evenRec`, `rel₄_of_oddRec_evenRec` and
+`IsEllSequence.of_oddRec_evenRec`, and — for the four-index sorting and the net entry point —
+`IsEllSequence.rel₄` and `IsEllSequence.net`. That file's header reads
+`Authors: David Kurniadi Angdinata`; following this repository's convention for adapted material
+the upstream authorship is credited here rather than in the copyright header. J. Xu is
+acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
+co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
+an author of the declarations above.
 
 The source states its expansions against its own `addMulSub` and `rel₄`, which Mathlib now
 supplies as `atom` and `atomRel` with the same definitions, so those statements transfer by
@@ -366,14 +369,6 @@ private theorem atomRelFin4_eq_zero_of_injective (odd : W.Odd)
   rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with h | h <;> rw [h] at hzero <;>
     simpa using hzero
 
-/-- Taking absolute values preserves parity, which is what lets the sign-equivariance reduction
-to nonnegative indices keep the hypothesis the descent needs. `omega` cannot see through `|·|`,
-so the two cases are supplied by `abs_choice`. -/
-private theorem abs_emod_two (x : ℤ) : |x| % 2 = x % 2 := by
-  rcases abs_choice x with h | h
-  · rw [h]
-  · rw [h]; omega
-
 /-- **The relator vanishes at any quadruple of one parity.** All four indices are made
 nonnegative by sign equivariance, a coincidence between any two is one of Mathlib's
 `atomRel_same` lemmas, and the remaining pairwise-distinct case is sorted. This is the net
@@ -399,8 +394,10 @@ private theorem atomRel_eq_zero_of_parity (odd : W.Odd) (zero : W 0 = 0)
   · rw [← hcd, atomRel_same₃₄]; simp [zero]
   have hpar : ∀ i j : Fin 4, (![|a|, |b|, |c|, |d|] : Fin 4 → ℤ) i % 2 =
       (![|a|, |b|, |c|, |d|] : Fin 4 → ℤ) j % 2 := by
-    have ha := abs_emod_two a; have hb := abs_emod_two b
-    have hc := abs_emod_two c; have hd := abs_emod_two d
+    have ha : |a| % 2 = a % 2 := Int.abs_modEq_two
+    have hb : |b| % 2 = b % 2 := Int.abs_modEq_two
+    have hc : |c| % 2 = c % 2 := Int.abs_modEq_two
+    have hd : |d| % 2 = d % 2 := Int.abs_modEq_two
     intro i j; fin_cases i <;> fin_cases j <;> simp <;> omega
   have hinj : Function.Injective (![|a|, |b|, |c|, |d|] : Fin 4 → ℤ) := by
     intro i j hij
@@ -432,7 +429,7 @@ theorem isEllipticSequence_of_rel (odd : W.Odd) (zero : W 0 = 0) (one : W 1 ∈ 
     (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
     (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) :
     IsEllipticSequence W :=
-  fun p q r ↦ isEllipticNet_of_rel odd zero one two oddRec evenRec p q r 0
+  (isEllipticNet_of_rel odd zero one two oddRec evenRec).isEllipticSequence
 
 end IsEllipticNet
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -396,18 +396,18 @@ private theorem atomRel_eq_zero_of_parity (odd : W.Odd) (zero : W 0 = 0)
   · rw [← hbd, atomRel_same₂₄ odd]; simp [zero]
   by_cases hcd : |c| = |d|
   · rw [← hcd, atomRel_same₃₄]; simp [zero]
+  have habs : ∀ x : ℤ, |x| % 2 = x % 2 := fun _ ↦ Int.abs_modEq_two
   have hpar : ∀ i j : Fin 4, (![|a|, |b|, |c|, |d|] : Fin 4 → ℤ) i % 2 =
       (![|a|, |b|, |c|, |d|] : Fin 4 → ℤ) j % 2 := by
-    have ha : |a| % 2 = a % 2 := Int.abs_modEq_two
-    have hb : |b| % 2 = b % 2 := Int.abs_modEq_two
-    have hc : |c| % 2 = c % 2 := Int.abs_modEq_two
-    have hd : |d| % 2 = d % 2 := Int.abs_modEq_two
-    intro i j; fin_cases i <;> fin_cases j <;> simp <;> omega
+    intro i j; fin_cases i <;> fin_cases j <;> simp [habs] <;> omega
   have hinj : Function.Injective (![|a|, |b|, |c|, |d|] : Fin 4 → ℤ) := by
     intro i j hij
     fin_cases i <;> fin_cases j <;> simp_all
-  simpa using atomRelFin4_eq_zero_of_injective odd descent
-    (t := ![|a|, |b|, |c|, |d|]) (fun i ↦ by fin_cases i <;> simp [abs_nonneg]) hpar hinj
+  have hzero := atomRelFin4_eq_zero_of_injective odd descent (t := ![|a|, |b|, |c|, |d|])
+    (fun i ↦ by fin_cases i <;> simp [abs_nonneg]) hpar hinj
+  -- `atomRelFin4_def` is the bridge back to `atomRel`; `simp` then only reduces the projections.
+  rw [atomRelFin4_def] at hzero
+  simpa using hzero
 
 /-- **An elliptic net from the two doubling recurrences.** A sequence that is odd, vanishes at
 `0`, has `W 1` and `W 2` nonzerodivisors, and satisfies the odd recurrence from `m = 2` and the

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -42,10 +42,9 @@ hypotheses that `atom_even`, `atom_odd` and `atomRel_eq` carry.
 ## Main results
 
 * `isEllipticNet_iff`: the equivalence at **four** indices, and the headline result of the file.
-* `isEllipticSequence_iff`: its `s = 0` case, the three-index equivalence.
+* `isEllipticSequence_iff`: the classical three-index equivalence, its `s = 0` case.
 * `IsEllipticNet.isEllipticNet_of_rel`: the hard direction of the first, with the recurrences in
   relator form.
-* `IsEllipticNet.isEllipticSequence_of_rel`: the `s = 0` case of that.
 * `IsEllipticNet.atom_mul_atomRel_eq_of_last_eq_fst`, `…_of_last_eq_snd`,
   `IsEllipticNet.atom_mul_atomRel_eq`: the three-term and ten-term expansions that drive it.
 
@@ -54,6 +53,13 @@ hypotheses that `atom_even`, `atom_odd` and `atomRel_eq` carry.
 The descent itself is private. `AtomRelVanishes` and the three lemmas lowering it are shaped by
 this proof rather than by any consumer, and the interface a caller wants is the equivalence and
 its hard direction.
+
+Both levels are stated. `isEllipticNet_iff` is the stronger statement and everything is proved
+through it, but `IsEllipticSequence` is the predicate Mathlib defines and that
+`IsEllipticDvdSequence` is built from, so the three-index equivalence is kept named rather than
+left as `(isEllipticNet_iff …).mpr … |>.isEllipticSequence` at each use. The relator-form
+`isEllipticSequence_of_rel` is *not* kept: it restated `isEllipticNet_of_rel` in the spelling
+this file uses internally, and had no consumer.
 
 That predicate carries the parity and ordering conditions *inside* it. The induction applies its
 hypothesis at quadruples whose validity is not known in advance, so the recursive call has to be
@@ -371,8 +377,7 @@ private theorem atomRelFin4_eq_zero_of_injective (odd : W.Odd)
 /-- **The relator vanishes at any quadruple of one parity.** All four indices are made
 nonnegative by sign equivariance, a coincidence between any two is one of Mathlib's
 `atomRel_same` lemmas, and the remaining pairwise-distinct case is sorted. This is the net
-statement, and the only reduction the file needs: the sequence case is `isEllipticSequence_of_rel`
-applying it at `d = 0`. -/
+statement, and the only reduction the file needs: the sequence case is its `d = 0` instance. -/
 private theorem atomRel_eq_zero_of_parity (odd : W.Odd) (zero : W 0 = 0)
     (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d) {a b c d : ℤ}
     (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
@@ -406,29 +411,17 @@ private theorem atomRel_eq_zero_of_parity (odd : W.Odd) (zero : W 0 = 0)
 
 /-- **An elliptic net from the two doubling recurrences.** A sequence that is odd, vanishes at
 `0`, has `W 1` and `W 2` nonzerodivisors, and satisfies the odd recurrence from `m = 2` and the
-even one from `m = 3`, satisfies the full four-index relation at *every* quadruple.
-
-`rel_eq` writes `rel W p q r s` as the relator at `(2p + s, 2q + s, 2r + s, s)`, whose four
-indices are all congruent to `s`, so this is exactly `atomRel_eq_zero_of_parity` at that
-quadruple. -/
+even one from `m = 3`, satisfies the full four-index relation at *every* quadruple. -/
 theorem isEllipticNet_of_rel (odd : W.Odd) (zero : W 0 = 0) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
     (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
     (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) :
     IsEllipticNet W := by
+  -- `rel_eq` writes `rel W p q r s` as the relator at `(2p + s, 2q + s, 2r + s, s)`, whose four
+  -- indices are all congruent to `s`, so this is `atomRel_eq_zero_of_parity` at that quadruple.
   intro p q r s
   rw [rel_eq]
   exact atomRel_eq_zero_of_parity odd zero (atomRelVanishes_of_rel one two oddRec evenRec)
     ⟨by omega, by omega, by omega⟩
-
-/-- **An elliptic sequence from its two doubling recurrences**, the last index held at `0`.
-
-This is the converse direction to `IsEllipticSequence.rel_odd` and `rel_even`: those read the two
-recurrences off the relation, this rebuilds the relation from them. -/
-theorem isEllipticSequence_of_rel (odd : W.Odd) (zero : W 0 = 0) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
-    (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
-    (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) :
-    IsEllipticSequence W :=
-  (isEllipticNet_of_rel odd zero one two oddRec evenRec).isEllipticSequence
 
 end IsEllipticNet
 
@@ -437,14 +430,10 @@ that is odd, vanishes at `0` and has `W 1`, `W 2` nonzerodivisors, the **four**-
 every quadruple is equivalent to the odd recurrence from `m = 2` and the even one from `m = 3` —
 finitely many equations per index rather than a condition on quadruples.
 
-The forward direction reads the two recurrences off the net through its `s = 0` sequence; the
-reverse is the descent, which rebuilds the whole net from them.
-
-So under these hypotheses being an elliptic net and being an elliptic sequence are the same
-condition, which is what makes `isEllipticSequence_iff` below a corollary. They are not the same
-condition in general: `normEDS b c d` at arbitrary parameters need not have `W 2 = b` a
-nonzerodivisor, and `NormEDS.lean` reaches the net there by transporting from the universal ring
-rather than through this equivalence. -/
+Under these hypotheses, therefore, being an elliptic net and being an elliptic sequence are the
+same condition. They are not the same condition in general: `normEDS b c d` at arbitrary
+parameters need not have `W 2 = b` a nonzerodivisor, and `NormEDS.lean` obtains the net there
+without this equivalence. -/
 theorem isEllipticNet_iff {R : Type*} [CommRing R] {W : ℤ → R} (odd : W.Odd) (zero : W 0 = 0)
     (one : W 1 ∈ nonZeroDivisors R) (two : W 2 ∈ nonZeroDivisors R) :
     IsEllipticNet W ↔
@@ -464,9 +453,8 @@ sequence that is odd, vanishes at `0` and has `W 1`, `W 2` nonzerodivisors, the 
 three-index relation is equivalent to the odd recurrence from `m = 2` and the even one from
 `m = 3` — finitely many equations per index rather than a condition on triples.
 
-The forward direction is `IsEllipticSequence.rel_odd` and `rel_even`, which read the two
-recurrences off the relation; the reverse is `isEllipticNet_iff` at `s = 0`, the descent having
-rebuilt the entire net from the same two recurrences. -/
+This is the classical statement, about the predicate `IsEllipticSequence`; `isEllipticNet_iff`
+is its four-index strengthening. -/
 theorem isEllipticSequence_iff {R : Type*} [CommRing R] {W : ℤ → R} (odd : W.Odd) (zero : W 0 = 0)
     (one : W 1 ∈ nonZeroDivisors R) (two : W 2 ∈ nonZeroDivisors R) :
     IsEllipticSequence W ↔

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Recurrence
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Transfer
+import Mathlib.Data.Fin.Tuple.Sort
 import TauCeti.NumberTheory.EllipticDivisibilitySequence.SignEquivariance
 
 /-!
@@ -376,6 +377,31 @@ private theorem atomRel_eq_zero_of_ne (odd : W.Odd)
         simpa using h
       · exact absurd h₃ hyz
       · exact sorted px py pz hz h₃ h₁
+
+/-- **Four pairwise distinct nonnegative indices of one parity, in any order.** The tuple is
+sorted by `Tuple.sort` and the relator read off the sorted order, `atomRelFin4_perm` supplying the
+sign. Unlike the three-index case below, no index is pinned at `0`, so there is no distinguished
+minimum and the general permutation argument is what the sorting needs. -/
+private theorem atomRelFin4_eq_zero_of_injective (odd : W.Odd)
+    (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d) {t : Fin 4 → ℤ}
+    (nonneg : ∀ i, 0 ≤ t i) (par : ∀ i j, t i % 2 = t j % 2) (inj : Function.Injective t) :
+    atomRelFin4 W t = 0 := by
+  set σ : Equiv.Perm (Fin 4) := Fin.revPerm.trans (Tuple.sort t) with hσ
+  -- `t ∘ Tuple.sort t` is monotone, so precomposing with the reversal makes it antitone; with `t`
+  -- injective that antitone tuple is *strictly* decreasing, which is what the descent consumes.
+  have hanti : ∀ i j : Fin 4, i < j → (t ∘ σ) j < (t ∘ σ) i := by
+    intro i j hij
+    refine lt_of_le_of_ne (Tuple.monotone_sort t (by simpa [hσ] using Fin.rev_le_rev.mpr hij.le)) ?_
+    exact fun h ↦ absurd ((σ.injective (inj h)).symm) (by simpa using hij.ne)
+  have hzero : atomRelFin4 W (t ∘ σ) = 0 := by
+    rw [atomRelFin4_def]
+    refine descent _ _ _ _ ⟨par _ _, par _ _, par _ _⟩ ?_
+    rw [nonnegStrictAnti₄_iff]
+    exact ⟨nonneg _, hanti 2 3 (by decide), hanti 1 2 (by decide), hanti 0 1 (by decide)⟩
+  rw [atomRelFin4_perm odd σ t] at hzero
+  -- the sign is a unit of `ℤ`, so it cancels; splitting on `±1` avoids naming a units lemma
+  rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with h | h <;> rw [h] at hzero <;>
+    simpa using hzero
 
 /-- Three nonnegative even indices against `0`, with no distinctness assumed: every coincidence
 puts two indices of the relator equal, and each such case is one of Mathlib's `atomRel_same`

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -8,6 +8,7 @@ public import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Recurrence
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Transfer
 import Mathlib.Data.Fin.Tuple.Sort
+import Mathlib.Tactic.FinCases
 import TauCeti.NumberTheory.EllipticDivisibilitySequence.SignEquivariance
 
 /-!
@@ -402,6 +403,47 @@ private theorem atomRelFin4_eq_zero_of_injective (odd : W.Odd)
   -- the sign is a unit of `ℤ`, so it cancels; splitting on `±1` avoids naming a units lemma
   rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with h | h <;> rw [h] at hzero <;>
     simpa using hzero
+
+/-- Taking absolute values preserves parity, which is what lets the sign-equivariance reduction
+to nonnegative indices keep the hypothesis the descent needs. `omega` cannot see through `|·|`,
+so the two cases are supplied by `abs_choice`. -/
+private theorem abs_emod_two (x : ℤ) : |x| % 2 = x % 2 := by
+  rcases abs_choice x with h | h
+  · rw [h]
+  · rw [h]; omega
+
+/-- **The relator vanishes at any quadruple of one parity.** All four indices are made
+nonnegative by sign equivariance, a coincidence between any two is one of Mathlib's
+`atomRel_same` lemmas, and the remaining pairwise-distinct case is sorted. This is the net
+statement; `atomRel_eq_zero_of_nonneg` below is its `d = 0` specialisation. -/
+private theorem atomRel_eq_zero_of_parity (odd : W.Odd) (zero : W 0 = 0)
+    (descent : ∀ a b c d : ℤ, AtomRelVanishes W a b c d) {a b c d : ℤ}
+    (parity : d % 2 = a % 2 ∧ d % 2 = b % 2 ∧ d % 2 = c % 2) :
+    atomRel W a b c d = 0 := by
+  obtain ⟨pa, pb, pc⟩ := parity
+  rw [← atomRel_abs₁ odd, ← atomRel_abs₂ odd, ← atomRel_abs₃ odd, ← atomRel_abs₄]
+  by_cases hab : |a| = |b|
+  · rw [hab, atomRel_same₁₂]; simp [zero]
+  by_cases hac : |a| = |c|
+  · rw [← hac, atomRel_same₁₃ odd]; simp [zero]
+  by_cases had : |a| = |d|
+  · rw [← had, atomRel_same₁₄ odd]; simp [zero]
+  by_cases hbc : |b| = |c|
+  · rw [← hbc, atomRel_same₂₃]; simp [zero]
+  by_cases hbd : |b| = |d|
+  · rw [← hbd, atomRel_same₂₄ odd]; simp [zero]
+  by_cases hcd : |c| = |d|
+  · rw [← hcd, atomRel_same₃₄]; simp [zero]
+  have hpar : ∀ i j : Fin 4, (![|a|, |b|, |c|, |d|] : Fin 4 → ℤ) i % 2 =
+      (![|a|, |b|, |c|, |d|] : Fin 4 → ℤ) j % 2 := by
+    have ha := abs_emod_two a; have hb := abs_emod_two b
+    have hc := abs_emod_two c; have hd := abs_emod_two d
+    intro i j; fin_cases i <;> fin_cases j <;> simp <;> omega
+  have hinj : Function.Injective (![|a|, |b|, |c|, |d|] : Fin 4 → ℤ) := by
+    intro i j hij
+    fin_cases i <;> fin_cases j <;> simp_all
+  simpa using atomRelFin4_eq_zero_of_injective odd descent
+    (t := ![|a|, |b|, |c|, |d|]) (fun i ↦ by fin_cases i <;> simp [abs_nonneg]) hpar hinj
 
 /-- Three nonnegative even indices against `0`, with no distinctness assumed: every coincidence
 puts two indices of the relator equal, and each such case is one of Mathlib's `atomRel_same`

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -43,8 +43,8 @@ hypotheses that `atom_even`, `atom_odd` and `atomRel_eq` carry.
 
 * `isEllipticNet_iff`: the equivalence at **four** indices, and the headline result of the file.
 * `isEllipticSequence_iff`: the classical three-index equivalence, its `s = 0` case.
-* `IsEllipticNet.isEllipticNet_of_rel`: the hard direction of the first, with the recurrences in
-  relator form.
+* `IsEllipticNet.of_rel`: the hard direction of the first, with the recurrences in relator
+  form.
 * `IsEllipticNet.atom_mul_atomRel_eq_of_last_eq_fst`, `…_of_last_eq_snd`,
   `IsEllipticNet.atom_mul_atomRel_eq`: the three-term and ten-term expansions that drive it.
 
@@ -58,7 +58,7 @@ Both levels are stated. `isEllipticNet_iff` is the stronger statement and everyt
 through it, but `IsEllipticSequence` is the predicate Mathlib defines and that
 `IsEllipticDvdSequence` is built from, so the three-index equivalence is kept named rather than
 left as `(isEllipticNet_iff …).mpr … |>.isEllipticSequence` at each use. The relator-form
-`isEllipticSequence_of_rel` is *not* kept: it restated `isEllipticNet_of_rel` in the spelling
+`isEllipticSequence_of_rel` is *not* kept: it restated `IsEllipticNet.of_rel` in the spelling
 this file uses internally, and had no consumer.
 
 That predicate carries the parity and ordering conditions *inside* it. The induction applies its
@@ -412,7 +412,7 @@ private theorem atomRel_eq_zero_of_parity (odd : W.Odd) (zero : W 0 = 0)
 /-- **An elliptic net from the two doubling recurrences.** A sequence that is odd, vanishes at
 `0`, has `W 1` and `W 2` nonzerodivisors, and satisfies the odd recurrence from `m = 2` and the
 even one from `m = 3`, satisfies the full four-index relation at *every* quadruple. -/
-theorem isEllipticNet_of_rel (odd : W.Odd) (zero : W 0 = 0) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
+theorem of_rel (odd : W.Odd) (zero : W 0 = 0) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
     (oddRec : ∀ m : ℤ, 2 ≤ m → rel W (m + 1) m 1 0 = 0)
     (evenRec : ∀ m : ℤ, 3 ≤ m → rel W (m + 1) (m - 1) 1 0 = 0) :
     IsEllipticNet W := by
@@ -442,7 +442,7 @@ theorem isEllipticNet_iff {R : Type*} [CommRing R] {W : ℤ → R} (odd : W.Odd)
             W m * (W (m - 1) ^ 2 * W (m + 2) - W (m - 2) * W (m + 1) ^ 2) := by
   refine ⟨fun h ↦ ⟨fun m _ ↦ h.isEllipticSequence.rel_odd m,
     fun m _ ↦ h.isEllipticSequence.rel_even m⟩, fun ⟨hodd, heven⟩ ↦ ?_⟩
-  refine IsEllipticNet.isEllipticNet_of_rel odd zero one two (fun m hm ↦ ?_) fun m hm ↦ ?_
+  refine IsEllipticNet.of_rel odd zero one two (fun m hm ↦ ?_) fun m hm ↦ ?_
   · rw [IsEllipticNet.rel_odd]
     linear_combination hodd m hm
   · rw [IsEllipticNet.rel_even]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -353,21 +353,19 @@ private theorem atomRelFin4_eq_zero_of_injective (odd : W.Odd)
     (nonneg : ∀ i, 0 ≤ t i) (par : ∀ i j, t i % 2 = t j % 2) (inj : Function.Injective t) :
     atomRelFin4 W t = 0 := by
   set σ : Equiv.Perm (Fin 4) := Fin.revPerm.trans (Tuple.sort t) with hσ
-  -- `t ∘ Tuple.sort t` is monotone, so precomposing with the reversal makes it antitone; with `t`
-  -- injective that antitone tuple is *strictly* decreasing, which is what the descent consumes.
-  have hanti : ∀ i j : Fin 4, i < j → (t ∘ σ) j < (t ∘ σ) i := by
-    intro i j hij
-    refine lt_of_le_of_ne (Tuple.monotone_sort t (by simpa [hσ] using Fin.rev_le_rev.mpr hij.le)) ?_
-    exact fun h ↦ absurd ((σ.injective (inj h)).symm) (by simpa using hij.ne)
+  -- `t ∘ Tuple.sort t` is monotone and injective, hence strictly monotone; precomposing with the
+  -- reversal turns that into the strict decrease the descent consumes.
+  have hstrict : StrictMono (t ∘ Tuple.sort t) :=
+    (Tuple.monotone_sort t).strictMono_of_injective (inj.comp (Tuple.sort t).injective)
+  have hanti : ∀ i j : Fin 4, i < j → (t ∘ σ) j < (t ∘ σ) i := fun i j hij ↦ by
+    simpa [hσ, Function.comp_assoc] using hstrict (Fin.rev_lt_rev.mpr hij)
   have hzero : atomRelFin4 W (t ∘ σ) = 0 := by
     rw [atomRelFin4_def]
     refine descent _ _ _ _ ⟨par _ _, par _ _, par _ _⟩ ?_
     rw [nonnegStrictAnti₄_iff]
     exact ⟨nonneg _, hanti 2 3 (by decide), hanti 1 2 (by decide), hanti 0 1 (by decide)⟩
   rw [atomRelFin4_perm odd σ t] at hzero
-  -- the sign is a unit of `ℤ`, so it cancels; splitting on `±1` avoids naming a units lemma
-  rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with h | h <;> rw [h] at hzero <;>
-    simpa using hzero
+  exact (smul_eq_zero_iff_eq (Equiv.Perm.sign σ)).mp hzero
 
 /-- **The relator vanishes at any quadruple of one parity.** All four indices are made
 nonnegative by sign equivariance, a coincidence between any two is one of Mathlib's

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -24,9 +24,11 @@ is left to its own slice.
 The net is what the invariant layer needs. `IsEllipticNet.invarNum_mul_invarDenom` takes an
 `IsEllipticNet` hypothesis — its cross-multiplication identity is proved from the relation at four
 free indices, not three — so stopping at the sequence would leave that consumer inapplicable to
-`normEDS`. Applied to `isEllipticNet_normEDS` it gives, for every `b`, `c`, `d`,
+`normEDS`. Applied to `isEllipticNet_normEDS` it gives, writing `W` for `normEDS b c d`,
 
-`invarNum W s m * invarDenom W s n = invarNum W s n * invarDenom W s m`.
+`invarNum W s m * invarDenom W s n = invarNum W s n * invarDenom W s m`
+
+for every `b`, `c`, `d`, `s`, `m` and `n`.
 
 That is **weaker** than index-independence of an invariant ratio, which needs the denominators
 invertible and so does not hold over a general commutative ring; `Invariant.lean` states the
@@ -68,9 +70,10 @@ acknowledged for the surrounding LutzNagell development — he authors `Universa
 co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
 an author of the declarations above.
 
-The source proves the hypothesis-carrying version from its own descent development; here that
-step is `isEllipticSequence_iff`, so the helper is six lines rather than a file. The universal
-transport is the source's argument, with `normEDS_eq_aeval` in place of its inline rewriting.
+The source proves the hypothesis-carrying version from its own descent development; here that step
+is `Descent.lean`'s `IsEllipticNet.isEllipticNet_of_rel`, fed the two recurrences in relator form,
+so the helper is six lines rather than a file. The universal transport is the source's argument,
+with `normEDS_eq_aeval` in place of its inline rewriting.
 -/
 
 public section

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -39,8 +39,9 @@ distinction where the identity is proved.
 * `isEllipticNet_normEDS`: `IsEllipticNet (normEDS b c d)`, with no hypothesis on the parameters.
 * `isEllipticSequence_normEDS`: its `s = 0` case.
 
-The first consumer this unlocks is `IsEllipticNet.invarNum_mul_invarDenom`, which is applied to
-`isEllipticNet_normEDS` directly rather than restated here.
+The first consumer this unlocks is `IsEllipticNet.invarNum_mul_invarDenom`, which callers can
+apply to `isEllipticNet_normEDS` directly; it is deliberately not restated here as a
+specialisation.
 
 The `s = 0` case is kept as a named theorem rather than left to `.isEllipticSequence` at each
 use: `IsEllipticSequence` is the predicate Mathlib defines, `IsEllipticDvdSequence` is

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -51,11 +51,12 @@ waiting on, not the slice that lands them.
 ## Provenance
 
 Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
-declarations `IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That
-file's header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
-adapted material the upstream authorship is credited here rather than in the copyright header. J.
-Xu is acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations
+`IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That file's header
+reads `Authors: David Kurniadi Angdinata`; following this repository's convention for adapted
+material the upstream authorship is credited here rather than in the copyright header. J. Xu is
+acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
 co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
 an author of the declarations above.
 
@@ -106,7 +107,7 @@ theorem isEllipticNet_normEDS (b c d : R) : IsEllipticNet (normEDS b c d) := by
 
 /-- **A normalised EDS is an elliptic sequence**, the last index of the net held at `0`. -/
 theorem isEllipticSequence_normEDS (b c d : R) : IsEllipticSequence (normEDS b c d) :=
-  fun p q r ↦ isEllipticNet_normEDS b c d p q r 0
+  (isEllipticNet_normEDS b c d).isEllipticSequence
 
 /-- **The invariant of a normalised EDS is symmetric in its two indices.** This is what the
 elliptic-net structure buys for `normEDS`: `IsEllipticNet.invarNum_mul_invarDenom` needs the full

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Descent
-public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Invariant
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Universal
 
 /-!
@@ -23,15 +22,23 @@ conjunct needs a general `normEDS_mul_complEDS`, of which Mathlib has only the `
 is left to its own slice.
 
 The net is what the invariant layer needs. `IsEllipticNet.invarNum_mul_invarDenom` takes an
-`IsEllipticNet` hypothesis — the cross identity is proved from the relation at four free indices,
-not three — so stopping at the sequence would leave that consumer unusable for `normEDS`.
+`IsEllipticNet` hypothesis — its cross-multiplication identity is proved from the relation at four
+free indices, not three — so stopping at the sequence would leave that consumer inapplicable to
+`normEDS`. Applied to `isEllipticNet_normEDS` it gives, for every `b`, `c`, `d`,
+
+`invarNum W s m * invarDenom W s n = invarNum W s n * invarDenom W s m`.
+
+That is **weaker** than index-independence of an invariant ratio, which needs the denominators
+invertible and so does not hold over a general commutative ring; `Invariant.lean` states the
+distinction where the identity is proved.
 
 ## Main results
 
 * `isEllipticNet_normEDS`: `IsEllipticNet (normEDS b c d)`, with no hypothesis on the parameters.
 * `isEllipticSequence_normEDS`: its `s = 0` case.
-* `IsEllipticNet.invarNum_mul_invarDenom_normEDS`: the invariant of `normEDS` is symmetric in its
-  two indices — the first consumer the net unlocks.
+
+The first consumer this unlocks is `IsEllipticNet.invarNum_mul_invarDenom`, which is applied to
+`isEllipticNet_normEDS` directly rather than restated here.
 
 ## Implementation notes
 
@@ -53,7 +60,8 @@ waiting on, not the slice that lands them.
 Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
 `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations
-`IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That file's header
+`IsEllSequence.normEDS_of_mem_nonZeroDivisors`, `IsEllSequence.normEDS`, `net_normEDS` and
+`IsEllSequence.invar`. That file's header
 reads `Authors: David Kurniadi Angdinata`; following this repository's convention for adapted
 material the upstream authorship is credited here rather than in the copyright header. J. Xu is
 acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
@@ -108,16 +116,3 @@ theorem isEllipticNet_normEDS (b c d : R) : IsEllipticNet (normEDS b c d) := by
 /-- **A normalised EDS is an elliptic sequence**, the last index of the net held at `0`. -/
 theorem isEllipticSequence_normEDS (b c d : R) : IsEllipticSequence (normEDS b c d) :=
   (isEllipticNet_normEDS b c d).isEllipticSequence
-
-/-- **The invariant of a normalised EDS is symmetric in its two indices.** This is what the
-elliptic-net structure buys for `normEDS`: `IsEllipticNet.invarNum_mul_invarDenom` needs the full
-four-index relation, which `isEllipticNet_normEDS` now supplies unconditionally, so the cross
-identity holds for every `b`, `c`, `d` over any commutative ring.
-
-It is the entry point to the invariant and denominator layer — `invar₂`, `redInvar` and the
-reduced denominator are read off it — and the reason this file proves the net rather than
-stopping at the sequence. -/
-theorem IsEllipticNet.invarNum_mul_invarDenom_normEDS (b c d : R) (s m n : ℤ) :
-    invarNum (normEDS b c d) s m * invarDenom (normEDS b c d) s n =
-      invarNum (normEDS b c d) s n * invarDenom (normEDS b c d) s m :=
-  invarNum_mul_invarDenom (isEllipticNet_normEDS b c d) s m n

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -79,9 +79,9 @@ an author of the declarations above.
 The net strengthening here adapts one further declaration of that same file, `net_normEDS`.
 
 The source proves the hypothesis-carrying version from its own descent development; here that step
-is `Descent.lean`'s `IsEllipticNet.isEllipticNet_of_rel`, fed the two recurrences in relator form,
-so the helper is six lines rather than a file. The universal transport is the source's argument,
-with `normEDS_eq_aeval` in place of its inline rewriting.
+is `Descent.lean`'s `IsEllipticNet.of_rel`, fed the two recurrences in relator form, so the helper
+is six lines rather than a file. The universal transport is the source's argument, with
+`normEDS_eq_aeval` in place of its inline rewriting.
 -/
 
 public section
@@ -94,11 +94,11 @@ variable {R : Type*} [CommRing R] {b c d : R}
 /-- **A normalised EDS is an elliptic net, given that `b` is a nonzerodivisor.** Superseded by
 `isEllipticNet_normEDS`, which carries no hypothesis; this is the form that transports.
 
-The two recurrences are supplied in relator form, which is what `isEllipticNet_of_rel` consumes;
+The two recurrences are supplied in relator form, which is what `IsEllipticNet.of_rel` consumes;
 `rel_odd` and `rel_even` turn each into the equation `normEDS_odd` and `normEDS_even` state. -/
 private theorem isEllipticNet_normEDS_of_mem (hb : b ∈ R⁰) :
     IsEllipticNet (normEDS b c d) := by
-  refine IsEllipticNet.isEllipticNet_of_rel (fun k ↦ normEDS_neg b c d k) (normEDS_zero b c d)
+  refine IsEllipticNet.of_rel (fun k ↦ normEDS_neg b c d k) (normEDS_zero b c d)
     (by simp [normEDS_one]) (by simpa [normEDS_two] using hb) (fun m _ ↦ ?_) fun m _ ↦ ?_
   · rw [IsEllipticNet.rel_odd]
     simp only [normEDS_one, one_pow, mul_one]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -42,6 +42,13 @@ distinction where the identity is proved.
 The first consumer this unlocks is `IsEllipticNet.invarNum_mul_invarDenom`, which is applied to
 `isEllipticNet_normEDS` directly rather than restated here.
 
+The `s = 0` case is kept as a named theorem rather than left to `.isEllipticSequence` at each
+use: `IsEllipticSequence` is the predicate Mathlib defines, `IsEllipticDvdSequence` is
+`IsEllipticSequence ∧ IsDvdSequence`, and so this is the term discharging the first conjunct of
+the TODO cited above. Three files already name it as the fact they rest on —
+`Universal.lean`, `ReducedInvariant.lean` and
+`AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean`.
+
 ## Implementation notes
 
 The direct argument needs `normEDS b c d 2 = b` to be a nonzerodivisor, which is a genuine
@@ -100,9 +107,8 @@ private theorem isEllipticNet_normEDS_of_mem (hb : b ∈ R⁰) :
     simp only [normEDS_one, normEDS_two, one_pow, mul_one]
     linear_combination normEDS_even b c d m
 
-/-- **A normalised EDS is an elliptic net.** No hypothesis on `b`, `c`, `d`: the statement is
-proved over `ℤ[B, C, D]`, where the second term is the indeterminate `X B` and so a nonzerodivisor,
-and transported along `aeval` to an arbitrary commutative ring. -/
+/-- **A normalised EDS is an elliptic net**, for arbitrary `b`, `c`, `d` over any commutative
+ring. In particular no nonzerodivisor hypothesis is needed on the parameters. -/
 theorem isEllipticNet_normEDS (b c d : R) : IsEllipticNet (normEDS b c d) := by
   -- Supply the defining equation rather than leaving it to `isDefEq`: `universalNormEDS`'s body
   -- is not exposed, so unification cannot cheaply see it as `normEDS (X B) (X C) (X D)`.

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -60,15 +60,15 @@ waiting on, not the slice that lands them.
 ## Provenance
 
 Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
-`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations
-`IsEllSequence.normEDS_of_mem_nonZeroDivisors`, `IsEllSequence.normEDS`, `net_normEDS` and
-`IsEllSequence.invar`. That file's header
-reads `Authors: David Kurniadi Angdinata`; following this repository's convention for adapted
-material the upstream authorship is credited here rather than in the copyright header. J. Xu is
-acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That
+file's header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
+adapted material the upstream authorship is credited here rather than in the copyright header. J.
+Xu is acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
 co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
 an author of the declarations above.
+
+The net strengthening here adapts one further declaration of that same file, `net_normEDS`.
 
 The source proves the hypothesis-carrying version from its own descent development; here that step
 is `Descent.lean`'s `IsEllipticNet.isEllipticNet_of_rel`, fed the two recurrences in relator form,

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -5,25 +5,33 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Descent
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Invariant
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Universal
 
 /-!
-# A normalised EDS is an elliptic sequence
+# A normalised EDS is an elliptic net
 
 `normEDS b c d` is defined by the doubling recursion, so it satisfies that recursion by
-construction. This file draws the consequence: it satisfies the full three-index elliptic
-relation, for arbitrary `b`, `c`, `d` in any commutative ring.
+construction. This file draws the consequence: it satisfies the full **four**-index elliptic
+relation, for arbitrary `b`, `c`, `d` in any commutative ring. Being an elliptic *sequence* is
+the last index held at `0`.
 
-This is the first half of the TODO Mathlib records at
+The three-index statement is the first half of the TODO Mathlib records at
 `Mathlib/NumberTheory/EllipticDivisibilitySequence.lean:70`, "prove that `normEDS` satisfies
 `IsEllipticDvdSequence`". That predicate is `IsEllipticSequence ∧ IsDvdSequence`; the second
 conjunct needs a general `normEDS_mul_complEDS`, of which Mathlib has only the `k = 2` case, and
 is left to its own slice.
 
+The net is what the invariant layer needs. `IsEllipticNet.invarNum_mul_invarDenom` takes an
+`IsEllipticNet` hypothesis — the cross identity is proved from the relation at four free indices,
+not three — so stopping at the sequence would leave that consumer unusable for `normEDS`.
+
 ## Main results
 
-* `isEllipticSequence_normEDS`: `IsEllipticSequence (normEDS b c d)`, with no hypothesis on the
-  parameters.
+* `isEllipticNet_normEDS`: `IsEllipticNet (normEDS b c d)`, with no hypothesis on the parameters.
+* `isEllipticSequence_normEDS`: its `s = 0` case.
+* `IsEllipticNet.invarNum_mul_invarDenom_normEDS`: the invariant of `normEDS` is symmetric in its
+  two indices — the first consumer the net unlocks.
 
 ## Implementation notes
 
@@ -63,27 +71,52 @@ open MvPolynomial NormEDSParam
 
 variable {R : Type*} [CommRing R] {b c d : R}
 
-/-- **A normalised EDS is an elliptic sequence, given that `b` is a nonzerodivisor.** Superseded
-by `isEllipticSequence_normEDS`, which carries no hypothesis; this is the form that transports. -/
-private theorem isEllipticSequence_normEDS_of_mem (hb : b ∈ R⁰) :
-    IsEllipticSequence (normEDS b c d) := by
-  refine (isEllipticSequence_iff (fun k ↦ normEDS_neg b c d k) (normEDS_zero b c d)
-    (by simp [normEDS_one]) (by simpa [normEDS_two] using hb)).mpr ⟨fun m _ ↦ ?_, fun m _ ↦ ?_⟩
-  · simpa [normEDS_one] using normEDS_odd b c d m
+/-- **A normalised EDS is an elliptic net, given that `b` is a nonzerodivisor.** Superseded by
+`isEllipticNet_normEDS`, which carries no hypothesis; this is the form that transports.
+
+The two recurrences are supplied in relator form, which is what `isEllipticNet_of_rel` consumes;
+`rel_odd` and `rel_even` turn each into the equation `normEDS_odd` and `normEDS_even` state. -/
+private theorem isEllipticNet_normEDS_of_mem (hb : b ∈ R⁰) :
+    IsEllipticNet (normEDS b c d) := by
+  refine IsEllipticNet.isEllipticNet_of_rel (fun k ↦ normEDS_neg b c d k) (normEDS_zero b c d)
+    (by simp [normEDS_one]) (by simpa [normEDS_two] using hb) (fun m _ ↦ ?_) fun m _ ↦ ?_
+  · rw [IsEllipticNet.rel_odd]
+    simp only [normEDS_one, one_pow, mul_one]
+    linear_combination normEDS_odd b c d m
   -- `linear_combination` needs `normEDS _ _ _ 2` and `… 1` as `b` and `1` before it can match.
-  · simp only [normEDS_one, normEDS_two, one_pow, mul_one]
+  · rw [IsEllipticNet.rel_even]
+    simp only [normEDS_one, normEDS_two, one_pow, mul_one]
     linear_combination normEDS_even b c d m
 
-/-- **A normalised EDS is an elliptic sequence.** No hypothesis on `b`, `c`, `d`. -/
-theorem isEllipticSequence_normEDS (b c d : R) : IsEllipticSequence (normEDS b c d) := by
+/-- **A normalised EDS is an elliptic net.** No hypothesis on `b`, `c`, `d`: the statement is
+proved over `ℤ[B, C, D]`, where the second term is the indeterminate `X B` and so a nonzerodivisor,
+and transported along `aeval` to an arbitrary commutative ring. -/
+theorem isEllipticNet_normEDS (b c d : R) : IsEllipticNet (normEDS b c d) := by
   -- Supply the defining equation rather than leaving it to `isDefEq`: `universalNormEDS`'s body
   -- is not exposed, so unification cannot cheaply see it as `normEDS (X B) (X C) (X D)`.
-  have huniv : IsEllipticSequence (universalNormEDS : ℤ → MvPolynomial NormEDSParam ℤ) := by
+  have huniv : IsEllipticNet (universalNormEDS : ℤ → MvPolynomial NormEDSParam ℤ) := by
     have hfun : (universalNormEDS : ℤ → MvPolynomial NormEDSParam ℤ)
         = normEDS (X B) (X C) (X D) := funext universalNormEDS_apply
     rw [hfun]
-    exact isEllipticSequence_normEDS_of_mem (mem_nonZeroDivisors_of_ne_zero (X_ne_zero B))
-  intro p q r
+    exact isEllipticNet_normEDS_of_mem (mem_nonZeroDivisors_of_ne_zero (X_ne_zero B))
+  intro p q r s
   -- `map_rel` is stated for `f ∘ W`, `normEDS_eq_aeval` for the eta-expanded lambda.
   rw [normEDS_eq_aeval (b := b) (c := c) (d := d), ← Function.comp_def,
     ← IsEllipticNet.map_rel, huniv, map_zero]
+
+/-- **A normalised EDS is an elliptic sequence**, the last index of the net held at `0`. -/
+theorem isEllipticSequence_normEDS (b c d : R) : IsEllipticSequence (normEDS b c d) :=
+  fun p q r ↦ isEllipticNet_normEDS b c d p q r 0
+
+/-- **The invariant of a normalised EDS is symmetric in its two indices.** This is what the
+elliptic-net structure buys for `normEDS`: `IsEllipticNet.invarNum_mul_invarDenom` needs the full
+four-index relation, which `isEllipticNet_normEDS` now supplies unconditionally, so the cross
+identity holds for every `b`, `c`, `d` over any commutative ring.
+
+It is the entry point to the invariant and denominator layer — `invar₂`, `redInvar` and the
+reduced denominator are read off it — and the reason this file proves the net rather than
+stopping at the sequence. -/
+theorem IsEllipticNet.invarNum_mul_invarDenom_normEDS (b c d : R) (s m n : ℤ) :
+    invarNum (normEDS b c d) s m * invarDenom (normEDS b c d) s n =
+      invarNum (normEDS b c d) s n * invarDenom (normEDS b c d) s m :=
+  invarNum_mul_invarDenom (isEllipticNet_normEDS b c d) s m n


### PR DESCRIPTION
`normEDS b c d` satisfies the **four**-index elliptic-net relation, for arbitrary parameters over
any commutative ring.

```lean
theorem isEllipticNet_normEDS (b c d : R) : IsEllipticNet (normEDS b c d)
```

#3270 proved the three-index case. That is not enough for the invariant layer:
`IsEllipticNet.invarNum_mul_invarDenom` takes an `IsEllipticNet` hypothesis, because its
cross-multiplication identity is derived from the relation at four *free* indices. So the consumer
sitting in `Invariant.lean` could not be applied to `normEDS` at all. Now it can — callers write

```lean
IsEllipticNet.invarNum_mul_invarDenom (isEllipticNet_normEDS b c d) s m n
```

directly. An earlier draft of this PR added that specialisation as a named theorem;
`reuse` was right that it duplicated the general lemma's API and forced an otherwise unnecessary
public import of `Invariant`, so it is gone and the application is shown here instead.

Note what the identity is and is not: it says `invarNum W s m * invarDenom W s n` equals
`invarNum W s n * invarDenom W s m`, which is **weaker** than index-independence of an invariant
ratio — that needs the denominators invertible and fails over a general commutative ring.
`Invariant.lean` draws the distinction where the lemma is proved, and an earlier draft of this PR
blurred it by calling the identity "symmetry of the invariant"; `documentation` caught that.

## Why the net is harder than the sequence, and what it cost

Mathlib's `rel_eq` writes `rel W p q r s` as the relator at `(2p + s, 2q + s, 2r + s, s)` — four
indices all congruent to `s` mod 2, with `s` **free**. The sequence is the case `s = 0`, where the
last index is both fixed and minimal.

#3226 exploited exactly that. Its docstring said, twice, that only the first three indices are
ever permuted "the last being held at `0`", and that the source's `Tuple.sort` argument over four
indices "reduces to six orderings of three". True for the sequence; false for the net, which has
no distinguished index. So this PR restores the general permutation argument:

* `atomRelFin4_eq_zero_of_injective` — sorts all four via `Tuple.sort` composed with the reversal,
  with `SignEquivariance.lean`'s `atomRelFin4_perm` supplying the sign. Monotone-plus-injective is
  upgraded to strict by `Monotone.strictMono_of_injective`, and the sign cancels by
  `smul_eq_zero_iff_eq`; an earlier draft hand-rolled both, which `reuse` caught.
* `atomRel_eq_zero_of_parity` — the reduction at *any* same-parity quadruple: sign equivariance
  makes all four nonnegative, each of the six coincidences is one of Mathlib's `atomRel_same`
  lemmas, and the pairwise-distinct case is sorted.

Both docstring sentences are corrected here, since the deletion below makes them false.

## What this deletes

Making `IsEllipticNet.of_rel` the entry point removes the last call site of the three-index
reduction:

* `atomRel_eq_zero_of_nonneg` — three nonnegative even indices against `0`
* `atomRel_eq_zero_of_ne` — its six-orderings sort, built from the adjacent transpositions
* `abs_two_mul_emod_two` — a parity helper used only by those

All three are deleted, each verified to have no remaining reference rather than removed on
inspection. `isEllipticSequence_normEDS_of_mem` goes the same way in `NormEDS.lean`, superseded by
the net helper. Tau Ceti keeps no obsolete surface, so they go in this PR rather than a follow-up.

`isEllipticSequence_of_rel` goes the same way, on `reuse`'s finding: once `IsEllipticNet.of_rel`
exists, it restated it in the relator spelling this file uses internally, and nothing referred to
it.

Net effect on the public API: `isEllipticNet_iff`, `IsEllipticNet.of_rel` and
`isEllipticNet_normEDS` are added; `isEllipticSequence_iff` and `isEllipticSequence_normEDS` keep
their statements exactly and become one-line corollaries; `isEllipticSequence_of_rel` is removed.

### Why the other two sequence-level statements are kept

`reuse` asked for all three to go, as wrappers around the net versions. Two are load-bearing:

* `isEllipticSequence_normEDS` — `IsEllipticSequence` is the predicate **Mathlib** defines, and
  `IsEllipticDvdSequence` is `IsEllipticSequence ∧ IsDvdSequence`, so this is the term that
  discharges the first conjunct of the TODO this file cites. Three merged files across two
  directories already name it as the fact they rest on: `Universal.lean:92`,
  `ReducedInvariant.lean:50` and
  `AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean:59`. Deleting it would
  falsify three docstrings in files this PR does not touch.
* `isEllipticSequence_iff` — the classical three-index theorem, and `Descent.lean`'s pre-existing
  headline. It is the only named form of that statement; the net version is about a different
  predicate.

Both pre-date this PR on `main`, which only demotes their proofs to corollaries while leaving
their statements byte-identical. The one whose *only* purpose had become restating a net lemma is
the one deleted.

## The equivalence, not just the implication

`Descent.lean` advertised `isEllipticSequence_iff` as its headline — an equivalence at three
indices — so adding only the one-way `IsEllipticNet.of_rel` left the file stating strictly less
about the stronger predicate than about the weaker one. `api-design` caught that asymmetry, and
`isEllipticNet_iff` closes it: under the same hypotheses the **four**-index relation at every
quadruple is equivalent to the same two one-parameter families of equations.
`isEllipticSequence_iff` keeps its exact statement and is now proved from it.

A consequence worth stating, since it bears on why this PR is not circular: under those hypotheses
`IsEllipticNet W` and `IsEllipticSequence W` are the *same* condition. They are not the same
condition for `normEDS b c d` at arbitrary parameters, where `W 2 = b` need not be a
nonzerodivisor — which is exactly why `NormEDS.lean` reaches the net by transporting from the
universal ring rather than through this equivalence.

## What is reused rather than rewritten

The parity hypothesis has to survive the reduction to absolute values, and **`omega` cannot see
through `|·|` at all**. An earlier draft of this PR proved a three-line `abs_emod_two` for that;
`reuse` pointed out it duplicates Mathlib's `Int.abs_modEq_two`, which `Transfer.lean` in this
very directory already uses for exactly this. Deleted, and the Mathlib lemma used instead.

Likewise both net-to-sequence corollaries now go through Mathlib's `IsEllipticNet.isEllipticSequence`
rather than repeating its `fun p q r ↦ h p q r 0`.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, the **Layer 6** torsion/Nagell–Lutz strand. The
earliest milestone this feeds is the invariant and denominator layer — `invar₂`, `redInvar` and
`redInvarDenom` are all read off the cross identity proved here — not `lutz_nagell` itself, which
sits several layers further on behind `ω` and `ZSMul`.

## Provenance

Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0 per file header, `main` at
`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `IsEllSequence.rel₄`,
`IsEllSequence.net` and `net_normEDS`, each named in the provenance block of the file that follows
it. Those blocks name the new declarations in a sentence appended to the existing paragraph rather
than by reflowing it, so #3297's merged attribution wording stays byte-identical and out of this
diff. `IsEllSequence.invar` was cited by an earlier draft and is no longer, the invariant
specialisation it backed having been deleted on `reuse`'s finding. That file's header reads
`Authors: David Kurniadi Angdinata`. J. Xu is acknowledged for the surrounding LutzNagell
development — he authors `Universal.lean` and co-authors `DivisionPolynomialOmega.lean` at the
same revision — as context for this port, not as an author of the declarations above. #3297
corrects the same attribution across the ten existing files in this directory.

The source's `rel₄` sorts four indices with `relFin4_perm`; here that is
`SignEquivariance.lean`'s `atomRelFin4_perm`, already in this repository.

## Gates

`lake build` PASS at 7886 jobs, rebased onto current `main`. No `sorry`; no line over 100
codepoints, measured in codepoints rather than bytes.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-net-normeds"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
