### PR TITLE
refactor(Fredholm): name the absorption step of the local-properness proof

### DIFF
--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -65,6 +65,31 @@ variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpac
   [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
 variable {f : E → F} {f' : E →L[𝕜] F} {a : E}
 
+omit [ProperSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- **A linear lower bound survives a good enough nonlinear approximation.** Suppose every vector
+is controlled by its image under `f'` together with a projection `P`, as `‖z‖ ≤ C * ‖f' z‖ + ‖P z‖`,
+and `f` approximates `f'` on `N` to within `(2 * C)⁻¹`. Then on `N` the same control holds for `f`
+in place of `f'`, at the cost of a factor two. -/
+private theorem norm_sub_le_of_approximatesLinearOn {P : E →L[𝕜] E} {C : ℝ} {N : Set E} {ε : ℝ≥0}
+    (hC : 0 < C) (hest : ∀ z, ‖z‖ ≤ C * ‖f' z‖ + ‖P z‖)
+    (happ : ApproximatesLinearOn f f' N ε) (hε : (ε : ℝ) = (2 * C)⁻¹)
+    {x : E} (hx : x ∈ N) {y : E} (hy : y ∈ N) :
+    ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
+  have h1 := hest (x - y)
+  have h2 := happ x hx y hy
+  have h3 : ‖f' (x - y)‖ ≤ ‖f x - f y‖ + (ε : ℝ) * ‖x - y‖ := by
+    have hrw : f' (x - y) = f x - f y - (f x - f y - f' (x - y)) := by abel
+    rw [hrw]
+    exact (norm_sub_le _ _).trans (by linarith)
+  have h4 : C * ‖f' (x - y)‖ ≤ C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖) :=
+    mul_le_mul_of_nonneg_left h3 hC.le
+  have h5 : C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖)
+      = C * ‖f x - f y‖ + 1 / 2 * ‖x - y‖ := by
+    rw [mul_add, ← mul_assoc, hε]
+    field_simp
+  rw [map_sub P x y] at h1
+  linarith
+
 /-- **Local properness of a map with upper semi-Fredholm derivative.** If `f` is strictly
 differentiable at `a` and its derivative there has closed range and finite-dimensional
 complemented kernel, then `f` is proper on a neighbourhood `N` of `a`: the part of the preimage of
@@ -94,22 +119,8 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
   have hcontOn : ContinuousOn f N := happN.continuousOn
   -- the two-sided bound on `N`
   have key : ∀ x ∈ N, ∀ y ∈ N,
-      ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
-    intro x hx y hy
-    have h1 := hest (x - y)
-    have h2 := happN x hx y hy
-    have h3 : ‖f' (x - y)‖ ≤ ‖f x - f y‖ + (ε : ℝ) * ‖x - y‖ := by
-      have hrw : f' (x - y) = f x - f y - (f x - f y - f' (x - y)) := by abel
-      rw [hrw]
-      exact (norm_sub_le _ _).trans (by linarith)
-    have h4 : C * ‖f' (x - y)‖ ≤ C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖) :=
-      mul_le_mul_of_nonneg_left h3 hC.le
-    have h5 : C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖)
-        = C * ‖f x - f y‖ + 1 / 2 * ‖x - y‖ := by
-      rw [mul_add, ← mul_assoc, hεcoe]
-      field_simp
-    rw [map_sub P x y] at h1
-    linarith
+      ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := fun _ hx _ hy =>
+    norm_sub_le_of_approximatesLinearOn hC hest happN hεcoe hx hy
   refine ⟨N, Metric.closedBall_mem_nhds a (by linarith), fun L hL => ?_⟩
   -- the compact box the projection lands in
   have hPmem : ∀ x, P x ∈ f'.ker := by

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -72,7 +72,7 @@ and `f` approximates `f'` on `N` to within `(2 * C)⁻¹`. Then on `N` the same 
 in place of `f'`, at the cost of a factor two. -/
 private theorem norm_sub_le_of_approximatesLinearOn {P : E →L[𝕜] E} {C : ℝ} {N : Set E} {ε : ℝ≥0}
     (hC : 0 < C) (hest : ∀ z, ‖z‖ ≤ C * ‖f' z‖ + ‖P z‖)
-    (happ : ApproximatesLinearOn f f' N ε) (hε : (ε : ℝ) = (2 * C)⁻¹)
+    (happ : ApproximatesLinearOn f f' N ε) (hε : (ε : ℝ) ≤ (2 * C)⁻¹)
     {x : E} (hx : x ∈ N) {y : E} (hy : y ∈ N) :
     ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
   have h1 := hest (x - y)
@@ -83,10 +83,13 @@ private theorem norm_sub_le_of_approximatesLinearOn {P : E →L[𝕜] E} {C : �
     exact (norm_sub_le _ _).trans (by linarith)
   have h4 : C * ‖f' (x - y)‖ ≤ C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖) :=
     mul_le_mul_of_nonneg_left h3 hC.le
+  have hCε : C * (ε : ℝ) ≤ 1 / 2 := by
+    have h := mul_le_mul_of_nonneg_left hε hC.le
+    rwa [show C * (2 * C)⁻¹ = 1 / 2 by field_simp] at h
   have h5 : C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖)
-      = C * ‖f x - f y‖ + 1 / 2 * ‖x - y‖ := by
-    rw [mul_add, ← mul_assoc, hε]
-    field_simp
+      ≤ C * ‖f x - f y‖ + 1 / 2 * ‖x - y‖ := by
+    have hnn : (0 : ℝ) ≤ ‖x - y‖ := norm_nonneg _
+    nlinarith
   rw [map_sub P x y] at h1
   linarith
 
@@ -120,7 +123,7 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
   -- the two-sided bound on `N`
   have key : ∀ x ∈ N, ∀ y ∈ N,
       ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := fun _ hx _ hy =>
-    norm_sub_le_of_approximatesLinearOn hC hest happN hεcoe hx hy
+    norm_sub_le_of_approximatesLinearOn hC hest happN hεcoe.le hx hy
   refine ⟨N, Metric.closedBall_mem_nhds a (by linarith), fun L hL => ?_⟩
   -- the compact box the projection lands in
   have hPmem : ∀ x, P x ∈ f'.ker := by

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -39,6 +39,8 @@ sends `N ∩ f ⁻¹' L` into a compact box; being anti-Lipschitz, it reflects t
 
 ## Main declarations
 
+* `TauCeti.one_sub_mul_norm_sub_le`: an a priori estimate survives a nonlinear
+  approximation, degraded by its quality — the absorption step behind Peetre's lemma.
 * `HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage`: local properness.
 * `HasStrictFDerivAt.exists_mem_nhds_isCompact_inter_preimage_singleton`: an arbitrary fibre is
   compact near the point of differentiation.
@@ -66,15 +68,18 @@ variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpac
 variable {f : E → F} {f' : E →L[𝕜] F} {a : E}
 
 omit [ProperSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
-/-- **A linear lower bound survives a nonlinear approximation, degraded by its quality.** Suppose
-every vector is controlled by its image under `f'` together with a projection `P`, as
+/-- **An a priori estimate survives a nonlinear approximation, degraded by its quality.** Suppose
+every vector is controlled by its image under `f'` together with an auxiliary linear map `P`, as
 `‖z‖ ≤ C * ‖f' z‖ + ‖P z‖`, and `f` approximates `f'` on `N` to within `ε`. Then the same control
 holds for `f` on `N`, with the left side scaled by `1 - C * ε`; it has content exactly when
 `C * ε < 1`, and taking `ε ≤ (2 * C)⁻¹` gives the factor-two form the properness argument uses.
 
-This is the absorption step behind Peetre's lemma: a bound below modulo `P` is stable under a
-Lipschitz-small perturbation. -/
-private theorem one_sub_mul_norm_sub_le {P : E →L[𝕜] E} {C : ℝ} {N : Set E} {ε : ℝ≥0}
+`P` is only required to be linear: neither idempotence nor any constraint on its target is used.
+Taking it to be the projection onto `ker f'` from
+`ContinuousLinearMap.exists_projection_norm_le` recovers the Peetre estimate, which characterises
+semi-Fredholm operators — see Wendl, *Fredholm operators*, Lemma 5.2. -/
+theorem one_sub_mul_norm_sub_le {G : Type*} [NormedAddCommGroup G] [Module 𝕜 G]
+    {P : E →ₗ[𝕜] G} {C : ℝ} {N : Set E} {ε : ℝ≥0}
     (hC : 0 ≤ C) (hest : ∀ z, ‖z‖ ≤ C * ‖f' z‖ + ‖P z‖)
     (happ : ApproximatesLinearOn f f' N ε) {x : E} (hx : x ∈ N) {y : E} (hy : y ∈ N) :
     (1 - C * (ε : ℝ)) * ‖x - y‖ ≤ C * ‖f x - f y‖ + ‖P x - P y‖ := by
@@ -121,8 +126,9 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
   have key : ∀ x ∈ N, ∀ y ∈ N,
       ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
     intro x hx y hy
-    have h := one_sub_mul_norm_sub_le hC.le hest happN hx hy
+    have h := one_sub_mul_norm_sub_le (P := (P : E →ₗ[𝕜] E)) hC.le hest happN hx hy
     rw [hCε] at h
+    simp only [ContinuousLinearMap.coe_coe] at h
     linarith
   refine ⟨N, Metric.closedBall_mem_nhds a (by linarith), fun L hL => ?_⟩
   -- the compact box the projection lands in

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -66,15 +66,19 @@ variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpac
 variable {f : E → F} {f' : E →L[𝕜] F} {a : E}
 
 omit [ProperSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
-/-- **A linear lower bound survives a good enough nonlinear approximation.** Suppose every vector
-is controlled by its image under `f'` together with a projection `P`, as `‖z‖ ≤ C * ‖f' z‖ + ‖P z‖`,
-and `f` approximates `f'` on `N` to within `(2 * C)⁻¹`. Then on `N` the same control holds for `f`
-in place of `f'`, at the cost of a factor two. -/
+/-- **A linear lower bound survives a nonlinear approximation, degraded by its quality.** Suppose
+every vector is controlled by its image under `f'` together with a projection `P`, as
+`‖z‖ ≤ C * ‖f' z‖ + ‖P z‖`, and `f` approximates `f'` on `N` to within `ε`. Then the same control
+holds for `f` on `N`, with the left side scaled by `1 - C * ε`; it has content exactly when
+`C * ε < 1`, and taking `ε ≤ (2 * C)⁻¹` gives the factor-two form the properness argument uses.
+
+This is the absorption step behind Peetre's lemma: a bound below modulo `P` is stable under a
+Lipschitz-small perturbation. -/
 private theorem norm_sub_le_of_approximatesLinearOn {P : E →L[𝕜] E} {C : ℝ} {N : Set E} {ε : ℝ≥0}
-    (hC : 0 < C) (hest : ∀ z, ‖z‖ ≤ C * ‖f' z‖ + ‖P z‖)
-    (happ : ApproximatesLinearOn f f' N ε) (hε : (ε : ℝ) ≤ (2 * C)⁻¹)
+    (hC : 0 ≤ C) (hest : ∀ z, ‖z‖ ≤ C * ‖f' z‖ + ‖P z‖)
+    (happ : ApproximatesLinearOn f f' N ε)
     {x : E} (hx : x ∈ N) {y : E} (hy : y ∈ N) :
-    ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
+    (1 - C * (ε : ℝ)) * ‖x - y‖ ≤ C * ‖f x - f y‖ + ‖P x - P y‖ := by
   have h1 := hest (x - y)
   have h2 := happ x hx y hy
   have h3 : ‖f' (x - y)‖ ≤ ‖f x - f y‖ + (ε : ℝ) * ‖x - y‖ := by
@@ -82,16 +86,9 @@ private theorem norm_sub_le_of_approximatesLinearOn {P : E →L[𝕜] E} {C : �
     rw [hrw]
     exact (norm_sub_le _ _).trans (by linarith)
   have h4 : C * ‖f' (x - y)‖ ≤ C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖) :=
-    mul_le_mul_of_nonneg_left h3 hC.le
-  have hCε : C * (ε : ℝ) ≤ 1 / 2 := by
-    have h := mul_le_mul_of_nonneg_left hε hC.le
-    rwa [show C * (2 * C)⁻¹ = 1 / 2 by field_simp] at h
-  have h5 : C * (‖f x - f y‖ + (ε : ℝ) * ‖x - y‖)
-      ≤ C * ‖f x - f y‖ + 1 / 2 * ‖x - y‖ := by
-    have hnn : (0 : ℝ) ≤ ‖x - y‖ := norm_nonneg _
-    nlinarith
+    mul_le_mul_of_nonneg_left h3 hC
   rw [map_sub P x y] at h1
-  linarith
+  nlinarith
 
 /-- **Local properness of a map with upper semi-Fredholm derivative.** If `f` is strictly
 differentiable at `a` and its derivative there has closed range and finite-dimensional
@@ -121,9 +118,13 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
   have happN : ApproximatesLinearOn f f' N ε := happ.mono_set hNs
   have hcontOn : ContinuousOn f N := happN.continuousOn
   -- the two-sided bound on `N`
+  have hCε : C * (ε : ℝ) = 1 / 2 := by rw [hεcoe]; field_simp
   have key : ∀ x ∈ N, ∀ y ∈ N,
-      ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := fun _ hx _ hy =>
-    norm_sub_le_of_approximatesLinearOn hC hest happN hεcoe.le hx hy
+      ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
+    intro x hx y hy
+    have h := norm_sub_le_of_approximatesLinearOn hC.le hest happN hx hy
+    rw [hCε] at h
+    linarith
   refine ⟨N, Metric.closedBall_mem_nhds a (by linarith), fun L hL => ?_⟩
   -- the compact box the projection lands in
   have hPmem : ∀ x, P x ∈ f'.ker := by

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -74,10 +74,9 @@ holds for `f` on `N`, with the left side scaled by `1 - C * ε`; it has content 
 
 This is the absorption step behind Peetre's lemma: a bound below modulo `P` is stable under a
 Lipschitz-small perturbation. -/
-private theorem norm_sub_le_of_approximatesLinearOn {P : E →L[𝕜] E} {C : ℝ} {N : Set E} {ε : ℝ≥0}
+private theorem one_sub_mul_norm_sub_le {P : E →L[𝕜] E} {C : ℝ} {N : Set E} {ε : ℝ≥0}
     (hC : 0 ≤ C) (hest : ∀ z, ‖z‖ ≤ C * ‖f' z‖ + ‖P z‖)
-    (happ : ApproximatesLinearOn f f' N ε)
-    {x : E} (hx : x ∈ N) {y : E} (hy : y ∈ N) :
+    (happ : ApproximatesLinearOn f f' N ε) {x : E} (hx : x ∈ N) {y : E} (hy : y ∈ N) :
     (1 - C * (ε : ℝ)) * ‖x - y‖ ≤ C * ‖f x - f y‖ + ‖P x - P y‖ := by
   have h1 := hest (x - y)
   have h2 := happ x hx y hy
@@ -122,7 +121,7 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
   have key : ∀ x ∈ N, ∀ y ∈ N,
       ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
     intro x hx y hy
-    have h := norm_sub_le_of_approximatesLinearOn hC.le hest happN hx hy
+    have h := one_sub_mul_norm_sub_le hC.le hest happN hx hy
     rw [hCε] at h
     linarith
   refine ⟨N, Metric.closedBall_mem_nhds a (by linarith), fun L hL => ?_⟩

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -69,17 +69,18 @@ variable {f : E → F} {f' : E →L[𝕜] F} {a : E}
 
 omit [ProperSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- **An a priori estimate survives a nonlinear approximation, degraded by its quality.** Suppose
-every vector is controlled by its image under `f'` together with an auxiliary linear map `P`, as
-`‖z‖ ≤ C * ‖f' z‖ + ‖P z‖`, and `f` approximates `f'` on `N` to within `ε`. Then the same control
-holds for `f` on `N`, with the left side scaled by `1 - C * ε`; it has content exactly when
-`C * ε < 1`, and taking `ε ≤ (2 * C)⁻¹` gives the factor-two form the properness argument uses.
+every vector is controlled by its image under `f'` together with an auxiliary additive map `P`,
+as `‖z‖ ≤ C * ‖f' z‖ + ‖P z‖`, and `f` approximates `f'` on `N` to within `ε`. Then the same
+control holds for `f` on `N`, with the left side scaled by `1 - C * ε`; it has content exactly
+when `C * ε < 1`, and taking `ε ≤ (2 * C)⁻¹` gives the factor-two form properness uses.
 
-`P` is only required to be linear: neither idempotence nor any constraint on its target is used.
-Taking it to be the projection onto `ker f'` from
-`ContinuousLinearMap.exists_projection_norm_le` recovers the Peetre estimate, which characterises
-semi-Fredholm operators — see Wendl, *Fredholm operators*, Lemma 5.2. -/
-theorem one_sub_mul_norm_sub_le {G : Type*} [NormedAddCommGroup G] [Module 𝕜 G]
-    {P : E →ₗ[𝕜] G} {C : ℝ} {N : Set E} {ε : ℝ≥0}
+Nothing about `P` beyond `map_sub` enters, so it need only be additive into a seminormed additive
+group — no scalar-linearity, no idempotence, no constraint on its target. Taking it to be the
+projection onto `ker f'` from `ContinuousLinearMap.exists_projection_norm_le` recovers the Peetre
+estimate, which characterises semi-Fredholm operators — see Wendl, *Fredholm operators*,
+Lemma 5.2. -/
+theorem one_sub_mul_norm_sub_le {G : Type*} [SeminormedAddGroup G]
+    {P : E →+ G} {C : ℝ} {N : Set E} {ε : ℝ≥0}
     (hC : 0 ≤ C) (hest : ∀ z, ‖z‖ ≤ C * ‖f' z‖ + ‖P z‖)
     (happ : ApproximatesLinearOn f f' N ε) {x : E} (hx : x ∈ N) {y : E} (hy : y ∈ N) :
     (1 - C * (ε : ℝ)) * ‖x - y‖ ≤ C * ‖f x - f y‖ + ‖P x - P y‖ := by
@@ -126,9 +127,9 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
   have key : ∀ x ∈ N, ∀ y ∈ N,
       ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
     intro x hx y hy
-    have h := one_sub_mul_norm_sub_le (P := (P : E →ₗ[𝕜] E)) hC.le hest happN hx hy
+    have h := one_sub_mul_norm_sub_le (P := P.toLinearMap.toAddMonoidHom) hC.le hest happN hx hy
     rw [hCε] at h
-    simp only [ContinuousLinearMap.coe_coe] at h
+    simp only [LinearMap.toAddMonoidHom_coe, ContinuousLinearMap.coe_coe] at h
     linarith
   refine ⟨N, Metric.closedBall_mem_nhds a (by linarith), fun L hL => ?_⟩
   -- the compact box the projection lands in


### PR DESCRIPTION
`HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage` — Smale's local-properness
lemma — ran to 91 lines. Its middle phase was a self-contained inequality with no properness
content at all.

## The extraction

**`one_sub_mul_norm_sub_le`.** A lower bound holding modulo an auxiliary linear map survives a
nonlinear perturbation, degraded by the perturbation's quality:

`(1 - C * ε) * ‖x - y‖ ≤ C * ‖f x - f y‖ + ‖P x - P y‖`

given `‖z‖ ≤ C * ‖f' z‖ + ‖P z‖` and `ApproximatesLinearOn f f' N ε`. This is the absorption step
behind **Peetre's lemma**.

It needs none of the ambient analytic structure: the `unusedSectionVars` linter failed the build
naming `[ProperSpace 𝕜]`, `[CompleteSpace E]` and `[CompleteSpace F]`, all three in scope in the
parent and none used. It is a pure inequality.

## What the required passes changed

I first wrote this with `ε` pinned to exactly `(2 * C)⁻¹`, then weakened it to `≤`. Both were
wrong. `/mathlibable` found the literature-standard form carries **no smallness hypothesis at
all** — the `(1 - C * ε)` factor is the honest statement, holding for every `ε`, with smallness
needed only to divide. So `hε` is gone entirely and `0 < C` weakened to `0 ≤ C`; the caller now
does the division. Sharpness is checked: at `C * ε = 1` the bound is vacuous, and
`E = F = ℝ, f' = C⁻¹ • id, P = 0, f = 0` admits no bound there.

Sources located for the statement: Wendl, *Fredholm operators*, Lemma 5.2 (the hypothesis is a
Peetre estimate); McDuff–Salamon Cor. A.1.2(ii) carries the linear prototype with the same
`1 - c‖A‖` denominator. Neither states the nonlinear two-point form as a named result.

**Not in mathlib**, in either the sharp or the factor-two shape — five search methods, an
untruncated grep, and a compiled `exact?` probe. Mathlib has no Peetre-estimate predicate, no
upper-semi-Fredholm API and no reduced minimum modulus. The obvious neighbour,
`ApproximatesLinearOn.antilipschitz`, does not apply: it takes `f'` as a continuous linear
**equiv** and uses `f'.symm`, whereas here `f'` has a kernel and the bound holds only modulo `P`.

`/cleanup` then caught that the restatement had left the name describing the old conclusion —
`norm_sub_le_of_…` for a statement whose left side is now `(1 - C * ε) * ‖x - y‖`. Renamed.

## Review round 1 (`de4a3986`)

**generality**, over two rounds. `P` was `E →L[𝕜] E`, but the proof uses neither continuity nor
the codomain — only `map_sub`. Round 1 took it to `P : E →ₗ[𝕜] G`; round 2 pointed out that
scalar-linearity is still unused, and it was right. `P : E →+ G` now, which lets the ambient on
`G` fall all the way to `[SeminormedAddGroup G]` — no `Module`, no `NormedSpace`, no
commutativity. The caller passes `P.toLinearMap.toAddMonoidHom`.

Each step of that descent was fixed by a *discriminating* probe rather than by eye: the weakened
form compiles **and** a must-fail control (dropping the ambient entirely) does fail, so the
green is not the vacuous kind.

**api-design.** Now public and listed under `## Main declarations`. I have *not* moved it to
`Estimate.lean` as the finding suggested in parentheses: the statement mentions
`ApproximatesLinearOn`, which `Estimate.lean` cannot see — it imports only
`Mathlib.Analysis.Normed.Operator.Banach` and `TauCeti.Analysis.Fredholm.Basic`. I tried the move
and it fails to elaborate. Making it public where it already lives gets the reuse the finding
asks for without pulling the inverse-function-theorem import into a file that is pure
Banach-space operator theory.

**documentation.** The docstring called `P` a projection although nothing constrains it; it now
says "auxiliary linear map" and records what is *not* assumed (no idempotence, no constraint on
the target).

**attribution.** Wendl, *Fredholm operators*, Lemma 5.2 is now cited in the docstring itself, not
only in this description.

## Result

| | before | after |
|---|---|---|
| `exists_mem_nhds_forall_isCompact_inter_preimage` | 91 | 82 |
| `one_sub_mul_norm_sub_le` | — | 10 |

The parent grows by four lines relative to the factor-two version, absorbing the `C * ε = 1/2`
step, and by one more for the coercion rewrite the generalisation costs at the call site. That is
the price of the helper stating the true inequality rather than the specialisation this one caller
happens to want.

Gates re-run on `67ab0dc7`: `lake build` (7885 jobs), `lake exe axioms` (46290 declarations),
`lake exe module-system` (2212 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`, 67 grandfathered).

Roadmap: HeegaardFloer
