### PR TITLE
feat(EllipticCurve): the universal ψ and φ at the cusp

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Cusp
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.NormEDS
 
@@ -28,11 +29,32 @@ Each proof is the same two steps: unfold `polyEval` into a `map` followed by `ev
   auxiliary `preΨ₄`, are the universal ones evaluated through `Universal.polyEval`.
 * `WeierstrassCurve.Universal.isEllipticSequence_polyToField_ψ`: the universal `ψ` family, taken
   into `Universal.Field`, is an elliptic sequence.
+* `WeierstrassCurve.Universal.polyEval_cusp_ψ`: specialised to the cusp curve at `(1, 1)`, the
+  `n`-division polynomial evaluates to `n` itself.
 
 ## Implementation notes
 
 `Ψ₃` and `preΨ₄` are univariate, so their statements evaluate `C W.Ψ₃` rather than `W.Ψ₃`; the two
 extra rewrites in those proofs (`map_C`, `coe_mapRingHom`) only move that `C` past the base change.
+
+`polyEval_cusp_ψ` is where the three transport lemmas above earn their keep. `Cusp.lean` collapses
+`ψ₂`, `Ψ₃` and `preΨ₄` on `cusp R` to `2Y`, `3X⁴` and `2X⁶`; rewriting the transports backwards
+turns `polyEval (cusp ℤ) 1 1 (curve.ψ n)` into those three evaluated at `(1, 1)`, which are `2`,
+`3` and `2` — so the sequence is `normEDS 2 3 2`, and the identity of #3364 finishes it. That is
+the only reason this file imports `Cusp.lean`.
+
+**Three cusp companions of the source are deliberately absent, for two different reasons.**
+`polyEval_cusp_ψc` and `polyEval_cusp_ω` need `ψc` and `two_mul_ω`, both part of the `ω` API that
+`DivisionPolynomial/Invariant.lean` records as not yet here. `polyEval_cusp_φ` is blocked
+differently, and the obstruction is worth recording because it is the module system rather than a
+missing prerequisite: the source closes it with `simp_rw [φ, map_sub, …, polyEval]`, unfolding
+`polyEval`'s definition, which is rejected across a module boundary — *"Invalid simp theorem
+`polyEval`: Expected a definition with an exposed body"*. The usual escape is unavailable too,
+because `map_sub` does not fire on `polyEval (cusp ℤ) 1 1 (A - B)` by `rw` or `simp only`, so the
+ring hom cannot be pushed inward first; and plain `simp`, which does get through via
+`polyEval_apply`, rewrites `polyEval` into `evalEval ∘ Polynomial.map` and thereby destroys the
+left-hand side `polyEval_cusp_ψ` needs to match. It waits for either an `evalEval`-level restatement
+or an exposed `polyEval`.
 
 The companion transport for `ω` is **not** here. It cannot be: `WeierstrassCurve.ω` does not exist
 in this repository or in the pinned Mathlib, and neither does the `map_ω` such a proof would rewrite
@@ -53,6 +75,14 @@ reason above. `isEllipticSequence_polyToField_ψ` adapts that same file's `isEll
 That file's header reads `Authors: David Kurniadi Angdinata, Junyan Xu`; following this
 repository's convention for adapted material the upstream authorship is credited here rather than
 in the copyright header.
+
+`polyEval_cusp_ψ` adapts that same file's declaration of that name, at the roadmap's NagellLutz
+pin `dev/modular-curves @ 9fec8eba7652`. The proof is the source's, with two changes: `ψ` needs
+qualifying because this file opens `Universal` rather than `WeierstrassCurve` alone, and the
+source's `normEDS_two_three_two` hint is dropped rather than renamed — `normEDS_two_three_two_eq_id`
+is redundant here, since #3364's general `normEDS_two_three_two_eq_intCast` is `@[simp]` and reaches
+the same normal form first. The source's `polyEval_cusp_φ`, `polyEval_cusp_ψc` and
+`polyEval_cusp_ω` are excluded for the reasons above.
 
 The `evalEval_*` statements are the source's unchanged. Docstrings are added here, and the
 source's shared `variable {m n : ℤ}` is narrowed to `n`: of those five only `evalEval_ψ` and
@@ -110,6 +140,12 @@ lemma isEllipticSequence_polyToField_ψ :
     funext n; rw [← _root_.map_normEDS]; rfl
   rw [h]
   exact isEllipticSequence_normEDS _ _ _
+
+/-- **On the cusp curve at `(1, 1)`, the `n`-division polynomial evaluates to `n`.** -/
+lemma polyEval_cusp_ψ : polyEval (cusp ℤ) 1 1 (curve.ψ n) = n := by
+  rw [WeierstrassCurve.ψ, map_normEDS, ← evalEval_ψ₂, ← evalEval_Ψ₃, ← evalEval_preΨ₄, cusp_ψ₂,
+    cusp_Ψ₃, cusp_preΨ₄]
+  simp [evalEval]
 
 end Universal
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -29,8 +29,8 @@ Each proof is the same two steps: unfold `polyEval` into a `map` followed by `ev
   auxiliary `preΨ₄`, are the universal ones evaluated through `Universal.polyEval`.
 * `WeierstrassCurve.Universal.isEllipticSequence_polyToField_ψ`: the universal `ψ` family, taken
   into `Universal.Field`, is an elliptic sequence.
-* `WeierstrassCurve.Universal.polyEval_cusp_ψ`: specialised to the cusp curve at `(1, 1)`, the
-  `n`-division polynomial evaluates to `n` itself.
+* `WeierstrassCurve.Universal.polyEval_cusp_ψ`, `.polyEval_cusp_φ`: specialised to the cusp curve
+  at `(1, 1)`, `ψₙ` evaluates to `n` itself and the numerator `φₙ` to `1`.
 
 ## Implementation notes
 
@@ -43,18 +43,20 @@ turns `polyEval (cusp ℤ) 1 1 (curve.ψ n)` into those three evaluated at `(1, 
 `3` and `2` — so the sequence is `normEDS 2 3 2`, and the identity of #3364 finishes it. That is
 the only reason this file imports `Cusp.lean`.
 
-**Three cusp companions of the source are deliberately absent, for two different reasons.**
-`polyEval_cusp_ψc` and `polyEval_cusp_ω` need `ψc` and `two_mul_ω`, both part of the `ω` API that
-`DivisionPolynomial/Invariant.lean` records as not yet here. `polyEval_cusp_φ` is blocked
-differently, and the obstruction is worth recording because it is the module system rather than a
-missing prerequisite: the source closes it with `simp_rw [φ, map_sub, …, polyEval]`, unfolding
+**`polyEval_cusp_φ` does not port as written, and the reason is the module system rather than a
+missing prerequisite.** The source closes it with `simp_rw [φ, map_sub, …, polyEval]`, unfolding
 `polyEval`'s definition, which is rejected across a module boundary — *"Invalid simp theorem
-`polyEval`: Expected a definition with an exposed body"*. The usual escape is unavailable too,
-because `map_sub` does not fire on `polyEval (cusp ℤ) 1 1 (A - B)` by `rw` or `simp only`, so the
-ring hom cannot be pushed inward first; and plain `simp`, which does get through via
-`polyEval_apply`, rewrites `polyEval` into `evalEval ∘ Polynomial.map` and thereby destroys the
-left-hand side `polyEval_cusp_ψ` needs to match. It waits for either an `evalEval`-level restatement
-or an exposed `polyEval`.
+`polyEval`: Expected a definition with an exposed body"*. Supplying the equation lemma instead does
+not help either: `polyEval`'s image lives in `Poly`, whose `Sub` and `Mul` instances are themselves
+unexposed, so a bare `map_sub` cannot solve `?f` in the pattern `?f (?a - ?b)` and fails to fire at
+all. **Naming the ring hom is what fixes it** — `map_sub (polyEval (cusp ℤ) 1 1)` makes the match
+first-order, and the same for `map_mul` and `map_pow`. That leaves the arithmetic
+`polyEval (cusp ℤ) 1 1 (C X) * n ^ 2 - (n + 1) * (n - 1) = 1`, which `ring` closes once `C X`
+evaluates to `1`.
+
+The remaining two companions, `polyEval_cusp_ψc` and `polyEval_cusp_ω`, need `ψc` and `two_mul_ω`,
+both part of the `ω` API that `DivisionPolynomial/Invariant.lean` records as not yet here. Those are
+ordinary missing prerequisites and arrive with `ω`.
 
 The companion transport for `ω` is **not** here. It cannot be: `WeierstrassCurve.ω` does not exist
 in this repository or in the pinned Mathlib, and neither does the `map_ω` such a proof would rewrite
@@ -76,13 +78,14 @@ That file's header reads `Authors: David Kurniadi Angdinata, Junyan Xu`; followi
 repository's convention for adapted material the upstream authorship is credited here rather than
 in the copyright header.
 
-`polyEval_cusp_ψ` adapts that same file's declaration of that name, at the roadmap's NagellLutz
-pin `dev/modular-curves @ 9fec8eba7652`. The proof is the source's, with two changes: `ψ` needs
-qualifying because this file opens `Universal` rather than `WeierstrassCurve` alone, and the
-source's `normEDS_two_three_two` hint is dropped rather than renamed — `normEDS_two_three_two_eq_id`
-is redundant here, since #3364's general `normEDS_two_three_two_eq_intCast` is `@[simp]` and reaches
-the same normal form first. The source's `polyEval_cusp_φ`, `polyEval_cusp_ψc` and
-`polyEval_cusp_ω` are excluded for the reasons above.
+`polyEval_cusp_ψ` and `polyEval_cusp_φ` adapt that same file's declarations of those names, at the
+roadmap's NagellLutz pin `dev/modular-curves @ 9fec8eba7652`. Three changes. `ψ` and `φ` need
+qualifying, because this file opens `Universal` rather than `WeierstrassCurve` alone. The source's
+`normEDS_two_three_two` hint is dropped rather than renamed — `normEDS_two_three_two_eq_id` is
+redundant here, since #3364's general `normEDS_two_three_two_eq_intCast` is `@[simp]` and reaches
+the same normal form first. And `polyEval_cusp_φ`'s proof is restructured for the reason given
+above: the source's unfold of `polyEval` is unavailable, so each `map_*` names its ring hom.
+The source's `polyEval_cusp_ψc` and `polyEval_cusp_ω` are excluded.
 
 The `evalEval_*` statements are the source's unchanged. Docstrings are added here, and the
 source's shared `variable {m n : ℤ}` is narrowed to `n`: of those five only `evalEval_ψ` and
@@ -146,6 +149,18 @@ lemma polyEval_cusp_ψ : polyEval (cusp ℤ) 1 1 (curve.ψ n) = n := by
   rw [WeierstrassCurve.ψ, map_normEDS, ← evalEval_ψ₂, ← evalEval_Ψ₃, ← evalEval_preΨ₄, cusp_ψ₂,
     cusp_Ψ₃, cusp_preΨ₄]
   simp [evalEval]
+
+/-- **On the cusp curve at `(1, 1)`, the numerator `φₙ` evaluates to `1`.**
+
+Each `map_*` names its ring hom explicitly. `Poly`'s own `Sub`/`Mul` instances are unexposed, so
+the bare `map_sub` cannot solve `?f` for `?f (?a - ?b)`; supplying `polyEval (cusp ℤ) 1 1` makes
+the match first-order and it goes through. -/
+lemma polyEval_cusp_φ : polyEval (cusp ℤ) 1 1 (curve.φ n) = 1 := by
+  rw [WeierstrassCurve.φ, map_sub (polyEval (cusp ℤ) 1 1), map_mul (polyEval (cusp ℤ) 1 1),
+    map_mul (polyEval (cusp ℤ) 1 1), map_pow (polyEval (cusp ℤ) 1 1), polyEval_cusp_ψ,
+    polyEval_cusp_ψ, polyEval_cusp_ψ]
+  simp [polyEval_apply, evalEval]
+  ring
 
 end Universal
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -150,12 +150,9 @@ lemma polyEval_cusp_ψ : polyEval (cusp ℤ) 1 1 (curve.ψ n) = n := by
     cusp_Ψ₃, cusp_preΨ₄]
   simp [evalEval]
 
-/-- **On the cusp curve at `(1, 1)`, the numerator `φₙ` evaluates to `1`.**
-
-Each `map_*` names its ring hom explicitly. `Poly`'s own `Sub`/`Mul` instances are unexposed, so
-the bare `map_sub` cannot solve `?f` for `?f (?a - ?b)`; supplying `polyEval (cusp ℤ) 1 1` makes
-the match first-order and it goes through. -/
+/-- **On the cusp curve at `(1, 1)`, the numerator `φₙ` evaluates to `1`.** -/
 lemma polyEval_cusp_φ : polyEval (cusp ℤ) 1 1 (curve.φ n) = 1 := by
+  -- Each `map_*` names its ring hom; the implementation notes say why unification cannot.
   rw [WeierstrassCurve.φ, map_sub (polyEval (cusp ℤ) 1 1), map_mul (polyEval (cusp ℤ) 1 1),
     map_mul (polyEval (cusp ℤ) 1 1), map_pow (polyEval (cusp ℤ) 1 1), polyEval_cusp_ψ,
     polyEval_cusp_ψ, polyEval_cusp_ψ]


### PR DESCRIPTION
The universal `n`-division polynomial, specialised to the cusp curve at `(1, 1)`, is `n` itself —
and its numerator is `1`.

```lean
lemma polyEval_cusp_ψ : polyEval (cusp ℤ) 1 1 (curve.ψ n) = n
lemma polyEval_cusp_φ : polyEval (cusp ℤ) 1 1 (curve.φ n) = 1
```

## Why it is one line of rewriting

This file already carries the three transport lemmas `evalEval_ψ₂`, `evalEval_Ψ₃` and
`evalEval_preΨ₄`, which identify a curve's low division polynomials at a point with the universal
ones under `polyEval`. `Cusp.lean` (merged) collapses the same three on `cusp R` to `2Y`, `3X⁴` and
`2X⁶`. Rewriting the transports **backwards** turns `polyEval (cusp ℤ) 1 1 (curve.ψ n)` into those
three evaluated at `(1, 1)` — which are `2`, `3` and `2`. So the family is `normEDS 2 3 2`, and the
identity that landed in #3364 finishes it.

That composition is the only reason this file now imports `Cusp.lean`, and it is why the lemma
belongs here rather than there: `Cusp.lean` knows nothing of `polyEval` or the universal curve, and
giving it those imports for one lemma would widen its graph for material that is not its topic.

## Two of the source's four cusp evaluations are absent, and the third took two tries

**`polyEval_cusp_ψc` and `polyEval_cusp_ω`** need `ψc` and `two_mul_ω`. Both belong to the `ω` API
that `DivisionPolynomial/Invariant.lean` already records as not yet in this repository. Ordinary
missing prerequisites; they arrive with `ω`.

**`polyEval_cusp_φ` I first judged unportable, and that was wrong** — the diagnosis was half right
and I am recording both halves, because the half I got wrong is the reusable part.

The half that was right: the source closes it with

```lean
simp_rw [φ, map_sub, map_mul, map_pow, polyEval_cusp_ψ, polyEval]
```

unfolding `polyEval`'s **definition**, and across a module boundary that is rejected outright —
*"Invalid simp theorem `polyEval`: Expected a definition with an exposed body."* This is the sixth
occurrence of that trap in this campaign, after `cusp`, `universalNormEDS` (twice), `invarNum` and
`invarDenom`.

The half that was wrong: I recorded `map_sub` failing to fire on `polyEval (cusp ℤ) 1 1 (A - B)` as
a *second, independent* obstacle, and concluded the lemma needed an `evalEval`-level restatement or
an exposed `polyEval`. It is the same cause one level down. `polyEval`'s argument lives in `Poly`,
whose `Sub` and `Mul` **instances** are themselves unexposed, so higher-order unification cannot
solve `?f` in the pattern `?f (?a - ?b)`. The elaborator says so if asked directly:

```
Note: The following definitions were not unfolded because their definition is not exposed:
  instAdd ↦ 12
```

**Naming the ring hom makes each match first-order, and it goes through:**

```lean
rw [WeierstrassCurve.φ, map_sub (polyEval (cusp ℤ) 1 1), map_mul (polyEval (cusp ℤ) 1 1),
  map_mul (polyEval (cusp ℤ) 1 1), map_pow (polyEval (cusp ℤ) 1 1), polyEval_cusp_ψ,
  polyEval_cusp_ψ, polyEval_cusp_ψ]
simp [polyEval_apply, evalEval]
ring
```

which leaves `polyEval (cusp ℤ) 1 1 (C X) * n ^ 2 - (n + 1) * (n - 1) = 1`. The module docstring
carries the escape rather than the obstruction, since an unexposed *instance* — as opposed to an
unexposed definition body — is a trap a reader is likelier to hit than to have a name for.

## Reuse

Checked in both trees, as a substring rather than an anchored name — `polyEval_cusp` returned
nothing anywhere in `TauCeti/` before this PR, against a positive control of `evalEval_ψ₂`, which
returns its three real occurrences in this file. Mathlib has no `Universal.curve`, no `polyEval`
and no `cusp` in this sense, so the statement is not expressible upstream.

`Cusp.lean` proves the *base* collapses (`cusp_ψ₂`, `cusp_Ψ₃`, `cusp_preΨ₄`, `cusp_Ψ₂Sq`); this is
the general index, and it consumes those rather than restating them.

## Gates

`lake build` PASS at 8006 jobs. `lake exe axioms` PASS — 48627 declarations, allowlist only
(48624 on unmodified main, so the delta is these declarations rather than a stale tree).
`lake exe module-system` PASS — 2301 modules. `scripts/lint-env.sh` PASS, no new violations.
Two lemmas, proofs of four and six lines against the 30-line threshold; no `sorry`, no
`set_option`, no `erw`.

## Review status

**Opened without a scoreboard; no reviewer exists to run one.** Both codex credentials on this
machine are over quota (`~/.codex` to 2026-08-20, `~/.codex2` to 2026-09-14) and the claude weekly
limit is also reached, so a local run returns rubrics at `cost=$0.0000` — the provider never ran.
Posting that would be worse than posting nothing: `merge_from_scoreboard.py` takes the newest
scoreboard by `updated_at` with no access bar, so a wall of `error` states would overwrite a
maintainer's verdict as the canonical record. The repository's automated reviewer (`review.yml`) is
`disabled_manually`, so this waits on a human running the CLI, as #3392, #3361 and #3405 all did.

## Roadmap

`TauCetiRoadmap/EllipticCurves/README.md:99` — "**`[n]` is division polynomials**", whose lines
103–104 name mathlib #13782 and `ZSMul.lean` as "the mathlib-track anchor Layer 1 consumes".
`ZSMul.lean` is the source file for both. The onward consumer is Layer 6's "**The torsion subgroup
and Nagell–Lutz**" (`README.md:821`), whose stated route is division polynomials. Read from
`origin/main` of the canonical roadmap rather than from a local checkout.

## Provenance

Adapted from J. Xu and D. K. Angdinata's `LutzNagell/ZSMul.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at **`dev/modular-curves @ 9fec8eba7652`** — the
revision `TauCetiRoadmap/EllipticCurves/README.md` pins for the NagellLutz project. Declarations
`polyEval_cusp_ψ` and `polyEval_cusp_φ`, under their source names. That file's header reads
`Authors: David Kurniadi Angdinata, Junyan Xu`; following this repository's convention for adapted
material the upstream authorship is credited in the module docstring rather than in the copyright
header.

Three changes from the source. `ψ` and `φ` need qualifying, because this file opens `Universal`
rather than `WeierstrassCurve` alone. `polyEval_cusp_φ`'s proof is restructured for the reason
above — the unfold of `polyEval` is unavailable, so each `map_*` names its ring hom. And the
source's `normEDS_two_three_two` hint is **dropped** rather than renamed: #3364's general
`normEDS_two_three_two_eq_intCast` is `@[simp]` and reaches the same normal form first, so passing the `ℤ` identity as well is an unused simp argument — which the
`unusedSimpArgs` linter fails the build on.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-polyeval-cusp"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
