### PR TITLE
docs: two claims left stale by the Koopman route landing

### DIFF
--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Basic.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Basic.lean
@@ -26,9 +26,10 @@ Because it lives over the **value** space `α`, it needs only `[StandardBorelSpa
 This is the tail-conditioned directing measure: the object the martingale route proves to be a
 `ConditionallyIIDWith` witness, and the one any route conditioning on `tailProcess X` will use. A
 route conditioning on a different σ-algebra builds its own conditional law — see
-`DeFinetti.ViaKoopman.InvariantConditionalLaw` for the shift-invariant candidate, which is not yet
-proved to direct anything — and whether two such objects agree a.e. is a theorem about them, not a
-property of this file.
+`DeFinetti.ViaKoopman.InvariantConditionalLaw` for the shift-invariant one, which
+`ContractableLaw.conditionallyIIDWith_invariantConditionalProbabilityMeasure` proves is a witness in
+its own right — and whether two such objects agree a.e. is a theorem about them, not a property of
+this file.
 
 This file records the basic theory: it is a probability measure
 (`isProbabilityMeasure_directingMeasure`), its set evaluations are `tailProcess X`-measurable

--- a/TauCeti/Probability/DeFinetti/ViaKoopman/Decoupling.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/Decoupling.lean
@@ -73,8 +73,9 @@ end.
 This is the engine of the Koopman factorization: the `m`-independence is what allows the average
 over `m` to be inserted for free, and that average is what the ergodic theorem consumes.
 
-The induction on `r` that iterates this decoupling across a whole block, and the `ℝ≥0∞` ending it
-feeds, are not here yet.
+The induction on `r` that iterates this decoupling across a whole block is
+`ViaKoopman/BlockFactorization.lean`, and the `ℝ≥0∞` ending it feeds is
+`ViaKoopman/CylinderMass.lean`.
 -/
 
 public section


### PR DESCRIPTION
Two docstring claims that the Koopman route's landing made false.

**`DirectingMeasure/Basic.lean`** described the shift-invariant conditional law as "not yet proved
to direct anything". `ContractableLaw.conditionallyIIDWith_invariantConditionalProbabilityMeasure`
proves exactly that, merged in #3170; the sentence now says so, keeping the point it was making —
that whether the two witnesses agree a.e. is a theorem about them, not a property of that file.

**`ViaKoopman/Decoupling.lean`** said the induction across a block and the `ℝ≥0∞` ending "are not
here yet". Both exist — `ViaKoopman/BlockFactorization.lean` and `ViaKoopman/CylinderMass.lean` —
and the docstring now points at them instead of implying they are unwritten.

The similar wording in `InvariantConditionalLaw.lean` ("nothing here proves…") is module-local and
still accurate, so it is untouched.

Roadmap: Exchangeability

Documentation-only; no declarations, statements or proofs change.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
