### PR TITLE
refactor(Winding): call the segment-identification lemmas that already exist

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -143,11 +143,8 @@ private lemma telescope_rho_add_one_piece_arc_second (H : ℝ) :
           (fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1)) =
       Complex.log (fdBoundary H 3 - ((UpperHalfPlane.ρ : ℂ) + 1)) -
         Complex.log (fdBoundary H 2 - ((UpperHalfPlane.ρ : ℂ) + 1)) := by
-  have heval : ∀ s ∈ Icc (2 : ℝ) 3, fdBoundary H s = fdBoundarySegment3 s := by
-    intro s hs
-    rcases eq_or_lt_of_le hs.1 with h2 | h2
-    · rw [← h2, fdBoundary_apply_two, fdBoundarySegment3_apply_two]
-    · exact fdBoundary_of_le_three h2 hs.2
+  have heval : ∀ s ∈ Icc (2 : ℝ) 3, fdBoundary H s = fdBoundarySegment3 s :=
+    fun _ hs ↦ eqOn_fdBoundarySegment3 H hs
   have hd : deriv (fun s ↦ fdBoundarySegment3 s - ((UpperHalfPlane.ρ : ℂ) + 1)) = fun s ↦
       (2 * Real.pi / 3 - Real.pi / 2) •
         (circleMap 0 1 (Real.pi / 2 + (s - 2) * (2 * Real.pi / 3 - Real.pi / 2)) *
@@ -198,11 +195,8 @@ private lemma telescope_rho_add_one_piece_left_vertical (hH : Real.sqrt 3 / 2 < 
           (fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1)) =
       Complex.log (fdBoundary H 4 - ((UpperHalfPlane.ρ : ℂ) + 1)) -
         Complex.log (fdBoundary H 3 - ((UpperHalfPlane.ρ : ℂ) + 1)) := by
-  have heval : ∀ s ∈ Icc (3 : ℝ) 4, fdBoundary H s = fdBoundarySegment4 H s := by
-    intro s hs
-    rcases eq_or_lt_of_le hs.1 with h3 | h3
-    · rw [← h3, fdBoundary_apply_three, fdBoundarySegment4_apply_three]
-    · exact fdBoundary_of_le_four h3 hs.2
+  have heval : ∀ s ∈ Icc (3 : ℝ) 4, fdBoundary H s = fdBoundarySegment4 H s :=
+    fun _ hs ↦ eqOn_fdBoundarySegment4 H hs
   have hd : deriv (fun s ↦ fdBoundarySegment4 H s - ((UpperHalfPlane.ρ : ℂ) + 1)) =
       fun _ ↦ -1 / 2 + H * Complex.I - (UpperHalfPlane.ρ : ℂ) :=
     funext fun s ↦ by rw [deriv_sub_const, deriv_fdBoundarySegment4]
@@ -252,11 +246,8 @@ private lemma telescope_rho_add_one_piece_ceiling (hH : Real.sqrt 3 / 2 < H) :
           (fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1)) =
       Complex.log (fdBoundary H 5 - ((UpperHalfPlane.ρ : ℂ) + 1)) -
         Complex.log (fdBoundary H 4 - ((UpperHalfPlane.ρ : ℂ) + 1)) := by
-  have heval : ∀ s ∈ Icc (4 : ℝ) 5, fdBoundary H s = fdBoundarySegment5 H s := by
-    intro s hs
-    rcases eq_or_lt_of_le hs.1 with h4 | h4
-    · rw [← h4, fdBoundary_apply_four, fdBoundarySegment5_apply_four]
-    · exact fdBoundary_of_gt_four h4
+  have heval : ∀ s ∈ Icc (4 : ℝ) 5, fdBoundary H s = fdBoundarySegment5 H s :=
+    fun _ hs ↦ eqOn_fdBoundarySegment5 H hs
   have hd : deriv (fun s ↦ fdBoundarySegment5 H s - ((UpperHalfPlane.ρ : ℂ) + 1)) =
       fun _ ↦ (1 : ℂ) :=
     funext fun s ↦ by rw [deriv_sub_const, deriv_fdBoundarySegment5]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -144,41 +144,29 @@ private lemma telescope_rho_add_one_piece_arc_second (H : ℝ) :
       Complex.log (fdBoundary H 3 - ((UpperHalfPlane.ρ : ℂ) + 1)) -
         Complex.log (fdBoundary H 2 - ((UpperHalfPlane.ρ : ℂ) + 1)) := by
   have heval : ∀ s ∈ Icc (2 : ℝ) 3, fdBoundary H s = fdBoundarySegment3 s :=
-    fun _ hs ↦ eqOn_fdBoundarySegment3 H hs
+    eqOn_fdBoundarySegment3 H
   have hd : deriv (fun s ↦ fdBoundarySegment3 s - ((UpperHalfPlane.ρ : ℂ) + 1)) = fun s ↦
       (2 * Real.pi / 3 - Real.pi / 2) •
         (circleMap 0 1 (Real.pi / 2 + (s - 2) * (2 * Real.pi / 3 - Real.pi / 2)) *
           Complex.I) :=
     funext fun s ↦ by rw [deriv_sub_const, deriv_fdBoundarySegment3]
-  have hθc : Continuous fun s : ℝ ↦
-      Real.pi / 2 + (s - 2) * (2 * Real.pi / 3 - Real.pi / 2) := by
-    fun_prop
   have hne : ∀ t ∈ Icc (2 : ℝ) 3, fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1) ≠ 0 := by
     intro t ht
     rcases eq_or_lt_of_le ht.2 with h3 | h3
-    · rw [h3, fdBoundary_apply_three]
-      norm_num
-    · have him := im_fdBoundary_sub_rho_add_one_arc_pos H (by linarith [ht.1]) h3
-      exact fun h0 ↦ by rw [h0] at him; simp at him
-  have hne' : ∀ t ∈ Icc (2 : ℝ) 3,
-      fdBoundarySegment3 t - ((UpperHalfPlane.ρ : ℂ) + 1) ≠ 0 := fun t ht ↦
-    heval t ht ▸ hne t ht
+    · simp [h3, fdBoundary_apply_three]
+    · exact ne_of_apply_ne Complex.im
+        (im_fdBoundary_sub_rho_add_one_arc_pos H (by linarith [ht.1]) h3).ne'
   exact intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_im_nonneg_of_le
     (g := fun s ↦ fdBoundary H s - ((UpperHalfPlane.ρ : ℂ) + 1))
     (h := fun s ↦ fdBoundarySegment3 s - ((UpperHalfPlane.ρ : ℂ) + 1)) (by norm_num)
     (Continuous.continuousOn (Differentiable.continuous fun s ↦
       (hasDerivAt_fdBoundarySegment3 s).differentiableAt.sub_const _))
     (fun t _ ↦ (hasDerivAt_fdBoundarySegment3 t).differentiableAt.sub_const _)
-    (by
-      rw [hd]
-      exact (Continuous.const_smul
-        (((continuous_circleMap 0 1).comp hθc).mul continuous_const)
-        (2 * Real.pi / 3 - Real.pi / 2)).continuousOn)
-    hne'
-    (fun t ht ↦
-      heval t ht ▸ im_fdBoundary_sub_rho_add_one_arc_nonneg H ⟨by linarith [ht.1], ht.2⟩)
+    (by rw [hd]; fun_prop)
+    (fun t ht ↦ heval t ht ▸ hne t ht)
+    (fun t ht ↦ heval t ht ▸ im_fdBoundary_sub_rho_add_one_arc_nonneg H ⟨by linarith [ht.1], ht.2⟩)
     (fun t ht ↦ heval t ⟨ht.1.le, ht.2.le⟩ ▸ Complex.mem_slitPlane_iff.mpr (Or.inr
-      (ne_of_gt (im_fdBoundary_sub_rho_add_one_arc_pos H (by linarith [ht.1]) ht.2))))
+      (im_fdBoundary_sub_rho_add_one_arc_pos H (by linarith [ht.1]) ht.2).ne'))
     (fun t ht ↦ congrArg (· - ((UpperHalfPlane.ρ : ℂ) + 1)) (heval t ⟨ht.1.le, ht.2.le⟩))
     (congrArg (· - ((UpperHalfPlane.ρ : ℂ) + 1)) (heval 2 (left_mem_Icc.mpr (by norm_num))))
     (congrArg (· - ((UpperHalfPlane.ρ : ℂ) + 1)) (heval 3 (right_mem_Icc.mpr (by norm_num))))
@@ -196,25 +184,16 @@ private lemma telescope_rho_add_one_piece_left_vertical (hH : Real.sqrt 3 / 2 < 
       Complex.log (fdBoundary H 4 - ((UpperHalfPlane.ρ : ℂ) + 1)) -
         Complex.log (fdBoundary H 3 - ((UpperHalfPlane.ρ : ℂ) + 1)) := by
   have heval : ∀ s ∈ Icc (3 : ℝ) 4, fdBoundary H s = fdBoundarySegment4 H s :=
-    fun _ hs ↦ eqOn_fdBoundarySegment4 H hs
+    eqOn_fdBoundarySegment4 H
   have hd : deriv (fun s ↦ fdBoundarySegment4 H s - ((UpperHalfPlane.ρ : ℂ) + 1)) =
       fun _ ↦ -1 / 2 + H * Complex.I - (UpperHalfPlane.ρ : ℂ) :=
     funext fun s ↦ by rw [deriv_sub_const, deriv_fdBoundarySegment4]
-  have him : ∀ t ∈ Icc (3 : ℝ) 4,
-      (fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1)).im =
-        (t - 3) * (H - Real.sqrt 3 / 2) := fun t ht ↦ by
-    rw [fdBoundary_sub_rho_add_one_of_mem_Icc_three_four H ht]
-    simp
-  have hne : ∀ t ∈ Icc (3 : ℝ) 4, fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1) ≠ 0 := by
-    intro t ht h0
-    have hre : (fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1)).re = -1 := by
-      rw [fdBoundary_sub_rho_add_one_of_mem_Icc_three_four H ht]
-      simp
-    rw [h0] at hre
-    norm_num at hre
-  have hne' : ∀ t ∈ Icc (3 : ℝ) 4,
-      fdBoundarySegment4 H t - ((UpperHalfPlane.ρ : ℂ) + 1) ≠ 0 := fun t ht ↦
-    heval t ht ▸ hne t ht
+  have him : ∀ t ∈ Icc (3 : ℝ) 4, (fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1)).im =
+      (t - 3) * (H - Real.sqrt 3 / 2) := fun t ht ↦ by
+    simp [fdBoundary_sub_rho_add_one_of_mem_Icc_three_four H ht]
+  have hne : ∀ t ∈ Icc (3 : ℝ) 4, fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1) ≠ 0 :=
+    fun t ht ↦ ne_of_apply_ne Complex.re <| by
+      simp [fdBoundary_sub_rho_add_one_of_mem_Icc_three_four H ht]
   exact intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_im_nonneg_of_le
     (g := fun s ↦ fdBoundary H s - ((UpperHalfPlane.ρ : ℂ) + 1))
     (h := fun s ↦ fdBoundarySegment4 H s - ((UpperHalfPlane.ρ : ℂ) + 1)) (by norm_num)
@@ -222,15 +201,11 @@ private lemma telescope_rho_add_one_piece_left_vertical (hH : Real.sqrt 3 / 2 < 
       (hasDerivAt_fdBoundarySegment4 H s).differentiableAt.sub_const _))
     (fun t _ ↦ (hasDerivAt_fdBoundarySegment4 H t).differentiableAt.sub_const _)
     (by rw [hd]; exact continuousOn_const)
-    hne'
-    (fun t ht ↦ heval t ht ▸ (by
-      rw [him t ht]
-      exact mul_nonneg (by linarith [ht.1]) (by linarith)))
-    (fun t ht ↦ heval t ⟨ht.1.le, ht.2.le⟩ ▸ Complex.mem_slitPlane_iff.mpr (Or.inr (by
-      rw [him t ⟨ht.1.le, ht.2.le⟩]
-      have := mul_pos (by linarith [ht.1] : (0 : ℝ) < t - 3) (by linarith :
-        (0 : ℝ) < H - Real.sqrt 3 / 2)
-      linarith)))
+    (fun t ht ↦ heval t ht ▸ hne t ht)
+    (fun t ht ↦ heval t ht ▸ him t ht ▸ mul_nonneg (by linarith [ht.1]) (by linarith))
+    (fun t ht ↦ heval t ⟨ht.1.le, ht.2.le⟩ ▸ Complex.mem_slitPlane_iff.mpr (Or.inr
+      (him t ⟨ht.1.le, ht.2.le⟩ ▸ (mul_pos (by linarith [ht.1] : (0 : ℝ) < t - 3)
+        (by linarith)).ne')))
     (fun t ht ↦ congrArg (· - ((UpperHalfPlane.ρ : ℂ) + 1)) (heval t ⟨ht.1.le, ht.2.le⟩))
     (congrArg (· - ((UpperHalfPlane.ρ : ℂ) + 1)) (heval 3 (left_mem_Icc.mpr (by norm_num))))
     (congrArg (· - ((UpperHalfPlane.ρ : ℂ) + 1)) (heval 4 (right_mem_Icc.mpr (by norm_num))))
@@ -247,28 +222,23 @@ private lemma telescope_rho_add_one_piece_ceiling (hH : Real.sqrt 3 / 2 < H) :
       Complex.log (fdBoundary H 5 - ((UpperHalfPlane.ρ : ℂ) + 1)) -
         Complex.log (fdBoundary H 4 - ((UpperHalfPlane.ρ : ℂ) + 1)) := by
   have heval : ∀ s ∈ Icc (4 : ℝ) 5, fdBoundary H s = fdBoundarySegment5 H s :=
-    fun _ hs ↦ eqOn_fdBoundarySegment5 H hs
+    eqOn_fdBoundarySegment5 H
   have hd : deriv (fun s ↦ fdBoundarySegment5 H s - ((UpperHalfPlane.ρ : ℂ) + 1)) =
       fun _ ↦ (1 : ℂ) :=
     funext fun s ↦ by rw [deriv_sub_const, deriv_fdBoundarySegment5]
-  have hslit : ∀ t ∈ Icc (4 : ℝ) 5,
-      fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1) ∈ Complex.slitPlane := by
-    intro t ht
-    refine Complex.mem_slitPlane_iff.mpr (Or.inr ?_)
-    have him : (fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1)).im =
-        H - Real.sqrt 3 / 2 := by
-      rw [Complex.sub_im, im_fdBoundarySegment5 H ht]
-      norm_num [UpperHalfPlane.ρ]
-    rw [him]
-    linarith
+  have him : ∀ t ∈ Icc (4 : ℝ) 5,
+      (fdBoundary H t - ((UpperHalfPlane.ρ : ℂ) + 1)).im = H - Real.sqrt 3 / 2 := fun t ht ↦ by
+    rw [Complex.sub_im, im_fdBoundarySegment5 H ht]
+    norm_num [UpperHalfPlane.ρ]
   exact intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_mem_slitPlane_of_le
     (g := fun s ↦ fdBoundary H s - ((UpperHalfPlane.ρ : ℂ) + 1))
     (h := fun s ↦ fdBoundarySegment5 H s - ((UpperHalfPlane.ρ : ℂ) + 1)) (by norm_num)
     (Continuous.continuousOn (Differentiable.continuous fun s ↦
-      ((hasDerivAt_fdBoundarySegment5 H s).differentiableAt.sub_const _)))
+      (hasDerivAt_fdBoundarySegment5 H s).differentiableAt.sub_const _))
     (fun t _ ↦ (hasDerivAt_fdBoundarySegment5 H t).differentiableAt.sub_const _)
     (by rw [hd]; exact continuousOn_const)
-    (fun t ht ↦ heval t ht ▸ hslit t ht)
+    (fun t ht ↦ heval t ht ▸ Complex.mem_slitPlane_iff.mpr
+      (Or.inr ((him t ht).trans_ne (sub_pos.mpr hH).ne')))
     (fun t ht ↦ congrArg (· - ((UpperHalfPlane.ρ : ℂ) + 1)) (heval t ⟨ht.1.le, ht.2.le⟩))
     (congrArg (· - ((UpperHalfPlane.ρ : ℂ) + 1)) (heval 4 (left_mem_Icc.mpr (by norm_num))))
     (congrArg (· - ((UpperHalfPlane.ρ : ℂ) + 1)) (heval 5 (right_mem_Icc.mpr (by norm_num))))

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -95,24 +95,18 @@ private lemma telescope_rho_piece_arc_first (H : ℝ) :
       Complex.log (fdBoundary H 2 - (UpperHalfPlane.ρ : ℂ)) -
         Complex.log (fdBoundary H 1 - (UpperHalfPlane.ρ : ℂ)) := by
   have heval : ∀ s ∈ Icc (1 : ℝ) 2, fdBoundary H s = fdBoundarySegment2 s :=
-    fun _ hs ↦ eqOn_fdBoundarySegment2 H hs
+    eqOn_fdBoundarySegment2 H
   have hd : deriv (fun s ↦ fdBoundarySegment2 s - (UpperHalfPlane.ρ : ℂ)) = fun s ↦
       (Real.pi / 2 - Real.pi / 3) •
         (circleMap 0 1 (Real.pi / 3 + (s - 1) * (Real.pi / 2 - Real.pi / 3)) * Complex.I) :=
     funext fun s ↦ by rw [deriv_sub_const, deriv_fdBoundarySegment2]
-  have hθc : Continuous fun s : ℝ ↦ Real.pi / 3 + (s - 1) * (Real.pi / 2 - Real.pi / 3) := by
-    fun_prop
   exact intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_mem_slitPlane_of_le
     (g := fun s ↦ fdBoundary H s - (UpperHalfPlane.ρ : ℂ))
     (h := fun s ↦ fdBoundarySegment2 s - (UpperHalfPlane.ρ : ℂ)) (by norm_num)
-    (Continuous.continuousOn (Differentiable.continuous fun s ↦
-      ((hasDerivAt_fdBoundarySegment2 s).differentiableAt.sub_const _)))
+    (Differentiable.continuous fun s ↦
+      (hasDerivAt_fdBoundarySegment2 s).differentiableAt.sub_const _).continuousOn
     (fun t _ ↦ (hasDerivAt_fdBoundarySegment2 t).differentiableAt.sub_const _)
-    (by
-      rw [hd]
-      exact (Continuous.const_smul
-        (((continuous_circleMap 0 1).comp hθc).mul continuous_const)
-        (Real.pi / 2 - Real.pi / 3)).continuousOn)
+    (by rw [hd]; fun_prop)
     (fun t ht ↦ heval t ht ▸
       fdBoundary_sub_rho_arc_mem_slitPlane_of_lt_three H ht.1 (by linarith [ht.2]))
     (fun t ht ↦ congrArg (· - (UpperHalfPlane.ρ : ℂ)) (heval t ⟨ht.1.le, ht.2.le⟩))
@@ -134,29 +128,21 @@ private lemma telescope_rho_piece_arc_second (H : ℝ) (hδL : 0 < δL) (hδL1 :
   have hab : (2 : ℝ) ≤ 3 - δL := by linarith
   -- the excised range sits inside `[2, 3]`, so the segment identification restricts to it
   have heval : ∀ s ∈ Icc (2 : ℝ) (3 - δL), fdBoundary H s = fdBoundarySegment3 s :=
-    fun _ hs ↦ eqOn_fdBoundarySegment3 H ⟨hs.1, by linarith [hs.2]⟩
+    (eqOn_fdBoundarySegment3 H).mono (Icc_subset_Icc_right (by linarith))
   have hd : deriv (fun s ↦ fdBoundarySegment3 s - (UpperHalfPlane.ρ : ℂ)) = fun s ↦
       (2 * Real.pi / 3 - Real.pi / 2) •
         (circleMap 0 1 (Real.pi / 2 + (s - 2) * (2 * Real.pi / 3 - Real.pi / 2)) *
           Complex.I) :=
     funext fun s ↦ by rw [deriv_sub_const, deriv_fdBoundarySegment3]
-  have hθc : Continuous fun s : ℝ ↦
-      Real.pi / 2 + (s - 2) * (2 * Real.pi / 3 - Real.pi / 2) := by
-    fun_prop
   exact intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_mem_slitPlane_of_le
     (g := fun s ↦ fdBoundary H s - (UpperHalfPlane.ρ : ℂ))
     (h := fun s ↦ fdBoundarySegment3 s - (UpperHalfPlane.ρ : ℂ)) hab
-    (Continuous.continuousOn (Differentiable.continuous fun s ↦
-      ((hasDerivAt_fdBoundarySegment3 s).differentiableAt.sub_const _)))
+    (Differentiable.continuous fun s ↦
+      (hasDerivAt_fdBoundarySegment3 s).differentiableAt.sub_const _).continuousOn
     (fun t _ ↦ (hasDerivAt_fdBoundarySegment3 t).differentiableAt.sub_const _)
-    (by
-      rw [hd]
-      exact (Continuous.const_smul
-        (((continuous_circleMap 0 1).comp hθc).mul continuous_const)
-        (2 * Real.pi / 3 - Real.pi / 2)).continuousOn)
+    (by rw [hd]; fun_prop)
     (fun t ht ↦ heval t ht ▸
-      fdBoundary_sub_rho_arc_mem_slitPlane_of_lt_three H (by linarith [ht.1])
-        (by linarith [ht.2]))
+      fdBoundary_sub_rho_arc_mem_slitPlane_of_lt_three H (by linarith [ht.1]) (by linarith [ht.2]))
     (fun t ht ↦ congrArg (· - (UpperHalfPlane.ρ : ℂ)) (heval t ⟨ht.1.le, ht.2.le⟩))
     (congrArg (· - (UpperHalfPlane.ρ : ℂ)) (heval 2 (left_mem_Icc.mpr hab)))
     (congrArg (· - (UpperHalfPlane.ρ : ℂ)) (heval (3 - δL) (right_mem_Icc.mpr hab)))
@@ -205,15 +191,14 @@ private lemma telescope_rho_piece_ceiling (hH : Real.sqrt 3 / 2 < H) :
       Complex.log (fdBoundary H 5 - (UpperHalfPlane.ρ : ℂ)) -
         Complex.log (fdBoundary H 4 - (UpperHalfPlane.ρ : ℂ)) := by
   have heval : ∀ s ∈ Icc (4 : ℝ) 5, fdBoundary H s = fdBoundarySegment5 H s :=
-    fun _ hs ↦ eqOn_fdBoundarySegment5 H hs
-  have hd : deriv (fun s ↦ fdBoundarySegment5 H s - (UpperHalfPlane.ρ : ℂ)) =
-      fun _ ↦ (1 : ℂ) :=
+    eqOn_fdBoundarySegment5 H
+  have hd : deriv (fun s ↦ fdBoundarySegment5 H s - (UpperHalfPlane.ρ : ℂ)) = fun _ ↦ (1 : ℂ) :=
     funext fun s ↦ by rw [deriv_sub_const, deriv_fdBoundarySegment5]
   exact intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_mem_slitPlane_of_le
     (g := fun s ↦ fdBoundary H s - (UpperHalfPlane.ρ : ℂ))
     (h := fun s ↦ fdBoundarySegment5 H s - (UpperHalfPlane.ρ : ℂ)) (by norm_num)
-    (Continuous.continuousOn (Differentiable.continuous fun s ↦
-      ((hasDerivAt_fdBoundarySegment5 H s).differentiableAt.sub_const _)))
+    (Differentiable.continuous fun s ↦
+      (hasDerivAt_fdBoundarySegment5 H s).differentiableAt.sub_const _).continuousOn
     (fun t _ ↦ (hasDerivAt_fdBoundarySegment5 H t).differentiableAt.sub_const _)
     (by rw [hd]; exact continuousOn_const)
     (fun t ht ↦ heval t ht ▸ fdBoundary_sub_rho_mem_slitPlane_of_mem_Icc_four_five hH ht)

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -94,11 +94,8 @@ private lemma telescope_rho_piece_arc_first (H : ℝ) :
           (fdBoundary H t - (UpperHalfPlane.ρ : ℂ)) =
       Complex.log (fdBoundary H 2 - (UpperHalfPlane.ρ : ℂ)) -
         Complex.log (fdBoundary H 1 - (UpperHalfPlane.ρ : ℂ)) := by
-  have heval : ∀ s ∈ Icc (1 : ℝ) 2, fdBoundary H s = fdBoundarySegment2 s := by
-    intro s hs
-    rcases eq_or_lt_of_le hs.1 with h1 | h1
-    · rw [← h1, fdBoundary_apply_one, fdBoundarySegment2_apply_one]
-    · exact fdBoundary_of_le_two h1 hs.2
+  have heval : ∀ s ∈ Icc (1 : ℝ) 2, fdBoundary H s = fdBoundarySegment2 s :=
+    fun _ hs ↦ eqOn_fdBoundarySegment2 H hs
   have hd : deriv (fun s ↦ fdBoundarySegment2 s - (UpperHalfPlane.ρ : ℂ)) = fun s ↦
       (Real.pi / 2 - Real.pi / 3) •
         (circleMap 0 1 (Real.pi / 3 + (s - 1) * (Real.pi / 2 - Real.pi / 3)) * Complex.I) :=
@@ -135,11 +132,9 @@ private lemma telescope_rho_piece_arc_second (H : ℝ) (hδL : 0 < δL) (hδL1 :
       Complex.log (fdBoundary H (3 - δL) - (UpperHalfPlane.ρ : ℂ)) -
         Complex.log (fdBoundary H 2 - (UpperHalfPlane.ρ : ℂ)) := by
   have hab : (2 : ℝ) ≤ 3 - δL := by linarith
-  have heval : ∀ s ∈ Icc (2 : ℝ) (3 - δL), fdBoundary H s = fdBoundarySegment3 s := by
-    intro s hs
-    rcases eq_or_lt_of_le hs.1 with h2 | h2
-    · rw [← h2, fdBoundary_apply_two, fdBoundarySegment3_apply_two]
-    · exact fdBoundary_of_le_three h2 (by linarith [hs.2])
+  -- the excised range sits inside `[2, 3]`, so the segment identification restricts to it
+  have heval : ∀ s ∈ Icc (2 : ℝ) (3 - δL), fdBoundary H s = fdBoundarySegment3 s :=
+    fun _ hs ↦ eqOn_fdBoundarySegment3 H ⟨hs.1, by linarith [hs.2]⟩
   have hd : deriv (fun s ↦ fdBoundarySegment3 s - (UpperHalfPlane.ρ : ℂ)) = fun s ↦
       (2 * Real.pi / 3 - Real.pi / 2) •
         (circleMap 0 1 (Real.pi / 2 + (s - 2) * (2 * Real.pi / 3 - Real.pi / 2)) *
@@ -209,11 +204,8 @@ private lemma telescope_rho_piece_ceiling (hH : Real.sqrt 3 / 2 < H) :
           (fdBoundary H t - (UpperHalfPlane.ρ : ℂ)) =
       Complex.log (fdBoundary H 5 - (UpperHalfPlane.ρ : ℂ)) -
         Complex.log (fdBoundary H 4 - (UpperHalfPlane.ρ : ℂ)) := by
-  have heval : ∀ s ∈ Icc (4 : ℝ) 5, fdBoundary H s = fdBoundarySegment5 H s := by
-    intro s hs
-    rcases eq_or_lt_of_le hs.1 with h4 | h4
-    · rw [← h4, fdBoundary_apply_four, fdBoundarySegment5_apply_four]
-    · exact fdBoundary_of_gt_four h4
+  have heval : ∀ s ∈ Icc (4 : ℝ) 5, fdBoundary H s = fdBoundarySegment5 H s :=
+    fun _ hs ↦ eqOn_fdBoundarySegment5 H hs
   have hd : deriv (fun s ↦ fdBoundarySegment5 H s - (UpperHalfPlane.ρ : ℂ)) =
       fun _ ↦ (1 : ℂ) :=
     funext fun s ↦ by rw [deriv_sub_const, deriv_fdBoundarySegment5]


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"modularforms-rho-telescope-call-existing-lemmas"}-->

Refactor of existing code, so no fresh roadmap target is claimed; `ModularForms` is the
roadmap the touched files serve (the level-one valence formula's fundamental-domain boundary
winding).

### The pattern

`FundamentalDomainBoundary/Basic.lean` has provided `eqOn_fdBoundarySegment1..5` and
`eqOn_fdBoundary_arc` all along. Six sites across the two ρ-corner telescope files re-derived
that identification inline instead — five lines each, character-for-character the body of the
existing lemma, down to the binder name. Each site is now one reference: calls to the
`eqOn_fdBoundarySegment*` family go from **2 to 8**.

One site needed a genuine restriction rather than a plain call. The excised range
`Icc 2 (3 - δL)` is a sub-interval of the segment's `Icc 2 3`, so it goes through the canonical

```lean
(eqOn_fdBoundarySegment3 H).mono (Icc_subset_Icc_right (by linarith))
```

which now states exactly what the comment beside it had been claiming in prose.

A seventh grep hit in `NonCorner/Vertical.lean` is a false positive — that `rcases` sits inside
a `Complex.ext` imaginary-part proof, not a segment identification — and is left alone.

### Cleanup pass

`/cleanup` Mode A ran over each of the six declarations. The recurring find was unrelated to the
reroute and worth naming: five sites hand-built a continuity chain

```lean
Continuous.const_smul (((continuous_circleMap 0 1).comp hθc).mul continuous_const) …
```

re-deriving what `fun_prop` already knows, since `continuous_circleMap` carries
`@[continuity, fun_prop]` upstream. Each collapses to `(by rw [hd]; fun_prop)`, and the `hθc`
helper that existed only to feed it is gone.

The remainder is local: proof-by-contradiction blocks replaced by `ne_of_apply_ne` and
`Eq.trans_ne`, non-terminal `rw`+`simp` pairs merged into terminal `simp`s, single-use `have`s
inlined, and `ne_of_gt (…)` → `(…).ne'`.

**Statements are byte-identical throughout** — only proof bodies and their local scaffolding
moved. The six bodies go 24→18, 29→21, 16→15, 39→27, 39→26 and 26→21 lines. Net **+48 / −110**
across the two files. As a side effect rather than the aim, the two 42-line telescope proofs
that motivated the work now sit at 39, under the decompose threshold.

### Deliberately out of scope

* `((ρ : ℂ) + 1).im = √3/2` is proved by an inline `norm_num [UpperHalfPlane.ρ]` in **four**
  places — once here and three times in `AddOne/Geometry.lean`. One public lemma there would
  replace all four; different file, so it belongs in its own PR.
* Two sibling lemmas outside this PR's declarations (`…_right_vertical`, `…_arc_first`) still
  carry the superseded `hθc` + `Continuous.const_smul` idiom.
* Signature reflow: the per-line width tables show several under-packed signature rows, but all
  ten `telescope_rho_piece_*` / `telescope_rho_add_one_piece_*` lemmas share one layout, and
  repacking six of ten would desynchronise the family. A file-wide formatting pass is the right
  vehicle.

One generalisation was tried and **rejected on the mathematics**: weakening `√3/2 < H` to `≤`
elaborates, but at `H = √3/2` the left vertical degenerates to the point `−1` and the ceiling
lies on the row through `ρ + 1`, in both cases putting the contour on the branch cut. The strict
inequality is load-bearing.

### Verification

`lake build` green (7975 jobs); `lake exe axioms` clean over 47713 declarations;
`lake exe module-system` clean over 2277 modules; `LINT-ENV: PASS — no new violations`.
