### PR TITLE
refactor(DividedPowers): drop the ℕ→ℚ casts that nothing needed

### DIFF
--- a/TauCeti/RingTheory/DividedPowers/NormalOrdering.lean
+++ b/TauCeti/RingTheory/DividedPowers/NormalOrdering.lean
@@ -169,18 +169,14 @@ private theorem mul_normalOrderTerm {x y z : A} (hxy : x * y = y * x + z)
         (m + 1 - k) •
           (dividedPower (n - k) y * dividedPower k z *
             dividedPower (m + 1 - k) x) := by
-    rw [hxmove, hxx]
-    simp_rw [← Nat.cast_smul_eq_nsmul ℚ]
-    rw [mul_smul_comm, mul_smul_comm, mul_assoc]
+    rw [hxmove, hxx, mul_smul_comm, mul_smul_comm, mul_assoc]
   have hsecond :
       dividedPower (n - (k + 1)) y *
           (z * (dividedPower k z * dividedPower (m - k) x)) =
         (k + 1) •
           (dividedPower (n - (k + 1)) y * dividedPower (k + 1) z *
             dividedPower (m - k) x) := by
-    rw [hzmove, hzz]
-    simp_rw [← Nat.cast_smul_eq_nsmul ℚ]
-    rw [smul_mul_assoc, mul_smul_comm, mul_assoc]
+    rw [hzmove, hzz, smul_mul_assoc, mul_smul_comm, mul_assoc]
   rw [mul_assoc (dividedPower (n - k) y) (dividedPower k z),
     ← mul_assoc x (dividedPower (n - k) y), hxy', add_mul,
     mul_assoc (dividedPower (n - k) y) x,
@@ -198,9 +194,7 @@ private theorem mul_normalOrderLast {x z : A} (hxz : Commute x z) {m n : ℕ} (h
       x * dividedPower (m - n) x =
         (m + 1 - n) • dividedPower (m + 1 - n) x := by
     rw [self_mul_dividedPower, hmn]
-  rw [← mul_assoc, hxzn.eq, mul_assoc, hxx]
-  simp_rw [← Nat.cast_smul_eq_nsmul ℚ]
-  rw [mul_smul_comm]
+  rw [← mul_assoc, hxzn.eq, mul_assoc, hxx, mul_smul_comm]
 
 /-- **Coefficient-one normal ordering for divided powers with central commutator.** Suppose
 `x * y = y * x + z`, and `z` commutes with both `x` and `y`. Then
@@ -247,7 +241,6 @@ theorem dividedPower_mul_dividedPower_of_commutator_eq {x y z : A}
             (M := n) (C := m + 1) (Nat.le_succ_of_le hnm)
         conv_rhs => rw [Finset.sum_range_succ]
         simp only [Finset.sum_range_succ, Nat.sub_self, dividedPower_zero, one_mul] at hsum ⊢
-        simp_rw [← Nat.cast_smul_eq_nsmul ℚ] at hsum ⊢
         rw [← hsum]
         abel
       · have hmn : m < n := Nat.lt_of_not_ge hnm


### PR DESCRIPTION
Four places in `NormalOrdering.lean` stepped a goal through `← Nat.cast_smul_eq_nsmul ℚ` before
applying `mul_smul_comm`, `smul_mul_assoc` or `abel`. None of those tactics needs it — ℕ-smul
already commutes with multiplication in any semiring via `AddMonoid.nat_smulCommClass`, and `abel`
handles ℕ-smul natively — so the cast was pure ceremony. With it gone the surrounding `rw` chains
are otherwise **unchanged** and collapse onto one line each:

```lean
-    rw [hxmove, hxx]
-    simp_rw [← Nat.cast_smul_eq_nsmul ℚ]
-    rw [mul_smul_comm, mul_smul_comm, mul_assoc]
+    rw [hxmove, hxx, mul_smul_comm, mul_smul_comm, mul_assoc]
```

## Which casts stay

The interesting part of this PR is the boundary, so it was drawn by probing rather than by eye.
`Nat.cast_smul_eq_nsmul` appears six times across the two `DividedPowers` files that use it, and
they are doing two different jobs:

* **Removable (4, all in `NormalOrdering.lean`):** the cast only precedes `mul_smul_comm` /
  `smul_mul_assoc` / `abel`, all of which are ℕ-smul-native.
* **Load-bearing (2 here, 4 in `Associative.lean`):** the cast moves a ℕ-smul *goal* into ℚ so that
  rational coefficient arithmetic can happen — `field_simp`, `inv_factorial_mul_inv_factorial`,
  `inv_mul_cancel₀`, and the `module` call in `sum_sub_nsmul_add_succ_nsmul` that needs truncated
  ℕ-subtraction to become additive.

Every one of the six was tested by deletion. The four removals build; each of the six retentions is
a **must-fail control that does fail** (4 errors, 2 errors, and 8 errors for `Associative.lean`'s
four taken together), so the probe discriminates rather than passing vacuously.

No statement changed — this is tactic script only, so no docstring, signature or `Main results`
entry moves with it.

## Result

| | before | after |
|---|---|---|
| `mul_normalOrderTerm` | 49 | 45 |
| `dividedPower_mul_dividedPower_of_commutator_eq` | 48 | 47 |
| `mul_normalOrderLast` | 10 | 8 |

Net `-7` lines, no new declarations.

Gates run on `2a119f33`: `lake build` (7905 jobs), `lake exe axioms` (46691 declarations),
`lake exe module-system` (2232 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`, 67 grandfathered).

Roadmap: ReductiveGroups
