### PR TITLE
feat: prove the Lie-group Trotter formula

### DIFF
--- a/TauCeti/Analysis/Calculus/RescaledDerivative.lean
+++ b/TauCeti/Analysis/Calculus/RescaledDerivative.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.Slope
+
+/-!
+# Rescaled derivative limits
+
+This file records the normed-space limit obtained by sampling a differentiable curve at `t / n`
+and multiplying its value by `n`.
+
+## Main result
+
+* `tendsto_nsmul_apply_div_of_hasDerivAt`: a curve through zero with derivative `f'` satisfies
+  `n • f (t / n) → t • f'`.
+-/
+
+public section
+
+open Filter
+
+/-- If `f` passes through zero with derivative `f'`, then `n • f (t / n)` tends to `t • f'`. -/
+theorem tendsto_nsmul_apply_div_of_hasDerivAt
+    {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+    {f : ℝ → F} {f' : F} (hf : HasDerivAt f f' 0) (hf0 : f 0 = 0) (t : ℝ) :
+    Tendsto (fun n : ℕ => n • f (t / n)) atTop (nhds (t • f')) := by
+  by_cases ht : t = 0
+  · subst t
+    simpa only [zero_div, hf0, nsmul_zero, zero_smul] using tendsto_const_nhds
+  have hs : Tendsto (fun n : ℕ => t / (n : ℝ)) atTop (nhds 0) :=
+    tendsto_const_div_atTop_nhds_zero_nat t
+  have hs_ne : ∀ᶠ n : ℕ in (atTop : Filter ℕ), t / (n : ℝ) ≠ 0 := by
+    filter_upwards [eventually_gt_atTop (0 : ℕ)] with n hnpos
+    exact div_ne_zero ht (show (n : ℝ) ≠ 0 from
+      Nat.cast_ne_zero.mpr (Nat.ne_of_gt hnpos))
+  have hs' : Tendsto (fun n : ℕ => t / (n : ℝ)) atTop
+      (nhdsWithin 0 ({0} : Set ℝ)ᶜ) :=
+    tendsto_nhdsWithin_iff.mpr ⟨hs, hs_ne⟩
+  have hscaled := (hf.tendsto_slope_zero.comp hs').const_smul t
+  convert hscaled using 1
+  funext n
+  by_cases hn0 : n = 0
+  · subst n
+    simp [hf0]
+  rw [show n • f (t / (n : ℝ)) = (n : ℝ) • f (t / (n : ℝ)) by
+    exact (Nat.cast_smul_eq_nsmul ℝ n _).symm]
+  simp only [Function.comp_apply, zero_add, hf0, sub_zero]
+  rw [smul_smul]
+  congr 1
+  field_simp
+
+end

--- a/TauCeti/Geometry/Lie/Exponential/Derivative/Log.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Derivative/Log.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Lie.Exponential.LocalInverse
+
+/-!
+# Derivatives involving the local Lie logarithm
+
+This file records first-order interactions between the local logarithm, the exponential, and
+group multiplication.
+
+## Main result
+
+* `hasDerivAt_mulInvariantLog_mulInvariantExp_smul_mul_mulInvariantExp_smul`: the local logarithm
+  of the product of two exponential lines has initial derivative `X + Y`.
+-/
+
+public section
+
+open Function Manifold
+open scoped ContDiff Manifold Topology
+
+noncomputable section
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [IsManifold I 1 G]
+
+attribute [local instance] LieGroup.minSmoothnessThree
+
+-- Multiplication's tangent-map API and `extChartAt` use dependent tangent-space synonyms at
+-- definitionally equal basepoints. The conversions below state each semantic boundary explicitly.
+private theorem hasFDerivAt_extChartAt_mulInvariantExp_smul_mul_mulInvariantExp_smul
+    [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
+    (X Y : GroupLieAlgebra I G) :
+    HasFDerivAt
+      (fun t : ℝ => extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) (t • X) *
+          mulInvariantExp (I := I) (G := G) (t • Y)))
+      ((1 : ℝ →L[ℝ] ℝ).smulRight ((show E from X) + (show E from Y))) 0 := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  have hX := hasMFDerivAt_mulInvariantExp_smul_zero (I := I) (G := G) X
+  have hY := hasMFDerivAt_mulInvariantExp_smul_zero (I := I) (G := G) Y
+  have hpair := hX.prodMk hY
+  have hmul := (contMDiff_mul (G := G) I ∞).contMDiffAt
+    (x := (mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X),
+      mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y)))
+    |>.mdifferentiableAt (by simp)
+  have hcurve := hmul.hasMFDerivAt.comp 0 hpair
+  have hzero :
+      mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) *
+        mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y) = (1 : G) := by
+    simp
+  rw [hzero] at hcurve
+  have hsource :
+      mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) *
+          mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y) ∈
+        (chartAt H (1 : G)).source := by
+    rw [hzero]
+    exact mem_chart_source H (1 : G)
+  have hext := (mdifferentiableAt_extChartAt (I := I)
+    (x := (1 : G)) hsource).hasMFDerivAt
+  have hchart := hext.comp 0 hcurve
+  simp only [Function.comp_apply] at hchart
+  rw [hzero] at hchart
+  apply hchart.mdifferentiableAt.differentiableAt.hasFDerivAt.congr_fderiv
+  rw [← mfderiv_eq_fderiv, hchart.mfderiv]
+  apply DFunLike.coe_injective
+  funext t
+  rw [show (0 : ℝ) • X = 0 by exact zero_smul ℝ X,
+    show (0 : ℝ) • Y = 0 by exact zero_smul ℝ Y,
+    mulInvariantExp_zero]
+  have hmul_apply := mfderiv_mul_apply_one (I := I) (G := G) (t • X) (t • Y)
+  have hmul_model := congrArg (fun Z : GroupLieAlgebra I G => show E from Z)
+    (hmul_apply.trans (smul_add t X Y).symm)
+  rw [mfderiv_extChartAt_self]
+  -- `extChartAt` lands in the self-model, whose tangent space is the model-space synonym `E`.
+  -- Expose that final chart boundary before applying the model-space equality above.
+  change
+    (show E from
+      (mfderiv (I.prod I) I (fun p : G × G => p.1 * p.2) ((1, 1) : G × G))
+        (t • X, t • Y)) =
+      (show E from t • (X + Y))
+  exact hmul_model
+
+/-- The local logarithm of the product of two exponential lines has initial derivative `X + Y`. -/
+theorem hasDerivAt_mulInvariantLog_mulInvariantExp_smul_mul_mulInvariantExp_smul
+    [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
+    (X Y : GroupLieAlgebra I G) :
+    HasDerivAt
+      (fun t : ℝ => (show E from mulInvariantLog (I := I) (G := G)
+        (mulInvariantExp (I := I) (G := G) (t • X) *
+          mulInvariantExp (I := I) (G := G) (t • Y))))
+      ((show E from X) + (show E from Y)) 0 := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  have hlog := hasFDerivAt_mulInvariantLogChart_one (I := I) (G := G)
+  have hcurve :=
+    hasFDerivAt_extChartAt_mulInvariantExp_smul_mul_mulInvariantExp_smul
+      (I := I) (G := G) X Y
+  have hlog' : HasFDerivAt (mulInvariantLogChart (I := I) (G := G))
+      (ContinuousLinearMap.id ℝ E)
+      (extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) *
+          mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y))) := by
+    simpa using hlog
+  have hcomp' := (hlog'.comp 0 hcurve).hasDerivAt
+  rw [show (mulInvariantLogChart (I := I) (G := G) ∘
+      fun t : ℝ => extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) (t • X) *
+          mulInvariantExp (I := I) (G := G) (t • Y))) =
+      fun t : ℝ => (show E from mulInvariantLog (I := I) (G := G)
+        (mulInvariantExp (I := I) (G := G) (t • X) *
+          mulInvariantExp (I := I) (G := G) (t • Y))) by
+    funext t
+    exact (mulInvariantLog_eq_chart (I := I) (G := G) _).symm] at hcomp'
+  simpa only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.id_apply,
+    ContinuousLinearMap.smulRight_apply, one_apply_eq_self, one_smul] using hcomp'
+
+end

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 public import TauCeti.Geometry.Lie.Exponential.Derivative.Basic
+import Mathlib.Analysis.Calculus.FDeriv.OfCompLeft
 public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.ContDiff
 public import Mathlib.Geometry.Manifold.LocalDiffeomorph
 /-!
@@ -19,6 +20,8 @@ tangent-space exponential.
 
 * `mulInvariantLog`: a local logarithm from the group to its tangent Lie algebra.
 * `lieLog`: the same chosen local logarithm, valued in left-invariant derivations.
+* `hasFDerivAt_mulInvariantLogChart_one`: the coordinate logarithm has derivative the identity
+  at the identity coordinate.
 * `eventually_mulInvariantExp_log`: exponential followed after logarithm is locally the identity.
 * `eventually_mulInvariantLog_exp`: logarithm followed after exponential is locally the identity.
 * `isLocalDiffeomorphAt_lieExp_zero`: the canonical Lie-group exponential is a local
@@ -218,6 +221,24 @@ theorem contDiffAt_mulInvariantLogChart_one [FiniteDimensional ℝ E]
     exact hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)
   · rw [hlog, hφ]
     exact contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)
+
+/-- The coordinate logarithm has derivative the identity at the identity coordinate. -/
+theorem hasFDerivAt_mulInvariantLogChart_one [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    HasFDerivAt (mulInvariantLogChart (I := I) (G := G))
+      (ContinuousLinearMap.id ℝ E) (extChartAt I (1 : G) (1 : G)) := by
+  let φ := mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)
+  have hlog : φ.symm (extChartAt I (1 : G) (1 : G)) = 0 :=
+    mulInvariantLogChart_one (I := I) (G := G)
+  have h := φ.hasFDerivAt_symm
+    one_mem_mulInvariantExpOpenPartialHomeomorph_target
+    (f' := ContinuousLinearEquiv.refl ℝ E) (by
+      have hφ : (φ : E → E) = mulInvariantExpChart (I := I) (G := G) := by
+        funext v
+        exact mulInvariantExpOpenPartialHomeomorph_apply (I := I) (G := G) v
+      rw [hlog, hφ]
+      simpa using hasFDerivAt_mulInvariantExpChart_zero (I := I) (G := G))
+  simpa [mulInvariantLogChart, φ] using h
 
 /-- The local logarithm of a group element, valued in the tangent Lie algebra at the identity. It
 is the coordinate logarithm transported back from the manifold model space. Its values outside

--- a/TauCeti/Geometry/Lie/Exponential/Trotter.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Trotter.lean
@@ -3,27 +3,33 @@ Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
-public import TauCeti.Geometry.Lie.Exponential.LocalInverse
+public import TauCeti.Analysis.Calculus.RescaledDerivative
+public import TauCeti.Geometry.Lie.Exponential.Derivative.Log
 public import TauCeti.Geometry.Lie.Interior
 
 /-!
 # The Trotter product formula
 
-This file proves a tangent-to-identity power limit and applies it to the product of two
-exponential curves.
+This file proves a tangent-to-identity power limit for finite-dimensional real Lie groups and
+applies it to the product of two exponential curves. The resulting Trotter formula supplies the
+addition-closure input for the subgroup Lie algebra in Deliverable A, Layer 2 of the Lie-groups
+roadmap.
 
 ## Main results
 
 * `tendsto_pow_div_of_hasDerivAt_mulInvariantLog`: a curve whose local logarithm has initial
   derivative `X` has rescaled powers converging to `exp (t X)`.
-* `tendsto_mulInvariantExp_mul_pow_div`: the Trotter product formula in the tangent model.
-* `tendsto_lieExp_mul_pow_div`: the Trotter product formula for left-invariant derivations.
+* `tendsto_mulInvariantExp_smul_mul_mulInvariantExp_smul_pow`: the Trotter product formula in the
+  tangent model.
+* `tendsto_lieExp_smul_mul_lieExp_smul_pow`: the Trotter product formula for left-invariant
+  derivations.
 
 ## References
 
-* H. Liu, *Notes for Lie Groups & Representations*, Proposition 2.4.3.
+* [H. Liu, *Notes for Lie Groups & Representations*](https://member.ipmu.jp/henry.liu/notes/f16-lie-groups.pdf),
+  notes from Andrei Okounkov's Fall 2016 course, Proposition 2.4.3.
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
-  Deliverable A, Layer 2, "Closed subgroups and automatic smoothness".
+  Deliverable A, Layer 2, "The Lie subalgebra of a subgroup".
 -/
 
 public section
@@ -32,37 +38,6 @@ open Filter Function Manifold
 open scoped ContDiff Manifold Topology
 
 noncomputable section
-
-private theorem tendsto_nsmul_apply_div_of_hasDerivAt
-    {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
-    {f : ℝ → F} {f' : F} (hf : HasDerivAt f f' 0) (hf0 : f 0 = 0) (t : ℝ) :
-    Tendsto (fun n : ℕ => n • f (t / n)) atTop (nhds (t • f')) := by
-  by_cases ht : t = 0
-  · subst t
-    simpa only [zero_div, hf0, nsmul_zero, zero_smul] using tendsto_const_nhds
-  have hn : Tendsto (fun n : ℕ => (n : ℝ)⁻¹) atTop (nhds 0) :=
-    tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop
-  have hs : Tendsto (fun n : ℕ => t / (n : ℝ)) atTop (nhds 0) := by
-    simpa only [div_eq_mul_inv, mul_comm, mul_zero] using hn.mul_const t
-  have hs_ne : ∀ᶠ n : ℕ in (atTop : Filter ℕ), t / (n : ℝ) ≠ 0 := by
-    filter_upwards [eventually_gt_atTop (0 : ℕ)] with n hnpos
-    exact div_ne_zero ht (show (n : ℝ) ≠ 0 from
-      Nat.cast_ne_zero.mpr (Nat.ne_of_gt hnpos))
-  have hs' : Tendsto (fun n : ℕ => t / (n : ℝ)) atTop
-      (nhdsWithin 0 ({0} : Set ℝ)ᶜ) :=
-    tendsto_nhdsWithin_iff.mpr ⟨hs, hs_ne⟩
-  have hscaled := (hf.tendsto_slope_zero.comp hs').const_smul t
-  convert hscaled using 1
-  funext n
-  by_cases hn0 : n = 0
-  · subst n
-    simp [hf0]
-  rw [show n • f (t / (n : ℝ)) = (n : ℝ) • f (t / (n : ℝ)) by
-    exact (Nat.cast_smul_eq_nsmul ℝ n _).symm]
-  simp only [Function.comp_apply, zero_add, hf0, sub_zero]
-  rw [smul_smul]
-  congr 1
-  field_simp
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
@@ -76,11 +51,10 @@ attribute [local instance] ContMDiffMul.boundarylessManifold
 stated in local logarithmic coordinates so the result can be reused independently of a chosen
 manifold expression for the curve. -/
 theorem tendsto_pow_div_of_hasDerivAt_mulInvariantLog [FiniteDimensional ℝ E]
-    [LieGroup I ∞ G] :
+    [LieGroup I ∞ G] {f : ℝ → G} (X : GroupLieAlgebra I G) (hf0 : f 0 = 1) :
     let _ : BoundarylessManifold I G := ContMDiffMul.boundarylessManifold
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
-    ∀ {f : ℝ → G} (X : GroupLieAlgebra I G) (_hf0 : f 0 = 1),
-      ContinuousAt f 0 →
+    ContinuousAt f 0 →
       HasDerivAt (fun s =>
         (show E from mulInvariantLog (I := I) (G := G) (f s)))
         (show E from X) 0 →
@@ -89,7 +63,7 @@ theorem tendsto_pow_div_of_hasDerivAt_mulInvariantLog [FiniteDimensional ℝ E]
   let _ : BoundarylessManifold I G := ContMDiffMul.boundarylessManifold
   let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   dsimp only
-  intro f X hf0 hf hlog t
+  intro hf hlog t
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   have hlog0 : (show E from mulInvariantLog (I := I) (G := G) (f 0)) = 0 := by
     rw [hf0]
@@ -97,10 +71,8 @@ theorem tendsto_pow_div_of_hasDerivAt_mulInvariantLog [FiniteDimensional ℝ E]
   have hseq := tendsto_nsmul_apply_div_of_hasDerivAt hlog hlog0 t
   have hexp :=
     (contMDiff_mulInvariantExp (I := I) (G := G)).continuous.continuousAt.tendsto.comp hseq
-  have hn : Tendsto (fun n : ℕ => (n : ℝ)⁻¹) atTop (nhds 0) :=
-    tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop
-  have hs : Tendsto (fun n : ℕ => t / (n : ℝ)) atTop (nhds 0) := by
-    simpa only [div_eq_mul_inv, mul_comm, mul_zero] using hn.mul_const t
+  have hs : Tendsto (fun n : ℕ => t / (n : ℝ)) atTop (nhds 0) :=
+    tendsto_const_div_atTop_nhds_zero_nat t
   have hfseq : Tendsto (fun n : ℕ => f (t / (n : ℝ))) atTop (nhds (1 : G)) := by
     have hf' := hf.tendsto
     rw [hf0] at hf'
@@ -117,121 +89,8 @@ theorem tendsto_pow_div_of_hasDerivAt_mulInvariantLog [FiniteDimensional ℝ E]
         GroupLieAlgebra I G)) = f (t / (n : ℝ)) ^ n
   rw [mulInvariantExp_nsmul, hnlog]
 
-private theorem hasFDerivAt_mulInvariantLogChart_one [FiniteDimensional ℝ E]
-    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
-    HasFDerivAt (mulInvariantLogChart (I := I) (G := G))
-      (ContinuousLinearMap.id ℝ E) (extChartAt I (1 : G) (1 : G)) := by
-  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  have hexp : HasStrictFDerivAt (mulInvariantExpChart (I := I) (G := G))
-      ((ContinuousLinearEquiv.refl ℝ E : E ≃L[ℝ] E) : E →L[ℝ] E) 0 :=
-    (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)).hasStrictFDerivAt'
-      (hasFDerivAt_mulInvariantExpChart_zero (I := I) (G := G)) (by simp)
-  have hlog := hexp.to_local_left_inverse
-    (eventually_mulInvariantLogChart_exp (I := I) (G := G))
-  simpa using hlog.hasFDerivAt
-
--- Multiplication's tangent-map API and `extChartAt` use dependent tangent-space synonyms at
--- definitionally equal basepoints. The conversions below state each semantic boundary explicitly.
-private theorem hasFDerivAt_mulInvariantExp_mul_chartCurve [FiniteDimensional ℝ E]
-    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
-    (X Y : GroupLieAlgebra I G) :
-    HasFDerivAt
-      (fun t : ℝ => extChartAt I (1 : G)
-        (mulInvariantExp (I := I) (G := G) (t • X) *
-          mulInvariantExp (I := I) (G := G) (t • Y)))
-      ((1 : ℝ →L[ℝ] ℝ).smulRight ((show E from X) + (show E from Y))) 0 := by
-  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  have hX := hasMFDerivAt_mulInvariantExp_smul_zero (I := I) (G := G) X
-  have hY := hasMFDerivAt_mulInvariantExp_smul_zero (I := I) (G := G) Y
-  have hpair := hX.prodMk hY
-  have hmul := (contMDiff_mul (G := G) I ∞).contMDiffAt
-    (x := (mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X),
-      mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y)))
-    |>.mdifferentiableAt (by simp)
-  have hcurve := hmul.hasMFDerivAt.comp 0 hpair
-  have hzero :
-      mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) *
-        mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y) = (1 : G) := by
-    simp
-  rw [hzero] at hcurve
-  have hsource :
-      mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) *
-          mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y) ∈
-        (chartAt H (1 : G)).source := by
-    rw [hzero]
-    exact mem_chart_source H (1 : G)
-  have hext := (mdifferentiableAt_extChartAt (I := I)
-    (x := (1 : G)) hsource).hasMFDerivAt
-  have hchart := hext.comp 0 hcurve
-  simp only [Function.comp_apply] at hchart
-  rw [hzero] at hchart
-  apply hchart.mdifferentiableAt.differentiableAt.hasFDerivAt.congr_fderiv
-  rw [← mfderiv_eq_fderiv, hchart.mfderiv]
-  apply DFunLike.coe_injective
-  funext t
-  let s : ℝ := show ℝ from t
-  rw [show (0 : ℝ) • X = 0 by exact zero_smul ℝ X,
-    show (0 : ℝ) • Y = 0 by exact zero_smul ℝ Y,
-    mulInvariantExp_zero]
-  have hmul_tangent := tangentMap_mul_prod_apply (I := I) (G := G)
-    (⟨1, s • X⟩ : TangentBundle I G) (⟨1, s • Y⟩ : TangentBundle I G)
-  have hmul_apply := congrArg (fun z : TangentBundle I G => z.2) hmul_tangent
-  -- Project the bundled tangent-map equation to its fiberwise `mfderiv` statement.
-  change
-    (mfderiv (I.prod I) I (fun p : G × G => p.1 * p.2) ((1, 1) : G × G))
-        (s • X, s • Y) =
-      (mfderiv I I (fun z : G => z * 1) 1) (s • X) +
-        (mfderiv I I (fun z : G => 1 * z) 1) (s • Y) at hmul_apply
-  rw [show (fun z : G => z * 1) = id by funext z; simp,
-    show (fun z : G => 1 * z) = id by funext z; simp, mfderiv_id] at hmul_apply
-  -- Apply the two identity derivatives and expose scalar multiplication in the group tangent space.
-  change
-    (mfderiv (I.prod I) I (fun p : G × G => p.1 * p.2) ((1, 1) : G × G))
-        (s • X, s • Y) = s • X + s • Y at hmul_apply
-  have hmul_model := congrArg (fun Z : GroupLieAlgebra I G => show E from Z)
-    (hmul_apply.trans (smul_add s X Y).symm)
-  rw [mfderiv_extChartAt_self]
-  -- `extChartAt` lands in the self-model, whose tangent space is the model-space synonym `E`.
-  -- Expose that final chart boundary before applying the model-space equality above.
-  change
-    (show E from
-      (mfderiv (I.prod I) I (fun p : G × G => p.1 * p.2) ((1, 1) : G × G))
-        (s • X, s • Y)) =
-      (show E from s • (X + Y))
-  simpa only [s] using hmul_model
-
-private theorem hasDerivAt_mulInvariantLog_mulInvariantExp_mul [FiniteDimensional ℝ E]
-    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
-    (X Y : GroupLieAlgebra I G) :
-    HasDerivAt
-      (fun t : ℝ => (show E from mulInvariantLog (I := I) (G := G)
-        (mulInvariantExp (I := I) (G := G) (t • X) *
-          mulInvariantExp (I := I) (G := G) (t • Y))))
-      ((show E from X) + (show E from Y)) 0 := by
-  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  have hlog := hasFDerivAt_mulInvariantLogChart_one (I := I) (G := G)
-  have hcurve := hasFDerivAt_mulInvariantExp_mul_chartCurve (I := I) (G := G) X Y
-  have hlog' : HasFDerivAt (mulInvariantLogChart (I := I) (G := G))
-      (ContinuousLinearMap.id ℝ E)
-      (extChartAt I (1 : G)
-        (mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) *
-          mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y))) := by
-    simpa using hlog
-  have hcomp' := (hlog'.comp 0 hcurve).hasDerivAt
-  rw [show (mulInvariantLogChart (I := I) (G := G) ∘
-      fun t : ℝ => extChartAt I (1 : G)
-        (mulInvariantExp (I := I) (G := G) (t • X) *
-          mulInvariantExp (I := I) (G := G) (t • Y))) =
-      fun t : ℝ => (show E from mulInvariantLog (I := I) (G := G)
-        (mulInvariantExp (I := I) (G := G) (t • X) *
-          mulInvariantExp (I := I) (G := G) (t • Y))) by
-    funext t
-    exact (mulInvariantLog_eq_chart (I := I) (G := G) _).symm] at hcomp'
-  simpa only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.id_apply,
-    ContinuousLinearMap.smulRight_apply, one_apply_eq_self, one_smul] using hcomp'
-
 /-- The Trotter product formula for the tangent-space exponential. -/
-theorem tendsto_mulInvariantExp_mul_pow_div [FiniteDimensional ℝ E]
+theorem tendsto_mulInvariantExp_smul_mul_mulInvariantExp_smul_pow [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] :
     let _ : BoundarylessManifold I G := ContMDiffMul.boundarylessManifold
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
@@ -251,14 +110,14 @@ theorem tendsto_mulInvariantExp_mul_pow_div [FiniteDimensional ℝ E]
   have hf : ContinuousAt f 0 := by
     exact ((contMDiff_mulInvariantExp_smul (I := I) (G := G) X).mul
       (contMDiff_mulInvariantExp_smul (I := I) (G := G) Y)).continuous.continuousAt
-  have hlog := hasDerivAt_mulInvariantLog_mulInvariantExp_mul
+  have hlog := hasDerivAt_mulInvariantLog_mulInvariantExp_smul_mul_mulInvariantExp_smul
     (I := I) (G := G) X Y
   simpa only [f] using
     tendsto_pow_div_of_hasDerivAt_mulInvariantLog (I := I) (G := G)
       (X + Y) hf0 hf hlog t
 
 /-- The Trotter product formula for the exponential of left-invariant derivations. -/
-theorem tendsto_lieExp_mul_pow_div [FiniteDimensional ℝ E]
+theorem tendsto_lieExp_smul_mul_lieExp_smul_pow [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] :
     let _ : BoundarylessManifold I G := ContMDiffMul.boundarylessManifold
     let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
@@ -272,4 +131,5 @@ theorem tendsto_lieExp_mul_pow_div [FiniteDimensional ℝ E]
   let L := leftInvariantDerivationEquivGroupLieAlgebra
     (I := I) (G := G) BoundarylessManifold.isInteriorPoint
   simpa only [lieExp_eq_mulInvariantExp, map_smul, map_add] using
-    tendsto_mulInvariantExp_mul_pow_div (I := I) (G := G) (L X) (L Y) t
+    tendsto_mulInvariantExp_smul_mul_mulInvariantExp_smul_pow
+      (I := I) (G := G) (L X) (L Y) t

--- a/TauCeti/Geometry/Lie/Exponential/Trotter.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Trotter.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 public import TauCeti.Geometry.Lie.Exponential.LocalInverse
+public import TauCeti.Geometry.Lie.Interior
 
 /-!
 # The Trotter product formula
@@ -69,20 +70,26 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   [IsManifold I 1 G]
 
 attribute [local instance] LieGroup.minSmoothnessThree
+attribute [local instance] ContMDiffMul.boundarylessManifold
 
 /-- A tangent-to-identity curve has the expected exponential power limit. The derivative is
 stated in local logarithmic coordinates so the result can be reused independently of a chosen
 manifold expression for the curve. -/
 theorem tendsto_pow_div_of_hasDerivAt_mulInvariantLog [FiniteDimensional ℝ E]
-    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
-    {f : ℝ → G} (X : GroupLieAlgebra I G) (hf0 : f 0 = 1)
-    (hf : ContinuousAt f 0)
-    (hlog : HasDerivAt (fun s =>
-      (show E from mulInvariantLog (I := I) (G := G) (f s)))
-      (show E from X) 0)
-    (t : ℝ) :
-    Tendsto (fun n : ℕ => (f (t / n)) ^ n) atTop
-      (nhds (mulInvariantExp (I := I) (G := G) (t • X))) := by
+    [LieGroup I ∞ G] :
+    let _ : BoundarylessManifold I G := ContMDiffMul.boundarylessManifold
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+    ∀ {f : ℝ → G} (X : GroupLieAlgebra I G) (_hf0 : f 0 = 1),
+      ContinuousAt f 0 →
+      HasDerivAt (fun s =>
+        (show E from mulInvariantLog (I := I) (G := G) (f s)))
+        (show E from X) 0 →
+      ∀ t : ℝ, Tendsto (fun n : ℕ => (f (t / n)) ^ n) atTop
+        (nhds (mulInvariantExp (I := I) (G := G) (t • X))) := by
+  let _ : BoundarylessManifold I G := ContMDiffMul.boundarylessManifold
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
+  intro f X hf0 hf hlog t
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   have hlog0 : (show E from mulInvariantLog (I := I) (G := G) (f 0)) = 0 := by
     rw [hf0]
@@ -225,12 +232,18 @@ private theorem hasDerivAt_mulInvariantLog_mulInvariantExp_mul [FiniteDimensiona
 
 /-- The Trotter product formula for the tangent-space exponential. -/
 theorem tendsto_mulInvariantExp_mul_pow_div [FiniteDimensional ℝ E]
-    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
-    (X Y : GroupLieAlgebra I G) (t : ℝ) :
-    Tendsto (fun n : ℕ =>
-      (mulInvariantExp (I := I) (G := G) ((t / n) • X) *
-        mulInvariantExp (I := I) (G := G) ((t / n) • Y)) ^ n) atTop
-      (nhds (mulInvariantExp (I := I) (G := G) (t • (X + Y)))) := by
+    [LieGroup I ∞ G] :
+    let _ : BoundarylessManifold I G := ContMDiffMul.boundarylessManifold
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+    ∀ (X Y : GroupLieAlgebra I G) (t : ℝ),
+      Tendsto (fun n : ℕ =>
+        (mulInvariantExp (I := I) (G := G) ((t / n) • X) *
+          mulInvariantExp (I := I) (G := G) ((t / n) • Y)) ^ n) atTop
+        (nhds (mulInvariantExp (I := I) (G := G) (t • (X + Y)))) := by
+  let _ : BoundarylessManifold I G := ContMDiffMul.boundarylessManifold
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
+  intro X Y t
   let f : ℝ → G := fun s =>
     mulInvariantExp (I := I) (G := G) (s • X) *
       mulInvariantExp (I := I) (G := G) (s • Y)
@@ -246,10 +259,16 @@ theorem tendsto_mulInvariantExp_mul_pow_div [FiniteDimensional ℝ E]
 
 /-- The Trotter product formula for the exponential of left-invariant derivations. -/
 theorem tendsto_lieExp_mul_pow_div [FiniteDimensional ℝ E]
-    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
-    (X Y : LeftInvariantDerivation I G) (t : ℝ) :
-    Tendsto (fun n : ℕ => (lieExp ((t / n) • X) * lieExp ((t / n) • Y)) ^ n) atTop
-      (nhds (lieExp (t • (X + Y)))) := by
+    [LieGroup I ∞ G] :
+    let _ : BoundarylessManifold I G := ContMDiffMul.boundarylessManifold
+    let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+    ∀ (X Y : LeftInvariantDerivation I G) (t : ℝ),
+      Tendsto (fun n : ℕ => (lieExp ((t / n) • X) * lieExp ((t / n) • Y)) ^ n) atTop
+        (nhds (lieExp (t • (X + Y)))) := by
+  let _ : BoundarylessManifold I G := ContMDiffMul.boundarylessManifold
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  dsimp only
+  intro X Y t
   let L := leftInvariantDerivationEquivGroupLieAlgebra
     (I := I) (G := G) BoundarylessManifold.isInteriorPoint
   simpa only [lieExp_eq_mulInvariantExp, map_smul, map_add] using

--- a/TauCeti/Geometry/Lie/Exponential/Trotter.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Trotter.lean
@@ -124,9 +124,7 @@ private theorem hasFDerivAt_mulInvariantLogChart_one [FiniteDimensional ℝ E]
   simpa using hlog.hasFDerivAt
 
 -- Multiplication's tangent-map API and `extChartAt` use dependent tangent-space synonyms at
--- definitionally equal basepoints. This scope lets Lean elaborate those existing interfaces; the
--- three conversions below state each semantic boundary explicitly.
-set_option backward.isDefEq.respectTransparency false in
+-- definitionally equal basepoints. The conversions below state each semantic boundary explicitly.
 private theorem hasFDerivAt_mulInvariantExp_mul_chartCurve [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
     (X Y : GroupLieAlgebra I G) :
@@ -160,9 +158,10 @@ private theorem hasFDerivAt_mulInvariantExp_mul_chartCurve [FiniteDimensional �
   have hchart := hext.comp 0 hcurve
   simp only [Function.comp_apply] at hchart
   rw [hzero] at hchart
-  apply hchart.hasFDerivAt.congr_fderiv
-  apply ContinuousLinearMap.ext
-  intro t
+  apply hchart.mdifferentiableAt.differentiableAt.hasFDerivAt.congr_fderiv
+  rw [← mfderiv_eq_fderiv, hchart.mfderiv]
+  apply DFunLike.coe_injective
+  funext t
   let s : ℝ := show ℝ from t
   rw [show (0 : ℝ) • X = 0 by exact zero_smul ℝ X,
     show (0 : ℝ) • Y = 0 by exact zero_smul ℝ Y,
@@ -185,7 +184,6 @@ private theorem hasFDerivAt_mulInvariantExp_mul_chartCurve [FiniteDimensional �
   have hmul_model := congrArg (fun Z : GroupLieAlgebra I G => show E from Z)
     (hmul_apply.trans (smul_add s X Y).symm)
   rw [mfderiv_extChartAt_self]
-  simp only [ContinuousLinearMap.comp_apply]
   -- `extChartAt` lands in the self-model, whose tangent space is the model-space synonym `E`.
   -- Expose that final chart boundary before applying the model-space equality above.
   change

--- a/TauCeti/Geometry/Lie/Exponential/Trotter.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Trotter.lean
@@ -1,0 +1,258 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+public import TauCeti.Geometry.Lie.Exponential.LocalInverse
+
+/-!
+# The Trotter product formula
+
+This file proves a tangent-to-identity power limit and applies it to the product of two
+exponential curves.
+
+## Main results
+
+* `tendsto_pow_div_of_hasDerivAt_mulInvariantLog`: a curve whose local logarithm has initial
+  derivative `X` has rescaled powers converging to `exp (t X)`.
+* `tendsto_mulInvariantExp_mul_pow_div`: the Trotter product formula in the tangent model.
+* `tendsto_lieExp_mul_pow_div`: the Trotter product formula for left-invariant derivations.
+
+## References
+
+* H. Liu, *Notes for Lie Groups & Representations*, Proposition 2.4.3.
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 2, "Closed subgroups and automatic smoothness".
+-/
+
+public section
+
+open Filter Function Manifold
+open scoped ContDiff Manifold Topology
+
+noncomputable section
+
+private theorem tendsto_nsmul_apply_div_of_hasDerivAt
+    {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+    {f : ℝ → F} {f' : F} (hf : HasDerivAt f f' 0) (hf0 : f 0 = 0) (t : ℝ) :
+    Tendsto (fun n : ℕ => n • f (t / n)) atTop (nhds (t • f')) := by
+  by_cases ht : t = 0
+  · subst t
+    simpa only [zero_div, hf0, nsmul_zero, zero_smul] using tendsto_const_nhds
+  have hn : Tendsto (fun n : ℕ => (n : ℝ)⁻¹) atTop (nhds 0) :=
+    tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop
+  have hs : Tendsto (fun n : ℕ => t / (n : ℝ)) atTop (nhds 0) := by
+    simpa only [div_eq_mul_inv, mul_comm, mul_zero] using hn.mul_const t
+  have hs_ne : ∀ᶠ n : ℕ in (atTop : Filter ℕ), t / (n : ℝ) ≠ 0 := by
+    filter_upwards [eventually_gt_atTop (0 : ℕ)] with n hnpos
+    exact div_ne_zero ht (show (n : ℝ) ≠ 0 from
+      Nat.cast_ne_zero.mpr (Nat.ne_of_gt hnpos))
+  have hs' : Tendsto (fun n : ℕ => t / (n : ℝ)) atTop
+      (nhdsWithin 0 ({0} : Set ℝ)ᶜ) :=
+    tendsto_nhdsWithin_iff.mpr ⟨hs, hs_ne⟩
+  have hscaled := (hf.tendsto_slope_zero.comp hs').const_smul t
+  convert hscaled using 1
+  funext n
+  by_cases hn0 : n = 0
+  · subst n
+    simp [hf0]
+  rw [show n • f (t / (n : ℝ)) = (n : ℝ) • f (t / (n : ℝ)) by
+    exact (Nat.cast_smul_eq_nsmul ℝ n _).symm]
+  simp only [Function.comp_apply, zero_add, hf0, sub_zero]
+  rw [smul_smul]
+  congr 1
+  field_simp
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [IsManifold I 1 G]
+
+attribute [local instance] LieGroup.minSmoothnessThree
+
+/-- A tangent-to-identity curve has the expected exponential power limit. The derivative is
+stated in local logarithmic coordinates so the result can be reused independently of a chosen
+manifold expression for the curve. -/
+theorem tendsto_pow_div_of_hasDerivAt_mulInvariantLog [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
+    {f : ℝ → G} (X : GroupLieAlgebra I G) (hf0 : f 0 = 1)
+    (hf : ContinuousAt f 0)
+    (hlog : HasDerivAt (fun s =>
+      (show E from mulInvariantLog (I := I) (G := G) (f s)))
+      (show E from X) 0)
+    (t : ℝ) :
+    Tendsto (fun n : ℕ => (f (t / n)) ^ n) atTop
+      (nhds (mulInvariantExp (I := I) (G := G) (t • X))) := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  have hlog0 : (show E from mulInvariantLog (I := I) (G := G) (f 0)) = 0 := by
+    rw [hf0]
+    exact mulInvariantLog_one (I := I) (G := G)
+  have hseq := tendsto_nsmul_apply_div_of_hasDerivAt hlog hlog0 t
+  have hexp :=
+    (contMDiff_mulInvariantExp (I := I) (G := G)).continuous.continuousAt.tendsto.comp hseq
+  have hn : Tendsto (fun n : ℕ => (n : ℝ)⁻¹) atTop (nhds 0) :=
+    tendsto_inv_atTop_zero.comp tendsto_natCast_atTop_atTop
+  have hs : Tendsto (fun n : ℕ => t / (n : ℝ)) atTop (nhds 0) := by
+    simpa only [div_eq_mul_inv, mul_comm, mul_zero] using hn.mul_const t
+  have hfseq : Tendsto (fun n : ℕ => f (t / (n : ℝ))) atTop (nhds (1 : G)) := by
+    have hf' := hf.tendsto
+    rw [hf0] at hf'
+    -- Expose the sequence as a composition so `ContinuousAt.tendsto` can consume `hs`.
+    change Tendsto (f ∘ fun n : ℕ => t / (n : ℝ)) atTop (nhds (1 : G))
+    exact hf'.comp hs
+  have hevent := hfseq.eventually
+    (eventually_mulInvariantExp_log (I := I) (G := G))
+  apply hexp.congr'
+  filter_upwards [hevent] with n hnlog
+  -- Unwrap the tangent-space power formula before rewriting by the local exp-log inverse.
+  change mulInvariantExp (I := I) (G := G)
+      (n • (mulInvariantLog (I := I) (G := G) (f (t / (n : ℝ))) :
+        GroupLieAlgebra I G)) = f (t / (n : ℝ)) ^ n
+  rw [mulInvariantExp_nsmul, hnlog]
+
+private theorem hasFDerivAt_mulInvariantLogChart_one [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    HasFDerivAt (mulInvariantLogChart (I := I) (G := G))
+      (ContinuousLinearMap.id ℝ E) (extChartAt I (1 : G) (1 : G)) := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  have hexp : HasStrictFDerivAt (mulInvariantExpChart (I := I) (G := G))
+      ((ContinuousLinearEquiv.refl ℝ E : E ≃L[ℝ] E) : E →L[ℝ] E) 0 :=
+    (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)).hasStrictFDerivAt'
+      (hasFDerivAt_mulInvariantExpChart_zero (I := I) (G := G)) (by simp)
+  have hlog := hexp.to_local_left_inverse
+    (eventually_mulInvariantLogChart_exp (I := I) (G := G))
+  simpa using hlog.hasFDerivAt
+
+-- Multiplication's tangent-map API and `extChartAt` use dependent tangent-space synonyms at
+-- definitionally equal basepoints. This scope lets Lean elaborate those existing interfaces; the
+-- three conversions below state each semantic boundary explicitly.
+set_option backward.isDefEq.respectTransparency false in
+private theorem hasFDerivAt_mulInvariantExp_mul_chartCurve [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
+    (X Y : GroupLieAlgebra I G) :
+    HasFDerivAt
+      (fun t : ℝ => extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) (t • X) *
+          mulInvariantExp (I := I) (G := G) (t • Y)))
+      ((1 : ℝ →L[ℝ] ℝ).smulRight ((show E from X) + (show E from Y))) 0 := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  have hX := hasMFDerivAt_mulInvariantExp_smul_zero (I := I) (G := G) X
+  have hY := hasMFDerivAt_mulInvariantExp_smul_zero (I := I) (G := G) Y
+  have hpair := hX.prodMk hY
+  have hmul := (contMDiff_mul (G := G) I ∞).contMDiffAt
+    (x := (mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X),
+      mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y)))
+    |>.mdifferentiableAt (by simp)
+  have hcurve := hmul.hasMFDerivAt.comp 0 hpair
+  have hzero :
+      mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) *
+        mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y) = (1 : G) := by
+    simp
+  rw [hzero] at hcurve
+  have hsource :
+      mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) *
+          mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y) ∈
+        (chartAt H (1 : G)).source := by
+    rw [hzero]
+    exact mem_chart_source H (1 : G)
+  have hext := (mdifferentiableAt_extChartAt (I := I)
+    (x := (1 : G)) hsource).hasMFDerivAt
+  have hchart := hext.comp 0 hcurve
+  simp only [Function.comp_apply] at hchart
+  rw [hzero] at hchart
+  apply hchart.hasFDerivAt.congr_fderiv
+  apply ContinuousLinearMap.ext
+  intro t
+  let s : ℝ := show ℝ from t
+  rw [show (0 : ℝ) • X = 0 by exact zero_smul ℝ X,
+    show (0 : ℝ) • Y = 0 by exact zero_smul ℝ Y,
+    mulInvariantExp_zero]
+  have hmul_tangent := tangentMap_mul_prod_apply (I := I) (G := G)
+    (⟨1, s • X⟩ : TangentBundle I G) (⟨1, s • Y⟩ : TangentBundle I G)
+  have hmul_apply := congrArg (fun z : TangentBundle I G => z.2) hmul_tangent
+  -- Project the bundled tangent-map equation to its fiberwise `mfderiv` statement.
+  change
+    (mfderiv (I.prod I) I (fun p : G × G => p.1 * p.2) ((1, 1) : G × G))
+        (s • X, s • Y) =
+      (mfderiv I I (fun z : G => z * 1) 1) (s • X) +
+        (mfderiv I I (fun z : G => 1 * z) 1) (s • Y) at hmul_apply
+  rw [show (fun z : G => z * 1) = id by funext z; simp,
+    show (fun z : G => 1 * z) = id by funext z; simp, mfderiv_id] at hmul_apply
+  -- Apply the two identity derivatives and expose scalar multiplication in the group tangent space.
+  change
+    (mfderiv (I.prod I) I (fun p : G × G => p.1 * p.2) ((1, 1) : G × G))
+        (s • X, s • Y) = s • X + s • Y at hmul_apply
+  have hmul_model := congrArg (fun Z : GroupLieAlgebra I G => show E from Z)
+    (hmul_apply.trans (smul_add s X Y).symm)
+  rw [mfderiv_extChartAt_self]
+  simp only [ContinuousLinearMap.comp_apply]
+  -- `extChartAt` lands in the self-model, whose tangent space is the model-space synonym `E`.
+  -- Expose that final chart boundary before applying the model-space equality above.
+  change
+    (show E from
+      (mfderiv (I.prod I) I (fun p : G × G => p.1 * p.2) ((1, 1) : G × G))
+        (s • X, s • Y)) =
+      (show E from s • (X + Y))
+  simpa only [s] using hmul_model
+
+private theorem hasDerivAt_mulInvariantLog_mulInvariantExp_mul [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
+    (X Y : GroupLieAlgebra I G) :
+    HasDerivAt
+      (fun t : ℝ => (show E from mulInvariantLog (I := I) (G := G)
+        (mulInvariantExp (I := I) (G := G) (t • X) *
+          mulInvariantExp (I := I) (G := G) (t • Y))))
+      ((show E from X) + (show E from Y)) 0 := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  have hlog := hasFDerivAt_mulInvariantLogChart_one (I := I) (G := G)
+  have hcurve := hasFDerivAt_mulInvariantExp_mul_chartCurve (I := I) (G := G) X Y
+  have hlog' : HasFDerivAt (mulInvariantLogChart (I := I) (G := G))
+      (ContinuousLinearMap.id ℝ E)
+      (extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) ((0 : ℝ) • X) *
+          mulInvariantExp (I := I) (G := G) ((0 : ℝ) • Y))) := by
+    simpa using hlog
+  have hcomp' := (hlog'.comp 0 hcurve).hasDerivAt
+  rw [show (mulInvariantLogChart (I := I) (G := G) ∘
+      fun t : ℝ => extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) (t • X) *
+          mulInvariantExp (I := I) (G := G) (t • Y))) =
+      fun t : ℝ => (show E from mulInvariantLog (I := I) (G := G)
+        (mulInvariantExp (I := I) (G := G) (t • X) *
+          mulInvariantExp (I := I) (G := G) (t • Y))) by
+    funext t
+    exact (mulInvariantLog_eq_chart (I := I) (G := G) _).symm] at hcomp'
+  simpa only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.id_apply,
+    ContinuousLinearMap.smulRight_apply, one_apply_eq_self, one_smul] using hcomp'
+
+/-- The Trotter product formula for the tangent-space exponential. -/
+theorem tendsto_mulInvariantExp_mul_pow_div [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
+    (X Y : GroupLieAlgebra I G) (t : ℝ) :
+    Tendsto (fun n : ℕ =>
+      (mulInvariantExp (I := I) (G := G) ((t / n) • X) *
+        mulInvariantExp (I := I) (G := G) ((t / n) • Y)) ^ n) atTop
+      (nhds (mulInvariantExp (I := I) (G := G) (t • (X + Y)))) := by
+  let f : ℝ → G := fun s =>
+    mulInvariantExp (I := I) (G := G) (s • X) *
+      mulInvariantExp (I := I) (G := G) (s • Y)
+  have hf0 : f 0 = 1 := by simp [f]
+  have hf : ContinuousAt f 0 := by
+    exact ((contMDiff_mulInvariantExp_smul (I := I) (G := G) X).mul
+      (contMDiff_mulInvariantExp_smul (I := I) (G := G) Y)).continuous.continuousAt
+  have hlog := hasDerivAt_mulInvariantLog_mulInvariantExp_mul
+    (I := I) (G := G) X Y
+  simpa only [f] using
+    tendsto_pow_div_of_hasDerivAt_mulInvariantLog (I := I) (G := G)
+      (X + Y) hf0 hf hlog t
+
+/-- The Trotter product formula for the exponential of left-invariant derivations. -/
+theorem tendsto_lieExp_mul_pow_div [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
+    (X Y : LeftInvariantDerivation I G) (t : ℝ) :
+    Tendsto (fun n : ℕ => (lieExp ((t / n) • X) * lieExp ((t / n) • Y)) ^ n) atTop
+      (nhds (lieExp (t • (X + Y)))) := by
+  let L := leftInvariantDerivationEquivGroupLieAlgebra
+    (I := I) (G := G) BoundarylessManifold.isInteriorPoint
+  simpa only [lieExp_eq_mulInvariantExp, map_smul, map_add] using
+    tendsto_mulInvariantExp_mul_pow_div (I := I) (G := G) (L X) (L Y) t

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Basic.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Basic.lean
@@ -24,6 +24,7 @@ tangent-bundle smoothness inputs from `TauCeti.Geometry.Manifold.VectorField.Reg
   tangent bundles.
 * `tangentMap_mul_prod_apply`: the value of that tangent map is the sum of the two partial
   derivatives of multiplication.
+* `mfderiv_mul_apply_one`: at the identity pair, the derivative of multiplication is addition.
 * `mfderiv_mul_left_mulInvariantVectorField`: left translation intertwines a left-invariant vector
   field with itself.
 * `contMDiff_tangentMap_mul_prod_comp`: regularity after feeding two smooth tangent-bundle inputs
@@ -79,6 +80,30 @@ theorem tangentMap_mul_prod_apply [ContMDiffMul I 1 G] (p q : TangentBundle I G)
   simp +instances [equivTangentBundleProd]
 
 end Multiplication
+
+section MultiplicationAtOne
+
+variable {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+
+/-- At the identity pair, the derivative of multiplication is addition on the tangent Lie
+algebra. -/
+theorem mfderiv_mul_apply_one [ContMDiffMul I 1 G] (v w : GroupLieAlgebra I G) :
+    mfderiv (I.prod I) I (fun p : G × G => p.1 * p.2) ((1, 1) : G × G) (v, w) =
+      v + w := by
+  have hmul_tangent := tangentMap_mul_prod_apply (I := I) (G := G)
+    (⟨1, v⟩ : TangentBundle I G) (⟨1, w⟩ : TangentBundle I G)
+  have hmul_apply := congrArg (fun z : TangentBundle I G => z.2) hmul_tangent
+  -- Project the bundled tangent-map equation to its fiberwise `mfderiv` statement.
+  change
+    (mfderiv (I.prod I) I (fun p : G × G => p.1 * p.2) ((1, 1) : G × G))
+        (v, w) =
+      (mfderiv I I (fun z : G => z * 1) 1) v +
+        (mfderiv I I (fun z : G => 1 * z) 1) w at hmul_apply
+  rw [show (fun z : G => z * 1) = id by funext z; simp,
+    show (fun z : G => 1 * z) = id by funext z; simp, mfderiv_id] at hmul_apply
+  exact hmul_apply
+
+end MultiplicationAtOne
 
 section TangentMapInputs
 


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Proves the Trotter product formula for finite-dimensional real Lie groups.

- Establishes a tangent-to-identity power limit in local logarithmic coordinates.
- Derives tangent-space and left-invariant-derivation forms of Trotter.

## Roadmap target

Supplies the addition-closure input for Layer 2 closed-subgroup Lie algebras:
https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-2-the-closed-subgroup-cartan-theorem

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"LieGroups/Suggested.lean#lieSubalgebraOfSubgroup"}-->

## Verification

Full and focused builds, audits, lint, downstream consumer, golf, and fresh complete aggregate review pair pass at `0b8a833d0c0bcf2393971bdfc0fcf19f5f3cdf5b`.

## Scale and generality

Adds focused calculus and logarithmic-derivative modules, then extends the existing Trotter interface for finite-dimensional real smooth Lie groups. The generic theorem accepts any continuous curve through the identity whose local logarithm has the prescribed derivative.

## Scope

- **Consumes:** Lie exponential/local inverse and the multiplication tangent map.
- **Provides:** the tangent-to-identity power limit and two Trotter formulas.
- **Fits:** supplies addition closure for the subgroup Lie algebra used by Cartan closed-subgroup work.
- **Boundary:** subgroup Lie algebras, embedded structures, and automatic smoothness remain downstream.

<sub>🤖 GPT-5.6 Sol high · [rubrics](https://github.com/TauCetiProject/TauCetiReview/commit/2c299e1d1950d731786005ef33209486b2fa7f9d) · local 2+1 review @ [8429746](https://github.com/utensil/formal-land/commit/8429746) fixed: placement (1), proof-quality (1), reuse (1)</sub>