### PR TITLE
feat: construct the split exact structure on an additive category

### DIFF
--- a/TauCeti/CategoryTheory/Exact/Split.lean
+++ b/TauCeti/CategoryTheory/Exact/Split.lean
@@ -93,7 +93,7 @@ namespace ConflationClass
 variable (C) in
 /-- The class of short complexes admitting a splitting. These are the conflations of the split
 exact structure. -/
-@[expose] def split : ConflationClass C where
+def split : ConflationClass C where
   Conflation S := Nonempty S.Splitting
   isKernelCokernelPair _ hS := .of_splitting hS.some
   isClosedUnderIsomorphisms := ⟨fun e hS => ⟨hS.some.ofIso e⟩⟩
@@ -108,6 +108,53 @@ theorem split_conflation_iff (S : ShortComplex C) :
 theorem split_conflation_biprodShortComplex (X Z : C) [HasBinaryBiproduct X Z] :
     (split C).Conflation (biprodShortComplex X Z) :=
   ⟨biprodShortComplexSplitting X Z⟩
+
+/-- The short complex `Z ⟶ X ⊞ Z ⟶ X` on the other biproduct summand is a split conflation. -/
+theorem split_conflation_biprod_inr_fst (X Z : C) [HasBinaryBiproduct X Z] :
+    (split C).Conflation
+      (ShortComplex.mk (biprod.inr : Z ⟶ X ⊞ Z) (biprod.fst : X ⊞ Z ⟶ X) (by simp)) :=
+  ⟨{ r := biprod.snd
+     s := biprod.inl
+     id := by rw [add_comm]; exact biprod.total }⟩
+
+/-- A biproduct inclusion is a split inflation. -/
+@[simp]
+theorem split_isInflation_biprod_inl (X Z : C) [HasBinaryBiproduct X Z] :
+    (split C).IsInflation (biprod.inl : X ⟶ X ⊞ Z) :=
+  (split C).isInflation_f (split_conflation_biprodShortComplex X Z)
+
+/-- The other biproduct inclusion is a split inflation as well. -/
+@[simp]
+theorem split_isInflation_biprod_inr (X Z : C) [HasBinaryBiproduct X Z] :
+    (split C).IsInflation (biprod.inr : Z ⟶ X ⊞ Z) :=
+  (split C).isInflation_f (split_conflation_biprod_inr_fst X Z)
+
+/-- A biproduct projection is a split deflation. -/
+@[simp]
+theorem split_isDeflation_biprod_snd (X Z : C) [HasBinaryBiproduct X Z] :
+    (split C).IsDeflation (biprod.snd : X ⊞ Z ⟶ Z) :=
+  (split C).isDeflation_g (split_conflation_biprodShortComplex X Z)
+
+/-- The other biproduct projection is a split deflation as well. -/
+@[simp]
+theorem split_isDeflation_biprod_fst (X Z : C) [HasBinaryBiproduct X Z] :
+    (split C).IsDeflation (biprod.fst : X ⊞ Z ⟶ X) :=
+  (split C).isDeflation_g (split_conflation_biprod_inr_fst X Z)
+
+/-- Every split inflation is a split monomorphism. The converse fails in general: a split
+monomorphism is an inflation only once its complementary idempotent splits. -/
+theorem isSplitMono_of_split_isInflation {X Y : C} {i : X ⟶ Y}
+    (hi : (split C).IsInflation i) : IsSplitMono i := by
+  obtain ⟨Z, p, zero, hS⟩ := (isInflation_iff (split C) i).mp hi
+  obtain ⟨s⟩ := (split_conflation_iff _).mp hS
+  exact ⟨⟨s.r, s.f_r⟩⟩
+
+/-- Every split deflation is a split epimorphism. -/
+theorem isSplitEpi_of_split_isDeflation {Y Z : C} {p : Y ⟶ Z}
+    (hp : (split C).IsDeflation p) : IsSplitEpi p := by
+  obtain ⟨X, i, zero, hS⟩ := (isDeflation_iff (split C) p).mp hp
+  obtain ⟨s⟩ := (split_conflation_iff _).mp hS
+  exact ⟨⟨s.s, s.s_g⟩⟩
 
 variable [HasBinaryBiproducts C]
 
@@ -145,29 +192,6 @@ theorem split_isDeflation_iff {Y Z : C} (p : Y ⟶ Z) :
       (split_conflation_iff _).mpr ⟨?_⟩⟩
     exact (biprodShortComplexSplitting X Z).ofIso
       (ShortComplex.isoMk (Iso.refl _) e.symm (Iso.refl _) (by simp) (by simpa using he))
-
-/-- A biproduct inclusion is a split inflation. -/
-theorem split_isInflation_biprod_inl (X Z : C) :
-    (split C).IsInflation (biprod.inl : X ⟶ X ⊞ Z) :=
-  (split_isInflation_iff _).mpr ⟨Z, Iso.refl _, by simp⟩
-
-/-- A biproduct projection is a split deflation. -/
-theorem split_isDeflation_biprod_snd (X Z : C) :
-    (split C).IsDeflation (biprod.snd : X ⊞ Z ⟶ Z) :=
-  (split_isDeflation_iff _).mpr ⟨X, Iso.refl _, by simp⟩
-
-/-- Every split inflation is a split monomorphism. The converse fails in general: a split
-monomorphism is an inflation only once its complementary idempotent splits. -/
-theorem isSplitMono_of_split_isInflation {X Y : C} {i : X ⟶ Y}
-    (hi : (split C).IsInflation i) : IsSplitMono i := by
-  obtain ⟨Z, e, he⟩ := (split_isInflation_iff i).mp hi
-  exact ⟨⟨e.hom ≫ biprod.fst, by rw [← Category.assoc, he, biprod.inl_fst]⟩⟩
-
-/-- Every split deflation is a split epimorphism. -/
-theorem isSplitEpi_of_split_isDeflation {Y Z : C} {p : Y ⟶ Z}
-    (hp : (split C).IsDeflation p) : IsSplitEpi p := by
-  obtain ⟨X, e, he⟩ := (split_isDeflation_iff p).mp hp
-  exact ⟨⟨biprod.inr ≫ e.inv, by rw [Category.assoc, he, biprod.inr_snd]⟩⟩
 
 /-- **E1 for the split exact structure**: a composite of split inflations is a split inflation.
 The cokernel of `i ≫ j` is the biproduct of the two cokernels. -/
@@ -327,12 +351,30 @@ theorem split_toConflationClass :
     (ExactStructure.split C).toConflationClass = ConflationClass.split C :=
   rfl
 
+/-- The conflations of the split exact structure are exactly the short complexes admitting a
+splitting. This is not `@[simp]`: `split_toConflationClass` together with
+`TauCeti.ConflationClass.split_conflation_iff` already rewrites the left-hand side. -/
+theorem split_conflation (S : ShortComplex C) :
+    (ExactStructure.split C).Conflation S ↔ Nonempty S.Splitting :=
+  ConflationClass.split_conflation_iff S
+
+/-- **The inflations of the split exact structure are the biproduct inclusions.** -/
+theorem split_isInflation_iff {X Y : C} (i : X ⟶ Y) :
+    (ExactStructure.split C).IsInflation i ↔ ∃ (Z : C) (e : Y ≅ X ⊞ Z), i ≫ e.hom = biprod.inl :=
+  ConflationClass.split_isInflation_iff i
+
+/-- **The deflations of the split exact structure are the biproduct projections.** -/
+theorem split_isDeflation_iff {Y Z : C} (p : Y ⟶ Z) :
+    (ExactStructure.split C).IsDeflation p ↔ ∃ (X : C) (e : Y ≅ X ⊞ Z), e.inv ≫ p = biprod.snd :=
+  ConflationClass.split_isDeflation_iff p
+
 /-- In every exact structure the biproduct short complex `X ⟶ X ⊞ Z ⟶ Z` is a conflation.
 
 The proof is Bühler's: E0op produces a conflation whose deflation is `𝟙 Z`, so its inflation
 `i : K ⟶ Z` is zero, and the square exhibiting `X ⊞ Z` as the pushout of `i` along the zero map
 `K ⟶ X` turns `biprod.inl` into an inflation by E2. The cokernel of `biprod.inl` supplied by
 that conflation is then identified with `biprod.snd`. -/
+@[simp]
 theorem conflation_biprodShortComplex (E : ExactStructure C) (X Z : C) :
     E.Conflation (biprodShortComplex X Z) := by
   obtain ⟨K, i, hi, hK⟩ :=

--- a/TauCeti/CategoryTheory/Exact/Split.lean
+++ b/TauCeti/CategoryTheory/Exact/Split.lean
@@ -1,0 +1,418 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.CategoryTheory.Exact.ExactStructure
+public import Mathlib.CategoryTheory.Preadditive.Biproducts
+
+/-!
+# The split exact structure on an additive category
+
+Every additive category `C` carries a Quillen exact structure `ExactStructure.split C` whose
+conflations are the short complexes admitting a splitting, that is, the short complexes
+isomorphic to `X ⟶ X ⊞ Z ⟶ Z`.
+
+In this exact structure a morphism `i : X ⟶ Y` is an inflation exactly when it is the inclusion
+of a biproduct summand: there are an object `Z` and an isomorphism `e : Y ≅ X ⊞ Z` with
+`i ≫ e.hom = biprod.inl`. Being a split monomorphism is *not* enough, because the complementary
+summand need not exist; the two notions agree as soon as the relevant idempotent splits.
+
+The split structure is the smallest exact structure on `C`: the last section proves that a short
+complex with a splitting is a conflation for *every* exact structure `E` on `C`, whence also
+that every isomorphism is both an `E`-inflation and an `E`-deflation. This is Bühler's Lemma
+2.7, and it is what makes the comparison out of split `K₀` available for an arbitrary exact
+structure.
+
+## Main definitions
+
+* `TauCeti.biprodShortComplex X Z`: the short complex `X ⟶ X ⊞ Z ⟶ Z`.
+* `TauCeti.ConflationClass.split`: the class of short complexes admitting a splitting.
+* `TauCeti.ExactStructure.split`: the split exact structure on an additive category.
+
+## Main results
+
+* `TauCeti.ConflationClass.split_isInflation_iff` and
+  `TauCeti.ConflationClass.split_isDeflation_iff`: the split inflations are the biproduct
+  inclusions and the split deflations are the biproduct projections.
+* `TauCeti.ConflationClass.exists_isPushout_of_split_isInflation` and
+  `TauCeti.ConflationClass.exists_isPullback_of_split_isDeflation`: the E2/E2op squares, computed
+  explicitly in the biproduct decomposition.
+* `TauCeti.ExactStructure.conflation_of_splitting`: a split short complex is a conflation of
+  every exact structure, so `ExactStructure.split C` is the smallest one.
+* `TauCeti.ExactStructure.isInflation_of_isIso` and
+  `TauCeti.ExactStructure.isDeflation_of_isIso`: in every exact structure an isomorphism is both
+  an inflation and a deflation.
+
+## References
+
+* Theo Bühler, *Exact categories*, Expositiones Mathematicae **28** (2010), 1–69,
+  <https://arxiv.org/abs/0811.1480>. Section 13.1 constructs the split exact structure, and
+  Lemma 2.7 shows that split short complexes are conflations of any exact structure.
+* Charles A. Weibel, *The K-book: An Introduction to Algebraic K-theory*, Chapter II,
+  Section 5, where split `K₀` is presented through the split exact structure.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits ZeroObject
+
+universe v u
+
+variable {C : Type u} [Category.{v} C] [Preadditive C]
+
+section BiprodShortComplex
+
+variable (X Z : C) [HasBinaryBiproduct X Z]
+
+/-- The biproduct short complex `X ⟶ X ⊞ Z ⟶ Z`. Up to isomorphism these are exactly the
+conflations of the split exact structure. -/
+noncomputable abbrev biprodShortComplex : ShortComplex C :=
+  ShortComplex.mk (biprod.inl : X ⟶ X ⊞ Z) biprod.snd (by simp)
+
+/-- The tautological splitting of `X ⟶ X ⊞ Z ⟶ Z`. -/
+noncomputable def biprodShortComplexSplitting : (biprodShortComplex X Z).Splitting :=
+  ShortComplex.Splitting.ofHasBinaryBiproduct X Z
+
+variable {X Z}
+
+/-- A splitting of `S` identifies `S` with the biproduct short complex on its outer terms. -/
+noncomputable def isoBiprodShortComplex {S : ShortComplex C} (s : S.Splitting)
+    [HasBinaryBiproduct S.X₁ S.X₃] : S ≅ biprodShortComplex S.X₁ S.X₃ :=
+  ShortComplex.isoMk (Iso.refl _) s.isoBinaryBiproduct (Iso.refl _)
+    (by apply biprod.hom_ext <;> simp) (by simp)
+
+end BiprodShortComplex
+
+namespace ConflationClass
+
+variable (C) in
+/-- The class of short complexes admitting a splitting. These are the conflations of the split
+exact structure. -/
+@[expose] def split : ConflationClass C where
+  Conflation S := Nonempty S.Splitting
+  isKernelCokernelPair _ hS := .of_splitting hS.some
+  isClosedUnderIsomorphisms := ⟨fun e hS => ⟨hS.some.ofIso e⟩⟩
+
+/-- The split conflations are exactly the short complexes admitting a splitting. -/
+@[simp]
+theorem split_conflation_iff (S : ShortComplex C) :
+    (split C).Conflation S ↔ Nonempty S.Splitting :=
+  Iff.rfl
+
+/-- The biproduct short complex `X ⟶ X ⊞ Z ⟶ Z` is a split conflation. -/
+theorem split_conflation_biprodShortComplex (X Z : C) [HasBinaryBiproduct X Z] :
+    (split C).Conflation (biprodShortComplex X Z) :=
+  ⟨biprodShortComplexSplitting X Z⟩
+
+variable [HasBinaryBiproducts C]
+
+/-- **The split inflations are the biproduct inclusions.** A split monomorphism whose
+complementary idempotent does not split is *not* an inflation of the split exact structure. -/
+theorem split_isInflation_iff {X Y : C} (i : X ⟶ Y) :
+    (split C).IsInflation i ↔ ∃ (Z : C) (e : Y ≅ X ⊞ Z), i ≫ e.hom = biprod.inl := by
+  rw [isInflation_iff]
+  constructor
+  · rintro ⟨Z, p, zero, hS⟩
+    obtain ⟨s⟩ := (split_conflation_iff _).mp hS
+    have hr : i ≫ s.r = 𝟙 X := s.f_r
+    refine ⟨Z, s.isoBinaryBiproduct, ?_⟩
+    apply biprod.hom_ext <;> simp [hr, zero]
+  · rintro ⟨Z, e, he⟩
+    have hi : biprod.inl ≫ e.inv = i := by
+      rw [← he, Category.assoc, e.hom_inv_id, Category.comp_id]
+    refine ⟨Z, e.hom ≫ biprod.snd, by rw [← Category.assoc, he]; simp,
+      (split_conflation_iff _).mpr ⟨?_⟩⟩
+    exact (biprodShortComplexSplitting X Z).ofIso
+      (ShortComplex.isoMk (Iso.refl _) e.symm (Iso.refl _) (by simpa using hi.symm) (by simp))
+
+/-- **The split deflations are the biproduct projections.** -/
+theorem split_isDeflation_iff {Y Z : C} (p : Y ⟶ Z) :
+    (split C).IsDeflation p ↔ ∃ (X : C) (e : Y ≅ X ⊞ Z), e.inv ≫ p = biprod.snd := by
+  rw [isDeflation_iff]
+  constructor
+  · rintro ⟨X, i, zero, hS⟩
+    obtain ⟨s⟩ := (split_conflation_iff _).mp hS
+    have hs : s.s ≫ p = 𝟙 Z := s.s_g
+    refine ⟨X, s.isoBinaryBiproduct, ?_⟩
+    apply biprod.hom_ext' <;> simp [hs, zero]
+  · rintro ⟨X, e, he⟩
+    refine ⟨X, biprod.inl ≫ e.inv, by rw [Category.assoc, he]; simp,
+      (split_conflation_iff _).mpr ⟨?_⟩⟩
+    exact (biprodShortComplexSplitting X Z).ofIso
+      (ShortComplex.isoMk (Iso.refl _) e.symm (Iso.refl _) (by simp) (by simpa using he))
+
+/-- A biproduct inclusion is a split inflation. -/
+theorem split_isInflation_biprod_inl (X Z : C) :
+    (split C).IsInflation (biprod.inl : X ⟶ X ⊞ Z) :=
+  (split_isInflation_iff _).mpr ⟨Z, Iso.refl _, by simp⟩
+
+/-- A biproduct projection is a split deflation. -/
+theorem split_isDeflation_biprod_snd (X Z : C) :
+    (split C).IsDeflation (biprod.snd : X ⊞ Z ⟶ Z) :=
+  (split_isDeflation_iff _).mpr ⟨X, Iso.refl _, by simp⟩
+
+/-- Every split inflation is a split monomorphism. The converse fails in general: a split
+monomorphism is an inflation only once its complementary idempotent splits. -/
+theorem isSplitMono_of_split_isInflation {X Y : C} {i : X ⟶ Y}
+    (hi : (split C).IsInflation i) : IsSplitMono i := by
+  obtain ⟨Z, e, he⟩ := (split_isInflation_iff i).mp hi
+  exact ⟨⟨e.hom ≫ biprod.fst, by rw [← Category.assoc, he, biprod.inl_fst]⟩⟩
+
+/-- Every split deflation is a split epimorphism. -/
+theorem isSplitEpi_of_split_isDeflation {Y Z : C} {p : Y ⟶ Z}
+    (hp : (split C).IsDeflation p) : IsSplitEpi p := by
+  obtain ⟨X, e, he⟩ := (split_isDeflation_iff p).mp hp
+  exact ⟨⟨biprod.inr ≫ e.inv, by rw [Category.assoc, he, biprod.inr_snd]⟩⟩
+
+/-- **E1 for the split exact structure**: a composite of split inflations is a split inflation.
+The cokernel of `i ≫ j` is the biproduct of the two cokernels. -/
+theorem split_isInflation_comp {X Y W : C} {i : X ⟶ Y} {j : Y ⟶ W}
+    (hi : (split C).IsInflation i) (hj : (split C).IsInflation j) :
+    (split C).IsInflation (i ≫ j) := by
+  obtain ⟨Z₁, p, hip, hS₁⟩ := (isInflation_iff (split C) i).mp hi
+  obtain ⟨Z₂, q, hjq, hS₂⟩ := (isInflation_iff (split C) j).mp hj
+  obtain ⟨s₁⟩ := (split_conflation_iff _).mp hS₁
+  obtain ⟨s₂⟩ := (split_conflation_iff _).mp hS₂
+  have hir : i ≫ s₁.r = 𝟙 X := s₁.f_r
+  have hsp : s₁.s ≫ p = 𝟙 Z₁ := s₁.s_g
+  have hid₁ : s₁.r ≫ i + p ≫ s₁.s = 𝟙 Y := s₁.id
+  have hjr : j ≫ s₂.r = 𝟙 Y := s₂.f_r
+  have hsq : s₂.s ≫ q = 𝟙 Z₂ := s₂.s_g
+  have hsr : s₂.s ≫ s₂.r = 0 := s₂.s_r
+  have hid₂ : s₂.r ≫ j + q ≫ s₂.s = 𝟙 W := s₂.id
+  have key : s₁.r ≫ i ≫ j + p ≫ s₁.s ≫ j = j := by
+    rw [← Category.assoc, ← Category.assoc, ← Preadditive.add_comp, hid₁, Category.id_comp]
+  refine (isInflation_iff (split C) _).mpr ⟨Z₁ ⊞ Z₂, biprod.lift (s₂.r ≫ p) q, by
+    apply biprod.hom_ext <;> simp [reassoc_of% hjr, hip, hjq],
+    (split_conflation_iff _).mpr ⟨?_⟩⟩
+  exact
+    { r := s₂.r ≫ s₁.r
+      s := biprod.desc (s₁.s ≫ j) s₂.s
+      f_r := by simp [reassoc_of% hjr, hir]
+      s_g := by ext <;> simp [reassoc_of% hjr, hsp, hjq, reassoc_of% hsr, hsq]
+      id := by
+        simp only [biprod.lift_desc, Category.assoc]
+        rw [← add_assoc, ← Preadditive.comp_add, key]
+        exact hid₂ }
+
+/-- **E1op for the split exact structure**: a composite of split deflations is a split
+deflation. The kernel of `p ≫ q` is the biproduct of the two kernels. -/
+theorem split_isDeflation_comp {X Y Z : C} {p : X ⟶ Y} {q : Y ⟶ Z}
+    (hp : (split C).IsDeflation p) (hq : (split C).IsDeflation q) :
+    (split C).IsDeflation (p ≫ q) := by
+  obtain ⟨K₁, i₁, hi₁p, hS₁⟩ := (isDeflation_iff (split C) p).mp hp
+  obtain ⟨K₂, i₂, hi₂q, hS₂⟩ := (isDeflation_iff (split C) q).mp hq
+  obtain ⟨t₁⟩ := (split_conflation_iff _).mp hS₁
+  obtain ⟨t₂⟩ := (split_conflation_iff _).mp hS₂
+  have hi₁r : i₁ ≫ t₁.r = 𝟙 K₁ := t₁.f_r
+  have hsp : t₁.s ≫ p = 𝟙 Y := t₁.s_g
+  have hsr : t₁.s ≫ t₁.r = 0 := t₁.s_r
+  have hid₁ : t₁.r ≫ i₁ + p ≫ t₁.s = 𝟙 X := t₁.id
+  have hi₂r : i₂ ≫ t₂.r = 𝟙 K₂ := t₂.f_r
+  have hsq : t₂.s ≫ q = 𝟙 Z := t₂.s_g
+  have hid₂ : t₂.r ≫ i₂ + q ≫ t₂.s = 𝟙 Y := t₂.id
+  have key : t₂.r ≫ i₂ ≫ t₁.s + q ≫ t₂.s ≫ t₁.s = t₁.s := by
+    rw [← Category.assoc, ← Category.assoc, ← Preadditive.add_comp, hid₂, Category.id_comp]
+  refine (isDeflation_iff (split C) _).mpr ⟨K₁ ⊞ K₂, biprod.desc i₁ (i₂ ≫ t₁.s), by
+    apply biprod.hom_ext' <;> simp [reassoc_of% hi₁p, reassoc_of% hsp, hi₂q],
+    (split_conflation_iff _).mpr ⟨?_⟩⟩
+  exact
+    { r := biprod.lift t₁.r (p ≫ t₂.r)
+      s := t₂.s ≫ t₁.s
+      f_r := by ext <;> simp [hi₁r, reassoc_of% hi₁p, reassoc_of% hsp, hi₂r]
+      s_g := by simp [reassoc_of% hsp, hsq]
+      id := by
+        simp only [biprod.lift_desc, Category.assoc]
+        rw [add_assoc, ← Preadditive.comp_add, key]
+        exact hid₁ }
+
+/-- **E2 for the split exact structure**: the pushout of a split inflation `i : A ⟶ B` along an
+arbitrary `g : A ⟶ A'` exists and its cobase change is again a split inflation. Concretely, if
+`B ≅ A ⊞ Z` identifies `i` with `biprod.inl`, then the pushout is `A' ⊞ Z`. -/
+theorem exists_isPushout_of_split_isInflation {A B A' : C} {i : A ⟶ B}
+    (hi : (split C).IsInflation i) (g : A ⟶ A') :
+    ∃ (T : C) (inl : B ⟶ T) (inr : A' ⟶ T),
+      IsPushout i g inl inr ∧ (split C).IsInflation inr := by
+  obtain ⟨Z, e, he⟩ := (split_isInflation_iff i).mp hi
+  have hi' : biprod.inl ≫ e.inv = i := by
+    rw [← he, Category.assoc, e.hom_inv_id, Category.comp_id]
+  have hcomm : (biprod.inl : A ⟶ A ⊞ Z) ≫ biprod.map g (𝟙 Z) = g ≫ biprod.inl := by simp
+  have hbase : IsPushout (biprod.inl : A ⟶ A ⊞ Z) g (biprod.map g (𝟙 Z))
+      (biprod.inl : A' ⟶ A' ⊞ Z) :=
+    IsPushout.of_isColimit' ⟨hcomm⟩ (PushoutCocone.IsColimit.mk hcomm
+      (fun s => biprod.desc s.inr (biprod.inr ≫ s.inl))
+      (fun s => by apply biprod.hom_ext' <;> simp [s.condition])
+      (fun _ => by simp)
+      (fun s m h₁ h₂ => by
+        apply biprod.hom_ext'
+        · simpa using h₂
+        · simpa using biprod.inr ≫= h₁))
+  refine ⟨A' ⊞ Z, e.hom ≫ biprod.map g (𝟙 Z), biprod.inl, ?_, split_isInflation_biprod_inl A' Z⟩
+  exact hbase.of_iso (Iso.refl A) e.symm (Iso.refl A') (Iso.refl _) (by simpa using hi')
+    (by simp) (by simp) (by simp)
+
+/-- **E2op for the split exact structure**: the pullback of a split deflation `p : Y ⟶ Z` along
+an arbitrary `f : A ⟶ Z` exists and its base change is again a split deflation. Concretely, if
+`Y ≅ X ⊞ Z` identifies `p` with `biprod.snd`, then the pullback is `X ⊞ A`. -/
+theorem exists_isPullback_of_split_isDeflation {Y Z A : C} {p : Y ⟶ Z}
+    (hp : (split C).IsDeflation p) (f : A ⟶ Z) :
+    ∃ (T : C) (fst : T ⟶ A) (snd : T ⟶ Y),
+      IsPullback fst snd f p ∧ (split C).IsDeflation fst := by
+  obtain ⟨X, e, he⟩ := (split_isDeflation_iff p).mp hp
+  have hcomm : (biprod.snd : X ⊞ A ⟶ A) ≫ f = biprod.map (𝟙 X) f ≫ biprod.snd := by simp
+  have hbase : IsPullback (biprod.snd : X ⊞ A ⟶ A) (biprod.map (𝟙 X) f) f
+      (biprod.snd : X ⊞ Z ⟶ Z) :=
+    IsPullback.of_isLimit' ⟨hcomm⟩ (PullbackCone.IsLimit.mk hcomm
+      (fun s => biprod.lift (s.snd ≫ biprod.fst) s.fst)
+      (fun _ => by simp)
+      (fun s => by apply biprod.hom_ext <;> simp [s.condition])
+      (fun s m h₁ h₂ => by
+        apply biprod.hom_ext
+        · simpa using h₂ =≫ (biprod.fst : X ⊞ Z ⟶ X)
+        · simpa using h₁))
+  refine ⟨X ⊞ A, biprod.snd, biprod.map (𝟙 X) f ≫ e.inv, ?_, split_isDeflation_biprod_snd X A⟩
+  exact hbase.of_iso (Iso.refl _) (Iso.refl A) e.symm (Iso.refl Z) (by simp) (by simp) (by simp)
+    (by simpa using he.symm)
+
+end ConflationClass
+
+variable (C) in
+/-- The **split exact structure** on an additive category: its conflations are the short
+complexes admitting a splitting.
+
+This is genuinely smaller than the canonical exact structure of an abelian category, whose
+conflations are all the short exact short complexes; see
+`TauCeti.ExactStructure.conflation_of_splitting` for the general comparison. -/
+@[expose] noncomputable def ExactStructure.split [HasZeroObject C] [HasBinaryBiproducts C] :
+    ExactStructure C where
+  toConflationClass := ConflationClass.split C
+  isInflation_id X := by
+    refine (ConflationClass.isInflation_iff _ _).mpr
+      ⟨0, 0, by simp, (ConflationClass.split_conflation_iff _).mpr ⟨?_⟩⟩
+    exact ShortComplex.Splitting.ofIsIsoOfIsZero _ (inferInstanceAs (IsIso (𝟙 X)))
+      (isZero_zero C)
+  isDeflation_id X := by
+    refine (ConflationClass.isDeflation_iff _ _).mpr
+      ⟨0, 0, by simp, (ConflationClass.split_conflation_iff _).mpr ⟨?_⟩⟩
+    exact ShortComplex.Splitting.ofIsZeroOfIsIso _ (isZero_zero C)
+      (inferInstanceAs (IsIso (𝟙 X)))
+  isInflation_comp _ _ hi hj := ConflationClass.split_isInflation_comp hi hj
+  isDeflation_comp _ _ hp hq := ConflationClass.split_isDeflation_comp hp hq
+  hasPushouts_inflations := ⟨fun g hf => by
+    obtain ⟨_, _, _, sq, -⟩ := ConflationClass.exists_isPushout_of_split_isInflation hf g
+    exact sq.hasPushout⟩
+  isStableUnderCobaseChange_inflations :=
+    .of_forall_exists_isPullback fun _ g _ hf =>
+      ConflationClass.exists_isPushout_of_split_isInflation hf g
+  hasPullbacks_deflations := ⟨fun g hf => by
+    obtain ⟨_, _, _, sq, -⟩ := ConflationClass.exists_isPullback_of_split_isDeflation hf g
+    exact sq.flip.hasPullback⟩
+  isStableUnderBaseChange_deflations :=
+    .of_forall_exists_isPullback fun f _ _ hg =>
+      ConflationClass.exists_isPullback_of_split_isDeflation hg f
+
+namespace ExactStructure
+
+variable [HasZeroObject C] [HasBinaryBiproducts C]
+
+/-- The underlying conflation class of the split exact structure. Rewriting with this makes the
+whole `TauCeti.ConflationClass.split` API available for `TauCeti.ExactStructure.split`. -/
+@[simp]
+theorem split_toConflationClass :
+    (ExactStructure.split C).toConflationClass = ConflationClass.split C :=
+  rfl
+
+/-- In every exact structure the biproduct short complex `X ⟶ X ⊞ Z ⟶ Z` is a conflation.
+
+The proof is Bühler's: E0op produces a conflation whose deflation is `𝟙 Z`, so its inflation
+`i : K ⟶ Z` is zero, and the square exhibiting `X ⊞ Z` as the pushout of `i` along the zero map
+`K ⟶ X` turns `biprod.inl` into an inflation by E2. The cokernel of `biprod.inl` supplied by
+that conflation is then identified with `biprod.snd`. -/
+theorem conflation_biprodShortComplex (E : ExactStructure C) (X Z : C) :
+    E.Conflation (biprodShortComplex X Z) := by
+  obtain ⟨K, i, hi, hK⟩ :=
+    (ConflationClass.isDeflation_iff E.toConflationClass _).mp (E.isDeflation_id Z)
+  have hi0 : i = 0 := by simpa using hi
+  -- `X ⊞ Z` is the pushout of the zero span `X ⟵ K ⟶ Z`.
+  have hcomm : (0 : K ⟶ X) ≫ (biprod.inl : X ⟶ X ⊞ Z) = i ≫ biprod.inr := by
+    rw [hi0]; simp
+  have sq : IsPushout (0 : K ⟶ X) i (biprod.inl : X ⟶ X ⊞ Z) (biprod.inr : Z ⟶ X ⊞ Z) :=
+    IsPushout.of_isColimit' ⟨hcomm⟩ (PushoutCocone.IsColimit.mk hcomm
+      (fun s => biprod.desc s.inl s.inr) (fun _ => by simp) (fun _ => by simp)
+      (fun _ m h₁ h₂ => by apply biprod.hom_ext' <;> simp [h₁, h₂]))
+  have hinl : E.IsInflation (biprod.inl : X ⟶ X ⊞ Z) :=
+    E.isStableUnderCobaseChange_inflations.of_isPushout sq
+      (E.toConflationClass.isInflation_f hK)
+  obtain ⟨Z', q, hq, hQ⟩ := (ConflationClass.isInflation_iff E.toConflationClass _).mp hinl
+  -- Both `q` and `biprod.snd` are cokernels of `biprod.inl`, hence canonically isomorphic.
+  have hpair := E.isKernelCokernelPair _ hQ
+  have hzero : (biprod.inl : X ⟶ X ⊞ Z) ≫ (biprod.snd : X ⊞ Z ⟶ Z) = 0 := by simp
+  have hpair' : IsKernelCokernelPair
+      (ShortComplex.mk (biprod.inl : X ⟶ X ⊞ Z) biprod.snd hzero) :=
+    IsKernelCokernelPair.of_hasBinaryBiproduct X Z
+  obtain ⟨d, hd⟩ : ∃ d : Z' ⟶ Z, q ≫ d = biprod.snd :=
+    ⟨hpair.desc _ hzero, hpair.g_desc _ _⟩
+  obtain ⟨d', hd'⟩ : ∃ d' : Z ⟶ Z', (biprod.snd : X ⊞ Z ⟶ Z) ≫ d' = q :=
+    ⟨hpair'.desc q hq, hpair'.g_desc _ _⟩
+  have hepi : Epi q := hpair.epi_g
+  have hepi' : Epi (biprod.snd : X ⊞ Z ⟶ Z) := hpair'.epi_g
+  have hiso : IsIso d := by
+    refine ⟨d', ?_, ?_⟩
+    · rw [← cancel_epi q, ← Category.assoc, hd, hd', Category.comp_id]
+    · rw [← cancel_epi (biprod.snd : X ⊞ Z ⟶ Z), ← Category.assoc, hd', hd, Category.comp_id]
+  refine E.toConflationClass.conflation_of_iso ?_ hQ
+  exact ShortComplex.isoMk (Iso.refl _) (Iso.refl _) (asIso d) (by simp) (by simpa using hd.symm)
+
+/-- **A short complex with a splitting is a conflation of every exact structure.**
+Equivalently, the split exact structure is the smallest exact structure on `C`. -/
+theorem conflation_of_splitting (E : ExactStructure C) {S : ShortComplex C} (s : S.Splitting) :
+    E.Conflation S :=
+  E.toConflationClass.conflation_of_iso (isoBiprodShortComplex s).symm
+    (E.conflation_biprodShortComplex S.X₁ S.X₃)
+
+/-- A conflation of the split exact structure is a conflation of every exact structure. -/
+theorem conflation_of_split_conflation (E : ExactStructure C) {S : ShortComplex C}
+    (hS : (ExactStructure.split C).Conflation S) : E.Conflation S :=
+  E.conflation_of_splitting
+    ((ConflationClass.split_conflation_iff (C := C) S).mp hS).some
+
+/-- In every exact structure an isomorphism is an inflation. -/
+theorem isInflation_of_isIso (E : ExactStructure C) {X Y : C} (f : X ⟶ Y) [IsIso f] :
+    E.IsInflation f := by
+  refine (ConflationClass.isInflation_iff E.toConflationClass f).mpr ⟨0, 0, by simp, ?_⟩
+  refine E.conflation_of_splitting
+    (ShortComplex.Splitting.ofIsIsoOfIsZero _ ?_ (isZero_zero C))
+  exact inferInstanceAs (IsIso f)
+
+/-- In every exact structure an isomorphism is a deflation. -/
+theorem isDeflation_of_isIso (E : ExactStructure C) {X Y : C} (f : X ⟶ Y) [IsIso f] :
+    E.IsDeflation f := by
+  refine (ConflationClass.isDeflation_iff E.toConflationClass f).mpr ⟨0, 0, by simp, ?_⟩
+  refine E.conflation_of_splitting
+    (ShortComplex.Splitting.ofIsZeroOfIsIso _ (isZero_zero C) ?_)
+  exact inferInstanceAs (IsIso f)
+
+/-- Every split inflation is an inflation of any exact structure. -/
+theorem isInflation_of_split_isInflation (E : ExactStructure C) {X Y : C} {i : X ⟶ Y}
+    (hi : (ExactStructure.split C).IsInflation i) : E.IsInflation i := by
+  obtain ⟨Z, p, zero, hS⟩ :=
+    (ConflationClass.isInflation_iff (ConflationClass.split C) i).mp hi
+  exact (ConflationClass.isInflation_iff E.toConflationClass i).mpr
+    ⟨Z, p, zero, E.conflation_of_split_conflation hS⟩
+
+/-- Every split deflation is a deflation of any exact structure. -/
+theorem isDeflation_of_split_isDeflation (E : ExactStructure C) {Y Z : C} {p : Y ⟶ Z}
+    (hp : (ExactStructure.split C).IsDeflation p) : E.IsDeflation p := by
+  obtain ⟨X, i, zero, hS⟩ :=
+    (ConflationClass.isDeflation_iff (ConflationClass.split C) p).mp hp
+  exact (ConflationClass.isDeflation_iff E.toConflationClass p).mpr
+    ⟨X, i, zero, E.conflation_of_split_conflation hS⟩
+
+end ExactStructure
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Exact/Split.lean
+++ b/TauCeti/CategoryTheory/Exact/Split.lean
@@ -44,9 +44,6 @@ structure.
 * `TauCeti.ExactStructure.split_isInflation_iff` and
   `TauCeti.ExactStructure.split_isDeflation_iff`: the characteristic API of
   `TauCeti.ExactStructure.split`.
-* `TauCeti.ExactStructure.isInflation_of_isIso` and
-  `TauCeti.ExactStructure.isDeflation_of_isIso`: in every exact structure an isomorphism is both
-  an inflation and a deflation.
 
 ## References
 
@@ -75,10 +72,6 @@ variable (X Z : C) [HasBinaryBiproduct X Z]
 conflations of the split exact structure. -/
 noncomputable abbrev biprodShortComplex : ShortComplex C :=
   ShortComplex.mk (biprod.inl : X ⟶ X ⊞ Z) biprod.snd (by simp)
-
-/-- The tautological splitting of `X ⟶ X ⊞ Z ⟶ Z`. -/
-noncomputable def biprodShortComplexSplitting : (biprodShortComplex X Z).Splitting :=
-  ShortComplex.Splitting.ofHasBinaryBiproduct X Z
 
 variable {X Z}
 
@@ -109,7 +102,7 @@ theorem split_conflation_iff (S : ShortComplex C) :
 /-- The biproduct short complex `X ⟶ X ⊞ Z ⟶ Z` is a split conflation. -/
 theorem split_conflation_biprodShortComplex (X Z : C) [HasBinaryBiproduct X Z] :
     (split C).Conflation (biprodShortComplex X Z) :=
-  ⟨biprodShortComplexSplitting X Z⟩
+  ⟨ShortComplex.Splitting.ofHasBinaryBiproduct X Z⟩
 
 /-- The short complex `Z ⟶ X ⊞ Z ⟶ X` on the other biproduct summand is a split conflation. -/
 theorem split_conflation_biprod_inr_fst (X Z : C) [HasBinaryBiproduct X Z] :
@@ -176,7 +169,7 @@ theorem split_isInflation_iff {X Y : C} (i : X ⟶ Y) :
       rw [← he, Category.assoc, e.hom_inv_id, Category.comp_id]
     refine ⟨Z, e.hom ≫ biprod.snd, by rw [← Category.assoc, he]; simp,
       (split_conflation_iff _).mpr ⟨?_⟩⟩
-    exact (biprodShortComplexSplitting X Z).ofIso
+    exact (ShortComplex.Splitting.ofHasBinaryBiproduct X Z).ofIso
       (ShortComplex.isoMk (Iso.refl _) e.symm (Iso.refl _) (by simpa using hi.symm) (by simp))
 
 /-- **The split deflations are the biproduct projections.** -/
@@ -192,7 +185,7 @@ theorem split_isDeflation_iff {Y Z : C} (p : Y ⟶ Z) :
   · rintro ⟨X, e, he⟩
     refine ⟨X, biprod.inl ≫ e.inv, by rw [Category.assoc, he]; simp,
       (split_conflation_iff _).mpr ⟨?_⟩⟩
-    exact (biprodShortComplexSplitting X Z).ofIso
+    exact (ShortComplex.Splitting.ofHasBinaryBiproduct X Z).ofIso
       (ShortComplex.isoMk (Iso.refl _) e.symm (Iso.refl _) (by simp) (by simpa using he))
 
 /-- **E1 for the split exact structure**: a composite of split inflations is a split inflation.
@@ -267,17 +260,12 @@ theorem exists_isPushout_of_split_isInflation {A B A' : C} {i : A ⟶ B}
   obtain ⟨Z, e, he⟩ := (split_isInflation_iff i).mp hi
   have hi' : biprod.inl ≫ e.inv = i := by
     rw [← he, Category.assoc, e.hom_inv_id, Category.comp_id]
-  have hcomm : (biprod.inl : A ⟶ A ⊞ Z) ≫ biprod.map g (𝟙 Z) = g ≫ biprod.inl := by simp
+  -- Mathlib's pushout square for `coprod.inl`, transported along `A ⨿ Z ≅ A ⊞ Z`.
   have hbase : IsPushout (biprod.inl : A ⟶ A ⊞ Z) g (biprod.map g (𝟙 Z))
       (biprod.inl : A' ⟶ A' ⊞ Z) :=
-    IsPushout.of_isColimit' ⟨hcomm⟩ (PushoutCocone.IsColimit.mk hcomm
-      (fun s => biprod.desc s.inr (biprod.inr ≫ s.inl))
-      (fun s => by apply biprod.hom_ext' <;> simp [s.condition])
-      (fun _ => by simp)
-      (fun s m h₁ h₂ => by
-        apply biprod.hom_ext'
-        · simpa using h₂
-        · simpa using biprod.inr ≫= h₁))
+    (IsPushout.of_coprod_inl_with_id g Z).of_iso (Iso.refl A) (biprod.isoCoprod A Z).symm
+      (Iso.refl A') (biprod.isoCoprod A' Z).symm (by simp [coprod.inl_desc]) (by simp)
+      (by ext <;> simp) (by simp [coprod.inl_desc])
   refine ⟨A' ⊞ Z, e.hom ≫ biprod.map g (𝟙 Z), biprod.inl, ?_, split_isInflation_biprod_inl A' Z⟩
   exact hbase.of_iso (Iso.refl A) e.symm (Iso.refl A') (Iso.refl _) (by simpa using hi')
     (by simp) (by simp) (by simp)
@@ -290,17 +278,13 @@ theorem exists_isPullback_of_split_isDeflation {Y Z A : C} {p : Y ⟶ Z}
     ∃ (T : C) (fst : T ⟶ A) (snd : T ⟶ Y),
       IsPullback fst snd f p ∧ (split C).IsDeflation fst := by
   obtain ⟨X, e, he⟩ := (split_isDeflation_iff p).mp hp
-  have hcomm : (biprod.snd : X ⊞ A ⟶ A) ≫ f = biprod.map (𝟙 X) f ≫ biprod.snd := by simp
+  -- Mathlib's pullback square for `prod.fst`, transported along `A ⨯ X ≅ A ⊞ X ≅ X ⊞ A`.
   have hbase : IsPullback (biprod.snd : X ⊞ A ⟶ A) (biprod.map (𝟙 X) f) f
       (biprod.snd : X ⊞ Z ⟶ Z) :=
-    IsPullback.of_isLimit' ⟨hcomm⟩ (PullbackCone.IsLimit.mk hcomm
-      (fun s => biprod.lift (s.snd ≫ biprod.fst) s.fst)
-      (fun _ => by simp)
-      (fun s => by apply biprod.hom_ext <;> simp [s.condition])
-      (fun s m h₁ h₂ => by
-        apply biprod.hom_ext
-        · simpa using h₂ =≫ (biprod.fst : X ⊞ Z ⟶ X)
-        · simpa using h₁))
+    (IsPullback.of_prod_fst_with_id f X).of_iso
+      ((biprod.isoProd A X).symm ≪≫ biprod.braiding A X) (Iso.refl A)
+      ((biprod.isoProd Z X).symm ≪≫ biprod.braiding Z X) (Iso.refl Z)
+      (by simp) (by ext <;> simp) (by simp) (by simp)
   refine ⟨X ⊞ A, biprod.snd, biprod.map (𝟙 X) f ≫ e.inv, ?_, split_isDeflation_biprod_snd X A⟩
   exact hbase.of_iso (Iso.refl _) (Iso.refl A) e.symm (Iso.refl Z) (by simp) (by simp) (by simp)
     (by simpa using he.symm)
@@ -393,18 +377,12 @@ theorem conflation_biprodShortComplex (E : ExactStructure C) (X Z : C) :
   have hpair' : IsKernelCokernelPair
       (ShortComplex.mk (biprod.inl : X ⟶ X ⊞ Z) biprod.snd hzero) :=
     IsKernelCokernelPair.of_hasBinaryBiproduct X Z
-  obtain ⟨d, hd⟩ : ∃ d : Z' ⟶ Z, q ≫ d = biprod.snd :=
-    ⟨hpair.desc _ hzero, hpair.g_desc _ _⟩
-  obtain ⟨d', hd'⟩ : ∃ d' : Z ⟶ Z', (biprod.snd : X ⊞ Z ⟶ Z) ≫ d' = q :=
-    ⟨hpair'.desc q hq, hpair'.g_desc _ _⟩
-  have hepi : Epi q := hpair.epi_g
-  have hepi' : Epi (biprod.snd : X ⊞ Z ⟶ Z) := hpair'.epi_g
-  have hiso : IsIso d := by
-    refine ⟨d', ?_, ?_⟩
-    · rw [← cancel_epi q, ← Category.assoc, hd, hd', Category.comp_id]
-    · rw [← cancel_epi (biprod.snd : X ⊞ Z ⟶ Z), ← Category.assoc, hd', hd, Category.comp_id]
+  let e : Z' ≅ Z := IsColimit.coconePointUniqueUpToIso hpair.gIsCokernel hpair'.gIsCokernel
+  have hd : q ≫ e.hom = biprod.snd :=
+    IsColimit.comp_coconePointUniqueUpToIso_hom hpair.gIsCokernel hpair'.gIsCokernel
+      WalkingParallelPair.one
   refine E.toConflationClass.conflation_of_iso ?_ hQ
-  exact ShortComplex.isoMk (Iso.refl _) (Iso.refl _) (asIso d) (by simp) (by simpa using hd.symm)
+  exact ShortComplex.isoMk (Iso.refl _) (Iso.refl _) e (by simp) (by simpa using hd.symm)
 
 /-- **A short complex with a splitting is a conflation of every exact structure.**
 Equivalently, the split exact structure is the smallest exact structure on `C`. -/
@@ -417,16 +395,6 @@ theorem conflation_of_splitting (E : ExactStructure C) {S : ShortComplex C} (s :
 theorem conflation_of_split_conflation (E : ExactStructure C) {S : ShortComplex C}
     (hS : (ExactStructure.split C).Conflation S) : E.Conflation S :=
   E.conflation_of_splitting ((split_conflation S).mp hS).some
-
-/-- In every exact structure an isomorphism is an inflation. -/
-theorem isInflation_of_isIso (E : ExactStructure C) {X Y : C} (f : X ⟶ Y) [IsIso f] :
-    E.IsInflation f :=
-  E.inflations.of_isIso f
-
-/-- In every exact structure an isomorphism is a deflation. -/
-theorem isDeflation_of_isIso (E : ExactStructure C) {X Y : C} (f : X ⟶ Y) [IsIso f] :
-    E.IsDeflation f :=
-  E.deflations.of_isIso f
 
 /-- Every split inflation is an inflation of any exact structure. -/
 theorem isInflation_of_split_isInflation (E : ExactStructure C) {X Y : C} {i : X ⟶ Y}

--- a/TauCeti/CategoryTheory/Exact/Split.lean
+++ b/TauCeti/CategoryTheory/Exact/Split.lean
@@ -21,9 +21,8 @@ of a biproduct summand: there are an object `Z` and an isomorphism `e : Y ≅ X 
 summand need not exist; the two notions agree as soon as the relevant idempotent splits.
 
 The split structure is the smallest exact structure on `C`: the last section proves that a short
-complex with a splitting is a conflation for *every* exact structure `E` on `C`, whence also
-that every isomorphism is both an `E`-inflation and an `E`-deflation. This is Bühler's Lemma
-2.7, and it is what makes the comparison out of split `K₀` available for an arbitrary exact
+complex with a splitting is a conflation for *every* exact structure `E` on `C`. This is Bühler's
+Lemma 2.7, and it is what makes the comparison out of split `K₀` available for an arbitrary exact
 structure.
 
 ## Main definitions
@@ -42,6 +41,9 @@ structure.
   explicitly in the biproduct decomposition.
 * `TauCeti.ExactStructure.conflation_of_splitting`: a split short complex is a conflation of
   every exact structure, so `ExactStructure.split C` is the smallest one.
+* `TauCeti.ExactStructure.split_isInflation_iff` and
+  `TauCeti.ExactStructure.split_isDeflation_iff`: the characteristic API of
+  `TauCeti.ExactStructure.split`.
 * `TauCeti.ExactStructure.isInflation_of_isIso` and
   `TauCeti.ExactStructure.isDeflation_of_isIso`: in every exact structure an isomorphism is both
   an inflation and a deflation.
@@ -309,10 +311,10 @@ variable (C) in
 /-- The **split exact structure** on an additive category: its conflations are the short
 complexes admitting a splitting.
 
-This is genuinely smaller than the canonical exact structure of an abelian category, whose
-conflations are all the short exact short complexes; see
+Its conflations are only the split short complexes, whereas those of the canonical exact
+structure of an abelian category are all the short exact ones; see
 `TauCeti.ExactStructure.conflation_of_splitting` for the general comparison. -/
-@[expose] noncomputable def ExactStructure.split [HasZeroObject C] [HasBinaryBiproducts C] :
+noncomputable def ExactStructure.split [HasZeroObject C] [HasBinaryBiproducts C] :
     ExactStructure C where
   toConflationClass := ConflationClass.split C
   isInflation_id X := by
@@ -344,36 +346,30 @@ namespace ExactStructure
 
 variable [HasZeroObject C] [HasBinaryBiproducts C]
 
-/-- The underlying conflation class of the split exact structure. Rewriting with this makes the
-whole `TauCeti.ConflationClass.split` API available for `TauCeti.ExactStructure.split`. -/
-@[simp]
-theorem split_toConflationClass :
-    (ExactStructure.split C).toConflationClass = ConflationClass.split C :=
-  rfl
-
 /-- The conflations of the split exact structure are exactly the short complexes admitting a
-splitting. This is not `@[simp]`: `split_toConflationClass` together with
-`TauCeti.ConflationClass.split_conflation_iff` already rewrites the left-hand side. -/
+splitting. -/
+@[simp]
 theorem split_conflation (S : ShortComplex C) :
     (ExactStructure.split C).Conflation S ↔ Nonempty S.Splitting :=
   ConflationClass.split_conflation_iff S
 
 /-- **The inflations of the split exact structure are the biproduct inclusions.** -/
+@[simp]
 theorem split_isInflation_iff {X Y : C} (i : X ⟶ Y) :
     (ExactStructure.split C).IsInflation i ↔ ∃ (Z : C) (e : Y ≅ X ⊞ Z), i ≫ e.hom = biprod.inl :=
   ConflationClass.split_isInflation_iff i
 
 /-- **The deflations of the split exact structure are the biproduct projections.** -/
+@[simp]
 theorem split_isDeflation_iff {Y Z : C} (p : Y ⟶ Z) :
     (ExactStructure.split C).IsDeflation p ↔ ∃ (X : C) (e : Y ≅ X ⊞ Z), e.inv ≫ p = biprod.snd :=
   ConflationClass.split_isDeflation_iff p
 
 /-- In every exact structure the biproduct short complex `X ⟶ X ⊞ Z ⟶ Z` is a conflation.
 
-The proof is Bühler's: E0op produces a conflation whose deflation is `𝟙 Z`, so its inflation
-`i : K ⟶ Z` is zero, and the square exhibiting `X ⊞ Z` as the pushout of `i` along the zero map
-`K ⟶ X` turns `biprod.inl` into an inflation by E2. The cokernel of `biprod.inl` supplied by
-that conflation is then identified with `biprod.snd`. -/
+No exact structure can therefore omit a biproduct decomposition. This is the key step of
+Bühler's Lemma 2.7, from which `TauCeti.ExactStructure.conflation_of_splitting` — the
+minimality of the split exact structure — follows by closure under isomorphisms. -/
 @[simp]
 theorem conflation_biprodShortComplex (E : ExactStructure C) (X Z : C) :
     E.Conflation (biprodShortComplex X Z) := by
@@ -420,30 +416,23 @@ theorem conflation_of_splitting (E : ExactStructure C) {S : ShortComplex C} (s :
 /-- A conflation of the split exact structure is a conflation of every exact structure. -/
 theorem conflation_of_split_conflation (E : ExactStructure C) {S : ShortComplex C}
     (hS : (ExactStructure.split C).Conflation S) : E.Conflation S :=
-  E.conflation_of_splitting
-    ((ConflationClass.split_conflation_iff (C := C) S).mp hS).some
+  E.conflation_of_splitting ((split_conflation S).mp hS).some
 
 /-- In every exact structure an isomorphism is an inflation. -/
 theorem isInflation_of_isIso (E : ExactStructure C) {X Y : C} (f : X ⟶ Y) [IsIso f] :
-    E.IsInflation f := by
-  refine (ConflationClass.isInflation_iff E.toConflationClass f).mpr ⟨0, 0, by simp, ?_⟩
-  refine E.conflation_of_splitting
-    (ShortComplex.Splitting.ofIsIsoOfIsZero _ ?_ (isZero_zero C))
-  exact inferInstanceAs (IsIso f)
+    E.IsInflation f :=
+  E.inflations.of_isIso f
 
 /-- In every exact structure an isomorphism is a deflation. -/
 theorem isDeflation_of_isIso (E : ExactStructure C) {X Y : C} (f : X ⟶ Y) [IsIso f] :
-    E.IsDeflation f := by
-  refine (ConflationClass.isDeflation_iff E.toConflationClass f).mpr ⟨0, 0, by simp, ?_⟩
-  refine E.conflation_of_splitting
-    (ShortComplex.Splitting.ofIsZeroOfIsIso _ (isZero_zero C) ?_)
-  exact inferInstanceAs (IsIso f)
+    E.IsDeflation f :=
+  E.deflations.of_isIso f
 
 /-- Every split inflation is an inflation of any exact structure. -/
 theorem isInflation_of_split_isInflation (E : ExactStructure C) {X Y : C} {i : X ⟶ Y}
     (hi : (ExactStructure.split C).IsInflation i) : E.IsInflation i := by
   obtain ⟨Z, p, zero, hS⟩ :=
-    (ConflationClass.isInflation_iff (ConflationClass.split C) i).mp hi
+    (ConflationClass.isInflation_iff (ExactStructure.split C).toConflationClass i).mp hi
   exact (ConflationClass.isInflation_iff E.toConflationClass i).mpr
     ⟨Z, p, zero, E.conflation_of_split_conflation hS⟩
 
@@ -451,7 +440,7 @@ theorem isInflation_of_split_isInflation (E : ExactStructure C) {X Y : C} {i : X
 theorem isDeflation_of_split_isDeflation (E : ExactStructure C) {Y Z : C} {p : Y ⟶ Z}
     (hp : (ExactStructure.split C).IsDeflation p) : E.IsDeflation p := by
   obtain ⟨X, i, zero, hS⟩ :=
-    (ConflationClass.isDeflation_iff (ConflationClass.split C) p).mp hp
+    (ConflationClass.isDeflation_iff (ExactStructure.split C).toConflationClass p).mp hp
   exact (ConflationClass.isDeflation_iff E.toConflationClass p).mpr
     ⟨X, i, zero, E.conflation_of_split_conflation hS⟩
 


### PR DESCRIPTION
This PR constructs `TauCeti.ExactStructure.split`, the split Quillen exact structure on an
additive category, and proves that it is the smallest exact structure on that category. Layer 0
of the Grothendieck/Euler roadmap asks for "the three fundamental constructions": the split exact
structure on every additive category, the canonical exact structure on every abelian category
(landed in #3396), and the induced structure on a replete extension-closed additive subcategory.
This supplies the first of the three, together with two of the layer's listed standard
consequences of the axioms — split sequences are conflations, and isomorphisms are both
inflations and deflations. After this PR the Layer 0 milestone still needs the extension-closed
subcategory structure, conflation-exact functors, and the opposite exact structure before Layer 1
can begin.

New file `TauCeti/CategoryTheory/Exact/Split.lean` (417 lines):

- `TauCeti.biprodShortComplex X Z`, the short complex `X ⟶ X ⊞ Z ⟶ Z`, and
  `TauCeti.isoBiprodShortComplex`, which turns any splitting of `S` into an
  isomorphism `S ≅ biprodShortComplex S.X₁ S.X₃`.
- `TauCeti.ConflationClass.split`, the isomorphism-closed class of short complexes admitting a
  splitting, resting on the landed `IsKernelCokernelPair.of_splitting`.
- `split_isInflation_iff` and `split_isDeflation_iff`: `i` is a split inflation exactly when
  some `e : Y ≅ X ⊞ Z` satisfies `i ≫ e.hom = biprod.inl`, and dually for deflations. These
  record the point Bühler makes in Section 13.1: a split monomorphism whose complementary
  idempotent does not split is *not* an inflation, so `IsSplitMono` is only a consequence
  (`isSplitMono_of_split_isInflation`), not a characterisation.
- The six axioms: `split_isInflation_comp` and `split_isDeflation_comp` build the composite's
  cokernel (resp. kernel) as the biproduct of the two given ones, and
  `exists_isPushout_of_split_isInflation` / `exists_isPullback_of_split_isDeflation` produce
  genuine universal squares, computed as `A' ⊞ Z` and `X ⊞ A` in the biproduct decomposition, so
  E2/E2op assume no ambient pushouts or pullbacks.
- `TauCeti.ExactStructure.split`, assembling these, with the `@[simp]` characteristic lemmas
  `split_conflation`, `split_isInflation_iff` and `split_isDeflation_iff` as its interface.
- `TauCeti.ExactStructure.conflation_biprodShortComplex` and `conflation_of_splitting`: in *any*
  exact structure `E`, E0op forces the inflation of the `𝟙 Z` conflation to be zero, `X ⊞ Z` is
  the pushout of that zero span, E2 makes `biprod.inl` an inflation, and its cokernel is
  identified with `biprod.snd`; hence every split short complex is an `E`-conflation. This is
  Bühler's Lemma 2.7, and it is what will let Layer 2 define the comparison
  `splitK₀ C ⟶ exactK₀ (C, E)` for an arbitrary exact structure.

The construction is stated for a bare `Preadditive` category with a zero object and binary
biproducts, so the abelian and split structures on an abelian category stay distinct, as the
roadmap's standing conventions require. No Mathlib source was vendored.

Roadmap: GrothendieckEulerForms

<!--tauceti-target:v1 {"focus":"GrothendieckEulerForms","id":"exactstructure-split"}-->

🤖 Prepared with Claude Code

