### PR TITLE
feat: add signature laws for lattice scaling

### DIFF
--- a/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
@@ -7,14 +7,16 @@ module
 
 public import TauCeti.LinearAlgebra.BilinearForm.Basic
 public import TauCeti.LinearAlgebra.IntegralLattice.Gram
+public import TauCeti.LinearAlgebra.IntegralLattice.Signature
 
 /-!
 # Scaling and negating integral lattices
 
 Multiplying the form of an integral lattice by an integer leaves its carrier fixed and preserves
 integrality. This file equips integral lattices with that scalar action and computes the induced
-integral form, Gram matrix, determinant, and discriminant. In particular, negating the form changes
-the signed determinant by `(-1) ^ rank` and leaves the discriminant unchanged.
+integral form, Gram matrix, determinant, discriminant, radical, and signature. Positive scaling
+preserves the positive and negative indices of inertia, while negative scaling exchanges them;
+negating the form is the special case `-1`.
 
 The scalar is integral because arbitrary rational scaling need not preserve an integral form. A
 later development may admit rational scalars together with the necessary integrality hypothesis;
@@ -32,7 +34,12 @@ the canonical operation internal to integral lattices is the integer action defi
   lattice rank.
 * `TauCeti.IntegralLattice.discriminant_smul`: the discriminant is multiplied by the absolute
   scalar to the lattice rank.
+* `TauCeti.IntegralLattice.signature_smul_of_pos` and
+  `TauCeti.IntegralLattice.signature_smul_of_neg`: scaling preserves or exchanges the two
+  non-null indices according to the sign.
 * `TauCeti.IntegralLattice.discriminant_neg`: form negation preserves the discriminant.
+* `TauCeti.IntegralLattice.signature_neg`: form negation exchanges the positive and negative
+  indices and preserves the null index.
 
 ## References
 
@@ -165,6 +172,73 @@ theorem nondegenerate_smul_iff {n : ℤ} (hn : n ≠ 0) (L : IntegralLattice V) 
   exact TauCeti.BilinForm.nondegenerate_smul_iff
     (IsRegular.of_ne_zero (Int.cast_ne_zero.mpr hn))
 
+/-! ## Radical and signature -/
+
+/-- Scaling by a nonzero integer preserves the radical. -/
+theorem radical_smul {n : ℤ} (hn : n ≠ 0) (L : IntegralLattice V) :
+    (n • L).radical = L.radical := by
+  ext x
+  rw [(n • L).mem_radical_iff, L.mem_radical_iff, smul_form]
+  simp only [LinearMap.smul_apply, smul_eq_mul]
+  constructor
+  · intro hx y
+    exact (mul_eq_zero.mp (hx y)).resolve_left (Int.cast_ne_zero.mpr hn)
+  · intro hx y
+    rw [hx y, mul_zero]
+
+/-- Scaling by a nonzero integer preserves the null index. -/
+theorem sigNull_smul {n : ℤ} (hn : n ≠ 0) (L : IntegralLattice V) :
+    (n • L).sigNull = L.sigNull := by
+  rw [sigNull, radical_smul hn, sigNull]
+
+/-- Scaling by a positive integer preserves the positive index. -/
+theorem sigPos_smul_of_pos {n : ℤ} (hn : 0 < n) (L : IntegralLattice V) :
+    (n • L).sigPos = L.sigPos := by
+  let _ := L.finiteDimensional
+  have hnq : (0 : ℚ) < n := by exact_mod_cast hn
+  change _root_.sigPos (n • L).form.toQuadraticMap = _root_.sigPos L.form.toQuadraticMap
+  rw [smul_form, LinearMap.BilinMap.toQuadraticMap_smul]
+  exact QuadraticForm.sigPos_smul_of_pos L.form.toQuadraticMap hnq
+
+/-- Scaling by a positive integer preserves the negative index. -/
+theorem sigNeg_smul_of_pos {n : ℤ} (hn : 0 < n) (L : IntegralLattice V) :
+    (n • L).sigNeg = L.sigNeg := by
+  let _ := L.finiteDimensional
+  have hnq : (0 : ℚ) < n := by exact_mod_cast hn
+  change _root_.sigNeg (n • L).form.toQuadraticMap = _root_.sigNeg L.form.toQuadraticMap
+  rw [smul_form, LinearMap.BilinMap.toQuadraticMap_smul]
+  exact QuadraticForm.sigNeg_smul_of_pos L.form.toQuadraticMap hnq
+
+/-- Scaling by a positive integer preserves the signature. -/
+theorem signature_smul_of_pos {n : ℤ} (hn : 0 < n) (L : IntegralLattice V) :
+    (n • L).signature = L.signature := by
+  rw [signature, sigPos_smul_of_pos hn, sigNull_smul hn.ne', sigNeg_smul_of_pos hn,
+    signature]
+
+/-- Scaling by a negative integer exchanges the positive and negative indices. -/
+theorem sigPos_smul_of_neg {n : ℤ} (hn : n < 0) (L : IntegralLattice V) :
+    (n • L).sigPos = L.sigNeg := by
+  let _ := L.finiteDimensional
+  have hnq : (n : ℚ) < 0 := by exact_mod_cast hn
+  change _root_.sigPos (n • L).form.toQuadraticMap = _root_.sigNeg L.form.toQuadraticMap
+  rw [smul_form, LinearMap.BilinMap.toQuadraticMap_smul]
+  exact QuadraticForm.sigPos_smul_of_neg L.form.toQuadraticMap hnq
+
+/-- Scaling by a negative integer exchanges the negative and positive indices. -/
+theorem sigNeg_smul_of_neg {n : ℤ} (hn : n < 0) (L : IntegralLattice V) :
+    (n • L).sigNeg = L.sigPos := by
+  let _ := L.finiteDimensional
+  have hnq : (n : ℚ) < 0 := by exact_mod_cast hn
+  change _root_.sigNeg (n • L).form.toQuadraticMap = _root_.sigPos L.form.toQuadraticMap
+  rw [smul_form, LinearMap.BilinMap.toQuadraticMap_smul]
+  exact QuadraticForm.sigNeg_smul_of_neg L.form.toQuadraticMap hnq
+
+/-- Scaling by a negative integer exchanges the positive and negative indices and preserves the
+null index. -/
+theorem signature_smul_of_neg {n : ℤ} (hn : n < 0) (L : IntegralLattice V) :
+    (n • L).signature = (L.sigNeg, L.sigNull, L.sigPos) := by
+  rw [signature, sigPos_smul_of_neg hn, sigNull_smul hn.ne, sigNeg_smul_of_neg hn]
+
 /-- Scaling multiplies the discriminant by the absolute scalar to the rank of the lattice. -/
 @[simp]
 theorem discriminant_smul (n : ℤ) (L : IntegralLattice V) :
@@ -246,6 +320,32 @@ theorem nondegenerate_neg_iff (L : IntegralLattice V) :
     (-L).form.Nondegenerate ↔ L.form.Nondegenerate := by
   rw [neg_def]
   exact nondegenerate_smul_iff (by norm_num) L
+
+/-- Form negation preserves the radical. -/
+@[simp]
+theorem radical_neg (L : IntegralLattice V) : (-L).radical = L.radical := by
+  rw [neg_def, radical_smul (by norm_num)]
+
+/-- Form negation preserves the null index. -/
+@[simp]
+theorem sigNull_neg (L : IntegralLattice V) : (-L).sigNull = L.sigNull := by
+  rw [neg_def, sigNull_smul (by norm_num)]
+
+/-- Form negation exchanges the positive and negative indices. -/
+@[simp]
+theorem sigPos_neg (L : IntegralLattice V) : (-L).sigPos = L.sigNeg := by
+  rw [neg_def, sigPos_smul_of_neg (by norm_num)]
+
+/-- Form negation exchanges the negative and positive indices. -/
+@[simp]
+theorem sigNeg_neg (L : IntegralLattice V) : (-L).sigNeg = L.sigPos := by
+  rw [neg_def, sigNeg_smul_of_neg (by norm_num)]
+
+/-- Form negation exchanges the positive and negative indices and preserves the null index. -/
+@[simp]
+theorem signature_neg (L : IntegralLattice V) :
+    (-L).signature = (L.sigNeg, L.sigNull, L.sigPos) := by
+  rw [neg_def, signature_smul_of_neg (by norm_num)]
 
 /-- Form negation preserves the nonnegative discriminant. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
@@ -196,7 +196,7 @@ theorem sigPos_smul_of_pos {n : ℤ} (hn : 0 < n) (L : IntegralLattice V) :
     (n • L).sigPos = L.sigPos := by
   let _ := L.finiteDimensional
   have hnq : (0 : ℚ) < n := by exact_mod_cast hn
-  change _root_.sigPos (n • L).form.toQuadraticMap = _root_.sigPos L.form.toQuadraticMap
+  rw [sigPos]
   rw [smul_form, LinearMap.BilinMap.toQuadraticMap_smul]
   exact QuadraticForm.sigPos_smul_of_pos L.form.toQuadraticMap hnq
 
@@ -205,7 +205,7 @@ theorem sigNeg_smul_of_pos {n : ℤ} (hn : 0 < n) (L : IntegralLattice V) :
     (n • L).sigNeg = L.sigNeg := by
   let _ := L.finiteDimensional
   have hnq : (0 : ℚ) < n := by exact_mod_cast hn
-  change _root_.sigNeg (n • L).form.toQuadraticMap = _root_.sigNeg L.form.toQuadraticMap
+  rw [sigNeg]
   rw [smul_form, LinearMap.BilinMap.toQuadraticMap_smul]
   exact QuadraticForm.sigNeg_smul_of_pos L.form.toQuadraticMap hnq
 
@@ -220,7 +220,7 @@ theorem sigPos_smul_of_neg {n : ℤ} (hn : n < 0) (L : IntegralLattice V) :
     (n • L).sigPos = L.sigNeg := by
   let _ := L.finiteDimensional
   have hnq : (n : ℚ) < 0 := by exact_mod_cast hn
-  change _root_.sigPos (n • L).form.toQuadraticMap = _root_.sigNeg L.form.toQuadraticMap
+  rw [sigPos, sigNeg]
   rw [smul_form, LinearMap.BilinMap.toQuadraticMap_smul]
   exact QuadraticForm.sigPos_smul_of_neg L.form.toQuadraticMap hnq
 
@@ -229,7 +229,7 @@ theorem sigNeg_smul_of_neg {n : ℤ} (hn : n < 0) (L : IntegralLattice V) :
     (n • L).sigNeg = L.sigPos := by
   let _ := L.finiteDimensional
   have hnq : (n : ℚ) < 0 := by exact_mod_cast hn
-  change _root_.sigNeg (n • L).form.toQuadraticMap = _root_.sigPos L.form.toQuadraticMap
+  rw [sigNeg, sigPos]
   rw [smul_form, LinearMap.BilinMap.toQuadraticMap_smul]
   exact QuadraticForm.sigNeg_smul_of_neg L.form.toQuadraticMap hnq
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
@@ -175,6 +175,7 @@ theorem nondegenerate_smul_iff {n : ℤ} (hn : n ≠ 0) (L : IntegralLattice V) 
 /-! ## Radical and signature -/
 
 /-- Scaling by a nonzero integer preserves the radical. -/
+@[simp]
 theorem radical_smul {n : ℤ} (hn : n ≠ 0) (L : IntegralLattice V) :
     (n • L).radical = L.radical := by
   ext x
@@ -187,11 +188,13 @@ theorem radical_smul {n : ℤ} (hn : n ≠ 0) (L : IntegralLattice V) :
     rw [hx y, mul_zero]
 
 /-- Scaling by a nonzero integer preserves the null index. -/
+@[simp]
 theorem sigNull_smul {n : ℤ} (hn : n ≠ 0) (L : IntegralLattice V) :
     (n • L).sigNull = L.sigNull := by
   rw [sigNull, radical_smul hn, sigNull]
 
 /-- Scaling by a positive integer preserves the positive index. -/
+@[simp]
 theorem sigPos_smul_of_pos {n : ℤ} (hn : 0 < n) (L : IntegralLattice V) :
     (n • L).sigPos = L.sigPos := by
   let _ := L.finiteDimensional
@@ -201,6 +204,7 @@ theorem sigPos_smul_of_pos {n : ℤ} (hn : 0 < n) (L : IntegralLattice V) :
   exact QuadraticForm.sigPos_smul_of_pos L.form.toQuadraticMap hnq
 
 /-- Scaling by a positive integer preserves the negative index. -/
+@[simp]
 theorem sigNeg_smul_of_pos {n : ℤ} (hn : 0 < n) (L : IntegralLattice V) :
     (n • L).sigNeg = L.sigNeg := by
   let _ := L.finiteDimensional
@@ -210,12 +214,14 @@ theorem sigNeg_smul_of_pos {n : ℤ} (hn : 0 < n) (L : IntegralLattice V) :
   exact QuadraticForm.sigNeg_smul_of_pos L.form.toQuadraticMap hnq
 
 /-- Scaling by a positive integer preserves the signature. -/
+@[simp]
 theorem signature_smul_of_pos {n : ℤ} (hn : 0 < n) (L : IntegralLattice V) :
     (n • L).signature = L.signature := by
   rw [signature, sigPos_smul_of_pos hn, sigNull_smul hn.ne', sigNeg_smul_of_pos hn,
     signature]
 
 /-- Scaling by a negative integer exchanges the positive and negative indices. -/
+@[simp]
 theorem sigPos_smul_of_neg {n : ℤ} (hn : n < 0) (L : IntegralLattice V) :
     (n • L).sigPos = L.sigNeg := by
   let _ := L.finiteDimensional
@@ -225,6 +231,7 @@ theorem sigPos_smul_of_neg {n : ℤ} (hn : n < 0) (L : IntegralLattice V) :
   exact QuadraticForm.sigPos_smul_of_neg L.form.toQuadraticMap hnq
 
 /-- Scaling by a negative integer exchanges the negative and positive indices. -/
+@[simp]
 theorem sigNeg_smul_of_neg {n : ℤ} (hn : n < 0) (L : IntegralLattice V) :
     (n • L).sigNeg = L.sigPos := by
   let _ := L.finiteDimensional
@@ -235,6 +242,7 @@ theorem sigNeg_smul_of_neg {n : ℤ} (hn : n < 0) (L : IntegralLattice V) :
 
 /-- Scaling by a negative integer exchanges the positive and negative indices and preserves the
 null index. -/
+@[simp]
 theorem signature_smul_of_neg {n : ℤ} (hn : n < 0) (L : IntegralLattice V) :
     (n • L).signature = (L.sigNeg, L.sigNull, L.sigPos) := by
   rw [signature, sigPos_smul_of_neg hn, sigNull_smul hn.ne, sigNeg_smul_of_neg hn]

--- a/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
@@ -81,16 +81,11 @@ theorem sigPos_smul_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < a) :
   · obtain ⟨U, hUrank, hU⟩ := exists_finrank_eq_sigPos_and_posDef (a • Q)
     rw [← hUrank]
     apply le_sigPos_of_posDef
-    intro x hx
-    have h := hU x hx
-    simp only [QuadraticMap.restrict_apply, smul_apply, smul_eq_mul] at h
-    exact pos_of_mul_pos_right h ha.le
+    exact (posDef_smul_iff_of_pos (Q.restrict U) ha).mp hU
   · obtain ⟨U, hUrank, hU⟩ := exists_finrank_eq_sigPos_and_posDef Q
     rw [← hUrank]
     apply le_sigPos_of_posDef
-    intro x hx
-    simp only [QuadraticMap.restrict_apply, smul_apply, smul_eq_mul]
-    exact mul_pos ha (hU x hx)
+    exact (posDef_smul_iff_of_pos (Q.restrict U) ha).mpr hU
 
 /-- Multiplication by a positive scalar preserves the negative index of inertia. -/
 theorem sigNeg_smul_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < a) :

--- a/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
@@ -75,6 +75,7 @@ theorem posDef_smul_iff_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < 
   · exact fun hQ ↦ hQ.smul ha
 
 /-- Multiplication by a positive scalar preserves the positive index of inertia. -/
+@[simp]
 theorem sigPos_smul_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < a) :
     sigPos (a • Q) = sigPos Q := by
   apply le_antisymm
@@ -88,6 +89,7 @@ theorem sigPos_smul_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < a) :
     exact (posDef_smul_iff_of_pos (Q.restrict U) ha).mpr hU
 
 /-- Multiplication by a positive scalar preserves the negative index of inertia. -/
+@[simp]
 theorem sigNeg_smul_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < a) :
     sigNeg (a • Q) = sigNeg Q := by
   calc
@@ -97,6 +99,7 @@ theorem sigNeg_smul_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < a) :
     _ = sigNeg Q := sigPos_neg
 
 /-- Multiplication by a negative scalar exchanges the positive and negative indices of inertia. -/
+@[simp]
 theorem sigPos_smul_of_neg (Q : _root_.QuadraticForm K M) {a : K} (ha : a < 0) :
     sigPos (a • Q) = sigNeg Q := by
   have hpos : 0 < -a := neg_pos.mpr ha
@@ -104,6 +107,7 @@ theorem sigPos_smul_of_neg (Q : _root_.QuadraticForm K M) {a : K} (ha : a < 0) :
   rw [hform, sigPos_smul_of_pos (-Q) hpos, sigPos_neg]
 
 /-- Multiplication by a negative scalar exchanges the negative and positive indices of inertia. -/
+@[simp]
 theorem sigNeg_smul_of_neg (Q : _root_.QuadraticForm K M) {a : K} (ha : a < 0) :
     sigNeg (a • Q) = sigPos Q := by
   have hpos : 0 < -a := neg_pos.mpr ha

--- a/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
@@ -18,8 +18,9 @@ opposite index of inertia. It also characterizes positive-definiteness by the ne
 index and the radical. These are convenient consequences of Sylvester's law of inertia which
 complement Mathlib's definitions of `QuadraticMap.PosDef`, `sigPos`, and `sigNeg`.
 
-It also proves that restriction to a subspace cannot increase either index of inertia, and that
-quotienting a quadratic form by its radical preserves both indices.
+It also proves that restriction to a subspace cannot increase either index of inertia, that
+quotienting a quadratic form by its radical preserves both indices, and that multiplication by a
+positive scalar preserves both indices while multiplication by a negative scalar exchanges them.
 
 ## Main results
 
@@ -31,6 +32,10 @@ quotienting a quadratic form by its radical preserves both indices.
   positive index of inertia.
 * `TauCeti.QuadraticForm.sigNeg_restrict_le`: restriction to a subspace cannot increase the
   negative index of inertia.
+* `TauCeti.QuadraticForm.sigPos_smul_of_pos` and
+  `TauCeti.QuadraticForm.sigNeg_smul_of_pos`: positive scaling preserves both indices.
+* `TauCeti.QuadraticForm.sigPos_smul_of_neg` and
+  `TauCeti.QuadraticForm.sigNeg_smul_of_neg`: negative scaling exchanges the two indices.
 * `TauCeti.QuadraticForm.sigPos_lift_radical`: quotienting by the radical preserves the positive
   index of inertia.
 * `TauCeti.QuadraticForm.sigNeg_lift_radical`: quotienting by the radical preserves the negative
@@ -55,6 +60,62 @@ open _root_.QuadraticForm
 
 variable {K M : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
   [AddCommGroup M] [Module K M] [FiniteDimensional K M]
+
+omit [FiniteDimensional K M] in
+/-- Multiplication by a positive scalar preserves positive-definiteness. The reverse implication
+is included because `QuadraticMap.PosDef.smul` only supplies the forward implication. -/
+@[simp]
+theorem posDef_smul_iff_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < a) :
+    (a • Q).PosDef ↔ Q.PosDef := by
+  constructor
+  · intro hQ x hx
+    have h := hQ x hx
+    simp only [smul_apply, smul_eq_mul] at h
+    exact pos_of_mul_pos_right h ha.le
+  · exact fun hQ ↦ hQ.smul ha
+
+/-- Multiplication by a positive scalar preserves the positive index of inertia. -/
+theorem sigPos_smul_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < a) :
+    sigPos (a • Q) = sigPos Q := by
+  apply le_antisymm
+  · obtain ⟨U, hUrank, hU⟩ := exists_finrank_eq_sigPos_and_posDef (a • Q)
+    rw [← hUrank]
+    apply le_sigPos_of_posDef
+    intro x hx
+    have h := hU x hx
+    simp only [QuadraticMap.restrict_apply, smul_apply, smul_eq_mul] at h
+    exact pos_of_mul_pos_right h ha.le
+  · obtain ⟨U, hUrank, hU⟩ := exists_finrank_eq_sigPos_and_posDef Q
+    rw [← hUrank]
+    apply le_sigPos_of_posDef
+    intro x hx
+    simp only [QuadraticMap.restrict_apply, smul_apply, smul_eq_mul]
+    exact mul_pos ha (hU x hx)
+
+/-- Multiplication by a positive scalar preserves the negative index of inertia. -/
+theorem sigNeg_smul_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < a) :
+    sigNeg (a • Q) = sigNeg Q := by
+  calc
+    sigNeg (a • Q) = sigPos (-(a • Q)) := (sigPos_neg (Q := a • Q)).symm
+    _ = sigPos (a • (-Q)) := by rw [smul_neg]
+    _ = sigPos (-Q) := sigPos_smul_of_pos (-Q) ha
+    _ = sigNeg Q := sigPos_neg
+
+/-- Multiplication by a negative scalar exchanges the positive and negative indices of inertia. -/
+theorem sigPos_smul_of_neg (Q : _root_.QuadraticForm K M) {a : K} (ha : a < 0) :
+    sigPos (a • Q) = sigNeg Q := by
+  have hpos : 0 < -a := neg_pos.mpr ha
+  have hform : a • Q = (-a) • (-Q) := by simp
+  rw [hform, sigPos_smul_of_pos (-Q) hpos, sigPos_neg]
+
+/-- Multiplication by a negative scalar exchanges the negative and positive indices of inertia. -/
+theorem sigNeg_smul_of_neg (Q : _root_.QuadraticForm K M) {a : K} (ha : a < 0) :
+    sigNeg (a • Q) = sigPos Q := by
+  have hpos : 0 < -a := neg_pos.mpr ha
+  calc
+    sigNeg (a • Q) = sigPos (-(a • Q)) := (sigPos_neg (Q := a • Q)).symm
+    _ = sigPos ((-a) • Q) := congrArg sigPos (neg_smul a Q).symm
+    _ = sigPos Q := sigPos_smul_of_pos Q hpos
 
 /-- A quadratic form is nonnegative exactly when its negative index of inertia vanishes. -/
 theorem forall_nonneg_iff_sigNeg_eq_zero (Q : _root_.QuadraticForm K M) :

--- a/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
@@ -62,8 +62,8 @@ variable {K M : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
   [AddCommGroup M] [Module K M] [FiniteDimensional K M]
 
 omit [FiniteDimensional K M] in
-/-- Multiplication by a positive scalar preserves positive-definiteness. The reverse implication
-is included because `QuadraticMap.PosDef.smul` only supplies the forward implication. -/
+/-- Multiplication by a positive scalar preserves positive-definiteness. Thus a quadratic form is
+positive-definite if and only if its positive scalar multiple is. -/
 @[simp]
 theorem posDef_smul_iff_of_pos (Q : _root_.QuadraticForm K M) {a : K} (ha : 0 < a) :
     (a • Q).PosDef ↔ Q.PosDef := by


### PR DESCRIPTION
This PR adds the signature laws for scaling and negating integral lattices. Prove at the natural quadratic-form level that multiplication by a positive scalar preserves both inertia indices and multiplication by a negative scalar exchanges them; then specialize to integral lattices, proving preservation of the radical and null index under nonzero scaling, the positive- and negative-scaling formulas for `sigPos`, `sigNeg`, and `signature`, and the corresponding simp API for form negation.

It advances the exact target in `TauCetiRoadmap/IntegralLattices/README.md`, Layer 1 milestone “lattices with forms”: “Construct form scaling, form negation, and orthogonal direct sums. State exactly how ... the radical, and the signature behave,” including that negation exchanges `n₊` and `n₋` and fixes `n₀`, and that nonzero scaling preserves or exchanges them according to its sign.

After this PR, the scaling-and-negation signature subtarget is complete; Layer 1 still needs radical and signature additivity for orthogonal sums and the remaining isometry-invariance API, while the canonical orthogonal-sum isometries and acceptance examples are in flight in #3451 and #3419.

The preferred `CFSGStatement` roadmap has no viable unclaimed direct step on current `main`: I0 and S1 are complete, `classificationStatement_of_zero` is in flight in #3058, RootSystems Layer 6 is blocked by the open E7 datum in #2809, and L0 explicitly waits on ReductiveGroups Layer 9. Following that dependency also reaches in-flight work: #3449 is changing the explicit integer-algebra interface required to bundle the next Kostant root-subgroup natural transformation, while #3053 and #3061 occupy the immediate PBW and Kostant base-change prerequisites. Building their consumers on current `main` would duplicate or bypass open work, so this PR falls back to the next unclaimed coherent Layer 1 step in `IntegralLattices`.

The proof reuses Mathlib's `QuadraticMap.PosDef.smul`, the defining greatest-subspace API `exists_finrank_eq_sigPos_and_posDef` and `le_sigPos_of_posDef`, the existing negation laws for `sigPos` and `sigNeg`, and Tau Ceti's established integral-lattice signature and scaling definitions. No Mathlib infrastructure is vendored. The lattice conventions follow W. Ebeling, *Lattices and Codes*, Chapter 1, as already credited in both module documentations.

Modify `TauCeti/LinearAlgebra/QuadraticForm/Signature.lean` and `TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean` with 165 insertions and 4 deletions.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"signature-scaling-negation"}-->

🤖 Prepared with Codex
