### PR TITLE
refactor(Fredholm): drop hand-written coe_comp from the compact-perturbation proof

### DIFF
--- a/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
+++ b/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
@@ -37,6 +37,8 @@ forces the values at `c = 0` and `c = 1` to agree.
 
 * `TauCeti.isFredholm_one_sub` and `TauCeti.isFredholm_one_add`: `1 - K` and `1 + K` are Fredholm
   for `K` compact.
+* `TauCeti.isFredholm_add_of_hasFiniteRange_sub_one`: a compact perturbation of an operator that
+  is the identity up to finite range is Fredholm.
 * `ContinuousLinearMap.IsFredholm.add_of_isCompactOperator`: a compact perturbation of a Fredholm
   operator is Fredholm.
 * `TauCeti.ContinuousLinearMap.index_add_of_isCompactOperator`: a compact perturbation leaves the
@@ -76,6 +78,19 @@ theorem isFredholm_one_add {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
   rw [hrw]
   exact isFredholm_one_sub hneg
 
+/-- **A compact perturbation of a near-identity operator is Fredholm.** If `A` agrees with the
+identity up to an operator of finite range, and `K` is compact, then `A + K` is Fredholm.
+
+This is where Riesz--Schauder enters Atkinson's argument. A quasi-inverse `S` of a Fredholm `T`
+does not invert it on the nose: `S ∘ T` is the identity only up to finite rank, so the operator
+actually handed to Riesz--Schauder is not `1 + K` but a near-identity `A` plus a compact `K`. -/
+theorem isFredholm_add_of_hasFiniteRange_sub_one {A K : E →L[𝕜] E}
+    (hA : LinearMap.HasFiniteRange ((A - 1 : E →L[𝕜] E) : E →ₗ[𝕜] E)) (hK : IsCompactOperator K) :
+    ContinuousLinearMap.IsFredholm (A + K) := by
+  have hrw : A + K = (1 + K) + (A - 1) := by abel
+  rw [hrw]
+  exact (isFredholm_one_add hK).add_hasFiniteRange hA
+
 variable {T C : E →L[𝕜] F}
 
 /-- A compact perturbation of a Fredholm operator between Banach spaces is Fredholm.
@@ -97,29 +112,11 @@ theorem _root_.ContinuousLinearMap.IsFredholm.add_of_isCompactOperator
       ContinuousLinearMap.toLinearMap_one, Module.End.one_eq_id] using
       LinearMap.FiniteRangeSetoid.equiv_iff_hasFiniteRange.mp hS.2
   have hcomp₁ : ContinuousLinearMap.IsFredholm (S.comp (T + C)) := by
-    have hcompact : IsCompactOperator (S.comp C) := by
-      have hcomp : (⇑(S.comp C) : E → E) = ⇑S ∘ ⇑C := by
-        ext x
-        rw [Function.comp_apply, ContinuousLinearMap.comp_apply]
-      rw [hcomp]
-      exact hC.clm_comp S
-    have hrw : S.comp (T + C) = (1 + S.comp C) + (S.comp T - 1) := by
-      rw [ContinuousLinearMap.comp_add]
-      abel
-    rw [hrw]
-    exact (isFredholm_one_add hcompact).add_hasFiniteRange hleft
+    rw [ContinuousLinearMap.comp_add]
+    exact isFredholm_add_of_hasFiniteRange_sub_one hleft (hC.clm_comp S :)
   have hcomp₂ : ContinuousLinearMap.IsFredholm ((T + C).comp S) := by
-    have hcompact : IsCompactOperator (C.comp S) := by
-      have hcomp : (⇑(C.comp S) : F → F) = ⇑C ∘ ⇑S := by
-        ext x
-        rw [Function.comp_apply, ContinuousLinearMap.comp_apply]
-      rw [hcomp]
-      exact hC.comp_clm S
-    have hrw : (T + C).comp S = (1 + C.comp S) + (T.comp S - 1) := by
-      rw [ContinuousLinearMap.add_comp]
-      abel
-    rw [hrw]
-    exact (isFredholm_one_add hcompact).add_hasFiniteRange hright
+    rw [ContinuousLinearMap.add_comp]
+    exact isFredholm_add_of_hasFiniteRange_sub_one hright (hC.comp_clm S :)
   refine ContinuousLinearMap.IsFredholm.of_finite_ker_coker _ ?_ ?_
   · -- The kernel of `T + C` sits inside that of `S ∘ (T + C)`.
     have hker : LinearMap.ker ((T + C : E →L[𝕜] F) : E →ₗ[𝕜] F)

--- a/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
+++ b/TauCeti/Analysis/Fredholm/CompactPerturbation.lean
@@ -37,8 +37,6 @@ forces the values at `c = 0` and `c = 1` to agree.
 
 * `TauCeti.isFredholm_one_sub` and `TauCeti.isFredholm_one_add`: `1 - K` and `1 + K` are Fredholm
   for `K` compact.
-* `TauCeti.isFredholm_add_of_hasFiniteRange_sub_one`: a compact perturbation of an operator that
-  is the identity up to finite range is Fredholm.
 * `ContinuousLinearMap.IsFredholm.add_of_isCompactOperator`: a compact perturbation of a Fredholm
   operator is Fredholm.
 * `TauCeti.ContinuousLinearMap.index_add_of_isCompactOperator`: a compact perturbation leaves the
@@ -78,19 +76,6 @@ theorem isFredholm_one_add {K : E →L[𝕜] E} (hK : IsCompactOperator K) :
   rw [hrw]
   exact isFredholm_one_sub hneg
 
-/-- **A compact perturbation of a near-identity operator is Fredholm.** If `A` agrees with the
-identity up to an operator of finite range, and `K` is compact, then `A + K` is Fredholm.
-
-This is where Riesz--Schauder enters Atkinson's argument. A quasi-inverse `S` of a Fredholm `T`
-does not invert it on the nose: `S ∘ T` is the identity only up to finite rank, so the operator
-actually handed to Riesz--Schauder is not `1 + K` but a near-identity `A` plus a compact `K`. -/
-theorem isFredholm_add_of_hasFiniteRange_sub_one {A K : E →L[𝕜] E}
-    (hA : LinearMap.HasFiniteRange ((A - 1 : E →L[𝕜] E) : E →ₗ[𝕜] E)) (hK : IsCompactOperator K) :
-    ContinuousLinearMap.IsFredholm (A + K) := by
-  have hrw : A + K = (1 + K) + (A - 1) := by abel
-  rw [hrw]
-  exact (isFredholm_one_add hK).add_hasFiniteRange hA
-
 variable {T C : E →L[𝕜] F}
 
 /-- A compact perturbation of a Fredholm operator between Banach spaces is Fredholm.
@@ -112,11 +97,17 @@ theorem _root_.ContinuousLinearMap.IsFredholm.add_of_isCompactOperator
       ContinuousLinearMap.toLinearMap_one, Module.End.one_eq_id] using
       LinearMap.FiniteRangeSetoid.equiv_iff_hasFiniteRange.mp hS.2
   have hcomp₁ : ContinuousLinearMap.IsFredholm (S.comp (T + C)) := by
-    rw [ContinuousLinearMap.comp_add]
-    exact isFredholm_add_of_hasFiniteRange_sub_one hleft (hC.clm_comp S :)
+    have hrw : S.comp (T + C) = (1 + S.comp C) + (S.comp T - 1) := by
+      rw [ContinuousLinearMap.comp_add]
+      abel
+    rw [hrw]
+    exact (isFredholm_one_add (hC.clm_comp S :)).add_hasFiniteRange hleft
   have hcomp₂ : ContinuousLinearMap.IsFredholm ((T + C).comp S) := by
-    rw [ContinuousLinearMap.add_comp]
-    exact isFredholm_add_of_hasFiniteRange_sub_one hright (hC.comp_clm S :)
+    have hrw : (T + C).comp S = (1 + C.comp S) + (T.comp S - 1) := by
+      rw [ContinuousLinearMap.add_comp]
+      abel
+    rw [hrw]
+    exact (isFredholm_one_add (hC.comp_clm S :)).add_hasFiniteRange hright
   refine ContinuousLinearMap.IsFredholm.of_finite_ker_coker _ ?_ ?_
   · -- The kernel of `T + C` sits inside that of `S ∘ (T + C)`.
     have hker : LinearMap.ker ((T + C : E →L[𝕜] F) : E →ₗ[𝕜] F)


### PR DESCRIPTION
`ContinuousLinearMap.IsFredholm.add_of_isCompactOperator` — Atkinson's theorem, that a compact
perturbation of a Fredholm operator is Fredholm — ran to 52 lines. Ten of those were mathlib API
written out by hand, twice.

## What was open-coded

The proof composes a quasi-inverse `S` of `T` on each side, and each side established the
compactness of the composite like this:

```lean
    have hcompact : IsCompactOperator (S.comp C) := by
      have hcomp : (⇑(S.comp C) : E → E) = ⇑S ∘ ⇑C := by
        ext x
        rw [Function.comp_apply, ContinuousLinearMap.comp_apply]
      rw [hcomp]
      exact hC.clm_comp S
```

The inner `have` is `ContinuousLinearMap.coe_comp`
(`Mathlib/Topology/Algebra/Module/ContinuousLinearMap/Basic.lean:477`), which is `@[norm_cast]`
and proved by `rfl`. Being `rfl`, it needs no rewrite at all — mathlib's own idiom for exactly
this situation is a bare type ascription, as at
`Mathlib/Analysis/Normed/Operator/Compact/Basic.lean:298`:

```lean
    IsCompactOperator T := (isCompactOperator_id.comp_clm T :)
```

So each five-line block becomes `(hC.clm_comp S :)` / `(hC.comp_clm S :)` inline in the `exact`.

## Review round 1: the extraction I withdrew

I originally also extracted the shared shape of the two remaining blocks as a lemma
`isFredholm_add_of_hasFiniteRange_sub_one` ("`A` near the identity, `K` compact ⟹ `A + K`
Fredholm"). Both `reuse` and `api-design` flagged it, and they were right: beyond composing
`isFredholm_one_add` with mathlib's `IsFredholm.add_hasFiniteRange`, its only content is the
reassociation `A + K = (1 + K) + (A - 1)`. That is not a statement worth a name — it asserts
nothing the two lemmas it calls do not already assert between them. Withdrawn; the reassociation
is now a local `have` at each site, which is where a two-line algebraic step belongs.

The `coe_comp` half of the cleanup is untouched by those findings and is what this PR now is.

## On mathlib

Worth recording, since it is easy to assume otherwise: mathlib **does** have a full linear
Fredholm API — `ContinuousLinearMap.IsFredholm`, `FredholmPackage`,
`isFredholm_iff_exists_isQuasiInverse`, `IsFredholm.add_hasFiniteRange` — in
`Mathlib/Analysis/Normed/Operator/Fredholm/Basic.lean`, and this file already imports rather than
duplicates it. What mathlib has nowhere is the compact-operator bridge: its Fredholm file contains
no occurrence of `IsCompactOperator`, and its `Operator/Compact/` directory none of `isFredholm`.

## Result

| | before | after |
|---|---|---|
| `IsFredholm.add_of_isCompactOperator` | 52 | 40 |

Net `-12` lines, no new declarations.

Gates run on `1e8093a7`: `lake build` (7900 jobs), `lake exe axioms` (46670 declarations),
`lake exe module-system` (2227 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`, 67 grandfathered).

Roadmap: HeegaardFloer
