### PR TITLE
refactor(ViaKoopman): weaken the route to finite measures

### DIFF
--- a/TauCeti/Probability/DeFinetti/ViaKoopman/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/BlockFactorization.lean
@@ -80,7 +80,7 @@ Peeling the last coordinate replaces `𝟙_{B_r}(x_r)` by its conditional expect
 shift-invariant σ-algebra; the factors already peeled ride along as the weight of the next step,
 which is why the whole chain is stated against one. -/
 theorem setIntegral_weight_mul_blockIndicatorProd_prefix_eq_prod_condExp
-    {ρ : Measure (ℕ → α)} [IsProbabilityMeasure ρ] (hρ : ContractableLaw ρ)
+    {ρ : Measure (ℕ → α)} [IsFiniteMeasure ρ] (hρ : ContractableLaw ρ)
     {A : Set (ℕ → α)} (hA : MeasurableSet[MeasurableSpace.invariants (shift α)] A) :
     ∀ (r : ℕ) (B : Fin r → Set α), (∀ i, MeasurableSet (B i)) →
       ∀ w : (ℕ → α) → ℝ, Measurable[MeasurableSpace.invariants (shift α)] w →
@@ -160,7 +160,7 @@ factors, so it does not care what multiplies them. -/
 theorem
     setIntegral_weight_mul_blockIndicatorProd_prefix_eq_prod_invariantConditionalProbabilityMeasure
     [StandardBorelSpace α] [Nonempty α]
-    {ρ : Measure (ℕ → α)} [IsProbabilityMeasure ρ] (hρ : ContractableLaw ρ)
+    {ρ : Measure (ℕ → α)} [IsFiniteMeasure ρ] (hρ : ContractableLaw ρ)
     {A : Set (ℕ → α)} (hA : MeasurableSet[MeasurableSpace.invariants (shift α)] A)
     (r : ℕ) (B : Fin r → Set α) (hB : ∀ i, MeasurableSet (B i))
     (w : (ℕ → α) → ℝ) (hw : Measurable[MeasurableSpace.invariants (shift α)] w)
@@ -183,7 +183,7 @@ theorem
 specialisation of the theorem above. -/
 theorem setIntegral_blockIndicatorProd_prefix_eq_prod_invariantConditionalProbabilityMeasure
     [StandardBorelSpace α] [Nonempty α]
-    {ρ : Measure (ℕ → α)} [IsProbabilityMeasure ρ] (hρ : ContractableLaw ρ)
+    {ρ : Measure (ℕ → α)} [IsFiniteMeasure ρ] (hρ : ContractableLaw ρ)
     {A : Set (ℕ → α)} (hA : MeasurableSet[MeasurableSpace.invariants (shift α)] A)
     (r : ℕ) (B : Fin r → Set α) (hB : ∀ i, MeasurableSet (B i)) :
     ∫ x in A, ∏ i : Fin r, (B i).indicator (fun _ => (1 : ℝ)) (x (i : ℕ)) ∂ρ

--- a/TauCeti/Probability/DeFinetti/ViaKoopman/CylinderMass.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/CylinderMass.lean
@@ -71,7 +71,7 @@ of a block cylinder is the integral of the product of the invariant conditional 
 coordinate sets. -/
 theorem measure_inter_blockCylinder_eq_setLIntegral_of_measurableSet_invariants
     [StandardBorelSpace α] [Nonempty α]
-    {ρ : Measure (ℕ → α)} [IsProbabilityMeasure ρ] (hρ : ContractableLaw ρ)
+    {ρ : Measure (ℕ → α)} [IsFiniteMeasure ρ] (hρ : ContractableLaw ρ)
     {r : ℕ} {k : Fin r → ℕ} (hk : StrictMono k)
     {A : Set (ℕ → α)} (hA_inv : MeasurableSet[MeasurableSpace.invariants (shift α)] A)
     {B : Fin r → Set α} (hB : ∀ i, MeasurableSet (B i)) :

--- a/TauCeti/Probability/DeFinetti/ViaKoopman/Decoupling.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/Decoupling.lean
@@ -129,7 +129,7 @@ private theorem birkhoffAverage_shift_coord_eq {B : Set α} (r n : ℕ) (x : ℕ
 applied to the indicator of `B` at coordinate `r`: the limit is the conditional expectation of that
 same indicator given the shift-invariant σ-algebra. -/
 private theorem tendsto_integral_abs_birkhoffAverage_indicator_coord
-    {ρ : Measure (ℕ → α)} [IsProbabilityMeasure ρ] (hmp : MeasurePreserving (shift α) ρ ρ)
+    {ρ : Measure (ℕ → α)} [IsFiniteMeasure ρ] (hmp : MeasurePreserving (shift α) ρ ρ)
     {B : Set α} (hB : MeasurableSet B) (r : ℕ) :
     Filter.Tendsto (fun n => ∫ x,
         |birkhoffAverage ℝ (shift α) (fun y : ℕ → α => B.indicator (fun _ => (1 : ℝ)) (y r)) n x
@@ -154,7 +154,7 @@ witness's characteristic property at coordinate `0` with the transport fact that
 agree over invariant events. This is what lets the Birkhoff limit at coordinate `r` be named as the
 witness. -/
 theorem condExp_indicator_coord_ae_eq_invariantConditionalProbabilityMeasure
-    [StandardBorelSpace α] [Nonempty α] {ρ : Measure (ℕ → α)} [IsProbabilityMeasure ρ]
+    [StandardBorelSpace α] [Nonempty α] {ρ : Measure (ℕ → α)} [IsFiniteMeasure ρ]
     (hρ : ContractableLaw ρ) {B : Set α} (hB : MeasurableSet B) (r : ℕ) :
     ρ[fun y : ℕ → α => B.indicator (fun _ => (1 : ℝ)) (y r) |
         MeasurableSpace.invariants (shift α)]
@@ -331,7 +331,7 @@ Where the two halves meet: the averaged sequence is *constant* in `n` by
 sequence converges to the right-hand side by the `L¹` mean ergodic theorem; a sequence has one
 limit. -/
 theorem setIntegral_weight_mul_prefix_mul_indicator_eq_condExp
-    {ρ : Measure (ℕ → α)} [IsProbabilityMeasure ρ] (hρ : ContractableLaw ρ) {r : ℕ}
+    {ρ : Measure (ℕ → α)} [IsFiniteMeasure ρ] (hρ : ContractableLaw ρ) {r : ℕ}
     {w : (ℕ → α) → ℝ} (hw : Measurable[MeasurableSpace.invariants (shift α)] w)
     (hw_bdd : ∀ᵐ x ∂ρ, |w x| ≤ 1)
     {g : (Fin r → α) → ℝ} (hg : Measurable g) (hg_bdd : ∀ y, |g y| ≤ 1)
@@ -404,7 +404,7 @@ theorem setIntegral_weight_mul_prefix_mul_indicator_eq_condExp
 coordinate decouples; this says what it decouples into. -/
 theorem setIntegral_weight_mul_prefix_mul_indicator_eq_invariantConditionalProbabilityMeasure
     [StandardBorelSpace α] [Nonempty α]
-    {ρ : Measure (ℕ → α)} [IsProbabilityMeasure ρ] (hρ : ContractableLaw ρ) {r : ℕ}
+    {ρ : Measure (ℕ → α)} [IsFiniteMeasure ρ] (hρ : ContractableLaw ρ) {r : ℕ}
     {w : (ℕ → α) → ℝ} (hw : Measurable[MeasurableSpace.invariants (shift α)] w)
     (hw_bdd : ∀ᵐ x ∂ρ, |w x| ≤ 1)
     {g : (Fin r → α) → ℝ} (hg : Measurable g) (hg_bdd : ∀ y, |g y| ≤ 1)


### PR DESCRIPTION
Every statement in the Koopman chain required `[IsProbabilityMeasure ρ]`, but nothing in the proofs
uses it. Both places the assumption could plausibly bite are finite-measure statements already:

* `tendsto_integral_abs_birkhoffAverage_sub_condExp` — the mean ergodic input — takes
  `[IsFiniteMeasure μ]`;
* `invariantConditionalProbabilityMeasure` — the witness — is defined for `[IsFiniteMeasure ρ]`.

So the assumption was mine rather than the mathematics', and it propagated the length of the route,
ending at the summit wrappers in #3170.

## Why this rather than normalising

The `generality` finding on #3170 proposed stating the wrappers with `[IsFiniteMeasure μ]` and
handling the general case by splitting off the zero measure, normalising a nonzero finite measure,
and transporting the conclusion back under scaling. That would work, but it builds machinery around
an assumption that was never needed. Deleting the assumption is both smaller and closer to the
truth: `deFinetti_viaL2` has always been a finite-measure statement because the `L²` route never
made this mistake.

This PR is the prerequisite; #3170's wrappers follow once it lands.

Roadmap: Exchangeability

Advances `TauCetiRoadmap/Exchangeability/README.md`, **Layer 5** (Koopman operators and invariant
σ-algebras), milestone `deFinetti_viaKoopman`.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
