### PR TITLE
refactor(ViaKoopman): reuse Mathlib's indicator norm bound

### DIFF
--- a/TauCeti/Probability/DeFinetti/ViaKoopman/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/BlockFactorization.lean
@@ -117,10 +117,8 @@ theorem setIntegral_weight_mul_blockIndicatorProd_prefix_eq_prod_condExp
       hw.mul (stronglyMeasurable_condExp).measurable
     have hE_bdd : ∀ᵐ x ∂ρ, ‖E x‖ ≤ 1 :=
       ae_bdd_norm_condExp_of_ae_bdd_norm (Filter.Eventually.of_forall fun y => by
-        have h0 : (0 : ℝ) ≤ (B (Fin.last r)).indicator (fun _ => (1 : ℝ)) (y r) :=
-          Set.indicator_apply_nonneg fun _ => zero_le_one
-        rw [Real.norm_eq_abs, abs_of_nonneg h0]
-        exact Set.indicator_apply_le' (fun _ => le_rfl) fun _ => zero_le_one)
+        simpa only [norm_one] using
+          norm_indicator_le_norm_self (fun _ => (1 : ℝ)) (y r))
     have hwE_bdd : ∀ᵐ x ∂ρ, |w x * E x| ≤ 1 := by
       filter_upwards [hw_bdd, hE_bdd] with x hwx hEx
       rw [abs_mul]

--- a/TauCeti/Probability/DeFinetti/ViaKoopman/Decoupling.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/Decoupling.lean
@@ -140,12 +140,8 @@ private theorem tendsto_integral_abs_birkhoffAverage_indicator_coord
       Filter.atTop (nhds 0) := by
   have hmeas : Measurable fun y : ℕ → α => B.indicator (fun _ => (1 : ℝ)) (y r) :=
     (measurable_const.indicator hB).comp (measurable_pi_apply r)
-  have hbdd : ∀ y : ℕ → α, ‖B.indicator (fun _ => (1 : ℝ)) (y r)‖ ≤ 1 := by
-    intro y
-    have h0 : 0 ≤ B.indicator (fun _ => (1 : ℝ)) (y r) :=
-      Set.indicator_apply_nonneg fun _ => zero_le_one
-    rw [Real.norm_eq_abs, abs_of_nonneg h0]
-    exact Set.indicator_apply_le' (fun _ => le_rfl) fun _ => zero_le_one
+  have hbdd : ∀ y : ℕ → α, ‖B.indicator (fun _ => (1 : ℝ)) (y r)‖ ≤ 1 := fun y => by
+    simpa only [norm_one] using norm_indicator_le_norm_self (fun _ => (1 : ℝ)) (y r)
   exact tendsto_integral_abs_birkhoffAverage_sub_condExp (shift α) hmp
     (MemLp.of_bound hmeas.aestronglyMeasurable 1 (Filter.Eventually.of_forall hbdd))
 
@@ -168,12 +164,9 @@ theorem condExp_indicator_coord_ae_eq_invariantConditionalProbabilityMeasure
     fun s => (measurable_const.indicator hB).comp (measurable_pi_apply s)
   have hint : ∀ s : ℕ, Integrable (fun y : ℕ → α => B.indicator (fun _ => (1 : ℝ)) (y s)) ρ := by
     intro s
-    refine ⟨(hmeas s).aestronglyMeasurable, .of_bounded (C := 1) (Filter.Eventually.of_forall ?_)⟩
-    intro y
-    have h0 : 0 ≤ B.indicator (fun _ => (1 : ℝ)) (y s) :=
-      Set.indicator_apply_nonneg fun _ => zero_le_one
-    rw [Real.norm_eq_abs, abs_of_nonneg h0]
-    exact Set.indicator_apply_le' (fun _ => le_rfl) fun _ => zero_le_one
+    refine ⟨(hmeas s).aestronglyMeasurable, .of_bounded (C := 1)
+      (Filter.Eventually.of_forall fun y => ?_)⟩
+    simpa only [norm_one] using norm_indicator_le_norm_self (fun _ => (1 : ℝ)) (y s)
   -- The witness is the conditional expectation at coordinate `0`.
   have hwit := invariantConditionalProbabilityMeasure_ae_eq_condExp (ρ := ρ) hB
   refine Filter.EventuallyEq.symm (ae_eq_condExp_of_forall_setIntegral_eq hle (hint r)


### PR DESCRIPTION
Three Koopman proofs established that a real indicator has norm at most one by hand — unfolding to
`abs`, discharging nonnegativity with `Set.indicator_apply_nonneg`, then bounding with
`Set.indicator_apply_le'`:

```lean
have h0 : 0 ≤ B.indicator (fun _ => (1 : ℝ)) (y r) := Set.indicator_apply_nonneg fun _ => zero_le_one
rw [Real.norm_eq_abs, abs_of_nonneg h0]
exact Set.indicator_apply_le' (fun _ => le_rfl) fun _ => zero_le_one
```

Mathlib's `norm_indicator_le_norm_self` gives it directly, and the `L²` route already uses exactly
that idiom — `ViaL2/EmpiricalToDirecting.lean:62` and `Independence/Conditional.lean:449`:

```lean
simpa only [norm_one] using norm_indicator_le_norm_self (fun _ => (1 : ℝ)) (y r)
```

Sixteen lines become seven, at `Decoupling.lean` (two sites) and `BlockFactorization.lean` (one).
No statement changes, and no new indicator-bound helper is introduced — the point is to use the
lemma that already exists rather than add a fourth spelling of it.

Roadmap: Exchangeability

Improving existing proofs; no mathematical content changes.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
