### PR TITLE
feat: preserve unipotence under products

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Product.lean
@@ -35,6 +35,8 @@ instances of pre-composition with the bialgebra morphisms from
 * `TauCeti.AffineGroup.Product.pointsMulEquiv`: the convolution monoid isomorphism between
   `(H₁ ⊗[R] H₂) →ₐ[R] A` and the product `(H₁ →ₐ[R] A) × (H₂ →ₐ[R] A)`. When `H₁` and `H₂` are
   Hopf algebras these are convolution groups, so this is automatically a group isomorphism.
+* `TauCeti.AffineGroup.Product.mapDomain_projectLeft` and `mapDomain_projectRight`: precomposition
+  with a tensor-product projection inserts a point into the corresponding product factor.
 * `TauCeti.AffineGroup.Product.pointsMulEquiv_mapValue`: the product-points equivalence is
   natural in the value algebra.
 
@@ -140,6 +142,42 @@ theorem pointsMulEquiv_symm_apply
     (p : WithConv (H₁ →ₐ[R] A) × WithConv (H₂ →ₐ[R] A)) :
     pointsMulEquiv.symm p = toConv (Algebra.TensorProduct.productMap p.1.ofConv p.2.ofConv) :=
   rfl
+
+/-- Precomposition with the left tensor-product projection inserts a point as the left factor of
+the product, with the identity in the right factor. -/
+@[simp]
+theorem mapDomain_projectLeft (g : WithConv (H₁ →ₐ[R] A)) :
+    toConv (g.ofConv.comp (Bialgebra.TensorProduct.projectLeft
+      (R := R) (H₁ := H₁) (H₂ := H₂)).toAlgHom) =
+      pointsMulEquiv.symm (g, 1) := by
+  apply WithConv.ofConv_injective
+  apply Algebra.TensorProduct.ext'
+  intro x y
+  -- Extensionality retains the coercions from `WithConv` and `BialgHom`; expose pointwise
+  -- evaluation so the pure-tensor formula for the projection can rewrite the goal.
+  change g.ofConv (Bialgebra.TensorProduct.projectLeft
+      (R := R) (H₁ := H₁) (H₂ := H₂) (x ⊗ₜ[R] y)) =
+    g.ofConv x * (1 : WithConv (H₂ →ₐ[R] A)) y
+  rw [Bialgebra.TensorProduct.projectLeft_tmul, map_smul, AlgHom.convOne_apply]
+  simp only [Algebra.smul_def]
+  exact mul_comm _ _
+
+/-- Precomposition with the right tensor-product projection inserts a point as the right factor of
+the product, with the identity in the left factor. -/
+@[simp]
+theorem mapDomain_projectRight (g : WithConv (H₂ →ₐ[R] A)) :
+    toConv (g.ofConv.comp (Bialgebra.TensorProduct.projectRight
+      (R := R) (H₁ := H₁) (H₂ := H₂)).toAlgHom) =
+      pointsMulEquiv.symm ((1 : WithConv (H₁ →ₐ[R] A)), g) := by
+  apply WithConv.ofConv_injective
+  apply Algebra.TensorProduct.ext'
+  intro x y
+  -- As above, expose pointwise evaluation across the two bundled coercions.
+  change g.ofConv (Bialgebra.TensorProduct.projectRight
+      (R := R) (H₁ := H₁) (H₂ := H₂) (x ⊗ₜ[R] y)) =
+    (1 : WithConv (H₁ →ₐ[R] A)) x * g.ofConv y
+  rw [Bialgebra.TensorProduct.projectRight_tmul, map_smul, AlgHom.convOne_apply]
+  rw [Algebra.smul_def]
 
 variable {B : Type*} [CommSemiring B] [Algebra R B]
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Product.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.Product
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+
+/-!
+# Products of smooth unipotent affine groups
+
+The tensor product of two commutative Hopf algebras is the coordinate algebra of the direct
+product of their affine group schemes. This file proves that the representation-theoretic
+unipotence condition is preserved and reflected by this product.
+
+For points `g` and `h` of the two factors, the corresponding product point factors as
+
+```text
+(g, h) = (g, 1) * (1, h).
+```
+
+The two factors commute. Each is unipotent because it is obtained from `g` or `h` by
+precomposition with the bialgebra projection that applies the counit to the other tensor factor.
+Thus their product is unipotent. Conversely, the two components of a unipotent product point are
+unipotent by precomposition with the coordinate inclusions.
+
+Combining this pointwise result with stability of smoothness and finite type under tensor products
+shows that direct products of smooth unipotent affine groups are smooth unipotent.
+
+## Main declarations
+
+* `TauCeti.HopfAlgebra.isUnipotentPoint_pointsMulEquiv_iff`: a product point is unipotent exactly
+  when both of its components are.
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.tensorProduct`: geometric-point
+  unipotence is closed under products.
+* `TauCeti.smoothUnipotentCommHopfAlgProperty.tensorProduct`: smooth unipotent finite-type affine
+  groups are closed under products.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+
+This advances Layer 5, "Unipotent groups", of the ReductiveGroups roadmap by establishing the
+basic product closure needed to assemble unipotent groups from simpler factors.
+-/
+
+public section
+
+open TensorProduct WithConv
+
+namespace TauCeti
+
+universe u v w
+
+namespace HopfAlgebra
+
+variable {k : Type u} [CommSemiring k]
+variable {H K : Type v} [CommSemiring H] [CommSemiring K]
+variable [_root_.HopfAlgebra k H] [_root_.HopfAlgebra k K]
+variable {A : Type w} [CommRing A] [Algebra k A]
+
+/-- A point of a product affine group is unipotent exactly when both factor points are
+unipotent. -/
+theorem isUnipotentPoint_pointsMulEquiv_iff
+    (g : WithConv ((H ⊗[k] K) →ₐ[k] A)) :
+    IsUnipotentPoint g ↔
+      IsUnipotentPoint (AffineGroup.Product.pointsMulEquiv g).1 ∧
+        IsUnipotentPoint (AffineGroup.Product.pointsMulEquiv g).2 := by
+  constructor
+  · intro hg
+    exact ⟨hg.mapDomain Bialgebra.TensorProduct.includeLeft,
+      hg.mapDomain Bialgebra.TensorProduct.includeRight⟩
+  · rintro ⟨hleft, hright⟩
+    let e := AffineGroup.Product.pointsMulEquiv
+      (R := k) (H₁ := H) (H₂ := K) (A := A)
+    let gleft := e.symm ((e g).1, 1)
+    let gright := e.symm (1, (e g).2)
+    have hgleft : IsUnipotentPoint gleft := by
+      have h := hleft.mapDomain (Bialgebra.TensorProduct.projectLeft
+        (R := k) (H₁ := H) (H₂ := K))
+      simpa only [AlgHom.mapDomain_apply, gleft, e,
+        AffineGroup.Product.mapDomain_projectLeft] using h
+    have hgright : IsUnipotentPoint gright := by
+      have h := hright.mapDomain (Bialgebra.TensorProduct.projectRight
+        (R := k) (H₁ := H) (H₂ := K))
+      simpa only [AlgHom.mapDomain_apply, gright, e,
+        AffineGroup.Product.mapDomain_projectRight] using h
+    have hcomm : Commute gleft gright := by
+      rw [commute_iff_eq]
+      apply e.injective
+      simp only [map_mul, e, gleft, gright, MulEquiv.apply_symm_apply]
+      ext <;> simp
+    have hfactor : g = gleft * gright := by
+      apply e.injective
+      simp only [map_mul, e, gleft, gright, MulEquiv.apply_symm_apply]
+      ext <;> simp
+    rw [hfactor]
+    exact hgleft.mul_of_commute hgright hcomm
+
+end HopfAlgebra
+
+namespace geometricallyUnipotentPointsCommHopfAlgProperty
+
+variable (k : Type u) [Field k]
+
+/-- The tensor product of two coordinate Hopf algebras with unipotent geometric points again has
+only unipotent geometric points. Contravariantly, geometric-point unipotence is closed under
+direct products of affine groups. -/
+theorem tensorProduct (H K : CommHopfAlgCat.{v} k)
+    (hH : geometricallyUnipotentPointsCommHopfAlgProperty k H)
+    (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k
+      (CommHopfAlgCat.of k (H ⊗[k] K)) := by
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hH hK ⊢
+  intro g
+  rw [HopfAlgebra.isUnipotentPoint_pointsMulEquiv_iff]
+  exact ⟨hH _, hK _⟩
+
+end geometricallyUnipotentPointsCommHopfAlgProperty
+
+namespace smoothUnipotentCommHopfAlgProperty
+
+variable (k : Type u) [Field k]
+
+/-- The tensor product of two smooth unipotent finite-type coordinate Hopf algebras is smooth
+unipotent. Contravariantly, direct products of smooth unipotent affine groups are smooth
+unipotent. -/
+theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, v} k)
+    (hH : smoothUnipotentCommHopfAlgProperty k H)
+    (hK : smoothUnipotentCommHopfAlgProperty k K) :
+    smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.tensorProduct H K) := by
+  rw [smoothUnipotentCommHopfAlgProperty_iff] at hH hK ⊢
+  let smoothH : Algebra.Smooth k H := hH.1
+  let smoothK : Algebra.Smooth k K := hK.1
+  let smoothOverH : Algebra.Smooth H (H ⊗[k] K) :=
+    @Algebra.Smooth.baseChange k _ K H _ _ _ _ smoothK
+  refine ⟨@Algebra.Smooth.comp k _ H (H ⊗[k] K) _ _ _ _ _ _
+    smoothH smoothOverH, ?_⟩
+  intro g
+  rw [HopfAlgebra.isUnipotentPoint_pointsMulEquiv_iff]
+  exact ⟨hH.2 _, hK.2 _⟩
+
+end smoothUnipotentCommHopfAlgProperty
+
+end TauCeti

--- a/TauCeti/Algebra/Bialgebra/TensorProduct.lean
+++ b/TauCeti/Algebra/Bialgebra/TensorProduct.lean
@@ -7,10 +7,11 @@ module
 public import Mathlib.RingTheory.Bialgebra.TensorProduct
 
 /-!
-# Bialgebra maps into tensor products
+# Canonical bialgebra maps for tensor products
 
-This file packages the canonical maps `x ↦ x ⊗ₜ 1` and `y ↦ 1 ⊗ₜ y` into a tensor product
-of bialgebras as bialgebra morphisms, and records their underlying algebra maps.
+This file packages the canonical inclusions into and projections out of a tensor product of
+bialgebras as bialgebra morphisms, and records their action on pure tensors. The projections are
+obtained by applying the counit to the other tensor factor.
 
 The tensor-product bialgebra structure and its unit isomorphisms are from Mathlib's
 `Mathlib.RingTheory.Bialgebra.TensorProduct`.
@@ -60,6 +61,50 @@ theorem includeRight_toAlgHom :
     (includeRight : H₂ →ₐc[R] H₁ ⊗[R] H₂).toAlgHom = Algebra.TensorProduct.includeRight := by
   ext y
   simp only [BialgHom.coe_toAlgHom, includeRight_apply, Algebra.TensorProduct.includeRight_apply]
+
+/-- The left projection `H₁ ⊗[R] H₂ → H₁`, given on pure tensors by
+`x ⊗ₜ y ↦ ε(y) • x`, as a bialgebra morphism. -/
+noncomputable def projectLeft : H₁ ⊗[R] H₂ →ₐc[R] H₁ :=
+  (_root_.Bialgebra.TensorProduct.rid R R H₁).toBialgHom.comp <|
+    _root_.Bialgebra.TensorProduct.map (BialgHom.id R H₁)
+      (_root_.Bialgebra.counitBialgHom R H₂)
+
+/-- The right projection `H₁ ⊗[R] H₂ → H₂`, given on pure tensors by
+`x ⊗ₜ y ↦ ε(x) • y`, as a bialgebra morphism. -/
+noncomputable def projectRight : H₁ ⊗[R] H₂ →ₐc[R] H₂ :=
+  (_root_.Bialgebra.TensorProduct.lid R H₂).toBialgHom.comp <|
+    _root_.Bialgebra.TensorProduct.map (_root_.Bialgebra.counitBialgHom R H₁)
+      (BialgHom.id R H₂)
+
+@[simp]
+theorem projectLeft_tmul (x : H₁) (y : H₂) :
+    projectLeft (R := R) (H₁ := H₁) (H₂ := H₂) (x ⊗ₜ[R] y) =
+      Coalgebra.counit (R := R) (A := H₂) y • x := by
+  simp [projectLeft]
+
+@[simp]
+theorem projectRight_tmul (x : H₁) (y : H₂) :
+    projectRight (R := R) (H₁ := H₁) (H₂ := H₂) (x ⊗ₜ[R] y) =
+      Coalgebra.counit (R := R) (A := H₁) x • y := by
+  simp [projectRight]
+
+/-- The left projection is a retraction of the left inclusion. -/
+@[simp]
+theorem projectLeft_comp_includeLeft :
+    (projectLeft (R := R) (H₁ := H₁) (H₂ := H₂)).comp includeLeft = BialgHom.id R H₁ := by
+  ext x
+  rw [BialgHom.comp_apply, includeLeft_apply, projectLeft_tmul,
+    Bialgebra.counit_one, one_smul]
+  rfl
+
+/-- The right projection is a retraction of the right inclusion. -/
+@[simp]
+theorem projectRight_comp_includeRight :
+    (projectRight (R := R) (H₁ := H₁) (H₂ := H₂)).comp includeRight = BialgHom.id R H₂ := by
+  ext y
+  rw [BialgHom.comp_apply, includeRight_apply, projectRight_tmul,
+    Bialgebra.counit_one, one_smul]
+  rfl
 
 end Bialgebra.TensorProduct
 


### PR DESCRIPTION
This PR proves that a point of a product affine group is unipotent exactly when both factor points are, and concludes that direct products of smooth unipotent finite-type affine groups are smooth unipotent. It advances the exact target `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5, **“Unipotent groups”**, specifically the characterization by embeddings into upper-unitriangular groups: the inductive construction of `Uₙ` has additive vector-group factors, so product closure is the step that turns unipotence of `𝔾ₐ` into unipotence of those factors before extension closure assembles `Uₙ`. After this PR, the milestone still needs the unipotence of `𝔾ₐ` and the upper-unitriangular coordinate Hopf algebra currently in flight, closure under the relevant extensions, the closed immersion `Uₙ ↪ GLₙ`, the converse embedding characterization, Lie–Kolchin, solvability, and the unipotent radical.

The proof uses the existing product-points equivalence. It adds the canonical bialgebra projections `H ⊗ K → H` and `H ⊗ K → K`, obtained by applying the counit to the other factor, and proves that precomposition with them inserts a point as `(g, 1)` or `(1, h)`. These inserted points are unipotent by functoriality, commute, and multiply to the original product point; the converse follows from the coordinate inclusions. The pointwise equivalence is stated over an arbitrary commutative semiring base and arbitrary commutative value algebra, while only the geometric object-property consequences specialize to fields and algebraic closures. Smoothness of the tensor product reuses Mathlib's stability under base change and composition.

Add `TauCeti/Algebra/AlgebraicGroup/Unipotent/Product.lean` (148 lines) and extend the existing tensor-product bialgebra and product-points APIs in `TauCeti/Algebra/Bialgebra/TensorProduct.lean` and `TauCeti/Algebra/AlgebraicGroup/Product.lean`; the complete diff is 234 insertions and 3 deletions. No Mathlib infrastructure or external formalization is vendored. The mathematics follows Jantzen, *Representations of Algebraic Groups*, I.2, and Springer, *Linear Algebraic Groups*, §2.4, as credited in the new module.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"smooth-unipotent-products"}-->

🤖 Prepared with Codex
