### PR TITLE
feat(Modular): orders of the point stabilisers of the modular group

### DIFF
--- a/TauCeti/NumberTheory/Modular/Stabilizer.lean
+++ b/TauCeti/NumberTheory/Modular/Stabilizer.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Modular.Orbits
+
+/-!
+# Orders of the point stabilisers of the modular group
+
+The stabiliser of a point of `ℍ` in `SL(2, ℤ)` is finite, and its order depends only on the
+orbit. Off the two elliptic orbits that order is `2` — the centre `±1`, which acts trivially —
+while on the orbit of `i` it is `4` and on the orbit of `ρ` it is `6`. Dividing by the centre
+these are the `PSL(2, ℤ)`-orders `e_i = 2`, `e_ρ = 3` and `e_P = 1` elsewhere, the weights the
+valence formula attaches to its orbits.
+
+Mathlib classifies the stabilising matrices (`ModularGroup.stabilizer_I`,
+`ModularGroup.stabilizer_ρ`, `ModularGroup.stabilizer_of_ne`), but only at a point of the closed
+fundamental domain `𝒟`. Added here is the passage to an arbitrary point of `ℍ`, which
+`ModularGroup.exists_smul_mem_fd` and conjugation supply, together with the resulting counts.
+
+The three orbit-level counts are stated with their hypotheses on the class of `z` in
+`MulAction.orbitRel.Quotient SL(2, ℤ) ℍ`, rather than on a fundamental-domain representative,
+because that is the form the valence formula's index type consumes: its non-elliptic orbits are
+literally the `q` with `q ≠ ⟦i⟧` and `q ≠ ⟦ρ⟧`.
+
+## Main declarations
+
+* `TauCeti.ModularGroup.finite_stabilizer`: every point stabiliser is finite, so the elliptic
+  order is defined at every point of `ℍ`.
+* `TauCeti.ModularGroup.card_stabilizer_I` and `TauCeti.ModularGroup.card_stabilizer_ρ`: the
+  orders `4` and `6` at the two elliptic points themselves.
+* `TauCeti.ModularGroup.card_stabilizer_of_orbit_eq_I` and
+  `TauCeti.ModularGroup.card_stabilizer_of_orbit_eq_ρ`: the same orders everywhere on those two
+  orbits.
+* `TauCeti.ModularGroup.card_stabilizer_eq_two_of_orbit_ne`: order `2` on every other orbit.
+
+## References
+
+* Diamond–Shurman, *A First Course in Modular Forms*, §2.3 — the elliptic points of `SL(2, ℤ)`
+  and their stabiliser orders.
+-/
+
+public section
+
+open MulAction UpperHalfPlane ModularGroup
+
+open scoped MatrixGroups Modular
+
+namespace TauCeti
+
+namespace ModularGroup
+
+variable {w z : ℍ}
+
+private theorem finite_stabilizer_of_subset (s : Finset SL(2, ℤ))
+    (hs : ∀ g : SL(2, ℤ), g • w = w → g ∈ s) : Finite (stabilizer SL(2, ℤ) w) :=
+  (s.finite_toSet.subset fun g hg ↦ hs g hg).to_subtype
+
+private theorem finite_stabilizer_of_smul (g : SL(2, ℤ))
+    (h : Finite (stabilizer SL(2, ℤ) (g • z))) : Finite (stabilizer SL(2, ℤ) z) :=
+  Finite.of_equiv _ (stabilizerEquivStabilizerOfOrbitRel
+    (⟨g, rfl⟩ : MulAction.orbitRel SL(2, ℤ) ℍ (g • z) z)).toEquiv
+
+private theorem card_stabilizer_smul (g : SL(2, ℤ)) (z : ℍ) :
+    Nat.card (stabilizer SL(2, ℤ) (g • z)) = Nat.card (stabilizer SL(2, ℤ) z) :=
+  Nat.card_congr (stabilizerEquivStabilizerOfOrbitRel
+    (⟨g, rfl⟩ : MulAction.orbitRel SL(2, ℤ) ℍ (g • z) z)).toEquiv
+
+/-- **Every point stabiliser is finite**, so the elliptic order `e_P` is defined at every point
+of `ℍ` and not only inside the fundamental domain. -/
+instance finite_stabilizer (z : ℍ) : Finite (stabilizer SL(2, ℤ) z) := by
+  obtain ⟨g, hg⟩ := exists_smul_mem_fd z
+  refine finite_stabilizer_of_smul g ?_
+  by_cases hI : g • z = I
+  · exact hI ▸ finite_stabilizer_of_subset {1, -1, S, -S} fun _ h ↦ stabilizer_I.mp h
+  by_cases hρ : g • z = ρ
+  · exact hρ ▸ finite_stabilizer_of_subset _ fun _ h ↦ stabilizer_ρ.mp h
+  by_cases hρ' : g • z = (1 : ℝ) +ᵥ ρ
+  · -- `ρ + 1` is `T • ρ`, so its stabiliser is conjugate to the one at `ρ`
+    rw [hρ', ← modular_T_smul]
+    refine finite_stabilizer_of_smul T⁻¹ ?_
+    rw [← mul_smul, inv_mul_cancel, one_smul]
+    exact finite_stabilizer_of_subset _ fun _ h ↦ stabilizer_ρ.mp h
+  · exact finite_stabilizer_of_subset {1, -1} fun _ h ↦ by
+      rcases stabilizer_of_ne hg h hI hρ hρ' with rfl | rfl <;> simp
+
+private theorem card_stabilizer_of_coe_eq {s : Finset SL(2, ℤ)}
+    (h : (stabilizer SL(2, ℤ) w : Set SL(2, ℤ)) = ↑s) :
+    Nat.card (stabilizer SL(2, ℤ) w) = s.card := by
+  rw [← SetLike.coe_sort_coe, h, Nat.card_coe_set_eq, Set.ncard_eq_toFinset_card']
+  simp
+
+/-- **The stabiliser of `i` has order `4`**: the centre `±1` together with `±S`, the inversion
+fixing `i`. In `PSL(2, ℤ)` this is the elliptic order `e_i = 2`. -/
+theorem card_stabilizer_I : Nat.card (stabilizer SL(2, ℤ) I) = 4 :=
+  (card_stabilizer_of_coe_eq (s := {1, -1, S, -S}) (by ext g; simpa using stabilizer_I)).trans
+    (by decide)
+
+/-- **The stabiliser of `ρ` has order `6`**: the centre `±1` together with `±ST` and `±T⁻¹S`,
+the two rotations of order three fixing `ρ`. In `PSL(2, ℤ)` this is the elliptic order
+`e_ρ = 3`. -/
+theorem card_stabilizer_ρ : Nat.card (stabilizer SL(2, ℤ) ρ) = 6 :=
+  (card_stabilizer_of_coe_eq (s := {1, -1, S * T, -(S * T), T⁻¹ * S, -(T⁻¹ * S)})
+    (by ext g; simpa using stabilizer_ρ)).trans (by decide)
+
+/-- **Order `4` everywhere on the orbit of `i`**, not just at `i`: conjugate stabilisers have
+equal order, so `card_stabilizer_I` propagates along the orbit. -/
+theorem card_stabilizer_of_orbit_eq_I
+    (hz : (Quotient.mk'' z : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) = Quotient.mk'' I) :
+    Nat.card (stabilizer SL(2, ℤ) z) = 4 := by
+  obtain ⟨g, rfl⟩ : ∃ g : SL(2, ℤ), g • (I : ℍ) = z := Quotient.exact' hz
+  exact (card_stabilizer_smul g I).trans card_stabilizer_I
+
+/-- **Order `6` everywhere on the orbit of `ρ`**, not just at `ρ`; the companion of
+`card_stabilizer_of_orbit_eq_I`. -/
+theorem card_stabilizer_of_orbit_eq_ρ
+    (hz : (Quotient.mk'' z : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) = Quotient.mk'' ρ) :
+    Nat.card (stabilizer SL(2, ℤ) z) = 6 := by
+  obtain ⟨g, rfl⟩ : ∃ g : SL(2, ℤ), g • (ρ : ℍ) = z := Quotient.exact' hz
+  exact (card_stabilizer_smul g ρ).trans card_stabilizer_ρ
+
+/-- **Away from the two elliptic orbits the stabiliser is just the centre**, of order `2`, so
+`e_P = 1` in `PSL(2, ℤ)`. No fundamental-domain membership is asked of `z`: the exclusions are
+read on its orbit, which is what the valence formula's non-elliptic index type carries. -/
+theorem card_stabilizer_eq_two_of_orbit_ne (z : ℍ)
+    (hI : (Quotient.mk'' z : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) ≠ Quotient.mk'' I)
+    (hρ : (Quotient.mk'' z : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) ≠ Quotient.mk'' ρ) :
+    Nat.card (stabilizer SL(2, ℤ) z) = 2 := by
+  obtain ⟨g, hg⟩ := exists_smul_mem_fd z
+  have hq : (Quotient.mk'' (g • z) : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) = Quotient.mk'' z :=
+    Quotient.sound' ⟨g, rfl⟩
+  -- the representative in `𝒟` inherits both exclusions, so Mathlib's classification applies
+  have hI' : g • z ≠ I := fun h ↦ hI (hq ▸ (orbit_mk_eq_I_iff hg).mpr h)
+  have hρ' : g • z ≠ ρ := fun h ↦ hρ (hq ▸ (orbit_mk_eq_ρ_iff hg).mpr (Or.inl h))
+  have hρ'' : g • z ≠ (1 : ℝ) +ᵥ ρ := fun h ↦ hρ (hq ▸ (orbit_mk_eq_ρ_iff hg).mpr (Or.inr h))
+  rw [← card_stabilizer_smul g z]
+  refine (card_stabilizer_of_coe_eq (s := {1, -1}) ?_).trans (by decide)
+  ext x
+  refine ⟨fun hx ↦ ?_, fun hx ↦ ?_⟩
+  · rcases stabilizer_of_ne hg hx hI' hρ' hρ'' with rfl | rfl <;> simp
+  · simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff,
+      Set.mem_singleton_iff] at hx
+    rcases hx with rfl | rfl <;> simp [MulAction.mem_stabilizer_iff]
+
+end ModularGroup
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/Modular/Stabilizer.lean
+++ b/TauCeti/NumberTheory/Modular/Stabilizer.lean
@@ -28,6 +28,8 @@ literally the `q` with `q ≠ ⟦i⟧` and `q ≠ ⟦ρ⟧`.
 
 ## Main declarations
 
+* `TauCeti.ModularGroup.card_stabilizer_smul`: the order is invariant along the action, so it
+  is an invariant of the orbit rather than of the point.
 * `TauCeti.ModularGroup.finite_stabilizer`: every point stabiliser is finite, so the elliptic
   order is defined at every point of `ℍ`.
 * `TauCeti.ModularGroup.card_stabilizer_I` and `TauCeti.ModularGroup.card_stabilizer_ρ`: the
@@ -35,7 +37,8 @@ literally the `q` with `q ≠ ⟦i⟧` and `q ≠ ⟦ρ⟧`.
 * `TauCeti.ModularGroup.card_stabilizer_of_orbit_eq_I` and
   `TauCeti.ModularGroup.card_stabilizer_of_orbit_eq_ρ`: the same orders everywhere on those two
   orbits.
-* `TauCeti.ModularGroup.card_stabilizer_eq_two_of_orbit_ne`: order `2` on every other orbit.
+* `TauCeti.ModularGroup.card_stabilizer_eq_two_of_orbit_ne_I_of_orbit_ne_ρ`: order `2` on every
+  other orbit.
 
 ## References
 
@@ -64,7 +67,13 @@ private theorem finite_stabilizer_of_smul (g : SL(2, ℤ))
   Finite.of_equiv _ (stabilizerEquivStabilizerOfOrbitRel
     (⟨g, rfl⟩ : MulAction.orbitRel SL(2, ℤ) ℍ (g • z) z)).toEquiv
 
-private theorem card_stabilizer_smul (g : SL(2, ℤ)) (z : ℍ) :
+/-- **The stabiliser order is invariant along the action**, the stabilisers of `g • z` and of
+`z` being conjugate. This is the transport rule behind every count below: it is what lets the
+valence formula attach the weight `1 / e_P` to an orbit rather than to a chosen point of it.
+
+Not `@[simp]`: the left-hand side is not in simp-normal form, since `ModularGroup.sl_moeb`
+rewrites the `SL(2, ℤ)`-action inside it, and `simpNF` rejects the attribute for that reason. -/
+theorem card_stabilizer_smul (g : SL(2, ℤ)) (z : ℍ) :
     Nat.card (stabilizer SL(2, ℤ) (g • z)) = Nat.card (stabilizer SL(2, ℤ) z) :=
   Nat.card_congr (stabilizerEquivStabilizerOfOrbitRel
     (⟨g, rfl⟩ : MulAction.orbitRel SL(2, ℤ) ℍ (g • z) z)).toEquiv
@@ -125,7 +134,7 @@ theorem card_stabilizer_of_orbit_eq_ρ
 /-- **Away from the two elliptic orbits the stabiliser is just the centre**, of order `2`, so
 `e_P = 1` in `PSL(2, ℤ)`. No fundamental-domain membership is asked of `z`: the exclusions are
 read on its orbit, which is what the valence formula's non-elliptic index type carries. -/
-theorem card_stabilizer_eq_two_of_orbit_ne (z : ℍ)
+theorem card_stabilizer_eq_two_of_orbit_ne_I_of_orbit_ne_ρ (z : ℍ)
     (hI : (Quotient.mk'' z : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) ≠ Quotient.mk'' I)
     (hρ : (Quotient.mk'' z : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) ≠ Quotient.mk'' ρ) :
     Nat.card (stabilizer SL(2, ℤ) z) = 2 := by


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"modularforms-interior-stabilizer-orders"}-->

Advances **`TauCetiRoadmap/ModularForms/README.md`, Layer 1**. That layer names an *order
dictionary* as a milestone set of three items, "stated here because the theorem quantifies over
every finite-index `Γ`":

> "orders at interior points through the finite `PSL₂`-stabilizers; orders at cusps read in the
> **width parameter** …; and finite support of the order divisor of a nonzero form"

This PR is the **first** of the three. (The third landed as #3330; the cusp-width convention is
still open.)

### What this adds

One new file, `TauCeti/NumberTheory/Modular/Stabilizer.lean` (152 lines), in the namespace
`TauCeti.ModularGroup` alongside the existing `Modular/Orbits.lean`.

```lean
instance finite_stabilizer (z : ℍ) : Finite (stabilizer SL(2, ℤ) z)

theorem card_stabilizer_I : Nat.card (stabilizer SL(2, ℤ) I) = 4
theorem card_stabilizer_ρ : Nat.card (stabilizer SL(2, ℤ) ρ) = 6

theorem card_stabilizer_of_orbit_eq_I (hz : ⟦z⟧ = ⟦I⟧) : Nat.card (stabilizer SL(2, ℤ) z) = 4
theorem card_stabilizer_of_orbit_eq_ρ (hz : ⟦z⟧ = ⟦ρ⟧) : Nat.card (stabilizer SL(2, ℤ) z) = 6
theorem card_stabilizer_smul (g : SL(2, ℤ)) (z : ℍ) :
    Nat.card (stabilizer SL(2, ℤ) (g • z)) = Nat.card (stabilizer SL(2, ℤ) z)

theorem card_stabilizer_eq_two_of_orbit_ne_I_of_orbit_ne_ρ (z : ℍ)
    (hI : ⟦z⟧ ≠ ⟦I⟧) (hρ : ⟦z⟧ ≠ ⟦ρ⟧) : Nat.card (stabilizer SL(2, ℤ) z) = 2
```

Dividing by the centre `±1`, which acts trivially on `ℍ`, these are the `PSL(2, ℤ)` elliptic
orders `e_i = 2`, `e_ρ = 3`, `e_P = 1` — the weights the valence formula attaches to its orbits.
The halving itself is deliberately **not** done here; it needs the projective group and is a
separate rung.

### Review round 1 — both findings addressed

* **api-design** — `card_stabilizer_smul`, the invariance of the order along the action, was
  private; it is the characteristic property behind every count here, so it is now public with a
  docstring. **Its `@[simp]` was tried and reverted.** The finding made the attribute conditional
  ("if simplification tests confirm the intended normal form") and the test *disconfirms* it:
  `lint-env` failed with `simpNF` on `card_stabilizer_smul`, because the left-hand side is not in
  simp-normal form — `ModularGroup.sl_moeb` rewrites the action inside
  `Nat.card (stabilizer SL(2, ℤ) (g • z))`. The negative result is recorded in the docstring so
  it is not re-added.
* **naming** — `card_stabilizer_eq_two_of_orbit_ne` →
  `card_stabilizer_eq_two_of_orbit_ne_I_of_orbit_ne_ρ`, naming both excluded orbits in argument
  order.

### Why the counts are stated on orbits

The three orbit-level counts take their hypotheses on the class of `z` in
`MulAction.orbitRel.Quotient SL(2, ℤ) ℍ`, not on a fundamental-domain representative, because
that is exactly what the valence formula's index type already carries: `NonEllipticOrbit` is
defined in `Order/Orbits.lean` as `{q // q ≠ Quotient.mk'' I ∧ q ≠ Quotient.mk'' ρ}`. A count
phrased as "`z ∈ 𝒟` and `z ≠ i, ρ, ρ+1`" would have to be re-derived at every use site.

### What Mathlib supplies, and what it does not

Mathlib classifies the stabilising *matrices*, but only at a point of the closed fundamental
domain: `ModularGroup.stabilizer_I`, `ModularGroup.stabilizer_ρ` and
`ModularGroup.stabilizer_of_ne`, the last of which needs `z ∈ 𝒟` together with `z ≠ i, ρ, ρ+1`.
It has **no finiteness and no cardinality statement** anywhere for this action — a full-tree grep
for `Nat.card.*stabilizer|card_stabilizer` returns only `RamificationInertia`,
`NumberField.InfinitePlace` and `Cyclotomic` hits, none modular, and none about the order being
constant along an orbit.

What is added is therefore the passage from `𝒟` to an arbitrary point of `ℍ`, in two steps:
`ModularGroup.exists_smul_mem_fd` moves `z` into `𝒟`, and
`MulAction.stabilizerEquivStabilizerOfOrbitRel` transports the answer back, conjugate stabilisers
being isomorphic. The `ρ + 1` corner is handled by the same transport from `ρ`, since
`ρ + 1 = T • ρ`.

### Provenance

**Not a port.** `github.com/CBirkbeck/AINTLIB` @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`: its
valence development hard-codes the weights `1/2` and `1/3` at `ellipticPointI'` and
`ellipticPointRho'` and never forms a stabiliser, so there is no order dictionary there to port.
Written directly against Mathlib's classification lemmas named above.

### Verification

`lake build` green (7915 jobs); `lake exe axioms` clean over 46845 declarations;
`lake exe module-system` clean over 2240 modules; `lint-env` PASS (it is what caught the `simpNF`
problem above). The file is diagnostics-clean and its widest line is 97 codepoints.

