### PR TITLE
feat(Isogeny): the intermediate ring is a Dedekind domain

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
@@ -35,9 +35,15 @@ Noetherianity from the trace pairing, which is nondegenerate exactly in the sepa
 
 So the hypothesis set here matches the sibling `Isogeny.moduleFinite_intermediateRing` rather than
 `Isogeny.isIntegrallyClosed_intermediateRing`, and for the same reason: both go through the trace.
-In particular this statement does **not** cover inseparable isogenies, Frobenius included, whereas
-the normality of the same ring does. That asymmetry is real rather than an artefact of the route
-taken — see `IntermediateRing/Finite.lean`, which flags the general case as separate work.
+
+**The hypothesis is a limitation of the route, not of the result.** `W₂.CoordinateRing` is a
+finite-type algebra over a field and therefore Nagata, so its normalization in a finite extension
+is finite — and the conclusion is expected to hold with no separability at all, inseparable
+isogenies and Frobenius included. What blocks that here is availability: every finiteness route in
+`Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean` sits under `Algebra.IsSeparable`, and the
+pinned Mathlib carries no usable Nagata normalization-finiteness API. Removing the hypothesis
+therefore means building that route first, which is separate work; this is the interim result.
+`IntermediateRing/Finite.lean` records the same limitation for the finiteness half.
 
 `IsDedekindDomain W₂.CoordinateRing` is taken as a hypothesis rather than derived. For an elliptic
 curve it is supplied by `WeierstrassCurve.Affine.isDedekindDomain_coordinateRing`, which needs
@@ -72,8 +78,10 @@ variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
 `W₂.CoordinateRing` in `W₁.FunctionField`, and the integral closure of a Dedekind domain in a
 finite separable extension of its fraction field is again Dedekind.
 
-Separability is genuinely needed, unlike for `Isogeny.isIntegrallyClosed_intermediateRing`: the
-Noetherian half of the conjunction comes from the trace pairing. -/
+Separability is required by the route rather than by the statement: the Noetherian half of the
+conjunction is obtained from the trace pairing, which is what Mathlib's
+`IsIntegralClosure.isDedekindDomain` uses. The conclusion is expected to hold inseparably too,
+since `W₂.CoordinateRing` is Nagata — see the module docstring. -/
 theorem isDedekindDomain_intermediateRing (φ : Isogeny W₁ W₂)
     [IsDedekindDomain W₂.CoordinateRing]
     [Algebra W₂.CoordinateRing W₁.FunctionField]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
+public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
+
+/-!
+# The intermediate ring is a Dedekind domain
+
+For an isogeny `φ : Isogeny W₁ W₂`, the intermediate ring — the integral closure of
+`W₂.CoordinateRing` in `W₁.FunctionField` — is a Dedekind domain whenever the target's coordinate
+ring is one and the extension of function fields is separable.
+
+This is what the relative ideal norm asks of the *middle* ring: `ClassGroup.relNorm`, and through
+it `ClassGroup.extendedRelNormHom`, is stated over a module-finite extension of Dedekind domains,
+so `Isogeny.pushClass` needs `φ.intermediateRing` to be Dedekind and not merely normal.
+
+## Main results
+
+* `TauCeti.Isogeny.isDedekindDomain_intermediateRing`: `φ.intermediateRing` is a Dedekind domain.
+
+## Design
+
+**Why this is separate from `IntegrallyClosed.lean`, and why it costs more.**
+`Isogeny.isIntegrallyClosed_intermediateRing` is hypothesis-free: an integral closure is integrally
+closed because integral closure is idempotent, and that argument sees no trace form. Being
+*Dedekind* is a conjunction — integrally closed, Noetherian, dimension at most one — and the
+Noetherian half is where the cost enters. Mathlib's route, `IsIntegralClosure.isDedekindDomain`,
+is stated for a finite **separable** extension of the fraction field, because it obtains
+Noetherianity from the trace pairing, which is nondegenerate exactly in the separable case.
+
+So the hypothesis set here matches the sibling `Isogeny.moduleFinite_intermediateRing` rather than
+`Isogeny.isIntegrallyClosed_intermediateRing`, and for the same reason: both go through the trace.
+In particular this statement does **not** cover inseparable isogenies, Frobenius included, whereas
+the normality of the same ring does. That asymmetry is real rather than an artefact of the route
+taken — see `IntermediateRing/Finite.lean`, which flags the general case as separate work.
+
+`IsDedekindDomain W₂.CoordinateRing` is taken as a hypothesis rather than derived. For an elliptic
+curve it is supplied by `WeierstrassCurve.Affine.isDedekindDomain_coordinateRing`, which needs
+`[W₂.IsElliptic]`; taking the Dedekind property directly keeps that ellipticity out of this file,
+exactly as the sibling takes `[IsIntegrallyClosed W₂.CoordinateRing]` rather than assuming a curve.
+
+## Provenance
+
+⚠ *mathlib-track*. `TauCetiRoadmap/EllipticCurves/README.md:1092` lists the `IntermediateRing`
+with `intermediateRingFinite` and `intermediateRingIsIntegrallyClosed` among the components of
+D. Angdinata's shared isogeny development, on the way to `pushClass` and `toPointHom`; the Dedekind
+property is what those two facts are combined for.
+
+AINTLIB proves the same statement about the same object as
+`NormConormIntegralClosure.instDedekindB` (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
+`HasseWeil/Curves/NormConormIntegralClosure.lean`, by Chris Birkbeck), for
+`B := integralClosure C₂.CoordinateRing C₁.FunctionField`. What is adapted here is the reduction to
+`intermediateRing` as this repository defines it — through the corestricted pullback and
+`Isogeny.isIntegralClosure_intermediateRing` — rather than to Mathlib's literal `integralClosure`
+subalgebra.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Isogeny
+
+variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
+
+/-- **The intermediate ring is a Dedekind domain.** It is the integral closure of
+`W₂.CoordinateRing` in `W₁.FunctionField`, and the integral closure of a Dedekind domain in a
+finite separable extension of its fraction field is again Dedekind.
+
+Separability is genuinely needed, unlike for `Isogeny.isIntegrallyClosed_intermediateRing`: the
+Noetherian half of the conjunction comes from the trace pairing. -/
+theorem isDedekindDomain_intermediateRing (φ : Isogeny W₁ W₂)
+    [IsDedekindDomain W₂.CoordinateRing]
+    [Algebra W₂.CoordinateRing W₁.FunctionField]
+    [Algebra W₂.FunctionField W₁.FunctionField]
+    [IsScalarTower W₂.CoordinateRing W₂.FunctionField W₁.FunctionField]
+    [Algebra W₂.CoordinateRing φ.intermediateRing]
+    [IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField]
+    [Algebra.IsSeparable W₂.FunctionField W₁.FunctionField]
+    (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
+    IsDedekindDomain φ.intermediateRing := by
+  -- the integral-closure property is not assumed: it is what `intermediateRing` is
+  have := φ.isIntegralClosure_intermediateRing h
+  have := φ.finiteDimensional_functionField (φ.algebraMap_functionField_eq_fieldPullback h)
+  exact IsIntegralClosure.isDedekindDomain W₂.CoordinateRing W₂.FunctionField W₁.FunctionField
+    φ.intermediateRing
+
+end Isogeny
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
@@ -40,11 +40,20 @@ So the hypothesis set here matches the sibling `Isogeny.moduleFinite_intermediat
 **The hypothesis is a limitation of the route, not of the result.** `W₂.CoordinateRing` is a
 finite-type algebra over a field and therefore Nagata, so its normalization in a finite extension
 is finite — and the conclusion is expected to hold with no separability at all, inseparable
-isogenies and Frobenius included. What blocks that here is availability: every finiteness route in
-`Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean` sits under `Algebra.IsSeparable`, and the
-pinned Mathlib carries no usable Nagata normalization-finiteness API. Removing the hypothesis
-therefore means building that route first, which is separate work; this is the interim result.
-`IntermediateRing/Finite.lean` records the same limitation for the finiteness half.
+isogenies and Frobenius included. What blocks that here is availability, and it is measurable:
+every route to the Noetherian half in `Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean`
+falls under the section variable `[Algebra.IsSeparable K L]` declared at its line 147, and the
+pinned Mathlib has no Krull–Akizuki (the identifier and the hyphenated prose spelling both occur
+zero times, against 69 files mentioning `IsDedekindDomain`) and no usable Nagata
+normalization-finiteness API.
+
+Removing the hypothesis therefore means building that route first. That is not an open-ended
+wish: `TauCetiRoadmap/EllipticCurves/README.md:1096` already names
+`RingTheory/IntegralClosure/NormalizationFinite` as one of the supports of this same isogeny
+development. So the inseparable statement is scheduled work with a home, and a slice of its own
+under this repository's one-topic-per-PR rule — not something to be folded into this file. This
+is the interim result until it lands. `IntermediateRing/Finite.lean` records the same limitation
+for the finiteness half.
 
 `IsDedekindDomain W₂.CoordinateRing` is taken as a hypothesis rather than derived. For an elliptic
 curve it is supplied by `WeierstrassCurve.Affine.isDedekindDomain_coordinateRing`, which needs
@@ -79,10 +88,8 @@ variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
 `W₂.CoordinateRing` in `W₁.FunctionField`, and the integral closure of a Dedekind domain in a
 finite separable extension of its fraction field is again Dedekind.
 
-Separability is required by the route rather than by the statement: the Noetherian half of the
-conjunction is obtained from the trace pairing, which is what Mathlib's
-`IsIntegralClosure.isDedekindDomain` uses. The conclusion is expected to hold inseparably too,
-since `W₂.CoordinateRing` is Nagata — see the module docstring. -/
+Separability is a restriction of the proof route, not of the result; the module docstring's
+Design section says why, and what removing it would take. -/
 theorem isDedekindDomain_intermediateRing (φ : Isogeny W₁ W₂)
     [IsDedekindDomain W₂.CoordinateRing]
     [Algebra W₂.CoordinateRing W₁.FunctionField]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
@@ -5,7 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Basic
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
+-- Proof-only: `finiteDimensional_functionField` is used inside the proof, not in the statement.
+import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
 public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
 
 /-!
@@ -87,11 +88,14 @@ theorem isDedekindDomain_intermediateRing (φ : Isogeny W₁ W₂)
     [Algebra W₂.CoordinateRing W₁.FunctionField]
     [Algebra W₂.FunctionField W₁.FunctionField]
     [IsScalarTower W₂.CoordinateRing W₂.FunctionField W₁.FunctionField]
-    [Algebra W₂.CoordinateRing φ.intermediateRing]
-    [IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField]
     [Algebra.IsSeparable W₂.FunctionField W₁.FunctionField]
     (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
     IsDedekindDomain φ.intermediateRing := by
+  -- the algebra structure on the intermediate ring and its tower are the canonical ones built
+  -- from `φ`, so they are installed here rather than demanded of the caller
+  let _ := φ.pullbackToIntermediateRing.toAlgebra
+  have : IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField :=
+    φ.isScalarTower_intermediateRing rfl h
   -- the integral-closure property is not assumed: it is what `intermediateRing` is
   have := φ.isIntegralClosure_intermediateRing h
   have := φ.finiteDimensional_functionField (φ.algebraMap_functionField_eq_fieldPullback h)


### PR DESCRIPTION
The intermediate ring of an isogeny — the integral closure of `W₂.CoordinateRing` in
`W₁.FunctionField` — is a Dedekind domain.

```lean
theorem Isogeny.isDedekindDomain_intermediateRing (φ : Isogeny W₁ W₂)
    [IsDedekindDomain W₂.CoordinateRing] …
    [Algebra.IsSeparable W₂.FunctionField W₁.FunctionField]
    (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
    IsDedekindDomain φ.intermediateRing
```

## Why this is the next thing needed

`ClassGroup.extendedRelNormHom` (#3403, merged) is stated over a module-finite extension of
**Dedekind** domains:

```lean
variable (A M R : Type*) … [IsDedekindDomain M] [IsDedekindDomain R] …
```

with `M := φ.intermediateRing`. `IsDedekindDomain` currently appears **nowhere** in
`TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/`, so `Isogeny.pushClass` cannot be stated
without this. Both ingredients landed tonight: `moduleFinite_intermediateRing` (#3347) and
`isIntegrallyClosed_intermediateRing` (#3404).

## Separability is required, and that is not an artefact of the route

Mathlib's `IsIntegralClosure.isDedekindDomain` is stated for a finite **separable** extension of
the fraction field, because the Noetherian half of the conjunction comes from the trace pairing,
nondegenerate exactly in the separable case.

So this sits deliberately between its two siblings:

| | separability |
|---|---|
| `isIntegrallyClosed_intermediateRing` (#3404) | **not needed** — closure is idempotent, no trace |
| `moduleFinite_intermediateRing` (#3347) | required — `IsIntegralClosure.finite`, trace pairing |
| **this** | required — same reason as finiteness |

In particular this does **not** cover inseparable isogenies, Frobenius included, while normality of
the same ring does. The file states that asymmetry rather than leaving it to be assumed.

`IsDedekindDomain W₂.CoordinateRing` is a hypothesis rather than derived from `[W₂.IsElliptic]`
(which supplies it via `isDedekindDomain_coordinateRing`), keeping ellipticity out of the file
exactly as the sibling takes `[IsIntegrallyClosed W₂.CoordinateRing]`. The roadmap is explicit that
`IsElliptic` appears nowhere in this development.

## Placement

New file `Isogeny/IntermediateRing/Dedekind.lean`, beside `Basic`/`Finite`/`IntegrallyClosed`,
matching the directory's one-property-per-file split.

## Gates on this head

```
lake build TauCeti   8042 jobs, 0 errors
lint-env             PASS (67 grandfathered, no new)
axioms               49194 declarations, all within [propext, Classical.choice, Quot.sound]
module-system        2333 modules opt in
```

## Review status

Opened without a pre-PR scoreboard: no review provider on this machine is runnable. The engine
supports `claude`/`codex`/`kiro`/`pi`; `kiro` and `pi` are not installed, both `CODEX_HOME`s are
quota-exhausted (Aug 20 / Sep 14), and `claude` falls back to `HOME=~` where the reviewer would
read this author's own notes. Posting a wall of `error` states would displace a real verdict, so
nothing was posted.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"intermediatering-dedekind"}-->

Provenance: original reduction to `Isogeny.intermediateRing`; AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0) proves the same statement about the same object as
`NormConormIntegralClosure.instDedekindB` for `B := integralClosure C₂.CoordinateRing
C₁.FunctionField`.

🤖 Prepared with Claude Code (Claude Opus 5)
