### PR TITLE
feat: make the identity component a Hopf ideal

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
@@ -111,16 +111,7 @@ private theorem map_connectedComponentIdempotent_augmentationPoint_eq_one_of_mem
       connectedComponent (Bialgebra.augmentationPoint k H)) :
     g.ofConv
         (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) = 1 := by
-  let p : PrimeSpectrum H := AlgHom.kernelPoint g.ofConv
-  let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
-  change p ∈ connectedComponent z at hg
-  have he : PrimeSpectrum.connectedComponentIdempotent p =
-      PrimeSpectrum.connectedComponentIdempotent z := by
-    apply (PrimeSpectrum.eq_connectedComponentIdempotent_iff
-      (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent p) z).mpr
-    rw [PrimeSpectrum.basicOpen_connectedComponentIdempotent]
-    exact (connectedComponent_eq hg).symm
-  rw [← he]
+  rw [← connectedComponentIdempotent_kernelPoint_eq_augmentationPoint g hg]
   exact AlgHom.map_connectedComponentIdempotent_kernelPoint_eq_one g.ofConv
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
@@ -156,22 +147,23 @@ private theorem kernelPoint_comp_quotient_mem_connectedComponent
           (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) ∈
       connectedComponent (Bialgebra.augmentationPoint k H) := by
   let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
-  let I : Ideal H :=
-    PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)
-  let p : PrimeSpectrum H :=
-    AlgHom.kernelPoint (f.comp (Ideal.Quotient.mkₐ k I))
-  change p ∈ connectedComponent z
-  rw [← PrimeSpectrum.zeroLocus_connectedComponentIdeal z]
-  rw [← PrimeSpectrum.range_comap_quotientMk_eq_zeroLocus]
-  refine ⟨AlgHom.kernelPoint f, ?_⟩
-  apply PrimeSpectrum.ext
-  ext x
-  change Ideal.Quotient.mk I x ∈ (AlgHom.kernelPoint f).asIdeal ↔ x ∈ p.asIdeal
-  rw [AlgHom.kernelPoint_asIdeal]
-  change f (Ideal.Quotient.mk I x) = 0 ↔ x ∈ p.asIdeal
-  rw [show p.asIdeal = RingHom.ker
-    (f.comp (Ideal.Quotient.mkₐ k I) : H →+* k) from AlgHom.kernelPoint_asIdeal _]
-  rfl
+  let y : PrimeSpectrum (H ⧸ PrimeSpectrum.connectedComponentIdeal z) :=
+    AlgHom.kernelPoint f
+  have hy := (PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent z y).property
+  rw [PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent_apply_coe] at hy
+  dsimp only [y, z] at hy
+  have hcomap :
+      PrimeSpectrum.comap
+          (Ideal.Quotient.mk
+            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))
+          (AlgHom.kernelPoint f) =
+        AlgHom.kernelPoint
+          (f.comp (Ideal.Quotient.mkₐ k
+            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) :=
+    AlgHom.comap_kernelPoint f (Ideal.Quotient.mkₐ k
+      (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))
+  rw [hcomap] at hy
+  exact hy
 
 private theorem map_tensorSquare_quotient_comul_connectedComponentIdempotent_eq_one
     [LocallyConnectedSpace (PrimeSpectrum H)] :

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
@@ -244,10 +244,17 @@ private theorem comul_one_sub_connectedComponentIdempotent_mem
       exact Ideal.Quotient.mkₐ_ker k I
     -- Unfold the local tensor-square map abbreviation before tensor-product exactness rewrites it.
     change RingHom.ker (Algebra.TensorProduct.map q q) = _
-    rw [Algebra.TensorProduct.map_ker (f := q) (g := q) hq hq, hqker,
-      HopfIdeal.leftTensorIdeal_def, HopfIdeal.rightTensorIdeal_def]
-    simp only [AlgHom.toRingHom_eq_coe]
-    apply congr_arg₂ (fun J K : Ideal (H ⊗[k] H) ↦ J ⊔ K) <;> rfl
+    have hleft :
+        I.map (Algebra.TensorProduct.includeLeft (R := k) (S := k) (A := H) (B := H)) =
+          HopfIdeal.leftTensorIdeal (R := k) (H := H) I := by
+      rw [HopfIdeal.leftTensorIdeal_def, AlgHom.toRingHom_eq_coe]
+      exact AlgHom.coe_ideal_map _ I
+    have hright :
+        I.map (Algebra.TensorProduct.includeRight (R := k) (A := H) (B := H)) =
+          HopfIdeal.rightTensorIdeal (R := k) (H := H) I := by
+      rw [HopfIdeal.rightTensorIdeal_def, AlgHom.toRingHom_eq_coe]
+      exact AlgHom.coe_ideal_map _ I
+    rw [Algebra.TensorProduct.map_ker (f := q) (g := q) hq hq, hqker, hleft, hright]
   rwa [hker_eq] at hker
 
 /-- The ideal cutting out the augmentation point's connected component is stable under

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
@@ -10,8 +10,10 @@ public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Basic
 import TauCeti.Algebra.AlgebraicGroup.Connected.Translation
 import TauCeti.AlgebraicGeometry.AugmentationPoint.ConnectedComponent
 import TauCeti.RingTheory.FiniteType.PointSeparation
+public import TauCeti.Topology.NoetherianSpace.ConnectedComponents
 import Mathlib.RingTheory.FiniteStability
 import Mathlib.RingTheory.Idempotents
+public import Mathlib.RingTheory.Spectrum.Prime.Noetherian
 
 /-!
 # The identity component as a Hopf ideal
@@ -111,22 +113,15 @@ private theorem map_connectedComponentIdempotent_augmentationPoint_eq_one_of_mem
         (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) = 1 := by
   let p : PrimeSpectrum H := AlgHom.kernelPoint g.ofConv
   let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
-  let e := PrimeSpectrum.connectedComponentIdempotent z
-  -- Reduce the `Spec` carrier and the local abbreviations once so that the basic-open
-  -- characterization can compare the component membership with ideal membership.
   change p ∈ connectedComponent z at hg
-  have hnot : e ∉ p.asIdeal := by
-    have hpopen : p ∈ (PrimeSpectrum.basicOpen e : Set (PrimeSpectrum H)) := by
-      rw [show e = PrimeSpectrum.connectedComponentIdempotent z from rfl,
-        PrimeSpectrum.basicOpen_connectedComponentIdempotent]
-      exact hg
-    exact (PrimeSpectrum.mem_basicOpen e p).mp hpopen
-  change e ∉ (AlgHom.kernelPoint g.ofConv).asIdeal at hnot
-  rw [AlgHom.kernelPoint_asIdeal, RingHom.mem_ker] at hnot
-  have he : IsIdempotentElem (g.ofConv e) :=
-    (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent
-      (Bialgebra.augmentationPoint k H)).map g.ofConv.toRingHom
-  exact (IsIdempotentElem.iff_eq_zero_or_one.mp he).resolve_left hnot
+  have he : PrimeSpectrum.connectedComponentIdempotent p =
+      PrimeSpectrum.connectedComponentIdempotent z := by
+    apply (PrimeSpectrum.eq_connectedComponentIdempotent_iff
+      (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent p) z).mpr
+    rw [PrimeSpectrum.basicOpen_connectedComponentIdempotent]
+    exact (connectedComponent_eq hg).symm
+  rw [← he]
+  exact AlgHom.map_connectedComponentIdempotent_kernelPoint_eq_one g.ofConv
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 private theorem map_tensorSquare_comul_apply
@@ -161,20 +156,22 @@ private theorem kernelPoint_comp_quotient_mem_connectedComponent
           (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) ∈
       connectedComponent (Bialgebra.augmentationPoint k H) := by
   let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
-  let I := PrimeSpectrum.connectedComponentIdeal z
-  let p : PrimeSpectrum H := AlgHom.kernelPoint
-    (f.comp (Ideal.Quotient.mkₐ k I))
-  -- Reduce the `Spec` carrier and kernel-point wrapper before using the zero-locus criterion.
+  let I : Ideal H :=
+    PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)
+  let p : PrimeSpectrum H :=
+    AlgHom.kernelPoint (f.comp (Ideal.Quotient.mkₐ k I))
   change p ∈ connectedComponent z
-  rw [← PrimeSpectrum.zeroLocus_connectedComponentIdeal]
-  rw [PrimeSpectrum.mem_zeroLocus]
-  intro x hx
-  change x ∈ I at hx
-  change x ∈ (AlgHom.kernelPoint
-    (f.comp (Ideal.Quotient.mkₐ k I))).asIdeal
-  rw [AlgHom.kernelPoint_asIdeal, RingHom.mem_ker]
-  change f (Ideal.Quotient.mk I x) = 0
-  rw [Ideal.Quotient.eq_zero_iff_mem.mpr hx, map_zero]
+  rw [← PrimeSpectrum.zeroLocus_connectedComponentIdeal z]
+  rw [← PrimeSpectrum.range_comap_quotientMk_eq_zeroLocus]
+  refine ⟨AlgHom.kernelPoint f, ?_⟩
+  apply PrimeSpectrum.ext
+  ext x
+  change Ideal.Quotient.mk I x ∈ (AlgHom.kernelPoint f).asIdeal ↔ x ∈ p.asIdeal
+  rw [AlgHom.kernelPoint_asIdeal]
+  change f (Ideal.Quotient.mk I x) = 0 ↔ x ∈ p.asIdeal
+  rw [show p.asIdeal = RingHom.ker
+    (f.comp (Ideal.Quotient.mkₐ k I) : H →+* k) from AlgHom.kernelPoint_asIdeal _]
+  rfl
 
 private theorem map_tensorSquare_quotient_comul_connectedComponentIdempotent_eq_one
     [LocallyConnectedSpace (PrimeSpectrum H)] :
@@ -264,13 +261,19 @@ private theorem comul_one_sub_connectedComponentIdempotent_mem
 /-- The ideal cutting out the augmentation point's connected component is stable under
 comultiplication. -/
 theorem comul_mem_connectedComponentIdeal_augmentationPoint
-    [LocallyConnectedSpace (PrimeSpectrum H)] {x : H}
-    (hx : x ∈ PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) :
-    Coalgebra.comul (R := k) x ∈
-      HopfIdeal.leftTensorIdeal (R := k) (H := H)
-          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) ⊔
-        HopfIdeal.rightTensorIdeal (R := k) (H := H)
-          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) := by
+    {x : H} :
+    letI : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+    letI : LocallyConnectedSpace (PrimeSpectrum H) := inferInstance
+    x ∈ PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) →
+      Coalgebra.comul (R := k) x ∈
+        HopfIdeal.leftTensorIdeal (R := k) (H := H)
+            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) ⊔
+          HopfIdeal.rightTensorIdeal (R := k) (H := H)
+            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) := by
+  dsimp only
+  let _ : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+  let _ : LocallyConnectedSpace (PrimeSpectrum H) := inferInstance
+  intro hx
   let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
   let I := PrimeSpectrum.connectedComponentIdeal z
   let e := PrimeSpectrum.connectedComponentIdempotent z
@@ -287,37 +290,42 @@ theorem comul_mem_connectedComponentIdeal_augmentationPoint
 
 /-- The Hopf ideal cutting out the connected component of the identity in a finite-type affine
 group over an algebraically closed field. -/
-@[expose] noncomputable def identityComponentHopfIdeal
-    [LocallyConnectedSpace (PrimeSpectrum H)] : HopfIdeal k H :=
-  HopfIdeal.ofIdeal
-    (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H))
-    (fun _ hx ↦ comul_mem_connectedComponentIdeal_augmentationPoint hx)
-    (fun x hx ↦ by
-      have hx' : x ∈ RingHom.ker
-          (_root_.Bialgebra.counitAlgHom k H).toRingHom :=
-        TauCeti.AlgHom.connectedComponentIdeal_kernelPoint_le_ker
-          (_root_.Bialgebra.counitAlgHom k H) hx
-      rw [← Bialgebra.counitAlgHom_apply]
-      exact RingHom.mem_ker.mp hx')
-    (fun _ hx ↦
-      (antipode_mem_connectedComponentIdeal_augmentationPoint_iff (k := k)).mpr hx)
+noncomputable def identityComponentHopfIdeal : HopfIdeal k H := by
+  letI : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+  letI : LocallyConnectedSpace (PrimeSpectrum H) := inferInstance
+  exact HopfIdeal.ofIdeal
+      (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H))
+      (fun _ hx ↦ comul_mem_connectedComponentIdeal_augmentationPoint hx)
+      (fun x hx ↦ by
+        have hx' : x ∈ RingHom.ker
+            (_root_.Bialgebra.counitAlgHom k H).toRingHom :=
+          TauCeti.AlgHom.connectedComponentIdeal_kernelPoint_le_ker
+            (_root_.Bialgebra.counitAlgHom k H) hx
+        rw [← Bialgebra.counitAlgHom_apply]
+        exact RingHom.mem_ker.mp hx')
+      (fun _ hx ↦
+        (antipode_mem_connectedComponentIdeal_augmentationPoint_iff (k := k)).mpr hx)
 
 /-- The underlying ideal of the identity-component Hopf ideal is the ideal generated by the
 complement of the augmentation point's component idempotent. -/
 @[simp]
 theorem identityComponentHopfIdeal_toIdeal
-    [LocallyConnectedSpace (PrimeSpectrum H)] :
-    (identityComponentHopfIdeal (k := k) (H := H)).toIdeal =
-      PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) :=
+    : letI : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+      letI : LocallyConnectedSpace (PrimeSpectrum H) := inferInstance
+      (identityComponentHopfIdeal (k := k) (H := H)).toIdeal =
+        PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) := by
+  dsimp only
   rfl
 
 /-- Membership in the identity-component Hopf ideal is membership in the ideal cutting out the
 augmentation point's connected component. -/
 @[simp]
 theorem mem_identityComponentHopfIdeal
-    [LocallyConnectedSpace (PrimeSpectrum H)] {x : H} :
-    x ∈ identityComponentHopfIdeal (k := k) (H := H) ↔
-      x ∈ PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) :=
-  Iff.rfl
+    {x : H} : letI : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+      letI : LocallyConnectedSpace (PrimeSpectrum H) := inferInstance
+      x ∈ identityComponentHopfIdeal (k := k) (H := H) ↔
+        x ∈ PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) := by
+  dsimp only
+  rfl
 
 end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Connected.IdentityComponent
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Basic
+import TauCeti.Algebra.AlgebraicGroup.Connected.Translation
+import TauCeti.AlgebraicGeometry.AugmentationPoint.ConnectedComponent
+import TauCeti.RingTheory.FiniteType.PointSeparation
+import Mathlib.RingTheory.FiniteStability
+import Mathlib.RingTheory.Idempotents
+
+/-!
+# The identity component as a Hopf ideal
+
+Let `H` be a commutative Hopf algebra of finite type over an algebraically closed field.  The
+connected component of the counit point is stable under multiplication: equivalently, the
+comultiplication of the ideal cutting out that component lies in `I ⊗ H + H ⊗ I`.  Together
+with the counit and antipode results already available for this ideal, this packages the identity
+component as a `HopfIdeal`.
+
+The multiplication argument is carried out on algebraically closed points of the component
+quotient.  Translation stability shows that the product of two such points is still in the
+identity component.  The affine Nullstellensatz then promotes this pointwise statement to the
+required identity in the tensor square; tensor-product right exactness identifies its kernel with
+`I ⊗ H + H ⊗ I`.
+
+The algebraically closed hypothesis is the natural one for the geometric identity component in
+the reductive-groups roadmap.  Descent of this construction to the ground field and construction
+of the component group are separate steps.
+
+## Main declarations
+
+* `TauCeti.HopfAlgebra.comul_mem_connectedComponentIdeal_augmentationPoint`: the component ideal
+  is stable under comultiplication.
+* `TauCeti.HopfAlgebra.identityComponentHopfIdeal`: the Hopf ideal cutting out the identity
+  component.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 2.37.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Section 6.7.
+
+This advances Layer 3, "Identity component `G°` and component group `π₀(G)`", of the
+ReductiveGroups roadmap.  The quotient Hopf algebra now gives the identity component over an
+algebraically closed field; descent, geometric connectedness over a general field, and the finite
+étale component group remain.
+-/
+
+public section
+
+open AlgebraicGeometry
+open scoped TensorProduct
+
+namespace TauCeti.HopfAlgebra
+
+universe u v
+
+variable {k : Type u} [Field k] [IsAlgClosed k]
+variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H] [Algebra.FiniteType k H]
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem rightTranslationHomeomorph_kernelPoint
+    (g h : WithConv (H →ₐ[k] k)) :
+    rightTranslationHomeomorph h (AlgHom.kernelPoint g.ofConv) =
+      AlgHom.kernelPoint (g * h).ofConv := by
+  rw [rightTranslationHomeomorph_apply]
+  -- `Spec (CommRingCat.of H)` has `PrimeSpectrum H` as its reducible carrier; expose that carrier
+  -- and the algebra-hom composition before applying the kernel-point API.
+  change PrimeSpectrum.comap
+      ((rightTranslationAlgEquiv h).toAlgHom : H →+* H)
+        (AlgHom.kernelPoint g.ofConv) = _
+  rw [AlgHom.comap_kernelPoint, rightTranslationAlgEquiv_toAlgHom]
+  congr 1
+  ext x
+  -- Composition of algebra homomorphisms must be exposed at application level before the
+  -- translation formula can rewrite it.
+  change g.ofConv (rightTranslationAlgHom h x) = (g * h).ofConv x
+  rw [rightTranslationAlgHom_apply, AlgHom.convMul_apply]
+  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp [hx, hy]
+  | tmul x y =>
+      simp [TensorProduct.map_tmul, TensorProduct.rid_tmul,
+        Algebra.TensorProduct.lift_tmul, Algebra.smul_def, mul_comm]
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem kernelPoint_mul_mem_connectedComponent_augmentationPoint
+    (g h : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H))
+    (hh : AlgHom.kernelPoint h.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
+    AlgHom.kernelPoint (g * h).ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H) := by
+  have himage :=
+    rightTranslationHomeomorph_image_connectedComponent_augmentationPoint_eq_self h hh
+  rw [← himage]
+  exact ⟨AlgHom.kernelPoint g.ofConv, hg, rightTranslationHomeomorph_kernelPoint g h⟩
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem map_connectedComponentIdempotent_augmentationPoint_eq_one_of_mem
+    [LocallyConnectedSpace (PrimeSpectrum H)]
+    (g : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
+    g.ofConv
+        (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) = 1 := by
+  let p : PrimeSpectrum H := AlgHom.kernelPoint g.ofConv
+  let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  let e := PrimeSpectrum.connectedComponentIdempotent z
+  -- Reduce the `Spec` carrier and the local abbreviations once so that the basic-open
+  -- characterization can compare the component membership with ideal membership.
+  change p ∈ connectedComponent z at hg
+  have hnot : e ∉ p.asIdeal := by
+    have hpopen : p ∈ (PrimeSpectrum.basicOpen e : Set (PrimeSpectrum H)) := by
+      rw [show e = PrimeSpectrum.connectedComponentIdempotent z from rfl,
+        PrimeSpectrum.basicOpen_connectedComponentIdempotent]
+      exact hg
+    exact (PrimeSpectrum.mem_basicOpen e p).mp hpopen
+  change e ∉ (AlgHom.kernelPoint g.ofConv).asIdeal at hnot
+  rw [AlgHom.kernelPoint_asIdeal, RingHom.mem_ker] at hnot
+  have he : IsIdempotentElem (g.ofConv e) :=
+    (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent
+      (Bialgebra.augmentationPoint k H)).map g.ofConv.toRingHom
+  exact (IsIdempotentElem.iff_eq_zero_or_one.mp he).resolve_left hnot
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem map_tensorSquare_comul_apply
+    {B : Type v} [CommRing B] [Algebra k B]
+    (q : H →ₐ[k] B) (f : (B ⊗[k] B) →ₐ[k] k) (x : H) :
+    f (Algebra.TensorProduct.map q q (Coalgebra.comul (R := k) x)) =
+      ((WithConv.toConv
+          ((f.comp (Algebra.TensorProduct.includeLeft
+            (R := k) (S := k) (A := B) (B := B))).comp q)) *
+        WithConv.toConv
+          ((f.comp (Algebra.TensorProduct.includeRight
+            (R := k) (A := B) (B := B))).comp q)).ofConv x := by
+  rw [AlgHom.convMul_apply]
+  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp [hx, hy]
+  | tmul x y =>
+      rw [Algebra.TensorProduct.map_tmul, Algebra.TensorProduct.lift_tmul]
+      -- The convolution wrappers reduce to the two restrictions of `f` only after application.
+      change f (q x ⊗ₜ[k] q y) = f (q x ⊗ₜ[k] 1) * f (1 ⊗ₜ[k] q y)
+      rw [← map_mul]
+      congr 1
+      simp
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem kernelPoint_comp_quotient_mem_connectedComponent
+    [LocallyConnectedSpace (PrimeSpectrum H)]
+    (f : (H ⧸ PrimeSpectrum.connectedComponentIdeal
+      (Bialgebra.augmentationPoint k H)) →ₐ[k] k) :
+    AlgHom.kernelPoint
+        (f.comp (Ideal.Quotient.mkₐ k
+          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) ∈
+      connectedComponent (Bialgebra.augmentationPoint k H) := by
+  let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  let I := PrimeSpectrum.connectedComponentIdeal z
+  let p : PrimeSpectrum H := AlgHom.kernelPoint
+    (f.comp (Ideal.Quotient.mkₐ k I))
+  -- Reduce the `Spec` carrier and kernel-point wrapper before using the zero-locus criterion.
+  change p ∈ connectedComponent z
+  rw [← PrimeSpectrum.zeroLocus_connectedComponentIdeal]
+  rw [PrimeSpectrum.mem_zeroLocus]
+  intro x hx
+  change x ∈ I at hx
+  change x ∈ (AlgHom.kernelPoint
+    (f.comp (Ideal.Quotient.mkₐ k I))).asIdeal
+  rw [AlgHom.kernelPoint_asIdeal, RingHom.mem_ker]
+  change f (Ideal.Quotient.mk I x) = 0
+  rw [Ideal.Quotient.eq_zero_iff_mem.mpr hx, map_zero]
+
+private theorem map_tensorSquare_quotient_comul_connectedComponentIdempotent_eq_one
+    [LocallyConnectedSpace (PrimeSpectrum H)] :
+    Algebra.TensorProduct.map
+        (Ideal.Quotient.mkₐ k
+          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))
+        (Ideal.Quotient.mkₐ k
+          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))
+        (Coalgebra.comul (R := k)
+          (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H))) = 1 := by
+  let I := PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)
+  let e := PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)
+  let B := H ⧸ I
+  let q : H →ₐ[k] B := Ideal.Quotient.mkₐ k I
+  let F : (H ⊗[k] H) →ₐ[k] (B ⊗[k] B) := Algebra.TensorProduct.map q q
+  let _ : Algebra.FiniteType k (B ⊗[k] B) :=
+    Algebra.FiniteType.trans (R := k) (S := B) (A := B ⊗[k] B) inferInstance inferInstance
+  have ha_idem : IsIdempotentElem (F (Coalgebra.comul (R := k) e)) := by
+    exact ((PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent
+      (Bialgebra.augmentationPoint k H)).map
+        (_root_.Bialgebra.comulAlgHom k H).toRingHom).map F.toRingHom
+  have ha_eq_one : F (Coalgebra.comul (R := k) e) = 1 := by
+    apply _root_.eq_of_isNilpotent_sub_of_isIdempotentElem
+      ha_idem IsIdempotentElem.one
+    rw [← forall_algHom_apply_eq_zero_iff_isNilpotent (k := k) (K := k)]
+    intro f
+    let f₁ : B →ₐ[k] k :=
+      f.comp (Algebra.TensorProduct.includeLeft (R := k) (S := k) (A := B) (B := B))
+    let f₂ : B →ₐ[k] k :=
+      f.comp (Algebra.TensorProduct.includeRight (R := k) (A := B) (B := B))
+    let g : WithConv (H →ₐ[k] k) := WithConv.toConv (f₁.comp q)
+    let h : WithConv (H →ₐ[k] k) := WithConv.toConv (f₂.comp q)
+    have hg : AlgHom.kernelPoint g.ofConv ∈
+        connectedComponent (Bialgebra.augmentationPoint k H) := by
+      exact kernelPoint_comp_quotient_mem_connectedComponent f₁
+    have hh : AlgHom.kernelPoint h.ofConv ∈
+        connectedComponent (Bialgebra.augmentationPoint k H) := by
+      exact kernelPoint_comp_quotient_mem_connectedComponent f₂
+    have hmul := kernelPoint_mul_mem_connectedComponent_augmentationPoint g h hg hh
+    have heval :=
+      map_connectedComponentIdempotent_augmentationPoint_eq_one_of_mem (g * h) hmul
+    rw [map_sub, map_one, sub_eq_zero]
+    rw [map_tensorSquare_comul_apply q f e]
+    exact heval
+  -- Expose the local quotient and tensor-square abbreviations to return the public expression.
+  change F (Coalgebra.comul (R := k) e) = 1
+  exact ha_eq_one
+
+private theorem comul_one_sub_connectedComponentIdempotent_mem
+    [LocallyConnectedSpace (PrimeSpectrum H)] :
+    Coalgebra.comul (R := k)
+        (1 - PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) ∈
+      HopfIdeal.leftTensorIdeal (R := k) (H := H)
+          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) ⊔
+        HopfIdeal.rightTensorIdeal (R := k) (H := H)
+          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) := by
+  let I := PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)
+  let e := PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)
+  let B := H ⧸ I
+  let q : H →ₐ[k] B := Ideal.Quotient.mkₐ k I
+  let F : (H ⊗[k] H) →ₐ[k] (B ⊗[k] B) := Algebra.TensorProduct.map q q
+  have hq : Function.Surjective q := Ideal.Quotient.mkₐ_surjective k I
+  have ha_eq_one : F (Coalgebra.comul (R := k) e) = 1 :=
+    map_tensorSquare_quotient_comul_connectedComponentIdempotent_eq_one
+  have hker : Coalgebra.comul (R := k) (1 - e) ∈ RingHom.ker F.toRingHom := by
+    rw [RingHom.mem_ker]
+    rw [map_sub, Bialgebra.comul_one, map_sub, map_one]
+    -- The ring-hom coercion of `F` blocks rewriting by the named equality until application is
+    -- exposed.
+    change 1 - F (Coalgebra.comul (R := k) e) = 0
+    rw [ha_eq_one, sub_self]
+  have hker_eq : RingHom.ker F.toRingHom =
+      HopfIdeal.leftTensorIdeal (R := k) (H := H) I ⊔
+        HopfIdeal.rightTensorIdeal (R := k) (H := H) I := by
+    have hqker : RingHom.ker q = I := by
+      -- Unfold the local quotient-map abbreviation for Mathlib's kernel theorem.
+      change RingHom.ker (Ideal.Quotient.mkₐ k I) = I
+      exact Ideal.Quotient.mkₐ_ker k I
+    -- Unfold the local tensor-square map abbreviation before tensor-product exactness rewrites it.
+    change RingHom.ker (Algebra.TensorProduct.map q q) = _
+    rw [Algebra.TensorProduct.map_ker (f := q) (g := q) hq hq, hqker,
+      HopfIdeal.leftTensorIdeal_def, HopfIdeal.rightTensorIdeal_def]
+    simp only [AlgHom.toRingHom_eq_coe]
+    apply congr_arg₂ (fun J K : Ideal (H ⊗[k] H) ↦ J ⊔ K) <;> rfl
+  rwa [hker_eq] at hker
+
+/-- The ideal cutting out the augmentation point's connected component is stable under
+comultiplication. -/
+theorem comul_mem_connectedComponentIdeal_augmentationPoint
+    [LocallyConnectedSpace (PrimeSpectrum H)] {x : H}
+    (hx : x ∈ PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) :
+    Coalgebra.comul (R := k) x ∈
+      HopfIdeal.leftTensorIdeal (R := k) (H := H)
+          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) ⊔
+        HopfIdeal.rightTensorIdeal (R := k) (H := H)
+          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)) := by
+  let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  let I := PrimeSpectrum.connectedComponentIdeal z
+  let e := PrimeSpectrum.connectedComponentIdempotent z
+  -- Expose the local component ideal so its principal-generator characterization can rewrite.
+  change x ∈ I at hx
+  change Coalgebra.comul (R := k) x ∈
+    HopfIdeal.leftTensorIdeal (R := k) (H := H) I ⊔
+      HopfIdeal.rightTensorIdeal (R := k) (H := H) I
+  rw [PrimeSpectrum.mem_connectedComponentIdeal_iff] at hx
+  obtain ⟨a, rfl⟩ := hx
+  rw [Bialgebra.comul_mul]
+  exact Ideal.mul_mem_left _ _
+    (comul_one_sub_connectedComponentIdempotent_mem (k := k) (H := H))
+
+/-- The Hopf ideal cutting out the connected component of the identity in a finite-type affine
+group over an algebraically closed field. -/
+@[expose] noncomputable def identityComponentHopfIdeal
+    [LocallyConnectedSpace (PrimeSpectrum H)] : HopfIdeal k H :=
+  HopfIdeal.ofIdeal
+    (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H))
+    (fun _ hx ↦ comul_mem_connectedComponentIdeal_augmentationPoint hx)
+    (fun x hx ↦ by
+      have hx' : x ∈ RingHom.ker
+          (_root_.Bialgebra.counitAlgHom k H).toRingHom :=
+        TauCeti.AlgHom.connectedComponentIdeal_kernelPoint_le_ker
+          (_root_.Bialgebra.counitAlgHom k H) hx
+      rw [← Bialgebra.counitAlgHom_apply]
+      exact RingHom.mem_ker.mp hx')
+    (fun _ hx ↦
+      (antipode_mem_connectedComponentIdeal_augmentationPoint_iff (k := k)).mpr hx)
+
+/-- The underlying ideal of the identity-component Hopf ideal is the ideal generated by the
+complement of the augmentation point's component idempotent. -/
+@[simp]
+theorem identityComponentHopfIdeal_toIdeal
+    [LocallyConnectedSpace (PrimeSpectrum H)] :
+    (identityComponentHopfIdeal (k := k) (H := H)).toIdeal =
+      PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) :=
+  rfl
+
+/-- Membership in the identity-component Hopf ideal is membership in the ideal cutting out the
+augmentation point's connected component. -/
+@[simp]
+theorem mem_identityComponentHopfIdeal
+    [LocallyConnectedSpace (PrimeSpectrum H)] {x : H} :
+    x ∈ identityComponentHopfIdeal (k := k) (H := H) ↔
+      x ∈ PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H) :=
+  Iff.rfl
+
+end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -69,9 +69,11 @@ theorem rightTranslationHomeomorph_image_connectedComponent_augmentationPoint_eq
 
 variable [LocallyConnectedSpace (PrimeSpectrum H)]
 
+omit [_root_.HopfAlgebra k H] in
 /-- Points in the identity component have the same connected-component idempotent as the
 augmentation point. -/
 theorem connectedComponentIdempotent_kernelPoint_eq_augmentationPoint
+    [_root_.Bialgebra k H]
     (g : WithConv (H →ₐ[k] k))
     (hg : AlgHom.kernelPoint g.ofConv ∈
       connectedComponent (Bialgebra.augmentationPoint k H)) :

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -72,6 +72,7 @@ variable [LocallyConnectedSpace (PrimeSpectrum H)]
 omit [_root_.HopfAlgebra k H] in
 /-- Points in the identity component have the same connected-component idempotent as the
 augmentation point. -/
+@[simp]
 theorem connectedComponentIdempotent_kernelPoint_eq_augmentationPoint
     [_root_.Bialgebra k H]
     (g : WithConv (H →ₐ[k] k))

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -69,7 +69,9 @@ theorem rightTranslationHomeomorph_image_connectedComponent_augmentationPoint_eq
 
 variable [LocallyConnectedSpace (PrimeSpectrum H)]
 
-private theorem connectedComponentIdempotent_kernelPoint_eq_augmentationPoint
+/-- Points in the identity component have the same connected-component idempotent as the
+augmentation point. -/
+theorem connectedComponentIdempotent_kernelPoint_eq_augmentationPoint
     (g : WithConv (H →ₐ[k] k))
     (hg : AlgHom.kernelPoint g.ofConv ∈
       connectedComponent (Bialgebra.augmentationPoint k H)) :

--- a/TauCeti/Algebra/HopfAlgebra/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Augmentation.lean
@@ -32,7 +32,6 @@ variable {k : Type u} [Field k]
 variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H]
 
 /-- Contraction along the antipode fixes the prime defined by the counit. -/
-@[simp]
 theorem comap_antipodeAlgHom_augmentationPoint_eq_self :
     PrimeSpectrum.comap (_root_.HopfAlgebra.antipodeAlgHom k H)
         (Bialgebra.augmentationPoint k H) = Bialgebra.augmentationPoint k H := by

--- a/TauCeti/AlgebraicGeometry/AugmentationPoint/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AugmentationPoint/Basic.lean
@@ -47,6 +47,7 @@ theorem kernelPoint_asIdeal :
 
 /-- Contracting a kernel point along an algebra homomorphism gives the kernel point of the
 composite algebra homomorphism. -/
+@[simp]
 theorem comap_kernelPoint {A : Type w} [CommRing A] [Algebra k A] (g : A →ₐ[k] H) :
     PrimeSpectrum.comap (g : A →+* H) (kernelPoint f) = kernelPoint (f.comp g) :=
   PrimeSpectrum.comap_comp_apply (g : A →+* H) (f : H →+* k) (closedPoint k)

--- a/TauCeti/AlgebraicGeometry/AugmentationPoint/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AugmentationPoint/Basic.lean
@@ -25,7 +25,7 @@ open AlgebraicGeometry IsLocalRing
 
 namespace TauCeti.AlgHom
 
-universe u v
+universe u v w
 
 variable {k : Type u} [Field k]
 variable {H : Type v} [CommRing H] [Algebra k H]
@@ -45,10 +45,10 @@ theorem kernelPoint_asIdeal :
   rw [IsLocalRing.maximalIdeal_eq_bot]
   rfl
 
-/-- Contracting a kernel point along an algebra endomorphism gives the kernel point of the
+/-- Contracting a kernel point along an algebra homomorphism gives the kernel point of the
 composite algebra homomorphism. -/
-theorem comap_kernelPoint (g : H →ₐ[k] H) :
-    PrimeSpectrum.comap (g : H →+* H) (kernelPoint f) = kernelPoint (f.comp g) :=
-  PrimeSpectrum.comap_comp_apply (g : H →+* H) (f : H →+* k) (closedPoint k)
+theorem comap_kernelPoint {A : Type w} [CommRing A] [Algebra k A] (g : A →ₐ[k] H) :
+    PrimeSpectrum.comap (g : A →+* H) (kernelPoint f) = kernelPoint (f.comp g) :=
+  PrimeSpectrum.comap_comp_apply (g : A →+* H) (f : H →+* k) (closedPoint k)
 
 end TauCeti.AlgHom


### PR DESCRIPTION
This PR proves that the ideal cutting out the augmentation point's connected component is stable under comultiplication over an algebraically closed field, and packages it as `HopfAlgebra.identityComponentHopfIdeal`. It advances the exact target in `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3 milestone “Identity component `G°` and component group `π₀(G)`,” specifically the construction of the identity component as a closed subgroup through its coordinate Hopf ideal.

This is the most effective current step because `Connected/IdentityComponent.lean` and the newly merged `Connected/Translation.lean` both identify comultiplication closure as the next missing condition. The proof restricts an arbitrary point of the tensor square of the component quotient to its two factors, uses translation stability to keep their convolution product in the identity component, promotes the resulting pointwise idempotent identity by the affine Nullstellensatz, and applies tensor-product right exactness to identify the kernel as `I ⊗ H + H ⊗ I`.

Add `TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean` (323 lines), with `comul_mem_connectedComponentIdeal_augmentationPoint`, `identityComponentHopfIdeal`, and its characteristic ideal and membership lemmas. The algebraically closed hypothesis matches the roadmap's geometric identity component after base change; the argument does not claim descent over an arbitrary ground field.

After this PR, the Layer 3 milestone still needs descent of the geometric identity component to the stated generality, its affine-group-scheme packaging and base-change compatibility, and construction and finite étaleness of `π₀(G)` under the roadmap's smoothness hypotheses.

The mathematics follows J. S. Milne, *Algebraic Groups* (2017), Proposition 2.37, and W. C. Waterhouse, *Introduction to Affine Group Schemes*, Section 6.7, as credited in the module documentation. The implementation reuses Mathlib's tensor-product kernel theorem and idempotent API together with Tau Ceti's affine Nullstellensatz, component-idempotent API, and point-translation stability; no Mathlib infrastructure or external formalization is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"identity-component-comultiplication-closure"}-->

🤖 Prepared with Codex
