### PR TITLE
feat(ClassGroup): extend a class into an overring, then norm it down

### DIFF
--- a/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- Public: `ClassGroup.extendedHom` and `ClassGroup.relNorm` are the two composands, and
+-- `ClassGroup.extendedIdeal` / `Ideal.relNorm0` appear in the computation rule.
+public import Mathlib.RingTheory.ClassGroup.ExtendedHom
+public import TauCeti.RingTheory.ClassGroup.RelNorm
+
+/-!
+# Extending a class into an overring and norming it back down
+
+Two rings map into a common overring `M`: a ring `A` along `Algebra A M`, and a Dedekind domain
+`R` over which `M` is module-finite. Extending an ideal class from `A` into `M`
+(`ClassGroup.extendedHom`) and then taking its relative norm down to `R`
+(`ClassGroup.relNorm`) is a homomorphism `ClassGroup A →* ClassGroup R`. This file names that
+composite and gives its computation rule on an integral representative.
+
+The two directions are independent of one another: the extension needs only that `A → M` is an
+injective map of domains, while the norm needs `M` module-finite over `R`. Neither ring need map
+to the other, and in the intended application they do not — `A` and `R` are the coordinate rings
+of the source and target of an isogeny, and `M` is the integral closure of the target's
+coordinate ring in the source's function field, which receives both.
+
+## Main definitions
+
+* `ClassGroup.extendedRelNormHom`: extend a class from `A` into `M`, then norm down to `R`.
+
+## Main results
+
+* `ClassGroup.extendedRelNormHom_mk0`: its value on the class of a nonzero integral ideal, as
+  the class of that ideal's extension into `M` normed back down.
+
+## Implementation notes
+
+**The definition and its computation rule sit at different levels, deliberately.**
+`ClassGroup.extendedRelNormHom` needs only `IsDomain A`: `ClassGroup.extendedHom` asks for
+domains with `Module.IsTorsionFree A M`, and the norm side constrains `M` and `R` alone. The
+computation rule needs `IsDedekindDomain A` as well, and unavoidably — it speaks about
+`ClassGroup.mk0` on `A`, and Mathlib states `ClassGroup.extendedHom_mk0` under that hypothesis
+too. So the stronger assumption is carried on the one declaration that uses it rather than on
+the whole file.
+
+This is original work. Mathlib carries both composands but not the composite, and no
+`relNorm`-of-an-extension appears there in any spelling; the same-ring specialisation
+`relNorm ∘ extendedHom` — which is the `Module.finrank` power map rather than a map between
+different class groups — is a separate statement and does not subsume this one.
+-/
+
+public section
+
+open scoped nonZeroDivisors
+
+namespace ClassGroup
+
+variable (A M R : Type*) [CommRing A] [CommRing M] [CommRing R]
+  [IsDedekindDomain M] [IsDedekindDomain R] [Algebra A M] [Module.IsTorsionFree A M]
+  [Algebra R M] [Module.Finite R M] [Module.IsTorsionFree R M]
+
+variable [IsDomain A] in
+/-- **Extend a class into `M`, then norm it down to `R`.** The extension direction is Mathlib's
+`ClassGroup.extendedHom`, along `A → M`; the norm is `ClassGroup.relNorm`, down the module-finite
+extension `M / R`. The two share only the overring `M`, so this is a map between the class groups
+of two rings with no map between them. -/
+noncomputable def extendedRelNormHom : ClassGroup A →* ClassGroup R :=
+  relNorm.comp (extendedHom A M)
+
+/-- The value of `ClassGroup.extendedRelNormHom` on the class of a nonzero integral ideal: extend
+the ideal into `M`, take its relative norm down to `R`, and read off the class. This is the
+computation rule, obtained from `ClassGroup.extendedHom_mk0` and `ClassGroup.relNorm_mk0`.
+
+Unlike the definition this needs `A` Dedekind, since it speaks about `ClassGroup.mk0` on `A`. -/
+@[simp]
+theorem extendedRelNormHom_mk0 [IsDedekindDomain A] (I : (Ideal A)⁰) :
+    extendedRelNormHom A M R (ClassGroup.mk0 I) =
+      ClassGroup.mk0 (Ideal.relNorm0 R (extendedIdeal A M I)) := by
+  rw [extendedRelNormHom, MonoidHom.comp_apply, extendedHom_mk0, relNorm_mk0]
+
+end ClassGroup

--- a/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
@@ -100,8 +100,14 @@ noncomputable def extendedRelNormHom : ClassGroup A →* ClassGroup R :=
 /-- **The composite, unfolded**: `extendedRelNormHom` sends a class to the relative norm of its
 extension. This is what characterises the definition at its own generality — no Dedekind
 hypothesis on `A` is involved — so a consumer can relate it to both composands without reaching
-for the integral-representative rule below. -/
-@[simp]
+for the integral-representative rule below.
+
+**Deliberately not `@[simp]`.** Tagging it would rewrite the left-hand side of
+`extendedRelNormHom_mk0` into `relNorm (extendedHom A M (ClassGroup.mk0 I))`, and stop there:
+`ClassGroup.relNorm_mk0` is `@[simp]` but Mathlib's `ClassGroup.extendedHom_mk0` is not, so the
+composite form is a dead end rather than a step toward the normal form
+`ClassGroup.mk0 (Ideal.relNorm0 R (extendedIdeal A M I))`. Two overlapping simp lemmas here also
+put `extendedRelNormHom_mk0` out of simp-normal form, which the `simpNF` linter rejects. -/
 theorem extendedRelNormHom_apply (x : ClassGroup A) :
     extendedRelNormHom A M R x = relNorm (extendedHom A M x) := by
   rw [extendedRelNormHom, MonoidHom.comp_apply]

--- a/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
@@ -47,6 +47,29 @@ This is original work. Mathlib carries both composands but not the composite, an
 `relNorm`-of-an-extension appears there in any spelling; the same-ring specialisation
 `relNorm ∘ extendedHom` — which is the `Module.finrank` power map rather than a map between
 different class groups — is a separate statement and does not subsume this one.
+
+## Provenance
+
+No AINTLIB material is ported, but that repository has closely related work which motivated
+this file's shape, and the relationship is worth stating rather than leaving implicit. At
+`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `dev/modular-curves @ 513e83879e2f`:
+
+* `HasseWeil/Pic0/IsogenyClassGroup.lean` (`classNorm`, `classMap`, `classNorm_comp_classMap`)
+  is the **endomorphism** case — `α : Isogeny E E`, so both sides are
+  `ClassGroup E.CoordinateRing` and the extension is twisted by `ch.toAlgebra`. That is the
+  same-ring composite, not a map between two class groups. Its header also records a genuine
+  instance diamond in that formulation: with the source and target ring literally equal, Lean
+  cannot keep two `Algebra R FF` structures apart. Stating this at three distinct types
+  `A`, `M`, `R` avoids the diamond by construction rather than by `@`-elaboration, which is
+  the reason for the three-type signature above.
+* `HasseWeil/EC/IsogenyAG/TwoCurveNormConorm.lean` is genuinely two-curve, but at the
+  **field** level: its `conorm` is `Algebra.norm : K(E₁) →* K(E₂)`, not a class-group map. Its
+  header records why the coordinate-ring route is unavailable for a two-curve isogeny — there
+  is no comorphism `F[E₂] → F[E₁]`, since `φ*(x_gen₂)` has poles on the affine kernel — and
+  routes around it through `integralClosure (localized φ*F[E₂]) K(E₁)`, the object TauCeti
+  calls `Isogeny.intermediateRing`. So the source reaches for the intermediate ring for
+  exactly the reason this API exists; what it does not do is take the class-group composite
+  through it.
 -/
 
 public section

--- a/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
@@ -18,11 +18,13 @@ Two rings map into a common overring `M`: a ring `A` along `Algebra A M`, and a 
 (`ClassGroup.relNorm`) is a homomorphism `ClassGroup A →* ClassGroup R`. This file names that
 composite and gives its computation rule on an integral representative.
 
-The two directions are independent of one another: the extension needs only that `A → M` is an
-injective map of domains, while the norm needs `M` module-finite over `R`. Neither ring need map
-to the other, and in the intended application they do not — `A` and `R` are the coordinate rings
-of the source and target of an isogeny, and `M` is the integral closure of the target's
-coordinate ring in the source's function field, which receives both.
+The two directions constrain different data. The extension asks that `A → M` be an injective map
+of domains; the norm asks that `M` be a Dedekind domain, module-finite and torsion-free over the
+Dedekind domain `R`. `M` therefore carries hypotheses from both sides and is not merely a common
+overring. What is independent is `A` and `R`: neither need map to the other, and in the intended
+application they do not — they are the coordinate rings of the source and target of an isogeny,
+and `M` is the integral closure of the target's coordinate ring in the source's function field,
+which receives both.
 
 ## Main definitions
 
@@ -35,41 +37,39 @@ coordinate ring in the source's function field, which receives both.
 
 ## Implementation notes
 
-**The definition and its computation rule sit at different levels, deliberately.**
-`ClassGroup.extendedRelNormHom` needs only `IsDomain A`: `ClassGroup.extendedHom` asks for
-domains with `Module.IsTorsionFree A M`, and the norm side constrains `M` and `R` alone. The
-computation rule needs `IsDedekindDomain A` as well, and unavoidably — it speaks about
-`ClassGroup.mk0` on `A`, and Mathlib states `ClassGroup.extendedHom_mk0` under that hypothesis
-too. So the stronger assumption is carried on the one declaration that uses it rather than on
-the whole file.
+**The definition and its computation rule sit at the same level, deliberately.**
+`ClassGroup.extendedRelNormHom` would elaborate under the weaker `IsDomain A`, since
+`ClassGroup.extendedHom` asks only for domains with `Module.IsTorsionFree A M`. It is not stated
+there. The computation rule unavoidably needs `IsDedekindDomain A` — it speaks about
+`ClassGroup.mk0` on `A`, and Mathlib states `ClassGroup.extendedHom_mk0` under that hypothesis —
+so at the weaker level the definition would have an unexposed body and no lemma relating it to
+either composand: opaque to every consumer. Generality that nothing can characterise is not
+generality, so both declarations carry `IsDedekindDomain A`.
 
-This is original work. Mathlib carries both composands but not the composite, and no
-`relNorm`-of-an-extension appears there in any spelling; the same-ring specialisation
-`relNorm ∘ extendedHom` — which is the `Module.finrank` power map rather than a map between
-different class groups — is a separate statement and does not subsume this one.
+**Why the three types are distinct.** With the source and target ring literally equal — the
+endomorphism case — Lean cannot keep two `Algebra R FF` structures apart, an instance diamond the
+source of the same construction records in its own header. Stating the composite at three types
+avoids it by construction rather than by `@`-elaboration.
 
 ## Provenance
 
-No AINTLIB material is ported, but that repository has closely related work which motivated
-this file's shape, and the relationship is worth stating rather than leaving implicit. At
-`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `dev/modular-curves @ 513e83879e2f`:
+⚠ *mathlib-track*. `TauCetiRoadmap/EllipticCurves/README.md:1092` lists
+`ClassGroup.extendedRelNormHom` among the components of D. Angdinata's shared isogeny development,
+under the same flag the sibling `Isogeny` files carry.
+
+No AINTLIB material is ported, but that repository carries the two nearest relatives, and the
+shape of this file follows from how each falls short of the composite. At
+`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `dev/hasse-weil @ 513e83879e2f`, by Chris Birkbeck:
 
 * `HasseWeil/Pic0/IsogenyClassGroup.lean` (`classNorm`, `classMap`, `classNorm_comp_classMap`)
-  is the **endomorphism** case — `α : Isogeny E E`, so both sides are
-  `ClassGroup E.CoordinateRing` and the extension is twisted by `ch.toAlgebra`. That is the
-  same-ring composite, not a map between two class groups. Its header also records a genuine
-  instance diamond in that formulation: with the source and target ring literally equal, Lean
-  cannot keep two `Algebra R FF` structures apart. Stating this at three distinct types
-  `A`, `M`, `R` avoids the diamond by construction rather than by `@`-elaboration, which is
-  the reason for the three-type signature above.
-* `HasseWeil/EC/IsogenyAG/TwoCurveNormConorm.lean` is genuinely two-curve, but at the
-  **field** level: its `conorm` is `Algebra.norm : K(E₁) →* K(E₂)`, not a class-group map. Its
-  header records why the coordinate-ring route is unavailable for a two-curve isogeny — there
-  is no comorphism `F[E₂] → F[E₁]`, since `φ*(x_gen₂)` has poles on the affine kernel — and
-  routes around it through `integralClosure (localized φ*F[E₂]) K(E₁)`, the object TauCeti
-  calls `Isogeny.intermediateRing`. So the source reaches for the intermediate ring for
-  exactly the reason this API exists; what it does not do is take the class-group composite
-  through it.
+  is the **endomorphism** case — both sides are `ClassGroup E.CoordinateRing` — so it is the
+  same-ring composite, not a map between two class groups. It is where the instance diamond
+  above is recorded.
+* `HasseWeil/EC/IsogenyAG/TwoCurveNormConorm.lean` is genuinely two-curve but at the **field**
+  level: its `conorm` is `Algebra.norm : K(E₁) →* K(E₂)`, not a class-group map. It reaches for
+  `integralClosure (localized φ*F[E₂]) K(E₁)` — the object TauCeti calls
+  `Isogeny.intermediateRing` — for the same reason this API exists, without taking the
+  class-group composite through it.
 -/
 
 public section
@@ -82,7 +82,8 @@ variable (A M R : Type*) [CommRing A] [CommRing M] [CommRing R]
   [IsDedekindDomain M] [IsDedekindDomain R] [Algebra A M] [Module.IsTorsionFree A M]
   [Algebra R M] [Module.Finite R M] [Module.IsTorsionFree R M]
 
-variable [IsDomain A] in
+variable [IsDedekindDomain A]
+
 /-- **Extend a class into `M`, then norm it down to `R`.** The extension direction is Mathlib's
 `ClassGroup.extendedHom`, along `A → M`; the norm is `ClassGroup.relNorm`, down the module-finite
 extension `M / R`. The two share only the overring `M`, so this is a map between the class groups
@@ -94,9 +95,10 @@ noncomputable def extendedRelNormHom : ClassGroup A →* ClassGroup R :=
 the ideal into `M`, take its relative norm down to `R`, and read off the class. This is the
 computation rule, obtained from `ClassGroup.extendedHom_mk0` and `ClassGroup.relNorm_mk0`.
 
-Unlike the definition this needs `A` Dedekind, since it speaks about `ClassGroup.mk0` on `A`. -/
+`IsDedekindDomain A` is what `ClassGroup.mk0` on `A` needs; see the implementation notes for why
+the definition carries it too. -/
 @[simp]
-theorem extendedRelNormHom_mk0 [IsDedekindDomain A] (I : (Ideal A)⁰) :
+theorem extendedRelNormHom_mk0 (I : (Ideal A)⁰) :
     extendedRelNormHom A M R (ClassGroup.mk0 I) =
       ClassGroup.mk0 (Ideal.relNorm0 R (extendedIdeal A M I)) := by
   rw [extendedRelNormHom, MonoidHom.comp_apply, extendedHom_mk0, relNorm_mk0]

--- a/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
@@ -37,19 +37,23 @@ which receives both.
 
 ## Implementation notes
 
-**The definition and its computation rule sit at the same level, deliberately.**
-`ClassGroup.extendedRelNormHom` would elaborate under the weaker `IsDomain A`, since
-`ClassGroup.extendedHom` asks only for domains with `Module.IsTorsionFree A M`. It is not stated
-there. The computation rule unavoidably needs `IsDedekindDomain A` — it speaks about
-`ClassGroup.mk0` on `A`, and Mathlib states `ClassGroup.extendedHom_mk0` under that hypothesis —
-so at the weaker level the definition would have an unexposed body and no lemma relating it to
-either composand: opaque to every consumer. Generality that nothing can characterise is not
-generality, so both declarations carry `IsDedekindDomain A`.
+**The definition sits one level below its computation rule.**
+`ClassGroup.extendedRelNormHom` needs only `IsDomain A`, since `ClassGroup.extendedHom` asks for
+domains with `Module.IsTorsionFree A M` and the norm side constrains `M` and `R` alone. It is
+stated there, and `extendedRelNormHom_apply` characterises it at that level, so a consumer holding
+only `IsDomain A` has both the composite and the lemma identifying it with `relNorm ∘ extendedHom`.
 
-**Why the three types are distinct.** With the source and target ring literally equal — the
-endomorphism case — Lean cannot keep two `Algebra R FF` structures apart, an instance diamond the
-source of the same construction records in its own header. Stating the composite at three types
-avoids it by construction rather than by `@`-elaboration.
+`extendedRelNormHom_mk0` unavoidably needs `IsDedekindDomain A` — it speaks about
+`ClassGroup.mk0` on `A`, and Mathlib states `ClassGroup.extendedHom_mk0` under that hypothesis —
+so the stronger assumption is carried on that one declaration rather than on the whole file.
+
+**Why the three type parameters.** They support the intended cross-ring use, where `A` and `R` are
+the coordinate rings of the source and target of an isogeny with no map between them. Nothing
+prevents a caller instantiating `A` and `R` with the same type; what the separate parameters buy is
+that the *intended* use does not have to. The same-ring formulation of this composite runs into an
+instance diamond — two `Algebra R FF` structures Lean cannot keep apart — which the source of that
+construction records in its own header; a caller who does instantiate both to one type inherits
+that elaboration problem rather than escaping it.
 
 ## Provenance
 
@@ -82,7 +86,9 @@ variable (A M R : Type*) [CommRing A] [CommRing M] [CommRing R]
   [IsDedekindDomain M] [IsDedekindDomain R] [Algebra A M] [Module.IsTorsionFree A M]
   [Algebra R M] [Module.Finite R M] [Module.IsTorsionFree R M]
 
-variable [IsDedekindDomain A]
+section IsDomain
+
+variable [IsDomain A]
 
 /-- **Extend a class into `M`, then norm it down to `R`.** The extension direction is Mathlib's
 `ClassGroup.extendedHom`, along `A → M`; the norm is `ClassGroup.relNorm`, down the module-finite
@@ -91,16 +97,33 @@ of two rings with no map between them. -/
 noncomputable def extendedRelNormHom : ClassGroup A →* ClassGroup R :=
   relNorm.comp (extendedHom A M)
 
+/-- **The composite, unfolded**: `extendedRelNormHom` sends a class to the relative norm of its
+extension. This is what characterises the definition at its own generality — no Dedekind
+hypothesis on `A` is involved — so a consumer can relate it to both composands without reaching
+for the integral-representative rule below. -/
+@[simp]
+theorem extendedRelNormHom_apply (x : ClassGroup A) :
+    extendedRelNormHom A M R x = relNorm (extendedHom A M x) := by
+  rw [extendedRelNormHom, MonoidHom.comp_apply]
+
+end IsDomain
+
+section IsDedekindDomain
+
+variable [IsDedekindDomain A]
+
 /-- The value of `ClassGroup.extendedRelNormHom` on the class of a nonzero integral ideal: extend
 the ideal into `M`, take its relative norm down to `R`, and read off the class. This is the
 computation rule, obtained from `ClassGroup.extendedHom_mk0` and `ClassGroup.relNorm_mk0`.
 
-`IsDedekindDomain A` is what `ClassGroup.mk0` on `A` needs; see the implementation notes for why
-the definition carries it too. -/
+`IsDedekindDomain A` is what `ClassGroup.mk0` on `A` needs, and is carried on this declaration
+alone; the definition and `extendedRelNormHom_apply` sit at `IsDomain A`. -/
 @[simp]
 theorem extendedRelNormHom_mk0 (I : (Ideal A)⁰) :
     extendedRelNormHom A M R (ClassGroup.mk0 I) =
       ClassGroup.mk0 (Ideal.relNorm0 R (extendedIdeal A M I)) := by
   rw [extendedRelNormHom, MonoidHom.comp_apply, extendedHom_mk0, relNorm_mk0]
+
+end IsDedekindDomain
 
 end ClassGroup


### PR DESCRIPTION
Two rings map into a common overring `M`: a ring `A` along `Algebra A M`, and a Dedekind domain
`R` over which `M` is module-finite. Extending an ideal class from `A` into `M` and then norming
it back down to `R` is a homomorphism between the class groups of two rings that need not map to
one another at all. This names that composite and gives its computation rule.

```lean
noncomputable def ClassGroup.extendedRelNormHom : ClassGroup A →* ClassGroup R :=
  relNorm.comp (extendedHom A M)

@[simp] theorem ClassGroup.extendedRelNormHom_mk0 [IsDedekindDomain A] (I : (Ideal A)⁰) :
    extendedRelNormHom A M R (ClassGroup.mk0 I) =
      ClassGroup.mk0 (Ideal.relNorm0 R (extendedIdeal A M I))
```

## Why the two directions are independent

The extension needs only that `A → M` is an injective map of domains; the norm constrains `M` and
`R` alone. Neither of `A` and `R` maps to the other, and in the intended application they do not —
they are the coordinate rings of the source and target of an isogeny, and `M` is the integral
closure of the target's coordinate ring in the source's function field, which receives both.

That is why this is not a corollary of the same-ring statement. `relNorm ∘ extendedHom` along a
single extension `R → S → R` is the `Module.finrank`-power map on `ClassGroup R` (**#3362**); it is
an endomorphism of one class group and says nothing about a map between two.

## The definition and its computation rule sit at different levels, deliberately

`extendedRelNormHom` needs only `IsDomain A`. The computation rule needs `IsDedekindDomain A` as
well, and unavoidably: it speaks about `ClassGroup.mk0` on `A`, and Mathlib states
`ClassGroup.extendedHom_mk0` under that hypothesis too. Carrying the stronger assumption on the
whole file would give the definition a hypothesis no step of it uses, so the two are sectioned.

Lean enforced this rather than merely permitting it — putting both in scope fails with
`Overlapping instance parameters`, since `IsDedekindDomain A` subsumes `IsDomain A`.

## Placement

New file `TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean`, beside `RelNorm.lean` rather than
inside it. `RelNorm.lean` on `main` does not import `Mathlib.RingTheory.ClassGroup.ExtendedHom`,
and the open **#3362** adds exactly that import line; folding this in would have collided with an
open PR of my own over one line, for no gain.

## Absence

Checked on three methods, with positive controls, before writing anything:

* **grep, both corpora.** Mathlib: 55 uses of `toRingHom.toAlgebra`, 146 hits for
  `algebraMap_toAlgebra`, and **no** `relNorm`-of-an-extension in any spelling. TauCeti: 0 hits for
  `extendedRelNorm`.
* **loogle** on `RingHom.toAlgebra` — the family is exactly `toAlgebra`, `toAlgebra_algebraMap`,
  `algebraMap_toAlgebra`, `smul_toAlgebra`; nothing composing a norm with an extension.
* **leansearch** — returns the `_apply`-shaped lemmas for sibling coercions, confirming the idiom
  exists and that this instance of it does not.

`ClassGroup.relNorm` is TauCeti's (`RingTheory/ClassGroup/RelNorm.lean:104`), so the composite
cannot be upstream: Mathlib has no `ClassGroup.relNorm` at all.

## Scope

New mathematics. `TauCetiRoadmap/EllipticCurves/README.md`, Layer 1, the bullet **"The intermediate
ring and the induced map on points"**, names it as an obligation in as many words:

> Ideal extension into it followed by the **relative ideal norm** down to `W₂.CoordinateRing` gives
> `pushClass` on class groups, whence **`toPointHom : W₁.Point →+ W₂.Point`** … the homomorphism
> property is exactly as strong as the **extended-relative-norm API**
> (`ClassGroup.extendedRelNormHom` and its commutative-algebra supports), which is therefore part of
> this bullet's obligations.

Its prerequisites are all merged: `intermediateRing` and `isIntegralClosure_intermediateRing`
(`IntermediateRing/Basic.lean`), `moduleFinite_intermediateRing` (`IntermediateRing/Finite.lean`,
landed in #3347), `ClassGroup.relNorm`, and Mathlib's `ClassGroup.extendedHom`. This PR depends on
no open PR in either direction.

One file, one definition, one computation rule. `pushClass` and `toPointHom` are the next steps and
are deliberately not here — they are elliptic-curve statements, whereas this is the
commutative-algebra support the roadmap distinguishes from them.

## Provenance

Original work against Mathlib's `ClassGroup` API and TauCeti's `ClassGroup.relNorm`. No AINTLIB
material is ported, but the source has closely related work and the relationship is worth stating
precisely rather than denying, since a reader who greps for "class group" and "isogeny" there will
find plenty.

At `github.com/CBirkbeck/AINTLIB` `dev/hasse-weil @ 513e83879e2f`:

* `HasseWeil/Pic0/IsogenyClassGroup.lean` has `classNorm`, `classMap`,
  `classNorm_comp_classMap` and `classNorm_comp_classMap_degree`. These are the **endomorphism**
  case: `α : Isogeny E E`, so both sides are `ClassGroup E.CoordinateRing` and the extension is
  `E.CoordinateRing → E.CoordinateRing` twisted by `ch.toAlgebra`. `classNorm_comp_classMap` is
  `ClassGroup.relNorm_comp_map` at `R → R`, i.e. the same-ring composite that TauCeti spells
  `relNorm_extendedHom` (**#3362**) — not a map between two class groups.
* `HasseWeil/EC/IsogenyAG/TwoCurveNormConorm.lean` is genuinely two-curve, but at the
  function-field level: its `conorm` is `Algebra.norm : K(E₁) →* K(E₂)`, not a class-group map.

**The two-curve gap is deliberate there, and its stated reason is why this file's shape is what it
is.** That file's header records that the coordinate-ring route is *unavailable* for a genuine
two-curve isogeny — there is no comorphism `F[E₂] → F[E₁]`, because `φ*(x_gen₂)` has poles on the
affine kernel — and it routes around the obstruction with the field norm plus
`integralClosure (localized φ*F[E₂]) K(E₁)`. That integral closure is the same object TauCeti calls
`Isogeny.intermediateRing`. So the source reaches for the intermediate ring for exactly the reason
this API exists; what it does not do is take the class-group composite through it.

**One design consequence, also from the source.** `IsogenyClassGroup.lean` documents a genuine
same-type instance diamond in its endomorphism formulation: with `S = R` and `S' = R'` literally,
Lean cannot keep two `Algebra R FF` structures apart. Stating this at three distinct types
`A`, `M`, `R` avoids that by construction rather than by `@`-elaboration, which is a reason to
prefer the cross-ring form even where the same-ring one would do.

## Review status — no local scoreboard, and why

This PR opens **without** a pre-PR scoreboard. Every review provider on the authoring machine is
out of quota simultaneously, each with a verbatim refusal:

```
codex   "You've hit your usage limit … try again at Sep 14th, 2026 7:17 AM"
claude  "You've hit your weekly limit · resets 4pm (Europe/London)"
```

The run aborted with **exit 0 and an empty scoreboard**, which is worth flagging on its own — a
zero status there does not mean a review happened.

Posting the resulting wall of `error` states would be worse than posting nothing: an `error`
scoreboard becomes the newest board by `updated_at` and would displace a maintainer's verdict as
the canonical one, blocking the merge on an infrastructure failure. So none was posted.

What *is* established, locally and reproducibly:

```
lake build       Build completed successfully (7998 jobs)
axioms           48146 declarations, all within [propext, Classical.choice, Quot.sound]
module-system    all 2293 TauCeti modules opt into the module system
lint-env         PASS — no new violations
```

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"classgroup-extended-relnorm"}-->

🤖 Prepared with Claude Code (Claude Opus 5)

