### PR TITLE
docs(DivisionPolynomial): half the ω chain has landed

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
@@ -58,9 +58,12 @@ identities listed below.
 `redInvarDenom` and `complEDS₂Aux`, and `ω_spec` additionally consumes `redInvar_normEDS`, which
 routes through `normEDS` being an elliptic sequence — that is `isEllipticSequence_normEDS` in
 `NormEDS.lean`, which the pinned Mathlib still records as an open TODO. What is missing for `ω`
-is `redInvarDenom` itself together with the chain
-`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`. Nothing in this file depends
-on any of it, so the identities land now and `ω` follows when that gap closes.
+is `redInvarDenom` itself together with the upper part of the chain
+`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`, which is written in the
+source's names. The lower two links have landed: `net_normEDS` is `isEllipticNet_normEDS` and
+`invar_normEDS` is `invarNum_mul_invarDenom`. What remains is `invar₂_normEDS` and
+`redInvar_normEDS`. Nothing in this file depends on any of it, so the identities land now and `ω`
+follows when that gap closes.
 
 ## Provenance
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -37,9 +37,11 @@ extra rewrites in those proofs (`map_C`, `coe_mapRingHom`) only move that `C` pa
 The companion transport for `ω` is **not** here. It cannot be: `WeierstrassCurve.ω` does not exist
 in this repository or in the pinned Mathlib, and neither does the `map_ω` such a proof would rewrite
 with. `DivisionPolynomial/Invariant.lean` lists both among what it deliberately leaves out, and
-records the chain still missing for them — `redInvarDenom` together with
-`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`. `evalEval_ω` belongs with that
-work rather than here.
+records the chain still missing for them — `redInvarDenom` together with the upper part of
+`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`, the source's names for it. The
+lower two links are `isEllipticNet_normEDS` and `invarNum_mul_invarDenom`, both present, so what
+remains is `invar₂_normEDS` and `redInvar_normEDS`. `evalEval_ω` belongs with that work rather
+than here.
 
 ## Provenance
 


### PR DESCRIPTION
Two module docstrings state the ω chain as entirely missing. Half of it has landed.

## What is wrong

`DivisionPolynomial/Invariant.lean` and `DivisionPolynomial/Universal.lean` both record what `ω`
still needs, in the source's vocabulary:

> `redInvarDenom` together with `redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`

Checked against `origin/main` by anchored declaration grep, in **TauCeti's** names rather than the
source's — which is where this chain has been mis-assessed repeatedly:

```
net_normEDS     →  isEllipticNet_normEDS      NormEDS.lean:113     PRESENT
invar_normEDS   →  invarNum_mul_invarDenom    Invariant.lean:138   PRESENT
invar₂_normEDS                                                     absent
redInvar_normEDS                                                   absent
```

Two of the four links exist. Both docstrings say all four are missing, and a reader taking either
at face value would conclude that work is needed which is already merged — this is the second time
that has happened on this exact chain.

## The fix

Each paragraph now labels the chain as the source's names, says which links have landed and under
what spelling, and lists only what genuinely remains. The `redInvarDenom` half of the sentence is
untouched, being still correct.

**No file paths are cited for the landed declarations, deliberately.** `invarNum_mul_invarDenom`
currently lives in `EllipticDivisibilitySequence/Invariant.lean`, and #3361 moves that file to
`Invariant/Basic.lean`. Naming the path would make this prose stale on the merge of an already-open
PR, in the same commit that fixes it for being stale. Declaration names are stable across that move;
paths are not.

## Why this is its own PR

It is documentation of existing code, which needs no roadmap entry. It touches no declaration, adds
nothing, and gates on nothing — so it is independent of the `ω` work it describes and of every open
PR. It also does not collide: of the open PRs, only #3361 touches either file, at the import line
and its provenance echo, not at the paragraphs corrected here.

## How it was found

Not by reading the files for their own sake. Every absence check on this chain routes through these
two paragraphs, so a stale one propagates into scope arguments and into other PRs' bodies. The
general rule this is the fourth instance of: **a docstring sentence naming a declaration as missing
is a liability with a due date**, and nothing in the build ever checks it — the compiler is
indifferent to prose, so the only thing that catches it is someone re-running the grep.

## Gates

`lake build` PASS at 7974 jobs. `lake exe axioms` PASS — 47633 declarations, allowlist only.
`lake exe module-system` PASS. `scripts/lint-env.sh` PASS, no new violations. No declarations
added, removed or renamed; the diff is two prose paragraphs.

## Roadmap

`Roadmap: EllipticCurves`. Documentation of existing code, so no roadmap target is claimed — the
files being corrected serve `TauCetiRoadmap/EllipticCurves/README.md:99`, "**`[n]` is division
polynomials**", and the chain they describe is the route to `ω` that Layer 6's Nagell–Lutz
consumes.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-omega-chain-prose"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
