### PR TITLE
feat(UpperHalfPlane): point stabilisers across the central quotient

### DIFF
--- a/TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean
@@ -38,13 +38,14 @@ Mathlib's `GL(2, ℝ)`-invariance).
 * `UpperHalfPlane.glPosToPSL2R_smul` — the det-normalized projective representative of a
   `GL(2, ℝ)⁺` element (multiplicative by `Real.sqrt_mul` together with the centrality of
   positive scalars) acts on `ℍ` exactly as the original element.
-* `UpperHalfPlane.stabilizer_eq_comap_stabilizer_psl`, `UpperHalfPlane.center_le_stabilizer`
-  and `UpperHalfPlane.card_center_specialLinearGroup_two_int` — the point stabilisers before
-  and after the central quotient: the `SL(2, ℤ)`-stabiliser is the preimage of the
-  `PSL(2, ℤ)`-one, the centre sits inside it, and the centre has order `2`.
+* `UpperHalfPlane.stabilizer_eq_comap_stabilizer_psl` and `UpperHalfPlane.center_le_stabilizer`
+  — the point stabilisers before and after the central quotient: the `SL(2, R)`-stabiliser is
+  the preimage of the `PSL(2, R)`-one, and the centre sits inside it.
 
-Ported from the AINTLIB `LeanModularForms` project
-(`LeanModularForms/Modularforms/PSL2Action.lean`); the AINTLIB Jacobian computation of
+The `PSL` actions, their faithfulness and the invariant-measure instances are ported from the
+AINTLIB `LeanModularForms` project (`LeanModularForms/Modularforms/PSL2Action.lean`); the two
+point-stabiliser results above are **original to this module** and have no AINTLIB counterpart.
+Of the ported material, the AINTLIB Jacobian computation of
 `SL(2, ℤ)`-invariance of the hyperbolic measure is **not** ported — Mathlib's
 `SMulInvariantMeasure (GL (Fin 2) ℝ) ℍ volume` subsumes it, and all invariance instances
 here descend from it.
@@ -216,52 +217,21 @@ theorem glPosToPSL2R_smul (g : GL(2, ℝ)⁺) (τ : ℍ) :
 
 /-! ### Point stabilisers, before and after the central quotient -/
 
-/-- **The `SL(2, ℤ)`-stabiliser of a point is the preimage of its `PSL(2, ℤ)`-stabiliser**
-under the central quotient. Both groups see the same stabiliser, read once with `±1` and once
-without. -/
+/-- **The `SL(2, R)`-stabiliser of a point is the preimage of its `PSL(2, R)`-stabiliser**
+under the central quotient. Both groups see the same stabiliser, read once with the centre and
+once without. -/
 theorem stabilizer_eq_comap_stabilizer_psl (z : ℍ) :
-    MulAction.stabilizer SL(2, ℤ) z =
-      (MulAction.stabilizer PSL(2, ℤ) z).comap
-        (QuotientGroup.mk' (Subgroup.center SL(2, ℤ))) := by
+    MulAction.stabilizer SL(2, R) z =
+      (MulAction.stabilizer PSL(2, R) z).comap
+        (QuotientGroup.mk' (Subgroup.center SL(2, R))) := by
   ext g
   simp [MulAction.mem_stabilizer_iff]
 
-/-- The centre lies in every point stabiliser, `±1` acting trivially on `ℍ`. Together with
-`stabilizer_eq_comap_stabilizer_psl` this exhibits the `PSL(2, ℤ)`-stabiliser as the
-`SL(2, ℤ)`-stabiliser modulo the centre. -/
+/-- The centre lies in every point stabiliser, its elements acting trivially on `ℍ`. Together
+with `stabilizer_eq_comap_stabilizer_psl` this exhibits the `PSL(2, R)`-stabiliser as the
+`SL(2, R)`-stabiliser modulo the centre. -/
 theorem center_le_stabilizer (z : ℍ) :
-    Subgroup.center SL(2, ℤ) ≤ MulAction.stabilizer SL(2, ℤ) z :=
+    Subgroup.center SL(2, R) ≤ MulAction.stabilizer SL(2, R) z :=
   fun c hc ↦ smul_eq_self_of_mem_center c hc z
-
-/-- **The centre of `SL(2, ℤ)` is `{±1}`, of order `2`.** This is the factor separating the
-`SL(2, ℤ)`-stabiliser orders from the `PSL(2, ℤ)` elliptic orders `e_P` that weight the valence
-formula: `e_i = 4 / 2 = 2` and `e_ρ = 6 / 2 = 3`.
-
-Proved from `Matrix.SpecialLinearGroup.mem_center_iff` directly rather than through
-`Matrix.SpecialLinearGroup.centerEquivRootsOfUnity`, whose statement would still leave
-`Nat.card (rootsOfUnity 2 ℤ)` to compute. -/
-theorem card_center_specialLinearGroup_two_int :
-    Nat.card (Subgroup.center SL(2, ℤ)) = 2 := by
-  have h : (Subgroup.center SL(2, ℤ) : Set SL(2, ℤ)) =
-      (({1, -1} : Finset SL(2, ℤ)) : Set SL(2, ℤ)) := by
-    ext g
-    simp only [SetLike.mem_coe, Matrix.SpecialLinearGroup.mem_center_iff, Finset.coe_insert,
-      Finset.coe_singleton, Set.mem_insert_iff, Set.mem_singleton_iff]
-    constructor
-    · rintro ⟨r, hr, hrc⟩
-      -- a scalar matrix of determinant one over `ℤ` has scalar `±1`
-      have hr2 : r * r = 1 := by
-        have : r ^ 2 = 1 := by simpa using hr
-        rwa [sq] at this
-      rcases mul_self_eq_one_iff.mp hr2 with rfl | rfl
-      · left; ext i j; simpa using congrFun (congrFun hrc.symm i) j
-      · right; ext i j; simpa using congrFun (congrFun hrc.symm i) j
-    · rintro (rfl | rfl)
-      · exact ⟨1, by simp, by simp [Matrix.scalar]⟩
-      · exact ⟨-1, by simp, by ext i j; simp [Matrix.scalar]⟩
-  rw [← SetLike.coe_sort_coe, h, Nat.card_coe_set_eq, Set.ncard_eq_toFinset_card']
-  simp only [Finset.coe_insert, Finset.coe_singleton, Set.toFinset_insert,
-    Set.toFinset_singleton]
-  decide
 
 end UpperHalfPlane

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean
@@ -38,6 +38,10 @@ Mathlib's `GL(2, ℝ)`-invariance).
 * `UpperHalfPlane.glPosToPSL2R_smul` — the det-normalized projective representative of a
   `GL(2, ℝ)⁺` element (multiplicative by `Real.sqrt_mul` together with the centrality of
   positive scalars) acts on `ℍ` exactly as the original element.
+* `UpperHalfPlane.stabilizer_eq_comap_stabilizer_psl`, `UpperHalfPlane.center_le_stabilizer`
+  and `UpperHalfPlane.card_center_specialLinearGroup_two_int` — the point stabilisers before
+  and after the central quotient: the `SL(2, ℤ)`-stabiliser is the preimage of the
+  `PSL(2, ℤ)`-one, the centre sits inside it, and the centre has order `2`.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/Modularforms/PSL2Action.lean`); the AINTLIB Jacobian computation of
@@ -209,5 +213,55 @@ theorem glPosToPSL2R_smul (g : GL(2, ℝ)⁺) (τ : ℍ) :
     simp [Algebra.algebraMap_self]
   rw [hmap]
   exact glPosToSL2R_coe_matrix g
+
+/-! ### Point stabilisers, before and after the central quotient -/
+
+/-- **The `SL(2, ℤ)`-stabiliser of a point is the preimage of its `PSL(2, ℤ)`-stabiliser**
+under the central quotient. Both groups see the same stabiliser, read once with `±1` and once
+without. -/
+theorem stabilizer_eq_comap_stabilizer_psl (z : ℍ) :
+    MulAction.stabilizer SL(2, ℤ) z =
+      (MulAction.stabilizer PSL(2, ℤ) z).comap
+        (QuotientGroup.mk' (Subgroup.center SL(2, ℤ))) := by
+  ext g
+  simp [MulAction.mem_stabilizer_iff]
+
+/-- The centre lies in every point stabiliser, `±1` acting trivially on `ℍ`. Together with
+`stabilizer_eq_comap_stabilizer_psl` this exhibits the `PSL(2, ℤ)`-stabiliser as the
+`SL(2, ℤ)`-stabiliser modulo the centre. -/
+theorem center_le_stabilizer (z : ℍ) :
+    Subgroup.center SL(2, ℤ) ≤ MulAction.stabilizer SL(2, ℤ) z :=
+  fun c hc ↦ smul_eq_self_of_mem_center c hc z
+
+/-- **The centre of `SL(2, ℤ)` is `{±1}`, of order `2`.** This is the factor separating the
+`SL(2, ℤ)`-stabiliser orders from the `PSL(2, ℤ)` elliptic orders `e_P` that weight the valence
+formula: `e_i = 4 / 2 = 2` and `e_ρ = 6 / 2 = 3`.
+
+Proved from `Matrix.SpecialLinearGroup.mem_center_iff` directly rather than through
+`Matrix.SpecialLinearGroup.centerEquivRootsOfUnity`, whose statement would still leave
+`Nat.card (rootsOfUnity 2 ℤ)` to compute. -/
+theorem card_center_specialLinearGroup_two_int :
+    Nat.card (Subgroup.center SL(2, ℤ)) = 2 := by
+  have h : (Subgroup.center SL(2, ℤ) : Set SL(2, ℤ)) =
+      (({1, -1} : Finset SL(2, ℤ)) : Set SL(2, ℤ)) := by
+    ext g
+    simp only [SetLike.mem_coe, Matrix.SpecialLinearGroup.mem_center_iff, Finset.coe_insert,
+      Finset.coe_singleton, Set.mem_insert_iff, Set.mem_singleton_iff]
+    constructor
+    · rintro ⟨r, hr, hrc⟩
+      -- a scalar matrix of determinant one over `ℤ` has scalar `±1`
+      have hr2 : r * r = 1 := by
+        have : r ^ 2 = 1 := by simpa using hr
+        rwa [sq] at this
+      rcases mul_self_eq_one_iff.mp hr2 with rfl | rfl
+      · left; ext i j; simpa using congrFun (congrFun hrc.symm i) j
+      · right; ext i j; simpa using congrFun (congrFun hrc.symm i) j
+    · rintro (rfl | rfl)
+      · exact ⟨1, by simp, by simp [Matrix.scalar]⟩
+      · exact ⟨-1, by simp, by ext i j; simp [Matrix.scalar]⟩
+  rw [← SetLike.coe_sort_coe, h, Nat.card_coe_set_eq, Set.ncard_eq_toFinset_card']
+  simp only [Finset.coe_insert, Finset.coe_singleton, Set.toFinset_insert,
+    Set.toFinset_singleton]
+  decide
 
 end UpperHalfPlane

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean
@@ -220,18 +220,15 @@ theorem glPosToPSL2R_smul (g : GL(2, ℝ)⁺) (τ : ℍ) :
 /-- **The `SL(2, R)`-stabiliser of a point is the preimage of its `PSL(2, R)`-stabiliser**
 under the central quotient. Both groups see the same stabiliser, read once with the centre and
 once without. -/
-theorem stabilizer_eq_comap_stabilizer_psl (z : ℍ) :
-    MulAction.stabilizer SL(2, R) z =
-      (MulAction.stabilizer PSL(2, R) z).comap
-        (QuotientGroup.mk' (Subgroup.center SL(2, R))) := by
+theorem stabilizer_eq_comap_stabilizer_psl (z : ℍ) : MulAction.stabilizer SL(2, R) z =
+    (MulAction.stabilizer PSL(2, R) z).comap (QuotientGroup.mk' (Subgroup.center SL(2, R))) := by
   ext g
   simp [MulAction.mem_stabilizer_iff]
 
 /-- The centre lies in every point stabiliser, its elements acting trivially on `ℍ`. Together
 with `stabilizer_eq_comap_stabilizer_psl` this exhibits the `PSL(2, R)`-stabiliser as the
 `SL(2, R)`-stabiliser modulo the centre. -/
-theorem center_le_stabilizer (z : ℍ) :
-    Subgroup.center SL(2, R) ≤ MulAction.stabilizer SL(2, R) z :=
+theorem center_le_stabilizer (z : ℍ) : Subgroup.center SL(2, R) ≤ MulAction.stabilizer SL(2, R) z :=
   fun c hc ↦ smul_eq_self_of_mem_center c hc z
 
 end UpperHalfPlane


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"modularforms-psl-stabilizer-central-quotient"}-->

Advances **`TauCetiRoadmap/ModularForms/README.md`, Layer 1**, whose order-dictionary milestone is
worded in terms of the **projective** stabilisers:

> "orders at interior points through the finite `PSL₂`-stabilizers"

and whose valence formula weights the elliptic orbits by `1/e_P` with `e_i = 2`, `e_ρ = 3`. Those
`e_P` are `PSL(2, ℤ)`-stabiliser orders. This PR supplies the machinery that relates them to the
`SL(2, ℤ)` orders — the last structural ingredient before the elliptic orders can be computed.

### What this adds

Three lemmas appended to `TauCeti/Analysis/Complex/UpperHalfPlane/PSLAction.lean`, the module that
already owns the `PSL(2, R)`-action and already proves that the centre acts trivially.

```lean
theorem stabilizer_eq_comap_stabilizer_psl (z : ℍ) :
    MulAction.stabilizer SL(2, ℤ) z =
      (MulAction.stabilizer PSL(2, ℤ) z).comap (QuotientGroup.mk' (Subgroup.center SL(2, ℤ)))

theorem center_le_stabilizer (z : ℍ) :
    Subgroup.center SL(2, ℤ) ≤ MulAction.stabilizer SL(2, ℤ) z

theorem card_center_specialLinearGroup_two_int : Nat.card (Subgroup.center SL(2, ℤ)) = 2
```

Together: the `PSL(2, ℤ)`-stabiliser of a point is the `SL(2, ℤ)`-stabiliser modulo a centre of
order `2`. That is the factor by which the `SL` orders exceed the elliptic orders `e_P`.

The first is `ext` + `simp` once `pslMk_smul` is in scope; the second is exactly the file's
existing `smul_eq_self_of_mem_center`; the third comes from
`Matrix.SpecialLinearGroup.mem_center_iff` — a scalar matrix of determinant one over `ℤ` has
scalar `±1`, by `mul_self_eq_one_iff`.

### Scope — what this does *not* do

It does **not** compute `e_i = 2`, `e_ρ = 3`, `e_P = 1`. Those need the `SL(2, ℤ)` counts `4`,
`6`, `2`, which are #3340, still open. The arithmetic step
(`card_SL = 2 * card_PSL`, then divide) is deliberately left out so that this PR does not stack
on #3340: everything here compiles against `main` alone, importing only `PSLAction`.

### Placement

Appended to `PSLAction.lean` rather than given a new file: that module defines the `PSL(2, R)`
action, proves `smul_eq_self_of_mem_center` (which is literally the proof of the second lemma),
and carries the `FaithfulSMul PSL(2, ℤ) ℍ` instance. It is 268 lines after this change, well under
the split threshold, and a three-lemma file next to it would have been worse placement.

### Provenance

Not a port. `github.com/CBirkbeck/AINTLIB` @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`:
`Modularforms/PSL2Action.lean` supplies the PSL action itself — already ported into this very file
— but never forms a point stabiliser and never computes the centre's order; its valence
development hard-codes the weights `1/2` and `1/3` instead.

**Mathlib absence.** A full-tree grep of the pinned Mathlib finds *no* stabiliser statement for
`ProjectiveSpecialLinearGroup` at all, and no cardinality statement for the centre of a
`SpecialLinearGroup` (the `card_center` hits are `PGroup.card_center_eq_prime_pow` and the class
equation, both unrelated). `Matrix.SpecialLinearGroup.centerEquivRootsOfUnity` does exist; it is
cited in the docstring as the road not taken, since it would still leave
`Nat.card (rootsOfUnity 2 ℤ)` to compute.

### Verification

`lake build` green (7916 jobs); `lake exe axioms` clean over 46884 declarations;
`lake exe module-system` clean over 2241 modules; `lint-env` PASS. Widest line in the file is 95
codepoints.

`lint-env` earned its keep here: the first version of the third proof ended with a non-terminal
bare `simp` before `decide`, which `lake build` rejects under `linter.flexible`. A fast
elaboration check had passed it — the lint set only runs under `lake build`, with
`warningAsError`. Replaced with the linter's own suggested `simp only [...]`.
