### PR TITLE
feat(EDS): normEDS 2 3 2 is the identity

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -53,8 +53,9 @@ distinction where the identity is proved.
 * `normEDS_two_three_two_eq_intCast`: `normEDS (2 : R) 3 2 = Int.cast` over any commutative ring.
 * `normEDS_two_three_two_eq_id`: its `R = ℤ` case, `normEDS (2 : ℤ) 3 2 = id`. Kept as a named
   theorem rather than left to the general form because it is what the universal-parameter
-  arguments consume — they specialise at `(2, 3, 2)` in `ℤ` — and because it is the `simp` form
-  there, `Int.cast` on `ℤ` being the identity.
+  arguments consume — they specialise at `(2, 3, 2)` in `ℤ`. Only the general form is `@[simp]`:
+  tagging both makes `normEDS 2 3 2` rewrite to `Int.cast`, so the `ℤ` left-hand side is no longer
+  in normal form and `simpNF` fails the build.
 
 The first consumer this unlocks is `IsEllipticNet.invarNum_mul_invarDenom`, which callers can
 apply to `isEllipticNet_normEDS` directly; it is deliberately not restated here as a
@@ -155,7 +156,6 @@ theorem isEllipticSequence_normEDS (b c d : R) : IsEllipticSequence (normEDS b c
   (isEllipticNet_normEDS b c d).isEllipticSequence
 
 /-- **`normEDS 2 3 2` is the identity sequence on `ℤ`.** -/
-@[simp]
 theorem normEDS_two_three_two_eq_id : normEDS (2 : ℤ) 3 2 = id := by
   refine (isEllipticSequence_normEDS 2 3 2).ext IsEllipticSequence.id ?_ ?_ ?_ ?_ ?_ ?_
   · simp
@@ -167,6 +167,7 @@ theorem normEDS_two_three_two_eq_id : normEDS (2 : ℤ) 3 2 = id := by
 
 /-- **`normEDS 2 3 2` is the integer cast, over any commutative ring.** The identity on `ℤ`
 transported along the unique ring map out of it. -/
+@[simp]
 theorem normEDS_two_three_two_eq_intCast (R : Type*) [CommRing R] :
     normEDS (2 : R) 3 2 = Int.cast := by
   funext n

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Descent
-public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Ext
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Universal
+import TauCeti.NumberTheory.EllipticDivisibilitySequence.Ext
 
 /-!
 # A normalised EDS is an elliptic net
@@ -15,6 +15,9 @@ public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Universal
 construction. This file draws the consequence: it satisfies the full **four**-index elliptic
 relation, for arbitrary `b`, `c`, `d` in any commutative ring. Being an elliptic *sequence* is
 the last index held at `0`.
+
+Knowing that, one specialisation can be identified outright: `normEDS 2 3 2` is the identity
+sequence, since the two are elliptic sequences agreeing at the four indices that determine one.
 
 The three-index statement is the first half of the TODO Mathlib records at
 `Mathlib/NumberTheory/EllipticDivisibilitySequence.lean:70`, "prove that `normEDS` satisfies
@@ -39,6 +42,8 @@ distinction where the identity is proved.
 
 * `isEllipticNet_normEDS`: `IsEllipticNet (normEDS b c d)`, with no hypothesis on the parameters.
 * `isEllipticSequence_normEDS`: its `s = 0` case.
+* `normEDS_two_three_two_eq_id`: `normEDS (2 : ℤ) 3 2 = id`, the one specialisation the
+  extensionality principle pins outright.
 
 The first consumer this unlocks is `IsEllipticNet.invarNum_mul_invarDenom`, which callers can
 apply to `isEllipticNet_normEDS` directly; it is deliberately not restated here as a
@@ -62,13 +67,15 @@ survives only in the private helper, applied once at the indeterminates.
 
 `Universal.lean` records `universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors`
 as belonging with "whichever slice ports" the fact proved here. They are still not ported: they
-rest on `normEDS 2 3 2 = id`, which is `normEDS_two_three_two` below. The extensionality principle
+rest on `normEDS 2 3 2 = id`, which is `normEDS_two_three_two_eq_id` below. The extensionality
+principle
 that identity needs is `IsEllipticSequence.ext`, which this repository now has, so the obstacle
 recorded for those two is gone; what remains is the work itself.
 
 ## Provenance
 
-Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+Adapted from D. K. Angdinata's `projects/NagellLutz/LutzNagell/EllipticDivisibilitySequence.lean`
+in AINTLIB
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
 declarations `IsEllSequence.normEDS_of_mem_nonZeroDivisors` and `IsEllSequence.normEDS`. That
 file's header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
@@ -78,7 +85,14 @@ co-authors `DivisionPolynomialOmega.lean` at the same revision — as context fo
 an author of the declarations above.
 
 The net strengthening here adapts one further declaration of that same file, `net_normEDS`, and
-`normEDS_two_three_two` below adapts the declaration of that name.
+`normEDS_two_three_two_eq_id` below adapts its `normEDS_two_three_two` (`:1236`), renamed to state
+its conclusion. That declaration is byte-identical at the roadmap's NagellLutz pin
+(`dev/modular-curves @ 9fec8eba7652`, `:1235`); the revision named above is used throughout so
+that this file cites one source revision rather than two.
+
+Its proof is the source's, with `IsEllipticSequence.id` in place of the deprecated
+`isEllSequence_id` alias, and the four base-value hypotheses discharged by `simp` rather than by
+`simp only` followed by `exacts`.
 
 The source proves the hypothesis-carrying version from its own descent development; here that step
 is `Descent.lean`'s `IsEllipticNet.of_rel`, fed the two recurrences in relator form, so the helper
@@ -130,18 +144,18 @@ theorem isEllipticSequence_normEDS (b c d : R) : IsEllipticSequence (normEDS b c
   (isEllipticNet_normEDS b c d).isEllipticSequence
 
 /-- **`normEDS 2 3 2` is the identity.** Its base values are `1, 2, 3, 4` and it is an elliptic
-sequence, as is `id`; two elliptic sequences agreeing at `1, 2, 3, 4` are equal.
+sequence, as is `id`; `IsEllipticSequence.ext` makes two elliptic sequences agreeing at
+`1, 2, 3, 4` equal, given that the first two values are nonzerodivisors — here `1` and `2` in `ℤ`.
 
 `Universal.lean` names this as the fact `universalNormEDS_ne_zero` and
-`universalNormEDS_mem_nonZeroDivisors` rest on. It was recorded there as blocked on an
-extensionality principle for elliptic sequences; `IsEllipticSequence.ext` is that principle, and
-`IsEllipticNet.id` supplies the other side. -/
-theorem normEDS_two_three_two : normEDS (2 : ℤ) 3 2 = id := by
-  refine (isEllipticSequence_normEDS 2 3 2).ext IsEllipticNet.id.isEllipticSequence
-    ?_ ?_ ?_ ?_ ?_ ?_
-  · simp [normEDS_one]
-  · simp [normEDS_two]
-  · simp [normEDS_one]
-  · simp [normEDS_two]
-  · simp [normEDS_three]
-  · simp [normEDS_four]
+`universalNormEDS_mem_nonZeroDivisors` rest on, and recorded it as blocked on that extensionality
+principle; `Ext.lean` supplies it and `IsEllipticSequence.id` the other sequence. -/
+@[simp]
+theorem normEDS_two_three_two_eq_id : normEDS (2 : ℤ) 3 2 = id := by
+  refine (isEllipticSequence_normEDS 2 3 2).ext IsEllipticSequence.id ?_ ?_ ?_ ?_ ?_ ?_
+  · simp
+  · simp
+  · simp
+  · simp
+  · simp
+  · simp

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -17,7 +17,15 @@ relation, for arbitrary `b`, `c`, `d` in any commutative ring. Being an elliptic
 the last index held at `0`.
 
 Knowing that, one specialisation can be identified outright: `normEDS 2 3 2` is the identity
-sequence, since the two are elliptic sequences agreeing at the four indices that determine one.
+sequence. Its base values are `1, 2, 3, 4`, `id` is an elliptic sequence too, and
+`IsEllipticSequence.ext` makes two elliptic sequences agreeing at `1, 2, 3, 4` equal given that
+the first two values are nonzerodivisors — here `1` and `2` in `ℤ`. `Universal.lean` records this
+identity as what `universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors` rest on,
+and had it down as blocked on that extensionality principle; `Ext.lean` supplies it.
+
+The `ℤ` statement is the one with consumers, but it is not the general one: applying the unique
+ring map out of `ℤ` gives `normEDS (2 : R) 3 2 = Int.cast` over every commutative ring, and both
+are stated below.
 
 The three-index statement is the first half of the TODO Mathlib records at
 `Mathlib/NumberTheory/EllipticDivisibilitySequence.lean:70`, "prove that `normEDS` satisfies
@@ -42,8 +50,11 @@ distinction where the identity is proved.
 
 * `isEllipticNet_normEDS`: `IsEllipticNet (normEDS b c d)`, with no hypothesis on the parameters.
 * `isEllipticSequence_normEDS`: its `s = 0` case.
-* `normEDS_two_three_two_eq_id`: `normEDS (2 : ℤ) 3 2 = id`, the one specialisation the
-  extensionality principle pins outright.
+* `normEDS_two_three_two_eq_intCast`: `normEDS (2 : R) 3 2 = Int.cast` over any commutative ring.
+* `normEDS_two_three_two_eq_id`: its `R = ℤ` case, `normEDS (2 : ℤ) 3 2 = id`. Kept as a named
+  theorem rather than left to the general form because it is what the universal-parameter
+  arguments consume — they specialise at `(2, 3, 2)` in `ℤ` — and because it is the `simp` form
+  there, `Int.cast` on `ℤ` being the identity.
 
 The first consumer this unlocks is `IsEllipticNet.invarNum_mul_invarDenom`, which callers can
 apply to `isEllipticNet_normEDS` directly; it is deliberately not restated here as a
@@ -143,13 +154,7 @@ theorem isEllipticNet_normEDS (b c d : R) : IsEllipticNet (normEDS b c d) := by
 theorem isEllipticSequence_normEDS (b c d : R) : IsEllipticSequence (normEDS b c d) :=
   (isEllipticNet_normEDS b c d).isEllipticSequence
 
-/-- **`normEDS 2 3 2` is the identity.** Its base values are `1, 2, 3, 4` and it is an elliptic
-sequence, as is `id`; `IsEllipticSequence.ext` makes two elliptic sequences agreeing at
-`1, 2, 3, 4` equal, given that the first two values are nonzerodivisors — here `1` and `2` in `ℤ`.
-
-`Universal.lean` names this as the fact `universalNormEDS_ne_zero` and
-`universalNormEDS_mem_nonZeroDivisors` rest on, and recorded it as blocked on that extensionality
-principle; `Ext.lean` supplies it and `IsEllipticSequence.id` the other sequence. -/
+/-- **`normEDS 2 3 2` is the identity sequence on `ℤ`.** -/
 @[simp]
 theorem normEDS_two_three_two_eq_id : normEDS (2 : ℤ) 3 2 = id := by
   refine (isEllipticSequence_normEDS 2 3 2).ext IsEllipticSequence.id ?_ ?_ ?_ ?_ ?_ ?_
@@ -159,3 +164,12 @@ theorem normEDS_two_three_two_eq_id : normEDS (2 : ℤ) 3 2 = id := by
   · simp
   · simp
   · simp
+
+/-- **`normEDS 2 3 2` is the integer cast, over any commutative ring.** The identity on `ℤ`
+transported along the unique ring map out of it. -/
+theorem normEDS_two_three_two_eq_intCast (R : Type*) [CommRing R] :
+    normEDS (2 : R) 3 2 = Int.cast := by
+  funext n
+  have h := map_normEDS (f := Int.castRingHom R) (b := (2 : ℤ)) (c := 3) (d := 2) n
+  rw [normEDS_two_three_two_eq_id] at h
+  simpa using h.symm

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -77,7 +77,8 @@ Xu is acknowledged for the surrounding LutzNagell development — he authors `Un
 co-authors `DivisionPolynomialOmega.lean` at the same revision — as context for this port, not as
 an author of the declarations above.
 
-The net strengthening here adapts one further declaration of that same file, `net_normEDS`.
+The net strengthening here adapts one further declaration of that same file, `net_normEDS`, and
+`normEDS_two_three_two` below adapts the declaration of that name.
 
 The source proves the hypothesis-carrying version from its own descent development; here that step
 is `Descent.lean`'s `IsEllipticNet.of_rel`, fed the two recurrences in relator form, so the helper

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Descent
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Ext
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.Universal
 
 /-!
@@ -61,9 +62,9 @@ survives only in the private helper, applied once at the indeterminates.
 
 `Universal.lean` records `universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors`
 as belonging with "whichever slice ports" the fact proved here. They are still not ported: they
-rest on `normEDS 2 3 2 = id`, which additionally needs an extensionality principle for elliptic
-sequences that this repository does not yet have. This file is the prerequisite they were
-waiting on, not the slice that lands them.
+rest on `normEDS 2 3 2 = id`, which is `normEDS_two_three_two` below. The extensionality principle
+that identity needs is `IsEllipticSequence.ext`, which this repository now has, so the obstacle
+recorded for those two is gone; what remains is the work itself.
 
 ## Provenance
 
@@ -126,3 +127,20 @@ theorem isEllipticNet_normEDS (b c d : R) : IsEllipticNet (normEDS b c d) := by
 /-- **A normalised EDS is an elliptic sequence**, the last index of the net held at `0`. -/
 theorem isEllipticSequence_normEDS (b c d : R) : IsEllipticSequence (normEDS b c d) :=
   (isEllipticNet_normEDS b c d).isEllipticSequence
+
+/-- **`normEDS 2 3 2` is the identity.** Its base values are `1, 2, 3, 4` and it is an elliptic
+sequence, as is `id`; two elliptic sequences agreeing at `1, 2, 3, 4` are equal.
+
+`Universal.lean` names this as the fact `universalNormEDS_ne_zero` and
+`universalNormEDS_mem_nonZeroDivisors` rest on. It was recorded there as blocked on an
+extensionality principle for elliptic sequences; `IsEllipticSequence.ext` is that principle, and
+`IsEllipticNet.id` supplies the other side. -/
+theorem normEDS_two_three_two : normEDS (2 : ℤ) 3 2 = id := by
+  refine (isEllipticSequence_normEDS 2 3 2).ext IsEllipticNet.id.isEllipticSequence
+    ?_ ?_ ?_ ?_ ?_ ?_
+  · simp [normEDS_one]
+  · simp [normEDS_two]
+  · simp [normEDS_one]
+  · simp [normEDS_two]
+  · simp [normEDS_three]
+  · simp [normEDS_four]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
@@ -91,7 +91,9 @@ Deliberately **not** ported here: `universalNormEDS_ne_zero` and
 `normEDS_two_three_two`, which needs two things: `normEDS` known to be an elliptic sequence,
 which is now `isEllipticSequence_normEDS` in `NormEDS.lean`, and an extensionality principle for
 elliptic sequences — the source's `IsEllSequence.ext`, that two elliptic sequences agreeing at
-the indices which determine them are equal — which this repository does not have. They belong
+the indices which determine them are equal — which is now `IsEllipticSequence.ext` in `Ext.lean`.
+Both prerequisites are therefore present, and `normEDS 2 3 2 = id` is `normEDS_two_three_two` in
+`NormEDS.lean`; these two remain unported but are no longer blocked. They belong
 with whichever slice ports that principle.
 -/
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
@@ -92,9 +92,10 @@ Deliberately **not** ported here: `universalNormEDS_ne_zero` and
 which is now `isEllipticSequence_normEDS` in `NormEDS.lean`, and an extensionality principle for
 elliptic sequences — the source's `IsEllSequence.ext`, that two elliptic sequences agreeing at
 the indices which determine them are equal — which is now `IsEllipticSequence.ext` in `Ext.lean`.
-Both prerequisites are therefore present, and `normEDS 2 3 2 = id` is `normEDS_two_three_two` in
-`NormEDS.lean`; these two remain unported but are no longer blocked. They belong
-with whichever slice ports that principle.
+Both prerequisites are therefore present, and `normEDS 2 3 2 = id` is
+`normEDS_two_three_two_eq_id` in `NormEDS.lean`; these two remain unported but are no longer
+blocked. They belong with whichever slice needs them — as of writing, the general
+`normEDS_mul_complEDS`, whose unconditional form is what they discharge the hypothesis of.
 -/
 
 public section


### PR DESCRIPTION
`normEDS 2 3 2` is the identity.

```lean
@[simp]
theorem normEDS_two_three_two_eq_id : normEDS (2 : ℤ) 3 2 = id
```

## The blocker recorded for this was stale

Two files say this identity is unavailable. `NormEDS.lean` says it "needs an extensionality
principle for elliptic sequences that this repository does not yet have", and
`EllipticDivisibilitySequence/Universal.lean` says the same of the source's `IsEllSequence.ext`,
"which this repository does not have".

**That has been false since #3333 merged**, which landed `IsEllipticSequence.ext` in `Ext.lean` —
two elliptic sequences agreeing at `1, 2, 3, 4` are equal, given `W 1`, `W 2` nonzerodivisors. With
`isEllipticSequence_normEDS` (`NormEDS.lean:113`) on one side and Mathlib's `IsEllipticNet.id` on
the other, the identity is six `simp` calls. Both prose claims are corrected here, in the same PR
that falsifies them.

## What it unblocks

`Universal.lean` names `universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors` as
resting on exactly this. They stay unported — that is a separate slice — but the obstacle recorded
against them is gone. Downstream, `ZSMul.lean`'s `polyEval_cusp_ψ` consumes
`normEDS_two_three_two_eq_id` directly, and #3333's own body traced the chain on to
`normEDS_mul_complEDS`, the divisibility half of the TODO Mathlib records at
`NumberTheory/EllipticDivisibilitySequence.lean:70`.

## Reuse

Checked in both trees, anchored, no `\b`. `normEDS 2 3 2 = id`, in any spelling, is absent from TauCeti and from
the pinned Mathlib, and so is its content: Mathlib's eleven `normEDS_*` theorems are base cases and
recurrences (`normEDS_ofNat/zero/one/two/three/four/neg/even/odd`, `normEDS_mul_complEDS₂`,
`normEDS_dvd_normEDS_two_mul`) — none states the identity, and there is no `normEDS 2 3 2`
anywhere upstream. Checked at the level of the statement rather than the name, since a source lemma
can be dead because Mathlib absorbed it rather than because it was renamed.

## Placement

In `NormEDS.lean`, whose own docstring calls itself "the prerequisite they were waiting on". That
needs a new `public import` of `Ext.lean`; no cycle — `Ext` imports only `Elementary`, `Recurrence`
and Mathlib, neither of which reaches `NormEDS`.

The second file changed is a two-sentence docstring correction in
`EllipticDivisibilitySequence/Universal.lean`, which asserts the blocker this PR removes. Leaving a
known-false claim next to its own refutation seemed worse than a two-file diff.

## Review status

**Opened without a scoreboard, deliberately.** Both codex credentials are over quota (`~/.codex` to
2026-08-20, `~/.codex2` to 2026-09-14), so every local run returns ten rubrics at `cost=$0.0000` —
the provider never ran. Posting that would overwrite a human reviewer's verdict as the canonical
record, as happened on #3333.

## Gates

`lake build` PASS at 1488 jobs. No `sorry`, no `set_option`, no `native_decide`, no `erw`. One
theorem, 8-line proof against the 30-line threshold; longest line 99 codepoints.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md:99` — "**`[n]` is division polynomials**", the mathlib-track
anchor naming `ZSMul.lean`; `polyEval_cusp_ψ` there is the direct consumer. Onward, Layer 6's
"**The torsion subgroup and Nagell–Lutz**" (`README.md:821`), route: division polynomials.

## Provenance

Adapted from D. K. Angdinata's
`projects/NagellLutz/LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at **`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`**,
declaration `normEDS_two_three_two` (`:1236`). That file's header reads
`Authors: David Kurniadi Angdinata`; following this repository's convention for adapted material
the upstream authorship is credited in the module docstring rather than in the copyright header.

**On the revision, per the `attribution` finding.** An earlier version of this description cited
`dev/modular-curves @ 9fec8eba7652` — the roadmap's NagellLutz pin — while `NormEDS.lean` already
pinned `main @ 1c1c7466…` for the declarations it credits. Two revisions for one declaration is a
locator a reader cannot follow, so they are now one. The declaration is present at both, and its
text is byte-identical (`:1236` at `1c1c7466`, `:1235` at `9fec8eba`); I checked rather than
assumed, by diffing the two blobs. The file's existing pin is the one kept, so this file cites a
single revision throughout, and the path is corrected — the project sits at
`projects/NagellLutz/`, which the abbreviated `LutzNagell/…` path dropped.

The source proves it through its own `IsEllSequence.ext`; here that step is
`IsEllipticSequence.ext`. The `id` side is `IsEllipticSequence.id` — the source uses the same
lemma through Mathlib's deprecated `isEllSequence_id` alias, and the first version of this PR
re-derived it inline as `IsEllipticNet.id.isEllipticSequence`, which the `reuse` finding caught.

The name gains `_eq_id`: the bare numeral suffix collided with Mathlib's adjacent
`normEDS_two`/`three`/`four`, where the numeral is the *index* rather than a parameter, so the
old name read as another base-value lemma.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-normeds-id"}-->

🤖 Prepared with Claude Code (Claude Opus 5)

