### PR TITLE
feat(Huber): the coefficient form of the restricted comparison map

### DIFF
--- a/TauCeti/RingTheory/Huber/Restricted/BaseChange.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/BaseChange.lean
@@ -35,7 +35,7 @@ type `M ⊗[A] MvPowerSeries (Fin k) A →ₗ[A] MvPowerSeries (Fin k) M`.
   `ContinuousConstSMul` does not give.
 * `coe_restrictedMvPowerSeriesBaseChange`, with `coe_restrictedMvPowerSeriesBaseChange_tmul`: read
   in the ambient series, the restricted map is the ambient one, at a general element and at a pure
-  tensor.
+  tensor; `coeff_restrictedMvPowerSeriesBaseChange_tmul` reads off a single coefficient.
 
 The isomorphism itself — Remark 8.29 proper, which needs `M` finitely generated over a complete
 strongly noetherian Tate ring — is not proved here.
@@ -174,6 +174,18 @@ theorem coe_restrictedMvPowerSeriesBaseChange_tmul (m : M)
   simp only [LinearMap.id_coe, id_eq, AlgHom.toLinearMap_apply,
     restrictedMvPowerSeriesSubringVal_apply, mvPowerSeriesBaseChange_tmul]
   rfl
+
+
+/-- The coefficient of `restrictedMvPowerSeriesBaseChange (m ⊗ₜ f)` at `s`, read through the
+function-type ascription that `IsRestricted` also uses. -/
+@[simp]
+theorem coeff_restrictedMvPowerSeriesBaseChange_tmul (m : M)
+    (f : restrictedMvPowerSeriesSubring k A) (s : Fin k →₀ ℕ) :
+    (((restrictedMvPowerSeriesBaseChange (TensorProduct.tmul A m f) :
+        restrictedMvPowerSeriesSubmodule k A M) : MvPowerSeries (Fin k) M) :
+      (Fin k →₀ ℕ) → M) s = MvPowerSeries.coeff s (f : MvPowerSeries (Fin k) A) • m := by
+  rw [coe_restrictedMvPowerSeriesBaseChange_tmul]
+  exact coeff_mvPowerSeriesBaseChange_tmul m _ s
 
 end Restricted
 


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"restricted-basechange-coeff"}-->

Completes a reviewer request from #3240 that I only half-implemented.

Round 4's `api-design` finding asked for the coefficient forms *at both levels*:

> Additionally add the coefficient forms consumers actually need: `@[simp] coeff_baseChange_tmul`
> … and the corresponding `coeff_baseChangeRestricted_tmul` on the underlying series of
> `baseChangeRestricted`.

I added the ambient one (`coeff_mvPowerSeriesBaseChange_tmul`) and missed the restricted one.
This is that lemma.

## The statement

```lean
@[simp]
theorem coeff_restrictedMvPowerSeriesBaseChange_tmul (m : M)
    (f : restrictedMvPowerSeriesSubring k A) (s : Fin k →₀ ℕ) :
    (((restrictedMvPowerSeriesBaseChange (TensorProduct.tmul A m f) :
        restrictedMvPowerSeriesSubmodule k A M) : MvPowerSeries (Fin k) M) :
      (Fin k →₀ ℕ) → M) s = MvPowerSeries.coeff s (f : MvPowerSeries (Fin k) A) • m
```

proved by composing the two lemmas a consumer would otherwise have to chain by hand:
`coe_restrictedMvPowerSeriesBaseChange_tmul` to reach the ambient map, then
`coeff_mvPowerSeriesBaseChange_tmul` to reach the coefficient.

## Two things the phrasing is deliberate about

* **Coefficients go through the `(· : (Fin k →₀ ℕ) → M)` ascription, not `MvPowerSeries.coeff`.**
  `coeff` is `R`-linear on `R`-valued series and so asks for `Semiring` on the coefficient type;
  `M` here is a module. This is the same constraint that #3240's `reuse` thread settled, and the
  file's implementation notes already record it. The `A`-side `coeff` on the right-hand side is
  fine — those coefficients live in `A`.
* **`@[simp]`, and it does not collide.** `coe_restrictedMvPowerSeriesBaseChange` is the simp
  normal form for the *map*; this is about a coefficient of it, one application further out, so
  neither rewrites the other's left-hand side.

## Gates

Build 7920 jobs; `axioms` 46943 declarations, allowlist only; `module-system` 2245 modules;
`LINT-ENV: PASS`. Branch level with `main`, pin unmoved. Main-results entry updated in the same
edit as the declaration.
