### PR TITLE
feat: filter the lattice chain complex by weight

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/Cube/Sublevel.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Sublevel.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LowDimTopology.Plumbing.Cube.Generator
+public import TauCeti.LowDimTopology.Plumbing.Weight.Sublevel
+
+/-!
+# Characteristic-weight sublevels of plumbing cubes
+
+For a characteristic covector `k` and an integer `N`, this file defines the plumbing cubes whose
+characteristic cube weight is at most `N`. These sublevels are closed under cubical faces and are
+finite when the plumbing form is negative definite.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L. The filtration by
+sublevel cubical complexes is the construction in A. Némethi,
+[arXiv:0709.0841](https://arxiv.org/abs/0709.0841), Section 3.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace PlumbingGraph
+
+variable {V : Type*} [DecidableEq V] [Fintype V]
+
+/-- The set of plumbing cubes whose characteristic weight is at most `N`. -/
+@[expose] def characteristicCubeWeightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors)
+    (N : ℤ) : Set (PlumbingCube V) :=
+  {C | C.characteristicWeight P k ≤ N}
+
+/-- Membership in a cube-weight sublevel set is the corresponding weight inequality. -/
+@[simp]
+theorem mem_characteristicCubeWeightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (C : PlumbingCube V) :
+    C ∈ P.characteristicCubeWeightSublevel k N ↔ C.characteristicWeight P k ≤ N :=
+  Iff.rfl
+
+/-- Characteristic cube-weight sublevel sets increase with the level. -/
+theorem characteristicCubeWeightSublevel_mono (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) :
+    P.characteristicCubeWeightSublevel k N ⊆ P.characteristicCubeWeightSublevel k M :=
+  fun _ hC ↦ hC.trans hNM
+
+/-- The lower face of a cube in a characteristic-weight sublevel remains in that sublevel. -/
+theorem lowerFace_mem_characteristicCubeWeightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N : ℤ} {C : PlumbingCube V}
+    (hC : C ∈ P.characteristicCubeWeightSublevel k N) {v : V} (hv : v ∈ C.directions) :
+    C.lowerFace v hv ∈ P.characteristicCubeWeightSublevel k N :=
+  (PlumbingCube.characteristicWeight_lowerFace_le P k C hv).trans hC
+
+/-- The upper face of a cube in a characteristic-weight sublevel remains in that sublevel. -/
+theorem upperFace_mem_characteristicCubeWeightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N : ℤ} {C : PlumbingCube V}
+    (hC : C ∈ P.characteristicCubeWeightSublevel k N) {v : V} (hv : v ∈ C.directions) :
+    C.upperFace v hv ∈ P.characteristicCubeWeightSublevel k N :=
+  (PlumbingCube.characteristicWeight_upperFace_le P k C hv).trans hC
+
+/-- On a negative-definite plumbing every characteristic cube-weight sublevel set is finite.
+
+A cube in the sublevel has its base point in the point-weight sublevel, while its direction set
+belongs to the finite type `Finset V`. The pair of these data determines the cube. -/
+theorem finite_characteristicCubeWeightSublevel (P : PlumbingGraph V)
+    (h : P.IsNegativeDefinite) (k : P.characteristicVectors) (N : ℤ) :
+    (P.characteristicCubeWeightSublevel k N).Finite := by
+  let encode : PlumbingCube V → (V → ℤ) × Finset V := fun C ↦ (C.base, C.directions)
+  have hencode : Function.Injective encode := by
+    intro C D hCD
+    exact PlumbingCube.ext (congrArg Prod.fst hCD) (congrArg Prod.snd hCD)
+  have hproduct :
+      ({x : V → ℤ | P.characteristicWeight k x ≤ N} ×ˢ
+        (Set.univ : Set (Finset V))).Finite :=
+    (P.finite_setOfPred_characteristicWeight_le h k N).prod Set.finite_univ
+  refine (hproduct.preimage hencode.injOn).subset ?_
+  intro C hC
+  refine ⟨?_, Set.mem_univ C.directions⟩
+  have hbase := P.characteristicWeight_le_characteristicCubeWeight_base
+    k C.base C.directions
+  rw [← PlumbingCube.characteristicWeight_mk] at hbase
+  exact hbase.trans ((P.mem_characteristicCubeWeightSublevel k N C).mp hC)
+
+end PlumbingGraph
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Sublevel.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Sublevel.lean
@@ -30,7 +30,7 @@ namespace PlumbingGraph
 variable {V : Type*} [DecidableEq V] [Fintype V]
 
 /-- The set of plumbing cubes whose characteristic weight is at most `N`. -/
-@[expose] def characteristicCubeWeightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors)
+def characteristicCubeWeightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors)
     (N : ℤ) : Set (PlumbingCube V) :=
   {C | C.characteristicWeight P k ≤ N}
 
@@ -45,21 +45,26 @@ theorem mem_characteristicCubeWeightSublevel (P : PlumbingGraph V)
 theorem characteristicCubeWeightSublevel_mono (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) :
     P.characteristicCubeWeightSublevel k N ⊆ P.characteristicCubeWeightSublevel k M :=
-  fun _ hC ↦ hC.trans hNM
+  fun C hC ↦ (P.mem_characteristicCubeWeightSublevel k M C).mpr
+    ((P.mem_characteristicCubeWeightSublevel k N C).mp hC |>.trans hNM)
 
 /-- The lower face of a cube in a characteristic-weight sublevel remains in that sublevel. -/
 theorem lowerFace_mem_characteristicCubeWeightSublevel (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N : ℤ} {C : PlumbingCube V}
     (hC : C ∈ P.characteristicCubeWeightSublevel k N) {v : V} (hv : v ∈ C.directions) :
     C.lowerFace v hv ∈ P.characteristicCubeWeightSublevel k N :=
-  (PlumbingCube.characteristicWeight_lowerFace_le P k C hv).trans hC
+  (P.mem_characteristicCubeWeightSublevel k N _).mpr
+    ((PlumbingCube.characteristicWeight_lowerFace_le P k C hv).trans
+      ((P.mem_characteristicCubeWeightSublevel k N C).mp hC))
 
 /-- The upper face of a cube in a characteristic-weight sublevel remains in that sublevel. -/
 theorem upperFace_mem_characteristicCubeWeightSublevel (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N : ℤ} {C : PlumbingCube V}
     (hC : C ∈ P.characteristicCubeWeightSublevel k N) {v : V} (hv : v ∈ C.directions) :
     C.upperFace v hv ∈ P.characteristicCubeWeightSublevel k N :=
-  (PlumbingCube.characteristicWeight_upperFace_le P k C hv).trans hC
+  (P.mem_characteristicCubeWeightSublevel k N _).mpr
+    ((PlumbingCube.characteristicWeight_upperFace_le P k C hv).trans
+      ((P.mem_characteristicCubeWeightSublevel k N C).mp hC))
 
 /-- On a negative-definite plumbing every characteristic cube-weight sublevel set is finite.
 

--- a/TauCeti/LowDimTopology/Plumbing/Filtration.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Filtration.lean
@@ -6,7 +6,7 @@ module
 
 public import Mathlib.RingTheory.Finiteness.Finsupp
 public import TauCeti.LowDimTopology.Plumbing.ChainComplex
-public import TauCeti.LowDimTopology.Plumbing.Weight.Sublevel
+public import TauCeti.LowDimTopology.Plumbing.Cube.Sublevel
 
 /-!
 # The weight filtration on the lattice chain complex
@@ -29,9 +29,10 @@ Némethi's `ℍ⁻` are subsequent steps.
 
 ## Main definitions
 
-* `TauCeti.PlumbingGraph.cubeWeightSublevel`: cubes of weight at most `N`.
-* `TauCeti.PlumbingChain.weightSublevel`: chains supported on those cubes.
-* `TauCeti.PlumbingChain.weightDegreePart`: the weight-`≤ N`, cubical-degree-`q` chain group.
+* `TauCeti.PlumbingGraph.characteristicCubeWeightSublevel`: cubes of weight at most `N`.
+* `TauCeti.PlumbingChain.supportedCharacteristicWeightSublevel`: chains supported on those cubes.
+* `TauCeti.PlumbingChain.characteristicWeightDegreePart`: the weight-`≤ N`,
+  cubical-degree-`q` chain group.
 * `TauCeti.PlumbingGraph.latticeDifferentialWeightDegree`: the restricted differential.
 * `TauCeti.PlumbingGraph.latticeWeightSublevelComplex`: the filtered chain complex at level `N`.
 * `TauCeti.PlumbingGraph.latticeWeightSublevelInclusion`: the inclusion between filtration levels.
@@ -50,193 +51,170 @@ namespace TauCeti
 
 open CategoryTheory
 
-namespace PlumbingGraph
-
-variable {V : Type*} [DecidableEq V] [Fintype V]
-
-/-- The set of plumbing cubes whose characteristic weight is at most `N`. -/
-def cubeWeightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ) :
-    Set (PlumbingCube V) :=
-  {C | C.characteristicWeight P k ≤ N}
-
-/-- Membership in a cube-weight sublevel set is the corresponding weight inequality. -/
-@[simp]
-theorem mem_cubeWeightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ)
-    (C : PlumbingCube V) :
-    C ∈ P.cubeWeightSublevel k N ↔ C.characteristicWeight P k ≤ N :=
-  Iff.rfl
-
-/-- Cube-weight sublevel sets increase with the level. -/
-theorem cubeWeightSublevel_mono (P : PlumbingGraph V) (k : P.characteristicVectors)
-    {N M : ℤ} (hNM : N ≤ M) : P.cubeWeightSublevel k N ⊆ P.cubeWeightSublevel k M :=
-  fun _ hC => hC.trans hNM
-
-/-- The lower face of a cube in a weight sublevel remains in that sublevel. -/
-theorem lowerFace_mem_cubeWeightSublevel (P : PlumbingGraph V)
-    (k : P.characteristicVectors) {N : ℤ} {C : PlumbingCube V}
-    (hC : C ∈ P.cubeWeightSublevel k N) {v : V} (hv : v ∈ C.directions) :
-    C.lowerFace v hv ∈ P.cubeWeightSublevel k N :=
-  (PlumbingCube.characteristicWeight_lowerFace_le P k C hv).trans hC
-
-/-- The upper face of a cube in a weight sublevel remains in that sublevel. -/
-theorem upperFace_mem_cubeWeightSublevel (P : PlumbingGraph V)
-    (k : P.characteristicVectors) {N : ℤ} {C : PlumbingCube V}
-    (hC : C ∈ P.cubeWeightSublevel k N) {v : V} (hv : v ∈ C.directions) :
-    C.upperFace v hv ∈ P.cubeWeightSublevel k N :=
-  (PlumbingCube.characteristicWeight_upperFace_le P k C hv).trans hC
-
-/-- On a negative-definite plumbing every cube-weight sublevel set is finite.
-
-A cube in the sublevel has its base point in the point-weight sublevel, while its direction set
-belongs to the finite type `Finset V`. The pair of these data determines the cube. -/
-theorem finite_cubeWeightSublevel (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
-    (k : P.characteristicVectors) (N : ℤ) : (P.cubeWeightSublevel k N).Finite := by
-  let encode : PlumbingCube V → (V → ℤ) × Finset V := fun C => (C.base, C.directions)
-  have hencode : Function.Injective encode := by
-    intro C D hCD
-    exact PlumbingCube.ext (congrArg Prod.fst hCD) (congrArg Prod.snd hCD)
-  have hproduct :
-      ({x : V → ℤ | P.characteristicWeight k x ≤ N} ×ˢ
-        (Set.univ : Set (Finset V))).Finite :=
-    (P.finite_setOfPred_characteristicWeight_le h k N).prod Set.finite_univ
-  refine (hproduct.preimage hencode.injOn).subset ?_
-  intro C hC
-  refine ⟨?_, Set.mem_univ C.directions⟩
-  have hbase := P.characteristicWeight_le_characteristicCubeWeight_base
-    k C.base C.directions
-  rw [← PlumbingCube.characteristicWeight_mk] at hbase
-  exact hbase.trans ((P.mem_cubeWeightSublevel k N C).mp hC)
-
-end PlumbingGraph
-
 namespace PlumbingChain
 
 variable {V : Type*} [DecidableEq V] [Fintype V]
 
+private theorem fg_supported_of_finite {R α : Type*} [Semiring R] (s : Set α)
+    (hs : s.Finite) : (Finsupp.supported R R s).FG := by
+  rw [Finsupp.supported_eq_span_single]
+  exact Submodule.fg_span (hs.image fun a ↦ Finsupp.single a 1)
+
 /-- The `𝔽₂[U]`-submodule of plumbing chains supported on cubes of weight at most `N`. -/
-noncomputable def weightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ) :
+@[expose] noncomputable def supportedCharacteristicWeightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) :
     Submodule PlumbingCoefficient (PlumbingChain V) :=
-  Finsupp.supported PlumbingCoefficient PlumbingCoefficient (P.cubeWeightSublevel k N)
+  Finsupp.supported PlumbingCoefficient PlumbingCoefficient (P.characteristicCubeWeightSublevel k N)
+
+/-- The chain-level characteristic-weight sublevel is the submodule supported on the
+corresponding cube sublevel. -/
+theorem supportedCharacteristicWeightSublevel_def (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) :
+    supportedCharacteristicWeightSublevel P k N =
+      Finsupp.supported PlumbingCoefficient PlumbingCoefficient
+        (P.characteristicCubeWeightSublevel k N) :=
+  rfl
 
 /-- A chain belongs to the weight sublevel exactly when every cube in its support has weight at
 most the level. -/
 @[simp]
-theorem mem_weightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ)
-    (c : PlumbingChain V) :
-    c ∈ weightSublevel P k N ↔
+theorem mem_supportedCharacteristicWeightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (c : PlumbingChain V) :
+    c ∈ supportedCharacteristicWeightSublevel P k N ↔
       ∀ C ∈ c.support, C.characteristicWeight P k ≤ N := by
-  rw [weightSublevel, Finsupp.mem_supported]
-  rfl
+  simp [supportedCharacteristicWeightSublevel, Finsupp.mem_supported, Set.subset_def]
 
 /-- A single cube of weight at most `N`, with any coefficient, belongs to the weight sublevel. -/
-theorem single_mem_weightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ)
-    (C : PlumbingCube V) (a : PlumbingCoefficient)
+theorem single_mem_supportedCharacteristicWeightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (C : PlumbingCube V) (a : PlumbingCoefficient)
     (hC : C.characteristicWeight P k ≤ N) :
-    Finsupp.single C a ∈ weightSublevel P k N :=
+    Finsupp.single C a ∈ supportedCharacteristicWeightSublevel P k N :=
   Finsupp.single_mem_supported PlumbingCoefficient a hC
 
 /-- The chain-level weight submodules increase with the level. -/
-theorem weightSublevel_mono (P : PlumbingGraph V) (k : P.characteristicVectors)
-    {N M : ℤ} (hNM : N ≤ M) : weightSublevel P k N ≤ weightSublevel P k M :=
-  Finsupp.supported_mono (P.cubeWeightSublevel_mono k hNM)
+theorem supportedCharacteristicWeightSublevel_mono (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) :
+    supportedCharacteristicWeightSublevel P k N ≤ supportedCharacteristicWeightSublevel P k M :=
+  Finsupp.supported_mono (P.characteristicCubeWeightSublevel_mono k hNM)
 
 /-- Every plumbing chain belongs to some weight sublevel. -/
-theorem exists_mem_weightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors)
-    (c : PlumbingChain V) : ∃ N : ℤ, c ∈ weightSublevel P k N := by
-  by_cases hc : c = 0
-  · exact ⟨0, hc ▸ Submodule.zero_mem _⟩
-  · have hs : c.support.Nonempty := Finsupp.support_nonempty_iff.mpr hc
-    let weights := c.support.image fun C => C.characteristicWeight P k
-    have hweights : weights.Nonempty := hs.image _
-    let N := weights.max' hweights
-    refine ⟨N, (mem_weightSublevel P k N c).mpr fun C hC => ?_⟩
-    exact Finset.le_max' weights _ (Finset.mem_image_of_mem _ hC)
+theorem exists_mem_supportedCharacteristicWeightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (c : PlumbingChain V) :
+    ∃ N : ℤ, c ∈ supportedCharacteristicWeightSublevel P k N := by
+  obtain ⟨N, hN⟩ := Finset.exists_le (c.support.image fun C ↦ C.characteristicWeight P k)
+  refine ⟨N, (mem_supportedCharacteristicWeightSublevel P k N c).mpr fun C hC ↦ ?_⟩
+  exact hN _ (Finset.mem_image_of_mem _ hC)
 
 /-- The weight filtration exhausts the full plumbing chain module. -/
-theorem iSup_weightSublevel_eq_top (P : PlumbingGraph V) (k : P.characteristicVectors) :
-    ⨆ N : ℤ, weightSublevel P k N = ⊤ := by
+theorem iSup_supportedCharacteristicWeightSublevel_eq_top (P : PlumbingGraph V)
+    (k : P.characteristicVectors) :
+    ⨆ N : ℤ, supportedCharacteristicWeightSublevel P k N = ⊤ := by
   apply top_unique
   intro c _
-  obtain ⟨N, hc⟩ := exists_mem_weightSublevel P k c
+  obtain ⟨N, hc⟩ := exists_mem_supportedCharacteristicWeightSublevel P k c
   exact Submodule.mem_iSup_of_mem N hc
 
 /-- On a negative-definite plumbing, each chain-level weight submodule is finitely generated over
 `𝔽₂[U]`. -/
-theorem weightSublevel_fg (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
-    (k : P.characteristicVectors) (N : ℤ) : (weightSublevel P k N).FG := by
-  rw [weightSublevel, Finsupp.supported_eq_span_single]
-  exact Submodule.fg_span ((P.finite_cubeWeightSublevel h k N).image fun C => Finsupp.single C 1)
+theorem supportedCharacteristicWeightSublevel_fg (P : PlumbingGraph V)
+    (h : P.IsNegativeDefinite) (k : P.characteristicVectors) (N : ℤ) :
+    (supportedCharacteristicWeightSublevel P k N).FG := by
+  rw [supportedCharacteristicWeightSublevel_def]
+  exact fg_supported_of_finite _ (P.finite_characteristicCubeWeightSublevel h k N)
 
 /-- The chains simultaneously lying in cubical degree `q` and weight at most `N`. -/
-noncomputable def weightDegreePart (P : PlumbingGraph V) (k : P.characteristicVectors)
-    (N : ℤ) (q : ℕ) :
+@[expose] noncomputable def characteristicWeightDegreePart (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
     Submodule PlumbingCoefficient (PlumbingChain V) :=
-  degreePart V q ⊓ weightSublevel P k N
+  degreePart V q ⊓ supportedCharacteristicWeightSublevel P k N
+
+/-- The filtered degree part is the intersection of the cubical-degree part and the
+chain-level characteristic-weight sublevel. -/
+theorem characteristicWeightDegreePart_def (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    characteristicWeightDegreePart P k N q =
+      degreePart V q ⊓ supportedCharacteristicWeightSublevel P k N :=
+  rfl
+
+/-- A filtered degree part lies in the corresponding unfiltered cubical-degree part. -/
+theorem characteristicWeightDegreePart_le_degreePart (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    characteristicWeightDegreePart P k N q ≤ degreePart V q :=
+  inf_le_left
+
+/-- A filtered degree part lies in the corresponding chain-level characteristic-weight
+sublevel. -/
+theorem characteristicWeightDegreePart_le_supportedCharacteristicWeightSublevel
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    characteristicWeightDegreePart P k N q ≤ supportedCharacteristicWeightSublevel P k N :=
+  inf_le_right
 
 /-- Membership in a weight-graded chain group means that every support cube has the specified
 cubical dimension and weight at most the level. -/
 @[simp]
-theorem mem_weightDegreePart (P : PlumbingGraph V) (k : P.characteristicVectors)
+theorem mem_characteristicWeightDegreePart (P : PlumbingGraph V)
+    (k : P.characteristicVectors)
     (N : ℤ) (q : ℕ) (c : PlumbingChain V) :
-    c ∈ weightDegreePart P k N q ↔
+    c ∈ characteristicWeightDegreePart P k N q ↔
       ∀ C ∈ c.support, C.dimension = q ∧ C.characteristicWeight P k ≤ N := by
-  rw [weightDegreePart, Submodule.mem_inf, mem_degreePart, mem_weightSublevel]
+  rw [characteristicWeightDegreePart, Submodule.mem_inf, mem_degreePart,
+    mem_supportedCharacteristicWeightSublevel]
   aesop
+
+/-- A filtered degree part is the submodule supported on cubes having the prescribed dimension
+and characteristic-weight bound. -/
+theorem characteristicWeightDegreePart_eq_supported (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    characteristicWeightDegreePart P k N q =
+      Finsupp.supported PlumbingCoefficient PlumbingCoefficient
+        {C | C.dimension = q ∧ C.characteristicWeight P k ≤ N} := by
+  have hdegree : degreePart V q =
+      Finsupp.supported PlumbingCoefficient PlumbingCoefficient {C | C.dimension = q} := by
+    ext c
+    rw [mem_degreePart, Finsupp.mem_supported]
+    simp only [Set.subset_def, Finset.mem_coe, Set.mem_ofPred_eq]
+  rw [characteristicWeightDegreePart_def, hdegree,
+    supportedCharacteristicWeightSublevel_def, ← Finsupp.supported_inter]
+  congr 1
 
 /-- A basis cube of dimension `q` and weight at most `N` belongs to the corresponding filtered
 chain group. -/
-theorem single_mem_weightDegreePart (P : PlumbingGraph V) (k : P.characteristicVectors)
-    (N : ℤ) (q : ℕ) (C : PlumbingCube V) (a : PlumbingCoefficient)
+theorem single_mem_characteristicWeightDegreePart (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) (C : PlumbingCube V)
+    (a : PlumbingCoefficient)
     (hdim : C.dimension = q) (hweight : C.characteristicWeight P k ≤ N) :
-    Finsupp.single C a ∈ weightDegreePart P k N q :=
-  ⟨single_mem_degreePart V C a hdim, single_mem_weightSublevel P k N C a hweight⟩
+    Finsupp.single C a ∈ characteristicWeightDegreePart P k N q :=
+  ⟨single_mem_degreePart V C a hdim,
+    single_mem_supportedCharacteristicWeightSublevel P k N C a hweight⟩
 
 /-- Filtered cubical-degree chain groups increase with the weight level. -/
-theorem weightDegreePart_mono (P : PlumbingGraph V) (k : P.characteristicVectors)
+theorem characteristicWeightDegreePart_mono (P : PlumbingGraph V)
+    (k : P.characteristicVectors)
     {N M : ℤ} (hNM : N ≤ M) (q : ℕ) :
-    weightDegreePart P k N q ≤ weightDegreePart P k M q :=
-  inf_le_inf_left _ (weightSublevel_mono P k hNM)
+    characteristicWeightDegreePart P k N q ≤ characteristicWeightDegreePart P k M q :=
+  inf_le_inf_left _ (supportedCharacteristicWeightSublevel_mono P k hNM)
 
 /-- In a fixed cubical degree, the weight filtration exhausts the full degree submodule. -/
-theorem iSup_weightDegreePart_eq_degreePart (P : PlumbingGraph V)
+theorem iSup_characteristicWeightDegreePart_eq_degreePart (P : PlumbingGraph V)
     (k : P.characteristicVectors) (q : ℕ) :
-    ⨆ N : ℤ, weightDegreePart P k N q = degreePart V q := by
+    ⨆ N : ℤ, characteristicWeightDegreePart P k N q = degreePart V q := by
   apply le_antisymm
   · exact iSup_le fun _ => inf_le_left
   · intro c hc
-    obtain ⟨N, hN⟩ := exists_mem_weightSublevel P k c
+    obtain ⟨N, hN⟩ := exists_mem_supportedCharacteristicWeightSublevel P k c
     exact Submodule.mem_iSup_of_mem N ⟨hc, hN⟩
-
-/-- The canonical inclusion from the filtered degree-`q` chains at level `N` to those at a
-larger level `M`. -/
-noncomputable def weightDegreeInclusion (P : PlumbingGraph V) (k : P.characteristicVectors)
-    {N M : ℤ} (hNM : N ≤ M) (q : ℕ) :
-    weightDegreePart P k N q →ₗ[PlumbingCoefficient] weightDegreePart P k M q :=
-  Submodule.inclusion (weightDegreePart_mono P k hNM q)
-
-/-- A filtered-degree inclusion does not change the underlying plumbing chain. -/
-@[simp]
-theorem weightDegreeInclusion_apply (P : PlumbingGraph V) (k : P.characteristicVectors)
-    {N M : ℤ} (hNM : N ≤ M) (q : ℕ) (c : weightDegreePart P k N q) :
-    (weightDegreeInclusion P k hNM q c : PlumbingChain V) = c :=
-  (rfl)
 
 /-- On a negative-definite plumbing, every filtered cubical-degree chain group is finitely
 generated over `𝔽₂[U]`. -/
-theorem weightDegreePart_fg (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+theorem characteristicWeightDegreePart_fg (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
     (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
-    (weightDegreePart P k N q).FG := by
-  have hsupport : weightDegreePart P k N q =
-      Finsupp.supported PlumbingCoefficient PlumbingCoefficient
-        {C | C.dimension = q ∧ C.characteristicWeight P k ≤ N} := by
-    ext c
-    rw [mem_weightDegreePart, Finsupp.mem_supported]
-    rfl
+    (characteristicWeightDegreePart P k N q).FG := by
   have hfinite : {C : PlumbingCube V |
       C.dimension = q ∧ C.characteristicWeight P k ≤ N}.Finite :=
-    (P.finite_cubeWeightSublevel h k N).subset fun _ hC => hC.2
-  rw [hsupport, Finsupp.supported_eq_span_single]
-  exact Submodule.fg_span (hfinite.image fun C => Finsupp.single C 1)
+    (P.finite_characteristicCubeWeightSublevel h k N).subset fun C hC =>
+      (P.mem_characteristicCubeWeightSublevel k N C).mpr hC.2
+  rw [characteristicWeightDegreePart_eq_supported]
+  exact fg_supported_of_finite _ hfinite
 
 end PlumbingChain
 
@@ -245,32 +223,36 @@ namespace PlumbingGraph
 variable {V : Type*} [DecidableEq V] [Fintype V]
 
 /-- The differential of a cube in a weight sublevel is supported in the same sublevel. -/
-theorem latticeDifferentialOnGenerator_mem_weightSublevel (P : PlumbingGraph V)
+theorem latticeDifferentialOnGenerator_mem_supportedCharacteristicWeightSublevel
+    (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N : ℤ} (C : PlumbingCube V)
     (hC : C.characteristicWeight P k ≤ N) :
-    P.latticeDifferentialOnGenerator k C ∈ PlumbingChain.weightSublevel P k N := by
+    P.latticeDifferentialOnGenerator k C ∈
+      PlumbingChain.supportedCharacteristicWeightSublevel P k N := by
   classical
   rw [latticeDifferentialOnGenerator_def]
   apply Submodule.sum_mem
   intro v _
   apply Submodule.add_mem
-  · exact PlumbingChain.single_mem_weightSublevel P k N _ _
-      ((PlumbingCube.characteristicWeight_lowerFace_le P k C v.property).trans hC)
-  · exact PlumbingChain.single_mem_weightSublevel P k N _ _
-      ((PlumbingCube.characteristicWeight_upperFace_le P k C v.property).trans hC)
+  · exact PlumbingChain.single_mem_supportedCharacteristicWeightSublevel P k N _ _
+      (P.lowerFace_mem_characteristicCubeWeightSublevel k hC v.property)
+  · exact PlumbingChain.single_mem_supportedCharacteristicWeightSublevel P k N _ _
+      (P.upperFace_mem_characteristicCubeWeightSublevel k hC v.property)
 
 /-- The lattice differential preserves every chain-level weight submodule. -/
-theorem latticeDifferential_mem_weightSublevel (P : PlumbingGraph V)
+theorem latticeDifferential_mem_supportedCharacteristicWeightSublevel (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N : ℤ} {c : PlumbingChain V}
-    (hc : c ∈ PlumbingChain.weightSublevel P k N) :
-    P.latticeDifferential k c ∈ PlumbingChain.weightSublevel P k N := by
-  rw [PlumbingChain.weightSublevel, Finsupp.supported_eq_span_single] at hc
+    (hc : c ∈ PlumbingChain.supportedCharacteristicWeightSublevel P k N) :
+    P.latticeDifferential k c ∈ PlumbingChain.supportedCharacteristicWeightSublevel P k N := by
+  rw [PlumbingChain.supportedCharacteristicWeightSublevel, Finsupp.supported_eq_span_single] at hc
   refine Submodule.span_induction
-    (p := fun c _ => P.latticeDifferential k c ∈ PlumbingChain.weightSublevel P k N)
+    (p := fun c _ =>
+      P.latticeDifferential k c ∈ PlumbingChain.supportedCharacteristicWeightSublevel P k N)
     ?_ (by rw [map_zero]; exact Submodule.zero_mem _) ?_ ?_ hc
   · rintro _ ⟨C, hC, rfl⟩
     rw [latticeDifferential_single]
-    exact Submodule.smul_mem _ _ (P.latticeDifferentialOnGenerator_mem_weightSublevel k C hC)
+    exact Submodule.smul_mem _ _
+      (P.latticeDifferentialOnGenerator_mem_supportedCharacteristicWeightSublevel k C hC)
   · intro x y _ _ hx hy
     simpa only [map_add] using Submodule.add_mem _ hx hy
   · intro a x _ hx
@@ -278,30 +260,30 @@ theorem latticeDifferential_mem_weightSublevel (P : PlumbingGraph V)
 
 /-- The lattice differential sends filtered chains of cubical degree `q + 1` to filtered chains
 of cubical degree `q`. -/
-theorem latticeDifferential_mem_weightDegreePart (P : PlumbingGraph V)
+theorem latticeDifferential_mem_characteristicWeightDegreePart (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N : ℤ} {q : ℕ} {c : PlumbingChain V}
-    (hc : c ∈ PlumbingChain.weightDegreePart P k N (q + 1)) :
-    P.latticeDifferential k c ∈ PlumbingChain.weightDegreePart P k N q :=
+    (hc : c ∈ PlumbingChain.characteristicWeightDegreePart P k N (q + 1)) :
+    P.latticeDifferential k c ∈ PlumbingChain.characteristicWeightDegreePart P k N q :=
   ⟨P.latticeDifferential_mem_degreePart k hc.1,
-    P.latticeDifferential_mem_weightSublevel k hc.2⟩
+    P.latticeDifferential_mem_supportedCharacteristicWeightSublevel k hc.2⟩
 
 /-- The lattice differential restricted to consecutive cubical degrees inside one weight
 sublevel. -/
 noncomputable def latticeDifferentialWeightDegree (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
-    PlumbingChain.weightDegreePart P k N (q + 1) →ₗ[PlumbingCoefficient]
-      PlumbingChain.weightDegreePart P k N q :=
+    PlumbingChain.characteristicWeightDegreePart P k N (q + 1) →ₗ[PlumbingCoefficient]
+      PlumbingChain.characteristicWeightDegreePart P k N q :=
   ((P.latticeDifferential k).domRestrict
-    (PlumbingChain.weightDegreePart P k N (q + 1))).codRestrict
-      (PlumbingChain.weightDegreePart P k N q) fun c =>
-        P.latticeDifferential_mem_weightDegreePart k c.property
+    (PlumbingChain.characteristicWeightDegreePart P k N (q + 1))).codRestrict
+      (PlumbingChain.characteristicWeightDegreePart P k N q) fun c =>
+        P.latticeDifferential_mem_characteristicWeightDegreePart k c.property
 
 /-- Forgetting the submodule wrappers, the filtered differential is the total lattice
 differential. -/
 @[simp]
 theorem latticeDifferentialWeightDegree_apply (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) (q : ℕ)
-    (c : PlumbingChain.weightDegreePart P k N (q + 1)) :
+    (c : PlumbingChain.characteristicWeightDegreePart P k N (q + 1)) :
     (P.latticeDifferentialWeightDegree k N q c : PlumbingChain V) =
       P.latticeDifferential k c :=
   (rfl)
@@ -321,13 +303,14 @@ theorem latticeDifferentialWeightDegree_comp (P : PlumbingGraph V)
 theorem latticeDifferentialWeightDegree_comp_inclusion (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) (q : ℕ) :
     (P.latticeDifferentialWeightDegree k M q).comp
-        (PlumbingChain.weightDegreeInclusion P k hNM (q + 1)) =
-      (PlumbingChain.weightDegreeInclusion P k hNM q).comp
+        (Submodule.inclusion
+          (PlumbingChain.characteristicWeightDegreePart_mono P k hNM (q + 1))) =
+      (Submodule.inclusion (PlumbingChain.characteristicWeightDegreePart_mono P k hNM q)).comp
         (P.latticeDifferentialWeightDegree k N q) := by
   apply LinearMap.ext
   intro c
   apply Subtype.ext
-  simp only [LinearMap.comp_apply, PlumbingChain.weightDegreeInclusion_apply,
+  simp only [LinearMap.comp_apply, Submodule.coe_inclusion,
     latticeDifferentialWeightDegree_apply]
 
 /-- The cubically graded lattice chain complex restricted to cubes of characteristic weight at
@@ -335,7 +318,8 @@ most `N`. -/
 noncomputable def latticeWeightSublevelComplex (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) : ChainComplex (ModuleCat PlumbingCoefficient) ℕ :=
   ChainComplex.of
-    (fun q => ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N q))
+    (fun q => ModuleCat.of PlumbingCoefficient
+      (PlumbingChain.characteristicWeightDegreePart P k N q))
     (fun q => ModuleCat.ofHom (R := PlumbingCoefficient)
       (P.latticeDifferentialWeightDegree k N q))
     fun q => by
@@ -348,7 +332,7 @@ cubical-degree chain group. -/
 theorem latticeWeightSublevelComplex_X (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
     (P.latticeWeightSublevelComplex k N).X q =
-      ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N q) := by
+      ModuleCat.of PlumbingCoefficient (PlumbingChain.characteristicWeightDegreePart P k N q) := by
   unfold latticeWeightSublevelComplex
   exact congrFun (ChainComplex.of_X _ _ _) q
 
@@ -356,36 +340,35 @@ theorem latticeWeightSublevelComplex_X (P : PlumbingGraph V)
 @[simp]
 theorem latticeWeightSublevelComplex_d (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
-    HEq ((P.latticeWeightSublevelComplex k N).d (q + 1) q)
-      (ModuleCat.ofHom (P.latticeDifferentialWeightDegree k N q) :
-        ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N (q + 1)) ⟶
-          ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N q)) := by
-  rw [latticeWeightSublevelComplex]
-  exact heq_of_eq (ChainComplex.of_d
-    (fun r => ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N r))
-    (fun r => ModuleCat.ofHom (R := PlumbingCoefficient)
-      (P.latticeDifferentialWeightDegree k N r)) q)
+    (P.latticeWeightSublevelComplex k N).d (q + 1) q =
+      eqToHom (P.latticeWeightSublevelComplex_X k N (q + 1)) ≫
+        ModuleCat.ofHom (P.latticeDifferentialWeightDegree k N q) ≫
+          eqToHom (P.latticeWeightSublevelComplex_X k N q).symm := by
+  rw [show P.latticeWeightSublevelComplex_X k N (q + 1) = rfl from Subsingleton.elim _ _,
+    show P.latticeWeightSublevelComplex_X k N q = rfl from Subsingleton.elim _ _]
+  unfold latticeWeightSublevelComplex
+  simp only [ChainComplex.of_d, eqToHom_refl, Category.id_comp, Category.comp_id]
 
 /-- The chain-complex inclusion from weight level `N` to a larger level `M`. -/
 noncomputable def latticeWeightSublevelInclusion (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) :
     P.latticeWeightSublevelComplex k N ⟶ P.latticeWeightSublevelComplex k M :=
-  by
-    unfold latticeWeightSublevelComplex
-    refine ChainComplex.ofHom
-      (fun q => ModuleCat.ofHom (PlumbingChain.weightDegreeInclusion P k hNM q)) ?_
-    intro q
-    simp only [ChainComplex.of_d, ← ModuleCat.ofHom_comp]
-    exact congrArg ModuleCat.ofHom
-      (P.latticeDifferentialWeightDegree_comp_inclusion k hNM q)
+  ChainComplex.ofHom
+    (fun q ↦ ModuleCat.ofHom (Submodule.inclusion
+      (PlumbingChain.characteristicWeightDegreePart_mono P k hNM q)))
+    (fun q ↦ by
+      simp only [latticeWeightSublevelComplex, ChainComplex.of_d, ← ModuleCat.ofHom_comp]
+      exact congrArg ModuleCat.ofHom
+        (P.latticeDifferentialWeightDegree_comp_inclusion k hNM q))
 
-/-- The component of a weight-sublevel inclusion is the corresponding inclusion of filtered
-degree parts, transported across the characteristic descriptions of the complex objects. -/
+/-- The component of a weight-sublevel inclusion is the corresponding submodule inclusion of
+filtered degree parts. -/
 theorem latticeWeightSublevelInclusion_f (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) (q : ℕ) :
     (P.latticeWeightSublevelInclusion k hNM).f q =
       eqToHom (P.latticeWeightSublevelComplex_X k N q) ≫
-        ModuleCat.ofHom (PlumbingChain.weightDegreeInclusion P k hNM q) ≫
+        ModuleCat.ofHom (Submodule.inclusion
+          (PlumbingChain.characteristicWeightDegreePart_mono P k hNM q)) ≫
           eqToHom (P.latticeWeightSublevelComplex_X k M q).symm := by
   unfold latticeWeightSublevelInclusion latticeWeightSublevelComplex
   rfl
@@ -397,8 +380,9 @@ theorem latticeWeightSublevelInclusion_apply (P : PlumbingGraph V)
     (c : (P.latticeWeightSublevelComplex k N).X q) :
     eqToHom (P.latticeWeightSublevelComplex_X k M q)
         ((P.latticeWeightSublevelInclusion k hNM).f q c) =
-      ModuleCat.ofHom (PlumbingChain.weightDegreeInclusion P k hNM q)
-        (eqToHom (P.latticeWeightSublevelComplex_X k N q) c) := by
+      ModuleCat.ofHom (Submodule.inclusion
+        (PlumbingChain.characteristicWeightDegreePart_mono P k hNM q))
+          (eqToHom (P.latticeWeightSublevelComplex_X k N q) c) := by
   rw [← CategoryTheory.comp_apply, latticeWeightSublevelInclusion_f]
   simp only [Category.assoc, eqToHom_trans, eqToHom_refl, Category.comp_id,
     CategoryTheory.comp_apply]
@@ -418,7 +402,7 @@ theorem latticeWeightSublevelInclusion_id (P : PlumbingGraph V)
   rw [CategoryTheory.comp_apply, latticeWeightSublevelInclusion_apply,
     HomologicalComplex.id_f, CategoryTheory.comp_apply, id_apply]
   apply Subtype.ext
-  exact PlumbingChain.weightDegreeInclusion_apply P k (le_refl N) q _
+  rfl
 
 /-- Weight-sublevel inclusions compose to the inclusion between the outer levels. -/
 @[simp]
@@ -436,12 +420,17 @@ theorem latticeWeightSublevelInclusion_comp (P : PlumbingGraph V)
     latticeWeightSublevelInclusion_apply, latticeWeightSublevelInclusion_apply,
     CategoryTheory.comp_apply, latticeWeightSublevelInclusion_apply]
   apply Subtype.ext
-  change ((PlumbingChain.weightDegreeInclusion P k hML q)
-      ((PlumbingChain.weightDegreeInclusion P k hNM q)
-        (eqToHom (P.latticeWeightSublevelComplex_X k N q) c)) : PlumbingChain V) =
-    (PlumbingChain.weightDegreeInclusion P k (hNM.trans hML) q
-      (eqToHom (P.latticeWeightSublevelComplex_X k N q) c) : PlumbingChain V)
-  simp only [PlumbingChain.weightDegreeInclusion_apply]
+  rfl
+
+/-- The characteristic-weight sublevel complexes and their canonical inclusions, as a filtered
+diagram indexed by the ordered set of integers. -/
+noncomputable def latticeWeightSublevelFunctor (P : PlumbingGraph V)
+    (k : P.characteristicVectors) :
+    CategoryTheory.Functor ℤ (ChainComplex (ModuleCat PlumbingCoefficient) ℕ) where
+  obj N := P.latticeWeightSublevelComplex k N
+  map f := P.latticeWeightSublevelInclusion k (leOfHom f)
+  map_id N := P.latticeWeightSublevelInclusion_id k N
+  map_comp f g := (P.latticeWeightSublevelInclusion_comp k (leOfHom f) (leOfHom g)).symm
 
 end PlumbingGraph
 

--- a/TauCeti/LowDimTopology/Plumbing/Filtration.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Filtration.lean
@@ -61,10 +61,17 @@ private theorem fg_supported_of_finite {R α : Type*} [Semiring R] (s : Set α)
   exact Submodule.fg_span (hs.image fun a ↦ Finsupp.single a 1)
 
 /-- The `𝔽₂[U]`-submodule of plumbing chains supported on cubes of weight at most `N`. -/
-@[expose] noncomputable def supportedCharacteristicWeightSublevel (P : PlumbingGraph V)
+noncomputable def supportedCharacteristicWeightSublevel (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) :
     Submodule PlumbingCoefficient (PlumbingChain V) :=
   Finsupp.supported PlumbingCoefficient PlumbingCoefficient (P.characteristicCubeWeightSublevel k N)
+
+private theorem supportedCharacteristicWeightSublevel_def_private (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) :
+    supportedCharacteristicWeightSublevel P k N =
+      Finsupp.supported PlumbingCoefficient PlumbingCoefficient
+        (P.characteristicCubeWeightSublevel k N) :=
+  rfl
 
 /-- The chain-level characteristic-weight sublevel is the submodule supported on the
 corresponding cube sublevel. -/
@@ -73,7 +80,7 @@ theorem supportedCharacteristicWeightSublevel_def (P : PlumbingGraph V)
     supportedCharacteristicWeightSublevel P k N =
       Finsupp.supported PlumbingCoefficient PlumbingCoefficient
         (P.characteristicCubeWeightSublevel k N) :=
-  rfl
+  supportedCharacteristicWeightSublevel_def_private P k N
 
 /-- A chain belongs to the weight sublevel exactly when every cube in its support has weight at
 most the level. -/
@@ -82,14 +89,17 @@ theorem mem_supportedCharacteristicWeightSublevel (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) (c : PlumbingChain V) :
     c ∈ supportedCharacteristicWeightSublevel P k N ↔
       ∀ C ∈ c.support, C.characteristicWeight P k ≤ N := by
-  simp [supportedCharacteristicWeightSublevel, Finsupp.mem_supported, Set.subset_def]
+  rw [supportedCharacteristicWeightSublevel_def, Finsupp.mem_supported]
+  simp only [Set.subset_def, Finset.mem_coe, P.mem_characteristicCubeWeightSublevel]
 
 /-- A single cube of weight at most `N`, with any coefficient, belongs to the weight sublevel. -/
 theorem single_mem_supportedCharacteristicWeightSublevel (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) (C : PlumbingCube V) (a : PlumbingCoefficient)
     (hC : C.characteristicWeight P k ≤ N) :
-    Finsupp.single C a ∈ supportedCharacteristicWeightSublevel P k N :=
-  Finsupp.single_mem_supported PlumbingCoefficient a hC
+    Finsupp.single C a ∈ supportedCharacteristicWeightSublevel P k N := by
+  rw [supportedCharacteristicWeightSublevel_def]
+  exact Finsupp.single_mem_supported PlumbingCoefficient a
+    ((P.mem_characteristicCubeWeightSublevel k N C).mpr hC)
 
 /-- The chain-level weight submodules increase with the level. -/
 theorem supportedCharacteristicWeightSublevel_mono (P : PlumbingGraph V)
@@ -123,10 +133,16 @@ theorem supportedCharacteristicWeightSublevel_fg (P : PlumbingGraph V)
   exact fg_supported_of_finite _ (P.finite_characteristicCubeWeightSublevel h k N)
 
 /-- The chains simultaneously lying in cubical degree `q` and weight at most `N`. -/
-@[expose] noncomputable def characteristicWeightDegreePart (P : PlumbingGraph V)
+noncomputable def characteristicWeightDegreePart (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
     Submodule PlumbingCoefficient (PlumbingChain V) :=
   degreePart V q ⊓ supportedCharacteristicWeightSublevel P k N
+
+private theorem characteristicWeightDegreePart_def_private (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    characteristicWeightDegreePart P k N q =
+      degreePart V q ⊓ supportedCharacteristicWeightSublevel P k N :=
+  rfl
 
 /-- The filtered degree part is the intersection of the cubical-degree part and the
 chain-level characteristic-weight sublevel. -/
@@ -134,7 +150,7 @@ theorem characteristicWeightDegreePart_def (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
     characteristicWeightDegreePart P k N q =
       degreePart V q ⊓ supportedCharacteristicWeightSublevel P k N :=
-  rfl
+  characteristicWeightDegreePart_def_private P k N q
 
 /-- A filtered degree part lies in the corresponding unfiltered cubical-degree part. -/
 theorem characteristicWeightDegreePart_le_degreePart (P : PlumbingGraph V)
@@ -157,7 +173,7 @@ theorem mem_characteristicWeightDegreePart (P : PlumbingGraph V)
     (N : ℤ) (q : ℕ) (c : PlumbingChain V) :
     c ∈ characteristicWeightDegreePart P k N q ↔
       ∀ C ∈ c.support, C.dimension = q ∧ C.characteristicWeight P k ≤ N := by
-  rw [characteristicWeightDegreePart, Submodule.mem_inf, mem_degreePart,
+  rw [characteristicWeightDegreePart_def, Submodule.mem_inf, mem_degreePart,
     mem_supportedCharacteristicWeightSublevel]
   aesop
 
@@ -176,6 +192,8 @@ theorem characteristicWeightDegreePart_eq_supported (P : PlumbingGraph V)
   rw [characteristicWeightDegreePart_def, hdegree,
     supportedCharacteristicWeightSublevel_def, ← Finsupp.supported_inter]
   congr 1
+  ext C
+  simp only [Set.mem_inter_iff, Set.mem_ofPred_eq, P.mem_characteristicCubeWeightSublevel]
 
 /-- A basis cube of dimension `q` and weight at most `N` belongs to the corresponding filtered
 chain group. -/
@@ -235,16 +253,21 @@ theorem latticeDifferentialOnGenerator_mem_supportedCharacteristicWeightSublevel
   intro v _
   apply Submodule.add_mem
   · exact PlumbingChain.single_mem_supportedCharacteristicWeightSublevel P k N _ _
-      (P.lowerFace_mem_characteristicCubeWeightSublevel k hC v.property)
+      ((P.mem_characteristicCubeWeightSublevel k N _).mp
+        (P.lowerFace_mem_characteristicCubeWeightSublevel k
+          ((P.mem_characteristicCubeWeightSublevel k N C).mpr hC) v.property))
   · exact PlumbingChain.single_mem_supportedCharacteristicWeightSublevel P k N _ _
-      (P.upperFace_mem_characteristicCubeWeightSublevel k hC v.property)
+      ((P.mem_characteristicCubeWeightSublevel k N _).mp
+        (P.upperFace_mem_characteristicCubeWeightSublevel k
+          ((P.mem_characteristicCubeWeightSublevel k N C).mpr hC) v.property))
 
 /-- The lattice differential preserves every chain-level weight submodule. -/
 theorem latticeDifferential_mem_supportedCharacteristicWeightSublevel (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N : ℤ} {c : PlumbingChain V}
     (hc : c ∈ PlumbingChain.supportedCharacteristicWeightSublevel P k N) :
     P.latticeDifferential k c ∈ PlumbingChain.supportedCharacteristicWeightSublevel P k N := by
-  rw [PlumbingChain.supportedCharacteristicWeightSublevel, Finsupp.supported_eq_span_single] at hc
+  rw [PlumbingChain.supportedCharacteristicWeightSublevel_def,
+    Finsupp.supported_eq_span_single] at hc
   refine Submodule.span_induction
     (p := fun c _ =>
       P.latticeDifferential k c ∈ PlumbingChain.supportedCharacteristicWeightSublevel P k N)
@@ -252,7 +275,8 @@ theorem latticeDifferential_mem_supportedCharacteristicWeightSublevel (P : Plumb
   · rintro _ ⟨C, hC, rfl⟩
     rw [latticeDifferential_single]
     exact Submodule.smul_mem _ _
-      (P.latticeDifferentialOnGenerator_mem_supportedCharacteristicWeightSublevel k C hC)
+      (P.latticeDifferentialOnGenerator_mem_supportedCharacteristicWeightSublevel k C
+        ((P.mem_characteristicCubeWeightSublevel k N C).mp hC))
   · intro x y _ _ hx hy
     simpa only [map_add] using Submodule.add_mem _ hx hy
   · intro a x _ hx
@@ -336,6 +360,13 @@ theorem latticeWeightSublevelComplex_X (P : PlumbingGraph V)
   unfold latticeWeightSublevelComplex
   exact congrFun (ChainComplex.of_X _ _ _) q
 
+-- `ChainComplex.of_X` identifies definitionally equal objects; proof irrelevance normalizes its
+-- equality proof so that the explicit transports in the public differential formula reduce.
+private theorem latticeWeightSublevelComplex_X_proof_eq_rfl (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    P.latticeWeightSublevelComplex_X k N q = rfl :=
+  Subsingleton.elim _ _
+
 /-- The differential of the weight-sublevel complex is the restricted lattice differential. -/
 @[simp]
 theorem latticeWeightSublevelComplex_d (P : PlumbingGraph V)
@@ -344,8 +375,8 @@ theorem latticeWeightSublevelComplex_d (P : PlumbingGraph V)
       eqToHom (P.latticeWeightSublevelComplex_X k N (q + 1)) ≫
         ModuleCat.ofHom (P.latticeDifferentialWeightDegree k N q) ≫
           eqToHom (P.latticeWeightSublevelComplex_X k N q).symm := by
-  rw [show P.latticeWeightSublevelComplex_X k N (q + 1) = rfl from Subsingleton.elim _ _,
-    show P.latticeWeightSublevelComplex_X k N q = rfl from Subsingleton.elim _ _]
+  rw [P.latticeWeightSublevelComplex_X_proof_eq_rfl k N (q + 1),
+    P.latticeWeightSublevelComplex_X_proof_eq_rfl k N q]
   unfold latticeWeightSublevelComplex
   simp only [ChainComplex.of_d, eqToHom_refl, Category.id_comp, Category.comp_id]
 
@@ -431,6 +462,40 @@ noncomputable def latticeWeightSublevelFunctor (P : PlumbingGraph V)
   map f := P.latticeWeightSublevelInclusion k (leOfHom f)
   map_id N := P.latticeWeightSublevelInclusion_id k N
   map_comp f g := (P.latticeWeightSublevelInclusion_comp k (leOfHom f) (leOfHom g)).symm
+
+private theorem latticeWeightSublevelFunctor_obj_private (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) :
+    (P.latticeWeightSublevelFunctor k).obj N = P.latticeWeightSublevelComplex k N :=
+  rfl
+
+/-- The object at level `N` in the characteristic-weight filtration diagram is the
+corresponding weight-sublevel complex. -/
+@[simp]
+theorem latticeWeightSublevelFunctor_obj (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) :
+    (P.latticeWeightSublevelFunctor k).obj N = P.latticeWeightSublevelComplex k N :=
+  P.latticeWeightSublevelFunctor_obj_private k N
+
+-- The functor's object field is definitionally the sublevel complex; normalize the proof used by
+-- the transported map formula below without exposing the functor's implementation.
+private theorem latticeWeightSublevelFunctor_obj_proof_eq_rfl (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) :
+    P.latticeWeightSublevelFunctor_obj k N = rfl :=
+  Subsingleton.elim _ _
+
+/-- The map in the characteristic-weight filtration diagram is the canonical inclusion
+between the corresponding weight-sublevel complexes. -/
+@[simp]
+theorem latticeWeightSublevelFunctor_map (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N M : ℤ} (f : N ⟶ M) :
+    eqToHom (P.latticeWeightSublevelFunctor_obj k N).symm ≫
+        (P.latticeWeightSublevelFunctor k).map f ≫
+      eqToHom (P.latticeWeightSublevelFunctor_obj k M) =
+        P.latticeWeightSublevelInclusion k (leOfHom f) := by
+  rw [P.latticeWeightSublevelFunctor_obj_proof_eq_rfl k N,
+    P.latticeWeightSublevelFunctor_obj_proof_eq_rfl k M]
+  unfold latticeWeightSublevelFunctor
+  simp only [eqToHom_refl, Category.id_comp, Category.comp_id]
 
 end PlumbingGraph
 

--- a/TauCeti/LowDimTopology/Plumbing/Filtration.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Filtration.lean
@@ -1,0 +1,370 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Finiteness.Finsupp
+public import TauCeti.LowDimTopology.Plumbing.ChainComplex
+public import TauCeti.LowDimTopology.Plumbing.Weight.Sublevel
+
+/-!
+# The weight filtration on the lattice chain complex
+
+For a characteristic covector `k` and an integer `N`, this file restricts Némethi's lattice
+chain complex to the plumbing cubes whose characteristic cube weight is at most `N`. The lower
+and upper faces of such a cube have no larger weight, so the weighted lattice differential
+preserves this submodule. Restricting in every cubical degree therefore gives a chain complex
+`latticeWeightSublevelComplex P k N`.
+
+When the plumbing form is negative definite, every weight sublevel contains only finitely many
+cubes. Indeed, a cube's base point is one of its vertices and hence has weight at most the cube
+weight; the possible base points are finite by the properness theorem for the characteristic
+weight, and the possible direction sets form the finite type `Finset V`. Consequently every
+chain group of the restricted complex is a finitely generated `𝔽₂[U]`-module.
+
+The inclusions for `N ≤ M` make these complexes the filtered system whose direct limit is the
+untruncated lattice complex. Constructing that direct limit and identifying its homology with
+Némethi's `ℍ⁻` are subsequent steps.
+
+## Main definitions
+
+* `TauCeti.PlumbingGraph.cubeWeightSublevel`: cubes of weight at most `N`.
+* `TauCeti.PlumbingChain.weightSublevel`: chains supported on those cubes.
+* `TauCeti.PlumbingChain.weightDegreePart`: the weight-`≤ N`, cubical-degree-`q` chain group.
+* `TauCeti.PlumbingGraph.latticeDifferentialWeightDegree`: the restricted differential.
+* `TauCeti.PlumbingGraph.latticeWeightSublevelComplex`: the filtered chain complex at level `N`.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L, which asks for
+Némethi's lattice homology from lattice points and weight functions. The filtration by the
+sublevel cubical complexes is the construction in A. Némethi,
+[arXiv:0709.0841](https://arxiv.org/abs/0709.0841), Section 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+namespace PlumbingGraph
+
+variable {V : Type*} [DecidableEq V] [Fintype V]
+
+/-- The set of plumbing cubes whose characteristic weight is at most `N`. -/
+def cubeWeightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ) :
+    Set (PlumbingCube V) :=
+  {C | C.characteristicWeight P k ≤ N}
+
+/-- Membership in a cube-weight sublevel set is the corresponding weight inequality. -/
+@[simp]
+theorem mem_cubeWeightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ)
+    (C : PlumbingCube V) :
+    C ∈ P.cubeWeightSublevel k N ↔ C.characteristicWeight P k ≤ N :=
+  Iff.rfl
+
+/-- Cube-weight sublevel sets increase with the level. -/
+theorem cubeWeightSublevel_mono (P : PlumbingGraph V) (k : P.characteristicVectors)
+    {N M : ℤ} (hNM : N ≤ M) : P.cubeWeightSublevel k N ⊆ P.cubeWeightSublevel k M :=
+  fun _ hC => hC.trans hNM
+
+/-- The lower face of a cube in a weight sublevel remains in that sublevel. -/
+theorem lowerFace_mem_cubeWeightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N : ℤ} {C : PlumbingCube V}
+    (hC : C ∈ P.cubeWeightSublevel k N) {v : V} (hv : v ∈ C.directions) :
+    C.lowerFace v hv ∈ P.cubeWeightSublevel k N :=
+  (PlumbingCube.characteristicWeight_lowerFace_le P k C hv).trans hC
+
+/-- The upper face of a cube in a weight sublevel remains in that sublevel. -/
+theorem upperFace_mem_cubeWeightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N : ℤ} {C : PlumbingCube V}
+    (hC : C ∈ P.cubeWeightSublevel k N) {v : V} (hv : v ∈ C.directions) :
+    C.upperFace v hv ∈ P.cubeWeightSublevel k N :=
+  (PlumbingCube.characteristicWeight_upperFace_le P k C hv).trans hC
+
+/-- On a negative-definite plumbing every cube-weight sublevel set is finite.
+
+A cube in the sublevel has its base point in the point-weight sublevel, while its direction set
+belongs to the finite type `Finset V`. The pair of these data determines the cube. -/
+theorem finite_cubeWeightSublevel (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+    (k : P.characteristicVectors) (N : ℤ) : (P.cubeWeightSublevel k N).Finite := by
+  let encode : PlumbingCube V → (V → ℤ) × Finset V := fun C => (C.base, C.directions)
+  have hencode : Function.Injective encode := by
+    intro C D hCD
+    exact PlumbingCube.ext (congrArg Prod.fst hCD) (congrArg Prod.snd hCD)
+  have hproduct :
+      ({x : V → ℤ | P.characteristicWeight k x ≤ N} ×ˢ
+        (Set.univ : Set (Finset V))).Finite :=
+    (P.finite_setOfPred_characteristicWeight_le h k N).prod Set.finite_univ
+  refine (hproduct.preimage hencode.injOn).subset ?_
+  intro C hC
+  refine ⟨?_, Set.mem_univ C.directions⟩
+  have hbase := P.characteristicWeight_le_characteristicCubeWeight_base
+    k C.base C.directions
+  rw [← PlumbingCube.characteristicWeight_mk] at hbase
+  exact hbase.trans ((P.mem_cubeWeightSublevel k N C).mp hC)
+
+end PlumbingGraph
+
+namespace PlumbingChain
+
+variable {V : Type*} [DecidableEq V] [Fintype V]
+
+/-- The `𝔽₂[U]`-submodule of plumbing chains supported on cubes of weight at most `N`. -/
+noncomputable def weightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ) :
+    Submodule PlumbingCoefficient (PlumbingChain V) :=
+  Finsupp.supported PlumbingCoefficient PlumbingCoefficient (P.cubeWeightSublevel k N)
+
+/-- A chain belongs to the weight sublevel exactly when every cube in its support has weight at
+most the level. -/
+@[simp]
+theorem mem_weightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ)
+    (c : PlumbingChain V) :
+    c ∈ weightSublevel P k N ↔
+      ∀ C ∈ c.support, C.characteristicWeight P k ≤ N := by
+  rw [weightSublevel, Finsupp.mem_supported]
+  rfl
+
+/-- A single cube of weight at most `N`, with any coefficient, belongs to the weight sublevel. -/
+theorem single_mem_weightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors) (N : ℤ)
+    (C : PlumbingCube V) (a : PlumbingCoefficient)
+    (hC : C.characteristicWeight P k ≤ N) :
+    Finsupp.single C a ∈ weightSublevel P k N :=
+  Finsupp.single_mem_supported PlumbingCoefficient a hC
+
+/-- The chain-level weight submodules increase with the level. -/
+theorem weightSublevel_mono (P : PlumbingGraph V) (k : P.characteristicVectors)
+    {N M : ℤ} (hNM : N ≤ M) : weightSublevel P k N ≤ weightSublevel P k M :=
+  Finsupp.supported_mono (P.cubeWeightSublevel_mono k hNM)
+
+/-- Every plumbing chain belongs to some weight sublevel. -/
+theorem exists_mem_weightSublevel (P : PlumbingGraph V) (k : P.characteristicVectors)
+    (c : PlumbingChain V) : ∃ N : ℤ, c ∈ weightSublevel P k N := by
+  by_cases hc : c = 0
+  · exact ⟨0, hc ▸ Submodule.zero_mem _⟩
+  · have hs : c.support.Nonempty := Finsupp.support_nonempty_iff.mpr hc
+    let weights := c.support.image fun C => C.characteristicWeight P k
+    have hweights : weights.Nonempty := hs.image _
+    let N := weights.max' hweights
+    refine ⟨N, (mem_weightSublevel P k N c).mpr fun C hC => ?_⟩
+    exact Finset.le_max' weights _ (Finset.mem_image_of_mem _ hC)
+
+/-- The weight filtration exhausts the full plumbing chain module. -/
+theorem iSup_weightSublevel_eq_top (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    ⨆ N : ℤ, weightSublevel P k N = ⊤ := by
+  apply top_unique
+  intro c _
+  obtain ⟨N, hc⟩ := exists_mem_weightSublevel P k c
+  exact Submodule.mem_iSup_of_mem N hc
+
+/-- On a negative-definite plumbing, each chain-level weight submodule is finitely generated over
+`𝔽₂[U]`. -/
+theorem weightSublevel_fg (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+    (k : P.characteristicVectors) (N : ℤ) : (weightSublevel P k N).FG := by
+  rw [weightSublevel, Finsupp.supported_eq_span_single]
+  exact Submodule.fg_span ((P.finite_cubeWeightSublevel h k N).image fun C => Finsupp.single C 1)
+
+/-- The chains simultaneously lying in cubical degree `q` and weight at most `N`. -/
+noncomputable def weightDegreePart (P : PlumbingGraph V) (k : P.characteristicVectors)
+    (N : ℤ) (q : ℕ) :
+    Submodule PlumbingCoefficient (PlumbingChain V) :=
+  degreePart V q ⊓ weightSublevel P k N
+
+/-- Membership in a weight-graded chain group means that every support cube has the specified
+cubical dimension and weight at most the level. -/
+@[simp]
+theorem mem_weightDegreePart (P : PlumbingGraph V) (k : P.characteristicVectors)
+    (N : ℤ) (q : ℕ) (c : PlumbingChain V) :
+    c ∈ weightDegreePart P k N q ↔
+      ∀ C ∈ c.support, C.dimension = q ∧ C.characteristicWeight P k ≤ N := by
+  rw [weightDegreePart, Submodule.mem_inf, mem_degreePart, mem_weightSublevel]
+  aesop
+
+/-- A basis cube of dimension `q` and weight at most `N` belongs to the corresponding filtered
+chain group. -/
+theorem single_mem_weightDegreePart (P : PlumbingGraph V) (k : P.characteristicVectors)
+    (N : ℤ) (q : ℕ) (C : PlumbingCube V) (a : PlumbingCoefficient)
+    (hdim : C.dimension = q) (hweight : C.characteristicWeight P k ≤ N) :
+    Finsupp.single C a ∈ weightDegreePart P k N q :=
+  ⟨single_mem_degreePart V C a hdim, single_mem_weightSublevel P k N C a hweight⟩
+
+/-- Filtered cubical-degree chain groups increase with the weight level. -/
+theorem weightDegreePart_mono (P : PlumbingGraph V) (k : P.characteristicVectors)
+    {N M : ℤ} (hNM : N ≤ M) (q : ℕ) :
+    weightDegreePart P k N q ≤ weightDegreePart P k M q :=
+  inf_le_inf_left _ (weightSublevel_mono P k hNM)
+
+/-- In a fixed cubical degree, the weight filtration exhausts the full degree submodule. -/
+theorem iSup_weightDegreePart_eq_degreePart (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (q : ℕ) :
+    ⨆ N : ℤ, weightDegreePart P k N q = degreePart V q := by
+  apply le_antisymm
+  · exact iSup_le fun _ => inf_le_left
+  · intro c hc
+    obtain ⟨N, hN⟩ := exists_mem_weightSublevel P k c
+    exact Submodule.mem_iSup_of_mem N ⟨hc, hN⟩
+
+/-- The canonical inclusion from the filtered degree-`q` chains at level `N` to those at a
+larger level `M`. -/
+noncomputable def weightDegreeInclusion (P : PlumbingGraph V) (k : P.characteristicVectors)
+    {N M : ℤ} (hNM : N ≤ M) (q : ℕ) :
+    weightDegreePart P k N q →ₗ[PlumbingCoefficient] weightDegreePart P k M q :=
+  Submodule.inclusion (weightDegreePart_mono P k hNM q)
+
+/-- A filtered-degree inclusion does not change the underlying plumbing chain. -/
+@[simp]
+theorem weightDegreeInclusion_apply (P : PlumbingGraph V) (k : P.characteristicVectors)
+    {N M : ℤ} (hNM : N ≤ M) (q : ℕ) (c : weightDegreePart P k N q) :
+    (weightDegreeInclusion P k hNM q c : PlumbingChain V) = c :=
+  (rfl)
+
+/-- On a negative-definite plumbing, every filtered cubical-degree chain group is finitely
+generated over `𝔽₂[U]`. -/
+theorem weightDegreePart_fg (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    (weightDegreePart P k N q).FG := by
+  have hsupport : weightDegreePart P k N q =
+      Finsupp.supported PlumbingCoefficient PlumbingCoefficient
+        {C | C.dimension = q ∧ C.characteristicWeight P k ≤ N} := by
+    ext c
+    rw [mem_weightDegreePart, Finsupp.mem_supported]
+    rfl
+  have hfinite : {C : PlumbingCube V |
+      C.dimension = q ∧ C.characteristicWeight P k ≤ N}.Finite :=
+    (P.finite_cubeWeightSublevel h k N).subset fun _ hC => hC.2
+  rw [hsupport, Finsupp.supported_eq_span_single]
+  exact Submodule.fg_span (hfinite.image fun C => Finsupp.single C 1)
+
+end PlumbingChain
+
+namespace PlumbingGraph
+
+variable {V : Type*} [DecidableEq V] [Fintype V]
+
+/-- The differential of a cube in a weight sublevel is supported in the same sublevel. -/
+theorem latticeDifferentialOnGenerator_mem_weightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N : ℤ} (C : PlumbingCube V)
+    (hC : C.characteristicWeight P k ≤ N) :
+    P.latticeDifferentialOnGenerator k C ∈ PlumbingChain.weightSublevel P k N := by
+  classical
+  rw [latticeDifferentialOnGenerator_def]
+  apply Submodule.sum_mem
+  intro v _
+  apply Submodule.add_mem
+  · exact PlumbingChain.single_mem_weightSublevel P k N _ _
+      ((PlumbingCube.characteristicWeight_lowerFace_le P k C v.property).trans hC)
+  · exact PlumbingChain.single_mem_weightSublevel P k N _ _
+      ((PlumbingCube.characteristicWeight_upperFace_le P k C v.property).trans hC)
+
+/-- The lattice differential preserves every chain-level weight submodule. -/
+theorem latticeDifferential_mem_weightSublevel (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N : ℤ} {c : PlumbingChain V}
+    (hc : c ∈ PlumbingChain.weightSublevel P k N) :
+    P.latticeDifferential k c ∈ PlumbingChain.weightSublevel P k N := by
+  rw [PlumbingChain.weightSublevel, Finsupp.supported_eq_span_single] at hc
+  refine Submodule.span_induction
+    (p := fun c _ => P.latticeDifferential k c ∈ PlumbingChain.weightSublevel P k N)
+    ?_ (by rw [map_zero]; exact Submodule.zero_mem _) ?_ ?_ hc
+  · rintro _ ⟨C, hC, rfl⟩
+    rw [latticeDifferential_single]
+    exact Submodule.smul_mem _ _ (P.latticeDifferentialOnGenerator_mem_weightSublevel k C hC)
+  · intro x y _ _ hx hy
+    simpa only [map_add] using Submodule.add_mem _ hx hy
+  · intro a x _ hx
+    simpa only [map_smul] using Submodule.smul_mem _ a hx
+
+/-- The lattice differential sends filtered chains of cubical degree `q + 1` to filtered chains
+of cubical degree `q`. -/
+theorem latticeDifferential_mem_weightDegreePart (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N : ℤ} {q : ℕ} {c : PlumbingChain V}
+    (hc : c ∈ PlumbingChain.weightDegreePart P k N (q + 1)) :
+    P.latticeDifferential k c ∈ PlumbingChain.weightDegreePart P k N q :=
+  ⟨P.latticeDifferential_mem_degreePart k hc.1,
+    P.latticeDifferential_mem_weightSublevel k hc.2⟩
+
+/-- The lattice differential restricted to consecutive cubical degrees inside one weight
+sublevel. -/
+noncomputable def latticeDifferentialWeightDegree (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    PlumbingChain.weightDegreePart P k N (q + 1) →ₗ[PlumbingCoefficient]
+      PlumbingChain.weightDegreePart P k N q :=
+  ((P.latticeDifferential k).domRestrict
+    (PlumbingChain.weightDegreePart P k N (q + 1))).codRestrict
+      (PlumbingChain.weightDegreePart P k N q) fun c =>
+        P.latticeDifferential_mem_weightDegreePart k c.property
+
+/-- Forgetting the submodule wrappers, the filtered differential is the total lattice
+differential. -/
+@[simp]
+theorem latticeDifferentialWeightDegree_apply (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ)
+    (c : PlumbingChain.weightDegreePart P k N (q + 1)) :
+    (P.latticeDifferentialWeightDegree k N q c : PlumbingChain V) =
+      P.latticeDifferential k c :=
+  (rfl)
+
+/-- Two consecutive differentials in a weight sublevel compose to zero. -/
+theorem latticeDifferentialWeightDegree_comp (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    (P.latticeDifferentialWeightDegree k N q).comp
+        (P.latticeDifferentialWeightDegree k N (q + 1)) = 0 := by
+  apply LinearMap.ext
+  intro c
+  apply Subtype.ext
+  simp only [LinearMap.comp_apply, latticeDifferentialWeightDegree_apply, LinearMap.zero_apply]
+  exact LinearMap.congr_fun (P.latticeDifferential_comp_self k) (c : PlumbingChain V)
+
+/-- Increasing the weight level commutes with the restricted lattice differential. -/
+theorem latticeDifferentialWeightDegree_comp_inclusion (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) (q : ℕ) :
+    (P.latticeDifferentialWeightDegree k M q).comp
+        (PlumbingChain.weightDegreeInclusion P k hNM (q + 1)) =
+      (PlumbingChain.weightDegreeInclusion P k hNM q).comp
+        (P.latticeDifferentialWeightDegree k N q) := by
+  apply LinearMap.ext
+  intro c
+  apply Subtype.ext
+  simp only [LinearMap.comp_apply, PlumbingChain.weightDegreeInclusion_apply,
+    latticeDifferentialWeightDegree_apply]
+
+/-- The cubically graded lattice chain complex restricted to cubes of characteristic weight at
+most `N`. -/
+noncomputable def latticeWeightSublevelComplex (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) : ChainComplex (ModuleCat PlumbingCoefficient) ℕ :=
+  ChainComplex.of
+    (fun q => ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N q))
+    (fun q => ModuleCat.ofHom (R := PlumbingCoefficient)
+      (P.latticeDifferentialWeightDegree k N q))
+    fun q => by
+      rw [← ModuleCat.ofHom_comp, P.latticeDifferentialWeightDegree_comp k N q,
+        ModuleCat.ofHom_zero]
+
+/-- The degree-`q` object of the weight-sublevel complex is the corresponding filtered
+cubical-degree chain group. -/
+@[simp]
+theorem latticeWeightSublevelComplex_X (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    (P.latticeWeightSublevelComplex k N).X q =
+      ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N q) := by
+  unfold latticeWeightSublevelComplex
+  exact congrFun (ChainComplex.of_X _ _ _) q
+
+/-- The differential of the weight-sublevel complex is the restricted lattice differential. -/
+@[simp]
+theorem latticeWeightSublevelComplex_d (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
+    HEq ((P.latticeWeightSublevelComplex k N).d (q + 1) q)
+      (ModuleCat.ofHom (P.latticeDifferentialWeightDegree k N q) :
+        ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N (q + 1)) ⟶
+          ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N q)) := by
+  rw [latticeWeightSublevelComplex]
+  exact heq_of_eq (ChainComplex.of_d
+    (fun r => ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N r))
+    (fun r => ModuleCat.ofHom (R := PlumbingCoefficient)
+      (P.latticeDifferentialWeightDegree k N r)) q)
+
+end PlumbingGraph
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/Filtration.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Filtration.lean
@@ -380,8 +380,12 @@ theorem latticeWeightSublevelComplex_d (P : PlumbingGraph V)
       (P.latticeDifferentialWeightDegree_comp_inclusion k hNM q)
 
 /-- The component of a weight-sublevel inclusion is the corresponding inclusion of filtered
-degree parts. -/
-@[simp]
+degree parts.
+
+This is deliberately not a `simp` lemma: its right-hand side is a morphism between the
+`ModuleCat.of` objects rather than between the complexes' `X` objects, so the rewritten term is
+type-correct only after unfolding `latticeWeightSublevelComplex` and no further `simp` lemma
+applies to it. Use `latticeWeightSublevelInclusion_apply` on elements instead. -/
 theorem latticeWeightSublevelInclusion_f (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) (q : ℕ) :
     (P.latticeWeightSublevelInclusion k hNM).f q =

--- a/TauCeti/LowDimTopology/Plumbing/Filtration.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Filtration.lean
@@ -162,7 +162,7 @@ theorem iSup_weightSublevel_eq_top (P : PlumbingGraph V) (k : P.characteristicVe
 
 /-- On a negative-definite plumbing, each chain-level weight submodule is finitely generated over
 `𝔽₂[U]`. -/
-theorem fg_weightSublevel (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+theorem weightSublevel_fg (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
     (k : P.characteristicVectors) (N : ℤ) : (weightSublevel P k N).FG := by
   rw [weightSublevel, Finsupp.supported_eq_span_single]
   exact Submodule.fg_span ((P.finite_cubeWeightSublevel h k N).image fun C => Finsupp.single C 1)
@@ -223,7 +223,7 @@ theorem weightDegreeInclusion_apply (P : PlumbingGraph V) (k : P.characteristicV
 
 /-- On a negative-definite plumbing, every filtered cubical-degree chain group is finitely
 generated over `𝔽₂[U]`. -/
-theorem fg_weightDegreePart (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+theorem weightDegreePart_fg (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
     (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
     (weightDegreePart P k N q).FG := by
   have hsupport : weightDegreePart P k N q =
@@ -332,7 +332,7 @@ theorem latticeDifferentialWeightDegree_comp_inclusion (P : PlumbingGraph V)
 
 /-- The cubically graded lattice chain complex restricted to cubes of characteristic weight at
 most `N`. -/
-@[expose] noncomputable def latticeWeightSublevelComplex (P : PlumbingGraph V)
+noncomputable def latticeWeightSublevelComplex (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) : ChainComplex (ModuleCat PlumbingCoefficient) ℕ :=
   ChainComplex.of
     (fun q => ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N q))
@@ -367,7 +367,7 @@ theorem latticeWeightSublevelComplex_d (P : PlumbingGraph V)
       (P.latticeDifferentialWeightDegree k N r)) q)
 
 /-- The chain-complex inclusion from weight level `N` to a larger level `M`. -/
-@[expose] noncomputable def latticeWeightSublevelInclusion (P : PlumbingGraph V)
+noncomputable def latticeWeightSublevelInclusion (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) :
     P.latticeWeightSublevelComplex k N ⟶ P.latticeWeightSublevelComplex k M :=
   by
@@ -380,26 +380,28 @@ theorem latticeWeightSublevelComplex_d (P : PlumbingGraph V)
       (P.latticeDifferentialWeightDegree_comp_inclusion k hNM q)
 
 /-- The component of a weight-sublevel inclusion is the corresponding inclusion of filtered
-degree parts.
-
-This is deliberately not a `simp` lemma: its right-hand side is a morphism between the
-`ModuleCat.of` objects rather than between the complexes' `X` objects, so the rewritten term is
-type-correct only after unfolding `latticeWeightSublevelComplex` and no further `simp` lemma
-applies to it. Use `latticeWeightSublevelInclusion_apply` on elements instead. -/
+degree parts, transported across the characteristic descriptions of the complex objects. -/
 theorem latticeWeightSublevelInclusion_f (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) (q : ℕ) :
     (P.latticeWeightSublevelInclusion k hNM).f q =
-      ModuleCat.ofHom (PlumbingChain.weightDegreeInclusion P k hNM q) :=
+      eqToHom (P.latticeWeightSublevelComplex_X k N q) ≫
+        ModuleCat.ofHom (PlumbingChain.weightDegreeInclusion P k hNM q) ≫
+          eqToHom (P.latticeWeightSublevelComplex_X k M q).symm := by
+  unfold latticeWeightSublevelInclusion latticeWeightSublevelComplex
   rfl
 
 /-- A weight-sublevel complex inclusion does not change the underlying filtered chain. -/
 @[simp]
 theorem latticeWeightSublevelInclusion_apply (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) (q : ℕ)
-    (c : PlumbingChain.weightDegreePart P k N q) :
-    (P.latticeWeightSublevelInclusion k hNM).f q c =
-      PlumbingChain.weightDegreeInclusion P k hNM q c :=
-  rfl
+    (c : (P.latticeWeightSublevelComplex k N).X q) :
+    eqToHom (P.latticeWeightSublevelComplex_X k M q)
+        ((P.latticeWeightSublevelInclusion k hNM).f q c) =
+      ModuleCat.ofHom (PlumbingChain.weightDegreeInclusion P k hNM q)
+        (eqToHom (P.latticeWeightSublevelComplex_X k N q) c) := by
+  rw [← CategoryTheory.comp_apply, latticeWeightSublevelInclusion_f]
+  simp only [Category.assoc, eqToHom_trans, eqToHom_refl, Category.comp_id,
+    CategoryTheory.comp_apply]
 
 /-- The weight-sublevel inclusion from a level to itself is the identity chain map. -/
 @[simp]
@@ -407,8 +409,16 @@ theorem latticeWeightSublevelInclusion_id (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) :
     P.latticeWeightSublevelInclusion k (le_refl N) =
       𝟙 (P.latticeWeightSublevelComplex k N) := by
-  ext q c
-  rfl
+  apply HomologicalComplex.hom_ext
+  intro q
+  apply (cancel_mono (eqToHom (P.latticeWeightSublevelComplex_X k N q))).1
+  apply ModuleCat.hom_ext
+  apply LinearMap.ext
+  intro c
+  rw [CategoryTheory.comp_apply, latticeWeightSublevelInclusion_apply,
+    HomologicalComplex.id_f, CategoryTheory.comp_apply, id_apply]
+  apply Subtype.ext
+  exact PlumbingChain.weightDegreeInclusion_apply P k (le_refl N) q _
 
 /-- Weight-sublevel inclusions compose to the inclusion between the outer levels. -/
 @[simp]
@@ -416,8 +426,22 @@ theorem latticeWeightSublevelInclusion_comp (P : PlumbingGraph V)
     (k : P.characteristicVectors) {N M L : ℤ} (hNM : N ≤ M) (hML : M ≤ L) :
     P.latticeWeightSublevelInclusion k hNM ≫ P.latticeWeightSublevelInclusion k hML =
       P.latticeWeightSublevelInclusion k (hNM.trans hML) := by
-  ext q c
-  rfl
+  apply HomologicalComplex.hom_ext
+  intro q
+  apply (cancel_mono (eqToHom (P.latticeWeightSublevelComplex_X k L q))).1
+  apply ModuleCat.hom_ext
+  apply LinearMap.ext
+  intro c
+  rw [CategoryTheory.comp_apply, HomologicalComplex.comp_f, CategoryTheory.comp_apply,
+    latticeWeightSublevelInclusion_apply, latticeWeightSublevelInclusion_apply,
+    CategoryTheory.comp_apply, latticeWeightSublevelInclusion_apply]
+  apply Subtype.ext
+  change ((PlumbingChain.weightDegreeInclusion P k hML q)
+      ((PlumbingChain.weightDegreeInclusion P k hNM q)
+        (eqToHom (P.latticeWeightSublevelComplex_X k N q) c)) : PlumbingChain V) =
+    (PlumbingChain.weightDegreeInclusion P k (hNM.trans hML) q
+      (eqToHom (P.latticeWeightSublevelComplex_X k N q) c) : PlumbingChain V)
+  simp only [PlumbingChain.weightDegreeInclusion_apply]
 
 end PlumbingGraph
 

--- a/TauCeti/LowDimTopology/Plumbing/Filtration.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Filtration.lean
@@ -34,6 +34,7 @@ Némethi's `ℍ⁻` are subsequent steps.
 * `TauCeti.PlumbingChain.weightDegreePart`: the weight-`≤ N`, cubical-degree-`q` chain group.
 * `TauCeti.PlumbingGraph.latticeDifferentialWeightDegree`: the restricted differential.
 * `TauCeti.PlumbingGraph.latticeWeightSublevelComplex`: the filtered chain complex at level `N`.
+* `TauCeti.PlumbingGraph.latticeWeightSublevelInclusion`: the inclusion between filtration levels.
 
 ## References
 
@@ -161,7 +162,7 @@ theorem iSup_weightSublevel_eq_top (P : PlumbingGraph V) (k : P.characteristicVe
 
 /-- On a negative-definite plumbing, each chain-level weight submodule is finitely generated over
 `𝔽₂[U]`. -/
-theorem weightSublevel_fg (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+theorem fg_weightSublevel (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
     (k : P.characteristicVectors) (N : ℤ) : (weightSublevel P k N).FG := by
   rw [weightSublevel, Finsupp.supported_eq_span_single]
   exact Submodule.fg_span ((P.finite_cubeWeightSublevel h k N).image fun C => Finsupp.single C 1)
@@ -222,7 +223,7 @@ theorem weightDegreeInclusion_apply (P : PlumbingGraph V) (k : P.characteristicV
 
 /-- On a negative-definite plumbing, every filtered cubical-degree chain group is finitely
 generated over `𝔽₂[U]`. -/
-theorem weightDegreePart_fg (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+theorem fg_weightDegreePart (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
     (k : P.characteristicVectors) (N : ℤ) (q : ℕ) :
     (weightDegreePart P k N q).FG := by
   have hsupport : weightDegreePart P k N q =
@@ -331,7 +332,7 @@ theorem latticeDifferentialWeightDegree_comp_inclusion (P : PlumbingGraph V)
 
 /-- The cubically graded lattice chain complex restricted to cubes of characteristic weight at
 most `N`. -/
-noncomputable def latticeWeightSublevelComplex (P : PlumbingGraph V)
+@[expose] noncomputable def latticeWeightSublevelComplex (P : PlumbingGraph V)
     (k : P.characteristicVectors) (N : ℤ) : ChainComplex (ModuleCat PlumbingCoefficient) ℕ :=
   ChainComplex.of
     (fun q => ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N q))
@@ -364,6 +365,55 @@ theorem latticeWeightSublevelComplex_d (P : PlumbingGraph V)
     (fun r => ModuleCat.of PlumbingCoefficient (PlumbingChain.weightDegreePart P k N r))
     (fun r => ModuleCat.ofHom (R := PlumbingCoefficient)
       (P.latticeDifferentialWeightDegree k N r)) q)
+
+/-- The chain-complex inclusion from weight level `N` to a larger level `M`. -/
+@[expose] noncomputable def latticeWeightSublevelInclusion (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) :
+    P.latticeWeightSublevelComplex k N ⟶ P.latticeWeightSublevelComplex k M :=
+  by
+    unfold latticeWeightSublevelComplex
+    refine ChainComplex.ofHom
+      (fun q => ModuleCat.ofHom (PlumbingChain.weightDegreeInclusion P k hNM q)) ?_
+    intro q
+    simp only [ChainComplex.of_d, ← ModuleCat.ofHom_comp]
+    exact congrArg ModuleCat.ofHom
+      (P.latticeDifferentialWeightDegree_comp_inclusion k hNM q)
+
+/-- The component of a weight-sublevel inclusion is the corresponding inclusion of filtered
+degree parts. -/
+@[simp]
+theorem latticeWeightSublevelInclusion_f (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) (q : ℕ) :
+    (P.latticeWeightSublevelInclusion k hNM).f q =
+      ModuleCat.ofHom (PlumbingChain.weightDegreeInclusion P k hNM q) :=
+  rfl
+
+/-- A weight-sublevel complex inclusion does not change the underlying filtered chain. -/
+@[simp]
+theorem latticeWeightSublevelInclusion_apply (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N M : ℤ} (hNM : N ≤ M) (q : ℕ)
+    (c : PlumbingChain.weightDegreePart P k N q) :
+    (P.latticeWeightSublevelInclusion k hNM).f q c =
+      PlumbingChain.weightDegreeInclusion P k hNM q c :=
+  rfl
+
+/-- The weight-sublevel inclusion from a level to itself is the identity chain map. -/
+@[simp]
+theorem latticeWeightSublevelInclusion_id (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (N : ℤ) :
+    P.latticeWeightSublevelInclusion k (le_refl N) =
+      𝟙 (P.latticeWeightSublevelComplex k N) := by
+  ext q c
+  rfl
+
+/-- Weight-sublevel inclusions compose to the inclusion between the outer levels. -/
+@[simp]
+theorem latticeWeightSublevelInclusion_comp (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {N M L : ℤ} (hNM : N ≤ M) (hML : M ≤ L) :
+    P.latticeWeightSublevelInclusion k hNM ≫ P.latticeWeightSublevelInclusion k hML =
+      P.latticeWeightSublevelInclusion k (hNM.trans hML) := by
+  ext q c
+  rfl
 
 end PlumbingGraph
 


### PR DESCRIPTION
This PR filters the cubically graded lattice chain complex by characteristic cube-weight sublevels. Define the face-closed cube sublevel `cubeWeightSublevel`, prove it is finite for a negative-definite plumbing by reducing each cube to its base point and finite direction set, and lift it to exhaustive `𝔽₂[U]`-submodules in every cubical degree. Restrict the existing weighted differential to these finitely generated groups, prove consecutive restricted differentials compose to zero and commute with level inclusions, and package each level as `latticeWeightSublevelComplex`.

The exact target is `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L, “Némethi's lattice (co)homology `ℍ⁻`/`ℍ⁰` as a `ℤ[U]`-module from lattice points and weight functions.” This is the most effective current step because the weighted lattice complex and finiteness of the point-weight sublevels have landed, while this PR connects those two results into the finite exhaustive filtration consumed by the direct-limit presentation and later computations. After this PR, Lane L still needs the direct-limit homology interface, a concrete nonempty plumbing computation, and chain-level invariance under the Neumann moves.

Add `TauCeti/LowDimTopology/Plumbing/Filtration.lean` (370 lines). Reuse Mathlib's `Finsupp.supported`, finite-set preimages, `Submodule.span_induction`, and `ChainComplex.of`, together with Tau Ceti's existing face-weight inequalities, sublevel properness theorem, cubical grading, and square-zero lattice differential. No Mathlib implementation or external formalization is vendored. The filtration follows A. Némethi, arXiv:0709.0841, Section 3, as credited in the module documentation.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"lattice-chain-weight-filtration"}-->

🤖 Prepared with Codex
