### PR TITLE
feat(EDS): the complement of a normalised EDS at a general multiple

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.NormEDS
+
+/-!
+# The complement of a normalised EDS at a general multiple
+
+Mathlib defines `complEDS b c d k` to witness `normEDS b c d k ∣ normEDS b c d (n * k)`, but
+proves the witnessing identity `normEDS b c d k * complEDS b c d k n = normEDS b c d (n * k)`
+only at `k = 2`, as `normEDS_mul_complEDS₂`. This file proves it at every `k`, on the hypothesis
+that `normEDS b c d k` is a nonzerodivisor.
+
+That identity is the second conjunct of the TODO Mathlib records at
+`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean:70`, "prove that `normEDS` satisfies
+`IsEllipticDvdSequence`". `NormEDS.lean` discharges the first conjunct and names this one as a
+slice of its own.
+
+## Main results
+
+* `normEDS_mul_complEDS_of_mem_nonZeroDivisors`:
+  `normEDS b c d k * complEDS b c d k n = normEDS b c d (n * k)`, for every `n`, over any
+  commutative ring, whenever `normEDS b c d k` is a nonzerodivisor.
+
+## Implementation notes
+
+The nonzerodivisor hypothesis is what the induction consumes. The odd step derives the identity
+multiplied through by `normEDS b c d k`, and cancelling that factor is the only use of `hk`; the
+even step and both base cases are unconditional. It is removable by specialising from the
+universal parameters, where the sequence is a nonzerodivisor at every index — the route
+`NormEDS.lean` takes for `isEllipticNet_normEDS` — but `universalNormEDS_mem_nonZeroDivisors` is
+not yet available, and `Universal.lean` records what that in turn waits on.
+
+The elliptic relation is instantiated once, at `ER((j + 2) * k, 1, (j + 1) * k, 0)`. Its middle
+term is then `W((2 * j + 3) * k) * W k`, the odd step's right-hand side times the factor to be
+cancelled, and its two outer terms are the products the recursion produces.
+
+`IsEllipticNet.rel` holds its indices unnormalised — `W (p + q + s)` at `s = 0`, `W (q - r)`
+where the goal has `W (r - q)` — so the instance and the goal disagree on the *arguments* of
+`normEDS`, which are atoms to `ring`. `linear_combination`'s default `ring1` closer does not
+descend into an atom's arguments, so the norm is switched to `ring_nf`, which does. That covers
+every index mismatch except the reflected one: `W (1 - x) = -W (x - 1)` is `normEDS_neg`, a fact
+about the sequence rather than about `ℤ`, and is the single rewrite done by hand.
+
+## Provenance
+
+Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at `dev/modular-curves @ 9fec8eba7652` — the revision
+`TauCetiRoadmap/EllipticCurves/README.md` pins for the NagellLutz project. Source declaration
+`normEDS_mul_complEDS_of_mem` (`:1324`), which is `private` there and public here, being this
+slice's deliverable rather than a step; the name gains Mathlib's full `_of_mem_nonZeroDivisors`
+suffix. That file's header reads `Authors: David Kurniadi Angdinata`; following this repository's
+convention for adapted material the upstream authorship is credited here rather than in the
+copyright header.
+
+Three departures from the source, all forced by Mathlib having since absorbed the construction.
+
+The source builds a *general* complement `EllSequence.compl'`, parametric in two sequences `W₁`
+and `compl₂`, and obtains this identity by specialising a general lemma about it at
+`W₁ := normEDS b c d` and `compl₂ := compl₂EDS b c d`. Mathlib's `complEDS'` is that construction
+with exactly those two arguments already substituted, and Mathlib defines it directly rather than
+through a general `compl`, so porting the general version would duplicate `complEDS'` without
+making it derivable. The induction is run on `complEDS` itself instead.
+
+The source's hypothesis `b ∈ R⁰` is dropped. It is needed there because the `n = 0` base case
+goes through `IsEllSequence.zero`, which asks for `W 2 = b` to be a nonzerodivisor; Mathlib's
+`normEDS_zero` gives `W 0 = 0` outright.
+
+The source splits at the `ℕ` level and unfolds `compl'`, because it has no `ℤ`-level recurrence.
+Mathlib states `complEDS_even` and `complEDS_odd` over `ℤ`, so the `Int.sign`/`Int.natAbs`
+bookkeeping disappears and the even step is four rewrites.
+-/
+
+public section
+
+open scoped nonZeroDivisors
+
+variable {R : Type*} [CommRing R] {b c d : R}
+
+/-- **The complement of a normalised EDS witnesses divisibility at every multiple.**
+
+`complEDS b c d k n` is Mathlib's division-free candidate for `W (n * k) / W k`; this is the
+identity that makes it one, given that `normEDS b c d k` is a nonzerodivisor. -/
+theorem normEDS_mul_complEDS_of_mem_nonZeroDivisors {k : ℤ} (hk : normEDS b c d k ∈ R⁰) (n : ℤ) :
+    normEDS b c d k * complEDS b c d k n = normEDS b c d (n * k) := by
+  induction n using Int.negInduction with
+  | nat n =>
+    refine n.strong_induction_on fun n ih ↦ ?_
+    obtain _ | _ | n := n
+    · simp
+    · simp
+    -- Mathlib states the two recurrences at the `ℤ` level, so split there rather than unfolding
+    -- `complEDS'` at the `ℕ` level as the source does.
+    obtain ⟨j, rfl | rfl⟩ := n.even_or_odd'
+    · -- the index is `2 * j + 2 = 2 * (j + 1)`
+      have hj : ((2 * j + 2 : ℕ) : ℤ) = 2 * (j + 1) := by push_cast; ring
+      have hih := ih (j + 1) (by omega)
+      -- the inductive hypothesis arrives at `↑(j + 1)`, which is not the goal's `↑j + 1`
+      push_cast at hih
+      rw [hj, complEDS_even, ← mul_assoc, hih, normEDS_mul_complEDS₂]
+      ring_nf
+    · -- the index is `2 * j + 3 = 2 * (j + 1) + 1`
+      have hj : ((2 * j + 1 + 2 : ℕ) : ℤ) = 2 * (j + 1) + 1 := by push_cast; ring
+      have hih₁ := ih (j + 1) (by omega)
+      have hih₂ := ih (j + 2) (by omega)
+      push_cast at hih₁ hih₂
+      have hell := isEllipticSequence_normEDS b c d (((j : ℤ) + 2) * k) 1 (((j : ℤ) + 1) * k)
+      simp only [IsEllipticNet.rel, add_zero, normEDS_one, mul_one] at hell
+      -- only the reflected index needs rewriting by hand; `ring_nf` normalises the rest
+      rw [show (1 : ℤ) - ((j : ℤ) + 1) * k = -(((j : ℤ) + 1) * k - 1) by ring, normEDS_neg,
+        ← hih₁, ← hih₂] at hell
+      rw [← mul_cancel_left_mem_nonZeroDivisors hk, hj, complEDS_odd]
+      linear_combination (norm := ring_nf) hell
+  | neg hn n =>
+    rw [neg_mul, normEDS_neg, complEDS_neg, mul_neg, hn n]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -52,7 +52,9 @@ That fact is `isEllipticSequence_normEDS` in `NormEDS.lean`, proved here through
 (`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean`: "prove that `normEDS` satisfies
 `IsEllipticDvdSequence`"). What the denominator side still lacks is the rest of each chain above:
 `redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS` for the first, and
-`normEDS_mul_complEDS_div ← normEDS_mul_complEDS ← normEDS_mul_complEDS_of_mem` for the second.
+`normEDS_mul_complEDS_div ← normEDS_mul_complEDS` for the second: that chain's base link, the
+source's `normEDS_mul_complEDS_of_mem`, is `normEDS_mul_complEDS_of_mem_nonZeroDivisors` in
+`Complement.lean`.
 Carrying the bare definition across before them would add a formula that no consumer can state
 anything about, so it waits for the layer that gives it meaning. Everything below is independent
 of that fact: nothing carries an ellipticity hypothesis, and the source discharges the

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -50,11 +50,13 @@ normEDS_mul_complEDS ← normEDS_mul_complEDS_of_mem ← IsEllipticSequence.norm
 That fact is `isEllipticSequence_normEDS` in `NormEDS.lean`, proved here through the descent of
 `Descent.lean`; the pinned Mathlib still records it as an open TODO
 (`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean`: "prove that `normEDS` satisfies
-`IsEllipticDvdSequence`"). What the denominator side still lacks is the rest of each chain above:
-`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS` for the first, and
-`normEDS_mul_complEDS_div ← normEDS_mul_complEDS` for the second: that chain's base link, the
-source's `normEDS_mul_complEDS_of_mem`, is `normEDS_mul_complEDS_of_mem_nonZeroDivisors` in
-`Complement.lean`.
+`IsEllipticDvdSequence`"). Both chains above are written in the source's names; what the
+denominator side still lacks is the upper part of each, the lower links having landed. For the
+first, `net_normEDS` is `isEllipticNet_normEDS` (`NormEDS.lean`) and `invar_normEDS` is
+`invarNum_mul_invarDenom` (`Invariant.lean`), so what remains is `invar₂_normEDS` and
+`redInvar_normEDS`. For the second, `normEDS_mul_complEDS_of_mem` is
+`normEDS_mul_complEDS_of_mem_nonZeroDivisors` (`Complement.lean`), so what remains is
+`normEDS_mul_complEDS` and `normEDS_mul_complEDS_div`.
 Carrying the bare definition across before them would add a formula that no consumer can state
 anything about, so it waits for the layer that gives it meaning. Everything below is independent
 of that fact: nothing carries an ellipticity hypothesis, and the source discharges the


### PR DESCRIPTION
The complement of a normalised EDS witnesses divisibility at **every** multiple, not just at `2`.

```lean
theorem normEDS_mul_complEDS_of_mem_nonZeroDivisors {k : ℤ} (hk : normEDS b c d k ∈ R⁰) (n : ℤ) :
    normEDS b c d k * complEDS b c d k n = normEDS b c d (n * k)
```

For every `n`, over any `CommRing`, with no hypothesis on `b`, `c` or `d`.

## Where this sits

Mathlib defines `complEDS b c d k` precisely to witness `normEDS b c d k ∣ normEDS b c d (n * k)`
— that is its docstring — but proves the witnessing identity only at `k = 2`
(`normEDS_mul_complEDS₂`, `EllipticDivisibilitySequence.lean:547`). The general case is the second
conjunct of the TODO at that file's line 70, "prove that `normEDS` satisfies
`IsEllipticDvdSequence`".

This is not a fresh claim of scope: `NormEDS.lean:21-23`, merged earlier in this campaign, names
it as the follow-up slice in so many words.

> the second conjunct needs a general `normEDS_mul_complEDS`, of which Mathlib has only the
> `k = 2` case, and is left to its own slice.

**The repository already wrote this chain down, before I looked at it.**
`ReducedInvariant.lean` — merged, on `main` — explains why its denominator side is absent and
lists exactly what is missing:

> What the denominator side still lacks is the rest of each chain above: […] and
> `normEDS_mul_complEDS_div ← normEDS_mul_complEDS ← normEDS_mul_complEDS_of_mem` for the second.

`normEDS_mul_complEDS_of_mem` is the base of that chain and is the declaration this PR adds. I
found this after writing the proof rather than before, which makes it corroboration rather than
motivation — but it is the repository's own account of the gap, not mine.

The rest of the chain is verified rather than assumed. In the source, the six-way `m % 6` case
split `invarDenom_eq_redInvarDenom_mul` (`:1389`) rewrites with `normEDS_mul_complEDS_div`
**nine times**; that lemma is one line off the unconditional `normEDS_mul_complEDS`, which is one
specialisation off this. So:

```
this PR  →  normEDS_mul_complEDS  →  normEDS_mul_complEDS_div
         →  invarDenom_eq_redInvarDenom_mul  →  redInvar_normEDS  →  ω
```

and ω is the piece `DivisionPolynomial/Invariant.lean` names as the gap on the way to the
`[n]`-formulas.

## The general construction is deliberately absent, and the reason is not brevity

The source proves this by building a *general* complement `EllSequence.compl'`, parametric in two
sequences `W₁` and `compl₂`, proving a general multiplication lemma about it, and specialising at
`W₁ := normEDS b c d`, `compl₂ := compl₂EDS b c d`.

I did not port that layer, and the reason is that Mathlib has already absorbed it — with the
substitution performed. Reading the two definitions side by side, Mathlib's `complEDS'`
(`:619`) **is** the source's `compl'` (`:1086`) at exactly those two arguments:

| source `compl' W₁ compl₂ m` | Mathlib `complEDS' b c d k` |
|---|---|
| `compl₂ (k * m) * compl' k` | `complEDS' m * complEDS₂ b c d (m * k)` |
| `W₁ ((k+1) * m + 1) * W₁ ((k+1) * m - 1) * compl' k ^ 2` | `complEDS' m ^ 2 * normEDS b c d ((m+1) * k + 1) * normEDS b c d ((m+1) * k - 1)` |

Same recursion, same branch condition, same `Int.sign`/`Int.natAbs` extension to `ℤ`. Since
Mathlib defines `complEDS'` **directly** rather than as `compl'` applied to two arguments, porting
the general construction would add a second copy of this recursion that Mathlib's own `complEDS`
could not be derived from — a duplicate, not a generalisation. The induction therefore runs on
`complEDS` itself.

**There is a second, independent reason, which I did not expect.** The general version would also
make the proof *worse*. The source has no `ℤ`-level recurrence for `compl'`, so its even step
opens with `rw [EllSequence.compl, Int.sign_eq_one_of_pos, Int.natAbs_natCast, compl',
Int.cast_one, one_mul]` before it can touch the mathematics. Mathlib states `complEDS_even` and
`complEDS_odd` over `ℤ`, so all of that bookkeeping disappears:

```lean
rw [hj, complEDS_even, ← mul_assoc, hih, normEDS_mul_complEDS₂]
ring_nf
```

Four rewrites. A reviewer weighing "why not the general version" gets an argument about the proof,
not only about duplication.

## One hypothesis dropped, one kept

**Dropped: `b ∈ R⁰`.** The source carries it. It needs it because its `n = 0` base case goes
through `IsEllSequence.zero`, which asks for `W 2 = b` to be a nonzerodivisor. Mathlib's
`normEDS_zero` gives `W 0 = 0` outright, so the base case is `simp` and the hypothesis is not
used anywhere else. I checked this by removing it and rebuilding rather than by reading.

**Kept: `normEDS b c d k ∈ R⁰`.** This one the induction genuinely consumes, in exactly one place.
The odd step derives the identity multiplied through by `normEDS b c d k` — the elliptic
relation's middle term is `W ((2j+3) * k) * W k`, and that `W k` is the surplus factor — so
cancelling it is what the hypothesis buys. Both base cases, the even step and the reflection to
negative indices are unconditional.

It is removable, by the same universal-parameters route `NormEDS.lean` already uses for
`isEllipticNet_normEDS`, but only once `universalNormEDS_mem_nonZeroDivisors` exists. That is
recorded as absent in `Universal.lean`, and #3364 removes what it in turn waits on. Building the
unconditional form here would mean stacking on an unmerged branch, which the overlay build would
red — so this PR is the conditional half, on purpose, and the removal is its own follow-up.

## A `ring` subtlety worth recording

`IsEllipticNet.rel` holds its indices unnormalised: at `s = 0` the arguments are literally
`p + q + 0`, and the third term carries `W (q - r)` where the goal has `W (r - q)`. The instance
and the goal therefore disagree inside the *arguments* of `normEDS`, which are atoms to `ring`.

`linear_combination`'s default `ring1` closer does **not** descend into an atom's arguments; the
first version of this proof needed four hand-written `show … by ring` rewrites purely to line the
indices up. Switching the norm to `ring_nf`, which does descend, removes all four. What survives
is the one mismatch that is not a ring fact at all — `W (1 - x) = -W (x - 1)` is `normEDS_neg`,
about the sequence rather than about `ℤ` — and that is the single rewrite still done by hand.

## One docstring correction, in the same commit

That `ReducedInvariant.lean` passage becomes **false** the moment this merges: it names
`normEDS_mul_complEDS_of_mem` among the things the repository lacks, in a file that would then sit
on `main` alongside the declaration. So the sentence is corrected here, naming
`normEDS_mul_complEDS_of_mem_nonZeroDivisors` in `Complement.lean` as the link that has landed.

This is the decay pattern this campaign keeps paying for, and it is invisible to the build: prose
recording an absence stays readable long after it stops being true. #3364 exists because
`normEDS 2 3 2 = id` was recorded as blocked in two files after the blocker was removed. The PR
that lands a declaration is the only place its recorded absence gets caught.

**The first chain in the same sentence was stale too, and `documentation` was right that leaving
it was wrong.** I originally corrected only the chain this PR touches, on the grounds that the
other belonged to other PRs. The rubric's line is better: a paragraph you edit is a paragraph you
own, and half-correcting one leaves a reader no way to tell which half to trust.

Both chains are now labelled as the source's names, and each lists only the links genuinely
absent. Checked against `origin/main` by anchored declaration grep rather than from memory:

```
isEllipticNet_normEDS      NormEDS.lean:113     present   (source: net_normEDS)
invarNum_mul_invarDenom    Invariant.lean:138   present   (source: invar_normEDS)
invar₂_normEDS                                  absent
redInvar_normEDS                                absent
normEDS_mul_complEDS                            absent
normEDS_mul_complEDS_div                        absent
```

## Reuse

Checked in **both** trees, and by the destination's vocabulary rather than the source's, which is
where this chain has been mis-assessed before.

`normEDS_mul_complEDS`, in any spelling, is absent from Mathlib: the file defines `complEDS`,
proves `complEDS_even`/`complEDS_odd`/`complEDS_neg` and the `k = 2` special case, and stops. Its
own line 70 TODO is the upstream statement that this is missing. It is absent from TauCeti, where
`ComplAux.lean` is the only file touching the complement API and concerns `complEDS₂Aux`, the
subtracted summand of the `k = 2` complement.

## Placement

New file. It needs `isEllipticSequence_normEDS`, so it must import
`EllipticDivisibilitySequence/NormEDS.lean`. `ComplAux.lean` is the one existing file about the
complement, and it is deliberately a leaf on Mathlib alone — adding `NormEDS.lean` to it would
pull `Descent` and `Universal` into `ComplAux`, and thence into `ReducedInvariant.lean`, which is
its only importer. The complement identity and the auxiliary summand of `complEDS₂` are also not
the same topic.

## Review status

**Opened without a scoreboard, deliberately.** Both codex credentials on the authoring machine are
over quota (`~/.codex` to 2026-08-20, `~/.codex2` to 2026-09-14), so every local run returns ten
rubrics at `cost=$0.0000` — the provider never ran. Posting that would be destructive rather than
useless: `merge_from_scoreboard.py` takes the newest scoreboard by `updated_at` with no access
bar, so a wall of `error` states overwrites a human reviewer's verdict as the canonical record, as
happened on #3333.

## Gates

`lake build` PASS at 7939 jobs, on a head rebased onto current `main`. `lake exe axioms` PASS —
47327 declarations, allowlist only. `lake exe module-system` PASS. `scripts/lint-env.sh` PASS.
`lake exe axioms` PASS — 47312 declarations, allowlist only. `lake exe module-system` PASS.
`scripts/lint-env.sh` PASS — no new violations.

No `sorry`, no `set_option`, no `native_decide`, no `erw`, no `λ`/`$`/`push_neg`. One theorem;
the proof is a 30-line span of which 26 are code, against the 30-line decomposition threshold and
the 50-line cap. Longest line 98 codepoints; file is 118 lines.

I am reporting span and code lines separately because the proof sits on the threshold rather than
comfortably below it. Decomposing it would mean extracting the odd step into a private helper
taking `hk` and the strong-induction hypothesis as explicit arguments, used once — which the
`reuse` rubric rejects. The natural decomposition is the case split, and `induction … with`
already provides it.

## Provenance

Adapted from D. K. Angdinata's `LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at **`dev/modular-curves @ 9fec8eba7652`** — the
revision `TauCetiRoadmap/EllipticCurves/README.md` pins for the NagellLutz project. Declaration
`normEDS_mul_complEDS_of_mem` (`:1324`). That file's header reads
`Authors: David Kurniadi Angdinata`; following this repository's convention for adapted material
the upstream authorship is credited in the module docstring rather than in the copyright header.

The source declaration is `private`; here it is public, being this slice's deliverable rather than
a step, and the name gains Mathlib's full `_of_mem_nonZeroDivisors` suffix. The three
mathematical departures — no general construction, no `b ∈ R⁰`, `ℤ`-level recurrences — are the
ones described above, and are recorded in the file's Provenance block as well.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md:99` — "**`[n]` is division polynomials**", the
mathlib-track anchor naming `ZSMul.lean`; ω is the piece of that anchor the chain above unblocks.
The onward consumer is Layer 6's "**The torsion subgroup and Nagell–Lutz**" (`README.md:821`),
whose stated route is division polynomials.

For completeness rather than as authorization: `README.md:254` names
`Mathlib/NumberTheory/EllipticDivisibilitySequence.lean` under "What Mathlib already has
(consume)", noting that "the sequence predicates' names are in flux upstream, so the roadmap does
not pin them". That is a consume entry, not a target — cited only because this PR completes a TODO
*inside* the file it names, and because it is why the roadmap cannot be searched for the
declaration names involved.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-complement"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
