### PR TITLE
feat(EDS): an elliptic sequence is determined by its first four terms

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Ext.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Ext.lean
@@ -12,9 +12,10 @@ public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Recurrence
 # An elliptic sequence is determined by its first four terms
 
 Two elliptic sequences that agree at `1, 2, 3, 4` are equal, provided the first two terms are
-nonzerodivisors. The two doubling recurrences determine every later term from four earlier ones,
-`Elementary.lean` supplies the value at `0` and the behaviour at negative indices, and
-`normEDSRec` is the induction that puts those together.
+nonzerodivisors. The two doubling recurrences determine every later term from a bounded window of
+earlier ones — five for the even step, four for the odd — `Elementary.lean` supplies the value at
+`0` and the behaviour at negative indices, and `normEDSRec` is the induction that puts those
+together.
 
 ## Main results
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Ext.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Ext.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Ring.NonZeroDivisors
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Elementary
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Recurrence
+
+/-!
+# An elliptic sequence is determined by its first four terms
+
+Two elliptic sequences that agree at `1, 2, 3, 4` are equal, provided the first two terms are
+nonzerodivisors. The two doubling recurrences determine every later term from four earlier ones,
+`Elementary.lean` supplies the value at `0` and the behaviour at negative indices, and
+`normEDSRec` is the induction that puts those together.
+
+## Main results
+
+* `IsEllipticSequence.ext`: `W = U` from agreement at `1, 2, 3, 4`.
+
+## Implementation notes
+
+The recurrences give the doubled-index term only up to a nonzerodivisor factor — `W 2 * W 1 ^ 2`
+at even indices and `W 1 ^ 3` at odd ones, which is exactly the shape `Recurrence.lean`'s
+docstring flags as needing "a hypothesis this file does not carry". Each inductive step therefore
+cancels that factor before comparing, which is where `one` and `two` are used.
+
+`normEDSRec` is indexed by `ℕ` while the recurrences are stated over `ℤ`, so each step pushes the
+cast through before rewriting; `Int.negInduction` then reduces negative indices to nonnegative
+ones through oddness.
+
+The index arithmetic then needs `ring_nf`. `rel_even` at `m + 3` writes its indices as `m + 3 - 1`
+and so on, while the induction hypotheses are stated at `m + 2`; `W` is opaque, so nothing equates
+those two terms until both are in normal form. Once they are, rewriting the hypotheses through the
+`W` side of the recurrence leaves it with the same right-hand side as the `U` side, and the two
+subtract.
+
+## Provenance
+
+Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
+declaration `IsEllSequence.ext`. That file's header reads
+`Authors: David Kurniadi Angdinata`; following this repository's convention for adapted material
+the upstream authorship is credited here rather than in the copyright header. J. Xu is
+acknowledged for the surrounding LutzNagell development — he authors `Universal.lean` and
+co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
+an author of the declaration above.
+
+The source derives the value at `0` and the oddness inline from its own `zero` and `neg`; here
+those are `Elementary.lean`'s `IsEllipticSequence.zero` and `IsEllipticSequence.neg`, so this file
+is the induction alone.
+-/
+
+public section
+
+open scoped nonZeroDivisors
+
+namespace IsEllipticSequence
+
+variable {R : Type*} [CommRing R] {W U : ℤ → R}
+
+/-- **An elliptic sequence is determined by its first four terms.** Two elliptic sequences
+agreeing at `1, 2, 3, 4` are equal, given that `W 1` and `W 2` are nonzerodivisors. -/
+protected theorem ext (hW : IsEllipticSequence W) (hU : IsEllipticSequence U)
+    (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
+    (h1 : W 1 = U 1) (h2 : W 2 = U 2) (h3 : W 3 = U 3) (h4 : W 4 = U 4) : W = U := by
+  have twoU : U 2 ∈ R⁰ := h2 ▸ two
+  have oneU : U 1 ∈ R⁰ := h1 ▸ one
+  funext n
+  induction n using Int.negInduction with
+  | nat n =>
+    refine normEDSRec ?_ h1 h2 h3 h4 (fun m e1 e2 e3 e4 e5 ↦ ?_) (fun m e1 e2 e3 e4 ↦ ?_) n
+    · rw [Nat.cast_zero, hW.zero 1 (by simpa using two), hU.zero 1 (by simpa using twoU)]
+    · have hw := hW.rel_even (m + 3)
+      have hu := hU.rel_even (m + 3)
+      push_cast at e1 e2 e3 e4 e5 ⊢
+      rw [← mul_cancel_right_mem_nonZeroDivisors (mul_mem two (pow_mem one 2))]
+      ring_nf at hw hu e1 e2 e3 e4 e5 ⊢
+      rw [e1, e2, e3, e4, e5, h1, h2] at hw
+      rw [h1, h2]
+      linear_combination hw - hu
+    · have hw := hW.rel_odd (m + 2)
+      have hu := hU.rel_odd (m + 2)
+      push_cast at e1 e2 e3 e4 ⊢
+      rw [← mul_cancel_right_mem_nonZeroDivisors (pow_mem one 3)]
+      ring_nf at hw hu e1 e2 e3 e4 ⊢
+      rw [e1, e2, e3, e4, h1] at hw
+      rw [h1]
+      linear_combination hw - hu
+  | neg hn n => rw [hW.neg one two, hU.neg oneU twoU, hn]
+
+end IsEllipticSequence


### PR DESCRIPTION
An elliptic sequence is determined by its first four terms.

```lean
protected theorem IsEllipticSequence.ext (hW : IsEllipticSequence W) (hU : IsEllipticSequence U)
    (one : W 1 ∈ R⁰) (two : W 2 ∈ R⁰)
    (h1 : W 1 = U 1) (h2 : W 2 = U 2) (h3 : W 3 = U 3) (h4 : W 4 = U 4) : W = U
```

The two doubling recurrences determine every later term from a bounded window of earlier ones, so
agreement at `1, 2, 3, 4` propagates. `normEDSRec` is the induction that does it — Mathlib already
has exactly the recursor this needs, five base cases with separate even and odd steps, the even
one consuming five earlier terms and the odd four — and `Int.negInduction` reduces negative
indices to nonnegative ones.

## It needs only two hypotheses, and that is the point of #3318

The recurrences alone are not enough: the induction also needs `W 0 = 0` and oddness, at both
sequences. Those are *not* hypotheses here — they are derived, by
`IsEllipticSequence.zero` and `IsEllipticSequence.neg` from #3318. Without that slice this
theorem would carry four extra hypotheses (`W 0 = 0`, `W.Odd`, `U 0 = 0`, `U.Odd`) and every
consumer would have to discharge them.

That is the whole reason #3318 went first, and it is worth checking against the code: the only
hypotheses beyond the two elliptic-sequence facts and the four agreements are `W 1, W 2 ∈ R⁰`.

## Why a nonzerodivisor hypothesis is unavoidable

`Recurrence.lean`'s docstring already states the difficulty, and this PR is the case it was
anticipating:

> The equations **relate** the doubled-index term to its neighbours; they do not determine it.
> Nothing here inverts `W 1` or `W 2 * W 1 ^ 2`, and over an arbitrary `CommRing` neither need be
> a unit, so solving for `W (2 * m + 1)` or `W (2 * m)` requires a hypothesis this file does not
> carry.

`W 1, W 2 ∈ R⁰` is that hypothesis. Each inductive step cancels the surviving factor —
`W 2 * W 1 ^ 2` at even indices, `W 1 ^ 3` at odd ones — via
`mul_cancel_right_mem_nonZeroDivisors`, which is weaker than inverting it.

## Mathlib absence

Checked semantically. The nearest result is `LinearRecurrence.sol_eq_of_eq_init`:

```lean
E.IsSolution u → E.IsSolution v → (u = v ↔ Set.EqOn u v ↑(Finset.range E.order))
```

— the same *shape* of theorem, and it does not apply: the elliptic relation is quadratic in the
sequence, not a linear recurrence, so `LinearRecurrence` cannot express it. Nothing in Mathlib's
`IsEllipticSequence` namespace (which contains exactly `id` and `smul`) is an extensionality
principle.

## Implementation note worth flagging for review

Each inductive step needs `ring_nf` before the hypotheses can be applied, and the reason is not
cosmetic: `rel_even` at `m + 3` writes its indices as `m + 3 - 1`, while the induction hypotheses
are stated at `m + 2`. `W` is opaque, so nothing equates `W (m + 3 - 1)` with `W (m + 2)` until
both are in normal form — `ring` alone fails on a difference of what are, semantically, identical
terms. Once normalised, rewriting the hypotheses through the `W` side of the recurrence leaves it
with the same right-hand side as the `U` side, and the two subtract.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md`, the **Layer 6** torsion/Nagell–Lutz strand. This is the
principle `Universal.lean` has been waiting on: it names `universalNormEDS_ne_zero` and
`universalNormEDS_mem_nonZeroDivisors` as deliberately not ported because they rest on
`normEDS 2 3 2 = id`, which "needs an extensionality principle for elliptic sequences that this
repository does not have". It does now. The chain from here is `normEDS 2 3 2 = id` → those two
lemmas → `normEDS_mul_complEDS`, the divisibility half of the TODO Mathlib records at
`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean:70`.

## Provenance

Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0 per file header, `main` at
`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declaration `IsEllSequence.ext`. That file's header
reads `Authors: David Kurniadi Angdinata`; following this repository's convention for adapted
material the upstream authorship is credited in the module docstring rather than in the copyright
header. J. Xu is acknowledged for the surrounding LutzNagell development — he authors
`Universal.lean` and co-authors `DivisionPolynomialOmega.lean` at the same revision — as context
for this port, not as an author of the declaration above.

The source derives the value at `0` and the oddness inline from its own `zero` and `neg`; here
both come from `Elementary.lean`, so this file is the induction alone. The source also closes its
steps with `erw` and `convert … <;> abel`; neither is used here — `ring_nf` plus
`linear_combination` does the same work without relying on reducible unfolding.

## Gates

`lake build` PASS at 7906 jobs, branch cut from current `main` (`62ad2a366`, which carries
#3318). No `sorry`, no `set_option`, no `native_decide`, no `erw`; the proof is 27 lines against
the 30-line threshold; no line over 100 codepoints — a limit `lake build` itself enforces, so the
green build is the evidence.

## Review status — please note

This PR is opened **without a local P8 scoreboard**, deliberately. The ChatGPT account behind
`~/.codex/auth.json` is over its usage limit until 2026-08-20, and `runner/reviewers.py` seeds its
reviewer's throwaway `CODEX_HOME` from that hardcoded path, so the second codex home on the machine
cannot be reached by exporting `CODEX_HOME`. Two P6 attempts returned all ten rubrics as
`rc=1 / PARSE_FAILED` at `cost=$0.0000` — zero cost meaning the provider never ran, so those are
infrastructure errors rather than verdicts.

The last genuine verdict is P6 round 1 at the parent commit: **9/10 green**, with `documentation`
correctly catching that I had written that both doubling recurrences determine a term from four
earlier terms when `normEDSRec`'s even step consumes five. That is fixed at this head.

CI's review therefore runs here instead of being displaced by a local post. That costs the project
a review my subscription would normally have covered, and I would rather flag it than have it
appear as an unexplained omission. Two workarounds were available and both were declined as not
mine to take: `--auth api` moves spend onto metered API keys, and `--reviewer claude` would publish
a Claude review of Claude-written Lean as the scoreboard that drives auto-merge — precisely what
pinning the reviewer to codex exists to prevent.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-ext"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
