### PR TITLE
refactor(ModularForms): use Complex.im_le_norm instead of hand-rolling it

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/SingularSets.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/SingularSets.lean
@@ -271,7 +271,7 @@ theorem im_pos_of_mem_verticalSingularSet {S : Finset ℍ} {s : ℂ}
 part is bounded by the norm. -/
 theorem im_lt_of_mem_arcSingularSet {S : Finset ℍ} {s : ℂ} {H : ℝ}
     (hs : s ∈ arcSingularSet S) (hH : 1 < H) : s.im < H := by
-  have h1 : s.im ≤ ‖s‖ := (le_abs_self _).trans (Complex.abs_im_le_norm s)
+  have h1 : s.im ≤ ‖s‖ := Complex.im_le_norm s
   rw [norm_eq_one_of_mem_arcSingularSet hs] at h1
   linarith
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ValencePV.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ValencePV.lean
@@ -404,7 +404,7 @@ theorem sum_orderOfVanishingAt_add_qExpansionOrderAtCusp_eq [SlashInvariantFormC
   -- Both are forced by the data: excision centres sit on the unit circle, and every divisor
   -- point has `|re| < 1/2` while the basepoint has real part exactly `1/2`.
   have hHgt : ∀ s ∈ S, s.im < H := fun s hs => by
-    have h1 : s.im ≤ ‖s‖ := (le_abs_self _).trans (Complex.abs_im_le_norm s)
+    have h1 : s.im ≤ ‖s‖ := Complex.im_le_norm s
     rw [hnorm s hs] at h1
     linarith
   have hbase : fdBoundary H 0 ∉ (T : Set ℂ) := fun hmem => by


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"modularforms-im-le-norm-adoption"}-->

Refactor only — no new mathematics, no statement changes. `Roadmap: ModularForms` is attribution:
both sites are in that roadmap's Layer-1 contour machinery.

### What this does

Two proofs derive `s.im ≤ ‖s‖` in two steps:

```lean
have h1 : s.im ≤ ‖s‖ := (le_abs_self _).trans (Complex.abs_im_le_norm s)
```

Mathlib states it directly as `Complex.im_le_norm` (`Mathlib/Analysis/Complex/Norm.lean:190`), so
both become

```lean
have h1 : s.im ≤ ‖s‖ := Complex.im_le_norm s
```

at `LevelOne/FundamentalDomainBoundary/ValencePV.lean:407` and
`LevelOne/FundamentalDomainBoundary/SingularSets.lean:274`.

### Why these two and not the others

`Complex.abs_im_le_norm` is used correctly in many other places in the repo — it states
`|z.im| ≤ ‖z‖`, and where the absolute value is genuinely wanted it is the right lemma. Only the
`(le_abs_self _).trans (…)` two-step, which throws the absolute value away immediately, duplicates
`Complex.im_le_norm`. These are the two such sites in `ModularForms`.

The three remaining instances are in `Interior.lean` and are fixed by **#3323**, which touches that
file for other reasons; the two PRs are disjoint by file and together remove the pattern from
`ModularForms` entirely.

### Verification

Full `lake build` green (7905 jobs); `lake exe axioms` clean over 46693 declarations;
`lake exe module-system` clean over 2232 modules; `lint-env` PASS. No line exceeds 100 codepoints.
