### PR TITLE
feat(Isogeny): the intermediate ring is integrally closed

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/IntegrallyClosed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/IntegrallyClosed.lean
@@ -29,21 +29,25 @@ isogenies, Frobenius included, and does not inherit the separability hypothesis 
 
 ## Design
 
-The hypotheses are those needed to *name* the integral closure, not to prove it normal. `h` fixes
-the `W₂.CoordinateRing`-algebra structure on `W₁.FunctionField` as the pullback, which is what
-`Isogeny.isIntegralClosure_intermediateRing` needs; the algebra structure on `φ.intermediateRing`
-and its scalar tower are what let integrality transit through it. A consumer builds both from the
-bundled `φ.pullbackToIntermediateRing` — `letI := φ.pullbackToIntermediateRing.toAlgebra` — together
-with `Isogeny.isScalarTower_intermediateRing`, exactly as for the finiteness result.
+**The statement takes the isogeny and nothing else.** Its conclusion mentions only
+`φ.intermediateRing`, so an `Algebra` argument, a scalar tower or a hypothesis pinning a structure
+map would all be proof infrastructure escaping into the API: every consumer would have to rebuild
+them to use a fact that does not depend on them. The structures the proof does need are the
+canonical ones — the pullback acting on `W₁.FunctionField`, and its corestriction
+`Isogeny.pullbackToIntermediateRing` acting on the intermediate ring — so the proof installs them
+itself.
 
-**Why not hypothesis-free.** The statement itself mentions no algebra structure, and mathematically
-it needs none: `intermediateRing` builds its own internally, and Mathlib's
-`IsIntegrallyClosedIn (integralClosure R A).toSubring A` is an unconditional instance. That instance
-cannot be used here, because `intermediateRing`'s body is not exposed across the module boundary —
-`Basic.lean` says so and offers `mem_intermediateRing_iff` as the escape hatch — so synthesis cannot
-see the two objects coincide. Every route from this module to the integral-closure property runs
-through `Isogeny.isIntegralClosure_intermediateRing`, which takes `h`. Removing the remaining
-hypotheses is therefore a change to `Basic.lean`'s exposed surface, not to this file.
+They stay local rather than becoming global instances: `IntermediateRing/Basic.lean` records that
+registering the pullback-induced structure would reintroduce the very diamond the `Subring` choice
+avoids, since one curve can receive several pullbacks. A `letI` inside a proof is the scoped use
+that design leaves open.
+
+**Why the sibling still takes them.** `Isogeny.moduleFinite_intermediateRing` concludes
+`Module.Finite W₂.CoordinateRing φ.intermediateRing` — its statement names the base and is therefore
+*relative to* a `W₂.CoordinateRing`-algebra structure, which the caller must supply and which the
+statement must let the caller choose. Being integrally closed is an absolute property of a single
+ring, so nothing is left for a caller to fix. The difference is in what the two statements say, not
+a difference of convention between the two files.
 
 ## Provenance
 
@@ -60,8 +64,9 @@ through the corestricted pullback, and the statement of normality on its own rat
 by-product of the Dedekind instance — which is what lets it hold without the finiteness that
 instance carries.
 
-The proof route — transitivity of integrality, then
-`IsIntegrallyClosed.of_isIntegrallyClosedIn` — is assembled from Mathlib and is not the source's.
+The proof route is assembled from Mathlib: `IsIntegrallyClosedIn.of_isIntegralClosure` for the
+closure being closed in the ambient field, then `IsIntegrallyClosed.of_isIntegrallyClosedIn` to
+read that as an absolute property over a field. Neither step is the source's.
 -/
 
 public section
@@ -76,24 +81,23 @@ variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
 `W₂.CoordinateRing` in `W₁.FunctionField`, and an integral closure is integrally closed in the
 ambient ring by transitivity of integrality; over a field that upgrades to `IsIntegrallyClosed`.
 
-No finiteness and no separability: unlike the sibling `Isogeny.moduleFinite_intermediateRing` this
-covers inseparable isogenies, Frobenius included. -/
-theorem isIntegrallyClosed_intermediateRing (φ : Isogeny W₁ W₂)
-    [Algebra W₂.CoordinateRing W₁.FunctionField]
-    [Algebra W₂.CoordinateRing φ.intermediateRing]
-    [IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField]
-    (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
+No hypotheses beyond the isogeny: the algebra structures the proof runs through are the canonical
+pullback ones, installed locally rather than asked of the caller.
+
+No finiteness and no separability either: unlike the sibling `Isogeny.moduleFinite_intermediateRing`
+this covers inseparable isogenies, Frobenius included. -/
+theorem isIntegrallyClosed_intermediateRing (φ : Isogeny W₁ W₂) :
     IsIntegrallyClosed φ.intermediateRing := by
+  let _ := φ.pullback.toRingHom.toAlgebra
+  let _ := φ.pullbackToIntermediateRing.toAlgebra
+  have hpb : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x := fun x ↦ by
+    rw [RingHom.algebraMap_toAlgebra, AlgHom.toRingHom_eq_coe, AlgHom.coe_toRingHom]
+  have : IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField :=
+    φ.isScalarTower_intermediateRing rfl hpb
   -- the integral-closure property is not assumed: it is what `intermediateRing` is
-  have := φ.isIntegralClosure_intermediateRing h
-  have : Algebra.IsIntegral W₂.CoordinateRing φ.intermediateRing :=
-    IsIntegralClosure.isIntegral_algebra W₂.CoordinateRing W₁.FunctionField
-  have : IsIntegrallyClosedIn φ.intermediateRing W₁.FunctionField := by
-    rw [isIntegrallyClosedIn_iff]
-    refine ⟨FaithfulSMul.algebraMap_injective _ _, fun {x} hx ↦ ?_⟩
-    -- `x` is integral over the closure, hence over `W₂.CoordinateRing`, hence already in it
-    exact (IsIntegralClosure.isIntegral_iff (A := φ.intermediateRing)).mp
-      (isIntegral_trans (R := W₂.CoordinateRing) x hx)
+  have := φ.isIntegralClosure_intermediateRing hpb
+  have : IsIntegrallyClosedIn φ.intermediateRing W₁.FunctionField :=
+    IsIntegrallyClosedIn.of_isIntegralClosure W₂.CoordinateRing
   exact IsIntegrallyClosed.of_isIntegrallyClosedIn _ W₁.FunctionField
 
 end Isogeny

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/IntegrallyClosed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/IntegrallyClosed.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
+public import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
+
+/-!
+# The intermediate ring is integrally closed
+
+For an isogeny `φ : Isogeny W₁ W₂`, the intermediate ring — the integral closure of
+`W₂.CoordinateRing` in `W₁.FunctionField` — is itself integrally closed. Together with
+module-finiteness (`Isogeny.moduleFinite_intermediateRing`) this is the normality half of what the
+relative ideal norm needs, and through it `pushClass` and the induced map on points.
+
+**This costs strictly less than the finiteness half.** `Isogeny.moduleFinite_intermediateRing`
+carries `[Algebra.IsSeparable W₂.FunctionField W₁.FunctionField]` because its only upstream route,
+`IsIntegralClosure.finite`, argues through the trace pairing. Nothing here does: an integral closure
+inside a finite field extension is integrally closed for the formal reason that integral closure is
+idempotent. So this statement holds for **inseparable** isogenies too, Frobenius included, and does
+not inherit the sibling's limitation.
+
+## Main results
+
+* `TauCeti.Isogeny.isIntegrallyClosed_intermediateRing`: `φ.intermediateRing` is integrally closed.
+
+## Design
+
+The hypotheses mirror `Isogeny.moduleFinite_intermediateRing` — arbitrary algebra structures whose
+structure maps are the pullback, rather than one fixed choice, since registering such a structure
+globally would be a diamond. A consumer builds them from the bundled `φ.pullbackToIntermediateRing`
+(`letI := φ.pullbackToIntermediateRing.toAlgebra`) together with
+`Isogeny.isScalarTower_intermediateRing`, exactly as for the finiteness result.
+
+Two hypotheses of the sibling are **absent** rather than merely unused, and the difference is the
+point of this file: `[Algebra.IsSeparable W₂.FunctionField W₁.FunctionField]` and
+`[IsIntegrallyClosed W₂.CoordinateRing]`. Integral closedness of the base is not needed because the
+conclusion is about the closure, not about the base:
+`integralClosure.isIntegrallyClosedOfFiniteExtension` asks only that the base be a domain with
+`W₂.FunctionField` as its fraction field.
+
+## Provenance
+
+Original work against Mathlib's `integralClosure.isIntegrallyClosedOfFiniteExtension` and this
+repository's `Isogeny.isIntegralClosure_intermediateRing`. The transfer from Mathlib's literal
+`integralClosure` subalgebra to `φ.intermediateRing` goes through `IsIntegralClosure.equiv`, the
+standard way two integral closures of the same base in the same field are identified.
+
+AINTLIB's `HasseWeil/Curves/RamificationFinite.lean` (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
+`dev/hasse-weil @ 513e83879e2f`) — the source of the sibling `moduleFinite_intermediateRing` —
+proves the finiteness half only; it *assumes* normality of the closure where it needs it rather
+than deriving it, so this statement is not a port of anything there.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Isogeny
+
+variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
+
+/-- **The intermediate ring is integrally closed.** It is the integral closure of
+`W₂.CoordinateRing` in `W₁.FunctionField`, and an integral closure inside a finite extension of the
+base's fraction field is integrally closed.
+
+Unlike the sibling `Isogeny.moduleFinite_intermediateRing`, this needs neither separability of the
+function-field extension nor integral closedness of `W₂.CoordinateRing` — see the module
+docstring. -/
+theorem isIntegrallyClosed_intermediateRing (φ : Isogeny W₁ W₂)
+    [Algebra W₂.CoordinateRing W₁.FunctionField]
+    [Algebra W₂.FunctionField W₁.FunctionField]
+    [IsScalarTower W₂.CoordinateRing W₂.FunctionField W₁.FunctionField]
+    [Algebra W₂.CoordinateRing φ.intermediateRing]
+    [IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField]
+    (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
+    IsIntegrallyClosed φ.intermediateRing := by
+  -- the integral-closure property is not assumed: it is what `intermediateRing` is
+  have := φ.isIntegralClosure_intermediateRing h
+  have := φ.finiteDimensional_functionField (φ.algebraMap_functionField_eq_fieldPullback h)
+  have hclosure : IsIntegrallyClosed (integralClosure W₂.CoordinateRing W₁.FunctionField) :=
+    integralClosure.isIntegrallyClosedOfFiniteExtension W₂.FunctionField
+  exact IsIntegrallyClosed.of_equiv
+    (IsIntegralClosure.equiv W₂.CoordinateRing
+      (integralClosure W₂.CoordinateRing W₁.FunctionField) W₁.FunctionField
+      φ.intermediateRing).toRingEquiv
+
+end Isogeny
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/IntegrallyClosed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/IntegrallyClosed.lean
@@ -5,23 +5,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Basic
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
 public import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
 
 /-!
 # The intermediate ring is integrally closed
 
 For an isogeny `φ : Isogeny W₁ W₂`, the intermediate ring — the integral closure of
-`W₂.CoordinateRing` in `W₁.FunctionField` — is itself integrally closed. Together with
-module-finiteness (`Isogeny.moduleFinite_intermediateRing`) this is the normality half of what the
-relative ideal norm needs, and through it `pushClass` and the induced map on points.
+`W₂.CoordinateRing` in `W₁.FunctionField` — is itself integrally closed. With
+`Isogeny.moduleFinite_intermediateRing` this is the normality half of what the relative ideal norm
+needs, and through it `pushClass` and the induced map on points.
 
-**This costs strictly less than the finiteness half.** `Isogeny.moduleFinite_intermediateRing`
-carries `[Algebra.IsSeparable W₂.FunctionField W₁.FunctionField]` because its only upstream route,
-`IsIntegralClosure.finite`, argues through the trace pairing. Nothing here does: an integral closure
-inside a finite field extension is integrally closed for the formal reason that integral closure is
-idempotent. So this statement holds for **inseparable** isogenies too, Frobenius included, and does
-not inherit the sibling's limitation.
+**No finiteness is involved.** An integral closure is integrally closed in the ambient ring for the
+formal reason that integrality is transitive: an element of `W₁.FunctionField` integral over the
+closure is integral over `W₂.CoordinateRing`, hence already in it. Since `W₁.FunctionField` is a
+field, being integrally closed *in* it upgrades to `IsIntegrallyClosed`
+(`IsIntegrallyClosed.of_isIntegrallyClosedIn`). In particular this holds for **inseparable**
+isogenies, Frobenius included, and does not inherit the separability hypothesis that the sibling
+`Isogeny.moduleFinite_intermediateRing` carries for want of a trace-free route to finiteness.
 
 ## Main results
 
@@ -29,30 +29,39 @@ not inherit the sibling's limitation.
 
 ## Design
 
-The hypotheses mirror `Isogeny.moduleFinite_intermediateRing` — arbitrary algebra structures whose
-structure maps are the pullback, rather than one fixed choice, since registering such a structure
-globally would be a diamond. A consumer builds them from the bundled `φ.pullbackToIntermediateRing`
-(`letI := φ.pullbackToIntermediateRing.toAlgebra`) together with
-`Isogeny.isScalarTower_intermediateRing`, exactly as for the finiteness result.
+The hypotheses are those needed to *name* the integral closure, not to prove it normal. `h` fixes
+the `W₂.CoordinateRing`-algebra structure on `W₁.FunctionField` as the pullback, which is what
+`Isogeny.isIntegralClosure_intermediateRing` needs; the algebra structure on `φ.intermediateRing`
+and its scalar tower are what let integrality transit through it. A consumer builds both from the
+bundled `φ.pullbackToIntermediateRing` — `letI := φ.pullbackToIntermediateRing.toAlgebra` — together
+with `Isogeny.isScalarTower_intermediateRing`, exactly as for the finiteness result.
 
-Two hypotheses of the sibling are **absent** rather than merely unused, and the difference is the
-point of this file: `[Algebra.IsSeparable W₂.FunctionField W₁.FunctionField]` and
-`[IsIntegrallyClosed W₂.CoordinateRing]`. Integral closedness of the base is not needed because the
-conclusion is about the closure, not about the base:
-`integralClosure.isIntegrallyClosedOfFiniteExtension` asks only that the base be a domain with
-`W₂.FunctionField` as its fraction field.
+**Why not hypothesis-free.** The statement itself mentions no algebra structure, and mathematically
+it needs none: `intermediateRing` builds its own internally, and Mathlib's
+`IsIntegrallyClosedIn (integralClosure R A).toSubring A` is an unconditional instance. That instance
+cannot be used here, because `intermediateRing`'s body is not exposed across the module boundary —
+`Basic.lean` says so and offers `mem_intermediateRing_iff` as the escape hatch — so synthesis cannot
+see the two objects coincide. Every route from this module to the integral-closure property runs
+through `Isogeny.isIntegralClosure_intermediateRing`, which takes `h`. Removing the remaining
+hypotheses is therefore a change to `Basic.lean`'s exposed surface, not to this file.
 
 ## Provenance
 
-Original work against Mathlib's `integralClosure.isIntegrallyClosedOfFiniteExtension` and this
-repository's `Isogeny.isIntegralClosure_intermediateRing`. The transfer from Mathlib's literal
-`integralClosure` subalgebra to `φ.intermediateRing` goes through `IsIntegralClosure.equiv`, the
-standard way two integral closures of the same base in the same field are identified.
+⚠ *mathlib-track*. `TauCetiRoadmap/EllipticCurves/README.md:1092` lists
+`intermediateRingIsIntegrallyClosed` among the components of D. Angdinata's shared isogeny
+development, under the same flag the sibling `Isogeny` files carry.
 
-AINTLIB's `HasseWeil/Curves/RamificationFinite.lean` (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
-`dev/hasse-weil @ 513e83879e2f`) — the source of the sibling `moduleFinite_intermediateRing` —
-proves the finiteness half only; it *assumes* normality of the closure where it needs it rather
-than deriving it, so this statement is not a port of anything there.
+The result is also proved in the AINTLIB project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, by
+Chris Birkbeck), though not separately: `HasseWeil/Curves/RamificationFinite.lean` proves
+`instDedekindB` for `B := integralClosure C₂.CoordinateRing C₁.FunctionField`, the same object this
+file calls `φ.intermediateRing`, and a Dedekind domain is integrally closed. What is built here
+rather than taken from there is the reduction to `intermediateRing` as this repository defines it,
+through the corestricted pullback, and the statement of normality on its own rather than as a
+by-product of the Dedekind instance — which is what lets it hold without the finiteness that
+instance carries.
+
+The proof route — transitivity of integrality, then
+`IsIntegrallyClosed.of_isIntegrallyClosedIn` — is assembled from Mathlib and is not the source's.
 -/
 
 public section
@@ -64,29 +73,28 @@ namespace Isogeny
 variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
 
 /-- **The intermediate ring is integrally closed.** It is the integral closure of
-`W₂.CoordinateRing` in `W₁.FunctionField`, and an integral closure inside a finite extension of the
-base's fraction field is integrally closed.
+`W₂.CoordinateRing` in `W₁.FunctionField`, and an integral closure is integrally closed in the
+ambient ring by transitivity of integrality; over a field that upgrades to `IsIntegrallyClosed`.
 
-Unlike the sibling `Isogeny.moduleFinite_intermediateRing`, this needs neither separability of the
-function-field extension nor integral closedness of `W₂.CoordinateRing` — see the module
-docstring. -/
+No finiteness and no separability: unlike the sibling `Isogeny.moduleFinite_intermediateRing` this
+covers inseparable isogenies, Frobenius included. -/
 theorem isIntegrallyClosed_intermediateRing (φ : Isogeny W₁ W₂)
     [Algebra W₂.CoordinateRing W₁.FunctionField]
-    [Algebra W₂.FunctionField W₁.FunctionField]
-    [IsScalarTower W₂.CoordinateRing W₂.FunctionField W₁.FunctionField]
     [Algebra W₂.CoordinateRing φ.intermediateRing]
     [IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField]
     (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
     IsIntegrallyClosed φ.intermediateRing := by
   -- the integral-closure property is not assumed: it is what `intermediateRing` is
   have := φ.isIntegralClosure_intermediateRing h
-  have := φ.finiteDimensional_functionField (φ.algebraMap_functionField_eq_fieldPullback h)
-  have hclosure : IsIntegrallyClosed (integralClosure W₂.CoordinateRing W₁.FunctionField) :=
-    integralClosure.isIntegrallyClosedOfFiniteExtension W₂.FunctionField
-  exact IsIntegrallyClosed.of_equiv
-    (IsIntegralClosure.equiv W₂.CoordinateRing
-      (integralClosure W₂.CoordinateRing W₁.FunctionField) W₁.FunctionField
-      φ.intermediateRing).toRingEquiv
+  have : Algebra.IsIntegral W₂.CoordinateRing φ.intermediateRing :=
+    IsIntegralClosure.isIntegral_algebra W₂.CoordinateRing W₁.FunctionField
+  have : IsIntegrallyClosedIn φ.intermediateRing W₁.FunctionField := by
+    rw [isIntegrallyClosedIn_iff]
+    refine ⟨FaithfulSMul.algebraMap_injective _ _, fun {x} hx ↦ ?_⟩
+    -- `x` is integral over the closure, hence over `W₂.CoordinateRing`, hence already in it
+    exact (IsIntegralClosure.isIntegral_iff (A := φ.intermediateRing)).mp
+      (isIntegral_trans (R := W₂.CoordinateRing) x hx)
+  exact IsIntegrallyClosed.of_isIntegrallyClosedIn _ W₁.FunctionField
 
 end Isogeny
 


### PR DESCRIPTION
The intermediate ring of an isogeny — the integral closure of `W₂.CoordinateRing` in
`W₁.FunctionField` — is itself integrally closed.

```lean
theorem Isogeny.isIntegrallyClosed_intermediateRing (φ : Isogeny W₁ W₂) :
    IsIntegrallyClosed φ.intermediateRing
```

With `moduleFinite_intermediateRing` (#3347) this completes the pair of commutative-algebra
supports the relative ideal norm needs from the intermediate ring: **finite** and **normal**.

## Round 2: all five findings had one root cause, and both halves are now fixed

**The statement takes the isogeny and nothing else.** It previously carried two `Algebra`
instances, an `IsScalarTower`, and a hypothesis `h` pinning the structure map. `api-design` and
`generality` were right that this is proof infrastructure escaping into the API: the conclusion
mentions only `φ.intermediateRing`, so every consumer had to reconstruct machinery for a fact that
does not depend on it. The structures needed are the canonical ones — the pullback on
`W₁.FunctionField` and its corestriction `pullbackToIntermediateRing` — so the proof now installs
them itself and `h` is discharged internally rather than demanded.

**The proof reuses Mathlib instead of reproving it.** `reuse` and `proof-quality` both named
`IsIntegrallyClosedIn.of_isIntegralClosure`
(`Mathlib/RingTheory/IntegralClosure/IntegrallyClosed.lean:215`) — it is exactly "an integral
closure is integrally closed in the ambient ring", with the same proof I had written out by hand
over nine lines. It is used directly now.

The whole proof:

```lean
  let _ := φ.pullback.toRingHom.toAlgebra
  let _ := φ.pullbackToIntermediateRing.toAlgebra
  have hpb : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x := fun x ↦ by
    rw [RingHom.algebraMap_toAlgebra, AlgHom.toRingHom_eq_coe, AlgHom.coe_toRingHom]
  have : IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField :=
    φ.isScalarTower_intermediateRing rfl hpb
  have := φ.isIntegralClosure_intermediateRing hpb
  have : IsIntegrallyClosedIn φ.intermediateRing W₁.FunctionField :=
    IsIntegrallyClosedIn.of_isIntegralClosure W₂.CoordinateRing
  exact IsIntegrallyClosed.of_isIntegrallyClosedIn _ W₁.FunctionField
```

`let _` rather than `letI` is required here and is the file's own idiom: the goal is a
proposition, so `linter.style.haveILetI` rejects `letI`. `IntermediateRing/Basic.lean` shows both
sides of that rule — `letI` at lines 104/133 inside a `def`, `let _` at 173/193 inside tactic
proofs of propositions.

## Why the sibling still takes hypotheses — the documentation fix

The previous body and module docstring claimed the hypotheses could not be removed, because
"every route from this module to the integral-closure property runs through
`isIntegralClosure_intermediateRing`, which takes `h`". That was **wrong**, and `documentation`
caught it: `h` is constructible here from the pullback, so the route exists.

The real distinction, now stated in the file, is about what the two statements *say*:

| | conclusion | consequence |
|---|---|---|
| `moduleFinite_intermediateRing` | `Module.Finite W₂.CoordinateRing φ.intermediateRing` | names the base, so it is **relative to** an algebra structure the caller must choose — the statement has to accept one |
| this | `IsIntegrallyClosed φ.intermediateRing` | names one ring; an **absolute** property, nothing left for a caller to fix |

So the difference between the two files is not a convention, and not an oversight in either.

## It still costs strictly less than the finiteness half

| | `moduleFinite_intermediateRing` | this |
|---|---|---|
| `[Algebra.IsSeparable W₂.FunctionField W₁.FunctionField]` | **required** | not needed |
| `[IsIntegrallyClosed W₂.CoordinateRing]` | **required** | not needed |

The sibling needs separability because its only upstream route, `IsIntegralClosure.finite`, argues
through the trace pairing, and the trace form is nondegenerate exactly for separable extensions.
Nothing here goes near a trace: integral closure is **idempotent**. So this holds for
**inseparable isogenies, Frobenius included**.

**The roadmap asks for exactly this hypothesis set**, which is a constraint rather than a
permission:

> `finiteDimensional`, `intermediateRingFinite` and `intermediateRingIsIntegrallyClosed` need
> nothing more; only the class-group half — `pushClass`, `toPointHom` — needs
> `[IsIntegrallyClosed W₂.CoordinateRing]`

So carrying the base hypothesis here would have been a defect, not a harmless extra.

## Placement

New file `Isogeny/IntermediateRing/IntegrallyClosed.lean`, beside `Basic.lean` and `Finite.lean`,
matching the existing one-property-per-file split rather than growing `Basic.lean`.

## Scope

New mathematics. `TauCetiRoadmap/EllipticCurves/README.md` names
`intermediateRingIsIntegrallyClosed` twice as a component of the `toPointHom` development (lines
1092 and 1099), and the Layer-1 bullet **"The intermediate ring and the induced map on points"**
requires the intermediate ring to be module-finite over `W₂.CoordinateRing` and **integrally
closed**.

Prerequisites are all merged: `intermediateRing`, `isIntegralClosure_intermediateRing` and
`isScalarTower_intermediateRing` (`IntermediateRing/Basic.lean`). **This PR depends on no open
PR** — in particular not on #3403, which supplies the class-group half.

## Provenance

Original work against Mathlib's `IsIntegrallyClosedIn.of_isIntegralClosure` and
`IsIntegrallyClosed.of_isIntegrallyClosedIn`, and this repository's
`Isogeny.isIntegralClosure_intermediateRing`.

AINTLIB's `HasseWeil/Curves/RamificationFinite.lean` (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
`dev/hasse-weil @ 513e83879e2f`, by Chris Birkbeck) proves `instDedekindB` for
`B := integralClosure C₂.CoordinateRing C₁.FunctionField` — the same object — and a Dedekind domain
is integrally closed. What is built here rather than taken from there is the reduction to
`intermediateRing` as this repository defines it, through the corestricted pullback, and the
statement of normality on its own rather than as a by-product of the Dedekind instance, which is
what lets it hold without finiteness.

## Gates on this head

```
lake build <module>   Build completed successfully (1990 jobs), 0 errors
```

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"intermediatering-integrally-closed"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
