### PR TITLE
feat: add orthogonal sum isometries

### DIFF
--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -6,18 +6,19 @@ module
 
 public import TauCeti.LinearAlgebra.IntegralLattice.Even
 public import TauCeti.LinearAlgebra.IntegralLattice.Gram
+public import TauCeti.LinearAlgebra.IntegralLattice.Isometry
 import Mathlib.LinearAlgebra.Basis.Prod
 
 /-!
 # Orthogonal sums of integral lattices
 
 The orthogonal sum has product carrier and block-diagonal form. This file constructs the lattice,
-its canonical carrier maps and product bases, and proves the currently available invariant laws:
-rank is additive, Gram matrices are block diagonal, determinant and discriminant are
-multiplicative, and evenness and nondegeneracy are componentwise.
+its canonical carrier maps and product bases, and proves several invariant laws: rank is additive,
+Gram matrices are block diagonal, determinant and discriminant are multiplicative, and evenness
+and nondegeneracy are componentwise. Orthogonal sums are functorial under lattice isometries and
+are associative and commutative up to canonical lattice isometry.
 
-Associativity, commutativity, and functoriality as lattice isometries, together with signature
-additivity, belong after the lattice-isometry and signature APIs targeted by the same roadmap.
+Signature additivity remains to be developed with the signature API targeted by the same roadmap.
 
 ## Main definitions
 
@@ -25,6 +26,9 @@ additivity, belong after the lattice-isometry and signature APIs targeted by the
 * `TauCeti.IntegralLattice.orthogonalSum`: the orthogonal sum lattice.
 * `TauCeti.IntegralLattice.orthogonalSumCarrierEquiv`: the carrier-product equivalence.
 * `TauCeti.IntegralLattice.orthogonalSumBasis`: the product of two carrier bases.
+* `TauCeti.IntegralLattice.Isometry.orthogonalSum`: the product of two lattice isometries.
+* `TauCeti.IntegralLattice.orthogonalSumComm`: the canonical commutativity isometry.
+* `TauCeti.IntegralLattice.orthogonalSumAssoc`: the canonical associativity isometry.
 
 ## References
 
@@ -38,7 +42,7 @@ open Module
 
 namespace TauCeti.IntegralLattice
 
-universe u v w x
+universe u v w x y z
 
 variable {V : Type u} {W : Type v}
 variable [AddCommGroup V] [Module ℚ V] [AddCommGroup W] [Module ℚ W]
@@ -330,5 +334,172 @@ theorem nondegenerate_orthogonalSum_iff (L : IntegralLattice V) (M : IntegralLat
     (L.orthogonalSum M).form.Nondegenerate ↔
       L.form.Nondegenerate ∧ M.form.Nondegenerate := by
   rw [orthogonalSum_form, nondegenerate_orthogonalSumForm_iff]
+
+/-! ## Isometries of orthogonal sums -/
+
+section Isometry
+
+variable {X : Type w} {Y : Type x} {U : Type y} {Z : Type z}
+variable [AddCommGroup X] [Module ℚ X] [AddCommGroup Y] [Module ℚ Y]
+variable [AddCommGroup U] [Module ℚ U] [AddCommGroup Z] [Module ℚ Z]
+
+namespace Isometry
+
+variable {L : IntegralLattice V} {M : IntegralLattice W}
+variable {L' : IntegralLattice X} {M' : IntegralLattice Y}
+
+/-- The orthogonal sum of two integral-lattice isometries. -/
+def orthogonalSum (f : Isometry L L') (g : Isometry M M') :
+    Isometry (L.orthogonalSum M) (L'.orthogonalSum M') where
+  toIsometryEquiv :=
+    { toLinearEquiv := (f : V ≃ₗ[ℚ] X).prodCongr (g : W ≃ₗ[ℚ] Y)
+      map_app' := by
+        intro p q
+        -- Expose the product equivalence once so the componentwise form equations apply.
+        change L'.form (f p.1) (f q.1) + M'.form (g p.2) (g q.2) =
+          L.form p.1 q.1 + M.form p.2 q.2
+        rw [f.map_app, g.map_app] }
+  map_carrier := by
+    ext p
+    constructor
+    · rintro ⟨q, hq, rfl⟩
+      exact ⟨(f.apply_mem_carrier_iff q.1).2 hq.1,
+        (g.apply_mem_carrier_iff q.2).2 hq.2⟩
+    · intro hp
+      refine ⟨(f.symm p.1, g.symm p.2), ?_, ?_⟩
+      · exact ⟨(f.symm.apply_mem_carrier_iff p.1).2 hp.1,
+          (g.symm.apply_mem_carrier_iff p.2).2 hp.2⟩
+      · -- The restricted product equivalence has the same componentwise action as the ambient one.
+        change (f (f.symm p.1), g (g.symm p.2)) = p
+        simp
+
+/-- The product isometry acts componentwise on the ambient product. -/
+@[simp]
+theorem orthogonalSum_apply (f : Isometry L L') (g : Isometry M M') (p : V × W) :
+    f.orthogonalSum g p = (f p.1, g p.2) :=
+  by rw [orthogonalSum]; rfl
+
+/-- The product of identity isometries is the identity of the orthogonal sum. -/
+@[simp]
+theorem orthogonalSum_refl (L : IntegralLattice V) (M : IntegralLattice W) :
+    (Isometry.refl L).orthogonalSum (Isometry.refl M) =
+      Isometry.refl (L.orthogonalSum M) := by
+  apply Isometry.ext
+  intro p
+  simp only [orthogonalSum_apply, Isometry.refl_apply]
+
+/-- The inverse of a product isometry is the product of the inverse isometries. -/
+@[simp]
+theorem orthogonalSum_symm (f : Isometry L L') (g : Isometry M M') :
+    (f.orthogonalSum g).symm = f.symm.orthogonalSum g.symm := by
+  apply Isometry.ext
+  intro p
+  apply (f.orthogonalSum g).injective
+  -- `Function.Injective` exposes the underlying linear equivalence; return to the isometry
+  -- coercion so its inverse law and the componentwise application lemma can rewrite.
+  change (f.orthogonalSum g) ((f.orthogonalSum g).symm p) =
+    (f.orthogonalSum g) (f.symm.orthogonalSum g.symm p)
+  rw [Isometry.apply_symm_apply, orthogonalSum_apply, orthogonalSum_apply]
+  simp
+
+/-- Product isometries preserve composition componentwise. -/
+@[simp]
+theorem orthogonalSum_trans {L'' : IntegralLattice U} {M'' : IntegralLattice Z}
+    (f : Isometry L L') (g : Isometry M M')
+    (f' : Isometry L' L'') (g' : Isometry M' M'') :
+    (f.orthogonalSum g).trans (f'.orthogonalSum g') =
+      (f.trans f').orthogonalSum (g.trans g') := by
+  apply Isometry.ext
+  intro p
+  simp only [Isometry.trans_apply, orthogonalSum_apply]
+
+end Isometry
+
+/-- Orthogonal sum is commutative up to the canonical factor-swapping lattice isometry. -/
+def orthogonalSumComm (L : IntegralLattice V) (M : IntegralLattice W) :
+    Isometry (L.orthogonalSum M) (M.orthogonalSum L) where
+  toIsometryEquiv :=
+    { toLinearEquiv := LinearEquiv.prodComm ℚ V W
+      map_app' := by
+        intro p q
+        -- Expose the swap once so form preservation reduces to commutativity of addition.
+        change M.form p.2 q.2 + L.form p.1 q.1 =
+          L.form p.1 q.1 + M.form p.2 q.2
+        rw [add_comm] }
+  map_carrier := by
+    ext p
+    constructor
+    · rintro ⟨q, hq, rfl⟩
+      exact ⟨hq.2, hq.1⟩
+    · intro hp
+      exact ⟨(p.2, p.1), ⟨hp.2, hp.1⟩, rfl⟩
+
+/-- The commutativity isometry swaps the two ambient components. -/
+@[simp]
+theorem orthogonalSumComm_apply (L : IntegralLattice V) (M : IntegralLattice W) (p : V × W) :
+    orthogonalSumComm L M p = (p.2, p.1) :=
+  by rw [orthogonalSumComm]; rfl
+
+/-- Swapping the two factors twice is the identity lattice isometry. -/
+@[simp]
+theorem orthogonalSumComm_trans (L : IntegralLattice V) (M : IntegralLattice W) :
+    (orthogonalSumComm L M).trans (orthogonalSumComm M L) = Isometry.refl _ := by
+  apply Isometry.ext
+  intro p
+  simp only [Isometry.trans_apply, orthogonalSumComm_apply, Isometry.refl_apply]
+
+/-- The commutativity isometry is natural with respect to isometries of both factors. -/
+theorem orthogonalSumComm_naturality {L : IntegralLattice V} {M : IntegralLattice W}
+    {L' : IntegralLattice X} {M' : IntegralLattice Y}
+    (f : Isometry L L') (g : Isometry M M') :
+    (f.orthogonalSum g).trans (orthogonalSumComm L' M') =
+      (orthogonalSumComm L M).trans (g.orthogonalSum f) := by
+  apply Isometry.ext
+  intro p
+  simp only [Isometry.trans_apply, Isometry.orthogonalSum_apply, orthogonalSumComm_apply]
+
+/-- Orthogonal sum is associative up to the canonical reassociation lattice isometry. -/
+def orthogonalSumAssoc (L : IntegralLattice V) (M : IntegralLattice W)
+    (N : IntegralLattice U) :
+    Isometry ((L.orthogonalSum M).orthogonalSum N)
+      (L.orthogonalSum (M.orthogonalSum N)) where
+  toIsometryEquiv :=
+    { toLinearEquiv := LinearEquiv.prodAssoc ℚ V W U
+      map_app' := by
+        intro p q
+        -- Expose reassociation once so form preservation is exactly associativity of addition.
+        change L.form p.1.1 q.1.1 +
+            (M.form p.1.2 q.1.2 + N.form p.2 q.2) =
+          (L.form p.1.1 q.1.1 + M.form p.1.2 q.1.2) + N.form p.2 q.2
+        rw [add_assoc] }
+  map_carrier := by
+    ext p
+    constructor
+    · rintro ⟨q, hq, rfl⟩
+      exact ⟨hq.1.1, hq.1.2, hq.2⟩
+    · intro hp
+      exact ⟨((p.1, p.2.1), p.2.2), ⟨⟨hp.1, hp.2.1⟩, hp.2.2⟩, rfl⟩
+
+/-- The associativity isometry reassociates the three ambient components. -/
+@[simp]
+theorem orthogonalSumAssoc_apply (L : IntegralLattice V) (M : IntegralLattice W)
+    (N : IntegralLattice U) (p : (V × W) × U) :
+    orthogonalSumAssoc L M N p = (p.1.1, (p.1.2, p.2)) :=
+  by rw [orthogonalSumAssoc]; rfl
+
+/-- The inverse associativity isometry restores left-associated products. -/
+@[simp]
+theorem orthogonalSumAssoc_symm_apply (L : IntegralLattice V) (M : IntegralLattice W)
+    (N : IntegralLattice U) (p : V × (W × U)) :
+    (orthogonalSumAssoc L M N).symm p = ((p.1, p.2.1), p.2.2) :=
+  by
+    apply (orthogonalSumAssoc L M N).injective
+    -- `Function.Injective` exposes the underlying linear equivalence; return to the isometry
+    -- coercion so its inverse law and the public application lemma can rewrite.
+    change orthogonalSumAssoc L M N ((orthogonalSumAssoc L M N).symm p) =
+      orthogonalSumAssoc L M N ((p.1, p.2.1), p.2.2)
+    rw [Isometry.apply_symm_apply, orthogonalSumAssoc_apply]
+
+end Isometry
 
 end TauCeti.IntegralLattice

--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -27,8 +27,8 @@ Signature additivity remains to be developed with the signature API targeted by 
 * `TauCeti.IntegralLattice.orthogonalSumCarrierEquiv`: the carrier-product equivalence.
 * `TauCeti.IntegralLattice.orthogonalSumBasis`: the product of two carrier bases.
 * `TauCeti.IntegralLattice.Isometry.orthogonalSum`: the product of two lattice isometries.
-* `TauCeti.IntegralLattice.orthogonalSumComm`: the canonical commutativity isometry.
-* `TauCeti.IntegralLattice.orthogonalSumAssoc`: the canonical associativity isometry.
+* `TauCeti.IntegralLattice.Isometry.orthogonalSumComm`: the canonical commutativity isometry.
+* `TauCeti.IntegralLattice.Isometry.orthogonalSumAssoc`: the canonical associativity isometry.
 
 ## References
 
@@ -408,24 +408,24 @@ theorem orthogonalSumCarrierEquiv_carrierEquiv (f : Isometry L L') (g : Isometry
         orthogonalSum_apply, orthogonalSumSnd_apply]
 
 /-- Product isometries commute with the first canonical carrier projection. -/
+@[simp]
 theorem orthogonalSumFst_carrierEquiv (f : Isometry L L') (g : Isometry M M')
     (p : L.orthogonalSum M) :
     orthogonalSumFst L' M' ((f.orthogonalSum g).carrierEquiv p) =
       f.carrierEquiv (orthogonalSumFst L M p) :=
   by
-    apply Subtype.ext
-    simp only [orthogonalSumFst_apply, coe_orthogonalSumCarrierEquiv_fst,
-      Isometry.coe_carrierEquiv_apply, orthogonalSum_apply]
+    simpa only [orthogonalSumFst_apply] using
+      congrArg Prod.fst (orthogonalSumCarrierEquiv_carrierEquiv f g p)
 
 /-- Product isometries commute with the second canonical carrier projection. -/
+@[simp]
 theorem orthogonalSumSnd_carrierEquiv (f : Isometry L L') (g : Isometry M M')
     (p : L.orthogonalSum M) :
     orthogonalSumSnd L' M' ((f.orthogonalSum g).carrierEquiv p) =
       g.carrierEquiv (orthogonalSumSnd L M p) :=
   by
-    apply Subtype.ext
-    simp only [orthogonalSumSnd_apply, coe_orthogonalSumCarrierEquiv_snd,
-      Isometry.coe_carrierEquiv_apply, orthogonalSum_apply]
+    simpa only [orthogonalSumSnd_apply] using
+      congrArg Prod.snd (orthogonalSumCarrierEquiv_carrierEquiv f g p)
 
 /-- The product of identity isometries is the identity of the orthogonal sum. -/
 @[simp]
@@ -456,8 +456,6 @@ theorem orthogonalSum_trans {L'' : IntegralLattice U} {M'' : IntegralLattice Z}
   apply Isometry.ext
   intro p
   simp only [Isometry.trans_apply, orthogonalSum_apply]
-
-end Isometry
 
 /-- Orthogonal sum is commutative up to the canonical factor-swapping lattice isometry. -/
 def orthogonalSumComm (L : IntegralLattice V) (M : IntegralLattice W) :
@@ -556,7 +554,8 @@ theorem orthogonalSumAssoc_symm_apply (L : IntegralLattice V) (M : IntegralLatti
     (orthogonalSumAssoc L M N).symm p = ((p.1, p.2.1), p.2.2) :=
   by
     rw [Isometry.coe_symm]
-    rfl
+    apply (LinearEquiv.symm_apply_eq _).2
+    exact (orthogonalSumAssoc_apply L M N ((p.1, p.2.1), p.2.2)).symm
 
 /-- The associativity isometry is natural with respect to isometries of all three factors. -/
 theorem orthogonalSumAssoc_naturality {L : IntegralLattice V} {M : IntegralLattice W}
@@ -568,6 +567,8 @@ theorem orthogonalSumAssoc_naturality {L : IntegralLattice V} {M : IntegralLatti
   apply Isometry.ext
   intro p
   simp only [Isometry.trans_apply, Isometry.orthogonalSum_apply, orthogonalSumAssoc_apply]
+
+end Isometry
 
 end Isometry
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -392,8 +392,22 @@ theorem orthogonalSum_carrierEquiv_inr (f : Isometry L L') (g : Isometry M M') (
     simp only [Isometry.coe_carrierEquiv_apply, orthogonalSumInr_apply,
       orthogonalSum_apply, map_zero]
 
-/-- Product isometries commute with the first canonical carrier projection. -/
+/-- Product isometries commute with the canonical carrier-product equivalence. -/
 @[simp]
+theorem orthogonalSumCarrierEquiv_carrierEquiv (f : Isometry L L') (g : Isometry M M')
+    (p : L.orthogonalSum M) :
+    orthogonalSumCarrierEquiv L' M' ((f.orthogonalSum g).carrierEquiv p) =
+      (f.carrierEquiv (orthogonalSumFst L M p), g.carrierEquiv (orthogonalSumSnd L M p)) :=
+  by
+    apply Prod.ext
+    · apply Subtype.ext
+      simp only [coe_orthogonalSumCarrierEquiv_fst, Isometry.coe_carrierEquiv_apply,
+        orthogonalSum_apply, orthogonalSumFst_apply]
+    · apply Subtype.ext
+      simp only [coe_orthogonalSumCarrierEquiv_snd, Isometry.coe_carrierEquiv_apply,
+        orthogonalSum_apply, orthogonalSumSnd_apply]
+
+/-- Product isometries commute with the first canonical carrier projection. -/
 theorem orthogonalSumFst_carrierEquiv (f : Isometry L L') (g : Isometry M M')
     (p : L.orthogonalSum M) :
     orthogonalSumFst L' M' ((f.orthogonalSum g).carrierEquiv p) =
@@ -404,7 +418,6 @@ theorem orthogonalSumFst_carrierEquiv (f : Isometry L L') (g : Isometry M M')
       Isometry.coe_carrierEquiv_apply, orthogonalSum_apply]
 
 /-- Product isometries commute with the second canonical carrier projection. -/
-@[simp]
 theorem orthogonalSumSnd_carrierEquiv (f : Isometry L L') (g : Isometry M M')
     (p : L.orthogonalSum M) :
     orthogonalSumSnd L' M' ((f.orthogonalSum g).carrierEquiv p) =

--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -408,7 +408,6 @@ theorem orthogonalSumCarrierEquiv_carrierEquiv (f : Isometry L L') (g : Isometry
         orthogonalSum_apply, orthogonalSumSnd_apply]
 
 /-- Product isometries commute with the first canonical carrier projection. -/
-@[simp]
 theorem orthogonalSumFst_carrierEquiv (f : Isometry L L') (g : Isometry M M')
     (p : L.orthogonalSum M) :
     orthogonalSumFst L' M' ((f.orthogonalSum g).carrierEquiv p) =
@@ -418,7 +417,6 @@ theorem orthogonalSumFst_carrierEquiv (f : Isometry L L') (g : Isometry M M')
       congrArg Prod.fst (orthogonalSumCarrierEquiv_carrierEquiv f g p)
 
 /-- Product isometries commute with the second canonical carrier projection. -/
-@[simp]
 theorem orthogonalSumSnd_carrierEquiv (f : Isometry L L') (g : Isometry M M')
     (p : L.orthogonalSum M) :
     orthogonalSumSnd L' M' ((f.orthogonalSum g).carrierEquiv p) =

--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -408,6 +408,7 @@ theorem orthogonalSumCarrierEquiv_carrierEquiv (f : Isometry L L') (g : Isometry
         orthogonalSum_apply, orthogonalSumSnd_apply]
 
 /-- Product isometries commute with the first canonical carrier projection. -/
+@[simp]
 theorem orthogonalSumFst_carrierEquiv (f : Isometry L L') (g : Isometry M M')
     (p : L.orthogonalSum M) :
     orthogonalSumFst L' M' ((f.orthogonalSum g).carrierEquiv p) =
@@ -417,6 +418,7 @@ theorem orthogonalSumFst_carrierEquiv (f : Isometry L L') (g : Isometry M M')
       congrArg Prod.fst (orthogonalSumCarrierEquiv_carrierEquiv f g p)
 
 /-- Product isometries commute with the second canonical carrier projection. -/
+@[simp]
 theorem orthogonalSumSnd_carrierEquiv (f : Isometry L L') (g : Isometry M M')
     (p : L.orthogonalSum M) :
     orthogonalSumSnd L' M' ((f.orthogonalSum g).carrierEquiv p) =

--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -34,6 +34,8 @@ Signature additivity remains to be developed with the signature API targeted by 
 
 * W. Ebeling, *Lattices and Codes*, Chapter 1.
 * `TauCetiRoadmap/IntegralLattices/README.md`, Layer 1.
+* The isometry constructions follow Mathlib's `QuadraticMap.IsometryEquiv.prod` and `prodComm` in
+  `Mathlib/LinearAlgebra/QuadraticForm/Prod.lean`.
 -/
 
 public section
@@ -355,29 +357,62 @@ def orthogonalSum (f : Isometry L L') (g : Isometry M M') :
     { toLinearEquiv := (f : V ≃ₗ[ℚ] X).prodCongr (g : W ≃ₗ[ℚ] Y)
       map_app' := by
         intro p q
-        -- Expose the product equivalence once so the componentwise form equations apply.
-        change L'.form (f p.1) (f q.1) + M'.form (g p.2) (g q.2) =
-          L.form p.1 q.1 + M.form p.2 q.2
-        rw [f.map_app, g.map_app] }
+        exact congrArg₂ (· + ·) (f.map_app p.1 q.1) (g.map_app p.2 q.2) }
   map_carrier := by
-    ext p
-    constructor
-    · rintro ⟨q, hq, rfl⟩
-      exact ⟨(f.apply_mem_carrier_iff q.1).2 hq.1,
-        (g.apply_mem_carrier_iff q.2).2 hq.2⟩
-    · intro hp
-      refine ⟨(f.symm p.1, g.symm p.2), ?_, ?_⟩
-      · exact ⟨(f.symm.apply_mem_carrier_iff p.1).2 hp.1,
-          (g.symm.apply_mem_carrier_iff p.2).2 hp.2⟩
-      · -- The restricted product equivalence has the same componentwise action as the ambient one.
-        change (f (f.symm p.1), g (g.symm p.2)) = p
-        simp
+    -- Expose the restricted product linear map to reuse `LinearMap.prodMap_map_prod`.
+    change (L.carrier.prod M.carrier).map
+        (LinearMap.prodMap (((f : V ≃ₗ[ℚ] X).restrictScalars ℤ).toLinearMap)
+          (((g : W ≃ₗ[ℚ] Y).restrictScalars ℤ).toLinearMap)) =
+      L'.carrier.prod M'.carrier
+    rw [LinearMap.prodMap_map_prod, f.map_carrier, g.map_carrier]
 
 /-- The product isometry acts componentwise on the ambient product. -/
 @[simp]
 theorem orthogonalSum_apply (f : Isometry L L') (g : Isometry M M') (p : V × W) :
     f.orthogonalSum g p = (f p.1, g p.2) :=
   by rw [orthogonalSum]; rfl
+
+/-- Product isometries commute with the first canonical carrier inclusion. -/
+@[simp]
+theorem orthogonalSum_carrierEquiv_inl (f : Isometry L L') (g : Isometry M M') (a : L) :
+    (f.orthogonalSum g).carrierEquiv (orthogonalSumInl L M a) =
+      orthogonalSumInl L' M' (f.carrierEquiv a) :=
+  by
+    apply Subtype.ext
+    simp only [Isometry.coe_carrierEquiv_apply, orthogonalSumInl_apply,
+      orthogonalSum_apply, map_zero]
+
+/-- Product isometries commute with the second canonical carrier inclusion. -/
+@[simp]
+theorem orthogonalSum_carrierEquiv_inr (f : Isometry L L') (g : Isometry M M') (b : M) :
+    (f.orthogonalSum g).carrierEquiv (orthogonalSumInr L M b) =
+      orthogonalSumInr L' M' (g.carrierEquiv b) :=
+  by
+    apply Subtype.ext
+    simp only [Isometry.coe_carrierEquiv_apply, orthogonalSumInr_apply,
+      orthogonalSum_apply, map_zero]
+
+/-- Product isometries commute with the first canonical carrier projection. -/
+@[simp]
+theorem orthogonalSumFst_carrierEquiv (f : Isometry L L') (g : Isometry M M')
+    (p : L.orthogonalSum M) :
+    orthogonalSumFst L' M' ((f.orthogonalSum g).carrierEquiv p) =
+      f.carrierEquiv (orthogonalSumFst L M p) :=
+  by
+    apply Subtype.ext
+    simp only [orthogonalSumFst_apply, coe_orthogonalSumCarrierEquiv_fst,
+      Isometry.coe_carrierEquiv_apply, orthogonalSum_apply]
+
+/-- Product isometries commute with the second canonical carrier projection. -/
+@[simp]
+theorem orthogonalSumSnd_carrierEquiv (f : Isometry L L') (g : Isometry M M')
+    (p : L.orthogonalSum M) :
+    orthogonalSumSnd L' M' ((f.orthogonalSum g).carrierEquiv p) =
+      g.carrierEquiv (orthogonalSumSnd L M p) :=
+  by
+    apply Subtype.ext
+    simp only [orthogonalSumSnd_apply, coe_orthogonalSumCarrierEquiv_snd,
+      Isometry.coe_carrierEquiv_apply, orthogonalSum_apply]
 
 /-- The product of identity isometries is the identity of the orthogonal sum. -/
 @[simp]
@@ -394,13 +429,9 @@ theorem orthogonalSum_symm (f : Isometry L L') (g : Isometry M M') :
     (f.orthogonalSum g).symm = f.symm.orthogonalSum g.symm := by
   apply Isometry.ext
   intro p
-  apply (f.orthogonalSum g).injective
-  -- `Function.Injective` exposes the underlying linear equivalence; return to the isometry
-  -- coercion so its inverse law and the componentwise application lemma can rewrite.
-  change (f.orthogonalSum g) ((f.orthogonalSum g).symm p) =
-    (f.orthogonalSum g) (f.symm.orthogonalSum g.symm p)
-  rw [Isometry.apply_symm_apply, orthogonalSum_apply, orthogonalSum_apply]
-  simp
+  rw [Isometry.coe_symm, orthogonalSum_apply]
+  simp only [orthogonalSum, LinearEquiv.prodCongr_symm, LinearEquiv.prodCongr_apply]
+  rw [Isometry.coe_symm f, Isometry.coe_symm g]
 
 /-- Product isometries preserve composition componentwise. -/
 @[simp]
@@ -422,10 +453,7 @@ def orthogonalSumComm (L : IntegralLattice V) (M : IntegralLattice W) :
     { toLinearEquiv := LinearEquiv.prodComm ℚ V W
       map_app' := by
         intro p q
-        -- Expose the swap once so form preservation reduces to commutativity of addition.
-        change M.form p.2 q.2 + L.form p.1 q.1 =
-          L.form p.1 q.1 + M.form p.2 q.2
-        rw [add_comm] }
+        exact add_comm _ _ }
   map_carrier := by
     ext p
     constructor
@@ -440,13 +468,38 @@ theorem orthogonalSumComm_apply (L : IntegralLattice V) (M : IntegralLattice W) 
     orthogonalSumComm L M p = (p.2, p.1) :=
   by rw [orthogonalSumComm]; rfl
 
-/-- Swapping the two factors twice is the identity lattice isometry. -/
+/-- The commutativity isometry exchanges the canonical carrier inclusions. -/
 @[simp]
-theorem orthogonalSumComm_trans (L : IntegralLattice V) (M : IntegralLattice W) :
-    (orthogonalSumComm L M).trans (orthogonalSumComm M L) = Isometry.refl _ := by
+theorem orthogonalSumComm_carrierEquiv_inl (L : IntegralLattice V) (M : IntegralLattice W)
+    (a : L) :
+    (orthogonalSumComm L M).carrierEquiv (orthogonalSumInl L M a) =
+      orthogonalSumInr M L a :=
+  by
+    apply Subtype.ext
+    simp only [Isometry.coe_carrierEquiv_apply, orthogonalSumInl_apply,
+      orthogonalSumInr_apply, orthogonalSumComm_apply]
+
+/-- The commutativity isometry exchanges the canonical carrier inclusions. -/
+@[simp]
+theorem orthogonalSumComm_carrierEquiv_inr (L : IntegralLattice V) (M : IntegralLattice W)
+    (b : M) :
+    (orthogonalSumComm L M).carrierEquiv (orthogonalSumInr L M b) =
+      orthogonalSumInl M L b :=
+  by
+    apply Subtype.ext
+    simp only [Isometry.coe_carrierEquiv_apply, orthogonalSumInr_apply,
+      orthogonalSumInl_apply, orthogonalSumComm_apply]
+
+/-- The inverse commutativity isometry swaps the factors in the opposite order. -/
+@[simp]
+theorem orthogonalSumComm_symm (L : IntegralLattice V) (M : IntegralLattice W) :
+    (orthogonalSumComm L M).symm = orthogonalSumComm M L := by
   apply Isometry.ext
   intro p
-  simp only [Isometry.trans_apply, orthogonalSumComm_apply, Isometry.refl_apply]
+  rw [Isometry.coe_symm, orthogonalSumComm_apply]
+  simp only [orthogonalSumComm, LinearEquiv.symm_prodComm,
+    LinearEquiv.prodComm_apply]
+  rfl
 
 /-- The commutativity isometry is natural with respect to isometries of both factors. -/
 theorem orthogonalSumComm_naturality {L : IntegralLattice V} {M : IntegralLattice W}
@@ -467,11 +520,7 @@ def orthogonalSumAssoc (L : IntegralLattice V) (M : IntegralLattice W)
     { toLinearEquiv := LinearEquiv.prodAssoc ℚ V W U
       map_app' := by
         intro p q
-        -- Expose reassociation once so form preservation is exactly associativity of addition.
-        change L.form p.1.1 q.1.1 +
-            (M.form p.1.2 q.1.2 + N.form p.2 q.2) =
-          (L.form p.1.1 q.1.1 + M.form p.1.2 q.1.2) + N.form p.2 q.2
-        rw [add_assoc] }
+        exact (add_assoc _ _ _).symm }
   map_carrier := by
     ext p
     constructor
@@ -493,12 +542,19 @@ theorem orthogonalSumAssoc_symm_apply (L : IntegralLattice V) (M : IntegralLatti
     (N : IntegralLattice U) (p : V × (W × U)) :
     (orthogonalSumAssoc L M N).symm p = ((p.1, p.2.1), p.2.2) :=
   by
-    apply (orthogonalSumAssoc L M N).injective
-    -- `Function.Injective` exposes the underlying linear equivalence; return to the isometry
-    -- coercion so its inverse law and the public application lemma can rewrite.
-    change orthogonalSumAssoc L M N ((orthogonalSumAssoc L M N).symm p) =
-      orthogonalSumAssoc L M N ((p.1, p.2.1), p.2.2)
-    rw [Isometry.apply_symm_apply, orthogonalSumAssoc_apply]
+    rw [Isometry.coe_symm]
+    rfl
+
+/-- The associativity isometry is natural with respect to isometries of all three factors. -/
+theorem orthogonalSumAssoc_naturality {L : IntegralLattice V} {M : IntegralLattice W}
+    {N : IntegralLattice U} {L' : IntegralLattice X} {M' : IntegralLattice Y}
+    {N' : IntegralLattice Z} (f : Isometry L L') (g : Isometry M M')
+    (h : Isometry N N') :
+    ((f.orthogonalSum g).orthogonalSum h).trans (orthogonalSumAssoc L' M' N') =
+      (orthogonalSumAssoc L M N).trans (f.orthogonalSum (g.orthogonalSum h)) := by
+  apply Isometry.ext
+  intro p
+  simp only [Isometry.trans_apply, Isometry.orthogonalSum_apply, orthogonalSumAssoc_apply]
 
 end Isometry
 


### PR DESCRIPTION
This PR makes orthogonal direct sums functorial under integral-lattice isometries and supplies their canonical commutativity and associativity isometries. It advances `TauCetiRoadmap/IntegralLattices/README.md`, Layer 1 milestone “lattices with forms,” specifically the target “Construct form scaling, form negation, and orthogonal direct sums,” whose required interface includes canonical associativity/commutativity isometries and compatibility of isometries with direct sum.

Define `IntegralLattice.Isometry.orthogonalSum` from the product rational linear equivalence, prove directly that it preserves the block-diagonal form and maps the product carrier onto the product carrier, and expose its action together with identity, inverse, and composition laws. Define `orthogonalSumComm` from `LinearEquiv.prodComm` and `orthogonalSumAssoc` from `LinearEquiv.prodAssoc`, prove their carrier and form equations, and record swap involutivity plus naturality of commutativity. This is the most effective current Layer 1 step because the orthogonal-sum construction and lattice-isometry foundations are both merged, and the existing module explicitly named these isometries as its next deferred API.

After this PR, the orthogonal-sum part of Layer 1 still needs radical and signature additivity, while the broader layer still needs the remaining signature laws for scaling and negation and the in-flight acceptance examples to land.

The preferred `CFSGStatement` roadmap has no viable unclaimed step on current `main`: I0 and S1 are complete, universe transport remains in flight in #3058, RootSystems Layer 6 still waits on the open E7 datum in #2809, and CFSG L0’s ReductiveGroups Layer 9 path is covered by open PBW and root-subgroup work. In particular, the next scheme-level Kostant root-subgroup reconstruction needs the explicit `ℤ`-algebra interface currently being changed by #3449, so implementing it now would duplicate an open dependency.

The implementation reuses Mathlib’s `LinearEquiv.prodCongr`, `LinearEquiv.prodComm`, and `LinearEquiv.prodAssoc`, together with Tau Ceti’s existing lattice-isometry carrier API; no Mathlib infrastructure or external formalization is vendored. The orthogonal-sum conventions follow W. Ebeling, *Lattices and Codes*, Chapter 1, as credited in the module documentation.

Extend `TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean` from 334 to 505 lines (177 insertions, 6 deletions).

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"orthogonal-sum-isometries"}-->

🤖 Prepared with Codex
