### PR TITLE
feat: add the affine fppf site

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.AlgebraicGeometry.Group.Affine
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
 
 /-!
 # Scheme-valued points of affine Hopf spectra
@@ -40,6 +41,8 @@ Hopf algebra.
   becomes postcomposition by its contravariant `hopfSpec` image.
 * `TauCeti.CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain`: contravariance for arbitrary
   named point equivalences characterized by their underlying spectrum maps.
+* `TauCeti.CommHopfAlgCat.pointsPresheafIsoSchemePointsPresheaf`: the natural comparison between
+  convolution points and relative-spectrum points.
 -/
 
 public section
@@ -246,7 +249,62 @@ theorem pointMulEquivOfPresentation_mapDomain
   rw [← Category.assoc, ← Spec.map_comp, ← CommRingCat.ofHom_comp]
   rfl
 
+/-- Scheme-valued affine-group points, restricted along relative `Spec` and regarded as a
+type-valued presheaf on opposite commutative algebras. -/
+noncomputable abbrev schemePointsPresheaf (H : _root_.CommHopfAlgCat.{u} R) :
+    ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ ⥤ Type u :=
+  (AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙
+    yoneda.obj
+      ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X
+
+/-- The scheme-points presheaf at `A` is the set of morphisms over `Spec R` from `Spec A` to
+`Spec H`. -/
+theorem schemePointsPresheaf_obj (H : _root_.CommHopfAlgCat.{u} R)
+    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ) :
+    (schemePointsPresheaf H).obj A =
+      ((Spec (CommRingCat.of A.unop.unop)).asOver (Spec (CommRingCat.of R)) ⟶
+        ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X) :=
+  rfl
+
+/-- **Convolution points agree naturally with scheme-valued points.** This is Mathlib's
+`Spec.mapMulEquiv`, assembled over all value algebras. -/
+noncomputable def pointsPresheafIsoSchemePointsPresheaf
+    (H : _root_.CommHopfAlgCat.{u} R) :
+    HopfAlgebra.pointsPresheaf H ≅ schemePointsPresheaf H :=
+  NatIso.ofComponents
+    (fun A =>
+      (AlgebraicGeometry.Spec.mapMulEquiv
+        (R := R) (S := H) (T := A.unop.unop)).toEquiv.toIso)
+    (by
+      intro A B f
+      ext p
+      exact mapMulEquiv_mapValue H f.unop.unop p)
+
+-- These component lemmas are deliberately not `@[simp]`: `simpNF` first unfolds the presheaf
+-- object expressions in their left-hand sides through functor composition and Yoneda evaluation.
+
+/-- The comparison from convolution points to scheme-valued points is Mathlib's spectrum-points
+equivalence at every value algebra. -/
+theorem pointsPresheafIsoSchemePointsPresheaf_hom_app_apply
+    (H : _root_.CommHopfAlgCat.{u} R)
+    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ)
+    (p : WithConv (H →ₐ[R] A.unop.unop)) :
+    (pointsPresheafIsoSchemePointsPresheaf H).hom.app A p =
+      AlgebraicGeometry.Spec.mapMulEquiv p := by
+  rw [pointsPresheafIsoSchemePointsPresheaf]
+  rfl
+
+/-- The inverse comparison recovers the convolution point represented by a relative spectrum
+morphism. -/
+theorem pointsPresheafIsoSchemePointsPresheaf_inv_app_apply
+    (H : _root_.CommHopfAlgCat.{u} R)
+    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ)
+    (p : (schemePointsPresheaf H).obj A) :
+    (pointsPresheafIsoSchemePointsPresheaf H).inv.app A p =
+      AlgebraicGeometry.Spec.mapMulEquiv.symm p := by
+  rw [pointsPresheafIsoSchemePointsPresheaf]
+  rfl
+
 end CommHopfAlgCat
 
 end TauCeti
-

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
@@ -453,6 +453,16 @@ private theorem isRepresentable_unopUnop_comp_iff_isCorepresentable
             Quiver.Hom.unop_op] }
     exact r.isRepresentable
 
+/-- Presenting the corepresentable underlying points functor on the double opposite of
+`CommAlgCat R` produces a representable presheaf on `(CommAlgCat R)ᵒᵖ`. -/
+instance pointsFunctorForget_unopUnop_isRepresentable
+    (H : Type u) [CommRing H] [_root_.HopfAlgebra R H] :
+    (unopUnop (CommAlgCat.{u} R) ⋙
+      (HopfAlgebra.pointsFunctor (R := R) (H := H) ⋙ forget GrpCat.{u})).IsRepresentable :=
+  (isRepresentable_unopUnop_comp_iff_isCorepresentable
+    (R := R) (HopfAlgebra.pointsFunctor (R := R) (H := H) ⋙
+      forget GrpCat.{u})).mpr inferInstance
+
 /-- Transport the generic essential image of group-object Yoneda across the double-opposite
 equivalence. -/
 private theorem essImage_yonedaGrp_doubleOp :

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
@@ -37,6 +37,8 @@ shrinking part.
   isomorphism.
 * `TauCeti.HopfAlgebra.pointsFunctorForget_isCorepresentable`: the discoverable
   corepresentability instance.
+* `TauCeti.HopfAlgebra.pointsGroupPresheaf` and `TauCeti.HopfAlgebra.pointsPresheaf`: the
+  group- and type-valued points functors as presheaves on opposite commutative algebras.
 * `TauCeti.CommHopfAlgCat.groupYonedaPointsFunctor`: the group-object Yoneda model of the
   functor of points.
 * `TauCeti.CommHopfAlgCat.groupYonedaPointsHomEquiv`: the carrier equivalence from the opaque
@@ -182,6 +184,27 @@ instance pointsFunctorForget_isCorepresentable
     (H : Type v) [CommRing H] [_root_.HopfAlgebra R H] :
     (pointsFunctor (R := R) (H := H) ⋙ forget GrpCat.{v}).IsCorepresentable :=
   (pointsCorepresentableBy (R := R) H).isCorepresentable
+
+/-- The group-valued presheaf of convolution points of a commutative Hopf algebra.
+
+The double-opposite equivalence presents the covariant functor on `CommAlgCat R` as a presheaf on
+the opposite category. -/
+noncomputable abbrev pointsGroupPresheaf (H : _root_.CommHopfAlgCat.{v} R) :
+    ((CommAlgCat.{v} R)ᵒᵖ)ᵒᵖ ⥤ GrpCat.{v} :=
+  (opOpEquivalence (CommAlgCat.{v} R)).functor ⋙
+    pointsFunctor (R := R) (H := H)
+
+/-- The underlying type-valued presheaf of convolution points of a commutative Hopf algebra. -/
+noncomputable abbrev pointsPresheaf (H : _root_.CommHopfAlgCat.{v} R) :
+    ((CommAlgCat.{v} R)ᵒᵖ)ᵒᵖ ⥤ Type v :=
+  pointsGroupPresheaf H ⋙ forget GrpCat
+
+/-- Evaluating the points presheaf at an affine `R`-scheme gives its convolution group of
+algebra-valued points, with the group structure forgotten. -/
+theorem pointsPresheaf_obj (H : _root_.CommHopfAlgCat.{v} R)
+    (A : ((CommAlgCat.{v} R)ᵒᵖ)ᵒᵖ) :
+    (pointsPresheaf H).obj A = WithConv (H →ₐ[R] A.unop.unop) :=
+  rfl
 
 -- The two component lemmas below are deliberately not `@[simp]`: their left-hand sides carry
 -- the value type `(pointsFunctor ⋙ forget GrpCat).obj A` of the corepresented functor, which
@@ -500,5 +523,21 @@ theorem essImage_pointsFunctor :
     essImage_yonedaGrp_doubleOp]
 
 end CommHopfAlgCat
+
+namespace HopfAlgebra
+
+variable {R : Type u} [CommRing R]
+
+/-- The type-valued points presheaf is represented by the coordinate algebra on the opposite
+category. -/
+instance pointsPresheaf_isRepresentable (H : _root_.CommHopfAlgCat.{u} R) :
+    (pointsPresheaf H).IsRepresentable := by
+  -- Unfolding the two presheaf abbreviations exposes the registered representability of the
+  -- underlying points functor after precomposition by the double-opposite equivalence.
+  change (unopUnop (CommAlgCat.{u} R) ⋙
+    (pointsFunctor (R := R) (H := H) ⋙ forget GrpCat.{u})).IsRepresentable
+  exact CommHopfAlgCat.pointsFunctorForget_unopUnop_isRepresentable H
+
+end HopfAlgebra
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SchemePoints
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
 public import TauCeti.Algebra.Category.CommAlgCat.Fppf
 
 /-!
@@ -20,23 +19,16 @@ variance
 CommAlgCat R ⥤ Type.
 ```
 
-For a commutative Hopf algebra `H`, the underlying type-valued presheaf of convolution points
-`A ↦ WithConv (H →ₐ[R] A)` is then compared with the restriction of the Yoneda presheaf represented
-by `Spec H`. Mathlib's multiplicative spectrum-points equivalence gives the components, while its
-naturality in the value algebra gives the natural isomorphism. Independently, the existing
-corepresentability of the points functor makes this presheaf representable on the opposite site,
-so subcanonicity implies that affine-group points form an fppf sheaf.
+For a commutative Hopf algebra `H`, the imported Yoneda and scheme-points modules identify the
+underlying type-valued presheaf of convolution points `A ↦ WithConv (H →ₐ[R] A)` with the
+restriction of the Yoneda presheaf represented by `Spec H`. Its registered representability and
+subcanonicity imply that affine-group points form an fppf sheaf.
 
 This is the affine-site foundation for fppf sheafification of pointwise quotients. It does not
 assert that such a quotient sheaf is representable; representability requires separate hypotheses.
 
 ## Main declarations
 
-* `TauCeti.HopfAlgebra.pointsGroupPresheaf`: the group-valued convolution-points presheaf.
-* `TauCeti.HopfAlgebra.pointsPresheaf`: its underlying type-valued presheaf.
-* `TauCeti.CommHopfAlgCat.schemePointsPresheaf`: the same presheaf through relative `Spec` and
-  Yoneda.
-* `TauCeti.CommHopfAlgCat.pointsPresheafIsoSchemePointsPresheaf`: the natural comparison.
 * `TauCeti.HopfAlgebra.pointsPresheaf_isSheaf`: affine-group points satisfy fppf descent.
 * `TauCeti.HopfAlgebra.pointsFppfSheaf`: affine-group points bundled as an fppf sheaf.
 
@@ -63,105 +55,11 @@ namespace HopfAlgebra
 
 variable {R : Type u} [CommRing R]
 
-/-- The group-valued presheaf of convolution points of a commutative Hopf algebra.
-
-The double-opposite equivalence presents the existing covariant functor on `CommAlgCat R` as a
-presheaf on the site `(CommAlgCat R)ᵒᵖ`. -/
-noncomputable abbrev pointsGroupPresheaf (H : _root_.CommHopfAlgCat.{u} R) :
-    ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ ⥤ GrpCat.{u} :=
-  (opOpEquivalence (CommAlgCat.{u} R)).functor ⋙
-    pointsFunctor (R := R) (H := H)
-
-/-- The underlying type-valued presheaf of convolution points of a commutative Hopf algebra.
-
-This is `pointsGroupPresheaf` followed by the forgetful functor from groups to types. -/
-noncomputable abbrev pointsPresheaf (H : _root_.CommHopfAlgCat.{u} R) :
-    ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ ⥤ Type u :=
-  pointsGroupPresheaf H ⋙ forget GrpCat
-
-/-- Evaluating the points presheaf at an affine `R`-scheme gives its convolution group of
-algebra-valued points, with the group structure forgotten. -/
-theorem pointsPresheaf_obj (H : _root_.CommHopfAlgCat.{u} R)
-    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ) :
-    (pointsPresheaf H).obj A = WithConv (H →ₐ[R] A.unop.unop) :=
-  rfl
-
-end HopfAlgebra
-
-namespace CommHopfAlgCat
-
-variable {R : Type u} [CommRing R]
-
-/-- Scheme-valued affine-group points, restricted along relative `Spec` and regarded as a
-type-valued presheaf on the affine fppf site. -/
-noncomputable abbrev schemePointsPresheaf (H : _root_.CommHopfAlgCat.{u} R) :
-    ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ ⥤ Type u :=
-  (AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙
-    yoneda.obj
-      ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X
-
-/-- The scheme-points presheaf at `A` is the set of morphisms over `Spec R` from `Spec A` to
-`Spec H`. -/
-theorem schemePointsPresheaf_obj (H : _root_.CommHopfAlgCat.{u} R)
-    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ) :
-    (schemePointsPresheaf H).obj A =
-      ((Spec (CommRingCat.of A.unop.unop)).asOver (Spec (CommRingCat.of R)) ⟶
-        ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X) :=
-  rfl
-
-/-- **Convolution points agree naturally with scheme-valued points.** This is Mathlib's
-`Spec.mapMulEquiv`, assembled over all value algebras. -/
-noncomputable def pointsPresheafIsoSchemePointsPresheaf
-    (H : _root_.CommHopfAlgCat.{u} R) :
-    HopfAlgebra.pointsPresheaf H ≅ schemePointsPresheaf H :=
-  NatIso.ofComponents
-    (fun A =>
-      (AlgebraicGeometry.Spec.mapMulEquiv
-        (R := R) (S := H) (T := A.unop.unop)).toEquiv.toIso)
-    (by
-      intro A B f
-      ext p
-      exact mapMulEquiv_mapValue H f.unop.unop p)
-
-/-- The comparison from convolution points to scheme-valued points is Mathlib's spectrum-points
-equivalence at every value algebra. -/
-theorem pointsPresheafIsoSchemePointsPresheaf_hom_app_apply
-    (H : _root_.CommHopfAlgCat.{u} R)
-    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ)
-    (p : WithConv (H →ₐ[R] A.unop.unop)) :
-    (pointsPresheafIsoSchemePointsPresheaf H).hom.app A p =
-      AlgebraicGeometry.Spec.mapMulEquiv p :=
-  by
-    rw [pointsPresheafIsoSchemePointsPresheaf]
-    rfl
-
-/-- The inverse comparison recovers the convolution point represented by a relative spectrum
-morphism. -/
-theorem pointsPresheafIsoSchemePointsPresheaf_inv_app_apply
-    (H : _root_.CommHopfAlgCat.{u} R)
-    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ)
-    (p : (schemePointsPresheaf H).obj A) :
-    (pointsPresheafIsoSchemePointsPresheaf H).inv.app A p =
-      AlgebraicGeometry.Spec.mapMulEquiv.symm p :=
-  by
-    rw [pointsPresheafIsoSchemePointsPresheaf]
-    rfl
-
-end CommHopfAlgCat
-
-namespace HopfAlgebra
-
-variable {R : Type u} [CommRing R]
-
 /-- **Affine-group points form an fppf sheaf.** The type-valued convolution-points presheaf is
 representable on the opposite site because the original covariant points functor is
 corepresentable. -/
 theorem pointsPresheaf_isSheaf (H : _root_.CommHopfAlgCat.{u} R) :
     Presheaf.IsSheaf (CommAlgCat.fppfTopology R) (pointsPresheaf H) := by
-  let _ : (pointsPresheaf H).IsRepresentable := by
-    change (unopUnop (CommAlgCat.{u} R) ⋙
-      (pointsFunctor (R := R) (H := H) ⋙ forget GrpCat.{u})).IsRepresentable
-    infer_instance
   exact (isSheaf_iff_isSheaf_of_type _ _).mpr <|
     GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable (pointsPresheaf H)
 

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean
@@ -4,39 +4,34 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.AlgebraicGeometry.Sites.Fpqc
-public import Mathlib.CategoryTheory.Sites.InducedTopology
-public import Mathlib.CategoryTheory.Sites.SubcanonicalOver
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SchemePoints
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
+public import TauCeti.Algebra.Category.CommAlgCat.Fppf
 
 /-!
-# The affine fppf site and affine-group points
+# Affine-group points on the affine fppf site
 
 For a commutative ring `R`, the category `(CommAlgCat R)ᵒᵖ` is the category of affine schemes
-over `Spec R`. This file equips it with the fppf topology induced by Mathlib's fppf topology on
-schemes over `Spec R`. Thus a presheaf on this site has the expected variance
+over `Spec R`. The imported generic affine-site module equips it with the fppf topology induced by
+Mathlib's fppf topology on schemes over `Spec R`. Thus a presheaf on this site has the expected
+variance
 
 ```text
 CommAlgCat R ⥤ Type.
 ```
 
-The induced affine topology is subcanonical. The proof restricts each representable presheaf on
-schemes over `Spec R` along the fully faithful relative spectrum functor and identifies the result
-with the corresponding affine representable presheaf.
-
 For a commutative Hopf algebra `H`, the underlying type-valued presheaf of convolution points
 `A ↦ WithConv (H →ₐ[R] A)` is then compared with the restriction of the Yoneda presheaf represented
 by `Spec H`. Mathlib's multiplicative spectrum-points equivalence gives the components, while its
-naturality in the value algebra gives the natural isomorphism. Consequently affine-group points
-form an fppf sheaf.
+naturality in the value algebra gives the natural isomorphism. Independently, the existing
+corepresentability of the points functor makes this presheaf representable on the opposite site,
+so subcanonicity implies that affine-group points form an fppf sheaf.
 
 This is the affine-site foundation for fppf sheafification of pointwise quotients. It does not
 assert that such a quotient sheaf is representable; representability requires separate hypotheses.
 
 ## Main declarations
 
-* `TauCeti.CommAlgCat.fppfTopology`: the fppf topology on opposite commutative `R`-algebras.
-* `TauCeti.CommAlgCat.fppfTopology_subcanonical`: affine representable functors are fppf sheaves.
 * `TauCeti.HopfAlgebra.pointsGroupPresheaf`: the group-valued convolution-points presheaf.
 * `TauCeti.HopfAlgebra.pointsPresheaf`: its underlying type-valued presheaf.
 * `TauCeti.CommHopfAlgCat.schemePointsPresheaf`: the same presheaf through relative `Spec` and
@@ -63,65 +58,6 @@ open scoped CategoryTheory.MonObj
 namespace TauCeti
 
 universe u
-
-namespace CommAlgCat
-
-/-- The fppf topology on affine schemes over `Spec R`, expressed on the equivalent category
-`(CommAlgCat R)ᵒᵖ`.
-
-It is the topology induced along the relative spectrum functor from the fppf topology on schemes
-over `Spec R`. -/
-noncomputable def fppfTopology (R : Type u) [CommRing R] :
-    GrothendieckTopology (CommAlgCat.{u} R)ᵒᵖ :=
-  (AlgebraicGeometry.algSpec (CommRingCat.of R)).inducedTopology
-    (Scheme.fppfTopology.over (Spec (CommRingCat.of R)))
-
-/-- Relative spectrum is continuous from the affine fppf site to the fppf site of schemes over
-the base. -/
-instance algSpec_isContinuous_fppfTopology (R : Type u) [CommRing R] :
-    (AlgebraicGeometry.algSpec (CommRingCat.of R)).IsContinuous
-      (fppfTopology R)
-      (Scheme.fppfTopology.over (Spec (CommRingCat.of R))) := by
-  unfold fppfTopology
-  infer_instance
-
-/-- **The affine fppf topology is subcanonical.** Every presheaf represented by an affine scheme
-over `Spec R` is an fppf sheaf. -/
-noncomputable instance fppfTopology_subcanonical (R : Type u) [CommRing R] :
-    (fppfTopology R).Subcanonical := by
-  let K := Scheme.fppfTopology.over (Spec (CommRingCat.of R))
-  let _ : K.Subcanonical := by
-    dsimp only [K]
-    infer_instance
-  apply GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj
-  intro X
-  let P := yoneda.obj
-    ((AlgebraicGeometry.algSpec (CommRingCat.of R)).obj X)
-  have hP : Presieve.IsSheaf K P :=
-    GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable P
-  let S : Sheaf K (Type u) :=
-    ⟨P, (isSheaf_iff_isSheaf_of_type K P).mpr hP⟩
-  have hpull' : Presieve.IsSheaf (fppfTopology R)
-      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
-    Functor.op_comp_isSheaf_of_types
-      (AlgebraicGeometry.algSpec (CommRingCat.of R)) (fppfTopology R) K S
-  have hpull : Presheaf.IsSheaf (fppfTopology R)
-      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
-    (isSheaf_iff_isSheaf_of_type _ _).mpr hpull'
-  let e : yoneda.obj X ≅
-      (AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P :=
-    NatIso.ofComponents
-      (fun _ =>
-        (AlgebraicGeometry.algSpec.fullyFaithful
-          (R := CommRingCat.of R)).homEquiv.toIso)
-      (by
-        intro Y Z f
-        ext g
-        exact (AlgebraicGeometry.algSpec (CommRingCat.of R)).map_comp f.unop g)
-  exact (isSheaf_iff_isSheaf_of_type _ _).mp <|
-    (Presheaf.isSheaf_of_iso_iff e).mpr hpull
-
-end CommAlgCat
 
 namespace HopfAlgebra
 
@@ -175,7 +111,7 @@ theorem schemePointsPresheaf_obj (H : _root_.CommHopfAlgCat.{u} R)
 
 /-- **Convolution points agree naturally with scheme-valued points.** This is Mathlib's
 `Spec.mapMulEquiv`, assembled over all value algebras. -/
-@[expose] noncomputable def pointsPresheafIsoSchemePointsPresheaf
+noncomputable def pointsPresheafIsoSchemePointsPresheaf
     (H : _root_.CommHopfAlgCat.{u} R) :
     HopfAlgebra.pointsPresheaf H ≅ schemePointsPresheaf H :=
   NatIso.ofComponents
@@ -195,7 +131,9 @@ theorem pointsPresheafIsoSchemePointsPresheaf_hom_app_apply
     (p : WithConv (H →ₐ[R] A.unop.unop)) :
     (pointsPresheafIsoSchemePointsPresheaf H).hom.app A p =
       AlgebraicGeometry.Spec.mapMulEquiv p :=
-  rfl
+  by
+    rw [pointsPresheafIsoSchemePointsPresheaf]
+    rfl
 
 /-- The inverse comparison recovers the convolution point represented by a relative spectrum
 morphism. -/
@@ -205,7 +143,9 @@ theorem pointsPresheafIsoSchemePointsPresheaf_inv_app_apply
     (p : (schemePointsPresheaf H).obj A) :
     (pointsPresheafIsoSchemePointsPresheaf H).inv.app A p =
       AlgebraicGeometry.Spec.mapMulEquiv.symm p :=
-  rfl
+  by
+    rw [pointsPresheafIsoSchemePointsPresheaf]
+    rfl
 
 end CommHopfAlgCat
 
@@ -214,29 +154,16 @@ namespace HopfAlgebra
 variable {R : Type u} [CommRing R]
 
 /-- **Affine-group points form an fppf sheaf.** The type-valued convolution-points presheaf is
-the restriction of the representable scheme-valued points functor along relative `Spec`. -/
+representable on the opposite site because the original covariant points functor is
+corepresentable. -/
 theorem pointsPresheaf_isSheaf (H : _root_.CommHopfAlgCat.{u} R) :
     Presheaf.IsSheaf (CommAlgCat.fppfTopology R) (pointsPresheaf H) := by
-  let K := Scheme.fppfTopology.over (Spec (CommRingCat.of R))
-  let _ : K.Subcanonical := by
-    dsimp only [K]
+  let _ : (pointsPresheaf H).IsRepresentable := by
+    change (unopUnop (CommAlgCat.{u} R) ⋙
+      (pointsFunctor (R := R) (H := H) ⋙ forget GrpCat.{u})).IsRepresentable
     infer_instance
-  let G := (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)
-  let P := yoneda.obj G.X
-  have hP : Presieve.IsSheaf K P :=
-    GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable P
-  let S : Sheaf K (Type u) :=
-    ⟨P, (isSheaf_iff_isSheaf_of_type K P).mpr hP⟩
-  have hscheme' : Presieve.IsSheaf (CommAlgCat.fppfTopology R)
-      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
-    Functor.op_comp_isSheaf_of_types
-      (AlgebraicGeometry.algSpec (CommRingCat.of R))
-      (CommAlgCat.fppfTopology R) K S
-  have hscheme : Presheaf.IsSheaf (CommAlgCat.fppfTopology R)
-      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
-    (isSheaf_iff_isSheaf_of_type _ _).mpr hscheme'
-  exact (Presheaf.isSheaf_of_iso_iff
-    (CommHopfAlgCat.pointsPresheafIsoSchemePointsPresheaf H)).mpr hscheme
+  exact (isSheaf_iff_isSheaf_of_type _ _).mpr <|
+    GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable (pointsPresheaf H)
 
 /-- **The group-valued convolution-points presheaf is an fppf sheaf.** This is the group-valued
 form of `pointsPresheaf_isSheaf`; the forgetful functor from groups preserves limits and reflects
@@ -251,6 +178,12 @@ theorem pointsGroupPresheaf_isSheaf (H : _root_.CommHopfAlgCat.{u} R) :
 noncomputable def pointsFppfSheaf (H : _root_.CommHopfAlgCat.{u} R) :
     Sheaf (CommAlgCat.fppfTopology R) GrpCat.{u} :=
   ⟨pointsGroupPresheaf H, pointsGroupPresheaf_isSheaf H⟩
+
+/-- The presheaf underlying `pointsFppfSheaf` is the convolution-points presheaf. -/
+@[simp]
+theorem pointsFppfSheaf_obj (H : _root_.CommHopfAlgCat.{u} R) :
+    (pointsFppfSheaf H).obj = pointsGroupPresheaf H :=
+  by rw [pointsFppfSheaf]
 
 end HopfAlgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SchemePoints
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
 public import TauCeti.Algebra.Category.CommAlgCat.Fppf
 
 /-!
@@ -19,10 +19,9 @@ variance
 CommAlgCat R ⥤ Type.
 ```
 
-For a commutative Hopf algebra `H`, the imported Yoneda and scheme-points modules identify the
-underlying type-valued presheaf of convolution points `A ↦ WithConv (H →ₐ[R] A)` with the
-restriction of the Yoneda presheaf represented by `Spec H`. Its registered representability and
-subcanonicity imply that affine-group points form an fppf sheaf.
+For a commutative Hopf algebra `H`, the imported Yoneda module registers the underlying type-valued
+presheaf of convolution points `A ↦ WithConv (H →ₐ[R] A)` as representable. Its representability
+and subcanonicity imply that affine-group points form an fppf sheaf.
 
 This is the affine-site foundation for fppf sheafification of pointwise quotients. It does not
 assert that such a quotient sheaf is representable; representability requires separate hypotheses.

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean
@@ -1,0 +1,257 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Sites.Fpqc
+public import Mathlib.CategoryTheory.Sites.InducedTopology
+public import Mathlib.CategoryTheory.Sites.SubcanonicalOver
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SchemePoints
+
+/-!
+# The affine fppf site and affine-group points
+
+For a commutative ring `R`, the category `(CommAlgCat R)ᵒᵖ` is the category of affine schemes
+over `Spec R`. This file equips it with the fppf topology induced by Mathlib's fppf topology on
+schemes over `Spec R`. Thus a presheaf on this site has the expected variance
+
+```text
+CommAlgCat R ⥤ Type.
+```
+
+The induced affine topology is subcanonical. The proof restricts each representable presheaf on
+schemes over `Spec R` along the fully faithful relative spectrum functor and identifies the result
+with the corresponding affine representable presheaf.
+
+For a commutative Hopf algebra `H`, the underlying type-valued presheaf of convolution points
+`A ↦ WithConv (H →ₐ[R] A)` is then compared with the restriction of the Yoneda presheaf represented
+by `Spec H`. Mathlib's multiplicative spectrum-points equivalence gives the components, while its
+naturality in the value algebra gives the natural isomorphism. Consequently affine-group points
+form an fppf sheaf.
+
+This is the affine-site foundation for fppf sheafification of pointwise quotients. It does not
+assert that such a quotient sheaf is representable; representability requires separate hypotheses.
+
+## Main declarations
+
+* `TauCeti.CommAlgCat.fppfTopology`: the fppf topology on opposite commutative `R`-algebras.
+* `TauCeti.CommAlgCat.fppfTopology_subcanonical`: affine representable functors are fppf sheaves.
+* `TauCeti.HopfAlgebra.pointsGroupPresheaf`: the group-valued convolution-points presheaf.
+* `TauCeti.HopfAlgebra.pointsPresheaf`: its underlying type-valued presheaf.
+* `TauCeti.CommHopfAlgCat.schemePointsPresheaf`: the same presheaf through relative `Spec` and
+  Yoneda.
+* `TauCeti.CommHopfAlgCat.pointsPresheafIsoSchemePointsPresheaf`: the natural comparison.
+* `TauCeti.HopfAlgebra.pointsPresheaf_isSheaf`: affine-group points satisfy fppf descent.
+* `TauCeti.HopfAlgebra.pointsFppfSheaf`: affine-group points bundled as an fppf sheaf.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Sections 2 and 5.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Sections 1 and 14.
+
+This advances the cross-cutting sheaves-and-descent prerequisite and Layer 3, "Normality and
+quotients", of the ReductiveGroups roadmap. The next step is to sheafify the existing pointwise
+quotient presheaf and prove its quotient universal property in the fppf topos.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti
+
+universe u
+
+namespace CommAlgCat
+
+/-- The fppf topology on affine schemes over `Spec R`, expressed on the equivalent category
+`(CommAlgCat R)ᵒᵖ`.
+
+It is the topology induced along the relative spectrum functor from the fppf topology on schemes
+over `Spec R`. -/
+noncomputable def fppfTopology (R : Type u) [CommRing R] :
+    GrothendieckTopology (CommAlgCat.{u} R)ᵒᵖ :=
+  (AlgebraicGeometry.algSpec (CommRingCat.of R)).inducedTopology
+    (Scheme.fppfTopology.over (Spec (CommRingCat.of R)))
+
+/-- Relative spectrum is continuous from the affine fppf site to the fppf site of schemes over
+the base. -/
+instance algSpec_isContinuous_fppfTopology (R : Type u) [CommRing R] :
+    (AlgebraicGeometry.algSpec (CommRingCat.of R)).IsContinuous
+      (fppfTopology R)
+      (Scheme.fppfTopology.over (Spec (CommRingCat.of R))) := by
+  unfold fppfTopology
+  infer_instance
+
+/-- **The affine fppf topology is subcanonical.** Every presheaf represented by an affine scheme
+over `Spec R` is an fppf sheaf. -/
+noncomputable instance fppfTopology_subcanonical (R : Type u) [CommRing R] :
+    (fppfTopology R).Subcanonical := by
+  let K := Scheme.fppfTopology.over (Spec (CommRingCat.of R))
+  let _ : K.Subcanonical := by
+    dsimp only [K]
+    infer_instance
+  apply GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj
+  intro X
+  let P := yoneda.obj
+    ((AlgebraicGeometry.algSpec (CommRingCat.of R)).obj X)
+  have hP : Presieve.IsSheaf K P :=
+    GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable P
+  let S : Sheaf K (Type u) :=
+    ⟨P, (isSheaf_iff_isSheaf_of_type K P).mpr hP⟩
+  have hpull' : Presieve.IsSheaf (fppfTopology R)
+      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
+    Functor.op_comp_isSheaf_of_types
+      (AlgebraicGeometry.algSpec (CommRingCat.of R)) (fppfTopology R) K S
+  have hpull : Presheaf.IsSheaf (fppfTopology R)
+      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
+    (isSheaf_iff_isSheaf_of_type _ _).mpr hpull'
+  let e : yoneda.obj X ≅
+      (AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P :=
+    NatIso.ofComponents
+      (fun _ =>
+        (AlgebraicGeometry.algSpec.fullyFaithful
+          (R := CommRingCat.of R)).homEquiv.toIso)
+      (by
+        intro Y Z f
+        ext g
+        exact (AlgebraicGeometry.algSpec (CommRingCat.of R)).map_comp f.unop g)
+  exact (isSheaf_iff_isSheaf_of_type _ _).mp <|
+    (Presheaf.isSheaf_of_iso_iff e).mpr hpull
+
+end CommAlgCat
+
+namespace HopfAlgebra
+
+variable {R : Type u} [CommRing R]
+
+/-- The group-valued presheaf of convolution points of a commutative Hopf algebra.
+
+The double-opposite equivalence presents the existing covariant functor on `CommAlgCat R` as a
+presheaf on the site `(CommAlgCat R)ᵒᵖ`. -/
+noncomputable abbrev pointsGroupPresheaf (H : _root_.CommHopfAlgCat.{u} R) :
+    ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ ⥤ GrpCat.{u} :=
+  (opOpEquivalence (CommAlgCat.{u} R)).functor ⋙
+    pointsFunctor (R := R) (H := H)
+
+/-- The underlying type-valued presheaf of convolution points of a commutative Hopf algebra.
+
+This is `pointsGroupPresheaf` followed by the forgetful functor from groups to types. -/
+noncomputable abbrev pointsPresheaf (H : _root_.CommHopfAlgCat.{u} R) :
+    ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ ⥤ Type u :=
+  pointsGroupPresheaf H ⋙ forget GrpCat
+
+/-- Evaluating the points presheaf at an affine `R`-scheme gives its convolution group of
+algebra-valued points, with the group structure forgotten. -/
+theorem pointsPresheaf_obj (H : _root_.CommHopfAlgCat.{u} R)
+    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ) :
+    (pointsPresheaf H).obj A = WithConv (H →ₐ[R] A.unop.unop) :=
+  rfl
+
+end HopfAlgebra
+
+namespace CommHopfAlgCat
+
+variable {R : Type u} [CommRing R]
+
+/-- Scheme-valued affine-group points, restricted along relative `Spec` and regarded as a
+type-valued presheaf on the affine fppf site. -/
+noncomputable abbrev schemePointsPresheaf (H : _root_.CommHopfAlgCat.{u} R) :
+    ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ ⥤ Type u :=
+  (AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙
+    yoneda.obj
+      ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X
+
+/-- The scheme-points presheaf at `A` is the set of morphisms over `Spec R` from `Spec A` to
+`Spec H`. -/
+theorem schemePointsPresheaf_obj (H : _root_.CommHopfAlgCat.{u} R)
+    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ) :
+    (schemePointsPresheaf H).obj A =
+      ((Spec (CommRingCat.of A.unop.unop)).asOver (Spec (CommRingCat.of R)) ⟶
+        ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X) :=
+  rfl
+
+/-- **Convolution points agree naturally with scheme-valued points.** This is Mathlib's
+`Spec.mapMulEquiv`, assembled over all value algebras. -/
+@[expose] noncomputable def pointsPresheafIsoSchemePointsPresheaf
+    (H : _root_.CommHopfAlgCat.{u} R) :
+    HopfAlgebra.pointsPresheaf H ≅ schemePointsPresheaf H :=
+  NatIso.ofComponents
+    (fun A =>
+      (AlgebraicGeometry.Spec.mapMulEquiv
+        (R := R) (S := H) (T := A.unop.unop)).toEquiv.toIso)
+    (by
+      intro A B f
+      ext p
+      exact mapMulEquiv_mapValue H f.unop.unop p)
+
+/-- The comparison from convolution points to scheme-valued points is Mathlib's spectrum-points
+equivalence at every value algebra. -/
+theorem pointsPresheafIsoSchemePointsPresheaf_hom_app_apply
+    (H : _root_.CommHopfAlgCat.{u} R)
+    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ)
+    (p : WithConv (H →ₐ[R] A.unop.unop)) :
+    (pointsPresheafIsoSchemePointsPresheaf H).hom.app A p =
+      AlgebraicGeometry.Spec.mapMulEquiv p :=
+  rfl
+
+/-- The inverse comparison recovers the convolution point represented by a relative spectrum
+morphism. -/
+theorem pointsPresheafIsoSchemePointsPresheaf_inv_app_apply
+    (H : _root_.CommHopfAlgCat.{u} R)
+    (A : ((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ)
+    (p : (schemePointsPresheaf H).obj A) :
+    (pointsPresheafIsoSchemePointsPresheaf H).inv.app A p =
+      AlgebraicGeometry.Spec.mapMulEquiv.symm p :=
+  rfl
+
+end CommHopfAlgCat
+
+namespace HopfAlgebra
+
+variable {R : Type u} [CommRing R]
+
+/-- **Affine-group points form an fppf sheaf.** The type-valued convolution-points presheaf is
+the restriction of the representable scheme-valued points functor along relative `Spec`. -/
+theorem pointsPresheaf_isSheaf (H : _root_.CommHopfAlgCat.{u} R) :
+    Presheaf.IsSheaf (CommAlgCat.fppfTopology R) (pointsPresheaf H) := by
+  let K := Scheme.fppfTopology.over (Spec (CommRingCat.of R))
+  let _ : K.Subcanonical := by
+    dsimp only [K]
+    infer_instance
+  let G := (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)
+  let P := yoneda.obj G.X
+  have hP : Presieve.IsSheaf K P :=
+    GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable P
+  let S : Sheaf K (Type u) :=
+    ⟨P, (isSheaf_iff_isSheaf_of_type K P).mpr hP⟩
+  have hscheme' : Presieve.IsSheaf (CommAlgCat.fppfTopology R)
+      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
+    Functor.op_comp_isSheaf_of_types
+      (AlgebraicGeometry.algSpec (CommRingCat.of R))
+      (CommAlgCat.fppfTopology R) K S
+  have hscheme : Presheaf.IsSheaf (CommAlgCat.fppfTopology R)
+      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
+    (isSheaf_iff_isSheaf_of_type _ _).mpr hscheme'
+  exact (Presheaf.isSheaf_of_iso_iff
+    (CommHopfAlgCat.pointsPresheafIsoSchemePointsPresheaf H)).mpr hscheme
+
+/-- **The group-valued convolution-points presheaf is an fppf sheaf.** This is the group-valued
+form of `pointsPresheaf_isSheaf`; the forgetful functor from groups preserves limits and reflects
+isomorphisms. -/
+theorem pointsGroupPresheaf_isSheaf (H : _root_.CommHopfAlgCat.{u} R) :
+    Presheaf.IsSheaf (CommAlgCat.fppfTopology R) (pointsGroupPresheaf H) := by
+  exact Presheaf.isSheaf_of_isSheaf_comp
+    (CommAlgCat.fppfTopology R) (pointsGroupPresheaf H) (forget GrpCat.{u})
+    (pointsPresheaf_isSheaf H)
+
+/-- The convolution-points functor, bundled as a group-valued sheaf on the affine fppf site. -/
+noncomputable def pointsFppfSheaf (H : _root_.CommHopfAlgCat.{u} R) :
+    Sheaf (CommAlgCat.fppfTopology R) GrpCat.{u} :=
+  ⟨pointsGroupPresheaf H, pointsGroupPresheaf_isSheaf H⟩
+
+end HopfAlgebra
+
+end TauCeti

--- a/TauCeti/Algebra/Category/CommAlgCat/Fppf.lean
+++ b/TauCeti/Algebra/Category/CommAlgCat/Fppf.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Sites.Fpqc
+public import Mathlib.AlgebraicGeometry.Group.Affine
+public import Mathlib.CategoryTheory.Sites.InducedTopology
+public import Mathlib.CategoryTheory.Sites.SubcanonicalOver
+
+/-!
+# The affine fppf site
+
+For a commutative ring `R`, this file equips `(CommAlgCat R)ᵒᵖ` with the topology induced by
+Mathlib's fppf topology on schemes over `Spec R`. This is the category of affine schemes over
+`Spec R`, presented contravariantly through their coordinate algebras.
+
+The induced affine topology is subcanonical. The proof restricts each representable presheaf on
+schemes over `Spec R` along the fully faithful relative spectrum functor and identifies the result
+with the corresponding affine representable presheaf.
+
+## Main declarations
+
+* `TauCeti.CommAlgCat.fppfTopology`: the fppf topology on opposite commutative `R`-algebras.
+* `TauCeti.CommAlgCat.fppfTopology_subcanonical`: affine representable functors are fppf sheaves.
+
+This advances the cross-cutting sheaves-and-descent prerequisite in the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry
+
+namespace TauCeti
+
+universe u
+
+namespace CommAlgCat
+
+/-- The fppf topology on affine schemes over `Spec R`, expressed on the equivalent category
+`(CommAlgCat R)ᵒᵖ`.
+
+It is the topology induced along the relative spectrum functor from the fppf topology on schemes
+over `Spec R`. -/
+noncomputable def fppfTopology (R : Type u) [CommRing R] :
+    GrothendieckTopology (CommAlgCat.{u} R)ᵒᵖ :=
+  (AlgebraicGeometry.algSpec (CommRingCat.of R)).inducedTopology
+    (Scheme.fppfTopology.over (Spec (CommRingCat.of R)))
+
+/-- Relative spectrum is continuous from the affine fppf site to the fppf site of schemes over
+the base. -/
+instance algSpec_isContinuous_fppfTopology (R : Type u) [CommRing R] :
+    (AlgebraicGeometry.algSpec (CommRingCat.of R)).IsContinuous
+      (fppfTopology R)
+      (Scheme.fppfTopology.over (Spec (CommRingCat.of R))) := by
+  unfold fppfTopology
+  infer_instance
+
+/-- **The affine fppf topology is subcanonical.** Every presheaf represented by an affine scheme
+over `Spec R` is an fppf sheaf. -/
+noncomputable instance fppfTopology_subcanonical (R : Type u) [CommRing R] :
+    (fppfTopology R).Subcanonical := by
+  let K := Scheme.fppfTopology.over (Spec (CommRingCat.of R))
+  let _ : K.Subcanonical := by
+    dsimp only [K]
+    infer_instance
+  apply GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj
+  intro X
+  let P := yoneda.obj
+    ((AlgebraicGeometry.algSpec (CommRingCat.of R)).obj X)
+  have hP : Presieve.IsSheaf K P :=
+    GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable P
+  let S : Sheaf K (Type u) :=
+    ⟨P, (isSheaf_iff_isSheaf_of_type K P).mpr hP⟩
+  have hpull' : Presieve.IsSheaf (fppfTopology R)
+      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
+    Functor.op_comp_isSheaf_of_types
+      (AlgebraicGeometry.algSpec (CommRingCat.of R)) (fppfTopology R) K S
+  have hpull : Presheaf.IsSheaf (fppfTopology R)
+      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
+    (isSheaf_iff_isSheaf_of_type _ _).mpr hpull'
+  let e : yoneda.obj X ≅
+      (AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P :=
+    NatIso.ofComponents
+      (fun _ =>
+        (AlgebraicGeometry.algSpec.fullyFaithful
+          (R := CommRingCat.of R)).homEquiv.toIso)
+      (by
+        intro Y Z f
+        ext g
+        exact (AlgebraicGeometry.algSpec (CommRingCat.of R)).map_comp f.unop g)
+  exact (isSheaf_iff_isSheaf_of_type _ _).mp <|
+    (Presheaf.isSheaf_of_iso_iff e).mpr hpull
+
+end CommAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/Category/CommAlgCat/Fppf.lean
+++ b/TauCeti/Algebra/Category/CommAlgCat/Fppf.lean
@@ -47,6 +47,15 @@ noncomputable def fppfTopology (R : Type u) [CommRing R] :
   (AlgebraicGeometry.algSpec (CommRingCat.of R)).inducedTopology
     (Scheme.fppfTopology.over (Spec (CommRingCat.of R)))
 
+/-- The affine fppf topology is induced from the fppf topology on schemes over `Spec R`. -/
+theorem fppfTopology_def (R : Type u) [CommRing R] :
+    fppfTopology R =
+      (AlgebraicGeometry.algSpec (CommRingCat.of R)).inducedTopology
+        (Scheme.fppfTopology.over (Spec (CommRingCat.of R))) :=
+  by
+    unfold fppfTopology
+    rfl
+
 /-- **The affine fppf topology is subcanonical.** Every presheaf represented by an affine scheme
 over `Spec R` is an fppf sheaf. -/
 noncomputable instance fppfTopology_subcanonical (R : Type u) [CommRing R] :
@@ -55,7 +64,7 @@ noncomputable instance fppfTopology_subcanonical (R : Type u) [CommRing R] :
     (AlgebraicGeometry.algSpec.fullyFaithful (R := CommRingCat.of R)).full
   let _ : (AlgebraicGeometry.algSpec (CommRingCat.of R)).Faithful :=
     (AlgebraicGeometry.algSpec.fullyFaithful (R := CommRingCat.of R)).faithful
-  unfold fppfTopology
+  rw [fppfTopology_def]
   exact GrothendieckTopology.subcanonical_of_full_of_faithful
     (AlgebraicGeometry.algSpec (CommRingCat.of R)) _
       (Scheme.fppfTopology.over (Spec (CommRingCat.of R)))

--- a/TauCeti/Algebra/Category/CommAlgCat/Fppf.lean
+++ b/TauCeti/Algebra/Category/CommAlgCat/Fppf.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.AlgebraicGeometry.Sites.Fpqc
 public import Mathlib.AlgebraicGeometry.Group.Affine
 public import Mathlib.CategoryTheory.Sites.InducedTopology
+public import Mathlib.CategoryTheory.Sites.Subcanonical
 public import Mathlib.CategoryTheory.Sites.SubcanonicalOver
 
 /-!
@@ -16,9 +17,7 @@ For a commutative ring `R`, this file equips `(CommAlgCat R)ᵒᵖ` with the top
 Mathlib's fppf topology on schemes over `Spec R`. This is the category of affine schemes over
 `Spec R`, presented contravariantly through their coordinate algebras.
 
-The induced affine topology is subcanonical. The proof restricts each representable presheaf on
-schemes over `Spec R` along the fully faithful relative spectrum functor and identifies the result
-with the corresponding affine representable presheaf.
+The induced affine topology is subcanonical by full faithfulness of the relative spectrum functor.
 
 ## Main declarations
 
@@ -48,50 +47,18 @@ noncomputable def fppfTopology (R : Type u) [CommRing R] :
   (AlgebraicGeometry.algSpec (CommRingCat.of R)).inducedTopology
     (Scheme.fppfTopology.over (Spec (CommRingCat.of R)))
 
-/-- Relative spectrum is continuous from the affine fppf site to the fppf site of schemes over
-the base. -/
-instance algSpec_isContinuous_fppfTopology (R : Type u) [CommRing R] :
-    (AlgebraicGeometry.algSpec (CommRingCat.of R)).IsContinuous
-      (fppfTopology R)
-      (Scheme.fppfTopology.over (Spec (CommRingCat.of R))) := by
-  unfold fppfTopology
-  infer_instance
-
 /-- **The affine fppf topology is subcanonical.** Every presheaf represented by an affine scheme
 over `Spec R` is an fppf sheaf. -/
 noncomputable instance fppfTopology_subcanonical (R : Type u) [CommRing R] :
     (fppfTopology R).Subcanonical := by
-  let K := Scheme.fppfTopology.over (Spec (CommRingCat.of R))
-  let _ : K.Subcanonical := by
-    dsimp only [K]
-    infer_instance
-  apply GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj
-  intro X
-  let P := yoneda.obj
-    ((AlgebraicGeometry.algSpec (CommRingCat.of R)).obj X)
-  have hP : Presieve.IsSheaf K P :=
-    GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable P
-  let S : Sheaf K (Type u) :=
-    ⟨P, (isSheaf_iff_isSheaf_of_type K P).mpr hP⟩
-  have hpull' : Presieve.IsSheaf (fppfTopology R)
-      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
-    Functor.op_comp_isSheaf_of_types
-      (AlgebraicGeometry.algSpec (CommRingCat.of R)) (fppfTopology R) K S
-  have hpull : Presheaf.IsSheaf (fppfTopology R)
-      ((AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P) :=
-    (isSheaf_iff_isSheaf_of_type _ _).mpr hpull'
-  let e : yoneda.obj X ≅
-      (AlgebraicGeometry.algSpec (CommRingCat.of R)).op ⋙ P :=
-    NatIso.ofComponents
-      (fun _ =>
-        (AlgebraicGeometry.algSpec.fullyFaithful
-          (R := CommRingCat.of R)).homEquiv.toIso)
-      (by
-        intro Y Z f
-        ext g
-        exact (AlgebraicGeometry.algSpec (CommRingCat.of R)).map_comp f.unop g)
-  exact (isSheaf_iff_isSheaf_of_type _ _).mp <|
-    (Presheaf.isSheaf_of_iso_iff e).mpr hpull
+  let _ : (AlgebraicGeometry.algSpec (CommRingCat.of R)).Full :=
+    (AlgebraicGeometry.algSpec.fullyFaithful (R := CommRingCat.of R)).full
+  let _ : (AlgebraicGeometry.algSpec (CommRingCat.of R)).Faithful :=
+    (AlgebraicGeometry.algSpec.fullyFaithful (R := CommRingCat.of R)).faithful
+  unfold fppfTopology
+  exact GrothendieckTopology.subcanonical_of_full_of_faithful
+    (AlgebraicGeometry.algSpec (CommRingCat.of R)) _
+      (Scheme.fppfTopology.over (Spec (CommRingCat.of R)))
 
 end CommAlgCat
 


### PR DESCRIPTION
This PR equips `(CommAlgCat R)ᵒᵖ` with the fppf topology induced from schemes over `Spec R`, proves it subcanonical, identifies the convolution-points presheaf of every commutative Hopf algebra with restricted scheme-valued Yoneda points, and bundles those points as a group-valued fppf sheaf.

The exact roadmap target is `ReductiveGroups/README.md`’s cross-cutting “sheaves and descent” prerequisite—specifically presheaves on `CommAlgCat k`, Yoneda/representability, and fppf sheafification—and the consumer milestone is Layer 3, “Normality and quotients,” where `G/H` must first be constructed as the fppf sheaf quotient. This is the most effective current step because the pointwise quotient presheaf and faithfully flat point descent already exist, while the affine fppf site connecting them did not. After this PR, the milestone still needs sheafification of `pointwiseQuotientFunctor`, the quotient universal property in the fppf topos, torsor/descent machinery, and representability under explicit hypotheses.

Add `TauCeti/Algebra/AlgebraicGroup/Fppf/Basic.lean` (257 lines). Reuse Mathlib’s scheme fppf topology, over-site and induced-topology APIs, subcanonical Yoneda machinery, full faithfulness of relative `algSpec`, and `Spec.mapMulEquiv`; no Mathlib infrastructure or external formalization is vendored. The module documentation credits Milne, Sections 2 and 5, and Waterhouse, Sections 1 and 14.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"commalgcat-fppf-topology"}-->

🤖 Prepared with Codex
