### PR TITLE
refactor(ViaKoopman): reuse the block-average API for the Birkhoff bound

### DIFF
--- a/TauCeti/Probability/DeFinetti/ViaKoopman/Decoupling.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/Decoupling.lean
@@ -8,6 +8,7 @@ public import TauCeti.Probability.Exchangeability.PathSpace.ContractableLaw
 import TauCeti.Probability.Exchangeability.PathSpace.Invariant.BlockTransport
 public import TauCeti.Probability.DeFinetti.ViaKoopman.InvariantConditionalLaw
 import Mathlib.Dynamics.BirkhoffSum.Average
+import TauCeti.Probability.Process.BlockAverage
 import TauCeti.Probability.Ergodic.CondExpProjection
 import TauCeti.MeasureTheory.Integral.Bochner.Basic
 
@@ -358,19 +359,9 @@ theorem setIntegral_weight_mul_prefix_mul_indicator_eq_condExp
     exact hsum.const_smul ((n : ℝ)⁻¹)
   have havg_bdd : ∀ (n : ℕ) (x : ℕ → α), ‖birkhoffAverage ℝ (shift α) φ n x‖ ≤ 1 := by
     intro n x
-    rcases Nat.eq_zero_or_pos n with rfl | hn
-    · simp [birkhoffAverage, birkhoffSum]
-    · have hs0 : 0 ≤ ∑ m ∈ Finset.range n, φ ((shift α)^[m] x) :=
-        Finset.sum_nonneg fun m _ => hind_nonneg _
-      have hsn : ∑ m ∈ Finset.range n, φ ((shift α)^[m] x) ≤ (n : ℝ) := by
-        calc ∑ m ∈ Finset.range n, φ ((shift α)^[m] x)
-            ≤ ∑ _m ∈ Finset.range n, (1 : ℝ) := Finset.sum_le_sum fun m _ => hind_le _
-          _ = (n : ℝ) := by simp
-      rw [birkhoffAverage, birkhoffSum, smul_eq_mul, Real.norm_eq_abs,
-        abs_of_nonneg (by positivity)]
-      calc (n : ℝ)⁻¹ * ∑ m ∈ Finset.range n, φ ((shift α)^[m] x)
-          ≤ (n : ℝ)⁻¹ * (n : ℝ) := by gcongr
-        _ = 1 := inv_mul_cancel₀ (Nat.cast_ne_zero.mpr hn.ne')
+    rw [birkhoffAverage_eq_prefixAverage, prefixAverage_def, Real.norm_eq_abs,
+      abs_of_nonneg (blockAverage_nonneg fun i => hind_nonneg _)]
+    exact blockAverage_le_one fun i => hind_le _
   have havg_int : ∀ n : ℕ, Integrable (birkhoffAverage ℝ (shift α) φ n) ρ := fun n =>
     ⟨(havg_meas n).aestronglyMeasurable,
       .of_bounded (C := 1) (Filter.Eventually.of_forall (havg_bdd n))⟩


### PR DESCRIPTION
`Process/BlockAverage.lean` provides `birkhoffAverage_eq_prefixAverage`, `blockAverage_nonneg` and
`blockAverage_le_one`, and its own docstring says the Birkhoff bridge exists for the Koopman route
to read the mean ergodic theorem in terms of prefix averages. The decoupling chain did not use it:
it rebuilt the bridge inline and reproved the `[0,1]` bound by hand, splitting on `n = 0`, bounding
the sum by `n`, and cancelling.

Going through the intended API:

```lean
rw [birkhoffAverage_eq_prefixAverage, prefixAverage_def, Real.norm_eq_abs,
  abs_of_nonneg (blockAverage_nonneg fun i => hind_nonneg _)]
exact blockAverage_le_one fun i => hind_le _
```

Thirteen lines become four, and the nonlinear steps — `gcongr`, `positivity`,
`inv_mul_cancel₀` — disappear along with the case split.

`Process.BlockAverage` is imported non-publicly: it occurs only inside this proof, not in any
exported statement.

Roadmap: Exchangeability

Advances `TauCetiRoadmap/Exchangeability/README.md`, **Layer 5** (Koopman operators and invariant
σ-algebras). Improving an existing proof, so no new mathematical scope.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
