### PR TITLE
refactor(Contour): factor the ε→0 passage out of every principal value

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -126,6 +126,21 @@ theorem hasCauchyPVAt_iff {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀
           (𝓝[>] 0) (𝓝 L) :=
   Iff.rfl
 
+/-- **The `ε → 0` passage, once.** A principal value is computed by exhibiting the excised
+integral in closed form on a punctured right-neighbourhood of `0` and taking the limit; this
+packages that step, so a caller supplies only the closed form `F` and its limit.
+
+The excised integral is asked to equal `F ε` rather than a specific shape such as `L - c ε`,
+because the closed forms met in practice differ: constant in `ε` along a straight edge, and
+`L` minus an `arcsin` correction at a corner or along an arc. -/
+theorem hasCauchyPVAt_of_tendsto {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ} {F : ℝ → ℂ}
+    (hF : Tendsto F (𝓝[>] (0 : ℝ)) (𝓝 L))
+    (h : ∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
+        (fun t ↦ if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) MeasureTheory.volume a b ∧
+      ∫ t in a..b, (if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) = F ε) :
+    HasCauchyPVAt γ a b f z₀ L :=
+  hasCauchyPVAt_iff.mpr ⟨h.mono fun _ hε ↦ hε.1, hF.congr' (h.mono fun _ hε ↦ hε.2.symm)⟩
+
 /-- The **Cauchy principal value at `z₀`** of `∮_γ f`, excluding the symmetric `ε`-ball about `z₀`.
 `limUnder`-based; returns junk when the limit does not exist, so use `HasCauchyPVAt` for the
 predicate and `HasCauchyPVAt.cauchyPVAt_eq` to read the value off it. -/

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -48,6 +48,8 @@ versus `MeromorphicOn` (on a set).
 * `hasCauchyPVAt_iff` — restates the predicate as its two defining clauses, so consumers can
   characterize `HasCauchyPVAt` without unfolding its hidden body; the value `cauchyPVAt` is read off
   a witness through `HasCauchyPVAt.cauchyPVAt_eq`.
+* `HasCauchyPVAt.of_tendsto` — the shared `ε → 0` closing step: from a closed form `F` that the
+  excised integral eventually equals, and its limit `L`, concludes `HasCauchyPVAt` at `L`.
 * `intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le` — where the curve
   stays within `ε` of the centre, the truncated integrand is integrable and integrates to `0`.
 * `HasCauchyPVAt.intro` — build the predicate from its two clauses; `HasCauchyPVAt.tendsto`,
@@ -133,7 +135,7 @@ packages that step, so a caller supplies only the closed form `F` and its limit.
 The excised integral is asked to equal `F ε` rather than a specific shape such as `L - c ε`,
 because the closed forms met in practice differ: constant in `ε` along a straight edge, and
 `L` minus an `arcsin` correction at a corner or along an arc. -/
-theorem hasCauchyPVAt_of_tendsto {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ} {F : ℝ → ℂ}
+theorem HasCauchyPVAt.of_tendsto {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ} {F : ℝ → ℂ}
     (hF : Tendsto F (𝓝[>] (0 : ℝ)) (𝓝 L))
     (h : ∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
         (fun t ↦ if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) MeasureTheory.volume a b ∧

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
@@ -481,12 +481,7 @@ theorem hasCauchyPVAt_fdBoundary_arc (hH : 1 < H) (hnorm : ‖w‖ = 1)
         (min_le_left _ _))))
       (hε.2.trans_le ((min_le_right _ _).trans ((min_le_right _ _).trans
         (min_le_right _ _))))
-  refine Contour.hasCauchyPVAt_iff.mpr ⟨?_, ?_⟩
-  · filter_upwards [hIoo] with ε hε
-    exact (hspec ε hε).1
-  · refine Tendsto.congr' ?_ tendsto_neg_pi_sub_arcsin
-    filter_upwards [hIoo] with ε hε
-    exact ((hspec ε hε).2).symm
+  exact Contour.hasCauchyPVAt_of_tendsto tendsto_neg_pi_sub_arcsin (eventually_of_mem hIoo hspec)
 
 /-- **The winding number of the boundary contour at an arc point is `-1/2`**: the point sits
 on the open unit arc, and the principal-value normalization sees exactly half a clockwise

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
@@ -481,7 +481,7 @@ theorem hasCauchyPVAt_fdBoundary_arc (hH : 1 < H) (hnorm : ‖w‖ = 1)
         (min_le_left _ _))))
       (hε.2.trans_le ((min_le_right _ _).trans ((min_le_right _ _).trans
         (min_le_right _ _))))
-  exact Contour.hasCauchyPVAt_of_tendsto tendsto_neg_pi_sub_arcsin (eventually_of_mem hIoo hspec)
+  exact Contour.HasCauchyPVAt.of_tendsto tendsto_neg_pi_sub_arcsin (eventually_of_mem hIoo hspec)
 
 /-- **The winding number of the boundary contour at an arc point is `-1/2`**: the point sits
 on the open unit arc, and the principal-value normalization sees exactly half a clockwise

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Vertical.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Vertical.lean
@@ -509,12 +509,7 @@ theorem hasCauchyPVAt_fdBoundary_vertical (hre : w.re = 2⁻¹ ∨ w.re = -(2⁻
     rcases hre with h | h
     · exact truncated_integral_spec_right h him_lo himH hε.1 h1 ha hc hv
     · exact truncated_integral_spec_left h him_lo himH hε.1 h1 ha hc hv
-  refine Contour.hasCauchyPVAt_iff.mpr ⟨?_, ?_⟩
-  · filter_upwards [hIoo] with ε hε
-    exact (hspec ε hε).1
-  · refine Tendsto.congr' ?_ tendsto_const_nhds
-    filter_upwards [hIoo] with ε hε
-    exact ((hspec ε hε).2).symm
+  exact Contour.hasCauchyPVAt_of_tendsto tendsto_const_nhds (eventually_of_mem hIoo hspec)
 
 /-- **The winding number of the boundary contour at a vertical-edge point is `-1/2`**: the
 point sits on an open vertical edge, and the principal-value normalization sees exactly half

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Vertical.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Vertical.lean
@@ -509,7 +509,7 @@ theorem hasCauchyPVAt_fdBoundary_vertical (hre : w.re = 2⁻¹ ∨ w.re = -(2⁻
     rcases hre with h | h
     · exact truncated_integral_spec_right h him_lo himH hε.1 h1 ha hc hv
     · exact truncated_integral_spec_left h him_lo himH hε.1 h1 ha hc hv
-  exact Contour.hasCauchyPVAt_of_tendsto tendsto_const_nhds (eventually_of_mem hIoo hspec)
+  exact Contour.HasCauchyPVAt.of_tendsto tendsto_const_nhds (eventually_of_mem hIoo hspec)
 
 /-- **The winding number of the boundary contour at a vertical-edge point is `-1/2`**: the
 point sits on an open vertical edge, and the principal-value normalization sees exactly half

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -476,12 +476,7 @@ theorem hasCauchyPVAt_fdBoundary_rho_add_one (hH : Real.sqrt 3 / 2 < H) :
       refine continuous_const.sub ((Complex.continuous_ofReal.comp ?_).mul continuous_const)
       exact Real.continuous_arcsin.comp (continuous_id.div_const 2)
     simpa [Real.arcsin_zero] using (hc.tendsto 0).mono_left nhdsWithin_le_nhds
-  refine Contour.hasCauchyPVAt_iff.mpr ⟨?_, ?_⟩
-  · filter_upwards [hIoo] with ε hε
-    exact (hspec ε hε).1
-  · refine Tendsto.congr' ?_ hcont
-    filter_upwards [hIoo] with ε hε
-    exact ((hspec ε hε).2).symm
+  exact Contour.HasCauchyPVAt.of_tendsto hcont (eventually_of_mem hIoo hspec)
 
 /-- **The winding number of the boundary contour at `ρ + 1` is `-1/6`**: the corner
 `ρ + 1` sits on the contour with interior angle `π/3` — the gap between the one-sided

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -436,12 +436,7 @@ theorem hasCauchyPVAt_fdBoundary_rho (hH : Real.sqrt 3 / 2 < H) :
       refine continuous_const.sub ((Complex.continuous_ofReal.comp ?_).mul continuous_const)
       exact Real.continuous_arcsin.comp (continuous_id.div_const 2)
     simpa [Real.arcsin_zero] using (hc.tendsto 0).mono_left nhdsWithin_le_nhds
-  refine Contour.hasCauchyPVAt_iff.mpr ⟨?_, ?_⟩
-  · filter_upwards [hIoo] with ε hε
-    exact (hspec ε hε).1
-  · refine Tendsto.congr' ?_ hcont
-    filter_upwards [hIoo] with ε hε
-    exact ((hspec ε hε).2).symm
+  exact Contour.HasCauchyPVAt.of_tendsto hcont (eventually_of_mem hIoo hspec)
 
 /-- **The winding number of the boundary contour at `ρ` is `-1/6`**: the corner `ρ`
 sits on the contour with interior angle `π/3`, and the principal-value normalization


### PR DESCRIPTION
Roadmap: none

<!--tauceti-target:v1 {"focus":"Contour","id":"contour-cauchypv-limit-engine"}-->

`Roadmap: none` because this is cross-cutting contour infrastructure: it adds no mathematics, and
factors a step that four existing principal-value computations already perform identically.

### The repeated step

Every `HasCauchyPVAt` proof in the tree ends the same way — exhibit the excised integral in closed
form on a punctured right-neighbourhood of `0`, then pass to the limit:

```lean
refine Contour.hasCauchyPVAt_iff.mpr ⟨?_, ?_⟩
· filter_upwards [hIoo] with ε hε
  exact (hspec ε hε).1
· refine Tendsto.congr' ?_ <limit>
  filter_upwards [hIoo] with ε hε
  exact ((hspec ε hε).2).symm
```

Four sites, character-identical apart from `<limit>`:

| site | limit supplied |
|---|---|
| `Winding/NonCorner/Arc.lean` | `tendsto_neg_pi_sub_arcsin` |
| `Winding/NonCorner/Vertical.lean` | `tendsto_const_nhds` |
| `Winding/Rho/Value.lean` | local `hcont` |
| `Winding/Rho/AddOne/Value.lean` | local `hcont` |

### What is added

```lean
theorem HasCauchyPVAt.of_tendsto {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ L : ℂ} {F : ℝ → ℂ}
    (hF : Tendsto F (𝓝[>] (0 : ℝ)) (𝓝 L))
    (h : ∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
        (fun t ↦ if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) MeasureTheory.volume a b ∧
      ∫ t in a..b, (if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) = F ε) :
    HasCauchyPVAt γ a b f z₀ L :=
  hasCauchyPVAt_iff.mpr ⟨h.mono fun _ hε ↦ hε.1, hF.congr' (h.mono fun _ hε ↦ hε.2.symm)⟩
```

in `Contour/Cauchy/PrincipalValue/Basic.lean`, directly after `hasCauchyPVAt_iff`. Each call site
collapses to one line:

```lean
exact Contour.HasCauchyPVAt.of_tendsto tendsto_neg_pi_sub_arcsin (eventually_of_mem hIoo hspec)
```

### Why the hypothesis is `= F ε` and not `= L - c ε`

The first draft asked for `L - c ε` with `c → 0`, which reads more informatively and covers the two
ρ corners and the arc. It does **not** cover the vertical edge, whose excised integral is *constant*
in `ε` — so the tighter shape would have excluded one of its own four consumers. Taking the limit
hypothesis directly costs nothing: `L - c ε` is recovered in one line by
`HasCauchyPVAt.of_tendsto (by simpa using tendsto_const_nhds.sub hc) h`, which was checked before
choosing this form.

### Scope

**All four sites are rerouted here.** The two ρ-corner files were held by #3366 until it merged at
13:19Z; they went on as a second commit rather than a separate PR, since they are the same topic
and the engine's value is precisely its consumer count.

### Verification

`lake build` green (7939 jobs); `lake exe axioms` clean over 47337 declarations;
`lake exe module-system` clean over 2264 modules; `lint-env` PASS. Branch carries a merge of
`main`.
