### PR TITLE
refactor(Cylinder): give the block cylinder its intersection form

### DIFF
--- a/TauCeti/Probability/DeFinetti/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/BlockFactorization.lean
@@ -101,7 +101,8 @@ theorem condExp_blockIndicatorProd_ae_eq_prod_of_iCondIndepFun_tailProcess
     (fun i => hX_meas (k i))).1 hCI Finset.univ (sets := C) (fun i _ => hC i)
   -- The intersection over the selection is the block cylinder.
   have hcyl : ⋂ i ∈ (Finset.univ : Finset (Fin m)), X (k i) ⁻¹' C i = blockCylinder X k C := by
-    ext ω; simp [mem_blockCylinder, Set.mem_iInter, Set.mem_preimage]
+    rw [blockCylinder_eq_iInter]
+    simp
   rw [hcyl] at hfac
   -- Goal LHS = `μ⟦blockCylinder X k C | tail⟧`, the block-indicator conditional expectation.
   rw [blockIndicatorProd_eq_indicator]

--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -21,10 +21,11 @@ For a process `X : ℕ → Ω → α` and a finite coordinate selection `k : Fin
 * `blockIndicatorProd X k C ω = ∏ i, 𝟙_{C i}(X (k i) ω)` — its (`ℝ`-valued) indicator product.
 
 These are the finite-dimensional events and integrands the de Finetti block-product factorisation
-manipulates. `blockCylinder_eq_preimage_univ_pi` and `blockLaw_blockCylinder` bridge the cylinder to
-the existing rectangle/`blockLaw` interface; `blockIndicatorProd_eq_indicator` identifies the
-product with the cylinder indicator; and `integrable_blockIndicatorProd` records integrability under
-a finite measure.
+manipulates. `blockCylinder_eq_preimage_univ_pi` and `blockLaw_blockCylinder` bridge the cylinder
+to the existing rectangle/`blockLaw` interface, while `blockCylinder_eq_iInter` gives the
+intersection form, which is what a proof meeting the cylinder with another event wants.
+`blockIndicatorProd_eq_indicator` identifies the product with the cylinder indicator, and
+`integrable_blockIndicatorProd` records integrability under a finite measure.
 
 Adapted from `cameronfreer/exchangeability` (`PathSpace/CylinderHelpers.lean`,
 `DeFinetti/ViaMartingale/IndicatorAlgebra.lean`, pin
@@ -65,6 +66,15 @@ theorem blockCylinder_eq_preimage_univ_pi (X : ℕ → Ω → α) {m : ℕ} (k :
     blockCylinder X k C = (fun ω i => X (k i) ω) ⁻¹' Set.univ.pi C := by
   ext ω
   simp only [mem_blockCylinder, Set.mem_preimage, Set.mem_univ_pi]
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+/-- The block cylinder is the intersection of the selected coordinates' preimages. This is the
+`⋂` counterpart of `blockCylinder_eq_preimage_univ_pi`: the rectangle form suits pushforwards and
+block laws, this one suits intersections with another event. -/
+theorem blockCylinder_eq_iInter (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) (C : Fin m → Set α) :
+    blockCylinder X k C = ⋂ i, X (k i) ⁻¹' C i := by
+  ext ω
+  simp only [mem_blockCylinder, Set.mem_iInter, Set.mem_preimage]
 
 /-- The block cylinder of a process with measurable selected coordinates on measurable sets is
 measurable. -/


### PR DESCRIPTION
`blockCylinder_eq_iInter` states the block cylinder as the intersection of its selected
coordinates' preimages:

```lean
blockCylinder X k C = ⋂ i, X (k i) ⁻¹' C i
```

It is the counterpart of the existing `blockCylinder_eq_preimage_univ_pi`: the rectangle form suits
pushforwards and block laws, this one suits meeting the cylinder with another event.
`DeFinetti/BlockFactorization.lean` proved that identity inline; it now rewrites.

## One candidate site was left alone

`ConditionallyIID/Moments.lean` has a related identity inside
`ConditionallyIIDWith.lintegral_mul_indicator_iInter`, but it is not the same statement: it compares
an indicator on `Fin m → α` with one on `Ω`, across the selected-coordinate map. Rewriting through
the cylinder needs a `Set.indicator_comp_right` step whose `1 ∘ f` does not reduce to `1`
syntactically, and a `simp` close makes no progress. I tried both and reverted; the existing
`by_cases` proof there is left untouched rather than replaced with something longer.

Roadmap: Exchangeability

Advances `TauCetiRoadmap/Exchangeability/README.md`, **Layer 0** (sequence laws, finite marginals
and symmetry notions), whose cylinder vocabulary this extends. Factoring a duplicated identity out
of an existing proof, so no new mathematical scope.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
