### PR TITLE
refactor(Topology): drop locallyConnectedSpace_of_isQuotientMap for Mathlib's IsCoinducing

### DIFF
--- a/TauCeti/Topology/LocallyConnected.lean
+++ b/TauCeti/Topology/LocallyConnected.lean
@@ -10,24 +10,19 @@ public import Mathlib.Topology.Maps.Basic
 public import Mathlib.Topology.Separation.Hausdorff
 
 /-!
-# Local connectedness passes to quotients
+# Local connectedness of continuous images of compact spaces
 
 Local connectedness is not preserved by continuous images in general — every metric space is a
 continuous image of a discrete one — but it *is* preserved by quotient maps, and hence by the
 continuous images that are automatically quotient maps: those of a compact space in a Hausdorff
-one. This file proves both, in the type-level form and in the set-level form
+one. This file proves that, in the type-level form and in the set-level form
 `TauCeti.locallyConnectedSpace_image_of_isCompact` that a subset of a topological space needs.
 
-Mathlib has `LocallyConnectedSpace` with its `connectedComponentIn` characterization, and knows
-that the property passes to open subspaces (`Topology.IsOpenEmbedding.locallyConnectedSpace`,
-`IsOpen.locallyConnectedSpace`), but records no behaviour under quotients.
-
-The proof is the standard one and uses `locallyConnectedSpace_iff_connectedComponentIn_open` on
-both sides: for `V` open in the target and `y ∈ V`, the preimage of the connected component of `y`
-in `V` is a union of connected components of the open set `q ⁻¹' V`, because a connected component
-`C` of `q ⁻¹' V` has connected image inside `V`, so that image lies in a single component of `V`.
-Those components are open downstairs by local connectedness, so the preimage is open, and the
-component itself is then open because `q` is a quotient map.
+The quotient step itself is Mathlib's. `Topology.IsCoinducing.locallyConnectedSpace` states that
+a topology coinduced by a locally connected one is locally connected, which reaches quotient maps
+through `IsQuotientMap.isCoinducing` and is strictly more general, since coinducing does not ask
+for surjectivity. What is added here is the passage from that to a continuous surjection out of a
+compact space, which is closed and therefore a quotient map.
 
 The intended consumer is layer **L5** of the conformal-mapping roadmap, Carathéodory's boundary
 correspondence: a conformal map that extends continuously to the closure of its domain carries a
@@ -37,8 +32,6 @@ Carathéodory's continuity theorem. That application is in
 
 ## Main results
 
-* `TauCeti.locallyConnectedSpace_of_isQuotientMap` — a quotient of a locally connected space is
-  locally connected.
 * `TauCeti.locallyConnectedSpace_of_continuous_surjective` — the continuous image of a compact
   locally connected space in a Hausdorff space is locally connected.
 * `TauCeti.locallyConnectedSpace_image_of_isCompact` — the set-level form: `f '' s` is locally
@@ -54,45 +47,17 @@ public section
 
 namespace TauCeti
 
-open Filter Set Topology
+open Set Topology
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
-/-- **A quotient of a locally connected space is locally connected.** No separation or compactness
-hypothesis is needed: being a quotient map is exactly what lets openness of the connected
-components be transported downstairs.
-
-Some hypothesis beyond continuity and surjectivity is needed: every metric space is the continuous
-image of the same set with the discrete topology, which is locally connected. -/
-theorem locallyConnectedSpace_of_isQuotientMap [LocallyConnectedSpace X] {q : X → Y}
-    (hq : IsQuotientMap q) : LocallyConnectedSpace Y := by
-  rw [locallyConnectedSpace_iff_connectedComponentIn_open]
-  intro V hV y _
-  rw [← hq.isCoinducing.isOpen_preimage]
-  -- It suffices to show that every point of `q ⁻¹' connectedComponentIn V y` has the connected
-  -- component containing it in the open set `q ⁻¹' V` as a neighbourhood inside that preimage.
-  refine isOpen_iff_mem_nhds.mpr fun x hx => ?_
-  have hxV : x ∈ q ⁻¹' V := connectedComponentIn_subset V y hx
-  have hopen : IsOpen (connectedComponentIn (q ⁻¹' V) x) :=
-    (hV.preimage hq.continuous).connectedComponentIn
-  refine mem_of_superset (hopen.mem_nhds (mem_connectedComponentIn hxV)) fun z hz => ?_
-  -- The image of that component is connected, lies in `V` and meets `connectedComponentIn V y`,
-  -- so it is contained in it.
-  have himg : q '' connectedComponentIn (q ⁻¹' V) x ⊆ connectedComponentIn V y := by
-    have hpre : IsPreconnected (q '' connectedComponentIn (q ⁻¹' V) x) :=
-      isPreconnected_connectedComponentIn.image _ hq.continuous.continuousOn
-    rw [connectedComponentIn_eq hx]
-    exact hpre.subset_connectedComponentIn ⟨x, mem_connectedComponentIn hxV, rfl⟩
-      (image_subset_iff.mpr (connectedComponentIn_subset _ _))
-  exact himg ⟨z, hz, rfl⟩
-
 /-- **The continuous image of a compact locally connected space in a Hausdorff space is locally
 connected.** A continuous surjection out of a compact space onto a Hausdorff one is closed, hence
-a quotient map, so `TauCeti.locallyConnectedSpace_of_isQuotientMap` applies. -/
+a quotient map, hence coinducing, so `Topology.IsCoinducing.locallyConnectedSpace` applies. -/
 theorem locallyConnectedSpace_of_continuous_surjective [LocallyConnectedSpace X] [CompactSpace X]
     [T2Space Y] {f : X → Y} (hf : Continuous f) (hsurj : Function.Surjective f) :
     LocallyConnectedSpace Y :=
-  locallyConnectedSpace_of_isQuotientMap (hf.isClosedMap.isQuotientMap hf hsurj)
+  (hf.isClosedMap.isQuotientMap hf hsurj).isCoinducing.locallyConnectedSpace
 
 /-- **The set-level form: a compact, locally connected set has locally connected continuous
 images.** Stated with the subtype topologies on `s` and on `f '' s`, which is how a boundary or a
@@ -101,10 +66,7 @@ theorem locallyConnectedSpace_image_of_isCompact [T2Space Y] {s : Set X} {f : X 
     [LocallyConnectedSpace s] (hs : IsCompact s) (hf : ContinuousOn f s) :
     LocallyConnectedSpace (f '' s) := by
   have : CompactSpace s := isCompact_iff_compactSpace.mp hs
-  have hsurj : Function.Surjective ((mapsTo_image f s).restrict f s (f '' s)) := by
-    rintro ⟨-, x, hx, rfl⟩
-    exact ⟨⟨x, hx⟩, rfl⟩
-  exact locallyConnectedSpace_of_continuous_surjective
-    (hf.mapsToRestrict (mapsTo_image f s)) hsurj
+  exact locallyConnectedSpace_of_continuous_surjective (hf.mapsToRestrict (mapsTo_image f s))
+    (surjective_mapsTo_image_restrict f s)
 
 end TauCeti


### PR DESCRIPTION
Mathlib now proves the quotient step this file was carrying, and proves it strictly more
generally, so `TauCeti.locallyConnectedSpace_of_isQuotientMap` is deleted and its one consumer
rewired to Mathlib. Per the no-backwards-compatibility rule the removal and the rewiring land
together — no alias, no shim.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"topology/locallyconnected-mathlib-supersession"}-->

## What changes

`TauCeti/Topology/LocallyConnected.lean` only — `+12 / -50`, net 38 lines removed:

| | before | after |
|---|---|---|
| `locallyConnectedSpace_of_isQuotientMap` | 19-line proof | **deleted** — Mathlib's |
| `locallyConnectedSpace_of_continuous_surjective` | via the local lemma | via `IsCoinducing.locallyConnectedSpace` |
| `locallyConnectedSpace_image_of_isCompact` | 6-line body | 3-line body (see *Golf* below) |

**The supersession.** Mathlib's `Topology.IsCoinducing.locallyConnectedSpace`
(`Mathlib/Topology/Connected/LocallyConnected.lean:155`) states that a topology coinduced by a
locally connected one is locally connected. It reaches quotient maps through
`IsQuotientMap.isCoinducing` and is **strictly more general**, since coinducing does not require
surjectivity, which `IsQuotientMap` does.

The evidence that this is the *same* result and not a lookalike: our deleted proof's own first
tactic was `rw [← hq.isCoinducing.isOpen_preimage]` — it already routed through `isCoinducing` —
and both proofs open with `locallyConnectedSpace_iff_connectedComponentIn_open`.

The one consumer becomes a single term:

```lean
theorem locallyConnectedSpace_of_continuous_surjective [LocallyConnectedSpace X] [CompactSpace X]
    [T2Space Y] {f : X → Y} (hf : Continuous f) (hsurj : Function.Surjective f) :
    LocallyConnectedSpace Y :=
  (hf.isClosedMap.isQuotientMap hf hsurj).isCoinducing.locallyConnectedSpace
```

## What is *not* deleted, and why

The two remaining theorems are **not** in Mathlib. Its complete inventory of results producing a
`LocallyConnectedSpace` instance is seven — `IsOpenEmbedding`, `IsOpen`, `IsCoinducing`, `Prod`,
`Pi`, `Homeomorph`, `ChartedSpace` — and none is the compact-to-Hausdorff form or the set-level
image form.

Nor should `locallyConnectedSpace_of_continuous_surjective` be weakened to take `IsClosedMap`
directly: that would make it a bare wrapper around the Mathlib lemma. Its content is precisely
the compact + Hausdorff packaging, which is what call sites have.

## Golf: a re-proved Mathlib lemma

`locallyConnectedSpace_image_of_isCompact` hand-rolled the surjectivity of the restricted map:

```lean
  have hsurj : Function.Surjective ((mapsTo_image f s).restrict f s (f '' s)) := by
    rintro ⟨-, x, hx, rfl⟩
    exact ⟨⟨x, hx⟩, rfl⟩
```

That is `Set.surjective_mapsTo_image_restrict` (`Mathlib/Data/Set/Restrict.lean:260`) verbatim.
Replaced by the named lemma; the body drops 6 lines to 3.

## Docstring

The module docstring asserted *"Mathlib … records no behaviour under quotients"*, which this PR
makes false, and listed the deleted lemma under Main results. Both are fixed, the title now
describes what the file actually proves, and the Mathlib route is named explicitly so the next
reader does not re-derive it. `open Filter` went dead with the deleted proof and is removed.

## Checks

Four gates, each exit code captured separately, with
`WATCHDOG_TOOLCHAIN=…/leanprover--lean4---v4.34.0-rc1` exported so `lint-env.sh` is not a silent
green: `lake build`; `lake exe axioms`; `lake exe module-system`; `bash scripts/lint-env.sh`
(asserted on its printed `lint-env:` lines, not its exit code).

Blast radius: `grep -rn locallyConnectedSpace_of_isQuotientMap TauCeti/` returns nothing after
the change. The three downstream files using the surviving API — `UniformlyLocallyConnected`,
`JordanCurve/Basic`, `Conformal/LocallyConnectedBoundary` — are unchanged and rebuild clean.
