### PR TITLE
feat(EDS): an elliptic sequence vanishes at zero and is odd

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Elementary.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Elementary.lean
@@ -24,10 +24,11 @@ apply exactly where a caller already has `IsEllipticSequence W` in hand.
 
 * `IsEllipticSequence.zero`: `W 0 = 0`, given that some even term is a nonzerodivisor.
 * `IsEllipticSequence.neg`: `W (-m) = -W m`, given that `W 1` and `W 2` are nonzerodivisors.
-* `IsEllipticSequence.odd`: the same, packaged as Mathlib's `Function.Odd`.
 
-Nothing else is exported. The symmetrisation the oddness proof turns on is a local `have` inside
-it rather than a theorem: it is a step of that argument, not a fact a caller wants.
+Nothing else is exported. `W.Odd` unfolds to `neg`'s statement, so consumers taking Mathlib's
+spelling — `SignEquivariance.lean` and `Descent.lean` — apply `neg` itself rather than a second
+declaration. The symmetrisation the oddness proof turns on is likewise a local `have`: a step of
+that argument, not a fact a caller wants.
 
 ## Implementation notes
 
@@ -72,10 +73,7 @@ namespace IsEllipticSequence
 
 variable {R : Type*} [CommRing R] {W : ℤ → R}
 
-/-- **An elliptic sequence vanishes at `0`**, given that some even term is a nonzerodivisor.
-
-At `(m, m, 2 * m)` the relator's two outer terms are equal and cancel, leaving
-`W 0 * W (2 * m) ^ 3`. -/
+/-- **An elliptic sequence vanishes at `0`**, given that some even term is a nonzerodivisor. -/
 protected theorem zero (h : IsEllipticSequence W) (m : ℤ) (mem : W (2 * m) ∈ R⁰) : W 0 = 0 := by
   have key : W 0 * W (2 * m) ^ 3 = 0 := by
     have := h m m (2 * m)
@@ -86,8 +84,7 @@ protected theorem zero (h : IsEllipticSequence W) (m : ℤ) (mem : W (2 * m) ∈
 
 /-- **An elliptic sequence is an odd function**, given that `W 1` and `W 2` are nonzerodivisors.
 
-Both terms are needed because the two parities divide by different quantities: the even case by
-`W 2 * W 1 ^ 2`, the odd case by `W 1 ^ 3`. -/
+`W.Odd` is this statement, so a caller wanting Mathlib's spelling applies this directly. -/
 protected theorem neg (h : IsEllipticSequence W) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰) (m : ℤ) :
     W (-m) = -W m := by
   -- Adding the relator to itself with the first two indices exchanged cancels its outer terms
@@ -108,10 +105,5 @@ protected theorem neg (h : IsEllipticSequence W) (one : W 1 ∈ R⁰) (two : W 2
   · have := key (-k) (k + 1) 1
     ring_nf at this ⊢
     exact (mul_mem one (pow_mem one 2)).2 _ (by linear_combination this)
-
-/-- **An elliptic sequence is odd**, in Mathlib's `Function.Odd` spelling — the form
-`SignEquivariance.lean` and `Descent.lean` take as a hypothesis. -/
-protected theorem odd (h : IsEllipticSequence W) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰) : W.Odd :=
-  fun m ↦ h.neg one two m
 
 end IsEllipticSequence

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Elementary.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Elementary.lean
@@ -26,6 +26,9 @@ apply exactly where a caller already has `IsEllipticSequence W` in hand.
 * `IsEllipticSequence.neg`: `W (-m) = -W m`, given that `W 1` and `W 2` are nonzerodivisors.
 * `IsEllipticSequence.odd`: the same, packaged as Mathlib's `Function.Odd`.
 
+Nothing else is exported. The symmetrisation the oddness proof turns on is a local `have` inside
+it rather than a theorem: it is a step of that argument, not a fact a caller wants.
+
 ## Implementation notes
 
 Each proof specialises the relator at indices chosen to make all but one term cancel, then
@@ -34,22 +37,27 @@ divides by the surviving nonzerodivisor.
 For `zero` the choice is `(m, m, 2 * m)`: the two outer terms of `rel` coincide and cancel, and
 the first collapses to `W 0 * W (2 * m) ^ 3`.
 
-For `neg` the relator is symmetrised first. Adding `rel W m n r 0` to `rel W n m r 0` cancels the
-two outer terms against each other and leaves `(W (m - n) + W (n - m)) * W (m + n) * W r ^ 2`,
-which is `sub_add_neg_sub_mul_eq_zero`. Choosing `(1 - k, k + 1, 1)` puts `2` in the middle slot
-and `-(2 * k)` in the first, and `(-k, k + 1, 1)` puts `1` and `-(2 * k + 1)` there; those are the
-even and odd cases, and they are why both `W 1` and `W 2` are needed.
+For `neg` the relator is symmetrised first. Adding `rel W p q r 0` to `rel W q p r 0` cancels the
+two outer terms against each other and leaves `(W (p - q) + W (q - p)) * W (p + q) * W r ^ 2`.
+Choosing `(1 - k, k + 1, 1)` puts `2` in the middle slot and `-(2 * k)` in the first, and
+`(-k, k + 1, 1)` puts `1` and `-(2 * k + 1)` there; those are the even and odd cases, and they are
+why both `W 1` and `W 2` are needed.
+
+The index arithmetic is left to `ring_nf` rather than to explicit rewrites. It has to happen
+*inside* `W`'s argument: `W` is opaque, so `linear_combination` cannot on its own see that
+`W (1 - k - (k + 1))` and `W (-(2 * k))` are the same term.
 
 ## Provenance
 
 Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
-declarations `IsEllSequence.zero`, `IsEllSequence.sub_add_neg_sub_mul_eq_zero` and
-`IsEllSequence.neg`. That file's header reads `Authors: David Kurniadi Angdinata`; following this
-repository's convention for adapted material the upstream authorship is credited here rather than
-in the copyright header. J. Xu is acknowledged for the surrounding LutzNagell development — he
-authors `Universal.lean` and co-authors `DivisionPolynomialOmega.lean` at the same revision — as
-context for this port, not as an author of the declarations above.
+declarations `IsEllSequence.zero`, `IsEllSequence.sub_add_neg_sub_mul_eq_zero` — inlined here as
+a local step of `neg` rather than exported — and `IsEllSequence.neg`. That file's header reads
+`Authors: David Kurniadi Angdinata`; following this repository's convention for adapted material
+the upstream authorship is credited here rather than in the copyright header. J. Xu is
+acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
+co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
+an author of the declarations above.
 
 The source also carries a `zero'` proved from `IsReduced R` rather than from a nonzerodivisor.
 It is not ported: `zero` below is what the development uses, and `IsReduced` is a hypothesis no
@@ -72,37 +80,33 @@ protected theorem zero (h : IsEllipticSequence W) (m : ℤ) (mem : W (2 * m) ∈
   have key : W 0 * W (2 * m) ^ 3 = 0 := by
     have := h m m (2 * m)
     rw [IsEllipticNet.rel] at this
-    simp only [add_zero] at this
-    rw [show m + m = 2 * m by ring, show m - m = (0 : ℤ) by ring] at this
+    ring_nf at this ⊢
     linear_combination this
   exact (pow_mem mem 3).2 _ key
 
-/-- **The symmetrised relator vanishes.** Adding `rel W m n r 0` to `rel W n m r 0` cancels the
-two outer terms against each other, leaving the first slot's contribution from each. -/
-theorem sub_add_neg_sub_mul_eq_zero (h : IsEllipticSequence W) (m n r : ℤ) :
-    (W (m - n) + W (n - m)) * W (m + n) * W r ^ 2 = 0 := by
-  have hmn := h m n r
-  have hnm := h n m r
-  rw [IsEllipticNet.rel] at hmn hnm
-  simp only [add_zero] at hmn hnm
-  rw [show n + m = m + n by ring] at hnm
-  linear_combination hmn + hnm
-
 /-- **An elliptic sequence is an odd function**, given that `W 1` and `W 2` are nonzerodivisors.
 
-The two parities use different slots of `sub_add_neg_sub_mul_eq_zero`, which is why both terms
-are needed: the even case divides by `W 2 * W 1 ^ 2`, the odd case by `W 1 ^ 3`. -/
+Both terms are needed because the two parities divide by different quantities: the even case by
+`W 2 * W 1 ^ 2`, the odd case by `W 1 ^ 3`. -/
 protected theorem neg (h : IsEllipticSequence W) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰) (m : ℤ) :
     W (-m) = -W m := by
+  -- Adding the relator to itself with the first two indices exchanged cancels its outer terms
+  -- against each other and leaves the symmetrised first slot.
+  have key : ∀ p q r : ℤ, (W (p - q) + W (q - p)) * W (p + q) * W r ^ 2 = 0 := fun p q r ↦ by
+    have hpq := h p q r
+    have hqp := h q p r
+    rw [IsEllipticNet.rel] at hpq hqp
+    ring_nf at hpq hqp ⊢
+    linear_combination hpq + hqp
   rw [eq_neg_iff_add_eq_zero]
+  -- `ring_nf` is what puts the indices in normal form: `W` is opaque, so `linear_combination`
+  -- cannot see that `W (1 - k - (k + 1))` and `W (-(2 * k))` are the same term.
   obtain ⟨k, rfl | rfl⟩ := m.even_or_odd'
-  · have := h.sub_add_neg_sub_mul_eq_zero (1 - k) (k + 1) 1
-    rw [show (1 : ℤ) - k - (k + 1) = -(2 * k) by ring,
-      show (k + 1) - (1 - k) = 2 * k by ring, show (1 : ℤ) - k + (k + 1) = 2 by ring] at this
+  · have := key (1 - k) (k + 1) 1
+    ring_nf at this ⊢
     exact (mul_mem two (pow_mem one 2)).2 _ (by linear_combination this)
-  · have := h.sub_add_neg_sub_mul_eq_zero (-k) (k + 1) 1
-    rw [show (-k : ℤ) - (k + 1) = -(2 * k + 1) by ring,
-      show (k + 1) - -k = 2 * k + 1 by ring, show (-k : ℤ) + (k + 1) = 1 by ring] at this
+  · have := key (-k) (k + 1) 1
+    ring_nf at this ⊢
     exact (mul_mem one (pow_mem one 2)).2 _ (by linear_combination this)
 
 /-- **An elliptic sequence is odd**, in Mathlib's `Function.Odd` spelling — the form

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Elementary.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Elementary.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
+public import Mathlib.NumberTheory.EllipticDivisibilitySequence
+
+/-!
+# Vanishing at zero and oddness of an elliptic sequence
+
+`IsEllipticSequence W` constrains `W` on every triple of integers. Two facts about `W` alone
+follow, given that suitable terms are nonzerodivisors: `W` vanishes at `0`, and `W` is an odd
+function.
+
+Both are used elsewhere as *hypotheses*. `Descent.lean` carries `zero : W 0 = 0` and
+`odd : W.Odd` on `IsEllipticNet.of_rel` and on the two equivalences, and it must: those results
+reconstruct the relation from the two doubling recurrences, so they cannot assume the relation
+they are proving. The lemmas here go the other way — the relation is the hypothesis — so they
+apply exactly where a caller already has `IsEllipticSequence W` in hand.
+
+## Main results
+
+* `IsEllipticSequence.zero`: `W 0 = 0`, given that some even term is a nonzerodivisor.
+* `IsEllipticSequence.neg`: `W (-m) = -W m`, given that `W 1` and `W 2` are nonzerodivisors.
+* `IsEllipticSequence.odd`: the same, packaged as Mathlib's `Function.Odd`.
+
+## Implementation notes
+
+Each proof specialises the relator at indices chosen to make all but one term cancel, then
+divides by the surviving nonzerodivisor.
+
+For `zero` the choice is `(m, m, 2 * m)`: the two outer terms of `rel` coincide and cancel, and
+the first collapses to `W 0 * W (2 * m) ^ 3`.
+
+For `neg` the relator is symmetrised first. Adding `rel W m n r 0` to `rel W n m r 0` cancels the
+two outer terms against each other and leaves `(W (m - n) + W (n - m)) * W (m + n) * W r ^ 2`,
+which is `sub_add_neg_sub_mul_eq_zero`. Choosing `(1 - k, k + 1, 1)` puts `2` in the middle slot
+and `-(2 * k)` in the first, and `(-k, k + 1, 1)` puts `1` and `-(2 * k + 1)` there; those are the
+even and odd cases, and they are why both `W 1` and `W 2` are needed.
+
+## Provenance
+
+Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declarations `IsEllSequence.zero`, `IsEllSequence.sub_add_neg_sub_mul_eq_zero` and
+`IsEllSequence.neg`. That file's header reads `Authors: David Kurniadi Angdinata`; following this
+repository's convention for adapted material the upstream authorship is credited here rather than
+in the copyright header. J. Xu is acknowledged for the surrounding LutzNagell development — he
+authors `Universal.lean` and co-authors `DivisionPolynomialOmega.lean` at the same revision — as
+context for this port, not as an author of the declarations above.
+
+The source also carries a `zero'` proved from `IsReduced R` rather than from a nonzerodivisor.
+It is not ported: `zero` below is what the development uses, and `IsReduced` is a hypothesis no
+consumer in this repository has.
+-/
+
+public section
+
+open scoped nonZeroDivisors
+
+namespace IsEllipticSequence
+
+variable {R : Type*} [CommRing R] {W : ℤ → R}
+
+/-- **An elliptic sequence vanishes at `0`**, given that some even term is a nonzerodivisor.
+
+At `(m, m, 2 * m)` the relator's two outer terms are equal and cancel, leaving
+`W 0 * W (2 * m) ^ 3`. -/
+protected theorem zero (h : IsEllipticSequence W) (m : ℤ) (mem : W (2 * m) ∈ R⁰) : W 0 = 0 := by
+  have key : W 0 * W (2 * m) ^ 3 = 0 := by
+    have := h m m (2 * m)
+    rw [IsEllipticNet.rel] at this
+    simp only [add_zero] at this
+    rw [show m + m = 2 * m by ring, show m - m = (0 : ℤ) by ring] at this
+    linear_combination this
+  exact (pow_mem mem 3).2 _ key
+
+/-- **The symmetrised relator vanishes.** Adding `rel W m n r 0` to `rel W n m r 0` cancels the
+two outer terms against each other, leaving the first slot's contribution from each. -/
+theorem sub_add_neg_sub_mul_eq_zero (h : IsEllipticSequence W) (m n r : ℤ) :
+    (W (m - n) + W (n - m)) * W (m + n) * W r ^ 2 = 0 := by
+  have hmn := h m n r
+  have hnm := h n m r
+  rw [IsEllipticNet.rel] at hmn hnm
+  simp only [add_zero] at hmn hnm
+  rw [show n + m = m + n by ring] at hnm
+  linear_combination hmn + hnm
+
+/-- **An elliptic sequence is an odd function**, given that `W 1` and `W 2` are nonzerodivisors.
+
+The two parities use different slots of `sub_add_neg_sub_mul_eq_zero`, which is why both terms
+are needed: the even case divides by `W 2 * W 1 ^ 2`, the odd case by `W 1 ^ 3`. -/
+protected theorem neg (h : IsEllipticSequence W) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰) (m : ℤ) :
+    W (-m) = -W m := by
+  rw [eq_neg_iff_add_eq_zero]
+  obtain ⟨k, rfl | rfl⟩ := m.even_or_odd'
+  · have := h.sub_add_neg_sub_mul_eq_zero (1 - k) (k + 1) 1
+    rw [show (1 : ℤ) - k - (k + 1) = -(2 * k) by ring,
+      show (k + 1) - (1 - k) = 2 * k by ring, show (1 : ℤ) - k + (k + 1) = 2 by ring] at this
+    exact (mul_mem two (pow_mem one 2)).2 _ (by linear_combination this)
+  · have := h.sub_add_neg_sub_mul_eq_zero (-k) (k + 1) 1
+    rw [show (-k : ℤ) - (k + 1) = -(2 * k + 1) by ring,
+      show (k + 1) - -k = 2 * k + 1 by ring, show (-k : ℤ) + (k + 1) = 1 by ring] at this
+    exact (mul_mem one (pow_mem one 2)).2 _ (by linear_combination this)
+
+/-- **An elliptic sequence is odd**, in Mathlib's `Function.Odd` spelling — the form
+`SignEquivariance.lean` and `Descent.lean` take as a hypothesis. -/
+protected theorem odd (h : IsEllipticSequence W) (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰) : W.Odd :=
+  fun m ↦ h.neg one two m
+
+end IsEllipticSequence

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Elementary.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Elementary.lean
@@ -25,10 +25,17 @@ apply exactly where a caller already has `IsEllipticSequence W` in hand.
 * `IsEllipticSequence.zero`: `W 0 = 0`, given that some even term is a nonzerodivisor.
 * `IsEllipticSequence.neg`: `W (-m) = -W m`, given that `W 1` and `W 2` are nonzerodivisors.
 
-Nothing else is exported. `W.Odd` unfolds to `neg`'s statement, so consumers taking Mathlib's
-spelling — `SignEquivariance.lean` and `Descent.lean` — apply `neg` itself rather than a second
-declaration. The symmetrisation the oddness proof turns on is likewise a local `have`: a step of
-that argument, not a fact a caller wants.
+Nothing else is exported. `W.Odd` unfolds to `neg`'s statement, so a second declaration for
+Mathlib's spelling would be a definitional restatement; a caller wanting `W.Odd` supplies `neg`
+directly. No file consumes either lemma yet — `SignEquivariance.lean` and `Descent.lean` take
+`W.Odd` and `W 0 = 0` as *hypotheses* and do not import this module. The symmetrisation the
+oddness proof turns on is likewise a local `have`: a step of that argument, not a fact a caller
+wants.
+
+Neither lemma is `@[simp]`, and neither can be: `W` is a variable, so `W (-m)` has a variable head
+symbol and Lean rejects the attribute outright — simp would have to try the rewrite at every step.
+Mathlib tags `normEDS_neg`, `preNormEDS_neg` and `complEDS_neg` because those are stated for the
+*concrete* sequences, whose head symbol is a constant.
 
 ## Implementation notes
 


### PR DESCRIPTION
Two facts about an elliptic sequence that this repository has so far only ever *assumed*.

```lean
protected theorem IsEllipticSequence.zero (h : IsEllipticSequence W) (m : ℤ)
    (mem : W (2 * m) ∈ R⁰) : W 0 = 0

protected theorem IsEllipticSequence.neg (h : IsEllipticSequence W)
    (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰) (m : ℤ) : W (-m) = -W m
```

`Descent.lean` carries `zero : W 0 = 0` and `odd : W.Odd` as explicit hypotheses on
`IsEllipticNet.of_rel`, on both equivalences, and throughout the descent. Nothing in the
repository derives either. These do.

## Why this does not simplify `Descent.lean`

The tempting inference is that those hypotheses are now redundant. They are not, and the reason
is worth stating so nobody re-derives it: `of_rel` and the two `iff`s **reconstruct** the elliptic
relation from the two doubling recurrences, so they cannot assume the relation they are proving.
The reverse direction of each `iff` needs `zero` and `odd` as genuine inputs.

The lemmas here run the other way — `IsEllipticSequence W` is the hypothesis — so they apply
exactly where a caller already holds the relation. That is the situation of the extensionality
principle these unblock, which is why the source's `ext` needs only `W 1, W 2 ∈ R⁰` and not four
extra hypotheses.

## The proofs are two choices of index

`rel W p q r 0` is
`W (p+q) * W (p-q) * W r * W r - W (p+r) * W (p-r) * W q * W q + W (q+r) * W (q-r) * W p * W p`.

* **`zero`** takes `(m, m, 2 * m)`. The two outer terms become literally equal and cancel; the
  first collapses to `W 0 * W (2 * m) ^ 3`. Dividing by the nonzerodivisor gives `W 0 = 0`.
* **`neg`** symmetrises first. Adding `rel W p q r 0` to `rel W q p r 0` cancels the outer terms
  against *each other* and leaves `(W (p - q) + W (q - p)) * W (p + q) * W r ^ 2`, a local `have`
  inside the proof. Then `(1 - k, k + 1, 1)` puts `2` in the middle slot with
  `-(2 * k)` in the first, and `(-k, k + 1, 1)` puts `1` there with `-(2 * k + 1)`. Those are the
  even and odd cases, and they are exactly why both `W 1` and `W 2` are needed — one per parity.

There is deliberately no separate `odd : W.Odd`. An earlier draft exported one; `reuse` was right
that `W.Odd` unfolds to exactly `neg`'s statement, so it was a definitional restatement. A caller
wanting Mathlib's spelling supplies `neg` directly. Keeping the pointwise form as the primitive
also matches Mathlib's neighbouring `normEDS_neg`, `ψ_neg` and `Ψ_neg`, which are all stated that
way.

**Neither lemma is `@[simp]`, and neither can be.** `api-design` asked for the tag on `neg`, by
analogy with Mathlib tagging `normEDS_neg`, `preNormEDS_neg` and `complEDS_neg`. Lean rejects it:

```
error: Left-hand side of simp theorem has a variable as head symbol. This means the
       theorem will be tried on every simp step, which can be expensive.
```

`W` is a variable, so `W (-m)` has a variable head. Mathlib's analogues are stated for the
*concrete* sequences, whose head symbol is a constant — which is exactly why the tag is fine
there and impossible here. The reason is recorded in the module docstring so it is not
rediscovered.

Neither file consumes these yet: `SignEquivariance.lean` and `Descent.lean` take `W.Odd` and
`W 0 = 0` as hypotheses and do not import this module. An earlier draft of this body said they
"apply `neg`"; `documentation` correctly called that false.

Both are marked `protected`, since either bare name would shadow a root-level one, matching
Mathlib's own `IsEllipticSequence.id` and `IsEllipticSequence.smul`. Dot notation is unaffected.

## Mathlib absence

Checked semantically rather than by spelling, since a grep only measures the latter:

| query | result |
|---|---|
| "an elliptic divisibility sequence vanishes at zero" | `normEDS_zero`, `preNormEDS_zero`, `preNormEDS'_zero`, `ψ_zero`, `Ψ_zero` |
| "an elliptic sequence is an odd function, W(-n) = -W(n)" | `normEDS_neg`, `ψ_neg`, `Ψ_neg`, `Function.Odd` |

Every hit is about a **concrete** sequence — `normEDS`, `preNormEDS`, the division polynomials.
None derives either fact from the predicate `IsEllipticSequence`. Mathlib's `IsEllipticSequence`
namespace contains exactly `id` and `smul`.

## Placement

A new file. `Recurrence.lean` is the neighbouring candidate and was considered: it also derives
consequences of the relation, and its docstring already ends by noting that determination
"requires a hypothesis this file does not carry" — which is precisely `W 1, W 2 ∈ R⁰`. But that
file is specifically the *doubling* interface, and neither statement here is a doubling relation.
Splitting keeps both files single-topic.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, the **Layer 6** torsion/Nagell–Lutz strand. These are
prerequisites rather than a milestone: the chain is `ext` → `normEDS 2 3 2 = id` →
`universalNormEDS_ne_zero` / `_mem_nonZeroDivisors` → `normEDS_mul_complEDS`, which is the
divisibility half of the TODO Mathlib records at
`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean:70`. `Universal.lean` already names the
two `universalNormEDS` lemmas as waiting on exactly this development.

## Provenance

Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0 per file header, `main` at
`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `IsEllSequence.zero`,
`IsEllSequence.sub_add_neg_sub_mul_eq_zero` — inlined here as a local step rather than exported —
and `IsEllSequence.neg`. That file's header reads
`Authors: David Kurniadi Angdinata`; following this repository's convention for adapted material
the upstream authorship is credited in the module docstring rather than in the copyright header.
J. Xu is acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
an author of the declarations above.

The source's `zero'`, which proves the same conclusion from `IsReduced R` instead of a
nonzerodivisor, is deliberately **not** ported: `zero` is what the development uses, and no
consumer in this repository carries `IsReduced`.

## Gates

`lake build` PASS, branch cut from current `main`. No `sorry`, no `set_option`, no
`native_decide`; longest proof 22 lines against the 30-line threshold; no line over 100
codepoints — a limit `lake build` itself enforces, so the green build is the evidence.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-seq-zero-neg"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
