### PR TITLE
docs(ModularForms): #3330 has landed — correct the Norm/Order references

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Norm/Order.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Order.lean
@@ -24,6 +24,8 @@ order of the norm is the sum of the orders of the factors.
 
 * `TauCeti.SlashInvariantForm.quotientFunc_ne_zero`: a coset factor of the norm of a nonzero
   form is nonzero.
+* `TauCeti.SlashInvariantForm.orderOfVanishingAt_quotientFunc_mk`: a coset factor's vanishing
+  order at `p` is the form's own order at a translate of `p`.
 * `TauCeti.ModularForm.orderOfVanishingAt_norm`: the vanishing order of the norm at a point
   is the sum, over the coset space, of the vanishing orders of the coset factors.
 * `TauCeti.ModularForm.orderOfVanishingAt_quotientFunc_le_orderOfVanishingAt_norm`: each coset
@@ -40,10 +42,9 @@ order of the norm is the sum of the orders of the factors.
 * The two-step route used here — order domination under the norm carries the support into the
   finite support of the level-one norm, and finite index makes the fibres of the orbit comparison
   finite — was arrived at independently of, and concurrently with,
-  [PR #3330](https://github.com/TauCetiProject/TauCeti/pull/3330), which proposes the same
-  argument for a subgroup of `SL(2, ℤ)` of finite index. That pull request is unmerged at the time
-  of writing, so nothing here depends on it and it is cited as prior art rather than as a
-  reference into this library.
+  [PR #3330](https://github.com/TauCetiProject/TauCeti/pull/3330), which gives the same argument
+  for a subgroup of `SL(2, ℤ)` of finite index. That work has since landed; nothing here depends
+  on it, and the two remain independent derivations rather than one building on the other.
 
   The statements differ in the group: this one takes `𝒢 ≤ GL (Fin 2) ℝ` of finite *relative* index
   in `𝒮ℒ`, which **need not lie inside `𝒮ℒ`**. That is also why the order is not descended to the
@@ -73,6 +74,24 @@ public lemma quotientFunc_ne_zero [SlashInvariantFormClass F 𝒢 k] {f : F}
   | h g =>
     rw [_root_.SlashInvariantForm.quotientFunc_mk]
     exact fun hzero ↦ hf ((SlashAction.slash_eq_zero_iff k g.val⁻¹ (⇑f : ℍ → ℂ)).1 hzero)
+
+/-- **A coset factor's vanishing order at `p` is the form's order at a translate of `p`.** The
+factor at the class of `h` is `f ∣[k] h⁻¹`, so its order at `p` is the order of `f` at
+`h⁻¹ • p`.
+
+This is what turns the norm's order — a sum over the coset space, by
+`TauCeti.ModularForm.orderOfVanishingAt_norm` — into a statement about the orders of `f` itself
+at a family of points, which is the shape the general-level valence formula sums over orbits.
+
+The determinant hypothesis is not removable at this generality: `ℋ` is only asked to satisfy
+`Subgroup.HasDetPlusMinusOne`, so `h` may have determinant `-1`, while the order transports
+along the slash action only for positive determinant. For `ℋ = 𝒮ℒ`, the case the valence
+formula uses, every determinant is `1`. -/
+public lemma orderOfVanishingAt_quotientFunc_mk [SlashInvariantFormClass F 𝒢 k] (f : F) (h : ℋ)
+    (hdet : 0 < ((h : GL (Fin 2) ℝ)⁻¹).val.det) (p : ℍ) :
+    orderOfVanishingAt (_root_.SlashInvariantForm.quotientFunc f (⟦h⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ)) p =
+      orderOfVanishingAt (⇑f) (((h : GL (Fin 2) ℝ)⁻¹) • p) := by
+  rw [_root_.SlashInvariantForm.quotientFunc_mk, orderOfVanishingAt_slash (k := k) _ hdet]
 
 end SlashInvariantForm
 

--- a/TauCeti/NumberTheory/ModularForms/Norm/Order.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Order.lean
@@ -24,8 +24,6 @@ order of the norm is the sum of the orders of the factors.
 
 * `TauCeti.SlashInvariantForm.quotientFunc_ne_zero`: a coset factor of the norm of a nonzero
   form is nonzero.
-* `TauCeti.SlashInvariantForm.orderOfVanishingAt_quotientFunc_mk`: a coset factor's vanishing
-  order at `p` is the form's own order at a translate of `p`.
 * `TauCeti.ModularForm.orderOfVanishingAt_norm`: the vanishing order of the norm at a point
   is the sum, over the coset space, of the vanishing orders of the coset factors.
 * `TauCeti.ModularForm.orderOfVanishingAt_quotientFunc_le_orderOfVanishingAt_norm`: each coset
@@ -74,24 +72,6 @@ public lemma quotientFunc_ne_zero [SlashInvariantFormClass F 𝒢 k] {f : F}
   | h g =>
     rw [_root_.SlashInvariantForm.quotientFunc_mk]
     exact fun hzero ↦ hf ((SlashAction.slash_eq_zero_iff k g.val⁻¹ (⇑f : ℍ → ℂ)).1 hzero)
-
-/-- **A coset factor's vanishing order at `p` is the form's order at a translate of `p`.** The
-factor at the class of `h` is `f ∣[k] h⁻¹`, so its order at `p` is the order of `f` at
-`h⁻¹ • p`.
-
-This is what turns the norm's order — a sum over the coset space, by
-`TauCeti.ModularForm.orderOfVanishingAt_norm` — into a statement about the orders of `f` itself
-at a family of points, which is the shape the general-level valence formula sums over orbits.
-
-The determinant hypothesis is not removable at this generality: `ℋ` is only asked to satisfy
-`Subgroup.HasDetPlusMinusOne`, so `h` may have determinant `-1`, while the order transports
-along the slash action only for positive determinant. For `ℋ = 𝒮ℒ`, the case the valence
-formula uses, every determinant is `1`. -/
-public lemma orderOfVanishingAt_quotientFunc_mk [SlashInvariantFormClass F 𝒢 k] (f : F) (h : ℋ)
-    (hdet : 0 < ((h : GL (Fin 2) ℝ)⁻¹).val.det) (p : ℍ) :
-    orderOfVanishingAt (_root_.SlashInvariantForm.quotientFunc f (⟦h⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ)) p =
-      orderOfVanishingAt (⇑f) (((h : GL (Fin 2) ℝ)⁻¹) • p) := by
-  rw [_root_.SlashInvariantForm.quotientFunc_mk, orderOfVanishingAt_slash (k := k) _ hdet]
 
 end SlashInvariantForm
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"modularforms-coset-factor-order-translate"}-->

### What this is now

A one-paragraph correction to the References of
`TauCeti/NumberTheory/ModularForms/Norm/Order.lean`. The file said PR #3330 "is unmerged at the
time of writing, so nothing here depends on it"; #3330 merged at `2026-08-15T15:45:57Z` (checked
via `gh`, not assumed). The substantive claim is unchanged and still correct — the two derivations
were arrived at independently and neither builds on the other — so only the merge status moves.

### What it no longer is, and why

It opened as `orderOfVanishingAt_quotientFunc_mk`, a lemma rewriting a coset factor's vanishing
order at `p` as the form's own order at `h⁻¹ • p`. **A `reuse` request asked for it to be deleted,
and was right.** It composed `SlashInvariantForm.quotientFunc_mk` and `orderOfVanishingAt_slash`
and asserted nothing that neither already states, and it had no consumer — the one-use composition
helper the rubric rejects. Callers can `rw` with the two lemmas directly.

I had applied that exact test correctly two hours earlier, dropping a `Nat.card_pos` wrapper from
another branch for the same reason, and then failed to apply it here.

A companion `documentation` request was also right, and is the sharper mistake: the docstring
justified the explicit determinant hypothesis by saying `ℋ` "is only asked to satisfy
`Subgroup.HasDetPlusMinusOne`" — but I had deliberately placed the lemma in the
`SlashInvariantForm` namespace *so that it would carry no such typeclass*. The placement decision
falsified the docstring inside a single commit. It is moot now the declaration is gone, but it is
the reason to re-read prose against the declaration after any placement change.

### Why the lemma is not simply re-added later under a different name

It will be wanted by the coset-to-orbit regrouping that the general-level valence formula needs.
That is precisely the "will have a consumer" argument the `scope` and `reuse` rubrics decline, so
it belongs in the PR that brings the consumer, not this one.

### Verification

`lake build` green (8082 jobs, 0 error lines); `lake exe axioms` clean over 49728
declarations; `lake exe module-system` clean over 2364 modules; `LINT-ENV: PASS`
(67 grandfathered, 3 ratchetable). Documentation-only diff: +3/-4 in one file.
