### PR TITLE
feat(Filter): finite sums of functions vanishing or bounded along a filter

### DIFF
--- a/TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean
+++ b/TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean
@@ -22,6 +22,17 @@ without these each call site reruns it.
 
 * `Filter.ZeroAtFilter.sum`: a finite sum of functions vanishing along `l` vanishes along `l`.
 * `Filter.BoundedAtFilter.sum`: a finite sum of functions bounded along `l` is bounded along `l`.
+
+## Provenance
+
+No code is transcribed. The gap was identified while porting the cusp chain of the AINTLIB
+`LeanModularForms` project (Chris Birkbeck, Apache-2.0),
+`LeanModularForms/HeckeRIngs/GL2/AdjointTheory.lean` at commit
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`: its `heckeT_p_ut_zero_at_cusps` (lines 62-70)
+open-codes precisely this induction with `Finset.sum_induction`, which is also the proof plan
+`BoundedAtFilter.sum` follows below. The statements here are about Mathlib's
+`Filter.ZeroAtFilter` / `Filter.BoundedAtFilter` at an arbitrary filter and index type, not about
+modular forms.
 -/
 
 public section
@@ -32,10 +43,8 @@ namespace Filter
 
 variable {α β ι : Type*} {l : Filter α} {s : Finset ι} {f : ι → α → β}
 
-/-- **A finite sum of functions vanishing along `l` vanishes along `l`.** This is the additive
-companion of `Filter.BoundedAtFilter.prod`, and it is `zeroAtFilterAddSubmonoid`'s closure under
-`Finset.sum`. It needs `AddCommMonoid` rather than the submonoid's `AddZeroClass`, since that is
-what `Finset.sum` itself requires. -/
+/-- **A finite sum of functions vanishing along `l` vanishes along `l`.** The additive companion
+of `Filter.BoundedAtFilter.prod`. The `AddCommMonoid` hypothesis is what `Finset.sum` requires. -/
 theorem ZeroAtFilter.sum [TopologicalSpace β] [AddCommMonoid β] [ContinuousAdd β]
     (h : ∀ i ∈ s, ZeroAtFilter l (f i)) : ZeroAtFilter l (∑ i ∈ s, f i) :=
   sum_mem (S := zeroAtFilterAddSubmonoid l) h

--- a/TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean
+++ b/TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Order.Filter.ZeroAndBoundedAtFilter
+
+/-!
+# Finite sums of functions vanishing or bounded along a filter
+
+Mathlib's `Filter.ZeroAtFilter` and `Filter.BoundedAtFilter` are closed under binary sums
+(`Filter.ZeroAtFilter.add`, `Filter.BoundedAtFilter.add`), and the bounded functions are closed
+under a `Finset.prod` (`Filter.BoundedAtFilter.prod`, via `boundedFilterSubalgebra`). The additive
+counterpart of that product lemma is not recorded upstream; this file adds it for both predicates.
+
+The gap shows up wherever an operator is a finite sum of slashes: proving that such an operator
+stays bounded, or stays vanishing, along `atImInfty` is an induction over the summands, and
+without these each call site reruns it.
+
+## Main results
+
+* `Filter.ZeroAtFilter.sum`: a finite sum of functions vanishing along `l` vanishes along `l`.
+* `Filter.BoundedAtFilter.sum`: a finite sum of functions bounded along `l` is bounded along `l`.
+-/
+
+public section
+
+open Finset
+
+namespace Filter
+
+variable {α β ι : Type*} {l : Filter α} {s : Finset ι} {f : ι → α → β}
+
+/-- **A finite sum of functions vanishing along `l` vanishes along `l`.** This is the additive
+companion of `Filter.BoundedAtFilter.prod`, and it is `zeroAtFilterAddSubmonoid`'s closure under
+`Finset.sum`. It needs `AddCommMonoid` rather than the submonoid's `AddZeroClass`, since that is
+what `Finset.sum` itself requires. -/
+theorem ZeroAtFilter.sum [TopologicalSpace β] [AddCommMonoid β] [ContinuousAdd β]
+    (h : ∀ i ∈ s, ZeroAtFilter l (f i)) : ZeroAtFilter l (∑ i ∈ s, f i) :=
+  sum_mem (S := zeroAtFilterAddSubmonoid l) h
+
+/-- **A finite sum of functions bounded along `l` is bounded along `l`** — the additive companion
+of `Filter.BoundedAtFilter.prod`. -/
+theorem BoundedAtFilter.sum [SeminormedAddCommGroup β]
+    (h : ∀ i ∈ s, BoundedAtFilter l (f i)) : BoundedAtFilter l (∑ i ∈ s, f i) :=
+  Finset.sum_induction f (BoundedAtFilter l) (fun _ _ ↦ BoundedAtFilter.add)
+    (const_boundedAtFilter l 0) h
+
+end Filter
+
+end


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke/filter-sum"}-->

## What is added

Two lemmas in `TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean`:

```lean
theorem Filter.ZeroAtFilter.sum    (h : ∀ i ∈ s, ZeroAtFilter l (f i))    : ZeroAtFilter l (∑ i ∈ s, f i)
theorem Filter.BoundedAtFilter.sum (h : ∀ i ∈ s, BoundedAtFilter l (f i)) : BoundedAtFilter l (∑ i ∈ s, f i)
```

## Why this is a real gap, not a convenience wrapper

Mathlib already has, in `Mathlib/Order/Filter/ZeroAndBoundedAtFilter.lean`:

| | exists upstream |
|---|---|
| binary sum | `ZeroAtFilter.add` (:40), `BoundedAtFilter.add` (:88) |
| `Finset.prod` | `BoundedAtFilter.prod` (:137), via `boundedFilterSubalgebra` |
| **`Finset.sum`** | **absent, for both predicates** |

So the multiplicative closure over a `Finset` is recorded and the additive one is not. These are
the missing companions.

Searched before writing — `BoundedAtFilter.sum`, `ZeroAtFilter.sum`, and also
`IsBoundedAtImInfty.add` / `.sum` (nothing exists for `IsBoundedAtImInfty` either). The search was
run with a **positive control**: the same query shape does find `.add` and `.prod`, so the
negative result is trustworthy rather than a mis-typed grep.

## Proofs

`ZeroAtFilter.sum` is `sum_mem` on the existing `zeroAtFilterAddSubmonoid` — mathlib already
packages these functions as an `AddSubmonoid`, so no induction is needed.

`BoundedAtFilter.sum` goes through `Finset.sum_induction` with the existing `.add` and
`const_boundedAtFilter l 0`; the bounded functions are a `Submodule` only after fixing a scalar
ring, which would impose typeclasses the statement does not otherwise need.

## On the hypotheses

`ZeroAtFilter.sum` asks for `AddCommMonoid β` where `zeroAtFilterAddSubmonoid` itself only needs
`AddZeroClass β`. That is not slack: `Finset.sum` requires `AddCommMonoid`, so the stronger
hypothesis is forced by the statement rather than by the proof. The docstring records this.

## Why it is wanted

Roadmap `ModularForms`, Layer 2(b) "the action on forms". The Hecke operators there are finite
sums of slashes, and the cusp analysis needs each such sum to stay bounded (resp. vanishing) along
`atImInfty`. Mathlib's `IsBoundedAtImInfty.slash` supplies the individual summand; closing the sum
is what is missing, and without these lemmas each call site reruns the induction by hand — which
is exactly what the AINTLIB source does.

## Provenance

No code is transcribed. The gap was identified while porting the cusp chain of the AINTLIB
`LeanModularForms` project (Chris Birkbeck, Apache-2.0),
`LeanModularForms/HeckeRIngs/GL2/AdjointTheory.lean` at commit
`2baa76f742bdb4fb8ee323fabba41203bd390e08`, whose `heckeT_p_ut_zero_at_cusps` (lines 62-70)
open-codes precisely this induction with `Finset.sum_induction`. The statements here are about
Mathlib's `Filter.ZeroAtFilter` / `Filter.BoundedAtFilter` at an arbitrary filter and index type,
not about modular forms.

## Note on review

No local dry-run was run: this machine's codex credits are exhausted until 2026-08-20, and
invoking `--post` while walled publishes an all-`error` board that replaces the real one (this
happened to #3323 today). Opening non-draft so that a reviewer with quota picks it up, since the
sweep skips drafts.

Roadmap: ModularForms
