### PR TITLE
perf(L2): derive the square-root bound directly

### DIFF
--- a/TauCeti/Probability/Exchangeability/L2/Cesaro/Convergence.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Cesaro/Convergence.lean
@@ -104,20 +104,7 @@ private theorem dist_blockAverage_toLp_le_of_disjoint {μ : Measure Ω}
               (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / n :=
         add_le_add le_rfl hfrac
       _ = 2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / n := by ring
-  have hnonneg : 0 ≤ 2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / (n : ℝ) := by positivity
-  have hdist_nonneg :
-      0 ≤ dist
-        ((memLp_blockAverage k fun i => hY_L2 (k i)).toLp (blockAverage Y k))
-        (hB_L2.toLp B) :=
-    dist_nonneg
-  have hdist_le_sqrt :
-      dist
-          ((memLp_blockAverage k fun i => hY_L2 (k i)).toLp (blockAverage Y k))
-          (hB_L2.toLp B) ≤
-        Real.sqrt (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / n) := by
-    nlinarith [hdist_nonneg, Real.sqrt_nonneg
-      (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / n), Real.sq_sqrt hnonneg]
-  simpa only [B] using hdist_le_sqrt
+  simpa only [B] using Real.le_sqrt_of_sq_le hsq
 
 /-- Compare two block averages in `L²` through a longer block disjoint from both. -/
 private theorem dist_blockAverages_toLp_le_via_disjoint {μ : Measure Ω}


### PR DESCRIPTION
The Cesàro convergence proof reached its square-root bound through `nlinarith`, supported by two
nonnegativity hypotheses and `Real.sq_sqrt`:

```lean
have hnonneg : 0 ≤ 2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / (n : ℝ) := by positivity
have hdist_nonneg : 0 ≤ dist … := dist_nonneg
have hdist_le_sqrt : dist … ≤ Real.sqrt … := by
  nlinarith [hdist_nonneg, Real.sqrt_nonneg …, Real.sq_sqrt hnonneg]
simpa only [B] using hdist_le_sqrt
```

But the `hsq` established just above it is exactly `dist … ^ 2 ≤ …`, which is the hypothesis of
`Real.le_sqrt_of_sq_le (h : x ^ 2 ≤ y) : x ≤ √y` — a lemma needing no nonnegativity, since
`Real.sqrt` is junk-valued below zero. So the whole block is:

```lean
simpa only [B] using Real.le_sqrt_of_sq_le hsq
```

Fourteen lines out, one in. Proof-only: no statement, name or hypothesis changes.

Roadmap: Exchangeability

Advances `TauCetiRoadmap/Exchangeability/README.md`, **Layer 3** (`L²` averaging library and the
standard-Borel de Finetti route). Improving an existing proof, so no new mathematical scope.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
