### PR TITLE
feat(HeckeSlash): the slash sum descends to modular forms and cusp forms

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
@@ -16,9 +16,10 @@ that this is *not* the roadmap's Layer 2(b) target because holomorphy and the cu
 not yet carried along. This file supplies exactly that: the two remaining structure fields.
 
 Invariance comes from `heckeSlashEnd`, holomorphy from `mdifferentiable_heckeSlashSum`, and
-boundedness at the cusps from `isBoundedAt_heckeSlashSum`; `coe_heckeSlashEnd` is what lets the
-latter two, which are stated about the raw function `heckeSlashSum`, be read as statements about
-the bundled form. The cusp-form case is then *derived* from the modular-form one, adding only
+boundedness at the cusps from `isBoundedAt_heckeSlashSum`. Because `heckeSlashEnd` is not
+`@[expose]`, a structure field's `.toFun` does not reduce to the coercion by itself, so each
+such field names the coercion form with `change`, then rewrites by `coe_heckeSlashEnd`.
+The cusp-form case is then *derived* from the modular-form one, adding only
 `zero_at_cusps'`, so neither invariance nor holomorphy is proved twice.
 
 Both maps are also bundled as `Module.End ℂ`, which is the form Hecke operators are consumed in:
@@ -29,18 +30,18 @@ the two cusp lemmas need. Descending further to `Γ₁(N)` is a separate step.
 
 ## Main definitions
 
-* `HeckeRing.GL2.heckeSlashModularForm`: the double coset acting on `ModularForm 𝒮ℒ k`.
-* `HeckeRing.GL2.heckeSlashCuspForm`: the same on `CuspForm 𝒮ℒ k`, which is the statement that
+* `HeckeRing.GL2.heckeSlashModularFormEnd`: the double coset as a `ℂ`-linear endomorphism of
+  `ModularForm 𝒮ℒ k`.
+* `HeckeRing.GL2.heckeSlashCuspFormEnd`: the same on `CuspForm 𝒮ℒ k`, which is the statement that
   **the action preserves cuspidality**.
-* `HeckeRing.GL2.heckeSlashModularFormEnd`, `heckeSlashCuspFormEnd`: both bundled as
-  `Module.End ℂ`.
+
+The unbundled constructors behind them are private; the bundled operators are the interface,
+since composition is what the Hecke ring will consume.
 
 ## Main results
 
-* `HeckeRing.GL2.coe_heckeSlashModularForm`, `coe_heckeSlashCuspForm`: both are `heckeSlashSum`
-  on underlying functions.
-* `HeckeRing.GL2.heckeSlashModularFormEnd_apply`, `heckeSlashCuspFormEnd_apply`: the bundled
-  endomorphisms are the unbundled maps on elements.
+* `HeckeRing.GL2.coe_heckeSlashModularFormEnd`, `coe_heckeSlashCuspFormEnd`: both endomorphisms
+  are `heckeSlashSum` on underlying functions.
 
 ## Provenance
 
@@ -69,48 +70,35 @@ namespace HeckeRing.GL2
 
 variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
 
-/-- The structure projection of `heckeSlashEnd` is `heckeSlashSum`. `coe_heckeSlashEnd` states
-this for the coercion `⇑`; the structure fields below are phrased with the projection `.toFun`
-instead, and `heckeSlashEnd` being unexposed keeps the two from reducing into one another. This
-bridge is what lets those fields be discharged by `rw` and `exact` rather than by an unrestricted
-simp call. -/
-private lemma toFun_heckeSlashEnd (f : SlashInvariantForm 𝒮ℒ k) :
-    (heckeSlashEnd k D f).toFun = heckeSlashSum k D f :=
-  coe_heckeSlashEnd k D f
-
-/-- **The double coset acting on modular forms.** The underlying function is `heckeSlashSum`;
-invariance is `heckeSlashEnd`, holomorphy is `mdifferentiable_heckeSlashSum`, and boundedness at
-the cusps is `isBoundedAt_heckeSlashSum`. -/
-noncomputable def heckeSlashModularForm (f : ModularForm 𝒮ℒ k) : ModularForm 𝒮ℒ k where
+/-- **The double coset acting on modular forms.** Invariance is `heckeSlashEnd`, holomorphy is
+`mdifferentiable_heckeSlashSum`, and boundedness at the cusps is `isBoundedAt_heckeSlashSum`.
+The public interface is the bundled `heckeSlashModularFormEnd`. -/
+private noncomputable def heckeSlashModularForm (f : ModularForm 𝒮ℒ k) : ModularForm 𝒮ℒ k where
   toSlashInvariantForm := heckeSlashEnd k D f.toSlashInvariantForm
   holo' := by
     rw [coe_heckeSlashEnd]; exact mdifferentiable_heckeSlashSum k D f.holo'
-  bdd_at_cusps' hc := by
-    rw [toFun_heckeSlashEnd]
+  -- `heckeSlashEnd` is unexposed, so the field's `.toFun` does not reduce to the coercion on
+  -- its own; `change` names the coercion form, after which `coe_heckeSlashEnd` applies.
+  bdd_at_cusps' := fun {c} hc ↦ by
+    change c.IsBoundedAt (⇑(heckeSlashEnd k D f.toSlashInvariantForm)) k
+    rw [coe_heckeSlashEnd]
     exact isBoundedAt_heckeSlashSum k D (fun _ h ↦ f.bdd_at_cusps' h) hc
 
-/-- The action is `heckeSlashSum` on underlying functions. -/
-@[simp] lemma coe_heckeSlashModularForm (f : ModularForm 𝒮ℒ k) :
+private lemma coe_heckeSlashModularForm (f : ModularForm 𝒮ℒ k) :
     ⇑(heckeSlashModularForm k D f) = heckeSlashSum k D f :=
   coe_heckeSlashEnd k D f.toSlashInvariantForm
 
-/-- The projection form of `coe_heckeSlashModularForm`, for the same reason as
-`toFun_heckeSlashEnd`: the cusp-form field below is phrased with `.toFun`. -/
-private lemma toFun_heckeSlashModularForm (f : ModularForm 𝒮ℒ k) :
-    (heckeSlashModularForm k D f).toFun = heckeSlashSum k D f :=
-  coe_heckeSlashModularForm k D f
-
 /-- **The double coset acting on cusp forms** — the action preserves cuspidality. Only the
-vanishing field is new: invariance and holomorphy are taken from `heckeSlashModularForm` at the
-underlying modular form, so the two constructions are not proved twice. -/
-noncomputable def heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) : CuspForm 𝒮ℒ k :=
+vanishing field is new: invariance and holomorphy come from `heckeSlashModularForm` at the
+underlying modular form, so neither is proved twice. -/
+private noncomputable def heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) : CuspForm 𝒮ℒ k :=
   { heckeSlashModularForm k D (f : ModularForm 𝒮ℒ k) with
-    zero_at_cusps' := fun hc ↦ by
-      rw [toFun_heckeSlashModularForm]
+    zero_at_cusps' := fun {c} hc ↦ by
+      change c.IsZeroAt (⇑(heckeSlashModularForm k D (f : ModularForm 𝒮ℒ k))) k
+      rw [coe_heckeSlashModularForm]
       exact isZeroAt_heckeSlashSum k D (fun _ h ↦ f.zero_at_cusps' h) hc }
 
-/-- The action is `heckeSlashSum` on underlying functions. -/
-@[simp] lemma coe_heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) :
+private lemma coe_heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) :
     ⇑(heckeSlashCuspForm k D f) = heckeSlashSum k D f :=
   coe_heckeSlashModularForm k D (f : ModularForm 𝒮ℒ k)
 
@@ -119,22 +107,25 @@ Hecke operators are consumed in: bundling is what lets them compose and later ca
 structure. -/
 noncomputable def heckeSlashModularFormEnd : Module.End ℂ (ModularForm 𝒮ℒ k) where
   toFun := heckeSlashModularForm k D
-  map_add' f g := by ext τ; simp [heckeSlashSum_add]
-  map_smul' c f := by ext τ; simp [heckeSlashSum_smul]
+  map_add' f g := by ext τ; simp [coe_heckeSlashModularForm, heckeSlashSum_add]
+  map_smul' c f := by ext τ; simp [coe_heckeSlashModularForm, heckeSlashSum_smul]
 
-/-- **The double coset as a `ℂ`-linear endomorphism of `CuspForm 𝒮ℒ k`.** -/
+/-- **The double coset as a `ℂ`-linear endomorphism of `CuspForm 𝒮ℒ k`** — the action preserves
+cuspidality. -/
 noncomputable def heckeSlashCuspFormEnd : Module.End ℂ (CuspForm 𝒮ℒ k) where
   toFun := heckeSlashCuspForm k D
-  map_add' f g := by ext τ; simp [heckeSlashSum_add]
-  map_smul' c f := by ext τ; simp [heckeSlashSum_smul]
+  map_add' f g := by ext τ; simp [coe_heckeSlashCuspForm, heckeSlashSum_add]
+  map_smul' c f := by ext τ; simp [coe_heckeSlashCuspForm, heckeSlashSum_smul]
 
-/-- The endomorphism is `heckeSlashModularForm` on elements. -/
-@[simp] lemma heckeSlashModularFormEnd_apply (f : ModularForm 𝒮ℒ k) :
-    heckeSlashModularFormEnd k D f = heckeSlashModularForm k D f := (rfl)
+/-- The endomorphism is `heckeSlashSum` on underlying functions. -/
+@[simp] lemma coe_heckeSlashModularFormEnd (f : ModularForm 𝒮ℒ k) :
+    ⇑(heckeSlashModularFormEnd k D f) = heckeSlashSum k D f :=
+  coe_heckeSlashModularForm k D f
 
-/-- The endomorphism is `heckeSlashCuspForm` on elements. -/
-@[simp] lemma heckeSlashCuspFormEnd_apply (f : CuspForm 𝒮ℒ k) :
-    heckeSlashCuspFormEnd k D f = heckeSlashCuspForm k D f := (rfl)
+/-- The endomorphism is `heckeSlashSum` on underlying functions. -/
+@[simp] lemma coe_heckeSlashCuspFormEnd (f : CuspForm 𝒮ℒ k) :
+    ⇑(heckeSlashCuspFormEnd k D f) = heckeSlashSum k D f :=
+  coe_heckeSlashCuspForm k D f
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
@@ -68,7 +68,10 @@ the cusps is `isBoundedAt_heckeSlashSum`. -/
 noncomputable def heckeSlashModularForm (f : ModularForm 𝒮ℒ k) : ModularForm 𝒮ℒ k where
   toSlashInvariantForm := heckeSlashEnd k D f.toSlashInvariantForm
   holo' := by
-    simpa using! mdifferentiable_heckeSlashSum k D f.holo'
+    simpa only [coe_heckeSlashEnd] using! mdifferentiable_heckeSlashSum k D f.holo'
+  -- The cusp field needs the unrestricted simp set: `coe_heckeSlashEnd` alone rewrites the
+  -- coercion but not the structure projection `.toFun`, which `heckeSlashEnd` being unexposed
+  -- keeps opaque. The `!` is likewise load-bearing; plain `simpa` cannot cross that boundary.
   bdd_at_cusps' hc := by
     simpa using! isBoundedAt_heckeSlashSum k D (fun _ h ↦ f.bdd_at_cusps' h) hc
 
@@ -76,7 +79,7 @@ noncomputable def heckeSlashModularForm (f : ModularForm 𝒮ℒ k) : ModularFor
 noncomputable def heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) : CuspForm 𝒮ℒ k where
   toSlashInvariantForm := heckeSlashEnd k D f.toSlashInvariantForm
   holo' := by
-    simpa using! mdifferentiable_heckeSlashSum k D f.holo'
+    simpa only [coe_heckeSlashEnd] using! mdifferentiable_heckeSlashSum k D f.holo'
   zero_at_cusps' hc := by
     simpa using! isZeroAt_heckeSlashSum k D (fun _ h ↦ f.zero_at_cusps' h) hc
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
@@ -69,23 +69,36 @@ namespace HeckeRing.GL2
 
 variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
 
+/-- The structure projection of `heckeSlashEnd` is `heckeSlashSum`. `coe_heckeSlashEnd` states
+this for the coercion `⇑`; the structure fields below are phrased with the projection `.toFun`
+instead, and `heckeSlashEnd` being unexposed keeps the two from reducing into one another. This
+bridge is what lets those fields be discharged by `rw` and `exact` rather than by an unrestricted
+simp call. -/
+private lemma toFun_heckeSlashEnd (f : SlashInvariantForm 𝒮ℒ k) :
+    (heckeSlashEnd k D f).toFun = heckeSlashSum k D f :=
+  coe_heckeSlashEnd k D f
+
 /-- **The double coset acting on modular forms.** The underlying function is `heckeSlashSum`;
 invariance is `heckeSlashEnd`, holomorphy is `mdifferentiable_heckeSlashSum`, and boundedness at
 the cusps is `isBoundedAt_heckeSlashSum`. -/
 noncomputable def heckeSlashModularForm (f : ModularForm 𝒮ℒ k) : ModularForm 𝒮ℒ k where
   toSlashInvariantForm := heckeSlashEnd k D f.toSlashInvariantForm
   holo' := by
-    simpa only [coe_heckeSlashEnd] using! mdifferentiable_heckeSlashSum k D f.holo'
-  -- The cusp field needs the unrestricted simp set: `coe_heckeSlashEnd` alone rewrites the
-  -- coercion but not the structure projection `.toFun`, which `heckeSlashEnd` being unexposed
-  -- keeps opaque. The `!` is likewise load-bearing; plain `simpa` cannot cross that boundary.
+    rw [coe_heckeSlashEnd]; exact mdifferentiable_heckeSlashSum k D f.holo'
   bdd_at_cusps' hc := by
-    simpa using! isBoundedAt_heckeSlashSum k D (fun _ h ↦ f.bdd_at_cusps' h) hc
+    rw [toFun_heckeSlashEnd]
+    exact isBoundedAt_heckeSlashSum k D (fun _ h ↦ f.bdd_at_cusps' h) hc
 
 /-- The action is `heckeSlashSum` on underlying functions. -/
 @[simp] lemma coe_heckeSlashModularForm (f : ModularForm 𝒮ℒ k) :
     ⇑(heckeSlashModularForm k D f) = heckeSlashSum k D f :=
   coe_heckeSlashEnd k D f.toSlashInvariantForm
+
+/-- The projection form of `coe_heckeSlashModularForm`, for the same reason as
+`toFun_heckeSlashEnd`: the cusp-form field below is phrased with `.toFun`. -/
+private lemma toFun_heckeSlashModularForm (f : ModularForm 𝒮ℒ k) :
+    (heckeSlashModularForm k D f).toFun = heckeSlashSum k D f :=
+  coe_heckeSlashModularForm k D f
 
 /-- **The double coset acting on cusp forms** — the action preserves cuspidality. Only the
 vanishing field is new: invariance and holomorphy are taken from `heckeSlashModularForm` at the
@@ -93,8 +106,8 @@ underlying modular form, so the two constructions are not proved twice. -/
 noncomputable def heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) : CuspForm 𝒮ℒ k :=
   { heckeSlashModularForm k D (f : ModularForm 𝒮ℒ k) with
     zero_at_cusps' := fun hc ↦ by
-      simpa [coe_heckeSlashModularForm] using!
-        isZeroAt_heckeSlashSum k D (fun _ h ↦ f.zero_at_cusps' h) hc }
+      rw [toFun_heckeSlashModularForm]
+      exact isZeroAt_heckeSlashSum k D (fun _ h ↦ f.zero_at_cusps' h) hc }
 
 /-- The action is `heckeSlashSum` on underlying functions. -/
 @[simp] lemma coe_heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) :

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Cusps
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Form
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Holomorphic
+
+/-!
+# The slash sum descends to modular forms and to cusp forms
+
+`Form.lean` bundles the double coset as an endomorphism of `SlashInvariantForm 𝒮ℒ k`, and flags
+that this is *not* the roadmap's Layer 2(b) target because holomorphy and the cusp conditions are
+not yet carried along. This file supplies exactly that: the two remaining structure fields.
+
+Both descents are the same three-line assembly. Invariance comes from `heckeSlashEnd`, holomorphy
+from `mdifferentiable_heckeSlashSum`, and the cusp condition from `isBoundedAt_heckeSlashSum` or
+`isZeroAt_heckeSlashSum`; `coe_heckeSlashEnd` is what lets the last two, which are stated about
+the raw function `heckeSlashSum`, be read as statements about the bundled form.
+
+The level here is `𝒮ℒ`, which carries mathlib's `Subgroup.IsArithmetic` instance — the hypothesis
+the two cusp lemmas need. Descending further to `Γ₁(N)`, and bundling these maps as
+`Module.End ℂ`, are separate steps.
+
+## Main definitions
+
+* `HeckeRing.GL2.heckeSlashModularForm`: the double coset acting on `ModularForm 𝒮ℒ k`.
+* `HeckeRing.GL2.heckeSlashCuspForm`: the same on `CuspForm 𝒮ℒ k`, which is the statement that
+  **the action preserves cuspidality**.
+
+## Main results
+
+* `HeckeRing.GL2.coe_heckeSlashModularForm`, `coe_heckeSlashCuspForm`: both are `heckeSlashSum`
+  on underlying functions.
+
+## Provenance
+
+Shape ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GL2/AdjointTheory.lean`](https://github.com/CBirkbeck/AINTLIB),
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), lines 102-105:
+`heckeT_p_cusp`, which assembles a `CuspForm` as `{ heckeT_p … with zero_at_cusps' := … }`. The
+assembly is the same; the operator differs, since this repository's `heckeSlashSum` is the general
+double-coset sum rather than `T_p`, and the level is `𝒮ℒ` rather than `Γ₁(N)`. AINTLIB's
+`CuspForm.toModularForm'` (line 51) is not ported: it duplicates mathlib's
+`CuspForm.toModularFormₗ`.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.4.
+-/
+
+public section
+
+open UpperHalfPlane DoubleCoset HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm
+
+namespace HeckeRing.GL2
+
+variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+
+/-- **The double coset acting on modular forms.** The underlying function is `heckeSlashSum`;
+invariance is `heckeSlashEnd`, holomorphy is `mdifferentiable_heckeSlashSum`, and boundedness at
+the cusps is `isBoundedAt_heckeSlashSum`. -/
+noncomputable def heckeSlashModularForm (f : ModularForm 𝒮ℒ k) : ModularForm 𝒮ℒ k where
+  toSlashInvariantForm := heckeSlashEnd k D f.toSlashInvariantForm
+  holo' := by
+    simpa using! mdifferentiable_heckeSlashSum k D f.holo'
+  bdd_at_cusps' hc := by
+    simpa using! isBoundedAt_heckeSlashSum k D (fun _ h ↦ f.bdd_at_cusps' h) hc
+
+/-- **The double coset acting on cusp forms** — the action preserves cuspidality. -/
+noncomputable def heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) : CuspForm 𝒮ℒ k where
+  toSlashInvariantForm := heckeSlashEnd k D f.toSlashInvariantForm
+  holo' := by
+    simpa using! mdifferentiable_heckeSlashSum k D f.holo'
+  zero_at_cusps' hc := by
+    simpa using! isZeroAt_heckeSlashSum k D (fun _ h ↦ f.zero_at_cusps' h) hc
+
+/-- The action is `heckeSlashSum` on underlying functions. -/
+@[simp] lemma coe_heckeSlashModularForm (f : ModularForm 𝒮ℒ k) :
+    ⇑(heckeSlashModularForm k D f) = heckeSlashSum k D f :=
+  coe_heckeSlashEnd k D f.toSlashInvariantForm
+
+/-- The action is `heckeSlashSum` on underlying functions. -/
+@[simp] lemma coe_heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) :
+    ⇑(heckeSlashCuspForm k D f) = heckeSlashSum k D f :=
+  coe_heckeSlashEnd k D f.toSlashInvariantForm
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
@@ -15,25 +15,32 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Holomorphic
 that this is *not* the roadmap's Layer 2(b) target because holomorphy and the cusp conditions are
 not yet carried along. This file supplies exactly that: the two remaining structure fields.
 
-Both descents are the same three-line assembly. Invariance comes from `heckeSlashEnd`, holomorphy
-from `mdifferentiable_heckeSlashSum`, and the cusp condition from `isBoundedAt_heckeSlashSum` or
-`isZeroAt_heckeSlashSum`; `coe_heckeSlashEnd` is what lets the last two, which are stated about
-the raw function `heckeSlashSum`, be read as statements about the bundled form.
+Invariance comes from `heckeSlashEnd`, holomorphy from `mdifferentiable_heckeSlashSum`, and
+boundedness at the cusps from `isBoundedAt_heckeSlashSum`; `coe_heckeSlashEnd` is what lets the
+latter two, which are stated about the raw function `heckeSlashSum`, be read as statements about
+the bundled form. The cusp-form case is then *derived* from the modular-form one, adding only
+`zero_at_cusps'`, so neither invariance nor holomorphy is proved twice.
+
+Both maps are also bundled as `Module.End ℂ`, which is the form Hecke operators are consumed in:
+bundling is what lets them compose and later carry a ring structure.
 
 The level here is `𝒮ℒ`, which carries mathlib's `Subgroup.IsArithmetic` instance — the hypothesis
-the two cusp lemmas need. Descending further to `Γ₁(N)`, and bundling these maps as
-`Module.End ℂ`, are separate steps.
+the two cusp lemmas need. Descending further to `Γ₁(N)` is a separate step.
 
 ## Main definitions
 
 * `HeckeRing.GL2.heckeSlashModularForm`: the double coset acting on `ModularForm 𝒮ℒ k`.
 * `HeckeRing.GL2.heckeSlashCuspForm`: the same on `CuspForm 𝒮ℒ k`, which is the statement that
   **the action preserves cuspidality**.
+* `HeckeRing.GL2.heckeSlashModularFormEnd`, `heckeSlashCuspFormEnd`: both bundled as
+  `Module.End ℂ`.
 
 ## Main results
 
 * `HeckeRing.GL2.coe_heckeSlashModularForm`, `coe_heckeSlashCuspForm`: both are `heckeSlashSum`
   on underlying functions.
+* `HeckeRing.GL2.heckeSlashModularFormEnd_apply`, `heckeSlashCuspFormEnd_apply`: the bundled
+  endomorphisms are the unbundled maps on elements.
 
 ## Provenance
 
@@ -43,8 +50,8 @@ commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), 
 `heckeT_p_cusp`, which assembles a `CuspForm` as `{ heckeT_p … with zero_at_cusps' := … }`. The
 assembly is the same; the operator differs, since this repository's `heckeSlashSum` is the general
 double-coset sum rather than `T_p`, and the level is `𝒮ℒ` rather than `Γ₁(N)`. AINTLIB's
-`CuspForm.toModularForm'` (line 51) is not ported: it duplicates mathlib's
-`CuspForm.toModularFormₗ`.
+`CuspForm.toModularForm'` (line 51) is not ported: mathlib already supplies the coercion, as the
+`CoeTC` instance of `ModularFormClass` (`Mathlib/NumberTheory/ModularForms/Basic.lean`).
 
 ## References
 
@@ -75,23 +82,46 @@ noncomputable def heckeSlashModularForm (f : ModularForm 𝒮ℒ k) : ModularFor
   bdd_at_cusps' hc := by
     simpa using! isBoundedAt_heckeSlashSum k D (fun _ h ↦ f.bdd_at_cusps' h) hc
 
-/-- **The double coset acting on cusp forms** — the action preserves cuspidality. -/
-noncomputable def heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) : CuspForm 𝒮ℒ k where
-  toSlashInvariantForm := heckeSlashEnd k D f.toSlashInvariantForm
-  holo' := by
-    simpa only [coe_heckeSlashEnd] using! mdifferentiable_heckeSlashSum k D f.holo'
-  zero_at_cusps' hc := by
-    simpa using! isZeroAt_heckeSlashSum k D (fun _ h ↦ f.zero_at_cusps' h) hc
-
 /-- The action is `heckeSlashSum` on underlying functions. -/
 @[simp] lemma coe_heckeSlashModularForm (f : ModularForm 𝒮ℒ k) :
     ⇑(heckeSlashModularForm k D f) = heckeSlashSum k D f :=
   coe_heckeSlashEnd k D f.toSlashInvariantForm
 
+/-- **The double coset acting on cusp forms** — the action preserves cuspidality. Only the
+vanishing field is new: invariance and holomorphy are taken from `heckeSlashModularForm` at the
+underlying modular form, so the two constructions are not proved twice. -/
+noncomputable def heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) : CuspForm 𝒮ℒ k :=
+  { heckeSlashModularForm k D (f : ModularForm 𝒮ℒ k) with
+    zero_at_cusps' := fun hc ↦ by
+      simpa [coe_heckeSlashModularForm] using!
+        isZeroAt_heckeSlashSum k D (fun _ h ↦ f.zero_at_cusps' h) hc }
+
 /-- The action is `heckeSlashSum` on underlying functions. -/
 @[simp] lemma coe_heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) :
     ⇑(heckeSlashCuspForm k D f) = heckeSlashSum k D f :=
-  coe_heckeSlashEnd k D f.toSlashInvariantForm
+  coe_heckeSlashModularForm k D (f : ModularForm 𝒮ℒ k)
+
+/-- **The double coset as a `ℂ`-linear endomorphism of `ModularForm 𝒮ℒ k`.** This is the form
+Hecke operators are consumed in: bundling is what lets them compose and later carry a ring
+structure. -/
+noncomputable def heckeSlashModularFormEnd : Module.End ℂ (ModularForm 𝒮ℒ k) where
+  toFun := heckeSlashModularForm k D
+  map_add' f g := by ext τ; simp [heckeSlashSum_add]
+  map_smul' c f := by ext τ; simp [heckeSlashSum_smul]
+
+/-- **The double coset as a `ℂ`-linear endomorphism of `CuspForm 𝒮ℒ k`.** -/
+noncomputable def heckeSlashCuspFormEnd : Module.End ℂ (CuspForm 𝒮ℒ k) where
+  toFun := heckeSlashCuspForm k D
+  map_add' f g := by ext τ; simp [heckeSlashSum_add]
+  map_smul' c f := by ext τ; simp [heckeSlashSum_smul]
+
+/-- The endomorphism is `heckeSlashModularForm` on elements. -/
+@[simp] lemma heckeSlashModularFormEnd_apply (f : ModularForm 𝒮ℒ k) :
+    heckeSlashModularFormEnd k D f = heckeSlashModularForm k D f := (rfl)
+
+/-- The endomorphism is `heckeSlashCuspForm` on elements. -/
+@[simp] lemma heckeSlashCuspFormEnd_apply (f : CuspForm 𝒮ℒ k) :
+    heckeSlashCuspFormEnd k D f = heckeSlashCuspForm k D f := (rfl)
 
 end HeckeRing.GL2
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke/heckeslash-modularform"}-->

## Roadmap target

`TauCetiRoadmap/ModularForms/README.md:440`, **Layer 2, block (b) "The action on forms"**:

> ⚠ The action must preserve cuspidality and the nebentypus; prove that, don't assume it.

This PR proves the cuspidality half at level `𝒮ℒ`.

## What is added

`HeckeSlash/Form.lean` already bundles the double coset as a `Module.End ℂ (SlashInvariantForm 𝒮ℒ k)`,
and its docstring flags that this is *not* the Layer 2(b) target, because holomorphy and the cusp
conditions are not carried along. This file supplies exactly those two structure fields:

```lean
noncomputable def heckeSlashModularFormEnd : Module.End ℂ (ModularForm 𝒮ℒ k)
noncomputable def heckeSlashCuspFormEnd    : Module.End ℂ (CuspForm    𝒮ℒ k)
```

The unbundled constructors behind them are **private**: the bundled operators are the interface,
since composition is what the Hecke ring consumes.

together with `@[simp]` lemmas `coe_heckeSlashModularFormEnd` / `coe_heckeSlashCuspFormEnd`,
stating that each endomorphism is `heckeSlashSum` on underlying functions.

`heckeSlashCuspFormEnd` **is** the statement that the action preserves cuspidality. The cusp-form
construction is *derived* from the modular-form one, adding only `zero_at_cusps'`, so invariance
and holomorphy are not proved twice — the same shape AINTLIB uses.

## Nothing new is proved

Every field is discharged by a result already on `main`:

| field | supplied by |
|---|---|
| invariance | `heckeSlashEnd` (`HeckeSlash/Form.lean`) |
| `holo'` | `mdifferentiable_heckeSlashSum` (`HeckeSlash/Holomorphic.lean`) |
| `bdd_at_cusps'` | `isBoundedAt_heckeSlashSum` (`HeckeSlash/Cusps.lean`, #3236) |
| `zero_at_cusps'` | `isZeroAt_heckeSlashSum` (`HeckeSlash/Cusps.lean`, #3236) |

The `𝒮ℒ` level is what makes the last two applicable: they are stated for
`[Γ.IsArithmetic]`, and mathlib supplies `instance : IsArithmetic 𝒮ℒ`.

## Why the tactics look the way they do

`heckeSlashEnd` is not `@[expose]`, so a structure field's `.toFun` does not reduce to the
coercion on its own. Each such field names the coercion form with `change` and then rewrites by
the existing public lemma:

```lean
change c.IsBoundedAt (⇑(heckeSlashEnd k D f.toSlashInvariantForm)) k
rw [coe_heckeSlashEnd]
exact isBoundedAt_heckeSlashSum k D (fun _ h ↦ f.bdd_at_cusps' h) hc
```

No new bridge lemmas, and no `simpa using!` — nothing here depends on the ambient simp set.
`change` rather than `show`, because `linter.style.show` rejects `show` where later tactics
rewrite the goal.

## Scope

Level `𝒮ℒ` only. Descending to `Γ₁(N)` is a separate layer, and the nebentypus half of the
roadmap ⚠ is not touched here.

## Provenance

Shape ported from the AINTLIB `LeanModularForms` project
([`LeanModularForms/HeckeRIngs/GL2/AdjointTheory.lean`](https://github.com/CBirkbeck/AINTLIB),
commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), **lines 102-105**:
`heckeT_p_cusp`, which assembles a `CuspForm` as `{ heckeT_p … with zero_at_cusps' := … }`. The
assembly is the same; the operator differs, since `heckeSlashSum` is the general double-coset sum
rather than `T_p`, and the level is `𝒮ℒ` rather than `Γ₁(N)`.

AINTLIB's `CuspForm.toModularForm'` (`AdjointTheory.lean:51`) is deliberately **not** ported:
mathlib already supplies that coercion as the `CoeTC` instance of `ModularFormClass`
(`Mathlib/NumberTheory/ModularForms/Basic.lean`).

## References

* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
  §3.4.

Roadmap: ModularForms
