### PR TITLE
feat: add identity-component point translations

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -72,6 +72,7 @@ theorem rightTranslationAlgHom_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
   | add z w hz hw => simp [hz, hw]
   | tmul z w => simp [Algebra.smul_def, mul_comm]
 
+/-- The linear equivalence underlying right translation. -/
 private noncomputable def rightTranslationLinearEquiv (g : WithConv (H →ₐ[k] k)) :
     H ≃ₗ[k] H :=
   (TensorProduct.lid k H).symm.trans
@@ -144,10 +145,9 @@ theorem counitAlgHom_comp_rightTranslationAlgHom (g : WithConv (H →ₐ[k] k)) 
 @[simp]
 theorem comap_rightTranslationAlgEquiv_augmentationPoint
     (g : WithConv (H →ₐ[k] k)) :
-    PrimeSpectrum.comap ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H)
+    PrimeSpectrum.comap (rightTranslationAlgEquiv g)
         (Bialgebra.augmentationPoint k H) =
       AlgHom.kernelPoint g.ofConv := by
-  rw [AlgEquiv.toRingEquiv_toRingHom]
   change PrimeSpectrum.comap
       ((rightTranslationAlgEquiv g).toAlgHom : H →+* H)
         (AlgHom.kernelPoint (_root_.Bialgebra.counitAlgHom k H)) =
@@ -174,10 +174,10 @@ theorem rightTranslationHomeomorph_apply (g : WithConv (H →ₐ[k] k))
 @[simp]
 theorem rightTranslationHomeomorph_augmentationPoint
     (g : WithConv (H →ₐ[k] k)) :
-    rightTranslationHomeomorph g (Bialgebra.augmentationPoint k H) =
+    PrimeSpectrum.comap (rightTranslationAlgEquiv g)
+        (Bialgebra.augmentationPoint k H) =
       AlgHom.kernelPoint g.ofConv := by
-  rw [rightTranslationHomeomorph_apply,
-    comap_rightTranslationAlgEquiv_augmentationPoint]
+  rw [comap_rightTranslationAlgEquiv_augmentationPoint]
 
 /-- Right translation transports the connected component of a point to the connected component
 of its translate. -/
@@ -199,6 +199,7 @@ theorem rightTranslation_preserves_augmentationPoint_connectedComponent
         connectedComponent (Bialgebra.augmentationPoint k H) =
       connectedComponent (Bialgebra.augmentationPoint k H) := by
   rw [rightTranslationHomeomorph_image_connectedComponent,
+    rightTranslationHomeomorph_apply, AlgEquiv.toRingEquiv_toRingHom,
     rightTranslationHomeomorph_augmentationPoint]
   exact (connectedComponent_eq hg).symm
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -170,15 +170,6 @@ theorem rightTranslationHomeomorph_apply (g : WithConv (H →ₐ[k] k))
       PrimeSpectrum.comap ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H) x :=
   rfl
 
-/-- Right translation sends the identity point to the translating point. -/
-@[simp]
-theorem rightTranslationHomeomorph_augmentationPoint
-    (g : WithConv (H →ₐ[k] k)) :
-    PrimeSpectrum.comap (rightTranslationAlgEquiv g)
-        (Bialgebra.augmentationPoint k H) =
-      AlgHom.kernelPoint g.ofConv := by
-  rw [comap_rightTranslationAlgEquiv_augmentationPoint]
-
 /-- Right translation transports the connected component of a point to the connected component
 of its translate. -/
 theorem rightTranslationHomeomorph_image_connectedComponent
@@ -200,7 +191,7 @@ theorem rightTranslation_preserves_augmentationPoint_connectedComponent
       connectedComponent (Bialgebra.augmentationPoint k H) := by
   rw [rightTranslationHomeomorph_image_connectedComponent,
     rightTranslationHomeomorph_apply, AlgEquiv.toRingEquiv_toRingHom,
-    rightTranslationHomeomorph_augmentationPoint]
+    comap_rightTranslationAlgEquiv_augmentationPoint]
   exact (connectedComponent_eq hg).symm
 
 variable [LocallyConnectedSpace (PrimeSpectrum H)]

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -106,6 +106,7 @@ private theorem connectedComponentIdeal_kernelPoint_eq_augmentationPoint
 
 /-- The inverse coordinate-algebra automorphism of translation by an identity-component point
 fixes the idempotent selecting the identity component. -/
+@[simp]
 theorem rightTranslationAlgEquiv_symm_connectedComponentIdempotent_eq_self
     (g : WithConv (H →ₐ[k] k))
     (hg : AlgHom.kernelPoint g.ofConv ∈
@@ -139,6 +140,7 @@ theorem rightTranslationAlgEquiv_symm_connectedComponentIdempotent_eq_self
 
 /-- The coordinate-algebra automorphism of translation by an identity-component point fixes the
 idempotent selecting the identity component. -/
+@[simp]
 theorem rightTranslationAlgEquiv_connectedComponentIdempotent_eq_self
     (g : WithConv (H →ₐ[k] k))
     (hg : AlgHom.kernelPoint g.ofConv ∈
@@ -196,6 +198,7 @@ theorem map_rightTranslationAlgEquiv_connectedComponentIdeal_eq_self
 
 /-- Membership in the identity-component ideal is invariant under translation by a point of the
 identity component. -/
+@[simp]
 theorem rightTranslationAlgEquiv_mem_connectedComponentIdeal_iff
     (g : WithConv (H →ₐ[k] k))
     (hg : AlgHom.kernelPoint g.ofConv ∈

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -5,32 +5,21 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Connected.IdentityComponent
-public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Translation
 
 /-!
-# Translations of an affine group
+# Translations of the identity component
 
-An algebra-valued point of an affine group acts on its coordinate algebra by translation.  For a
-commutative Hopf algebra `H` over `k`, a `k`-point `g : H →ₐ[k] k` defines the algebra
-endomorphism
-
-```text
-x ↦ ∑ x₍₁₎ g(x₍₂₎).
-```
-
-The regular-comodule action shows that this endomorphism is bijective, with inverse obtained from
-the convolution inverse point.  This file packages it as an algebra equivalence and identifies its
-action on prime spectra.  In particular, translating by a point in the connected component of the
-counit preserves that component.
+Right translation by a `k`-rational point induces a homeomorphism of the prime spectrum. This file
+proves that a point in the connected component of the counit translates that component onto itself
+and preserves its defining idempotent and ideal.
 
 ## Main declarations
 
-* `TauCeti.HopfAlgebra.rightTranslationAlgHom`: pullback by right translation by a point.
-* `TauCeti.HopfAlgebra.rightTranslationAlgEquiv`: right translation as an algebra automorphism.
-* `TauCeti.HopfAlgebra.comap_rightTranslationAlgEquiv_augmentationPoint`: the translated counit
-  point is the given point.
-* `TauCeti.HopfAlgebra.rightTranslation_preserves_augmentationPoint_connectedComponent`: a point
-  in the identity component translates that component to itself.
+* `rightTranslationHomeomorph_image_connectedComponent_augmentationPoint_eq_self`: a point in the
+  identity component translates that component to itself.
+* `map_rightTranslationAlgEquiv_connectedComponentIdeal_eq_self`: translation by an
+  identity-component point fixes its defining ideal.
 
 ## References
 
@@ -46,7 +35,6 @@ component, giving comultiplication closure of its defining ideal.
 public section
 
 open AlgebraicGeometry
-open scoped TensorProduct
 
 namespace TauCeti.HopfAlgebra
 
@@ -54,121 +42,6 @@ universe u v
 
 variable {k : Type u} [Field k]
 variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H]
-
-/-- Pullback by right translation by a `k`-point of an affine group, on its coordinate algebra. -/
-noncomputable def rightTranslationAlgHom (g : WithConv (H →ₐ[k] k)) : H →ₐ[k] H :=
-  (WithConv.toConv (AlgHom.id k H) *
-    WithConv.toConv ((Algebra.ofId k H).comp g.ofConv)).ofConv
-
-/-- Right translation evaluates by applying the point to the second tensor factor of the
-comultiplication. -/
-theorem rightTranslationAlgHom_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
-    rightTranslationAlgHom g x =
-      TensorProduct.rid k H
-        (TensorProduct.map LinearMap.id g.ofConv.toLinearMap (Coalgebra.comul x)) := by
-  rw [rightTranslationAlgHom, AlgHom.convMul_apply]
-  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
-  | zero => simp
-  | add z w hz hw => simp [hz, hw]
-  | tmul z w => simp [Algebra.smul_def, mul_comm]
-
-/-- The linear equivalence underlying right translation. -/
-private noncomputable def rightTranslationLinearEquiv (g : WithConv (H →ₐ[k] k)) :
-    H ≃ₗ[k] H :=
-  (TensorProduct.lid k H).symm.trans
-    ((Comodule.pointsAction H g).trans (TensorProduct.lid k H))
-
-private theorem rightTranslationLinearEquiv_toLinearMap
-    (g : WithConv (H →ₐ[k] k)) :
-    (rightTranslationLinearEquiv g).toLinearMap = (rightTranslationAlgHom g).toLinearMap := by
-  ext x
-  rw [rightTranslationLinearEquiv]
-  -- Composition of the three linear equivalences is intentionally reduced to application here;
-  -- the public comparison theorem below prevents consumers from relying on this representation.
-  change TensorProduct.lid k H
-      (Comodule.pointsAction H g ((TensorProduct.lid k H).symm x)) =
-    rightTranslationAlgHom g x
-  rw [TensorProduct.lid_symm_apply]
-  have haction : Comodule.pointsAction H g (1 ⊗ₜ[k] x) =
-      Comodule.endOfPoint H g.ofConv (1 ⊗ₜ[k] x) :=
-    DFunLike.congr_fun (Comodule.pointsAction_toLinearMap H g) (1 ⊗ₜ[k] x)
-  rw [haction, Comodule.endOfPoint_tmul, Comodule.instSelf_coact,
-    rightTranslationAlgHom_apply]
-  simp [LinearMap.lTensor_def]
-
-private theorem rightTranslationAlgHom_bijective (g : WithConv (H →ₐ[k] k)) :
-    Function.Bijective (rightTranslationAlgHom g) := by
-  change Function.Bijective (rightTranslationAlgHom g).toLinearMap
-  rw [← rightTranslationLinearEquiv_toLinearMap g]
-  exact (rightTranslationLinearEquiv g).bijective
-
-/-- Pullback by right translation by a `k`-point, as an algebra automorphism of the coordinate
-algebra. -/
-noncomputable def rightTranslationAlgEquiv (g : WithConv (H →ₐ[k] k)) : H ≃ₐ[k] H :=
-  AlgEquiv.ofBijective (rightTranslationAlgHom g) (rightTranslationAlgHom_bijective g)
-
-/-- The algebra equivalence underlying right translation is the right-translation algebra
-homomorphism. -/
-@[simp]
-theorem rightTranslationAlgEquiv_toAlgHom (g : WithConv (H →ₐ[k] k)) :
-    (rightTranslationAlgEquiv g).toAlgHom = rightTranslationAlgHom g :=
-  AlgEquiv.toAlgHom_ofBijective _ _
-
-/-- Right translation as an algebra equivalence has the expected evaluation formula. -/
-theorem rightTranslationAlgEquiv_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
-    rightTranslationAlgEquiv g x =
-      TensorProduct.rid k H
-        (TensorProduct.map LinearMap.id g.ofConv.toLinearMap (Coalgebra.comul x)) := by
-  rw [← rightTranslationAlgHom_apply]
-  rfl
-
-/-- Evaluating a right-translated function at the identity evaluates the original function at
-the translating point. -/
-@[simp]
-theorem counitAlgHom_comp_rightTranslationAlgHom (g : WithConv (H →ₐ[k] k)) :
-    (_root_.Bialgebra.counitAlgHom k H).comp (rightTranslationAlgHom g) = g.ofConv := by
-  rw [rightTranslationAlgHom, AlgHom.comp_convMul_distrib]
-  have hcounit :
-      (_root_.Bialgebra.counitAlgHom k H).comp (AlgHom.id k H) =
-        _root_.Bialgebra.counitAlgHom k H := by
-    rw [AlgHom.comp_id]
-  have hpoint :
-      (_root_.Bialgebra.counitAlgHom k H).comp
-          ((Algebra.ofId k H).comp g.ofConv) = g.ofConv := by
-    ext x
-    simp
-  rw [hcounit, hpoint]
-  change (1 * g).ofConv = g.ofConv
-  rw [one_mul]
-
-/-- Contraction of the augmentation point along right translation gives the translating point. -/
-@[simp]
-theorem comap_rightTranslationAlgEquiv_augmentationPoint
-    (g : WithConv (H →ₐ[k] k)) :
-    PrimeSpectrum.comap (rightTranslationAlgEquiv g)
-        (Bialgebra.augmentationPoint k H) =
-      AlgHom.kernelPoint g.ofConv := by
-  change PrimeSpectrum.comap
-      ((rightTranslationAlgEquiv g).toAlgHom : H →+* H)
-        (AlgHom.kernelPoint (_root_.Bialgebra.counitAlgHom k H)) =
-    AlgHom.kernelPoint g.ofConv
-  rw [rightTranslationAlgEquiv_toAlgHom, AlgHom.comap_kernelPoint,
-    counitAlgHom_comp_rightTranslationAlgHom]
-
-/-- Right translation on the prime spectrum.  The inverse algebra equivalence occurs because
-`Spec` is contravariant. -/
-@[expose] noncomputable def rightTranslationHomeomorph (g : WithConv (H →ₐ[k] k)) :
-    Spec (CommRingCat.of H) ≃ₜ Spec (CommRingCat.of H) :=
-  PrimeSpectrum.homeomorphOfRingEquiv (rightTranslationAlgEquiv g).symm.toRingEquiv
-
-/-- Right translation on the prime spectrum is contraction along the right-translation algebra
-automorphism. -/
-@[simp]
-theorem rightTranslationHomeomorph_apply (g : WithConv (H →ₐ[k] k))
-    (x : Spec (CommRingCat.of H)) :
-    rightTranslationHomeomorph g x =
-      PrimeSpectrum.comap ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H) x :=
-  rfl
 
 /-- Right translation transports the connected component of a point to the connected component
 of its translate. -/
@@ -182,7 +55,7 @@ theorem rightTranslationHomeomorph_image_connectedComponent
       (s := Set.univ) (x := x) (Set.mem_univ x)
 
 /-- A point in the identity component right-translates that component onto itself. -/
-theorem rightTranslation_preserves_augmentationPoint_connectedComponent
+theorem rightTranslationHomeomorph_image_connectedComponent_augmentationPoint_eq_self
     (g : WithConv (H →ₐ[k] k))
     (hg : AlgHom.kernelPoint g.ofConv ∈
       connectedComponent (Bialgebra.augmentationPoint k H)) :
@@ -204,6 +77,7 @@ private theorem connectedComponentIdempotent_kernelPoint_eq_augmentationPoint
       PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H) := by
   let p : PrimeSpectrum H := AlgHom.kernelPoint g.ofConv
   let e : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  -- `Spec (CommRingCat.of H)` has `PrimeSpectrum H` as its reducible carrier.
   change PrimeSpectrum.connectedComponentIdempotent p =
     PrimeSpectrum.connectedComponentIdempotent e
   change p ∈ connectedComponent e at hg
@@ -211,6 +85,24 @@ private theorem connectedComponentIdempotent_kernelPoint_eq_augmentationPoint
     (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent p) e).mpr
   rw [PrimeSpectrum.basicOpen_connectedComponentIdempotent]
   exact (connectedComponent_eq hg).symm
+
+private theorem connectedComponentIdeal_kernelPoint_eq_augmentationPoint
+    (g : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
+    PrimeSpectrum.connectedComponentIdeal (AlgHom.kernelPoint g.ofConv) =
+      PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) := by
+  let p : PrimeSpectrum H := AlgHom.kernelPoint g.ofConv
+  let e : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  have h := connectedComponentIdempotent_kernelPoint_eq_augmentationPoint g hg
+  -- Reduce the two `Spec` point abbreviations once, then use the named idempotent equality.
+  change PrimeSpectrum.connectedComponentIdempotent p =
+    PrimeSpectrum.connectedComponentIdempotent e at h
+  change PrimeSpectrum.connectedComponentIdeal p = PrimeSpectrum.connectedComponentIdeal e
+  apply Ideal.ext
+  intro x
+  rw [PrimeSpectrum.mem_connectedComponentIdeal_iff,
+    PrimeSpectrum.mem_connectedComponentIdeal_iff, h]
 
 /-- The inverse coordinate-algebra automorphism of translation by an identity-component point
 fixes the idempotent selecting the identity component. -/
@@ -221,28 +113,28 @@ theorem rightTranslationAlgEquiv_symm_connectedComponentIdempotent_eq_self
     (rightTranslationAlgEquiv g).symm
         (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) =
       PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H) := by
-  let e : PrimeSpectrum H := Bialgebra.augmentationPoint k H
-  change (rightTranslationAlgEquiv g).symm
-      (PrimeSpectrum.connectedComponentIdempotent e) =
-    PrimeSpectrum.connectedComponentIdempotent e
   have he : PrimeSpectrum.comap
-      ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H) e =
+      ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H)
+        (Bialgebra.augmentationPoint k H) =
       AlgHom.kernelPoint g.ofConv :=
     comap_rightTranslationAlgEquiv_augmentationPoint g
   calc
     (rightTranslationAlgEquiv g).symm
-        (PrimeSpectrum.connectedComponentIdempotent e) =
+        (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) =
       PrimeSpectrum.connectedComponentIdempotent
         (PrimeSpectrum.comap
-          (((rightTranslationAlgEquiv g).symm.toRingEquiv).symm : H →+* H) e) :=
+          (((rightTranslationAlgEquiv g).symm.toRingEquiv).symm : H →+* H)
+            (Bialgebra.augmentationPoint k H)) :=
       PrimeSpectrum.map_connectedComponentIdempotent
-        (rightTranslationAlgEquiv g).symm.toRingEquiv e
+        (rightTranslationAlgEquiv g).symm.toRingEquiv (Bialgebra.augmentationPoint k H)
     _ = PrimeSpectrum.connectedComponentIdempotent
         (PrimeSpectrum.comap
-          ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H) e) := by rfl
+          ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H)
+            (Bialgebra.augmentationPoint k H)) := by
+      rw [AlgEquiv.symm_toRingEquiv, RingEquiv.symm_symm]
     _ = PrimeSpectrum.connectedComponentIdempotent (AlgHom.kernelPoint g.ofConv) :=
       congrArg PrimeSpectrum.connectedComponentIdempotent he
-    _ = PrimeSpectrum.connectedComponentIdempotent e :=
+    _ = PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H) :=
       connectedComponentIdempotent_kernelPoint_eq_augmentationPoint g hg
 
 /-- The coordinate-algebra automorphism of translation by an identity-component point fixes the
@@ -258,39 +150,6 @@ theorem rightTranslationAlgEquiv_connectedComponentIdempotent_eq_self
     (rightTranslationAlgEquiv_symm_connectedComponentIdempotent_eq_self g hg)
   simpa using h.symm
 
-/-- Membership in the identity-component ideal is invariant under translation by a point of the
-identity component. -/
-theorem rightTranslationAlgEquiv_mem_connectedComponentIdeal_iff
-    (g : WithConv (H →ₐ[k] k))
-    (hg : AlgHom.kernelPoint g.ofConv ∈
-      connectedComponent (Bialgebra.augmentationPoint k H)) {x : H} :
-    rightTranslationAlgEquiv g x ∈
-        PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) ↔
-      x ∈ PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) := by
-  let e : PrimeSpectrum H := Bialgebra.augmentationPoint k H
-  change rightTranslationAlgEquiv g x ∈
-      PrimeSpectrum.connectedComponentIdeal e ↔
-    x ∈ PrimeSpectrum.connectedComponentIdeal e
-  rw [PrimeSpectrum.mem_connectedComponentIdeal_iff,
-    PrimeSpectrum.mem_connectedComponentIdeal_iff]
-  have hsymm : (rightTranslationAlgEquiv g).symm
-      (PrimeSpectrum.connectedComponentIdempotent e) =
-      PrimeSpectrum.connectedComponentIdempotent e :=
-    rightTranslationAlgEquiv_symm_connectedComponentIdempotent_eq_self g hg
-  have hforward : rightTranslationAlgEquiv g
-      (PrimeSpectrum.connectedComponentIdempotent e) =
-      PrimeSpectrum.connectedComponentIdempotent e :=
-    rightTranslationAlgEquiv_connectedComponentIdempotent_eq_self g hg
-  constructor
-  · rintro ⟨a, ha⟩
-    refine ⟨(rightTranslationAlgEquiv g).symm a, ?_⟩
-    have h := congrArg (rightTranslationAlgEquiv g).symm ha
-    simpa [hsymm] using h
-  · rintro ⟨a, ha⟩
-    refine ⟨rightTranslationAlgEquiv g a, ?_⟩
-    have h := congrArg (rightTranslationAlgEquiv g) ha
-    simpa [hforward] using h
-
 /-- Translation by a point in the identity component fixes the ideal cutting out that
 component. -/
 @[simp]
@@ -301,16 +160,60 @@ theorem map_rightTranslationAlgEquiv_connectedComponentIdeal_eq_self
     Ideal.map (rightTranslationAlgEquiv g)
         (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) =
       PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) := by
-  apply Ideal.ext
-  intro y
-  rw [Ideal.mem_map_of_equiv]
-  constructor
-  · rintro ⟨x, hx, rfl⟩
-    exact (rightTranslationAlgEquiv_mem_connectedComponentIdeal_iff g hg).mpr hx
-  · intro hy
-    refine ⟨(rightTranslationAlgEquiv g).symm y, ?_, ?_⟩
-    · exact (rightTranslationAlgEquiv_mem_connectedComponentIdeal_iff g hg).mp
-        (by simpa using hy)
-    · exact (rightTranslationAlgEquiv g).apply_symm_apply y
+  let φ : H ≃+* H := (rightTranslationAlgEquiv g).toRingEquiv
+  let p : PrimeSpectrum H := AlgHom.kernelPoint g.ofConv
+  let e : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  let I : Ideal H := PrimeSpectrum.connectedComponentIdeal e
+  -- Reduce the algebra-equivalence and `Spec` wrappers once; the proof below stays in the generic
+  -- ring-equivalence and prime-spectrum API.
+  change Ideal.map φ I = I
+  have he : PrimeSpectrum.comap (φ : H →+* H) e = p := by
+    change PrimeSpectrum.comap
+        ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H)
+          (Bialgebra.augmentationPoint k H) =
+      AlgHom.kernelPoint g.ofConv
+    exact comap_rightTranslationAlgEquiv_augmentationPoint g
+  have hp : PrimeSpectrum.connectedComponentIdeal p = I := by
+    change PrimeSpectrum.connectedComponentIdeal (AlgHom.kernelPoint g.ofConv) =
+      PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)
+    exact connectedComponentIdeal_kernelPoint_eq_augmentationPoint g hg
+  have hsymm : Ideal.map φ.symm I = I := by
+    calc
+      Ideal.map φ.symm I =
+          PrimeSpectrum.connectedComponentIdeal
+            (PrimeSpectrum.comap (φ.symm.symm : H →+* H) e) :=
+        PrimeSpectrum.map_connectedComponentIdeal φ.symm e
+      _ = PrimeSpectrum.connectedComponentIdeal (PrimeSpectrum.comap (φ : H →+* H) e) := by
+        rw [RingEquiv.symm_symm]
+      _ = PrimeSpectrum.connectedComponentIdeal p :=
+        congrArg PrimeSpectrum.connectedComponentIdeal he
+      _ = I := hp
+  calc
+    Ideal.map φ I = Ideal.map φ (Ideal.map φ.symm I) := by rw [hsymm]
+    _ = Ideal.map ((φ : H →+* H).comp (φ.symm : H →+* H)) I :=
+      Ideal.map_map (φ.symm : H →+* H) (φ : H →+* H)
+    _ = I := by simp
+
+/-- Membership in the identity-component ideal is invariant under translation by a point of the
+identity component. -/
+theorem rightTranslationAlgEquiv_mem_connectedComponentIdeal_iff
+    (g : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) {x : H} :
+    rightTranslationAlgEquiv g x ∈
+        PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) ↔
+      x ∈ PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) := by
+  have hmap := map_rightTranslationAlgEquiv_connectedComponentIdeal_eq_self g hg
+  calc
+    rightTranslationAlgEquiv g x ∈
+          PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) ↔
+        rightTranslationAlgEquiv g x ∈
+          Ideal.map (rightTranslationAlgEquiv g)
+            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) := by
+      rw [hmap]
+    _ ↔ x ∈ PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) :=
+      Ideal.apply_mem_of_equiv_iff
+        (I := PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H))
+        (f := (rightTranslationAlgEquiv g).toRingEquiv) (x := x)
 
 end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -1,0 +1,324 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.IdentityComponent
+public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
+
+/-!
+# Translations of an affine group
+
+An algebra-valued point of an affine group acts on its coordinate algebra by translation.  For a
+commutative Hopf algebra `H` over `k`, a `k`-point `g : H →ₐ[k] k` defines the algebra
+endomorphism
+
+```text
+x ↦ ∑ x₍₁₎ g(x₍₂₎).
+```
+
+The regular-comodule action shows that this endomorphism is bijective, with inverse obtained from
+the convolution inverse point.  This file packages it as an algebra equivalence and identifies its
+action on prime spectra.  In particular, translating by a point in the connected component of the
+counit preserves that component.
+
+## Main declarations
+
+* `TauCeti.HopfAlgebra.rightTranslationAlgHom`: pullback by right translation by a point.
+* `TauCeti.HopfAlgebra.rightTranslationAlgEquiv`: right translation as an algebra automorphism.
+* `TauCeti.HopfAlgebra.comap_rightTranslationAlgEquiv_augmentationPoint`: the translated counit
+  point is the given point.
+* `TauCeti.HopfAlgebra.rightTranslation_preserves_augmentationPoint_connectedComponent`: a point
+  in the identity component translates that component to itself.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 2.37.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Section 6.7.
+
+This is the translation prerequisite for Layer 3, "Identity component `G°` and component group
+`π₀(G)`", of the ReductiveGroups roadmap.  The next step uses these automorphisms to prove
+that multiplication carries the product of the identity component with itself into the identity
+component, giving comultiplication closure of its defining ideal.
+-/
+
+public section
+
+open AlgebraicGeometry
+open scoped TensorProduct
+
+namespace TauCeti.HopfAlgebra
+
+universe u v
+
+variable {k : Type u} [Field k]
+variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H]
+
+/-- Pullback by right translation by a `k`-point of an affine group, on its coordinate algebra. -/
+noncomputable def rightTranslationAlgHom (g : WithConv (H →ₐ[k] k)) : H →ₐ[k] H :=
+  (WithConv.toConv (AlgHom.id k H) *
+    WithConv.toConv ((Algebra.ofId k H).comp g.ofConv)).ofConv
+
+/-- Right translation evaluates by applying the point to the second tensor factor of the
+comultiplication. -/
+theorem rightTranslationAlgHom_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
+    rightTranslationAlgHom g x =
+      TensorProduct.rid k H
+        (TensorProduct.map LinearMap.id g.ofConv.toLinearMap (Coalgebra.comul x)) := by
+  rw [rightTranslationAlgHom, AlgHom.convMul_apply]
+  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
+  | zero => simp
+  | add z w hz hw => simp [hz, hw]
+  | tmul z w => simp [Algebra.smul_def, mul_comm]
+
+private noncomputable def rightTranslationLinearEquiv (g : WithConv (H →ₐ[k] k)) :
+    H ≃ₗ[k] H :=
+  (TensorProduct.lid k H).symm.trans
+    ((Comodule.pointsAction H g).trans (TensorProduct.lid k H))
+
+private theorem rightTranslationLinearEquiv_toLinearMap
+    (g : WithConv (H →ₐ[k] k)) :
+    (rightTranslationLinearEquiv g).toLinearMap = (rightTranslationAlgHom g).toLinearMap := by
+  ext x
+  rw [rightTranslationLinearEquiv]
+  -- Composition of the three linear equivalences is intentionally reduced to application here;
+  -- the public comparison theorem below prevents consumers from relying on this representation.
+  change TensorProduct.lid k H
+      (Comodule.pointsAction H g ((TensorProduct.lid k H).symm x)) =
+    rightTranslationAlgHom g x
+  rw [TensorProduct.lid_symm_apply]
+  have haction : Comodule.pointsAction H g (1 ⊗ₜ[k] x) =
+      Comodule.endOfPoint H g.ofConv (1 ⊗ₜ[k] x) :=
+    DFunLike.congr_fun (Comodule.pointsAction_toLinearMap H g) (1 ⊗ₜ[k] x)
+  rw [haction, Comodule.endOfPoint_tmul, Comodule.instSelf_coact,
+    rightTranslationAlgHom_apply]
+  simp [LinearMap.lTensor_def]
+
+private theorem rightTranslationAlgHom_bijective (g : WithConv (H →ₐ[k] k)) :
+    Function.Bijective (rightTranslationAlgHom g) := by
+  change Function.Bijective (rightTranslationAlgHom g).toLinearMap
+  rw [← rightTranslationLinearEquiv_toLinearMap g]
+  exact (rightTranslationLinearEquiv g).bijective
+
+/-- Pullback by right translation by a `k`-point, as an algebra automorphism of the coordinate
+algebra. -/
+noncomputable def rightTranslationAlgEquiv (g : WithConv (H →ₐ[k] k)) : H ≃ₐ[k] H :=
+  AlgEquiv.ofBijective (rightTranslationAlgHom g) (rightTranslationAlgHom_bijective g)
+
+/-- The algebra equivalence underlying right translation is the right-translation algebra
+homomorphism. -/
+@[simp]
+theorem rightTranslationAlgEquiv_toAlgHom (g : WithConv (H →ₐ[k] k)) :
+    (rightTranslationAlgEquiv g).toAlgHom = rightTranslationAlgHom g :=
+  AlgEquiv.toAlgHom_ofBijective _ _
+
+/-- Right translation as an algebra equivalence has the expected evaluation formula. -/
+theorem rightTranslationAlgEquiv_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
+    rightTranslationAlgEquiv g x =
+      TensorProduct.rid k H
+        (TensorProduct.map LinearMap.id g.ofConv.toLinearMap (Coalgebra.comul x)) := by
+  rw [← rightTranslationAlgHom_apply]
+  rfl
+
+/-- Evaluating a right-translated function at the identity evaluates the original function at
+the translating point. -/
+@[simp]
+theorem counitAlgHom_comp_rightTranslationAlgHom (g : WithConv (H →ₐ[k] k)) :
+    (_root_.Bialgebra.counitAlgHom k H).comp (rightTranslationAlgHom g) = g.ofConv := by
+  rw [rightTranslationAlgHom, AlgHom.comp_convMul_distrib]
+  have hcounit :
+      (_root_.Bialgebra.counitAlgHom k H).comp (AlgHom.id k H) =
+        _root_.Bialgebra.counitAlgHom k H := by
+    rw [AlgHom.comp_id]
+  have hpoint :
+      (_root_.Bialgebra.counitAlgHom k H).comp
+          ((Algebra.ofId k H).comp g.ofConv) = g.ofConv := by
+    ext x
+    simp
+  rw [hcounit, hpoint]
+  change (1 * g).ofConv = g.ofConv
+  rw [one_mul]
+
+/-- Contraction of the augmentation point along right translation gives the translating point. -/
+@[simp]
+theorem comap_rightTranslationAlgEquiv_augmentationPoint
+    (g : WithConv (H →ₐ[k] k)) :
+    PrimeSpectrum.comap ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H)
+        (Bialgebra.augmentationPoint k H) =
+      AlgHom.kernelPoint g.ofConv := by
+  rw [AlgEquiv.toRingEquiv_toRingHom]
+  change PrimeSpectrum.comap
+      ((rightTranslationAlgEquiv g).toAlgHom : H →+* H)
+        (AlgHom.kernelPoint (_root_.Bialgebra.counitAlgHom k H)) =
+    AlgHom.kernelPoint g.ofConv
+  rw [rightTranslationAlgEquiv_toAlgHom, AlgHom.comap_kernelPoint,
+    counitAlgHom_comp_rightTranslationAlgHom]
+
+/-- Right translation on the prime spectrum.  The inverse algebra equivalence occurs because
+`Spec` is contravariant. -/
+@[expose] noncomputable def rightTranslationHomeomorph (g : WithConv (H →ₐ[k] k)) :
+    Spec (CommRingCat.of H) ≃ₜ Spec (CommRingCat.of H) :=
+  PrimeSpectrum.homeomorphOfRingEquiv (rightTranslationAlgEquiv g).symm.toRingEquiv
+
+/-- Right translation on the prime spectrum is contraction along the right-translation algebra
+automorphism. -/
+@[simp]
+theorem rightTranslationHomeomorph_apply (g : WithConv (H →ₐ[k] k))
+    (x : Spec (CommRingCat.of H)) :
+    rightTranslationHomeomorph g x =
+      PrimeSpectrum.comap ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H) x :=
+  rfl
+
+/-- Right translation sends the identity point to the translating point. -/
+@[simp]
+theorem rightTranslationHomeomorph_augmentationPoint
+    (g : WithConv (H →ₐ[k] k)) :
+    rightTranslationHomeomorph g (Bialgebra.augmentationPoint k H) =
+      AlgHom.kernelPoint g.ofConv := by
+  rw [rightTranslationHomeomorph_apply,
+    comap_rightTranslationAlgEquiv_augmentationPoint]
+
+/-- Right translation transports the connected component of a point to the connected component
+of its translate. -/
+theorem rightTranslationHomeomorph_image_connectedComponent
+    (g : WithConv (H →ₐ[k] k)) (x : Spec (CommRingCat.of H)) :
+    rightTranslationHomeomorph g '' connectedComponent x =
+      connectedComponent (rightTranslationHomeomorph g x) := by
+  simpa only [connectedComponentIn_univ,
+    Set.image_univ_of_surjective (rightTranslationHomeomorph g).surjective] using
+    (rightTranslationHomeomorph g).image_connectedComponentIn
+      (s := Set.univ) (x := x) (Set.mem_univ x)
+
+/-- A point in the identity component right-translates that component onto itself. -/
+theorem rightTranslation_preserves_augmentationPoint_connectedComponent
+    (g : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
+    rightTranslationHomeomorph g ''
+        connectedComponent (Bialgebra.augmentationPoint k H) =
+      connectedComponent (Bialgebra.augmentationPoint k H) := by
+  rw [rightTranslationHomeomorph_image_connectedComponent,
+    rightTranslationHomeomorph_augmentationPoint]
+  exact (connectedComponent_eq hg).symm
+
+variable [LocallyConnectedSpace (PrimeSpectrum H)]
+
+private theorem connectedComponentIdempotent_kernelPoint_eq_augmentationPoint
+    (g : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
+    PrimeSpectrum.connectedComponentIdempotent (AlgHom.kernelPoint g.ofConv) =
+      PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H) := by
+  let p : PrimeSpectrum H := AlgHom.kernelPoint g.ofConv
+  let e : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  change PrimeSpectrum.connectedComponentIdempotent p =
+    PrimeSpectrum.connectedComponentIdempotent e
+  change p ∈ connectedComponent e at hg
+  apply (PrimeSpectrum.eq_connectedComponentIdempotent_iff
+    (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent p) e).mpr
+  rw [PrimeSpectrum.basicOpen_connectedComponentIdempotent]
+  exact (connectedComponent_eq hg).symm
+
+/-- The inverse coordinate-algebra automorphism of translation by an identity-component point
+fixes the idempotent selecting the identity component. -/
+theorem rightTranslationAlgEquiv_symm_connectedComponentIdempotent_eq_self
+    (g : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
+    (rightTranslationAlgEquiv g).symm
+        (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) =
+      PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H) := by
+  let e : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  change (rightTranslationAlgEquiv g).symm
+      (PrimeSpectrum.connectedComponentIdempotent e) =
+    PrimeSpectrum.connectedComponentIdempotent e
+  have he : PrimeSpectrum.comap
+      ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H) e =
+      AlgHom.kernelPoint g.ofConv :=
+    comap_rightTranslationAlgEquiv_augmentationPoint g
+  calc
+    (rightTranslationAlgEquiv g).symm
+        (PrimeSpectrum.connectedComponentIdempotent e) =
+      PrimeSpectrum.connectedComponentIdempotent
+        (PrimeSpectrum.comap
+          (((rightTranslationAlgEquiv g).symm.toRingEquiv).symm : H →+* H) e) :=
+      PrimeSpectrum.map_connectedComponentIdempotent
+        (rightTranslationAlgEquiv g).symm.toRingEquiv e
+    _ = PrimeSpectrum.connectedComponentIdempotent
+        (PrimeSpectrum.comap
+          ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H) e) := by rfl
+    _ = PrimeSpectrum.connectedComponentIdempotent (AlgHom.kernelPoint g.ofConv) :=
+      congrArg PrimeSpectrum.connectedComponentIdempotent he
+    _ = PrimeSpectrum.connectedComponentIdempotent e :=
+      connectedComponentIdempotent_kernelPoint_eq_augmentationPoint g hg
+
+/-- The coordinate-algebra automorphism of translation by an identity-component point fixes the
+idempotent selecting the identity component. -/
+theorem rightTranslationAlgEquiv_connectedComponentIdempotent_eq_self
+    (g : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
+    rightTranslationAlgEquiv g
+        (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) =
+      PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H) := by
+  have h := congrArg (rightTranslationAlgEquiv g)
+    (rightTranslationAlgEquiv_symm_connectedComponentIdempotent_eq_self g hg)
+  simpa using h.symm
+
+/-- Membership in the identity-component ideal is invariant under translation by a point of the
+identity component. -/
+theorem rightTranslationAlgEquiv_mem_connectedComponentIdeal_iff
+    (g : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) {x : H} :
+    rightTranslationAlgEquiv g x ∈
+        PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) ↔
+      x ∈ PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) := by
+  let e : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  change rightTranslationAlgEquiv g x ∈
+      PrimeSpectrum.connectedComponentIdeal e ↔
+    x ∈ PrimeSpectrum.connectedComponentIdeal e
+  rw [PrimeSpectrum.mem_connectedComponentIdeal_iff,
+    PrimeSpectrum.mem_connectedComponentIdeal_iff]
+  have hsymm : (rightTranslationAlgEquiv g).symm
+      (PrimeSpectrum.connectedComponentIdempotent e) =
+      PrimeSpectrum.connectedComponentIdempotent e :=
+    rightTranslationAlgEquiv_symm_connectedComponentIdempotent_eq_self g hg
+  have hforward : rightTranslationAlgEquiv g
+      (PrimeSpectrum.connectedComponentIdempotent e) =
+      PrimeSpectrum.connectedComponentIdempotent e :=
+    rightTranslationAlgEquiv_connectedComponentIdempotent_eq_self g hg
+  constructor
+  · rintro ⟨a, ha⟩
+    refine ⟨(rightTranslationAlgEquiv g).symm a, ?_⟩
+    have h := congrArg (rightTranslationAlgEquiv g).symm ha
+    simpa [hsymm] using h
+  · rintro ⟨a, ha⟩
+    refine ⟨rightTranslationAlgEquiv g a, ?_⟩
+    have h := congrArg (rightTranslationAlgEquiv g) ha
+    simpa [hforward] using h
+
+/-- Translation by a point in the identity component fixes the ideal cutting out that
+component. -/
+@[simp]
+theorem map_rightTranslationAlgEquiv_connectedComponentIdeal_eq_self
+    (g : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
+    Ideal.map (rightTranslationAlgEquiv g)
+        (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) =
+      PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) := by
+  apply Ideal.ext
+  intro y
+  rw [Ideal.mem_map_of_equiv]
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact (rightTranslationAlgEquiv_mem_connectedComponentIdeal_iff g hg).mpr hx
+  · intro hy
+    refine ⟨(rightTranslationAlgEquiv g).symm y, ?_, ?_⟩
+    · exact (rightTranslationAlgEquiv_mem_connectedComponentIdeal_iff g hg).mp
+        (by simpa using hy)
+    · exact (rightTranslationAlgEquiv g).apply_symm_apply y
+
+end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
@@ -1,0 +1,239 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
+public import TauCeti.Algebra.HopfAlgebra.Augmentation
+
+/-!
+# Translations of an affine group
+
+A `k`-rational point of an affine group acts on its coordinate algebra by translation. For a
+commutative Hopf algebra `H` over `k`, a point `g : H →ₐ[k] k` defines the algebra endomorphism
+
+```text
+x ↦ ∑ x₍₁₎ g(x₍₂₎).
+```
+
+The regular-comodule action shows that this endomorphism is bijective, with inverse obtained from
+the convolution inverse point. This file packages it as an algebra equivalence, records its group
+action laws, and identifies its action on the prime spectrum.
+
+## Main declarations
+
+* `TauCeti.HopfAlgebra.rightTranslationAlgHom`: pullback by right translation by a point.
+* `TauCeti.HopfAlgebra.rightTranslationAlgEquiv`: right translation as an algebra automorphism.
+* `TauCeti.HopfAlgebra.rightTranslationAlgEquiv_mul`: right translation respects the convolution
+  product of points.
+* `TauCeti.HopfAlgebra.comap_rightTranslationAlgEquiv_augmentationPoint`: the translated counit
+  point is the given point.
+* `TauCeti.HopfAlgebra.rightTranslationHomeomorph`: right translation on the prime spectrum.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 2.37.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Section 6.7.
+
+This is translation infrastructure for Layer 3, "Identity component `G°` and component group
+`π₀(G)`", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open AlgebraicGeometry
+open scoped TensorProduct
+
+namespace TauCeti.HopfAlgebra
+
+universe u v
+
+variable {k : Type u} [Field k]
+variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H]
+
+/-- Pullback by right translation by a `k`-point of an affine group, on its coordinate algebra. -/
+noncomputable def rightTranslationAlgHom (g : WithConv (H →ₐ[k] k)) : H →ₐ[k] H :=
+  (WithConv.toConv (AlgHom.id k H) *
+    WithConv.toConv ((Algebra.ofId k H).comp g.ofConv)).ofConv
+
+/-- Right translation evaluates by applying the point to the second tensor factor of the
+comultiplication. -/
+theorem rightTranslationAlgHom_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
+    rightTranslationAlgHom g x =
+      TensorProduct.rid k H
+        (TensorProduct.map LinearMap.id g.ofConv.toLinearMap (Coalgebra.comul x)) := by
+  rw [rightTranslationAlgHom, AlgHom.convMul_apply]
+  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
+  | zero => simp
+  | add z w hz hw => simp [hz, hw]
+  | tmul z w => simp [Algebra.smul_def, mul_comm]
+
+/-- The linear equivalence underlying right translation. -/
+private noncomputable def rightTranslationLinearEquiv (g : WithConv (H →ₐ[k] k)) :
+    H ≃ₗ[k] H :=
+  (TensorProduct.lid k H).symm.trans
+    ((Comodule.pointsAction H g).trans (TensorProduct.lid k H))
+
+private theorem rightTranslationLinearEquiv_toLinearMap
+    (g : WithConv (H →ₐ[k] k)) :
+    (rightTranslationLinearEquiv g).toLinearMap = (rightTranslationAlgHom g).toLinearMap := by
+  ext x
+  rw [rightTranslationLinearEquiv]
+  -- Composition of the three linear equivalences is intentionally reduced to application here;
+  -- the public comparison theorem below prevents consumers from relying on this representation.
+  change TensorProduct.lid k H
+      (Comodule.pointsAction H g ((TensorProduct.lid k H).symm x)) =
+    rightTranslationAlgHom g x
+  rw [TensorProduct.lid_symm_apply]
+  have haction : Comodule.pointsAction H g (1 ⊗ₜ[k] x) =
+      Comodule.endOfPoint H g.ofConv (1 ⊗ₜ[k] x) :=
+    DFunLike.congr_fun (Comodule.pointsAction_toLinearMap H g) (1 ⊗ₜ[k] x)
+  rw [haction, Comodule.endOfPoint_tmul, Comodule.instSelf_coact,
+    rightTranslationAlgHom_apply]
+  simp [LinearMap.lTensor_def]
+
+private theorem rightTranslationAlgHom_bijective (g : WithConv (H →ₐ[k] k)) :
+    Function.Bijective (rightTranslationAlgHom g) := by
+  -- An algebra hom and its underlying linear map have definitionally the same function.
+  change Function.Bijective (rightTranslationAlgHom g).toLinearMap
+  rw [← rightTranslationLinearEquiv_toLinearMap g]
+  exact (rightTranslationLinearEquiv g).bijective
+
+/-- Pullback by right translation by a `k`-point, as an algebra automorphism of the coordinate
+algebra. -/
+noncomputable def rightTranslationAlgEquiv (g : WithConv (H →ₐ[k] k)) : H ≃ₐ[k] H :=
+  AlgEquiv.ofBijective (rightTranslationAlgHom g) (rightTranslationAlgHom_bijective g)
+
+/-- The algebra equivalence underlying right translation is the right-translation algebra
+homomorphism. -/
+@[simp]
+theorem rightTranslationAlgEquiv_toAlgHom (g : WithConv (H →ₐ[k] k)) :
+    (rightTranslationAlgEquiv g).toAlgHom = rightTranslationAlgHom g :=
+  AlgEquiv.toAlgHom_ofBijective _ _
+
+private theorem rightTranslationAlgEquiv_toLinearEquiv
+    (g : WithConv (H →ₐ[k] k)) :
+    (rightTranslationAlgEquiv g).toLinearEquiv = rightTranslationLinearEquiv g := by
+  ext x
+  -- Both bundled equivalences have the algebra hom's function as their reducible carrier.
+  change rightTranslationAlgEquiv g x = rightTranslationLinearEquiv g x
+  rw [show rightTranslationAlgEquiv g x = (rightTranslationAlgEquiv g).toAlgHom x from rfl,
+    rightTranslationAlgEquiv_toAlgHom]
+  exact (LinearMap.congr_fun (rightTranslationLinearEquiv_toLinearMap g) x).symm
+
+private theorem rightTranslationLinearEquiv_one :
+    rightTranslationLinearEquiv (1 : WithConv (H →ₐ[k] k)) = 1 := by
+  ext x
+  simp [rightTranslationLinearEquiv]
+
+private theorem rightTranslationLinearEquiv_mul
+    (g h : WithConv (H →ₐ[k] k)) :
+    rightTranslationLinearEquiv (g * h) =
+      rightTranslationLinearEquiv g * rightTranslationLinearEquiv h := by
+  ext x
+  simp [rightTranslationLinearEquiv]
+
+/-- Translation by the identity point is the identity algebra automorphism. -/
+@[simp]
+theorem rightTranslationAlgEquiv_one :
+    rightTranslationAlgEquiv (1 : WithConv (H →ₐ[k] k)) = 1 := by
+  apply AlgEquiv.ext
+  intro x
+  calc
+    rightTranslationAlgEquiv (1 : WithConv (H →ₐ[k] k)) x =
+        rightTranslationLinearEquiv (1 : WithConv (H →ₐ[k] k)) x :=
+      LinearEquiv.congr_fun
+        (rightTranslationAlgEquiv_toLinearEquiv (1 : WithConv (H →ₐ[k] k))) x
+    _ = x := by rw [rightTranslationLinearEquiv_one]; simp
+    _ = (1 : H ≃ₐ[k] H) x := (AlgEquiv.one_apply x).symm
+
+/-- Translation by a convolution product is the composite of the two translations. -/
+@[simp]
+theorem rightTranslationAlgEquiv_mul (g h : WithConv (H →ₐ[k] k)) :
+    rightTranslationAlgEquiv (g * h) =
+      rightTranslationAlgEquiv g * rightTranslationAlgEquiv h := by
+  apply AlgEquiv.ext
+  intro x
+  calc
+    rightTranslationAlgEquiv (g * h) x = rightTranslationLinearEquiv (g * h) x :=
+      LinearEquiv.congr_fun (rightTranslationAlgEquiv_toLinearEquiv (g * h)) x
+    _ = (rightTranslationLinearEquiv g * rightTranslationLinearEquiv h) x :=
+      LinearEquiv.congr_fun (rightTranslationLinearEquiv_mul g h) x
+    _ = rightTranslationLinearEquiv g (rightTranslationLinearEquiv h x) :=
+      LinearEquiv.mul_apply _ _ x
+    _ = rightTranslationLinearEquiv g (rightTranslationAlgEquiv h x) :=
+      congrArg (rightTranslationLinearEquiv g)
+        (LinearEquiv.congr_fun (rightTranslationAlgEquiv_toLinearEquiv h) x).symm
+    _ = rightTranslationAlgEquiv g (rightTranslationAlgEquiv h x) :=
+      (LinearEquiv.congr_fun (rightTranslationAlgEquiv_toLinearEquiv g)
+        (rightTranslationAlgEquiv h x)).symm
+    _ = (rightTranslationAlgEquiv g * rightTranslationAlgEquiv h) x :=
+      (AlgEquiv.mul_apply _ _ x).symm
+
+/-- Translation by an inverse point is the inverse algebra automorphism. -/
+@[simp]
+theorem rightTranslationAlgEquiv_inv (g : WithConv (H →ₐ[k] k)) :
+    rightTranslationAlgEquiv g⁻¹ = (rightTranslationAlgEquiv g)⁻¹ := by
+  exact map_inv (MonoidHom.mk' rightTranslationAlgEquiv rightTranslationAlgEquiv_mul) g
+
+/-- Right translation as an algebra equivalence has the expected evaluation formula. -/
+theorem rightTranslationAlgEquiv_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
+    rightTranslationAlgEquiv g x =
+      TensorProduct.rid k H
+        (TensorProduct.map LinearMap.id g.ofConv.toLinearMap (Coalgebra.comul x)) := by
+  change (rightTranslationAlgEquiv g).toAlgHom x = _
+  rw [rightTranslationAlgEquiv_toAlgHom, rightTranslationAlgHom_apply]
+
+/-- Evaluating a right-translated function at the identity evaluates the original function at
+the translating point. -/
+@[simp]
+theorem counitAlgHom_comp_rightTranslationAlgHom (g : WithConv (H →ₐ[k] k)) :
+    (_root_.Bialgebra.counitAlgHom k H).comp (rightTranslationAlgHom g) = g.ofConv := by
+  rw [rightTranslationAlgHom, AlgHom.comp_convMul_distrib]
+  have hcounit :
+      (_root_.Bialgebra.counitAlgHom k H).comp (AlgHom.id k H) =
+        _root_.Bialgebra.counitAlgHom k H := by
+    rw [AlgHom.comp_id]
+  have hpoint :
+      (_root_.Bialgebra.counitAlgHom k H).comp
+          ((Algebra.ofId k H).comp g.ofConv) = g.ofConv := by
+    ext x
+    simp
+  rw [hcounit, hpoint]
+  -- `WithConv.ofConv` is the wrapper field, so expose it once to use the point-group identity.
+  change (1 * g).ofConv = g.ofConv
+  rw [one_mul]
+
+/-- Contraction of the augmentation point along right translation gives the translating point. -/
+@[simp]
+theorem comap_rightTranslationAlgEquiv_augmentationPoint
+    (g : WithConv (H →ₐ[k] k)) :
+    PrimeSpectrum.comap (rightTranslationAlgEquiv g)
+        (Bialgebra.augmentationPoint k H) =
+      AlgHom.kernelPoint g.ofConv := by
+  -- These abbreviations reduce `Spec H` points to kernels of their representing algebra maps.
+  change PrimeSpectrum.comap
+      ((rightTranslationAlgEquiv g).toAlgHom : H →+* H)
+        (AlgHom.kernelPoint (_root_.Bialgebra.counitAlgHom k H)) =
+    AlgHom.kernelPoint g.ofConv
+  rw [rightTranslationAlgEquiv_toAlgHom, AlgHom.comap_kernelPoint,
+    counitAlgHom_comp_rightTranslationAlgHom]
+
+/-- Right translation on the prime spectrum. The inverse algebra equivalence occurs because
+`Spec` is contravariant. -/
+noncomputable def rightTranslationHomeomorph (g : WithConv (H →ₐ[k] k)) :
+    Spec (CommRingCat.of H) ≃ₜ Spec (CommRingCat.of H) :=
+  PrimeSpectrum.homeomorphOfRingEquiv (rightTranslationAlgEquiv g).symm.toRingEquiv
+
+/-- Right translation on the prime spectrum is contraction along the right-translation algebra
+automorphism. -/
+@[simp]
+theorem rightTranslationHomeomorph_apply (g : WithConv (H →ₐ[k] k))
+    (x : Spec (CommRingCat.of H)) :
+    rightTranslationHomeomorph g x =
+      PrimeSpectrum.comap ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H) x := by
+  rw [rightTranslationHomeomorph]
+  rfl
+
+end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
@@ -10,7 +10,7 @@ public import TauCeti.Algebra.HopfAlgebra.Augmentation
 /-!
 # Translations of an affine group
 
-A `k`-rational point of an affine group acts on its coordinate algebra by translation. For a
+A `k`-point of an affine group acts on its coordinate algebra by translation. For a
 commutative Hopf algebra `H` over `k`, a point `g : H →ₐ[k] k` defines the algebra endomorphism
 
 ```text
@@ -49,7 +49,9 @@ namespace TauCeti.HopfAlgebra
 
 universe u v
 
-variable {k : Type u} [Field k]
+section CommRing
+
+variable {k : Type u} [CommRing k]
 variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H]
 
 /-- Pullback by right translation by a `k`-point of an affine group, on its coordinate algebra. -/
@@ -182,8 +184,12 @@ theorem rightTranslationAlgEquiv_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
     rightTranslationAlgEquiv g x =
       TensorProduct.rid k H
         (TensorProduct.map LinearMap.id g.ofConv.toLinearMap (Coalgebra.comul x)) := by
-  change (rightTranslationAlgEquiv g).toAlgHom x = _
-  rw [rightTranslationAlgEquiv_toAlgHom, rightTranslationAlgHom_apply]
+  calc
+    rightTranslationAlgEquiv g x = (rightTranslationAlgEquiv g).toAlgHom x :=
+      (rightTranslationAlgEquiv g).toAlgHom_apply x |>.symm
+    _ = rightTranslationAlgHom g x :=
+      DFunLike.congr_fun (rightTranslationAlgEquiv_toAlgHom g) x
+    _ = _ := rightTranslationAlgHom_apply g x
 
 /-- Evaluating a right-translated function at the identity evaluates the original function at
 the translating point. -/
@@ -205,21 +211,6 @@ theorem counitAlgHom_comp_rightTranslationAlgHom (g : WithConv (H →ₐ[k] k)) 
   change (1 * g).ofConv = g.ofConv
   rw [one_mul]
 
-/-- Contraction of the augmentation point along right translation gives the translating point. -/
-@[simp]
-theorem comap_rightTranslationAlgEquiv_augmentationPoint
-    (g : WithConv (H →ₐ[k] k)) :
-    PrimeSpectrum.comap (rightTranslationAlgEquiv g)
-        (Bialgebra.augmentationPoint k H) =
-      AlgHom.kernelPoint g.ofConv := by
-  -- These abbreviations reduce `Spec H` points to kernels of their representing algebra maps.
-  change PrimeSpectrum.comap
-      ((rightTranslationAlgEquiv g).toAlgHom : H →+* H)
-        (AlgHom.kernelPoint (_root_.Bialgebra.counitAlgHom k H)) =
-    AlgHom.kernelPoint g.ofConv
-  rw [rightTranslationAlgEquiv_toAlgHom, AlgHom.comap_kernelPoint,
-    counitAlgHom_comp_rightTranslationAlgHom]
-
 /-- Right translation on the prime spectrum. The inverse algebra equivalence occurs because
 `Spec` is contravariant. -/
 noncomputable def rightTranslationHomeomorph (g : WithConv (H →ₐ[k] k)) :
@@ -235,5 +226,29 @@ theorem rightTranslationHomeomorph_apply (g : WithConv (H →ₐ[k] k))
       PrimeSpectrum.comap ((rightTranslationAlgEquiv g).toRingEquiv : H →+* H) x := by
   rw [rightTranslationHomeomorph]
   rfl
+
+end CommRing
+
+section Field
+
+variable {k : Type u} [Field k]
+variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H]
+
+/-- Contraction of the augmentation point along right translation gives the translating point. -/
+@[simp]
+theorem comap_rightTranslationAlgEquiv_augmentationPoint
+    (g : WithConv (H →ₐ[k] k)) :
+    PrimeSpectrum.comap (rightTranslationAlgEquiv g)
+        (Bialgebra.augmentationPoint k H) =
+      AlgHom.kernelPoint g.ofConv := by
+  -- These abbreviations reduce `Spec H` points to kernels of their representing algebra maps.
+  change PrimeSpectrum.comap
+      ((rightTranslationAlgEquiv g).toAlgHom : H →+* H)
+        (AlgHom.kernelPoint (_root_.Bialgebra.counitAlgHom k H)) =
+    AlgHom.kernelPoint g.ofConv
+  rw [rightTranslationAlgEquiv_toAlgHom, AlgHom.comap_kernelPoint,
+    counitAlgHom_comp_rightTranslationAlgHom]
+
+end Field
 
 end TauCeti.HopfAlgebra


### PR DESCRIPTION
This PR adds right translation by a rational point as an algebra automorphism of a commutative Hopf algebra, identifies the induced homeomorphism on the prime spectrum, and proves that a point in the identity component preserves both that component and its defining idempotent ideal.

The exact ReductiveGroups roadmap target is `ReductiveGroups/README.md`, Layer 3 milestone “Identity component `G°` and component group `π₀(G)`.” This prerequisite supplies `rightTranslationAlgEquiv` and `rightTranslation_preserves_augmentationPoint_connectedComponent`, which the milestone's next comultiplication-closure proof consumes to show multiplication carries the identity component times itself into the identity component.

After this PR, comultiplication closure of the connected-component ideal and construction of the quotient Hopf algebra remain before the roadmap can proceed to geometric connectedness and the finite étale component group under its stated hypotheses.

The construction reuses Mathlib's convolution algebra-hom infrastructure and Tau Ceti's regular-comodule point action; no infrastructure is vendored.

The targeted module build, changed-declaration axiom audit, and changed-environment lint check pass.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"point-translation-connected-components"}-->

🤖 Prepared with Codex
