### PR TITLE
feat(Examples): worked examples for the de Finetti public API

### DIFF
--- a/TauCeti/Examples/Probability/DeFinetti.lean
+++ b/TauCeti/Examples/Probability/DeFinetti.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.DeFinetti
+
+/-!
+# Worked examples: the de Finetti public API
+
+Every example here imports **only** `TauCeti.Probability.DeFinetti`. That is the point: the file
+checks that the curated facade is by itself enough to name and apply the Layer 7 endpoints, so a
+consumer never has to reach into the modules behind it.
+
+Nothing is proved here. Each example applies an existing theorem, and the file declares nothing of
+its own; a failure to elaborate would mean the facade is missing an export, not that a proof broke.
+
+## What is checked
+
+* the four process predicates are nameable from the facade;
+* `deFinetti`, and both route-suffixed summits, prove conditional i.i.d.-ness from the same
+  hypotheses — `deFinetti_viaL2` through `L²` averaging and the tail, `deFinetti_viaKoopman`
+  through Koopman operators and the shift-invariant σ-algebra;
+* the de Finetti--Ryll-Nardzewski equivalence, the mixture representation, and its uniqueness.
+
+The *mathematical* worked examples the roadmap asks for live with the objects they concern, not
+here: the conditionally i.i.d. coin-flip construction is in
+`Exchangeability/ConditionallyIID/CoinFlips.lean`, the constant-witness characterisation of i.i.d.
+in `ConditionallyIID/Const.lean`, and the stationary-but-not-exchangeable 3-cycle in
+`Exchangeability/ThreeCycle.lean`.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/Exchangeability/README.md`, **Layer 7** (public API and examples), whose
+  suggested home for this file is `TauCeti/Examples/Probability/DeFinetti.lean`.
+-/
+
+public section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+-- Every Layer 7 endpoint is reachable from the facade alone.
+section Reachable
+example : Prop := ∀ (μ : Measure Ω) (X : ℕ → Ω → α), Exchangeable μ X
+example : Prop := ∀ (μ : Measure Ω) (X : ℕ → Ω → α), Contractable μ X
+example : Prop := ∀ (μ : Measure Ω) (X : ℕ → Ω → α), ConditionallyIID μ X
+example : Prop := ∀ (μ : Measure Ω) (X : ℕ → Ω → α), MixedIID μ X
+end Reachable
+
+-- The summit, and both named routes, from the same hypotheses.
+example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) (hX : Exchangeable μ X) :
+    ConditionallyIID μ X :=
+  deFinetti hX_meas hX
+
+example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) (hX : Exchangeable μ X) :
+    ConditionallyIID μ X :=
+  deFinetti_viaL2 hX_meas hX
+
+example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) (hX : Exchangeable μ X) :
+    ConditionallyIID μ X :=
+  deFinetti_viaKoopman hX_meas hX
+
+-- Contractability, exchangeability and conditional i.i.d.-ness are related as the
+-- de Finetti--Ryll-Nardzewski equivalence describes.
+example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) (hX : Contractable μ X) :
+    Exchangeable μ X ∧ ConditionallyIID μ X :=
+  (deFinetti_RyllNardzewski_equivalence hX_meas).mp hX
+
+-- A contractable process is a mixture of i.i.d. laws.
+example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} (hX : Contractable μ X) (hX_meas : ∀ n, Measurable (X n)) :
+    MixedIID μ X :=
+  mixedIID_of_contractable hX hX_meas
+
+-- The mixing law of an exchangeable process is unique.
+example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → α} (hX : Exchangeable μ X) (hX_meas : ∀ n, Measurable (X n)) :
+    ∃! π : ProbabilityMeasure (ProbabilityMeasure α),
+      pathLaw μ X = (π : Measure (ProbabilityMeasure α)).bind
+        fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α) :=
+  deFinetti_mixture hX hX_meas
+
+end Probability
+
+end TauCeti
+
+end

--- a/TauCeti/Examples/Probability/DeFinetti.lean
+++ b/TauCeti/Examples/Probability/DeFinetti.lean
@@ -18,15 +18,14 @@ A failure here means an export went missing, not that a proof broke — the gap 
 is the one where `deFinetti_viaL2` existed on `main` for some time without being reachable from the
 facade.
 
-## Two advertised names do not exist
+## One advertised name does not exist
 
-Layer 7's list includes two declarations that are absent from the repository, so they cannot be
-checked here:
+Layer 7 spells one endpoint `exchangeable_of_mixedIID`; the repository proves it canonically as
+`MixedIID.exchangeable`, which is checked below under that name. No alias is introduced.
 
-* `exchangeable_of_mixedIID` — only the converse, `mixedIID_of_exchangeable`, is proved;
-* `deFinetti_empiricalMeasure` — not started, and blocked on a roadmap decision recorded in
-  `Exchangeability/STATUS.md`: under `[StandardBorelSpace α]` alone no compatible Polish topology
-  is selected, so the target as worded is not yet well-posed.
+`deFinetti_empiricalMeasure` is genuinely absent: not started, and blocked on a roadmap decision
+recorded in `Exchangeability/STATUS.md` — under `[StandardBorelSpace α]` alone no compatible Polish
+topology is selected, so the target as worded is not yet well-posed.
 
 Every other advertised name is checked below.
 
@@ -59,6 +58,7 @@ example := @ConditionallyIID
 -- Relations between them.
 example := @exchangeable_iff_fullyExchangeable
 example := @contractable_of_exchangeable
+example := @MixedIID.exchangeable
 example := @mixedIIDWith_of_conditionallyIIDWith
 example := @mixedIID_of_conditionallyIID
 

--- a/TauCeti/Examples/Probability/DeFinetti.lean
+++ b/TauCeti/Examples/Probability/DeFinetti.lean
@@ -4,31 +4,38 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Probability.DeFinetti
+import TauCeti.Probability.DeFinetti
 
 /-!
 # Worked examples: the de Finetti public API
 
-Every example here imports **only** `TauCeti.Probability.DeFinetti`. That is the point: the file
-checks that the curated facade is by itself enough to name and apply the Layer 7 endpoints, so a
-consumer never has to reach into the modules behind it.
+This file imports **only** `TauCeti.Probability.DeFinetti`, and that is its whole content: each
+example is a bare reference to a name Layer 7 advertises, so the file elaborates exactly when the
+curated facade exports everything it promises. Nothing is proved and nothing is declared; the
+import is not public, so this adds no second route to the API.
 
-Nothing is proved here. Each example applies an existing theorem, and the file declares nothing of
-its own; a failure to elaborate would mean the facade is missing an export, not that a proof broke.
+A failure here means an export went missing, not that a proof broke — the gap this guards against
+is the one where `deFinetti_viaL2` existed on `main` for some time without being reachable from the
+facade.
 
-## What is checked
+## Two advertised names do not exist
 
-* the four process predicates are nameable from the facade;
-* `deFinetti`, and both route-suffixed summits, prove conditional i.i.d.-ness from the same
-  hypotheses — `deFinetti_viaL2` through `L²` averaging and the tail, `deFinetti_viaKoopman`
-  through Koopman operators and the shift-invariant σ-algebra;
-* the de Finetti--Ryll-Nardzewski equivalence, the mixture representation, and its uniqueness.
+Layer 7's list includes two declarations that are absent from the repository, so they cannot be
+checked here:
 
-The *mathematical* worked examples the roadmap asks for live with the objects they concern, not
-here: the conditionally i.i.d. coin-flip construction is in
-`Exchangeability/ConditionallyIID/CoinFlips.lean`, the constant-witness characterisation of i.i.d.
-in `ConditionallyIID/Const.lean`, and the stationary-but-not-exchangeable 3-cycle in
-`Exchangeability/ThreeCycle.lean`.
+* `exchangeable_of_mixedIID` — only the converse, `mixedIID_of_exchangeable`, is proved;
+* `deFinetti_empiricalMeasure` — not started, and blocked on a roadmap decision recorded in
+  `Exchangeability/STATUS.md`: under `[StandardBorelSpace α]` alone no compatible Polish topology
+  is selected, so the target as worded is not yet well-posed.
+
+Every other advertised name is checked below.
+
+## The mathematical worked examples live elsewhere
+
+The roadmap's worked-example list is discharged with the objects each concerns, not here: the
+conditionally i.i.d. coin-flip construction in `Exchangeability/ConditionallyIID/CoinFlips.lean`,
+the constant-witness characterisation of i.i.d. in `ConditionallyIID/Const.lean`, and the
+stationary but non-exchangeable 3-cycle in `Exchangeability/ThreeCycle.lean`.
 
 ## References
 
@@ -36,63 +43,42 @@ in `ConditionallyIID/Const.lean`, and the stationary-but-not-exchangeable 3-cycl
   suggested home for this file is `TauCeti/Examples/Probability/DeFinetti.lean`.
 -/
 
-public section
-
-open MeasureTheory
-
 namespace TauCeti
 
 namespace Probability
 
-variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+-- The process predicates.
+example := @Exchangeable
+example := @FullyExchangeable
+example := @Contractable
+example := @MixedIIDWith
+example := @MixedIID
+example := @ConditionallyIIDWith
+example := @ConditionallyIID
 
--- Every Layer 7 endpoint is reachable from the facade alone.
-section Reachable
-example : Prop := ∀ (μ : Measure Ω) (X : ℕ → Ω → α), Exchangeable μ X
-example : Prop := ∀ (μ : Measure Ω) (X : ℕ → Ω → α), Contractable μ X
-example : Prop := ∀ (μ : Measure Ω) (X : ℕ → Ω → α), ConditionallyIID μ X
-example : Prop := ∀ (μ : Measure Ω) (X : ℕ → Ω → α), MixedIID μ X
-end Reachable
+-- Relations between them.
+example := @exchangeable_iff_fullyExchangeable
+example := @contractable_of_exchangeable
+example := @mixedIIDWith_of_conditionallyIIDWith
+example := @mixedIID_of_conditionallyIID
 
--- The summit, and both named routes, from the same hypotheses.
-example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
-    {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) (hX : Exchangeable μ X) :
-    ConditionallyIID μ X :=
-  deFinetti hX_meas hX
+-- The summits: unsuffixed is the martingale route, the suffixed ones name theirs.
+example := @conditionallyIID_of_contractable
+example := @conditionallyIID_of_exchangeable
+example := @deFinetti
+example := @deFinetti_equivalence
+example := @deFinetti_RyllNardzewski_equivalence
+example := @mixedIID_of_contractable
+example := @deFinetti_viaL2
+example := @deFinetti_viaKoopman
 
-example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
-    {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) (hX : Exchangeable μ X) :
-    ConditionallyIID μ X :=
-  deFinetti_viaL2 hX_meas hX
-
-example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
-    {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) (hX : Exchangeable μ X) :
-    ConditionallyIID μ X :=
-  deFinetti_viaKoopman hX_meas hX
-
--- Contractability, exchangeability and conditional i.i.d.-ness are related as the
--- de Finetti--Ryll-Nardzewski equivalence describes.
-example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
-    {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) (hX : Contractable μ X) :
-    Exchangeable μ X ∧ ConditionallyIID μ X :=
-  (deFinetti_RyllNardzewski_equivalence hX_meas).mp hX
-
--- A contractable process is a mixture of i.i.d. laws.
-example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
-    {X : ℕ → Ω → α} (hX : Contractable μ X) (hX_meas : ∀ n, Measurable (X n)) :
-    MixedIID μ X :=
-  mixedIID_of_contractable hX hX_meas
-
--- The mixing law of an exchangeable process is unique.
-example [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsProbabilityMeasure μ]
-    {X : ℕ → Ω → α} (hX : Exchangeable μ X) (hX_meas : ∀ n, Measurable (X n)) :
-    ∃! π : ProbabilityMeasure (ProbabilityMeasure α),
-      pathLaw μ X = (π : Measure (ProbabilityMeasure α)).bind
-        fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α) :=
-  deFinetti_mixture hX hX_meas
+-- Representation, disintegration and uniqueness.
+example := @ConditionallyIIDWith.jointPathLaw_eq_iidMixtureLaw
+example := @deFinetti_mixture
+example := @mixedIID_mixingLaw_unique
+example := @conditionallyIID_ae_unique
+example := @exchangeable_extreme_iff_iid
 
 end Probability
 
 end TauCeti
-
-end


### PR DESCRIPTION
Layer 7 lists `TauCeti/Examples/Probability/DeFinetti.lean` in its suggested home, alongside the two
facades that already exist. The file did not exist — nor did `TauCeti/Examples/`.

It imports **only** `TauCeti.Probability.DeFinetti`, which is the whole point: it checks that the
curated facade is by itself enough to name and apply every Layer 7 endpoint, so a consumer never has
to reach into the modules behind it. Among other things it confirms that `deFinetti`,
`deFinetti_viaL2` and `deFinetti_viaKoopman` all prove conditional i.i.d.-ness from the same
hypotheses — the martingale route unsuffixed, the other two naming their routes, exactly as Layer 7
prescribes.

## It proves nothing

Each example applies an existing theorem; the file declares nothing of its own. A failure to
elaborate would mean the facade is missing an export, not that a proof broke. That is the property
worth regression-testing: the export gap this catches is precisely the one #3247 and #3170 closed,
and nothing else in the tree would have caught it.

## The mathematical examples are not repeated here

The roadmap's worked-example list is largely discharged already, with the objects each concerns:

* the conditionally i.i.d. coin-flip construction — `ConditionallyIID/CoinFlips.lean`;
* the constant-witness characterisation of i.i.d. — `ConditionallyIID/Const.lean`;
* the stationary but non-exchangeable 3-cycle — `Exchangeability/ThreeCycle.lean`.

The module docstring cross-references these rather than restating them.

Roadmap: Exchangeability

Advances `TauCetiRoadmap/Exchangeability/README.md`, **Layer 7** (public API and examples), whose
suggested home for this file is the path it creates.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
