### PR TITLE
feat(DivisionPolynomial): the universal ψ family is an elliptic sequence

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.NormEDS
 
 /-!
 # Division polynomials of the universal curve
@@ -25,6 +26,8 @@ Each proof is the same two steps: unfold `polyEval` into a `map` followed by `ev
 * `WeierstrassCurve.Universal.evalEval_ψ₂`, `.evalEval_Ψ₃`, `.evalEval_preΨ₄`, `.evalEval_ψ`,
   `.evalEval_φ`: the polynomials `ψ₂`, `Ψ₃`, `ψₙ` and `φₙ` of `W` at `(x, y)`, together with the
   auxiliary `preΨ₄`, are the universal ones evaluated through `Universal.polyEval`.
+* `WeierstrassCurve.Universal.isEllipticSequence_polyToField_ψ`: the universal `ψ` family, taken
+  into `Universal.Field`, is an elliptic sequence.
 
 ## Implementation notes
 
@@ -84,6 +87,22 @@ lemma evalEval_ψ : (W.ψ n).evalEval x y = polyEval W x y (curve.ψ n) := by
 /-- The numerator `φₙ` of `W` at `(x, y)` is the universal one under `polyEval`. -/
 lemma evalEval_φ : (W.φ n).evalEval x y = polyEval W x y (curve.φ n) := by
   simp_rw [polyEval_apply, ← map_φ, map_specialize]
+
+/-- **The universal `ψ` family is an elliptic sequence.** Pushing `ψₙ` of the universal curve into
+`Universal.Field` gives a normalised EDS, hence an elliptic sequence — over the universal field,
+with no hypothesis on any coefficient.
+
+This is the form `Universal.lean` needs: it records `universalNormEDS_ne_zero` and
+`universalNormEDS_mem_nonZeroDivisors` as absent because they rest on `normEDS 2 3 2 = id`, which
+requires recognising the universal division polynomials as a `normEDS` in the first place. -/
+lemma isEllipticSequence_polyToField_ψ :
+    IsEllipticSequence fun n : ℤ ↦ polyToField (curve.ψ n) := by
+  have h : (fun n : ℤ ↦ polyToField (curve.ψ n))
+      = normEDS (polyToField curve.ψ₂) (polyToField (Polynomial.C curve.Ψ₃))
+          (polyToField (Polynomial.C curve.preΨ₄)) := by
+    funext n; rw [← _root_.map_normEDS]; rfl
+  rw [h]
+  exact isEllipticSequence_normEDS _ _ _
 
 end Universal
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -47,11 +47,16 @@ Adapted from `LutzNagell/ZSMul.lean` in AINTLIB (`github.com/CBirkbeck/AINTLIB`,
 at `dev/modular-curves @ 9fec8eba7652` — the revision `TauCetiRoadmap/EllipticCurves/README.md`
 pins for the NagellLutz project. Declarations `Universal.evalEval_ψ₂`, `evalEval_Ψ₃`,
 `evalEval_preΨ₄`, `evalEval_ψ` and `evalEval_φ`; the sixth, `evalEval_ω`, is excluded for the
-reason above. That file's header reads `Authors: David Kurniadi Angdinata, Junyan Xu`.
+reason above. `isEllipticSequence_polyToField_ψ` adapts that same file's `isEllSequence_ψᵤ`.
+That file's header reads `Authors: David Kurniadi Angdinata, Junyan Xu`; following this
+repository's convention for adapted material the upstream authorship is credited here rather than
+in the copyright header.
 
-The statements are the source's unchanged. Docstrings are added here, and the source's shared
-`variable {m n : ℤ}` is narrowed to `n`: of the five results only `evalEval_ψ` and `evalEval_φ`
-carry an index, and both use `n` alone.
+The `evalEval_*` statements are the source's unchanged. Docstrings are added here, and the
+source's shared `variable {m n : ℤ}` is narrowed to `n`: of those five only `evalEval_ψ` and
+`evalEval_φ` carry an index, and both use `n` alone. `isEllSequence_ψᵤ` is stated upstream through
+an `abbrev ψᵤ` and its own `ψᵤ_eq_normEDS`; here the abbreviation is dropped and that equation is
+inlined as a `have`, so the statement is spelled on `fun n ↦ polyToField (curve.ψ n)` directly.
 -/
 
 public section


### PR DESCRIPTION
The universal `ψ` family, taken into `Universal.Field`, is an elliptic sequence.

```lean
lemma isEllipticSequence_polyToField_ψ :
    IsEllipticSequence fun n : ℤ ↦ polyToField (curve.ψ n)
```

Over the universal field, with no hypothesis on any coefficient.

## Why this one

`Universal.lean` names its own blocker. It records `universalNormEDS_ne_zero` and
`universalNormEDS_mem_nonZeroDivisors` as deliberately absent because they rest on
`normEDS 2 3 2 = id`, which first requires recognising the universal division polynomials as a
`normEDS`. This is that recognition, in the form the downstream results consume.

The proof is two steps: `map_normEDS` moves `polyToField` inside — Mathlib defines `ψ` *as*
`normEDS ψ₂ (C Ψ₃) (C preΨ₄)`, so the two sides are definitionally equal and `rfl` closes the
rewrite — and then `isEllipticSequence_normEDS` (`NormEDS.lean:127`) applies unconditionally.

## This supersedes #3348, which I closed

#3348 proposed `abbrev ψᵤ` plus `ψᵤ_eq_normEDS`, and took a correct `reuse: block`:
`ψᵤ_eq_normEDS` was `map_normEDS` at `f := polyToField` wrapped in `funext`, and `ψᵤ` had a single
use. Both findings were right and I closed it rather than reworking the branch.

Two things are different here, and they are the reasons this is not the same PR again:

1. **It has content.** The block's argument was that a consumer can write `map_normEDS` at the use
   site. That is true of the *equation*; it is not true of `IsEllipticSequence`, which is a
   different proposition requiring `isEllipticSequence_normEDS` on top. The equation is a step
   inside this proof rather than the deliverable.
2. **No abbreviation.** The statement is spelled on `fun n ↦ polyToField (curve.ψ n)` directly, so
   there is no one-use wrapper to object to.

**And a correction to #3348's docstring, which was wrong on two counts.** It claimed `normEDS` was
not known to be an elliptic sequence and that `net_normEDS` did not exist "in this repository or
upstream". Both exist here, unconditionally over any commutative ring — `isEllipticSequence_normEDS`
at `NormEDS.lean:127` and `isEllipticNet_normEDS` at `:113`. I had searched **Mathlib's**
`IsEllipticSequence` namespace, found `id` and `smul`, and concluded absence about TauCeti. The
rename is recorded in `NormEDS.lean:79`, which names `net_normEDS` as the declaration it adapts —
reading the destination file's provenance would have settled it in seconds.

## Reuse

Checked in both trees, by TauCeti's vocabulary rather than the source's. No declaration states that
the universal `ψ` family is an elliptic sequence: `NormEDS.lean` proves it for a general `normEDS`,
and nothing composes that with `polyToField ∘ curve.ψ`. The statement mentions `Universal.curve` and
`polyToField`, which have no Mathlib spelling, so it is not expressible upstream.

## Placement

It goes in `DivisionPolynomial/Universal.lean`, the file #3341 added, next to the `evalEval_*`
transport lemmas — which is where I said in #3348 it belonged. The only new import is TauCeti's
`NormEDS.lean`; that direction is already established, as `DivisionPolynomial/Invariant.lean`
imports `NumberTheory/EllipticDivisibilitySequence/Invariant.lean`.

One consequence of that import worth recording: it brings `MvPolynomial.C` into scope alongside
`Polynomial.C`, so the statement qualifies `Polynomial.C` explicitly and the proof uses
`_root_.map_normEDS`. Without those the file no longer elaborates.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md:99` — "**`[n]` is division polynomials**", the mathlib-track
anchor naming `ZSMul.lean`. The onward consumer is Layer 6's "**The torsion subgroup and
Nagell–Lutz**" (`README.md:821`), whose stated route is division polynomials.

## Review status

**Opened without a scoreboard, deliberately.** Both codex credentials on the authoring machine are
over quota (`~/.codex` to 2026-08-20, `~/.codex2` to 2026-09-14), so every local run returns ten
rubrics at `cost=$0.0000` — the provider never ran. Posting that would be destructive rather than
useless: `merge_from_scoreboard.py` takes the newest scoreboard by `updated_at` with no access bar,
so a wall of `error` states overwrites a human reviewer's verdict as the canonical record, as
happened on #3333.

## Gates

`lake build` PASS at 2008 jobs. No `sorry`, no `set_option`, no `native_decide`, no `erw`, no
`λ`/`$`/`push_neg`. One lemma, 7-line proof against the 30-line threshold; longest line exactly 100
codepoints; file is 110 lines.

## Provenance

Adapted from `LutzNagell/ZSMul.lean` in AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at
**`dev/modular-curves @ 9fec8eba7652`** — the revision `TauCetiRoadmap/EllipticCurves/README.md`
pins for the NagellLutz project. Declaration `isEllSequence_ψᵤ`. That file's header reads
`Authors: David Kurniadi Angdinata, Junyan Xu`; following this repository's convention for adapted
material the upstream authorship is credited in the module docstring rather than in the copyright
header.

The source states this through its `ψᵤ` abbreviation and its own `ψᵤ_eq_normEDS`; here the
abbreviation is dropped per #3348's `reuse` finding and the equation is inlined as a `have`.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-univ-psi-seq"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
