### PR TITLE
feat(DivisionPolynomial): division polynomials of the universal curve

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
+
+/-!
+# Division polynomials of the universal curve
+
+Every Weierstrass curve is a specialization of the universal one, and division polynomials commute
+with base change. Composing the two identifies the division polynomials of a curve `W` over `R`,
+evaluated at a point `(x, y)` of the affine plane, with those of `Universal.curve` pushed forward
+along `Universal.polyEval`.
+
+Each proof is the same two steps: unfold `polyEval` into a `map` followed by `evalEval`
+(`polyEval_apply`), then rewrite the base change of the universal curve back to `W`
+(`map_specialize`). The division polynomial in between is carried across by the relevant Mathlib
+`map_*` lemma.
+
+## Main results
+
+* `WeierstrassCurve.Universal.evalEval_ψ₂`, `.evalEval_Ψ₃`, `.evalEval_preΨ₄`, `.evalEval_ψ`,
+  `.evalEval_φ`: the division polynomials `ψ₂`, `Ψ₃`, `preΨ₄`, `ψₙ` and `φₙ` of `W` at `(x, y)`
+  are the universal ones evaluated through `Universal.polyEval`.
+
+## Implementation notes
+
+`Ψ₃` and `preΨ₄` are univariate, so their statements evaluate `C W.Ψ₃` rather than `W.Ψ₃`; the two
+extra rewrites in those proofs (`map_C`, `coe_mapRingHom`) only move that `C` past the base change.
+
+The companion transport for `ω` is **not** here. It cannot be: `WeierstrassCurve.ω` does not exist
+in this repository or in the pinned Mathlib, and neither does the `map_ω` such a proof would rewrite
+with. `DivisionPolynomial/Invariant.lean` lists both among what it deliberately leaves out, and
+records the chain still missing for them — `redInvarDenom` together with
+`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`. `evalEval_ω` belongs with that
+work rather than here.
+
+## Provenance
+
+Adapted from `LutzNagell/ZSMul.lean` in AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0),
+at `dev/modular-curves @ 9fec8eba7652` — the revision `TauCetiRoadmap/EllipticCurves/README.md`
+pins for the NagellLutz project. Declarations `Universal.evalEval_ψ₂`, `evalEval_Ψ₃`,
+`evalEval_preΨ₄`, `evalEval_ψ` and `evalEval_φ`; the sixth, `evalEval_ω`, is excluded for the
+reason above. That file's header reads `Authors: David Kurniadi Angdinata, Junyan Xu`.
+
+The statements are the source's unchanged. Docstrings are added here, and the source's shared
+`variable {m n : ℤ}` is narrowed to `n`, which is the only index either statement mentions.
+-/
+
+public section
+
+noncomputable section
+
+open Polynomial
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R) {x y : R}
+
+namespace Universal
+
+/-- The `2`-division polynomial of `W` at `(x, y)` is the universal one under `polyEval`. -/
+lemma evalEval_ψ₂ : W.ψ₂.evalEval x y = polyEval W x y curve.ψ₂ := by
+  simp_rw [polyEval_apply, ← map_ψ₂, map_specialize]
+
+/-- The `3`-division polynomial of `W` at `(x, y)` is the universal one under `polyEval`. -/
+lemma evalEval_Ψ₃ : (C W.Ψ₃).evalEval x y = polyEval W x y (C curve.Ψ₃) := by
+  simp_rw [polyEval_apply, map_C, coe_mapRingHom, ← map_Ψ₃, map_specialize]
+
+/-- The polynomial `preΨ₄` of `W` at `(x, y)` is the universal one under `polyEval`. -/
+lemma evalEval_preΨ₄ : (C W.preΨ₄).evalEval x y = polyEval W x y (C curve.preΨ₄) := by
+  simp_rw [polyEval_apply, map_C, coe_mapRingHom, ← map_preΨ₄, map_specialize]
+
+variable {n : ℤ}
+
+/-- The `n`-division polynomial `ψₙ` of `W` at `(x, y)` is the universal one under `polyEval`. -/
+lemma evalEval_ψ : (W.ψ n).evalEval x y = polyEval W x y (curve.ψ n) := by
+  simp_rw [polyEval_apply, ← map_ψ, map_specialize]
+
+/-- The numerator `φₙ` of `W` at `(x, y)` is the universal one under `polyEval`. -/
+lemma evalEval_φ : (W.φ n).evalEval x y = polyEval W x y (curve.φ n) := by
+  simp_rw [polyEval_apply, ← map_φ, map_specialize]
+
+end Universal
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -23,8 +23,8 @@ Each proof is the same two steps: unfold `polyEval` into a `map` followed by `ev
 ## Main results
 
 * `WeierstrassCurve.Universal.evalEval_ψ₂`, `.evalEval_Ψ₃`, `.evalEval_preΨ₄`, `.evalEval_ψ`,
-  `.evalEval_φ`: the division polynomials `ψ₂`, `Ψ₃`, `preΨ₄`, `ψₙ` and `φₙ` of `W` at `(x, y)`
-  are the universal ones evaluated through `Universal.polyEval`.
+  `.evalEval_φ`: the polynomials `ψ₂`, `Ψ₃`, `ψₙ` and `φₙ` of `W` at `(x, y)`, together with the
+  auxiliary `preΨ₄`, are the universal ones evaluated through `Universal.polyEval`.
 
 ## Implementation notes
 
@@ -47,7 +47,8 @@ pins for the NagellLutz project. Declarations `Universal.evalEval_ψ₂`, `evalE
 reason above. That file's header reads `Authors: David Kurniadi Angdinata, Junyan Xu`.
 
 The statements are the source's unchanged. Docstrings are added here, and the source's shared
-`variable {m n : ℤ}` is narrowed to `n`, which is the only index either statement mentions.
+`variable {m n : ℤ}` is narrowed to `n`: of the five results only `evalEval_ψ` and `evalEval_φ`
+carry an index, and both use `n` alone.
 -/
 
 public section


### PR DESCRIPTION
Division polynomials of the universal curve, transported to an arbitrary curve at a point.

```lean
lemma evalEval_ψ : (W.ψ n).evalEval x y = polyEval W x y (curve.ψ n)
```

and the same for `ψ₂`, `Ψ₃`, `preΨ₄` and `φ`. Five lemmas, one `simp_rw` each.

## What makes them one-liners

Two facts already in the repository do the work, and this file only composes them:

* `WeierstrassCurve.map_specialize` (`Universal.lean:321`) — every Weierstrass curve is a
  specialization of the universal one;
* Mathlib's `map_ψ₂`, `map_Ψ₃`, `map_preΨ₄`, `map_ψ`, `map_φ`
  (`Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean:498–541`) — division
  polynomials commute with base change.

`polyEval_apply` (`Universal.lean:336`) unfolds `polyEval` into a `map` followed by `evalEval`, at
which point the two meet. `Ψ₃` and `preΨ₄` are univariate, so their statements carry a `C` and their
proofs two extra rewrites (`map_C`, `coe_mapRingHom`) that only move it past the base change.

## The sixth lemma is deliberately absent

The source block has six; this PR ports five. `evalEval_ω` cannot be stated here:
**`WeierstrassCurve.ω` does not exist in this repository or in the pinned Mathlib**, and neither
does the `map_ω` its proof would rewrite with. That is not an oversight in either place —
`DivisionPolynomial/Invariant.lean` lists both under "What is deliberately not here", and records
the chain still missing for them:

> What is missing for `ω` is `redInvarDenom` itself together with the chain
> `redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`.

All four of those links are unbuilt — they appear in that file only as prose about their own
absence, not as declarations. `ω_spec` additionally consumes `isEllipticSequence_normEDS`, which
the pinned Mathlib still records as an open TODO. So `evalEval_ω` sits four lemmas plus an upstream
gap downstream of here, and belongs with that work rather than with this.

## Reuse

Checked against **both** trees, not just Mathlib — the statements mention `Universal.curve` and
`polyEval`, which have no Mathlib spelling at all, so a Mathlib absence proof would have answered
the wrong question. In TauCeti, `DivisionPolynomial/Eval.lean` already carries
`evalEval_ψ_eq_evalEval_Ψ`, `evalEval_Ψ_sq_eq_eval_ΨSq` and `evalEval_φ_eq_eval_Φ`; those relate
`ψ`/`Ψ`/`φ` to each other *on a fixed curve* under a point hypothesis, and are unrelated to
transporting along `specialize`. No overlap.

These have no consumer in the repository yet — they are the transport layer the rest of `ZSMul.lean`
is built on, and the next slice (`cusp_ψ₂`, `cusp_Ψ₃`, `cusp_preΨ₄`) is their first caller. Per the
precedent in #2860/#2878, a prerequisite may land ahead of its consumer.

## Review status — please note

**This PR is opened without a scoreboard, deliberately, and that is not an oversight.** Both codex
credentials on the authoring machine are over their usage limits (`~/.codex` until 2026-08-20,
`~/.codex2` until 2026-09-14), and `.github/workflows/review.yml` is `disabled_manually`. Every
local review attempt returned all ten rubrics at `cost=$0.0000` — zero cost meaning the provider
never ran, so those are infrastructure errors and not verdicts.

Posting one anyway would be worse than posting none: `merge_from_scoreboard.py` takes the newest
scoreboard by `updated_at` with no access bar, so a scoreboard full of `error` states **overwrites
a human reviewer's verdict as the canonical record**. On #3333 that is exactly what happened — a
human posted ten green at 06:30 and a failed local run replaced it at 06:36. This PR will not
repeat that.

Two workarounds exist and both were declined as not mine to take: `--auth api` moves spend onto
metered API keys, and `--reviewer claude` would publish a Claude review of Claude-written Lean as
the scoreboard driving auto-merge — precisely what pinning the reviewer to codex exists to prevent.

## Gates

`lake build` PASS at 1999 jobs, on a branch rebased onto current `main` and rebuilt after the
rebase. No `sorry`, no `set_option`, no `native_decide`, no `erw`, no `λ`/`$`/`push_neg`. Longest
proof is 2 lines against the 30-line threshold; longest line is exactly 100 codepoints against the
100 limit — a limit `lake build` itself enforces, so the green build is the evidence. File is 89
lines.

## Provenance

Adapted from `LutzNagell/ZSMul.lean` in AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at
**`dev/modular-curves @ 9fec8eba7652`** — the revision `TauCetiRoadmap/EllipticCurves/README.md`
pins for the NagellLutz project. Declarations `Universal.evalEval_ψ₂`, `evalEval_Ψ₃`,
`evalEval_preΨ₄`, `evalEval_ψ`, `evalEval_φ`. That file's header reads
`Authors: David Kurniadi Angdinata, Junyan Xu`; following this repository's convention for adapted
material the upstream authorship is credited in the module docstring rather than in the copyright
header.

The statements are the source's unchanged. Docstrings are added here, and the source's shared
`variable {m n : ℤ}` is narrowed to `n`, the only index either statement mentions.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-univ-evaleval"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
