### PR TITLE
feat(SpecialLinearGroup): the centre of SL₂ is {±I} over a ring without zero divisors

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -18,9 +18,9 @@ The natural reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)` is surjective (strong
 `SL₂`; Shimura §1.6, Serre Ch. VII), and the base-change map `SL(n, R) → GL(n, S)` sends
 `-I` to `-I`.
 
-Both of those concern `±I`, and so does the third result here: over a commutative ring
-without zero divisors the centre of `SL₂` is exactly `{±I}`, the scalar form Mathlib gives
-having no other square roots of `1` to offer.
+The third result pins down `±I` itself, which is what the base-change statement moves around:
+over a commutative ring without zero divisors the centre of `SL₂` is exactly `{±I}`, the
+scalar form Mathlib gives having no other square roots of `1` to offer.
 
 The surjectivity is ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/HeckeRIngs/GLn/SL2Surjection.lean`, Chris Birkbeck). Prerequisite for the
@@ -65,10 +65,10 @@ variable {R : Type*} [CommRing R]
 into an alternative. The hypothesis is needed, not incidental — over `ZMod 8` the scalar `3`
 also squares to `1`, so the centre is strictly larger than `{±I}` there.
 
-Not `@[simp]`, matching the lemma it specialises: Mathlib's
-`Matrix.SpecialLinearGroup.mem_center_iff` (`Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean`)
-carries no attribute either, and central membership is a hypothesis one discharges rather than a
-term one normalises. -/
+`@[simp]` because the rewrite terminates: it takes a structured membership to a disjunction of
+equalities, and nothing rewrites `γ ∈ Subgroup.center _` first — Mathlib's general
+`Subgroup.mem_center_iff` is `@[to_additive]` but carries no `simp` attribute. -/
+@[simp]
 theorem mem_center_iff_eq_one_or_eq_neg_one [NoZeroDivisors R] {γ : SpecialLinearGroup (Fin 2) R} :
     γ ∈ Subgroup.center (SpecialLinearGroup (Fin 2) R) ↔ γ = 1 ∨ γ = -1 := by
   refine ⟨fun hγ ↦ ?_, ?_⟩

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -12,11 +12,15 @@ import Mathlib.Tactic.LinearCombination
 import TauCeti.Data.ZMod.Units
 
 /-!
-# Special linear groups: surjectivity of reduction, and the image of `-I`
+# Special linear groups: surjectivity of reduction, the centre, and the image of `-I`
 
 The natural reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)` is surjective (strong approximation for
 `SL₂`; Shimura §1.6, Serre Ch. VII), and the base-change map `SL(n, R) → GL(n, S)` sends
 `-I` to `-I`.
+
+Both of those concern `±I`, and so does the third result here: over a commutative ring
+without zero divisors the centre of `SL₂` is exactly `{±I}`, the scalar form Mathlib gives
+having no other square roots of `1` to offer.
 
 The surjectivity is ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/HeckeRIngs/GLn/SL2Surjection.lean`, Chris Birkbeck). Prerequisite for the
@@ -27,6 +31,8 @@ diamond operators of the ModularForms roadmap (Layer 0), where it realizes every
 
 * `Matrix.SpecialLinearGroup.map_intCast_zmod_surjective`: strong approximation for `SL₂`.
 * `Matrix.SpecialLinearGroup.mapGL_neg_one`: `mapGL S (-1) = -1`.
+* `Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one`: the centre of `SL₂` is
+  `{±I}` when `R` has no zero divisors.
 
 ## References
 
@@ -51,6 +57,28 @@ lemma mapGL_neg_one {n R S : Type*} [Fintype n] [DecidableEq n] [CommRing R] [Co
   rcases eq_or_ne i j with h | h <;> simp [mapGL, h]
 
 variable {R : Type*} [CommRing R]
+
+/-- **The centre of `SL₂` is `{±I}`** over any commutative ring without zero divisors.
+
+`Matrix.SpecialLinearGroup.mem_center_iff` puts a central element in scalar form `r • I` with
+`r ^ 2 = 1`; without zero divisors the only such scalars are `±1`, which turns that existential
+into an alternative. The hypothesis is needed, not incidental — over `ZMod 8` the scalar `3`
+also squares to `1`, so the centre is strictly larger than `{±I}` there.
+
+Not `@[simp]`, matching the lemma it specialises: Mathlib's
+`Matrix.SpecialLinearGroup.mem_center_iff` (`Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean`)
+carries no attribute either, and central membership is a hypothesis one discharges rather than a
+term one normalises. -/
+theorem mem_center_iff_eq_one_or_eq_neg_one [NoZeroDivisors R] {γ : SpecialLinearGroup (Fin 2) R} :
+    γ ∈ Subgroup.center (SpecialLinearGroup (Fin 2) R) ↔ γ = 1 ∨ γ = -1 := by
+  refine ⟨fun hγ ↦ ?_, ?_⟩
+  · obtain ⟨r, hr, hscal⟩ := mem_center_iff.mp hγ
+    -- `r ^ 2 = 1` has only the two roots because `R` has no zero divisors.
+    rcases mul_self_eq_one_iff.mp (by simpa [pow_two] using hr) with rfl | rfl <;> [left; right] <;>
+      exact Subtype.ext (by simpa [map_neg, map_one] using hscal.symm)
+  · rintro (rfl | rfl)
+    · exact Subgroup.one_mem _
+    · exact Subgroup.mem_center_iff.mpr fun g ↦ by rw [neg_one_mul, mul_neg_one]
 
 /-- The `(1,0)` coordinate of the inverse of an `SL₂` element, from `SL2_inv_expl`. -/
 @[simp]

--- a/TauCeti/NumberTheory/ModularForms/WithCenter.lean
+++ b/TauCeti/NumberTheory/ModularForms/WithCenter.lean
@@ -11,9 +11,10 @@ public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
 # Adjoining the centre to a subgroup of `SL(2, ℤ)`
 
 `Subgroup.withCenter` adjoins the centre of the ambient group. For `Γ ≤ SL(2, ℤ)` that centre is
-`{±I}`, so the general characterisation `Subgroup.mem_withCenter_iff` — an element of `Γ·Z(G)` is
-one of `Γ` times a central one — sharpens to the concrete reading recorded here: `Γ·{±I}` is
-exactly `Γ` together with its negatives.
+`{±I}`, by `Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one`, so the general
+characterisation `Subgroup.mem_withCenter_iff` — an element of `Γ·Z(G)` is one of `Γ` times a
+central one — sharpens to the concrete reading recorded here: `Γ·{±I}` is exactly `Γ` together
+with its negatives.
 
 This is the form every `SL(2, ℤ)` consumer wants, and it depends on nothing beyond the general
 `withCenter` API and the description of the centre of `SpecialLinearGroup`, so it sits here rather
@@ -42,16 +43,14 @@ theorem _root_.Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg {γ : SL(2, ℤ)}
     γ ∈ Γ.withCenter ↔ ∃ γ' ∈ Γ, γ = γ' ∨ γ = -γ' := by
   refine ⟨fun hγ ↦ ?_, ?_⟩
   · obtain ⟨a, ha, b, hb, rfl⟩ := Subgroup.mem_withCenter_iff.mp hγ
-    obtain ⟨r, hr, hscal⟩ := Matrix.SpecialLinearGroup.mem_center_iff.mp hb
-    have hb1 : b = 1 ∨ b = -1 := by
-      have hr1 : r = 1 ∨ r = -1 :=
-        Int.isUnit_iff.mp (IsUnit.of_mul_eq_one r (by simpa [pow_two] using hr))
-      rcases hr1 with rfl | rfl <;> [left; right] <;> exact Subtype.ext (by simpa using hscal.symm)
-    exact ⟨a, ha, by rcases hb1 with rfl | rfl <;> simp⟩
+    exact ⟨a, ha, by
+      rcases Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one.mp hb with rfl | rfl <;>
+        simp⟩
   · rintro ⟨γ', hγ', rfl | rfl⟩
     · exact Subgroup.mem_withCenter_iff.mpr ⟨_, hγ', 1, Subgroup.one_mem _, mul_one _⟩
     · exact Subgroup.mem_withCenter_iff.mpr ⟨_, hγ', -1,
-        Subgroup.mem_center_iff.mpr fun g ↦ by rw [neg_one_mul, mul_neg_one], mul_neg_one _⟩
+        Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one.mpr (Or.inr rfl),
+        mul_neg_one _⟩
 
 end TauCeti.ModularForm
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"modularforms-sl2-center-pm-one"}-->

Refactor of existing code — the fact was already proved, inline and unnamed, inside one proof —
so no fresh roadmap target is claimed. `ModularForms` is the roadmap that motivates it: the
`withCenter` API this serves is the `±Γ` half of the level-one index bookkeeping, and the
destination file already records itself as a Layer-0 prerequisite for the diamond operators.

### The fact had no name

`Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg` (merged in #3414) needed "a central element of
`SL(2, ℤ)` is `±I`", and proved it inline as an anonymous `have`:

```lean
have hb1 : b = 1 ∨ b = -1 := by
  have hr1 : r = 1 ∨ r = -1 :=
    Int.isUnit_iff.mp (IsUnit.of_mul_eq_one r (by simpa [pow_two] using hr))
  rcases hr1 with rfl | rfl <;> [left; right] <;> exact Subtype.ext (by simpa using hscal.symm)
```

Nothing else could reach it. That matters right now because #3373's
`Subgroup.relIndex_withCenter_eq_two` and `Subgroup.index_eq_two_mul_index_withCenter` are on
`main` taking

```lean
(hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a)
```

and **no consumer anywhere outside `GroupTheory/Index.lean` supplies it** — at `SL(2, ℤ)` the
hypothesis was simply unprovable from the public API. This names the fact, so it can be.

### It is not about `ℤ`

Written out, the proof uses the integers only to know that `r * r = 1` forces `r = ±1`. That is
`mul_self_eq_one_iff`, whose hypotheses are `[NonAssocRing R] [NoZeroDivisors R]` — so the lemma is
stated over any commutative ring without zero divisors:

```lean
theorem mem_center_iff_eq_one_or_eq_neg_one [NoZeroDivisors R] {γ : SpecialLinearGroup (Fin 2) R} :
    γ ∈ Subgroup.center (SpecialLinearGroup (Fin 2) R) ↔ γ = 1 ∨ γ = -1
```

`NoZeroDivisors` is load-bearing, not decorative — dropping it fails with
`failed to synthesize NoZeroDivisors R` (drop-tested), and the mathematical reason is concrete:
over `ZMod 8` the scalar `3` also squares to `1`, so the centre there is strictly larger than
`{±I}`. That counterexample is recorded on the declaration.

### Placement

Because it is general, it does **not** belong in a `ModularForms` file. It goes to
`TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean`, which already owns the general
`SpecialLinearGroup (Fin 2) R` lemmas (`inv_apply_*`) under exactly the `variable {R} [CommRing R]`
this needs, is already imported by `WithCenter.lean`, and already carries the neighbouring `±I`
result `mapGL_neg_one`. **No new import is required** in either file.

### Effect on the caller

`WithCenter.lean`'s forward branch loses the scalar-unfolding entirely:

```lean
    exact ⟨a, ha, by
      rcases Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one.mp hb with rfl | rfl <;>
        simp⟩
```

and the reverse branch stops hand-building `-1 ∈ center` from `Subgroup.mem_center_iff`, using the
new lemma's `.mpr` instead — so it is consumed in **both** directions, not merely relocated.

The extraction also shortened the proof: `mul_self_eq_one_iff` replaces the
`Int.isUnit_iff` + `IsUnit.of_mul_eq_one` pair, which only ever existed because the fact was
trapped at `ℤ`.

### Mathlib absence

Mathlib has the general shape and not this one. `Matrix.SpecialLinearGroup.mem_center_iff`
(`Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean:256`) gives the scalar form `∃ r, r ^ card n
= 1 ∧ scalar n r = A`, and `center_equiv_rootsOfUnity'` packages the centre as `rootsOfUnity`;
neither resolves the dimension-2 case to an alternative. Searched the **whole** pinned tree, not
one file — including the separate *module* `SpecialLinearGroup R V` in
`Mathlib/LinearAlgebra/SpecialLinearGroup.lean`, whose `mem_center_iff` and
`centerEquivRootsOfUnity` are a different type reachable only through `toLin_equiv`, and the PSL
files (`Projectivization/PSL/PSL2.lean`, `Matrix/ProjectiveSpecialLinearGroup.lean`), which mention
the centre only as the thing being quotiented by. No group-level `neg_one_mem_center` exists
either; Mathlib's `Set.neg_mem_center` is about a *ring's* `Set.center`, and `SL(2, R)` is not a
ring.

In TauCeti the only pre-existing centre facts at `SL(2, ℤ)` are the **private**
`card_center : Nat.card (Subgroup.center SL(2, ℤ)) = 2` and `sl2zToPSL2R_ker`, neither of which is
this statement.

### Follow-up, deliberately not in this PR

That private `card_center` (`NumberTheory/Modular/Stabilizer.lean:173`) currently goes the long way
round, through `centerCongr`, `toLin'_equiv` and `centerEquivRootsOfUnity`; it is a short corollary
of this lemma. It is **not** touched here because open PR #3350 already modifies that same file,
and forking it across two branches is how stacked PRs get painful. It goes in after #3350 lands.

### Verification

`lake build` green; `lake exe axioms` clean; `lake exe module-system` clean; `LINT-ENV: PASS`.
Exact counts in the commit trail. No line over 100 codepoints (measured with `wc -m`, not
`awk length`).
