### PR TITLE
feat(EDS): the reduced invariant denominator of a normalised EDS

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
@@ -57,8 +57,9 @@ identities listed below.
 `ω_one`, `ψc_neg`, `map_ω`, `ω_neg` — are **not** in this file. `ω` is defined through
 `redInvarDenom` and `complEDS₂Aux`, and `ω_spec` additionally consumes `redInvar_normEDS`, which
 routes through `normEDS` being an elliptic sequence — that is `isEllipticSequence_normEDS` in
-`NormEDS.lean`, which the pinned Mathlib still records as an open TODO. What is missing for `ω`
-is `redInvarDenom` itself together with the top of the chain
+`NormEDS.lean`, which the pinned Mathlib still records as an open TODO. The denominator itself
+has landed as `reducedInvarDenom` (`EllipticDivisibilitySequence/ReducedInvariant.lean`, the
+source's `redInvarDenom` respelt), so what is missing for `ω` is the top of the chain
 `redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`, which is written in the
 source's names. The lower three links have landed: `net_normEDS` is `isEllipticNet_normEDS`,
 `invar_normEDS` is `invarNum_mul_invarDenom`, and `invar₂_normEDS` is

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -61,8 +61,9 @@ ordinary missing prerequisites and arrive with `ω`.
 The companion transport for `ω` is **not** here. It cannot be: `WeierstrassCurve.ω` does not exist
 in this repository or in the pinned Mathlib, and neither does the `map_ω` such a proof would rewrite
 with. `DivisionPolynomial/Invariant.lean` lists both among what it deliberately leaves out, and
-records the chain still missing for them — `redInvarDenom` together with the top of
-`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`, the source's names for it. The
+records the chain still missing for them — the top of
+`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`, the source's names for it; the
+denominator itself has landed as `reducedInvarDenom`. The
 lower three links are `isEllipticNet_normEDS`, `invarNum_mul_invarDenom` and
 `IsEllipticNet.invarNum_normEDS_one_mul_eq_invarDenom_mul`, all present, so what remains is
 `redInvar_normEDS`. `evalEval_ω` belongs with that work rather than here.

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
@@ -59,9 +59,14 @@ Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in
 `normEDS_mul_complEDS_of_mem` (`:1324`), `private` in both, the name gaining Mathlib's full
 `_of_mem_nonZeroDivisors` suffix. The unconditional form adapts
 `normEDS_mul_complEDS` (`:1339`) of that same file, under its source name. The source's divisor
-reindexing `normEDS_mul_complEDS_div` (`:1350`) is deliberately not ported: what consumers take
-from it is the divisibility, and that is stated directly here as `normEDS_dvd_normEDS_mul` and
-`isDvdSequence_normEDS`, so the reindexing itself would have no call site. That file's
+reindexing `normEDS_mul_complEDS_div` (`:1350`) is ported here too, under its source name.
+
+That reverses an earlier decision recorded in this file, and the reason is worth keeping: the
+reindexing was left out because what consumers took from it was the divisibility, stated directly
+here as `normEDS_dvd_normEDS_mul` and `isDvdSequence_normEDS`, so it had no call site. It has six
+now — the `reducedInvarDenom_of_emod_eq_*` branch lemmas of `ReducedInvariant.lean` each need the
+identity in divisor form, `W k * complEDS b c d k (n / k) = W n`, rather than the divisibility it
+witnesses. That file's
 header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
 adapted material the upstream authorship is credited here rather than in the copyright header.
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
@@ -163,3 +163,15 @@ theorem isDvdSequence_normEDS (b c d : R) : IsDvdSequence (normEDS b c d) := by
   rintro k _ ⟨n, rfl⟩
   rw [mul_comm]
   exact normEDS_dvd_normEDS_mul b c d k n
+
+/-- **The complement at a divisor.** When `k ∣ n`, the `k`-complement at index `n / k` multiplies
+`normEDS b c d k` back up to `normEDS b c d n`. This is the divisor-indexed form of
+`normEDS_mul_complEDS` (`Complement.lean`), which is stated at `n * k`; `Int.ediv_mul_cancel` is
+what converts between the two. Unconditional, like the identity it rests on.
+
+Its consumers are the six residue branches of
+`IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`, each of which reindexes one
+complement this way. -/
+theorem normEDS_mul_complEDS_div (k n : ℤ) (hn : k ∣ n) :
+    normEDS b c d k * complEDS b c d k (n / k) = normEDS b c d n := by
+  rw [normEDS_mul_complEDS, Int.ediv_mul_cancel hn]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -149,8 +149,8 @@ theorem reducedInvarNum_def : reducedInvarNum b c d m =
 /-- The reduced invariant denominator, the counterpart of `reducedInvarNum`.
 
 `IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul` is what identifies this with
-`invarDenom (normEDS b c d) 1 m` divided by `b * c`, under the nonzerodivisor hypotheses recorded
-in the module docstring. The paragraph below motivates the shape of the split.
+`invarDenom (normEDS b c d) 1 m` divided by `b * c`, unconditionally over any commutative ring.
+The paragraph below motivates the shape of the split.
 
 `invarDenom (normEDS b c d) 1 m` is `W (m + 1) * W m * W (m - 1)`, and the divisibility
 `W k ∣ W (n * k)` witnessed by Mathlib's `complEDS` lets `b = W 2` and `c = W 3` be taken out of
@@ -162,9 +162,10 @@ case has `6 ∣ m`, so the middle factor `W m` gives up `b * c` at once through
 is split between two factors, one giving up `b` through a `2`-complement and another giving up `c`
 through a `3`-complement.
 
-The factor `normEDS b c d 5 - d ^ 2` appearing in the residues `0`, `1` and `5` is the extra
-factor the `6`-complement carries relative to the `2`- and `3`-complements used in the other
-three. It is not claimed to be a unit: over an arbitrary commutative ring nothing here proves it
+The factor `normEDS b c d 5 - d ^ 2` appearing in the residues `0`, `1` and `5` is `normEDS b c d
+6` with `b * c` removed: `WeierstrassCurve.normEDS_six` reads `W 6 = (W 5 - d ^ 2) * b * c`, so a
+residue that takes `b * c` out through the single `6`-complement is left carrying the remaining
+factor. It is not claimed to be a unit: over an arbitrary commutative ring nothing here proves it
 invertible. -/
 def reducedInvarDenom : R :=
   let C := complEDS b c d
@@ -277,7 +278,14 @@ definition its meaning.
 `normEDS b c d k`; the divisibility that `Int.ediv_mul_cancel` needs comes from `m % 6 = r`
 itself. The residues `0`, `1` and `5` additionally rewrite `normEDS b c d 6` through
 `WeierstrassCurve.normEDS_six` (`Six.lean`), which is likewise an identity rather than a
-hypothesis. -/
+hypothesis.
+
+The **priority is load-bearing**, exactly as for the numerator counterpart. `invarDenom_def` is
+itself `@[simp]`, and at equal priority it wins on this term: with a plain `@[simp]` the left-hand
+side would expand to `W (m + 1) * W m * W (m - 1)` and this lemma would never fire. At `high` it
+fires first, and because `reducedInvarDenom_def` is deliberately not `@[simp]` the result stays
+folded at `reducedInvarDenom b c d m * (b * c)`. -/
+@[simp high]
 theorem invarDenom_normEDS_one_eq_reducedInvarDenom_mul :
     invarDenom (normEDS b c d) 1 m = reducedInvarDenom b c d m * (b * c) := by
   have e : ∀ k n : ℤ, k ∣ n →

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -73,8 +73,8 @@ statement hypothesis-free.
 The numerator needs none of this because its cancellation is an identity between polynomial
 expressions, proved by `ring` from the complement recurrences rather than through a division.
 
-The divisor form is `normEDS_mul_complEDS_div` below. Each residue reduces `W k * complEDS b c d k
-(n / k)` to
+The divisor form is `normEDS_mul_complEDS_div`, which this development adds to `Complement.lean`
+beside the identity it reindexes. Each residue reduces `W k * complEDS b c d k (n / k)` to
 `W n` by `normEDS_mul_complEDS` — which is stated at `W (n * k)` — followed
 by `Int.ediv_mul_cancel` on the divisibility that `m % 6 = r` supplies. The factor
 `W 5 - d ^ 2` carried by the residues `0`, `1` and `5` is `W 6` with `b * c` removed, which is
@@ -116,9 +116,10 @@ complement identity they rest on lives in `Complement.lean` as `normEDS_mul_comp
 The source's `invarDenom_eq_redInvarDenom_mul`, which identifies the denominator formula as the
 cancelled quotient, is ported here as
 `IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`. Both links the source's proof
-uses are available in this repository: `normEDS_mul_complEDS_div` is replaced by the unconditional
-`normEDS_mul_complEDS` (`Complement.lean`) together with `Int.ediv_mul_cancel`, and
-`normEDS_six_eq_mul` is `WeierstrassCurve.normEDS_six` (`Six.lean`).
+uses are available in this repository: `normEDS_mul_complEDS_div` is ported by this development
+into `Complement.lean`, derived there from the unconditional `normEDS_mul_complEDS` together with
+`Int.ediv_mul_cancel` rather than proved afresh, and `normEDS_six_eq_mul` is
+`WeierstrassCurve.normEDS_six` (`Six.lean`).
 
 That file's header reads `Authors: David Kurniadi Angdinata`; following this
 repository's convention for adapted material the upstream authorship is credited here rather than
@@ -195,8 +196,19 @@ def reducedInvarDenom : R :=
   else if m % 6 = 4 then C 3 ((m - 1) / 3) * C 2 (m / 2) * W (m + 1)
   else C 3 (m / 3) * C 2 ((m - 1) / 2) * W (m + 1)
 
-/-- The defining formula for `reducedInvarDenom`, not `@[simp]` for the same reason
-`reducedInvarNum_def` is not. -/
+/-- The defining formula for `reducedInvarDenom`. The definition body is not exposed, so this
+equation lemma is how a consumer computes with it.
+
+Not `@[simp]`, but **not** for `reducedInvarNum_def`'s reason. There the point is that `simp`
+should never unfold the term at all. Here it should: the whole content of `reducedInvarDenom` is
+the residue split, so the six `reducedInvarDenom_of_emod_eq_*` lemmas below *are* `@[simp]` and do
+unfold it — each into a single product, once the residue is known.
+
+What is wrong is unfolding it into the six-way `if` chain, which is what tagging this lemma would
+do: every goal mentioning `reducedInvarDenom` would acquire five undischarged conditions, and the
+branch lemmas would then have nothing left to fire on. So the simp normal form of
+`reducedInvarDenom b c d m` is "the selected branch, when `m % 6` is known, and the folded term
+otherwise" — which is exactly this lemma off simp and those six on. -/
 theorem reducedInvarDenom_def : reducedInvarDenom b c d m =
     if m % 6 = 0 then
       (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (m / 6) *

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -73,7 +73,8 @@ statement hypothesis-free.
 The numerator needs none of this because its cancellation is an identity between polynomial
 expressions, proved by `ring` from the complement recurrences rather than through a division.
 
-No divisor-form lemma is involved. Each residue reduces `W k * complEDS b c d k (n / k)` to
+The divisor form is `normEDS_mul_complEDS_div` below. Each residue reduces `W k * complEDS b c d k
+(n / k)` to
 `W n` by `normEDS_mul_complEDS` — which is stated at `W (n * k)` — followed
 by `Int.ediv_mul_cancel` on the divisibility that `m % 6 = r` supplies. The factor
 `W 5 - d ^ 2` carried by the residues `0`, `1` and `5` is `W 6` with `b * c` removed, which is
@@ -95,8 +96,13 @@ Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in 
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `invarNum_normEDS`, `redInvarNum`, `compl₂EDS_eq_redInvarNum_sub`,
 `invarNum_eq_redInvarNum_mul` and `map_redInvarNum` for the numerator, and `redInvarDenom`,
-`redInvarDenom_zero`, `redInvarDenom_one`, `redInvarDenom_two` and `map_redInvarDenom` for the
-denominator — the source's own names, which this file respells with `reduced` written out.
+`redInvarDenom_zero`, `redInvarDenom_one`, `redInvarDenom_two`, `map_redInvarDenom` and
+`invarDenom_eq_redInvarDenom_mul` for the denominator — the source's own names, which this file
+respells with `reduced` written out.
+
+Three declarations here are **not** from that file: the six `reducedInvarDenom_of_emod_eq_*`
+branch lemmas and `normEDS_mul_complEDS_div` have no counterpart in the source, which eliminates
+the split inline and reaches the divisor form through a chain this repository does not carry.
 
 The source's `invarDenom_eq_redInvarDenom_mul`, which identifies the denominator formula as the
 cancelled quotient, is ported here as
@@ -111,8 +117,10 @@ in the copyright header. J. Xu is acknowledged for the surrounding LutzNagell de
 authors `Universal.lean` and co-authors `DivisionPolynomialOmega.lean` at the same revision — as
 context for this port, not as an author of the declarations above.
 
-The same declarations sit in **Mathlib PR #13057**, the upstreaming of that AINTLIB file, so they
-are portable under this project's rule and deduplicate if and when it lands.
+The **numerator** declarations sit in **Mathlib PR #13057**, the upstreaming of that AINTLIB
+file, so they are portable under this project's rule and deduplicate if and when it lands. That
+PR does not carry the denominator side, so nothing added here for the denominator is covered by
+it — the deduplication claim scopes to the numerator alone.
 They are spelt with Mathlib's later names (`compl₂EDS → complEDS₂`, `IsEllSequence →
 IsEllipticSequence`), which #13057 predates, and follow `ComplAux.lean` in keeping the
 `normEDS`-family declarations in the **root** namespace where Mathlib keeps `normEDS`, `complEDS`
@@ -273,6 +281,18 @@ theorem complEDS₂_eq_reducedInvarNum_sub :
       reducedInvarNum b c d m - normEDS b c d m ^ 3 * b - 2 * complEDS₂Aux b c d m := by
   rw [reducedInvarNum_def]; ring
 
+/-- **The complement at a divisor.** When `k ∣ n`, the `k`-complement at index `n / k` multiplies
+`normEDS b c d k` back up to `normEDS b c d n`. This is the divisor-indexed form of
+`normEDS_mul_complEDS` (`Complement.lean`), which is stated at `n * k`; `Int.ediv_mul_cancel` is
+what converts between the two. Unconditional, like the identity it rests on.
+
+Its consumers are the six residue branches of
+`IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`, each of which reindexes one
+complement this way. -/
+theorem normEDS_mul_complEDS_div (k n : ℤ) (hn : k ∣ n) :
+    normEDS b c d k * complEDS b c d k (n / k) = normEDS b c d n := by
+  rw [normEDS_mul_complEDS, Int.ediv_mul_cancel hn]
+
 namespace IsEllipticNet
 
 /-- **The cancellation `reducedInvarDenom` is named for**: the invariant denominator of a
@@ -295,25 +315,28 @@ folded at `reducedInvarDenom b c d m * (b * c)`. -/
 @[simp high]
 theorem invarDenom_normEDS_one_eq_reducedInvarDenom_mul :
     invarDenom (normEDS b c d) 1 m = reducedInvarDenom b c d m * (b * c) := by
-  have e : ∀ k n : ℤ, k ∣ n →
-      normEDS b c d k * complEDS b c d k (n / k) = normEDS b c d n := fun k n hn ↦ by
-    rw [normEDS_mul_complEDS, Int.ediv_mul_cancel hn]
   have hcase : m % 6 = 0 ∨ m % 6 = 1 ∨ m % 6 = 2 ∨ m % 6 = 3 ∨ m % 6 = 4 ∨ m % 6 = 5 := by omega
   rw [invarDenom_def]
   rcases hcase with h | h | h | h | h | h
-  · rw [reducedInvarDenom_of_emod_eq_zero b c d m h, ← e 6 m (by omega),
+  · rw [reducedInvarDenom_of_emod_eq_zero b c d m h,
+    ← normEDS_mul_complEDS_div b c d 6 m (by omega),
       WeierstrassCurve.normEDS_six]
     ring
-  · rw [reducedInvarDenom_of_emod_eq_one b c d m h, ← e 6 (m - 1) (by omega),
+  · rw [reducedInvarDenom_of_emod_eq_one b c d m h,
+    ← normEDS_mul_complEDS_div b c d 6 (m - 1) (by omega),
       WeierstrassCurve.normEDS_six]
     ring
-  · rw [reducedInvarDenom_of_emod_eq_two b c d m h, ← e 3 (m + 1) (by omega),
-      ← e 2 m (by omega), normEDS_two, normEDS_three]; ring
-  · rw [reducedInvarDenom_of_emod_eq_three b c d m h, ← e 3 m (by omega),
-      ← e 2 (m - 1) (by omega), normEDS_two, normEDS_three]; ring
-  · rw [reducedInvarDenom_of_emod_eq_four b c d m h, ← e 3 (m - 1) (by omega),
-      ← e 2 m (by omega), normEDS_two, normEDS_three]; ring
-  · rw [reducedInvarDenom_of_emod_eq_five b c d m h, ← e 6 (m + 1) (by omega),
+  · rw [reducedInvarDenom_of_emod_eq_two b c d m h,
+    ← normEDS_mul_complEDS_div b c d 3 (m + 1) (by omega),
+      ← normEDS_mul_complEDS_div b c d 2 m (by omega), normEDS_two, normEDS_three]; ring
+  · rw [reducedInvarDenom_of_emod_eq_three b c d m h,
+    ← normEDS_mul_complEDS_div b c d 3 m (by omega),
+      ← normEDS_mul_complEDS_div b c d 2 (m - 1) (by omega), normEDS_two, normEDS_three]; ring
+  · rw [reducedInvarDenom_of_emod_eq_four b c d m h,
+    ← normEDS_mul_complEDS_div b c d 3 (m - 1) (by omega),
+      ← normEDS_mul_complEDS_div b c d 2 m (by omega), normEDS_two, normEDS_three]; ring
+  · rw [reducedInvarDenom_of_emod_eq_five b c d m h,
+    ← normEDS_mul_complEDS_div b c d 6 (m + 1) (by omega),
       WeierstrassCurve.normEDS_six]
     ring
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -92,13 +92,22 @@ source discharges the ellipticity variables over exactly this block.
 
 ## Provenance
 
-Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
-declarations `invarNum_normEDS`, `redInvarNum`, `compl₂EDS_eq_redInvarNum_sub`,
+Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in the AINTLIB
+**NagellLutz** project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), at the revision
+`TauCetiRoadmap` pins for that project, `dev/modular-curves @ 9fec8eba7652`. Declarations
+`invarNum_normEDS`, `redInvarNum`, `compl₂EDS_eq_redInvarNum_sub`,
 `invarNum_eq_redInvarNum_mul` and `map_redInvarNum` for the numerator, and `redInvarDenom`,
 `redInvarDenom_zero`, `redInvarDenom_one`, `redInvarDenom_two`, `map_redInvarDenom` and
 `invarDenom_eq_redInvarDenom_mul` for the denominator — the source's own names, which this file
 respells with `reduced` written out.
+
+Those names also occur in AINTLIB's **HasseWeil** project, pinned separately at
+`dev/hasse-weil @ 513e83879e2f`, so the credit above picks between two candidates rather than
+recording the only match a search returns. Two details fix it on NagellLutz. That project spells
+the cancellation `invarDenom_eq_redInvarDenom_mul`, where HasseWeil spells it
+`invarDenom_normEDS_eq_redInvarDenom_mul`; and its `map_redInvarDenom` is oriented
+`f (redInvarDenom …) = redInvarDenom (f b) …`, where HasseWeil states the converse. This file
+carries the NagellLutz spelling and the NagellLutz orientation in both places.
 
 Six declarations here are **not** from that file: the `reducedInvarDenom_of_emod_eq_*` branch
 lemmas have no counterpart in the source, which eliminates the split inline. The divisor-form

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -5,7 +5,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.ComplAux
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Complement
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Invariant.Basic
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Six
 
 /-!
 # The reduced invariant of a normalised EDS
@@ -26,51 +28,84 @@ by which the elliptic-net identities reach the division polynomials in the Lutz�
 ## Main definitions
 
 * `reducedInvarNum`: the invariant numerator of a normalised EDS with one factor of `b` cancelled.
+* `reducedInvarDenom`: the invariant denominator with the factor `b * c` cancelled — a six-way
+  split on `m % 6`, since which of `W (m+1)`, `W m`, `W (m-1)` gives up `b = W 2` and `c = W 3`
+  depends on the residue.
 
 ## Main results
 
 * `IsEllipticNet.invarNum_normEDS_one_eq_reducedInvarNum_mul`: `invarNum (normEDS b c d) 1 m` is
   `reducedInvarNum b c d m * b` — the cancellation the reduced numerator is named for.
 * `complEDS₂_eq_reducedInvarNum_sub`: the second complement read off the reduced numerator.
-* `map_reducedInvarNum`: it is natural in the coefficient ring, so a specialisation or base change
-  may be pushed through it rather than around the unexposed body.
+* `map_reducedInvarNum` and `map_reducedInvarDenom`: both are natural in the coefficient ring, so
+  a specialisation or base change may be pushed through them rather than around the unexposed
+  bodies.
+* `IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`: `invarDenom (normEDS b c d) 1 m`
+  is `reducedInvarDenom b c d m * (b * c)` — the cancellation the reduced denominator is named
+  for, with no hypotheses.
+* `reducedInvarDenom_of_emod_eq_zero` and its five siblings: the per-residue elimination
+  principle, one lemma per branch, so a consumer holding `m % 6 = r` reaches its branch without
+  discharging the preceding `if` conditions.
+* `reducedInvarDenom_zero`, `reducedInvarDenom_one`, `reducedInvarDenom_two`: its values at the
+  small indices; the last is what fixes the normalisation.
 
-## What is deliberately not here
+## Both cancellations, and why neither needs a hypothesis
 
-The **denominator** side of the reduction is absent, by measurement rather than oversight. The
-source's `redInvarDenom` — a piecewise expression for `W (m + 1) * W m * W (m - 1)` with the
-constant factor `W 3 * W 2` cancelled — is worth having only together with the results identifying
-it as that quotient, `redInvar_normEDS` and `invarDenom_eq_redInvarDenom_mul` (the source's names).
-Both route through the fact that `normEDS` is an elliptic sequence, along
+Each reduced quantity comes with the cancellation it is named for:
+`invarNum_normEDS_one_eq_reducedInvarNum_mul` for the numerator, and
+`invarDenom_normEDS_one_eq_reducedInvarDenom_mul` for the denominator. Both hold over an arbitrary
+commutative ring.
 
-`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS ← IsEllipticSequence.normEDS`
+The denominator side reads `invarDenom (normEDS b c d) 1 m = W (m + 1) * W m * W (m - 1)`, and
+which of the three factors gives up `b = W 2` and `c = W 3` depends on `m` modulo `6` — hence the
+six-way split. Each branch reindexes a complement by `normEDS_mul_complEDS` (`Complement.lean`),
+`W k * complEDS b c d k n = W (n * k)`, taking `n = m / k` and turning `(m / k) * k` back into `m`
+with `Int.ediv_mul_cancel` on the divisibility that `m % 6 = r` supplies. The residues `0`, `1`
+and `5` go through the `6`-complement and rewrite `W 6` as `(W 5 - d ^ 2) * b * c`
+(`WeierstrassCurve.normEDS_six`, `Six.lean`); the residues `2`, `3` and `4` split the work between
+a `2`-complement and a `3`-complement.
 
-for the first, and `invarDenom_eq_redInvarDenom_mul ← normEDS_mul_complEDS_div ←
-normEDS_mul_complEDS ← normEDS_mul_complEDS_of_mem ← IsEllipticSequence.normEDS` for the second.
-That fact is `isEllipticSequence_normEDS` in `NormEDS.lean`, proved here through the descent of
-`Descent.lean`; the pinned Mathlib still records it as an open TODO
-(`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean`: "prove that `normEDS` satisfies
-`IsEllipticDvdSequence`"). Both chains above are written in the source's names, and their lower
-links have landed. For the first, `net_normEDS` is `isEllipticNet_normEDS` (`NormEDS.lean`),
-`invar_normEDS` is `invarNum_mul_invarDenom` (`Invariant/Basic.lean`) and `invar₂_normEDS` is
-`invarNum_normEDS_one_mul_eq_invarDenom_mul` (`Invariant/NormEDS.lean`), so what remains is
-`redInvar_normEDS` alone. For the second, `Complement.lean` proves `normEDS_mul_complEDS`
-unconditionally — the source's `normEDS_mul_complEDS_of_mem` having become a private step of it —
-and states the divisibility it witnesses as `normEDS_dvd_normEDS_mul` and `isDvdSequence_normEDS`,
-which is what the source reaches through `normEDS_mul_complEDS_div`; so what remains there is
-`invarDenom_eq_redInvarDenom_mul` alone.
-Carrying the bare definition across before them would add a formula that no consumer can state
-anything about, so it waits for the layer that gives it meaning. Everything below is independent
-of that fact: nothing carries an ellipticity hypothesis, and the source discharges the
-ellipticity variables over exactly this block.
+Note that `b, c ≠ 0` over a domain would **not** by itself make `normEDS b c d 6` a
+nonzerodivisor — that needs `normEDS b c d 5 - d ^ 2 ≠ 0` as well — which is why the
+unconditional `normEDS_mul_complEDS` rather than a nonvanishing side condition is what makes this
+statement hypothesis-free.
+
+The numerator needs none of this because its cancellation is an identity between polynomial
+expressions, proved by `ring` from the complement recurrences rather than through a division.
+
+No divisor-form lemma is involved. Each residue reduces `W k * complEDS b c d k (n / k)` to
+`W n` by `normEDS_mul_complEDS` — which is stated at `W (n * k)` — followed
+by `Int.ediv_mul_cancel` on the divisibility that `m % 6 = r` supplies. The factor
+`W 5 - d ^ 2` carried by the residues `0`, `1` and `5` is `W 6` with `b * c` removed, which is
+`WeierstrassCurve.normEDS_six` (`Six.lean`).
+
+For the other half of the reduced-invariant theory — `redInvar_normEDS ← invar₂_normEDS ←
+invar_normEDS ← net_normEDS`, written in the source's names — every lower link has now landed:
+`net_normEDS` is `isEllipticNet_normEDS` (`NormEDS.lean`), `invar_normEDS` is
+`invarNum_mul_invarDenom` (`Invariant/Basic.lean`), and `invar₂_normEDS` is
+`invarNum_normEDS_one_mul_eq_invarDenom_mul` (`Invariant/NormEDS.lean`), so `redInvar_normEDS`
+alone remains there.
+
+Everything below is independent of all of that: nothing carries an ellipticity hypothesis, and the
+source discharges the ellipticity variables over exactly this block.
 
 ## Provenance
 
 Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
-declarations `invarNum_normEDS`, `redInvarNum`, `compl₂EDS_eq_redInvarNum_sub` and
-`invarNum_eq_redInvarNum_mul` — the source's own names, which this file respells with `reduced`
-written out. That file's header reads `Authors: David Kurniadi Angdinata`; following this
+declarations `invarNum_normEDS`, `redInvarNum`, `compl₂EDS_eq_redInvarNum_sub`,
+`invarNum_eq_redInvarNum_mul` and `map_redInvarNum` for the numerator, and `redInvarDenom`,
+`redInvarDenom_zero`, `redInvarDenom_one`, `redInvarDenom_two` and `map_redInvarDenom` for the
+denominator — the source's own names, which this file respells with `reduced` written out.
+
+The source's `invarDenom_eq_redInvarDenom_mul`, which identifies the denominator formula as the
+cancelled quotient, is ported here as
+`IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`. Both links the source's proof
+uses are available in this repository: `normEDS_mul_complEDS_div` is replaced by the unconditional
+`normEDS_mul_complEDS` (`Complement.lean`) together with `Int.ediv_mul_cancel`, and
+`normEDS_six_eq_mul` is `WeierstrassCurve.normEDS_six` (`Six.lean`).
+
+That file's header reads `Authors: David Kurniadi Angdinata`; following this
 repository's convention for adapted material the upstream authorship is credited here rather than
 in the copyright header. J. Xu is acknowledged for the surrounding LutzNagell development — he
 authors `Universal.lean` and co-authors `DivisionPolynomialOmega.lean` at the same revision — as
@@ -111,6 +146,117 @@ defeat the point of naming the term. -/
 theorem reducedInvarNum_def : reducedInvarNum b c d m =
     complEDS₂ b c d m + normEDS b c d m ^ 3 * b + 2 * complEDS₂Aux b c d m := (rfl)
 
+/-- The reduced invariant denominator, the counterpart of `reducedInvarNum`.
+
+`IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul` is what identifies this with
+`invarDenom (normEDS b c d) 1 m` divided by `b * c`, under the nonzerodivisor hypotheses recorded
+in the module docstring. The paragraph below motivates the shape of the split.
+
+`invarDenom (normEDS b c d) 1 m` is `W (m + 1) * W m * W (m - 1)`, and the divisibility
+`W k ∣ W (n * k)` witnessed by Mathlib's `complEDS` lets `b = W 2` and `c = W 3` be taken out of
+that product. Which factors give them up — and whether one factor supplies both or two factors
+supply one each — depends on `m` modulo `6`, so the definition is a six-way split on `m % 6` rather
+than a single formula. At residues `0`, `1` and `5` a single factor supplies both: the residue-`0`
+case has `6 ∣ m`, so the middle factor `W m` gives up `b * c` at once through
+`complEDS b c d 6 (m / 6)`, and the outer two survive whole. At residues `2`, `3` and `4` the work
+is split between two factors, one giving up `b` through a `2`-complement and another giving up `c`
+through a `3`-complement.
+
+The factor `normEDS b c d 5 - d ^ 2` appearing in the residues `0`, `1` and `5` is the extra
+factor the `6`-complement carries relative to the `2`- and `3`-complements used in the other
+three. It is not claimed to be a unit: over an arbitrary commutative ring nothing here proves it
+invertible. -/
+def reducedInvarDenom : R :=
+  let C := complEDS b c d
+  let W := normEDS b c d
+  let r₆ := W 5 - d ^ 2
+  if m % 6 = 0 then r₆ * C 6 (m / 6) * W (m + 1) * W (m - 1)
+  else if m % 6 = 1 then r₆ * C 6 ((m - 1) / 6) * W (m + 1) * W m
+  else if m % 6 = 5 then r₆ * C 6 ((m + 1) / 6) * W m * W (m - 1)
+  else if m % 6 = 2 then C 3 ((m + 1) / 3) * C 2 (m / 2) * W (m - 1)
+  else if m % 6 = 4 then C 3 ((m - 1) / 3) * C 2 (m / 2) * W (m + 1)
+  else C 3 (m / 3) * C 2 ((m - 1) / 2) * W (m + 1)
+
+/-- The defining formula for `reducedInvarDenom`, not `@[simp]` for the same reason
+`reducedInvarNum_def` is not. -/
+theorem reducedInvarDenom_def : reducedInvarDenom b c d m =
+    if m % 6 = 0 then
+      (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (m / 6) *
+        normEDS b c d (m + 1) * normEDS b c d (m - 1)
+    else if m % 6 = 1 then
+      (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 ((m - 1) / 6) *
+        normEDS b c d (m + 1) * normEDS b c d m
+    else if m % 6 = 5 then
+      (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 ((m + 1) / 6) *
+        normEDS b c d m * normEDS b c d (m - 1)
+    else if m % 6 = 2 then
+      complEDS b c d 3 ((m + 1) / 3) * complEDS b c d 2 (m / 2) * normEDS b c d (m - 1)
+    else if m % 6 = 4 then
+      complEDS b c d 3 ((m - 1) / 3) * complEDS b c d 2 (m / 2) * normEDS b c d (m + 1)
+    else
+      complEDS b c d 3 (m / 3) * complEDS b c d 2 ((m - 1) / 2) * normEDS b c d (m + 1) := (rfl)
+
+/-- The residue-`0` branch, selected. The six `reducedInvarDenom_of_emod_eq_*` lemmas are the
+elimination principle for `reducedInvarDenom`: the whole content of the definition is the split, so
+a consumer that knows `m % 6` should reach its branch directly rather than rewriting by
+`reducedInvarDenom_def` and discharging the preceding `if` conditions by hand. -/
+theorem reducedInvarDenom_of_emod_eq_zero (h : m % 6 = 0) :
+    reducedInvarDenom b c d m = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (m / 6) *
+      normEDS b c d (m + 1) * normEDS b c d (m - 1) := by
+  simp [reducedInvarDenom_def, h]
+
+/-- The residue-`1` branch, selected. -/
+theorem reducedInvarDenom_of_emod_eq_one (h : m % 6 = 1) :
+    reducedInvarDenom b c d m = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 ((m - 1) / 6) *
+      normEDS b c d (m + 1) * normEDS b c d m := by
+  simp [reducedInvarDenom_def, h]
+
+/-- The residue-`5` branch, selected. -/
+theorem reducedInvarDenom_of_emod_eq_five (h : m % 6 = 5) :
+    reducedInvarDenom b c d m = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 ((m + 1) / 6) *
+      normEDS b c d m * normEDS b c d (m - 1) := by
+  simp [reducedInvarDenom_def, h]
+
+/-- The residue-`2` branch, selected. -/
+theorem reducedInvarDenom_of_emod_eq_two (h : m % 6 = 2) :
+    reducedInvarDenom b c d m =
+      complEDS b c d 3 ((m + 1) / 3) * complEDS b c d 2 (m / 2) * normEDS b c d (m - 1) := by
+  simp [reducedInvarDenom_def, h]
+
+/-- The residue-`4` branch, selected. -/
+theorem reducedInvarDenom_of_emod_eq_four (h : m % 6 = 4) :
+    reducedInvarDenom b c d m =
+      complEDS b c d 3 ((m - 1) / 3) * complEDS b c d 2 (m / 2) * normEDS b c d (m + 1) := by
+  simp [reducedInvarDenom_def, h]
+
+/-- The residue-`3` branch, selected — the final `else`, so no positive condition remains. -/
+theorem reducedInvarDenom_of_emod_eq_three (h : m % 6 = 3) :
+    reducedInvarDenom b c d m =
+      complEDS b c d 3 (m / 3) * complEDS b c d 2 ((m - 1) / 2) * normEDS b c d (m + 1) := by
+  simp [reducedInvarDenom_def, h]
+
+/-- The formula vanishes at `0`. The factor responsible is the *complement*, not a `normEDS`: at
+`m = 0` the residue-`0` branch is `(W 5 - d ^ 2) * complEDS b c d 6 0 * normEDS b c d 1 *
+normEDS b c d (-1)`, whose `normEDS` factors are `1` and `-1`, and `complEDS_zero` kills it. -/
+@[simp]
+theorem reducedInvarDenom_zero : reducedInvarDenom b c d 0 = 0 := by
+  simp [reducedInvarDenom_def]
+
+/-- It vanishes at `1` as well, by the same mechanism: at `m = 1` the residue-`1` branch is
+`(W 5 - d ^ 2) * complEDS b c d 6 ((1 - 1) / 6) * normEDS b c d 2 * normEDS b c d 1`, and
+`(1 - 1) / 6 = 0`, so `complEDS_zero` applies again. No `normEDS b c d 0` occurs in either
+branch. -/
+@[simp]
+theorem reducedInvarDenom_one : reducedInvarDenom b c d 1 = 0 := by
+  simp [reducedInvarDenom_def]
+
+/-- The formula takes the value `1` at `2`, the residue-`2` branch collapsing to
+`complEDS b c d 3 1 * complEDS b c d 2 1 * normEDS b c d 1`. This is the value that fixes the
+formula's normalisation. -/
+@[simp]
+theorem reducedInvarDenom_two : reducedInvarDenom b c d 2 = 1 := by
+  simp [reducedInvarDenom_def]
+
 /-- **The second complement read off the reduced numerator.** This is the direction the Lutz–Nagell
 development uses: it expresses `complEDS₂` through the invariant of the elliptic net, rather than
 through its own defining difference. -/
@@ -120,6 +266,41 @@ theorem complEDS₂_eq_reducedInvarNum_sub :
   rw [reducedInvarNum_def]; ring
 
 namespace IsEllipticNet
+
+/-- **The cancellation `reducedInvarDenom` is named for**: the invariant denominator of a
+normalised EDS at `s = 1` is `reducedInvarDenom` times `b * c`. This is what identifies the
+six-way formula as the denominator with its constant factor removed, and so what gives the
+definition its meaning.
+
+**Unconditional over any commutative ring.** Each residue reindexes a complement through
+`normEDS_mul_complEDS` (`Complement.lean`), which holds with no nonzerodivisor hypothesis on
+`normEDS b c d k`; the divisibility that `Int.ediv_mul_cancel` needs comes from `m % 6 = r`
+itself. The residues `0`, `1` and `5` additionally rewrite `normEDS b c d 6` through
+`WeierstrassCurve.normEDS_six` (`Six.lean`), which is likewise an identity rather than a
+hypothesis. -/
+theorem invarDenom_normEDS_one_eq_reducedInvarDenom_mul :
+    invarDenom (normEDS b c d) 1 m = reducedInvarDenom b c d m * (b * c) := by
+  have e : ∀ k n : ℤ, k ∣ n →
+      normEDS b c d k * complEDS b c d k (n / k) = normEDS b c d n := fun k n hn ↦ by
+    rw [normEDS_mul_complEDS, Int.ediv_mul_cancel hn]
+  have hcase : m % 6 = 0 ∨ m % 6 = 1 ∨ m % 6 = 2 ∨ m % 6 = 3 ∨ m % 6 = 4 ∨ m % 6 = 5 := by omega
+  rw [invarDenom_def]
+  rcases hcase with h | h | h | h | h | h
+  · rw [reducedInvarDenom_of_emod_eq_zero b c d m h, ← e 6 m (by omega),
+      WeierstrassCurve.normEDS_six]
+    ring
+  · rw [reducedInvarDenom_of_emod_eq_one b c d m h, ← e 6 (m - 1) (by omega),
+      WeierstrassCurve.normEDS_six]
+    ring
+  · rw [reducedInvarDenom_of_emod_eq_two b c d m h, ← e 3 (m + 1) (by omega),
+      ← e 2 m (by omega), normEDS_two, normEDS_three]; ring
+  · rw [reducedInvarDenom_of_emod_eq_three b c d m h, ← e 3 m (by omega),
+      ← e 2 (m - 1) (by omega), normEDS_two, normEDS_three]; ring
+  · rw [reducedInvarDenom_of_emod_eq_four b c d m h, ← e 3 (m - 1) (by omega),
+      ← e 2 m (by omega), normEDS_two, normEDS_three]; ring
+  · rw [reducedInvarDenom_of_emod_eq_five b c d m h, ← e 6 (m + 1) (by omega),
+      WeierstrassCurve.normEDS_six]
+    ring
 
 /-- **The cancellation `reducedInvarNum` is named for**: the invariant numerator of a normalised EDS
 at `s = 1` is `reducedInvarNum` times `b`. The factor of `b` is constant in `m`, which is what makes
@@ -147,3 +328,11 @@ variable {F : Type*} [FunLike F R S] [RingHomClass F R S] (f : F)
 theorem map_reducedInvarNum :
     f (reducedInvarNum b c d m) = reducedInvarNum (f b) (f c) (f d) m := by
   simp [reducedInvarNum_def, map_ofNat]
+
+/-- The reduced denominator is natural in the coefficient ring, so a specialisation or base change
+may be pushed through it rather than around the unexposed body. The six-way split on `m % 6` does
+not depend on the ring, so a ring map passes it unchanged. -/
+@[simp]
+theorem map_reducedInvarDenom :
+    f (reducedInvarDenom b c d m) = reducedInvarDenom (f b) (f c) (f d) m := by
+  simp [reducedInvarDenom_def, apply_ite f]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -100,9 +100,9 @@ declarations `invarNum_normEDS`, `redInvarNum`, `compl₂EDS_eq_redInvarNum_sub`
 `invarDenom_eq_redInvarDenom_mul` for the denominator — the source's own names, which this file
 respells with `reduced` written out.
 
-Three declarations here are **not** from that file: the six `reducedInvarDenom_of_emod_eq_*`
-branch lemmas and `normEDS_mul_complEDS_div` have no counterpart in the source, which eliminates
-the split inline and reaches the divisor form through a chain this repository does not carry.
+Six declarations here are **not** from that file: the `reducedInvarDenom_of_emod_eq_*` branch
+lemmas have no counterpart in the source, which eliminates the split inline. The divisor-form
+complement identity they rest on lives in `Complement.lean` as `normEDS_mul_complEDS_div`.
 
 The source's `invarDenom_eq_redInvarDenom_mul`, which identifies the denominator formula as the
 cancelled quotient, is ported here as
@@ -281,18 +281,6 @@ theorem complEDS₂_eq_reducedInvarNum_sub :
       reducedInvarNum b c d m - normEDS b c d m ^ 3 * b - 2 * complEDS₂Aux b c d m := by
   rw [reducedInvarNum_def]; ring
 
-/-- **The complement at a divisor.** When `k ∣ n`, the `k`-complement at index `n / k` multiplies
-`normEDS b c d k` back up to `normEDS b c d n`. This is the divisor-indexed form of
-`normEDS_mul_complEDS` (`Complement.lean`), which is stated at `n * k`; `Int.ediv_mul_cancel` is
-what converts between the two. Unconditional, like the identity it rests on.
-
-Its consumers are the six residue branches of
-`IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`, each of which reindexes one
-complement this way. -/
-theorem normEDS_mul_complEDS_div (k n : ℤ) (hn : k ∣ n) :
-    normEDS b c d k * complEDS b c d k (n / k) = normEDS b c d n := by
-  rw [normEDS_mul_complEDS, Int.ediv_mul_cancel hn]
-
 namespace IsEllipticNet
 
 /-- **The cancellation `reducedInvarDenom` is named for**: the invariant denominator of a
@@ -319,24 +307,24 @@ theorem invarDenom_normEDS_one_eq_reducedInvarDenom_mul :
   rw [invarDenom_def]
   rcases hcase with h | h | h | h | h | h
   · rw [reducedInvarDenom_of_emod_eq_zero b c d m h,
-    ← normEDS_mul_complEDS_div b c d 6 m (by omega),
+    ← normEDS_mul_complEDS_div 6 m (by omega),
       WeierstrassCurve.normEDS_six]
     ring
   · rw [reducedInvarDenom_of_emod_eq_one b c d m h,
-    ← normEDS_mul_complEDS_div b c d 6 (m - 1) (by omega),
+    ← normEDS_mul_complEDS_div 6 (m - 1) (by omega),
       WeierstrassCurve.normEDS_six]
     ring
   · rw [reducedInvarDenom_of_emod_eq_two b c d m h,
-    ← normEDS_mul_complEDS_div b c d 3 (m + 1) (by omega),
-      ← normEDS_mul_complEDS_div b c d 2 m (by omega), normEDS_two, normEDS_three]; ring
+    ← normEDS_mul_complEDS_div 3 (m + 1) (by omega),
+      ← normEDS_mul_complEDS_div 2 m (by omega), normEDS_two, normEDS_three]; ring
   · rw [reducedInvarDenom_of_emod_eq_three b c d m h,
-    ← normEDS_mul_complEDS_div b c d 3 m (by omega),
-      ← normEDS_mul_complEDS_div b c d 2 (m - 1) (by omega), normEDS_two, normEDS_three]; ring
+    ← normEDS_mul_complEDS_div 3 m (by omega),
+      ← normEDS_mul_complEDS_div 2 (m - 1) (by omega), normEDS_two, normEDS_three]; ring
   · rw [reducedInvarDenom_of_emod_eq_four b c d m h,
-    ← normEDS_mul_complEDS_div b c d 3 (m - 1) (by omega),
-      ← normEDS_mul_complEDS_div b c d 2 m (by omega), normEDS_two, normEDS_three]; ring
+    ← normEDS_mul_complEDS_div 3 (m - 1) (by omega),
+      ← normEDS_mul_complEDS_div 2 m (by omega), normEDS_two, normEDS_three]; ring
   · rw [reducedInvarDenom_of_emod_eq_five b c d m h,
-    ← normEDS_mul_complEDS_div b c d 6 (m + 1) (by omega),
+    ← normEDS_mul_complEDS_div 6 (m + 1) (by omega),
       WeierstrassCurve.normEDS_six]
     ring
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -201,36 +201,42 @@ theorem reducedInvarDenom_def : reducedInvarDenom b c d m =
 elimination principle for `reducedInvarDenom`: the whole content of the definition is the split, so
 a consumer that knows `m % 6` should reach its branch directly rather than rewriting by
 `reducedInvarDenom_def` and discharging the preceding `if` conditions by hand. -/
+@[simp]
 theorem reducedInvarDenom_of_emod_eq_zero (h : m % 6 = 0) :
     reducedInvarDenom b c d m = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (m / 6) *
       normEDS b c d (m + 1) * normEDS b c d (m - 1) := by
   simp [reducedInvarDenom_def, h]
 
 /-- The residue-`1` branch, selected. -/
+@[simp]
 theorem reducedInvarDenom_of_emod_eq_one (h : m % 6 = 1) :
     reducedInvarDenom b c d m = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 ((m - 1) / 6) *
       normEDS b c d (m + 1) * normEDS b c d m := by
   simp [reducedInvarDenom_def, h]
 
 /-- The residue-`5` branch, selected. -/
+@[simp]
 theorem reducedInvarDenom_of_emod_eq_five (h : m % 6 = 5) :
     reducedInvarDenom b c d m = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 ((m + 1) / 6) *
       normEDS b c d m * normEDS b c d (m - 1) := by
   simp [reducedInvarDenom_def, h]
 
 /-- The residue-`2` branch, selected. -/
+@[simp]
 theorem reducedInvarDenom_of_emod_eq_two (h : m % 6 = 2) :
     reducedInvarDenom b c d m =
       complEDS b c d 3 ((m + 1) / 3) * complEDS b c d 2 (m / 2) * normEDS b c d (m - 1) := by
   simp [reducedInvarDenom_def, h]
 
 /-- The residue-`4` branch, selected. -/
+@[simp]
 theorem reducedInvarDenom_of_emod_eq_four (h : m % 6 = 4) :
     reducedInvarDenom b c d m =
       complEDS b c d 3 ((m - 1) / 3) * complEDS b c d 2 (m / 2) * normEDS b c d (m + 1) := by
   simp [reducedInvarDenom_def, h]
 
 /-- The residue-`3` branch, selected — the final `else`, so no positive condition remains. -/
+@[simp]
 theorem reducedInvarDenom_of_emod_eq_three (h : m % 6 = 3) :
     reducedInvarDenom b c d m =
       complEDS b c d 3 (m / 3) * complEDS b c d 2 ((m - 1) / 2) * normEDS b c d (m + 1) := by
@@ -239,9 +245,10 @@ theorem reducedInvarDenom_of_emod_eq_three (h : m % 6 = 3) :
 /-- The formula vanishes at `0`. The factor responsible is the *complement*, not a `normEDS`: at
 `m = 0` the residue-`0` branch is `(W 5 - d ^ 2) * complEDS b c d 6 0 * normEDS b c d 1 *
 normEDS b c d (-1)`, whose `normEDS` factors are `1` and `-1`, and `complEDS_zero` kills it. -/
-@[simp]
+-- Not `@[simp]`: with the per-residue lemmas tagged, `simp` derives this from
+-- `reducedInvarDenom_of_emod_eq_zero`, and `simpNF` rejects the redundant annotation.
 theorem reducedInvarDenom_zero : reducedInvarDenom b c d 0 = 0 := by
-  simp [reducedInvarDenom_def]
+  simp
 
 /-- It vanishes at `1` as well, by the same mechanism: at `m = 1` the residue-`1` branch is
 `(W 5 - d ^ 2) * complEDS b c d 6 ((1 - 1) / 6) * normEDS b c d 2 * normEDS b c d 1`, and
@@ -249,14 +256,14 @@ theorem reducedInvarDenom_zero : reducedInvarDenom b c d 0 = 0 := by
 branch. -/
 @[simp]
 theorem reducedInvarDenom_one : reducedInvarDenom b c d 1 = 0 := by
-  simp [reducedInvarDenom_def]
+  simp
 
 /-- The formula takes the value `1` at `2`, the residue-`2` branch collapsing to
 `complEDS b c d 3 1 * complEDS b c d 2 1 * normEDS b c d 1`. This is the value that fixes the
 formula's normalisation. -/
 @[simp]
 theorem reducedInvarDenom_two : reducedInvarDenom b c d 2 = 1 := by
-  simp [reducedInvarDenom_def]
+  simp
 
 /-- **The second complement read off the reduced numerator.** This is the direction the Lutz–Nagell
 development uses: it expresses `complEDS₂` through the invariant of the elliptic net, rather than


### PR DESCRIPTION
The denominator counterpart of the `reducedInvarNum` already in this file: `invarDenom` of a
normalised EDS at `s = 1`, with the constant factor `b * c` cancelled. One file, one definition and
five theorems.

```lean
def reducedInvarDenom : R :=
  let C := complEDS b c d
  let W := normEDS b c d
  let r₆ := W 5 - d ^ 2
  if m % 6 = 0 then r₆ * C 6 (m / 6) * W (m + 1) * W (m - 1)
  else if m % 6 = 1 then r₆ * C 6 ((m - 1) / 6) * W (m + 1) * W m
  …
```

## Why the six-way split is intrinsic

`invarDenom (normEDS b c d) 1 m` is `W (m + 1) * W m * W (m - 1)`, and the reduction cancels
`b = W 2` and `c = W 3`. Mathlib's `complEDS` witnesses `W k ∣ W (n * k)`, so a factor gives up
`b` exactly when `2` divides its index and `c` exactly when `3` does — and **which** of the three
factors does so depends on `m` modulo `6`. At residue `0` the middle factor `W m` supplies both,
through `complEDS b c d 6 (m / 6)`, and the outer two survive whole; at residue `2` they come from
a `3`-complement on `W (m + 1)` and a `2`-complement on `W m`. Six residues, six shapes. The
`normEDS b c d 5 - d ^ 2` factor in residues `0`, `1`, `5` is the extra unit the `6`-complement
carries relative to the `2`- and `3`-complements.

## What is proved

The defining formula; the six `reducedInvarDenom_of_emod_eq_*` branch lemmas that select a residue
class; the three small-index values (`0`, `1`, `2` — the last fixes the normalisation, `invarDenom`
at `m = 2` being `W 3 * W 2 * W 1 = c * b` exactly); naturality in the coefficient ring; and **the
identification theorem** `IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`, which is
what makes the six-way formula the denominator with its constant factor `b * c` removed.

To reach it the PR also adds `normEDS_mul_complEDS_div` to `Complement.lean`, beside the identity
it reindexes, derived there from the unconditional `normEDS_mul_complEDS` together with
`Int.ediv_mul_cancel` rather than proved afresh.

### Correction: earlier revisions of this description said the opposite

This section previously read *"**Not** proved … the theorem identifying it as the quotient …
That needs `normEDS_mul_complEDS_div`, which exists in **neither Mathlib nor this repository**"*,
and argued for shipping the definition alone. That was accurate of the first slice and became
false as the PR grew: the diff now proves the identification theorem and supplies the prerequisite
it said was missing. `scope` and `correctness` were both right to flag it, and three module
docstrings had drifted the same way — all four are corrected on this head.

The general hazard is worth keeping, because it is what produced the drift: **a well-documented
omission survives the change that fills it.** Prose saying "X is deliberately not here" reads as
current long after X arrives, and it also defeats the grep used to prove independence — a naive
search still finds the name, in the sentence explaining its absence. The fix is to grep the
blocker a note names before believing the note, and to treat "deliberately not here" sections as
things that must be revisited whenever the file gains a declaration.

## Reuse

Uses Mathlib's `complEDS` (`NumberTheory/EllipticDivisibilitySequence.lean:654`) rather than
rebuilding the divisibility witness, and sits beside `reducedInvarNum` whose `_def`/naturality
conventions it follows — a `def` plus a deliberately non-`simp` `_def` lemma, since definition
bodies are not exposed across the module boundary.

## Provenance

Ported from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in the AINTLIB
**NagellLutz** project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), at the revision
`TauCetiRoadmap` pins for that project — `dev/modular-curves @ 9fec8eba7652`
(`EllipticCurves/README.md:1071-1072`). Declarations `redInvarDenom`, `redInvarDenom_zero`,
`redInvarDenom_one`, `redInvarDenom_two`, `map_redInvarDenom` and
`invarDenom_eq_redInvarDenom_mul`, respelt with `reduced` written out to match this file's
existing `reducedInvarNum`.

### Correction: this section used to credit HasseWeil, and the description was the wrong half

Earlier revisions of this description said the denominator material came from the **HasseWeil**
project at `dev/hasse-weil @ 513e83879e2f`, and asserted "this file is HasseWeil's". That
contradicted the module's own Provenance block, which credits NagellLutz. `attribution` raised
the conflict in round 2 and again in round 8, and was right that the pair leaves the origin
unreproducible.

Its suggested fix was to move the code to the HasseWeil credit. I did not do that, because the
evidence runs the other way and it would have replaced a true attribution with a false one. The
declaration names occur in **both** projects, so a name search alone does not decide it — but two
details do, and both point at NagellLutz:

| | NagellLutz `9fec8eba7652` | HasseWeil `513e83879e2f` | ported here as |
|---|---|---|---|
| cancellation lemma | `invarDenom_eq_redInvarDenom_mul` | `invarDenom_normEDS_eq_redInvarDenom_mul` | NagellLutz's name |
| `map_redInvarDenom` | `f (redInvarDenom …) = redInvarDenom (f b) …` | the converse orientation | NagellLutz's orientation |

Counted separately over the two files: `invarDenom_eq_redInvarDenom_mul` is **2** in NagellLutz
and **0** in HasseWeil; `invarDenom_normEDS_eq_redInvarDenom_mul` is **2** in HasseWeil and **0**
in NagellLutz. Control `redInvarDenom_two` is **1** in each, so both files genuinely carry
denominator material and the zeros above discriminate rather than measure an empty haystack.

So this commit keeps the NagellLutz credit and re-pins it from `main @ 1c1c74664e40…` to the
roadmap's own NagellLutz pin `9fec8eba7652`, where the block is identical apart from one line
wrap. That dissolves the mismatch the HasseWeil story had been invented to explain: module,
description and roadmap now agree on one pin per project. The docstring keeps the two
discriminators so the next reader need not redo this.

## Review state

Round 8 board on `2645bf514` was **9/10 green** with `attribution` request_changes; this commit
answers it. Gates on the new head: `lake build TauCeti` PASS, `lint-env` PASS, no `sorry`, no
`maxHeartbeats`, no `haveI`/`letI`, nothing over 100 codepoints, merge-base diff, rebased on
current `main`.

## Scope — which roadmap target this serves

Named explicitly, since the `scope` rubric is right that the PR did not do so and right about why
the obvious citation is the wrong one. `TauCetiRoadmap/EllipticCurves/README.md:254-257` mentions
the elliptic-divisibility-sequence development only as an **existing Mathlib dependency** ("cited by
file: the sequence predicates' names are in flux upstream"), not as a build target. It is not the
node this serves.

The target is **Layer 6, "The torsion subgroup and Nagell-Lutz"** (README.md:821-834). Its stated
route is division polynomials — "*Route: division polynomials*" — and the statements it needs are
`lutz_nagell_integrality_general` for the integral long model and `lutz_nagell` for the short model
`y^2 = x^3 + Ax + B`. The reduced invariant denominator feeds that route: `omega` is what the
division-polynomial argument consumes, and `reducedInvarDenom` is the denominator half of the
reduced invariant `omega` is built from. The numerator half, `reducedInvarNum`, is already in this
file with its identification `invarNum_normEDS_one_eq_reducedInvarNum_mul`; this PR supplies the
denominator's formula, and the matching identification follows the complement-divisibility chain
(#3405).

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-reduced-invar-denom"}-->

🤖 Prepared with Claude Code (Claude Opus 5)



