### PR TITLE
docs(DeFinetti): correct route-scope claims and drop PR narration

### DIFF
--- a/TauCeti/Probability/DeFinetti.lean
+++ b/TauCeti/Probability/DeFinetti.lean
@@ -62,6 +62,7 @@ directing measure is pinned down almost everywhere.
 This facade exports the stable representation and uniqueness API. Proof routes keep their own
 endpoints and internals in their own modules, and the worked examples live with the examples;
 both are reachable directly.
+
 ## References
 
 * Roadmap: `TauCetiRoadmap/Exchangeability/README.md`, **Layer 7** (public API), which specifies

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/BlockCylinder.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/BlockCylinder.lean
@@ -11,7 +11,7 @@ public import TauCeti.Probability.Process.Tail.Basic
 /-!
 # The mass of a directing-measure event met with a block cylinder
 
-One lemma, the integration step shared by every de Finetti route:
+One lemma, the integration step shared by the routes that condition on the **tail** σ-algebra:
 
 ```text
 μ ((ν ⁻¹' S) ∩ blockCylinder X k B) = ∫⁻ ω in ν ⁻¹' S, ∏ i, directingMeasure μ X ω (B i) ∂μ
@@ -20,7 +20,9 @@ One lemma, the integration step shared by every de Finetti route:
 given the conditional factorization of the block along `k`. That factorization is a **hypothesis**,
 not a conclusion: this file proves none of it, and so depends on no route that establishes it. Each
 route supplies its own — the martingale route from `TailFactorization`, the `L²` route from
-`ViaL2/BlockFactorization.lean` — and both then instantiate this lemma.
+`ViaL2/BlockFactorization.lean` — and both then instantiate this lemma. The Koopman route
+conditions on the shift-invariant σ-algebra and builds a different witness, so it does not reach
+this file at all.
 
 That is the whole point of stating it this way. The routes are required to stay independent at the
 level of imports, so the shared material has to be the part that *neither* proves: here, the

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Coord.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Coord.lean
@@ -11,11 +11,12 @@ public import TauCeti.Probability.Exchangeability.Basic
 /-!
 # The directing measure is the conditional law of every coordinate
 
-`directingMeasure_ae_eq_condExp` (in `DirectingMeasure.lean`) identifies the directing measure with
-the conditional law of the initial coordinate `X 0` given the tail σ-algebra. For a **contractable**
-process the same holds for every coordinate. `Contractable.directingMeasure_ae_eq_condExp_coord`
-promotes that identity from `X 0` to every `X m`, using the "extreme members agree on the tail"
-collapse `Contractable.condExp_indicator_tailProcess_eq`.
+`directingMeasure_ae_eq_condExp` (in `DirectingMeasure/Basic.lean`) identifies the directing
+measure with the conditional law of the initial coordinate `X 0` given the tail σ-algebra. For
+a **contractable** process the same holds for every coordinate.
+`Contractable.directingMeasure_ae_eq_condExp_coord` promotes that identity from `X 0` to every
+`X m`, using the "extreme members agree on the tail" collapse
+`Contractable.condExp_indicator_tailProcess_eq`.
 
 This is the per-coordinate input to the de Finetti block-product factorisation: it is what lets the
 single directing measure serve as the common conditional law of all coordinates.

--- a/TauCeti/Probability/DeFinetti/ViaKoopman/Theorem.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/Theorem.lean
@@ -38,9 +38,8 @@ given the tail. This route uses actual invariance of the test event under the sh
 `Bool`. They are deliberately not unified into one σ-algebra-parametric theorem.
 
 Both routes are finite-measure statements: these wrappers and `deFinetti_viaL2` alike ask only for
-`[IsFiniteMeasure μ]`. The Koopman chain briefly assumed a probability measure, but nothing in it
-used that — the mean ergodic input and the witness are both finite-measure statements — and the
-assumption was removed in #3326.
+`[IsFiniteMeasure μ]`. Nothing in the Koopman chain needs more: the mean ergodic input and the
+witness are both finite-measure statements.
 
 ## Source
 

--- a/TauCeti/Probability/DeFinetti/ViaL2/ConditionallyIID.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/ConditionallyIID.lean
@@ -41,10 +41,10 @@ consumes one.
 
 * Roadmap: `TauCetiRoadmap/Exchangeability/README.md`, **Layer 3** — the martingale-free
   standard-Borel de Finetti route, `deFinetti_viaL2`.
-* The integration step was previously duplicated: it lived privately in
-  `DeFinetti/JointRectangle.lean` for the prefix selection, and was reimplemented here. #2958
-  extracted it as `measure_inter_blockCylinder_eq_setLIntegral_of_condExp`, which both routes now
-  call; this file no longer carries its own copy.
+* The integration step is shared, not route-specific:
+  `measure_inter_blockCylinder_eq_setLIntegral_of_condExp` in
+  `DeFinetti/DirectingMeasure/BlockCylinder.lean` serves both this route and the prefix selection
+  in `DeFinetti/JointRectangle.lean`.
 -/
 
 public section

--- a/TauCeti/Probability/Exchangeability.lean
+++ b/TauCeti/Probability/Exchangeability.lean
@@ -48,6 +48,7 @@ worked example ("an i.i.d. sequence is mixed i.i.d., exchangeable, and contracta
 exported here because it doubles as constructor API — the results that build the representation
 predicates from independence together with a common law — not because examples are curated in
 general.
+
 ## References
 
 * Roadmap: `TauCetiRoadmap/Exchangeability/README.md`, **Layer 7** (public API), which specifies


### PR DESCRIPTION
Six header-docstring claims in the de Finetti tree had drifted from the code. No declaration,
statement, or proof is touched.

## The two that were factually wrong

**`DirectingMeasure/BlockCylinder.lean`** described its lemma as "the integration step shared by
every de Finetti route". It is not shared by every route — the Koopman route's import closure (37
modules from `ViaKoopman/Theorem.lean`) does not contain this file at all. The actual callers of
`measure_inter_blockCylinder_eq_setLIntegral_of_condExp` are `DeFinetti/JointRectangle.lean` and
`DeFinetti/ViaL2/ConditionallyIID.lean` — exactly the routes that condition on the **tail**
σ-algebra. The docstring is now scoped to those, and says why Koopman does not reach it: it
conditions on the shift-invariant σ-algebra and builds a different witness.

**`DirectingMeasure/Coord.lean`** cited `directingMeasure_ae_eq_condExp` as living "in
`DirectingMeasure.lean`". No such file exists — `DirectingMeasure` is a directory, and the theorem
is in `DirectingMeasure/Basic.lean`.

## Narration of the repo's own history

`ViaKoopman/Theorem.lean` explained that the Koopman chain "briefly assumed a probability measure …
and the assumption was removed in #3326"; `ViaL2/ConditionallyIID.lean` explained that the
integration step "was previously duplicated … #2958 extracted it … this file no longer carries its
own copy." A reader wants the present shape of the code, not its changelog — git already has that.
Both now state the current fact directly, and the L² note additionally points at the shared lemma's
real home rather than describing the move.

## Formatting

Both facades (`Probability/DeFinetti.lean`, `Probability/Exchangeability.lean`) ran prose straight
into `## References` with no blank line separating them.

## Not included

`ConditionalCommonEnding.lean:117` claims a route conditioning on invariant σ-algebras "could
consume the same statement, though none currently does" — false since `ViaKoopman/Theorem.lean:77`
`refine`s exactly that seam. That line sits three lines below a hunk in #3423, so it is left for a
one-line follow-up once #3423 lands rather than risking a conflict here.

Roadmap: Exchangeability

Documenting existing code; no new mathematics.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
