### PR TITLE
feat: preserve unipotence under smooth closed subgroups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean
@@ -65,6 +65,7 @@ variable [Field L] [Algebra k L] [PerfectField L]
 
 Contravariantly, this says that a point of a closed subgroup is unipotent exactly when its image
 in the ambient affine group is unipotent. -/
+@[simp]
 theorem isUnipotentPoint_mapDomain_iff_of_surjective
     (f : H →ₐc[k] K) (hf : Function.Surjective f)
     (g : WithConv (K →ₐ[k] L)) :
@@ -72,29 +73,20 @@ theorem isUnipotentPoint_mapDomain_iff_of_surjective
   constructor
   · intro hg
     rw [Point.isUnipotentPoint_iff_semisimplePart_eq_one] at hg ⊢
-    have hmap :
-        AlgHom.mapDomain f (Point.semisimplePart k K L g) =
-          (1 : WithConv (H →ₐ[k] L)) := by
-      rw [← Point.semisimplePart_mapDomain]
-      exact hg
     let f' : CommHopfAlgCat.of k H ⟶ CommHopfAlgCat.of k K := CommHopfAlgCat.ofHom f
     apply CommHopfAlgCat.mapPointsFunctor_app_injective_of_surjective f' hf
       (CommAlgCat.of k L)
-    -- Expose the concrete group-hom application produced by the categorical point functor.
-    change AlgHom.mapDomain f (Point.semisimplePart k K L g) = AlgHom.mapDomain f 1
-    simpa only [map_one] using hmap
+    have hmap' :
+        (CommHopfAlgCat.mapPointsFunctor f').app (CommAlgCat.of k L)
+          (Point.semisimplePart k K L g) = 1 := by
+      rw [CommHopfAlgCat.mapPointsFunctor_app_apply]
+      simp only [HopfAlgebra.pointsFunctor_obj]
+      dsimp [f']
+      rw [← AlgHom.mapDomain_apply, ← Point.semisimplePart_mapDomain]
+      exact hg
+    exact hmap'.trans (map_one _).symm
   · intro hg
     exact hg.mapDomain f
-
-/-- Simp-normal form of `isUnipotentPoint_mapDomain_iff_of_surjective`, with the precomposed point
-written after normalization by `AlgHom.mapDomain_apply`. -/
-@[simp]
-theorem isUnipotentPoint_toConv_comp_iff_of_surjective
-    (f : H →ₐc[k] K) (hf : Function.Surjective f)
-    (g : WithConv (K →ₐ[k] L)) :
-    IsUnipotentPoint (toConv (g.ofConv.comp (f : H →ₐ[k] K))) ↔ IsUnipotentPoint g := by
-  simpa only [AlgHom.mapDomain_apply] using
-    isUnipotentPoint_mapDomain_iff_of_surjective f hf g
 
 end HopfAlgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean
@@ -31,8 +31,8 @@ of the smooth unipotent group `𝔾ₐ`.
   precomposition with a surjective coordinate morphism.
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty_of_surjective`: geometric unipotence
   descends to a quotient coordinate Hopf algebra.
-* `TauCeti.smoothUnipotentCommHopfAlgProperty_of_surjective`: a smooth quotient of a smooth
-  unipotent finite-type coordinate Hopf algebra is smooth unipotent.
+* `TauCeti.smoothUnipotentCommHopfAlgProperty_of_surjective`: a smooth quotient of a
+  geometrically unipotent finite-type coordinate Hopf algebra is smooth unipotent.
 * `TauCeti.smoothUnipotentCommHopfAlgProperty_quotient`: the preceding result for the quotient by
   a Hopf ideal, hence for a smooth closed subgroup scheme.
 
@@ -86,6 +86,16 @@ theorem isUnipotentPoint_mapDomain_iff_of_surjective
   · intro hg
     exact hg.mapDomain f
 
+/-- Simp-normal form of `isUnipotentPoint_mapDomain_iff_of_surjective`, with the precomposed point
+written after normalization by `AlgHom.mapDomain_apply`. -/
+@[simp]
+theorem isUnipotentPoint_toConv_comp_iff_of_surjective
+    (f : H →ₐc[k] K) (hf : Function.Surjective f)
+    (g : WithConv (K →ₐ[k] L)) :
+    IsUnipotentPoint (toConv (g.ofConv.comp (f : H →ₐ[k] K))) ↔ IsUnipotentPoint g := by
+  simpa only [AlgHom.mapDomain_apply] using
+    isUnipotentPoint_mapDomain_iff_of_surjective f hf g
+
 end HopfAlgebra
 
 /-- Geometric-point unipotence descends along a surjective morphism of coordinate Hopf algebras.
@@ -100,7 +110,7 @@ theorem geometricallyUnipotentPointsCommHopfAlgProperty_of_surjective
   intro g
   exact (HopfAlgebra.isUnipotentPoint_mapDomain_iff_of_surjective f.hom hf g).mp (hH _)
 
-/-- A smooth quotient of a smooth unipotent finite-type coordinate Hopf algebra is smooth
+/-- A smooth quotient of a geometrically unipotent finite-type coordinate Hopf algebra is smooth
 unipotent.
 
 Contravariantly, the quotient coordinate algebra represents a smooth closed subgroup of the
@@ -109,24 +119,22 @@ subgroups of smooth group schemes need not be smooth in positive characteristic.
 theorem smoothUnipotentCommHopfAlgProperty_of_surjective
     (k : Type u) [Field k] {H K : FiniteTypeCommHopfAlgCat.{u, u} k}
     (f : H ⟶ K) (hf : Function.Surjective (FiniteTypeCommHopfAlgCat.toBialgHom f))
-    (hH : smoothUnipotentCommHopfAlgProperty k H)
+    (hH : geometricallyUnipotentPointsCommHopfAlgProperty k H.obj)
     (hK : Algebra.Smooth k K) :
     smoothUnipotentCommHopfAlgProperty k K := by
-  rw [smoothUnipotentCommHopfAlgProperty_iff] at hH ⊢
+  rw [smoothUnipotentCommHopfAlgProperty_iff]
   refine ⟨hK, ?_⟩
-  intro g
-  exact (HopfAlgebra.isUnipotentPoint_mapDomain_iff_of_surjective
-      (FiniteTypeCommHopfAlgCat.toBialgHom f) hf g).mp
-    (hH.2 (AlgHom.mapDomain (FiniteTypeCommHopfAlgCat.toBialgHom f) g))
+  rw [← geometricallyUnipotentPointsCommHopfAlgProperty_iff]
+  exact geometricallyUnipotentPointsCommHopfAlgProperty_of_surjective k f.hom hf hH
 
-/-- A smooth Hopf-ideal quotient of a smooth unipotent finite-type coordinate Hopf algebra is
+/-- A smooth Hopf-ideal quotient of a geometrically unipotent finite-type coordinate Hopf algebra is
 smooth unipotent.
 
 The spectrum of `H ⧸ I` is the closed subgroup scheme cut out by `I`; thus this is the coordinate
 form of closure of smooth unipotent affine groups under smooth closed subgroup schemes. -/
 theorem smoothUnipotentCommHopfAlgProperty_quotient
     (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k)
-    (I : HopfIdeal k H) (hH : smoothUnipotentCommHopfAlgProperty k H)
+    (I : HopfIdeal k H) (hH : geometricallyUnipotentPointsCommHopfAlgProperty k H.obj)
     (hI : Algebra.Smooth k (H ⧸ I.toIdeal)) :
     smoothUnipotentCommHopfAlgProperty k (FiniteTypeCommHopfAlgCat.quotient H I) := by
   apply smoothUnipotentCommHopfAlgProperty_of_surjective k

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean
@@ -69,7 +69,8 @@ in the ambient affine group is unipotent. -/
 theorem isUnipotentPoint_mapDomain_iff_of_surjective
     (f : H →ₐc[k] K) (hf : Function.Surjective f)
     (g : WithConv (K →ₐ[k] L)) :
-    IsUnipotentPoint (AlgHom.mapDomain f g) ↔ IsUnipotentPoint g := by
+    IsUnipotentPoint (toConv (g.ofConv.comp (f : H →ₐ[k] K))) ↔ IsUnipotentPoint g := by
+  rw [← AlgHom.mapDomain_apply]
   constructor
   · intro hg
     rw [Point.isUnipotentPoint_iff_semisimplePart_eq_one] at hg ⊢

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Representation.JordanDecomposition.Naturality
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+
+/-!
+# Closed subgroups of smooth unipotent affine groups
+
+A closed subgroup of an affine group is represented contravariantly by a surjective morphism of
+coordinate Hopf algebras. This file proves that geometric-point unipotence descends along such a
+morphism. Consequently, a smooth closed subgroup of a smooth unipotent affine group is again
+smooth unipotent.
+
+The pointwise argument uses naturality and uniqueness of Jordan decomposition. If `f : H ⟶ K`
+is surjective and a `K`-point `g` becomes unipotent after precomposition with `f`, naturality says
+that the semisimple part of `g` also becomes the identity after precomposition. Surjectivity makes
+precomposition injective on points, so the semisimple part of `g` was already the identity.
+
+Smoothness of the subgroup is retained as an explicit hypothesis. It cannot be deduced from the
+closed immersion: in positive characteristic, the nonsmooth group scheme `αₚ` is a closed subgroup
+of the smooth unipotent group `𝔾ₐ`.
+
+## Main declarations
+
+* `TauCeti.HopfAlgebra.isUnipotentPoint_mapDomain_iff_of_surjective`: unipotence is reflected by
+  precomposition with a surjective coordinate morphism.
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty_of_surjective`: geometric unipotence
+  descends to a quotient coordinate Hopf algebra.
+* `TauCeti.smoothUnipotentCommHopfAlgProperty_of_surjective`: a smooth quotient of a smooth
+  unipotent finite-type coordinate Hopf algebra is smooth unipotent.
+* `TauCeti.smoothUnipotentCommHopfAlgProperty_quotient`: the preceding result for the quotient by
+  a Hopf ideal, hence for a smooth closed subgroup scheme.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+
+This is a closure result needed in Layer 5, "Unipotent groups", of the ReductiveGroups roadmap.
+It supplies a basic input for comparing connected normal unipotent closed subgroups in the
+construction of the unipotent radical.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u
+
+namespace HopfAlgebra
+
+variable {k H K L : Type u} [Field k]
+variable [CommRing H] [_root_.HopfAlgebra k H]
+variable [CommRing K] [_root_.HopfAlgebra k K]
+variable [Field L] [Algebra k L] [PerfectField L]
+
+/-- Precomposition with a surjective coordinate Hopf-algebra morphism detects unipotent points.
+
+Contravariantly, this says that a point of a closed subgroup is unipotent exactly when its image
+in the ambient affine group is unipotent. -/
+theorem isUnipotentPoint_mapDomain_iff_of_surjective
+    (f : H →ₐc[k] K) (hf : Function.Surjective f)
+    (g : WithConv (K →ₐ[k] L)) :
+    IsUnipotentPoint (AlgHom.mapDomain f g) ↔ IsUnipotentPoint g := by
+  constructor
+  · intro hg
+    rw [Point.isUnipotentPoint_iff_semisimplePart_eq_one] at hg ⊢
+    have hmap :
+        AlgHom.mapDomain f (Point.semisimplePart k K L g) =
+          (1 : WithConv (H →ₐ[k] L)) := by
+      rw [← Point.semisimplePart_mapDomain]
+      exact hg
+    let f' : CommHopfAlgCat.of k H ⟶ CommHopfAlgCat.of k K := CommHopfAlgCat.ofHom f
+    apply CommHopfAlgCat.mapPointsFunctor_app_injective_of_surjective f' hf
+      (CommAlgCat.of k L)
+    -- Expose the concrete group-hom application produced by the categorical point functor.
+    change AlgHom.mapDomain f (Point.semisimplePart k K L g) = AlgHom.mapDomain f 1
+    simpa only [map_one] using hmap
+  · intro hg
+    exact hg.mapDomain f
+
+end HopfAlgebra
+
+/-- Geometric-point unipotence descends along a surjective morphism of coordinate Hopf algebras.
+
+The corresponding morphism of affine groups is a closed immersion in the opposite direction. -/
+theorem geometricallyUnipotentPointsCommHopfAlgProperty_of_surjective
+    (k : Type u) [Field k] {H K : CommHopfAlgCat.{u} k}
+    (f : H ⟶ K) (hf : Function.Surjective f.hom)
+    (hH : geometricallyUnipotentPointsCommHopfAlgProperty k H) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k K := by
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hH ⊢
+  intro g
+  exact (HopfAlgebra.isUnipotentPoint_mapDomain_iff_of_surjective f.hom hf g).mp (hH _)
+
+/-- A smooth quotient of a smooth unipotent finite-type coordinate Hopf algebra is smooth
+unipotent.
+
+Contravariantly, the quotient coordinate algebra represents a smooth closed subgroup of the
+original affine group. Smoothness of the quotient is an explicit hypothesis because closed
+subgroups of smooth group schemes need not be smooth in positive characteristic. -/
+theorem smoothUnipotentCommHopfAlgProperty_of_surjective
+    (k : Type u) [Field k] {H K : FiniteTypeCommHopfAlgCat.{u, u} k}
+    (f : H ⟶ K) (hf : Function.Surjective (FiniteTypeCommHopfAlgCat.toBialgHom f))
+    (hH : smoothUnipotentCommHopfAlgProperty k H)
+    (hK : Algebra.Smooth k K) :
+    smoothUnipotentCommHopfAlgProperty k K := by
+  rw [smoothUnipotentCommHopfAlgProperty_iff] at hH ⊢
+  refine ⟨hK, ?_⟩
+  intro g
+  exact (HopfAlgebra.isUnipotentPoint_mapDomain_iff_of_surjective
+      (FiniteTypeCommHopfAlgCat.toBialgHom f) hf g).mp
+    (hH.2 (AlgHom.mapDomain (FiniteTypeCommHopfAlgCat.toBialgHom f) g))
+
+/-- A smooth Hopf-ideal quotient of a smooth unipotent finite-type coordinate Hopf algebra is
+smooth unipotent.
+
+The spectrum of `H ⧸ I` is the closed subgroup scheme cut out by `I`; thus this is the coordinate
+form of closure of smooth unipotent affine groups under smooth closed subgroup schemes. -/
+theorem smoothUnipotentCommHopfAlgProperty_quotient
+    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (I : HopfIdeal k H) (hH : smoothUnipotentCommHopfAlgProperty k H)
+    (hI : Algebra.Smooth k (H ⧸ I.toIdeal)) :
+    smoothUnipotentCommHopfAlgProperty k (FiniteTypeCommHopfAlgCat.quotient H I) := by
+  apply smoothUnipotentCommHopfAlgProperty_of_surjective k
+    (FiniteTypeCommHopfAlgCat.mkQuotient H I) _ hH hI
+  exact Ideal.Quotient.mkₐ_surjective k I.toIdeal
+
+end TauCeti


### PR DESCRIPTION
This PR proves that precomposition along a surjective coordinate Hopf-algebra morphism detects unipotent points, then packages the result for smooth finite-type quotients and Hopf-ideal quotients. It advances the exact target in `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5 milestone “Unipotent groups,” specifically the construction of the unipotent radical as the maximal connected normal unipotent closed subgroup.

This is the most effective current step because point Jordan decomposition, smooth unipotence, and the Hopf-ideal classification of closed subgroup schemes are on `main`, while the upper-unitriangular group scheme and quotient-sheaf work are separately in flight. The proof uses naturality of the semisimple Jordan factor: if a subgroup point becomes unipotent in the ambient group, its semisimple part becomes the identity, and injectivity of points along a surjective coordinate map reflects that equality back to the subgroup. Smoothness remains an explicit hypothesis, as required by the counterexample `αₚ ⊂ 𝔾ₐ` in positive characteristic.

After this PR, the Layer 5 milestone still needs Lie–Kolchin and the embedding characterization by an upper-unitriangular group, extension closure where applicable, and construction and maximality of the unipotent radical.

Add `TauCeti/Algebra/AlgebraicGroup/Unipotent/ClosedSubgroup.lean` (136 lines). The implementation reuses Tau Ceti’s naturality of point Jordan decomposition, injectivity of the functor of points along surjective coordinate maps, finite-type Hopf-ideal quotient, and smooth-unipotence APIs; no Mathlib infrastructure is vendored. The mathematical closure result follows J. C. Jantzen, *Representations of Algebraic Groups*, I.2, and T. A. Springer, *Linear Algebraic Groups*, §2.4, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"smooth-unipotent-closed-subgroups"}-->

🤖 Prepared with Codex
