### PR TITLE
chore: drop dead classical from the exchangeability proofs

### DIFF
--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/BlockCylinder.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/BlockCylinder.lean
@@ -63,7 +63,6 @@ theorem measure_inter_blockCylinder_eq_setLIntegral_of_condExp [StandardBorelSpa
     μ ((directingProbabilityMeasure μ X ⁻¹' S) ∩ blockCylinder X k B)
       = ∫⁻ ω in directingProbabilityMeasure μ X ⁻¹' S,
           ∏ i, directingMeasure μ X ω (B i) ∂μ := by
-  classical
   have hTail : tailProcess X ≤ ‹MeasurableSpace Ω› :=
     tailProcess_le_ambient 0 fun j _ => hX_meas j
   have : IsFiniteMeasure (μ.trim hTail) := isFiniteMeasure_trim hTail

--- a/TauCeti/Probability/DeFinetti/JointRectangle.lean
+++ b/TauCeti/Probability/DeFinetti/JointRectangle.lean
@@ -145,7 +145,6 @@ private theorem measure_inter_blockCylinder_eq_setLIntegral_of_injective
         ∩ blockCylinder (fun j (x : ℕ → α) => x j) k B)
       = ∫⁻ ω in directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S,
           ∏ i, directingMeasure μ (fun j (x : ℕ → α) => x j) ω (B i) ∂μ := by
-  classical
   have hY_meas : ∀ j, Measurable (fun x : ℕ → α => x j) := fun j => measurable_pi_apply j
   obtain ⟨π, hπfin, hπval⟩ := Equiv.Perm.exists_finite_compl_fixedBy_apply_eq
     (⟨Fin.val, Fin.val_injective⟩ : Fin m ↪ ℕ) ⟨k, hk⟩

--- a/TauCeti/Probability/DeFinetti/TailFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/TailFactorization.lean
@@ -62,7 +62,6 @@ lemma condExp_blockIndicatorProd_tailProcess_ae_eq_prod
       =ᵐ[μ]
     (fun ω => ∏ i : Fin r,
       μ[Set.indicator (C i) (fun _ => (1 : ℝ)) ∘ X 0 | tailProcess X] ω) := by
-  classical
   -- Reverse-martingale convergence: `μ[f | tailFamily X (m+1)] → μ[f | tailProcess X]` a.e.
   have hconv : ∀ f : Ω → ℝ, ∀ᵐ ω ∂μ,
       Tendsto (fun m => μ[f | tailFamily X (m + 1)] ω) atTop

--- a/TauCeti/Probability/Exchangeability/CondExp.lean
+++ b/TauCeti/Probability/Exchangeability/CondExp.lean
@@ -82,7 +82,6 @@ private theorem map_block_future_eq_pathLaw_map {μ : Measure Ω} [IsFiniteMeasu
     {r c : ℕ} {k : Fin r → ℕ} (hk : StrictMono k) (hkc : ∀ i, k i < c) :
     μ.map (fun ω => (fun i : Fin r => X (k i) ω, fun n => X (c + n) ω))
       = (pathLaw μ X).map (prefixSplitEquiv r) := by
-  classical
   set φ := (prefixSplitEquiv (α := ℕ) r).symm (k, fun n => c + n) with hφdef
   have hφ : StrictMono φ := strictMono_prefixSplitEquiv_symm_block_future hk hkc
   have hsplit : Measurable (prefixSplitEquiv (α := α) r) := (prefixSplitEquiv r).measurable
@@ -137,7 +136,6 @@ theorem Contractable.condExp_block_comp_tailProcess_ae_eq {μ : Measure Ω} [IsF
     {f : (Fin r → α) → ℝ} (hf : Measurable f) :
     μ[fun ω => f (fun i => X (k i) ω) | tailProcess X]
       =ᵐ[μ] μ[fun ω => f (fun i => X (l i) ω) | tailProcess X] := by
-  classical
   set c := max (Finset.univ.sup fun i => k i) (Finset.univ.sup fun i => l i) + 1 with hc
   have hkc : ∀ i, k i < c := fun i => by
     have := Finset.le_sup (f := fun i => k i) (Finset.mem_univ i)

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Moments.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Moments.lean
@@ -208,7 +208,6 @@ private theorem integral_sq_average_sub [IsProbabilityMeasure μ] {e : ℕ → �
       ∫ ω, (e i ω - q ω) * (e j ω - q ω) ∂μ = if i = j then c else 0)
     (hn : n ≠ 0) :
     ∫ ω, ((n : ℝ)⁻¹ * (∑ i ∈ Finset.range n, e i ω) - q ω) ^ 2 ∂μ = (n : ℝ)⁻¹ * c := by
-  classical
   have hdb : ∀ i ∈ Finset.range n, ∀ ω, |e i ω - q ω| ≤ 2 := by
     intro i hi ω
     have h1 := abs_le.mp (heb i hi ω)
@@ -338,7 +337,6 @@ private theorem ConditionallyIIDWith.integral_indicator_sub_directing_mul_indica
       = if i = j then
           (∫ ω, ((ν ω : Measure α) B).toReal ∂μ - ∫ ω, ((ν ω : Measure α) B).toReal ^ 2 ∂μ)
         else 0 := by
-  classical
   have hq : Measurable fun ω => ((ν ω : Measure α) B).toReal :=
     (TauCeti.MeasureTheory.measurable_probabilityMeasure_toMeasure_apply_toReal hB).comp
       h.measurable_directing
@@ -392,7 +390,6 @@ theorem ConditionallyIIDWith.integral_empiricalFrequency_sub_sq [IsProbabilityMe
           - ((ν ω : Measure α) B).toReal) ^ 2 ∂μ
       = (n : ℝ)⁻¹ * (∫ ω, ((ν ω : Measure α) B).toReal ∂μ
           - ∫ ω, ((ν ω : Measure α) B).toReal ^ 2 ∂μ) := by
-  classical
   have hq : Measurable fun ω => ((ν ω : Measure α) B).toReal :=
     (TauCeti.MeasureTheory.measurable_probabilityMeasure_toMeasure_apply_toReal hB).comp
       h.measurable_directing

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -254,7 +254,6 @@ private theorem map_prod_tail_eq_pathLaw_map {μ : Measure Ω} [IsFiniteMeasure 
     {h : ℕ} (hh : h < g 0) :
     μ.map (fun ω => (X h ω, fun n => X (g n) ω))
       = (pathLaw μ X).map (fun f : ℕ → α => (f 0, fun n => f (n + 1))) := by
-  classical
   let headTail : (ℕ → α) → α × (ℕ → α) := fun f => (f 0, fun n => f (n + 1))
   have hheadTail_meas : Measurable headTail :=
     (measurable_pi_apply 0).prodMk (measurable_pi_lambda _ fun n => measurable_pi_apply (n + 1))

--- a/TauCeti/Probability/Exchangeability/PathSpace/Invariant/BlockTransport.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Invariant/BlockTransport.lean
@@ -236,7 +236,6 @@ theorem ContractableLaw.setIntegral_comp_coord_eq_comp_zero_of_measurableSet_inv
     {A : Set (ℕ → α)} (hA : MeasurableSet[MeasurableSpace.invariants (shift α)] A)
     {f : α → ℝ} (hf : Measurable f) :
     ∫ x in A, f (x r) ∂ρ = ∫ x in A, f (x 0) ∂ρ := by
-  classical
   have hmap := hρ.map_restrict_prefixProj_of_strictMono_of_measurableSet_invariants
     (k := fun _ : Fin 1 => r) (Subsingleton.strictMono _) hA
   have hmap0 := hρ.map_restrict_prefixProj_of_strictMono_of_measurableSet_invariants

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -49,7 +49,6 @@ theorem exists_strictMono_nat_extending_fin_eventually_add {m : ℕ} {k : Fin m 
     (hk : StrictMono k) :
     ∃ (φ : ℕ → ℕ) (C : ℕ), StrictMono φ ∧ (∀ i : Fin m, φ i.val = k i) ∧
       ∀ n, m ≤ n → φ n = n + C := by
-  classical
   let C := Finset.univ.sup k + 1
   let φ : ℕ → ℕ := fun n => if h : n < m then k ⟨n, h⟩ else n + C
   refine ⟨φ, C, ?_, ?_, ?_⟩


### PR DESCRIPTION
Eleven bare `classical` invocations across eight modules, none of which any proof needs.

Verified per file rather than in bulk: each file was rebuilt with its `classical` lines deleted, and
each compiled unchanged. No proof, statement or hypothesis is touched.

```
Exchangeability/PermutationExtension.lean
Exchangeability/CondExp.lean                        (2)
Exchangeability/Contractability.lean
Exchangeability/ConditionallyIID/Moments.lean       (3)
Exchangeability/PathSpace/Invariant/BlockTransport.lean
DeFinetti/TailFactorization.lean
DeFinetti/DirectingMeasure/BlockCylinder.lean
DeFinetti/JointRectangle.lean
```

The same dead-scaffolding finding was raised by `proof-quality` on #3152 and #3168, and fixed for one
file in #3312. This clears the remainder in the area rather than waiting for it to be raised eight
more times.

Roadmap: Exchangeability

Dead-code removal in existing proofs; no mathematical content changes.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
