### PR TITLE
feat(ModularForms): the ±Γ index doubling at SL(2, ℤ)

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/WithCenter.lean
+++ b/TauCeti/NumberTheory/ModularForms/WithCenter.lean
@@ -23,6 +23,9 @@ than inside any one consumer.
 
 * `Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg`: membership in `Γ·{±I}` is being `±` an
   element of `Γ`.
+* `TauCeti.ModularForm.index_eq_two_mul_index_withCenter_of_neg_one_notMem` and
+  `TauCeti.ModularForm.relIndex_withCenter_eq_two_of_neg_one_notMem`: when `-I ∉ Γ`,
+  `[SL₂(ℤ) : Γ] = 2 · [SL₂(ℤ) : ±Γ]`.
 -/
 
 public section
@@ -52,6 +55,28 @@ theorem _root_.Subgroup.mem_withCenter_iff_exists_eq_or_eq_neg {γ : SL(2, ℤ)}
     · exact Subgroup.mem_withCenter_iff.mpr ⟨_, hγ', 1, Subgroup.one_mem _, mul_one _⟩
     · exact Subgroup.mem_withCenter_iff.mpr ⟨_, hγ', -1,
         Subgroup.mem_center_iff.mpr fun g ↦ by rw [neg_one_mul, mul_neg_one], mul_neg_one _⟩
+
+/-- **The `±Γ` factor of two, index form**: when `-I ∉ Γ`, the index of `Γ` in `SL(2, ℤ)` is
+twice the projective index `[SL₂(ℤ) : ±Γ]`.
+
+This is the conversion the general-level valence formula and the Sturm bound are stated
+against: both read `k · [SL₂(ℤ) : ±Γ] / 12`, while a full-coset norm product is computed over
+`Γ`-cosets, which is twice as many. -/
+theorem index_eq_two_mul_index_withCenter_of_neg_one_notMem (h : (-1 : SL(2, ℤ)) ∉ Γ) :
+    Γ.index = 2 * Γ.withCenter.index :=
+  Subgroup.index_eq_two_mul_index_withCenter
+    (Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one.mpr (Or.inr rfl)) h
+    fun _ hc ↦ Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one.mp hc
+
+/-- **The `±Γ` factor of two, relative-index form**: `Γ` has index `2` inside `Γ·{±I}` when
+`-I ∉ Γ`. The geometric reading of
+`index_eq_two_mul_index_withCenter_of_neg_one_notMem`: adjoining `-I` exactly halves the
+number of cosets. -/
+theorem relIndex_withCenter_eq_two_of_neg_one_notMem (h : (-1 : SL(2, ℤ)) ∉ Γ) :
+    Γ.relIndex Γ.withCenter = 2 :=
+  Subgroup.relIndex_withCenter_eq_two
+    (Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one.mpr (Or.inr rfl)) h
+    fun _ hc ↦ Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one.mp hc
 
 end TauCeti.ModularForm
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"modularforms-pm-gamma-index-doubling"}-->

### What this adds

Two `SL(2, ℤ)` specialisations, in the file that already holds the `withCenter` characterisation:

```lean
theorem index_eq_two_mul_index_withCenter_of_neg_one_notMem (h : (-1 : SL(2, ℤ)) ∉ Γ) :
    Γ.index = 2 * Γ.withCenter.index

theorem relIndex_withCenter_eq_two_of_neg_one_notMem (h : (-1 : SL(2, ℤ)) ∉ Γ) :
    Γ.relIndex Γ.withCenter = 2
```

`Γ.withCenter` is `Γ·{±I}`, so `Γ.withCenter.index` **is** the projective index `[SL₂(ℤ) : ±Γ]`.

### Why these two, and why now

The roadmap states the general-level valence formula and the Sturm bound against the *projective*
index throughout — `Σ_{P ∈ Γ\ℍ*} (1/e_P)·ord_P(f) = k·[SL₂(ℤ):±Γ]/12`, and
`ord_∞(f) ≤ k·[SL₂(ℤ):±Γ]/12` — while the norm map that proves them is a product over the **full**
coset space. It names the conversion in as many words:

> ⚠ never by projective cosets … When `−I ∈ Γ` or `k` is even the cosets pair under `γ ↔ −γ` and
> the full-coset computation is twice the projective one — **divide by `2` at the end**.

These are that division, as theorems.

They also give the general lemmas their first consumer. `Subgroup.index_eq_two_mul_index_withCenter`
and `Subgroup.relIndex_withCenter_eq_two` landed with #3373 taking

```lean
(hcenter : ∀ c ∈ Subgroup.center G, c = 1 ∨ c = a)
```

and until #3417 there was **no way to supply that hypothesis at `SL(2, ℤ)`**, so they sat with no
consumer anywhere outside `GroupTheory/Index.lean` itself. #3417 named the centre; this connects it.

### The proofs are one application each

```lean
  Subgroup.index_eq_two_mul_index_withCenter
    (Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one.mpr (Or.inr rfl)) h
    fun _ hc ↦ Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one.mp hc
```

The centre characterisation is used in both directions — `.mpr` to witness `-1 ∈ center`, `.mp` to
discharge the `∀ c ∈ center G` hypothesis — which is exactly the shape #3417's lemma was extracted
for.

**No import was needed.** Both general lemmas come from `TauCeti.GroupTheory.Index` and the centre
characterisation from `TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic`; `WithCenter.lean`
already imports both.

### Note on the merge

This branch was cut from `main` before #3417 landed, and the addition was deliberately **appended
at the end of the file** rather than placed next to the existing theorem — #3417 edits that
theorem's proof body, and appending kept the two changes disjoint. The merge of `main` was
conflict-free and the staged proofs compiled with no edit, since the only symbol they were missing
arrived with it.

### Verification

`lake build` green (8042 jobs, 0 error lines); `lake exe axioms` clean over 49211 declarations;
`lake exe module-system` clean over 2333 modules; `LINT-ENV: PASS` (67 grandfathered,
3 ratchetable). No line over 100 codepoints, measured with `wc -m`.
