### PR TITLE
docs(ConditionalCommonEnding): the Koopman route does consume the seam

### DIFF
--- a/TauCeti/Probability/DeFinetti/ConditionalCommonEnding.lean
+++ b/TauCeti/Probability/DeFinetti/ConditionalCommonEnding.lean
@@ -118,8 +118,9 @@ linear order on the index — hence `ℕ`. The others quantify over an arbitrary
 
 This is a reusable seam: nothing here mentions how `ν` was built, so a route supplies only its own
 factorization identity. The martingale route reaches it from tail conditional laws and consumes it
-in `conditionallyIIDWith_of_contractable_pathSpace`; a route conditioning on invariant σ-algebras
-instead could consume the same statement, though none currently does.
+in `conditionallyIIDWith_of_contractable_pathSpace`; the Koopman route conditions on the
+shift-invariant σ-algebra instead and consumes it in
+`ContractableLaw.conditionallyIIDWith_invariantConditionalProbabilityMeasure`.
 
 In particular there is **no** standard-Borel or non-empty hypothesis on either space: those are
 needed to *construct* a directing measure, not to recognise one. -/


### PR DESCRIPTION
`ConditionalCommonEnding.lean` described its set-integral seam as reusable, then said:

> a route conditioning on invariant σ-algebras instead could consume the same statement, though
> none currently does.

One does. `ViaKoopman/Theorem.lean` `refine`s exactly this theorem inside
`ContractableLaw.conditionallyIIDWith_invariantConditionalProbabilityMeasure` — the Koopman route
conditions on the shift-invariant σ-algebra and consumes the seam. The claim has been false since
that route landed, and it understates the seam: the sentence's whole point is that the statement is
route-agnostic, which is better evidenced by naming the second consumer than by saying there isn't
one.

The martingale consumer was already named in the same sentence; the Koopman one now is too.

Documentation only — no declaration, statement, or proof is touched.

This was split out of #3433: the line sits three lines below a hunk in #3423, so editing it there
risked a conflict. Both are now merged.

Roadmap: Exchangeability

Documenting existing code; no new mathematics.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
