### PR TITLE
feat(DivisionPolynomial): division polynomials of the cusp curve

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Cusp.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Cusp.lean
@@ -20,9 +20,11 @@ whereas `ψ₂ = 2Y + a₁X + a₃` contains no `bᵢ` at all and collapses dire
 * `WeierstrassCurve.cusp_ψ₂`, `.cusp_Ψ₂Sq`, `.cusp_Ψ₃`, `.cusp_preΨ₄`: on the cusp curve
   `ψ₂ = 2Y`, `Ψ₂Sq = 4X³`, `Ψ₃ = 3X⁴` and `preΨ₄ = 2X⁶`.
 
-These are the four base values of the `preNormEDS` family — `preΨ' n` is generated from
-`Ψ₂Sq ^ 2`, `Ψ₃` and `preΨ₄` — so together they let `simp` reduce `preΨ`, `ΨSq` and `Φ` on the
-cusp curve as well.
+Three of these parameterise the univariate family: `preΨ'` is generated from `Ψ₂Sq ^ 2`, `Ψ₃`
+and `preΨ₄`, so collapsing those collapses `preΨ`, `ΨSq` and `Φ` on the cusp curve too — but only
+once the consumer unfolds whichever of those definitions it is working with, since they are
+definitions rather than simp lemmas and bare `simp` does not reduce them. `ψ₂` is not one of the
+three; it serves the bivariate division polynomials.
 
 ## Implementation notes
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Cusp.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Cusp.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Weierstrass
+
+/-!
+# Division polynomials of the cusp curve
+
+The cusp curve `Y² = X³` has every coefficient zero, so its low division polynomials collapse to
+their leading terms: each `bᵢ` vanishes and only the monomial that carries no `bᵢ` survives.
+
+## Main results
+
+* `WeierstrassCurve.cusp_ψ₂`, `.cusp_Ψ₃`, `.cusp_preΨ₄`: `ψ₂ = 2Y`, `Ψ₃ = 3X⁴` and
+  `preΨ₄ = 2X⁶` on the cusp curve.
+
+## Implementation notes
+
+`cusp`'s definition body is unexposed, so these proofs do not unfold it — they project through the
+`@[simp]` lemmas `cusp_a₁` … `cusp_a₆` that `Weierstrass.lean` provides for exactly this purpose.
+The `bᵢ` are then reduced by unfolding, which is available because Mathlib's
+`DivisionPolynomial/Basic.lean` marks its section `@[expose]`.
+
+## Provenance
+
+Adapted from `LutzNagell/ZSMul.lean` in AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at
+`dev/modular-curves @ 9fec8eba7652` — the revision `TauCetiRoadmap/EllipticCurves/README.md` pins
+for the NagellLutz project. Declarations `cusp_ψ₂`, `cusp_Ψ₃`, `cusp_preΨ₄`. That file's header
+reads `Authors: David Kurniadi Angdinata, Junyan Xu`; following this repository's convention for
+adapted material the upstream authorship is credited here rather than in the copyright header.
+
+Two changes from the source. The statements are generalised from `cusp ℤ` to `cusp R` over any
+`CommRing R` — nothing in them is specific to `ℤ`. And the source unfolds `cusp` directly
+(`simp [cusp, ψ₂, …]`), which is not available across a module boundary; the projection lemmas
+are used instead.
+-/
+
+public section
+
+noncomputable section
+
+open Polynomial
+
+open scoped Polynomial.Bivariate
+
+namespace WeierstrassCurve
+
+variable (R : Type*) [CommRing R]
+
+/-- On the cusp curve `Y² = X³`, the `2`-division polynomial is `2Y`. -/
+@[simp]
+lemma cusp_ψ₂ : (cusp R).ψ₂ = 2 * Y := by
+  simp [ψ₂, Affine.polynomialY, C_ofNat]
+
+/-- On the cusp curve `Y² = X³`, the `3`-division polynomial is `3X⁴`. -/
+@[simp]
+lemma cusp_Ψ₃ : (cusp R).Ψ₃ = 3 * X ^ 4 := by
+  simp [Ψ₃, b₂, b₄, b₆, b₈]
+
+/-- On the cusp curve `Y² = X³`, the auxiliary polynomial `preΨ₄` is `2X⁶`. -/
+@[simp]
+lemma cusp_preΨ₄ : (cusp R).preΨ₄ = 2 * X ^ 6 := by
+  simp [preΨ₄, b₂, b₄, b₆, b₈]
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Cusp.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Cusp.lean
@@ -11,19 +11,42 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.Weierstrass
 # Division polynomials of the cusp curve
 
 The cusp curve `Y² = X³` has every coefficient zero, so its low division polynomials collapse to
-their leading terms: each `bᵢ` vanishes and only the monomial that carries no `bᵢ` survives.
+their leading terms. Two different mechanisms produce that collapse: `Ψ₂Sq`, `Ψ₃` and `preΨ₄` are
+polynomials in the `bᵢ`, all of which vanish, leaving the one monomial that carries no `bᵢ`;
+whereas `ψ₂ = 2Y + a₁X + a₃` contains no `bᵢ` at all and collapses directly because `a₁ = a₃ = 0`.
 
 ## Main results
 
-* `WeierstrassCurve.cusp_ψ₂`, `.cusp_Ψ₃`, `.cusp_preΨ₄`: `ψ₂ = 2Y`, `Ψ₃ = 3X⁴` and
-  `preΨ₄ = 2X⁶` on the cusp curve.
+* `WeierstrassCurve.cusp_ψ₂`, `.cusp_Ψ₂Sq`, `.cusp_Ψ₃`, `.cusp_preΨ₄`: on the cusp curve
+  `ψ₂ = 2Y`, `Ψ₂Sq = 4X³`, `Ψ₃ = 3X⁴` and `preΨ₄ = 2X⁶`.
+
+These are the four base values of the `preNormEDS` family — `preΨ' n` is generated from
+`Ψ₂Sq ^ 2`, `Ψ₃` and `preΨ₄` — so together they let `simp` reduce `preΨ`, `ΨSq` and `Φ` on the
+cusp curve as well.
 
 ## Implementation notes
 
 `cusp`'s definition body is unexposed, so these proofs do not unfold it — they project through the
 `@[simp]` lemmas `cusp_a₁` … `cusp_a₆` that `Weierstrass.lean` provides for exactly this purpose.
-The `bᵢ` are then reduced by unfolding, which is available because Mathlib's
-`DivisionPolynomial/Basic.lean` marks its section `@[expose]`.
+Everything else here *is* unfolded, and each name is exposed by a different Mathlib module, which
+is worth recording separately since a future bump could move any one of them:
+
+* `ψ₂`, `Ψ₂Sq`, `Ψ₃`, `preΨ₄` — Mathlib's `DivisionPolynomial/Basic.lean`, whose
+  `@[expose] public section` is at line 94;
+* `b₂`, `b₄`, `b₆`, `b₈` — Mathlib's `EllipticCurve/Weierstrass.lean`, definitions at 101–114
+  under the `@[expose] public section` at line 66;
+* `Affine.polynomialY`, which `cusp_ψ₂` alone unfolds — `Affine/Basic.lean:192`, exposed at line 49.
+
+`C_ofNat` appears in two of the proofs because the `Ψ₂Sq` and `ψ₂` normal forms end with a
+constant polynomial `C 4` / `C 2` that must be matched against the numeral in the statement.
+
+## Roadmap
+
+`TauCetiRoadmap/EllipticCurves/README.md:99` — "**`[n]` is division polynomials**", which names
+`ZSMul.lean` and mathlib #13782 as "the mathlib-track anchor Layer 1 consumes". Three of these
+four are that file's cusp specialisation, used to evaluate the universal division polynomials at
+`(1, 1)`; `cusp_Ψ₂Sq` completes the family. The onward consumer is Layer 6's "**The torsion
+subgroup and Nagell–Lutz**" (`README.md:821`), whose stated route is division polynomials.
 
 ## Provenance
 
@@ -33,10 +56,12 @@ for the NagellLutz project. Declarations `cusp_ψ₂`, `cusp_Ψ₃`, `cusp_preΨ
 reads `Authors: David Kurniadi Angdinata, Junyan Xu`; following this repository's convention for
 adapted material the upstream authorship is credited here rather than in the copyright header.
 
-Two changes from the source. The statements are generalised from `cusp ℤ` to `cusp R` over any
-`CommRing R` — nothing in them is specific to `ℤ`. And the source unfolds `cusp` directly
-(`simp [cusp, ψ₂, …]`), which is not available across a module boundary; the projection lemmas
-are used instead.
+Three changes from the source. The statements are generalised from `cusp ℤ` to `cusp R` over any
+`CommRing R` — nothing in them is specific to `ℤ`. The source unfolds `cusp` directly
+(`simp [cusp, ψ₂, …]`), which is not available across a module boundary, so the projection lemmas
+are used instead. And `cusp_Ψ₂Sq` has no counterpart upstream: it is added here to complete the
+family, since without it `simp` leaves `(cusp R).Ψ₂Sq` irreducible and any consumer of `preΨ`,
+`ΨSq` or `Φ` on the cusp curve would have to re-derive it.
 -/
 
 public section
@@ -55,6 +80,11 @@ variable (R : Type*) [CommRing R]
 @[simp]
 lemma cusp_ψ₂ : (cusp R).ψ₂ = 2 * Y := by
   simp [ψ₂, Affine.polynomialY, C_ofNat]
+
+/-- On the cusp curve `Y² = X³`, the univariate polynomial congruent to `ψ₂²` is `4X³`. -/
+@[simp]
+lemma cusp_Ψ₂Sq : (cusp R).Ψ₂Sq = 4 * X ^ 3 := by
+  simp [Ψ₂Sq, b₂, b₄, b₆, C_ofNat]
 
 /-- On the cusp curve `Y² = X³`, the `3`-division polynomial is `3X⁴`. -/
 @[simp]


### PR DESCRIPTION
On the cusp curve `Y² = X³` every coefficient vanishes, so the low division polynomials collapse to
their leading terms.

```lean
@[simp] lemma cusp_ψ₂    : (cusp R).ψ₂    = 2 * Y
@[simp] lemma cusp_Ψ₂Sq  : (cusp R).Ψ₂Sq  = 4 * X ^ 3
@[simp] lemma cusp_Ψ₃    : (cusp R).Ψ₃    = 3 * X ^ 4
@[simp] lemma cusp_preΨ₄ : (cusp R).preΨ₄ = 2 * X ^ 6
```

Two mechanisms, not one. `Ψ₂Sq`, `Ψ₃` and `preΨ₄` are polynomials in the `bᵢ`, all of which vanish,
leaving the single monomial that carries no `bᵢ`. `ψ₂ = 2Y + a₁X + a₃` contains no `bᵢ` at all and
collapses because `a₁ = a₃ = 0` — which is why its proof unfolds `Affine.polynomialY` rather than
the `bᵢ`.

Three of them parameterise the univariate family — `preΨ'` is generated from `Ψ₂Sq ^ 2`, `Ψ₃`,
`preΨ₄` — so collapsing those collapses `preΨ`, `ΨSq` and `Φ` on the cusp curve as well, once the
consumer unfolds whichever downstream definition it is using; those are definitions, not simp
lemmas, so bare `simp` does not reduce them. `ψ₂` is not one of the three: it serves the bivariate
division polynomials.
`cusp_Ψ₂Sq` has no counterpart in the source; it is added here because without it `simp` leaves
`(cusp R).Ψ₂Sq` irreducible and every such consumer would re-derive it by hand.

## Three deliberate departures from the source

**The proofs do not unfold `cusp`.** The source writes `simp [cusp, ψ₂, Affine.polynomialY,
C_ofNat]`, which is fine inside the module that defines `cusp` but not from outside it: `cusp`'s
definition body is unexposed, as `Weierstrass.lean` states in the docstring of `cusp_a₁` —

> The definition body is unexposed, so these are how a consumer projects out of `cusp` — for
> instance when specialising the universal curve along it.

so these proofs go through the `@[simp]` projections `cusp_a₁` … `cusp_a₆` that exist for exactly
that purpose. Everything else *is* unfoldable, but by three different modules' markers, which is worth recording
because a bump could move any one: `ψ₂`/`Ψ₂Sq`/`Ψ₃`/`preΨ₄` via `DivisionPolynomial/Basic.lean:94`;
`b₂`…`b₈` via `Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean` (defined 101–114, exposed
at 66); `Affine.polynomialY` via `Affine/Basic.lean:192`, exposed at 49. My first version of this
note credited all of it to `DivisionPolynomial/Basic.lean`, which was wrong — the `bᵢ` are not in
that file.

**The statements are generalised** from the source's `cusp ℤ` to `cusp R` over any `CommRing R`.
Nothing in them is specific to `ℤ`; the source specialises because its only consumer does.

**`cusp_Ψ₂Sq` is not in the source.** It is added to complete the family, per the `api-design`
finding. Its proof needed `C_ofNat` beyond the suggested `simp [Ψ₂Sq, b₂, b₄, b₆]`: `Ψ₂Sq` reduces
to `C 4 * X ^ 3`, and `C 4` is not syntactically the numeral `4` — the same gap `cusp_ψ₂` hits.

## On the `@[simp]` attributes

These are marked `@[simp]` where the source marks nothing. Two reasons: each rewrites a closed
description of a division polynomial to a normal form strictly simpler than it, and the immediate
neighbours in `Weierstrass.lean` — `cusp_a₁` through `cusp_a₆` — are all `@[simp]` for the same
reason. Flagging it as a judgement call rather than a transcription, in case the reviewer disagrees.

(Lean accepts the attribute here because each left-hand side has a constant head symbol, `ψ₂` /
`Ψ₂Sq` / `Ψ₃` / `preΨ₄`. That is not automatic for lemmas of this shape — a sibling in this campaign,
`IsEllipticSequence.neg`, is rejected as a simp lemma because its head is the sequence variable.)

## Roadmap target

`TauCetiRoadmap/EllipticCurves/README.md:99` — "**`[n]` is division polynomials**", which names
`ZSMul.lean` and mathlib #13782 as "the mathlib-track anchor Layer 1 consumes". These are that
file's cusp specialisation, used to evaluate the universal division polynomials at `(1, 1)`. The
onward consumer is Layer 6's "**The torsion subgroup and Nagell–Lutz**" (`README.md:821`), whose
stated route is division polynomials.

(The bullet sits in the introductory milestone list rather than inside the Layer 1 section — it is
the anchor Layer 1 *consumes*, at line 99, not a Layer 1 entry.)

## Reuse

Checked in **both** trees. `cusp_ψ₂`, `cusp_Ψ₂Sq`, `cusp_Ψ₃` and `cusp_preΨ₄` exist in neither TauCeti nor the
pinned Mathlib; `cusp` itself is TauCeti's (`Weierstrass.lean:99`) and has no Mathlib spelling, so
the statements are not expressible upstream and cannot duplicate anything there. The existing
`cusp_a₁` … `cusp_a₆` are coefficient projections, not division polynomials.

No consumer in the repository yet. These are the second slice of the `ZSMul.lean` port: the first
(#3341) transports division polynomials to the universal curve, and the two meet in
`polyEval_cusp_ψ`, which needs both plus `normEDS_two_three_two`. Per the precedent in
#2860/#2878, a prerequisite may land ahead of its consumer.

## Review status

**Opened without a scoreboard, deliberately.** Both codex credentials on the authoring machine are
over quota (`~/.codex` until 2026-08-20, `~/.codex2` until 2026-09-14) and
`.github/workflows/review.yml` is `disabled_manually`, so every local review attempt returns all ten
rubrics at `cost=$0.0000` — the provider never ran, so those are infrastructure errors, not
verdicts.

Posting one anyway would be actively harmful rather than merely useless: `merge_from_scoreboard.py`
takes the newest scoreboard by `updated_at` with no access bar, so a scoreboard of `error` states
**overwrites a human reviewer's verdict as the canonical record**. That happened on #3333 — a human
posted ten green, and a failed local run replaced it six minutes later. Not repeating it.

## Gates

`lake build` PASS at 1994 jobs. No `sorry`, no `set_option`, no `native_decide`, no `erw`, no
`λ`/`$`/`push_neg`. Four lemmas, each a 2-line proof against the 30-line threshold; longest line
exactly 100 codepoints against the 100 limit; file is 100 lines.

## Provenance

Adapted from `LutzNagell/ZSMul.lean` in AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at
**`dev/modular-curves @ 9fec8eba7652`** — the revision `TauCetiRoadmap/EllipticCurves/README.md`
pins for the NagellLutz project. Declarations `cusp_ψ₂`, `cusp_Ψ₃`, `cusp_preΨ₄`. That file's header
reads `Authors: David Kurniadi Angdinata, Junyan Xu`; following this repository's convention for
adapted material the upstream authorship is credited in the module docstring rather than in the
copyright header.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-cusp-divpoly"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
