### PR TITLE
feat(EDS): the universal normalised EDS is nonzero away from 0

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -99,9 +99,9 @@ lemma evalEval_φ : (W.φ n).evalEval x y = polyEval W x y (curve.φ n) := by
 `Universal.Field` gives a normalised EDS, hence an elliptic sequence — over the universal field,
 with no hypothesis on any coefficient.
 
-This is the form `Universal.lean` needs: it records `universalNormEDS_ne_zero` and
-`universalNormEDS_mem_nonZeroDivisors` as absent because they rest on `normEDS 2 3 2 = id`, which
-requires recognising the universal division polynomials as a `normEDS` in the first place. -/
+The proof recognises the family as a `normEDS` outright, which is what puts the whole `normEDS` API
+— including `NormEDS.lean`'s `universalNormEDS_ne_zero` — within reach of the universal division
+polynomials. -/
 lemma isEllipticSequence_polyToField_ψ :
     IsEllipticSequence fun n : ℤ ↦ polyToField (curve.ψ n) := by
   have h : (fun n : ℤ ↦ polyToField (curve.ψ n))

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
@@ -31,8 +31,9 @@ The nonzerodivisor hypothesis is what the induction consumes. The odd step deriv
 multiplied through by `normEDS b c d k`, and cancelling that factor is the only use of `hk`; the
 even step and both base cases are unconditional. It is removable by specialising from the
 universal parameters, where the sequence is a nonzerodivisor at every index — the route
-`NormEDS.lean` takes for `isEllipticNet_normEDS` — but `universalNormEDS_mem_nonZeroDivisors` is
-not yet available, and `Universal.lean` records what that in turn waits on.
+`NormEDS.lean` takes for `isEllipticNet_normEDS`. That is now available: `universalNormEDS_ne_zero`
+(`NormEDS.lean`) gives the nonvanishing, and `mem_nonZeroDivisors_of_ne_zero` turns it into the
+hypothesis this induction consumes, `ℤ[B, C, D]` being a domain.
 
 The elliptic relation is instantiated once, at `ER((j + 2) * k, 1, (j + 1) * k, 0)`. Its middle
 term is then `W((2 * j + 3) * k) * W k`, the odd step's right-hand side times the factor to be

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -56,6 +56,8 @@ distinction where the identity is proved.
   arguments consume — they specialise at `(2, 3, 2)` in `ℤ`. Only the general form is `@[simp]`:
   tagging both makes `normEDS 2 3 2` rewrite to `Int.cast`, so the `ℤ` left-hand side is no longer
   in normal form and `simpNF` fails the build.
+* `universalNormEDS_ne_zero`, `universalNormEDS_mem_nonZeroDivisors`: the universal sequence
+  vanishes only at `0`, which is what the previous item buys.
 
 The first consumer this unlocks is `IsEllipticNet.invarNum_mul_invarDenom`, which callers can
 apply to `isEllipticNet_normEDS` directly; it is deliberately not restated here as a
@@ -77,12 +79,10 @@ domain is a domain, and then transporting along `aeval`. Every `normEDS b c d` i
 specialisation of `universalNormEDS`, which is what `normEDS_eq_aeval` says, so the hypothesis
 survives only in the private helper, applied once at the indeterminates.
 
-`Universal.lean` records `universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors`
-as belonging with "whichever slice ports" the fact proved here. They are still not ported: they
-rest on `normEDS 2 3 2 = id`, which is `normEDS_two_three_two_eq_id` below. The extensionality
-principle
-that identity needs is `IsEllipticSequence.ext`, which this repository now has, so the obstacle
-recorded for those two is gone; what remains is the work itself.
+`universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors` are here rather than in
+`Universal.lean`, where the definition lives, because they rest on `normEDS 2 3 2 = id` and so on
+`IsEllipticSequence.ext` — both downstream of that file, which this one imports. Stating them
+there would invert the import direction.
 
 ## Provenance
 
@@ -174,3 +174,17 @@ theorem normEDS_two_three_two_eq_intCast (R : Type*) [CommRing R] :
   have h := map_normEDS (f := Int.castRingHom R) (b := (2 : ℤ)) (c := 3) (d := 2) n
   rw [normEDS_two_three_two_eq_id] at h
   simpa using h.symm
+
+/-- **The universal normalised EDS is nonzero away from `0`.** Specialising the three
+indeterminates at `(2, 3, 2)` sends `universalNormEDS n` to `n` itself, by
+`normEDS_two_three_two_eq_id`, so a vanishing value forces a vanishing index. -/
+theorem universalNormEDS_ne_zero {n : ℤ} (hn : n ≠ 0) : universalNormEDS n ≠ 0 := fun h ↦ hn <| by
+  apply_fun aeval (NormEDSParam.rec (2 : ℤ) 3 2) at h
+  simpa using h
+
+/-- **The universal normalised EDS is a nonzerodivisor away from `0`**, `ℤ[B, C, D]` being a
+domain. This is the hypothesis a universal-specialisation argument needs in order to cancel a
+value of the sequence, as opposed to cancelling one of the parameters. -/
+theorem universalNormEDS_mem_nonZeroDivisors {n : ℤ} (hn : n ≠ 0) :
+    universalNormEDS n ∈ (MvPolynomial NormEDSParam ℤ)⁰ :=
+  mem_nonZeroDivisors_of_ne_zero (universalNormEDS_ne_zero hn)

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -20,8 +20,8 @@ Knowing that, one specialisation can be identified outright: `normEDS 2 3 2` is 
 sequence. Its base values are `1, 2, 3, 4`, `id` is an elliptic sequence too, and
 `IsEllipticSequence.ext` makes two elliptic sequences agreeing at `1, 2, 3, 4` equal given that
 the first two values are nonzerodivisors — here `1` and `2` in `ℤ`. `Universal.lean` records this
-identity as what `universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors` rest on,
-and had it down as blocked on that extensionality principle; `Ext.lean` supplies it.
+identity as what `universalNormEDS_ne_zero` rests on, and had it down as blocked on that
+extensionality principle; `Ext.lean` supplies it.
 
 The `ℤ` statement is the one with consumers, but it is not the general one: applying the unique
 ring map out of `ℤ` gives `normEDS (2 : R) 3 2 = Int.cast` over every commutative ring, and both
@@ -56,8 +56,8 @@ distinction where the identity is proved.
   arguments consume — they specialise at `(2, 3, 2)` in `ℤ`. Only the general form is `@[simp]`:
   tagging both makes `normEDS 2 3 2` rewrite to `Int.cast`, so the `ℤ` left-hand side is no longer
   in normal form and `simpNF` fails the build.
-* `universalNormEDS_ne_zero`, `universalNormEDS_mem_nonZeroDivisors`: the universal sequence
-  vanishes only at `0`, which is what the previous item buys.
+* `universalNormEDS_ne_zero`: the universal sequence vanishes only at `0`, which is what the
+  previous item buys.
 
 The first consumer this unlocks is `IsEllipticNet.invarNum_mul_invarDenom`, which callers can
 apply to `isEllipticNet_normEDS` directly; it is deliberately not restated here as a
@@ -79,10 +79,16 @@ domain is a domain, and then transporting along `aeval`. Every `normEDS b c d` i
 specialisation of `universalNormEDS`, which is what `normEDS_eq_aeval` says, so the hypothesis
 survives only in the private helper, applied once at the indeterminates.
 
-`universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors` are here rather than in
-`Universal.lean`, where the definition lives, because they rest on `normEDS 2 3 2 = id` and so on
-`IsEllipticSequence.ext` — both downstream of that file, which this one imports. Stating them
-there would invert the import direction.
+`universalNormEDS_ne_zero` is here rather than in `Universal.lean`, where the definition lives,
+because it rests on `normEDS 2 3 2 = id`, and that identity needs `isEllipticSequence_normEDS` —
+which is proved in *this* file, downstream of `Universal.lean`. Stating the nonvanishing lemma
+beside the definition would invert that direction. `IsEllipticSequence.ext` is a further import the
+identity uses, but it is not what fixes the placement: `Ext.lean` imports neither file.
+
+The companion `mem_nonZeroDivisors` form is deliberately absent. `ℤ[B, C, D]` is a domain, so a
+consumer needing the nonzerodivisor hypothesis writes
+`mem_nonZeroDivisors_of_ne_zero (universalNormEDS_ne_zero hn)`; naming that composition would add a
+second declaration for one Mathlib lemma applied to the one above it.
 
 ## Provenance
 
@@ -110,6 +116,13 @@ The source proves the hypothesis-carrying version from its own descent developme
 is `Descent.lean`'s `IsEllipticNet.of_rel`, fed the two recurrences in relator form, so the helper
 is six lines rather than a file. The universal transport is the source's argument, with
 `normEDS_eq_aeval` in place of its inline rewriting.
+
+`universalNormEDS_ne_zero` adapts the same file's `universalNormEDS_ne_zero` (`:1251`) at the
+roadmap's NagellLutz pin `dev/modular-curves @ 9fec8eba7652`. One departure: the source proves it
+by `simp only [universalNormEDS, …]`, unfolding the definition. That does not port —
+`universalNormEDS`'s body is unexposed across module boundaries — so the proof goes through the
+`@[simp]` equation lemma instead, which is also why it collapses to `simpa`. The source's adjacent
+`universalNormEDS_mem_nonZeroDivisors` (`:1258`) is not ported, for the reason given above.
 -/
 
 public section
@@ -182,9 +195,3 @@ theorem universalNormEDS_ne_zero {n : ℤ} (hn : n ≠ 0) : universalNormEDS n �
   apply_fun aeval (NormEDSParam.rec (2 : ℤ) 3 2) at h
   simpa using h
 
-/-- **The universal normalised EDS is a nonzerodivisor away from `0`**, `ℤ[B, C, D]` being a
-domain. This is the hypothesis a universal-specialisation argument needs in order to cancel a
-value of the sequence, as opposed to cancelling one of the parameters. -/
-theorem universalNormEDS_mem_nonZeroDivisors {n : ℤ} (hn : n ≠ 0) :
-    universalNormEDS n ∈ (MvPolynomial NormEDSParam ℤ)⁰ :=
-  mem_nonZeroDivisors_of_ne_zero (universalNormEDS_ne_zero hn)

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
@@ -86,13 +86,13 @@ complements but not for `preNormEDS`, although Mathlib's `map_preNormEDS` makes 
 one-line proof and consumers reaching for the pre-normalised sequence would otherwise have to
 redo it.
 
-`universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors` are **not** here, and the
-reason is the import direction rather than a gap. They rest on `normEDS 2 3 2 = id`, which is
-`normEDS_two_three_two_eq_id`; that in turn needs `normEDS` to be an elliptic sequence
-(`isEllipticSequence_normEDS`) and an extensionality principle for them
-(`IsEllipticSequence.ext`). Both live downstream of this file — `NormEDS.lean` imports it, not the
-other way round — so the two nonvanishing lemmas are stated in `NormEDS.lean`, beside the identity
-they are one line from.
+`universalNormEDS_ne_zero` is **not** here, and the reason is the import direction rather than a
+gap. It rests on `normEDS 2 3 2 = id`, which is `normEDS_two_three_two_eq_id`; that in turn needs
+`normEDS` to be an elliptic sequence, `isEllipticSequence_normEDS`, which is proved in
+`NormEDS.lean` — downstream of this file, since `NormEDS.lean` imports it and not the other way
+round. So the nonvanishing lemma is stated there, beside the identity it is one line from. (The
+identity also uses `IsEllipticSequence.ext` from `Ext.lean`, but that file imports neither this one
+nor `NormEDS.lean`, so it is not what fixes the direction.)
 -/
 
 public section

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
@@ -86,16 +86,13 @@ complements but not for `preNormEDS`, although Mathlib's `map_preNormEDS` makes 
 one-line proof and consumers reaching for the pre-normalised sequence would otherwise have to
 redo it.
 
-Deliberately **not** ported here: `universalNormEDS_ne_zero` and
-`universalNormEDS_mem_nonZeroDivisors`. They rest on `normEDS 2 3 2 = id`, the source's
-`normEDS_two_three_two`, which needs two things: `normEDS` known to be an elliptic sequence,
-which is now `isEllipticSequence_normEDS` in `NormEDS.lean`, and an extensionality principle for
-elliptic sequences — the source's `IsEllSequence.ext`, that two elliptic sequences agreeing at
-the indices which determine them are equal — which is now `IsEllipticSequence.ext` in `Ext.lean`.
-Both prerequisites are therefore present, and `normEDS 2 3 2 = id` is
-`normEDS_two_three_two_eq_id` in `NormEDS.lean`; these two remain unported but are no longer
-blocked. They belong with whichever slice needs them — as of writing, the general
-`normEDS_mul_complEDS`, whose unconditional form is what they discharge the hypothesis of.
+`universalNormEDS_ne_zero` and `universalNormEDS_mem_nonZeroDivisors` are **not** here, and the
+reason is the import direction rather than a gap. They rest on `normEDS 2 3 2 = id`, which is
+`normEDS_two_three_two_eq_id`; that in turn needs `normEDS` to be an elliptic sequence
+(`isEllipticSequence_normEDS`) and an extensionality principle for them
+(`IsEllipticSequence.ext`). Both live downstream of this file — `NormEDS.lean` imports it, not the
+other way round — so the two nonvanishing lemmas are stated in `NormEDS.lean`, beside the identity
+they are one line from.
 -/
 
 public section


### PR DESCRIPTION
The universal normalised EDS is nonzero away from `0`.

```lean
theorem universalNormEDS_ne_zero {n : ℤ} (hn : n ≠ 0) : universalNormEDS n ≠ 0
```

**The `mem_nonZeroDivisors` companion was dropped on review.** The first version of this PR also
carried `universalNormEDS_mem_nonZeroDivisors`, the source's adjacent declaration. `reuse` pointed
out that it is `mem_nonZeroDivisors_of_ne_zero` applied to the lemma above it, with no call site
anywhere in the repository — a second public name for one Mathlib lemma composed with one local
one. It is gone, and the consumer writes
`mem_nonZeroDivisors_of_ne_zero (universalNormEDS_ne_zero hn)`; `NormEDS.lean`'s implementation
notes record that so the next reader does not re-add it.

## Where this sits

`Universal.lean` has recorded this as deliberately absent since it was written, and named what it
waits on: `normEDS 2 3 2 = id`. That landed in #3364 as `normEDS_two_three_two_eq_id`, so this is
the slice that block was describing.

The proof is the specialisation the identity was for. Sending the three indeterminates to
`(2, 3, 2)` takes `universalNormEDS n` to `n` itself, so a vanishing value forces a vanishing
index; and `ℤ[B, C, D]` is a domain, so nonvanishing is nonzerodivision.

**The onward consumer is the unconditional complement identity.**
`normEDS_mul_complEDS_of_mem_nonZeroDivisors` (#3369, merged) carries a hypothesis that
`normEDS b c d k` is a nonzerodivisor; discharging it over the universal parameters is exactly what
this lemma is for. That in turn is what `invarDenom_eq_redInvarDenom_mul` needs — nine call sites
in the source — and so what `ω` needs. `Complement.lean`'s own note, which said the route was not
yet available, is updated to say it is.

## Placement: not beside the definition, and the reason is the import direction

Both the source and `Universal.lean`'s own docstring read this as belonging with
`universalNormEDS`. It cannot go there. The proof needs `normEDS_two_three_two_eq_id`, which needs
`isEllipticSequence_normEDS` — proved in `NormEDS.lean`, which imports `Universal.lean` rather than
the reverse. Stating the lemma beside the definition inverts that direction, so it sits beside the
identity it is one line from.

**That paragraph named the wrong blocker, and `documentation` was right.** Both files said the
direction was forced by `IsEllipticSequence.ext`. It is not: `Ext.lean` imports `Elementary` and
`Recurrence` and neither `Universal.lean` nor `NormEDS.lean`, so it is orthogonal to the cycle. The
identity does use it — it is just not what fixes the placement. Corrected in both files.

## One thing verified rather than assumed

`universalNormEDS_ne_zero` closes with `simpa using h`, and #3364 moved `@[simp]` from the `ℤ`
identity to the general `normEDS_two_three_two_eq_intCast`. So `simp` now takes
`normEDS (2 : ℤ) 3 2` to `Int.cast` and needs `Int.cast_id` to finish. `Int.cast_id` is `@[simp]`
in Mathlib, so it ought to work — but "ought to" and "did" are different things, and this branch
was rebuilt against **merged** main to check rather than reasoned about. It closes.

## Reuse

Checked in both trees, in TauCeti's vocabulary. Neither statement exists here or upstream:
`universalNormEDS` is this repository's (`Universal.lean`), so neither is expressible in Mathlib,
and nothing in TauCeti asserts nonvanishing of any universal division-polynomial family.

## Gates

`lake build` PASS at 8000 jobs. `lake exe axioms` PASS — 48266 declarations, allowlist only.
`lake exe module-system` PASS — 2295 modules. `scripts/lint-env.sh` PASS, no new violations. One
theorem, a four-line proof; no `sorry`, no `set_option`, no `erw`.

## Provenance

Adapted from D. K. Angdinata's
`projects/NagellLutz/LutzNagell/EllipticDivisibilitySequence.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at `dev/modular-curves @ 9fec8eba7652` — the revision
`TauCetiRoadmap/EllipticCurves/README.md` pins for the NagellLutz project. Declaration
`universalNormEDS_ne_zero` (`:1251`); its neighbour `universalNormEDS_mem_nonZeroDivisors`
(`:1258`) is deliberately not ported, per `reuse` above. That file's header reads `Authors: David
Kurniadi Angdinata`; following this repository's convention for adapted material the upstream
authorship is credited in the module docstring rather than in the copyright header. **This is now
recorded in the code as well as here** — `attribution` and `documentation` both noted that the
module's provenance section named every other adapted declaration but not this one.

One departure. The source proves the first by `simp only [universalNormEDS, …]`, unfolding the
definition. That does not port: `universalNormEDS`'s body is unexposed across module boundaries —
the fifth occurrence of that trap in this campaign — so the proof goes through the `@[simp]`
equation lemma instead, which is also why the whole thing collapses to `simpa`.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md:99` — "**`[n]` is division polynomials**", the
mathlib-track anchor naming `ZSMul.lean`; `ω` is the piece of that anchor this chain unblocks. The
onward consumer is Layer 6's "**The torsion subgroup and Nagell–Lutz**" (`README.md:821`), whose
stated route is division polynomials.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-univ-nonzero"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
