### PR TITLE
feat: commute finite duals with base change

### DIFF
--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.HopfAlgebra.TensorProduct
-public import Mathlib.Algebra.Module.Projective
 public import Mathlib.RingTheory.TensorProduct.Finite
 public import TauCeti.Algebra.HopfAlgebra.FiniteDual.Basic
 public import TauCeti.LinearAlgebra.Dual.BaseChange
@@ -48,7 +47,7 @@ universe u v w
 
 variable {k : Type u} {K : Type v} {H : Type w}
 variable [CommRing k] [CommRing K] [Algebra k K]
-variable [CommRing H] [Bialgebra k H]
+variable [Semiring H] [Bialgebra k H]
 
 /-- The scalar-extended evaluation map, with convolution wrappers on its source and target. -/
 private noncomputable def baseChangeGenerator :
@@ -112,10 +111,10 @@ private theorem baseChangeLinearEquiv_tmul_apply_tmul
 omit [Module.Finite k H] [Module.Projective k H] in
 private theorem baseChange_one :
     baseChange (k := k) (K := K) (H := H) 1 = 1 := by
-  rw [show (1 : K ⊗[k] ConvolutionDual k H) =
-      1 ⊗ₜ[k] (1 : ConvolutionDual k H) by exact Algebra.TensorProduct.one_def]
+  rw [Algebra.TensorProduct.one_def]
   apply WithConv.ofConv_injective
   ext x
+  -- Unwrap `WithConv` after testing the functionals on a pure tensor.
   change (baseChange (k := k) (K := K) (H := H)
       (1 ⊗ₜ[k] (1 : ConvolutionDual k H))).ofConv (1 ⊗ₜ[k] x) =
     (1 : ConvolutionDual K (K ⊗[k] H)).ofConv (1 ⊗ₜ[k] x)
@@ -131,6 +130,7 @@ private theorem baseChange_mul (z w : K ⊗[k] ConvolutionDual k H) :
   intro a b φ ψ
   apply WithConv.ofConv_injective
   ext x
+  -- Unwrap tensor-product multiplication and convolution after evaluation at `1 ⊗ₜ x`.
   change (baseChange (k := k) (K := K) (H := H)
       ((a * b) ⊗ₜ[k] (φ * ψ))).ofConv (1 ⊗ₜ[k] x) =
     (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ) *
@@ -162,6 +162,72 @@ private theorem baseChangeAlgEquiv_tmul_apply_tmul
         (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) :=
   baseChange_tmul_apply_tmul a b φ x
 
+/-- The base-change algebra equivalence preserves the finite-dual counit. -/
+private theorem baseChange_counit :
+    (Bialgebra.counitAlgHom K (ConvolutionDual K (K ⊗[k] H))).comp
+        (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom =
+      Bialgebra.counitAlgHom K (K ⊗[k] ConvolutionDual k H) := by
+  apply AlgHom.ext (R := K) (A := K ⊗[k] ConvolutionDual k H) (B := K)
+  intro z
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z w hz hw => simp only [map_add, hz, hw]
+  | tmul a φ =>
+      -- `AlgHom.comp` and `baseChangeAlgEquiv` reduce to their underlying counit and map.
+      change Coalgebra.counit (R := K)
+          (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)) =
+        Coalgebra.counit (R := K) (a ⊗ₜ[k] φ)
+      rw [ConvolutionDual.counit_apply]
+      -- The finite-dual counit is evaluation at the tensor-product unit `1 ⊗ₜ 1`.
+      change (baseChange (k := k) (K := K) (H := H)
+          (a ⊗ₜ[k] φ)).ofConv (1 ⊗ₜ[k] (1 : H)) = _
+      rw [baseChange_tmul_apply_tmul]
+      simp [ConvolutionDual.counit_apply, Algebra.smul_def, mul_comm]
+
+/-- The base-change algebra equivalence preserves the finite-dual comultiplication. -/
+private theorem baseChange_comul :
+    (Algebra.TensorProduct.map
+        (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom
+        (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom).comp
+        (Bialgebra.comulAlgHom K (K ⊗[k] ConvolutionDual k H)) =
+      (Bialgebra.comulAlgHom K (ConvolutionDual K (K ⊗[k] H))).comp
+        (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom := by
+  apply AlgHom.ext (R := K) (A := K ⊗[k] ConvolutionDual k H)
+    (B := ConvolutionDual K (K ⊗[k] H) ⊗[K] ConvolutionDual K (K ⊗[k] H))
+  intro z
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z w hz hw => simp only [map_add, hz, hw]
+  | tmul a φ =>
+      apply (dualDistribEquiv K (K ⊗[k] H)).injective
+      ext x y
+      -- Unwrap the two composed bialgebra maps, then compare distributions on pure tensors.
+      change dualDistribEquiv K (K ⊗[k] H)
+          ((Algebra.TensorProduct.map
+            (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom
+            (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom)
+              (Coalgebra.comul (R := K) (a ⊗ₜ[k] φ)))
+            ((1 ⊗ₜ[k] x) ⊗ₜ[K] (1 ⊗ₜ[k] y)) =
+        dualDistribEquiv K (K ⊗[k] H)
+          (Coalgebra.comul (R := K)
+            (baseChangeAlgEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)))
+            ((1 ⊗ₜ[k] x) ⊗ₜ[K] (1 ⊗ₜ[k] y))
+      rw [ConvolutionDual.dualDistribEquiv_comul_apply]
+      simp only [Algebra.TensorProduct.tmul_mul_tmul, one_mul]
+      rw [baseChangeAlgEquiv_tmul_apply_tmul]
+      rw [← ConvolutionDual.dualDistribEquiv_comul_apply k H φ x y]
+      simp only [TensorProduct.comul_tmul]
+      generalize Coalgebra.comul (R := k) (A := ConvolutionDual k H) φ = q
+      induction q using TensorProduct.induction_on with
+      | zero => simp
+      | add q r hq hr =>
+          simp only [TensorProduct.tmul_add, map_add, hq, hr,
+            LinearMap.add_apply, mul_add]
+      | tmul ψ χ =>
+          simp [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
+            baseChangeAlgEquiv_tmul_apply_tmul, map_mul]
+          ring
+
 /-- Finite dualization commutes with extension of scalars for finite projective bialgebras.
 
 The equivalence preserves the Hopf algebra structure whenever `H` is a Hopf algebra, since
@@ -172,56 +238,7 @@ noncomputable def baseChangeBialgEquiv :
     (R := K) (A := K ⊗[k] ConvolutionDual k H)
     (B := ConvolutionDual K (K ⊗[k] H))
     (baseChangeAlgEquiv (k := k) (K := K) (H := H))
-    (by
-      apply AlgHom.ext (R := K) (A := K ⊗[k] ConvolutionDual k H) (B := K)
-      intro z
-      induction z using TensorProduct.induction_on with
-      | zero => simp
-      | add z w hz hw => simp only [map_add, hz, hw]
-      | tmul a φ =>
-          change Coalgebra.counit (R := K)
-              (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)) =
-            Coalgebra.counit (R := K) (a ⊗ₜ[k] φ)
-          rw [ConvolutionDual.counit_apply]
-          change (baseChange (k := k) (K := K) (H := H)
-              (a ⊗ₜ[k] φ)).ofConv (1 ⊗ₜ[k] (1 : H)) = _
-          rw [baseChange_tmul_apply_tmul]
-          simp [ConvolutionDual.counit_apply, Algebra.smul_def, mul_comm])
-    (by
-      apply AlgHom.ext (R := K) (A := K ⊗[k] ConvolutionDual k H)
-        (B := ConvolutionDual K (K ⊗[k] H) ⊗[K] ConvolutionDual K (K ⊗[k] H))
-      intro z
-      induction z using TensorProduct.induction_on with
-      | zero => simp
-      | add z w hz hw => simp only [map_add, hz, hw]
-      | tmul a φ =>
-          apply (dualDistribEquiv K (K ⊗[k] H)).injective
-          ext x y
-          change dualDistribEquiv K (K ⊗[k] H)
-              ((Algebra.TensorProduct.map
-                (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom
-                (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom)
-                  (Coalgebra.comul (R := K) (a ⊗ₜ[k] φ)))
-                ((1 ⊗ₜ[k] x) ⊗ₜ[K] (1 ⊗ₜ[k] y)) =
-            dualDistribEquiv K (K ⊗[k] H)
-              (Coalgebra.comul (R := K)
-                (baseChangeAlgEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)))
-                ((1 ⊗ₜ[k] x) ⊗ₜ[K] (1 ⊗ₜ[k] y))
-          rw [ConvolutionDual.dualDistribEquiv_comul_apply]
-          simp only [Algebra.TensorProduct.tmul_mul_tmul, one_mul]
-          rw [baseChangeAlgEquiv_tmul_apply_tmul]
-          rw [← ConvolutionDual.dualDistribEquiv_comul_apply k H φ x y]
-          simp only [TensorProduct.comul_tmul]
-          generalize Coalgebra.comul (R := k) (A := ConvolutionDual k H) φ = q
-          induction q using TensorProduct.induction_on with
-          | zero => simp
-          | add q r hq hr =>
-              simp only [TensorProduct.tmul_add, map_add, hq, hr,
-                LinearMap.add_apply, mul_add]
-          | tmul ψ χ =>
-              simp [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
-                baseChangeAlgEquiv_tmul_apply_tmul, map_mul]
-              ring)
+    baseChange_counit baseChange_comul
 
 /-- The base-change equivalence evaluates pure tensors by scalar-extended evaluation. -/
 @[simp]
@@ -230,8 +247,6 @@ theorem baseChangeBialgEquiv_tmul_apply_tmul (a b : K)
     (baseChangeBialgEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv
         (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) := by
   rw [baseChangeBialgEquiv, BialgEquiv.ofAlgEquiv_apply]
-  change (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv
-    (b ⊗ₜ[k] x) = _
-  exact baseChange_tmul_apply_tmul a b φ x
+  exact baseChangeAlgEquiv_tmul_apply_tmul a b φ x
 
 end TauCeti.ConvolutionDual

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
@@ -49,93 +49,48 @@ variable {k : Type u} {K : Type v} {H : Type w}
 variable [CommRing k] [CommRing K] [Algebra k K]
 variable [Semiring H] [Bialgebra k H]
 
-/-- The scalar-extended evaluation map, with convolution wrappers on its source and target. -/
-private noncomputable def baseChangeGenerator :
-    ConvolutionDual k H →ₗ[k] Module.Dual K (K ⊗[k] H) :=
-  Module.Dual.baseChange K ∘ₗ (WithConv.linearEquiv k _).toLinearMap
-
-/-- Extend a convolution-dual functional and restore the convolution wrapper. -/
-private noncomputable def baseChange :
-    K ⊗[k] ConvolutionDual k H →ₗ[K] ConvolutionDual K (K ⊗[k] H) where
-  toFun z := WithConv.toConv
-    ((baseChangeGenerator (k := k) (K := K) (H := H)).liftBaseChange K z)
-  map_add' x y := by apply WithConv.ofConv_injective; simp
-  map_smul' a x := by apply WithConv.ofConv_injective; simp
-
-@[simp]
-private theorem baseChange_tmul_apply_tmul (a b : K) (φ : ConvolutionDual k H) (x : H) :
-    (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv (b ⊗ₜ[k] x) =
-      a * b * algebraMap k K (φ.ofConv x) := by
-  simp [baseChange, baseChangeGenerator, Algebra.smul_def]
-  ac_rfl
-
 variable [Module.Finite k H] [Module.Projective k H]
-
-/-- The underlying bijection of the base-change map, assembled from linear equivalences. -/
-private noncomputable def baseChangeEquivAux :
-    (K ⊗[k] ConvolutionDual k H) ≃ ConvolutionDual K (K ⊗[k] H) :=
-  (TensorProduct.congr (LinearEquiv.refl k K) (WithConv.linearEquiv k _)).toEquiv.trans <|
-    (Module.Dual.baseChangeEquiv (R := k) (A := K) (M := H)).toEquiv.trans <|
-      (WithConv.linearEquiv K _).symm.toEquiv
-
-private theorem baseChange_coe_eq_baseChangeEquivAux :
-    (baseChange (k := k) (K := K) (H := H) :
-      K ⊗[k] ConvolutionDual k H → ConvolutionDual K (K ⊗[k] H)) =
-        baseChangeEquivAux (k := k) (K := K) (H := H) := by
-  funext z
-  induction z using TensorProduct.induction_on with
-  | zero => simp [baseChangeEquivAux]
-  | add z w hz hw =>
-      rw [map_add, hz, hw]
-      simp [baseChangeEquivAux]
-  | tmul a φ =>
-      apply WithConv.ofConv_injective
-      ext x
-      simp [baseChangeEquivAux, baseChange, baseChangeGenerator,
-        Algebra.smul_def]
 
 /-- The scalar-extended evaluation map as a linear equivalence. -/
 private noncomputable def baseChangeLinearEquiv :
     K ⊗[k] ConvolutionDual k H ≃ₗ[K] ConvolutionDual K (K ⊗[k] H) :=
-  LinearEquiv.ofBijective (baseChange (k := k) (K := K) (H := H)) <| by
-    rw [baseChange_coe_eq_baseChangeEquivAux]
-    exact (baseChangeEquivAux (k := k) (K := K) (H := H)).bijective
+  ((WithConv.linearEquiv k _).baseChange k K).trans <|
+    (Module.Dual.baseChangeEquiv (R := k) (A := K) (M := H)).trans <|
+      (WithConv.linearEquiv K _).symm
 
 @[simp]
 private theorem baseChangeLinearEquiv_tmul_apply_tmul
     (a b : K) (φ : ConvolutionDual k H) (x : H) :
     (baseChangeLinearEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv
         (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) :=
-  baseChange_tmul_apply_tmul a b φ x
+  by simp [baseChangeLinearEquiv]
 
-omit [Module.Finite k H] [Module.Projective k H] in
 private theorem baseChange_one :
-    baseChange (k := k) (K := K) (H := H) 1 = 1 := by
-  rw [Algebra.TensorProduct.one_def]
+    baseChangeLinearEquiv (k := k) (K := K) (H := H)
+      (1 ⊗ₜ[k] (1 : ConvolutionDual k H)) = 1 := by
   apply WithConv.ofConv_injective
   ext x
   -- Unwrap `WithConv` after testing the functionals on a pure tensor.
-  change (baseChange (k := k) (K := K) (H := H)
+  change (baseChangeLinearEquiv (k := k) (K := K) (H := H)
       (1 ⊗ₜ[k] (1 : ConvolutionDual k H))).ofConv (1 ⊗ₜ[k] x) =
     (1 : ConvolutionDual K (K ⊗[k] H)).ofConv (1 ⊗ₜ[k] x)
-  rw [baseChange_tmul_apply_tmul]
+  rw [baseChangeLinearEquiv_tmul_apply_tmul]
   simp [Algebra.smul_def]
 
-omit [Module.Finite k H] [Module.Projective k H] in
-private theorem baseChange_mul (z w : K ⊗[k] ConvolutionDual k H) :
-    baseChange (k := k) (K := K) (H := H) (z * w) =
-      baseChange (k := k) (K := K) (H := H) z *
-        baseChange (k := k) (K := K) (H := H) w := by
-  apply LinearMap.map_mul_of_map_mul_tmul
-  intro a b φ ψ
+private theorem baseChange_mul (a b : K) (φ ψ : ConvolutionDual k H) :
+    baseChangeLinearEquiv (k := k) (K := K) (H := H)
+        ((a * b) ⊗ₜ[k] (φ * ψ)) =
+      baseChangeLinearEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ) *
+        baseChangeLinearEquiv (k := k) (K := K) (H := H) (b ⊗ₜ[k] ψ) := by
   apply WithConv.ofConv_injective
   ext x
   -- Unwrap tensor-product multiplication and convolution after evaluation at `1 ⊗ₜ x`.
-  change (baseChange (k := k) (K := K) (H := H)
+  change (baseChangeLinearEquiv (k := k) (K := K) (H := H)
       ((a * b) ⊗ₜ[k] (φ * ψ))).ofConv (1 ⊗ₜ[k] x) =
-    (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ) *
-      baseChange (k := k) (K := K) (H := H) (b ⊗ₜ[k] ψ)).ofConv (1 ⊗ₜ[k] x)
-  rw [baseChange_tmul_apply_tmul]
+    (baseChangeLinearEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ) *
+      baseChangeLinearEquiv (k := k) (K := K) (H := H)
+        (b ⊗ₜ[k] ψ)).ofConv (1 ⊗ₜ[k] x)
+  rw [baseChangeLinearEquiv_tmul_apply_tmul]
   rw [LinearMap.convMul_apply, LinearMap.convMul_apply]
   simp only [TensorProduct.comul_tmul, Bialgebra.comul_one, Algebra.TensorProduct.one_def]
   generalize Coalgebra.comul (R := k) (A := H) x = q
@@ -146,21 +101,22 @@ private theorem baseChange_mul (z w : K ⊗[k] ConvolutionDual k H) :
   | tmul y z =>
       simp only [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
         TensorProduct.map_tmul, LinearMap.mul'_apply,
-        baseChange_tmul_apply_tmul, map_mul]
+        baseChangeLinearEquiv_tmul_apply_tmul, map_mul]
       ring
 
 /-- The scalar-extended evaluation map as an algebra equivalence. -/
 private noncomputable def baseChangeAlgEquiv :
     K ⊗[k] ConvolutionDual k H ≃ₐ[K] ConvolutionDual K (K ⊗[k] H) :=
-  AlgEquiv.ofLinearEquiv (baseChangeLinearEquiv (k := k) (K := K) (H := H))
-    baseChange_one baseChange_mul
+  Algebra.TensorProduct.algEquivOfLinearEquivTensorProduct
+    (baseChangeLinearEquiv (k := k) (K := K) (H := H))
+    baseChange_mul baseChange_one
 
 @[simp]
 private theorem baseChangeAlgEquiv_tmul_apply_tmul
     (a b : K) (φ : ConvolutionDual k H) (x : H) :
     (baseChangeAlgEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv
         (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) :=
-  baseChange_tmul_apply_tmul a b φ x
+  baseChangeLinearEquiv_tmul_apply_tmul a b φ x
 
 /-- The base-change algebra equivalence preserves the finite-dual counit. -/
 private theorem baseChange_counit :
@@ -175,13 +131,13 @@ private theorem baseChange_counit :
   | tmul a φ =>
       -- `AlgHom.comp` and `baseChangeAlgEquiv` reduce to their underlying counit and map.
       change Coalgebra.counit (R := K)
-          (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)) =
+          (baseChangeLinearEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)) =
         Coalgebra.counit (R := K) (a ⊗ₜ[k] φ)
       rw [ConvolutionDual.counit_apply]
       -- The finite-dual counit is evaluation at the tensor-product unit `1 ⊗ₜ 1`.
-      change (baseChange (k := k) (K := K) (H := H)
+      change (baseChangeLinearEquiv (k := k) (K := K) (H := H)
           (a ⊗ₜ[k] φ)).ofConv (1 ⊗ₜ[k] (1 : H)) = _
-      rw [baseChange_tmul_apply_tmul]
+      rw [baseChangeLinearEquiv_tmul_apply_tmul]
       simp [ConvolutionDual.counit_apply, Algebra.smul_def, mul_comm]
 
 /-- The base-change algebra equivalence preserves the finite-dual comultiplication. -/

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
@@ -138,14 +138,6 @@ private theorem baseChangeAlgEquiv_tmul_apply_tmul
   rw [baseChangeAlgEquiv_apply]
   exact baseChangeLinearEquiv_tmul_apply_tmul a b φ x
 
-@[simp]
-private theorem baseChangeAlgEquiv_toAlgHom_tmul_apply_tmul
-    (a b : K) (φ : ConvolutionDual k H) (x : H) :
-    ((baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom (a ⊗ₜ[k] φ)).ofConv
-        (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) := by
-  rw [baseChangeAlgEquiv_toAlgHom_apply]
-  exact baseChangeLinearEquiv_tmul_apply_tmul a b φ x
-
 /-- The base-change algebra equivalence preserves the finite-dual counit. -/
 private theorem baseChangeAlgEquiv_counit_comp :
     (Bialgebra.counitAlgHom K (ConvolutionDual K (K ⊗[k] H))).comp
@@ -188,7 +180,7 @@ private theorem baseChangeAlgEquiv_map_comp_comul :
       intro x y
       rw [ConvolutionDual.dualDistribEquiv_comul_apply]
       simp only [Algebra.TensorProduct.tmul_mul_tmul, one_mul]
-      rw [baseChangeAlgEquiv_toAlgHom_tmul_apply_tmul]
+      rw [AlgEquiv.coe_toAlgHom, baseChangeAlgEquiv_tmul_apply_tmul]
       rw [← ConvolutionDual.dualDistribEquiv_comul_apply k H φ x y]
       simp only [TensorProduct.comul_tmul]
       have comul_self : Coalgebra.comul (R := K) a = a ⊗ₜ[K] 1 :=
@@ -210,7 +202,7 @@ private theorem baseChangeAlgEquiv_map_comp_comul :
             TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
             Algebra.TensorProduct.map_tmul,
             ConvolutionDual.dualDistribEquiv_tmul_apply,
-            baseChangeAlgEquiv_toAlgHom_tmul_apply_tmul, map_mul]
+            AlgEquiv.coe_toAlgHom, baseChangeAlgEquiv_tmul_apply_tmul, map_mul]
           ring
 
 /-- Finite dualization commutes with extension of scalars for finite projective bialgebras. -/

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
@@ -1,0 +1,237 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.HopfAlgebra.TensorProduct
+public import Mathlib.Algebra.Module.Projective
+public import Mathlib.RingTheory.TensorProduct.Finite
+public import TauCeti.Algebra.HopfAlgebra.FiniteDual.Basic
+public import TauCeti.LinearAlgebra.Dual.BaseChange
+
+/-!
+# Base change of the finite dual
+
+The finite dual of a finite projective bialgebra commutes with extension of scalars. More
+precisely, for a map of commutative rings `k → K` and a finite projective `k`-bialgebra `H`,
+there is a canonical `K`-bialgebra equivalence
+
+```text
+K ⊗[k] ConvolutionDual k H ≃ₐc[K] ConvolutionDual K (K ⊗[k] H).
+```
+
+On pure tensors this sends `a ⊗ φ` to the functional taking `b ⊗ x` to
+`a * b * algebraMap k K (φ x)`. This is the affine algebraic base-change square needed to
+transport Cartier duality for finite locally free commutative group schemes over a general base.
+
+## Main declarations
+
+* `TauCeti.ConvolutionDual.baseChangeBialgEquiv`: finite dualization commutes with extension of
+  scalars.
+* `TauCeti.ConvolutionDual.baseChangeBialgEquiv_tmul_apply_tmul`: the equivalence's value on pure
+  tensors.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+* J. S. Milne, *Algebraic Groups* (2017), Section 12.e.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.ConvolutionDual
+
+universe u v w
+
+variable {k : Type u} {K : Type v} {H : Type w}
+variable [CommRing k] [CommRing K] [Algebra k K]
+variable [CommRing H] [Bialgebra k H]
+
+/-- The scalar-extended evaluation map, with convolution wrappers on its source and target. -/
+private noncomputable def baseChangeGenerator :
+    ConvolutionDual k H →ₗ[k] Module.Dual K (K ⊗[k] H) :=
+  Module.Dual.baseChange K ∘ₗ (WithConv.linearEquiv k _).toLinearMap
+
+/-- Extend a convolution-dual functional and restore the convolution wrapper. -/
+private noncomputable def baseChange :
+    K ⊗[k] ConvolutionDual k H →ₗ[K] ConvolutionDual K (K ⊗[k] H) where
+  toFun z := WithConv.toConv
+    ((baseChangeGenerator (k := k) (K := K) (H := H)).liftBaseChange K z)
+  map_add' x y := by apply WithConv.ofConv_injective; simp
+  map_smul' a x := by apply WithConv.ofConv_injective; simp
+
+@[simp]
+private theorem baseChange_tmul_apply_tmul (a b : K) (φ : ConvolutionDual k H) (x : H) :
+    (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv (b ⊗ₜ[k] x) =
+      a * b * algebraMap k K (φ.ofConv x) := by
+  simp [baseChange, baseChangeGenerator, Algebra.smul_def]
+  ac_rfl
+
+variable [Module.Finite k H] [Module.Projective k H]
+
+/-- The underlying bijection of the base-change map, assembled from linear equivalences. -/
+private noncomputable def baseChangeEquivAux :
+    (K ⊗[k] ConvolutionDual k H) ≃ ConvolutionDual K (K ⊗[k] H) :=
+  (TensorProduct.congr (LinearEquiv.refl k K) (WithConv.linearEquiv k _)).toEquiv.trans <|
+    (Module.Dual.baseChangeEquiv (R := k) (A := K) (M := H)).toEquiv.trans <|
+      (WithConv.linearEquiv K _).symm.toEquiv
+
+private theorem baseChange_coe_eq_baseChangeEquivAux :
+    (baseChange (k := k) (K := K) (H := H) :
+      K ⊗[k] ConvolutionDual k H → ConvolutionDual K (K ⊗[k] H)) =
+        baseChangeEquivAux (k := k) (K := K) (H := H) := by
+  funext z
+  induction z using TensorProduct.induction_on with
+  | zero => simp [baseChangeEquivAux]
+  | add z w hz hw =>
+      rw [map_add, hz, hw]
+      simp [baseChangeEquivAux]
+  | tmul a φ =>
+      apply WithConv.ofConv_injective
+      ext x
+      simp [baseChangeEquivAux, baseChange, baseChangeGenerator,
+        Algebra.smul_def]
+
+/-- The scalar-extended evaluation map as a linear equivalence. -/
+private noncomputable def baseChangeLinearEquiv :
+    K ⊗[k] ConvolutionDual k H ≃ₗ[K] ConvolutionDual K (K ⊗[k] H) :=
+  LinearEquiv.ofBijective (baseChange (k := k) (K := K) (H := H)) <| by
+    rw [baseChange_coe_eq_baseChangeEquivAux]
+    exact (baseChangeEquivAux (k := k) (K := K) (H := H)).bijective
+
+@[simp]
+private theorem baseChangeLinearEquiv_tmul_apply_tmul
+    (a b : K) (φ : ConvolutionDual k H) (x : H) :
+    (baseChangeLinearEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv
+        (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) :=
+  baseChange_tmul_apply_tmul a b φ x
+
+omit [Module.Finite k H] [Module.Projective k H] in
+private theorem baseChange_one :
+    baseChange (k := k) (K := K) (H := H) 1 = 1 := by
+  rw [show (1 : K ⊗[k] ConvolutionDual k H) =
+      1 ⊗ₜ[k] (1 : ConvolutionDual k H) by exact Algebra.TensorProduct.one_def]
+  apply WithConv.ofConv_injective
+  ext x
+  change (baseChange (k := k) (K := K) (H := H)
+      (1 ⊗ₜ[k] (1 : ConvolutionDual k H))).ofConv (1 ⊗ₜ[k] x) =
+    (1 : ConvolutionDual K (K ⊗[k] H)).ofConv (1 ⊗ₜ[k] x)
+  rw [baseChange_tmul_apply_tmul]
+  simp [Algebra.smul_def]
+
+omit [Module.Finite k H] [Module.Projective k H] in
+private theorem baseChange_mul (z w : K ⊗[k] ConvolutionDual k H) :
+    baseChange (k := k) (K := K) (H := H) (z * w) =
+      baseChange (k := k) (K := K) (H := H) z *
+        baseChange (k := k) (K := K) (H := H) w := by
+  apply LinearMap.map_mul_of_map_mul_tmul
+  intro a b φ ψ
+  apply WithConv.ofConv_injective
+  ext x
+  change (baseChange (k := k) (K := K) (H := H)
+      ((a * b) ⊗ₜ[k] (φ * ψ))).ofConv (1 ⊗ₜ[k] x) =
+    (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ) *
+      baseChange (k := k) (K := K) (H := H) (b ⊗ₜ[k] ψ)).ofConv (1 ⊗ₜ[k] x)
+  rw [baseChange_tmul_apply_tmul]
+  rw [LinearMap.convMul_apply, LinearMap.convMul_apply]
+  simp only [TensorProduct.comul_tmul, Bialgebra.comul_one, Algebra.TensorProduct.one_def]
+  generalize Coalgebra.comul (R := k) (A := H) x = q
+  induction q using TensorProduct.induction_on with
+  | zero => simp
+  | add q r hq hr =>
+      simp only [map_add, hq, hr, mul_add, TensorProduct.tmul_add]
+  | tmul y z =>
+      simp only [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
+        TensorProduct.map_tmul, LinearMap.mul'_apply,
+        baseChange_tmul_apply_tmul, map_mul]
+      ring
+
+/-- The scalar-extended evaluation map as an algebra equivalence. -/
+private noncomputable def baseChangeAlgEquiv :
+    K ⊗[k] ConvolutionDual k H ≃ₐ[K] ConvolutionDual K (K ⊗[k] H) :=
+  AlgEquiv.ofLinearEquiv (baseChangeLinearEquiv (k := k) (K := K) (H := H))
+    baseChange_one baseChange_mul
+
+@[simp]
+private theorem baseChangeAlgEquiv_tmul_apply_tmul
+    (a b : K) (φ : ConvolutionDual k H) (x : H) :
+    (baseChangeAlgEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv
+        (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) :=
+  baseChange_tmul_apply_tmul a b φ x
+
+/-- Finite dualization commutes with extension of scalars for finite projective bialgebras.
+
+The equivalence preserves the Hopf algebra structure whenever `H` is a Hopf algebra, since
+bialgebra morphisms commute with antipodes. -/
+noncomputable def baseChangeBialgEquiv :
+    K ⊗[k] ConvolutionDual k H ≃ₐc[K] ConvolutionDual K (K ⊗[k] H) :=
+  BialgEquiv.ofAlgEquiv
+    (R := K) (A := K ⊗[k] ConvolutionDual k H)
+    (B := ConvolutionDual K (K ⊗[k] H))
+    (baseChangeAlgEquiv (k := k) (K := K) (H := H))
+    (by
+      apply AlgHom.ext (R := K) (A := K ⊗[k] ConvolutionDual k H) (B := K)
+      intro z
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | add z w hz hw => simp only [map_add, hz, hw]
+      | tmul a φ =>
+          change Coalgebra.counit (R := K)
+              (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)) =
+            Coalgebra.counit (R := K) (a ⊗ₜ[k] φ)
+          rw [ConvolutionDual.counit_apply]
+          change (baseChange (k := k) (K := K) (H := H)
+              (a ⊗ₜ[k] φ)).ofConv (1 ⊗ₜ[k] (1 : H)) = _
+          rw [baseChange_tmul_apply_tmul]
+          simp [ConvolutionDual.counit_apply, Algebra.smul_def, mul_comm])
+    (by
+      apply AlgHom.ext (R := K) (A := K ⊗[k] ConvolutionDual k H)
+        (B := ConvolutionDual K (K ⊗[k] H) ⊗[K] ConvolutionDual K (K ⊗[k] H))
+      intro z
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | add z w hz hw => simp only [map_add, hz, hw]
+      | tmul a φ =>
+          apply (dualDistribEquiv K (K ⊗[k] H)).injective
+          ext x y
+          change dualDistribEquiv K (K ⊗[k] H)
+              ((Algebra.TensorProduct.map
+                (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom
+                (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom)
+                  (Coalgebra.comul (R := K) (a ⊗ₜ[k] φ)))
+                ((1 ⊗ₜ[k] x) ⊗ₜ[K] (1 ⊗ₜ[k] y)) =
+            dualDistribEquiv K (K ⊗[k] H)
+              (Coalgebra.comul (R := K)
+                (baseChangeAlgEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)))
+                ((1 ⊗ₜ[k] x) ⊗ₜ[K] (1 ⊗ₜ[k] y))
+          rw [ConvolutionDual.dualDistribEquiv_comul_apply]
+          simp only [Algebra.TensorProduct.tmul_mul_tmul, one_mul]
+          rw [baseChangeAlgEquiv_tmul_apply_tmul]
+          rw [← ConvolutionDual.dualDistribEquiv_comul_apply k H φ x y]
+          simp only [TensorProduct.comul_tmul]
+          generalize Coalgebra.comul (R := k) (A := ConvolutionDual k H) φ = q
+          induction q using TensorProduct.induction_on with
+          | zero => simp
+          | add q r hq hr =>
+              simp only [TensorProduct.tmul_add, map_add, hq, hr,
+                LinearMap.add_apply, mul_add]
+          | tmul ψ χ =>
+              simp [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
+                baseChangeAlgEquiv_tmul_apply_tmul, map_mul]
+              ring)
+
+/-- The base-change equivalence evaluates pure tensors by scalar-extended evaluation. -/
+@[simp]
+theorem baseChangeBialgEquiv_tmul_apply_tmul (a b : K)
+    (φ : ConvolutionDual k H) (x : H) :
+    (baseChangeBialgEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv
+        (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) := by
+  rw [baseChangeBialgEquiv, BialgEquiv.ofAlgEquiv_apply]
+  change (baseChange (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv
+    (b ⊗ₜ[k] x) = _
+  exact baseChange_tmul_apply_tmul a b φ x
+
+end TauCeti.ConvolutionDual

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
@@ -148,7 +148,7 @@ private theorem baseChangeAlgEquiv_counit_comp :
       simp only [AlgHom.comp_apply, Bialgebra.counitAlgHom_apply]
       rw [AlgEquiv.coe_toAlgHom, baseChangeAlgEquiv_apply]
       rw [ConvolutionDual.counit_apply]
-      rw [show (1 : K ⊗[k] H) = 1 ⊗ₜ[k] 1 from Algebra.TensorProduct.one_def]
+      rw [Algebra.TensorProduct.one_def]
       rw [baseChangeLinearEquiv_tmul_apply_tmul]
       simp only [TensorProduct.counit_tmul, ConvolutionDual.counit_apply,
         CommSemiring.counit_apply, Algebra.smul_def, mul_one, mul_comm]

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.HopfAlgebra.TensorProduct
+public import Mathlib.RingTheory.Bialgebra.TensorProduct
 public import Mathlib.RingTheory.TensorProduct.Finite
 public import TauCeti.Algebra.HopfAlgebra.FiniteDual.Basic
 public import TauCeti.LinearAlgebra.Dual.BaseChange
@@ -55,7 +55,7 @@ variable [Module.Finite k H] [Module.Projective k H]
 private noncomputable def baseChangeLinearEquiv :
     K ⊗[k] ConvolutionDual k H ≃ₗ[K] ConvolutionDual K (K ⊗[k] H) :=
   ((WithConv.linearEquiv k _).baseChange k K).trans <|
-    (Module.Dual.baseChangeEquiv (R := k) (A := K) (M := H)).trans <|
+    (Module.Dual.baseChangeEvaluationEquiv (R := k) (A := K) (M := H)).trans <|
       (WithConv.linearEquiv K _).symm
 
 @[simp]
@@ -65,31 +65,39 @@ private theorem baseChangeLinearEquiv_tmul_apply_tmul
         (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) :=
   by simp [baseChangeLinearEquiv]
 
-private theorem baseChange_one :
-    baseChangeLinearEquiv (k := k) (K := K) (H := H)
-      (1 ⊗ₜ[k] (1 : ConvolutionDual k H)) = 1 := by
+omit [Module.Finite k H] [Module.Projective k H] in
+private theorem ofConv_ext {φ ψ : ConvolutionDual K (K ⊗[k] H)}
+    (h : ∀ x : H, φ.ofConv (1 ⊗ₜ[k] x) = ψ.ofConv (1 ⊗ₜ[k] x)) : φ = ψ := by
   apply WithConv.ofConv_injective
   ext x
-  -- Unwrap `WithConv` after testing the functionals on a pure tensor.
-  change (baseChangeLinearEquiv (k := k) (K := K) (H := H)
-      (1 ⊗ₜ[k] (1 : ConvolutionDual k H))).ofConv (1 ⊗ₜ[k] x) =
-    (1 : ConvolutionDual K (K ⊗[k] H)).ofConv (1 ⊗ₜ[k] x)
-  rw [baseChangeLinearEquiv_tmul_apply_tmul]
-  simp [Algebra.smul_def]
+  exact h x
 
-private theorem baseChange_mul (a b : K) (φ ψ : ConvolutionDual k H) :
+private theorem dualDistribEquiv_ext
+    {w z : ConvolutionDual K (K ⊗[k] H) ⊗[K] ConvolutionDual K (K ⊗[k] H)}
+    (h : ∀ x y : H,
+      dualDistribEquiv K (K ⊗[k] H) w ((1 ⊗ₜ[k] x) ⊗ₜ[K] (1 ⊗ₜ[k] y)) =
+        dualDistribEquiv K (K ⊗[k] H) z ((1 ⊗ₜ[k] x) ⊗ₜ[K] (1 ⊗ₜ[k] y))) :
+    w = z := by
+  apply (dualDistribEquiv K (K ⊗[k] H)).injective
+  ext x y
+  exact h x y
+
+private theorem baseChangeLinearEquiv_one :
+    baseChangeLinearEquiv (k := k) (K := K) (H := H)
+      (1 ⊗ₜ[k] (1 : ConvolutionDual k H)) = 1 := by
+  apply ofConv_ext
+  intro x
+  rw [baseChangeLinearEquiv_tmul_apply_tmul]
+  simp only [LinearMap.convOne_apply, TensorProduct.counit_tmul,
+    Bialgebra.counit_one, Algebra.algebraMap_self_apply, Algebra.smul_def, mul_one, one_mul]
+
+private theorem baseChangeLinearEquiv_mul (a b : K) (φ ψ : ConvolutionDual k H) :
     baseChangeLinearEquiv (k := k) (K := K) (H := H)
         ((a * b) ⊗ₜ[k] (φ * ψ)) =
       baseChangeLinearEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ) *
         baseChangeLinearEquiv (k := k) (K := K) (H := H) (b ⊗ₜ[k] ψ) := by
-  apply WithConv.ofConv_injective
-  ext x
-  -- Unwrap tensor-product multiplication and convolution after evaluation at `1 ⊗ₜ x`.
-  change (baseChangeLinearEquiv (k := k) (K := K) (H := H)
-      ((a * b) ⊗ₜ[k] (φ * ψ))).ofConv (1 ⊗ₜ[k] x) =
-    (baseChangeLinearEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ) *
-      baseChangeLinearEquiv (k := k) (K := K) (H := H)
-        (b ⊗ₜ[k] ψ)).ofConv (1 ⊗ₜ[k] x)
+  apply ofConv_ext
+  intro x
   rw [baseChangeLinearEquiv_tmul_apply_tmul]
   rw [LinearMap.convMul_apply, LinearMap.convMul_apply]
   simp only [TensorProduct.comul_tmul, Bialgebra.comul_one, Algebra.TensorProduct.one_def]
@@ -109,13 +117,18 @@ private noncomputable def baseChangeAlgEquiv :
     K ⊗[k] ConvolutionDual k H ≃ₐ[K] ConvolutionDual K (K ⊗[k] H) :=
   Algebra.TensorProduct.algEquivOfLinearEquivTensorProduct
     (baseChangeLinearEquiv (k := k) (K := K) (H := H))
-    baseChange_mul baseChange_one
+    baseChangeLinearEquiv_mul baseChangeLinearEquiv_one
 
 private theorem baseChangeAlgEquiv_apply (z : K ⊗[k] ConvolutionDual k H) :
     baseChangeAlgEquiv (k := k) (K := K) (H := H) z =
       baseChangeLinearEquiv (k := k) (K := K) (H := H) z := by
   rw [baseChangeAlgEquiv,
     Algebra.TensorProduct.algEquivOfLinearEquivTensorProduct_apply]
+
+private theorem baseChangeAlgEquiv_toAlgHom_apply (z : K ⊗[k] ConvolutionDual k H) :
+    (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom z =
+      baseChangeLinearEquiv (k := k) (K := K) (H := H) z :=
+  baseChangeAlgEquiv_apply z
 
 @[simp]
 private theorem baseChangeAlgEquiv_tmul_apply_tmul
@@ -125,8 +138,16 @@ private theorem baseChangeAlgEquiv_tmul_apply_tmul
   rw [baseChangeAlgEquiv_apply]
   exact baseChangeLinearEquiv_tmul_apply_tmul a b φ x
 
+@[simp]
+private theorem baseChangeAlgEquiv_toAlgHom_tmul_apply_tmul
+    (a b : K) (φ : ConvolutionDual k H) (x : H) :
+    ((baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom (a ⊗ₜ[k] φ)).ofConv
+        (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) := by
+  rw [baseChangeAlgEquiv_toAlgHom_apply]
+  exact baseChangeLinearEquiv_tmul_apply_tmul a b φ x
+
 /-- The base-change algebra equivalence preserves the finite-dual counit. -/
-private theorem baseChange_counit :
+private theorem baseChangeAlgEquiv_counit_comp :
     (Bialgebra.counitAlgHom K (ConvolutionDual K (K ⊗[k] H))).comp
         (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom =
       Bialgebra.counitAlgHom K (K ⊗[k] ConvolutionDual k H) := by
@@ -136,19 +157,19 @@ private theorem baseChange_counit :
   | zero => simp
   | add z w hz hw => simp only [map_add, hz, hw]
   | tmul a φ =>
-      -- `AlgHom.comp` and `baseChangeAlgEquiv` reduce to their underlying counit and map.
-      change Coalgebra.counit (R := K)
-          (baseChangeLinearEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)) =
-        Coalgebra.counit (R := K) (a ⊗ₜ[k] φ)
+      simp only [AlgHom.comp_apply, Bialgebra.counitAlgHom_apply]
+      rw [baseChangeAlgEquiv_toAlgHom_apply]
       rw [ConvolutionDual.counit_apply]
-      -- The finite-dual counit is evaluation at the tensor-product unit `1 ⊗ₜ 1`.
-      change (baseChangeLinearEquiv (k := k) (K := K) (H := H)
-          (a ⊗ₜ[k] φ)).ofConv (1 ⊗ₜ[k] (1 : H)) = _
+      rw [show (1 : K ⊗[k] H) = 1 ⊗ₜ[k] 1 from Algebra.TensorProduct.one_def]
       rw [baseChangeLinearEquiv_tmul_apply_tmul]
-      simp [ConvolutionDual.counit_apply, Algebra.smul_def, mul_comm]
+      have counit_self : Coalgebra.counit (R := K) a = a := by
+        rw [← Bialgebra.counitAlgHom_apply, Bialgebra.counitAlgHom_self]
+        rfl
+      simp only [TensorProduct.counit_tmul, ConvolutionDual.counit_apply,
+        Algebra.smul_def, mul_one, mul_comm, counit_self]
 
 /-- The base-change algebra equivalence preserves the finite-dual comultiplication. -/
-private theorem baseChange_comul :
+private theorem baseChangeAlgEquiv_map_comp_comul :
     (Algebra.TensorProduct.map
         (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom
         (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom).comp
@@ -162,24 +183,22 @@ private theorem baseChange_comul :
   | zero => simp
   | add z w hz hw => simp only [map_add, hz, hw]
   | tmul a φ =>
-      apply (dualDistribEquiv K (K ⊗[k] H)).injective
-      ext x y
-      -- Unwrap the two composed bialgebra maps, then compare distributions on pure tensors.
-      change dualDistribEquiv K (K ⊗[k] H)
-          ((Algebra.TensorProduct.map
-            (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom
-            (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom)
-              (Coalgebra.comul (R := K) (a ⊗ₜ[k] φ)))
-            ((1 ⊗ₜ[k] x) ⊗ₜ[K] (1 ⊗ₜ[k] y)) =
-        dualDistribEquiv K (K ⊗[k] H)
-          (Coalgebra.comul (R := K)
-            (baseChangeAlgEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)))
-            ((1 ⊗ₜ[k] x) ⊗ₜ[K] (1 ⊗ₜ[k] y))
+      simp only [AlgHom.comp_apply, Bialgebra.comulAlgHom_apply]
+      apply dualDistribEquiv_ext
+      intro x y
       rw [ConvolutionDual.dualDistribEquiv_comul_apply]
       simp only [Algebra.TensorProduct.tmul_mul_tmul, one_mul]
-      rw [baseChangeAlgEquiv_tmul_apply_tmul]
+      rw [baseChangeAlgEquiv_toAlgHom_tmul_apply_tmul]
       rw [← ConvolutionDual.dualDistribEquiv_comul_apply k H φ x y]
       simp only [TensorProduct.comul_tmul]
+      have comul_self : Coalgebra.comul (R := K) a = a ⊗ₜ[K] 1 :=
+        calc
+          Coalgebra.comul (R := K) a =
+              Coalgebra.comul (R := K) (algebraMap K K a) := by
+            rw [Algebra.algebraMap_self_apply]
+          _ = algebraMap K (K ⊗[K] K) a := Bialgebra.comul_algebraMap a
+          _ = a ⊗ₜ[K] 1 := by
+            rw [Algebra.TensorProduct.algebraMap_apply, Algebra.algebraMap_self_apply]
       generalize Coalgebra.comul (R := k) (A := ConvolutionDual k H) φ = q
       induction q using TensorProduct.induction_on with
       | zero => simp
@@ -187,21 +206,21 @@ private theorem baseChange_comul :
           simp only [TensorProduct.tmul_add, map_add, hq, hr,
             LinearMap.add_apply, mul_add]
       | tmul ψ χ =>
-          simp [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
-            baseChangeAlgEquiv_tmul_apply_tmul, map_mul]
+          simp only [comul_self,
+            TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
+            Algebra.TensorProduct.map_tmul,
+            ConvolutionDual.dualDistribEquiv_tmul_apply,
+            baseChangeAlgEquiv_toAlgHom_tmul_apply_tmul, map_mul]
           ring
 
-/-- Finite dualization commutes with extension of scalars for finite projective bialgebras.
-
-The equivalence preserves the Hopf algebra structure whenever `H` is a Hopf algebra, since
-bialgebra morphisms commute with antipodes. -/
+/-- Finite dualization commutes with extension of scalars for finite projective bialgebras. -/
 noncomputable def baseChangeBialgEquiv :
     K ⊗[k] ConvolutionDual k H ≃ₐc[K] ConvolutionDual K (K ⊗[k] H) :=
   BialgEquiv.ofAlgEquiv
     (R := K) (A := K ⊗[k] ConvolutionDual k H)
     (B := ConvolutionDual K (K ⊗[k] H))
     (baseChangeAlgEquiv (k := k) (K := K) (H := H))
-    baseChange_counit baseChange_comul
+    baseChangeAlgEquiv_counit_comp baseChangeAlgEquiv_map_comp_comul
 
 /-- The base-change equivalence evaluates pure tensors by scalar-extended evaluation. -/
 @[simp]

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
@@ -6,7 +6,7 @@ module
 
 public import Mathlib.RingTheory.Bialgebra.TensorProduct
 public import Mathlib.RingTheory.TensorProduct.Finite
-public import TauCeti.Algebra.HopfAlgebra.FiniteDual.Basic
+public import TauCeti.Algebra.HopfAlgebra.FiniteDual.Functoriality
 public import TauCeti.LinearAlgebra.Dual.BaseChange
 
 /-!
@@ -30,6 +30,7 @@ transport Cartier duality for finite locally free commutative group schemes over
   scalars.
 * `TauCeti.ConvolutionDual.baseChangeBialgEquiv_tmul_apply_tmul`: the equivalence's value on pure
   tensors.
+* `TauCeti.ConvolutionDual.baseChangeBialgEquiv_naturality`: compatibility with finite-dual maps.
 
 ## References
 
@@ -43,7 +44,7 @@ open scoped TensorProduct
 
 namespace TauCeti.ConvolutionDual
 
-universe u v w
+universe u v w x
 
 variable {k : Type u} {K : Type v} {H : Type w}
 variable [CommRing k] [CommRing K] [Algebra k K]
@@ -125,11 +126,6 @@ private theorem baseChangeAlgEquiv_apply (z : K ⊗[k] ConvolutionDual k H) :
   rw [baseChangeAlgEquiv,
     Algebra.TensorProduct.algEquivOfLinearEquivTensorProduct_apply]
 
-private theorem baseChangeAlgEquiv_toAlgHom_apply (z : K ⊗[k] ConvolutionDual k H) :
-    (baseChangeAlgEquiv (k := k) (K := K) (H := H)).toAlgHom z =
-      baseChangeLinearEquiv (k := k) (K := K) (H := H) z :=
-  baseChangeAlgEquiv_apply z
-
 @[simp]
 private theorem baseChangeAlgEquiv_tmul_apply_tmul
     (a b : K) (φ : ConvolutionDual k H) (x : H) :
@@ -150,15 +146,12 @@ private theorem baseChangeAlgEquiv_counit_comp :
   | add z w hz hw => simp only [map_add, hz, hw]
   | tmul a φ =>
       simp only [AlgHom.comp_apply, Bialgebra.counitAlgHom_apply]
-      rw [baseChangeAlgEquiv_toAlgHom_apply]
+      rw [AlgEquiv.coe_toAlgHom, baseChangeAlgEquiv_apply]
       rw [ConvolutionDual.counit_apply]
       rw [show (1 : K ⊗[k] H) = 1 ⊗ₜ[k] 1 from Algebra.TensorProduct.one_def]
       rw [baseChangeLinearEquiv_tmul_apply_tmul]
-      have counit_self : Coalgebra.counit (R := K) a = a := by
-        rw [← Bialgebra.counitAlgHom_apply, Bialgebra.counitAlgHom_self]
-        rfl
       simp only [TensorProduct.counit_tmul, ConvolutionDual.counit_apply,
-        Algebra.smul_def, mul_one, mul_comm, counit_self]
+        CommSemiring.counit_apply, Algebra.smul_def, mul_one, mul_comm]
 
 /-- The base-change algebra equivalence preserves the finite-dual comultiplication. -/
 private theorem baseChangeAlgEquiv_map_comp_comul :
@@ -185,12 +178,11 @@ private theorem baseChangeAlgEquiv_map_comp_comul :
       simp only [TensorProduct.comul_tmul]
       have comul_self : Coalgebra.comul (R := K) a = a ⊗ₜ[K] 1 :=
         calc
-          Coalgebra.comul (R := K) a =
-              Coalgebra.comul (R := K) (algebraMap K K a) := by
-            rw [Algebra.algebraMap_self_apply]
-          _ = algebraMap K (K ⊗[K] K) a := Bialgebra.comul_algebraMap a
+          Coalgebra.comul (R := K) a = 1 ⊗ₜ[K] a := CommSemiring.comul_apply K a
+          _ = 1 ⊗ₜ[K] (a • (1 : K)) := by rw [smul_eq_mul, mul_one]
+          _ = (a • (1 : K)) ⊗ₜ[K] 1 := TensorProduct.tmul_smul _ _ _
           _ = a ⊗ₜ[K] 1 := by
-            rw [Algebra.TensorProduct.algebraMap_apply, Algebra.algebraMap_self_apply]
+            rw [smul_eq_mul, mul_one]
       generalize Coalgebra.comul (R := k) (A := ConvolutionDual k H) φ = q
       induction q using TensorProduct.induction_on with
       | zero => simp
@@ -206,7 +198,10 @@ private theorem baseChangeAlgEquiv_map_comp_comul :
           ring
 
 /-- Finite dualization commutes with extension of scalars for finite projective bialgebras. -/
-noncomputable def baseChangeBialgEquiv :
+noncomputable def baseChangeBialgEquiv (k : Type u) (K : Type v) (H : Type w)
+    [CommRing k] [CommRing K] [Algebra k K]
+    [Semiring H] [Bialgebra k H]
+    [Module.Finite k H] [Module.Projective k H] :
     K ⊗[k] ConvolutionDual k H ≃ₐc[K] ConvolutionDual K (K ⊗[k] H) :=
   BialgEquiv.ofAlgEquiv
     (R := K) (A := K ⊗[k] ConvolutionDual k H)
@@ -215,12 +210,30 @@ noncomputable def baseChangeBialgEquiv :
     baseChangeAlgEquiv_counit_comp baseChangeAlgEquiv_map_comp_comul
 
 /-- The base-change equivalence evaluates pure tensors by scalar-extended evaluation. -/
-@[simp]
+@[simp, grind =]
 theorem baseChangeBialgEquiv_tmul_apply_tmul (a b : K)
     (φ : ConvolutionDual k H) (x : H) :
-    (baseChangeBialgEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv
+    (baseChangeBialgEquiv k K H (a ⊗ₜ[k] φ)).ofConv
         (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) := by
   rw [baseChangeBialgEquiv, BialgEquiv.ofAlgEquiv_apply]
   exact baseChangeAlgEquiv_tmul_apply_tmul a b φ x
+
+/-- The finite-dual base-change equivalence is natural in finite projective bialgebras. -/
+theorem baseChangeBialgEquiv_naturality {H' : Type x} [Semiring H'] [Bialgebra k H']
+    [Module.Finite k H'] [Module.Projective k H'] (f : H →ₐc[k] H') :
+    (map K (Bialgebra.TensorProduct.map (BialgHom.id K K) f)).comp
+        (baseChangeBialgEquiv k K H') =
+      (baseChangeBialgEquiv k K H :
+        K ⊗[k] ConvolutionDual k H →ₐc[K] ConvolutionDual K (K ⊗[k] H)).comp
+        (Bialgebra.TensorProduct.map (BialgHom.id K K) (map k f)) := by
+  ext z x
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z w hz hw =>
+      simpa only [map_add, WithConv.ofConv_add,
+        TensorProduct.AlgebraTensorModule.curry_apply, TensorProduct.curry_apply,
+        LinearMap.restrictScalars_apply, LinearMap.add_apply] using
+        congrArg₂ (fun a b => a + b) hz hw
+  | tmul a φ => simp
 
 end TauCeti.ConvolutionDual

--- a/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
+++ b/TauCeti/Algebra/HopfAlgebra/FiniteDual/BaseChange.lean
@@ -111,12 +111,19 @@ private noncomputable def baseChangeAlgEquiv :
     (baseChangeLinearEquiv (k := k) (K := K) (H := H))
     baseChange_mul baseChange_one
 
+private theorem baseChangeAlgEquiv_apply (z : K ⊗[k] ConvolutionDual k H) :
+    baseChangeAlgEquiv (k := k) (K := K) (H := H) z =
+      baseChangeLinearEquiv (k := k) (K := K) (H := H) z := by
+  rw [baseChangeAlgEquiv,
+    Algebra.TensorProduct.algEquivOfLinearEquivTensorProduct_apply]
+
 @[simp]
 private theorem baseChangeAlgEquiv_tmul_apply_tmul
     (a b : K) (φ : ConvolutionDual k H) (x : H) :
     (baseChangeAlgEquiv (k := k) (K := K) (H := H) (a ⊗ₜ[k] φ)).ofConv
-        (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) :=
-  baseChangeLinearEquiv_tmul_apply_tmul a b φ x
+        (b ⊗ₜ[k] x) = a * b * algebraMap k K (φ.ofConv x) := by
+  rw [baseChangeAlgEquiv_apply]
+  exact baseChangeLinearEquiv_tmul_apply_tmul a b φ x
 
 /-- The base-change algebra equivalence preserves the finite-dual counit. -/
 private theorem baseChange_counit :

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -5,15 +5,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.Dual.BaseChange
+import Mathlib.LinearAlgebra.Contraction
 
 /-!
 # Evaluation after scalar extension
 
 This file defines the canonical pairing between the scalar extensions of a module and its linear
 dual. It sends an `R`-linear functional extended to `A` to the corresponding `A`-linear functional
-on the scalar extension of its domain. No finiteness hypothesis is required, and the construction
-is not asserted to identify the scalar extension of the dual with the full dual of the scalar
-extension.
+on the scalar extension of its domain. For a finite projective module, this map is an equivalence.
 
 ## Main declarations
 
@@ -21,6 +20,8 @@ extension.
 * `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul`: evaluation at a scalar-extended
   functional with coefficient one is its base change.
 * `TauCeti.Module.Dual.baseChangeEvaluation_tmul`: its value on two pure tensors.
+* `TauCeti.Module.Dual.baseChangeEquiv`: scalar extension commutes with the dual of a finite
+  projective module.
 * `TauCeti.Module.Dual.baseChange_coord`: base-changed dual basis elements recover the
   coordinates in the base-changed basis.
 * `TauCeti.Module.Dual.eq_of_baseChange_eq`: base changes of all dual elements jointly
@@ -63,6 +64,47 @@ theorem baseChangeEvaluation_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
     Module.Dual.baseChange_apply_tmul, Algebra.smul_def]
   rw [Algebra.algebraMap_self_apply]
   ac_rfl
+
+section FiniteProjective
+
+variable [Module.Finite R M] [Module.Projective R M]
+
+/-- The scalar extension of the dual of a finite projective module is canonically equivalent to
+the dual of its scalar extension. -/
+private noncomputable def baseChangeEquivRestrictScalars :
+    A ⊗[R] Module.Dual R M ≃ₗ[R] Module.Dual A (A ⊗[R] M) :=
+  (TensorProduct.comm R A (Module.Dual R M)).trans
+    (dualTensorHomEquiv R M A) |>.trans
+      ((LinearMap.liftBaseChangeEquiv A).restrictScalars R)
+
+private theorem baseChangeEquivRestrictScalars_toLinearMap :
+    (baseChangeEquivRestrictScalars (R := R) (A := A) (M := M)).toLinearMap =
+      (baseChangeEvaluation (R := R) (M := M) (A := A)).restrictScalars R := by
+  ext a φ b
+  simp [baseChangeEquivRestrictScalars, baseChangeEvaluation]
+
+/-- Scalar extension commutes with the linear dual of a finite projective module. -/
+noncomputable def baseChangeEquiv :
+    A ⊗[R] Module.Dual R M ≃ₗ[A] Module.Dual A (A ⊗[R] M) :=
+  LinearEquiv.ofBijective (baseChangeEvaluation (R := R) (M := M) (A := A)) <| by
+    rw [← LinearMap.coe_restrictScalars R]
+    rw [← baseChangeEquivRestrictScalars_toLinearMap]
+    exact (baseChangeEquivRestrictScalars (R := R) (A := A) (M := M)).bijective
+
+/-- The finite-projective equivalence is the canonical scalar-extended evaluation map. -/
+@[simp]
+theorem baseChangeEquiv_apply (z : A ⊗[R] Module.Dual R M) :
+    baseChangeEquiv (R := R) (A := A) (M := M) z =
+      baseChangeEvaluation (R := R) (M := M) (A := A) z :=
+  by simp only [baseChangeEquiv, LinearEquiv.ofBijective_apply]
+
+/-- The finite-projective base-change equivalence has the expected evaluation on pure tensors. -/
+theorem baseChangeEquiv_tmul_apply_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
+    baseChangeEquiv (R := R) (A := A) (M := M) (a ⊗ₜ[R] φ) (b ⊗ₜ[R] m) =
+      a * b * algebraMap R A (φ m) :=
+  baseChangeEvaluation_tmul a b φ m
+
+end FiniteProjective
 
 /-- A coordinate in a base-changed basis is evaluation against the base change of the
 corresponding element of the dual basis. -/

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -106,8 +106,9 @@ theorem baseChangeEquiv_apply (z : A ⊗[R] Module.Dual R M) :
 /-- The finite-projective base-change equivalence has the expected evaluation on pure tensors. -/
 theorem baseChangeEquiv_tmul_apply_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
     baseChangeEquiv (R := R) (A := A) (M := M) (a ⊗ₜ[R] φ) (b ⊗ₜ[R] m) =
-      a * b * algebraMap R A (φ m) :=
-  baseChangeEvaluation_tmul a b φ m
+      a * b * algebraMap R A (φ m) := by
+  rw [baseChangeEquiv_apply]
+  exact baseChangeEvaluation_tmul a b φ m
 
 end FiniteProjective
 

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -20,8 +20,8 @@ on the scalar extension of its domain. For a finite projective module, this map 
 * `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul`: evaluation at a scalar-extended
   functional with coefficient one is its base change.
 * `TauCeti.Module.Dual.baseChangeEvaluation_tmul`: its value on two pure tensors.
-* `TauCeti.Module.Dual.baseChangeEquiv`: scalar extension commutes with the dual of a finite
-  projective module.
+* `TauCeti.Module.Dual.baseChangeEvaluationEquiv`: scalar extension commutes with the dual of a
+  finite projective module.
 * `TauCeti.Module.Dual.baseChange_coord`: base-changed dual basis elements recover the
   coordinates in the base-changed basis.
 * `TauCeti.Module.Dual.eq_of_baseChange_eq`: base changes of all dual elements jointly
@@ -48,7 +48,8 @@ variable [CommSemiring A] [Algebra R A]
 /-- The canonical pairing of scalar extensions, as the map sending a scalar-extended
 `R`-linear functional to an `A`-linear functional on the scalar extension of its domain.
 
-This map requires no finiteness hypothesis and is not asserted to be an equivalence. -/
+This map needs no finiteness hypothesis; for finite projective `M` it is an equivalence, see
+`baseChangeEvaluationEquiv`. -/
 def baseChangeEvaluation :
     A ⊗[R] Module.Dual R M →ₗ[A] Module.Dual A (A ⊗[R] M) :=
   (Module.Dual.baseChange A).liftBaseChange A
@@ -76,39 +77,32 @@ variable [Module.Finite R M] [Module.Projective R M]
 
 /-- The scalar extension of the dual of a finite projective module is canonically equivalent to
 the dual of its scalar extension. -/
-private noncomputable def baseChangeEquivRestrictScalars :
+private noncomputable def baseChangeEvaluationEquivRestrictScalars :
     A ⊗[R] Module.Dual R M ≃ₗ[R] Module.Dual A (A ⊗[R] M) :=
   (TensorProduct.comm R A (Module.Dual R M)).trans
     (dualTensorHomEquiv R M A) |>.trans
       ((LinearMap.liftBaseChangeEquiv A).restrictScalars R)
 
-private theorem baseChangeEquivRestrictScalars_toLinearMap :
-    (baseChangeEquivRestrictScalars (R := R) (A := A) (M := M)).toLinearMap =
+private theorem baseChangeEvaluationEquivRestrictScalars_toLinearMap :
+    (baseChangeEvaluationEquivRestrictScalars (R := R) (A := A) (M := M)).toLinearMap =
       (baseChangeEvaluation (R := R) (M := M) (A := A)).restrictScalars R := by
   ext a φ b
-  simp [baseChangeEquivRestrictScalars, baseChangeEvaluation]
+  simp [baseChangeEvaluationEquivRestrictScalars, baseChangeEvaluation]
 
 /-- Scalar extension commutes with the linear dual of a finite projective module. -/
-noncomputable def baseChangeEquiv :
+noncomputable def baseChangeEvaluationEquiv :
     A ⊗[R] Module.Dual R M ≃ₗ[A] Module.Dual A (A ⊗[R] M) :=
   LinearEquiv.ofBijective (baseChangeEvaluation (R := R) (M := M) (A := A)) <| by
     rw [← LinearMap.coe_restrictScalars R]
-    rw [← baseChangeEquivRestrictScalars_toLinearMap]
-    exact (baseChangeEquivRestrictScalars (R := R) (A := A) (M := M)).bijective
+    rw [← baseChangeEvaluationEquivRestrictScalars_toLinearMap]
+    exact (baseChangeEvaluationEquivRestrictScalars (R := R) (A := A) (M := M)).bijective
 
 /-- The finite-projective equivalence is the canonical scalar-extended evaluation map. -/
 @[simp]
-theorem baseChangeEquiv_apply (z : A ⊗[R] Module.Dual R M) :
-    baseChangeEquiv (R := R) (A := A) (M := M) z =
+theorem baseChangeEvaluationEquiv_apply (z : A ⊗[R] Module.Dual R M) :
+    baseChangeEvaluationEquiv (R := R) (A := A) (M := M) z =
       baseChangeEvaluation (R := R) (M := M) (A := A) z :=
-  by simp only [baseChangeEquiv, LinearEquiv.ofBijective_apply]
-
-/-- The finite-projective base-change equivalence has the expected evaluation on pure tensors. -/
-theorem baseChangeEquiv_tmul_apply_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
-    baseChangeEquiv (R := R) (A := A) (M := M) (a ⊗ₜ[R] φ) (b ⊗ₜ[R] m) =
-      a * b * algebraMap R A (φ m) := by
-  rw [baseChangeEquiv_apply]
-  exact baseChangeEvaluation_tmul a b φ m
+  by simp only [baseChangeEvaluationEquiv, LinearEquiv.ofBijective_apply]
 
 end FiniteProjective
 

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -26,6 +26,11 @@ on the scalar extension of its domain. For a finite projective module, this map 
   coordinates in the base-changed basis.
 * `TauCeti.Module.Dual.eq_of_baseChange_eq`: base changes of all dual elements jointly
   separate vectors when the original module is free.
+
+## References
+
+The finite-projective equivalence is assembled from Mathlib's `dualTensorHomEquiv` and
+`LinearMap.liftBaseChangeEquiv`.
 -/
 
 public section


### PR DESCRIPTION
This PR makes the finite dual of a finite projective bialgebra commute with arbitrary extension of scalars. It advances the Cartier-duality lane identified in [`ReductiveGroups/README.md` Layer 4](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/ReductiveGroups/README.md#layer-4-jordan-decomposition-diagonalizable-groups-tori), where Cartier duality proper is described as the duality of finite locally free commutative group schemes; the corresponding [`STATUS.md`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/ReductiveGroups/STATUS.md) records that Layer 4 currently has no Cartier duality. This PR supplies the affine base-change compatibility needed to extend the existing field-level `Spec` transport in `TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality.lean` to a general base.

The change proves the general finite-projective linear equivalence `A ⊗[R] Dual R M ≃ₗ[A] Dual A (A ⊗[R] M)` from Mathlib's `dualTensorHomEquiv` and `LinearMap.liftBaseChangeEquiv`, then lifts it to the canonical bialgebra equivalence `K ⊗[k] ConvolutionDual k H ≃ₐc[K] ConvolutionDual K (K ⊗[k] H)`. The proof checks convolution multiplication, counit, and comultiplication directly through the finite-projective dual-distribution pairing, and records the pure-tensor evaluation formula.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"cartier-duality-base-change"}-->

🤖 Prepared with Codex
