### PR TITLE
feat(FieldTheory): separable and inseparable degrees under a surjective base change

### DIFF
--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.FieldTheory.IntermediateField.Basic
 public import Mathlib.LinearAlgebra.Dimension.Finrank
 public import Mathlib.FieldTheory.PurelyInseparable.Basic
+import Mathlib.FieldTheory.PurelyInseparable.Tower
 
 /-!
 # The degree above the range of a field embedding
@@ -76,14 +77,25 @@ theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, al
 /-- **The inseparable degree above the range of a field embedding equals the one above its
 source**, under the same hypotheses as `finSepDegree_fieldRange`. -/
 theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z)
-    [FiniteDimensional K L] :
+    [Algebra.IsAlgebraic K L] :
     Field.finInsepDegree f.fieldRange L = Field.finInsepDegree K L := by
-  have hsep := finSepDegree_fieldRange f h
-  have hrank := finrank_fieldRange f h
-  have hL := Field.finSepDegree_mul_finInsepDegree (f.fieldRange) L
-  have hK := Field.finSepDegree_mul_finInsepDegree K L
-  rw [hsep] at hL
-  rw [hrank] at hL
-  exact Nat.eq_of_mul_eq_mul_left (NeZero.pos (Field.finSepDegree K L)) (hL.trans hK.symm)
+  let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
+  have : IsScalarTower K f.fieldRange L :=
+    IsScalarTower.of_algebraMap_eq fun z ↦ by
+      rw [RingHom.algebraMap_toAlgebra]
+      exact (h z).trans (_root_.AlgHom.equivFieldRange_apply_coe f z).symm
+  have h1 : Field.finInsepDegree K f.fieldRange = 1 := by
+    have he : Field.finInsepDegree K K = Field.finInsepDegree K f.fieldRange :=
+      Field.finInsepDegree_eq_of_equiv K K f.fieldRange
+        (AlgEquiv.ofRingEquiv (f := (f.equivFieldRange).toRingEquiv) fun z ↦ by
+          rw [RingHom.algebraMap_toAlgebra]; rfl)
+    rw [← he, Field.finInsepDegree_self]
+  have : FiniteDimensional K f.fieldRange :=
+    Module.Finite.of_surjective (Algebra.linearMap K f.fieldRange) fun y ↦
+      ⟨f.equivFieldRange.symm y, by
+        simp [Algebra.linearMap_apply, RingHom.algebraMap_toAlgebra]⟩
+  have hmul := Field.finInsepDegree_mul_finInsepDegree_of_isAlgebraic K f.fieldRange L
+  rw [h1, one_mul] at hmul
+  exact hmul
 
 end TauCeti.AlgHom

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -52,9 +52,21 @@ theorem finrank_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebra
   exact (Algebra.finrank_eq_of_equiv_equiv f.equivFieldRange.toRingEquiv (RingEquiv.refl L)
     hsquare).symm
 
+/-- The transported base algebra structure on `f.fieldRange` has `f.equivFieldRange` as its
+structure map. Private: it exists so the degree transports below do not lean on definitional
+equality between the `AlgHom`, `RingHom` and `AlgEquiv` wrappers. -/
+private theorem algebraMap_equivFieldRange (f : K →ₐ[F] L) (z : K) :
+    letI := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
+    algebraMap K f.fieldRange z = f.equivFieldRange z := by
+  rw [RingHom.algebraMap_toAlgebra]
+  rfl
+
 /-- **The separable degree above the range of a field embedding equals the one above its
 source.** The separable analogue of `finrank_fieldRange`, for an algebraic `K`-algebra structure
-on `L` whose structure map is `f`. -/
+on `L` whose structure map is `f`.
+
+Its inseparable twin needs no algebraicity, because Mathlib's inseparable tower law asks only for
+the lower step; the separable one asks for the upper. -/
 theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z)
     [Algebra.IsAlgebraic K L] :
     Field.finSepDegree f.fieldRange L = Field.finSepDegree K L := by
@@ -66,8 +78,8 @@ theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, al
   have h1 : Field.finSepDegree K f.fieldRange = 1 := by
     have he : Field.finSepDegree K K = Field.finSepDegree K f.fieldRange :=
       Field.finSepDegree_eq_of_equiv K K f.fieldRange
-        (AlgEquiv.ofRingEquiv (f := (f.equivFieldRange).toRingEquiv) fun z ↦ by
-          rw [RingHom.algebraMap_toAlgebra]; rfl)
+        (AlgEquiv.ofRingEquiv (f := (f.equivFieldRange).toRingEquiv)
+          (algebraMap_equivFieldRange f))
     rw [← he, Field.finSepDegree_self]
   have : Algebra.IsAlgebraic (f.fieldRange) L := Algebra.IsAlgebraic.tower_top (K := K) _
   have hmul := Field.finSepDegree_mul_finSepDegree_of_isAlgebraic K f.fieldRange L
@@ -76,8 +88,7 @@ theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, al
 
 /-- **The inseparable degree above the range of a field embedding equals the one above its
 source**, under the same hypotheses as `finSepDegree_fieldRange`. -/
-theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z)
-    [Algebra.IsAlgebraic K L] :
+theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
     Field.finInsepDegree f.fieldRange L = Field.finInsepDegree K L := by
   let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
   have : IsScalarTower K f.fieldRange L :=
@@ -87,8 +98,8 @@ theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, 
   have h1 : Field.finInsepDegree K f.fieldRange = 1 := by
     have he : Field.finInsepDegree K K = Field.finInsepDegree K f.fieldRange :=
       Field.finInsepDegree_eq_of_equiv K K f.fieldRange
-        (AlgEquiv.ofRingEquiv (f := (f.equivFieldRange).toRingEquiv) fun z ↦ by
-          rw [RingHom.algebraMap_toAlgebra]; rfl)
+        (AlgEquiv.ofRingEquiv (f := (f.equivFieldRange).toRingEquiv)
+          (algebraMap_equivFieldRange f))
     rw [← he, Field.finInsepDegree_self]
   have : FiniteDimensional K f.fieldRange :=
     Module.Finite.of_surjective (Algebra.linearMap K f.fieldRange) fun y ↦

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -52,34 +52,9 @@ theorem finrank_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebra
   exact (Algebra.finrank_eq_of_equiv_equiv f.equivFieldRange.toRingEquiv (RingEquiv.refl L)
     hsquare).symm
 
-/-- **The separable degree is unchanged by a surjective base change.** For a tower
-`K → E → L` whose lower map is onto, an `L`-embedding is `E`-linear exactly when it is
-`K`-linear, so the two embedding sets coincide. -/
-theorem _root_.Field.finSepDegree_of_surjective {E : Type*} [Field E] [Algebra K L] [Algebra K E]
-    [Algebra E L] [IsScalarTower K E L] (hsurj : Function.Surjective (algebraMap K E)) :
-    Field.finSepDegree E L = Field.finSepDegree K L := by
-  unfold Field.finSepDegree
-  exact Nat.card_congr (AlgHom.extendScalarsOfSurjective hsurj).symm
-
-/-- **The inseparable degree is unchanged by a surjective base change**, by the same tower: a
-surjective map of fields is bijective, so the lower step has degree one. -/
-theorem _root_.Field.finInsepDegree_of_surjective {E : Type*} [Field E] [Algebra K L]
-    [Algebra K E] [Algebra E L] [IsScalarTower K E L] [Algebra.IsAlgebraic K E]
-    (hsurj : Function.Surjective (algebraMap K E)) :
-    Field.finInsepDegree E L = Field.finInsepDegree K L := by
-  have hrank : Module.finrank K E = 1 :=
-    finrank_eq_one_iff_of_nonzero' (1 : E) one_ne_zero |>.2 fun w ↦
-      ⟨(hsurj w).choose, by simpa [Algebra.smul_def] using (hsurj w).choose_spec⟩
-  have h1 : Field.finInsepDegree K E = 1 := by
-    have hmul := Field.finSepDegree_mul_finInsepDegree K E
-    rw [hrank] at hmul
-    exact Nat.eq_one_of_mul_eq_one_left hmul
-  have hmul := Field.finInsepDegree_mul_finInsepDegree_of_isAlgebraic K E L
-  rw [h1, one_mul] at hmul
-  exact hmul
-
 /-- **The separable degree above the range of a field embedding equals the one above its
-source.** The `f.fieldRange` case of `Field.finSepDegree_of_surjective`. -/
+source.** `f.equivFieldRange` is onto, so an `L`-embedding is `f.fieldRange`-linear exactly when
+it is `K`-linear and the two embedding sets coincide. -/
 theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
     Field.finSepDegree f.fieldRange L = Field.finSepDegree K L := by
   let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
@@ -87,12 +62,15 @@ theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, al
     IsScalarTower.of_algebraMap_eq fun z ↦ by
       rw [RingHom.algebraMap_toAlgebra]
       exact (h z).trans (_root_.AlgHom.equivFieldRange_apply_coe f z).symm
-  exact Field.finSepDegree_of_surjective fun r ↦
+  have hsurj : Function.Surjective (algebraMap K f.fieldRange) := fun r ↦
     ⟨f.equivFieldRange.symm r, by
       rw [RingHom.algebraMap_toAlgebra]; exact f.equivFieldRange.apply_symm_apply r⟩
+  unfold Field.finSepDegree
+  exact Nat.card_congr (AlgHom.extendScalarsOfSurjective hsurj).symm
 
 /-- **The inseparable degree above the range of a field embedding equals the one above its
-source.** The `f.fieldRange` case of `Field.finInsepDegree_of_surjective`. -/
+source.** Along the same identification: the lower step of the tower `K → f.fieldRange → L` is
+bijective, hence of degree one, so the tower law leaves the upper step's degree unchanged. -/
 theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
     Field.finInsepDegree f.fieldRange L = Field.finInsepDegree K L := by
   let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
@@ -105,6 +83,14 @@ theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, 
       rw [RingHom.algebraMap_toAlgebra]; exact f.equivFieldRange.apply_symm_apply r⟩
   have : FiniteDimensional K f.fieldRange :=
     Module.Finite.of_surjective (Algebra.linearMap K f.fieldRange) hsurj
-  exact Field.finInsepDegree_of_surjective hsurj
+  have hrank : Module.finrank K f.fieldRange = 1 :=
+    Module.finrank_of_bijective_algebraMap ⟨FaithfulSMul.algebraMap_injective _ _, hsurj⟩
+  have h1 : Field.finInsepDegree K f.fieldRange = 1 := by
+    have hmul := Field.finSepDegree_mul_finInsepDegree K f.fieldRange
+    rw [hrank] at hmul
+    exact Nat.eq_one_of_mul_eq_one_left hmul
+  have hmul := Field.finInsepDegree_mul_finInsepDegree_of_isAlgebraic K f.fieldRange L
+  rw [h1, one_mul] at hmul
+  exact hmul
 
 end TauCeti.AlgHom

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -63,29 +63,32 @@ private theorem algebraMap_equivFieldRange (f : K →ₐ[F] L) (z : K) :
   rfl
 
 /-- **The separable degree above the range of a field embedding equals the one above its
-source.** The separable analogue of `finrank_fieldRange`, for an algebraic `K`-algebra structure
-on `L` whose structure map is `f`.
-
-Its inseparable twin needs no algebraicity, because Mathlib's inseparable tower law asks only for
-the lower step; the separable one asks for the upper. -/
-theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z)
-    [Algebra.IsAlgebraic K L] :
+source.** The separable analogue of `finrank_fieldRange`, for any `K`-algebra structure on `L`
+whose structure map is `f`. No algebraicity is needed: the two embedding sets are the same maps,
+carrying `K`-linearity and `f.fieldRange`-linearity interchangeably. -/
+theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
     Field.finSepDegree f.fieldRange L = Field.finSepDegree K L := by
   let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
-  have : IsScalarTower K f.fieldRange L :=
+  have htow : IsScalarTower K f.fieldRange L :=
     IsScalarTower.of_algebraMap_eq fun z ↦ by
       rw [RingHom.algebraMap_toAlgebra]
       exact (h z).trans (_root_.AlgHom.equivFieldRange_apply_coe f z).symm
-  have h1 : Field.finSepDegree K f.fieldRange = 1 := by
-    have he : Field.finSepDegree K K = Field.finSepDegree K f.fieldRange :=
-      Field.finSepDegree_eq_of_equiv K K f.fieldRange
-        (AlgEquiv.ofRingEquiv (f := (f.equivFieldRange).toRingEquiv)
-          (algebraMap_equivFieldRange f))
-    rw [← he, Field.finSepDegree_self]
-  have : Algebra.IsAlgebraic (f.fieldRange) L := Algebra.IsAlgebraic.tower_top (K := K) _
-  have hmul := Field.finSepDegree_mul_finSepDegree_of_isAlgebraic K f.fieldRange L
-  rw [h1, one_mul] at hmul
-  exact hmul
+  have htow2 : IsScalarTower K f.fieldRange (AlgebraicClosure L) :=
+    IsScalarTower.of_algebraMap_eq fun z ↦ by
+      rw [IsScalarTower.algebraMap_apply K L (AlgebraicClosure L),
+        IsScalarTower.algebraMap_apply K f.fieldRange L,
+        ← IsScalarTower.algebraMap_apply (f.fieldRange) L (AlgebraicClosure L)]
+  have hsurj : Function.Surjective (algebraMap K f.fieldRange) := fun r ↦
+    ⟨f.equivFieldRange.symm r, by
+      rw [RingHom.algebraMap_toAlgebra]; exact f.equivFieldRange.apply_symm_apply r⟩
+  unfold Field.finSepDegree
+  refine Nat.card_congr ⟨fun σ => σ.restrictScalars K, fun σ => ⟨σ.toRingHom, ?_⟩, ?_, ?_⟩
+  · intro r
+    obtain ⟨k, rfl⟩ := hsurj r
+    simp only [← IsScalarTower.algebraMap_apply]
+    simp
+  · intro σ; rfl
+  · intro σ; rfl
 
 /-- **The inseparable degree above the range of a field embedding equals the one above its
 source.** Needs only the `K`-algebra structure on `L` whose structure map is `f` — no

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -6,8 +6,7 @@ module
 
 public import Mathlib.FieldTheory.IntermediateField.Basic
 public import Mathlib.LinearAlgebra.Dimension.Finrank
-public import Mathlib.FieldTheory.SeparableClosure
-import Mathlib.FieldTheory.PurelyInseparable.Tower
+public import TauCeti.FieldTheory.SeparableDegree
 
 /-!
 # The degree above the range of a field embedding
@@ -29,7 +28,9 @@ different embeddings `f` induce different structures, so none can be registered 
 
 * `TauCeti.AlgHom.finrank_fieldRange`: `[L : f.fieldRange] = [L : K]`.
 * `TauCeti.AlgHom.finSepDegree_fieldRange` and `TauCeti.AlgHom.finInsepDegree_fieldRange`: the
-  same for the separable and inseparable degrees.
+  same for the separable and inseparable degrees. These are the `f.fieldRange` cases of the
+  general transports in `TauCeti.FieldTheory.SeparableDegree`, which is where a caller holding
+  some other surjectively-presented intermediate field should look.
 -/
 
 public section
@@ -53,8 +54,7 @@ theorem finrank_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebra
     hsquare).symm
 
 /-- **The separable degree above the range of a field embedding equals the one above its
-source.** `f.equivFieldRange` is onto, so an `L`-embedding is `f.fieldRange`-linear exactly when
-it is `K`-linear and the two embedding sets coincide. -/
+source.** The `f.fieldRange` case of `Field.finSepDegree_eq_of_surjective`. -/
 theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
     Field.finSepDegree f.fieldRange L = Field.finSepDegree K L := by
   let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
@@ -62,15 +62,12 @@ theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, al
     IsScalarTower.of_algebraMap_eq fun z ↦ by
       rw [RingHom.algebraMap_toAlgebra]
       exact (h z).trans (_root_.AlgHom.equivFieldRange_apply_coe f z).symm
-  have hsurj : Function.Surjective (algebraMap K f.fieldRange) := fun r ↦
+  exact Field.finSepDegree_eq_of_surjective fun r ↦
     ⟨f.equivFieldRange.symm r, by
       rw [RingHom.algebraMap_toAlgebra]; exact f.equivFieldRange.apply_symm_apply r⟩
-  unfold Field.finSepDegree
-  exact Nat.card_congr (AlgHom.extendScalarsOfSurjective hsurj).symm
 
 /-- **The inseparable degree above the range of a field embedding equals the one above its
-source.** Along the same identification: the lower step of the tower `K → f.fieldRange → L` is
-bijective, hence of degree one, so the tower law leaves the upper step's degree unchanged. -/
+source.** The `f.fieldRange` case of `Field.finInsepDegree_eq_of_surjective`. -/
 theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
     Field.finInsepDegree f.fieldRange L = Field.finInsepDegree K L := by
   let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
@@ -78,19 +75,8 @@ theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, 
     IsScalarTower.of_algebraMap_eq fun z ↦ by
       rw [RingHom.algebraMap_toAlgebra]
       exact (h z).trans (_root_.AlgHom.equivFieldRange_apply_coe f z).symm
-  have hsurj : Function.Surjective (algebraMap K f.fieldRange) := fun r ↦
+  exact Field.finInsepDegree_eq_of_surjective fun r ↦
     ⟨f.equivFieldRange.symm r, by
       rw [RingHom.algebraMap_toAlgebra]; exact f.equivFieldRange.apply_symm_apply r⟩
-  have : FiniteDimensional K f.fieldRange :=
-    Module.Finite.of_surjective (Algebra.linearMap K f.fieldRange) hsurj
-  have hrank : Module.finrank K f.fieldRange = 1 :=
-    Module.finrank_of_bijective_algebraMap ⟨FaithfulSMul.algebraMap_injective _ _, hsurj⟩
-  have h1 : Field.finInsepDegree K f.fieldRange = 1 := by
-    have hmul := Field.finSepDegree_mul_finInsepDegree K f.fieldRange
-    rw [hrank] at hmul
-    exact Nat.eq_one_of_mul_eq_one_left hmul
-  have hmul := Field.finInsepDegree_mul_finInsepDegree_of_isAlgebraic K f.fieldRange L
-  rw [h1, one_mul] at hmul
-  exact hmul
 
 end TauCeti.AlgHom

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -53,8 +53,8 @@ theorem finrank_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebra
     hsquare).symm
 
 /-- **The separable degree above the range of a field embedding equals the one above its
-source.** The separable analogue of `finrank_fieldRange`, for any `K`-algebra structure on `L`
-whose structure map is `f`. -/
+source.** The separable analogue of `finrank_fieldRange`, for an algebraic `K`-algebra structure
+on `L` whose structure map is `f`. -/
 theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z)
     [Algebra.IsAlgebraic K L] :
     Field.finSepDegree f.fieldRange L = Field.finSepDegree K L := by

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -6,7 +6,8 @@ module
 
 public import Mathlib.FieldTheory.IntermediateField.Basic
 public import Mathlib.LinearAlgebra.Dimension.Finrank
-public import Mathlib.FieldTheory.PurelyInseparable.Basic
+public import Mathlib.FieldTheory.SeparableClosure
+import Mathlib.FieldTheory.PurelyInseparable.Basic
 import Mathlib.FieldTheory.PurelyInseparable.Tower
 
 /-!
@@ -87,7 +88,9 @@ theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, al
   exact hmul
 
 /-- **The inseparable degree above the range of a field embedding equals the one above its
-source**, under the same hypotheses as `finSepDegree_fieldRange`. -/
+source.** Needs only the `K`-algebra structure on `L` whose structure map is `f` — no
+algebraicity of `L / K`, unlike its separable twin, because Mathlib's inseparable tower law asks
+only for the lower step. -/
 theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
     Field.finInsepDegree f.fieldRange L = Field.finInsepDegree K L := by
   let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -7,7 +7,6 @@ module
 public import Mathlib.FieldTheory.IntermediateField.Basic
 public import Mathlib.LinearAlgebra.Dimension.Finrank
 public import Mathlib.FieldTheory.SeparableClosure
-import Mathlib.FieldTheory.PurelyInseparable.Basic
 import Mathlib.FieldTheory.PurelyInseparable.Tower
 
 /-!
@@ -82,18 +81,11 @@ theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, al
     ⟨f.equivFieldRange.symm r, by
       rw [RingHom.algebraMap_toAlgebra]; exact f.equivFieldRange.apply_symm_apply r⟩
   unfold Field.finSepDegree
-  refine Nat.card_congr ⟨fun σ => σ.restrictScalars K, fun σ => ⟨σ.toRingHom, ?_⟩, ?_, ?_⟩
-  · intro r
-    obtain ⟨k, rfl⟩ := hsurj r
-    simp only [← IsScalarTower.algebraMap_apply]
-    simp
-  · intro σ; rfl
-  · intro σ; rfl
+  exact Nat.card_congr (AlgHom.extendScalarsOfSurjective hsurj).symm
 
 /-- **The inseparable degree above the range of a field embedding equals the one above its
-source.** Needs only the `K`-algebra structure on `L` whose structure map is `f` — no
-algebraicity of `L / K`, unlike its separable twin, because Mathlib's inseparable tower law asks
-only for the lower step. -/
+source.** The inseparable analogue of `finSepDegree_fieldRange`, for any `K`-algebra structure on
+`L` whose structure map is `f`. -/
 theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
     Field.finInsepDegree f.fieldRange L = Field.finInsepDegree K L := by
   let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -52,15 +52,6 @@ theorem finrank_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebra
   exact (Algebra.finrank_eq_of_equiv_equiv f.equivFieldRange.toRingEquiv (RingEquiv.refl L)
     hsquare).symm
 
-/-- The transported base algebra structure on `f.fieldRange` has `f.equivFieldRange` as its
-structure map. Private: it exists so the degree transports below do not lean on definitional
-equality between the `AlgHom`, `RingHom` and `AlgEquiv` wrappers. -/
-private theorem algebraMap_equivFieldRange (f : K →ₐ[F] L) (z : K) :
-    letI := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
-    algebraMap K f.fieldRange z = f.equivFieldRange z := by
-  rw [RingHom.algebraMap_toAlgebra]
-  rfl
-
 /-- **The separable degree above the range of a field embedding equals the one above its
 source.** The separable analogue of `finrank_fieldRange`, for any `K`-algebra structure on `L`
 whose structure map is `f`. No algebraicity is needed: the two embedding sets are the same maps,
@@ -97,7 +88,7 @@ theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, 
     have he : Field.finInsepDegree K K = Field.finInsepDegree K f.fieldRange :=
       Field.finInsepDegree_eq_of_equiv K K f.fieldRange
         (AlgEquiv.ofRingEquiv (f := (f.equivFieldRange).toRingEquiv)
-          (algebraMap_equivFieldRange f))
+          fun z ↦ by rw [RingHom.algebraMap_toAlgebra]; rfl)
     rw [← he, Field.finInsepDegree_self]
   have : FiniteDimensional K f.fieldRange :=
     Module.Finite.of_surjective (Algebra.linearMap K f.fieldRange) fun y ↦

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.FieldTheory.IntermediateField.Basic
 public import Mathlib.LinearAlgebra.Dimension.Finrank
+public import Mathlib.FieldTheory.PurelyInseparable.Basic
 
 /-!
 # The degree above the range of a field embedding
@@ -26,6 +27,8 @@ different embeddings `f` induce different structures, so none can be registered 
 ## Main results
 
 * `TauCeti.AlgHom.finrank_fieldRange`: `[L : f.fieldRange] = [L : K]`.
+* `TauCeti.AlgHom.finSepDegree_fieldRange` and `TauCeti.AlgHom.finInsepDegree_fieldRange`: the
+  same for the separable and inseparable degrees.
 -/
 
 public section
@@ -47,5 +50,40 @@ theorem finrank_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebra
     exact (_root_.AlgHom.equivFieldRange_apply_coe f z).trans (h z).symm
   exact (Algebra.finrank_eq_of_equiv_equiv f.equivFieldRange.toRingEquiv (RingEquiv.refl L)
     hsquare).symm
+
+/-- **The separable degree above the range of a field embedding equals the one above its
+source.** The separable analogue of `finrank_fieldRange`, for any `K`-algebra structure on `L`
+whose structure map is `f`. -/
+theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z)
+    [Algebra.IsAlgebraic K L] :
+    Field.finSepDegree f.fieldRange L = Field.finSepDegree K L := by
+  let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
+  have : IsScalarTower K f.fieldRange L :=
+    IsScalarTower.of_algebraMap_eq fun z ↦ by
+      rw [RingHom.algebraMap_toAlgebra]
+      exact (h z).trans (_root_.AlgHom.equivFieldRange_apply_coe f z).symm
+  have h1 : Field.finSepDegree K f.fieldRange = 1 := by
+    have he : Field.finSepDegree K K = Field.finSepDegree K f.fieldRange :=
+      Field.finSepDegree_eq_of_equiv K K f.fieldRange
+        (AlgEquiv.ofRingEquiv (f := (f.equivFieldRange).toRingEquiv) fun z ↦ by
+          rw [RingHom.algebraMap_toAlgebra]; rfl)
+    rw [← he, Field.finSepDegree_self]
+  have : Algebra.IsAlgebraic (f.fieldRange) L := Algebra.IsAlgebraic.tower_top (K := K) _
+  have hmul := Field.finSepDegree_mul_finSepDegree_of_isAlgebraic K f.fieldRange L
+  rw [h1, one_mul] at hmul
+  exact hmul
+
+/-- **The inseparable degree above the range of a field embedding equals the one above its
+source**, under the same hypotheses as `finSepDegree_fieldRange`. -/
+theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z)
+    [FiniteDimensional K L] :
+    Field.finInsepDegree f.fieldRange L = Field.finInsepDegree K L := by
+  have hsep := finSepDegree_fieldRange f h
+  have hrank := finrank_fieldRange f h
+  have hL := Field.finSepDegree_mul_finInsepDegree (f.fieldRange) L
+  have hK := Field.finSepDegree_mul_finInsepDegree K L
+  rw [hsep] at hL
+  rw [hrank] at hL
+  exact Nat.eq_of_mul_eq_mul_left (NeZero.pos (Field.finSepDegree K L)) (hL.trans hK.symm)
 
 end TauCeti.AlgHom

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -52,31 +52,47 @@ theorem finrank_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebra
   exact (Algebra.finrank_eq_of_equiv_equiv f.equivFieldRange.toRingEquiv (RingEquiv.refl L)
     hsquare).symm
 
-/-- **The separable degree above the range of a field embedding equals the one above its
-source.** The separable analogue of `finrank_fieldRange`, for any `K`-algebra structure on `L`
-whose structure map is `f`. No algebraicity is needed: the two embedding sets are the same maps,
-carrying `K`-linearity and `f.fieldRange`-linearity interchangeably. -/
-theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
-    Field.finSepDegree f.fieldRange L = Field.finSepDegree K L := by
-  let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
-  have htow : IsScalarTower K f.fieldRange L :=
-    IsScalarTower.of_algebraMap_eq fun z ↦ by
-      rw [RingHom.algebraMap_toAlgebra]
-      exact (h z).trans (_root_.AlgHom.equivFieldRange_apply_coe f z).symm
-  have htow2 : IsScalarTower K f.fieldRange (AlgebraicClosure L) :=
-    IsScalarTower.of_algebraMap_eq fun z ↦ by
-      rw [IsScalarTower.algebraMap_apply K L (AlgebraicClosure L),
-        IsScalarTower.algebraMap_apply K f.fieldRange L,
-        ← IsScalarTower.algebraMap_apply (f.fieldRange) L (AlgebraicClosure L)]
-  have hsurj : Function.Surjective (algebraMap K f.fieldRange) := fun r ↦
-    ⟨f.equivFieldRange.symm r, by
-      rw [RingHom.algebraMap_toAlgebra]; exact f.equivFieldRange.apply_symm_apply r⟩
+/-- **The separable degree is unchanged by a surjective base change.** For a tower
+`K → E → L` whose lower map is onto, an `L`-embedding is `E`-linear exactly when it is
+`K`-linear, so the two embedding sets coincide. -/
+theorem _root_.Field.finSepDegree_of_surjective {E : Type*} [Field E] [Algebra K L] [Algebra K E]
+    [Algebra E L] [IsScalarTower K E L] (hsurj : Function.Surjective (algebraMap K E)) :
+    Field.finSepDegree E L = Field.finSepDegree K L := by
   unfold Field.finSepDegree
   exact Nat.card_congr (AlgHom.extendScalarsOfSurjective hsurj).symm
 
+/-- **The inseparable degree is unchanged by a surjective base change**, by the same tower: a
+surjective map of fields is bijective, so the lower step has degree one. -/
+theorem _root_.Field.finInsepDegree_of_surjective {E : Type*} [Field E] [Algebra K L]
+    [Algebra K E] [Algebra E L] [IsScalarTower K E L] [Algebra.IsAlgebraic K E]
+    (hsurj : Function.Surjective (algebraMap K E)) :
+    Field.finInsepDegree E L = Field.finInsepDegree K L := by
+  have hrank : Module.finrank K E = 1 :=
+    finrank_eq_one_iff_of_nonzero' (1 : E) one_ne_zero |>.2 fun w ↦
+      ⟨(hsurj w).choose, by simpa [Algebra.smul_def] using (hsurj w).choose_spec⟩
+  have h1 : Field.finInsepDegree K E = 1 := by
+    have hmul := Field.finSepDegree_mul_finInsepDegree K E
+    rw [hrank] at hmul
+    exact Nat.eq_one_of_mul_eq_one_left hmul
+  have hmul := Field.finInsepDegree_mul_finInsepDegree_of_isAlgebraic K E L
+  rw [h1, one_mul] at hmul
+  exact hmul
+
+/-- **The separable degree above the range of a field embedding equals the one above its
+source.** The `f.fieldRange` case of `Field.finSepDegree_of_surjective`. -/
+theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
+    Field.finSepDegree f.fieldRange L = Field.finSepDegree K L := by
+  let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
+  have : IsScalarTower K f.fieldRange L :=
+    IsScalarTower.of_algebraMap_eq fun z ↦ by
+      rw [RingHom.algebraMap_toAlgebra]
+      exact (h z).trans (_root_.AlgHom.equivFieldRange_apply_coe f z).symm
+  exact Field.finSepDegree_of_surjective fun r ↦
+    ⟨f.equivFieldRange.symm r, by
+      rw [RingHom.algebraMap_toAlgebra]; exact f.equivFieldRange.apply_symm_apply r⟩
+
 /-- **The inseparable degree above the range of a field embedding equals the one above its
-source.** The inseparable analogue of `finSepDegree_fieldRange`, for any `K`-algebra structure on
-`L` whose structure map is `f`. -/
+source.** The `f.fieldRange` case of `Field.finInsepDegree_of_surjective`. -/
 theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
     Field.finInsepDegree f.fieldRange L = Field.finInsepDegree K L := by
   let _ : Algebra K f.fieldRange := (f.equivFieldRange).toAlgHom.toRingHom.toAlgebra
@@ -84,18 +100,11 @@ theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, 
     IsScalarTower.of_algebraMap_eq fun z ↦ by
       rw [RingHom.algebraMap_toAlgebra]
       exact (h z).trans (_root_.AlgHom.equivFieldRange_apply_coe f z).symm
-  have h1 : Field.finInsepDegree K f.fieldRange = 1 := by
-    have he : Field.finInsepDegree K K = Field.finInsepDegree K f.fieldRange :=
-      Field.finInsepDegree_eq_of_equiv K K f.fieldRange
-        (AlgEquiv.ofRingEquiv (f := (f.equivFieldRange).toRingEquiv)
-          fun z ↦ by rw [RingHom.algebraMap_toAlgebra]; rfl)
-    rw [← he, Field.finInsepDegree_self]
+  have hsurj : Function.Surjective (algebraMap K f.fieldRange) := fun r ↦
+    ⟨f.equivFieldRange.symm r, by
+      rw [RingHom.algebraMap_toAlgebra]; exact f.equivFieldRange.apply_symm_apply r⟩
   have : FiniteDimensional K f.fieldRange :=
-    Module.Finite.of_surjective (Algebra.linearMap K f.fieldRange) fun y ↦
-      ⟨f.equivFieldRange.symm y, by
-        simp [Algebra.linearMap_apply, RingHom.algebraMap_toAlgebra]⟩
-  have hmul := Field.finInsepDegree_mul_finInsepDegree_of_isAlgebraic K f.fieldRange L
-  rw [h1, one_mul] at hmul
-  exact hmul
+    Module.Finite.of_surjective (Algebra.linearMap K f.fieldRange) hsurj
+  exact Field.finInsepDegree_of_surjective hsurj
 
 end TauCeti.AlgHom

--- a/TauCeti/FieldTheory/SeparableDegree.lean
+++ b/TauCeti/FieldTheory/SeparableDegree.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.FieldTheory.SeparableClosure
+public import Mathlib.LinearAlgebra.Dimension.Finrank
+import Mathlib.FieldTheory.PurelyInseparable.Tower
+
+/-!
+# Separable and inseparable degrees under a surjective base change
+
+In a tower `K → E → L` of fields whose lower map `algebraMap K E` is onto, `E` carries no more
+information over `K` than `K` itself does, so the degree of `L` is the same whichever of the two
+it is measured over. This file records that for the separable and inseparable degrees, alongside
+`Module.finrank`, for which Mathlib already has the statement.
+
+The hypothesis is surjectivity rather than bijectivity because a map of fields is automatically
+injective; and it is stated for an arbitrary tower rather than for a specific construction, so
+that a caller with any surjectively-presented intermediate field can use it.
+
+## Main results
+
+* `Field.finSepDegree_eq_of_surjective`: `[L : E]_s = [L : K]_s`.
+* `Field.finInsepDegree_eq_of_surjective`: `[L : E]_i = [L : K]_i`.
+-/
+
+public section
+
+variable {K L : Type*} [Field K] [Field L]
+
+/-- **The separable degree is unchanged by a surjective base change.** Use this to move a
+separable degree between an intermediate field and a field presented as mapping onto it. -/
+theorem Field.finSepDegree_eq_of_surjective {E : Type*} [Field E] [Algebra K L] [Algebra K E]
+    [Algebra E L] [IsScalarTower K E L] (hsurj : Function.Surjective (algebraMap K E)) :
+    Field.finSepDegree E L = Field.finSepDegree K L := by
+  -- an `L`-embedding is `E`-linear exactly when it is `K`-linear, so the embedding sets agree
+  unfold Field.finSepDegree
+  exact Nat.card_congr (AlgHom.extendScalarsOfSurjective hsurj).symm
+
+/-- **The inseparable degree is unchanged by a surjective base change.** The inseparable
+counterpart of `Field.finSepDegree_eq_of_surjective`, for the same tower. -/
+theorem Field.finInsepDegree_eq_of_surjective {E : Type*} [Field E] [Algebra K L] [Algebra K E]
+    [Algebra E L] [IsScalarTower K E L] (hsurj : Function.Surjective (algebraMap K E)) :
+    Field.finInsepDegree E L = Field.finInsepDegree K L := by
+  -- the lower step is bijective, hence of degree one, so the tower law leaves the upper step alone
+  have : FiniteDimensional K E := Module.Finite.of_surjective (Algebra.linearMap K E) hsurj
+  have hrank : Module.finrank K E = 1 :=
+    Module.finrank_of_bijective_algebraMap ⟨FaithfulSMul.algebraMap_injective _ _, hsurj⟩
+  have h1 : Field.finInsepDegree K E = 1 := by
+    have hmul := Field.finSepDegree_mul_finInsepDegree K E
+    rw [hrank] at hmul
+    exact Nat.eq_one_of_mul_eq_one_left hmul
+  have hmul := Field.finInsepDegree_mul_finInsepDegree_of_isAlgebraic K E L
+  rw [h1, one_mul] at hmul
+  exact hmul


### PR DESCRIPTION
The separable analogues of the existing `TauCeti.AlgHom.finrank_fieldRange`: the general
surjective-base-change transports, and the `fieldRange` cases that specialise them.

```lean
theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
    Field.finSepDegree f.fieldRange L = Field.finSepDegree K L

theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
    Field.finInsepDegree f.fieldRange L = Field.finInsepDegree K L
```

## Why it is worth its own PR

`finrank_fieldRange` already exists in `FieldRange.lean`, and `Isogeny.degree_eq_finrank` is built
on it: that is how an isogeny's degree is read off an arbitrary pullback-induced algebra structure
rather than a globally registered one. The separable and inseparable degrees need exactly the same
service.

It is deliberately **not** bundled with the isogeny-side consumer. That consumer —
`Isogeny.separableDegree` / `inseparableDegree` and their composition laws — is
`Roadmap: EllipticCurves` material in `AlgebraicGeometry/EllipticCurve/`, whereas these two are
general field theory usable by anything with an `AlgHom` between fields. Reviewing them together
meant every round judged both surfaces at once, with findings on one blocking the other. The
repository's one-topic rule says to ship the prerequisite separately, and that is what this is.

## The route

`Field.finSepDegree A L` is `Nat.card (Field.Emb A L)`, and an `L →ₐ[A] AlgebraicClosure L` is a
ring map carrying an `A`-linearity condition. When `algebraMap K E` is onto, the `K`-condition and
the `E`-condition pick out the *same* maps, which is exactly what
`AlgHom.extendScalarsOfSurjective` provides as a bijection.

The inseparable case runs through Mathlib's inseparable tower law instead: a surjective map of
fields is bijective, so `Module.finrank K E = 1`, hence `[E : K]_i = 1`, and the tower law leaves
`[L : E]_i = [L : K]_i`. Neither statement needs an algebraicity hypothesis — surjectivity already
gives `FiniteDimensional K E`, so it is derived internally rather than demanded of callers.

## Scope

Four theorems: two general transports and the two `fieldRange` cases that specialise them, the
latter mirroring `finrank_fieldRange` in signature and purpose.

They are field theory, but not free-floating: they exist to serve Layer 1 of
`TauCetiRoadmap/EllipticCurves/README.md`, the bullet reading "the separable and inseparable
degrees, and separability of `φ`, are those of the field extension — Mathlib's existing
`FieldTheory`, not a flatness theory of morphisms". `Isogeny.degree_eq_finrank` already rests on
`finrank_fieldRange` in exactly this way; these two supply the same service for the split degrees,
and the isogeny-side consumers follow in their own PR.

## Two files, because the content is general and the application is not

The transports use only surjectivity of `algebraMap K E` in a tower `K → E → L`; nothing about
`AlgHom.fieldRange` enters. So they live in a new general file,
`TauCeti/FieldTheory/SeparableDegree.lean`:

```lean
theorem Field.finSepDegree_eq_of_surjective {E : Type*} [Field E] [Algebra K L] [Algebra K E]
    [Algebra E L] [IsScalarTower K E L] (hsurj : Function.Surjective (algebraMap K E)) :
    Field.finSepDegree E L = Field.finSepDegree K L

theorem Field.finInsepDegree_eq_of_surjective  -- same hypotheses
```

`FieldRange.lean` imports that and keeps only the two `fieldRange` corollaries, beside the
`finrank_fieldRange` they mirror. Neither transport takes an algebraicity hypothesis:
surjectivity already gives `FiniteDimensional K E`, which is derived inside the proof.

## Provenance

Original work against Mathlib's `FieldTheory`. The arithmetic inputs are Mathlib's:
`AlgHom.extendScalarsOfSurjective` (the embedding bijection under a surjective base change),
`Field.finInsepDegree_mul_finInsepDegree_of_isAlgebraic` and
`Field.finSepDegree_mul_finInsepDegree` (the tower and factorisation laws), and
`Module.finrank_of_bijective_algebraMap` (a bijective structure map has degree one). No external
source.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"fieldrange-sep-transport"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
