### PR TITLE
feat(ClassGroup): extending a class then taking its relative norm is the finrank power

### DIFF
--- a/TauCeti/RingTheory/ClassGroup/RelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/RelNorm.lean
@@ -35,14 +35,16 @@ descent instead goes through the monoid congruence `Con.ker` and
 * `ClassGroup.relNorm_extendedHom`: **extend then norm is the `finrank`-th power**,
   `relNorm (extendedHom R S c) = c ^ Module.finrank R S`, with
   `ClassGroup.relNorm_comp_extendedHom` the same statement as an identity of monoid homomorphisms.
-  The extension direction is Mathlib's `ClassGroup.extendedHom`; only this composite is new.
+  The extension direction is Mathlib's `ClassGroup.extendedHom`; the composite itself is the
+  source's `ClassGroup.relNorm_comp_map`, respelt against it.
 
 ## Provenance
 
 Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
 `HasseWeil/Pic0/ClassGroupNorm.lean`, declarations `relNorm0`, `mk0CompRelNorm0`,
 `mk0CompRelNorm0_apply`, `mk0CompRelNorm0_eq_of_mk0_eq`, `ClassGroup.relNorm`,
-`ClassGroup.relNorm_mk0` and `ClassGroup.relNorm_mk0'`.
+`ClassGroup.relNorm_mk0`, `ClassGroup.relNorm_mk0'`, `ClassGroup.relNorm_comp_map` and
+`ClassGroup.relNorm_comp_map_eq`.
 
 Deviations from the source. It descends by `Function.surjInv` on `ClassGroup.mk0_surjective`, with
 `Function.surjInv_eq` rewrites discharging `map_one'` and `map_mul'`; the congruence route used
@@ -60,8 +62,17 @@ first version of this file duplicated them under the source's names and `reuse` 
 `Ideal.relNorm_map_algebraMap` is likewise not ported: it converts `Ideal.relNorm_algebraMap`'s
 exponent from `Module.finrank (FractionRing R) (FractionRing S)` to `Module.finrank R S`, and the
 pinned `Ideal.relNorm_algebraMap` already concludes in the latter form, with the converting lemma
-`finrank_of_isFractionRing` now deprecated. What remains genuinely new is the composite
-`relNorm ∘ extendedHom`, which needs `ClassGroup.relNorm` and so cannot be upstream.
+`finrank_of_isFractionRing` now deprecated.
+
+**The composite is ported, not original.** `relNorm_extendedHom` and `relNorm_comp_extendedHom` are
+the source's `ClassGroup.relNorm_comp_map` and `ClassGroup.relNorm_comp_map_eq`, respelt so that the
+extension direction is Mathlib's `ClassGroup.extendedHom` rather than the source's own
+`ClassGroup.map`. What is new here is only that respelling and the shape of the proof: the source
+reaches the ideal level inline, by `congrArg ClassGroup.mk0`, `Subtype.ext` and a `change`, landing
+on its own `Ideal.relNorm_map_algebraMap`; this file names that step as
+`Ideal.relNorm0_extendedIdeal` and lands on Mathlib's `Ideal.relNorm_algebraMap` directly, no
+exponent conversion being needed. The composite is nonetheless new *relative to Mathlib*, since it
+needs `ClassGroup.relNorm`, which Mathlib does not carry.
 -/
 
 public section
@@ -83,6 +94,16 @@ noncomputable def Ideal.relNorm0 : (Ideal S)⁰ →* (Ideal R)⁰ :=
 theorem Ideal.coe_relNorm0 (I : (Ideal S)⁰) :
     (Ideal.relNorm0 R I : Ideal R) = Ideal.relNorm R (I : Ideal S) :=
   (rfl)
+
+/-- **Norm of an extended ideal is the `finrank`-th power**, on nonzero ideals: the
+`(Ideal R)⁰`-level form of Mathlib's `Ideal.relNorm_algebraMap`, against Mathlib's
+`ClassGroup.extendedIdeal`. -/
+@[simp]
+theorem Ideal.relNorm0_extendedIdeal (I : (Ideal R)⁰) :
+    Ideal.relNorm0 R (ClassGroup.extendedIdeal R S I) = I ^ Module.finrank R S := by
+  refine Subtype.ext ?_
+  rw [Ideal.coe_relNorm0, SubmonoidClass.coe_pow]
+  exact Ideal.relNorm_algebraMap S (I : Ideal R)
 
 namespace ClassGroup
 
@@ -134,21 +155,12 @@ theorem relNorm_mk0 (I : (Ideal S)⁰) :
   rw [relNorm, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, h]
   rfl
 
-/-- **Norm of an extended ideal is the `finrank`-th power**, on nonzero ideals: the
-`(Ideal R)⁰`-level form of Mathlib's `Ideal.relNorm_algebraMap`, against Mathlib's
-`ClassGroup.extendedIdeal`. -/
-@[simp]
-theorem _root_.Ideal.relNorm0_extendedIdeal (I : (Ideal R)⁰) :
-    Ideal.relNorm0 R (ClassGroup.extendedIdeal R S I) = I ^ Module.finrank R S := by
-  refine Subtype.ext ?_
-  rw [Ideal.coe_relNorm0, SubmonoidClass.coe_pow]
-  exact Ideal.relNorm_algebraMap S (I : Ideal R)
-
 /-- **Extending a class and taking its relative norm raises it to the `finrank`-th power.**
 
 The extension direction is Mathlib's `ClassGroup.extendedHom`; the arithmetic is Mathlib's
 `Ideal.relNorm_algebraMap`, which needs no separability, Galois or perfect-field hypothesis, so
-neither does this. Only the composite with `relNorm` is new. -/
+neither does this. The composite is the source's `ClassGroup.relNorm_comp_map`; see the
+module's Provenance. -/
 @[simp]
 theorem relNorm_extendedHom (c : ClassGroup R) :
     relNorm (ClassGroup.extendedHom R S c) = c ^ Module.finrank R S := by

--- a/TauCeti/RingTheory/ClassGroup/RelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/RelNorm.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.ClassGroup.Basic
+public import Mathlib.RingTheory.ClassGroup.ExtendedHom
 public import Mathlib.RingTheory.Ideal.Norm.RelNorm
 import Mathlib.GroupTheory.Congruence.Basic
 
@@ -25,27 +26,23 @@ descent instead goes through the monoid congruence `Con.ker` and
 
 * `Ideal.relNorm0 : (Ideal S)⁰ →* (Ideal R)⁰`: the relative ideal norm on nonzero ideals.
 * `ClassGroup.relNorm : ClassGroup S →* ClassGroup R`.
-* `Ideal.extend0 : (Ideal R)⁰ →* (Ideal S)⁰`: ideal extension along `algebraMap R S`, on
-  nonzero ideals.
-* `ClassGroup.extend : ClassGroup R →* ClassGroup S`: the class-group extension map, the partner
-  of `relNorm` in the other direction.
+
 
 ## Main results
 
 * `ClassGroup.relNorm_mk0`: `relNorm (mk0 I) = mk0 (relNorm0 I)`, the defining computation on an
-  integral representative, and `ClassGroup.extend_mk0` likewise.
-* `ClassGroup.relNorm_extend`: **extend then norm is the `finrank`-th power**,
-  `relNorm (extend c) = c ^ Module.finrank R S`, with `ClassGroup.relNorm_comp_extend` the same
-  statement as an identity of monoid homomorphisms.
+  integral representative.
+* `ClassGroup.relNorm_extendedHom`: **extend then norm is the `finrank`-th power**,
+  `relNorm (extendedHom R S c) = c ^ Module.finrank R S`, with
+  `ClassGroup.relNorm_comp_extendedHom` the same statement as an identity of monoid homomorphisms.
+  The extension direction is Mathlib's `ClassGroup.extendedHom`; only this composite is new.
 
 ## Provenance
 
 Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
 `HasseWeil/Pic0/ClassGroupNorm.lean`, declarations `relNorm0`, `mk0CompRelNorm0`,
 `mk0CompRelNorm0_apply`, `mk0CompRelNorm0_eq_of_mk0_eq`, `ClassGroup.relNorm`,
-`ClassGroup.relNorm_mk0` and `ClassGroup.relNorm_mk0'`; and, for the extension direction,
-`map0`, `mk0CompMap0`, `mk0CompMap0_apply`, `mk0CompMap0_eq_of_mk0_eq`, `ClassGroup.map`,
-`ClassGroup.map_mk0` and `ClassGroup.relNorm_comp_map`.
+`ClassGroup.relNorm_mk0` and `ClassGroup.relNorm_mk0'`.
 
 Deviations from the source. It descends by `Function.surjInv` on `ClassGroup.mk0_surjective`, with
 `Function.surjInv_eq` rewrites discharging `map_one'` and `map_mul'`; the congruence route used
@@ -55,18 +52,16 @@ alongside `IsDedekindDomain` for both rings, which are implied. Its intermediate
 directly about `mk0 ∘ relNorm0`. Finally its `relNorm_mk0'`, a restatement of `relNorm_mk0` with
 the membership proof spelled out inline, is not ported.
 
-The extension direction follows the same deviations, and two more. Its `ClassGroup.map` is renamed
-`ClassGroup.extend`: `map` is the standard name for the *ideal*-level operation this descends from,
-and a `ClassGroup.map` would collide with it on sight. Its `ClassGroup.map_one` and
-`ClassGroup.map_mul` are not ported — both are `map_one`/`map_mul` applied to a bundled
-`MonoidHom`, so they restate what the bundling already gives.
-
-Its `Ideal.relNorm_map_algebraMap` is **not** ported either, and this is not a deviation of taste:
-that lemma converts `Ideal.relNorm_algebraMap`'s exponent from
-`Module.finrank (FractionRing R) (FractionRing S)` to `Module.finrank R S`. In the Mathlib pinned
-here `Ideal.relNorm_algebraMap` already concludes `= I ^ Module.finrank R S`, so the conversion is
-a no-op and the lemma performing it (`finrank_of_isFractionRing`) is deprecated. The source itself
-says the arithmetic core "is already available in mathlib as `Ideal.relNorm_algebraMap`".
+**The source's extension direction is not ported at all.** Its `map0`, `mk0CompMap0`,
+`ClassGroup.map`, `ClassGroup.map_mk0`, `ClassGroup.map_one` and `ClassGroup.map_mul` are Mathlib's
+`ClassGroup.extendedIdeal`, `ClassGroup.extendedHom` and `ClassGroup.extendedHom_mk0`
+(`Mathlib/RingTheory/ClassGroup/ExtendedHom.lean`), which the pinned Mathlib already carries; the
+first version of this file duplicated them under the source's names and `reuse` blocked it. Its
+`Ideal.relNorm_map_algebraMap` is likewise not ported: it converts `Ideal.relNorm_algebraMap`'s
+exponent from `Module.finrank (FractionRing R) (FractionRing S)` to `Module.finrank R S`, and the
+pinned `Ideal.relNorm_algebraMap` already concludes in the latter form, with the converting lemma
+`finrank_of_isFractionRing` now deprecated. What remains genuinely new is the composite
+`relNorm ∘ extendedHom`, which needs `ClassGroup.relNorm` and so cannot be upstream.
 -/
 
 public section
@@ -139,93 +134,32 @@ theorem relNorm_mk0 (I : (Ideal S)⁰) :
   rw [relNorm, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, h]
   rfl
 
-variable (S) in
-omit [Module.Finite R S] in
-/-- The extension of an integral ideal along `algebraMap R S`, restricted to nonzero ideals.
-
-Extension reflects `⊥` because `algebraMap R S` is injective
-(`Ideal.map_eq_bot_iff_of_injective`), which is what keeps it inside `(Ideal S)⁰`. -/
-noncomputable def _root_.Ideal.extend0 : (Ideal R)⁰ →* (Ideal S)⁰ where
-  toFun I := ⟨Ideal.map (algebraMap R S) (I : Ideal R), by
-    rw [mem_nonZeroDivisors_iff_ne_zero, ne_eq, ← bot_eq_zero,
-      Ideal.map_eq_bot_iff_of_injective (FaithfulSMul.algebraMap_injective R S), bot_eq_zero,
-      ← ne_eq, ← mem_nonZeroDivisors_iff_ne_zero]
-    exact I.2⟩
-  map_one' := by ext; simp [Ideal.one_eq_top, Ideal.map_top]
-  map_mul' I J := by ext; simp [Ideal.map_mul]
-
-omit [Module.Finite R S] in
-@[simp]
-theorem _root_.Ideal.coe_extend0 (I : (Ideal R)⁰) :
-    (Ideal.extend0 S I : Ideal S) = Ideal.map (algebraMap R S) (I : Ideal R) :=
-  (rfl)
-
-omit [Module.Finite R S] in
-/-- **Well-definedness of the class-group extension**: integral ideals with the same class have
-extensions with the same class.
-
-By `ClassGroup.mk0_eq_mk0_iff` the hypothesis says `span {x} * I = span {y} * J` for nonzero
-`x y : R`. Extension is multiplicative and carries `span {x}` to `span {algebraMap R S x}`
-(`Ideal.map_span`), and those generators stay nonzero because `algebraMap R S` is injective. -/
-private theorem mk0_extend0_eq_of_mk0_eq {I J : (Ideal R)⁰}
-    (h : ClassGroup.mk0 I = ClassGroup.mk0 J) :
-    ClassGroup.mk0 (Ideal.extend0 S I) = ClassGroup.mk0 (Ideal.extend0 S J) := by
-  have hinj := FaithfulSMul.algebraMap_injective R S
-  rw [ClassGroup.mk0_eq_mk0_iff] at h
-  obtain ⟨x, y, hx, hy, hxy⟩ := h
-  have hspan : ∀ a : R, Ideal.span {algebraMap R S a}
-      = Ideal.map (algebraMap R S) (Ideal.span {a}) := fun a => by
-    rw [Ideal.map_span, Set.image_singleton]
-  refine ClassGroup.mk0_eq_mk0_iff.mpr ⟨algebraMap R S x, algebraMap R S y,
-    (map_ne_zero_iff _ hinj).mpr hx, (map_ne_zero_iff _ hinj).mpr hy, ?_⟩
-  rw [Ideal.coe_extend0, Ideal.coe_extend0, hspan x, hspan y, ← Ideal.map_mul, ← Ideal.map_mul,
-    hxy]
-
-omit [Module.Finite R S] in
-/-- The **extension map on class groups**, induced by `Ideal.map (algebraMap R S)`.
-
-The partner of `ClassGroup.relNorm` in the other direction, descended the same way: every class has
-an integral representative and the class of the extension does not depend on which. -/
-noncomputable def extend : ClassGroup R →* ClassGroup S :=
-  ((Con.ker (ClassGroup.mk0 (R := R))).lift ((ClassGroup.mk0 (R := S)).comp (Ideal.extend0 S))
-      fun _ _ h => mk0_extend0_eq_of_mk0_eq h).comp
-    (Con.quotientKerEquivOfSurjective _ ClassGroup.mk0_surjective).symm.toMonoidHom
-
-omit [Module.Finite R S] in
-/-- The extension of the class represented by a nonzero ideal `I` is the class represented by `I`'s
-extension. This is the computation rule for `ClassGroup.extend`. -/
-@[simp]
-theorem extend_mk0 (I : (Ideal R)⁰) :
-    extend (S := S) (ClassGroup.mk0 I) = ClassGroup.mk0 (Ideal.extend0 S I) := by
-  have h : (Con.quotientKerEquivOfSurjective _ ClassGroup.mk0_surjective).symm
-      (ClassGroup.mk0 (R := R) I) = (I : (Con.ker (ClassGroup.mk0 (R := R))).Quotient) :=
-    (MulEquiv.symm_apply_eq _).mpr rfl
-  rw [extend, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, h]
-  rfl
-
 /-- **Norm of an extended ideal is the `finrank`-th power**, on nonzero ideals: the
-`(Ideal R)⁰`-level form of Mathlib's `Ideal.relNorm_algebraMap`, which supplies the whole
-arithmetic content. -/
-theorem _root_.Ideal.relNorm0_extend0 (I : (Ideal R)⁰) :
-    Ideal.relNorm0 R (Ideal.extend0 S I) = I ^ Module.finrank R S := by
+`(Ideal R)⁰`-level form of Mathlib's `Ideal.relNorm_algebraMap`, against Mathlib's
+`ClassGroup.extendedIdeal`. -/
+theorem _root_.Ideal.relNorm0_extendedIdeal (I : (Ideal R)⁰) :
+    Ideal.relNorm0 R (ClassGroup.extendedIdeal R S I) = I ^ Module.finrank R S := by
   refine Subtype.ext ?_
-  rw [Ideal.coe_relNorm0, Ideal.coe_extend0, SubmonoidClass.coe_pow]
+  rw [Ideal.coe_relNorm0, SubmonoidClass.coe_pow]
   exact Ideal.relNorm_algebraMap S (I : Ideal R)
 
 /-- **Extending a class and taking its relative norm raises it to the `finrank`-th power.**
 
-Mathlib's `Ideal.relNorm_algebraMap` needs no separability, Galois or perfect-field hypothesis, so
-neither does this. -/
-theorem relNorm_extend (c : ClassGroup R) :
-    relNorm (extend (S := S) c) = c ^ Module.finrank R S := by
+The extension direction is Mathlib's `ClassGroup.extendedHom`; the arithmetic is Mathlib's
+`Ideal.relNorm_algebraMap`, which needs no separability, Galois or perfect-field hypothesis, so
+neither does this. Only the composite with `relNorm` is new. -/
+theorem relNorm_extendedHom (c : ClassGroup R) :
+    relNorm (ClassGroup.extendedHom R S c) = c ^ Module.finrank R S := by
   obtain ⟨I, rfl⟩ := ClassGroup.mk0_surjective c
-  rw [extend_mk0, relNorm_mk0, Ideal.relNorm0_extend0]
+  rw [ClassGroup.extendedHom_mk0, relNorm_mk0, Ideal.relNorm0_extendedIdeal]
   exact map_pow ClassGroup.mk0 I (Module.finrank R S)
 
-/-- `ClassGroup.relNorm_extend` as an identity of monoid homomorphisms. -/
-theorem relNorm_comp_extend :
-    (relNorm (R := R)).comp (extend (S := S)) = powMonoidHom (Module.finrank R S) := by
+/-- `ClassGroup.relNorm_extendedHom` as an identity of monoid homomorphisms: the composite
+`relNorm ∘ extendedHom` is the `finrank`-th power map on `ClassGroup R`. -/
+theorem relNorm_comp_extendedHom :
+    (relNorm (R := R)).comp (ClassGroup.extendedHom R S) = powMonoidHom (Module.finrank R S) := by
   ext c
-  rw [MonoidHom.comp_apply, powMonoidHom_apply, relNorm_extend]
+  rw [MonoidHom.comp_apply, powMonoidHom_apply, relNorm_extendedHom]
+
 
 end ClassGroup

--- a/TauCeti/RingTheory/ClassGroup/RelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/RelNorm.lean
@@ -25,18 +25,27 @@ descent instead goes through the monoid congruence `Con.ker` and
 
 * `Ideal.relNorm0 : (Ideal S)⁰ →* (Ideal R)⁰`: the relative ideal norm on nonzero ideals.
 * `ClassGroup.relNorm : ClassGroup S →* ClassGroup R`.
+* `Ideal.extend0 : (Ideal R)⁰ →* (Ideal S)⁰`: ideal extension along `algebraMap R S`, on
+  nonzero ideals.
+* `ClassGroup.extend : ClassGroup R →* ClassGroup S`: the class-group extension map, the partner
+  of `relNorm` in the other direction.
 
 ## Main results
 
 * `ClassGroup.relNorm_mk0`: `relNorm (mk0 I) = mk0 (relNorm0 I)`, the defining computation on an
-  integral representative.
+  integral representative, and `ClassGroup.extend_mk0` likewise.
+* `ClassGroup.relNorm_extend`: **extend then norm is the `finrank`-th power**,
+  `relNorm (extend c) = c ^ Module.finrank R S`, with `ClassGroup.relNorm_comp_extend` the same
+  statement as an identity of monoid homomorphisms.
 
 ## Provenance
 
 Ported from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
 `HasseWeil/Pic0/ClassGroupNorm.lean`, declarations `relNorm0`, `mk0CompRelNorm0`,
 `mk0CompRelNorm0_apply`, `mk0CompRelNorm0_eq_of_mk0_eq`, `ClassGroup.relNorm`,
-`ClassGroup.relNorm_mk0` and `ClassGroup.relNorm_mk0'`.
+`ClassGroup.relNorm_mk0` and `ClassGroup.relNorm_mk0'`; and, for the extension direction,
+`map0`, `mk0CompMap0`, `mk0CompMap0_apply`, `mk0CompMap0_eq_of_mk0_eq`, `ClassGroup.map`,
+`ClassGroup.map_mk0` and `ClassGroup.relNorm_comp_map`.
 
 Deviations from the source. It descends by `Function.surjInv` on `ClassGroup.mk0_surjective`, with
 `Function.surjInv_eq` rewrites discharging `map_one'` and `map_mul'`; the congruence route used
@@ -45,6 +54,19 @@ alongside `IsDedekindDomain` for both rings, which are implied. Its intermediate
 `mk0CompRelNorm0` and that lemma's `_apply` are inlined, the well-definedness fact being stated
 directly about `mk0 ∘ relNorm0`. Finally its `relNorm_mk0'`, a restatement of `relNorm_mk0` with
 the membership proof spelled out inline, is not ported.
+
+The extension direction follows the same deviations, and two more. Its `ClassGroup.map` is renamed
+`ClassGroup.extend`: `map` is the standard name for the *ideal*-level operation this descends from,
+and a `ClassGroup.map` would collide with it on sight. Its `ClassGroup.map_one` and
+`ClassGroup.map_mul` are not ported — both are `map_one`/`map_mul` applied to a bundled
+`MonoidHom`, so they restate what the bundling already gives.
+
+Its `Ideal.relNorm_map_algebraMap` is **not** ported either, and this is not a deviation of taste:
+that lemma converts `Ideal.relNorm_algebraMap`'s exponent from
+`Module.finrank (FractionRing R) (FractionRing S)` to `Module.finrank R S`. In the Mathlib pinned
+here `Ideal.relNorm_algebraMap` already concludes `= I ^ Module.finrank R S`, so the conversion is
+a no-op and the lemma performing it (`finrank_of_isFractionRing`) is deprecated. The source itself
+says the arithmetic core "is already available in mathlib as `Ideal.relNorm_algebraMap`".
 -/
 
 public section
@@ -116,5 +138,94 @@ theorem relNorm_mk0 (I : (Ideal S)⁰) :
     (MulEquiv.symm_apply_eq _).mpr rfl
   rw [relNorm, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, h]
   rfl
+
+variable (S) in
+omit [Module.Finite R S] in
+/-- The extension of an integral ideal along `algebraMap R S`, restricted to nonzero ideals.
+
+Extension reflects `⊥` because `algebraMap R S` is injective
+(`Ideal.map_eq_bot_iff_of_injective`), which is what keeps it inside `(Ideal S)⁰`. -/
+noncomputable def _root_.Ideal.extend0 : (Ideal R)⁰ →* (Ideal S)⁰ where
+  toFun I := ⟨Ideal.map (algebraMap R S) (I : Ideal R), by
+    rw [mem_nonZeroDivisors_iff_ne_zero, ne_eq, ← bot_eq_zero,
+      Ideal.map_eq_bot_iff_of_injective (FaithfulSMul.algebraMap_injective R S), bot_eq_zero,
+      ← ne_eq, ← mem_nonZeroDivisors_iff_ne_zero]
+    exact I.2⟩
+  map_one' := by ext; simp [Ideal.one_eq_top, Ideal.map_top]
+  map_mul' I J := by ext; simp [Ideal.map_mul]
+
+omit [Module.Finite R S] in
+@[simp]
+theorem _root_.Ideal.coe_extend0 (I : (Ideal R)⁰) :
+    (Ideal.extend0 S I : Ideal S) = Ideal.map (algebraMap R S) (I : Ideal R) :=
+  (rfl)
+
+omit [Module.Finite R S] in
+/-- **Well-definedness of the class-group extension**: integral ideals with the same class have
+extensions with the same class.
+
+By `ClassGroup.mk0_eq_mk0_iff` the hypothesis says `span {x} * I = span {y} * J` for nonzero
+`x y : R`. Extension is multiplicative and carries `span {x}` to `span {algebraMap R S x}`
+(`Ideal.map_span`), and those generators stay nonzero because `algebraMap R S` is injective. -/
+private theorem mk0_extend0_eq_of_mk0_eq {I J : (Ideal R)⁰}
+    (h : ClassGroup.mk0 I = ClassGroup.mk0 J) :
+    ClassGroup.mk0 (Ideal.extend0 S I) = ClassGroup.mk0 (Ideal.extend0 S J) := by
+  have hinj := FaithfulSMul.algebraMap_injective R S
+  rw [ClassGroup.mk0_eq_mk0_iff] at h
+  obtain ⟨x, y, hx, hy, hxy⟩ := h
+  have hspan : ∀ a : R, Ideal.span {algebraMap R S a}
+      = Ideal.map (algebraMap R S) (Ideal.span {a}) := fun a => by
+    rw [Ideal.map_span, Set.image_singleton]
+  refine ClassGroup.mk0_eq_mk0_iff.mpr ⟨algebraMap R S x, algebraMap R S y,
+    (map_ne_zero_iff _ hinj).mpr hx, (map_ne_zero_iff _ hinj).mpr hy, ?_⟩
+  rw [Ideal.coe_extend0, Ideal.coe_extend0, hspan x, hspan y, ← Ideal.map_mul, ← Ideal.map_mul,
+    hxy]
+
+omit [Module.Finite R S] in
+/-- The **extension map on class groups**, induced by `Ideal.map (algebraMap R S)`.
+
+The partner of `ClassGroup.relNorm` in the other direction, descended the same way: every class has
+an integral representative and the class of the extension does not depend on which. -/
+noncomputable def extend : ClassGroup R →* ClassGroup S :=
+  ((Con.ker (ClassGroup.mk0 (R := R))).lift ((ClassGroup.mk0 (R := S)).comp (Ideal.extend0 S))
+      fun _ _ h => mk0_extend0_eq_of_mk0_eq h).comp
+    (Con.quotientKerEquivOfSurjective _ ClassGroup.mk0_surjective).symm.toMonoidHom
+
+omit [Module.Finite R S] in
+/-- The extension of the class represented by a nonzero ideal `I` is the class represented by `I`'s
+extension. This is the computation rule for `ClassGroup.extend`. -/
+@[simp]
+theorem extend_mk0 (I : (Ideal R)⁰) :
+    extend (S := S) (ClassGroup.mk0 I) = ClassGroup.mk0 (Ideal.extend0 S I) := by
+  have h : (Con.quotientKerEquivOfSurjective _ ClassGroup.mk0_surjective).symm
+      (ClassGroup.mk0 (R := R) I) = (I : (Con.ker (ClassGroup.mk0 (R := R))).Quotient) :=
+    (MulEquiv.symm_apply_eq _).mpr rfl
+  rw [extend, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, h]
+  rfl
+
+/-- **Norm of an extended ideal is the `finrank`-th power**, on nonzero ideals: the
+`(Ideal R)⁰`-level form of Mathlib's `Ideal.relNorm_algebraMap`, which supplies the whole
+arithmetic content. -/
+theorem _root_.Ideal.relNorm0_extend0 (I : (Ideal R)⁰) :
+    Ideal.relNorm0 R (Ideal.extend0 S I) = I ^ Module.finrank R S := by
+  refine Subtype.ext ?_
+  rw [Ideal.coe_relNorm0, Ideal.coe_extend0, SubmonoidClass.coe_pow]
+  exact Ideal.relNorm_algebraMap S (I : Ideal R)
+
+/-- **Extending a class and taking its relative norm raises it to the `finrank`-th power.**
+
+Mathlib's `Ideal.relNorm_algebraMap` needs no separability, Galois or perfect-field hypothesis, so
+neither does this. -/
+theorem relNorm_extend (c : ClassGroup R) :
+    relNorm (extend (S := S) c) = c ^ Module.finrank R S := by
+  obtain ⟨I, rfl⟩ := ClassGroup.mk0_surjective c
+  rw [extend_mk0, relNorm_mk0, Ideal.relNorm0_extend0]
+  exact map_pow ClassGroup.mk0 I (Module.finrank R S)
+
+/-- `ClassGroup.relNorm_extend` as an identity of monoid homomorphisms. -/
+theorem relNorm_comp_extend :
+    (relNorm (R := R)).comp (extend (S := S)) = powMonoidHom (Module.finrank R S) := by
+  ext c
+  rw [MonoidHom.comp_apply, powMonoidHom_apply, relNorm_extend]
 
 end ClassGroup

--- a/TauCeti/RingTheory/ClassGroup/RelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/RelNorm.lean
@@ -137,6 +137,7 @@ theorem relNorm_mk0 (I : (Ideal S)⁰) :
 /-- **Norm of an extended ideal is the `finrank`-th power**, on nonzero ideals: the
 `(Ideal R)⁰`-level form of Mathlib's `Ideal.relNorm_algebraMap`, against Mathlib's
 `ClassGroup.extendedIdeal`. -/
+@[simp]
 theorem _root_.Ideal.relNorm0_extendedIdeal (I : (Ideal R)⁰) :
     Ideal.relNorm0 R (ClassGroup.extendedIdeal R S I) = I ^ Module.finrank R S := by
   refine Subtype.ext ?_
@@ -148,6 +149,7 @@ theorem _root_.Ideal.relNorm0_extendedIdeal (I : (Ideal R)⁰) :
 The extension direction is Mathlib's `ClassGroup.extendedHom`; the arithmetic is Mathlib's
 `Ideal.relNorm_algebraMap`, which needs no separability, Galois or perfect-field hypothesis, so
 neither does this. Only the composite with `relNorm` is new. -/
+@[simp]
 theorem relNorm_extendedHom (c : ClassGroup R) :
     relNorm (ClassGroup.extendedHom R S c) = c ^ Module.finrank R S := by
   obtain ⟨I, rfl⟩ := ClassGroup.mk0_surjective c


### PR DESCRIPTION
`ClassGroup.relNorm` has had no partner in the other direction. Mathlib supplies the extension
direction; this adds the composite that makes the pair useful.

```lean
theorem Ideal.relNorm0_extendedIdeal (I : (Ideal R)⁰) :
    Ideal.relNorm0 R (ClassGroup.extendedIdeal R S I) = I ^ Module.finrank R S

theorem ClassGroup.relNorm_extendedHom (c : ClassGroup R) :
    relNorm (ClassGroup.extendedHom R S c) = c ^ Module.finrank R S

theorem ClassGroup.relNorm_comp_extendedHom :
    (relNorm (R := R)).comp (ClassGroup.extendedHom R S) = powMonoidHom (Module.finrank R S)
```

`relNorm_extendedHom` is the arithmetic core, on ideal classes, of the dual relation
`φ̂ ∘ φ = [deg φ]`.

## Absence check

Stated with counts so the numbers reproduce. Over `origin/main`, `TauCeti/**/*.lean`, line-anchored
patterns and no `\b`:

| name | declarations | textual mentions |
|---|---|---|
| `relNorm_comp_map` | 0 | 0 |
| `relNorm_map_algebraMap` | 0 | 0 |
| `extendedRelNormHom` | 0 | 0 |
| `relNorm_mk0` (positive control) | 1 | — |

**That table is where I went wrong, and `reuse` blocked the first version of this PR for it.** I
also checked `ClassGroup.map` and found nothing, and concluded the extension direction was absent.
It is present, as **`ClassGroup.extendedHom`** in `Mathlib/RingTheory/ClassGroup/ExtendedHom.lean`,
with `ClassGroup.extendedIdeal` and `ClassGroup.extendedHom_mk0` beside it. I searched the right
corpus for the *source's* name instead of for the concept, so the first version reimplemented all
three. They are now deleted and the statements are against Mathlib's API.

The roadmap even names it `ClassGroup.extendedRelNormHom` — the word "extended" was in the text
quoted below the whole time.

## What is not ported, and why

The source's whole extension direction — `map0`, `mk0CompMap0`, `ClassGroup.map`,
`ClassGroup.map_mk0`, `map_one`, `map_mul` — is Mathlib's `extendedIdeal` / `extendedHom` /
`extendedHom_mk0`, so none of it is here.

Its `Ideal.relNorm_map_algebraMap` is not ported either, for a different reason: it converts
`Ideal.relNorm_algebraMap`'s exponent from `Module.finrank (FractionRing R) (FractionRing S)` to
`Module.finrank R S`, and against the pinned Mathlib `relNorm_algebraMap` already concludes in the
latter form while the converting lemma `finrank_of_isFractionRing` is deprecated.

What is left is the composite. It cannot be upstream because it mentions `ClassGroup.relNorm`,
which is this file's rather than Mathlib's.

## Scope

The Layer-1 "points come along" bullet of `TauCetiRoadmap/EllipticCurves/README.md` names this
directly: the homomorphism property of `toPointHom` "is exactly as strong as the
**extended-relative-norm API** (`ClassGroup.extendedRelNormHom` and its commutative-algebra
supports), which is therefore part of this bullet's obligations".

This is those supports. It is pure commutative algebra over Dedekind domains — no elliptic curve,
no isogeny, no dependency on the intermediate-ring work in #3347 — which is why it can land
independently of it.

**There is no in-repo call site yet**, and I would rather say so than imply otherwise. The consumer
is `pushClass`/`toPointHom`, later slices of the same bullet. This is the #2860/#2878 prerequisite
shape, whose adjudicated precedent is that a prerequisite may land ahead of its consumer.

## Provenance

Adapted from the AINTLIB `HasseWeil` project (Apache-2.0), revision `513e83879e2f`, file
`HasseWeil/Pic0/ClassGroupNorm.lean`. Of that file's extension-and-composite block, the only
declarations that land here are `ClassGroup.relNorm_comp_map` and `ClassGroup.relNorm_comp_map_eq`,
respelt `relNorm_extendedHom` / `relNorm_comp_extendedHom` against Mathlib's `extendedHom`, plus
their `(Ideal R)⁰`-level step. The rest of the source block — `map0`, `mk0CompMap0`,
`mk0CompMap0_apply`, `mk0CompMap0_eq_of_mk0_eq`, `ClassGroup.map`, `ClassGroup.map_mk0`,
`ClassGroup.map_one`, `ClassGroup.map_mul` and `Ideal.relNorm_map_algebraMap` — is **not** ported,
for the two reasons above. The file's Provenance section records the same.

## Review state

No scoreboard: both codex subscriptions on this machine are out of quota, so no rubric verdicts can
be produced locally, and `/taupr` pins reviews to codex for independence (Claude wrote the Lean).
Round 1 produced a `reuse` **block**, addressed above; the other eight rubrics had not yet run when
it landed. Local gates on the current head: `lake build` PASS (7925 jobs), no `sorry`, no
`maxHeartbeats`, no `haveI`/`letI`, nothing over 100 codepoints, single-file merge-base diff.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"classgroup-relnorm-extendedhom-finrank"}-->

🤖 Prepared with Claude Code (Claude Opus 5)

