### PR TITLE
feat: collar charts are smooth

### DIFF
--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
@@ -158,27 +158,12 @@ section Smooth
 
 variable [ChartedSpace (EuclideanHalfSpace (n + 1)) M]
 
-/-- The collar identification is a diffeomorphism at every regularity, so in particular `C^k`.
-The chart is built at `⊤`; since that is the top of `WithTop ℕ∞`, `le_top` downcasts it to
-whatever `k` a caller needs. -/
-private theorem contMDiff_collarDiffeomorph :
-    ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
-      (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n) :=
-  (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n).contMDiff.of_le le_top
-
-/-- The inverse collar identification is `C^k`, for the reason given at
-`contMDiff_collarDiffeomorph`. -/
-private theorem contMDiff_collarDiffeomorph_symm :
-    ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-      (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n).symm :=
-  (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n).symm.contMDiff.of_le le_top
-
 /-- **A collar chart is `C^k` on its source.** The collar identification is a diffeomorphism, so
 splitting an ambient chart into a tangential and a normal coordinate costs no regularity. -/
 theorem contMDiffOn_collarChart {e : OpenPartialHomeomorph M (EuclideanHalfSpace (n + 1))}
     (he : e ∈ IsManifold.maximalAtlas (𝓡∂ (n + 1)) k M) :
     ContMDiffOn (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k (collarChart e) e.source :=
-  (contMDiff_collarDiffeomorph_symm.comp_contMDiffOn
+  (((EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n).symm.contMDiff.of_le le_top).comp_contMDiffOn
     (contMDiffOn_of_mem_maximalAtlas he)).congr fun x _ => collarChart_apply e x
 
 /-- **The inverse of a collar chart is `C^k` on its target.** With `contMDiffOn_collarChart`,
@@ -194,7 +179,8 @@ theorem contMDiffOn_collarChart_symm
       (collarChart e).target e.target := fun p hp => by
     rwa [collarChart_target] at hp
   exact ((contMDiffOn_symm_of_mem_maximalAtlas he).comp
-    contMDiff_collarDiffeomorph.contMDiffOn hmaps).congr fun p _ => collarChart_symm_apply e p
+    ((EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n).contMDiff.of_le le_top).contMDiffOn
+    hmaps).congr fun p _ => collarChart_symm_apply e p
 
 end Smooth
 

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
@@ -28,18 +28,22 @@ are the content of the file.
   manifold built in `Boundary.Charts`. The two files therefore describe one coordinate system,
   not two.
 
-The chart is built from `collarDiffeomorph` at the top regularity `⊤` and used only through its
-underlying homeomorphism: charts are topological data, and the map underlying `collarDiffeomorph`
-does not depend on the regularity exponent. Smoothness statements instantiate the diffeomorphism
-at whatever exponent they need.
+The chart is built from `collarDiffeomorph` at the top regularity `⊤`. Since `⊤` is the top of
+`WithTop ℕ∞`, `ContMDiff.of_le le_top` downcasts its smoothness to whatever exponent a caller
+needs, so one chart serves every regularity.
 
-This is the first step of the collar-neighbourhood target in Layer 1 of the GeometricTopology
-roadmap, taken after `Boundary.Collar.Basic`'s standard-model calculation: it puts the product
-coordinates on a general manifold. The two steps that remain for the collar theorem itself are
-not proved here — that the collar charts have `C^k` transitions, so `M` is also a manifold for
-the product model `(𝓡 n).prod (𝓡∂ 1)`; and the global statement, that a whole neighbourhood of
-`I.boundary M` is diffeomorphic to `I.boundary M × [0, 1)`, which needs these local product
-coordinates patched with a partition of unity.
+Those coordinates are smooth, not merely continuous: `contMDiffOn_collarChart` and
+`contMDiffOn_collarChart_symm` make a collar chart a `C^k` diffeomorphism between its source and
+its target. Together with `mem_boundary_iff_collarChart_snd_apply_zero_eq_zero` that is a *local*
+collar — around any point, `M` is smoothly a tangential coordinate together with a normal one, and
+the boundary is exactly where the normal one vanishes.
+
+This serves the collar-neighbourhood target in Layer 1 of the GeometricTopology roadmap
+(`TauCetiRoadmap/GeometricTopology/README.md`), after `Boundary.Collar.Basic`'s standard-model
+calculation. What remains is the global statement, that a whole neighbourhood of
+`I.boundary M` is diffeomorphic to `I.boundary M × [0, 1)`. Both textbook routes glue these local
+collars along an inward-pointing vector field, which needs flows from boundary points; Mathlib's
+integral curves are still restricted to interior points, so that step waits on it.
 
 ## Main definitions
 
@@ -59,6 +63,8 @@ coordinates patched with a partition of unity.
   collar chart, so it never has to be unfolded.
 * `TauCeti.collarChartedSpace_chartAt` and `TauCeti.collarChartedSpace_atlas`: its preferred
   charts and its atlas.
+* `TauCeti.contMDiffOn_collarChart` and `TauCeti.contMDiffOn_collarChart_symm`: a collar chart
+  and its inverse are `C^k`, so the local product structure is smooth.
 
 ## References
 
@@ -137,6 +143,49 @@ Not `@[simp]`, for the reason given at `collarChart_fst`. -/
 theorem collarChart_snd_apply_zero (e : OpenPartialHomeomorph M (EuclideanHalfSpace (n + 1)))
     (x : M) : (collarChart e x).2.1 0 = (e x).1 0 := by
   rw [collarChart_apply, EuclideanHalfSpace.collarDiffeomorph_symm_apply_snd_apply_zero]
+
+section Smooth
+
+variable [ChartedSpace (EuclideanHalfSpace (n + 1)) M]
+
+/-- The collar identification is a diffeomorphism at every regularity, so in particular `C^k`.
+The chart is built at `⊤`; since that is the top of `WithTop ℕ∞`, `le_top` downcasts it to
+whatever `k` a caller needs. -/
+private theorem contMDiff_collarDiffeomorph :
+    ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
+      (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n) :=
+  (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n).contMDiff.of_le le_top
+
+/-- The inverse collar identification is `C^k`, for the reason given at
+`contMDiff_collarDiffeomorph`. -/
+private theorem contMDiff_collarDiffeomorph_symm :
+    ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
+      (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n).symm :=
+  (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n).symm.contMDiff.of_le le_top
+
+/-- **A collar chart is `C^k` on its source.** The collar identification is a diffeomorphism, so
+splitting an ambient chart into a tangential and a normal coordinate costs no regularity. -/
+theorem contMDiffOn_collarChart {e : OpenPartialHomeomorph M (EuclideanHalfSpace (n + 1))}
+    (he : e ∈ IsManifold.maximalAtlas (𝓡∂ (n + 1)) k M) :
+    ContMDiffOn (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k (collarChart e) e.source :=
+  (contMDiff_collarDiffeomorph_symm.comp_contMDiffOn
+    (contMDiffOn_of_mem_maximalAtlas he)).congr fun x _ => collarChart_apply e x
+
+/-- **The inverse of a collar chart is `C^k` on its target.** With
+`contMDiffOn_collarChart`, a collar chart is a diffeomorphism between its source and its
+target: near any point, `M` is smoothly a tangential coordinate together with a normal one. -/
+theorem contMDiffOn_collarChart_symm
+    {e : OpenPartialHomeomorph M (EuclideanHalfSpace (n + 1))}
+    (he : e ∈ IsManifold.maximalAtlas (𝓡∂ (n + 1)) k M) :
+    ContMDiffOn ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k (collarChart e).symm
+      (collarChart e).target := by
+  have hmaps : Set.MapsTo (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n)
+      (collarChart e).target e.target := fun p hp => by
+    rwa [collarChart_target] at hp
+  exact ((contMDiffOn_symm_of_mem_maximalAtlas he).comp
+    contMDiff_collarDiffeomorph.contMDiffOn hmaps).congr fun p _ => collarChart_symm_apply e p
+
+end Smooth
 
 section Atlas
 

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
@@ -17,8 +17,7 @@ manifold `M` modeled on that half-space, by composing an ambient chart of `M` wi
 identification.
 
 The resulting *collar chart* reads a point of `M` as a pair: a tangential coordinate in the
-boundary model, and a normal coordinate in `[0, ∞)`. Two facts make it deserve the name, and they
-are the content of the file.
+boundary model, and a normal coordinate in `[0, ∞)`. Two facts make it deserve the name.
 
 * **The boundary is the zero slice.** For an atlas chart `e` and a point of `e.source`, lying on
   `I.boundary M` becomes the vanishing of one product factor — the normal coordinate — of the
@@ -49,10 +48,13 @@ calculation. Two steps remain, neither proved here.
   they are about single charts against the half-space model, not about the transitions — but no
   `HasGroupoid` or `IsManifold` instance for `collarChartedSpace` exists yet.
 * The global statement, that a whole neighbourhood of `I.boundary M` is diffeomorphic to
-  `I.boundary M × [0, 1)`. Both textbook routes first build collars near boundary points — which
-  this file does not do — and then glue them along an inward-pointing vector field, which needs
-  flows from boundary points; Mathlib's integral curves are still restricted to interior points,
-  so that step waits on it.
+  `I.boundary M × [0, 1)`. The two textbook routes differ in what they need. Lee Thm 9.25 goes
+  through the Boundary Flowout Theorem, gluing an inward-pointing vector field and flowing it,
+  which needs flows from boundary points; Mathlib's integral curves are still restricted to
+  interior points, so that route waits on them. Hirsch Thm 6.1 instead glues local retractions
+  with a bump function and pairs the resulting retraction `r` with a `g` vanishing on the boundary
+  and regular there, taking `h = (r, g)`; that route needs no flows. (Hirsch §5.2 gives the
+  differential-equations proof as an alternative.)
 
 ## Main definitions
 

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
@@ -34,16 +34,25 @@ needs, so one chart serves every regularity.
 
 Those coordinates are smooth, not merely continuous: `contMDiffOn_collarChart` and
 `contMDiffOn_collarChart_symm` make a collar chart a `C^k` diffeomorphism between its source and
-its target. Together with `mem_boundary_iff_collarChart_snd_apply_zero_eq_zero` that is a *local*
-collar — around any point, `M` is smoothly a tangential coordinate together with a normal one, and
-the boundary is exactly where the normal one vanishes.
+its target, for a chart in `IsManifold.maximalAtlas`. Read with
+`mem_boundary_iff_collarChart_snd_apply_zero_eq_zero`, they give smooth local product
+*coordinates* whose normal component cuts out the boundary. They do not give a collar: the target
+of a collar chart is `⇑collarDiffeomorph ⁻¹' e.target`, an open subset of the product model, and
+shrinking it to a product neighbourhood `V × [0, 1)` is not proved here.
 
 This serves the collar-neighbourhood target in Layer 1 of the GeometricTopology roadmap
 (`TauCetiRoadmap/GeometricTopology/README.md`), after `Boundary.Collar.Basic`'s standard-model
-calculation. What remains is the global statement, that a whole neighbourhood of
-`I.boundary M` is diffeomorphic to `I.boundary M × [0, 1)`. Both textbook routes glue these local
-collars along an inward-pointing vector field, which needs flows from boundary points; Mathlib's
-integral curves are still restricted to interior points, so that step waits on it.
+calculation. Two steps remain, neither proved here.
+
+* That the collar charts have `C^k` transitions, so `M` is also a manifold for the product model
+  `(𝓡 n).prod (𝓡∂ 1)` via `collarChartedSpace`. The two lemmas above bring this within reach —
+  they are about single charts against the half-space model, not about the transitions — but no
+  `HasGroupoid` or `IsManifold` instance for `collarChartedSpace` exists yet.
+* The global statement, that a whole neighbourhood of `I.boundary M` is diffeomorphic to
+  `I.boundary M × [0, 1)`. Both textbook routes first build collars near boundary points — which
+  this file does not do — and then glue them along an inward-pointing vector field, which needs
+  flows from boundary points; Mathlib's integral curves are still restricted to interior points,
+  so that step waits on it.
 
 ## Main definitions
 
@@ -64,7 +73,7 @@ integral curves are still restricted to interior points, so that step waits on i
 * `TauCeti.collarChartedSpace_chartAt` and `TauCeti.collarChartedSpace_atlas`: its preferred
   charts and its atlas.
 * `TauCeti.contMDiffOn_collarChart` and `TauCeti.contMDiffOn_collarChart_symm`: a collar chart
-  and its inverse are `C^k`, so the local product structure is smooth.
+  and its inverse are `C^k`, so the local product coordinates are smooth.
 
 ## References
 
@@ -89,8 +98,9 @@ variable {n : ℕ} {k : WithTop ℕ∞} {M : Type*} [TopologicalSpace M]
 /-- The collar chart attached to an ambient chart `e` of `M`: read a point through `e`, then split
 the model half-space into its boundary model and the inward normal coordinate.
 
-`collarDiffeomorph` is taken at the top regularity because only its underlying homeomorphism is
-used here; the map does not depend on the exponent.
+`collarDiffeomorph` is taken at the top regularity `⊤` because `ContMDiff.of_le le_top` downcasts
+its smoothness to any `k`, so this one chart serves every regularity. Its underlying map does not
+depend on the exponent either, so the topological lemmas below are equally unaffected.
 
 No body here or below is exposed: the lemmas in this section name the value, source, target and
 inverse of a collar chart, so downstream code rewrites with those instead of unfolding. -/
@@ -171,9 +181,10 @@ theorem contMDiffOn_collarChart {e : OpenPartialHomeomorph M (EuclideanHalfSpace
   (contMDiff_collarDiffeomorph_symm.comp_contMDiffOn
     (contMDiffOn_of_mem_maximalAtlas he)).congr fun x _ => collarChart_apply e x
 
-/-- **The inverse of a collar chart is `C^k` on its target.** With
-`contMDiffOn_collarChart`, a collar chart is a diffeomorphism between its source and its
-target: near any point, `M` is smoothly a tangential coordinate together with a normal one. -/
+/-- **The inverse of a collar chart is `C^k` on its target.** With `contMDiffOn_collarChart`,
+a collar chart of a `maximalAtlas` member is a `C^k` diffeomorphism between its source and its
+target, so on that source `M` carries smooth tangential and normal coordinates. The target is an
+open subset of the product model, not a product neighbourhood. -/
 theorem contMDiffOn_collarChart_symm
     {e : OpenPartialHomeomorph M (EuclideanHalfSpace (n + 1))}
     (he : e ∈ IsManifold.maximalAtlas (𝓡∂ (n + 1)) k M) :
@@ -216,8 +227,8 @@ the one-dimensional half-space.
 
 It is `ChartedSpace.comp` applied to `EuclideanHalfSpace.collarModelChartedSpace`, rather than an
 atlas written out by hand, so that `chartAt_comp`, the `extChartAt` composition lemmas and
-`HasGroupoid.comp` all apply to it — `HasGroupoid.comp` is the route to the `C^k` transitions
-named above.
+`HasGroupoid.comp` all apply to it — `HasGroupoid.comp` is the route to the `C^k` transitions that
+would make `M` a manifold for the product model, which is not proved yet.
 
 `n` and `M` are explicit so that `letI := collarChartedSpace n M` determines both; there is no
 expected type at a `letI` to solve them from.


### PR DESCRIPTION
`Boundary/Collar/Chart.lean` built the collar charts as topological data — its own docstring said so, and every result in it was about continuity: where the boundary sits, what the tangential and normal coordinates are, what the atlas is. A collar is a *smooth* product, so the analytic content was missing, and no collar statement could be phrased as a diffeomorphism.

* `TauCeti.contMDiffOn_collarChart` — a collar chart is `C^k` on its source.
* `TauCeti.contMDiffOn_collarChart_symm` — its inverse is `C^k` on its target.

For a chart in `IsManifold.maximalAtlas`, the two together make a collar chart a `C^k` diffeomorphism between its source and its target. Both come from the model identification composed with an atlas chart, through Mathlib's `contMDiffOn_of_mem_maximalAtlas` and `contMDiffOn_symm_of_mem_maximalAtlas`.

## What this gives, and what it does not

Read with the merged `mem_boundary_iff_collarChart_snd_apply_zero_eq_zero`, these are smooth local product **coordinates** whose normal component cuts out the boundary.

They are **not** a local collar. A collar chart's target is `⇑collarDiffeomorph ⁻¹' e.target`, an arbitrary open subset of the product model; shrinking it to a product neighbourhood `V × [0, 1)` is not proved here. An earlier revision of this description and of the module docstring claimed otherwise, and that was wrong.

## What this advances

`TauCetiRoadmap/GeometricTopology/README.md`, Layer 1, **Collar neighbourhoods**: *"A boundary component has a neighbourhood diffeomorphic to `∂M × [0, 1)`."* The word carrying the content is *diffeomorphic*, and nothing merged so far could express it: the collar charts existed only as homeomorphisms. This supplies the regularity that every later collar statement has to quote.

Two steps still remain, both named in the module docstring:

1. The `C^k` transitions making `M` a manifold for the product model `(𝓡 n).prod (𝓡∂ 1)` via `collarChartedSpace`. These lemmas bring it within reach — they concern single charts against the half-space model, not the transitions — but no `HasGroupoid`/`IsManifold` instance exists yet.
2. The global statement. The two textbook routes differ in what they need. Lee GTM 218 Thm 9.25 goes through the Boundary Flowout Theorem, gluing an inward-pointing vector field and flowing it — that needs flows from boundary points, and Mathlib's integral curves are still restricted to interior points. Hirsch GTM 33 Thm 6.1 instead glues local retractions with a bump function and takes `h = (r, g)` for a `g` vanishing on the boundary with `0` a regular value; that route needs no flows. (Hirsch §5.2 gives the differential-equations proof as an alternative.)

## Notes

* Neither statement assumes `IsManifold`: membership in `maximalAtlas` already carries what the proofs use.
* The chart is built at `⊤`, the top of `WithTop ℕ∞`, so one `ContMDiff.of_le le_top` serves every regularity; no regularity-independence lemma is needed.
* Nothing already on `main` is removed or renamed, and the `@[simp]` set is unchanged, so the simp normal forms settled during review of #3104 still hold. The only edits to existing text are docstrings, updated because they described the file as topological-only, justified the `⊤` regularity by a reason this PR falsifies, or pointed at a paragraph that had been rewritten.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"collar-charts-smooth"}-->

🤖 Prepared with Claude Code
