### PR TITLE
feat(Spa): the containment criterion for rational subsets

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -124,6 +124,27 @@ theorem rationalSubset_subset_spa (Aplus : Subring A) (T : Finset A) (s : A) :
     rationalSubset Aplus T s ⊆ spa Aplus :=
   rationalSubset_def Aplus T s ▸ Set.inter_subset_left
 
+/-- **The containment criterion for rational subsets.** One rational subset is contained in
+another exactly when, at every point of the smaller, the larger one's numerators are dominated
+by its denominator and that denominator is off the support.
+
+Containment in `spa A⁺` is automatic on both sides, so it drops out of the criterion: only the
+`T`-over-`s` conditions are left to check. This is the set-level input to Wedhorn's comparison of
+two presentations (§8.2) — it says *which* valuation-theoretic facts a containment gives you,
+leaving the passage from those facts to invertibility of `s` and power-boundedness of `t/s` in
+the coordinate ring as a separate, genuinely algebraic step. -/
+theorem rationalSubset_subset_rationalSubset_iff (Aplus : Subring A) (T T' : Finset A)
+    (s s' : A) :
+    rationalSubset Aplus T' s' ⊆ rationalSubset Aplus T s ↔
+      ∀ v ∈ rationalSubset Aplus T' s',
+        (∀ t ∈ T, v.toValuativeRel.vle t s) ∧ ¬ v.toValuativeRel.vle s 0 := by
+  constructor
+  · intro h v hv
+    exact ((mem_rationalSubset_iff Aplus T s v).mp (h hv)).2
+  · intro h v hv
+    exact (mem_rationalSubset_iff Aplus T s v).mpr
+      ⟨rationalSubset_subset_spa Aplus T' s' hv, (h v hv).1, (h v hv).2⟩
+
 open scoped Classical in
 /-- Inserting the denominator among the numerators changes nothing — Wedhorn's "one may
 replace `T` by `T ∪ {s}`" (Definition 7.29). -/


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"rational-subset-containment"}-->

Part of TauCetiProject/TauCetiRoadmap#174.

**When is one rational subset contained in another?**

`rationalSubset_subset_rationalSubset_iff`: `R(T'/s') ⊆ R(T/s)` exactly when, at every point of
`R(T'/s')`, each `t ∈ T` is dominated by `s` and `s` is off the support. Containment in
`spa A⁺` holds on both sides, so it drops out and only the `T`-over-`s` conditions remain.

It is placed immediately after `rationalSubset_subset_spa`, whose statement the reverse direction
consumes, and the proof is seven lines through `mem_rationalSubset_iff` in both directions.

## Why this exists

Comparing two presentations of the same rational subset (Wedhorn §8.2) needs to turn a set-level
relation between `R(T/s)` and `R(T'/s')` into algebraic facts about the coordinate rings — that
`s` becomes a unit in `A⟨T'/s'⟩` and each `t/s` power-bounded there. Nothing on `main` connects
rational-subset membership to either: `Spa/RationalSubset/` is entirely set-level and topological,
and there is no `IsUnit` criterion anywhere under `Spa/`.

This is the first half of that bridge, and **only** the first half. It says precisely which
valuation facts a containment hands you. Getting from those to invertibility and power-boundedness
is the genuinely algebraic step, and the docstring says so explicitly rather than letting the
lemma's name suggest presentation independence has been established.

Gates: `lake build` clean (7926 jobs, no warnings), `axioms` within the allowlist (47060
declarations), `module-system` clean (2251 modules), `lint-env` PASS.
