### PR TITLE
feat(GroupTheory): adjoining a two-element centre doubles the index

### DIFF
--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -17,16 +17,16 @@ subgroup.
 Because the order of a subgroup divides the order of the group -- with the index as cofactor --
 invertibility of the order of a finite group in a semiring passes to every subgroup.
 
-Adjoining a two-element normal subgroup `N ⊄ Γ` is also quantified: `Γ` then has relative index
-exactly `2` in `Γ ⊔ N`, so `Γ.index = 2 * (Γ ⊔ N).index`. Taking `N` to be the centre gives the
-`Γ.withCenter` readings.
+Adjoining a two-element subgroup `N ⊄ Γ` normalised by `Γ` is also quantified: `Γ` then has
+relative index exactly `2` in `Γ ⊔ N`, so `Γ.index = 2 * (Γ ⊔ N).index`. Taking `N` to be the
+centre gives the `Γ.withCenter` readings.
 
 ## Main results
 
 * `Subgroup.mem_withCenter_iff` and `Subgroup.withCenter_eq_self_iff`: membership in `Γ·Z(G)`,
   and the case in which adjoining the centre changes nothing.
 * `Subgroup.relIndex_sup_eq_two`, `Subgroup.index_eq_two_mul_index_sup`: the relative index `2`
-  and the index doubling, for a normal `N` whose elements are `1` and `a ∉ Γ`.
+  and the index doubling, for an `N` normalised by `Γ` whose elements are `1` and `a ∉ Γ`.
 * `Subgroup.relIndex_withCenter_eq_two`, `Subgroup.index_eq_two_mul_index_withCenter`: the same
   two facts on `Γ.withCenter`, when the centre is `{1, a}`.
 -/
@@ -57,8 +57,19 @@ theorem withCenter_def {G : Type*} [Group G] (Γ : Subgroup G) :
 lemma le_withCenter {G : Type*} [Group G] (Γ : Subgroup G) : Γ ≤ Γ.withCenter :=
   le_sup_left
 
+/-- The centre sits inside `Γ` with the centre adjoined — the other half of the supremum. -/
+lemma center_le_withCenter {G : Type*} [Group G] (Γ : Subgroup G) :
+    Subgroup.center G ≤ Γ.withCenter :=
+  le_sup_right
+
 /-- **Characteristic membership for `withCenter`**: an element of `Γ·Z(G)` is one of `Γ` times a
-central one. The centre is normal, so the supremum is the pointwise product. -/
+central one. The centre is normal, so the supremum is the pointwise product.
+
+Not `@[simp]`, tested: its left-hand side `g ∈ Γ.withCenter` is the same shape as that of the
+`SL(2, ℤ)`-specific `Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg`, which *is* `@[simp]` and
+resolves the centre to `{±1}`. Tagging this one too takes that lemma's left-hand side out of
+simp-normal form — `simpNF` rejects it — and would pre-empt the sharper rewrite everywhere the
+group is `SL(2, ℤ)`. -/
 theorem mem_withCenter_iff {G : Type*} [Group G] {Γ : Subgroup G} {g : G} :
     g ∈ Γ.withCenter ↔ ∃ γ ∈ Γ, ∃ c ∈ Subgroup.center G, g = γ * c := by
   rw [withCenter_def, Subgroup.mem_sup_of_normal_right]
@@ -78,9 +89,14 @@ instance instFiniteIndexWithCenter {G : Type*} [Group G] (Γ : Subgroup G)
 
 variable {G : Type*} [Group G] {Γ : Subgroup G} {a : G}
 
-/-- **A two-element normal subgroup not already inside `Γ` has relative index `2`.** If every
-element of `N` is `1` or `a`, and `a ∉ Γ`, then `Γ ⊔ N` splits into the two cosets `Γ` and
-`Γ * a`.
+/-- **A two-element subgroup normalised by `Γ` and not already inside it has relative index
+`2`.** If every element of `N` is `1` or `a`, and `a ∉ Γ`, then `Γ ⊔ N` splits into the two
+cosets `Γ` and `Γ * a`.
+
+Only `Γ ≤ Subgroup.normalizer N` is asked for, not normality of `N` in the whole group: all the
+proof needs is that `Γ ⊔ N` is the pointwise product `Γ * N`, which
+`Subgroup.coe_mul_of_left_le_normalizer_right` supplies from the weaker hypothesis. A globally
+normal `N` is the special case `Subgroup.le_normalizer_of_normal`.
 
 Stated for an arbitrary `N` rather than for the centre, because the centre is often larger than
 two elements — in `GL (Fin 2) ℝ` it is every scalar — while the two-element subgroup one actually
@@ -92,24 +108,27 @@ would force `a = 1 ∈ Γ`.
 Generalises Mathlib's `Subgroup.relindex_adjoinNegOne_eq_two`
 (`Mathlib/NumberTheory/ModularForms/ArithmeticSubgroups.lean`) from `𝒢 ≤ GL n R` with `a = -1` to
 an arbitrary group, by the same `Subgroup.relIndex_eq_two_iff_exists_notMem_and` criterion. -/
-theorem relIndex_sup_eq_two (N : Subgroup G) [N.Normal] (ha : a ∈ N) (haΓ : a ∉ Γ)
-    (hN : ∀ c ∈ N, c = 1 ∨ c = a) : Γ.relIndex (Γ ⊔ N) = 2 := by
+theorem relIndex_sup_eq_two (N : Subgroup G) (hnorm : Γ ≤ Subgroup.normalizer N) (ha : a ∈ N)
+    (haΓ : a ∉ Γ) (hN : ∀ c ∈ N, c = 1 ∨ c = a) : Γ.relIndex (Γ ⊔ N) = 2 := by
   have ha2 : a * a = 1 := by
     rcases hN _ (N.mul_mem ha ha) with h | h
     · exact h
     · exact absurd (mul_eq_left.mp h ▸ Γ.one_mem) haΓ
   refine Subgroup.relIndex_eq_two_iff_exists_notMem_and.mpr
     ⟨a, Subgroup.mem_sup_right ha, haΓ, fun b hb ↦ ?_⟩
-  obtain ⟨g, hg, c, hc, rfl⟩ := Subgroup.mem_sup_of_normal_right.mp hb
+  rw [← SetLike.mem_coe, Subgroup.coe_mul_of_left_le_normalizer_right Γ N hnorm] at hb
+  obtain ⟨g, hg, c, hc, rfl⟩ := hb
   rcases hN c hc with rfl | rfl
   · exact Or.inr (by simpa using hg)
   · exact Or.inl (by simpa [mul_assoc, ha2] using hg)
 
-/-- **The index doubles on adjoining a two-element normal subgroup not inside `Γ`.** The counting
-form of `Subgroup.relIndex_sup_eq_two`. -/
-theorem index_eq_two_mul_index_sup (N : Subgroup G) [N.Normal] (ha : a ∈ N) (haΓ : a ∉ Γ)
-    (hN : ∀ c ∈ N, c = 1 ∨ c = a) : Γ.index = 2 * (Γ ⊔ N).index := by
-  rw [← Subgroup.relIndex_mul_index (le_sup_left : Γ ≤ Γ ⊔ N), relIndex_sup_eq_two N ha haΓ hN]
+/-- **The index doubles on adjoining a two-element subgroup normalised by `Γ` and not inside
+it.** The counting form of `Subgroup.relIndex_sup_eq_two`. -/
+theorem index_eq_two_mul_index_sup (N : Subgroup G) (hnorm : Γ ≤ Subgroup.normalizer N)
+    (ha : a ∈ N) (haΓ : a ∉ Γ) (hN : ∀ c ∈ N, c = 1 ∨ c = a) :
+    Γ.index = 2 * (Γ ⊔ N).index := by
+  rw [← Subgroup.relIndex_mul_index (le_sup_left : Γ ≤ Γ ⊔ N),
+    relIndex_sup_eq_two N hnorm ha haΓ hN]
 
 /-- **When the centre is `{1, a}` and `a ∉ Γ`, `Γ` has relative index exactly `2` in
 `Γ.withCenter`.** The centre reading of `Subgroup.relIndex_sup_eq_two`. This is the branch in
@@ -121,7 +140,8 @@ dichotomy recorded on `Subgroup.withCenter`: cosets of `Γ` count each translate
 unless `-I ∈ Γ` already. -/
 theorem relIndex_withCenter_eq_two (ha : a ∈ Subgroup.center G) (haΓ : a ∉ Γ)
     (hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a) : Γ.relIndex Γ.withCenter = 2 :=
-  Subgroup.withCenter_def Γ ▸ relIndex_sup_eq_two _ ha haΓ hcenter
+  Subgroup.withCenter_def Γ ▸
+    relIndex_sup_eq_two _ Subgroup.le_normalizer_of_normal ha haΓ hcenter
 
 /-- **When the centre is `{1, a}` and `a ∉ Γ`, the index of `Γ` is twice that of
 `Γ.withCenter`.** The counting form of `Subgroup.relIndex_withCenter_eq_two`: it is
@@ -129,7 +149,8 @@ theorem relIndex_withCenter_eq_two (ha : a ∈ Subgroup.center G) (haΓ : a ∉ 
 twice the geometric one. -/
 theorem index_eq_two_mul_index_withCenter (ha : a ∈ Subgroup.center G) (haΓ : a ∉ Γ)
     (hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a) : Γ.index = 2 * Γ.withCenter.index :=
-  Subgroup.withCenter_def Γ ▸ index_eq_two_mul_index_sup _ ha haΓ hcenter
+  Subgroup.withCenter_def Γ ▸
+    index_eq_two_mul_index_sup _ Subgroup.le_normalizer_of_normal ha haΓ hcenter
 
 end Subgroup
 

--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -17,13 +17,16 @@ subgroup.
 Because the order of a subgroup divides the order of the group -- with the index as cofactor --
 invertibility of the order of a finite group in a semiring passes to every subgroup.
 
-Adjoining the centre is also quantified: when the centre is `{1, a}` with `a ∉ Γ`, the subgroup
-`Γ` has relative index exactly `2` in `Γ.withCenter`, so `Γ.index = 2 * Γ.withCenter.index`.
+Adjoining a two-element normal subgroup `N ⊄ Γ` is also quantified: `Γ` then has relative index
+exactly `2` in `Γ ⊔ N`, so `Γ.index = 2 * (Γ ⊔ N).index`. Taking `N` to be the centre gives the
+`Γ.withCenter` readings.
 
 ## Main results
 
-* `Subgroup.relIndex_withCenter_eq_two`, `Subgroup.index_eq_two_mul_index_withCenter`: the
-  relative index `2` and the index doubling, for a two-element centre not contained in `Γ`.
+* `Subgroup.relIndex_sup_eq_two`, `Subgroup.index_eq_two_mul_index_sup`: the relative index `2`
+  and the index doubling, for a normal `N` whose elements are `1` and `a ∉ Γ`.
+* `Subgroup.relIndex_withCenter_eq_two`, `Subgroup.index_eq_two_mul_index_withCenter`: the same
+  two facts on `Γ.withCenter`, when the centre is `{1, a}`.
 -/
 
 public section
@@ -58,38 +61,58 @@ instance instFiniteIndexWithCenter {G : Type*} [Group G] (Γ : Subgroup G)
 
 variable {G : Type*} [Group G] {Γ : Subgroup G} {a : G}
 
-/-- **When the centre is `{1, a}` and `a ∉ Γ`, `Γ` has relative index exactly `2` in
-`Γ.withCenter`.** Only this branch is proved here; the complementary `a ∈ Γ` case, in which the
-two subgroups coincide, is an unformalised remark.
+/-- **A two-element normal subgroup not already inside `Γ` has relative index `2`.** If every
+element of `N` is `1` or `a`, and `a ∉ Γ`, then `Γ ⊔ N` splits into the two cosets `Γ` and
+`Γ * a`.
 
-For `Γ ≤ SL(2, ℤ)` the centre is `{±I}` and `a = -I`, so this is the quantitative form of the
-dichotomy recorded on `Subgroup.withCenter`: cosets of `Γ` count each translate of `𝒟` twice
-unless `-I ∈ Γ` already.
+Stated for an arbitrary `N` rather than for the centre, because the centre is often larger than
+two elements — in `GL (Fin 2) ℝ` it is every scalar — while the two-element subgroup one actually
+wants there is `Subgroup.zpowers (-1)`. A caller supplies whichever `N` is in hand.
 
-`a` is not assumed to be an involution — that follows, since `a * a` lies in the centre and
-`a * a = a` would force `a = 1 ∈ Γ`. -/
-theorem relIndex_withCenter_eq_two (ha : a ∈ Subgroup.center G) (haΓ : a ∉ Γ)
-    (hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a) : Γ.relIndex Γ.withCenter = 2 := by
+`a` is not assumed to be an involution: `a * a` lies in `N`, hence is `1` or `a`, and `a * a = a`
+would force `a = 1 ∈ Γ`.
+
+Generalises Mathlib's `Subgroup.relindex_adjoinNegOne_eq_two`
+(`Mathlib/NumberTheory/ModularForms/ArithmeticSubgroups.lean`) from `𝒢 ≤ GL n R` with `a = -1` to
+an arbitrary group, by the same `Subgroup.relIndex_eq_two_iff_exists_notMem_and` criterion. -/
+theorem relIndex_sup_eq_two (N : Subgroup G) [N.Normal] (ha : a ∈ N) (haΓ : a ∉ Γ)
+    (hN : ∀ c ∈ N, c = 1 ∨ c = a) : Γ.relIndex (Γ ⊔ N) = 2 := by
   have ha2 : a * a = 1 := by
-    rcases hcenter _ ((Subgroup.center G).mul_mem ha ha) with h | h
+    rcases hN _ (N.mul_mem ha ha) with h | h
     · exact h
     · exact absurd (mul_eq_left.mp h ▸ Γ.one_mem) haΓ
   refine Subgroup.relIndex_eq_two_iff_exists_notMem_and.mpr
-    ⟨a, Subgroup.withCenter_def Γ ▸ Subgroup.mem_sup_right ha, haΓ, fun b hb ↦ ?_⟩
-  -- `withCenter` is a supremum with a normal subgroup, so its elements factor as `g * c`
-  obtain ⟨g, hg, c, hc, rfl⟩ :=
-    Subgroup.mem_sup_of_normal_right.mp (Subgroup.withCenter_def Γ ▸ hb)
-  rcases hcenter c hc with rfl | rfl
+    ⟨a, Subgroup.mem_sup_right ha, haΓ, fun b hb ↦ ?_⟩
+  obtain ⟨g, hg, c, hc, rfl⟩ := Subgroup.mem_sup_of_normal_right.mp hb
+  rcases hN c hc with rfl | rfl
   · exact Or.inr (by simpa using hg)
   · exact Or.inl (by simpa [mul_assoc, ha2] using hg)
 
+/-- **The index doubles on adjoining a two-element normal subgroup not inside `Γ`.** The counting
+form of `Subgroup.relIndex_sup_eq_two`. -/
+theorem index_eq_two_mul_index_sup (N : Subgroup G) [N.Normal] (ha : a ∈ N) (haΓ : a ∉ Γ)
+    (hN : ∀ c ∈ N, c = 1 ∨ c = a) : Γ.index = 2 * (Γ ⊔ N).index := by
+  rw [← Subgroup.relIndex_mul_index (le_sup_left : Γ ≤ Γ ⊔ N), relIndex_sup_eq_two N ha haΓ hN]
+
+/-- **When the centre is `{1, a}` and `a ∉ Γ`, `Γ` has relative index exactly `2` in
+`Γ.withCenter`.** The centre reading of `Subgroup.relIndex_sup_eq_two`. Only this branch is
+proved; the complementary `a ∈ Γ` case, in which the two subgroups coincide, is an unformalised
+remark.
+
+For `Γ ≤ SL(2, ℤ)` the centre is `{±I}` and `a = -I`, so this is the quantitative form of the
+dichotomy recorded on `Subgroup.withCenter`: cosets of `Γ` count each translate of `𝒟` twice
+unless `-I ∈ Γ` already. -/
+theorem relIndex_withCenter_eq_two (ha : a ∈ Subgroup.center G) (haΓ : a ∉ Γ)
+    (hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a) : Γ.relIndex Γ.withCenter = 2 :=
+  Subgroup.withCenter_def Γ ▸ relIndex_sup_eq_two _ ha haΓ hcenter
+
 /-- **When the centre is `{1, a}` and `a ∉ Γ`, the index of `Γ` is twice that of
-`Γ.withCenter`.** The counting form of
-`Subgroup.relIndex_withCenter_eq_two`: it is `Γ.withCenter`, not `Γ`, whose cosets index the
-distinct translates, so a count over `Γ`-cosets is twice the geometric one. -/
+`Γ.withCenter`.** The counting form of `Subgroup.relIndex_withCenter_eq_two`: it is
+`Γ.withCenter`, not `Γ`, whose cosets index the distinct translates, so a count over `Γ`-cosets is
+twice the geometric one. -/
 theorem index_eq_two_mul_index_withCenter (ha : a ∈ Subgroup.center G) (haΓ : a ∉ Γ)
-    (hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a) : Γ.index = 2 * Γ.withCenter.index := by
-  rw [← Subgroup.relIndex_mul_index Γ.le_withCenter, relIndex_withCenter_eq_two ha haΓ hcenter]
+    (hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a) : Γ.index = 2 * Γ.withCenter.index :=
+  Subgroup.withCenter_def Γ ▸ index_eq_two_mul_index_sup _ ha haΓ hcenter
 
 end Subgroup
 

--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -112,9 +112,9 @@ theorem index_eq_two_mul_index_sup (N : Subgroup G) [N.Normal] (ha : a ∈ N) (h
   rw [← Subgroup.relIndex_mul_index (le_sup_left : Γ ≤ Γ ⊔ N), relIndex_sup_eq_two N ha haΓ hN]
 
 /-- **When the centre is `{1, a}` and `a ∉ Γ`, `Γ` has relative index exactly `2` in
-`Γ.withCenter`.** The centre reading of `Subgroup.relIndex_sup_eq_two`. Only this branch is
-proved; the complementary `a ∈ Γ` case, in which the two subgroups coincide, is an unformalised
-remark.
+`Γ.withCenter`.** The centre reading of `Subgroup.relIndex_sup_eq_two`. This is the branch in
+which the two subgroups genuinely differ; the complementary case, in which they coincide, is
+`Subgroup.withCenter_eq_self_iff` above.
 
 For `Γ ≤ SL(2, ℤ)` the centre is `{±I}` and `a = -I`, so this is the quantitative form of the
 dichotomy recorded on `Subgroup.withCenter`: cosets of `Γ` count each translate of `𝒟` twice

--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -23,8 +23,6 @@ centre gives the `Γ.withCenter` readings.
 
 ## Main results
 
-* `Subgroup.mem_withCenter_iff` and `Subgroup.withCenter_eq_self_iff`: membership in `Γ·Z(G)`,
-  and the case in which adjoining the centre changes nothing.
 * `Subgroup.relIndex_sup_eq_two`, `Subgroup.index_eq_two_mul_index_sup`: the relative index `2`
   and the index doubling, for an `N` normalised by `Γ` whose elements are `1` and `a ∉ Γ`.
 * `Subgroup.relIndex_withCenter_eq_two`, `Subgroup.index_eq_two_mul_index_withCenter`: the same
@@ -56,32 +54,6 @@ theorem withCenter_def {G : Type*} [Group G] (Γ : Subgroup G) :
 /-- `Γ` sits inside `Γ` with the centre adjoined. -/
 lemma le_withCenter {G : Type*} [Group G] (Γ : Subgroup G) : Γ ≤ Γ.withCenter :=
   le_sup_left
-
-/-- The centre sits inside `Γ` with the centre adjoined — the other half of the supremum. -/
-lemma center_le_withCenter {G : Type*} [Group G] (Γ : Subgroup G) :
-    Subgroup.center G ≤ Γ.withCenter :=
-  le_sup_right
-
-/-- **Characteristic membership for `withCenter`**: an element of `Γ·Z(G)` is one of `Γ` times a
-central one. The centre is normal, so the supremum is the pointwise product.
-
-Not `@[simp]`, tested: its left-hand side `g ∈ Γ.withCenter` is the same shape as that of the
-`SL(2, ℤ)`-specific `Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg`, which *is* `@[simp]` and
-resolves the centre to `{±1}`. Tagging this one too takes that lemma's left-hand side out of
-simp-normal form — `simpNF` rejects it — and would pre-empt the sharper rewrite everywhere the
-group is `SL(2, ℤ)`. -/
-theorem mem_withCenter_iff {G : Type*} [Group G] {Γ : Subgroup G} {g : G} :
-    g ∈ Γ.withCenter ↔ ∃ γ ∈ Γ, ∃ c ∈ Subgroup.center G, g = γ * c := by
-  rw [withCenter_def, Subgroup.mem_sup_of_normal_right]
-  exact ⟨fun ⟨γ, hγ, c, hc, h⟩ ↦ ⟨γ, hγ, c, hc, h.symm⟩,
-    fun ⟨γ, hγ, c, hc, h⟩ ↦ ⟨γ, hγ, c, hc, h.symm⟩⟩
-
-/-- **Adjoining the centre changes nothing exactly when the centre is already inside `Γ`** —
-the other half of the dichotomy `Subgroup.withCenter` describes. -/
-@[simp]
-theorem withCenter_eq_self_iff {G : Type*} [Group G] {Γ : Subgroup G} :
-    Γ.withCenter = Γ ↔ Subgroup.center G ≤ Γ :=
-  sup_eq_left
 
 instance instFiniteIndexWithCenter {G : Type*} [Group G] (Γ : Subgroup G)
     [Γ.FiniteIndex] : Γ.withCenter.FiniteIndex :=
@@ -130,8 +102,8 @@ theorem index_eq_two_mul_index_sup (N : Subgroup G) (hnorm : Γ ≤ Subgroup.nor
 
 /-- **When the centre is `{1, a}` and `a ∉ Γ`, `Γ` has relative index exactly `2` in
 `Γ.withCenter`.** The centre reading of `Subgroup.relIndex_sup_eq_two`. This is the branch in
-which the two subgroups genuinely differ; the complementary case, in which they coincide, is
-`Subgroup.withCenter_eq_self_iff` above.
+which the two subgroups genuinely differ; they coincide exactly when the centre already lies
+inside `Γ`.
 
 For `Γ ≤ SL(2, ℤ)` the centre is `{±I}` and `a = -I`, so this is the quantitative form of the
 dichotomy recorded on `Subgroup.withCenter`: cosets of `Γ` count each translate of `𝒟` twice

--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -93,21 +93,19 @@ variable {G : Type*} [Group G] {Γ : Subgroup G} {a : G}
 `2`.** If every element of `N` is `1` or `a`, and `a ∉ Γ`, then `Γ ⊔ N` splits into the two
 cosets `Γ` and `Γ * a`.
 
-Only `Γ ≤ Subgroup.normalizer N` is asked for, not normality of `N` in the whole group: all the
-proof needs is that `Γ ⊔ N` is the pointwise product `Γ * N`, which
-`Subgroup.coe_mul_of_left_le_normalizer_right` supplies from the weaker hypothesis. A globally
-normal `N` is the special case `Subgroup.le_normalizer_of_normal`.
+Only normalisation by `Γ` is asked for, not normality of `N` in the whole group, so a
+two-element subgroup normalised by `Γ` alone is covered. A globally normal `N` is the special
+case `Subgroup.le_normalizer_of_normal`.
 
 Stated for an arbitrary `N` rather than for the centre, because the centre is often larger than
 two elements — in `GL (Fin 2) ℝ` it is every scalar — while the two-element subgroup one actually
 wants there is `Subgroup.zpowers (-1)`. A caller supplies whichever `N` is in hand.
 
-`a` is not assumed to be an involution: `a * a` lies in `N`, hence is `1` or `a`, and `a * a = a`
-would force `a = 1 ∈ Γ`.
+`a` is not assumed to be an involution; it follows from the hypotheses that it is one.
 
 Generalises Mathlib's `Subgroup.relindex_adjoinNegOne_eq_two`
 (`Mathlib/NumberTheory/ModularForms/ArithmeticSubgroups.lean`) from `𝒢 ≤ GL n R` with `a = -1` to
-an arbitrary group, by the same `Subgroup.relIndex_eq_two_iff_exists_notMem_and` criterion. -/
+an arbitrary group. -/
 theorem relIndex_sup_eq_two (N : Subgroup G) (hnorm : Γ ≤ Subgroup.normalizer N) (ha : a ∈ N)
     (haΓ : a ∉ Γ) (hN : ∀ c ∈ N, c = 1 ∨ c = a) : Γ.relIndex (Γ ⊔ N) = 2 := by
   have ha2 : a * a = 1 := by

--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -6,10 +6,6 @@ module
 
 public import Mathlib.GroupTheory.Index
 
--- the pointwise product `↑(H ⊔ N) = ↑H * ↑N` serves only the proof below, so it stays off the
--- public surface
-import Mathlib.Algebra.Group.Subgroup.Pointwise
-
 /-!
 # Consequences of the index formula
 
@@ -20,6 +16,14 @@ subgroup.
 
 Because the order of a subgroup divides the order of the group -- with the index as cofactor --
 invertibility of the order of a finite group in a semiring passes to every subgroup.
+
+Adjoining the centre is also quantified: when the centre is `{1, a}` with `a ∉ Γ`, the subgroup
+`Γ` has relative index exactly `2` in `Γ.withCenter`, so `Γ.index = 2 * Γ.withCenter.index`.
+
+## Main results
+
+* `Subgroup.relIndex_withCenter_eq_two`, `Subgroup.index_eq_two_mul_index_withCenter`: the
+  relative index `2` and the index doubling, for a two-element centre not contained in `Γ`.
 -/
 
 public section
@@ -54,9 +58,9 @@ instance instFiniteIndexWithCenter {G : Type*} [Group G] (Γ : Subgroup G)
 
 variable {G : Type*} [Group G] {Γ : Subgroup G} {a : G}
 
-/-- **Adjoining a two-element centre either changes nothing or doubles the index.** When the
-centre is `{1, a}` and `a ∉ Γ`, the subgroup `Γ` has relative index exactly `2` in
-`Γ.withCenter`; when `a ∈ Γ` the two subgroups coincide and the relative index is `1`.
+/-- **When the centre is `{1, a}` and `a ∉ Γ`, `Γ` has relative index exactly `2` in
+`Γ.withCenter`.** Only this branch is proved here; the complementary `a ∈ Γ` case, in which the
+two subgroups coincide, is an unformalised remark.
 
 For `Γ ≤ SL(2, ℤ)` the centre is `{±I}` and `a = -I`, so this is the quantitative form of the
 dichotomy recorded on `Subgroup.withCenter`: cosets of `Γ` count each translate of `𝒟` twice
@@ -71,15 +75,16 @@ theorem relIndex_withCenter_eq_two (ha : a ∈ Subgroup.center G) (haΓ : a ∉ 
     · exact h
     · exact absurd (mul_eq_left.mp h ▸ Γ.one_mem) haΓ
   refine Subgroup.relIndex_eq_two_iff_exists_notMem_and.mpr
-    ⟨a, Subgroup.mem_sup_right ha, haΓ, fun b hb ↦ ?_⟩
+    ⟨a, Subgroup.withCenter_def Γ ▸ Subgroup.mem_sup_right ha, haΓ, fun b hb ↦ ?_⟩
   -- `withCenter` is a supremum with a normal subgroup, so its elements factor as `g * c`
-  rw [Subgroup.withCenter_def, ← SetLike.mem_coe, Subgroup.mul_normal] at hb
-  obtain ⟨g, hg, c, hc, rfl⟩ := hb
+  obtain ⟨g, hg, c, hc, rfl⟩ :=
+    Subgroup.mem_sup_of_normal_right.mp (Subgroup.withCenter_def Γ ▸ hb)
   rcases hcenter c hc with rfl | rfl
   · exact Or.inr (by simpa using hg)
   · exact Or.inl (by simpa [mul_assoc, ha2] using hg)
 
-/-- **The index halves on adjoining a central involution outside `Γ`.** The counting form of
+/-- **When the centre is `{1, a}` and `a ∉ Γ`, the index of `Γ` is twice that of
+`Γ.withCenter`.** The counting form of
 `Subgroup.relIndex_withCenter_eq_two`: it is `Γ.withCenter`, not `Γ`, whose cosets index the
 distinct translates, so a count over `Γ`-cosets is twice the geometric one. -/
 theorem index_eq_two_mul_index_withCenter (ha : a ∈ Subgroup.center G) (haΓ : a ∉ Γ)

--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -6,6 +6,10 @@ module
 
 public import Mathlib.GroupTheory.Index
 
+-- the pointwise product `↑(H ⊔ N) = ↑H * ↑N` serves only the proof below, so it stays off the
+-- public surface
+import Mathlib.Algebra.Group.Subgroup.Pointwise
+
 /-!
 # Consequences of the index formula
 
@@ -47,6 +51,40 @@ lemma le_withCenter {G : Type*} [Group G] (Γ : Subgroup G) : Γ ≤ Γ.withCent
 instance instFiniteIndexWithCenter {G : Type*} [Group G] (Γ : Subgroup G)
     [Γ.FiniteIndex] : Γ.withCenter.FiniteIndex :=
   Subgroup.finiteIndex_of_le Γ.le_withCenter
+
+variable {G : Type*} [Group G] {Γ : Subgroup G} {a : G}
+
+/-- **Adjoining a two-element centre either changes nothing or doubles the index.** When the
+centre is `{1, a}` and `a ∉ Γ`, the subgroup `Γ` has relative index exactly `2` in
+`Γ.withCenter`; when `a ∈ Γ` the two subgroups coincide and the relative index is `1`.
+
+For `Γ ≤ SL(2, ℤ)` the centre is `{±I}` and `a = -I`, so this is the quantitative form of the
+dichotomy recorded on `Subgroup.withCenter`: cosets of `Γ` count each translate of `𝒟` twice
+unless `-I ∈ Γ` already.
+
+`a` is not assumed to be an involution — that follows, since `a * a` lies in the centre and
+`a * a = a` would force `a = 1 ∈ Γ`. -/
+theorem relIndex_withCenter_eq_two (ha : a ∈ Subgroup.center G) (haΓ : a ∉ Γ)
+    (hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a) : Γ.relIndex Γ.withCenter = 2 := by
+  have ha2 : a * a = 1 := by
+    rcases hcenter _ ((Subgroup.center G).mul_mem ha ha) with h | h
+    · exact h
+    · exact absurd (mul_eq_left.mp h ▸ Γ.one_mem) haΓ
+  refine Subgroup.relIndex_eq_two_iff_exists_notMem_and.mpr
+    ⟨a, Subgroup.mem_sup_right ha, haΓ, fun b hb ↦ ?_⟩
+  -- `withCenter` is a supremum with a normal subgroup, so its elements factor as `g * c`
+  rw [Subgroup.withCenter_def, ← SetLike.mem_coe, Subgroup.mul_normal] at hb
+  obtain ⟨g, hg, c, hc, rfl⟩ := hb
+  rcases hcenter c hc with rfl | rfl
+  · exact Or.inr (by simpa using hg)
+  · exact Or.inl (by simpa [mul_assoc, ha2] using hg)
+
+/-- **The index halves on adjoining a central involution outside `Γ`.** The counting form of
+`Subgroup.relIndex_withCenter_eq_two`: it is `Γ.withCenter`, not `Γ`, whose cosets index the
+distinct translates, so a count over `Γ`-cosets is twice the geometric one. -/
+theorem index_eq_two_mul_index_withCenter (ha : a ∈ Subgroup.center G) (haΓ : a ∉ Γ)
+    (hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a) : Γ.index = 2 * Γ.withCenter.index := by
+  rw [← Subgroup.relIndex_mul_index Γ.le_withCenter, relIndex_withCenter_eq_two ha haΓ hcenter]
 
 end Subgroup
 

--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -23,6 +23,8 @@ exactly `2` in `Γ ⊔ N`, so `Γ.index = 2 * (Γ ⊔ N).index`. Taking `N` to b
 
 ## Main results
 
+* `Subgroup.mem_withCenter_iff` and `Subgroup.withCenter_eq_self_iff`: membership in `Γ·Z(G)`,
+  and the case in which adjoining the centre changes nothing.
 * `Subgroup.relIndex_sup_eq_two`, `Subgroup.index_eq_two_mul_index_sup`: the relative index `2`
   and the index doubling, for a normal `N` whose elements are `1` and `a ∉ Γ`.
 * `Subgroup.relIndex_withCenter_eq_two`, `Subgroup.index_eq_two_mul_index_withCenter`: the same
@@ -54,6 +56,21 @@ theorem withCenter_def {G : Type*} [Group G] (Γ : Subgroup G) :
 /-- `Γ` sits inside `Γ` with the centre adjoined. -/
 lemma le_withCenter {G : Type*} [Group G] (Γ : Subgroup G) : Γ ≤ Γ.withCenter :=
   le_sup_left
+
+/-- **Characteristic membership for `withCenter`**: an element of `Γ·Z(G)` is one of `Γ` times a
+central one. The centre is normal, so the supremum is the pointwise product. -/
+theorem mem_withCenter_iff {G : Type*} [Group G] {Γ : Subgroup G} {g : G} :
+    g ∈ Γ.withCenter ↔ ∃ γ ∈ Γ, ∃ c ∈ Subgroup.center G, g = γ * c := by
+  rw [withCenter_def, Subgroup.mem_sup_of_normal_right]
+  exact ⟨fun ⟨γ, hγ, c, hc, h⟩ ↦ ⟨γ, hγ, c, hc, h.symm⟩,
+    fun ⟨γ, hγ, c, hc, h⟩ ↦ ⟨γ, hγ, c, hc, h.symm⟩⟩
+
+/-- **Adjoining the centre changes nothing exactly when the centre is already inside `Γ`** —
+the other half of the dichotomy `Subgroup.withCenter` describes. -/
+@[simp]
+theorem withCenter_eq_self_iff {G : Type*} [Group G] {Γ : Subgroup G} :
+    Γ.withCenter = Γ ↔ Subgroup.center G ≤ Γ :=
+  sup_eq_left
 
 instance instFiniteIndexWithCenter {G : Type*} [Group G] (Γ : Subgroup G)
     [Γ.FiniteIndex] : Γ.withCenter.FiniteIndex :=

--- a/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
@@ -43,7 +43,7 @@ positive-definite Hermitian form is all that the adjoint theory downstream needs
 
 ## Main results
 
-* `Subgroup.mem_withCenter_iff_eq_neg`: an element of `Γ·{±I}` is `±` one of `Γ`.
+* `Subgroup.mem_withCenter_iff_eq_or_eq_neg`: an element of `Γ·{±I}` is `±` one of `Γ`.
 * `CuspForm.exists_slash_eq_smul_of_mem_withCenter`: slashing by an element of `Γ·{±I}` scales
   every form by one and the same unimodular constant.
 * `CuspForm.peterssonInner_slash_of_mem_withCenter`: the summand is independent of the coset
@@ -131,11 +131,10 @@ omit [Γ.FiniteIndex] in
 /-- Membership in `Γ·{±I}`: its elements are exactly `±` the elements of `Γ`. The adjoined
 centre of `SL₂(ℤ)` is `{±I}`, so the supremum only adds the negatives. -/
 @[simp]
-theorem _root_.Subgroup.mem_withCenter_iff_eq_neg {γ : SL(2, ℤ)} :
+theorem _root_.Subgroup.mem_withCenter_iff_eq_or_eq_neg {γ : SL(2, ℤ)} :
     γ ∈ Γ.withCenter ↔ ∃ γ' ∈ Γ, γ = γ' ∨ γ = -γ' := by
   refine ⟨fun hγ ↦ ?_, ?_⟩
-  · rw [Subgroup.withCenter_def, ← SetLike.mem_coe, Subgroup.mul_normal] at hγ
-    obtain ⟨a, ha, b, hb, rfl⟩ := hγ
+  · obtain ⟨a, ha, b, hb, rfl⟩ := Subgroup.mem_withCenter_iff.mp hγ
     obtain ⟨r, hr, hscal⟩ := Matrix.SpecialLinearGroup.mem_center_iff.mp hb
     have hb1 : b = 1 ∨ b = -1 := by
       have : r = 1 ∨ r = -1 :=
@@ -160,7 +159,7 @@ trivially on `ℍ` and contributes only the automorphy factor. Unimodularity `co
 what makes the constant invisible to the conjugate-linear Petersson pairing. -/
 theorem exists_slash_eq_smul_of_mem_withCenter {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) :
     ∃ c : ℂ, conj c * c = 1 ∧ ∀ f : CuspForm (Γ.map (mapGL ℝ)) k, ⇑f ∣[k] γ = c • ⇑f := by
-  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff_eq_neg.mp hγ
+  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff_eq_or_eq_neg.mp hγ
   rcases hcase with rfl | rfl
   · exact ⟨1, by simp, fun f ↦ by rw [SlashInvariantFormClass.SL_slash_eq f _ hγ', one_smul]⟩
   · refine ⟨(-1 : ℂ) ^ k, ?_, fun f ↦ ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
@@ -43,7 +43,7 @@ positive-definite Hermitian form is all that the adjoint theory downstream needs
 
 ## Main results
 
-* `Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg`: an element of `Γ·{±I}` is `±` one of `Γ`.
+* `Subgroup.mem_withCenter_iff`: an element of `Γ·{±I}` is `±` one of `Γ`.
 * `CuspForm.exists_slash_eq_smul_of_mem_withCenter`: slashing by an element of `Γ·{±I}` scales
   every form by one and the same unimodular constant.
 * `CuspForm.peterssonInner_slash_of_mem_withCenter`: the summand is independent of the coset
@@ -131,10 +131,11 @@ omit [Γ.FiniteIndex] in
 /-- Membership in `Γ·{±I}`: its elements are exactly `±` the elements of `Γ`. The adjoined
 centre of `SL₂(ℤ)` is `{±I}`, so the supremum only adds the negatives. -/
 @[simp]
-theorem _root_.Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg {γ : SL(2, ℤ)} :
+theorem _root_.Subgroup.mem_withCenter_iff {γ : SL(2, ℤ)} :
     γ ∈ Γ.withCenter ↔ ∃ γ' ∈ Γ, γ = γ' ∨ γ = -γ' := by
   refine ⟨fun hγ ↦ ?_, ?_⟩
-  · obtain ⟨a, ha, b, hb, rfl⟩ := Subgroup.mem_withCenter_iff.mp hγ
+  · rw [Subgroup.withCenter_def, ← SetLike.mem_coe, Subgroup.mul_normal] at hγ
+    obtain ⟨a, ha, b, hb, rfl⟩ := hγ
     obtain ⟨r, hr, hscal⟩ := Matrix.SpecialLinearGroup.mem_center_iff.mp hb
     have hb1 : b = 1 ∨ b = -1 := by
       have : r = 1 ∨ r = -1 :=
@@ -150,8 +151,7 @@ theorem _root_.Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg {γ : SL(2, ℤ)}
     · exact Γ.le_withCenter hγ'
     · have hcenter : (-1 : SL(2, ℤ)) ∈ Subgroup.center SL(2, ℤ) :=
         Subgroup.mem_center_iff.mpr fun g ↦ by rw [neg_one_mul, mul_neg_one]
-      exact mul_neg_one γ' ▸
-        Γ.withCenter.mul_mem (Γ.le_withCenter hγ') (Γ.center_le_withCenter hcenter)
+      exact Subgroup.withCenter_def Γ ▸ mul_neg_one γ' ▸ Subgroup.mul_mem_sup hγ' hcenter
 
 omit [Γ.FiniteIndex] in
 /-- **Slashing by `Γ·{±I}` scales every form by one and the same unimodular constant**: by `1`
@@ -160,7 +160,7 @@ trivially on `ℍ` and contributes only the automorphy factor. Unimodularity `co
 what makes the constant invisible to the conjugate-linear Petersson pairing. -/
 theorem exists_slash_eq_smul_of_mem_withCenter {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) :
     ∃ c : ℂ, conj c * c = 1 ∧ ∀ f : CuspForm (Γ.map (mapGL ℝ)) k, ⇑f ∣[k] γ = c • ⇑f := by
-  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg.mp hγ
+  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff.mp hγ
   rcases hcase with rfl | rfl
   · exact ⟨1, by simp, fun f ↦ by rw [SlashInvariantFormClass.SL_slash_eq f _ hγ', one_smul]⟩
   · refine ⟨(-1 : ℂ) ^ k, ?_, fun f ↦ ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
@@ -43,7 +43,7 @@ positive-definite Hermitian form is all that the adjoint theory downstream needs
 
 ## Main results
 
-* `Subgroup.mem_withCenter_iff_eq_or_eq_neg`: an element of `Γ·{±I}` is `±` one of `Γ`.
+* `Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg`: an element of `Γ·{±I}` is `±` one of `Γ`.
 * `CuspForm.exists_slash_eq_smul_of_mem_withCenter`: slashing by an element of `Γ·{±I}` scales
   every form by one and the same unimodular constant.
 * `CuspForm.peterssonInner_slash_of_mem_withCenter`: the summand is independent of the coset
@@ -131,7 +131,7 @@ omit [Γ.FiniteIndex] in
 /-- Membership in `Γ·{±I}`: its elements are exactly `±` the elements of `Γ`. The adjoined
 centre of `SL₂(ℤ)` is `{±I}`, so the supremum only adds the negatives. -/
 @[simp]
-theorem _root_.Subgroup.mem_withCenter_iff_eq_or_eq_neg {γ : SL(2, ℤ)} :
+theorem _root_.Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg {γ : SL(2, ℤ)} :
     γ ∈ Γ.withCenter ↔ ∃ γ' ∈ Γ, γ = γ' ∨ γ = -γ' := by
   refine ⟨fun hγ ↦ ?_, ?_⟩
   · obtain ⟨a, ha, b, hb, rfl⟩ := Subgroup.mem_withCenter_iff.mp hγ
@@ -150,7 +150,8 @@ theorem _root_.Subgroup.mem_withCenter_iff_eq_or_eq_neg {γ : SL(2, ℤ)} :
     · exact Γ.le_withCenter hγ'
     · have hcenter : (-1 : SL(2, ℤ)) ∈ Subgroup.center SL(2, ℤ) :=
         Subgroup.mem_center_iff.mpr fun g ↦ by rw [neg_one_mul, mul_neg_one]
-      exact Subgroup.withCenter_def Γ ▸ mul_neg_one γ' ▸ Subgroup.mul_mem_sup hγ' hcenter
+      exact mul_neg_one γ' ▸
+        Γ.withCenter.mul_mem (Γ.le_withCenter hγ') (Γ.center_le_withCenter hcenter)
 
 omit [Γ.FiniteIndex] in
 /-- **Slashing by `Γ·{±I}` scales every form by one and the same unimodular constant**: by `1`
@@ -159,7 +160,7 @@ trivially on `ℍ` and contributes only the automorphy factor. Unimodularity `co
 what makes the constant invisible to the conjugate-linear Petersson pairing. -/
 theorem exists_slash_eq_smul_of_mem_withCenter {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) :
     ∃ c : ℂ, conj c * c = 1 ∧ ∀ f : CuspForm (Γ.map (mapGL ℝ)) k, ⇑f ∣[k] γ = c • ⇑f := by
-  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff_eq_or_eq_neg.mp hγ
+  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg.mp hγ
   rcases hcase with rfl | rfl
   · exact ⟨1, by simp, fun f ↦ by rw [SlashInvariantFormClass.SL_slash_eq f _ hγ', one_smul]⟩
   · refine ⟨(-1 : ℂ) ^ k, ?_, fun f ↦ ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
@@ -43,7 +43,7 @@ positive-definite Hermitian form is all that the adjoint theory downstream needs
 
 ## Main results
 
-* `Subgroup.mem_withCenter_iff`: an element of `Γ·{±I}` is `±` one of `Γ`.
+* `Subgroup.mem_withCenter_iff_eq_neg`: an element of `Γ·{±I}` is `±` one of `Γ`.
 * `CuspForm.exists_slash_eq_smul_of_mem_withCenter`: slashing by an element of `Γ·{±I}` scales
   every form by one and the same unimodular constant.
 * `CuspForm.peterssonInner_slash_of_mem_withCenter`: the summand is independent of the coset
@@ -131,7 +131,7 @@ omit [Γ.FiniteIndex] in
 /-- Membership in `Γ·{±I}`: its elements are exactly `±` the elements of `Γ`. The adjoined
 centre of `SL₂(ℤ)` is `{±I}`, so the supremum only adds the negatives. -/
 @[simp]
-theorem _root_.Subgroup.mem_withCenter_iff {γ : SL(2, ℤ)} :
+theorem _root_.Subgroup.mem_withCenter_iff_eq_neg {γ : SL(2, ℤ)} :
     γ ∈ Γ.withCenter ↔ ∃ γ' ∈ Γ, γ = γ' ∨ γ = -γ' := by
   refine ⟨fun hγ ↦ ?_, ?_⟩
   · rw [Subgroup.withCenter_def, ← SetLike.mem_coe, Subgroup.mul_normal] at hγ
@@ -160,7 +160,7 @@ trivially on `ℍ` and contributes only the automorphy factor. Unimodularity `co
 what makes the constant invisible to the conjugate-linear Petersson pairing. -/
 theorem exists_slash_eq_smul_of_mem_withCenter {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) :
     ∃ c : ℂ, conj c * c = 1 ∧ ∀ f : CuspForm (Γ.map (mapGL ℝ)) k, ⇑f ∣[k] γ = c • ⇑f := by
-  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff.mp hγ
+  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff_eq_neg.mp hγ
   rcases hcase with rfl | rfl
   · exact ⟨1, by simp, fun f ↦ by rw [SlashInvariantFormClass.SL_slash_eq f _ hγ', one_smul]⟩
   · refine ⟨(-1 : ℂ) ^ k, ?_, fun f ↦ ?_⟩


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"modularforms-withcenter-index-two"}-->

The index doubling that the ModularForms Layer-1 general-level valence target needs: a count
over `Γ`-cosets is twice the geometric one unless `-I ∈ Γ` already.

### What is added

Four theorems, all in `TauCeti/GroupTheory/Index.lean`, and nothing else. The PR touches that
one file.

```lean
theorem relIndex_sup_eq_two (N : Subgroup G) (hnorm : Γ ≤ Subgroup.normalizer N) (ha : a ∈ N)
    (haΓ : a ∉ Γ) (hN : ∀ c ∈ N, c = 1 ∨ c = a) : Γ.relIndex (Γ ⊔ N) = 2

theorem index_eq_two_mul_index_sup (N : Subgroup G) (hnorm : Γ ≤ Subgroup.normalizer N)
    (ha : a ∈ N) (haΓ : a ∉ Γ) (hN : ∀ c ∈ N, c = 1 ∨ c = a) :
    Γ.index = 2 * (Γ ⊔ N).index

theorem relIndex_withCenter_eq_two (ha : a ∈ Subgroup.center G) (haΓ : a ∉ Γ)
    (hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a) : Γ.relIndex Γ.withCenter = 2

theorem index_eq_two_mul_index_withCenter (ha : a ∈ Subgroup.center G) (haΓ : a ∉ Γ)
    (hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a) : Γ.index = 2 * Γ.withCenter.index
```

The last two are the centre readings of the first two. No declaration is renamed, and no other
module is touched.

### Why the hypotheses are what they are

**`Γ ≤ Subgroup.normalizer N` rather than `[N.Normal]`.** Nothing in the proof uses global
normality — all it needs is that `Γ ⊔ N` is the pointwise product `Γ * N`. A globally normal `N`
is the special case `Subgroup.le_normalizer_of_normal`, which is how the two centre readings
discharge it, so callers holding normality are unaffected.

**Stated for an arbitrary two-element `N`, not for the centre.** The centre is often larger than
two elements — in `GL (Fin 2) ℝ` it is every scalar — while the subgroup one actually wants there
is `Subgroup.zpowers (-1)`. A caller supplies whichever `N` is in hand.

**`a` is not assumed to be an involution.** It follows from the hypotheses.

Generalises Mathlib's `Subgroup.relindex_adjoinNegOne_eq_two`
(`Mathlib/NumberTheory/ModularForms/ArithmeticSubgroups.lean`) from `𝒢 ≤ GL n R` with `a = -1` to
an arbitrary group, and relaxes normality.

### Scope

An earlier revision of this PR also carried a `withCenter` membership API —
`mem_withCenter_iff`, `center_le_withCenter`, `withCenter_eq_self_iff` — together with the rename
and proof rewrites in `Petersson/FiniteIndex.lean` that adding a general `mem_withCenter_iff`
forced. None of it is used by the four theorems above, and `withCenter_eq_self_iff` had no
consumer anywhere in the tree. That material is **removed here** and will come back as its own
`withCenter`-API PR; `Petersson/FiniteIndex.lean` is byte-identical to `main` again.

`withCenter`, `withCenter_def`, `le_withCenter` and `instFiniteIndexWithCenter` are pre-existing
on `main` and untouched.

### Verification

`lake build` green (7937 jobs); `lake exe axioms` clean over 47312 declarations;
`lake exe module-system` clean over 2262 modules; `LINT-ENV: PASS`.
