### PR TITLE
feat: the Cartan-Killing classification of finite-type Cartan matrices

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classification.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classification.lean
@@ -4,19 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.LinearAlgebra.RootSystem.Classification
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Classification
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Star.Reindex
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.TripleEdge
-public import TauCeti.LinearAlgebra.RootSystem.FiniteType.TypeA
 
 public section
 
 /-!
 # The Cartan-Killing classification of finite-type Cartan matrices
 
-This file proves the central theorem of Layer 5 of the root systems roadmap: every connected
-finite-type Cartan matrix reindexes to the standard Cartan matrix of a **unique valid**
+This file proves the central theorem of Layer 5 of the root systems roadmap: every nonempty
+connected finite-type Cartan matrix reindexes to the standard Cartan matrix of a **unique valid**
 `DynkinType`, and every base of an irreducible reduced crystallographic finite root system has a
 unique valid `DynkinType` (`TauCeti.existsUnique_dynkinType`).
 
@@ -39,8 +37,8 @@ Uniqueness among valid types is supplied by `TauCeti.DynkinType.eq_of_valid_of_f
 
 ## Main results
 
-* `TauCeti.IsFiniteType.existsUnique_dynkinType`: every connected finite-type Cartan matrix has a
-  unique valid Dynkin type.
+* `TauCeti.IsFiniteType.existsUnique_dynkinType`: every nonempty connected finite-type Cartan matrix
+  has a unique valid Dynkin type.
 * `TauCeti.existsUnique_dynkinType`: the Cartan-Killing classification for irreducible reduced
   crystallographic finite root systems.
 
@@ -60,8 +58,7 @@ variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
 /-- **The classification of finite-type Cartan matrices.** Every nonempty connected finite-type
 matrix agrees with the standard Cartan matrix of a unique valid Dynkin type after a simultaneous
 relabelling of its rows and columns. -/
-theorem existsUnique_dynkinType (h : IsFiniteType A) (hconn : (diagramGraph A).Connected)
-    (hB : Nonempty B) :
+theorem existsUnique_dynkinType (h : IsFiniteType A) (hconn : (diagramGraph A).Connected) :
     ∃! t : DynkinType, t.Valid ∧
       ∃ e : B ≃ Fin t.rank, ∀ i j, A i j = t.cartanMatrix (e i) (e j) := by
   classical
@@ -114,7 +111,7 @@ theorem existsUnique_dynkinType (h : IsFiniteType A) (hconn : (diagramGraph A).C
           have hne3 : (diagramGraph A).degree v ≠ 3 := fun hv3 ↦ hc ⟨v, hv3⟩
           omega
         obtain ⟨e, he⟩ := h.exists_equiv_forall_eq_cartanMatrix_A hconn hsl hdeg
-        have hcard : 1 ≤ Fintype.card B := Fintype.card_pos_iff.mpr hB
+        have hcard : 1 ≤ Fintype.card B := Fintype.card_pos_iff.mpr hconn.nonempty
         refine ⟨.A (Fintype.card B), ⟨DynkinType.valid_A.mpr hcard, e, he⟩, fun s hs ↦ ?_⟩
         exact DynkinType.eq_of_valid_of_forall_eq hs.1 (DynkinType.valid_A.mpr hcard)
           hs.2.choose e hs.2.choose_spec he
@@ -131,10 +128,9 @@ variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommG
 irreducible reduced crystallographic finite root system has a unique valid `DynkinType`. -/
 theorem existsUnique_dynkinType (b : P.Base) :
     ∃! t : DynkinType, t.Valid ∧ HasCartanType P b t := by
-  have hB : Nonempty b.support := Finset.nonempty_coe_sort.mpr b.support_nonempty
   obtain ⟨t, ⟨ht, e, he⟩, -⟩ :=
     (isFiniteType_cartanMatrix b).existsUnique_dynkinType
-      (connected_diagramGraph_cartanMatrix b) hB
+      (connected_diagramGraph_cartanMatrix b)
   exact ((hasCartanType_iff b t).mpr ⟨e, he⟩).existsUnique_of_valid ht
 
 end RootPairing

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classification.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classification.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.Classification
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Classification
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Star.Reindex
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.TripleEdge
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.TypeA
+
+public section
+
+/-!
+# The Cartan-Killing classification of finite-type Cartan matrices
+
+This file proves the central theorem of Layer 5 of the root systems roadmap: every connected
+finite-type Cartan matrix reindexes to the standard Cartan matrix of a **unique valid**
+`DynkinType`, and every base of an irreducible reduced crystallographic finite root system has a
+unique valid `DynkinType` (`TauCeti.existsUnique_dynkinType`).
+
+The proof assembles the four geometric branches established in the subdiagram modules:
+1. **Triple edge**:
+   `TauCeti.IsFiniteType.exists_equiv_cartanMatrix_eq_G2_of_apply_mul_apply_eq_three` in
+   `TauCeti.LinearAlgebra.RootSystem.FiniteType.TripleEdge` isolates the exceptional type `G₂`.
+2. **Double edge**: `TauCeti.IsFiniteType.existsUnique_dynkinType_of_apply_mul_apply_eq_two` in
+   `TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Classification` classifies the families
+   `Bₙ`, `Cₙ`, and the exceptional type `F₄`.
+3. **Simply-laced branching**:
+   `TauCeti.IsFiniteType.existsUnique_dynkinType_of_isSimplyLaced_of_degree_eq_three` in
+   `TauCeti.LinearAlgebra.RootSystem.FiniteType.Star.Reindex` classifies the forks `Dₙ` and the
+   exceptional types `E₆`, `E₇`, `E₈`.
+4. **Simply-laced chain**: `TauCeti.IsFiniteType.exists_equiv_forall_eq_cartanMatrix_A` in
+   `TauCeti.LinearAlgebra.RootSystem.FiniteType.TypeA` classifies the linear chains `Aₙ`.
+
+Uniqueness among valid types is supplied by `TauCeti.DynkinType.eq_of_valid_of_forall_eq` in
+`TauCeti.LinearAlgebra.RootSystem.Classification`.
+
+## Main results
+
+* `TauCeti.IsFiniteType.existsUnique_dynkinType`: every connected finite-type Cartan matrix has a
+  unique valid Dynkin type.
+* `TauCeti.existsUnique_dynkinType`: the Cartan-Killing classification for irreducible reduced
+  crystallographic finite root systems.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Ch. VI, §4.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, Ch. III, §11.
+* `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, Layer 5.
+-/
+
+namespace TauCeti
+
+namespace IsFiniteType
+
+variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
+
+/-- **The classification of finite-type Cartan matrices.** Every nonempty connected finite-type
+matrix agrees with the standard Cartan matrix of a unique valid Dynkin type after a simultaneous
+relabelling of its rows and columns. -/
+theorem existsUnique_dynkinType (h : IsFiniteType A) (hconn : (diagramGraph A).Connected)
+    (hB : Nonempty B) :
+    ∃! t : DynkinType, t.Valid ∧
+      ∃ e : B ≃ Fin t.rank, ∀ i j, A i j = t.cartanMatrix (e i) (e j) := by
+  classical
+  by_cases h3 : ∃ u v : B, A u v * A v u = 3
+  · obtain ⟨u, v, huv⟩ := h3
+    obtain ⟨e, he⟩ := h.exists_equiv_cartanMatrix_eq_G2_of_apply_mul_apply_eq_three
+      hconn.preconnected huv
+    refine ⟨.G2, ⟨DynkinType.valid_G2, e, he⟩, fun s hs ↦ ?_⟩
+    exact DynkinType.eq_of_valid_of_forall_eq hs.1 DynkinType.valid_G2 hs.2.choose e
+      hs.2.choose_spec he
+  · by_cases h2 : ∃ u v : B, A u v * A v u = 2
+    · obtain ⟨u, v, huv⟩ := h2
+      exact h.existsUnique_dynkinType_of_apply_mul_apply_eq_two hconn.preconnected huv
+    · have hsl : A.IsSimplyLaced := by
+        intro i j hij
+        have hmem := h.apply_mul_apply_mem_of_ne hij
+        have hle_i : A i j ≤ 0 := h.apply_le_zero_of_ne hij
+        have hle_j : A j i ≤ 0 := h.apply_le_zero_of_ne hij.symm
+        have hnot3 : A i j * A j i ≠ 3 := fun h' ↦ h3 ⟨i, j, h'⟩
+        have hnot2 : A i j * A j i ≠ 2 := fun h' ↦ h2 ⟨i, j, h'⟩
+        simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
+        rcases hmem with h0 | h1 | h2' | h3'
+        · have hz : A i j = 0 := by
+            by_contra hnz
+            have hjz : A j i = 0 := by
+              cases mul_eq_zero.mp h0 with
+              | inl h' => contradiction
+              | inr h' => exact h'
+            have hsymm := h.apply_eq_zero_symm hjz
+            exact hnz hsymm
+          left; exact hz
+        · have : A i j = -1 := by
+            have hne : A i j ≠ 0 := fun hc ↦ by rw [hc, zero_mul] at h1; contradiction
+            have hlt : A i j ≤ -1 := by omega
+            have hne' : A j i ≠ 0 := fun hc ↦ by rw [hc, mul_zero] at h1; contradiction
+            have hlt' : A j i ≤ -1 := by omega
+            by_contra hc
+            have : A i j ≤ -2 := by omega
+            have : 2 ≤ A i j * A j i := by nlinarith
+            omega
+          right; exact this
+        · contradiction
+        · contradiction
+      by_cases hc : ∃ c : B, (diagramGraph A).degree c = 3
+      · obtain ⟨c, hc3⟩ := hc
+        exact h.existsUnique_dynkinType_of_isSimplyLaced_of_degree_eq_three hconn hsl hc3
+      · have hdeg : ∀ v : B, (diagramGraph A).degree v ≤ 2 := by
+          intro v
+          have h3le := h.degree_le_three v
+          have hne3 : (diagramGraph A).degree v ≠ 3 := fun hv3 ↦ hc ⟨v, hv3⟩
+          omega
+        obtain ⟨e, he⟩ := h.exists_equiv_forall_eq_cartanMatrix_A hconn hsl hdeg
+        have hcard : 1 ≤ Fintype.card B := Fintype.card_pos_iff.mpr hB
+        refine ⟨.A (Fintype.card B), ⟨DynkinType.valid_A.mpr hcard, e, he⟩, fun s hs ↦ ?_⟩
+        exact DynkinType.eq_of_valid_of_forall_eq hs.1 (DynkinType.valid_A.mpr hcard)
+          hs.2.choose e hs.2.choose_spec he
+
+end IsFiniteType
+
+section RootPairing
+
+variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  {P : RootPairing ι R M N} [Finite ι] [CharZero R] [IsDomain R]
+  [P.IsRootSystem] [P.IsCrystallographic] [P.IsReduced] [P.IsIrreducible] [Nonempty ι]
+
+/-- **The Cartan-Killing classification, existence and uniqueness of the Dynkin type.** Every
+irreducible reduced crystallographic finite root system has a unique valid `DynkinType`. -/
+theorem existsUnique_dynkinType (b : P.Base) :
+    ∃! t : DynkinType, t.Valid ∧ HasCartanType P b t := by
+  have hB : Nonempty b.support := Finset.nonempty_coe_sort.mpr b.support_nonempty
+  obtain ⟨t, ⟨ht, e, he⟩, -⟩ :=
+    (isFiniteType_cartanMatrix b).existsUnique_dynkinType
+      (connected_diagramGraph_cartanMatrix b) hB
+  exact ((hasCartanType_iff b t).mpr ⟨e, he⟩).existsUnique_of_valid ht
+
+end RootPairing
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Classification.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Classification.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.LinearAlgebra.RootSystem.Classification
-public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Basic
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.NoBranch
 import TauCeti.LinearAlgebra.RootSystem.FiniteType.Dynkin
 
@@ -26,9 +25,10 @@ towards the double edge, followed by the first chain away from it. Under this or
 type follows from `TauCeti.DynkinType.isFiniteType_cartanMatrix_F4`, and combining this with the
 double-edge bound gives a complete characterization of when the model diagram is of finite type.
 
-The result classifies the model double-edge chains themselves. The preceding extraction problem --
-showing that a connected finite-type Cartan matrix carrying a double edge has this shape -- remains
-part of the existence half of the Cartan--Killing classification.
+This file classifies the model double-edge chains themselves, and combines this with the no-branch
+extraction theorem to establish the double-edge branch of the classification: every connected
+finite-type Cartan matrix carrying a double edge has a unique valid Dynkin type
+(`Bₙ`, `Cₙ`, or `F₄`).
 
 ## Main results
 
@@ -36,6 +36,10 @@ part of the existence half of the Cartan--Killing classification.
   explicit simultaneous reindexing.
 * `TauCeti.isFiniteType_doubleEdgeCartanMatrix_iff`: two nonempty chains joined by a double edge
   are of finite type exactly for the `B_n`, `C_n`, and `F₄` shapes.
+* `TauCeti.IsFiniteType.existsUnique_dynkinType_of_apply_mul_apply_eq_two`: a connected finite-type
+  Cartan matrix with a double edge has a unique valid Dynkin type (`Bₙ`, `Cₙ`, or `F₄`).
+* `TauCeti.existsUnique_dynkinType_of_apply_mul_apply_eq_two`: the root-system counterpart for
+  an irreducible reduced crystallographic finite root system with a double edge.
 
 ## References
 
@@ -102,11 +106,11 @@ followed by the lone vertex of the first chain. -/
 def doubleEdgeBEquiv (q : ℕ) : Fin 1 ⊕ Fin q ≃ Fin (q + 1) :=
   (Equiv.sumComm (Fin 1) (Fin q)).trans finSumFinEquiv
 
-@[simp] lemma doubleEdgeBEquiv_inl (q : ℕ) (i : Fin 1) :
+@[simp] lemma doubleEdgeBEquiv_inl_val (q : ℕ) (i : Fin 1) :
     (doubleEdgeBEquiv q (Sum.inl i) : ℕ) = q := by
   simp [doubleEdgeBEquiv]
 
-@[simp] lemma doubleEdgeBEquiv_inr (q : ℕ) (i : Fin q) :
+@[simp] lemma doubleEdgeBEquiv_inr_val (q : ℕ) (i : Fin q) :
     (doubleEdgeBEquiv q (Sum.inr i) : ℕ) = i := by
   simp [doubleEdgeBEquiv]
 
@@ -117,13 +121,11 @@ theorem doubleEdgeCartanMatrix_one_left (q : ℕ) :
   ext v w
   rcases v with a | a <;> rcases w with b | b <;>
     have ha := a.isLt <;> have hb := b.isLt <;>
-    simp only [doubleEdgeBEquiv, Equiv.trans_apply, Equiv.sumComm_apply,
-      Sum.swap_inl, Sum.swap_inr, Matrix.submatrix_apply,
-      finSumFinEquiv_apply_left, finSumFinEquiv_apply_right,
+    simp only [Matrix.submatrix_apply,
+      doubleEdgeBEquiv_inl_val, doubleEdgeBEquiv_inr_val,
       doubleEdgeCartanMatrix_inl_inl, doubleEdgeCartanMatrix_inr_inr,
       doubleEdgeCartanMatrix_inl_inr, doubleEdgeCartanMatrix_inr_inl,
-      CartanMatrix.B, Matrix.of_apply, chainEntry_def, Fin.ext_iff,
-      Fin.val_castAdd, Fin.val_natAdd] <;>
+      CartanMatrix.B, Matrix.of_apply, chainEntry_def, Fin.ext_iff] <;>
     split_ifs <;> omega
 
 /-- **Classification of finite double-edge chains.** Suppose both chains are nonempty. Their
@@ -140,7 +142,7 @@ double-edge diagram is of finite type exactly when the second chain is a single 
     · exact isFiniteType_doubleEdgeCartanMatrix_two_two
 
 /-- Every admissible finite-type double-edge chain carries a unique valid Dynkin type. -/
-theorem doubleEdgeCartanMatrix_exists_valid_dynkinType (p q : ℕ) (hp : 0 < p) (hq : 0 < q)
+private theorem doubleEdgeCartanMatrix_existsUnique_dynkinType (p q : ℕ) (hp : 0 < p) (hq : 0 < q)
     (h : q = 1 ∨ p = 1 ∨ (p = 2 ∧ q = 2)) :
     ∃! t : DynkinType, t.Valid ∧
       ∃ e : Fin p ⊕ Fin q ≃ Fin t.rank,
@@ -184,7 +186,7 @@ theorem existsUnique_dynkinType_of_apply_mul_apply_eq_two
   obtain ⟨p, q, hp, hq, hadm, e, he⟩ :=
     h.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_apply_mul_apply_eq_two hconn huv
   obtain ⟨t, ⟨htv, et, het⟩, -⟩ :=
-    doubleEdgeCartanMatrix_exists_valid_dynkinType p q hp hq hadm
+    doubleEdgeCartanMatrix_existsUnique_dynkinType p q hp hq hadm
   refine ⟨t, ⟨htv, e.trans et, fun i j ↦ by rw [he, het]; rfl⟩, ?_⟩
   intro s hs
   exact DynkinType.eq_of_valid_of_forall_eq hs.1 htv hs.2.choose (e.trans et)

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Classification.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/DoubleEdge/Classification.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.LinearAlgebra.RootSystem.Classification
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Basic
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.NoBranch
 import TauCeti.LinearAlgebra.RootSystem.FiniteType.Dynkin
 
 public section
@@ -94,6 +96,36 @@ theorem isFiniteType_doubleEdgeCartanMatrix_two_two :
   rw [doubleEdgeCartanMatrix_two_two]
   exact DynkinType.isFiniteType_cartanMatrix_F4.submatrix doubleEdgeF4Equiv.injective
 
+/-- The equivalence identifying the double-edge chain with one vertex on the first chain with the
+standard Bourbaki-numbered `B_{q+1}` diagram. It puts the `q` vertices of the second chain first,
+followed by the lone vertex of the first chain. -/
+def doubleEdgeBEquiv (q : ℕ) : Fin 1 ⊕ Fin q ≃ Fin (q + 1) :=
+  (Equiv.sumComm (Fin 1) (Fin q)).trans finSumFinEquiv
+
+@[simp] lemma doubleEdgeBEquiv_inl (q : ℕ) (i : Fin 1) :
+    (doubleEdgeBEquiv q (Sum.inl i) : ℕ) = q := by
+  simp [doubleEdgeBEquiv]
+
+@[simp] lemma doubleEdgeBEquiv_inr (q : ℕ) (i : Fin q) :
+    (doubleEdgeBEquiv q (Sum.inr i) : ℕ) = i := by
+  simp [doubleEdgeBEquiv]
+
+/-- **A double-edge chain whose first chain is a single vertex is of type `Bₙ`.** -/
+theorem doubleEdgeCartanMatrix_one_left (q : ℕ) :
+    doubleEdgeCartanMatrix 1 q =
+      (CartanMatrix.B (q + 1)).submatrix (doubleEdgeBEquiv q) (doubleEdgeBEquiv q) := by
+  ext v w
+  rcases v with a | a <;> rcases w with b | b <;>
+    have ha := a.isLt <;> have hb := b.isLt <;>
+    simp only [doubleEdgeBEquiv, Equiv.trans_apply, Equiv.sumComm_apply,
+      Sum.swap_inl, Sum.swap_inr, Matrix.submatrix_apply,
+      finSumFinEquiv_apply_left, finSumFinEquiv_apply_right,
+      doubleEdgeCartanMatrix_inl_inl, doubleEdgeCartanMatrix_inr_inr,
+      doubleEdgeCartanMatrix_inl_inr, doubleEdgeCartanMatrix_inr_inl,
+      CartanMatrix.B, Matrix.of_apply, chainEntry_def, Fin.ext_iff,
+      Fin.val_castAdd, Fin.val_natAdd] <;>
+    split_ifs <;> omega
+
 /-- **Classification of finite double-edge chains.** Suppose both chains are nonempty. Their
 double-edge diagram is of finite type exactly when the second chain is a single vertex (type
 `C_n`), the first chain is a single vertex (type `B_n`), or both chains have two vertices (type
@@ -106,5 +138,77 @@ double-edge diagram is of finite type exactly when the second chain is a single 
     · exact isFiniteType_doubleEdgeCartanMatrix_one_right p
     · exact isFiniteType_doubleEdgeCartanMatrix_one_left q
     · exact isFiniteType_doubleEdgeCartanMatrix_two_two
+
+/-- Every admissible finite-type double-edge chain carries a unique valid Dynkin type. -/
+theorem doubleEdgeCartanMatrix_exists_valid_dynkinType (p q : ℕ) (hp : 0 < p) (hq : 0 < q)
+    (h : q = 1 ∨ p = 1 ∨ (p = 2 ∧ q = 2)) :
+    ∃! t : DynkinType, t.Valid ∧
+      ∃ e : Fin p ⊕ Fin q ≃ Fin t.rank,
+        ∀ i j, doubleEdgeCartanMatrix p q i j = t.cartanMatrix (e i) (e j) := by
+  have hex : ∃ t : DynkinType, t.Valid ∧
+      ∃ e : Fin p ⊕ Fin q ≃ Fin t.rank,
+        ∀ i j, doubleEdgeCartanMatrix p q i j = t.cartanMatrix (e i) (e j) := by
+    rcases h with rfl | rfl | ⟨rfl, rfl⟩
+    · by_cases hp2 : 2 ≤ p
+      · refine ⟨.C (p + 1), ?_, finSumFinEquiv, fun i j ↦ ?_⟩
+        · simp only [DynkinType.valid_C]; omega
+        · rw [DynkinType.cartanMatrix_C, doubleEdgeCartanMatrix_one_right]
+          rfl
+      · have hp1 : p = 1 := by omega
+        subst hp1
+        refine ⟨.B 2, by simp only [DynkinType.valid_B]; omega, doubleEdgeBEquiv 1, fun i j ↦ ?_⟩
+        rw [DynkinType.cartanMatrix_B, doubleEdgeCartanMatrix_one_left]
+        rfl
+    · refine ⟨.B (q + 1), ?_, doubleEdgeBEquiv q, fun i j ↦ ?_⟩
+      · simp only [DynkinType.valid_B]; omega
+      · rw [DynkinType.cartanMatrix_B, doubleEdgeCartanMatrix_one_left]
+        rfl
+    · refine ⟨.F4, DynkinType.valid_F4, doubleEdgeF4Equiv, fun i j ↦ ?_⟩
+      rw [doubleEdgeCartanMatrix_two_two]
+      rfl
+  obtain ⟨t, htv, ht⟩ := hex
+  exact ⟨t, ⟨htv, ht⟩, fun s hs ↦ DynkinType.eq_of_valid_of_forall_eq hs.1 htv hs.2.choose ht.choose
+    hs.2.choose_spec ht.choose_spec⟩
+
+namespace IsFiniteType
+
+variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
+
+/-- **The double-edge branch of the finite-type classification.** A connected finite-type matrix
+containing a double edge has a unique valid Dynkin type. It is one of `Bₙ`, `Cₙ`, or `F₄`. -/
+theorem existsUnique_dynkinType_of_apply_mul_apply_eq_two
+    (h : IsFiniteType A) (hconn : (diagramGraph A).Preconnected)
+    {u v : B} (huv : A u v * A v u = 2) :
+    ∃! t : DynkinType, t.Valid ∧
+      ∃ e : B ≃ Fin t.rank, ∀ i j, A i j = t.cartanMatrix (e i) (e j) := by
+  obtain ⟨p, q, hp, hq, hadm, e, he⟩ :=
+    h.exists_equiv_forall_eq_doubleEdgeCartanMatrix_of_apply_mul_apply_eq_two hconn huv
+  obtain ⟨t, ⟨htv, et, het⟩, -⟩ :=
+    doubleEdgeCartanMatrix_exists_valid_dynkinType p q hp hq hadm
+  refine ⟨t, ⟨htv, e.trans et, fun i j ↦ by rw [he, het]; rfl⟩, ?_⟩
+  intro s hs
+  exact DynkinType.eq_of_valid_of_forall_eq hs.1 htv hs.2.choose (e.trans et)
+    hs.2.choose_spec (fun i j ↦ by rw [he, het]; rfl)
+
+end IsFiniteType
+
+section RootPairing
+
+variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  {P : RootPairing ι R M N} [Finite ι] [CharZero R] [IsDomain R]
+  [P.IsRootSystem] [P.IsCrystallographic] [P.IsReduced] [P.IsIrreducible]
+
+/-- **An irreducible root system with a double edge has a unique valid Dynkin type.** The type is
+one of `Bₙ`, `Cₙ`, or `F₄`. -/
+theorem existsUnique_dynkinType_of_apply_mul_apply_eq_two (b : P.Base)
+    {u v : b.support} (huv : b.cartanMatrix u v * b.cartanMatrix v u = 2) :
+    ∃! t : DynkinType, t.Valid ∧ HasCartanType P b t := by
+  have : Nonempty ι := ⟨u.1⟩
+  obtain ⟨t, ⟨ht, e, he⟩, -⟩ :=
+    (isFiniteType_cartanMatrix b).existsUnique_dynkinType_of_apply_mul_apply_eq_two
+      (connected_diagramGraph_cartanMatrix b).preconnected huv
+  exact ((hasCartanType_iff b t).mpr ⟨e, he⟩).existsUnique_of_valid ht
+
+end RootPairing
 
 end TauCeti


### PR DESCRIPTION
This PR proves the central classification theorem of Layer 5 of `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, milestone "the classification of finite-type Cartan matrices": every nonempty connected finite-type Cartan matrix agrees with the standard Cartan matrix of a unique valid Dynkin type (`TauCeti.IsFiniteType.existsUnique_dynkinType`), and every base of an irreducible reduced crystallographic finite root system has a unique valid Dynkin type (`TauCeti.existsUnique_dynkinType`).

The classification assembles the four geometric subdiagram branches:
1. **Triple-edge case**: isolated by `TauCeti.IsFiniteType.exists_equiv_cartanMatrix_eq_G2_of_apply_mul_apply_eq_three` into type $G_2$.
2. **Double-edge case**: this PR identifies the branchless double-edge chains with standard Bourbaki matrices $B_n$, $C_n$, and $F_4$ via `doubleEdgeBEquiv`, `doubleEdgeCartanMatrix_one_left`, `doubleEdgeCartanMatrix_one_right`, and `doubleEdgeCartanMatrix_two_two`, yielding `IsFiniteType.existsUnique_dynkinType_of_apply_mul_apply_eq_two`.
3. **Simply-laced branching**: classified by `TauCeti.IsFiniteType.existsUnique_dynkinType_of_isSimplyLaced_of_degree_eq_three` into $D_n$, $E_6$, $E_7$, $E_8$.
4. **Simply-laced chain**: classified by `TauCeti.IsFiniteType.exists_equiv_forall_eq_cartanMatrix_A` into $A_n$.

Uniqueness among valid Dynkin types is discharged by `TauCeti.DynkinType.eq_of_valid_of_forall_eq` from `TauCeti.LinearAlgebra.RootSystem.Classification`.

This PR is the natural next step following the recent merges of the branchless double-edge classification (#3346) and simply-laced reindexing (#3224), completing the existence and uniqueness of Dynkin types for the RootSystems roadmap.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"exists-unique-dynkin-type"}-->
