### PR TITLE
refactor(Fredholm): name the two steps of the local-properness proof

### DIFF
--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -95,6 +95,63 @@ theorem one_sub_mul_norm_sub_le {G : Type*} [SeminormedAddGroup G]
   rw [map_sub P x y] at h1
   nlinarith
 
+omit [ProperSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- **At approximation quality `C * ε = 1 / 2` the estimate becomes a two-sided bound with a
+factor of two.** This is `one_sub_mul_norm_sub_le` at the `ε` that halves the left-hand factor;
+the factor two is the form the properness argument consumes. -/
+private theorem norm_sub_le_two_mul_add_two_mul {G : Type*} [SeminormedAddGroup G] {P : E →+ G}
+    {C : ℝ} {N : Set E} {ε : ℝ≥0} (hC : 0 ≤ C) (hCε : C * (ε : ℝ) = 1 / 2)
+    (hest : ∀ z, ‖z‖ ≤ C * ‖f' z‖ + ‖P z‖) (happ : ApproximatesLinearOn f f' N ε)
+    {x : E} (hx : x ∈ N) {y : E} (hy : y ∈ N) :
+    ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
+  have h := one_sub_mul_norm_sub_le hC hest happ hx hy
+  rw [hCε] at h
+  linarith
+
+omit [ProperSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
+/-- **The two-sided bound is exactly anti-Lipschitzness of the coordinate `x ↦ (f x, P x)`.**
+The bound of `one_sub_mul_norm_sub_le` controls `‖x - y‖` by the two components separately; since
+the product norm is the maximum, each is at most the distance between the pairs, and the two
+constants add.
+
+The constant `2 * C + 2` is not sharp — the maximum norm is what costs the factor. Sharpness
+would need the weighted norm `‖u‖ + C⁻¹ * ‖v‖`, which mathlib does not instantiate on a product,
+and no consumer here uses it. -/
+private theorem antilipschitzWith_prodMk {G : Type*} [SeminormedAddCommGroup G] {N : Set E}
+    {g : E → F} {P : E → G} {C : ℝ} (hC : 0 ≤ C)
+    (key : ∀ x ∈ N, ∀ y ∈ N, ‖x - y‖ ≤ 2 * (C * ‖g x - g y‖) + 2 * ‖P x - P y‖) :
+    AntilipschitzWith ⟨2 * C + 2, by positivity⟩ fun x : N => (g (x : E), P (x : E)) := by
+  refine AntilipschitzWith.of_le_mul_dist fun x y => ?_
+  have hd1 : ‖g (x : E) - g (y : E)‖ ≤ dist (g (x : E), P (x : E)) (g (y : E), P (y : E)) := by
+    rw [Prod.dist_eq, ← dist_eq_norm]
+    exact le_max_left _ _
+  have hd2 : ‖P (x : E) - P (y : E)‖ ≤ dist (g (x : E), P (x : E)) (g (y : E), P (y : E)) := by
+    rw [Prod.dist_eq, ← dist_eq_norm]
+    exact le_max_right _ _
+  have hCd := mul_le_mul_of_nonneg_left hd1 hC
+  have hpos : (0 : ℝ) ≤ dist (g (x : E), P (x : E)) (g (y : E), P (y : E)) := dist_nonneg
+  rw [Subtype.dist_eq, dist_eq_norm]
+  calc ‖(x : E) - (y : E)‖
+      ≤ 2 * (C * ‖g (x : E) - g (y : E)‖) + 2 * ‖P (x : E) - P (y : E)‖ :=
+        key (x : E) x.2 (y : E) y.2
+    _ ≤ (2 * C + 2) * dist (g (x : E), P (x : E)) (g (y : E), P (y : E)) := by nlinarith
+
+omit [CompleteSpace E] [CompleteSpace F] in
+/-- **A continuous linear map into a finite-dimensional subspace sends a bounded set into a
+compact one.** This is where the finite-dimensionality of `ker f'` is spent: in `V` bounded sets
+are relatively compact, so the projection of a ball has compact closure even though the ball
+itself does not. -/
+private theorem exists_isCompact_forall_mem_of_norm_le {V : Submodule 𝕜 E}
+    [FiniteDimensional 𝕜 V] (P : E →L[𝕜] E) (hPV : ∀ x, P x ∈ V) (r : ℝ) :
+    ∃ K : Set E, IsCompact K ∧ ∀ x, ‖x‖ ≤ r → P x ∈ K := by
+  have : ProperSpace V := FiniteDimensional.proper 𝕜 V
+  refine ⟨V.subtypeL '' Metric.closedBall (0 : V) (‖P‖ * r),
+    (isCompact_closedBall _ _).image V.subtypeL.continuous, fun x hx => ⟨⟨P x, hPV x⟩, ?_, rfl⟩⟩
+  simp only [Metric.mem_closedBall, dist_zero_right]
+  calc ‖(⟨P x, hPV x⟩ : V)‖ = ‖P x‖ := rfl
+    _ ≤ ‖P‖ * ‖x‖ := P.le_opNorm x
+    _ ≤ ‖P‖ * r := by gcongr
+
 /-- **Local properness of a map with upper semi-Fredholm derivative.** If `f` is strictly
 differentiable at `a` and its derivative there has closed range and finite-dimensional
 complemented kernel, then `f` is proper on a neighbourhood `N` of `a`: the part of the preimage of
@@ -125,12 +182,9 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
   -- the two-sided bound on `N`
   have hCε : C * (ε : ℝ) = 1 / 2 := by rw [hεcoe]; field_simp
   have key : ∀ x ∈ N, ∀ y ∈ N,
-      ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
-    intro x hx y hy
-    have h := one_sub_mul_norm_sub_le (P := P.toLinearMap.toAddMonoidHom) hC.le hest happN hx hy
-    rw [hCε] at h
-    simp only [LinearMap.toAddMonoidHom_coe, ContinuousLinearMap.coe_coe] at h
-    linarith
+      ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := fun x hx y hy => by
+    simpa using norm_sub_le_two_mul_add_two_mul (P := P.toLinearMap.toAddMonoidHom) hC.le hCε
+      hest happN hx hy
   refine ⟨N, Metric.closedBall_mem_nhds a (by linarith), fun L hL => ?_⟩
   -- the compact box the projection lands in
   have hPmem : ∀ x, P x ∈ f'.ker := by
@@ -138,43 +192,19 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
     rw [← hPrange]
     exact ⟨x, rfl⟩
   let _ : FiniteDimensional 𝕜 f'.ker := hfinite
-  have : ProperSpace f'.ker := FiniteDimensional.proper 𝕜 f'.ker
-  set Kp : Set E := f'.ker.subtypeL '' Metric.closedBall (0 : f'.ker) (‖P‖ * (‖a‖ + δ / 2))
-  have hKpc : IsCompact Kp :=
-    (isCompact_closedBall _ _).image f'.ker.subtypeL.continuous
-  have hPN : ∀ x ∈ N, P x ∈ Kp := by
-    intro x hx
-    refine ⟨⟨P x, hPmem x⟩, ?_, rfl⟩
+  obtain ⟨Kp, hKpc, hKp⟩ :=
+    exists_isCompact_forall_mem_of_norm_le (V := f'.ker) P hPmem (‖a‖ + δ / 2)
+  have hPN : ∀ x ∈ N, P x ∈ Kp := fun x hx => hKp x <| by
     have hxa : ‖x - a‖ ≤ δ / 2 := by
       rw [hNdef, Metric.mem_closedBall, dist_eq_norm] at hx
       exact hx
-    have hnx : ‖x‖ ≤ ‖a‖ + δ / 2 := by
-      calc ‖x‖ = ‖a + (x - a)‖ := by rw [add_sub_cancel]
-        _ ≤ ‖a‖ + ‖x - a‖ := norm_add_le _ _
-        _ ≤ ‖a‖ + δ / 2 := by linarith
-    simp only [Metric.mem_closedBall, dist_zero_right]
-    calc ‖(⟨P x, hPmem x⟩ : f'.ker)‖ = ‖P x‖ := rfl
-      _ ≤ ‖P‖ * ‖x‖ := P.le_opNorm x
-      _ ≤ ‖P‖ * (‖a‖ + δ / 2) := by gcongr
+    calc ‖x‖ = ‖a + (x - a)‖ := by rw [add_sub_cancel]
+      _ ≤ ‖a‖ + ‖x - a‖ := norm_add_le _ _
+      _ ≤ ‖a‖ + δ / 2 := by linarith
   -- the anti-Lipschitz coordinate on `N`
   set Θ : N → F × E := fun x => (f (x : E), P (x : E))
-  have hanti : AntilipschitzWith ⟨2 * C + 2, by positivity⟩ Θ := by
-    refine AntilipschitzWith.of_le_mul_dist fun x y => ?_
-    have hd1 : ‖f (x : E) - f (y : E)‖ ≤ dist (Θ x) (Θ y) := by
-      rw [Prod.dist_eq, ← dist_eq_norm]
-      exact le_max_left _ _
-    have hd2 : ‖P (x : E) - P (y : E)‖ ≤ dist (Θ x) (Θ y) := by
-      rw [Prod.dist_eq, ← dist_eq_norm]
-      exact le_max_right _ _
-    have hk := key (x : E) x.2 (y : E) y.2
-    have hCd : C * ‖f (x : E) - f (y : E)‖ ≤ C * dist (Θ x) (Θ y) :=
-      mul_le_mul_of_nonneg_left hd1 hC.le
-    rw [Subtype.dist_eq, dist_eq_norm]
-    calc
-      ‖(x : E) - (y : E)‖ ≤ 2 * (C * ‖f (x : E) - f (y : E)‖) +
-          2 * ‖P (x : E) - P (y : E)‖ := hk
-      _ ≤ (2 * C + 2) * dist (Θ x) (Θ y) := by
-        nlinarith [dist_nonneg (x := Θ x) (y := Θ y)]
+  have hanti : AntilipschitzWith ⟨2 * C + 2, by positivity⟩ Θ :=
+    antilipschitzWith_prodMk hC.le key
   have hΘlip : LipschitzWith (‖f'‖₊ + ε + ‖P‖₊) Θ := by
     have h1 : LipschitzWith (‖f'‖₊ + ε) fun x : N => f (x : E) := happN.lipschitz
     have h2 : LipschitzWith ‖P‖₊ fun x : N => P (x : E) := P.lipschitz.restrict N

--- a/TauCeti/Analysis/Fredholm/Proper.lean
+++ b/TauCeti/Analysis/Fredholm/Proper.lean
@@ -96,19 +96,6 @@ theorem one_sub_mul_norm_sub_le {G : Type*} [SeminormedAddGroup G]
   nlinarith
 
 omit [ProperSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
-/-- **At approximation quality `C * ε = 1 / 2` the estimate becomes a two-sided bound with a
-factor of two.** This is `one_sub_mul_norm_sub_le` at the `ε` that halves the left-hand factor;
-the factor two is the form the properness argument consumes. -/
-private theorem norm_sub_le_two_mul_add_two_mul {G : Type*} [SeminormedAddGroup G] {P : E →+ G}
-    {C : ℝ} {N : Set E} {ε : ℝ≥0} (hC : 0 ≤ C) (hCε : C * (ε : ℝ) = 1 / 2)
-    (hest : ∀ z, ‖z‖ ≤ C * ‖f' z‖ + ‖P z‖) (happ : ApproximatesLinearOn f f' N ε)
-    {x : E} (hx : x ∈ N) {y : E} (hy : y ∈ N) :
-    ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
-  have h := one_sub_mul_norm_sub_le hC hest happ hx hy
-  rw [hCε] at h
-  linarith
-
-omit [ProperSpace 𝕜] [CompleteSpace E] [CompleteSpace F] in
 /-- **The two-sided bound is exactly anti-Lipschitzness of the coordinate `x ↦ (f x, P x)`.**
 The bound of `one_sub_mul_norm_sub_le` controls `‖x - y‖` by the two components separately; since
 the product norm is the maximum, each is at most the distance between the pairs, and the two
@@ -146,9 +133,10 @@ private theorem exists_isCompact_forall_mem_of_norm_le {V : Submodule 𝕜 E}
     ∃ K : Set E, IsCompact K ∧ ∀ x, ‖x‖ ≤ r → P x ∈ K := by
   have : ProperSpace V := FiniteDimensional.proper 𝕜 V
   refine ⟨V.subtypeL '' Metric.closedBall (0 : V) (‖P‖ * r),
-    (isCompact_closedBall _ _).image V.subtypeL.continuous, fun x hx => ⟨⟨P x, hPV x⟩, ?_, rfl⟩⟩
+    (isCompact_closedBall _ _).image V.subtypeL.continuous,
+    fun x hx => ⟨⟨P x, hPV x⟩, ?_, V.subtypeL_apply _⟩⟩
   simp only [Metric.mem_closedBall, dist_zero_right]
-  calc ‖(⟨P x, hPV x⟩ : V)‖ = ‖P x‖ := rfl
+  calc ‖(⟨P x, hPV x⟩ : V)‖ = ‖P x‖ := Submodule.coe_norm _
     _ ≤ ‖P‖ * ‖x‖ := P.le_opNorm x
     _ ≤ ‖P‖ * r := by gcongr
 
@@ -182,9 +170,12 @@ theorem _root_.HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage
   -- the two-sided bound on `N`
   have hCε : C * (ε : ℝ) = 1 / 2 := by rw [hεcoe]; field_simp
   have key : ∀ x ∈ N, ∀ y ∈ N,
-      ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := fun x hx y hy => by
-    simpa using norm_sub_le_two_mul_add_two_mul (P := P.toLinearMap.toAddMonoidHom) hC.le hCε
-      hest happN hx hy
+      ‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖ := by
+    intro x hx y hy
+    have h := one_sub_mul_norm_sub_le (P := P.toLinearMap.toAddMonoidHom) hC.le hest happN hx hy
+    rw [hCε] at h
+    simp only [LinearMap.toAddMonoidHom_coe, ContinuousLinearMap.coe_coe] at h
+    linarith
   refine ⟨N, Metric.closedBall_mem_nhds a (by linarith), fun L hL => ?_⟩
   -- the compact box the projection lands in
   have hPmem : ∀ x, P x ∈ f'.ker := by


### PR DESCRIPTION
`HasStrictFDerivAt.exists_mem_nhds_forall_isCompact_inter_preimage` carried an 82-line proof —
the longest in `Analysis/Fredholm/` and the only one over the 50-line bar. This names two of its
steps, taking the body to **58 lines**. No statement changes; both new lemmas are `private`.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"fredholm/proper-decompose-rung3"}-->

## Why these two

The module docstring already describes the argument in these steps, but the proof left them
anonymous — the prose named them and the code did not:

> "On a small enough closed ball `N` around `a`, strict differentiability turns this into the
> two-sided bound `‖x - y‖ ≤ 2 * (C * ‖f x - f y‖) + 2 * ‖P x - P y‖`, **so the map
> `x ↦ (f x, P x)` is anti-Lipschitz on `N`**. Its second component takes values in the
> finite-dimensional space `ker f'`, **where bounded sets have compact closure**, so
> `x ↦ (f x, P x)` sends `N ∩ f ⁻¹' L` into a compact box"

| new `private` lemma | what it names | replaces |
|---|---|---|
| `antilipschitzWith_prodMk` | the two-sided bound **is** anti-Lipschitzness of `(f, P)` | the 17-line `hanti` |
| `exists_isCompact_forall_mem_of_norm_le` | finite-dimensionality of `ker f'` being spent | the `Kp`/`hKpc`/`hPN` block |

The first is the mathematical content of the file, and stating it separately makes visible that it
is about a **product** map. That matters: mathlib's `ApproximatesLinearOn.antilipschitz` is about
`f` alone and needs `f'` invertible, so it does not apply here and would not apply even if
generalised to a bounded-below `f'` — the map being inverted is `(f, P)`, not `f`. Keeping that
distinction in a named statement is worth more than the lines saved.

The second is stated for an arbitrary submodule and radius rather than for `ker f'` and
`‖a‖ + δ / 2`, since nothing in it is specific to the Fredholm setting.

## Constant

`antilipschitzWith_prodMk` records that `2 * C + 2` is not sharp, and why: the product norm is the
maximum, so each component is bounded by the pair distance and the constants add. Sharpness would
need the weighted norm `‖u‖ + C⁻¹ * ‖v‖`, which mathlib does not instantiate on a product. No
consumer here uses sharpness. Stating this in the docstring rather than leaving a bare `2 * C + 2`
is the point of naming the step.

## Round 1 review — all three findings accepted

**`reuse` was right, and the reason is worth recording.** The first revision had a third private
lemma, `norm_sub_le_two_mul_add_two_mul`, specialising `one_sub_mul_norm_sub_le` at
`C * ε = 1 / 2`. It asserted nothing the public lemma did not; it was a rewrite plus `linarith`
at one call site. I added it to get the body under the 50-line bar — which is the wrong reason to
introduce a wrapper, and the bar is not worth buying with a declaration that names nothing.
Deleted; the call site does the specialisation inline, as it did before.

**Both `proof-quality` findings were also right.**

* The bare `simpa` at the `key` call site hid the `AddMonoidHom`/`ContinuousLinearMap` coercion
  conversion behind the global simp set. Restored to the explicit
  `simp only [LinearMap.toAddMonoidHom_coe, ContinuousLinearMap.coe_coe]` — which is what the
  code did before this PR, so that was a regression I introduced.
* `exists_isCompact_forall_mem_of_norm_le` leaned on two undocumented definitional equalities:
  `V.subtypeL ⟨P x, _⟩ = P x` and the subtype norm. Both now go through named lemmas —
  `Submodule.subtypeL_apply` and `Submodule.coe_norm`.

## Still over the bar — flagged, not hidden

At 58 lines the main proof is **still above the 50-line bar**, and one line further above it than
the previous revision, because accepting `reuse` removed the wrapper that was buying the
difference. What remains is the `ε`/`δ`/`N` construction, the projection plumbing, and the closing
totally-bounded-to-compact argument; those are individually small and mutually interleaved, and
carving them further would produce lemmas that name nothing — the exact defect `reuse` just
flagged. Flagging for a further `/decompose-proof` pass rather than forcing it here.

This is the third rung of a decomposition chain on this file:

* #3315 — named the absorption step (`one_sub_mul_norm_sub_le`)
* #3322 — dropped a hand-written `coe_comp`
* this PR — names the two steps above

## Provenance

Not a port. `one_sub_mul_norm_sub_le` is TauCeti's own (#3315). The extracted proofs are the
existing inline ones, moved and generalised in their hypotheses; no argument is new.

## Checks

Four gates, each exit code captured separately, `WATCHDOG_TOOLCHAIN` exported so `lint-env.sh` is
not a silent green — asserted on its printed `lint-env:` lines, not its exit code.
