### PR TITLE
feat: make Kostant root subgroup points natural

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup.lean
@@ -78,7 +78,7 @@ noncomputable def kostantRootSubgroupPoints :
 
 /-- The linear equivalence underlying a Kostant root-subgroup point is the integral
 divided-power exponential with the corresponding `𝔾ₐ` parameter. -/
-theorem kostantRootSubgroupPoints_toLinearEquiv
+@[simp] theorem kostantRootSubgroupPoints_toLinearEquiv
     (f : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A)) :
     (kostantRootSubgroupPoints e h ρ M hM i hnil f).toLinearEquiv =
       baseChangeKostantExpHom e h ρ M hM i hnil
@@ -88,7 +88,7 @@ theorem kostantRootSubgroupPoints_toLinearEquiv
 
 /-- On an elementary tensor, a Kostant root-subgroup point acts by the expected finite
 divided-power formula. -/
-theorem kostantRootSubgroupPoints_tmul
+@[simp] theorem kostantRootSubgroupPoints_tmul
     (f : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A)) (a : A) (m : M) :
     (kostantRootSubgroupPoints e h ρ M hM i hnil f).val (a ⊗ₜ[ℤ] m) =
       ∑ n ∈ Finset.range

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup.lean
@@ -5,7 +5,7 @@ Authors: Codex
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup.Scheme
+public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup.Basic
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.BaseChangeAction
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 
@@ -70,7 +70,7 @@ commutative ring `A`.
 Under the usual equivalence `𝔾ₐ(A) ≃ A⁺`, the parameter `t` acts on `A ⊗[ℤ] M` by the finite
 divided-power exponential of `ρ(eᵢ)`. -/
 noncomputable def kostantRootSubgroupPoints :
-    WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A) →*
+    WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A) →*
       LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M) :=
   (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[ℤ] M)).symm.toMonoidHom.comp <|
     (baseChangeKostantExpHom e h ρ M hM i hnil).comp
@@ -79,7 +79,7 @@ noncomputable def kostantRootSubgroupPoints :
 /-- The linear equivalence underlying a Kostant root-subgroup point is the integral
 divided-power exponential with the corresponding `𝔾ₐ` parameter. -/
 @[simp] theorem kostantRootSubgroupPoints_toLinearEquiv
-    (f : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A)) :
+    (f : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
     (kostantRootSubgroupPoints e h ρ M hM i hnil f).toLinearEquiv =
       baseChangeKostantExpHom e h ρ M hM i hnil
         (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) := by
@@ -89,7 +89,7 @@ divided-power exponential with the corresponding `𝔾ₐ` parameter. -/
 /-- On an elementary tensor, a Kostant root-subgroup point acts by the expected finite
 divided-power formula. -/
 @[simp] theorem kostantRootSubgroupPoints_tmul
-    (f : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A)) (a : A) (m : M) :
+    (f : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) (a : A) (m : M) :
     (kostantRootSubgroupPoints e h ρ M hM i hnil f).val (a ⊗ₜ[ℤ] m) =
       ∑ n ∈ Finset.range
           (nilpotencyClass (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)))),
@@ -118,23 +118,20 @@ coordinate of every tensor intertwines the automorphism attached to `t : A` with
 automorphism attached to `φ(t) : B`. -/
 theorem map_kostantRootSubgroupPoints
     (φ : A →+* B)
-    (f : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A)) :
+    (f : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
     ∀ z : A ⊗[ℤ] M,
       TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id
           ((kostantRootSubgroupPoints e h ρ M hM i hnil f).val z) =
         (kostantRootSubgroupPoints e h ρ M hM i hnil
-            (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra ℤ) φ.toIntAlgHom f)).val
+            (AlgHom.mapValue (H := SymmetricAlgebra ℤ ℤ) φ.toIntAlgHom f)).val
           (TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id z) := by
   intro z
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | tmul a m =>
-      rw [TensorProduct.map_tmul, kostantRootSubgroupPoints_tmul,
-        kostantRootSubgroupPoints_tmul,
-        AdditiveGroup.toAdd_gaPointsMulEquiv_mapValue]
-      simp only [map_sum, TensorProduct.map_tmul, LinearMap.id_apply,
-        AlgHom.toLinearMap_apply, map_pow, map_mul]
-  | add x y hx hy => simp [hx, hy]
+  rw [← LinearMap.GeneralLinearGroup.coe_toLinearEquiv,
+    kostantRootSubgroupPoints_toLinearEquiv, coe_baseChangeKostantExpHom,
+    ← LinearMap.GeneralLinearGroup.coe_toLinearEquiv,
+    kostantRootSubgroupPoints_toLinearEquiv, coe_baseChangeKostantExpHom,
+    AdditiveGroup.toAdd_gaPointsMulEquiv_mapValue]
+  exact map_baseChangeExp φ _ _ _ _ z
 
 end Naturality
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup.Scheme
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.BaseChangeAction
+public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
+
+/-!
+# Root subgroups from Kostant-stable integral modules
+
+Let `U_ℤ = kostantForm e h` be a Kostant integral form acting on a rational vector space `V`,
+and let `M ≤ V` be an additive subgroup preserved by `U_ℤ`. If a designated root vector `eᵢ`
+acts nilpotently, its integral divided powers define, over every commutative ring `A`, an
+additive one-parameter subgroup
+
+```text
+A⁺ → Aut_A(A ⊗[ℤ] M),    t ↦ ∑ₙ tⁿ ρ(eᵢ)⁽ⁿ⁾.
+```
+
+This file proves that these homomorphisms are natural in `A`, turning the ring-by-ring exponential
+actions from `TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.BaseChangeAction` into a natural
+root-subgroup map on points. Once integral PBW supplies a finite free admissible lattice, its basis
+will identify these automorphisms with `GLₙ(A)` and the existing full-faithfulness theorem for the
+functor of points will recover the scheme morphism `𝔾ₐ → GLₙ`.
+
+## Main declarations
+
+* `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupPoints`: the root subgroup on
+  algebra-valued points.
+* `TauCeti.UniversalEnvelopingAlgebra.map_kostantRootSubgroupPoints`: naturality under a
+  homomorphism of value rings.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27.
+* R. W. Carter, *Simple Groups of Lie Type*, §4.4.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+open TensorProduct WithConv
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+universe u v w
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {ι : Type w} {κ : Type*}
+variable {V : Type v} [AddCommGroup V] [Module ℚ V]
+
+variable (e : ι → L) (h : κ → L)
+variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+variable (M : AddSubgroup V)
+variable (hM : ∀ u ∈ kostantForm e h, ∀ v ∈ M, ρ u v ∈ M)
+variable (i : ι)
+variable (hnil : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+
+section Points
+
+variable {A : Type*} [CommRing A]
+
+/-- The root subgroup attached to a nilpotent root-vector action, on points valued in a
+commutative ring `A`.
+
+Under the usual equivalence `𝔾ₐ(A) ≃ A⁺`, the parameter `t` acts on `A ⊗[ℤ] M` by the finite
+divided-power exponential of `ρ(eᵢ)`. -/
+noncomputable def kostantRootSubgroupPoints :
+    WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A) →*
+      LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M) :=
+  (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[ℤ] M)).symm.toMonoidHom.comp <|
+    (baseChangeKostantExpHom e h ρ M hM i hnil).comp
+      (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).toMonoidHom
+
+/-- The linear equivalence underlying a Kostant root-subgroup point is the integral
+divided-power exponential with the corresponding `𝔾ₐ` parameter. -/
+theorem kostantRootSubgroupPoints_toLinearEquiv
+    (f : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A)) :
+    (kostantRootSubgroupPoints e h ρ M hM i hnil f).toLinearEquiv =
+      baseChangeKostantExpHom e h ρ M hM i hnil
+        (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) := by
+  rw [kostantRootSubgroupPoints]
+  exact (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[ℤ] M)).apply_symm_apply _
+
+/-- On an elementary tensor, a Kostant root-subgroup point acts by the expected finite
+divided-power formula. -/
+theorem kostantRootSubgroupPoints_tmul
+    (f : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A)) (a : A) (m : M) :
+    (kostantRootSubgroupPoints e h ρ M hM i hnil f).val (a ⊗ₜ[ℤ] m) =
+      ∑ n ∈ Finset.range
+          (nilpotencyClass (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)))),
+        ((Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv f)) ^ n * a) ⊗ₜ[ℤ]
+          integralDividedPower
+            (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M n
+            (fun _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem
+              e h ρ hM i n hv) m := by
+  rw [← LinearMap.GeneralLinearGroup.coe_toLinearEquiv,
+    kostantRootSubgroupPoints_toLinearEquiv]
+  rw [coe_baseChangeKostantExpHom]
+  exact baseChangeExp_tmul
+    (R := A) (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
+      (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem
+        e h ρ hM i n hv)
+      (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv f)) a m
+
+end Points
+
+section Naturality
+
+variable {A B : Type*} [CommRing A] [CommRing B]
+
+/-- Kostant root-subgroup points are natural in the value ring. Applying `φ` to the scalar
+coordinate of every tensor intertwines the automorphism attached to `t : A` with the
+automorphism attached to `φ(t) : B`. -/
+theorem map_kostantRootSubgroupPoints
+    (φ : A →+* B)
+    (f : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A)) :
+    ∀ z : A ⊗[ℤ] M,
+      TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id
+          ((kostantRootSubgroupPoints e h ρ M hM i hnil f).val z) =
+        (kostantRootSubgroupPoints e h ρ M hM i hnil
+            (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra ℤ) φ.toIntAlgHom f)).val
+          (TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id z) := by
+  intro z
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul a m =>
+      rw [TensorProduct.map_tmul, kostantRootSubgroupPoints_tmul,
+        kostantRootSubgroupPoints_tmul,
+        AdditiveGroup.toAdd_gaPointsMulEquiv_mapValue]
+      simp only [map_sum, TensorProduct.map_tmul, LinearMap.id_apply,
+        AlgHom.toLinearMap_apply, map_pow, map_mul]
+  | add x y hx hy => simp [hx, hy]
+
+end Naturality
+
+end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
+++ b/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
@@ -37,6 +37,7 @@ characteristic.
   subgroup.
 * `TauCeti.mul_integralDividedPower`: multiplication formula for restricted divided powers.
 * `TauCeti.baseChangeExp`: the finite divided-power exponential on `R ⊗[ℤ] M` for an element of `A`.
+* `TauCeti.map_baseChangeExp`: naturality of the exponential under a map of parameter rings.
 * `TauCeti.baseChangeExp_add`: its one-parameter group law.
 * `TauCeti.baseChangeExpLinearEquiv`: the resulting linear automorphism.
 * `TauCeti.baseChangeExpHom`: the additive one-parameter subgroup over `R`.
@@ -142,6 +143,23 @@ theorem baseChangeExp_tmul (x : A) (M : S)
       ∑ n ∈ range (nilpotencyClass x), (t ^ n * r) ⊗ₜ[ℤ]
         integralDividedPower x M n (hM n) v := by
   simp [baseChangeExp, smul_tmul']
+
+/-- The base-changed divided-power exponential is natural under maps of parameter rings. -/
+theorem map_baseChangeExp {T : Type*} [CommRing T] (φ : R →+* T) (x : A) (M : S)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) (t : R) :
+    ∀ z : R ⊗[ℤ] M,
+      TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id (baseChangeExp x M hM t z) =
+        baseChangeExp x M hM (φ t)
+          (TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id z) := by
+  intro z
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul r m =>
+      rw [TensorProduct.map_tmul, baseChangeExp_tmul, baseChangeExp_tmul]
+      simp only [map_sum, TensorProduct.map_tmul, LinearMap.id_apply,
+        AlgHom.toLinearMap_apply, map_pow, map_mul]
+      rfl
+  | add y z hy hz => simp [hy, hz]
 
 private theorem baseChange_mul_integralDividedPower
     (x : A) (M : S)


### PR DESCRIPTION
This PR packages the existing Kostant divided-power exponentials as additive-group points in the general linear group and proves that they are natural under homomorphisms of value rings. It adds the pointwise root-subgroup homomorphism, identifies its underlying linear equivalence and elementary-tensor formula, and establishes the scalar-extension square needed to pass from ring-by-ring actions to a morphism of functors of points.

The exact target is the ReductiveGroups roadmap's Layer 9 milestone “Root subgroup maps,” specifically the construction of the maps `x_α : 𝔾ₐ → G`. This is the most effective current step because `baseChangeKostantExpHom` already supplies each component of the exponential action, while naturality in the value ring is the missing prerequisite for treating those components as one root-subgroup map and later invoking the existing full-faithfulness result for affine-scheme points. Layer 9 is the roadmap input for the pinned split reductive model used by CFSGStatement L0.

After this PR, the milestone still needs integral PBW to provide a finite free admissible lattice, a basis and coordinate realization in `GLₙ`, reconstruction of the scheme morphism, and assembly of the general pinned Chevalley–Demazure group with its commutator and pinning relations.

The implementation reuses Tau Ceti's additive-group point equivalence, Kostant exponential action, and Mathlib's tensor-product scalar map. No Mathlib infrastructure is vendored; the mathematical construction follows the Humphreys, Carter, and Jantzen references recorded in the module documentation.

Validation completed with the targeted Lake build, the changed-module axiom audit, and the changed-module lint environment.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"kostant-root-subgroup-points-map"}-->

🤖 Prepared with Codex
